### PR TITLE
feat(git): add branch picker delete flow

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -607,8 +607,10 @@ Mode values:
 | 5 | substitute_confirm | `"replace with foo?"` | no | `"y/n/a/q (2 of 15)"` |
 | 6 | extension_confirm | (plugin prompt) | no | (empty) |
 | 7 | describe_key | `"Press key: "` | no | (accumulated keys) |
+| 8 | delete_confirm | `"Delete 'file.txt'? (y/n)"` | no | (empty) |
+| 9 | branch_delete_confirm | `"Delete branch feature? (y/n)"` | no | (empty) |
 
-`cursor_pos` is the 0-indexed character position within `input` for the beam cursor. `0xFFFF` means no cursor (prompt-only modes 5-7). `context` is right-aligned supplementary text. `match_score` is 0-255 fuzzy match quality. `candidate_count == 0` naturally represents "input visible, no completions."
+`cursor_pos` is the 0-indexed character position within `input` for the beam cursor. `0xFFFF` means no cursor (prompt-only modes 5-9). `context` is right-aligned supplementary text. `match_score` is 0-255 fuzzy match quality. `candidate_count == 0` naturally represents "input visible, no completions."
 
 ### 0x80 — gui_window_content (sectioned format)
 

--- a/lib/minga/mode.ex
+++ b/lib/minga/mode.ex
@@ -44,6 +44,7 @@ defmodule Minga.Mode do
           | :extension_confirm
           | :tool_confirm
           | :delete_confirm
+          | :branch_delete_confirm
 
   @typedoc """
   A command to execute. Either a bare atom (e.g. `:move_left`) or a
@@ -70,6 +71,7 @@ defmodule Minga.Mode do
           | Minga.Mode.ExtensionConfirmState.t()
           | Minga.Mode.ToolConfirmState.t()
           | Minga.Mode.DeleteConfirmState.t()
+          | Minga.Mode.BranchDeleteConfirmState.t()
 
   @typedoc """
   Result returned by a mode's `handle_key/2`.
@@ -136,6 +138,7 @@ defmodule Minga.Mode do
   def display(:extension_confirm), do: "-- UPDATE --"
   def display(:tool_confirm), do: "-- INSTALL? --"
   def display(:delete_confirm), do: "-- DELETE? --"
