### PR TITLE
Fix TUI workspace row click routing

### DIFF
--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -39,6 +39,7 @@ defmodule MingaEditor.Commands do
   alias MingaEditor.Commands.Operators
   alias MingaEditor.Commands.Tool
   alias MingaEditor.Commands.Visual
+  alias MingaEditor.Commands.Workspace, as: WorkspaceCommands
   alias MingaEditor.Editing
   alias MingaEditor.LspActions
   alias MingaEditor.MinibufferData
@@ -263,6 +264,11 @@ defmodule MingaEditor.Commands do
 
   def execute(state, {:move_to_screen, _} = cmd) do
     guard_buffer(state, fn -> Movement.execute(state, cmd) end)
+  end
+
+  def execute(state, {:workspace_goto, workspace_id})
+      when is_integer(workspace_id) and workspace_id >= 0 do
+    WorkspaceCommands.workspace_goto_by_id(state, workspace_id)
   end
 
   # ── Parameterized editing ─────────────────────────────────────────────────

--- a/lib/minga_editor/commands/workspace.ex
+++ b/lib/minga_editor/commands/workspace.ex
@@ -95,6 +95,12 @@ defmodule MingaEditor.Commands.Workspace do
     end
   end
 
+  @doc "Jump directly to a workspace by id."
+  @spec workspace_goto_by_id(state(), non_neg_integer()) :: state()
+  def workspace_goto_by_id(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, workspace_id) do
+    switch_via_workspace(state, TabBar.switch_to_workspace(tb, workspace_id))
+  end
+
   # Takes a TabBar with a potentially new active_id from a workspace switch.
   # Routes through EditorState.switch_tab so snapshots and restores happen properly.
   # No-op if the active tab didn't change.

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -817,7 +817,12 @@ defmodule MingaEditor.Mouse do
     end
   end
 
-  @spec dispatch_tab_bar_command(state(), atom()) :: state()
+  @spec dispatch_tab_bar_command(state(), atom() | {:workspace_goto, non_neg_integer()}) ::
+          state()
+  defp dispatch_tab_bar_command(state, {:workspace_goto, _} = cmd) do
+    MingaEditor.dispatch_command(state, cmd)
+  end
+
   defp dispatch_tab_bar_command(state, cmd) do
     case Atom.to_string(cmd) do
       "tab_close_" <> _ -> close_tab_by_command(state, cmd)
@@ -1646,7 +1651,7 @@ defmodule MingaEditor.Mouse do
   end
 
   @spec parse_tab_id(atom()) :: {:ok, pos_integer()} | :error
-  defp parse_tab_id(cmd) do
+  defp parse_tab_id(cmd) when is_atom(cmd) do
     case Atom.to_string(cmd) do
       "tab_goto_" <> id_str ->
         case Integer.parse(id_str) do
@@ -1665,10 +1670,12 @@ defmodule MingaEditor.Mouse do
     end
   end
 
+  defp parse_tab_id(_cmd), do: :error
+
   # ── Tab bar click detection ──────────────────────────────────────────────
 
   @spec tab_bar_click(state(), non_neg_integer(), non_neg_integer()) ::
-          {:command, atom()} | :not_tab_bar
+          {:command, atom() | {:workspace_goto, non_neg_integer()}} | :not_tab_bar
   defp tab_bar_click(state, row, col) do
     layout = Layout.get(state)
 
@@ -1690,7 +1697,7 @@ defmodule MingaEditor.Mouse do
           [MingaEditor.Shell.Traditional.TabBarRenderer.click_region()],
           non_neg_integer(),
           non_neg_integer()
-        ) :: {:command, atom()} | :not_tab_bar
+        ) :: {:command, atom() | {:workspace_goto, non_neg_integer()}} | :not_tab_bar
   defp find_tab_bar_region(regions, row, col) do
     case Enum.find(regions, &tab_bar_region_hit?(&1, row, col)) do
       {_, _, cmd} -> {:command, cmd}

