### PR TITLE
Add EditorState workspace convenience helpers

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -86,7 +86,6 @@ defmodule MingaEditor do
           | {:suppress_tool_prompts, boolean()}
 
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State.LSP, as: LSPState
   alias MingaEditor.State.Session, as: EditorSessionState
 
@@ -436,7 +435,7 @@ defmodule MingaEditor do
     new_state = %{
       (state
        |> EditorState.set_terminal_viewport(vp)
-       |> EditorState.update_workspace(&SessionState.set_viewport(&1, vp)))
+       |> EditorState.set_viewport(vp))
       | capabilities: caps,
         layout: nil
     }
@@ -485,7 +484,7 @@ defmodule MingaEditor do
     new_state =
       state
       |> EditorState.set_terminal_viewport(vp)
-      |> EditorState.update_workspace(&SessionState.set_viewport(&1, vp))
+      |> EditorState.set_viewport(vp)
 
     # Invalidate the cached layout so resize_all_windows computes fresh
     # rectangles from the new viewport dimensions.
@@ -2053,11 +2052,8 @@ defmodule MingaEditor do
   def do_file_tree_open(state, pid, path, tree) do
     new_state = register_buffer(state, pid, path)
 
-    EditorState.update_workspace(new_state, fn ws ->
-      SessionState.set_file_tree(
-        ws,
-        FileTreeState.set_tree(ws.file_tree, FileTree.reveal(tree, path))
-      )
+    EditorState.update_file_tree(new_state, fn file_tree ->
+      FileTreeState.set_tree(file_tree, FileTree.reveal(tree, path))
     end)
   end
 
@@ -2207,9 +2203,7 @@ defmodule MingaEditor do
   @spec register_buffer_background(state(), pid(), String.t()) :: state()
   defp register_buffer_background(state, buffer_pid, file_path) do
     state =
-      EditorState.update_workspace(state, fn ws ->
-        SessionState.set_buffers(ws, Buffers.add_background(ws.buffers, buffer_pid))
-      end)
+      EditorState.update_buffers(state, &Buffers.add_background(&1, buffer_pid))
 
     state = EditorState.monitor_buffer(state, buffer_pid)
     log_message(state, "Opened (agent): #{file_path}")

--- a/lib/minga_editor/agent_activation.ex
+++ b/lib/minga_editor/agent_activation.ex
@@ -131,20 +131,17 @@ defmodule MingaEditor.AgentActivation do
 
   @spec set_agent_scope(EditorState.t()) :: EditorState.t()
   defp set_agent_scope(state) do
-    EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :agent))
+    EditorState.set_keymap_scope(state, :agent)
   end
 
   @spec set_agent_chat_window_content(EditorState.t(), pid()) :: EditorState.t()
   defp set_agent_chat_window_content(state, session) do
     active_id = state.workspace.windows.active
 
-    EditorState.update_workspace(state, fn ws ->
-      windows =
-        Windows.update(ws.windows, active_id, fn active_win ->
-          %{active_win | content: Content.agent_chat(session)}
-        end)
-
-      SessionState.set_windows(ws, windows)
+    EditorState.update_windows(state, fn windows ->
+      Windows.update(windows, active_id, fn active_win ->
+        %{active_win | content: Content.agent_chat(session)}
+      end)
     end)
   end
 
@@ -170,7 +167,7 @@ defmodule MingaEditor.AgentActivation do
   defp restore_return_target(state, nil), do: state
 
   defp restore_return_target(state, return_target) do
-    EditorState.update_workspace(state, &restore_workspace(&1, return_target))
+    EditorState.set_workspace(state, restore_workspace(state.workspace, return_target))
   end
 
   @spec restore_workspace(SessionState.t(), UIState.View.return_target()) :: SessionState.t()
@@ -207,10 +204,10 @@ defmodule MingaEditor.AgentActivation do
   @spec restore_deactivated_scope(EditorState.t(), UIState.View.return_target() | nil) ::
           EditorState.t()
   defp restore_deactivated_scope(state, %{keymap_scope: keymap_scope}) do
-    EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, keymap_scope))
+    EditorState.set_keymap_scope(state, keymap_scope)
   end
 
   defp restore_deactivated_scope(state, _return_target) do
-    EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :editor))
+    EditorState.set_keymap_scope(state, :editor)
   end
 end

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -670,10 +670,7 @@ defmodule MingaEditor.Commands do
   @spec restore_file_tree_scope(EditorState.t()) :: EditorState.t()
   defp restore_file_tree_scope(state) do
     if state.workspace.file_tree.tree != nil do
-      EditorState.update_workspace(
-        state,
-        &MingaEditor.Session.State.set_keymap_scope(&1, :file_tree)
-      )
+      EditorState.set_keymap_scope(state, :file_tree)
     else
       state
     end

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -268,37 +268,39 @@ defmodule MingaEditor.Commands.Agent do
 
   @spec restore_return_keymap_scope(state(), UIState.View.return_target() | nil) :: state()
   defp restore_return_keymap_scope(state, %{keymap_scope: keymap_scope}) do
-    EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, keymap_scope))
+    EditorState.set_keymap_scope(state, keymap_scope)
   end
 
   defp restore_return_keymap_scope(state, _return_target) do
-    EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :editor))
+    EditorState.set_keymap_scope(state, :editor)
   end
 
   @spec restore_return_target_without_tab(state(), UIState.View.return_target() | nil) :: state()
   defp restore_return_target_without_tab(state, nil) do
     state
     |> mark_agent_view_inactive()
-    |> EditorState.update_workspace(&SessionState.set_keymap_scope(&1, :editor))
+    |> EditorState.set_keymap_scope(:editor)
     |> EditorState.set_status("No file tabs in this workspace")
   end
 
   defp restore_return_target_without_tab(state, return_target) do
     state
     |> mark_agent_view_inactive()
-    |> EditorState.update_workspace(&restore_workspace_return_target(&1, return_target))
+    |> restore_workspace_return_target(return_target)
     |> restore_prompt_focus(return_target.prompt_focused)
     |> EditorState.set_status("No file tabs in this workspace")
   end
 
-  @spec restore_workspace_return_target(SessionState.t(), UIState.View.return_target()) ::
-          SessionState.t()
-  defp restore_workspace_return_target(workspace, return_target) do
-    workspace
-    |> SessionState.set_keymap_scope(return_target.keymap_scope)
-    |> SessionState.set_windows(return_target.windows)
-    |> SessionState.set_file_tree(return_target.file_tree)
-    |> restore_return_target_buffer(return_target.active_buffer)
+  @spec restore_workspace_return_target(state(), UIState.View.return_target()) :: state()
+  defp restore_workspace_return_target(state, return_target) do
+    workspace =
+      state.workspace
+      |> SessionState.set_keymap_scope(return_target.keymap_scope)
+      |> SessionState.set_windows(return_target.windows)
+      |> SessionState.set_file_tree(return_target.file_tree)
+      |> restore_return_target_buffer(return_target.active_buffer)
+
+    EditorState.set_workspace(state, workspace)
   end
 
   @spec restore_return_target_buffer(SessionState.t(), pid() | nil) :: SessionState.t()

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -20,7 +20,6 @@ defmodule MingaEditor.Commands.AgentSession do
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Windows
-  alias MingaEditor.Session.State, as: WorkspaceState
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
 
@@ -656,7 +655,7 @@ defmodule MingaEditor.Commands.AgentSession do
 
     state
     |> EditorState.set_tab_bar(tb)
-    |> EditorState.update_workspace(&WorkspaceState.set_agent_ui(&1, agent_ui))
+    |> EditorState.set_agent_ui(agent_ui)
   end
 
   @spec maybe_update_bound_workspace_project_view(state(), pid(), ProjectView.t() | nil) ::

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -39,7 +39,6 @@ defmodule MingaEditor.Commands.BufferManagement do
   alias Minga.Mode.ToolConfirmState
   alias Minga.Tool.Recipe.Registry, as: RecipeRegistry
   alias MingaEditor.UI.Popup.Lifecycle, as: PopupLifecycle
-  alias MingaEditor.Session.State, as: SessionState
 
   @type state :: EditorState.t()
 
@@ -946,7 +945,7 @@ defmodule MingaEditor.Commands.BufferManagement do
           new_bs = Buffers.replace_list(bs, new_buffers, new_idx)
 
           state
-          |> EditorState.update_workspace(&SessionState.set_buffers(&1, new_bs))
+          |> EditorState.set_buffers(new_bs)
           |> EditorState.sync_active_window_buffer()
       end
     end
@@ -1469,7 +1468,7 @@ defmodule MingaEditor.Commands.BufferManagement do
           :ok ->
             state
             |> EditorState.set_tab_bar(TabBar.remove_workspace(tb, workspace.id))
-            |> EditorState.update_workspace(&SessionState.set_keymap_scope(&1, :editor))
+            |> EditorState.set_keymap_scope(:editor)
             |> remove_current_tab()
             |> restore_active_tab_context()
 
@@ -1507,7 +1506,7 @@ defmodule MingaEditor.Commands.BufferManagement do
       MingaEditor.log_to_messages("Closed agent tab")
 
       state
-      |> EditorState.update_workspace(&SessionState.set_keymap_scope(&1, :editor))
+      |> EditorState.set_keymap_scope(:editor)
       |> remove_current_tab()
       |> restore_active_tab_context()
     else
@@ -2086,9 +2085,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp focus_popup_window(state, buffer_pid) do
     case find_popup_for_buffer(state, buffer_pid) do
       {:ok, popup_window_id} ->
-        EditorState.update_workspace(state, fn ws ->
-          SessionState.set_windows(ws, Windows.set_active(ws.windows, popup_window_id))
-        end)
+        EditorState.update_windows(state, &Windows.set_active(&1, popup_window_id))
 
       :none ->
         state
@@ -2130,16 +2127,11 @@ defmodule MingaEditor.Commands.BufferManagement do
          ) do
       {:ok, new_buf} ->
         state
-        |> EditorState.update_workspace(
-          &SessionState.set_buffers(&1, Buffers.replace_list(bs, [new_buf], 0))
-        )
+        |> EditorState.set_buffers(Buffers.replace_list(bs, [new_buf], 0))
         |> EditorState.sync_active_window_buffer()
 
       {:error, _} ->
-        EditorState.update_workspace(
-          state,
-          &SessionState.set_buffers(&1, Buffers.replace_list(bs, [], 0))
-        )
+        EditorState.set_buffers(state, Buffers.replace_list(bs, [], 0))
     end
   end
 
@@ -2462,7 +2454,7 @@ defmodule MingaEditor.Commands.BufferManagement do
         {updated_vim, updated_state}
       end)
 
-    EditorState.update_workspace(final_state, &SessionState.set_editing(&1, final_vim))
+    EditorState.set_editing(final_state, final_vim)
   end
 
   @spec string_to_key_tuple(String.t()) :: Minga.Mode.key()

--- a/lib/minga_editor/commands/dired.ex
+++ b/lib/minga_editor/commands/dired.ex
@@ -15,7 +15,6 @@ defmodule MingaEditor.Commands.Dired do
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Dired, as: DiredState
-  alias MingaEditor.Session.State, as: SessionState
 
   @type state :: EditorState.t()
 
@@ -149,11 +148,8 @@ defmodule MingaEditor.Commands.Dired do
 
       state
       |> Commands.add_buffer(pid)
-      |> EditorState.update_workspace(fn ws ->
-        ws
-        |> SessionState.set_dired(dired_state)
-        |> SessionState.set_keymap_scope(:dired)
-      end)
+      |> EditorState.set_dired(dired_state)
+      |> EditorState.set_keymap_scope(:dired)
       |> EditorState.set_status("Dired: #{dired.directory}")
     else
       {:error, reason} ->
@@ -196,7 +192,7 @@ defmodule MingaEditor.Commands.Dired do
             dired_state = DiredState.update_dired(state.workspace.dired, new_dired)
 
             state
-            |> EditorState.update_workspace(&SessionState.set_dired(&1, dired_state))
+            |> EditorState.set_dired(dired_state)
             |> EditorState.set_status("Dired: #{new_dired.directory}")
 
           {:error, reason} ->
@@ -225,16 +221,14 @@ defmodule MingaEditor.Commands.Dired do
     case state.workspace.dired do
       %{active?: true, buffer: buf} when is_pid(buf) ->
         state =
-          EditorState.update_workspace(state, fn ws ->
-            ws
-            |> SessionState.set_dired(DiredState.deactivate(ws.dired))
-            |> SessionState.set_keymap_scope(:editor)
-          end)
+          state
+          |> EditorState.update_dired(&DiredState.deactivate/1)
+          |> EditorState.set_keymap_scope(:editor)
 
         Commands.execute(state, :kill_buffer)
 
       _ ->
-        EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :editor))
+        EditorState.set_keymap_scope(state, :editor)
     end
   end
 
@@ -252,7 +246,7 @@ defmodule MingaEditor.Commands.Dired do
             dired_state = DiredState.update_dired(state.workspace.dired, new_dired)
 
             state
