### PR TITLE
Extract mouse buffer hit testing

### DIFF
--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -35,6 +35,8 @@ defmodule MingaEditor.Mouse do
   alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.FoldMap
   alias MingaEditor.Layout
+  alias MingaEditor.Mouse.HitTest
+  alias MingaEditor.Mouse.Target.Buffer, as: BufferTarget
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -1111,7 +1113,7 @@ defmodule MingaEditor.Mouse do
          buf when is_pid(buf) <- window.buffer do
       total_lines = Buffer.line_count(buf)
       {cursor_line, _} = window.cursor
-      scroll_top = window_scroll_top(window, win_h, content_w, cursor_line, buf)
+      scroll_top = HitTest.scroll_top(window, win_h, content_w, cursor_line, buf)
 
       case fold_target_line_at_row(
              buf,
@@ -1145,7 +1147,7 @@ defmodule MingaEditor.Mouse do
 
     first_buf_line = display_map_scroll_top(window, scroll_top)
 
-    text_width = display_map_content_width(buf, total_lines, content_w)
+    text_width = HitTest.content_text_width(buf, total_lines, content_w)
 
     case DisplayMap.compute(window.fold_map, decs, first_buf_line, win_h, total_lines, text_width) do
       nil ->
@@ -1232,37 +1234,17 @@ defmodule MingaEditor.Mouse do
     end
   end
 
-  @spec gutter_width(state(), non_neg_integer()) :: non_neg_integer()
-  defp gutter_width(%{workspace: %{buffers: %{active: buf}}}, total_lines) do
-    buffer_gutter_width(buf, total_lines)
-  end
-
-  @spec buffer_gutter_width(pid() | nil, non_neg_integer()) :: non_neg_integer()
-  defp buffer_gutter_width(buf, total_lines) do
-    ln_style =
-      if buf, do: Buffer.get_option(buf, :line_numbers), else: :none
-
-    number_w =
-      if ln_style == :none, do: 0, else: Viewport.gutter_width(total_lines)
-
-    # Sign column is always reserved for consistent gutter layout.
-    Gutter.total_width(number_w)
-  end
-
-  @spec display_map_content_width(pid(), non_neg_integer(), pos_integer()) :: pos_integer()
-  defp display_map_content_width(buf, total_lines, content_w) do
-    max(content_w - buffer_gutter_width(buf, total_lines), 1)
-  end
-
   # ── Screen-to-buffer coordinate translation ────────────────────────────────
 
-  @spec mouse_to_buffer_pos(state(), non_neg_integer(), non_neg_integer()) ::
+  @spec mouse_to_buffer_pos(state(), integer(), integer()) ::
           {non_neg_integer(), non_neg_integer()} | nil
   defp mouse_to_buffer_pos(state, row, col) do
-    if EditorState.split?(state) do
-      mouse_to_buffer_pos_split(state, row, col)
-    else
-      mouse_to_buffer_pos_single(state, row, col)
+    case HitTest.resolve_buffer(state, row, col) do
+      {:buffer, target} ->
+        BufferTarget.position(target)
+
+      :miss ->
+        nil
     end
   end
 
@@ -1276,7 +1258,7 @@ defmodule MingaEditor.Mouse do
         window = EditorState.active_window_struct(state)
         total_lines = Buffer.line_count(buf)
         {cursor_line, _} = Buffer.cursor(buf)
-        scroll_top = window_scroll_top(window, win_h, content_w, cursor_line, buf)
+        scroll_top = HitTest.scroll_top(window, win_h, content_w, cursor_line, buf)
         local_row = row - win_row
         target_line = local_row + scroll_top
 
@@ -1287,71 +1269,6 @@ defmodule MingaEditor.Mouse do
         end
 
       nil ->
-        nil
-    end
-  end
-
-  @spec mouse_to_buffer_pos_single(state(), non_neg_integer(), non_neg_integer()) ::
-          {non_neg_integer(), non_neg_integer()} | nil
-  defp mouse_to_buffer_pos_single(%{workspace: %{buffers: %{active: buf}}} = state, row, col) do
-    layout = Layout.get(state)
-
-    case Layout.active_window_layout(layout, state) do
-      %{content: {win_row, win_col, content_w, win_h}} ->
-        window = EditorState.active_window_struct(state)
-        total_lines = Buffer.line_count(buf)
-        gutter_w = gutter_width(state, total_lines)
-        {cursor_line, _} = Buffer.cursor(buf)
-        scroll_top = window_scroll_top(window, win_h, content_w, cursor_line, buf)
-        local_row = row - win_row
-        local_col = max(col - win_col - gutter_w, 0) + current_viewport(state).left
-
-        resolve_with_display_map(
-          buf,
-          window,
-          local_row,
-          local_col,
-          scroll_top,
-          win_h,
-          content_w,
-          total_lines
-        )
-
-      nil ->
-        nil
-    end
-  end
-
-  @spec mouse_to_buffer_pos_split(state(), non_neg_integer(), non_neg_integer()) ::
-          {non_neg_integer(), non_neg_integer()} | nil
-  defp mouse_to_buffer_pos_split(state, row, col) do
-    layout = Layout.get(state)
-
-    case WindowTree.window_at(state.workspace.windows.tree, layout.editor_area, row, col) do
-      {:ok, id, {win_row, win_col, _win_w, _win_h}} ->
-        window = Map.fetch!(state.workspace.windows.map, id)
-        win_layout = Map.fetch!(layout.window_layouts, id)
-        {_cr, _cc, content_w, content_h} = win_layout.content
-        buf = window.buffer
-        total_lines = Buffer.line_count(buf)
-        gutter_w = buffer_gutter_width(buf, total_lines)
-        {cursor_line, _} = window.cursor
-        scroll_top = window_scroll_top(window, content_h, content_w, cursor_line, buf)
-        local_row = row - win_row
-        local_col = max(col - win_col - gutter_w, 0) + window.viewport.left
-
-        resolve_with_display_map(
-          buf,
-          window,
-          local_row,
-          local_col,
-          scroll_top,
-          content_h,
-          content_w,
-          total_lines
-        )
-
-      :error ->
         nil
     end
   end
@@ -1398,16 +1315,16 @@ defmodule MingaEditor.Mouse do
          col
        ) do
     total_lines = Buffer.line_count(buf)
