### PR TITLE
feat(installer): mix minga.new extension project generator

### DIFF
--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,0 +1,2 @@
+/_build/
+/deps/

--- a/installer/lib/mix/tasks/minga.new.ex
+++ b/installer/lib/mix/tasks/minga.new.ex
@@ -1,0 +1,105 @@
+defmodule Mix.Tasks.Minga.New do
+  @moduledoc """
+  Creates a new Minga editor extension project.
+
+      mix minga.new my_extension
+
+  This generates a complete, compilable extension project with the
+  right directory structure, SDK dependency, and `use Minga.Extension`
+  boilerplate.
+
+  ## Options
+
+    * `--path` - the directory to create the project in (defaults to the extension name)
+  """
+
+  use Mix.Task
+
+  @version "0.1.0"
+
+  @shortdoc "Creates a new Minga editor extension project"
+
+  @switches [path: :string]
+
+  @impl true
+  def run(argv) do
+    case OptionParser.parse!(argv, strict: @switches) do
+      {opts, [name]} ->
+        generate(name, opts)
+
+      {_opts, []} ->
+        Mix.raise("Expected extension name. Usage: mix minga.new my_extension")
+
+      {_opts, _} ->
+        Mix.raise("Expected a single extension name. Usage: mix minga.new my_extension")
+    end
+  end
+
+  defp generate(name, opts) do
+    module = Macro.camelize(name)
+    path = Keyword.get(opts, :path, name)
+    binding = [name: name, module: module, version: @version]
+
+    if File.exists?(path) do
+      Mix.raise("Directory #{path} already exists")
+    end
+
+    Mix.shell().info("Creating Minga extension #{name}...")
+
+    File.mkdir_p!(path)
+    File.mkdir_p!(Path.join(path, "lib/#{name}"))
+    File.mkdir_p!(Path.join(path, "test"))
+
+    templates = [
+      {"mix.exs.eex", "mix.exs"},
+      {"extension.ex.eex", "lib/#{name}.ex"},
+      {"commands.ex.eex", "lib/#{name}/commands.ex"},
+      {"extension_test.exs.eex", "test/#{name}_test.exs"},
+      {"test_helper.exs.eex", "test/test_helper.exs"},
+      {"formatter.exs.eex", ".formatter.exs"},
+      {"gitignore.eex", ".gitignore"}
+    ]
+
+    for {template, dest} <- templates do
+      content = render_template(template, binding)
+      dest_path = Path.join(path, dest)
+      File.write!(dest_path, content)
+      Mix.shell().info("  * creating #{dest}")
+    end
+
+    Mix.shell().info("""
+
+    Your Minga extension is ready! Next steps:
+
+        cd #{path}
+        mix deps.get
+        mix test
+
+    To install in Minga, add to your config:
+
+        extension :#{name},
+          path: "#{Path.expand(path)}"
+
+    """)
+  end
+
+  defp render_template(name, binding) do
+    path = Path.join(template_dir(), name)
+    EEx.eval_file(path, binding)
+  end
+
+  defp template_dir do
+    case Application.app_dir(:minga_new, "templates") do
+      path when is_binary(path) ->
+        if File.dir?(path), do: path, else: source_template_dir()
+    end
+  rescue
+    _ -> source_template_dir()
+  end
+
+  defp source_template_dir do
+    __DIR__
+    |> Path.join("../../../templates")
+    |> Path.expand()
+  end
+end

--- a/installer/lib/mix/tasks/minga.new.ex
+++ b/installer/lib/mix/tasks/minga.new.ex
@@ -36,6 +36,12 @@ defmodule Mix.Tasks.Minga.New do
   end
 
   defp generate(name, opts) do
+    unless name =~ ~r/^[a-z][a-z0-9_]*$/ do
+      Mix.raise(
+        "Extension name must start with a lowercase letter and contain only lowercase letters, digits, and underscores. Got: #{name}"
+      )
+    end
+
     module = Macro.camelize(name)
     path = Keyword.get(opts, :path, name)
     binding = [name: name, module: module, version: @version]

--- a/installer/mix.exs
+++ b/installer/mix.exs
@@ -1,0 +1,35 @@
+defmodule MingaNew.MixProject do
+  use Mix.Project
+
+  @version "0.1.0"
+  @source_url "https://github.com/jsmestad/minga"
+
+  def project do
+    [
+      app: :minga_new,
+      version: @version,
+      elixir: "~> 1.17",
+      start_permanent: false,
+      deps: deps(),
+      description: "Mix task for generating Minga editor extension projects",
+      package: package(),
+      source_url: @source_url
+    ]
+  end
+
+  def application do
+    [extra_applications: []]
+  end
+
+  defp deps do
+    []
+  end
+
+  defp package do
+    [
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url},
+      files: ["lib", "templates", "mix.exs", "README.md"]
+    ]
+  end
+end

