### PR TITLE
feat(agent): move lifecycle state to workspaces

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -50,6 +50,7 @@ defmodule MingaEditor do
   alias MingaEditor.State.Remote
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
   alias MingaEditor.Viewport
 
   alias MingaEditor.Handlers.FileEventHandler
@@ -1332,8 +1333,17 @@ defmodule MingaEditor do
 
   @spec restore_ended_remote_tab(EditorState.t(), Tab.t(), [term()]) :: EditorState.t()
   defp restore_ended_remote_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, tab, messages) do
-    tb = TabBar.update_tab(tb, tab.id, &Tab.set_connection_status(&1, :ended))
-    state = EditorState.set_tab_bar(state, tb)
+    tb =
+      TabBar.update_tab(tb, tab.id, fn remote_tab ->
+        remote_tab
+        |> Tab.set_session(nil)
+        |> Tab.set_connection_status(:ended)
+      end)
+
+    state =
+      state
+      |> EditorState.set_tab_bar(tb)
+      |> clear_remote_workspace_session(tab)
 
     if tb.active_id == tab.id do
       case AgentAccess.agent(state).buffer do
@@ -1362,7 +1372,10 @@ defmodule MingaEditor do
         |> Tab.set_connection_status(:connected)
       end)
 
-    state = EditorState.set_tab_bar(state, tb)
+    state =
+      state
+      |> EditorState.set_tab_bar(tb)
+      |> sync_remote_workspace_session(tab, pid)
 
     if tb.active_id == tab.id do
       state
@@ -1391,13 +1404,78 @@ defmodule MingaEditor do
   @spec mark_remote_tab_status(EditorState.t(), Tab.t(), Tab.connection_status()) ::
           EditorState.t()
   defp mark_remote_tab_status(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, tab, status) do
-    EditorState.set_tab_bar(
-      state,
-      TabBar.update_tab(tb, tab.id, &Tab.set_connection_status(&1, status))
-    )
+    tb = TabBar.update_tab(tb, tab.id, &mark_remote_tab(&1, status))
+
+    state
+    |> EditorState.set_tab_bar(tb)
+    |> maybe_clear_remote_workspace_session(tab, status)
   end
 
   defp mark_remote_tab_status(state, _tab, _status), do: state
+
+  @spec mark_remote_tab(Tab.t(), Tab.connection_status()) :: Tab.t()
+  defp mark_remote_tab(%Tab{} = tab, status) when status in [:ended, :unavailable] do
+    tab
+    |> Tab.set_session(nil)
+    |> Tab.set_connection_status(status)
+  end
+
+  defp mark_remote_tab(%Tab{} = tab, status), do: Tab.set_connection_status(tab, status)
+
+  @spec sync_remote_workspace_session(EditorState.t(), Tab.t(), pid()) :: EditorState.t()
+  defp sync_remote_workspace_session(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %Tab{group_id: workspace_id},
+         pid
+       )
+       when is_pid(pid) do
+    case TabBar.get_workspace(tb, workspace_id) do
+      %Workspace{kind: :agent} ->
+        EditorState.set_tab_bar(
+          state,
+          TabBar.update_workspace(tb, workspace_id, &Workspace.set_session(&1, pid))
+        )
+
+      _workspace ->
+        state
+    end
+  end
+
+  defp sync_remote_workspace_session(state, _tab, _pid), do: state
+
+  @spec maybe_clear_remote_workspace_session(EditorState.t(), Tab.t(), Tab.connection_status()) ::
+          EditorState.t()
+  defp maybe_clear_remote_workspace_session(state, tab, status)
+       when status in [:ended, :unavailable] do
+    clear_remote_workspace_session(state, tab)
+  end
+
+  defp maybe_clear_remote_workspace_session(state, _tab, _status), do: state
+
+  @spec clear_remote_workspace_session(EditorState.t(), Tab.t()) :: EditorState.t()
+  defp clear_remote_workspace_session(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %Tab{group_id: workspace_id, session: stale_session}
+       ) do
+    case TabBar.get_workspace(tb, workspace_id) do
+      %Workspace{kind: :agent, session: ^stale_session} when is_pid(stale_session) ->
+        EditorState.set_tab_bar(
+          state,
+          TabBar.update_workspace(tb, workspace_id, &Workspace.clear_session/1)
+        )
+
+      %Workspace{kind: :agent, session: nil} ->
+        EditorState.set_tab_bar(
+          state,
+          TabBar.update_workspace(tb, workspace_id, &Workspace.clear_session/1)
+        )
+
+      _workspace ->
+        state
+    end
+  end
+
+  defp clear_remote_workspace_session(state, _tab), do: state
 
   @spec active_remote_server?(EditorState.t(), String.t()) :: boolean()
   defp active_remote_server?(state, server_name) do
@@ -2586,7 +2664,10 @@ defmodule MingaEditor do
     {shell_state, workspace} =
       state.shell.handle_gui_action(state.shell_state, state.workspace, action)
 
-    %{state | shell_state: shell_state, workspace: workspace}
+    state
+    |> EditorState.update_shell_state(fn _shell_state -> shell_state end)
+    |> EditorState.update_workspace(fn _workspace -> workspace end)
+    |> EditorState.sync_agent_ui_from_active_workspace()
   end
 
   defp handle_gui_action(state, {:workspace_rename, _ws_id, _name} = action) do

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -51,6 +51,7 @@ defmodule MingaEditor do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace
+  alias MingaEditor.State.Workspace.RemoteSession
   alias MingaEditor.Viewport
 
   alias MingaEditor.Handlers.FileEventHandler
@@ -1281,31 +1282,34 @@ defmodule MingaEditor do
          server_name,
          remote_node
        ) do
-    Enum.reduce(tb.tabs, state, fn
-      %Tab{server_name: ^server_name, remote_session_id: session_id} = tab, acc
-      when is_binary(session_id) ->
-        reconnect_remote_tab(acc, tab, remote_node, session_id)
+    workspaces = TabBar.remote_workspaces_for_server(tb, server_name)
 
-      _tab, acc ->
-        acc
+    Enum.reduce(workspaces, state, fn workspace, acc ->
+      reconnect_remote_workspace(acc, workspace, remote_node)
     end)
   end
 
   defp reconnect_remote_tabs(state, _server_name, _remote_node), do: state
 
-  @spec reconnect_remote_tab(EditorState.t(), Tab.t(), node(), String.t()) :: EditorState.t()
-  defp reconnect_remote_tab(state, tab, remote_node, session_id) do
+  @spec reconnect_remote_workspace(EditorState.t(), Workspace.t(), node()) :: EditorState.t()
+  defp reconnect_remote_workspace(
+         state,
+         %Workspace{remote_session: %RemoteSession{session_id: session_id}} = workspace,
+         remote_node
+       ) do
     case remote_session_pid(remote_node, session_id) do
       {:ok, pid} ->
-        restore_remote_tab(state, tab, pid)
+        restore_remote_workspace(state, workspace, pid)
 
       {:error, :not_found} ->
-        restore_remote_session_from_store(state, tab, remote_node, session_id)
+        restore_remote_session_from_store(state, workspace, remote_node, session_id)
 
       {:error, _reason} ->
-        mark_remote_tab_status(state, tab, :disconnected)
+        mark_remote_workspace_status(state, workspace, :disconnected)
     end
   end
+
+  defp reconnect_remote_workspace(state, %Workspace{}, _remote_node), do: state
 
   @spec remote_session_pid(node(), String.t()) :: {:ok, pid()} | {:error, term()}
   defp remote_session_pid(remote_node, session_id) do
@@ -1314,12 +1318,12 @@ defmodule MingaEditor do
     :exit, reason -> {:error, {:remote_unavailable, reason}}
   end
 
-  @spec restore_remote_session_from_store(EditorState.t(), Tab.t(), node(), String.t()) ::
+  @spec restore_remote_session_from_store(EditorState.t(), Workspace.t(), node(), String.t()) ::
           EditorState.t()
-  defp restore_remote_session_from_store(state, tab, remote_node, session_id) do
+  defp restore_remote_session_from_store(state, workspace, remote_node, session_id) do
     case remote_session_data(remote_node, session_id) do
-      {:ok, %{messages: messages}} -> restore_ended_remote_tab(state, tab, messages)
-      {:error, _reason} -> mark_remote_tab_status(state, tab, :unavailable)
+      {:ok, %{messages: messages}} -> restore_ended_remote_workspace(state, workspace, messages)
+      {:error, _reason} -> mark_remote_workspace_status(state, workspace, :unavailable)
     end
   end
 
@@ -1331,21 +1335,17 @@ defmodule MingaEditor do
     :exit, reason -> {:error, {:remote_unavailable, reason}}
   end
 
-  @spec restore_ended_remote_tab(EditorState.t(), Tab.t(), [term()]) :: EditorState.t()
-  defp restore_ended_remote_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, tab, messages) do
-    tb =
-      TabBar.update_tab(tb, tab.id, fn remote_tab ->
-        remote_tab
-        |> Tab.set_session(nil)
-        |> Tab.set_connection_status(:ended)
-      end)
+  @spec restore_ended_remote_workspace(EditorState.t(), Workspace.t(), [term()]) ::
+          EditorState.t()
+  defp restore_ended_remote_workspace(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %Workspace{id: workspace_id} = workspace,
+         messages
+       ) do
+    tb = set_workspace_remote_state(tb, workspace, nil, :ended)
+    state = EditorState.set_tab_bar(state, tb)
 
-    state =
-      state
-      |> EditorState.set_tab_bar(tb)
-      |> clear_remote_workspace_session(tab)
-
-    if tb.active_id == tab.id do
+    if active_workspace?(tb, workspace_id) do
       case AgentAccess.agent(state).buffer do
         pid when is_pid(pid) -> AgentBufferSync.sync(pid, messages)
         _ -> :ok
@@ -1359,40 +1359,31 @@ defmodule MingaEditor do
     end
   end
 
-  defp restore_ended_remote_tab(state, _tab, _messages), do: state
+  defp restore_ended_remote_workspace(state, %Workspace{}, _messages), do: state
 
-  @spec restore_remote_tab(EditorState.t(), Tab.t(), pid()) :: EditorState.t()
-  defp restore_remote_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, %Tab{} = tab, pid) do
+  @spec restore_remote_workspace(EditorState.t(), Workspace.t(), pid()) :: EditorState.t()
+  defp restore_remote_workspace(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %Workspace{id: workspace_id} = workspace,
+         pid
+       ) do
     MingaAgent.Session.subscribe(pid, self())
 
-    tb =
-      TabBar.update_tab(tb, tab.id, fn remote_tab ->
-        remote_tab
-        |> Tab.set_session(pid)
-        |> Tab.set_connection_status(:connected)
-      end)
+    tb = set_workspace_remote_state(tb, workspace, pid, :connected)
+    state = EditorState.set_tab_bar(state, tb)
 
-    state =
+    if active_workspace?(tb, workspace_id) do
       state
-      |> EditorState.set_tab_bar(tb)
-      |> sync_remote_workspace_session(tab, pid)
-
-    if tb.active_id == tab.id do
-      state
-      |> EditorState.rebuild_agent_from_session(
-        tab
-        |> Tab.set_session(pid)
-        |> Tab.set_connection_status(:connected)
-      )
+      |> maybe_rebuild_agent_from_workspace(workspace_id)
       |> AgentLifecycle.sync_buffer()
     else
       state
     end
   catch
-    :exit, _reason -> mark_remote_tab_status(state, tab, :disconnected)
+    :exit, _reason -> mark_remote_workspace_status(state, workspace, :disconnected)
   end
 
-  defp restore_remote_tab(state, _tab, _pid), do: state
+  defp restore_remote_workspace(state, %Workspace{}, _pid), do: state
 
   @spec mark_remote_tabs(EditorState.t(), String.t(), Tab.connection_status()) :: EditorState.t()
   defp mark_remote_tabs(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, server_name, status) do
@@ -1401,83 +1392,101 @@ defmodule MingaEditor do
 
   defp mark_remote_tabs(state, _server_name, _status), do: state
 
-  @spec mark_remote_tab_status(EditorState.t(), Tab.t(), Tab.connection_status()) ::
+  @spec mark_remote_workspace_status(
+          EditorState.t(),
+          Workspace.t(),
+          :connected | :disconnected | :unavailable
+        ) ::
           EditorState.t()
-  defp mark_remote_tab_status(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, tab, status) do
-    tb = TabBar.update_tab(tb, tab.id, &mark_remote_tab(&1, status))
-
-    state
-    |> EditorState.set_tab_bar(tb)
-    |> maybe_clear_remote_workspace_session(tab, status)
+  defp mark_remote_workspace_status(state, workspace, :unavailable) do
+    mark_remote_workspace_without_live_session(state, workspace, :unavailable)
   end
 
-  defp mark_remote_tab_status(state, _tab, _status), do: state
-
-  @spec mark_remote_tab(Tab.t(), Tab.connection_status()) :: Tab.t()
-  defp mark_remote_tab(%Tab{} = tab, status) when status in [:ended, :unavailable] do
-    tab
-    |> Tab.set_session(nil)
-    |> Tab.set_connection_status(status)
-  end
-
-  defp mark_remote_tab(%Tab{} = tab, status), do: Tab.set_connection_status(tab, status)
-
-  @spec sync_remote_workspace_session(EditorState.t(), Tab.t(), pid()) :: EditorState.t()
-  defp sync_remote_workspace_session(
+  defp mark_remote_workspace_status(
          %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
-         %Tab{group_id: workspace_id},
-         pid
-       )
-       when is_pid(pid) do
-    case TabBar.get_workspace(tb, workspace_id) do
-      %Workspace{kind: :agent} ->
-        EditorState.set_tab_bar(
-          state,
-          TabBar.update_workspace(tb, workspace_id, &Workspace.set_session(&1, pid))
-        )
-
-      _workspace ->
-        state
-    end
-  end
-
-  defp sync_remote_workspace_session(state, _tab, _pid), do: state
-
-  @spec maybe_clear_remote_workspace_session(EditorState.t(), Tab.t(), Tab.connection_status()) ::
-          EditorState.t()
-  defp maybe_clear_remote_workspace_session(state, tab, status)
-       when status in [:ended, :unavailable] do
-    clear_remote_workspace_session(state, tab)
-  end
-
-  defp maybe_clear_remote_workspace_session(state, _tab, _status), do: state
-
-  @spec clear_remote_workspace_session(EditorState.t(), Tab.t()) :: EditorState.t()
-  defp clear_remote_workspace_session(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
-         %Tab{group_id: workspace_id, session: stale_session}
+         %Workspace{} = workspace,
+         status
        ) do
-    case TabBar.get_workspace(tb, workspace_id) do
-      %Workspace{kind: :agent, session: ^stale_session} when is_pid(stale_session) ->
-        EditorState.set_tab_bar(
-          state,
-          TabBar.update_workspace(tb, workspace_id, &Workspace.clear_session/1)
-        )
+    EditorState.set_tab_bar(
+      state,
+      set_workspace_remote_state(tb, workspace, workspace.session, status)
+    )
+  end
 
-      %Workspace{kind: :agent, session: nil} ->
-        EditorState.set_tab_bar(
-          state,
-          TabBar.update_workspace(tb, workspace_id, &Workspace.clear_session/1)
-        )
+  defp mark_remote_workspace_status(state, %Workspace{}, _status), do: state
 
-      _workspace ->
-        state
+  @spec mark_remote_workspace_without_live_session(
+          EditorState.t(),
+          Workspace.t(),
+          :unavailable
+        ) :: EditorState.t()
+  defp mark_remote_workspace_without_live_session(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %Workspace{} = workspace,
+         status
+       ) do
+    EditorState.set_tab_bar(state, set_workspace_remote_state(tb, workspace, nil, status))
+  end
+
+  defp mark_remote_workspace_without_live_session(state, %Workspace{}, _status), do: state
+
+  @spec set_workspace_remote_state(
+          TabBar.t(),
+          Workspace.t(),
+          pid() | nil,
+          RemoteSession.connection_status()
+        ) ::
+          TabBar.t()
+  defp set_workspace_remote_state(%TabBar{} = tb, %Workspace{id: workspace_id}, session, status) do
+    tb
+    |> TabBar.update_workspace(workspace_id, fn workspace ->
+      workspace
+      |> set_workspace_live_session(session)
+      |> Workspace.set_remote_connection_status(status)
+    end)
+    |> TabBar.sync_workspace_agent_tab_projection(workspace_id)
+  end
+
+  @spec set_workspace_live_session(Workspace.t(), pid() | nil) :: Workspace.t()
+  defp set_workspace_live_session(%Workspace{} = workspace, nil),
+    do: Workspace.clear_session(workspace)
+
+  defp set_workspace_live_session(%Workspace{} = workspace, session) when is_pid(session) do
+    Workspace.set_session(workspace, session)
+  end
+
+  @spec maybe_rebuild_agent_from_workspace(EditorState.t(), non_neg_integer()) :: EditorState.t()
+  defp maybe_rebuild_agent_from_workspace(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         workspace_id
+       ) do
+    case workspace_agent_tab(tb, workspace_id) do
+      %Tab{} = tab -> EditorState.rebuild_agent_from_session(state, tab)
+      nil -> state
     end
   end
 
-  defp clear_remote_workspace_session(state, _tab), do: state
+  defp maybe_rebuild_agent_from_workspace(state, _workspace_id), do: state
+
+  @spec workspace_agent_tab(TabBar.t(), non_neg_integer()) :: Tab.t() | nil
+  defp workspace_agent_tab(%TabBar{} = tb, workspace_id) do
+    tb
+    |> TabBar.tabs_in_workspace(workspace_id)
+    |> Enum.find(&(&1.kind == :agent))
+  end
+
+  @spec active_workspace?(TabBar.t(), non_neg_integer()) :: boolean()
+  defp active_workspace?(%TabBar{} = tb, workspace_id),
+    do: TabBar.active_workspace_id(tb) == workspace_id
 
   @spec active_remote_server?(EditorState.t(), String.t()) :: boolean()
+  defp active_remote_server?(%{shell_state: %{tab_bar: %TabBar{} = tb}}, server_name) do
+    case TabBar.active_workspace(tb) do
+      %Workspace{} = workspace -> Workspace.remote_server?(workspace, server_name)
+      _workspace -> false
+    end
+  end
+
   defp active_remote_server?(state, server_name) do
     case state.shell.active_tab(state.shell_state) do
       %Tab{server_name: ^server_name} -> true

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -477,23 +477,27 @@ defmodule MingaEditor.Agent.Events do
   defp sync_tab_agent_status(state, status) do
     session = AgentAccess.session(state)
 
-    case session && TabBar.find_by_session(EditorState.tab_bar(state), session) do
-      %Tab{id: id} ->
-        tb = TabBar.update_tab(EditorState.tab_bar(state), id, &Tab.set_agent_status(&1, status))
-        # Also sync workspace agent status
-        tb =
-          case TabBar.find_workspace_by_session(tb, session) do
-            %Workspace{id: ws_id} ->
-              TabBar.update_workspace(tb, ws_id, &Workspace.set_agent_status(&1, status))
+    if is_pid(session) do
+      tb = EditorState.tab_bar(state)
 
-            nil ->
-              tb
-          end
+      tb =
+        case TabBar.find_workspace_by_session(tb, session) do
+          %Workspace{id: ws_id} ->
+            TabBar.update_workspace(tb, ws_id, &Workspace.set_agent_status(&1, status))
 
-        EditorState.set_tab_bar(state, tb)
+          nil ->
+            tb
+        end
 
-      _ ->
-        state
+      tb =
+        case TabBar.find_by_session(tb, session) do
+          %Tab{id: id} -> TabBar.update_tab(tb, id, &Tab.set_agent_status(&1, status))
+          nil -> tb
+        end
+
+      EditorState.set_tab_bar(state, tb)
+    else
+      state
     end
   end
 

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -135,7 +135,7 @@ defmodule MingaEditor.Commands.Agent do
         tb = TabBar.update_context(tb, new_tab.id, context)
 
         # Switch back to the original active tab
-        tb = %{tb | active_id: original_active_id}
+        tb = TabBar.switch_to(tb, original_active_id)
         EditorState.set_tab_bar(state, tb)
 
       _existing ->

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -76,8 +76,8 @@ defmodule MingaEditor.Commands.Agent do
             # switch — otherwise it would always see nil from the file tab.
             state
             |> EditorState.switch_tab(agent_id)
-            |> activate_agent_view(return_target)
             |> maybe_start_session()
+            |> activate_agent_view(return_target)
 
           nil ->
             state
@@ -129,11 +129,13 @@ defmodule MingaEditor.Commands.Agent do
         # Create agent tab in the background (don't switch to it).
         # Group creation happens later in start_agent_session when
         # the session pid is available (ensure_agent_workspace/2).
-        {tb, new_tab} = TabBar.add(EditorState.tab_bar(state), :agent, "Agent")
+        tab_bar = EditorState.tab_bar(state) || TabBar.new(Tab.new_file(1, "File"))
+        original_active_id = tab_bar.active_id
+        {tb, new_tab} = TabBar.add(tab_bar, :agent, "Agent")
         tb = TabBar.update_context(tb, new_tab.id, context)
 
         # Switch back to the original active tab
-        tb = %{tb | active_id: EditorState.tab_bar(state).active_id}
+        tb = %{tb | active_id: original_active_id}
         EditorState.set_tab_bar(state, tb)
 
       _existing ->

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -14,6 +14,7 @@ defmodule MingaEditor.Commands.AgentSession do
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Workspace
+  alias MingaEditor.State.Workspace.RemoteSession
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
@@ -167,6 +168,7 @@ defmodule MingaEditor.Commands.AgentSession do
         |> rebuild_agent_from_tab(tab_id)
         |> apply_remote_snapshot(snapshot)
         |> ensure_agent_workspace(remote_pid)
+        |> set_remote_workspace(server_name, session_id, remote_pid, :connected)
         |> EditorState.set_status("Connected to #{server_name} session #{session_id}")
 
       {:error, reason} ->
@@ -193,15 +195,8 @@ defmodule MingaEditor.Commands.AgentSession do
   @spec stop_current_session(state()) :: state()
   def stop_current_session(state) do
     case AgentAccess.session(state) do
-      nil ->
-        state
-
-      session when node(session) == node() ->
-        MingaAgent.SessionManager.stop_session_by_pid(session)
-        state
-
-      session ->
-        stop_remote_session(state, session)
+      nil -> state
+      session -> stop_current_session_pid(state, session)
     end
   catch
     :exit, reason -> EditorState.set_status(state, "Failed to stop session: #{inspect(reason)}")
@@ -420,6 +415,40 @@ defmodule MingaEditor.Commands.AgentSession do
 
   defp set_remote_tab(state, _tab_id, _server_name, _session_id, _remote_pid), do: state
 
+  @spec set_remote_workspace(
+          state(),
+          String.t(),
+          String.t(),
+          pid(),
+          RemoteSession.connection_status()
+        ) :: state()
+  defp set_remote_workspace(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         server_name,
+         session_id,
+         remote_pid,
+         status
+       ) do
+    case TabBar.find_workspace_by_session(tb, remote_pid) do
+      %Workspace{id: workspace_id} ->
+        tb =
+          tb
+          |> TabBar.update_workspace(workspace_id, fn workspace ->
+            workspace
+            |> Workspace.set_session(remote_pid)
+            |> Workspace.put_remote_session(server_name, session_id, status)
+          end)
+          |> TabBar.sync_workspace_agent_tab_projection(workspace_id)
+
+        EditorState.set_tab_bar(state, tb)
+
+      nil ->
+        state
+    end
+  end
+
+  defp set_remote_workspace(state, _server_name, _session_id, _remote_pid, _status), do: state
+
   @spec rebuild_agent_from_tab(state(), Tab.id()) :: state()
   defp rebuild_agent_from_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, tab_id) do
     case TabBar.get(tb, tab_id) do
