### PR TITLE
File tabs stay inside active workspace

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -131,7 +131,9 @@ Frontends should apply this only to the current file-tree model. If no full `gui
 
 ### 0x71 — gui_tab_bar
 
-Tab bar state with visible tab entries.
+Visible file tabs for the active workspace.
+
+Only file tabs from the active workspace are sent here. Agent tabs and tabs from inactive workspaces are omitted; native GUI frontends use gui_agent_groups (0x86) to render inactive workspace capsules and workspace switching UI.
 
 ```
 opcode(1) + active_index(1) + tab_count(1) + entries...
@@ -142,17 +144,14 @@ Per entry:
 Flags bits:
   bit 0: is_active
   bit 1: is_dirty
-  bit 2: is_agent (agent chat tab vs file tab)
+  bit 2: is_agent (always 0 in the active-workspace projection)
   bit 3: has_attention
   bits 4-6: agent_status (0=idle, 1=thinking, 2=tool_executing, 3=error, 4=plan)
 
 group_id: workspace group this tab belongs to. 0 = manual/ungrouped workspace.
-Non-zero values match workspace IDs from gui_agent_groups (0x86). The frontend
-renders group separators at group_id transitions in the tab strip.
+Non-zero values match workspace IDs from gui_agent_groups (0x86). Frontends use this to keep file open/close/navigation scoped to the active workspace while rendering inactive workspace capsules from gui_agent_groups.
 
