### PR TITLE
feat(extension): EditorAPI facade for extension editor actions

### DIFF
--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -670,19 +670,12 @@ defmodule MingaEditor.Commands do
   @spec start_buffer(String.t()) :: {:ok, pid()} | {:error, term()}
   @spec start_buffer(String.t(), Minga.Config.Options.server() | nil) ::
           {:ok, pid()} | {:error, term()}
-  def start_buffer(file_path, options_server \\ Minga.Config.Options.default_server()) do
+  def start_buffer(file_path, options_server \\ nil) do
     options_server = normalize_options_server(options_server)
 
-    case Buffer.pid_for_path(file_path) do
-      {:ok, pid} ->
-        {:ok, pid}
-
-      :not_found ->
-        DynamicSupervisor.start_child(
-          Minga.Buffer.Supervisor,
-          {Minga.Buffer, file_path: file_path, options_server: options_server}
-        )
-    end
+    Buffer.ensure_for_path(file_path, Minga.Events.default_registry(),
+      options_server: options_server
+    )
   end
 
   @doc "Adds a new buffer to the list and makes it active."

--- a/lib/minga_editor/extension/editor_api.ex
+++ b/lib/minga_editor/extension/editor_api.ex
@@ -1,0 +1,86 @@
+defmodule MingaEditor.Extension.EditorAPI do
+  @moduledoc """
+  High-level editor actions for extensions.
+
+  Extensions call these functions from command callbacks instead of
+  reaching into `EditorState` internals. Each function accepts editor
+  state and returns modified state, matching the extension command
+  contract.
+
+  ## Usage in an extension command
+
+      command :my_open, "Open a specific file",
+        execute: {MyExtension.Commands, :open_target}
+
+      # In MyExtension.Commands:
+      def open_target(state) do
+        Minga.Extension.EditorAPI.open_file(state, "/path/to/file.ex")
+      end
+  """
+
+  alias MingaEditor.Handlers.BufferRegistry
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Windows
+  alias Minga.Buffer
+
+  @typedoc "Editor state (opaque to extensions)."
+  @type state :: EditorState.t()
+
+  @doc """
+  Opens a file by path in the current window.
+
+  If the file is already open in the active workspace, switches to its
+  tab. Otherwise, creates a new buffer and tab for it. Sets a status
+  message on failure (file not found, permission error).
+  """
+  @spec open_file(state(), String.t()) :: state()
+  def open_file(state, path) when is_binary(path) do
+    abs_path = Path.expand(path)
+    BufferRegistry.open_file_by_path(state, abs_path)
+  end
+
+  @doc """
+  Focuses the window showing a specific buffer.
+
+  Finds the window whose buffer matches `buffer_pid` and switches
+  focus to it. Returns state unchanged if no window shows that buffer.
+  """
+  @spec focus_buffer(state(), pid()) :: state()
+  def focus_buffer(state, buffer_pid) when is_pid(buffer_pid) do
+    case Windows.find_by_content(state.workspace.windows, &(&1.buffer == buffer_pid)) do
+      {window_id, _window} -> EditorState.focus_window(state, window_id)
+      nil -> state
+    end
+  end
+
+  @doc """
+  Opens a file and moves the cursor to a specific line and column.
+
+  Combines `open_file/2` with cursor navigation. The cursor moves
+  after the file is opened and its buffer is active.
+  """
+  @spec navigate_to(state(), String.t(), non_neg_integer(), non_neg_integer()) :: state()
+  def navigate_to(state, path, line, col \\ 0) when is_binary(path) do
+    state = open_file(state, path)
+
+    case state.workspace.buffers.active do
+      pid when is_pid(pid) ->
+        Buffer.move_to(pid, {line, col})
+        state
+
+      _ ->
+        state
+    end
+  end
+
+  @doc """
+  Sets a transient status bar message.
+
+  The message clears on the next user action, matching the standard
+  editor status message behavior.
+  """
+  @spec set_status(state(), String.t()) :: state()
+  def set_status(state, message) when is_binary(message) do
+    EditorState.set_status(state, message)
+  end
+end