@@ -441,10 +470,36 @@ defmodule MingaEditor.Commands.AgentSession do
     end)
   end
 
+  @spec stop_current_session_pid(state(), pid()) :: state()
+  defp stop_current_session_pid(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, session)
+       when is_pid(session) do
+    case remote_session_for_live_pid(tb, session) do
+      %RemoteSession{} ->
+        stop_remote_session(state, session)
+
+      nil when node(session) == node() ->
+        MingaAgent.SessionManager.stop_session_by_pid(session)
+        state
+
+      nil ->
+        stop_remote_session(state, session)
+    end
+  end
+
+  defp stop_current_session_pid(state, session)
+       when is_pid(session) and node(session) == node() do
+    MingaAgent.SessionManager.stop_session_by_pid(session)
+    state
+  end
+
+  defp stop_current_session_pid(state, session) when is_pid(session) do
+    stop_remote_session(state, session)
+  end
+
   @spec stop_remote_session(state(), pid()) :: state()
   defp stop_remote_session(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, session) do
-    case TabBar.find_by_session(tb, session) do
-      %Tab{remote_session_id: session_id} when is_binary(session_id) ->
+    case remote_session_for_live_pid(tb, session) do
+      %RemoteSession{session_id: session_id} ->
         case :erpc.call(
                node(session),
                MingaAgent.SessionManager,
@@ -459,7 +514,7 @@ defmodule MingaEditor.Commands.AgentSession do
             EditorState.set_status(state, "Failed to stop remote session: #{inspect(reason)}")
         end
 
-      _ ->
+      nil ->
         EditorState.set_status(state, "Remote session id is unavailable")
     end
   catch
@@ -468,6 +523,29 @@ defmodule MingaEditor.Commands.AgentSession do
   end
 
   defp stop_remote_session(state, _session), do: state
+
+  @spec remote_session_for_live_pid(TabBar.t(), pid()) :: RemoteSession.t() | nil
+  defp remote_session_for_live_pid(%TabBar{} = tb, session) when is_pid(session) do
+    case TabBar.find_workspace_by_session(tb, session) do
+      %Workspace{remote_session: %RemoteSession{} = remote_session} ->
+        remote_session
+
+      _workspace ->
+        remote_session_for_tab_pid(tb, session)
+    end
+  end
+
+  @spec remote_session_for_tab_pid(TabBar.t(), pid()) :: RemoteSession.t() | nil
+  defp remote_session_for_tab_pid(%TabBar{} = tb, session) when is_pid(session) do
+    case TabBar.find_by_session(tb, session) do
+      %Tab{server_name: server_name, remote_session_id: session_id}
+      when is_binary(server_name) and is_binary(session_id) ->
+        RemoteSession.new(server_name, session_id, :connected)
+
+      _tab ->
+        nil
+    end
+  end
 
   @spec buffer_name_for_language(String.t()) :: String.t()
   defp buffer_name_for_language(""), do: "*Agent: text*"

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -41,14 +41,10 @@ defmodule MingaEditor.Commands.AgentSession do
     session = AgentAccess.session(state)
 
     if session do
-      try do
-        MingaAgent.SessionManager.stop_session_by_pid(session)
-      catch
-        :exit, _ -> :ok
-      end
+      stop_session_pid(session)
     end
 
-    state = state |> clear_active_tab_session() |> reset_agent_cache()
+    state = state |> clear_restart_session(session) |> reset_agent_cache()
     state = EditorState.set_status(state, message)
     if AgentAccess.panel(state).visible, do: start_agent_session(state), else: state
   end
@@ -57,12 +53,37 @@ defmodule MingaEditor.Commands.AgentSession do
     EditorState.set_status(state, "Session restart is not supported on this shell")
   end
 
-  @spec clear_active_tab_session(state()) :: state()
-  defp clear_active_tab_session(%{shell_state: %{tab_bar: %TabBar{active_id: id}}} = state) do
-    EditorState.set_tab_session(state, id, nil)
+  @spec clear_restart_session(state(), pid() | nil) :: state()
+  defp clear_restart_session(state, nil), do: state
+
+  defp clear_restart_session(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, session) do
+    tb = tb |> clear_tab_sessions(session) |> clear_workspace_sessions(session)
+    EditorState.set_tab_bar(state, tb)
   end
 
-  defp clear_active_tab_session(state), do: state
+  defp clear_restart_session(state, _session), do: state
+
+  @spec clear_tab_sessions(TabBar.t(), pid()) :: TabBar.t()
+  defp clear_tab_sessions(%TabBar{} = tb, session) do
+    Enum.reduce(tb.tabs, tb, fn
+      %Tab{id: tab_id, session: ^session}, acc ->
+        TabBar.update_tab(acc, tab_id, &Tab.set_session(&1, nil))
+
+      _tab, acc ->
+        acc
+    end)
+  end
+
+  @spec clear_workspace_sessions(TabBar.t(), pid()) :: TabBar.t()
+  defp clear_workspace_sessions(%TabBar{} = tb, session) do
+    Enum.reduce(tb.workspaces, tb, fn
+      %Workspace{id: workspace_id, session: ^session}, acc ->
+        TabBar.update_workspace(acc, workspace_id, &Workspace.clear_session/1)
+
+      _workspace, acc ->
+        acc
+    end)
+  end
 
   @spec reset_agent_cache(state()) :: state()
   defp reset_agent_cache(state) do
@@ -105,6 +126,30 @@ defmodule MingaEditor.Commands.AgentSession do
         Minga.Log.error(:agent, "[Agent] #{msg}")
         AgentAccess.update_agent(state, &AgentState.set_error(&1, msg))
     end
+  end
+
+  @doc "Stops a session pid, routing remote pids to their owning node."
+  @spec stop_session_pid(pid()) :: :ok | {:error, term()}
+  def stop_session_pid(session) when is_pid(session) and node(session) == node() do
+    MingaAgent.SessionManager.stop_session_by_pid(session)
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  def stop_session_pid(session) when is_pid(session) do
+    case :erpc.call(
+           node(session),
+           MingaAgent.SessionManager,
+           :stop_session_by_pid,
+           [session],
+           5_000
+         ) do
+      :ok -> :ok
+      {:error, _reason} = error -> error
+      other -> {:error, other}
+    end
+  catch
+    :exit, reason -> {:error, reason}
   end
 
   @doc "Connects the local GUI to an existing remote agent session."
@@ -220,7 +265,7 @@ defmodule MingaEditor.Commands.AgentSession do
 
   @spec assign_session_to_tab(state(), pid()) :: state()
   defp assign_session_to_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, pid) do
-    case TabBar.find_sessionless_agent(tb) do
+    case preferred_sessionless_agent(tb) do
       %Tab{id: agent_tab_id} ->
         tb = TabBar.update_tab(tb, agent_tab_id, &Tab.set_session(&1, pid))
         EditorState.set_tab_bar(state, tb)
@@ -231,6 +276,28 @@ defmodule MingaEditor.Commands.AgentSession do
   end
 
   defp assign_session_to_tab(state, _pid), do: state
+
+  @spec preferred_sessionless_agent(TabBar.t()) :: Tab.t() | nil
+  defp preferred_sessionless_agent(%TabBar{} = tb) do
+    active_workspace_sessionless_agent(tb) || TabBar.find_sessionless_agent(tb)
+  end
+
+  @spec active_workspace_sessionless_agent(TabBar.t()) :: Tab.t() | nil
+  defp active_workspace_sessionless_agent(%TabBar{} = tb) do
+    case TabBar.active_workspace(tb) do
+      %Workspace{id: workspace_id, kind: :agent} ->
+        tb
+        |> TabBar.tabs_in_workspace(workspace_id)
+        |> Enum.find(&sessionless_agent?/1)
+
+      _workspace ->
+        nil
+    end
+  end
+
+  @spec sessionless_agent?(Tab.t()) :: boolean()
+  defp sessionless_agent?(%Tab{kind: :agent, session: nil}), do: true
+  defp sessionless_agent?(%Tab{}), do: false
 
   @spec start_and_subscribe(keyword()) :: {:ok, pid()} | {:error, term()}
   defp start_and_subscribe(opts) do
@@ -466,27 +533,83 @@ defmodule MingaEditor.Commands.AgentSession do
         state
 
       nil ->
-        # Create workspace and assign the agent tab to it.
-        {tb, ws} = TabBar.add_workspace(tb, "Agent", session_pid)
-
-        tb =
-          case TabBar.find_by_session(tb, session_pid) do
-            %Tab{id: tab_id} = tab ->
-              tb
-              |> TabBar.move_tab_to_workspace(tab_id, ws.id)
-              |> TabBar.update_context(
-                tab_id,
-                TabContext.put_fields(tab.context, keymap_scope: :agent)
-              )
-
-            nil ->
-              tb
-          end
-
-        state = EditorState.set_tab_bar(state, tb)
-        EditorState.update_workspace(state, &WorkspaceState.set_agent_ui(&1, ws.agent_ui))
+        bind_session_to_agent_workspace(state, tb, session_pid)
     end
   end
 
   defp ensure_agent_workspace(state, _session_pid), do: state
+
+  @spec bind_session_to_agent_workspace(state(), TabBar.t(), pid()) :: state()
+  defp bind_session_to_agent_workspace(state, %TabBar{} = tb, session_pid) do
+    case reusable_active_agent_workspace(tb) do
+      %Workspace{id: workspace_id} ->
+        tb =
+          tb
+          |> bind_session_to_workspace_agent_tab(workspace_id, session_pid)
+          |> TabBar.update_workspace(workspace_id, &Workspace.set_session(&1, session_pid))
+
+        sync_state_to_workspace(state, tb, workspace_id)
+
+      nil ->
+        create_agent_workspace(state, tb, session_pid)
+    end
+  end
+
+  @spec reusable_active_agent_workspace(TabBar.t()) :: Workspace.t() | nil
+  defp reusable_active_agent_workspace(%TabBar{} = tb) do
+    case TabBar.active_workspace(tb) do
+      %Workspace{kind: :agent} = workspace -> workspace
+      _workspace -> nil
+    end
+  end
+
+  @spec bind_session_to_workspace_agent_tab(TabBar.t(), non_neg_integer(), pid()) :: TabBar.t()
+  defp bind_session_to_workspace_agent_tab(%TabBar{} = tb, workspace_id, session_pid) do
+    case sessionless_agent_in_workspace(tb, workspace_id) do
+      %Tab{id: tab_id} -> TabBar.update_tab(tb, tab_id, &Tab.set_session(&1, session_pid))
+      nil -> tb
+    end
+  end
+
+  @spec sessionless_agent_in_workspace(TabBar.t(), non_neg_integer()) :: Tab.t() | nil
+  defp sessionless_agent_in_workspace(%TabBar{} = tb, workspace_id) do
+    tb
+    |> TabBar.tabs_in_workspace(workspace_id)
+    |> Enum.find(&sessionless_agent?/1)
+  end
+
+  @spec create_agent_workspace(state(), TabBar.t(), pid()) :: state()
+  defp create_agent_workspace(state, %TabBar{} = tb, session_pid) do
+    # Create workspace and assign the agent tab to it.
+    {tb, ws} = TabBar.add_workspace(tb, "Agent", session_pid)
+
+    tb =
+      case TabBar.find_by_session(tb, session_pid) do
+        %Tab{id: tab_id} = tab ->
+          tb
+          |> TabBar.move_tab_to_workspace(tab_id, ws.id)
+          |> TabBar.update_context(
+            tab_id,
+            TabContext.put_fields(tab.context, keymap_scope: :agent)
+          )
+
+        nil ->
+          tb
+      end
+
+    sync_state_to_workspace(state, tb, ws.id)
+  end
+
+  @spec sync_state_to_workspace(state(), TabBar.t(), non_neg_integer()) :: state()
+  defp sync_state_to_workspace(state, %TabBar{} = tb, workspace_id) do
+    agent_ui =
+      case TabBar.get_workspace(tb, workspace_id) do
+        %Workspace{agent_ui: %MingaEditor.Agent.UIState{} = agent_ui} -> agent_ui
+        _ -> MingaEditor.Agent.UIState.new()
+      end
+
+    state
+    |> EditorState.set_tab_bar(tb)
+    |> EditorState.update_workspace(&WorkspaceState.set_agent_ui(&1, agent_ui))
+  end
 end

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -15,8 +15,10 @@ defmodule MingaEditor.Commands.AgentSession do
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Workspace
   alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Windows
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
 
@@ -92,12 +94,7 @@ defmodule MingaEditor.Commands.AgentSession do
             state
           end
 