-    gutter_w = buffer_gutter_width(buf, total_lines)
+    gutter_w = HitTest.buffer_gutter_width(buf, total_lines)
     {cursor_line, _} = window.cursor
-    scroll_top = window_scroll_top(window, content_h, content_w, cursor_line, buf)
+    scroll_top = HitTest.scroll_top(window, content_h, content_w, cursor_line, buf)
     local_row = row - content_row
     local_col = max(col - content_col - gutter_w, 0) + window.viewport.left
 
     if local_row < 0 or local_row >= content_h do
       resolve_drag_buffer_pos(buf, local_row, local_col, scroll_top, content_h, total_lines)
     else
-      case resolve_with_display_map(
+      case HitTest.position(
              buf,
              window,
              local_row,
@@ -1417,11 +1334,11 @@ defmodule MingaEditor.Mouse do
              content_w,
              total_lines
            ) do
-        nil ->
-          resolve_drag_buffer_pos(buf, local_row, local_col, scroll_top, content_h, total_lines)
-
-        pos ->
+        {:position, pos} ->
           pos
+
+        _target_or_miss ->
+          resolve_drag_buffer_pos(buf, local_row, local_col, scroll_top, content_h, total_lines)
       end
     end
   catch
@@ -1438,7 +1355,7 @@ defmodule MingaEditor.Mouse do
         ) :: {non_neg_integer(), non_neg_integer()}
   defp resolve_drag_buffer_pos(buf, local_row, local_col, scroll_top, content_h, total_lines) do
     line = drag_target_line(local_row, scroll_top, content_h, total_lines)
-    {line, clamp_col_to_line(buf, line, local_col)}
+    {line, HitTest.clamp_col_to_line(buf, line, local_col)}
   end
 
   @spec drag_target_line(integer(), non_neg_integer(), pos_integer(), non_neg_integer()) ::
@@ -1454,122 +1371,6 @@ defmodule MingaEditor.Mouse do
 
   defp drag_target_line(local_row, scroll_top, _content_h, total_lines) do
     (scroll_top + local_row) |> max(0) |> min(total_lines - 1)
