### PR TITLE
Extract LSP event handling from Editor GenServer

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -33,7 +33,6 @@ defmodule MingaEditor do
 
   alias MingaEditor.Commands
   alias MingaEditor.CompletionHandling
-  alias MingaEditor.CompletionTrigger
   alias MingaEditor.FileWatcherHelpers
   alias MingaEditor.HighlightEvents
   alias MingaEditor.HighlightSync
@@ -58,6 +57,7 @@ defmodule MingaEditor do
 
   alias MingaEditor.Handlers.FileEventHandler
   alias MingaEditor.Handlers.HighlightHandler
+  alias MingaEditor.Handlers.LspEventHandler
   alias MingaEditor.Handlers.SessionHandler
   alias MingaEditor.Handlers.ToolHandler
   # WarningLog removed in #825; warnings route through MessageLog with level override
@@ -624,72 +624,32 @@ defmodule MingaEditor do
     {:noreply, apply_effects(state, effects)}
   end
 
-  # Completion debounce timer fired — send the actual completion request
-  def handle_info({:completion_debounce, clients, buffer_pid}, state) do
-    new_bridge =
-      CompletionTrigger.flush_debounce(
-        MingaEditor.State.ModalOverlay.completion_trigger(state),
-        clients,
-        buffer_pid
-      )
-
-    {:noreply, MingaEditor.State.ModalOverlay.put_completion_trigger(state, new_bridge)}
+  # LSP/completion timer events routed through a focused handler.
+  def handle_info({:completion_debounce, _clients, _buffer_pid} = msg, state) do
+    {state, effects} = LspEventHandler.handle(state, msg)
+    {:noreply, apply_effects(state, effects)}
   end
 
-  # LSP async response — route to the appropriate handler based on lsp.pending
-  def handle_info({:lsp_response, ref, result}, state) do
-    case Map.fetch(state.workspace.lsp_pending, ref) do
-      {:ok, :completion_resolve} ->
-        new_state = delete_lsp_pending(state, ref)
-        new_state = CompletionHandling.handle_resolve_response(new_state, result)
-        {:noreply, Renderer.render_or_async(new_state)}
-
-      {:ok, :signature_help} ->
-        new_state = delete_lsp_pending(state, ref)
-        new_state = CompletionHandling.handle_signature_help_response(new_state, result)
-        {:noreply, Renderer.render_or_async(new_state)}
-
-      {:ok, {:semantic_tokens, buf_pid}} ->
-        new_state = delete_lsp_pending(state, ref)
-        new_state = SemanticTokenSync.handle_response(new_state, buf_pid, result)
-        {:noreply, Renderer.render_or_async(new_state)}
-
-      {:ok, kind} when is_atom(kind) ->
-        new_state = delete_lsp_pending(state, ref)
-        new_state = dispatch_lsp_response(kind, new_state, result)
-        {:noreply, Renderer.render_or_async(new_state)}
-
-      {:ok, kind} when is_tuple(kind) ->
-        new_state = delete_lsp_pending(state, ref)
-        new_state = dispatch_lsp_response(kind, new_state, result)
-        {:noreply, Renderer.render_or_async(new_state)}
-
-      :error ->
-        # Not a tracked request — try completion handler
-        handle_lsp_completion_response(ref, result, state)
-    end
+  def handle_info({:lsp_response, _ref, _result} = msg, state) do
+    {state, effects} = LspEventHandler.handle(state, msg)
+    {:noreply, apply_effects(state, effects)}
   end
 
-  # LSP debounce timers (inlay hints and document highlight)
   @lsp_debounce_atoms [:inlay_hint_scroll_debounce, :document_highlight_debounce]
 
   def handle_info(msg, state) when msg in @lsp_debounce_atoms do
-    {:noreply, handle_lsp_debounce(state, msg)}
+    {state, effects} = LspEventHandler.handle(state, msg)
+    {:noreply, apply_effects(state, effects)}
   end
 
