### PR TITLE
macOS shows workspaces above workspace file tabs

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		531166B714D49278BA811033 /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
 		5311F1060367B40B4077309F /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
 		53736DA2E4420D55D3D4E0A4 /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
+		545597C675EA0D630D24A4C8 /* WorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */; };
 		58D1135E113BF3A33EF7815F /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		59546703C9DBB4BA6E15DE28 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */; };
 		5BEEC2FD4D95EBA70FE036E7 /* BottomPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */; };
@@ -96,6 +97,7 @@
 		6E796E1FBD379D96E98C4DF7 /* EditorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9448826AA38AB5FC0CEB79 /* EditorSettingsView.swift */; };
 		6EE7C16703E92B31CC9CE9C0 /* NonBlockingEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3DDF1EB804D4E31EDFA519 /* NonBlockingEncoderTests.swift */; };
 		6F7F50CEC5067770E4865C2A /* CompletionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */; };
+		726E3D5BE1E9DA98E17C92B9 /* WorkspaceHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */; };
 		73955B38CEFC09D29EADAD85 /* FloatPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C47F406747CA6DD924A1AB /* FloatPopupOverlay.swift */; };
 		74D29226F82E6ADE18E2E108 /* MinibufferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2D3B0C9A042E9A5C485E1 /* MinibufferState.swift */; };
 		7680EFD077E0B916411123FA /* SymbolsNerdFontMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FD66FBCBFC20D50D22A969C8 /* SymbolsNerdFontMono-Regular.ttf */; };
@@ -118,6 +120,7 @@
 		8A0B62C670C71DB327CE1A29 /* RecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A6769D066EC44A58791CFC /* RecoveryManager.swift */; };
 		8AB3B55F301192FA4F4A4E41 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
 		8B944E100C80DFF282D25D4C /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */; };
+		8C9C3976E598C7F553B003B6 /* WorkspaceHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */; };
 		8CB3E1EEDEA109F6C0183597 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */; };
 		8D55764B8CF042B4C48AA5D0 /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
 		8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
@@ -138,6 +141,7 @@
 		A613934E53A1D3B8BAEB69FB /* SignatureHelpOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0070B497768FE68A63F5F114 /* SignatureHelpOverlay.swift */; };
 		A6327C6FAB3DCFD57327FBF4 /* DecoderRobustnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B35E8311966948B1BA7AEF /* DecoderRobustnessTests.swift */; };
 		A78FBA1CD5BB02EEBA8ACB45 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
+		A860586A88D34A562CAC0CBF /* WorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */; };
 		A9EE5F81AE818C176D03A6E3 /* RecoveryManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */; };
 		AA47831C0288E59E8B4DBEB5 /* KeybindingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50661EF3472E892F77AF9C2 /* KeybindingsSettingsView.swift */; };
 		AB200EDC2BD9693D8D52CE98 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
@@ -261,6 +265,7 @@
 		52F606681DE9AA9D502A42AA /* PickerOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerOverlay.swift; sourceTree = "<group>"; };
 		53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Instrumentation.swift; sourceTree = "<group>"; };
 		5458552EC58E44C7CD15A98A /* FileTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeView.swift; sourceTree = "<group>"; };
+		556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceHeaderView.swift; sourceTree = "<group>"; };
 		5634B25BE5BB945A83E30FAD /* StateLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateLifecycleTests.swift; sourceTree = "<group>"; };
 		56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolDecoder.swift; sourceTree = "<group>"; };
 		56B00002D020FED57D265C74 /* SystemColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemColorTests.swift; sourceTree = "<group>"; };
@@ -327,6 +332,7 @@
 		F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorsTests.swift; sourceTree = "<group>"; };
 		F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BEAMProcessManager.swift; sourceTree = "<group>"; };
 		F220A60775A252A728477659 /* ProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolTests.swift; sourceTree = "<group>"; };
+		F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceState.swift; sourceTree = "<group>"; };
 		F5647A59C841B3C408994CC7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMECompositionTests.swift; sourceTree = "<group>"; };
 		FD66FBCBFC20D50D22A969C8 /* SymbolsNerdFontMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SymbolsNerdFontMono-Regular.ttf"; sourceTree = "<group>"; };
@@ -484,7 +490,9 @@
 				ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */,
 				CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */,
 				70D5765529645C5D860576B7 /* WhichKeyState.swift */,
+				556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */,
 				73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */,
+				F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */,
 				8BF88DE53DE8F2D7ACD9276B /* Board */,
 				CA9FBB32D6FA803D937F1B97 /* Settings */,
 			);
@@ -860,7 +868,9 @@
 				5FDD7CBBCB910BDC63276AA7 /* WhichKeyState.swift in Sources */,
 				58D1135E113BF3A33EF7815F /* WindowContent.swift in Sources */,
 				4ADE54090FEEF5AA2A6C86A0 /* WindowContentRenderer.swift in Sources */,
+				8C9C3976E598C7F553B003B6 /* WorkspaceHeaderView.swift in Sources */,
 				A0351D1D024158F048BA1C25 /* WorkspaceIconPicker.swift in Sources */,
