### PR TITLE
fix(macos): remove picker key hint bar

### DIFF
--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -42,11 +42,6 @@ struct PickerOverlay: View {
                         let listHeight = min(CGFloat(state.items.count) * itemHeight, max(geo.size.height * 0.5, 200))
                         resultsList(maxListHeight: listHeight)
 
-                        if !state.items.isEmpty {
-                            Divider()
-                                .overlay(theme.popupBorder.opacity(0.3))
-                            bottomBar
-                        }
                     }
                     .frame(width: panelWidth)
                     .background(
@@ -102,6 +97,19 @@ struct PickerOverlay: View {
             }
 
             Spacer()
+
+            let markedCount = state.items.filter { $0.isMarked }.count
+            if markedCount > 0 {
+                Text("\(markedCount) selected")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(theme.accent)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(theme.accent.opacity(0.14))
+                    )
+            }
 
             if state.totalCount > 0 {
                 Text("\(state.filteredCount)/\(state.totalCount)")
@@ -223,49 +231,6 @@ struct PickerOverlay: View {
             )
             Text(attributed)
                 .lineLimit(1)
-        }
-    }
-
-    // MARK: - Bottom bar
-
-    @ViewBuilder
-    private var bottomBar: some View {
-        HStack(spacing: 12) {
-            let markedCount = state.items.filter { $0.isMarked }.count
-            if markedCount > 0 {
-                Text("\(markedCount) selected")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(theme.accent)
-            }
-
-            Spacer()
-
-            Group {
-                keyHint("↑↓", label: "navigate")
-                keyHint("⏎", label: "open")
-                keyHint("⇥", label: "mark")
-                keyHint("⎋", label: "close")
-            }
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 5)
-    }
-
-    @ViewBuilder
-    private func keyHint(_ key: String, label: String) -> some View {
-        HStack(spacing: 3) {
-            Text(key)
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundStyle(theme.popupFg.opacity(0.45))
-                .padding(.horizontal, 4)
-                .padding(.vertical, 1)
-                .background(
-                    RoundedRectangle(cornerRadius: 3)
-                        .fill(theme.popupFg.opacity(0.08))
-                )
-            Text(label)
-                .font(.system(size: 10))
-                .foregroundStyle(theme.popupFg.opacity(0.3))
         }
     }
 


### PR DESCRIPTION
# TL;DR
The macOS picker no longer spends a row on permanent key hints. Marked-item counts still stay visible in the picker header when multi-select is active.

Closes #1724

## Context
Issue #1724 trims visual weight from the native macOS picker and matches the existing TUI behavior: actions stay available on demand through `C-o`, but the picker does not reserve space for always-visible hints.

## Changes
- Removed the macOS picker bottom hint bar from `PickerOverlay`.
- Deleted the unused bottom-bar and key-hint view helpers.
- Moved the marked-item count into the search/header row as a compact accent badge, so multi-select state remains visible without costing a result row.

## Verification
- `rg "bottomBar|navigate|mark\"\)|close\"\)" macos/Sources/Views/PickerOverlay.swift` exited 1, confirming the local bottom-bar and key-hint strings are gone.
- `git diff --check` passed.
- `make lint` passed.
- `mix test.llm` ran the full suite, but hit 3 unrelated Elixir agent-session timeout failures. The exact failing tests passed afterward in this branch and on `main`:
  - `mix test.llm test/minga_editor/integration/file_open_from_agent_tab_test.exs:138 test/minga_editor/integration/agent_cursor_test.exs:142 test/minga_editor/input/cua_tui_integration_test.exs:135`
- `mix swift.build` could not run a real macOS build in this Linux environment because `xcodebuild` is unavailable; the task compiled prerequisites and skipped the Swift build.

Manual macOS verification still needed: open any picker, confirm there is no bottom hint bar, mark items with Tab, confirm the selected count appears in the header, and confirm `C-o` still opens the action menu.

## Acceptance Criteria Addressed
- macOS frontend picker no longer renders a permanent bottom bar with key hints ✅
- `C-o` contextual action menu remains available ✅
- Marked-item count still appears somewhere visible when items are marked ✅
- TUI bottom-layout picker is unchanged ✅
