### PR TITLE
perf(buffer): line index cache to eliminate full-text materialization

### DIFF
--- a/lib/minga/buffer/cursor.ex
+++ b/lib/minga/buffer/cursor.ex
@@ -80,7 +80,8 @@ defmodule Minga.Buffer.Cursor do
       | before: before,
         after: after_,
         cursor_line: line,
-        cursor_col: column
+        cursor_col: column,
+        line_offsets: line_starts
     }
   end
 

--- a/lib/minga/buffer/cursor.ex
+++ b/lib/minga/buffer/cursor.ex
@@ -80,8 +80,7 @@ defmodule Minga.Buffer.Cursor do
       | before: before,
         after: after_,
         cursor_line: line,
-        cursor_col: column,
-        line_offsets: nil
+        cursor_col: column
     }
   end
 

--- a/lib/minga/buffer/document.ex
+++ b/lib/minga/buffer/document.ex
@@ -244,8 +244,10 @@ defmodule Minga.Buffer.Document do
   @spec delete_at(t()) :: t()
   def delete_at(%__MODULE__{after: ""} = buf), do: buf
 
-  def delete_at(%__MODULE__{after: after_, cursor_line: line, line_count: lc, line_offsets: ls} =
-                  buf) do
+  def delete_at(
+        %__MODULE__{after: after_, cursor_line: line, line_count: lc, line_offsets: ls} =
+          buf
+      ) do
     case Cursor.next_character(after_) do
       {"\n", rest} ->
         new_ls =

--- a/lib/minga/buffer/document.ex
+++ b/lib/minga/buffer/document.ex
@@ -37,10 +37,16 @@ defmodule Minga.Buffer.Document do
 
   alias Minga.Buffer.{Cursor, Lines, Position, Selection}
 
-  @enforce_keys [:before, :after, :cursor_line, :cursor_col, :line_count]
+  @enforce_keys [:before, :after, :cursor_line, :cursor_col, :line_count, :line_offsets]
   defstruct [:before, :after, :cursor_line, :cursor_col, :line_count, :line_offsets]
 
-  @typedoc "Cached line offset tuple, or `nil` when stale."
+  @typedoc """
+  Cached line-start byte offsets.
+
+  Clean: a tuple of line-start positions `{0, 6, 12, ...}`.
+  Pending: `{:pending, starts_tuple, adjust_after_line, delta}` for
+  deferred shift. `nil` when the cache needs a full rebuild.
+  """
   @type line_offsets :: tuple() | nil
 
   @typedoc "A gap buffer instance."
@@ -73,13 +79,17 @@ defmodule Minga.Buffer.Document do
   """
   @spec new(String.t()) :: t()
   def new(text \\ "") do
-    lc =
-      case text do
-        "" -> 1
-        _ -> Lines.count(text)
-      end
+    line_starts = Lines.build_index(text)
+    lc = tuple_size(line_starts)
 
-    %__MODULE__{before: "", after: text, cursor_line: 0, cursor_col: 0, line_count: lc}
+    %__MODULE__{
+      before: "",
+      after: text,
+      cursor_line: 0,
+      cursor_col: 0,
+      line_count: lc,
+      line_offsets: line_starts
+    }
   end
 
   # ── Queries ──
@@ -152,21 +162,29 @@ defmodule Minga.Buffer.Document do
   def insert_text(
         %__MODULE__{
           before: before,
-          # after: after_,
           cursor_line: line,
           cursor_col: col,
-          line_count: lc
+          line_count: lc,
+          line_offsets: ls
         } = mod,
         text
       ) do
+    gap = byte_size(before)
     {new_line, new_col, new_lc} = compute_cursor_after_insert(line, col, lc, text)
+
+    new_ls =
+      case ls do
+        nil -> nil
+        _ -> Lines.update_after_insert(ls, line, gap, text)
+      end
 
     %{
       mod
       | before: before <> text,
         cursor_line: new_line,
         cursor_col: new_col,
-        line_count: new_lc
+        line_count: new_lc,
+        line_offsets: new_ls
     }
   end
 
@@ -186,17 +204,37 @@ defmodule Minga.Buffer.Document do
   def delete_before(%__MODULE__{before: ""} = buf), do: buf
 
   def delete_before(
-        %__MODULE__{before: before, cursor_line: line, cursor_col: _col, line_count: lc} = buf
+        %__MODULE__{
+          before: before,
+          cursor_line: line,
+          cursor_col: _col,
+          line_count: lc,
+          line_offsets: ls
+        } = buf
       ) do
     {new_before, removed} = Cursor.previous_character(before)
+    newline? = removed == "\n"
 
     {new_line, new_col, new_lc} =
-      case removed do
-        "\n" -> {line - 1, Lines.last_line_width(new_before), lc - 1}
-        _ -> {line, Lines.last_line_width(new_before), lc}
+      case newline? do
+        true -> {line - 1, Lines.last_line_width(new_before), lc - 1}
+        false -> {line, Lines.last_line_width(new_before), lc}
       end
 
-    %{buf | before: new_before, cursor_line: new_line, cursor_col: new_col, line_count: new_lc}
+    new_ls =
+      case ls do
+        nil -> nil
+        _ -> Lines.update_after_delete_before(ls, line, byte_size(removed), newline?)
+      end
+
+    %{
+      buf
+      | before: new_before,
+        cursor_line: new_line,
+        cursor_col: new_col,
+        line_count: new_lc,
+        line_offsets: new_ls
+    }
   end
 
   @doc """
