### PR TITLE
feat(macos): add sidebar activity bar

### DIFF
--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -258,8 +258,11 @@ struct ContentView: View {
     @State private var rightPaneHeight: CGFloat = 600
     @State private var sidebarWidth: CGFloat = 240
     @State private var changeSummaryWidth: CGFloat = 280
+    @State private var activeSidebarPanel: ActivityBarPanel = .fileTree
 
-    private var showSidebar: Bool {
+    private let activityBarWidth: CGFloat = 32
+
+    private var showSidebarContent: Bool {
         appState.gui.fileTreeState.visible || appState.gui.gitStatusState.visible
     }
 
@@ -301,6 +304,13 @@ struct ContentView: View {
         .preferredColorScheme(appState.windowBgIsDark ? .dark : .light)
         .onAppear {
             sidebarWidth = CGFloat(appState.gui.fileTreeState.treeWidth) * 7.5
+            syncActiveSidebarPanel()
+        }
+        .onChange(of: appState.gui.fileTreeState.visible) { _, _ in
+            syncActiveSidebarPanel()
+        }
+        .onChange(of: appState.gui.gitStatusState.visible) { _, _ in
+            syncActiveSidebarPanel()
         }
     }
 
@@ -323,9 +333,14 @@ struct ContentView: View {
     private var unifiedToolbar: some View {
         ZStack(alignment: .bottom) {
             HStack(spacing: 0) {
-                if showSidebar {
-                    sidebarHeaderContent
-                        .frame(width: sidebarWidth + 8) // +8 aligns with resize handle
+                if showSidebarContent {
+                    HStack(spacing: 0) {
+                        Color.clear
+                            .frame(width: activityBarWidth)
+
+                        sidebarHeaderContent
+                            .frame(width: sidebarWidth + 8) // +8 aligns with resize handle
+                    }
 
                     // Thin vertical separator between sidebar header and tab bar
                     Rectangle()
@@ -427,14 +442,31 @@ struct ContentView: View {
 
     @ViewBuilder
     private var sidebarBody: some View {
-        if showSidebar {
-            SidebarContainer(
-                fileTreeState: appState.gui.fileTreeState,
-                gitStatusState: appState.gui.gitStatusState,
+        HStack(spacing: 0) {
+            ActivityBar(
+                activePanel: activeSidebarPanel,
+                gitStatusCount: appState.gui.gitStatusState.totalCount,
                 theme: theme,
-                encoder: appState.encoder,
-                sidebarWidth: $sidebarWidth
+                encoder: appState.encoder
             )
+
+            if showSidebarContent {
+                SidebarContainer(
+                    fileTreeState: appState.gui.fileTreeState,
+                    gitStatusState: appState.gui.gitStatusState,
+                    theme: theme,
+                    encoder: appState.encoder,
+                    sidebarWidth: $sidebarWidth
+                )
+            }
+        }
+    }
+
+    private func syncActiveSidebarPanel() {
+        if appState.gui.gitStatusState.visible {
+            activeSidebarPanel = .gitStatus
+        } else if appState.gui.fileTreeState.visible {
+            activeSidebarPanel = .fileTree
         }
     }
 

--- a/macos/Sources/Views/ActivityBar.swift
+++ b/macos/Sources/Views/ActivityBar.swift
@@ -1,0 +1,144 @@
+/// Vertical activity bar for switching sidebar panels in the macOS GUI.
+///
+/// The activity bar is intentionally separate from `SidebarContainer`: it stays visible when the sidebar content is collapsed so users can reopen the last panel with a click.
+
+import SwiftUI
+
+/// Sidebar panels exposed by the activity bar.
+enum ActivityBarPanel: CaseIterable, Hashable {
+    case fileTree
+    case gitStatus
+
+    var protocolPanel: UInt8 {
+        switch self {
+        case .fileTree: 0
+        case .gitStatus: 2
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .fileTree: "folder"
+        case .gitStatus: "point.3.filled.connected.trianglepath.dotted"
+        }
+    }
+
+    var tooltip: String {
+        switch self {
+        case .fileTree: "File tree (SPC o p)"
+        case .gitStatus: "Git status (SPC g g)"
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .fileTree: "File tree"
+        case .gitStatus: "Git status"
+        }
+    }
+}
+
+/// Thin VS Code-style icon strip for sidebar panel discovery and switching.
+struct ActivityBar: View {
+    let activePanel: ActivityBarPanel
+    let gitStatusCount: Int
+    let theme: ThemeColors
+    let encoder: InputEncoder?
+
+    private let width: CGFloat = 32
+    private let buttonSize: CGFloat = 28
+
+    var body: some View {
+        VStack(spacing: 4) {
+            ForEach(ActivityBarPanel.allCases, id: \.self) { panel in
+                activityButton(for: panel)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.top, 6)
+        .frame(width: width)
+        .frame(maxHeight: .infinity)
+        .background(theme.treeHeaderBg)
+        .overlay(alignment: .trailing) {
+            Rectangle()
+                .fill(theme.treeSeparatorFg.opacity(0.45))
+                .frame(width: 1)
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private func activityButton(for panel: ActivityBarPanel) -> some View {
+        let isActive = panel == activePanel
+        let button = activityButtonBase(for: panel, isActive: isActive)
+        let spokenValue = accessibilityValue(for: panel)
+
+        if let spokenValue {
+            if isActive {
+                button
+                    .accessibilityValue(spokenValue)
+                    .accessibilityAddTraits(.isSelected)
+            } else {
+                button.accessibilityValue(spokenValue)
+            }
+        } else if isActive {
+            button.accessibilityAddTraits(.isSelected)
+        } else {
+            button
+        }
+    }
+
+    private func activityButtonBase(for panel: ActivityBarPanel, isActive: Bool) -> some View {
+        Button {
+            encoder?.sendTogglePanel(panel: panel.protocolPanel)
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: panel.systemImageName)
+                    .font(.system(size: 15, weight: isActive ? .semibold : .regular))
+                    .foregroundStyle(isActive ? theme.accent : theme.treeFg.opacity(0.45))
+                    .frame(width: buttonSize, height: buttonSize)
+
+                if let badgeText = badgeText(for: panel) {
+                    Text(badgeText)
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(theme.modeNormalFg)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                        .padding(.horizontal, 4)
+                        .frame(minWidth: 14, minHeight: 14)
+                        .background(Capsule().fill(theme.accent))
+                        .offset(x: 3, y: -2)
+                }
+            }
+            .frame(width: buttonSize, height: buttonSize)
+            .background {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isActive ? theme.accent.opacity(0.14) : Color.clear)
+            }
+            .overlay(alignment: .leading) {
+                if isActive {
+                    Capsule()
+                        .fill(theme.accent)
+                        .frame(width: 3, height: 18)
+                        .offset(x: -2)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(panel.tooltip)
+        .accessibilityLabel(panel.accessibilityLabel)
+    }
+
+    private func badgeText(for panel: ActivityBarPanel) -> String? {
+        guard panel == .gitStatus, gitStatusCount > 0 else { return nil }
+        return gitStatusCount > 99 ? "99+" : String(gitStatusCount)
+    }
+
+    private func accessibilityValue(for panel: ActivityBarPanel) -> String? {
+        guard panel == .gitStatus, gitStatusCount > 0 else { return nil }
+        let countText = gitStatusCount > 99 ? "99+" : String(gitStatusCount)
+        return gitStatusCount == 1 ? "1 changed file" : "\(countText) changed files"
+    }
+}

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -1,5 +1,5 @@
-/// View structure tests for sidebar components (FileTreeView, GitStatusView,
-/// SidebarContainer, SidebarHeaderButton).
+/// View structure tests for sidebar components (ActivityBar, FileTreeView,
+/// GitStatusView, SidebarContainer, SidebarHeaderButton).
 ///
 /// Verifies that structural refactors (header backgrounds, button extraction,
 /// shared resize handle) didn't break text rendering or button counts.
@@ -8,6 +8,47 @@
 import Testing
 import SwiftUI
 import ViewInspector
+
+// MARK: - ActivityBar
+
+@Suite("ActivityBar View Structure")
+struct ActivityBarViewTests {
+
+    @Test("Renders one icon per sidebar panel")
+    @MainActor func rendersPanelIcons() throws {
+        let sut = ActivityBar(activePanel: .fileTree, gitStatusCount: 0, theme: ThemeColors(), encoder: nil)
+        let body = try sut.inspect()
+        let buttons = body.findAll(ViewType.Button.self)
+
+        #expect(buttons.count == ActivityBarPanel.allCases.count)
+    }
+
+    @Test("Tap sends the matching panel toggle")
+    @MainActor func tapSendsPanelToggle() throws {
+        let spy = SpyEncoder()
+        let sut = ActivityBar(activePanel: .fileTree, gitStatusCount: 0, theme: ThemeColors(), encoder: spy)
+        let body = try sut.inspect()
+        let buttons = body.findAll(ViewType.Button.self)
+
+        try buttons[0].tap()
+        try buttons[1].tap()
+
+        #expect(spy.guiActions == [.togglePanel(panel: 0), .togglePanel(panel: 2)])
+    }
+
+    @Test("Git badge shows changed file count and buttons keep accessibility labels")
+    @MainActor func gitBadgeAndLabels() throws {
+        let sut = ActivityBar(activePanel: .gitStatus, gitStatusCount: 7, theme: ThemeColors(), encoder: nil)
+        let body = try sut.inspect()
+        let buttons = body.findAll(ViewType.Button.self)
+        let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(buttons.count == ActivityBarPanel.allCases.count)
+        #expect(try buttons[1].accessibilityLabel().string() == "Git status")
+        #expect(try buttons[0].accessibilityLabel().string() == "File tree")
+        #expect(strings.contains("7"))
+    }
+}
 
 // MARK: - SidebarHeaderButton
 


### PR DESCRIPTION
# TL;DR
Adds a macOS sidebar activity bar so users can discover and switch between the file tree and git status panels without knowing keybindings.

Closes #1146

## Context
The macOS sidebar already had file tree and git status panels, but the git panel was hidden behind keyboard shortcuts and status bar controls. This PR adds the left icon strip used by editors like VS Code and Xcode, while keeping the BEAM as the source of truth for panel visibility.

## Changes
- Added `ActivityBar`, a 32px SwiftUI icon strip with file tree and git status buttons.
- Wired the bar beside `SidebarContainer` so it stays visible when sidebar content is collapsed, allowing the active icon to reopen its panel.
- Tracks the active sidebar panel from BEAM-driven visibility state so keyboard shortcuts update the highlighted icon.
- Shows a git badge from `gitStatusState.totalCount` when changed files are present.
- Added ViewInspector coverage for icon count, panel toggle routing, and the git badge.

## Verification
- `git diff --cached --check` passed.
- `make lint` passed.
- `mix test.llm` passed: 52 doctests, 99 properties, 8102 tests, 0 failures, 5 skipped, 198 excluded.
- `mix test.debug test/minga_agent/session_test.exs:1286` passed after an earlier full-suite timeout in that unrelated test.
- `mix test.llm test/minga_agent/session_test.exs` passed.
- `mix swift.build` could not run a real local Swift build because this Linux runner does not have `xcodebuild`.
- `mix swift.harness` could not run locally because this Linux runner does not have `swiftc`. The macOS CI jobs run the authoritative Xcode build, Xcode tests, and Swift harness.

## Acceptance Criteria Addressed
- Thin 28-32px vertical strip appears on the left edge of the sidebar ✅
- File tree and git status icons are present ✅
- Active icon is highlighted and inactive icons are dimmed ✅
- Clicking inactive icons switches panels through the BEAM panel toggle action ✅
- Clicking the active icon toggles sidebar content closed, with the activity bar still available to reopen it ✅
- Git status badge shows changed file count from `gitStatusState.totalCount` ✅
- Activity bar remains visible when sidebar content is hidden ✅
- Keyboard shortcuts continue to update the highlighted active icon via BEAM visibility updates ✅

## Notes for Review
- Please rely on the macOS CI jobs for Swift compilation and ViewInspector execution because this runner is Linux-only.
- Manual GUI QA should verify the visual spacing, highlight treatment, collapsed-sidebar reopen behavior, and git badge count in the native app.
