### PR TITLE
feat(command): check ex-command registration drift

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -31,6 +31,7 @@
           {Minga.Credo.NoDirectStateMachineWriteCheck, []},
           {Minga.Credo.NoDirectModalOverlayWriteCheck, []},
           {Minga.Credo.NoRawWorkspaceSnapshotCheck, []},
+          {Minga.Credo.CommandRegistrationCheck, []},
 
           # ── Readability ────────────────────────────────────────────────────
           {Credo.Check.Readability.AliasOrder, false},

--- a/credo/checks/command_registration_check.exs
+++ b/credo/checks/command_registration_check.exs
@@ -1,0 +1,383 @@
+defmodule Minga.Credo.CommandRegistrationCheck do
+  @moduledoc """
+  Cross-checks ex-command parser, type, registry, and dispatch registration.
+
+  Ex commands are easy to break because the parser, `parsed` type union, command registry providers, and tuple dispatcher live in different files. This check keeps those sites honest by deriving the command atom sets from source and flagging mismatches during `mix credo`.
+  """
+
+  use Credo.Check,
+    id: "EX9007",
+    base_priority: :high,
+    category: :warning,
+    explanations: [
+      check: """
+      Every ex-command atom parsed by `Minga.Command.Parser` must be represented in the `parsed` type and must have either a direct `execute_ex_command` dispatcher or a registered provider command. Every provider module under `lib/minga_editor/commands/` must also be listed in `Minga.Command.Registry`.
+      """
+    ]
+
+  @non_command_parser_atoms ~w(absolute current_line last_line no_range visual whole_buffer)a
+
+  @impl Credo.Check
+  @spec run(Credo.SourceFile.t(), keyword()) :: [Credo.Issue.t()]
+  def run(%SourceFile{} = source_file, params) do
+    if target_file?(source_file.filename, params) do
+      issue_meta = IssueMeta.for(source_file, params)
+      root = root_path(params)
+
+      root
+      |> collect_sites()
+      |> issues_for_sites(issue_meta)
+    else
+      []
+    end
+  end
+
+  @spec target_file?(String.t(), keyword()) :: boolean()
+  defp target_file?(filename, params) do
+    target = params |> root_path() |> Path.join(parser_path(params)) |> Path.expand()
+
+    filename
+    |> Path.expand()
+    |> String.ends_with?(target)
+  end
+
+  @spec collect_sites(String.t()) :: map()
+  defp collect_sites(root) do
+    parser = read_file(root, parser_path([]))
+    commands = read_file(root, "lib/minga_editor/commands.ex")
+    buffer_management = read_file(root, "lib/minga_editor/commands/buffer_management.ex")
+    registry = read_file(root, "lib/minga/command/registry.ex")
+    provider_sources = provider_sources(root)
+
+    registered_modules = registered_modules(registry)
+    provider_modules = provider_modules(provider_sources)
+
+    %{
+      parser_atoms: parser_atoms(parser),
+      type_atoms: type_atoms(parser),
+      dispatch_atoms:
+        dispatch_atoms(commands, buffer_management, provider_sources, registered_modules),
+      registered_modules: registered_modules,
+      provider_modules: provider_modules
+    }
+  end
+
+  @spec issues_for_sites(map(), Credo.IssueMeta.t()) :: [Credo.Issue.t()]
+  defp issues_for_sites(sites, issue_meta) do
+    []
+    |> add_atom_difference_issue(
+      sites.parser_atoms,
+      sites.type_atoms,
+      issue_meta,
+      "Parser returns ex-command atoms missing from `@type parsed`:"
+    )
+    |> add_atom_difference_issue(
+      sites.type_atoms,
+      sites.parser_atoms,
+      issue_meta,
+      "`@type parsed` contains ex-command atoms that the parser never returns:"
+    )
+    |> add_atom_difference_issue(
+      sites.parser_atoms,
+      sites.dispatch_atoms,
+      issue_meta,
+      "Parser returns ex-command atoms with no direct dispatcher or registered provider command:"
+    )
+    |> add_module_difference_issue(
+      sites.provider_modules,
+      sites.registered_modules,
+      issue_meta,
+      "Command provider modules missing from `Minga.Command.Registry @command_modules`:"
+    )
+    |> add_module_difference_issue(
+      sites.registered_modules,
+      sites.provider_modules,
+      issue_meta,
+      "Registry lists modules that do not declare `Minga.Command.Provider`:"
+    )
+  end
+
+  @spec add_atom_difference_issue(
+          [Credo.Issue.t()],
+          MapSet.t(atom()),
+          MapSet.t(atom()),
+          Credo.IssueMeta.t(),
+          String.t()
+        ) :: [Credo.Issue.t()]
+  defp add_atom_difference_issue(issues, left, right, issue_meta, message) do
+    left
+    |> MapSet.difference(right)
+    |> MapSet.to_list()
+    |> Enum.sort()
+    |> add_difference_issue(issues, issue_meta, message)
+  end
+
+  @spec add_module_difference_issue(
+          [Credo.Issue.t()],
+          MapSet.t(String.t()),
+          MapSet.t(String.t()),
+          Credo.IssueMeta.t(),
+          String.t()
+        ) :: [Credo.Issue.t()]
+  defp add_module_difference_issue(issues, left, right, issue_meta, message) do
+    left
+    |> MapSet.difference(right)
+    |> MapSet.to_list()
+    |> Enum.sort()
+    |> add_difference_issue(issues, issue_meta, message)
+  end
+
+  @spec add_difference_issue(
+          [atom()] | [String.t()],
+          [Credo.Issue.t()],
+          Credo.IssueMeta.t(),
+          String.t()
+        ) :: [Credo.Issue.t()]
+  defp add_difference_issue([], issues, _issue_meta, _message), do: issues
+
+  defp add_difference_issue(values, issues, issue_meta, message) do
+    trigger = Enum.map_join(values, ", ", &to_string/1)
+
+    issue =
+      format_issue(issue_meta,
+        message: "#{message} #{trigger}",
+        trigger: trigger,
+        line_no: 1
+      )
+
+    [issue | issues]
+  end
+
+  @spec parser_atoms(String.t()) :: MapSet.t(atom())
+  defp parser_atoms(parser) do
+    parser
+    |> parser_without_parsed_type()
+    |> tuple_command_atoms()
+    |> MapSet.difference(MapSet.new(@non_command_parser_atoms))
+  end
+
+  @spec type_atoms(String.t()) :: MapSet.t(atom())
+  defp type_atoms(parser) do
+    parser
+    |> parsed_type_block()
+    |> tuple_command_atoms()
+  end
+
+  @spec tuple_command_atoms(String.t()) :: MapSet.t(atom())
+  defp tuple_command_atoms(source) do
+    ~r/\{:(?<name>[a-zA-Z_][a-zA-Z0-9_]*)(?:,|\})/
+    |> Regex.scan(source, capture: ["name"])
+    |> Enum.map(fn [name] -> String.to_atom(name) end)
+    |> MapSet.new()
+  end
+
+  @spec parsed_type_block(String.t()) :: String.t()
+  defp parsed_type_block(parser) do
+    case Regex.run(parsed_type_regex(), parser, capture: ["body"]) do
+      [body] -> body
+      nil -> ""
+    end
+  end
+
+  @spec parser_without_parsed_type(String.t()) :: String.t()
+  defp parser_without_parsed_type(parser) do
+    Regex.replace(parsed_type_regex(), parser, "")
+  end
+
+  @spec parsed_type_regex() :: Regex.t()
+  defp parsed_type_regex do
+    ~r/@type parsed ::(?<body>.*?)(?=\n\s*@(?:type|typedoc|doc|spec)\b|\n\s*defp?\s)/s
+  end
+
+  @spec dispatch_atoms(String.t(), String.t(), [{String.t(), String.t()}], MapSet.t(String.t())) ::
+          MapSet.t(atom())
+  defp dispatch_atoms(commands, buffer_management, provider_sources, registered_modules) do
+    commands
+    |> direct_execute_ex_atoms(buffer_management)
+    |> MapSet.union(ex_tuple_dispatch_atoms(commands))
+    |> MapSet.union(registered_provider_command_atoms(provider_sources, registered_modules))
+  end
+
+  @spec direct_execute_ex_atoms(String.t(), String.t()) :: MapSet.t(atom())
+  defp direct_execute_ex_atoms(commands, buffer_management) do
+    ~r/\{:execute_ex_command,\s*\{:(?<name>[a-zA-Z_][a-zA-Z0-9_]*)(?:,|\})/s
+    |> Regex.scan(commands <> "\n" <> buffer_management, capture: ["name"])
+    |> Enum.map(fn [name] -> String.to_atom(name) end)
+    |> MapSet.new()
+  end
+
+  @spec ex_tuple_dispatch_atoms(String.t()) :: MapSet.t(atom())
+  defp ex_tuple_dispatch_atoms(commands) do
+    case Regex.run(~r/@ex_tuple_dispatch_commands\s+\[(?<body>.*?)\]/s, commands,
+           capture: ["body"]
+         ) do
+      [body] -> atom_literals(body)
+      nil -> MapSet.new()
+    end
+  end
+
+  @spec registered_provider_command_atoms([{String.t(), String.t()}], MapSet.t(String.t())) ::
+          MapSet.t(atom())
+  defp registered_provider_command_atoms(provider_sources, registered_modules) do
+    provider_sources
+    |> Enum.filter(fn {module, _source} -> MapSet.member?(registered_modules, module) end)
+    |> Enum.reduce(MapSet.new(), fn {_module, source}, acc ->
+      MapSet.union(acc, provider_command_atoms(source))
+    end)
+  end
+
+  @spec provider_command_atoms(String.t()) :: MapSet.t(atom())
+  defp provider_command_atoms(source) do
+    []
+    |> MapSet.new()
+    |> MapSet.union(command_macro_atoms(source))
+    |> MapSet.union(command_struct_atoms(source))
+    |> MapSet.union(command_list_attr_atoms(source))
+  end
+
+  @spec command_macro_atoms(String.t()) :: MapSet.t(atom())
+  defp command_macro_atoms(source) do
+    ~r/\bcommand\(:(?<name>[a-zA-Z_][a-zA-Z0-9_]*)/
+    |> Regex.scan(source, capture: ["name"])
+    |> Enum.map(fn [name] -> String.to_atom(name) end)
+    |> MapSet.new()
+  end
+
+  @spec command_struct_atoms(String.t()) :: MapSet.t(atom())
+  defp command_struct_atoms(source) do
+    ~r/%(?:Minga\.)?Command\{[^}]*name:\s*:(?<name>[a-zA-Z_][a-zA-Z0-9_]*)/s
+    |> Regex.scan(source, capture: ["name"])
+    |> Enum.map(fn [name] -> String.to_atom(name) end)
+    |> MapSet.new()
+  end
+
+  @spec command_list_attr_atoms(String.t()) :: MapSet.t(atom())
+  defp command_list_attr_atoms(source) do
+    source
+    |> referenced_command_list_attrs()
+    |> Enum.reduce(MapSet.new(), fn attr_name, acc ->
+      MapSet.union(acc, command_list_attr_atoms_for(source, attr_name))
+    end)
+  end
+
+  @spec referenced_command_list_attrs(String.t()) :: MapSet.t(String.t())
+  defp referenced_command_list_attrs(source) do
+    command_list_attr_reference_regexes()
+    |> Enum.reduce(MapSet.new(), fn regex, acc ->
+      regex
+      |> Regex.scan(source, capture: ["name"])
+      |> Enum.map(fn [name] -> name end)
+      |> MapSet.new()
+      |> MapSet.union(acc)
+    end)
+  end
+
+  @spec command_list_attr_reference_regexes() :: [Regex.t()]
+  defp command_list_attr_reference_regexes do
+    [
+      ~r/\bcommands\s*\(@(?<name>[a-zA-Z_][a-zA-Z0-9_]*)\b/,
+      ~r/\bnumbered_commands\s*\(@(?<name>[a-zA-Z_][a-zA-Z0-9_]*)\b/,
+      ~r/\bEnum\.(?:map|flat_map|reduce|reduce_while)\s*\(@(?<name>[a-zA-Z_][a-zA-Z0-9_]*)\b/
+    ]
+  end
+
+  @spec command_list_attr_atoms_for(String.t(), String.t()) :: MapSet.t(atom())
+  defp command_list_attr_atoms_for(source, attr_name) do
+    case Regex.run(command_list_attr_regex(attr_name), source, capture: ["body"]) do
+      [body] ->
+        ~r/\{:(?<name>[a-zA-Z_][a-zA-Z0-9_]*),\s*/
+        |> Regex.scan(body, capture: ["name"])
+        |> Enum.map(fn [name] -> String.to_atom(name) end)
+        |> MapSet.new()
+
+      nil ->
+        MapSet.new()
+    end
+  end
+
+  @spec command_list_attr_regex(String.t()) :: Regex.t()
+  defp command_list_attr_regex(attr_name) do
+    Regex.compile!("@#{attr_name}\\s+\\[(?<body>.*?)\\]", "s")
+  end
+
+  @spec registered_modules(String.t()) :: MapSet.t(String.t())
+  defp registered_modules(registry) do
+    registry
+    |> command_modules_block()
+    |> module_names()
+  end
+
+  @spec command_modules_block(String.t()) :: String.t()
+  defp command_modules_block(registry) do
+    case Regex.run(~r/@command_modules\s+\[(?<body>.*?)\]/s, registry, capture: ["body"]) do
+      [body] -> body
+      nil -> ""
+    end
+  end
+
+  @spec provider_modules([{String.t(), String.t()}]) :: MapSet.t(String.t())
+  defp provider_modules(provider_sources) do
+    provider_sources
+    |> Enum.filter(fn {_module, source} -> provider_source?(source) end)
+    |> Enum.map(fn {module, _source} -> module end)
+    |> Enum.reject(&(&1 == "MingaEditor.Commands.Provider"))
+    |> MapSet.new()
+  end
+
+  @spec provider_source?(String.t()) :: boolean()
+  defp provider_source?(source) do
+    String.contains?(source, "use MingaEditor.Commands.Provider") or
+      String.contains?(source, "@behaviour Minga.Command.Provider")
+  end
+
+  @spec provider_sources(String.t()) :: [{String.t(), String.t()}]
+  defp provider_sources(root) do
+    root
+    |> Path.join("lib/minga_editor/commands/*.ex")
+    |> Path.wildcard()
+    |> Enum.map(&source_with_module/1)
+  end
+
+  @spec source_with_module(String.t()) :: {String.t(), String.t()}
+  defp source_with_module(path) do
+    source = File.read!(path)
+    {module_name(source), source}
+  end
+
+  @spec module_name(String.t()) :: String.t()
+  defp module_name(source) do
+    case Regex.run(~r/defmodule\s+(?<name>[A-Za-z0-9_.]+)/, source, capture: ["name"]) do
+      [name] -> name
+      nil -> ""
+    end
+  end
+
+  @spec module_names(String.t()) :: MapSet.t(String.t())
+  defp module_names(source) do
+    ~r/MingaEditor\.Commands\.[A-Za-z0-9_.]+/
+    |> Regex.scan(source)
+    |> Enum.map(fn [name] -> name end)
+    |> MapSet.new()
+  end
+
+  @spec atom_literals(String.t()) :: MapSet.t(atom())
+  defp atom_literals(source) do
+    ~r/:(?<name>[a-zA-Z_][a-zA-Z0-9_]*)/
+    |> Regex.scan(source, capture: ["name"])
+    |> Enum.map(fn [name] -> String.to_atom(name) end)
+    |> MapSet.new()
+  end
+
+  @spec read_file(String.t(), String.t()) :: String.t()
+  defp read_file(root, path) do
+    root
+    |> Path.join(path)
+    |> File.read!()
+  end
+
+  @spec root_path(keyword()) :: String.t()
+  defp root_path(params), do: params |> Keyword.get(:root_path, File.cwd!()) |> Path.expand()
+
+  @spec parser_path(keyword()) :: String.t()
+  defp parser_path(params), do: Keyword.get(params, :parser_path, "lib/minga/command/parser.ex")
+end

--- a/lib/minga/command/parser.ex
+++ b/lib/minga/command/parser.ex
@@ -87,6 +87,9 @@ defmodule Minga.Command.Parser do
           | {:buffer_next, []}
           | {:buffer_prev, []}
           | {:lsp_info, []}
+          | {:lsp_restart, []}
+          | {:lsp_stop, []}
+          | {:lsp_start, []}
           | {:extensions, []}
           | {:extension_update, []}
           | {:extension_update_all, []}
@@ -98,13 +101,27 @@ defmodule Minga.Command.Parser do
           | {:tutor, []}
           | {:agent_abort, []}
           | {:agent_new_session, []}
+          | {:agent_clear_history, []}
           | {:agent_set_model, [String.t()]}
           | {:agent_pick_model, []}
           | {:agent_cycle_model, []}
+          | {:agent_summarize, []}
           | {:agent_cycle_thinking, []}
           | {:tool_install_named, [String.t()]}
           | {:tool_uninstall_named, [String.t()]}
           | {:tool_update_named, [String.t()]}
+          | {:tool_install, []}
+          | {:tool_uninstall, []}
+          | {:tool_update, []}
+          | {:tool_list, []}
+          | {:tool_manage, []}
+          | {:view_warnings, []}
+          | {:reload_highlights, []}
+          | {:split_vertical, []}
+          | {:split_horizontal, []}
+          | {:window_close, []}
+          | {:set_filetype, [String.t()]}
+          | {:terminal, []}
           | {:goto_line, pos_integer()}
           | {:set, atom()}
           | {:setglobal, atom()}
@@ -277,6 +294,7 @@ defmodule Minga.Command.Parser do
   defp do_parse("ToolUpdate"), do: {:tool_update, []}
   defp do_parse("ToolList"), do: {:tool_list, []}
   defp do_parse("ToolManage"), do: {:tool_manage, []}
+  defp do_parse("terminal"), do: {:terminal, []}
   defp do_parse("warnings"), do: {:view_warnings, []}
   defp do_parse("describe-command"), do: {:describe_command, []}
   defp do_parse("describe-command " <> name), do: {:describe_command_named, [String.trim(name)]}

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -60,6 +60,38 @@ defmodule MingaEditor.Commands do
           | {:replay_macro, String.t()}
           | {:whichkey_update, EditorState.WhichKey.t()}
 
+  # These ex commands stay on the direct BufferManagement path so shutdown, save, and tab behavior stay as-is.
+  @buffer_management_ex_commands [
+    :abort_quit,
+    :buffer_next,
+    :buffer_prev,
+    :buffers,
+    :checktime,
+    :force_edit,
+    :force_quit,
+    :force_quit_all,
+    :force_save,
+    :new_buffer,
+    :quit,
+    :quit_all,
+    :reload_highlights,
+    :save,
+    :save_quit,
+    :save_quit_all,
+    :split_horizontal,
+    :split_vertical,
+    :terminal,
+    :view_warnings,
+    :window_close
+  ]
+
+  @ex_tuple_dispatch_commands [
+    :agent_set_model,
+    :tool_install_named,
+    :tool_uninstall_named,
+    :tool_update_named
+  ]
+
   @doc """
   Executes a single command against the editor state.
 
@@ -534,6 +566,23 @@ defmodule MingaEditor.Commands do
 
   def execute(state, {:execute_ex_command, {:rename, new_name}}) do
     LspActions.rename(state, new_name)
+  end
+
+  def execute(state, {:execute_ex_command, {name, []} = parsed})
+      when is_atom(name) and name in @buffer_management_ex_commands do
+    BufferManagement.execute(state, {:execute_ex_command, parsed})
+  end
+
+  def execute(state, {:execute_ex_command, {name, []} = parsed}) when is_atom(name) do
+    case Command.lookup(name) do
+      {:ok, %Command{}} -> execute(state, name)
+      :error -> BufferManagement.execute(state, {:execute_ex_command, parsed})
+    end
+  end
+
+  def execute(state, {:execute_ex_command, {name, _args} = parsed})
+      when is_atom(name) and name in @ex_tuple_dispatch_commands do
+    execute(state, parsed)
   end
 
   def execute(state, {:execute_ex_command, _} = cmd), do: BufferManagement.execute(state, cmd)

--- a/test/minga/command/parser_test.exs
+++ b/test/minga/command/parser_test.exs
@@ -102,6 +102,7 @@ defmodule Minga.Command.ParserTest do
         {"agent-new", {:agent_new_session, []}},
         {"parser-restart", {:parser_restart, []}},
         {"ParserRestart", {:parser_restart, []}},
+        {"terminal", {:terminal, []}},
         {"reload-highlights", {:reload_highlights, []}},
         {"rh", {:reload_highlights, []}}
       ])

--- a/test/minga/credo/command_registration_check_test.exs
+++ b/test/minga/credo/command_registration_check_test.exs
@@ -1,0 +1,271 @@
+Code.require_file("credo/checks/command_registration_check.exs")
+
+defmodule Minga.Credo.CommandRegistrationCheckTest do
+  use Credo.Test.Case, async: true
+
+  alias Minga.Credo.CommandRegistrationCheck
+
+  @moduletag :credo
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  test "current command registration sites are in sync" do
+    "defmodule Minga.Command.Parser do end"
+    |> to_source_file("lib/minga/command/parser.ex")
+    |> run_check(CommandRegistrationCheck, [])
+    |> refute_issues()
+  end
+
+  test "flags parser atoms missing from the parsed type" do
+    root = fixture_root()
+
+    write_parser_fixture(root, """
+    defmodule Minga.Command.Parser do
+      @type parsed :: {:bar, []}
+      defp do_parse("foo"), do: {:foo, []}
+    end
+    """)
+
+    write_commands_fixture(
+      root,
+      "def execute(state, {:execute_ex_command, {:foo, []}}), do: state"
+    )
+
+    write_registry_fixture(root, [])
+
+    issues = check_fixture(root)
+
+    assert Enum.any?(issues, fn issue ->
+             issue.message =~ "missing from `@type parsed`" and issue.message =~ "foo"
+           end)
+  end
+
+  test "flags parsed type atoms the parser never returns" do
+    root = fixture_root()
+
+    write_parser_fixture(root, """
+    defmodule Minga.Command.Parser do
+      @type parsed :: {:foo, []} | {:bar, []}
+      defp do_parse("foo"), do: {:foo, []}
+    end
+    """)
+
+    write_commands_fixture(
+      root,
+      "def execute(state, {:execute_ex_command, {:foo, []}}), do: state"
+    )
+
+    write_registry_fixture(root, [])
+
+    issues = check_fixture(root)
+
+    assert Enum.any?(issues, fn issue ->
+             issue.message =~ "contains ex-command atoms that the parser never returns" and
+               issue.message =~ "bar"
+           end)
+  end
+
+  test "flags parser atoms with no direct dispatcher or registered provider command" do
+    root = fixture_root()
+
+    write_parser_fixture(root, """
+    defmodule Minga.Command.Parser do
+      @type parsed :: {:foo, []}
+      defp do_parse("foo"), do: {:foo, []}
+    end
+    """)
+
+    write_commands_fixture(root, "")
+    write_registry_fixture(root, [])
+
+    issues = check_fixture(root)
+
+    assert Enum.any?(issues, fn issue ->
+             issue.message =~ "no direct dispatcher or registered provider command" and
+               issue.message =~ "foo"
+           end)
+  end
+
+  test "flags registry modules that do not declare a provider" do
+    root = fixture_root()
+
+    write_parser_fixture(root, """
+    defmodule Minga.Command.Parser do
+      @type parsed :: {:foo, []}
+      defp do_parse("foo"), do: {:foo, []}
+    end
+    """)
+
+    write_commands_fixture(
+      root,
+      "def execute(state, {:execute_ex_command, {:foo, []}}), do: state"
+    )
+
+    write_registry_fixture(root, ["MingaEditor.Commands.Broken"])
+
+    write_fixture(root, "lib/minga_editor/commands/broken.ex", """
+    defmodule MingaEditor.Commands.Broken do
+      def execute(state, :broken), do: state
+    end
+    """)
+
+    issues = check_fixture(root)
+
+    assert Enum.any?(issues, fn issue ->
+             issue.message =~ "do not declare `Minga.Command.Provider`" and
+               issue.message =~ "MingaEditor.Commands.Broken"
+           end)
+  end
+
+  test "flags provider modules missing from the registry" do
+    root = fixture_root()
+
+    write_parser_fixture(root, """
+    defmodule Minga.Command.Parser do
+      @type parsed :: {:foo, []}
+      defp do_parse("foo"), do: {:foo, []}
+    end
+    """)
+
+    write_commands_fixture(
+      root,
+      "def execute(state, {:execute_ex_command, {:foo, []}}), do: state"
+    )
+
+    write_provider_source(root, "Foo", """
+      use MingaEditor.Commands.Provider
+      command(:foo, "Foo", requires_buffer: false)
+    """)
+
+    write_registry_fixture(root, [])
+
+    issues = check_fixture(root)
+
+    assert Enum.any?(issues, fn issue ->
+             issue.message =~ "missing from `Minga.Command.Registry @command_modules`" and
+               issue.message =~ "MingaEditor.Commands.Foo"
+           end)
+  end
+
+  test "accepts command macros, command spec lists, command structs, and ignores unrelated tuples" do
+    root = fixture_root()
+
+    write_parser_fixture(root, """
+    defmodule Minga.Command.Parser do
+      @type parsed :: {:foo, []} | {:bar, []} | {:baz, []}
+      defp do_parse("foo"), do: {:foo, []}
+      defp do_parse("bar"), do: {:bar, []}
+      defp do_parse("baz"), do: {:baz, []}
+    end
+    """)
+
+    write_commands_fixture(
+      root,
+      "def execute(state, {:execute_ex_command, {:foo, []}}), do: state"
+    )
+
+    write_provider_source(
+      root,
+      "Mixed",
+      """
+      @behaviour Minga.Command.Provider
+
+      alias Minga.Command
+
+      command(:foo, "Foo", requires_buffer: false)
+
+      @command_specs [
+        {:bar, "Bar", true}
+      ]
+
+      commands(@command_specs)
+
+      def __commands__ do
+        [
+          %Minga.Command{
+            name: :baz,
+            description: "Baz",
+            requires_buffer: false,
+            execute: fn state -> state end
+          }
+        ]
+      end
+
+      @status_messages [
+        {:error, "No active file"}
+      ]
+      """
+    )
+
+    write_registry_fixture(root, ["MingaEditor.Commands.Mixed"])
+
+    root
+    |> check_fixture()
+    |> refute_issues()
+  end
+
+  defp check_fixture(root) do
+    "defmodule Minga.Command.Parser do end"
+    |> to_source_file(Path.join(root, "lib/minga/command/parser.ex"))
+    |> run_check(CommandRegistrationCheck, root_path: root)
+  end
+
+  defp fixture_root do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "minga-command-registration-check-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+    root
+  end
+
+  defp write_parser_fixture(root, content) do
+    write_fixture(root, "lib/minga/command/parser.ex", content)
+  end
+
+  defp write_commands_fixture(root, body) do
+    write_fixture(root, "lib/minga_editor/commands.ex", """
+    defmodule MingaEditor.Commands do
+      @ex_tuple_dispatch_commands []
+      #{body}
+    end
+    """)
+
+    write_fixture(root, "lib/minga_editor/commands/buffer_management.ex", """
+    defmodule MingaEditor.Commands.BufferManagement do
+    end
+    """)
+  end
+
+  defp write_registry_fixture(root, modules) do
+    module_entries = Enum.join(modules, ",\n")
+
+    write_fixture(root, "lib/minga/command/registry.ex", """
+    defmodule Minga.Command.Registry do
+      @command_modules [
+        #{module_entries}
+      ]
+    end
+    """)
+  end
+
+  defp write_provider_source(root, name, body) do
+    write_fixture(root, "lib/minga_editor/commands/#{Macro.underscore(name)}.ex", """
+    defmodule MingaEditor.Commands.#{name} do
+    #{body}
+    end
+    """)
+  end
+
+  defp write_fixture(root, path, content) do
+    full_path = Path.join(root, path)
+    File.mkdir_p!(Path.dirname(full_path))
+    File.write!(full_path, content)
+  end
+end

--- a/test/minga_editor/commands/buffer_management_shutdown_test.exs
+++ b/test/minga_editor/commands/buffer_management_shutdown_test.exs
@@ -5,6 +5,12 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Config.Options
   alias MingaEditor
+  alias MingaEditor.Commands
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Session.State, as: SessionState
 
   setup do
     previous_shutdown_fn = Application.fetch_env(:minga, :shutdown_fn)
@@ -75,6 +81,27 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
       type_string(editor, ":cq!\r")
       assert_receive {:shutdown_called, 1}
     end
+
+    test "quit-all ex command exits when no buffer is active" do
+      {:ok, options} = Options.start_link(name: nil)
+      state = no_buffer_state(options)
+
+      Commands.execute(state, {:execute_ex_command, {:quit_all, []}})
+
+      assert_receive {:shutdown_called, 0}
+    end
+  end
+
+  defp no_buffer_state(options) do
+    %EditorState{
+      options_server: options,
+      port_manager: nil,
+      workspace: %SessionState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{active: nil, list: []},
+        editing: VimState.new()
+      }
+    }
   end
 
   defp start_editor(content) do

--- a/test/minga_editor/commands/ex_dispatch_test.exs
+++ b/test/minga_editor/commands/ex_dispatch_test.exs
@@ -1,0 +1,40 @@
+defmodule MingaEditor.Commands.ExDispatchTest do
+  # This suite touches the global command registry, so it must not run async.
+  use ExUnit.Case, async: false
+
+  alias MingaEditor.Commands
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Viewport
+
+  setup do
+    if Process.whereis(Minga.Command.Registry) == nil do
+      start_supervised!(Minga.Command.Registry)
+    end
+
+    Minga.Command.Registry.reset()
+    :ok
+  end
+
+  test "zero-arg provider-backed ex commands resolve through the registry and execute" do
+    new_state = Commands.execute(state(), {:execute_ex_command, {:indent_picker, []}})
+
+    assert ModalOverlay.tag(EditorState.modal(new_state)) == :picker
+  end
+
+  test "tuple-arg ex commands in the registry bypass list execute through tuple handling" do
+    new_state = Commands.execute(state(), {:execute_ex_command, {:agent_set_model, ["gpt-4o"]}})
+
+    assert MingaEditor.State.AgentAccess.panel(new_state).model_name == "gpt-4o"
+  end
+
+  defp state do
+    %EditorState{
+      port_manager: nil,
+      workspace: %SessionState{
+        viewport: Viewport.new(24, 80)
+      }
+    }
+  end
+end


### PR DESCRIPTION
# TL;DR
This adds a custom Credo check that catches ex-command registration drift across the parser, parsed type, command registry providers, and dispatcher. It also routes zero-argument registered ex commands through the command registry where safe, while preserving BufferManagement behavior for quit and other direct ex commands.

Closes #1564

## Context
Adding or changing an ex command currently requires several files to stay in sync. This PR adds the Phase 1 safety net from #1564 so missing parser/type/registry/dispatch updates fail during `mix credo` instead of reaching runtime or review.

## Changes
- Adds `Minga.Credo.CommandRegistrationCheck` and enables it in `.credo.exs`.
- Cross-checks parser-returned command atoms against `@type parsed`, direct `execute_ex_command` dispatch, registered provider command names, and provider modules listed in `Minga.Command.Registry`.
- Completes missing `Minga.Command.Parser.parsed/0` variants for existing parser outputs.
- Adds registry-backed fallback dispatch for zero-argument ex commands that are registered provider commands.
- Keeps BufferManagement-owned ex commands on the direct path so quit, save, buffer, split, and terminal commands keep existing behavior.
- Adds regression coverage for command registration drift and no-buffer `:quit_all` behavior.

## Verification
- `mix test.llm test/minga/command/parser_test.exs test/minga/credo/command_registration_check_test.exs`
- `mix test.llm test/minga_editor/commands/buffer_management_shutdown_test.exs test/minga/credo/command_registration_check_test.exs`
- `mix test.debug test/minga_editor/mouse_test.exs:322 test/minga_agent/session_test.exs:1286`
- `mix test --failed`
- `mix test.llm test/minga/command/parser_test.exs test/minga/credo/command_registration_check_test.exs test/minga_editor/commands/ex_dispatch_test.exs test/minga_editor/commands/buffer_management_shutdown_test.exs`
- `make lint`

## Acceptance Criteria Addressed
- Adding a new ex-command with a parser string now has automated validation across parser, type union, registry providers, and dispatch coverage. ✅
- Forgetting to register a provider or keep the parser/type/dispatch sites aligned is caught during `mix credo`. ✅
- Existing commands continue to work, including BufferManagement quit paths with no active buffer. ✅


---
**Updated after review:** Added focused coverage for generic ex-command dispatch, the remaining Credo mismatch branches, and narrowed provider extraction to avoid unrelated tuple false positives.
