### PR TITLE
feat(git): add git log picker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,9 @@ jobs:
       - name: Generate Xcode project
         run: cd macos && xcodegen generate
 
+      - name: Clear stale Swift module cache
+        run: rm -rf macos/DerivedData/ModuleCache.noindex macos/DerivedData/SDKStatCaches.noindex
+
       - name: Build
         run: |
           cd macos

--- a/lib/minga/git.ex
+++ b/lib/minga/git.ex
@@ -68,6 +68,11 @@ defmodule Minga.Git do
   @typedoc "A structured stash entry."
   @type stash_entry :: StashEntry.t()
 
+  @typedoc "Accepted diff options. Unknown keys, duplicate keys, and invalid values are rejected. `:commit` may be combined with `:staged`, but only when `:staged` is `false`."
+  @type diff_opt :: {:path, String.t()} | {:staged, boolean()} | {:commit, String.t()}
+
+  @type diff_opts :: [diff_opt()]
+
   # ── Delegated operations (go through the backend) ──────────────────────
 
   @doc """
@@ -124,9 +129,15 @@ defmodule Minga.Git do
   Returns the diff for a specific file or all changes.
 
   Options: `:path` (file path), `:staged` (boolean, default false), `:commit` (commit hash).
+  `:commit` may be combined with `:staged, false`; commit diffs can still be narrowed with `:path`.
   """
-  @spec diff(String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
-  def diff(git_root, opts \\ []), do: impl().diff(git_root, opts)
+  @spec diff(String.t(), diff_opts()) :: {:ok, String.t()} | {:error, String.t()}
+  def diff(git_root, opts \\ []) do
+    case Minga.Git.DiffOptions.validate(opts) do
+      :ok -> impl().diff(git_root, opts)
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
   @doc """
   Returns recent commits as structured entries.

--- a/lib/minga/git.ex
+++ b/lib/minga/git.ex
@@ -123,7 +123,7 @@ defmodule Minga.Git do
   @doc """
   Returns the diff for a specific file or all changes.
 
-  Options: `:path` (file path), `:staged` (boolean, default false).
+  Options: `:path` (file path), `:staged` (boolean, default false), `:commit` (commit hash).
   """
   @spec diff(String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
   def diff(git_root, opts \\ []), do: impl().diff(git_root, opts)

--- a/lib/minga/git/backend.ex
+++ b/lib/minga/git/backend.ex
@@ -30,7 +30,7 @@ defmodule Minga.Git.Backend do
   @callback status(git_root :: String.t()) ::
               {:ok, [Minga.Git.status_entry()]} | {:error, String.t()}
 
-  @callback diff(git_root :: String.t(), opts :: keyword()) ::
+  @callback diff(git_root :: String.t(), opts :: Minga.Git.diff_opts()) ::
               {:ok, String.t()} | {:error, String.t()}
 
   @callback log(git_root :: String.t(), opts :: keyword()) ::

--- a/lib/minga/git/diff_options.ex
+++ b/lib/minga/git/diff_options.ex
@@ -1,0 +1,83 @@
+defmodule Minga.Git.DiffOptions do
+  @moduledoc false
+
+  @allowed_keys [:path, :staged, :commit]
+
+  @spec validate(keyword()) :: :ok | {:error, String.t()}
+  def validate(opts) when is_list(opts) do
+    with :ok <- validate_keyword(opts),
+         :ok <- validate_allowed_keys(opts),
+         :ok <- validate_duplicate_keys(opts),
+         :ok <- validate_types(opts),
+         :ok <- validate_commit_staged(opts) do
+      :ok
+    end
+  end
+
+  def validate(_opts), do: {:error, "git diff options must be a keyword list"}
+
+  @spec validate_keyword(keyword()) :: :ok | {:error, String.t()}
+  defp validate_keyword(opts) do
+    if Keyword.keyword?(opts) do
+      :ok
+    else
+      {:error, "git diff options must be a keyword list"}
+    end
+  end
+
+  @spec validate_allowed_keys(keyword()) :: :ok | {:error, String.t()}
+  defp validate_allowed_keys(opts) do
+    case Enum.find(opts, fn {key, _value} -> key not in @allowed_keys end) do
+      nil -> :ok
+      {key, _value} -> {:error, "git diff option #{inspect(key)} is not supported"}
+    end
+  end
+
+  @spec validate_duplicate_keys(keyword()) :: :ok | {:error, String.t()}
+  defp validate_duplicate_keys(opts) do
+    case duplicate_keys(opts) do
+      [] -> :ok
+      keys ->
+        key_list = Enum.map_join(keys, ", ", &inspect/1)
+        {:error, "git diff options contain duplicate keys: #{key_list}"}
+    end
+  end
+
+  @spec validate_types(keyword()) :: :ok | {:error, String.t()}
+  defp validate_types([]), do: :ok
+
+  defp validate_types([{:path, path} | rest]) when is_binary(path), do: validate_types(rest)
+  defp validate_types([{:path, _path} | _rest]), do: {:error, "git diff option :path must be a binary"}
+
+  defp validate_types([{:staged, staged} | rest]) when is_boolean(staged),
+    do: validate_types(rest)
+
+  defp validate_types([{:staged, _staged} | _rest]),
+    do: {:error, "git diff option :staged must be a boolean"}
+
+  defp validate_types([{:commit, commit} | rest]) when is_binary(commit),
+    do: validate_types(rest)
+
+  defp validate_types([{:commit, _commit} | _rest]),
+    do: {:error, "git diff option :commit must be a binary"}
+
+  defp validate_types([_other | rest]), do: validate_types(rest)
+
+  @spec validate_commit_staged(keyword()) :: :ok | {:error, String.t()}
+  defp validate_commit_staged(opts) do
+    if Keyword.get(opts, :commit) != nil and Keyword.get(opts, :staged, false) == true do
+      {:error, "git diff options: :commit cannot be combined with :staged"}
+    else
+      :ok
+    end
+  end
+
+  @spec duplicate_keys(keyword()) :: [atom()]
+  defp duplicate_keys(opts) do
+    opts
+    |> Enum.frequencies_by(fn {key, _value} -> key end)
+    |> Enum.filter(fn {_key, count} -> count > 1 end)
+    |> Enum.map(fn {key, _count} -> key end)
+    |> Enum.filter(&(&1 in @allowed_keys))
+  end
+end

--- a/lib/minga/git/diff_options.ex
+++ b/lib/minga/git/diff_options.ex
@@ -36,7 +36,9 @@ defmodule Minga.Git.DiffOptions do
   @spec validate_duplicate_keys(keyword()) :: :ok | {:error, String.t()}
   defp validate_duplicate_keys(opts) do
     case duplicate_keys(opts) do
-      [] -> :ok
+      [] ->
+        :ok
+
       keys ->
         key_list = Enum.map_join(keys, ", ", &inspect/1)
         {:error, "git diff options contain duplicate keys: #{key_list}"}
@@ -47,7 +49,9 @@ defmodule Minga.Git.DiffOptions do
   defp validate_types([]), do: :ok
 
   defp validate_types([{:path, path} | rest]) when is_binary(path), do: validate_types(rest)
-  defp validate_types([{:path, _path} | _rest]), do: {:error, "git diff option :path must be a binary"}
+
+  defp validate_types([{:path, _path} | _rest]),
+    do: {:error, "git diff option :path must be a binary"}
 
   defp validate_types([{:staged, staged} | rest]) when is_boolean(staged),
     do: validate_types(rest)

--- a/lib/minga/git/diff_options.ex
+++ b/lib/minga/git/diff_options.ex
@@ -8,9 +8,8 @@ defmodule Minga.Git.DiffOptions do
     with :ok <- validate_keyword(opts),
          :ok <- validate_allowed_keys(opts),
          :ok <- validate_duplicate_keys(opts),
-         :ok <- validate_types(opts),
-         :ok <- validate_commit_staged(opts) do
-      :ok
+         :ok <- validate_types(opts) do
+      validate_commit_staged(opts)
     end
   end
 

--- a/lib/minga/git/system.ex
+++ b/lib/minga/git/system.ex
@@ -127,13 +127,15 @@ defmodule Minga.Git.System do
   end
 
   @impl true
-  @spec diff(String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec diff(String.t(), Minga.Git.diff_opts()) :: {:ok, String.t()} | {:error, String.t()}
   def diff(git_root, opts \\ []) when is_binary(git_root) do
-    args = diff_args(opts)
+    with :ok <- Minga.Git.DiffOptions.validate(opts) do
+      args = diff_args(opts)
 
-    case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
-      {output, 0} -> {:ok, output}
-      {output, _} -> {:error, "git diff failed: #{String.trim(output)}"}
+      case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
+        {output, 0} -> {:ok, output}
+        {output, _} -> {:error, "git diff failed: #{String.trim(output)}"}
+      end
     end
   rescue
     e in [ErlangError, ArgumentError] -> {:error, "git diff error: #{Exception.message(e)}"}

--- a/lib/minga/git/system.ex
+++ b/lib/minga/git/system.ex
@@ -129,12 +129,7 @@ defmodule Minga.Git.System do
   @impl true
   @spec diff(String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
   def diff(git_root, opts \\ []) when is_binary(git_root) do
-    path = Keyword.get(opts, :path)
-    staged = Keyword.get(opts, :staged, false)
-
-    args = ["diff"]
-    args = if staged, do: args ++ ["--cached"], else: args
-    args = if path, do: args ++ ["--", path], else: args
+    args = diff_args(opts)
 
     case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
       {output, 0} -> {:ok, output}
@@ -144,13 +139,36 @@ defmodule Minga.Git.System do
     e in [ErlangError, ArgumentError] -> {:error, "git diff error: #{Exception.message(e)}"}
   end
 
+  @spec diff_args(keyword()) :: [String.t()]
+  defp diff_args(opts) do
+    case Keyword.get(opts, :commit) do
+      nil -> working_tree_diff_args(opts)
+      commit -> commit_diff_args(commit, Keyword.get(opts, :path))
+    end
+  end
+
+  @spec working_tree_diff_args(keyword()) :: [String.t()]
+  defp working_tree_diff_args(opts) do
+    path = Keyword.get(opts, :path)
+    staged = Keyword.get(opts, :staged, false)
+
+    args = ["diff"]
+    args = if staged, do: args ++ ["--cached"], else: args
+    if path, do: args ++ ["--", path], else: args
+  end
+
+  @spec commit_diff_args(String.t(), String.t() | nil) :: [String.t()]
+  defp commit_diff_args(commit, nil), do: ["show", commit, "--format=", "--patch"]
+
+  defp commit_diff_args(commit, path), do: ["show", commit, "--format=", "--patch", "--", path]
+
   @impl true
   @spec log(String.t(), keyword()) :: {:ok, [Minga.Git.log_entry()]} | {:error, String.t()}
   def log(git_root, opts \\ []) when is_binary(git_root) do
     count = Keyword.get(opts, :count, 10)
     path = Keyword.get(opts, :path)
 
-    format = "%H%x1f%h%x1f%an%x1f%ai%x1f%s"
+    format = "%H%x1f%h%x1f%an%x1f%cr%x1f%s"
     args = ["log", "--format=#{format}", "-n", "#{count}"]
     args = if path, do: args ++ ["--", path], else: args
 

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -118,6 +118,7 @@ defmodule Minga.Keymap.Defaults do
     # ── Git ──────────────────────────────────────────────────────────────────────
     {~k(g g), :git_status_toggle, "Git status"},
     {~k(g f), :git_changed_files, "Changed files"},
+    {~k(g l), :git_log, "Git log"},
     {~k(g B), :git_branch_picker, "Switch branch"},
     {~k(g P), :git_push, "Push"},
     {~k(g p), :git_pull, "Pull"},

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -20,6 +20,8 @@ defmodule MingaEditor.Commands.Git do
   alias Minga.Git.MergeConflict.Region
   alias Minga.Language
   alias MingaEditor.UI.Picker.GitChangedSource
+  alias MingaEditor.UI.Picker.GitLogFileSource
+  alias MingaEditor.UI.Picker.GitLogSource
   alias MingaEditor.UI.Picker.GitStashSource
 
   @type state :: EditorState.t()
@@ -35,6 +37,8 @@ defmodule MingaEditor.Commands.Git do
   @command_specs [
     {:git_status_toggle, "Git status", false},
     {:git_changed_files, "Changed files", false},
+    {:git_log, "Git log", false},
+    {:git_log_file, "Git log for current file", true},
     {:git_branch_picker, "Switch branch", false},
     {:git_stash_save, "Stash changes", false},
     {:git_stash_pop, "Pop stash", false},
@@ -88,6 +92,16 @@ defmodule MingaEditor.Commands.Git do
 
   def execute(state, :git_changed_files) do
     PickerUI.open(state, GitChangedSource)
+  end
+
+  def execute(state, :git_log) do
+    PickerUI.open(state, GitLogSource)
+  end
+
+  def execute(state, :git_log_file) do
+    with_git_buffer(state, fn _git_pid, _buf ->
+      PickerUI.open(state, GitLogFileSource)
+    end)
   end
 
   def execute(state, :git_branch_picker) do

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -653,7 +653,7 @@ defmodule MingaEditor.Frontend.Emit.GUI do
     # Preview content is NOT in the fingerprint: a file changing on disk while
     # the picker is open won't refresh the preview. Acceptable trade-off for
     # scroll perf since the picker isn't open during normal editing.
-    has_preview = source != nil and Picker.Source.preview?(source)
+    has_preview = source != nil and Picker.Source.gui_preview?(source)
     fp = picker_fingerprint(picker, has_preview, action_menu, mode_prefix, 100)
 
     if fp != caches.last_gui_picker_fp do

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -679,8 +679,8 @@ defmodule MingaEditor.Frontend.Emit.GUI do
       picker.filtered
       |> Enum.take(limit)
       |> Enum.map(fn item ->
-        {item.id, item.label, item.description, item.annotation, item.icon_color, item.two_line,
-         item.match_positions, Picker.marked?(picker, item)}
+        {item.id, item.label, item.description, item.annotation, item.search_text,
+         item.icon_color, item.two_line, item.match_positions, Picker.marked?(picker, item)}
       end)
 
     :erlang.phash2({
@@ -700,14 +700,18 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   # Returns a list of lines, where each line is a list of {text, fg_color, bold} segments.
   @spec build_picker_preview(ctx()) :: [[ProtocolGUI.preview_segment()]] | nil
   defp build_picker_preview(
-         %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = ctx
+         %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+           ctx
        ) do
     case Picker.selected_item(picker) do
       nil ->
         nil
 
-      %Picker.Item{id: id} ->
-        build_preview_for_item(ctx, id)
+      %Picker.Item{id: id} = item ->
+        case Picker.Source.preview(source, item, ctx) do
+          nil -> build_preview_for_item(ctx, id)
+          lines -> lines
+        end
     end
   end
 

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -47,6 +47,8 @@ defmodule MingaEditor.PickerUI do
   # When a prefix character is typed as the first query char in a switchable
   # source (file picker, recent files), the picker swaps to the mapped source
   # and strips the prefix from the fuzzy query.
+  # Git log no longer uses a single-letter switch, so fuzzy search input like
+  # "fix" stays in the query instead of changing picker modes.
   @file_mode_prefixes %{
     ">" => MingaEditor.UI.Picker.CommandSource,
     "#" => MingaEditor.UI.Picker.ProjectSearchSource,
@@ -55,8 +57,7 @@ defmodule MingaEditor.PickerUI do
 
   @mode_prefixes %{
     MingaEditor.UI.Picker.FileSource => @file_mode_prefixes,
-    MingaEditor.UI.Picker.RecentFileSource => @file_mode_prefixes,
-    MingaEditor.UI.Picker.GitLogSource => %{"f" => MingaEditor.UI.Picker.GitLogFileSource}
+    MingaEditor.UI.Picker.RecentFileSource => @file_mode_prefixes
   }
 
   defmodule RenderInput do
@@ -441,7 +442,7 @@ defmodule MingaEditor.PickerUI do
   @spec select_item_and_close(EditorState.t(), Picker.item(), module()) ::
           EditorState.t() | {EditorState.t(), {:execute_command, atom()}}
   defp select_item_and_close(state, item, source) do
-    if Picker.Source.preview?(source) and previewed?(state) do
+    if Picker.Source.live_preview?(source) and previewed?(state) do
       promote_previewed_buffer(state)
     else
       run_select_and_close(state, item, source)
@@ -1049,7 +1050,7 @@ defmodule MingaEditor.PickerUI do
 
   defp previewed?(_state), do: false
 
-  # Preview: temporarily apply the source's on_select for the highlighted item.
+  # Live preview: temporarily apply the source's on_select for the highlighted item.
   # Sets buffer_add_context to :preview so add_buffer calls inside on_select update
   # the current tab in-place instead of creating a new tab.
   @spec maybe_preview_selection(state()) :: state()
@@ -1057,7 +1058,7 @@ defmodule MingaEditor.PickerUI do
          %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
            state
        ) do
-    if Picker.Source.preview?(source) do
+    if Picker.Source.live_preview?(source) do
       case Picker.selected_item(picker) do
         nil ->
           state

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -47,17 +47,17 @@ defmodule MingaEditor.PickerUI do
   # When a prefix character is typed as the first query char in a switchable
   # source (file picker, recent files), the picker swaps to the mapped source
   # and strips the prefix from the fuzzy query.
-  @mode_prefixes %{
+  @file_mode_prefixes %{
     ">" => MingaEditor.UI.Picker.CommandSource,
     "#" => MingaEditor.UI.Picker.ProjectSearchSource,
     "@" => MingaEditor.UI.Picker.BufferSource
   }
 
-  # Sources that support mode switching via prefix.
-  @switchable_sources [
-    MingaEditor.UI.Picker.FileSource,
-    MingaEditor.UI.Picker.RecentFileSource
-  ]
+  @mode_prefixes %{
+    MingaEditor.UI.Picker.FileSource => @file_mode_prefixes,
+    MingaEditor.UI.Picker.RecentFileSource => @file_mode_prefixes,
+    MingaEditor.UI.Picker.GitLogSource => %{"f" => MingaEditor.UI.Picker.GitLogFileSource}
+  }
 
   defmodule RenderInput do
     @moduledoc """
@@ -956,8 +956,10 @@ defmodule MingaEditor.PickerUI do
          char,
          query
        ) do
