### PR TITLE
fix(release): allow base-version prerelease tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
   BURRITO_ZIG_VERSION: "0.15.2"
 
 jobs:
-  # ── Gate: validate tag matches mix.exs version ─────────────────────────
+  # ── Gate: validate tag matches mix.exs release version ────────────────
   validate:
     name: Validate Version
     runs-on: ubuntu-latest
@@ -24,18 +24,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check tag matches mix.exs version
+      - name: Check tag matches mix.exs release version
         id: check
         run: |
           # Extract version from mix.exs @version attribute
           mix_version=$(grep -oP '@version\s+"\K[^"]+' mix.exs)
           tag_version="${GITHUB_REF_NAME#v}"
+          release_version="${tag_version%%-*}"
 
-          echo "mix.exs version: $mix_version"
-          echo "Tag version:     $tag_version"
+          echo "mix.exs version:    $mix_version"
+          echo "Tag version:        $tag_version"
+          echo "Release version:    $release_version"
 
-          if [ "$mix_version" != "$tag_version" ]; then
-            echo "::error::Version mismatch! mix.exs has '$mix_version' but tag is 'v$tag_version'"
+          if [ "$mix_version" != "$release_version" ]; then
+            echo "::error::Version mismatch! mix.exs has '$mix_version' but tag '$GITHUB_REF_NAME' targets release '$release_version'"
             exit 1
           fi
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -26,11 +26,12 @@ The built-in `GITHUB_TOKEN` handles creating the GitHub Release and updating `CH
    git tag v0.1.0
    git push origin v0.1.0
    ```
-4. The release workflow validates the tag matches `mix.exs`, runs CI, builds binaries for all four platforms, smoke-tests each one, creates a GitHub Release with checksums, updates the Homebrew tap, and prepends the changelog.
+4. The release workflow validates the tag targets the version in `mix.exs`, runs CI, builds binaries for all four platforms, smoke-tests each one, creates a GitHub Release with checksums, updates the Homebrew tap, and prepends the changelog.
 
 ### Pre-releases
 
-Tags with a hyphen (e.g., `v0.1.0-rc.1`) are treated as pre-releases:
+Tags with a hyphen (e.g., `v0.1.0-alpha.1` or `v0.1.0-rc.1`) are treated as pre-releases:
+- The tag's base version must match `mix.exs`. For example, `mix.exs` can stay at `0.1.0` while you cut `v0.1.0-alpha.1` and `v0.1.0-rc.1`.
 - The GitHub Release is marked as a pre-release.
 - The Homebrew tap is **not** updated (only stable releases update the formula and cask).
 


### PR DESCRIPTION
# TL;DR
Prerelease tags can now test the release pipeline without changing `mix.exs` away from the stable base version. `v0.1.0-alpha.1` and `v0.1.0-rc.1` are accepted when `mix.exs` is `0.1.0`, while mismatched bases still fail.

## Context
We want to test the release workflow with an alpha before cutting the Homebrew-updating stable release. The old validation required the full tag string to equal `mix.exs`, which meant `v0.1.0-alpha.1` would fail while `mix.exs` stayed at `0.1.0`.

## Changes
- Compare `mix.exs` to the tag's base release version by stripping any prerelease suffix after `-`.
- Keep prerelease detection unchanged so alpha and RC tags still create GitHub prereleases and skip the Homebrew tap update.
- Document that prerelease tags can use the stable base version from `mix.exs`.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- Shell simulation accepted `0.1.0`, `0.1.0-alpha.1`, and `0.1.0-rc.1` for `mix.exs` version `0.1.0`.
- Shell simulation rejected `0.2.0-alpha.1` for `mix.exs` version `0.1.0`.
- `git diff --check`
- Final reviewer gate: PASS.

## Acceptance Criteria Addressed
- Alpha and RC tags can test the release pipeline without changing `mix.exs`. ✅
- Mismatched release bases still fail validation. ✅
- Docs explain the prerelease behavior. ✅
