### PR TITLE
feat(ui): picker empty state, loading indicator, and error feedback (#1731)

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -83,6 +83,8 @@ defmodule MingaEditor do
   alias MingaEditor.State.Session, as: EditorSessionState
 
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
 
   alias MingaEditor.MouseHoverTooltip
 
@@ -770,7 +772,7 @@ defmodule MingaEditor do
     state = %{state | git_commit_gen_ref: nil}
 
     state =
-      if MingaEditor.State.ModalOverlay.active?(EditorState.modal(state)) do
+      if ModalOverlay.active?(EditorState.modal(state)) do
         EditorState.set_status(state, "Commit message ready (prompt already open)")
       else
         state
@@ -805,6 +807,41 @@ defmodule MingaEditor do
     {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
+  # ── Async picker candidate fetching ─────────────────────────────────────
+  # When a picker source is async, PickerUI.open/3 opens the picker immediately
+  # with a loading indicator, then sends this message to spawn the background fetch.
+
+  def handle_info({:picker_fetch_candidates, source_module, ctx}, state) do
+    editor = self()
+
+    Task.start(fn ->
+      result =
+        try do
+          {:ok, source_module.candidates(ctx)}
+        rescue
+          e -> {:error, Exception.message(e)}
+        catch
+          :exit, reason -> {:error, "Source timed out: #{inspect(reason)}"}
+          :throw, value -> {:error, "Source failed: #{inspect(value)}"}
+        end
+
+      send(editor, {:picker_candidates_result, source_module, result})
+    end)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:picker_candidates_result, source_module, result}, state) do
+    case state.shell_state.modal do
+      {:picker, %{picker_ui: %{source: ^source_module}} = payload} ->
+        new_state = handle_picker_candidates(state, payload, result)
+        {:noreply, Renderer.render_or_async(new_state)}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
   def handle_info(_msg, state) do
     {:noreply, state}
   end
@@ -821,6 +858,35 @@ defmodule MingaEditor do
   defp setup_highlight_or_defer(state) do
     send(self(), :setup_highlight)
     state
+  end
+
+  @spec handle_picker_candidates(
+          state(),
+          PickerPayload.t(),
+          {:ok, [term()]} | {:error, String.t()}
+        ) :: state()
+  defp handle_picker_candidates(state, payload, {:ok, items}) do
+    picker_state = payload.picker_ui
+    picker = %{picker_state.picker | items: items}
+    picker = MingaEditor.UI.Picker.filter(picker, picker.query)
+    new_picker_state = %{picker_state | picker: picker, load_status: :ready}
+
+    ModalOverlay.transition(
+      state,
+      :picker,
+      PickerPayload.put_picker_ui(payload, new_picker_state)
+    )
+  end
+
+  defp handle_picker_candidates(state, payload, {:error, reason}) do
+    picker_state = payload.picker_ui
+    new_picker_state = %{picker_state | load_status: {:error, reason}}
+
+    ModalOverlay.transition(
+      state,
+      :picker,
+      PickerPayload.put_picker_ui(payload, new_picker_state)
+    )
   end
 
   @spec current_observatory_token?(state(), reference()) :: boolean()

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -867,8 +867,7 @@ defmodule MingaEditor do
         ) :: state()
   defp handle_picker_candidates(state, payload, {:ok, items}) do
     picker_state = payload.picker_ui
-    picker = %{picker_state.picker | items: items}
-    picker = MingaEditor.UI.Picker.filter(picker, picker.query)
+    picker = MingaEditor.UI.Picker.replace_items(picker_state.picker, items)
     new_picker_state = %{picker_state | picker: picker, load_status: :ready}
 
     ModalOverlay.transition(

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -632,7 +632,17 @@ defmodule MingaEditor.Frontend.Emit.GUI do
        %{picker_ui: picker_ui = %{picker: picker, source: source, action_menu: action_menu}}}
       when picker != nil ->
         mode_prefix = Map.get(picker_ui, :mode_prefix, "")
-        do_build_gui_picker_cmd(ctx, picker, source, action_menu, mode_prefix, caches)
+        load_status = Map.get(picker_ui, :load_status, :ready)
+
+        do_build_gui_picker_cmd(
+          ctx,
+          picker,
+          source,
+          action_menu,
+          mode_prefix,
+          load_status,
+          caches
+        )
 
       _ ->
         if caches.last_gui_picker_fp != :closed do
@@ -647,21 +657,32 @@ defmodule MingaEditor.Frontend.Emit.GUI do
     end
   end
 
-  @spec do_build_gui_picker_cmd(ctx(), term(), module() | nil, term(), String.t(), Caches.t()) ::
+  @spec do_build_gui_picker_cmd(
+          ctx(),
+          term(),
+          module() | nil,
+          term(),
+          String.t(),
+          MingaEditor.State.Picker.load_status(),
+          Caches.t()
+        ) ::
           {binary() | nil, Caches.t()}
-  defp do_build_gui_picker_cmd(ctx, picker, source, action_menu, mode_prefix, caches) do
-    # Preview content is NOT in the fingerprint: a file changing on disk while
-    # the picker is open won't refresh the preview. Acceptable trade-off for
-    # scroll perf since the picker isn't open during normal editing.
+  defp do_build_gui_picker_cmd(ctx, picker, source, action_menu, mode_prefix, load_status, caches) do
     has_preview = source != nil and Picker.Source.gui_preview?(source)
-    fp = picker_fingerprint(picker, has_preview, action_menu, mode_prefix, 100)
+    fp = picker_fingerprint(picker, has_preview, action_menu, mode_prefix, 100, load_status)
 
     if fp != caches.last_gui_picker_fp do
       preview_lines = if has_preview, do: build_picker_preview(ctx)
-      # Picker always pairs with its preview; concatenate so they arrive as
-      # adjacent frames in the batched port write.
+
       picker_cmd =
-        ProtocolGUI.encode_gui_picker(picker, has_preview, action_menu, 100, mode_prefix)
+        ProtocolGUI.encode_gui_picker(
+          picker,
+          has_preview,
+          action_menu,
+          100,
+          mode_prefix,
+          load_status
+        )
 
       preview_cmd = ProtocolGUI.encode_gui_picker_preview(preview_lines)
       {IO.iodata_to_binary([picker_cmd, preview_cmd]), %{caches | last_gui_picker_fp: fp}}