-    if query == "" and source in @switchable_sources and Map.has_key?(@mode_prefixes, char) do
-      target_source = Map.fetch!(@mode_prefixes, char)
+    source_prefixes = Map.get(@mode_prefixes, source, %{})
+
+    if query == "" and Map.has_key?(source_prefixes, char) do
+      target_source = Map.fetch!(source_prefixes, char)
       {:switched, switch_to_source(state, target_source, char)}
     else
       :no_switch

--- a/lib/minga_editor/state/picker.ex
+++ b/lib/minga_editor/state/picker.ex
@@ -37,6 +37,12 @@ defmodule MingaEditor.State.Picker do
   def open?(%__MODULE__{picker: nil}), do: false
   def open?(%__MODULE__{}), do: true
 
+  @doc "Returns a picker state with updated source context."
+  @spec put_context(t(), map() | nil) :: t()
+  def put_context(%__MODULE__{} = ps, context) do
+    %{ps | context: context}
+  end
+
   @doc "Updates the inner `MingaEditor.UI.Picker` instance."
   @spec update_picker(t(), MingaEditor.UI.Picker.t()) :: t()
   def update_picker(%__MODULE__{} = ps, picker) do

--- a/lib/minga_editor/ui/picker.ex
+++ b/lib/minga_editor/ui/picker.ex
@@ -312,8 +312,8 @@ defmodule MingaEditor.UI.Picker do
 
   @spec score_item_with_positions(Item.t(), [String.t()], String.t()) ::
           {Item.t(), non_neg_integer()}
-  defp score_item_with_positions(%Item{label: label, description: desc} = item, segments, query) do
-    score = score_item(label, desc, segments)
+  defp score_item_with_positions(%Item{label: label} = item, segments, query) do
+    score = score_item(item, segments)
     positions = if score > 0, do: match_positions(label, query), else: []
     {%{item | match_positions: positions}, score}
   end
@@ -326,20 +326,20 @@ defmodule MingaEditor.UI.Picker do
     |> String.split(~r/\s+/, trim: true)
   end
 
-  @spec score_item(String.t(), String.t(), [String.t()]) :: non_neg_integer()
-  defp score_item(label, desc, segments) do
+  @spec score_item(Item.t(), [String.t()]) :: non_neg_integer()
+  defp score_item(%Item{label: label} = item, segments) do
     scoring_label = label |> String.downcase() |> strip_icon_prefix()
-    down_desc = String.downcase(desc)
+    searchable = searchable_text(item)
 
     segment_scores =
       Enum.map(segments, fn seg ->
         label_score = score_segment(scoring_label, seg)
-        desc_score = score_segment(down_desc, seg)
+        search_score = score_segment(searchable, seg)
 
         if label_score > 0 do
           label_score + 200
         else
-          desc_score
+          search_score
         end
       end)
 
@@ -350,6 +350,14 @@ defmodule MingaEditor.UI.Picker do
       length_bonus = max(0, 50 - String.length(scoring_label))
       base + length_bonus
     end
+  end
+
+  @spec searchable_text(Item.t()) :: String.t()
+  defp searchable_text(%Item{} = item) do
+    [item.description, item.annotation, item.search_text]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" ")
+    |> String.downcase()
   end
 
   @spec strip_icon_prefix(String.t()) :: String.t()

--- a/lib/minga_editor/ui/picker/buffer_all_source.ex
+++ b/lib/minga_editor/ui/picker/buffer_all_source.ex
@@ -23,6 +23,10 @@ defmodule MingaEditor.UI.Picker.BufferAllSource do
   def preview?, do: true
 
   @impl true
+  @spec gui_preview?() :: boolean()
+  def gui_preview?, do: true
+
+  @impl true
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(ctx), do: BufferSource.build_candidates(ctx, include_special: true)
 

--- a/lib/minga_editor/ui/picker/buffer_source.ex
+++ b/lib/minga_editor/ui/picker/buffer_source.ex
@@ -27,6 +27,10 @@ defmodule MingaEditor.UI.Picker.BufferSource do
   def preview?, do: true
 
   @impl true