--- a/lib/minga_editor/extension/editor_api.ex
+++ b/lib/minga_editor/extension/editor_api.ex
@@ -61,10 +61,11 @@ defmodule MingaEditor.Extension.EditorAPI do
   """
   @spec navigate_to(state(), String.t(), non_neg_integer(), non_neg_integer()) :: state()
   def navigate_to(state, path, line, col \\ 0) when is_binary(path) do
+    prev_active = state.workspace.buffers.active
     state = open_file(state, path)
 
     case state.workspace.buffers.active do
-      pid when is_pid(pid) ->
+      pid when is_pid(pid) and pid != prev_active ->
         Buffer.move_to(pid, {line, col})
         state
 

--- a/lib/minga_editor/extension/editor_api.ex
+++ b/lib/minga_editor/extension/editor_api.ex
@@ -14,7 +14,7 @@ defmodule MingaEditor.Extension.EditorAPI do
 
       # In MyExtension.Commands:
       def open_target(state) do
-        Minga.Extension.EditorAPI.open_file(state, "/path/to/file.ex")
+        MingaEditor.Extension.EditorAPI.open_file(state, "/path/to/file.ex")
       end
   """
 

--- a/test/minga/extension/editor_api_test.exs
+++ b/test/minga/extension/editor_api_test.exs
@@ -51,9 +51,43 @@ defmodule MingaEditor.Extension.EditorAPITest do
       assert is_pid(active_buf)
       assert Minga.Buffer.cursor(active_buf) == {2, 0}
     end
+
+    test "leaves cursor unchanged when file does not exist" do
+      ctx = start_editor("original")
+      state = editor_state(ctx)
+      original_cursor = Minga.Buffer.cursor(state.workspace.buffers.active)
+
+      new_state = EditorAPI.navigate_to(state, "/nonexistent/file.ex", 5, 3)
+
+      assert Minga.Buffer.cursor(new_state.workspace.buffers.active) == original_cursor
+    end
   end
 
   describe "focus_buffer/2" do
+    test "switches focus to the window showing the target buffer" do
+      path = write_temp_file("focus_buf_test", "second file")
+      ctx = start_editor("first file")
+      state = editor_state(ctx)
+      original_buffer = state.workspace.buffers.active
+      original_window = state.workspace.windows.active
+
+      new_window_id = state.workspace.windows.next_id
+      state = MingaEditor.Commands.Movement.execute(state, :split_vertical)
+
+      second_buffer = start_supervised!({Minga.Buffer.Process, content: "second file", file_path: path}, id: {:buffer, make_ref()})
+
+      windows = MingaEditor.State.Windows.update(state.workspace.windows, new_window_id, fn w ->
+        %{w | buffer: second_buffer, content: {:buffer, second_buffer}}
+      end)
+      state = put_in(state.workspace.windows, windows)
+      state = EditorState.focus_window(state, new_window_id)
+      assert state.workspace.windows.active == new_window_id
+
+      new_state = EditorAPI.focus_buffer(state, original_buffer)
+
+      assert new_state.workspace.windows.active == original_window
+    end
+
     test "returns state unchanged when buffer is not in any window" do
       ctx = start_editor("hello")
       state = editor_state(ctx)