-            |> EditorState.update_workspace(&SessionState.set_dired(&1, dired_state))
+            |> EditorState.set_dired(dired_state)
             |> EditorState.set_status(status_for_dired(new_dired))
 
           {:error, reason} ->
@@ -272,7 +266,7 @@ defmodule MingaEditor.Commands.Dired do
   @spec clear_confirming(state()) :: state()
   defp clear_confirming(state) do
     new_dired = DiredState.exit_confirmation(state.workspace.dired)
-    EditorState.update_workspace(state, &SessionState.set_dired(&1, new_dired))
+    EditorState.set_dired(state, new_dired)
   end
 
   @spec compute_pending_ops(pid(), [Dired.entry()], String.t()) :: [Dired.operation()]
@@ -290,9 +284,7 @@ defmodule MingaEditor.Commands.Dired do
     summary = format_operations_summary(ops)
 
     state
-    |> EditorState.update_workspace(fn ws ->
-      SessionState.set_dired(ws, DiredState.enter_confirmation(ws.dired, ops))
-    end)
+    |> EditorState.update_dired(&DiredState.enter_confirmation(&1, ops))
     |> EditorState.set_status("#{summary} — apply? (y/n)")
   end
 

--- a/lib/minga_editor/commands/editing.ex
+++ b/lib/minga_editor/commands/editing.ex
@@ -17,8 +17,6 @@ defmodule MingaEditor.Commands.Editing do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.UI.Highlight
   alias MingaEditor.State.Registers
-  alias MingaEditor.VimState
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.Mode
   alias Minga.Mode.ReplaceState
   alias Minga.Mode.VisualState
@@ -255,9 +253,7 @@ defmodule MingaEditor.Commands.Editing do
     Buffer.insert_char(buf, char)
     new_ms = %{ms | original_chars: [original | ms.original_chars]}
 
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_mode_state(&1, new_ms))
-    end)
+    EditorState.set_mode_state(state, new_ms)
   end
 
   def execute(state, {:replace_overwrite, _char}), do: state
@@ -276,9 +272,7 @@ defmodule MingaEditor.Commands.Editing do
     Buffer.move(buf, :left)
     new_ms = %{ms | original_chars: rest}
 
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_mode_state(&1, new_ms))
-    end)
+    EditorState.set_mode_state(state, new_ms)
   end
 
   def execute(

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -13,7 +13,6 @@ defmodule MingaEditor.Commands.FileTree do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias Minga.Mode.DeleteConfirmState
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
   alias MingaEditor.FileTree.DropIntent
@@ -31,11 +30,9 @@ defmodule MingaEditor.Commands.FileTree do
 
     scope = restore_scope(state)
 
-    EditorState.update_workspace(state, fn ws ->
-      ws
-      |> SessionState.set_file_tree(FileTreeState.close(ws.file_tree))
-      |> SessionState.set_keymap_scope(scope)
-    end)
+    state
+    |> EditorState.update_file_tree(&FileTreeState.close/1)
+    |> EditorState.set_keymap_scope(scope)
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
@@ -44,11 +41,9 @@ defmodule MingaEditor.Commands.FileTree do
     FileTreeFreshness.unwatch_expanded_dirs(tree)
     scope = restore_scope(state)
 
-    EditorState.update_workspace(state, fn ws ->
-      ws
-      |> SessionState.set_file_tree(FileTreeState.close(ws.file_tree))
-      |> SessionState.set_keymap_scope(scope)
-    end)
+    state
+    |> EditorState.update_file_tree(&FileTreeState.close/1)
+    |> EditorState.set_keymap_scope(scope)
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
@@ -56,11 +51,9 @@ defmodule MingaEditor.Commands.FileTree do
   def toggle(state) do
     scope = restore_scope(state)
 
-    EditorState.update_workspace(state, fn ws ->
-      ws
-      |> SessionState.set_file_tree(FileTreeState.close(ws.file_tree))
-      |> SessionState.set_keymap_scope(scope)
-    end)
+    state
+    |> EditorState.update_file_tree(&FileTreeState.close/1)
+    |> EditorState.set_keymap_scope(scope)
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
@@ -70,14 +63,12 @@ defmodule MingaEditor.Commands.FileTree do
 
   @spec set_file_tree(state(), FileTreeState.t()) :: state()
   defp set_file_tree(state, file_tree) do
-    EditorState.update_workspace(state, &SessionState.set_file_tree(&1, file_tree))
+    EditorState.set_file_tree(state, file_tree)
   end
 
   @spec update_file_tree(state(), (FileTreeState.t() -> FileTreeState.t())) :: state()
   defp update_file_tree(state, fun) when is_function(fun, 1) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_file_tree(ws, fun.(ws.file_tree))
-    end)
+    EditorState.update_file_tree(state, fun)
   end
 
   @spec open_or_toggle(state()) :: state()
@@ -93,7 +84,7 @@ defmodule MingaEditor.Commands.FileTree do
         state = update_file_tree(state, &FileTreeState.unfocus/1)
         # Opening a file buffer always uses :editor scope (not restore_scope)
         # because the new buffer becomes the active window content.
-        state = EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :editor))
+        state = EditorState.set_keymap_scope(state, :editor)
         open_file_from_tree(state, path, tree)
 
       nil ->
@@ -522,7 +513,7 @@ defmodule MingaEditor.Commands.FileTree do
         state = sync_and_update(state, tree)
         state = update_file_tree(state, &FileTreeState.focus/1)
 
-        EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :file_tree))
+        EditorState.set_keymap_scope(state, :file_tree)
         |> Layout.invalidate()
         |> EditorState.invalidate_all_windows()
     end
@@ -542,21 +533,17 @@ defmodule MingaEditor.Commands.FileTree do
 
     scope = restore_scope(state)
 
-    EditorState.update_workspace(state, fn ws ->
-      ws
-      |> SessionState.set_file_tree(FileTreeState.close(ws.file_tree))
-      |> SessionState.set_keymap_scope(scope)
-    end)
+    state
+    |> EditorState.update_file_tree(&FileTreeState.close/1)
+    |> EditorState.set_keymap_scope(scope)
   end
 
   def close(state) do
     scope = restore_scope(state)
 
-    EditorState.update_workspace(state, fn ws ->
-      ws
-      |> SessionState.set_file_tree(FileTreeState.close(ws.file_tree))
-      |> SessionState.set_keymap_scope(scope)
-    end)
+    state
+    |> EditorState.update_file_tree(&FileTreeState.close/1)
+    |> EditorState.set_keymap_scope(scope)
   end
 
   # ── Private helpers ───────────────────────────────────────────────────────
@@ -778,7 +765,7 @@ defmodule MingaEditor.Commands.FileTree do
   defp close_git_status_if_open(state),
     do:
       state
-      |> EditorState.update_workspace(&SessionState.set_keymap_scope(&1, :editor))
+      |> EditorState.set_keymap_scope(:editor)
       |> EditorState.close_git_status_panel()
 
   # Opens a file from the tree, reusing an existing buffer when one exists
@@ -829,11 +816,9 @@ defmodule MingaEditor.Commands.FileTree do
     FileTreeFreshness.watch_expanded_dirs(tree)
     buf = BufferSync.start_buffer(tree, EditorState.options_server(state))
 
-    EditorState.update_workspace(state, fn ws ->
-      ws
-      |> SessionState.set_file_tree(FileTreeState.open(ws.file_tree, tree, buf))
-      |> SessionState.set_keymap_scope(:file_tree)
-    end)
+    state
+    |> EditorState.update_file_tree(&FileTreeState.open(&1, tree, buf))
+    |> EditorState.set_keymap_scope(:file_tree)
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -15,7 +15,6 @@ defmodule MingaEditor.Commands.Git do
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
   alias Minga.Git
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.Language
   alias MingaEditor.UI.Picker.GitChangedSource
 
@@ -59,7 +58,7 @@ defmodule MingaEditor.Commands.Git do
   def execute(state, :git_status_toggle) do
     if state.workspace.keymap_scope == :git_status do
       state
-      |> EditorState.update_workspace(&SessionState.set_keymap_scope(&1, :editor))
+      |> EditorState.set_keymap_scope(:editor)
       |> EditorState.close_git_status_panel()
       |> Layout.invalidate()
       |> EditorState.invalidate_all_windows()
@@ -843,7 +842,7 @@ defmodule MingaEditor.Commands.Git do
         state = close_file_tree_if_open(state)
 
         state =
-          EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :git_status))
+          EditorState.set_keymap_scope(state, :git_status)
 
         state
         |> EditorState.set_git_status_panel(panel_data)
@@ -867,7 +866,7 @@ defmodule MingaEditor.Commands.Git do
     state = close_file_tree_if_open(state)
 
     state =
-      EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :git_status))
+      EditorState.set_keymap_scope(state, :git_status)
 
     state
     |> EditorState.set_git_status_panel(panel_data)

--- a/lib/minga_editor/commands/help.ex
+++ b/lib/minga_editor/commands/help.ex
@@ -19,7 +19,6 @@ defmodule MingaEditor.Commands.Help do
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.Mode
 
   @type state :: EditorState.t()
@@ -883,9 +882,7 @@ defmodule MingaEditor.Commands.Help do
     {:ok, pid} = start_special_buffer(state, "*Help*")
 
     state =
-      EditorState.update_workspace(state, fn ws ->
-        SessionState.set_buffers(ws, Buffers.set_help(ws.buffers, pid))
-      end)
+      EditorState.update_buffers(state, &Buffers.set_help(&1, pid))
 
     {state, pid}
   end

--- a/lib/minga_editor/commands/marks.ex
+++ b/lib/minga_editor/commands/marks.ex
@@ -10,9 +10,7 @@ defmodule MingaEditor.Commands.Marks do
   alias Minga.Buffer.Document
   alias MingaEditor.Commands.Helpers
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.VimState
   alias Minga.Mode
-  alias MingaEditor.Session.State, as: SessionState
 
   @type state :: EditorState.t()
 
@@ -32,9 +30,7 @@ defmodule MingaEditor.Commands.Marks do
     buf_marks = Map.get(marks, buf, %{})
     new_marks = Map.put(marks, buf, Map.put(buf_marks, char, pos))
 
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_marks(&1, new_marks))
-    end)
+    EditorState.set_marks(state, new_marks)
   end
 
   def execute(
@@ -88,9 +84,7 @@ defmodule MingaEditor.Commands.Marks do
     target = Minga.Editing.first_non_blank(tmp_buf, {last_line, 0})
     Buffer.move_to(buf, target)
 
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_last_jump_pos(&1, current_pos))
-    end)
+    EditorState.set_last_jump_pos(state, current_pos)
   end
 
   def execute(state, :jump_to_last_pos_line), do: state
@@ -103,9 +97,7 @@ defmodule MingaEditor.Commands.Marks do
     current_pos = Buffer.cursor(buf)
     Buffer.move_to(buf, last_pos)
 
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_last_jump_pos(&1, current_pos))
-    end)
+    EditorState.set_last_jump_pos(state, current_pos)
   end
 
   def execute(state, :jump_to_last_pos_exact), do: state

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -22,9 +22,7 @@ defmodule MingaEditor.Commands.Movement do
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Windows
-  alias MingaEditor.VimState
   alias MingaEditor.Viewport
-  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
   alias Minga.Mode
@@ -258,9 +256,7 @@ defmodule MingaEditor.Commands.Movement do
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, {:find_char, dir, char}) do
     Helpers.apply_find_char(buf, dir, char)
 
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_last_find_char(&1, {dir, char}))
-    end)
+    EditorState.set_last_find_char(state, {dir, char})
   end
 
   def execute(
@@ -535,7 +531,7 @@ defmodule MingaEditor.Commands.Movement do
           |> Windows.set_tree(new_tree)
           |> Windows.add_window(new_window)
 
-        state = EditorState.update_workspace(state, &SessionState.set_windows(&1, new_windows))
+        state = EditorState.set_windows(state, new_windows)
 
         resize_windows_to_layout(state)
 
@@ -565,7 +561,7 @@ defmodule MingaEditor.Commands.Movement do
   defp navigate_window(%{workspace: %{file_tree: %{focused: true}}} = state, :right) do
     state = update_file_tree(state, &FileTreeState.unfocus/1)
     scope = EditorState.scope_for_active_window(state)
-    EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, scope))
+    EditorState.set_keymap_scope(state, scope)
   end
 
   defp navigate_window(state, direction) do
@@ -592,7 +588,7 @@ defmodule MingaEditor.Commands.Movement do
          :left
        ) do
     state = update_file_tree(state, &FileTreeState.focus/1)
-    EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :file_tree))
+    EditorState.set_keymap_scope(state, :file_tree)
   end
 
   defp maybe_focus_file_tree(state, _direction), do: state
@@ -634,11 +630,9 @@ defmodule MingaEditor.Commands.Movement do
     new_windows = Windows.set_active(removed_windows, new_active)
     new_buffers = Buffers.set_active_override(state.workspace.buffers, new_active_window.buffer)
 