+  @spec gui_preview?() :: boolean()
+  def gui_preview?, do: true
+
+  @impl true
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(ctx), do: build_candidates(ctx, include_special: false)
 

--- a/lib/minga_editor/ui/picker/context.ex
+++ b/lib/minga_editor/ui/picker/context.ex
@@ -106,6 +106,12 @@ defmodule MingaEditor.UI.Picker.Context do
     }
   end
 
+  @doc "Returns a copy of the picker context with source-specific context data."
+  @spec with_picker_context(t(), map() | nil) :: t()
+  def with_picker_context(%__MODULE__{picker_ui: picker_ui} = ctx, context) do
+    %{ctx | picker_ui: PickerState.put_context(picker_ui, context)}
+  end
+
   @spec active_document_symbols(State.t()) :: [Minga.Language.Symbol.t()]
   defp active_document_symbols(%State{} = state) do
     case State.active_window_struct(state) do

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -26,6 +26,10 @@ defmodule MingaEditor.UI.Picker.FileSource do
   def preview?, do: true
 
   @impl true
+  @spec gui_preview?() :: boolean()
+  def gui_preview?, do: true
+
+  @impl true
   @spec candidates(Context.t() | nil) :: [Item.t()]
   def candidates(ctx) do
     root = project_root(ctx)

--- a/lib/minga_editor/ui/picker/git_changed_source.ex
+++ b/lib/minga_editor/ui/picker/git_changed_source.ex
@@ -26,6 +26,10 @@ defmodule MingaEditor.UI.Picker.GitChangedSource do
   def preview?, do: true
 
   @impl true
+  @spec gui_preview?() :: boolean()
+  def gui_preview?, do: true
+
+  @impl true
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(_ctx) do
     root = Minga.Project.resolve_root()

--- a/lib/minga_editor/ui/picker/git_log_file_source.ex
+++ b/lib/minga_editor/ui/picker/git_log_file_source.ex
@@ -1,0 +1,59 @@
+defmodule MingaEditor.UI.Picker.GitLogFileSource do
+  @moduledoc """
+  Current-file variant of the git log picker source.
+
+  This source delegates display and preview behavior to `GitLogSource` after deriving the active buffer's git root and relative path from the picker context.
+  """
+
+  @behaviour MingaEditor.UI.Picker.Source
+
+  alias Minga.Git
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.GitLogSource
+  alias MingaEditor.UI.Picker.Item
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Git Log"
+
+  @impl true
+  @spec preview?() :: boolean()
+  def preview?, do: true
+
+  @impl true
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{buffers: %{active: buf}} = ctx) when is_pid(buf) do
+    case Git.tracking_pid(buf) do
+      nil -> []
+      git_pid -> candidates_for_git_buffer(ctx, git_pid)
+    end
+  catch
+    :exit, _ -> []
+  end
+
+  def candidates(_ctx), do: []
+
+  @impl true
+  @spec on_select(Item.t(), term()) :: term()
+  defdelegate on_select(item, state), to: GitLogSource
+
+  @impl true
+  @spec on_cancel(term()) :: term()
+  defdelegate on_cancel(state), to: GitLogSource
+
+  @impl true
+  @spec preview(Item.t(), term()) :: [[MingaEditor.UI.Picker.Source.preview_segment()]] | nil
+  defdelegate preview(item, ctx), to: GitLogSource
+
+  @spec candidates_for_git_buffer(Context.t(), pid()) :: [Item.t()]
+  defp candidates_for_git_buffer(ctx, git_pid) do
+    context = %{
+      git_root: Git.Buffer.git_root(git_pid),
+      path: Git.Buffer.relative_path(git_pid)
+    }
+
+    ctx
+    |> Context.with_picker_context(context)
+    |> GitLogSource.candidates()
+  end
+end

--- a/lib/minga_editor/ui/picker/git_log_file_source.ex
+++ b/lib/minga_editor/ui/picker/git_log_file_source.ex
@@ -50,10 +50,11 @@ defmodule MingaEditor.UI.Picker.GitLogFileSource do
   defdelegate on_cancel(state), to: GitLogSource
 
   @impl true
-  @spec preview(Item.t(), MingaEditor.Frontend.Emit.Context.t()) :: [
-          [MingaEditor.UI.Picker.Source.preview_segment()]
-        ]
-        | nil
+  @spec preview(Item.t(), MingaEditor.Frontend.Emit.Context.t()) ::
+          [
+            [MingaEditor.UI.Picker.Source.preview_segment()]
+          ]
+          | nil
   defdelegate preview(item, ctx), to: GitLogSource
 
   @spec candidates_for_git_buffer(Context.t(), pid()) :: [Item.t()]

--- a/lib/minga_editor/ui/picker/git_log_file_source.ex
+++ b/lib/minga_editor/ui/picker/git_log_file_source.ex
@@ -21,6 +21,14 @@ defmodule MingaEditor.UI.Picker.GitLogFileSource do
   def preview?, do: true
 
   @impl true
+  @spec live_preview?() :: boolean()
+  def live_preview?, do: false
+
+  @impl true
+  @spec gui_preview?() :: boolean()
+  def gui_preview?, do: true
+
+  @impl true
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(%Context{buffers: %{active: buf}} = ctx) when is_pid(buf) do
     case Git.tracking_pid(buf) do
@@ -42,18 +50,32 @@ defmodule MingaEditor.UI.Picker.GitLogFileSource do
   defdelegate on_cancel(state), to: GitLogSource
 
   @impl true
-  @spec preview(Item.t(), term()) :: [[MingaEditor.UI.Picker.Source.preview_segment()]] | nil
+  @spec preview(Item.t(), MingaEditor.Frontend.Emit.Context.t()) :: [
+          [MingaEditor.UI.Picker.Source.preview_segment()]
+        ]
+        | nil
   defdelegate preview(item, ctx), to: GitLogSource
 
   @spec candidates_for_git_buffer(Context.t(), pid()) :: [Item.t()]
   defp candidates_for_git_buffer(ctx, git_pid) do
-    context = %{
-      git_root: Git.Buffer.git_root(git_pid),
-      path: Git.Buffer.relative_path(git_pid)
-    }
+    context =
+      %{
+        git_root: Git.Buffer.git_root(git_pid),
+        path: Git.Buffer.relative_path(git_pid),
+        source: __MODULE__
+      }
+      |> maybe_put_count(ctx)
 
     ctx
     |> Context.with_picker_context(context)
     |> GitLogSource.candidates()
   end
+
+  @spec maybe_put_count(map(), Context.t()) :: map()
+  defp maybe_put_count(context, %Context{picker_ui: %{context: %{count: count}}})
+       when is_integer(count) and count > 0 do
+    Map.put(context, :count, count)
+  end
+
+  defp maybe_put_count(context, _ctx), do: context
 end

--- a/lib/minga_editor/ui/picker/git_log_source.ex
+++ b/lib/minga_editor/ui/picker/git_log_source.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
 
   alias Minga.Git
   alias Minga.Log
+  alias MingaEditor.Frontend.Emit.Context, as: EmitContext
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.UI.Picker.Context
@@ -34,10 +35,18 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
   def preview?, do: true
 
   @impl true
+  @spec live_preview?() :: boolean()
+  def live_preview?, do: false
+
+  @impl true
+  @spec gui_preview?() :: boolean()
+  def gui_preview?, do: true
+
+  @impl true
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(%Context{} = ctx) do
     case git_root(ctx) do
-      {:ok, git_root} -> build_candidates(git_root, picker_path(ctx), picker_count(ctx))
+      {:ok, git_root} -> build_candidates(git_root, picker_path(ctx), picker_count(ctx), picker_source(ctx))
       :not_git -> []
     end
   catch
@@ -46,8 +55,13 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
 
   @impl true
   @spec on_select(Item.t(), EditorState.t()) :: EditorState.t()
+  def on_select(%Item{id: {:git_log_load_more, source_module, git_root, path, count}}, state)
+      when is_atom(source_module) do
+    PickerUI.open(state, source_module, load_more_context(git_root, path, count, source_module))
+  end
+
   def on_select(%Item{id: {:git_log_load_more, git_root, path, count}}, state) do
-    PickerUI.open(state, __MODULE__, load_more_context(git_root, path, count))
+    PickerUI.open(state, __MODULE__, load_more_context(git_root, path, count, __MODULE__))
   end
 
   def on_select(%Item{id: {:git_log_commit, _git_root, hash, _path}}, state) do
@@ -61,7 +75,7 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
   def on_cancel(state), do: state
 
   @impl true
-  @spec preview(Item.t(), term()) :: [[preview_segment()]] | nil
+  @spec preview(Item.t(), EmitContext.t()) :: [[preview_segment()]] | nil
   def preview(%Item{id: {:git_log_commit, git_root, hash, path}}, ctx) do
     case Git.diff(git_root, diff_opts(hash, path)) do
       {:ok, ""} -> [[{"No diff for this commit", preview_fg(ctx), false}]]
@@ -72,23 +86,23 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
 
   def preview(_item, _ctx), do: nil
 
-  @spec build_candidates(String.t(), String.t() | nil, pos_integer()) :: [Item.t()]
-  defp build_candidates(git_root, path, count) do
+  @spec build_candidates(String.t(), String.t() | nil, pos_integer(), module()) :: [Item.t()]
+  defp build_candidates(git_root, path, count, source_module) do
     case Git.log(git_root, count: count + 1, path: path) do
-      {:ok, entries} -> format_entries(entries, git_root, path, count)
+      {:ok, entries} -> format_entries(entries, git_root, path, count, source_module)
       {:error, reason} -> log_failure(reason)
     end
   end
 
-  @spec format_entries([Git.log_entry()], String.t(), String.t() | nil, pos_integer()) :: [
+  @spec format_entries([Git.log_entry()], String.t(), String.t() | nil, pos_integer(), module()) :: [
           Item.t()
         ]
-  defp format_entries(entries, git_root, path, count) do
+  defp format_entries(entries, git_root, path, count, source_module) do
     visible_entries = Enum.take(entries, count)
     items = Enum.map(visible_entries, &format_entry(&1, git_root, path))
 
     if length(entries) > count do
-      items ++ [load_more_item(git_root, path, count + @load_more_step)]
+      items ++ [load_more_item(git_root, path, count + @load_more_step, source_module)]
     else
       items
     end
@@ -105,10 +119,10 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
     }
   end
 