+  def display(:branch_delete_confirm), do: "-- DELETE BRANCH? --"
 
   @doc """
   Returns the status-line label for a mode, using the FSM state for
@@ -188,6 +191,14 @@ defmodule Minga.Mode do
     "Cannot trash. Permanently delete '#{s.name}'? (y/n)"
   end
 
+  def display(:branch_delete_confirm, %Minga.Mode.BranchDeleteConfirmState{phase: :delete} = s) do
+    "Delete branch #{s.name}? (y/n)"
+  end
+
+  def display(:branch_delete_confirm, %Minga.Mode.BranchDeleteConfirmState{phase: :force} = s) do
+    "Force delete branch #{s.name}? (y/n)"
+  end
+
   def display(mode, _state), do: display(mode)
 
   # ── Private ──────────────────────────────────────────────────────────────────
@@ -206,6 +217,7 @@ defmodule Minga.Mode do
   defp mode_module(:extension_confirm), do: Minga.Mode.ExtensionConfirm
   defp mode_module(:tool_confirm), do: Minga.Mode.ToolConfirm
   defp mode_module(:delete_confirm), do: Minga.Mode.DeleteConfirm
+  defp mode_module(:branch_delete_confirm), do: Minga.Mode.BranchDeleteConfirm
 
   @spec apply_result(mode(), result()) :: {mode(), [command()], state()}
   defp apply_result(mode, {:continue, state}) do

--- a/lib/minga/mode/branch_delete_confirm.ex
+++ b/lib/minga/mode/branch_delete_confirm.ex
@@ -1,0 +1,39 @@
+defmodule Minga.Mode.BranchDeleteConfirm do
+  @moduledoc """
+  Git branch delete confirmation mode.
+
+  Prompts the user before deleting a branch from the branch picker. If safe deletion reports unmerged commits, the command re-enters this mode with a force-delete prompt.
+  """
+
+  @behaviour Minga.Mode
+
+  alias Minga.Mode
+  alias Minga.Mode.BranchDeleteConfirmState
+
+  @escape 27
+
+  @impl Mode
+  @spec handle_key(Mode.key(), BranchDeleteConfirmState.t()) :: Mode.result()
+
+  def handle_key({?y, _mods}, %BranchDeleteConfirmState{phase: :delete} = state) do
+    commands = [{:branch_delete_confirm, state.git_root, state.name, false}]
+    {:execute_then_transition, commands, :normal, state}
+  end
+
+  def handle_key({?y, _mods}, %BranchDeleteConfirmState{phase: :force} = state) do
+    commands = [{:branch_delete_confirm, state.git_root, state.name, true}]
+    {:execute_then_transition, commands, :normal, state}
+  end
+
+  def handle_key({?n, _mods}, %BranchDeleteConfirmState{} = state) do
+    {:execute_then_transition, [:branch_delete_cancel], :normal, state}
+  end
+
+  def handle_key({@escape, _mods}, %BranchDeleteConfirmState{} = state) do
+    {:execute_then_transition, [:branch_delete_cancel], :normal, state}
+  end
+
+  def handle_key(_key, %BranchDeleteConfirmState{} = state) do
+    {:continue, state}
+  end
+end

--- a/lib/minga/mode/branch_delete_confirm_state.ex
+++ b/lib/minga/mode/branch_delete_confirm_state.ex
@@ -1,0 +1,32 @@
+defmodule Minga.Mode.BranchDeleteConfirmState do
+  @moduledoc """
+  FSM state for confirming git branch deletion.
+
+  Holds the git root, branch name, and whether the prompt is the initial safe delete or the force-delete fallback after git reports unmerged commits.
+  """
+
+  @enforce_keys [:git_root, :name]
+  defstruct [:git_root, :name, phase: :delete, reason: nil, count: nil]
+
+  @type phase :: :delete | :force
+
+  @type t :: %__MODULE__{
+          git_root: String.t(),
+          name: String.t(),
+          phase: phase(),
+          reason: String.t() | nil,
+          count: non_neg_integer() | nil
+        }
+
+  @doc "Creates a new branch delete confirmation state."
+  @spec new(String.t(), String.t()) :: t()
+  def new(git_root, name) when is_binary(git_root) and is_binary(name) do
+    %__MODULE__{git_root: git_root, name: name}
+  end
+
+  @doc "Transitions to the force-delete confirmation prompt."
+  @spec to_force(t(), String.t()) :: t()
+  def to_force(%__MODULE__{} = state, reason) when is_binary(reason) do
+    %{state | phase: :force, reason: reason}
+  end
+end

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -26,6 +26,7 @@ defmodule MingaEditor.Commands do
 
   alias Minga.Buffer
   alias Minga.Command
+  alias Minga.Git
   alias MingaEditor.Commands.Agent, as: AgentCommands
   alias MingaEditor.Commands.BufferManagement
   alias MingaEditor.Commands.Editing, as: EditingCommands
@@ -270,6 +271,29 @@ defmodule MingaEditor.Commands do
 
   def execute(state, :delete_confirm_cancel) do
     restore_file_tree_scope(state)
+  end
+
+  # ── Branch delete confirmation commands ───────────────────────────────────
+
+  def execute(state, {:branch_delete_confirm, git_root, name, force}) do
+    case Git.branch_delete(git_root, name, force) do
+      :ok ->
+        refresh_branch_delete_repo(git_root)
+        MingaEditor.log_to_messages("[git] Deleted branch: #{name}")
+
+        state
+        |> EditorState.set_status("Deleted branch #{name}")
+        |> MingaEditor.PickerUI.open(MingaEditor.UI.Picker.GitBranchSource)
+
+      {:error, reason} ->
+        handle_branch_delete_error(state, git_root, name, force, reason)
+    end
+  end
+
+  def execute(state, :branch_delete_cancel) do
+    state
+    |> EditorState.set_status("Branch delete cancelled")
+    |> MingaEditor.PickerUI.open(MingaEditor.UI.Picker.GitBranchSource)
   end
 
   # ── Agent tuple commands ──────────────────────────────────────────────────
@@ -662,6 +686,44 @@ defmodule MingaEditor.Commands do
   @spec normalize_options_server(term() | nil) :: Minga.Config.Options.server()
   defp normalize_options_server(nil), do: Minga.Config.Options.default_server()
   defp normalize_options_server(server), do: Minga.Config.Options.validate_server!(server)
+
+  @spec handle_branch_delete_error(state(), String.t(), String.t(), boolean(), String.t()) ::
+          state()
+  defp handle_branch_delete_error(state, git_root, name, false, reason) do
+    if forceable_branch_delete_error?(reason) do
+      mode_state =
+        git_root
+        |> Minga.Mode.BranchDeleteConfirmState.new(name)
+        |> Minga.Mode.BranchDeleteConfirmState.to_force(reason)
+
+      state
+      |> EditorState.set_status("Delete failed: #{reason}")
+      |> EditorState.transition_mode(:branch_delete_confirm, mode_state)
+    else
+      EditorState.set_status(state, "Delete failed: #{reason}")
+    end
+  end
+
+  defp handle_branch_delete_error(state, _git_root, _name, true, reason) do
+    EditorState.set_status(state, "Force delete failed: #{reason}")
+  end
+
+  @spec forceable_branch_delete_error?(String.t()) :: boolean()
+  defp forceable_branch_delete_error?(reason) do
+    normalized = String.downcase(reason)
+
+    String.contains?(normalized, "not fully merged") or
+      String.contains?(normalized, "unmerged") or
+      String.contains?(normalized, "not merged")
+  end
+
+  @spec refresh_branch_delete_repo(String.t()) :: :ok
+  defp refresh_branch_delete_repo(git_root) do
+    case Git.lookup_repo(git_root) do
+      nil -> :ok
+      pid -> Git.Repo.refresh(pid)
+    end
+  end
 
   # Remove the current tool from the prompt queue after accept/decline.
   @spec drain_tool_prompt_queue(state()) :: state()

--- a/lib/minga_editor/minibuffer_data.ex
+++ b/lib/minga_editor/minibuffer_data.ex
@@ -60,6 +60,8 @@ defmodule MingaEditor.MinibufferData do
   @mode_substitute_confirm 5
   @mode_extension_confirm 6
   @mode_describe_key 7
+  @mode_delete_confirm 8
+  @mode_branch_delete_confirm 9
 
   # Maximum candidates to send (keep the list manageable)
   @max_candidates 15
@@ -172,6 +174,32 @@ defmodule MingaEditor.MinibufferData do
       mode: @mode_extension_confirm,
       cursor_pos: 0xFFFF,
       prompt: prompt,
+      input: "",
+      context: "",
+      selected_index: 0,
+      candidates: []
+    }
+  end
+
+  def from_state(%{workspace: %{editing: %{mode: :delete_confirm, mode_state: ms}}}) do
+    %__MODULE__{
+      visible: true,
+      mode: @mode_delete_confirm,
+      cursor_pos: 0xFFFF,
+      prompt: Minga.Mode.display(:delete_confirm, ms),
+      input: "",
+      context: "",
+      selected_index: 0,
+      candidates: []
+    }
+  end
+
+  def from_state(%{workspace: %{editing: %{mode: :branch_delete_confirm, mode_state: ms}}}) do
+    %__MODULE__{
+      visible: true,
+      mode: @mode_branch_delete_confirm,
+      cursor_pos: 0xFFFF,
+      prompt: Minga.Mode.display(:branch_delete_confirm, ms),
       input: "",
       context: "",
       selected_index: 0,

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -25,6 +25,7 @@ defmodule MingaEditor.PickerUI do
   alias MingaEditor.State.WhichKey, as: WhichKeyState
   alias MingaEditor.UI.Picker
   alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.Item
 
   import Bitwise
 
@@ -172,8 +173,9 @@ defmodule MingaEditor.PickerUI do
         update_picker(state, &%{&1 | action_menu: nil})
 
       {{_name, action_id}, item} ->
-        new_state = close(update_picker(state, &%{&1 | action_menu: nil}))
-        source.on_action(action_id, item, new_state)
+        state
+        |> update_picker(&%{&1 | action_menu: nil})
+        |> run_source_action_and_close(source, action_id, item)
     end
   end
 
@@ -330,6 +332,31 @@ defmodule MingaEditor.PickerUI do
     end
   end
 
+  # C-d → branch picker delete flow only. Keeps printable `d` available for
+  # normal picker filtering, including sources that define alternative delete
+  # actions for other purposes.
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+          state,
+        ?d,
+        mods
+      )
+      when band(mods, @ctrl) != 0 and source == MingaEditor.UI.Picker.GitBranchSource do
+    case Picker.selected_item(picker) do
+      %Item{id: {:branch, _name, _current?, true}} ->
+        state
+
+      %Item{id: {:branch, _name, true, false}} = item ->
+        run_source_action_and_close(state, source, :delete, item)
+
+      %Item{id: {:branch, _name, false, false}} = item ->
+        run_source_action_and_close(state, source, :delete, item)
+
+      _other ->
+        state
+    end
+  end
+
   # Backspace (with mode-switch detection: if query becomes empty and we're in a switched mode, switch back)
   def handle_key(
         %{
@@ -373,21 +400,32 @@ defmodule MingaEditor.PickerUI do
         state
 
       c ->
-        # Check if this is a mode-switching prefix (first char, empty query, switchable source)
-        case maybe_switch_mode(state, c, picker.query) do
-          {:switched, new_state} ->
-            new_state
-
-          :no_switch ->
-            new_picker = Picker.type_char(picker, c)
-            state = update_picker(state, &%{&1 | picker: new_picker})
-            maybe_preview_selection(state)
-        end
+        type_printable_char(state, picker, c)
     end
   end
 
   # Ignore all other keys
   def handle_key(state, _cp, _mods), do: state
+
+  @spec run_source_action_and_close(EditorState.t(), module(), atom(), Picker.item()) ::
+          EditorState.t()
+  defp run_source_action_and_close(state, source, action_id, item) do
+    new_state = close(state)
+    source.on_action(action_id, item, new_state)
+  end
+
+  @spec type_printable_char(EditorState.t(), Picker.t(), String.t()) :: EditorState.t()
+  defp type_printable_char(state, picker, char) do
+    case maybe_switch_mode(state, char, picker.query) do
+      {:switched, new_state} ->
+        new_state
+
+      :no_switch ->
+        new_picker = Picker.type_char(picker, char)
+        state = update_picker(state, &%{&1 | picker: new_picker})
+        maybe_preview_selection(state)
+    end
+  end
 
   @spec select_item(EditorState.t(), Picker.item(), module()) ::
           EditorState.t() | {EditorState.t(), {:execute_command, atom()}}

--- a/lib/minga_editor/renderer/minibuffer.ex
+++ b/lib/minga_editor/renderer/minibuffer.ex
@@ -126,6 +126,22 @@ defmodule MingaEditor.Renderer.Minibuffer do
     )
   end
 
+  def render(
+        %{workspace: %{editing: %{mode: :branch_delete_confirm, mode_state: ms}}, theme: theme},
+        row,
+        cols
+      ) do
+    prompt = Minga.Mode.display(:branch_delete_confirm, ms)
+    mb = theme.minibuffer
+
+    DisplayList.draw(
+      row,
+      0,
+      String.pad_trailing(prompt, cols),
+      Face.new(fg: mb.fg, bg: mb.bg)
+    )
+  end
+
   def render(%{workspace: %{editing: %{mode: :command, mode_state: ms}}, theme: theme}, row, cols) do
     cmd_text = ":" <> ms.input
     mb = theme.minibuffer

--- a/lib/minga_editor/shell/traditional/modeline.ex
+++ b/lib/minga_editor/shell/traditional/modeline.ex
@@ -936,6 +936,7 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
   defp mode_badge(:extension_confirm, _state), do: "UPDATE"
   defp mode_badge(:tool_confirm, _state), do: "INSTALL"
   defp mode_badge(:delete_confirm, _state), do: "DELETE"
+  defp mode_badge(:branch_delete_confirm, _state), do: "BRANCH DEL"
 
   @spec filetype_label(atom()) :: String.t()
   defp filetype_label(filetype) do

--- a/lib/minga_editor/ui/picker/git_branch_source.ex
+++ b/lib/minga_editor/ui/picker/git_branch_source.ex
@@ -50,7 +50,47 @@ defmodule MingaEditor.UI.Picker.GitBranchSource do
     end
   end
 
+  def on_select(%Item{id: {:branch, name, _current?, _remote?}}, state) do
+    switch_branch(name, state)
+  end
+
   def on_select(%Item{id: {:branch, name}}, state) do
+    switch_branch(name, state)
+  end
+
+  def on_select(_, state), do: state
+
+  @impl true
+  @spec actions(Item.t()) :: [MingaEditor.UI.Picker.Source.action_entry()]
+  def actions(%Item{id: {:branch, _name, false, false}}), do: [{"Delete", :delete}]
+  def actions(_item), do: []
+
+  @impl true
+  @spec on_action(atom(), Item.t(), term()) :: term()
+  def on_action(:delete, %Item{id: {:branch, _name, true, false}}, state) do
+    MingaEditor.State.set_status(state, "Cannot delete current branch")
+  end
+
+  def on_action(:delete, %Item{id: {:branch, name, false, false}}, state) do
+    case resolve_git_root() do
+      nil ->
+        MingaEditor.State.set_status(state, "Not in a git repository")
+
+      git_root ->
+        mode_state = Minga.Mode.BranchDeleteConfirmState.new(git_root, name)
+        MingaEditor.State.transition_mode(state, :branch_delete_confirm, mode_state)
+    end
+  end
+
+  def on_action(_action, _item, state), do: state
+
+  @impl true
+  def on_cancel(state), do: state
+
+  # ── Private ────────────────────────────────────────────────────────────
+
+  @spec switch_branch(String.t(), term()) :: term()
+  defp switch_branch(name, state) do
     case resolve_git_root() do
       nil ->
         MingaEditor.State.set_status(state, "Not in a git repository")
@@ -66,13 +106,6 @@ defmodule MingaEditor.UI.Picker.GitBranchSource do
         end
     end
   end
-
-  def on_select(_, state), do: state
-
-  @impl true
-  def on_cancel(state), do: state
-
-  # ── Private ────────────────────────────────────────────────────────────
 
   @spec build_candidates(String.t()) :: [Item.t()]
   defp build_candidates(git_root) do
@@ -93,20 +126,20 @@ defmodule MingaEditor.UI.Picker.GitBranchSource do
 
   @spec format_branch(Git.BranchInfo.t()) :: Item.t()
   defp format_branch(branch) do
-    annotation =
-      cond do
-        branch.current -> "✓"
-        branch.remote -> "remote"
-        true -> nil
-      end
+    annotation = branch_annotation(branch)
 
     %Item{
-      id: {:branch, branch.name},
+      id: {:branch, branch.name, branch.current, branch.remote},
       label: branch.name,
       description: branch_description(branch),
       annotation: annotation
     }
   end
+
+  @spec branch_annotation(Git.BranchInfo.t()) :: String.t() | nil
+  defp branch_annotation(%Git.BranchInfo{current: true}), do: "✓"
+  defp branch_annotation(%Git.BranchInfo{remote: true}), do: "remote"
+  defp branch_annotation(%Git.BranchInfo{}), do: nil
 
   @spec branch_description(Git.BranchInfo.t()) :: String.t()
   defp branch_description(branch) do

--- a/lib/minga_editor/vim_state.ex
+++ b/lib/minga_editor/vim_state.ex
@@ -104,6 +104,7 @@ defmodule MingaEditor.VimState do
   defp expected_struct(:extension_confirm), do: Minga.Mode.ExtensionConfirmState
   defp expected_struct(:tool_confirm), do: Minga.Mode.ToolConfirmState
   defp expected_struct(:delete_confirm), do: Minga.Mode.DeleteConfirmState
+  defp expected_struct(:branch_delete_confirm), do: Minga.Mode.BranchDeleteConfirmState
 
   @doc """
   Transitions to a new mode, returning an updated VimState.