@@ -206,11 +244,29 @@ defmodule Minga.Buffer.Document do
   @spec delete_at(t()) :: t()
   def delete_at(%__MODULE__{after: ""} = buf), do: buf
 
-  def delete_at(%__MODULE__{after: after_, line_count: lc} = buf) do
+  def delete_at(%__MODULE__{after: after_, cursor_line: line, line_count: lc, line_offsets: ls} =
+                  buf) do
     case Cursor.next_character(after_) do
-      {"\n", rest} -> %{buf | after: rest, line_count: lc - 1}
-      {_grapheme, rest} -> %{buf | after: rest}
-      nil -> buf
+      {"\n", rest} ->
+        new_ls =
+          case ls do
+            nil -> nil
+            _ -> Lines.update_after_delete_at(ls, line, 1, true)
+          end
+
+        %{buf | after: rest, line_count: lc - 1, line_offsets: new_ls}
+
+      {grapheme, rest} ->
+        new_ls =
+          case ls do
+            nil -> nil
+            _ -> Lines.update_after_delete_at(ls, line, byte_size(grapheme), false)
+          end
+
+        %{buf | after: rest, line_offsets: new_ls}
+
+      nil ->
+        buf
     end
   end
 

--- a/lib/minga/buffer/lines.ex
+++ b/lib/minga/buffer/lines.ex
@@ -2,7 +2,24 @@ defmodule Minga.Buffer.Lines do
   @moduledoc """
   Presents document content as editor lines.
 
-  This module owns line-oriented questions: fetching visible line text, taking line ranges, and measuring how inserted text changes the current line.
+  This module owns line-oriented questions: fetching visible line text,
+  taking line ranges, maintaining the cached line index, and measuring
+  how inserted text changes the current line.
+
+  ## Line index representation
+
+  The line index (`line_offsets` on `Document`) has three states:
+
+  - **Clean tuple** `{0, 6, 12, ...}`: accurate line-start byte offsets.
+  - **Pending delta** `{:pending, starts, adjust_after, delta}`: the tuple
+    `starts` is stale; lines after `adjust_after` are shifted by `delta`.
+    Queries apply the delta on the fly in O(1).
+  - **`nil`**: needs a full rebuild from content.
+
+  Single-character inserts and deletes (the hot path) produce pending
+  deltas in O(1). Newline insertion/deletion flushes the delta and
+  splices entries, which is O(line_count) but rare relative to
+  non-newline edits.
   """
 
   alias Minga.Buffer.Document
@@ -13,8 +30,38 @@ defmodule Minga.Buffer.Lines do
   @type line_span :: {start :: non_neg_integer(), length :: non_neg_integer()}
   @type snapshot :: {line_starts(), String.t()}
 
+  # ── Line extraction (zero-copy from gap buffer halves) ──
+
   @doc "Returns the content of one editor line without its trailing newline."
   @spec fetch(Document.t(), line_index()) :: String.t() | nil