--- a/test/minga/extension/editor_api_test.exs
+++ b/test/minga/extension/editor_api_test.exs
@@ -1,0 +1,79 @@
+defmodule MingaEditor.Extension.EditorAPITest do
+  use Minga.Test.EditorCase, async: true
+
+  alias MingaEditor.Extension.EditorAPI
+  alias MingaEditor.State, as: EditorState
+
+  describe "set_status/2" do
+    test "sets transient status message" do
+      ctx = start_editor("hello world")
+      state = editor_state(ctx)
+
+      new_state = EditorAPI.set_status(state, "Test status message")
+
+      assert EditorState.status_msg(new_state) == "Test status message"
+    end
+  end
+
+  describe "open_file/2" do
+    test "opens an existing file and makes its buffer active" do
+      path = write_temp_file("extension_editor_api_test", "file content here")
+      ctx = start_editor("original content")
+      state = editor_state(ctx)
+
+      new_state = EditorAPI.open_file(state, path)
+
+      active_buf = new_state.workspace.buffers.active
+      assert is_pid(active_buf)
+      assert Minga.Buffer.file_path(active_buf) == path
+    end
+
+    test "does not crash on nonexistent file" do
+      ctx = start_editor("original content")
+      state = editor_state(ctx)
+
+      new_state = EditorAPI.open_file(state, "/nonexistent/path/to/file.ex")
+
+      assert %EditorState{} = new_state
+    end
+  end
+
+  describe "navigate_to/4" do
+    test "opens file and moves cursor to specified line" do
+      content = "line one\nline two\nline three\nline four\n"
+      path = write_temp_file("editor_api_nav_test", content)
+      ctx = start_editor("original")
+      state = editor_state(ctx)
+
+      new_state = EditorAPI.navigate_to(state, path, 2, 0)
+
+      active_buf = new_state.workspace.buffers.active
+      assert is_pid(active_buf)
+      assert Minga.Buffer.cursor(active_buf) == {2, 0}
+    end
+  end
+
+  describe "focus_buffer/2" do
+    test "returns state unchanged when buffer is not in any window" do
+      ctx = start_editor("hello")
+      state = editor_state(ctx)
+      fake_pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      new_state = EditorAPI.focus_buffer(state, fake_pid)
+
+      assert new_state.workspace.windows.active == state.workspace.windows.active
+
+      Process.exit(fake_pid, :kill)
+    end
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────────
+
+  defp write_temp_file(prefix, content) do
+    dir = System.tmp_dir!()
+    path = Path.join(dir, "#{prefix}_#{System.unique_integer([:positive])}.txt")
+    File.write!(path, content)
+    on_exit(fn -> File.rm(path) end)
+    path
+  end
+end

--- a/test/minga/extension/editor_api_test.exs
+++ b/test/minga/extension/editor_api_test.exs
@@ -74,11 +74,16 @@ defmodule MingaEditor.Extension.EditorAPITest do
       new_window_id = state.workspace.windows.next_id
       state = MingaEditor.Commands.Movement.execute(state, :split_vertical)
 
-      second_buffer = start_supervised!({Minga.Buffer.Process, content: "second file", file_path: path}, id: {:buffer, make_ref()})
+      second_buffer =
+        start_supervised!({Minga.Buffer.Process, content: "second file", file_path: path},
+          id: {:buffer, make_ref()}
+        )
 
-      windows = MingaEditor.State.Windows.update(state.workspace.windows, new_window_id, fn w ->
-        %{w | buffer: second_buffer, content: {:buffer, second_buffer}}
-      end)
+      windows =
+        MingaEditor.State.Windows.update(state.workspace.windows, new_window_id, fn w ->
+          %{w | buffer: second_buffer, content: {:buffer, second_buffer}}
+        end)
+
       state = put_in(state.workspace.windows, windows)
       state = EditorState.focus_window(state, new_window_id)
       assert state.workspace.windows.active == new_window_id


### PR DESCRIPTION
## Summary

- Adds `MingaEditor.Extension.EditorAPI`, a Layer 2 facade for common editor actions extensions need from command callbacks
- `open_file/2`: opens file by path (reuses existing tab or creates new buffer)
- `focus_buffer/2`: switches to the window showing a specific buffer
- `navigate_to/4`: opens file and moves cursor to a specific line/col
- `set_status/2`: sets transient status bar message
- Lives at Layer 2 (`MingaEditor.*`) to avoid layer violations with `EditorState` and `BufferRegistry`
- Part of the Extension Rendering API epic (#1905)

## Test plan

- [x] `mix test.llm test/minga/extension/editor_api_test.exs` (5 tests pass)
- [x] `make lint` passes (format, credo with zero design violations, dialyzer)
- [x] Layer violation check clean (module at Layer 2, dependencies are all Layer 2)
- [x] Tests use headless editor via `EditorCase` for real state mutations

Closes #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)