### PR TITLE
refactor(editing): remove Layer 0 cond branches

### DIFF
--- a/lib/minga/editing/auto_pair.ex
+++ b/lib/minga/editing/auto_pair.ex
@@ -83,33 +83,15 @@ defmodule Minga.Editing.AutoPair do
   def on_insert(%Document{} = buffer, {line, col}, char) do
     char_at_cursor = char_at(buffer, line, col)
 
-    cond do
-      # Typing a closing delimiter that matches char under cursor → skip
-      MapSet.member?(@closing_chars, char) and char_at_cursor == char ->
-        {:skip, char}
-
-      # Symmetric quote that matches char under cursor → skip
-      Map.has_key?(@quote_pairs, char) and char_at_cursor == char ->
-        {:skip, char}
-
-      # Opening bracket → always pair
-      Map.has_key?(@pair_map, char) ->
-        {:pair, char, Map.fetch!(@pair_map, char)}
-
-      # Quote character → pair only if not preceded by a word character
-      Map.has_key?(@quote_pairs, char) ->
-        char_before = char_before(buffer, line, col)
-
-        if word_char?(char_before) do
-          {:passthrough, char}
-        else
-          {:pair, char, Map.fetch!(@quote_pairs, char)}
-        end
-
-      # Everything else
-      true ->
-        {:passthrough, char}
-    end
+    on_insert_action(
+      buffer,
+      {line, col},
+      char,
+      MapSet.member?(@closing_chars, char) and char_at_cursor == char,
+      Map.has_key?(@quote_pairs, char) and char_at_cursor == char,
+      Map.has_key?(@pair_map, char),
+      Map.has_key?(@quote_pairs, char)
+    )
   end
 
   @doc """
@@ -158,6 +140,43 @@ defmodule Minga.Editing.AutoPair do
   """
   @spec closing_for(String.t()) :: String.t() | nil
   def closing_for(char), do: Map.get(@all_pairs, char)
+
+  @spec on_insert_action(
+          Document.t(),
+          position(),
+          String.t(),
+          boolean(),
+          boolean(),
+          boolean(),
+          boolean()
+        ) ::
+          insert_action()
+  defp on_insert_action(_buffer, _position, char, true, _quote_match?, _opening?, _quote?),
+    do: {:skip, char}
+
+  defp on_insert_action(_buffer, _position, char, false, true, _opening?, _quote?),
+    do: {:skip, char}
+
+  defp on_insert_action(_buffer, _position, char, false, false, true, _quote?),
+    do: {:pair, char, Map.fetch!(@pair_map, char)}
+
+  defp on_insert_action(buffer, {line, col}, char, false, false, false, true) do
+    quote_insert_action(char, char_before(buffer, line, col))
+  end
+
+  defp on_insert_action(_buffer, _position, char, false, false, false, false),
+    do: {:passthrough, char}
+
+  @spec quote_insert_action(String.t(), String.t() | nil) :: insert_action()
+  defp quote_insert_action(char, char_before) do
+    quote_insert_action_for_word_char(char, word_char?(char_before))
+  end
+
+  @spec quote_insert_action_for_word_char(String.t(), boolean()) :: insert_action()
+  defp quote_insert_action_for_word_char(char, true), do: {:passthrough, char}
+
+  defp quote_insert_action_for_word_char(char, false),
+    do: {:pair, char, Map.fetch!(@quote_pairs, char)}
 
   # ── Private helpers ──────────────────────────────────────────────────────────
 

--- a/lib/minga/editing/block_pair.ex
+++ b/lib/minga/editing/block_pair.ex
@@ -10,7 +10,7 @@ defmodule Minga.Editing.BlockPair do
   @doc """
   Returns the closing keyword for a block-opening line, or `nil` when the line is not a block opener.
 
-  The matcher rejects keywords embedded in longer identifiers and treats Ruby line-head keywords as block openers only when they start the trimmed line. That avoids modifier forms such as `return x if cond`.
+  The matcher rejects keywords embedded in longer identifiers and treats Ruby line-head keywords as block openers only when they start the trimmed line. That avoids modifier forms such as `return x if ready`.
   """
   @spec closing_for([BlockPairSpec.t()], String.t()) :: String.t() | nil
   def closing_for(block_pairs, line_text) when is_list(block_pairs) and is_binary(line_text) do