-        # Set the session PID on the agent tab that was just created
-        # (or the active agent tab). find_sessionless_agent avoids the
-        # ambiguity of find_by_kind(:agent) when multiple agent tabs exist.
-        # Tab.session is the source of truth; the rendering cache on
-        # state.shell_state.agent (status, error, pending_approval) is
-        # populated lazily on tab switch via rebuild_agent_from_session/2.
+        # Attach the new session as a temporary tab locator until the workspace owns it.
         state = assign_session_to_tab(state, pid)
 
         # Create an workspace for this session (if one doesn't exist yet)
@@ -224,8 +221,12 @@ defmodule MingaEditor.Commands.AgentSession do
   @spec assign_session_to_tab(state(), pid()) :: state()
   defp assign_session_to_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, pid) do
     case TabBar.find_sessionless_agent(tb) do
-      %Tab{id: agent_tab_id} -> EditorState.set_tab_session(state, agent_tab_id, pid)
-      nil -> state
+      %Tab{id: agent_tab_id} ->
+        tb = TabBar.update_tab(tb, agent_tab_id, &Tab.set_session(&1, pid))
+        EditorState.set_tab_bar(state, tb)
+
+      nil ->
+        state
     end
   end
 
@@ -465,17 +466,25 @@ defmodule MingaEditor.Commands.AgentSession do
         state
 
       nil ->
-        # Create workspace and assign the agent tab to it
+        # Create workspace and assign the agent tab to it.
         {tb, ws} = TabBar.add_workspace(tb, "Agent", session_pid)
 
-        # Find the agent tab with this session and move it into the workspace
         tb =
           case TabBar.find_by_session(tb, session_pid) do
-            %Tab{id: tab_id} -> TabBar.move_tab_to_workspace(tb, tab_id, ws.id)
-            nil -> tb
+            %Tab{id: tab_id} = tab ->
+              tb
+              |> TabBar.move_tab_to_workspace(tab_id, ws.id)
+              |> TabBar.update_context(
+                tab_id,
+                TabContext.put_fields(tab.context, keymap_scope: :agent)
+              )
+
+            nil ->
+              tb
           end
 
-        EditorState.set_tab_bar(state, tb)
+        state = EditorState.set_tab_bar(state, tb)
+        EditorState.update_workspace(state, &WorkspaceState.set_agent_ui(&1, ws.agent_ui))
     end
   end
 

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -26,6 +26,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
   alias MingaEditor.Window
   alias Minga.Mode
   alias Minga.Mode.ToolConfirmState
@@ -1047,9 +1048,16 @@ defmodule MingaEditor.Commands.BufferManagement do
          %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
          session_pid
        ) do
-    case TabBar.find_by_session(tb, session_pid) do
-      %Tab{id: tab_id, server_name: server_name} when is_binary(server_name) ->
-        tb = TabBar.update_tab(tb, tab_id, &Tab.set_connection_status(&1, :disconnected))
+    case TabBar.find_workspace_by_session(tb, session_pid) do
+      %Workspace{id: workspace_id, remote_session: %{server_name: server_name}}
+      when is_binary(server_name) ->
+        tb =
+          tb
+          |> TabBar.update_workspace(
+            workspace_id,
+            &Workspace.set_remote_connection_status(&1, :disconnected)
+          )
+          |> TabBar.sync_workspace_agent_tab_projection(workspace_id)
 
         state
         |> EditorState.set_tab_bar(tb)
@@ -1057,7 +1065,7 @@ defmodule MingaEditor.Commands.BufferManagement do
         |> AgentAccess.update_agent(&AgentState.set_error(&1, "Disconnected from #{server_name}"))
         |> EditorState.set_status("[#{server_name}] disconnected, reconnecting...")
 
-      _ ->
+      _workspace ->
         state
     end
   end
@@ -1135,14 +1143,9 @@ defmodule MingaEditor.Commands.BufferManagement do
       Enum.reduce(tb.workspaces, tb, fn
         %{id: workspace_id, session: ^session_pid}, acc ->
           acc
-          |> TabBar.update_workspace(
-            workspace_id,
-            &MingaEditor.State.Workspace.set_session(&1, nil)
-          )
-          |> TabBar.update_workspace(
-            workspace_id,
-            &MingaEditor.State.Workspace.set_agent_status(&1, status)
-          )
+          |> TabBar.update_workspace(workspace_id, &Workspace.set_session(&1, nil))
+          |> TabBar.update_workspace(workspace_id, &Workspace.set_agent_status(&1, status))
+          |> TabBar.sync_workspace_agent_tab_projection(workspace_id)
 
         _workspace, acc ->
           acc
@@ -1171,7 +1174,8 @@ defmodule MingaEditor.Commands.BufferManagement do
   #
   # For file tabs, this closes the tab without killing the buffer (matching
   # Neovim where `:q` closes the window but the buffer stays in memory).
-  # For agent tabs, session cleanup is needed so we delegate to close_agent_tab.
+  # For agent tabs, workspace close is the session teardown path, so closing
+  # the tab only removes the projection.
   # Checks whether a quit should be confirmed. Dirty buffers use the existing
   # confirm_quit option; last-file `:q` always asks before exiting so Vim-style
   # close semantics do not surprise users by terminating the app.

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -6,7 +6,6 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   use MingaEditor.Commands.Provider
 
-  alias MingaAgent.Session
   alias Minga.Buffer
   alias Minga.FileRef
   alias Minga.Buffer.Document
@@ -947,32 +946,6 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   defp remove_current_buffer(state), do: state
 
-  # Pure cleanup: stops the agent session, spinner, and group without
-  # touching tabs or navigation. Callers handle tab removal separately.
-  @spec cleanup_agent_session(state()) :: state()
-  defp cleanup_agent_session(%{shell_state: %{tab_bar: %TabBar{}}} = state) do
-    session = AgentAccess.session(state)
-
-    # Stop and unsubscribe from the live session.
-    if session do
-      try do
-        Session.unsubscribe(session)
-      catch
-        :exit, _ -> :ok
-      end
-
-      try do
-        GenServer.stop(session, :normal)
-      catch
-        :exit, _ -> :ok
-      end
-    end
-
-    state = scrub_agent_tab_state(state, session)
-    MingaEditor.log_to_messages("Closed agent tab")
-    state
-  end
-
   @doc """
   Cleans up editor state after an agent session dies (`:DOWN` handler).
 
@@ -1113,10 +1086,9 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   defp handle_remote_session_disconnected(state, _session_pid), do: state
 
-  # Shared state cleanup for agent sessions: stops spinner, clears agent state session,
-  # clears Tab.session/agent_status, and removes the agent workspace.
+  # Shared cleanup stops the spinner and clears workspace-level session/status without removing files or tabs.
   @spec scrub_agent_tab_state(state(), pid() | nil, Tab.agent_status()) :: state()
-  defp scrub_agent_tab_state(state, session, tab_status \\ :idle) do
+  defp scrub_agent_tab_state(state, session, tab_status) do
     state = AgentAccess.update_agent(state, &AgentState.stop_spinner_timer/1)
     state = AgentAccess.update_agent(state, &AgentState.reset_cache/1)
 
@@ -1128,16 +1100,10 @@ defmodule MingaEditor.Commands.BufferManagement do
         state
       end
 
-    # Remove the agent's group from the tab bar.
-    case session && TabBar.find_workspace_by_session(state.shell_state.tab_bar, session) do
-      %{id: workspace_id} ->
-        EditorState.set_tab_bar(
-          state,
-          TabBar.remove_workspace(state.shell_state.tab_bar, workspace_id)
-        )
-
-      _ ->
-        state
+    if session do
+      clear_session_from_workspaces(state, session, tab_status)
+    else
+      state
     end
   end
 
@@ -1159,14 +1125,39 @@ defmodule MingaEditor.Commands.BufferManagement do
     EditorState.set_tab_bar(state, updated_tb)
   end
 
-  # Closes the active agent tab: cleans up the session, removes the tab,
+  @spec clear_session_from_workspaces(state(), pid(), Tab.agent_status()) :: state()
+  defp clear_session_from_workspaces(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         session_pid,
+         status
+       ) do
+    updated_tb =
+      Enum.reduce(tb.workspaces, tb, fn
+        %{id: workspace_id, session: ^session_pid}, acc ->
+          acc
+          |> TabBar.update_workspace(
+            workspace_id,
+            &MingaEditor.State.Workspace.set_session(&1, nil)
+          )
+          |> TabBar.update_workspace(
+            workspace_id,
+            &MingaEditor.State.Workspace.set_agent_status(&1, status)
+          )
+
+        _workspace, acc ->
+          acc
+      end)
+
+    EditorState.set_tab_bar(state, updated_tb)
+  end
+
+  # Closes the active agent tab without stopping the workspace-owned session,
   # and switches to the nearest file tab. Only called from multi-tab
   # contexts (close_tab_or_quit's first clause); the last-tab case is
   # handled directly by close_tab_or_quit.
   @spec close_agent_tab(state()) :: state()
   defp close_agent_tab(%{shell_state: %{tab_bar: %TabBar{}}} = state) do
     state
-    |> cleanup_agent_session()
     |> EditorState.update_workspace(&WorkspaceState.set_keymap_scope(&1, :editor))
     |> remove_current_tab()
     |> restore_active_tab_context()
@@ -1259,9 +1250,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec close_agent_tab_or_quit(state()) :: state()
   defp close_agent_tab_or_quit(%{shell_state: %{tab_bar: %TabBar{tabs: [_single]}}} = state) do
-    state
-    |> cleanup_agent_session()
-    |> shutdown_editor()
+    shutdown_editor(state)
   end
 
   defp close_agent_tab_or_quit(state), do: close_agent_tab(state)
@@ -1446,7 +1435,7 @@ defmodule MingaEditor.Commands.BufferManagement do
     case EditorState.active_tab(state) do
       %Tab{context: context} when is_map(context) ->
         if TabContext.empty?(context) do
-          state
+          EditorState.sync_agent_ui_from_active_workspace(state)
         else
           EditorState.restore_tab_context(state, context)
         end

--- a/lib/minga_editor/commands/workspace.ex
+++ b/lib/minga_editor/commands/workspace.ex
@@ -51,7 +51,12 @@ defmodule MingaEditor.Commands.Workspace do
   """
   @spec workspace_close(state()) :: state()
   def workspace_close(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
-    EditorState.set_tab_bar(state, TabBar.remove_workspace(tb, TabBar.active_workspace_id(tb)))
+    workspace_id = TabBar.active_workspace_id(tb)
+    stop_workspace_session(TabBar.get_workspace(tb, workspace_id))
+
+    state
+    |> EditorState.set_tab_bar(TabBar.remove_workspace(tb, workspace_id))
+    |> EditorState.sync_agent_ui_from_active_workspace()
   end
 
   @doc "Open the workspace picker."
@@ -100,6 +105,16 @@ defmodule MingaEditor.Commands.Workspace do
   def workspace_goto_by_id(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, workspace_id) do
     switch_via_workspace(state, TabBar.switch_to_workspace(tb, workspace_id))
   end
+
+  @spec stop_workspace_session(MingaEditor.State.Workspace.t() | nil) :: :ok
+  defp stop_workspace_session(%MingaEditor.State.Workspace{session: session})
+       when is_pid(session) do
+    MingaAgent.SessionManager.stop_session_by_pid(session)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp stop_workspace_session(_workspace), do: :ok
 
   # Takes a TabBar with a potentially new active_id from a workspace switch.
   # Routes through EditorState.switch_tab so snapshots and restores happen properly.

--- a/lib/minga_editor/commands/workspace.ex
+++ b/lib/minga_editor/commands/workspace.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Commands.Workspace do
 
   use MingaEditor.Commands.Provider
 
+  alias MingaEditor.Commands.AgentSession
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.TabBar
 
@@ -109,9 +110,8 @@ defmodule MingaEditor.Commands.Workspace do
   @spec stop_workspace_session(MingaEditor.State.Workspace.t() | nil) :: :ok
   defp stop_workspace_session(%MingaEditor.State.Workspace{session: session})
        when is_pid(session) do
-    MingaAgent.SessionManager.stop_session_by_pid(session)
-  catch
-    :exit, _ -> :ok
+    AgentSession.stop_session_pid(session)
+    :ok
   end
 
   defp stop_workspace_session(_workspace), do: :ok

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -35,6 +35,7 @@ defmodule MingaEditor.Shell.Traditional do
 
   alias MingaEditor.Agent.BufferSync, as: AgentBufferSync
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Commands.AgentSession
   alias Minga.Buffer
   alias Minga.Project.FileRef
   alias MingaEditor.State.Workspace
@@ -130,7 +131,10 @@ defmodule MingaEditor.Shell.Traditional do
         {:workspace_close, ws_id}
       ) do
     stop_workspace_session(TabBar.get_workspace(tb, ws_id))
-    {%{shell_state | tab_bar: TabBar.remove_workspace(tb, ws_id)}, workspace}
+    tab_bar = TabBar.remove_workspace(tb, ws_id)
+    shell_state = ShellState.set_tab_bar(shell_state, tab_bar)
+    workspace = sync_workspace_agent_ui(tab_bar, workspace)
+    {shell_state, workspace}
   end
 
   def handle_gui_action(
@@ -731,11 +735,21 @@ defmodule MingaEditor.Shell.Traditional do
 
   defp buffer_label(_), do: "[unknown]"
 
+  @spec sync_workspace_agent_ui(TabBar.t(), WorkspaceState.t()) :: WorkspaceState.t()
+  defp sync_workspace_agent_ui(%TabBar{} = tab_bar, %WorkspaceState{} = workspace) do
+    agent_ui =
+      case TabBar.active_workspace(tab_bar) do
+        %Workspace{agent_ui: %UIState{} = agent_ui} -> agent_ui
+        _ -> UIState.new()
+      end
+
+    WorkspaceState.set_agent_ui(workspace, agent_ui)
+  end
+
   @spec stop_workspace_session(Workspace.t() | nil) :: :ok
   defp stop_workspace_session(%Workspace{session: session}) when is_pid(session) do
-    MingaAgent.SessionManager.stop_session_by_pid(session)
-  catch
-    :exit, _ -> :ok
+    AgentSession.stop_session_pid(session)
+    :ok
   end
 
   defp stop_workspace_session(_workspace), do: :ok

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -84,7 +84,13 @@ defmodule MingaEditor.Shell.Traditional do
         |> Tab.set_agent_status(:thinking)
         |> Tab.mark_background_subagent(handle)
 
-      tb = TabBar.update_tab(tb, tab.id, fn _ -> tab end)
+      {tb, agent_workspace} = TabBar.add_workspace(tb, label, handle.pid)
+
+      tb =
+        tb
+        |> TabBar.update_tab(tab.id, fn _ -> tab end)
+        |> TabBar.move_tab_to_workspace(tab.id, agent_workspace.id)
+
       context = background_agent_context(workspace)
       tb = TabBar.update_context(tb, tab.id, context)
       {%{shell_state | tab_bar: tb}, workspace}
@@ -123,6 +129,7 @@ defmodule MingaEditor.Shell.Traditional do
         workspace,
         {:workspace_close, ws_id}
       ) do
+    stop_workspace_session(TabBar.get_workspace(tb, ws_id))
     {%{shell_state | tab_bar: TabBar.remove_workspace(tb, ws_id)}, workspace}
   end
 
@@ -328,7 +335,16 @@ defmodule MingaEditor.Shell.Traditional do
         session_pid,
         {:status_changed, status}
       ) do
-    # Update the tab's agent status badge
+    # Update workspace and legacy tab status badges.
+    tb =
+      case TabBar.find_workspace_by_session(tb, session_pid) do
+        %Workspace{id: id} ->
+          TabBar.update_workspace(tb, id, &Workspace.set_agent_status(&1, status))
+
+        nil ->
+          tb
+      end
+
     tb =
       case TabBar.find_by_session(tb, session_pid) do
         %Tab{id: id} -> TabBar.update_tab(tb, id, &Tab.set_agent_status(&1, status))
@@ -409,6 +425,15 @@ defmodule MingaEditor.Shell.Traditional do
   end
 
   def set_tab_session(%ShellState{tab_bar: tb} = shell_state, tab_id, session_pid) do
+    tb =
+      case TabBar.get(tb, tab_id) do
+        %Tab{group_id: workspace_id} ->
+          TabBar.update_workspace(tb, workspace_id, &Workspace.set_session(&1, session_pid))
+
+        nil ->
+          tb
+      end
+
     %{shell_state | tab_bar: TabBar.update_tab(tb, tab_id, &Tab.set_session(&1, session_pid))}
   end
 
@@ -417,8 +442,8 @@ defmodule MingaEditor.Shell.Traditional do
   def active_session(%ShellState{tab_bar: nil}), do: nil
 
   def active_session(%ShellState{tab_bar: tb}) do
-    case TabBar.active(tb) do
-      %Tab{session: pid} -> pid
+    case TabBar.active_workspace(tb) do
+      %Workspace{session: pid} when is_pid(pid) -> pid
       _ -> nil
     end
   end
@@ -705,6 +730,15 @@ defmodule MingaEditor.Shell.Traditional do
   end
 
   defp buffer_label(_), do: "[unknown]"
+
+  @spec stop_workspace_session(Workspace.t() | nil) :: :ok
+  defp stop_workspace_session(%Workspace{session: session}) when is_pid(session) do
+    MingaAgent.SessionManager.stop_session_by_pid(session)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp stop_workspace_session(_workspace), do: :ok
 
   @spec tab_has_active_buffer?(Tab.t(), pid()) :: boolean()
   defp tab_has_active_buffer?(%Tab{context: context}, pid) do

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -1247,7 +1247,9 @@ defmodule MingaEditor.State do
         {TabContext.from_map(context), state}
       end
 
-    %{state | workspace: WorkspaceState.restore_tab_context(state.workspace, context)}
+    state
+    |> Map.put(:workspace, WorkspaceState.restore_tab_context(state.workspace, context))
+    |> sync_agent_ui_from_active_workspace()
   end
 
   # Builds a typed file-tab context for a brand-new tab.
@@ -1292,8 +1294,7 @@ defmodule MingaEditor.State do
       injection_ranges: %{},
       search: %Search{},
       editing: VimState.new(),
-      document_highlights: nil,
-      agent_ui: UIState.new()
+      document_highlights: nil
     })
   end
 
@@ -1322,8 +1323,7 @@ defmodule MingaEditor.State do
       injection_ranges: %{},
       search: %Search{},
       editing: VimState.new(),
-      document_highlights: nil,
-      agent_ui: UIState.new()
+      document_highlights: nil
     })
   end
 