-  end
-
-  # Resolves a click position using the DisplayMap to correctly handle
-  # block decorations, virtual lines, and folds. If the clicked display
-  # row is a block decoration, dispatches on_click and returns nil.
-  @spec resolve_with_display_map(
-          pid(),
-          Window.t() | nil,
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          pos_integer(),
-          pos_integer(),
-          non_neg_integer()
-        ) :: {non_neg_integer(), non_neg_integer()} | nil
-  defp resolve_with_display_map(
-         buf,
-         window,
-         local_row,
-         local_col,
-         scroll_top,
-         win_h,
-         content_w,
-         total_lines
-       ) do
-    decs = Buffer.decorations(buf)
-    fold_map = if window, do: window.fold_map, else: FoldMap.new()
-
-    text_width = display_map_content_width(buf, total_lines, content_w)
-
-    case DisplayMap.compute(fold_map, decs, scroll_top, win_h, total_lines, text_width) do
-      nil ->
-        # No display map needed, use direct line mapping
-        target_line = local_row + scroll_top
-        resolve_buffer_pos(buf, local_row, win_h, target_line, local_col, total_lines)
-
-      %DisplayMap{} = dm ->
-        # Look up what's at this display row
-        case DisplayMap.buf_line_for_display_row(dm, local_row) do
-          nil ->
-            nil
-
-          target_line ->
-            entry = Enum.at(dm.entries, local_row)
-
-            handle_display_row_click(
-              entry,
-              buf,
-              local_row,
-              local_col,
-              win_h,
-              target_line,
-              total_lines
-            )
-        end
-    end
-  catch
-    :exit, _ ->
-      target_line = local_row + scroll_top
-      resolve_buffer_pos(buf, local_row, win_h, target_line, local_col, total_lines)
-  end
-
-  defp handle_display_row_click(
-         {_line, {:block, block, line_idx}},
-         _buf,
-         _row,
-         col,
-         _win_h,
-         _target,
-         _total
-       ) do
-    if block.on_click, do: block.on_click.(line_idx, col)
-    nil
-  end
-
-  defp handle_display_row_click(
-         {_line, {:virtual_line, _}},
-         _buf,
-         _row,
-         _col,
-         _win_h,
-         _target,
-         _total
-       ) do
-    nil
-  end
-
-  defp handle_display_row_click(
-         _entry,
-         buf,
-         local_row,
-         local_col,
-         win_h,
-         target_line,
-         total_lines
-       ) do
-    resolve_buffer_pos(buf, local_row, win_h, target_line, local_col, total_lines)
-  end
-
-  defp resolve_buffer_pos(_buf, row, visible_rows, _line, _col, _total)
-       when row >= visible_rows,
-       do: nil
-
-  defp resolve_buffer_pos(_buf, _row, _visible, target_line, _col, total)
-       when target_line >= total,
-       do: nil
-
-  defp resolve_buffer_pos(_buf, _row, _visible, target_line, _col, _total)
-       when target_line < 0,
-       do: nil
-
-  defp resolve_buffer_pos(buf, _row, _visible, target_line, target_col, _total) do
-    # Adjust for inline virtual text: the target_col is a display column,
-    # but if inline virtual text is present, the buffer column is different.
-    adjusted_col = adjust_col_for_virtual_text(buf, target_line, target_col)
-    {target_line, clamp_col_to_line(buf, target_line, adjusted_col)}
   end
 
   @spec auto_copy_selection(EditorState.t()) :: EditorState.t()
@@ -1610,34 +1411,6 @@ defmodule MingaEditor.Mouse do
   end
 
   defp maybe_copy_to_clipboard(_state, _text), do: :ok
