### PR TITLE
feat(sdk): minga_sdk compile-time package for extension authors

### DIFF
--- a/sdk/.formatter.exs
+++ b/sdk/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -1,0 +1,5 @@
+/_build/
+/deps/
+/doc/
+*.beam
+mix.lock

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,54 @@
+# Minga SDK
+
+Compile-time SDK for building [Minga](https://github.com/jsmestad/minga) editor extensions.
+
+This package provides the types, behaviours, macros, and API stubs that extension authors need to compile their code. At runtime, the real Minga modules in the editor's BEAM VM take over.
+
+## Installation
+
+Add `minga_sdk` to your extension's dependencies:
+
+```elixir
+def deps do
+  [
+    {:minga_sdk, "~> 0.1", only: [:dev, :test], runtime: false}
+  ]
+end
+```
+
+## Usage
+
+```elixir
+defmodule MyExtension do
+  use Minga.Extension
+
+  option :enabled, :boolean, default: true, description: "Enable the extension"
+
+  command :my_command, "Does something useful",
+    execute: {MyExtension.Commands, :run}
+
+  keybind :normal, "SPC m x", :my_command, "Run my command"
+
+  @impl true
+  def name, do: :my_extension
+
+  @impl true
+  def description, do: "My cool extension"
+
+  @impl true
+  def version, do: "0.1.0"
+
+  @impl true
+  def init(_config), do: {:ok, %{}}
+end
+```
+
+## What's included
+
+- `Minga.Extension` behaviour and DSL macros (`option`, `command`, `keybind`, `modeline_segment`)
+- `Minga.Extension.Overlay` API for rendering positioned overlays on the editor surface
+- `Minga.Extension.AgentAPI` for querying agent session state
+- `MingaEditor.Extension.EditorAPI` for triggering editor actions from commands
+- `Minga.Events` for subscribing to editor events
+- `Minga.Buffer` public API types
+- `Minga.Core.Decorations` types for buffer-level visual decorations

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -51,4 +51,4 @@ end
 - `MingaEditor.Extension.EditorAPI` for triggering editor actions from commands
 - `Minga.Events` for subscribing to editor events
 - `Minga.Buffer` public API types
-- `Minga.Core.Decorations` types for buffer-level visual decorations
+- `Minga.Buffer.EditSource` and `Minga.Buffer.EditDelta` types for tracking edit origins and positions

--- a/sdk/lib/minga/buffer.ex
+++ b/sdk/lib/minga/buffer.ex
@@ -1,0 +1,50 @@
+defmodule Minga.Buffer do
+  @moduledoc """
+  Public API for buffer operations.
+
+  Extensions use this module to read buffer content, query cursor
+  position, check file paths, and manage decorations.
+
+  This is a compile-time stub. At runtime, the real module in Minga's
+  BEAM VM provides the implementation.
+  """
+
+  @type t :: GenServer.server()
+  @type position :: {line :: non_neg_integer(), col :: non_neg_integer()}
+
+  @spec content(t()) :: String.t()
+  def content(_server), do: raise("minga_sdk is compile-time only")
+
+  @spec cursor(t()) :: position()
+  def cursor(_server), do: raise("minga_sdk is compile-time only")
+
+  @spec move_to(t(), position()) :: :ok
+  def move_to(_server, _pos), do: raise("minga_sdk is compile-time only")
+
+  @spec file_path(t()) :: String.t() | nil
+  def file_path(_server), do: raise("minga_sdk is compile-time only")
+
+  @spec filetype(t()) :: atom()
+  def filetype(_server), do: raise("minga_sdk is compile-time only")
+
+  @spec line_count(t()) :: pos_integer()
+  def line_count(_server), do: raise("minga_sdk is compile-time only")
+
+  @spec dirty?(t()) :: boolean()
+  def dirty?(_server), do: raise("minga_sdk is compile-time only")
+
+  @spec read_only?(t()) :: boolean()
+  def read_only?(_server), do: raise("minga_sdk is compile-time only")
+
+  @spec lines(t(), non_neg_integer(), non_neg_integer()) :: [String.t()]
+  def lines(_server, _start, _count), do: raise("minga_sdk is compile-time only")
+
+  @spec decorations(t()) :: term()
+  def decorations(_server), do: raise("minga_sdk is compile-time only")
+
+  @spec batch_decorations(t(), (term() -> term())) :: :ok
+  def batch_decorations(_server, _fun), do: raise("minga_sdk is compile-time only")
+
+  @spec get_option(t(), atom()) :: term()
+  def get_option(_server, _name), do: raise("minga_sdk is compile-time only")
+end

--- a/sdk/lib/minga/buffer/edit_delta.ex
+++ b/sdk/lib/minga/buffer/edit_delta.ex
@@ -1,0 +1,40 @@
+defmodule Minga.Buffer.EditDelta do
+  @moduledoc """
+  Describes a single edit applied to a buffer.
+
+  Extensions receive this in `BufferChangedEvent.delta` when tracking
+  agent edit positions. The `new_end_position` field gives the cursor
+  position after the edit.
+
+  This is a compile-time stub.
+  """
+
+  @enforce_keys [
+    :start_byte,
+    :old_end_byte,
+    :new_end_byte,
+    :start_position,
+    :old_end_position,
+    :new_end_position,
+    :inserted_text
+  ]
+  defstruct [
+    :start_byte,
+    :old_end_byte,
+    :new_end_byte,
+    :start_position,
+    :old_end_position,
+    :new_end_position,
+    :inserted_text
+  ]
+
+  @type t :: %__MODULE__{
+          start_byte: non_neg_integer(),
+          old_end_byte: non_neg_integer(),
+          new_end_byte: non_neg_integer(),
+          start_position: {non_neg_integer(), non_neg_integer()},
+          old_end_position: {non_neg_integer(), non_neg_integer()},
+          new_end_position: {non_neg_integer(), non_neg_integer()},
+          inserted_text: String.t()
+        }
+end

--- a/sdk/lib/minga/buffer/edit_source.ex
+++ b/sdk/lib/minga/buffer/edit_source.ex
@@ -1,0 +1,23 @@
+defmodule Minga.Buffer.EditSource do
+  @moduledoc """
+  Identifies who made an edit to a buffer.
+
+  Extensions pattern-match on the source in `BufferChangedEvent` to
+  filter for agent-sourced edits:
+
+      case event.source do
+        {:agent, session_pid, tool_call_id} -> handle_agent_edit(...)
+        :user -> ignore
+        _ -> ignore
+      end
+
+  This is a compile-time stub.
+  """
+
+  @type t ::
+          :user
+          | {:agent, session_id :: pid(), tool_call_id :: String.t()}
+          | {:lsp, server_name :: atom()}
+          | :formatter
+          | :unknown
+end

--- a/sdk/lib/minga/events.ex
+++ b/sdk/lib/minga/events.ex
@@ -29,6 +29,7 @@ defmodule Minga.Events do
 
   defmodule BufferChangedEvent do
     @moduledoc "Payload for `:buffer_changed` events."
+    @enforce_keys [:buffer, :source]
     defstruct [:buffer, :source, :delta, :version]
 
     @type t :: %__MODULE__{
@@ -41,6 +42,7 @@ defmodule Minga.Events do
 
   defmodule BufferEvent do
     @moduledoc "Payload for `:buffer_saved` and `:buffer_opened` events."
+    @enforce_keys [:buffer, :path]
     defstruct [:buffer, :path]
 
     @type t :: %__MODULE__{buffer: pid(), path: String.t()}

--- a/sdk/lib/minga/events.ex
+++ b/sdk/lib/minga/events.ex
@@ -1,0 +1,48 @@
+defmodule Minga.Events do
+  @moduledoc """
+  Event bus for subscribing to editor lifecycle events.
+
+  Extensions use `subscribe/1` to receive events in their process mailbox
+  as `{:minga_event, topic, payload}` messages.
+
+  This is a compile-time stub. At runtime, the real module in Minga's
+  BEAM VM provides the implementation.
+  """
+
+  @type topic ::
+          :buffer_saved
+          | :buffer_opened
+          | :buffer_closed
+          | :buffer_changed
+          | :mode_changed
+          | :git_status_changed
+          | :diagnostics_updated
+          | :agent_session_stopped
+          | :agent_hook
+          | :file_written
+
+  @spec subscribe(topic()) :: :ok
+  def subscribe(_topic), do: raise("minga_sdk is compile-time only")
+
+  @spec unsubscribe(topic()) :: :ok
+  def unsubscribe(_topic), do: raise("minga_sdk is compile-time only")
+
+  defmodule BufferChangedEvent do
+    @moduledoc "Payload for `:buffer_changed` events."
+    defstruct [:buffer, :source, :delta, :version]
+
+    @type t :: %__MODULE__{
+            buffer: pid(),
+            source: term(),
+            delta: term(),
+            version: non_neg_integer() | nil
+          }
+  end
+
+  defmodule BufferEvent do
+    @moduledoc "Payload for `:buffer_saved` and `:buffer_opened` events."
+    defstruct [:buffer, :path]
+
+    @type t :: %__MODULE__{buffer: pid(), path: String.t()}
+  end
+end

--- a/sdk/lib/minga/extension.ex
+++ b/sdk/lib/minga/extension.ex
@@ -1,0 +1,387 @@
+defmodule Minga.Extension do
+  @moduledoc """
+  Behaviour and DSL for Minga editor extensions.
+
+  Extensions are self-contained Elixir modules that add functionality to
+  the editor. Each extension runs under its own supervisor, so a crash in
+  one extension never affects others or the editor itself.
+
+  ## Implementing an extension
+
+      defmodule MingaOrg do
+        use Minga.Extension
+
+        option :conceal, :boolean,
+          default: true,
+          description: "Hide markup delimiters and show styled content"
+
+        option :todo_keywords, :string_list,
+          default: ["TODO", "DONE"],
+          description: "TODO keyword cycle sequence"
+
+        command :org_cycle_todo, "Cycle TODO keyword",
+          execute: {MingaOrg.Todo, :cycle},
+          requires_buffer: true
+
+        command :org_toggle_checkbox, "Toggle checkbox",
+          execute: {MingaOrg.Checkbox, :toggle},
+          requires_buffer: true
+
+        keybind :normal, "SPC m t", :org_cycle_todo, "Cycle TODO", filetype: :org
+        keybind :normal, "SPC m x", :org_toggle_checkbox, "Toggle checkbox", filetype: :org
+
+        @impl true
+        def name, do: :minga_org
+
+        @impl true
+        def description, do: "Org-mode support"
+
+        @impl true
+        def version, do: "0.1.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+
+  Commands and keybindings declared with `command/3` and `keybind/4` are
+  auto-registered by the framework when the extension loads. Extensions
+  that need runtime-dynamic commands can still call the source-owned
+  `Minga.Command.Registry.register/5` and `Minga.Keymap.Active.bind/6`
+  APIs directly from `init/1`.
+
+  ## Config declaration
+
+      use Minga.Config
+
+      extension :minga_org, git: "https://github.com/jsmestad/minga-org",
+        conceal: false,
+        pretty_bullets: true
+
+  Options declared with `option/3` are validated against their type at
+  load time. Users get clear errors for type mismatches. Unknown keys
+  produce a warning log.
+
+  ## Reading options at runtime
+
+      Minga.Config.get_extension_option(:minga_org, :conceal)
+      # => false
+
+  ## Lifecycle
+
+  1. The extension module is compiled from the declared path
+  2. Options from the extension declaration are validated against the schema
+  3. `init/1` is called with the config keyword list (minus `:path`)
+  4. The extension's `child_spec/1` is started under `Minga.Extension.Supervisor`
+  5. On config reload (`SPC h r`), all extensions are stopped and re-loaded
+  """
+
+  @typedoc "Extension runtime status."
+  @type extension_status :: :running | :stopped | :crashed | :load_error
+
+  @typedoc "Extension metadata and runtime info. See `Minga.Extension.Entry`."
+  @type extension_info :: Minga.Extension.Entry.t()
+
+  @doc "The extension's unique name (atom)."
+  @callback name() :: atom()
+
+  @doc "A short human-readable description of what the extension does."
+  @callback description() :: String.t()
+
+  @doc "The extension's version string (e.g. `\"0.1.0\"`)."
+  @callback version() :: String.t()
+
+  @doc """
+  Called when the extension is loaded. Receives the config keyword list
+  from the extension declaration (with source keys like `:path` removed).
+
+  Return `{:ok, state}` to start successfully, or `{:error, reason}` to
+  report a load failure without crashing the editor.
+  """
+  @callback init(config :: keyword()) :: {:ok, term()} | {:error, term()}
+
+  @doc """
+  Optional. Returns a child spec for the extension's supervision subtree.
+
+  The default implementation (provided by `use Minga.Extension`) starts
+  a simple Agent that holds the state returned by `init/1`. Override this
+  if your extension needs a custom GenServer, multiple processes, or a
+  full supervision tree.
+  """
+  @callback child_spec(config :: keyword()) :: Supervisor.child_spec()
+
+  @optional_callbacks [child_spec: 1]
+
+  @typedoc """
+  A single option specification: `{name, type, default, description}`.
+
+  The type descriptor uses the same types as `Minga.Config.Options`:
+  `:boolean`, `:pos_integer`, `:string`, `:string_list`, `{:enum, [atoms]}`, etc.
+
+  The doc string is used by `SPC h v` (describe option) and other
+  introspection features.
+  """
+  @type option_spec ::
+          {atom(), Minga.Config.type_descriptor(), term(), description :: String.t()}
+
+  @typedoc """
+  A single command specification: `{name, description, opts}`.
+
+  The opts keyword list supports:
+
+  * `:execute` (required) — `{Module, :function}` MFA tuple. The function
+    receives editor state and returns new state. Extensions that need
+    config should call `Minga.Config.Options.get_extension_option/2`
+    inside the function body.
+  * `:requires_buffer` — when `true`, command is skipped if no buffer
+    is active (default: `false`)
+  """
+  @type command_spec :: {atom(), String.t(), keyword()}
+
+  @typedoc """
+  Vim modes that extensions can bind keys in.
+
+  Extensions bindable modes are the user-facing editing modes. Internal
+  modes like `:search_prompt`, `:substitute_confirm`, and `:extension_confirm`
+  are framework internals that extensions should not bind into.
+  """
+  @type bindable_mode :: :normal | :insert | :visual | :operator_pending
+
+  @typedoc """
+  A single keybinding specification: `{mode, key_string, command, description, opts}`.
+
+  The mode must be a `bindable_mode` (`:normal`, `:insert`, `:visual`,
+  or `:operator_pending`). The key string uses the same format as
+  `Minga.Keymap.Active.bind/5` (e.g. `"SPC m t"`, `"M-h"`, `"TAB"`).
+  Opts supports `:filetype` for scoping.
+  """
+  @type keybind_spec :: {bindable_mode(), String.t(), atom(), String.t(), keyword()}
+
+  @typedoc "A modeline segment declaration: `{name, opts, {module, function}}`."
+  @type modeline_segment_spec :: {atom(), keyword(), {module(), atom()}}
+
+  @doc """
+  Injects the `Minga.Extension` behaviour, DSL macros (`option/3`,
+  `command/3`, `keybind/4`, `keybind/5`), and a default `child_spec/1`.
+
+  ## The `option` macro
+
+  Declares a typed config option the extension accepts:
+
+      option :conceal, :boolean, default: true
+      option :heading_bullets, :string_list, default: ["◉", "○", "◈", "◇"]
+
+  At compile time, these are accumulated into `__option_schema__/0`,
+  a generated function the framework reads at load time to validate
+  user config and register options in ETS.
+
+  ## The `command` macro
+
+  Declares an editor command the extension provides:
+
+      command :org_cycle_todo, "Cycle TODO keyword",
+        execute: {MingaOrg.Todo, :cycle},
+        requires_buffer: true
+
+  Accumulated into `__command_schema__/0`. The framework registers
+  these in `Minga.Command.Registry` when the extension loads. The
+  execute MFA must be a `{Module, :function}` tuple whose function
+  accepts editor state and returns new state.
+
+  ## The `keybind` macro
+
+  Declares a keybinding the extension provides:
+
+      keybind :normal, "SPC m t", :org_cycle_todo, "Cycle TODO", filetype: :org
+
+  Accumulated into `__keybind_schema__/0`. The framework registers
+  these in `Minga.Keymap.Active` when the extension loads.
+
+  ## Supported option types
+
+  `:boolean`, `:pos_integer`, `:non_neg_integer`, `:integer`, `:string`,
+  `:string_or_nil`, `:string_list`, `:atom`, `{:enum, [atoms]}`,
+  `:map_or_nil`, `:any`.
+  """
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Minga.Extension
+      Module.register_attribute(__MODULE__, :__extension_options__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__extension_commands__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__extension_keybinds__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__extension_modeline_segments__, accumulate: true)
+      @before_compile Minga.Extension
+
+      @doc false
+      @spec child_spec(keyword()) :: Supervisor.child_spec()
+      def child_spec(config) do
+        %{
+          id: __MODULE__,
+          start: {Agent, :start_link, [fn -> config end]},
+          restart: :permanent,
+          type: :worker
+        }
+      end
+
+      defoverridable child_spec: 1
+
+      import Minga.Extension,
+        only: [
+          option: 3,
+          command: 3,
+          keybind: 4,
+          keybind: 5,
+          modeline_segment: 2,
+          modeline_segment: 3
+        ]
+    end
+  end
+
+  @doc """
+  Declares a typed config option for this extension.
+
+  Accumulated at compile time and exposed via `__option_schema__/0`.
+
+  ## Options
+
+  - `:default` (required) — the default value when the user doesn't set it
+  - `:description` (required) — a short human-readable description shown by `SPC h v`
+
+  ## Examples
+
+      option :conceal, :boolean,
+        default: true,
+        description: "Hide markup delimiters and show styled content"
+
+      option :format, {:enum, [:html, :pdf, :md]},
+        default: :html,
+        description: "Default export format"
+
+      option :heading_bullets, :string_list,
+        default: ["◉", "○"],
+        description: "Unicode bullets for heading levels (cycles when depth exceeds list length)"
+  """
+  defmacro option(name, type, opts) do
+    quote do
+      @__extension_options__ {
+        unquote(name),
+        unquote(type),
+        Keyword.fetch!(unquote(opts), :default),
+        Keyword.fetch!(unquote(opts), :description)
+      }
+    end
+  end
+
+  @doc """
+  Declares an editor command this extension provides.
+
+  Accumulated at compile time and exposed via `__command_schema__/0`.
+  The framework auto-registers these commands when the extension loads.
+
+  ## Options
+
+  - `:execute` (required) — `{Module, :function}` MFA tuple. The function
+    receives editor state and returns new state.
+  - `:requires_buffer` — when `true`, command is skipped if no buffer
+    is active (default: `false`)
+
+  ## Examples
+
+      command :org_cycle_todo, "Cycle TODO keyword",
+        execute: {MingaOrg.Todo, :cycle},
+        requires_buffer: true
+
+      command :org_toggle_checkbox, "Toggle checkbox",
+        execute: {MingaOrg.Checkbox, :toggle},
+        requires_buffer: true
+  """
+  defmacro command(name, description, opts) do
+    quote do
+      @__extension_commands__ {unquote(name), unquote(description), unquote(opts)}
+    end
+  end
+
+  @doc """
+  Declares a modeline segment this extension provides.
+
+  The block receives `ctx`, the same context map used by built-in modeline segments, and returns a segment tuple, a list of segment tuples, `nil`, or `[]`.
+
+  ## Examples
+
+      modeline_segment :word_count, side: :right, priority: 50 do
+        if ctx.data.filetype in [:markdown, :text, :org] do
+          {" WORDS ", ctx.info_fg, ctx.bar_bg, [], nil}
+        end
+      end
+  """
+  defmacro modeline_segment(name, opts \\ [], do: block) do
+    fun_name = :"__modeline_segment_#{name}__"
+
+    quote do
+      @__extension_modeline_segments__ {unquote(name), unquote(opts),
+                                        {__MODULE__, unquote(fun_name)}}
+
+      @doc false
+      @spec unquote(fun_name)(map()) :: term()
+      def unquote(fun_name)(var!(ctx)) do
+        unquote(block)
+      end
+    end
+  end
+
+  @doc """
+  Declares a keybinding this extension provides.
+
+  Accumulated at compile time and exposed via `__keybind_schema__/0`.
+  The framework auto-registers these keybindings when the extension loads.
+
+  ## Examples
+
+      keybind :normal, "SPC m t", :org_cycle_todo, "Cycle TODO"
+      keybind :normal, "M-h", :org_promote_heading, "Promote heading", filetype: :org
+  """
+  defmacro keybind(mode, key_string, command_name, description) do
+    quote do
+      @__extension_keybinds__ {unquote(mode), unquote(key_string), unquote(command_name),
+                               unquote(description), []}
+    end
+  end
+
+  @doc false
+  defmacro keybind(mode, key_string, command_name, description, opts) do
+    quote do
+      @__extension_keybinds__ {unquote(mode), unquote(key_string), unquote(command_name),
+                               unquote(description), unquote(opts)}
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    options = Module.get_attribute(env.module, :__extension_options__) || []
+    commands = Module.get_attribute(env.module, :__extension_commands__) || []
+    keybinds = Module.get_attribute(env.module, :__extension_keybinds__) || []
+    modeline_segments = Module.get_attribute(env.module, :__extension_modeline_segments__) || []
+    # Accumulated attributes are in reverse order; restore declaration order
+    options = Enum.reverse(options)
+    commands = Enum.reverse(commands)
+    keybinds = Enum.reverse(keybinds)
+    modeline_segments = Enum.reverse(modeline_segments)
+
+    quote do
+      @doc false
+      @spec __option_schema__() :: [Minga.Extension.option_spec()]
+      def __option_schema__, do: unquote(Macro.escape(options))
+
+      @doc false
+      @spec __command_schema__() :: [Minga.Extension.command_spec()]
+      def __command_schema__, do: unquote(Macro.escape(commands))
+
+      @doc false
+      @spec __keybind_schema__() :: [Minga.Extension.keybind_spec()]
+      def __keybind_schema__, do: unquote(Macro.escape(keybinds))
+
+      @doc false
+      @spec __modeline_segment_schema__() :: [Minga.Extension.modeline_segment_spec()]
+      def __modeline_segment_schema__, do: unquote(Macro.escape(modeline_segments))
+    end
+  end
+end

--- a/sdk/lib/minga/extension/agent_api.ex
+++ b/sdk/lib/minga/extension/agent_api.ex
@@ -27,7 +27,8 @@ defmodule Minga.Extension.AgentAPI do
           cost: float(),
           input_tokens: non_neg_integer(),
           output_tokens: non_neg_integer(),
-          turn_count: non_neg_integer()
+          turn_count: non_neg_integer(),
+          files_touched: [String.t()]
         }
 
   @spec list_sessions() :: [session_summary()]

--- a/sdk/lib/minga/extension/agent_api.ex
+++ b/sdk/lib/minga/extension/agent_api.ex
@@ -1,0 +1,44 @@
+defmodule Minga.Extension.AgentAPI do
+  @moduledoc """
+  Read-only facade for querying agent session state from extensions.
+
+  This is a compile-time stub. At runtime, the real module in Minga's
+  BEAM VM provides the implementation.
+  """
+
+  @type session_summary :: %{
+          id: String.t(),
+          pid: pid(),
+          status: :idle | :plan | :thinking | :tool_executing | :error,
+          label: String.t(),
+          model: String.t(),
+          active_tool: String.t() | nil,
+          created_at: DateTime.t()
+        }
+
+  @type session_info :: %{
+          id: String.t(),
+          pid: pid(),
+          status: :idle | :plan | :thinking | :tool_executing | :error,
+          label: String.t(),
+          model: String.t(),
+          active_tool: String.t() | nil,
+          created_at: DateTime.t(),
+          cost: float(),
+          input_tokens: non_neg_integer(),
+          output_tokens: non_neg_integer(),
+          turn_count: non_neg_integer()
+        }
+
+  @spec list_sessions() :: [session_summary()]
+  def list_sessions, do: raise("minga_sdk is compile-time only")
+
+  @spec session_info(pid()) :: {:ok, session_info()} | {:error, :not_found}
+  def session_info(_pid), do: raise("minga_sdk is compile-time only")
+
+  @spec subscribe() :: :ok
+  def subscribe, do: raise("minga_sdk is compile-time only")
+
+  @spec subscribe_edits() :: :ok
+  def subscribe_edits, do: raise("minga_sdk is compile-time only")
+end

--- a/sdk/lib/minga/extension/overlay.ex
+++ b/sdk/lib/minga/extension/overlay.ex
@@ -1,0 +1,51 @@
+defmodule Minga.Extension.Overlay do
+  @moduledoc """
+  Registry for extension-owned overlays on the editor surface.
+
+  Extensions register overlays anchored to buffer positions. The editor
+  reads this registry during rendering and displays the overlays on the
+  appropriate frontend surface.
+
+  This is a compile-time stub. At runtime, the real module in Minga's
+  BEAM VM provides the implementation.
+  """
+
+  @type shape :: :cursor | :cursor_with_label | :label | :indicator
+
+  @type style :: %{
+          optional(:fg) => non_neg_integer(),
+          optional(:opacity) => 0..255
+        }
+
+  @type entry :: %{
+          extension: atom(),
+          overlay_id: term(),
+          buffer: pid(),
+          position: {non_neg_integer(), non_neg_integer()},
+          content: String.t(),
+          style: style(),
+          shape: shape()
+        }
+
+  @spec set(atom(), term(), pid(), keyword()) :: :ok
+  def set(_extension_name, _overlay_id, _buffer_pid, _opts),
+    do: raise("minga_sdk is compile-time only")
+
+  @spec remove(atom(), term()) :: :ok
+  def remove(_extension_name, _overlay_id),
+    do: raise("minga_sdk is compile-time only")
+
+  @spec remove_all(atom()) :: :ok
+  def remove_all(_extension_name),
+    do: raise("minga_sdk is compile-time only")
+
+  @spec for_buffer(pid()) :: [entry()]
+  def for_buffer(_buffer_pid),
+    do: raise("minga_sdk is compile-time only")
+
+  @spec all() :: [entry()]
+  def all, do: raise("minga_sdk is compile-time only")
+
+  @spec empty?() :: boolean()
+  def empty?, do: raise("minga_sdk is compile-time only")
+end

--- a/sdk/lib/minga_editor/extension/editor_api.ex
+++ b/sdk/lib/minga_editor/extension/editor_api.ex
@@ -1,0 +1,25 @@
+defmodule MingaEditor.Extension.EditorAPI do
+  @moduledoc """
+  High-level editor actions for extensions.
+
+  Extensions call these functions from command callbacks to trigger
+  common editor operations without reaching into EditorState internals.
+
+  This is a compile-time stub. At runtime, the real module in Minga's
+  BEAM VM provides the implementation.
+  """
+
+  @type state :: term()
+
+  @spec open_file(state(), String.t()) :: state()
+  def open_file(_state, _path), do: raise("minga_sdk is compile-time only")
+
+  @spec focus_buffer(state(), pid()) :: state()
+  def focus_buffer(_state, _buffer_pid), do: raise("minga_sdk is compile-time only")
+
+  @spec navigate_to(state(), String.t(), non_neg_integer(), non_neg_integer()) :: state()
+  def navigate_to(_state, _path, _line, _col \\ 0), do: raise("minga_sdk is compile-time only")
+
+  @spec set_status(state(), String.t()) :: state()
+  def set_status(_state, _message), do: raise("minga_sdk is compile-time only")
+end

--- a/sdk/mix.exs
+++ b/sdk/mix.exs
@@ -32,7 +32,7 @@ defmodule MingaSdk.MixProject do
     [
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
-      files: ["lib", "mix.exs", "README.md", "LICENSE"]
+      files: ["lib", "mix.exs", "README.md"]
     ]
   end
 

--- a/sdk/mix.exs
+++ b/sdk/mix.exs
@@ -1,0 +1,45 @@
+defmodule MingaSdk.MixProject do
+  use Mix.Project
+
+  @version "0.1.0"
+  @source_url "https://github.com/jsmestad/minga"
+
+  def project do
+    [
+      app: :minga_sdk,
+      version: @version,
+      elixir: "~> 1.17",
+      start_permanent: false,
+      deps: deps(),
+      description: "Compile-time SDK for building Minga editor extensions",
+      package: package(),
+      source_url: @source_url,
+      docs: docs()
+    ]
+  end
+
+  def application do
+    [extra_applications: []]
+  end
+
+  defp deps do
+    [
+      {:ex_doc, "~> 0.34", only: :dev, runtime: false}
+    ]
+  end
+
+  defp package do
+    [
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url},
+      files: ["lib", "mix.exs", "README.md", "LICENSE"]
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      extras: ["README.md"]
+    ]
+  end
+end

