### PR TITLE
feat(ui): enable TUI scroll region optimization

### DIFF
--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -175,12 +175,15 @@ defmodule MingaEditor.Frontend.Emit do
         end
       end)
 
+    editing_mode = if ctx.editing, do: ctx.editing.mode, else: nil
+
     %{
       caches
       | emit_prev_viewport_tops: tops,
         emit_prev_content_rects: rects,
         emit_prev_gutter_ws: gutter_ws,
-        emit_prev_buf_versions: buf_versions
+        emit_prev_buf_versions: buf_versions,
+        emit_prev_editing_mode: editing_mode
     }
   end
 

--- a/lib/minga_editor/frontend/emit/tui.ex
+++ b/lib/minga_editor/frontend/emit/tui.ex
@@ -20,8 +20,10 @@ defmodule MingaEditor.Frontend.Emit.TUI do
   sending the ANSI scroll region sequences (`VaxisSurface.scrollRegion`),
   so the subsequent `render()` diff only repaints the newly revealed rows.
 
-  Bails out to a full redraw when visual selection is active, since the
-  selection highlight on shifted rows would be stale.
+  Bails out to a full redraw when the editing mode changed since the last
+  frame (e.g., exiting visual mode would leave stale selection highlights
+  on shifted rows) or when the current mode has per-frame visual state
+  changes that affect content styling (visual selection, search highlights).
   """
 
   alias MingaEditor.DisplayList
@@ -89,7 +91,7 @@ defmodule MingaEditor.Frontend.Emit.TUI do
 
   @spec detect_scroll_regions(ctx(), Caches.t()) :: [scroll_delta()] | nil
   defp detect_scroll_regions(ctx, caches) do
-    if scroll_optimization_enabled?() and not visual_mode?(ctx) do
+    if scroll_optimization_enabled?() and scroll_compatible_mode?(ctx, caches) do
       detect_scroll_regions_impl(ctx, caches)
     else
       nil
@@ -101,12 +103,20 @@ defmodule MingaEditor.Frontend.Emit.TUI do
     Application.get_env(:minga, :tui_scroll_optimization, true) == true
   end
 
-  # Visual mode has selection highlight on content rows that changes every
-  # frame as the cursor moves. Shifted rows would show stale selection
-  # styling, so we bail out to a full redraw.
-  @spec visual_mode?(ctx()) :: boolean()
-  defp visual_mode?(ctx) do
-    ctx.editing != nil and ctx.editing.mode in [:visual, :visual_line, :visual_block]
+  # Modes where content styling changes every frame (selection highlight,
+  # search match highlight). Shifted rows would show stale styling.
+  @volatile_modes [:visual, :visual_line, :visual_block, :search, :search_prompt]
+
+  # Returns true when the scroll optimization is safe to attempt.
+  # Bails out when the editing mode changed since the last frame (stale
+  # highlights from the previous mode would persist on shifted rows) or
+  # when the current mode has per-frame visual state changes.
+  @spec scroll_compatible_mode?(ctx(), Caches.t()) :: boolean()
+  defp scroll_compatible_mode?(ctx, caches) do
+    current_mode = if ctx.editing, do: ctx.editing.mode, else: nil
+    prev_mode = caches.emit_prev_editing_mode
+
+    current_mode not in @volatile_modes and current_mode == prev_mode
   end
 
   @spec detect_scroll_regions_impl(ctx(), Caches.t()) :: [scroll_delta()] | nil

--- a/lib/minga_editor/frontend/emit/tui.ex
+++ b/lib/minga_editor/frontend/emit/tui.ex
@@ -9,13 +9,19 @@ defmodule MingaEditor.Frontend.Emit.TUI do
   ## Scroll region optimization
 
   When the viewport shifts by 1-3 lines between frames and no structural
-  changes occurred (layout, gutter width, window set), we send a
-  `scroll_region` command instead of a full `clear + redraw`. The terminal
-  emulator shifts its internal buffer, then only the newly revealed lines
-  are drawn. This eliminates the majority of cell writes for the most
-  common scroll case (Ctrl-e/y, mouse wheel, cursor near edges).
+  changes occurred (layout, gutter width, window set, buffer content), we
+  send a `scroll_region` command instead of a full `clear + redraw`. The
+  terminal emulator shifts its internal buffer, then only the newly
+  revealed lines are drawn. This eliminates the majority of cell writes
+  for the most common scroll case (Ctrl-e/y, mouse wheel, cursor near
+  edges).
 
-  Currently disabled pending a libvaxis buffer sync fix.
+  The Zig renderer syncs its internal libvaxis screen buffers after
+  sending the ANSI scroll region sequences (`VaxisSurface.scrollRegion`),
+  so the subsequent `render()` diff only repaints the newly revealed rows.
+
+  Bails out to a full redraw when visual selection is active, since the
+  selection highlight on shifted rows would be stale.
   """
 
   alias MingaEditor.DisplayList