--- a/lib/minga/editing/operator.ex
+++ b/lib/minga/editing/operator.ex
@@ -119,30 +119,40 @@ defmodule Minga.Editing.Operator do
     line_text =
       Minga.Buffer.lines(server, line_index, 1) |> List.first() |> then(&(&1 || ""))
 
-    line_len = byte_size(line_text)
+    line_range(server, line_index, total_lines, line_text, byte_size(line_text))
+  end
 
-    cond do
-      # Only line in the buffer — delete from col 0 through last byte of last grapheme.
-      # If the line is empty, delete_range handles it gracefully (delete_count clamped to 0).
-      total_lines == 1 ->
-        last_col = if line_len == 0, do: 0, else: Unicode.last_grapheme_byte_offset(line_text)
-        {{0, 0}, {0, last_col}}
+  @spec line_range(
+          GenServer.server(),
+          non_neg_integer(),
+          pos_integer(),
+          String.t(),
+          non_neg_integer()
+        ) ::
+          {position(), position()}
+  # Only line in the buffer — delete from col 0 through last byte of last grapheme.
+  # If the line is empty, delete_range handles it gracefully (delete_count clamped to 0).
+  defp line_range(_server, _line_index, 1, line_text, line_len) do
+    last_col = if line_len == 0, do: 0, else: Unicode.last_grapheme_byte_offset(line_text)
+    {{0, 0}, {0, last_col}}
+  end
 
-      # Last line — also consume the preceding newline so no orphan line remains.
-      # The newline lives at byte_col == byte_size(prev_text) on the previous line.
-      line_index >= total_lines - 1 ->
-        prev_text =
-          Minga.Buffer.lines(server, line_index - 1, 1)
-          |> List.first()
-          |> then(&(&1 || ""))
+  # Last line — also consume the preceding newline so no orphan line remains.
+  # The newline lives at byte_col == byte_size(prev_text) on the previous line.
+  defp line_range(server, line_index, total_lines, line_text, line_len)
+       when line_index >= total_lines - 1 do
+    prev_text =
+      Minga.Buffer.lines(server, line_index - 1, 1)
+      |> List.first()
+      |> then(&(&1 || ""))
 
-        prev_len = byte_size(prev_text)
-        last_col = if line_len == 0, do: 0, else: Unicode.last_grapheme_byte_offset(line_text)
-        {{line_index - 1, prev_len}, {line_index, last_col}}
+    prev_len = byte_size(prev_text)
+    last_col = if line_len == 0, do: 0, else: Unicode.last_grapheme_byte_offset(line_text)
+    {{line_index - 1, prev_len}, {line_index, last_col}}
+  end
 
-      # Any other line — include the trailing newline using byte_col == byte_size(line).
-      true ->
-        {{line_index, 0}, {line_index, line_len}}
-    end
+  # Any other line — include the trailing newline using byte_col == byte_size(line).
+  defp line_range(_server, line_index, _total_lines, _line_text, line_len) do
+    {{line_index, 0}, {line_index, line_len}}
   end
 end

--- a/lib/minga/editing/text_object.ex
+++ b/lib/minga/editing/text_object.ex
@@ -114,18 +114,7 @@ defmodule Minga.Editing.TextObject do
       after_end = end_g + 1
 
       {final_start_g, final_end_g} =
-        cond do
-          after_end < len and whitespace?(elem(graphemes, after_end)) ->
-            trail_end = scan_right_tuple(graphemes, after_end, &whitespace?/1)
-            {start_g, trail_end}
-
-          start_g > 0 and whitespace?(elem(graphemes, start_g - 1)) ->
-            lead_start = scan_left_tuple(graphemes, start_g - 1, &whitespace?/1)
-            {lead_start, end_g}
-
-          true ->
-            {start_g, end_g}
-        end
+        around_word_grapheme_bounds(graphemes, len, start_g, end_g, after_end)
 
       start_byte = elem(byte_offsets, final_start_g)
       end_byte = elem(byte_offsets, final_end_g)
