### PR TITLE
refactor(keymap): reuse agent newline group

### DIFF
--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -27,7 +27,6 @@ defmodule Minga.Keymap.Scope.Agent do
 
   # Modifier bitmasks
   @ctrl 0x02
-  @shift 0x01
   @alt 0x04
   @cmd 0x08
 
@@ -37,7 +36,7 @@ defmodule Minga.Keymap.Scope.Agent do
   # Group specs for each vim state.
   @insert_groups [:ctrl_agent_common, :newline_variants]
   @input_normal_groups [:ctrl_agent_common]
-  @cua_groups [{:cua_navigation, exclude: [:half_page_up, :half_page_down]}]
+  @cua_groups [:newline_variants, {:cua_navigation, exclude: [:half_page_up, :half_page_down]}]
 
   # ── Behaviour callbacks ────────────────────────────────────────────────────
 
@@ -306,10 +305,6 @@ defmodule Minga.Keymap.Scope.Agent do
         |> Bindings.bind(~k(C-a), :select_all, "Select all")
         # Input field bindings (used when input focused)
         |> Bindings.bind(~k(DEL), :agent_input_backspace, "Delete character")
-        |> Bindings.bind([{@enter, @shift}], :agent_insert_newline, "Insert newline")
-        |> Bindings.bind(~k(C-j), :agent_insert_newline, "Insert newline")
-        |> Bindings.bind([{0x0A, 0}], :agent_insert_newline, "Insert newline")
-        |> Bindings.bind([{@enter, @alt}], :agent_insert_newline, "Insert newline")
         # Arrow up/down in input: history navigation
         |> Bindings.bind([{57_352, 0}], :agent_input_up, "Move up / history prev")
         |> Bindings.bind([{57_353, 0}], :agent_input_down, "Move down / history next")

--- a/test/minga/keymap/scope/cua_scope_test.exs
+++ b/test/minga/keymap/scope/cua_scope_test.exs
@@ -19,7 +19,9 @@ defmodule Minga.Keymap.Scope.CUAScopeTest do
 
   @enter 13
   @escape 27
+  @shift 0x01
   @ctrl 0x02
+  @alt 0x04
   @cmd 0x08
 
   # ── File tree scope ────────────────────────────────────────────────────────
@@ -59,6 +61,13 @@ defmodule Minga.Keymap.Scope.CUAScopeTest do
       # Bug 2 regression: Enter must submit when input is focused,
       # not just focus the input every time
       assert {:command, :agent_focus_or_submit} = Scope.resolve_key(:agent, :cua, {@enter, 0})
+    end
+
+    test "newline variants resolve through shared group" do
+      assert {:command, :agent_insert_newline} = Scope.resolve_key(:agent, :cua, {@enter, @shift})
+      assert {:command, :agent_insert_newline} = Scope.resolve_key(:agent, :cua, {?j, @ctrl})
+      assert {:command, :agent_insert_newline} = Scope.resolve_key(:agent, :cua, {0x0A, 0})
+      assert {:command, :agent_insert_newline} = Scope.resolve_key(:agent, :cua, {@enter, @alt})
     end
 
     test "arrow up/down resolve to agent-specific navigation" do


### PR DESCRIPTION
# TL;DR
Centralizes the agent CUA newline bindings on the existing shared `:newline_variants` keymap group. This keeps Shift+Enter, Ctrl+J, raw LF, and Alt+Enter behavior unchanged while removing duplicate binding declarations missed after #1871 merged.

Follow-up to #1871.

## Context
PR #1871 added the readable key sigil and keymap migration. A deferred cleanup landed on the old PR branch after it had already merged, so this PR carries that small cleanup onto `main`.

## Changes
- Adds `:newline_variants` to the agent CUA scope group list.
- Removes the duplicate inline newline bindings from `Minga.Keymap.Scope.Agent.cua_trie/0`.
- Adds CUA scope regression coverage for all four newline encodings.

## Verification
- `make lint` ✅
- `mix format --check-formatted` ✅
- `mix test.llm test/minga/keymap` ✅, 7 doctests, 353 tests, 0 failures
- `git diff --check` ✅

## Acceptance Criteria Addressed
- Agent CUA newline bindings are declared in one shared group ✅
- Existing CUA newline behavior is preserved for all supported encodings ✅
