### PR TITLE
feat(git): add GUI side-by-side diff view

### DIFF
--- a/lib/minga/core/diff_view.ex
+++ b/lib/minga/core/diff_view.ex
@@ -8,12 +8,21 @@ defmodule Minga.Core.DiffView do
 
   alias Minga.Core.Diff
 
+  @type line_type :: :context | :added | :removed | :header | :fold
+  @type pane_line_type :: :context | :added | :removed | :blank | :fold
+
   @typedoc "Metadata for a single display line in the diff view."
   @type line_meta :: %{
-          type: :context | :added | :removed | :header | :fold,
-          original_line: non_neg_integer() | nil,
-          fold_count: non_neg_integer() | nil,
-          word_changes: [Diff.char_range()] | nil
+          required(:type) => line_type(),
+          required(:original_line) => non_neg_integer() | nil,
+          required(:fold_count) => non_neg_integer() | nil,
+          required(:word_changes) => [Diff.char_range()] | nil,
+          optional(:left_type) => pane_line_type(),
+          optional(:right_type) => pane_line_type(),
+          optional(:left_width) => pos_integer(),
+          optional(:separator_col) => non_neg_integer(),
+          optional(:left_word_changes) => [Diff.char_range()] | nil,
+          optional(:right_word_changes) => [Diff.char_range()] | nil
         }
 
   @typedoc "Result of building a diff view: the text content and per-line metadata."
@@ -29,12 +38,22 @@ defmodule Minga.Core.DiffView do
            | {:unpaired_new, String.t(), non_neg_integer()}
 
   @typep indexed_line :: {String.t(), non_neg_integer()}
+  @typep side_by_side_line :: %{
+           left: String.t(),
+           right: String.t(),
+           left_type: pane_line_type(),
+           right_type: pane_line_type(),
+           original_line: non_neg_integer() | nil,
+           fold_count: non_neg_integer() | nil,
+           left_word_changes: [Diff.char_range()] | nil,
+           right_word_changes: [Diff.char_range()] | nil
+         }
 
   @context_lines 3
   @fold_threshold 6
   @line_pair_similarity_threshold 0.35
   @max_line_pair_similarity_attempts 400
