### PR TITLE
docs(test): codify boundary-focused testing

### DIFF
--- a/.pi/agents/reviewer.md
+++ b/.pi/agents/reviewer.md
@@ -240,45 +240,44 @@ When a PR adds or modifies test files, check these in addition to the code quali
 - [ ] Mox stubs/expects actually get called in the test. Dead stubs copied between files are cleanup items.
 - [ ] Tests asserting on lists of filesystem entries (file tree, directory listings) assert on content/presence, not index position.
 
-## Test Design Review
+## Test Design Boundary Review
 
-This step runs after CI checks pass but before issuing a verdict. It enforces the project rule that test-advisor must be consulted before writing significant new tests. Without this gate, LLMs write tests at the wrong layer (EditorCase integration tests for pure function behavior), with internal state assertions (`:sys.get_state` + field checks), and without considering the right test strategy. Those tests pass locally, flake on CI, and break on the next refactor.
+This step runs after CI checks pass but before issuing a verdict. It enforces the Sandi Metz-style rule from AGENTS.md: tests should verify the public promise at the cheapest useful layer. Do not block solely because test-advisor was not consulted. Block for the actual test-quality problem: wrong layer, brittle internal assertions, duplicated full-stack coverage, weak or missing public behavior coverage, or unsafe synchronization.
 
-### Step 1: Count new test functions in the diff
+### Step 1: Identify changed test intent
 
-```bash
-git diff main -- '*.exs' | grep -c '^\+.*test "'
-git diff main -- '*.swift' | grep -c '^\+.*@Test('
-```
+Use the diff to answer these questions for each changed test file:
 
-If both counts are zero, skip this section entirely. No new tests means no gate to enforce.
+- What public behavior is being promised?
+- Who is the client of that behavior?
+- What is the cheapest useful layer that proves it?
+- Does the diff remove a public behavior check that is not covered elsewhere?
 
-### Step 2: Determine if the additions are exempt
+For large consolidations, compare the before/after intent, not raw test count. A large drop is acceptable when table-driven or scenario tests still cover the same public contract.
 
-New tests are exempt from the test-advisor gate when **all** of these are true:
-- The diff adds 1-2 new test functions total (across all files)
-- The new tests are inside an existing `describe` block (not a new one)
-- The new tests clearly follow the exact structure of the test immediately above them in the same file
+### Step 2: Enforce layer boundaries
 
-Check exemption by inspecting context around each new `test "` line in the diff. If the test is in a new file or a new `describe` block, it is not exempt regardless of count.
+Flag these as **Critical** when introduced or left in changed test code:
 
-### Step 3: Check for test-advisor consultation
+- Pure functions, Mode FSMs, parsers, text objects, motions, or command-state behavior tested through `EditorCase` or a live Editor GenServer when a direct call would prove the contract.
+- Integration tests that retest every key, alias, status, or flag after a cheaper unit or command test already proves the behavior.
+- `:sys.get_state` field assertions when public query helpers, buffer content, emitted commands, events, or rendered output can prove the same behavior.
+- `Process.sleep` used as synchronization for GenServers, events, timers, or rendering.
+- Tests whose names describe implementation details instead of behavior.
+- Consolidations that delete meaningful edge-case coverage without replacing it at any layer.
 
-If the diff adds 3+ new test functions, or the additions are not exempt per Step 2:
+### Step 3: Respect intentional exceptions
 
-1. Check whether the implementing agent mentioned consulting test-advisor in their review request or task description. Look for phrases like "consulted test-advisor", "test-advisor recommended", or evidence that test strategy was discussed with the subagent.
-2. If no evidence of consultation exists, issue a **BLOCKED** verdict with: "New tests written without consulting test-advisor. Run test-advisor with a description of what you built and what tests you need, then re-request review."
+Do not block these solely for being exhaustive or internal-looking:
 
-### Step 4: Verify tests follow advisor recommendations
+- Protocol and wire-format compatibility tests where the public contract is byte-level or cross-process compatibility.
+- Core data structure tests that use many examples or property tests to protect invariants (`Document`, interval trees, unicode, folds, decorations).
+- Render-cache, state-machine, and parser-range tests that assert internal fields because those fields are the public behavior of the unit under test.
+- Thin integration smoke tests whose purpose is wiring only.
 
-If test-advisor was consulted, verify the resulting tests align with the project's test layer selection rules (from AGENTS.md):
+### Step 4: Test-advisor evidence is supporting evidence, not a gate
 
-- [ ] Pure functions are tested directly, not through EditorCase or GenServer wrappers
-- [ ] No `:sys.get_state` field assertions (use EditorCase query helpers like `buffer_content`, `buffer_cursor`, `editor_mode` instead)
-- [ ] Test layer matches the behavior being tested (pure function test for pure functions, GenServer test for GenServer operations, EditorCase only for input dispatch or rendered output)
-- [ ] No `Process.sleep` for synchronization in unit or integration tests
-
-Violations here are **Critical** items, same as any other code quality issue.
+If test-advisor was consulted, use its recommendation as context for whether the layer and assertions make sense. If it was not consulted, judge the tests directly. Only mention missing test-advisor as a cleanup/process note when the test strategy is genuinely risky or unclear; never make missing consultation the only blocker.
 
 ## Output Format
 

