### PR TITLE
test: collapse aggressive boundary batch 5

### DIFF
--- a/test/minga/command/parser_test.exs
+++ b/test/minga/command/parser_test.exs
@@ -4,483 +4,180 @@ defmodule Minga.Command.ParserTest do
 
   alias Minga.Command.Parser
 
-  describe "parse/1 — write commands" do
-    test ":w parses to {:save, []}" do
-      assert {:save, []} = Parser.parse("w")
-    end
-
-    test "leading/trailing whitespace is trimmed" do
-      assert {:save, []} = Parser.parse("  w  ")
-    end
-  end
-
-  describe "parse/1 — quit commands" do
-    test ":q parses to {:quit, []}" do
-      assert {:quit, []} = Parser.parse("q")
-    end
-
-    test ":q! parses to {:force_quit, []}" do
-      assert {:force_quit, []} = Parser.parse("q!")
-    end
-
-    test ":wq parses to {:save_quit, []}" do
-      assert {:save_quit, []} = Parser.parse("wq")
-    end
-
-    test ":wqa parses to {:save_quit_all, []}" do
-      assert {:save_quit_all, []} = Parser.parse("wqa")
-    end
-
-    test ":wqall parses to {:save_quit_all, []}" do
-      assert {:save_quit_all, []} = Parser.parse("wqall")
-    end
-
-    test ":qa parses to {:quit_all, []}" do
-      assert {:quit_all, []} = Parser.parse("qa")
-    end
-
-    test ":qa! parses to {:force_quit_all, []}" do
-      assert {:force_quit_all, []} = Parser.parse("qa!")
-    end
-
-    test ":qall parses to {:quit_all, []}" do
-      assert {:quit_all, []} = Parser.parse("qall")
-    end
-
-    test ":qall! parses to {:force_quit_all, []}" do
-      assert {:force_quit_all, []} = Parser.parse("qall!")
-    end
-
-    test ":cq parses to {:abort_quit, []}" do
-      assert {:abort_quit, []} = Parser.parse("cq")
-    end
-
-    test ":cquit parses to {:abort_quit, []}" do
-      assert {:abort_quit, []} = Parser.parse("cquit")
-    end
-
-    test ":cq! parses to {:abort_quit, []}" do
-      assert {:abort_quit, []} = Parser.parse("cq!")
-    end
-
-    test ":cquit! parses to {:abort_quit, []}" do
-      assert {:abort_quit, []} = Parser.parse("cquit!")
+  describe "parse/1 basics" do
+    test "write, quit, edit, buffer navigation, line jumps, and unknown commands" do
+      assert_parse_cases([
+        {"w", {:save, []}},
+        {"  w  ", {:save, []}},
+        {"q", {:quit, []}},
+        {"q!", {:force_quit, []}},
+        {"wq", {:save_quit, []}},
+        {"wqa", {:save_quit_all, []}},
+        {"wqall", {:save_quit_all, []}},
+        {"qa", {:quit_all, []}},
+        {"qa!", {:force_quit_all, []}},
+        {"qall", {:quit_all, []}},
+        {"qall!", {:force_quit_all, []}},
+        {"cq", {:abort_quit, []}},
+        {"cquit", {:abort_quit, []}},
+        {"cq!", {:abort_quit, []}},
+        {"cquit!", {:abort_quit, []}},
+        {"e README.md", {:edit, "README.md"}},
+        {"e my file.txt", {:edit, "my file.txt"}},
+        {"e", {:unknown, "e"}},
+        {"buffers", {:buffers, []}},
+        {"ls", {:buffers, []}},
+        {"bnext", {:buffer_next, []}},
+        {"bn", {:buffer_next, []}},
+        {"bprev", {:buffer_prev, []}},
+        {"bp", {:buffer_prev, []}},
+        {"42", {:goto_line, 42}},
+        {"1", {:goto_line, 1}},
+        {"999", {:goto_line, 999}},
+        {"0", {:unknown, "0"}},
+        {"-5", {:unknown, "-5"}},
+        {"xyz", {:unknown, "xyz"}},
+        {"", {:unknown, ""}},
+        {"wo", {:unknown, "wo"}},
+        {"agent-provider native", {:unknown, "agent-provider native"}}
+      ])
     end
   end
 
-  describe "parse/1 — edit command" do
-    test ":e filename parses to {:edit, filename}" do
-      assert {:edit, "README.md"} = Parser.parse("e README.md")
-    end
-
-    test ":e with path containing spaces (first word is filename)" do
-      assert {:edit, "my file.txt"} = Parser.parse("e my file.txt")
-    end
-
-    test ":e with no filename falls back to :unknown" do
-      assert {:unknown, "e"} = Parser.parse("e")
-    end
-  end
-
-  describe "parse/1 — range prefixes" do
-    test "% for whole buffer still works with %s" do
-      assert {:substitute, "old", "new", []} = Parser.parse("%s/old/new/")
-    end
-
-    test "single number is treated as goto_line, not a range" do
-      assert {:goto_line, 42} = Parser.parse("42")
-    end
-  end
-
-  describe "parse/1 — buffer navigation commands" do
-    test ":buffers parses to {:buffers, []}" do
-      assert {:buffers, []} = Parser.parse("buffers")
-    end
-
-    test ":ls parses to {:buffers, []}" do
-      assert {:buffers, []} = Parser.parse("ls")
-    end
-
-    test ":bnext parses to {:buffer_next, []}" do
-      assert {:buffer_next, []} = Parser.parse("bnext")
-    end
-
-    test ":bn parses to {:buffer_next, []}" do
-      assert {:buffer_next, []} = Parser.parse("bn")
-    end
-
-    test ":bprev parses to {:buffer_prev, []}" do
-      assert {:buffer_prev, []} = Parser.parse("bprev")
-    end
-
-    test ":bp parses to {:buffer_prev, []}" do
-      assert {:buffer_prev, []} = Parser.parse("bp")
+  describe "options and filetypes" do
+    test "set, setglobal, and set filetype aliases map to option commands" do
+      assert_parse_cases([
+        {"set number", {:set, :number}},
+        {"set nu", {:set, :number}},
+        {"set nonumber", {:set, :nonumber}},
+        {"set nonu", {:set, :nonumber}},
+        {"set relativenumber", {:set, :relativenumber}},
+        {"set rnu", {:set, :relativenumber}},
+        {"set norelativenumber", {:set, :norelativenumber}},
+        {"set nornu", {:set, :norelativenumber}},
+        {"setglobal number", {:setglobal, :number}},
+        {"setglobal nu", {:setglobal, :number}},
+        {"setglobal nonumber", {:setglobal, :nonumber}},
+        {"setglobal nonu", {:setglobal, :nonumber}},
+        {"setglobal relativenumber", {:setglobal, :relativenumber}},
+        {"setglobal rnu", {:setglobal, :relativenumber}},
+        {"setglobal norelativenumber", {:setglobal, :norelativenumber}},
+        {"setglobal nornu", {:setglobal, :norelativenumber}},
+        {"setglobal wrap", {:setglobal, :wrap}},
+        {"setglobal nowrap", {:setglobal, :nowrap}},
+        {"set ft=python", {:set_filetype, ["python"]}},
+        {"set filetype=elixir", {:set_filetype, ["elixir"]}},
+        {"setf ruby", {:set_filetype, ["ruby"]}},
+        {"setfiletype go", {:set_filetype, ["go"]}},
+        {"set ft=  python  ", {:set_filetype, ["python"]}}
+      ])
     end
   end
 
-  describe "parse/1 — goto line" do
-    test ":42 parses to {:goto_line, 42}" do
-      assert {:goto_line, 42} = Parser.parse("42")
-    end
-
-    test ":1 parses to {:goto_line, 1}" do
-      assert {:goto_line, 1} = Parser.parse("1")
-    end
-
-    test ":999 parses to {:goto_line, 999}" do
-      assert {:goto_line, 999} = Parser.parse("999")
-    end
-
-    test "zero is treated as unknown (lines are 1-indexed)" do
-      assert {:unknown, "0"} = Parser.parse("0")
-    end
-
-    test "negative number is treated as unknown" do
-      assert {:unknown, _} = Parser.parse("-5")
+  describe "substitute and ranges" do
+    test "substitute handles whole-buffer ranges, flags, missing trailing delimiters, escaped delimiters, empty replacements, and alternate delimiters" do
+      assert_parse_cases([
+        {"%s/old/new/", {:substitute, "old", "new", []}},
+        {"%s/old/new/g", {:substitute, "old", "new", [:global]}},
+        {"s/old/new/", {:substitute, "old", "new", []}},
+        {"%s/old/new/gc", {:substitute, "old", "new", [:global, :confirm]}},
+        {"%s/old/new", {:substitute, "old", "new", []}},
+        {"%s/a\\/b/c/", {:substitute, "a\\/b", "c", []}},
+        {"%s/old//g", {:substitute, "old", "", [:global]}},
+        {"%s#old#new#g", {:substitute, "old", "new", [:global]}}
+      ])
     end
   end
 
-  describe "parse/1 — set commands" do
-    test ":set number" do
-      assert {:set, :number} = Parser.parse("set number")
-      assert {:set, :number} = Parser.parse("set nu")
-    end
-
-    test ":set nonumber" do
-      assert {:set, :nonumber} = Parser.parse("set nonumber")
-      assert {:set, :nonumber} = Parser.parse("set nonu")
-    end
-
-    test ":set relativenumber" do
-      assert {:set, :relativenumber} = Parser.parse("set relativenumber")
-      assert {:set, :relativenumber} = Parser.parse("set rnu")
-    end
-
-    test ":set norelativenumber" do
-      assert {:set, :norelativenumber} = Parser.parse("set norelativenumber")
-      assert {:set, :norelativenumber} = Parser.parse("set nornu")
+  describe "help, agent, and parser commands" do
+    test "describe, agent, and parser restart commands parse their arguments and aliases" do
+      assert_parse_cases([
+        {"describe", {:describe_option, []}},
+        {"describe tab_width", {:describe_option_named, ["tab_width"]}},
+        {"describe-command", {:describe_command, []}},
+        {"describe-command save", {:describe_command_named, ["save"]}},
+        {"describe-command   save  ", {:describe_command_named, ["save"]}},
+        {"agent-clear-history", {:agent_clear_history, []}},
+        {"agent-stop", {:agent_abort, []}},
+        {"agent-new", {:agent_new_session, []}},
+        {"parser-restart", {:parser_restart, []}},
+        {"ParserRestart", {:parser_restart, []}}
+      ])
     end
   end
 
-  describe "parse/1 — setglobal commands" do
-    test ":setglobal number" do
-      assert {:setglobal, :number} = Parser.parse("setglobal number")
-      assert {:setglobal, :number} = Parser.parse("setglobal nu")
+  describe "sort, read, shell, and global commands" do
+    test "sort parses whole-buffer and explicit ranges with combinable flags" do
+      assert_parse_cases([
+        {"sort", {:sort, :whole_buffer, []}},
+        {"sort r", {:sort, :whole_buffer, [:reverse]}},
+        {"sort n", {:sort, :whole_buffer, [:numeric]}},
+        {"sort rn", {:sort, :whole_buffer, [:reverse, :numeric]}},
+        {"sort ru", {:sort, :whole_buffer, [:reverse, :unique]}},
+        {"%sort", {:sort, :whole_buffer, []}},
+        {"1,10sort", {:sort, {:absolute, 1, 10}, []}},
+        {"1,10sort r", {:sort, {:absolute, 1, 10}, [:reverse]}}
+      ])
     end
 