-
+  @default_side_by_side_pane_width 80
   @doc """
   Builds a unified diff view from base and current content.
 
@@ -87,7 +106,343 @@ defmodule Minga.Core.DiffView do
     }
   end
 
+  @doc """
+  Builds a GUI side-by-side diff view from base and current content.
+
+  The result uses one rendered buffer line per aligned row. The left pane carries the old version, the right pane carries the new version, and blank filler rows preserve vertical alignment across additions and deletions. Metadata includes pane-local change ranges so GUI decorations can highlight each pane independently.
+  """
+  @spec build_side_by_side(String.t(), String.t(), pos_integer()) :: diff_view_result()
+  def build_side_by_side(
+        base_content,
+        current_content,
+        pane_width \\ @default_side_by_side_pane_width
+      ) do
+    base_lines = split_lines(base_content)
+    current_lines = split_lines(current_content)
+    hunks = Diff.diff_lines(base_lines, current_lines)
+
+    build_side_by_side_from_hunks(base_lines, current_lines, hunks, pane_width)
+  end
+
+  @doc """
+  Builds a GUI side-by-side diff view from pre-computed hunks.
+  """
+  @spec build_side_by_side_from_hunks([String.t()], [String.t()], [Diff.hunk()], pos_integer()) ::
+          diff_view_result()
+  def build_side_by_side_from_hunks(_base_lines, _current_lines, [], pane_width) do
+    {line, meta} = format_side_by_side_line(no_changes_side_by_side_line(), pane_width)
+
+    %{
+      text: line,
+      line_metadata: [meta],
+      hunk_lines: []
+    }
+  end
+
+  def build_side_by_side_from_hunks(base_lines, current_lines, hunks, pane_width) do
+    regions = build_side_by_side_regions(base_lines, current_lines, hunks)
+
+    {display_lines, metadata, hunk_indices} =
+      Enum.reduce(regions, {[], [], []}, fn
+        {:context, ctx_lines, start_orig}, {lines_acc, meta_acc, hunk_acc} ->
+          add_context_side_by_side(
+            lines_acc,
+            meta_acc,
+            hunk_acc,
+            ctx_lines,
+            start_orig,
+            pane_width
+          )
+
+        {:hunk, hunk}, {lines_acc, meta_acc, hunk_acc} ->
+          display_line_idx = length(lines_acc)
+
+          add_hunk_side_by_side(
+            lines_acc,
+            meta_acc,
+            hunk_acc,
+            hunk,
+            current_lines,
+            display_line_idx,
+            pane_width
+          )
+      end)
+
+    %{
+      text: Enum.join(display_lines, "\n"),
+      line_metadata: metadata,
+      hunk_lines: Enum.reverse(hunk_indices)
+    }
+  end
+
   # ── Private ────────────────────────────────────────────────────────────
+
+  @spec add_hunk_side_by_side(
+          [String.t()],
+          [line_meta()],
+          [non_neg_integer()],
+          Diff.hunk(),
+          [String.t()],
+          non_neg_integer(),
+          pos_integer()
+        ) :: {[String.t()], [line_meta()], [non_neg_integer()]}
+  defp add_hunk_side_by_side(
+         lines_acc,
+         meta_acc,
+         hunk_acc,
+         hunk,
+         current_lines,
+         display_line_idx,
+         pane_width
+       ) do
+    side_lines = build_hunk_side_by_side(hunk, current_lines)
+    hunk_acc = [display_line_idx + length(side_lines) - 1 | hunk_acc]
+    {hunk_text, hunk_meta} = encode_side_by_side_lines(side_lines, pane_width)
+    {lines_acc ++ hunk_text, meta_acc ++ hunk_meta, hunk_acc}
+  end
+
+  @spec add_context_side_by_side(
+          [String.t()],
+          [line_meta()],
+          [non_neg_integer()],
+          [String.t()],
+          non_neg_integer(),
+          pos_integer()
+        ) :: {[String.t()], [line_meta()], [non_neg_integer()]}
+  defp add_context_side_by_side(lines, meta, hunks, ctx_lines, start_orig, pane_width) do
+    count = length(ctx_lines)
+
+    if count > @fold_threshold do
+      add_folded_context_side_by_side(lines, meta, hunks, ctx_lines, start_orig, pane_width)
+    else
+      side_lines = context_side_by_side_lines(ctx_lines, start_orig)
+      {text, text_meta} = encode_side_by_side_lines(side_lines, pane_width)
+      {lines ++ text, meta ++ text_meta, hunks}
+    end
+  end
+
+  @spec add_folded_context_side_by_side(
+          [String.t()],
+          [line_meta()],
+          [non_neg_integer()],
+          [String.t()],
+          non_neg_integer(),
+          pos_integer()
+        ) :: {[String.t()], [line_meta()], [non_neg_integer()]}
+  defp add_folded_context_side_by_side(lines, meta, hunks, ctx_lines, start_orig, pane_width) do
+    count = length(ctx_lines)
+    head = Enum.take(ctx_lines, @context_lines)
+    tail = Enum.take(ctx_lines, -@context_lines)
+    fold_count = count - @context_lines * 2
+    tail_start = start_orig + count - @context_lines
+
+    side_lines =
+      context_side_by_side_lines(head, start_orig) ++
+        [fold_side_by_side_line(fold_count)] ++ context_side_by_side_lines(tail, tail_start)
+
+    {text, text_meta} = encode_side_by_side_lines(side_lines, pane_width)
+    {lines ++ text, meta ++ text_meta, hunks}
+  end
+
+  @spec context_side_by_side_lines([String.t()], non_neg_integer()) :: [side_by_side_line()]
+  defp context_side_by_side_lines(ctx_lines, start_orig) do
+    ctx_lines
+    |> Enum.with_index(start_orig)
+    |> Enum.map(fn {line, idx} ->
+      %{
+        left: line,
+        right: line,
+        left_type: :context,
+        right_type: :context,
+        original_line: idx,
+        fold_count: nil,
+        left_word_changes: nil,
+        right_word_changes: nil
+      }
+    end)
+  end
+
+  @spec fold_side_by_side_line(non_neg_integer()) :: side_by_side_line()
+  defp fold_side_by_side_line(fold_count) do
+    text = "  #{fold_count} unchanged lines"
+
+    %{
+      left: text,
+      right: "",
+      left_type: :fold,
+      right_type: :blank,
+      original_line: nil,
+      fold_count: fold_count,
+      left_word_changes: nil,
+      right_word_changes: nil
+    }
+  end
+
+  @spec no_changes_side_by_side_line() :: side_by_side_line()
+  defp no_changes_side_by_side_line do
+    %{
+      left: "No changes",
+      right: "No changes",
+      left_type: :context,
+      right_type: :context,
+      original_line: nil,
+      fold_count: nil,
+      left_word_changes: nil,
+      right_word_changes: nil
+    }
+  end
+
+  @spec build_hunk_side_by_side(Diff.hunk(), [String.t()]) :: [side_by_side_line()]
+  defp build_hunk_side_by_side(%{type: :added} = hunk, current_lines) do
+    current_lines
+    |> Enum.slice(hunk.start_line..(hunk.start_line + hunk.count - 1))
+    |> Enum.with_index(hunk.start_line)
+    |> Enum.map(fn {line, idx} ->
+      %{
+        left: "",
+        right: line,
+        left_type: :blank,
+        right_type: :added,
+        original_line: idx,
+        fold_count: nil,
+        left_word_changes: nil,
+        right_word_changes: nil
+      }
+    end)
+  end
+
+  defp build_hunk_side_by_side(%{type: :deleted} = hunk, _current_lines) do
+    Enum.map(hunk.old_lines, fn line ->
+      %{
+        left: line,
+        right: "",
+        left_type: :removed,
+        right_type: :blank,
+        original_line: nil,
+        fold_count: nil,
+        left_word_changes: nil,
+        right_word_changes: nil
+      }
+    end)
+  end
+
+  defp build_hunk_side_by_side(%{type: :modified} = hunk, current_lines) do
+    new_lines = Enum.slice(current_lines, hunk.start_line..(hunk.start_line + hunk.count - 1))
+
+    hunk.old_lines
+    |> pair_modified_lines(new_lines)
+    |> Enum.map(&modified_pair_side_by_side_line(&1, hunk.start_line))
+  end
+
+  @spec modified_pair_side_by_side_line(modified_line_pair(), non_neg_integer()) ::
+          side_by_side_line()
+  defp modified_pair_side_by_side_line(
+         {:paired, old_line, new_line, _old_idx, new_idx},
+         start_line
+       ) do
+    {del_ranges, ins_ranges} = Diff.word_diff_ranges(old_line, new_line)
+
+    %{
+      left: old_line,
+      right: new_line,
+      left_type: :removed,
+      right_type: :added,
+      original_line: start_line + new_idx,
+      fold_count: nil,
+      left_word_changes: del_ranges,
+      right_word_changes: ins_ranges
+    }
+  end
+
+  defp modified_pair_side_by_side_line({:unpaired_old, old_line}, _start_line) do
+    %{
+      left: old_line,
+      right: "",
+      left_type: :removed,
+      right_type: :blank,
+      original_line: nil,
+      fold_count: nil,
+      left_word_changes: nil,
+      right_word_changes: nil
+    }
+  end
+
+  defp modified_pair_side_by_side_line({:unpaired_new, new_line, new_idx}, start_line) do
+    %{
+      left: "",
+      right: new_line,
+      left_type: :blank,
+      right_type: :added,
+      original_line: start_line + new_idx,
+      fold_count: nil,
+      left_word_changes: nil,
+      right_word_changes: nil
+    }
+  end
+
+  @spec encode_side_by_side_lines([side_by_side_line()], pos_integer()) ::
+          {[String.t()], [line_meta()]}
+  defp encode_side_by_side_lines(side_lines, pane_width) do
+    side_lines
+    |> Enum.map(&format_side_by_side_line(&1, pane_width))
+    |> Enum.unzip()
+  end
+
+  @spec format_side_by_side_line(side_by_side_line(), pos_integer()) :: {String.t(), line_meta()}
+  defp format_side_by_side_line(line, pane_width) do
+    left = truncate_for_pane(line.left, pane_width)
+    right = truncate_for_pane(line.right, pane_width)
+    separator = " │ "
+    text = String.pad_trailing(left, pane_width) <> separator <> right
+    separator_col = pane_width + 1
+
+    meta = %{
+      type: combined_side_by_side_type(line.left_type, line.right_type),
+      original_line: line.original_line,
+      fold_count: line.fold_count,
+      word_changes: nil,
+      left_type: line.left_type,
+      right_type: line.right_type,
+      left_width: pane_width,
+      separator_col: separator_col,
+      left_word_changes: clamp_word_changes(line.left_word_changes, pane_width),
+      right_word_changes: clamp_word_changes(line.right_word_changes, pane_width)
+    }
+
+    {text, meta}
+  end
+
+  @spec truncate_for_pane(String.t(), pos_integer()) :: String.t()
+  defp truncate_for_pane(text, pane_width) do
+    if String.length(text) > pane_width do
+      String.slice(text, 0, pane_width)
+    else
+      text
+    end
+  end
+
+  @spec clamp_word_changes([Diff.char_range()] | nil, pos_integer()) :: [Diff.char_range()] | nil
+  defp clamp_word_changes(nil, _pane_width), do: nil
+
+  defp clamp_word_changes(word_changes, pane_width) do
+    word_changes
+    |> Enum.map(&clamp_word_change(&1, pane_width))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  @spec clamp_word_change(Diff.char_range(), pos_integer()) :: Diff.char_range() | nil
+  defp clamp_word_change({start_col, _end_col}, pane_width) when start_col >= pane_width, do: nil
+
+  defp clamp_word_change({start_col, end_col}, pane_width) do
+    {start_col, min(end_col, pane_width)}
+  end
+
+  @spec combined_side_by_side_type(pane_line_type(), pane_line_type()) :: line_type()
+  defp combined_side_by_side_type(:fold, _right_type), do: :fold
+  defp combined_side_by_side_type(_left_type, :fold), do: :fold
+  defp combined_side_by_side_type(:removed, _right_type), do: :removed
+  defp combined_side_by_side_type(_left_type, :added), do: :added
+  defp combined_side_by_side_type(_left_type, _right_type), do: :context
 
   @spec add_hunk_lines(
           [String.t()],
@@ -117,12 +472,25 @@ defmodule Minga.Core.DiffView do
 
   @spec build_regions([String.t()], [String.t()], [Diff.hunk()]) :: [term()]
   defp build_regions(base_lines, current_lines, hunks) do
-    # Sort hunks by start_line
+    build_regions(base_lines, current_lines, hunks, &build_hunk_display/3)
+  end
+
+  @spec build_side_by_side_regions([String.t()], [String.t()], [Diff.hunk()]) :: [term()]
+  defp build_side_by_side_regions(base_lines, current_lines, hunks) do
+    build_regions(base_lines, current_lines, hunks, fn hunk, _base_lines, _current_lines ->
+      hunk
+    end)
+  end
+
+  @spec build_regions([String.t()], [String.t()], [Diff.hunk()], (Diff.hunk(),
+                                                                  [String.t()],
+                                                                  [String.t()] ->
+                                                                    term())) :: [term()]
+  defp build_regions(base_lines, current_lines, hunks, build_hunk) do
     sorted_hunks = Enum.sort_by(hunks, & &1.start_line)
 
     {regions_reversed, last_end} =
       Enum.reduce(sorted_hunks, {[], 0}, fn hunk, {regions_acc, prev_end} ->
-        # Context before this hunk
         ctx_start = prev_end
         ctx_end = hunk.start_line
 
@@ -134,10 +502,8 @@ defmodule Minga.Core.DiffView do
             regions_acc
           end
 
-        # The hunk itself
-        hunk_display = build_hunk_display(hunk, base_lines, current_lines)
+        hunk_display = build_hunk.(hunk, base_lines, current_lines)
 
-        # Calculate where the hunk ends in current lines
         hunk_end =
           case hunk.type do
             :deleted -> hunk.start_line
@@ -149,7 +515,6 @@ defmodule Minga.Core.DiffView do
 
     regions = Enum.reverse(regions_reversed)
 
-    # Trailing context after last hunk
     if last_end < length(current_lines) do
       ctx = Enum.slice(current_lines, last_end..(length(current_lines) - 1))
       regions ++ [{:context, ctx, last_end}]

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -37,6 +37,7 @@ defmodule MingaEditor.Commands.Git do
     {:git_fetch, "Fetch", false},
     {:git_pull_and_retry, "Pull and retry push", false},
     {:git_diff_file, "View diff", true},
+    {:git_diff_toggle_layout, "Toggle side-by-side diff", true},
     {:next_git_hunk, "Next git hunk", true},
     {:prev_git_hunk, "Previous git hunk", true},
     {:git_stage_hunk, "Stage hunk", true},
@@ -110,6 +111,15 @@ defmodule MingaEditor.Commands.Git do
   def execute(state, :git_diff_toggle_staged) do
     active_buf = state.workspace.buffers.active
     toggle_diff_staged(state, active_buf)
+  end
+
+  def execute(state, :git_diff_toggle_layout) do
+    if MingaEditor.Frontend.gui?(state.capabilities) do
+      active_buf = state.workspace.buffers.active
+      toggle_diff_layout(state, active_buf)
+    else
+      EditorState.set_status(state, "Side-by-side diff is only available in GUI")
+    end
   end
 
   # ── AI commit message ──────────────────────────────────────────────────────
@@ -275,7 +285,7 @@ defmodule MingaEditor.Commands.Git do
     staged = Keyword.get(opts, :staged, false)
     label = if staged, do: "staged", else: "unstaged"
 
-    diff_result = DiffView.build(base_content, current_content)
+    diff_result = build_diff_result(base_content, current_content, state, :unified)
     filename = Path.basename(rel_path)
     filetype = Language.detect_filetype(filename)
 
@@ -296,7 +306,9 @@ defmodule MingaEditor.Commands.Git do
           rel_path: rel_path,
           staged: staged,
           line_metadata: diff_result.line_metadata,
-          hunk_lines: diff_result.hunk_lines
+          hunk_lines: diff_result.hunk_lines,
+          view_mode: :unified,
+          pane_width: diff_pane_width(state)
         }
 
         state
@@ -318,12 +330,17 @@ defmodule MingaEditor.Commands.Git do
 
   @spec open_diff_view(state(), pid(), pid(), boolean()) :: state()
   defp open_diff_view(state, git_pid, buf, staged) do
+    open_diff_view(state, git_pid, buf, staged, :unified)
+  end
+
+  @spec open_diff_view(state(), pid(), pid(), boolean(), :unified | :side_by_side) :: state()
+  defp open_diff_view(state, git_pid, buf, staged, view_mode) do
     git_root = Git.Buffer.git_root(git_pid)
     rel_path = Git.Buffer.relative_path(git_pid)
 
     {base_content, current_content} = diff_contents(git_root, rel_path, buf, staged)
 
-    diff_result = DiffView.build(base_content, current_content)
+    diff_result = build_diff_result(base_content, current_content, state, view_mode)
     filename = Path.basename(rel_path)
     filetype = Language.detect_filetype(filename)
     label = if staged, do: "staged", else: "unstaged"
@@ -345,7 +362,9 @@ defmodule MingaEditor.Commands.Git do
           rel_path: rel_path,
           staged: staged,
           line_metadata: diff_result.line_metadata,
-          hunk_lines: diff_result.hunk_lines
+          hunk_lines: diff_result.hunk_lines,
+          view_mode: view_mode,
+          pane_width: diff_pane_width(state)
         }
 
         state
@@ -410,6 +429,24 @@ defmodule MingaEditor.Commands.Git do
 
   defp staged_deleted_entry?(%Git.StatusEntry{}, _rel_path), do: false
 
+  @spec build_diff_result(String.t(), String.t(), state(), :unified | :side_by_side) ::
+          DiffView.diff_view_result()
+  defp build_diff_result(base_content, current_content, _state, :unified) do
+    DiffView.build(base_content, current_content)
+  end
+
+  defp build_diff_result(base_content, current_content, state, :side_by_side) do
+    DiffView.build_side_by_side(base_content, current_content, diff_pane_width(state))
+  end
+
+  @spec diff_pane_width(state()) :: pos_integer()
+  defp diff_pane_width(%{workspace: %{viewport: %{cols: cols}}})
+       when is_integer(cols) and cols > 20 do
+    max(div(cols - 5, 2), 20)
+  end
+
+  defp diff_pane_width(_state), do: 80
+
   @spec apply_diff_decorations(pid(), [DiffView.line_meta()], MingaEditor.UI.Theme.t()) :: :ok
   defp apply_diff_decorations(diff_buf, line_metadata, theme) do
     Buffer.batch_decorations(diff_buf, fn decs ->
@@ -427,6 +464,42 @@ defmodule MingaEditor.Commands.Git do
           non_neg_integer(),
           non_neg_integer()
         ) :: Minga.Core.Decorations.t()
+  defp apply_line_decoration(
+         decs,
+         %{left_type: _left_type, right_type: _right_type} = meta,
+         line_idx,
+         added_bg,
+         removed_bg,
+         added_word_bg,
+         removed_word_bg,
+         fold_fg
+       ) do
+    decs
+    |> apply_side_pane_decoration(
+      meta.left_type,
+      line_idx,
+      0,
+      meta.left_width,
+      removed_bg,
+      fold_fg
+    )
+    |> apply_side_pane_decoration(
+      meta.right_type,
+      line_idx,
+      meta.left_width + 3,
+      9999,
+      added_bg,
+      fold_fg
+    )
+    |> apply_word_highlights_at(line_idx, meta[:left_word_changes], removed_word_bg, 0)
+    |> apply_word_highlights_at(
+      line_idx,
+      meta[:right_word_changes],
+      added_word_bg,
+      meta.left_width + 3
+    )
+  end
+
   defp apply_line_decoration(
          decs,
          %{type: :added} = meta,
@@ -516,19 +589,83 @@ defmodule MingaEditor.Commands.Git do
     Bitwise.bsl(r, 16) + Bitwise.bsl(g, 8) + b
   end
 
+  @spec apply_side_pane_decoration(
+          Minga.Core.Decorations.t(),
+          DiffView.pane_line_type(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: Minga.Core.Decorations.t()
+  defp apply_side_pane_decoration(decs, :added, line_idx, start_col, end_col, bg, _fold_fg) do
+    add_pane_highlight(decs, line_idx, start_col, end_col, bg, :diff)
+  end
+
+  defp apply_side_pane_decoration(decs, :removed, line_idx, start_col, end_col, bg, _fold_fg) do
+    add_pane_highlight(decs, line_idx, start_col, end_col, bg, :diff)
+  end
+
+  defp apply_side_pane_decoration(decs, :fold, line_idx, start_col, end_col, _bg, fold_fg) do
+    {_id, decs} =
+      Minga.Core.Decorations.add_highlight(decs, {line_idx, start_col}, {line_idx, end_col},
+        style: Face.new(fg: fold_fg, italic: true),
+        priority: 1,
+        group: :diff
+      )
+
+    decs
+  end
+
+  defp apply_side_pane_decoration(decs, _type, _line_idx, _start_col, _end_col, _bg, _fold_fg),
+    do: decs
+
+  @spec add_pane_highlight(
+          Minga.Core.Decorations.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          atom()
+        ) :: Minga.Core.Decorations.t()
+  defp add_pane_highlight(decs, line_idx, start_col, end_col, bg, group) do
+    {_id, decs} =
+      Minga.Core.Decorations.add_highlight(decs, {line_idx, start_col}, {line_idx, end_col},
+        style: Face.new(bg: bg),
+        priority: 1,
+        group: group
+      )
+
+    decs
+  end
+
   @spec apply_word_highlights(
           Minga.Core.Decorations.t(),
           non_neg_integer(),
           [Diff.char_range()] | nil,
           non_neg_integer()
         ) :: Minga.Core.Decorations.t()
-  defp apply_word_highlights(decs, _line_idx, nil, _word_bg), do: decs
-  defp apply_word_highlights(decs, _line_idx, [], _word_bg), do: decs
-
   defp apply_word_highlights(decs, line_idx, word_changes, word_bg) do
+    apply_word_highlights_at(decs, line_idx, word_changes, word_bg, 0)
+  end
+
+  @spec apply_word_highlights_at(
+          Minga.Core.Decorations.t(),
+          non_neg_integer(),
+          [Diff.char_range()] | nil,
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: Minga.Core.Decorations.t()
+  defp apply_word_highlights_at(decs, _line_idx, nil, _word_bg, _offset), do: decs
+  defp apply_word_highlights_at(decs, _line_idx, [], _word_bg, _offset), do: decs
+
+  defp apply_word_highlights_at(decs, line_idx, word_changes, word_bg, offset) do
     Enum.reduce(word_changes, decs, fn {start_col, end_col}, acc ->
       {_id, acc} =
-        Minga.Core.Decorations.add_highlight(acc, {line_idx, start_col}, {line_idx, end_col},
+        Minga.Core.Decorations.add_highlight(
+          acc,
+          {line_idx, offset + start_col},
+          {line_idx, offset + end_col},
           style: Face.new(bg: word_bg),
           priority: 2,
           group: :diff_word
@@ -565,17 +702,38 @@ defmodule MingaEditor.Commands.Git do
       %{source_buf: nil} ->
         EditorState.set_status(state, "Cannot toggle staged: diff opened from status panel")
 
-      %{source_buf: source_buf, staged: staged} ->
+      %{source_buf: source_buf, staged: staged} = diff_info ->
         new_staged = not staged
+        view_mode = Map.get(diff_info, :view_mode, :unified)
         git_pid = Git.tracking_pid(source_buf)
 
         if git_pid do
           GenServer.stop(active_buf, :normal)
           state = EditorState.unregister_diff_view(state, active_buf)
-          open_diff_view(state, git_pid, source_buf, new_staged)
+          open_diff_view(state, git_pid, source_buf, new_staged, view_mode)
         else
           EditorState.set_status(state, "Source buffer no longer tracked by git")
         end
+    end
+  end
+
+  @spec toggle_diff_layout(state(), pid()) :: state()
+  defp toggle_diff_layout(state, active_buf) do
+    case EditorState.diff_view_info(state, active_buf) do
+      nil ->
+        EditorState.set_status(state, "Not a diff view")
+
+      %{view_mode: :side_by_side} = diff_info ->
+        refresh_diff_view_content(state, active_buf, Map.put(diff_info, :view_mode, :unified))
+        |> EditorState.set_status("Diff layout: unified")
+
+      diff_info ->
+        refresh_diff_view_content(
+          state,
+          active_buf,
+          Map.put(diff_info, :view_mode, :side_by_side)
+        )
+        |> EditorState.set_status("Diff layout: side-by-side")
     end
   end
 
@@ -588,17 +746,17 @@ defmodule MingaEditor.Commands.Git do
   def refresh_diff_views_for_buffer(state, saved_buf) do
     diff_views = EditorState.diff_views_for_source(state, saved_buf)
 
-    Enum.reduce(diff_views, state, fn {diff_buf,
-                                       %{git_root: git_root, rel_path: rel_path, staged: staged}},
-                                      acc ->
-      refresh_diff_buffer(acc, diff_buf, saved_buf, git_root, rel_path, staged)
+    Enum.reduce(diff_views, state, fn {diff_buf, diff_info}, acc ->
+      refresh_diff_buffer(acc, diff_buf, saved_buf, diff_info)
     end)
   end
 
-  @spec refresh_diff_buffer(state(), pid(), pid(), String.t(), String.t(), boolean()) :: state()
-  defp refresh_diff_buffer(state, diff_buf, source_buf, git_root, rel_path, staged) do
+  @spec refresh_diff_buffer(state(), pid(), pid(), EditorState.diff_view_info()) :: state()
+  defp refresh_diff_buffer(state, diff_buf, source_buf, diff_info) do
+    %{git_root: git_root, rel_path: rel_path, staged: staged} = diff_info
+    view_mode = Map.get(diff_info, :view_mode, :unified)
     {base_content, current_content} = diff_contents(git_root, rel_path, source_buf, staged)
-    diff_result = DiffView.build(base_content, current_content)
+    diff_result = build_diff_result(base_content, current_content, state, view_mode)
 
     Buffer.replace_content_with_decorations(
       diff_buf,
@@ -615,7 +773,9 @@ defmodule MingaEditor.Commands.Git do
       rel_path: rel_path,
       staged: staged,
       line_metadata: diff_result.line_metadata,
-      hunk_lines: diff_result.hunk_lines
+      hunk_lines: diff_result.hunk_lines,
+      view_mode: view_mode,
+      pane_width: diff_pane_width(state)
     }
 
     EditorState.register_diff_view(state, diff_buf, diff_info)
@@ -1125,11 +1285,32 @@ defmodule MingaEditor.Commands.Git do
           [Diff.hunk()]
         ) :: boolean()
   defp stale_diff_view?(diff_buf, diff_info, base_lines, current_lines, hunks) do
-    fresh = DiffView.build_from_hunks(base_lines, current_lines, hunks)
+    fresh = diff_result_from_hunks(diff_info, base_lines, current_lines, hunks)
     {displayed_text, _cursor} = Buffer.content_and_cursor(diff_buf)
 
     displayed_text != fresh.text or diff_info.line_metadata != fresh.line_metadata or
       diff_info.hunk_lines != fresh.hunk_lines
+  end
+
+  @spec diff_result_from_hunks(EditorState.diff_view_info(), [String.t()], [String.t()], [
+          Diff.hunk()
+        ]) :: DiffView.diff_view_result()
+  defp diff_result_from_hunks(
+         %{view_mode: :side_by_side} = diff_info,
+         base_lines,
+         current_lines,
+         hunks
+       ) do
+    DiffView.build_side_by_side_from_hunks(
+      base_lines,
+      current_lines,
+      hunks,
+      Map.get(diff_info, :pane_width, 80)
+    )
+  end
+
+  defp diff_result_from_hunks(_diff_info, base_lines, current_lines, hunks) do
+    DiffView.build_from_hunks(base_lines, current_lines, hunks)
   end
 
   @spec diff_view_lines(EditorState.diff_view_info(), String.t()) ::
@@ -1201,12 +1382,12 @@ defmodule MingaEditor.Commands.Git do
   end
 
   @spec refresh_diff_view_content(state(), pid(), EditorState.diff_view_info()) :: state()
-  defp refresh_diff_view_content(state, diff_buf, %{staged: false} = diff_info) do
-    %{git_root: git_root, rel_path: rel_path} = diff_info
-    current_content = current_content_for_diff(diff_info)
+  defp refresh_diff_view_content(state, diff_buf, diff_info) do
+    %{git_root: git_root, rel_path: rel_path, staged: staged} = diff_info
+    view_mode = Map.get(diff_info, :view_mode, :unified)
     base_content = head_content(git_root, rel_path)
-
-    diff_result = DiffView.build(base_content, current_content)
+    current_content = diff_view_current_content(diff_info, git_root, rel_path, staged)
+    diff_result = build_diff_result(base_content, current_content, state, view_mode)
 
     Buffer.replace_content_with_decorations(
       diff_buf,
@@ -1217,13 +1398,25 @@ defmodule MingaEditor.Commands.Git do
       end
     )
 
-    updated_info = %{
-      diff_info
-      | line_metadata: diff_result.line_metadata,
-        hunk_lines: diff_result.hunk_lines
-    }
+    updated_info =
+      Map.merge(diff_info, %{
+        line_metadata: diff_result.line_metadata,
+        hunk_lines: diff_result.hunk_lines,
+        view_mode: view_mode,
+        pane_width: diff_pane_width(state)
+      })
 
     EditorState.register_diff_view(state, diff_buf, updated_info)
+  end
+
+  @spec diff_view_current_content(EditorState.diff_view_info(), String.t(), String.t(), boolean()) ::
+          String.t()
+  defp diff_view_current_content(_diff_info, git_root, rel_path, true) do
+    staged_content(git_root, rel_path)
+  end
+
+  defp diff_view_current_content(diff_info, _git_root, _rel_path, false) do
+    current_content_for_diff(diff_info)
   end
 
   @spec split_lines(String.t()) :: [String.t()]

--- a/lib/minga_editor/key_dispatch.ex
+++ b/lib/minga_editor/key_dispatch.ex
@@ -25,6 +25,7 @@ defmodule MingaEditor.KeyDispatch do
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.CommandCompletion, as: CommandCompletionPayload
   alias Minga.Keymap
+  alias Minga.Keymap.Bindings
   alias Minga.Mode
 
   @doc """
