### PR TITLE
feat(git): add stash operations

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -773,7 +773,7 @@ When no splits are active, the BEAM sends counts of 0 for both separator types.
 Git status panel data for the native sidebar, plus remote operation feedback used by the sidebar and status bar.
 
 ```
-opcode(1) + repo_state(1) + syncing(1) + ahead(2) + behind(2) + branch_len(2) + branch(branch_len) + entry_count(2) + entries... + toast_present(1) + toast? + entry_base_path_len(2) + entry_base_path(entry_base_path_len) + last_commit_message_len(2) + last_commit_message(last_commit_message_len)
+opcode(1) + repo_state(1) + syncing(1) + ahead(2) + behind(2) + branch_len(2) + branch(branch_len) + entry_count(2) + entries... + toast_present(1) + toast? + entry_base_path_len(2) + entry_base_path(entry_base_path_len) + last_commit_message_len(2) + last_commit_message(last_commit_message_len) + stash_count(2)
 
 Per entry:
   path_hash(4) + section(1) + status(1) + path_len(2) + path(path_len)
@@ -789,6 +789,7 @@ Toast when toast_present == 1:
 `status`: 0 = unknown, 1 = modified, 2 = added, 3 = deleted, 4 = renamed, 5 = copied, 6 = untracked, 7 = conflict.
 `level`: 0 = success, 1 = error.
 `action`: 0 = none, 1 = pull_and_retry.
+`stash_count`: number of stashes in the repository, clamped to 65,535. Frontends should show it only when greater than zero.
 
 When the git status panel is closed, the BEAM sends `repo_state = not_a_repo`, no entries, and an empty `entry_base_path` as the hide signal. A non-git project opened in the Source Control tab also uses `repo_state = not_a_repo`, but includes the project root so the frontend can show the native "Not a git repository" empty state instead of hiding the panel. The frontend should still copy `syncing` and `toast` so remote operation feedback remains accurate while the panel is hidden.
 

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -149,7 +149,15 @@ defmodule Minga.Events do
   defmodule GitStatusEvent do
     @moduledoc "Payload for `:git_status_changed` events. Published by `Git.Repo` when repo status changes."
     @enforce_keys [:git_root, :entries, :branch, :ahead, :behind]
-    defstruct [:git_root, :entries, :branch, :ahead, :behind, last_commit_message: ""]
+    defstruct [
+      :git_root,
+      :entries,
+      :branch,
+      :ahead,
+      :behind,
+      last_commit_message: "",
+      stash_count: 0
+    ]
 
     @type t :: %__MODULE__{
             git_root: String.t(),
@@ -157,7 +165,8 @@ defmodule Minga.Events do
             branch: String.t() | nil,
             ahead: non_neg_integer(),
             behind: non_neg_integer(),
-            last_commit_message: String.t()
+            last_commit_message: String.t(),
+            stash_count: non_neg_integer()
           }
   end
 

--- a/lib/minga/git.ex
+++ b/lib/minga/git.ex
@@ -8,6 +8,8 @@ defmodule Minga.Git do
       config :minga, git_module: Minga.Git.Stub
   """
 
+  alias Minga.Git.StashEntry
+
   defmodule StatusEntry do
     @moduledoc false
     @enforce_keys [:path, :status, :staged]
@@ -62,6 +64,9 @@ defmodule Minga.Git do
 
   @typedoc "A structured log entry."
   @type log_entry :: LogEntry.t()
+
+  @typedoc "A structured stash entry."
+  @type stash_entry :: StashEntry.t()
 
   # ── Delegated operations (go through the backend) ──────────────────────
 
@@ -203,6 +208,22 @@ defmodule Minga.Git do
   @spec branch_delete(String.t(), String.t(), boolean()) :: :ok | {:error, String.t()}
   def branch_delete(git_root, name, force \\ false),
     do: impl().branch_delete(git_root, name, force)
+
+  @doc "Saves current worktree changes to a stash."
+  @spec stash(String.t(), keyword()) :: :ok | {:error, String.t()}
+  def stash(git_root, opts \\ []), do: impl().stash(git_root, opts)
+
+  @doc "Pops the most recent stash."
+  @spec stash_pop(String.t()) :: :ok | {:error, String.t()}
+  def stash_pop(git_root), do: impl().stash_pop(git_root)
+
+  @doc "Lists stashes for a repository."
+  @spec stash_list(String.t()) :: {:ok, [stash_entry()]} | {:error, String.t()}
+  def stash_list(git_root), do: impl().stash_list(git_root)
+
+  @doc "Drops a stash by index."
+  @spec stash_drop(String.t(), non_neg_integer()) :: :ok | {:error, String.t()}
+  def stash_drop(git_root, index), do: impl().stash_drop(git_root, index)
 
   @doc "Pushes the current branch to its upstream remote."
   @spec push(String.t(), keyword()) :: :ok | {:error, String.t()}

--- a/lib/minga/git/backend.ex
+++ b/lib/minga/git/backend.ex
@@ -75,6 +75,18 @@ defmodule Minga.Git.Backend do
   @callback branch_delete(git_root :: String.t(), name :: String.t(), force :: boolean()) ::
               :ok | {:error, String.t()}
 
+  @callback stash(git_root :: String.t(), opts :: keyword()) ::
+              :ok | {:error, String.t()}
+
+  @callback stash_pop(git_root :: String.t()) ::
+              :ok | {:error, String.t()}
+
+  @callback stash_list(git_root :: String.t()) ::
+              {:ok, [Minga.Git.stash_entry()]} | {:error, String.t()}
+
+  @callback stash_drop(git_root :: String.t(), index :: non_neg_integer()) ::
+              :ok | {:error, String.t()}
+
   @callback push(git_root :: String.t(), opts :: keyword()) ::
               :ok | {:error, String.t()}
 

--- a/lib/minga/git/repo.ex
+++ b/lib/minga/git/repo.ex
@@ -39,6 +39,7 @@ defmodule Minga.Git.Repo do
     ahead: 0,
     behind: 0,
     last_commit_message: "",
+    stash_count: 0,
     watcher_pid: nil,
     debounce_ref: nil,
     events_registry: Minga.Events.default_registry()
@@ -53,6 +54,7 @@ defmodule Minga.Git.Repo do
           ahead: non_neg_integer(),
           behind: non_neg_integer(),
           last_commit_message: String.t(),
+          stash_count: non_neg_integer(),
           watcher_pid: pid() | nil,
           debounce_ref: reference() | nil,
           events_registry: Minga.Events.registry()
@@ -73,7 +75,8 @@ defmodule Minga.Git.Repo do
           unstaged_count: non_neg_integer(),
           untracked_count: non_neg_integer(),
           conflict_count: non_neg_integer(),
-          last_commit_message: String.t()
+          last_commit_message: String.t(),
+          stash_count: non_neg_integer()
         }
 
   # ── Client API ─────────────────────────────────────────────────────────
@@ -216,9 +219,8 @@ defmodule Minga.Git.Repo do
   @spec handle_info(term(), t()) :: {:noreply, t()}
   def handle_info({:file_event, _watcher_pid, {path, _events}}, state) do
     path_str = to_string(path)
-    basename = Path.basename(path_str)
 
-    if basename in ["index", "HEAD", "MERGE_HEAD", "REBASE_HEAD"] do
+    if refresh_path?(path_str) do
       {:noreply, schedule_debounce(state)}
     else
       {:noreply, state}
@@ -267,11 +269,13 @@ defmodule Minga.Git.Repo do
     old_ahead = state.ahead
     old_behind = state.behind
     old_last_commit_message = state.last_commit_message
+    old_stash_count = state.stash_count
 
     entries = fetch_status(state.git_root, state.project_root)
     branch = fetch_branch(state.git_root)
     {ahead, behind} = fetch_ahead_behind(state.git_root)
     last_commit_message = fetch_last_commit_message(state.git_root)
+    stash_count = fetch_stash_count(state.git_root)
 
     state = %{
       state
@@ -279,14 +283,15 @@ defmodule Minga.Git.Repo do
         branch: branch,
         ahead: ahead,
         behind: behind,
-        last_commit_message: last_commit_message
+        last_commit_message: last_commit_message,
+        stash_count: stash_count
     }
 
     # Broadcast only if something changed
     changed =
       entries != old_entries or branch != old_branch or
         ahead != old_ahead or behind != old_behind or
-        last_commit_message != old_last_commit_message
+        last_commit_message != old_last_commit_message or stash_count != old_stash_count
 
     if changed do
       Minga.Events.broadcast(
@@ -297,13 +302,30 @@ defmodule Minga.Git.Repo do
           branch: branch,
           ahead: ahead,
           behind: behind,
-          last_commit_message: last_commit_message
+          last_commit_message: last_commit_message,
+          stash_count: stash_count
         },
         state.events_registry
       )
     end
 
     state
+  end
+
+  @spec refresh_path?(String.t()) :: boolean()
+  defp refresh_path?(path_str) do
+    basename = Path.basename(path_str)
+    git_status_file?(basename) or stash_ref_path?(path_str)
+  end
+
+  @spec git_status_file?(String.t()) :: boolean()
+  defp git_status_file?(basename) do
+    basename in ["index", "HEAD", "MERGE_HEAD", "REBASE_HEAD"]
+  end
+
+  @spec stash_ref_path?(String.t()) :: boolean()
+  defp stash_ref_path?(path_str) do
+    String.ends_with?(path_str, "/refs/stash") or String.ends_with?(path_str, "/logs/refs/stash")
   end
 
   @spec fetch_status(String.t(), String.t() | nil) :: [StatusEntry.t()]
@@ -340,6 +362,20 @@ defmodule Minga.Git.Repo do
       {:ok, message} -> message
       :error -> ""
     end
+  end
+
+  @spec fetch_stash_count(String.t()) :: non_neg_integer()
+  defp fetch_stash_count(git_root) do
+    case Git.stash_list(git_root) do
+      {:ok, entries} -> length(entries)
+      {:error, reason} -> log_stash_count_failure(reason)
+    end
+  end
+
+  @spec log_stash_count_failure(String.t()) :: 0
+  defp log_stash_count_failure(reason) do
+    Minga.Log.warning(:editor, "[Git.Repo] stash list failed: #{reason}")
+    0
   end
 
   @spec maybe_relativize_paths([StatusEntry.t()], String.t(), String.t() | nil) :: [
@@ -381,7 +417,8 @@ defmodule Minga.Git.Repo do
       unstaged_count: counts.unstaged,
       untracked_count: counts.untracked,
       conflict_count: counts.conflict,
-      last_commit_message: state.last_commit_message
+      last_commit_message: state.last_commit_message,
+      stash_count: state.stash_count
     }
   end
 

--- a/lib/minga/git/stash_entry.ex
+++ b/lib/minga/git/stash_entry.ex
@@ -1,0 +1,13 @@
+defmodule Minga.Git.StashEntry do
+  @moduledoc "Structured information about a git stash."
+
+  @enforce_keys [:index, :ref, :message, :date]
+  defstruct [:index, :ref, :message, :date]
+
+  @type t :: %__MODULE__{
+          index: non_neg_integer(),
+          ref: String.t(),
+          message: String.t(),
+          date: String.t()
+        }
+end

--- a/lib/minga/git/system.ex
+++ b/lib/minga/git/system.ex
@@ -372,6 +372,74 @@ defmodule Minga.Git.System do
   end
 
   @impl true
+  @spec stash(String.t(), keyword()) :: :ok | {:error, String.t()}
+  def stash(git_root, opts \\ []) when is_binary(git_root) do
+    args = ["stash", "push"]
+
+    args =
+      if Keyword.get(opts, :include_untracked, false),
+        do: args ++ ["--include-untracked"],
+        else: args
+
+    case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
+      {_, 0} -> :ok
+      {output, _} -> {:error, "git stash failed: #{String.trim(output)}"}
+    end
+  rescue
+    e in [ErlangError, ArgumentError] -> {:error, "git stash error: #{Exception.message(e)}"}
+  end
+
+  @impl true
+  @spec stash_pop(String.t()) :: :ok | {:error, String.t()}
+  def stash_pop(git_root) when is_binary(git_root) do
+    case System.cmd("git", ["stash", "pop"], cd: git_root, stderr_to_stdout: true) do
+      {_, 0} -> :ok
+      {output, _} -> {:error, "git stash pop failed: #{String.trim(output)}"}
+    end
+  rescue
+    e in [ErlangError, ArgumentError] -> {:error, "git stash pop error: #{Exception.message(e)}"}
+  end
+
+  @impl true
+  @spec stash_list(String.t()) :: {:ok, [Minga.Git.stash_entry()]} | {:error, String.t()}
+  def stash_list(git_root) when is_binary(git_root) do
+    format = "%gd%x1f%cr%x1f%gs"
+
+    case System.cmd("git", ["stash", "list", "--format=#{format}"],
+           cd: git_root,
+           stderr_to_stdout: true
+         ) do
+      {output, 0} ->
+        entries =
+          output
+          |> String.split("\n", trim: true)
+          |> Enum.map(&parse_stash_line/1)
+          |> Enum.reject(&is_nil/1)
+
+        {:ok, entries}
+
+      {output, _} ->
+        {:error, "git stash list failed: #{String.trim(output)}"}
+    end
+  rescue
+    e in [ErlangError, ArgumentError] -> {:error, "git stash list error: #{Exception.message(e)}"}
+  end
+
+  @impl true
+  @spec stash_drop(String.t(), non_neg_integer()) :: :ok | {:error, String.t()}
+  def stash_drop(git_root, index) when is_binary(git_root) and is_integer(index) and index >= 0 do
+    case System.cmd("git", ["stash", "drop", "stash@{#{index}}"],
+           cd: git_root,
+           stderr_to_stdout: true
+         ) do
+      {_, 0} -> :ok
+      {output, _} -> {:error, "git stash drop failed: #{String.trim(output)}"}
+    end
+  rescue
+    e in [ErlangError, ArgumentError] -> {:error, "git stash drop error: #{Exception.message(e)}"}
+  end
+
+  @impl true
   @spec push(String.t(), keyword()) :: :ok | {:error, String.t()}
   def push(git_root, opts \\ []) when is_binary(git_root) do
     args = ["push"]
@@ -553,6 +621,30 @@ defmodule Minga.Git.System do
 
       _ ->
         nil
+    end
+  end
+
+  @spec parse_stash_line(String.t()) :: Minga.Git.stash_entry() | nil
+  defp parse_stash_line(line) do
+    case String.split(line, <<0x1F>>) do
+      [ref, date, message] -> build_stash_entry(stash_index(ref), ref, date, message)
+      _ -> nil
+    end
+  end
+
+  @spec build_stash_entry({:ok, non_neg_integer()} | :error, String.t(), String.t(), String.t()) ::
+          Minga.Git.stash_entry() | nil
+  defp build_stash_entry({:ok, index}, ref, date, message) do
+    %Minga.Git.StashEntry{index: index, ref: ref, date: date, message: message}
+  end
+
+  defp build_stash_entry(:error, _ref, _date, _message), do: nil
+
+  @spec stash_index(String.t()) :: {:ok, non_neg_integer()} | :error
+  defp stash_index(ref) do
+    case Regex.run(~r/stash@\{(\d+)\}/, ref) do
+      [_, index] -> {:ok, String.to_integer(index)}
+      _ -> :error
     end
   end
 

--- a/lib/minga/git/system.ex
+++ b/lib/minga/git/system.ex
@@ -388,7 +388,8 @@ defmodule Minga.Git.System do
           _ -> :ok
         end
 
-      {output, _} -> {:error, "git stash failed: #{String.trim(output)}"}
+      {output, _} ->
+        {:error, "git stash failed: #{String.trim(output)}"}
     end
   rescue
     e in [ErlangError, ArgumentError] -> {:error, "git stash error: #{Exception.message(e)}"}

--- a/lib/minga/git/system.ex
+++ b/lib/minga/git/system.ex
@@ -382,7 +382,12 @@ defmodule Minga.Git.System do
         else: args
 
     case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
-      {_, 0} -> :ok
+      {output, 0} ->
+        case String.trim(output) do
+          "No local changes to save" -> {:error, "No changes to stash"}
+          _ -> :ok
+        end
+
       {output, _} -> {:error, "git stash failed: #{String.trim(output)}"}
     end
   rescue

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -134,6 +134,10 @@ defmodule Minga.Keymap.Defaults do
     {~k(g x c), :git_accept_current_conflict, "Accept current conflict"},
     {~k(g x i), :git_accept_incoming_conflict, "Accept incoming conflict"},
     {~k(g x b), :git_accept_both_conflict, "Accept both conflict sides"},
+    {~k(g z z), :git_stash_save, "Stash changes"},
+    {~k(g z p), :git_stash_pop, "Pop stash"},
+    {~k(g z l), :git_stash_list, "List stashes"},
+    {~k(g z d), :git_stash_drop, "Drop stash"},
     {~k(g c g), :git_generate_commit_message, "Generate AI commit message"},
 
     # ── Project ────────────────────────────────────────────────────────────────
@@ -216,6 +220,7 @@ defmodule Minga.Keymap.Defaults do
     {~k(g), "+git"},
     {~k(g c), "+commit"},
     {~k(g x), "+conflict"},
+    {~k(g z), "+stash"},
     {~k(w), "+window"},
     {~k(q), "+quit"},
     {~k(h), "+help"},

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -1163,9 +1163,14 @@ defmodule MingaEditor.Commands.Git do
   end
 
   @spec stash_save_status(state(), String.t()) :: state()
-  defp stash_save_status(state, "No changes to stash"), do: EditorState.set_status(state, "No changes to stash")
-  defp stash_save_status(state, "No local changes to save"), do: EditorState.set_status(state, "No changes to stash")
-  defp stash_save_status(state, reason), do: EditorState.set_status(state, "Stash failed: #{reason}")
+  defp stash_save_status(state, "No changes to stash"),
+    do: EditorState.set_status(state, "No changes to stash")
+
+  defp stash_save_status(state, "No local changes to save"),
+    do: EditorState.set_status(state, "No changes to stash")
+
+  defp stash_save_status(state, reason),
+    do: EditorState.set_status(state, "Stash failed: #{reason}")
 
   @spec refresh_repo(String.t()) :: :ok
   defp refresh_repo(git_root) do

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -20,6 +20,7 @@ defmodule MingaEditor.Commands.Git do
   alias Minga.Git.MergeConflict.Region
   alias Minga.Language
   alias MingaEditor.UI.Picker.GitChangedSource
+  alias MingaEditor.UI.Picker.GitStashSource
 
   @type state :: EditorState.t()
 
@@ -35,6 +36,10 @@ defmodule MingaEditor.Commands.Git do
     {:git_status_toggle, "Git status", false},
     {:git_changed_files, "Changed files", false},
     {:git_branch_picker, "Switch branch", false},
+    {:git_stash_save, "Stash changes", false},
+    {:git_stash_pop, "Pop stash", false},
+    {:git_stash_list, "List stashes", false},
+    {:git_stash_drop, "Drop stash", false},
     {:git_push, "Push", false},
     {:git_pull, "Pull", false},
     {:git_fetch, "Fetch", false},
@@ -87,6 +92,42 @@ defmodule MingaEditor.Commands.Git do
 
   def execute(state, :git_branch_picker) do
     PickerUI.open(state, MingaEditor.UI.Picker.GitBranchSource)
+  end
+
+  def execute(state, :git_stash_save) do
+    with_git_root(state, fn git_root ->
+      case Git.stash(git_root, include_untracked: true) do
+        :ok ->
+          refresh_repo(git_root)
+          EditorState.set_status(state, "Stashed changes")
+
+        {:error, reason} ->
+          EditorState.set_status(state, "Stash failed: #{reason}")
+      end
+    end)
+  end
+
+  def execute(state, :git_stash_pop) do
+    with_git_root(state, fn git_root ->
+      case Git.stash_pop(git_root) do
+        :ok ->
+          refresh_repo(git_root)
+          EditorState.set_status(state, "Popped stash")
+
+        {:error, reason} ->
+          EditorState.set_status(state, "Stash pop failed: #{reason}")
+      end
+    end)
+  end
+
+  def execute(state, :git_stash_list) do
+    PickerUI.open(state, GitStashSource)
+  end
+
+  def execute(state, :git_stash_drop) do
+    with_git_root(state, fn git_root ->
+      PickerUI.open(state, GitStashSource, %{git_root: git_root, action: :drop})
+    end)
   end
 
   def execute(state, :git_push) do
@@ -1129,6 +1170,16 @@ defmodule MingaEditor.Commands.Git do
     end
   end
 
+  @spec with_git_root(state(), (String.t() -> state())) :: state()
+  defp with_git_root(state, fun) do
+    project_root = Minga.Project.resolve_root()
+
+    case Git.root_for(project_root) do
+      {:ok, git_root} -> fun.(git_root)
+      :not_git -> EditorState.set_status(state, "Not in a git repository")
+    end
+  end
+
   @spec open_git_status_panel(state()) :: state()
   defp open_git_status_panel(state) do
     project_root = Minga.Project.resolve_root()
@@ -1156,7 +1207,8 @@ defmodule MingaEditor.Commands.Git do
           behind: summary.behind,
           entries: entries,
           entry_base_path: Minga.Project.resolve_root(),
-          last_commit_message: summary.last_commit_message
+          last_commit_message: summary.last_commit_message,
+          stash_count: summary.stash_count
         }
 
         # Mutual exclusivity: close file tree when opening git status
@@ -1181,7 +1233,8 @@ defmodule MingaEditor.Commands.Git do
       behind: 0,
       entries: [],
       entry_base_path: project_root,
-      last_commit_message: ""
+      last_commit_message: "",
+      stash_count: 0
     }
 
     state = close_file_tree_if_open(state)

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -102,7 +102,7 @@ defmodule MingaEditor.Commands.Git do
           EditorState.set_status(state, "Stashed changes")
 
         {:error, reason} ->
-          EditorState.set_status(state, "Stash failed: #{reason}")
+          stash_save_status(state, reason)
       end
     end)
   end
@@ -1161,6 +1161,11 @@ defmodule MingaEditor.Commands.Git do
         EditorState.set_status(state, "Not in a git repository")
     end
   end
+
+  @spec stash_save_status(state(), String.t()) :: state()
+  defp stash_save_status(state, "No changes to stash"), do: EditorState.set_status(state, "No changes to stash")
+  defp stash_save_status(state, "No local changes to save"), do: EditorState.set_status(state, "No changes to stash")
+  defp stash_save_status(state, reason), do: EditorState.set_status(state, "Stash failed: #{reason}")
 
   @spec refresh_repo(String.t()) :: :ok
   defp refresh_repo(git_root) do

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -463,6 +463,7 @@ defmodule MingaEditor.Frontend.Emit.GUI do
           entries: [],
           entry_base_path: "",
           last_commit_message: "",
+          stash_count: 0,
           git_toast: toast
         })
 

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -3931,7 +3931,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
           behind: non_neg_integer(),
           entries: [Minga.Git.StatusEntry.t()],
           entry_base_path: String.t(),
-          last_commit_message: String.t()
+          last_commit_message: String.t(),
+          stash_count: non_neg_integer()
         }
 
   @typedoc "Git status data enriched with syncing/toast for protocol encoding."
@@ -3944,6 +3945,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
           entries: [Minga.Git.StatusEntry.t()],
           entry_base_path: String.t(),
           last_commit_message: String.t(),
+          stash_count: non_neg_integer(),
           git_toast: git_toast() | nil
         }
 
@@ -3957,7 +3959,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     then toast section:
       toast_present:1, [toast_level:1, action:1, msg_len:2, msg]
     then repo metadata:
-      entry_base_path_len:2, entry_base_path, last_commit_message_len:2, last_commit_message
+      entry_base_path_len:2, entry_base_path, last_commit_message_len:2, last_commit_message,
+      stash_count:2
   """
   @spec encode_gui_git_status(git_status_data()) :: binary()
   def encode_gui_git_status(
@@ -3996,13 +3999,16 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     last_commit_message_bytes =
       utf8_prefix_bytes(Map.get(data, :last_commit_message) || "", @max_u16)
 
+    stash_count = min(Map.get(data, :stash_count, 0), @max_u16)
+
     IO.iodata_to_binary([
       <<@op_gui_git_status, repo_state_byte::8, syncing_byte::8, ahead::16, behind::16,
         byte_size(branch_bytes)::16, branch_bytes::binary, entry_count::16>>,
       entry_binaries,
       toast_binary,
       <<byte_size(entry_base_path_bytes)::16, entry_base_path_bytes::binary,
-        byte_size(last_commit_message_bytes)::16, last_commit_message_bytes::binary>>
+        byte_size(last_commit_message_bytes)::16, last_commit_message_bytes::binary,
+        stash_count::16>>
     ])
   end
 

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -108,7 +108,8 @@ defmodule MingaEditor.Handlers.FileEventHandler do
           behind: behind,
           entries: entries,
           entry_base_path: Minga.Project.resolve_root(),
-          last_commit_message: event.last_commit_message
+          last_commit_message: event.last_commit_message,
+          stash_count: event.stash_count
         }
 
         state = EditorState.set_git_status_panel(state, git_status_data)

--- a/lib/minga_editor/renderer/caches.ex
+++ b/lib/minga_editor/renderer/caches.ex
@@ -81,7 +81,10 @@ defmodule MingaEditor.Renderer.Caches do
             | {:file_tree_state, String.t(), non_neg_integer(), term()}
             | {:no_tree, String.t()}
             | nil,
-          last_gui_git_status_fp: integer() | {:no_git, boolean(), MingaEditor.Frontend.Protocol.GUI.git_toast() | nil} | nil,
+          last_gui_git_status_fp:
+            integer()
+            | {:no_git, boolean(), MingaEditor.Frontend.Protocol.GUI.git_toast() | nil}
+            | nil,
           last_gui_which_key_fp: integer() | nil,
           last_gui_completion_fp: integer() | nil,
           last_gui_breadcrumb_fp: integer() | nil,

--- a/lib/minga_editor/renderer/caches.ex
+++ b/lib/minga_editor/renderer/caches.ex
@@ -81,7 +81,7 @@ defmodule MingaEditor.Renderer.Caches do
             | {:file_tree_state, String.t(), non_neg_integer(), term()}
             | {:no_tree, String.t()}
             | nil,
-          last_gui_git_status_fp: integer() | {:no_git, boolean()} | nil,
+          last_gui_git_status_fp: integer() | {:no_git, boolean(), MingaEditor.Frontend.Protocol.GUI.git_toast() | nil} | nil,
           last_gui_which_key_fp: integer() | nil,
           last_gui_completion_fp: integer() | nil,
           last_gui_breadcrumb_fp: integer() | nil,

--- a/lib/minga_editor/shell/traditional/git_status_renderer.ex
+++ b/lib/minga_editor/shell/traditional/git_status_renderer.ex
@@ -74,7 +74,8 @@ defmodule MingaEditor.Shell.Traditional.GitStatusRenderer do
     ahead = Map.get(panel, :ahead) || 0
     behind = Map.get(panel, :behind) || 0
 
-    header_text = header_text(branch, ahead, behind)
+    stash_count = Map.get(panel, :stash_count) || 0
+    header_text = header_text(branch, ahead, behind, stash_count)
     header_display = String.slice(header_text, 0, width) |> String.pad_trailing(width)
 
     header = [
@@ -157,8 +158,9 @@ defmodule MingaEditor.Shell.Traditional.GitStatusRenderer do
     ]
   end
 
-  @spec header_text(String.t(), non_neg_integer(), non_neg_integer()) :: String.t()
-  defp header_text(branch, ahead, behind) do
+  @spec header_text(String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          String.t()
+  defp header_text(branch, ahead, behind, stash_count) do
     badge =
       case {ahead, behind} do
         {0, 0} -> ""
@@ -167,7 +169,9 @@ defmodule MingaEditor.Shell.Traditional.GitStatusRenderer do
         {a, b} -> " ↑#{a}↓#{b}"
       end
 
-    "  #{branch}#{badge}"
+    stash_badge = if stash_count > 0, do: " Stashes: #{stash_count}", else: ""
+
+    "  #{branch}#{badge}#{stash_badge}"
   end
 
   @spec status_character(atom()) :: String.t()

--- a/lib/minga_editor/ui/picker/git_stash_source.ex
+++ b/lib/minga_editor/ui/picker/git_stash_source.ex
@@ -1,0 +1,118 @@
+defmodule MingaEditor.UI.Picker.GitStashSource do
+  @moduledoc """
+  Picker source for browsing and dropping git stashes.
+  """
+
+  @behaviour MingaEditor.UI.Picker.Source
+
+  alias Minga.Git
+  alias Minga.Log
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.Item
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Git Stashes"
+
+  @impl true
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{} = ctx) do
+    case git_root(ctx) do
+      {:ok, git_root} -> build_candidates(git_root, stash_action(ctx))
+      :not_git -> []
+    end
+  catch
+    :exit, _ -> []
+  end
+
+  @impl true
+  @spec on_select(Item.t(), EditorState.t()) :: EditorState.t()
+  def on_select(%Item{id: {:stash, git_root, index, :drop}}, state) do
+    drop_stash(git_root, index, state)
+  end
+
+  def on_select(%Item{id: {:stash, _git_root, _index, _action}, label: label}, state) do
+    EditorState.set_status(state, "Stash: #{label}")
+  end
+
+  def on_select(_, state), do: state
+
+  @impl true
+  @spec on_cancel(EditorState.t()) :: EditorState.t()
+  def on_cancel(state), do: state
+
+  @impl true
+  @spec actions(Item.t()) :: [MingaEditor.UI.Picker.Source.action_entry()]
+  def actions(%Item{id: {:stash, _git_root, _index, _action}}), do: [{"Drop", :drop}]
+  def actions(_item), do: []
+
+  @impl true
+  @spec on_action(atom(), Item.t(), EditorState.t()) :: EditorState.t()
+  def on_action(:drop, %Item{id: {:stash, git_root, index, _action}}, state) do
+    drop_stash(git_root, index, state)
+  end
+
+  def on_action(_action, _item, state), do: state
+
+  @typep stash_action :: :list | :drop
+
+  @spec build_candidates(String.t(), stash_action()) :: [Item.t()]
+  defp build_candidates(git_root, action) do
+    case Git.stash_list(git_root) do
+      {:ok, entries} -> Enum.map(entries, &format_entry(&1, git_root, action))
+      {:error, reason} -> log_failure(reason)
+    end
+  end
+
+  @spec format_entry(Git.stash_entry(), String.t(), stash_action()) :: Item.t()
+  defp format_entry(entry, git_root, action) do
+    %Item{
+      id: {:stash, git_root, entry.index, action},
+      label: entry.message,
+      description: entry.date,
+      annotation: entry.ref
+    }
+  end
+
+  @spec git_root(Context.t()) :: {:ok, String.t()} | :not_git
+  defp git_root(%Context{picker_ui: %{context: %{git_root: git_root}}})
+       when is_binary(git_root) do
+    {:ok, git_root}
+  end
+
+  defp git_root(_ctx) do
+    Minga.Project.resolve_root()
+    |> Git.root_for()
+  end
+
+  @spec stash_action(Context.t()) :: stash_action()
+  defp stash_action(%Context{picker_ui: %{context: %{action: :drop}}}), do: :drop
+  defp stash_action(_ctx), do: :list
+
+  @spec log_failure(String.t()) :: []
+  defp log_failure(reason) do
+    Log.warning(:editor, "[git_stash_picker] stash_list failed: #{reason}")
+    []
+  end
+
+  @spec drop_stash(String.t(), non_neg_integer(), EditorState.t()) :: EditorState.t()
+  defp drop_stash(git_root, index, state) do
+    case Git.stash_drop(git_root, index) do
+      :ok ->
+        refresh_repo(git_root)
+        EditorState.set_status(state, "Dropped stash@{#{index}}")
+
+      {:error, reason} ->
+        EditorState.set_status(state, "Drop stash failed: #{reason}")
+    end
+  end
+
+  @spec refresh_repo(String.t()) :: :ok
+  defp refresh_repo(git_root) do
+    case Git.lookup_repo(git_root) do
+      nil -> :ok
+      pid -> Git.refresh_repo(pid)
+    end
+  end
+end

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -204,7 +204,7 @@ enum RenderCommand: Sendable {
     case guiLineSpacing(spacing: Float)
     case guiCursorAnimation(enabled: Bool)
     case guiSplitSeparators(borderColor: UInt32, verticals: [Wire.VerticalSeparator], horizontals: [Wire.HorizontalSeparator])
-    case guiGitStatus(repoState: UInt8, syncing: Bool, ahead: UInt16, behind: UInt16, branchName: String, entries: [Wire.GitStatusEntry], toast: (message: String, level: UInt8, action: UInt8)?, entryBasePath: String, lastCommitMessage: String)
+    case guiGitStatus(repoState: UInt8, syncing: Bool, ahead: UInt16, behind: UInt16, branchName: String, entries: [Wire.GitStatusEntry], toast: (message: String, level: UInt8, action: UInt8)?, entryBasePath: String, lastCommitMessage: String, stashCount: UInt16)
     case guiWorkspaces(version: UInt8, activeWorkspaceId: UInt16, mode: UInt8, flags: UInt8, workspaces: [Wire.WorkspaceEntry], visibleTabs: [Wire.WorkspaceTabEntry])
     case guiBoard(visible: Bool, focusedCardId: UInt32, cards: [BoardCard], filterMode: Bool, filterText: String)
     case guiAgentContext(visible: Bool, task: String, dispatchTimestamp: Date, status: CardStatus, canApprove: Bool)
@@ -2040,7 +2040,10 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         let gsLastCommitMessageData = data[gsPos..<(gsPos + gsLastCommitMessageLen)]
         let gsLastCommitMessage = try readRequiredUTF8(gsLastCommitMessageData)
         gsPos += gsLastCommitMessageLen
-        return (.guiGitStatus(repoState: gsRepoState, syncing: gsSyncing, ahead: gsAhead, behind: gsBehind, branchName: gsBranchName, entries: gsEntries, toast: gsToast, entryBasePath: gsEntryBasePath, lastCommitMessage: gsLastCommitMessage),
+        guard data.count >= gsPos + 2 else { throw ProtocolDecodeError.malformed }
+        let gsStashCount = readU16(data, gsPos)
+        gsPos += 2
+        return (.guiGitStatus(repoState: gsRepoState, syncing: gsSyncing, ahead: gsAhead, behind: gsBehind, branchName: gsBranchName, entries: gsEntries, toast: gsToast, entryBasePath: gsEntryBasePath, lastCommitMessage: gsLastCommitMessage, stashCount: gsStashCount),
                 gsPos - offset)
 
     case OP_GUI_WORKSPACES:

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -425,7 +425,7 @@ final class CommandDispatcher {
                 guiState.floatPopupState.hide()
             }
 
-        case .guiGitStatus(let repoState, let syncing, let ahead, let behind, let branchName, let rawEntries, let rawToast, let entryBasePath, let lastCommitMessage):
+        case .guiGitStatus(let repoState, let syncing, let ahead, let behind, let branchName, let rawEntries, let rawToast, let entryBasePath, let lastCommitMessage, let stashCount):
             // When git_status_panel is nil, the BEAM sends notARepo + empty
             // entries as the "panel closed" signal (same pattern as file tree
             // sending empty entries to trigger hide). Can't gate on
@@ -471,7 +471,8 @@ final class CommandDispatcher {
                     entries: entries,
                     toast: toast,
                     entryBasePath: entryBasePath,
-                    lastCommitMessage: lastCommitMessage
+                    lastCommitMessage: lastCommitMessage,
+                    stashCount: stashCount
                 )
             }
         }

--- a/macos/Sources/Views/GitStatusHeaderContent.swift
+++ b/macos/Sources/Views/GitStatusHeaderContent.swift
@@ -44,12 +44,22 @@ struct GitStatusHeaderContent: View {
 
             Spacer(minLength: 4)
 
+            if state.stashCount > 0 {
+                stashBadge
+            }
+
             if state.ahead > 0 || state.behind > 0 {
                 aheadBehindBadge
             }
         }
         .padding(.leading, leadingPadding)
         .padding(.trailing, 10)
+    }
+
+    private var stashBadge: some View {
+        Text("Stashes: \(state.stashCount)")
+            .font(.system(size: 10, weight: .medium).monospacedDigit())
+            .foregroundStyle(theme.tabActiveFg.opacity(0.7))
     }
 
     @ViewBuilder

--- a/macos/Sources/Views/GitStatusState.swift
+++ b/macos/Sources/Views/GitStatusState.swift
@@ -85,6 +85,7 @@ final class GitStatusState {
     var ahead: UInt16 = 0
     var behind: UInt16 = 0
     var entryBasePath: String = ""
+    var stashCount: UInt16 = 0
 
     // Toast notification (shown after remote operations)
     var toastMessage: String? = nil
@@ -138,7 +139,7 @@ final class GitStatusState {
     }
 
     /// Update from a decoded gui_git_status protocol message.
-    func update(repoState: GitRepoState, branchName: String, ahead: UInt16, behind: UInt16, syncing: Bool, entries: [GitStatusEntry], toast: (String, ToastLevel, ToastAction)?, entryBasePath: String, lastCommitMessage: String) {
+    func update(repoState: GitRepoState, branchName: String, ahead: UInt16, behind: UInt16, syncing: Bool, entries: [GitStatusEntry], toast: (String, ToastLevel, ToastAction)?, entryBasePath: String, lastCommitMessage: String, stashCount: UInt16) {
         self.visible = true
         self.repoState = repoState
         self.branchName = branchName
@@ -147,6 +148,7 @@ final class GitStatusState {
         self.syncing = syncing
         self.entryBasePath = entryBasePath
         self.previousCommitMessage = lastCommitMessage
+        self.stashCount = stashCount
 
         // Partition entries by section in a single pass.
         var staged: [GitStatusEntry] = []
@@ -182,6 +184,7 @@ final class GitStatusState {
         visible = false
         self.syncing = syncing
         entryBasePath = ""
+        stashCount = 0
         applyToast(toast)
     }
 

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -212,11 +212,12 @@ struct CommandDispatcherRoutingTests {
             Wire.GitStatusEntry(pathHash: 12345, section: 1, status: 1, path: "lib/editor.ex")
         ]
         dispatcher.dispatch(.guiGitStatus(repoState: 0, syncing: false, ahead: 2, behind: 0,
-                                           branchName: "main", entries: rawEntries, toast: nil, entryBasePath: "", lastCommitMessage: ""))
+                                           branchName: "main", entries: rawEntries, toast: nil, entryBasePath: "", lastCommitMessage: "", stashCount: 4))
 
         #expect(gui.gitStatusState.visible == true)
         #expect(gui.gitStatusState.branchName == "main")
         #expect(gui.gitStatusState.ahead == 2)
+        #expect(gui.gitStatusState.stashCount == 4)
         #expect(gui.gitStatusState.changedEntries.count == 1)
         #expect(gui.gitStatusState.changedEntries[0].path == "lib/editor.ex")
     }
@@ -229,12 +230,12 @@ struct CommandDispatcherRoutingTests {
             Wire.GitStatusEntry(pathHash: 12345, section: 1, status: 1, path: "lib/editor.ex")
         ]
         dispatcher.dispatch(.guiGitStatus(repoState: 0, syncing: false, ahead: 0, behind: 0,
-                                           branchName: "main", entries: rawEntries, toast: nil, entryBasePath: "", lastCommitMessage: ""))
+                                           branchName: "main", entries: rawEntries, toast: nil, entryBasePath: "", lastCommitMessage: "", stashCount: 0))
         #expect(gui.gitStatusState.visible == true)
 
         // Then send the "panel closed" sentinel: notARepo (1) + empty entries. Syncing and toast still update because remote operations can finish while the panel is hidden.
         dispatcher.dispatch(.guiGitStatus(repoState: 1, syncing: true, ahead: 0, behind: 0,
-                                           branchName: "", entries: [], toast: (message: "Push failed", level: 1, action: 1), entryBasePath: "", lastCommitMessage: ""))
+                                           branchName: "", entries: [], toast: (message: "Push failed", level: 1, action: 1), entryBasePath: "", lastCommitMessage: "", stashCount: 0))
         #expect(gui.gitStatusState.visible == false)
         #expect(gui.gitStatusState.syncing == true)
         #expect(gui.gitStatusState.toastMessage == "Push failed")
@@ -249,7 +250,7 @@ struct CommandDispatcherRoutingTests {
             Wire.GitStatusEntry(pathHash: 12346, section: 1, status: 99, path: "lib/invalid-status.ex")
         ]
         dispatcher.dispatch(.guiGitStatus(repoState: 0, syncing: false, ahead: 0, behind: 0,
-                                           branchName: "main", entries: rawEntries, toast: nil, entryBasePath: "", lastCommitMessage: ""))
+                                           branchName: "main", entries: rawEntries, toast: nil, entryBasePath: "", lastCommitMessage: "", stashCount: 0))
 
         #expect(gui.gitStatusState.changedEntries.count == 2)
         #expect(gui.gitStatusState.changedEntries[0].status == .unknown)
@@ -263,7 +264,7 @@ struct CommandDispatcherRoutingTests {
             Wire.GitStatusEntry(pathHash: 12345, section: 99, status: 1, path: "lib/bad-section.ex")
         ]
         dispatcher.dispatch(.guiGitStatus(repoState: 0, syncing: false, ahead: 0, behind: 0,
-                                           branchName: "main", entries: rawEntries, toast: nil, entryBasePath: "", lastCommitMessage: ""))
+                                           branchName: "main", entries: rawEntries, toast: nil, entryBasePath: "", lastCommitMessage: "", stashCount: 0))
 
         #expect(gui.gitStatusState.totalCount == 0)
     }
@@ -273,7 +274,7 @@ struct CommandDispatcherRoutingTests {
         let (dispatcher, gui) = makeDispatcher()
 
         dispatcher.dispatch(.guiGitStatus(repoState: 1, syncing: false, ahead: 0, behind: 0,
-                                           branchName: "", entries: [], toast: nil, entryBasePath: "/project", lastCommitMessage: ""))
+                                           branchName: "", entries: [], toast: nil, entryBasePath: "/project", lastCommitMessage: "", stashCount: 0))
 
         #expect(gui.gitStatusState.visible == true)
         #expect(gui.gitStatusState.repoState == .notARepo)
@@ -286,7 +287,7 @@ struct CommandDispatcherRoutingTests {
         // Normal repo (0) with zero entries is a clean working tree, NOT
         // a hide signal. Only notARepo + empty triggers hide.
         dispatcher.dispatch(.guiGitStatus(repoState: 0, syncing: false, ahead: 0, behind: 0,
-                                           branchName: "main", entries: [], toast: nil, entryBasePath: "", lastCommitMessage: ""))
+                                           branchName: "main", entries: [], toast: nil, entryBasePath: "", lastCommitMessage: "", stashCount: 0))
         #expect(gui.gitStatusState.visible == true)
         #expect(gui.gitStatusState.branchName == "main")
     }
@@ -295,14 +296,14 @@ struct CommandDispatcherRoutingTests {
     @MainActor func guiGitStatusToastFallback() {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.dispatch(.guiGitStatus(repoState: 0, syncing: false, ahead: 0, behind: 0,
-                                           branchName: "main", entries: [], toast: (message: "Remote failed", level: 99, action: 99), entryBasePath: "", lastCommitMessage: ""))
+                                           branchName: "main", entries: [], toast: (message: "Remote failed", level: 99, action: 99), entryBasePath: "", lastCommitMessage: "", stashCount: 0))
 
         #expect(gui.gitStatusState.toastMessage == "Remote failed")
         #expect(gui.gitStatusState.toastLevel == .error)
         #expect(gui.gitStatusState.toastAction == .none)
 
         dispatcher.dispatch(.guiGitStatus(repoState: 0, syncing: false, ahead: 0, behind: 0,
-                                           branchName: "main", entries: [], toast: nil, entryBasePath: "", lastCommitMessage: ""))
+                                           branchName: "main", entries: [], toast: nil, entryBasePath: "", lastCommitMessage: "", stashCount: 0))
 
         #expect(gui.gitStatusState.toastMessage == nil)
         #expect(gui.gitStatusState.toastLevel == .success)

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -2704,11 +2704,12 @@ struct GUIGitStatusDecoderTests {
         appendString16(&data, "Push failed: fetch first")
         appendString16(&data, "/repo")
         appendString16(&data, "feat: previous commit")
+        appendU16(&data, 3) // stash_count
 
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiGitStatus(let repoState, let syncing, let ahead, let behind, let branchName, let entries, let toast, let entryBasePath, let lastCommitMessage) = cmd else {
+        guard case .guiGitStatus(let repoState, let syncing, let ahead, let behind, let branchName, let entries, let toast, let entryBasePath, let lastCommitMessage, let stashCount) = cmd else {
             Issue.record("Expected .guiGitStatus"); return
         }
 
@@ -2727,6 +2728,7 @@ struct GUIGitStatusDecoderTests {
         #expect(toast?.action == 1)
         #expect(entryBasePath == "/repo")
         #expect(lastCommitMessage == "feat: previous commit")
+        #expect(stashCount == 3)
     }
 
     @Test("Invalid repo state in gui_git_status throws malformed")

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -172,6 +172,20 @@ struct GitStatusViewBranchHeaderTests {
 
         #expect(strings.contains("No branch"))
     }
+
+    @Test("Branch header shows stash count when present")
+    @MainActor func showsStashCount() throws {
+        let state = GitStatusState()
+        state.repoState = .normal
+        state.branchName = "main"
+        state.stashCount = 2
+
+        let sut = GitStatusHeaderContent(state: state, theme: ThemeColors(), projectName: "minga", leadingPadding: 10)
+        let body = try sut.inspect()
+        let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("Stashes: 2"))
+    }
 }
 
 // MARK: - FileTreeView
@@ -548,7 +562,7 @@ struct GitStatusViewSectionTests {
     @Test("Amend mode pre-fills previous commit message without clobbering user text")
     @MainActor func amendModePrefillsPreviousCommitMessageWithoutClobberingUserText() {
         let state = GitStatusState()
-        state.update(repoState: .normal, branchName: "main", ahead: 0, behind: 0, syncing: false, entries: [], toast: nil, entryBasePath: "/repo", lastCommitMessage: "feat: previous subject")
+        state.update(repoState: .normal, branchName: "main", ahead: 0, behind: 0, syncing: false, entries: [], toast: nil, entryBasePath: "/repo", lastCommitMessage: "feat: previous subject", stashCount: 0)
 
         state.setAmendMode(true)
         #expect(state.commitMessage == "feat: previous subject")

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -748,8 +748,8 @@ struct TabBarViewViewTests {
         #expect(!sut.canMoveTabRight(tab(id: 5, groupId: 1)))
     }
 
-    @Test("Tab context menu items disable move actions at bucket edges")
-    @MainActor func tabContextMenuItemsDisableMoveActionsAtBucketEdges() throws {
+    @Test("Tab context menu move actions use bucket edge rules")
+    @MainActor func tabContextMenuMoveActionsUseBucketEdgeRules() throws {
         let state = TabBarState()
         state.update(activeIndex: 0, entries: [
             wireTab(id: 1, isActive: true, isPinned: true, label: "pinned-1.ex"),

--- a/test/minga/git/backend_operations_test.exs
+++ b/test/minga/git/backend_operations_test.exs
@@ -1,6 +1,6 @@
 defmodule Minga.Git.BackendOperationsTest do
   @moduledoc """
-  Tests for the unstage, unstage_all, and discard backend callbacks.
+  Tests for the unstage, unstage_all, discard, and stash backend callbacks.
 
   Uses a real temporary git repository (async: false) since these
   operations require actual git state. Each test creates a clean repo
@@ -121,6 +121,50 @@ defmodule Minga.Git.BackendOperationsTest do
 
       result = Minga.Git.System.discard(dir, "nonexistent.txt")
       assert {:error, _} = result
+    end
+  end
+
+  describe "stash operations" do
+    @tag :tmp_dir
+    test "saves tracked and untracked changes and pops them back", %{tmp_dir: dir} do
+      init_git_repo(dir)
+      file = Path.join(dir, "file.txt")
+      untracked = Path.join(dir, "new.txt")
+      File.write!(file, "original")
+      git_cmd(dir, ["add", "."])
+      git_cmd(dir, ["commit", "-m", "init"])
+
+      File.write!(file, "modified")
+      File.write!(untracked, "new")
+
+      assert :ok = Minga.Git.System.stash(dir, include_untracked: true)
+      assert File.read!(file) == "original"
+      refute File.exists?(untracked)
+
+      assert {:ok, [entry]} = Minga.Git.System.stash_list(dir)
+      assert entry.index == 0
+      assert entry.ref == "stash@{0}"
+      assert entry.message =~ "WIP on main"
+
+      assert :ok = Minga.Git.System.stash_pop(dir)
+      assert File.read!(file) == "modified"
+      assert File.read!(untracked) == "new"
+    end
+
+    @tag :tmp_dir
+    test "drops a stash by index", %{tmp_dir: dir} do
+      init_git_repo(dir)
+      file = Path.join(dir, "file.txt")
+      File.write!(file, "original")
+      git_cmd(dir, ["add", "."])
+      git_cmd(dir, ["commit", "-m", "init"])
+      File.write!(file, "modified")
+
+      assert :ok = Minga.Git.System.stash(dir)
+      assert {:ok, [_entry]} = Minga.Git.System.stash_list(dir)
+
+      assert :ok = Minga.Git.System.stash_drop(dir, 0)
+      assert {:ok, []} = Minga.Git.System.stash_list(dir)
     end
   end
 

--- a/test/minga/git/backend_operations_test.exs
+++ b/test/minga/git/backend_operations_test.exs
@@ -152,6 +152,18 @@ defmodule Minga.Git.BackendOperationsTest do
     end
 
     @tag :tmp_dir
+    test "returns a no-op error when there are no changes to stash", %{tmp_dir: dir} do
+      init_git_repo(dir)
+      file = Path.join(dir, "file.txt")
+      File.write!(file, "original")
+      git_cmd(dir, ["add", "."])
+      git_cmd(dir, ["commit", "-m", "init"])
+
+      assert {:error, "No changes to stash"} = Minga.Git.System.stash(dir, include_untracked: true)
+      assert {:ok, []} = Minga.Git.System.stash_list(dir)
+    end
+
+    @tag :tmp_dir
     test "drops a stash by index", %{tmp_dir: dir} do
       init_git_repo(dir)
       file = Path.join(dir, "file.txt")

--- a/test/minga/git/backend_operations_test.exs
+++ b/test/minga/git/backend_operations_test.exs
@@ -159,7 +159,9 @@ defmodule Minga.Git.BackendOperationsTest do
       git_cmd(dir, ["add", "."])
       git_cmd(dir, ["commit", "-m", "init"])
 
-      assert {:error, "No changes to stash"} = Minga.Git.System.stash(dir, include_untracked: true)
+      assert {:error, "No changes to stash"} =
+               Minga.Git.System.stash(dir, include_untracked: true)
+
       assert {:ok, []} = Minga.Git.System.stash_list(dir)
     end
 

--- a/test/minga/git/repo_test.exs
+++ b/test/minga/git/repo_test.exs
@@ -4,6 +4,7 @@ defmodule Minga.Git.RepoTest do
 
   alias Minga.Events
   alias Minga.Git.Repo
+  alias Minga.Git.StashEntry
   alias Minga.Git.StatusEntry
   alias Minga.Git.Stub, as: GitStub
 
@@ -40,6 +41,21 @@ defmodule Minga.Git.RepoTest do
       summary = Repo.summary(repo)
       assert summary.ahead == 3
       assert summary.behind == 1
+    end
+
+    test "loads stash count on start", %{tmp_dir: dir} do
+      stash_dir = dir <> "/stashes"
+      GitStub.set_root(stash_dir, stash_dir)
+
+      GitStub.set_stashes(stash_dir, [
+        %StashEntry{index: 0, ref: "stash@{0}", date: "1 minute ago", message: "WIP"}
+      ])
+
+      on_exit(fn -> GitStub.clear(stash_dir) end)
+
+      repo = start_supervised!({Repo, git_root: stash_dir}, id: {Repo, stash_dir})
+
+      assert Repo.summary(repo).stash_count == 1
     end
   end
 
@@ -131,6 +147,52 @@ defmodule Minga.Git.RepoTest do
       assert Repo.summary(repo).last_commit_message == "feat: updated subject"
     end
 
+    test "refresh publishes and caches stash count changes", %{root: dir, repo: repo} do
+      Events.subscribe(:git_status_changed)
+
+      GitStub.set_stashes(dir, [
+        %StashEntry{index: 0, ref: "stash@{0}", date: "1 minute ago", message: "WIP"}
+      ])
+
+      Repo.refresh(repo)
+      :sys.get_state(repo)
+
+      assert_receive {:minga_event, :git_status_changed,
+                      %Events.GitStatusEvent{git_root: ^dir, stash_count: 1}}
+
+      assert Repo.summary(repo).stash_count == 1
+    end
+
+    test "stash ref file events refresh stash count", %{root: dir, repo: repo} do
+      Events.subscribe(:git_status_changed)
+
+      GitStub.set_stashes(dir, [
+        %StashEntry{index: 0, ref: "stash@{0}", date: "1 minute ago", message: "WIP"}
+      ])
+
+      send(repo, {:file_event, self(), {Path.join([dir, ".git", "refs", "stash"]), []}})
+      send(repo, :debounce_refresh)
+      :sys.get_state(repo)
+
+      assert_receive {:minga_event, :git_status_changed,
+                      %Events.GitStatusEvent{git_root: ^dir, stash_count: 1}}
+    end
+
+    test "stash log file events refresh stash count", %{root: dir, repo: repo} do
+      Events.subscribe(:git_status_changed)
+
+      GitStub.set_stashes(dir, [
+        %StashEntry{index: 0, ref: "stash@{0}", date: "1 minute ago", message: "WIP"}
+      ])
+
+      send(repo, {:file_event, self(), {Path.join([dir, ".git", "logs", "refs", "stash"]), []}})
+      send(repo, :debounce_refresh)
+      :sys.get_state(repo)
+
+      assert_receive {:minga_event, :git_status_changed,
+                      %Events.GitStatusEvent{git_root: ^dir, stash_count: 1}}
+    end
+
     test "refresh publishes git_status_changed when branch changes", %{root: dir, repo: repo} do
       Events.subscribe(:git_status_changed)
       GitStub.set_branch(dir, "feature/new")
@@ -167,6 +229,7 @@ defmodule Minga.Git.RepoTest do
       assert summary.unstaged_count == 1
       assert summary.untracked_count == 1
       assert summary.conflict_count == 1
+      assert summary.stash_count == 0
     end
 
     test "with zero entries returns all-zero counts", %{tmp_dir: dir} do

--- a/test/minga/git_test.exs
+++ b/test/minga/git_test.exs
@@ -95,13 +95,18 @@ defmodule Minga.GitTest do
 
     test "stashing on top of an existing stash keeps the newest entry at stash@{0}", %{root: dir} do
       GitStub.set_status(dir, [%Git.StatusEntry{path: "a.ex", status: :modified, staged: false}])
+
       GitStub.set_stashes(dir, [
         %Git.StashEntry{index: 0, ref: "stash@{0}", message: "older", date: "2 hours ago"}
       ])
 
       assert :ok = Git.stash(dir, include_untracked: true)
-      assert {:ok, [%Git.StashEntry{index: 0, ref: "stash@{0}", message: "WIP on main"},
-                    %Git.StashEntry{index: 1, ref: "stash@{1}", message: "older"}]} =
+
+      assert {:ok,
+              [
+                %Git.StashEntry{index: 0, ref: "stash@{0}", message: "WIP on main"},
+                %Git.StashEntry{index: 1, ref: "stash@{1}", message: "older"}
+              ]} =
                Git.stash_list(dir)
 
       assert :ok = Git.stash_drop(dir, 0)

--- a/test/minga/git_test.exs
+++ b/test/minga/git_test.exs
@@ -64,6 +64,19 @@ defmodule Minga.GitTest do
       assert {:ok, [^entry]} = Git.log(dir)
     end
 
+    test "stash_list returns configured entries", %{root: dir} do
+      entry = %Git.StashEntry{index: 0, ref: "stash@{0}", message: "WIP", date: "2 hours ago"}
+
+      GitStub.set_stashes(dir, [entry])
+      assert {:ok, [^entry]} = Git.stash_list(dir)
+    end
+
+    test "stash operations return :ok", %{root: dir} do
+      assert :ok = Git.stash(dir, include_untracked: true)
+      assert :ok = Git.stash_pop(dir)
+      assert :ok = Git.stash_drop(dir, 0)
+    end
+
     test "stage returns :ok", %{root: dir} do
       assert :ok = Git.stage(dir, ["file.txt"])
     end

--- a/test/minga/git_test.exs
+++ b/test/minga/git_test.exs
@@ -71,10 +71,44 @@ defmodule Minga.GitTest do
       assert {:ok, [^entry]} = Git.stash_list(dir)
     end
 
-    test "stash operations return :ok", %{root: dir} do
+    test "stash returns :ok when there are changes to save", %{root: dir} do
+      GitStub.set_status(dir, [%Git.StatusEntry{path: "a.ex", status: :modified, staged: false}])
+
       assert :ok = Git.stash(dir, include_untracked: true)
+    end
+
+    test "stash_pop returns :ok when stashes exist", %{root: dir} do
+      GitStub.set_stashes(dir, [
+        %Git.StashEntry{index: 0, ref: "stash@{0}", message: "WIP", date: "2 hours ago"}
+      ])
+
       assert :ok = Git.stash_pop(dir)
+    end
+
+    test "stash_drop returns :ok when the requested index exists", %{root: dir} do
+      GitStub.set_stashes(dir, [
+        %Git.StashEntry{index: 0, ref: "stash@{0}", message: "WIP", date: "2 hours ago"}
+      ])
+
       assert :ok = Git.stash_drop(dir, 0)
+    end
+
+    test "stashing on top of an existing stash keeps the newest entry at stash@{0}", %{root: dir} do
+      GitStub.set_status(dir, [%Git.StatusEntry{path: "a.ex", status: :modified, staged: false}])
+      GitStub.set_stashes(dir, [
+        %Git.StashEntry{index: 0, ref: "stash@{0}", message: "older", date: "2 hours ago"}
+      ])
+
+      assert :ok = Git.stash(dir, include_untracked: true)
+      assert {:ok, [%Git.StashEntry{index: 0, ref: "stash@{0}", message: "WIP on main"},
+                    %Git.StashEntry{index: 1, ref: "stash@{1}", message: "older"}]} =
+               Git.stash_list(dir)
+
+      assert :ok = Git.stash_drop(dir, 0)
+      assert {:ok, [remaining]} = Git.stash_list(dir)
+      assert remaining.index == 0
+      assert remaining.ref == "stash@{0}"
+      assert remaining.message == "older"
     end
 
     test "stage returns :ok", %{root: dir} do

--- a/test/minga_editor/commands/git_remote_test.exs
+++ b/test/minga_editor/commands/git_remote_test.exs
@@ -18,6 +18,10 @@ defmodule MingaEditor.Commands.GitRemoteTest do
       assert :git_push in names
       assert :git_fetch in names
       assert :git_pull_and_retry in names
+      assert :git_stash_save in names
+      assert :git_stash_pop in names
+      assert :git_stash_list in names
+      assert :git_stash_drop in names
     end
   end
 

--- a/test/minga_editor/commands/git_stash_test.exs
+++ b/test/minga_editor/commands/git_stash_test.exs
@@ -1,0 +1,132 @@
+defmodule MingaEditor.Commands.GitStashTest do
+  @moduledoc "Tests for the git stash editor commands."
+  # Mutates the global Git.Stub root mapping because these commands resolve the project root internally.
+  use ExUnit.Case, async: false
+
+  alias Minga.Git.Repo
+  alias Minga.Git.StashEntry
+  alias Minga.Git.StatusEntry
+  alias Minga.Git.Stub, as: GitStub
+  alias MingaEditor.Commands.Git, as: GitCommands
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.UI.Picker.GitStashSource
+  alias MingaEditor.Viewport
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: dir} do
+    project_root = Minga.Project.resolve_root()
+    GitStub.set_root(project_root, dir)
+
+    on_exit(fn ->
+      GitStub.clear(project_root)
+      GitStub.clear(dir)
+    end)
+
+    {:ok, root: dir, project_root: project_root}
+  end
+
+  describe "stash save/pop" do
+    test "save success clears the repo and reports success", %{root: dir} do
+      repo = start_repo(dir, [tracked_change()], [])
+
+      result = GitCommands.execute(build_state(), :git_stash_save)
+      :sys.get_state(repo)
+
+      assert EditorState.status_msg(result) == "Stashed changes"
+      assert Repo.status(repo) == []
+
+      summary = Repo.summary(repo)
+      assert summary.staged_count == 0
+      assert summary.unstaged_count == 0
+      assert summary.untracked_count == 0
+      assert summary.conflict_count == 0
+      assert summary.stash_count == 1
+    end
+
+    test "save with no changes reports a no-op", %{root: dir} do
+      repo = start_repo(dir, [], [])
+
+      result = GitCommands.execute(build_state(), :git_stash_save)
+      :sys.get_state(repo)
+
+      assert EditorState.status_msg(result) == "No changes to stash"
+      assert Repo.summary(repo).stash_count == 0
+    end
+
+    test "pop restores the stashed repo status", %{root: dir} do
+      repo = start_repo(dir, [tracked_change()], [])
+
+      save_result = GitCommands.execute(build_state(), :git_stash_save)
+      :sys.get_state(repo)
+
+      assert EditorState.status_msg(save_result) == "Stashed changes"
+      assert Repo.status(repo) == []
+      assert Repo.summary(repo).stash_count == 1
+
+      pop_result = GitCommands.execute(build_state(), :git_stash_pop)
+      :sys.get_state(repo)
+
+      assert EditorState.status_msg(pop_result) == "Popped stash"
+      assert Repo.status(repo) == [tracked_change()]
+
+      summary = Repo.summary(repo)
+      assert summary.staged_count == 0
+      assert summary.unstaged_count == 1
+      assert summary.untracked_count == 0
+      assert summary.conflict_count == 0
+      assert summary.stash_count == 0
+    end
+
+    test "pop failure reports the backend error", %{root: dir} do
+      start_repo(dir, [], [])
+
+      result = GitCommands.execute(build_state(), :git_stash_pop)
+
+      assert EditorState.status_msg(result) == "Stash pop failed: No stash entries to pop"
+    end
+  end
+
+  describe "stash picker commands" do
+    test "list opens the stash picker", %{root: dir} do
+      GitStub.set_stashes(dir, [stash_entry(0)])
+
+      result = GitCommands.execute(build_state(), :git_stash_list)
+
+      assert {:picker, %{picker_ui: %{source: GitStashSource}}} = result.shell_state.modal
+    end
+
+    test "drop opens the stash picker in drop mode", %{root: dir} do
+      GitStub.set_stashes(dir, [stash_entry(0)])
+
+      result = GitCommands.execute(build_state(), :git_stash_drop)
+
+      assert {:picker, %{picker_ui: %{source: GitStashSource, context: context}}} =
+               result.shell_state.modal
+
+      assert context == %{git_root: dir, action: :drop}
+    end
+  end
+
+  defp build_state do
+    %EditorState{
+      port_manager: nil,
+      workspace: %SessionState{viewport: Viewport.new(24, 80)}
+    }
+  end
+
+  defp start_repo(dir, status_entries, stashes) do
+    GitStub.set_status(dir, status_entries)
+    GitStub.set_stashes(dir, stashes)
+    start_supervised!({Repo, git_root: dir}, id: {Repo, dir})
+  end
+
+  defp tracked_change do
+    %StatusEntry{path: "file.txt", status: :modified, staged: false}
+  end
+
+  defp stash_entry(index) do
+    %StashEntry{index: index, ref: "stash@{#{index}}", date: "1 minute ago", message: "WIP"}
+  end
+end

--- a/test/minga_editor/frontend/gui_git_status_test.exs
+++ b/test/minga_editor/frontend/gui_git_status_test.exs
@@ -19,12 +19,12 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
 
       binary = ProtocolGUI.encode_gui_git_status(data)
 
-      # Header, empty entries, no toast, empty entry_base_path, and empty last_commit_message.
-      assert byte_size(binary) == 1 + 1 + 1 + 2 + 2 + 2 + 4 + 2 + 1 + 2 + 2
+      # Header, empty entries, no toast, empty entry_base_path, empty last_commit_message, and stash_count.
+      assert byte_size(binary) == 1 + 1 + 1 + 2 + 2 + 2 + 4 + 2 + 1 + 2 + 2 + 2
 
       <<0x85, repo_state::8, syncing::8, ahead::16, behind::16, branch_len::16,
         branch::binary-size(branch_len), entry_count::16, toast_present::8,
-        entry_base_path_len::16, last_commit_len::16>> = binary
+        entry_base_path_len::16, last_commit_len::16, stash_count::16>> = binary
 
       assert repo_state == 0
       assert syncing == 0
@@ -35,6 +35,7 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
       assert toast_present == 0
       assert entry_base_path_len == 0
       assert last_commit_len == 0
+      assert stash_count == 0
     end
 
     test "truncates entry_base_path and last commit message without breaking UTF-8" do
@@ -56,7 +57,8 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
       <<0x85, _repo::8, _syncing::8, _ahead::16, _behind::16, branch_len::16,
         _branch::binary-size(branch_len), _entry_count::16, _toast_present::8,
         entry_base_path_len::16, entry_base_path::binary-size(entry_base_path_len),
-        last_commit_len::16, last_commit_message::binary-size(last_commit_len)>> = binary
+        last_commit_len::16, last_commit_message::binary-size(last_commit_len), stash_count::16>> =
+        binary
 
       assert entry_base_path_len <= 65_535
       assert last_commit_len <= 65_535
@@ -64,6 +66,7 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
       assert String.valid?(last_commit_message)
       assert String.length(entry_base_path) > 0
       assert String.length(last_commit_message) > 0
+      assert stash_count == 0
     end
 
     test "encodes syncing flag when true" do
@@ -134,6 +137,26 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
       assert behind == 1
     end
 
+    test "encodes stash count" do
+      binary =
+        ProtocolGUI.encode_gui_git_status(%{
+          repo_state: :normal,
+          syncing: false,
+          branch: "main",
+          ahead: 0,
+          behind: 0,
+          entries: [],
+          git_toast: nil,
+          stash_count: 7
+        })
+
+      <<0x85, _repo::8, _syncing::8, _ahead::16, _behind::16, branch_len::16,
+        _branch::binary-size(branch_len), _entry_count::16, _toast_present::8,
+        _entry_base_path_len::16, _last_commit_len::16, stash_count::16>> = binary
+
+      assert stash_count == 7
+    end
+
     test "encodes staged and unstaged entries" do
       entries = [
         %StatusEntry{path: "lib/foo.ex", status: :modified, staged: true},
@@ -177,7 +200,7 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
 
       # Parse third entry (untracked) -- toast_present byte follows
       <<_hash3::32, section3::8, status3::8, path3_len::16, path3::binary-size(path3_len),
-        toast_present::8, entry_base_path_len::16, last_commit_len::16>> = rest3
+        toast_present::8, entry_base_path_len::16, last_commit_len::16, stash_count::16>> = rest3
 
       assert section3 == 2
       assert status3 == 6
@@ -185,6 +208,7 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
       assert toast_present == 0
       assert entry_base_path_len == 0
       assert last_commit_len == 0
+      assert stash_count == 0
     end
 
     test "encodes conflict entries in section 3" do
@@ -264,7 +288,7 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
       <<0x85, _repo::8, _syncing::8, _ahead::16, _behind::16, branch_len::16,
         _branch::binary-size(branch_len), _count::16, toast_present::8, toast_level::8,
         toast_action::8, msg_len::16, msg::binary-size(msg_len), entry_base_path_len::16,
-        last_commit_len::16>> = binary
+        last_commit_len::16, stash_count::16>> = binary
 
       assert toast_present == 1
       assert toast_level == 0
@@ -272,6 +296,7 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
       assert msg == "Pushed"
       assert entry_base_path_len == 0
       assert last_commit_len == 0
+      assert stash_count == 0
     end
 
     test "encodes error toast with pull_and_retry action" do
@@ -290,7 +315,7 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
       <<0x85, _repo::8, _syncing::8, _ahead::16, _behind::16, branch_len::16,
         _branch::binary-size(branch_len), _count::16, toast_present::8, toast_level::8,
         toast_action::8, msg_len::16, msg::binary-size(msg_len), entry_base_path_len::16,
-        last_commit_len::16>> = binary
+        last_commit_len::16, stash_count::16>> = binary
 
       assert toast_present == 1
       assert toast_level == 1
@@ -298,6 +323,7 @@ defmodule MingaEditor.Frontend.GUIGitStatusTest do
       assert msg == "Push failed: rejected"
       assert entry_base_path_len == 0
       assert last_commit_len == 0
+      assert stash_count == 0
     end
   end
 

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -50,7 +50,8 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
            branch: "develop",
            ahead: 1,
            behind: 0,
-           last_commit_message: "feat: previous subject"
+           last_commit_message: "feat: previous subject",
+           stash_count: 2
          }}
 
       {new_state, effects} = FileEventHandler.handle(state, event)
@@ -59,6 +60,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       assert panel.branch == "develop"
       assert panel.ahead == 1
       assert panel.last_commit_message == "feat: previous subject"
+      assert panel.stash_count == 2
       assert {:render, 16} in effects
     end
 

--- a/test/minga_editor/shell/traditional/git_status_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/git_status_renderer_test.exs
@@ -31,7 +31,8 @@ defmodule MingaEditor.Shell.Traditional.GitStatusRendererTest do
       branch: "main",
       ahead: 0,
       behind: 0,
-      entries: entries
+      entries: entries,
+      stash_count: 0
     }
   end
 
@@ -167,6 +168,15 @@ defmodule MingaEditor.Shell.Traditional.GitStatusRendererTest do
       header_text = elem(hd(draws), 2)
       assert String.contains?(header_text, "↑3")
       assert String.contains?(header_text, "↓1")
+    end
+
+    test "renders stash count in header" do
+      panel = make_panel([]) |> Map.put(:stash_count, 2)
+      state = base_state(panel)
+      draws = GitStatusRenderer.render(state, @rect)
+
+      header_text = elem(hd(draws), 2)
+      assert String.contains?(header_text, "Stashes: 2")
     end
   end
 end

--- a/test/minga_editor/ui/picker/git_stash_source_test.exs
+++ b/test/minga_editor/ui/picker/git_stash_source_test.exs
@@ -1,0 +1,83 @@
+defmodule MingaEditor.UI.Picker.GitStashSourceTest do
+  @moduledoc "Tests for the git stash picker source."
+  use ExUnit.Case, async: true
+
+  alias Minga.Git.StashEntry
+  alias Minga.Git.Stub, as: GitStub
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.GitStashSource
+  alias MingaEditor.UI.Picker.Item
+
+  @moduletag :tmp_dir
+
+  describe "candidates/1" do
+    test "formats stash entries from context git root", %{tmp_dir: dir} do
+      GitStub.set_stashes(dir, [
+        %StashEntry{index: 0, ref: "stash@{0}", date: "2 minutes ago", message: "WIP on main"}
+      ])
+
+      on_exit(fn -> GitStub.clear(dir) end)
+
+      assert [item] = GitStashSource.candidates(context(dir))
+      assert item.id == {:stash, dir, 0, :list}
+      assert item.label == "WIP on main"
+      assert item.description == "2 minutes ago"
+      assert item.annotation == "stash@{0}"
+    end
+
+    test "marks entries for default drop when opened in drop mode", %{tmp_dir: dir} do
+      GitStub.set_stashes(dir, [
+        %StashEntry{index: 1, ref: "stash@{1}", date: "1 hour ago", message: "work in progress"}
+      ])
+
+      on_exit(fn -> GitStub.clear(dir) end)
+
+      assert [%Item{id: {:stash, ^dir, 1, :drop}}] =
+               GitStashSource.candidates(context(dir, :drop))
+    end
+  end
+
+  describe "selection" do
+    test "list mode reports the selected stash message", %{tmp_dir: dir} do
+      state = test_state()
+      item = %Item{id: {:stash, dir, 0, :list}, label: "WIP on main"}
+
+      assert %{shell_state: %{status_msg: "Stash: WIP on main"}} =
+               GitStashSource.on_select(item, state)
+    end
+
+    test "drop mode drops the selected stash", %{tmp_dir: dir} do
+      state = test_state()
+      item = %Item{id: {:stash, dir, 1, :drop}, label: "WIP on feature"}
+
+      assert %{shell_state: %{status_msg: "Dropped stash@{1}"}} =
+               GitStashSource.on_select(item, state)
+    end
+
+    test "drop action is available from list mode", %{tmp_dir: dir} do
+      item = %Item{id: {:stash, dir, 0, :list}, label: "WIP on main"}
+
+      assert GitStashSource.actions(item) == [{"Drop", :drop}]
+
+      assert %{shell_state: %{status_msg: "Dropped stash@{0}"}} =
+               GitStashSource.on_action(:drop, item, test_state())
+    end
+  end
+
+  defp context(git_root, action \\ :list) do
+    %Context{
+      buffers: nil,
+      editing: nil,
+      search: nil,
+      viewport: nil,
+      tab_bar: nil,
+      picker_ui: %{context: %{git_root: git_root, action: action}},
+      capabilities: %{},
+      theme: nil
+    }
+  end
+
+  defp test_state do
+    %{shell_state: %{status_msg: nil}}
+  end
+end

--- a/test/minga_editor/ui/picker/git_stash_source_test.exs
+++ b/test/minga_editor/ui/picker/git_stash_source_test.exs
@@ -47,6 +47,13 @@ defmodule MingaEditor.UI.Picker.GitStashSourceTest do
     end
 
     test "drop mode drops the selected stash", %{tmp_dir: dir} do
+      GitStub.set_stashes(dir, [
+        %StashEntry{index: 0, ref: "stash@{0}", date: "2 minutes ago", message: "WIP on main"},
+        %StashEntry{index: 1, ref: "stash@{1}", date: "1 hour ago", message: "WIP on feature"}
+      ])
+
+      on_exit(fn -> GitStub.clear(dir) end)
+
       state = test_state()
       item = %Item{id: {:stash, dir, 1, :drop}, label: "WIP on feature"}
 
@@ -55,6 +62,12 @@ defmodule MingaEditor.UI.Picker.GitStashSourceTest do
     end
 
     test "drop action is available from list mode", %{tmp_dir: dir} do
+      GitStub.set_stashes(dir, [
+        %StashEntry{index: 0, ref: "stash@{0}", date: "2 minutes ago", message: "WIP on main"}
+      ])
+
+      on_exit(fn -> GitStub.clear(dir) end)
+
       item = %Item{id: {:stash, dir, 0, :list}, label: "WIP on main"}
 
       assert GitStashSource.actions(item) == [{"Drop", :drop}]

--- a/test/support/git_stub.ex
+++ b/test/support/git_stub.ex
@@ -67,6 +67,20 @@ defmodule Minga.Git.Stub do
     :ok
   end
 
+  @doc "Sets the ahead/behind counts returned for `git_root`."
+  @spec set_ahead_behind(String.t(), non_neg_integer(), non_neg_integer()) :: :ok
+  def set_ahead_behind(git_root, ahead, behind) do
+    :ets.insert(@table, {{:ahead_behind, Path.expand(git_root)}, {ahead, behind}})
+    :ok
+  end
+
+  @doc "Sets the last commit message returned for `git_root`."
+  @spec set_last_commit_message(String.t(), String.t()) :: :ok
+  def set_last_commit_message(git_root, message) when is_binary(message) do
+    :ets.insert(@table, {{:last_commit_message, Path.expand(git_root)}, message})
+    :ok
+  end
+
   @doc "Sets the log entries returned for `git_root`."
   @spec set_log(String.t(), [Minga.Git.log_entry()]) :: :ok
   def set_log(git_root, entries) when is_list(entries) do
@@ -91,7 +105,10 @@ defmodule Minga.Git.Stub do
   @doc "Sets stash entries returned for `git_root`."
   @spec set_stashes(String.t(), [Minga.Git.stash_entry()]) :: :ok
   def set_stashes(git_root, entries) when is_list(entries) do
-    :ets.insert(@table, {{:stashes, Path.expand(git_root)}, entries})
+    git_root = Path.expand(git_root)
+    stash_state = Enum.map(entries, &{&1, nil})
+    :ets.insert(@table, {{:stash_state, git_root}, stash_state})
+    :ets.insert(@table, {{:stashes, git_root}, entries})
     :ok
   end
 
@@ -119,6 +136,7 @@ defmodule Minga.Git.Stub do
     :ets.match_delete(@table, {{:branches, expanded}, :_})
     :ets.match_delete(@table, {{:branch_delete, expanded, :_, :_}, :_})
     :ets.match_delete(@table, {{:stashes, expanded}, :_})
+    :ets.match_delete(@table, {{:stash_state, expanded}, :_})
     :ets.match_delete(@table, {{:ahead_behind, expanded}, :_})
     :ets.match_delete(@table, {{:last_commit_message, expanded}, :_})
     :ok
@@ -277,25 +295,114 @@ defmodule Minga.Git.Stub do
   end
 
   @impl true
-  @spec stash(String.t(), keyword()) :: :ok
-  def stash(_git_root, _opts \\ []), do: :ok
+  @spec stash(String.t(), keyword()) :: :ok | {:error, String.t()}
+  def stash(git_root, _opts \\ []) do
+    git_root = Path.expand(git_root)
 
-  @impl true
-  @spec stash_pop(String.t()) :: :ok
-  def stash_pop(_git_root), do: :ok
+    case status(git_root) do
+      {:ok, []} -> {:error, "No changes to stash"}
+      {:ok, entries} ->
+        stash_state = load_stash_state(git_root)
+        branch = branch_name(git_root)
+        entry = new_stash_entry(branch)
 
-  @impl true
-  @spec stash_list(String.t()) :: {:ok, [Minga.Git.stash_entry()]}
-  def stash_list(git_root) do
-    case :ets.lookup(@table, {:stashes, Path.expand(git_root)}) do
-      [{_, entries}] -> {:ok, entries}
-      [] -> {:ok, []}
+        put_stash_state(git_root, reindex_stash_state([{entry, entries} | stash_state]))
+        set_status(git_root, [])
+        :ok
     end
   end
 
   @impl true
-  @spec stash_drop(String.t(), non_neg_integer()) :: :ok
-  def stash_drop(_git_root, _index), do: :ok
+  @spec stash_pop(String.t()) :: :ok | {:error, String.t()}
+  def stash_pop(git_root) do
+    git_root = Path.expand(git_root)
+
+    case load_stash_state(git_root) do
+      [] -> {:error, "No stash entries to pop"}
+      [{_latest_entry, snapshot} | rest] ->
+        maybe_restore_status(git_root, snapshot)
+        put_stash_state(git_root, reindex_stash_state(rest))
+        :ok
+    end
+  end
+
+  @impl true
+  @spec stash_list(String.t()) :: {:ok, [Minga.Git.stash_entry()]}
+  def stash_list(git_root) do
+    {:ok, Enum.map(load_stash_state(Path.expand(git_root)), fn {entry, _snapshot} -> entry end)}
+  end
+
+  @impl true
+  @spec stash_drop(String.t(), non_neg_integer()) :: :ok | {:error, String.t()}
+  def stash_drop(git_root, index) when is_integer(index) and index >= 0 do
+    git_root = Path.expand(git_root)
+
+    case Enum.split(load_stash_state(git_root), index) do
+      {prefix, [{_dropped_entry, _snapshot} | suffix]} ->
+        put_stash_state(git_root, reindex_stash_state(prefix ++ suffix))
+        :ok
+
+      _ -> {:error, "No stash entry at stash@{#{index}}"}
+    end
+  end
+
+  @spec load_stash_state(String.t()) :: [{Minga.Git.stash_entry(), [Minga.Git.status_entry()] | nil}]
+  defp load_stash_state(git_root) do
+    case :ets.lookup(@table, {:stash_state, git_root}) do
+      [{_, entries}] -> entries
+      [] -> load_legacy_stashes(git_root)
+    end
+  end
+
+  @spec load_legacy_stashes(String.t()) :: [{Minga.Git.stash_entry(), nil}]
+  defp load_legacy_stashes(git_root) do
+    case :ets.lookup(@table, {:stashes, git_root}) do
+      [{_, entries}] -> Enum.map(entries, &{&1, nil})
+      [] -> []
+    end
+  end
+
+  @spec put_stash_state(String.t(), [{Minga.Git.stash_entry(), [Minga.Git.status_entry()] | nil}]) :: true
+  defp put_stash_state(git_root, entries) do
+    :ets.insert(@table, {{:stash_state, git_root}, entries})
+    :ets.insert(@table, {{:stashes, git_root}, Enum.map(entries, fn {entry, _snapshot} -> entry end)})
+  end
+
+  @spec reindex_stash_state([{Minga.Git.stash_entry(), [Minga.Git.status_entry()] | nil}]) :: [
+          {Minga.Git.stash_entry(), [Minga.Git.status_entry()] | nil}
+        ]
+  defp reindex_stash_state(entries) do
+    entries
+    |> Enum.with_index()
+    |> Enum.map(fn {{entry, snapshot}, index} ->
+      {%{entry | index: index, ref: "stash@{#{index}}"}, snapshot}
+    end)
+  end
+
+  @spec maybe_restore_status(String.t(), [Minga.Git.status_entry()] | nil) :: :ok
+  defp maybe_restore_status(_git_root, nil), do: :ok
+
+  defp maybe_restore_status(git_root, snapshot) do
+    set_status(git_root, snapshot)
+  end
+
+  @spec new_stash_entry(String.t()) :: Minga.Git.stash_entry()
+  defp new_stash_entry(branch) do
+    %Minga.Git.StashEntry{
+      index: 0,
+      ref: "stash@{0}",
+      date: "now",
+      message: "WIP on #{branch}"
+    }
+  end
+
+  @spec branch_name(String.t()) :: String.t()
+  defp branch_name(git_root) do
+    case current_branch(git_root) do
+      {:ok, branch} when is_binary(branch) -> branch
+      _ -> "main"
+    end
+  end
 
   @impl true
   @spec push(String.t(), keyword()) :: :ok
@@ -324,20 +431,6 @@ defmodule Minga.Git.Stub do
   def set_branch_delete_result(git_root, name, force, result)
       when is_binary(name) and is_boolean(force) do
     :ets.insert(@table, {{:branch_delete, Path.expand(git_root), name, force}, result})
-    :ok
-  end
-
-  @doc "Sets the ahead/behind counts for a git root."
-  @spec set_ahead_behind(String.t(), non_neg_integer(), non_neg_integer()) :: :ok
-  def set_ahead_behind(git_root, ahead, behind) do
-    :ets.insert(@table, {{:ahead_behind, Path.expand(git_root)}, {ahead, behind}})
-    :ok
-  end
-
-  @doc "Sets the last commit message returned for `git_root`."
-  @spec set_last_commit_message(String.t(), String.t()) :: :ok
-  def set_last_commit_message(git_root, message) when is_binary(message) do
-    :ets.insert(@table, {{:last_commit_message, Path.expand(git_root)}, message})
     :ok
   end
 

--- a/test/support/git_stub.ex
+++ b/test/support/git_stub.ex
@@ -300,7 +300,9 @@ defmodule Minga.Git.Stub do
     git_root = Path.expand(git_root)
 
     case status(git_root) do
-      {:ok, []} -> {:error, "No changes to stash"}
+      {:ok, []} ->
+        {:error, "No changes to stash"}
+
       {:ok, entries} ->
         stash_state = load_stash_state(git_root)
         branch = branch_name(git_root)
@@ -318,7 +320,9 @@ defmodule Minga.Git.Stub do
     git_root = Path.expand(git_root)
 
     case load_stash_state(git_root) do
-      [] -> {:error, "No stash entries to pop"}
+      [] ->
+        {:error, "No stash entries to pop"}
+
       [{_latest_entry, snapshot} | rest] ->
         maybe_restore_status(git_root, snapshot)
         put_stash_state(git_root, reindex_stash_state(rest))
@@ -342,11 +346,14 @@ defmodule Minga.Git.Stub do
         put_stash_state(git_root, reindex_stash_state(prefix ++ suffix))
         :ok
 
-      _ -> {:error, "No stash entry at stash@{#{index}}"}
+      _ ->
+        {:error, "No stash entry at stash@{#{index}}"}
     end
   end
 
-  @spec load_stash_state(String.t()) :: [{Minga.Git.stash_entry(), [Minga.Git.status_entry()] | nil}]
+  @spec load_stash_state(String.t()) :: [
+          {Minga.Git.stash_entry(), [Minga.Git.status_entry()] | nil}
+        ]
   defp load_stash_state(git_root) do
     case :ets.lookup(@table, {:stash_state, git_root}) do
       [{_, entries}] -> entries
@@ -362,10 +369,15 @@ defmodule Minga.Git.Stub do
     end
   end
 
-  @spec put_stash_state(String.t(), [{Minga.Git.stash_entry(), [Minga.Git.status_entry()] | nil}]) :: true
+  @spec put_stash_state(String.t(), [{Minga.Git.stash_entry(), [Minga.Git.status_entry()] | nil}]) ::
+          true
   defp put_stash_state(git_root, entries) do
     :ets.insert(@table, {{:stash_state, git_root}, entries})
-    :ets.insert(@table, {{:stashes, git_root}, Enum.map(entries, fn {entry, _snapshot} -> entry end)})
+
+    :ets.insert(
+      @table,
+      {{:stashes, git_root}, Enum.map(entries, fn {entry, _snapshot} -> entry end)}
+    )
   end
 
   @spec reindex_stash_state([{Minga.Git.stash_entry(), [Minga.Git.status_entry()] | nil}]) :: [

--- a/test/support/git_stub.ex
+++ b/test/support/git_stub.ex
@@ -88,6 +88,13 @@ defmodule Minga.Git.Stub do
     :ok
   end
 
+  @doc "Sets stash entries returned for `git_root`."
+  @spec set_stashes(String.t(), [Minga.Git.stash_entry()]) :: :ok
+  def set_stashes(git_root, entries) when is_list(entries) do
+    :ets.insert(@table, {{:stashes, Path.expand(git_root)}, entries})
+    :ok
+  end
+
   @doc "Returns paths staged through the stub for `git_root`."
   @spec staged_paths(String.t()) :: [String.t()]
   def staged_paths(git_root) do
@@ -111,6 +118,7 @@ defmodule Minga.Git.Stub do
     :ets.match_delete(@table, {{:branch, expanded}, :_})
     :ets.match_delete(@table, {{:branches, expanded}, :_})
     :ets.match_delete(@table, {{:branch_delete, expanded, :_, :_}, :_})
+    :ets.match_delete(@table, {{:stashes, expanded}, :_})
     :ets.match_delete(@table, {{:ahead_behind, expanded}, :_})
     :ets.match_delete(@table, {{:last_commit_message, expanded}, :_})
     :ok
@@ -267,6 +275,27 @@ defmodule Minga.Git.Stub do
         :ok
     end
   end
+
+  @impl true
+  @spec stash(String.t(), keyword()) :: :ok
+  def stash(_git_root, _opts \\ []), do: :ok
+
+  @impl true
+  @spec stash_pop(String.t()) :: :ok
+  def stash_pop(_git_root), do: :ok
+
+  @impl true
+  @spec stash_list(String.t()) :: {:ok, [Minga.Git.stash_entry()]}
+  def stash_list(git_root) do
+    case :ets.lookup(@table, {:stashes, Path.expand(git_root)}) do
+      [{_, entries}] -> {:ok, entries}
+      [] -> {:ok, []}
+    end
+  end
+
+  @impl true
+  @spec stash_drop(String.t(), non_neg_integer()) :: :ok
+  def stash_drop(_git_root, _index), do: :ok
 
   @impl true
   @spec push(String.t(), keyword()) :: :ok


### PR DESCRIPTION
## Summary
- Adds stash save, pop, list, and drop commands and keybindings.
- Adds Git backend stash operations plus stash entry parsing.
- Surfaces stash count through git status data, TUI rendering, GUI protocol, and macOS git status UI.

Closes #988

## Validation
- `make lint` passed in prior session.
- Full `mix test.llm` passed before final targeted fixes in prior session.
- Targeted git/status/picker tests passed after final fixes in prior session.
- `git diff --check` passed.
- Final reviewer found only the environment blocker: local Linux environment lacks `xcodebuild`, so Swift tests must run in CI or on macOS.