--- a/.pi/agents/test-advisor.md
+++ b/.pi/agents/test-advisor.md
@@ -25,6 +25,8 @@ Also read the existing test file for the module (if one exists) to understand es
 
 ## Testing Philosophy: What to Test and What to Skip
 
+Start with the public contract, not the test tool. Before naming test files or helpers, identify what behavior is promised, who relies on it, what layer proves it cheapest, and what should not be tested because it is an implementation detail or already covered at a cheaper layer.
+
 Follow Sandi Metz's message-origin grid (from "The Magic Tricks of Testing" and "99 Bottles of OOP"), adapted for Elixir/OTP. Classify every piece of behavior by where the message originates and whether it's a query (returns data) or a command (causes a side effect). This tells you what deserves a test and what doesn't.
 
 ### The Grid
@@ -45,7 +47,7 @@ Follow Sandi Metz's message-origin grid (from "The Magic Tricks of Testing" and 
 **Sent to self** is everything internal. Don't test it directly.
 
 - `defp` functions. Test them only through the public function that calls them. If a private function is complex enough that you want to test it in isolation, that's a signal it should be extracted into its own module with its own public API.
-- `handle_info` clauses triggered by `Process.send_after(self(), ...)` or internal scheduling. These are implementation details of how a GenServer manages timing. Test the observable outcome ("after the interval elapses, the public API returns X"), not the message itself. Don't send `:tick` to a process in a test; that couples you to the internal scheduling strategy.
+- `handle_info` clauses triggered by `Process.send_after(self(), ...)` or internal scheduling. These are implementation details of how a GenServer manages timing. Test the observable outcome, not the private scheduling mechanism. In Minga tests, prefer the deterministic AGENTS.md pattern for timers: send the exact timer message directly when it is the trigger you need, follow it with a synchronization barrier, then assert the public outcome. Do not assert that a timer ref exists or that an internal `:tick` was scheduled.
 - Internal GenServer state shape. Use `:sys.get_state/1` only as a synchronization barrier in tests (to ensure messages have been processed), never to assert on state fields. If you're pattern-matching on `%State{some_field: value}` in a test, you're testing implementation and the test will break on any refactor.
 - Private helper modules that exist only to organize code for one parent module. Test through the parent's public API.
 
@@ -114,43 +116,61 @@ Don't list 20 edge cases for completeness. Pick the 3-5 that are most likely to 
 
 ## Output Format
 
+Start every answer with the boundary decision. Do not bury the most important guidance after a long list of possible tests.
+
 ```markdown
 ## Test Design: {what's being tested}
 
+### Public Contract
+{One or two sentences naming the behavior callers rely on. Example: "The command parser promises to turn user command-line text into command tuples without losing arguments."}
+
+### Cheapest Useful Layer
+{Name the layer and why it is enough: pure function, Mode FSM, command module, single GenServer, EditorCase wiring, renderer output, protocol compatibility. If you recommend a heavier layer, justify the specific user-visible or cross-process contract it proves.}
+
 ### Behavior Tests
-{List each test with a descriptive name and what it verifies. Include the key assertion.}
+{List each test with a descriptive name and the key setup/action/assertion. Prefer one contract test with table cases over one test per alias or key when the behavior is the same.}
 
 1. **"inserting text at cursor position moves cursor forward"**
-   - Insert "hello" at {0, 0}, assert cursor is at {0, 5}
-   - Insert at middle of existing text, assert surrounding text preserved
+   - Setup: buffer with "abc" and cursor at {0, 1}
+   - Action: insert "X"
+   - Assert: content is "aXbc" and cursor is {0, 2}
 
 2. **"undo reverses the last edit"**
-   - Insert, undo, assert content matches original
-   - Multiple edits, multiple undos, assert each step reverses correctly
+   - Setup: buffer with "hello"
+   - Action: insert, then undo
+   - Assert: content matches the original
 
 ### Property Tests (if applicable)
-{Generator design and properties to verify.}
+{Generator design and properties to verify. Use property tests for true data structures and broad invariants, not for every scenario.}
 
-- **Generator:** `StreamData.string(:printable)` for content, `{StreamData.integer(0..max_line), StreamData.integer(0..max_col)}` for positions
-- **Property:** "insert then delete at same position produces original content"
+- **Generator:** `StreamData.string(:printable)` for content, plus valid positions derived from the generated document
+- **Property:** "insert then delete at the same position produces original content"
 - **Property:** "cursor position after insert is always within buffer bounds"
 
 ### Edge Cases
-{The 3-5 most important ones.}
+{The 3-5 boundaries most likely to expose bugs.}
 
 1. Empty buffer + delete = no crash, buffer unchanged
-2. Insert at end of file (no trailing newline)
+2. Insert at end of file with no trailing newline
 3. Multi-byte unicode: cursor advances by grapheme, not byte
 
-### Skip
-{What doesn't need a test and why, referencing the grid.}
+### Tests Not to Write
+{Explicitly name duplicate or too-deep tests to avoid. This is part of the deliverable, not an afterthought.}
 
-- `content/1` is a pure delegation to Document.content, tested there (outgoing query)
-- GenServer plumbing (start_link, init) covered by existing test helpers (framework)
-- Internal state shape: don't assert on `:sys.get_state` fields (sent-to-self)
+- Do not use EditorCase for pure parser or Mode FSM behavior.
+- Do not assert `:sys.get_state` fields when public helpers can observe the outcome.
+- Do not retest every key through the full editor when a cheaper mode or command test already proves the contract.
+
+### Exceptions
+{If protocol compatibility, render-cache internals, or core data-structure invariants justify heavier or more exhaustive tests, say so explicitly.}
 
 ### Existing Patterns
-{If you read the existing test file, note any helpers, setup conventions, or patterns the new tests should follow for consistency.}
+{If you read the existing test file, note helpers, setup conventions, and nearby examples to follow or intentionally avoid.}
+
+### Concurrency
+- **async:** true/false, with the exact global resource if false
+- **Synchronization:** {barrier, event, monitor, or public query}
+- **Isolation:** {ETS tables, Application env, temp dirs, OS process stubs}
 ```
 
 ## Concurrency Safety

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,6 +469,37 @@ end
 - **Edge cases always tested**: empty state, boundaries, unicode
 - **Screen snapshot tests** for UI regression detection. See [docs/SNAPSHOT_TESTING.md](docs/SNAPSHOT_TESTING.md) for how to write, update, and review snapshot tests. When your change modifies the rendered UI, run `UPDATE_SNAPSHOTS=1 mix test test/minga/integration/` to regenerate baselines, then review the diffs before committing.
 