--- a/macos/Sources/Views/MinibufferState.swift
+++ b/macos/Sources/Views/MinibufferState.swift
@@ -27,6 +27,8 @@ enum MinibufferMode: UInt8 {
     case substituteConfirm = 5
     case extensionConfirm = 6
     case describeKey = 7
+    case deleteConfirm = 8
+    case branchDeleteConfirm = 9
 }
 
 @MainActor

--- a/macos/Sources/Views/StatusBarView.swift
+++ b/macos/Sources/Views/StatusBarView.swift
@@ -194,9 +194,6 @@ struct StatusBarView: View {
     private let rightFixedControlsWidth: CGFloat = 34
     private let maxCenterStatusWidth: CGFloat = 320
 
-    @State private var gitCopied = false
-    @State private var gitCopyResetTask: Task<Void, Never>?
-
     var body: some View {
         GeometryReader { proxy in
             let layout = modelineLayout(totalWidth: proxy.size.width)
@@ -347,7 +344,7 @@ struct StatusBarView: View {
         case "filename":
             filenameSegment(group: group, command: command(in: group))
         case "git":
-            if state.hasGit && !state.gitBranch.isEmpty { gitSegment }
+            if state.hasGit && !state.gitBranch.isEmpty { gitSegment(command: command(in: group)) }
         case "agent":
             agentStatusIcon
         case "background_agent":
@@ -437,34 +434,25 @@ struct StatusBarView: View {
     }
 
     @ViewBuilder
-    private var gitSegment: some View {
+    private func gitSegment(command: String?) -> some View {
         Button(action: {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(state.gitBranch, forType: .string)
-            gitCopied = true
-            gitCopyResetTask?.cancel()
-            gitCopyResetTask = Task { @MainActor in
-                try? await Task.sleep(for: .seconds(2))
-                guard !Task.isCancelled else { return }
-                gitCopied = false
-                gitCopyResetTask = nil
-            }
+            encoder?.sendExecuteCommand(name: command ?? "git_branch_picker")
         }) {
             HStack(spacing: 3) {
-                Image(systemName: gitCopied ? "checkmark" : "arrow.triangle.branch")
+                Image(systemName: "arrow.triangle.branch")
                     .font(.system(size: 9, weight: .medium))
-                Text(gitCopied ? "Copied!" : state.gitBranch)
+                Text(state.gitBranch)
                     .font(.system(size: 11))
                     .lineLimit(1)
 
-                if !gitCopied && gitSyncing {
+                if gitSyncing {
                     ProgressView()
                         .controlSize(.mini)
                         .scaleEffect(0.45)
                         .frame(width: 12, height: barHeight)
                 }
 
-                if !gitCopied, state.hasGitDiffStats {
+                if state.hasGitDiffStats {
                     HStack(spacing: 4) {
                         if state.gitAdded > 0 {
                             Text("+\(state.gitAdded)")
@@ -487,15 +475,11 @@ struct StatusBarView: View {
             .foregroundStyle(theme.modelineBarFg.opacity(0.6))
         }
         .buttonStyle(.plain)
-        .help("Click to copy branch name")
-        .accessibilityLabel(gitCopied ? "Git branch copied" : "Git branch \(state.gitBranch)")
-        .accessibilityHint("Copies the branch name")
+        .help("Open branch picker")
+        .accessibilityLabel("Git branch \(state.gitBranch)")
+        .accessibilityHint("Opens the branch picker")
         .padding(.horizontal, 6)
         .statusBarPointingHand()
-        .onDisappear {
-            gitCopyResetTask?.cancel()
-            gitCopyResetTask = nil
-        }
     }
 
     @ViewBuilder

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -505,6 +505,32 @@ struct StatusBarViewViewTests {
         #expect(strings.contains("NORMAL"))
     }
 
+    @Test("Git branch click opens branch picker")
+    @MainActor func gitBranchClickOpensBranchPicker() throws {
+        let spy = SpyEncoder()
+        let state = StatusBarState()
+        state.update(from: StatusBarUpdate(
+            contentKind: 0, mode: 0, cursorLine: 1, cursorCol: 1,
+            lineCount: 1, flags: 0x02, lspStatus: 0, gitBranch: "main",
+            message: "", filetype: "", errorCount: 0, warningCount: 0,
+            modelName: "", messageCount: 0, sessionStatus: 0,
+            infoCount: 0, hintCount: 0, macroRecording: 0, parserStatus: 0, agentStatus: 0,
+            gitAdded: 0, gitModified: 0, gitDeleted: 0,
+            icon: "", iconColorR: 0, iconColorG: 0, iconColorB: 0, filename: "", diagnosticHint: "",
+            backgroundSubagentCount: 0, backgroundSubagentLabel: "",
+            modelineLeftSegments: [segment(0, " main ", kind: "git")], modelineRightSegments: []
+        ))
+
+        let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: spy)
+        let buttons = try sut.inspect().findAll(ViewType.Button.self)
+
+        for button in buttons {
+            try button.tap()
+        }
+
+        #expect(spy.guiActions.contains(.executeCommand(name: "git_branch_picker")))
+    }
+
     @Test("Git branch shown when flag is set")
     @MainActor func gitBranch() throws {
         let state = StatusBarState()

--- a/test/minga/mode/branch_delete_confirm_display_test.exs
+++ b/test/minga/mode/branch_delete_confirm_display_test.exs
@@ -1,0 +1,22 @@
+defmodule Minga.Mode.BranchDeleteConfirmDisplayTest do
+  @moduledoc "Tests display text for branch delete confirmation prompts."
+  use ExUnit.Case, async: true
+
+  alias Minga.Mode
+  alias Minga.Mode.BranchDeleteConfirmState
+
+  test "safe delete prompt includes branch name" do
+    state = BranchDeleteConfirmState.new("/repo", "feature")
+
+    assert Mode.display(:branch_delete_confirm, state) == "Delete branch feature? (y/n)"
+  end
+
+  test "force delete prompt includes branch name" do
+    state =
+      "/repo"
+      |> BranchDeleteConfirmState.new("feature")
+      |> BranchDeleteConfirmState.to_force("not fully merged")
+
+    assert Mode.display(:branch_delete_confirm, state) == "Force delete branch feature? (y/n)"
+  end
+end

--- a/test/minga/mode/branch_delete_confirm_test.exs
+++ b/test/minga/mode/branch_delete_confirm_test.exs
@@ -1,0 +1,42 @@
+defmodule Minga.Mode.BranchDeleteConfirmTest do
+  @moduledoc "Tests for git branch delete confirmation mode."
+  use ExUnit.Case, async: true
+
+  alias Minga.Mode.BranchDeleteConfirm
+  alias Minga.Mode.BranchDeleteConfirmState
+
+  describe "handle_key/2" do
+    test "y confirms safe branch deletion" do
+      state = BranchDeleteConfirmState.new("/repo", "feature")
+
+      assert {:execute_then_transition, [{:branch_delete_confirm, "/repo", "feature", false}],
+              :normal, ^state} = BranchDeleteConfirm.handle_key({?y, 0}, state)
+    end
+
+    test "y confirms force branch deletion in force phase" do
+      state =
+        "/repo"
+        |> BranchDeleteConfirmState.new("feature")
+        |> BranchDeleteConfirmState.to_force("not fully merged")
+
+      assert {:execute_then_transition, [{:branch_delete_confirm, "/repo", "feature", true}],
+              :normal, ^state} = BranchDeleteConfirm.handle_key({?y, 0}, state)
+    end
+
+    test "n and escape cancel" do
+      state = BranchDeleteConfirmState.new("/repo", "feature")
+
+      assert {:execute_then_transition, [:branch_delete_cancel], :normal, ^state} =
+               BranchDeleteConfirm.handle_key({?n, 0}, state)
+
+      assert {:execute_then_transition, [:branch_delete_cancel], :normal, ^state} =
+               BranchDeleteConfirm.handle_key({27, 0}, state)
+    end
+
+    test "other keys are ignored" do
+      state = BranchDeleteConfirmState.new("/repo", "feature")
+
+      assert {:continue, ^state} = BranchDeleteConfirm.handle_key({?x, 0}, state)
+    end
+  end
+end

--- a/test/minga/mode/properties_test.exs
+++ b/test/minga/mode/properties_test.exs
@@ -14,6 +14,7 @@ defmodule Minga.Mode.PropertiesTest do
   alias Minga.Mode
 
   alias Minga.Mode.{
+    BranchDeleteConfirmState,
     CommandState,
     DeleteConfirmState,
     EvalState,
@@ -47,7 +48,8 @@ defmodule Minga.Mode.PropertiesTest do
     :substitute_confirm,
     :extension_confirm,
     :tool_confirm,
-    :delete_confirm
+    :delete_confirm,
+    :branch_delete_confirm
   ]
 
   # Modes Mode.process/3 actually dispatches. :visual_line and :visual_block
@@ -67,7 +69,8 @@ defmodule Minga.Mode.PropertiesTest do
     :substitute_confirm,
     :extension_confirm,
     :tool_confirm,
-    :delete_confirm
+    :delete_confirm,
+    :branch_delete_confirm
   ]
 
   defp base_state do
@@ -107,6 +110,10 @@ defmodule Minga.Mode.PropertiesTest do
 
   defp default_mode_state(:delete_confirm) do
     %DeleteConfirmState{path: "/tmp/x", name: "x", dir?: false}
+  end
+
+  defp default_mode_state(:branch_delete_confirm) do
+    %BranchDeleteConfirmState{git_root: "/tmp/repo", name: "feature"}
   end
 
   # Codepoints span ASCII (0..127) so the generator hits printable characters

--- a/test/minga_editor/commands/git_branch_delete_test.exs
+++ b/test/minga_editor/commands/git_branch_delete_test.exs
@@ -1,0 +1,100 @@
+defmodule MingaEditor.Commands.GitBranchDeleteTest do
+  @moduledoc "Tests branch delete confirmation command handling."
+
+  # Uses the global Minga.Project singleton to verify picker reopen behavior.
+  use ExUnit.Case, async: false
+
+  alias Minga.Git
+  alias Minga.Git.Stub, as: GitStub
+  alias Minga.Mode.BranchDeleteConfirmState
+  alias MingaEditor.Commands
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.UI.Picker
+  alias MingaEditor.Viewport
+
+  setup %{tmp_dir: dir} do
+    reset_global_project!()
+    GitStub.set_root(dir, dir)
+
+    GitStub.set_branches(dir, [
+      %Git.BranchInfo{name: "main", current: true},
+      %Git.BranchInfo{name: "feature", current: false}
+    ])
+
+    Minga.Project.switch(dir)
+    await_project_rebuild(dir)
+
+    on_exit(fn ->
+      GitStub.clear(dir)
+      reset_global_project!()
+    end)
+
+    %{git_root: dir}
+  end
+
+  @tag :tmp_dir
+  test "successful branch delete reports success and reopens the branch picker", %{
+    git_root: git_root
+  } do
+    state = build_state()
+
+    result = Commands.execute(state, {:branch_delete_confirm, git_root, "feature", false})
+
+    assert result.shell_state.status_msg == "Deleted branch feature"
+
+    assert {:picker,
+            %{picker_ui: %{source: MingaEditor.UI.Picker.GitBranchSource, picker: picker}}} =
+             result.shell_state.modal
+
+    assert %Picker{items: items} = picker
+    refute Enum.any?(items, fn item -> item.label == "feature" end)
+  end
+
+  @tag :tmp_dir
+  test "unmerged safe-delete failure enters force confirmation", %{git_root: git_root} do
+    GitStub.set_branch_delete_result(git_root, "feature", false, {:error, "not fully merged"})
+    state = build_state()
+
+    result = Commands.execute(state, {:branch_delete_confirm, git_root, "feature", false})
+
+    assert result.shell_state.status_msg == "Delete failed: not fully merged"
+    assert result.workspace.editing.mode == :branch_delete_confirm
+
+    assert %BranchDeleteConfirmState{name: "feature", phase: :force, reason: "not fully merged"} =
+             result.workspace.editing.mode_state
+  end
+
+  @tag :tmp_dir
+  test "force delete failure reports force-specific error", %{git_root: git_root} do
+    GitStub.set_branch_delete_result(git_root, "feature", true, {:error, "branch not found"})
+    state = build_state()
+
+    result = Commands.execute(state, {:branch_delete_confirm, git_root, "feature", true})
+
+    assert result.shell_state.status_msg == "Force delete failed: branch not found"
+  end
+
+  defp build_state do
+    %EditorState{port_manager: nil, workspace: %SessionState{viewport: Viewport.new(24, 80)}}
+  end
+
+  defp reset_global_project! do
+    root = File.cwd!()
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(root)
+    await_project_rebuild(root)
+  end
+
+  defp await_project_rebuild(root) do
+    state = :sys.get_state(Minga.Project)
+
+    if state.rebuilding? do
+      assert_receive {:minga_event, :project_rebuilt,
+                      %Minga.Events.ProjectRebuiltEvent{root: ^root}},
+                     5_000
+    end
+
+    :sys.get_state(Minga.Project)
+  end
+end

--- a/test/minga_editor/frontend/gui_minibuffer_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_minibuffer_protocol_test.exs
@@ -114,6 +114,24 @@ defmodule MingaEditor.Frontend.GUIMinibufferProtocolTest do
                "y/n/a/q (2 of 15)", 0::16, 0::16, 0::16>> = result
     end
 
+    test "branch delete confirm mode 9 encodes with no cursor" do
+      data = %MinibufferData{
+        visible: true,
+        mode: 9,
+        cursor_pos: 0xFFFF,
+        prompt: "Force delete branch feature? (y/n)",
+        input: "",
+        context: "",
+        selected_index: 0,
+        candidates: []
+      }
+
+      result = ProtocolGUI.encode_gui_minibuffer(data)
+
+      assert <<@op_gui_minibuffer, 1, 9, 0xFFFF::16, 34, "Force delete branch feature? (y/n)",
+               0::16, "", 0::16, "", 0::16, 0::16, 0::16>> = result
+    end
+
     test "match_score is clamped to 255" do
       data = %MinibufferData{
         visible: true,

--- a/test/minga_editor/minibuffer_data_test.exs
+++ b/test/minga_editor/minibuffer_data_test.exs
@@ -179,6 +179,48 @@ defmodule MingaEditor.MinibufferDataTest do
     end
   end
 
+  describe "from_state/1 branch delete confirm" do
+    test "shows branch delete confirmation prompt" do
+      state = %{
+        workspace: %{
+          editing: %{
+            mode: :branch_delete_confirm,
+            mode_state: Minga.Mode.BranchDeleteConfirmState.new("/repo", "feature")
+          }
+        }
+      }
+
+      result = MinibufferData.from_state(state)
+
+      assert result.visible == true
+      assert result.mode == 9
+      assert result.cursor_pos == 0xFFFF
+      assert result.prompt == "Delete branch feature? (y/n)"
+      assert result.candidates == []
+    end
+
+    test "force delete fallback shows a force prompt" do
+      state = %{
+        workspace: %{
+          editing: %{
+            mode: :branch_delete_confirm,
+            mode_state:
+              Minga.Mode.BranchDeleteConfirmState.new("/repo", "feature")
+              |> Minga.Mode.BranchDeleteConfirmState.to_force("not fully merged")
+          }
+        }
+      }
+
+      result = MinibufferData.from_state(state)
+
+      assert result.visible == true
+      assert result.mode == 9
+      assert result.cursor_pos == 0xFFFF
+      assert result.prompt == "Force delete branch feature? (y/n)"
+      assert result.candidates == []
+    end
+  end
+
   describe "from_state/1 describe key" do
     test "accumulates pressed keys into context" do
       state = %{

--- a/test/minga_editor/picker_branch_delete_shortcut_test.exs
+++ b/test/minga_editor/picker_branch_delete_shortcut_test.exs
@@ -1,0 +1,106 @@
+defmodule MingaEditor.PickerBranchDeleteShortcutTest do
+  @moduledoc "Tests the branch picker Ctrl-D shortcut in a serial test because it uses the global Minga.Project singleton."
+
+  use ExUnit.Case, async: false
+
+  alias Minga.Git
+  alias Minga.Git.Stub, as: GitStub
+  alias MingaEditor.PickerUI
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.State.Picker, as: PickerState
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.UI.Picker
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: dir} do
+    reset_global_project!()
+    GitStub.set_root(dir, dir)
+
+    GitStub.set_branches(dir, [
+      %Git.BranchInfo{name: "main", current: true},
+      %Git.BranchInfo{name: "feature", current: false}
+    ])
+
+    Minga.Project.switch(dir)
+    await_project_rebuild(dir)
+
+    on_exit(fn ->
+      GitStub.clear(dir)
+      reset_global_project!()
+    end)
+
+    %{git_root: dir}
+  end
+
+  test "Ctrl-D on a non-current local branch enters branch delete confirm", %{git_root: git_root} do
+    picker =
+      Picker.new([%Item{id: {:branch, "feature", false, false}, label: "feature"}],
+        title: "Switch Branch"
+      )
+
+    state = picker_state(picker)
+
+    result = PickerUI.handle_key(state, ?d, MingaEditor.Input.mod_ctrl())
+
+    assert result.shell_state.modal == :none
+    assert result.workspace.editing.mode == :branch_delete_confirm
+
+    assert %Minga.Mode.BranchDeleteConfirmState{git_root: ^git_root, name: "feature"} =
+             result.workspace.editing.mode_state
+  end
+
+  test "Ctrl-D on the current branch closes the picker and reports the error" do
+    picker =
+      Picker.new([%Item{id: {:branch, "main", true, false}, label: "main"}],
+        title: "Switch Branch"
+      )
+
+    state = picker_state(picker)
+
+    result = PickerUI.handle_key(state, ?d, MingaEditor.Input.mod_ctrl())
+
+    assert result.shell_state.modal == :none
+    assert result.shell_state.status_msg == "Cannot delete current branch"
+    assert result.workspace.editing.mode == :normal
+  end
+
+  defp picker_state(picker) do
+    picker_state = %PickerState{
+      picker: picker,
+      source: MingaEditor.UI.Picker.GitBranchSource,
+      restore: 0
+    }
+
+    %EditorState{
+      port_manager: nil,
+      workspace: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()},
+      shell_state: %MingaEditor.Shell.Traditional.State{
+        modal: {:picker, PickerPayload.new(picker_state)}
+      }
+    }
+  end
+
+  defp reset_global_project! do
+    root = File.cwd!()
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(root)
+    await_project_rebuild(root)
+  end
+
+  defp await_project_rebuild(root) do
+    state = :sys.get_state(Minga.Project)
+
+    if state.rebuilding? do
+      assert_receive {:minga_event, :project_rebuilt,
+                      %Minga.Events.ProjectRebuiltEvent{root: ^root}},
+                     5_000
+    end
+
+    :sys.get_state(Minga.Project)
+  end
+end

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -399,6 +399,32 @@ defmodule MingaEditor.PickerUITest do
     end
   end
 
+  describe "branch delete shortcut" do
+    test "plain d remains query input for a generic picker that exposes delete actions" do
+      picker =
+        Picker.new([%Item{id: :delete_me, label: "Delete me"}], title: "Delete Action Test")
+
+      picker_state = %PickerState{
+        picker: picker,
+        source: Minga.Test.DeleteActionPickerSource,
+        restore: 0
+      }
+
+      state = %EditorState{
+        port_manager: nil,
+        workspace: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()},
+        shell_state: %ShellState{modal: {:picker, PickerPayload.new(picker_state)}}
+      }
+
+      result = PickerUI.handle_key(state, ?d, 0)
+      {:picker, %{picker_ui: picker_ui}} = result.shell_state.modal
+
+      assert picker_ui.picker.query == "d"
+      assert result.shell_state.status_msg == nil
+      assert result.workspace.editing.mode == :normal
+    end
+  end
+
   describe "preview promotion" do
     test "restores the original tab before creating the promoted preview tab" do
       {state, original_buf, preview_buf} = preview_promotion_state()

--- a/test/minga_editor/ui/picker/git_branch_source_test.exs
+++ b/test/minga_editor/ui/picker/git_branch_source_test.exs
@@ -1,0 +1,38 @@
+defmodule MingaEditor.UI.Picker.GitBranchSourceTest do
+  @moduledoc "Tests branch picker branch-management actions."
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.UI.Picker.GitBranchSource
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.Viewport
+
+  test "local branch items expose a delete action" do
+    item = %Item{id: {:branch, "feature", false, false}, label: "feature"}
+
+    assert [{"Delete", :delete}] = GitBranchSource.actions(item)
+  end
+
+  test "current and remote branch items do not expose delete actions" do
+    current = %Item{id: {:branch, "main", true, false}, label: "main"}
+    remote = %Item{id: {:branch, "origin/main", false, true}, label: "origin/main"}
+
+    assert GitBranchSource.actions(current) == []
+    assert GitBranchSource.actions(remote) == []
+  end
+
+  test "delete action on current branch reports an error without entering confirmation" do
+    state = %EditorState{
+      port_manager: nil,
+      workspace: %SessionState{viewport: Viewport.new(24, 80)}
+    }
+
+    item = %Item{id: {:branch, "main", true, false}, label: "main"}
+
+    result = GitBranchSource.on_action(:delete, item, state)
+
+    assert result.shell_state.status_msg == "Cannot delete current branch"
+    assert result.workspace.editing.mode == :normal
+  end
+end

--- a/test/support/delete_action_picker_source.ex
+++ b/test/support/delete_action_picker_source.ex
@@ -1,0 +1,37 @@
+defmodule Minga.Test.DeleteActionPickerSource do
+  @moduledoc "Test picker source with a delete action for PickerUI action dispatch regressions."
+
+  @behaviour MingaEditor.UI.Picker.Source
+
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.UI.Picker.Item
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Delete Action Test"
+
+  @impl true
+  @spec candidates(term()) :: [Item.t()]
+  def candidates(_ctx), do: [%Item{id: :delete_me, label: "Delete me"}]
+
+  @impl true
+  @spec on_select(Item.t(), term()) :: term()
+  def on_select(%Item{}, state), do: state
+
+  @impl true
+  @spec on_cancel(term()) :: term()
+  def on_cancel(state), do: state
+
+  @impl true
+  @spec actions(Item.t()) :: [MingaEditor.UI.Picker.Source.action_entry()]
+  def actions(%Item{id: :delete_me}), do: [{"Delete", :delete}]
+  def actions(_item), do: []
+
+  @impl true
+  @spec on_action(atom(), Item.t(), term()) :: term()
+  def on_action(:delete, %Item{id: :delete_me}, state) do
+    EditorState.set_status(state, "Deleted via action")
+  end
+
+  def on_action(_action, _item, state), do: state
+end

--- a/test/support/git_stub.ex
+++ b/test/support/git_stub.ex
@@ -99,6 +99,8 @@ defmodule Minga.Git.Stub do
     :ets.match_delete(@table, {{:log, expanded}, :_})
     :ets.match_delete(@table, {{:diff, expanded}, :_})
     :ets.match_delete(@table, {{:branch, expanded}, :_})
+    :ets.match_delete(@table, {{:branches, expanded}, :_})
+    :ets.match_delete(@table, {{:branch_delete, expanded, :_, :_}, :_})
     :ets.match_delete(@table, {{:ahead_behind, expanded}, :_})
     :ets.match_delete(@table, {{:last_commit_message, expanded}, :_})
     :ok
@@ -230,8 +232,19 @@ defmodule Minga.Git.Stub do
   def branch_switch(_git_root, _name), do: :ok
 
   @impl true
-  @spec branch_delete(String.t(), String.t(), boolean()) :: :ok
-  def branch_delete(_git_root, _name, _force \\ false), do: :ok
+  @spec branch_delete(String.t(), String.t(), boolean()) :: :ok | {:error, String.t()}
+  def branch_delete(git_root, name, force \\ false) do
+    expanded = Path.expand(git_root)
+
+    case :ets.lookup(@table, {:branch_delete, expanded, name, force}) do
+      [{_, result}] ->
+        result
+
+      [] ->
+        delete_branch_from_list(expanded, name)
+        :ok
+    end
+  end
 
   @impl true
   @spec push(String.t(), keyword()) :: :ok
@@ -246,6 +259,22 @@ defmodule Minga.Git.Stub do
   def fetch_remotes(_git_root, _opts \\ []), do: :ok
 
   # ── Additional Stub Configuration ─────────────────────────────────────
+
+  @doc "Sets the branches returned for `git_root`."
+  @spec set_branches(String.t(), [Minga.Git.BranchInfo.t()]) :: :ok
+  def set_branches(git_root, branches) when is_list(branches) do
+    :ets.insert(@table, {{:branches, Path.expand(git_root)}, branches})
+    :ok
+  end
+
+  @doc "Sets the result returned by branch_delete/3 for a branch and force flag."
+  @spec set_branch_delete_result(String.t(), String.t(), boolean(), :ok | {:error, String.t()}) ::
+          :ok
+  def set_branch_delete_result(git_root, name, force, result)
+      when is_binary(name) and is_boolean(force) do
+    :ets.insert(@table, {{:branch_delete, Path.expand(git_root), name, force}, result})
+    :ok
+  end
 
   @doc "Sets the ahead/behind counts for a git root."
   @spec set_ahead_behind(String.t(), non_neg_integer(), non_neg_integer()) :: :ok
@@ -262,6 +291,19 @@ defmodule Minga.Git.Stub do
   end
 
   # ── Private ────────────────────────────────────────────────────────────
+
+  @spec delete_branch_from_list(String.t(), String.t()) :: :ok
+  defp delete_branch_from_list(git_root, name) do
+    case :ets.lookup(@table, {:branches, git_root}) do
+      [{_, branches}] ->
+        updated = Enum.reject(branches, fn branch -> branch.name == name end)
+        :ets.insert(@table, {{:branches, git_root}, updated})
+        :ok
+
+      [] ->
+        :ok
+    end
+  end
 
   # Walks up the directory tree looking for a registered root, just like
   # real git walks up looking for .git/.


### PR DESCRIPTION
# TL;DR
Branch picker users can now delete local branches from the picker with confirmation, including a force-delete fallback for unmerged branches. The macOS status bar branch segment now opens the branch picker through the existing execute-command GUI action path.

Closes #1032

## Context
Issue #1032 tracks two gaps from the branch picker work: branch deletion was implemented in the Git backend but not exposed in the picker UI, and the native macOS branch status segment did not open the branch picker when clicked.

## Changes
- Added a `branch_delete_confirm` Vim mode and minibuffer rendering path for `Delete branch {name}? (y/n)` and force-delete confirmation.
- Wired branch picker item delete actions so `Ctrl-D` on a local branch starts the delete flow without stealing plain `d` from picker filtering.
- Blocks deleting the current branch with a status message, and keeps remote branches out of the local delete action path.
- Handles safe delete errors for unmerged branches by offering a force-delete confirmation, then reopens the branch picker after successful deletion.
- Changed the macOS status bar git branch segment to call `sendExecuteCommand(name: "git_branch_picker")`, while still respecting BEAM-provided command overrides.
- Documented GUI minibuffer modes 8 and 9 for delete confirmation prompts.
- Added regression coverage for mode dispatch, picker action dispatch, branch delete command handling, minibuffer data and wire encoding, Git branch source behavior, and the SwiftUI branch-click command.

## Verification
- `make lint` passed.
- `mix test.llm` passed: 52 doctests, 99 properties, 8193 tests, 0 failures.
- Focused tests passed: branch delete shortcut, PickerUI, branch delete commands, minibuffer data, GUI minibuffer protocol, and Git branch source tests.
- `git diff --check` passed.
- `mix swift.build` could not build locally because this environment has no `xcodebuild`; it prints `xcodebuild not found; skipping Swift build`.
- `mix swift.harness` could not run locally because this environment has no `swiftc`.

## Acceptance Criteria Addressed
- Branch delete from picker with a designated key (`Ctrl-D`) ✅
- Confirmation prompt via minibuffer ✅
- Force delete option when safe delete reports unmerged commits ✅
- Current branch delete is blocked with an error message ✅
- Picker refreshes by reopening after deletion ✅
- GUI status bar branch click opens `:git_branch_picker` via `gui_action` execute-command dispatch ✅

---
**Updated after review:** Changed the direct delete shortcut from plain `d` to `Ctrl-D` so normal picker filtering remains safe, added refresh/force-prompt coverage, and updated GUI protocol docs for minibuffer modes 8 and 9.
