### PR TITLE
Center project switcher picker

### DIFF
--- a/lib/minga_editor/renderer/server.ex
+++ b/lib/minga_editor/renderer/server.ex
@@ -51,6 +51,9 @@ defmodule MingaEditor.Renderer.Server do
   @typedoc "Render pipeline output after a frame has run."
   @type render_output :: Input.t()
 
+  @typedoc "Injected render pipeline function."
+  @type pipeline :: (Input.t() -> render_output())
+
   @typedoc "Click-region writeback payload sent to the Editor after each frame."
   @type writeback :: %{
           required(:caches) => MingaEditor.Renderer.Caches.t(),
@@ -70,14 +73,16 @@ defmodule MingaEditor.Renderer.Server do
           rendering?: boolean(),
           pending: {Input.t(), non_neg_integer(), integer()} | nil,
           in_flight: {Input.t(), non_neg_integer(), integer()} | nil,
-          font_registry: FontRegistry.t()
+          font_registry: FontRegistry.t(),
+          pipeline: pipeline()
         }
 
   defstruct editor_pid: nil,
             rendering?: false,
             pending: nil,
             in_flight: nil,
-            font_registry: FontRegistry.new()
+            font_registry: FontRegistry.new(),
+            pipeline: &RenderPipeline.run/1
 
   # ── API ────────────────────────────────────────────────────────────────────
 
@@ -108,7 +113,8 @@ defmodule MingaEditor.Renderer.Server do
   @spec init(keyword()) :: {:ok, t()}
   def init(opts) do
     editor_pid = Keyword.get(opts, :editor_pid, MingaEditor)
-    {:ok, %__MODULE__{editor_pid: editor_pid}}
+    pipeline = Keyword.get(opts, :pipeline, &RenderPipeline.run/1)
+    {:ok, %__MODULE__{editor_pid: editor_pid, pipeline: pipeline}}
   end
 
   @impl true
@@ -138,7 +144,7 @@ defmodule MingaEditor.Renderer.Server do
       Telemetry.span(
         [:minga, :render, :pipeline],
         %{frame_seq: seq},
-        fn -> snap |> Input.with_font_registry(state.font_registry) |> RenderPipeline.run() end
+        fn -> snap |> Input.with_font_registry(state.font_registry) |> state.pipeline.() end
       )
 
     emit_complete_at = monotonic_now()

--- a/lib/minga_editor/ui/picker/project_source.ex
+++ b/lib/minga_editor/ui/picker/project_source.ex
@@ -18,6 +18,10 @@ defmodule MingaEditor.UI.Picker.ProjectSource do
   def title, do: "Switch project"
 
   @impl true
+  @spec layout() :: MingaEditor.UI.Picker.Source.layout()
+  def layout, do: :centered
+
+  @impl true
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(_ctx) do
     Project.known_projects()

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -33,7 +33,7 @@ defmodule MingaEditor.Renderer.ServerTest do
   end
 
   test "pipeline crashes drop frames without killing the server" do
-    renderer = start_renderer(self())
+    renderer = start_renderer(self(), pipeline: fn _input -> raise "boom" end)
 
     RendererServer.cast_snapshot(renderer, stub_snapshot(), 42)
 
@@ -42,23 +42,25 @@ defmodule MingaEditor.Renderer.ServerTest do
   end
 
   test "successful async render sends writeback and emits a frame" do
-    renderer = start_renderer(self())
+    renderer = start_renderer(self(), pipeline: &emit_batch_end/1)
     state = build_editor_state(:tui, nil)
     snapshot = Input.from_editor_state(state)
     frame_ref = Minga.Test.HeadlessPort.prepare_await(state.port_manager)
 
     RendererServer.cast_snapshot(renderer, snapshot, 123)
 
+    assert {:ok, _screen} =
+             Minga.Test.HeadlessPort.collect_frame(frame_ref, @async_render_timeout)
+
     assert_receive {:render_done, %{frame_seq: 123, caches: %MingaEditor.Renderer.Caches{}}},
                    @async_render_timeout
 
-    assert {:ok, _screen} = Minga.Test.HeadlessPort.collect_frame(frame_ref)
     refute renderer_busy?(renderer)
   end
 
   describe "render_or_async dispatch" do
     test "non-headless backend with renderer dispatches asynchronously" do
-      renderer = start_renderer(self())
+      renderer = start_renderer(self(), pipeline: & &1)
       state = build_editor_state(:tui, renderer)
 
       result = MingaEditor.Renderer.render_or_async(state)
@@ -95,8 +97,17 @@ defmodule MingaEditor.Renderer.ServerTest do
     end
   end
 
-  defp start_renderer(editor_pid) do
-    start_supervised!({RendererServer, name: nil, editor_pid: editor_pid})
+  defp start_renderer(editor_pid, opts \\ []) do
+    opts = Keyword.merge([name: nil, editor_pid: editor_pid], opts)
+    start_supervised!({RendererServer, opts})
+  end
+
+  defp emit_batch_end(input) do
+    MingaEditor.Frontend.send_commands(input.port_manager, [
+      MingaEditor.Frontend.Protocol.encode_batch_end()
+    ])
+
+    input
   end
 
   defp attach_coalesce_handler do

--- a/test/minga_editor/ui/picker/source_test.exs
+++ b/test/minga_editor/ui/picker/source_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.UI.Picker.SourceTest do
 
   use ExUnit.Case, async: true
 
+  alias MingaEditor.UI.Picker.ProjectSource
   alias MingaEditor.UI.Picker.Source
 
   defmodule NoActionsSource do
@@ -69,6 +70,12 @@ defmodule MingaEditor.UI.Picker.SourceTest do
   describe "preview?/1" do
     test "returns false for source without preview? callback" do
       refute Source.preview?(NoActionsSource)
+    end
+  end
+
+  describe "layout/1" do
+    test "returns centered layout for project switcher" do
+      assert Source.layout(ProjectSource) == :centered
     end
   end
 end


### PR DESCRIPTION
# TL;DR
Project switching now opens in the centered picker layout, so it presents as a focused workspace decision instead of a bottom navigation picker.

Closes #1723

## Context
The project switcher is different from file and buffer navigation because there is no in-project preview to show. This PR opts the project source into the existing centered picker path while preserving project selection and cancel behavior.

## Changes
- Added `ProjectSource.layout/0` returning `:centered`.
- Added a regression assertion that `Source.layout(ProjectSource)` resolves to `:centered`.
- Stabilized renderer server unit tests by injecting the render pipeline in tests, keeping the module `async: true` while avoiding full render-pipeline work in server orchestration tests.

## Verification
- `mix test.debug test/minga_editor/renderer/server_test.exs`: PASS, 6 tests, 0 failures
- `mix test.debug test/minga_editor/ui/picker/source_test.exs`: PASS, 6 tests, 0 failures
- `mix compile --warnings-as-errors`: PASS
- `make lint`: PASS, existing struct-size warnings only
- `mix test.llm`: PASS, 52 doctests, 99 properties, 8103 tests, 0 failures, 5 skipped, 198 excluded
- `git diff --check`: PASS

Manual visual verification was not performed in this headless environment.

## Acceptance Criteria Addressed
- `ProjectSource` uses `:centered` layout instead of `:bottom` ✅
- The centered picker auto-sizes to known projects through the existing centered picker behavior from #1722 ✅
- Project name remains prominent, full path remains the description on the same line ✅
- Selecting a project still switches root and opens the file finder ✅
- Canceling returns to the previous state without side effects ✅