@@ -83,19 +89,24 @@ defmodule MingaEditor.Frontend.Emit.TUI do
 
   @spec detect_scroll_regions(ctx(), Caches.t()) :: [scroll_delta()] | nil
   defp detect_scroll_regions(ctx, caches) do
-    if scroll_optimization_enabled?() do
+    if scroll_optimization_enabled?() and not visual_mode?(ctx) do
       detect_scroll_regions_impl(ctx, caches)
     else
       nil
     end
   end
 
-  # Kill switch for the scroll region optimization. Set
-  # `config :minga, :tui_scroll_optimization, true` to re-enable once the
-  # libvaxis buffer sync issue is resolved.
   @spec scroll_optimization_enabled?() :: boolean()
   defp scroll_optimization_enabled? do
-    Application.get_env(:minga, :tui_scroll_optimization, false) == true
+    Application.get_env(:minga, :tui_scroll_optimization, true) == true
+  end
+
+  # Visual mode has selection highlight on content rows that changes every
+  # frame as the cursor moves. Shifted rows would show stale selection
+  # styling, so we bail out to a full redraw.
+  @spec visual_mode?(ctx()) :: boolean()
+  defp visual_mode?(ctx) do
+    ctx.editing != nil and ctx.editing.mode in [:visual, :visual_line, :visual_block]
   end
 
   @spec detect_scroll_regions_impl(ctx(), Caches.t()) :: [scroll_delta()] | nil

--- a/lib/minga_editor/renderer/caches.ex
+++ b/lib/minga_editor/renderer/caches.ex
@@ -35,6 +35,7 @@ defmodule MingaEditor.Renderer.Caches do
     emit_prev_content_rects: %{},
     emit_prev_gutter_ws: %{},
     emit_prev_buf_versions: %{},
+    emit_prev_editing_mode: nil,
     last_title: nil,
     last_window_bg: nil,
 
@@ -71,6 +72,7 @@ defmodule MingaEditor.Renderer.Caches do
           emit_prev_content_rects: %{term() => term()},
           emit_prev_gutter_ws: %{term() => non_neg_integer()},
           emit_prev_buf_versions: %{term() => non_neg_integer()},
+          emit_prev_editing_mode: atom() | nil,
           last_title: String.t() | nil,
           last_window_bg: non_neg_integer() | nil,
           last_gui_theme: integer() | nil,

--- a/test/minga_editor/frontend/emit/tui_test.exs
+++ b/test/minga_editor/frontend/emit/tui_test.exs
@@ -58,18 +58,17 @@ defmodule MingaEditor.Frontend.Emit.TUITest do
       :ok
     end
 
-    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
     test "uses scroll_region when viewport shifts by 1 line" do
       state = base_state(rows: 24, cols: 80, content: long_content(100))
 
       state1 = seed_state(state, 0)
       frame1 = build_frame_with_window(state1, viewport_top: 0)
-      Emit.emit(frame1, Context.from_editor_state(state1))
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
       assert_receive {:"$gen_cast", {:send_commands, _first_commands}}
 
       state2 = simulate_scroll(state, 1)
       frame2 = build_frame_with_window(state2, viewport_top: 1)
-      Emit.emit(frame2, Context.from_editor_state(state2))
+      Emit.emit(frame2, Context.from_editor_state(state2), nil, caches)
 
       assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
       refute match?([<<0x12>> | _], scroll_commands)