-    EditorState.update_workspace(state, fn workspace ->
-      workspace
-      |> SessionState.set_windows(new_windows)
-      |> SessionState.set_buffers(new_buffers)
-    end)
+    state
+    |> EditorState.set_windows(new_windows)
+    |> EditorState.set_buffers(new_buffers)
   end
 
   # ── Private helpers ──────────────────────────────────────────────────────
@@ -682,9 +676,7 @@ defmodule MingaEditor.Commands.Movement do
 
   @spec update_file_tree(state(), (FileTreeState.t() -> FileTreeState.t())) :: state()
   defp update_file_tree(state, fun) when is_function(fun, 1) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_file_tree(ws, fun.(ws.file_tree))
-    end)
+    EditorState.update_file_tree(state, fun)
   end
 
   @spec visual_line_move(GenServer.server(), state(), :up | :down) :: state()

--- a/lib/minga_editor/commands/search.ex
+++ b/lib/minga_editor/commands/search.ex
@@ -14,7 +14,6 @@ defmodule MingaEditor.Commands.Search do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Search, as: SearchData
   alias MingaEditor.Window
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.Mode
   alias Minga.Mode.CommandState
   alias Minga.Mode.SearchState
@@ -220,9 +219,7 @@ defmodule MingaEditor.Commands.Search do
         msg = if truncated?, do: "Results truncated to 10,000", else: nil
 
         state =
-          EditorState.update_workspace(state, fn ws ->
-            SessionState.update_search(ws, &SearchData.set_project_results(&1, matches))
-          end)
+          EditorState.update_search(state, &SearchData.set_project_results(&1, matches))
 
         state = PickerUI.open(state, MingaEditor.UI.Picker.ProjectSearchSource)
         if msg, do: EditorState.set_status(state, msg), else: state
@@ -319,9 +316,7 @@ defmodule MingaEditor.Commands.Search do
 
     if text != "" do
       state =
-        EditorState.update_workspace(state, fn ws ->
-          SessionState.set_search(ws, SearchData.record(ws.search, text, :forward))
-        end)
+        EditorState.update_search(state, &SearchData.record(&1, text, :forward))
 
       if state.backend in [:gui, :native_gui] and state.port_manager do
         MingaEditor.Frontend.clipboard_write(state.port_manager, text, :find)
@@ -410,15 +405,11 @@ defmodule MingaEditor.Commands.Search do
 
   @spec put_in_search(state(), atom(), term()) :: state()
   defp put_in_search(state, :last_pattern, value) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_search(ws, &SearchData.record_pattern(&1, value))
-    end)
+    EditorState.update_search(state, &SearchData.record_pattern(&1, value))
   end
 
   defp put_in_search(state, :last_direction, value) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_search(ws, &SearchData.set_last_direction(&1, value))
-    end)
+    EditorState.update_search(state, &SearchData.set_last_direction(&1, value))
   end
 
   # Replace a match at a specific line/col/length in content string.

--- a/lib/minga_editor/commands/tutor.ex
+++ b/lib/minga_editor/commands/tutor.ex
@@ -11,7 +11,6 @@ defmodule MingaEditor.Commands.Tutor do
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
-  alias MingaEditor.Session.State, as: SessionState
 
   @type state :: EditorState.t()
 
@@ -84,9 +83,7 @@ defmodule MingaEditor.Commands.Tutor do
 
     state =
       if idx do
-        EditorState.update_workspace(state, fn ws ->
-          SessionState.set_buffers(ws, Buffers.switch_to(ws.buffers, idx))
-        end)
+        EditorState.update_buffers(state, &Buffers.switch_to(&1, idx))
       else
         Commands.add_buffer(state, buffer)
       end

--- a/lib/minga_editor/commands/visual.ex
+++ b/lib/minga_editor/commands/visual.ex
@@ -13,7 +13,6 @@ defmodule MingaEditor.Commands.Visual do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.VimState
   alias Minga.Mode
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.Mode.VisualState
 
   @type state :: EditorState.t()
@@ -139,10 +138,7 @@ defmodule MingaEditor.Commands.Visual do
         new_ms = %{ms | visual_anchor: start_pos, visual_type: visual_type_for_text_object(spec)}
         Buffer.move_to(buf, end_pos)
 
-        EditorState.update_workspace(
-          state,
-          &SessionState.set_editing(&1, VimState.set_mode_state(vim, new_ms))
-        )
+        EditorState.set_editing(state, VimState.set_mode_state(vim, new_ms))
     end
   end
 

--- a/lib/minga_editor/completion_handling.ex
+++ b/lib/minga_editor/completion_handling.ex
@@ -14,7 +14,6 @@ defmodule MingaEditor.CompletionHandling do
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.SignatureHelp
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State.ModalOverlay
   alias Minga.LSP.Client
   alias Minga.LSP.SyncServer
@@ -191,9 +190,7 @@ defmodule MingaEditor.CompletionHandling do
 
   @spec put_lsp_pending(EditorState.t(), reference(), atom() | tuple()) :: EditorState.t()
   defp put_lsp_pending(state, ref, kind) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_lsp_pending(ws, Map.put(ws.lsp_pending, ref, kind))
-    end)
+    EditorState.put_lsp_pending(state, ref, kind)
   end
 
   @spec accept_text(EditorState.t(), Completion.t(), String.t()) :: EditorState.t()

--- a/lib/minga_editor/editing.ex
+++ b/lib/minga_editor/editing.ex
@@ -15,9 +15,7 @@ defmodule MingaEditor.Editing do
   alias MingaEditor.MacroRecorder
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Registers
-  alias MingaEditor.VimState
   alias Minga.Mode
-  alias MingaEditor.Session.State, as: SessionState
 
   # ── Vim-specific reads ─────────────────────────────────────────────────────
 
@@ -59,42 +57,29 @@ defmodule MingaEditor.Editing do
   @doc "Sets the active register to `name`."
   @spec set_active_register(EditorState.t(), String.t()) :: EditorState.t()
   def set_active_register(%EditorState{} = state, name) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, fn vim ->
-        VimState.set_registers(vim, Registers.set_active(vim.reg, name))
-      end)
-    end)
+    EditorState.set_registers(state, Registers.set_active(state.workspace.editing.reg, name))
   end
 
   @doc "Stores `text` in register `name` with the given type."
   @spec put_register(EditorState.t(), String.t(), String.t(), Registers.reg_type()) ::
           EditorState.t()
   def put_register(%EditorState{} = state, name, text, reg_type \\ :charwise) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, fn vim ->
-        VimState.set_registers(vim, Registers.put(vim.reg, name, text, reg_type))
-      end)
-    end)
+    EditorState.set_registers(
+      state,
+      Registers.put(state.workspace.editing.reg, name, text, reg_type)
+    )
   end
 
   @doc "Resets the active register back to unnamed."
   @spec reset_active_register(EditorState.t()) :: EditorState.t()
   def reset_active_register(%EditorState{} = state) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, fn vim ->
-        VimState.set_registers(vim, Registers.reset_active(vim.reg))
-      end)
-    end)
+    EditorState.set_registers(state, Registers.reset_active(state.workspace.editing.reg))
   end
 
   @doc "Sets the leader_node on mode_state."
   @spec set_leader_node(EditorState.t(), term()) :: EditorState.t()
   def set_leader_node(%EditorState{} = state, node) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, fn vim ->
