### PR TITLE
Compact contextual picker height

### DIFF
--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -270,13 +270,17 @@ defmodule MingaEditor.FocusTree do
   end
 
   @spec add_picker_overlay(t(), map(), Layout.t()) :: t()
-  defp add_picker_overlay(%TreeNode{} = root, %{picker: %PickerData{}, layout: :centered}, layout) do
+  defp add_picker_overlay(
+         %TreeNode{} = root,
+         %{picker: %PickerData{} = picker, layout: :centered},
+         layout
+       ) do
     backdrop =
       TreeNode.new(:picker_backdrop, layout.terminal,
         handler: Input.Picker,
         scrollable?: true,
         children: [
-          TreeNode.new(:picker, centered_picker_rect(layout),
+          TreeNode.new(:picker, centered_picker_rect(layout, picker),
             handler: Input.Picker,
             scrollable?: true,
             focusable?: true
@@ -335,10 +339,13 @@ defmodule MingaEditor.FocusTree do
     %{root | children: children ++ [child]}
   end
 
-  @spec centered_picker_rect(Layout.t()) :: Layout.rect()
-  defp centered_picker_rect(%Layout{terminal: {_row, _col, cols, rows}}) do
+  @spec centered_picker_rect(Layout.t(), PickerData.t()) :: Layout.rect()
+  defp centered_picker_rect(%Layout{terminal: {_row, _col, cols, rows}}, picker) do
+    max_height = max(div(rows * 70, 100), 5)
+    item_capacity = max_height - 3
+    {visible, _selected_offset} = PickerData.visible_items(picker, item_capacity)
     width = max(div(cols * 60, 100), 1)
-    height = max(div(rows * 70, 100), 1)
+    height = min(length(visible) + 3, max_height) |> min(rows) |> max(1)
     row = max(div(rows - height, 2), 0)
     col = max(div(cols - width, 2), 0)
     {row, col, width, height}
@@ -346,7 +353,7 @@ defmodule MingaEditor.FocusTree do
 
   @spec bottom_picker_rect(Layout.t(), PickerData.t()) :: Layout.rect()
   defp bottom_picker_rect(%Layout{terminal: {_row, _col, cols, rows}}, picker) do
-    {visible, _selected_offset} = PickerData.visible_items(picker)
+    {visible, _selected_offset} = PickerData.visible_items(picker, max(rows - 3, 1))
     item_count = length(visible)
     prompt_row = rows - 1
     separator_row = prompt_row - item_count - 1

--- a/lib/minga_editor/input/picker.ex
+++ b/lib/minga_editor/input/picker.ex
@@ -153,30 +153,52 @@ defmodule MingaEditor.Input.Picker do
   defp handle_picker_click(state, node, picker, source, row) do
     {:picker, %{picker_ui: %{layout: layout}}} = state.shell_state.modal
 
-    clicked_idx =
-      case layout do
-        :centered -> centered_click_index(node, row)
-        _bottom -> bottom_click_index(state, picker, row)
-      end
+    case clicked_item(layout, state, node, picker, row) do
+      nil -> state
+      item -> confirm_clicked_item(state, source, item)
+    end
+  end
 
-    {visible, _selected_offset} = PickerData.visible_items(picker)
-
-    case Enum.at(visible, clicked_idx) do
+  @spec clicked_item(
+          MingaEditor.UI.Picker.Source.layout(),
+          EditorState.t(),
+          FocusNode.t(),
+          PickerData.t(),
+          integer()
+        ) :: PickerData.item() | nil
+  defp clicked_item(layout, state, node, picker, row) do
+    case click_index(layout, state, node, picker, row) do
       nil ->
-        state
+        nil
 
-      item ->
-        new_state = PickerUI.close(state)
-        new_state = source.on_select(item, new_state)
+      idx ->
+        {visible, _selected_offset} = visible_items_for_click(layout, state, node, picker)
+        Enum.at(visible, idx)
+    end
+  end
 
-        case Map.get(new_state, :pending_command) do
-          nil ->
-            new_state
+  @spec click_index(
+          MingaEditor.UI.Picker.Source.layout(),
+          EditorState.t(),
+          FocusNode.t(),
+          PickerData.t(),
+          integer()
+        ) :: non_neg_integer() | nil
+  defp click_index(:centered, _state, node, _picker, row), do: centered_click_index(node, row)
+  defp click_index(_bottom, state, _node, picker, row), do: bottom_click_index(state, picker, row)
 
-          cmd ->
-            record_command_execution(source, cmd)
-            MingaEditor.dispatch_command(Map.delete(new_state, :pending_command), cmd)
-        end
+  @spec confirm_clicked_item(EditorState.t(), module(), PickerData.item()) :: EditorState.t()
+  defp confirm_clicked_item(state, source, item) do
+    new_state = PickerUI.close(state)
+    new_state = source.on_select(item, new_state)
+
+    case Map.get(new_state, :pending_command) do
+      nil ->
+        new_state
+
+      cmd ->
+        record_command_execution(source, cmd)
+        MingaEditor.dispatch_command(Map.delete(new_state, :pending_command), cmd)
     end
   end
 
@@ -191,19 +213,54 @@ defmodule MingaEditor.Input.Picker do
   defp record_command_execution(_source, _command_name), do: :ok
 
   # Bottom-anchored: items grow upward from the prompt at viewport bottom.
-  @spec bottom_click_index(EditorState.t(), PickerData.t(), integer()) :: integer()
+  @spec bottom_click_index(EditorState.t(), PickerData.t(), integer()) :: non_neg_integer() | nil
   defp bottom_click_index(state, picker, row) do
-    {visible, _} = PickerData.visible_items(picker)
+    {visible, _} = PickerData.visible_items(picker, bottom_item_capacity(state))
     item_count = length(visible)
     prompt_row = state.terminal_viewport.rows - 1
     first_item_row = prompt_row - item_count
-    row - first_item_row
+    clicked_idx = row - first_item_row
+
+    if clicked_idx >= 0 and clicked_idx < item_count do
+      clicked_idx
+    else
+      nil
+    end
   end
 
+  @spec visible_items_for_click(
+          MingaEditor.UI.Picker.Source.layout(),
+          EditorState.t(),
+          FocusNode.t(),
+          PickerData.t()
+        ) :: {[PickerData.item()], non_neg_integer()}
+  defp visible_items_for_click(:centered, _state, node, picker) do
+    PickerData.visible_items(picker, centered_item_capacity(node))
+  end
+
+  defp visible_items_for_click(_bottom, state, _node, picker) do
+    PickerData.visible_items(picker, bottom_item_capacity(state))
+  end
+
+  @spec bottom_item_capacity(EditorState.t()) :: pos_integer()
+  defp bottom_item_capacity(state), do: max(state.terminal_viewport.rows - 3, 1)
+
   # Centered: items start at the top of the FloatingWindow interior.
-  @spec centered_click_index(FocusNode.t(), integer()) :: integer()
-  defp centered_click_index(%FocusNode{rect: {box_row, _box_col, _box_w, _box_h}}, row) do
+  @spec centered_click_index(FocusNode.t(), integer()) :: non_neg_integer() | nil
+  defp centered_click_index(%FocusNode{rect: {box_row, _box_col, _box_w, _box_h}} = node, row) do
     interior_row = box_row + 1
-    row - interior_row
+    item_rows = centered_item_capacity(node)
+    clicked_idx = row - interior_row
+
+    if clicked_idx >= 0 and clicked_idx < item_rows do
+      clicked_idx
+    else
+      nil
+    end
+  end
+
+  @spec centered_item_capacity(FocusNode.t()) :: non_neg_integer()
+  defp centered_item_capacity(%FocusNode{rect: {_box_row, _box_col, _box_w, box_h}}) do
+    max(box_h - 3, 0)
   end
 end

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -669,11 +669,13 @@ defmodule MingaEditor.PickerUI do
          theme_picker: pc,
          viewport: viewport
        }) do
-    {visible, selected_offset} = Picker.visible_items(picker)
+    item_capacity = centered_item_capacity(viewport.rows)
+    {visible, selected_offset} = Picker.visible_items(picker, item_capacity)
 
     # Compute float window dimensions
     float_width = {:percent, 60}
-    float_height = {:percent, 70}
+    float_height_rows = centered_float_height(visible, viewport)
+    float_height = {:rows, float_height_rows}
 
     popup_theme = %{
       fg: pc.text_fg,
@@ -736,7 +738,7 @@ defmodule MingaEditor.PickerUI do
     # Compute absolute cursor position inside the floating window
     {vp_rows, vp_cols} = {viewport.rows, viewport.cols}
     box_w = resolve_percent(60, vp_cols)
-    box_h = resolve_percent(70, vp_rows)
+    box_h = min(float_height_rows, vp_rows)
     box_row = max(div(vp_rows - box_h, 2), 0)
     box_col = max(div(vp_cols - box_w, 2), 0)
     # Interior starts at box + 1 (border inset)
@@ -844,6 +846,17 @@ defmodule MingaEditor.PickerUI do
     else
       do_highlight_matches(row, lt, llt, query, col + Unicode.display_width(lc), fg, bg, acc)
     end
+  end
+
+  @spec centered_item_capacity(pos_integer()) :: pos_integer()
+  defp centered_item_capacity(viewport_rows) do
+    max(div(viewport_rows * 7, 10), 5) - 3
+  end
+
+  @spec centered_float_height([Picker.item()], MingaEditor.Viewport.t()) :: pos_integer()
+  defp centered_float_height(visible, viewport) do
+    max_height = max(div(viewport.rows * 7, 10), 5)
+    min(length(visible) + 3, max_height)
   end
 
   @spec resolve_percent(pos_integer(), pos_integer()) :: pos_integer()

--- a/lib/minga_editor/ui/picker.ex
+++ b/lib/minga_editor/ui/picker.ex
@@ -167,11 +167,17 @@ defmodule MingaEditor.UI.Picker do
   Returns `{visible_items, selected_offset}`.
   """
   @spec visible_items(t()) :: {[item()], non_neg_integer()}
-  def visible_items(%__MODULE__{filtered: [], max_visible: _max}) do
+  def visible_items(%__MODULE__{max_visible: max} = picker), do: visible_items(picker, max)
+
+  @doc "Returns the visible slice using an explicit maximum item count."
+  @spec visible_items(t(), non_neg_integer()) :: {[item()], non_neg_integer()}
+  def visible_items(%__MODULE__{}, 0), do: {[], 0}
+
+  def visible_items(%__MODULE__{filtered: []}, _max) do
     {[], 0}
   end
 
-  def visible_items(%__MODULE__{filtered: filtered, selected: sel, max_visible: max}) do
+  def visible_items(%__MODULE__{filtered: filtered, selected: sel}, max) do
     total = length(filtered)
 
     if total <= max do

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -39,7 +39,8 @@ struct PickerOverlay: View {
                         Divider()
                             .overlay(theme.popupBorder.opacity(0.3))
 
-                        resultsList(maxListHeight: max(geo.size.height * 0.5, 200))
+                        let listHeight = min(CGFloat(state.items.count) * itemHeight, max(geo.size.height * 0.5, 200))
+                        resultsList(maxListHeight: listHeight)
 
                         if !state.items.isEmpty {
                             Divider()
@@ -112,7 +113,7 @@ struct PickerOverlay: View {
                     }
                 }
             }
-            .frame(maxHeight: min(CGFloat(state.items.count) * itemHeight, maxListHeight))
+            .frame(maxHeight: maxListHeight)
             .onChange(of: state.selectedIndex) { _, newIndex in
                 withAnimation(nil) {
                     proxy.scrollTo(newIndex, anchor: .center)

--- a/test/minga_editor/focus_tree_test.exs
+++ b/test/minga_editor/focus_tree_test.exs
@@ -12,6 +12,17 @@ defmodule MingaEditor.FocusTreeTest do
   alias MingaEditor.FocusTree
   alias MingaEditor.FocusTree.Node, as: TreeNode
   alias MingaEditor.Layout
+  alias MingaEditor.PickerUI
+  alias MingaEditor.PickerUI.RenderInput
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.State.Picker, as: PickerState
+  alias MingaEditor.UI.Picker
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Theme
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
 
   defp single_window_layout do
     %Layout{
@@ -47,6 +58,25 @@ defmodule MingaEditor.FocusTreeTest do
       agent_panel: nil,
       status_bar: {22, 0, 80, 1},
       minibuffer: {23, 0, 80, 1}
+    }
+  end
+
+  defp centered_picker_state(items, max_visible) do
+    picker = Picker.new(items, title: "Models", max_visible: max_visible)
+
+    %MingaEditor.State{
+      port_manager: self(),
+      workspace: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()},
+      layout: single_window_layout(),
+      shell_state: %ShellState{
+        modal:
+          {:picker,
+           PickerPayload.new(%PickerState{
+             picker: picker,
+             source: nil,
+             layout: :centered
+           })}
+      }
     }
   end
 
@@ -167,6 +197,30 @@ defmodule MingaEditor.FocusTreeTest do
       tree = FocusTree.from_layout(single_window_layout())
       # Terminal is {0, 0, 80, 24} → rows 0..23, cols 0..79.
       assert FocusTree.hit_test(tree, 24, 80) == nil
+    end
+  end
+
+  describe "centered picker overlay height" do
+    test "hit-test height matches the compact rendered popup height for tall lists" do
+      items = for n <- 1..20, do: %Item{id: Integer.to_string(n), label: "model-#{n}"}
+      picker = Picker.new(items, title: "Models", max_visible: 20)
+      state = centered_picker_state(items, 20)
+
+      {draws, _cursor} =
+        PickerUI.render(%RenderInput{
+          picker_state: %PickerState{picker: picker, source: nil, layout: :centered},
+          theme_picker: Theme.get!(:doom_one).picker,
+          viewport: Viewport.new(24, 80)
+        })
+
+      rendered_rows = Enum.map(draws, fn {row, _col, _text, _style} -> row end)
+      rendered_height = Enum.max(rendered_rows) - Enum.min(rendered_rows) + 1
+
+      tree = FocusTree.from_state(state)
+      picker_backdrop = Enum.find(tree.children, &(&1.content_type == :picker_backdrop))
+      picker_node = hd(picker_backdrop.children)
+
+      assert elem(picker_node.rect, 3) == rendered_height
     end
   end
 

--- a/test/minga_editor/input/picker_mouse_test.exs
+++ b/test/minga_editor/input/picker_mouse_test.exs
@@ -24,9 +24,9 @@ defmodule MingaEditor.Input.PickerMouseTest do
     def title, do: "Test"
   end
 
-  defp picker_state(items) do
+  defp picker_state(items, max_visible \\ 10) do
     picker =
-      PickerData.new(items, max_visible: 10, title: "Test")
+      PickerData.new(items, max_visible: max_visible, title: "Test")
 
     vp = Viewport.new(30, 80)
 
@@ -75,7 +75,37 @@ defmodule MingaEditor.Input.PickerMouseTest do
       # Picker should be closed
       assert new_state.shell_state.modal == :none
       # Source's on_select should have been called
-      assert Map.has_key?(new_state, :selected_item)
+      assert new_state.selected_item.id == 1
+    end
+
+    test "clicking the only bottom candidate selects and confirms it" do
+      state = picker_state([%{id: 1, label: "only"}])
+
+      {:handled, new_state} = PickerInput.handle_mouse(state, 28, 10, :left, 0, :press, 1)
+
+      assert new_state.shell_state.modal == :none
+      assert new_state.selected_item.id == 1
+    end
+
+    test "clicking the last rendered bottom candidate selects it when the list is viewport-capped" do
+      items = for n <- 1..40, do: %{id: n, label: "item-#{n}"}
+      state = picker_state(items, 40)
+
+      # 30 rows leave 27 item rows, plus separator and prompt. The last rendered item is item 27.
+      {:handled, new_state} = PickerInput.handle_mouse(state, 28, 10, :left, 0, :press, 1)
+
+      assert new_state.shell_state.modal == :none
+      assert new_state.selected_item.id == 27
+    end
+
+    test "clicking the bottom picker separator does not select from the end of the list" do
+      items = for n <- 1..40, do: %{id: n, label: "item-#{n}"}
+      state = picker_state(items, 40)
+
+      {:handled, new_state} = PickerInput.handle_mouse(state, 1, 10, :left, 0, :press, 1)
+
+      assert ModalOverlay.match(new_state.shell_state.modal, :picker)
+      refute Map.has_key?(new_state, :selected_item)
     end
 
     test "clicking outside items area is handled but does nothing" do
@@ -90,9 +120,9 @@ defmodule MingaEditor.Input.PickerMouseTest do
   end
 
   describe "centered picker clicks" do
-    defp centered_picker_state(items) do
+    defp centered_picker_state(items, max_visible \\ 10) do
       picker =
-        PickerData.new(items, max_visible: 10, title: "Test")
+        PickerData.new(items, max_visible: max_visible, title: "Test")
 
       %EditorState{
         port_manager: nil,
@@ -116,21 +146,63 @@ defmodule MingaEditor.Input.PickerMouseTest do
       items = [%{id: 1, label: "alpha"}, %{id: 2, label: "beta"}]
       state = centered_picker_state(items)
 
-      # 70% of 24 rows = 16 rows, centered: box starts at row 4
-      # Interior starts at row 5 (box_row + 1 border)
-      # First item is at interior row 0 = screen row 5
-      {:handled, new_state} = PickerInput.handle_mouse(state, 5, 20, :left, 0, :press, 1)
+      # Two visible items + prompt + border = 5 rows, centered: box starts at row 9.
+      # Interior starts at row 10 (box_row + 1 border).
+      # First item is at interior row 0 = screen row 10.
+      {:handled, new_state} = PickerInput.handle_mouse(state, 10, 20, :left, 0, :press, 1)
 
       assert new_state.shell_state.modal == :none
       assert Map.has_key?(new_state, :selected_item)
+    end
+
+    test "clicking the prompt row in a tall centered picker ignores hidden items" do
+      items = for n <- 1..20, do: %{id: n, label: "item-#{n}"}
+      state = centered_picker_state(items, 20)
+
+      max_height = max(div(24 * 7, 10), 5)
+      box_h = min(length(items) + 3, max_height)
+      box_row = div(24 - box_h, 2)
+      prompt_row = box_row + box_h - 2
+
+      # The prompt row is still inside the hit-test rect; it must not map to a hidden item.
+      {:handled, new_state} = PickerInput.handle_mouse(state, prompt_row, 20, :left, 0, :press, 1)
+
+      assert ModalOverlay.match(new_state.shell_state.modal, :picker)
+      refute Map.has_key?(new_state, :selected_item)
+    end
+
+    test "clicking the last rendered row in a tall centered picker selects the selected-visible slice" do
+      items = for n <- 1..20, do: %{id: n, label: "item-#{n}"}
+
+      state =
+        items
+        |> centered_picker_state(20)
+        |> MingaEditor.PickerUI.update_picker(fn picker_ui ->
+          picker =
+            Enum.reduce(1..19, picker_ui.picker, fn _n, acc -> PickerData.move_down(acc) end)
+
+          %{picker_ui | picker: picker}
+        end)
+
+      max_height = max(div(24 * 7, 10), 5)
+      box_h = min(length(items) + 3, max_height)
+      box_row = div(24 - box_h, 2)
+      last_item_row = box_row + 1 + (box_h - 3) - 1
+
+      {:handled, new_state} =
+        PickerInput.handle_mouse(state, last_item_row, 20, :left, 0, :press, 1)
+
+      assert new_state.shell_state.modal == :none
+      assert new_state.selected_item.id == 20
     end
 
     test "clicking outside the centered float dismisses the picker" do
       items = [%{id: 1, label: "alpha"}]
       state = centered_picker_state(items)
 
-      # Click at row 0, col 0 (outside the centered box)
-      {:handled, new_state} = PickerInput.handle_mouse(state, 0, 0, :left, 0, :press, 1)
+      # One visible item + prompt + border = 4 rows, centered: box starts at row 10.
+      # Row 5 was inside the old 70% hit-test rect but is outside the compact popup.
+      {:handled, new_state} = PickerInput.handle_mouse(state, 5, 20, :left, 0, :press, 1)
 
       # Picker should be closed (dismissed), no item selected
       assert new_state.shell_state.modal == :none

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -118,6 +118,32 @@ defmodule MingaEditor.PickerUITest do
       assert cursor_row == 23
     end
 
+    test "bottom picker keeps the selected item visible when viewport-capped" do
+      items =
+        for n <- 1..40 do
+          %Item{id: Integer.to_string(n), label: "file-#{n}"}
+        end
+
+      picker =
+        items
+        |> Picker.new(title: "Files", max_visible: 40)
+        |> then(fn picker ->
+          Enum.reduce(1..39, picker, fn _n, acc -> Picker.move_down(acc) end)
+        end)
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+      texts = Enum.map(draws, fn {_row, _col, text, _style} -> text end)
+
+      assert Enum.any?(texts, &String.contains?(&1, "file-40"))
+      refute Enum.any?(texts, &String.contains?(&1, "file-1 "))
+    end
+
     test "draw tuples have valid 4-element structure" do
       items = [
         %Item{id: "1", label: "alpha.ex", description: "lib/"},
@@ -325,7 +351,7 @@ defmodule MingaEditor.PickerUITest do
       assert is_integer(cursor_col)
     end
 
-    test "all draws are within the floating window rect" do
+    test "all draws are within the auto-sized floating window rect" do
       items = [
         %Item{id: "1", label: "model-a", description: "desc"},
         %Item{id: "2", label: "model-b", description: "desc"}
@@ -343,9 +369,9 @@ defmodule MingaEditor.PickerUITest do
 
       {draws, _cursor} = PickerUI.render(input)
 
-      # FloatingWindow at 60% x 70% centered in 80x24
+      # FloatingWindow stays at 60% width and sizes height to visible items + prompt + border.
       box_w = div(80 * 60, 100)
-      box_h = div(24 * 70, 100)
+      box_h = length(items) + 3
       box_row = div(24 - box_h, 2)
       box_col = div(80 - box_w, 2)
 
@@ -356,6 +382,65 @@ defmodule MingaEditor.PickerUITest do
         assert col >= box_col and col < box_col + box_w,
                "draw col #{col} outside box (#{box_col}..#{box_col + box_w - 1})"
       end)
+    end
+
+    test "centered picker with five items renders as a compact popup" do
+      items =
+        for n <- 1..5 do
+          %Item{id: Integer.to_string(n), label: "model-#{n}"}
+        end
+
+      picker = Picker.new(items, title: "Models", max_visible: 10)
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil, layout: :centered},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, {cursor_row, _cursor_col}} = PickerUI.render(input)
+      rows = Enum.map(draws, fn {row, _col, _text, _style} -> row end)
+
+      box_h = length(items) + 3
+      box_row = div(24 - box_h, 2)
+
+      assert Enum.min(rows) == box_row
+      assert Enum.max(rows) == box_row + box_h - 1
+      assert cursor_row == box_row + box_h - 2
+    end
+
+    test "large centered picker caps height and keeps the cursor inside" do
+      items =
+        for n <- 1..20 do
+          %Item{id: Integer.to_string(n), label: "model-#{n}"}
+        end
+
+      picker =
+        items
+        |> Picker.new(title: "Models", max_visible: 20)
+        |> then(fn picker ->
+          Enum.reduce(1..19, picker, fn _n, acc -> Picker.move_down(acc) end)
+        end)
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil, layout: :centered},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, {cursor_row, _cursor_col}} = PickerUI.render(input)
+      rows = Enum.map(draws, fn {row, _col, _text, _style} -> row end)
+      texts = Enum.map(draws, fn {_row, _col, text, _style} -> text end)
+
+      max_height = max(div(24 * 7, 10), 5)
+      box_h = min(length(items) + 3, max_height)
+      box_row = div(24 - box_h, 2)
+
+      assert Enum.min(rows) == box_row
+      assert Enum.max(rows) == box_row + box_h - 1
+      assert cursor_row == box_row + box_h - 2
+      assert Enum.any?(texts, &String.contains?(&1, "model-20"))
+      refute Enum.any?(texts, &String.contains?(&1, "model-1 "))
     end
 
     test "cursor is inside the floating window (not at viewport bottom)" do
@@ -371,12 +456,12 @@ defmodule MingaEditor.PickerUITest do
       {_draws, {cursor_row, _col}} = PickerUI.render(input)
 
       # In centered mode, cursor should NOT be at the viewport bottom (row 23)
-      # It should be inside the float box
-      box_h = div(24 * 70, 100)
+      # It should be inside the auto-sized float box, on the prompt row.
+      box_h = 1 + 3
       box_row = div(24 - box_h, 2)
 
-      assert cursor_row >= box_row and cursor_row < box_row + box_h,
-             "cursor row #{cursor_row} should be inside the float box"
+      assert cursor_row == box_row + box_h - 2,
+             "cursor row #{cursor_row} should be on the prompt row inside the float box"
     end
 
     test "contains border characters from rounded style" do

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -13,6 +13,9 @@ defmodule MingaEditor.Renderer.ServerTest do
   alias MingaEditor.Shell.Board.State, as: BoardState
   alias MingaEditor.Viewport
 
+  # Async renderer writeback can lag a bit under CI load, keep this local to the renderer assertions.
+  @async_render_timeout 5_000
+
   test "coalescing replaces older pending snapshots and emits telemetry" do
     renderer = start_renderer(self())
     attach_coalesce_handler()
@@ -47,7 +50,7 @@ defmodule MingaEditor.Renderer.ServerTest do
     RendererServer.cast_snapshot(renderer, snapshot, 123)
 
     assert_receive {:render_done, %{frame_seq: 123, caches: %MingaEditor.Renderer.Caches{}}},
-                   1_000
+                   @async_render_timeout
 
     assert {:ok, _screen} = Minga.Test.HeadlessPort.collect_frame(frame_ref)
     refute renderer_busy?(renderer)
@@ -61,7 +64,9 @@ defmodule MingaEditor.Renderer.ServerTest do
       result = MingaEditor.Renderer.render_or_async(state)
 
       assert result == state
-      assert_receive {:render_done, %{caches: %MingaEditor.Renderer.Caches{}}}, 1_000
+
+      assert_receive {:render_done, %{caches: %MingaEditor.Renderer.Caches{}}},
+                     @async_render_timeout
     end
 
     test "nil renderer falls back to synchronous rendering" do


### PR DESCRIPTION
# TL;DR
Centered contextual pickers now size to their visible content instead of filling 70% of the viewport, while keeping large pickers capped. This makes small code action, model, and agent group pickers feel like lightweight popups instead of modal panels.

Closes #1722

## Context
Issue #1722 calls out that centered pickers used a fixed 60% width and 70% height even when only a few items were visible. This PR keeps the existing width behavior but makes height proportional to the visible item count plus picker chrome.

## Changes
- Compute TUI centered picker height as `visible_items + 3`, capped at 70% of the viewport.
- Keep the centered picker cursor, prompt, border, title, and footer aligned with the new compact height.
- Update the focus-tree hit-test rect and mouse selection logic to match the rendered compact picker, so clicks outside rendered items do not select clipped, prompt, separator, or border rows.
- Make the macOS picker overlay list height item-count driven while preserving the existing maximum height cap and fixed panel width.
- Add regression coverage for compact 5-item rendering, capped large-list rendering, selected-item visibility, bottom and centered mouse hit testing, and focus-tree/render height sync.
- Harden the async renderer receive timeout locally, with the broader session timeout reverted after targeted validation.

## Verification
- `mix test.llm test/minga_editor/picker_ui_test.exs test/minga_editor/input/picker_mouse_test.exs test/minga_editor/focus_tree_test.exs test/minga_editor/renderer/server_test.exs test/minga_agent/session_test.exs test/minga_editor/ui/picker_test.exs`: PASS, 151 tests
- `make lint`: PASS
- `mix test.llm`: PASS, 52 doctests, 99 properties, 8105 tests, 0 failures, 5 skipped, 198 excluded
- `mix swift.build`: ran, but local environment has no `xcodebuild`, so the project task skipped Swift build
- `mix swift.harness`: not runnable locally because `swiftc` is not installed

## Acceptance Criteria Addressed
- Centered pickers auto-size height to visible item count plus prompt and border chrome, capped at max height ✅
- A picker with 5 items renders as a compact popup, not a 70%-height window ✅
- Width remains 60% on TUI and fixed-width on macOS ✅
- Prompt, border, title, and footer render correctly at the auto-sized height ✅

## Review Notes
The Swift-facing change is intentionally small and limited to list height calculation. I could not run native Swift validation locally because this environment does not have Xcode or Swift installed, so macOS CI or a local Mac should verify the overlay visually.