-  @spec load_more_item(String.t(), String.t() | nil, pos_integer()) :: Item.t()
-  defp load_more_item(git_root, path, count) do
+  @spec load_more_item(String.t(), String.t() | nil, pos_integer(), module()) :: Item.t()
+  defp load_more_item(git_root, path, count, source_module) do
     %Item{
-      id: {:git_log_load_more, git_root, path, count},
+      id: {:git_log_load_more, source_module, git_root, path, count},
       label: "Load more...",
       description: "Show #{count} commits",
       annotation: "+#{@load_more_step}"
@@ -143,17 +157,18 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
 
   defp picker_count(_ctx), do: @default_count
 
-  @spec load_more_context(String.t(), String.t() | nil, pos_integer()) :: map()
-  defp load_more_context(git_root, nil, count), do: %{git_root: git_root, count: count}
+  @spec load_more_context(String.t(), String.t() | nil, pos_integer(), module()) :: map()
+  defp load_more_context(git_root, nil, count, source_module),
+    do: %{git_root: git_root, count: count, source: source_module}
 
-  defp load_more_context(git_root, path, count),
-    do: %{git_root: git_root, path: path, count: count}
+  defp load_more_context(git_root, path, count, source_module),
+    do: %{git_root: git_root, path: path, count: count, source: source_module}
 
   @spec diff_opts(String.t(), String.t() | nil) :: keyword()
   defp diff_opts(hash, nil), do: [commit: hash]
   defp diff_opts(hash, path), do: [commit: hash, path: path]
 
-  @spec diff_preview_lines(String.t(), term()) :: [[preview_segment()]]
+  @spec diff_preview_lines(String.t(), EmitContext.t()) :: [[preview_segment()]]
   defp diff_preview_lines(diff, ctx) do
     diff
     |> String.split("\n")
@@ -161,7 +176,7 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
     |> Enum.map(&style_diff_line(&1, ctx))
   end
 
-  @spec style_diff_line(String.t(), term()) :: [preview_segment()]
+  @spec style_diff_line(String.t(), EmitContext.t()) :: [preview_segment()]
   defp style_diff_line("diff --git" <> _ = line, _ctx), do: [{line, @header_fg, true}]
   defp style_diff_line("@@" <> _ = line, _ctx), do: [{line, @hunk_fg, true}]
   defp style_diff_line("+++" <> _ = line, _ctx), do: [{line, @hash_fg, true}]
@@ -170,7 +185,11 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
   defp style_diff_line("-" <> _ = line, _ctx), do: [{line, @deleted_fg, false}]
   defp style_diff_line(line, ctx), do: [{line, preview_fg(ctx), false}]
 
-  @spec preview_fg(term()) :: non_neg_integer()
+  @spec preview_fg(EmitContext.t()) :: non_neg_integer()
   defp preview_fg(%{theme: theme}) when is_map(theme), do: Map.get(theme, :fg, @default_fg)
   defp preview_fg(_ctx), do: @default_fg
+
+  @spec picker_source(Context.t()) :: module()
+  defp picker_source(%Context{picker_ui: %{context: %{source: source}}}) when is_atom(source), do: source
+  defp picker_source(_ctx), do: __MODULE__
 end

--- a/lib/minga_editor/ui/picker/git_log_source.ex
+++ b/lib/minga_editor/ui/picker/git_log_source.ex
@@ -1,0 +1,176 @@
+defmodule MingaEditor.UI.Picker.GitLogSource do
+  @moduledoc """
+  Picker source for browsing recent git commits with diff previews.
+
+  The source powers the project log picker and the current-file log picker. Commit rows stay compact, while the GUI picker preview pane shows the selected commit's patch via the existing picker preview protocol.
+  """
+
+  @behaviour MingaEditor.UI.Picker.Source
+
+  alias Minga.Git
+  alias Minga.Log
+  alias MingaEditor.PickerUI
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.Item
+
+  @default_count 50
+  @load_more_step 50
+  @default_fg 0xCCCCCC
+  @hash_fg 0x61AFEF
+  @header_fg 0xC678DD
+  @hunk_fg 0x56B6C2
+  @added_fg 0x98C379
+  @deleted_fg 0xE06C75
+
+  @type preview_segment :: {String.t(), non_neg_integer(), boolean()}
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Git Log"
+
+  @impl true
+  @spec preview?() :: boolean()
+  def preview?, do: true
+
+  @impl true
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{} = ctx) do
+    case git_root(ctx) do
+      {:ok, git_root} -> build_candidates(git_root, picker_path(ctx), picker_count(ctx))
+      :not_git -> []
+    end
+  catch
+    :exit, _ -> []
+  end
+
+  @impl true
+  @spec on_select(Item.t(), EditorState.t()) :: EditorState.t()
+  def on_select(%Item{id: {:git_log_load_more, git_root, path, count}}, state) do
+    PickerUI.open(state, __MODULE__, load_more_context(git_root, path, count))
+  end
+
+  def on_select(%Item{id: {:git_log_commit, _git_root, hash, _path}}, state) do
+    EditorState.set_status(state, "Git commit #{String.slice(hash, 0, 12)}")
+  end
+
+  def on_select(_item, state), do: state
+
+  @impl true
+  @spec on_cancel(EditorState.t()) :: EditorState.t()
+  def on_cancel(state), do: state
+
+  @impl true
+  @spec preview(Item.t(), term()) :: [[preview_segment()]] | nil
+  def preview(%Item{id: {:git_log_commit, git_root, hash, path}}, ctx) do
+    case Git.diff(git_root, diff_opts(hash, path)) do
+      {:ok, ""} -> [[{"No diff for this commit", preview_fg(ctx), false}]]
+      {:ok, diff} -> diff_preview_lines(diff, ctx)
+      {:error, reason} -> [[{"Failed to load diff: #{reason}", @deleted_fg, false}]]
+    end
+  end
+
+  def preview(_item, _ctx), do: nil
+
+  @spec build_candidates(String.t(), String.t() | nil, pos_integer()) :: [Item.t()]
+  defp build_candidates(git_root, path, count) do
+    case Git.log(git_root, count: count + 1, path: path) do
+      {:ok, entries} -> format_entries(entries, git_root, path, count)
+      {:error, reason} -> log_failure(reason)
+    end
+  end
+
+  @spec format_entries([Git.log_entry()], String.t(), String.t() | nil, pos_integer()) :: [
+          Item.t()
+        ]
+  defp format_entries(entries, git_root, path, count) do
+    visible_entries = Enum.take(entries, count)
+    items = Enum.map(visible_entries, &format_entry(&1, git_root, path))
+
+    if length(entries) > count do
+      items ++ [load_more_item(git_root, path, count + @load_more_step)]
+    else
+      items
+    end
+  end
+
+  @spec format_entry(Git.log_entry(), String.t(), String.t() | nil) :: Item.t()
+  defp format_entry(entry, git_root, path) do
+    %Item{
+      id: {:git_log_commit, git_root, entry.hash, path},
+      label: entry.message,
+      description: "#{entry.author} · #{entry.date}",
+      annotation: entry.short_hash,
+      search_text: "#{entry.hash} #{entry.short_hash} #{entry.author} #{entry.message}"
+    }
+  end
+
+  @spec load_more_item(String.t(), String.t() | nil, pos_integer()) :: Item.t()
+  defp load_more_item(git_root, path, count) do
+    %Item{
+      id: {:git_log_load_more, git_root, path, count},
+      label: "Load more...",
+      description: "Show #{count} commits",
+      annotation: "+#{@load_more_step}"
+    }
+  end
+
+  @spec log_failure(String.t()) :: []
+  defp log_failure(reason) do
+    Log.warning(:editor, "[git_log_picker] git log failed: #{reason}")
+    []
+  end
+
+  @spec git_root(Context.t()) :: {:ok, String.t()} | :not_git
+  defp git_root(%Context{picker_ui: %{context: %{git_root: git_root}}})
+       when is_binary(git_root) do
+    {:ok, git_root}
+  end
+
+  defp git_root(_ctx) do
+    Minga.Project.resolve_root()
+    |> Git.root_for()
+  end
+
+  @spec picker_path(Context.t()) :: String.t() | nil
+  defp picker_path(%Context{picker_ui: %{context: %{path: path}}}) when is_binary(path), do: path
+  defp picker_path(_ctx), do: nil
+
+  @spec picker_count(Context.t()) :: pos_integer()
+  defp picker_count(%Context{picker_ui: %{context: %{count: count}}})
+       when is_integer(count) and count > 0,
+       do: count
+
+  defp picker_count(_ctx), do: @default_count
+
+  @spec load_more_context(String.t(), String.t() | nil, pos_integer()) :: map()
+  defp load_more_context(git_root, nil, count), do: %{git_root: git_root, count: count}
+
+  defp load_more_context(git_root, path, count),
+    do: %{git_root: git_root, path: path, count: count}
+
+  @spec diff_opts(String.t(), String.t() | nil) :: keyword()
+  defp diff_opts(hash, nil), do: [commit: hash]
+  defp diff_opts(hash, path), do: [commit: hash, path: path]
+
+  @spec diff_preview_lines(String.t(), term()) :: [[preview_segment()]]
+  defp diff_preview_lines(diff, ctx) do
+    diff
+    |> String.split("\n")
+    |> Enum.take(200)
+    |> Enum.map(&style_diff_line(&1, ctx))
+  end
+
+  @spec style_diff_line(String.t(), term()) :: [preview_segment()]
+  defp style_diff_line("diff --git" <> _ = line, _ctx), do: [{line, @header_fg, true}]
+  defp style_diff_line("@@" <> _ = line, _ctx), do: [{line, @hunk_fg, true}]
+  defp style_diff_line("+++" <> _ = line, _ctx), do: [{line, @hash_fg, true}]
+  defp style_diff_line("---" <> _ = line, _ctx), do: [{line, @hash_fg, true}]
+  defp style_diff_line("+" <> _ = line, _ctx), do: [{line, @added_fg, false}]
+  defp style_diff_line("-" <> _ = line, _ctx), do: [{line, @deleted_fg, false}]
+  defp style_diff_line(line, ctx), do: [{line, preview_fg(ctx), false}]
+
+  @spec preview_fg(term()) :: non_neg_integer()
+  defp preview_fg(%{theme: theme}) when is_map(theme), do: Map.get(theme, :fg, @default_fg)
+  defp preview_fg(_ctx), do: @default_fg
+end

--- a/lib/minga_editor/ui/picker/git_log_source.ex
+++ b/lib/minga_editor/ui/picker/git_log_source.ex
@@ -46,8 +46,11 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(%Context{} = ctx) do
     case git_root(ctx) do
-      {:ok, git_root} -> build_candidates(git_root, picker_path(ctx), picker_count(ctx), picker_source(ctx))
-      :not_git -> []
+      {:ok, git_root} ->
+        build_candidates(git_root, picker_path(ctx), picker_count(ctx), picker_source(ctx))
+
+      :not_git ->
+        []
     end
   catch
     :exit, _ -> []
@@ -94,9 +97,10 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
     end
   end
 
-  @spec format_entries([Git.log_entry()], String.t(), String.t() | nil, pos_integer(), module()) :: [
-          Item.t()
-        ]
+  @spec format_entries([Git.log_entry()], String.t(), String.t() | nil, pos_integer(), module()) ::
+          [
+            Item.t()
+          ]
   defp format_entries(entries, git_root, path, count, source_module) do
     visible_entries = Enum.take(entries, count)
     items = Enum.map(visible_entries, &format_entry(&1, git_root, path))
@@ -190,6 +194,8 @@ defmodule MingaEditor.UI.Picker.GitLogSource do
   defp preview_fg(_ctx), do: @default_fg
 
   @spec picker_source(Context.t()) :: module()
-  defp picker_source(%Context{picker_ui: %{context: %{source: source}}}) when is_atom(source), do: source
+  defp picker_source(%Context{picker_ui: %{context: %{source: source}}}) when is_atom(source),
+    do: source
+
   defp picker_source(_ctx), do: __MODULE__
 end

--- a/lib/minga_editor/ui/picker/item.ex
+++ b/lib/minga_editor/ui/picker/item.ex
@@ -18,6 +18,7 @@ defmodule MingaEditor.UI.Picker.Item do
   - `:icon_color` — 24-bit RGB color for the first grapheme (the icon) of the label
   - `:annotation` — right-aligned metadata (keybinding, status indicator),
     styled distinctly from the description (e.g., "SPC f s" for commands)
