### PR TITLE
fix(input): route global save through command dispatch

### DIFF
--- a/lib/minga_editor/input/global_bindings.ex
+++ b/lib/minga_editor/input/global_bindings.ex
@@ -13,24 +13,16 @@ defmodule MingaEditor.Input.GlobalBindings do
 
   import Bitwise
 
-  alias Minga.Buffer
-
   @ctrl MingaEditor.Input.mod_ctrl()
 
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
 
-  # Ctrl+S: save current buffer
+  # Ctrl+S: save current buffer through the command system.
   def handle_key(state, ?s, mods) when band(mods, @ctrl) != 0 do
-    if state.workspace.buffers.active do
-      case Buffer.save(state.workspace.buffers.active) do
-        :ok -> :ok
-        {:error, reason} -> Minga.Log.error(:editor, "Save failed: #{inspect(reason)}")
-      end
-    end
-
-    {:handled, state}
+    new_state = MingaEditor.dispatch_command(state, :save)
+    {:handled, new_state}
   end
 
   # Ctrl+Q: quit behavior depends on editing model.

--- a/test/minga_editor/input/handler_test.exs
+++ b/test/minga_editor/input/handler_test.exs
@@ -76,10 +76,12 @@ defmodule MingaEditor.Input.HandlerTest do
   end
 
   describe "GlobalBindings" do
-    test "handles Ctrl+S" do
+    test "handles Ctrl+S through save command status" do
       state = base_state()
       ctrl = Protocol.mod_ctrl()
-      assert {:handled, _} = GlobalBindings.handle_key(state, ?s, ctrl)
+
+      assert {:handled, new_state} = GlobalBindings.handle_key(state, ?s, ctrl)
+      assert EditorState.status_msg(new_state) == "No file name — use :w <filename>"
     end
 
     test "passes through non-global keys" do


### PR DESCRIPTION
# TL;DR
Ctrl+S now uses the normal `:save` command path instead of calling `Buffer.save/1` directly from the global input handler. Save failures now come back through the command result state and surface as the same user-visible status messages as `:w`.

Closes #1661

## Context
Issue #1661 flagged an architecture violation in `MingaEditor.Input.GlobalBindings`: the Ctrl+S handler performed disk I/O directly, swallowed the result, and returned the original state. That made failures hard to surface and bypassed the command execution path used elsewhere.

## Changes
- Replaced the direct `Buffer.save/1` call in `GlobalBindings.handle_key/3` with `MingaEditor.dispatch_command(state, :save)`.
- Return `{:handled, new_state}` so Ctrl+S reflects the save command result.
- Updated the input handler test to assert Ctrl+S surfaces the command path's no-file status message.

## Verification
- `mix test.debug test/minga_editor/input/handler_test.exs`
- `mix test.llm test/minga_editor/input/handler_test.exs test/minga_editor/commands/buffer_management_test.exs`
- `make lint`
- `mix test.llm`

## Acceptance Criteria Addressed
- Save operation is dispatched as a command through the normal command execution path ✅
- Save failures are surfaced to the user via status message ✅
- Input handler returns `{:handled, state}` with state reflecting the save result ✅
- Existing tests pass ✅
