### PR TITLE
Show picker mode indicator

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -286,23 +286,38 @@ Fuzzy finder / command palette state. Uses sectioned envelope: `opcode(1) + sect
 | 0x02 | Query | query string |
 | 0x03 | Items | item_count + items (positional per item) |
 | 0x04 | ActionMenu | visible flag + selected + actions |
+| 0x05 | ModePrefix | mode prefix string |
 
 ```
 When visible:
-  opcode(1) + 1(1) + selected_index(2) + filtered_count(2) + total_count(2)
-  + title_len(2) + title(title_len) + query_len(2) + query(query_len)
-  + has_preview(1) + item_count(2) + items...
+  opcode(1) + section_count(1) + sections...
+
+Each section:
+  section_id(1) + payload_len(2) + payload(payload_len)
+
+Header section 0x01 payload:
+  visible(1) + selected_index(2) + filtered_count(2) + total_count(2)
+  + has_preview(1) + title_len(2) + title(title_len)
+
+Query section 0x02 payload:
+  query_len(2) + query(query_len)
+
+Items section 0x03 payload:
+  item_count(2) + items...
 
 Per item:
   icon_color(3) + flags(1) + label_len(2) + label(label_len)
   + desc_len(2) + desc(desc_len) + annotation_len(2) + annotation(annotation_len)
   + match_pos_count(1) + match_positions(match_pos_count * 2)
 
-After all items, action menu:
+ActionMenu section 0x04 payload:
   action_visible(1)
   When action_visible == 1:
     selected_action(1) + action_count(1) + actions...
     Per action: name_len(2) + name(name_len)
+
+ModePrefix section 0x05 payload:
+  mode_prefix_len(2) + mode_prefix(mode_prefix_len)
 
 icon_color is a 24-bit RGB value for the item's icon.
 flags bits:
@@ -313,6 +328,7 @@ match_positions is a list of uint16 character indices for highlighting matched c
 has_preview indicates whether the picker source supports preview (triggers split layout).
 filtered_count and total_count enable "X/Y" display in the search field.
 action menu shows source-specific actions (e.g., "Open", "Delete", "Open in split").
+mode prefix badges show switched picker sources like command, buffer, or project search.
 
 When hidden:
   opcode(1) + 0(1)

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -625,9 +625,11 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   @spec build_gui_picker_cmd(ctx(), Caches.t()) :: {binary() | nil, Caches.t()}
   defp build_gui_picker_cmd(ctx, caches) do
     case ctx.shell_state.modal do
-      {:picker, %{picker_ui: %{picker: picker, source: source, action_menu: action_menu}}}
+      {:picker,
+       %{picker_ui: picker_ui = %{picker: picker, source: source, action_menu: action_menu}}}
       when picker != nil ->
-        do_build_gui_picker_cmd(ctx, picker, source, action_menu, caches)
+        mode_prefix = Map.get(picker_ui, :mode_prefix, "")
+        do_build_gui_picker_cmd(ctx, picker, source, action_menu, mode_prefix, caches)
 
       _ ->
         if caches.last_gui_picker_fp != :closed do
@@ -642,20 +644,22 @@ defmodule MingaEditor.Frontend.Emit.GUI do
     end
   end
 
-  @spec do_build_gui_picker_cmd(ctx(), term(), module() | nil, term(), Caches.t()) ::
+  @spec do_build_gui_picker_cmd(ctx(), term(), module() | nil, term(), String.t(), Caches.t()) ::
           {binary() | nil, Caches.t()}
-  defp do_build_gui_picker_cmd(ctx, picker, source, action_menu, caches) do
+  defp do_build_gui_picker_cmd(ctx, picker, source, action_menu, mode_prefix, caches) do
     # Preview content is NOT in the fingerprint: a file changing on disk while
     # the picker is open won't refresh the preview. Acceptable trade-off for
     # scroll perf since the picker isn't open during normal editing.
     has_preview = source != nil and Picker.Source.preview?(source)
-    fp = picker_fingerprint(picker, has_preview, action_menu, 100)
+    fp = picker_fingerprint(picker, has_preview, action_menu, mode_prefix, 100)
 
     if fp != caches.last_gui_picker_fp do
       preview_lines = if has_preview, do: build_picker_preview(ctx)
       # Picker always pairs with its preview; concatenate so they arrive as
       # adjacent frames in the batched port write.
-      picker_cmd = ProtocolGUI.encode_gui_picker(picker, has_preview, action_menu, 100)
+      picker_cmd =
+        ProtocolGUI.encode_gui_picker(picker, has_preview, action_menu, 100, mode_prefix)
+
       preview_cmd = ProtocolGUI.encode_gui_picker_preview(preview_lines)
       {IO.iodata_to_binary([picker_cmd, preview_cmd]), %{caches | last_gui_picker_fp: fp}}
     else
@@ -663,8 +667,9 @@ defmodule MingaEditor.Frontend.Emit.GUI do
     end
   end
 
-  @spec picker_fingerprint(Picker.t(), boolean(), term(), non_neg_integer()) :: integer()
-  defp picker_fingerprint(picker, has_preview, action_menu, max_items) do
+  @spec picker_fingerprint(Picker.t(), boolean(), term(), String.t(), non_neg_integer()) ::
+          integer()
+  defp picker_fingerprint(picker, has_preview, action_menu, mode_prefix, max_items) do
     limit = if max_items > 0, do: max_items, else: picker.max_visible
 
     visible_items =
