### PR TITLE
test(editor): batch trim boundary smoke tests

### DIFF
--- a/test/minga/command/parser_test.exs
+++ b/test/minga/command/parser_test.exs
@@ -101,7 +101,9 @@ defmodule Minga.Command.ParserTest do
         {"agent-stop", {:agent_abort, []}},
         {"agent-new", {:agent_new_session, []}},
         {"parser-restart", {:parser_restart, []}},
-        {"ParserRestart", {:parser_restart, []}}
+        {"ParserRestart", {:parser_restart, []}},
+        {"reload-highlights", {:reload_highlights, []}},
+        {"rh", {:reload_highlights, []}}
       ])
     end
   end

--- a/test/minga_editor/commands/dired_test.exs
+++ b/test/minga_editor/commands/dired_test.exs
@@ -27,10 +27,8 @@ defmodule MingaEditor.Commands.DiredTest do
                Options.set_for_filetype(options_server, :dired, :autopair_block, false)
 
       ctx = start_editor("", options_server: options_server)
-      state = send_keys_sync(ctx, ":dired #{dir}<CR>")
+      send_keys_sync(ctx, ":dired #{dir}<CR>")
 
-      assert state.workspace.keymap_scope == :dired
-      assert state.workspace.dired.active?
       assert BufferProcess.get_option(active_buffer(ctx), :autopair_block) == false
       content = active_content(ctx)
       assert content =~ "hello.txt"
@@ -48,10 +46,10 @@ defmodule MingaEditor.Commands.DiredTest do
       ctx = start_editor("", options_server: options_server)
       send_keys_sync(ctx, ":dired #{dir}<CR>")
 
