### PR TITLE
feat(agent): add project view facade

### DIFF
--- a/lib/minga_agent/buffer_fork_store.ex
+++ b/lib/minga_agent/buffer_fork_store.ex
@@ -76,10 +76,24 @@ defmodule MingaAgent.BufferForkStore do
     GenServer.call(store, :merge_all_keep_failed, 30_000)
   end
 
+  @doc "Merges only the forks whose paths are listed, keeping failed forks alive."
+  @spec merge_paths_keep_failed(GenServer.server(), [String.t()]) :: [
+          {String.t(), :ok | {:conflict, term()} | {:error, term()}}
+        ]
+  def merge_paths_keep_failed(store, paths) when is_list(paths) do
+    GenServer.call(store, {:merge_paths_keep_failed, paths}, 30_000)
+  end
+
   @doc "Discards all forks without merging."
   @spec discard_all(GenServer.server()) :: :ok
   def discard_all(store) do
     GenServer.call(store, :discard_all)
+  end
+
+  @doc "Discards only the forks whose paths are listed."
+  @spec discard_paths(GenServer.server(), [String.t()]) :: :ok
+  def discard_paths(store, paths) when is_list(paths) do
+    GenServer.call(store, {:discard_paths, paths})
   end
 
   @doc "Stops the store, cleaning up all forks."
@@ -136,15 +150,23 @@ defmodule MingaAgent.BufferForkStore do
   end
 
   def handle_call(:merge_all_keep_failed, _from, state) do
-    results = Enum.map(state.forks, fn {path, fork_pid} -> merge_fork(path, fork_pid) end)
-    successful_paths = successful_merge_paths(results)
-    state = stop_forks_for_paths(state, successful_paths)
+    {results, state} = merge_paths_keep_failed_state(state, Map.keys(state.forks))
+    {:reply, results, state}
+  end
+
+  def handle_call({:merge_paths_keep_failed, paths}, _from, state) do
+    {results, state} = merge_paths_keep_failed_state(state, paths)
     {:reply, results, state}
   end
 
   def handle_call(:discard_all, _from, state) do
-    stop_all_forks(state)
-    {:reply, :ok, %{state | forks: %{}, monitors: %{}}}
+    state = discard_paths_state(state, Map.keys(state.forks))
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:discard_paths, paths}, _from, state) do
+    state = discard_paths_state(state, paths)
+    {:reply, :ok, state}
   end
 
   @impl true
@@ -181,8 +203,10 @@ defmodule MingaAgent.BufferForkStore do
   defp do_merge_fork(path, fork_pid) do
     case Fork.merge(fork_pid) do
       {:ok, merged_text} ->
-        apply_merge_to_parent(path, merged_text)
-        {path, :ok}
+        case apply_merge_to_parent(path, merged_text) do
+          :ok -> {path, :ok}
+          {:error, reason} -> {path, {:error, reason}}
+        end
 
       {:conflict, hunks} ->
         {path, {:conflict, hunks}}
@@ -201,6 +225,31 @@ defmodule MingaAgent.BufferForkStore do
       {_path, _result} -> []
     end)
     |> MapSet.new()
+  end
+
+  @spec merge_paths_keep_failed_state(state(), [String.t()]) ::
+          {[{String.t(), :ok | {:conflict, term()} | {:error, term()}}], state()}
+  defp merge_paths_keep_failed_state(state, paths) do
+    paths_to_merge =
+      paths
+      |> Enum.uniq()
+      |> Enum.sort()
+      |> Enum.flat_map(fn path ->
+        case Map.fetch(state.forks, path) do
+          {:ok, fork_pid} -> [{path, fork_pid}]
+          :error -> []
+        end
+      end)
+
+    results = Enum.map(paths_to_merge, fn {path, fork_pid} -> merge_fork(path, fork_pid) end)
+    successful_paths = successful_merge_paths(results)
+    state = stop_forks_for_paths(state, successful_paths)
+    {results, state}
+  end
+
+  @spec discard_paths_state(state(), [String.t()]) :: state()
+  defp discard_paths_state(state, paths) do
+    stop_forks_for_paths(state, MapSet.new(paths))
   end
 
   @spec stop_forks_for_paths(state(), MapSet.t(String.t())) :: state()
@@ -242,15 +291,18 @@ defmodule MingaAgent.BufferForkStore do
   defp apply_merge_to_parent(path, merged_text) do
     case Minga.Buffer.pid_for_path(path) do
       {:ok, buf_pid} ->
-        Minga.Buffer.replace_content(buf_pid, merged_text, :agent)
-        :ok
+        try do
+          case Minga.Buffer.replace_content(buf_pid, merged_text, :agent) do
+            :ok -> :ok
+            {:error, reason} -> {:error, reason}
+          end
+        catch
+          :exit, _ -> {:error, :parent_unreachable}
+        end
 
       :not_found ->
         # Buffer was closed while fork was active; write to disk
         File.write(path, merged_text)
-        :ok
     end
-  rescue
-    _ -> {:error, :parent_unreachable}
   end
 end

--- a/lib/minga_agent/buffer_fork_store.ex
+++ b/lib/minga_agent/buffer_fork_store.ex
@@ -68,6 +68,14 @@ defmodule MingaAgent.BufferForkStore do
     GenServer.call(store, :merge_all, 30_000)
   end
 
+  @doc "Merges forks and keeps failed forks alive for later conflict handling."
+  @spec merge_all_keep_failed(GenServer.server()) :: [
+          {String.t(), :ok | {:conflict, term()} | {:error, term()}}
+        ]
+  def merge_all_keep_failed(store) do
+    GenServer.call(store, :merge_all_keep_failed, 30_000)
+  end
+
   @doc "Discards all forks without merging."
   @spec discard_all(GenServer.server()) :: :ok
   def discard_all(store) do
@@ -127,6 +135,13 @@ defmodule MingaAgent.BufferForkStore do
     {:reply, results, %{state | forks: %{}, monitors: %{}}}
   end
 
+  def handle_call(:merge_all_keep_failed, _from, state) do
+    results = Enum.map(state.forks, fn {path, fork_pid} -> merge_fork(path, fork_pid) end)
+    successful_paths = successful_merge_paths(results)
+    state = stop_forks_for_paths(state, successful_paths)
+    {:reply, results, state}
+  end
+
   def handle_call(:discard_all, _from, state) do
     stop_all_forks(state)
     {:reply, :ok, %{state | forks: %{}, monitors: %{}}}
@@ -175,6 +190,39 @@ defmodule MingaAgent.BufferForkStore do
       {:error, reason} ->
         {path, {:error, reason}}
     end
+  end
+
+  @spec successful_merge_paths([{String.t(), :ok | {:conflict, term()} | {:error, term()}}]) ::
+          MapSet.t(String.t())
+  defp successful_merge_paths(results) do
+    results
+    |> Enum.flat_map(fn
+      {path, :ok} -> [path]
+      {_path, _result} -> []
+    end)
+    |> MapSet.new()
+  end
+
+  @spec stop_forks_for_paths(state(), MapSet.t(String.t())) :: state()
+  defp stop_forks_for_paths(state, paths) do
+    {refs_to_stop, monitors} =
+      split_map_by_paths(state.monitors, paths, fn {_ref, path} -> path end)
+
+    {forks_to_stop, forks} = split_map_by_paths(state.forks, paths, fn {path, _pid} -> path end)
+
+    Enum.each(refs_to_stop, fn {ref, _path} -> Process.demonitor(ref, [:flush]) end)
+
+    Enum.each(forks_to_stop, fn {_path, fork_pid} ->
+      if Process.alive?(fork_pid), do: GenServer.stop(fork_pid, :normal)
+    end)
+
+    %{state | forks: Map.new(forks), monitors: Map.new(monitors)}
+  end
+
+  @spec split_map_by_paths(map(), MapSet.t(String.t()), (term() -> String.t())) ::
+          {[term()], [term()]}
+  defp split_map_by_paths(map, paths, path_fun) do
+    Enum.split_with(map, fn entry -> MapSet.member?(paths, path_fun.(entry)) end)
   end
 
   @spec stop_all_forks(state()) :: :ok

