### PR TITLE
Start new agent workspaces empty

### DIFF
--- a/docs/AGENTIC-KEYMAP.md
+++ b/docs/AGENTIC-KEYMAP.md
@@ -131,7 +131,7 @@ See [Agent tool approval](CONFIGURATION.md#agent-tool-approval) for how to confi
 
 | Key | Action |
 |-----|--------|
-| `SPC a n` | New agent session |
+| `SPC a n` | New agent workspace |
 | `SPC a s` | Stop / abort agent |
 | `SPC a m` | Pick agent model |
 | `SPC a T` | Cycle thinking level |

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -150,7 +150,7 @@ defmodule Minga.Keymap.Defaults do
     {[{?a, @none}, {?v, @none}], :toggle_agent_split, "Toggle agent split pane"},
     {[{?a, @none}, {?s, @none}], :agent_abort, "Abort agent turn"},
     {[{?a, @none}, {?S, @none}], :agent_stop_session, "Stop agent session"},
-    {[{?a, @none}, {?n, @none}], :agent_new_session, "New agent session"},
+    {[{?a, @none}, {?n, @none}], :agent_new_session, "New agent workspace"},
     {[{?a, @none}, {?m, @none}], :agent_pick_model, "Pick agent model"},
     {[{?a, @none}, {?M, @none}], :agent_cycle_model, "Cycle agent model"},
     {[{?a, @none}, {?h, @none}], :agent_session_history, "Resume session"},

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -655,23 +655,71 @@ defmodule MingaEditor.Commands.Agent do
   end
 
   @doc """
-  Creates a new agent tab with a fresh session.
+  Creates a new active agent workspace with a fresh session.
 
-  If the current tab is a file tab, snapshots it and switches to a new
-  agent tab. If already on an agent tab, creates a new one alongside it.
+  The new workspace starts with no file membership. The agent tab is the zoom surface for the workspace, not a file tab copied from the source workspace.
   """
   @spec new_agent_session(state()) :: state()
   def new_agent_session(state) do
-    # Reset agent state for a fresh session, then start it.
-    # The agent buffer is reused (content will be cleared by buffer sync).
-    state =
-      AgentAccess.update_agent(state, fn _a ->
-        %AgentState{buffer: AgentAccess.agent(state).buffer}
-      end)
-
-    state = AgentAccess.update_agent_ui(state, fn _a -> UIState.new() end)
-    AgentSession.start_agent_session(state)
+    state
+    |> create_active_agent_tab()
+    |> reset_agent_state_for_new_session()
+    |> AgentLifecycle.setup_agent_highlight()
+    |> AgentSession.start_agent_session()
   end
+
+  @spec reset_agent_state_for_new_session(state()) :: state()
+  defp reset_agent_state_for_new_session(state) do
+    agent_buf = AgentAccess.agent(state).buffer
+
+    state
+    |> AgentAccess.update_agent(fn _a -> %AgentState{buffer: agent_buf} end)
+    |> AgentAccess.update_agent_ui(fn _a -> UIState.new() end)
+  end
+
+  @spec create_active_agent_tab(state()) :: state()
+  defp create_active_agent_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+    {state, agent_buf} = create_fresh_agent_buffer(state)
+    rows = max(state.terminal_viewport.rows, 1)
+    cols = max(state.terminal_viewport.cols, 1)
+    windows = agent_tab_windows(agent_buf, rows, cols)
+    context = EditorState.build_agent_tab_defaults(state, windows, agent_buf)
+    {tb, tab} = TabBar.insert(tb, :agent, "Agent")
+    tb = TabBar.update_context(tb, tab.id, context)
+
+    state
+    |> EditorState.set_tab_bar(tb)
+    |> EditorState.switch_tab(tab.id)
+  end
+
+  defp create_active_agent_tab(state), do: state
+
+  @spec create_fresh_agent_buffer(state()) :: {state(), pid() | nil}
+  defp create_fresh_agent_buffer(state) do
+    case AgentBufferSync.start_buffer(EditorState.options_server(state)) do
+      pid when is_pid(pid) ->
+        state = AgentAccess.update_agent(state, &AgentState.set_buffer(&1, pid))
+        {EditorState.monitor_buffer(state, pid), pid}
+
+      _ ->
+        {state, nil}
+    end
+  end
+
+  @spec agent_tab_windows(pid() | nil, pos_integer(), pos_integer()) :: Windows.t()
+  defp agent_tab_windows(agent_buf, rows, cols) when is_pid(agent_buf) do
+    win_id = 1
+    agent_window = Window.new_agent_chat(win_id, agent_buf, rows, cols)
+
+    %Windows{
+      tree: WindowTree.new(win_id),
+      map: %{win_id => agent_window},
+      active: win_id,
+      next_id: win_id + 1
+    }
+  end
+
+  defp agent_tab_windows(_agent_buf, _rows, _cols), do: %Windows{}
 
   @doc "Stops the current agent session process."
   @spec stop_current_session(state()) :: state()
@@ -1470,7 +1518,7 @@ defmodule MingaEditor.Commands.Agent do
     {:cycle_agent_tabs, "Cycle agent tabs (opens split if none)", :cycle_agent_tabs},
     {:agent_abort, "Abort current AI agent turn", :abort_agent},
     {:agent_stop_session, "Stop AI agent session", :stop_current_session},
-    {:agent_new_session, "New AI agent session", :start_session_picker},
+    {:agent_new_session, "New agent workspace", :start_session_picker},
     {:agent_cycle_model, "Cycle AI agent model", :cycle_model},
     {:agent_summarize, "Summarize session to context artifact", :summarize},
     {:agent_cycle_thinking, "Cycle AI thinking level", :cycle_thinking_level},

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -14,17 +14,23 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Project.FileRef
   alias MingaEditor.Commands.Agent, as: AgentCommands
+  alias MingaEditor.Commands.AgentSession
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace, as: WorkspaceModel
   alias MingaEditor.State.Windows
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.Window
+  alias MingaEditor.WindowTree
   alias MingaEditor.Input
   alias Minga.Test.StubServer
 
@@ -77,6 +83,61 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       },
       shell_state: %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tb},
       focus_stack: Input.default_stack()
