### PR TITLE
Agent tool approval trust levels

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -190,18 +190,21 @@ Each segment has a priority. When the window is too narrow, Minga drops the lowe
 When the AI agent wants to run a destructive tool (writing a file, editing a file, or running a shell command), Minga pauses and shows a confirmation prompt:
 
 ```
-⚠ Execute shell: mix test?  [y]es  [n]o  [a]ll
+⚠ Execute shell: mix test?  [y]es  [a]ll for session  [t]his turn  [n]o
 ```
 
-- **y** or **Enter** approves the tool and lets it run.
+- **y** or **Enter** approves the tool once.
+- **a** trusts this tool for the rest of the session.
+- **t** trusts this tool for the current turn.
 - **n** rejects the tool. The agent gets "Tool rejected by user" as the result and continues its turn.
-- **a** approves this tool and all remaining tools in the current turn without further prompts.
 
-The approval mode resets at the start of each new agent turn.
+The approval mode resets at the start of each new agent turn. Session trust stays active until you revoke it or end the session. Turn trust clears when the current turn finishes.
+
+Use `/trust list` to inspect trusted tools, `/trust revoke <tool>` to remove one, and `/trust clear` to remove all trusted tools.
 
 ### Controlling when approval is required
 
-The `:agent_tool_approval` option controls the gate:
+The `:agent_tool_approval` option controls the gate. Set it to `:destructive` to prompt only for destructive tools, `:all` to prompt for every tool call, or `:none` to auto-approve everything:
 
 ```elixir
 # Default: prompt only for destructive tools

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -391,13 +391,15 @@ Typed payloads:
   0x01 (user):      type(1) + text_len(4) + text
   0x02 (assistant): type(1) + text_len(4) + text
   0x03 (thinking):  type(1) + collapsed(1) + text_len(4) + text
-  0x04 (tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + result_len(4) + result
+  0x04 (tool_call): type(1) + status(1) + error(1) + collapsed(1) + auto_approved(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + result_len(4) + result
   0x05 (system):    type(1) + level(1) + text_len(4) + text
   0x06 (usage):     type(1) + input(4) + output(4) + cache_read(4) + cache_write(4) + cost_micros(4)
   0x07 (styled_assistant): type(1) + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url. Link URLs are limited to http, https, and mailto.
-  0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url. Link URLs are limited to http, https, and mailto.
+  0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + auto_approved(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url. Link URLs are limited to http, https, and mailto.
   0x09 (approval_tool_call): type(1) + status(1) + name_len(2) + name + summary_len(2) + summary + tool_call_id_len(2) + tool_call_id + preview_kind(1) + preview_line_count(2), per line: line_len(2) + line
 ```
+
+`auto_approved`: 0=not auto-approved, 1=session trust, 2=turn trust.
 
 Styled run flags: 0x01=bold, 0x02=italic, 0x04=underline, 0x08=link URL present.
 

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -368,7 +368,7 @@ Each section uses `section_id(1) + section_len(2) + payload(section_len)`. Secti
 | 0x03 | Prompt | `prompt_len(2) + prompt + line_count(1) + cursor_line(2) + cursor_col(2) + vim_mode(1) + visible_rows(1)` |
 | 0x04 | Pending | legacy pending approval banner payload. Current BEAM frames send `0` and render approvals inline as message type `0x09`. |
 | 0x05 | Help | `visible(1) + optional groups` |
-| 0x06 | Messages | `message_count(2) + messages...` |
+| 0x06 | Messages | `0xFF + version(1) + message_count(2) + framed messages...` |
 | 0x07 | Completion | prompt completion popup state |
 | 0x08 | Thinking | `level_len(2) + level`, where level is `off`, `low`, `medium`, or `high` |
 
@@ -382,24 +382,27 @@ Pending approval payload:
 
 Messages payload:
 ```
-message_count(2) + messages...
+0xFF(1) + version(1) + message_count(2) + framed messages...
 
-Per message:
+version 1 framed message:
+  message_len(4) + message(message_len)
+
+message:
   message_id(4) + typed_payload
 
 Typed payloads:
   0x01 (user):      type(1) + text_len(4) + text
   0x02 (assistant): type(1) + text_len(4) + text
   0x03 (thinking):  type(1) + collapsed(1) + text_len(4) + text
-  0x04 (tool_call): type(1) + status(1) + error(1) + collapsed(1) + auto_approved(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + result_len(4) + result
+  0x04 (tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + result_len(4) + result + auto_approved(1)
   0x05 (system):    type(1) + level(1) + text_len(4) + text
   0x06 (usage):     type(1) + input(4) + output(4) + cache_read(4) + cache_write(4) + cost_micros(4)
   0x07 (styled_assistant): type(1) + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url. Link URLs are limited to http, https, and mailto.
-  0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + auto_approved(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url. Link URLs are limited to http, https, and mailto.
+  0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url, auto_approved(1). The summary uses a UTF-8-safe preview budget so the styled payload and trailing auto_approved byte still fit. Link URLs are limited to http, https, and mailto.
   0x09 (approval_tool_call): type(1) + status(1) + name_len(2) + name + summary_len(2) + summary + tool_call_id_len(2) + tool_call_id + preview_kind(1) + preview_line_count(2), per line: line_len(2) + line
 ```
 
-`auto_approved`: 0=not auto-approved, 1=session trust, 2=turn trust.
+`auto_approved`: 0=not auto-approved, 1=session trust, 2=turn trust. The frame length makes appended fields deterministic and lets decoders distinguish current payloads from legacy unframed messages.
 
 Styled run flags: 0x01=bold, 0x02=italic, 0x04=underline, 0x08=link URL present.
 

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1370,6 +1370,7 @@ defmodule MingaAgent.Providers.Native do
             session_pid,
             tool_call,
             available_tools,
+            mode,
             config,
             hook_runner
           )
@@ -1423,7 +1424,15 @@ defmodule MingaAgent.Providers.Native do
          config,
          hook_runner
        ) do
-    request_approval(provider_pid, session_pid, tool_call, available_tools, config, hook_runner)
+    request_approval(
+      provider_pid,
+      session_pid,
+      tool_call,
+      available_tools,
+      :ask_all,
+      config,
+      hook_runner
+    )
   end
 
   defp execute_with_global_mode(
@@ -1436,7 +1445,15 @@ defmodule MingaAgent.Providers.Native do
          hook_runner
        ) do
     if Tools.destructive?(tool_call.name, tool_call.arguments || %{}) do
-      request_approval(provider_pid, session_pid, tool_call, available_tools, config, hook_runner)
+      request_approval(
+        provider_pid,
+        session_pid,
+        tool_call,
+        available_tools,
+        :ask,
+        config,
+        hook_runner
+      )
     else
       {result, is_error} =
         run_single_tool(
@@ -1487,15 +1504,17 @@ defmodule MingaAgent.Providers.Native do
           pid() | nil,
           map(),
           [ReqLLM.Tool.t()],
+          approval_mode(),
           AgentConfig.t(),
           hook_runner()
         ) ::
-          {String.t(), boolean(), :ask}
+          {String.t(), boolean(), approval_mode()}
   defp request_approval(
          provider_pid,
          session_pid,
          tool_call,
          available_tools,
+         mode,
          config,
          hook_runner
        ) do
@@ -1524,13 +1543,13 @@ defmodule MingaAgent.Providers.Native do
             hook_runner
           )
 
-        {result, is_error, :ask}
+        {result, is_error, mode}
 
       {:tool_approval_response, _tool_call_id, :reject} ->
-        {"Tool rejected by user", true, :ask}
+        {"Tool rejected by user", true, mode}
     after
       config.approval_timeout_ms ->
-        {"Tool approval timed out", true, :ask}
+        {"Tool approval timed out", true, mode}
     end
   end
 

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1318,7 +1318,7 @@ defmodule MingaAgent.Providers.Native do
     final_ctx
   end
 
-  @typep approval_mode :: :none | :ask | :ask_all | :approve_all
+  @typep approval_mode :: :none | :ask | :ask_all
 
   @spec execute_with_approval(
           pid(),
@@ -1419,21 +1419,6 @@ defmodule MingaAgent.Providers.Native do
          session_pid,
          tool_call,
          available_tools,
-         :approve_all,
-         config,
-         hook_runner
-       ) do
-    {result, is_error} =
-      run_single_tool(tool_call, available_tools, provider_pid, session_pid, config, hook_runner)
-
-    {result, is_error, :approve_all}
-  end
-
-  defp execute_with_global_mode(
-         provider_pid,
-         session_pid,
-         tool_call,
-         available_tools,
          :ask_all,
          config,
          hook_runner
@@ -1505,7 +1490,7 @@ defmodule MingaAgent.Providers.Native do
           AgentConfig.t(),
           hook_runner()
         ) ::
-          {String.t(), boolean(), :ask | :approve_all}
+          {String.t(), boolean(), :ask}
   defp request_approval(
          provider_pid,
          session_pid,
@@ -1540,19 +1525,6 @@ defmodule MingaAgent.Providers.Native do
           )
 
         {result, is_error, :ask}
-
-      {:tool_approval_response, _tool_call_id, :approve_all} ->
-        {result, is_error} =
-          run_single_tool(
-            tool_call,
-            available_tools,
-            provider_pid,
-            session_pid,
-            config,
-            hook_runner
-          )
-
-        {result, is_error, :approve_all}
 
       {:tool_approval_response, _tool_call_id, :reject} ->
         {"Tool rejected by user", true, :ask}

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1325,7 +1325,12 @@ defmodule MingaAgent.Session do
         end
       end)
 
-    state = %{state | messages: messages}
+    state = %{
+      state
+      | messages: messages,
+        pending_auto_approvals: Map.delete(state.pending_auto_approvals, event.tool_call_id)
+    }
+
     state = track_active_tool_end(state, event.tool_call_id)
     status = if event.is_error, do: :error, else: :done
     broadcast(state, {:tool_ended, event.name, event.result, status})

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -49,6 +49,9 @@ defmodule MingaAgent.Session do
   @typedoc "Pending tool approval data."
   @type pending_approval :: MingaAgent.ToolApproval.t()
 