-  # Completion resolve debounce timer fired — send the actual resolve request
-  def handle_info({:completion_resolve, index}, state) do
-    state = CompletionHandling.flush_resolve(state, index)
-    {:noreply, state}
+  def handle_info({:completion_resolve, _index} = msg, state) do
+    {state, effects} = LspEventHandler.handle(state, msg)
+    {:noreply, apply_effects(state, effects)}
   end
 
-  # Refresh the cached LSP status for the modeline indicator.
-  # Fired after buffer open (with delay for async LSP initialization)
-  # and periodically while LSP clients are connecting.
-  def handle_info(:request_code_lens_and_inlay_hints, state) do
-    state = LspActions.code_lens(state)
-    state = LspActions.inlay_hints(state)
-    {:noreply, state}
+  def handle_info(:request_code_lens_and_inlay_hints = msg, state) do
+    {state, effects} = LspEventHandler.handle(state, msg)
+    {:noreply, apply_effects(state, effects)}
   end
 
   # ── Event bus messages ────────────────────────────────────────────────────────
@@ -1495,86 +1455,6 @@ defmodule MingaEditor do
 
   # ── LSP response dispatch ──────────────────────────────────────────────────
 
-  @spec set_lsp_pending(state(), %{reference() => atom() | tuple()}) :: state()
-  defp set_lsp_pending(state, pending) do
-    EditorState.update_workspace(state, &SessionState.set_lsp_pending(&1, pending))
-  end
-
-  @spec delete_lsp_pending(state(), reference()) :: state()
-  defp delete_lsp_pending(state, ref) do
-    set_lsp_pending(state, Map.delete(state.workspace.lsp_pending, ref))
-  end
-
-  # Dispatches an LSP response to the appropriate handler based on the kind atom.
-  @spec dispatch_lsp_response(term(), EditorState.t(), term()) :: EditorState.t()
-  defp dispatch_lsp_response(:definition, state, result),
-    do: LspActions.handle_definition_response(state, result)
-
-  defp dispatch_lsp_response(:peek_definition, state, result),
-    do: LspActions.handle_peek_definition_response(state, result)
-
-  defp dispatch_lsp_response(:hover, state, result),
-    do: LspActions.handle_hover_response(state, result)
-
-  defp dispatch_lsp_response({:hover_mouse, row, col}, state, result),
-    do: LspActions.handle_hover_mouse_response(state, result, row, col)
-
-  defp dispatch_lsp_response(:references, state, result),
-    do: LspActions.handle_references_response(state, result)
-
-  defp dispatch_lsp_response(:document_highlight, state, result),
-    do: LspActions.handle_document_highlight_response(state, result)
-
-  defp dispatch_lsp_response(:code_action, state, result),
-    do: LspActions.handle_code_action_response(state, result)
-
-  defp dispatch_lsp_response(:prepare_rename, state, result),
-    do: LspActions.handle_prepare_rename_response(state, result)
-
-  defp dispatch_lsp_response(:rename, state, result),
-    do: LspActions.handle_rename_response(state, result)
-
-  defp dispatch_lsp_response(:type_definition, state, result),
-    do: LspActions.handle_type_definition_response(state, result)
-
-  defp dispatch_lsp_response(:implementation, state, result),
-    do: LspActions.handle_implementation_response(state, result)
-
-  defp dispatch_lsp_response(:document_symbol, state, result),
-    do: LspActions.handle_document_symbol_response(state, result)
-
-  defp dispatch_lsp_response(:workspace_symbol, state, result),
-    do: LspActions.handle_workspace_symbol_response(state, result)
-
-  defp dispatch_lsp_response(:selection_range, state, result),
-    do: LspActions.handle_selection_range_response(state, result)
-
-  defp dispatch_lsp_response(:prepare_call_hierarchy, state, result),
-    do: LspActions.handle_prepare_call_hierarchy_response(state, result)
-
-  defp dispatch_lsp_response(:incoming_calls, state, result),
-    do: LspActions.handle_incoming_calls_response(state, result)
-
-  defp dispatch_lsp_response(:outgoing_calls, state, result),
-    do: LspActions.handle_outgoing_calls_response(state, result)
-
-  defp dispatch_lsp_response(:prepare_outgoing_hierarchy, state, result),
-    do: LspActions.handle_prepare_outgoing_hierarchy_response(state, result)
-
-  defp dispatch_lsp_response(:code_lens, state, result),
-    do: LspActions.handle_code_lens_response(state, result)
-
-  defp dispatch_lsp_response(:code_lens_resolve, state, result),
-    do: LspActions.handle_code_lens_resolve_response(state, result)
-
-  defp dispatch_lsp_response(:inlay_hint, state, result),
-    do: LspActions.handle_inlay_hint_response(state, result)
-
-  defp dispatch_lsp_response(kind, state, _result) do
-    Minga.Log.debug(:lsp, "Unhandled LSP response kind: #{inspect(kind)}")
-    state
-  end
-
   # ── Agent event dispatch ──────────────────────────────────────────────────
 
   @spec route_agent_event(EditorState.t(), pid(), term()) :: {:noreply, EditorState.t()}
