### PR TITLE
feat(buffer): provenance undo for agent edits

### DIFF
--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -252,6 +252,10 @@ defmodule Minga.Buffer do
   @spec redo(t()) :: :ok | :empty
   defdelegate redo(server), to: BufferProcess
 
+  @doc "Undo all consecutive agent-sourced entries from the top of the undo stack."
+  @spec undo_agent_session(t()) :: {:ok, non_neg_integer()} | :empty
+  defdelegate undo_agent_session(server), to: BufferProcess
+
   @doc "Force the next edit to start a new undo group."
   @spec break_undo_coalescing(t()) :: :ok
   defdelegate break_undo_coalescing(server), to: BufferProcess

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -631,6 +631,12 @@ defmodule Minga.Buffer.Process do
     GenServer.call(server, :redo)
   end
 
+  @doc "Undoes all consecutive agent-sourced entries from the top of the undo stack."
+  @spec undo_agent_session(GenServer.server()) :: {:ok, non_neg_integer()} | :empty
+  def undo_agent_session(server) do
+    GenServer.call(server, :undo_agent_session)
+  end
+
   @doc "Returns the edit source of the most recent undo entry, or `nil` if the undo stack is empty."
   @spec last_undo_source(GenServer.server()) :: Minga.Buffer.State.edit_source() | nil
   def last_undo_source(server) do
@@ -1543,6 +1549,32 @@ defmodule Minga.Buffer.Process do
 
         log_undo_source(:redo, restore.source)
         {:reply, :ok, new_state}
+    end
+  end
+
+  def handle_call(:undo_agent_session, _from, state) do
+    case UndoHistory.undo_agent_session(
+           state.undo_history,
+           BufState.version(state),
+           state.document
+         ) do
+      :empty ->
+        {:reply, :empty, state}
+
+      {:ok, restore, undo_history, count} ->
+        event_source = EditSource.from_undo_source(:agent)
+
+        new_state =
+          %{
+            BufState.restore_version(state, restore.version)
+            | document: restore.document,
+              undo_history: undo_history
+          }
+          |> sync_dirty()
+          |> clear_edits(event_source)
+
+        Minga.Log.debug(:editor, "Undo agent session: reverted #{count} agent edits")
+        {:reply, {:ok, count}, new_state}
     end
   end
 

--- a/lib/minga/buffer/undo_history.ex
+++ b/lib/minga/buffer/undo_history.ex
@@ -106,6 +106,39 @@ defmodule Minga.Buffer.UndoHistory do
     {:ok, Restore.new(next_version, next_document, source), new_history}
   end
 
+  @doc """
+  Undoes all consecutive `:agent`-sourced entries from the top of the undo stack.
+
+  Walks backward through the undo stack, popping every entry whose source is `:agent`, applying its patches to roll back the document, and pushing corresponding redo entries. Stops at the first non-agent entry or when the stack is empty.
+
+  Returns `{:ok, restore, updated_history, undone_count}` with the final document state after all agent entries are reversed, or `:empty` when no agent entries are on top.
+  """
+  @spec undo_agent_session(t(), version(), Document.t()) ::
+          {:ok, Restore.t(), t(), pos_integer()} | :empty
+  def undo_agent_session(%__MODULE__{} = history, current_version, %Document{} = current_document) do
+    case history.undo_entries do
+      [{_version, _patches, :agent} | _rest] ->
+        do_undo_agent_session(history, current_version, current_document, 0)
+
+      _ ->
+        :empty
+    end
+  end
+
+  @spec do_undo_agent_session(t(), version(), Document.t(), non_neg_integer()) ::
+          {:ok, Restore.t(), t(), pos_integer()}
+  defp do_undo_agent_session(%__MODULE__{} = history, current_version, current_document, count) do
+    case history.undo_entries do
+      [{_version, _patches, :agent} | _rest] ->
+        {:ok, restore, new_history} = undo(history, current_version, current_document)
+        do_undo_agent_session(new_history, restore.version, restore.document, count + 1)
+
+      _ ->
+        restore = Restore.new(current_version, current_document, :agent)
+        {:ok, restore, history, count}
+    end
+  end
+
   @doc "Clears undo and redo entries and resets coalescing state."
   @spec clear(t()) :: t()
   def clear(%__MODULE__{} = history) do

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -173,6 +173,7 @@ defmodule Minga.Keymap.Defaults do
     {~k(a z), :agent_summarize, "Summarize session to artifact"},
     {~k(a q), :agent_dequeue, "Dequeue queued messages to editor"},
     {~k(a f), :agent_queue_follow_up, "Queue current input as follow-up"},
+    {~k(a u), :undo_agent_session, "Undo all agent edits"},
 
     # ── Tab ──────────────────────────────────────────────────────────────────
     {~k(TAB n), :tab_next, "Next tab"},

--- a/lib/minga_editor/commands/editing.ex
+++ b/lib/minga_editor/commands/editing.ex
@@ -34,6 +34,7 @@ defmodule MingaEditor.Commands.Editing do
     {:replace_restore, "Restore replaced character", true},
     {:undo, "Undo the last change", true},
     {:redo, "Redo the last undone change", true},