+  @typedoc "Tool trust lifetime."
+  @type trust_scope :: :session | :turn
+
   @typedoc "File touch record."
   @type file_touch :: %{
           path: String.t(),
@@ -79,6 +82,8 @@ defmodule MingaAgent.Session do
           pending_approval: pending_approval() | nil,
           active_tool_calls: [active_tool_call()],
           active_tool_name: String.t() | nil,
+          trust_levels: %{String.t() => trust_scope()},
+          pending_auto_approvals: %{String.t() => trust_scope()},
           model_name: String.t(),
           provider_name: String.t(),
           notifier: module() | {module(), term()},
@@ -201,10 +206,33 @@ defmodule MingaAgent.Session do
   on `receive`, then clears the pending approval and broadcasts
   the resolution to subscribers.
   """
-  @spec respond_to_approval(GenServer.server(), :approve | :reject | :approve_all) ::
+  @type approval_decision :: :approve | :approve_session | :approve_turn | :reject
+
+  @spec respond_to_approval(GenServer.server(), approval_decision()) ::
           :ok | {:error, :no_pending_approval}
-  def respond_to_approval(session, decision) when decision in [:approve, :reject, :approve_all] do
+  def respond_to_approval(session, decision)
+      when decision in [:approve, :approve_session, :approve_turn, :reject] do
     GenServer.call(session, {:respond_to_approval, decision})
+  end
+
+  @doc "Trusts a tool for the session or current turn."
+  @spec set_tool_trust(GenServer.server(), String.t(), trust_scope()) :: :ok
+  def set_tool_trust(session, name, scope)
+      when is_binary(name) and scope in [:session, :turn] do
+    GenServer.call(session, {:set_tool_trust, name, scope})
+  end
+
+  @doc "Revokes trust for one tool, or all tools with `:all`."
+  @spec revoke_tool_trust(GenServer.server(), String.t() | :all) :: :ok
+  def revoke_tool_trust(session, name_or_all)
+      when is_binary(name_or_all) or name_or_all == :all do
+    GenServer.call(session, {:revoke_tool_trust, name_or_all})
+  end
+
+  @doc "Lists trusted tools and their trust scope."
+  @spec list_tool_trust(GenServer.server()) :: %{String.t() => trust_scope()}
+  def list_tool_trust(session) do
+    GenServer.call(session, :list_tool_trust)
   end
 
   @doc "Returns the session ID."
@@ -532,6 +560,8 @@ defmodule MingaAgent.Session do
       pending_approval: nil,
       active_tool_calls: [],
       active_tool_name: nil,
+      trust_levels: %{},
+      pending_auto_approvals: %{},
       model_name: model_name,
       provider_name: provider_name,
       notifier: Keyword.get(opts, :notifier, Notifier),
@@ -750,7 +780,9 @@ defmodule MingaAgent.Session do
         steering_queue: [],
         follow_up_queue: [],
         touched_files: %{},
-        boundaries: %{}
+        boundaries: %{},
+        trust_levels: %{},
+        pending_auto_approvals: %{}
     }
 
     state = reset_messages(state, [Message.system("Session cleared · #{timestamp}")])
@@ -860,15 +892,32 @@ defmodule MingaAgent.Session do
 
   def handle_call({:respond_to_approval, decision}, _from, state) do
     %{tool_call_id: tool_call_id, reply_to: reply_to} = approval = state.pending_approval
+    state = maybe_set_trust_for_decision(state, approval.name, decision)
 
-    # Send the decision directly to the blocked Task process
-    send(reply_to, {:tool_approval_response, tool_call_id, decision})
+    # Send the execution decision directly to the blocked Task process.
+    send(reply_to, {:tool_approval_response, tool_call_id, execution_decision(decision)})
 
     state = maybe_record_rejection(state, approval, decision)
     state = %{state | pending_approval: nil}
     state = notify_messages_changed(state)
     broadcast(state, {:approval_resolved, decision})
     {:reply, :ok, state}
+  end
+
+  def handle_call({:set_tool_trust, name, scope}, _from, state) do
+    {:reply, :ok, put_tool_trust(state, name, scope)}
+  end
+
+  def handle_call({:revoke_tool_trust, :all}, _from, state) do
+    {:reply, :ok, %{state | trust_levels: %{}}}
+  end
+
+  def handle_call({:revoke_tool_trust, name}, _from, state) do
+    {:reply, :ok, %{state | trust_levels: Map.delete(state.trust_levels, name)}}
+  end
+
+  def handle_call(:list_tool_trust, _from, state) do
+    {:reply, state.trust_levels, state}
   end
 
   def handle_call({:subscribe, pid}, _from, state) do
@@ -1153,6 +1202,7 @@ defmodule MingaAgent.Session do
       end
 
     dispatch_stop(state)
+    state = clear_turn_trust(state)
 
     # Collect pending messages from both queues. Steering messages that arrived
     # after the last tool call (or just before AgentEnd) would otherwise be
@@ -1217,7 +1267,15 @@ defmodule MingaAgent.Session do
   end
 
   defp handle_provider_event(%Event.ToolStart{} = event, state) do
-    msg = Message.tool_call(event.tool_call_id, event.name, event.args)
+    {scope, pending_auto_approvals} = Map.pop(state.pending_auto_approvals, event.tool_call_id)
+
+    msg =
+      event.tool_call_id
+      |> ToolCall.new(event.name, event.args)
+      |> ToolCall.set_auto_approved_scope(scope)
+      |> then(&{:tool_call, &1})
+
+    state = %{state | pending_auto_approvals: pending_auto_approvals}
     state = append_msg(state, msg)
     state = track_active_tool_start(state, event.tool_call_id, event.name)
     state = set_working_status(state, :tool_executing)
@@ -1237,19 +1295,13 @@ defmodule MingaAgent.Session do
   end
 
   defp handle_provider_event(%Event.ToolApproval{} = event, state) do
-    notify(state, :approval, "Approval needed: #{event.name}")
+    case Map.get(state.trust_levels, event.name) do
+      nil ->
+        request_tool_approval(event, state)
 
-    approval =
-      MingaAgent.ToolApproval.new(
-        tool_call_id: event.tool_call_id,
-        name: event.name,
-        args: event.args,
-        reply_to: event.reply_to
-      )
-
-    state = %{state | pending_approval: approval}
-    broadcast(state, {:approval_pending, MingaAgent.ToolApproval.public(approval)})
-    state
+      scope ->
+        auto_approve_tool(event, state, scope)
+    end
   end
 
   defp handle_provider_event(%Event.ToolUpdate{} = event, state) do
@@ -1297,6 +1349,39 @@ defmodule MingaAgent.Session do
     state = append_system_message(state, "Error: #{message}", :error)
     broadcast(state, {:error, message})
     state
+  end
+
+  @spec request_tool_approval(Event.ToolApproval.t(), state()) :: state()
+  defp request_tool_approval(event, state) do
+    notify(state, :approval, "Approval needed: #{event.name}")
+
+    approval =
+      MingaAgent.ToolApproval.new(
+        tool_call_id: event.tool_call_id,
+        name: event.name,
+        args: event.args,
+        reply_to: event.reply_to
+      )
+
+    state = %{state | pending_approval: approval}
+    broadcast(state, {:approval_pending, MingaAgent.ToolApproval.public(approval)})
+    state
+  end
+
+  @spec auto_approve_tool(Event.ToolApproval.t(), state(), trust_scope()) :: state()
+  defp auto_approve_tool(event, state, scope) do
+    send(event.reply_to, {:tool_approval_response, event.tool_call_id, :approve})
+
+    pending_auto_approvals = Map.put(state.pending_auto_approvals, event.tool_call_id, scope)
+
+    messages =
+      update_tool_call(state.messages, event.tool_call_id, fn tc ->
+        ToolCall.set_auto_approved_scope(tc, scope)
+      end)
+
+    state = %{state | messages: messages, pending_auto_approvals: pending_auto_approvals}
+    broadcast(state, {:tool_auto_approved, event.tool_call_id, event.name, scope})
+    notify_messages_changed(state)
   end
 
   @spec completion_notification(state()) :: String.t()
@@ -1368,6 +1453,24 @@ defmodule MingaAgent.Session do
     msg = Message.system(text, level)
     append_msg(state, msg)
   end
+
+  @spec maybe_set_trust_for_decision(state(), String.t(), approval_decision()) :: state()
+  defp maybe_set_trust_for_decision(state, name, :approve_session),
+    do: put_tool_trust(state, name, :session)
+
+  defp maybe_set_trust_for_decision(state, name, :approve_turn),
+    do: put_tool_trust(state, name, :turn)
+
+  defp maybe_set_trust_for_decision(state, _name, _decision), do: state
+
+  @spec put_tool_trust(state(), String.t(), trust_scope()) :: state()
+  defp put_tool_trust(state, name, scope) when is_binary(name) and scope in [:session, :turn] do
+    %{state | trust_levels: Map.put(state.trust_levels, name, scope)}
+  end
+
+  @spec execution_decision(approval_decision()) :: :approve | :reject
+  defp execution_decision(:reject), do: :reject
+  defp execution_decision(_decision), do: :approve
 
   @spec maybe_record_rejection(state(), MingaAgent.ToolApproval.t(), atom()) :: state()
   defp maybe_record_rejection(state, approval, :reject) do
@@ -1449,8 +1552,26 @@ defmodule MingaAgent.Session do
         clear_active_tool_tracking(state)
       end
 
+    state = clear_turn_trust_for_status(state, new_status)
     broadcast(state, {:status_changed, new_status})
     state
+  end
+
+  @spec clear_turn_trust_for_status(state(), status()) :: state()
+  defp clear_turn_trust_for_status(state, status) when status in [:idle, :error] do
+    clear_turn_trust(state)
+  end
+
+  defp clear_turn_trust_for_status(state, _status), do: state
+
+  @spec clear_turn_trust(state()) :: state()
+  defp clear_turn_trust(state) do
+    %{state | trust_levels: drop_turn_trust(state.trust_levels), pending_auto_approvals: %{}}
+  end
+
+  @spec drop_turn_trust(%{String.t() => trust_scope()}) :: %{String.t() => trust_scope()}
+  defp drop_turn_trust(trust_levels) do
+    Map.reject(trust_levels, fn {_name, scope} -> scope == :turn end)
   end
 
   @spec set_working_status(state(), :thinking | :tool_executing) :: state()
@@ -1790,7 +1911,9 @@ defmodule MingaAgent.Session do
             steering_queue: [],
             follow_up_queue: [],
             touched_files: %{},
-            boundaries: %{}
+            boundaries: %{},
+            trust_levels: %{},
+            pending_auto_approvals: %{}
         }
 
         apply_loaded_model_to_provider(state)

--- a/lib/minga_agent/session_store.ex
+++ b/lib/minga_agent/session_store.ex
@@ -195,6 +195,7 @@ defmodule MingaAgent.SessionStore do
       "result" => tc.result,
       "is_error" => tc.is_error,
       "collapsed" => tc.collapsed,
+      "auto_approved_scope" => serialize_auto_approved_scope(tc.auto_approved_scope),
       "duration_ms" => tc.duration_ms
     }
   end
@@ -264,6 +265,7 @@ defmodule MingaAgent.SessionStore do
        result: raw["result"] || "",
        is_error: raw["is_error"] || false,
        collapsed: raw["collapsed"] || true,
+       auto_approved_scope: deserialize_auto_approved_scope(raw["auto_approved_scope"]),
        started_at: nil,
        duration_ms: raw["duration_ms"]
      }}
@@ -289,6 +291,17 @@ defmodule MingaAgent.SessionStore do
       size_kb: attachment["size_kb"] || attachment[:size_kb] || 0
     }
   end
+
+  @spec serialize_auto_approved_scope(MingaAgent.ToolCall.auto_approved_scope() | nil) ::
+          String.t() | nil
+  defp serialize_auto_approved_scope(nil), do: nil
+  defp serialize_auto_approved_scope(scope), do: Atom.to_string(scope)
+
+  @spec deserialize_auto_approved_scope(String.t() | nil) ::
+          MingaAgent.ToolCall.auto_approved_scope() | nil
+  defp deserialize_auto_approved_scope("session"), do: :session
+  defp deserialize_auto_approved_scope("turn"), do: :turn
+  defp deserialize_auto_approved_scope(_scope), do: nil
 
   @spec deserialize_tool_status(String.t() | nil) :: MingaAgent.ToolCall.status()
   defp deserialize_tool_status("running"), do: :running

--- a/lib/minga_agent/tool_approval.ex
+++ b/lib/minga_agent/tool_approval.ex
@@ -72,7 +72,7 @@ defmodule MingaAgent.ToolApproval do
     cwd =
       stringify_value(Map.get(args, "cwd") || Map.get(args, "working_directory") || File.cwd!())
 
-    Preview.new(:command, truncate(command, 120), preview_lines(["$ #{command}", "cwd: #{cwd}"]))
+    Preview.new(:command, command, preview_lines(["$ #{command}", "cwd: #{cwd}"]))
   end
 
   defp do_build_preview("write_file", %{"path" => path} = args) when is_binary(path) do

--- a/lib/minga_agent/tool_call.ex
+++ b/lib/minga_agent/tool_call.ex
@@ -14,6 +14,9 @@ defmodule MingaAgent.ToolCall do
   @typedoc "Tool call execution status."
   @type status :: :running | :complete | :error
 
+  @typedoc "Scope that auto-approved this tool call."
+  @type auto_approved_scope :: :session | :turn
+
   @typedoc "A tool call."
   @type t :: %__MODULE__{
           id: String.t(),
@@ -23,6 +26,7 @@ defmodule MingaAgent.ToolCall do
           result: String.t(),
           is_error: boolean(),
           collapsed: boolean(),
+          auto_approved_scope: auto_approved_scope() | nil,
           started_at: integer() | nil,
           duration_ms: non_neg_integer() | nil
         }
@@ -35,6 +39,7 @@ defmodule MingaAgent.ToolCall do
             result: "",
             is_error: false,
             collapsed: true,
+            auto_approved_scope: nil,
             started_at: nil,
             duration_ms: nil
 
@@ -92,6 +97,12 @@ defmodule MingaAgent.ToolCall do
   @spec set_collapsed(t(), boolean()) :: t()
   def set_collapsed(%__MODULE__{} = tc, collapsed) when is_boolean(collapsed) do
     %{tc | collapsed: collapsed}
+  end
+
+  @doc "Records the trust scope that auto-approved this tool call."
+  @spec set_auto_approved_scope(t(), auto_approved_scope() | nil) :: t()
+  def set_auto_approved_scope(%__MODULE__{} = tc, scope) when scope in [:session, :turn, nil] do
+    %{tc | auto_approved_scope: scope}
   end
 
   @doc "Returns true if the tool call has finished (complete or error)."

--- a/lib/minga_editor/agent/chat_decorations.ex
+++ b/lib/minga_editor/agent/chat_decorations.ex
@@ -349,7 +349,8 @@ defmodule MingaEditor.Agent.ChatDecorations do
     # Build header text with timing and command info
     duration_text = format_tool_duration(tc)
     command_text = format_tool_command(tc)
-    header_text = "┌─ #{status_icon} #{tc.name}#{duration_text}#{command_text}"
+    trust_text = format_auto_approved_scope(tc)
+    header_text = "┌─ #{status_icon} #{tc.name}#{duration_text}#{trust_text}#{command_text}"
 
     # Block decoration: tool header (with approval prompt when awaiting)
     {_id, decs} =
@@ -419,6 +420,13 @@ defmodule MingaEditor.Agent.ChatDecorations do
     end
   end
 
+  @spec format_auto_approved_scope(MingaAgent.ToolCall.t()) :: String.t()
+  defp format_auto_approved_scope(%{auto_approved_scope: :session}),
+    do: " · auto-approved session"
+
+  defp format_auto_approved_scope(%{auto_approved_scope: :turn}), do: " · auto-approved turn"
+  defp format_auto_approved_scope(_tc), do: ""
+
   @spec add_approval_card(
           Decorations.t(),
           non_neg_integer(),
@@ -470,10 +478,12 @@ defmodule MingaEditor.Agent.ChatDecorations do
       {"\n│ ", Face.new(fg: status_fg)},
       {"[y]", Face.new(fg: theme.tool_header, bold: true)},
       {" approve  ", Face.new(fg: status_fg)},
+      {"[a]", Face.new(fg: theme.tool_header, bold: true)},
+      {" trust session  ", Face.new(fg: status_fg)},
+      {"[t]", Face.new(fg: theme.tool_header, bold: true)},
+      {" trust turn  ", Face.new(fg: status_fg)},
       {"[n]", Face.new(fg: theme.status_error, bold: true)},
-      {" deny  ", Face.new(fg: status_fg)},
-      {"[Y]", Face.new(fg: theme.tool_header, bold: true)},
-      {" approve all", Face.new(fg: status_fg)},
+      {" deny", Face.new(fg: status_fg)},
       {"\n└─", Face.new(fg: status_fg)}
     ]
 
@@ -501,10 +511,12 @@ defmodule MingaEditor.Agent.ChatDecorations do
         {"Approve? ", Face.new(fg: status_fg, bold: true)},
         {"[y]", Face.new(fg: theme.tool_header, bold: true)},
         {"es ", Face.new(fg: status_fg)},
+        {"[a]", Face.new(fg: theme.tool_header, bold: true)},
+        {"llow-session ", Face.new(fg: status_fg)},
+        {"[t]", Face.new(fg: theme.tool_header, bold: true)},
+        {"urn ", Face.new(fg: status_fg)},
         {"[n]", Face.new(fg: theme.status_error, bold: true)},
-        {"o ", Face.new(fg: status_fg)},
-        {"[Y]", Face.new(fg: theme.tool_header, bold: true)},
-        {"es-all", Face.new(fg: status_fg)}
+        {"o", Face.new(fg: status_fg)}
       ]
     end
   end

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -39,6 +39,7 @@ defmodule MingaEditor.Agent.SlashCommand do
       description: "Set thinking level: /thinking [off|low|medium|high]"
     },
     %Command{name: "model", description: "Set the model: /model <name>"},
+    %Command{name: "trust", description: "Manage tool trust: /trust list|revoke <tool>|clear"},
     %Command{name: "help", description: "Show available slash commands"},
     %Command{name: "plan", description: "Enter plan mode (destructive tools blocked)"},
     %Command{name: "exec", description: "Leave plan mode and allow execution"},
@@ -130,6 +131,7 @@ defmodule MingaEditor.Agent.SlashCommand do
   defp dispatch(state, "abort", _args), do: {:ok, do_stop(state)}
   defp dispatch(state, "thinking", args), do: {:ok, do_thinking(state, args)}
   defp dispatch(state, "model", args), do: do_model(state, args)
+  defp dispatch(state, "trust", args), do: do_trust(state, args)
   defp dispatch(state, "help", _args), do: {:ok, do_help(state)}
   defp dispatch(state, "?", _args), do: {:ok, do_help(state)}
   defp dispatch(state, "plan", _args), do: do_plan(state)
@@ -206,6 +208,51 @@ defmodule MingaEditor.Agent.SlashCommand do
     model = String.trim(model)
     state = AgentCommands.set_model(state, model)
     {:ok, state}
+  end
+
+  @spec do_trust(state(), String.t()) :: {:ok, state()} | {:error, String.t()}
+  defp do_trust(state, args) do
+    args
+    |> String.trim()
+    |> String.split(" ", parts: 2, trim: true)
+    |> do_trust_parts(state)
+  end
+
+  @spec do_trust_parts([String.t()], state()) :: {:ok, state()} | {:error, String.t()}
+  defp do_trust_parts(["list"], state) do
+    with {:ok, session} <- require_session(state) do
+      trust = Session.list_tool_trust(session)
+      {:ok, emit_system_message(state, trust_list_message(trust))}
+    end
+  end
+
+  defp do_trust_parts(["revoke", name], state) do
+    with {:ok, session} <- require_session(state) do
+      tool_name = String.trim(name)
+      :ok = Session.revoke_tool_trust(session, tool_name)
+      {:ok, emit_system_message(state, "Trust cleared for #{tool_name}")}
+    end
+  end
+
+  defp do_trust_parts(["clear"], state) do
+    with {:ok, session} <- require_session(state) do
+      :ok = Session.revoke_tool_trust(session, :all)
+      {:ok, emit_system_message(state, "All tool trust cleared")}
+    end
+  end
+
+  defp do_trust_parts(_parts, _state), do: {:error, "Usage: /trust list|revoke <tool-name>|clear"}
+
+  @spec trust_list_message(%{String.t() => Session.trust_scope()}) :: String.t()
+  defp trust_list_message(trust) when map_size(trust) == 0, do: "No trusted tools"
+
+  defp trust_list_message(trust) do
+    entries =
+      trust
+      |> Enum.sort_by(fn {name, _scope} -> name end)
+      |> Enum.map_join(", ", fn {name, scope} -> "#{name} (#{scope})" end)
+
+    "Trusted tools: #{entries}\nTurn trust is cleared when the current response finishes or errors."
   end
 
   @spec do_help(state()) :: state()

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -1334,8 +1334,11 @@ defmodule MingaEditor.Commands.Agent do
   @spec scope_approve_tool(state()) :: state()
   defdelegate scope_approve_tool(state), to: AgentSubStates, as: :approve_tool
 
-  @spec scope_approve_all_tools(state()) :: state()
-  defdelegate scope_approve_all_tools(state), to: AgentSubStates, as: :approve_all_tools
+  @spec scope_trust_tool_session(state()) :: state()
+  defdelegate scope_trust_tool_session(state), to: AgentSubStates, as: :trust_tool_session
+
+  @spec scope_trust_tool_turn(state()) :: state()
+  defdelegate scope_trust_tool_turn(state), to: AgentSubStates, as: :trust_tool_turn
 
   @spec scope_deny_tool(state()) :: state()
   defdelegate scope_deny_tool(state), to: AgentSubStates, as: :deny_tool
@@ -1637,7 +1640,8 @@ defmodule MingaEditor.Commands.Agent do
     {:agent_accept_all_hunks, "Accept all agent hunks", :scope_accept_all_hunks},
     {:agent_reject_all_hunks, "Reject all agent hunks", :scope_reject_all_hunks},
     {:agent_approve_tool, "Approve agent tool", :scope_approve_tool},
-    {:agent_approve_all_tools, "Approve all agent tools", :scope_approve_all_tools},
+    {:agent_trust_tool_session, "Trust agent tool for session", :scope_trust_tool_session},
+    {:agent_trust_tool_turn, "Trust agent tool for turn", :scope_trust_tool_turn},
     {:agent_deny_tool, "Deny agent tool", :scope_deny_tool}
   ]
 

--- a/lib/minga_editor/commands/agent_sub_states.ex
+++ b/lib/minga_editor/commands/agent_sub_states.ex
@@ -260,15 +260,19 @@ defmodule MingaEditor.Commands.AgentSubStates do
   @spec approve_tool(state()) :: state()
   def approve_tool(state), do: respond_to_tool_approval(state, :approve)
 
-  @doc "Approves the current and all subsequent tool executions in this turn."
-  @spec approve_all_tools(state()) :: state()
-  def approve_all_tools(state), do: respond_to_tool_approval(state, :approve_all)
+  @doc "Approves this tool for the rest of the session."
+  @spec trust_tool_session(state()) :: state()
+  def trust_tool_session(state), do: respond_to_tool_approval(state, :approve_session)
+
+  @doc "Approves this tool for the current turn."
+  @spec trust_tool_turn(state()) :: state()
+  def trust_tool_turn(state), do: respond_to_tool_approval(state, :approve_turn)
 
   @doc "Denies the pending tool execution."
   @spec deny_tool(state()) :: state()
   def deny_tool(state), do: respond_to_tool_approval(state, :reject)
 
-  @spec respond_to_tool_approval(state(), :approve | :approve_all | :reject) :: state()
+  @spec respond_to_tool_approval(state(), Session.approval_decision()) :: state()
   defp respond_to_tool_approval(state, decision) do
     agent = AgentAccess.agent(state)
     session = AgentAccess.session(state)

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -2610,15 +2610,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   @type gui_chat_message ::
           MingaAgent.Message.t()
           | {:styled_assistant, [[styled_run()]]}
-          | {:styled_tool_call,
-             %{
-               name: String.t(),
-               status: :running | :complete | :error,
-               is_error: boolean(),
-               collapsed: boolean(),
-               duration_ms: non_neg_integer() | nil,
-               result: String.t() | nil
-             }, [[styled_run()]]}
+          | {:styled_tool_call, MingaAgent.ToolCall.t(), [[styled_run()]]}
           | {:approval_tool_call, MingaAgent.ToolCall.t(), map()}
 
   @spec encode_chat_messages([gui_chat_message() | {pos_integer(), gui_chat_message()}]) ::
@@ -2799,9 +2791,10 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     duration = tc.duration_ms || 0
     error_byte = if tc.is_error, do: 1, else: 0
     collapsed_byte = if tc.collapsed, do: 1, else: 0
+    auto_approved_byte = auto_approved_scope_byte(tc.auto_approved_scope)
 
-    <<0x04::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32,
-      byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
+    <<0x04::8, status_byte::8, error_byte::8, collapsed_byte::8, auto_approved_byte::8,
+      duration::32, byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
       summary_bytes::binary, byte_size(result_bytes)::32, result_bytes::binary>>
   end
 
@@ -2813,7 +2806,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp encode_chat_message_body({:approval_tool_call, tc, approval}) do
     preview = Map.get(approval, :preview, MingaAgent.ToolApproval.build_preview(tc.name, tc.args))
     name_bytes = preview_text_bytes(tc.name, 120)
-    summary_bytes = preview_text_bytes(Map.get(preview, :summary, tool_call_summary(tc)), 300)
+    summary_bytes = approval_summary_bytes(preview, tool_call_summary(tc))
     id_bytes = preview_text_bytes(Map.get(approval, :tool_call_id, tc.id), 120)
 
     line_binaries =
@@ -2835,7 +2828,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
   # Styled tool call: same header fields as tool_call (0x04), but result is styled runs.
   # Sub-opcode 0x08. Layout:
-  #   0x08, status::8, error::8, collapsed::8, duration::32,
+  #   0x08, status::8, error::8, collapsed::8, auto_approved::8, duration::32,
   #   name_len::16, name, summary_len::16, summary, line_count::16, then per line:
   #   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8,
   #   and when flags bit 0x08 is set: url_len::16, url.
@@ -2853,6 +2846,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     duration = tc.duration_ms || 0
     error_byte = if tc.is_error, do: 1, else: 0
     collapsed_byte = if tc.collapsed, do: 1, else: 0
+    auto_approved_byte = auto_approved_scope_byte(tc.auto_approved_scope)
 
     line_binaries =
       Enum.map(styled_lines, fn runs ->
@@ -2863,8 +2857,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
       end)
 
     IO.iodata_to_binary([
-      <<0x08::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32,
-        byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
+      <<0x08::8, status_byte::8, error_byte::8, collapsed_byte::8, auto_approved_byte::8,
+        duration::32, byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
         summary_bytes::binary, length(styled_lines)::16>>
       | line_binaries
     ])
@@ -2880,6 +2874,24 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     cost_int = round((u.cost || 0.0) * 1_000_000)
     <<0x06::8, u.input::32, u.output::32, u.cache_read::32, u.cache_write::32, cost_int::32>>
   end
+
+  @spec approval_summary_bytes(map(), String.t()) :: binary()
+  defp approval_summary_bytes(%{kind: :command} = preview, fallback) do
+    preview
+    |> Map.get(:summary, fallback)
+    |> preview_text_bytes(@max_u16)
+  end
+
+  defp approval_summary_bytes(preview, fallback) do
+    preview
+    |> Map.get(:summary, fallback)
+    |> preview_text_bytes(300)
+  end
+
+  @spec auto_approved_scope_byte(MingaAgent.ToolCall.auto_approved_scope() | nil) :: 0 | 1 | 2
+  defp auto_approved_scope_byte(:session), do: 1
+  defp auto_approved_scope_byte(:turn), do: 2
+  defp auto_approved_scope_byte(nil), do: 0
 
   @spec encode_styled_run(styled_run()) :: binary()
   defp encode_styled_run({text, fg, bg, flags, url}) do

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -2511,9 +2511,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp encode_pending_approval(nil), do: <<0::8>>
 
   defp encode_pending_approval(%{name: name, args: args}) do
-    name_b = :erlang.iolist_to_binary([name])
-    summary = summarize_tool_args(name, args)
-    summary_b = :erlang.iolist_to_binary([summary])
+    name_b = utf8_prefix_bytes(name, 120)
+    summary_b = utf8_prefix_bytes(summarize_tool_args(name, args), @max_chat_text_bytes)
     <<1::8, byte_size(name_b)::16, name_b::binary, byte_size(summary_b)::16, summary_b::binary>>
   end
 
@@ -2546,17 +2545,16 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
   defp encode_help_overlay(_, _), do: <<0::8>>
 
-  # Computes a short summary for a tool call from its name and args.
+  # Computes a display summary for a tool call from its name and args.
   # Reuses summarize_tool_args/2 (shared with the approval banner).
-  # Truncates to 100 chars max to keep the wire payload small.
   @spec tool_call_summary(MingaAgent.ToolCall.t()) :: String.t()
   defp tool_call_summary(%MingaAgent.ToolCall{name: name, args: args}) when is_map(args) do
-    summarize_tool_args(name, args) |> String.slice(0, 100)
+    summarize_tool_args(name, args)
   end
 
   defp tool_call_summary(%MingaAgent.ToolCall{name: name} = tc) do
     args = Map.get(tc, :args) || %{}
-    summarize_tool_args(name, args) |> String.slice(0, 100)
+    summarize_tool_args(name, args)
   end
 
   @spec preview_kind_byte(atom()) :: non_neg_integer()
@@ -2701,7 +2699,13 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
           binary()
   defp encode_chat_messages_payload(messages) do
     msg_binaries = Enum.map(messages, &encode_chat_message/1)
-    IO.iodata_to_binary([<<length(msg_binaries)::16>> | msg_binaries])
+
+    framed_messages =
+      Enum.map(msg_binaries, fn msg ->
+        <<byte_size(msg)::32, msg::binary>>
+      end)
+
+    IO.iodata_to_binary([<<0xFF::8, 1::8, length(msg_binaries)::16>> | framed_messages])
   end
 
   @spec strip_chat_message_links(gui_chat_message() | {pos_integer(), gui_chat_message()}) ::
@@ -2778,7 +2782,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
   defp encode_chat_message_body({:tool_call, tc}) do
     name_bytes = :erlang.iolist_to_binary([tc.name])
-    summary_bytes = :erlang.iolist_to_binary([tool_call_summary(tc)])
+    summary_bytes = utf8_prefix_bytes(tool_call_summary(tc), @max_chat_text_bytes)
     result_bytes = :erlang.iolist_to_binary([tc.result])
 
     status_byte =
@@ -2793,9 +2797,10 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     collapsed_byte = if tc.collapsed, do: 1, else: 0
     auto_approved_byte = auto_approved_scope_byte(tc.auto_approved_scope)
 
-    <<0x04::8, status_byte::8, error_byte::8, collapsed_byte::8, auto_approved_byte::8,
-      duration::32, byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
-      summary_bytes::binary, byte_size(result_bytes)::32, result_bytes::binary>>
+    <<0x04::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32,
+      byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
+      summary_bytes::binary, byte_size(result_bytes)::32, result_bytes::binary,
+      auto_approved_byte::8>>
   end
 
   # Approval tool call: inline approval card attached to the tool message.
@@ -2828,13 +2833,13 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
   # Styled tool call: same header fields as tool_call (0x04), but result is styled runs.
   # Sub-opcode 0x08. Layout:
-  #   0x08, status::8, error::8, collapsed::8, auto_approved::8, duration::32,
-  #   name_len::16, name, summary_len::16, summary, line_count::16, then per line:
-  #   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8,
-  #   and when flags bit 0x08 is set: url_len::16, url.
+  #   0x08, status::8, error::8, collapsed::8, duration::32, name_len::16, name,
+  #   summary_len::16, summary, line_count::16, then per line: run_count::16,
+  #   then per run: text_len::16, text, fg::24, bg::24, flags::8,
+  #   and when flags bit 0x08 is set: url_len::16, url. auto_approved::8 is appended after the styled line payload.
   defp encode_chat_message_body({:styled_tool_call, tc, styled_lines}) do
     name_bytes = :erlang.iolist_to_binary([tc.name])
-    summary_bytes = :erlang.iolist_to_binary([tool_call_summary(tc)])
+    summary_bytes = utf8_prefix_bytes(tool_call_summary(tc), @max_chat_text_bytes)
 
     status_byte =
       case tc.status do
@@ -2857,10 +2862,11 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
       end)
 
     IO.iodata_to_binary([
-      <<0x08::8, status_byte::8, error_byte::8, collapsed_byte::8, auto_approved_byte::8,
-        duration::32, byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
-        summary_bytes::binary, length(styled_lines)::16>>
-      | line_binaries
+      <<0x08::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32,
+        byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
+        summary_bytes::binary, length(styled_lines)::16>>,
+      line_binaries,
+      <<auto_approved_byte::8>>
     ])
   end
 
@@ -2879,13 +2885,13 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp approval_summary_bytes(%{kind: :command} = preview, fallback) do
     preview
     |> Map.get(:summary, fallback)
-    |> preview_text_bytes(@max_u16)
+    |> utf8_prefix_bytes(@max_chat_text_bytes)
   end
 
   defp approval_summary_bytes(preview, fallback) do
     preview
     |> Map.get(:summary, fallback)
-    |> preview_text_bytes(300)
+    |> utf8_prefix_bytes(300)
   end
 
   @spec auto_approved_scope_byte(MingaAgent.ToolCall.auto_approved_scope() | nil) :: 0 | 1 | 2

--- a/lib/minga_editor/input/tool_approval.ex
+++ b/lib/minga_editor/input/tool_approval.ex
@@ -1,10 +1,10 @@
 defmodule MingaEditor.Input.ToolApproval do
   @moduledoc """
-  Input handler for the tool approval sub-state (y/n/Y).
+  Input handler for the tool approval sub-state (y/a/t/n).
 
   Active when `agent.pending_approval` is non-nil and the panel
-  input is not focused. Handles y (approve), n (deny), Y (approve all),
-  and swallows all other keys.
+  input is not focused. Handles y (approve), a (trust this tool for the session),
+  t (trust this tool for the current turn), n (deny), and swallows all other keys.
   """
 
   @behaviour MingaEditor.Input.Handler
@@ -30,8 +30,9 @@ defmodule MingaEditor.Input.ToolApproval do
 
   @spec dispatch_approval(EditorState.t(), non_neg_integer()) :: EditorState.t()
   defp dispatch_approval(state, ?y), do: Commands.execute(state, :agent_approve_tool)
+  defp dispatch_approval(state, ?a), do: Commands.execute(state, :agent_trust_tool_session)
+  defp dispatch_approval(state, ?t), do: Commands.execute(state, :agent_trust_tool_turn)
   defp dispatch_approval(state, ?n), do: Commands.execute(state, :agent_deny_tool)
-  defp dispatch_approval(state, ?Y), do: Commands.execute(state, :agent_approve_all_tools)
   defp dispatch_approval(state, 27), do: Commands.execute(state, :agent_dismiss_or_noop)
   defp dispatch_approval(state, _cp), do: state
 end

--- a/lib/minga_editor/input/tool_approval.ex
+++ b/lib/minga_editor/input/tool_approval.ex
@@ -1,9 +1,9 @@
 defmodule MingaEditor.Input.ToolApproval do
   @moduledoc """
-  Input handler for the tool approval sub-state (y/a/t/n).
+  Input handler for the tool approval sub-state (y/Enter/a/t/n).
 
   Active when `agent.pending_approval` is non-nil and the panel
-  input is not focused. Handles y (approve), a (trust this tool for the session),
+  input is not focused. Handles y or Enter (approve), a (trust this tool for the session),
   t (trust this tool for the current turn), n (deny), and swallows all other keys.
   """
 
@@ -30,6 +30,7 @@ defmodule MingaEditor.Input.ToolApproval do
 
   @spec dispatch_approval(EditorState.t(), non_neg_integer()) :: EditorState.t()
   defp dispatch_approval(state, ?y), do: Commands.execute(state, :agent_approve_tool)
+  defp dispatch_approval(state, 13), do: Commands.execute(state, :agent_approve_tool)
   defp dispatch_approval(state, ?a), do: Commands.execute(state, :agent_trust_tool_session)
   defp dispatch_approval(state, ?t), do: Commands.execute(state, :agent_trust_tool_turn)
   defp dispatch_approval(state, ?n), do: Commands.execute(state, :agent_deny_tool)

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1280,22 +1280,23 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 messages.append(Wire.ChatMessage(beamId: beamId, content: .thinking(text: t, collapsed: collapsed)))
                 pos += 6 + tLen
             case 0x04: // tool_call
-                guard messagesEnd >= pos + 10 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 11 else { throw ProtocolDecodeError.malformed }
                 let tcStatus = data[pos + 1]
                 let isError = data[pos + 2] != 0
                 let tcCollapsed = data[pos + 3] != 0
-                let duration = readU32(data, pos + 4)
-                let nameLen = Int(readU16(data, pos + 8))
-                guard messagesEnd >= pos + 10 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
-                let name = String(data: data[(pos + 10)..<(pos + 10 + nameLen)], encoding: .utf8) ?? ""
-                let summaryLen = Int(readU16(data, pos + 10 + nameLen))
-                guard messagesEnd >= pos + 12 + nameLen + summaryLen + 4 else { throw ProtocolDecodeError.malformed }
-                let summary = String(data: data[(pos + 12 + nameLen)..<(pos + 12 + nameLen + summaryLen)], encoding: .utf8) ?? ""
-                let resultLen = Int(readU32(data, pos + 12 + nameLen + summaryLen))
-                guard messagesEnd >= pos + 16 + nameLen + summaryLen + resultLen else { throw ProtocolDecodeError.malformed }
-                let result = String(data: data[(pos + 16 + nameLen + summaryLen)..<(pos + 16 + nameLen + summaryLen + resultLen)], encoding: .utf8) ?? ""
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, durationMs: duration, result: result)))
-                pos += 16 + nameLen + summaryLen + resultLen
+                let autoApprovedScope = data[pos + 4]
+                let duration = readU32(data, pos + 5)
+                let nameLen = Int(readU16(data, pos + 9))
+                guard messagesEnd >= pos + 11 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
+                let name = String(data: data[(pos + 11)..<(pos + 11 + nameLen)], encoding: .utf8) ?? ""
+                let summaryLen = Int(readU16(data, pos + 11 + nameLen))
+                guard messagesEnd >= pos + 13 + nameLen + summaryLen + 4 else { throw ProtocolDecodeError.malformed }
+                let summary = String(data: data[(pos + 13 + nameLen)..<(pos + 13 + nameLen + summaryLen)], encoding: .utf8) ?? ""
+                let resultLen = Int(readU32(data, pos + 13 + nameLen + summaryLen))
+                guard messagesEnd >= pos + 17 + nameLen + summaryLen + resultLen else { throw ProtocolDecodeError.malformed }
+                let result = String(data: data[(pos + 17 + nameLen + summaryLen)..<(pos + 17 + nameLen + summaryLen + resultLen)], encoding: .utf8) ?? ""
+                messages.append(Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result)))
+                pos += 17 + nameLen + summaryLen + resultLen
             case 0x05: // system
                 guard messagesEnd >= pos + 6 else { throw ProtocolDecodeError.malformed }
                 let isError = data[pos + 1] != 0
@@ -1368,25 +1369,26 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 pos = rPos
             case 0x08: // styled_tool_call
                 // Same header as tool_call (0x04) but result is styled runs instead of plain text.
-                // Format: 0x08, status::8, error::8, collapsed::8, duration::32,
+                // Format: 0x08, status::8, error::8, collapsed::8, auto_approved::8, duration::32,
                 //   name_len::16, name, summary_len::16, summary, line_count::16, then per line:
                 //   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8,
                 //   and when flags bit 0x08 is set: url_len::16, url.
-                guard messagesEnd >= pos + 10 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 11 else { throw ProtocolDecodeError.malformed }
                 let stcStatus = data[pos + 1]
                 let stcIsError = data[pos + 2] != 0
                 let stcCollapsed = data[pos + 3] != 0
-                let stcDuration = readU32(data, pos + 4)
-                let stcNameLen = Int(readU16(data, pos + 8))
-                guard messagesEnd >= pos + 10 + stcNameLen + 2 else { throw ProtocolDecodeError.malformed }
-                let stcName = String(data: data[(pos + 10)..<(pos + 10 + stcNameLen)], encoding: .utf8) ?? ""
-                let stcSummaryLen = Int(readU16(data, pos + 10 + stcNameLen))
-                guard messagesEnd >= pos + 12 + stcNameLen + stcSummaryLen + 2 else { throw ProtocolDecodeError.malformed }
-                let stcSummary = String(data: data[(pos + 12 + stcNameLen)..<(pos + 12 + stcNameLen + stcSummaryLen)], encoding: .utf8) ?? ""
-                let stcLineCount = Int(readU16(data, pos + 12 + stcNameLen + stcSummaryLen))
+                let stcAutoApprovedScope = data[pos + 4]
+                let stcDuration = readU32(data, pos + 5)
+                let stcNameLen = Int(readU16(data, pos + 9))
+                guard messagesEnd >= pos + 11 + stcNameLen + 2 else { throw ProtocolDecodeError.malformed }
+                let stcName = String(data: data[(pos + 11)..<(pos + 11 + stcNameLen)], encoding: .utf8) ?? ""
+                let stcSummaryLen = Int(readU16(data, pos + 11 + stcNameLen))
+                guard messagesEnd >= pos + 13 + stcNameLen + stcSummaryLen + 2 else { throw ProtocolDecodeError.malformed }
+                let stcSummary = String(data: data[(pos + 13 + stcNameLen)..<(pos + 13 + stcNameLen + stcSummaryLen)], encoding: .utf8) ?? ""
+                let stcLineCount = Int(readU16(data, pos + 13 + stcNameLen + stcSummaryLen))
                 var stcLines: [[Wire.StyledTextRun]] = []
                 stcLines.reserveCapacity(stcLineCount)
-                var stcPos = pos + 14 + stcNameLen + stcSummaryLen
+                var stcPos = pos + 15 + stcNameLen + stcSummaryLen
                 for _ in 0..<stcLineCount {
                     guard messagesEnd >= stcPos + 2 else { throw ProtocolDecodeError.malformed }
                     let runCount = Int(readU16(data, stcPos))
@@ -1423,7 +1425,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                     }
                     stcLines.append(runs)
                 }
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, durationMs: stcDuration, resultLines: stcLines)))
+                messages.append(Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: stcAutoApprovedScope, durationMs: stcDuration, resultLines: stcLines)))
                 pos = stcPos
             case 0x09: // approval_tool_call
                 guard messagesEnd >= pos + 8 else { throw ProtocolDecodeError.malformed }

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1244,220 +1244,33 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                     }
                 }
 
-            case 0x06: // Messages: msg_count(2) + messages... (same internal format as before)
+            case 0x06: // Messages: framed v1 payload, with legacy unframed fallback
                 guard csLen >= 2 else { break }
-                let msgCount = Int(readU16(data, csStart))
-                messages.reserveCapacity(msgCount)
                 let messagesEnd = csStart + csLen
-                var pos = csStart + 2
-        for _ in 0..<msgCount {
-            // Each message is prefixed with a stable uint32 ID from the BEAM
-            guard messagesEnd >= pos + 5 else { throw ProtocolDecodeError.malformed }
-            let beamId = readU32(data, pos)
-            pos += 4
-            let msgType = data[pos]
-            switch msgType {
-            case 0x01: // user
-                guard messagesEnd >= pos + 5 else { throw ProtocolDecodeError.malformed }
-                let tLen = Int(readU32(data, pos + 1))
-                guard messagesEnd >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
-                let t = String(data: data[(pos + 5)..<(pos + 5 + tLen)], encoding: .utf8) ?? ""
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .user(text: t)))
-                pos += 5 + tLen
-            case 0x02: // assistant
-                guard messagesEnd >= pos + 5 else { throw ProtocolDecodeError.malformed }
-                let tLen = Int(readU32(data, pos + 1))
-                guard messagesEnd >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
-                let t = String(data: data[(pos + 5)..<(pos + 5 + tLen)], encoding: .utf8) ?? ""
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .assistant(text: t)))
-                pos += 5 + tLen
-            case 0x03: // thinking
-                guard messagesEnd >= pos + 6 else { throw ProtocolDecodeError.malformed }
-                let collapsed = data[pos + 1] != 0
-                let tLen = Int(readU32(data, pos + 2))
-                guard messagesEnd >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
-                let t = String(data: data[(pos + 6)..<(pos + 6 + tLen)], encoding: .utf8) ?? ""
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .thinking(text: t, collapsed: collapsed)))
-                pos += 6 + tLen
-            case 0x04: // tool_call
-                guard messagesEnd >= pos + 11 else { throw ProtocolDecodeError.malformed }
-                let tcStatus = data[pos + 1]
-                let isError = data[pos + 2] != 0
-                let tcCollapsed = data[pos + 3] != 0
-                let autoApprovedScope = data[pos + 4]
-                let duration = readU32(data, pos + 5)
-                let nameLen = Int(readU16(data, pos + 9))
-                guard messagesEnd >= pos + 11 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
-                let name = String(data: data[(pos + 11)..<(pos + 11 + nameLen)], encoding: .utf8) ?? ""
-                let summaryLen = Int(readU16(data, pos + 11 + nameLen))
-                guard messagesEnd >= pos + 13 + nameLen + summaryLen + 4 else { throw ProtocolDecodeError.malformed }
-                let summary = String(data: data[(pos + 13 + nameLen)..<(pos + 13 + nameLen + summaryLen)], encoding: .utf8) ?? ""
-                let resultLen = Int(readU32(data, pos + 13 + nameLen + summaryLen))
-                guard messagesEnd >= pos + 17 + nameLen + summaryLen + resultLen else { throw ProtocolDecodeError.malformed }
-                let result = String(data: data[(pos + 17 + nameLen + summaryLen)..<(pos + 17 + nameLen + summaryLen + resultLen)], encoding: .utf8) ?? ""
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result)))
-                pos += 17 + nameLen + summaryLen + resultLen
-            case 0x05: // system
-                guard messagesEnd >= pos + 6 else { throw ProtocolDecodeError.malformed }
-                let isError = data[pos + 1] != 0
-                let tLen = Int(readU32(data, pos + 2))
-                guard messagesEnd >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
-                let t = String(data: data[(pos + 6)..<(pos + 6 + tLen)], encoding: .utf8) ?? ""
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .system(text: t, isError: isError)))
-                pos += 6 + tLen
-            case 0x06: // usage
-                guard messagesEnd >= pos + 21 else { throw ProtocolDecodeError.malformed }
-                let inp = readU32(data, pos + 1)
-                let outp = readU32(data, pos + 5)
-                let cacheR = readU32(data, pos + 9)
-                let cacheW = readU32(data, pos + 13)
-                let costM = readU32(data, pos + 17)
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .usage(input: inp, output: outp, cacheRead: cacheR, cacheWrite: cacheW, costMicros: costM)))
-                pos += 21
-            case 0x07: // styled_assistant
-                // Format: 0x07, line_count::16, then per line:
-                //   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8,
-                //   and when flags bit 0x08 is set: url_len::16, url.
-                guard messagesEnd >= pos + 3 else { throw ProtocolDecodeError.malformed }
-                let lineCount = Int(readU16(data, pos + 1))
-                var lines: [[Wire.StyledTextRun]] = []
-                lines.reserveCapacity(lineCount)
-                var rPos = pos + 3
-                for _ in 0..<lineCount {
-                    guard messagesEnd >= rPos + 2 else { throw ProtocolDecodeError.malformed }
-                    let runCount = Int(readU16(data, rPos))
-                    var runs: [Wire.StyledTextRun] = []
-                    runs.reserveCapacity(runCount)
-                    rPos += 2
-                    for _ in 0..<runCount {
-                        guard messagesEnd >= rPos + 9 else { throw ProtocolDecodeError.malformed }
-                        let textLen = Int(readU16(data, rPos))
-                        guard messagesEnd >= rPos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
-                        let runText = String(data: data[(rPos + 2)..<(rPos + 2 + textLen)], encoding: .utf8) ?? ""
-                        let fgOff = rPos + 2 + textLen
-                        let fgR = data[fgOff]
-                        let fgG = data[fgOff + 1]
-                        let fgB = data[fgOff + 2]
-                        let bgR = data[fgOff + 3]
-                        let bgG = data[fgOff + 4]
-                        let bgB = data[fgOff + 5]
-                        let flags = data[fgOff + 6]
-                        var nextRunPos = fgOff + 7
-                        var linkURL: String? = nil
-                        if (flags & 0x08) != 0 {
-                            guard messagesEnd >= nextRunPos + 2 else { throw ProtocolDecodeError.malformed }
-                            let urlLen = Int(readU16(data, nextRunPos))
-                            guard messagesEnd >= nextRunPos + 2 + urlLen else { throw ProtocolDecodeError.malformed }
-                            guard let decodedLinkURL = String(data: data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
-                            linkURL = decodedLinkURL
-                            nextRunPos += 2 + urlLen
-                        }
-                        runs.append(Wire.StyledTextRun(
-                            text: runText,
-                            fgR: fgR, fgG: fgG, fgB: fgB,
-                            bgR: bgR, bgG: bgG, bgB: bgB,
-                            bold: (flags & 0x01) != 0,
-                            italic: (flags & 0x02) != 0,
-                            underline: (flags & 0x04) != 0,
-                            linkURL: linkURL
-                        ))
-                        rPos = nextRunPos
-                    }
-                    lines.append(runs)
+                if data[csStart] == 0xFF {
+                    guard csLen >= 4 else { throw ProtocolDecodeError.malformed }
+                    let version = data[csStart + 1]
+                    guard version == 1 else { throw ProtocolDecodeError.malformed }
+                    let msgCount = Int(readU16(data, csStart + 2))
+                    let decodedMessages = try decodeFramedChatMessages(
+                        data: data,
+                        start: csStart + 4,
+                        end: messagesEnd,
+                        count: msgCount
+                    )
+                    messages.append(contentsOf: decodedMessages)
+                } else {
+                    let msgCount = Int(readU16(data, csStart))
+                    let messagesStart = csStart + 2
+                    let (decodedMessages, decodedEnd) = try decodeLegacyChatMessages(
+                        data: data,
+                        start: messagesStart,
+                        end: messagesEnd,
+                        remaining: msgCount
+                    )
+                    messages.append(contentsOf: decodedMessages)
+                    guard decodedEnd == messagesEnd else { throw ProtocolDecodeError.malformed }
                 }
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .styledAssistant(lines: lines)))
-                pos = rPos
-            case 0x08: // styled_tool_call
-                // Same header as tool_call (0x04) but result is styled runs instead of plain text.
-                // Format: 0x08, status::8, error::8, collapsed::8, auto_approved::8, duration::32,
-                //   name_len::16, name, summary_len::16, summary, line_count::16, then per line:
-                //   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8,
-                //   and when flags bit 0x08 is set: url_len::16, url.
-                guard messagesEnd >= pos + 11 else { throw ProtocolDecodeError.malformed }
-                let stcStatus = data[pos + 1]
-                let stcIsError = data[pos + 2] != 0
-                let stcCollapsed = data[pos + 3] != 0
-                let stcAutoApprovedScope = data[pos + 4]
-                let stcDuration = readU32(data, pos + 5)
-                let stcNameLen = Int(readU16(data, pos + 9))
-                guard messagesEnd >= pos + 11 + stcNameLen + 2 else { throw ProtocolDecodeError.malformed }
-                let stcName = String(data: data[(pos + 11)..<(pos + 11 + stcNameLen)], encoding: .utf8) ?? ""
-                let stcSummaryLen = Int(readU16(data, pos + 11 + stcNameLen))
-                guard messagesEnd >= pos + 13 + stcNameLen + stcSummaryLen + 2 else { throw ProtocolDecodeError.malformed }
-                let stcSummary = String(data: data[(pos + 13 + stcNameLen)..<(pos + 13 + stcNameLen + stcSummaryLen)], encoding: .utf8) ?? ""
-                let stcLineCount = Int(readU16(data, pos + 13 + stcNameLen + stcSummaryLen))
-                var stcLines: [[Wire.StyledTextRun]] = []
-                stcLines.reserveCapacity(stcLineCount)
-                var stcPos = pos + 15 + stcNameLen + stcSummaryLen
-                for _ in 0..<stcLineCount {
-                    guard messagesEnd >= stcPos + 2 else { throw ProtocolDecodeError.malformed }
-                    let runCount = Int(readU16(data, stcPos))
-                    var runs: [Wire.StyledTextRun] = []
-                    runs.reserveCapacity(runCount)
-                    stcPos += 2
-                    for _ in 0..<runCount {
-                        guard messagesEnd >= stcPos + 9 else { throw ProtocolDecodeError.malformed }
-                        let textLen = Int(readU16(data, stcPos))
-                        guard messagesEnd >= stcPos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
-                        let runText = String(data: data[(stcPos + 2)..<(stcPos + 2 + textLen)], encoding: .utf8) ?? ""
-                        let fgOff = stcPos + 2 + textLen
-                        let flags = data[fgOff + 6]
-                        var nextRunPos = fgOff + 7
-                        var linkURL: String? = nil
-                        if (flags & 0x08) != 0 {
-                            guard messagesEnd >= nextRunPos + 2 else { throw ProtocolDecodeError.malformed }
-                            let urlLen = Int(readU16(data, nextRunPos))
-                            guard messagesEnd >= nextRunPos + 2 + urlLen else { throw ProtocolDecodeError.malformed }
-                            guard let decodedLinkURL = String(data: data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
-                            linkURL = decodedLinkURL
-                            nextRunPos += 2 + urlLen
-                        }
-                        runs.append(Wire.StyledTextRun(
-                            text: runText,
-                            fgR: data[fgOff], fgG: data[fgOff + 1], fgB: data[fgOff + 2],
-                            bgR: data[fgOff + 3], bgG: data[fgOff + 4], bgB: data[fgOff + 5],
-                            bold: (flags & 0x01) != 0,
-                            italic: (flags & 0x02) != 0,
-                            underline: (flags & 0x04) != 0,
-                            linkURL: linkURL
-                        ))
-                        stcPos = nextRunPos
-                    }
-                    stcLines.append(runs)
-                }
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: stcAutoApprovedScope, durationMs: stcDuration, resultLines: stcLines)))
-                pos = stcPos
-            case 0x09: // approval_tool_call
-                guard messagesEnd >= pos + 8 else { throw ProtocolDecodeError.malformed }
-                let nameLen = Int(readU16(data, pos + 2))
-                guard messagesEnd >= pos + 4 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
-                let name = String(data: data[(pos + 4)..<(pos + 4 + nameLen)], encoding: .utf8) ?? ""
-                let summaryLen = Int(readU16(data, pos + 4 + nameLen))
-                guard messagesEnd >= pos + 6 + nameLen + summaryLen + 2 else { throw ProtocolDecodeError.malformed }
-                let summary = String(data: data[(pos + 6 + nameLen)..<(pos + 6 + nameLen + summaryLen)], encoding: .utf8) ?? ""
-                let idLen = Int(readU16(data, pos + 6 + nameLen + summaryLen))
-                guard messagesEnd >= pos + 8 + nameLen + summaryLen + idLen + 3 else { throw ProtocolDecodeError.malformed }
-                let toolCallId = String(data: data[(pos + 8 + nameLen + summaryLen)..<(pos + 8 + nameLen + summaryLen + idLen)], encoding: .utf8) ?? ""
-                let previewKind = data[pos + 8 + nameLen + summaryLen + idLen]
-                let lineCount = Int(readU16(data, pos + 9 + nameLen + summaryLen + idLen))
-                var approvalPos = pos + 11 + nameLen + summaryLen + idLen
-                var previewLines: [String] = []
-                previewLines.reserveCapacity(lineCount)
-                for _ in 0..<lineCount {
-                    guard messagesEnd >= approvalPos + 2 else { throw ProtocolDecodeError.malformed }
-                    let lineLen = Int(readU16(data, approvalPos))
-                    guard messagesEnd >= approvalPos + 2 + lineLen else { throw ProtocolDecodeError.malformed }
-                    let line = String(data: data[(approvalPos + 2)..<(approvalPos + 2 + lineLen)], encoding: .utf8) ?? ""
-                    previewLines.append(line)
-                    approvalPos += 2 + lineLen
-                }
-                messages.append(Wire.ChatMessage(beamId: beamId, content: .approvalToolCall(name: name, summary: summary, toolCallId: toolCallId, previewKind: previewKind, previewLines: previewLines)))
-                pos = approvalPos
-            default:
-                throw ProtocolDecodeError.malformed
-            }
-        }
-                guard pos == messagesEnd else { throw ProtocolDecodeError.malformed }
 
             default: break
             }
@@ -2751,6 +2564,280 @@ private func decodeStatusBarSegments(data: Data, pos: inout Int, count: Int, end
     }
 
     return segments
+}
+
+private struct DecodedChatMessageCandidate {
+    let message: Wire.ChatMessage
+    let nextOffset: Int
+}
+
+private func decodeFramedChatMessages(data: Data, start: Int, end: Int, count: Int) throws -> [Wire.ChatMessage] {
+    var messages: [Wire.ChatMessage] = []
+    messages.reserveCapacity(count)
+    var pos = start
+
+    for _ in 0..<count {
+        guard pos + 4 <= end else { throw ProtocolDecodeError.malformed }
+        let messageLen = Int(readU32(data, pos))
+        let messageStart = pos + 4
+        let messageEnd = messageStart + messageLen
+        guard messageEnd <= end else { throw ProtocolDecodeError.malformed }
+
+        let candidates = try decodeChatMessageCandidates(data: data, start: messageStart, end: messageEnd)
+        guard let candidate = candidates.first(where: { $0.nextOffset == messageEnd }) else {
+            throw ProtocolDecodeError.malformed
+        }
+
+        messages.append(candidate.message)
+        pos = messageEnd
+    }
+
+    guard pos == end else { throw ProtocolDecodeError.malformed }
+    return messages
+}
+
+private func decodeLegacyChatMessages(data: Data, start: Int, end: Int, remaining: Int) throws -> ([Wire.ChatMessage], Int) {
+    if remaining == 0 {
+        guard start == end else { throw ProtocolDecodeError.malformed }
+        return ([], start)
+    }
+
+    let candidates = try decodeChatMessageCandidates(data: data, start: start, end: end)
+
+    for candidate in candidates {
+        if let (rest, decodedEnd) = try? decodeLegacyChatMessages(
+            data: data,
+            start: candidate.nextOffset,
+            end: end,
+            remaining: remaining - 1
+        ) {
+            return ([candidate.message] + rest, decodedEnd)
+        }
+    }
+
+    throw ProtocolDecodeError.malformed
+}
+
+private func decodeChatMessageCandidates(data: Data, start: Int, end: Int) throws -> [DecodedChatMessageCandidate] {
+    guard start + 5 <= end else { throw ProtocolDecodeError.malformed }
+
+    let beamId = readU32(data, start)
+    let msgType = data[start + 4]
+    let pos = start + 4
+
+    switch msgType {
+    case 0x01: // user
+        guard end >= pos + 5 else { throw ProtocolDecodeError.malformed }
+        let tLen = Int(readU32(data, pos + 1))
+        guard end >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
+        let t = String(data: data[(pos + 5)..<(pos + 5 + tLen)], encoding: .utf8) ?? ""
+        return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .user(text: t)), nextOffset: pos + 5 + tLen)]
+
+    case 0x02: // assistant
+        guard end >= pos + 5 else { throw ProtocolDecodeError.malformed }
+        let tLen = Int(readU32(data, pos + 1))
+        guard end >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
+        let t = String(data: data[(pos + 5)..<(pos + 5 + tLen)], encoding: .utf8) ?? ""
+        return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .assistant(text: t)), nextOffset: pos + 5 + tLen)]
+
+    case 0x03: // thinking
+        guard end >= pos + 6 else { throw ProtocolDecodeError.malformed }
+        let collapsed = data[pos + 1] != 0
+        let tLen = Int(readU32(data, pos + 2))
+        guard end >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
+        let t = String(data: data[(pos + 6)..<(pos + 6 + tLen)], encoding: .utf8) ?? ""
+        return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .thinking(text: t, collapsed: collapsed)), nextOffset: pos + 6 + tLen)]
+
+    case 0x04: // tool_call
+        guard end >= pos + 10 else { throw ProtocolDecodeError.malformed }
+        let tcStatus = data[pos + 1]
+        let isError = data[pos + 2] != 0
+        let tcCollapsed = data[pos + 3] != 0
+        let duration = readU32(data, pos + 4)
+        let nameLen = Int(readU16(data, pos + 8))
+        guard end >= pos + 10 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
+        let name = String(data: data[(pos + 10)..<(pos + 10 + nameLen)], encoding: .utf8) ?? ""
+        let summaryLen = Int(readU16(data, pos + 10 + nameLen))
+        guard end >= pos + 12 + nameLen + summaryLen + 4 else { throw ProtocolDecodeError.malformed }
+        let summary = String(data: data[(pos + 12 + nameLen)..<(pos + 12 + nameLen + summaryLen)], encoding: .utf8) ?? ""
+        let resultLen = Int(readU32(data, pos + 12 + nameLen + summaryLen))
+        let baseOffset = pos + 16 + nameLen + summaryLen + resultLen
+        guard end >= baseOffset else { throw ProtocolDecodeError.malformed }
+        let result = String(data: data[(pos + 16 + nameLen + summaryLen)..<(pos + 16 + nameLen + summaryLen + resultLen)], encoding: .utf8) ?? ""
+        var candidates: [DecodedChatMessageCandidate] = []
+        if end > baseOffset {
+            let autoApprovedScope = data[baseOffset]
+            if autoApprovedScope <= 2 {
+                let messageWithAuto = Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result))
+                candidates.append(DecodedChatMessageCandidate(message: messageWithAuto, nextOffset: baseOffset + 1))
+            }
+        }
+        let messageWithoutAuto = Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: 0, durationMs: duration, result: result))
+        candidates.append(DecodedChatMessageCandidate(message: messageWithoutAuto, nextOffset: baseOffset))
+        return candidates
+
+    case 0x05: // system
+        guard end >= pos + 6 else { throw ProtocolDecodeError.malformed }
+        let isError = data[pos + 1] != 0
+        let tLen = Int(readU32(data, pos + 2))
+        guard end >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
+        let t = String(data: data[(pos + 6)..<(pos + 6 + tLen)], encoding: .utf8) ?? ""
+        return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .system(text: t, isError: isError)), nextOffset: pos + 6 + tLen)]
+
+    case 0x06: // usage
+        guard end >= pos + 21 else { throw ProtocolDecodeError.malformed }
+        let inp = readU32(data, pos + 1)
+        let outp = readU32(data, pos + 5)
+        let cacheR = readU32(data, pos + 9)
+        let cacheW = readU32(data, pos + 13)
+        let costM = readU32(data, pos + 17)
+        return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .usage(input: inp, output: outp, cacheRead: cacheR, cacheWrite: cacheW, costMicros: costM)), nextOffset: pos + 21)]
+
+    case 0x07: // styled_assistant
+        guard end >= pos + 3 else { throw ProtocolDecodeError.malformed }
+        let lineCount = Int(readU16(data, pos + 1))
+        var lines: [[Wire.StyledTextRun]] = []
+        lines.reserveCapacity(lineCount)
+        var rPos = pos + 3
+        for _ in 0..<lineCount {
+            guard end >= rPos + 2 else { throw ProtocolDecodeError.malformed }
+            let runCount = Int(readU16(data, rPos))
+            var runs: [Wire.StyledTextRun] = []
+            runs.reserveCapacity(runCount)
+            rPos += 2
+            for _ in 0..<runCount {
+                guard end >= rPos + 9 else { throw ProtocolDecodeError.malformed }
+                let textLen = Int(readU16(data, rPos))
+                guard end >= rPos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
+                let runText = String(data: data[(rPos + 2)..<(rPos + 2 + textLen)], encoding: .utf8) ?? ""
+                let fgOff = rPos + 2 + textLen
+                let fgR = data[fgOff]
+                let fgG = data[fgOff + 1]
+                let fgB = data[fgOff + 2]
+                let bgR = data[fgOff + 3]
+                let bgG = data[fgOff + 4]
+                let bgB = data[fgOff + 5]
+                let flags = data[fgOff + 6]
+                var nextRunPos = fgOff + 7
+                var linkURL: String? = nil
+                if (flags & 0x08) != 0 {
+                    guard end >= nextRunPos + 2 else { throw ProtocolDecodeError.malformed }
+                    let urlLen = Int(readU16(data, nextRunPos))
+                    guard end >= nextRunPos + 2 + urlLen else { throw ProtocolDecodeError.malformed }
+                    guard let decodedLinkURL = String(data: data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+                    linkURL = decodedLinkURL
+                    nextRunPos += 2 + urlLen
+                }
+                runs.append(Wire.StyledTextRun(
+                    text: runText,
+                    fgR: fgR, fgG: fgG, fgB: fgB,
+                    bgR: bgR, bgG: bgG, bgB: bgB,
+                    bold: (flags & 0x01) != 0,
+                    italic: (flags & 0x02) != 0,
+                    underline: (flags & 0x04) != 0,
+                    linkURL: linkURL
+                ))
+                rPos = nextRunPos
+            }
+            lines.append(runs)
+        }
+        return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .styledAssistant(lines: lines)), nextOffset: rPos)]
+
+    case 0x08: // styled_tool_call
+        guard end >= pos + 10 else { throw ProtocolDecodeError.malformed }
+        let stcStatus = data[pos + 1]
+        let stcIsError = data[pos + 2] != 0
+        let stcCollapsed = data[pos + 3] != 0
+        let stcDuration = readU32(data, pos + 4)
+        let stcNameLen = Int(readU16(data, pos + 8))
+        guard end >= pos + 10 + stcNameLen + 2 else { throw ProtocolDecodeError.malformed }
+        let stcName = String(data: data[(pos + 10)..<(pos + 10 + stcNameLen)], encoding: .utf8) ?? ""
+        let stcSummaryLen = Int(readU16(data, pos + 10 + stcNameLen))
+        guard end >= pos + 12 + stcNameLen + stcSummaryLen + 2 else { throw ProtocolDecodeError.malformed }
+        let stcSummary = String(data: data[(pos + 12 + stcNameLen)..<(pos + 12 + stcNameLen + stcSummaryLen)], encoding: .utf8) ?? ""
+        let stcLineCount = Int(readU16(data, pos + 12 + stcNameLen + stcSummaryLen))
+        var stcLines: [[Wire.StyledTextRun]] = []
+        stcLines.reserveCapacity(stcLineCount)
+        var stcPos = pos + 14 + stcNameLen + stcSummaryLen
+        for _ in 0..<stcLineCount {
+            guard end >= stcPos + 2 else { throw ProtocolDecodeError.malformed }
+            let runCount = Int(readU16(data, stcPos))
+            var runs: [Wire.StyledTextRun] = []
+            runs.reserveCapacity(runCount)
+            stcPos += 2
+            for _ in 0..<runCount {
+                guard end >= stcPos + 9 else { throw ProtocolDecodeError.malformed }
+                let textLen = Int(readU16(data, stcPos))
+                guard end >= stcPos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
+                let runText = String(data: data[(stcPos + 2)..<(stcPos + 2 + textLen)], encoding: .utf8) ?? ""
+                let fgOff = stcPos + 2 + textLen
+                let flags = data[fgOff + 6]
+                var nextRunPos = fgOff + 7
+                var linkURL: String? = nil
+                if (flags & 0x08) != 0 {
+                    guard end >= nextRunPos + 2 else { throw ProtocolDecodeError.malformed }
+                    let urlLen = Int(readU16(data, nextRunPos))
+                    guard end >= nextRunPos + 2 + urlLen else { throw ProtocolDecodeError.malformed }
+                    guard let decodedLinkURL = String(data: data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+                    linkURL = decodedLinkURL
+                    nextRunPos += 2 + urlLen
+                }
+                runs.append(Wire.StyledTextRun(
+                    text: runText,
+                    fgR: data[fgOff], fgG: data[fgOff + 1], fgB: data[fgOff + 2],
+                    bgR: data[fgOff + 3], bgG: data[fgOff + 4], bgB: data[fgOff + 5],
+                    bold: (flags & 0x01) != 0,
+                    italic: (flags & 0x02) != 0,
+                    underline: (flags & 0x04) != 0,
+                    linkURL: linkURL
+                ))
+                stcPos = nextRunPos
+            }
+            stcLines.append(runs)
+        }
+        let stcBaseOffset = stcPos
+        guard end >= stcBaseOffset else { throw ProtocolDecodeError.malformed }
+        var stcCandidates: [DecodedChatMessageCandidate] = []
+        if end > stcBaseOffset {
+            let stcAutoApprovedScope = data[stcBaseOffset]
+            if stcAutoApprovedScope <= 2 {
+                let stcMessageWithAuto = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: stcAutoApprovedScope, durationMs: stcDuration, resultLines: stcLines))
+                stcCandidates.append(DecodedChatMessageCandidate(message: stcMessageWithAuto, nextOffset: stcBaseOffset + 1))
+            }
+        }
+        let stcMessageWithoutAuto = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: 0, durationMs: stcDuration, resultLines: stcLines))
+        stcCandidates.append(DecodedChatMessageCandidate(message: stcMessageWithoutAuto, nextOffset: stcBaseOffset))
+        return stcCandidates
+
+    case 0x09: // approval_tool_call
+        guard end >= pos + 8 else { throw ProtocolDecodeError.malformed }
+        let nameLen = Int(readU16(data, pos + 2))
+        guard end >= pos + 4 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
+        let name = String(data: data[(pos + 4)..<(pos + 4 + nameLen)], encoding: .utf8) ?? ""
+        let summaryLen = Int(readU16(data, pos + 4 + nameLen))
+        guard end >= pos + 6 + nameLen + summaryLen + 2 else { throw ProtocolDecodeError.malformed }
+        let summary = String(data: data[(pos + 6 + nameLen)..<(pos + 6 + nameLen + summaryLen)], encoding: .utf8) ?? ""
+        let idLen = Int(readU16(data, pos + 6 + nameLen + summaryLen))
+        guard end >= pos + 8 + nameLen + summaryLen + idLen + 3 else { throw ProtocolDecodeError.malformed }
+        let toolCallId = String(data: data[(pos + 8 + nameLen + summaryLen)..<(pos + 8 + nameLen + summaryLen + idLen)], encoding: .utf8) ?? ""
+        let previewKind = data[pos + 8 + nameLen + summaryLen + idLen]
+        let lineCount = Int(readU16(data, pos + 9 + nameLen + summaryLen + idLen))
+        var approvalPos = pos + 11 + nameLen + summaryLen + idLen
+        var previewLines: [String] = []
+        previewLines.reserveCapacity(lineCount)
+        for _ in 0..<lineCount {
+            guard end >= approvalPos + 2 else { throw ProtocolDecodeError.malformed }
+            let lineLen = Int(readU16(data, approvalPos))
+            guard end >= approvalPos + 2 + lineLen else { throw ProtocolDecodeError.malformed }
+            let line = String(data: data[(approvalPos + 2)..<(approvalPos + 2 + lineLen)], encoding: .utf8) ?? ""
+            previewLines.append(line)
+            approvalPos += 2 + lineLen
+        }
+        return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .approvalToolCall(name: name, summary: summary, toolCallId: toolCallId, previewKind: previewKind, previewLines: previewLines)), nextOffset: approvalPos)]
+
+    default:
+        throw ProtocolDecodeError.malformed
+    }
 }
 
 private func readU16(_ data: Data, _ offset: Int) -> UInt16 {

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -535,9 +535,9 @@ enum Wire {
         /// Assistant message with pre-styled text runs from tree-sitter.
         case styledAssistant(lines: [[StyledTextRun]])
         case thinking(text: String, collapsed: Bool)
-        case toolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, result: String)
+        case toolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String)
         /// Tool call with pre-styled result runs from tree-sitter.
-        case styledToolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, resultLines: [[StyledTextRun]])
+        case styledToolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, resultLines: [[StyledTextRun]])
         case approvalToolCall(name: String, summary: String, toolCallId: String, previewKind: UInt8, previewLines: [String])
         case system(text: String, isError: Bool)
         case usage(input: UInt32, output: UInt32, cacheRead: UInt32, cacheWrite: UInt32, costMicros: UInt32)

--- a/macos/Sources/Views/AgentChatState.swift
+++ b/macos/Sources/Views/AgentChatState.swift
@@ -9,9 +9,9 @@ enum ChatMessageEntry: Identifiable {
     /// Assistant message with pre-styled text runs from the BEAM (tree-sitter or markdown parser).
     case styledAssistant(id: Int, lines: [[Wire.StyledTextRun]])
     case thinking(id: Int, text: String, collapsed: Bool)
-    case toolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, result: String)
-    case styledToolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, resultLines: [[Wire.StyledTextRun]])
-    case approvalToolCall(id: Int, name: String, summary: String, previewKind: UInt8, previewLines: [String])
+    case toolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String)
+    case styledToolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, resultLines: [[Wire.StyledTextRun]])
+    case approvalToolCall(id: Int, name: String, summary: String, toolCallId: String, previewKind: UInt8, previewLines: [String])
     case system(id: Int, text: String, isError: Bool)
     case usage(id: Int, input: UInt32, output: UInt32, cacheRead: UInt32, cacheWrite: UInt32, costMicros: UInt32)
 
@@ -19,9 +19,9 @@ enum ChatMessageEntry: Identifiable {
         switch self {
         case .user(let id, _), .assistant(let id, _), .styledAssistant(let id, _),
              .thinking(let id, _, _),
-             .toolCall(let id, _, _, _, _, _, _, _),
-             .styledToolCall(let id, _, _, _, _, _, _, _),
-             .approvalToolCall(let id, _, _, _, _),
+             .toolCall(let id, _, _, _, _, _, _, _, _),
+             .styledToolCall(let id, _, _, _, _, _, _, _, _),
+             .approvalToolCall(let id, _, _, _, _, _),
              .system(let id, _, _),
              .usage(let id, _, _, _, _, _):
             return id
@@ -135,12 +135,12 @@ final class AgentChatState {
                 return .styledAssistant(id: id, lines: lines)
             case .thinking(let text, let collapsed):
                 return .thinking(id: id, text: text, collapsed: collapsed)
-            case .toolCall(let name, let summary, let st, let isError, let collapsed, let duration, let result):
-                return .toolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, durationMs: duration, result: result)
-            case .styledToolCall(let name, let summary, let st, let isError, let collapsed, let duration, let resultLines):
-                return .styledToolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, durationMs: duration, resultLines: resultLines)
-            case .approvalToolCall(let name, let summary, _, let previewKind, let previewLines):
-                return .approvalToolCall(id: id, name: name, summary: summary, previewKind: previewKind, previewLines: previewLines)
+            case .toolCall(let name, let summary, let st, let isError, let collapsed, let autoApprovedScope, let duration, let result):
+                return .toolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result)
+            case .styledToolCall(let name, let summary, let st, let isError, let collapsed, let autoApprovedScope, let duration, let resultLines):
+                return .styledToolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, resultLines: resultLines)
+            case .approvalToolCall(let name, let summary, let toolCallId, let previewKind, let previewLines):
+                return .approvalToolCall(id: id, name: name, summary: summary, toolCallId: toolCallId, previewKind: previewKind, previewLines: previewLines)
             case .system(let text, let isError):
                 return .system(id: id, text: text, isError: isError)
             case .usage(let inp, let outp, let cacheR, let cacheW, let costM):

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -538,11 +538,7 @@ struct AgentChatView: View {
 
                 // Tool summary (command, path, etc.)
                 if !summary.isEmpty {
-                    Text(summary)
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundStyle(theme.agentTextFg.opacity(0.5))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+                    toolCallSummaryView(name: name, summary: summary)
                 }
 
                 Spacer(minLength: 8)
@@ -672,6 +668,26 @@ struct AgentChatView: View {
     }
 
     @ViewBuilder
+    private func toolCallSummaryView(name: String, summary: String) -> some View {
+        if name == "shell" {
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(summary)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(theme.agentTextFg.opacity(0.5))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            Text(summary)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(theme.agentTextFg.opacity(0.5))
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    @ViewBuilder
     private func approvalToolCallSummary(summary: String, previewKind: UInt8) -> some View {
         if previewKind == 2 {
             ScrollView(.horizontal, showsIndicators: false) {
@@ -718,13 +734,13 @@ struct AgentChatView: View {
             .controlSize(.small)
 
             HStack(spacing: 6) {
-                Button("Trust this tool (a)") {
+                Button("Trust for session (a)") {
                     encoder?.sendKeyPress(codepoint: 0x61, modifiers: 0)
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
 
-                Button("For this turn (t)") {
+                Button("Trust for this turn (t)") {
                     encoder?.sendKeyPress(codepoint: 0x74, modifiers: 0)
                 }
                 .buttonStyle(.bordered)

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -317,12 +317,12 @@ struct AgentChatView: View {
                     .frame(height: 1)
                     .padding(.horizontal, 4)
             }
-            messageView(msg)
+            messageView(msg, index: index)
         }
     }
 
     @ViewBuilder
-    private func messageView(_ msg: ChatMessageEntry) -> some View {
+    private func messageView(_ msg: ChatMessageEntry, index: Int) -> some View {
         switch msg {
         case .user(_, let text):
             userMessage(text)
@@ -332,12 +332,12 @@ struct AgentChatView: View {
             styledAssistantBlock(lines)
         case .thinking(_, let text, let collapsed):
             thinkingBlock(text, collapsed: collapsed)
-        case .toolCall(let id, let name, let summary, let status, let isError, let collapsed, let duration, let result):
-            toolCallCard(messageIndex: id, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, durationMs: duration, result: result, resultLines: nil)
-        case .styledToolCall(let id, let name, let summary, let status, let isError, let collapsed, let duration, let resultLines):
-            toolCallCard(messageIndex: id, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, durationMs: duration, result: nil, resultLines: resultLines)
-        case .approvalToolCall(_, let name, let summary, let previewKind, let previewLines):
-            approvalToolCallCard(name: name, summary: summary, previewKind: previewKind, previewLines: previewLines)
+        case .toolCall(_, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let result):
+            toolCallCard(messageIndex: index, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result, resultLines: nil)
+        case .styledToolCall(_, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let resultLines):
+            toolCallCard(messageIndex: index, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: nil, resultLines: resultLines)
+        case .approvalToolCall(_, let name, let summary, let toolCallId, let previewKind, let previewLines):
+            approvalToolCallCard(name: name, summary: summary, toolCallId: toolCallId, previewKind: previewKind, previewLines: previewLines)
         case .system(_, let text, let isError):
             systemMessage(text, isError: isError)
         case .usage(_, let input, let output, _, _, let costMicros):
@@ -507,8 +507,8 @@ struct AgentChatView: View {
     }
 
     @ViewBuilder
-    private func toolCallCard(messageIndex: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, result: String?, resultLines: [[Wire.StyledTextRun]]?) -> some View {
-        let hasResult = (result != nil && !result!.isEmpty) || (resultLines != nil && !resultLines!.isEmpty)
+    private func toolCallCard(messageIndex: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String?, resultLines: [[Wire.StyledTextRun]]?) -> some View {
+        let hasResult = result?.isEmpty == false || resultLines?.isEmpty == false
 
         VStack(alignment: .leading, spacing: 0) {
             // Header (clickable to toggle collapse)
@@ -554,6 +554,10 @@ struct AgentChatView: View {
                 }
 
                 statusBadge(status, isError: isError)
+
+                if let autoApprovedLabel = autoApprovedScopeLabel(autoApprovedScope) {
+                    autoApprovedPill(label: autoApprovedLabel)
+                }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
@@ -629,21 +633,17 @@ struct AgentChatView: View {
     }
 
     @ViewBuilder
-    private func approvalToolCallCard(name: String, summary: String, previewKind: UInt8, previewLines: [String]) -> some View {
+    private func approvalToolCallCard(name: String, summary: String, toolCallId: String, previewKind: UInt8, previewLines: [String]) -> some View {
         let visiblePreviewLines = Array(previewLines.prefix(8))
 
         VStack(alignment: .leading, spacing: 10) {
-            approvalToolCallHeader(name: name)
-
-            if !summary.isEmpty {
-                approvalToolCallSummary(summary: summary, previewKind: previewKind)
-            }
+            approvalToolCallHeader(name: name, summary: summary, previewKind: previewKind)
 
             if !visiblePreviewLines.isEmpty {
                 approvalPreviewLines(visiblePreviewLines)
             }
 
-            approvalButtons
+            approvalButtons(toolCallId: toolCallId)
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -651,8 +651,8 @@ struct AgentChatView: View {
         .overlay(approvalCardBorder)
     }
 
-    private func approvalToolCallHeader(name: String) -> some View {
-        HStack(spacing: 8) {
+    private func approvalToolCallHeader(name: String, summary: String, previewKind: UInt8) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
             Image(systemName: "exclamationmark.shield")
                 .font(.system(size: 13))
                 .foregroundStyle(Color.orange)
@@ -662,18 +662,31 @@ struct AgentChatView: View {
                 .foregroundStyle(theme.agentTextFg)
 
             Text(name)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .font(.system(size: 12, weight: .bold, design: .monospaced))
                 .foregroundStyle(theme.agentToolHeader)
 
-            Spacer()
+            if !summary.isEmpty {
+                approvalToolCallSummary(summary: summary, previewKind: previewKind)
+            }
         }
     }
 
+    @ViewBuilder
     private func approvalToolCallSummary(summary: String, previewKind: UInt8) -> some View {
-        Text("\(approvalPreviewLabel(previewKind)): \(summary)")
-            .font(.system(size: 11, design: .monospaced))
-            .foregroundStyle(theme.agentTextFg.opacity(0.75))
-            .lineLimit(2)
+        if previewKind == 2 {
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(summary)
+                    .font(.system(size: 12, weight: .regular, design: .monospaced))
+                    .foregroundStyle(theme.agentTextFg)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+        } else {
+            Text(summary)
+                .font(.system(size: 12, weight: .regular, design: .monospaced))
+                .foregroundStyle(theme.agentTextFg)
+                .lineLimit(2)
+        }
     }
 
     private func approvalPreviewLines(_ lines: [String]) -> some View {
@@ -696,22 +709,30 @@ struct AgentChatView: View {
             .truncationMode(.tail)
     }
 
-    private var approvalButtons: some View {
-        HStack(spacing: 8) {
-            Button("Approve") {
+    private func approvalButtons(toolCallId _: String) -> some View {
+        HStack(spacing: 6) {
+            Button("Approve (y)") {
                 encoder?.sendKeyPress(codepoint: 0x79, modifiers: 0)
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
 
-            Button("Deny") {
-                encoder?.sendKeyPress(codepoint: 0x6E, modifiers: 0)
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
+            HStack(spacing: 6) {
+                Button("Trust this tool (a)") {
+                    encoder?.sendKeyPress(codepoint: 0x61, modifiers: 0)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
 
-            Button("Approve all") {
-                encoder?.sendKeyPress(codepoint: 0x59, modifiers: 0)
+                Button("For this turn (t)") {
+                    encoder?.sendKeyPress(codepoint: 0x74, modifiers: 0)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            Button("Deny (n)") {
+                encoder?.sendKeyPress(codepoint: 0x6E, modifiers: 0)
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
@@ -1134,6 +1155,21 @@ struct AgentChatView: View {
                     RoundedRectangle(cornerRadius: 4)
                         .fill(color.opacity(0.1))
                 )
+        }
+    }
+
+    private func autoApprovedPill(label: String) -> some View {
+        Text("auto-approved · \(label)")
+            .font(.system(size: 10, design: .rounded))
+            .foregroundStyle(theme.agentTextFg.opacity(0.55))
+            .accessibilityLabel("Auto-approved for this \(label)")
+    }
+
+    private func autoApprovedScopeLabel(_ scope: UInt8) -> String? {
+        switch scope {
+        case 1: return "session"
+        case 2: return "turn"
+        default: return nil
         }
     }
 

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -339,11 +339,12 @@ func chatMessageToJSON(_ msg: Wire.ChatMessage) -> [String: Any] {
         result["kind"] = "styled_assistant"; result["lines"] = linesJSON
     case .thinking(let text, let collapsed):
         result["kind"] = "thinking"; result["text"] = text; result["collapsed"] = collapsed
-    case .toolCall(let name, let summary, let status, let isError, let collapsed, let durationMs, let resultStr):
+    case .toolCall(let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let durationMs, let resultStr):
         result["kind"] = "tool_call"; result["name"] = name; result["summary"] = summary
         result["status"] = Int(status); result["is_error"] = isError; result["collapsed"] = collapsed
+        result["auto_approved_scope"] = Int(autoApprovedScope)
         result["duration_ms"] = Int(durationMs); result["result"] = resultStr
-    case .styledToolCall(let name, let summary, let status, let isError, let collapsed, let durationMs, let resultLines):
+    case .styledToolCall(let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let durationMs, let resultLines):
         let linesJSON: [[Any]] = resultLines.map { runs in
             runs.map { run -> [String: Any] in
                 return [
@@ -358,6 +359,7 @@ func chatMessageToJSON(_ msg: Wire.ChatMessage) -> [String: Any] {
         }
         result["kind"] = "styled_tool_call"; result["name"] = name; result["summary"] = summary
         result["status"] = Int(status); result["is_error"] = isError; result["collapsed"] = collapsed
+        result["auto_approved_scope"] = Int(autoApprovedScope)
         result["duration_ms"] = Int(durationMs); result["result_lines"] = linesJSON
     case .approvalToolCall(let name, let summary, let toolCallId, let previewKind, let previewLines):
         result["kind"] = "approval_tool_call"

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -1825,11 +1825,24 @@ struct GUIAgentChatDecoderTests {
         return data
     }
 
-    /// Builds a messages section payload with the given raw message data.
+    /// Builds a legacy unframed messages section payload with the given raw message data.
     private func buildMessagesPayload(count: Int, _ rawMessages: Data) -> Data {
         var payload = Data()
         appendU16(&payload, UInt16(count))
         payload.append(rawMessages)
+        return payload
+    }
+
+    /// Builds the current framed v1 messages section payload.
+    private func buildFramedMessagesPayload(_ messages: [Data]) -> Data {
+        var payload = Data()
+        payload.append(0xFF)
+        payload.append(1)
+        appendU16(&payload, UInt16(messages.count))
+        for message in messages {
+            appendU32(&payload, UInt32(message.count))
+            payload.append(message)
+        }
         return payload
     }
 
@@ -1924,13 +1937,14 @@ struct GUIAgentChatDecoderTests {
         var msgs = Data()
         appendU32(&msgs, 5) // beam_id
         msgs.append(0x04) // tool_call
-        msgs.append(1); msgs.append(0); msgs.append(1); msgs.append(2) // status, isError, collapsed, autoApprovedScope
+        msgs.append(1); msgs.append(0); msgs.append(1) // status, isError, collapsed
         appendU32(&msgs, 1234) // durationMs
         appendString16(&msgs, "read_file")
         appendString16(&msgs, "lib/minga.ex")
         let result = "file contents here"
         appendU32(&msgs, UInt32(result.utf8.count))
         msgs.append(contentsOf: result.utf8)
+        msgs.append(2) // autoApprovedScope at end
 
         let data = buildChatData(status: 2, model: "claude", messages: buildMessagesPayload(count: 1, msgs))
         let (cmd, _) = try decodeCommand(data: data, offset: 0)
@@ -1944,6 +1958,76 @@ struct GUIAgentChatDecoderTests {
         #expect(autoApprovedScope == 2)
         #expect(duration == 1234)
         #expect(tcResult == "file contents here")
+    }
+
+    @Test("Decode gui_agent_chat framed tool_call with auto_approved followed by another message")
+    func decodeFramedToolCallWithAutoApprovedAndTrailingMessage() throws {
+        var toolMessage = Data()
+        appendU32(&toolMessage, 5)
+        toolMessage.append(0x04)
+        toolMessage.append(1); toolMessage.append(0); toolMessage.append(1)
+        appendU32(&toolMessage, 1234)
+        appendString16(&toolMessage, "read_file")
+        appendString16(&toolMessage, "lib/minga.ex")
+        let result = "file contents here"
+        appendU32(&toolMessage, UInt32(result.utf8.count))
+        toolMessage.append(contentsOf: result.utf8)
+        toolMessage.append(2)
+
+        var trailingMessage = Data()
+        appendU32(&trailingMessage, 6)
+        trailingMessage.append(0x01)
+        appendU32(&trailingMessage, 5)
+        trailingMessage.append(contentsOf: "later".utf8)
+
+        let data = buildChatData(status: 2, model: "claude", messages: buildFramedMessagesPayload([toolMessage, trailingMessage]))
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+
+        guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
+        guard messages.count == 2 else { Issue.record("Expected 2 messages"); return }
+        guard case .toolCall(let name, _, _, _, _, let autoApprovedScope, _, let tcResult) = messages[0].content else { Issue.record("Expected .toolCall"); return }
+        guard case .user(let laterText) = messages[1].content else { Issue.record("Expected trailing user message"); return }
+
+        #expect(name == "read_file")
+        #expect(autoApprovedScope == 2)
+        #expect(tcResult == "file contents here")
+        #expect(laterText == "later")
+    }
+
+    @Test("Decode gui_agent_chat legacy tool_call without auto_approved byte")
+    func decodeLegacyToolCallWithoutAutoApproved() throws {
+        var msgs = Data()
+        appendU32(&msgs, 5)
+        msgs.append(0x04)
+        msgs.append(1)
+        msgs.append(0)
+        msgs.append(1)
+        appendU32(&msgs, 1234)
+        appendString16(&msgs, "read_file")
+        appendString16(&msgs, "lib/minga.ex")
+        let result = "file contents here"
+        appendU32(&msgs, UInt32(result.utf8.count))
+        msgs.append(contentsOf: result.utf8)
+
+        appendU32(&msgs, 6)
+        msgs.append(0x01)
+        appendU32(&msgs, 5)
+        msgs.append(contentsOf: "later".utf8)
+
+        let data = buildChatData(status: 2, model: "claude", messages: buildMessagesPayload(count: 2, msgs))
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+
+        guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
+        guard messages.count == 2 else { Issue.record("Expected 2 messages"); return }
+        guard case .toolCall(let name, _, _, _, _, let autoApprovedScope, _, let tcResult) = messages[0].content else { Issue.record("Expected .toolCall"); return }
+        guard case .user(let laterText) = messages[1].content else { Issue.record("Expected trailing user message"); return }
+
+        #expect(name == "read_file")
+        #expect(autoApprovedScope == 0)
+        #expect(tcResult == "file contents here")
+        #expect(laterText == "later")
     }
 
     @Test("Decode gui_agent_chat with inline approval tool call (sectioned)")
@@ -1971,6 +2055,7 @@ struct GUIAgentChatDecoderTests {
         #expect(previewKind == 3)
         #expect(previewLines == ["file: config.toml", "1 edit(s)"])
     }
+
 
     @Test("Decode gui_agent_chat with system message (sectioned)")
     func decodeSystem() throws {
@@ -2056,6 +2141,86 @@ struct GUIAgentChatDecoderTests {
         #expect(lines[0][1].italic == true)
         #expect(lines[1][0].text == "  :ok")
         #expect(lines[1][0].underline == true)
+    }
+
+    @Test("Decode gui_agent_chat framed styled_tool_call with auto_approved followed by another message")
+    func decodeFramedStyledToolCallWithAutoApprovedAndTrailingMessage() throws {
+        var toolMessage = Data()
+        appendU32(&toolMessage, 42)
+        toolMessage.append(0x08)
+        toolMessage.append(1)
+        toolMessage.append(0)
+        toolMessage.append(1)
+        appendU32(&toolMessage, 99)
+        appendString16(&toolMessage, "shell")
+        appendString16(&toolMessage, "🚀🚀🚀")
+        appendU16(&toolMessage, 1)
+        appendU16(&toolMessage, 1)
+        appendString16(&toolMessage, "result")
+        appendRGB(&toolMessage, 0x61, 0xAF, 0xEF)
+        appendRGB(&toolMessage, 0x00, 0x00, 0x00)
+        toolMessage.append(0x01)
+        toolMessage.append(1)
+
+        var trailingMessage = Data()
+        appendU32(&trailingMessage, 43)
+        trailingMessage.append(0x02)
+        appendU32(&trailingMessage, 5)
+        trailingMessage.append(contentsOf: "later".utf8)
+
+        let data = buildChatData(model: "claude", messages: buildFramedMessagesPayload([toolMessage, trailingMessage]))
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+
+        guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
+        guard messages.count == 2 else { Issue.record("Expected 2 messages"); return }
+        guard case .styledToolCall(let name, _, _, _, _, let autoApprovedScope, _, let resultLines) = messages[0].content else { Issue.record("Expected .styledToolCall"); return }
+        guard case .assistant(let laterText) = messages[1].content else { Issue.record("Expected trailing assistant message"); return }
+
+        #expect(name == "shell")
+        #expect(autoApprovedScope == 1)
+        #expect(resultLines.count == 1)
+        #expect(resultLines[0][0].text == "result")
+        #expect(laterText == "later")
+    }
+
+    @Test("Decode gui_agent_chat legacy styled_tool_call without auto_approved byte")
+    func decodeLegacyStyledToolCallWithoutAutoApproved() throws {
+        var msgs = Data()
+        appendU32(&msgs, 42)
+        msgs.append(0x08)
+        msgs.append(1)
+        msgs.append(0)
+        msgs.append(1)
+        appendU32(&msgs, 99)
+        appendString16(&msgs, "shell")
+        appendString16(&msgs, "🚀🚀🚀")
+        appendU16(&msgs, 1)
+        appendU16(&msgs, 1)
+        appendString16(&msgs, "result")
+        appendRGB(&msgs, 0x61, 0xAF, 0xEF)
+        appendRGB(&msgs, 0x00, 0x00, 0x00)
+        msgs.append(0x01)
+
+        appendU32(&msgs, 43)
+        msgs.append(0x02)
+        appendU32(&msgs, 5)
+        msgs.append(contentsOf: "later".utf8)
+
+        let data = buildChatData(model: "claude", messages: buildMessagesPayload(count: 2, msgs))
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+
+        guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
+        guard messages.count == 2 else { Issue.record("Expected 2 messages"); return }
+        guard case .styledToolCall(let name, _, _, _, _, let autoApprovedScope, _, let resultLines) = messages[0].content else { Issue.record("Expected .styledToolCall"); return }
+        guard case .assistant(let laterText) = messages[1].content else { Issue.record("Expected trailing assistant message"); return }
+
+        #expect(name == "shell")
+        #expect(autoApprovedScope == 0)
+        #expect(resultLines.count == 1)
+        #expect(resultLines[0][0].text == "result")
+        #expect(laterText == "later")
     }
 
     @Test("Decode gui_agent_chat styled_assistant link run")

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -1924,7 +1924,7 @@ struct GUIAgentChatDecoderTests {
         var msgs = Data()
         appendU32(&msgs, 5) // beam_id
         msgs.append(0x04) // tool_call
-        msgs.append(1); msgs.append(0); msgs.append(1) // status, isError, collapsed
+        msgs.append(1); msgs.append(0); msgs.append(1); msgs.append(2) // status, isError, collapsed, autoApprovedScope
         appendU32(&msgs, 1234) // durationMs
         appendString16(&msgs, "read_file")
         appendString16(&msgs, "lib/minga.ex")
@@ -1936,11 +1936,12 @@ struct GUIAgentChatDecoderTests {
         let (cmd, _) = try decodeCommand(data: data, offset: 0)
         guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
         guard messages.count == 1 else { Issue.record("Expected 1 message"); return }
-        guard case .toolCall(let name, _, let tcStatus, let isError, let collapsed, let duration, let tcResult) = messages[0].content else { Issue.record("Expected .toolCall"); return }
+        guard case .toolCall(let name, _, let tcStatus, let isError, let collapsed, let autoApprovedScope, let duration, let tcResult) = messages[0].content else { Issue.record("Expected .toolCall"); return }
         #expect(name == "read_file")
         #expect(tcStatus == 1)
         #expect(isError == false)
         #expect(collapsed == true)
+        #expect(autoApprovedScope == 2)
         #expect(duration == 1234)
         #expect(tcResult == "file contents here")
     }

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -359,7 +359,7 @@ struct AgentChatStateLifecycleTests {
             Wire.ChatMessage(beamId: 2, content: .assistant(text: "hi")),
             Wire.ChatMessage(beamId: 3, content: .thinking(text: "analyzing...", collapsed: false)),
             Wire.ChatMessage(beamId: 4, content: .toolCall(name: "read_file", summary: "lib/minga.ex", status: 1, isError: false,
-                     collapsed: true, durationMs: 500, result: "contents")),
+                     collapsed: true, autoApprovedScope: 0, durationMs: 500, result: "contents")),
             Wire.ChatMessage(beamId: 5, content: .system(text: "session started", isError: false)),
             Wire.ChatMessage(beamId: 6, content: .usage(input: 100, output: 50, cacheRead: 80, cacheWrite: 20, costMicros: 5000))
         ]

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -782,6 +782,15 @@ struct WorkspaceHeaderViewTests {
 @Suite("AgentChatView View Structure")
 struct AgentChatViewTests {
 
+    @MainActor private func chatState(messages: [ChatMessageEntry] = []) -> AgentChatState {
+        let state = AgentChatState()
+        state.visible = true
+        state.model = "claude-sonnet-4"
+        state.status = 0
+        state.messages = messages
+        return state
+    }
+
     @Test("Empty messages shows header and prompt area")
     @MainActor func emptyMessages() throws {
         let state = AgentChatState()
@@ -847,6 +856,48 @@ struct AgentChatViewTests {
         }))
         try highButton.tap()
         #expect(spy.guiActions.contains(.executeCommand(name: "agent_thinking_high")))
+    }
+
+    @Test("Approval buttons dispatch the matching trust keypresses")
+    @MainActor func approvalButtonsDispatchKeys() throws {
+        let spy = SpyEncoder()
+        let state = chatState(messages: [
+            .approvalToolCall(id: 1, name: "shell", summary: "git diff --cached", toolCallId: "call-1", previewKind: 2, previewLines: ["git diff --cached"])
+        ])
+
+        let sut = AgentChatView(state: state, theme: ThemeColors(), isInsertMode: false, encoder: spy)
+        let body = try sut.inspect()
+        let buttons = try body.findAll(ViewType.Button.self)
+
+        func tap(_ title: String) throws {
+            let button = try #require(buttons.first(where: {
+                ((try? $0.labelView().text().string()) ?? "") == title
+            }))
+            try button.tap()
+        }
+
+        try tap("Approve (y)")
+        try tap("Trust this tool (a)")
+        try tap("For this turn (t)")
+        try tap("Deny (n)")
+
+        #expect(spy.keyPressCalls.map(\.codepoint) == [0x79, 0x61, 0x74, 0x6E])
+        #expect(spy.keyPressCalls.allSatisfy { $0.modifiers == 0 })
+    }
+
+    @Test("Auto-approved tool calls show the subtle scope pill")
+    @MainActor func autoApprovedIndicatorRenders() throws {
+        let state = chatState(messages: [
+            .toolCall(id: 1, name: "shell", summary: "git diff --cached", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 500, result: ""),
+            .toolCall(id: 2, name: "shell", summary: "git status --short", status: 1, isError: false, collapsed: true, autoApprovedScope: 2, durationMs: 250, result: "")
+        ])
+
+        let sut = AgentChatView(state: state, theme: ThemeColors(), isInsertMode: false, encoder: nil)
+        let body = try sut.inspect()
+        let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("auto-approved · session"))
+        #expect(strings.contains("auto-approved · turn"))
     }
 
     @Test("User message renders as bubble")

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -877,8 +877,8 @@ struct AgentChatViewTests {
         }
 
         try tap("Approve (y)")
-        try tap("Trust this tool (a)")
-        try tap("For this turn (t)")
+        try tap("Trust for session (a)")
+        try tap("Trust for this turn (t)")
         try tap("Deny (n)")
 
         #expect(spy.keyPressCalls.map(\.codepoint) == [0x79, 0x61, 0x74, 0x6E])

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -422,6 +422,90 @@ defmodule MingaAgent.Providers.NativeTest do
       assert Enum.any?(events, &match?(%Event.AgentEnd{}, &1))
     end
 
+    test "tool approval mode :all preserves the batch prompt after per-tool ask overrides", %{
+      tmp_dir: dir
+    } do
+      File.write!(Path.join(dir, "test.txt"), "file contents")
+      File.mkdir_p!(Path.join(dir, "subdir"))
+      call_count = :counters.new(1, [:atomics])
+
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call("read_file", %{"path" => "test.txt"}, %{
+                  id: "tc_1",
+                  index: 0
+                }),
+                ReqLLM.StreamChunk.tool_call("list_directory", %{"path" => "."}, %{
+                  id: "tc_2",
+                  index: 1
+                }),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              [
+                ReqLLM.StreamChunk.text("done"),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+              ]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      tools = Tools.all(project_root: dir)
+
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: dir,
+          llm_client: client,
+          tools: tools,
+          config: agent_config(tool_approval: :all, tool_permissions: %{"read_file" => :ask})
+        )
+
+      assert :ok = Native.send_prompt(pid, "Read the file and then list the directory")
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolApproval{tool_call_id: "tc_1", reply_to: reply_to_1}},
+                     1_000
+
+      send(reply_to_1, {:tool_approval_response, "tc_1", :approve})
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolStart{tool_call_id: "tc_1", name: "read_file"}},
+                     1_000
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolEnd{tool_call_id: "tc_1", name: "read_file", is_error: false}},
+                     1_000
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolApproval{tool_call_id: "tc_2", reply_to: reply_to_2}},
+                     1_000
+
+      send(reply_to_2, {:tool_approval_response, "tc_2", :approve})
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolStart{tool_call_id: "tc_2", name: "list_directory"}},
+                     1_000
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolEnd{
+                        tool_call_id: "tc_2",
+                        name: "list_directory",
+                        is_error: false
+                      }},
+                     1_000
+
+      assert_receive {:agent_provider_event, %Event.AgentEnd{}}, 1_000
+    end
+
     test "uses ProjectView-backed tools when project_view is passed to Native.start_link", %{
       tmp_dir: dir
     } do

--- a/test/minga_agent/session_store_test.exs
+++ b/test/minga_agent/session_store_test.exs
@@ -29,6 +29,7 @@ defmodule MingaAgent.SessionStoreTest do
            result: "defmodule Foo do\nend",
            is_error: false,
            collapsed: true,
+           auto_approved_scope: :session,
            started_at: nil,
            duration_ms: 42
          }},
@@ -92,6 +93,7 @@ defmodule MingaAgent.SessionStoreTest do
       assert tc.name == "read_file"
       assert tc.duration_ms == 42
       assert tc.status == :complete
+      assert tc.auto_approved_scope == :session
     end
 
     test "loads corrupted message atoms defensively", %{tmp_dir: dir} do

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -266,6 +266,26 @@ defmodule MingaAgent.SessionTest do
     session
   end
 
+  defp agent_config(fields) do
+    struct!(MingaAgent.Config, fields)
+  end
+
+  defp build_stream_response(chunks, usage \\ %{}) do
+    {:ok, handle} =
+      ReqLLM.StreamResponse.MetadataHandle.start_link(fn ->
+        %{usage: usage, finish_reason: :stop}
+      end)
+
+    {:ok,
+     %ReqLLM.StreamResponse{
+       stream: chunks,
+       metadata_handle: handle,
+       cancel: fn -> :ok end,
+       model: elem(ReqLLM.model("anthropic:claude-sonnet-4-20250514"), 1),
+       context: ReqLLM.Context.new()
+     }}
+  end
+
   defp send_approval(session, reply_to \\ self()) do
     approval = %Event.ToolApproval{
       tool_call_id: "tc1",
@@ -1029,18 +1049,75 @@ defmodule MingaAgent.SessionTest do
       assert Session.list_tool_trust(session) == %{"read_file" => :session}
     end
 
-    test "turn trust clears before automatically queued follow-up turns" do
-      session = start_subscribed_session()
+    test "turn trust clears before automatically queued follow-up turns", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "test.txt"), "file contents")
+      call_count = :counters.new(1, [:atomics])
 
-      send_provider_event(session, %Event.AgentStart{})
-      assert :ok = Session.set_tool_trust(session, "shell", :turn)
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call("read_file", %{"path" => "test.txt"}, %{
+                  id: "tc_1",
+                  index: 0
+                }),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            1 ->
+              [
+                ReqLLM.StreamChunk.text("first turn done"),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+              ]
+
+            2 ->
+              [
+                ReqLLM.StreamChunk.tool_call("read_file", %{"path" => "test.txt"}, %{
+                  id: "tc_2",
+                  index: 0
+                }),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              [
+                ReqLLM.StreamChunk.text("follow-up done"),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+              ]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      tools = MingaAgent.Tools.all(project_root: dir)
+
+      session =
+        start_subscribed_session(Native,
+          project_root: dir,
+          llm_client: client,
+          tools: tools,
+          config: agent_config(tool_approval: :all),
+          skip_api_key_env: true
+        )
+
+      assert :ok = Session.set_tool_trust(session, "read_file", :turn)
+      assert :ok = Session.send_prompt(session, "Read test.txt")
       assert {:queued, :follow_up} = Session.queue_follow_up(session, "next turn")
 
-      send(session, {:agent_provider_event, %Event.AgentEnd{}})
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
-      await_turn_complete()
+      assert_receive {:agent_event, _, {:tool_auto_approved, _, "read_file", :turn}},
+                     @event_timeout
 
+      assert_receive {:agent_event, _, {:approval_pending, pending}}, @event_timeout
+      assert pending.name == "read_file"
       assert Session.list_tool_trust(session) == %{}
+
+      assert :ok = Session.respond_to_approval(session, :approve)
+      assert_receive {:agent_event, _, {:tool_started, "read_file", _}}, @event_timeout
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "turn trust clears on errors" do

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -920,12 +920,17 @@ defmodule MingaAgent.SessionTest do
     end
 
     test "respond_to_approval resolves each supported decision" do
-      for decision <- [:approve, :reject, :approve_all] do
+      for {decision, execution_decision} <- [
+            {:approve, :approve},
+            {:approve_session, :approve},
+            {:approve_turn, :approve},
+            {:reject, :reject}
+          ] do
         session = start_subscribed_session()
         send_approval(session)
 
         assert :ok = Session.respond_to_approval(session, decision)
-        assert_receive {:tool_approval_response, "tc1", ^decision}, @event_timeout
+        assert_receive {:tool_approval_response, "tc1", ^execution_decision}, @event_timeout
         assert_receive {:agent_event, _, {:approval_resolved, ^decision}}, @event_timeout
         assert {:error, :no_pending_approval} = Session.respond_to_approval(session, :approve)
 
@@ -934,6 +939,138 @@ defmodule MingaAgent.SessionTest do
           assert Enum.any?(messages, &match?({:system, "Denied shell" <> _, :info}, &1))
         end
       end
+    end
+
+    test "approve_session and approve_turn set the matching tool trust scope" do
+      session = start_subscribed_session()
+      send_approval(session)
+      assert :ok = Session.respond_to_approval(session, :approve_session)
+      assert_receive {:tool_approval_response, "tc1", :approve}, @event_timeout
+      assert Session.list_tool_trust(session) == %{"shell" => :session}
+
+      session = start_subscribed_session()
+      send_approval(session)
+      assert :ok = Session.respond_to_approval(session, :approve_turn)
+      assert_receive {:tool_approval_response, "tc1", :approve}, @event_timeout
+      assert Session.list_tool_trust(session) == %{"shell" => :turn}
+    end
+
+    test "bare approve sets no tool trust" do
+      session = start_subscribed_session()
+      send_approval(session)
+      assert :ok = Session.respond_to_approval(session, :approve)
+      assert_receive {:tool_approval_response, "tc1", :approve}, @event_timeout
+      assert Session.list_tool_trust(session) == %{}
+    end
+
+    test "trusted tool approvals are auto-approved without pending approval" do
+      session = start_subscribed_session()
+      assert :ok = Session.set_tool_trust(session, "shell", :session)
+
+      approval = %Event.ToolApproval{
+        tool_call_id: "tc_auto",
+        name: "shell",
+        args: %{"command" => "pwd"},
+        reply_to: self()
+      }
+
+      send_provider_event(session, approval)
+
+      assert_receive {:tool_approval_response, "tc_auto", :approve}, @event_timeout
+
+      assert_receive {:agent_event, _, {:tool_auto_approved, "tc_auto", "shell", :session}},
+                     @event_timeout
+
+      refute_received {:agent_event, _, {:approval_pending, _}}
+      assert {:error, :no_pending_approval} = Session.respond_to_approval(session, :approve)
+    end
+
+    test "auto-approved scope is applied when the tool starts and survives updates" do
+      session = start_subscribed_session()
+      assert :ok = Session.set_tool_trust(session, "shell", :turn)
+
+      approval = %Event.ToolApproval{
+        tool_call_id: "tc_auto",
+        name: "shell",
+        args: %{"command" => "pwd"},
+        reply_to: self()
+      }
+
+      send_provider_event(session, approval)
+      assert_receive {:tool_approval_response, "tc_auto", :approve}, @event_timeout
+
+      send_provider_event(session, %Event.ToolStart{
+        tool_call_id: "tc_auto",
+        name: "shell",
+        args: %{"command" => "pwd"}
+      })
+
+      assert {:tool_call, %{auto_approved_scope: :turn}} =
+               Enum.find(Session.messages(session), &match?({:tool_call, _}, &1))
+
+      send_provider_event(session, %Event.ToolUpdate{
+        tool_call_id: "tc_auto",
+        name: "shell",
+        partial_result: "out"
+      })
+
+      assert {:tool_call, %{auto_approved_scope: :turn, result: "out"}} =
+               Enum.find(Session.messages(session), &match?({:tool_call, _}, &1))
+    end
+
+    test "turn trust clears when the session returns to idle while session trust persists" do
+      session = start_subscribed_session()
+      assert :ok = Session.set_tool_trust(session, "shell", :turn)
+      assert :ok = Session.set_tool_trust(session, "read_file", :session)
+
+      send_provider_event(session, %Event.AgentStart{})
+      send_provider_event(session, %Event.AgentEnd{})
+
+      assert Session.list_tool_trust(session) == %{"read_file" => :session}
+    end
+
+    test "turn trust clears before automatically queued follow-up turns" do
+      session = start_subscribed_session()
+
+      send_provider_event(session, %Event.AgentStart{})
+      assert :ok = Session.set_tool_trust(session, "shell", :turn)
+      assert {:queued, :follow_up} = Session.queue_follow_up(session, "next turn")
+
+      send(session, {:agent_provider_event, %Event.AgentEnd{}})
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
+      await_turn_complete()
+
+      assert Session.list_tool_trust(session) == %{}
+    end
+
+    test "turn trust clears on errors" do
+      session = start_subscribed_session()
+      assert :ok = Session.set_tool_trust(session, "shell", :turn)
+
+      send_provider_event(session, %Event.Error{message: "boom"})
+
+      assert Session.list_tool_trust(session) == %{}
+    end
+
+    test "revoke_tool_trust removes one or all entries" do
+      session = start_subscribed_session()
+      assert :ok = Session.set_tool_trust(session, "shell", :session)
+      assert :ok = Session.set_tool_trust(session, "read_file", :turn)
+
+      assert :ok = Session.revoke_tool_trust(session, "shell")
+      assert Session.list_tool_trust(session) == %{"read_file" => :turn}
+
+      assert :ok = Session.revoke_tool_trust(session, :all)
+      assert Session.list_tool_trust(session) == %{}
+    end
+
+    test "new_session clears session trust" do
+      session = start_subscribed_session()
+      assert :ok = Session.set_tool_trust(session, "shell", :session)
+
+      assert :ok = Session.new_session(session)
+
+      assert Session.list_tool_trust(session) == %{}
     end
 
     test "respond_to_approval with no pending returns error", %{session: session} do

--- a/test/minga_agent/tool_call_test.exs
+++ b/test/minga_agent/tool_call_test.exs
@@ -14,6 +14,7 @@ defmodule MingaAgent.ToolCallTest do
       assert tc.result == ""
       assert tc.is_error == false
       assert tc.collapsed == true
+      assert tc.auto_approved_scope == nil
       assert is_integer(tc.started_at)
       assert tc.duration_ms == nil
     end
@@ -99,6 +100,18 @@ defmodule MingaAgent.ToolCallTest do
       tc = ToolCall.new("tc1", "bash")
       expanded = ToolCall.set_collapsed(tc, false)
       assert expanded.collapsed == false
+    end
+  end
+
+  describe "set_auto_approved_scope/2" do
+    test "records the auto-approval scope" do
+      tc = ToolCall.new("tc1", "bash")
+
+      trusted = ToolCall.set_auto_approved_scope(tc, :session)
+      assert trusted.auto_approved_scope == :session
+
+      cleared = ToolCall.set_auto_approved_scope(trusted, nil)
+      assert cleared.auto_approved_scope == nil
     end
   end
 

--- a/test/minga_editor/agent/chat_decorations_test.exs
+++ b/test/minga_editor/agent/chat_decorations_test.exs
@@ -72,6 +72,32 @@ defmodule MingaEditor.Agent.ChatDecorationsTest do
       assert Decorations.has_fold_regions?(result)
     end
 
+    test "auto-approved tool call shows a subtle header indicator" do
+      tc = %MingaAgent.ToolCall{
+        id: "tc-auto",
+        name: "shell",
+        status: :complete,
+        result: "ok",
+        collapsed: true,
+        auto_approved_scope: :session
+      }
+
+      decs = Decorations.new()
+      messages = [{:tool_call, tc}]
+      offsets = [{0, 0, 1}]
+
+      result = ChatDecorations.build_decorations(decs, messages, offsets, test_theme())
+      {above, _below} = Decorations.blocks_for_line(result, 0)
+
+      rendered_text =
+        above
+        |> List.first()
+        |> then(fn block -> block.render.(80) end)
+        |> Enum.map_join("", fn {text, _style} -> text end)
+
+      assert rendered_text =~ "auto-approved session"
+    end
+
     test "running tool call has no fold (still streaming)" do
       tc = %MingaAgent.ToolCall{
         id: "tc-2",
@@ -119,8 +145,10 @@ defmodule MingaEditor.Agent.ChatDecorationsTest do
       rendered_text = Enum.map_join(rendered, "", fn {text, _style} -> text end)
       assert rendered_text =~ "Approval required"
       assert rendered_text =~ "[y]"
+      assert rendered_text =~ "[a]"
+      assert rendered_text =~ "[t]"
       assert rendered_text =~ "[n]"
-      assert rendered_text =~ "[Y]"
+      refute rendered_text =~ "[Y]"
     end
 
     test "tool call awaiting approval renders preview content" do

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -93,6 +93,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       assert "stop" in names
       assert "thinking" in names
       assert "model" in names
+      assert "trust" in names
       assert "plan" in names
       assert "exec" in names
       assert "resume" in names
@@ -296,6 +297,50 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       :ok = Session.enter_plan(session)
       {:ok, _state} = SlashCommand.execute(mock_state(session: session), "/skill:off:plan")
       assert Session.status(session) == :idle
+    end
+
+    test "/trust list summarizes trusted tools" do
+      session = start_session()
+      :ok = Session.set_tool_trust(session, "shell", :session)
+      :ok = Session.set_tool_trust(session, "write_file", :turn)
+
+      {:ok, state} = SlashCommand.execute(mock_state(session: session), "/trust list")
+
+      assert state.shell_state.status_msg =~ "Trusted tools:"
+      messages = Session.messages(session)
+      assert Enum.any?(messages, &match?({:system, "Trusted tools:" <> _, :info}, &1))
+    end
+
+    test "/trust revoke removes one trusted tool" do
+      session = start_session()
+      :ok = Session.set_tool_trust(session, "shell", :session)
+      :ok = Session.set_tool_trust(session, "write_file", :turn)
+
+      {:ok, state} = SlashCommand.execute(mock_state(session: session), "/trust revoke shell")
+
+      assert state.shell_state.status_msg == "Trust cleared for shell"
+      assert Session.list_tool_trust(session) == %{"write_file" => :turn}
+    end
+
+    test "/trust clear removes all trusted tools" do
+      session = start_session()
+      :ok = Session.set_tool_trust(session, "shell", :session)
+      :ok = Session.set_tool_trust(session, "write_file", :turn)
+
+      {:ok, state} = SlashCommand.execute(mock_state(session: session), "/trust clear")
+
+      assert state.shell_state.status_msg == "All tool trust cleared"
+      assert Session.list_tool_trust(session) == %{}
+    end
+
+    test "/trust without an active session returns a clear error" do
+      assert {:error, "No active agent session"} =
+               SlashCommand.execute(mock_state(), "/trust list")
+    end
+
+    test "/trust usage errors clearly" do
+      assert {:error, "Usage: /trust list|revoke <tool-name>|clear"} =
+               SlashCommand.execute(mock_state(session: start_session()), "/trust revoke")
     end
 
     test "/plan without an active session returns a clear error" do

--- a/test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
@@ -79,13 +79,14 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
       messages_payload = extract_section(binary, 0x06)
       assert <<1::16, 0::32, msg_payload::binary>> = messages_payload
 
-      <<0x08::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32, name_len::16,
-        name::binary-size(name_len), summary_len::16, summary::binary-size(summary_len),
-        line_count::16, rest::binary>> = msg_payload
+      <<0x08::8, status_byte::8, error_byte::8, collapsed_byte::8, auto_approved_byte::8,
+        duration::32, name_len::16, name::binary-size(name_len), summary_len::16,
+        summary::binary-size(summary_len), line_count::16, rest::binary>> = msg_payload
 
       assert status_byte == 1
       assert error_byte == 0
       assert collapsed_byte == 0
+      assert auto_approved_byte == 0
       assert duration == 1234
       assert name == "bash"
       # No args in test data, so summary is empty
@@ -234,6 +235,7 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
         status: :running,
         is_error: false,
         collapsed: true,
+        auto_approved_scope: :session,
         duration_ms: 0,
         result: "file contents"
       }
@@ -248,7 +250,41 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
       }
 
       binary = ProtocolGUI.encode_gui_agent_chat(data)
-      assert :binary.match(binary, <<0x04>>) != :nomatch
+      messages_payload = extract_section(binary, 0x06)
+
+      <<1::16, 0::32, 0x04::8, 0::8, 0::8, 1::8, 1::8, 0::32, _rest::binary>> =
+        messages_payload
+    end
+
+    test "encodes command approval summaries without the short preview cap" do
+      command = String.duplicate("echo long ", 40)
+      tc = MingaAgent.ToolCall.new("tc-approval", "shell", %{"command" => command})
+
+      approval =
+        MingaAgent.ToolApproval.public(
+          MingaAgent.ToolApproval.new(
+            tool_call_id: "tc-approval",
+            name: "shell",
+            args: %{"command" => command}
+          )
+        )
+
+      data = %{
+        visible: true,
+        messages: [{:approval_tool_call, tc, approval}],
+        status: :tool_executing,
+        model: "",
+        prompt: "",
+        pending_approval: nil
+      }
+
+      binary = ProtocolGUI.encode_gui_agent_chat(data)
+      messages_payload = extract_section(binary, 0x06)
+
+      <<1::16, 0::32, 0x09::8, 0::8, name_len::16, _name::binary-size(name_len), summary_len::16,
+        summary::binary-size(summary_len), _rest::binary>> = messages_payload
+
+      assert summary == command
     end
   end
 

--- a/test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
@@ -3,8 +3,19 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
 
   alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
 
-  # Extracts a section payload by ID from a sectioned binary (skips opcode + section_count header)
+  # Extracts a section payload by ID from a sectioned binary.
+  # Message sections are normalized to the legacy count + concatenated messages shape.
   defp extract_section(binary, target_id) do
+    payload = extract_raw_section(binary, target_id)
+
+    if target_id == 0x06 do
+      normalize_messages_payload(payload)
+    else
+      payload
+    end
+  end
+
+  defp extract_raw_section(binary, target_id) do
     <<_opcode::8, section_count::8, rest::binary>> = binary
     find_section(rest, section_count, target_id)
   end
@@ -21,6 +32,24 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
     else
       find_section(rest, remaining - 1, target_id)
     end
+  end
+
+  defp normalize_messages_payload(<<0xFF::8, 1::8, count::16, frames::binary>>) do
+    messages = unwrap_message_frames(frames, count, [])
+    IO.iodata_to_binary([<<count::16>> | messages])
+  end
+
+  defp normalize_messages_payload(payload), do: payload
+
+  defp unwrap_message_frames(<<>>, 0, acc), do: Enum.reverse(acc)
+
+  defp unwrap_message_frames(
+         <<message_len::32, message::binary-size(message_len), rest::binary>>,
+         remaining,
+         acc
+       )
+       when remaining > 0 do
+    unwrap_message_frames(rest, remaining - 1, [message | acc])
   end
 
   describe "decode_gui_action for agent_tool_toggle" do
@@ -79,9 +108,10 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
       messages_payload = extract_section(binary, 0x06)
       assert <<1::16, 0::32, msg_payload::binary>> = messages_payload
 
-      <<0x08::8, status_byte::8, error_byte::8, collapsed_byte::8, auto_approved_byte::8,
-        duration::32, name_len::16, name::binary-size(name_len), summary_len::16,
-        summary::binary-size(summary_len), line_count::16, rest::binary>> = msg_payload
+      <<0x08::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32, name_len::16,
+        name::binary-size(name_len), summary_len::16, summary::binary-size(summary_len),
+        line_count::16, run_count::16, text_len::16, text::binary-size(text_len), fg::24, bg::24,
+        flags::8, auto_approved_byte::8>> = msg_payload
 
       assert status_byte == 1
       assert error_byte == 0
@@ -94,14 +124,31 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
       assert line_count == 1
 
       # Parse the single line's single run
-      <<run_count::16, text_len::16, text::binary-size(text_len), fg::24, bg::24, flags::8>> =
-        rest
-
       assert run_count == 1
       assert text == "hello"
       assert fg == 0xFF0000
       assert bg == 0x000000
       assert flags == 0x01
+    end
+
+    test "frames chat messages with deterministic v1 message lengths" do
+      data = %{
+        visible: true,
+        messages: [{1, {:user, "hello"}}, {2, {:assistant, "hi"}}],
+        status: :idle,
+        model: "test",
+        prompt: "",
+        pending_approval: nil
+      }
+
+      binary = ProtocolGUI.encode_gui_agent_chat(data)
+      messages_payload = extract_raw_section(binary, 0x06)
+
+      assert <<0xFF::8, 1::8, 2::16, first_len::32, first::binary-size(first_len), second_len::32,
+               second::binary-size(second_len)>> = messages_payload
+
+      assert <<1::32, 0x01::8, 5::32, "hello">> = first
+      assert <<2::32, 0x02::8, 2::32, "hi">> = second
     end
 
     test "encodes styled assistant link runs with url metadata" do
@@ -252,8 +299,14 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
       binary = ProtocolGUI.encode_gui_agent_chat(data)
       messages_payload = extract_section(binary, 0x06)
 
-      <<1::16, 0::32, 0x04::8, 0::8, 0::8, 1::8, 1::8, 0::32, _rest::binary>> =
-        messages_payload
+      <<1::16, 0::32, 0x04::8, 0::8, 0::8, 1::8, 0::32, name_len::16, name::binary-size(name_len),
+        summary_len::16, summary::binary-size(summary_len), result_len::32,
+        result::binary-size(result_len), auto_approved_byte::8>> = messages_payload
+
+      assert name == "read"
+      assert summary == ""
+      assert result == "file contents"
+      assert auto_approved_byte == 1
     end
 
     test "encodes command approval summaries without the short preview cap" do
@@ -285,6 +338,102 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
         summary::binary-size(summary_len), _rest::binary>> = messages_payload
 
       assert summary == command
+    end
+
+    test "encodes long multibyte shell summaries within UTF-8 byte limits" do
+      command = String.duplicate("🚀", 20_000)
+      tc = MingaAgent.ToolCall.new("tc-multi", "shell", %{"command" => command})
+
+      approval =
+        MingaAgent.ToolApproval.public(
+          MingaAgent.ToolApproval.new(
+            tool_call_id: "tc-multi",
+            name: "shell",
+            args: %{"command" => command}
+          )
+        )
+
+      tool_binary =
+        ProtocolGUI.encode_gui_agent_chat(%{
+          visible: true,
+          messages: [{:tool_call, tc}],
+          status: :idle,
+          model: "",
+          prompt: "",
+          pending_approval: nil
+        })
+
+      approval_binary =
+        ProtocolGUI.encode_gui_agent_chat(%{
+          visible: true,
+          messages: [{:approval_tool_call, tc, approval}],
+          status: :tool_executing,
+          model: "",
+          prompt: "",
+          pending_approval: nil
+        })
+
+      tool_payload = extract_section(tool_binary, 0x06)
+      approval_payload = extract_section(approval_binary, 0x06)
+
+      <<1::16, 0::32, 0x04::8, _status::8, _error::8, _collapsed::8, _duration::32, name_len::16,
+        _name::binary-size(name_len), tool_summary_len::16,
+        tool_summary::binary-size(tool_summary_len), result_len::32,
+        _result::binary-size(result_len), _auto::8>> = tool_payload
+
+      assert tool_summary_len <= 65_535
+      assert String.valid?(tool_summary)
+      assert String.ends_with?(tool_summary, "… [truncated]")
+
+      <<1::16, 0::32, 0x09::8, 0::8, name_len::16, _name::binary-size(name_len),
+        approval_summary_len::16, approval_summary::binary-size(approval_summary_len),
+        _rest::binary>> = approval_payload
+
+      assert approval_summary_len <= 65_535
+      assert String.valid?(approval_summary)
+      assert String.ends_with?(approval_summary, "… [truncated]")
+    end
+
+    test "encodes long multibyte styled tool summaries within UTF-8 byte limits" do
+      command = String.duplicate("🚀", 20_000)
+
+      tc = %MingaAgent.ToolCall{
+        id: "tc-styled-multi",
+        name: "shell",
+        args: %{"command" => command},
+        status: :complete,
+        is_error: false,
+        collapsed: false,
+        duration_ms: 42,
+        result: "ok"
+      }
+
+      styled_lines = [
+        [{"result", 0x61AFEF, 0x000000, 0x01}]
+      ]
+
+      binary =
+        ProtocolGUI.encode_gui_agent_chat(%{
+          visible: true,
+          messages: [{:styled_tool_call, tc, styled_lines}],
+          status: :idle,
+          model: "",
+          prompt: "",
+          pending_approval: nil
+        })
+
+      messages_payload = extract_section(binary, 0x06)
+
+      <<1::16, 0::32, 0x08::8, _status::8, _error::8, _collapsed::8, _duration::32, name_len::16,
+        _name::binary-size(name_len), summary_len::16, summary::binary-size(summary_len),
+        line_count::16, run_count::16, text_len::16, _text::binary-size(text_len), _fg::24,
+        _bg::24, _flags::8, _auto_approved::8>> = messages_payload
+
+      assert line_count == 1
+      assert run_count == 1
+      assert summary_len <= 60_000
+      assert String.valid?(summary)
+      assert String.ends_with?(summary, "… [truncated]")
     end
   end
 

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -3,8 +3,15 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
   alias MingaEditor.Frontend.Protocol
 
-  defp gui_agent_chat_section!(sections, target_id),
-    do: do_gui_agent_chat_section!(sections, target_id)
+  defp gui_agent_chat_section!(sections, target_id) do
+    payload = do_gui_agent_chat_section!(sections, target_id)
+
+    if target_id == 0x06 do
+      normalize_messages_payload(payload)
+    else
+      payload
+    end
+  end
 
   defp do_gui_agent_chat_section!(
          <<target_id::8, len::16, payload::binary-size(len), _rest::binary>>,
@@ -17,6 +24,24 @@ defmodule MingaEditor.Frontend.ProtocolTest do
          target_id
        ),
        do: do_gui_agent_chat_section!(rest, target_id)
+
+  defp normalize_messages_payload(<<0xFF::8, 1::8, count::16, frames::binary>>) do
+    messages = unwrap_message_frames(frames, count, [])
+    IO.iodata_to_binary([<<count::16>> | messages])
+  end
+
+  defp normalize_messages_payload(payload), do: payload
+
+  defp unwrap_message_frames(<<>>, 0, acc), do: Enum.reverse(acc)
+
+  defp unwrap_message_frames(
+         <<message_len::32, message::binary-size(message_len), rest::binary>>,
+         remaining,
+         acc
+       )
+       when remaining > 0 do
+    unwrap_message_frames(rest, remaining - 1, [message | acc])
+  end
 
   defp take_string16(<<len::16, value::binary-size(len), rest::binary>>), do: {value, rest}
   defp take_string8(<<len::8, value::binary-size(len), rest::binary>>), do: {value, rest}

--- a/test/minga_editor/input/scoped_test.exs
+++ b/test/minga_editor/input/scoped_test.exs
@@ -652,7 +652,7 @@ defmodule MingaEditor.Input.ScopedTest do
     end
 
     test "approval decision keys are handled", %{state: state} do
-      for key <- [?y, ?n, ?Y] do
+      for key <- [?y, ?a, ?t, ?n] do
         assert {:handled, _new_state} = walk_surface_handlers(state, key, 0)
       end
     end

--- a/test/minga_editor/input/sub_state_handlers_test.exs
+++ b/test/minga_editor/input/sub_state_handlers_test.exs
@@ -146,9 +146,14 @@ defmodule MingaEditor.Input.SubStateHandlersTest do
       {:handled, _} = ToolApproval.handle_key(state, ?n, 0)
     end
 
-    test "handles uppercase Y as approve all when approval is pending", %{approval: approval} do
+    test "handles a as session trust when approval is pending", %{approval: approval} do
       state = base_state(keymap_scope: :agent, agentic_active: true, pending_approval: approval)
-      {:handled, _} = ToolApproval.handle_key(state, ?Y, 0)
+      {:handled, _} = ToolApproval.handle_key(state, ?a, 0)
+    end
+
+    test "handles t as turn trust when approval is pending", %{approval: approval} do
+      state = base_state(keymap_scope: :agent, agentic_active: true, pending_approval: approval)
+      {:handled, _} = ToolApproval.handle_key(state, ?t, 0)
     end
 
     test "swallows unrelated keys when approval is pending", %{approval: approval} do

--- a/test/minga_editor/input/sub_state_handlers_test.exs
+++ b/test/minga_editor/input/sub_state_handlers_test.exs
@@ -141,6 +141,11 @@ defmodule MingaEditor.Input.SubStateHandlersTest do
       {:handled, _} = ToolApproval.handle_key(state, ?y, 0)
     end
 
+    test "handles Enter when approval is pending", %{approval: approval} do
+      state = base_state(keymap_scope: :agent, agentic_active: true, pending_approval: approval)
+      {:handled, _} = ToolApproval.handle_key(state, 13, 0)
+    end
+
     test "handles n when approval is pending", %{approval: approval} do
       state = base_state(keymap_scope: :agent, agentic_active: true, pending_approval: approval)
       {:handled, _} = ToolApproval.handle_key(state, ?n, 0)

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -273,6 +273,7 @@ defmodule Minga.Integration.GUIProtocolTest do
         status: :complete,
         is_error: false,
         collapsed: false,
+        auto_approved_scope: :turn,
         duration_ms: 1500,
         result: "output text"
       }
@@ -306,6 +307,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert msg["status"] == 1
       assert msg["is_error"] == false
       assert msg["collapsed"] == false
+      assert msg["auto_approved_scope"] == 2
       assert msg["duration_ms"] == 1500
       assert length(msg["result_lines"]) == 2
 
@@ -324,6 +326,7 @@ defmodule Minga.Integration.GUIProtocolTest do
         status: :running,
         is_error: false,
         collapsed: true,
+        auto_approved_scope: :session,
         duration_ms: 0,
         result: "file content here"
       }
@@ -349,6 +352,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert msg["kind"] == "tool_call"
       assert msg["name"] == "read_file"
       assert msg["collapsed"] == true
+      assert msg["auto_approved_scope"] == 1
       assert msg["result"] == "file content here"
     end
 


### PR DESCRIPTION
# TL;DR
Agent tool approvals now show the concrete command/path being approved and support per-tool trust for this call, the current turn, or the rest of the session. Trusted tools auto-approve without showing a blocking banner and surface a subtle auto-approved indicator in the agent UI.

Closes #1156

## Context
Issue #1156 called out two trust and usability gaps in agent tool approval: the approval banner did not make the requested action prominent, and users had to approve repeated calls to the same tool one at a time. This PR keeps trust state on `MingaAgent.Session`, where approval replies already flow, and extends the GUI chat protocol so native frontends can render auto-approved tool calls without a banner flash.

## Changes
- Added session and turn scoped per-tool trust APIs on `MingaAgent.Session`, including auto-approval interception, pending auto-approval propagation to tool calls, turn-scope cleanup, and revoke/list support.
- Replaced the old approve-all flow with `y/a/t/n` approval decisions: approve once, trust this tool for session, trust this tool for the current turn, or deny.
- Added `/trust list`, `/trust revoke <tool>`, and `/trust clear` slash commands with system messages for user-visible trust management.
- Added `auto_approved_scope` to `MingaAgent.ToolCall`, session persistence, the GUI chat protocol, Swift decoder/state, and macOS tool call card rendering.
- Reworked approval card rendering so the tool summary is inline and prominent, with shell commands shown in a horizontal scroll area instead of being truncated to one line.
- Updated TUI agent chat decorations and tests so approval prompts and auto-approved indicators match the new trust model.

## Verification
- `git diff --check` passed.
- `make lint` passed.
- `mix test.llm` passed: 52 doctests, 99 properties, 8193 tests, 0 failures, 5 skipped, 198 excluded.
- `mix swift.build` was attempted and skipped locally because `xcodebuild` is not installed in this Linux environment.
- `mix swift.harness` was attempted and blocked locally because `swiftc` is not installed in this Linux environment.

## Acceptance Criteria Addressed
- Approval banner prominently displays the tool summary at the same visual weight as the tool name. ✅
- Shell commands are sent with the full command summary and rendered in a horizontal scroll area when long. ✅
- Approval options include `y`, `a`, `t`, and `n`. ✅
- Session-level trust persists until the session ends or trust is cleared. ✅
- Turn-level trust clears when the current response completes, including queued follow-up turns. ✅
- Trusted tools auto-approve and show a subtle auto-approved indicator in the tool call card header. ✅
- Users can revoke session trust with `/trust revoke <tool>` or clear all trust with `/trust clear`. ✅
- Keyboard shortcuts for all approval options work in the approval input handler. ✅

## Notes for Reviewers
Swift compile and harness checks need to run on a machine with Xcode or Swift installed. The local Linux environment has neither `xcodebuild` nor `swiftc`, so the Swift changes were validated by decoder/test updates and BEAM protocol tests here, with toolchain verification left to CI or a macOS developer machine.