+  - `:search_text` — hidden text included in fuzzy matching but not rendered
   - `:match_positions` — 0-based character indices of matched characters in the
     label, computed during fuzzy filtering for rendering highlights
   - `:two_line` — when true, renders description on a second line below the label
@@ -31,6 +32,7 @@ defmodule MingaEditor.UI.Picker.Item do
     description: "",
     icon_color: nil,
     annotation: nil,
+    search_text: "",
     match_positions: [],
     two_line: false
   ]
@@ -41,6 +43,7 @@ defmodule MingaEditor.UI.Picker.Item do
           description: String.t(),
           icon_color: non_neg_integer() | nil,
           annotation: String.t() | nil,
+          search_text: String.t(),
           match_positions: [non_neg_integer()],
           two_line: boolean()
         }

--- a/lib/minga_editor/ui/picker/recent_file_source.ex
+++ b/lib/minga_editor/ui/picker/recent_file_source.ex
@@ -26,6 +26,10 @@ defmodule MingaEditor.UI.Picker.RecentFileSource do
   def preview?, do: true
 
   @impl true
+  @spec gui_preview?() :: boolean()
+  def gui_preview?, do: true
+
+  @impl true
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(_ctx) do
     files = Project.recent_files()

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -12,6 +12,7 @@ defmodule MingaEditor.UI.Picker.Source do
   - `on_select/2` — called when the user selects an item; returns new editor state
   - `on_cancel/1` — called when the user cancels; returns new editor state
   - `preview?/0` — whether navigating the picker should preview the selection (default: false)
+  - `preview/2` — optional source-provided GUI preview content for the selected item
   - `title/0` — the picker title shown in the separator bar
 
   ## Example
@@ -59,6 +60,12 @@ defmodule MingaEditor.UI.Picker.Source do
   @doc "Whether navigating the picker should live-preview the selection."
   @callback preview?() :: boolean()
 
+  @typedoc "A styled preview segment: display text, 24-bit foreground color, bold flag."
+  @type preview_segment :: {String.t(), non_neg_integer(), boolean()}
+
+  @doc "Returns source-provided GUI preview content for an item."
+  @callback preview(Picker.item(), context :: term()) :: [[preview_segment()]] | nil
+
   @typedoc "An alternative action: display name and action identifier."
   @type action_entry :: {name :: String.t(), action_id :: atom()}
 
@@ -96,7 +103,14 @@ defmodule MingaEditor.UI.Picker.Source do
   """
   @callback keep_open_on_select?() :: boolean()
 
-  @optional_callbacks [preview?: 0, actions: 1, on_action: 3, layout: 0, keep_open_on_select?: 0]
+  @optional_callbacks [
+    preview?: 0,
+    preview: 2,
+    actions: 1,
+    on_action: 3,
+    layout: 0,
+    keep_open_on_select?: 0
+  ]
 
   @doc """
   Default `on_cancel` implementation: restores the buffer that was active
@@ -124,6 +138,18 @@ defmodule MingaEditor.UI.Picker.Source do
       module.preview?()
     else
       false
+    end
+  end
+
+  @doc """
+  Returns source-provided preview content, or nil when no preview callback exists.
+  """
+  @spec preview(module(), Picker.item(), term()) :: [[preview_segment()]] | nil
+  def preview(module, item, context) do
+    if exported?(module, :preview, 2) do
+      module.preview(item, context)
+    else
+      nil
     end
   end
 

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -11,8 +11,10 @@ defmodule MingaEditor.UI.Picker.Source do
   - `candidates/1` — returns the list of picker items given some context
   - `on_select/2` — called when the user selects an item; returns new editor state
   - `on_cancel/1` — called when the user cancels; returns new editor state
-  - `preview?/0` — whether navigating the picker should preview the selection (default: false)
-  - `preview/2` — optional source-provided GUI preview content for the selected item
+  - `preview?/0` — legacy live-navigation preview flag (default: false)
+  - `live_preview?/0` — whether navigating the picker should temporarily run `on_select/2` for the highlighted item (default: `preview?/0` for backwards compatibility)
+  - `gui_preview?/0` — whether the GUI preview pane should be shown for this source (default: false)
+  - `preview/2` — optional source-provided GUI preview content for the selected item, called with the render context
   - `title/0` — the picker title shown in the separator bar
 
   ## Example
@@ -34,6 +36,7 @@ defmodule MingaEditor.UI.Picker.Source do
       end
   """
 
+  alias MingaEditor.Frontend.Emit.Context, as: EmitContext
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.UI.Picker
   alias MingaEditor.UI.Picker.Context
@@ -57,14 +60,23 @@ defmodule MingaEditor.UI.Picker.Source do
   @doc "Called when the user cancels the picker. Returns the new editor state."
   @callback on_cancel(state :: term()) :: term()
 
-  @doc "Whether navigating the picker should live-preview the selection."
+  @doc "Legacy live-navigation preview flag."
   @callback preview?() :: boolean()
+
+  @doc "Whether navigating the picker should live-preview the selection."
+  @callback live_preview?() :: boolean()
+
+  @doc "Whether the GUI preview pane should be shown for this source."
+  @callback gui_preview?() :: boolean()
 
   @typedoc "A styled preview segment: display text, 24-bit foreground color, bold flag."
   @type preview_segment :: {String.t(), non_neg_integer(), boolean()}
 
+  @typedoc "Render context passed to `preview/2` from the GUI emit pipeline."
+  @type preview_context :: EmitContext.t()
+
   @doc "Returns source-provided GUI preview content for an item."
-  @callback preview(Picker.item(), context :: term()) :: [[preview_segment()]] | nil
+  @callback preview(Picker.item(), context :: preview_context()) :: [[preview_segment()]] | nil
 
   @typedoc "An alternative action: display name and action identifier."
   @type action_entry :: {name :: String.t(), action_id :: atom()}
@@ -105,6 +117,8 @@ defmodule MingaEditor.UI.Picker.Source do
 
   @optional_callbacks [
     preview?: 0,
+    live_preview?: 0,
+    gui_preview?: 0,
     preview: 2,
     actions: 1,
     on_action: 3,
@@ -129,7 +143,7 @@ defmodule MingaEditor.UI.Picker.Source do
   end
 
   @doc """
