### PR TITLE
Load bundled languages from extension pack

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -496,7 +496,7 @@ for_filetype :elixir, tab_width: 2, autopair: true
 
 When you open a Go file, `tab_width` is 8. When you open an Elixir file, it's 2. Buffers with no filetype (or filetypes without overrides) use the global value.
 
-You can set any option that `set/2` accepts. The filetype atom matches what [`Minga.Filetype`](https://jsmestad.github.io/minga/Minga.Filetype.html) detects (`:elixir`, `:go`, `:python`, `:rust`, `:javascript`, etc.).
+You can set any option that `set/2` accepts. The filetype atom matches what `Minga.Language.detect_filetype/1` detects (`:elixir`, `:go`, `:python`, `:rust`, `:javascript`, etc.).
 
 ## Formatters
 
@@ -673,12 +673,14 @@ bold = true
 
 ### Registering custom filetypes
 
-If Minga doesn't recognize a file extension, you can register it in your config so the right grammar is used:
+If Minga doesn't recognize a file extension, the preferred fix is a language pack: define a `%Minga.Language{}` in a pack and register it with `Minga.Language.Registry.register/2`. That one registration owns file extensions, exact filenames, shebangs, devicons, grammar metadata, formatter defaults, and LSP defaults together.
+
+For temporary local overrides, you can still register a filetype mapping in config:
 
 ```elixir
 # In config.exs
-Minga.Filetype.Registry.register(".astro", :astro)
-Minga.Filetype.Registry.register("Justfile", :just)
+Minga.Language.Filetype.Registry.register(".astro", :astro)
+Minga.Language.Filetype.Registry.register("Justfile", :just)
 ```
 
 This tells Minga the filetype, but highlighting only works if a grammar for that language is compiled into the editor. See below for adding new grammars.
@@ -691,9 +693,9 @@ Adding a grammar for a language Minga doesn't ship requires building from source
 2. **Add a highlight query**: place a `highlights.scm` at `zig/src/queries/{lang}/highlights.scm`. The grammar's upstream repo usually has one you can start from.
 3. **Register in the Zig build**: add an entry to the `grammars` array in `zig/build.zig` with `has_scanner` set appropriately.
 4. **Register in the highlighter**: in `zig/src/highlighter.zig`, add an `extern fn tree_sitter_{lang}()` declaration and an entry in the `languages` array.
-5. **Register the filetype**: add extension/filename mappings in `lib/minga/filetype.ex` so files are detected correctly.
+5. **Register the language in a pack**: create a language module that returns `%Minga.Language{}` with its extensions, filenames, shebangs, grammar name, icon, formatter, and LSP defaults, then add that module to the bundled language pack's `language_modules/0` list.
 
-After rebuilding (`mix compile`), the grammar is compiled into the binary and available immediately.
+After rebuilding (`mix compile`), the grammar is compiled into the binary and the language pack makes it available immediately.
 
 If you add a grammar for a popular language, consider opening a PR so everyone gets it.
 

--- a/docs/EXTENSIBILITY.md
+++ b/docs/EXTENSIBILITY.md
@@ -436,10 +436,10 @@ The DSL is syntactic sugar over these APIs, not a replacement. Use whichever fit
 
 Extensions can ship tree-sitter grammar source files and have Minga compile and load them at runtime, enabling syntax highlighting for new languages without rebuilding the binary.
 
-The entry point is `Minga.TreeSitter.register_grammar/3`:
+The entry point is `Minga.Language.register/3`:
 
 ```elixir
-Minga.TreeSitter.register_grammar(
+Minga.Language.register(
   "org",
   "/path/to/tree-sitter-org/src",
   highlights: "/path/to/queries/org/highlights.scm",
@@ -455,12 +455,12 @@ This single call handles the full pipeline:
 2. **Caches** the compiled library at `~/.local/share/minga/grammars/` (respects `$XDG_DATA_HOME`). Subsequent startups skip recompilation when the cache is newer than sources.
 3. **Loads** the shared library into the parser Port via the `load_grammar` protocol message.
 4. **Sends** highlight and injection queries to the parser.
-5. **Registers** filetype mappings so `Minga.Filetype.detect/1` recognizes the new file extensions.
-6. **Registers** the language in `Minga.Highlight.Grammar` so buffers with the new filetype get syntax highlighting.
+5. **Registers** filetype mappings so `Minga.Language.detect_filetype/1` recognizes the new file extensions.
+6. **Registers** the filetype-to-grammar mapping in `Minga.Language.Grammar` so buffers with the new filetype get syntax highlighting.
 
-Extensions that add new languages should call `register_grammar/3` from their `init/1` callback. If no C compiler is available, a warning is logged and the extension loads without highlighting.
+`Minga.Language.register/3` reports compile/setup failures synchronously. The parser-side load response is asynchronous, so a successful return means the grammar was accepted for loading, not that every parser process has finished applying it yet. Extensions that add new languages should call `Minga.Language.register/3` from their `init/1` callback and decide whether to fail the extension or continue without highlighting when it returns `{:error, reason}`.
 
-The dynamic grammar registry is an ETS table (`read_concurrency: true`) initialized at application startup. Dynamic mappings take precedence over the compiled-in defaults, so extensions can override built-in grammars if needed.
+The dynamic grammar registry is an ETS table (`read_concurrency: true`) initialized at application startup. Dynamic mappings take precedence over the registered language definitions, so extensions can override bundled grammars if needed.
 
 ---
 

--- a/docs/EXTENSION_API.md
+++ b/docs/EXTENSION_API.md
@@ -434,12 +434,61 @@ Annotations are line-anchored: they automatically shift when lines are inserted 
 
 ---
 
+## Language Packs
+
+Language support is owned by language packs. A pack is a normal extension module that lists language definition modules and registers their `%Minga.Language{}` structs with a source tag. That source tag is what makes reload safe: unloading the pack removes the whole language record, so the language name, file extensions, exact filenames, shebang mappings, devicon, grammar metadata, formatter, and LSP defaults disappear together.
+
+```elixir
+defmodule MyLanguages do
+  use Minga.Extension
+
+  @languages [MyLanguages.Astro]
+
+  @impl true
+  def name, do: :my_languages
+
+  @impl true
+  def description, do: "Project language definitions"
+
+  @impl true
+  def version, do: "0.1.0"
+
+  @impl true
+  def init(_config) do
+    case Minga.Extensions.LanguagePacks.register_pack(__MODULE__) do
+      :ok -> {:ok, %{languages: length(@languages)}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def language_modules, do: @languages
+end
+
+defmodule MyLanguages.Astro do
+  def definition do
+    %Minga.Language{
+      name: :astro,
+      label: "Astro",
+      comment_token: "// ",
+      extensions: ["astro"],
+      icon: "\u{E6B3}",
+      icon_color: 0xFF5D01,
+      grammar: "astro"
+    }
+  end
+end
+```
+
+If you add a language to Minga itself, create a language module inside the bundled pack and add that module to the pack's `language_modules/0` list. Do not edit a central registry list or add hardcoded filetype maps in core.
+
+---
+
 ## Tree-Sitter Grammars
 
 Extensions can ship tree-sitter grammar source files and have Minga compile and load them at runtime. One call does everything: compile, cache, load, register filetype, send highlight query.
 
 ```elixir
-Minga.TreeSitter.register_grammar(
+Minga.Language.register(
   "org",
   "/path/to/tree-sitter-org/src",
   highlights: "/path/to/queries/org/highlights.scm",
@@ -449,9 +498,9 @@ Minga.TreeSitter.register_grammar(
 )
 ```
 
-The grammar's `parser.c` (and optional `scanner.c`) is compiled into a shared library using the system C compiler, then cached at `~/.local/share/minga/grammars/`. Subsequent startups skip compilation. If no C compiler is available, a warning is logged and the extension loads without highlighting.
+The grammar's `parser.c` (and optional `scanner.c`) is compiled into a shared library using the system C compiler, then cached at `~/.local/share/minga/grammars/`. Subsequent startups skip compilation. `Minga.Language.register/3` returns `{:error, reason}` for compilation or other synchronous setup failures. A successful `:ok` means the parser load request was accepted, not that every parser process has already applied it. Your `init/1` decides whether that should fail the extension or continue without highlighting.
 
-For more detail on what `register_grammar/3` does under the hood, see the [Extensibility](EXTENSIBILITY.md#runtime-grammar-loading-for-extensions) page.
+For more detail on what `Minga.Language.register/3` does under the hood, see the [Extensibility](EXTENSIBILITY.md#runtime-grammar-loading-for-extensions) page.
 
 ---
 

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -12,6 +12,7 @@ defmodule Minga.Application do
       Minga.Supervisor (rest_for_one)
       ├── Minga.Foundation.Supervisor (rest_for_one)
       │   ├── Minga.Language.Registry
+      │   ├── Minga.Extensions.LanguagePacks
       │   ├── Minga.Events (Registry, :duplicate)
       │   ├── Minga.Config.Options
       │   ├── Minga.Keymap.Active

--- a/lib/minga/extensions/language_packs.ex
+++ b/lib/minga/extensions/language_packs.ex
@@ -1,0 +1,176 @@
+defmodule Minga.Extensions.LanguagePacks do
+  @moduledoc """
+  Starts bundled language packs and registers their catalog data through extension-owned sources.
+
+  Bundled packs use the same `Minga.Language.Registry.register/2` path as third-party language packs. Each `%Minga.Language{}` carries its own extensions, filenames, shebangs, devicon, grammar, formatter, and LSP defaults, so stopping or reloading a pack removes the whole language record from the registry instead of leaving stale derived data behind.
+  """
+
+  use Agent
+
+  alias Minga.Language
+  alias Minga.Language.Registry, as: LanguageRegistry
+
+  @typedoc "A module that implements the language-pack extension callbacks."
+  @type pack_module :: module()
+
+  @typedoc "Runtime state for the bundled pack starter."
+  @type state :: %{loaded: [atom()], failed: [{atom(), term()}]}
+
+  @typedoc "Pack validation error when two language definitions claim the same key."
+  @type pack_validation_error :: {:duplicate_pack_key, term(), module(), module()}
+
+  @packs [Minga.Extensions.LanguagePacks.Bundled]
+
+  @doc "Starts the bundled language pack loader."
+  @spec start_link(keyword()) :: Agent.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    packs = Keyword.get(opts, :packs, @packs)
+    disabled = Keyword.get(opts, :disabled, disabled_pack_names())
+
+    Agent.start_link(fn -> load_packs(packs, disabled) end, name: name)
+  end
+
+  @doc "Returns bundled language pack modules in startup order."
+  @spec packs() :: [pack_module()]
+  def packs, do: @packs
+
+  @doc "Registers all languages owned by a pack, replacing stale entries from an earlier load."
+  @spec register_pack(pack_module()) :: :ok | {:error, term()}
+  def register_pack(pack_module) when is_atom(pack_module) do
+    source = source_for(pack_module)
+
+    case collect_pack_languages(pack_module) do
+      {:ok, languages} -> register_collected_pack(languages, source)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Unregisters all language catalog data owned by a pack."
+  @spec unregister_pack(pack_module()) :: :ok
+  def unregister_pack(pack_module) when is_atom(pack_module) do
+    LanguageRegistry.unregister_source(source_for(pack_module))
+  end
+
+  @doc "Reloads a pack by removing its previous source-owned entries, then registering its current modules."
+  @spec reload_pack(pack_module()) :: :ok | {:error, term()}
+  def reload_pack(pack_module) when is_atom(pack_module), do: register_pack(pack_module)
+
+  @doc "Returns the contribution source used for a pack."
+  @spec source_for(pack_module()) :: {:extension, atom()}
+  def source_for(pack_module) when is_atom(pack_module), do: {:extension, pack_module.name()}
+
+  @spec load_packs([pack_module()], [atom()]) :: state()
+  defp load_packs(packs, disabled) do
+    Enum.reduce(packs, %{loaded: [], failed: []}, fn pack, state ->
+      load_pack(pack, disabled, state)
+    end)
+  end
+
+  @spec load_pack(pack_module(), [atom()], state()) :: state()
+  defp load_pack(pack, disabled, state) do
+    name = pack.name()
+
+    if name in disabled do
+      unregister_pack(pack)
+      state
+    else
+      case register_pack(pack) do
+        :ok -> %{state | loaded: state.loaded ++ [name]}
+        {:error, reason} -> record_failed_pack(state, name, reason)
+      end
+    end
+  end
+
+  @spec record_failed_pack(state(), atom(), term()) :: state()
+  defp record_failed_pack(state, name, reason) do
+    Minga.Log.warning(:config, "Language pack #{name} failed to load: #{inspect(reason)}")
+    %{state | failed: state.failed ++ [{name, reason}]}
+  end
+
+  @spec disabled_pack_names() :: [atom()]
+  defp disabled_pack_names do
+    Application.get_env(:minga, :disabled_language_packs, [])
+  end
+
+  @spec register_collected_pack([Language.t()], LanguageRegistry.contribution_source()) ::
+          :ok | {:error, term()}
+  defp register_collected_pack(languages, source) do
+    LanguageRegistry.unregister_source(source)
+
+    languages
+    |> Enum.reduce_while(:ok, &register_collected_language(&1, &2, source))
+    |> cleanup_failed_register(source)
+  end
+
+  @spec register_collected_language(Language.t(), :ok, LanguageRegistry.contribution_source()) ::
+          {:cont, :ok} | {:halt, {:error, term()}}
+  defp register_collected_language(%Language{} = lang, :ok, source) do
+    case LanguageRegistry.register(lang, source) do
+      :ok -> {:cont, :ok}
+      {:error, reason} -> {:halt, {:error, reason}}
+    end
+  end
+
+  @spec collect_pack_languages(pack_module()) ::
+          {:ok, [Language.t()]} | {:error, pack_validation_error()}
+  defp collect_pack_languages(pack_module) do
+    pack_module.language_modules()
+    |> Enum.reduce_while({[], %{}}, fn mod, {languages, seen} ->
+      lang = mod.definition()
+
+      case validate_pack_language_keys(lang, mod, seen) do
+        {:ok, next_seen} -> {:cont, {[lang | languages], next_seen}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:error, _} = error -> error
+      {languages, _seen} -> {:ok, Enum.reverse(languages)}
+    end
+  end
+
+  @spec validate_pack_language_keys(
+          Language.t(),
+          module(),
+          map()
+        ) :: {:ok, map()} | {:error, pack_validation_error()}
+  defp validate_pack_language_keys(%Language{} = lang, mod, seen) do
+    lang
+    |> language_keys()
+    |> Enum.reduce_while(seen, &validate_pack_language_key(&1, &2, mod))
+    |> normalize_pack_key_validation()
+  end
+
+  @spec validate_pack_language_key(term(), map(), module()) ::
+          {:cont, map()} | {:halt, {:error, pack_validation_error()}}
+  defp validate_pack_language_key(key, seen, mod) do
+    case Map.fetch(seen, key) do
+      {:ok, previous_mod} -> {:halt, {:error, {:duplicate_pack_key, key, previous_mod, mod}}}
+      :error -> {:cont, Map.put(seen, key, mod)}
+    end
+  end
+
+  @spec normalize_pack_key_validation(map() | {:error, pack_validation_error()}) ::
+          {:ok, map()} | {:error, pack_validation_error()}
+  defp normalize_pack_key_validation({:error, _reason} = error), do: error
+  defp normalize_pack_key_validation(seen), do: {:ok, seen}
+
+  @spec language_keys(Language.t()) :: [term()]
+  defp language_keys(%Language{} = lang) do
+    name_key = {:name, lang.name}
+    ext_keys = Enum.map(lang.extensions, &{:ext, String.downcase(&1)})
+    filename_keys = Enum.map(lang.filenames, &{:filename, &1})
+    shebang_keys = Enum.map(lang.shebangs, &{:shebang, &1})
+    [name_key | ext_keys ++ filename_keys ++ shebang_keys]
+  end
+
+  @spec cleanup_failed_register(:ok | {:error, term()}, LanguageRegistry.contribution_source()) ::
+          :ok | {:error, term()}
+  defp cleanup_failed_register(:ok, _source), do: :ok
+
+  defp cleanup_failed_register({:error, reason}, source) do
+    LanguageRegistry.unregister_source(source)
+    {:error, reason}
+  end
+end

--- a/lib/minga/extensions/language_packs/bundled.ex
+++ b/lib/minga/extensions/language_packs/bundled.ex
@@ -1,0 +1,94 @@
+defmodule Minga.Extensions.LanguagePacks.Bundled do
+  @moduledoc """
+  Bundled language catalog shipped with normal Minga builds.
+
+  The language definitions still live in `Minga.Language.*` modules. This pack owns how those modules reach the runtime registry, which lets reload and disable paths remove the whole catalog without leaving stale filetype, shebang, devicon, grammar, or LSP data behind.
+  """
+
+  use Minga.Extension
+
+  @language_modules [
+    Minga.Language.Bash,
+    Minga.Language.C,
+    Minga.Language.Clojure,
+    Minga.Language.Conf,
+    Minga.Language.Cpp,
+    Minga.Language.CSharp,
+    Minga.Language.Css,
+    Minga.Language.Csv,
+    Minga.Language.Dart,
+    Minga.Language.Diff,
+    Minga.Language.Dockerfile,
+    Minga.Language.EditorConfig,
+    Minga.Language.Elixir,
+    Minga.Language.EmacsLisp,
+    Minga.Language.Erlang,
+    Minga.Language.Fish,
+    Minga.Language.GitConfig,
+    Minga.Language.GitIgnore,
+    Minga.Language.Gleam,
+    Minga.Language.Go,
+    Minga.Language.GraphQL,
+    Minga.Language.Haskell,
+    Minga.Language.Hcl,
+    Minga.Language.Heex,
+    Minga.Language.Html,
+    Minga.Language.Ini,
+    Minga.Language.Java,
+    Minga.Language.JavaScript,
+    Minga.Language.JavaScriptReact,
+    Minga.Language.Json,
+    Minga.Language.Kotlin,
+    Minga.Language.Lfe,
+    Minga.Language.Lua,
+    Minga.Language.Make,
+    Minga.Language.Markdown,
+    Minga.Language.Nix,
+    Minga.Language.ObjectiveC,
+    Minga.Language.OCaml,
+    Minga.Language.Perl,
+    Minga.Language.Php,
+    Minga.Language.Protobuf,
+    Minga.Language.Python,
+    Minga.Language.R,
+    Minga.Language.Ruby,
+    Minga.Language.Rust,
+    Minga.Language.Scala,
+    Minga.Language.Scss,
+    Minga.Language.Sql,
+    Minga.Language.Swift,
+    Minga.Language.Text,
+    Minga.Language.Toml,
+    Minga.Language.TypeScript,
+    Minga.Language.TypeScriptReact,
+    Minga.Language.Vim,
+    Minga.Language.Xml,
+    Minga.Language.Yaml,
+    Minga.Language.Zig
+  ]
+
+  @impl true
+  @spec name() :: atom()
+  def name, do: :minga_language_pack
+
+  @impl true
+  @spec description() :: String.t()
+  def description, do: "Bundled Minga language definitions"
+
+  @impl true
+  @spec version() :: String.t()
+  def version, do: "0.1.0"
+
+  @impl true
+  @spec init(keyword()) :: {:ok, map()} | {:error, term()}
+  def init(_config) do
+    case Minga.Extensions.LanguagePacks.register_pack(__MODULE__) do
+      :ok -> {:ok, %{languages: length(@language_modules)}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Returns the language definition modules owned by this pack."
+  @spec language_modules() :: [module()]
+  def language_modules, do: @language_modules
+end

--- a/lib/minga/foundation/supervisor.ex
+++ b/lib/minga/foundation/supervisor.ex
@@ -12,6 +12,7 @@ defmodule Minga.Foundation.Supervisor do
 
       Foundation.Supervisor (rest_for_one)
       ├── Minga.Language.Registry      ETS, language definitions
+      ├── Minga.Extensions.LanguagePacks Bundled language catalog loader
       ├── Minga.Events                 Registry(:duplicate), pub/sub bus
       ├── Minga.Config.Options         GenServer, typed options
       ├── Minga.Keymap.Active          Active keymap state
@@ -21,9 +22,7 @@ defmodule Minga.Foundation.Supervisor do
       ├── MingaAgent.Tool.Registry     Agent tool specs (ETS)
       └── Minga.Language.Filetype.Registry      Filetype detection
 
-  Language.Registry is first because it has no dependencies and nothing
-  depends on it within this group. Events is second so that everything
-  after it re-subscribes on Events restart.
+  Language.Registry is first because it owns the ETS table. Bundled language packs start next so consumers see the default language catalog before services, LSP, syntax highlighting, or filetype detection query it. Events follows so everything after it re-subscribes on Events restart.
   """
 
   use Supervisor
@@ -39,6 +38,7 @@ defmodule Minga.Foundation.Supervisor do
   def init(_opts) do
     children = [
       Minga.Language.Registry,
+      Minga.Extensions.LanguagePacks,
       Minga.Events,
       Minga.Config.Options,
       Minga.Keymap.Active,

--- a/lib/minga/language.ex
+++ b/lib/minga/language.ex
@@ -7,22 +7,15 @@ defmodule Minga.Language do
   `Formatter`, `LSP.ServerRegistry`, `Highlight.Grammar`, `Devicon`,
   `Modeline`, and `Project.Detector`.
 
-  Language definitions live in `lib/minga/language/*.ex`, one module per
-  language. Each module exports a `definition/0` function returning a
-  `%Language{}` struct. The `Language.Registry` collects them at startup
-  and provides O(1) lookups by name, extension, and filename.
+  Language definitions live in modules that export a `definition/0` function returning a `%Language{}` struct. Bundled definitions are grouped into language pack extensions under `Minga.Extensions.LanguagePacks`, and third-party packs register the same struct shape through `Minga.Language.Registry.register/2`.
 
   ## Adding a new language
 
-  Create a new module under `Minga.Language.*` (e.g., `Minga.Language.Dart`)
-  and return a `%Language{}` from `definition/0`. Register the module in
-  `Minga.Language.Registry.@language_modules`. That's it: one file, one place.
+  Create a language module inside a pack, return a `%Language{}` from `definition/0`, and add that module to the pack's `language_modules/0` list. Removing the pack's registry source removes the whole language record, so the language name, filetypes, shebangs, devicon, grammar metadata, formatter, and LSP defaults go away together.
 
   ## Extension languages
 
-  Extensions register languages at runtime via
-  `Minga.Language.Registry.register/1`, passing a `%Language{}` struct.
-  Runtime registrations override built-in definitions for the same name.
+  Extensions register languages at runtime via `Minga.Language.Registry.register/2`, passing a `%Language{}` struct and a `{:extension, name}` source.
   """
 
   alias Minga.Language.BlockPair
@@ -73,7 +66,9 @@ defmodule Minga.Language do
 
   Compiles the tree-sitter grammar sources, loads them into the parser,
   sends highlight/injection queries, and registers filetype mappings.
-  Extensions call this to add language support at runtime.
+  Compilation and setup failures are reported synchronously; the parser-side
+  load response is asynchronous, so callers decide whether to fail the
+  extension or continue without highlighting.
 
   `name` is the language identifier (e.g., `"org"`).
   `source_dir` is the path containing the grammar's `parser.c` and

--- a/lib/minga/language/filetype.ex
+++ b/lib/minga/language/filetype.ex
@@ -2,152 +2,20 @@ defmodule Minga.Language.Filetype do
   @moduledoc """
   Detects a file's language from its path and content.
 
-  Detection priority (matching Neovim):
-  1. Exact filename match (case-sensitive)
-  2. File extension (case-insensitive)
-  3. `.env*` / `.envrc*` pattern → `:bash`
-  4. Shebang line from first line of content
-  5. Fall back to `:text`
+  Detection priority follows Neovim-style behavior:
 
-  This module is pure — no GenServer, no side effects. For runtime
-  extensibility (adding new patterns), see `Minga.Language.Filetype.Registry`.
+  1. Runtime exact filename overrides from `Minga.Language.Filetype.Registry`
+  2. Source-owned exact filename entries from `Minga.Language.Registry`
+  3. Runtime extension overrides from `Minga.Language.Filetype.Registry`
+  4. Source-owned extension entries from `Minga.Language.Registry`
+  5. `.env*` / `.envrc*` pattern when `:bash` is still registered
+  6. Shebang line from the first line of content
+  7. Fall back to `:text`
+
+  Built-in language mappings come from registered language definitions in `Minga.Language.Registry`. Runtime overrides stay separate so config and extensions can temporarily redirect a pattern without owning a full language definition.
   """
 
-  # ── Exact filename → filetype (case-sensitive) ─────────────────────────────
-
-  @filenames %{
-    "Makefile" => :make,
-    "GNUmakefile" => :make,
-    "Dockerfile" => :dockerfile,
-    "Gemfile" => :ruby,
-    "Rakefile" => :ruby,
-    "Brewfile" => :ruby,
-    ".gitconfig" => :gitconfig,
-    ".gitignore" => :gitignore,
-    ".gitattributes" => :gitignore,
-    ".gitmodules" => :gitconfig,
-    ".editorconfig" => :editorconfig,
-    ".vimrc" => :vim,
-    "_vimrc" => :vim,
-    ".gvimrc" => :vim,
-    "mix.lock" => :elixir,
-    "rebar.config" => :erlang,
-    "rebar.lock" => :erlang
-  }
-
-  # ── Extension → filetype (looked up after downcasing) ──────────────────────
-
-  @extensions %{
-    "ex" => :elixir,
-    "exs" => :elixir,
-    "erl" => :erlang,
-    "hrl" => :erlang,
-    "heex" => :heex,
-    "leex" => :heex,
-    "rb" => :ruby,
-    "rake" => :ruby,
-    "gemspec" => :ruby,
-    "js" => :javascript,
-    "mjs" => :javascript,
-    "cjs" => :javascript,
-    "ts" => :typescript,
-    "mts" => :typescript,
-    "cts" => :typescript,
-    "jsx" => :javascript_react,
-    "tsx" => :typescript_react,
-    "go" => :go,
-    "rs" => :rust,
-    "zig" => :zig,
-    "zon" => :zig,
-    "c" => :c,
-    "h" => :c,
-    "cpp" => :cpp,
-    "cc" => :cpp,
-    "cxx" => :cpp,
-    "hpp" => :cpp,
-    "lua" => :lua,
-    "py" => :python,
-    "pyi" => :python,
-    "sh" => :bash,
-    "bash" => :bash,
-    "zsh" => :bash,
-    "fish" => :fish,
-    "pl" => :perl,
-    "pm" => :perl,
-    "t" => :perl,
-    "html" => :html,
-    "htm" => :html,
-    "css" => :css,
-    "scss" => :scss,
-    "sass" => :scss,
-    "json" => :json,
-    "jsonc" => :json,
-    "yaml" => :yaml,
-    "yml" => :yaml,
-    "toml" => :toml,
-    "md" => :markdown,
-    "markdown" => :markdown,
-    "sql" => :sql,
-    "graphql" => :graphql,
-    "gql" => :graphql,
-    "kt" => :kotlin,
-    "kts" => :kotlin,
-    "gleam" => :gleam,
-    "dockerfile" => :dockerfile,
-    "el" => :emacs_lisp,
-    "lfe" => :lfe,
-    "xml" => :xml,
-    "svg" => :xml,
-    "txt" => :text,
-    "csv" => :csv,
-    "tsv" => :csv,
-    "vim" => :vim,
-    "diff" => :diff,
-    "patch" => :diff,
-    "ini" => :ini,
-    "conf" => :conf,
-    "cfg" => :conf,
-    "nix" => :nix,
-    "proto" => :protobuf,
-    "java" => :java,
-    "swift" => :swift,
-    "r" => :r,
-    "rmd" => :r,
-    "cs" => :c_sharp,
-    "csx" => :c_sharp,
-    "php" => :php,
-    "phtml" => :php,
-    "tf" => :hcl,
-    "tfvars" => :hcl,
-    "hcl" => :hcl,
-    "ml" => :ocaml,
-    "mli" => :ocaml,
-    "hs" => :haskell,
-    "lhs" => :haskell,
-    "scala" => :scala,
-    "sbt" => :scala,
-    "sc" => :scala,
-    "dart" => :dart,
-    "mk" => :make,
-    "mak" => :make
-  }
-
-  # ── Shebang interpreter → filetype ────────────────────────────────────────
-
-  @shebang_interpreters %{
-    "ruby" => :ruby,
-    "python" => :python,
-    "python3" => :python,
-    "node" => :javascript,
-    "bash" => :bash,
-    "sh" => :bash,
-    "zsh" => :bash,
-    "fish" => :fish,
-    "perl" => :perl,
-    "elixir" => :elixir,
-    "escript" => :erlang,
-    "lua" => :lua
-  }
+  alias Minga.Language.Registry, as: LangRegistry
 
   @typedoc "A language identifier atom."
   @type filetype :: atom()
@@ -157,11 +25,8 @@ defmodule Minga.Language.Filetype do
   @doc """
   Detects the language of a file from its path alone.
 
-  Checks exact filename (case-sensitive), then extension (case-insensitive),
-  then `.env*`/`.envrc*` patterns. Returns `:text` if nothing matches.
+  Checks runtime filename overrides, bundled exact filenames, runtime extension overrides, bundled extensions, and `.env*`/`.envrc*` patterns in that order. Returns `:text` if nothing matches.
   """
-  alias Minga.Language.Registry, as: LangRegistry
-
   @spec detect(String.t() | nil) :: filetype()
   def detect(nil), do: :text
 
@@ -169,8 +34,8 @@ defmodule Minga.Language.Filetype do
     basename = Path.basename(file_path)
 
     with :miss <- lookup_registry_filename(basename),
-         :miss <- lookup_registry_extension(basename),
          :miss <- lookup_lang_registry_filename(basename),
+         :miss <- lookup_registry_extension(basename),
          :miss <- lookup_lang_registry_extension(basename),
          :miss <- detect_env_pattern(basename) do
       :text
@@ -180,8 +45,7 @@ defmodule Minga.Language.Filetype do
   @doc """
   Detects the language from a file path and the first line of content.
 
-  Tries `detect/1` first. If that returns `:text`, attempts shebang
-  detection from `first_line`. Returns `:text` if nothing matches.
+  Tries `detect/1` first. If that returns `:text`, attempts shebang detection from `first_line`. Returns `:text` if nothing matches.
   """
   @spec detect_from_content(String.t() | nil, String.t() | nil) :: filetype()
   def detect_from_content(file_path, first_line) do
@@ -191,17 +55,17 @@ defmodule Minga.Language.Filetype do
     end
   end
 
-  @doc "Returns the hardcoded filename → filetype map."
+  @doc "Returns runtime filename overrides. Registered language definitions live in `Minga.Language.Registry`, so this map is empty in normal builds."
   @spec filenames() :: %{String.t() => filetype()}
-  def filenames, do: @filenames
+  def filenames, do: %{}
 
-  @doc "Returns the hardcoded extension → filetype map."
+  @doc "Returns runtime extension overrides. Registered language definitions live in `Minga.Language.Registry`, so this map is empty in normal builds."
   @spec extensions() :: %{String.t() => filetype()}
-  def extensions, do: @extensions
+  def extensions, do: %{}
 
-  @doc "Returns the hardcoded shebang interpreter → filetype map."
+  @doc "Returns runtime shebang overrides. Registered language definitions live in `Minga.Language.Registry`, so this map is empty in normal builds."
   @spec shebang_interpreters() :: %{String.t() => filetype()}
-  def shebang_interpreters, do: @shebang_interpreters
+  def shebang_interpreters, do: %{}
 
   # ── Private ────────────────────────────────────────────────────────────────
 
@@ -258,11 +122,14 @@ defmodule Minga.Language.Filetype do
   end
 
   @spec detect_env_pattern(String.t()) :: filetype() | :miss
-  defp detect_env_pattern(basename) do
-    cond do
-      String.starts_with?(basename, ".env") -> :bash
-      String.starts_with?(basename, ".envrc") -> :bash
-      true -> :miss
+  defp detect_env_pattern(".env" <> _rest), do: lookup_lang_registry_bash()
+  defp detect_env_pattern(_basename), do: :miss
+
+  @spec lookup_lang_registry_bash() :: filetype() | :miss
+  defp lookup_lang_registry_bash do
+    case LangRegistry.get(:bash) do
+      %{name: :bash} -> :bash
+      nil -> :miss
     end
   end
 
@@ -276,37 +143,28 @@ defmodule Minga.Language.Filetype do
       |> String.trim()
       |> extract_interpreter()
 
-    # Check Filetype.Registry first (runtime overrides), then Language registry,
-    # then fall back to the compile-time map for any stragglers
     case Minga.Language.Filetype.Registry.lookup_shebang(interpreter) do
-      nil ->
-        case LangRegistry.for_shebang(interpreter) do
-          %{name: name} -> name
-          nil -> Map.get(@shebang_interpreters, interpreter, :text)
-        end
-
-      filetype ->
-        filetype
+      nil -> lookup_lang_registry_shebang(interpreter)
+      filetype -> filetype
     end
   end
 
   defp parse_shebang(_), do: :text
 
+  @spec lookup_lang_registry_shebang(String.t()) :: filetype()
+  defp lookup_lang_registry_shebang(interpreter) do
+    case LangRegistry.for_shebang(interpreter) do
+      %{name: name} -> name
+      nil -> :text
+    end
+  end
+
   @spec extract_interpreter(String.t()) :: String.t()
   defp extract_interpreter(shebang_path) do
-    parts = String.split(shebang_path)
-
-    case parts do
-      # #!/usr/bin/env ruby
-      [_env_path, interpreter | _] ->
-        Path.basename(interpreter)
-
-      # #!/usr/bin/ruby
-      [path | _] ->
-        Path.basename(path)
-
-      [] ->
-        ""
+    case String.split(shebang_path) do
+      [_env_path, interpreter | _] -> Path.basename(interpreter)
+      [path | _] -> Path.basename(path)
+      [] -> ""
     end
   end
 end

--- a/lib/minga/language/filetype/registry.ex
+++ b/lib/minga/language/filetype/registry.ex
@@ -2,15 +2,14 @@ defmodule Minga.Language.Filetype.Registry do
   @moduledoc """
   Runtime-extensible filetype registry backed by an Agent.
 
-  Starts with the hardcoded defaults from `Minga.Language.Filetype` and allows
-  new patterns to be registered at runtime via `register/2`. This
-  enables future config/plugin systems to add custom filetype mappings.
+  Starts empty and allows config or extensions to register overrides at runtime via `register/2`. Built-in language filetypes come from `Minga.Language.Registry`, where they are owned by their language pack source.
 
   ## Examples
 
       Minga.Language.Filetype.Registry.register(".astro", :astro)
       Minga.Language.Filetype.Registry.register("Justfile", :just)
-      :astro = Minga.Language.Filetype.Registry.lookup("component.astro")
+      :astro = Minga.Language.Filetype.Registry.lookup_extension("astro")
+      :just = Minga.Language.Filetype.Registry.lookup_filename("Justfile")
   """
 
   use Agent
@@ -26,21 +25,12 @@ defmodule Minga.Language.Filetype.Registry do
 
   # ── Client API ─────────────────────────────────────────────────────────────
 
-  @doc "Starts the registry with defaults from `Minga.Language.Filetype`."
+  @doc "Starts the registry for runtime filetype overrides."
   @spec start_link(keyword()) :: Agent.on_start()
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
 
-    Agent.start_link(
-      fn ->
-        %{
-          extensions: Filetype.extensions(),
-          filenames: Filetype.filenames(),
-          shebang_interpreters: Filetype.shebang_interpreters()
-        }
-      end,
-      name: name
-    )
+    Agent.start_link(fn -> empty_state() end, name: name)
   end
 
   @doc """
@@ -50,10 +40,22 @@ defmodule Minga.Language.Filetype.Registry do
   - An extension string starting with `.` (e.g., `".astro"`) — case-insensitive
   - An exact filename string (e.g., `"Justfile"`) — case-sensitive
   """
-  @spec register(String.t(), Filetype.filetype()) :: :ok
+  @spec register(String.t(), Filetype.filetype() | nil) :: :ok
+  def register("." <> ext, nil) do
+    Agent.update(__MODULE__, fn state ->
+      %{state | extensions: Map.delete(state.extensions, String.downcase(ext))}
+    end)
+  end
+
   def register("." <> ext, filetype) when is_atom(filetype) do
     Agent.update(__MODULE__, fn state ->
       %{state | extensions: Map.put(state.extensions, String.downcase(ext), filetype)}
+    end)
+  end
+
+  def register(filename, nil) when is_binary(filename) do
+    Agent.update(__MODULE__, fn state ->
+      %{state | filenames: Map.delete(state.filenames, filename)}
     end)
   end
 
@@ -68,7 +70,13 @@ defmodule Minga.Language.Filetype.Registry do
 
   `interpreter` is the basename of the interpreter (e.g., `"deno"`).
   """
-  @spec register_shebang(String.t(), Filetype.filetype()) :: :ok
+  @spec register_shebang(String.t(), Filetype.filetype() | nil) :: :ok
+  def register_shebang(interpreter, nil) when is_binary(interpreter) do
+    Agent.update(__MODULE__, fn state ->
+      %{state | shebang_interpreters: Map.delete(state.shebang_interpreters, interpreter)}
+    end)
+  end
+
   def register_shebang(interpreter, filetype)
       when is_binary(interpreter) and is_atom(filetype) do
     Agent.update(__MODULE__, fn state ->
@@ -104,5 +112,10 @@ defmodule Minga.Language.Filetype.Registry do
   @spec all_filenames() :: %{String.t() => Filetype.filetype()}
   def all_filenames do
     Agent.get(__MODULE__, fn state -> state.filenames end)
+  end
+
+  @spec empty_state() :: state()
+  defp empty_state do
+    %{extensions: %{}, filenames: %{}, shebang_interpreters: %{}}
   end
 end

--- a/lib/minga/language/grammar.ex
+++ b/lib/minga/language/grammar.ex
@@ -1,11 +1,8 @@
 defmodule Minga.Language.Grammar do
   @moduledoc """
-  Maps filetypes to tree-sitter language names and locates highlight queries.
+  Maps filetypes to tree-sitter grammar names and locates highlight queries.
 
-  Filetypes (atoms from `Minga.Language.Filetype`) map to tree-sitter grammar names
-  (strings matching Zig's compiled-in registry). Highlight queries are loaded
-  from `priv/queries/{language}/highlights.scm` with an optional user override
-  in `~/.config/minga/queries/{language}/highlights.scm`.
+  Filetypes (atoms from `Minga.Language.Filetype`) resolve to tree-sitter grammar names from the registered `%Minga.Language{}` definitions. The fallback grammar name comes from the language record itself, not a static in-module table. Highlight queries are loaded from `priv/queries/{language}/highlights.scm` with an optional user override in `~/.config/minga/queries/{language}/highlights.scm`.
   """
 
   alias Minga.Language
@@ -16,9 +13,7 @@ defmodule Minga.Language.Grammar do
   @doc """
   Initializes the dynamic language registry ETS table.
 
-  Called once at application startup. The table stores runtime-registered
-  filetype-to-language mappings from extensions. Lookups check this table
-  first, then fall back to the compile-time map.
+  Called once at application startup. The table stores runtime-registered filetype-to-grammar mappings from extensions. Lookups check this table first, then fall back to the grammar name on the registered `%Minga.Language{}` definition.
   """
   @spec init_registry() :: :ok
   def init_registry do
@@ -31,11 +26,9 @@ defmodule Minga.Language.Grammar do
   end
 
   @doc """
-  Registers a dynamic filetype-to-language mapping.
+  Registers a dynamic filetype-to-grammar mapping.
 
-  Extensions call this to make their grammar available for syntax
-  highlighting. The mapping is checked before the compile-time defaults,
-  so extensions can override built-in grammars.
+  Extensions call this to make their grammar available for syntax highlighting. The mapping is checked before the registered-language fallback, so extensions can override bundled grammars.
 
   ## Examples
 
@@ -51,8 +44,7 @@ defmodule Minga.Language.Grammar do
   @doc """
   Returns the tree-sitter language name for a filetype atom.
 
-  Checks the dynamic registry (populated by extensions) first, then
-  falls back to the compile-time mapping.
+  Checks the dynamic registry (populated by extensions) first, then falls back to the grammar name on the registered `%Minga.Language{}` definition.
 
   ## Examples
 
@@ -152,7 +144,7 @@ defmodule Minga.Language.Grammar do
   end
 
   @doc """
-  Returns the full filetype-to-language mapping, including dynamic registrations.
+  Returns the full filetype-to-grammar mapping, including dynamic registrations.
   """
   @spec supported_languages() :: %{atom() => language()}
   def supported_languages do

--- a/lib/minga/language/registry.ex
+++ b/lib/minga/language/registry.ex
@@ -1,10 +1,8 @@
 defmodule Minga.Language.Registry do
   @moduledoc """
-  Collects all language definitions at startup and provides O(1) lookups.
+  Provides O(1) language catalog lookups for `%Minga.Language{}` definitions registered by config and extension-owned language packs.
 
-  Backed by ETS with `read_concurrency: true` for lock-free reads on
-  every keystroke, render frame, and comment toggle. The GenServer exists
-  only to own the ETS table lifecycle. All reads go directly to ETS.
+  Backed by ETS with `read_concurrency: true` for lock-free reads on every keystroke, render frame, and comment toggle. The GenServer exists only to own the ETS table lifecycle. All reads go directly to ETS.
 
   ## Lookup functions
 
@@ -15,8 +13,7 @@ defmodule Minga.Language.Registry do
 
   ## Runtime registration
 
-  Extensions register new languages via `register/1`. Runtime
-  registrations override built-in definitions for the same name.
+  Extensions register languages via `register/2` with `{:extension, name}` as the source. Reload and unload paths remove the whole `%Minga.Language{}` record, so its names, extensions, filenames, shebangs, devicons, grammar metadata, formatter, and LSP defaults disappear together.
   """
 
   use GenServer
@@ -30,67 +27,6 @@ defmodule Minga.Language.Registry do
   @type contribution_source :: :builtin | :config | {:extension, atom()}
 
   @type register_error :: {:duplicate_key, term(), contribution_source(), contribution_source()}
-
-  # All built-in language definition modules. Add new languages here.
-  @language_modules [
-    Minga.Language.Bash,
-    Minga.Language.C,
-    Minga.Language.Clojure,
-    Minga.Language.Conf,
-    Minga.Language.Cpp,
-    Minga.Language.CSharp,
-    Minga.Language.Css,
-    Minga.Language.Csv,
-    Minga.Language.Dart,
-    Minga.Language.Diff,
-    Minga.Language.Dockerfile,
-    Minga.Language.EditorConfig,
-    Minga.Language.Elixir,
-    Minga.Language.EmacsLisp,
-    Minga.Language.Erlang,
-    Minga.Language.Fish,
-    Minga.Language.GitConfig,
-    Minga.Language.GitIgnore,
-    Minga.Language.Gleam,
-    Minga.Language.Go,
-    Minga.Language.GraphQL,
-    Minga.Language.Haskell,
-    Minga.Language.Hcl,
-    Minga.Language.Heex,
-    Minga.Language.Html,
-    Minga.Language.Ini,
-    Minga.Language.Java,
-    Minga.Language.JavaScript,
-    Minga.Language.JavaScriptReact,
-    Minga.Language.Json,
-    Minga.Language.Kotlin,
-    Minga.Language.Lfe,
-    Minga.Language.Lua,
-    Minga.Language.Make,
-    Minga.Language.Markdown,
-    Minga.Language.Nix,
-    Minga.Language.ObjectiveC,
-    Minga.Language.OCaml,
-    Minga.Language.Perl,
-    Minga.Language.Php,
-    Minga.Language.Protobuf,
-    Minga.Language.Python,
-    Minga.Language.R,
-    Minga.Language.Ruby,
-    Minga.Language.Rust,
-    Minga.Language.Scala,
-    Minga.Language.Scss,
-    Minga.Language.Sql,
-    Minga.Language.Swift,
-    Minga.Language.Text,
-    Minga.Language.Toml,
-    Minga.Language.TypeScript,
-    Minga.Language.TypeScriptReact,
-    Minga.Language.Vim,
-    Minga.Language.Xml,
-    Minga.Language.Yaml,
-    Minga.Language.Zig
-  ]
 
   # ── Client API ─────────────────────────────────────────────────────────────
 
@@ -229,6 +165,19 @@ defmodule Minga.Language.Registry do
     end
   end
 
+  @doc "Returns the contribution source for a registry key, or `nil` if the key is unknown."
+  @spec source_for(term()) :: contribution_source() | nil
+  def source_for(key) do
+    ensure_source_table!()
+
+    case :ets.lookup(@source_table, key) do
+      [{^key, source}] -> source
+      [] -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
   @doc "Removes every language and lookup index contributed by a source."
   @spec unregister_source(contribution_source()) :: :ok
   def unregister_source(source) do
@@ -266,11 +215,6 @@ defmodule Minga.Language.Registry do
       :public,
       read_concurrency: true
     ])
-
-    for mod <- @language_modules do
-      lang = mod.definition()
-      insert_language(lang, :builtin)
-    end
 
     {:ok, :no_state}
   end

--- a/test/minga/extensions/language_packs_test.exs
+++ b/test/minga/extensions/language_packs_test.exs
@@ -1,0 +1,131 @@
+defmodule Minga.Extensions.LanguagePacksTest do
+  @moduledoc "Tests for bundled language pack lifecycle registration."
+  # Mutates the global language registry to verify source-owned unload and reload behavior.
+  use ExUnit.Case, async: false
+
+  alias Minga.Extensions.LanguagePacks
+  alias Minga.Extensions.LanguagePacks.Bundled
+  alias Minga.Language
+  alias Minga.Language.Devicon
+  alias Minga.Language.Registry
+
+  setup do
+    on_exit(fn ->
+      Minga.Language.Filetype.Registry.register("config.json", nil)
+      Registry.unregister_source({:extension, :language_pack_cleanup_existing})
+      LanguagePacks.reload_pack(Bundled)
+    end)
+
+    :ok
+  end
+
+  test "bundled pack owns the default language catalog" do
+    source = LanguagePacks.source_for(Bundled)
+
+    assert source == {:extension, :minga_language_pack}
+    assert %Language{name: :elixir} = Registry.get(:elixir)
+    assert Registry.source_for({:name, :elixir}) == source
+    assert Registry.source_for({:ext, "ex"}) == source
+    assert Registry.source_for({:filename, "Makefile"}) == source
+    assert Registry.source_for({:shebang, "python3"}) == source
+  end
+
+  test "unregistering the bundled pack removes language, filetype, shebang, and devicon data" do
+    assert :ok = LanguagePacks.unregister_pack(Bundled)
+
+    assert Registry.get(:elixir) == nil
+    assert Registry.for_extension("ex") == nil
+    assert Registry.for_filename("Makefile") == nil
+    assert Registry.for_shebang("python3") == nil
+    assert Language.detect_filetype("lib/example.ex") == :text
+    assert Language.detect_filetype(".env") == :text
+    assert Language.detect_filetype(".envrc") == :text
+    assert Language.detect_filetype_from_content("script", "#!/usr/bin/env python3") == :text
+    assert Devicon.icon_and_color(:elixir) == {"\u{E612}", 0x6D8086}
+  end
+
+  test "duplicate extension inside one pack is rejected before mutating the registry" do
+    pack = Minga.Test.Fixtures.LanguagePacks.DuplicateExtensionPack
+
+    assert {:error,
+            {:duplicate_pack_key, {:ext, "language_pack_duplicate_extension"},
+             Minga.Test.Fixtures.LanguagePacks.DuplicateExtensionPack.FirstLanguage,
+             Minga.Test.Fixtures.LanguagePacks.DuplicateExtensionPack.DuplicateLanguage}} =
+             LanguagePacks.register_pack(pack)
+
+    assert Registry.get(:language_pack_duplicate_extension_ok) == nil
+    assert Registry.for_extension("language_pack_duplicate_extension") == nil
+    assert %Language{name: :elixir} = Registry.get(:elixir)
+    assert Registry.for_extension("ex").name == :elixir
+  end
+
+  test "cleanup_failed_register/2 removes partial inserts and preserves external collision source" do
+    source = {:extension, :language_pack_cleanup_existing}
+
+    existing = %Language{
+      name: :language_pack_cleanup_existing,
+      label: "Language Pack Cleanup Existing",
+      comment_token: "# ",
+      extensions: ["language_pack_cleanup_collision"]
+    }
+
+    assert :ok = Registry.register(existing, source)
+
+    assert {:error,
+            {:duplicate_key, {:ext, "language_pack_cleanup_collision"}, ^source,
+             {:extension, :language_pack_cleanup_failure_test}}} =
+             LanguagePacks.register_pack(Minga.Test.Fixtures.LanguagePacks.CleanupFailurePack)
+
+    assert Registry.get(:language_pack_cleanup_ok) == nil
+    assert Registry.for_extension("language_pack_cleanup_ok") == nil
+
+    assert %Language{name: :language_pack_cleanup_existing} =
+             Registry.get(:language_pack_cleanup_existing)
+
+    assert Registry.source_for({:ext, "language_pack_cleanup_collision"}) == source
+  end
+
+  test "runtime filename override takes precedence over bundled extension lookup" do
+    Minga.Language.Filetype.Registry.register("config.json", :json_custom)
+
+    assert Language.detect_filetype("config.json") == :json_custom
+    assert Language.detect_filetype("data.json") == :json
+  end
+
+  test "reloading the bundled pack removes stale entries from the same source before re-registering" do
+    source = LanguagePacks.source_for(Bundled)
+
+    stale = %Language{
+      name: :stale_pack_language,
+      label: "Stale Pack Language",
+      comment_token: "// ",
+      extensions: ["stale_pack_ext"],
+      filenames: ["Stalefile"],
+      shebangs: ["stale-pack"]
+    }
+
+    assert :ok = Registry.register(stale, source)
+    assert %Language{name: :stale_pack_language} = Registry.for_extension("stale_pack_ext")
+
+    assert :ok = LanguagePacks.reload_pack(Bundled)
+
+    assert Registry.get(:stale_pack_language) == nil
+    assert Registry.for_extension("stale_pack_ext") == nil
+    assert Registry.for_filename("Stalefile") == nil
+    assert Registry.for_shebang("stale-pack") == nil
+    assert %Language{name: :elixir} = Registry.for_extension("ex")
+  end
+
+  test "disabled bundled packs remove any previously loaded entries and leave safe text fallbacks" do
+    assert %Language{name: :elixir} = Registry.get(:elixir)
+
+    name = :language_packs_disabled_test
+    start_supervised!({LanguagePacks, name: name, disabled: [:minga_language_pack]})
+
+    assert Registry.get(:elixir) == nil
+    assert Registry.for_extension("ex") == nil
+    assert Language.detect_filetype("lib/example.ex") == :text
+    assert Language.detect_filetype(".env") == :text
+    assert Devicon.icon_and_color(:elixir) == {"\u{E612}", 0x6D8086}
+  end
+end

--- a/test/minga/language/filetype/registry_test.exs
+++ b/test/minga/language/filetype/registry_test.exs
@@ -38,20 +38,10 @@ defmodule Minga.Language.Filetype.RegistryTest do
   end
 
   describe "defaults" do
-    test "includes hardcoded extensions", %{name: name} do
-      assert lookup_ext(name, "ex") == :elixir
-      assert lookup_ext(name, "go") == :go
-      assert lookup_ext(name, "rs") == :rust
-    end
-
-    test "includes hardcoded filenames", %{name: name} do
-      assert lookup_fname(name, "Makefile") == :make
-      assert lookup_fname(name, "Dockerfile") == :dockerfile
-    end
-
-    test "includes hardcoded shebang interpreters", %{name: name} do
-      assert lookup_shebang(name, "ruby") == :ruby
-      assert lookup_shebang(name, "python3") == :python
+    test "starts empty because bundled defaults come from language packs", %{name: name} do
+      assert lookup_ext(name, "ex") == nil
+      assert lookup_fname(name, "Makefile") == nil
+      assert lookup_shebang(name, "python3") == nil
     end
   end
 
@@ -68,7 +58,8 @@ defmodule Minga.Language.Filetype.RegistryTest do
       assert lookup_fname(name, "Justfile") == :just
     end
 
-    test "overrides an existing extension", %{name: name} do
+    test "updates an existing runtime extension", %{name: name} do
+      register_ext(name, ".h", :c)
       assert lookup_ext(name, "h") == :c
       register_ext(name, ".h", :cpp)
       assert lookup_ext(name, "h") == :cpp

--- a/test/minga/language/filetype/runtime_registry_test.exs
+++ b/test/minga/language/filetype/runtime_registry_test.exs
@@ -6,12 +6,14 @@ defmodule Minga.Language.Filetype.RuntimeRegistryTest do
 
   setup do
     on_exit(fn ->
-      # Restore .json to its compile-time default in case a test overrode it.
-      # .org and Justfile are test-only registrations that don't exist in the
-      # compile-time map, so re-registering them to nil cleans them up.
-      Minga.Language.Filetype.Registry.register(".json", :json)
+      # Runtime overrides are global, so remove test registrations after each case.
+      Minga.Language.Filetype.Registry.register(".json", nil)
       Minga.Language.Filetype.Registry.register(".org", nil)
+      Minga.Language.Filetype.Registry.register(".lock", nil)
       Minga.Language.Filetype.Registry.register("Justfile", nil)
+      Minga.Language.Filetype.Registry.register("config.json", nil)
+      Minga.Language.Filetype.Registry.register("Makefile", nil)
+      Minga.Language.Filetype.Registry.register_shebang("python3", nil)
     end)
 
     :ok
@@ -28,13 +30,35 @@ defmodule Minga.Language.Filetype.RuntimeRegistryTest do
       assert Filetype.detect("Justfile") == :just
     end
 
-    test "runtime registry takes precedence over compile-time map" do
-      # .json is normally :json in the compile-time map
+    test "bundled exact filename beats runtime extension overrides" do
+      Minga.Language.Filetype.Registry.register(".lock", :lock_custom)
+
+      assert Filetype.detect("mix.lock") == :elixir
+    end
+
+    test "runtime registry takes precedence over bundled language pack defaults" do
       assert Filetype.detect("data.json") == :json
 
-      # Override it at runtime
       Minga.Language.Filetype.Registry.register(".json", :json_custom)
       assert Filetype.detect("data.json") == :json_custom
+    end
+
+    test "removing runtime overrides restores bundled filename, extension, and shebang fallbacks" do
+      Minga.Language.Filetype.Registry.register(".json", :json_custom)
+      Minga.Language.Filetype.Registry.register("Makefile", :make_custom)
+      Minga.Language.Filetype.Registry.register_shebang("python3", :python_custom)
+
+      assert Filetype.detect("data.json") == :json_custom
+      assert Filetype.detect("Makefile") == :make_custom
+      assert Filetype.detect_from_content("script", "#!/usr/bin/env python3") == :python_custom
+
+      Minga.Language.Filetype.Registry.register(".json", nil)
+      Minga.Language.Filetype.Registry.register("Makefile", nil)
+      Minga.Language.Filetype.Registry.register_shebang("python3", nil)
+
+      assert Filetype.detect("data.json") == :json
+      assert Filetype.detect("Makefile") == :make
+      assert Filetype.detect_from_content("script", "#!/usr/bin/env python3") == :python
     end
   end
 end

--- a/test/minga/language/registry_test.exs
+++ b/test/minga/language/registry_test.exs
@@ -209,7 +209,7 @@ defmodule Minga.Language.RegistryTest do
       Registry.unregister_source(other_source)
     end
 
-    test "runtime registration rejects duplicate built-in definitions from another source" do
+    test "runtime registration rejects duplicate bundled pack definitions from another source" do
       assert Registry.get(:elixir).label == "Elixir"
 
       override = %Language{
@@ -219,10 +219,22 @@ defmodule Minga.Language.RegistryTest do
         extensions: ["ex", "exs"]
       }
 
-      assert {:error, {:duplicate_key, {:name, :elixir}, :builtin, :config}} =
+      assert {:error,
+              {:duplicate_key, {:name, :elixir}, {:extension, :minga_language_pack}, :config}} =
                Registry.register(override)
 
       assert Registry.get(:elixir).label == "Elixir"
+    end
+  end
+
+  describe "source ownership" do
+    test "bundled languages and filetype indexes are owned by the language pack extension" do
+      source = {:extension, :minga_language_pack}
+
+      assert Registry.source_for({:name, :elixir}) == source
+      assert Registry.source_for({:ext, "ex"}) == source
+      assert Registry.source_for({:filename, "Makefile"}) == source
+      assert Registry.source_for({:shebang, "python3"}) == source
     end
   end
 

--- a/test/support/fixtures/language_packs/cleanup_collision_language.ex
+++ b/test/support/fixtures/language_packs/cleanup_collision_language.ex
@@ -1,0 +1,15 @@
+defmodule Minga.Test.Fixtures.LanguagePacks.CleanupFailurePack.CollisionLanguage do
+  @moduledoc false
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :language_pack_cleanup_collision,
+      label: "Language Pack Cleanup Collision",
+      comment_token: "# ",
+      extensions: ["language_pack_cleanup_collision"]
+    }
+  end
+end

--- a/test/support/fixtures/language_packs/cleanup_failure_pack.ex
+++ b/test/support/fixtures/language_packs/cleanup_failure_pack.ex
@@ -1,0 +1,13 @@
+defmodule Minga.Test.Fixtures.LanguagePacks.CleanupFailurePack do
+  @moduledoc false
+
+  @spec name() :: atom()
+  def name, do: :language_pack_cleanup_failure_test
+
+  @spec language_modules() :: [module()]
+  def language_modules,
+    do: [
+      Minga.Test.Fixtures.LanguagePacks.CleanupFailurePack.FirstLanguage,
+      Minga.Test.Fixtures.LanguagePacks.CleanupFailurePack.CollisionLanguage
+    ]
+end

--- a/test/support/fixtures/language_packs/cleanup_first_language.ex
+++ b/test/support/fixtures/language_packs/cleanup_first_language.ex
@@ -1,0 +1,15 @@
+defmodule Minga.Test.Fixtures.LanguagePacks.CleanupFailurePack.FirstLanguage do
+  @moduledoc false
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :language_pack_cleanup_ok,
+      label: "Language Pack Cleanup Ok",
+      comment_token: "# ",
+      extensions: ["language_pack_cleanup_ok"]
+    }
+  end
+end

--- a/test/support/fixtures/language_packs/duplicate_language.ex
+++ b/test/support/fixtures/language_packs/duplicate_language.ex
@@ -1,0 +1,15 @@
+defmodule Minga.Test.Fixtures.LanguagePacks.DuplicateExtensionPack.DuplicateLanguage do
+  @moduledoc false
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :language_pack_duplicate_extension_duplicate,
+      label: "Language Pack Duplicate Extension Duplicate",
+      comment_token: "# ",
+      extensions: ["language_pack_duplicate_extension"]
+    }
+  end
+end

--- a/test/support/fixtures/language_packs/failing_pack.ex
+++ b/test/support/fixtures/language_packs/failing_pack.ex
@@ -1,0 +1,13 @@
+defmodule Minga.Test.Fixtures.LanguagePacks.DuplicateExtensionPack do
+  @moduledoc false
+
+  @spec name() :: atom()
+  def name, do: :language_pack_duplicate_extension_test
+
+  @spec language_modules() :: [module()]
+  def language_modules,
+    do: [
+      Minga.Test.Fixtures.LanguagePacks.DuplicateExtensionPack.FirstLanguage,
+      Minga.Test.Fixtures.LanguagePacks.DuplicateExtensionPack.DuplicateLanguage
+    ]
+end

--- a/test/support/fixtures/language_packs/filename_duplicate_language.ex
+++ b/test/support/fixtures/language_packs/filename_duplicate_language.ex
@@ -1,0 +1,16 @@
+defmodule Minga.Test.Fixtures.LanguagePacks.FilenameFailingPack.DuplicateLanguage do
+  @moduledoc false
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :language_pack_filename_duplicate,
+      label: "Language Pack Filename Duplicate",
+      comment_token: "# ",
+      extensions: ["language_pack_filename_duplicate"],
+      filenames: ["LanguagePackFilename"]
+    }
+  end
+end

--- a/test/support/fixtures/language_packs/filename_failing_pack.ex
+++ b/test/support/fixtures/language_packs/filename_failing_pack.ex
@@ -1,0 +1,13 @@
+defmodule Minga.Test.Fixtures.LanguagePacks.FilenameFailingPack do
+  @moduledoc false
+
+  @spec name() :: atom()
+  def name, do: :language_pack_filename_failure_test
+
+  @spec language_modules() :: [module()]
+  def language_modules,
+    do: [
+      Minga.Test.Fixtures.LanguagePacks.FilenameFailingPack.FirstLanguage,
+      Minga.Test.Fixtures.LanguagePacks.FilenameFailingPack.DuplicateLanguage
+    ]
+end

--- a/test/support/fixtures/language_packs/filename_first_language.ex
+++ b/test/support/fixtures/language_packs/filename_first_language.ex
@@ -1,0 +1,16 @@
+defmodule Minga.Test.Fixtures.LanguagePacks.FilenameFailingPack.FirstLanguage do
+  @moduledoc false
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :language_pack_filename_ok,
+      label: "Language Pack Filename Ok",
+      comment_token: "# ",
+      extensions: ["language_pack_filename_ok"],
+      filenames: ["LanguagePackFilename"]
+    }
+  end
+end

--- a/test/support/fixtures/language_packs/first_language.ex
+++ b/test/support/fixtures/language_packs/first_language.ex
@@ -1,0 +1,15 @@
+defmodule Minga.Test.Fixtures.LanguagePacks.DuplicateExtensionPack.FirstLanguage do
+  @moduledoc false
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :language_pack_duplicate_extension_ok,
+      label: "Language Pack Duplicate Extension Ok",
+      comment_token: "# ",
+      extensions: ["language_pack_duplicate_extension"]
+    }
+  end
+end


### PR DESCRIPTION
# TL;DR
Built-in language definitions now load through a bundled, source-owned language pack instead of a hardcoded runtime list in `Minga.Language.Registry`. This proves unload/reload safety for language catalog data before any larger feature extraction.

Closes #1848
Part of #1747

## Context
This is the first data-pack extraction after #1748 landed. It keeps the language definition modules in `Minga.Language.*`, but moves runtime ownership into a bundled extension pack tagged as `{:extension, :minga_language_pack}`.

## Changes
- Added `Minga.Extensions.LanguagePacks` and `Minga.Extensions.LanguagePacks.Bundled` to register the bundled language catalog through the same source-owned path third-party packs will use.
- Removed runtime seeding from `Minga.Language.Registry.@language_modules`; the registry now starts empty and receives bundled languages from the pack loader.
- Wired the bundled language pack loader immediately after `Minga.Language.Registry` in the Foundation supervisor so default language lookups are available before consumers start.
- Moved built-in filetype detection to language-registry lookups, while keeping `Minga.Language.Filetype.Registry` for runtime overrides.
- Added duplicate-key validation for language packs before registry mutation, plus rollback cleanup when a pack fails after partial registration.
- Added unload/reload tests covering language names, extensions, filenames, shebangs, devicon fallback, `.env*` fallback safety, stale same-source cleanup, runtime override restoration, duplicate pack rejection, and external collision rollback.
- Updated docs so adding a language means creating a language module inside a pack, not editing a core registry list.

## Verification
- `make lint`
- `mix test.llm` (8,485 tests, 56 doctests, 99 properties, 0 failures)
- `mix test.llm test/minga/extensions/language_packs_test.exs test/minga/language/filetype/runtime_registry_test.exs test/minga/language/filetype/registry_test.exs test/minga/language/filetype_test.exs test/minga/language/registry_test.exs`
- `mix compile --warnings-as-errors`
- `git diff --check`

## Review Notes
- This PR uses one bundled language pack for the first slice. The ticket allows this; future work can split it into smaller packs once the API has more real usage.
- Parent-orchestrated review loop ran multiple focused passes for correctness, tests, and docs. Findings around filetype priority, stale cleanup, same-pack duplicate keys, partial rollback, and doc wording were fixed.
- One full test run surfaced a remote-node test failure outside this diff; the exact test and file passed when scoped, and the full suite passed on rerun.

## Acceptance Criteria Addressed
- Built-in languages register through the source-owned language registration path with `{:extension, :minga_language_pack}` ✅
- Disabling/unregistering the bundled language pack removes language names, filetype extensions, filenames, shebang mappings, and devicon/metadata-backed results together ✅
- Reloading the bundled language pack removes stale same-source registrations before re-registering ✅
- Default startup preserves bundled language lookup behavior for `get/1`, `for_extension/1`, `for_filename/1`, and `for_shebang/1` ✅
- Editor boots with the bundled language set when no user config is present ✅
- Docs describe adding a language as creating a module inside a pack ✅
- This slice does not move feature code beyond the language catalog ownership boundary ✅