@@ -670,9 +691,16 @@ defmodule MingaEditor.Frontend.Emit.GUI do
     end
   end
 
-  @spec picker_fingerprint(Picker.t(), boolean(), term(), String.t(), non_neg_integer()) ::
+  @spec picker_fingerprint(
+          Picker.t(),
+          boolean(),
+          term(),
+          String.t(),
+          non_neg_integer(),
+          MingaEditor.State.Picker.load_status()
+        ) ::
           integer()
-  defp picker_fingerprint(picker, has_preview, action_menu, mode_prefix, max_items) do
+  defp picker_fingerprint(picker, has_preview, action_menu, mode_prefix, max_items, load_status) do
     limit = if max_items > 0, do: max_items, else: picker.max_visible
 
     visible_items =
@@ -693,7 +721,8 @@ defmodule MingaEditor.Frontend.Emit.GUI do
       Picker.marked_count(picker),
       has_preview,
       visible_items,
-      action_menu
+      action_menu,
+      load_status
     })
   end
 

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -2556,8 +2556,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp encode_load_status(:loading), do: <<1::8>>
 
   defp encode_load_status({:error, reason}) do
-    reason_bytes = :erlang.iolist_to_binary([reason])
-    <<2::8, byte_size(reason_bytes)::16, reason_bytes::binary>>
+    <<2::8, byte_size(reason)::16, reason::binary>>
   end
 
   # ── Picker preview ──

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -289,6 +289,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   @section_picker_items 0x03
   @section_picker_action_menu 0x04
   @section_picker_mode_prefix 0x05
+  @section_picker_load_status 0x06
 
   # gui_agent_chat sections
   @section_chat_header 0x01
@@ -2430,6 +2431,11 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   ModePrefix section 0x05 payload:
     mode_prefix_len(2) + mode_prefix(mode_prefix_len)
 
+  LoadStatus section 0x06 payload:
+    status(1): 0=ready, 1=loading, 2=error
+    When status == 2:
+      error_len(2) + error_message(error_len)
+
   Flags bits:
     bit 0: two_line (file-style two-line layout)
     bit 1: marked (multi-select checkmark)
@@ -2444,7 +2450,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
           boolean(),
           action_menu_state(),
           non_neg_integer(),
-          String.t()
+          String.t(),
+          MingaEditor.State.Picker.load_status()
         ) ::
           binary()
   def encode_gui_picker(
@@ -2452,10 +2459,11 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
         has_preview \\ false,
         action_menu \\ nil,
         max_items \\ 0,
-        mode_prefix \\ ""
+        mode_prefix \\ "",
+        load_status \\ :ready
       )
 
-  def encode_gui_picker(nil, _has_preview, _action_menu, _max_items, _mode_prefix),
+  def encode_gui_picker(nil, _has_preview, _action_menu, _max_items, _mode_prefix, _load_status),
     do: <<@op_gui_picker, 0::8>>
 
   def encode_gui_picker(
@@ -2463,7 +2471,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
         has_preview,
         action_menu,
         max_items,
-        mode_prefix
+        mode_prefix,
+        load_status
       ) do
     limit = if max_items > 0, do: max_items, else: picker.max_visible
     items = Enum.take(picker.filtered, limit)
@@ -2511,7 +2520,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
       encode_section(
         @section_picker_mode_prefix,
         <<byte_size(mode_prefix_bytes)::16, mode_prefix_bytes::binary>>
-      )
+      ),
+      encode_section(@section_picker_load_status, encode_load_status(load_status))
     ]
 
     IO.iodata_to_binary([<<@op_gui_picker, length(sections)::8>> | sections])
@@ -2539,6 +2549,15 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     two_line = if item.two_line, do: 1, else: 0
     marked = if MingaEditor.UI.Picker.marked?(picker, item), do: 1, else: 0
     bor(two_line, marked <<< 1)
+  end
+
+  @spec encode_load_status(MingaEditor.State.Picker.load_status()) :: binary()
+  defp encode_load_status(:ready), do: <<0::8>>
+  defp encode_load_status(:loading), do: <<1::8>>
+
+  defp encode_load_status({:error, reason}) do
+    reason_bytes = :erlang.iolist_to_binary([reason])
+    <<2::8, byte_size(reason_bytes)::16, reason_bytes::binary>>
   end
 
   # ── Picker preview ──

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -582,6 +582,9 @@ defmodule MingaEditor.PickerUI do
     {visible, selected_offset, item_rows} = bottom_visible_items(picker, row_budget)
     selected_row_offset = row_offset_for_visible_index(visible, selected_offset)
 
+    no_matches? = visible == [] and picker.query != ""
+    item_rows = if no_matches?, do: 1, else: item_rows
+
     # Layout: item rows grow upward from row N-2, prompt on row N-1
     prompt_row = viewport.rows - 1
     separator_row = prompt_row - item_rows - 1
@@ -634,27 +637,39 @@ defmodule MingaEditor.PickerUI do
       match_fg: match_fg
     }
 