+
+  def fetch(%Document{before: before, after: after_, line_offsets: ls}, line)
+      when is_tuple(ls) and is_integer(elem(ls, 0)) and line >= 0 do
+    text_size = byte_size(before) + byte_size(after_)
+
+    case span(ls, line, text_size) do
+      nil -> nil
+      {start, length} -> extract_from_gap(before, after_, start, length)
+    end
+  end
+
+  def fetch(
+        %Document{
+          before: before,
+          after: after_,
+          line_offsets: {:pending, starts, adjust_after, delta}
+        },
+        line
+      )
+      when line >= 0 do
+    text_size = byte_size(before) + byte_size(after_)
+
+    case adjusted_span(starts, line, text_size, adjust_after, delta) do
+      nil -> nil
+      {start, length} -> extract_from_gap(before, after_, start, length)
+    end
+  end
+
   def fetch(%Document{} = doc, line) when line >= 0 do
     {line_starts, text} = snapshot(doc)
 
@@ -26,7 +73,53 @@ defmodule Minga.Buffer.Lines do
 
   @doc "Returns up to `count` editor lines starting at `first_line`."
   @spec slice(Document.t(), line_index(), non_neg_integer()) :: [String.t()]
-  def slice(%Document{} = doc, first_line, count) when first_line >= 0 and count >= 0 do
+
+  def slice(
+        %Document{before: before, after: after_, line_offsets: ls},
+        first_line,
+        count
+      )
+      when is_tuple(ls) and is_integer(elem(ls, 0)) and first_line >= 0 and count >= 0 do
+    text_size = byte_size(before) + byte_size(after_)
+    last_line = tuple_size(ls) - 1
+    final_line = min(first_line + count - 1, last_line)
+
+    if first_line > last_line do
+      []
+    else
+      for line <- first_line..final_line do
+        {start, length} = span(ls, line, text_size)
+        extract_from_gap(before, after_, start, length)
+      end
+    end
+  end
+
+  def slice(
+        %Document{
+          before: before,
+          after: after_,
+          line_offsets: {:pending, starts, adjust_after, delta}
+        },
+        first_line,
+        count
+      )
+      when first_line >= 0 and count >= 0 do
+    text_size = byte_size(before) + byte_size(after_)
+    last_line = tuple_size(starts) - 1
+    final_line = min(first_line + count - 1, last_line)
+
+    if first_line > last_line do
+      []
+    else
+      for line <- first_line..final_line do
+        {start, length} = adjusted_span(starts, line, text_size, adjust_after, delta)
+        extract_from_gap(before, after_, start, length)
+      end
+    end
+  end
+
+  def slice(%Document{} = doc, first_line, count)
+      when first_line >= 0 and count >= 0 do
     {line_starts, text} = snapshot(doc)
     text_size = byte_size(text)
     last_line = tuple_size(line_starts) - 1
@@ -44,14 +137,21 @@ defmodule Minga.Buffer.Lines do
 
   @doc "Returns indexed document text so callers can answer multiple line questions without rebuilding the line index."
   @spec snapshot(Document.t()) :: snapshot()
-  def snapshot(%Document{line_offsets: line_starts} = doc) when is_tuple(line_starts) do
-    {line_starts, Document.content(doc)}
+
+  def snapshot(%Document{line_offsets: ls} = doc) when is_tuple(ls) and is_integer(elem(ls, 0)) do
+    {ls, Document.content(doc)}
+  end
+
+  def snapshot(%Document{line_offsets: {:pending, starts, adjust_after, delta}} = doc) do
+    {flush_to_tuple(starts, adjust_after, delta), Document.content(doc)}
   end
 
   def snapshot(%Document{} = doc) do
     text = Document.content(doc)
     {build_index(text), text}
   end
+
+  # ── Line metrics ──
 
   @doc "Returns how many editor lines `text` occupies."
   @spec count(String.t()) :: line_count()
@@ -69,6 +169,8 @@ defmodule Minga.Buffer.Lines do
   def last_line_width(text) do
     byte_size(text) - last_line_start(text)
   end
+
+  # ── Index queries ──
 
   @doc "Returns the content span for one editor line."
   @spec span(line_starts(), line_index(), non_neg_integer()) :: line_span() | nil
@@ -91,12 +193,180 @@ defmodule Minga.Buffer.Lines do
     elem(line_starts, line)
   end
 