-active_index: zero-based index into the visible tab entries, or 255 when the
-current active tab is not present in the visible list (for example, an active
-agent chat tab with only its workspace's file tabs shown).
+active_index: zero-based index into the visible tab entries, or 255 when the current active tab is not present in the visible list (for example, an active agent chat tab with only its workspace's file tabs shown).
 ```
 
 ### 0x72 — gui_which_key
@@ -773,7 +772,7 @@ Agent-workspace indicator and dropdown data for progressive tab grouping. Sent a
 This is the legacy agent-group opcode. The BEAM-side `Workspace.ChromeState` projection includes the synthesized manual workspace, but this opcode sends only agent workspaces so existing native decoders do not infer a manual workspace from the agent-group payload. A later canonical workspace opcode can carry manual-vs-agent kind explicitly.
 
 ```
-opcode(1) + active_group_id(2) + agent_workspace_count(1) + agent_workspaces...
+opcode(1) + active_workspace_id(2) + agent_workspace_count(1) + agent_workspaces...
 
 Per agent workspace:
   id(2) + agent_status(1) + color_r(1) + color_g(1) + color_b(1)
@@ -784,9 +783,9 @@ color: 24-bit sRGB accent color for group separators and workspace indicator
 tab_count: number of tabs currently in this agent workspace
 ```
 
-Agent workspaces are auto-created when an agent session starts and removed when the session ends (their tabs migrate to the manual workspace).
+There is no kind byte in the payload. The implicit manual/ungrouped workspace is represented by `active_workspace_id = 0` and `group_id = 0` file tabs in gui_tab_bar; the emitted workspace list contains only agent workspaces created by agents. The icon fields carry the workspace icon name, and the BEAM currently falls back to `cpu` when no icon is set.
 
-The frontend uses `active_group_id` to highlight the active agent workspace in the indicator/dropdown. Tab entries in gui_tab_bar carry a `group_id` field that matches workspace IDs, enabling the frontend to render group separators at group transitions.
+The frontend uses `active_workspace_id` to highlight the active agent workspace in the indicator/dropdown. Inactive workspace capsules in the tab strip should be rendered from this agent-workspace list, not from gui_tab_bar entries. Tab entries in gui_tab_bar carry a `group_id` field that matches workspace IDs, enabling the frontend to render group separators for the active workspace projection.
 
 ## GUI Action Input Opcode (Frontend → BEAM)
 

--- a/lib/minga/file_ref.ex
+++ b/lib/minga/file_ref.ex
@@ -1,0 +1,23 @@
+defmodule Minga.FileRef do
+  @moduledoc """
+  Stable identity for a logical file path.
+
+  File tabs should compare the file they represent, not their display label. The label is usually a basename and can collide across directories, while a file ref stores the normalized path used by buffer processes.
+  """
+
+  @type t :: %__MODULE__{path: String.t()}
+
+  @enforce_keys [:path]
+  defstruct [:path]
+
+  @doc "Builds a file reference from a filesystem path."
+  @spec new(String.t()) :: t()
+  def new(path) when is_binary(path) do
+    %__MODULE__{path: Path.expand(path)}
+  end
+
+  @doc "Returns true when two file references identify the same logical file."
+  @spec same?(t(), t()) :: boolean()
+  def same?(%__MODULE__{path: path}, %__MODULE__{path: path}), do: true
+  def same?(%__MODULE__{}, %__MODULE__{}), do: false
+end

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -20,6 +20,7 @@ defmodule MingaEditor do
   alias Minga.Clipboard
   alias Minga.Config
   alias Minga.Editing.Completion
+  alias Minga.FileRef
   alias Minga.FileWatcher
   alias Minga.Git
   alias Minga.LSP.Supervisor, as: LspSupervisor
@@ -307,10 +308,8 @@ defmodule MingaEditor do
   @impl true
   @spec handle_call(term(), GenServer.from(), state()) :: {:reply, term(), state()}
   def handle_call({:open_file, file_path}, _from, state) do
-    case Commands.start_buffer(file_path, EditorState.options_server(state)) do
-      {:ok, pid} ->
-        new_state = register_buffer(state, pid, file_path)
-        new_state = AgentLifecycle.maybe_set_auto_context(new_state, file_path, pid)
+    case open_file_by_path_result(state, file_path) do
+      {:ok, new_state} ->
         new_state = Renderer.render_or_async(new_state)
         {:reply, :ok, new_state}
 
@@ -2877,43 +2876,115 @@ defmodule MingaEditor do
 
   @spec open_file_by_path(state(), String.t()) :: state()
   defp open_file_by_path(state, abs_path) do
-    idx = buffer_index_for_path(state, abs_path)
+    case open_file_by_path_result(state, abs_path) do
+      {:ok, new_state} -> new_state
+      {:error, _reason} -> EditorState.set_status(state, "Could not open #{abs_path}")
+    end
+  end
 
-    case idx do
-      nil ->
-        case Commands.start_buffer(abs_path, EditorState.options_server(state)) do
-          {:ok, pid} -> Commands.add_buffer(state, pid)
-          {:error, _reason} -> EditorState.set_status(state, "Could not open #{abs_path}")
-        end
+  @spec open_file_by_path_result(state(), String.t()) :: {:ok, state()} | {:error, term()}
+  defp open_file_by_path_result(state, abs_path) do
+    case file_tab_for_path_in_active_workspace(state, abs_path) do
+      %Tab{id: id} -> {:ok, EditorState.switch_tab(state, id)}
+      nil -> start_and_register_file(state, abs_path)
+    end
+  end
 
-      i ->
-        EditorState.switch_buffer(state, i)
+  @spec start_and_register_file(state(), String.t()) :: {:ok, state()} | {:error, term()}
+  defp start_and_register_file(state, abs_path) do
+    case Commands.start_buffer(abs_path, EditorState.options_server(state)) do
+      {:ok, pid} ->
+        new_state = register_buffer(state, pid, abs_path)
+        {:ok, AgentLifecycle.maybe_set_auto_context(new_state, abs_path, pid)}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
   @spec open_file_by_path_in_active_window(state(), String.t()) :: state()
   defp open_file_by_path_in_active_window(state, abs_path) do
-    case buffer_index_for_path(state, abs_path) do
+    case file_tab_for_path_in_active_workspace(state, abs_path) do
+      %Tab{} = tab ->
+        open_tab_buffer_in_active_window(state, tab, abs_path)
+
       nil ->
         case Commands.start_buffer(abs_path, EditorState.options_server(state)) do
           {:ok, pid} -> register_buffer_in_active_window(state, pid, abs_path)
           {:error, _reason} -> EditorState.set_status(state, "Could not open #{abs_path}")
         end
-
-      i ->
-        EditorState.switch_buffer(state, i)
     end
   end
 
-  @spec buffer_index_for_path(state(), String.t()) :: non_neg_integer() | nil
-  defp buffer_index_for_path(state, abs_path) do
-    Enum.find_index(state.workspace.buffers.list, fn buf ->
-      try do
-        Buffer.file_path(buf) == abs_path
-      catch
-        :exit, _ -> false
-      end
+  @spec open_tab_buffer_in_active_window(state(), Tab.t(), String.t()) :: state()
+  defp open_tab_buffer_in_active_window(state, tab, abs_path) do
+    case tab_active_buffer(tab) do
+      pid when is_pid(pid) -> show_buffer_in_active_window(state, pid)
+      nil -> EditorState.set_status(state, "Could not open #{abs_path}")
+    end
+  end
+
+  @spec show_buffer_in_active_window(state(), pid()) :: state()
+  defp show_buffer_in_active_window(state, pid) when is_pid(pid) do
+    EditorState.update_workspace(state, fn workspace ->
+      buffers =
+        case Enum.find_index(workspace.buffers.list, &(&1 == pid)) do
+          nil -> Buffers.add(workspace.buffers, pid)
+          idx -> Buffers.switch_to(workspace.buffers, idx)
+        end
+
+      workspace
+      |> WorkspaceState.set_buffers(buffers)
+      |> WorkspaceState.sync_active_window_buffer()
     end)
+  end
+
+  @spec tab_active_buffer(Tab.t()) :: pid() | nil
+  defp tab_active_buffer(%Tab{context: context}) when is_map(context) do
+    case TabContext.to_workspace_map(context) do
+      %{buffers: %Buffers{active: pid}} when is_pid(pid) -> pid
+      _ -> nil
+    end
+  end
+
+  @spec file_tab_for_path_in_active_workspace(state(), String.t()) :: Tab.t() | nil
+  defp file_tab_for_path_in_active_workspace(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         path
+       ) do
+    file_ref = FileRef.new(path)
+
+    if active_buffer_matches_file_ref?(state, file_ref) do
+      EditorState.active_tab(state)
+    else
+      TabBar.find_file_tab_in_workspace(tb, TabBar.active_group_id(tb), file_ref)
+    end
+  end
+
+  defp file_tab_for_path_in_active_workspace(_state, _path), do: nil
+
+  @spec active_buffer_matches_file_ref?(state(), FileRef.t()) :: boolean()
+  defp active_buffer_matches_file_ref?(
+         %{workspace: %{buffers: %{active: active}}},
+         %FileRef{} = file_ref
+       )
+       when is_pid(active) do
+    case buffer_file_ref(active) do
+      %FileRef{} = active_ref -> FileRef.same?(active_ref, file_ref)
+      nil -> false
+    end
+  end
+
+  defp active_buffer_matches_file_ref?(_state, _file_ref), do: false
+
+  @spec buffer_file_ref(pid()) :: FileRef.t() | nil
+  defp buffer_file_ref(pid) when is_pid(pid) do
+    case Buffer.file_path(pid) do
+      path when is_binary(path) -> FileRef.new(path)
+      _ -> nil
+    end
+  catch
+    :exit, _ -> nil
   end
 
   @spec register_buffer_in_active_window(state(), pid(), String.t()) :: state()

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   alias MingaAgent.Session
   alias Minga.Buffer
+  alias Minga.FileRef
   alias Minga.Buffer.Document
   alias Minga.Config
 
@@ -253,20 +254,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   def execute(state, {:execute_ex_command, {:edit, file_path}}) do
-    case EditorState.find_buffer_by_path(state, file_path) do
-      nil ->
-        case Commands.start_buffer(file_path, EditorState.options_server(state)) do
-          {:ok, pid} ->
-            Commands.add_buffer(state, pid)
-
-          {:error, reason} ->
-            Minga.Log.error(:editor, "Failed to open file: #{inspect(reason)}")
-            state
-        end
-
-      idx ->
-        switch_to_buffer(state, idx)
-    end
+    open_file_in_active_workspace(state, file_path)
   end
 
   def execute(
@@ -676,6 +664,60 @@ defmodule MingaEditor.Commands.BufferManagement do
     EditorState.set_status(state, "Terminal not yet available")
   end
 
+  @spec open_file_in_active_workspace(state(), String.t()) :: state()
+  defp open_file_in_active_workspace(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         file_path
+       ) do
+    file_ref = FileRef.new(file_path)
+    workspace_id = TabBar.active_group_id(tb)
+
+    case existing_file_tab_in_workspace(state, tb, workspace_id, file_ref) do
+      %Tab{id: id} -> EditorState.switch_tab(state, id)
+      nil -> start_file_buffer(state, file_path)
+    end
+  end
+
+  defp open_file_in_active_workspace(state, file_path) do
+    start_file_buffer(state, file_path)
+  end
+
+  @spec existing_file_tab_in_workspace(state(), TabBar.t(), non_neg_integer(), FileRef.t()) ::
+          Tab.t() | nil
+  defp existing_file_tab_in_workspace(state, tb, workspace_id, file_ref) do
+    if active_buffer_matches_file_ref?(state, file_ref) do
+      EditorState.active_tab(state)
+    else
+      TabBar.find_file_tab_in_workspace(tb, workspace_id, file_ref)
+    end
+  end
+
+  @spec active_buffer_matches_file_ref?(state(), FileRef.t()) :: boolean()
+  defp active_buffer_matches_file_ref?(
+         %{workspace: %{buffers: %{active: active}}},
+         %FileRef{} = file_ref
+       )
+       when is_pid(active) do
+    case buffer_file_ref(active) do
+      %FileRef{} = active_ref -> FileRef.same?(active_ref, file_ref)
+      nil -> false
+    end
+  end
+
+  defp active_buffer_matches_file_ref?(_state, _file_ref), do: false
+
+  @spec start_file_buffer(state(), String.t()) :: state()
+  defp start_file_buffer(state, file_path) do
+    case Commands.start_buffer(file_path, EditorState.options_server(state)) do
+      {:ok, pid} ->
+        Commands.add_buffer(state, pid)
+
+      {:error, reason} ->
+        Minga.Log.error(:editor, "Failed to open file: #{inspect(reason)}")
+        state
+    end
+  end
+
   @spec switch_to_buffer(state(), non_neg_integer()) :: state()
   defp switch_to_buffer(
          %{shell_state: %{tab_bar: %TabBar{} = tb}, workspace: %{buffers: %{list: buffers}}} =
@@ -724,15 +766,15 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec buffer_cycle_order([pid()], state()) :: [pid()]
   defp buffer_cycle_order(buffers, %{shell_state: %{tab_bar: %TabBar{} = tb}}) do
-    tab_buffers = file_tab_buffers(tb)
+    tab_buffers = visible_file_tab_buffers(tb)
     buffers ++ Enum.reject(tab_buffers, &(&1 in buffers))
   end
 
   defp buffer_cycle_order(buffers, _state), do: buffers
 
-  @spec file_tab_buffers(TabBar.t()) :: [pid()]
-  defp file_tab_buffers(%TabBar{tabs: tabs}) do
-    Enum.flat_map(tabs, fn tab ->
+  @spec visible_file_tab_buffers(TabBar.t()) :: [pid()]
+  defp visible_file_tab_buffers(%TabBar{} = tb) do
+    Enum.flat_map(TabBar.visible_file_tabs(tb), fn tab ->
       case tab_context_active_buffer(tab) do
         pid when is_pid(pid) -> [pid]
         _ -> []
@@ -767,16 +809,12 @@ defmodule MingaEditor.Commands.BufferManagement do
   @spec find_tab_for_buffer(TabBar.t(), pid() | nil) :: Tab.id() | nil
   defp find_tab_for_buffer(_tb, nil), do: nil
 
-  defp find_tab_for_buffer(%TabBar{tabs: tabs}, target_buf) do
-    Enum.find_value(tabs, fn
-      %{kind: :file, id: id} = tab ->
-        case tab_context_active_buffer(tab) do
-          ^target_buf -> id
-          _ -> nil
-        end
-
-      _ ->
-        nil
+  defp find_tab_for_buffer(%TabBar{} = tb, target_buf) do
+    Enum.find_value(TabBar.visible_file_tabs(tb), fn %{id: id} = tab ->
+      case tab_context_active_buffer(tab) do
+        ^target_buf -> id
+        _ -> nil
+      end
     end)
   end
 
@@ -789,6 +827,16 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   defp tab_context_active_buffer(_tab), do: nil
+
+  @spec buffer_file_ref(pid()) :: FileRef.t() | nil
+  defp buffer_file_ref(pid) when is_pid(pid) do
+    case Buffer.file_path(pid) do
+      path when is_binary(path) -> FileRef.new(path)
+      _ -> nil
+    end
+  catch
+    :exit, _ -> nil
+  end
 
   @spec next_tab(state()) :: state()
   defp next_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
@@ -1216,10 +1264,10 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp close_agent_tab_or_quit(state), do: close_agent_tab(state)
 
   @spec close_file_tab_or_quit(state(), Tab.id()) :: state()
-  defp close_file_tab_or_quit(state, active_id) do
+  defp close_file_tab_or_quit(state, _active_id) do
     tb = EditorState.tab_bar(state)
 
-    if has_other_file_tab?(tb, active_id) do
+    if TabBar.count(tb) > 1 do
       close_file_tab(state)
     else
       shutdown_editor(state)
@@ -1229,7 +1277,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   @spec quit_would_exit_editor?(state()) :: boolean()
   defp quit_would_exit_editor?(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
     case EditorState.active_tab(state) do
-      %Tab{kind: :file, id: active_id} -> not has_other_file_tab?(tb, active_id)
+      %Tab{kind: :file} -> TabBar.count(tb) == 1
       %Tab{kind: :agent} -> TabBar.count(tb) == 1
       _ -> true
     end
@@ -1237,43 +1285,27 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   defp quit_would_exit_editor?(_state), do: true
 
-  @spec has_other_file_tab?(TabBar.t(), Tab.id()) :: boolean()
-  defp has_other_file_tab?(%TabBar{tabs: tabs}, active_id) do
-    Enum.any?(tabs, &(&1.kind == :file and &1.id != active_id))
-  end
-
   @spec close_other_tabs(state()) :: state()
   defp close_other_tabs(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
     active_id = tb.active_id
+    closed_tabs = Enum.reject(TabBar.visible_file_tabs(tb), &(&1.id == active_id))
+    tb = remove_tabs(tb, closed_tabs)
 
-    closed_tabs = Enum.reject(tb.tabs, &(&1.id == active_id))
-    Enum.each(closed_tabs, &stop_closed_agent_tab/1)
-
-    tb = TabBar.keep_only(tb, active_id)
     MingaEditor.log_to_messages("Closed other tabs")
     EditorState.set_tab_bar(state, tb)
   end
 
   defp close_other_tabs(state), do: state
 
-  @spec stop_closed_agent_tab(Tab.t()) :: :ok
-  defp stop_closed_agent_tab(%Tab{kind: :agent, session: session}) when is_pid(session) do
-    try do
-      Session.unsubscribe(session)
-    catch
-      :exit, _ -> :ok
-    end
-
-    try do
-      GenServer.stop(session, :normal)
-    catch
-      :exit, _ -> :ok
-    end
-
-    :ok
+  @spec remove_tabs(TabBar.t(), [Tab.t()]) :: TabBar.t()
+  defp remove_tabs(tb, tabs) do
+    Enum.reduce(tabs, tb, fn tab, acc ->
+      case TabBar.remove(acc, tab.id) do
+        {:ok, new_tb} -> new_tb
+        :last_tab -> acc
+      end
+    end)
   end
-
-  defp stop_closed_agent_tab(%Tab{}), do: :ok
 
   # Saves all dirty buffers in the buffer list. Called by :wqa before
   # shutting down. Returns state unchanged (side-effectual only).
@@ -1318,7 +1350,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp close_file_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
     active_tab = EditorState.active_tab(state)
     label = if active_tab, do: active_tab.label, else: "tab"
-    replacement_id = active_tab && replacement_file_tab_id(tb, active_tab.id)
+    replacement_id = active_tab && replacement_tab_id(tb, active_tab)
     MingaEditor.log_to_messages("Closed: #{label}")
 
     state
@@ -1368,8 +1400,16 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp maybe_switch_to_replacement(tb, nil), do: tb
   defp maybe_switch_to_replacement(tb, replacement_id), do: TabBar.switch_to(tb, replacement_id)
 
+  @spec replacement_tab_id(TabBar.t(), Tab.t()) :: Tab.id() | nil
+  defp replacement_tab_id(%TabBar{} = tb, %Tab{id: active_id, group_id: group_id}) do
+    replacement_file_tab_id(tb, active_id) ||
+      replacement_tab_in_workspace_id(tb, active_id, group_id)
+  end
+
   @spec replacement_file_tab_id(TabBar.t(), Tab.id()) :: Tab.id() | nil
-  defp replacement_file_tab_id(%TabBar{tabs: tabs}, active_id) do
+  defp replacement_file_tab_id(%TabBar{} = tb, active_id) do
+    tabs = TabBar.visible_file_tabs(tb)
+
     case Enum.find_index(tabs, &(&1.id == active_id)) do
       nil -> nil
       idx -> replacement_file_tab_id(tabs, idx)
@@ -1378,10 +1418,18 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec replacement_file_tab_id([Tab.t()], non_neg_integer()) :: Tab.id() | nil
   defp replacement_file_tab_id(tabs, idx) do
-    right = tabs |> Enum.drop(idx + 1) |> Enum.find(&(&1.kind == :file))
-    left = tabs |> Enum.take(idx) |> Enum.reverse() |> Enum.find(&(&1.kind == :file))
+    right = Enum.drop(tabs, idx + 1)
+    left = tabs |> Enum.take(idx) |> Enum.reverse()
 
-    case right || left do
+    case right ++ left do
+      [%Tab{id: id} | _] -> id
+      [] -> nil
+    end
+  end
+
+  @spec replacement_tab_in_workspace_id(TabBar.t(), Tab.id(), non_neg_integer()) :: Tab.id() | nil
+  defp replacement_tab_in_workspace_id(%TabBar{tabs: tabs}, active_id, group_id) do
+    case Enum.find(tabs, &(&1.group_id == group_id and &1.id != active_id)) do
       %Tab{id: id} -> id
       nil -> nil
     end

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -681,6 +681,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   tab is omitted from `ChromeState.visible_tabs`, active_index is 255 to
   signal that no visible tab is active.
   """
+  @no_visible_active_tab 255
+
   @spec encode_gui_tab_bar(TabBar.t() | ChromeState.t(), pid() | nil) :: binary()
   def encode_gui_tab_bar(tab_bar_or_chrome_state, active_win_buffer \\ nil)
 
@@ -700,21 +702,25 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   end
 
   def encode_gui_tab_bar(%TabBar{} = tb, active_win_buffer) do
-    active_index = TabBar.active_index(tb)
+    visible_tabs = TabBar.visible_file_tabs(tb)
+
+    active_index =
+      case Enum.find_index(visible_tabs, &(&1.id == tb.active_id)) do
+        nil -> @no_visible_active_tab
+        index -> index
+      end
 
     entries =
-      Enum.map(tb.tabs, fn tab ->
+      Enum.map(visible_tabs, fn tab ->
         encode_gui_tab_entry(tab, tb.active_id, active_win_buffer)
       end)
 
     IO.iodata_to_binary([
       @op_gui_tab_bar,
-      <<active_index::8, length(tb.tabs)::8>>
+      <<active_index::8, length(visible_tabs)::8>>
       | entries
     ])
   end
-
-  @no_visible_active_tab 255
 
   @spec active_summary_index(ChromeState.t()) :: non_neg_integer()
   defp active_summary_index(%ChromeState{visible_tabs: tabs, active_tab_id: active_id}) do

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -826,12 +826,15 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   `ChromeState` includes the synthesized manual workspace, but this legacy opcode intentionally sends only agent workspaces. A later canonical workspace protocol can carry manual-vs-agent kind explicitly without overloading this agent-group contract.
 
   Wire format:
-    opcode(1) + active_group_id(2) + agent_workspace_count(1) + agent_workspaces...
+    opcode(1) + active_workspace_id(2) + agent_workspace_count(1) + agent_workspaces...
 
   Per agent workspace:
     id(2) + agent_status(1) + color_r(1) + color_g(1) + color_b(1)
     + tab_count(2) + label_len(1) + label(label_len) + icon_len(1) + icon(icon_len)
 
+  There is no kind byte in the payload. The emitted list contains only agent
+  workspaces created by agents, and the icon fields carry the workspace icon
+  name.
   Agent status: 0 = idle, 1 = thinking, 2 = tool_executing, 3 = error, 4 = plan.
   """
   @spec encode_gui_agent_groups(TabBar.t() | ChromeState.t()) :: binary()

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -36,6 +36,7 @@ defmodule MingaEditor.Shell.Traditional do
   alias MingaEditor.Agent.BufferSync, as: AgentBufferSync
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer
+  alias Minga.FileRef
   alias MingaEditor.State.AgentGroup
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
@@ -382,9 +383,9 @@ defmodule MingaEditor.Shell.Traditional do
   def find_tab_by_buffer(%ShellState{tab_bar: nil}, _pid), do: nil
 
   def find_tab_by_buffer(%ShellState{tab_bar: tb}, pid) do
-    Enum.find(tb.tabs, fn tab ->
-      tab.kind == :file and tab_has_active_buffer?(tab, pid)
-    end)
+    tb
+    |> TabBar.visible_file_tabs()
+    |> Enum.find(&tab_has_active_buffer?(&1, pid))
   end
 
   @impl true
@@ -460,10 +461,21 @@ defmodule MingaEditor.Shell.Traditional do
   defp background_agent_windows(_agent_buf, _rows, _cols), do: %Windows{}
 
   @spec find_tab_for_buffer(TabBar.t(), pid()) :: Tab.t() | nil
-  defp find_tab_for_buffer(%TabBar{tabs: tabs}, pid) when is_pid(pid) do
-    Enum.find(tabs, fn tab ->
-      tab.kind == :file and tab_has_active_buffer?(tab, pid)
-    end)
+  defp find_tab_for_buffer(%TabBar{} = tb, pid) when is_pid(pid) do
+    case buffer_file_ref(pid) do
+      %FileRef{} = file_ref ->
+        TabBar.find_file_tab_in_workspace(tb, TabBar.active_group_id(tb), file_ref)
+
+      nil ->
+        find_visible_tab_for_buffer(tb, pid)
+    end
+  end
+
+  @spec find_visible_tab_for_buffer(TabBar.t(), pid()) :: Tab.t() | nil
+  defp find_visible_tab_for_buffer(%TabBar{} = tb, pid) when is_pid(pid) do
+    tb
+    |> TabBar.visible_file_tabs()
+    |> Enum.find(&tab_has_active_buffer?(&1, pid))
   end
 
   # Switch to an existing file tab that matches the buffer being opened.
@@ -523,8 +535,11 @@ defmodule MingaEditor.Shell.Traditional do
     context = WorkspaceState.to_tab_context(prev_workspace)
     tb = TabBar.update_context(tb, tb.active_id, context)
 
+    workspace_id = TabBar.active_group_id(tb)
+
     # Create file tab (TabBar.add auto-activates it)
     {tb, new_tab} = TabBar.add(tb, :file, label)
+    tb = TabBar.move_tab_to_group(tb, new_tab.id, workspace_id)
 
     # Leave agent UI view: reset to editor scope and window content type
     workspace =
@@ -563,8 +578,11 @@ defmodule MingaEditor.Shell.Traditional do
     context = WorkspaceState.to_tab_context(prev_workspace)
     tb = TabBar.update_context(tb, tb.active_id, context)
 
+    workspace_id = TabBar.active_group_id(tb)
+
     # Create file tab (TabBar.add auto-activates it)
     {tb, new_tab} = TabBar.add(tb, :file, label)
+    tb = TabBar.move_tab_to_group(tb, new_tab.id, workspace_id)
     workspace = WorkspaceState.sync_active_window_buffer(workspace)
 
     # Snapshot the new tab's context
@@ -625,5 +643,15 @@ defmodule MingaEditor.Shell.Traditional do
       %{buffers: %Buffers{active: ^pid}} -> true
       _ -> false
     end
+  end
+
+  @spec buffer_file_ref(pid()) :: FileRef.t() | nil
+  defp buffer_file_ref(pid) when is_pid(pid) do
+    case Buffer.file_path(pid) do
+      path when is_binary(path) -> FileRef.new(path)
+      _ -> nil
+    end
+  catch
+    :exit, _ -> nil
   end
 end

--- a/lib/minga_editor/shell/traditional/tab_bar_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tab_bar_renderer.ex
@@ -113,7 +113,8 @@ defmodule MingaEditor.Shell.Traditional.TabBarRenderer do
 
   @spec build_segments(TabBar.t(), map()) :: [segment()]
   defp build_segments(tb, colors) do
-    tb.tabs
+    tb
+    |> TabBar.visible_file_tabs()
     |> Enum.with_index(1)
     |> Enum.map(fn {tab, position} ->
       is_active = tab.id == tb.active_id

--- a/lib/minga_editor/state/tab_bar.ex
+++ b/lib/minga_editor/state/tab_bar.ex
@@ -13,8 +13,12 @@ defmodule MingaEditor.State.TabBar do
   - Tab ids are unique and monotonically increasing.
   """
 
+  alias Minga.Buffer
+  alias Minga.FileRef
   alias MingaEditor.State.AgentGroup
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context, as: TabContext
 
   @typedoc "Tab bar state."
   @type t :: %__MODULE__{
@@ -182,27 +186,16 @@ defmodule MingaEditor.State.TabBar do
     end
   end
 
-  @doc "Switches to the next tab, wrapping around."
+  @doc "Switches to the next visible file tab in the active workspace, wrapping around."
   @spec next(t()) :: t()
-  def next(%__MODULE__{tabs: [_single]} = tb), do: tb
-
-  def next(%__MODULE__{tabs: tabs} = tb) do
-    idx = active_index(tb)
-    next_idx = rem(idx + 1, length(tabs))
-    next_tab = Enum.at(tabs, next_idx)
-    %{tb | active_id: next_tab.id}
+  def next(%__MODULE__{} = tb) do
+    cycle_visible_file_tab(tb, 1)
   end
 
-  @doc "Switches to the previous tab, wrapping around."
+  @doc "Switches to the previous visible file tab in the active workspace, wrapping around."
   @spec prev(t()) :: t()
-  def prev(%__MODULE__{tabs: [_single]} = tb), do: tb
-
-  def prev(%__MODULE__{tabs: tabs} = tb) do
-    idx = active_index(tb)
-    len = length(tabs)
-    prev_idx = if idx == 0, do: len - 1, else: idx - 1
-    prev_tab = Enum.at(tabs, prev_idx)
-    %{tb | active_id: prev_tab.id}
+  def prev(%__MODULE__{} = tb) do
+    cycle_visible_file_tab(tb, -1)
   end
 
   @doc "Updates the context of the tab with the given id."
@@ -400,6 +393,81 @@ defmodule MingaEditor.State.TabBar do
       nil -> 0
     end
   end
+
+  @doc "Returns visible file tabs for the active workspace."
+  @spec visible_file_tabs(t()) :: [Tab.t()]
+  def visible_file_tabs(%__MODULE__{} = tb) do
+    visible_file_tabs(tb, active_group_id(tb))
+  end
+
+  @doc "Returns visible file tabs for the given workspace id. Agent chat tabs are excluded."
+  @spec visible_file_tabs(t(), non_neg_integer()) :: [Tab.t()]
+  def visible_file_tabs(%__MODULE__{tabs: tabs}, workspace_id)
+      when is_integer(workspace_id) and workspace_id >= 0 do
+    Enum.filter(tabs, &visible_file_tab?(&1, workspace_id))
+  end
+
+  @doc "Finds the file tab in a workspace that represents the given file reference."
+  @spec find_file_tab_in_workspace(t(), non_neg_integer(), FileRef.t()) :: Tab.t() | nil
+  def find_file_tab_in_workspace(%__MODULE__{} = tb, workspace_id, %FileRef{} = file_ref)
+      when is_integer(workspace_id) and workspace_id >= 0 do
+    tb
+    |> visible_file_tabs(workspace_id)
+    |> Enum.find(&tab_matches_file_ref?(&1, file_ref))
+  end
+
+  @spec visible_file_tab?(Tab.t(), non_neg_integer()) :: boolean()
+  defp visible_file_tab?(%Tab{kind: :file, group_id: workspace_id}, workspace_id), do: true
+  defp visible_file_tab?(%Tab{}, _workspace_id), do: false
+
+  @spec tab_matches_file_ref?(Tab.t(), FileRef.t()) :: boolean()
+  defp tab_matches_file_ref?(%Tab{} = tab, %FileRef{} = file_ref) do
+    case tab_file_ref(tab) do
+      %FileRef{} = tab_ref -> FileRef.same?(tab_ref, file_ref)
+      nil -> false
+    end
+  end
+
+  @spec tab_file_ref(Tab.t()) :: FileRef.t() | nil
+  defp tab_file_ref(%Tab{context: context}) when is_map(context) do
+    case TabContext.to_workspace_map(context) do
+      %{buffers: %Buffers{active: pid}} when is_pid(pid) -> buffer_file_ref(pid)
+      _ -> nil
+    end
+  end
+
+  @spec buffer_file_ref(pid()) :: FileRef.t() | nil
+  defp buffer_file_ref(pid) do
+    case Buffer.file_path(pid) do
+      path when is_binary(path) -> FileRef.new(path)
+      _ -> nil
+    end
+  catch
+    :exit, _ -> nil
+  end
+
+  @spec cycle_visible_file_tab(t(), 1 | -1) :: t()
+  defp cycle_visible_file_tab(%__MODULE__{} = tb, step) do
+    case visible_file_tabs(tb) do
+      [] -> tb
+      [_single] -> tb
+      tabs -> switch_to_cycle_neighbor(tb, tabs, step)
+    end
+  end
+
+  @spec switch_to_cycle_neighbor(t(), [Tab.t()], 1 | -1) :: t()
+  defp switch_to_cycle_neighbor(%__MODULE__{active_id: active_id} = tb, tabs, step) do
+    idx = Enum.find_index(tabs, &(&1.id == active_id))
+    target_idx = cycle_target_index(idx, length(tabs), step)
+    %{tb | active_id: Enum.at(tabs, target_idx).id}
+  end
+
+  @spec cycle_target_index(non_neg_integer() | nil, pos_integer(), 1 | -1) :: non_neg_integer()
+  defp cycle_target_index(nil, _len, 1), do: 0
+  defp cycle_target_index(nil, len, -1), do: len - 1
+  defp cycle_target_index(idx, len, 1), do: rem(idx + 1, len)
+  defp cycle_target_index(0, len, -1), do: len - 1
+  defp cycle_target_index(idx, _len, -1), do: idx - 1
 
   @doc """
   Adds an agent agent group and returns `{updated_tab_bar, agent group}`.

--- a/test/minga_editor/commands/buffer_management_test.exs
+++ b/test/minga_editor/commands/buffer_management_test.exs
@@ -180,19 +180,35 @@ defmodule MingaEditor.Commands.BufferManagementTest do
       refute Enum.any?(tab_labels(result), &String.starts_with?(&1, "[new"))
     end
 
-    test ":q with the last file tab and an agent tab prompts instead of activating the agent" do
+    test ":q with the last file tab and an agent tab closes the file tab" do
       {state, _buffer} = start_command_state("first file")
-      {state, _agent_tab_id} = add_agent_tab_after_active_and_return_to_file(state)
+      {state, agent_tab_id} = add_agent_tab_after_active_and_return_to_file(state)
       active_tab_id = EditorState.tab_bar(state).active_id
 
       result = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
 
-      assert result.pending_quit == :quit
-      assert result.shell_state.status_msg == "Quit Minga? (y/n)"
-      assert tab_count(result) == 2
-      assert EditorState.tab_bar(result).active_id == active_tab_id
-      assert EditorState.active_tab_kind(result) == :file
+      assert result.pending_quit == nil
+      assert tab_count(result) == 1
+      assert EditorState.tab_bar(result).active_id == agent_tab_id
+      refute active_tab_id in Enum.map(EditorState.tab_bar(result).tabs, & &1.id)
       refute Enum.any?(tab_labels(result), &String.starts_with?(&1, "[new"))
+    end
+
+    test ":q closes only the active workspace file tab when another workspace has a file tab" do
+      {state, _buffer} = start_command_state("first file")
+      {state, hidden_buffer} = add_file_tab_with_buffer(state)
+      hidden_tab_id = EditorState.tab_bar(state).active_id
+      {tb, group} = TabBar.add_agent_group(EditorState.tab_bar(state), "Agent")
+      tb = TabBar.move_tab_to_group(tb, hidden_tab_id, group.id)
+      tb = TabBar.switch_to(tb, 1)
+      state = EditorState.set_tab_bar(state, tb)
+
+      result = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
+
+      assert tab_count(result) == 1
+      assert EditorState.tab_bar(result).active_id == hidden_tab_id
+      assert TabBar.get(EditorState.tab_bar(result), hidden_tab_id) != nil
+      refute_process_down(hidden_buffer)
     end
 
     test ":q with a file and agent neighbor activates another file tab" do
@@ -213,7 +229,7 @@ defmodule MingaEditor.Commands.BufferManagementTest do
   end
 
   describe "close_other_tabs command state" do
-    test "closes all tabs except the active tab" do
+    test "closes all visible workspace tabs except the active tab" do
       {state, _buffer} = start_command_state("first file")
 
       state =
@@ -227,6 +243,24 @@ defmodule MingaEditor.Commands.BufferManagementTest do
 
       assert tab_count(result) == 1
       assert EditorState.tab_bar(result).active_id == active_tab_id
+    end
+
+    test "close_other_tabs leaves tabs from other workspaces alone" do
+      {state, _buffer} = start_command_state("first file")
+      state = add_file_tab(state, "manual sibling")
+      visible_tab_id = EditorState.tab_bar(state).active_id
+      state = add_file_tab(state, "hidden workspace")
+      hidden_tab_id = EditorState.tab_bar(state).active_id
+      {tb, group} = TabBar.add_agent_group(EditorState.tab_bar(state), "Agent")
+      tb = TabBar.move_tab_to_group(tb, hidden_tab_id, group.id)
+      tb = TabBar.switch_to(tb, visible_tab_id)
+      state = EditorState.set_tab_bar(state, tb)
+
+      result = BufferManagement.execute(state, :close_other_tabs)
+
+      assert TabBar.get(EditorState.tab_bar(result), visible_tab_id) != nil
+      assert TabBar.get(EditorState.tab_bar(result), hidden_tab_id) != nil
+      refute TabBar.has_tab?(EditorState.tab_bar(result), 1)
     end
 
     test "ignores stopped-session events for tabs that were already removed" do

--- a/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
+++ b/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
@@ -34,8 +34,8 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
       assert group_id == 0
     end
 
-    test "multiple tabs each carry their own group_id" do
-      tab1 = %Tab{id: 1, kind: :file, label: "a.ex", group_id: 0}
+    test "multiple visible tabs each carry their own group_id" do
+      tab1 = %Tab{id: 1, kind: :file, label: "a.ex", group_id: 5}
       tab2 = %Tab{id: 2, kind: :file, label: "b.ex", group_id: 5}
       tb = %TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
 
@@ -47,7 +47,7 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
 
       <<_flags2::8, _id2::32, gid2::16, _rest3::binary>> = rest2
 
-      assert gid1 == 0
+      assert gid1 == 5
       assert gid2 == 5
     end
 
@@ -86,6 +86,19 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
       assert active_index == 255
       assert tab_count == 1
       assert Bitwise.band(flags, 0x01) == 0
+    end
+
+    test "agent tabs and file tabs from other workspaces are omitted" do
+      tab1 = %Tab{id: 1, kind: :file, label: "a.ex", group_id: 0}
+      tab2 = %Tab{id: 2, kind: :agent, label: "Agent", group_id: 7}
+      tab3 = %Tab{id: 3, kind: :file, label: "b.ex", group_id: 7}
+      tb = %TabBar{tabs: [tab1, tab2, tab3], active_id: 2, next_id: 4}
+
+      <<0x71, active_index::8, 1::8, rest::binary>> = ProtocolGUI.encode_gui_tab_bar(tb)
+      <<_flags::8, id::32, _rest::binary>> = rest
+
+      assert active_index == 255
+      assert id == 3
     end
   end
 

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -1356,7 +1356,7 @@ defmodule MingaEditor.Frontend.ProtocolTest do
       # First byte is opcode 0x71 (gui_tab_bar)
       assert <<0x71, active_index::8, tab_count::8, rest::binary>> = encoded
       assert active_index == 0
-      assert tab_count == 2
+      assert tab_count == 1
 
       # First tab: flags has is_active=1
       assert <<flags1::8, id1::32, _rest1::binary>> = rest

--- a/test/minga_editor/integration/file_open_from_agent_tab_test.exs
+++ b/test/minga_editor/integration/file_open_from_agent_tab_test.exs
@@ -10,8 +10,10 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor
   alias MingaEditor.Agent.BufferSync, as: AgentBufferSync
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.Window
   alias Minga.Test.HeadlessPort
   alias Minga.Test.StubServer
@@ -51,7 +53,14 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
         | map: Map.put(state.workspace.windows.map, win_id, agent_window)
       }
 
-      agent_tab_bar = TabBar.new(Tab.new_agent(1, "Agent"))
+      manual_tab =
+        Tab.new_file(1, "unnamed")
+        |> Tab.set_context(WorkspaceState.to_tab_context(state.workspace))
+
+      agent_tab_bar = TabBar.new(manual_tab)
+      {agent_tab_bar, agent_tab} = TabBar.add(agent_tab_bar, :agent, "Agent")
+      {agent_tab_bar, group} = TabBar.add_agent_group(agent_tab_bar, "Agent")
+      agent_tab_bar = TabBar.move_tab_to_group(agent_tab_bar, agent_tab.id, group.id)
 
       agent_state =
         state.shell_state.agent
@@ -115,6 +124,36 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
       send_keys_sync(ctx, "i# <Esc>")
 
       assert screen_contains?(ctx, "# configs = [:editor]")
+    end
+
+    test "opens the same path as separate file tabs in different workspaces", %{tmp_dir: tmp_dir} do
+      ctx = start_editor_in_agent_mode()
+      file_path = Path.join(tmp_dir, "shared.ex")
+      File.write!(file_path, "value = :shared\n")
+
+      open_file_and_wait(ctx, file_path)
+
+      agent_state = :sys.get_state(ctx.editor)
+      agent_workspace_id = TabBar.active_group_id(agent_state.shell_state.tab_bar)
+      agent_file_tabs = TabBar.visible_file_tabs(agent_state.shell_state.tab_bar)
+      assert Enum.map(agent_file_tabs, & &1.group_id) == [agent_workspace_id]
+
+      :sys.replace_state(ctx.editor, &EditorState.switch_tab(&1, 1))
+      open_file_and_wait(ctx, file_path)
+
+      state = :sys.get_state(ctx.editor)
+      manual_tabs = TabBar.visible_file_tabs(state.shell_state.tab_bar, 0)
+      agent_tabs = TabBar.visible_file_tabs(state.shell_state.tab_bar, agent_workspace_id)
+
+      assert length(manual_tabs) == 2
+      assert length(agent_tabs) == 1
+      assert Enum.map(manual_tabs ++ agent_tabs, & &1.id) |> Enum.uniq() |> length() == 3
+
+      :ok = MingaEditor.open_file(ctx.editor, file_path)
+      reopened_state = :sys.get_state(ctx.editor)
+
+      assert length(TabBar.visible_file_tabs(reopened_state.shell_state.tab_bar, 0)) == 2
+      assert TabBar.active_group_id(reopened_state.shell_state.tab_bar) == 0
     end
   end
 end

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -71,17 +71,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       cmd = ProtocolGUI.encode_gui_tab_bar(tb)
       Port.command(port, cmd)
 
-      # With visible tabs, the harness sends both a JSON report and a gui_action.
-      # Find the JSON one.
-      messages =
-        for _ <- 1..2,
-            do:
-              (
-                assert_receive {^port, {:data, d}}, 5_000
-                d
-              )
-
-      json = Enum.find(messages, &String.starts_with?(&1, "{"))
+      assert_receive {^port, {:data, json}}, 5_000
       decoded = Jason.decode!(json)
 
       assert decoded["type"] == "gui_tab_bar"

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -71,7 +71,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       cmd = ProtocolGUI.encode_gui_tab_bar(tb)
       Port.command(port, cmd)
 
-      # With 2 tabs, the harness sends both a JSON report and a gui_action.
+      # With visible tabs, the harness sends both a JSON report and a gui_action.
       # Find the JSON one.
       messages =
         for _ <- 1..2,
@@ -86,15 +86,13 @@ defmodule Minga.Integration.GUIProtocolTest do
 
       assert decoded["type"] == "gui_tab_bar"
       assert decoded["active_index"] == 0
-      assert length(decoded["tabs"]) == 2
+      assert length(decoded["tabs"]) == 1
 
-      [t1, t2] = decoded["tabs"]
+      [t1] = decoded["tabs"]
       assert t1["id"] == 1
       assert t1["label"] == "editor.ex"
       assert t1["is_active"] == true
-      assert t2["id"] == 2
-      assert t2["label"] == "Agent"
-      assert t2["is_agent"] == true
+      assert t1["is_agent"] == false
     end
 
     test "gui_breadcrumb encodes and decodes correctly", %{port: port} do

--- a/test/minga_editor/shell/traditional/tab_bar_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tab_bar_renderer_test.exs
@@ -231,7 +231,7 @@ defmodule MingaEditor.Shell.Traditional.TabBarRendererTest do
   end
 
   describe "click regions" do
-    test "each tab has goto and close click regions" do
+    test "each visible file tab has goto and close click regions" do
       tab1 = Tab.new_file(1, "a.ex")
       tb = TabBar.new(tab1)
       {tb, _} = TabBar.add(tb, :file, "b.ex")
@@ -241,15 +241,13 @@ defmodule MingaEditor.Shell.Traditional.TabBarRendererTest do
 
       commands = Enum.map(regions, fn {_, _, cmd} -> cmd end) |> MapSet.new()
 
-      # Goto regions
       assert :tab_goto_1 in commands
       assert :tab_goto_2 in commands
-      assert :tab_goto_3 in commands
+      refute :tab_goto_3 in commands
 
-      # Close regions
       assert :tab_close_1 in commands
       assert :tab_close_2 in commands
-      assert :tab_close_3 in commands
+      refute :tab_close_3 in commands
     end
 
     test "goto and close regions for the same tab don't overlap" do
@@ -368,14 +366,15 @@ defmodule MingaEditor.Shell.Traditional.TabBarRendererTest do
   end
 
   describe "agent tabs" do
-    test "agent tab shows agent icon" do
+    test "agent tabs are not rendered in the file tab strip" do
       tab = Tab.new_agent(1, "My Session")
       tb = TabBar.new(tab)
 
-      {draws, _} = TabBarRenderer.render(0, 80, tb, doom_theme())
+      {draws, regions} = TabBarRenderer.render(0, 80, tb, doom_theme())
 
       all_text = Enum.map_join(draws, fn {_, _, text, _} -> text end)
-      assert String.contains?(all_text, "\u{F06A9}")
+      refute String.contains?(all_text, "\u{F06A9}")
+      assert regions == []
     end
   end
 end

--- a/test/minga_editor/state/tab_bar_test.exs
+++ b/test/minga_editor/state/tab_bar_test.exs
@@ -1,6 +1,8 @@
 defmodule MingaEditor.State.TabBarTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.FileRef
   alias MingaEditor.State.AgentGroup
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
@@ -23,6 +25,15 @@ defmodule MingaEditor.State.TabBarTest do
 
   defp labels(tb), do: Enum.map(tb.tabs, & &1.label)
   defp active_label(tb), do: TabBar.active(tb).label
+
+  defp buffer_for_path(path) do
+    {:ok, pid} = BufferProcess.start_link(file_path: path)
+    pid
+  end
+
+  defp tab_with_active_buffer(tab, buffer) do
+    Tab.set_context(tab, %{buffers: %Buffers{active: buffer, list: [buffer], active_index: 0}})
+  end
 
   defp two_agent_groups do
     tb = TabBar.new(file_tab(1, "a.ex"))
@@ -155,6 +166,31 @@ defmodule MingaEditor.State.TabBarTest do
       assert TabBar.next(single) == single
       assert TabBar.prev(single) == single
     end
+
+    test "cycles only within the active workspace" do
+      tb =
+        tab_bar(
+          file: "manual-a",
+          file: "manual-b",
+          agent: "Agent",
+          file: "agent-a",
+          file: "agent-b"
+        )
+
+      {tb, group} = TabBar.add_agent_group(tb, "Agent")
+      tb = TabBar.move_tab_to_group(tb, 3, group.id)
+      tb = TabBar.move_tab_to_group(tb, 4, group.id)
+      tb = TabBar.move_tab_to_group(tb, 5, group.id)
+
+      tb = TabBar.switch_to(tb, 4)
+      assert TabBar.next(tb).active_id == 5
+      assert TabBar.next(TabBar.next(tb)).active_id == 4
+      assert TabBar.prev(tb).active_id == 5
+
+      tb = TabBar.switch_to(tb, 1)
+      assert TabBar.next(tb).active_id == 2
+      assert TabBar.prev(tb).active_id == 2
+    end
   end
 
   describe "tab updates" do
@@ -181,6 +217,39 @@ defmodule MingaEditor.State.TabBarTest do
       assert TabBar.find_by_kind(TabBar.new(file_tab(1)), :agent) == nil
       assert length(TabBar.filter_by_kind(tb, :file)) == 2
       assert length(TabBar.filter_by_kind(tb, :agent)) == 1
+    end
+  end
+
+  describe "visible_file_tabs/1 and visible_file_tabs/2" do
+    test "returns only file tabs in the active workspace" do
+      tb = tab_bar(file: "manual.ex", agent: "Agent", file: "agent.ex", file: "other.ex")
+      {tb, group} = TabBar.add_agent_group(tb, "Agent")
+      tb = TabBar.move_tab_to_group(tb, 2, group.id)
+      tb = TabBar.move_tab_to_group(tb, 3, group.id)
+      tb = TabBar.switch_to(tb, 2)
+
+      assert Enum.map(TabBar.visible_file_tabs(tb), & &1.label) == ["agent.ex"]
+      assert Enum.map(TabBar.visible_file_tabs(tb, 0), & &1.label) == ["manual.ex", "other.ex"]
+    end
+
+    test "finds same-path file tabs by workspace and excludes agent tabs" do
+      path = "/tmp/minga-tab-bar-same-file.ex"
+      manual_buffer = buffer_for_path(path)
+      agent_buffer = buffer_for_path(path)
+
+      manual_tab = tab_with_active_buffer(file_tab(1, "same.ex"), manual_buffer)
+      agent_tab = Tab.new_agent(2, "Agent")
+      agent_file_tab = tab_with_active_buffer(file_tab(3, "same.ex"), agent_buffer)
+
+      tb = %TabBar{tabs: [manual_tab, agent_tab, agent_file_tab], active_id: 2, next_id: 4}
+      {tb, group} = TabBar.add_agent_group(tb, "Agent")
+      tb = TabBar.move_tab_to_group(tb, 2, group.id)
+      tb = TabBar.move_tab_to_group(tb, 3, group.id)
+      file_ref = FileRef.new(path)
+
+      assert TabBar.find_file_tab_in_workspace(tb, 0, file_ref).id == 1
+      assert TabBar.find_file_tab_in_workspace(tb, group.id, file_ref).id == 3
+      refute Enum.any?(TabBar.visible_file_tabs(tb), &(&1.kind == :agent))
     end
   end
 


### PR DESCRIPTION
# TL;DR
File tab projection is now scoped to the active workspace, so file tab open, close, and next/previous navigation stay inside the current workspace. Agent chat tabs remain outside the visible file tab strip.

Closes #1777

## Context
File tabs and agent workspaces were sharing one global strip. That made workspace boundaries unclear and could let a close or navigation command land the user in an unrelated workspace.

## Changes
- Added `Minga.FileRef` and workspace-scoped `TabBar.visible_file_tabs/1,2` plus `TabBar.find_file_tab_in_workspace/3` so file reuse compares logical file identity, not display labels.
- Updated Traditional shell open paths, command-mode `:e`, direct editor open, split open, close, close-others, and tab next/previous behavior to use active-workspace file tabs.
- Updated GUI protocol emission and TUI tab rendering to project only file tabs from the active workspace.
- Added regression coverage for same-path files in multiple workspaces, active-workspace reuse, close isolation, next/previous scoping, and GUI/TUI projection excluding agent tabs.

## Verification
- `mix test.llm test/minga_editor/state/tab_bar_test.exs test/minga_editor/integration/file_open_from_agent_tab_test.exs test/minga_editor/commands/buffer_management_test.exs test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs test/minga_editor/frontend/protocol_test.exs test/minga_editor/integration/gui_protocol_test.exs`
- `mix test.llm test/minga_editor/shell/traditional/tab_bar_renderer_test.exs`
- `make lint`
- `mix test.llm` (PASS: 52 doctests, 99 properties, 7826 tests, 0 failures, 5 skipped, 194 excluded)
- `git diff --check`

## Acceptance Criteria Addressed
- Visible tab projection contains only file tabs whose `group_id` or workspace id matches the active workspace id. ✅
- Agent chat tabs are not included in the visible file tab projection. ✅
- Opening a file reuses an existing tab only in the active workspace. ✅
- The same logical file path can appear as separate tab instances in two workspaces. ✅
- Closing a file tab closes only that workspace's tab and never closes or mutates the same file tab in another workspace. ✅
- Next/previous tab commands operate within the active workspace. ✅