@@ -1331,8 +1331,7 @@ defmodule MingaEditor.State do
   Builds a fresh agent-shaped workspace context for a Board card on first zoom.
 
   Returns a `Tab.context()` carrying a single agent-chat window sized to the
-  current viewport, with the agent keymap scope and a fresh `agent_ui`. The
-  caller restores it via `restore_tab_context/2` and then runs
+  current viewport, with the agent keymap scope. The caller restores it via `restore_tab_context/2` and then runs
   `AgentActivation.activate_for_card/2` to attach the card's session pid to
   the window content.
 
@@ -1420,6 +1419,7 @@ defmodule MingaEditor.State do
         state = set_tab_bar(state, tb)
 
         state = restore_tab_context(state, target.context)
+        state = sync_agent_ui_from_active_workspace(state)
 
         # If the active modal is completion belonging to the leaving tab,
         # dismiss it so it doesn't follow us to the new tab.
@@ -1461,6 +1461,22 @@ defmodule MingaEditor.State do
     {state, effects} = switch_tab_pure(state, target_id)
     apply_buffer_effects(state, effects)
   end
+
+  @doc "Syncs the live workspace agent UI mirror from the active workspace."
+  @spec sync_agent_ui_from_active_workspace(t()) :: t()
+  def sync_agent_ui_from_active_workspace(
+        %__MODULE__{shell_state: %{tab_bar: %TabBar{} = tab_bar}, workspace: workspace} = state
+      ) do
+    agent_ui =
+      case TabBar.active_workspace(tab_bar) do
+        %{agent_ui: %UIState{} = agent_ui} -> agent_ui
+        _ -> UIState.new()
+      end
+
+    %{state | workspace: %{workspace | agent_ui: agent_ui}}
+  end
+
+  def sync_agent_ui_from_active_workspace(state), do: state
 
   @spec active_tab(t()) :: Tab.t() | nil
   def active_tab(%__MODULE__{} = state), do: state.shell.active_tab(state.shell_state)

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -1465,7 +1465,7 @@ defmodule MingaEditor.State do
   @doc "Syncs the live workspace agent UI mirror from the active workspace."
   @spec sync_agent_ui_from_active_workspace(t()) :: t()
   def sync_agent_ui_from_active_workspace(
-        %__MODULE__{shell_state: %{tab_bar: %TabBar{} = tab_bar}, workspace: workspace} = state
+        %__MODULE__{shell_state: %{tab_bar: %TabBar{} = tab_bar}} = state
       ) do
     agent_ui =
       case TabBar.active_workspace(tab_bar) do
@@ -1473,7 +1473,7 @@ defmodule MingaEditor.State do
         _ -> UIState.new()
       end
 
-    %{state | workspace: %{workspace | agent_ui: agent_ui}}
+    update_workspace(state, &WorkspaceState.set_agent_ui(&1, agent_ui))
   end
 
   def sync_agent_ui_from_active_workspace(state), do: state

--- a/lib/minga_editor/state/agent_access.ex
+++ b/lib/minga_editor/state/agent_access.ex
@@ -14,6 +14,7 @@ defmodule MingaEditor.State.AgentAccess do
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.Workspace.State, as: WorkspaceState
 
   # ── Readers ────────────────────────────────────────────────────────────────
@@ -179,16 +180,33 @@ defmodule MingaEditor.State.AgentAccess do
           tab_bar
       end
 
-    %{
-      state
-      | shell_state: %{state.shell_state | tab_bar: tab_bar},
-        workspace: set_live_agent_ui(workspace, next_ui)
-    }
+    state
+    |> set_tab_bar(tab_bar)
+    |> set_workspace(set_live_agent_ui(workspace, next_ui))
   end
 
   defp update_workspace_agent_ui(%{workspace: %{agent_ui: agent_ui} = workspace} = state, fun) do
     next_ui = fun.(agent_ui || UIState.new())
     %{state | workspace: set_live_agent_ui(workspace, next_ui)}
+  end
+
+  @spec set_tab_bar(EditorState.t() | map(), TabBar.t()) :: EditorState.t() | map()
+  defp set_tab_bar(%EditorState{} = state, %TabBar{} = tab_bar) do
+    EditorState.set_tab_bar(state, tab_bar)
+  end
+
+  defp set_tab_bar(%{shell_state: shell_state} = state, %TabBar{} = tab_bar) do
+    %{state | shell_state: ShellState.set_tab_bar(shell_state, tab_bar)}
+  end
+
+  @spec set_workspace(EditorState.t() | map(), WorkspaceState.t() | map()) ::
+          EditorState.t() | map()
+  defp set_workspace(%EditorState{} = state, workspace) do
+    EditorState.update_workspace(state, fn _workspace -> workspace end)
+  end
+
+  defp set_workspace(%{workspace: _workspace} = state, workspace) do
+    %{state | workspace: workspace}
   end
 
   @spec set_live_agent_ui(WorkspaceState.t() | map(), UIState.t()) :: WorkspaceState.t() | map()

--- a/lib/minga_editor/state/agent_access.ex
+++ b/lib/minga_editor/state/agent_access.ex
@@ -2,26 +2,9 @@ defmodule MingaEditor.State.AgentAccess do
   @moduledoc """
   Direct accessors for agent state on EditorState.
 
-  Agent-related state is split across three locations:
+  Agent lifecycle data is workspace-owned for the Traditional shell. The active agent workspace stores its session pid and `MingaEditor.Agent.UIState`; `state.workspace.agent_ui` is only a live mirror for renderers that still read the current workspace struct directly.
 
-  - `state.shell_state.agent` (`MingaEditor.State.Agent`) — rendering
-    cache for the user's current view. Holds `runtime` (status), `error`,
-    `pending_approval`, `spinner_timer`, and `buffer`. Repopulated on
-    every tab/card switch from the active session's
-    `MingaAgent.Session.editor_snapshot/1`. **Not the source of truth
-    for the session pid.**
-  - The active session pid lives on `Tab.session` (Traditional shell)
-    or `Card.session` (Board shell). `session/1` reads it through
-    `Shell.active_session/1`.
-  - `state.workspace.agent_ui` (`Agent.UIState`) — full UI state
-    wrapping Panel and View. Per-tab.
-    - `state.workspace.agent_ui.panel` (`UIState.Panel`) — prompt
-      editing and chat display.
-    - `state.workspace.agent_ui.view` (`UIState.View`) — layout,
-      search, preview, toasts.
-
-  This module provides read/write functions so callers don't need to
-  know the field layout.
+  The Board shell still owns session pids on cards until it moves to the same workspace model.
   """
 
   alias MingaEditor.Agent.UIState
@@ -29,6 +12,9 @@ defmodule MingaEditor.State.AgentAccess do
   alias MingaEditor.Agent.UIState.View
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
+  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   # ── Readers ────────────────────────────────────────────────────────────────
 
@@ -41,34 +27,38 @@ defmodule MingaEditor.State.AgentAccess do
 
   @doc "Returns the full agent UI state (wrapping Panel and View)."
   @spec agent_ui(EditorState.t() | map()) :: UIState.t()
-  def agent_ui(%EditorState{workspace: %{agent_ui: a}}), do: a
-  def agent_ui(%{workspace: %{agent_ui: a}}), do: a
-  def agent_ui(%{agent_ui: a}), do: a
+  def agent_ui(%EditorState{} = state),
+    do: active_workspace_agent_ui(state) || state.workspace.agent_ui
+
+  def agent_ui(%{shell_state: %{tab_bar: %TabBar{}}, workspace: %{agent_ui: agent_ui}} = state),
+    do: active_workspace_agent_ui(state) || agent_ui || UIState.new()
+
+  def agent_ui(%{workspace: %{agent_ui: a}}), do: a || UIState.new()
+  def agent_ui(%{agent_ui: a}), do: a || UIState.new()
   def agent_ui(_), do: UIState.new()
 
   @doc "Returns the agent panel state (prompt editing and chat display)."
   @spec panel(EditorState.t() | map()) :: Panel.t()
-  def panel(%EditorState{workspace: %{agent_ui: %UIState{panel: p}}}), do: p
-  def panel(%{workspace: %{agent_ui: %UIState{panel: p}}}), do: p
-  def panel(%{agent_ui: %UIState{panel: p}}), do: p
-  def panel(_), do: Panel.new()
+  def panel(state), do: agent_ui(state).panel
 
   @doc "Returns the agent view state (layout, search, preview, toasts)."
   @spec view(EditorState.t() | map()) :: View.t()
-  def view(%EditorState{workspace: %{agent_ui: %UIState{view: v}}}), do: v
-  def view(%{workspace: %{agent_ui: %UIState{view: v}}}), do: v
-  def view(%{agent_ui: %UIState{view: v}}), do: v
-  def view(_), do: View.new()
+  def view(state), do: agent_ui(state).view
 
   @doc """
   Returns the agent session pid for the user's current view, or `nil`.
 
-  Reads through the shell behaviour: Traditional returns the active tab's
-  session, Board returns the zoomed card's session. The session pid is
-  owned by the tab/card; `state.shell_state.agent` only caches the
-  rendering fields (status, error, pending_approval) for that session.
+  Traditional reads the active workspace. Board reads through the shell behaviour until Board moves onto the same workspace model.
   """
   @spec session(EditorState.t() | map()) :: pid() | nil
+  def session(%EditorState{shell: MingaEditor.Shell.Traditional} = state) do
+    active_workspace_session(state)
+  end
+
+  def session(%{shell: MingaEditor.Shell.Traditional} = state) do
+    active_workspace_session(state)
+  end
+
   def session(%EditorState{shell: shell, shell_state: shell_state})
       when is_atom(shell) and not is_nil(shell) do
     shell.active_session(shell_state)
@@ -110,12 +100,16 @@ defmodule MingaEditor.State.AgentAccess do
   @doc "Updates the full agent UI state. Prefer update_panel/2 or update_view/2."
   @spec update_agent_ui(EditorState.t() | map(), (UIState.t() -> UIState.t())) ::
           EditorState.t() | map()
-  def update_agent_ui(%EditorState{workspace: ws} = state, fun) do
-    %{state | workspace: %{ws | agent_ui: fun.(ws.agent_ui)}}
+  def update_agent_ui(%EditorState{} = state, fun) do
+    update_workspace_agent_ui(state, fun)
+  end
+
+  def update_agent_ui(%{shell_state: %{tab_bar: %TabBar{}}} = state, fun) do
+    update_workspace_agent_ui(state, fun)
   end
 
   def update_agent_ui(%{workspace: %{agent_ui: a} = ws} = state, fun) do
-    %{state | workspace: %{ws | agent_ui: fun.(a)}}
+    %{state | workspace: %{ws | agent_ui: fun.(a || UIState.new())}}
   end
 
   def update_agent_ui(%{agent_ui: a} = state, fun) do
@@ -125,33 +119,84 @@ defmodule MingaEditor.State.AgentAccess do
   @doc "Updates just the panel sub-struct via a transform function."
   @spec update_panel(EditorState.t() | map(), (Panel.t() -> Panel.t())) ::
           EditorState.t() | map()
-  def update_panel(
-        %EditorState{workspace: %{agent_ui: %UIState{panel: p} = ui} = ws} = state,
-        fun
-      ) do
-    %{state | workspace: %{ws | agent_ui: %{ui | panel: fun.(p)}}}
-  end
-
-  def update_panel(%{workspace: %{agent_ui: %UIState{panel: p} = ui} = ws} = state, fun) do
-    %{state | workspace: %{ws | agent_ui: %{ui | panel: fun.(p)}}}
-  end
-
-  def update_panel(%{agent_ui: %UIState{panel: p} = ui} = state, fun) do
-    %{state | agent_ui: %{ui | panel: fun.(p)}}
+  def update_panel(state, fun) do
+    update_agent_ui(state, fn
+      %UIState{panel: %Panel{} = panel} = ui -> %{ui | panel: fun.(panel)}
+      _ -> %{UIState.new() | panel: fun.(Panel.new())}
+    end)
   end
 
   @doc "Updates just the view sub-struct via a transform function."
   @spec update_view(EditorState.t() | map(), (View.t() -> View.t())) ::
           EditorState.t() | map()
-  def update_view(%EditorState{workspace: %{agent_ui: %UIState{view: v} = ui} = ws} = state, fun) do
-    %{state | workspace: %{ws | agent_ui: %{ui | view: fun.(v)}}}
+  def update_view(state, fun) do
+    update_agent_ui(state, fn
+      %UIState{view: %View{} = view} = ui -> %{ui | view: fun.(view)}
+      _ -> %{UIState.new() | view: fun.(View.new())}
+    end)
   end
 
-  def update_view(%{workspace: %{agent_ui: %UIState{view: v} = ui} = ws} = state, fun) do
-    %{state | workspace: %{ws | agent_ui: %{ui | view: fun.(v)}}}
+  @spec active_workspace_agent_ui(EditorState.t() | map()) :: UIState.t() | nil
+  defp active_workspace_agent_ui(%{shell_state: %{tab_bar: %TabBar{} = tab_bar}}) do
+    case TabBar.active_workspace(tab_bar) do
+      %Workspace{agent_ui: %UIState{} = agent_ui} -> agent_ui
+      _ -> nil
+    end
   end
 
-  def update_view(%{agent_ui: %UIState{view: v} = ui} = state, fun) do
-    %{state | agent_ui: %{ui | view: fun.(v)}}
+  defp active_workspace_agent_ui(_state), do: nil
+
+  @spec active_workspace_session(EditorState.t() | map()) :: pid() | nil
+  defp active_workspace_session(%{shell_state: %{tab_bar: %TabBar{} = tab_bar}}) do
+    case TabBar.active_workspace(tab_bar) do
+      %Workspace{session: session} when is_pid(session) -> session
+      _ -> nil
+    end
+  end
+
+  defp active_workspace_session(_state), do: nil
+
+  @spec update_workspace_agent_ui(EditorState.t() | map(), (UIState.t() -> UIState.t())) ::
+          EditorState.t() | map()
+  defp update_workspace_agent_ui(
+         %{shell_state: %{tab_bar: %TabBar{} = tab_bar}, workspace: workspace} = state,
+         fun
+       ) do
+    current_ui =
+      active_workspace_agent_ui(state) || Map.get(workspace, :agent_ui) || UIState.new()
+
+    next_ui = fun.(current_ui)
+
+    tab_bar =
+      case TabBar.active_workspace(tab_bar) do
+        %Workspace{kind: :agent, id: workspace_id} ->
+          TabBar.update_workspace(tab_bar, workspace_id, &Workspace.set_agent_ui(&1, next_ui))
+
+        %Workspace{session: session, id: workspace_id} when is_pid(session) ->
+          TabBar.update_workspace(tab_bar, workspace_id, &Workspace.set_agent_ui(&1, next_ui))
+
+        _workspace ->
+          tab_bar
+      end
+
+    %{
+      state
+      | shell_state: %{state.shell_state | tab_bar: tab_bar},
+        workspace: set_live_agent_ui(workspace, next_ui)
+    }
+  end
+
+  defp update_workspace_agent_ui(%{workspace: %{agent_ui: agent_ui} = workspace} = state, fun) do
+    next_ui = fun.(agent_ui || UIState.new())
+    %{state | workspace: set_live_agent_ui(workspace, next_ui)}
+  end
+
+  @spec set_live_agent_ui(WorkspaceState.t() | map(), UIState.t()) :: WorkspaceState.t() | map()
+  defp set_live_agent_ui(%WorkspaceState{} = workspace, %UIState{} = agent_ui) do
+    WorkspaceState.set_agent_ui(workspace, agent_ui)
+  end
+
+  defp set_live_agent_ui(workspace, %UIState{} = agent_ui) when is_map(workspace) do
+    Map.put(workspace, :agent_ui, agent_ui)
   end
 end

--- a/lib/minga_editor/state/tab.ex
+++ b/lib/minga_editor/state/tab.ex
@@ -14,6 +14,7 @@ defmodule MingaEditor.State.Tab do
 
   alias Minga.Project.FileRef
   alias MingaEditor.State.Tab.Context
+  alias MingaEditor.State.Workspace.RemoteSession
 
   @typedoc "Unique tab identifier."
   @type id :: pos_integer()
@@ -120,13 +121,41 @@ defmodule MingaEditor.State.Tab do
   @spec set_remote_session(t(), String.t(), String.t(), pid()) :: t()
   def set_remote_session(%__MODULE__{} = tab, server_name, session_id, pid)
       when is_binary(server_name) and is_binary(session_id) and is_pid(pid) do
+    tab
+    |> set_remote_projection(RemoteSession.new(server_name, session_id, :connected))
+    |> set_session(pid)
+  end
+
+  @doc "Projects workspace-owned remote metadata onto this tab for display."
+  @spec set_remote_projection(t(), RemoteSession.t()) :: t()
+  def set_remote_projection(%__MODULE__{} = tab, %RemoteSession{} = remote_session) do
     %{
       tab
-      | server_name: server_name,
-        remote_session_id: session_id,
-        session: pid,
-        connection_status: :connected
+      | server_name: remote_session.server_name,
+        remote_session_id: remote_session.session_id,
+        connection_status: remote_session.connection_status
     }
+  end
+
+  @doc "Clears projected remote metadata from this tab."
+  @spec clear_remote_projection(t()) :: t()
+  def clear_remote_projection(%__MODULE__{} = tab) do
+    %{
+      tab
+      | server_name: nil,
+        remote_session_id: nil,
+        connection_status: nil
+    }
+  end
+
+  @doc "Clears agent lifecycle projection data from this tab."
+  @spec clear_agent_projection(t()) :: t()
+  def clear_agent_projection(%__MODULE__{} = tab) do
+    tab
+    |> set_session(nil)
+    |> clear_remote_projection()
+    |> set_agent_status(nil)
+    |> set_attention(false)
   end
 
   @doc "Updates remote connection status for the tab."