@@ -909,11 +898,65 @@ defmodule Minga.Editing.TextObject do
 
   @spec classifier_for(String.t()) :: (String.t() -> boolean())
   defp classifier_for(char) do
-    cond do
-      word_char?(char) -> &word_char?/1
-      whitespace?(char) -> &whitespace?/1
-      true -> fn c -> not word_char?(c) and not whitespace?(c) end
-    end
+    classifier_for(char, word_char?(char), whitespace?(char))
+  end
+
+  @spec classifier_for(String.t(), boolean(), boolean()) :: (String.t() -> boolean())
+  defp classifier_for(_char, true, _whitespace?), do: &word_char?/1
+  defp classifier_for(_char, false, true), do: &whitespace?/1
+
+  defp classifier_for(_char, false, false),
+    do: fn c -> not word_char?(c) and not whitespace?(c) end
+
+  @spec around_word_grapheme_bounds(
+          tuple(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp around_word_grapheme_bounds(graphemes, len, start_g, end_g, after_end) do
+    trailing_whitespace? = after_end < len and whitespace?(elem(graphemes, after_end))
+    leading_whitespace? = start_g > 0 and whitespace?(elem(graphemes, start_g - 1))
+
+    around_word_grapheme_bounds(
+      graphemes,
+      start_g,
+      end_g,
+      after_end,
+      trailing_whitespace?,
+      leading_whitespace?
+    )
+  end
+
+  @spec around_word_grapheme_bounds(
+          tuple(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean(),
+          boolean()
+        ) :: {non_neg_integer(), non_neg_integer()}
+  defp around_word_grapheme_bounds(
+         graphemes,
+         start_g,
+         _end_g,
+         after_end,
+         true,
+         _leading_whitespace?
+       ) do
+    trail_end = scan_right_tuple(graphemes, after_end, &whitespace?/1)
+    {start_g, trail_end}
+  end
+
+  defp around_word_grapheme_bounds(graphemes, start_g, end_g, _after_end, false, true) do
+    lead_start = scan_left_tuple(graphemes, start_g - 1, &whitespace?/1)
+    {lead_start, end_g}
+  end
+
+  defp around_word_grapheme_bounds(_graphemes, start_g, end_g, _after_end, false, false) do
+    {start_g, end_g}
   end
 
   @spec word_char?(String.t()) :: boolean()
@@ -1092,19 +1135,33 @@ defmodule Minga.Editing.TextObject do
   defp find_open(flat, idx, open_char, close_char, depth) do
     {g, _pos} = Enum.at(flat, idx)
 
-    cond do
-      g == close_char ->
-        find_open(flat, idx - 1, open_char, close_char, depth + 1)
+    find_open_for_grapheme(flat, idx, open_char, close_char, depth, g)
+  end
 
-      g == open_char and depth > 0 ->
-        find_open(flat, idx - 1, open_char, close_char, depth - 1)
+  @spec find_open_for_grapheme(
+          [{String.t(), position()}],
+          non_neg_integer(),
+          String.t(),
+          String.t(),
+          non_neg_integer(),
+          String.t()
+        ) :: non_neg_integer() | nil
+  defp find_open_for_grapheme(flat, idx, open_char, close_char, depth, grapheme)
+       when grapheme == close_char do
+    find_open(flat, idx - 1, open_char, close_char, depth + 1)
+  end
 
-      g == open_char ->
-        idx
+  defp find_open_for_grapheme(flat, idx, open_char, close_char, depth, grapheme)
+       when grapheme == open_char and depth > 0 do
+    find_open(flat, idx - 1, open_char, close_char, depth - 1)
+  end
 
-      true ->
-        find_open(flat, idx - 1, open_char, close_char, depth)
-    end
+  defp find_open_for_grapheme(_flat, idx, open_char, _close_char, _depth, grapheme)
+       when grapheme == open_char,
+       do: idx
+
+  defp find_open_for_grapheme(flat, idx, open_char, close_char, depth, _grapheme) do
+    find_open(flat, idx - 1, open_char, close_char, depth)
   end
 
   @spec find_close(
@@ -1120,20 +1177,34 @@ defmodule Minga.Editing.TextObject do
         nil
 
       {g, _pos} ->
-        cond do
-          g == open_char ->
-            find_close(flat, idx + 1, open_char, close_char, depth + 1)
-
-          g == close_char and depth > 1 ->
-            find_close(flat, idx + 1, open_char, close_char, depth - 1)
-
-          g == close_char ->
-            idx
-
-          true ->
-            find_close(flat, idx + 1, open_char, close_char, depth)
-        end
+        find_close_for_grapheme(flat, idx, open_char, close_char, depth, g)
     end
+  end
+
+  @spec find_close_for_grapheme(
+          [{String.t(), position()}],
+          non_neg_integer(),
+          String.t(),
+          String.t(),
+          pos_integer(),
+          String.t()
+        ) :: non_neg_integer() | nil
+  defp find_close_for_grapheme(flat, idx, open_char, close_char, depth, grapheme)
+       when grapheme == open_char do
+    find_close(flat, idx + 1, open_char, close_char, depth + 1)
+  end
+
+  defp find_close_for_grapheme(flat, idx, open_char, close_char, depth, grapheme)
+       when grapheme == close_char and depth > 1 do
+    find_close(flat, idx + 1, open_char, close_char, depth - 1)
+  end
+
+  defp find_close_for_grapheme(_flat, idx, _open_char, close_char, _depth, grapheme)
+       when grapheme == close_char,
+       do: idx
+
+  defp find_close_for_grapheme(flat, idx, open_char, close_char, depth, _grapheme) do
+    find_close(flat, idx + 1, open_char, close_char, depth)
   end
 
   # Advances a position by one grapheme (byte-aware).


### PR DESCRIPTION
# TL;DR
Removed the remaining `cond` matches from Layer 0 buffer/editing code so the core modules comply with the project style rule. This is a behavior-preserving refactor covered by focused editing tests, lint, and the full LLM test suite.

Closes #1658

## Context
Issue #1658 called out stale `cond` usage in Layer 0 modules and required `lib/minga/buffer` plus `lib/minga/editing` to grep clean. `document.ex` was already clean on the current base branch, so this PR focuses on the remaining matches in `lib/minga/editing` and removes a docstring example that caused a false-positive grep match.

## Changes
- Replaced `TextObject` branching for around-word bounds, classifier selection, and delimiter scanning with private multi-clause helpers.
- Replaced `AutoPair.on_insert/3` branch selection with private helper clauses that preserve the same skip, pair, and passthrough behavior.
- Replaced `Operator.line_range/2` branch selection with arity-specific private clauses.
- Updated the `BlockPair` docstring example so `rg "\bcond\b" lib/minga/buffer lib/minga/editing` only reflects actual code usage.

## Verification
- `rg -n "\bcond\b" lib/minga/buffer lib/minga/editing || true`: no output
- `mix test.llm test/minga/editing/text_object_test.exs test/minga/editing/auto_pair_test.exs test/minga/editing/operator_test.exs`: PASS, 123 tests
- `make lint`: PASS
- `mix test.llm`: PASS, 52 doctests, 99 properties, 8096 tests, 0 failures, 5 skipped, 198 excluded
- `mix test.llm test/minga/distribution/connection_manager_test.exs:63`: PASS on recheck after reviewer saw a non-reproducing failure
- `mix test.llm test/minga/distribution/connection_manager_test.exs`: PASS, 6 tests
- `git diff --check`: no output

## Acceptance Criteria Addressed
- All `cond` blocks in `lib/minga/buffer/document.ex` are replaced with multi-clause private functions using pattern matching and guards ✅, already satisfied on current `origin/main`; `document.ex` has no `cond` or `line_byte_range` matches.
- All `cond` blocks in `lib/minga/editing/text_object.ex` are replaced similarly ✅
- Grep confirms zero `cond` usage in `lib/minga/buffer/` and `lib/minga/editing/` ✅
- All existing tests pass, `mix lint` clean ✅
- No behavior changes ✅