+    }
+  end
+
+  defp source_workspace_state do
+    state = base_state(session: nil)
+    source_ref = FileRef.from_buffer(state.workspace.buffers.active)
+
+    file_tab =
+      Tab.new_file(1, FileRef.display_label(source_ref))
+      |> Tab.set_file_ref(source_ref)
+      |> Tab.set_context(WorkspaceState.to_tab_context(state.workspace))
+
+    tab_bar =
+      file_tab
+      |> TabBar.new()
+      |> TabBar.update_workspace(0, fn workspace ->
+        workspace
+        |> WorkspaceModel.add_file(source_ref)
+        |> WorkspaceModel.set_active_file(source_ref)
+      end)
+
+    %{state | shell_state: %{state.shell_state | tab_bar: tab_bar}}
+  end
+
+  defp source_workspace_with_background_agent_tab do
+    state = source_workspace_state()
+    {tab_bar, _agent_tab} = TabBar.insert(state.shell_state.tab_bar, :agent, "Agent")
+    %{state | shell_state: %{state.shell_state | tab_bar: tab_bar}}
+  end
+
+  defp active_agent_workspace_state do
+    {:ok, agent_buf} = BufferProcess.start_link(content: "old chat")
+    state = base_state(agent_buffer: agent_buf)
+    windows = agent_windows(agent_buf)
+
+    EditorState.update_workspace(state, fn workspace ->
+      workspace
+      |> WorkspaceState.set_buffers(%Buffers{
+        active: agent_buf,
+        list: [agent_buf],
+        active_index: 0
+      })
+      |> WorkspaceState.set_windows(windows)
+      |> WorkspaceState.set_agent_ui(UIState.new())
+    end)
+  end
+
+  defp agent_windows(agent_buf) when is_pid(agent_buf) do
+    win_id = 1
+
+    %Windows{
+      tree: WindowTree.new(win_id),
+      map: %{win_id => Window.new_agent_chat(win_id, agent_buf, 24, 80)},
+      active: win_id,
+      next_id: win_id + 1
     }
   end
 