-    test ":setglobal nonumber" do
-      assert {:setglobal, :nonumber} = Parser.parse("setglobal nonumber")
-      assert {:setglobal, :nonumber} = Parser.parse("setglobal nonu")
-    end
-
-    test ":setglobal relativenumber" do
-      assert {:setglobal, :relativenumber} = Parser.parse("setglobal relativenumber")
-      assert {:setglobal, :relativenumber} = Parser.parse("setglobal rnu")
-    end
-
-    test ":setglobal norelativenumber" do
-      assert {:setglobal, :norelativenumber} = Parser.parse("setglobal norelativenumber")
-      assert {:setglobal, :norelativenumber} = Parser.parse("setglobal nornu")
-    end
-
-    test ":setglobal wrap" do
-      assert {:setglobal, :wrap} = Parser.parse("setglobal wrap")
-    end
-
-    test ":setglobal nowrap" do
-      assert {:setglobal, :nowrap} = Parser.parse("setglobal nowrap")
-    end
-  end
-
-  describe "parse/1 — substitute commands" do
-    test ":%s/old/new/g parses to {:substitute, ...}" do
-      assert {:substitute, "old", "new", [:global]} = Parser.parse("%s/old/new/g")
-    end
-
-    test ":s/old/new/ parses without flags" do
-      assert {:substitute, "old", "new", []} = Parser.parse("s/old/new/")
-    end
-
-    test ":%s/old/new/gc parses both flags" do
-      assert {:substitute, "old", "new", flags} = Parser.parse("%s/old/new/gc")
-      assert :global in flags
-      assert :confirm in flags
-    end
-
-    test ":%s/old/new parses without trailing delimiter" do
-      assert {:substitute, "old", "new", []} = Parser.parse("%s/old/new")
-    end
-
-    test "handles escaped delimiters in pattern" do
-      assert {:substitute, "a\\/b", "c", []} = Parser.parse("%s/a\\/b/c/")
-    end
-
-    test "handles empty replacement (delete)" do
-      assert {:substitute, "old", "", [:global]} = Parser.parse("%s/old//g")
-    end
-
-    test "handles alternate delimiter #" do
-      assert {:substitute, "old", "new", [:global]} = Parser.parse("%s#old#new#g")
+    test "read, shell, and global commands preserve arguments" do
+      assert_parse_cases([
+        {"read file.txt", {:read, "file.txt"}},
+        {"r file.txt", {:read, "file.txt"}},
+        {"read path/to/file.txt", {:read, "path/to/file.txt"}},
+        {"read", {:unknown, "read"}},
+        {"!ls", {:shell_command, "ls"}},
+        {"!make test", {:shell_command, "make test"}},
+        {"!", {:shell_command, ""}},
+        {"g/pattern/cmd", {:global, "pattern", "cmd"}},
+        {"g/foo/delete", {:global, "foo", "delete"}},
+        {"g/test/s/old/new/g", {:global, "test", "s/old/new/g"}},
+        {"gpattern", {:unknown, "gpattern"}}
+      ])
     end
   end
 
-  describe "parse/1 — describe commands" do
-    test ":describe opens the option picker" do
-      assert {:describe_option, []} = Parser.parse("describe")
-    end
-
-    test ":describe option parses the option name" do
-      assert {:describe_option_named, ["tab_width"]} = Parser.parse("describe tab_width")
-    end
-
-    test ":describe-command opens the command picker" do
-      assert {:describe_command, []} = Parser.parse("describe-command")
-    end
-
-    test ":describe-command with name parses the command name" do
-      assert {:describe_command_named, ["save"]} = Parser.parse("describe-command save")
-    end
-
-    test ":describe-command trims whitespace from name" do
-      assert {:describe_command_named, ["save"]} = Parser.parse("describe-command   save  ")
+  describe "normal command" do
+    test "normal and norm parse key strings with supported ranges and reject missing keys" do
+      assert_parse_cases([
+        {"normal dd", {:normal, :whole_buffer, "dd"}},
+        {"norm w", {:normal, :whole_buffer, "w"}},
+        {"normal j", {:normal, :whole_buffer, "j"}},
+        {"normal dw", {:normal, :whole_buffer, "dw"}},
+        {"normal ^d", {:normal, :whole_buffer, "^d"}},
+        {"normal gJ", {:normal, :whole_buffer, "gJ"}},
+        {"%normal dd", {:normal, :whole_buffer, "dd"}},
+        {"1,5normal w", {:normal, {:absolute, 1, 5}, "w"}},
+        {".normal dd", {:normal, :current_line, "dd"}},
+        {"$normal dd", {:normal, :last_line, "dd"}},
+        {"normal", {:unknown, "normal"}},
+        {"norm", {:unknown, "norm"}},
+        {"normal    ", {:unknown, "normal"}}
+      ])
     end
   end
 
-  describe "parse/1 — unknown commands" do
-    test "unrecognised command returns {:unknown, raw}" do
-      assert {:unknown, "xyz"} = Parser.parse("xyz")
-    end
-
-    test "empty string returns {:unknown, \"\"}" do
-      assert {:unknown, ""} = Parser.parse("")
-    end
-
-    test "partial command returns {:unknown, raw}" do
-      assert {:unknown, "wo"} = Parser.parse("wo")
-    end
-
-    test "agent-provider is no longer a dedicated command" do
-      assert {:unknown, "agent-provider native"} = Parser.parse("agent-provider native")
+  describe "dired / oil" do
+    test "dired and oil parse optional paths" do
+      assert_parse_cases([
+        {"dired", {:dired, nil}},
+        {"oil", {:dired, nil}},
+        {"dired /tmp/foo", {:dired, "/tmp/foo"}},
+        {"oil /tmp/foo", {:dired, "/tmp/foo"}},
+        {"dired   ", {:dired, nil}},
+        {"oil   ", {:dired, nil}}
+      ])
     end
   end
 
-  describe "set filetype commands" do
-    test ":set ft=python parses to set_filetype" do
-      assert {:set_filetype, ["python"]} = Parser.parse("set ft=python")
-    end
-
-    test ":set filetype=elixir parses to set_filetype" do
-      assert {:set_filetype, ["elixir"]} = Parser.parse("set filetype=elixir")
-    end
-
-    test ":setf ruby parses to set_filetype" do
-      assert {:set_filetype, ["ruby"]} = Parser.parse("setf ruby")
-    end
-
-    test ":setfiletype go parses to set_filetype" do
-      assert {:set_filetype, ["go"]} = Parser.parse("setfiletype go")
-    end
-
-    test "trims whitespace from filetype name" do
-      assert {:set_filetype, ["python"]} = Parser.parse("set ft=  python  ")
+  defp assert_parse_cases(cases) do
+    for {input, expected} <- cases do
+      assert normalize(Parser.parse(input)) == normalize(expected),
+             "expected #{inspect(input)} to parse as #{inspect(expected)}"
     end
   end
 
-  describe "parse/1 — agent commands" do
-    test ":agent-clear-history parses to {:agent_clear_history, []}" do
-      assert {:agent_clear_history, []} = Parser.parse("agent-clear-history")
-    end
-
-    test ":agent-stop parses to {:agent_abort, []}" do
-      assert {:agent_abort, []} = Parser.parse("agent-stop")
-    end
-
-    test ":agent-new parses to {:agent_new_session, []}" do
-      assert {:agent_new_session, []} = Parser.parse("agent-new")
-    end
-  end
-
-  describe "parse/1 — parser commands" do
-    test ":parser-restart parses to {:parser_restart, []}" do
-      assert {:parser_restart, []} = Parser.parse("parser-restart")
-    end
-
-    test ":ParserRestart parses to {:parser_restart, []}" do
-      assert {:parser_restart, []} = Parser.parse("ParserRestart")
-    end
-  end
-
-  describe "parse/1 — sort command" do
-    test ":sort parses to {:sort, :whole_buffer, []}" do
-      assert {:sort, :whole_buffer, []} = Parser.parse("sort")
-    end
-
-    test ":sort r parses with reverse flag" do
-      assert {:sort, :whole_buffer, [:reverse]} = Parser.parse("sort r")
-    end
-
-    test ":sort n parses with numeric flag" do
-      assert {:sort, :whole_buffer, [:numeric]} = Parser.parse("sort n")
-    end
-
-    test ":sort rn parses with reverse and numeric flags" do
-      result = Parser.parse("sort rn")
-      assert {:sort, :whole_buffer, flags} = result
-      assert :reverse in flags
-      assert :numeric in flags
-    end
-
-    test ":sort ru parses with reverse and unique flags" do
-      result = Parser.parse("sort ru")
-      assert {:sort, :whole_buffer, flags} = result
-      assert :reverse in flags
-      assert :unique in flags
-    end
-
-    test ":% sort parses with range" do
-      assert {:sort, :whole_buffer, []} = Parser.parse("%sort")
-    end
-
-    test ":1,10 sort parses with numeric range" do
-      assert {:sort, {:absolute, 1, 10}, []} = Parser.parse("1,10sort")
-    end
-
-    test ":1,10 sort r parses with numeric range and flags" do
-      assert {:sort, {:absolute, 1, 10}, [:reverse]} = Parser.parse("1,10sort r")
-    end
-  end
-
-  describe "parse/1 — read/r command" do
-    test ":read file.txt parses to {:read, filename}" do
-      assert {:read, "file.txt"} = Parser.parse("read file.txt")
-    end
-
-    test ":r file.txt parses to {:read, filename}" do
-      assert {:read, "file.txt"} = Parser.parse("r file.txt")
-    end
-
-    test ":read with path containing spaces" do
-      assert {:read, "path/to/file.txt"} = Parser.parse("read path/to/file.txt")
-    end
-
-    test ":read with no filename falls back to unknown" do
-      assert {:unknown, "read"} = Parser.parse("read")
-    end
-  end
-
-  describe "parse/1 — shell command" do
-    test ":!ls parses to {:shell_command, cmd}" do
-      assert {:shell_command, "ls"} = Parser.parse("!ls")
-    end
-
-    test ":!make test parses with full command" do
-      assert {:shell_command, "make test"} = Parser.parse("!make test")
-    end
-
-    test ":! with no command parses to empty string" do
-      assert {:shell_command, ""} = Parser.parse("!")
-    end
-  end
-
-  describe "parse/1 — global command" do
-    test ":g/pattern/cmd parses to {:global, pattern, cmd}" do
-      assert {:global, "pattern", "cmd"} = Parser.parse("g/pattern/cmd")
-    end
-
-    test ":g/foo/delete parses pattern and command" do
-      assert {:global, "foo", "delete"} = Parser.parse("g/foo/delete")
-    end
-
-    test ":g/test/s/old/new/g parses substitute as command" do
-      assert {:global, "test", "s/old/new/g"} = Parser.parse("g/test/s/old/new/g")
-    end
-
-    test ":g/pattern/cmd without trailing slash" do
-      assert {:global, "pattern", "cmd"} = Parser.parse("g/pattern/cmd")
-    end
-
-    test ":g without slash falls back to unknown" do
-      assert {:unknown, _} = Parser.parse("gpattern")
-    end
-  end
-
-  describe "parse/1 — normal command" do
-    test ":normal dd parses to {:normal, :whole_buffer, keys}" do
-      assert {:normal, :whole_buffer, "dd"} = Parser.parse("normal dd")
-    end
-
-    test ":norm w parses to {:normal, :whole_buffer, keys}" do
-      assert {:normal, :whole_buffer, "w"} = Parser.parse("norm w")
-    end
-
-    test ":normal j parses single key" do
-      assert {:normal, :whole_buffer, "j"} = Parser.parse("normal j")
-    end
-
-    test ":normal with multiple keys" do
-      assert {:normal, :whole_buffer, "dw"} = Parser.parse("normal dw")
-    end
-
-    test ":normal with ^" do
-      assert {:normal, :whole_buffer, "^d"} = Parser.parse("normal ^d")
-    end
-
-    test ":normal with gJ (g motion)" do
-      assert {:normal, :whole_buffer, "gJ"} = Parser.parse("normal gJ")
-    end
-
-    test ":% normal dd parses with whole_buffer range" do
-      assert {:normal, :whole_buffer, "dd"} = Parser.parse("%normal dd")
-    end
-
-    test ":1,5 normal w parses with numeric range" do
-      assert {:normal, {:absolute, 1, 5}, "w"} = Parser.parse("1,5normal w")
-    end
-
-    test ":. normal dd parses with current_line range" do
-      assert {:normal, :current_line, "dd"} = Parser.parse(".normal dd")
-    end
-
-    test ":$ normal dd parses with last_line range" do
-      assert {:normal, :last_line, "dd"} = Parser.parse("$normal dd")
-    end
-
-    test ":normal with no keys falls back to unknown" do
-      assert {:unknown, "normal"} = Parser.parse("normal")
-    end
-
-    test ":norm with no keys falls back to unknown" do
-      assert {:unknown, "norm"} = Parser.parse("norm")
-    end
-
-    test ":normal with only spaces falls back to unknown" do
-      assert {:unknown, "normal"} = Parser.parse("normal    ")
-    end
-  end
-
-  describe "parse/1 — dired / oil commands" do
-    test ":dired parses to {:dired, nil}" do
-      assert {:dired, nil} = Parser.parse("dired")
-    end
-
-    test ":oil parses to {:dired, nil}" do
-      assert {:dired, nil} = Parser.parse("oil")
-    end
-
-    test ":dired with path" do
-      assert {:dired, "/tmp/foo"} = Parser.parse("dired /tmp/foo")
-    end
-
-    test ":oil with path" do
-      assert {:dired, "/tmp/foo"} = Parser.parse("oil /tmp/foo")
-    end
-
-    test ":dired with whitespace-only arg" do
-      assert {:dired, nil} = Parser.parse("dired   ")
-    end
-
-    test ":oil with whitespace-only arg" do
-      assert {:dired, nil} = Parser.parse("oil   ")
-    end
-  end
+  defp normalize({:substitute, old, new, flags}), do: {:substitute, old, new, Enum.sort(flags)}
+  defp normalize({:sort, range, flags}), do: {:sort, range, Enum.sort(flags)}
+  defp normalize(other), do: other
 end

