### PR TITLE
Fix create_worktree pipefail

### DIFF
--- a/scripts/create_worktree
+++ b/scripts/create_worktree
@@ -25,10 +25,13 @@ branch=$1
 base_ref=${2:-main}
 repo_root=$(git rev-parse --show-toplevel)
 main_worktree=$(git -C "$repo_root" worktree list --porcelain | awk '
-  NR == 1 && $1 == "worktree" {
+  $1 == "worktree" && main_worktree == "" {
     sub(/^worktree /, "")
-    print
-    exit
+    main_worktree = $0
+  }
+
+  END {
+    print main_worktree
   }
 ')
 


### PR DESCRIPTION
## Summary
- Fix scripts/create_worktree aborting with exit 141 under pipefail when many worktrees are listed
- Preserve the same primary worktree selection without exiting awk early and closing the pipe

## Tests
- bash -n scripts/create_worktree
- scripts/create_worktree tmp/validate-create-worktree-pipefail origin/main, then removed the temp worktree and branch

## Review
- reviewer PASS