-
-  @spec adjust_col_for_virtual_text(pid(), non_neg_integer(), non_neg_integer()) ::
-          non_neg_integer()
-  defp adjust_col_for_virtual_text(buf, line, display_col) do
-    Decorations.display_col_to_buf_col(Buffer.decorations(buf), line, display_col)
-  catch
-    :exit, _ -> display_col
-  end
-
-  # Computes the scroll top the same way the render pipeline does:
-  # Returns the viewport's scroll top. Now reads from the window's
-  # persistent viewport instead of computing a throwaway one each time.
-  @spec window_scroll_top(
-          Window.t() | nil,
-          pos_integer(),
-          pos_integer(),
-          non_neg_integer(),
-          pid()
-        ) ::
-          non_neg_integer()
-  defp window_scroll_top(%Window{viewport: vp}, _h, _w, _cursor, _buf), do: vp.top
-
-  defp window_scroll_top(nil, content_height, content_width, cursor_line, buf) do
-    # Fallback when no window struct is available
-    vp = Viewport.new(content_height, content_width, 0)
-    vp = Viewport.scroll_to_cursor(vp, {cursor_line, 0}, buf)
-    vp.top
-  end
 
   # ── Viewport helpers ───────────────────────────────────────────────────────
 
@@ -1730,7 +1503,7 @@ defmodule MingaEditor.Mouse do
       clamp_with_margin(cursor_line, first_line, last_line, effective_margin, direction)
 
     if target_line != cursor_line do
-      Buffer.move_to(buf, {target_line, clamp_col_to_line(buf, target_line, cursor_col)})
+      Buffer.move_to(buf, {target_line, HitTest.clamp_col_to_line(buf, target_line, cursor_col)})
     end
 
     state
@@ -1841,17 +1614,6 @@ defmodule MingaEditor.Mouse do
   defp enter_visual_if_needed(state, anchor) do
     visual_state = %VisualState{visual_anchor: anchor, visual_type: :char}
     EditorState.transition_mode(state, :visual, visual_state)