--- a/test/minga/mode/operator_pending_test.exs
+++ b/test/minga/mode/operator_pending_test.exs
@@ -5,463 +5,157 @@ defmodule Minga.Mode.OperatorPendingTest do
   alias Minga.Mode.OperatorPending
   alias Minga.Mode.OperatorPendingState
 
-  # Build the FSM state as it would look after transitioning from Normal on `d`.
-  defp op_state(operator, op_count \\ 1) do
-    %OperatorPendingState{operator: operator, op_count: op_count}
-  end
+  defp op_state(operator, op_count \\ 1),
+    do: %OperatorPendingState{operator: operator, op_count: op_count}
 
-  # ── d + motion ─────────────────────────────────────────────────────────────
+  describe "motion operators" do
+    test "delete, change, and yank map motions to operator commands and target modes" do
+      cases = [
+        {:delete, ?w, 0, {:delete_motion, :word_forward}, :normal},
+        {:delete, ?b, 0, {:delete_motion, :word_backward}, :normal},
+        {:delete, ?e, 0, {:delete_motion, :word_end}, :normal},
+        {:delete, ?0, 0, {:delete_motion, :line_start}, :normal},
+        {:delete, ?$, 0, {:delete_motion, :line_end}, :normal},
+        {:delete, ?G, 0, {:delete_motion, :document_end}, :normal},
+        {:change, ?w, 0, {:change_motion, :word_forward}, :insert},
+        {:change, ?e, 0, {:change_motion, :word_end}, :insert},
+        {:change, ?$, 0, {:change_motion, :line_end}, :insert},
+        {:yank, ?w, 0, {:yank_motion, :word_forward}, :normal},
+        {:yank, ?b, 0, {:yank_motion, :word_backward}, :normal},
+        {:delete, ?d, 0x02, {:delete_motion, :half_page_down}, :normal},
+        {:delete, ?u, 0x02, {:delete_motion, :half_page_up}, :normal},
+        {:yank, ?f, 0x02, {:yank_motion, :page_down}, :normal},
+        {:change, ?b, 0x02, {:change_motion, :page_up}, :insert}
+      ]
 
-  describe "delete operator with motion" do
-    test "d+w emits {:delete_motion, :word_forward} and transitions to :normal" do
-      state = op_state(:delete)
+      for {operator, key, mods, command, mode} <- cases do
+        assert {:execute_then_transition, [^command], ^mode, _state} =
+                 OperatorPending.handle_key({key, mods}, op_state(operator))
+      end
 
-      assert {:execute_then_transition, [{:delete_motion, :word_forward}], :normal, _} =
-               OperatorPending.handle_key({?w, 0}, state)
+      {:continue, pending_g} = OperatorPending.handle_key({?g, 0}, op_state(:delete))
+
+      assert {:execute_then_transition, [{:delete_motion, :document_start}], :normal, _state} =
+               OperatorPending.handle_key({?g, 0}, pending_g)
     end
 
-    test "d+b emits {:delete_motion, :word_backward} and transitions to :normal" do
-      state = op_state(:delete)
-
-      assert {:execute_then_transition, [{:delete_motion, :word_backward}], :normal, _} =
-               OperatorPending.handle_key({?b, 0}, state)
-    end
-
-    test "d+e emits {:delete_motion, :word_end} and transitions to :normal" do
-      state = op_state(:delete)
-
-      assert {:execute_then_transition, [{:delete_motion, :word_end}], :normal, _} =
-               OperatorPending.handle_key({?e, 0}, state)
-    end
-
-    test "d+0 emits {:delete_motion, :line_start} and transitions to :normal" do
-      state = op_state(:delete)
-
-      assert {:execute_then_transition, [{:delete_motion, :line_start}], :normal, _} =
-               OperatorPending.handle_key({?0, 0}, state)
-    end
-
-    test "d+$ emits {:delete_motion, :line_end} and transitions to :normal" do
-      state = op_state(:delete)
-
-      assert {:execute_then_transition, [{:delete_motion, :line_end}], :normal, _} =
-               OperatorPending.handle_key({?$, 0}, state)
-    end
-
-    test "d+G emits {:delete_motion, :document_end} and transitions to :normal" do
-      state = op_state(:delete)
-
-      assert {:execute_then_transition, [{:delete_motion, :document_end}], :normal, _} =
-               OperatorPending.handle_key({?G, 0}, state)
-    end
-
-    test "d+g+g emits {:delete_motion, :document_start} and transitions to :normal" do
-      state = op_state(:delete)
-      {:continue, state2} = OperatorPending.handle_key({?g, 0}, state)
-
-      assert {:execute_then_transition, [{:delete_motion, :document_start}], :normal, _} =
-               OperatorPending.handle_key({?g, 0}, state2)
-    end
-  end
-
-  # ── c + motion ─────────────────────────────────────────────────────────────
-
-  describe "change operator with motion" do
-    test "c+w emits {:change_motion, :word_forward} and transitions to :insert" do
-      state = op_state(:change)
-
-      assert {:execute_then_transition, [{:change_motion, :word_forward}], :insert, _} =
-               OperatorPending.handle_key({?w, 0}, state)
-    end
-
-    test "c+e emits {:change_motion, :word_end} and transitions to :insert" do
-      state = op_state(:change)
-
-      assert {:execute_then_transition, [{:change_motion, :word_end}], :insert, _} =
-               OperatorPending.handle_key({?e, 0}, state)
-    end
-
-    test "c+$ emits {:change_motion, :line_end} and transitions to :insert" do
-      state = op_state(:change)
-
-      assert {:execute_then_transition, [{:change_motion, :line_end}], :insert, _} =
-               OperatorPending.handle_key({?$, 0}, state)
-    end
-  end
-
-  # ── y + motion ─────────────────────────────────────────────────────────────
-
-  describe "yank operator with motion" do
-    test "y+w emits {:yank_motion, :word_forward} and transitions to :normal" do
-      state = op_state(:yank)
-
-      assert {:execute_then_transition, [{:yank_motion, :word_forward}], :normal, _} =
-               OperatorPending.handle_key({?w, 0}, state)
-    end
-
-    test "y+b emits {:yank_motion, :word_backward} and transitions to :normal" do
-      state = op_state(:yank)
-
-      assert {:execute_then_transition, [{:yank_motion, :word_backward}], :normal, _} =
-               OperatorPending.handle_key({?b, 0}, state)
-    end
-  end
-
-  # ── Double-operator (line-wise) ────────────────────────────────────────────
-
-  describe "dd (delete line)" do
-    test "d+d emits {:delete_lines_counted, 1} and transitions to :normal" do
-      state = op_state(:delete)
-
-      assert {:execute_then_transition, [{:delete_lines_counted, 1}], :normal, _} =
-               OperatorPending.handle_key({?d, 0}, state)
-    end
-
-    test "dd with op_count=3 emits {:delete_lines_counted, 3}" do
-      state = op_state(:delete, 3)
-
-      assert {:execute_then_transition, [{:delete_lines_counted, 3}], :normal, _} =
-               OperatorPending.handle_key({?d, 0}, state)
-    end
-  end
-
-  describe "cc (change line)" do
-    test "c+c emits {:change_lines_counted, 1} and transitions to :insert" do
-      state = op_state(:change)
-
-      assert {:execute_then_transition, [{:change_lines_counted, 1}], :insert, _} =
-               OperatorPending.handle_key({?c, 0}, state)
-    end
-  end
-
-  describe "yy (yank line)" do
-    test "y+y emits {:yank_lines_counted, 1} and transitions to :normal" do
-      state = op_state(:yank)
-
-      assert {:execute_then_transition, [{:yank_lines_counted, 1}], :normal, _} =
-               OperatorPending.handle_key({?y, 0}, state)
-    end
-  end
-
-  # ── Escape cancels ─────────────────────────────────────────────────────────
-
-  describe "page / half-page motions" do
-    test "d+Ctrl+d emits {:delete_motion, :half_page_down}" do
-      ctrl = 0x02
-      state = %OperatorPendingState{operator: :delete, op_count: 1}
-
-      assert {:execute_then_transition, [{:delete_motion, :half_page_down}], :normal, _} =
-               OperatorPending.handle_key({?d, ctrl}, state)
-    end
-
-    test "d+Ctrl+u emits {:delete_motion, :half_page_up}" do
-      ctrl = 0x02
-      state = %OperatorPendingState{operator: :delete, op_count: 1}
-
-      assert {:execute_then_transition, [{:delete_motion, :half_page_up}], :normal, _} =
-               OperatorPending.handle_key({?u, ctrl}, state)
-    end
-
-    test "y+Ctrl+f emits {:yank_motion, :page_down}" do
-      ctrl = 0x02
-      state = %OperatorPendingState{operator: :yank, op_count: 1}
-
-      assert {:execute_then_transition, [{:yank_motion, :page_down}], :normal, _} =
-               OperatorPending.handle_key({?f, ctrl}, state)
-    end
-
-    test "c+Ctrl+b emits {:change_motion, :page_up} and transitions to insert" do
-      ctrl = 0x02
-      state = %OperatorPendingState{operator: :change, op_count: 1}
-
-      assert {:execute_then_transition, [{:change_motion, :page_up}], :insert, _} =
-               OperatorPending.handle_key({?b, ctrl}, state)
-    end
-  end
-
-  describe "Escape" do
-    test "Escape transitions back to :normal" do
-      state = op_state(:delete)
-      assert {:transition, :normal, _} = OperatorPending.handle_key({27, 0}, state)
-    end
-
-    test "Escape returns base Mode.State without operator fields" do
-      state = op_state(:delete)
-      {:transition, :normal, new_state} = OperatorPending.handle_key({27, 0}, state)
-      assert %Mode.State{} = new_state
-    end
-  end
-
-  # ── Count accumulation ─────────────────────────────────────────────────────
-
-  describe "count prefix inside operator-pending" do
-    test "digit accumulates count" do
-      state = op_state(:delete)
-      {:continue, s2} = OperatorPending.handle_key({?3, 0}, state)
-      assert s2.count == 3
-    end
-
-    test "two digits accumulate" do
-      state = op_state(:delete)
-      {:continue, s2} = OperatorPending.handle_key({?1, 0}, state)
-      {:continue, s3} = OperatorPending.handle_key({?2, 0}, s2)
-      assert s3.count == 12
-    end
-
-    test "0 after digit extends count" do
-      state = op_state(:delete)
-      {:continue, s2} = OperatorPending.handle_key({?1, 0}, state)
+    test "counts accumulate inside operator-pending and multiply pre-operator counts" do
+      {:continue, s1} = OperatorPending.handle_key({?1, 0}, op_state(:delete))
+      {:continue, s2} = OperatorPending.handle_key({?2, 0}, s1)
       {:continue, s3} = OperatorPending.handle_key({?0, 0}, s2)
-      assert s3.count == 10
-    end
+      assert s3.count == 120
 
-    test "motion count multiplies op_count" do
-      # op_count=2 (from `2d`), then press `3w` (motion count=3) → 6 commands
-      state = %OperatorPendingState{operator: :delete, op_count: 2}
-      {:continue, s2} = OperatorPending.handle_key({?3, 0}, state)
+      {:continue, counted_motion} = OperatorPending.handle_key({?3, 0}, op_state(:delete, 2))
 
-      assert {:execute_then_transition, cmds, :normal, _} =
-               OperatorPending.handle_key({?w, 0}, s2)
+      assert {:execute_then_transition, commands, :normal, _state} =
+               OperatorPending.handle_key({?w, 0}, counted_motion)
 
-      assert length(cmds) == 6
-      assert Enum.all?(cmds, &(&1 == {:delete_motion, :word_forward}))
+      assert length(commands) == 6
+      assert Enum.all?(commands, &(&1 == {:delete_motion, :word_forward}))
     end
   end
 
