### PR TITLE
refactor(editor): remove apply_effects defdelegate, update callers

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -510,7 +510,7 @@ defmodule MingaEditor do
     new_state = FileWatcherHelpers.handle_file_change(state, path)
     new_state = log_message(new_state, "External change detected: #{path}")
     {new_state, effects} = FileEventHandler.handle(new_state, msg)
-    {:noreply, apply_effects(new_state, effects)}
+    {:noreply, EffectHandler.apply_effects(new_state, effects)}
   end
 
   def handle_info(
@@ -600,7 +600,7 @@ defmodule MingaEditor do
   def handle_info(msg, state) when is_map_key(@handler_atom_dispatch, msg) do
     handler = @handler_atom_dispatch[msg]
     {state, effects} = handler.handle(state, msg)
-    {:noreply, apply_effects(state, effects)}
+    {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
   # ── Highlight events from Parser.Manager ──────────────────────────────────────
@@ -612,7 +612,7 @@ defmodule MingaEditor do
 
   def handle_info({:minga_highlight, _} = msg, state) do
     {state, effects} = HighlightHandler.handle(state, msg)
-    {:noreply, apply_effects(state, effects)}
+    {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
   # Remaining {:minga_input, _} messages are highlight/parser events forwarded
@@ -621,35 +621,35 @@ defmodule MingaEditor do
   # capabilities_updated) are matched above, so this catch-all is safe.
   def handle_info({:minga_input, _} = msg, state) do
     {state, effects} = HighlightHandler.handle(state, msg)
-    {:noreply, apply_effects(state, effects)}
+    {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
   # LSP/completion timer events routed through a focused handler.
   def handle_info({:completion_debounce, _clients, _buffer_pid} = msg, state) do
     {state, effects} = LspEventHandler.handle(state, msg)
-    {:noreply, apply_effects(state, effects)}
+    {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
   def handle_info({:lsp_response, _ref, _result} = msg, state) do
     {state, effects} = LspEventHandler.handle(state, msg)
-    {:noreply, apply_effects(state, effects)}
+    {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
   @lsp_debounce_atoms [:inlay_hint_scroll_debounce, :document_highlight_debounce]
 
   def handle_info(msg, state) when msg in @lsp_debounce_atoms do
     {state, effects} = LspEventHandler.handle(state, msg)
-    {:noreply, apply_effects(state, effects)}
+    {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
   def handle_info({:completion_resolve, _index} = msg, state) do
     {state, effects} = LspEventHandler.handle(state, msg)
-    {:noreply, apply_effects(state, effects)}
+    {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
   def handle_info(:request_code_lens_and_inlay_hints = msg, state) do
     {state, effects} = LspEventHandler.handle(state, msg)
-    {:noreply, apply_effects(state, effects)}
+    {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
   # ── Event bus messages ────────────────────────────────────────────────────────
@@ -668,7 +668,7 @@ defmodule MingaEditor do
   # Debounced file-tree refresh timer fired — rescan the cached tree once for a burst of filesystem events.
   def handle_info(:file_tree_refresh_timer, state) do
     {state, effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
-    {:noreply, apply_effects(state, effects)}
+    {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
   # Renderer.Server writeback after each async frame completes.
@@ -802,7 +802,7 @@ defmodule MingaEditor do
 
   def handle_info({:git_remote_result, ref, _result} = msg, state) when is_reference(ref) do
     {state, effects} = FileEventHandler.handle(state, msg)
-    {:noreply, apply_effects(state, effects)}
+    {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
   def handle_info(_msg, state) do
@@ -982,7 +982,7 @@ defmodule MingaEditor do
       state.shell.on_agent_event(state.shell_state, state.workspace, session_pid, event)
 
     state = %{state | shell_state: shell_state, workspace: workspace}
-    state = apply_effects(state, shell_effects)
+    state = EffectHandler.apply_effects(state, shell_effects)
     {:noreply, schedule_render(state, 16)}
   end
 
@@ -1014,20 +1014,12 @@ defmodule MingaEditor do
   @spec dispatch_agent_event(EditorState.t(), term()) :: EditorState.t()
   defp dispatch_agent_event(state, event) do
     {state, effects} = Events.handle(state, event)
-    apply_effects(state, effects)
+    EffectHandler.apply_effects(state, effects)
   end
 
   # ── Agent lifecycle ──────────────────────────────────────────────────────
 
   @type effect :: EffectHandler.effect()
-
-  @doc """
-  Applies a list of effects to the editor state.
-
-  Delegates to `MingaEditor.Handlers.EffectHandler.apply_effects/2`.
-  """
-  @spec apply_effects(EditorState.t(), [effect()]) :: EditorState.t()
-  defdelegate apply_effects(state, effects), to: EffectHandler
 
   # Tab bar, view state, capabilities, parser subscription helpers
 

--- a/lib/minga_editor/handlers/event_dispatcher.ex
+++ b/lib/minga_editor/handlers/event_dispatcher.ex
@@ -14,6 +14,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
   alias MingaEditor.AgentLifecycle
   alias MingaEditor.Commands
   alias MingaEditor.Frontend.Protocol
+  alias MingaEditor.Handlers.EffectHandler
   alias MingaEditor.Handlers.FileEventHandler
   alias MingaEditor.Handlers.Notifications
   alias MingaEditor.Handlers.ToolHandler
@@ -55,12 +56,12 @@ defmodule MingaEditor.Handlers.EventDispatcher do
   @spec dispatch(EditorState.t(), atom(), term(), term()) :: EditorState.t()
   def dispatch(state, event, _payload, msg) when event in @tool_events do
     {state, effects} = ToolHandler.handle(state, msg)
-    MingaEditor.apply_effects(state, effects)
+    EffectHandler.apply_effects(state, effects)
   end
 
   def dispatch(state, event, _payload, msg) when event in @file_events do
     {state, effects} = FileEventHandler.handle(state, msg)
-    MingaEditor.apply_effects(state, effects)
+    EffectHandler.apply_effects(state, effects)
   end
 
   def dispatch(
@@ -87,7 +88,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
     if effects == [] do
       MingaEditor.schedule_render(state, 16)
     else
-      MingaEditor.apply_effects(state, effects)
+      EffectHandler.apply_effects(state, effects)
     end
   end
 

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -219,11 +219,17 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
     test "applying repeated refresh effects keeps one pending timer", %{tmp_dir: tmp_dir} do
       state = state_with_tree(tmp_dir)
 
-      first_state = MingaEditor.apply_effects(state, [{:schedule_file_tree_refresh, 1_000}])
+      first_state =
+        MingaEditor.Handlers.EffectHandler.apply_effects(state, [
+          {:schedule_file_tree_refresh, 1_000}
+        ])
+
       first_ref = first_state.workspace.file_tree.refresh_timer
 
       second_state =
-        MingaEditor.apply_effects(first_state, [{:schedule_file_tree_refresh, 1_000}])
+        MingaEditor.Handlers.EffectHandler.apply_effects(first_state, [
+          {:schedule_file_tree_refresh, 1_000}
+        ])
 
       assert is_reference(first_ref)
       assert second_state.workspace.file_tree.refresh_timer == first_ref


### PR DESCRIPTION
## Summary

Removes the last `defdelegate` forwarding stub from the editor. All 17 call sites (13 in editor, 3 in EventDispatcher, 1 in tests) now call `EffectHandler.apply_effects/2` directly.

The `@type effect :: EffectHandler.effect()` delegation stays since dozens of files across the codebase reference `MingaEditor.effect()` in their specs.

Editor: 1,254 → 1,247 lines.

Part of #1433 (carve mega-modules into focused submodules).

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test --exclude system_clipboard --exclude conformance` passes (8,458 passed, 0 failures)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)