-  end
-
-  @spec clamp_col_to_line(pid(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
-  defp clamp_col_to_line(buf, line, col) do
-    case Buffer.lines(buf, line, 1) do
-      [text] when byte_size(text) > 0 ->
-        min(col, Unicode.last_grapheme_byte_offset(text))
-
-      _ ->
-        0
-    end
   end
 
   @spec cancel_mode_for_mouse(state()) :: state()

--- a/lib/minga_editor/mouse/hit_test.ex
+++ b/lib/minga_editor/mouse/hit_test.ex
@@ -1,0 +1,212 @@
+defmodule MingaEditor.Mouse.HitTest do
+  @moduledoc "Resolves mouse screen coordinates to editor targets."
+
+  alias Minga.Buffer
+  alias Minga.Core.Decorations
+  alias Minga.Core.Unicode
+  alias MingaEditor.DisplayMap
+  alias MingaEditor.FoldMap
+  alias MingaEditor.Layout
+  alias MingaEditor.Mouse.Target.Buffer, as: BufferTarget
+  alias MingaEditor.Renderer.Gutter
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
+  alias MingaEditor.Window
+  alias MingaEditor.WindowTree
+
+  @type state :: EditorState.t()
+  @type target :: {:buffer, BufferTarget.t()} | :miss
+  @type position_result :: {:position, BufferTarget.position()} | :miss
+
+  @spec resolve_buffer(state(), integer(), integer()) :: target()
+  def resolve_buffer(_state, row, _col) when row < 0, do: :miss
+  def resolve_buffer(_state, _row, col) when col < 0, do: :miss
+
+  def resolve_buffer(state, row, col) do
+    with %{id: id, window: window, buffer: buffer, content: content} <-
+           window_context_at(state, row, col),
+         {content_row, content_col, content_width, content_height} = content,
+         total_lines = Buffer.line_count(buffer),
+         gutter_width = buffer_gutter_width(buffer, total_lines),
+         {cursor_line, _cursor_col} = window.cursor,
+         top = scroll_top(window, content_height, content_width, cursor_line, buffer),
+         local_row = row - content_row,
+         local_col = max(col - content_col - gutter_width, 0),
+         display_col = local_col + window.viewport.left,
+         {:position, {line, target_col}} <-
+           position(
+             buffer,
+             window,
+             local_row,
+             display_col,
+             top,
+             content_height,
+             content_width,
+             total_lines
+           ) do
+      {:buffer,
+       BufferTarget.new(%{
+         window_id: id,
+         buffer: buffer,
+         line: line,
+         col: target_col,
+         local_row: local_row,
+         local_col: local_col,
+         viewport: window.viewport
+       })}
+    else
+      _ -> :miss
+    end
+  end
+
+  @spec position(
+          pid(),
+          Window.t() | nil,
+          integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pos_integer(),
+          pos_integer(),
+          non_neg_integer()
+        ) :: position_result()
+  def position(_buf, _window, local_row, _local_col, _scroll_top, win_h, _content_w, _total_lines)
+      when local_row < 0 or local_row >= win_h,
+      do: :miss
+
+  def position(buf, window, local_row, local_col, scroll_top, win_h, content_w, total_lines) do
+    decs = Buffer.decorations(buf)
+    fold_map = if window, do: window.fold_map, else: FoldMap.new()
+
+    first_line = display_map_scroll_top(fold_map, scroll_top)
+
+    case DisplayMap.compute(
+           fold_map,
+           decs,
+           first_line,
+           win_h,
+           total_lines,
+           content_text_width(buf, total_lines, content_w)
+         ) do
+      nil ->
+        direct_position(buf, local_row, win_h, local_row + scroll_top, local_col, total_lines)
+
+      %DisplayMap{} = display_map ->
+        display_map_position(display_map, buf, local_row, local_col, win_h, total_lines)
+    end
+  catch
+    :exit, _ ->
+      direct_position(buf, local_row, win_h, local_row + scroll_top, local_col, total_lines)
+  end
+
+  @spec scroll_top(Window.t() | nil, pos_integer(), pos_integer(), non_neg_integer(), pid()) ::
+          non_neg_integer()
+  def scroll_top(%Window{viewport: viewport}, _height, _width, _cursor_line, _buffer),
+    do: viewport.top
+
+  def scroll_top(nil, content_height, content_width, cursor_line, buffer) do
+    viewport = Viewport.new(content_height, content_width, 0)
+    viewport = Viewport.scroll_to_cursor(viewport, {cursor_line, 0}, buffer)
+    viewport.top
+  end
+
+  @spec buffer_gutter_width(pid() | nil, non_neg_integer()) :: non_neg_integer()
+  def buffer_gutter_width(buffer, total_lines) do
+    line_number_style = if buffer, do: Buffer.get_option(buffer, :line_numbers), else: :none
+
+    Gutter.total_width(
+      if line_number_style == :none, do: 0, else: Viewport.gutter_width(total_lines)
+    )
+  end
+
+  @spec content_text_width(pid(), non_neg_integer(), pos_integer()) :: pos_integer()
+  def content_text_width(buffer, total_lines, content_width),
+    do: max(content_width - buffer_gutter_width(buffer, total_lines), 1)
+
+  @spec clamp_col_to_line(pid(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  def clamp_col_to_line(buffer, line, col) do
+    case Buffer.lines(buffer, line, 1) do
+      [text] when byte_size(text) > 0 -> min(col, Unicode.last_grapheme_byte_offset(text))
+      _ -> 0
+    end
+  end
+
+  defp window_context_at(state, row, col) do
+    layout = Layout.get(state)
+
+    if EditorState.split?(state) do
+      with {:ok, id, _rect} <-
+             WindowTree.window_at(state.workspace.windows.tree, layout.editor_area, row, col) do
+        context_from_window(state, layout, id, row, col)
+      end
+    else
+      context_from_window(state, layout, state.workspace.windows.active, row, col)
+    end
+  end
+
+  defp context_from_window(state, layout, id, row, col) do
+    with %{content: content} <- Map.get(layout.window_layouts, id),
+         true <- point_in_rect?(row, col, content),
+         %Window{buffer: buffer} = window <- Map.get(state.workspace.windows.map, id),
+         true <- is_pid(buffer) do
+      %{id: id, window: window, buffer: buffer, content: content}
+    else
+      _ -> nil
+    end
+  end
+
+  defp point_in_rect?(row, col, {rect_row, rect_col, width, height}) do
+    row >= rect_row and row < rect_row + height and col >= rect_col and col < rect_col + width
+  end
+
+  defp display_map_scroll_top(%FoldMap{folds: []}, scroll_top), do: scroll_top
+
+  defp display_map_scroll_top(fold_map, scroll_top),
+    do: FoldMap.visible_to_buffer(fold_map, scroll_top)
+
+  defp display_map_position(
+         %DisplayMap{entries: entries},
+         buffer,
+         local_row,
+         local_col,
+         win_h,
+         total_lines
+       ) do
+    case Enum.at(entries, local_row) do
+      {_line, {:virtual_line, _}} ->
+        :miss
+
+      {_line, {:block, block, line_index}} ->
+        click_block(block, line_index, local_col)
+
+      {target_line, _entry_type} ->
+        direct_position(buffer, local_row, win_h, target_line, local_col, total_lines)
+
+      nil ->
+        :miss
+    end
+  end
+
+  defp click_block(block, line_index, col) do
+    if block.on_click, do: block.on_click.(line_index, col)
+    :miss
+  end
+
+  defp direct_position(_buffer, row, visible_rows, _line, _col, _total_lines)
+       when row < 0 or row >= visible_rows,
+       do: :miss
+
+  defp direct_position(_buffer, _row, _visible_rows, target_line, _col, total_lines)
+       when target_line < 0 or target_line >= total_lines,
+       do: :miss
+
+  defp direct_position(buffer, _row, _visible_rows, target_line, target_col, _total_lines) do
+    adjusted_col = adjust_col_for_virtual_text(buffer, target_line, target_col)
+    {:position, {target_line, clamp_col_to_line(buffer, target_line, adjusted_col)}}
+  end
+
+  defp adjust_col_for_virtual_text(buffer, line, display_col) do
+    Decorations.display_col_to_buf_col(Buffer.decorations(buffer), line, display_col)
+  catch
+    :exit, _ -> display_col
+  end
+end

--- a/lib/minga_editor/mouse/target/buffer.ex
+++ b/lib/minga_editor/mouse/target/buffer.ex
@@ -1,0 +1,26 @@
+defmodule MingaEditor.Mouse.Target.Buffer do
+  @moduledoc "A buffer-content mouse hit target resolved from screen coordinates."
+
+  alias MingaEditor.Viewport
+  alias MingaEditor.Window
+
+  @type position :: {line :: non_neg_integer(), col :: non_neg_integer()}
+  @type t :: %__MODULE__{
+          window_id: Window.id(),
+          buffer: pid(),
+          line: non_neg_integer(),
+          col: non_neg_integer(),
+          local_row: non_neg_integer(),
+          local_col: non_neg_integer(),
+          viewport: Viewport.t()
+        }
+
+  @enforce_keys [:window_id, :buffer, :line, :col, :local_row, :local_col, :viewport]
+  defstruct [:window_id, :buffer, :line, :col, :local_row, :local_col, :viewport]
+
+  @spec new(map()) :: t()
+  def new(attrs), do: struct!(__MODULE__, attrs)
+
+  @spec position(t()) :: position()
+  def position(%__MODULE__{line: line, col: col}), do: {line, col}
+end

--- a/test/minga_editor/mouse/hit_test_test.exs
+++ b/test/minga_editor/mouse/hit_test_test.exs
@@ -1,0 +1,152 @@
+defmodule MingaEditor.Mouse.HitTestTest do
+  @moduledoc """
+  Focused tests for resolving mouse screen coordinates to buffer targets.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Editing.Fold.Range, as: FoldRange
+  alias MingaEditor.Commands.Movement
+  alias MingaEditor.Layout
+  alias MingaEditor.Mouse.HitTest
+  alias MingaEditor.Mouse.Target.Buffer, as: BufferTarget
+  alias MingaEditor.Startup
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Window
+
+  describe "resolve_buffer/3" do
+    test "resolves a single-window buffer target with gutter-adjusted columns" do
+      {state, buffer} = start_mouse_state("zero\none\ntwo")
+      %{content: {row, col, _width, _height}} = active_window_layout(state)
+      gutter_width = HitTest.buffer_gutter_width(buffer, BufferProcess.line_count(buffer))
+
+      assert {:buffer, %BufferTarget{} = target} =
+               HitTest.resolve_buffer(state, row + 1, col + gutter_width + 2)
+
+      assert target.window_id == state.workspace.windows.active
+      assert target.buffer == buffer
+      assert BufferTarget.position(target) == {1, 2}
+      assert target.local_row == 1
+      assert target.local_col == 2
+      assert target.viewport == EditorState.active_window_struct(state).viewport
+    end
+
+    test "resolves split-window targets without stealing active-window context" do
+      {state, _buffer} = start_mouse_state("zero\none\ntwo")
+      state = Movement.execute(state, :split_vertical)
+      active_id = state.workspace.windows.active
+      layout = Layout.get(state)
+      {target_id, %{content: {row, col, _width, _height}}} = rightmost_window_layout(layout)
+      target_window = Map.fetch!(state.workspace.windows.map, target_id)
+
+      gutter_width =
+        HitTest.buffer_gutter_width(
+          target_window.buffer,
+          BufferProcess.line_count(target_window.buffer)
+        )
+
+      assert target_id != active_id
+
+      assert {:buffer, %BufferTarget{} = target} =
+               HitTest.resolve_buffer(state, row + 2, col + gutter_width + 1)
+
+      assert target.window_id == target_id
+      assert target.buffer == target_window.buffer
+      assert BufferTarget.position(target) == {2, 1}
+      assert state.workspace.windows.active == active_id
+    end
+
+    test "adds horizontal viewport offset to the resolved target column" do
+      {state, buffer} = start_mouse_state("abcdefghijklmnopqrstuvwxyz")
+
+      state =
+        EditorState.update_window(
+          state,
+          state.workspace.windows.active,
+          &Window.scroll_horizontal(&1, 5)
+        )
+
+      %{content: {row, col, _width, _height}} = active_window_layout(state)
+      gutter_width = HitTest.buffer_gutter_width(buffer, BufferProcess.line_count(buffer))
+
+      assert {:buffer, %BufferTarget{} = target} =
+               HitTest.resolve_buffer(state, row, col + gutter_width + 3)
+
+      assert BufferTarget.position(target) == {0, 8}
+      assert target.local_col == 3
+      assert target.viewport.left == 5
+    end
+
+    test "maps folded scrolled viewport rows back to buffer lines" do
+      {state, buffer} = start_mouse_state(lines(0..49))
+
+      state =
+        EditorState.update_window(state, state.workspace.windows.active, fn window ->
+          window
+          |> Window.set_fold_ranges([FoldRange.new!(0, 2)])
+          |> Window.fold_at(0)
+          |> Window.scroll_viewport(1, BufferProcess.line_count(buffer))
+        end)
+
+      %{content: {row, col, _width, _height}} = active_window_layout(state)
+      gutter_width = HitTest.buffer_gutter_width(buffer, BufferProcess.line_count(buffer))
+
+      assert {:buffer, %BufferTarget{} = target} =
+               HitTest.resolve_buffer(state, row, col + gutter_width)
+
+      assert BufferTarget.position(target) == {3, 0}
+    end
+
+    test "returns miss outside buffer content" do
+      {state, _buffer} = start_mouse_state("zero\none")
+
+      assert HitTest.resolve_buffer(state, 999, 999) == :miss
+    end
+  end
+
+  defp start_mouse_state(content, opts \\ []) do
+    id = :erlang.unique_integer([:positive])
+    events_registry = :"#{__MODULE__}.Events.#{id}"
+    project_root = Path.join(System.tmp_dir!(), "minga-hit-test-#{id}")
+    File.mkdir_p!(project_root)
+    start_supervised!({Minga.Events, name: events_registry}, id: {:events, id})
+
+    options_server =
+      start_supervised!({Minga.Config.Options, name: nil, events_registry: events_registry},
+        id: {:options, id}
+      )
+
+    buffer =
+      start_supervised!(
+        {BufferProcess,
+         content: content, events_registry: events_registry, options_server: options_server},
+        id: {:buffer, id}
+      )
+
+    state =
+      Startup.build_initial_state(
+        port_manager: nil,
+        buffer: buffer,
+        width: Keyword.get(opts, :width, 40),
+        height: Keyword.get(opts, :height, 10),
+        editing_model: :vim,
+        options_server: options_server,
+        events_registry: events_registry,
+        project_root: project_root,
+        suppress_tool_prompts: true
+      )
+
+    {state, buffer}
+  end
+
+  defp active_window_layout(state), do: Layout.active_window_layout(Layout.get(state), state)
+
+  defp lines(range), do: Enum.map_join(range, "\n", &"line #{&1}")
+
+  defp rightmost_window_layout(layout) do
+    Enum.max_by(layout.window_layouts, fn {_id, %{content: {_row, content_col, _width, _height}}} ->
+      content_col
+    end)
+  end
+end

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -239,6 +239,29 @@ defmodule MingaEditor.MouseTest do
     end
   end
 
+  describe "block decoration clicks" do
+    test "clicking a block decoration dispatches its on_click callback" do
+      test_pid = self()
+      {state, buffer} = start_mouse_state("agent output\nline two")
+
+      BufferProcess.batch_decorations(buffer, fn decorations ->
+        {_id, decorations} =
+          Decorations.add_block_decoration(decorations, 0,
+            placement: :above,
+            render: fn _width -> [{"clickable", Minga.Core.Face.new()}] end,
+            on_click: fn line_index, col -> send(test_pid, {:block_clicked, line_index, col}) end
+          )
+
+        decorations
+      end)
+
+      {row, col} = active_content_origin(state)
+      mouse(state, row, col + @gutter + 4, :left, :press)
+
+      assert_receive {:block_clicked, 0, 4}
+    end
+  end
+
   describe "fold gutter clicks" do
     test "clicking a fold indicator toggles the window fold" do
       {state, _buffer} = start_mouse_state("defmodule Example do\n  def run, do: :ok\nend")


### PR DESCRIPTION
# TL;DR
Buffer-content mouse clicks now resolve through one shared hit-test path before mouse handlers decide what to do. This keeps normal click behavior intact while removing the old parallel single-window and split-window coordinate conversions.

Closes #1741

## Context
Mouse coordinate handling in `MingaEditor.Mouse` had separate paths for single-window clicks, split-window clicks, and drag-specific conversion. This PR extracts the normal buffer-content hit-test path so future mouse targets can build on one resolver instead of copying coordinate math.

## Changes
- Added `MingaEditor.Mouse.HitTest` to resolve screen row/col into a typed buffer target with window id, buffer pid, buffer line/col, local row/col, and viewport snapshot.
- Added `MingaEditor.Mouse.Target.Buffer` as the result struct and constructor owner.
- Routed the existing normal buffer click wrapper through the shared resolver, so left click, middle click, right click, modifier click, double-click, and triple-click paths use the same buffer target lookup.
- Removed the independent `mouse_to_buffer_pos_single/3` and `mouse_to_buffer_pos_split/3` implementations from `MingaEditor.Mouse`.
- Kept drag selection, tab clicks, modeline clicks, fold gutter clicks, and separator resizing on their existing behavior paths, except where shared helpers were reused to preserve current behavior.

## Mouse handling LOC
- Before: `lib/minga_editor/mouse.ex` = 1995 lines.
- After: `lib/minga_editor/mouse.ex` + `lib/minga_editor/mouse/hit_test.ex` + `lib/minga_editor/mouse/target/buffer.ex` = 1995 lines.
- Result: neutral LOC across the mouse handling area.

## Verification
- `mix test.debug test/minga_editor/mouse/hit_test_test.exs test/minga_editor/mouse_test.exs` passed, 26 tests.
- `mix test.llm` passed. Follow-up `mix test --failed` reported no tests to run.
- `make lint` passed, with existing non-blocking large-struct warnings only.
- `git diff --check` passed.
- `rg "mouse_to_buffer_pos_single|mouse_to_buffer_pos_split" lib/minga_editor/mouse.ex` returned no matches.

## Acceptance Criteria Addressed
- Shared mouse hit-test module resolves buffer-content coordinates to a typed target or `:miss`. ✅
- Resolver handles single-window and split-window layouts, gutter offsets, horizontal viewport offsets, window viewport top, folded/display-map mapping, virtual text adjustment, and block-decoration click behavior. ✅
- Normal buffer-content mouse actions use the shared resolver through the existing wrapper. ✅
- Old independent single/split coordinate conversion paths were removed. ✅
- Mouse handling LOC is neutral. ✅
- Focused hit-test tests were added, and existing mouse behavior tests continue to pass. ✅

## Follow-up scope intentionally left out
- Drag selection coordinate paths.
- Tab/modeline click target extraction.
- Split separator resizing target extraction.
- Fold gutter target extraction.