-  # ── Mode.process integration ───────────────────────────────────────────────
+  describe "linewise operators and cancellation" do
+    test "repeating operators emits counted linewise commands with the right target mode" do
+      cases = [
+        {:delete, ?d, 1, {:delete_lines_counted, 1}, :normal},
+        {:delete, ?d, 3, {:delete_lines_counted, 3}, :normal},
+        {:change, ?c, 1, {:change_lines_counted, 1}, :insert},
+        {:yank, ?y, 1, {:yank_lines_counted, 1}, :normal},
+        {:indent, ?>, 1, {:indent_lines, 1}, :normal},
+        {:indent, ?>, 3, {:indent_lines, 3}, :normal},
+        {:dedent, ?<, 1, {:dedent_lines, 1}, :normal},
+        {:dedent, ?<, 3, {:dedent_lines, 3}, :normal},
+        {:reindent, ?=, 1, {:reindent_lines, 1}, :normal},
+        {:reindent, ?=, 3, {:reindent_lines, 3}, :normal}
+      ]
 
-  describe "integration via Mode.process/3" do
-    test "d in normal transitions to operator_pending" do
-      state = Mode.initial_state()
-      {new_mode, _cmds, new_state} = Mode.process(:normal, {?d, 0}, state)
-      assert new_mode == :operator_pending
-      assert new_state.operator == :delete
+      for {operator, key, count, command, mode} <- cases do
+        assert {:execute_then_transition, [^command], ^mode, _state} =
+                 OperatorPending.handle_key({key, 0}, op_state(operator, count))
+      end
     end
 
-    test "c in normal transitions to operator_pending with :change" do
-      state = Mode.initial_state()
-      {new_mode, _cmds, new_state} = Mode.process(:normal, {?c, 0}, state)
-      assert new_mode == :operator_pending
-      assert new_state.operator == :change
-    end
-
-    test "y in normal transitions to operator_pending with :yank" do
-      state = Mode.initial_state()
-      {new_mode, _cmds, new_state} = Mode.process(:normal, {?y, 0}, state)
-      assert new_mode == :operator_pending
-      assert new_state.operator == :yank
-    end
-
-    test "d then w produces delete_motion command and normal mode" do
-      state = Mode.initial_state()
-      {op_mode, _, op_state} = Mode.process(:normal, {?d, 0}, state)
-      assert op_mode == :operator_pending
-
-      {new_mode, cmds, _} = Mode.process(:operator_pending, {?w, 0}, op_state)
-      assert new_mode == :normal
-      assert [{:delete_motion, :word_forward}] = cmds
-    end
-
-    test "d then d produces {:delete_lines_counted, 1} command and normal mode" do
-      state = Mode.initial_state()
-      {_, _, op_state} = Mode.process(:normal, {?d, 0}, state)
-      {new_mode, cmds, _} = Mode.process(:operator_pending, {?d, 0}, op_state)
-      assert new_mode == :normal
-      assert cmds == [{:delete_lines_counted, 1}]
-    end
-
-    test "Escape from operator_pending returns to normal" do
-      state = Mode.initial_state()
-      {_, _, op_state} = Mode.process(:normal, {?d, 0}, state)
-      {new_mode, cmds, _} = Mode.process(:operator_pending, {27, 0}, op_state)
-      assert new_mode == :normal
-      assert cmds == []
-    end
-
-    test "3d saves op_count and transitions" do
-      state = Mode.initial_state()
-      {_, _, s1} = Mode.process(:normal, {?3, 0}, state)
-      {mode, _, op_state} = Mode.process(:normal, {?d, 0}, s1)
-      assert mode == :operator_pending
-      # op_count preserved (count was reset by reset_count, but op_count was saved first)
-      assert op_state.op_count == 3
-      assert op_state.count == nil
-    end
-  end
-
-  # ── Unknown key ────────────────────────────────────────────────────────────
-
-  describe "unknown key" do
-    test "unknown key is a no-op continue" do
+    test "escape returns base mode state and unknown keys continue unchanged" do
       state = op_state(:delete)
+      assert {:transition, :normal, %Mode.State{}} = OperatorPending.handle_key({27, 0}, state)
       assert {:continue, ^state} = OperatorPending.handle_key({?z, 0}, state)
     end
   end
 
-  # ── Indent operator (#57) ──────────────────────────────────────────────────
+  describe "Mode.process integration" do
+    test "normal mode enters operator-pending with operators and counts, then resolves commands" do
+      for {key, operator} <- [
+            {?d, :delete},
+            {?c, :change},
+            {?y, :yank},
+            {?>, :indent},
+            {?<, :dedent}
+          ] do
+        assert {:operator_pending, _commands, %{operator: ^operator, op_count: 1}} =
+                 Mode.process(:normal, {key, 0}, Mode.initial_state())
+      end
 
-  describe ">< (indent/dedent) operator entry from Normal" do
-    test "> from Normal transitions to :operator_pending with :indent" do
-      state = Mode.initial_state()
-      {mode, _cmds, op_state} = Mode.process(:normal, {?>, 0}, state)
-      assert mode == :operator_pending
-      assert op_state.operator == :indent
-      assert op_state.op_count == 1
-    end
+      {_, _, counted} = Mode.process(:normal, {?3, 0}, Mode.initial_state())
 
-    test "< from Normal transitions to :operator_pending with :dedent" do
-      state = Mode.initial_state()
-      {mode, _cmds, op_state} = Mode.process(:normal, {?<, 0}, state)
-      assert mode == :operator_pending
-      assert op_state.operator == :dedent
-      assert op_state.op_count == 1
-    end
+      assert {:operator_pending, _commands, %{operator: :delete, op_count: 3, count: nil}} =
+               Mode.process(:normal, {?d, 0}, counted)
 
-    test "3> from Normal gives op_count=3 for indent" do
-      state = Mode.initial_state()
-      {_, _, s1} = Mode.process(:normal, {?3, 0}, state)
-      {mode, _, op_state} = Mode.process(:normal, {?>, 0}, s1)
-      assert mode == :operator_pending
-      assert op_state.operator == :indent
-      assert op_state.op_count == 3
-    end
-  end
+      {_, _, op_state} = Mode.process(:normal, {?d, 0}, Mode.initial_state())
 
-  describe ">> (indent current lines)" do
-    test ">> emits {:indent_lines, 1} and returns to :normal" do
-      state = op_state(:indent)
+      assert {:normal, [{:delete_motion, :word_forward}], _state} =
+               Mode.process(:operator_pending, {?w, 0}, op_state)
 
-      assert {:execute_then_transition, [{:indent_lines, 1}], :normal, _} =
-               OperatorPending.handle_key({?>, 0}, state)
-    end
+      assert {:normal, [{:delete_lines_counted, 1}], _state} =
+               Mode.process(:operator_pending, {?d, 0}, op_state)
 
-    test ">> with op_count=3 emits {:indent_lines, 3}" do
-      state = op_state(:indent, 3)
-
-      assert {:execute_then_transition, [{:indent_lines, 3}], :normal, _} =
-               OperatorPending.handle_key({?>, 0}, state)
+      assert {:normal, [], _state} = Mode.process(:operator_pending, {27, 0}, op_state)
     end
   end
 
-  describe "<< (dedent current lines)" do
-    test "<< emits {:dedent_lines, 1} and returns to :normal" do
-      state = op_state(:dedent)
+  describe "indent, dedent, and reindent motions" do
+    test "formatting operators support line motions, paragraph/document motions, and gg" do
+      cases = [
+        {:indent, ?w, 0, {:indent_motion, :word_forward}},
+        {:indent, ?}, 0, {:indent_motion, :paragraph_forward}},
+        {:indent, ?G, 0, {:indent_motion, :document_end}},
+        {:dedent, ?w, 0, {:dedent_motion, :word_forward}},
+        {:reindent, ?w, 0, {:reindent_motion, :word_forward}},
+        {:reindent, ?G, 0, {:reindent_motion, :document_end}}
+      ]
 
-      assert {:execute_then_transition, [{:dedent_lines, 1}], :normal, _} =
-               OperatorPending.handle_key({?<, 0}, state)
+      for {operator, key, mods, command} <- cases do
+        assert {:execute_then_transition, [^command], :normal, _state} =
+                 OperatorPending.handle_key({key, mods}, op_state(operator))
+      end
+
+      for {operator, command} <- [
+            dedent: {:dedent_motion, :document_start},
+            reindent: {:reindent_motion, :document_start}
+          ] do
+        state = %OperatorPendingState{operator: operator, op_count: 1, pending_g: true}
+
+        assert {:execute_then_transition, [^command], :normal, _state} =
+                 OperatorPending.handle_key({?g, 0}, state)
+      end
     end
 
-    test "<< with op_count=3 emits {:dedent_lines, 3}" do
-      state = op_state(:dedent, 3)
+    test "reindent text objects emit structural object commands for inner and around modifiers" do
+      cases = [
+        {:inner, {:reindent_text_object, :inner, {:structural, :function}}},
+        {:around, {:reindent_text_object, :around, {:structural, :function}}}
+      ]
 
-      assert {:execute_then_transition, [{:dedent_lines, 3}], :normal, _} =
-               OperatorPending.handle_key({?<, 0}, state)
-    end
-  end
+      for {modifier, command} <- cases do
+        state = %OperatorPendingState{
+          operator: :reindent,
+          op_count: 1,
+          text_object_modifier: modifier
+        }
 
-  describe ">motion (indent to motion target)" do
-    test ">w emits {:indent_motion, :word_forward} and returns to :normal" do
-      state = op_state(:indent)
-
-      assert {:execute_then_transition, [{:indent_motion, :word_forward}], :normal, _} =
-               OperatorPending.handle_key({?w, 0}, state)
-    end
-
-    test ">} emits {:indent_motion, :paragraph_forward} and returns to :normal" do
-      state = op_state(:indent)
-
-      assert {:execute_then_transition, [{:indent_motion, :paragraph_forward}], :normal, _} =
-               OperatorPending.handle_key({?}, 0}, state)
-    end
-
-    test ">G emits {:indent_motion, :document_end} and returns to :normal" do
-      state = op_state(:indent)
-
-      assert {:execute_then_transition, [{:indent_motion, :document_end}], :normal, _} =
-               OperatorPending.handle_key({?G, 0}, state)
-    end
-  end
-
-  describe "<motion (dedent to motion target)" do
-    test "<w emits {:dedent_motion, :word_forward} and returns to :normal" do
-      state = op_state(:dedent)
-
-      assert {:execute_then_transition, [{:dedent_motion, :word_forward}], :normal, _} =
-               OperatorPending.handle_key({?w, 0}, state)
-    end
-
-    test "<gg emits {:dedent_motion, :document_start} and returns to :normal" do
-      state = %OperatorPendingState{operator: :dedent, op_count: 1, pending_g: true}
-
-      assert {:execute_then_transition, [{:dedent_motion, :document_start}], :normal, _} =
-               OperatorPending.handle_key({?g, 0}, state)
-    end
-  end
-
-  # ── Reindent (= operator) ─────────────────────────────────────────────────
-
-  describe "== (reindent current lines)" do
-    test "== emits {:reindent_lines, 1} and returns to :normal" do
-      state = op_state(:reindent)
-
-      assert {:execute_then_transition, [{:reindent_lines, 1}], :normal, _} =
-               OperatorPending.handle_key({?=, 0}, state)
-    end
-
-    test "== with op_count=3 emits {:reindent_lines, 3}" do
-      state = op_state(:reindent, 3)
-
-      assert {:execute_then_transition, [{:reindent_lines, 3}], :normal, _} =
-               OperatorPending.handle_key({?=, 0}, state)
-    end
-  end
-
-  describe "=motion (reindent to motion target)" do
-    test "=w emits {:reindent_motion, :word_forward} and returns to :normal" do
-      state = op_state(:reindent)
-
-      assert {:execute_then_transition, [{:reindent_motion, :word_forward}], :normal, _} =
-               OperatorPending.handle_key({?w, 0}, state)
-    end
-
-    test "=G emits {:reindent_motion, :document_end} and returns to :normal" do
-      state = op_state(:reindent)
-
-      assert {:execute_then_transition, [{:reindent_motion, :document_end}], :normal, _} =
-               OperatorPending.handle_key({?G, 0}, state)
-    end
-
-    test "=gg emits {:reindent_motion, :document_start} and returns to :normal" do
-      state = %OperatorPendingState{operator: :reindent, op_count: 1, pending_g: true}
-
-      assert {:execute_then_transition, [{:reindent_motion, :document_start}], :normal, _} =
-               OperatorPending.handle_key({?g, 0}, state)
-    end
-  end
-
-  describe "=<text_object> (reindent text object)" do
-    test "=if emits {:reindent_text_object, :inner, {:structural, :function}}" do
-      state = %OperatorPendingState{
-        operator: :reindent,
-        op_count: 1,
-        text_object_modifier: :inner
-      }
-
-      assert {:execute_then_transition,
-              [{:reindent_text_object, :inner, {:structural, :function}}], :normal, _} =
-               OperatorPending.handle_key({?f, 0}, state)
-    end
-
-    test "=af emits {:reindent_text_object, :around, {:structural, :function}}" do
-      state = %OperatorPendingState{
-        operator: :reindent,
-        op_count: 1,
-        text_object_modifier: :around
-      }
-
-      assert {:execute_then_transition,
-              [{:reindent_text_object, :around, {:structural, :function}}], :normal, _} =
-               OperatorPending.handle_key({?f, 0}, state)
+        assert {:execute_then_transition, [^command], :normal, _state} =
+                 OperatorPending.handle_key({?f, 0}, state)
+      end
     end
   end
 end