@@ -283,11 +284,55 @@ defmodule MingaEditor.KeyDispatch do
 
   @spec fetch_leader_trie(EditorState.t()) :: Minga.Keymap.Bindings.node_t()
   defp fetch_leader_trie(state) do
-    Keymap.leader_trie(EditorState.keymap_server(state))
+    state
+    |> EditorState.keymap_server()
+    |> Keymap.leader_trie()
+    |> add_gui_only_leader_bindings(state)
   catch
     :exit, _ ->
       Minga.Log.warning(:config, "leader_trie unavailable; falling back to defaults")
-      Keymap.default_leader_trie()
+      Keymap.default_leader_trie() |> add_gui_only_leader_bindings(state)
+  end
+
+  @spec add_gui_only_leader_bindings(Bindings.node_t(), EditorState.t()) :: Bindings.node_t()
+  defp add_gui_only_leader_bindings(trie, state) do
+    if MingaEditor.Frontend.gui?(state.capabilities) do
+      trie
+      |> promote_default_diff_binding_for_gui()
+      |> bind_gui_side_by_side_if_missing()
+    else
+      trie
+    end
+  end
+
+  @spec promote_default_diff_binding_for_gui(Bindings.node_t()) :: Bindings.node_t()
+  defp promote_default_diff_binding_for_gui(%Bindings.Node{} = trie) do
+    case Bindings.lookup_sequence(trie, [{?g, 0}, {?d, 0}]) do
+      {:command, :git_diff_file, _description} ->
+        trie
+        |> Bindings.unbind([{?g, 0}, {?d, 0}])
+        |> Bindings.bind_prefix([{?g, 0}, {?d, 0}], "+diff")
+        |> Bindings.bind([{?g, 0}, {?d, 0}, {?f, 0}], :git_diff_file, "View diff")
+
+      _ ->
+        trie
+    end
+  end
+
+  @spec bind_gui_side_by_side_if_missing(Bindings.node_t()) :: Bindings.node_t()
+  defp bind_gui_side_by_side_if_missing(%Bindings.Node{} = trie) do
+    case Bindings.lookup_sequence(trie, [{?g, 0}, {?d, 0}, {?s, 0}]) do
+      :not_found ->
+        Bindings.bind(
+          trie,
+          [{?g, 0}, {?d, 0}, {?s, 0}],
+          :git_diff_toggle_layout,
+          "Toggle side-by-side diff"
+        )
+
+      _ ->
+        trie
+    end
   end
 
   @spec fetch_normal_bindings(EditorState.t()) :: %{

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -703,12 +703,14 @@ defmodule MingaEditor.State do
 
   @typedoc "Metadata for an open diff view buffer."
   @type diff_view_info :: %{
-          source_buf: pid() | nil,
-          git_root: String.t(),
-          rel_path: String.t(),
-          staged: boolean(),
-          line_metadata: [Minga.Core.DiffView.line_meta()],
-          hunk_lines: [non_neg_integer()]
+          required(:source_buf) => pid() | nil,
+          required(:git_root) => String.t(),
+          required(:rel_path) => String.t(),
+          required(:staged) => boolean(),
+          required(:line_metadata) => [Minga.Core.DiffView.line_meta()],
+          required(:hunk_lines) => [non_neg_integer()],
+          optional(:view_mode) => :unified | :side_by_side,
+          optional(:pane_width) => pos_integer()
         }
 
   @typedoc "The git_remote_op tracking tuple, or nil when no operation is in flight."

--- a/test/minga/core/diff_view_test.exs
+++ b/test/minga/core/diff_view_test.exs
@@ -105,6 +105,83 @@ defmodule Minga.Core.DiffViewTest do
     end
   end
 
+  describe "build_side_by_side/3" do
+    test "aligns added lines with a blank filler in the left pane" do
+      result = DiffView.build_side_by_side("line1\nline3\n", "line1\nline2\nline3\n", 8)
+      lines = String.split(result.text, "\n")
+
+      assert Enum.any?(lines, &String.ends_with?(&1, "line2"))
+
+      added_meta = Enum.find(result.line_metadata, fn m -> m.right_type == :added end)
+      assert added_meta.left_type == :blank
+      assert added_meta.left_width == 8
+    end
+
+    test "aligns deleted lines with a blank filler in the right pane" do
+      result = DiffView.build_side_by_side("line1\nline2\nline3\n", "line1\nline3\n", 8)
+
+      removed_meta = Enum.find(result.line_metadata, fn m -> m.left_type == :removed end)
+      assert removed_meta.right_type == :blank
+    end
+
+    test "keeps paired word-level changes on their own panes" do
+      result = DiffView.build_side_by_side("hello world\n", "hello earth\n", 16)
+
+      meta =
+        Enum.find(result.line_metadata, fn m ->
+          m.left_type == :removed and m.right_type == :added
+        end)
+
+      assert [_ | _] = meta.left_word_changes
+      assert [_ | _] = meta.right_word_changes
+    end
+
+    test "preserves inserted line alignment inside uneven modified hunks" do
+      result =
+        DiffView.build_side_by_side("foo one\nbar two\n", "foo uno\nINSERTED\nbar dos\n", 12)
+
+      lines_with_meta = Enum.zip(String.split(result.text, "\n"), result.line_metadata)
+
+      assert Enum.any?(lines_with_meta, fn
+               {line, %{left_type: :blank, right_type: :added}} ->
+                 String.contains?(line, "INSERTED")
+
+               _ ->
+                 false
+             end)
+
+      assert Enum.any?(lines_with_meta, fn
+               {line, %{left_type: :removed, right_type: :added}} ->
+                 String.contains?(line, "bar two") and String.contains?(line, "bar dos")
+
+               _ ->
+                 false
+             end)
+    end
+
+    test "clips pane-local word ranges to the visible pane width" do
+      result =
+        DiffView.build_side_by_side(
+          "prefix unchanged oldtail\n",
+          "prefix unchanged newtail\n",
+          10
+        )
+
+      meta =
+        Enum.find(result.line_metadata, fn m ->
+          m.left_type == :removed and m.right_type == :added
+        end)
+
+      assert Enum.all?(meta.left_word_changes, fn {_start_col, end_col} ->
+               end_col <= meta.left_width
+             end)
+
+      assert Enum.all?(meta.right_word_changes, fn {_start_col, end_col} ->
+               end_col <= meta.left_width
+             end)
+    end
+  end
+
   describe "word_changes in metadata" do
     test "modified lines carry word_changes in metadata" do
       base = "line1\nhello world\nline3\n"

--- a/test/minga/keymap/active_test.exs
+++ b/test/minga/keymap/active_test.exs
@@ -22,6 +22,13 @@ defmodule Minga.Keymap.ActiveTest do
       # SPC m should be a prefix node (registered by defaults)
       assert {:prefix, _m_node} = Bindings.lookup(trie, {?m, 0})
     end
+
+    test "keeps shared diff command on SPC g d", %{store: s} do
+      trie = Active.leader_trie(s)
+      assert {:prefix, g_node} = Bindings.lookup(trie, {?g, 0})
+      assert {:command, :git_diff_file} = Bindings.lookup(g_node, {?d, 0})
+      assert :not_found = Bindings.lookup_sequence(trie, [{?g, 0}, {?d, 0}, {?s, 0}])
+    end
   end
 
   describe "normal_bindings/1" do

--- a/test/minga_editor/commands/git_diff_decorations_test.exs
+++ b/test/minga_editor/commands/git_diff_decorations_test.exs
@@ -8,6 +8,7 @@ defmodule MingaEditor.Commands.GitDiffDecorationsTest do
   alias Minga.Git
   alias Minga.Git.Stub, as: GitStub
   alias MingaEditor.Commands.Git, as: GitCommands
+  alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
 
@@ -210,6 +211,174 @@ defmodule MingaEditor.Commands.GitDiffDecorationsTest do
       assert buffer_content(source_buf) == current
     end
 
+    test "non-GUI diff layout toggle leaves unified diff unchanged" do
+      git_root = unique_git_root()
+      rel_path = "file.txt"
+      base = "old\n"
+      current = "new\n"
+
+      GitStub.set_head(git_root, rel_path, base)
+      on_exit(fn -> GitStub.clear(git_root) end)
+
+      diff_result = DiffView.build(base, current)
+      {:ok, source_buf} = Buffer.start_link(content: current)
+      {:ok, diff_buf} = Buffer.start_link(content: diff_result.text)
+
+      state =
+        build_state()
+        |> EditorState.add_buffer(source_buf)
+        |> EditorState.add_buffer(diff_buf)
+        |> EditorState.register_diff_view(diff_buf, %{
+          source_buf: source_buf,
+          git_root: git_root,
+          rel_path: rel_path,
+          staged: false,
+          line_metadata: diff_result.line_metadata,
+          hunk_lines: diff_result.hunk_lines,
+          view_mode: :unified,
+          pane_width: 20
+        })
+
+      state = GitCommands.execute(state, :git_diff_toggle_layout)
+
+      assert EditorState.status_msg(state) == "Side-by-side diff is only available in GUI"
+      assert state.diff_views[diff_buf].view_mode == :unified
+      refute buffer_content(diff_buf) =~ " │ "
+    end
+
+    test "stage hunk from side-by-side diff preserves the side-by-side layout" do
+      git_root = unique_git_root()
+      rel_path = "file.txt"
+      base = "old\n"
+      current = "new\n"
+
+      GitStub.set_head(git_root, rel_path, base)
+      on_exit(fn -> GitStub.clear(git_root) end)
+
+      diff_result = DiffView.build_side_by_side(base, current, 20)
+
+      changed_line =
+        Enum.find_index(diff_result.line_metadata, fn meta ->
+          meta.left_type == :removed and meta.right_type == :added
+        end)
+
+      {:ok, source_buf} = Buffer.start_link(content: current)
+      {:ok, diff_buf} = Buffer.start_link(content: diff_result.text)
+      Buffer.move_to(diff_buf, {changed_line, 0})
+
+      state =
+        build_state()
+        |> EditorState.set_viewport(Viewport.new(24, 40))
+        |> Map.put(:capabilities, %Capabilities{frontend_type: :native_gui})
+        |> EditorState.add_buffer(source_buf)
+        |> EditorState.add_buffer(diff_buf)
+        |> EditorState.register_diff_view(diff_buf, %{
+          source_buf: source_buf,
+          git_root: git_root,
+          rel_path: rel_path,
+          staged: false,
+          line_metadata: diff_result.line_metadata,
+          hunk_lines: diff_result.hunk_lines,
+          view_mode: :side_by_side,
+          pane_width: 20
+        })
+
+      state = GitCommands.execute(state, :git_stage_hunk)
+
+      assert EditorState.status_msg(state) == "Hunk 1/1 staged"
+      assert state.diff_views[diff_buf].view_mode == :side_by_side
+    end
+
+    test "revert hunk from side-by-side diff preserves the side-by-side layout" do
+      git_root = unique_git_root()
+      rel_path = "file.txt"
+      base = "old\n"
+      current = "new\n"
+
+      GitStub.set_head(git_root, rel_path, base)
+      on_exit(fn -> GitStub.clear(git_root) end)
+
+      diff_result = DiffView.build_side_by_side(base, current, 20)
+
+      changed_line =
+        Enum.find_index(diff_result.line_metadata, fn meta ->
+          meta.left_type == :removed and meta.right_type == :added
+        end)
+
+      {:ok, source_buf} = Buffer.start_link(content: current)
+      {:ok, diff_buf} = Buffer.start_link(content: diff_result.text)
+      Buffer.move_to(diff_buf, {changed_line, 0})
+
+      state =
+        build_state()
+        |> EditorState.set_viewport(Viewport.new(24, 40))
+        |> Map.put(:capabilities, %Capabilities{frontend_type: :native_gui})
+        |> EditorState.add_buffer(source_buf)
+        |> EditorState.add_buffer(diff_buf)
+        |> EditorState.register_diff_view(diff_buf, %{
+          source_buf: source_buf,
+          git_root: git_root,
+          rel_path: rel_path,
+          staged: false,
+          line_metadata: diff_result.line_metadata,
+          hunk_lines: diff_result.hunk_lines,
+          view_mode: :side_by_side,
+          pane_width: 20
+        })
+
+      state = GitCommands.execute(state, :git_revert_hunk)
+
+      assert EditorState.status_msg(state) == "Hunk 1/1 reverted"
+      assert state.diff_views[diff_buf].view_mode == :side_by_side
+      assert buffer_content(source_buf) == base
+    end
+
+    test "side-by-side diff decorations include word highlights on both panes" do
+      git_root = unique_git_root()
+      rel_path = "file.txt"
+      base = "alpha old\n"
+      current = "alpha new\n"
+
+      GitStub.set_head(git_root, rel_path, base)
+      on_exit(fn -> GitStub.clear(git_root) end)
+
+      diff_result = DiffView.build(base, current)
+      {:ok, source_buf} = Buffer.start_link(content: current)
+      {:ok, diff_buf} = Buffer.start_link(content: diff_result.text)
+
+      state =
+        build_state()
+        |> EditorState.set_viewport(Viewport.new(24, 40))
+        |> Map.put(:capabilities, %Capabilities{frontend_type: :native_gui})
+        |> EditorState.add_buffer(source_buf)
+        |> EditorState.add_buffer(diff_buf)
+        |> EditorState.register_diff_view(diff_buf, %{
+          source_buf: source_buf,
+          git_root: git_root,
+          rel_path: rel_path,
+          staged: false,
+          line_metadata: diff_result.line_metadata,
+          hunk_lines: diff_result.hunk_lines,
+          view_mode: :unified,
+          pane_width: 20
+        })
+
+      state = GitCommands.execute(state, :git_diff_toggle_layout)
+
+      highlights =
+        Buffer.decorations(diff_buf)
+        |> Decorations.highlights_for_line(0)
+        |> Enum.filter(&(&1.group == :diff_word))
+        |> Enum.sort_by(& &1.start)
+
+      assert Enum.map(highlights, &{&1.start, &1.end_}) == [
+               {{0, 6}, {0, 9}},
+               {{0, 29}, {0, 32}}
+             ]
+
+      assert state.diff_views[diff_buf].view_mode == :side_by_side
+    end
+
     test "stage hunk from diff view refreshes stale views instead of staging by index" do
       git_root = unique_git_root()
       rel_path = "file.txt"
@@ -289,6 +458,42 @@ defmodule MingaEditor.Commands.GitDiffDecorationsTest do
 
       assert buffer_content(source_buf) == working
       assert EditorState.status_msg(state) == "Cannot revert from a staged diff view"
+    end
+
+    test "GUI diff layout toggle rebuilds active diff as side-by-side" do
+      git_root = unique_git_root()
+      rel_path = "file.txt"
+      base = "old\n"
+      current = "new\n"
+
+      GitStub.set_head(git_root, rel_path, base)
+      on_exit(fn -> GitStub.clear(git_root) end)
+
+      diff_result = DiffView.build(base, current)
+      {:ok, source_buf} = Buffer.start_link(content: current)
+      {:ok, diff_buf} = Buffer.start_link(content: diff_result.text)
+
+      state =
+        build_state()
+        |> Map.put(:capabilities, %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui})
+        |> EditorState.add_buffer(source_buf)
+        |> EditorState.add_buffer(diff_buf)
+        |> EditorState.register_diff_view(diff_buf, %{
+          source_buf: source_buf,
+          git_root: git_root,
+          rel_path: rel_path,
+          staged: false,
+          line_metadata: diff_result.line_metadata,
+          hunk_lines: diff_result.hunk_lines,
+          view_mode: :unified,
+          pane_width: 20
+        })
+
+      state = GitCommands.execute(state, :git_diff_toggle_layout)
+
+      assert buffer_content(diff_buf) =~ " │ "
+      assert state.diff_views[diff_buf].view_mode == :side_by_side
+      assert EditorState.status_msg(state) == "Diff layout: side-by-side"
     end
 
     test "staged diff toggle treats staged deletions as empty index content" do

