### PR TITLE
fix(release): prepare Homebrew tap release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ env:
   ELIXIR_VERSION: "1.19.5"
   OTP_VERSION: "28.4.1"
   ZIG_VERSION: "0.16.0"
+  BURRITO_ZIG_VERSION: "0.15.2"
 
 jobs:
   # ── Gate: validate tag matches mix.exs version ─────────────────────────
@@ -147,7 +148,16 @@ jobs:
           restore-keys: release-deps-${{ runner.os }}-${{ runner.arch }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
 
       - run: mix deps.get --only prod
-      - run: mix release minga
+      - name: Compile with project Zig
+        run: mix compile
+
+      - name: Switch to Burrito Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.BURRITO_ZIG_VERSION }}
+
+      - name: Build Burrito release
+        run: mix release minga --no-compile
 
       - name: Check release contents
         run: scripts/check-release-contents _build/prod/rel/minga
@@ -493,7 +503,7 @@ jobs:
           import os, textwrap
           v = os.environ["VERSION"].lstrip("v")
           dmg_sha = os.environ["DMG_SHA"]
-          cask = f'''cask "minga" do
+          cask = f'''cask "minga-mac" do
             version "{v}"
             sha256 "{dmg_sha}"
 
@@ -508,13 +518,16 @@ jobs:
             zap trash: [
               "~/Library/Application Support/minga",
               "~/Library/Preferences/com.minga.editor.plist",
+              "~/Library/Preferences/com.minga.minga-mac.plist",
               "~/Library/Caches/com.minga.editor",
+              "~/Library/Caches/com.minga.minga-mac",
             ]
           end
           '''
-          with open("homebrew-tap/Casks/minga.rb", "w") as f:
+          with open("homebrew-tap/Casks/minga-mac.rb", "w") as f:
               f.write(textwrap.dedent(cask).lstrip())
           PYEOF
+            rm -f homebrew-tap/Casks/minga.rb
           else
             echo "No .dmg found in release, skipping cask update"
           fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,11 +6,16 @@ This document covers how to cut a release and what infrastructure supports it.
 
 ### GitHub Secrets
 
-The release workflow requires one secret configured in the repo's Settings > Secrets and variables > Actions:
+The release workflow requires these secrets in the repo's Settings > Secrets and variables > Actions:
 
-- **`HOMEBREW_TAP_TOKEN`**: A GitHub Personal Access Token (classic) with `repo` scope, scoped to the `jsmestad/homebrew-minga` repository. The release workflow uses this to push formula updates to the Homebrew tap after a stable release is published.
+- **`HOMEBREW_TAP_TOKEN`**: A GitHub Personal Access Token (classic) with `repo` scope, scoped to the `jsmestad/homebrew-minga` repository. The release workflow uses this to push formula and cask updates to the Homebrew tap after a stable release is published.
+- **`APPLE_CERTIFICATE_P12`**: Base64-encoded Developer ID Application certificate used to sign `Minga.app`.
+- **`APPLE_CERTIFICATE_PASSWORD`**: Password for the Developer ID certificate.
+- **`APPLE_ID`**: Apple ID used for notarization.
+- **`APPLE_APP_PASSWORD`**: App-specific password for the Apple ID.
+- **`APPLE_TEAM_ID`**: Apple Developer Team ID used for notarization.
 
-The built-in `GITHUB_TOKEN` handles everything else (creating the GitHub Release, updating `CHANGELOG.md`).
+The built-in `GITHUB_TOKEN` handles creating the GitHub Release and updating `CHANGELOG.md`.
 
 ## Cutting a Release
 
@@ -27,7 +32,7 @@ The built-in `GITHUB_TOKEN` handles everything else (creating the GitHub Release
 
 Tags with a hyphen (e.g., `v0.1.0-rc.1`) are treated as pre-releases:
 - The GitHub Release is marked as a pre-release.
-- The Homebrew tap is **not** updated (only stable releases update the formula).
+- The Homebrew tap is **not** updated (only stable releases update the formula and cask).
 
 ### What Gets Built
 
@@ -40,7 +45,7 @@ Tags with a hyphen (e.g., `v0.1.0-rc.1`) are treated as pre-releases:
 
 ### Homebrew Cask (macOS GUI)
 
-The release workflow also generates a Homebrew cask for the macOS GUI app, but only if a `Minga.dmg` artifact exists in the release. Until the GUI ships `.dmg` builds, the cask step is skipped automatically.
+The release workflow also generates the `minga-mac` Homebrew cask for the macOS GUI app, but only if a `Minga.dmg` artifact exists in the release. Until the GUI ships `.dmg` builds, the cask step is skipped automatically.
 
 ## Verifying a Release
 
@@ -55,8 +60,11 @@ chmod +x minga_macos_aarch64
 # Or install via Homebrew (stable releases only)
 brew install jsmestad/minga/minga
 minga --version
+
+# Install the macOS app cask
+brew install --cask jsmestad/minga/minga-mac
 ```
 
 ## Burrito
 
-Minga uses [Burrito](https://github.com/burrito-elixir/burrito) to package the Elixir release as a self-extracting binary. The Burrito dependency is pinned to a specific commit SHA in `mix.exs` for reproducibility. When upgrading Burrito, update both the `ref:` in `mix.exs` and run `mix deps.get` to update `mix.lock`.
+Minga uses [Burrito](https://github.com/burrito-elixir/burrito) to package the Elixir release as a self-extracting binary. Burrito currently requires Zig 0.15.2 for the wrap step, while Minga's Zig renderer uses the project Zig version from `.tool-versions`. The release workflow compiles the project with `ZIG_VERSION`, switches to `BURRITO_ZIG_VERSION`, then runs `mix release minga --no-compile` so Burrito can wrap the already-compiled release. When upgrading Burrito, check `Burrito.get_versions/0`, update `BURRITO_ZIG_VERSION` if needed, and run `mix deps.get` to update `mix.lock`.


### PR DESCRIPTION
# TL;DR
This fixes the two release blockers found before tagging `v0.1.0`: Burrito now wraps with its required Zig version, and the Homebrew cask update preserves the existing `minga-mac` token.

## Context
The release workflow was using Zig 0.16.0 for every step, but Burrito currently requires Zig 0.15.2 during wrapping. The tap also already has `Casks/minga-mac.rb`, while the workflow was going to generate `Casks/minga.rb`.

## Changes
- Added `BURRITO_ZIG_VERSION` and changed the Burrito binary build to compile with the project Zig version first, then switch to Burrito's Zig version for `mix release minga --no-compile`.
- Updated the Homebrew cask generator to write `Casks/minga-mac.rb` with `cask "minga-mac"`.
- Removed stale `Casks/minga.rb` during tap updates if it exists.
- Updated `docs/RELEASING.md` with the actual required secrets, cask install command, and the two-Zig-version release behavior.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- `mix help release | grep -n -- '--no-compile'`
- `git diff --check`
- Simulated the generated `minga-mac` cask content with placeholder values.
- Final reviewer gate: PASS.

## Acceptance Criteria Addressed
- Release workflow no longer runs Burrito wrapping under Zig 0.16.0. ✅
- Homebrew cask update matches the existing tap cask token. ✅
- Release documentation matches the workflow behavior. ✅