@@ -79,18 +78,17 @@ defmodule MingaEditor.Frontend.Emit.TUITest do
              end)
     end
 
-    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
     test "uses scroll_region when viewport shifts by 3 lines" do
       state = base_state(rows: 24, cols: 80, content: long_content(100))
 
       state1 = seed_state(state, 0)
       frame1 = build_frame_with_window(state1, viewport_top: 0)
-      Emit.emit(frame1, Context.from_editor_state(state1))
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
       assert_receive {:"$gen_cast", {:send_commands, _}}
 
       state2 = simulate_scroll(state, 3)
       frame2 = build_frame_with_window(state2, viewport_top: 3)
-      Emit.emit(frame2, Context.from_editor_state(state2))
+      Emit.emit(frame2, Context.from_editor_state(state2), nil, caches)
 
       assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
       refute match?([<<0x12>> | _], scroll_commands)
@@ -106,12 +104,12 @@ defmodule MingaEditor.Frontend.Emit.TUITest do
 
       state1 = seed_state(state, 0)
       frame1 = build_frame_with_window(state1, viewport_top: 0)
-      Emit.emit(frame1, Context.from_editor_state(state1))
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
       assert_receive {:"$gen_cast", {:send_commands, _}}
 
       state2 = simulate_scroll(state, 4)
       frame2 = build_frame_with_window(state2, viewport_top: 4)
-      Emit.emit(frame2, Context.from_editor_state(state2))
+      Emit.emit(frame2, Context.from_editor_state(state2), nil, caches)
 
       assert_receive {:"$gen_cast", {:send_commands, commands}}
       assert [<<0x12>> | _] = commands
@@ -122,28 +120,27 @@ defmodule MingaEditor.Frontend.Emit.TUITest do
 
       state1 = seed_state(state, 5)
       frame1 = build_frame_with_window(state1, viewport_top: 5)
-      Emit.emit(frame1, Context.from_editor_state(state1))
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
       assert_receive {:"$gen_cast", {:send_commands, _}}
 
       frame2 = build_frame_with_window(state1, viewport_top: 5)
-      Emit.emit(frame2, Context.from_editor_state(state1))
+      Emit.emit(frame2, Context.from_editor_state(state1), nil, caches)
 
       assert_receive {:"$gen_cast", {:send_commands, commands}}
       assert [<<0x12>> | _] = commands
     end
 
-    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
     test "scroll_region uses negative delta for scrolling up" do
       state = base_state(rows: 24, cols: 80, content: long_content(100))
 
       state1 = seed_state(state, 10)
       frame1 = build_frame_with_window(state1, viewport_top: 10)
-      Emit.emit(frame1, Context.from_editor_state(state1))
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
       assert_receive {:"$gen_cast", {:send_commands, _}}
 
       state2 = simulate_scroll(state, 8)
       frame2 = build_frame_with_window(state2, viewport_top: 8)
-      Emit.emit(frame2, Context.from_editor_state(state2))
+      Emit.emit(frame2, Context.from_editor_state(state2), nil, caches)
 
       assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
       refute match?([<<0x12>> | _], scroll_commands)
@@ -155,39 +152,71 @@ defmodule MingaEditor.Frontend.Emit.TUITest do
       assert delta == -2
     end
 
-    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
     test "always includes batch_end in scroll region commands" do
       state = base_state(rows: 24, cols: 80, content: long_content(100))
 
       state1 = seed_state(state, 0)
       frame1 = build_frame_with_window(state1, viewport_top: 0)
-      Emit.emit(frame1, Context.from_editor_state(state1))
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
       assert_receive {:"$gen_cast", {:send_commands, _}}
 
       state2 = simulate_scroll(state, 1)
       frame2 = build_frame_with_window(state2, viewport_top: 1)
-      Emit.emit(frame2, Context.from_editor_state(state2))
+      Emit.emit(frame2, Context.from_editor_state(state2), nil, caches)
 
       assert_receive {:"$gen_cast", {:send_commands, commands}}
       assert <<0x13>> = List.last(commands)
     end
 