--- a/test/minga/mode/visual_test.exs
+++ b/test/minga/mode/visual_test.exs
@@ -5,495 +5,135 @@ defmodule Minga.Mode.VisualTest do
   alias Minga.Mode
   alias Minga.Mode.Normal
   alias Minga.Mode.Visual
-
   alias Minga.Mode.VisualState
 
-  # Build a fresh FSM state as if visual mode was just entered with anchor at
-  # the given position and the given type.
-  defp visual_state(anchor \\ {0, 0}, type \\ :char) do
-    %VisualState{visual_anchor: anchor, visual_type: type}
-  end
+  defp visual_state(anchor \\ {0, 0}, type \\ :char),
+    do: %VisualState{visual_anchor: anchor, visual_type: type}
 
-  # ── Entering visual from Normal ──────────────────────────────────────────────
+  describe "entering and leaving visual mode" do
+    test "v and V enter visual variants, display correctly, and round-trip out" do
+      assert {:visual, [], %VisualState{visual_type: :char, visual_anchor: {0, 0}}} =
+               Mode.process(:normal, {?v, 0}, Mode.initial_state())
 
-  describe "entering visual mode from Normal via 'v' (characterwise)" do
-    test "v transitions to :visual mode" do
-      state = Mode.initial_state()
-      {new_mode, commands, new_state} = Mode.process(:normal, {?v, 0}, state)
-      assert new_mode == :visual
-      assert commands == []
-      assert new_state.visual_type == :char
-    end
+      assert {:transition, :visual, %VisualState{visual_type: :char, visual_anchor: {0, 0}}} =
+               Normal.handle_key({?v, 0}, Mode.initial_state())
 
-    test "v sets visual_type to :char in the mode state" do
-      {:transition, :visual, new_state} = Normal.handle_key({?v, 0}, Mode.initial_state())
-      assert new_state.visual_type == :char
-    end
+      assert {:visual, [], %VisualState{visual_type: :line} = line_state} =
+               Mode.process(:normal, {?V, 0}, Mode.initial_state())
 
-    test "v returns VisualState with default anchor (editor overrides it)" do
-      {:transition, :visual, new_state} = Normal.handle_key({?v, 0}, Mode.initial_state())
-      assert %VisualState{} = new_state
-      # Default anchor is {0, 0}; the editor overwrites this with the real cursor position
-      assert new_state.visual_anchor == {0, 0}
-    end
-  end
+      assert {:transition, :visual, %VisualState{visual_type: :line}} =
+               Normal.handle_key({?V, 0}, Mode.initial_state())
 
-  describe "entering visual mode from Normal via 'V' (linewise)" do
-    test "V transitions to :visual mode" do
-      state = Mode.initial_state()
-      {new_mode, commands, new_state} = Mode.process(:normal, {?V, 0}, state)
-      assert new_mode == :visual
-      assert commands == []
-      assert new_state.visual_type == :line
-    end
-
-    test "V sets visual_type to :line in the mode state" do
-      {:transition, :visual, new_state} = Normal.handle_key({?V, 0}, Mode.initial_state())
-      assert new_state.visual_type == :line
-    end
-  end
-
-  # ── Escape cancels visual selection ─────────────────────────────────────────
-
-  describe "Escape cancels visual selection" do
-    test "Escape transitions back to :normal" do
-      state = visual_state({0, 0}, :char)
-      assert {:transition, :normal, _} = Visual.handle_key({27, 0}, state)
-    end
-
-    test "Escape with modifier also transitions to :normal" do
-      state = visual_state({2, 3}, :line)
-      assert {:transition, :normal, _} = Visual.handle_key({27, 4}, state)
-    end
-
-    test "Mode.process: Escape in visual returns :normal with no commands" do
-      state = visual_state({0, 0})
-      {new_mode, commands, _} = Mode.process(:visual, {27, 0}, state)
-      assert new_mode == :normal
-      assert commands == []
-    end
-  end
-
-  # ── Movement extends selection ───────────────────────────────────────────────
-
-  describe "movement keys in visual mode" do
-    test "h emits :move_left" do
-      state = visual_state()
-      assert {:execute, :move_left, _} = Visual.handle_key({?h, 0}, state)
-    end
-
-    test "j emits :move_down" do
-      state = visual_state()
-      assert {:execute, :move_down, _} = Visual.handle_key({?j, 0}, state)
-    end
-
-    test "k emits :move_up" do
-      state = visual_state()
-      assert {:execute, :move_up, _} = Visual.handle_key({?k, 0}, state)
-    end
-
-    test "l emits :move_right" do
-      state = visual_state()
-      assert {:execute, :move_right, _} = Visual.handle_key({?l, 0}, state)
-    end
-
-    test "Alt+h emits structural parent navigation" do
-      state = visual_state()
-      assert {:execute, :nav_parent, _} = Visual.handle_key({?h, 0x04}, state)
-    end
-
-    test "Alt+l emits structural first child navigation" do
-      state = visual_state()
-      assert {:execute, :nav_first_child, _} = Visual.handle_key({?l, 0x04}, state)
-    end
-
-    test "Alt+j emits structural next sibling navigation" do
-      state = visual_state()
-      assert {:execute, :nav_next_sibling, _} = Visual.handle_key({?j, 0x04}, state)
-    end
-
-    test "Alt+k emits structural previous sibling navigation" do
-      state = visual_state()
-      assert {:execute, :nav_prev_sibling, _} = Visual.handle_key({?k, 0x04}, state)
-    end
-
-    test "w emits :word_forward" do
-      state = visual_state()
-      assert {:execute, :word_forward, _} = Visual.handle_key({?w, 0}, state)
-    end
-
-    test "b emits :word_backward" do
-      state = visual_state()
-      assert {:execute, :word_backward, _} = Visual.handle_key({?b, 0}, state)
-    end
-
-    test "e emits :word_end" do
-      state = visual_state()
-      assert {:execute, :word_end, _} = Visual.handle_key({?e, 0}, state)
-    end
-
-    test "Mode.process: j in visual emits :move_down and stays in :visual" do
-      state = visual_state()
-      {new_mode, commands, _} = Mode.process(:visual, {?j, 0}, state)
-      assert new_mode == :visual
-      assert commands == [:move_down]
-    end
-
-    test "Mode.process: movement stays in visual mode (does not cancel selection)" do
-      state = visual_state({1, 2})
-      {new_mode, _, new_state} = Mode.process(:visual, {?l, 0}, state)
-      assert new_mode == :visual
-      # anchor is preserved through movements
-      assert new_state.visual_anchor == {1, 2}
-    end
-  end
-
-  describe "page / half-page scrolling in visual mode" do
-    test "Ctrl+d emits :half_page_down" do
-      assert {:execute, :half_page_down, _} = Visual.handle_key({?d, 0x02}, visual_state())
-    end
-
-    test "Ctrl+u emits :half_page_up" do
-      assert {:execute, :half_page_up, _} = Visual.handle_key({?u, 0x02}, visual_state())
-    end
-
-    test "Ctrl+f emits :page_down" do
-      assert {:execute, :page_down, _} = Visual.handle_key({?f, 0x02}, visual_state())
-    end
-
-    test "Ctrl+b emits :page_up" do
-      assert {:execute, :page_up, _} = Visual.handle_key({?b, 0x02}, visual_state())
-    end
-  end
-
-  describe "arrow keys in visual mode" do
-    test "up arrow (57_352) emits :move_up" do
-      assert {:execute, :move_up, _} = Visual.handle_key({57_352, 0}, visual_state())
-    end
-
-    test "down arrow (57_353) emits :move_down" do
-      assert {:execute, :move_down, _} = Visual.handle_key({57_353, 0}, visual_state())
-    end
-
-    test "left arrow (57_350) emits :move_left" do
-      assert {:execute, :move_left, _} = Visual.handle_key({57_350, 0}, visual_state())
-    end
-
-    test "right arrow (57_351) emits :move_right" do
-      assert {:execute, :move_right, _} = Visual.handle_key({57_351, 0}, visual_state())
-    end
-  end
-
-  # ── Operators on selection ───────────────────────────────────────────────────
-
-  describe "d — delete selection, transition to Normal" do
-    test "d emits :delete_visual_selection and transitions to :normal" do
-      state = visual_state({0, 0}, :char)
-
-      assert {:execute_then_transition, [:delete_visual_selection], :normal, _} =
-               Visual.handle_key({?d, 0}, state)
-    end
-
-    test "Mode.process: d returns :normal mode with :delete_visual_selection command" do
-      state = visual_state()
-      {new_mode, commands, _} = Mode.process(:visual, {?d, 0}, state)
-      assert new_mode == :normal
-      assert commands == [:delete_visual_selection]
-    end
-
-    test "d works identically in linewise visual mode" do
-      state = visual_state({2, 0}, :line)
-
-      assert {:execute_then_transition, [:delete_visual_selection], :normal, _} =
-               Visual.handle_key({?d, 0}, state)
-    end
-  end
-
-  describe "x deletes selection and transitions to Normal" do
-    test "x behaves exactly like d for visual delete" do
-      state = visual_state({0, 0}, :char)
-
-      assert Visual.handle_key({?x, 0}, state) == Visual.handle_key({?d, 0}, state)
-    end
-
-    test "x emits :delete_visual_selection and transitions to :normal" do
-      state = visual_state({0, 0}, :char)
-
-      assert {:execute_then_transition, [:delete_visual_selection], :normal, _} =
-               Visual.handle_key({?x, 0}, state)
-    end
-
-    test "Mode.process: x returns :normal mode with :delete_visual_selection command" do
-      state = visual_state()
-      {new_mode, commands, _} = Mode.process(:visual, {?x, 0}, state)
-      assert new_mode == :normal
-      assert commands == [:delete_visual_selection]
-    end
-
-    test "x works identically in linewise visual mode" do
-      state = visual_state({2, 0}, :line)
-
-      assert {:execute_then_transition, [:delete_visual_selection], :normal, _} =
-               Visual.handle_key({?x, 0}, state)
-    end
-  end
-
-  describe "c — delete selection, transition to Insert" do
-    test "c emits :delete_visual_selection and transitions to :insert" do
-      state = visual_state({0, 3}, :char)
-
-      assert {:execute_then_transition, [:delete_visual_selection], :insert, _} =
-               Visual.handle_key({?c, 0}, state)
-    end
-
-    test "Mode.process: c returns :insert mode with :delete_visual_selection command" do
-      state = visual_state()
-      {new_mode, commands, _} = Mode.process(:visual, {?c, 0}, state)
-      assert new_mode == :insert
-      assert commands == [:delete_visual_selection]
-    end
-  end
-
-  describe "y — yank selection, transition to Normal" do
-    test "y emits :yank_visual_selection and transitions to :normal" do
-      state = visual_state({1, 4}, :char)
-
-      assert {:execute_then_transition, [:yank_visual_selection], :normal, _} =
-               Visual.handle_key({?y, 0}, state)
-    end
-
-    test "Mode.process: y returns :normal mode with :yank_visual_selection command" do
-      state = visual_state()
-      {new_mode, commands, _} = Mode.process(:visual, {?y, 0}, state)
-      assert new_mode == :normal
-      assert commands == [:yank_visual_selection]
-    end
-
-    test "y does not modify the state (buffer unchanged at mode level)" do
-      state = visual_state({0, 0})
-      {:execute_then_transition, _, _, returned_state} = Visual.handle_key({?y, 0}, state)
-      assert returned_state == state
-    end
-  end
-
-  # ── Linewise vs characterwise ────────────────────────────────────────────────
-
-  describe "linewise visual mode (V)" do
-    test "visual_type is :line when entered via V" do
-      {:transition, :visual, new_state} = Normal.handle_key({?V, 0}, Mode.initial_state())
-      assert new_state.visual_type == :line
-    end
-
-    test "operators in linewise visual still emit the same commands" do
-      state = visual_state({3, 0}, :line)
-
-      assert {:execute_then_transition, [:delete_visual_selection], :normal, _} =
-               Visual.handle_key({?d, 0}, state)
-    end
-
-    test "Mode.display shows -- VISUAL LINE -- for linewise" do
       assert Mode.display(:visual, %VisualState{visual_type: :line}) == "-- VISUAL LINE --"