--- a/lib/minga_agent/changeset.ex
+++ b/lib/minga_agent/changeset.ex
@@ -94,6 +94,18 @@ defmodule MingaAgent.Changeset do
   end
 
   @doc """
+  Validates the merge plan back to the real project without applying it.
+
+  This performs the same path validation and conflict planning as `merge/1`
+  but does not write, delete, or clean up anything. It is useful when a caller
+  needs to know whether a merge would succeed before mutating other state.
+  """
+  @spec preflight_merge(changeset()) :: {:ok, [map()]} | {:error, term()}
+  def preflight_merge(cs) do
+    GenServer.call(cs, :preflight_merge)
+  end
+
+  @doc """
   Merges changes back to the real project with three-way merge.
 
   If someone edited the same files since the changeset was created,

--- a/lib/minga_agent/changeset/server.ex
+++ b/lib/minga_agent/changeset/server.ex
@@ -11,6 +11,7 @@ defmodule MingaAgent.Changeset.Server do
 
   alias Minga.Core.Overlay
   alias MingaAgent.Changeset.MergedEvent
+  alias MingaAgent.ProjectView.PathResolver
 
   @typedoc "Internal server state."
   @type state :: %{
@@ -201,6 +202,9 @@ defmodule MingaAgent.Changeset.Server do
         Overlay.cleanup(state.overlay)
         broadcast_merged(state)
         {:stop, :normal, {:ok, :merged_with_conflicts, details}, state}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
     end
   rescue
     e ->
@@ -234,27 +238,35 @@ defmodule MingaAgent.Changeset.Server do
       end)
 
     all_results = modification_results ++ deletion_results
-    conflicts = Enum.filter(all_results, &match?({:conflict, _, _}, &1))
 
-    if conflicts == [] do
-      :ok
-    else
-      {:ok, :merged_with_conflicts, all_results}
+    case Enum.find(all_results, &match?({:error, _}, &1)) do
+      {:error, reason} ->
+        {:error, reason}
+
+      nil ->
+        conflicts = Enum.filter(all_results, &match?({:conflict, _, _}, &1))
+
+        if conflicts == [] do
+          :ok
+        else
+          {:ok, :merged_with_conflicts, all_results}
+        end
     end
   end
 
-  @spec merge_one_file(state(), String.t(), binary()) :: tuple()
+  @spec merge_one_file(state(), String.t(), binary()) :: tuple() | {:error, term()}
   defp merge_one_file(state, path, changeset_content) do
-    real_path = Path.join(state.project_root, path)
-    original = Map.get(state.originals, path)
+    with {:ok, real_path} <- safe_real_path(state, path) do
+      original = Map.get(state.originals, path)
 
-    current_real =
-      case File.read(real_path) do
-        {:ok, c} -> c
-        {:error, :enoent} -> nil
-      end
+      current_real =
+        case File.read(real_path) do
+          {:ok, c} -> c
+          {:error, :enoent} -> nil
+        end
 
-    merge_strategy(real_path, path, original, current_real, changeset_content)
+      merge_strategy(real_path, path, original, current_real, changeset_content)
+    end
   end
 
   # New file: didn't exist when changeset was created
@@ -294,21 +306,22 @@ defmodule MingaAgent.Changeset.Server do
     end
   end
 
-  @spec merge_one_deletion(state(), String.t()) :: tuple()
+  @spec merge_one_deletion(state(), String.t()) :: tuple() | {:error, term()}
   defp merge_one_deletion(state, path) do
-    real_path = Path.join(state.project_root, path)
-    original = Map.get(state.originals, path)
+    with {:ok, real_path} <- safe_real_path(state, path) do
+      original = Map.get(state.originals, path)
 
-    case File.read(real_path) do
-      {:ok, content} when content == original ->
-        File.rm!(real_path)
-        {:ok, path, :deleted}
+      case File.read(real_path) do
+        {:ok, content} when content == original ->
+          File.rm!(real_path)
+          {:ok, path, :deleted}
 
-      {:ok, _changed} ->
-        {:conflict, path, :modified_before_delete}
+        {:ok, _changed} ->
+          {:conflict, path, :modified_before_delete}
 
-      {:error, :enoent} ->
-        {:ok, path, :already_deleted}
+        {:error, :enoent} ->
+          {:ok, path, :already_deleted}
+      end
     end
   end
 
@@ -392,14 +405,19 @@ defmodule MingaAgent.Changeset.Server do
   @spec restore_original(state(), String.t()) :: :ok
   defp restore_original(state, path) do
     overlay_path = Path.join(state.overlay.overlay_dir, path)
-    project_path = Path.join(state.project_root, path)
 
     File.rm(overlay_path)
     File.rm(overlay_path <> ".__changeset_deleted__")
 
-    if File.regular?(project_path) do
-      File.mkdir_p!(Path.dirname(overlay_path))
-      relink_file(state.overlay, project_path, overlay_path)
+    case safe_real_path(state, path) do
+      {:ok, project_path} ->
+        if File.regular?(project_path) do
+          File.mkdir_p!(Path.dirname(overlay_path))
+          relink_file(state.overlay, project_path, overlay_path)
+        end
+
+      {:error, _reason} ->
+        :ok
     end
 
     :ok
@@ -418,24 +436,18 @@ defmodule MingaAgent.Changeset.Server do
   end
 
   @spec normalize_path(state(), String.t()) ::
-          {:ok, String.t()} | {:error, :invalid_path | :path_traversal}
+          {:ok, String.t()} | {:error, :invalid_path | :path_traversal | :symlink_traversal}
   defp normalize_path(state, path) do
-    root = Path.expand(state.project_root)
-    target = Path.join(root, path) |> Path.expand()
-
-    normalize_target(root, target)
+    case safe_real_path(state, path) do
+      {:ok, target} -> {:ok, Path.relative_to(target, Path.expand(state.project_root))}
+      {:error, _} = error -> error
+    end
   end
 
-  @spec normalize_target(String.t(), String.t()) ::
-          {:ok, String.t()} | {:error, :invalid_path | :path_traversal}
-  defp normalize_target(root, root), do: {:error, :invalid_path}
-
-  defp normalize_target(root, target) do
-    if String.starts_with?(target, root <> "/") do
-      {:ok, Path.relative_to(target, root)}
-    else
-      {:error, :path_traversal}
-    end
+  @spec safe_real_path(state(), String.t()) ::
+          {:ok, String.t()} | {:error, :invalid_path | :path_traversal | :symlink_traversal}
+  defp safe_real_path(%{project_root: project_root}, path) do
+    PathResolver.resolve(project_root, path)
   end
 
   @spec broadcast_merged(state()) :: :ok

--- a/lib/minga_agent/changeset/server.ex
+++ b/lib/minga_agent/changeset/server.ex
@@ -191,6 +191,10 @@ defmodule MingaAgent.Changeset.Server do
     {:reply, :ok, state}
   end
 
+  def handle_call(:preflight_merge, _from, state) do
+    {:reply, build_merge_plan(state), state}
+  end
+
   def handle_call(:merge, _from, state) do
     case do_merge(state) do
       :ok ->
@@ -227,101 +231,229 @@ defmodule MingaAgent.Changeset.Server do
 
   @spec do_merge(state()) :: :ok | {:ok, :merged_with_conflicts, list()} | {:error, term()}
   defp do_merge(state) do
-    modification_results =
-      Enum.map(state.modifications, fn {path, changeset_content} ->
-        merge_one_file(state, path, changeset_content)
-      end)
-
-    deletion_results =
-      Enum.map(state.deletions, fn path ->
-        merge_one_deletion(state, path)
-      end)
-
-    all_results = modification_results ++ deletion_results
-
-    case Enum.find(all_results, &match?({:error, _}, &1)) do
-      {:error, reason} ->
-        {:error, reason}
-
-      nil ->
-        conflicts = Enum.filter(all_results, &match?({:conflict, _, _}, &1))
-
-        if conflicts == [] do
-          :ok
-        else
-          {:ok, :merged_with_conflicts, all_results}
-        end
+    with {:ok, plan} <- build_merge_plan(state) do
+      apply_merge_plan(plan)
     end
   end
 
-  @spec merge_one_file(state(), String.t(), binary()) :: tuple() | {:error, term()}
-  defp merge_one_file(state, path, changeset_content) do
-    with {:ok, real_path} <- safe_real_path(state, path) do
+  @spec build_merge_plan(state()) :: {:ok, [map()]} | {:error, term()}
+  defp build_merge_plan(state) do
+    with {:ok, modification_plans} <- build_modification_plans(state),
+         {:ok, deletion_plans} <- build_deletion_plans(state) do
+      {:ok, modification_plans ++ deletion_plans}
+    end
+  end
+
+  @spec build_modification_plans(state()) :: {:ok, [map()]} | {:error, term()}
+  defp build_modification_plans(state) do
+    state.modifications
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.reduce_while({:ok, []}, fn {path, changeset_content}, {:ok, plans} ->
+      case plan_merge_one_file(state, path, changeset_content) do
+        {:ok, plan} -> {:cont, {:ok, [plan | plans]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, plans} -> {:ok, Enum.reverse(plans)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @spec build_deletion_plans(state()) :: {:ok, [map()]} | {:error, term()}
+  defp build_deletion_plans(state) do
+    state.deletions
+    |> MapSet.to_list()
+    |> Enum.sort()
+    |> Enum.reduce_while({:ok, []}, fn path, {:ok, plans} ->
+      case plan_merge_one_deletion(state, path) do
+        {:ok, plan} -> {:cont, {:ok, [plan | plans]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, plans} -> {:ok, Enum.reverse(plans)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @spec plan_merge_one_file(state(), String.t(), binary()) :: {:ok, map()} | {:error, term()}
+  defp plan_merge_one_file(state, path, changeset_content) do
+    with {:ok, real_path} <- safe_real_path(state, path),
+         {:ok, current_real} <- read_current_real(real_path) do
       original = Map.get(state.originals, path)
-
-      current_real =
-        case File.read(real_path) do
-          {:ok, c} -> c
-          {:error, :enoent} -> nil
-        end
-
-      merge_strategy(real_path, path, original, current_real, changeset_content)
+      plan_merge_action(path, real_path, original, current_real, changeset_content)
     end
   end
 
-  # New file: didn't exist when changeset was created
-  @spec merge_strategy(String.t(), String.t(), binary() | nil, binary() | nil, binary()) ::
-          tuple()
-  defp merge_strategy(real_path, path, nil = _original, nil = _current_real, changeset_content) do
-    File.mkdir_p!(Path.dirname(real_path))
-    File.write!(real_path, changeset_content)
-    {:ok, path, :created}
+  @spec plan_merge_action(String.t(), String.t(), binary() | nil, binary() | nil, binary()) ::
+          {:ok, map()}
+  defp plan_merge_action(path, real_path, nil, nil, changeset_content) do
+    {:ok,
+     %{
+       kind: :write,
+       mkdir_p: true,
+       real_path: real_path,
+       content: changeset_content,
+       result: {path, :ok}
+     }}
   end
 
-  # New file but someone else also created it
-  defp merge_strategy(_real_path, path, nil = _original, _current_real, _changeset_content) do
-    {:conflict, path, :both_created}
+  defp plan_merge_action(path, _real_path, nil, _current_real, _changeset_content) do
+    {:ok, %{kind: :result, result: {path, {:conflict, :both_created}}}}
   end
 
-  # Real file unchanged since changeset was created: apply directly
-  defp merge_strategy(real_path, path, original, current_real, changeset_content)
+  defp plan_merge_action(path, real_path, original, current_real, changeset_content)
+       when current_real == original and is_binary(original) do
+    {:ok,
+     %{
+       kind: :write,
+       mkdir_p: false,
+       real_path: real_path,
+       content: changeset_content,
+       result: {path, :ok}
+     }}
+  end
+
+  defp plan_merge_action(path, _real_path, original, nil, _changeset_content)
+       when is_binary(original) do
+    {:ok, %{kind: :result, result: {path, {:conflict, :deleted_before_merge}}}}
+  end
+
+  defp plan_merge_action(path, real_path, original, current_real, changeset_content)
+       when is_binary(original) and is_binary(current_real) do
+    {:ok,
+     %{
+       kind: :merge3,
+       path: path,
+       real_path: real_path,
+       original: original,
+       current_real: current_real,
+       content: changeset_content
+     }}
+  end
+
+  @spec plan_merge_one_deletion(state(), String.t()) :: {:ok, map()} | {:error, term()}
+  defp plan_merge_one_deletion(state, path) do
+    with {:ok, real_path} <- safe_real_path(state, path),
+         {:ok, current_real} <- read_current_real(real_path) do
+      original = Map.get(state.originals, path)
+      plan_delete_action(path, real_path, original, current_real)
+    end
+  end
+
+  @spec plan_delete_action(String.t(), String.t(), binary() | nil, binary() | nil) ::
+          {:ok, map()}
+  defp plan_delete_action(path, _real_path, _original, nil) do
+    {:ok, %{kind: :result, result: {path, :ok}}}
+  end
+
+  defp plan_delete_action(path, real_path, original, current_real)
        when current_real == original do
-    File.write!(real_path, changeset_content)
-    {:ok, path, :applied}
+    {:ok,
+     %{
+       kind: :delete,
+       real_path: real_path,
+       result: {path, :ok}
+     }}
   end
 
-  # Real file was also modified: three-way merge
-  defp merge_strategy(real_path, path, original, current_real, changeset_content) do
+  defp plan_delete_action(path, _real_path, nil, _current_real) do
+    {:ok, %{kind: :result, result: {path, {:conflict, :both_created}}}}
+  end
+
+  defp plan_delete_action(path, _real_path, _original, _current_real) do
+    {:ok, %{kind: :result, result: {path, {:conflict, :modified_before_delete}}}}
+  end
+
+  @spec apply_merge_plan([map()]) ::
+          :ok | {:ok, :merged_with_conflicts, list()} | {:error, term()}
+  defp apply_merge_plan(plan) do
+    plan
+    |> Enum.reduce_while({:ok, []}, &apply_merge_plan_reducer/2)
+    |> merge_plan_result()
+  end
+
+  @spec apply_merge_plan_reducer(map(), {:ok, [tuple()]}) ::
+          {:cont, {:ok, [tuple()]}} | {:halt, {:error, term()}}
+  defp apply_merge_plan_reducer(entry, {:ok, results}) do
+    case apply_merge_plan_entry(entry) do
+      {:error, reason} -> {:halt, {:error, reason}}
+      result -> {:cont, {:ok, [result | results]}}
+    end
+  end
+
+  @spec merge_plan_result({:ok, [tuple()]} | {:error, term()}) ::
+          :ok | {:ok, :merged_with_conflicts, list()} | {:error, term()}
+  defp merge_plan_result({:error, reason}), do: {:error, reason}
+
+  defp merge_plan_result({:ok, results}) do
+    results
+    |> Enum.reverse()
+    |> merge_plan_success_result()
+  end
+
+  @spec merge_plan_success_result([tuple()]) :: :ok | {:ok, :merged_with_conflicts, list()}
+  defp merge_plan_success_result(results) do
+    if Enum.any?(results, &match?({_path, {:conflict, _}}, &1)) do
+      {:ok, :merged_with_conflicts, results}
+    else
+      :ok
+    end
+  end
+
+  @spec apply_merge_plan_entry(map()) :: tuple() | {:error, term()}
+  defp apply_merge_plan_entry(%{kind: :result, result: result}), do: result
+
+  defp apply_merge_plan_entry(
+         %{
+           kind: :write,
+           real_path: real_path,
+           content: content,
+           result: result
+         } = entry
+       ) do
+    if Map.get(entry, :mkdir_p, false) do
+      File.mkdir_p!(Path.dirname(real_path))
+    end
+
+    File.write!(real_path, content)
+    result
+  end
+
+  defp apply_merge_plan_entry(%{
+         kind: :merge3,
+         real_path: real_path,
+         path: path,
+         original: original,
+         current_real: current_real,
+         content: content
+       }) do
     ancestor_lines = String.split(original, "\n", trim: false)
-    ours_lines = String.split(changeset_content, "\n", trim: false)
+    ours_lines = String.split(content, "\n", trim: false)
     theirs_lines = String.split(current_real, "\n", trim: false)
 
     case Minga.Core.Diff.merge3(ancestor_lines, ours_lines, theirs_lines) do
       {:ok, merged_lines} ->
         File.write!(real_path, Enum.join(merged_lines, "\n"))
-        {:ok, path, :merged_three_way}
+        {path, :ok}
 
       {:conflict, _hunks} ->
-        {:conflict, path, :concurrent_edit}
+        {path, {:conflict, :concurrent_edit}}
     end
   end
 
-  @spec merge_one_deletion(state(), String.t()) :: tuple() | {:error, term()}
-  defp merge_one_deletion(state, path) do
-    with {:ok, real_path} <- safe_real_path(state, path) do
-      original = Map.get(state.originals, path)
+  defp apply_merge_plan_entry(%{kind: :delete, real_path: real_path, result: result}) do
+    File.rm!(real_path)
+    result
+  end
 
-      case File.read(real_path) do
-        {:ok, content} when content == original ->
-          File.rm!(real_path)
-          {:ok, path, :deleted}
-
-        {:ok, _changed} ->
-          {:conflict, path, :modified_before_delete}
-
-        {:error, :enoent} ->
-          {:ok, path, :already_deleted}
-      end
+  @spec read_current_real(String.t()) :: {:ok, binary() | nil} | {:error, term()}
+  defp read_current_real(real_path) do
+    case File.read(real_path) do
+      {:ok, content} -> {:ok, content}
+      {:error, :enoent} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/minga_agent/project_view.ex
+++ b/lib/minga_agent/project_view.ex
@@ -1,0 +1,151 @@
+defmodule MingaAgent.ProjectView do
+  @moduledoc """
+  Facade for workspace-local project file access.
+
+  A project view gives agent code one stable API for direct project files and isolated overlay-backed files. Paths are logical paths relative to `project_root`; callers never use frontend labels, tab labels, or backend worktree paths.
+  """
+
+  alias MingaAgent.ProjectView
+  alias MingaAgent.ProjectView.Direct
+  alias MingaAgent.ProjectView.Overlay
+
+  @typedoc "Project view handle."
+  @type t :: %__MODULE__{
+          id: String.t(),
+          project_root: String.t(),
+          backend: module(),
+          ref: ProjectView.Backend.ref(),
+          workspace_id: non_neg_integer() | nil
+        }
+
+  @enforce_keys [:id, :project_root, :backend, :ref]
+  defstruct [:id, :project_root, :backend, :ref, workspace_id: nil]
+
+  @doc "Creates a direct project view rooted at `project_root`."
+  @spec direct(String.t(), keyword()) :: {:ok, t()} | {:error, term()}
+  def direct(project_root, opts \\ []) when is_binary(project_root) do
+    Direct.create(project_root, opts)
+  end
+
+  @doc "Creates an overlay-backed project view rooted at `project_root`."
+  @spec overlay(String.t(), keyword()) :: {:ok, t()} | {:error, term()}
+  def overlay(project_root, opts \\ []) when is_binary(project_root) do
+    Overlay.create(project_root, opts)
+  end
+
+  @doc "Reads a file from the view."
+  @spec read_file(t(), String.t()) :: {:ok, binary()} | {:error, term()}
+  def read_file(%__MODULE__{} = view, relative_path) when is_binary(relative_path) do
+    with {:ok, path} <- normalize_relative_path(relative_path) do
+      view.backend.read_file(view, path)
+    end
+  end
+
+  @doc "Writes a file in the view."
+  @spec write_file(t(), String.t(), binary()) :: :ok | {:error, term()}
+  def write_file(%__MODULE__{} = view, relative_path, content)
+      when is_binary(relative_path) and is_binary(content) do
+    with {:ok, path} <- normalize_relative_path(relative_path) do
+      view.backend.write_file(view, path, content)
+    end
+  end
+
+  @doc "Replaces exact text in a file in the view."
+  @spec edit_file(t(), String.t(), String.t(), String.t()) :: :ok | {:error, term()}
+  def edit_file(%__MODULE__{} = view, relative_path, old_text, new_text)
+      when is_binary(relative_path) and is_binary(old_text) and is_binary(new_text) do
+    with {:ok, path} <- normalize_relative_path(relative_path) do
+      view.backend.edit_file(view, path, old_text, new_text)
+    end
+  end
+
+  @doc "Deletes a file from the view."
+  @spec delete_file(t(), String.t()) :: :ok | {:error, term()}
+  def delete_file(%__MODULE__{} = view, relative_path) when is_binary(relative_path) do
+    with {:ok, path} <- normalize_relative_path(relative_path) do
+      view.backend.delete_file(view, path)
+    end
+  end
+
+  @doc "Lists a directory in the view."
+  @spec list_directory(t(), String.t()) ::
+          {:ok, [ProjectView.Backend.directory_entry()]} | {:error, term()}
+  def list_directory(%__MODULE__{} = view, relative_path) when is_binary(relative_path) do
+    with {:ok, path} <- normalize_relative_path(relative_path, allow_root: true) do
+      view.backend.list_directory(view, path)
+    end
+  end
+
+  @doc "Returns the directory shell commands should run in for this view."
+  @spec working_dir(t()) :: String.t()
+  def working_dir(%__MODULE__{} = view), do: view.backend.working_dir(view)
+
+  @doc "Returns environment variables shell commands should use for this view."
+  @spec command_env(t()) :: [{String.t(), String.t()}]
+  def command_env(%__MODULE__{} = view), do: view.backend.command_env(view)
+
+  @doc "Returns backend-specific diff data for the view."
+  @spec diff(t()) :: {:ok, [map()]} | {:error, term()}
+  def diff(%__MODULE__{} = view), do: view.backend.diff(view)
+
+  @doc "Promotes view-local changes to `target`."
+  @spec promote(t(), term()) :: :ok | {:ok, term()} | {:error, term()}
+  def promote(%__MODULE__{} = view, target), do: view.backend.promote(view, target)
+
+  @doc "Discards view-local state."
+  @spec discard(t()) :: :ok | {:error, term()}
+  def discard(%__MODULE__{} = view), do: view.backend.discard(view)
+
+  @doc "Returns capability flags for this view."
+  @spec capabilities(t()) :: ProjectView.Backend.capabilities()
+  def capabilities(%__MODULE__{} = view), do: view.backend.capabilities(view)
+
+  @doc false
+  @spec new(module(), String.t(), ProjectView.Backend.ref(), keyword()) :: t()
+  def new(backend, project_root, ref, opts) when is_atom(backend) and is_binary(project_root) do
+    %__MODULE__{
+      id: Keyword.get_lazy(opts, :id, fn -> unique_id() end),
+      project_root: Path.expand(project_root),
+      backend: backend,
+      ref: ref,
+      workspace_id: Keyword.get(opts, :workspace_id)
+    }
+  end
+
+  @doc false
+  @spec normalize_relative_path(String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, :invalid_path | :path_traversal}
+  def normalize_relative_path(path, opts \\ []) when is_binary(path) do
+    allow_root? = Keyword.get(opts, :allow_root, false)
+    reject_invalid_relative_path(path, normalized_components(path), allow_root?)
+  end
+
+  @spec normalized_components(String.t()) :: [String.t()]
+  defp normalized_components(path) do
+    path
+    |> String.trim_leading("./")
+    |> Path.split()
+    |> Enum.reject(&(&1 in [".", ""]))
+  end
+
+  @spec reject_invalid_relative_path(String.t(), [String.t()], boolean()) ::
+          {:ok, String.t()} | {:error, :invalid_path | :path_traversal}
+  defp reject_invalid_relative_path(path, components, allow_root?) do
+    if String.starts_with?(path, "/") or Enum.member?(components, "..") do
+      {:error, :path_traversal}
+    else
+      relative_path_from_components(components, allow_root?)
+    end
+  end
+
+  @spec relative_path_from_components([String.t()], boolean()) ::
+          {:ok, String.t()} | {:error, :invalid_path}
+  defp relative_path_from_components([], true), do: {:ok, ""}
+  defp relative_path_from_components([], false), do: {:error, :invalid_path}
+  defp relative_path_from_components(components, _allow_root?), do: {:ok, Path.join(components)}
+
+  @spec unique_id() :: String.t()
+  defp unique_id do
+    :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/minga_agent/project_view/backend.ex
+++ b/lib/minga_agent/project_view/backend.ex
@@ -1,0 +1,38 @@
+defmodule MingaAgent.ProjectView.Backend do
+  @moduledoc """
+  Behaviour for workspace project view backends.
+
+  Backends implement file access for one workspace-local view. Callers use `MingaAgent.ProjectView`; backend modules stay hidden behind the facade.
+  """
+
+  alias MingaAgent.ProjectView
+
+  @typedoc "Backend-owned reference, usually a pid or small state map."
+  @type ref :: term()
+
+  @typedoc "Directory listing entry."
+  @type directory_entry :: %{name: String.t(), type: :file | :directory}
+
+  @typedoc "Backend capability flags."
+  @type capabilities :: %{
+          isolation: :none | :overlay,
+          mutates_project_root: boolean(),
+          supports_promote: boolean(),
+          supports_discard: boolean(),
+          supports_command_env: boolean()
+        }
+
+  @callback read_file(ProjectView.t(), String.t()) :: {:ok, binary()} | {:error, term()}
+  @callback write_file(ProjectView.t(), String.t(), binary()) :: :ok | {:error, term()}
+  @callback edit_file(ProjectView.t(), String.t(), String.t(), String.t()) ::
+              :ok | {:error, term()}
+  @callback delete_file(ProjectView.t(), String.t()) :: :ok | {:error, term()}
+  @callback list_directory(ProjectView.t(), String.t()) ::
+              {:ok, [directory_entry()]} | {:error, term()}
+  @callback working_dir(ProjectView.t()) :: String.t()
+  @callback command_env(ProjectView.t()) :: [{String.t(), String.t()}]
+  @callback diff(ProjectView.t()) :: {:ok, [map()]} | {:error, term()}
+  @callback promote(ProjectView.t(), term()) :: :ok | {:ok, term()} | {:error, term()}
+  @callback discard(ProjectView.t()) :: :ok | {:error, term()}
+  @callback capabilities(ProjectView.t()) :: capabilities()
+end

--- a/lib/minga_agent/project_view/direct.ex
+++ b/lib/minga_agent/project_view/direct.ex
@@ -8,6 +8,7 @@ defmodule MingaAgent.ProjectView.Direct do
   @behaviour MingaAgent.ProjectView.Backend
 
   alias MingaAgent.ProjectView
+  alias MingaAgent.ProjectView.PathResolver
 
   @type direct_state :: %{modified: MapSet.t(String.t()), deleted: MapSet.t(String.t())}
 
@@ -27,15 +28,16 @@ defmodule MingaAgent.ProjectView.Direct do
   @impl true
   @spec read_file(ProjectView.t(), String.t()) :: {:ok, binary()} | {:error, term()}
   def read_file(%ProjectView{} = view, relative_path) do
-    view |> target_path(relative_path) |> File.read()
+    with {:ok, target} <- safe_target(view, relative_path) do
+      File.read(target)
+    end
   end
 
   @impl true
   @spec write_file(ProjectView.t(), String.t(), binary()) :: :ok | {:error, term()}
   def write_file(%ProjectView{} = view, relative_path, content) do
-    target = target_path(view, relative_path)
-
-    with :ok <- File.mkdir_p(Path.dirname(target)),
+    with {:ok, target} <- safe_target(view, relative_path),
+         :ok <- File.mkdir_p(Path.dirname(target)),
          :ok <- File.write(target, content) do
       track_modified(view, relative_path)
     end
@@ -53,9 +55,9 @@ defmodule MingaAgent.ProjectView.Direct do
   @impl true
   @spec delete_file(ProjectView.t(), String.t()) :: :ok | {:error, term()}
   def delete_file(%ProjectView{} = view, relative_path) do
-    case view |> target_path(relative_path) |> File.rm() do
-      :ok -> track_deleted(view, relative_path)
-      {:error, reason} -> {:error, reason}
+    with {:ok, target} <- safe_target(view, relative_path),
+         :ok <- File.rm(target) do
+      track_deleted(view, relative_path)
     end
   end
 
@@ -63,11 +65,11 @@ defmodule MingaAgent.ProjectView.Direct do
   @spec list_directory(ProjectView.t(), String.t()) ::
           {:ok, [ProjectView.Backend.directory_entry()]} | {:error, term()}
   def list_directory(%ProjectView{} = view, relative_path) do
-    dir = target_path(view, relative_path)
-
-    case File.ls(dir) do
-      {:ok, entries} -> {:ok, Enum.map(Enum.sort(entries), &directory_entry(dir, &1))}
-      {:error, reason} -> {:error, reason}
+    with {:ok, dir} <- safe_target(view, relative_path, allow_root: true) do
+      case File.ls(dir) do
+        {:ok, entries} -> {:ok, Enum.map(Enum.sort(entries), &directory_entry(dir, &1))}
+        {:error, reason} -> {:error, reason}
+      end
     end
   end
 
@@ -129,9 +131,10 @@ defmodule MingaAgent.ProjectView.Direct do
     }
   end
 
-  @spec target_path(ProjectView.t(), String.t()) :: String.t()
-  defp target_path(%ProjectView{project_root: project_root}, relative_path) do
-    Path.join(project_root, relative_path)
+  @spec safe_target(ProjectView.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, :invalid_path | :path_traversal | :symlink_traversal}
+  defp safe_target(%ProjectView{project_root: project_root}, relative_path, opts \\ []) do
+    PathResolver.resolve(project_root, relative_path, opts)
   end
 
   @spec replace_exact(binary(), String.t(), String.t()) ::

--- a/lib/minga_agent/project_view/direct.ex
+++ b/lib/minga_agent/project_view/direct.ex
@@ -1,0 +1,170 @@
+defmodule MingaAgent.ProjectView.Direct do
+  @moduledoc """
+  Direct project view backend.
+
+  Reads and writes files directly under the project root. The backend keeps a small in-memory operation index so `diff/1` and `discard/1` have the same shape as overlay-backed views, but direct writes intentionally mutate the project root immediately.
+  """
+
+  @behaviour MingaAgent.ProjectView.Backend
+
+  alias MingaAgent.ProjectView
+
+  @type direct_state :: %{modified: MapSet.t(String.t()), deleted: MapSet.t(String.t())}
+
+  @doc "Creates a direct backend view."
+  @spec create(String.t(), keyword()) :: {:ok, ProjectView.t()} | {:error, term()}
+  def create(project_root, opts \\ []) when is_binary(project_root) do
+    root = Path.expand(project_root)
+
+    if File.dir?(root) do
+      {:ok, ref} = Agent.start_link(fn -> %{modified: MapSet.new(), deleted: MapSet.new()} end)
+      {:ok, ProjectView.new(__MODULE__, root, ref, opts)}
+    else
+      {:error, {:not_a_directory, root}}
+    end
+  end
+
+  @impl true
+  @spec read_file(ProjectView.t(), String.t()) :: {:ok, binary()} | {:error, term()}
+  def read_file(%ProjectView{} = view, relative_path) do
+    view |> target_path(relative_path) |> File.read()
+  end
+
+  @impl true
+  @spec write_file(ProjectView.t(), String.t(), binary()) :: :ok | {:error, term()}
+  def write_file(%ProjectView{} = view, relative_path, content) do
+    target = target_path(view, relative_path)
+
+    with :ok <- File.mkdir_p(Path.dirname(target)),
+         :ok <- File.write(target, content) do
+      track_modified(view, relative_path)
+    end
+  end
+
+  @impl true
+  @spec edit_file(ProjectView.t(), String.t(), String.t(), String.t()) :: :ok | {:error, term()}
+  def edit_file(%ProjectView{} = view, relative_path, old_text, new_text) do
+    with {:ok, content} <- read_file(view, relative_path),
+         {:ok, edited} <- replace_exact(content, old_text, new_text) do
+      write_file(view, relative_path, edited)
+    end
+  end
+
+  @impl true
+  @spec delete_file(ProjectView.t(), String.t()) :: :ok | {:error, term()}
+  def delete_file(%ProjectView{} = view, relative_path) do
+    case view |> target_path(relative_path) |> File.rm() do
+      :ok -> track_deleted(view, relative_path)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
+  @spec list_directory(ProjectView.t(), String.t()) ::
+          {:ok, [ProjectView.Backend.directory_entry()]} | {:error, term()}
+  def list_directory(%ProjectView{} = view, relative_path) do
+    dir = target_path(view, relative_path)
+
+    case File.ls(dir) do
+      {:ok, entries} -> {:ok, Enum.map(Enum.sort(entries), &directory_entry(dir, &1))}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
+  @spec working_dir(ProjectView.t()) :: String.t()
+  def working_dir(%ProjectView{project_root: project_root}), do: project_root
+
+  @impl true
+  @spec command_env(ProjectView.t()) :: [{String.t(), String.t()}]
+  def command_env(%ProjectView{}), do: []
+
+  @impl true
+  @spec diff(ProjectView.t()) :: {:ok, [map()]} | {:error, term()}
+  def diff(%ProjectView{} = view) do
+    state = Agent.get(view.ref, & &1)
+
+    modified =
+      state.modified
+      |> MapSet.to_list()
+      |> Enum.sort()
+      |> Enum.map(&%{path: &1, kind: :modified})
+
+    deleted =
+      state.deleted
+      |> MapSet.to_list()
+      |> Enum.sort()
+      |> Enum.map(&%{path: &1, kind: :deleted})
+
+    {:ok, modified ++ deleted}
+  end
+
+  @impl true
+  @spec promote(ProjectView.t(), term()) :: :ok | {:error, term()}
+  def promote(%ProjectView{}, :project_root), do: :ok
+
+  def promote(%ProjectView{project_root: root}, target) when is_binary(target) do
+    if Path.expand(target) == root, do: :ok, else: {:error, {:unsupported_target, target}}
+  end
+
+  def promote(%ProjectView{}, target), do: {:error, {:unsupported_target, target}}
+
+  @impl true
+  @spec discard(ProjectView.t()) :: :ok | {:error, term()}
+  def discard(%ProjectView{} = view) do
+    Agent.update(view.ref, fn _ -> %{modified: MapSet.new(), deleted: MapSet.new()} end)
+  catch
+    :exit, _ -> :ok
+  end
+
+  @impl true
+  @spec capabilities(ProjectView.t()) :: ProjectView.Backend.capabilities()
+  def capabilities(%ProjectView{}) do
+    %{
+      isolation: :none,
+      mutates_project_root: true,
+      supports_promote: false,
+      supports_discard: false,
+      supports_command_env: false
+    }
+  end
+
+  @spec target_path(ProjectView.t(), String.t()) :: String.t()
+  defp target_path(%ProjectView{project_root: project_root}, relative_path) do
+    Path.join(project_root, relative_path)
+  end
+
+  @spec replace_exact(binary(), String.t(), String.t()) ::
+          {:ok, binary()} | {:error, :old_text_not_found}
+  defp replace_exact(content, old_text, new_text) do
+    if String.contains?(content, old_text) do
+      {:ok, String.replace(content, old_text, new_text, global: false)}
+    else
+      {:error, :old_text_not_found}
+    end
+  end
+
+  @spec directory_entry(String.t(), String.t()) :: ProjectView.Backend.directory_entry()
+  defp directory_entry(dir, name) do
+    type = if File.dir?(Path.join(dir, name)), do: :directory, else: :file
+    %{name: name, type: type}
+  end
+
+  @spec track_modified(ProjectView.t(), String.t()) :: :ok
+  defp track_modified(%ProjectView{} = view, relative_path) do
+    Agent.update(view.ref, fn state ->
+      state
+      |> Map.update!(:modified, &MapSet.put(&1, relative_path))
+      |> Map.update!(:deleted, &MapSet.delete(&1, relative_path))
+    end)
+  end
+
+  @spec track_deleted(ProjectView.t(), String.t()) :: :ok
+  defp track_deleted(%ProjectView{} = view, relative_path) do
+    Agent.update(view.ref, fn state ->
+      state
+      |> Map.update!(:modified, &MapSet.delete(&1, relative_path))
+      |> Map.update!(:deleted, &MapSet.put(&1, relative_path))
+    end)
+  end
+end

--- a/lib/minga_agent/project_view/overlay.ex
+++ b/lib/minga_agent/project_view/overlay.ex
@@ -1,0 +1,188 @@
+defmodule MingaAgent.ProjectView.Overlay do
+  @moduledoc """
+  Overlay-backed project view backend.
+
+  This backend delegates isolation to existing `MingaAgent.Changeset` and uses `MingaAgent.BufferForkStore` only for lifecycle operations when a fork store is provided.
+  """
+
+  @behaviour MingaAgent.ProjectView.Backend
+
+  alias MingaAgent.BufferForkStore
+  alias MingaAgent.Changeset
+  alias MingaAgent.ProjectView
+
+  @type ref :: %{changeset: pid(), fork_store: pid() | nil}
+
+  @doc "Creates an overlay-backed view."
+  @spec create(String.t(), keyword()) :: {:ok, ProjectView.t()} | {:error, term()}
+  def create(project_root, opts \\ []) when is_binary(project_root) do
+    root = Path.expand(project_root)
+
+    with {:ok, changeset} <- Changeset.create(root, Keyword.get(opts, :changeset_opts, [])) do
+      ref = %{changeset: changeset, fork_store: Keyword.get(opts, :fork_store)}
+      {:ok, ProjectView.new(__MODULE__, root, ref, opts)}
+    end
+  end
+
+  @impl true
+  @spec read_file(ProjectView.t(), String.t()) :: {:ok, binary()} | {:error, term()}
+  def read_file(%ProjectView{} = view, relative_path) do
+    Changeset.read_file(changeset(view), relative_path)
+  end
+
+  @impl true
+  @spec write_file(ProjectView.t(), String.t(), binary()) :: :ok | {:error, term()}
+  def write_file(%ProjectView{} = view, relative_path, content) do
+    Changeset.write_file(changeset(view), relative_path, content)
+  end
+
+  @impl true
+  @spec edit_file(ProjectView.t(), String.t(), String.t(), String.t()) :: :ok | {:error, term()}
+  def edit_file(%ProjectView{} = view, relative_path, old_text, new_text) do
+    Changeset.edit_file(changeset(view), relative_path, old_text, new_text)
+  end
+
+  @impl true
+  @spec delete_file(ProjectView.t(), String.t()) :: :ok | {:error, term()}
+  def delete_file(%ProjectView{} = view, relative_path) do
+    Changeset.delete_file(changeset(view), relative_path)
+  end
+
+  @impl true
+  @spec list_directory(ProjectView.t(), String.t()) ::
+          {:ok, [ProjectView.Backend.directory_entry()]} | {:error, term()}
+  def list_directory(%ProjectView{} = view, relative_path) do
+    dir = Path.join(working_dir(view), relative_path)
+
+    case File.ls(dir) do
+      {:ok, entries} ->
+        {:ok, entries |> reject_tombstones() |> Enum.map(&directory_entry(dir, &1))}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl true
+  @spec working_dir(ProjectView.t()) :: String.t()
+  def working_dir(%ProjectView{} = view), do: Changeset.overlay_path(changeset(view))
+
+  @impl true
+  @spec command_env(ProjectView.t()) :: [{String.t(), String.t()}]
+  def command_env(%ProjectView{} = view), do: GenServer.call(changeset(view), :command_env)
+
+  @impl true
+  @spec diff(ProjectView.t()) :: {:ok, [map()]} | {:error, term()}
+  def diff(%ProjectView{} = view) do
+    fork_entries = fork_diff(view)
+    changeset_entries = Changeset.summary(changeset(view))
+    {:ok, Enum.sort_by(fork_entries ++ changeset_entries, & &1.path)}
+  end
+
+  @impl true
+  @spec promote(ProjectView.t(), term()) :: :ok | {:ok, term()} | {:error, term()}
+  def promote(%ProjectView{} = view, :project_root) do
+    with :ok <- promote_forks(view) do
+      Changeset.merge(changeset(view))
+    end
+  end
+
+  def promote(%ProjectView{project_root: root} = view, target) when is_binary(target) do
+    if Path.expand(target) == root do
+      promote(view, :project_root)
+    else
+      {:error, {:unsupported_target, target}}
+    end
+  end
+
+  def promote(%ProjectView{}, target), do: {:error, {:unsupported_target, target}}
+
+  @impl true
+  @spec discard(ProjectView.t()) :: :ok | {:error, term()}
+  def discard(%ProjectView{} = view) do
+    discard_forks(view)
+    Changeset.discard(changeset(view))
+  end
+
+  @impl true
+  @spec capabilities(ProjectView.t()) :: ProjectView.Backend.capabilities()
+  def capabilities(%ProjectView{}) do
+    %{
+      isolation: :overlay,
+      mutates_project_root: false,
+      supports_promote: true,
+      supports_discard: true,
+      supports_command_env: true
+    }
+  end
+
+  @spec changeset(ProjectView.t()) :: pid()
+  defp changeset(%ProjectView{ref: %{changeset: changeset}}), do: changeset
+
+  @spec fork_store(ProjectView.t()) :: pid() | nil
+  defp fork_store(%ProjectView{ref: %{fork_store: fork_store}}), do: fork_store
+
+  @spec reject_tombstones([String.t()]) :: [String.t()]
+  defp reject_tombstones(entries) do
+    entries
+    |> Enum.reject(fn entry ->
+      String.ends_with?(entry, ".__changeset_deleted__") or
+        Enum.member?(entries, entry <> ".__changeset_deleted__")
+    end)
+    |> Enum.sort()
+  end
+
+  @spec directory_entry(String.t(), String.t()) :: ProjectView.Backend.directory_entry()
+  defp directory_entry(dir, name) do
+    type = if File.dir?(Path.join(dir, name)), do: :directory, else: :file
+    %{name: name, type: type}
+  end
+
+  @spec fork_diff(ProjectView.t()) :: [map()]
+  defp fork_diff(%ProjectView{} = view) do
+    case fork_store(view) do
+      nil ->
+        []
+
+      store ->
+        store
+        |> BufferForkStore.all()
+        |> Map.keys()
+        |> Enum.map(&%{path: Path.relative_to(&1, view.project_root), kind: :modified})
+    end
+  catch
+    :exit, _ -> []
+  end
+
+  @spec promote_forks(ProjectView.t()) :: :ok | {:error, {:fork_merge_failed, [term()]}}
+  defp promote_forks(%ProjectView{} = view) do
+    case fork_store(view) do
+      nil ->
+        :ok
+
+      store ->
+        store
+        |> BufferForkStore.merge_all_keep_failed()
+        |> fork_merge_result()
+    end
+  catch
+    :exit, reason -> {:error, {:fork_merge_failed, [{:exit, reason}]}}
+  end
+
+  @spec fork_merge_result([{String.t(), :ok | {:conflict, term()} | {:error, term()}}]) ::
+          :ok | {:error, {:fork_merge_failed, [term()]}}
+  defp fork_merge_result(results) do
+    failures = Enum.reject(results, &match?({_path, :ok}, &1))
+    if failures == [], do: :ok, else: {:error, {:fork_merge_failed, failures}}
+  end
+
+  @spec discard_forks(ProjectView.t()) :: :ok
+  defp discard_forks(%ProjectView{} = view) do
+    case fork_store(view) do
+      nil -> :ok
+      store -> BufferForkStore.discard_all(store)
+    end
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/lib/minga_agent/project_view/overlay.ex
+++ b/lib/minga_agent/project_view/overlay.ex
@@ -10,6 +10,7 @@ defmodule MingaAgent.ProjectView.Overlay do
   alias MingaAgent.BufferForkStore
   alias MingaAgent.Changeset
   alias MingaAgent.ProjectView
+  alias MingaAgent.ProjectView.PathResolver
 
   @type ref :: %{changeset: pid(), fork_store: pid() | nil}
 
@@ -52,14 +53,18 @@ defmodule MingaAgent.ProjectView.Overlay do
   @spec list_directory(ProjectView.t(), String.t()) ::
           {:ok, [ProjectView.Backend.directory_entry()]} | {:error, term()}
   def list_directory(%ProjectView{} = view, relative_path) do
-    dir = Path.join(working_dir(view), relative_path)
+    with {:ok, project_dir} <-
+           PathResolver.resolve(view.project_root, relative_path, allow_root: true) do
+      relative_dir = Path.relative_to(project_dir, view.project_root)
+      dir = Path.join(working_dir(view), relative_dir)
 
-    case File.ls(dir) do
-      {:ok, entries} ->
-        {:ok, entries |> reject_tombstones() |> Enum.map(&directory_entry(dir, &1))}
+      case File.ls(dir) do
+        {:ok, entries} ->
+          {:ok, entries |> reject_tombstones() |> Enum.map(&directory_entry(dir, &1))}
 
-      {:error, reason} ->
-        {:error, reason}
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 
@@ -140,18 +145,13 @@ defmodule MingaAgent.ProjectView.Overlay do
 
   @spec fork_diff(ProjectView.t()) :: [map()]
   defp fork_diff(%ProjectView{} = view) do
-    case fork_store(view) do
-      nil ->
-        []
+    case scoped_fork_paths(view, on_invalid: :ignore) do
+      {:ok, paths} ->
+        Enum.map(paths, &%{path: Path.relative_to(&1, view.project_root), kind: :modified})
 
-      store ->
-        store
-        |> BufferForkStore.all()
-        |> Map.keys()
-        |> Enum.map(&%{path: Path.relative_to(&1, view.project_root), kind: :modified})
+      {:error, _} ->
+        []
     end
-  catch
-    :exit, _ -> []
   end
 
   @spec promote_forks(ProjectView.t()) :: :ok | {:error, {:fork_merge_failed, [term()]}}
@@ -161,9 +161,10 @@ defmodule MingaAgent.ProjectView.Overlay do
         :ok
 
       store ->
-        store
-        |> BufferForkStore.merge_all_keep_failed()
-        |> fork_merge_result()
+        with {:ok, paths} <- scoped_fork_paths(view, on_invalid: :error),
+             results <- BufferForkStore.merge_paths_keep_failed(store, paths) do
+          fork_merge_result(results)
+        end
     end
   catch
     :exit, reason -> {:error, {:fork_merge_failed, [{:exit, reason}]}}
@@ -179,10 +180,81 @@ defmodule MingaAgent.ProjectView.Overlay do
   @spec discard_forks(ProjectView.t()) :: :ok
   defp discard_forks(%ProjectView{} = view) do
     case fork_store(view) do
-      nil -> :ok
-      store -> BufferForkStore.discard_all(store)
+      nil ->
+        :ok
+
+      store ->
+        case scoped_fork_paths(view, on_invalid: :ignore) do
+          {:ok, paths} -> BufferForkStore.discard_paths(store, paths)
+          {:error, _} -> :ok
+        end
     end
   catch
     :exit, _ -> :ok
   end
+
+  @spec scoped_fork_paths(ProjectView.t(), keyword()) :: {:ok, [String.t()]} | {:error, term()}
+  defp scoped_fork_paths(%ProjectView{} = view, opts) do
+    on_invalid = Keyword.get(opts, :on_invalid, :error)
+
+    case fork_store(view) do
+      nil ->
+        {:ok, []}
+
+      store ->
+        try do
+          paths =
+            store
+            |> BufferForkStore.all()
+            |> Map.keys()
+            |> Enum.reduce_while([], fn path, acc ->
+              case scoped_fork_path(view.project_root, path) do
+                {:ok, scoped_path} ->
+                  {:cont, [scoped_path | acc]}
+
+                :skip ->
+                  {:cont, acc}
+
+                {:error, reason} ->
+                  if on_invalid == :ignore do
+                    {:cont, acc}
+                  else
+                    {:halt, {:error, reason}}
+                  end
+              end
+            end)
+
+          case paths do
+            {:error, _} = error -> error
+            paths -> {:ok, Enum.sort(paths)}
+          end
+        catch
+          :exit, reason ->
+            if on_invalid == :ignore do
+              {:ok, []}
+            else
+              {:error, {:fork_store_unreachable, reason}}
+            end
+        end
+    end
+  end
+
+  @spec scoped_fork_path(String.t(), String.t()) :: :skip | {:ok, String.t()} | {:error, term()}
+  defp scoped_fork_path(root, path) do
+    expanded_path = Path.expand(path)
+
+    if inside_root?(expanded_path, root) do
+      relative_path = Path.relative_to(expanded_path, root)
+
+      case PathResolver.resolve(root, relative_path, allow_root: true) do
+        {:ok, _resolved} -> {:ok, expanded_path}
+        {:error, reason} -> {:error, {:fork_path_outside_project_root, expanded_path, reason}}
+      end
+    else
+      :skip
+    end
+  end
+
+  @spec inside_root?(String.t(), String.t()) :: boolean()
+  defp inside_root?(path, root), do: path == root or String.starts_with?(path, root <> "/")
 end

--- a/lib/minga_agent/project_view/overlay.ex
+++ b/lib/minga_agent/project_view/overlay.ex
@@ -87,8 +87,15 @@ defmodule MingaAgent.ProjectView.Overlay do
   @impl true
   @spec promote(ProjectView.t(), term()) :: :ok | {:ok, term()} | {:error, term()}
   def promote(%ProjectView{} = view, :project_root) do
-    with :ok <- promote_forks(view) do
-      Changeset.merge(changeset(view))
+    case preflight_changeset_merge(view) do
+      :ok ->
+        with :ok <- promote_forks(view) do
+          Changeset.merge(changeset(view))
+        end
+
+      {:error, reason} ->
+        quarantine_invalid_scoped_forks(view)
+        {:error, reason}
     end
   end
 
@@ -145,8 +152,8 @@ defmodule MingaAgent.ProjectView.Overlay do
 
   @spec fork_diff(ProjectView.t()) :: [map()]
   defp fork_diff(%ProjectView{} = view) do
-    case scoped_fork_paths(view, on_invalid: :ignore) do
-      {:ok, paths} ->
+    case scoped_fork_partition(view) do
+      {:ok, %{valid: paths}} ->
         Enum.map(paths, &%{path: Path.relative_to(&1, view.project_root), kind: :modified})
 
       {:error, _} ->
@@ -154,20 +161,63 @@ defmodule MingaAgent.ProjectView.Overlay do
     end
   end
 
-  @spec promote_forks(ProjectView.t()) :: :ok | {:error, {:fork_merge_failed, [term()]}}
+  @spec promote_forks(ProjectView.t()) :: :ok | {:error, term()}
   defp promote_forks(%ProjectView{} = view) do
     case fork_store(view) do
       nil ->
         :ok
 
       store ->
-        with {:ok, paths} <- scoped_fork_paths(view, on_invalid: :error),
-             results <- BufferForkStore.merge_paths_keep_failed(store, paths) do
-          fork_merge_result(results)
-        end
+        view
+        |> scoped_fork_partition()
+        |> promote_partition(store)
     end
   catch
     :exit, reason -> {:error, {:fork_merge_failed, [{:exit, reason}]}}
+  end
+
+  @spec promote_partition(
+          {:ok, %{valid: [String.t()], invalid: [{String.t(), term()}]}} | {:error, term()},
+          GenServer.server()
+        ) :: :ok | {:error, term()}
+  defp promote_partition({:ok, %{valid: valid_paths, invalid: []}}, store) do
+    store
+    |> BufferForkStore.merge_paths_keep_failed(valid_paths)
+    |> fork_merge_result()
+  end
+
+  defp promote_partition({:ok, %{invalid: [{_path, reason} | _] = invalid_paths}}, store) do
+    discard_scoped_paths(store, Enum.map(invalid_paths, &elem(&1, 0)))
+    {:error, reason}
+  end
+
+  defp promote_partition({:error, reason}, _store), do: {:error, reason}
+
+  @spec preflight_changeset_merge(ProjectView.t()) :: :ok | {:error, term()}
+  defp preflight_changeset_merge(%ProjectView{} = view) do
+    case Changeset.preflight_merge(changeset(view)) do
+      {:ok, _plan} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec quarantine_invalid_scoped_forks(ProjectView.t()) :: :ok
+  defp quarantine_invalid_scoped_forks(%ProjectView{} = view) do
+    case fork_store(view) do
+      nil ->
+        :ok
+
+      store ->
+        case scoped_fork_partition(view) do
+          {:ok, %{invalid: invalid_paths}} ->
+            discard_scoped_paths(store, Enum.map(invalid_paths, &elem(&1, 0)))
+
+          {:error, _} ->
+            :ok
+        end
+    end
+  catch
+    :exit, _ -> :ok
   end
 
   @spec fork_merge_result([{String.t(), :ok | {:conflict, term()} | {:error, term()}}]) ::
@@ -184,59 +234,60 @@ defmodule MingaAgent.ProjectView.Overlay do
         :ok
 
       store ->
-        case scoped_fork_paths(view, on_invalid: :ignore) do
-          {:ok, paths} -> BufferForkStore.discard_paths(store, paths)
-          {:error, _} -> :ok
+        case scoped_fork_partition(view) do
+          {:ok, %{valid: valid_paths, invalid: invalid_paths}} ->
+            discard_scoped_paths(store, valid_paths ++ Enum.map(invalid_paths, &elem(&1, 0)))
+
+          {:error, _} ->
+            :ok
         end
     end
   catch
     :exit, _ -> :ok
   end
 
-  @spec scoped_fork_paths(ProjectView.t(), keyword()) :: {:ok, [String.t()]} | {:error, term()}
-  defp scoped_fork_paths(%ProjectView{} = view, opts) do
-    on_invalid = Keyword.get(opts, :on_invalid, :error)
-
+  @spec scoped_fork_partition(ProjectView.t()) ::
+          {:ok, %{valid: [String.t()], invalid: [{String.t(), term()}]}} | {:error, term()}
+  defp scoped_fork_partition(%ProjectView{} = view) do
     case fork_store(view) do
       nil ->
-        {:ok, []}
+        {:ok, %{valid: [], invalid: []}}
 
       store ->
         try do
-          paths =
+          {valid_paths, invalid_paths} =
             store
             |> BufferForkStore.all()
             |> Map.keys()
-            |> Enum.reduce_while([], fn path, acc ->
+            |> Enum.reduce({[], []}, fn path, {valid_acc, invalid_acc} ->
               case scoped_fork_path(view.project_root, path) do
                 {:ok, scoped_path} ->
-                  {:cont, [scoped_path | acc]}
+                  {[scoped_path | valid_acc], invalid_acc}
 
                 :skip ->
-                  {:cont, acc}
+                  {valid_acc, invalid_acc}
 
                 {:error, reason} ->
-                  if on_invalid == :ignore do
-                    {:cont, acc}
-                  else
-                    {:halt, {:error, reason}}
-                  end
+                  {valid_acc, [{path, reason} | invalid_acc]}
               end
             end)
 
-          case paths do
-            {:error, _} = error -> error
-            paths -> {:ok, Enum.sort(paths)}
-          end
+          {:ok,
+           %{
+             valid: Enum.sort(valid_paths),
+             invalid: Enum.sort_by(invalid_paths, &elem(&1, 0))
+           }}
         catch
-          :exit, reason ->
-            if on_invalid == :ignore do
-              {:ok, []}
-            else
-              {:error, {:fork_store_unreachable, reason}}
-            end
+          :exit, reason -> {:error, {:fork_store_unreachable, reason}}
         end
     end
+  end
+
+  @spec discard_scoped_paths(GenServer.server(), [String.t()]) :: :ok
+  defp discard_scoped_paths(store, paths) do
+    BufferForkStore.discard_paths(store, Enum.uniq(paths))
+  catch
+    :exit, _ -> :ok
   end
 
   @spec scoped_fork_path(String.t(), String.t()) :: :skip | {:ok, String.t()} | {:error, term()}

--- a/lib/minga_agent/project_view/path_resolver.ex
+++ b/lib/minga_agent/project_view/path_resolver.ex
@@ -1,0 +1,207 @@
+defmodule MingaAgent.ProjectView.PathResolver do
+  @moduledoc false
+
+  @spec resolve(String.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, :invalid_path | :path_traversal | :symlink_traversal}
+  def resolve(project_root, relative_path, opts \\ [])
+      when is_binary(project_root) and is_binary(relative_path) do
+    allow_root? = Keyword.get(opts, :allow_root, false)
+    root = Path.expand(project_root)
+
+    with {:ok, components} <- validated_components(relative_path, allow_root?) do
+      resolve_components(root, root, root, components, allow_root?)
+    end
+  end
+
+  @spec validated_components(String.t(), boolean()) ::
+          {:ok, [String.t()]} | {:error, :invalid_path | :path_traversal}
+  defp validated_components(path, allow_root?) do
+    components = normalized_components(path)
+    reject_invalid_components(path, components, allow_root?)
+  end
+
+  @spec reject_invalid_components(String.t(), [String.t()], boolean()) ::
+          {:ok, [String.t()]} | {:error, :invalid_path | :path_traversal}
+  defp reject_invalid_components(<<"/", _::binary>>, _components, _allow_root?),
+    do: {:error, :path_traversal}
+
+  defp reject_invalid_components(_path, components, allow_root?)
+       when components == [] and allow_root?,
+       do: {:ok, components}
+
+  defp reject_invalid_components(_path, components, _allow_root?) when components == [],
+    do: {:error, :invalid_path}
+
+  defp reject_invalid_components(_path, components, _allow_root?) do
+    if Enum.member?(components, "..") do
+      {:error, :path_traversal}
+    else
+      {:ok, components}
+    end
+  end
+
+  @spec resolve_components(String.t(), String.t(), String.t(), [String.t()], boolean()) ::
+          {:ok, String.t()} | {:error, :invalid_path | :path_traversal | :symlink_traversal}
+  defp resolve_components(_root, _validation_current, output_current, [], true),
+    do: {:ok, output_current}
+
+  defp resolve_components(_root, _validation_current, _output_current, [], false),
+    do: {:error, :invalid_path}
+
+  defp resolve_components(
+         root,
+         validation_current,
+         output_current,
+         [component | rest],
+         allow_root?
+       ) do
+    validation_candidate = Path.join(validation_current, component)
+    output_candidate = Path.join(output_current, component)
+
+    validation_candidate
+    |> File.lstat()
+    |> resolve_candidate(root, validation_candidate, output_candidate, rest, allow_root?)
+  end
+
+  @spec resolve_candidate(
+          {:ok, File.Stat.t()} | {:error, File.posix()},
+          String.t(),
+          String.t(),
+          String.t(),
+          [String.t()],
+          boolean()
+        ) :: {:ok, String.t()} | {:error, term()}
+  defp resolve_candidate(
+         {:ok, %{type: :symlink}},
+         root,
+         validation_candidate,
+         output_candidate,
+         rest,
+         allow_root?
+       ) do
+    with {:ok, resolved} <- resolve_symlink_path(validation_candidate) do
+      resolve_symlink_candidate(root, resolved, output_candidate, rest, allow_root?)
+    end
+  end
+
+  defp resolve_candidate(
+         {:ok, %{type: :directory}},
+         root,
+         validation_candidate,
+         output_candidate,
+         rest,
+         allow_root?
+       ) do
+    resolve_components(root, validation_candidate, output_candidate, rest, allow_root?)
+  end
+
+  defp resolve_candidate(
+         {:ok, _stat},
+         _root,
+         _validation_candidate,
+         output_candidate,
+         [],
+         _allow_root?
+       ),
+       do: {:ok, output_candidate}
+
+  defp resolve_candidate(
+         {:ok, _stat},
+         _root,
+         _validation_candidate,
+         _output_candidate,
+         _rest,
+         _allow_root?
+       ),
+       do: {:error, :path_traversal}
+
+  defp resolve_candidate(
+         {:error, :enoent},
+         _root,
+         _validation_candidate,
+         output_candidate,
+         [],
+         _allow_root?
+       ),
+       do: {:ok, output_candidate}
+
+  defp resolve_candidate(
+         {:error, :enoent},
+         _root,
+         _validation_candidate,
+         output_candidate,
+         rest,
+         _allow_root?
+       ),
+       do: {:ok, Path.join([output_candidate | rest])}
+
+  defp resolve_candidate(
+         {:error, reason},
+         _root,
+         _validation_candidate,
+         _output_candidate,
+         _rest,
+         _allow_root?
+       ),
+       do: {:error, reason}
+
+  @spec resolve_symlink_candidate(String.t(), String.t(), String.t(), [String.t()], boolean()) ::
+          {:ok, String.t()} | {:error, :symlink_traversal | term()}
+  defp resolve_symlink_candidate(root, resolved, output_candidate, [], _allow_root?) do
+    if inside_root?(resolved, root),
+      do: {:ok, output_candidate},
+      else: {:error, :symlink_traversal}
+  end
+
+  defp resolve_symlink_candidate(root, resolved, output_candidate, rest, allow_root?) do
+    if inside_root?(resolved, root) do
+      resolve_components(root, resolved, output_candidate, rest, allow_root?)
+    else
+      {:error, :symlink_traversal}
+    end
+  end
+
+  @spec normalized_components(String.t()) :: [String.t()]
+  defp normalized_components(path) do
+    path
+    |> String.trim_leading("./")
+    |> Path.split()
+    |> Enum.reject(&(&1 in [".", ""]))
+  end
+
+  @spec inside_root?(String.t(), String.t()) :: boolean()
+  defp inside_root?(path, root), do: path == root or String.starts_with?(path, root <> "/")
+
+  @spec resolve_symlink_path(String.t()) :: {:ok, String.t()} | {:error, term()}
+  defp resolve_symlink_path(path), do: resolve_symlink_path(path, [])
+
+  @spec resolve_symlink_path(String.t(), [String.t()]) :: {:ok, String.t()} | {:error, term()}
+  defp resolve_symlink_path(path, seen) do
+    if path in seen do
+      {:error, :symlink_traversal}
+    else
+      read_symlink_target(path, seen)
+    end
+  end
+
+  @spec read_symlink_target(String.t(), [String.t()]) :: {:ok, String.t()} | {:error, term()}
+  defp read_symlink_target(path, seen) do
+    with {:ok, target} <- File.read_link(path) do
+      path
+      |> Path.dirname()
+      |> resolve_symlink_target(target, seen, path)
+    end
+  end
+
+  @spec resolve_symlink_target(String.t(), String.t(), [String.t()], String.t()) ::
+          {:ok, String.t()} | {:error, term()}
+  defp resolve_symlink_target(dirname, target, seen, path) do
+    resolved = Path.expand(target, dirname)
+
+    case File.lstat(resolved) do
+      {:ok, %{type: :symlink}} -> resolve_symlink_path(resolved, [path | seen])
+      {:ok, _stat} -> {:ok, resolved}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/minga_editor/mouse/hit_test.ex
+++ b/lib/minga_editor/mouse/hit_test.ex
@@ -57,6 +57,8 @@ defmodule MingaEditor.Mouse.HitTest do
     else
       _ -> :miss
     end
+  catch
+    :exit, _ -> :miss
   end
 
   @spec position(

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -1174,6 +1174,8 @@ defmodule MingaEditor.State do
       _ ->
         state
     end
+  catch
+    :exit, _ -> state
   end
 
   @doc """