--- a/lib/minga_editor/state/tab/context.ex
+++ b/lib/minga_editor/state/tab/context.ex
@@ -6,7 +6,6 @@ defmodule MingaEditor.State.Tab.Context do
   """
 
   alias Minga.Keymap.Scope
-  alias MingaEditor.Agent.UIState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Dired, as: DiredState
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -30,8 +29,7 @@ defmodule MingaEditor.State.Tab.Context do
     :lsp_pending,
     :search,
     :editing,
-    :document_highlights,
-    :agent_ui
+    :document_highlights
   ]
 
   @typedoc "Workspace fields carried by a tab context."
@@ -47,7 +45,6 @@ defmodule MingaEditor.State.Tab.Context do
           | :search
           | :editing
           | :document_highlights
-          | :agent_ui
 
   @typedoc "Legacy map persisted or built before tab contexts became typed structs."
   @type legacy :: map()
@@ -68,8 +65,7 @@ defmodule MingaEditor.State.Tab.Context do
           lsp_pending: %{reference() => atom() | tuple()} | nil,
           search: Search.t() | nil,
           editing: VimState.t() | nil,
-          document_highlights: [document_highlight()] | nil,
-          agent_ui: UIState.t() | nil
+          document_highlights: [document_highlight()] | nil
         }
 
   defstruct version: @version,
@@ -84,8 +80,7 @@ defmodule MingaEditor.State.Tab.Context do
             lsp_pending: nil,
             search: nil,
             editing: nil,
-            document_highlights: nil,
-            agent_ui: nil
+            document_highlights: nil
 
   @doc "Returns the workspace field names represented by this context."
   @spec field_names() :: [field_name()]
@@ -124,7 +119,6 @@ defmodule MingaEditor.State.Tab.Context do
       search: ws.search,
       editing: editing,
       document_highlights: ws.document_highlights,
-      agent_ui: ws.agent_ui,
       present_fields: @workspace_fields
     }
   end
@@ -231,7 +225,6 @@ defmodule MingaEditor.State.Tab.Context do
   defp valid_field?(:editing, %VimState{}), do: true
   defp valid_field?(:document_highlights, nil), do: true
   defp valid_field?(:document_highlights, value) when is_list(value), do: true
-  defp valid_field?(:agent_ui, %UIState{}), do: true
   defp valid_field?(_field, _value), do: false
 
   @spec fetch_version(map()) :: pos_integer()

--- a/lib/minga_editor/state/tab_bar.ex
+++ b/lib/minga_editor/state/tab_bar.ex
@@ -353,10 +353,48 @@ defmodule MingaEditor.State.TabBar do
     end)
   end
 
-  @doc "Updates all tabs for a remote server to the given connection status."
-  @spec set_remote_connection_status(t(), String.t(), Tab.connection_status()) :: t()
-  def set_remote_connection_status(%__MODULE__{tabs: tabs} = tb, server_name, status)
+  @doc "Returns the workspace matching a remote server/session id pair."
+  @spec find_workspace_by_remote_session(t(), String.t(), String.t()) :: Workspace.t() | nil
+  def find_workspace_by_remote_session(
+        %__MODULE__{workspaces: workspaces},
+        server_name,
+        session_id
+      )
+      when is_binary(server_name) and is_binary(session_id) do
+    Enum.find(workspaces, &Workspace.matches_remote_session?(&1, server_name, session_id))
+  end
+
+  @doc "Returns remote workspaces for a server."
+  @spec remote_workspaces_for_server(t(), String.t()) :: [Workspace.t()]
+  def remote_workspaces_for_server(%__MODULE__{workspaces: workspaces}, server_name)
       when is_binary(server_name) do
+    Enum.filter(workspaces, &Workspace.remote_server?(&1, server_name))
+  end
+
+  @doc "Updates all workspaces and projected tabs for a remote server to the given connection status."
+  @spec set_remote_connection_status(t(), String.t(), Tab.connection_status()) :: t()
+  def set_remote_connection_status(%__MODULE__{} = tb, server_name, status)
+      when is_binary(server_name) and status in [:connected, :disconnected, :ended, :unavailable] do
+    tb
+    |> set_workspace_remote_connection_status(server_name, status)
+    |> set_projected_tab_remote_connection_status(server_name, status)
+  end
+
+  @spec set_workspace_remote_connection_status(t(), String.t(), Workspace.connection_status()) ::
+          t()
+  defp set_workspace_remote_connection_status(%__MODULE__{} = tb, server_name, status) do
+    Enum.reduce(remote_workspaces_for_server(tb, server_name), tb, fn %Workspace{id: id}, acc ->
+      update_workspace(acc, id, &Workspace.set_remote_connection_status(&1, status))
+    end)
+  end
+
+  @spec set_projected_tab_remote_connection_status(t(), String.t(), Tab.connection_status()) ::
+          t()
+  defp set_projected_tab_remote_connection_status(
+         %__MODULE__{tabs: tabs} = tb,
+         server_name,
+         status
+       ) do
     new_tabs =
       Enum.map(tabs, fn
         %Tab{server_name: ^server_name} = tab -> Tab.set_connection_status(tab, status)
@@ -364,6 +402,44 @@ defmodule MingaEditor.State.TabBar do
       end)
 
     %{tb | tabs: new_tabs}
+  end
+
+  @doc "Synchronizes any agent-tab projection from workspace-owned lifecycle and remote metadata."
+  @spec sync_workspace_agent_tab_projection(t(), non_neg_integer()) :: t()
+  def sync_workspace_agent_tab_projection(%__MODULE__{} = tb, workspace_id)
+      when is_integer(workspace_id) do
+    case get_workspace(tb, workspace_id) do
+      %Workspace{} = workspace -> sync_workspace_agent_tab_projection(tb, workspace)
+      nil -> tb
+    end
+  end
+
+  @spec sync_workspace_agent_tab_projection(t(), Workspace.t()) :: t()
+  def sync_workspace_agent_tab_projection(%__MODULE__{tabs: tabs} = tb, %Workspace{} = workspace) do
+    new_tabs =
+      Enum.map(tabs, fn
+        %Tab{kind: :agent, group_id: workspace_id} = tab when workspace_id == workspace.id ->
+          project_workspace_onto_agent_tab(tab, workspace)
+
+        tab ->
+          tab
+      end)
+
+    %{tb | tabs: new_tabs}
+  end
+
+  @spec project_workspace_onto_agent_tab(Tab.t(), Workspace.t()) :: Tab.t()
+  defp project_workspace_onto_agent_tab(%Tab{} = tab, %Workspace{} = workspace) do
+    tab = Tab.set_session(tab, workspace.session)
+    tab = Tab.set_agent_status(tab, workspace.agent_status)
+
+    case workspace.remote_session do
+      %MingaEditor.State.Workspace.RemoteSession{} = remote_session ->
+        Tab.set_remote_projection(tab, remote_session)
+
+      nil ->
+        Tab.clear_remote_projection(tab)
+    end
   end
 
   @doc "Sets the attention flag on the tab matching the given session pid."
@@ -513,15 +589,29 @@ defmodule MingaEditor.State.TabBar do
   def remove_workspace(%__MODULE__{} = tb, 0), do: tb
 
   def remove_workspace(%__MODULE__{} = tb, workspace_id) do
+    closing_workspace = get_workspace(tb, workspace_id)
     workspaces = Enum.reject(tb.workspaces, &(&1.id == workspace_id))
 
     tabs =
       Enum.map(tb.tabs, fn tab ->
-        if tab.group_id == workspace_id, do: Tab.set_group(tab, 0), else: tab
+        if tab.group_id == workspace_id do
+          tab
+          |> Tab.set_group(0)
+          |> scrub_migrated_workspace_tab(closing_workspace)
+        else
+          tab
+        end
       end)
 
     %{tb | workspaces: workspaces, tabs: tabs}
   end
+
+  @spec scrub_migrated_workspace_tab(Tab.t(), Workspace.t() | nil) :: Tab.t()
+  defp scrub_migrated_workspace_tab(%Tab{} = tab, %Workspace{kind: :agent}) do
+    Tab.clear_agent_projection(tab)
+  end
+
+  defp scrub_migrated_workspace_tab(%Tab{} = tab, _workspace), do: tab
 
   @doc "Moves a tab to a different workspace."
   @spec move_tab_to_workspace(t(), Tab.id(), non_neg_integer()) :: t()

--- a/lib/minga_editor/state/workspace.ex
+++ b/lib/minga_editor/state/workspace.ex
@@ -85,6 +85,14 @@ defmodule MingaEditor.State.Workspace do
     %{workspace | session: session}
   end
 
+  @doc "Clears the agent session pid and returns the workspace to idle lifecycle status."
+  @spec clear_session(t()) :: t()
+  def clear_session(%__MODULE__{} = workspace) do
+    workspace
+    |> set_session(nil)
+    |> set_agent_status(:idle)
+  end
+
   @doc "Sets the agent UI state on the workspace."
   @spec set_agent_ui(t(), UIState.t()) :: t()
   def set_agent_ui(%__MODULE__{} = workspace, %UIState{} = agent_ui) do

--- a/lib/minga_editor/state/workspace.ex
+++ b/lib/minga_editor/state/workspace.ex
@@ -6,6 +6,7 @@ defmodule MingaEditor.State.Workspace do
   """
 
   alias Minga.Project.FileRef
+  alias MingaEditor.Agent.UIState
 
   @typedoc "Workspace kind."
   @type kind :: :manual | :agent
@@ -29,7 +30,7 @@ defmodule MingaEditor.State.Workspace do
           custom_name: String.t() | nil,
           files: [FileRef.t()],
           active_file: FileRef.t() | nil,
-          agent_ui: term() | nil,
+          agent_ui: UIState.t() | nil,
           project_view: term() | nil,
           review: term() | nil
         }
@@ -73,8 +74,27 @@ defmodule MingaEditor.State.Workspace do
       icon: "cpu",
       color: agent_color(id),
       agent_status: :idle,
-      session: session
+      session: session,
+      agent_ui: UIState.new()
     }
+  end
+
+  @doc "Sets the agent session pid on the workspace."
+  @spec set_session(t(), pid() | nil) :: t()
+  def set_session(%__MODULE__{} = workspace, session) when is_pid(session) or is_nil(session) do
+    %{workspace | session: session}
+  end
+
+  @doc "Sets the agent UI state on the workspace."
+  @spec set_agent_ui(t(), UIState.t()) :: t()
+  def set_agent_ui(%__MODULE__{} = workspace, %UIState{} = agent_ui) do
+    Map.put(workspace, :agent_ui, agent_ui)
+  end
+
+  @doc "Updates the agent UI state on the workspace."
+  @spec update_agent_ui(t(), (UIState.t() -> UIState.t())) :: t()
+  def update_agent_ui(%__MODULE__{} = workspace, fun) when is_function(fun, 1) do
+    set_agent_ui(workspace, fun.(workspace.agent_ui || UIState.new()))
   end
 
   @doc "Sets the agent status on the workspace."

--- a/lib/minga_editor/state/workspace.ex
+++ b/lib/minga_editor/state/workspace.ex
@@ -7,6 +7,7 @@ defmodule MingaEditor.State.Workspace do
 
   alias Minga.Project.FileRef
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.State.Workspace.RemoteSession
 
   @typedoc "Workspace kind."
   @type kind :: :manual | :agent
@@ -14,6 +15,9 @@ defmodule MingaEditor.State.Workspace do
   @typedoc "Agent status for workspace display."
   @type agent_status ::
           :idle | :plan | :thinking | :tool_executing | :error | :needs_review | :done | nil
+
+  @typedoc "Remote connection status for workspace-owned remote sessions."
+  @type connection_status :: RemoteSession.connection_status()
 
   @typedoc "Workspace icon identifier."
   @type icon :: String.t()
@@ -27,6 +31,7 @@ defmodule MingaEditor.State.Workspace do
           color: non_neg_integer(),
           agent_status: agent_status(),
           session: pid() | nil,
+          remote_session: RemoteSession.t() | nil,
           custom_name: String.t() | nil,
           files: [FileRef.t()],
           active_file: FileRef.t() | nil,
@@ -43,6 +48,7 @@ defmodule MingaEditor.State.Workspace do
             color: 0x51AFEF,
             agent_status: :idle,
             session: nil,
+            remote_session: nil,
             custom_name: nil,
             files: [],
             active_file: nil,
@@ -60,7 +66,8 @@ defmodule MingaEditor.State.Workspace do
       icon: "folder",
       color: 0x51AFEF,
       agent_status: nil,
-      session: nil
+      session: nil,
+      remote_session: nil
     }
   end
 
@@ -85,13 +92,71 @@ defmodule MingaEditor.State.Workspace do
     %{workspace | session: session}
   end
 
-  @doc "Clears the agent session pid and returns the workspace to idle lifecycle status."
+  @doc "Clears the live agent session pid and returns the workspace to idle lifecycle status. Durable remote identity is preserved."
   @spec clear_session(t()) :: t()
   def clear_session(%__MODULE__{} = workspace) do
     workspace
     |> set_session(nil)
     |> set_agent_status(:idle)
   end
+
+  @doc "Sets durable remote metadata on the workspace."
+  @spec set_remote_session(t(), RemoteSession.t() | nil) :: t()
+  def set_remote_session(%__MODULE__{} = workspace, %RemoteSession{} = remote_session) do
+    %{workspace | remote_session: remote_session}
+  end
+
+  def set_remote_session(%__MODULE__{} = workspace, nil) do
+    %{workspace | remote_session: nil}
+  end
+
+  @doc "Sets durable remote metadata from its fields."
+  @spec put_remote_session(t(), String.t(), String.t(), connection_status()) :: t()
+  def put_remote_session(%__MODULE__{} = workspace, server_name, session_id, status \\ :connected) do
+    set_remote_session(workspace, RemoteSession.new(server_name, session_id, status))
+  end
+
+  @doc "Updates durable remote connection status when the workspace has remote metadata."
+  @spec set_remote_connection_status(t(), connection_status()) :: t()
+  def set_remote_connection_status(
+        %__MODULE__{remote_session: %RemoteSession{} = remote_session} = workspace,
+        status
+      ) do
+    set_remote_session(workspace, RemoteSession.set_connection_status(remote_session, status))
+  end
+
+  def set_remote_connection_status(%__MODULE__{} = workspace, _status), do: workspace
+
+  @doc "Clears durable remote metadata. Use only when the workspace no longer represents a remote session."
+  @spec clear_remote_session(t()) :: t()
+  def clear_remote_session(%__MODULE__{} = workspace) do
+    set_remote_session(workspace, nil)
+  end
+
+  @doc "Returns true when the workspace has durable remote metadata."
+  @spec remote?(t()) :: boolean()
+  def remote?(%__MODULE__{remote_session: %RemoteSession{}}), do: true
+  def remote?(%__MODULE__{}), do: false
+
+  @doc "Returns true when the workspace represents the remote server/session pair."
+  @spec matches_remote_session?(t(), String.t(), String.t()) :: boolean()
+  def matches_remote_session?(
+        %__MODULE__{remote_session: %RemoteSession{} = remote_session},
+        server_name,
+        session_id
+      ) do
+    RemoteSession.matches?(remote_session, server_name, session_id)
+  end
+
+  def matches_remote_session?(%__MODULE__{}, _server_name, _session_id), do: false
+
+  @doc "Returns true when the workspace represents any session on the remote server."
+  @spec remote_server?(t(), String.t()) :: boolean()
+  def remote_server?(%__MODULE__{remote_session: %RemoteSession{} = remote_session}, server_name) do
+    RemoteSession.server?(remote_session, server_name)
+  end
+
+  def remote_server?(%__MODULE__{}, _server_name), do: false
 
   @doc "Sets the agent UI state on the workspace."
   @spec set_agent_ui(t(), UIState.t()) :: t()

--- a/lib/minga_editor/state/workspace/remote_session.ex
+++ b/lib/minga_editor/state/workspace/remote_session.ex
@@ -1,0 +1,51 @@
+defmodule MingaEditor.State.Workspace.RemoteSession do
+  @moduledoc """
+  Durable remote session identity for an agent workspace.
+
+  Workspaces own remote identity. Tabs may project this data for display, but lifecycle code should read the workspace copy so reconnect and teardown still work when a file tab is active or the agent tab has been closed.
+  """
+
+  @typedoc "Remote connection status."
+  @type connection_status :: :connected | :disconnected | :ended | :unavailable
+
+  @typedoc "Durable remote session metadata for a workspace."
+  @type t :: %__MODULE__{
+          server_name: String.t(),
+          session_id: String.t(),
+          connection_status: connection_status()
+        }
+
+  @enforce_keys [:server_name, :session_id, :connection_status]
+  defstruct [:server_name, :session_id, :connection_status]
+
+  @doc "Creates durable remote metadata."
+  @spec new(String.t(), String.t(), connection_status()) :: t()
+  def new(server_name, session_id, status \\ :connected)
+      when is_binary(server_name) and is_binary(session_id) and
+             status in [:connected, :disconnected, :ended, :unavailable] do
+    %__MODULE__{server_name: server_name, session_id: session_id, connection_status: status}
+  end
+
+  @doc "Updates the connection status."
+  @spec set_connection_status(t(), connection_status()) :: t()
+  def set_connection_status(%__MODULE__{} = remote_session, status)
+      when status in [:connected, :disconnected, :ended, :unavailable] do
+    %{remote_session | connection_status: status}
+  end
+
+  @doc "Returns true when the remote metadata points at the server/session pair."
+  @spec matches?(t(), String.t(), String.t()) :: boolean()
+  def matches?(
+        %__MODULE__{server_name: server_name, session_id: session_id},
+        server_name,
+        session_id
+      ),
+      do: true
+
+  def matches?(%__MODULE__{}, _server_name, _session_id), do: false
+
+  @doc "Returns true when the remote metadata belongs to the server."
+  @spec server?(t(), String.t()) :: boolean()
+  def server?(%__MODULE__{server_name: server_name}, server_name), do: true
+  def server?(%__MODULE__{}, _server_name), do: false
+end

--- a/test/minga_editor/agent/concurrent_sessions_test.exs
+++ b/test/minga_editor/agent/concurrent_sessions_test.exs
@@ -4,10 +4,7 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
   switching tabs while one session is mid-stream does not interrupt
   it or route its events to the wrong tab.
 
