### PR TITLE
fix(macos): complete tab interaction polish

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -910,6 +910,10 @@ opcode(1) + action_type(1) + payload...
 | 0x46 | notification_action | id_len(2) + id + action_id_len(2) + action_id | Invoke one inline notification action |
 | 0x47 | power_thermal_state | low_power(1) + thermal_state(1) | Report low power mode and thermal pressure changes. `thermal_state` is 0 nominal, 1 fair, 2 serious, 3 critical, 255 unknown. |
 | 0x48 | tab_reorder | tab_id(4) + new_index(2) | Move a visible tab to a zero-based visible index |
+| 0x49 | tab_pin | tab_id(4) | Pin a tab by id without selecting it first |
+| 0x4A | tab_unpin | tab_id(4) | Unpin a tab by id without selecting it first |
+| 0x4B | tab_move_left | tab_id(4) | Move a tab one visible slot left without selecting it first |
+| 0x4C | tab_move_right | tab_id(4) | Move a tab one visible slot right without selecting it first |
 | 0x34 | system_will_sleep | (empty) | System is about to sleep |
 | 0x35 | system_did_wake | (empty) | System woke and BEAM should refresh external state |
 | 0x36 | cmd_copy | (empty) | Execute mode-aware copy from the macOS menu |

--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -847,3 +847,19 @@ value = 0x47
 [[gui_actions]]
 name = "tab_reorder"
 value = 0x48
+
+[[gui_actions]]
+name = "tab_pin"
+value = 0x49
+
+[[gui_actions]]
+name = "tab_unpin"
+value = 0x4A
+
+[[gui_actions]]
+name = "tab_move_left"
+value = 0x4B
+
+[[gui_actions]]
+name = "tab_move_right"
+value = 0x4C

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -90,6 +90,10 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   | 0x44       | config_query            |
   | 0x47       | power_thermal_state     |
   | 0x48       | tab_reorder             |
+  | 0x49       | tab_pin                 |
+  | 0x4A       | tab_unpin               |
+  | 0x4B       | tab_move_left           |
+  | 0x4C       | tab_move_right          |
   | 0x34       | system_will_sleep       |
   | 0x35       | system_did_wake         |
 
@@ -220,6 +224,10 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   @gui_action_tab_copy_path Opcodes.gui_action_tab_copy_path()
   @gui_action_hover_open_action Opcodes.gui_action_hover_open_action()
   @gui_action_tab_reorder Opcodes.gui_action_tab_reorder()
+  @gui_action_tab_pin Opcodes.gui_action_tab_pin()
+  @gui_action_tab_unpin Opcodes.gui_action_tab_unpin()
+  @gui_action_tab_move_left Opcodes.gui_action_tab_move_left()
+  @gui_action_tab_move_right Opcodes.gui_action_tab_move_right()
   @gui_action_file_tree_drop Opcodes.gui_action_file_tree_drop()
   @gui_action_fold_toggle_at_line Opcodes.gui_action_fold_toggle_at_line()
   @gui_action_git_open_diff Opcodes.gui_action_git_open_diff()
@@ -368,6 +376,10 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
           | {:file_tree_open_in_split, index :: non_neg_integer()}
           | {:tab_copy_path, id :: pos_integer()}
           | {:tab_reorder, id :: pos_integer(), new_index :: non_neg_integer()}
+          | {:tab_pin, id :: pos_integer()}
+          | {:tab_unpin, id :: pos_integer()}
+          | {:tab_move_left, id :: pos_integer()}
+          | {:tab_move_right, id :: pos_integer()}
           | :hover_open_action
           | :system_will_sleep
           | :system_did_wake
@@ -3003,6 +3015,11 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
   def decode_gui_action(@gui_action_tab_reorder, <<id::32, new_index::16>>),
     do: {:ok, {:tab_reorder, id, new_index}}
+
+  def decode_gui_action(@gui_action_tab_pin, <<id::32>>), do: {:ok, {:tab_pin, id}}
+  def decode_gui_action(@gui_action_tab_unpin, <<id::32>>), do: {:ok, {:tab_unpin, id}}
+  def decode_gui_action(@gui_action_tab_move_left, <<id::32>>), do: {:ok, {:tab_move_left, id}}
+  def decode_gui_action(@gui_action_tab_move_right, <<id::32>>), do: {:ok, {:tab_move_right, id}}
 
   def decode_gui_action(@gui_action_hover_open_action, <<>>), do: {:ok, :hover_open_action}
 

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -194,6 +194,22 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     reorder_tab(state, id, new_index)
   end
 
+  defp dispatch_action(state, {:tab_pin, id}) do
+    update_tab_bar(state, &TabBar.pin_tab(&1, id))
+  end
+
+  defp dispatch_action(state, {:tab_unpin, id}) do
+    update_tab_bar(state, &TabBar.unpin_tab(&1, id))
+  end
+
+  defp dispatch_action(state, {:tab_move_left, id}) do
+    update_tab_bar(state, &TabBar.move_tab_left(&1, id))
+  end
+
+  defp dispatch_action(state, {:tab_move_right, id}) do
+    update_tab_bar(state, &TabBar.move_tab_right(&1, id))
+  end
+
   defp dispatch_action(state, :hover_open_action) do
     accept_hover_open_action(state)
   end