--- a/test/minga_agent/buffer_fork_store_test.exs
+++ b/test/minga_agent/buffer_fork_store_test.exs
@@ -64,14 +64,22 @@ defmodule MingaAgent.BufferForkStoreTest do
 
   describe "merge_all/1" do
     test "merges dirty forks back", %{store: store, parent: parent} do
-      {:ok, fork_pid} = BufferForkStore.get_or_create(store, "/test/foo.ex", parent)
+      merge_root =
+        Path.join(System.tmp_dir!(), "fork-merge-success-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(merge_root)
+      fork_path = Path.join(merge_root, "foo.ex")
+      File.write!(fork_path, "line one\nline two\nline three\n")
+
+      {:ok, fork_pid} = BufferForkStore.get_or_create(store, fork_path, parent)
 
       # Edit the fork
       Fork.replace_content(fork_pid, "modified content\n")
       assert Fork.dirty?(fork_pid)
 
       results = BufferForkStore.merge_all(store)
-      assert [{"/test/foo.ex", :ok}] = results
+      assert [{^fork_path, :ok}] = results
+      assert File.read!(fork_path) == "modified content\n"
 
       # Store is empty after merge
       assert %{} == BufferForkStore.all(store)
@@ -85,6 +93,87 @@ defmodule MingaAgent.BufferForkStoreTest do
     end
   end
 
+  describe "merge_all_keep_failed/1" do
+    test "removes successful forks and preserves forks whose fallback write fails", %{
+      store: store,
+      parent: parent
+    } do
+      {:ok, _success_fork} = BufferForkStore.get_or_create(store, "/test/success.ex", parent)
+      {:ok, conflict_fork} = BufferForkStore.get_or_create(store, "/test/conflict.ex", parent)
+
+      error_root =
+        Path.join(System.tmp_dir!(), "fork-merge-error-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(error_root)
+      error_path = Path.join(error_root, "error.ex")
+      File.write!(error_path, "line one\nline two\nline three\n")
+
+      {:ok, error_parent} =
+        start_supervised(
+          {Minga.Buffer.Process, content: "line one\nline two\nline three\n", name: nil},
+          id: :error_parent
+        )
+
+      {:ok, error_fork} = BufferForkStore.get_or_create(store, error_path, error_parent)
+
+      Fork.replace_content(conflict_fork, "line one\nfork change\nline three\n")
+      Fork.replace_content(error_fork, "line one\nerror change\nline three\n")
+
+      Minga.Buffer.Process.replace_content(
+        parent,
+        "line one\nparent change\nline three\n",
+        :agent
+      )
+
+      File.rm_rf!(error_root)
+
+      results = BufferForkStore.merge_all_keep_failed(store)
+      result_map = Map.new(results)
+
+      assert result_map["/test/success.ex"] == :ok
+      assert match?({:conflict, _}, result_map["/test/conflict.ex"])
+      assert result_map[error_path] == {:error, :enoent}
+
+      assert nil == BufferForkStore.get(store, "/test/success.ex")
+
+      assert %{
+               "/test/conflict.ex" => conflict_pid,
+               ^error_path => error_pid
+             } = BufferForkStore.all(store)
+
+      assert Fork.dirty?(conflict_pid)
+      assert Fork.dirty?(error_pid)
+      assert is_binary(Fork.content(conflict_pid))
+      assert is_binary(Fork.content(error_pid))
+    end
+  end
+
+  describe "merge_paths_keep_failed/2" do
+    test "removes only the selected forks and preserves the rest", %{store: store, parent: parent} do
+      merge_root =
+        Path.join(System.tmp_dir!(), "fork-merge-selected-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(merge_root)
+      selected_path = Path.join(merge_root, "selected.ex")
+      untouched_path = Path.join(merge_root, "untouched.ex")
+      File.write!(selected_path, "selected original\n")
+      File.write!(untouched_path, "untouched original\n")
+
+      {:ok, selected_fork} = BufferForkStore.get_or_create(store, selected_path, parent)
+      {:ok, untouched_fork} = BufferForkStore.get_or_create(store, untouched_path, parent)
+
+      Fork.replace_content(selected_fork, "selected change\n")
+      Fork.replace_content(untouched_fork, "untouched change\n")
+
+      results = BufferForkStore.merge_paths_keep_failed(store, [selected_path])
+      assert [{^selected_path, :ok}] = results
+      assert {:ok, "selected change\n"} = File.read(selected_path)
+      assert nil == BufferForkStore.get(store, selected_path)
+      assert BufferForkStore.get(store, untouched_path) == untouched_fork
+      assert Fork.dirty?(untouched_fork)
+    end
+  end
+
   describe "discard_all/1" do
     test "removes all forks without merging", %{store: store, parent: parent} do
       {:ok, fork_pid} = BufferForkStore.get_or_create(store, "/test/foo.ex", parent)
@@ -95,6 +184,21 @@ defmodule MingaAgent.BufferForkStoreTest do
 
       # Original buffer is untouched
       assert Minga.Buffer.Process.content(parent) == "line one\nline two\nline three\n"
+    end
+  end
+
+  describe "discard_paths/2" do
+    test "removes only the selected forks", %{store: store, parent: parent} do
+      {:ok, selected_fork} = BufferForkStore.get_or_create(store, "/test/selected.ex", parent)
+      {:ok, untouched_fork} = BufferForkStore.get_or_create(store, "/test/untouched.ex", parent)
+
+      Fork.replace_content(selected_fork, "selected change\n")
+      Fork.replace_content(untouched_fork, "untouched change\n")
+
+      assert :ok = BufferForkStore.discard_paths(store, ["/test/selected.ex"])
+      assert nil == BufferForkStore.get(store, "/test/selected.ex")
+      assert BufferForkStore.get(store, "/test/untouched.ex") == untouched_fork
+      assert Fork.dirty?(untouched_fork)
     end
   end
 

--- a/test/minga_agent/changeset/server_test.exs
+++ b/test/minga_agent/changeset/server_test.exs
@@ -313,6 +313,7 @@ defmodule MingaAgent.Changeset.ServerTest do
       server = start_server(project)
 
       GenServer.call(server, {:write_file, "hello.txt", "merged content"})
+      GenServer.call(server, {:write_file, "lib/foo.ex", "agent version"})
 
       outside_dir =
         Path.join(Path.dirname(project), "merge-escape-#{System.unique_integer([:positive])}")
@@ -320,14 +321,66 @@ defmodule MingaAgent.Changeset.ServerTest do
       File.mkdir_p!(outside_dir)
       outside_file = Path.join(outside_dir, "secret.txt")
       File.write!(outside_file, "secret")
-      File.rm!(Path.join(project, "hello.txt"))
-      File.ln_s!(outside_file, Path.join(project, "hello.txt"))
+      File.rm!(Path.join(project, "lib/foo.ex"))
+      File.ln_s!(outside_file, Path.join(project, "lib/foo.ex"))
 
       assert {:error, :symlink_traversal} = GenServer.call(server, :merge)
       assert File.read!(outside_file) == "secret"
+      assert File.read!(Path.join(project, "hello.txt")) == "original content"
 
       modified = GenServer.call(server, :modified_files)
       assert "hello.txt" in modified.modified
+      assert "lib/foo.ex" in modified.modified
+    end
+
+    test "preflight_merge validates the same plan without applying or cleaning up", %{
+      project: project
+    } do
+      server = start_server(project)
+
+      GenServer.call(server, {:write_file, "hello.txt", "merged content"})
+
+      outside_dir =
+        Path.join(Path.dirname(project), "preflight-escape-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(outside_dir)
+      outside_file = Path.join(outside_dir, "secret.txt")
+      File.write!(outside_file, "secret")
+      File.rm!(Path.join(project, "hello.txt"))
+      File.ln_s!(outside_file, Path.join(project, "hello.txt"))
+
+      assert {:error, :symlink_traversal} = MingaAgent.Changeset.preflight_merge(server)
+      assert File.read!(outside_file) == "secret"
+      assert File.dir?(GenServer.call(server, :overlay_path))
+
+      File.rm!(Path.join(project, "hello.txt"))
+      File.write!(Path.join(project, "hello.txt"), "project version")
+
+      assert {:ok, "merged content"} = GenServer.call(server, {:read_file, "hello.txt"})
+    end
+
+    test "preflight_merge returns read errors when a tracked file becomes a directory", %{
+      project: project
+    } do
+      server = start_server(project)
+      ref = Process.monitor(server)
+
+      assert :ok = GenServer.call(server, {:write_file, "hello.txt", "merged content"})
+      overlay = GenServer.call(server, :overlay_path)
+
+      File.rm!(Path.join(project, "hello.txt"))
+      File.mkdir_p!(Path.join(project, "hello.txt"))
+
+      assert {:error, reason} = MingaAgent.Changeset.preflight_merge(server)
+      assert reason in [:invalid_path, :eisdir]
+      refute_receive {:DOWN, ^ref, :process, ^server, _reason}, 0
+      assert File.dir?(overlay)
+      assert File.dir?(Path.join(project, "hello.txt"))
+
+      File.rm_rf!(Path.join(project, "hello.txt"))
+      File.write!(Path.join(project, "hello.txt"), "project version")
+
+      assert {:ok, "merged content"} = GenServer.call(server, {:read_file, "hello.txt"})
     end
 
     test "creates new files in the project", %{project: project} do

--- a/test/minga_agent/changeset/server_test.exs
+++ b/test/minga_agent/changeset/server_test.exs
@@ -52,6 +52,34 @@ defmodule MingaAgent.Changeset.ServerTest do
       refute File.exists?(escaped)
     end
 
+    test "rejects symlink escapes through linked directories", %{project: project} do
+      outside_dir =
+        Path.join(Path.dirname(project), "escape-root-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(Path.join(outside_dir, "nested"))
+      File.write!(Path.join(outside_dir, "nested/secret.txt"), "secret")
+      File.ln_s!(outside_dir, Path.join(project, "linked"))
+
+      server = start_server(project)
+
+      assert {:error, :symlink_traversal} =
+               GenServer.call(server, {:read_file, "linked/nested/secret.txt"})
+
+      assert {:error, :symlink_traversal} =
+               GenServer.call(server, {:write_file, "linked/new.txt", "pwned"})
+
+      assert {:error, :symlink_traversal} =
+               GenServer.call(
+                 server,
+                 {:edit_file, "linked/nested/secret.txt", "secret", "public"}
+               )
+
+      assert {:error, :symlink_traversal} =
+               GenServer.call(server, {:delete_file, "linked/nested/secret.txt"})
+
+      assert {:ok, "original content"} = GenServer.call(server, {:read_file, "hello.txt"})
+    end
+
     test "failed overlay writes do not create undo history", %{project: project} do
       dep_file = Path.join(project, "deps/some_dep/lib/real.ex")
       File.mkdir_p!(Path.dirname(dep_file))
@@ -279,6 +307,27 @@ defmodule MingaAgent.Changeset.ServerTest do
 
       # Project has the merged content
       assert File.read!(Path.join(project, "hello.txt")) == "merged content"
+    end
+
+    test "rejects merge when a tracked project file becomes a symlink escape", %{project: project} do
+      server = start_server(project)
+
+      GenServer.call(server, {:write_file, "hello.txt", "merged content"})
+
+      outside_dir =
+        Path.join(Path.dirname(project), "merge-escape-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(outside_dir)
+      outside_file = Path.join(outside_dir, "secret.txt")
+      File.write!(outside_file, "secret")
+      File.rm!(Path.join(project, "hello.txt"))
+      File.ln_s!(outside_file, Path.join(project, "hello.txt"))
+
+      assert {:error, :symlink_traversal} = GenServer.call(server, :merge)
+      assert File.read!(outside_file) == "secret"
+
+      modified = GenServer.call(server, :modified_files)
+      assert "hello.txt" in modified.modified
     end
 
     test "creates new files in the project", %{project: project} do

--- a/test/minga_agent/project_view/project_view_test.exs
+++ b/test/minga_agent/project_view/project_view_test.exs
@@ -1,0 +1,151 @@
+defmodule MingaAgent.ProjectViewTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.ProjectView
+
+  @moduletag :tmp_dir
+
+  describe "shared backend contract" do
+    test "runs the same file contract against direct and overlay backends", %{tmp_dir: dir} do
+      for {name, create_view} <- backend_factories() do
+        backend_dir = Path.join(dir, Atom.to_string(name))
+        seed_project(backend_dir)
+        {:ok, view} = create_view.(backend_dir)
+        assert_shared_file_contract(view)
+        ProjectView.discard(view)
+      end
+    end
+  end
+
+  describe "direct backend contract" do
+    test "read/write/edit/delete/list/diff/discard use logical relative paths", %{tmp_dir: dir} do
+      seed_project(dir)
+      {:ok, view} = ProjectView.direct(dir, workspace_id: 7)
+
+      assert view.workspace_id == 7
+      assert view.project_root == Path.expand(dir)
+      assert ProjectView.working_dir(view) == Path.expand(dir)
+      assert ProjectView.command_env(view) == []
+      assert %{isolation: :none, mutates_project_root: true} = ProjectView.capabilities(view)
+
+      assert {:ok, "one\n"} = ProjectView.read_file(view, "lib/a.txt")
+      assert :ok = ProjectView.write_file(view, "lib/new.txt", "new")
+      assert {:ok, "new"} = File.read(Path.join(dir, "lib/new.txt"))
+      assert :ok = ProjectView.edit_file(view, "lib/a.txt", "one", "ONE")
+      assert {:ok, "ONE\n"} = ProjectView.read_file(view, "lib/a.txt")
+
+      assert {:ok, entries} = ProjectView.list_directory(view, "lib")
+      assert %{name: "a.txt", type: :file} in entries
+      assert %{name: "new.txt", type: :file} in entries
+
+      assert :ok = ProjectView.delete_file(view, "lib/a.txt")
+      assert {:error, :enoent} = ProjectView.read_file(view, "lib/a.txt")
+      refute File.exists?(Path.join(dir, "lib/a.txt"))
+
+      assert {:ok, diff} = ProjectView.diff(view)
+      assert %{path: "lib/new.txt", kind: :modified} in diff
+      assert %{path: "lib/a.txt", kind: :deleted} in diff
+
+      assert :ok = ProjectView.promote(view, :project_root)
+      assert :ok = ProjectView.discard(view)
+      assert {:ok, []} = ProjectView.diff(view)
+    end
+  end
+
+  describe "overlay backend contract" do
+    test "read/write/edit/delete/list/diff/promote/discard stay isolated until promote", %{
+      tmp_dir: dir
+    } do
+      seed_project(dir)
+      {:ok, view} = ProjectView.overlay(dir, workspace_id: 9)
+
+      assert view.workspace_id == 9
+      assert view.project_root == Path.expand(dir)
+      assert ProjectView.working_dir(view) != Path.expand(dir)
+      assert File.dir?(ProjectView.working_dir(view))
+
+      assert {"MIX_BUILD_PATH", _} =
+               List.keyfind(ProjectView.command_env(view), "MIX_BUILD_PATH", 0)
+
+      assert %{isolation: :overlay, mutates_project_root: false} = ProjectView.capabilities(view)
+
+      assert {:ok, "one\n"} = ProjectView.read_file(view, "lib/a.txt")
+      assert :ok = ProjectView.write_file(view, "lib/new.txt", "new")
+      assert :ok = ProjectView.edit_file(view, "lib/a.txt", "one", "ONE")
+      assert {:ok, "ONE\n"} = ProjectView.read_file(view, "lib/a.txt")
+      assert {:ok, "one\n"} = File.read(Path.join(dir, "lib/a.txt"))
+      refute File.exists?(Path.join(dir, "lib/new.txt"))
+
+      assert {:ok, entries} = ProjectView.list_directory(view, "lib")
+      assert %{name: "new.txt", type: :file} in entries
+
+      assert :ok = ProjectView.delete_file(view, "lib/a.txt")
+      assert {:error, :deleted} = ProjectView.read_file(view, "lib/a.txt")
+      assert {:ok, entries_after_delete} = ProjectView.list_directory(view, "lib")
+      refute Enum.any?(entries_after_delete, &(&1.name == "a.txt"))
+      assert File.exists?(Path.join(dir, "lib/a.txt"))
+
+      assert {:ok, diff} = ProjectView.diff(view)
+      assert Enum.any?(diff, &(&1.path == "lib/new.txt" and &1.kind in [:new, :modified]))
+      assert %{path: "lib/a.txt", kind: :deleted, size: 0} in diff
+
+      assert :ok = ProjectView.promote(view, :project_root)
+      assert {:ok, "new"} = File.read(Path.join(dir, "lib/new.txt"))
+      refute File.exists?(Path.join(dir, "lib/a.txt"))
+    end
+
+    test "discard removes overlay changes without mutating project root", %{tmp_dir: dir} do
+      seed_project(dir)
+      {:ok, view} = ProjectView.overlay(dir)
+
+      assert :ok = ProjectView.write_file(view, "lib/new.txt", "new")
+      assert :ok = ProjectView.edit_file(view, "lib/a.txt", "one", "ONE")
+      assert :ok = ProjectView.discard(view)
+
+      refute File.exists?(Path.join(dir, "lib/new.txt"))
+      assert {:ok, "one\n"} = File.read(Path.join(dir, "lib/a.txt"))
+    end
+  end
+
+  describe "path validation" do
+    test "rejects absolute paths and traversal", %{tmp_dir: dir} do
+      seed_project(dir)
+      {:ok, view} = ProjectView.direct(dir)
+
+      assert {:error, :path_traversal} = ProjectView.read_file(view, "/etc/passwd")
+      assert {:error, :path_traversal} = ProjectView.read_file(view, "../outside")
+      assert {:error, :invalid_path} = ProjectView.read_file(view, "")
+      assert {:ok, _entries} = ProjectView.list_directory(view, ".")
+    end
+  end
+
+  defp backend_factories do
+    [
+      direct: &ProjectView.direct/1,
+      overlay: &ProjectView.overlay/1
+    ]
+  end
+
+  defp assert_shared_file_contract(view) do
+    assert {:ok, "one\n"} = ProjectView.read_file(view, "lib/a.txt")
+    assert :ok = ProjectView.write_file(view, "lib/shared.txt", "shared")
+    assert {:ok, "shared"} = ProjectView.read_file(view, "lib/shared.txt")
+    assert :ok = ProjectView.edit_file(view, "lib/shared.txt", "shared", "changed")
+    assert {:ok, "changed"} = ProjectView.read_file(view, "lib/shared.txt")
+    assert :ok = ProjectView.delete_file(view, "lib/shared.txt")
+    assert {:error, _reason} = ProjectView.read_file(view, "lib/shared.txt")
+    assert {:ok, entries} = ProjectView.list_directory(view, "lib")
+    assert %{name: "a.txt", type: :file} in entries
+    assert is_binary(ProjectView.working_dir(view))
+    assert is_list(ProjectView.command_env(view))
+    assert %{mutates_project_root: _} = ProjectView.capabilities(view)
+    assert {:ok, diff} = ProjectView.diff(view)
+    assert is_list(diff)
+  end
+
+  defp seed_project(dir) do
+    File.mkdir_p!(Path.join(dir, "lib"))
+    File.write!(Path.join(dir, "lib/a.txt"), "one\n")
+    File.write!(Path.join(dir, "README.md"), "readme\n")
+  end
+end

--- a/test/minga_agent/project_view/project_view_test.exs
+++ b/test/minga_agent/project_view/project_view_test.exs
@@ -55,10 +55,11 @@ defmodule MingaAgent.ProjectViewTest do
       seed_project(dir)
       outside_dir = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}")
       File.mkdir_p!(Path.join(outside_dir, "nested"))
-      File.write!(Path.join(outside_dir, "nested/secret.txt"), "secret\n")
+      File.write!(Path.join(outside_dir, "nested/secret.txt"), "secret
+")
       File.ln_s!(outside_dir, Path.join(dir, "linked"))
 
-      {:ok, view} = ProjectView.direct(dir)
+      {:ok, view} = ProjectView.overlay(dir)
 
       assert {:error, :symlink_traversal} =
                ProjectView.read_file(view, "linked/nested/secret.txt")
@@ -72,104 +73,53 @@ defmodule MingaAgent.ProjectViewTest do
                ProjectView.delete_file(view, "linked/nested/secret.txt")
 
       assert {:error, :symlink_traversal} = ProjectView.list_directory(view, "linked")
-      assert {:ok, "one\n"} = ProjectView.read_file(view, "lib/a.txt")
+      assert {:ok, "one
+"} = ProjectView.read_file(view, "lib/a.txt")
     end
 
-    test "allows a final symlinked file when it resolves inside the project root", %{tmp_dir: dir} do
-      seed_project(dir)
-      File.ln_s!(Path.join(dir, "lib/a.txt"), Path.join(dir, "alias.txt"))
-
-      {:ok, view} = ProjectView.direct(dir)
-
-      assert {:ok, "one\n"} = ProjectView.read_file(view, "alias.txt")
-      assert :ok = ProjectView.edit_file(view, "alias.txt", "one", "ONE")
-      assert {:ok, "ONE\n"} = ProjectView.read_file(view, "alias.txt")
-      assert {:ok, "ONE\n"} = File.read(Path.join(dir, "lib/a.txt"))
-    end
-  end
-
-  describe "overlay backend contract" do
-    test "read/write/edit/delete/list/diff/promote/discard stay isolated until promote", %{
-      tmp_dir: dir
-    } do
-      seed_project(dir)
-      {:ok, view} = ProjectView.overlay(dir, workspace_id: 9)
-
-      assert view.workspace_id == 9
-      assert view.project_root == Path.expand(dir)
-      assert ProjectView.working_dir(view) != Path.expand(dir)
-      assert File.dir?(ProjectView.working_dir(view))
-
-      assert {"MIX_BUILD_PATH", _} =
-               List.keyfind(ProjectView.command_env(view), "MIX_BUILD_PATH", 0)
-
-      assert %{isolation: :overlay, mutates_project_root: false} = ProjectView.capabilities(view)
-
-      assert {:ok, "one\n"} = ProjectView.read_file(view, "lib/a.txt")
-      assert :ok = ProjectView.write_file(view, "lib/new.txt", "new")
-      assert :ok = ProjectView.edit_file(view, "lib/a.txt", "one", "ONE")
-      assert {:ok, "ONE\n"} = ProjectView.read_file(view, "lib/a.txt")
-      assert {:ok, "one\n"} = File.read(Path.join(dir, "lib/a.txt"))
-      refute File.exists?(Path.join(dir, "lib/new.txt"))
-
-      assert {:ok, entries} = ProjectView.list_directory(view, "lib")
-      assert %{name: "new.txt", type: :file} in entries
-
-      assert :ok = ProjectView.delete_file(view, "lib/a.txt")
-      assert {:error, :deleted} = ProjectView.read_file(view, "lib/a.txt")
-      assert {:ok, entries_after_delete} = ProjectView.list_directory(view, "lib")
-      refute Enum.any?(entries_after_delete, &(&1.name == "a.txt"))
-      assert File.exists?(Path.join(dir, "lib/a.txt"))
-
-      assert {:ok, diff} = ProjectView.diff(view)
-      assert Enum.any?(diff, &(&1.path == "lib/new.txt" and &1.kind in [:new, :modified]))
-      assert %{path: "lib/a.txt", kind: :deleted, size: 0} in diff
-
-      assert :ok = ProjectView.promote(view, :project_root)
-      assert {:ok, "new"} = File.read(Path.join(dir, "lib/new.txt"))
-      refute File.exists?(Path.join(dir, "lib/a.txt"))
-    end
-
-    test "rejects promote when a tracked project file becomes a symlink escape", %{tmp_dir: dir} do
-      seed_project(dir)
-      {:ok, view} = ProjectView.overlay(dir)
-
-      assert :ok = ProjectView.edit_file(view, "lib/a.txt", "one", "ONE")
-
-      outside_dir = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}")
-      File.mkdir_p!(outside_dir)
-      File.write!(Path.join(outside_dir, "secret.txt"), "secret\n")
-      File.rm!(Path.join(dir, "lib/a.txt"))
-      File.ln_s!(Path.join(outside_dir, "secret.txt"), Path.join(dir, "lib/a.txt"))
-
-      assert {:error, :symlink_traversal} = ProjectView.promote(view, :project_root)
-      assert {:ok, diff} = ProjectView.diff(view)
-      assert Enum.any?(diff, &(&1.path == "lib/a.txt" and &1.kind == :modified))
-      assert {:ok, "secret\n"} = File.read(Path.join(outside_dir, "secret.txt"))
-    end
-
-    test "rejects symlink escapes through linked directories", %{tmp_dir: dir} do
+    test "discard quarantines symlink escape forks and leaves unrelated out-of-root forks alone",
+         %{tmp_dir: dir} do
       seed_project(dir)
       outside_dir = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}")
       File.mkdir_p!(Path.join(outside_dir, "nested"))
-      File.write!(Path.join(outside_dir, "nested/secret.txt"), "secret\n")
+      outside_file = Path.join(outside_dir, "nested/secret.txt")
+      File.write!(outside_file, "secret
+")
       File.ln_s!(outside_dir, Path.join(dir, "linked"))
 
-      {:ok, view} = ProjectView.overlay(dir)
+      {:ok, store} = start_supervised(MingaAgent.BufferForkStore)
 
-      assert {:error, :symlink_traversal} =
-               ProjectView.read_file(view, "linked/nested/secret.txt")
+      {:ok, parent} =
+        start_supervised({Minga.Buffer.Process, content: "line one
+", name: nil},
+          id: :project_view_discard_parent
+        )
 
-      assert {:error, :symlink_traversal} = ProjectView.write_file(view, "linked/new.txt", "new")
+      escaped_path = Path.join(dir, "linked/nested/secret.txt")
+      {:ok, escaped_fork} = MingaAgent.BufferForkStore.get_or_create(store, escaped_path, parent)
+      Minga.Buffer.Fork.replace_content(escaped_fork, "changed
+")
 
-      assert {:error, :symlink_traversal} =
-               ProjectView.edit_file(view, "linked/nested/secret.txt", "secret", "public")
+      unrelated_path = Path.join(outside_dir, "unrelated.txt")
+      File.write!(unrelated_path, "unrelated
+")
 
-      assert {:error, :symlink_traversal} =
-               ProjectView.delete_file(view, "linked/nested/secret.txt")
+      {:ok, unrelated_fork} =
+        MingaAgent.BufferForkStore.get_or_create(store, unrelated_path, parent)
 
-      assert {:error, :symlink_traversal} = ProjectView.list_directory(view, "linked")
-      assert {:ok, "one\n"} = File.read(Path.join(dir, "lib/a.txt"))
+      {:ok, view} = ProjectView.overlay(dir, fork_store: store)
+      assert :ok = ProjectView.discard(view)
+
+      assert {:ok, "secret
+"} = File.read(outside_file)
+      assert nil == MingaAgent.BufferForkStore.get(store, escaped_path)
+      assert MingaAgent.BufferForkStore.get(store, unrelated_path) == unrelated_fork
+
+      results = MingaAgent.BufferForkStore.merge_all(store)
+      refute Enum.any?(results, fn {path, _} -> path == escaped_path end)
+      assert Enum.any?(results, fn {path, _} -> path == unrelated_path end)
+      assert {:ok, "secret
+"} = File.read(outside_file)
     end
 
     test "discard removes overlay changes without mutating project root", %{tmp_dir: dir} do
@@ -262,32 +212,52 @@ defmodule MingaAgent.ProjectViewTest do
       assert Minga.Buffer.Fork.dirty?(outside_fork)
     end
 
-    test "rejects promoting fork paths that escape through a symlink", %{tmp_dir: dir} do
+    test "preflight failures quarantine invalid forks without merging valid forks early", %{
+      tmp_dir: dir
+    } do
       seed_project(dir)
       outside_dir = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}")
-      File.mkdir_p!(outside_dir)
-      File.write!(Path.join(outside_dir, "secret.txt"), "secret\n")
+      File.mkdir_p!(Path.join(outside_dir, "nested"))
+      outside_file = Path.join(outside_dir, "nested/secret.txt")
+      File.write!(outside_file, "secret\n")
       File.ln_s!(outside_dir, Path.join(dir, "linked"))
 
       {:ok, store} = start_supervised(MingaAgent.BufferForkStore)
 
       {:ok, parent} =
         start_supervised({Minga.Buffer.Process, content: "one\n", name: nil},
-          id: :symlink_overlay_parent
+          id: :preflight_overlay_parent
         )
 
-      fork_path = Path.join(dir, "linked/secret.txt")
+      fork_path = Path.join(dir, "lib/a.txt")
       {:ok, fork_pid} = MingaAgent.BufferForkStore.get_or_create(store, fork_path, parent)
-      Minga.Buffer.Fork.replace_content(fork_pid, "changed\n")
+      Minga.Buffer.Fork.replace_content(fork_pid, "forked one\n")
+
+      escaped_path = Path.join(dir, "linked/nested/secret.txt")
+      {:ok, escaped_fork} = MingaAgent.BufferForkStore.get_or_create(store, escaped_path, parent)
+      Minga.Buffer.Fork.replace_content(escaped_fork, "escaped secret\n")
 
       {:ok, view} = ProjectView.overlay(dir, fork_store: store)
+      assert :ok = ProjectView.write_file(view, "lib/new.txt", "new\n")
+      File.ln_s!(outside_file, Path.join(dir, "lib/new.txt"))
 
-      assert {:error, {:fork_path_outside_project_root, ^fork_path, :symlink_traversal}} =
-               ProjectView.promote(view, :project_root)
+      assert {:error, :symlink_traversal} = ProjectView.promote(view, :project_root)
 
+      assert {:ok, "one\n"} = File.read(Path.join(dir, "lib/a.txt"))
+      assert {:ok, "secret\n"} = File.read(outside_file)
+      assert nil == MingaAgent.BufferForkStore.get(store, escaped_path)
       assert MingaAgent.BufferForkStore.get(store, fork_path) == fork_pid
       assert Minga.Buffer.Fork.dirty?(fork_pid)
-      assert {:ok, "secret\n"} = File.read(Path.join(outside_dir, "secret.txt"))
+
+      File.rm!(Path.join(dir, "lib/new.txt"))
+      assert {:ok, "new\n"} = ProjectView.read_file(view, "lib/new.txt")
+
+      assert :ok = ProjectView.promote(view, :project_root)
+      assert {:ok, "forked one\n"} = File.read(Path.join(dir, "lib/a.txt"))
+      assert {:ok, "new\n"} = File.read(Path.join(dir, "lib/new.txt"))
+      assert {:ok, "secret\n"} = File.read(outside_file)
+      assert nil == MingaAgent.BufferForkStore.get(store, escaped_path)
+      assert nil == MingaAgent.BufferForkStore.get(store, fork_path)
     end
   end
 

--- a/test/minga_agent/project_view/project_view_test.exs
+++ b/test/minga_agent/project_view/project_view_test.exs
@@ -50,6 +50,42 @@ defmodule MingaAgent.ProjectViewTest do
       assert :ok = ProjectView.discard(view)
       assert {:ok, []} = ProjectView.diff(view)
     end
+
+    test "rejects symlink escapes through linked directories", %{tmp_dir: dir} do
+      seed_project(dir)
+      outside_dir = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(Path.join(outside_dir, "nested"))
+      File.write!(Path.join(outside_dir, "nested/secret.txt"), "secret\n")
+      File.ln_s!(outside_dir, Path.join(dir, "linked"))
+
+      {:ok, view} = ProjectView.direct(dir)
+
+      assert {:error, :symlink_traversal} =
+               ProjectView.read_file(view, "linked/nested/secret.txt")
+
+      assert {:error, :symlink_traversal} = ProjectView.write_file(view, "linked/new.txt", "new")
+
+      assert {:error, :symlink_traversal} =
+               ProjectView.edit_file(view, "linked/nested/secret.txt", "secret", "public")
+
+      assert {:error, :symlink_traversal} =
+               ProjectView.delete_file(view, "linked/nested/secret.txt")
+
+      assert {:error, :symlink_traversal} = ProjectView.list_directory(view, "linked")
+      assert {:ok, "one\n"} = ProjectView.read_file(view, "lib/a.txt")
+    end
+
+    test "allows a final symlinked file when it resolves inside the project root", %{tmp_dir: dir} do
+      seed_project(dir)
+      File.ln_s!(Path.join(dir, "lib/a.txt"), Path.join(dir, "alias.txt"))
+
+      {:ok, view} = ProjectView.direct(dir)
+
+      assert {:ok, "one\n"} = ProjectView.read_file(view, "alias.txt")
+      assert :ok = ProjectView.edit_file(view, "alias.txt", "one", "ONE")
+      assert {:ok, "ONE\n"} = ProjectView.read_file(view, "alias.txt")
+      assert {:ok, "ONE\n"} = File.read(Path.join(dir, "lib/a.txt"))
+    end
   end
 
   describe "overlay backend contract" do
@@ -94,6 +130,48 @@ defmodule MingaAgent.ProjectViewTest do
       refute File.exists?(Path.join(dir, "lib/a.txt"))
     end
 
+    test "rejects promote when a tracked project file becomes a symlink escape", %{tmp_dir: dir} do
+      seed_project(dir)
+      {:ok, view} = ProjectView.overlay(dir)
+
+      assert :ok = ProjectView.edit_file(view, "lib/a.txt", "one", "ONE")
+
+      outside_dir = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(outside_dir)
+      File.write!(Path.join(outside_dir, "secret.txt"), "secret\n")
+      File.rm!(Path.join(dir, "lib/a.txt"))
+      File.ln_s!(Path.join(outside_dir, "secret.txt"), Path.join(dir, "lib/a.txt"))
+
+      assert {:error, :symlink_traversal} = ProjectView.promote(view, :project_root)
+      assert {:ok, diff} = ProjectView.diff(view)
+      assert Enum.any?(diff, &(&1.path == "lib/a.txt" and &1.kind == :modified))
+      assert {:ok, "secret\n"} = File.read(Path.join(outside_dir, "secret.txt"))
+    end
+
+    test "rejects symlink escapes through linked directories", %{tmp_dir: dir} do
+      seed_project(dir)
+      outside_dir = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(Path.join(outside_dir, "nested"))
+      File.write!(Path.join(outside_dir, "nested/secret.txt"), "secret\n")
+      File.ln_s!(outside_dir, Path.join(dir, "linked"))
+
+      {:ok, view} = ProjectView.overlay(dir)
+
+      assert {:error, :symlink_traversal} =
+               ProjectView.read_file(view, "linked/nested/secret.txt")
+
+      assert {:error, :symlink_traversal} = ProjectView.write_file(view, "linked/new.txt", "new")
+
+      assert {:error, :symlink_traversal} =
+               ProjectView.edit_file(view, "linked/nested/secret.txt", "secret", "public")
+
+      assert {:error, :symlink_traversal} =
+               ProjectView.delete_file(view, "linked/nested/secret.txt")
+
+      assert {:error, :symlink_traversal} = ProjectView.list_directory(view, "linked")
+      assert {:ok, "one\n"} = File.read(Path.join(dir, "lib/a.txt"))
+    end
+
     test "discard removes overlay changes without mutating project root", %{tmp_dir: dir} do
       seed_project(dir)
       {:ok, view} = ProjectView.overlay(dir)
@@ -104,6 +182,112 @@ defmodule MingaAgent.ProjectViewTest do
 
       refute File.exists?(Path.join(dir, "lib/new.txt"))
       assert {:ok, "one\n"} = File.read(Path.join(dir, "lib/a.txt"))
+    end
+
+    test "promote returns fork merge failures without mutating project root", %{tmp_dir: dir} do
+      seed_project(dir)
+      {:ok, store} = start_supervised(MingaAgent.BufferForkStore)
+
+      {:ok, parent} =
+        start_supervised({Minga.Buffer.Process, content: "one\ntwo\nthree\n", name: nil},
+          id: :overlay_parent
+        )
+
+      fork_path = Path.join(dir, "lib/a.txt")
+      {:ok, fork_pid} = MingaAgent.BufferForkStore.get_or_create(store, fork_path, parent)
+      Minga.Buffer.Fork.replace_content(fork_pid, "one\nfork two\nthree\n")
+      Minga.Buffer.Process.replace_content(parent, "one\nparent two\nthree\n", :agent)
+
+      {:ok, view} = ProjectView.overlay(dir, fork_store: store)
+      assert :ok = ProjectView.write_file(view, "lib/new.txt", "new")
+      assert :ok = ProjectView.edit_file(view, "lib/a.txt", "one", "ONE")
+
+      assert {:error, {:fork_merge_failed, failures}} = ProjectView.promote(view, :project_root)
+      assert [{^fork_path, {:conflict, _}}] = failures
+      refute File.exists?(Path.join(dir, "lib/new.txt"))
+      assert {:ok, "one\n"} = File.read(Path.join(dir, "lib/a.txt"))
+      assert {:ok, "new"} = ProjectView.read_file(view, "lib/new.txt")
+      assert {:ok, "ONE\n"} = ProjectView.read_file(view, "lib/a.txt")
+      assert MingaAgent.BufferForkStore.get(store, fork_path) == fork_pid
+      assert Minga.Buffer.Fork.dirty?(fork_pid)
+    end
+
+    test "diff omits forks outside the project root", %{tmp_dir: dir} do
+      %{view: view, store: store, in_root_path: in_root_path, outside_path: outside_path} =
+        seed_overlay_with_scoped_forks(dir)
+
+      assert {:ok, diff} = ProjectView.diff(view)
+      assert Enum.any?(diff, &(&1.path == Path.relative_to(in_root_path, dir)))
+      refute Enum.any?(diff, &(&1.path == outside_path))
+      assert MingaAgent.BufferForkStore.get(store, outside_path) != nil
+    end
+
+    test "promote only merges forks under the project root and leaves unrelated forks untouched",
+         %{
+           tmp_dir: dir
+         } do
+      %{
+        view: view,
+        store: store,
+        in_root_path: in_root_path,
+        outside_path: outside_path,
+        outside_fork: outside_fork
+      } = seed_overlay_with_scoped_forks(dir)
+
+      assert :ok = ProjectView.promote(view, :project_root)
+      assert {:ok, "in-root promoted\n"} = File.read(in_root_path)
+      assert {:ok, "outside original\n"} = File.read(outside_path)
+      assert nil == MingaAgent.BufferForkStore.get(store, in_root_path)
+      assert MingaAgent.BufferForkStore.get(store, outside_path) == outside_fork
+      assert Minga.Buffer.Fork.dirty?(outside_fork)
+    end
+
+    test "discard only removes forks under the project root and leaves unrelated forks untouched",
+         %{
+           tmp_dir: dir
+         } do
+      %{
+        view: view,
+        store: store,
+        in_root_path: in_root_path,
+        outside_path: outside_path,
+        outside_fork: outside_fork
+      } = seed_overlay_with_scoped_forks(dir)
+
+      assert :ok = ProjectView.discard(view)
+      assert {:ok, "one\n"} = File.read(in_root_path)
+      assert {:ok, "outside original\n"} = File.read(outside_path)
+      assert nil == MingaAgent.BufferForkStore.get(store, in_root_path)
+      assert MingaAgent.BufferForkStore.get(store, outside_path) == outside_fork
+      assert Minga.Buffer.Fork.dirty?(outside_fork)
+    end
+
+    test "rejects promoting fork paths that escape through a symlink", %{tmp_dir: dir} do
+      seed_project(dir)
+      outside_dir = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(outside_dir)
+      File.write!(Path.join(outside_dir, "secret.txt"), "secret\n")
+      File.ln_s!(outside_dir, Path.join(dir, "linked"))
+
+      {:ok, store} = start_supervised(MingaAgent.BufferForkStore)
+
+      {:ok, parent} =
+        start_supervised({Minga.Buffer.Process, content: "one\n", name: nil},
+          id: :symlink_overlay_parent
+        )
+
+      fork_path = Path.join(dir, "linked/secret.txt")
+      {:ok, fork_pid} = MingaAgent.BufferForkStore.get_or_create(store, fork_path, parent)
+      Minga.Buffer.Fork.replace_content(fork_pid, "changed\n")
+
+      {:ok, view} = ProjectView.overlay(dir, fork_store: store)
+
+      assert {:error, {:fork_path_outside_project_root, ^fork_path, :symlink_traversal}} =
+               ProjectView.promote(view, :project_root)
+
+      assert MingaAgent.BufferForkStore.get(store, fork_path) == fork_pid
+      assert Minga.Buffer.Fork.dirty?(fork_pid)
+      assert {:ok, "secret\n"} = File.read(Path.join(outside_dir, "secret.txt"))
     end
   end
 
@@ -147,5 +331,39 @@ defmodule MingaAgent.ProjectViewTest do
     File.mkdir_p!(Path.join(dir, "lib"))
     File.write!(Path.join(dir, "lib/a.txt"), "one\n")
     File.write!(Path.join(dir, "README.md"), "readme\n")
+  end
+
+  defp seed_overlay_with_scoped_forks(dir) do
+    seed_project(dir)
+
+    {:ok, store} = start_supervised(MingaAgent.BufferForkStore)
+
+    {:ok, parent} =
+      start_supervised({Minga.Buffer.Process, content: "one\n", name: nil},
+        id: :scoped_overlay_parent
+      )
+
+    in_root_path = Path.join(dir, "lib/a.txt")
+    {:ok, in_root_fork} = MingaAgent.BufferForkStore.get_or_create(store, in_root_path, parent)
+    Minga.Buffer.Fork.replace_content(in_root_fork, "in-root promoted\n")
+
+    outside_dir = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(outside_dir)
+    outside_path = Path.join(outside_dir, "outside.txt")
+    File.write!(outside_path, "outside original\n")
+
+    {:ok, outside_fork} = MingaAgent.BufferForkStore.get_or_create(store, outside_path, parent)
+    Minga.Buffer.Fork.replace_content(outside_fork, "outside changed\n")
+
+    {:ok, view} = ProjectView.overlay(dir, fork_store: store)
+
+    %{
+      view: view,
+      store: store,
+      in_root_path: in_root_path,
+      in_root_fork: in_root_fork,
+      outside_path: outside_path,
+      outside_fork: outside_fork
+    }
   end
 end


### PR DESCRIPTION
# TL;DR
Adds `MingaAgent.ProjectView` as the workspace-local file access facade, with direct and overlay-backed implementations behind one behaviour. This gives workspace code one stable contract for file reads, writes, diffs, promotion, discard, and command execution context without making Git worktrees the product model.

Closes #1783

## Context
This is part of #1772. Workspaces need a project-owned boundary for file state before later tickets can route workspace tools and agent sessions through a consistent model. This PR adds that boundary only; it does not route existing agent tools through ProjectView.

## Changes
- Added `MingaAgent.ProjectView` with the requested facade API and `%ProjectView{id, project_root, backend, ref, workspace_id}` struct.
- Added `MingaAgent.ProjectView.Backend` with the v1 callback contract for file access, command context, diff, promote, discard, and capabilities.
- Added `Direct` and `Overlay` backends. Direct mutates the project root; Overlay delegates isolation to `MingaAgent.Changeset` and uses existing overlay behavior rather than duplicating it.
- Extended `MingaAgent.BufferForkStore` with a keep-failed merge path so overlay promotion can surface fork merge failures without clearing failed forks.
- Added relative-path normalization so callers use logical project-relative paths, with absolute paths and traversal rejected at the facade.
- Added shared contract tests that exercise both Direct and Overlay implementations.

## Verification
- `mix compile --warnings-as-errors`
- `make lint`
- `mix test.llm test/minga_agent/project_view`
- `mix test.llm`
- `git diff --check`
- Targeted reviewer re-check passed after removing `ToolRouter` from ProjectView overlay paths.

## Acceptance Criteria Addressed
- `MingaAgent.ProjectView` facade exists and is the only public API callers use ✅
- `MingaAgent.ProjectView.Backend` behaviour defines the v1 backend callbacks ✅
- Direct ProjectView supports current direct file access against a project root ✅
- Overlay ProjectView wraps existing `MingaAgent.Changeset`, `Minga.Core.Overlay`, and buffer fork concepts instead of duplicating overlay logic ✅
- The facade uses logical relative paths and project roots, not frontend labels or worktree paths ✅
- Capabilities expose backend behavior without callers pattern-matching backend modules ✅
- Shared contract tests run against Direct and Overlay implementations ✅