--- a/sdk/test/minga_sdk_test.exs
+++ b/sdk/test/minga_sdk_test.exs
@@ -1,0 +1,98 @@
+defmodule MingaSdkTest do
+  use ExUnit.Case, async: true
+
+  describe "Minga.Extension behaviour" do
+    test "use Minga.Extension compiles and generates schema functions" do
+      defmodule TestExtension do
+        use Minga.Extension
+
+        option(:enabled, :boolean, default: true, description: "Enable")
+        command(:test_cmd, "Test command", execute: {__MODULE__, :noop})
+        keybind(:normal, "SPC m t", :test_cmd, "Test")
+
+        @impl true
+        def name, do: :test_ext
+
+        @impl true
+        def description, do: "Test extension"
+
+        @impl true
+        def version, do: "0.1.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+
+        def noop(state), do: state
+      end
+
+      assert TestExtension.name() == :test_ext
+      assert [opt] = TestExtension.__option_schema__()
+      assert elem(opt, 0) == :enabled
+      assert [cmd] = TestExtension.__command_schema__()
+      assert elem(cmd, 0) == :test_cmd
+      assert [kb] = TestExtension.__keybind_schema__()
+      assert elem(kb, 2) == :test_cmd
+    end
+  end
+
+  describe "API module types compile" do
+    test "Overlay types are accessible" do
+      assert is_atom(Minga.Extension.Overlay)
+    end
+
+    test "AgentAPI types are accessible" do
+      assert is_atom(Minga.Extension.AgentAPI)
+    end
+
+    test "EditorAPI types are accessible" do
+      assert is_atom(MingaEditor.Extension.EditorAPI)
+    end
+
+    test "Events types are accessible" do
+      assert is_atom(Minga.Events)
+      assert %Minga.Events.BufferChangedEvent{buffer: nil, source: nil, delta: nil, version: nil}
+    end
+
+    test "Buffer types are accessible" do
+      assert is_atom(Minga.Buffer)
+    end
+
+    test "EditSource type is accessible" do
+      assert is_atom(Minga.Buffer.EditSource)
+    end
+
+    test "EditDelta struct is accessible" do
+      delta = %Minga.Buffer.EditDelta{
+        start_byte: 0,
+        old_end_byte: 5,
+        new_end_byte: 10,
+        start_position: {0, 0},
+        old_end_position: {0, 5},
+        new_end_position: {0, 10},
+        inserted_text: "hello"
+      }
+
+      assert delta.new_end_position == {0, 10}
+    end
+  end
+
+  describe "runtime stubs raise" do
+    test "Overlay.set/4 raises at runtime" do
+      assert_raise RuntimeError, ~r/compile-time only/, fn ->
+        Minga.Extension.Overlay.set(:test, "id", self(), position: {0, 0})
+      end
+    end
+
+    test "AgentAPI.list_sessions/0 raises at runtime" do
+      assert_raise RuntimeError, ~r/compile-time only/, fn ->
+        Minga.Extension.AgentAPI.list_sessions()
+      end
+    end
+
+    test "EditorAPI.set_status/2 raises at runtime" do
+      assert_raise RuntimeError, ~r/compile-time only/, fn ->
+        MingaEditor.Extension.EditorAPI.set_status(%{}, "test")
+      end
+    end
+  end
+end