@@ -879,8 +895,13 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec reorder_tab(state(), Tab.id(), non_neg_integer()) :: state()
   defp reorder_tab(state, id, new_index) do
+    update_tab_bar(state, &TabBar.reorder_tab(&1, id, new_index))
+  end
+
+  @spec update_tab_bar(state(), (TabBar.t() -> TabBar.t())) :: state()
+  defp update_tab_bar(state, fun) when is_function(fun, 1) do
     case EditorState.tab_bar(state) do
-      %TabBar{} = tb -> EditorState.set_tab_bar(state, TabBar.reorder_tab(tb, id, new_index))
+      %TabBar{} = tb -> EditorState.set_tab_bar(state, fun.(tb))
       nil -> state
     end
   end

--- a/lib/minga_editor/state/tab_bar.ex
+++ b/lib/minga_editor/state/tab_bar.ex
@@ -302,11 +302,19 @@ defmodule MingaEditor.State.TabBar do
 
   @doc "Moves the active tab one visible slot left within its workspace."
   @spec move_active_tab_left(t()) :: t()
-  def move_active_tab_left(%__MODULE__{} = tb), do: move_active_tab(tb, -1)
+  def move_active_tab_left(%__MODULE__{} = tb), do: move_tab(tb, tb.active_id, -1)
 
   @doc "Moves the active tab one visible slot right within its workspace."
   @spec move_active_tab_right(t()) :: t()
-  def move_active_tab_right(%__MODULE__{} = tb), do: move_active_tab(tb, 1)
+  def move_active_tab_right(%__MODULE__{} = tb), do: move_tab(tb, tb.active_id, 1)
+
+  @doc "Moves the tab with the given id one visible slot left within its workspace."
+  @spec move_tab_left(t(), Tab.id()) :: t()
+  def move_tab_left(%__MODULE__{} = tb, id), do: move_tab(tb, id, -1)
+
+  @doc "Moves the tab with the given id one visible slot right within its workspace."
+  @spec move_tab_right(t(), Tab.id()) :: t()
+  def move_tab_right(%__MODULE__{} = tb, id), do: move_tab(tb, id, 1)
 
   @doc "Reorders a visible file tab within its workspace by zero-based visible index."
   @spec reorder_tab(t(), Tab.id(), non_neg_integer()) :: t()
@@ -562,11 +570,22 @@ defmodule MingaEditor.State.TabBar do
     Enum.filter(tabs, & &1.pinned?) ++ Enum.reject(tabs, & &1.pinned?)
   end
 
-  @spec move_active_tab(t(), 1 | -1) :: t()
-  defp move_active_tab(%__MODULE__{active_id: active_id} = tb, step) do
-    tabs = visible_file_tabs(tb)
+  @spec move_tab(t(), Tab.id(), 1 | -1) :: t()
+  defp move_tab(%__MODULE__{} = tb, id, step) do
+    case get(tb, id) do
+      %Tab{kind: :file, group_id: workspace_id} ->
+        move_file_tab(tb, id, workspace_id, step)
 
-    case Enum.find_index(tabs, &(&1.id == active_id)) do
+      _ ->
+        tb
+    end
+  end
+
+  @spec move_file_tab(t(), Tab.id(), non_neg_integer(), 1 | -1) :: t()
+  defp move_file_tab(%__MODULE__{} = tb, id, workspace_id, step) do
+    tabs = visible_file_tabs(tb, workspace_id)
+
+    case Enum.find_index(tabs, &(&1.id == id)) do
       nil ->
         tb
 
@@ -574,7 +593,7 @@ defmodule MingaEditor.State.TabBar do
         target_index = current_index + step
 
         if visible_tab_reorder_allowed?(tabs, current_index, target_index) do
-          reorder_tab(tb, active_id, target_index)
+          reorder_tab(tb, id, target_index)
         else
           tb
         end

--- a/macos/Sources/Protocol/ProtocolEncoder.swift
+++ b/macos/Sources/Protocol/ProtocolEncoder.swift
@@ -23,6 +23,10 @@ protocol InputEncoder: AnyObject, Sendable {
     func sendCloseTab(id: UInt32)
     func sendTabCopyPath(id: UInt32)
     func sendTabReorder(id: UInt32, newIndex: UInt16)
+    func sendTabPin(id: UInt32)
+    func sendTabUnpin(id: UInt32)
+    func sendTabMoveLeft(id: UInt32)
+    func sendTabMoveRight(id: UInt32)
     func sendHoverOpenAction()
     func sendFileTreeClick(index: UInt16)
     func sendFileTreeToggle(index: UInt16)
@@ -342,6 +346,34 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
         buf[1] = GUI_ACTION_TAB_REORDER
         writeU32(&buf, 2, id)
         writeU16(&buf, 6, newIndex)
+        writeFrame(buf)
+    }
+
+    /// Send a gui_action: tab_pin. Layout: opcode(1) + action_type(1) + tab_id(4).
+    func sendTabPin(id: UInt32) {
+        sendTabIdAction(actionType: GUI_ACTION_TAB_PIN, id: id)
+    }
+
+    /// Send a gui_action: tab_unpin. Layout: opcode(1) + action_type(1) + tab_id(4).
+    func sendTabUnpin(id: UInt32) {
+        sendTabIdAction(actionType: GUI_ACTION_TAB_UNPIN, id: id)
+    }
+
+    /// Send a gui_action: tab_move_left. Layout: opcode(1) + action_type(1) + tab_id(4).
+    func sendTabMoveLeft(id: UInt32) {
+        sendTabIdAction(actionType: GUI_ACTION_TAB_MOVE_LEFT, id: id)
+    }
+
+    /// Send a gui_action: tab_move_right. Layout: opcode(1) + action_type(1) + tab_id(4).
+    func sendTabMoveRight(id: UInt32) {
+        sendTabIdAction(actionType: GUI_ACTION_TAB_MOVE_RIGHT, id: id)
+    }
+
+    private func sendTabIdAction(actionType: UInt8, id: UInt32) {
+        var buf = Data(count: 6)
+        buf[0] = OP_GUI_ACTION
+        buf[1] = actionType
+        writeU32(&buf, 2, id)
         writeFrame(buf)
     }
 

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -9,6 +9,15 @@
 /// back to a compact capsule showing the tab count.
 
 import SwiftUI