+#### Sandi Metz-style test boundaries
+
+Write tests against the public promise of the object at the cheapest useful layer. A good test should answer four questions before it asserts anything: what behavior is promised, who relies on that behavior, what is the cheapest layer that proves it, and would this fail after a refactor that kept the public behavior unchanged?
+
+Think in clients, not implementation. The client of `Minga.Mode.*` is the input dispatcher, so mode tests should mostly assert emitted commands and transitions. The client of `Minga.Command.Parser` is command execution, so parser tests should assert parsed command values. The client of a protocol encoder is another process or frontend, so exhaustive wire-format compatibility tests are legitimate. The client of `Window.RenderCache` is the render pipeline, so render-cache tests may assert cache fields because the cache is the object under test.
+
+Prefer behavior tests that read like documentation:
+
+- `"linewise paste inserts full lines below the cursor"`
+- `"operator-pending multiplies operator count by motion count"`
+- `"parser preserves shell command arguments"`
+- `"window invalidates cached draws when the viewport changes"`
+
+Avoid tests that mostly prove the implementation stayed the same:
+
+- Retesting the same command through pure function, command module, Editor GenServer, and rendered screen layers.
+- One test per key, alias, status, or flag when one table-driven contract test is clearer.
+- Full `EditorCase` tests for pure functions, parser behavior, mode FSM dispatch, or command-state behavior.
+- `:sys.get_state` field assertions when a public query helper or visible outcome exists.
+- Assertions on internal structs unless that struct is the unit under test.
+- Test names like `"works"`, `"handles foo"`, or `"test function_name/2"`.
+
+Exceptions are intentional, not loopholes:
+
+- Protocol and wire-format suites may stay exhaustive because compatibility is the public contract.
+- Core data structures (`Document`, interval trees, unicode helpers, folds, decorations) should use examples plus property tests when invariants matter.
+- Render-cache and state-machine modules may assert internal fields when those fields are the public behavior of the unit under test.
+- Integration smoke tests should stay thin and prove wiring only, not re-cover every behavior from cheaper layers.
+
+When consolidating tests, preserve the public promise even if the raw test count drops sharply. If removing a test would make a future behavior regression invisible at every layer, keep or replace it. If a cheaper boundary already proves the promise, delete the duplicate heavier test.
+
 #### Test Layer Selection
 
 Pick the lightest test layer that covers the behavior. Heavier tests are slower, flakier, and more sensitive to unrelated changes. Use this decision tree:


### PR DESCRIPTION
## Summary
- Adds Sandi Metz-style test boundary guidance to `AGENTS.md` so agents choose the cheapest useful test layer before writing tests.
- Updates the project `test-advisor` output format to start with public contract, cheapest useful layer, tests not to write, and exceptions.
- Updates the project `reviewer` guidance to block for actual test-quality problems instead of missing advisory-process evidence.

## Verification
- `git diff --check`
- Final reviewer gate: PASS

## Note
I also updated the global user-level `reviewer.md` and `test-advisor.md` locally with the generic version of this guidance. Those files are outside this repo and are not part of this PR.