-    end
-
-    test "Mode.display shows -- VISUAL -- for characterwise" do
       assert Mode.display(:visual, %{visual_type: :char}) == "-- VISUAL --"
-    end
-
-    test "Mode.display/1 still shows -- VISUAL -- for backward compat" do
       assert Mode.display(:visual) == "-- VISUAL --"
+
+      assert {:normal, [], _state} = Mode.process(:visual, {27, 0}, visual_state())
+      assert {:transition, :normal, _state} = Visual.handle_key({27, 4}, line_state)
+    end
+
+    test "movement, structural navigation, scrolling, and arrows stay in visual mode and preserve anchor" do
+      cases = [
+        {{?h, 0}, :move_left},
+        {{?j, 0}, :move_down},
+        {{?k, 0}, :move_up},
+        {{?l, 0}, :move_right},
+        {{?h, 0x04}, :nav_parent},
+        {{?l, 0x04}, :nav_first_child},
+        {{?j, 0x04}, :nav_next_sibling},
+        {{?k, 0x04}, :nav_prev_sibling},
+        {{?w, 0}, :word_forward},
+        {{?b, 0}, :word_backward},
+        {{?e, 0}, :word_end},
+        {{?d, 0x02}, :half_page_down},
+        {{?u, 0x02}, :half_page_up},
+        {{?f, 0x02}, :page_down},
+        {{?b, 0x02}, :page_up},
+        {{57_352, 0}, :move_up},
+        {{57_353, 0}, :move_down},
+        {{57_350, 0}, :move_left},
+        {{57_351, 0}, :move_right}
+      ]
+
+      for {key, command} <- cases do
+        assert {:execute, ^command, _state} = Visual.handle_key(key, visual_state({1, 2}))
+
+        assert {:visual, [^command], %VisualState{visual_anchor: {1, 2}}} =
+                 Mode.process(:visual, key, visual_state({1, 2}))
+      end
     end
   end
 
-  # ── Unknown keys ────────────────────────────────────────────────────────────
+  describe "selection operators" do
+    test "delete, change, yank, indent, and dedent emit selection commands and transition appropriately" do
+      cases = [
+        {?d, :normal, [:delete_visual_selection]},
+        {?x, :normal, [:delete_visual_selection]},
+        {?c, :insert, [:delete_visual_selection]},
+        {?y, :normal, [:yank_visual_selection]},
+        {?>, :normal, [:indent_visual_selection]},
+        {?<, :normal, [:dedent_visual_selection]}
+      ]
 
-  describe "> and < indent/dedent in visual mode (#57)" do
-    test "> emits :indent_visual_selection and transitions to :normal" do
-      state = visual_state({0, 0}, :char)
+      for {key, mode, commands} <- cases do
+        assert {:execute_then_transition, ^commands, ^mode, returned_state} =
+                 Visual.handle_key({key, 0}, visual_state({2, 0}, :line))
 
-      assert {:execute_then_transition, [:indent_visual_selection], :normal, _} =
-               Visual.handle_key({?>, 0}, state)
+        assert returned_state == visual_state({2, 0}, :line)
+        assert {^mode, ^commands, _state} = Mode.process(:visual, {key, 0}, visual_state())
+      end
+
+      assert Visual.handle_key({?x, 0}, visual_state()) ==
+               Visual.handle_key({?d, 0}, visual_state())
     end
 
-    test "< emits :dedent_visual_selection and transitions to :normal" do
-      state = visual_state({0, 0}, :char)
-
-      assert {:execute_then_transition, [:dedent_visual_selection], :normal, _} =
-               Visual.handle_key({?<, 0}, state)
-    end
-
-    test "> works in linewise visual mode" do
-      state = visual_state({2, 0}, :line)
-
-      assert {:execute_then_transition, [:indent_visual_selection], :normal, _} =
-               Visual.handle_key({?>, 0}, state)
-    end
-
-    test "< works in linewise visual mode" do
-      state = visual_state({2, 0}, :line)
-
-      assert {:execute_then_transition, [:dedent_visual_selection], :normal, _} =
-               Visual.handle_key({?<, 0}, state)
-    end
-
-    test "Mode.process: > returns :normal mode with :indent_visual_selection command" do
-      state = visual_state()
-      {new_mode, commands, _} = Mode.process(:visual, {?>, 0}, state)
-      assert new_mode == :normal
-      assert commands == [:indent_visual_selection]
-    end
-
-    test "Mode.process: < returns :normal mode with :dedent_visual_selection command" do
-      state = visual_state()
-      {new_mode, commands, _} = Mode.process(:visual, {?<, 0}, state)
-      assert new_mode == :normal
-      assert commands == [:dedent_visual_selection]
-    end
-  end
-
-  describe "unknown keys in visual mode" do
-    test "unknown key produces {:continue, state}" do
-      state = visual_state({0, 0})
-      assert {:continue, ^state} = Visual.handle_key({?z, 0}, state)
-    end
-
-    test "control character is ignored" do
-      state = visual_state()
-      assert {:continue, _} = Visual.handle_key({?x, 2}, state)
-    end
-
-    test "unknown key does not alter mode state" do
+    test "unknown and modified keys continue without mutating state" do
       state = visual_state({2, 5}, :line)
-      {:continue, returned} = Visual.handle_key({?q, 0}, state)
-      assert returned.visual_anchor == {2, 5}
-      assert returned.visual_type == :line
+      assert {:continue, ^state} = Visual.handle_key({?z, 0}, state)
+      assert {:continue, ^state} = Visual.handle_key({?q, 0}, state)
+      assert {:continue, ^state} = Visual.handle_key({?x, 2}, state)
     end
   end
 
-  # ── Round-trip: Normal → Visual → Normal ────────────────────────────────────
-
-  describe "Normal → Visual → Normal round-trip" do
-    test "v enters visual, Escape returns to normal" do
-      s0 = Mode.initial_state()
-      {mode1, _, s1} = Mode.process(:normal, {?v, 0}, s0)
-      assert mode1 == :visual
-
-      {mode2, _, _} = Mode.process(:visual, {27, 0}, s1)
-      assert mode2 == :normal
-    end
-
-    test "V enters visual line, d exits to normal" do
-      s0 = Mode.initial_state()
-      {mode1, _, s1} = Mode.process(:normal, {?V, 0}, s0)
-      assert mode1 == :visual
-      assert s1.visual_type == :line
-
-      {mode2, cmds, _} = Mode.process(:visual, {?d, 0}, s1)
-      assert mode2 == :normal
-      assert cmds == [:delete_visual_selection]
-    end
-
-    test "v enters visual, c exits to insert" do
-      s0 = Mode.initial_state()
-      {_mode, _, s1} = Mode.process(:normal, {?v, 0}, s0)
-      {mode2, cmds, _} = Mode.process(:visual, {?c, 0}, s1)
-      assert mode2 == :insert
-      assert cmds == [:delete_visual_selection]
-    end
-  end
-
-  # ── Integration: buffer operations ──────────────────────────────────────────
-
-  describe "delete_visual_selection with real buffer (characterwise)" do
-    setup do
+  describe "buffer selection behavior" do
+    test "characterwise selection deletes and yanks inclusive ranges" do
       {:ok, buf} = BufferProcess.start_link(content: "hello world\nfoo bar")
-      {:ok, buf: buf}
-    end
-
-    test "deleting 'hello' from start of line", %{buf: buf} do
-      # Place cursor at col 4 (on 'o')
       BufferProcess.move_to(buf, {0, 4})
 
-      # Simulate: anchor={0,0}, cursor={0,4}, delete char selection
-      anchor = {0, 0}
-      cursor = BufferProcess.cursor(buf)
-      assert cursor == {0, 4}
+      assert BufferProcess.text_between_inclusive(buf, {0, 0}, BufferProcess.cursor(buf)) ==
+               "hello"
 
-      # delete_range is inclusive on both ends
-      BufferProcess.delete_range(buf, anchor, cursor)
-
+      BufferProcess.delete_range(buf, {0, 0}, BufferProcess.cursor(buf))
       assert BufferProcess.content(buf) == " world\nfoo bar"
     end
 
-    test "yanking a range returns correct text", %{buf: buf} do
-      BufferProcess.move_to(buf, {0, 4})
-      text = BufferProcess.text_between_inclusive(buf, {0, 0}, {0, 4})
-      assert text == "hello"
-    end
-  end
-
-  describe "delete_visual_selection with real buffer (linewise)" do
-    setup do
+    test "linewise selection deletes line ranges and reads joined content" do
       {:ok, buf} = BufferProcess.start_link(content: "line one\nline two\nline three")
-      {:ok, buf: buf}
-    end
+      assert BufferProcess.content_on_lines(buf, 0, 1) == "line one\nline two"
 
-    test "deleting first two lines leaves only the third", %{buf: buf} do
-      BufferProcess.delete_lines(buf, 0, 1)
-      assert BufferProcess.content(buf) == "line three"
-    end
-
-    test "deleting the middle line preserves surrounding lines", %{buf: buf} do
       BufferProcess.delete_lines(buf, 1, 1)
       assert BufferProcess.content(buf) == "line one\nline three"
-    end
 
-    test "deleting all lines leaves an empty buffer", %{buf: buf} do
-      BufferProcess.delete_lines(buf, 0, 2)
+      BufferProcess.delete_lines(buf, 0, 1)
       assert BufferProcess.content(buf) == ""
-    end
-
-    test "content_on_lines returns joined text of a range", %{buf: buf} do
-      text = BufferProcess.content_on_lines(buf, 0, 1)
-      assert text == "line one\nline two"
     end
   end
 