-  Returns whether a source module supports preview.
+  Returns whether a source module should live-preview the highlighted item.
   Falls back to `false` if the callback is not implemented.
   """
   @spec preview?(module()) :: boolean()
@@ -144,12 +158,32 @@ defmodule MingaEditor.UI.Picker.Source do
   @doc """
   Returns source-provided preview content, or nil when no preview callback exists.
   """
-  @spec preview(module(), Picker.item(), term()) :: [[preview_segment()]] | nil
+  @spec preview(module(), Picker.item(), preview_context()) :: [[preview_segment()]] | nil
   def preview(module, item, context) do
     if exported?(module, :preview, 2) do
       module.preview(item, context)
     else
       nil
+    end
+  end
+
+  @doc "Returns whether navigating the picker should live-preview the selection."
+  @spec live_preview?(module()) :: boolean()
+  def live_preview?(module) do
+    if exported?(module, :live_preview?, 0) do
+      module.live_preview?()
+    else
+      preview?(module)
+    end
+  end
+
+  @doc "Whether the GUI preview pane should be shown for the source."
+  @spec gui_preview?(module()) :: boolean()
+  def gui_preview?(module) do
+    if exported?(module, :gui_preview?, 0) do
+      module.gui_preview?()
+    else
+      false
     end
   end
 

--- a/test/minga/command/registry_test.exs
+++ b/test/minga/command/registry_test.exs
@@ -99,6 +99,8 @@ defmodule Minga.Command.RegistryTest do
           :git_revert_hunk,
           :git_preview_hunk,
           :git_blame_line,
+          :git_log,
+          :git_log_file,
 
           # Folding
           :fold_toggle,

--- a/test/minga/git/backend_operations_test.exs
+++ b/test/minga/git/backend_operations_test.exs
@@ -182,6 +182,71 @@ defmodule Minga.Git.BackendOperationsTest do
     end
   end
 
+  describe "diff/2" do
+    @tag :tmp_dir
+    test "returns a commit diff for commit: hash", %{tmp_dir: dir} do
+      init_git_repo(dir)
+      file = Path.join(dir, "file.txt")
+      File.write!(file, "original\n")
+      git_cmd(dir, ["add", "file.txt"])
+      git_cmd(dir, ["commit", "-m", "init"])
+
+      File.write!(file, "changed\n")
+      git_cmd(dir, ["add", "file.txt"])
+      git_cmd(dir, ["commit", "-m", "update"])
+
+      {hash, 0} = git_cmd(dir, ["rev-parse", "HEAD"])
+      assert {:ok, diff} = Minga.Git.System.diff(dir, commit: String.trim(hash))
+
+      assert diff =~ "diff --git a/file.txt b/file.txt"
+      assert diff =~ "+changed"
+    end
+
+    @tag :tmp_dir
+    test "returns a commit diff when staged is explicitly false", %{tmp_dir: dir} do
+      init_git_repo(dir)
+      file = Path.join(dir, "file.txt")
+      File.write!(file, "original\n")
+      git_cmd(dir, ["add", "file.txt"])
+      git_cmd(dir, ["commit", "-m", "init"])
+
+      File.write!(file, "changed\n")
+      git_cmd(dir, ["add", "file.txt"])
+      git_cmd(dir, ["commit", "-m", "update"])
+
+      {hash, 0} = git_cmd(dir, ["rev-parse", "HEAD"])
+      commit = String.trim(hash)
+
+      assert {:ok, diff} = Minga.Git.System.diff(dir, commit: commit, staged: false)
+
+      assert diff =~ "diff --git a/file.txt b/file.txt"
+      assert diff =~ "+changed"
+    end
+
+    @tag :tmp_dir
+    test "returns a path-specific commit diff when commit and path are given", %{tmp_dir: dir} do
+      init_git_repo(dir)
+      file_a = Path.join(dir, "a.txt")
+      file_b = Path.join(dir, "b.txt")
+      File.write!(file_a, "a1\n")
+      File.write!(file_b, "b1\n")
+      git_cmd(dir, ["add", "."])
+      git_cmd(dir, ["commit", "-m", "init"])
+
+      File.write!(file_a, "a2\n")
+      File.write!(file_b, "b2\n")
+      git_cmd(dir, ["add", "."])
+      git_cmd(dir, ["commit", "-m", "update"])
+
+      {hash, 0} = git_cmd(dir, ["rev-parse", "HEAD"])
+      assert {:ok, diff} = Minga.Git.System.diff(dir, commit: String.trim(hash), path: "a.txt")
+
+      assert diff =~ "diff --git a/a.txt b/a.txt"
+      assert diff =~ "+a2"
+      refute diff =~ "b.txt"
+    end
+  end
+
   # ── Helpers ──────────────────────────────────────────────────────────────
 
   defp init_git_repo(dir) do

--- a/test/minga/git_test.exs
+++ b/test/minga/git_test.exs
@@ -56,6 +56,42 @@ defmodule Minga.GitTest do
       assert {:ok, "+commit line"} = Git.diff(dir, commit: "abc123")
     end
 
+    test "diff returns commit-specific text when staged is explicitly false", %{root: dir} do
+      GitStub.set_diff(dir, [commit: "abc123", staged: false], "+commit line")
+      assert {:ok, "+commit line"} = Git.diff(dir, commit: "abc123", staged: false)
+    end
+
+    test "diff returns path-specific commit text", %{root: dir} do
+      GitStub.set_diff(dir, [commit: "abc123", path: "lib/app.ex"], "+file line")
+      assert {:ok, "+file line"} = Git.diff(dir, commit: "abc123", path: "lib/app.ex")
+    end
+
+    test "diff rejects commit and staged together", %{root: dir} do
+      assert {:error, reason} = Git.diff(dir, commit: "abc123", staged: true)
+      assert reason =~ "cannot be combined"
+    end
+
+    test "diff rejects unknown option keys", %{root: dir} do
+      assert {:error, reason} = Git.diff(dir, foo: "bar")
+      assert reason =~ "not supported"
+    end
+
+    test "diff rejects duplicate option keys", %{root: dir} do
+      assert {:error, reason} = Git.diff(dir, [commit: "abc123", commit: "def456"])
+      assert reason =~ "duplicate keys"
+    end
+
+    test "diff rejects non-binary path, commit, and non-boolean staged values", %{root: dir} do
+      assert {:error, path_reason} = Git.diff(dir, path: :path)
+      assert path_reason =~ ":path"
+
+      assert {:error, commit_reason} = Git.diff(dir, commit: :commit)
+      assert commit_reason =~ ":commit"
+
+      assert {:error, staged_reason} = Git.diff(dir, staged: :staged)
+      assert staged_reason =~ ":staged"
+    end
+
     test "log returns configured entries", %{root: dir} do
       entry = %Git.LogEntry{
         hash: "abc",

--- a/test/minga/git_test.exs
+++ b/test/minga/git_test.exs
@@ -51,6 +51,11 @@ defmodule Minga.GitTest do
       assert {:ok, "+new line"} = Git.diff(dir)
     end
 
+    test "diff returns commit-specific text", %{root: dir} do
+      GitStub.set_diff(dir, [commit: "abc123"], "+commit line")
+      assert {:ok, "+commit line"} = Git.diff(dir, commit: "abc123")
+    end
+
     test "log returns configured entries", %{root: dir} do
       entry = %Git.LogEntry{
         hash: "abc",

--- a/test/minga/git_test.exs
+++ b/test/minga/git_test.exs
@@ -77,7 +77,7 @@ defmodule Minga.GitTest do
     end
 
     test "diff rejects duplicate option keys", %{root: dir} do
-      assert {:error, reason} = Git.diff(dir, [commit: "abc123", commit: "def456"])
+      assert {:error, reason} = Git.diff(dir, commit: "abc123", commit: "def456")
       assert reason =~ "duplicate keys"
     end
 

--- a/test/minga/keymap/defaults_test.exs
+++ b/test/minga/keymap/defaults_test.exs
@@ -96,6 +96,18 @@ defmodule Minga.Keymap.DefaultsTest do
 
     # ── Git bindings ──────────────────────────────────────────────────────────
 
+    test "SPC g l → :git_log" do
+      trie = Defaults.leader_trie()
+      {:prefix, g_node} = Bindings.lookup(trie, {?g, 0})
+      assert {:command, :git_log} = Bindings.lookup(g_node, {?l, 0})
+    end
+
+    test "SPC g f → :git_changed_files" do
+      trie = Defaults.leader_trie()
+      {:prefix, g_node} = Bindings.lookup(trie, {?g, 0})
+      assert {:command, :git_changed_files} = Bindings.lookup(g_node, {?f, 0})
+    end
+
     test "SPC g x c/i/b → merge conflict accept commands" do
       trie = Defaults.leader_trie()
       {:prefix, g_node} = Bindings.lookup(trie, {?g, 0})

--- a/test/minga_editor/commands/git_remote_test.exs
+++ b/test/minga_editor/commands/git_remote_test.exs
@@ -22,6 +22,8 @@ defmodule MingaEditor.Commands.GitRemoteTest do
       assert :git_stash_pop in names
       assert :git_stash_list in names
       assert :git_stash_drop in names
+      assert :git_log in names
+      assert :git_log_file in names
     end
   end
 

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -25,6 +25,36 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
 
   import MingaEditor.RenderPipeline.TestHelpers
 
+  defmodule PreviewSource do
+    @behaviour MingaEditor.UI.Picker.Source
+
+    alias MingaEditor.UI.Picker.Item
+
+    @impl true
+    def title, do: "Preview source"
+
+    @impl true
+    def preview?, do: true
+
+    @impl true
+    def live_preview?, do: false
+
+    @impl true
+    def gui_preview?, do: true
+
+    @impl true
+    def candidates(_ctx), do: [%Item{id: :preview, label: "preview"}]
+
+    @impl true
+    def on_select(_item, state), do: state
+
+    @impl true
+    def on_cancel(state), do: state
+
+    @impl true
+    def preview(_item, _ctx), do: [[{"source preview", 0xFFFFFF, false}]]
+  end
+
   @moduletag :tmp_dir
 
   describe "sync_swiftui_chrome/4 fingerprint caching" do
@@ -207,6 +237,14 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
       {_ctx, caches2, _cmds} = sync_chrome(state_b, caches)
 
       refute caches2.last_gui_picker_fp == caches.last_gui_picker_fp
+    end
+
+    test "picker sync emits source-provided GUI preview content" do
+      state = open_test_picker_with_source(gui_state(), "preview", PreviewSource)
+
+      {_ctx, _caches, cmds} = sync_chrome(state)
+
+      assert Enum.any?(cmds, &String.contains?(&1, "source preview"))
     end
 
     test "minibuffer cache changes when encoded candidate metadata changes" do
@@ -404,12 +442,16 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
   end
 
   defp open_test_picker(state, label, mode_prefix \\ "") do
+    open_test_picker_with_source(state, label, nil, mode_prefix)
+  end
+
+  defp open_test_picker_with_source(state, label, source, mode_prefix \\ "") do
     item = %MingaEditor.UI.Picker.Item{id: "same-id", label: label}
     picker = MingaEditor.UI.Picker.new([item], title: "Test")
 
     picker_state = %MingaEditor.State.Picker{
       picker: picker,
-      source: nil,
+      source: source,
       action_menu: nil,
       mode_prefix: mode_prefix
     }

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -514,6 +514,20 @@ defmodule MingaEditor.PickerUITest do
                  false
              end)
     end
+
+    test "typing fix in git log stays in the fuzzy query" do
+      {state, _original_buf, _preview_buf} = preview_promotion_state()
+
+      picker = Picker.new([%Item{id: "abc123", label: "abc123"}], title: "Git Log")
+      picker_state = %PickerState{picker: picker, source: MingaEditor.UI.Picker.GitLogSource}
+      state = put_in(state.shell_state.modal, {:picker, PickerPayload.new(picker_state)})
+
+      state = Enum.reduce(~c"fix", state, fn cp, acc -> PickerUI.handle_key(acc, cp, 0) end)
+      {:picker, %{picker_ui: pui}} = state.shell_state.modal
+
+      assert pui.source == MingaEditor.UI.Picker.GitLogSource
+      assert pui.picker.query == "fix"
+    end
   end
 
   describe "render/1 centered layout" do

--- a/test/minga_editor/ui/picker/git_log_source_test.exs
+++ b/test/minga_editor/ui/picker/git_log_source_test.exs
@@ -6,12 +6,18 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
   alias Minga.Buffer
   alias Minga.Git
   alias Minga.Git.Stub, as: GitStub
+  alias MingaEditor.PickerUI
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Picker, as: PickerState
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.UI.Picker
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.GitLogFileSource
   alias MingaEditor.UI.Picker.GitLogSource
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.Viewport
 
   @moduletag :tmp_dir
 
@@ -21,13 +27,8 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
     %{root: dir, ctx: context(dir)}
   end
 
-  test "candidates show commit message, hash annotation, author, and date", %{
-    root: root,
-    ctx: ctx
-  } do
-    GitStub.set_log(root, [
-      commit("abc123456789", "abc1234", "Ada", "2 days ago", "Add picker preview")
-    ])
+  test "candidates show commit message, hash annotation, author, and date", %{root: root, ctx: ctx} do
+    GitStub.set_log(root, [commit("abc123456789", "abc1234", "Ada", "2 days ago", "Add picker preview")])
 
     assert [item] = GitLogSource.candidates(ctx)
     assert item.label == "Add picker preview"
@@ -36,9 +37,7 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
   end
 
   test "commits are searchable by message, author, and hash", %{root: root, ctx: ctx} do
-    GitStub.set_log(root, [
-      commit("abc123456789", "abc1234", "Ada", "2 days ago", "Add picker preview")
-    ])
+    GitStub.set_log(root, [commit("abc123456789", "abc1234", "Ada", "2 days ago", "Add picker preview")])
 
     items = GitLogSource.candidates(ctx)
 
@@ -48,8 +47,7 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
   end
 
   test "candidate list includes a load more item when more commits exist", %{root: root, ctx: ctx} do
-    entries =
-      Enum.map(1..51, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
+    entries = Enum.map(1..51, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
 
     GitStub.set_log(root, entries)
 
@@ -59,7 +57,33 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
     assert List.last(items).label == "Load more..."
   end
 
+  test "highlighting load more does not load more commits until enter", %{root: root} do
+    entries = Enum.map(1..101, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
+    GitStub.set_log(root, entries)
+
+    {:ok, active_buf} = Buffer.start_link(content: "new\n")
+    state = file_log_state(active_buf)
+    state = PickerUI.open(state, GitLogSource, %{git_root: root})
+
+    state = Enum.reduce(1..50, state, fn _, acc -> PickerUI.handle_key(acc, 57_353, 0) end)
+    {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+
+    assert picker_ui.source == GitLogSource
+    assert picker_ui.context == %{git_root: root}
+    assert Picker.count(picker_ui.picker) == 51
+    assert Picker.selected_item(picker_ui.picker).label == "Load more..."
+
+    state = PickerUI.handle_key(state, 13, 0)
+    {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+
+    assert picker_ui.source == GitLogSource
+    assert picker_ui.context.source == GitLogSource
+    assert picker_ui.context.git_root == root
+    assert Picker.count(picker_ui.picker) == 101
+  end
+
   test "preview returns styled diff lines for the selected commit", %{root: root, ctx: ctx} do
+    preview_ctx = %{theme: %{fg: 0xCCCCCC}}
     GitStub.set_log(root, [commit("abc123456789", "abc1234", "Ada", "today", "Edit")])
 
     GitStub.set_diff(
@@ -75,7 +99,30 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
              [{"@@ -1 +1 @@", _hunk_color, true}],
              [{"-old", _deleted_color, false}],
              [{"+new", _added_color, false}]
-           ] = GitLogSource.preview(item, ctx)
+           ] = GitLogSource.preview(item, preview_ctx)
+  end
+
+  test "preview uses file-scoped diff options when a path is present", %{root: root} do
+    preview_ctx = %{theme: %{fg: 0xCCCCCC}}
+    rel_path = "lib/demo.ex"
+    GitStub.set_log(root, [commit("abc123456789", "abc1234", "Ada", "today", "Edit")])
+
+    GitStub.set_diff(root, [commit: "abc123456789"], "diff --git a/other.ex b/other.ex\n+wrong")
+
+    GitStub.set_diff(
+      root,
+      [commit: "abc123456789", path: rel_path],
+      "diff --git a/lib/demo.ex b/lib/demo.ex\n@@ -1 +1 @@\n-old\n+new"
+    )
+
+    item = %Item{id: {:git_log_commit, root, "abc123456789", rel_path}, label: "Edit"}
+
+    assert [
+             [{"diff --git a/lib/demo.ex b/lib/demo.ex", _header_color, true}],
+             [{"@@ -1 +1 @@", _hunk_color, true}],
+             [{"-old", _deleted_color, false}],
+             [{"+new", _added_color, false}]
+           ] = GitLogSource.preview(item, preview_ctx)
   end
 
   test "file source filters commits to the active buffer path", %{root: root, ctx: ctx} do
@@ -104,6 +151,46 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
     assert item.label == "Edit current file"
   end
 
+  test "loading more from a file-scoped git log keeps the file source", %{root: root} do
+    rel_path = "lib/demo.ex"
+    abs_path = Path.join(root, rel_path)
+    File.mkdir_p!(Path.dirname(abs_path))
+    File.write!(abs_path, "new\n")
+
+    entries = Enum.map(1..101, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
+    GitStub.set_log(root, [count: 51, path: rel_path], Enum.take(entries, 51))
+    GitStub.set_log(root, [count: 101, path: rel_path], Enum.take(entries, 101))
+
+    {:ok, source_buf} = Buffer.start_link(content: "new\n")
+
+    {:ok, git_buf} =
+      Minga.Git.Buffer.start_link(
+        git_root: root,
+        file_path: abs_path,
+        initial_content: "new\n"
+      )
+
+    put_tracking(source_buf, git_buf)
+
+    state = file_log_state(source_buf)
+    state = PickerUI.open(state, GitLogFileSource)
+
+    state = Enum.reduce(1..50, state, fn _, acc -> PickerUI.handle_key(acc, 57_353, 0) end)
+    {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+
+    assert picker_ui.source == GitLogFileSource
+    assert Picker.count(picker_ui.picker) == 51
+    assert Picker.selected_item(picker_ui.picker).label == "Load more..."
+
+    state = PickerUI.handle_key(state, 13, 0)
+    {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+
+    assert picker_ui.source == GitLogFileSource
+    assert picker_ui.context.source == GitLogFileSource
+    assert picker_ui.context.path == rel_path
+    assert Picker.count(picker_ui.picker) == 101
+  end
+
   defp context(root) do
     %Context{
       buffers: %Buffers{},
@@ -114,6 +201,17 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
       picker_ui: %PickerState{context: %{git_root: root}},
       capabilities: %{},
       theme: %{fg: 0xCCCCCC}
+    }
+  end
+
+  defp file_log_state(active_buf) do
+    %State{
+      port_manager: self(),
+      workspace: %SessionState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{active: active_buf, list: [active_buf], active_index: 0}
+      },
+      shell_state: %ShellState{}
     }
   end
 

--- a/test/minga_editor/ui/picker/git_log_source_test.exs
+++ b/test/minga_editor/ui/picker/git_log_source_test.exs
@@ -27,8 +27,13 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
     %{root: dir, ctx: context(dir)}
   end
 
-  test "candidates show commit message, hash annotation, author, and date", %{root: root, ctx: ctx} do
-    GitStub.set_log(root, [commit("abc123456789", "abc1234", "Ada", "2 days ago", "Add picker preview")])
+  test "candidates show commit message, hash annotation, author, and date", %{
+    root: root,
+    ctx: ctx
+  } do
+    GitStub.set_log(root, [
+      commit("abc123456789", "abc1234", "Ada", "2 days ago", "Add picker preview")
+    ])
 
     assert [item] = GitLogSource.candidates(ctx)
     assert item.label == "Add picker preview"
@@ -37,7 +42,9 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
   end
 
   test "commits are searchable by message, author, and hash", %{root: root, ctx: ctx} do
-    GitStub.set_log(root, [commit("abc123456789", "abc1234", "Ada", "2 days ago", "Add picker preview")])
+    GitStub.set_log(root, [
+      commit("abc123456789", "abc1234", "Ada", "2 days ago", "Add picker preview")
+    ])
 
     items = GitLogSource.candidates(ctx)
 
@@ -47,7 +54,8 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
   end
 
   test "candidate list includes a load more item when more commits exist", %{root: root, ctx: ctx} do
-    entries = Enum.map(1..51, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
+    entries =
+      Enum.map(1..51, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
 
     GitStub.set_log(root, entries)
 
@@ -58,7 +66,9 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
   end
 
   test "highlighting load more does not load more commits until enter", %{root: root} do
-    entries = Enum.map(1..101, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
+    entries =
+      Enum.map(1..101, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
+
     GitStub.set_log(root, entries)
 
     {:ok, active_buf} = Buffer.start_link(content: "new\n")
@@ -157,7 +167,9 @@ defmodule MingaEditor.UI.Picker.GitLogSourceTest do
     File.mkdir_p!(Path.dirname(abs_path))
     File.write!(abs_path, "new\n")
 
-    entries = Enum.map(1..101, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
+    entries =
+      Enum.map(1..101, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
+
     GitStub.set_log(root, [count: 51, path: rel_path], Enum.take(entries, 51))
     GitStub.set_log(root, [count: 101, path: rel_path], Enum.take(entries, 101))
 

--- a/test/minga_editor/ui/picker/git_log_source_test.exs
+++ b/test/minga_editor/ui/picker/git_log_source_test.exs
@@ -1,0 +1,140 @@
+defmodule MingaEditor.UI.Picker.GitLogSourceTest do
+  @moduledoc "Tests for the git log picker source."
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer
+  alias Minga.Git
+  alias Minga.Git.Stub, as: GitStub
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Picker, as: PickerState
+  alias MingaEditor.UI.Picker
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.GitLogFileSource
+  alias MingaEditor.UI.Picker.GitLogSource
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: dir} do
+    GitStub.set_root(dir, dir)
+    on_exit(fn -> GitStub.clear(dir) end)
+    %{root: dir, ctx: context(dir)}
+  end
+
+  test "candidates show commit message, hash annotation, author, and date", %{
+    root: root,
+    ctx: ctx
+  } do
+    GitStub.set_log(root, [
+      commit("abc123456789", "abc1234", "Ada", "2 days ago", "Add picker preview")
+    ])
+
+    assert [item] = GitLogSource.candidates(ctx)
+    assert item.label == "Add picker preview"
+    assert item.annotation == "abc1234"
+    assert item.description == "Ada · 2 days ago"
+  end
+
+  test "commits are searchable by message, author, and hash", %{root: root, ctx: ctx} do
+    GitStub.set_log(root, [
+      commit("abc123456789", "abc1234", "Ada", "2 days ago", "Add picker preview")
+    ])
+
+    items = GitLogSource.candidates(ctx)
+
+    assert Picker.new(items) |> Picker.filter("preview") |> Picker.count() == 1
+    assert Picker.new(items) |> Picker.filter("Ada") |> Picker.count() == 1
+    assert Picker.new(items) |> Picker.filter("abc123456789") |> Picker.count() == 1
+  end
+
+  test "candidate list includes a load more item when more commits exist", %{root: root, ctx: ctx} do
+    entries =
+      Enum.map(1..51, fn n -> commit("hash#{n}", "h#{n}", "Ada", "today", "Commit #{n}") end)
+
+    GitStub.set_log(root, entries)
+
+    items = GitLogSource.candidates(ctx)
+
+    assert length(items) == 51
+    assert List.last(items).label == "Load more..."
+  end
+
+  test "preview returns styled diff lines for the selected commit", %{root: root, ctx: ctx} do
+    GitStub.set_log(root, [commit("abc123456789", "abc1234", "Ada", "today", "Edit")])
+
+    GitStub.set_diff(
+      root,
+      [commit: "abc123456789"],
+      "diff --git a/a b/a\n@@ -1 +1 @@\n-old\n+new"
+    )
+
+    [item] = GitLogSource.candidates(ctx)
+
+    assert [
+             [{"diff --git a/a b/a", _header_color, true}],
+             [{"@@ -1 +1 @@", _hunk_color, true}],
+             [{"-old", _deleted_color, false}],
+             [{"+new", _added_color, false}]
+           ] = GitLogSource.preview(item, ctx)
+  end
+
+  test "file source filters commits to the active buffer path", %{root: root, ctx: ctx} do
+    rel_path = "lib/demo.ex"
+    abs_path = Path.join(root, rel_path)
+    File.mkdir_p!(Path.dirname(abs_path))
+    File.write!(abs_path, "new\n")
+
+    entry = commit("filehash", "file123", "Ada", "today", "Edit current file")
+    GitStub.set_head(root, rel_path, "old\n")
+    GitStub.set_log(root, [count: 51, path: rel_path], [entry])
+
+    {:ok, source_buf} = Buffer.start_link(content: "new\n")
+
+    {:ok, git_buf} =
+      Minga.Git.Buffer.start_link(
+        git_root: root,
+        file_path: abs_path,
+        initial_content: "new\n"
+      )
+
+    put_tracking(source_buf, git_buf)
+    file_ctx = %{ctx | buffers: %Buffers{active: source_buf, list: [source_buf]}}
+
+    assert [item] = GitLogFileSource.candidates(file_ctx)
+    assert item.label == "Edit current file"
+  end
+
+  defp context(root) do
+    %Context{
+      buffers: %Buffers{},
+      editing: nil,
+      search: nil,
+      viewport: nil,
+      tab_bar: nil,
+      picker_ui: %PickerState{context: %{git_root: root}},
+      capabilities: %{},
+      theme: %{fg: 0xCCCCCC}
+    }
+  end
+
+  defp commit(hash, short_hash, author, date, message) do
+    %Git.LogEntry{
+      hash: hash,
+      short_hash: short_hash,
+      author: author,
+      date: date,
+      message: message
+    }
+  end
+
+  defp put_tracking(source_buf, git_buf) do
+    table = Minga.Git.Tracker.Registry
+
+    if :ets.whereis(table) == :undefined do
+      :ets.new(table, [:named_table, :public, :set, read_concurrency: true])
+    end
+
+    :ets.insert(table, {source_buf, git_buf})
+    on_exit(fn -> if :ets.whereis(table) != :undefined, do: :ets.delete(table, source_buf) end)
+  end
+end

--- a/test/minga_editor/ui/picker/overhaul_test.exs
+++ b/test/minga_editor/ui/picker/overhaul_test.exs
@@ -103,6 +103,16 @@ defmodule MingaEditor.UI.Picker.OverhaulTest do
       assert item.match_positions != []
     end
 
+    test "filtering matches hidden search text" do
+      items = [
+        %Item{id: :a, label: "visible", description: "", search_text: "hidden hash abc123"}
+      ]
+
+      picker = Picker.new(items, title: "Test") |> Picker.filter("abc123")
+
+      assert Picker.count(picker) == 1
+    end
+
     test "empty query clears match_positions" do
       picker =
         Picker.new(@items, title: "Test")
@@ -143,6 +153,11 @@ defmodule MingaEditor.UI.Picker.OverhaulTest do
     test "match_positions defaults to empty list" do
       item = %Item{id: :test, label: "test"}
       assert item.match_positions == []
+    end
+
+    test "search_text defaults to an empty string" do
+      item = %Item{id: :test, label: "test"}
+      assert item.search_text == ""
     end
   end
 end

--- a/test/minga_editor/ui/picker/source_test.exs
+++ b/test/minga_editor/ui/picker/source_test.exs
@@ -154,9 +154,10 @@ defmodule MingaEditor.UI.Picker.SourceTest do
     end
 
     test "returns preview lines for source with preview callback" do
-      assert Source.preview(WithPreviewSource, {:a, "item", "desc"}, %{theme: %{fg: 0xFFFFFF}}) == [
-               [{"preview", 0xFFFFFF, false}]
-             ]
+      assert Source.preview(WithPreviewSource, {:a, "item", "desc"}, %{theme: %{fg: 0xFFFFFF}}) ==
+               [
+                 [{"preview", 0xFFFFFF, false}]
+               ]
     end
   end
 

--- a/test/minga_editor/ui/picker/source_test.exs
+++ b/test/minga_editor/ui/picker/source_test.exs
@@ -38,7 +38,45 @@ defmodule MingaEditor.UI.Picker.SourceTest do
     def on_cancel(state), do: state
 
     @impl true
-    def preview(_item, _context), do: [[{"preview", 0xFFFFFF, false}]]
+    def preview(_item, %{theme: %{fg: fg}}), do: [[{"preview", fg, false}]]
+  end
+
+  defmodule LivePreviewOnlySource do
+    @behaviour MingaEditor.UI.Picker.Source
+
+    @impl true
+    def title, do: "Live preview only"
+
+    @impl true
+    def candidates(_ctx), do: [{:a, "item", "desc"}]
+
+    @impl true
+    def on_select(_item, state), do: state
+
+    @impl true
+    def on_cancel(state), do: state
+
+    @impl true
+    def preview?, do: true
+  end
+
+  defmodule WithGuiPreviewSource do
+    @behaviour MingaEditor.UI.Picker.Source
+
+    @impl true
+    def title, do: "With GUI preview"
+
+    @impl true
+    def candidates(_ctx), do: [{:a, "item", "desc"}]
+
+    @impl true
+    def on_select(_item, state), do: state
+
+    @impl true
+    def on_cancel(state), do: state
+
+    @impl true
+    def gui_preview?, do: true
   end
 
   defmodule WithActionsSource do
@@ -86,9 +124,27 @@ defmodule MingaEditor.UI.Picker.SourceTest do
     end
   end
 
-  describe "preview?/1" do
-    test "returns false for source without preview? callback" do
+  describe "preview/live_preview/gui_preview helpers" do
+    test "returns false for source without preview callbacks" do
       refute Source.preview?(NoActionsSource)
+      refute Source.live_preview?(NoActionsSource)
+      refute Source.gui_preview?(NoActionsSource)
+    end
+
+    test "live preview falls back to preview?/0 for navigation-only sources" do
+      assert Source.preview?(LivePreviewOnlySource)
+      assert Source.live_preview?(LivePreviewOnlySource)
+      refute Source.gui_preview?(LivePreviewOnlySource)
+    end
+
+    test "preview/2 provides content but does not enable the GUI pane by itself" do
+      refute Source.gui_preview?(WithPreviewSource)
+    end
+
+    test "GUI preview can be enabled explicitly without preview/2" do
+      assert Source.gui_preview?(WithGuiPreviewSource)
+      refute Source.preview?(WithGuiPreviewSource)
+      refute Source.live_preview?(WithGuiPreviewSource)
     end
   end
 
@@ -98,7 +154,7 @@ defmodule MingaEditor.UI.Picker.SourceTest do
     end
 
     test "returns preview lines for source with preview callback" do
-      assert Source.preview(WithPreviewSource, {:a, "item", "desc"}, %{}) == [
+      assert Source.preview(WithPreviewSource, {:a, "item", "desc"}, %{theme: %{fg: 0xFFFFFF}}) == [
                [{"preview", 0xFFFFFF, false}]
              ]
     end

--- a/test/minga_editor/ui/picker/source_test.exs
+++ b/test/minga_editor/ui/picker/source_test.exs
@@ -22,6 +22,25 @@ defmodule MingaEditor.UI.Picker.SourceTest do
     def on_cancel(state), do: state
   end
 
+  defmodule WithPreviewSource do
+    @behaviour MingaEditor.UI.Picker.Source
+
+    @impl true
+    def title, do: "With preview"
+
+    @impl true
+    def candidates(_ctx), do: [{:a, "item", "desc"}]
+
+    @impl true
+    def on_select(_item, state), do: state
+
+    @impl true
+    def on_cancel(state), do: state
+
+    @impl true
+    def preview(_item, _context), do: [[{"preview", 0xFFFFFF, false}]]
+  end
+
   defmodule WithActionsSource do
     @behaviour MingaEditor.UI.Picker.Source
 
@@ -70,6 +89,18 @@ defmodule MingaEditor.UI.Picker.SourceTest do
   describe "preview?/1" do
     test "returns false for source without preview? callback" do
       refute Source.preview?(NoActionsSource)
+    end
+  end
+
+  describe "preview/3" do
+    test "returns nil for source without preview callback" do
+      assert Source.preview(NoActionsSource, {:a, "item", "desc"}, %{}) == nil
+    end
+
+    test "returns preview lines for source with preview callback" do
+      assert Source.preview(WithPreviewSource, {:a, "item", "desc"}, %{}) == [
+               [{"preview", 0xFFFFFF, false}]
+             ]
     end
   end
 

--- a/test/support/git_stub.ex
+++ b/test/support/git_stub.ex
@@ -198,7 +198,7 @@ defmodule Minga.Git.Stub do
   end
 
   @impl true
-  @spec diff(String.t(), keyword()) :: {:ok, String.t()}
+  @spec diff(String.t(), Minga.Git.diff_opts()) :: {:ok, String.t()}
   def diff(git_root, opts \\ []) do
     expanded = Path.expand(git_root)
 

--- a/test/support/git_stub.ex
+++ b/test/support/git_stub.ex
@@ -81,17 +81,31 @@ defmodule Minga.Git.Stub do
     :ok
   end
 
-  @doc "Sets the log entries returned for `git_root`."
+  @doc "Sets the default log entries returned for `git_root`."
   @spec set_log(String.t(), [Minga.Git.log_entry()]) :: :ok
   def set_log(git_root, entries) when is_list(entries) do
     :ets.insert(@table, {{:log, Path.expand(git_root)}, entries})
     :ok
   end
 
-  @doc "Sets the diff output returned for `git_root`."
+  @doc "Sets the log entries returned for `git_root` and a specific options keyword list."
+  @spec set_log(String.t(), keyword(), [Minga.Git.log_entry()]) :: :ok
+  def set_log(git_root, opts, entries) when is_list(opts) and is_list(entries) do
+    :ets.insert(@table, {{:log, Path.expand(git_root), normalize_opts(opts)}, entries})
+    :ok
+  end
+
+  @doc "Sets the default diff output returned for `git_root`."
   @spec set_diff(String.t(), String.t()) :: :ok
   def set_diff(git_root, diff_text) when is_binary(diff_text) do
     :ets.insert(@table, {{:diff, Path.expand(git_root)}, diff_text})
+    :ok
+  end
+
+  @doc "Sets the diff output returned for `git_root` and a specific options keyword list."
+  @spec set_diff(String.t(), keyword(), String.t()) :: :ok
+  def set_diff(git_root, opts, diff_text) when is_list(opts) and is_binary(diff_text) do
+    :ets.insert(@table, {{:diff, Path.expand(git_root), normalize_opts(opts)}, diff_text})
     :ok
   end
 
@@ -131,7 +145,9 @@ defmodule Minga.Git.Stub do
     :ets.match_delete(@table, {{:staged, expanded, :_}, :_})
     :ets.match_delete(@table, {{:staged_paths, expanded}, :_})
     :ets.match_delete(@table, {{:log, expanded}, :_})
+    :ets.match_delete(@table, {{:log, expanded, :_}, :_})
     :ets.match_delete(@table, {{:diff, expanded}, :_})
+    :ets.match_delete(@table, {{:diff, expanded, :_}, :_})
     :ets.match_delete(@table, {{:branch, expanded}, :_})
     :ets.match_delete(@table, {{:branches, expanded}, :_})
     :ets.match_delete(@table, {{:branch_delete, expanded, :_, :_}, :_})
@@ -183,19 +199,35 @@ defmodule Minga.Git.Stub do
 
   @impl true
   @spec diff(String.t(), keyword()) :: {:ok, String.t()}
-  def diff(git_root, _opts \\ []) do
-    case :ets.lookup(@table, {:diff, Path.expand(git_root)}) do
-      [{_, text}] -> {:ok, text}
-      [] -> {:ok, ""}
+  def diff(git_root, opts \\ []) do
+    expanded = Path.expand(git_root)
+
+    case :ets.lookup(@table, {:diff, expanded, normalize_opts(opts)}) do
+      [{_, text}] ->
+        {:ok, text}
+
+      [] ->
+        case :ets.lookup(@table, {:diff, expanded}) do
+          [{_, text}] -> {:ok, text}
+          [] -> {:ok, ""}
+        end
     end
   end
 
   @impl true
   @spec log(String.t(), keyword()) :: {:ok, [Minga.Git.log_entry()]}
-  def log(git_root, _opts \\ []) do
-    case :ets.lookup(@table, {:log, Path.expand(git_root)}) do
-      [{_, entries}] -> {:ok, entries}
-      [] -> {:ok, []}
+  def log(git_root, opts \\ []) do
+    expanded = Path.expand(git_root)
+
+    case :ets.lookup(@table, {:log, expanded, normalize_opts(opts)}) do
+      [{_, entries}] ->
+        {:ok, entries}
+
+      [] ->
+        case :ets.lookup(@table, {:log, expanded}) do
+          [{_, entries}] -> {:ok, entries}
+          [] -> {:ok, []}
+        end
     end
   end
 
@@ -459,6 +491,11 @@ defmodule Minga.Git.Stub do
       [] ->
         :ok
     end
+  end
+
+  @spec normalize_opts(keyword()) :: keyword()
+  defp normalize_opts(opts) do
+    Enum.sort_by(opts, fn {key, _value} -> key end)
   end
 
   # Walks up the directory tree looking for a registered root, just like


### PR DESCRIPTION
## Summary
- Adds a Git log picker with commit diff preview support.
- Adds `Git.diff(git_root, commit: hash)` support for commit previews.
- Adds picker source preview support and searchable metadata for commit hashes/authors.

Closes #986

## Validation
- `mix test.llm test/minga_editor/ui/picker test/minga/git_test.exs` passed in prior session.
- `mix test.llm test/minga_editor/picker_ui_test.exs test/minga_editor/ui/picker/git_log_source_test.exs test/minga_editor/ui/picker/source_test.exs` passed in prior session.
- `git diff --check` passed.
- `make lint` passed after rerun.
- Final reviewer targeted re-review passed.
- Full `mix test.llm` was attempted twice; unrelated intermittent failures passed in isolation.