@@ -283,14 +344,67 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       assert AgentAccess.agent(new_state).error == nil
     end
 
-    test "preserves the agent buffer across reset" do
+    test "creates a fresh agent buffer for the new workspace" do
       {:ok, agent_buf} = BufferProcess.start_link(content: "old chat")
       state = base_state(agent_buffer: agent_buf)
 
       new_state = AgentCommands.new_agent_session(state)
 
-      # Buffer should be preserved across session reset
-      assert AgentAccess.agent(new_state).buffer == agent_buf
+      assert is_pid(AgentAccess.agent(new_state).buffer)
+      assert AgentAccess.agent(new_state).buffer != agent_buf
+    end
+
+    test "creates an active agent workspace with no file context" do
+      state = source_workspace_state()
+      source_workspace = TabBar.get_workspace(state.shell_state.tab_bar, 0)
+
+      new_state = AgentCommands.new_agent_session(state)
+      tab_bar = new_state.shell_state.tab_bar
+      active_workspace = TabBar.active_workspace(tab_bar)
+
+      assert active_workspace.kind == :agent
+      assert active_workspace.files == []
+      assert active_workspace.active_file == nil
+      assert is_pid(active_workspace.session)
+      assert EditorState.active_tab_kind(new_state) == :agent
+      assert new_state.workspace.buffers.active == AgentAccess.agent(new_state).buffer
+      assert TabBar.get_workspace(tab_bar, 0) == source_workspace
+      assert TabBar.active(tab_bar).session == active_workspace.session
+    end
+
+    test "creating from an existing agent workspace preserves the source tab context" do
+      state = active_agent_workspace_state()
+      old_tab = TabBar.active(state.shell_state.tab_bar)
+      old_buffer = AgentAccess.agent(state).buffer
+      old_session = old_tab.session
+
+      new_state = AgentCommands.new_agent_session(state)
+      tab_bar = new_state.shell_state.tab_bar
+      updated_old_tab = TabBar.get(tab_bar, old_tab.id)
+      old_context = TabContext.to_workspace_map(updated_old_tab.context)
+      new_session = TabBar.active(tab_bar).session
+
+      assert old_context.buffers.active == old_buffer
+      assert old_session != nil
+      assert new_session != old_session
+      assert AgentAccess.agent(new_state).buffer != old_buffer
+      assert new_state.workspace.buffers.active == AgentAccess.agent(new_state).buffer
+    end
+
+    test "background agent session creation does not switch active workspace" do
+      state = source_workspace_with_background_agent_tab()
+      source_active_id = state.shell_state.tab_bar.active_id
+      source_workspace = TabBar.get_workspace(state.shell_state.tab_bar, 0)
+
+      new_state = AgentSession.start_agent_session(state)
+      tab_bar = new_state.shell_state.tab_bar
+      agent_workspaces = Enum.filter(tab_bar.workspaces, &(&1.kind == :agent))
+
+      assert tab_bar.active_id == source_active_id
+      assert TabBar.active_workspace_id(tab_bar) == 0
+      assert TabBar.get_workspace(tab_bar, 0) == source_workspace
+      assert [%{files: [], active_file: nil, session: session}] = agent_workspaces
+      assert is_pid(session)
     end
   end
 


### PR DESCRIPTION
## Summary
- Make user-initiated new agent workspace creation create and switch to a fresh agent tab/workspace
- Start the new workspace with no file membership and no active file
- Keep background agent session creation from changing the active workspace
- Rename the user-facing command text to "New agent workspace"

## Tests
- mix test.llm test/minga_editor/commands/agent_commands_test.exs test/minga_editor/state/tab_bar_test.exs
- make lint
- mix test.llm
- git diff --check

Fixes #1778