--- a/installer/templates/commands.ex.eex
+++ b/installer/templates/commands.ex.eex
@@ -1,0 +1,13 @@
+defmodule <%= module %>.Commands do
+  @moduledoc """
+  Command implementations for <%= module %>.
+
+  Each function receives the editor state and returns the modified state.
+  Register commands in the main extension module with the `command` macro.
+  """
+
+  @spec hello(term()) :: term()
+  def hello(state) do
+    MingaEditor.Extension.EditorAPI.set_status(state, "Hello from <%= module %>!")
+  end
+end

--- a/installer/templates/extension.ex.eex
+++ b/installer/templates/extension.ex.eex
@@ -7,7 +7,7 @@ defmodule <%= module %> do
 
   # ── Config options ──────────────────────────────────────────────────
   # Declare typed options users can set in their Minga config.
-  # Read at runtime with: Minga.Config.Options.get_extension_option(:<%= name %>, :enabled)
+  # Read at runtime with: Minga.Config.get_extension_option(:<%= name %>, :enabled)
 
   option :enabled, :boolean, default: true, description: "Enable <%= module %>"
 

--- a/installer/templates/extension.ex.eex
+++ b/installer/templates/extension.ex.eex
@@ -1,0 +1,64 @@
+defmodule <%= module %> do
+  @moduledoc """
+  <%= module %> extension for the Minga editor.
+  """
+
+  use Minga.Extension
+
+  # ── Config options ──────────────────────────────────────────────────
+  # Declare typed options users can set in their Minga config.
+  # Read at runtime with: Minga.Config.Options.get_extension_option(:<%= name %>, :enabled)
+
+  option :enabled, :boolean, default: true, description: "Enable <%= module %>"
+
+  # ── Commands ────────────────────────────────────────────────────────
+  # Commands appear in the command palette and can be bound to keys.
+
+  command :hello, "Say hello from <%= module %>",
+    execute: {<%= module %>.Commands, :hello}
+
+  # ── Keybindings ─────────────────────────────────────────────────────
+  # Bind commands to key sequences. Supports :normal, :insert, :visual modes.
+  # Use filetype: :elixir (etc.) to scope bindings to specific filetypes.
+
+  keybind :normal, "SPC m h", :hello, "Hello from <%= module %>"
+
+  # ── Extension callbacks ─────────────────────────────────────────────
+
+  @impl true
+  def name, do: :<%= name %>
+
+  @impl true
+  def description, do: "<%= module %> extension"
+
+  @impl true
+  def version, do: "0.1.0"
+
+  @impl true
+  def init(_config), do: {:ok, %{}}
+
+  # ── Rendering APIs (uncomment to use) ───────────────────────────────
+  #
+  # Overlays (positioned content on the editor surface):
+  #   Minga.Extension.Overlay.set(:<%= name %>, "cursor_1", buffer_pid,
+  #     position: {10, 5}, content: "label", shape: :cursor_with_label,
+  #     style: %{fg: 0x7C3AED, opacity: 102})
+  #
+  # Panels (structured content in a panel region):
+  #   Minga.Extension.Panel.set(:<%= name %>, "main", %{
+  #     title: "My Panel", position: :bottom, visible: true,
+  #     content: [{:text, "Hello"}, {:separator}, {:key_value, [{"Key", "Value"}]}]
+  #   })
+  #
+  # Badges (file tree and tab indicators):
+  #   Minga.Extension.Badge.set_file(:<%= name %>, "/path/to/file.ex",
+  #     color: 0x51AFEF, animation: :pulse)
+  #
+  # Agent session queries:
+  #   sessions = Minga.Extension.AgentAPI.list_sessions()
+  #   {:ok, info} = Minga.Extension.AgentAPI.session_info(pid)
+  #
+  # Editor actions (from command callbacks):
+  #   MingaEditor.Extension.EditorAPI.open_file(state, "/path/to/file.ex")
+  #   MingaEditor.Extension.EditorAPI.set_status(state, "Done!")
+end