+  # ── Index construction and incremental update ──
+
+  @doc "Builds a line-start index from a complete text."
   @spec build_index(String.t()) :: line_starts()
-  defp build_index(text) do
+  def build_index(text) do
     newline_positions = :binary.matches(text, "\n")
 
     [0 | Enum.map(newline_positions, fn {pos, _len} -> pos + 1 end)]
     |> List.to_tuple()
+  end
+
+  @doc "Applies the pending delta to produce a clean tuple."
+  @spec flush_to_tuple(line_starts(), non_neg_integer(), integer()) :: line_starts()
+  def flush_to_tuple(starts, adjust_after, delta) do
+    total = tuple_size(starts)
+
+    for i <- 0..(total - 1) do
+      raw = elem(starts, i)
+      if i > adjust_after, do: raw + delta, else: raw
+    end
+    |> List.to_tuple()
+  end
+
+  @doc "Updates line_offsets after inserting `text` at the cursor. O(1) when text has no newlines."
+  @spec update_after_insert(Document.line_offsets(), non_neg_integer(), non_neg_integer(), String.t()) ::
+          Document.line_offsets()
+  def update_after_insert(nil, _cursor_line, _gap, _text), do: nil
+
+  def update_after_insert(ls, cursor_line, gap, text) do
+    case :binary.match(text, "\n") do
+      :nomatch ->
+        accumulate_delta(ls, cursor_line, byte_size(text))
+
+      _ ->
+        clean = ensure_clean(ls)
+        splice_newline_insert(clean, cursor_line, gap, text)
+    end
+  end
+
+  @doc "Updates line_offsets after deleting one character before the cursor."
+  @spec update_after_delete_before(Document.line_offsets(), non_neg_integer(), non_neg_integer(), boolean()) ::
+          Document.line_offsets()
+  def update_after_delete_before(nil, _cursor_line, _char_size, _newline?), do: nil
+
+  def update_after_delete_before(ls, cursor_line, char_size, newline?) do
+    case newline? do
+      false ->
+        accumulate_delta(ls, cursor_line, -char_size)
+
+      true ->
+        clean = ensure_clean(ls)
+        remove_and_shift(clean, cursor_line, char_size)
+    end
+  end
+
+  @doc "Updates line_offsets after deleting one character at the cursor (forward delete)."
+  @spec update_after_delete_at(Document.line_offsets(), non_neg_integer(), non_neg_integer(), boolean()) ::
+          Document.line_offsets()
+  def update_after_delete_at(nil, _cursor_line, _char_size, _newline?), do: nil
+
+  def update_after_delete_at(ls, cursor_line, char_size, newline?) do
+    case newline? do
+      false ->
+        accumulate_delta(ls, cursor_line, -char_size)
+
+      true ->
+        clean = ensure_clean(ls)
+        remove_and_shift(clean, cursor_line + 1, char_size)
+    end
+  end
+
+  # ── Private helpers ──
+
+  @spec extract_from_gap(String.t(), String.t(), non_neg_integer(), non_neg_integer()) ::
+          String.t()
+  defp extract_from_gap(before, after_, start, length) do
+    gap = byte_size(before)
+    line_end = start + length
+
+    case {start >= gap, line_end <= gap} do
+      {_, true} ->
+        binary_part(before, start, length)
+
+      {true, _} ->
+        binary_part(after_, start - gap, length)
+
+      _ ->
+        before_len = gap - start
+        binary_part(before, start, before_len) <> binary_part(after_, 0, length - before_len)
+    end
+  end
+
+  @spec adjusted_span(line_starts(), line_index(), non_neg_integer(), non_neg_integer(), integer()) ::
+          line_span() | nil
+  defp adjusted_span(starts, line, _text_size, _adjust_after, _delta)
+       when line > tuple_size(starts) - 1,
+       do: nil
+
+  defp adjusted_span(starts, line, text_size, adjust_after, delta)
+       when line == tuple_size(starts) - 1 do
+    start = adjusted_offset(starts, line, adjust_after, delta)
+    {start, text_size - start}
+  end
+
+  defp adjusted_span(starts, line, _text_size, adjust_after, delta) do
+    start = adjusted_offset(starts, line, adjust_after, delta)
+    next = adjusted_offset(starts, line + 1, adjust_after, delta)
+    {start, next - start - 1}
+  end
+
+  @spec adjusted_offset(line_starts(), line_index(), non_neg_integer(), integer()) ::
+          non_neg_integer()
+  defp adjusted_offset(starts, line, adjust_after, delta) do
+    raw = elem(starts, line)
+    if line > adjust_after, do: raw + delta, else: raw
+  end
+
+  @spec accumulate_delta(Document.line_offsets(), non_neg_integer(), integer()) ::
+          Document.line_offsets()
+  defp accumulate_delta({:pending, starts, adjust_after, delta}, line, new_delta)
+       when adjust_after == line do
+    {:pending, starts, adjust_after, delta + new_delta}
+  end
+
+  defp accumulate_delta({:pending, starts, adjust_after, delta}, line, new_delta) do
+    clean = flush_to_tuple(starts, adjust_after, delta)
+    {:pending, clean, line, new_delta}
+  end
+
+  defp accumulate_delta(starts, line, new_delta)
+       when is_tuple(starts) and is_integer(elem(starts, 0)) do
+    {:pending, starts, line, new_delta}
+  end
+
+  @spec ensure_clean(Document.line_offsets()) :: line_starts()
+  defp ensure_clean({:pending, starts, adjust_after, delta}) do
+    flush_to_tuple(starts, adjust_after, delta)
+  end
+
+  defp ensure_clean(starts) when is_tuple(starts) and is_integer(elem(starts, 0)), do: starts
+
+  @spec splice_newline_insert(line_starts(), non_neg_integer(), non_neg_integer(), String.t()) ::
+          line_starts()
+  defp splice_newline_insert(starts, cursor_line, gap, text) do
+    text_size = byte_size(text)
+    newline_positions = :binary.matches(text, "\n")
+    total = tuple_size(starts)
+    new_entries = Enum.map(newline_positions, fn {pos, _len} -> gap + pos + 1 end)
+
+    kept = for i <- 0..cursor_line, do: elem(starts, i)
+
+    shifted =
+      if cursor_line + 1 < total do
+        for i <- (cursor_line + 1)..(total - 1), do: elem(starts, i) + text_size
+      else
+        []
+      end
+
+    (kept ++ new_entries ++ shifted) |> List.to_tuple()
+  end
+
+  @spec remove_and_shift(line_starts(), non_neg_integer(), non_neg_integer()) :: line_starts()
+  defp remove_and_shift(starts, remove_line, char_size) when remove_line > 0 do
+    total = tuple_size(starts)
+    kept = for i <- 0..(remove_line - 1)//1, do: elem(starts, i)
+
+    shifted =
+      if remove_line + 1 < total do
+        for i <- (remove_line + 1)..(total - 1), do: elem(starts, i) - char_size
+      else
+        []
+      end
+
+    (kept ++ shifted) |> List.to_tuple()
   end
 
   @spec last_line_start(String.t()) :: non_neg_integer()