-        VimState.set_mode_state(vim, %{vim.mode_state | leader_node: node})
-      end)
-    end)
+    EditorState.update_mode_state(state, &%{&1 | leader_node: node})
   end
 
   @doc """
@@ -107,43 +92,29 @@ defmodule MingaEditor.Editing do
   @spec update_mode_state(EditorState.t(), (Mode.state() -> Mode.state()) | map()) ::
           EditorState.t()
   def update_mode_state(%EditorState{} = state, fun) when is_function(fun, 1) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, fn vim ->
-        VimState.set_mode_state(vim, fun.(vim.mode_state))
-      end)
-    end)
+    EditorState.update_mode_state(state, fun)
   end
 
   def update_mode_state(%EditorState{} = state, updates) when is_map(updates) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, fn vim ->
-        VimState.set_mode_state(vim, Map.merge(vim.mode_state, updates))
-      end)
-    end)
+    EditorState.update_mode_state(state, &Map.merge(&1, updates))
   end
 
   @doc "Replaces the macro recorder."
   @spec set_macro_recorder(EditorState.t(), MacroRecorder.t()) :: EditorState.t()
   def set_macro_recorder(%EditorState{} = state, rec) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_macro_recorder(&1, rec))
-    end)
+    EditorState.set_macro_recorder(state, rec)
   end
 
   @doc "Replaces the change recorder."
   @spec set_change_recorder(EditorState.t(), term()) :: EditorState.t()
   def set_change_recorder(%EditorState{} = state, rec) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_change_recorder(&1, rec))
-    end)
+    EditorState.set_change_recorder(state, rec)
   end
 
   @doc "Saves the jump position when the cursor crosses a line boundary."
   @spec save_jump_pos(EditorState.t(), {non_neg_integer(), non_neg_integer()}) ::
           EditorState.t()
   def save_jump_pos(%EditorState{} = state, pos) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_last_jump_pos(&1, pos))
-    end)
+    EditorState.set_last_jump_pos(state, pos)
   end
 end

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -12,7 +12,6 @@ defmodule MingaEditor.FileTree.Freshness do
   alias Minga.Project.FileTree.GitStatus
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
-  alias MingaEditor.Session.State, as: SessionState
 
   @type state :: EditorState.t()
 
@@ -194,7 +193,7 @@ defmodule MingaEditor.FileTree.Freshness do
 
   @spec set_file_tree(state(), FileTreeState.t()) :: state()
   defp set_file_tree(%EditorState{} = state, %FileTreeState{} = file_tree) do
-    EditorState.update_workspace(state, &SessionState.set_file_tree(&1, file_tree))
+    EditorState.set_file_tree(state, file_tree)
   end
 
   @spec safe_watch_directory(String.t()) :: :ok

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -40,8 +40,6 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Windows
 
-  alias MingaEditor.Session.State, as: SessionState
-
   alias MingaAgent.Session, as: AgentSession
 
   alias MingaEditor.Frontend.Protocol
@@ -223,7 +221,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
         ft = FileTreeState.update_editing_text(state.workspace.file_tree, text)
 
         state =
-          EditorState.update_workspace(state, &SessionState.set_file_tree(&1, ft))
+          EditorState.set_file_tree(state, ft)
 
         Commands.FileTree.confirm_editing(state)
     end
@@ -479,7 +477,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
     state
     |> EditorState.update_shell_state(fn _shell_state -> shell_state end)
-    |> EditorState.update_workspace(fn _workspace -> workspace end)
+    |> EditorState.set_workspace(workspace)
     |> EditorState.sync_agent_ui_from_active_workspace()
   end
 
@@ -512,9 +510,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
        when is_pid(buf) do
     # Set the search pattern and execute search_next/search_prev
     state =
-      EditorState.update_workspace(state, fn ws ->
-        SessionState.set_search(ws, SearchData.record(ws.search, text, :forward))
-      end)
+      EditorState.update_search(state, &SearchData.record(&1, text, :forward))
 
     cmd = if direction == 1, do: :search_prev, else: :search_next
     MingaEditor.Commands.execute(state, cmd)
@@ -536,9 +532,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
         new_map = Map.put(win_map, active_win_id, new_win)
 
         new_state =
-          EditorState.update_workspace(state, fn ws ->
-            SessionState.set_windows(ws, Windows.set_map(ws.windows, new_map))
-          end)
+          EditorState.update_windows(state, &Windows.set_map(&1, new_map))
 
         Renderer.render_or_async(new_state)
     end
@@ -778,9 +772,8 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   defp move_tree_cursor(%{workspace: %{file_tree: %{tree: nil}}} = state, _index), do: state
 
   defp move_tree_cursor(state, index) do
-    EditorState.update_workspace(state, fn ws ->
-      tree = FileTree.select(ws.file_tree.tree, index)
-      SessionState.set_file_tree(ws, FileTreeState.set_tree(ws.file_tree, tree))
+    EditorState.update_file_tree(state, fn file_tree ->
+      FileTreeState.set_tree(file_tree, FileTree.select(file_tree.tree, index))
     end)
   end
 
@@ -826,11 +819,9 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec unfocus_file_tree_for_split(state()) :: state()
   defp unfocus_file_tree_for_split(state) do
-    EditorState.update_workspace(state, fn workspace ->
-      workspace
-      |> SessionState.set_file_tree(MingaEditor.State.FileTree.unfocus(workspace.file_tree))
-      |> SessionState.set_keymap_scope(:editor)
-    end)
+    state
+    |> EditorState.update_file_tree(&MingaEditor.State.FileTree.unfocus/1)
+    |> EditorState.set_keymap_scope(:editor)
   end
 
   # ── Hover open action ──────────────────────────────────────────────
@@ -978,17 +969,14 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec show_buffer_in_active_window(state(), pid()) :: state()
   defp show_buffer_in_active_window(state, pid) when is_pid(pid) do
-    EditorState.update_workspace(state, fn workspace ->
-      buffers =
-        case Enum.find_index(workspace.buffers.list, &(&1 == pid)) do
-          nil -> Buffers.add(workspace.buffers, pid)
-          idx -> Buffers.switch_to(workspace.buffers, idx)
-        end
-
-      workspace
-      |> SessionState.set_buffers(buffers)
-      |> SessionState.sync_active_window_buffer()
+    state
+    |> EditorState.update_buffers(fn buffers ->
+      case Enum.find_index(buffers.list, &(&1 == pid)) do
+        nil -> Buffers.add(buffers, pid)
+        idx -> Buffers.switch_to(buffers, idx)
+      end
     end)
+    |> EditorState.sync_active_window_buffer()
   end
 
   @spec tab_active_buffer(Tab.t()) :: pid() | nil
@@ -1003,11 +991,8 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   defp register_buffer_in_active_window(state, buffer_pid, file_path) do
     state =
       state
-      |> EditorState.update_workspace(fn workspace ->
-        workspace
-        |> SessionState.set_buffers(Buffers.add(workspace.buffers, buffer_pid))
-        |> SessionState.sync_active_window_buffer()
-      end)
+      |> EditorState.update_buffers(&Buffers.add(&1, buffer_pid))
+      |> EditorState.sync_active_window_buffer()
       |> EditorState.monitor_buffer(buffer_pid)
 
     state = MingaEditor.log_message(state, "Opened: #{file_path}")
@@ -1031,9 +1016,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec set_vim_mode_state(state(), term()) :: state()
   defp set_vim_mode_state(state, new_ms) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_mode_state(&1, new_ms))
-    end)
+    EditorState.update_editing(state, &VimState.set_mode_state(&1, new_ms))
   end
 
   @spec normalize_command_result(state() | {state(), term()}) :: state()

--- a/lib/minga_editor/handlers/highlight_handler.ex
+++ b/lib/minga_editor/handlers/highlight_handler.ex
@@ -19,7 +19,6 @@ defmodule MingaEditor.Handlers.HighlightHandler do
   alias MingaEditor.State.Highlighting
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Window
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.Editing.Fold.Range, as: FoldRange
 
   @typedoc "Effects that the highlight handler may return."
@@ -215,9 +214,7 @@ defmodule MingaEditor.Handlers.HighlightHandler do
 
   defp handle_injection_ranges(state, pid, _buffer_id, ranges) do
     new_state =
-      EditorState.update_workspace(state, fn ws ->
-        SessionState.set_injection_ranges(ws, Map.put(ws.injection_ranges, pid, ranges))
-      end)
+      EditorState.update_injection_ranges(state, &Map.put(&1, pid, ranges))
 
     {new_state, []}
   end
@@ -379,13 +376,7 @@ defmodule MingaEditor.Handlers.HighlightHandler do
 
   defp handle_document_symbols(state, pid, _buffer_id, symbols) do
     new_state =
-      EditorState.update_workspace(state, fn ws ->
-        SessionState.update_windows_for_buffer(
-          ws,
-          pid,
-          &Window.set_document_symbols(&1, symbols)
-        )
-      end)
+      EditorState.update_windows_for_buffer(state, pid, &Window.set_document_symbols(&1, symbols))
 
     {new_state, []}
   end
@@ -421,12 +412,10 @@ defmodule MingaEditor.Handlers.HighlightHandler do
 
     new_state =
       state
-      |> EditorState.update_workspace(fn ws ->
-        SessionState.update_highlight(ws, fn highlight ->
-          highlight
-          |> Highlighting.set_version(0)
-          |> Highlighting.set_highlights(reset_highlights)
-        end)
+      |> EditorState.update_highlight(fn highlight ->
+        highlight
+        |> Highlighting.set_version(0)
+        |> Highlighting.set_highlights(reset_highlights)
       end)
       |> Map.put(:parser_status, :available)
 

--- a/lib/minga_editor/handlers/lsp_event_handler.ex
+++ b/lib/minga_editor/handlers/lsp_event_handler.ex
@@ -9,7 +9,6 @@ defmodule MingaEditor.Handlers.LspEventHandler do
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.LspActions
   alias MingaEditor.SemanticTokenSync
-  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.LSP, as: LSPState
   alias MingaEditor.State.ModalOverlay
@@ -91,14 +90,9 @@ defmodule MingaEditor.Handlers.LspEventHandler do
     {CompletionHandling.handle_response(state, ref, result), [:render_now]}
   end
 
-  @spec set_lsp_pending(EditorState.t(), %{reference() => atom() | tuple()}) :: EditorState.t()
-  defp set_lsp_pending(state, pending) do
-    EditorState.update_workspace(state, &SessionState.set_lsp_pending(&1, pending))
-  end
-
   @spec delete_lsp_pending(EditorState.t(), reference()) :: EditorState.t()
   defp delete_lsp_pending(state, ref) do
-    set_lsp_pending(state, Map.delete(state.workspace.lsp_pending, ref))
+    EditorState.delete_lsp_pending(state, ref)
   end
 
   @spec dispatch_lsp_response(term(), EditorState.t(), term()) :: EditorState.t()

--- a/lib/minga_editor/highlight_sync.ex
+++ b/lib/minga_editor/highlight_sync.ex
@@ -10,7 +10,6 @@ defmodule MingaEditor.HighlightSync do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Highlighting
   alias MingaEditor.Frontend.Protocol
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.Parser.Manager, as: ParserManager
   alias MingaEditor.UI.Highlight
   alias MingaEditor.UI.Highlight.Grammar
@@ -92,10 +91,7 @@ defmodule MingaEditor.HighlightSync do
         ParserManager.send_commands([parse_cmd])
 
         state =
-          EditorState.update_workspace(
-            state,
-            &SessionState.update_highlight(&1, fn h -> %{h | version: version} end)
-          )
+          EditorState.update_highlight(state, fn h -> %{h | version: version} end)
 
         touch_buffer(state, buf_pid)
 
@@ -117,13 +113,7 @@ defmodule MingaEditor.HighlightSync do
          %EditorState{workspace: %{buffers: %{active: active_buf}}} = state
        )
        when is_pid(active_buf) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_windows_for_buffer(
-        ws,
-        active_buf,
-        &Window.set_document_symbols(&1, [])
-      )
-    end)
+    EditorState.update_windows_for_buffer(state, active_buf, &Window.set_document_symbols(&1, []))
   end
 
   defp clear_active_document_symbols(%EditorState{} = state), do: state
@@ -203,12 +193,10 @@ defmodule MingaEditor.HighlightSync do
       end
 
     state =
-      EditorState.update_workspace(state, fn ws ->
-        SessionState.update_highlight(ws, fn highlight ->
-          highlight
-          |> Highlighting.set_version(version)
-          |> Highlighting.set_syntax_overrides(syntax_overrides)
-        end)
+      EditorState.update_highlight(state, fn highlight ->
+        highlight
+        |> Highlighting.set_version(version)
+        |> Highlighting.set_syntax_overrides(syntax_overrides)
       end)
 
     touch_buffer(state, buf_pid)
@@ -235,10 +223,7 @@ defmodule MingaEditor.HighlightSync do
     now = System.monotonic_time(:millisecond)
     timestamps = Map.put(hl.last_active_at, buf_pid, now)
 
-    EditorState.update_workspace(
-      state,
-      &SessionState.update_highlight(&1, fn h -> %{h | last_active_at: timestamps} end)
-    )
+    EditorState.update_highlight(state, fn h -> %{h | last_active_at: timestamps} end)
   end
 
   @spec send_parse_only(EditorState.t(), String.t()) :: EditorState.t()
@@ -296,9 +281,7 @@ defmodule MingaEditor.HighlightSync do
     state = put_active_highlight(state, Highlight.from_theme(state.theme))
 
     state =
-      EditorState.update_workspace(state, fn ws ->
-        SessionState.update_highlight(ws, &Highlighting.set_version(&1, version))
-      end)
+      EditorState.update_highlight(state, &Highlighting.set_version(&1, version))
 
     touch_active(state)
   end
@@ -335,7 +318,7 @@ defmodule MingaEditor.HighlightSync do
         next_buffer_id: id + 1
     }
 
-    {id, EditorState.update_workspace(state, &SessionState.set_highlight(&1, new_hl))}
+    {id, EditorState.set_highlight(state, new_hl)}
   end
 
   @doc """
@@ -354,12 +337,10 @@ defmodule MingaEditor.HighlightSync do
         ParserManager.close_buffer(buffer_id)
         ParserManager.unregister_buffer(buffer_id)
 
-        EditorState.update_workspace(state, fn ws ->
-          SessionState.update_highlight(
-            ws,
-            &Highlighting.remove_buffer(&1, buffer_pid, buffer_id, remaining_ids)
-          )
-        end)
+        EditorState.update_highlight(
+          state,
+          &Highlighting.remove_buffer(&1, buffer_pid, buffer_id, remaining_ids)
+        )
     end
   end
 
@@ -528,10 +509,7 @@ defmodule MingaEditor.HighlightSync do
     ParserManager.send_commands(commands)
 
     state =
-      EditorState.update_workspace(
-        state,
-        &SessionState.update_highlight(&1, fn h -> %{h | version: version} end)
-      )
+      EditorState.update_highlight(state, fn h -> %{h | version: version} end)
 
     touch_active(state)
   end
@@ -560,10 +538,7 @@ defmodule MingaEditor.HighlightSync do
     now = System.monotonic_time(:millisecond)
     timestamps = Map.put(hl.last_active_at, state.workspace.buffers.active, now)
 