--- a/test/minga_editor/key_dispatch_gui_bindings_test.exs
+++ b/test/minga_editor/key_dispatch_gui_bindings_test.exs
@@ -1,0 +1,89 @@
+defmodule MingaEditor.KeyDispatchGUIBindingsTest do
+  @moduledoc "Tests GUI-only key dispatch bindings."
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer
+  alias Minga.Keymap.Active
+  alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.KeyDispatch
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
+
+  test "SPC g d s is available for GUI frontends only" do
+    gui_state = state_with_frontend(:native_gui)
+    tui_state = state_with_frontend(:tui)
+
+    assert "Not a diff view" =
+             dispatch_keys(gui_state, [32, ?g, ?d, ?s]) |> EditorState.status_msg()
+
+    assert "Not in a git repository" =
+             dispatch_keys(tui_state, [32, ?g, ?d, ?s]) |> EditorState.status_msg()
+  end
+
+  test "TUI keeps SPC g d as the direct diff command" do
+    state = state_with_frontend(:tui)
+
+    assert "Not in a git repository" =
+             dispatch_keys(state, [32, ?g, ?d]) |> EditorState.status_msg()
+  end
+
+  test "GUI moves the default diff command to SPC g d f" do
+    state = state_with_frontend(:native_gui)
+
+    assert nil == dispatch_keys(state, [32, ?g, ?d]) |> EditorState.status_msg()
+
+    assert "Not in a git repository" =
+             dispatch_keys(state, [32, ?g, ?d, ?f]) |> EditorState.status_msg()
+  end
+
+  test "an existing exact user binding for SPC g d s is preserved" do
+    keymap_server = start_supervised!({Active, name: nil})
+    :ok = Active.bind(keymap_server, :normal, "SPC g d s", :git_status_toggle, "User diff")
+
+    state = state_with_frontend(:native_gui, keymap_server)
+    state = dispatch_keys(state, [32, ?g, ?d, ?s])
+
+    assert state.workspace.keymap_scope == :git_status
+    assert EditorState.status_msg(state) == nil
+  end
+
+  test "an existing exact user binding for SPC g d is preserved in GUI" do
+    keymap_server = start_supervised!({Active, name: nil})
+    :ok = Active.bind(keymap_server, :normal, "SPC g d", :git_status_toggle, "User diff")
+
+    state = state_with_frontend(:native_gui, keymap_server)
+    state = dispatch_keys(state, [32, ?g, ?d])
+
+    assert state.workspace.keymap_scope == :git_status
+    assert EditorState.status_msg(state) == nil
+  end
+
+  defp state_with_frontend(frontend_type, keymap_server \\ nil) do
+    buf =
+      start_supervised!(
+        Supervisor.child_spec({Buffer, content: "x"}, id: {:buffer, frontend_type})
+      )
+
+    state = %EditorState{
+      port_manager: self(),
+      workspace: %SessionState{viewport: Viewport.new(24, 80)},
+      capabilities: %Capabilities{frontend_type: frontend_type}
+    }
+
+    state =
+      if keymap_server do
+        %{state | keymap_server: keymap_server}
+      else
+        state
+      end
+
+    EditorState.add_buffer(state, buf)
+  end
+
+  defp dispatch_keys(state, keys) do
+    Enum.reduce(keys, state, fn key, acc ->
+      KeyDispatch.handle_key(acc, key, 0)
+    end)
+  end
+end