--- a/lib/minga_editor/shell/traditional/tab_bar_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tab_bar_renderer.ex
@@ -34,9 +34,11 @@ defmodule MingaEditor.Shell.Traditional.TabBarRenderer do
 
   @typedoc "A clickable region: column range mapping to a command."
   @type click_region ::
-          {col_start :: non_neg_integer(), col_end :: non_neg_integer(), command :: atom()}
+          {col_start :: non_neg_integer(), col_end :: non_neg_integer(),
+           command :: atom() | {:workspace_goto, non_neg_integer()}}
           | {row :: non_neg_integer(), col_start :: non_neg_integer(),
-             col_end :: non_neg_integer(), command :: atom()}
+             col_end :: non_neg_integer(),
+             command :: atom() | {:workspace_goto, non_neg_integer()}}
 
   # Powerline separators (right-pointing triangle)
   @sep_right "\u{E0B0}"

--- a/lib/minga_editor/shell/traditional/workspace_row_renderer.ex
+++ b/lib/minga_editor/shell/traditional/workspace_row_renderer.ex
@@ -14,7 +14,7 @@ defmodule MingaEditor.Shell.Traditional.WorkspaceRowRenderer do
 
   @type click_region ::
           {row :: non_neg_integer(), col_start :: non_neg_integer(), col_end :: non_neg_integer(),
-           command :: atom()}
+           command :: atom() | {:workspace_goto, non_neg_integer()}}
 
   @overflow_left "◂"
   @overflow_right "▸"
@@ -48,13 +48,11 @@ defmodule MingaEditor.Shell.Traditional.WorkspaceRowRenderer do
            width: non_neg_integer(),
            fg: non_neg_integer(),
            bg: non_neg_integer(),
-           command: atom()
+           command: atom() | {:workspace_goto, non_neg_integer()}
          }
 
   @spec build_segments(ChromeState.t(), map()) :: [segment()]
   defp build_segments(%ChromeState{} = chrome_state, colors) do
-    agent_ordinals = agent_ordinals(chrome_state.workspaces)
-
     Enum.map(chrome_state.workspaces, fn workspace ->
       active? = workspace.id == chrome_state.active_workspace_id
       text = workspace_text(workspace, active?)
@@ -70,28 +68,13 @@ defmodule MingaEditor.Shell.Traditional.WorkspaceRowRenderer do
         width: Unicode.display_width(text),
         fg: fg,
         bg: bg,
-        command: workspace_command(workspace, agent_ordinals)
+        command: workspace_command(workspace)
       }
     end)
   end
 
-  @spec agent_ordinals([WorkspaceSummary.t()]) :: %{non_neg_integer() => pos_integer()}
-  defp agent_ordinals(workspaces) do
-    workspaces
-    |> Enum.filter(&(&1.kind == :agent))
-    |> Enum.with_index(1)
-    |> Map.new(fn {workspace, idx} -> {workspace.id, idx} end)
-  end
-
-  @spec workspace_command(WorkspaceSummary.t(), %{non_neg_integer() => pos_integer()}) :: atom()
-  defp workspace_command(%WorkspaceSummary{kind: :manual}, _ordinals), do: :manual_workspace
-
-  defp workspace_command(%WorkspaceSummary{id: id}, ordinals) do
-    case Map.get(ordinals, id) do
-      idx when is_integer(idx) and idx in 1..9 -> String.to_existing_atom("workspace_goto_#{idx}")
-      _idx -> :workspace_next_agent
-    end
-  end
+  @spec workspace_command(WorkspaceSummary.t()) :: {:workspace_goto, non_neg_integer()}
+  defp workspace_command(%WorkspaceSummary{id: id}), do: {:workspace_goto, id}
 
   @spec workspace_text(WorkspaceSummary.t(), boolean()) :: String.t()
   defp workspace_text(%WorkspaceSummary{} = workspace, active?) do

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -17,9 +17,12 @@ defmodule MingaEditor.MouseTest do
   alias MingaEditor.Mouse
   alias MingaEditor.Startup
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace, as: WorkspaceDomain
   alias MingaEditor.State.Windows
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
+  alias MingaEditor.Workspace.ChromeState
   alias MingaEditor.Workspace.State, as: WorkspaceState
 
   @content_row 1