+import UniformTypeIdentifiers
+
+/// Context-menu actions that target a specific tab without selecting it first.
+enum TabContextMenuAction: Equatable {
+    case pin
+    case unpin
+    case moveLeft
+    case moveRight
+}
 
 /// The tab bar strip rendered above the editor area.
 struct TabBarView: View {
@@ -159,6 +168,60 @@ struct TabBarView: View {
         }
 
         return tabBarState.tabs
+    }
+
+    func performTabContextMenuAction(_ action: TabContextMenuAction, for tab: TabEntry) {
+        switch action {
+        case .pin:
+            encoder?.sendTabPin(id: tab.id)
+        case .unpin:
+            encoder?.sendTabUnpin(id: tab.id)
+        case .moveLeft:
+            encoder?.sendTabMoveLeft(id: tab.id)
+        case .moveRight:
+            encoder?.sendTabMoveRight(id: tab.id)
+        }
+    }
+
+    func canMoveTabLeft(_ tab: TabEntry) -> Bool {
+        guard let index = movableTabIndex(tab) else { return false }
+        return index > 0
+    }
+
+    func canMoveTabRight(_ tab: TabEntry) -> Bool {
+        guard let index = movableTabIndex(tab) else { return false }
+        return index < movableTabs(for: tab).count - 1
+    }
+
+    func handleTabDrop(droppedTabs: [TabDragPayload], target tab: TabEntry, visibleIndex: Int) -> Bool {
+        guard let reorder = tabDropReorder(droppedTabs: droppedTabs, target: tab, visibleIndex: visibleIndex) else {
+            return false
+        }
+        encoder?.sendTabReorder(id: reorder.id, newIndex: reorder.newIndex)
+        return true
+    }
+
+    func tabDropReorder(droppedTabs: [TabDragPayload], target tab: TabEntry, visibleIndex: Int) -> (id: UInt32, newIndex: UInt16)? {
+        guard let draggedId = droppedTabs.first?.id,
+              draggedId != tab.id else {
+            return nil
+        }
+        guard let draggedTab = displayTabs.first(where: { $0.id == draggedId }),
+              draggedTab.groupId == tab.groupId,
+              draggedTab.isPinned == tab.isPinned else {
+            return nil
+        }
+        return (draggedId, UInt16(visibleIndex))
+    }
+
+    private func movableTabIndex(_ tab: TabEntry) -> Int? {
+        movableTabs(for: tab).firstIndex { $0.id == tab.id }
+    }
+
+    private func movableTabs(for tab: TabEntry) -> [TabEntry] {
+        displayTabs.filter { candidate in
+            candidate.groupId == tab.groupId && candidate.isPinned == tab.isPinned
+        }
     }
 
     // MARK: - Tab strip layouts
@@ -506,22 +569,11 @@ struct TabBarView: View {
                     tabDragInProgress = false
                 }
         )