-    EditorState.update_workspace(
-      state,
-      &SessionState.update_highlight(&1, fn h -> %{h | last_active_at: timestamps} end)
-    )
+    EditorState.update_highlight(state, fn h -> %{h | last_active_at: timestamps} end)
   end
 
   @doc """
@@ -645,7 +620,7 @@ defmodule MingaEditor.HighlightSync do
     new_hl =
       compute_post_eviction_state(state.workspace.highlight, evicted_ids, remaining_timestamps)
 
-    EditorState.update_workspace(state, &SessionState.set_highlight(&1, new_hl))
+    EditorState.set_highlight(state, new_hl)
   end
 
   # Pure calculation: produces the new Highlighting struct with evicted entries removed.
@@ -726,17 +701,13 @@ defmodule MingaEditor.HighlightSync do
         %EditorState{workspace: %{buffers: %{active: buf}}} = state,
         hl_data
       ) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_highlight(ws, &Highlighting.put_highlight(&1, buf, hl_data))
-    end)
+    EditorState.update_highlight(state, &Highlighting.put_highlight(&1, buf, hl_data))
   end
 
   @doc "Stores highlight data for a specific buffer PID."
   @spec put_highlight(EditorState.t(), pid(), Highlight.t()) :: EditorState.t()
   def put_highlight(%EditorState{} = state, buf_pid, hl_data) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_highlight(ws, &Highlighting.put_highlight(&1, buf_pid, hl_data))
-    end)
+    EditorState.update_highlight(state, &Highlighting.put_highlight(&1, buf_pid, hl_data))
   end
 
   # Updates the active buffer's highlight via a function.

--- a/lib/minga_editor/input/agent_nav.ex
+++ b/lib/minga_editor/input/agent_nav.ex
@@ -35,7 +35,6 @@ defmodule MingaEditor.Input.AgentNav do
   alias Minga.Buffer
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
-  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Window
 
@@ -155,9 +154,7 @@ defmodule MingaEditor.Input.AgentNav do
 
   @spec set_active_buffer_override(EditorState.t(), pid() | nil) :: EditorState.t()
   defp set_active_buffer_override(state, pid) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_buffers(ws, Buffers.set_active_override(ws.buffers, pid))
-    end)
+    EditorState.update_buffers(state, &Buffers.set_active_override(&1, pid))
   end
 
   # ── Private helpers ─────────────────────────────────────────────────────

--- a/lib/minga_editor/input/agent_panel.ex
+++ b/lib/minga_editor/input/agent_panel.ex
@@ -25,7 +25,6 @@ defmodule MingaEditor.Input.AgentPanel do
   alias MingaEditor.LayoutPreset
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
-  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Input
   alias MingaEditor.Input.AgentNav
@@ -160,9 +159,7 @@ defmodule MingaEditor.Input.AgentPanel do
 
   @spec set_active_buffer_override(EditorState.t(), pid() | nil) :: EditorState.t()
   defp set_active_buffer_override(state, pid) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_buffers(ws, Buffers.set_active_override(ws.buffers, pid))
-    end)
+    EditorState.update_buffers(state, &Buffers.set_active_override(&1, pid))
   end
 
   # ── Panel navigation mode ──────────────────────────────────────────────

--- a/lib/minga_editor/input/dired.ex
+++ b/lib/minga_editor/input/dired.ex
@@ -18,7 +18,6 @@ defmodule MingaEditor.Input.Dired do
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Dired, as: DiredState
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.Keymap
   alias Minga.Keymap.Scope
 
@@ -139,8 +138,6 @@ defmodule MingaEditor.Input.Dired do
 
   @spec update_pending_prefix(state(), Minga.Keymap.Bindings.node_t() | nil) :: state()
   defp update_pending_prefix(state, prefix) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_dired(ws, DiredState.set_pending_prefix(ws.dired, prefix))
-    end)
+    EditorState.update_dired(state, &DiredState.set_pending_prefix(&1, prefix))
   end
 end

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -23,7 +23,6 @@ defmodule MingaEditor.Input.FileTreeHandler do
   alias Minga.Keymap
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
-  alias MingaEditor.Session.State, as: SessionState
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
@@ -140,11 +139,9 @@ defmodule MingaEditor.Input.FileTreeHandler do
 
   @spec focus_file_tree_for_mouse(EditorState.t(), atom()) :: EditorState.t()
   defp focus_file_tree_for_mouse(state, :left) do
-    EditorState.update_workspace(state, fn workspace ->
-      workspace
-      |> SessionState.set_file_tree(FileTreeState.focus(workspace.file_tree))
-      |> SessionState.set_keymap_scope(:file_tree)
-    end)
+    state
+    |> EditorState.update_file_tree(&FileTreeState.focus/1)
+    |> EditorState.set_keymap_scope(:file_tree)
   end
 
   defp focus_file_tree_for_mouse(state, _button), do: state
@@ -378,15 +375,13 @@ defmodule MingaEditor.Input.FileTreeHandler do
 
   @spec set_active_buffer_override(EditorState.t(), pid() | nil) :: EditorState.t()
   defp set_active_buffer_override(state, pid) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_buffers(ws, Buffers.set_active_override(ws.buffers, pid))
-    end)
+    EditorState.update_buffers(state, &Buffers.set_active_override(&1, pid))
   end
 
   @spec set_file_tree(EditorState.t(), FileTreeState.t()) :: EditorState.t()
   defp set_file_tree(state, file_tree) do
     sync_buffer(file_tree)
-    EditorState.update_workspace(state, &SessionState.set_file_tree(&1, file_tree))
+    EditorState.set_file_tree(state, file_tree)
   end
 
   @spec sync_buffer(FileTreeState.t()) :: :ok
@@ -402,8 +397,6 @@ defmodule MingaEditor.Input.FileTreeHandler do
   @spec update_file_tree(EditorState.t(), (FileTreeState.t() -> FileTreeState.t())) ::
           EditorState.t()
   defp update_file_tree(state, fun) when is_function(fun, 1) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_file_tree(ws, fun.(ws.file_tree))
-    end)
+    EditorState.update_file_tree(state, fun)
   end
 end

--- a/lib/minga_editor/input/git_status.ex
+++ b/lib/minga_editor/input/git_status.ex
@@ -22,7 +22,6 @@ defmodule MingaEditor.Input.GitStatus do
   alias Minga.Keymap
   alias MingaEditor.PromptUI
   alias MingaEditor.UI.Prompt.GitCommit, as: CommitPrompt
-  alias MingaEditor.Session.State, as: SessionState
 
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
@@ -251,7 +250,7 @@ defmodule MingaEditor.Input.GitStatus do
   @spec close_panel(EditorState.t()) :: EditorState.t()
   defp close_panel(state) do
     state
-    |> EditorState.update_workspace(&SessionState.set_keymap_scope(&1, :editor))
+    |> EditorState.set_keymap_scope(:editor)
     |> EditorState.close_git_status_panel()
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()

--- a/lib/minga_editor/input/interrupt.ex
+++ b/lib/minga_editor/input/interrupt.ex
@@ -35,7 +35,6 @@ defmodule MingaEditor.Input.Interrupt do
   alias MingaEditor.State.WhichKey
   alias MingaEditor.VimState
   alias Minga.Mode
-  alias MingaEditor.Session.State, as: SessionState
 
   # Ctrl-G sends codepoint 7 (BEL / ASCII control code for ^G).
   @ctrl_g 7
@@ -72,8 +71,7 @@ defmodule MingaEditor.Input.Interrupt do
     do: {state, resets}
 
   defp maybe_reset_scope(%{workspace: %{keymap_scope: scope}} = state, resets) do
-    {EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :editor)),
-     ["scope #{scope} → :editor" | resets]}
+    {EditorState.set_keymap_scope(state, :editor), ["scope #{scope} → :editor" | resets]}
   end
 
   @spec maybe_reset_mode(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
@@ -88,7 +86,7 @@ defmodule MingaEditor.Input.Interrupt do
     if mode_state_dirty?(vim.mode_state, fresh_state) do
       new_vim = VimState.set_mode_state(vim, fresh_state)
 
-      {EditorState.update_workspace(state, &SessionState.set_editing(&1, new_vim)),
+      {EditorState.set_editing(state, new_vim),
        ["mode state reset (pending sequence cleared)" | resets]}
     else
       {state, resets}

--- a/lib/minga_editor/layout_preset.ex
+++ b/lib/minga_editor/layout_preset.ex
@@ -29,7 +29,6 @@ defmodule MingaEditor.LayoutPreset do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Windows
   alias MingaEditor.Window
-  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Window.Content
   alias MingaEditor.WindowTree
 
@@ -72,12 +71,12 @@ defmodule MingaEditor.LayoutPreset do
 
     case Windows.remove_window(state.workspace.windows, agent_win_id) do
       {:ok, windows} ->
-        state = EditorState.update_workspace(state, &SessionState.set_windows(&1, windows))
+        state = EditorState.set_windows(state, windows)
 
         # If we were in agent scope, return to editor scope since the
         # agent pane is gone.
         if state.workspace.keymap_scope == :agent do
-          EditorState.update_workspace(state, &SessionState.set_keymap_scope(&1, :editor))
+          EditorState.set_keymap_scope(state, :editor)
         else
           state
         end
@@ -134,7 +133,7 @@ defmodule MingaEditor.LayoutPreset do
             |> Windows.set_tree(new_tree)
             |> Windows.add_window(agent_window)
 
-          EditorState.update_workspace(state, &SessionState.set_windows(&1, windows))
+          EditorState.set_windows(state, windows)
 
         :error ->
           state

--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -33,7 +33,6 @@ defmodule MingaEditor.LspActions do
   alias MingaEditor.State.LSP, as: LSPState
   alias MingaEditor.VimState
   alias Minga.Log
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.LSP.Client
   alias Minga.LSP.DocumentHighlight
   alias Minga.LSP.SyncServer
@@ -484,7 +483,7 @@ defmodule MingaEditor.LspActions do
     vim = VimState.transition(state.workspace.editing, :normal)
 
     %{
-      EditorState.update_workspace(state, &SessionState.set_editing(&1, vim))
+      EditorState.set_editing(state, vim)
       | lsp: LSPState.clear_selection_ranges(state.lsp)
     }
   end
@@ -858,20 +857,20 @@ defmodule MingaEditor.LspActions do
   """
   @spec handle_document_highlight_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_document_highlight_response(state, {:error, _error}) do
-    EditorState.update_workspace(state, &SessionState.set_document_highlights(&1, nil))
+    EditorState.set_document_highlights(state, nil)
   end
 
   def handle_document_highlight_response(state, {:ok, nil}) do
-    EditorState.update_workspace(state, &SessionState.set_document_highlights(&1, nil))
+    EditorState.set_document_highlights(state, nil)
   end
 
   def handle_document_highlight_response(state, {:ok, []}) do
-    EditorState.update_workspace(state, &SessionState.set_document_highlights(&1, nil))
+    EditorState.set_document_highlights(state, nil)
   end
 
   def handle_document_highlight_response(state, {:ok, highlights}) when is_list(highlights) do
     parsed = Enum.map(highlights, &DocumentHighlight.from_lsp/1)
-    EditorState.update_workspace(state, &SessionState.set_document_highlights(&1, parsed))
+    EditorState.set_document_highlights(state, parsed)
   end
 
   # ── Code action response ──────────────────────────────────────────────────
@@ -925,7 +924,7 @@ defmodule MingaEditor.LspActions do
     # The ex-command parser handles "rename <new_name>" → {:rename, new_name}
     command_state = %CommandState{input: "rename #{placeholder}"}
     vim = VimState.transition(state.workspace.editing, :command, command_state)