+				A860586A88D34A562CAC0CBF /* WorkspaceState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -980,7 +990,9 @@
 				AB804A6366BEFE62E30C929B /* WindowContentRenderer.swift in Sources */,
 				B12FA22E8F25CE3E5F55366F /* WindowContentRendererTests.swift in Sources */,
 				FEA7FDF0B8C5551790872FCA /* WindowContentTests.swift in Sources */,
+				726E3D5BE1E9DA98E17C92B9 /* WorkspaceHeaderView.swift in Sources */,
 				06D57AD02306EA08C458CC11 /* WorkspaceIconPicker.swift in Sources */,
+				545597C675EA0D630D24A4C8 /* WorkspaceState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -309,6 +309,11 @@ struct ContentView: View {
     /// Single toolbar row spanning the full window width. Contains the
     /// sidebar header (when visible) and the tab bar, sharing one background.
     private let contentHeight: CGFloat = 28
+    private let workspaceHeaderHeight: CGFloat = 30
+
+    private var toolbarContentHeight: CGFloat {
+        appState.gui.workspaceState.hasCanonicalPayload ? contentHeight + workspaceHeaderHeight : contentHeight
+    }
 
     private var toolbarTopPadding: CGFloat {
         max(appState.trafficLightMidY - contentHeight / 2, 0)
@@ -330,17 +335,28 @@ struct ContentView: View {
                     compactProjectBranchHeader
                 }
 
-                if !appState.gui.tabBarState.tabs.isEmpty {
-                    TabBarView(
-                        tabBarState: appState.gui.tabBarState,
-                        theme: theme,
-                        encoder: appState.encoder
-                    )
-                } else {
-                    Spacer()
+                VStack(spacing: 0) {
+                    if appState.gui.workspaceState.hasCanonicalPayload {
+                        WorkspaceHeaderView(
+                            workspaceState: appState.gui.workspaceState,
+                            theme: theme,
+                            encoder: appState.encoder
+                        )
+                    }
+
+                    if !appState.gui.tabBarState.tabs.isEmpty || !appState.gui.workspaceState.visibleTabs.isEmpty {
+                        TabBarView(
+                            tabBarState: appState.gui.tabBarState,
+                            theme: theme,
+                            encoder: appState.encoder
+                        )
+                        .accessibilityIdentifier("workspace-tabbar")
+                    } else {
+                        Spacer()
+                    }
                 }
             }
-            .frame(height: contentHeight)
+            .frame(height: toolbarContentHeight)
             .padding(.top, toolbarTopPadding)
             .frame(maxHeight: .infinity, alignment: .top)
 
@@ -348,7 +364,7 @@ struct ContentView: View {
                 .fill(theme.tabSeparatorFg.opacity(0.3))
                 .frame(height: 1)
         }
-        .frame(height: contentHeight + toolbarTopPadding + 4)
+        .frame(height: toolbarContentHeight + toolbarTopPadding + 4)
         .background {
             ZStack {
                 theme.tabBg

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -186,7 +186,8 @@ final class CommandDispatcher {
         case .guiTabBar(let activeIndex, let tabs):
             guiState.tabBarState.update(activeIndex: activeIndex, entries: tabs)
 
-        case .guiWorkspaces(_, let activeWorkspaceId, let mode, let flags, let workspaces, let visibleTabs):
+        case .guiWorkspaces(let version, let activeWorkspaceId, let mode, let flags, let workspaces, let visibleTabs):
+            guiState.workspaceState.update(version: version, activeWorkspaceId: activeWorkspaceId, mode: mode, flags: flags, workspaces: workspaces, visibleTabs: visibleTabs)
             guiState.tabBarState.updateWorkspaces(activeWorkspaceId: activeWorkspaceId, mode: mode, flags: flags, entries: workspaces, visibleTabs: visibleTabs)
 
         case .guiBoard(let visible, let focusedCardId, let cards, let filterMode, let filterText):

--- a/macos/Sources/Views/GUIState.swift
+++ b/macos/Sources/Views/GUIState.swift
@@ -18,6 +18,9 @@ final class GUIState {
     /// Tab bar state.
     let tabBarState = TabBarState()
 
+    /// Workspace header and active-workspace file tab state.
+    let workspaceState = WorkspaceState()
+
     /// File tree sidebar state.
     let fileTreeState = FileTreeState()
     let gitStatusState = GitStatusState()

--- a/macos/Sources/Views/TabBarState.swift
+++ b/macos/Sources/Views/TabBarState.swift
@@ -43,6 +43,9 @@ struct WorkspaceTabEntry: Identifiable {
     let icon: String
     let label: String
     let path: String
+
+    var isDirty: Bool { flags & 0x0001 != 0 }
+    var hasAttention: Bool { flags & 0x0002 != 0 }
 }
 
 /// Observable state for the tab bar, driven by BEAM protocol messages.
@@ -57,6 +60,7 @@ final class TabBarState {
     var activeWorkspaceId: UInt16 = 0
     var workspaceMode: UInt8 = 0
     var workspaceFlags: UInt8 = 0
+    var hasCanonicalWorkspaceTabs: Bool = false
 
     /// Whether any agent workspaces exist (controls visibility of group UI).
     var hasWorkspaces: Bool {
@@ -92,6 +96,7 @@ final class TabBarState {
         self.activeWorkspaceId = activeWorkspaceId
         self.workspaceMode = mode
         self.workspaceFlags = flags
+        self.hasCanonicalWorkspaceTabs = true
         self.workspaces = entries.map { entry in
             WorkspaceEntry(
                 id: entry.id,
@@ -135,5 +140,6 @@ final class TabBarState {
         activeWorkspaceId = 0
         workspaceMode = 0
         workspaceFlags = 0
+        hasCanonicalWorkspaceTabs = false
     }
 }

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -45,8 +45,8 @@ struct TabBarView: View {
             // Thin separator after nav arrows
             verticalSeparator
 
-            // Workspace indicator (visible when active tab is in a group)
-            if let activeWorkspace = tabBarState.activeWorkspace {
+            // Legacy workspace indicator, hidden when the canonical workspace header is active.
+            if !tabBarState.hasCanonicalWorkspaceTabs, let activeWorkspace = tabBarState.activeWorkspace {
                 workspaceIndicator(activeWorkspace)
                 groupSeparator(color: activeWorkspace.color)
             }
@@ -54,7 +54,7 @@ struct TabBarView: View {
             // Tab strip with collapsible groups
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 0) {
-                    if tabBarState.hasWorkspaces {
+                    if tabBarState.hasWorkspaces && !tabBarState.hasCanonicalWorkspaceTabs {
                         groupedTabStrip
                     } else {
                         flatTabStrip
@@ -137,15 +137,35 @@ struct TabBarView: View {
         )
     }
 
+    private var displayTabs: [TabEntry] {
+        if tabBarState.hasCanonicalWorkspaceTabs {
+            return tabBarState.workspaceTabs.enumerated().map { index, tab in
+                TabEntry(
+                    id: tab.id,
+                    groupId: tab.workspaceId,
+                    isActive: index == Int(tabBarState.activeIndex),
+                    isDirty: tab.isDirty,
+                    isAgent: false,
+                    hasAttention: tab.hasAttention,
+                    agentStatus: 0,
+                    icon: tab.icon,
+                    label: tab.label
+                )
+            }
+        }
+
+        return tabBarState.tabs
+    }
+
     // MARK: - Tab strip layouts
 
     /// Flat tab strip (no workspaces active, Tier 0).
     @ViewBuilder
     private var flatTabStrip: some View {
-        ForEach(tabBarState.tabs) { tab in
+        ForEach(displayTabs) { tab in
             tabItem(tab)
 
-            if tab.id != tabBarState.tabs.last?.id {
+            if tab.id != displayTabs.last?.id {
                 verticalSeparator
             }
         }
@@ -448,6 +468,9 @@ struct TabBarView: View {
                 hoverTabId = hovering ? tab.id : nil
             }
         }
+        .accessibilityIdentifier("workspace-file-tab-\(tab.id)")
+        .accessibilityLabel("File tab \(tab.label)")
+        .accessibilityValue(tab.isDirty ? "modified" : "clean")
         .contextMenu {
             Button("Close") {
                 encoder?.sendCloseTab(id: tab.id)
@@ -473,7 +496,7 @@ struct TabBarView: View {
     /// Group 0 (manual) always comes first; agent workspaces sorted by id.
     /// Within each group, tab order is preserved from the BEAM's tab list.
     private func groupedTabs() -> [TabGroup] {
-        Dictionary(grouping: tabBarState.tabs, by: \.groupId)
+        Dictionary(grouping: displayTabs, by: \.groupId)
             .sorted { $0.key < $1.key }
             .map { TabGroup(groupId: $0.key, tabs: $0.value) }
     }

--- a/macos/Sources/Views/WorkspaceHeaderView.swift
+++ b/macos/Sources/Views/WorkspaceHeaderView.swift
@@ -1,0 +1,246 @@
+import SwiftUI
+
+/// Workspace header row rendered above active-workspace file tabs.
+struct WorkspaceHeaderView: View {
+    let workspaceState: WorkspaceState
+    let theme: ThemeColors
+    let encoder: InputEncoder?
+
+    @State private var isRenaming = false
+    @State private var renameText = ""
+    @State private var showIconPicker = false
+    @FocusState private var renameFieldFocused: Bool
+
+    private let rowHeight: CGFloat = 30
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if let activeWorkspace = workspaceState.activeWorkspace {
+                activeWorkspacePill(activeWorkspace)
+
+                workspaceSwitcher
+
+                if activeWorkspace.isAgent {
+                    agentStatusButton(activeWorkspace)
+                }
+
+                badges(for: activeWorkspace)
+
+                Spacer(minLength: 8)
+
+                if activeWorkspace.isCloseable {
+                    closeButton(activeWorkspace)
+                }
+            } else {
+                Text("Workspace")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(theme.tabInactiveFg)
+                Spacer(minLength: 8)
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: rowHeight)
+        .background(theme.tabBg)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.tabSeparatorFg.opacity(0.25))
+                .frame(height: 1)
+        }
+        .accessibilityIdentifier("workspace-header")
+    }
+
+    private func activeWorkspacePill(_ workspace: WorkspaceSummaryEntry) -> some View {
+        let pillBackground = Capsule().fill(workspace.color.opacity(0.18))
+        let pillBorder = Capsule().stroke(workspace.color.opacity(0.55), lineWidth: 1)
+
+        return HStack(spacing: 6) {
+            workspaceIcon(workspace)
+            workspaceTitle(workspace)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(pillBackground)
+        .overlay(pillBorder)
+        .accessibilityIdentifier("workspace-pill-\(workspace.id)")
+        .accessibilityLabel("Workspace \(workspace.label)")
+        .accessibilityValue(workspaceValue(workspace))
+        .contextMenu {
+            Button("Rename Workspace…") { beginRename(workspace) }
+            Button("Change Icon…") { showIconPicker = true }
+        }
+        .onTapGesture(count: 2) { beginRename(workspace) }
+        .popover(isPresented: $showIconPicker, arrowEdge: .bottom) {
+            WorkspaceIconPicker(currentIcon: workspace.icon, accentColor: workspace.color, theme: theme) { selectedIcon in
+                encoder?.sendWorkspaceSetIcon(id: workspace.id, icon: selectedIcon)
+                showIconPicker = false
+            }
+            .frame(width: 320, height: 260)
+        }
+    }
+
+    @ViewBuilder
+    private func workspaceTitle(_ workspace: WorkspaceSummaryEntry) -> some View {
+        if isRenaming {
+            TextField("Workspace name", text: $renameText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, weight: .semibold))
+                .frame(minWidth: 90, maxWidth: 180)
+                .focused($renameFieldFocused)
+                .onSubmit { commitRename(workspace) }
+                .onExitCommand { isRenaming = false }
+                .onChange(of: renameFieldFocused) { _, focused in
+                    if !focused { commitRename(workspace) }
+                }
+        } else {
+            Text(workspace.label)
+                .font(.system(size: 12, weight: .semibold))
+                .lineLimit(1)
+                .foregroundStyle(theme.tabActiveFg)
+        }
+    }
+
+    private var workspaceSwitcher: some View {
+        Menu {
+            ForEach(workspaceState.workspaces) { workspace in
+                Button {
+                    encoder?.sendExecuteCommand(name: workspaceState.switchCommand(for: workspace))
+                } label: {
+                    Label(workspace.label, systemImage: workspaceSystemImage(workspace))
+                }
+                .accessibilityIdentifier("workspace-row-\(workspace.id)")
+            }
+        } label: {
+            Image(systemName: "rectangle.grid.1x2")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(theme.tabInactiveFg)
+                .frame(width: 24, height: rowHeight)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .accessibilityIdentifier("workspace-switcher")
+        .accessibilityLabel("Workspace switcher")
+        .help("Switch workspace")
+    }
+
+    private func agentStatusButton(_ workspace: WorkspaceSummaryEntry) -> some View {
+        Button {
+            encoder?.sendExecuteCommand(name: "toggle_agentic_view")
+        } label: {
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(agentStatusColor(workspace.agentStatus, accent: workspace.color))
+                    .frame(width: 7, height: 7)
+                Text(agentStatusLabel(workspace.agentStatus))
+                    .font(.system(size: 11))
+            }
+            .foregroundStyle(theme.tabInactiveFg)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("workspace-agent-button")
+        .accessibilityLabel("Agent status")
+        .accessibilityValue(agentStatusLabel(workspace.agentStatus))
+        .help(agentStatusHelp(workspace.agentStatus))
+    }
+
+    @ViewBuilder
+    private func badges(for workspace: WorkspaceSummaryEntry) -> some View {
+        HStack(spacing: 5) {
+            if workspace.runningBackgroundCount > 0 {
+                badge("⚡\(workspace.runningBackgroundCount)", help: "Agent running in this workspace")
+            }
+            if workspace.draftCount > 0 {
+                badge("✓\(workspace.draftCount)", help: "Workspace drafts need review")
+            }
+            if workspace.conflictCount > 0 {
+                badge("⚠︎\(workspace.conflictCount)", help: "Workspace conflicts need resolution", color: .orange)
+            }
+            if workspace.hasAttention {
+                badge("!", help: "Workspace needs attention", color: .red)
+            }
+        }
+        .accessibilityLabel("Workspace badges")
+    }
+
+    private func closeButton(_ workspace: WorkspaceSummaryEntry) -> some View {
+        Button {
+            encoder?.sendWorkspaceClose(id: workspace.id)
+        } label: {
+            Image(systemName: "xmark.circle")
+                .font(.system(size: 13))
+                .foregroundStyle(theme.tabInactiveFg)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Close workspace \(workspace.label)")
+        .help("Close workspace")
+    }
+
+    private func badge(_ text: String, help: String, color: Color? = nil) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .semibold))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill((color ?? theme.tabInactiveFg).opacity(0.18)))
+            .foregroundStyle(color ?? theme.tabInactiveFg)
+            .help(help)
+            .accessibilityLabel(help)
+    }
+
+    @ViewBuilder
+    private func workspaceIcon(_ workspace: WorkspaceSummaryEntry) -> some View {
+        if workspace.isManual {
+            Image(systemName: "folder")
+                .font(.system(size: 12))
+                .foregroundStyle(workspace.color)
+        } else {
+            Image(systemName: workspace.icon.isEmpty ? "cpu" : workspace.icon)
+                .font(.system(size: 12))
+                .foregroundStyle(workspace.color)
+        }
+    }
+
+    private func workspaceSystemImage(_ workspace: WorkspaceSummaryEntry) -> String {
+        workspace.isManual ? "folder" : (workspace.icon.isEmpty ? "cpu" : workspace.icon)
+    }
+
+    private func beginRename(_ workspace: WorkspaceSummaryEntry) {
+        renameText = workspace.label
+        isRenaming = true
+        DispatchQueue.main.async { renameFieldFocused = true }
+    }
+
+    private func commitRename(_ workspace: WorkspaceSummaryEntry) {
+        guard isRenaming else { return }
+        isRenaming = false
+        let trimmed = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != workspace.label else { return }
+        encoder?.sendWorkspaceRename(id: workspace.id, name: trimmed)
+    }
+
+    private func workspaceValue(_ workspace: WorkspaceSummaryEntry) -> String {
+        [workspace.isManual ? "manual" : "agent", agentStatusLabel(workspace.agentStatus)]
+            .joined(separator: ", ")
+    }
+
+    private func agentStatusLabel(_ status: UInt8) -> String {
+        switch status {
+        case 1: return "Thinking"
+        case 2: return "Using tools"
+        case 3: return "Error"
+        case 4: return "Planning"
+        default: return "Idle"
+        }
+    }
+
+    private func agentStatusHelp(_ status: UInt8) -> String {
+        "Agent status: \(agentStatusLabel(status))"
+    }
+
+    private func agentStatusColor(_ status: UInt8, accent: Color) -> Color {
+        switch status {
+        case 1, 2: return accent
+        case 3: return .red
+        case 4: return theme.agentStatusNeedsYou
+        default: return theme.tabInactiveFg
+        }
+    }
+}

--- a/macos/Sources/Views/WorkspaceHeaderView.swift
+++ b/macos/Sources/Views/WorkspaceHeaderView.swift
@@ -25,6 +25,7 @@ struct WorkspaceHeaderView: View {
                 }
 
                 badges(for: activeWorkspace)
+                backgroundBadges
 
                 Spacer(minLength: 8)
 
@@ -159,6 +160,28 @@ struct WorkspaceHeaderView: View {
             }
         }
         .accessibilityLabel("Workspace badges")
+    }
+
+    @ViewBuilder
+    private var backgroundBadges: some View {
+        HStack(spacing: 5) {
+            if workspaceState.backgroundRunningCount > 0 {
+                badge("bg ⚡\(workspaceState.backgroundRunningCount)", help: "Background workspace agents are running")
+            }
+            if workspaceState.backgroundDraftCount > 0 {
+                badge("bg ✓\(workspaceState.backgroundDraftCount)", help: "Background workspace drafts need review")
+            }
+            if workspaceState.backgroundConflictCount > 0 {
+                badge("bg ⚠︎\(workspaceState.backgroundConflictCount)", help: "Background workspace conflicts need resolution", color: .orange)
+            }
+            if workspaceState.backgroundAttentionCount > 0 {
+                badge("bg !\(workspaceState.backgroundAttentionCount)", help: "Background workspaces need attention", color: .red)
+            }
+            if workspaceState.backgroundErrorCount > 0 {
+                badge("bg ✕\(workspaceState.backgroundErrorCount)", help: "Background workspace agents have errors", color: .red)
+            }
+        }
+        .accessibilityLabel("Background workspace badges")
     }
 
     private func closeButton(_ workspace: WorkspaceSummaryEntry) -> some View {

--- a/macos/Sources/Views/WorkspaceState.swift
+++ b/macos/Sources/Views/WorkspaceState.swift
@@ -57,6 +57,30 @@ final class WorkspaceState {
         flags & 0x01 != 0 || workspaces.contains(where: { $0.hasAttention })
     }
 
+    var backgroundWorkspaces: [WorkspaceSummaryEntry] {
+        workspaces.filter { $0.id != activeWorkspaceId }
+    }
+
+    var backgroundRunningCount: Int {
+        backgroundWorkspaces.reduce(0) { $0 + Int($1.runningBackgroundCount) }
+    }
+
+    var backgroundDraftCount: Int {
+        backgroundWorkspaces.reduce(0) { $0 + Int($1.draftCount) }
+    }
+
+    var backgroundConflictCount: Int {
+        backgroundWorkspaces.reduce(0) { $0 + Int($1.conflictCount) }
+    }
+
+    var backgroundAttentionCount: Int {
+        backgroundWorkspaces.filter { $0.hasAttention }.count
+    }
+
+    var backgroundErrorCount: Int {
+        backgroundWorkspaces.filter { $0.agentStatus == 3 }.count
+    }
+
     func update(version: UInt8, activeWorkspaceId: UInt16, mode: UInt8, flags: UInt8, workspaces: [Wire.WorkspaceEntry], visibleTabs: [Wire.WorkspaceTabEntry]) {
         self.activeWorkspaceId = activeWorkspaceId
         self.viewMode = mode

--- a/macos/Sources/Views/WorkspaceState.swift
+++ b/macos/Sources/Views/WorkspaceState.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+/// A workspace summary for native workspace chrome.
+struct WorkspaceSummaryEntry: Identifiable {
+    let id: UInt16
+    let kind: UInt8
+    let agentStatus: UInt8
+    let flags: UInt16
+    let color: Color
+    let tabCount: UInt16
+    let draftCount: UInt16
+    let conflictCount: UInt16
+    let runningBackgroundCount: UInt16
+    let label: String
+    let icon: String
+
+    var isManual: Bool { kind == 0 }
+    var isAgent: Bool { kind == 1 }
+    var hasAttention: Bool { flags & 0x0001 != 0 }
+    var isCloseable: Bool { flags & 0x0002 != 0 }
+}
+
+/// A visible file tab for the active workspace.
+struct WorkspaceFileTabEntry: Identifiable {
+    let id: UInt32
+    let workspaceId: UInt16
+    let kind: UInt8
+    let flags: UInt16
+    let pathHash: UInt32
+    let icon: String
+    let label: String
+    let path: String
+
+    var isDirty: Bool { flags & 0x0001 != 0 }
+    var hasAttention: Bool { flags & 0x0002 != 0 }
+    var isDraft: Bool { flags & 0x0004 != 0 }
+    var isDraftElsewhere: Bool { flags & 0x0008 != 0 }
+    var hasConflict: Bool { flags & 0x0010 != 0 }
+}
+
+/// Observable state for the workspace header and active-workspace file tabs.
+@MainActor
+@Observable
+final class WorkspaceState {
+    var workspaces: [WorkspaceSummaryEntry] = []
+    var visibleTabs: [WorkspaceFileTabEntry] = []
+    var activeWorkspaceId: UInt16 = 0
+    var viewMode: UInt8 = 0
+    var flags: UInt8 = 0
+    var hasCanonicalPayload: Bool = false
+
+    var activeWorkspace: WorkspaceSummaryEntry? {
+        workspaces.first { $0.id == activeWorkspaceId }
+    }
+
+    var hasAttention: Bool {
+        flags & 0x01 != 0 || workspaces.contains(where: { $0.hasAttention })
+    }
+
+    func update(version: UInt8, activeWorkspaceId: UInt16, mode: UInt8, flags: UInt8, workspaces: [Wire.WorkspaceEntry], visibleTabs: [Wire.WorkspaceTabEntry]) {
+        self.activeWorkspaceId = activeWorkspaceId
+        self.viewMode = mode
+        self.flags = flags
+        self.hasCanonicalPayload = version > 0
+        self.workspaces = workspaces.map { entry in
+            WorkspaceSummaryEntry(
+                id: entry.id,
+                kind: entry.kind,
+                agentStatus: entry.agentStatus,
+                flags: entry.flags,
+                color: Color(
+                    .sRGB,
+                    red: Double(entry.colorR) / 255.0,
+                    green: Double(entry.colorG) / 255.0,
+                    blue: Double(entry.colorB) / 255.0
+                ),
+                tabCount: entry.tabCount,
+                draftCount: entry.draftCount,
+                conflictCount: entry.conflictCount,
+                runningBackgroundCount: entry.runningBackgroundCount,
+                label: entry.label,
+                icon: entry.icon
+            )
+        }
+        self.visibleTabs = visibleTabs.map { entry in
+            WorkspaceFileTabEntry(
+                id: entry.id,
+                workspaceId: entry.workspaceId,
+                kind: entry.kind,
+                flags: entry.flags,
+                pathHash: entry.pathHash,
+                icon: entry.icon,
+                label: entry.label,
+                path: entry.path
+            )
+        }
+    }
+
+    func switchCommand(for workspace: WorkspaceSummaryEntry) -> String {
+        if workspace.isManual { return "manual_workspace" }
+
+        let agentWorkspaces = workspaces.filter { $0.isAgent }
+        guard let idx = agentWorkspaces.firstIndex(where: { $0.id == workspace.id }), idx < 9 else {
+            return "workspace_next_agent"
+        }
+        return "workspace_goto_\(idx + 1)"
+    }
+
+    func hide() {
+        workspaces = []
+        visibleTabs = []
+        activeWorkspaceId = 0
+        viewMode = 0
+        flags = 0
+        hasCanonicalPayload = false
+    }
+}

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -624,64 +624,75 @@ struct TabBarViewViewTests {
         #expect(strings.contains("test.ex"))
     }
 
-    @Test("Tab bar shows inactive agent capsules when visible tabs only cover the active workspace")
-    @MainActor func showsInactiveAgentCapsules() throws {
+    @Test("Tab bar uses canonical active-workspace visible tabs")
+    @MainActor func usesCanonicalVisibleTabs() throws {
         let state = TabBarState()
-        state.update(activeIndex: 255, entries: [
-            Wire.TabEntry(id: 1, groupId: 1, isActive: false, isDirty: false, isAgent: false,
-                       hasAttention: false, agentStatus: 0, icon: "", label: "active.ex")
+        state.update(activeIndex: 0, entries: [
+            Wire.TabEntry(id: 1, groupId: 1, isActive: true, isDirty: false, isAgent: false,
+                       hasAttention: false, agentStatus: 0, icon: "", label: "legacy-agent-chat"),
+            Wire.TabEntry(id: 2, groupId: 2, isActive: false, isDirty: false, isAgent: false,
+                       hasAttention: false, agentStatus: 0, icon: "", label: "background.ex")
         ])
         state.updateWorkspaces(activeWorkspaceId: 1, mode: 1, flags: 0, entries: [
-            Wire.WorkspaceEntry(id: 0, kind: 0, status: 0, flags: 0, colorR: 0x11, colorG: 0x22, colorB: 0x33,
-                                tabCount: 1, draftCount: 0, conflictCount: 0, runningBackgroundCount: 0, label: "minga", icon: "folder"),
             Wire.WorkspaceEntry(id: 1, kind: 1, status: 0, flags: 0, colorR: 0x11, colorG: 0x22, colorB: 0x33,
                                 tabCount: 1, draftCount: 0, conflictCount: 0, runningBackgroundCount: 0, label: "Active", icon: "cpu"),
             Wire.WorkspaceEntry(id: 2, kind: 1, status: 1, flags: 0, colorR: 0x44, colorG: 0x55, colorB: 0x66,
                                 tabCount: 3, draftCount: 0, conflictCount: 0, runningBackgroundCount: 1, label: "Research", icon: "cpu")
-        ], visibleTabs: [])
+        ], visibleTabs: [
+            Wire.WorkspaceTabEntry(id: 42, workspaceId: 1, kind: 0, flags: 0, pathHash: 0, icon: "", label: "active.ex", path: "/tmp/active.ex")
+        ])
 
         let sut = TabBarView(tabBarState: state, theme: ThemeColors(), encoder: nil)
-        let body = try sut.inspect()
-        let texts = body.findAll(ViewInspectorQuery.text)
-        let strings = texts.compactMap { try? $0.string() }
+        let strings = try sut.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
 
         #expect(strings.contains("active.ex"))
-        #expect(strings.contains("Research"))
+        #expect(!strings.contains("legacy-agent-chat"))
+        #expect(!strings.contains("background.ex"))
+        #expect(!strings.contains("Research"))
     }
+}
 
-    @Test("Second inactive agent capsule emits workspace goto command")
-    @MainActor func secondInactiveAgentCapsuleEmitsWorkspaceGotoCommand() throws {
-        let state = TabBarState()
-        state.update(activeIndex: 255, entries: [
-            Wire.TabEntry(id: 42, groupId: 1, isActive: false, isDirty: false, isAgent: false,
-                       hasAttention: false, agentStatus: 0, icon: "", label: "main.ex")
-        ])
-        state.updateWorkspaces(activeWorkspaceId: 1, mode: 1, flags: 0, entries: [
+// MARK: - WorkspaceHeaderView
+
+@Suite("WorkspaceHeaderView View Structure")
+struct WorkspaceHeaderViewTests {
+
+    @MainActor private func populatedState() -> WorkspaceState {
+        let state = WorkspaceState()
+        state.update(version: 1, activeWorkspaceId: 2, mode: 1, flags: 1, workspaces: [
             Wire.WorkspaceEntry(id: 0, kind: 0, status: 0, flags: 0, colorR: 0x11, colorG: 0x22, colorB: 0x33,
                                 tabCount: 1, draftCount: 0, conflictCount: 0, runningBackgroundCount: 0, label: "minga", icon: "folder"),
             Wire.WorkspaceEntry(id: 1, kind: 1, status: 0, flags: 0, colorR: 0x11, colorG: 0x22, colorB: 0x33,
-                                tabCount: 1, draftCount: 0, conflictCount: 0, runningBackgroundCount: 0, label: "Active", icon: "cpu"),
-            Wire.WorkspaceEntry(id: 2, kind: 1, status: 1, flags: 0, colorR: 0x44, colorG: 0x55, colorB: 0x66,
-                                tabCount: 2, draftCount: 0, conflictCount: 0, runningBackgroundCount: 1, label: "Research", icon: "cpu"),
-            Wire.WorkspaceEntry(id: 3, kind: 1, status: 2, flags: 0, colorR: 0x77, colorG: 0x88, colorB: 0x99,
-                                tabCount: 3, draftCount: 0, conflictCount: 0, runningBackgroundCount: 1, label: "Review", icon: "cpu")
-        ], visibleTabs: [])
+                                tabCount: 1, draftCount: 0, conflictCount: 0, runningBackgroundCount: 0, label: "Research", icon: "cpu"),
+            Wire.WorkspaceEntry(id: 2, kind: 1, status: 2, flags: 0x0003, colorR: 0x44, colorG: 0x55, colorB: 0x66,
+                                tabCount: 2, draftCount: 1, conflictCount: 1, runningBackgroundCount: 1, label: "Review", icon: "cpu")
+        ], visibleTabs: [
+            Wire.WorkspaceTabEntry(id: 42, workspaceId: 2, kind: 0, flags: 0, pathHash: 0, icon: "", label: "active.ex", path: "/tmp/active.ex")
+        ])
+        return state
+    }
 
-        let spy = SpyEncoder()
-        let sut = TabBarView(tabBarState: state, theme: ThemeColors(), encoder: spy)
-        let buttons = try sut.inspect().findAll(ViewType.Button.self)
+    @Test("Header shows active workspace metadata and badges")
+    @MainActor func showsActiveWorkspaceMetadataAndBadges() throws {
+        let sut = WorkspaceHeaderView(workspaceState: populatedState(), theme: ThemeColors(), encoder: nil)
+        let strings = try sut.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
 
-        var tapped = false
-        for button in buttons {
-            if (try? button.accessibilityLabel().string()) == "Switch to workspace Review" {
-                try button.tap()
-                tapped = true
-                break
-            }
-        }
+        #expect(strings.contains("Review"))
+        #expect(strings.contains("Using tools"))
+        #expect(strings.contains("⚡1"))
+        #expect(strings.contains("✓1"))
+        #expect(strings.contains("⚠︎1"))
+        #expect(strings.contains("!"))
+    }
 
-        #expect(tapped)
-        #expect(spy.guiActions == [.executeCommand(name: "workspace_goto_3")])
+    @Test("Switcher uses manual workspace and agent ordinals")
+    @MainActor func switcherUsesManualAndAgentOrdinals() throws {
+        let state = populatedState()
+        let manualWorkspace = try #require(state.workspaces.first { $0.isManual })
+        let reviewWorkspace = try #require(state.workspaces.first { $0.label == "Review" })
+
+        #expect(state.switchCommand(for: manualWorkspace) == "manual_workspace")
+        #expect(state.switchCommand(for: reviewWorkspace) == "workspace_goto_2")
     }
 }
 

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -685,6 +685,27 @@ struct WorkspaceHeaderViewTests {
         #expect(strings.contains("!"))
     }
 
+    @Test("Header exposes background workspace badges without activating them")
+    @MainActor func showsBackgroundWorkspaceBadges() throws {
+        let state = WorkspaceState()
+        state.update(version: 1, activeWorkspaceId: 0, mode: 0, flags: 0, workspaces: [
+            Wire.WorkspaceEntry(id: 0, kind: 0, status: 0, flags: 0, colorR: 0x11, colorG: 0x22, colorB: 0x33,
+                                tabCount: 1, draftCount: 0, conflictCount: 0, runningBackgroundCount: 0, label: "minga", icon: "folder"),
+            Wire.WorkspaceEntry(id: 1, kind: 1, status: 3, flags: 0x0001, colorR: 0x44, colorG: 0x55, colorB: 0x66,
+                                tabCount: 2, draftCount: 1, conflictCount: 1, runningBackgroundCount: 1, label: "Background", icon: "cpu")
+        ], visibleTabs: [])
+
+        let sut = WorkspaceHeaderView(workspaceState: state, theme: ThemeColors(), encoder: nil)
+        let strings = try sut.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("minga"))
+        #expect(strings.contains("bg ⚡1"))
+        #expect(strings.contains("bg ✓1"))
+        #expect(strings.contains("bg ⚠︎1"))
+        #expect(strings.contains("bg !1"))
+        #expect(strings.contains("bg ✕1"))
+    }
+
     @Test("Switcher uses manual workspace and agent ordinals")
     @MainActor func switcherUsesManualAndAgentOrdinals() throws {
         let state = populatedState()


### PR DESCRIPTION
# TL;DR
macOS now has a dedicated workspace header above the file tab row, so the active workspace is the parent context and file tabs stay scoped to that workspace. This keeps background agent work visible through badges without turning agent chat or background files into active file tabs.

Closes #1780

## Context
This is part of #1772 and is stacked on #1816, which adds the canonical `gui_workspaces` protocol payload. #1780 uses that protocol in the macOS frontend to replace the overloaded grouped tab strip with a clearer workspace-first hierarchy.

## Changes
- Added `WorkspaceState` as the protocol-driven Swift state owner for workspace summaries, active workspace id, view mode, and active-workspace visible tabs.
- Added `WorkspaceHeaderView` with the active workspace pill, workspace switcher, agent status button, badges, close action, rename, icon picker, accessibility labels, and stable identifiers.
- Updated the main macOS toolbar layout to render the workspace header above the existing file tab bar when canonical workspace data is present.
- Updated `TabBarView` to use `gui_workspaces.visibleTabs` for file tabs after the canonical payload arrives, with `gui_tab_bar` preserved as a legacy fallback.
- Added Swift view tests for canonical active-workspace tab filtering, workspace header metadata, badge rendering, and workspace switch command mapping.

## Verification
- `make lint`
- `mix test.llm test/minga_editor/watchdog_test.exs:15`
- `mix test.llm`
- `mix test --failed`
- `mix swift.harness`
- `mix swift.build`
- `cd macos && xcodebuild test -scheme Minga -destination 'platform=macOS' -quiet`
- `git diff --check`
- Final reviewer targeted re-review: PASS

## Acceptance Criteria Addressed
- macOS shows a workspace header above the file tab bar. ✅
- The header shows the active workspace pill, workspace switcher, agent status button, attention badge, and close workspace button when closeable. ✅
- The file tab bar below the header shows only active-workspace file tabs from `gui_workspaces`. ✅
- Agent chat is not rendered as a file tab in AgentWorkspace mode. ✅
- The non-agent workspace renders with the label provided by `gui_workspaces` and a folder icon, with no close button. ✅
- Agent, draft, conflict, attention, running, error, and tool states render with distinct visual cues and text/tooltips. ✅
- Background workspace updates change badges only and do not move focus, selected workspace, selected tab, or scroll position. ✅
- Workspace header and file tabs include accessibility labels, values, actions, and stable identifiers. ✅