-        .draggable(tabDragPayload(tab)) {
+        .draggable(TabDragPayload(id: tab.id)) {
             tabDragPreview(tab)
         }
-        .dropDestination(for: String.self) { droppedIds, _location in
-            guard let first = droppedIds.first,
-                  let draggedId = tabDragId(from: first),
-                  draggedId != tab.id else {
-                return false
-            }
-            guard let draggedTab = displayTabs.first(where: { $0.id == draggedId }),
-                  draggedTab.groupId == tab.groupId,
-                  draggedTab.isPinned == tab.isPinned else {
-                return false
-            }
-            encoder?.sendTabReorder(id: draggedId, newIndex: UInt16(visibleIndex))
-            return true
+        .dropDestination(for: TabDragPayload.self) { droppedTabs, _location in
+            handleTabDrop(droppedTabs: droppedTabs, target: tab, visibleIndex: visibleIndex)
         } isTargeted: { targeted in
             withAnimation(.easeOut(duration: 0.12)) {
                 dropTargetTabId = targeted ? tab.id : nil
@@ -533,18 +585,17 @@ struct TabBarView: View {
         .help(tab.label)
         .contextMenu {
             Button(tab.isPinned ? "Unpin Tab" : "Pin Tab") {
-                encoder?.sendSelectTab(id: tab.id)
-                encoder?.sendExecuteCommand(name: tab.isPinned ? "unpin_tab" : "pin_tab")
+                performTabContextMenuAction(tab.isPinned ? .unpin : .pin, for: tab)
             }
             Divider()
             Button("Move Tab Left") {
-                encoder?.sendSelectTab(id: tab.id)
-                encoder?.sendExecuteCommand(name: "move_tab_left")
+                performTabContextMenuAction(.moveLeft, for: tab)
             }
+            .disabled(!canMoveTabLeft(tab))
             Button("Move Tab Right") {
-                encoder?.sendSelectTab(id: tab.id)
-                encoder?.sendExecuteCommand(name: "move_tab_right")
+                performTabContextMenuAction(.moveRight, for: tab)
             }
+            .disabled(!canMoveTabRight(tab))
             Divider()
             Button("Close") {
                 encoder?.sendCloseTab(id: tab.id)
@@ -669,18 +720,6 @@ struct TabBarView: View {
         return nil
     }
 
-    private func tabDragPayload(_ tab: TabEntry) -> String {
-        "tab:\(tab.id)"
-    }
-
-    private func tabDragId(from payload: String) -> UInt32? {
-        guard payload.hasPrefix("tab:") else {
-            return nil
-        }
-
-        return UInt32(payload.dropFirst(4))
-    }
-
     private func tabAccessibilityValue(_ tab: TabEntry) -> String {
         var values: [String] = []
 
@@ -695,6 +734,19 @@ struct TabBarView: View {
         }
 
         return values.isEmpty ? "clean" : values.joined(separator: ", ")
+    }
+}
+
+// MARK: - Drag payload
+
+/// App-private tab drag payload used for in-window tab reordering.
+struct TabDragPayload: Codable, Hashable, Sendable, Transferable {
+    static let contentType = UTType(exportedAs: "com.minga.tab-id")
+
+    let id: UInt32
+
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: contentType)
     }
 }
 

--- a/macos/Tests/MingaTests/GUIActionEncoderTests.swift
+++ b/macos/Tests/MingaTests/GUIActionEncoderTests.swift
@@ -34,6 +34,23 @@ struct GUIActionEncoderTests {
         #expect(spy.guiActions == [.closeTab(id: 99)])
     }
 
+    @Test("tab context menu actions record tab IDs")
+    func tabContextMenuActions() {
+        let spy = SpyEncoder()
+        let encoder: InputEncoder = spy
+        encoder.sendTabPin(id: 7)
+        encoder.sendTabUnpin(id: 8)
+        encoder.sendTabMoveLeft(id: 9)
+        encoder.sendTabMoveRight(id: 10)
+
+        #expect(spy.guiActions == [
+            .tabPin(id: 7),
+            .tabUnpin(id: 8),
+            .tabMoveLeft(id: 9),
+            .tabMoveRight(id: 10)
+        ])
+    }
+
     @Test("sendNewTab records action")
     func newTab() {
         let spy = SpyEncoder()

--- a/macos/Tests/MingaTests/ProtocolEncoderBinaryTests.swift
+++ b/macos/Tests/MingaTests/ProtocolEncoderBinaryTests.swift
@@ -227,6 +227,23 @@ struct EncoderGUIActionTests {
         #expect(readU16(payload, 6) == 3)
     }
 
+    @Test("tab id-scoped actions encode action type and tab ID")
+    func tabIdScopedActionLayouts() {
+        let cases: [(Data, UInt8, UInt32)] = [
+            (captureFrame { $0.sendTabPin(id: 7) }, GUI_ACTION_TAB_PIN, 7),
+            (captureFrame { $0.sendTabUnpin(id: 8) }, GUI_ACTION_TAB_UNPIN, 8),
+            (captureFrame { $0.sendTabMoveLeft(id: 9) }, GUI_ACTION_TAB_MOVE_LEFT, 9),
+            (captureFrame { $0.sendTabMoveRight(id: 10) }, GUI_ACTION_TAB_MOVE_RIGHT, 10)
+        ]
+
+        for (payload, action, id) in cases {
+            #expect(payload.count == 6)
+            #expect(payload[0] == OP_GUI_ACTION)
+            #expect(payload[1] == action)
+            #expect(readU32(payload, 2) == id)
+        }
+    }
+
     @Test("file_tree_click encodes index as UInt16")
     func fileTreeClickLayout() {
         let payload = captureFrame { $0.sendFileTreeClick(index: 15) }

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -438,6 +438,10 @@ final class SpyEncoder: InputEncoder, Sendable {
         case closeTab(id: UInt32)
         case tabCopyPath(id: UInt32)
         case tabReorder(id: UInt32, newIndex: UInt16)
+        case tabPin(id: UInt32)
+        case tabUnpin(id: UInt32)
+        case tabMoveLeft(id: UInt32)
+        case tabMoveRight(id: UInt32)
         case hoverOpenAction
         case fileTreeClick(index: UInt16)
         case fileTreeToggle(index: UInt16)
@@ -538,6 +542,10 @@ final class SpyEncoder: InputEncoder, Sendable {
     func sendCloseTab(id: UInt32) { state.withLock { $0.guiActions.append(.closeTab(id: id)) } }
     func sendTabCopyPath(id: UInt32) { state.withLock { $0.guiActions.append(.tabCopyPath(id: id)) } }
     func sendTabReorder(id: UInt32, newIndex: UInt16) { state.withLock { $0.guiActions.append(.tabReorder(id: id, newIndex: newIndex)) } }
+    func sendTabPin(id: UInt32) { state.withLock { $0.guiActions.append(.tabPin(id: id)) } }
+    func sendTabUnpin(id: UInt32) { state.withLock { $0.guiActions.append(.tabUnpin(id: id)) } }
+    func sendTabMoveLeft(id: UInt32) { state.withLock { $0.guiActions.append(.tabMoveLeft(id: id)) } }
+    func sendTabMoveRight(id: UInt32) { state.withLock { $0.guiActions.append(.tabMoveRight(id: id)) } }
     func sendHoverOpenAction() { state.withLock { $0.guiActions.append(.hoverOpenAction) } }
     func sendFileTreeClick(index: UInt16) { state.withLock { $0.guiActions.append(.fileTreeClick(index: index)) } }
     func sendFileTreeToggle(index: UInt16) { state.withLock { $0.guiActions.append(.fileTreeToggle(index: index)) } }

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -11,6 +11,7 @@
 
 import Testing
 import SwiftUI
+import UniformTypeIdentifiers
 import ViewInspector
 
 // MARK: - CompletionOverlay
@@ -665,6 +666,14 @@ struct StatusBarViewViewTests {
 @Suite("TabBarView View Structure")
 struct TabBarViewViewTests {
 
+    private func wireTab(id: UInt32, groupId: UInt16 = 0, isActive: Bool = false, isPinned: Bool = false, label: String? = nil) -> Wire.TabEntry {
+        Wire.TabEntry(id: id, groupId: groupId, isActive: isActive, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: isPinned, tintColorRGB: 0, icon: "", label: label ?? "tab-\(id).ex")
+    }
+
+    private func tab(id: UInt32, groupId: UInt16 = 0, isActive: Bool = false, isPinned: Bool = false, label: String? = nil) -> TabEntry {
+        TabEntry(id: id, groupId: groupId, isActive: isActive, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: isPinned, tintColor: nil, icon: "", label: label ?? "tab-\(id).ex")
+    }
+
     @Test("Tab bar shows all tab labels")
     @MainActor func showsAllTabs() throws {
         let state = TabBarState()
@@ -682,6 +691,123 @@ struct TabBarViewViewTests {
 
         #expect(strings.contains("editor.ex"))
         #expect(strings.contains("test.ex"))
+    }
+
+    @Test("Inactive tab context menu actions use id-scoped events")
+    @MainActor func inactiveTabContextMenuActionsUseIdScopedEvents() throws {
+        let spy = SpyEncoder()
+        let state = TabBarState()
+        state.update(activeIndex: 0, entries: [
+            wireTab(id: 1, isActive: true),
+            wireTab(id: 2),
+            wireTab(id: 3, isPinned: true),
+        ])
+        let sut = TabBarView(tabBarState: state, theme: ThemeColors(), encoder: spy)
+        let inactive = tab(id: 2)
+        let pinnedInactive = tab(id: 3, isPinned: true)
+
+        sut.performTabContextMenuAction(.pin, for: inactive)
+        sut.performTabContextMenuAction(.unpin, for: pinnedInactive)
+        sut.performTabContextMenuAction(.moveLeft, for: inactive)
+        sut.performTabContextMenuAction(.moveRight, for: inactive)
+
+        #expect(spy.guiActions == [
+            .tabPin(id: 2),
+            .tabUnpin(id: 3),
+            .tabMoveLeft(id: 2),
+            .tabMoveRight(id: 2)
+        ])
+        #expect(!spy.guiActions.contains(.selectTab(id: 2)))
+        #expect(!spy.guiActions.contains { action in
+            if case .executeCommand = action { return true }
+            return false
+        })
+    }
+
+    @Test("Tab context menu disables impossible pinned-bucket moves")
+    @MainActor func tabContextMenuMoveEnablementHonorsPinnedBuckets() throws {
+        let state = TabBarState()
+        state.update(activeIndex: 0, entries: [
+            wireTab(id: 1, isActive: true, isPinned: true),
+            wireTab(id: 2, isPinned: true),
+            wireTab(id: 3),
+            wireTab(id: 4),
+            wireTab(id: 5, groupId: 1),
+        ])
+        let sut = TabBarView(tabBarState: state, theme: ThemeColors(), encoder: nil)
+
+        #expect(!sut.canMoveTabLeft(tab(id: 1, isActive: true, isPinned: true)))
+        #expect(sut.canMoveTabRight(tab(id: 1, isActive: true, isPinned: true)))
+        #expect(sut.canMoveTabLeft(tab(id: 2, isPinned: true)))
+        #expect(!sut.canMoveTabRight(tab(id: 2, isPinned: true)))
+        #expect(!sut.canMoveTabLeft(tab(id: 3)))
+        #expect(sut.canMoveTabRight(tab(id: 3)))
+        #expect(sut.canMoveTabLeft(tab(id: 4)))
+        #expect(!sut.canMoveTabRight(tab(id: 4)))
+        #expect(!sut.canMoveTabLeft(tab(id: 5, groupId: 1)))
+        #expect(!sut.canMoveTabRight(tab(id: 5, groupId: 1)))
+    }
+
+    @Test("Tab context menu items disable move actions at bucket edges")
+    @MainActor func tabContextMenuItemsDisableMoveActionsAtBucketEdges() throws {
+        let state = TabBarState()
+        state.update(activeIndex: 0, entries: [
+            wireTab(id: 1, isActive: true, isPinned: true, label: "pinned-1.ex"),
+            wireTab(id: 2, isPinned: true, label: "pinned-2.ex"),
+            wireTab(id: 3, label: "plain-1.ex"),
+            wireTab(id: 4, label: "plain-2.ex"),
+        ])
+        let sut = TabBarView(tabBarState: state, theme: ThemeColors(), encoder: nil)
+        let body = try sut.inspect()
+        let buttons = body.findAll(ViewType.Button.self)
+
+        let moveLeftButtons = buttons.filter {
+            ((try? $0.labelView().text().string()) ?? "") == "Move Tab Left"
+        }
+        let moveRightButtons = buttons.filter {
+            ((try? $0.labelView().text().string()) ?? "") == "Move Tab Right"
+        }
+
+        #expect(moveLeftButtons.count == 4)
+        #expect(moveRightButtons.count == 4)
+
+        let moveLeftDisabledStates = moveLeftButtons.map { $0.isDisabled() }
+        let moveRightDisabledStates = moveRightButtons.map { $0.isDisabled() }
+
+        #expect(moveLeftDisabledStates == [true, false, true, false])
+        #expect(moveRightDisabledStates == [false, true, false, true])
+    }
+
+    @Test("Tab drag payload stays private and drops only accept tab payloads in the same bucket")
+    @MainActor func tabDragPayloadAndDropGuard() throws {
+        let spy = SpyEncoder()
+        let state = TabBarState()
+        state.update(activeIndex: 0, entries: [
+            wireTab(id: 1),
+            wireTab(id: 2),
+            wireTab(id: 3, groupId: 1),
+            wireTab(id: 4, isPinned: true),
+        ])
+        let sut = TabBarView(tabBarState: state, theme: ThemeColors(), encoder: spy)
+        let target = tab(id: 2)
+
+        #expect(TabDragPayload.contentType.identifier == "com.minga.tab-id")
+        #expect(TabDragPayload.contentType != UTType.plainText)
+
+        if let reorder = sut.tabDropReorder(droppedTabs: [], target: target, visibleIndex: 1) {
+            Issue.record("Expected empty payload to be rejected, got \(reorder)")
+        }
+        if let reorder = sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 3)], target: target, visibleIndex: 1) {
+            Issue.record("Expected cross-workspace payload to be rejected, got \(reorder)")
+        }
+        if let reorder = sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 4)], target: target, visibleIndex: 1) {
+            Issue.record("Expected pinned-bucket mismatch to be rejected, got \(reorder)")
+        }
+
+        let accepted = sut.handleTabDrop(droppedTabs: [TabDragPayload(id: 1)], target: target, visibleIndex: 1)
+
+        #expect(accepted)
+        #expect(spy.guiActions == [.tabReorder(id: 1, newIndex: 1)])
     }
 
     @Test("Tab bar uses canonical active-workspace visible tabs")