-    EditorState.update_workspace(state, &SessionState.set_editing(&1, vim))
+    EditorState.set_editing(state, vim)
   end
 
   @doc """
@@ -1420,22 +1419,18 @@ defmodule MingaEditor.LspActions do
 
         ref = Client.request(client, method, params)
 
-        EditorState.update_workspace(state, fn ws ->
-          SessionState.set_lsp_pending(ws, Map.put(ws.lsp_pending, ref, kind))
-        end)
+        EditorState.put_lsp_pending(state, ref, kind)
     end
   end
 
   @spec put_lsp_pending(state(), reference(), atom() | tuple()) :: state()
   defp put_lsp_pending(state, ref, kind) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_lsp_pending(ws, Map.put(ws.lsp_pending, ref, kind))
-    end)
+    EditorState.put_lsp_pending(state, ref, kind)
   end
 
   @spec set_document_highlights(state(), [DocumentHighlight.t()] | nil) :: state()
   defp set_document_highlights(state, highlights) do
-    EditorState.update_workspace(state, &SessionState.set_document_highlights(&1, highlights))
+    EditorState.set_document_highlights(state, highlights)
   end
 
   @spec parse_single_location(map()) ::
@@ -1556,9 +1551,7 @@ defmodule MingaEditor.LspActions do
   defp set_jump_mark(%{workspace: %{buffers: %{active: buf}}} = state) when is_pid(buf) do
     pos = Buffer.cursor(buf)
 
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_last_jump_pos(&1, pos))
-    end)
+    EditorState.set_last_jump_pos(state, pos)
   end
 
   defp set_jump_mark(state), do: state
@@ -1944,7 +1937,7 @@ defmodule MingaEditor.LspActions do
       }
 
       vim = VimState.transition(state.workspace.editing, :visual, visual_state)
-      EditorState.update_workspace(state, &SessionState.set_editing(&1, vim))
+      EditorState.set_editing(state, vim)
     else
       state
     end

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -43,7 +43,6 @@ defmodule MingaEditor.Mouse do
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Mouse, as: MouseState
   alias MingaEditor.State.Windows
-  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State.WhichKey, as: WhichKeyState
   alias MingaEditor.Viewport
   alias MingaEditor.Window
@@ -148,11 +147,7 @@ defmodule MingaEditor.Mouse do
         :release,
         _cc
       ) do
-    state =
-      EditorState.update_workspace(
-        state,
-        &SessionState.set_mouse(&1, MouseState.stop_drag(&1.mouse))
-      )
+    state = EditorState.update_mouse(state, &MouseState.stop_drag/1)
 
     # TUI keeps legacy selection auto-copy. Native GUI selection stays separate from the clipboard.
     auto_copy_selection(state)
@@ -167,10 +162,7 @@ defmodule MingaEditor.Mouse do
         :release,
         _cc
       ) do
-    EditorState.update_workspace(
-      state,
-      &SessionState.set_mouse(&1, MouseState.stop_drag(&1.mouse))
-    )
+    EditorState.update_mouse(state, &MouseState.stop_drag/1)
   end
 
   # Ignore negative coordinates except active drags, which clamp to the originating window edge.
@@ -297,10 +289,7 @@ defmodule MingaEditor.Mouse do
         :release,
         _cc
       ) do
-    EditorState.update_workspace(
-      state,
-      &SessionState.set_mouse(&1, MouseState.stop_resize(&1.mouse))
-    )
+    EditorState.update_mouse(state, &MouseState.stop_resize/1)
   end
 
   # ── Mouse motion (hover tracking) ──
@@ -323,9 +312,7 @@ defmodule MingaEditor.Mouse do
 
   @spec update_mouse(state(), (MouseState.t() -> MouseState.t())) :: state()
   defp update_mouse(state, fun) when is_function(fun, 1) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_mouse(ws, fun.(ws.mouse))
-    end)
+    EditorState.update_mouse(state, fun)
   end
 
   @spec handle_left_drag(
@@ -474,7 +461,7 @@ defmodule MingaEditor.Mouse do
   defp handle_left_press(state, row, col, mods, native_click_count) do
     # Record press for multi-click detection
     mouse = MouseState.record_press(state.workspace.mouse, row, col, native_click_count)
-    state = EditorState.update_workspace(state, &SessionState.set_mouse(&1, mouse))
+    state = EditorState.set_mouse(state, mouse)
     click_count = mouse.click_count
 
     # Check modifier clicks first
@@ -824,9 +811,7 @@ defmodule MingaEditor.Mouse do
       windows = Windows.set_tree(state.workspace.windows, new_tree)
 
       state =
-        EditorState.update_workspace(state, fn workspace ->
-          SessionState.set_windows(workspace, windows)
-        end)
+        EditorState.set_windows(state, windows)
 
       {:ok, resize_windows_to_layout(state)}
     else
@@ -845,11 +830,9 @@ defmodule MingaEditor.Mouse do
         mouse = MouseState.update_resize(state.workspace.mouse, dir, new_pos)
 
         state =
-          EditorState.update_workspace(state, fn workspace ->
-            workspace
-            |> SessionState.set_windows(windows)
-            |> SessionState.set_mouse(mouse)
-          end)
+          state
+          |> EditorState.set_windows(windows)
+          |> EditorState.set_mouse(mouse)
 
         resize_windows_to_layout(state)
 
@@ -1184,11 +1167,9 @@ defmodule MingaEditor.Mouse do
   defp maybe_unfocus_file_tree_for_content_click(
          %{workspace: %{keymap_scope: :file_tree}} = state
        ) do
-    EditorState.update_workspace(state, fn workspace ->
-      workspace
-      |> SessionState.set_file_tree(FileTreeState.unfocus(workspace.file_tree))
-      |> SessionState.set_keymap_scope(:editor)
-    end)
+    state
+    |> EditorState.update_file_tree(&FileTreeState.unfocus/1)
+    |> EditorState.set_keymap_scope(:editor)
   end
 
   defp maybe_unfocus_file_tree_for_content_click(state), do: state

--- a/lib/minga_editor/mouse_hover_tooltip.ex
+++ b/lib/minga_editor/mouse_hover_tooltip.ex
@@ -11,7 +11,6 @@ defmodule MingaEditor.MouseHoverTooltip do
   alias Minga.Diagnostics
   alias MingaEditor.HoverPopup
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.LSP.Client
   alias Minga.LSP.SyncServer
 
@@ -103,9 +102,7 @@ defmodule MingaEditor.MouseHoverTooltip do
 
   @spec put_lsp_pending(state(), reference(), atom() | tuple()) :: state()
   defp put_lsp_pending(state, ref, kind) do
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.set_lsp_pending(ws, Map.put(ws.lsp_pending, ref, kind))
-    end)
+    EditorState.put_lsp_pending(state, ref, kind)
   end
 
   @spec gutter_width(term()) :: non_neg_integer()

--- a/lib/minga_editor/semantic_token_sync.ex
+++ b/lib/minga_editor/semantic_token_sync.ex
@@ -29,7 +29,6 @@ defmodule MingaEditor.SemanticTokenSync do
   alias MingaEditor.State.Highlighting
   alias Minga.LSP.Client
   alias Minga.LSP.SyncServer
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.LSP.SemanticTokens
   alias MingaEditor.UI.Highlight
 
@@ -53,7 +52,7 @@ defmodule MingaEditor.SemanticTokenSync do
       uri = "file://#{file_path}"
       ref = Client.request_semantic_tokens(client, uri)
       pending = Map.put(state.workspace.lsp_pending, ref, {:semantic_tokens, buf_pid})
-      EditorState.update_workspace(state, &SessionState.set_lsp_pending(&1, pending))
+      EditorState.set_lsp_pending(state, pending)
     else
       _ -> state
     end
@@ -130,9 +129,7 @@ defmodule MingaEditor.SemanticTokenSync do
 
       highlights = Map.put(state.workspace.highlight.highlights, buf_pid, hl)
 
-      EditorState.update_workspace(state, fn ws ->
-        SessionState.update_highlight(ws, &Highlighting.set_highlights(&1, highlights))
-      end)
+      EditorState.update_highlight(state, &Highlighting.set_highlights(&1, highlights))
     end
   end
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -36,6 +36,7 @@ defmodule MingaEditor.State do
   alias MingaEditor.KeystrokeHistory
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.Dired, as: DiredState
   alias MingaEditor.State.LSP, as: LSPState
   alias MingaEditor.State.Session, as: EditorSessionState
   alias MingaEditor.State.Buffers
@@ -219,6 +220,237 @@ defmodule MingaEditor.State do
   @spec update_workspace(t(), (SessionState.t() -> SessionState.t())) :: t()
   def update_workspace(%__MODULE__{workspace: ws} = state, fun) when is_function(fun, 1) do
     %{state | workspace: fun.(ws)}
+  end
+
+  @doc "Replaces the active workspace."
+  @spec set_workspace(t(), SessionState.t()) :: t()
+  def set_workspace(%__MODULE__{} = state, %SessionState{} = workspace) do
+    %{state | workspace: workspace}
+  end
+
+  @doc "Sets the active workspace viewport."
+  @spec set_viewport(t(), Viewport.t()) :: t()
+  def set_viewport(%__MODULE__{} = state, %Viewport{} = viewport) do
+    update_workspace(state, &SessionState.set_viewport(&1, viewport))
+  end
+
+  @doc "Sets the active workspace keymap scope."
+  @spec set_keymap_scope(t(), Minga.Keymap.Scope.scope_name()) :: t()
+  def set_keymap_scope(%__MODULE__{} = state, scope) do
+    update_workspace(state, &SessionState.set_keymap_scope(&1, scope))
+  end
+
+  @doc "Replaces the active workspace file-tree state."
+  @spec set_file_tree(t(), FileTreeState.t()) :: t()
+  def set_file_tree(%__MODULE__{} = state, %FileTreeState{} = file_tree) do
+    update_workspace(state, &SessionState.set_file_tree(&1, file_tree))
+  end
+
+  @doc "Updates the active workspace file-tree state."
+  @spec update_file_tree(t(), (FileTreeState.t() -> FileTreeState.t())) :: t()
+  def update_file_tree(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    update_workspace(state, fn workspace ->
+      SessionState.set_file_tree(workspace, fun.(workspace.file_tree))
+    end)
+  end
+
+  @doc "Replaces the active workspace buffer state."
+  @spec set_buffers(t(), Buffers.t()) :: t()
+  def set_buffers(%__MODULE__{} = state, %Buffers{} = buffers) do
+    update_workspace(state, &SessionState.set_buffers(&1, buffers))
+  end
+
+  @doc "Updates the active workspace buffer state."
+  @spec update_buffers(t(), (Buffers.t() -> Buffers.t())) :: t()
+  def update_buffers(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    update_workspace(state, fn workspace ->
+      SessionState.set_buffers(workspace, fun.(workspace.buffers))
+    end)
+  end
+
+  @doc "Replaces the active workspace window state."
+  @spec set_windows(t(), Windows.t()) :: t()
+  def set_windows(%__MODULE__{} = state, %Windows{} = windows) do
+    update_workspace(state, &SessionState.set_windows(&1, windows))
+  end
+
+  @doc "Updates the active workspace window state."
+  @spec update_windows(t(), (Windows.t() -> Windows.t())) :: t()
+  def update_windows(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    update_workspace(state, fn workspace ->
+      SessionState.set_windows(workspace, fun.(workspace.windows))
+    end)
+  end
+
+  @doc "Replaces the active workspace dired state."
+  @spec set_dired(t(), DiredState.t()) :: t()
+  def set_dired(%__MODULE__{} = state, %DiredState{} = dired) do
+    update_workspace(state, &SessionState.set_dired(&1, dired))
+  end
+
+  @doc "Updates the active workspace dired state."
+  @spec update_dired(t(), (DiredState.t() -> DiredState.t())) :: t()
+  def update_dired(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    update_workspace(state, fn workspace ->
+      SessionState.set_dired(workspace, fun.(workspace.dired))
+    end)
+  end
+
+  @doc "Replaces the active workspace mouse state."
+  @spec set_mouse(t(), Mouse.t()) :: t()
+  def set_mouse(%__MODULE__{} = state, %Mouse{} = mouse) do
+    update_workspace(state, &SessionState.set_mouse(&1, mouse))
+  end
+
+  @doc "Updates the active workspace mouse state."
+  @spec update_mouse(t(), (Mouse.t() -> Mouse.t())) :: t()
+  def update_mouse(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    update_workspace(state, fn workspace ->
+      SessionState.set_mouse(workspace, fun.(workspace.mouse))
+    end)
+  end
+
+  @doc "Replaces the active workspace search state."
+  @spec set_search(t(), Search.t()) :: t()
+  def set_search(%__MODULE__{} = state, %Search{} = search) do
+    update_workspace(state, &SessionState.set_search(&1, search))
+  end
+
+  @doc "Updates the active workspace search state."
+  @spec update_search(t(), (Search.t() -> Search.t())) :: t()
+  def update_search(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    update_workspace(state, fn workspace -> SessionState.update_search(workspace, fun) end)
+  end
+
+  @doc "Replaces the active workspace highlighting state."
+  @spec set_highlight(t(), Highlighting.t()) :: t()
+  def set_highlight(%__MODULE__{} = state, %Highlighting{} = highlight) do
+    update_workspace(state, &SessionState.set_highlight(&1, highlight))
+  end
+
+  @doc "Updates the active workspace highlighting state."
+  @spec update_highlight(t(), (Highlighting.t() -> Highlighting.t())) :: t()
+  def update_highlight(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    update_workspace(state, fn workspace -> SessionState.update_highlight(workspace, fun) end)
+  end
+
+  @doc "Replaces the active workspace editing state."
+  @spec set_editing(t(), VimState.t()) :: t()
+  def set_editing(%__MODULE__{} = state, %VimState{} = editing) do
+    update_workspace(state, &SessionState.set_editing(&1, editing))
+  end
+
+  @doc "Updates the active workspace editing state."
+  @spec update_editing(t(), (VimState.t() -> VimState.t())) :: t()
+  def update_editing(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    update_workspace(state, fn workspace -> SessionState.update_editing(workspace, fun) end)
+  end
+
+  @doc """
+  Replaces the current vim mode state without changing the mode.
+
+  Use this only for same-mode state updates where the replacement has the shape expected by the current mode. Use `transition_mode/3` when changing modes so `VimState` can keep `mode` and `mode_state` aligned.
+  """
+  @spec set_mode_state(t(), Mode.state()) :: t()
+  def set_mode_state(%__MODULE__{} = state, mode_state) do
+    update_editing(state, &VimState.set_mode_state(&1, mode_state))
+  end
+
+  @doc """
+  Updates the current vim mode state without changing the mode.
+
+  Use this only for same-mode state updates where the mapper preserves the state shape expected by the current mode. Use `transition_mode/3` when changing modes so `VimState` can keep `mode` and `mode_state` aligned.
+  """
+  @spec update_mode_state(t(), (Mode.state() -> Mode.state())) :: t()
+  def update_mode_state(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    update_editing(state, fn vim -> VimState.set_mode_state(vim, fun.(vim.mode_state)) end)
+  end
+
+  @doc "Replaces the vim register state."
+  @spec set_registers(t(), MingaEditor.State.Registers.t()) :: t()
+  def set_registers(%__MODULE__{} = state, %MingaEditor.State.Registers{} = registers) do
+    update_editing(state, &VimState.set_registers(&1, registers))
+  end
+
+  @doc "Replaces the vim marks map."
+  @spec set_marks(t(), VimState.marks()) :: t()
+  def set_marks(%__MODULE__{} = state, marks) when is_map(marks) do
+    update_editing(state, &VimState.set_marks(&1, marks))
+  end
+
+  @doc "Records the cursor position before a jump."
+  @spec set_last_jump_pos(t(), Buffer.position() | nil) :: t()
+  def set_last_jump_pos(%__MODULE__{} = state, pos) do
+    update_editing(state, &VimState.set_last_jump_pos(&1, pos))
+  end
+
+  @doc "Records the last find-char motion."
+  @spec set_last_find_char(t(), VimState.last_find_char()) :: t()
+  def set_last_find_char(%__MODULE__{} = state, find_char) do
+    update_editing(state, &VimState.set_last_find_char(&1, find_char))
+  end
+
+  @doc "Replaces the vim macro recorder."
+  @spec set_macro_recorder(t(), MingaEditor.MacroRecorder.t()) :: t()
+  def set_macro_recorder(%__MODULE__{} = state, recorder) do
+    update_editing(state, &VimState.set_macro_recorder(&1, recorder))
+  end
+
+  @doc "Replaces the vim change recorder."
+  @spec set_change_recorder(t(), MingaEditor.ChangeRecorder.t()) :: t()
+  def set_change_recorder(%__MODULE__{} = state, recorder) do
+    update_editing(state, &VimState.set_change_recorder(&1, recorder))
+  end
+
+  @doc "Replaces the active workspace document highlights."
+  @spec set_document_highlights(t(), [document_highlight()] | nil) :: t()
+  def set_document_highlights(%__MODULE__{} = state, highlights) do
+    update_workspace(state, &SessionState.set_document_highlights(&1, highlights))
+  end
+
+  @doc "Replaces the active workspace LSP pending request map."
+  @spec set_lsp_pending(t(), %{reference() => atom() | tuple()}) :: t()
+  def set_lsp_pending(%__MODULE__{} = state, pending) when is_map(pending) do
+    update_workspace(state, &SessionState.set_lsp_pending(&1, pending))
+  end
+
+  @doc "Adds or replaces an active workspace LSP pending request."
+  @spec put_lsp_pending(t(), reference(), atom() | tuple()) :: t()
+  def put_lsp_pending(%__MODULE__{} = state, ref, kind) when is_reference(ref) do
+    update_workspace(state, fn workspace ->
+      SessionState.set_lsp_pending(workspace, Map.put(workspace.lsp_pending, ref, kind))
+    end)
+  end
+
+  @doc "Deletes an active workspace LSP pending request."
+  @spec delete_lsp_pending(t(), reference()) :: t()
+  def delete_lsp_pending(%__MODULE__{} = state, ref) when is_reference(ref) do
+    update_workspace(state, fn workspace ->
+      SessionState.set_lsp_pending(workspace, Map.delete(workspace.lsp_pending, ref))
+    end)
+  end
+
+  @doc "Replaces the active workspace agent UI state."
+  @spec set_agent_ui(t(), UIState.t()) :: t()
+  def set_agent_ui(%__MODULE__{} = state, %UIState{} = agent_ui) do
+    update_workspace(state, &SessionState.set_agent_ui(&1, agent_ui))
+  end
+
+  @doc "Replaces the active workspace injection ranges map."
+  @spec set_injection_ranges(t(), %{pid() => [Minga.Language.Highlight.InjectionRange.t()]}) ::
+          t()
+  def set_injection_ranges(%__MODULE__{} = state, ranges) when is_map(ranges) do
+    update_workspace(state, &SessionState.set_injection_ranges(&1, ranges))
+  end
+
+  @doc "Updates the active workspace injection ranges map."
+  @spec update_injection_ranges(t(), (%{pid() => [Minga.Language.Highlight.InjectionRange.t()]} ->
+                                        %{pid() => [Minga.Language.Highlight.InjectionRange.t()]})) ::
+          t()
+  def update_injection_ranges(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    update_workspace(state, fn workspace ->
+      SessionState.set_injection_ranges(workspace, fun.(workspace.injection_ranges))
+    end)
   end
 
   # ── Render pipeline write-back ─────────────────────────────────────────────
@@ -764,6 +996,13 @@ defmodule MingaEditor.State do
   @spec update_window(t(), Window.id(), (Window.t() -> Window.t())) :: t()
   def update_window(%__MODULE__{} = state, id, fun) do
     update_workspace(state, &SessionState.update_window(&1, id, fun))
+  end
+
+  @doc "Updates every window showing a buffer via a mapper function."
+  @spec update_windows_for_buffer(t(), pid(), (Window.t() -> Window.t())) :: t()
+  def update_windows_for_buffer(%__MODULE__{} = state, buffer, fun)
+      when is_pid(buffer) and is_function(fun, 1) do
+    update_workspace(state, &SessionState.update_windows_for_buffer(&1, buffer, fun))
   end
 
   @doc """