-    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
     test "always includes cursor commands in scroll region output" do
       state = base_state(rows: 24, cols: 80, content: long_content(100))
 
       state1 = seed_state(state, 0)
       frame1 = build_frame_with_window(state1, viewport_top: 0)
-      Emit.emit(frame1, Context.from_editor_state(state1))
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
       assert_receive {:"$gen_cast", {:send_commands, _}}
 
       state2 = simulate_scroll(state, 1)
       frame2 = build_frame_with_window(state2, viewport_top: 1)
-      Emit.emit(frame2, Context.from_editor_state(state2))
+      Emit.emit(frame2, Context.from_editor_state(state2), nil, caches)
 
       assert_receive {:"$gen_cast", {:send_commands, commands}}
       assert Enum.any?(commands, fn cmd -> match?(<<0x11, _::binary>>, cmd) end)
       assert Enum.any?(commands, fn cmd -> match?(<<0x15, _::binary>>, cmd) end)
+    end
+
+    test "falls back to full redraw in visual mode" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 1)
+      visual_state2 = put_in(state2.workspace.editing.mode, :visual)
+      frame2 = build_frame_with_window(visual_state2, viewport_top: 1)
+      Emit.emit(frame2, Context.from_editor_state(visual_state2), nil, caches)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert [<<0x12>> | _] = commands
+    end
+
+    test "falls back to full redraw in visual line mode" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 1)
+      visual_state2 = put_in(state2.workspace.editing.mode, :visual_line)
+      frame2 = build_frame_with_window(visual_state2, viewport_top: 1)
+      Emit.emit(frame2, Context.from_editor_state(visual_state2), nil, caches)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert [<<0x12>> | _] = commands
     end
   end
 

--- a/test/minga_editor/frontend/emit/tui_test.exs
+++ b/test/minga_editor/frontend/emit/tui_test.exs
@@ -218,6 +218,40 @@ defmodule MingaEditor.Frontend.Emit.TUITest do
       assert_receive {:"$gen_cast", {:send_commands, commands}}
       assert [<<0x12>> | _] = commands
     end
+
+    test "falls back to full redraw in search mode" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 1)
+      search_state2 = put_in(state2.workspace.editing.mode, :search)
+      frame2 = build_frame_with_window(search_state2, viewport_top: 1)
+      Emit.emit(frame2, Context.from_editor_state(search_state2), nil, caches)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert [<<0x12>> | _] = commands
+    end
+
+    test "falls back to full redraw on mode transition (visual to normal)" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      visual_state1 = put_in(state.workspace.editing.mode, :visual)
+      state1 = seed_state(visual_state1, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      {caches, _} = Emit.emit(frame1, Context.from_editor_state(state1), nil)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      normal_state2 = simulate_scroll(put_in(state.workspace.editing.mode, :normal), 1)
+      frame2 = build_frame_with_window(normal_state2, viewport_top: 1)
+      Emit.emit(frame2, Context.from_editor_state(normal_state2), nil, caches)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert [<<0x12>> | _] = commands
+    end
   end
 
   describe "collect_chrome_draws/1" do


### PR DESCRIPTION
## Summary

- Enables the TUI scroll region optimization that was disabled pending a libvaxis buffer sync fix. The `syncScreenAfterScroll` implementation in `VaxisSurface` already correctly handles the sync by shifting both libvaxis screen buffers after ANSI scroll region sequences.
- Changes `:tui_scroll_optimization` default from `false` to `true`, turning a full-screen redraw (~50 lines) into a partial redraw (1-3 lines) for small viewport scrolls.
- Adds a visual mode guard so the optimization bails out to full redraw when selection highlight on shifted rows would be stale.

Closes #1890

## Test plan

- [x] Un-skipped 5 scroll optimization tests and fixed cache propagation between emit calls
- [x] Added 2 new tests for visual mode bail-out (`:visual` and `:visual_line`)
- [x] `make lint` passes (format + credo + compile + dialyzer)
- [x] Full test suite: 8503 tests, 0 failures
- [x] `mix zig.lint` passes
- [ ] Manual TUI scroll verification (j/k, Ctrl-E/Y, mouse wheel) to confirm no visual artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)