### PR DESCRIPTION
# TL;DR
Adds a GUI-only side-by-side diff layout that can be toggled with `SPC g d s`. The view keeps old and new lines aligned in one scrollable diff buffer, with filler blanks and pane-local word highlights.

Closes #990

## Context
Issue #990 asks for a GUI side-by-side diff view while keeping the TUI on unified diffs. This PR builds on the existing unified diff buffer and decoration path rather than adding a new frontend protocol surface.

## Changes
- Adds `Minga.Core.DiffView.build_side_by_side/3` and hunk-based side-by-side rendering that emits aligned old/new panes.
- Preserves vertical alignment by inserting blank pane rows for added, deleted, and unpaired modified lines.
- Carries pane-local metadata for line backgrounds and word-level highlights, including clipping word ranges to the visible pane width.
- Adds `:git_diff_toggle_layout` and keeps hunk refresh, stage, and revert paths aware of the active diff layout.
- Injects `SPC g d s` only for GUI frontends in key dispatch, while shared defaults keep the TUI on unified diff commands.
- Adds tests for side-by-side alignment, highlight clipping, hunk refresh behavior, and GUI-only key dispatch.

## Verification
- `git diff --check`
- `mix test.debug test/minga_editor/key_dispatch_gui_bindings_test.exs test/minga/core/diff_view_test.exs test/minga_editor/commands/git_diff_decorations_test.exs test/minga/command/registry_test.exs test/minga/keymap/active_test.exs`
- `make lint`
- `mix test.llm` (8202 tests, 0 failures)

Manual GUI visual verification was not available in this environment.

## Acceptance Criteria Addressed
- `SPC g d s` switches between unified and side-by-side in the GUI diff view ✅
- Side-by-side shows old version on the left and new version on the right ✅
- Scrolling is synchronized because both panes are rendered as one aligned diff buffer ✅
- Matching lines stay at the same vertical position ✅
- Added lines show blank filler in the left pane, and deleted lines show blank filler in the right pane ✅
- Word-level diff highlighting works in both panes ✅
- Hunk actions continue to work in side-by-side mode ✅
- TUI does not expose or implement the side-by-side toggle ✅