-      state = send_keys_sync(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
       active = active_buffer(ctx)
 
-      refute state.workspace.dired.active?
+      assert active_content(ctx) == "hello"
       assert BufferProcess.file_path(active) == Path.join(dir, "hello.txt")
       assert BufferProcess.get_option(active, :autopair_block) == false
     end
@@ -67,17 +65,7 @@ defmodule MingaEditor.Commands.DiredTest do
 
       state = send_keys_sync(ctx, ":w<CR>")
 
-      assert state.workspace.dired.active?
       assert File.read!(file) == "original"
-    end
-
-    test ":w with no changes shows no-changes status", %{tmp_dir: dir} do
-      File.write!(Path.join(dir, "file.txt"), "")
-
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
-      state = send_keys_sync(ctx, ":w<CR>")
-
       assert state.shell_state.status_msg =~ "No changes"
     end
 
@@ -133,21 +121,6 @@ defmodule MingaEditor.Commands.DiredTest do
       assert state.shell_state.status_msg =~ "Cancelled"
     end
 
-    test "Escape cancels confirmation", %{tmp_dir: dir} do
-      File.write!(Path.join(dir, "keep.txt"), "content")
-
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
-
-      send_keys_sync(ctx, "ciwgone.txt<Esc>")
-      send_keys_sync(ctx, ":w<CR>")
-
-      state = send_keys_sync(ctx, "<Esc>")
-
-      refute state.workspace.dired.confirming?
-      assert File.exists?(Path.join(dir, "keep.txt"))
-    end
-
     test "y applies file deletion", %{tmp_dir: dir} do
       File.write!(Path.join(dir, "delete_me.txt"), "gone")
       File.write!(Path.join(dir, "keep.txt"), "stay")
@@ -166,35 +139,20 @@ defmodule MingaEditor.Commands.DiredTest do
       assert state.shell_state.status_msg =~ "Applied"
     end
 
-    test "y applies new file creation", %{tmp_dir: dir} do
+    test "y applies added file and directory entries", %{tmp_dir: dir} do
       File.write!(Path.join(dir, "existing.txt"), "here")
 
       ctx = start_editor("")
       send_keys_sync(ctx, ":dired #{dir}<CR>")
 
-      send_keys_sync(ctx, "onewfile.txt<Esc>")
+      BufferProcess.replace_content(active_buffer(ctx), "existing.txt\nnewfile.txt\nnewdir/")
       send_keys_sync(ctx, ":w<CR>")
 
       state = send_keys_sync(ctx, "y")
 
       refute state.workspace.dired.confirming?
       assert File.exists?(Path.join(dir, "newfile.txt"))
-    end
-
-    test "y creates directory when name ends with /", %{tmp_dir: dir} do
-      File.write!(Path.join(dir, "file.txt"), "")
-
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
-
-      send_keys_sync(ctx, "onewdir/<Esc>")
-      send_keys_sync(ctx, ":w<CR>")
-
-      state = send_keys_sync(ctx, "y")
-
-      refute state.workspace.dired.confirming?
-      new_path = Path.join(dir, "newdir")
-      assert File.dir?(new_path)
+      assert File.dir?(Path.join(dir, "newdir"))
     end
   end
 
@@ -223,11 +181,11 @@ defmodule MingaEditor.Commands.DiredTest do
       ctx = start_editor("")
       send_keys_sync(ctx, ":dired #{subdir}<CR>")
 
-      state = send_keys_sync(ctx, "-")
+      send_keys_sync(ctx, "-")
 
       content = active_content(ctx)
       assert content =~ "shallow.txt"
-      assert state.workspace.dired.dired.directory == Path.expand(dir)
+      refute content =~ "deep.txt"
     end
 
     test "q closes dired and returns to editor scope", %{tmp_dir: dir} do
@@ -236,10 +194,9 @@ defmodule MingaEditor.Commands.DiredTest do
       ctx = start_editor("")
       send_keys_sync(ctx, ":dired #{dir}<CR>")
 
-      state = send_keys_sync(ctx, "q")
+      send_keys_sync(ctx, "q")
 
-      assert state.workspace.keymap_scope == :editor
-      refute state.workspace.dired.active?
+      refute active_content(ctx) =~ "file.txt"
     end
   end
 

--- a/test/minga_editor/integration/mouse_test.exs
+++ b/test/minga_editor/integration/mouse_test.exs
@@ -8,25 +8,13 @@ defmodule Minga.Integration.MouseTest do
 
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree
-  alias Minga.Test.HeadlessPort
   alias Minga.Test.StubServer
-
-  @sync_timeout 15_000
 
   defp start_editor_with_project(content) do
     id = :erlang.unique_integer([:positive])
     root = Path.join(System.tmp_dir!(), "minga-integration-mouse-#{id}")
     File.mkdir_p!(root)
     start_editor(content, project_root: root)
-  end
-
-  defp send_gui_action(%{editor: editor, port: port}, action) do
-    _ = GenServer.call(editor, :api_mode, @sync_timeout)
-    ref = HeadlessPort.prepare_await(port)
-    send(editor, {:minga_input, {:gui_action, action}})
-    {:ok, snapshot} = HeadlessPort.collect_frame(ref)
-    Process.put({:last_frame_snapshot, port}, snapshot)
-    :ok
   end
 
   defp inject_fake_session(%{editor: editor} = ctx) do
@@ -158,16 +146,6 @@ defmodule Minga.Integration.MouseTest do
       state = editor_state(ctx)
       assert state.lsp.selection_ranges == nil
       assert state.lsp.selection_range_index == 0
-    end
-
-    test "GUI tab actions run the full housekeeping pipeline" do
-      ctx = start_editor("hello world\nsecond line\nthird line")
-      tab_id = editor_state(ctx).shell_state.tab_bar.active_id
-
-      send_gui_action(ctx, {:select_tab, tab_id})
-
-      assert editor_mode(ctx) == :normal
-      assert active_content(ctx) == "hello world\nsecond line\nthird line"
     end
   end
 end

--- a/test/minga_editor/renderer/conceal_render_test.exs
+++ b/test/minga_editor/renderer/conceal_render_test.exs
@@ -1,10 +1,8 @@
 defmodule MingaEditor.Renderer.ConcealRenderTest do
   @moduledoc """
-  Tests that conceal ranges actually affect rendering output.
+  Visible rendering smoke tests for conceal ranges.
 
-  Uses the headless editor to verify that concealed characters disappear
-  from the display and replacement characters appear when specified.
-  Conceals are revealed on the cursor line (Neovim concealcursor behavior).
+  Decoration storage and raw buffer contents are covered at cheaper buffer/decoration layers. This file keeps only the user-visible rendering promises: non-cursor lines conceal text, replacement characters render, cursor lines reveal raw text, and removing conceals restores the display.
   """
 
   use Minga.Test.EditorCase, async: true
@@ -12,165 +10,69 @@ defmodule MingaEditor.Renderer.ConcealRenderTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Core.Decorations
 
-  # Content starts at row 1 because the tab bar occupies row 0.
   @content_row 1
 
   describe "conceal rendering" do
-    test "concealed characters are hidden on non-cursor line" do
-      # Conceals on line 0, cursor on line 1
+    test "non-cursor lines conceal text while the cursor line reveals it" do
+      ctx = start_editor("**bold**\n**italic**")
+
+      BufferProcess.batch_decorations(ctx.buffer, fn decs ->
+        decs
+        |> add_conceal({0, 0}, {0, 2})
+        |> add_conceal({0, 6}, {0, 8})
+        |> add_conceal({1, 0}, {1, 2})
+        |> add_conceal({1, 8}, {1, 10})
+      end)
+
+      send_key_sync(ctx, 0)
+
+      cursor_line = screen_row(ctx, @content_row)
+      non_cursor_line = screen_row(ctx, @content_row + 1)
+
+      assert cursor_line =~ "**bold**"
+      refute non_cursor_line =~ "**"
+      assert non_cursor_line =~ "italic"
+    end
+
+    test "replacement characters render on non-cursor lines" do
       ctx = start_editor("**bold**\nsecond line")
 
       BufferProcess.batch_decorations(ctx.buffer, fn decs ->
-        {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
-        {_id2, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 8}, group: :test)
         decs
+        |> add_conceal({0, 0}, {0, 2}, replacement: "·")
+        |> add_conceal({0, 6}, {0, 8}, replacement: "·")
       end)
 
-      # Move cursor to line 1 so line 0 conceals are active
       send_key_sync(ctx, ?j)
-
       row_text = screen_row(ctx, @content_row)
 
-      refute String.contains?(row_text, "**"),
-             "Expected ** to be concealed on non-cursor line, got: #{inspect(row_text)}"
-
-      assert String.contains?(row_text, "bold"),
-             "Expected 'bold' to be visible, got: #{inspect(row_text)}"
+      assert row_text =~ "·"
+      assert row_text =~ "bold"
     end
 
-    test "conceal with replacement character shows replacement on non-cursor line" do
+    test "removing conceals restores the raw display" do
       ctx = start_editor("**bold**\nsecond line")
 
       BufferProcess.batch_decorations(ctx.buffer, fn decs ->
-        {_id1, decs} =
-          Decorations.add_conceal(decs, {0, 0}, {0, 2}, replacement: "·", group: :test)
-
-        {_id2, decs} =
-          Decorations.add_conceal(decs, {0, 6}, {0, 8}, replacement: "·", group: :test)
-
-        decs
+        add_conceal(decs, {0, 0}, {0, 2})
       end)
 
-      # Move cursor to line 1
-      send_key_sync(ctx, ?j)
-
-      row_text = screen_row(ctx, @content_row)
-
-      assert String.contains?(row_text, "·"),
-             "Expected replacement char on non-cursor line, got: #{inspect(row_text)}"
-
-      assert String.contains?(row_text, "bold"),
-             "Expected 'bold' to be visible, got: #{inspect(row_text)}"
-    end
-
-    test "buffer content is not modified by concealment" do
-      ctx = start_editor("**bold**")
-
-      BufferProcess.batch_decorations(ctx.buffer, fn decs ->
-        {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
-        decs
-      end)
-
-      content = BufferProcess.content(ctx.buffer)
-      assert content == "**bold**"
-    end
-
-    test "removing conceals restores display" do
-      ctx = start_editor("**bold**\nsecond line")
-
-      BufferProcess.batch_decorations(ctx.buffer, fn decs ->
-        {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
-        decs
-      end)
-
-      # Move cursor off line 0, then remove conceals
       send_key_sync(ctx, ?j)
 
       BufferProcess.batch_decorations(ctx.buffer, fn decs ->
         Decorations.remove_conceal_group(decs, :test)
       end)
 
-      # Move back to line 0 to re-render
       send_key_sync(ctx, ?k)
 
-      row_text = screen_row(ctx, @content_row)
-
-      assert String.contains?(row_text, "**bold"),
-             "Expected ** to be visible after removal, got: #{inspect(row_text)}"
+      assert screen_row(ctx, @content_row) =~ "**bold"
     end
+  end
 
-    test "multiple conceals on one line" do
-      ctx = start_editor("# Heading\nsecond line")
+  defp add_conceal(decs, start_pos, end_pos, opts \\ []) do
+    {_id, decs} =
+      Decorations.add_conceal(decs, start_pos, end_pos, Keyword.put(opts, :group, :test))
 
-      BufferProcess.batch_decorations(ctx.buffer, fn decs ->
-        {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
-        decs
-      end)
-
-      # Move cursor to line 1 so line 0 conceals are active
-      send_key_sync(ctx, ?j)
-
-      row_text = screen_row(ctx, @content_row)
-
-      assert String.contains?(row_text, "Heading"),
-             "Expected 'Heading' to be visible, got: #{inspect(row_text)}"
-    end
-
-    test "cursor line reveals concealed text" do
-      ctx = start_editor("**bold**\nnormal line")
-
-      BufferProcess.batch_decorations(ctx.buffer, fn decs ->
-        {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
-        {_id2, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 8}, group: :test)
-        decs
-      end)
-
-      send_key_sync(ctx, 0)
-
-      # Cursor is on line 0, so conceals should be revealed
-      row_text = screen_row(ctx, @content_row)
-
-      assert String.contains?(row_text, "**"),
-             "Expected ** to be revealed on cursor line, got: #{inspect(row_text)}"
-    end
-
-    test "non-cursor line hides concealed text while cursor line reveals" do
-      ctx = start_editor("**bold**\n**italic**")
-
-      BufferProcess.batch_decorations(ctx.buffer, fn decs ->
-        {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
-        {_id2, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 8}, group: :test)
-        {_id3, decs} = Decorations.add_conceal(decs, {1, 0}, {1, 2}, group: :test)
-        {_id4, decs} = Decorations.add_conceal(decs, {1, 8}, {1, 10}, group: :test)
-        decs
-      end)
-
-      send_key_sync(ctx, 0)
-
-      # Cursor is on line 0: line 0 reveals, line 1 conceals
-      row_text_line1 = screen_row(ctx, @content_row + 1)
-
-      refute String.contains?(row_text_line1, "**"),
-             "Expected ** to be hidden on non-cursor line, got: #{inspect(row_text_line1)}"
-
-      assert String.contains?(row_text_line1, "italic"),
-             "Expected 'italic' to be visible, got: #{inspect(row_text_line1)}"
-    end
-
-    test "yank across concealed range produces raw text" do
-      ctx = start_editor("**bold**", clipboard: :none)
-
-      BufferProcess.batch_decorations(ctx.buffer, fn decs ->
-        {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
-        {_id2, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 8}, group: :test)
-        decs
-      end)
-
-      # Yank the line
-      send_keys_sync(ctx, "Vy")
-
-      content = BufferProcess.content(ctx.buffer)
-      assert content == "**bold**"
-    end
+    decs
   end
 end

--- a/test/minga_editor/user_query_override_test.exs
+++ b/test/minga_editor/user_query_override_test.exs
@@ -1,88 +1,40 @@
 defmodule MingaEditor.UserQueryOverrideTest do
   @moduledoc """
-  Tests for user-customizable highlight queries.
+  Tests for user-customizable highlight query behavior at the cheapest useful layers.
 
-  Verifies that custom query files in ~/.config/minga/queries/{lang}/
-  are sent to the Zig port, and that :reload-highlights re-triggers setup.
+  Parser aliases live in `Minga.Command.ParserTest`. This file keeps the command-level reload contract and the pure query path fallback.
   """
 
-  use Minga.Test.EditorCase, async: true
+  use ExUnit.Case, async: true
 
+  alias MingaEditor.Commands.BufferManagement
   alias MingaEditor.HighlightSync
+  alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.UI.Highlight.Grammar
 
-  alias Minga.Command.Parser
-
-  describe "parser recognizes reload-highlights" do
-    test "parses :reload-highlights" do
-      assert {:reload_highlights, []} = Parser.parse("reload-highlights")
-    end
-
-    test "parses :rh shorthand" do
-      assert {:reload_highlights, []} = Parser.parse("rh")
-    end
-  end
-
   describe ":reload-highlights command" do
-    @tag :tmp_dir
-    test "reload-highlights resets highlight state", %{tmp_dir: tmp_dir} do
-      path = Path.join(tmp_dir, "foo.ex")
-      File.write!(path, "defmodule Foo do\nend\n")
-      ctx = start_editor("defmodule Foo do\nend\n", file_path: path)
+    test "resets active highlights and requests a new parse" do
+      state = TestHelpers.base_state(content: "defmodule Foo do\nend\n", filetype: :elixir)
 
-      # Inject highlights
-      send(ctx.editor, {:minga_input, {:highlight_names, ["keyword"]}})
+      state =
+        state
+        |> HighlightSync.handle_names(["keyword"])
+        |> HighlightSync.handle_spans(1, [%{start_byte: 0, end_byte: 9, capture_id: 0}])
 
-      send(
-        ctx.editor,
-        {:minga_input, {:highlight_spans, 1, [%{start_byte: 0, end_byte: 9, capture_id: 0}]}}
-      )
-
-      state = :sys.get_state(ctx.editor)
-      assert HighlightSync.get_active_highlight(state).spans != []
-
+      refute HighlightSync.get_active_highlight(state).spans == {}
       version_before = state.workspace.highlight.version
 
-      # Run :reload-highlights
-      send_keys_sync(ctx, ":reload-highlights<CR>")
+      state = BufferManagement.execute(state, {:execute_ex_command, {:reload_highlights, []}})
 
-      state = :sys.get_state(ctx.editor)
-
-      # Highlight state should be reset (new Highlight struct with empty spans)
-      # and a new parse should be in-flight (version incremented)
-      assert HighlightSync.get_active_highlight(state).spans == {}
-      assert state.workspace.highlight.version > version_before
-    end
-
-    @tag :tmp_dir
-    test "rh shorthand works the same as reload-highlights", %{tmp_dir: tmp_dir} do
-      path = Path.join(tmp_dir, "bar.ex")
-      File.write!(path, "defmodule Bar do\nend\n")
-      ctx = start_editor("defmodule Bar do\nend\n", file_path: path)
-
-      send(ctx.editor, {:minga_input, {:highlight_names, ["keyword"]}})
-
-      send(
-        ctx.editor,
-        {:minga_input, {:highlight_spans, 1, [%{start_byte: 0, end_byte: 9, capture_id: 0}]}}
-      )
-
-      version_before = :sys.get_state(ctx.editor).workspace.highlight.version
-
-      send_keys_sync(ctx, ":rh<CR>")
-
-      state = :sys.get_state(ctx.editor)
       assert HighlightSync.get_active_highlight(state).spans == {}
       assert state.workspace.highlight.version > version_before
     end
   end
 
   describe "user query file detection" do
-    test "Grammar.query_path prefers user dir when file exists" do
-      # We can't easily test the actual ~/.config path in CI, but we can
-      # verify the Grammar.query_path logic by checking that priv path
-      # is returned when no user override exists
+    test "Grammar.query_path falls back to the bundled query" do
       path = Grammar.query_path("elixir")
+
       assert path != nil
       assert String.contains?(path, "priv/queries/elixir/highlights.scm")
     end


### PR DESCRIPTION
## Summary
- Thins conceal rendering tests to visible rendering promises only, leaving decoration/raw-buffer behavior to cheaper layers.
- Trims dired EditorCase coverage by removing internal state assertions and consolidating duplicate save/apply cases.
- Moves reload-highlight alias coverage to the parser test and checks reload behavior at the command/state layer instead of full EditorCase.
- Drops an unrelated GUI tab-action mouse smoke while keeping mouse routing and housekeeping coverage.

## Stats
- `conceal_render_test.exs`: 8 tests to 3, 176 lines to 78.
- `dired_test.exs`: 18 tests to 15, 303 lines to 260.
- `user_query_override_test.exs`: 5 tests to 2, 90 lines to 42.
- `mouse_test.exs`: 5 tests to 4, 173 lines to 151.
- Net diff: 55 insertions, 264 deletions.

## Verification
- `git diff --check`
- `mix test.llm test/minga_editor/renderer/conceal_render_test.exs test/minga/buffer/decorations_test.exs test/minga/buffer/conceal_range_test.exs test/minga_editor/commands/dired_test.exs test/minga/dired_test.exs test/minga/keymap/scope/dired_scope_test.exs test/minga_editor/user_query_override_test.exs test/minga/command/parser_test.exs test/minga_editor/integration/mouse_test.exs test/minga_editor/mouse_test.exs test/minga_editor/mouse_multi_click_test.exs`
- `make lint`
- Final reviewer gate: PASS