-  These tests exercise per-tab session ownership: `Tab.session` is the
-  source of truth, and `AgentAccess.session/1` reads it through the
-  shell's `active_session/1` callback. The editor's
-  `state.shell_state.agent` struct holds rendering caches only.
+  These tests exercise per-workspace session ownership: workspaces are the source of truth, while legacy tab session fields remain only as locators for event routing and migration paths. The editor's `state.shell_state.agent` struct holds rendering caches only.
   """
 
   use ExUnit.Case, async: true
@@ -55,7 +52,20 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
         %{acc | tabs: acc.tabs ++ [tab], next_id: max(acc.next_id, tab.id + 1)}
       end)
 
-    %{tb | active_id: active_id}
+    tb
+    |> attach_agent_workspaces()
+    |> Map.put(:active_id, active_id)
+  end
+
+  defp attach_agent_workspaces(%TabBar{} = tb) do
+    Enum.reduce(tb.tabs, tb, fn
+      %Tab{kind: :agent, id: tab_id, label: label, session: session}, acc when is_pid(session) ->
+        {acc, workspace} = TabBar.add_workspace(acc, label, session)
+        TabBar.move_tab_to_workspace(acc, tab_id, workspace.id)
+
+      _tab, acc ->
+        acc
+    end)
   end
 
   defp agent_tab_context(agent_buf) do
@@ -73,8 +83,7 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
         active: win_id,
         next_id: win_id + 1
       },
-      viewport: Viewport.new(rows, cols),
-      agent_ui: UIState.new()
+      viewport: Viewport.new(rows, cols)
     }
   end
 

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -128,6 +128,14 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       tab =
         MingaEditor.State.Tab.new_agent(1, "Agent") |> MingaEditor.State.Tab.set_session(session)
 
+      tab_bar =
+        tab
+        |> MingaEditor.State.TabBar.new()
+        |> MingaEditor.State.TabBar.update_workspace(
+          0,
+          &MingaEditor.State.Workspace.set_session(&1, session)
+        )
+
       %EditorState{
         port_manager: nil,
         shell: MingaEditor.Shell.Traditional,
@@ -138,7 +146,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
         },
         shell_state: %MingaEditor.Shell.Traditional.State{
           status_msg: nil,
-          tab_bar: MingaEditor.State.TabBar.new(tab),
+          tab_bar: tab_bar,
           agent: %AgentState{
             runtime: %RuntimeState{status: :idle},
             error: nil,

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -61,10 +61,17 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       }
     }
 
-    # Active tab is an agent tab carrying the session pid; AgentAccess.session/1
-    # reads it through the Traditional shell's active_session/1.
+    # Active workspace owns the session pid; the tab field is a legacy mirror only.
     agent_tab = Tab.new_agent(1, "Agent") |> Tab.set_session(default_session)
-    tb = TabBar.new(agent_tab)
+
+    tb =
+      agent_tab
+      |> TabBar.new()
+      |> TabBar.update_workspace(0, fn workspace ->
+        workspace
+        |> WorkspaceModel.set_session(default_session)
+        |> WorkspaceModel.set_agent_ui(agentic)
+      end)
 
     %EditorState{
       port_manager: nil,

--- a/test/minga_editor/commands/agent_session_down_test.exs
+++ b/test/minga_editor/commands/agent_session_down_test.exs
@@ -15,6 +15,7 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace, as: WorkspaceModel
   alias MingaEditor.Viewport
   alias MingaEditor.Workspace
 
@@ -38,12 +39,19 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
 
   defp tab_bar_with_remote_session(session_pid) do
     {tb, agent_tab} = TabBar.insert(empty_tab_bar(), :agent, "Agent")
+    {tb, workspace} = TabBar.add_workspace(tb, "Remote", session_pid)
 
-    TabBar.update_tab(
-      tb,
+    tb
+    |> TabBar.update_tab(
       agent_tab.id,
       &Tab.set_remote_session(&1, "home", "session-1", session_pid)
     )
+    |> TabBar.move_tab_to_workspace(agent_tab.id, workspace.id)
+    |> TabBar.update_workspace(workspace.id, fn workspace ->
+      workspace
+      |> WorkspaceModel.set_session(session_pid)
+      |> WorkspaceModel.put_remote_session("home", "session-1", :connected)
+    end)
   end
 
   describe "handle_agent_session_down/3 with TabBar shell" do
@@ -108,8 +116,10 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
       state = build_state(tab_bar_with_remote_session(session_pid))
 
       result = BufferManagement.handle_agent_session_down(state, session_pid, :noconnection)
+      remote_workspace = TabBar.find_workspace_by_session(result.shell_state.tab_bar, session_pid)
       remote_tab = Enum.find(result.shell_state.tab_bar.tabs, &(&1.session == session_pid))
 
+      assert remote_workspace.remote_session.connection_status == :disconnected
       assert remote_tab.connection_status == :disconnected
       assert result.shell_state.status_msg == "[home] disconnected, reconnecting..."
     end

--- a/test/minga_editor/commands/agent_split_toggle_test.exs
+++ b/test/minga_editor/commands/agent_split_toggle_test.exs
@@ -13,6 +13,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.Window
@@ -93,9 +94,15 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       }
 
       {tb, at} = TabBar.add(tb, :agent, "Agent")
-      tb = TabBar.update_tab(tb, at.id, &Tab.set_session(&1, session_pid))
-      tb = TabBar.update_context(tb, at.id, agent_ctx)
-      tb = TabBar.switch_to(tb, file_tab.id)
+      {tb, agent_workspace} = TabBar.add_workspace(tb, "Agent", session_pid)
+
+      tb =
+        tb
+        |> TabBar.update_tab(at.id, &Tab.set_session(&1, session_pid))
+        |> TabBar.move_tab_to_workspace(at.id, agent_workspace.id)
+        |> TabBar.update_workspace(agent_workspace.id, &Workspace.set_agent_ui(&1, agentic))
+        |> TabBar.update_context(at.id, agent_ctx)
+        |> TabBar.switch_to(file_tab.id)
 
       state =
         put_in(state.workspace.agent_ui, %{
@@ -121,9 +128,16 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       }
 
       {tb, at} = TabBar.add(tb, :agent, "Agent")
-      tb = TabBar.update_tab(tb, at.id, &Tab.set_session(&1, session_pid))
-      tb = TabBar.update_context(tb, at.id, agent_ctx)
-      tb = TabBar.switch_to(tb, file_tab.id)
+      {tb, agent_workspace} = TabBar.add_workspace(tb, "Agent", session_pid)
+
+      tb =
+        tb
+        |> TabBar.update_tab(at.id, &Tab.set_session(&1, session_pid))
+        |> TabBar.move_tab_to_workspace(at.id, agent_workspace.id)
+        |> TabBar.update_workspace(agent_workspace.id, &Workspace.set_agent_ui(&1, agentic))
+        |> TabBar.update_context(at.id, agent_ctx)
+        |> TabBar.switch_to(file_tab.id)
+
       MingaEditor.State.set_tab_bar(state, tb)
     end
   end

--- a/test/minga_editor/commands/workspace_test.exs
+++ b/test/minga_editor/commands/workspace_test.exs
@@ -3,6 +3,8 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Command
+  alias MingaAgent.SessionManager
+  alias MingaEditor.Commands.AgentSession
   alias MingaEditor.Commands.Workspace
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -10,6 +12,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Windows
+  alias MingaEditor.State.Workspace, as: WorkspaceModel
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.WorkspaceIconSource
   alias MingaEditor.UI.Picker.WorkspaceSource
@@ -224,6 +227,28 @@ defmodule MingaEditor.Commands.WorkspaceTest do
       state = make_state()
       assert Workspace.workspace_close(state) == state
     end
+
+    test "stops the session owned by the closed workspace" do
+      {:ok, _session_id, session} = SessionManager.start_session([])
+      on_exit(fn -> stop_session(session) end)
+      ref = Process.monitor(session)
+
+      state = make_state() |> Workspace.workspace_next()
+
+      tab_bar =
+        TabBar.update_workspace(
+          state.shell_state.tab_bar,
+          1,
+          &WorkspaceModel.set_session(&1, session)
+        )
+
+      state = EditorState.set_tab_bar(state, tab_bar)
+      result = Workspace.workspace_close(state)
+
+      assert_receive {:DOWN, ^ref, :process, ^session, _reason}
+      assert TabBar.get_workspace(result.shell_state.tab_bar, 1) == nil
+      assert SessionManager.session_id_for_pid(session) == {:error, :not_found}
+    end
   end
 
   describe "workspace_list/1" do
@@ -245,6 +270,12 @@ defmodule MingaEditor.Commands.WorkspaceTest do
       assert String.ends_with?(active_item.label, " •")
     end
   end
+
+  defp stop_session(pid) when is_pid(pid) do
+    AgentSession.stop_session_pid(pid)
+  end
+
+  defp stop_session(_pid), do: :ok
 
   describe "workspace_set_icon/1" do
     test "opens the icon picker for the active workspace" do

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -416,7 +416,15 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
     }
 
     tab = Tab.new_agent(1, "Agent") |> Tab.set_session(session)
-    tab_bar = TabBar.new(tab)
+
+    tab_bar =
+      tab
+      |> TabBar.new()
+      |> TabBar.update_workspace(0, fn active_workspace ->
+        active_workspace
+        |> MingaEditor.State.Workspace.set_session(session)
+        |> MingaEditor.State.Workspace.set_agent_ui(workspace.agent_ui)
+      end)
 
     state
     |> Map.put(:workspace, workspace)

--- a/test/minga_editor/remote_node_events_test.exs
+++ b/test/minga_editor/remote_node_events_test.exs
@@ -3,9 +3,12 @@ defmodule MingaEditor.RemoteNodeEventsTest do
 
   alias Minga.Distribution.Events.NodeConnectedEvent
   alias Minga.Distribution.Events.NodeDisconnectedEvent
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Project.FileRef
   alias MingaAgent.SessionManager
   alias MingaAgent.SessionStore
   alias MingaAgent.TurnUsage
+  alias MingaEditor.Agent.UIState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Remote
@@ -52,6 +55,38 @@ defmodule MingaEditor.RemoteNodeEventsTest do
     assert state.shell_state.status_msg == "[home] disconnected, reconnecting..."
   end
 
+  test "node_disconnected marks active remote workspace when a file tab is active" do
+    {:ok, remote_session_id, session} = SessionManager.start_session([])
+    on_exit(fn -> SessionManager.stop_session_by_pid(session) end)
+
+    ctx = start_editor("initial")
+
+    %{workspace_id: workspace_id, agent_tab_id: agent_tab_id} =
+      seed_remote_workspace(ctx.editor, remote_session_id, session, active: :file)
+
+    send(ctx.editor, {
+      :minga_event,
+      :node_disconnected,
+      %NodeDisconnectedEvent{
+        server_name: "home",
+        node: :"missing@127.0.0.1",
+        reason: :nodedown,
+        disconnected_at: DateTime.utc_now()
+      }
+    })
+
+    state = editor_state(ctx)
+    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+    agent_tab = TabBar.get(state.shell_state.tab_bar, agent_tab_id)
+
+    assert TabBar.active(state.shell_state.tab_bar).kind == :file
+    assert Remote.server_status(state.remote, "home") == :disconnected
+    assert workspace.remote_session.connection_status == :disconnected
+    assert agent_tab.connection_status == :disconnected
+    assert state.shell_state.agent.error == "[home] disconnected, reconnecting..."
+    assert state.shell_state.status_msg == "[home] disconnected, reconnecting..."
+  end
+
   test "node_connected remote reconnect syncs the owning workspace session" do
     {:ok, _old_session_id, old_session} = SessionManager.start_session([])
     {:ok, new_session_id, new_session} = SessionManager.start_session([])
@@ -81,7 +116,84 @@ defmodule MingaEditor.RemoteNodeEventsTest do
     assert tab.session == new_session
     assert tab.connection_status == :connected
     assert workspace.session == new_session
+    assert workspace.remote_session.session_id == new_session_id
+    assert workspace.remote_session.connection_status == :connected
     assert AgentAccess.session(state) == new_session
+  end
+
+  test "node_connected reconnects when a file tab is active in the remote workspace" do
+    {:ok, _old_session_id, old_session} = SessionManager.start_session([])
+    {:ok, new_session_id, new_session} = SessionManager.start_session([])
+
+    on_exit(fn ->
+      SessionManager.stop_session_by_pid(old_session)
+      SessionManager.stop_session_by_pid(new_session)
+    end)
+
+    ctx = start_editor("initial")
+
+    %{workspace_id: workspace_id, agent_tab_id: agent_tab_id} =
+      seed_remote_workspace(ctx.editor, new_session_id, old_session, active: :file)
+
+    send(ctx.editor, {
+      :minga_event,
+      :node_connected,
+      %NodeConnectedEvent{
+        server_name: "home",
+        node: node(),
+        connected_at: DateTime.utc_now()
+      }
+    })
+
+    state = editor_state(ctx)
+    tab = TabBar.active(state.shell_state.tab_bar)
+    agent_tab = TabBar.get(state.shell_state.tab_bar, agent_tab_id)
+    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+
+    assert tab.kind == :file
+    assert TabBar.active_workspace_id(state.shell_state.tab_bar) == workspace_id
+    assert agent_tab.session == new_session
+    assert agent_tab.connection_status == :connected
+    assert workspace.session == new_session
+    assert workspace.remote_session.connection_status == :connected
+    assert AgentAccess.session(state) == new_session
+  end
+
+  test "node_connected reconnects when only workspace remote metadata remains" do
+    {:ok, _old_session_id, old_session} = SessionManager.start_session([])
+    {:ok, new_session_id, new_session} = SessionManager.start_session([])
+
+    on_exit(fn ->
+      SessionManager.stop_session_by_pid(old_session)
+      SessionManager.stop_session_by_pid(new_session)
+    end)
+
+    ctx = start_editor("initial")
+
+    %{workspace_id: workspace_id} =
+      seed_remote_workspace(ctx.editor, new_session_id, old_session,
+        active: :file,
+        close_agent?: true
+      )
+
+    send(ctx.editor, {
+      :minga_event,
+      :node_connected,
+      %NodeConnectedEvent{
+        server_name: "home",
+        node: node(),
+        connected_at: DateTime.utc_now()
+      }
+    })
+
+    state = editor_state(ctx)
+    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+
+    assert TabBar.active(state.shell_state.tab_bar).kind == :file
+    assert workspace.session == new_session
+    assert workspace.remote_session.connection_status == :connected
+    assert AgentAccess.session(state) == new_session
+    refute Enum.any?(state.shell_state.tab_bar.tabs, &(&1.kind == :agent))
   end
 
   test "node_connected unavailable remote restore clears stale workspace session" do
@@ -91,7 +203,11 @@ defmodule MingaEditor.RemoteNodeEventsTest do
 
     ctx = start_editor("initial")
     missing_session_id = "missing-#{System.unique_integer([:positive])}"
-    workspace_id = seed_remote_agent_workspace(ctx.editor, missing_session_id, old_session)
+
+    %{workspace_id: workspace_id, file_ref: file_ref} =
+      seed_remote_workspace(ctx.editor, missing_session_id, old_session,
+        agent_status: :tool_executing
+      )
 
     send(ctx.editor, {
       :minga_event,
@@ -111,6 +227,10 @@ defmodule MingaEditor.RemoteNodeEventsTest do
     assert tab.connection_status == :unavailable
     assert workspace.session == nil
     assert workspace.agent_status == :idle
+    assert workspace.remote_session.session_id == missing_session_id
+    assert workspace.remote_session.connection_status == :unavailable
+    assert workspace.files == [file_ref]
+    assert prompt_text(workspace.agent_ui) == "remote draft"
     assert AgentAccess.session(state) == nil
   end
 
@@ -126,7 +246,9 @@ defmodule MingaEditor.RemoteNodeEventsTest do
     assert :ok = SessionStore.save(ended_session_data(ended_session_id))
 
     ctx = start_editor("initial")
-    workspace_id = seed_remote_agent_workspace(ctx.editor, ended_session_id, old_session)
+
+    %{workspace_id: workspace_id, file_ref: file_ref} =
+      seed_remote_workspace(ctx.editor, ended_session_id, old_session, agent_status: :thinking)
 
     send(ctx.editor, {
       :minga_event,
@@ -146,6 +268,10 @@ defmodule MingaEditor.RemoteNodeEventsTest do
     assert tab.connection_status == :ended
     assert workspace.session == nil
     assert workspace.agent_status == :idle
+    assert workspace.remote_session.session_id == ended_session_id
+    assert workspace.remote_session.connection_status == :ended
+    assert workspace.files == [file_ref]
+    assert prompt_text(workspace.agent_ui) == "remote draft"
     assert AgentAccess.session(state) == nil
   end
 
@@ -165,9 +291,17 @@ defmodule MingaEditor.RemoteNodeEventsTest do
   end
 
   defp seed_remote_agent_workspace(editor, remote_session_id, old_session) do
+    %{workspace_id: workspace_id} = seed_remote_workspace(editor, remote_session_id, old_session)
+    workspace_id
+  end
+
+  defp seed_remote_workspace(editor, remote_session_id, old_session, opts \\ []) do
     parent = self()
 
     :sys.replace_state(editor, fn state ->
+      file_ref = FileRef.from_buffer(state.workspace.buffers.active)
+      ui = UIState.new() |> put_prompt("remote draft")
+      agent_status = Keyword.get(opts, :agent_status, :idle)
       {tab_bar, agent_tab} = TabBar.add(state.shell_state.tab_bar, :agent, "Remote Agent")
       {tab_bar, workspace} = TabBar.add_workspace(tab_bar, "Remote Agent", old_session)
 
@@ -176,15 +310,55 @@ defmodule MingaEditor.RemoteNodeEventsTest do
         |> TabBar.update_tab(agent_tab.id, fn tab ->
           Tab.set_remote_session(tab, "home", remote_session_id, old_session)
         end)
+        |> TabBar.move_tab_to_workspace(1, workspace.id)
         |> TabBar.move_tab_to_workspace(agent_tab.id, workspace.id)
-        |> TabBar.update_workspace(workspace.id, &Workspace.set_session(&1, old_session))
-        |> TabBar.switch_to(agent_tab.id)
+        |> TabBar.update_workspace(workspace.id, fn workspace ->
+          workspace
+          |> Workspace.set_session(old_session)
+          |> Workspace.put_remote_session("home", remote_session_id, :disconnected)
+          |> Workspace.set_agent_status(agent_status)
+          |> Workspace.add_file(file_ref)
+          |> Workspace.set_agent_ui(ui)
+        end)
+        |> maybe_remove_agent_tab(agent_tab.id, Keyword.get(opts, :close_agent?, false))
+        |> switch_seed_active_tab(agent_tab.id, Keyword.get(opts, :active, :agent))
 
-      send(parent, {:workspace_id, workspace.id})
+      send(
+        parent,
+        {:workspace_info,
+         %{workspace_id: workspace.id, agent_tab_id: agent_tab.id, file_ref: file_ref}}
+      )
+
       EditorState.set_tab_bar(state, tab_bar)
     end)
 
-    assert_receive {:workspace_id, workspace_id}
-    workspace_id
+    assert_receive {:workspace_info, info}
+    info
   end
+
+  defp maybe_remove_agent_tab(%TabBar{} = tab_bar, _agent_tab_id, false), do: tab_bar
+
+  defp maybe_remove_agent_tab(%TabBar{} = tab_bar, agent_tab_id, true) do
+    case TabBar.remove(tab_bar, agent_tab_id) do
+      {:ok, tab_bar} -> tab_bar
+      :last_tab -> tab_bar
+    end
+  end
+
+  defp switch_seed_active_tab(%TabBar{} = tab_bar, _agent_tab_id, :file),
+    do: TabBar.switch_to(tab_bar, 1)
+
+  defp switch_seed_active_tab(%TabBar{} = tab_bar, agent_tab_id, :agent) do
+    if TabBar.get(tab_bar, agent_tab_id),
+      do: TabBar.switch_to(tab_bar, agent_tab_id),
+      else: TabBar.switch_to(tab_bar, 1)
+  end
+
+  defp put_prompt(%UIState{} = ui, text) do
+    ui = UIState.ensure_prompt_buffer(ui)
+    BufferProcess.replace_content(ui.panel.prompt_buffer, text)
+    ui
+  end
+
+  defp prompt_text(%UIState{} = ui), do: UIState.input_text(ui.panel)
 end

--- a/test/minga_editor/remote_node_events_test.exs
+++ b/test/minga_editor/remote_node_events_test.exs
@@ -3,7 +3,15 @@ defmodule MingaEditor.RemoteNodeEventsTest do
 
   alias Minga.Distribution.Events.NodeConnectedEvent
   alias Minga.Distribution.Events.NodeDisconnectedEvent
+  alias MingaAgent.SessionManager
+  alias MingaAgent.SessionStore
+  alias MingaAgent.TurnUsage
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Remote
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
 
   test "node_connected marks the remote server connected" do
     ctx = start_editor("initial")
@@ -42,5 +50,141 @@ defmodule MingaEditor.RemoteNodeEventsTest do
 
     assert Remote.server_status(state.remote, "home") == :disconnected
     assert state.shell_state.status_msg == "[home] disconnected, reconnecting..."
+  end
+
+  test "node_connected remote reconnect syncs the owning workspace session" do
+    {:ok, _old_session_id, old_session} = SessionManager.start_session([])
+    {:ok, new_session_id, new_session} = SessionManager.start_session([])
+
+    on_exit(fn ->
+      SessionManager.stop_session_by_pid(old_session)
+      SessionManager.stop_session_by_pid(new_session)
+    end)
+
+    ctx = start_editor("initial")
+    workspace_id = seed_remote_agent_workspace(ctx.editor, new_session_id, old_session)
+
+    send(ctx.editor, {
+      :minga_event,
+      :node_connected,
+      %NodeConnectedEvent{
+        server_name: "home",
+        node: node(),
+        connected_at: DateTime.utc_now()
+      }
+    })
+
+    state = editor_state(ctx)
+    tab = TabBar.active(state.shell_state.tab_bar)
+    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+
+    assert tab.session == new_session
+    assert tab.connection_status == :connected
+    assert workspace.session == new_session
+    assert AgentAccess.session(state) == new_session
+  end
+
+  test "node_connected unavailable remote restore clears stale workspace session" do
+    {:ok, _old_session_id, old_session} = SessionManager.start_session([])
+
+    on_exit(fn -> SessionManager.stop_session_by_pid(old_session) end)
+
+    ctx = start_editor("initial")
+    missing_session_id = "missing-#{System.unique_integer([:positive])}"
+    workspace_id = seed_remote_agent_workspace(ctx.editor, missing_session_id, old_session)
+
+    send(ctx.editor, {
+      :minga_event,
+      :node_connected,
+      %NodeConnectedEvent{
+        server_name: "home",
+        node: node(),
+        connected_at: DateTime.utc_now()
+      }
+    })
+
+    state = editor_state(ctx)
+    tab = TabBar.active(state.shell_state.tab_bar)
+    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+
+    assert tab.session == nil
+    assert tab.connection_status == :unavailable
+    assert workspace.session == nil
+    assert workspace.agent_status == :idle
+    assert AgentAccess.session(state) == nil
+  end
+
+  test "node_connected ended remote restore clears stale workspace session" do
+    {:ok, _old_session_id, old_session} = SessionManager.start_session([])
+    ended_session_id = "ended-#{System.unique_integer([:positive])}"
+
+    on_exit(fn ->
+      SessionManager.stop_session_by_pid(old_session)
+      SessionStore.delete(ended_session_id)
+    end)
+
+    assert :ok = SessionStore.save(ended_session_data(ended_session_id))
+
+    ctx = start_editor("initial")
+    workspace_id = seed_remote_agent_workspace(ctx.editor, ended_session_id, old_session)
+
+    send(ctx.editor, {
+      :minga_event,
+      :node_connected,
+      %NodeConnectedEvent{
+        server_name: "home",
+        node: node(),
+        connected_at: DateTime.utc_now()
+      }
+    })
+
+    state = editor_state(ctx)
+    tab = TabBar.active(state.shell_state.tab_bar)
+    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+
+    assert tab.session == nil
+    assert tab.connection_status == :ended
+    assert workspace.session == nil
+    assert workspace.agent_status == :idle
+    assert AgentAccess.session(state) == nil
+  end
+
+  defp ended_session_data(session_id) do
+    now = DateTime.to_iso8601(DateTime.utc_now())
+
+    %{
+      id: session_id,
+      timestamp: now,
+      last_message_at: now,
+      title: "Ended remote session",
+      model_name: "test-model",
+      provider_name: "test-provider",
+      messages: [{:assistant, "Session finished"}],
+      usage: %TurnUsage{}
+    }
+  end
+
+  defp seed_remote_agent_workspace(editor, remote_session_id, old_session) do
+    parent = self()
+
+    :sys.replace_state(editor, fn state ->
+      {tab_bar, agent_tab} = TabBar.add(state.shell_state.tab_bar, :agent, "Remote Agent")
+      {tab_bar, workspace} = TabBar.add_workspace(tab_bar, "Remote Agent", old_session)
+
+      tab_bar =
+        tab_bar
+        |> TabBar.update_tab(agent_tab.id, fn tab ->
+          Tab.set_remote_session(tab, "home", remote_session_id, old_session)
+        end)
+        |> TabBar.move_tab_to_workspace(agent_tab.id, workspace.id)
+        |> TabBar.update_workspace(workspace.id, &Workspace.set_session(&1, old_session))
+        |> TabBar.switch_to(agent_tab.id)
+
+      send(parent, {:workspace_id, workspace.id})
+      EditorState.set_tab_bar(state, tab_bar)
+    end)
+
+    assert_receive {:workspace_id, workspace_id}
+    workspace_id
   end
 end

--- a/test/minga_editor/state/agent_workspace_lifecycle_test.exs
+++ b/test/minga_editor/state/agent_workspace_lifecycle_test.exs
@@ -1,0 +1,176 @@
+defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
+  @moduledoc """
+  Tests workspace ownership for agent session and UI state.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Windows
+  alias MingaEditor.State.Workspace
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Window
+
+  test "switching file tabs in a workspace preserves workspace agent UI" do
+    state = state_with_agent_workspace_tabs()
+    state = MingaEditor.State.AgentAccess.update_agent_ui(state, &put_prompt(&1, "draft one"))
+
+    state = EditorState.switch_tab(state, 2)
+
+    assert prompt_text(state.workspace.agent_ui) == "draft one"
+    assert prompt_text(TabBar.active_workspace(state.shell_state.tab_bar).agent_ui) == "draft one"
+  end
+
+  test "switching to a workspace without agent UI clears the live mirror" do
+    state = state_with_tabs()
+    ui_two = put_prompt(UIState.new(), "workspace two")
+    {tab_bar, workspace_two} = TabBar.add_workspace(state.shell_state.tab_bar, "Agent")
+
+    tab_bar =
+      tab_bar
+      |> TabBar.move_tab_to_workspace(2, workspace_two.id)
+      |> Map.put(:active_id, 2)
+      |> TabBar.update_workspace(workspace_two.id, &Workspace.set_agent_ui(&1, ui_two))
+
+    state = %{
+      state
+      | shell_state: %{state.shell_state | tab_bar: tab_bar},
+        workspace: %{state.workspace | agent_ui: ui_two}
+    }
+
+    state = EditorState.switch_tab(state, 1)
+
+    assert prompt_text(state.workspace.agent_ui) == ""
+  end
+
+  test "closing a workspace clears stale agent UI after tabs migrate to manual" do
+    state = state_with_tabs()
+    ui_two = put_prompt(UIState.new(), "workspace two")
+    {tab_bar, workspace_two} = TabBar.add_workspace(state.shell_state.tab_bar, "Agent")
+
+    tab_bar =
+      tab_bar
+      |> TabBar.move_tab_to_workspace(2, workspace_two.id)
+      |> Map.put(:active_id, 2)
+      |> TabBar.update_workspace(workspace_two.id, &Workspace.set_agent_ui(&1, ui_two))
+
+    state = %{
+      state
+      | shell_state: %{state.shell_state | tab_bar: tab_bar},
+        workspace: %{state.workspace | agent_ui: ui_two}
+    }
+
+    state = MingaEditor.Commands.Workspace.workspace_close(state)
+
+    assert TabBar.active_workspace_id(state.shell_state.tab_bar) == 0
+    assert prompt_text(state.workspace.agent_ui) == ""
+  end
+
+  test "switching workspaces restores that workspace's agent UI and session" do
+    state = state_with_agent_workspace_tabs()
+
+    session_one =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    session_two =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    ui_one = put_prompt(UIState.new(), "workspace one")
+    ui_two = put_prompt(UIState.new(), "workspace two")
+
+    {tab_bar, workspace_two} =
+      TabBar.add_workspace(state.shell_state.tab_bar, "Agent", session_two)
+
+    workspace_one_id = TabBar.active_workspace_id(tab_bar)
+
+    tab_bar =
+      tab_bar
+      |> TabBar.move_tab_to_workspace(2, workspace_two.id)
+      |> TabBar.update_workspace(workspace_one_id, fn workspace ->
+        workspace
+        |> Workspace.set_session(session_one)
+        |> Workspace.set_agent_ui(ui_one)
+      end)
+      |> TabBar.update_workspace(workspace_two.id, &Workspace.set_agent_ui(&1, ui_two))
+
+    state = %{
+      state
+      | shell_state: %{state.shell_state | tab_bar: tab_bar},
+        workspace: %{state.workspace | agent_ui: ui_one}
+    }
+
+    state = EditorState.switch_tab(state, 2)
+
+    assert prompt_text(state.workspace.agent_ui) == "workspace two"
+    assert MingaEditor.State.AgentAccess.session(state) == session_two
+  end
+
+  defp state_with_agent_workspace_tabs do
+    state = state_with_tabs()
+    {tab_bar, workspace} = TabBar.add_workspace(state.shell_state.tab_bar, "Agent")
+
+    tab_bar =
+      tab_bar
+      |> TabBar.move_tab_to_workspace(1, workspace.id)
+      |> TabBar.move_tab_to_workspace(2, workspace.id)
+      |> TabBar.update_workspace(workspace.id, &Workspace.set_agent_ui(&1, UIState.new()))
+
+    %{state | shell_state: %{state.shell_state | tab_bar: tab_bar}}
+  end
+
+  defp state_with_tabs do
+    {:ok, buf_one} = BufferProcess.start_link(content: "one")
+    {:ok, buf_two} = BufferProcess.start_link(content: "two")
+
+    tab_one = Tab.new_file(1, "one")
+    tab_two = Tab.new_file(2, "two")
+
+    tab_bar = %TabBar{
+      tabs: [tab_one, tab_two],
+      active_id: 1,
+      next_id: 3,
+      workspaces: [Workspace.new_manual(nil)],
+      next_workspace_id: 1
+    }
+
+    %EditorState{
+      port_manager: nil,
+      shell: MingaEditor.Shell.Traditional,
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: VimState.new(),
+        buffers: %Buffers{active: buf_one, list: [buf_one, buf_two], active_index: 0},
+        windows: %Windows{
+          tree: {:leaf, 1},
+          map: %{1 => Window.new(1, buf_one, 24, 80)},
+          active: 1,
+          next_id: 2
+        },
+        agent_ui: UIState.new()
+      },
+      shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: tab_bar}
+    }
+  end
+
+  defp put_prompt(%UIState{} = ui, text) do
+    ui = UIState.ensure_prompt_buffer(ui)
+    BufferProcess.replace_content(ui.panel.prompt_buffer, text)
+    ui
+  end
+
+  defp prompt_text(%UIState{} = ui), do: UIState.input_text(ui.panel)
+end