@@ -1674,12 +1554,14 @@ defmodule MingaEditor do
   * `{:restore_session, opts}` — restore session from disk
   * `{:request_code_lens}` — request fresh code lenses from LSP
   * `{:request_inlay_hints}` — request fresh inlay hints from LSP
+  * `:render_now` — render immediately after a handler updates state
   * `{:save_session_deferred}` — send :save_session to self
   * `{:schedule_file_tree_refresh, delay}` — debounce one filesystem tree refresh
   * `{:handle_git_remote_result, ref, result}` — process git remote result
   """
   @type effect ::
           :render
+          | :render_now
           | {:render, delay_ms :: pos_integer()}
           | {:open_file, String.t()}
           | {:switch_buffer, pid()}
@@ -1731,6 +1613,8 @@ defmodule MingaEditor do
 
   @spec apply_effect(EditorState.t(), effect()) :: EditorState.t()
   defp apply_effect(state, :render), do: schedule_render(state, 16)
+
+  defp apply_effect(state, :render_now), do: Renderer.render_or_async(state)
 
   defp apply_effect(state, {:set_status, msg}) when is_binary(msg),
     do: EditorState.set_status(state, msg)
@@ -1921,24 +1805,6 @@ defmodule MingaEditor do
   # Tab bar, view state, capabilities, parser subscription helpers
 
   # Agent lifecycle helpers (session startup, auto-context, buffer sync,
-
-  @spec handle_lsp_debounce(state(), atom()) :: state()
-  defp handle_lsp_debounce(state, :inlay_hint_scroll_debounce) do
-    state = %{state | lsp: LSPState.clear_inlay_hint_timer(state.lsp)}
-    LspActions.inlay_hints(state)
-  end
-
-  defp handle_lsp_debounce(state, :document_highlight_debounce) do
-    state = %{state | lsp: LSPState.clear_highlight_timer(state.lsp)}
-    LspActions.document_highlight(state)
-  end
-
-  @spec handle_lsp_completion_response(reference(), term(), state()) :: {:noreply, state()}
-  defp handle_lsp_completion_response(ref, result, state) do
-    new_state = CompletionHandling.handle_response(state, ref, result)
-    new_state = Renderer.render_or_async(new_state)
-    {:noreply, new_state}
-  end
 
   # ── Render scheduling ────────────────────────────────────────────────────────
 

--- a/lib/minga_editor/handlers/lsp_event_handler.ex
+++ b/lib/minga_editor/handlers/lsp_event_handler.ex
@@ -1,0 +1,172 @@
+defmodule MingaEditor.Handlers.LspEventHandler do
+  @moduledoc """
+  Focused handler for Editor GenServer LSP and completion timer events.
+
+  Extracts LSP response dispatch, completion debounce flushing, completion resolve flushing, and LSP debounce timers from the Editor GenServer into `handle/2` callbacks that return `{state, effects}`.
+  """
+
+  alias MingaEditor.CompletionHandling
+  alias MingaEditor.CompletionTrigger
+  alias MingaEditor.LspActions
+  alias MingaEditor.SemanticTokenSync
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.LSP, as: LSPState
+  alias MingaEditor.State.ModalOverlay
+
+  @typedoc "Effects that the LSP event handler may return."
+  @type lsp_effect :: :render_now
+
+  @doc """
+  Dispatches an LSP or completion event to the appropriate handler.
+
+  Returns `{state, effects}` where effects encode Editor-owned side effects such as rendering.
+  """
+  @spec handle(EditorState.t(), term()) :: {EditorState.t(), [lsp_effect()]}
+
+  def handle(state, {:completion_debounce, clients, buffer_pid}) do
+    new_bridge =
+      CompletionTrigger.flush_debounce(
+        ModalOverlay.completion_trigger(state),
+        clients,
+        buffer_pid
+      )
+
+    {ModalOverlay.put_completion_trigger(state, new_bridge), []}
+  end
+
+  def handle(state, {:lsp_response, ref, result}) do
+    dispatch_tracked_response(state, ref, result, Map.fetch(state.workspace.lsp_pending, ref))
+  end
+
+  def handle(state, :inlay_hint_scroll_debounce) do
+    state = EditorState.update_lsp(state, &LSPState.clear_inlay_hint_timer/1)
+    {LspActions.inlay_hints(state), []}
+  end
+
+  def handle(state, :document_highlight_debounce) do
+    state = EditorState.update_lsp(state, &LSPState.clear_highlight_timer/1)
+    {LspActions.document_highlight(state), []}
+  end
+
+  def handle(state, {:completion_resolve, index}) do
+    {CompletionHandling.flush_resolve(state, index), []}
+  end
+
+  def handle(state, :request_code_lens_and_inlay_hints) do
+    state = LspActions.code_lens(state)
+    {LspActions.inlay_hints(state), []}
+  end
+
+  def handle(state, _msg), do: {state, []}
+
+  @spec dispatch_tracked_response(EditorState.t(), reference(), term(), {:ok, term()} | :error) ::
+          {EditorState.t(), [lsp_effect()]}
+  defp dispatch_tracked_response(state, ref, result, {:ok, :completion_resolve}) do
+    state = delete_lsp_pending(state, ref)
+    {CompletionHandling.handle_resolve_response(state, result), [:render_now]}
+  end
+
+  defp dispatch_tracked_response(state, ref, result, {:ok, :signature_help}) do
+    state = delete_lsp_pending(state, ref)
+    {CompletionHandling.handle_signature_help_response(state, result), [:render_now]}
+  end
+
+  defp dispatch_tracked_response(state, ref, result, {:ok, {:semantic_tokens, buf_pid}}) do
+    state = delete_lsp_pending(state, ref)
+    {SemanticTokenSync.handle_response(state, buf_pid, result), [:render_now]}
+  end
+
+  defp dispatch_tracked_response(state, ref, result, {:ok, kind}) when is_atom(kind) do
+    state = delete_lsp_pending(state, ref)
+    {dispatch_lsp_response(kind, state, result), [:render_now]}
+  end
+
+  defp dispatch_tracked_response(state, ref, result, {:ok, kind}) when is_tuple(kind) do
+    state = delete_lsp_pending(state, ref)
+    {dispatch_lsp_response(kind, state, result), [:render_now]}
+  end
+
+  defp dispatch_tracked_response(state, ref, result, :error) do
+    {CompletionHandling.handle_response(state, ref, result), [:render_now]}
+  end
+
+  @spec set_lsp_pending(EditorState.t(), %{reference() => atom() | tuple()}) :: EditorState.t()
+  defp set_lsp_pending(state, pending) do
+    EditorState.update_workspace(state, &SessionState.set_lsp_pending(&1, pending))
+  end
+
+  @spec delete_lsp_pending(EditorState.t(), reference()) :: EditorState.t()
+  defp delete_lsp_pending(state, ref) do
+    set_lsp_pending(state, Map.delete(state.workspace.lsp_pending, ref))
+  end
+
+  @spec dispatch_lsp_response(term(), EditorState.t(), term()) :: EditorState.t()
+  defp dispatch_lsp_response(:definition, state, result),
+    do: LspActions.handle_definition_response(state, result)
+
+  defp dispatch_lsp_response(:peek_definition, state, result),
+    do: LspActions.handle_peek_definition_response(state, result)
+
+  defp dispatch_lsp_response(:hover, state, result),
+    do: LspActions.handle_hover_response(state, result)
+
+  defp dispatch_lsp_response({:hover_mouse, row, col}, state, result),
+    do: LspActions.handle_hover_mouse_response(state, result, row, col)
+
+  defp dispatch_lsp_response(:references, state, result),
+    do: LspActions.handle_references_response(state, result)
+
+  defp dispatch_lsp_response(:document_highlight, state, result),
+    do: LspActions.handle_document_highlight_response(state, result)
+
+  defp dispatch_lsp_response(:code_action, state, result),
+    do: LspActions.handle_code_action_response(state, result)
+
+  defp dispatch_lsp_response(:prepare_rename, state, result),
+    do: LspActions.handle_prepare_rename_response(state, result)
+
+  defp dispatch_lsp_response(:rename, state, result),
+    do: LspActions.handle_rename_response(state, result)
+
+  defp dispatch_lsp_response(:type_definition, state, result),
+    do: LspActions.handle_type_definition_response(state, result)
+
+  defp dispatch_lsp_response(:implementation, state, result),
+    do: LspActions.handle_implementation_response(state, result)
+
+  defp dispatch_lsp_response(:document_symbol, state, result),
+    do: LspActions.handle_document_symbol_response(state, result)
+
+  defp dispatch_lsp_response(:workspace_symbol, state, result),
+    do: LspActions.handle_workspace_symbol_response(state, result)
+
+  defp dispatch_lsp_response(:selection_range, state, result),
+    do: LspActions.handle_selection_range_response(state, result)
+
+  defp dispatch_lsp_response(:prepare_call_hierarchy, state, result),
+    do: LspActions.handle_prepare_call_hierarchy_response(state, result)
+
+  defp dispatch_lsp_response(:incoming_calls, state, result),
+    do: LspActions.handle_incoming_calls_response(state, result)
+
+  defp dispatch_lsp_response(:outgoing_calls, state, result),
+    do: LspActions.handle_outgoing_calls_response(state, result)
+
+  defp dispatch_lsp_response(:prepare_outgoing_hierarchy, state, result),
+    do: LspActions.handle_prepare_outgoing_hierarchy_response(state, result)
+
+  defp dispatch_lsp_response(:code_lens, state, result),
+    do: LspActions.handle_code_lens_response(state, result)
+
+  defp dispatch_lsp_response(:code_lens_resolve, state, result),
+    do: LspActions.handle_code_lens_resolve_response(state, result)
+
+  defp dispatch_lsp_response(:inlay_hint, state, result),
+    do: LspActions.handle_inlay_hint_response(state, result)
+
+  defp dispatch_lsp_response(kind, state, _result) do
+    Minga.Log.debug(:lsp, "Unhandled LSP response kind: #{inspect(kind)}")
+    state
+  end
+end

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -1,0 +1,294 @@
+defmodule MingaEditor.Handlers.LspEventHandlerTest do
+  @moduledoc """
+  Handler tests for `MingaEditor.Handlers.LspEventHandler`.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Editing.Completion
+  alias MingaEditor.CompletionTrigger
+  alias MingaEditor.Handlers.LspEventHandler
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.SignatureHelp
+  alias MingaEditor.State.Highlighting
+  alias MingaEditor.State.LSP, as: LSPState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
+  alias MingaEditor.State.Windows
+  alias MingaEditor.VimState
+  alias MingaEditor.Viewport
+  alias MingaEditor.UI.Highlight
+  alias MingaEditor.Window
+  alias MingaEditor.WindowTree
+
+  describe "handle/2" do
+    test "tracked atom response deletes pending ref and returns render_now" do
+      state = base_state()
+      ref = make_ref()
+      state = put_lsp_pending(state, ref, :definition)
+
+      {new_state, effects} = LspEventHandler.handle(state, {:lsp_response, ref, {:ok, nil}})
+
+      assert new_state.workspace.lsp_pending == %{}
+      assert effects == [:render_now]
+    end
+
+    test "tuple-keyed hover_mouse response returns render_now without crashing" do
+      state = base_state()
+      ref = make_ref()
+      state = put_lsp_pending(state, ref, {:hover_mouse, 12, 34})
+
+      {new_state, effects} = LspEventHandler.handle(state, {:lsp_response, ref, {:ok, nil}})
+
+      assert new_state.workspace.lsp_pending == %{}
+      assert effects == [:render_now]
+    end
+
+    test "inlay debounce clears the timer ref" do
+      state = base_state()
+      timer = make_ref()
+      state = EditorState.update_lsp(state, &LSPState.set_inlay_hint_timer(&1, timer, 9))
+
+      {new_state, effects} = LspEventHandler.handle(state, :inlay_hint_scroll_debounce)
+
+      assert new_state.lsp.inlay_hint_debounce_timer == nil
+      assert effects == []
+    end
+
+    test "document highlight debounce clears the timer ref" do
+      state = base_state()
+      timer = make_ref()
+      state = EditorState.update_lsp(state, &LSPState.set_highlight_timer(&1, timer))
+
+      {new_state, effects} = LspEventHandler.handle(state, :document_highlight_debounce)
+
+      assert new_state.lsp.highlight_debounce_timer == nil
+      assert effects == []
+    end
+
+    test "completion debounce writes the flushed completion trigger back and sends a request" do
+      state = file_buffer_state("foo_bar\n")
+      client = start_fake_lsp_client()
+      timer = make_ref()
+      trigger = %{CompletionTrigger.new() | debounce_timer: timer}
+      payload = CompletionPayload.new(:tab1, trigger: trigger)
+      state = EditorState.set_modal(state, {:completion, payload})
+      buffer = state.workspace.buffers.active
+
+      {new_state, effects} =
+        LspEventHandler.handle(state, {:completion_debounce, [client], buffer})
+
+      assert effects == []
+      assert_receive {:lsp_request, "textDocument/completion", _params, caller, ref}
+      assert caller == self()
+
+      new_trigger = ModalOverlay.completion_trigger(new_state)
+      assert new_trigger.pending_ref == ref
+      assert MapSet.member?(new_trigger.pending_refs, ref)
+      assert new_trigger.debounce_timer == timer
+    end
+
+    test "completion resolve routes the request and records the pending ref" do
+      state = buffer_state("hello\n")
+      client = start_fake_lsp_client()
+      buffer = state.workspace.buffers.active
+      register_lsp_client(buffer, client)
+
+      item = %{
+        "label" => "resolve-me",
+        "kind" => 3,
+        "documentation" => "",
+        "sortText" => "resolve-me"
+      }
+
+      completion = Completion.new(Completion.parse_response(%{"items" => [item]}), {0, 0})
+      trigger = %{CompletionTrigger.new() | pending_ref: make_ref(), pending_refs: MapSet.new()}
+      payload = CompletionPayload.new(:tab1, completion: completion, trigger: trigger)
+      state = EditorState.set_modal(state, {:completion, payload})
+
+      {new_state, effects} = LspEventHandler.handle(state, {:completion_resolve, 0})
+
+      assert effects == []
+
+      assert_receive {:lsp_request, "completionItem/resolve", %{"label" => "resolve-me"}, caller,
+                      ref}
+
+      assert caller == self()
+
+      assert new_state.workspace.lsp_pending == %{ref => :completion_resolve}
+    end
+
+    test "tracked signature help response updates state and returns render_now" do
+      state = base_state()
+      ref = make_ref()
+      state = put_lsp_pending(state, ref, :signature_help)
+
+      response = %{
+        "signatures" => [
+          %{"label" => "foo(arg)", "parameters" => [%{"label" => "arg"}]}
+        ],
+        "activeSignature" => 0,
+        "activeParameter" => 0
+      }
+
+      {new_state, effects} = LspEventHandler.handle(state, {:lsp_response, ref, {:ok, response}})
+
+      assert new_state.workspace.lsp_pending == %{}
+      assert effects == [:render_now]
+
+      assert %SignatureHelp{signatures: [%{label: "foo(arg)"}]} =
+               new_state.shell_state.signature_help
+    end
+
+    test "tracked semantic token response updates highlights and returns render_now" do
+      state = file_buffer_state("hello\n")
+      buffer = state.workspace.buffers.active
+      client = start_fake_lsp_client()
+
+      state =
+        state
+        |> Map.put(:lsp_clients, %{Minga.Buffer.filetype(buffer) => client})
+        |> EditorState.update_workspace(fn workspace ->
+          SessionState.update_highlight(workspace, fn highlighting ->
+            Highlighting.put_highlight(highlighting, buffer, Highlight.new())
+          end)
+        end)
+
+      ref = make_ref()
+      state = put_lsp_pending(state, ref, {:semantic_tokens, buffer})
+
+      {new_state, effects} =
+        LspEventHandler.handle(state, {:lsp_response, ref, {:ok, %{"data" => [0, 0, 5, 0, 0]}}})
+
+      assert new_state.workspace.lsp_pending == %{}
+      assert effects == [:render_now]
+
+      highlight = Map.fetch!(new_state.workspace.highlight.highlights, buffer)
+      assert Tuple.to_list(highlight.capture_names) == ["@lsp.type.variable"]
+      assert [%{layer: 2}] = Tuple.to_list(highlight.spans)
+    end
+
+    test "untracked completion response updates the visible completion and returns render_now" do
+      state = buffer_state("hello\n")
+      ref = make_ref()
+      trigger = %{CompletionTrigger.new() | pending_ref: ref, pending_refs: MapSet.new([ref])}
+      payload = CompletionPayload.new(:tab1, trigger: trigger)
+      state = EditorState.set_modal(state, {:completion, payload})
+
+      completion_result = %{
+        "items" => [
+          %{
+            "label" => "hello_world",
+            "kind" => 3,
+            "documentation" => "docs",
+            "sortText" => "hello_world"
+          }
+        ]
+      }
+
+      {new_state, effects} =
+        LspEventHandler.handle(state, {:lsp_response, ref, {:ok, completion_result}})
+
+      assert effects == [:render_now]
+
+      completion = ModalOverlay.completion(new_state)
+      assert %Completion{} = completion
+      assert [%{label: "hello_world"}] = completion.filtered
+      assert completion.selected == 0
+
+      new_trigger = ModalOverlay.completion_trigger(new_state)
+      assert new_trigger.pending_ref == nil
+      assert MapSet.new() == new_trigger.pending_refs
+    end
+  end
+
+  defp put_lsp_pending(state, ref, kind) do
+    EditorState.update_workspace(state, &SessionState.set_lsp_pending(&1, %{ref => kind}))
+  end
+
+  defp base_state do
+    buffer_state("line one\nline two\nline three")
+  end
+
+  defp buffer_state(content) do
+    buffer = start_supervised!({BufferProcess, content: content}, id: {:buffer, make_ref()})
+    workspace = workspace_for(buffer)
+
+    %EditorState{port_manager: self(), workspace: workspace}
+  end
+
+  defp register_lsp_client(buffer, client) do
+    :ets.insert(Minga.LSP.SyncServer.Registry, {buffer, [client]})
+
+    on_exit(fn ->
+      if :ets.whereis(Minga.LSP.SyncServer.Registry) != :undefined do
+        :ets.delete(Minga.LSP.SyncServer.Registry, buffer)
+      end
+    end)
+  end
+
+  defp file_buffer_state(content) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "lsp-event-handler-#{System.unique_integer([:positive])}.ex"
+      )
+
+    File.write!(path, content)
+    on_exit(fn -> File.rm(path) end)
+
+    buffer =
+      start_supervised!(
+        {BufferProcess, file_path: path, content: content},
+        id: {:buffer, make_ref()}
+      )
+
+    workspace = workspace_for(buffer)
+    %EditorState{port_manager: self(), workspace: workspace}
+  end
+
+  defp workspace_for(buffer) do
+    %MingaEditor.Session.State{
+      viewport: Viewport.new(24, 80),
+      editing: VimState.new(),
+      buffers: %Buffers{active: buffer, list: [buffer], active_index: 0, messages: buffer},
+      windows: %Windows{
+        tree: WindowTree.new(1),
+        map: %{1 => Window.new(1, buffer, 24, 80)},
+        active: 1,
+        next_id: 2
+      }
+    }
+  end
+
+  defp start_fake_lsp_client do
+    parent = self()
+
+    start_supervised!(
+      {Task, fn -> fake_lsp_client_loop(parent) end},
+      id: {:fake_lsp_client, make_ref()}
+    )
+  end
+
+  defp fake_lsp_client_loop(parent) do
+    receive do
+      {:"$gen_call", from, :semantic_token_legend} ->
+        GenServer.reply(from, {["variable"], []})
+        fake_lsp_client_loop(parent)
+
+      {:"$gen_call", from, :encoding} ->
+        GenServer.reply(from, :utf16)
+        fake_lsp_client_loop(parent)
+
+      {:"$gen_cast", {:async_request, method, params, caller, ref}} ->
+        send(parent, {:lsp_request, method, params, caller, ref})
+        fake_lsp_client_loop(parent)
+
+      _other ->
+        fake_lsp_client_loop(parent)
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
This extracts the LSP and completion timer `handle_info` logic out of the Editor GenServer into a focused handler module. It is a small behavior-preserving slice of the larger mega-module carve tracked in #1433.