@@ -300,6 +303,67 @@ defmodule MingaEditor.MouseTest do
   end
 
   describe "tab bar clicks" do
+    test "row 0 workspace clicks ignore row 1 tab actions" do
+      {state, agent_workspace_id} = start_workspace_tab_state()
+
+      state =
+        set_tab_click_regions(state, [
+          {1, 0, 4, :tab_goto_1},
+          {1, 5, 7, :tab_close_3},
+          {0, 0, 4, {:workspace_goto, agent_workspace_id}}
+        ])
+
+      state = mouse(state, 0, 2, :left, :press)
+
+      assert ChromeState.from_editor_state(state).active_workspace_id == agent_workspace_id
+      assert state.shell_state.tab_bar.active_id == 2
+    end
+
+    test "row 1 tab goto and close still work" do
+      {state, _agent_workspace_id} = start_workspace_tab_state()
+
+      state =
+        set_tab_click_regions(state, [
+          {1, 0, 4, :tab_goto_1},
+          {1, 5, 7, :tab_close_3},
+          {0, 0, 4, {:workspace_goto, 1}}
+        ])
+
+      state = mouse(state, 1, 2, :left, :press)
+
+      assert state.shell_state.tab_bar.active_id == 1
+
+      state = mouse(state, 1, 6, :left, :press)
+
+      assert length(state.shell_state.tab_bar.tabs) == 2
+    end
+
+    test "clicking workspace id 10 selects workspace id 10 instead of ordinal 10" do
+      {state, _buffer} = start_mouse_state("manual one\nmanual two", width: 120)
+
+      second_buffer =
+        start_supervised!({BufferProcess, [content: "agent tab"]},
+          id: {:workspace_tab, System.unique_integer([:positive])}
+        )
+
+      state = EditorState.add_buffer(state, second_buffer, context: :open)
+      tab_bar = state.shell_state.tab_bar
+      manual_workspace = hd(tab_bar.workspaces)
+      workspace_10 = WorkspaceDomain.new_agent(10, "Tests", self())
+
+      tab_bar =
+        %{tab_bar | workspaces: [manual_workspace, workspace_10], next_workspace_id: 11}
+        |> TabBar.move_tab_to_workspace(2, 10)
+
+      state = EditorState.set_tab_bar(state, tab_bar)
+      state = set_tab_click_regions(state, [{0, 0, 4, {:workspace_goto, 10}}])
+
+      state = mouse(state, 0, 2, :left, :press)
+
+      assert ChromeState.from_editor_state(state).active_workspace_id == 10
+      assert state.shell_state.tab_bar.active_id == 2
+    end
+
     test "clicking tab close removes a non-last tab but leaves the final tab alone" do
       {state, _buf1, _buf2} = start_two_tab_state()
       active_id = state.shell_state.tab_bar.active_id
@@ -446,5 +510,28 @@ defmodule MingaEditor.MouseTest do
 
   defp set_tab_click_regions(state, regions) do
     EditorState.update_shell_state(state, &%{&1 | tab_bar_click_regions: regions})