@@ -678,6 +683,7 @@ defmodule MingaEditor.Frontend.Emit.GUI do
     :erlang.phash2({
       picker.title,
       picker.query,
+      mode_prefix,
       picker.selected,
       length(picker.filtered),
       length(picker.items),

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -21,7 +21,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   | 0x74   | gui_theme       | Theme color slots              |
   | 0x75   | gui_breadcrumb  | Path breadcrumb segments       |
   | 0x76   | gui_status_bar  | Status bar data                |
-  | 0x77   | gui_picker      | Fuzzy picker items             |
+  | 0x77   | gui_picker      | Fuzzy picker items + mode prefix |
   | 0x78   | gui_agent_chat  | Agent conversation view        |
   | 0x79   | gui_gutter_sep  | Gutter separator col + color   |
   | 0x7A   | gui_cursorline  | Cursorline row + bg color      |
@@ -263,6 +263,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   @section_picker_query 0x02
   @section_picker_items 0x03
   @section_picker_action_menu 0x04
+  @section_picker_mode_prefix 0x05
 
   # gui_agent_chat sections
   @section_chat_header 0x01
@@ -2203,14 +2204,35 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   @doc """
   Encodes a gui_picker command.
 
-  Wire format (v2, extended):
+  Wire format (sectioned):
   ```
-  opcode(1) + visible(1) + selected_index(2) + filtered_count(2) + total_count(2)
-  + title_len(2) + title + query_len(2) + query + has_preview(1) + item_count(2) + items...
+  opcode(1) + section_count(1) + sections...
+
+  Each section:
+    section_id(1) + payload_len(2) + payload(payload_len)
+
+  Header section 0x01 payload:
+    visible(1) + selected_index(2) + filtered_count(2) + total_count(2)
+    + has_preview(1) + title_len(2) + title(title_len)
+
+  Query section 0x02 payload:
+    query_len(2) + query(query_len)
+
+  Items section 0x03 payload:
+    item_count(2) + items...
 
   Per item:
     icon_color(3) + flags(1) + label_len(2) + label + desc_len(2) + desc
     + annotation_len(2) + annotation + match_pos_count(1) + match_positions(each 2 bytes)
+
+  ActionMenu section 0x04 payload:
+    action_visible(1)
+    When action_visible == 1:
+      selected_action(1) + action_count(1) + actions...
+      Per action: name_len(2) + name(name_len)
+
+  ModePrefix section 0x05 payload:
+    mode_prefix_len(2) + mode_prefix(mode_prefix_len)
 
   Flags bits:
     bit 0: two_line (file-style two-line layout)
@@ -2225,17 +2247,33 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
           MingaEditor.UI.Picker.t() | nil,
           boolean(),
           action_menu_state(),
-          non_neg_integer()
+          non_neg_integer(),
+          String.t()
         ) ::
           binary()
-  def encode_gui_picker(picker, has_preview \\ false, action_menu \\ nil, max_items \\ 0)
-  def encode_gui_picker(nil, _has_preview, _action_menu, _max_items), do: <<@op_gui_picker, 0::8>>
+  def encode_gui_picker(
+        picker,
+        has_preview \\ false,
+        action_menu \\ nil,
+        max_items \\ 0,
+        mode_prefix \\ ""
+      )
 
-  def encode_gui_picker(%MingaEditor.UI.Picker{} = picker, has_preview, action_menu, max_items) do
+  def encode_gui_picker(nil, _has_preview, _action_menu, _max_items, _mode_prefix),
+    do: <<@op_gui_picker, 0::8>>
+
+  def encode_gui_picker(
+        %MingaEditor.UI.Picker{} = picker,
+        has_preview,
+        action_menu,
+        max_items,
+        mode_prefix
+      ) do
     limit = if max_items > 0, do: max_items, else: picker.max_visible
     items = Enum.take(picker.filtered, limit)
     title_bytes = :erlang.iolist_to_binary([picker.title])
     query_bytes = :erlang.iolist_to_binary([picker.query])
+    mode_prefix_bytes = :erlang.iolist_to_binary([mode_prefix])
     filtered_count = length(picker.filtered)
     total_count = length(picker.items)
     has_preview_byte = if has_preview, do: 1, else: 0
@@ -2271,7 +2309,11 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
       ),
       encode_section(@section_picker_query, <<byte_size(query_bytes)::16, query_bytes::binary>>),
       encode_section(@section_picker_items, items_payload),
-      encode_section(@section_picker_action_menu, action_menu_bytes)
+      encode_section(@section_picker_action_menu, action_menu_bytes),
+      encode_section(
+        @section_picker_mode_prefix,
+        <<byte_size(mode_prefix_bytes)::16, mode_prefix_bytes::binary>>
+      )
     ]
 
     IO.iodata_to_binary([<<@op_gui_picker, length(sections)::8>> | sections])

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -478,7 +478,7 @@ defmodule MingaEditor.PickerUI do
   end
 
   def render(%RenderInput{
-        picker_state: %{picker: picker, action_menu: action_menu},
+        picker_state: %{picker: picker, action_menu: action_menu} = picker_state,
         theme_picker: pc,
         viewport: viewport
       }) do
@@ -562,21 +562,24 @@ defmodule MingaEditor.PickerUI do
     item_commands = List.flatten(item_commands)
 
     # Prompt line (replaces minibuffer)
-    prompt_text = "> " <> picker.query
+    prompt_text = prompt_prefix(picker_state) <> picker.query
 
-    prompt_cmd =
-      DisplayList.draw(
+    prompt_cmds =
+      render_prompt_line(
         prompt_row,
         0,
-        String.pad_trailing(prompt_text, viewport.cols),
-        Face.new(fg: highlight_fg, bg: prompt_bg)
+        viewport.cols,
+        prompt_text,
+        picker_state,
+        prompt_bg,
+        highlight_fg,
+        match_fg
       )
 
     cursor_col = Unicode.display_width(prompt_text)
     cursor_pos = {prompt_row, cursor_col}
 
-    # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
-    all_cmds = separator_cmd ++ item_commands ++ [prompt_cmd]
+    all_cmds = separator_cmd ++ item_commands ++ prompt_cmds
 
     # Render action menu overlay if open
     action_cmds =
@@ -611,6 +614,44 @@ defmodule MingaEditor.PickerUI do
 
     render(input)
   end
+
+  @spec prompt_prefix(PickerState.t()) :: String.t()
+  defp prompt_prefix(%PickerState{mode_prefix: prefix}) when is_binary(prefix) and prefix != "" do
+    "[#{prefix}] "
+  end
+
+  defp prompt_prefix(%PickerState{}), do: "> "
+
+  @spec render_prompt_line(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          String.t(),
+          PickerState.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [DisplayList.draw()]
+  defp render_prompt_line(row, col, width, text, picker_state, bg, fg, indicator_fg) do
+    base_draw =
+      DisplayList.draw(row, col, String.pad_trailing(text, width), Face.new(fg: fg, bg: bg))
+
+    [base_draw | render_mode_indicator(row, col, picker_state, bg, indicator_fg)]
+  end
+
+  @spec render_mode_indicator(
+          non_neg_integer(),
+          non_neg_integer(),
+          PickerState.t(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [DisplayList.draw()]
+  defp render_mode_indicator(row, col, %PickerState{mode_prefix: prefix}, bg, fg)
+       when is_binary(prefix) and prefix != "" do
+    [DisplayList.draw(row, col, "[#{prefix}]", Face.new(fg: fg, bg: bg, bold: true))]
+  end
+
+  defp render_mode_indicator(_row, _col, %PickerState{}, _bg, _fg), do: []
 
   @doc "Closes the picker and resets picker-related state."
   @spec close(state()) :: state()
@@ -665,7 +706,7 @@ defmodule MingaEditor.PickerUI do
   @spec render_centered(RenderInput.t()) ::
           {[DisplayList.draw()], {non_neg_integer(), non_neg_integer()} | nil}
   defp render_centered(%RenderInput{
-         picker_state: %{picker: picker},
+         picker_state: %{picker: picker} = picker_state,
          theme_picker: pc,
          viewport: viewport
        }) do
@@ -720,17 +761,21 @@ defmodule MingaEditor.PickerUI do
       end)
 
     # Prompt at the bottom of the interior
-    prompt_text = "> " <> picker.query
+    prompt_text = prompt_prefix(picker_state) <> picker.query
 
-    prompt_draw =
-      DisplayList.draw(
+    prompt_draws =
+      render_prompt_line(
         interior_h - 1,
         0,
-        String.pad_trailing(prompt_text, interior_w),
-        Face.new(fg: pc.highlight_fg, bg: pc.prompt_bg)
+        interior_w,
+        prompt_text,
+        picker_state,
+        pc.prompt_bg,
+        pc.highlight_fg,
+        pc.match_fg
       )
 
-    content = item_draws ++ [prompt_draw]
+    content = item_draws ++ prompt_draws
     spec = %{spec | content: content}
 
     draws = FloatingWindow.render(spec)

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -180,7 +180,7 @@ enum RenderCommand: Sendable {
     case guiWhichKey(visible: Bool, prefix: String, page: UInt8, pageCount: UInt8, bindings: [Wire.WhichKeyBinding])
     case guiBreadcrumb(segments: [String])
     case guiStatusBar(StatusBarUpdate)
-    case guiPicker(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, title: String, query: String, hasPreview: Bool, items: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?)
+    case guiPicker(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, title: String, query: String, hasPreview: Bool, items: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?, modePrefix: String)
     case guiPickerPreview(visible: Bool, lines: [Wire.PickerPreviewLine])
     case guiAgentChat(visible: Bool, status: UInt8, model: String, prompt: String, promptLineCount: UInt8, promptCursorLine: UInt16, promptCursorCol: UInt16, promptVimMode: UInt8, promptVisibleRows: UInt8, promptCompletion: Wire.PromptCompletion?, pendingToolName: String?, pendingToolSummary: String, helpVisible: Bool, helpGroups: [Wire.HelpGroup], messages: [Wire.ChatMessage])
     case guiGutterSeparator(col: UInt16, r: UInt8, g: UInt8, b: UInt8)
@@ -943,7 +943,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         guard data.count >= rest + 1 else { throw ProtocolDecodeError.malformed }
         let pickerSectionCount = Int(data[rest])
         if pickerSectionCount == 0 {
-            return (.guiPicker(visible: false, selectedIndex: 0, filteredCount: 0, totalCount: 0, title: "", query: "", hasPreview: false, items: [], actionMenu: nil), 2)
+            return (.guiPicker(visible: false, selectedIndex: 0, filteredCount: 0, totalCount: 0, title: "", query: "", hasPreview: false, items: [], actionMenu: nil, modePrefix: ""), 2)
         }
         var pickerPos = rest + 1
         var pkVisible = false
@@ -955,6 +955,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         var pkQuery = ""
         var pkItems: [Wire.PickerItem] = []
         var pkActionMenu: Wire.PickerActionMenu? = nil
+        var pkModePrefix = ""
 
         for _ in 0..<pickerSectionCount {
             guard data.count >= pickerPos + 3 else { throw ProtocolDecodeError.malformed }
@@ -983,6 +984,13 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 let qLen = Int(readU16(data, psStart))
                 if psLen >= 2 + qLen {
                     pkQuery = String(data: data[(psStart + 2)..<(psStart + 2 + qLen)], encoding: .utf8) ?? ""
+                }
+
+            case 0x05: // Mode prefix: mode_prefix_len(2) + mode_prefix
+                guard psLen >= 2 else { break }
+                let pLen = Int(readU16(data, psStart))
+                if psLen >= 2 + pLen {
+                    pkModePrefix = String(data: data[(psStart + 2)..<(psStart + 2 + pLen)], encoding: .utf8) ?? ""
                 }
 
             case 0x03: // Items: item_count(2) + items...
@@ -1039,7 +1047,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             pickerPos = psStart + psLen
         }
 
-        return (.guiPicker(visible: pkVisible, selectedIndex: pkSelectedIndex, filteredCount: pkFilteredCount, totalCount: pkTotalCount, title: pkTitle, query: pkQuery, hasPreview: pkHasPreview, items: pkItems, actionMenu: pkActionMenu), pickerPos - offset)
+        return (.guiPicker(visible: pkVisible, selectedIndex: pkSelectedIndex, filteredCount: pkFilteredCount, totalCount: pkTotalCount, title: pkTitle, query: pkQuery, hasPreview: pkHasPreview, items: pkItems, actionMenu: pkActionMenu, modePrefix: pkModePrefix), pickerPos - offset)
 
     case OP_GUI_PICKER_PREVIEW:
         guard data.count >= rest + 1 else { throw ProtocolDecodeError.malformed }

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -258,9 +258,9 @@ final class CommandDispatcher {
                 onModeChanged?(guiState.statusBarState.modeName)
             }
 
-        case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let title, let query, let hasPreview, let items, let actionMenu):
+        case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix):
             if visible {
-                guiState.pickerState.update(visible: true, selectedIndex: selectedIndex, filteredCount: filteredCount, totalCount: totalCount, title: title, query: query, hasPreview: hasPreview, rawItems: items, actionMenu: actionMenu)
+                guiState.pickerState.update(visible: true, selectedIndex: selectedIndex, filteredCount: filteredCount, totalCount: totalCount, title: title, query: query, hasPreview: hasPreview, rawItems: items, actionMenu: actionMenu, modePrefix: modePrefix)
             } else {
                 guiState.pickerState.hide()
             }

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -80,13 +80,25 @@ struct PickerOverlay: View {
                 .foregroundStyle(theme.popupFg.opacity(0.4))
 
             if state.query.isEmpty {
-                Text(state.title.isEmpty ? "Search..." : state.title)
-                    .font(.system(size: 13))
-                    .foregroundStyle(theme.popupFg.opacity(0.35))
+                HStack(spacing: 6) {
+                    if !state.modePrefix.isEmpty {
+                        modePrefixBadge
+                    }
+
+                    Text(state.title.isEmpty ? "Search..." : state.title)
+                        .font(.system(size: 13))
+                        .foregroundStyle(theme.popupFg.opacity(0.35))
+                }
             } else {
-                Text(state.query)
-                    .font(.system(size: 13, design: .monospaced))
-                    .foregroundStyle(theme.popupFg)
+                HStack(spacing: 6) {
+                    if !state.modePrefix.isEmpty {
+                        modePrefixBadge
+                    }
+
+                    Text(state.query)
+                        .font(.system(size: 13, design: .monospaced))
+                        .foregroundStyle(theme.popupFg)
+                }
             }
 
             Spacer()
@@ -99,6 +111,20 @@ struct PickerOverlay: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var modePrefixBadge: some View {
+        Text("[\(state.modePrefix)]")
+            .font(.system(size: 12, design: .monospaced))
+            .foregroundStyle(theme.accent)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(theme.accent.opacity(0.14))
+            )
+            .accessibilityLabel(Text("Picker mode \(state.modePrefix)"))
     }
 
     // MARK: - Results list

--- a/macos/Sources/Views/PickerState.swift
+++ b/macos/Sources/Views/PickerState.swift
@@ -66,18 +66,20 @@ final class PickerState {
     var totalCount: Int = 0
     var title: String = ""
     var query: String = ""
+    var modePrefix: String = ""
     var hasPreview: Bool = false
     var items: [PickerItem] = []
     var previewLines: [PreviewLine] = []
     var actionMenu: PickerActionMenu? = nil
 
-    func update(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, title: String, query: String, hasPreview: Bool, rawItems: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?) {
+    func update(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, title: String, query: String, hasPreview: Bool, rawItems: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?, modePrefix: String = "") {
         self.visible = visible
         self.selectedIndex = Int(selectedIndex)
         self.filteredCount = Int(filteredCount)
         self.totalCount = Int(totalCount)
         self.title = title
         self.query = query
+        self.modePrefix = modePrefix
         self.hasPreview = hasPreview
         self.items = rawItems.enumerated().map { i, item in
             PickerItem(
@@ -125,6 +127,7 @@ final class PickerState {
         visible = false
         items = []
         previewLines = []
+        modePrefix = ""
         hasPreview = false
         actionMenu = nil
     }

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -140,11 +140,11 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
         result["selection_size"] = Int(update.selection.size)
         return result
 
-    case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let title, let query, let hasPreview, let items, let actionMenu):
+    case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix):
         let itemArray = items.map { i -> [String: Any] in
             ["label": i.label, "description": i.description, "icon_color": Int(i.iconColor), "annotation": i.annotation, "flags": Int(i.flags), "match_positions": i.matchPositions.map { Int($0) }]
         }
-        var result: [String: Any] = ["type": "gui_picker", "visible": visible, "selected_index": Int(selectedIndex), "filtered_count": Int(filteredCount), "total_count": Int(totalCount), "title": title, "query": query, "has_preview": hasPreview, "items": itemArray]
+        var result: [String: Any] = ["type": "gui_picker", "visible": visible, "selected_index": Int(selectedIndex), "filtered_count": Int(filteredCount), "total_count": Int(totalCount), "title": title, "query": query, "mode_prefix": modePrefix, "has_preview": hasPreview, "items": itemArray]
         if let am = actionMenu {
             result["action_menu"] = ["selected_index": Int(am.selectedIndex), "actions": am.actions]
         }

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -432,11 +432,12 @@ struct CommandDispatcherRoutingTests {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.dispatch(.guiPicker(visible: true, selectedIndex: 0, filteredCount: 5,
                                         totalCount: 100, title: "Find File", query: "edi",
-                                        hasPreview: false, items: [], actionMenu: nil))
+                                        hasPreview: false, items: [], actionMenu: nil, modePrefix: ">"))
 
         #expect(gui.pickerState.visible == true)
         #expect(gui.pickerState.title == "Find File")
         #expect(gui.pickerState.query == "edi")
+        #expect(gui.pickerState.modePrefix == ">")
     }
 
     @Test("guiPicker hidden clears pickerState")
@@ -444,13 +445,14 @@ struct CommandDispatcherRoutingTests {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.dispatch(.guiPicker(visible: true, selectedIndex: 0, filteredCount: 5,
                                         totalCount: 100, title: "Find File", query: "edi",
-                                        hasPreview: false, items: [], actionMenu: nil))
+                                        hasPreview: false, items: [], actionMenu: nil, modePrefix: ">"))
         dispatcher.dispatch(.guiPicker(visible: false, selectedIndex: 0, filteredCount: 0,
                                         totalCount: 0, title: "", query: "",
-                                        hasPreview: false, items: [], actionMenu: nil))
+                                        hasPreview: false, items: [], actionMenu: nil, modePrefix: ""))
 
         #expect(gui.pickerState.visible == false)
         #expect(gui.pickerState.items.isEmpty)
+        #expect(gui.pickerState.modePrefix.isEmpty)
     }
 
     @Test("guiAgentChat visible updates agentChatState")

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -1522,18 +1522,23 @@ struct GUIPickerDecoderTests {
         appendString16(&actionMenu, "Open")
         appendString16(&actionMenu, "Split Right")
 
+        // Section 0x05: Mode prefix
+        var modePrefix = Data()
+        appendString16(&modePrefix, ">")
+
         var data = Data()
         data.append(OP_GUI_PICKER)
-        data.append(4) // section_count
+        data.append(5) // section_count
         data.append(contentsOf: buildSectionData(0x01, header))
         data.append(contentsOf: buildSectionData(0x02, query))
         data.append(contentsOf: buildSectionData(0x03, items))
         data.append(contentsOf: buildSectionData(0x04, actionMenu))
+        data.append(contentsOf: buildSectionData(0x05, modePrefix))
 
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let title, let q, let hasPreview, let decodedItems, let decodedMenu) = cmd else {
+        guard case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let title, let q, let hasPreview, let decodedItems, let decodedMenu, let modePrefix) = cmd else {
             Issue.record("Expected .guiPicker"); return
         }
 
@@ -1543,6 +1548,7 @@ struct GUIPickerDecoderTests {
         #expect(totalCount == 100)
         #expect(title == "Find File")
         #expect(q == "edi")
+        #expect(modePrefix == ">")
         #expect(hasPreview == true)
         #expect(decodedItems.count == 2)
         #expect(decodedItems[0].label == "editor.ex")
@@ -1562,10 +1568,11 @@ struct GUIPickerDecoderTests {
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == 2)
 
-        guard case .guiPicker(let visible, _, _, _, _, _, _, let items, let actionMenu) = cmd else {
+        guard case .guiPicker(let visible, _, _, _, _, _, _, let items, let actionMenu, let modePrefix) = cmd else {
             Issue.record("Expected .guiPicker"); return
         }
         #expect(visible == false)
+        #expect(modePrefix.isEmpty)
         #expect(items.isEmpty)
         #expect(actionMenu == nil)
     }
@@ -1581,6 +1588,9 @@ struct GUIPickerDecoderTests {
         var query = Data()
         appendString16(&query, "")
 
+        var modePrefix = Data()
+        appendString16(&modePrefix, "")
+
         var items = Data()
         appendU16(&items, 0)
 
@@ -1589,19 +1599,21 @@ struct GUIPickerDecoderTests {
 
         var data = Data()
         data.append(OP_GUI_PICKER)
-        data.append(4)
+        data.append(5)
         data.append(contentsOf: buildSectionData(0x01, header))
         data.append(contentsOf: buildSectionData(0x02, query))
+        data.append(contentsOf: buildSectionData(0x05, modePrefix))
         data.append(contentsOf: buildSectionData(0x03, items))
         data.append(contentsOf: buildSectionData(0x04, actionMenu))
 
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiPicker(let visible, _, _, _, _, _, _, _, let am) = cmd else {
+        guard case .guiPicker(let visible, _, _, _, _, _, _, _, let am, let modePrefix) = cmd else {
             Issue.record("Expected .guiPicker"); return
         }
         #expect(visible == true)
+        #expect(modePrefix == "")
         #expect(am == nil)
     }
 }

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -103,11 +103,13 @@ struct PickerStateLifecycleTests {
 
         state.update(visible: true, selectedIndex: 0, filteredCount: 2,
                      totalCount: 50, title: "Find File", query: "edi",
-                     hasPreview: true, rawItems: raw, actionMenu: actionMenu)
+                     hasPreview: true, rawItems: raw, actionMenu: actionMenu,
+                     modePrefix: ">")
 
         #expect(state.visible == true)
         #expect(state.title == "Find File")
         #expect(state.query == "edi")
+        #expect(state.modePrefix == ">")
         #expect(state.hasPreview == true)
         #expect(state.filteredCount == 2)
         #expect(state.totalCount == 50)
@@ -143,7 +145,8 @@ struct PickerStateLifecycleTests {
                      rawItems: [Wire.PickerItem(iconColor: 0, flags: 0, label: "x",
                                              description: "", annotation: "",
                                              matchPositions: [])],
-                     actionMenu: Wire.PickerActionMenu(selectedIndex: 0, actions: ["A"]))
+                     actionMenu: Wire.PickerActionMenu(selectedIndex: 0, actions: ["A"]),
+                     modePrefix: "#")
         state.updatePreview(lines: [[Wire.PickerPreviewSegment(fgColor: 0, bold: false, text: "x")]])
 
         state.hide()
@@ -151,6 +154,7 @@ struct PickerStateLifecycleTests {
         #expect(state.visible == false)
         #expect(state.items.isEmpty)
         #expect(state.previewLines.isEmpty)
+        #expect(state.modePrefix == "")
         #expect(state.hasPreview == false)
         #expect(state.actionMenu == nil)
     }

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -198,6 +198,17 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
       refute caches2.last_gui_picker_fp == caches.last_gui_picker_fp
     end
 
+    test "picker cache fingerprints mode prefix changes" do
+      state = gui_state()
+      state_a = open_test_picker(state, "same.txt")
+      state_b = open_test_picker(state, "same.txt", ">")
+
+      {_ctx, caches, _cmds} = sync_chrome(state_a)
+      {_ctx, caches2, _cmds} = sync_chrome(state_b, caches)
+
+      refute caches2.last_gui_picker_fp == caches.last_gui_picker_fp
+    end
+
     test "minibuffer cache changes when encoded candidate metadata changes" do
       state = gui_state()
 
@@ -365,10 +376,17 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
     {state, file_tree, file_path}
   end
 
-  defp open_test_picker(state, label) do
+  defp open_test_picker(state, label, mode_prefix \\ "") do
     item = %MingaEditor.UI.Picker.Item{id: "same-id", label: label}
     picker = MingaEditor.UI.Picker.new([item], title: "Test")
-    picker_state = %MingaEditor.State.Picker{picker: picker, source: nil, action_menu: nil}
+
+    picker_state = %MingaEditor.State.Picker{
+      picker: picker,
+      source: nil,
+      action_menu: nil,
+      mode_prefix: mode_prefix
+    }
+
     ModalOverlay.open(state, :picker, PickerPayload.new(picker_state))
   end
 

--- a/test/minga_editor/frontend/gui_picker_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_picker_protocol_test.exs
@@ -42,7 +42,7 @@ defmodule MingaEditor.Frontend.GUIPickerProtocolTest do
 
       # Sectioned: opcode(1) + section_count(1) + sections...
       assert <<0x77, section_count, _rest::binary>> = binary
-      assert section_count == 4
+      assert section_count == 5
     end
 
     test "encodes has_preview flag" do
@@ -53,10 +53,22 @@ defmodule MingaEditor.Frontend.GUIPickerProtocolTest do
       with_preview = ProtocolGUI.encode_gui_picker(picker, true)
 
       # Both should be valid sectioned format
-      assert <<0x77, 4, _::binary>> = without_preview
-      assert <<0x77, 4, _::binary>> = with_preview
+      assert <<0x77, 5, _::binary>> = without_preview
+      assert <<0x77, 5, _::binary>> = with_preview
       # They should differ (the has_preview byte in the header section)
       assert without_preview != with_preview
+    end
+
+    test "encodes mode prefix as the trailing section" do
+      items = [%Item{id: :a, label: "test.ex", description: ""}]
+      picker = Picker.new(items, title: "Test")
+
+      bare = ProtocolGUI.encode_gui_picker(picker)
+      prefixed = ProtocolGUI.encode_gui_picker(picker, false, nil, 0, ">")
+
+      assert <<0x77, 5, _::binary>> = prefixed
+      assert bare != prefixed
+      assert section_ids(prefixed) == [0x01, 0x02, 0x03, 0x04, 0x05]
     end
 
     test "encodes filtered and total counts in header" do
@@ -74,12 +86,22 @@ defmodule MingaEditor.Frontend.GUIPickerProtocolTest do
       # Sectioned: opcode(1) + section_count(1) + section_0x01 header
       # Section header: id(1) + len(2) + payload
       # Payload: visible(1) + selected(2) + filtered(2) + total(2) + has_preview(1) + title_len(2) + title
-      <<0x77, 4, 0x01, _slen::16, 1, _selected::16, filtered::16, total::16, _rest::binary>> =
+      <<0x77, 5, 0x01, _slen::16, 1, _selected::16, filtered::16, total::16, _rest::binary>> =
         binary
 
       assert filtered == 1
       assert total == 3
     end
+  end
+
+  defp section_ids(<<0x77, section_count, rest::binary>>) do
+    {ids, _rest} =
+      Enum.reduce(1..section_count, {[], rest}, fn _, {acc, bin} ->
+        <<id, len::16, _payload::binary-size(len), remaining::binary>> = bin
+        {[id | acc], remaining}
+      end)
+
+    Enum.reverse(ids)
   end
 
   describe "encode_gui_picker_preview/1" do

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -651,7 +651,7 @@ defmodule Minga.Integration.GUIProtocolTest do
         marked: MapSet.new()
       }
 
-      cmd = ProtocolGUI.encode_gui_picker(picker)
+      cmd = ProtocolGUI.encode_gui_picker(picker, false, nil, 0, ">")
       Port.command(port, cmd)
 
       assert_receive {^port, {:data, json}}, 5_000
@@ -661,6 +661,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert decoded["visible"] == true
       assert decoded["title"] == "Find File"
       assert decoded["query"] == "edi"
+      assert decoded["mode_prefix"] == ">"
       assert decoded["filtered_count"] == 1
       assert decoded["total_count"] == 1
       assert length(decoded["items"]) == 1

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -200,6 +200,35 @@ defmodule MingaEditor.PickerUITest do
              end)
     end
 
+    test "hash mode prompt renders the same styled badge" do
+      picker =
+        [%Item{id: "1", label: "main.ex"}]
+        |> Picker.new(title: "Files", max_visible: 5)
+        |> Picker.filter("main")
+
+      theme = theme_picker()
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil, mode_prefix: "#"},
+        theme_picker: theme,
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, {_cursor_row, cursor_col}} = PickerUI.render(input)
+
+      assert cursor_col == String.length("[#] main")
+
+      assert Enum.any?(draws, fn
+               {23, 0, "[#] main" <> _padding, face} -> face.fg == theme.highlight_fg
+               _ -> false
+             end)
+
+      assert Enum.any?(draws, fn
+               {23, 0, "[#]", face} -> face.fg == theme.match_fg and face.bg == theme.prompt_bg
+               _ -> false
+             end)
+    end
+
     test "draw tuples have valid 4-element structure" do
       items = [
         %Item{id: "1", label: "alpha.ex", description: "lib/"},
@@ -382,6 +411,82 @@ defmodule MingaEditor.PickerUITest do
       assert %Buffers{active: ^original_buf} = TabBar.get(tb, 1).context.buffers
       assert %Buffers{active: ^preview_buf} = TabBar.get(tb, 2).context.buffers
       assert new_state.workspace.buffers.active == preview_buf
+    end
+
+    test "backspace through a mode prefix restores the original source and prompt" do
+      {state, _original_buf, _preview_buf} = preview_promotion_state()
+
+      switched_state = PickerUI.handle_key(state, ?>, 0)
+      {:picker, %{picker_ui: switched_pui}} = switched_state.shell_state.modal
+      assert switched_pui.source == MingaEditor.UI.Picker.CommandSource
+      assert switched_pui.original_source == MingaEditor.UI.Picker.FileSource
+      assert switched_pui.mode_prefix == ">"
+
+      reverted_state = PickerUI.handle_key(switched_state, 127, 0)
+      {:picker, %{picker_ui: reverted_pui}} = reverted_state.shell_state.modal
+      assert reverted_pui.source == MingaEditor.UI.Picker.FileSource
+      assert reverted_pui.original_source == nil
+      assert reverted_pui.mode_prefix == ""
+
+      {draws, {cursor_row, cursor_col}} =
+        PickerUI.render(reverted_state, reverted_state.terminal_viewport)
+
+      assert cursor_row == reverted_state.terminal_viewport.rows - 1
+      assert cursor_col == 2
+
+      assert Enum.any?(draws, fn
+               {row, 0, text, _face} when row == reverted_state.terminal_viewport.rows - 1 ->
+                 String.starts_with?(text, "> ")
+
+               _ ->
+                 false
+             end)
+
+      refute Enum.any?(draws, fn
+               {row, 0, text, _face} when row == reverted_state.terminal_viewport.rows - 1 ->
+                 String.starts_with?(text, "[")
+
+               _ ->
+                 false
+             end)
+    end
+
+    test "hash mode switches to project search and backspaces to the original source" do
+      {state, _original_buf, _preview_buf} = preview_promotion_state()
+
+      switched_state = PickerUI.handle_key(state, ?#, 0)
+      {:picker, %{picker_ui: switched_pui}} = switched_state.shell_state.modal
+      assert switched_pui.source == MingaEditor.UI.Picker.ProjectSearchSource
+      assert switched_pui.original_source == MingaEditor.UI.Picker.FileSource
+      assert switched_pui.mode_prefix == "#"
+
+      reverted_state = PickerUI.handle_key(switched_state, 127, 0)
+      {:picker, %{picker_ui: reverted_pui}} = reverted_state.shell_state.modal
+      assert reverted_pui.source == MingaEditor.UI.Picker.FileSource
+      assert reverted_pui.original_source == nil
+      assert reverted_pui.mode_prefix == ""
+
+      {draws, {cursor_row, cursor_col}} =
+        PickerUI.render(reverted_state, reverted_state.terminal_viewport)
+
+      assert cursor_row == reverted_state.terminal_viewport.rows - 1
+      assert cursor_col == 2
+
+      assert Enum.any?(draws, fn
+               {row, 0, text, _face} when row == reverted_state.terminal_viewport.rows - 1 ->
+                 String.starts_with?(text, "> ")
+
+               _ ->
+                 false
+             end)
+
+      refute Enum.any?(draws, fn
+               {row, 0, text, _face} when row == reverted_state.terminal_viewport.rows - 1 ->
+                 String.starts_with?(text, "[")
+
+               _ ->
+                 false
+             end)
     end
   end
 

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -144,6 +144,62 @@ defmodule MingaEditor.PickerUITest do
       refute Enum.any?(texts, &String.contains?(&1, "file-1 "))
     end
 
+    test "default mode prompt keeps the plain greater-than prefix" do
+      picker =
+        [%Item{id: "1", label: "main.ex"}]
+        |> Picker.new(title: "Files", max_visible: 5)
+        |> Picker.filter("main")
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, {_cursor_row, cursor_col}} = PickerUI.render(input)
+
+      assert cursor_col == String.length("> main")
+
+      assert Enum.any?(draws, fn
+               {23, 0, "> main" <> _padding, _face} -> true
+               _ -> false
+             end)
+
+      refute Enum.any?(draws, fn
+               {23, 0, "[" <> _indicator, _face} -> true
+               _ -> false
+             end)
+    end
+
+    test "switched mode prompt renders a styled mode badge" do
+      picker =
+        [%Item{id: "1", label: "main.ex"}]
+        |> Picker.new(title: "Files", max_visible: 5)
+        |> Picker.filter("main")
+
+      theme = theme_picker()
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil, mode_prefix: ">"},
+        theme_picker: theme,
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, {_cursor_row, cursor_col}} = PickerUI.render(input)
+
+      assert cursor_col == String.length("[>] main")
+
+      assert Enum.any?(draws, fn
+               {23, 0, "[>] main" <> _padding, face} -> face.fg == theme.highlight_fg
+               _ -> false
+             end)
+
+      assert Enum.any?(draws, fn
+               {23, 0, "[>]", face} -> face.fg == theme.match_fg and face.bg == theme.prompt_bg
+               _ -> false
+             end)
+    end
+
     test "draw tuples have valid 4-element structure" do
       items = [
         %Item{id: "1", label: "alpha.ex", description: "lib/"},
@@ -479,6 +535,43 @@ defmodule MingaEditor.PickerUITest do
 
       assert Enum.any?(texts, &String.contains?(&1, "╭")), "expected rounded top-left border"
       assert Enum.any?(texts, &String.contains?(&1, "╰")), "expected rounded bottom-left border"
+    end
+
+    test "centered switched mode prompt renders a styled mode badge" do
+      picker =
+        [%Item{id: "1", label: "item"}]
+        |> Picker.new(title: "Test", max_visible: 5)
+        |> Picker.filter("item")
+
+      theme = theme_picker()
+
+      input = %RenderInput{
+        picker_state: %PickerState{
+          picker: picker,
+          source: nil,
+          layout: :centered,
+          mode_prefix: "@"
+        },
+        theme_picker: theme,
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, {_cursor_row, cursor_col}} = PickerUI.render(input)
+
+      assert cursor_col > String.length("[@] item")
+
+      assert Enum.any?(draws, fn
+               {_row, _col, "[@] item" <> _padding, face} -> face.fg == theme.highlight_fg
+               _ -> false
+             end)
+
+      assert Enum.any?(draws, fn
+               {_row, _col, "[@]", face} ->
+                 face.fg == theme.match_fg and face.bg == theme.prompt_bg
+
+               _ ->
+                 false
+             end)
     end
 
     test "title appears in the draws" do


### PR DESCRIPTION
# TL;DR
Picker mode switches now show a visible badge like `[>]`, `[@]`, or `[#]` in both the TUI/display-list picker and the native macOS GUI picker, so users can tell when the picker is in command, buffer, or project-search mode.

Closes #1721

## Context
The picker already supported prefix-based mode switching, but the prompt still looked like the default picker after a switch. This made it easy to type a query in the wrong source without noticing. The fix covers both frontend paths because macOS is the primary GUI surface.

## Changes
- Derive the rendered TUI picker prompt prefix from `PickerState.mode_prefix` in bottom and centered layouts.
- Render switched-mode TUI badges with `match_fg` on `prompt_bg` and keep the default prompt as `> ` when unswitched.
- Add `mode_prefix` to the sectioned GUI picker protocol as an append-only trailing section.
- Include `mode_prefix` in GUI picker cache fingerprints so mode-only changes invalidate chrome.
- Decode, store, reset, and render `modePrefix` in the macOS picker overlay, including empty-query badge plus title/placeholder context.
- Update GUI protocol docs and BEAM/macOS protocol tests for the new section.

## Verification
- `mix test.debug test/minga_editor/picker_ui_test.exs` passed, 22 tests.
- `mix test.debug test/minga_editor/frontend/gui_picker_protocol_test.exs` passed, 8 tests.
- `mix test.llm test/minga_editor/frontend/gui_picker_protocol_test.exs test/minga_editor/frontend/emit/gui_chrome_cache_test.exs test/minga_editor/integration/gui_protocol_test.exs test/minga_editor/picker_ui_test.exs` passed, 44 tests, 26 excluded.
- `make lint` passed.
- `git diff --check` passed.
- `mix swift.build` exited 0 but skipped Swift build because `xcodebuild` is not installed in this environment.
- Full `mix test.llm` was attempted earlier and hit unrelated mouse-test failures reproduced on clean `origin/main`; the reviewer accepted this as unrelated to this picker-only diff.

## Acceptance Criteria Addressed
- Switched picker modes show bracketed indicators before the query and cursor: `[>]`, `[@]`, `[#]` ✅
- The indicator uses a distinct badge style via `match_fg` on `prompt_bg` in TUI and native accent styling in macOS ✅
- Default unswitched mode keeps the current `> ` prompt ✅
- Deleting the prefix restores the original source and prompt, covered for command and project-search switches ✅