--- a/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
+++ b/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
@@ -50,6 +50,43 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
       assert gid2 == 5
     end
 
+    test "tab entry includes pinned flag and tint color bytes" do
+      tab =
+        TabSummary.new(
+          id: 1,
+          workspace_id: 3,
+          kind: :file,
+          label: "pinned.ex",
+          path: "/tmp/pinned.ex",
+          icon: "",
+          pinned?: true,
+          tint_color: 0x12_34_56
+        )
+
+      chrome_state = chrome_state(active_workspace_id: 3, active_tab_id: 1, visible_tabs: [tab])
+
+      <<0x71, 0::8, 1::8, flags::8, 1::32, 3::16, icon_len::8, _icon::binary-size(icon_len),
+        label_len::16, label::binary-size(label_len), tint::32>> =
+        ProtocolGUI.encode_gui_tab_bar(chrome_state)
+
+      assert Bitwise.band(flags, 0x80) == 0x80
+      assert label == "pinned.ex"
+      assert tint == 0x12_34_56
+    end
+
+    test "raw tab bar entry includes pinned flag and zero tint color" do
+      tab = %Tab{id: 1, kind: :file, label: "pinned.ex", pinned?: true}
+      tb = %TabBar{tabs: [tab], active_id: 1, next_id: 2}
+
+      <<0x71, 0::8, 1::8, flags::8, 1::32, 0::16, icon_len::8, _icon::binary-size(icon_len),
+        label_len::16, label::binary-size(label_len), tint::32>> =
+        ProtocolGUI.encode_gui_tab_bar(tb)
+
+      assert Bitwise.band(flags, 0x80) == 0x80
+      assert label == "pinned.ex"
+      assert tint == 0
+    end
+
     test "uses 255 active index when the active tab is hidden from visible tabs" do
       chrome_state = %ChromeState{
         workspaces: [
@@ -348,6 +385,13 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
     test "decodes tab reorder" do
       assert {:ok, {:tab_reorder, 42, 3}} ==
                ProtocolGUI.decode_gui_action(0x48, <<42::32, 3::16>>)
+    end
+
+    test "decodes id-scoped tab context actions" do
+      assert {:ok, {:tab_pin, 42}} == ProtocolGUI.decode_gui_action(0x49, <<42::32>>)
+      assert {:ok, {:tab_unpin, 42}} == ProtocolGUI.decode_gui_action(0x4A, <<42::32>>)
+      assert {:ok, {:tab_move_left, 42}} == ProtocolGUI.decode_gui_action(0x4B, <<42::32>>)
+      assert {:ok, {:tab_move_right, 42}} == ProtocolGUI.decode_gui_action(0x4C, <<42::32>>)
     end
 
     test "decodes hover open action" do

--- a/test/minga_editor/frontend/protocol_schema_test.exs
+++ b/test/minga_editor/frontend/protocol_schema_test.exs
@@ -221,7 +221,11 @@ defmodule MingaEditor.Frontend.ProtocolSchemaTest do
       notification_dismiss: 0x45,
       notification_action: 0x46,
       power_thermal_state: 0x47,
-      tab_reorder: 0x48
+      tab_reorder: 0x48,
+      tab_pin: 0x49,
+      tab_unpin: 0x4A,
+      tab_move_left: 0x4B,
+      tab_move_right: 0x4C
     )
   end
 

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -974,6 +974,19 @@ defmodule MingaEditor.Frontend.ProtocolTest do
       assert {:ok, {:gui_action, {:tab_reorder, 42, 3}}} = Protocol.decode_event(payload)
     end
 
+    test "tab id-scoped context actions" do
+      assert {:ok, {:gui_action, {:tab_pin, 42}}} = Protocol.decode_event(<<0x07, 0x49, 42::32>>)
+
+      assert {:ok, {:gui_action, {:tab_unpin, 42}}} =
+               Protocol.decode_event(<<0x07, 0x4A, 42::32>>)
+
+      assert {:ok, {:gui_action, {:tab_move_left, 42}}} =
+               Protocol.decode_event(<<0x07, 0x4B, 42::32>>)
+
+      assert {:ok, {:gui_action, {:tab_move_right, 42}}} =
+               Protocol.decode_event(<<0x07, 0x4C, 42::32>>)
+    end
+
     test "system_will_sleep with no payload" do
       payload = <<0x07, 0x34>>
       assert {:ok, {:gui_action, :system_will_sleep}} = Protocol.decode_event(payload)

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -8,8 +8,38 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
   alias Minga.Events
   alias MingaEditor.Handlers.GuiActionHandler
   alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ResourcePressure
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
   alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
+
+  test "tab context actions target the requested tab without selecting it" do
+    tab1 = Tab.new_file(1, "a.ex")
+    tab2 = Tab.new_file(2, "b.ex")
+    tab3 = Tab.new_file(3, "c.ex")
+    tab_bar = %TabBar{tabs: [tab1, tab2, tab3], active_id: 1, next_id: 4}
+    state = TestHelpers.base_state() |> EditorState.set_tab_bar(tab_bar)
+
+    pinned = GuiActionHandler.dispatch(state, {:tab_pin, 3})
+    pinned_tab_bar = EditorState.tab_bar(pinned)
+
+    assert pinned_tab_bar.active_id == 1
+    assert TabBar.get(pinned_tab_bar, 3).pinned?
+    assert Enum.map(TabBar.visible_file_tabs(pinned_tab_bar), & &1.id) == [3, 1, 2]
+
+    moved = GuiActionHandler.dispatch(pinned, {:tab_move_left, 2})
+    moved_tab_bar = EditorState.tab_bar(moved)
+
+    assert moved_tab_bar.active_id == 1
+    assert Enum.map(TabBar.visible_file_tabs(moved_tab_bar), & &1.id) == [3, 2, 1]
+
+    unpinned = GuiActionHandler.dispatch(moved, {:tab_unpin, 3})
+    unpinned_tab_bar = EditorState.tab_bar(unpinned)
+
+    assert unpinned_tab_bar.active_id == 1
+    refute TabBar.get(unpinned_tab_bar, 3).pinned?
+  end
 
   test "power thermal gui action updates resource pressure and broadcasts the event" do
     registry = power_thermal_events_registry()

--- a/test/minga_editor/state/tab_bar_test.exs
+++ b/test/minga_editor/state/tab_bar_test.exs
@@ -108,6 +108,29 @@ defmodule MingaEditor.State.TabBarTest do
       assert Enum.map(TabBar.visible_file_tabs(moved_right), & &1.label) == ["a", "b", "c"]
     end
 
+    test "moves a tab by id without changing the active tab" do
+      tb = tab_bar(file: "a", file: "b", file: "c") |> TabBar.switch_to(1)
+
+      moved_left = TabBar.move_tab_left(tb, 3)
+
+      assert moved_left.active_id == 1
+      assert Enum.map(TabBar.visible_file_tabs(moved_left), & &1.label) == ["a", "c", "b"]
+
+      moved_right = TabBar.move_tab_right(moved_left, 3)
+
+      assert moved_right.active_id == 1
+      assert Enum.map(TabBar.visible_file_tabs(moved_right), & &1.label) == ["a", "b", "c"]
+    end
+
+    test "moving a tab by id stays inside its workspace and pinned bucket" do
+      {tb, group1, group2} = two_workspaces()
+      tb = TabBar.pin_tab(tb, 3)
+
+      assert TabBar.move_tab_left(tb, 3) == tb
+      assert Enum.map(TabBar.visible_file_tabs(tb, group1.id), & &1.label) == ["b.ex"]
+      assert Enum.map(TabBar.visible_file_tabs(tb, group2.id), & &1.label) == ["c.ex"]
+    end
+
     test "reorders a dragged tab by visible index" do
       tb = tab_bar(file: "a", file: "b", file: "c")
 

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -184,6 +184,10 @@ pub const GUI_ACTION_NOTIFICATION_DISMISS = opcodes.GUI_ACTION_NOTIFICATION_DISM
 pub const GUI_ACTION_NOTIFICATION_ACTION = opcodes.GUI_ACTION_NOTIFICATION_ACTION;
 pub const GUI_ACTION_POWER_THERMAL_STATE = opcodes.GUI_ACTION_POWER_THERMAL_STATE;
 pub const GUI_ACTION_TAB_REORDER = opcodes.GUI_ACTION_TAB_REORDER;
+pub const GUI_ACTION_TAB_PIN = opcodes.GUI_ACTION_TAB_PIN;
+pub const GUI_ACTION_TAB_UNPIN = opcodes.GUI_ACTION_TAB_UNPIN;
+pub const GUI_ACTION_TAB_MOVE_LEFT = opcodes.GUI_ACTION_TAB_MOVE_LEFT;
+pub const GUI_ACTION_TAB_MOVE_RIGHT = opcodes.GUI_ACTION_TAB_MOVE_RIGHT;
 
 // Log levels// Log levels
 pub const LOG_LEVEL_ERR: u8 = 0;
@@ -2744,6 +2748,14 @@ test "decode draw_styled_text with underline style curl" {
 test "decode draw_styled_text truncated returns malformed" {
     const data = [_]u8{ 0x1C, 0x00, 0x03 }; // too short
     try std.testing.expectError(error.Malformed, decodeCommand(&data));
+}
+
+test "tab GUI action re-exports stay wired to generated opcodes" {
+    try std.testing.expectEqual(opcodes.GUI_ACTION_TAB_REORDER, GUI_ACTION_TAB_REORDER);
+    try std.testing.expectEqual(opcodes.GUI_ACTION_TAB_PIN, GUI_ACTION_TAB_PIN);
+    try std.testing.expectEqual(opcodes.GUI_ACTION_TAB_UNPIN, GUI_ACTION_TAB_UNPIN);
+    try std.testing.expectEqual(opcodes.GUI_ACTION_TAB_MOVE_LEFT, GUI_ACTION_TAB_MOVE_LEFT);
+    try std.testing.expectEqual(opcodes.GUI_ACTION_TAB_MOVE_RIGHT, GUI_ACTION_TAB_MOVE_RIGHT);
 }
 
 test {


### PR DESCRIPTION
# TL;DR
This follow-up finishes the tab interaction polish that came out of PR #1870 review. Inactive-tab context menu actions now target the clicked tab directly, tab drag/drop uses an app-private payload, and protocol coverage now guards the new tab actions across BEAM, Swift, and Zig.

Follow-up to #1870.

## Context
PR #1870 added macOS tab pinning and reorder support. After that PR merged, there were remaining non-blocking review items around native Mac context-menu behavior, drag payload privacy, and protocol test coverage. This PR lands those follow-ups on top of current `main`.

## Changes
- Added id-scoped GUI actions for tab pin, unpin, move left, and move right, so context-menu actions can mutate an inactive tab without selecting it first.
- Updated `TabBarView` to disable impossible move-left and move-right menu items at pinned/unpinned bucket edges.
- Replaced plain string tab drag payloads with an app-private `TabDragPayload` using the `com.minga.tab-id` UTI.
- Added Zig re-exports and a focused Zig test for the new generated GUI action constants.
- Added protocol, handler, state, Swift encoder, Swift view, and BEAM tab-bar encoding coverage for the new behavior.

## Verification
- `mix test.llm test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs test/minga_editor/frontend/protocol_schema_test.exs test/minga_editor/frontend/protocol_test.exs test/minga_editor/handlers/gui_action_handler_test.exs test/minga_editor/state/tab_bar_test.exs test/minga_editor/commands/buffer_management_test.exs test/minga_editor/shell/traditional/tab_bar_renderer_test.exs test/minga_editor/mouse_test.exs` passed, 359 tests.
- `mix protocol.gen --check` passed.
- `mix format --check-formatted lib/minga_editor/frontend/protocol/gui.ex lib/minga_editor/handlers/gui_action_handler.ex lib/minga_editor/state/tab_bar.ex test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs test/minga_editor/frontend/protocol_schema_test.exs test/minga_editor/frontend/protocol_test.exs test/minga_editor/handlers/gui_action_handler_test.exs test/minga_editor/state/tab_bar_test.exs` passed.
- `mix zig.lint` passed.
- `xcodebuild test -scheme Minga -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO -only-testing:MingaTests/GUIActionEncoderTests -only-testing:MingaTests/EncoderGUIActionTests -only-testing:MingaTests/ProtocolSchemaTests -only-testing:MingaTests/ProtocolEncoderBinaryTests -only-testing:MingaTests/SwiftUIViewTests -quiet` passed.
- `git diff --check` passed.