+  end
+
+  defp start_workspace_tab_state do
+    {state, _buf1} = start_mouse_state("manual one\nmanual two", width: 120)
+
+    buf2 =
+      start_supervised!({BufferProcess, [content: "agent tab"]},
+        id: {:workspace_tab, System.unique_integer([:positive])}
+      )
+
+    buf3 =
+      start_supervised!({BufferProcess, [content: "manual three"]},
+        id: {:workspace_tab, System.unique_integer([:positive])}
+      )
+
+    state = EditorState.add_buffer(state, buf2, context: :open)
+    state = EditorState.add_buffer(state, buf3, context: :open)
+
+    {tab_bar, agent_workspace} = TabBar.add_workspace(state.shell_state.tab_bar, "Tests", self())
+    tab_bar = TabBar.move_tab_to_workspace(tab_bar, 2, agent_workspace.id)
+
+    state = EditorState.set_tab_bar(state, tab_bar)
+    {state, agent_workspace.id}
   end
 end

--- a/test/minga_editor/shell/traditional/workspace_row_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/workspace_row_renderer_test.exs
@@ -73,7 +73,7 @@ defmodule MingaEditor.Shell.Traditional.WorkspaceRowRendererTest do
     assert String.contains?(text, "[2]")
 
     assert Enum.any?(regions, fn
-             {0, _start, _end, :workspace_goto_1} -> true
+             {0, _start, _end, {:workspace_goto, 1}} -> true
              _ -> false
            end)
   end
@@ -131,7 +131,34 @@ defmodule MingaEditor.Shell.Traditional.WorkspaceRowRendererTest do
     assert String.contains?(text, "VeryLongWorkspace6*")
 
     assert Enum.any?(regions, fn
-             {0, _start, _end, :workspace_goto_6} -> true
+             {0, _start, _end, {:workspace_goto, 6}} -> true
+             _ -> false
+           end)
+  end
+
+  test "targets the actual workspace id even after ordinal nine" do
+    workspaces =
+      [workspace(id: 0, kind: :manual, label: "m", icon: "folder")] ++
+        Enum.map(1..10, fn id ->
+          workspace(
+            id: id,
+            kind: :agent,
+            label: "W#{id}",
+            icon: "cpu",
+            closeable?: true
+          )
+        end)
+
+    {_draws, regions} =
+      WorkspaceRowRenderer.render(
+        0,
+        120,
+        chrome_state(workspaces: workspaces, active_workspace_id: 10),
+        doom_theme()
+      )
+
+    assert Enum.any?(regions, fn
+             {0, _start, _end, {:workspace_goto, 10}} -> true
              _ -> false
            end)
   end


### PR DESCRIPTION
# TL;DR
Workspace row clicks now route by stable workspace id instead of ordinal position, so clicking a visible workspace chip always opens that workspace even after ids become non-contiguous.

Follow-up to #1818.

## Context
The TUI workspace row introduced row-aware click regions and workspace chips. During review, we found that chips for workspaces beyond the ordinal shortcuts could carry the right id but dispatch through the old ordinal command path. That could no-op or select the wrong workspace after workspaces were closed or ids became non-contiguous.

## Changes
- Added a by-id workspace command path for `{:workspace_goto, id}` click commands.
- Preserved existing numbered workspace shortcut behavior through the ordinal command path.
- Updated mouse and renderer click-region specs to allow tuple workspace commands.
- Added mouse regression coverage for row 0 workspace clicks, row 1 tab goto/close clicks, and non-ordinal workspace id 10 routing.

## Verification
- `git diff --check`
- `mix compile --warnings-as-errors`
- `mix test.llm test/minga_editor/commands/workspace_test.exs test/minga_editor/mouse_test.exs test/minga_editor/shell/traditional/workspace_row_renderer_test.exs test/minga_editor/shell/traditional/tab_bar_renderer_test.exs test/minga_editor/layout_test.exs test/minga_editor/shell/traditional/modeline_test.exs test/minga_editor/status_bar/data_test.exs`
- `make lint`
- `mix test.llm`

## Acceptance Criteria Addressed
- Workspace row chip clicks target the actual clicked workspace id. ✅
- Existing ordinal workspace shortcuts continue to use ordinal behavior. ✅
- Row-aware top-chrome mouse routing is covered by focused regression tests. ✅