+    {:undo_agent_session, "Undo all agent edits from last session", true},
     {:paste_before, "Paste before cursor", true},
     {:paste_after, "Paste after cursor", true},
     {:indent_line, "Indent line", true},
@@ -293,6 +294,18 @@ defmodule MingaEditor.Commands.Editing do
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :redo) do
     Buffer.redo(buf)
     state
+  end
+
+  def execute(%{workspace: %{buffers: %{active: buf}}} = state, :undo_agent_session) do
+    case Buffer.undo_agent_session(buf) do
+      {:ok, count} ->
+        MingaEditor.log_to_messages("Reverted #{count} agent edit(s)")
+        state
+
+      :empty ->
+        MingaEditor.log_to_messages("No agent edits to undo")
+        state
+    end
   end
 
   # ── Paste ─────────────────────────────────────────────────────────────────

--- a/lib/minga_editor/commands/help.ex
+++ b/lib/minga_editor/commands/help.ex
@@ -424,8 +424,9 @@ defmodule MingaEditor.Commands.Help do
   defp normal_group(%{command: command})
        when command in [:half_page_down, :half_page_up, :page_down, :page_up], do: "Scrolling"
 
-  defp normal_group(%{command: command}) when command in [:undo, :redo, :dot_repeat],
-    do: "Undo / Redo"
+  defp normal_group(%{command: command})
+       when command in [:undo, :redo, :undo_agent_session, :dot_repeat],
+       do: "Undo / Redo"
 
   defp normal_group(%{command: command})
        when command in [

--- a/test/minga/buffer/undo_history_test.exs
+++ b/test/minga/buffer/undo_history_test.exs
@@ -126,6 +126,74 @@ defmodule Minga.Buffer.UndoHistoryTest do
     end
   end
 
+  describe "undo_agent_session/3" do
+    test "undoes all consecutive agent entries from top of stack" do
+      history =
+        UndoHistory.new()
+        |> UndoHistory.record_edit_force(0, patch("", "user typed"), :user)
+        |> UndoHistory.record_edit_force(
+          1,
+          patch("user typed", "user typed\nagent line 1"),
+          :agent
+        )
+        |> UndoHistory.record_edit_force(
+          2,
+          patch("user typed\nagent line 1", "user typed\nagent line 1\nagent line 2"),
+          :agent
+        )
+
+      assert {:ok, restore, new_history, 2} =
+               UndoHistory.undo_agent_session(
+                 history,
+                 3,
+                 doc("user typed\nagent line 1\nagent line 2")
+               )
+
+      assert Document.content(restore.document) == "user typed"
+      assert restore.source == :agent
+      assert UndoHistory.undo_count(new_history) == 1
+      assert UndoHistory.redo_count(new_history) == 2
+      assert UndoHistory.last_undo_source(new_history) == :user
+    end
+
+    test "returns :empty when top entry is not agent-sourced" do
+      history =
+        UndoHistory.new()
+        |> UndoHistory.record_edit_force(0, patch("", "user typed"), :user)
+
+      assert :empty = UndoHistory.undo_agent_session(history, 1, doc("user typed"))
+    end
+
+    test "returns :empty on empty history" do
+      assert :empty = UndoHistory.undo_agent_session(UndoHistory.new(), 0, doc(""))
+    end
+
+    test "stops at first non-agent entry" do
+      history =
+        UndoHistory.new()
+        |> UndoHistory.record_edit_force(0, patch("", "lsp edit"), :lsp)
+        |> UndoHistory.record_edit_force(1, patch("lsp edit", "lsp edit\nagent edit"), :agent)
+
+      assert {:ok, restore, new_history, 1} =
+               UndoHistory.undo_agent_session(history, 2, doc("lsp edit\nagent edit"))
+
+      assert Document.content(restore.document) == "lsp edit"
+      assert UndoHistory.undo_count(new_history) == 1
+      assert UndoHistory.last_undo_source(new_history) == :lsp
+    end
+
+    test "undoes single agent entry" do
+      history =
+        UndoHistory.new()
+        |> UndoHistory.record_edit_force(0, patch("original", "agent modified"), :agent)
+
+      assert {:ok, restore, _new_history, 1} =
+               UndoHistory.undo_agent_session(history, 1, doc("agent modified"))
+
+      assert Document.content(restore.document) == "original"
+    end
+  end
+
   describe "clear/1" do
     test "removes undo and redo entries" do
       history =


### PR DESCRIPTION
## Summary

- Adds `UndoHistory.undo_agent_session/3` that walks the undo stack backward, popping all consecutive `:agent`-sourced entries and pushing corresponding redo entries
- Wires through `Buffer.Process` and the `Buffer` facade as `undo_agent_session/1`
- Registers `:undo_agent_session` command with `SPC a u` keybinding
- Logs the count of reverted edits to `*Messages*`

Closes #1108 (partial: provenance undo mechanism; live edit streaming and macOS rendering tint are follow-up work)

## Test plan

- [x] 5 new tests in `undo_history_test.exs`: multi-entry rollback, empty stack, non-agent top entry, stop at boundary, single entry
- [x] Full suite passes: 8490 tests, 0 failures
- [x] `make lint` clean (format, credo, compile, dialyzer)
- [ ] Manual: open a file, run an agent session that edits it, press `SPC a u`, confirm all agent edits revert while human edits remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)