### PR TITLE
feat(editor): add observatory process tree data

### DIFF
--- a/lib/minga/system_observer.ex
+++ b/lib/minga/system_observer.ex
@@ -66,6 +66,10 @@ defmodule Minga.SystemObserver do
           processes: %{pid() => ProcessSnapshot.t()}
         }
 
+  @type child_type :: ProcessSnapshot.child_type()
+  @type child_modules :: [module()] | :dynamic
+  @type process_class :: ProcessSnapshot.process_class()
+
   @typedoc "Internal state for the SystemObserver GenServer."
   @type t :: %{
           monitors: %{reference() => atom()},
@@ -150,6 +154,34 @@ defmodule Minga.SystemObserver do
   @spec restart_history(GenServer.server()) :: [RestartRecord.t()]
   def restart_history(server \\ __MODULE__) do
     GenServer.call(server, :restart_history)
+  end
+
+  @doc """
+  Classifies a process for Observatory rendering.
+  """
+  @spec classify_process(pid(), atom() | nil, child_type()) :: process_class()
+  def classify_process(pid, registered_name, child_type) when is_pid(pid) do
+    classify_process(pid, registered_name, child_type, [])
+  end
+
+  @doc """
+  Classifies a process for Observatory rendering using supervisor child modules when available.
+  """
+  @spec classify_process(pid(), atom() | nil, child_type(), child_modules()) :: process_class()
+  def classify_process(pid, registered_name, child_type, child_modules) when is_pid(pid) do
+    classify_by_child_type(child_type) ||
+      classify_buffer_process(pid) ||
+      classify_by_modules(child_modules) ||
+      classify_by_registered_name(registered_name) ||
+      :worker
+  end
+
+  @doc """
+  Classifies a process by registered name and child type.
+  """
+  @spec classify_process(atom() | nil, child_type()) :: process_class()
+  def classify_process(registered_name, child_type) do
+    classify_by_child_type(child_type) || classify_by_registered_name(registered_name) || :worker
   end
 
   # ── GenServer callbacks ───────────────────────────────────────────────────
@@ -374,7 +406,7 @@ defmodule Minga.SystemObserver do
   defp walk_supervision_tree(supervisor_name) when is_atom(supervisor_name) do
     case Process.whereis(supervisor_name) do
       nil -> %{}
-      pid -> walk_supervisor(pid, %{})
+      pid -> walk_supervisor(pid, nil, %{})
     end
   end
 
@@ -382,15 +414,20 @@ defmodule Minga.SystemObserver do
   # Uses the `type` field from `which_children` to distinguish :supervisor
   # children (recurse) from :worker children (collect info only, don't call
   # which_children on them since that would crash them or deadlock).
-  @spec walk_supervisor(pid(), %{pid() => ProcessSnapshot.t()}) ::
+  @spec walk_supervisor(pid(), pid() | nil, %{pid() => ProcessSnapshot.t()}) ::
           %{pid() => ProcessSnapshot.t()}
-  defp walk_supervisor(sup_pid, acc) do
-    acc = Map.put(acc, sup_pid, collect_process_info(sup_pid))
+  defp walk_supervisor(sup_pid, parent_pid, acc) do
+    acc =
+      Map.put(
+        acc,
+        sup_pid,
+        collect_process_info(sup_pid, parent_pid, :supervisor, [Minga.Supervisor])
+      )
 
     children = Supervisor.which_children(sup_pid)
 
     Enum.reduce(children, acc, fn child, inner_acc ->
-      collect_child(child, inner_acc)
+      collect_child(child, sup_pid, inner_acc)
     end)
   catch
     :exit, _ ->
@@ -399,24 +436,28 @@ defmodule Minga.SystemObserver do
   end
 
   @spec collect_child(
-          {term(), pid() | :restarting | :undefined, :worker | :supervisor, [module()]},
+          {term(), pid() | :restarting | :undefined, :worker | :supervisor, child_modules()},
+          pid(),
           %{pid() => ProcessSnapshot.t()}
         ) :: %{pid() => ProcessSnapshot.t()}
-  defp collect_child({_id, child_pid, :supervisor, _modules}, acc) when is_pid(child_pid) do
-    walk_supervisor(child_pid, acc)
+  defp collect_child({_id, child_pid, :supervisor, _modules}, parent_pid, acc)
+       when is_pid(child_pid) do
+    walk_supervisor(child_pid, parent_pid, acc)
   end
 
-  defp collect_child({_id, child_pid, :worker, _modules}, acc) when is_pid(child_pid) do
-    Map.put(acc, child_pid, collect_process_info(child_pid))
+  defp collect_child({_id, child_pid, :worker, modules}, parent_pid, acc)
+       when is_pid(child_pid) do
+    Map.put(acc, child_pid, collect_process_info(child_pid, parent_pid, :worker, modules))
   end
 
-  defp collect_child({_id, _not_running, _type, _modules}, acc) do
+  defp collect_child({_id, _not_running, _type, _modules}, _parent_pid, acc) do
     # Child is :restarting or :undefined
     acc
   end
 
-  @spec collect_process_info(pid()) :: ProcessSnapshot.t()
-  defp collect_process_info(pid) do
+  @spec collect_process_info(pid(), pid() | nil, child_type(), child_modules()) ::
+          ProcessSnapshot.t()
+  defp collect_process_info(pid, parent_pid, child_type, child_modules) do
     info =
       Process.info(pid, [
         :memory,
@@ -428,24 +469,92 @@ defmodule Minga.SystemObserver do
 
     case info do
       nil ->
-        %ProcessSnapshot{
-          memory: 0,
-          message_queue_len: 0,
-          reductions: 0,
-          current_function: nil,
-          registered_name: nil
-        }
+        build_snapshot(pid, [], parent_pid, child_type, child_modules)
 
       info_list ->
-        %ProcessSnapshot{
-          memory: Keyword.get(info_list, :memory, 0),
-          message_queue_len: Keyword.get(info_list, :message_queue_len, 0),
-          reductions: Keyword.get(info_list, :reductions, 0),
-          current_function: Keyword.get(info_list, :current_function),
-          registered_name: Keyword.get(info_list, :registered_name)
-        }
+        build_snapshot(pid, info_list, parent_pid, child_type, child_modules)
     end
   end
+
+  @spec build_snapshot(pid(), keyword(), pid() | nil, child_type(), child_modules()) ::
+          ProcessSnapshot.t()
+  defp build_snapshot(pid, info_list, parent_pid, child_type, child_modules) do
+    registered_name = normalize_registered_name(Keyword.get(info_list, :registered_name))
+
+    %ProcessSnapshot{
+      memory: Keyword.get(info_list, :memory, 0),
+      message_queue_len: Keyword.get(info_list, :message_queue_len, 0),
+      reductions: Keyword.get(info_list, :reductions, 0),
+      current_function: Keyword.get(info_list, :current_function),
+      registered_name: registered_name,
+      parent_pid: parent_pid,
+      child_type: child_type,
+      process_class: classify_process(pid, registered_name, child_type, child_modules)
+    }
+  end
+
+  @spec normalize_registered_name(term()) :: atom() | nil
+  defp normalize_registered_name(name) when is_atom(name), do: name
+  defp normalize_registered_name(_name), do: nil
+
+  @spec classify_by_child_type(child_type()) :: process_class() | nil
+  defp classify_by_child_type(:supervisor), do: :supervisor
+  defp classify_by_child_type(_child_type), do: nil
+
+  @spec classify_buffer_process(pid()) :: :buffer | nil
+  defp classify_buffer_process(pid) do
+    case buffer_registry_keys(pid) do
+      [] -> nil
+      _keys -> :buffer
+    end
+  end
+
+  @spec buffer_registry_keys(pid()) :: [term()]
+  defp buffer_registry_keys(pid) do
+    Registry.keys(Minga.Buffer.Registry, pid)
+  rescue
+    ArgumentError -> []
+  end
+
+  @spec classify_by_modules(child_modules()) :: process_class() | nil
+  defp classify_by_modules(:dynamic), do: nil
+  defp classify_by_modules([]), do: nil
+
+  defp classify_by_modules([module | rest]) when is_atom(module) do
+    classify_by_module(module) || classify_by_modules(rest)
+  end
+
+  @spec classify_by_module(module()) :: process_class() | nil
+  defp classify_by_module(module) do
+    module
+    |> Atom.to_string()
+    |> classify_by_name_string()
+  end
+
+  @spec classify_by_registered_name(atom() | nil) :: process_class() | nil
+  defp classify_by_registered_name(nil), do: nil
+
+  defp classify_by_registered_name(registered_name) when is_atom(registered_name) do
+    registered_name
+    |> Atom.to_string()
+    |> classify_by_name_string()
+  end
+
+  @spec classify_by_name_string(String.t()) :: process_class() | nil
+  defp classify_by_name_string("Elixir.Minga.Buffer"), do: :buffer
+  defp classify_by_name_string("Elixir.Minga.Buffer." <> _suffix), do: :buffer
+  defp classify_by_name_string("Elixir.MingaAgent." <> _suffix), do: :agent_session
+  defp classify_by_name_string("Elixir.Minga.LSP." <> _suffix), do: :lsp
+  defp classify_by_name_string("Elixir.Minga.Config." <> _suffix), do: :service
+  defp classify_by_name_string("Elixir.Minga.Events"), do: :service
+  defp classify_by_name_string("Elixir.Minga.Foundation." <> _suffix), do: :service
+  defp classify_by_name_string("Elixir.Minga.Language." <> _suffix), do: :service
+  defp classify_by_name_string("Elixir.Minga.Command." <> _suffix), do: :service
+  defp classify_by_name_string("Elixir.Minga.Extension." <> _suffix), do: :service
+  defp classify_by_name_string("Elixir.Minga.Git." <> _suffix), do: :service
+  defp classify_by_name_string("Elixir.Minga.Project." <> _suffix), do: :service
+  defp classify_by_name_string("Elixir.Minga.Services." <> _suffix), do: :service
+  defp classify_by_name_string(_registered_name), do: nil
 
   @spec enqueue_bounded(:queue.queue(a), non_neg_integer(), a, pos_integer()) ::
           {:queue.queue(a), non_neg_integer()}

--- a/lib/minga/system_observer/process_snapshot.ex
+++ b/lib/minga/system_observer/process_snapshot.ex
@@ -6,13 +6,28 @@ defmodule Minga.SystemObserver.ProcessSnapshot do
   """
 
   @enforce_keys [:memory, :message_queue_len, :reductions]
-  defstruct [:memory, :message_queue_len, :reductions, :current_function, :registered_name]
+  defstruct [
+    :memory,
+    :message_queue_len,
+    :reductions,
+    :current_function,
+    :registered_name,
+    :parent_pid,
+    :child_type,
+    :process_class
+  ]
+
+  @type child_type :: :supervisor | :worker | :unknown
+  @type process_class :: :supervisor | :buffer | :agent_session | :lsp | :service | :worker
 
   @type t :: %__MODULE__{
           memory: non_neg_integer(),
           message_queue_len: non_neg_integer(),
           reductions: non_neg_integer(),
           current_function: {module(), atom(), arity()} | nil,
-          registered_name: atom() | nil
+          registered_name: atom() | nil,
+          parent_pid: pid() | nil,
+          child_type: child_type(),
+          process_class: process_class()
         }
 end

--- a/lib/minga/system_observer/tree_node.ex
+++ b/lib/minga/system_observer/tree_node.ex
@@ -1,0 +1,74 @@
+defmodule Minga.SystemObserver.TreeNode do
+  @moduledoc """
+  Render-oriented tree node derived from flat SystemObserver snapshots.
+
+  SystemObserver keeps snapshots in a flat map keyed by PID because that is cheap to collect and easy to sample over time. The Observatory derives this tree when it needs hierarchy for rendering.
+  """
+
+  alias Minga.SystemObserver.ProcessSnapshot
+
+  @enforce_keys [:pid, :snapshot, :children, :depth]
+  defstruct [:pid, :snapshot, :children, :depth]
+
+  @type t :: %__MODULE__{
+          pid: pid(),
+          snapshot: ProcessSnapshot.t(),
+          children: [t()],
+          depth: non_neg_integer()
+        }
+
+  @doc """
+  Builds a supervision tree from a flat `%{pid => ProcessSnapshot.t()}` map.
+
+  Returns `nil` when the snapshot has no root process. Children whose parent is missing from the map are ignored because they cannot be placed in the rendered tree safely.
+  """
+  @spec build_tree(%{pid() => ProcessSnapshot.t()}) :: t() | nil
+  def build_tree(snapshots) when map_size(snapshots) == 0, do: nil
+
+  def build_tree(snapshots) when is_map(snapshots) do
+    with {root_pid, root_snapshot} <- find_root(snapshots) do
+      children_by_parent = group_children_by_parent(snapshots)
+      build_node(root_pid, root_snapshot, children_by_parent, 0)
+    end
+  end
+
+  @spec find_root(%{pid() => ProcessSnapshot.t()}) :: {pid(), ProcessSnapshot.t()} | nil
+  defp find_root(snapshots) do
+    Enum.find(snapshots, fn {_pid, snapshot} -> snapshot.parent_pid == nil end)
+  end
+
+  @spec group_children_by_parent(%{pid() => ProcessSnapshot.t()}) :: %{
+          pid() => [{pid(), ProcessSnapshot.t()}]
+        }
+  defp group_children_by_parent(snapshots) do
+    snapshots
+    |> Enum.reject(fn {_pid, snapshot} -> snapshot.parent_pid == nil end)
+    |> Enum.group_by(fn {_pid, snapshot} -> snapshot.parent_pid end)
+  end
+
+  @spec build_node(
+          pid(),
+          ProcessSnapshot.t(),
+          %{pid() => [{pid(), ProcessSnapshot.t()}]},
+          non_neg_integer()
+        ) :: t()
+  defp build_node(pid, snapshot, children_by_parent, depth) do
+    children =
+      children_by_parent
+      |> Map.get(pid, [])
+      |> sort_children()
+      |> Enum.map(fn {child_pid, child_snapshot} ->
+        build_node(child_pid, child_snapshot, children_by_parent, depth + 1)
+      end)
+
+    %__MODULE__{pid: pid, snapshot: snapshot, children: children, depth: depth}
+  end
+
+  @spec sort_children([{pid(), ProcessSnapshot.t()}]) :: [{pid(), ProcessSnapshot.t()}]
+  defp sort_children(children) do
+    Enum.sort_by(children, fn {pid, snapshot} ->
+      {snapshot.process_class || :worker, snapshot.registered_name || :zzz_unnamed,
+       :erlang.pid_to_list(pid)}
+    end)
+  end
+end

--- a/test/minga/system_observer/tree_node_test.exs
+++ b/test/minga/system_observer/tree_node_test.exs
@@ -1,0 +1,82 @@
+defmodule Minga.SystemObserver.TreeNodeTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.SystemObserver.ProcessSnapshot
+  alias Minga.SystemObserver.TreeNode
+
+  describe "build_tree/1" do
+    test "returns nil for an empty snapshot map" do
+      assert TreeNode.build_tree(%{}) == nil
+    end
+
+    test "builds a hierarchy from flat process snapshots" do
+      root_pid = self()
+      child_pid = spawn_idle_process()
+      grandchild_pid = spawn_idle_process()
+      sibling_pid = spawn_idle_process()
+
+      snapshots = %{
+        root_pid =>
+          snapshot(parent_pid: nil, child_type: :supervisor, process_class: :supervisor),
+        child_pid =>
+          snapshot(parent_pid: root_pid, child_type: :supervisor, process_class: :supervisor),
+        grandchild_pid =>
+          snapshot(parent_pid: child_pid, child_type: :worker, process_class: :buffer),
+        sibling_pid => snapshot(parent_pid: root_pid, child_type: :worker, process_class: :worker)
+      }
+
+      tree = TreeNode.build_tree(snapshots)
+
+      assert %TreeNode{pid: ^root_pid, depth: 0, children: root_children} = tree
+      assert Enum.map(root_children, & &1.depth) == [1, 1]
+      assert Enum.any?(root_children, fn node -> node.pid == sibling_pid end)
+
+      child_node = Enum.find(root_children, fn node -> node.pid == child_pid end)
+      assert %TreeNode{children: [%TreeNode{pid: ^grandchild_pid, depth: 2}]} = child_node
+    end
+
+    test "ignores orphaned processes that cannot be attached to the root" do
+      root_pid = self()
+      orphan_parent_pid = spawn_idle_process()
+      orphan_pid = spawn_idle_process()
+
+      snapshots = %{
+        root_pid =>
+          snapshot(parent_pid: nil, child_type: :supervisor, process_class: :supervisor),
+        orphan_pid =>
+          snapshot(parent_pid: orphan_parent_pid, child_type: :worker, process_class: :worker)
+      }
+
+      tree = TreeNode.build_tree(snapshots)
+
+      assert %TreeNode{pid: ^root_pid, children: []} = tree
+    end
+  end
+
+  defp spawn_idle_process do
+    pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> send(pid, :stop) end)
+    pid
+  end
+
+  defp snapshot(attrs) do
+    attrs = Keyword.merge([parent_pid: nil, child_type: :worker, process_class: :worker], attrs)
+
+    %ProcessSnapshot{
+      memory: 1,
+      message_queue_len: 0,
+      reductions: 1,
+      current_function: nil,
+      registered_name: nil,
+      parent_pid: Keyword.fetch!(attrs, :parent_pid),
+      child_type: Keyword.fetch!(attrs, :child_type),
+      process_class: Keyword.fetch!(attrs, :process_class)
+    }
+  end
+end

--- a/test/minga/system_observer_test.exs
+++ b/test/minga/system_observer_test.exs
@@ -33,6 +33,16 @@ defmodule Minga.SystemObserverTest do
       assert first_process.memory >= 0
       assert is_integer(first_process.message_queue_len)
       assert is_integer(first_process.reductions)
+      assert first_process.child_type in [:supervisor, :worker]
+
+      assert first_process.process_class in [
+               :supervisor,
+               :buffer,
+               :agent_session,
+               :lsp,
+               :service,
+               :worker
+             ]
     end
   end
 
@@ -105,6 +115,58 @@ defmodule Minga.SystemObserverTest do
         Enum.filter(snapshot.processes, fn {_pid, info} -> info.registered_name != nil end)
 
       assert named_processes != []
+    end
+
+    test "collected snapshots include hierarchy fields for child processes", %{name: name} do
+      :ok = SystemObserver.subscribe(name)
+      poll_once(name)
+
+      snapshot = SystemObserver.snapshot(name)
+      root_pid = Process.whereis(Minga.Supervisor)
+      root_snapshot = Map.fetch!(snapshot.processes, root_pid)
+
+      assert root_snapshot.parent_pid == nil
+      assert root_snapshot.child_type == :supervisor
+      assert root_snapshot.process_class == :supervisor
+
+      child_snapshots =
+        Enum.reject(snapshot.processes, fn {_pid, info} -> info.parent_pid == nil end)
+
+      assert child_snapshots != []
+
+      assert Enum.all?(child_snapshots, fn {_pid, info} ->
+               Map.has_key?(snapshot.processes, info.parent_pid)
+             end)
+    end
+  end
+
+  describe "classify_process/3" do
+    test "classifies supervisors from child type" do
+      assert SystemObserver.classify_process(self(), nil, :supervisor) == :supervisor
+    end
+
+    test "classifies registered buffer processes" do
+      key = "buffer-#{System.unique_integer([:positive])}"
+      Registry.register(Minga.Buffer.Registry, key, nil)
+      on_exit(fn -> Registry.unregister(Minga.Buffer.Registry, key) end)
+
+      assert SystemObserver.classify_process(self(), nil, :worker) == :buffer
+    end
+
+    test "classifies agent, lsp, service, and fallback workers from registered names" do
+      assert SystemObserver.classify_process(MingaAgent.SessionManager, :worker) == :agent_session
+      assert SystemObserver.classify_process(Minga.LSP.Supervisor, :worker) == :lsp
+      assert SystemObserver.classify_process(Minga.Config.Options, :worker) == :service
+      assert SystemObserver.classify_process(:some_unrelated_process, :worker) == :worker
+    end
+
+    test "classifies unnamed dynamic workers from supervisor child modules" do
+      assert SystemObserver.classify_process(self(), nil, :worker, [Minga.Buffer]) == :buffer
+
+      assert SystemObserver.classify_process(self(), nil, :worker, [MingaAgent.Session]) ==
+               :agent_session
+
+      assert SystemObserver.classify_process(self(), nil, :worker, [Minga.LSP.Client]) == :lsp
     end
   end
 


### PR DESCRIPTION
# TL;DR
Adds the first BEAM Observatory data slice: process snapshots now include hierarchy and semantic classification, and flat snapshots can be derived into a render-ready tree.

Closes #1578
Part of #1081

## Context
This is the first sequenced child ticket for the BEAM Observatory epic. It keeps `SystemObserver`'s efficient flat snapshot storage, then derives a `TreeNode` hierarchy on demand for later GUI rendering work.

## Changes
- Added `parent_pid`, `child_type`, and `process_class` to `ProcessSnapshot` while keeping the existing `snapshot/0` and `samples/0` API shapes intact.
- Threaded parent PID and child module metadata through the supervision tree walk so snapshots preserve parent-child relationships.
- Added process classification for supervisors, buffers, agent sessions, LSP processes, services, and generic workers. Dynamic unnamed workers are classified from `Supervisor.which_children/1` module metadata.
- Added `Minga.SystemObserver.TreeNode.build_tree/1` to derive a render-oriented hierarchy from the flat snapshot map.
- Added focused tests for hierarchy fields, classification behavior, and tree building from synthetic snapshots.

## Verification
- `mix test.llm test/minga/system_observer_test.exs test/minga/system_observer/tree_node_test.exs` passed, 15 tests, 0 failures.
- `make lint` passed.
- `mix test.llm` passed, 8183 tests, 52 doctests, 99 properties, 0 failures.
- Bug-hunting review found a dynamic-worker classification gap. Fixed by threading child modules into classification, then targeted re-review passed.

## Acceptance Criteria Addressed
- `ProcessSnapshot` includes `parent_pid`, `child_type`, and `process_class` fields ✅
- `walk_supervision_tree` threads parent PID through the walk so each snapshot knows its parent ✅
- `classify_process/1` correctly classifies supervisors, buffers, agent sessions, LSP processes, and workers ✅
- `TreeNode.build_tree/1` produces a correct tree from a flat snapshot map ✅
- Existing `snapshot/0` and `samples/0` API remain backward compatible ✅
- Tests cover hierarchy derivation and all classification cases ✅