--- a/installer/templates/extension_test.exs.eex
+++ b/installer/templates/extension_test.exs.eex
@@ -1,0 +1,16 @@
+defmodule <%= module %>Test do
+  use ExUnit.Case, async: true
+
+  test "extension module compiles and exports schemas" do
+    assert <%= module %>.name() == :<%= name %>
+    assert is_binary(<%= module %>.description())
+    assert is_binary(<%= module %>.version())
+    assert is_list(<%= module %>.__option_schema__())
+    assert is_list(<%= module %>.__command_schema__())
+    assert is_list(<%= module %>.__keybind_schema__())
+  end
+
+  test "init returns {:ok, state}" do
+    assert {:ok, _state} = <%= module %>.init([])
+  end
+end

--- a/installer/templates/formatter.exs.eex
+++ b/installer/templates/formatter.exs.eex
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/installer/templates/gitignore.eex
+++ b/installer/templates/gitignore.eex
@@ -1,0 +1,5 @@
+/_build/
+/deps/
+/doc/
+*.beam
+mix.lock

--- a/installer/templates/mix.exs.eex
+++ b/installer/templates/mix.exs.eex
@@ -1,0 +1,28 @@
+defmodule <%= module %>.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :<%= name %>,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: false,
+      deps: deps(),
+      description: "<%= module %> extension for the Minga editor"
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:minga_sdk, github: "jsmestad/minga", sparse: "sdk/", only: [:dev, :test], runtime: false}
+    ]
+  end
+end

--- a/installer/templates/test_helper.exs.eex
+++ b/installer/templates/test_helper.exs.eex
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/installer/test/minga_new_test.exs
+++ b/installer/test/minga_new_test.exs
@@ -1,0 +1,50 @@
+defmodule MingaNewTest do
+  use ExUnit.Case, async: true
+
+  @tmp_dir System.tmp_dir!()
+
+  setup do
+    test_dir = Path.join(@tmp_dir, "minga_new_test_#{System.unique_integer([:positive])}")
+    on_exit(fn -> File.rm_rf!(test_dir) end)
+    {:ok, dir: test_dir}
+  end
+
+  test "generates a valid extension project", %{dir: dir} do
+    name = "test_extension"
+    path = Path.join(dir, name)
+
+    Mix.Tasks.Minga.New.run([name, "--path", path])
+
+    assert File.exists?(Path.join(path, "mix.exs"))
+    assert File.exists?(Path.join(path, "lib/test_extension.ex"))
+    assert File.exists?(Path.join(path, "lib/test_extension/commands.ex"))
+    assert File.exists?(Path.join(path, "test/test_extension_test.exs"))
+    assert File.exists?(Path.join(path, "test/test_helper.exs"))
+    assert File.exists?(Path.join(path, ".formatter.exs"))
+    assert File.exists?(Path.join(path, ".gitignore"))
+
+    mix_content = File.read!(Path.join(path, "mix.exs"))
+    assert mix_content =~ "minga_sdk"
+    assert mix_content =~ ":test_extension"
+
+    ext_content = File.read!(Path.join(path, "lib/test_extension.ex"))
+    assert ext_content =~ "use Minga.Extension"
+    assert ext_content =~ "TestExtension"
+    assert ext_content =~ ":test_extension"
+  end
+
+  test "raises on existing directory", %{dir: dir} do
+    path = Path.join(dir, "existing")
+    File.mkdir_p!(path)
+
+    assert_raise Mix.Error, ~r/already exists/, fn ->
+      Mix.Tasks.Minga.New.run(["existing", "--path", path])
+    end
+  end
+
+  test "raises without a name" do
+    assert_raise Mix.Error, ~r/Expected extension name/, fn ->
+      Mix.Tasks.Minga.New.run([])
+    end
+  end
+end

--- a/installer/test/test_helper.exs
+++ b/installer/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary

- Adds `installer/` at the repo root (like Phoenix's `installer/`), a mix archive project providing `mix minga.new my_extension`
- Generates a complete, compilable extension project with SDK dependency, `use Minga.Extension` boilerplate, commands module, tests, and commented examples of all rendering APIs
- Generated projects compile and pass tests immediately after `mix deps.get && mix test`
- Part of the Extension Rendering API epic (#1905)

## Generated project structure

```
my_extension/
  mix.exs              # {:minga_sdk, github: "jsmestad/minga", sparse: "sdk/"}
  lib/my_extension.ex  # use Minga.Extension, callbacks, commands, keybindings
  lib/my_extension/commands.ex  # Command implementations using EditorAPI
  test/                # Compilation and schema tests
  .formatter.exs, .gitignore
```

## Test plan

- [x] `cd installer && mix test` (3 tests pass)
- [x] Generated project contains all expected files with correct module names
- [x] Raises on existing directory
- [x] Raises without extension name
- [x] Main Minga project still compiles with installer/ present

Closes #1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)