-  # ── Visual wrapping ────────────────────────────────────────────────────────
+  describe "wrapping selections" do
+    test "paired delimiter keys wrap visual selections" do
+      cases = [
+        {?(, "(", ")"},
+        {?[, "[", "]"},
+        {?", "\"", "\""},
+        {?', "'", "'"},
+        {?`, "`", "`"}
+      ]
 
-  describe "wrapping with paired delimiters" do
-    test "( wraps selection in parens" do
-      state = visual_state({0, 0}, :char)
-      result = Visual.handle_key({?(, 0}, state)
-      assert {:execute_then_transition, [{:wrap_visual_selection, "(", ")"}], :normal, _} = result
-    end
-
-    test "[ wraps selection in brackets" do
-      state = visual_state({0, 0}, :char)
-      result = Visual.handle_key({?[, 0}, state)
-      assert {:execute_then_transition, [{:wrap_visual_selection, "[", "]"}], :normal, _} = result
-    end
-
-    # Note: { is paragraph-backward in Visual mode, so wrapping in braces
-    # is not available. Use operator-pending text objects instead.
-
-    test "\" wraps selection in double quotes" do
-      state = visual_state({0, 0}, :char)
-      result = Visual.handle_key({?", 0}, state)
-
-      assert {:execute_then_transition, [{:wrap_visual_selection, "\"", "\""}], :normal, _} =
-               result
-    end
-
-    test "' wraps selection in single quotes" do
-      state = visual_state({0, 0}, :char)
-      result = Visual.handle_key({?', 0}, state)
-      assert {:execute_then_transition, [{:wrap_visual_selection, "'", "'"}], :normal, _} = result
-    end
-
-    test "` wraps selection in backticks" do
-      state = visual_state({0, 0}, :char)
-      result = Visual.handle_key({?`, 0}, state)
-      assert {:execute_then_transition, [{:wrap_visual_selection, "`", "`"}], :normal, _} = result
+      for {key, left, right} <- cases do
+        assert {:execute_then_transition, [{:wrap_visual_selection, ^left, ^right}], :normal,
+                _state} =
+                 Visual.handle_key({key, 0}, visual_state())
+      end
     end
   end
 end

--- a/test/minga_editor/window_test.exs
+++ b/test/minga_editor/window_test.exs
@@ -1,17 +1,17 @@
 defmodule MingaEditor.WindowTest do
   use ExUnit.Case, async: true
 
-  alias MingaEditor.Window
   alias MingaEditor.UI.Popup.Active, as: PopupActive
   alias MingaEditor.UI.Popup.Rule, as: PopupRule
+  alias MingaEditor.Window
 
   defp make_window(opts \\ []) do
     buffer = Keyword.get_lazy(opts, :buffer, fn -> spawn(fn -> :ok end) end)
     Window.new(1, buffer, 24, 80)
   end
 
-  describe "new/4" do
-    test "creates a window with the given id, buffer, and dimensions" do
+  describe "construction and resizing" do
+    test "new windows initialize viewport, content, popup metadata, and empty render cache sentinels" do
       buffer = spawn(fn -> :ok end)
       window = Window.new(1, buffer, 24, 80)
 
@@ -21,442 +21,226 @@ defmodule MingaEditor.WindowTest do
       assert window.viewport.cols == 80
       assert window.viewport.top == 0
       assert window.viewport.left == 0
-    end
-
-    test "initializes with empty dirty set (sentinel values trigger full redraw on first detect)" do
-      window = make_window()
+      assert window.popup_meta == nil
+      refute Window.popup?(window)
       assert window.render_cache.dirty_lines == %{}
-    end
-
-    test "initializes with empty caches" do
-      window = make_window()
       assert window.render_cache.cached_gutter == %{}
       assert window.render_cache.cached_content == %{}
+
+      for field <- [
+            :last_viewport_top,
+            :last_viewport_cache_key,
+            :last_gutter_w,
+            :last_line_count,
+            :last_cursor_line,
+            :last_buf_version
+          ] do
+        assert Map.fetch!(window.render_cache, field) == -1
+      end
     end
 
-    test "initializes tracking fields to sentinel values" do
-      window = make_window()
-      assert window.render_cache.last_viewport_top == -1
-      assert window.render_cache.last_viewport_cache_key == -1
-      assert window.render_cache.last_gutter_w == -1
-      assert window.render_cache.last_line_count == -1
-      assert window.render_cache.last_cursor_line == -1
-      assert window.render_cache.last_buf_version == -1
-    end
-  end
+    test "resize updates viewport and fully invalidates cached render state" do
+      window =
+        make_window()
+        |> cached_window()
+        |> with_tracking(last_buf_version: 5, last_context_fingerprint: :fp, dirty_lines: %{})
 
-  describe "resize/3" do
-    test "updates viewport dimensions" do
-      window = make_window()
       resized = Window.resize(window, 12, 40)
 
+      assert resized.id == 1
       assert resized.viewport.rows == 12
       assert resized.viewport.cols == 40
-      assert resized.id == 1
-    end
-
-    test "marks all lines dirty and clears caches" do
-      window = make_window()
-      # Simulate a previous render with populated caches
-      window = Window.cache_line(window, 0, [{0, 0, "1", []}], [{0, 4, "hi", []}])
-
-      window = %{
-        window
-        | render_cache: %{
-            window.render_cache
-            | dirty_lines: %{},
-              last_buf_version: 5,
-              last_context_fingerprint: :fp
-          }
-      }
-
-      resized = Window.resize(window, 12, 40)
-
-      assert resized.render_cache.dirty_lines == :all
-      assert resized.render_cache.cached_gutter == %{}
-      assert resized.render_cache.cached_content == %{}
-      assert resized.render_cache.last_buf_version == -1
-      assert resized.render_cache.last_context_fingerprint == nil
+      assert_fully_invalidated(resized)
     end
   end
 
-  describe "mark_dirty/2" do
-    test "marks specific lines dirty" do
-      window = make_window()
-      window = Window.mark_dirty(window, [5, 10, 15])
-
-      assert Map.has_key?(window.render_cache.dirty_lines, 5)
-      assert Map.has_key?(window.render_cache.dirty_lines, 10)
-      assert Map.has_key?(window.render_cache.dirty_lines, 15)
-      refute Map.has_key?(window.render_cache.dirty_lines, 6)
-    end
-
-    test "accumulates dirty lines across calls" do
-      window = make_window()
-      window = Window.mark_dirty(window, [5])
-      window = Window.mark_dirty(window, [10])
-
-      assert Map.has_key?(window.render_cache.dirty_lines, 5)
-      assert Map.has_key?(window.render_cache.dirty_lines, 10)
-    end
-
-    test "marks all lines dirty with :all" do
-      window = make_window()
-      window = Window.mark_dirty(window, [1, 2, 3])
-      window = Window.mark_dirty(window, :all)
-      assert window.render_cache.dirty_lines == :all
-    end
-
-    test "adding specific lines to :all is a no-op" do
-      window = Window.invalidate(make_window())
-      assert window.render_cache.dirty_lines == :all
-      window = Window.mark_dirty(window, [5, 10])
-      assert window.render_cache.dirty_lines == :all
-    end
-  end
-
-  describe "invalidate/1" do
-    test "sets dirty_lines to :all and clears all render state" do
-      window = make_window()
-      window = Window.cache_line(window, 0, [{0, 0, "1", []}], [{0, 4, "hi", []}])
-
-      window = %{
-        window
-        | render_cache: %{
-            window.render_cache
-            | dirty_lines: Map.new([1, 2], &{&1, true}),
-              last_buf_version: 5,
-              last_context_fingerprint: :fp
-          }
-      }
-
-      window = Window.invalidate(window)
-
-      assert window.render_cache.dirty_lines == :all
-      assert window.render_cache.cached_gutter == %{}
-      assert window.render_cache.cached_content == %{}
-      assert window.render_cache.last_viewport_top == -1
-      assert window.render_cache.last_gutter_w == -1
-      assert window.render_cache.last_line_count == -1
-      assert window.render_cache.last_cursor_line == -1
-      assert window.render_cache.last_buf_version == -1
-      assert window.render_cache.last_context_fingerprint == nil
-    end
-  end
-
-  describe "dirty?/2" do
-    test "returns true for any line when dirty_lines is :all" do
-      window = Window.invalidate(make_window())
-      assert Window.dirty?(window, 0)
-      assert Window.dirty?(window, 999)
-    end
-
-    test "returns true only for lines in the dirty set" do
-      window = make_window()
-      window = Window.mark_dirty(window, [5, 10])
-      assert Window.dirty?(window, 5)
-      assert Window.dirty?(window, 10)
-      refute Window.dirty?(window, 0)
-      refute Window.dirty?(window, 6)
-    end
-
-    test "returns false for any line when dirty set is empty" do
+  describe "dirty-line tracking and invalidation" do
+    test "mark_dirty, dirty?, and invalidate handle targeted and full redraw states" do
       window = make_window()
       refute Window.dirty?(window, 0)
       refute Window.dirty?(window, 5)
+
+      window = window |> Window.mark_dirty([5]) |> Window.mark_dirty([10, 15])
+      assert Window.dirty?(window, 5)
+      assert Window.dirty?(window, 10)
+      assert Window.dirty?(window, 15)
+      refute Window.dirty?(window, 6)
+
+      window = Window.mark_dirty(window, :all)
+      assert window.render_cache.dirty_lines == :all
+      assert Window.dirty?(window, 0)
+      assert Window.dirty?(window, 999)
+
+      assert Window.mark_dirty(window, [5, 10]).render_cache.dirty_lines == :all
+      assert_fully_invalidated(Window.invalidate(cached_window(make_window())))
+    end
+
+    test "detect_invalidation only invalidates on structural render changes and preserves targeted dirtiness otherwise" do
+      window = Window.snapshot_after_render(make_window(), 0, 4, 100, 10, 5, :test_fp)
+      assert Window.detect_invalidation(window, 0, 4, 100, 5).render_cache.dirty_lines == %{}
+
+      invalidating_inputs = [
+        {5, 4, 100, 5},
+        {0, 5, 100, 5},
+        {0, 4, 101, 5},
+        {0, 4, 100, 6}
+      ]
+
+      for {viewport_top, gutter_w, line_count, version} <- invalidating_inputs do
+        result = Window.detect_invalidation(window, viewport_top, gutter_w, line_count, version)
+        assert result.render_cache.dirty_lines == :all
+      end
+
+      first_frame = Window.detect_invalidation(make_window(), 0, 4, 100, 1)
+      assert first_frame.render_cache.dirty_lines == :all
+
+      targeted = Window.mark_dirty(window, [5, 10])
+
+      assert Window.detect_invalidation(targeted, 0, 4, 100, 5).render_cache.dirty_lines ==
+               Map.new([5, 10], &{&1, true})
     end
   end
 
-  describe "detect_invalidation/5" do
-    setup do
-      window = make_window()
-
-      # Simulate a previous render that set tracking fields
-      window =
-        Window.snapshot_after_render(
-          window,
-          _viewport_top = 0,
-          _gutter_w = 4,
-          _line_count = 100,
-          _cursor_line = 10,
-          _buf_version = 5,
-          _fingerprint = :test_fp
-        )
-
-      %{window: window}
-    end
-
-    test "no invalidation when nothing changed", %{window: window} do
-      result = Window.detect_invalidation(window, 0, 4, 100, 5)
-      assert result.render_cache.dirty_lines == %{}
-    end
-
-    test "full invalidation when viewport scrolled", %{window: window} do
-      result = Window.detect_invalidation(window, 5, 4, 100, 5)
-      assert result.render_cache.dirty_lines == :all
-    end
-
-    test "full invalidation when gutter width changed", %{window: window} do
-      result = Window.detect_invalidation(window, 0, 5, 100, 5)
-      assert result.render_cache.dirty_lines == :all
-    end
-
-    test "full invalidation when line count changed", %{window: window} do
-      result = Window.detect_invalidation(window, 0, 4, 101, 5)
-      assert result.render_cache.dirty_lines == :all
-    end
-
-    test "full invalidation when buffer version changed without line count change", %{
-      window: window
-    } do
-      result = Window.detect_invalidation(window, 0, 4, 100, 6)
-      assert result.render_cache.dirty_lines == :all
-    end
-
-    test "full invalidation on first frame (sentinel tracking values)", %{window: _window} do
-      # Fresh window has sentinel last_buf_version=-1 → always full redraw
-      fresh = make_window()
-      result = Window.detect_invalidation(fresh, 0, 4, 100, 1)
-      assert result.render_cache.dirty_lines == :all
-    end
-
-    test "preserves existing dirty lines when no full invalidation needed", %{window: window} do
-      window = Window.mark_dirty(window, [5, 10])
-      result = Window.detect_invalidation(window, 0, 4, 100, 5)
-      assert result.render_cache.dirty_lines == Map.new([5, 10], &{&1, true})
-    end
-  end
-
-  describe "cache_line/4" do
-    test "stores gutter and content draws for a buffer line" do
+  describe "render cache lifecycle" do
+    test "cache_line stores and overwrites draws, snapshot stores tracking fields, and prune_cache bounds both caches" do
       window = make_window()
       gutter = [{0, 0, "  1", []}]
       content = [{0, 4, "hello world", []}]
-
       window = Window.cache_line(window, 0, gutter, content)
-
       assert window.render_cache.cached_gutter[0] == gutter
       assert window.render_cache.cached_content[0] == content
-    end
 
-    test "overwrites previous cache for the same line" do
-      window = make_window()
-      old_content = [{0, 4, "old text", []}]
-      new_content = [{0, 4, "new text", []}]
+      window = Window.cache_line(window, 0, [], [{0, 4, "new text", []}])
+      assert window.render_cache.cached_content[0] == [{0, 4, "new text", []}]
 
-      window = Window.cache_line(window, 5, [], old_content)
-      window = Window.cache_line(window, 5, [], new_content)
+      window =
+        Enum.reduce(1..20, window, fn line, acc ->
+          Window.cache_line(acc, line, [{line, 0, "#{line}", []}], [{line, 4, "text", []}])
+        end)
 
-      assert window.render_cache.cached_content[5] == new_content
-    end
+      assert map_size(window.render_cache.cached_gutter) == 21
+      assert map_size(window.render_cache.cached_content) == 21
 
-    test "caching multiple lines builds up the map" do
-      window = make_window()
+      pruned = Window.prune_cache(window, 5, 15)
+      assert map_size(pruned.render_cache.cached_content) == 11
+      assert map_size(pruned.render_cache.cached_gutter) == 11
+      refute Map.has_key?(pruned.render_cache.cached_content, 4)
+      assert Map.has_key?(pruned.render_cache.cached_content, 5)
+      assert Map.has_key?(pruned.render_cache.cached_content, 15)
+      refute Map.has_key?(pruned.render_cache.cached_content, 16)
 
-      window = Window.cache_line(window, 0, [{0, 0, "1", []}], [{0, 4, "line 0", []}])
-      window = Window.cache_line(window, 1, [{1, 0, "2", []}], [{1, 4, "line 1", []}])
-      window = Window.cache_line(window, 2, [{2, 0, "3", []}], [{2, 4, "line 2", []}])
-
-      assert map_size(window.render_cache.cached_gutter) == 3
-      assert map_size(window.render_cache.cached_content) == 3
-    end
-  end
-
-  describe "snapshot_after_render/7" do
-    test "clears the dirty set" do
-      window = Window.invalidate(make_window())
+      window = Window.invalidate(window)
       assert window.render_cache.dirty_lines == :all
 
-      window = Window.snapshot_after_render(window, 0, 4, 100, 10, 5, :test_fp)
-      assert window.render_cache.dirty_lines == %{}
-    end
-
-    test "updates all tracking fields" do
-      window = make_window()
       window = Window.snapshot_after_render(window, 10, 77, 5, 200, 25, 42, :test_fp)
-
+      assert window.render_cache.dirty_lines == %{}
       assert window.render_cache.last_viewport_top == 10
       assert window.render_cache.last_viewport_cache_key == 77
       assert window.render_cache.last_gutter_w == 5
       assert window.render_cache.last_line_count == 200
       assert window.render_cache.last_cursor_line == 25
       assert window.render_cache.last_buf_version == 42
-    end
-  end
 
-  describe "detect_context_change/2" do
-    test "marks all dirty when fingerprint changes" do
+      empty = Window.prune_cache(make_window(), 0, 10)
+      assert empty.render_cache.cached_content == %{}
+      assert empty.render_cache.cached_gutter == %{}
+    end
+
+    test "full dirty-line lifecycle covers first frame, clean frame, edit invalidation, and scroll invalidation" do
       window = make_window()
-      window = Window.snapshot_after_render(window, 0, 4, 100, 5, 1, :fp_a)
       assert window.render_cache.dirty_lines == %{}
 
-      window = Window.detect_context_change(window, :fp_b)
-      assert window.render_cache.dirty_lines == :all
-    end
-
-    test "marks all dirty when measured oracle cache contents differ" do
-      oracle1 = Minga.Core.WidthOracle.Measured.new(%{"wide" => 50})
-      oracle2 = Minga.Core.WidthOracle.Measured.new(%{"narrow" => 7})
-
-      fp1 = Minga.Core.WidthOracle.fingerprint(oracle1)
-      fp2 = Minga.Core.WidthOracle.fingerprint(oracle2)
-
-      refute fp1 == fp2
-
-      window = make_window()
-      window = Window.snapshot_after_render(window, 0, 4, 100, 5, 1, fp1)
-      window = Window.detect_context_change(window, fp2)
-
-      assert window.render_cache.dirty_lines == :all
-    end
-
-    test "no-op when fingerprint is the same" do
-      window = make_window()
-      window = Window.snapshot_after_render(window, 0, 4, 100, 5, 1, :fp_a)
-      assert window.render_cache.dirty_lines == %{}
-
-      window = Window.detect_context_change(window, :fp_a)
-      assert window.render_cache.dirty_lines == %{}
-    end
-
-    test "no-op when last fingerprint is nil (first frame)" do
-      window = make_window()
-      assert window.render_cache.last_context_fingerprint == nil
-
-      window = Window.detect_context_change(window, :fp_a)
-      assert window.render_cache.dirty_lines == %{}
-    end
-
-    test "detects changes in complex fingerprint tuples" do
-      fp1 = {:visual, {:char, {0, 0}, {5, 10}}, [], nil, %{}, %{}, 0, true}
-      fp2 = {:visual, nil, [], nil, %{}, %{}, 0, true}
-
-      window = make_window()
-      window = Window.snapshot_after_render(window, 0, 4, 100, 5, 1, fp1)
-      window = Window.detect_context_change(window, fp2)
-      assert window.render_cache.dirty_lines == :all
-    end
-  end
-
-  describe "prune_cache/3" do
-    test "removes entries outside the visible range" do
-      window = make_window()
-
-      window =
-        Enum.reduce(0..20, window, fn line, w ->
-          Window.cache_line(w, line, [{line, 0, "#{line}", []}], [{line, 4, "text", []}])
-        end)
-
-      assert map_size(window.render_cache.cached_content) == 21
-
-      window = Window.prune_cache(window, 5, 15)
-
-      assert map_size(window.render_cache.cached_content) == 11
-      refute Map.has_key?(window.render_cache.cached_content, 4)
-      assert Map.has_key?(window.render_cache.cached_content, 5)
-      assert Map.has_key?(window.render_cache.cached_content, 15)
-      refute Map.has_key?(window.render_cache.cached_content, 16)
-    end
-
-    test "gutter cache is also pruned" do
-      window = make_window()
-
-      window =
-        Enum.reduce(0..10, window, fn line, w ->
-          Window.cache_line(w, line, [{line, 0, "#{line}", []}], [])
-        end)
-
-      window = Window.prune_cache(window, 3, 7)
-      assert map_size(window.render_cache.cached_gutter) == 5
-    end
-
-    test "handles empty cache gracefully" do
-      window = make_window()
-      window = Window.prune_cache(window, 0, 10)
-      assert window.render_cache.cached_content == %{}
-      assert window.render_cache.cached_gutter == %{}
-    end
-  end
-
-  describe "full dirty-line lifecycle" do
-    test "first frame: detect_invalidation → all dirty → render → snapshot → next frame clean" do
-      window = make_window()
-
-      # Before detect_invalidation, window has empty dirty set
-      assert window.render_cache.dirty_lines == %{}
-
-      # detect_invalidation sees sentinel values → marks all dirty
       window = Window.detect_invalidation(window, 0, 4, 100, 1)
       assert window.render_cache.dirty_lines == :all
       assert Window.dirty?(window, 0)
       assert Window.dirty?(window, 99)
 
-      # Simulate rendering lines 0-9
       window =
-        Enum.reduce(0..9, window, fn line, w ->
-          Window.cache_line(w, line, [{line, 0, "#{line}", []}], [{line, 4, "text", []}])
-        end)
-
-      # Snapshot after render
-      window = Window.snapshot_after_render(window, 0, 4, 100, 5, 1, :test_fp)
-      assert window.render_cache.dirty_lines == %{}
-
-      # Frame 2: nothing changed → nothing dirty
-      window = Window.detect_invalidation(window, 0, 4, 100, 1)
-      assert window.render_cache.dirty_lines == %{}
-      refute Window.dirty?(window, 0)
-      refute Window.dirty?(window, 5)
-    end
-
-    test "edit cycle: snapshot → mark dirty → detect → only edited lines dirty" do
-      window = make_window()
-
-      # Initial render complete
-      window =
-        Enum.reduce(0..9, window, fn line, w ->
-          Window.cache_line(w, line, [{line, 0, "#{line}", []}], [{line, 4, "text", []}])
+        Enum.reduce(0..9, window, fn line, acc ->
+          Window.cache_line(acc, line, [{line, 0, "#{line}", []}], [{line, 4, "text", []}])
         end)
 
       window = Window.snapshot_after_render(window, 0, 4, 100, 5, 1, :test_fp)
-
-      # User types a character on line 5, bumping the buffer version.
-      # Redraw all visible lines so same-line-count edits cannot leave stale rows.
-      window = Window.detect_invalidation(window, 0, 4, 100, 2)
-      assert window.render_cache.dirty_lines == :all
-
-      # After rendering, snapshot with new version
-      window = Window.snapshot_after_render(window, 0, 4, 100, 5, 2, :test_fp)
       assert window.render_cache.dirty_lines == %{}
-    end
 
-    test "scroll cycle: viewport_top changes → full invalidation" do
-      window = make_window()
-      window = Window.snapshot_after_render(window, 0, 4, 100, 5, 1, :test_fp)
+      clean = Window.detect_invalidation(window, 0, 4, 100, 1)
+      assert clean.render_cache.dirty_lines == %{}
+      refute Window.dirty?(clean, 0)
 
-      # Scroll down
-      window = Window.detect_invalidation(window, 10, 4, 100, 1)
-      assert window.render_cache.dirty_lines == :all
+      edited = Window.detect_invalidation(window, 0, 4, 100, 2)
+      assert edited.render_cache.dirty_lines == :all
+
+      assert Window.snapshot_after_render(edited, 0, 4, 100, 5, 2, :test_fp).render_cache.dirty_lines ==
+               %{}
+
+      scrolled =
+        window
+        |> Window.snapshot_after_render(0, 4, 100, 5, 1, :test_fp)
+        |> Window.detect_invalidation(10, 4, 100, 1)
+
+      assert scrolled.render_cache.dirty_lines == :all
     end
   end
 
-  describe "popup?/1" do
-    test "returns false for a normal window" do
+  describe "context changes and popups" do
+    test "context fingerprint changes invalidate only after an initial fingerprint exists" do
+      first_frame = make_window()
+      assert first_frame.render_cache.last_context_fingerprint == nil
+      assert Window.detect_context_change(first_frame, :fp_a).render_cache.dirty_lines == %{}
+
+      window = Window.snapshot_after_render(make_window(), 0, 4, 100, 5, 1, :fp_a)
+      assert Window.detect_context_change(window, :fp_a).render_cache.dirty_lines == %{}
+      assert Window.detect_context_change(window, :fp_b).render_cache.dirty_lines == :all
+
+      oracle1 = Minga.Core.WidthOracle.Measured.new(%{"wide" => 50})
+      oracle2 = Minga.Core.WidthOracle.Measured.new(%{"narrow" => 7})
+      fp1 = Minga.Core.WidthOracle.fingerprint(oracle1)
+      fp2 = Minga.Core.WidthOracle.fingerprint(oracle2)
+      refute fp1 == fp2
+
+      assert make_window()
+             |> Window.snapshot_after_render(0, 4, 100, 5, 1, fp1)
+             |> Window.detect_context_change(fp2)
+             |> Map.fetch!(:render_cache)
+             |> Map.fetch!(:dirty_lines) == :all
+
+      complex1 = {:visual, {:char, {0, 0}, {5, 10}}, [], nil, %{}, %{}, 0, true}
+      complex2 = {:visual, nil, [], nil, %{}, %{}, 0, true}
+
+      assert make_window()
+             |> Window.snapshot_after_render(0, 4, 100, 5, 1, complex1)
+             |> Window.detect_context_change(complex2)
+             |> Map.fetch!(:render_cache)
+             |> Map.fetch!(:dirty_lines) == :all
+    end
+
+    test "popup? reflects popup metadata" do
       window = make_window()
       refute Window.popup?(window)
-    end
+      assert window.popup_meta == nil
 
-    test "returns true for a window with popup metadata" do
-      rule = PopupRule.new("*test*")
-      active = PopupActive.new(rule, 2, 1)
-      window = %{make_window() | popup_meta: active}
-      assert Window.popup?(window)
+      popup_window = %{window | popup_meta: PopupActive.new(PopupRule.new("*test*"), 2, 1)}
+      assert Window.popup?(popup_window)
     end
   end
 
-  describe "popup_meta field" do
-    test "defaults to nil" do
-      window = make_window()
-      assert window.popup_meta == nil
-    end
+  defp cached_window(window) do
+    Window.cache_line(window, 0, [{0, 0, "1", []}], [{0, 4, "hi", []}])
+  end
+
+  defp with_tracking(window, updates) do
+    %{window | render_cache: Map.merge(window.render_cache, Map.new(updates))}
+  end
+
+  defp assert_fully_invalidated(window) do
+    assert window.render_cache.dirty_lines == :all
+    assert window.render_cache.cached_gutter == %{}
+    assert window.render_cache.cached_content == %{}
+    assert window.render_cache.last_viewport_top == -1
+    assert window.render_cache.last_gutter_w == -1
+    assert window.render_cache.last_line_count == -1
+    assert window.render_cache.last_cursor_line == -1
+    assert window.render_cache.last_buf_version == -1
+    assert window.render_cache.last_context_fingerprint == nil
   end
 end


### PR DESCRIPTION
## Summary
- Consolidates the final requested cleanup batch into behavior-focused scenarios at the cheapest useful layer.
- Keeps coverage on public outcomes: visual-mode dispatch, operator-pending command emission, command parser contracts, and window render-cache behavior.
- Reduces the batch from 1,914 lines to 729 and from 268 tests to 30.

## Test suite reductions
| File | Lines | Tests |
| --- | ---: | ---: |
| `test/minga/mode/visual_test.exs` | 499 → 139 | 69 → 7 |
| `test/minga/mode/operator_pending_test.exs` | 467 → 161 | 53 → 7 |
| `test/minga/command/parser_test.exs` | 486 → 183 | 106 → 8 |
| `test/minga_editor/window_test.exs` | 462 → 246 | 40 → 8 |

## Verification
- `mix test.llm test/minga/mode/visual_test.exs test/minga/mode/operator_pending_test.exs test/minga/command/parser_test.exs test/minga_editor/window_test.exs` → PASS: 30 tests, 0 failures
- `mix credo --strict test/minga_editor/window_test.exs` → no issues
- Final reviewer gate: PASS