--- a/lib/minga/buffer/lines.ex
+++ b/lib/minga/buffer/lines.ex
@@ -217,7 +217,12 @@ defmodule Minga.Buffer.Lines do
   end
 
   @doc "Updates line_offsets after inserting `text` at the cursor. O(1) when text has no newlines."
-  @spec update_after_insert(Document.line_offsets(), non_neg_integer(), non_neg_integer(), String.t()) ::
+  @spec update_after_insert(
+          Document.line_offsets(),
+          non_neg_integer(),
+          non_neg_integer(),
+          String.t()
+        ) ::
           Document.line_offsets()
   def update_after_insert(nil, _cursor_line, _gap, _text), do: nil
 
@@ -233,7 +238,12 @@ defmodule Minga.Buffer.Lines do
   end
 
   @doc "Updates line_offsets after deleting one character before the cursor."
-  @spec update_after_delete_before(Document.line_offsets(), non_neg_integer(), non_neg_integer(), boolean()) ::
+  @spec update_after_delete_before(
+          Document.line_offsets(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean()
+        ) ::
           Document.line_offsets()
   def update_after_delete_before(nil, _cursor_line, _char_size, _newline?), do: nil
 
@@ -249,7 +259,12 @@ defmodule Minga.Buffer.Lines do
   end
 
   @doc "Updates line_offsets after deleting one character at the cursor (forward delete)."
-  @spec update_after_delete_at(Document.line_offsets(), non_neg_integer(), non_neg_integer(), boolean()) ::
+  @spec update_after_delete_at(
+          Document.line_offsets(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean()
+        ) ::
           Document.line_offsets()
   def update_after_delete_at(nil, _cursor_line, _char_size, _newline?), do: nil
 
@@ -285,7 +300,13 @@ defmodule Minga.Buffer.Lines do
     end
   end
 
-  @spec adjusted_span(line_starts(), line_index(), non_neg_integer(), non_neg_integer(), integer()) ::
+  @spec adjusted_span(
+          line_starts(),
+          line_index(),
+          non_neg_integer(),
+          non_neg_integer(),
+          integer()
+        ) ::
           line_span() | nil
   defp adjusted_span(starts, line, _text_size, _adjust_after, _delta)
        when line > tuple_size(starts) - 1,

--- a/lib/minga/buffer/lines.ex
+++ b/lib/minga/buffer/lines.ex
@@ -317,6 +317,10 @@ defmodule Minga.Buffer.Lines do
     {:pending, starts, adjust_after, delta + new_delta}
   end
 
+  # Edits on a different line than the pending delta require a flush because
+  # a single {adjust_after, delta} pair can't represent two independent shifts.
+  # This is O(line_count) but only triggers when the cursor crosses lines
+  # during editing, not on cursor movement alone.
   defp accumulate_delta({:pending, starts, adjust_after, delta}, line, new_delta) do
     clean = flush_to_tuple(starts, adjust_after, delta)
     {:pending, clean, line, new_delta}
@@ -355,7 +359,18 @@ defmodule Minga.Buffer.Lines do
   end
 
   @spec remove_and_shift(line_starts(), non_neg_integer(), non_neg_integer()) :: line_starts()
-  defp remove_and_shift(starts, remove_line, char_size) when remove_line > 0 do
+  defp remove_and_shift(starts, 0, char_size) do
+    total = tuple_size(starts)
+
+    if total <= 1 do
+      starts
+    else
+      for i <- 1..(total - 1), do: elem(starts, i) - char_size
+    end
+    |> List.to_tuple()
+  end
+
+  defp remove_and_shift(starts, remove_line, char_size) do
     total = tuple_size(starts)
     kept = for i <- 0..(remove_line - 1)//1, do: elem(starts, i)
 

--- a/test/minga/buffer/cursor_test.exs
+++ b/test/minga/buffer/cursor_test.exs
@@ -180,7 +180,8 @@ defmodule Minga.Buffer.CursorTest do
          after: after_,
          cursor_line: cursor_line,
          cursor_col: cursor_col,
-         line_count: line_count
+         line_count: line_count,
+         line_offsets: ls
        }) do
     lines_before = :binary.split(before, "\n", [:global])
     expected_line = length(lines_before) - 1