--- a/test/minga_editor/state/agent_workspace_lifecycle_test.exs
+++ b/test/minga_editor/state/agent_workspace_lifecycle_test.exs
@@ -238,6 +238,104 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     assert TabBar.get_workspace(state.shell_state.tab_bar, workspace_id) == nil
   end
 
+  test "closing a remote agent workspace stops the session and scrubs migrated tab projections" do
+    {:ok, _session_id, session} = SessionManager.start_session([])
+    ref = Process.monitor(session)
+
+    {state, workspace_id, _file_ref, agent_tab_id} =
+      state_with_active_remote_agent_workspace(session)
+
+    state = MingaEditor.Commands.Workspace.workspace_close(state)
+    assert_receive {:DOWN, ^ref, :process, ^session, _reason}
+
+    tab_bar = state.shell_state.tab_bar
+    agent_tab = TabBar.get(tab_bar, agent_tab_id)
+
+    assert TabBar.get_workspace(tab_bar, workspace_id) == nil
+    assert agent_tab.group_id == 0
+    assert agent_tab.session == nil
+    assert agent_tab.server_name == nil
+    assert agent_tab.remote_session_id == nil
+    assert agent_tab.connection_status == nil
+    assert agent_tab.agent_status == nil
+    refute agent_tab.attention
+  end
+
+  test "closing the agent tab preserves workspace files draft and remote metadata" do
+    {:ok, _session_id, session} = SessionManager.start_session([])
+    on_exit(fn -> stop_session(session) end)
+
+    {state, workspace_id, file_ref, agent_tab_id} =
+      state_with_active_remote_agent_workspace(session)
+
+    state = BufferManagement.execute(state, :force_quit)
+    tab_bar = state.shell_state.tab_bar
+    workspace = TabBar.get_workspace(tab_bar, workspace_id)
+
+    assert TabBar.get(tab_bar, agent_tab_id) == nil
+    assert workspace.session == session
+    assert workspace.files == [file_ref]
+    assert prompt_text(workspace.agent_ui) == "restart draft"
+    assert workspace.remote_session.server_name == "home"
+    assert workspace.remote_session.session_id == "session-1"
+    assert workspace.remote_session.connection_status == :connected
+  end
+
+  test "stop_current_session from file tab after closing remote agent tab routes through workspace metadata" do
+    {:ok, session_id, session} = SessionManager.start_session([])
+    on_exit(fn -> stop_session(session) end)
+    ref = Process.monitor(session)
+
+    {state, workspace_id, file_ref, agent_tab_id} =
+      state_with_active_remote_agent_workspace(session, session_id)
+
+    state =
+      state
+      |> BufferManagement.execute(:force_quit)
+      |> EditorState.switch_tab(1)
+
+    tab_bar = state.shell_state.tab_bar
+    workspace = TabBar.get_workspace(tab_bar, workspace_id)
+
+    assert TabBar.get(tab_bar, agent_tab_id) == nil
+    assert TabBar.active(tab_bar).kind == :file
+    assert TabBar.active_workspace_id(tab_bar) == workspace_id
+    assert workspace.session == session
+    assert workspace.remote_session.session_id == session_id
+
+    state = AgentSession.stop_current_session(state)
+    assert_receive {:DOWN, ^ref, :process, ^session, _reason}
+
+    state = BufferManagement.handle_agent_session_down(state, session, :normal)
+    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+
+    assert workspace.session == nil
+    assert workspace.agent_status == :idle
+    assert workspace.files == [file_ref]
+    assert prompt_text(workspace.agent_ui) == "restart draft"
+    assert workspace.remote_session.server_name == "home"
+    assert workspace.remote_session.session_id == session_id
+    assert workspace.remote_session.connection_status == :connected
+    refute Enum.any?(state.shell_state.tab_bar.tabs, &(&1.kind == :agent))
+  end
+
+  test "stop_current_session from file tab stops workspace session and preserves files and draft after cleanup" do
+    {:ok, _session_id, session} = SessionManager.start_session([])
+    ref = Process.monitor(session)
+    {state, workspace_id, file_ref} = state_with_active_agent_workspace(session)
+    state = EditorState.switch_tab(state, 1)
+
+    state = AgentSession.stop_current_session(state)
+    assert_receive {:DOWN, ^ref, :process, ^session, _reason}
+
+    state = BufferManagement.handle_agent_session_down(state, session, :shutdown)
+    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+
+    assert workspace.session == nil
+    assert workspace.files == [file_ref]
+    assert prompt_text(workspace.agent_ui) == "restart draft"
+  end
+
   defp state_with_agent_workspace_tabs do
     state = state_with_tabs()
     {tab_bar, workspace} = TabBar.add_workspace(state.shell_state.tab_bar, "Agent")
@@ -277,6 +375,22 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
       |> EditorState.update_workspace(&MingaEditor.Workspace.State.set_agent_ui(&1, ui))
 
     {state, workspace.id, file_ref}
+  end
+
+  defp state_with_active_remote_agent_workspace(session, remote_session_id \\ "session-1")
+       when is_pid(session) and is_binary(remote_session_id) do
+    {state, workspace_id, file_ref} = state_with_active_agent_workspace(session)
+    agent_tab_id = TabBar.active(state.shell_state.tab_bar).id
+
+    tab_bar =
+      state.shell_state.tab_bar
+      |> TabBar.update_workspace(workspace_id, fn workspace ->
+        Workspace.put_remote_session(workspace, "home", remote_session_id, :connected)
+      end)
+      |> TabBar.sync_workspace_agent_tab_projection(workspace_id)
+
+    state = EditorState.set_tab_bar(state, tab_bar)
+    {state, workspace_id, file_ref, agent_tab_id}
   end
 
   defp state_with_tabs do