-    {item_commands, _row_offset} =
-      visible
-      |> Enum.with_index()
-      |> Enum.map_reduce(0, fn {{item, rows_used}, idx}, row_offset ->
-        row = first_item_row + row_offset
-
-        commands =
-          render_visible_item(
-            row,
-            rows_used,
-            item,
-            idx == selected_offset,
-            picker.query,
-            viewport,
-            picker_colors
+    item_commands =
+      if no_matches? do
+        [
+          DisplayList.draw(
+            first_item_row,
+            0,
+            String.pad_trailing("  No matches", viewport.cols),
+            Face.new(fg: dim_fg, bg: bg)
           )
+        ]
+      else
+        {cmds, _row_offset} =
+          visible
+          |> Enum.with_index()
+          |> Enum.map_reduce(0, fn {{item, rows_used}, idx}, row_offset ->
+            row = first_item_row + row_offset
 
-        {commands, row_offset + rows_used}
-      end)
+            commands =
+              render_visible_item(
+                row,
+                rows_used,
+                item,
+                idx == selected_offset,
+                picker.query,
+                viewport,
+                picker_colors
+              )
 
-    item_commands = List.flatten(item_commands)
+            {commands, row_offset + rows_used}
+          end)
+
+        List.flatten(cmds)
+      end
 
     # Prompt line (replaces minibuffer)
     prompt_text = prompt_prefix(picker_state) <> picker.query
@@ -818,9 +833,11 @@ defmodule MingaEditor.PickerUI do
     item_capacity = centered_item_capacity(viewport.rows)
     {visible, selected_offset} = Picker.visible_items(picker, item_capacity)
 
+    no_matches? = visible == [] and picker.query != ""
+
     # Compute float window dimensions
     float_width = {:percent, 60}
-    float_height_rows = centered_float_height(visible, viewport)
+    float_height_rows = centered_float_height(visible, viewport, no_matches?)
     float_height = {:rows, float_height_rows}
 
     popup_theme = %{
@@ -847,23 +864,18 @@ defmodule MingaEditor.PickerUI do
 
     # Build content draws (relative to interior origin)
     item_draws =
-      visible
-      |> Enum.with_index()
-      |> Enum.flat_map(fn {item, idx} ->
-        if idx >= items_h,
-          do: [],
-          else:
-            render_centered_item(
-              idx,
-              item.label,
-              item.description,
-              idx == selected_offset,
-              picker.query,
-              interior_w,
-              pc,
-              item.icon_color
-            )
-      end)
+      if no_matches? do
+        [
+          DisplayList.draw(
+            0,
+            0,
+            String.pad_trailing("  No matches", interior_w),
+            Face.new(fg: pc.dim_fg, bg: pc.bg)
+          )
+        ]
+      else
+        render_centered_items(visible, items_h, selected_offset, picker.query, interior_w, pc)
+      end
 
     # Prompt at the bottom of the interior
     prompt_text = prompt_prefix(picker_state) <> picker.query
@@ -897,6 +909,34 @@ defmodule MingaEditor.PickerUI do
     cursor_pos = {cursor_row, cursor_col}
 
     {draws, cursor_pos}
+  end
+
+  @spec render_centered_items(
+          [Picker.item()],
+          non_neg_integer(),
+          non_neg_integer(),
+          String.t(),
+          pos_integer(),
+          map()
+        ) :: [DisplayList.draw()]
+  defp render_centered_items(visible, items_h, selected_offset, query, interior_w, pc) do
+    visible
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {item, idx} ->
+      if idx >= items_h,
+        do: [],
+        else:
+          render_centered_item(
+            idx,
+            item.label,
+            item.description,
+            idx == selected_offset,
+            query,
+            interior_w,
+            pc,
+            item.icon_color
+          )
+    end)
   end
 
   @spec render_centered_item(
@@ -1003,10 +1043,12 @@ defmodule MingaEditor.PickerUI do
     max(div(viewport_rows * 7, 10), 5) - 3
   end
 
-  @spec centered_float_height([Picker.item()], MingaEditor.Viewport.t()) :: pos_integer()
-  defp centered_float_height(visible, viewport) do
+  @spec centered_float_height([Picker.item()], MingaEditor.Viewport.t(), boolean()) ::
+          pos_integer()
+  defp centered_float_height(visible, viewport, no_matches?) do
     max_height = max(div(viewport.rows * 7, 10), 5)
-    min(length(visible) + 3, max_height)
+    item_count = if no_matches?, do: 1, else: length(visible)
+    min(item_count + 3, max_height)
   end
 
   @spec resolve_percent(pos_integer(), pos_integer()) :: pos_integer()

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -88,7 +88,15 @@ defmodule MingaEditor.PickerUI do
   """
   @spec open(state(), module(), map() | nil) :: state()
   def open(state, source_module, context \\ nil) do
-    # Context flows into Context.from_editor_state so candidates/1 can read it.
+    if MingaEditor.UI.Picker.Source.async?(source_module) do
+      open_async(state, source_module, context)
+    else
+      open_sync(state, source_module, context)
+    end
+  end
+
+  @spec open_sync(state(), module(), map() | nil) :: state()
+  defp open_sync(state, source_module, context) do
     ctx = Context.from_editor_state(state, context)
     items = source_module.candidates(ctx)
 
@@ -97,29 +105,64 @@ defmodule MingaEditor.PickerUI do
         state
 
       _ ->
-        max_vis = max(state.terminal_viewport.rows - 3, 5)
-        picker = Picker.new(items, title: source_module.title(), max_visible: max_vis)
+        open_with_items(state, source_module, items, context)
+    end
+  end
 
-        # Clear whichkey state if active
-        new_state =
-          if EditorState.whichkey(state).timer do
-            EditorState.set_whichkey(state, WhichKeyState.clear(EditorState.whichkey(state)))
-          else
-            state
-          end
+  @spec open_async(state(), module(), map() | nil) :: state()
+  defp open_async(state, source_module, context) do
+    max_vis = max(state.terminal_viewport.rows - 3, 5)
+    picker = Picker.new([], title: source_module.title(), max_visible: max_vis)
 
-        layout = MingaEditor.UI.Picker.Source.layout(source_module)
+    new_state = clear_whichkey(state)
+    layout = MingaEditor.UI.Picker.Source.layout(source_module)
 
-        picker_state = %PickerState{
-          picker: picker,
-          source: source_module,
-          restore: state.workspace.buffers.active_index,
-          restore_theme: state.theme,
-          context: context,
-          layout: layout
-        }
+    picker_state = %PickerState{
+      picker: picker,
+      source: source_module,
+      restore: state.workspace.buffers.active_index,
+      restore_theme: state.theme,
+      context: context,
+      layout: layout,
+      load_status: :loading
+    }
 
-        ModalOverlay.open(new_state, :picker, PickerPayload.new(picker_state))
+    new_state = ModalOverlay.open(new_state, :picker, PickerPayload.new(picker_state))
+
+    send(
+      self(),
+      {:picker_fetch_candidates, source_module, Context.from_editor_state(state, context)}
+    )
+
+    new_state
+  end
+
+  @spec open_with_items(state(), module(), [Picker.item()], map() | nil) :: state()
+  defp open_with_items(state, source_module, items, context) do
+    max_vis = max(state.terminal_viewport.rows - 3, 5)
+    picker = Picker.new(items, title: source_module.title(), max_visible: max_vis)
+
+    new_state = clear_whichkey(state)
+    layout = MingaEditor.UI.Picker.Source.layout(source_module)
+
+    picker_state = %PickerState{
+      picker: picker,
+      source: source_module,
+      restore: state.workspace.buffers.active_index,
+      restore_theme: state.theme,
+      context: context,
+      layout: layout
+    }
+
+    ModalOverlay.open(new_state, :picker, PickerPayload.new(picker_state))
+  end
+
+  @spec clear_whichkey(state()) :: state()
+  defp clear_whichkey(state) do
+    if EditorState.whichkey(state).timer do
+      EditorState.set_whichkey(state, WhichKeyState.clear(EditorState.whichkey(state)))
+    else
+      state
     end
   end
 
@@ -582,8 +625,8 @@ defmodule MingaEditor.PickerUI do
     {visible, selected_offset, item_rows} = bottom_visible_items(picker, row_budget)
     selected_row_offset = row_offset_for_visible_index(visible, selected_offset)
 
-    no_matches? = visible == [] and picker.query != ""
-    item_rows = if no_matches?, do: 1, else: item_rows
+    status_message = load_status_message(picker_state, visible, picker.query)
+    item_rows = if status_message, do: 1, else: item_rows
 
     # Layout: item rows grow upward from row N-2, prompt on row N-1
     prompt_row = viewport.rows - 1
@@ -638,12 +681,12 @@ defmodule MingaEditor.PickerUI do
     }
 
     item_commands =
-      if no_matches? do
+      if status_message do
         [
           DisplayList.draw(
             first_item_row,
             0,
-            String.pad_trailing("  No matches", viewport.cols),
+            String.pad_trailing("  #{status_message}", viewport.cols),
             Face.new(fg: dim_fg, bg: bg)
           )
         ]
@@ -833,11 +876,11 @@ defmodule MingaEditor.PickerUI do
     item_capacity = centered_item_capacity(viewport.rows)
     {visible, selected_offset} = Picker.visible_items(picker, item_capacity)
 
-    no_matches? = visible == [] and picker.query != ""
+    status_message = load_status_message(picker_state, visible, picker.query)
 
     # Compute float window dimensions
     float_width = {:percent, 60}
-    float_height_rows = centered_float_height(visible, viewport, no_matches?)
+    float_height_rows = centered_float_height(visible, viewport, status_message != nil)
     float_height = {:rows, float_height_rows}
 
     popup_theme = %{
@@ -864,12 +907,12 @@ defmodule MingaEditor.PickerUI do
 
     # Build content draws (relative to interior origin)
     item_draws =
-      if no_matches? do
+      if status_message do
         [
           DisplayList.draw(
             0,
             0,
-            String.pad_trailing("  No matches", interior_w),
+            String.pad_trailing("  #{status_message}", interior_w),
             Face.new(fg: pc.dim_fg, bg: pc.bg)
           )
         ]
@@ -1039,15 +1082,21 @@ defmodule MingaEditor.PickerUI do
   end
 
   @spec centered_item_capacity(pos_integer()) :: pos_integer()
+  @spec load_status_message(PickerState.t(), list(), String.t()) :: String.t() | nil
+  defp load_status_message(%{load_status: :loading}, _visible, _query), do: "Searching..."
+  defp load_status_message(%{load_status: {:error, reason}}, _visible, _query), do: reason
+  defp load_status_message(_picker_state, [], query) when query != "", do: "No matches"
+  defp load_status_message(_picker_state, _visible, _query), do: nil
+
   defp centered_item_capacity(viewport_rows) do
     max(div(viewport_rows * 7, 10), 5) - 3
   end
 
   @spec centered_float_height([Picker.item()], MingaEditor.Viewport.t(), boolean()) ::
           pos_integer()
-  defp centered_float_height(visible, viewport, no_matches?) do
+  defp centered_float_height(visible, viewport, has_status_message) do
     max_height = max(div(viewport.rows * 7, 10), 5)
-    item_count = if no_matches?, do: 1, else: length(visible)
+    item_count = if has_status_message, do: 1, else: length(visible)
     min(item_count + 3, max_height)
   end
 

--- a/lib/minga_editor/state/picker.ex
+++ b/lib/minga_editor/state/picker.ex
@@ -10,6 +10,9 @@ defmodule MingaEditor.State.Picker do
   @type action_menu ::
           {[MingaEditor.UI.Picker.Source.action_entry()], non_neg_integer()} | nil
 
+  @typedoc "Async loading status for sources that fetch candidates in the background."
+  @type load_status :: :ready | :loading | {:error, String.t()}
+
   @type t :: %__MODULE__{
           picker: MingaEditor.UI.Picker.t() | nil,
           source: module() | nil,
@@ -19,7 +22,8 @@ defmodule MingaEditor.State.Picker do
           context: map() | nil,
           layout: MingaEditor.UI.Picker.Source.layout(),
           original_source: module() | nil,
-          mode_prefix: String.t()
+          mode_prefix: String.t(),
+          load_status: load_status()
         }
 
   defstruct picker: nil,
@@ -30,7 +34,8 @@ defmodule MingaEditor.State.Picker do
             context: nil,
             layout: :bottom,
             original_source: nil,
-            mode_prefix: ""
+            mode_prefix: "",
+            load_status: :ready
 
   @doc "Returns true if a picker is currently open."
   @spec open?(t()) :: boolean()

--- a/lib/minga_editor/ui/picker.ex
+++ b/lib/minga_editor/ui/picker.ex
@@ -79,6 +79,12 @@ defmodule MingaEditor.UI.Picker do
     }
   end
 
+  @doc "Replaces the item list and refilters against the current query."
+  @spec replace_items(t(), [item()]) :: t()
+  def replace_items(%__MODULE__{} = picker, items) when is_list(items) do
+    refilter(%{picker | items: items})
+  end
+
   # ── Query manipulation ──────────────────────────────────────────────────────
 
   @doc "Appends a character to the query and refilters."

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -130,6 +130,14 @@ defmodule MingaEditor.UI.Picker.Source do
   """
   @callback keep_open_on_select?() :: boolean()
 
+  @doc """
+  Whether this source fetches candidates asynchronously.
+  When `true`, `PickerUI.open/3` opens the picker immediately with a
+  "Searching..." indicator and fetches candidates in a background task.
+  Defaults to `false` (synchronous).
+  """
+  @callback async?() :: boolean()
+
   @optional_callbacks [
     preview?: 0,
     live_preview?: 0,
@@ -141,7 +149,8 @@ defmodule MingaEditor.UI.Picker.Source do
     bulk_actions: 1,
     on_bulk_action: 3,
     layout: 0,
-    keep_open_on_select?: 0
+    keep_open_on_select?: 0,
+    async?: 0
   ]
 
   @doc """
@@ -284,6 +293,18 @@ defmodule MingaEditor.UI.Picker.Source do
   def keep_open_on_select?(module) do
     if exported?(module, :keep_open_on_select?, 0) do
       module.keep_open_on_select?()
+    else
+      false
+    end
+  end
+
+  @doc """
+  Returns whether a source fetches candidates asynchronously.
+  """
+  @spec async?(module()) :: boolean()
+  def async?(module) do
+    if exported?(module, :async?, 0) do
+      module.async?()
     else
       false
     end

--- a/lib/minga_editor/ui/picker/workspace_symbol_source.ex
+++ b/lib/minga_editor/ui/picker/workspace_symbol_source.ex
@@ -30,6 +30,10 @@ defmodule MingaEditor.UI.Picker.WorkspaceSymbolSource do
   def preview?, do: true
 
   @impl true
+  @spec async?() :: boolean()
+  def async?, do: true
+
+  @impl true
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(%Context{buffers: %{active: buf}}) when is_pid(buf) do
     # Send a synchronous workspace/symbol request with empty query.

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -184,7 +184,7 @@ enum RenderCommand: Sendable {
     case guiWhichKey(visible: Bool, prefix: String, page: UInt8, pageCount: UInt8, bindings: [Wire.WhichKeyBinding])
     case guiBreadcrumb(segments: [String])
     case guiStatusBar(StatusBarUpdate)
-    case guiPicker(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, markedCount: UInt16, title: String, query: String, hasPreview: Bool, items: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?, modePrefix: String)
+    case guiPicker(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, markedCount: UInt16, title: String, query: String, hasPreview: Bool, items: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?, modePrefix: String, loadStatus: Wire.PickerLoadStatus)
     case guiPickerPreview(visible: Bool, lines: [Wire.PickerPreviewLine])
     case guiAgentChat(visible: Bool, status: UInt8, model: String, thinkingLevel: String, prompt: String, promptLineCount: UInt8, promptCursorLine: UInt16, promptCursorCol: UInt16, promptVimMode: UInt8, promptVisibleRows: UInt8, promptCompletion: Wire.PromptCompletion?, pendingToolName: String?, pendingToolSummary: String, helpVisible: Bool, helpGroups: [Wire.HelpGroup], messages: [Wire.ChatMessage])
     case guiGutterSeparator(col: UInt16, r: UInt8, g: UInt8, b: UInt8)
@@ -1065,7 +1065,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         guard data.count >= rest + 1 else { throw ProtocolDecodeError.malformed }
         let pickerSectionCount = Int(data[rest])
         if pickerSectionCount == 0 {
-            return (.guiPicker(visible: false, selectedIndex: 0, filteredCount: 0, totalCount: 0, markedCount: 0, title: "", query: "", hasPreview: false, items: [], actionMenu: nil, modePrefix: ""), 2)
+            return (.guiPicker(visible: false, selectedIndex: 0, filteredCount: 0, totalCount: 0, markedCount: 0, title: "", query: "", hasPreview: false, items: [], actionMenu: nil, modePrefix: "", loadStatus: .ready), 2)
         }
         var pickerPos = rest + 1
         var pkVisible = false
@@ -1079,6 +1079,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         var pkItems: [Wire.PickerItem] = []
         var pkActionMenu: Wire.PickerActionMenu? = nil
         var pkModePrefix = ""
+        var pkLoadStatus: Wire.PickerLoadStatus = .ready
 
         for _ in 0..<pickerSectionCount {
             guard data.count >= pickerPos + 3 else { throw ProtocolDecodeError.malformed }
@@ -1167,13 +1168,29 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                     pkActionMenu = Wire.PickerActionMenu(selectedIndex: amSelected, actions: amNames)
                 }
 
+            case 0x06: // LoadStatus: status(1), if error: error_len(2) + error_message
+                guard psLen >= 1 else { break }
+                let statusByte = data[psStart]
+                switch statusByte {
+                case 1: pkLoadStatus = .loading
+                case 2:
+                    if psLen >= 3 {
+                        let errLen = Int(readU16(data, psStart + 1))
+                        if psLen >= 3 + errLen {
+                            let errMsg = String(data: data[(psStart + 3)..<(psStart + 3 + errLen)], encoding: .utf8) ?? "Unknown error"
+                            pkLoadStatus = .error(errMsg)
+                        }
+                    }
+                default: pkLoadStatus = .ready
+                }
+
             default: break
             }
 
             pickerPos = psStart + psLen
         }
 
-        return (.guiPicker(visible: pkVisible, selectedIndex: pkSelectedIndex, filteredCount: pkFilteredCount, totalCount: pkTotalCount, markedCount: pkMarkedCount, title: pkTitle, query: pkQuery, hasPreview: pkHasPreview, items: pkItems, actionMenu: pkActionMenu, modePrefix: pkModePrefix), pickerPos - offset)
+        return (.guiPicker(visible: pkVisible, selectedIndex: pkSelectedIndex, filteredCount: pkFilteredCount, totalCount: pkTotalCount, markedCount: pkMarkedCount, title: pkTitle, query: pkQuery, hasPreview: pkHasPreview, items: pkItems, actionMenu: pkActionMenu, modePrefix: pkModePrefix, loadStatus: pkLoadStatus), pickerPos - offset)
 
     case OP_GUI_PICKER_PREVIEW:
         guard data.count >= rest + 1 else { throw ProtocolDecodeError.malformed }

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -270,6 +270,13 @@ enum Wire {
         let actions: [String]
     }
 
+    /// Async loading status for picker sources.
+    enum PickerLoadStatus: Sendable, Equatable {
+        case ready
+        case loading
+        case error(String)
+    }
+
     /// A styled text segment for picker preview content.
     struct PickerPreviewSegment: Sendable {
         let fgColor: UInt32   // 24-bit RGB

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -265,9 +265,9 @@ final class CommandDispatcher {
                 onModeChanged?(guiState.statusBarState.modeName)
             }
 
-        case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let markedCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix):
+        case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let markedCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix, let loadStatus):
             if visible {
-                guiState.pickerState.update(visible: true, selectedIndex: selectedIndex, filteredCount: filteredCount, totalCount: totalCount, markedCount: markedCount, title: title, query: query, hasPreview: hasPreview, rawItems: items, actionMenu: actionMenu, modePrefix: modePrefix)
+                guiState.pickerState.update(visible: true, selectedIndex: selectedIndex, filteredCount: filteredCount, totalCount: totalCount, markedCount: markedCount, title: title, query: query, hasPreview: hasPreview, rawItems: items, actionMenu: actionMenu, modePrefix: modePrefix, loadStatus: loadStatus)
             } else {
                 guiState.pickerState.hide()
             }

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -140,7 +140,23 @@ struct PickerOverlay: View {
 
     @ViewBuilder
     private func resultsList(maxListHeight: CGFloat) -> some View {
-        if state.items.isEmpty && !state.query.isEmpty {
+        if case .loading = state.loadStatus {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Searching...")
+                    .font(.system(size: 13))
+                    .foregroundStyle(theme.popupFg.opacity(0.35))
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .frame(height: 48)
+        } else if case .error(let message) = state.loadStatus {
+            Text(message)
+                .font(.system(size: 13))
+                .foregroundStyle(theme.popupFg.opacity(0.35))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .frame(height: 48)
+        } else if state.items.isEmpty && !state.query.isEmpty {
             Text("No matches")
                 .font(.system(size: 13))
                 .foregroundStyle(theme.popupFg.opacity(0.35))

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -140,18 +140,26 @@ struct PickerOverlay: View {
 
     @ViewBuilder
     private func resultsList(maxListHeight: CGFloat) -> some View {
-        ScrollViewReader { proxy in
-            ScrollView(.vertical, showsIndicators: true) {
-                LazyVStack(spacing: 0) {
-                    ForEach(state.items) { item in
-                        itemRow(item)
+        if state.items.isEmpty && !state.query.isEmpty {
+            Text("No matches")
+                .font(.system(size: 13))
+                .foregroundStyle(theme.popupFg.opacity(0.35))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .frame(height: 48)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView(.vertical, showsIndicators: true) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(state.items) { item in
+                            itemRow(item)
+                        }
                     }
                 }
-            }
-            .frame(maxHeight: maxListHeight)
-            .onChange(of: state.selectedIndex) { _, newIndex in
-                withAnimation(nil) {
-                    proxy.scrollTo(newIndex, anchor: .center)
+                .frame(maxHeight: maxListHeight)
+                .onChange(of: state.selectedIndex) { _, newIndex in
+                    withAnimation(nil) {
+                        proxy.scrollTo(newIndex, anchor: .center)
+                    }
                 }
             }
         }

--- a/macos/Sources/Views/PickerState.swift
+++ b/macos/Sources/Views/PickerState.swift
@@ -69,11 +69,12 @@ final class PickerState {
     var query: String = ""
     var modePrefix: String = ""
     var hasPreview: Bool = false
+    var loadStatus: Wire.PickerLoadStatus = .ready
     var items: [PickerItem] = []
     var previewLines: [PreviewLine] = []
     var actionMenu: PickerActionMenu? = nil
 
-    func update(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, markedCount: UInt16, title: String, query: String, hasPreview: Bool, rawItems: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?, modePrefix: String = "") {
+    func update(visible: Bool, selectedIndex: UInt16, filteredCount: UInt16, totalCount: UInt16, markedCount: UInt16, title: String, query: String, hasPreview: Bool, rawItems: [Wire.PickerItem], actionMenu: Wire.PickerActionMenu?, modePrefix: String = "", loadStatus: Wire.PickerLoadStatus = .ready) {
         self.visible = visible
         self.selectedIndex = Int(selectedIndex)
         self.filteredCount = Int(filteredCount)
@@ -83,6 +84,7 @@ final class PickerState {
         self.query = query
         self.modePrefix = modePrefix
         self.hasPreview = hasPreview
+        self.loadStatus = loadStatus
         self.items = rawItems.enumerated().map { i, item in
             PickerItem(
                 id: i,
@@ -132,6 +134,7 @@ final class PickerState {
         previewLines = []
         modePrefix = ""
         hasPreview = false
+        loadStatus = .ready
         actionMenu = nil
     }
 }

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -141,13 +141,18 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
         result["selection_size"] = Int(update.selection.size)
         return result
 
-    case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let markedCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix):
+    case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let markedCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix, let loadStatus):
         let itemArray = items.map { i -> [String: Any] in
             ["label": i.label, "description": i.description, "icon_color": Int(i.iconColor), "annotation": i.annotation, "flags": Int(i.flags), "match_positions": i.matchPositions.map { Int($0) }]
         }
         var result: [String: Any] = ["type": "gui_picker", "visible": visible, "selected_index": Int(selectedIndex), "filtered_count": Int(filteredCount), "total_count": Int(totalCount), "marked_count": Int(markedCount), "title": title, "query": query, "mode_prefix": modePrefix, "has_preview": hasPreview, "items": itemArray]
         if let am = actionMenu {
             result["action_menu"] = ["selected_index": Int(am.selectedIndex), "actions": am.actions]
+        }
+        switch loadStatus {
+        case .ready: result["load_status"] = "ready"
+        case .loading: result["load_status"] = "loading"
+        case .error(let msg): result["load_status"] = "error"; result["load_status_error"] = msg
         }
         return result
 

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -462,7 +462,7 @@ struct CommandDispatcherRoutingTests {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.dispatch(.guiPicker(visible: true, selectedIndex: 0, filteredCount: 5,
                                         totalCount: 100, markedCount: 2, title: "Find File", query: "edi",
-                                        hasPreview: false, items: [], actionMenu: nil, modePrefix: ">"))
+                                        hasPreview: false, items: [], actionMenu: nil, modePrefix: ">", loadStatus: .ready))
 
         #expect(gui.pickerState.visible == true)
         #expect(gui.pickerState.title == "Find File")
@@ -476,10 +476,10 @@ struct CommandDispatcherRoutingTests {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.dispatch(.guiPicker(visible: true, selectedIndex: 0, filteredCount: 5,
                                         totalCount: 100, markedCount: 2, title: "Find File", query: "edi",
-                                        hasPreview: false, items: [], actionMenu: nil, modePrefix: ">"))
+                                        hasPreview: false, items: [], actionMenu: nil, modePrefix: ">", loadStatus: .ready))
         dispatcher.dispatch(.guiPicker(visible: false, selectedIndex: 0, filteredCount: 0,
                                         totalCount: 0, markedCount: 0, title: "", query: "",
-                                        hasPreview: false, items: [], actionMenu: nil, modePrefix: ""))
+                                        hasPreview: false, items: [], actionMenu: nil, modePrefix: "", loadStatus: .ready))
 
         #expect(gui.pickerState.visible == false)
         #expect(gui.pickerState.items.isEmpty)

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -1755,7 +1755,7 @@ struct GUIPickerDecoderTests {
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let markedCount, let title, let q, let hasPreview, let decodedItems, let decodedMenu, let modePrefix) = cmd else {
+        guard case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let markedCount, let title, let q, let hasPreview, let decodedItems, let decodedMenu, let modePrefix, _) = cmd else {
             Issue.record("Expected .guiPicker"); return
         }
 
@@ -1786,7 +1786,7 @@ struct GUIPickerDecoderTests {
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == 2)
 
-        guard case .guiPicker(let visible, _, _, _, let markedCount, _, _, _, let items, let actionMenu, let modePrefix) = cmd else {
+        guard case .guiPicker(let visible, _, _, _, let markedCount, _, _, _, let items, let actionMenu, let modePrefix, _) = cmd else {
             Issue.record("Expected .guiPicker"); return
         }
         #expect(visible == false)
@@ -1829,7 +1829,7 @@ struct GUIPickerDecoderTests {
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiPicker(let visible, _, _, _, _, _, _, _, _, let am, let modePrefix) = cmd else {
+        guard case .guiPicker(let visible, _, _, _, _, _, _, _, _, let am, let modePrefix, _) = cmd else {
             Issue.record("Expected .guiPicker"); return
         }
         #expect(visible == true)

--- a/test/minga_editor/frontend/gui_picker_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_picker_protocol_test.exs
@@ -42,7 +42,7 @@ defmodule MingaEditor.Frontend.GUIPickerProtocolTest do
 
       # Sectioned: opcode(1) + section_count(1) + sections...
       assert <<0x77, section_count, _rest::binary>> = binary
-      assert section_count == 5
+      assert section_count == 6
     end
 
     test "encodes has_preview flag" do
@@ -53,8 +53,8 @@ defmodule MingaEditor.Frontend.GUIPickerProtocolTest do
       with_preview = ProtocolGUI.encode_gui_picker(picker, true)
 
       # Both should be valid sectioned format
-      assert <<0x77, 5, _::binary>> = without_preview
-      assert <<0x77, 5, _::binary>> = with_preview
+      assert <<0x77, 6, _::binary>> = without_preview
+      assert <<0x77, 6, _::binary>> = with_preview
       # They should differ (the has_preview byte in the header section)
       assert without_preview != with_preview
     end
@@ -66,9 +66,9 @@ defmodule MingaEditor.Frontend.GUIPickerProtocolTest do
       bare = ProtocolGUI.encode_gui_picker(picker)
       prefixed = ProtocolGUI.encode_gui_picker(picker, false, nil, 0, ">")
 
-      assert <<0x77, 5, _::binary>> = prefixed
+      assert <<0x77, 6, _::binary>> = prefixed
       assert bare != prefixed
-      assert section_ids(prefixed) == [0x01, 0x02, 0x03, 0x04, 0x05]
+      assert section_ids(prefixed) == [0x01, 0x02, 0x03, 0x04, 0x05, 0x06]
     end
 
     test "encodes filtered, total, and marked counts in header" do
@@ -89,7 +89,7 @@ defmodule MingaEditor.Frontend.GUIPickerProtocolTest do
       # Sectioned: opcode(1) + section_count(1) + section_0x01 header
       # Section header: id(1) + len(2) + payload
       # Payload: visible(1) + selected(2) + filtered(2) + total(2) + has_preview(1) + title_len(2) + title + marked(2)
-      <<0x77, 5, 0x01, _slen::16, 1, _selected::16, filtered::16, total::16, _has_preview::8,
+      <<0x77, 6, 0x01, _slen::16, 1, _selected::16, filtered::16, total::16, _has_preview::8,
         title_len::16, title::binary-size(title_len), marked::16, _rest::binary>> = binary
 
       assert title == "Test"
@@ -107,6 +107,43 @@ defmodule MingaEditor.Frontend.GUIPickerProtocolTest do
       end)
 
     Enum.reverse(ids)
+  end
+
+  defp section_payloads(<<0x77, section_count, rest::binary>>) do
+    {map, _rest} =
+      Enum.reduce(1..section_count, {%{}, rest}, fn _, {acc, bin} ->
+        <<id, len::16, payload::binary-size(len), remaining::binary>> = bin
+        {Map.put(acc, id, payload), remaining}
+      end)
+
+    map
+  end
+
+  describe "encode_gui_picker load_status section" do
+    test "encodes :ready as status byte 0" do
+      items = [%Item{id: :a, label: "test.ex", description: ""}]
+      picker = Picker.new(items, title: "Test")
+      binary = ProtocolGUI.encode_gui_picker(picker, false, nil, 0, "", :ready)
+      sections = section_payloads(binary)
+      assert %{0x06 => <<0>>} = sections
+    end
+
+    test "encodes :loading as status byte 1" do
+      items = [%Item{id: :a, label: "test.ex", description: ""}]
+      picker = Picker.new(items, title: "Test")
+      binary = ProtocolGUI.encode_gui_picker(picker, false, nil, 0, "", :loading)
+      sections = section_payloads(binary)
+      assert %{0x06 => <<1>>} = sections
+    end
+
+    test "encodes {:error, reason} as status byte 2 with message" do
+      items = [%Item{id: :a, label: "test.ex", description: ""}]
+      picker = Picker.new(items, title: "Test")
+      binary = ProtocolGUI.encode_gui_picker(picker, false, nil, 0, "", {:error, "Timed out"})
+      sections = section_payloads(binary)
+      assert %{0x06 => <<2, err_len::16, err::binary-size(err_len)>>} = sections
+      assert err == "Timed out"
+    end
   end
 
   describe "encode_gui_picker_preview/1" do

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -506,6 +506,83 @@ defmodule MingaEditor.PickerUITest do
                String.contains?(text, "3/3 (2 marked)")
              end)
     end
+
+    test "bottom picker shows 'No matches' when query filters all items" do
+      items = [%Item{id: "1", label: "alpha.ex"}, %Item{id: "2", label: "beta.ex"}]
+      picker = items |> Picker.new(title: "Files", max_visible: 10) |> Picker.filter("zzzzz")
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+
+      assert Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "No matches")
+             end)
+    end
+
+    test "bottom picker does not show 'No matches' with an empty query" do
+      items = [%Item{id: "1", label: "alpha.ex"}]
+      picker = Picker.new(items, title: "Files", max_visible: 10)
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+
+      refute Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "No matches")
+             end)
+    end
+
+    test "centered picker shows 'No matches' when query filters all items" do
+      items = [%Item{id: "1", label: "alpha.ex"}, %Item{id: "2", label: "beta.ex"}]
+      picker = items |> Picker.new(title: "Files", max_visible: 10) |> Picker.filter("zzzzz")
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil, layout: :centered},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+
+      assert Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "No matches")
+             end)
+    end
+
+    test "'No matches' disappears when query is backspaced to a matching state" do
+      items = [%Item{id: "1", label: "alpha.ex"}, %Item{id: "2", label: "beta.ex"}]
+
+      picker =
+        items
+        |> Picker.new(title: "Files", max_visible: 10)
+        |> Picker.filter("zzzzz")
+        |> Picker.backspace()
+        |> Picker.backspace()
+        |> Picker.backspace()
+        |> Picker.backspace()
+        |> Picker.backspace()
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+
+      refute Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "No matches")
+             end)
+    end
   end
 
   describe "bulk picker actions" do

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -585,6 +585,106 @@ defmodule MingaEditor.PickerUITest do
     end
   end
 
+  describe "loading and error state rendering" do
+    test "bottom picker shows 'Searching...' when load_status is :loading" do
+      picker = Picker.new([], title: "Workspace Symbols", max_visible: 10)
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil, load_status: :loading},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+
+      assert Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "Searching...")
+             end)
+    end
+
+    test "centered picker shows 'Searching...' when load_status is :loading" do
+      picker = Picker.new([], title: "Workspace Symbols", max_visible: 10)
+
+      input = %RenderInput{
+        picker_state: %PickerState{
+          picker: picker,
+          source: nil,
+          layout: :centered,
+          load_status: :loading
+        },
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+
+      assert Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "Searching...")
+             end)
+    end
+
+    test "bottom picker shows error message when load_status is {:error, reason}" do
+      picker = Picker.new([], title: "Workspace Symbols", max_visible: 10)
+
+      input = %RenderInput{
+        picker_state: %PickerState{
+          picker: picker,
+          source: nil,
+          load_status: {:error, "Source timed out"}
+        },
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+
+      assert Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "Source timed out")
+             end)
+    end
+
+    test "centered picker shows error message when load_status is {:error, reason}" do
+      picker = Picker.new([], title: "Workspace Symbols", max_visible: 10)
+
+      input = %RenderInput{
+        picker_state: %PickerState{
+          picker: picker,
+          source: nil,
+          layout: :centered,
+          load_status: {:error, "LSP not available"}
+        },
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+
+      assert Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "LSP not available")
+             end)
+    end
+
+    test "loading state takes priority over 'No matches' even with non-empty query" do
+      picker = Picker.new([], title: "Symbols", max_visible: 10) |> Picker.filter("foo")
+
+      input = %RenderInput{
+        picker_state: %PickerState{picker: picker, source: nil, load_status: :loading},
+        theme_picker: theme_picker(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      {draws, _cursor} = PickerUI.render(input)
+
+      assert Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "Searching...")
+             end)
+
+      refute Enum.any?(draws, fn {_row, _col, text, _face} ->
+               String.contains?(text, "No matches")
+             end)
+    end
+  end
+
   describe "bulk picker actions" do
     test "C-o shows source bulk actions when items are marked" do
       state = picker_state_with_buffers(["alpha", "beta", "gamma"])


### PR DESCRIPTION
## Summary

Implements all four acceptance criteria from #1731:

**AC #1: "No matches" empty state** (commit 1)
- When a fuzzy query matches nothing, the picker shows a dim "No matches" message instead of blank space
- Covers TUI bottom layout, TUI centered (floating) layout, and macOS SwiftUI overlay
- The message disappears immediately when the user backspaces to a matching query

**AC #2: Loading indicator for async sources** (commit 2)
- Sources can opt into async fetching via the new `async?/0` callback
- The picker opens immediately with a "Searching..." indicator while candidates are fetched in a background task
- WorkspaceSymbolSource is the first async source, removing the 5-second GenServer block during workspace/symbol requests

**AC #3: Error feedback** (commit 2)
- If an async source's `candidates/1` raises, times out, or throws, the error message is shown in the picker
- Covers rescue (exceptions), exit (timeouts), and throw

**AC #4: Sync sources unchanged**
- Synchronous sources use the same `open_sync` path with identical behavior

Both TUI and macOS GUI render loading and error states. The GUI protocol adds section 0x06 for `load_status`.

Closes #1731

## Test plan

- [x] 4 new tests for "No matches" rendering (AC #1)
- [x] 5 new tests for loading/error rendering: bottom loading, centered loading, bottom error, centered error, loading priority over "No matches"
- [x] 3 new protocol encoding tests for load_status section (ready, loading, error)
- [x] `mix compile` clean, no warnings
- [x] `mix test.llm` — 8562 tests, 0 failures
- [x] `mix swift.build` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` — 13 pre-existing warnings, none in changed files
- [ ] Manual: open workspace symbols picker (SPC s w), verify "Searching..." appears briefly, then results load
- [ ] Manual: open file finder, type "zzzzzzz", verify "No matches" appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)