@@ -197,6 +198,21 @@ defmodule Minga.Buffer.CursorTest do
     assert cursor_col == expected_column
     assert line_count == expected_line_count
 
+    resolved_ls = resolve_offsets(ls)
+    assert is_tuple(resolved_ls), "line_offsets must resolve to a tuple, got: #{inspect(ls)}"
+    expected_ls = Minga.Buffer.Lines.build_index(text)
+
+    assert resolved_ls == expected_ls,
+           "line_offsets mismatch: resolved=#{inspect(resolved_ls)}, expected #{inspect(expected_ls)}"
+
     :ok
   end
+
+  @spec resolve_offsets(Document.line_offsets()) :: tuple() | nil
+  defp resolve_offsets({:pending, starts, adjust_after, delta}) do
+    Minga.Buffer.Lines.flush_to_tuple(starts, adjust_after, delta)
+  end
+
+  defp resolve_offsets(ls) when is_tuple(ls), do: ls
+  defp resolve_offsets(nil), do: nil
 end

--- a/test/minga/buffer/document_test.exs
+++ b/test/minga/buffer/document_test.exs
@@ -380,6 +380,28 @@ defmodule Minga.Buffer.DocumentTest do
       assert Document.cursor(buf) == {0, 0}
       assert Document.line_count(buf) == 1
     end