--- a/lib/minga_editor/state/agent_access.ex
+++ b/lib/minga_editor/state/agent_access.ex
@@ -201,8 +201,8 @@ defmodule MingaEditor.State.AgentAccess do
 
   @spec set_workspace(EditorState.t() | map(), WorkspaceState.t() | map()) ::
           EditorState.t() | map()
-  defp set_workspace(%EditorState{} = state, workspace) do
-    EditorState.update_workspace(state, fn _workspace -> workspace end)
+  defp set_workspace(%EditorState{} = state, %WorkspaceState{} = workspace) do
+    EditorState.set_workspace(state, workspace)
   end
 
   defp set_workspace(%{workspace: _workspace} = state, workspace) do

--- a/lib/minga_editor/ui/picker/buffer_source.ex
+++ b/lib/minga_editor/ui/picker/buffer_source.ex
@@ -17,7 +17,6 @@ defmodule MingaEditor.UI.Picker.BufferSource do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.UI.Devicon
-  alias MingaEditor.Session.State, as: SessionState
 
   @impl true
   @spec title() :: String.t()
@@ -130,10 +129,7 @@ defmodule MingaEditor.UI.Picker.BufferSource do
         new_active = min(bs.active_index, length(new_buffers) - 1)
         new_bs = %Buffers{bs | list: new_buffers}
 
-        EditorState.update_workspace(
-          state,
-          &SessionState.set_buffers(&1, Buffers.switch_to(new_bs, new_active))
-        )
+        EditorState.set_buffers(state, Buffers.switch_to(new_bs, new_active))
         |> EditorState.sync_active_window_buffer()
     end
   end

--- a/lib/minga_editor/ui/picker/location_source.ex
+++ b/lib/minga_editor/ui/picker/location_source.ex
@@ -23,10 +23,8 @@ defmodule MingaEditor.UI.Picker.LocationSource do
   alias Minga.Buffer
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.VimState
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
-  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.UI.Picker.Source
 
   @impl true
@@ -129,9 +127,7 @@ defmodule MingaEditor.UI.Picker.LocationSource do
   defp set_jump_mark(%{workspace: %{buffers: %{active: buf}}} = state) when is_pid(buf) do
     pos = Buffer.cursor(buf)
 
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_last_jump_pos(&1, pos))
-    end)
+    EditorState.set_last_jump_pos(state, pos)
   end
 
   defp set_jump_mark(state), do: state

--- a/lib/minga_editor/ui/picker/workspace_symbol_source.ex
+++ b/lib/minga_editor/ui/picker/workspace_symbol_source.ex
@@ -15,9 +15,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceSymbolSource do
   alias Minga.Buffer
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.VimState
   alias Minga.LSP.Client
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.LSP.SyncServer
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
@@ -120,9 +118,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceSymbolSource do
   defp set_jump_mark(%{workspace: %{buffers: %{active: buf}}} = state) when is_pid(buf) do
     pos = Buffer.cursor(buf)
 
-    EditorState.update_workspace(state, fn ws ->
-      SessionState.update_editing(ws, &VimState.set_last_jump_pos(&1, pos))
-    end)
+    EditorState.set_last_jump_pos(state, pos)
   end
 
   defp set_jump_mark(state), do: state

--- a/lib/minga_editor/ui/popup/lifecycle.ex
+++ b/lib/minga_editor/ui/popup/lifecycle.ex
@@ -43,7 +43,6 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   alias MingaEditor.UI.Popup.Active, as: PopupActive
   alias Minga.Popup.Registry, as: PopupRegistry
   alias Minga.Popup.Rule
-  alias MingaEditor.Session.State, as: SessionState
 
   @type state :: EditorState.t()
 
@@ -334,12 +333,12 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   @spec update_popup_windows(state(), Windows.t(), Window.id(), boolean()) :: state()
   defp update_popup_windows(state, windows, next_id, true) do
     state
-    |> EditorState.update_workspace(&SessionState.set_windows(&1, windows))
+    |> EditorState.set_windows(windows)
     |> EditorState.focus_window(next_id)
   end
 
   defp update_popup_windows(state, windows, _next_id, false) do
-    EditorState.update_workspace(state, &SessionState.set_windows(&1, windows))
+    EditorState.set_windows(state, windows)
   end
 
   @spec do_close(state(), Window.id(), PopupActive.t()) :: state()
@@ -367,7 +366,7 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
     # delete-window in Emacs). We used to restore a full tree snapshot,
     # but that clobbers any other popups that were opened after this one.
     new_windows = remove_popup_window(ws, window_id, meta)
-    state = EditorState.update_workspace(state, &SessionState.set_windows(&1, new_windows))
+    state = EditorState.set_windows(state, new_windows)
 
     Layout.invalidate(state)
   end

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -129,16 +129,14 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
     state = base_state(agent_buffer: agent_buf)
     windows = agent_windows(agent_buf)
 
-    EditorState.update_workspace(state, fn workspace ->
-      workspace
-      |> WorkspaceState.set_buffers(%Buffers{
-        active: agent_buf,
-        list: [agent_buf],
-        active_index: 0
-      })
-      |> WorkspaceState.set_windows(windows)
-      |> WorkspaceState.set_agent_ui(UIState.new())
-    end)
+    state
+    |> EditorState.set_buffers(%Buffers{
+      active: agent_buf,
+      list: [agent_buf],
+      active_index: 0
+    })
+    |> EditorState.set_windows(windows)
+    |> EditorState.set_agent_ui(UIState.new())
   end
 
   defp agent_windows(agent_buf) when is_pid(agent_buf) do

--- a/test/minga_editor/commands/buffer_management_test.exs
+++ b/test/minga_editor/commands/buffer_management_test.exs
@@ -19,7 +19,6 @@ defmodule MingaEditor.Commands.BufferManagementTest do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace, as: WorkspaceModel
-  alias MingaEditor.Session.State, as: SessionState
 
   @sync_timeout 30_000
   @ctrl 0x02
@@ -499,7 +498,7 @@ defmodule MingaEditor.Commands.BufferManagementTest do
 
     state
     |> EditorState.set_tab_bar(tb)
-    |> EditorState.update_workspace(&SessionState.set_keymap_scope(&1, :agent))
+    |> EditorState.set_keymap_scope(:agent)
   end
 
   defp refute_process_down(pid) do

--- a/test/minga_editor/commands/file_tree_editing_test.exs
+++ b/test/minga_editor/commands/file_tree_editing_test.exs
@@ -291,13 +291,11 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
       state =
         dir
         |> make_state(events_registry)
-        |> EditorState.update_workspace(
-          &SessionState.set_buffers(&1, %Buffers{
-            active: buffer,
-            list: [buffer],
-            active_index: 0
-          })
-        )
+        |> EditorState.set_buffers(%Buffers{
+          active: buffer,
+          list: [buffer],
+          active_index: 0
+        })
         |> select_entry("target.txt")
         |> Commands.FileTree.rename()
         |> replace_editing_text("renamed.txt")
@@ -471,7 +469,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
   defp replace_editing_text(%EditorState{} = state, text) when is_binary(text) do
     ft = FileTreeState.update_editing_text(state.workspace.file_tree, text)
-    EditorState.update_workspace(state, &SessionState.set_file_tree(&1, ft))
+    EditorState.set_file_tree(state, ft)
   end
 
   defp select_entry(%EditorState{} = state, name) when is_binary(name) do
@@ -485,6 +483,6 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
   defp replace_tree(%EditorState{} = state, %FileTree{} = tree) do
     ft = FileTreeState.replace_tree(state.workspace.file_tree, tree)
-    EditorState.update_workspace(state, &SessionState.set_file_tree(&1, ft))
+    EditorState.set_file_tree(state, ft)
   end
 end

--- a/test/minga_editor/commands/file_tree_neo_bindings_test.exs
+++ b/test/minga_editor/commands/file_tree_neo_bindings_test.exs
@@ -471,7 +471,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
   defp expand_path(state, path) do
     tree = FileTree.expand_path(state.workspace.file_tree.tree, path)
     file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
-    EditorState.update_workspace(state, &SessionState.set_file_tree(&1, file_tree))
+    EditorState.set_file_tree(state, file_tree)
   end
 
   defp select_entry(state, name) do
@@ -481,6 +481,6 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
     tree = FileTree.select(state.workspace.file_tree.tree, index)
     file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
-    EditorState.update_workspace(state, &SessionState.set_file_tree(&1, file_tree))
+    EditorState.set_file_tree(state, file_tree)
   end
 end

--- a/test/minga_editor/file_tree/rows_test.exs
+++ b/test/minga_editor/file_tree/rows_test.exs
@@ -12,7 +12,6 @@ defmodule MingaEditor.FileTree.RowsTest do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
-  alias MingaEditor.Session.State, as: SessionState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -318,12 +317,12 @@ defmodule MingaEditor.FileTree.RowsTest do
     tree = FileTree.new(root)
     file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
 
-    EditorState.update_workspace(base_state(), &SessionState.set_file_tree(&1, file_tree))
+    EditorState.set_file_tree(base_state(), file_tree)
   end
 
   defp put_buffers(state, [active | _rest] = buffers) do
     buffer_state = %Buffers{active: active, list: buffers, active_index: 0}
-    EditorState.update_workspace(state, &%{&1 | buffers: buffer_state})
+    EditorState.set_buffers(state, buffer_state)
   end
 
   defp active_row_name(state) do

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -544,11 +544,11 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
     tree = FileTree.new(root)
     file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
 
-    EditorState.update_workspace(base_state(), &SessionState.set_file_tree(&1, file_tree))
+    EditorState.set_file_tree(base_state(), file_tree)
   end
 
   defp put_active_buffer(state, buffer) do
     buffers = %Buffers{active: buffer, list: [buffer], active_index: 0}
-    EditorState.update_workspace(state, &%{&1 | buffers: buffers})
+    EditorState.set_buffers(state, buffers)
   end
 end

--- a/test/minga_editor/handlers/highlight_handler_test.exs
+++ b/test/minga_editor/handlers/highlight_handler_test.exs
@@ -9,7 +9,6 @@ defmodule MingaEditor.Handlers.HighlightHandlerTest do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.UI.Highlight
   alias MingaEditor.Window
-  alias MingaEditor.Session.State, as: SessionState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -324,10 +323,8 @@ defmodule MingaEditor.Handlers.HighlightHandlerTest do
     win_id = state.workspace.windows.active
 
     state =