--- a/test/minga_editor/state/agent_workspace_lifecycle_test.exs
+++ b/test/minga_editor/state/agent_workspace_lifecycle_test.exs
@@ -6,7 +6,12 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Project.FileRef
+  alias MingaAgent.SessionManager
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Commands.AgentSession
+  alias MingaEditor.Commands.BufferManagement
+  alias MingaEditor.Shell.Traditional
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
@@ -35,14 +40,13 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     tab_bar =
       tab_bar
       |> TabBar.move_tab_to_workspace(2, workspace_two.id)
-      |> Map.put(:active_id, 2)
+      |> TabBar.switch_to(2)
       |> TabBar.update_workspace(workspace_two.id, &Workspace.set_agent_ui(&1, ui_two))
 
-    state = %{
+    state =
       state
-      | shell_state: %{state.shell_state | tab_bar: tab_bar},
-        workspace: %{state.workspace | agent_ui: ui_two}
-    }
+      |> EditorState.set_tab_bar(tab_bar)
+      |> EditorState.update_workspace(&MingaEditor.Workspace.State.set_agent_ui(&1, ui_two))
 
     state = EditorState.switch_tab(state, 1)
 
@@ -57,14 +61,13 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     tab_bar =
       tab_bar
       |> TabBar.move_tab_to_workspace(2, workspace_two.id)
-      |> Map.put(:active_id, 2)
+      |> TabBar.switch_to(2)
       |> TabBar.update_workspace(workspace_two.id, &Workspace.set_agent_ui(&1, ui_two))
 
-    state = %{
+    state =
       state
-      | shell_state: %{state.shell_state | tab_bar: tab_bar},
-        workspace: %{state.workspace | agent_ui: ui_two}
-    }
+      |> EditorState.set_tab_bar(tab_bar)
+      |> EditorState.update_workspace(&MingaEditor.Workspace.State.set_agent_ui(&1, ui_two))
 
     state = MingaEditor.Commands.Workspace.workspace_close(state)
 
@@ -107,16 +110,132 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
       end)
       |> TabBar.update_workspace(workspace_two.id, &Workspace.set_agent_ui(&1, ui_two))
 
-    state = %{
+    state =
       state
-      | shell_state: %{state.shell_state | tab_bar: tab_bar},
-        workspace: %{state.workspace | agent_ui: ui_one}
-    }
+      |> EditorState.set_tab_bar(tab_bar)
+      |> EditorState.update_workspace(&MingaEditor.Workspace.State.set_agent_ui(&1, ui_one))
 
     state = EditorState.switch_tab(state, 2)
 
     assert prompt_text(state.workspace.agent_ui) == "workspace two"
     assert MingaEditor.State.AgentAccess.session(state) == session_two
+  end
+
+  test "restarting an active agent workspace reuses the workspace and preserves files and UI" do
+    {:ok, _session_id, old_session} = SessionManager.start_session([])
+    on_exit(fn -> stop_session(old_session) end)
+    old_ref = Process.monitor(old_session)
+    {state, workspace_id, file_ref} = state_with_active_agent_workspace(old_session)
+
+    state = AgentSession.restart_session(state, "Restarting agent")
+    new_session = MingaEditor.State.AgentAccess.session(state)
+    on_exit(fn -> stop_session(new_session) end)
+
+    assert_receive {:DOWN, ^old_ref, :process, ^old_session, _reason}
+    assert is_pid(new_session)
+    refute new_session == old_session
+
+    tab_bar = state.shell_state.tab_bar
+    assert TabBar.active_workspace_id(tab_bar) == workspace_id
+    workspace = TabBar.get_workspace(tab_bar, workspace_id)
+    assert workspace.session == new_session
+    assert workspace.files == [file_ref]
+    assert prompt_text(workspace.agent_ui) == "restart draft"
+    assert prompt_text(state.workspace.agent_ui) == "restart draft"
+    assert TabBar.active(tab_bar).session == new_session
+    assert Enum.count(tab_bar.workspaces, &(&1.kind == :agent)) == 1
+  end
+
+  test "restarting from a file tab reuses the active agent workspace" do
+    {:ok, _session_id, old_session} = SessionManager.start_session([])
+    on_exit(fn -> stop_session(old_session) end)
+    old_ref = Process.monitor(old_session)
+    {state, workspace_id, file_ref} = state_with_active_agent_workspace(old_session)
+    agent_tab_id = TabBar.active(state.shell_state.tab_bar).id
+
+    state = EditorState.switch_tab(state, 1)
+    assert TabBar.active(state.shell_state.tab_bar).kind == :file
+    assert TabBar.active_workspace_id(state.shell_state.tab_bar) == workspace_id
+
+    state = AgentSession.restart_session(state, "Restarting agent")
+    new_session = MingaEditor.State.AgentAccess.session(state)
+    on_exit(fn -> stop_session(new_session) end)
+
+    assert_receive {:DOWN, ^old_ref, :process, ^old_session, _reason}
+    assert is_pid(new_session)
+    refute new_session == old_session
+
+    tab_bar = state.shell_state.tab_bar
+    workspace = TabBar.get_workspace(tab_bar, workspace_id)
+    agent_tab = TabBar.get(tab_bar, agent_tab_id)
+
+    assert TabBar.active(tab_bar).kind == :file
+    assert TabBar.active_workspace_id(tab_bar) == workspace_id
+    assert workspace.session == new_session
+    assert workspace.files == [file_ref]
+    assert prompt_text(workspace.agent_ui) == "restart draft"
+    assert prompt_text(state.workspace.agent_ui) == "restart draft"
+    assert agent_tab.session == new_session
+    refute Enum.any?(tab_bar.tabs, &(&1.session == old_session))
+    refute Enum.any?(tab_bar.workspaces, &(&1.session == old_session))
+    assert Enum.count(tab_bar.workspaces, &(&1.kind == :agent)) == 1
+  end
+
+  test "GUI workspace close stops the owned session and refreshes the live mirror" do
+    {:ok, _session_id, session} = SessionManager.start_session([])
+    on_exit(fn -> stop_session(session) end)
+    ref = Process.monitor(session)
+    {state, workspace_id, _file_ref} = state_with_active_agent_workspace(session)
+
+    {shell_state, workspace} =
+      Traditional.handle_gui_action(
+        state.shell_state,
+        state.workspace,
+        {:workspace_close, workspace_id}
+      )
+
+    assert_receive {:DOWN, ^ref, :process, ^session, _reason}
+    assert TabBar.get_workspace(shell_state.tab_bar, workspace_id) == nil
+    assert TabBar.active_workspace_id(shell_state.tab_bar) == 0
+    assert prompt_text(workspace.agent_ui) == ""
+    assert SessionManager.session_id_for_pid(session) == {:error, :not_found}
+  end
+
+  test "session-down cleanup clears session and status while preserving draft and file membership" do
+    session = self()
+    {state, workspace_id, file_ref} = state_with_active_agent_workspace(session)
+
+    state = BufferManagement.handle_agent_session_down(state, session, :shutdown)
+    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+
+    assert workspace.session == nil
+    assert workspace.agent_status == :idle
+    assert workspace.files == [file_ref]
+    assert prompt_text(workspace.agent_ui) == "restart draft"
+    assert prompt_text(state.workspace.agent_ui) == "restart draft"
+
+    state = EditorState.switch_tab(state, 2)
+    assert prompt_text(state.workspace.agent_ui) == ""
+
+    state = EditorState.switch_tab(state, 3)
+    assert prompt_text(state.workspace.agent_ui) == "restart draft"
+  end
+
+  test "closing a file tab preserves workspace file membership until workspace close" do
+    {:ok, _session_id, session} = SessionManager.start_session([])
+    on_exit(fn -> stop_session(session) end)
+    {state, workspace_id, file_ref} = state_with_active_agent_workspace(session)
+    state = EditorState.switch_tab(state, 1)
+
+    state = BufferManagement.execute(state, :force_quit)
+    tab_bar = state.shell_state.tab_bar
+    workspace = TabBar.get_workspace(tab_bar, workspace_id)
+
+    assert TabBar.get(tab_bar, 1) == nil
+    assert workspace.files == [file_ref]
+
+    state = MingaEditor.Commands.Workspace.workspace_close(state)
+    assert TabBar.get_workspace(state.shell_state.tab_bar, workspace_id) == nil
   end
 
   defp state_with_agent_workspace_tabs do
@@ -129,7 +248,35 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
       |> TabBar.move_tab_to_workspace(2, workspace.id)
       |> TabBar.update_workspace(workspace.id, &Workspace.set_agent_ui(&1, UIState.new()))
 
-    %{state | shell_state: %{state.shell_state | tab_bar: tab_bar}}
+    EditorState.set_tab_bar(state, tab_bar)
+  end
+
+  defp state_with_active_agent_workspace(session) when is_pid(session) do
+    state = state_with_tabs()
+    file_ref = FileRef.from_buffer(state.workspace.buffers.active)
+    ui = UIState.new() |> put_prompt("restart draft") |> show_panel()
+
+    {tab_bar, agent_tab} = TabBar.add(state.shell_state.tab_bar, :agent, "Agent")
+    {tab_bar, workspace} = TabBar.add_workspace(tab_bar, "Agent", session)
+
+    tab_bar =
+      tab_bar
+      |> TabBar.update_tab(agent_tab.id, &MingaEditor.State.Tab.set_session(&1, session))
+      |> TabBar.move_tab_to_workspace(1, workspace.id)
+      |> TabBar.move_tab_to_workspace(agent_tab.id, workspace.id)
+      |> TabBar.update_workspace(workspace.id, fn workspace ->
+        workspace
+        |> Workspace.add_file(file_ref)
+        |> Workspace.set_agent_ui(ui)
+      end)
+      |> TabBar.switch_to(agent_tab.id)
+
+    state =
+      state
+      |> EditorState.set_tab_bar(tab_bar)
+      |> EditorState.update_workspace(&MingaEditor.Workspace.State.set_agent_ui(&1, ui))
+
+    {state, workspace.id, file_ref}
   end
 
   defp state_with_tabs do
@@ -171,6 +318,16 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     BufferProcess.replace_content(ui.panel.prompt_buffer, text)
     ui
   end
+
+  defp show_panel(%UIState{} = ui) do
+    %{ui | panel: %{ui.panel | visible: true}}
+  end
+
+  defp stop_session(pid) when is_pid(pid) do
+    AgentSession.stop_session_pid(pid)
+  end
+
+  defp stop_session(_pid), do: :ok
 
   defp prompt_text(%UIState{} = ui), do: UIState.input_text(ui.panel)
 end

--- a/test/minga_editor/state/event_routing_test.exs
+++ b/test/minga_editor/state/event_routing_test.exs
@@ -7,7 +7,7 @@ defmodule MingaEditor.State.EventRoutingTest do
   alias MingaAgent.RuntimeState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
-  alias MingaEditor.State.{Tab, TabBar}
+  alias MingaEditor.State.{Tab, TabBar, Workspace}
   alias MingaEditor.Viewport
 
   defp make_state(opts \\ []) do
@@ -194,7 +194,9 @@ defmodule MingaEditor.State.EventRoutingTest do
       state = EditorState.set_tab_session(state, tab.id, new_session)
 
       tab = TabBar.get(state.shell_state.tab_bar, tab.id)
+      workspace = TabBar.active_workspace(state.shell_state.tab_bar)
       assert tab.session == new_session
+      assert workspace.session == new_session
     end
   end
 
@@ -205,6 +207,7 @@ defmodule MingaEditor.State.EventRoutingTest do
 
       refute Map.has_key?(ctx, :agent)
       refute Map.has_key?(ctx, :agentic)
+      refute Map.has_key?(ctx, :agent_ui)
     end
   end
 
@@ -213,7 +216,12 @@ defmodule MingaEditor.State.EventRoutingTest do
       %{state: state, session: session} = make_state()
 
       {tb, agent_tab} = TabBar.add(state.shell_state.tab_bar, :agent, "Agent")
-      tb = TabBar.update_tab(tb, agent_tab.id, &Tab.set_session(&1, session))
+
+      tb =
+        tb
+        |> TabBar.update_tab(agent_tab.id, &Tab.set_session(&1, session))
+        |> TabBar.update_workspace(agent_tab.group_id, &Workspace.set_session(&1, session))
+
       state = MingaEditor.State.set_tab_bar(state, tb)
 
       {new_state, _effects} = AgentEvents.handle(state, {:status_changed, :thinking})
@@ -226,7 +234,12 @@ defmodule MingaEditor.State.EventRoutingTest do
       %{state: state, session: session} = make_state()
 
       {tb, agent_tab} = TabBar.add(state.shell_state.tab_bar, :agent, "Agent")
-      tb = TabBar.update_tab(tb, agent_tab.id, &Tab.set_session(&1, session))
+
+      tb =
+        tb
+        |> TabBar.update_tab(agent_tab.id, &Tab.set_session(&1, session))
+        |> TabBar.update_workspace(agent_tab.group_id, &Workspace.set_session(&1, session))
+
       state = MingaEditor.State.set_tab_bar(state, tb)
 
       {state, _} = AgentEvents.handle(state, {:status_changed, :thinking})

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -378,7 +378,6 @@ defmodule MingaEditor.State.SnapshotTest do
       assert new_ctx.search == old_ctx.search
       assert new_ctx.editing == old_ctx.editing
       assert new_ctx.document_highlights == old_ctx.document_highlights
-      assert new_ctx.agent_ui == old_ctx.agent_ui
 
       # present_fields contain the same fields (order is not semantically significant)
       assert Enum.sort(new_ctx.present_fields) == Enum.sort(old_ctx.present_fields)

--- a/test/minga_editor/state/workspace_test.exs
+++ b/test/minga_editor/state/workspace_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.State.WorkspaceTest do
   use ExUnit.Case, async: true
 
   alias Minga.Project.FileRef
+  alias MingaEditor.Agent.UIState
   alias MingaEditor.State.Workspace
 
   describe "new_manual/1" do
@@ -41,7 +42,7 @@ defmodule MingaEditor.State.WorkspaceTest do
       assert is_integer(workspace.color)
       assert workspace.files == []
       assert workspace.active_file == nil
-      assert workspace.agent_ui == nil
+      assert %UIState{} = workspace.agent_ui
       assert workspace.project_view == nil
       assert workspace.review == nil
     end

--- a/test/minga_editor/ui/picker/agent_session_source_test.exs
+++ b/test/minga_editor/ui/picker/agent_session_source_test.exs
@@ -324,9 +324,13 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
   defp state_with_agent_tab(session_pid) do
     tb = TabBar.new(Tab.new_file(1, "main.ex"))
     {tb, agent_tab} = TabBar.add(tb, :agent, "Agent 1")
-    tb = TabBar.update_tab(tb, agent_tab.id, &Tab.set_session(&1, session_pid))
-    # Make the agent tab active
-    tb = TabBar.switch_to(tb, agent_tab.id)
+    {tb, workspace} = TabBar.add_workspace(tb, "Agent 1", session_pid)
+
+    tb =
+      tb
+      |> TabBar.update_tab(agent_tab.id, &Tab.set_session(&1, session_pid))
+      |> TabBar.move_tab_to_workspace(agent_tab.id, workspace.id)
+      |> TabBar.switch_to(agent_tab.id)
 
     agent_ctx = %{
       shell_state: %MingaEditor.Shell.Traditional.State{
@@ -363,11 +367,21 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
   defp state_with_two_agent_tabs(session1, session2) do
     tb = TabBar.new(Tab.new_file(1, "main.ex"))
     {tb, tab1} = TabBar.add(tb, :agent, "Agent 1")
-    tb = TabBar.update_tab(tb, tab1.id, &Tab.set_session(&1, session1))
+    {tb, workspace1} = TabBar.add_workspace(tb, "Agent 1", session1)
+
+    tb =
+      tb
+      |> TabBar.update_tab(tab1.id, &Tab.set_session(&1, session1))
+      |> TabBar.move_tab_to_workspace(tab1.id, workspace1.id)
+
     {tb, tab2} = TabBar.add(tb, :agent, "Agent 2")
-    tb = TabBar.update_tab(tb, tab2.id, &Tab.set_session(&1, session2))
-    # First agent tab is active
-    tb = TabBar.switch_to(tb, tab1.id)
+    {tb, workspace2} = TabBar.add_workspace(tb, "Agent 2", session2)
+
+    tb =
+      tb
+      |> TabBar.update_tab(tab2.id, &Tab.set_session(&1, session2))
+      |> TabBar.move_tab_to_workspace(tab2.id, workspace2.id)
+      |> TabBar.switch_to(tab1.id)
 
     agent = %AgentState{runtime: %RuntimeState{status: :idle}}
     agentic = %UIState{view: %UIState.View{active: true, focus: :chat}}
@@ -389,7 +403,12 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
   defp state_with_two_tabs_file_active(session_pid) do
     tb = TabBar.new(Tab.new_file(1, "main.ex"))
     {tb, agent_tab} = TabBar.add(tb, :agent, "Agent 1")
-    tb = TabBar.update_tab(tb, agent_tab.id, &Tab.set_session(&1, session_pid))
+    {tb, workspace} = TabBar.add_workspace(tb, "Agent 1", session_pid)
+
+    tb =
+      tb
+      |> TabBar.update_tab(agent_tab.id, &Tab.set_session(&1, session_pid))
+      |> TabBar.move_tab_to_workspace(agent_tab.id, workspace.id)
 
     agent_ctx = %{
       shell_state: %MingaEditor.Shell.Traditional.State{


### PR DESCRIPTION
## Summary
- Move Traditional agent session and agent UI ownership to workspaces instead of tab contexts
- Keep the live workspace UI mirror synced when switching, closing, or restoring tabs/workspaces
- Preserve sessions/files/drafts across file tab closes and session stops, with workspace close as the teardown path

## Validation
- `mix compile --warnings-as-errors`
- `make lint`
- `mix test.llm test/minga_editor/commands test/minga_editor/agent test/minga_editor/state`
- `mix test.llm`
- `git diff --check`

Closes #1782