+
+    test "line_offsets survives cursor movement without rebuild" do
+      buf = Document.new("hello\nworld\nfoo")
+      original_offsets = buf.line_offsets
+
+      moved = buf |> Document.move(:right) |> Document.move(:down) |> Document.move_to({2, 1})
+      assert moved.line_offsets == original_offsets
+      assert_cache_valid(moved)
+    end
+
+    test "line_offsets updated incrementally on insert with newlines" do
+      buf =
+        Document.new("ab\ncd\nef")
+        |> Document.move_to({1, 1})
+        |> Document.insert_text("X\nY")
+
+      assert_cache_valid(buf)
+      assert Document.line_at(buf, 0) == "ab"
+      assert Document.line_at(buf, 1) == "cX"
+      assert Document.line_at(buf, 2) == "Yd"
+      assert Document.line_at(buf, 3) == "ef"
+    end
   end
 
   describe "content_range_length/3" do
@@ -441,23 +463,21 @@ defmodule Minga.Buffer.DocumentTest do
 
   # ── Test helpers ──
 
-  # Verifies that the cached cursor_line, cursor_col, and line_count fields
-  # match values recomputed from the raw buffer content.
-  # cursor_col is now a byte offset within the current line.
+  # Verifies that the cached cursor_line, cursor_col, line_count, and
+  # line_offsets fields match values recomputed from the raw buffer content.
   @spec assert_cache_valid(Document.t()) :: :ok
   defp assert_cache_valid(%Document{
          before: before,
          after: after_,
          cursor_line: cl,
          cursor_col: cc,
-         line_count: lc
+         line_count: lc,
+         line_offsets: ls
        }) do
-    # Recompute cursor from `before`
     lines_before = :binary.split(before, "\n", [:global])
     expected_line = length(lines_before) - 1
     expected_col = lines_before |> List.last() |> byte_size()
 
-    # Recompute line_count from full content
     text = before <> after_
 
     expected_lc =
@@ -475,10 +495,26 @@ defmodule Minga.Buffer.DocumentTest do
     assert lc == expected_lc,
            "line_count: got #{lc}, expected #{expected_lc} (content=#{inspect(text)})"
 
+    resolved_ls = resolve_offsets(ls)
+    assert is_tuple(resolved_ls), "line_offsets must resolve to a tuple, got: #{inspect(ls)}"
+
+    expected_ls = Minga.Buffer.Lines.build_index(text)
+
+    assert resolved_ls == expected_ls,
+           "line_offsets mismatch: resolved=#{inspect(resolved_ls)}, expected #{inspect(expected_ls)} (raw=#{inspect(ls)}, content=#{inspect(text)})"
+
     :ok
   end
 
   # Convert a byte offset in text to a {line, byte_col} position.
+  @spec resolve_offsets(Document.line_offsets()) :: tuple() | nil
+  defp resolve_offsets({:pending, starts, adjust_after, delta}) do
+    Minga.Buffer.Lines.flush_to_tuple(starts, adjust_after, delta)
+  end
+
+  defp resolve_offsets(ls) when is_tuple(ls), do: ls
+  defp resolve_offsets(nil), do: nil
+
   @spec byte_offset_to_position(String.t(), non_neg_integer()) :: Document.position()
   defp byte_offset_to_position(text, byte_offset) do
     before_cursor = binary_part(text, 0, min(byte_offset, byte_size(text)))


### PR DESCRIPTION
## Summary

- Document now eagerly builds a line-start index (`line_offsets`) in `new/1` and preserves it across cursor movements, eliminating the O(n) `before <> after_` concatenation that previously occurred on every `line_at/2` and `lines/3` call.
- `fetch/2` and `slice/3` extract text directly from the gap buffer halves via `binary_part/3` (zero-copy for refc binaries >64 bytes).
- Single-char mutations use a lazy delta (`{:pending, starts, adjust_after, delta}`) applied on-the-fly in O(1). Newline mutations flush the delta and splice entries in O(lines).

Closes #1886

## Test plan

- [x] All 627 buffer tests pass (25 properties + 602 tests)
- [x] All 11 perf tests pass in 0.3s (1M-line buffers)
- [x] `make lint` clean (format, credo, compile, dialyzer)
- [x] Property test extended to validate `line_offsets` consistency after random operations
- [x] New tests verify line_offsets survives cursor movement and incremental newline insertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)