--- a/sdk/test/minga_sdk_test.exs
+++ b/sdk/test/minga_sdk_test.exs
@@ -50,7 +50,7 @@ defmodule MingaSdkTest do
 
     test "Events types are accessible" do
       assert is_atom(Minga.Events)
-      assert %Minga.Events.BufferChangedEvent{buffer: nil, source: nil, delta: nil, version: nil}
+      assert %Minga.Events.BufferChangedEvent{buffer: self(), source: :user, delta: nil, version: nil}
     end
 
     test "Buffer types are accessible" do

--- a/sdk/test/test_helper.exs
+++ b/sdk/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary

- Adds `sdk/` at the repo root, a standalone mix project providing the compile-time API surface for Minga extension development
- Extension authors add `{:minga_sdk, "~> 0.1", only: [:dev, :test], runtime: false}` instead of needing a local clone of the full editor
- Replaces the `{:minga, path: "../minga"}` pattern used by `minga-org`
- Lives in-repo (not a separate repo) so API changes in the core and SDK stay in sync in the same commit, eliminating sync-drift

**Included modules:**
- `Minga.Extension` (real source, needed for `use` macro and `@before_compile`)
- `Minga.Extension.Overlay` (typed stub)
- `Minga.Extension.AgentAPI` (typed stub)
- `MingaEditor.Extension.EditorAPI` (typed stub)
- `Minga.Events` + event payload structs (typed stubs)
- `Minga.Buffer` + `EditSource` + `EditDelta` (typed stubs)

Stubs include full `@spec` and `@type` definitions for dialyzer/IDE support but raise at runtime (the dep is `runtime: false`).

## Test plan

- [x] `cd sdk && mix test` (11 tests pass)
- [x] `use Minga.Extension` macro compiles and generates `__option_schema__/0`, `__command_schema__/0`, `__keybind_schema__/0`
- [x] All type modules compile standalone (no Minga app dependency)
- [x] Stubs raise with clear message at runtime
- [x] Main Minga project still compiles with `sdk/` present (not picked up by Minga's compiler)

Closes #1913

🤖 Generated with [Claude Code](https://claude.com/claude-code)