-      EditorState.update_workspace(state, fn ws ->
-        SessionState.update_window(ws, win_id, fn window ->
-          Window.set_document_symbols(window, stale_symbols)
-        end)
+      EditorState.update_window(state, win_id, fn window ->
+        Window.set_document_symbols(window, stale_symbols)
       end)
 
     second_window = Window.new(2, other_buf, 24, 80)

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -9,7 +9,6 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
   alias Minga.Editing.Completion
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.Handlers.LspEventHandler
-  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.SignatureHelp
@@ -151,10 +150,8 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       register_lsp_client(buffer, client)
 
       state =
-        EditorState.update_workspace(state, fn workspace ->
-          SessionState.update_highlight(workspace, fn highlighting ->
-            Highlighting.put_highlight(highlighting, buffer, Highlight.new())
-          end)
+        EditorState.update_highlight(state, fn highlighting ->
+          Highlighting.put_highlight(highlighting, buffer, Highlight.new())
         end)
 
       ref = make_ref()
@@ -206,7 +203,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
   end
 
   defp put_lsp_pending(state, ref, kind) do
-    EditorState.update_workspace(state, &SessionState.set_lsp_pending(&1, %{ref => kind}))
+    EditorState.put_lsp_pending(state, ref, kind)
   end
 
   defp base_state do

--- a/test/minga_editor/input/file_tree_editing_input_test.exs
+++ b/test/minga_editor/input/file_tree_editing_input_test.exs
@@ -151,10 +151,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
 
       state =
-        EditorState.update_workspace(
-          state,
-          &MingaEditor.Session.State.set_file_tree(&1, file_tree)
-        )
+        EditorState.set_file_tree(state, file_tree)
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
       assert state.workspace.file_tree.filtering == true
@@ -179,10 +176,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       file_tree = FileTreeState.start_filtering(state.workspace.file_tree)
 
       state =
-        EditorState.update_workspace(
-          state,
-          &MingaEditor.Session.State.set_file_tree(&1, file_tree)
-        )
+        EditorState.set_file_tree(state, file_tree)
 
       {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
       assert state.workspace.file_tree.filtering == false
@@ -234,10 +228,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
     tree = FileTree.select(state.workspace.file_tree.tree, index)
     file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
 
-    EditorState.update_workspace(
-      state,
-      &MingaEditor.Session.State.set_file_tree(&1, file_tree)
-    )
+    EditorState.set_file_tree(state, file_tree)
   end
 
   describe "key swallowing (no leaking to mode FSM)" do

--- a/test/minga_editor/input/git_status_input_test.exs
+++ b/test/minga_editor/input/git_status_input_test.exs
@@ -68,7 +68,7 @@ defmodule MingaEditor.Input.GitStatusInputTest do
 
   test "passthrough for non-git-status scope" do
     state = make_state_with_git_panel()
-    state = EditorState.update_workspace(state, fn ws -> %{ws | keymap_scope: :editor} end)
+    state = EditorState.set_keymap_scope(state, :editor)
 
     {:passthrough, _state} = GitStatus.handle_key(state, @j, @none)
   end

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -23,7 +23,6 @@ defmodule MingaEditor.MouseTest do
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
   alias MingaEditor.Session.ChromeState
-  alias MingaEditor.Session.State, as: SessionState
 
   @content_row 1
   @ctrl 0x02
@@ -342,10 +341,7 @@ defmodule MingaEditor.MouseTest do
         Enum.find(layout.window_layouts, fn {id, _layout} -> id != origin_id end)
 
       other_state =
-        EditorState.update_workspace(
-          state,
-          &SessionState.set_windows(&1, Windows.set_active(&1.windows, other_id))
-        )
+        EditorState.update_windows(state, &Windows.set_active(&1, other_id))
 
       {origin_press_row, origin_press_col} = buffer_screen_pos(state, 0, 0)
       {other_drag_row, other_drag_col} = buffer_screen_pos(other_state, 0, 0)
@@ -550,6 +546,7 @@ defmodule MingaEditor.MouseTest do
     id = :erlang.unique_integer([:positive])
     events_registry = :"#{__MODULE__}.Events.#{id}"
     project_root = Path.join(System.tmp_dir!(), "minga-mouse-#{id}")
+    File.rm_rf!(project_root)
     File.mkdir_p!(project_root)
     start_supervised!({Minga.Events, name: events_registry}, id: {:events, id})
 
@@ -652,7 +649,7 @@ defmodule MingaEditor.MouseTest do
 
   defp set_window_tree(state, tree) do
     windows = Windows.set_tree(state.workspace.windows, tree)
-    EditorState.update_workspace(state, &SessionState.set_windows(&1, windows))
+    EditorState.set_windows(state, windows)
   end
 
   defp set_active_fold_ranges(state, ranges) do

--- a/test/minga_editor/state/agent_workspace_lifecycle_test.exs
+++ b/test/minga_editor/state/agent_workspace_lifecycle_test.exs
@@ -46,7 +46,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     state =
       state
       |> EditorState.set_tab_bar(tab_bar)
-      |> EditorState.update_workspace(&MingaEditor.Session.State.set_agent_ui(&1, ui_two))
+      |> EditorState.set_agent_ui(ui_two)
 
     state = EditorState.switch_tab(state, 1)
 
@@ -67,7 +67,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     state =
       state
       |> EditorState.set_tab_bar(tab_bar)
-      |> EditorState.update_workspace(&MingaEditor.Session.State.set_agent_ui(&1, ui_two))
+      |> EditorState.set_agent_ui(ui_two)
 
     state = MingaEditor.Commands.Workspace.workspace_close(state)
 
@@ -113,7 +113,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     state =
       state
       |> EditorState.set_tab_bar(tab_bar)
-      |> EditorState.update_workspace(&MingaEditor.Session.State.set_agent_ui(&1, ui_one))
+      |> EditorState.set_agent_ui(ui_one)
 
     state = EditorState.switch_tab(state, 2)
 
@@ -376,7 +376,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     state =
       state
       |> EditorState.set_tab_bar(tab_bar)
-      |> EditorState.update_workspace(&MingaEditor.Session.State.set_agent_ui(&1, ui))
+      |> EditorState.set_agent_ui(ui)
 
     {state, workspace.id, file_ref}
   end

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -342,9 +342,8 @@ defmodule MingaEditor.State.BufferLifecycleTest do
   end
 
   defp with_buffer_pool(state, buffers) do
-    EditorState.update_workspace(state, fn workspace ->
-      %Buffers{} = current = workspace.buffers
-      %{workspace | buffers: %{current | list: buffers}}
+    EditorState.update_buffers(state, fn %Buffers{} = current ->
+      %{current | list: buffers}
     end)
   end
 

--- a/test/minga_editor/state/shell_callbacks_test.exs
+++ b/test/minga_editor/state/shell_callbacks_test.exs
@@ -125,8 +125,8 @@ defmodule MingaEditor.State.ShellCallbacksTest do
       # Manually add buf2 to the buffer list without triggering tab creation
       # (EditorState.add_buffer from an agent tab would create a new file tab)
       state =
-        EditorState.update_workspace(state, fn workspace ->
-          %{workspace | buffers: %{workspace.buffers | list: [agent_buf, buf2]}}
+        EditorState.update_buffers(state, fn buffers ->
+          %{buffers | list: [agent_buf, buf2]}
         end)
 
       new_state = EditorState.switch_buffer(state, 1)

--- a/test/minga_editor/state/workspace_convenience_test.exs
+++ b/test/minga_editor/state/workspace_convenience_test.exs
@@ -1,0 +1,63 @@
+defmodule MingaEditor.State.WorkspaceConvenienceTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Mode
+  alias Minga.Mode.State, as: ModeState
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Search
+  alias MingaEditor.Viewport
+
+  defp editor_state do
+    %EditorState{
+      port_manager: nil,
+      workspace: %SessionState{viewport: Viewport.new(24, 80)}
+    }
+  end
+
+  test "workspace convenience setters route through the workspace owner" do
+    buffers = %Buffers{list: [self()], active: self(), active_index: 0}
+    search = Search.record(%Search{}, "needle", :forward)
+
+    state =
+      editor_state()
+      |> EditorState.set_keymap_scope(:file_tree)
+      |> EditorState.set_buffers(buffers)
+      |> EditorState.set_search(search)
+
+    assert state.workspace.keymap_scope == :file_tree
+    assert state.workspace.buffers == buffers
+    assert state.workspace.search == search
+  end
+
+  test "workspace convenience updaters apply mappers to the nested struct" do
+    state =
+      editor_state()
+      |> EditorState.update_buffers(&Buffers.add(&1, self()))
+      |> EditorState.update_search(&Search.record(&1, "needle", :forward))
+
+    assert state.workspace.buffers.active == self()
+    assert state.workspace.search.last_pattern == "needle"
+  end
+
+  test "vim convenience helpers update nested editing state" do
+    mode_state = %ModeState{pending: :replace}
+
+    state =
+      editor_state()
+      |> EditorState.set_mode_state(mode_state)
+      |> EditorState.update_mode_state(&%{&1 | pending: {:find, :f}})
+      |> EditorState.set_last_jump_pos({2, 4})
+
+    assert state.workspace.editing.mode_state.pending == {:find, :f}
+    assert state.workspace.editing.last_jump_pos == {2, 4}
+    assert state.workspace.editing.mode == :normal
+  end
+
+  test "transition_mode remains available for mode changes" do
+    state = EditorState.transition_mode(editor_state(), :insert, Mode.initial_state())
+
+    assert state.workspace.editing.mode == :insert
+  end
+end

--- a/test/minga_editor/ui/picker/buffer_source_test.exs
+++ b/test/minga_editor/ui/picker/buffer_source_test.exs
@@ -16,7 +16,6 @@ defmodule MingaEditor.UI.Picker.BufferSourceTest do
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Theme
-  alias MingaEditor.Session.State, as: SessionState
 
   defp start_buffer(opts) do
     {:ok, pid} = BufferProcess.start_link(opts)
@@ -61,7 +60,7 @@ defmodule MingaEditor.UI.Picker.BufferSourceTest do
         Buffers.add_background(acc, pid)
       end)
 
-    EditorState.update_workspace(state, &SessionState.set_buffers(&1, buffers))
+    EditorState.set_buffers(state, buffers)
   end
 
   describe "special?/1" do

--- a/test/support/minga_editor/command_state_helpers.ex
+++ b/test/support/minga_editor/command_state_helpers.ex
@@ -72,10 +72,6 @@ defmodule MingaEditor.CommandStateHelpers do
 
   @spec update_registers(state(), (Registers.t() -> Registers.t())) :: state()
   def update_registers(%EditorState{} = state, fun) when is_function(fun, 1) do
-    EditorState.update_workspace(state, fn workspace ->
-      SessionState.update_editing(workspace, fn vim ->
-        VimState.set_registers(vim, fun.(vim.reg))
-      end)
-    end)
+    EditorState.set_registers(state, fun.(state.workspace.editing.reg))
   end
 end


### PR DESCRIPTION
# TL;DR
Adds `EditorState` convenience helpers for common workspace and vim-state updates, then migrates the existing nested `update_workspace` call sites to use those intent-focused helpers.

Closes #1665

## Context
Issue #1665 called out that common editor-state updates were buried behind repeated nested `EditorState.update_workspace` and `SessionState` closures. This keeps `update_workspace/2` available for uncommon updates while giving the frequent cases direct names.

## Changes
- Added `EditorState` setters and updaters for common workspace fields, including buffers, windows, file tree, dired, search, highlighting, mouse, LSP pending requests, document highlights, agent UI, and injection ranges.
- Added vim-specific convenience helpers such as `set_mode_state/2`, `update_mode_state/2`, register updates, marks, jump position, find-char state, and recorders.
- Migrated existing `EditorState.update_workspace` call sites under `lib/`, `test/`, and `test/support/` to the new helpers.
- Added focused coverage for the new convenience layer in `test/minga_editor/state/workspace_convenience_test.exs`.
- Tightened a few mouse tests to derive the active content row from layout instead of assuming a fixed row.

## Verification
- `mix compile --warnings-as-errors` ✅
- `mix test.debug test/minga_editor/state/workspace_convenience_test.exs` ✅
- `mix test.llm test/minga_editor/state/workspace_convenience_test.exs test/minga_editor/commands/buffer_management_test.exs test/minga_editor/file_tree/rows_test.exs test/minga_editor/handlers/highlight_handler_test.exs test/minga_editor/ui/picker/buffer_source_test.exs` ✅
- `mix test.llm test/minga_editor/mouse_test.exs` ✅
- `make lint` ✅
- `mix test.llm` ✅, 52 doctests, 99 properties, 8106 tests, 0 failures, 5 skipped, 198 excluded
- Final reviewer gate ✅

## Acceptance Criteria Addressed
- Audit the `update_workspace` call sites to identify common patterns ✅
- Add convenience functions for common state updates ✅
- Migrate existing call sites to use the convenience functions ✅
- Preserve behavior ✅
- Existing tests pass and lint is clean ✅
- Keep `update_workspace/2` available for uncommon or complex updates ✅