Part of #1433

## Context
#1433 tracks carving several large modules into focused submodules. This PR takes one AC1 slice by moving LSP/completion event business logic out of `lib/minga_editor.ex` and into `lib/minga_editor/handlers/`, following the existing handler extraction pattern.

This does not close #1433. The Editor GenServer still needs more handler extraction before AC1 is complete.

## Changes
- Added `MingaEditor.Handlers.LspEventHandler` for completion debounce, LSP response dispatch, LSP debounce timers, completion resolve, and code lens/inlay hint refresh events.
- Kept `MingaEditor` as the side-effect interpreter by returning an explicit `:render_now` effect for LSP response paths that render immediately after state updates.
- Preserved state ownership by using `EditorState.update_lsp/2` and `EditorState.update_workspace/2` instead of direct cross-module production struct mutation.
- Added focused handler tests for tracked LSP responses, signature help, semantic tokens, completion debounce, completion resolve, and completion-response fallback routing.
- Removed the extracted private LSP response helpers from `lib/minga_editor.ex`.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.llm test/minga_editor/handlers/lsp_event_handler_test.exs test/minga_editor/completion_trigger_test.exs test/minga_editor/integration/lsp_wiring_test.exs test/minga_editor/lsp_actions_test.exs test/minga_editor/lsp_actions` (59 tests, 0 failures)
- `make lint`
- `git diff --check`
- Full-suite note: `mix test.llm` passed earlier in the branch before the test-only additions. After the added tests, one unrelated distribution test hit `erl_child_setup` EPIPE during the full concurrent run; the exact failing test and full `test/minga/distribution/connection_manager_test.exs` file both passed on focused rerun.

## Acceptance Criteria Addressed
- AC1 partial ✅: extracted one more Editor GenServer event cluster into `lib/minga_editor/handlers/`.
- Remaining #1433 ACs are unchanged: more Editor handlers, EditorState consolidation, LSP Actions split, Mouse split, and file-size cleanup still need follow-up PRs.
