### PR TITLE
feat(picker): add bulk marked actions

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -307,7 +307,7 @@ Fuzzy finder / command palette state. Uses sectioned envelope: `opcode(1) + sect
 
 | Section ID | Name | Content |
 |-----------|------|--------|
-| 0x01 | Header | visible, selected_index, filtered_count, total_count, has_preview, title |
+| 0x01 | Header | visible, selected_index, filtered_count, total_count, has_preview, title, marked_count |
 | 0x02 | Query | query string |
 | 0x03 | Items | item_count + items (positional per item) |
 | 0x04 | ActionMenu | visible flag + selected + actions |
@@ -322,7 +322,7 @@ Each section:
 
 Header section 0x01 payload:
   visible(1) + selected_index(2) + filtered_count(2) + total_count(2)
-  + has_preview(1) + title_len(2) + title(title_len)
+  + has_preview(1) + title_len(2) + title(title_len) + marked_count(2)
 
 Query section 0x02 payload:
   query_len(2) + query(query_len)
@@ -352,6 +352,7 @@ annotation is a right-aligned string (e.g., keybinding "SPC f s").
 match_positions is a list of uint16 character indices for highlighting matched characters.
 has_preview indicates whether the picker source supports preview (triggers split layout).
 filtered_count and total_count enable "X/Y" display in the search field.
+marked_count is authoritative across the full picker item set, including marked items hidden by the current filter or item limit.
 action menu shows source-specific actions (e.g., "Open", "Delete", "Open in split").
 mode prefix badges show switched picker sources like command, buffer, or project search.
 

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -690,6 +690,7 @@ defmodule MingaEditor.Frontend.Emit.GUI do
       picker.selected,
       length(picker.filtered),
       length(picker.items),
+      Picker.marked_count(picker),
       has_preview,
       visible_items,
       action_menu

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -2434,7 +2434,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   """
   @typedoc "Action menu state: `{actions, selected_index}` or nil."
   @type action_menu_state ::
-          {[{String.t(), atom()}], non_neg_integer()} | nil
+          {[{String.t(), term()}], non_neg_integer()} | nil
 
   @spec encode_gui_picker(
           MingaEditor.UI.Picker.t() | nil,
@@ -2469,6 +2469,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     mode_prefix_bytes = :erlang.iolist_to_binary([mode_prefix])
     filtered_count = length(picker.filtered)
     total_count = length(picker.items)
+    marked_count = MingaEditor.UI.Picker.marked_count(picker)
     has_preview_byte = if has_preview, do: 1, else: 0
 
     entries =
@@ -2498,7 +2499,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
       encode_section(
         @section_picker_header,
         <<1::8, picker.selected::16, filtered_count::16, total_count::16, has_preview_byte::8,
-          byte_size(title_bytes)::16, title_bytes::binary>>
+          byte_size(title_bytes)::16, title_bytes::binary, marked_count::16>>
       ),
       encode_section(@section_picker_query, <<byte_size(query_bytes)::16, query_bytes::binary>>),
       encode_section(@section_picker_items, items_payload),

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -2495,6 +2495,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     items_payload = IO.iodata_to_binary([<<length(items)::16>> | entries])
     action_menu_bytes = encode_picker_action_menu(action_menu)
 
+    # Header payload includes visibility, counts, preview flag, title, and marked_count.
     sections = [
       encode_section(
         @section_picker_header,

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -245,7 +245,7 @@ defmodule MingaEditor.PickerUI do
       ) do
     case Picker.selected_item(picker) do
       nil -> close(state)
-      item -> select_item(state, item, source)
+      item -> select_item(state, picker, item, source)
     end
   end
 
@@ -324,7 +324,7 @@ defmodule MingaEditor.PickerUI do
         state
 
       item ->
-        actions = Picker.Source.actions(source, item)
+        actions = action_menu_actions(source, picker, item)
 
         case actions do
           [] -> state
@@ -408,11 +408,11 @@ defmodule MingaEditor.PickerUI do
   # Ignore all other keys
   def handle_key(state, _cp, _mods), do: state
 
-  @spec run_source_action_and_close(EditorState.t(), module(), atom(), Picker.item()) ::
+  @spec run_source_action_and_close(EditorState.t(), module(), term(), Picker.item()) ::
           EditorState.t()
   defp run_source_action_and_close(state, source, action_id, item) do
     new_state = close(state)
-    source.on_action(action_id, item, new_state)
+    run_action(source, action_id, item, new_state)
   end
 
   @spec type_printable_char(EditorState.t(), Picker.t(), String.t()) :: EditorState.t()
@@ -428,9 +428,19 @@ defmodule MingaEditor.PickerUI do
     end
   end
 
-  @spec select_item(EditorState.t(), Picker.item(), module()) ::
+  @spec select_item(EditorState.t(), Picker.t(), Picker.item(), module()) ::
           EditorState.t() | {EditorState.t(), {:execute_command, atom()}}
-  defp select_item(state, item, source) do
+  defp select_item(state, picker, item, source) do
+    if bulk_select?(source, picker) do
+      run_bulk_select_and_close(state, picker, source)
+    else
+      select_single_item(state, item, source)
+    end
+  end
+
+  @spec select_single_item(EditorState.t(), Picker.item(), module()) ::
+          EditorState.t() | {EditorState.t(), {:execute_command, atom()}}
+  defp select_single_item(state, item, source) do
     if Picker.Source.keep_open_on_select?(source) do
       new_state = source.on_select(item, state)
       refresh_items(new_state)
@@ -493,6 +503,52 @@ defmodule MingaEditor.PickerUI do
     end
   end
 
+  @spec run_bulk_select_and_close(EditorState.t(), Picker.t(), module()) :: EditorState.t()
+  defp run_bulk_select_and_close(state, picker, source) do
+    items = Picker.marked_items(picker)
+
+    state
+    |> restore_picker_origin()
+    |> close()
+    |> then(&Picker.Source.bulk_select(source, items, &1))
+  end
+
+  @spec bulk_select?(module(), Picker.t()) :: boolean()
+  defp bulk_select?(source, picker) do
+    Picker.has_marks?(picker) and Picker.Source.has_bulk_select?(source)
+  end
+
+  @spec action_menu_actions(module(), Picker.t(), Picker.item()) :: [Picker.Source.action_entry()]
+  defp action_menu_actions(source, picker, item) do
+    if Picker.has_marks?(picker) do
+      bulk_action_menu_actions(source, Picker.marked_items(picker), item)
+    else
+      Picker.Source.actions(source, item)
+    end
+  end
+
+  @spec bulk_action_menu_actions(module(), [Picker.item()], Picker.item()) :: [
+          Picker.Source.action_entry()
+        ]
+  defp bulk_action_menu_actions(source, items, item) do
+    case Picker.Source.bulk_actions(source, items) do
+      [] ->
+        Picker.Source.actions(source, item)
+
+      actions ->
+        Enum.map(actions, fn {name, action_id} -> {name, {:bulk, action_id, items}} end)
+    end
+  end
+
+  @spec run_action(module(), term(), Picker.item(), EditorState.t()) :: EditorState.t()
+  defp run_action(source, {:bulk, action_id, items}, _item, state) do
+    Picker.Source.on_bulk_action(source, action_id, items, state)
+  end
+
+  defp run_action(source, action_id, item, state) do
+    source.on_action(action_id, item, state)
+  end
+
   @spec record_command_execution(module(), term()) :: :ok
   defp record_command_execution(MingaEditor.UI.Picker.CommandSource, command_name)
        when is_atom(command_name) do
@@ -541,7 +597,7 @@ defmodule MingaEditor.PickerUI do
 
     # Separator line
     title = picker.title
-    filter_info = "#{Picker.count(picker)}/#{Picker.total(picker)}"
+    filter_info = picker_filter_info(picker)
 
     sep_text =
       " #{title} " <>
@@ -629,6 +685,16 @@ defmodule MingaEditor.PickerUI do
       )
 
     {all_cmds ++ action_cmds, cursor_pos}
+  end
+
+  @spec picker_filter_info(Picker.t()) :: String.t()
+  defp picker_filter_info(picker) do
+    base = "#{Picker.count(picker)}/#{Picker.total(picker)}"
+
+    case Picker.marked_count(picker) do
+      0 -> base
+      count -> "#{base} (#{count} marked)"
+    end
   end
 
   @doc """

--- a/lib/minga_editor/ui/picker.ex
+++ b/lib/minga_editor/ui/picker.ex
@@ -221,16 +221,24 @@ defmodule MingaEditor.UI.Picker do
 
   @doc "Returns all marked items. If none are marked, returns the selected item in a list."
   @spec marked_items(t()) :: [Item.t()]
-  def marked_items(%__MODULE__{marked: marked, filtered: filtered} = picker) do
+  def marked_items(%__MODULE__{marked: marked, items: items} = picker) do
     if map_size(marked) == 0 do
       case selected_item(picker) do
         nil -> []
         item -> [item]
       end
     else
-      Enum.filter(filtered, fn %Item{id: id} -> Map.has_key?(marked, id) end)
+      Enum.filter(items, fn %Item{id: id} -> Map.has_key?(marked, id) end)
     end
   end
+
+  @doc "Returns true when the picker has explicit multi-select marks."
+  @spec has_marks?(t()) :: boolean()
+  def has_marks?(%__MODULE__{marked: marked}), do: map_size(marked) > 0
+
+  @doc "Returns the number of explicitly marked items."
+  @spec marked_count(t()) :: non_neg_integer()
+  def marked_count(%__MODULE__{marked: marked}), do: map_size(marked)
 
   @doc "Returns whether an item is marked."
   @spec marked?(t(), Item.t()) :: boolean()

--- a/lib/minga_editor/ui/picker/buffer_all_source.ex
+++ b/lib/minga_editor/ui/picker/buffer_all_source.ex
@@ -43,6 +43,18 @@ defmodule MingaEditor.UI.Picker.BufferAllSource do
   def actions(item), do: BufferSource.actions(item)
 
   @impl true
-  @spec on_action(atom(), Item.t(), term()) :: term()
+  @spec on_action(term(), Item.t(), term()) :: term()
   def on_action(action, item, state), do: BufferSource.on_action(action, item, state)
+
+  @impl true
+  @spec on_bulk_select([Item.t()], term()) :: term()
+  def on_bulk_select(items, state), do: BufferSource.on_bulk_select(items, state)
+
+  @impl true
+  @spec bulk_actions([Item.t()]) :: [MingaEditor.UI.Picker.Source.action_entry()]
+  def bulk_actions(items), do: BufferSource.bulk_actions(items)
+
+  @impl true
+  @spec on_bulk_action(term(), [Item.t()], term()) :: term()
+  def on_bulk_action(action, items, state), do: BufferSource.on_bulk_action(action, items, state)
 end

--- a/lib/minga_editor/ui/picker/buffer_source.ex
+++ b/lib/minga_editor/ui/picker/buffer_source.ex
@@ -158,21 +158,51 @@ defmodule MingaEditor.UI.Picker.BufferSource do
   defp kill_items(items, %{workspace: %{buffers: %Buffers{} = bs}} = state) do
     pids = items |> Enum.map(&item_pid(&1, bs.list)) |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
-    case pids do
-      [] ->
-        state
-
-      _ ->
-        Enum.each(pids, &stop_buffer/1)
-        new_bs = Enum.reduce(pids, bs, fn pid, acc -> Buffers.remove(acc, pid) end)
-
-        state
-        |> EditorState.set_buffers(new_bs)
-        |> EditorState.sync_active_window_buffer()
-    end
+    kill_pids(pids, bs, state)
   end
 
   defp kill_items(_items, state), do: state
+
+  @spec kill_pids([pid()], Buffers.t(), term()) :: term()
+  defp kill_pids([], _bs, state), do: state
+
+  defp kill_pids(pids, bs, state) do
+    pids
+    |> Enum.reduce(bs, fn pid, acc -> Buffers.remove(acc, pid) end)
+    |> apply_kill_result(pids, bs, state)
+  end
+
+  @spec apply_kill_result(Buffers.t(), [pid()], Buffers.t(), term()) :: term()
+  defp apply_kill_result(%Buffers{list: []}, pids, bs, state) do
+    case start_fallback_buffer(state) do
+      {:ok, new_buf} ->
+        Enum.each(pids, &stop_buffer/1)
+
+        state
+        |> EditorState.set_buffers(Buffers.replace_list(bs, [new_buf], 0))
+        |> EditorState.sync_active_window_buffer()
+
+      {:error, _} ->
+        state
+    end
+  end
+
+  defp apply_kill_result(%Buffers{} = new_bs, pids, _bs, state) do
+    Enum.each(pids, &stop_buffer/1)
+
+    state
+    |> EditorState.set_buffers(new_bs)
+    |> EditorState.sync_active_window_buffer()
+  end
+
+  @spec start_fallback_buffer(term()) :: {:ok, pid()} | {:error, term()}
+  defp start_fallback_buffer(state) do
+    DynamicSupervisor.start_child(
+      Minga.Buffer.Supervisor,
+      {Buffer,
+       content: "", buffer_name: "[new 1]", options_server: EditorState.options_server(state)}
+    )
+  end
 
   @spec item_pid(Item.t(), [pid()]) :: pid() | nil
   defp item_pid(%Item{id: {:pid, pid}}, _buffers) when is_pid(pid), do: pid

--- a/lib/minga_editor/ui/picker/buffer_source.ex
+++ b/lib/minga_editor/ui/picker/buffer_source.ex
@@ -104,41 +104,23 @@ defmodule MingaEditor.UI.Picker.BufferSource do
   end
 
   @impl true
-  @spec on_action(atom(), Item.t(), term()) :: term()
+  @spec on_action(term(), Item.t(), term()) :: term()
   def on_action(:switch, item, state), do: on_select(item, state)
-
-  def on_action(
-        :kill,
-        %Item{id: idx},
-        %{workspace: %{buffers: %MingaEditor.State.Buffers{list: buffers} = bs}} = state
-      )
-      when is_integer(idx) and idx < length(buffers) do
-    alias MingaEditor.State.Buffers
-
-    pid = Enum.at(buffers, idx)
-
-    try do
-      DynamicSupervisor.terminate_child(Minga.Buffer.Supervisor, pid)
-    catch
-      :exit, _ -> :ok
-    end
-
-    new_buffers = List.delete_at(buffers, idx)
-
-    case new_buffers do
-      [] ->
-        state
-
-      _ ->
-        new_active = min(bs.active_index, length(new_buffers) - 1)
-        new_bs = %Buffers{bs | list: new_buffers}
-
-        EditorState.set_buffers(state, Buffers.switch_to(new_bs, new_active))
-        |> EditorState.sync_active_window_buffer()
-    end
-  end
-
+  def on_action(:kill, item, state), do: kill_items([item], state)
   def on_action(_action, _item, state), do: state
+
+  @impl true
+  @spec on_bulk_select([Item.t()], term()) :: term()
+  def on_bulk_select(items, state), do: kill_items(items, state)
+
+  @impl true
+  @spec bulk_actions([Item.t()]) :: [MingaEditor.UI.Picker.Source.action_entry()]
+  def bulk_actions(_items), do: [{"Kill all marked", :kill_marked}]
+
+  @impl true
+  @spec on_bulk_action(term(), [Item.t()], term()) :: term()
+  def on_bulk_action(:kill_marked, items, state), do: kill_items(items, state)
+  def on_bulk_action(_action, _items, state), do: state
 
   @doc """
   Returns `true` if the buffer is a special buffer (name matches `*...*` pattern).
@@ -170,6 +152,39 @@ defmodule MingaEditor.UI.Picker.BufferSource do
   defp do_reject?(buf, false = _include_special) do
     # Default: reject unlisted buffers and special buffers
     Buffer.unlisted?(buf) or special?(buf)
+  end
+
+  @spec kill_items([Item.t()], term()) :: term()
+  defp kill_items(items, %{workspace: %{buffers: %Buffers{} = bs}} = state) do
+    pids = items |> Enum.map(&item_pid(&1, bs.list)) |> Enum.reject(&is_nil/1) |> Enum.uniq()
+
+    case pids do
+      [] ->
+        state
+
+      _ ->
+        Enum.each(pids, &stop_buffer/1)
+        new_bs = Enum.reduce(pids, bs, fn pid, acc -> Buffers.remove(acc, pid) end)
+
+        state
+        |> EditorState.set_buffers(new_bs)
+        |> EditorState.sync_active_window_buffer()
+    end
+  end
+
+  defp kill_items(_items, state), do: state
+
+  @spec item_pid(Item.t(), [pid()]) :: pid() | nil
+  defp item_pid(%Item{id: {:pid, pid}}, _buffers) when is_pid(pid), do: pid
+  defp item_pid(%Item{id: idx}, buffers) when is_integer(idx), do: Enum.at(buffers, idx)
+  defp item_pid(_item, _buffers), do: nil
+
+  @spec stop_buffer(pid()) :: :ok
+  defp stop_buffer(pid) when is_pid(pid) do
+    GenServer.stop(pid, :normal)
+    :ok
+  catch
+    :exit, _ -> :ok
   end
 
   # ── Private ─────────────────────────────────────────────────────────────────

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -141,7 +141,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   end
 
   @impl true
-  @spec on_action(atom(), Item.t(), term()) :: term()
+  @spec on_action(term(), Item.t(), term()) :: term()
   def on_action(:open, item, state), do: on_select(item, state)
 
   def on_action(:delete, %Item{id: rel_path}, state) do
@@ -160,7 +160,25 @@ defmodule MingaEditor.UI.Picker.FileSource do
 
   def on_action(_action, _item, state), do: state
 
+  @impl true
+  @spec on_bulk_select([Item.t()], term()) :: term()
+  def on_bulk_select(items, state), do: open_items(items, state)
+
+  @impl true
+  @spec bulk_actions([Item.t()]) :: [MingaEditor.UI.Picker.Source.action_entry()]
+  def bulk_actions(_items), do: [{"Open all marked", :open_marked}]
+
+  @impl true
+  @spec on_bulk_action(term(), [Item.t()], term()) :: term()
+  def on_bulk_action(:open_marked, items, state), do: open_items(items, state)
+  def on_bulk_action(_action, _items, state), do: state
+
   # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec open_items([Item.t()], term()) :: term()
+  defp open_items(items, state) do
+    Enum.reduce(items, state, fn item, acc -> on_select(item, acc) end)
+  end
 
   @spec absolute_path(String.t(), term()) :: String.t()
   defp absolute_path(rel_path, state), do: Path.expand(rel_path, project_root(state))

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -10,6 +10,7 @@ defmodule MingaEditor.UI.Picker.Source do
 
   - `candidates/1` — returns the list of picker items given some context
   - `on_select/2` — called when the user selects an item; returns new editor state
+  - `on_bulk_select/2` — optionally called when the user confirms explicitly marked items
   - `on_cancel/1` — called when the user cancels; returns new editor state
   - `preview?/0` — legacy live-navigation preview flag (default: false)
   - `live_preview?/0` — whether navigating the picker should temporarily run `on_select/2` for the highlighted item (default: `preview?/0` for backwards compatibility)
@@ -57,6 +58,14 @@ defmodule MingaEditor.UI.Picker.Source do
   """
   @callback on_select(Picker.item(), state :: term()) :: term()
 
+  @doc """
+  Called when the user confirms explicitly marked items. Returns the new editor state.
+
+  Sources that do not implement this callback ignore picker marks and keep the
+  single-selection behavior from `on_select/2`.
+  """
+  @callback on_bulk_select([Picker.item()], state :: term()) :: term()
+
   @doc "Called when the user cancels the picker. Returns the new editor state."
   @callback on_cancel(state :: term()) :: term()
 
@@ -79,7 +88,7 @@ defmodule MingaEditor.UI.Picker.Source do
   @callback preview(Picker.item(), context :: preview_context()) :: [[preview_segment()]] | nil
 
   @typedoc "An alternative action: display name and action identifier."
-  @type action_entry :: {name :: String.t(), action_id :: atom()}
+  @type action_entry :: {name :: String.t(), action_id :: term()}
 
   @doc """
   Returns the list of alternative actions available for a picker item.
@@ -95,7 +104,13 @@ defmodule MingaEditor.UI.Picker.Source do
   context required must travel with the `Picker.item()`; do not read
   `state.shell_state.modal` here.
   """
-  @callback on_action(atom(), Picker.item(), state :: term()) :: term()
+  @callback on_action(term(), Picker.item(), state :: term()) :: term()
+
+  @doc "Returns the list of alternative actions available for a marked item batch."
+  @callback bulk_actions([Picker.item()]) :: [action_entry()]
+
+  @doc "Executes an alternative action on a marked item batch."
+  @callback on_bulk_action(term(), [Picker.item()], state :: term()) :: term()
 
   @typedoc "Picker layout: bottom-anchored (default) or centered floating window."
   @type layout :: :bottom | :centered
@@ -122,6 +137,9 @@ defmodule MingaEditor.UI.Picker.Source do
     preview: 2,
     actions: 1,
     on_action: 3,
+    on_bulk_select: 2,
+    bulk_actions: 1,
+    on_bulk_action: 3,
     layout: 0,
     keep_open_on_select?: 0
   ]
@@ -204,6 +222,46 @@ defmodule MingaEditor.UI.Picker.Source do
       module.actions(item)
     else
       []
+    end
+  end
+
+  @doc "Returns whether a source module supports bulk select."
+  @spec has_bulk_select?(module()) :: boolean()
+  def has_bulk_select?(module), do: exported?(module, :on_bulk_select, 2)
+
+  @doc "Runs bulk select for a source, returning state unchanged if unsupported."
+  @spec bulk_select(module(), [Picker.item()], term()) :: term()
+  def bulk_select(module, items, state) do
+    if has_bulk_select?(module) do
+      module.on_bulk_select(items, state)
+    else
+      state
+    end
+  end
+
+  @doc "Returns whether a source module supports bulk alternative actions."
+  @spec has_bulk_actions?(module()) :: boolean()
+  def has_bulk_actions?(module) do
+    exported?(module, :bulk_actions, 1) and exported?(module, :on_bulk_action, 3)
+  end
+
+  @doc "Returns bulk actions for marked items, or an empty list if unsupported."
+  @spec bulk_actions(module(), [Picker.item()]) :: [action_entry()]
+  def bulk_actions(module, items) do
+    if has_bulk_actions?(module) do
+      module.bulk_actions(items)
+    else
+      []
+    end
+  end
+
+  @doc "Runs a bulk action for a source, returning state unchanged if unsupported."
+  @spec on_bulk_action(module(), term(), [Picker.item()], term()) :: term()
+  def on_bulk_action(module, action, items, state) do
+    if has_bulk_actions?(module) do
+      module.on_bulk_action(action, items, state)
+    else
+      state
     end
   end
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -184,7 +184,7 @@ enum RenderCommand: Sendable {
     case guiWhichKey(visible: Bool, prefix: String, page: UInt8, pageCount: UInt8, bindings: [Wire.WhichKeyBinding])
     case guiBreadcrumb(segments: [String])
     case guiStatusBar(StatusBarUpdate)
-    case guiPicker(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, title: String, query: String, hasPreview: Bool, items: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?, modePrefix: String)
+    case guiPicker(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, markedCount: UInt16, title: String, query: String, hasPreview: Bool, items: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?, modePrefix: String)
     case guiPickerPreview(visible: Bool, lines: [Wire.PickerPreviewLine])
     case guiAgentChat(visible: Bool, status: UInt8, model: String, thinkingLevel: String, prompt: String, promptLineCount: UInt8, promptCursorLine: UInt16, promptCursorCol: UInt16, promptVimMode: UInt8, promptVisibleRows: UInt8, promptCompletion: Wire.PromptCompletion?, pendingToolName: String?, pendingToolSummary: String, helpVisible: Bool, helpGroups: [Wire.HelpGroup], messages: [Wire.ChatMessage])
     case guiGutterSeparator(col: UInt16, r: UInt8, g: UInt8, b: UInt8)
@@ -1065,13 +1065,14 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         guard data.count >= rest + 1 else { throw ProtocolDecodeError.malformed }
         let pickerSectionCount = Int(data[rest])
         if pickerSectionCount == 0 {
-            return (.guiPicker(visible: false, selectedIndex: 0, filteredCount: 0, totalCount: 0, title: "", query: "", hasPreview: false, items: [], actionMenu: nil, modePrefix: ""), 2)
+            return (.guiPicker(visible: false, selectedIndex: 0, filteredCount: 0, totalCount: 0, markedCount: 0, title: "", query: "", hasPreview: false, items: [], actionMenu: nil, modePrefix: ""), 2)
         }
         var pickerPos = rest + 1
         var pkVisible = false
         var pkSelectedIndex: UInt16 = 0
         var pkFilteredCount: UInt16 = 0
         var pkTotalCount: UInt16 = 0
+        var pkMarkedCount: UInt16 = 0
         var pkHasPreview = false
         var pkTitle = ""
         var pkQuery = ""
@@ -1087,7 +1088,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             guard data.count >= psStart + psLen else { throw ProtocolDecodeError.malformed }
 
             switch psId {
-            case 0x01: // Header: visible(1) + selected(2) + filtered(2) + total(2) + has_preview(1) + title_len(2) + title
+            case 0x01: // Header: visible(1) + selected(2) + filtered(2) + total(2) + has_preview(1) + title_len(2) + title + marked_count(2)
                 guard psLen >= 8 else { break }
                 pkVisible = data[psStart] != 0
                 pkSelectedIndex = readU16(data, psStart + 1)
@@ -1098,6 +1099,9 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                     let tLen = Int(readU16(data, psStart + 8))
                     if psLen >= 10 + tLen {
                         pkTitle = String(data: data[(psStart + 10)..<(psStart + 10 + tLen)], encoding: .utf8) ?? ""
+                    }
+                    if psLen >= 12 + tLen {
+                        pkMarkedCount = readU16(data, psStart + 10 + tLen)
                     }
                 }
 
@@ -1169,7 +1173,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             pickerPos = psStart + psLen
         }
 
-        return (.guiPicker(visible: pkVisible, selectedIndex: pkSelectedIndex, filteredCount: pkFilteredCount, totalCount: pkTotalCount, title: pkTitle, query: pkQuery, hasPreview: pkHasPreview, items: pkItems, actionMenu: pkActionMenu, modePrefix: pkModePrefix), pickerPos - offset)
+        return (.guiPicker(visible: pkVisible, selectedIndex: pkSelectedIndex, filteredCount: pkFilteredCount, totalCount: pkTotalCount, markedCount: pkMarkedCount, title: pkTitle, query: pkQuery, hasPreview: pkHasPreview, items: pkItems, actionMenu: pkActionMenu, modePrefix: pkModePrefix), pickerPos - offset)
 
     case OP_GUI_PICKER_PREVIEW:
         guard data.count >= rest + 1 else { throw ProtocolDecodeError.malformed }

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -265,9 +265,9 @@ final class CommandDispatcher {
                 onModeChanged?(guiState.statusBarState.modeName)
             }
 
-        case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix):
+        case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let markedCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix):
             if visible {
-                guiState.pickerState.update(visible: true, selectedIndex: selectedIndex, filteredCount: filteredCount, totalCount: totalCount, title: title, query: query, hasPreview: hasPreview, rawItems: items, actionMenu: actionMenu, modePrefix: modePrefix)
+                guiState.pickerState.update(visible: true, selectedIndex: selectedIndex, filteredCount: filteredCount, totalCount: totalCount, markedCount: markedCount, title: title, query: query, hasPreview: hasPreview, rawItems: items, actionMenu: actionMenu, modePrefix: modePrefix)
             } else {
                 guiState.pickerState.hide()
             }

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -98,9 +98,8 @@ struct PickerOverlay: View {
 
             Spacer()
 
-            let markedCount = state.items.filter { $0.isMarked }.count
-            if markedCount > 0 {
-                Text("\(markedCount) selected")
+            if state.markedCount > 0 {
+                Text("\(state.markedCount) marked")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(theme.accent)
                     .padding(.horizontal, 6)
@@ -163,13 +162,13 @@ struct PickerOverlay: View {
         let isSelected = item.id == state.selectedIndex
 
         HStack(spacing: 6) {
-            // Multi-select checkmark
-            if item.isMarked {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 11))
-                    .foregroundStyle(theme.accent)
-                    .frame(width: 14)
-            }
+            // Multi-select checkmark column stays reserved so rows do not shift.
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 11))
+                .foregroundStyle(theme.accent)
+                .frame(width: 14)
+                .opacity(item.isMarked ? 1 : 0)
+                .accessibilityHidden(true)
 
             // File type icon
             Text(item.icon)

--- a/macos/Sources/Views/PickerState.swift
+++ b/macos/Sources/Views/PickerState.swift
@@ -64,6 +64,7 @@ final class PickerState {
     var selectedIndex: Int = 0
     var filteredCount: Int = 0
     var totalCount: Int = 0
+    var markedCount: Int = 0
     var title: String = ""
     var query: String = ""
     var modePrefix: String = ""
@@ -72,11 +73,12 @@ final class PickerState {
     var previewLines: [PreviewLine] = []
     var actionMenu: PickerActionMenu? = nil
 
-    func update(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, title: String, query: String, hasPreview: Bool, rawItems: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?, modePrefix: String = "") {
+    func update(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, markedCount: UInt16, title: String, query: String, hasPreview: Bool, rawItems: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?, modePrefix: String = "") {
         self.visible = visible
         self.selectedIndex = Int(selectedIndex)
         self.filteredCount = Int(filteredCount)
         self.totalCount = Int(totalCount)
+        self.markedCount = Int(markedCount)
         self.title = title
         self.query = query
         self.modePrefix = modePrefix
@@ -125,6 +127,7 @@ final class PickerState {
 
     func hide() {
         visible = false
+        markedCount = 0
         items = []
         previewLines = []
         modePrefix = ""

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -141,11 +141,11 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
         result["selection_size"] = Int(update.selection.size)
         return result
 
-    case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix):
+    case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let markedCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix):
         let itemArray = items.map { i -> [String: Any] in
             ["label": i.label, "description": i.description, "icon_color": Int(i.iconColor), "annotation": i.annotation, "flags": Int(i.flags), "match_positions": i.matchPositions.map { Int($0) }]
         }
-        var result: [String: Any] = ["type": "gui_picker", "visible": visible, "selected_index": Int(selectedIndex), "filtered_count": Int(filteredCount), "total_count": Int(totalCount), "title": title, "query": query, "mode_prefix": modePrefix, "has_preview": hasPreview, "items": itemArray]
+        var result: [String: Any] = ["type": "gui_picker", "visible": visible, "selected_index": Int(selectedIndex), "filtered_count": Int(filteredCount), "total_count": Int(totalCount), "marked_count": Int(markedCount), "title": title, "query": query, "mode_prefix": modePrefix, "has_preview": hasPreview, "items": itemArray]
         if let am = actionMenu {
             result["action_menu"] = ["selected_index": Int(am.selectedIndex), "actions": am.actions]
         }

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -461,28 +461,30 @@ struct CommandDispatcherRoutingTests {
     @MainActor func guiPickerVisible() {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.dispatch(.guiPicker(visible: true, selectedIndex: 0, filteredCount: 5,
-                                        totalCount: 100, title: "Find File", query: "edi",
+                                        totalCount: 100, markedCount: 2, title: "Find File", query: "edi",
                                         hasPreview: false, items: [], actionMenu: nil, modePrefix: ">"))
 
         #expect(gui.pickerState.visible == true)
         #expect(gui.pickerState.title == "Find File")
         #expect(gui.pickerState.query == "edi")
         #expect(gui.pickerState.modePrefix == ">")
+        #expect(gui.pickerState.markedCount == 2)
     }
 
     @Test("guiPicker hidden clears pickerState")
     @MainActor func guiPickerHidden() {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.dispatch(.guiPicker(visible: true, selectedIndex: 0, filteredCount: 5,
-                                        totalCount: 100, title: "Find File", query: "edi",
+                                        totalCount: 100, markedCount: 2, title: "Find File", query: "edi",
                                         hasPreview: false, items: [], actionMenu: nil, modePrefix: ">"))
         dispatcher.dispatch(.guiPicker(visible: false, selectedIndex: 0, filteredCount: 0,
-                                        totalCount: 0, title: "", query: "",
+                                        totalCount: 0, markedCount: 0, title: "", query: "",
                                         hasPreview: false, items: [], actionMenu: nil, modePrefix: ""))
 
         #expect(gui.pickerState.visible == false)
         #expect(gui.pickerState.items.isEmpty)
         #expect(gui.pickerState.modePrefix.isEmpty)
+        #expect(gui.pickerState.markedCount == 0)
     }
 
     @Test("guiAgentChat visible updates agentChatState")

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -1707,6 +1707,7 @@ struct GUIPickerDecoderTests {
         appendU16(&header, 100) // totalCount
         header.append(1) // hasPreview
         appendString16(&header, "Find File") // title
+        appendU16(&header, 3) // markedCount
 
         // Section 0x02: Query
         var query = Data()
@@ -1754,7 +1755,7 @@ struct GUIPickerDecoderTests {
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let title, let q, let hasPreview, let decodedItems, let decodedMenu, let modePrefix) = cmd else {
+        guard case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let markedCount, let title, let q, let hasPreview, let decodedItems, let decodedMenu, let modePrefix) = cmd else {
             Issue.record("Expected .guiPicker"); return
         }
 
@@ -1762,6 +1763,7 @@ struct GUIPickerDecoderTests {
         #expect(selectedIndex == 0)
         #expect(filteredCount == 5)
         #expect(totalCount == 100)
+        #expect(markedCount == 3)
         #expect(title == "Find File")
         #expect(q == "edi")
         #expect(modePrefix == ">")
@@ -1784,11 +1786,12 @@ struct GUIPickerDecoderTests {
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == 2)
 
-        guard case .guiPicker(let visible, _, _, _, _, _, _, let items, let actionMenu, let modePrefix) = cmd else {
+        guard case .guiPicker(let visible, _, _, _, let markedCount, _, _, _, let items, let actionMenu, let modePrefix) = cmd else {
             Issue.record("Expected .guiPicker"); return
         }
         #expect(visible == false)
         #expect(modePrefix.isEmpty)
+        #expect(markedCount == 0)
         #expect(items.isEmpty)
         #expect(actionMenu == nil)
     }
@@ -1800,6 +1803,7 @@ struct GUIPickerDecoderTests {
         appendU16(&header, 0); appendU16(&header, 0); appendU16(&header, 0)
         header.append(0) // hasPreview
         appendString16(&header, "")
+        appendU16(&header, 0) // markedCount
 
         var query = Data()
         appendString16(&query, "")
@@ -1825,7 +1829,7 @@ struct GUIPickerDecoderTests {
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiPicker(let visible, _, _, _, _, _, _, _, let am, let modePrefix) = cmd else {
+        guard case .guiPicker(let visible, _, _, _, _, _, _, _, _, let am, let modePrefix) = cmd else {
             Issue.record("Expected .guiPicker"); return
         }
         #expect(visible == true)

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -102,7 +102,7 @@ struct PickerStateLifecycleTests {
         let actionMenu = Wire.PickerActionMenu(selectedIndex: 0, actions: ["Open", "Split"])
 
         state.update(visible: true, selectedIndex: 0, filteredCount: 2,
-                     totalCount: 50, title: "Find File", query: "edi",
+                     totalCount: 50, markedCount: 7, title: "Find File", query: "edi",
                      hasPreview: true, rawItems: raw, actionMenu: actionMenu,
                      modePrefix: ">")
 
@@ -113,6 +113,7 @@ struct PickerStateLifecycleTests {
         #expect(state.hasPreview == true)
         #expect(state.filteredCount == 2)
         #expect(state.totalCount == 50)
+        #expect(state.markedCount == 7)
         #expect(state.items.count == 2)
         #expect(state.items[0].isTwoLine == true)
         #expect(state.items[0].isMarked == false)
@@ -140,7 +141,7 @@ struct PickerStateLifecycleTests {
     @MainActor func hideClearsAll() {
         let state = PickerState()
         state.update(visible: true, selectedIndex: 0, filteredCount: 1,
-                     totalCount: 1, title: "Test", query: "q",
+                     totalCount: 1, markedCount: 1, title: "Test", query: "q",
                      hasPreview: true,
                      rawItems: [Wire.PickerItem(iconColor: 0, flags: 0, label: "x",
                                              description: "", annotation: "",
@@ -155,6 +156,7 @@ struct PickerStateLifecycleTests {
         #expect(state.items.isEmpty)
         #expect(state.previewLines.isEmpty)
         #expect(state.modePrefix == "")
+        #expect(state.markedCount == 0)
         #expect(state.hasPreview == false)
         #expect(state.actionMenu == nil)
     }

--- a/test/minga_editor/frontend/gui_picker_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_picker_protocol_test.exs
@@ -71,26 +71,31 @@ defmodule MingaEditor.Frontend.GUIPickerProtocolTest do
       assert section_ids(prefixed) == [0x01, 0x02, 0x03, 0x04, 0x05]
     end
 
-    test "encodes filtered and total counts in header" do
+    test "encodes filtered, total, and marked counts in header" do
       items = [
         %Item{id: :a, label: "README.md", description: ""},
         %Item{id: :b, label: "config.exs", description: ""},
         %Item{id: :c, label: "mix.exs", description: ""}
       ]
 
-      picker = Picker.new(items, title: "Test")
-      picker = Picker.filter(picker, "config")
+      picker =
+        items
+        |> Picker.new(title: "Test")
+        |> Picker.toggle_mark()
+        |> Picker.filter("config")
 
       binary = ProtocolGUI.encode_gui_picker(picker)
 
       # Sectioned: opcode(1) + section_count(1) + section_0x01 header
       # Section header: id(1) + len(2) + payload
-      # Payload: visible(1) + selected(2) + filtered(2) + total(2) + has_preview(1) + title_len(2) + title
-      <<0x77, 5, 0x01, _slen::16, 1, _selected::16, filtered::16, total::16, _rest::binary>> =
-        binary
+      # Payload: visible(1) + selected(2) + filtered(2) + total(2) + has_preview(1) + title_len(2) + title + marked(2)
+      <<0x77, 5, 0x01, _slen::16, 1, _selected::16, filtered::16, total::16, _has_preview::8,
+        title_len::16, title::binary-size(title_len), marked::16, _rest::binary>> = binary
 
+      assert title == "Test"
       assert filtered == 1
       assert total == 3
+      assert marked == 1
     end
   end
 

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -11,6 +11,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   use ExUnit.Case, async: false
 
   alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
+  alias MingaEditor.UI.Picker
 
   @harness_path Path.join(:code.priv_dir(:minga), "minga-test-harness")
 
@@ -639,7 +640,7 @@ defmodule Minga.Integration.GUIProtocolTest do
 
   describe "gui_picker visible" do
     test "round-trips visible picker with items", %{port: port} do
-      item = %MingaEditor.UI.Picker.Item{
+      marked_item = %MingaEditor.UI.Picker.Item{
         id: "editor.ex",
         label: "editor.ex",
         description: "lib",
@@ -649,15 +650,20 @@ defmodule Minga.Integration.GUIProtocolTest do
         match_positions: [0, 3]
       }
 
-      picker = %MingaEditor.UI.Picker{
-        title: "Find File",
-        query: "edi",
-        selected: 0,
-        max_visible: 50,
-        items: [item],
-        filtered: [item],
-        marked: MapSet.new()
+      other_item = %MingaEditor.UI.Picker.Item{
+        id: "mix.exs",
+        label: "mix.exs",
+        description: "",
+        annotation: "",
+        icon_color: 0x98BE65,
+        two_line: false,
+        match_positions: []
       }
+
+      picker =
+        Picker.new([marked_item, other_item], title: "Find File", max_visible: 50)
+        |> Picker.toggle_mark()
+        |> Picker.filter("edi")
 
       cmd = ProtocolGUI.encode_gui_picker(picker, false, nil, 0, ">")
       Port.command(port, cmd)
@@ -671,7 +677,8 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert decoded["query"] == "edi"
       assert decoded["mode_prefix"] == ">"
       assert decoded["filtered_count"] == 1
-      assert decoded["total_count"] == 1
+      assert decoded["total_count"] == 2
+      assert decoded["marked_count"] == 1
       assert length(decoded["items"]) == 1
 
       item = hd(decoded["items"])

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -684,7 +684,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       item = hd(decoded["items"])
       assert item["label"] == "editor.ex"
       assert item["description"] == "lib"
-      assert item["match_positions"] == [0, 3]
+      assert item["match_positions"] == [0, 1, 2]
     end
   end
 

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -6,8 +6,10 @@ defmodule MingaEditor.PickerUITest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.PickerUI
   alias MingaEditor.PickerUI.RenderInput
+  alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.Picker, as: PickerState
   alias MingaEditor.State.Tab
@@ -25,6 +27,39 @@ defmodule MingaEditor.PickerUITest do
 
   defp theme_picker do
     Theme.get!(:doom_one).picker
+  end
+
+  defp marked_buffer_picker do
+    [
+      %Item{id: 0, label: "alpha"},
+      %Item{id: 1, label: "beta"},
+      %Item{id: 2, label: "gamma"}
+    ]
+    |> Picker.new(title: "Switch buffer", max_visible: 10)
+    |> Picker.move_down()
+    |> Picker.toggle_mark()
+    |> Picker.move_down()
+    |> Picker.toggle_mark()
+  end
+
+  defp picker_state_with_buffers([first_content | rest]) do
+    state = TestHelpers.base_state(content: first_content)
+
+    buffers =
+      Enum.reduce(rest, state.workspace.buffers, fn content, acc ->
+        {:ok, pid} = BufferProcess.start_link(content: content)
+        Buffers.add_background(acc, pid)
+      end)
+
+    picker_state = %PickerState{
+      picker: marked_buffer_picker(),
+      source: MingaEditor.UI.Picker.BufferSource,
+      restore: 0
+    }
+
+    state
+    |> EditorState.set_buffers(buffers)
+    |> ModalOverlay.open(:picker, PickerPayload.new(picker_state))
   end
 
   defp preview_promotion_state do
@@ -396,6 +431,55 @@ defmodule MingaEditor.PickerUITest do
       assert Enum.any?(draws, fn {row, col, text, _face} ->
                row == 9 and col == menu_col and String.starts_with?(text, " Actions")
              end)
+    end
+
+    test "bottom separator shows marked count" do
+      picker =
+        [
+          %Item{id: :one, label: "one.ex"},
+          %Item{id: :two, label: "two.ex"},
+          %Item{id: :three, label: "three.ex"}
+        ]
+        |> Picker.new(title: "Files", max_visible: 10)
+        |> Picker.toggle_mark()
+        |> Picker.move_down()
+        |> Picker.toggle_mark()
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(12, 90)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+
+      assert Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "3/3 (2 marked)")
+             end)
+    end
+  end
+
+  describe "bulk picker actions" do
+    test "C-o shows source bulk actions when items are marked" do
+      state = picker_state_with_buffers(["alpha", "beta", "gamma"])
+
+      new_state = PickerUI.handle_key(state, ?o, MingaEditor.Input.mod_ctrl())
+      {:picker, %{picker_ui: %{action_menu: {actions, 0}}}} = new_state.shell_state.modal
+
+      assert actions == [
+               {"Kill all marked",
+                {:bulk, :kill_marked, Picker.marked_items(marked_buffer_picker())}}
+             ]
+    end
+
+    test "Enter applies source bulk select when items are marked" do
+      state = picker_state_with_buffers(["alpha", "beta", "gamma"])
+
+      new_state = PickerUI.handle_key(state, 13, 0)
+
+      assert new_state.shell_state.modal == :none
+      assert length(new_state.workspace.buffers.list) == 1
+      assert Minga.Buffer.content(new_state.workspace.buffers.active) == "alpha"
     end
   end
 

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -108,6 +108,55 @@ defmodule MingaEditor.PickerUITest do
     {state, original_buf, preview_buf}
   end
 
+  defmodule NoBulkActionsSource do
+    @behaviour MingaEditor.UI.Picker.Source
+
+    alias MingaEditor.UI.Picker.Item
+
+    @impl true
+    def title, do: "No bulk actions"
+
+    @impl true
+    def candidates(_ctx), do: []
+
+    @impl true
+    def on_select(%Item{id: id}, state), do: Map.put(state, :selected_item_id, id)
+
+    @impl true
+    def on_cancel(state), do: state
+
+    @impl true
+    def actions(_item), do: [{"Open", :open}, {"Delete", :delete}]
+
+    @impl true
+    def on_action(:open, %Item{id: id}, state), do: Map.put(state, :action_item_id, id)
+
+    def on_action(:delete, %Item{id: id}, state),
+      do: Map.put(state, :action_item_id, {:delete, id})
+
+    def on_action(_action, _item, state), do: state
+  end
+
+  defp picker_state_for_source(state, source, items) do
+    picker = items |> Picker.new(title: "Test", max_visible: 10) |> mark_all_picker()
+
+    picker_state = %PickerState{
+      picker: picker,
+      source: source,
+      restore: state.workspace.buffers.active_index
+    }
+
+    ModalOverlay.open(state, :picker, PickerPayload.new(picker_state))
+  end
+
+  defp mark_all_picker(%Picker{items: []} = picker), do: picker
+
+  defp mark_all_picker(%Picker{} = picker) do
+    Enum.reduce(1..length(picker.items), picker, fn _, acc ->
+      Picker.toggle_mark(acc) |> Picker.move_down()
+    end)
+  end
+
   describe "render/1 with RenderInput" do
     test "returns empty draws when picker is nil" do
       input = %RenderInput{
@@ -506,6 +555,45 @@ defmodule MingaEditor.PickerUITest do
       assert picker_ui.picker.query == "d"
       assert result.shell_state.status_msg == nil
       assert result.workspace.editing.mode == :normal
+    end
+  end
+
+  describe "bulk action fallback for sources without bulk support" do
+    test "Enter still performs normal single select when marks exist" do
+      state = TestHelpers.base_state(content: "initial")
+
+      picker_state =
+        picker_state_for_source(state, NoBulkActionsSource, [
+          %Item{id: :first, label: "first"},
+          %Item{id: :second, label: "second"}
+        ])
+
+      new_state = PickerUI.handle_key(picker_state, 13, 0)
+
+      assert new_state.shell_state.modal == :none
+      assert Map.get(new_state, :selected_item_id) == :first
+      refute Map.has_key?(new_state, :bulk_selected)
+    end
+
+    test "C-o falls back to normal per-item actions and Enter dispatches on_action" do
+      state = TestHelpers.base_state(content: "initial")
+
+      picker_state =
+        picker_state_for_source(state, NoBulkActionsSource, [
+          %Item{id: :first, label: "first"},
+          %Item{id: :second, label: "second"}
+        ])
+
+      menu_state = PickerUI.handle_key(picker_state, ?o, MingaEditor.Input.mod_ctrl())
+
+      assert {:picker, %{picker_ui: %{action_menu: {actions, 0}}}} = menu_state.shell_state.modal
+      assert Enum.map(actions, &elem(&1, 0)) == ["Open", "Delete"]
+
+      new_state = PickerUI.handle_key(menu_state, 13, 0)
+
+      assert new_state.shell_state.modal == :none
+      assert Map.get(new_state, :action_item_id) == :first
+      refute Map.has_key?(new_state, :bulk_selected)
     end
   end
 

--- a/test/minga_editor/ui/picker/buffer_source_test.exs
+++ b/test/minga_editor/ui/picker/buffer_source_test.exs
@@ -135,6 +135,22 @@ defmodule MingaEditor.UI.Picker.BufferSourceTest do
 
       assert Buffer.content(selected.workspace.buffers.active) == "beta"
     end
+
+    test "bulk select kills all marked buffers" do
+      state = state_with_buffers(["alpha", "beta", "gamma"])
+      items = [%Item{id: 1, label: "beta"}, %Item{id: 2, label: "gamma"}]
+
+      selected = BufferSource.on_bulk_select(items, state)
+
+      assert length(selected.workspace.buffers.list) == 1
+      assert Buffer.content(selected.workspace.buffers.active) == "alpha"
+    end
+
+    test "bulk actions expose kill all marked" do
+      assert BufferSource.bulk_actions([%Item{id: 1, label: "beta"}]) == [
+               {"Kill all marked", :kill_marked}
+             ]
+    end
   end
 
   describe "build_candidates/2 with include_special: true (SPC b B)" do

--- a/test/minga_editor/ui/picker/buffer_source_test.exs
+++ b/test/minga_editor/ui/picker/buffer_source_test.exs
@@ -136,14 +136,32 @@ defmodule MingaEditor.UI.Picker.BufferSourceTest do
       assert Buffer.content(selected.workspace.buffers.active) == "beta"
     end
 
-    test "bulk select kills all marked buffers" do
+    test "bulk select creates a fallback buffer when all open buffers are killed" do
       state = state_with_buffers(["alpha", "beta", "gamma"])
-      items = [%Item{id: 1, label: "beta"}, %Item{id: 2, label: "gamma"}]
+
+      items = [
+        %Item{id: 0, label: "alpha"},
+        %Item{id: 1, label: "beta"},
+        %Item{id: 2, label: "gamma"}
+      ]
 
       selected = BufferSource.on_bulk_select(items, state)
 
+      fallback_pid = selected.workspace.buffers.active
+
+      on_exit(fn ->
+        try do
+          GenServer.stop(fallback_pid)
+        catch
+          :exit, _ -> :ok
+        end
+      end)
+
       assert length(selected.workspace.buffers.list) == 1
-      assert Buffer.content(selected.workspace.buffers.active) == "alpha"
+      assert fallback_pid != nil
+      assert EditorState.active_window_struct(selected).buffer == fallback_pid
+      assert Buffer.buffer_name(fallback_pid) == "[new 1]"
+      assert Buffer.content(fallback_pid) == ""
     end
 
     test "bulk actions expose kill all marked" do

--- a/test/minga_editor/ui/picker/file_source_test.exs
+++ b/test/minga_editor/ui/picker/file_source_test.exs
@@ -42,6 +42,41 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
     assert Minga.Project.frecency_scores()["lib/hot.ex"] > 0
   end
 
+  test "on_bulk_select opens all marked project-relative files", %{tmp_dir: tmp_dir} do
+    project = Path.join(tmp_dir, "frecency_bulk_project_#{:erlang.unique_integer([:positive])}")
+    lib = Path.join(project, "lib")
+    File.mkdir_p!(lib)
+    File.write!(Path.join(project, "mix.exs"), "")
+    File.write!(Path.join(project, "initial.ex"), "initial")
+    File.write!(Path.join(lib, "one.ex"), "one")
+    File.write!(Path.join(lib, "two.ex"), "two")
+
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(project)
+    await_project_rebuild(project)
+
+    ctx =
+      start_editor("initial", file_path: Path.join(project, "initial.ex"), project_root: project)
+
+    state =
+      FileSource.on_bulk_select(
+        [%Item{id: "lib/one.ex", label: "one.ex"}, %Item{id: "lib/two.ex", label: "two.ex"}],
+        editor_state(ctx)
+      )
+
+    paths = Enum.map(state.workspace.buffers.list, &Minga.Buffer.file_path/1)
+
+    assert Path.join(lib, "one.ex") in paths
+    assert Path.join(lib, "two.ex") in paths
+    assert Minga.Buffer.file_path(state.workspace.buffers.active) == Path.join(lib, "two.ex")
+  end
+
+  test "bulk actions expose open all marked" do
+    assert FileSource.bulk_actions([%Item{id: "lib/one.ex", label: "one.ex"}]) == [
+             {"Open all marked", :open_marked}
+           ]
+  end
+
   test "preview selections do not record frecency until confirmed", %{tmp_dir: tmp_dir} do
     project =
       Path.join(tmp_dir, "frecency_preview_project_#{:erlang.unique_integer([:positive])}")

--- a/test/minga_editor/ui/picker/file_source_test.exs
+++ b/test/minga_editor/ui/picker/file_source_test.exs
@@ -4,6 +4,11 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
   # Uses the global Minga.Project singleton to drive FileSource.project_root/0.
   use Minga.Test.EditorCase, async: false
 
+  alias MingaEditor.PickerUI
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.State.Picker, as: PickerState
+  alias MingaEditor.UI.Picker
   alias MingaEditor.UI.Picker.FileSource
   alias MingaEditor.UI.Picker.Item
 
@@ -35,8 +40,14 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
     ctx =
       start_editor("initial", file_path: Path.join(project, "initial.ex"), project_root: project)
 
-    state = FileSource.on_select(%Item{id: "lib/hot.ex", label: "hot.ex"}, editor_state(ctx))
+    state = editor_state(ctx)
+    initial_pids = state.workspace.buffers.list
+
+    state = FileSource.on_select(%Item{id: "lib/hot.ex", label: "hot.ex"}, state)
     flush_project()
+    new_pids = Enum.reject(state.workspace.buffers.list, &Enum.member?(initial_pids, &1))
+
+    on_exit(fn -> stop_pids(new_pids) end)
 
     assert Minga.Buffer.file_path(state.workspace.buffers.active) == Path.join(lib, "hot.ex")
     assert Minga.Project.frecency_scores()["lib/hot.ex"] > 0
@@ -58,17 +69,111 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
     ctx =
       start_editor("initial", file_path: Path.join(project, "initial.ex"), project_root: project)
 
+    state = editor_state(ctx)
+    initial_pids = state.workspace.buffers.list
+
     state =
       FileSource.on_bulk_select(
         [%Item{id: "lib/one.ex", label: "one.ex"}, %Item{id: "lib/two.ex", label: "two.ex"}],
-        editor_state(ctx)
+        state
       )
 
     paths = Enum.map(state.workspace.buffers.list, &Minga.Buffer.file_path/1)
+    new_pids = Enum.reject(state.workspace.buffers.list, &Enum.member?(initial_pids, &1))
+
+    on_exit(fn -> stop_pids(new_pids) end)
 
     assert Path.join(lib, "one.ex") in paths
     assert Path.join(lib, "two.ex") in paths
     assert Minga.Buffer.file_path(state.workspace.buffers.active) == Path.join(lib, "two.ex")
+  end
+
+  test "PickerUI Enter opens marked files through the UI path", %{tmp_dir: tmp_dir} do
+    project =
+      Path.join(tmp_dir, "frecency_ui_select_project_#{:erlang.unique_integer([:positive])}")
+
+    lib = Path.join(project, "lib")
+    File.mkdir_p!(lib)
+    File.write!(Path.join(project, "mix.exs"), "")
+    File.write!(Path.join(project, "initial.ex"), "initial")
+    File.write!(Path.join(lib, "one.ex"), "one")
+    File.write!(Path.join(lib, "two.ex"), "two")
+
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(project)
+    await_project_rebuild(project)
+
+    ctx =
+      start_editor("initial", file_path: Path.join(project, "initial.ex"), project_root: project)
+
+    state = editor_state(ctx)
+    initial_pids = state.workspace.buffers.list
+
+    picker_state =
+      build_file_picker_state(state, [
+        %Item{id: "lib/one.ex", label: "one.ex"},
+        %Item{id: "lib/two.ex", label: "two.ex"}
+      ])
+
+    new_state = PickerUI.handle_key(picker_state, 13, 0)
+    flush_project()
+    paths = Enum.map(new_state.workspace.buffers.list, &Minga.Buffer.file_path/1)
+    new_pids = Enum.reject(new_state.workspace.buffers.list, &Enum.member?(initial_pids, &1))
+
+    on_exit(fn -> stop_pids(new_pids) end)
+
+    assert new_state.shell_state.modal == :none
+    assert Path.join(lib, "one.ex") in paths
+    assert Path.join(lib, "two.ex") in paths
+    assert Minga.Buffer.file_path(new_state.workspace.buffers.active) == Path.join(lib, "two.ex")
+  end
+
+  test "PickerUI bulk action menu dispatches on_bulk_action for marked files", %{tmp_dir: tmp_dir} do
+    project =
+      Path.join(tmp_dir, "frecency_ui_bulk_project_#{:erlang.unique_integer([:positive])}")
+
+    lib = Path.join(project, "lib")
+    File.mkdir_p!(lib)
+    File.write!(Path.join(project, "mix.exs"), "")
+    File.write!(Path.join(project, "initial.ex"), "initial")
+    File.write!(Path.join(lib, "one.ex"), "one")
+    File.write!(Path.join(lib, "two.ex"), "two")
+
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(project)
+    await_project_rebuild(project)
+
+    ctx =
+      start_editor("initial", file_path: Path.join(project, "initial.ex"), project_root: project)
+
+    state = editor_state(ctx)
+    initial_pids = state.workspace.buffers.list
+
+    picker_state =
+      build_file_picker_state(state, [
+        %Item{id: "lib/one.ex", label: "one.ex"},
+        %Item{id: "lib/two.ex", label: "two.ex"}
+      ])
+
+    menu_state = PickerUI.handle_key(picker_state, ?o, MingaEditor.Input.mod_ctrl())
+
+    assert {:picker,
+            %{picker_ui: %{action_menu: {[{"Open all marked", {:bulk, :open_marked, items}}], 0}}}} =
+             menu_state.shell_state.modal
+
+    assert Enum.map(items, & &1.id) == ["lib/one.ex", "lib/two.ex"]
+
+    new_state = PickerUI.handle_key(menu_state, 13, 0)
+    flush_project()
+    paths = Enum.map(new_state.workspace.buffers.list, &Minga.Buffer.file_path/1)
+    new_pids = Enum.reject(new_state.workspace.buffers.list, &Enum.member?(initial_pids, &1))
+
+    on_exit(fn -> stop_pids(new_pids) end)
+
+    assert new_state.shell_state.modal == :none
+    assert Path.join(lib, "one.ex") in paths
+    assert Path.join(lib, "two.ex") in paths
+    assert Minga.Buffer.file_path(new_state.workspace.buffers.active) == Path.join(lib, "two.ex")
   end
 
   test "bulk actions expose open all marked" do
@@ -95,9 +200,13 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
       start_editor("initial", file_path: Path.join(project, "initial.ex"), project_root: project)
 
     state = editor_state(ctx) |> MingaEditor.State.set_buffer_add_context(:preview)
+    initial_pids = state.workspace.buffers.list
 
-    _state = FileSource.on_select(%Item{id: "lib/previewed.ex", label: "previewed.ex"}, state)
+    new_state = FileSource.on_select(%Item{id: "lib/previewed.ex", label: "previewed.ex"}, state)
     flush_project()
+    new_pids = Enum.reject(new_state.workspace.buffers.list, &Enum.member?(initial_pids, &1))
+
+    on_exit(fn -> stop_pids(new_pids) end)
 
     refute Map.has_key?(Minga.Project.frecency_scores(), "lib/previewed.ex")
   end
@@ -130,6 +239,36 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
     assert is_integer(hot_index)
     assert is_integer(cold_index)
     assert hot_index < cold_index
+  end
+
+  defp build_file_picker_state(state, items) do
+    picker = items |> Picker.new(title: "Find file", max_visible: 10) |> mark_all_picker()
+
+    picker_state = %PickerState{
+      picker: picker,
+      source: FileSource,
+      restore: state.workspace.buffers.active_index
+    }
+
+    ModalOverlay.open(state, :picker, PickerPayload.new(picker_state))
+  end
+
+  defp mark_all_picker(%Picker{items: []} = picker), do: picker
+
+  defp mark_all_picker(%Picker{} = picker) do
+    Enum.reduce(1..length(picker.items), picker, fn _, acc ->
+      Picker.toggle_mark(acc) |> Picker.move_down()
+    end)
+  end
+
+  defp stop_pids(pids) do
+    Enum.each(pids, fn pid ->
+      try do
+        GenServer.stop(pid)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
   end
 
   defp reset_global_project! do

--- a/test/minga_editor/ui/picker/overhaul_test.exs
+++ b/test/minga_editor/ui/picker/overhaul_test.exs
@@ -67,6 +67,25 @@ defmodule MingaEditor.UI.Picker.OverhaulTest do
       assert :c in ids
     end
 
+    test "marked_items keeps marked items that are hidden by the current filter" do
+      picker =
+        Picker.new(@items, title: "Test")
+        |> Picker.toggle_mark()
+        |> Picker.filter("mix")
+
+      assert Enum.map(Picker.marked_items(picker), & &1.id) == [:a]
+    end
+
+    test "has_marks? and marked_count track explicit marks" do
+      picker = Picker.new(@items, title: "Test")
+      refute Picker.has_marks?(picker)
+      assert Picker.marked_count(picker) == 0
+
+      marked = Picker.toggle_mark(picker)
+      assert Picker.has_marks?(marked)
+      assert Picker.marked_count(marked) == 1
+    end
+
     test "marked_items returns selected item when nothing is marked" do
       picker = Picker.new(@items, title: "Test")
       items = Picker.marked_items(picker)

--- a/test/minga_editor/ui/picker/source_test.exs
+++ b/test/minga_editor/ui/picker/source_test.exs
@@ -103,6 +103,32 @@ defmodule MingaEditor.UI.Picker.SourceTest do
     def on_action(_action, _item, state), do: state
   end
 
+  defmodule WithBulkSource do
+    @behaviour MingaEditor.UI.Picker.Source
+
+    @impl true
+    def title, do: "With bulk"
+
+    @impl true
+    def candidates(_ctx), do: [{:a, "item", "desc"}]
+
+    @impl true
+    def on_select(_item, state), do: state
+
+    @impl true
+    def on_cancel(state), do: state
+
+    @impl true
+    def on_bulk_select(items, state), do: Map.put(state, :bulk_selected, items)
+
+    @impl true
+    def bulk_actions(_items), do: [{"Apply all", :apply_all}]
+
+    @impl true
+    def on_bulk_action(:apply_all, items, state), do: Map.put(state, :bulk_action_items, items)
+    def on_bulk_action(_action, _items, state), do: state
+  end
+
   describe "has_actions?/1" do
     test "returns false for source without actions callback" do
       refute Source.has_actions?(NoActionsSource)
@@ -121,6 +147,38 @@ defmodule MingaEditor.UI.Picker.SourceTest do
     test "returns actions list for source with actions callback" do
       actions = Source.actions(WithActionsSource, {:a, "item", "desc"})
       assert actions == [{"Open", :open}, {"Delete", :delete}]
+    end
+  end
+
+  describe "bulk select helpers" do
+    test "bulk_select returns unchanged state for source without bulk callback" do
+      assert Source.bulk_select(NoActionsSource, [:a], %{untouched: true}) == %{untouched: true}
+    end
+
+    test "bulk_select delegates to source with bulk callback" do
+      assert Source.bulk_select(WithBulkSource, [:a, :b], %{}) == %{bulk_selected: [:a, :b]}
+    end
+  end
+
+  describe "bulk action helpers" do
+    test "bulk_actions returns empty list for source without bulk callbacks" do
+      assert Source.bulk_actions(NoActionsSource, [:a]) == []
+    end
+
+    test "bulk_actions delegates to source with bulk callbacks" do
+      assert Source.bulk_actions(WithBulkSource, [:a]) == [{"Apply all", :apply_all}]
+    end
+
+    test "on_bulk_action returns unchanged state for source without bulk callbacks" do
+      assert Source.on_bulk_action(NoActionsSource, :apply_all, [:a], %{untouched: true}) == %{
+               untouched: true
+             }
+    end
+
+    test "on_bulk_action delegates to source with bulk callbacks" do
+      assert Source.on_bulk_action(WithBulkSource, :apply_all, [:a, :b], %{}) == %{
+               bulk_action_items: [:a, :b]
+             }
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds bulk actions for marked picker items.
- Keeps marked-item behavior wired through picker/protocol paths covered by targeted tests.

Closes #1729

## Validation
- Focused picker/protocol tests passed in prior session.
- `mix test.llm` passed in prior session.
- `make lint` passed in prior session.
- Final reviewer passed after targeted re-review.
- `mix swift.build` was skipped locally because `xcodebuild` is unavailable.
