### PR TITLE
refactor(test): replace :sys.get_state field assertions with public query APIs

### DIFF
--- a/lib/minga/config/writer.ex
+++ b/lib/minga/config/writer.ex
@@ -55,6 +55,12 @@ defmodule Minga.Config.Writer do
     :exit, _ -> :ok
   end
 
+  @doc "Returns true when a debounce timer is scheduled for a pending flush."
+  @spec pending?(GenServer.server()) :: boolean()
+  def pending?(server \\ __MODULE__) do
+    GenServer.call(server, :pending?)
+  end
+
   @doc "Flushes pending writes immediately. Intended for tests and clean shutdown paths."
   @spec flush() :: :ok
   @spec flush(GenServer.server()) :: :ok
@@ -93,6 +99,10 @@ defmodule Minga.Config.Writer do
 
   def handle_call({:set_reloading, reloading?}, _from, state) do
     {:reply, :ok, set_reloading_state(state, reloading?)}
+  end
+
+  def handle_call(:pending?, _from, state) do
+    {:reply, state.timer != nil, state}
   end
 
   def handle_call(:flush, _from, state) do

--- a/lib/minga/debug_log.ex
+++ b/lib/minga/debug_log.ex
@@ -148,6 +148,12 @@ defmodule Minga.DebugLog do
   @spec path(GenServer.server()) :: path()
   def path(server), do: GenServer.call(server, :path)
 
+  @doc "Returns the current unflushed buffer contents as a binary."
+  @spec buffered_content(GenServer.server()) :: binary()
+  def buffered_content(server) do
+    GenServer.call(server, :buffered_content)
+  end
+
   @impl true
   @spec init({path(), keyword()}) :: {:ok, t()} | {:stop, term()}
   def init({path, opts}) do
@@ -169,8 +175,9 @@ defmodule Minga.DebugLog do
   end
 
   @impl true
-  @spec handle_call(:flush | :path, GenServer.from(), t()) ::
-          {:reply, :ok | {:error, term()} | path(), t()} | {:stop, term(), {:error, term()}, t()}
+  @spec handle_call(:flush | :path | :buffered_content, GenServer.from(), t()) ::
+          {:reply, :ok | {:error, term()} | path() | binary(), t()}
+          | {:stop, term(), {:error, term()}, t()}
   def handle_call(:flush, _from, state) do
     case flush_buffer(state) do
       {:ok, state} ->
@@ -182,6 +189,10 @@ defmodule Minga.DebugLog do
   end
 
   def handle_call(:path, _from, state), do: {:reply, state.path, state}
+
+  def handle_call(:buffered_content, _from, state) do
+    {:reply, IO.iodata_to_binary(state.buffer), state}
+  end
 
   @impl true
   @spec handle_info(term(), t()) :: {:noreply, t()} | {:stop, term(), t()}

--- a/lib/minga/distribution/connection_manager.ex
+++ b/lib/minga/distribution/connection_manager.ex
@@ -68,6 +68,12 @@ defmodule Minga.Distribution.ConnectionManager do
     call_or_default({:connected?, server_name}, false)
   end
 
+  @doc "Returns the retry timer reference for a server, or nil if no retry is scheduled."
+  @spec retry_timer(GenServer.server(), String.t()) :: reference() | nil
+  def retry_timer(server, server_name) when is_binary(server_name) do
+    GenServer.call(server, {:retry_timer, server_name})
+  end
+
   @doc "Returns the retry delay for `retry_count`, starting at 1s and doubling until the 30s cap. Clamps once the doubled value would exceed 30s."
   @spec backoff_ms(non_neg_integer()) :: pos_integer()
   def backoff_ms(retry_count) when is_integer(retry_count) and retry_count >= 5, do: 30_000
@@ -113,6 +119,16 @@ defmodule Minga.Distribution.ConnectionManager do
 
   def handle_call({:server_name_for_node, node}, _from, state) do
     {:reply, server_name_for_node_result(state, node), state}
+  end
+
+  def handle_call({:retry_timer, server_name}, _from, state) do
+    timer =
+      case Map.fetch(state.servers, server_name) do
+        {:ok, server} -> server.retry_timer
+        :error -> nil
+      end
+
+    {:reply, timer, state}
   end
 
   def handle_call({:connected?, server_name}, _from, state) do

--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -207,6 +207,18 @@ defmodule Minga.Project do
     GenServer.call(server, :command_frecency_scores)
   end
 
+  @doc "Returns true while a background file-cache rebuild is in progress."
+  @spec rebuilding?(GenServer.server()) :: boolean()
+  def rebuilding?(server \\ __MODULE__) do
+    GenServer.call(server, :rebuilding?)
+  end
+
+  @doc "Returns the raw command frecency map (command name => timestamp list)."
+  @spec command_frecency(GenServer.server()) :: command_frecency_map()
+  def command_frecency(server \\ __MODULE__) do
+    GenServer.call(server, :command_frecency)
+  end
+
   @doc "Scores a file's access timestamps using frecency decay buckets."
   @spec score_accesses([non_neg_integer()], non_neg_integer()) :: non_neg_integer()
   def score_accesses(timestamps, now_unix) when is_list(timestamps) and is_integer(now_unix) do
@@ -281,6 +293,14 @@ defmodule Minga.Project do
       end)
 
     {:reply, scores, state}
+  end
+
+  def handle_call(:rebuilding?, _from, state) do
+    {:reply, state.rebuilding?, state}
+  end
+
+  def handle_call(:command_frecency, _from, state) do
+    {:reply, state.command_frecency, state}
   end
 
   def handle_call(:command_frecency_scores, _from, state) do

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -262,6 +262,36 @@ defmodule MingaAgent.Providers.Native do
     GenServer.call(pid, {:refresh_project_view, project_view})
   end
 
+  @doc "Returns the current tool list registered with this provider."
+  @spec tools(GenServer.server()) :: [ReqLLM.Tool.t()]
+  def tools(pid) do
+    GenServer.call(pid, :tools)
+  end
+
+  @doc "Returns the PID of the fork store, or nil if not active."
+  @spec fork_store(GenServer.server()) :: pid() | nil
+  def fork_store(pid) do
+    GenServer.call(pid, :fork_store)
+  end
+
+  @doc "Returns the agent hooks from the provider's config."
+  @spec agent_hooks(GenServer.server()) :: [MingaAgent.Hooks.Hook.t()]
+  def agent_hooks(pid) do
+    GenServer.call(pid, :agent_hooks)
+  end
+
+  @doc "Returns the project view associated with this provider, or nil."
+  @spec project_view(GenServer.server()) :: ProjectView.t() | nil
+  def project_view(pid) do
+    GenServer.call(pid, :project_view)
+  end
+
+  @doc "Returns the changeset PID, or nil."
+  @spec changeset(GenServer.server()) :: pid() | nil
+  def changeset(pid) do
+    GenServer.call(pid, :changeset)
+  end
+
   # ── GenServer callbacks ─────────────────────────────────────────────────────
 
   @impl GenServer
@@ -582,6 +612,26 @@ defmodule MingaAgent.Providers.Native do
     Minga.Log.info(:agent, "[Agent.Native] new session started")
 
     {:reply, :ok, state}
+  end
+
+  def handle_call(:tools, _from, state) do
+    {:reply, state.tools, state}
+  end
+
+  def handle_call(:fork_store, _from, state) do
+    {:reply, state.fork_store, state}
+  end
+
+  def handle_call(:agent_hooks, _from, state) do
+    {:reply, state.config.agent_hooks, state}
+  end
+
+  def handle_call(:project_view, _from, state) do
+    {:reply, state.project_view, state}
+  end
+
+  def handle_call(:changeset, _from, state) do
+    {:reply, state.changeset, state}
   end
 
   def handle_call(:get_state, _from, state) do

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -515,6 +515,18 @@ defmodule MingaAgent.Session do
     GenServer.call(session, :get_provider)
   end
 
+  @doc "Returns whether this session persists its conversation to disk."
+  @spec persist?(GenServer.server()) :: boolean()
+  def persist?(session) do
+    GenServer.call(session, :persist?)
+  end
+
+  @doc "Returns whether hooks are enabled for this session."
+  @spec hooks_enabled?(GenServer.server()) :: boolean()
+  def hooks_enabled?(session) do
+    GenServer.call(session, :hooks_enabled?)
+  end
+
   # ── GenServer callbacks ─────────────────────────────────────────────────────
 
   @impl GenServer
@@ -852,6 +864,14 @@ defmodule MingaAgent.Session do
 
   def handle_call(:get_provider, _from, state) do
     {:reply, state.provider, state}
+  end
+
+  def handle_call(:persist?, _from, state) do
+    {:reply, state.persist?, state}
+  end
+
+  def handle_call(:hooks_enabled?, _from, state) do
+    {:reply, state.hooks_enabled?, state}
   end
 
   def handle_call(:editor_snapshot, _from, state) do

--- a/lib/minga_editor/renderer/server.ex
+++ b/lib/minga_editor/renderer/server.ex
@@ -107,6 +107,12 @@ defmodule MingaEditor.Renderer.Server do
     GenServer.cast(server, {:render, snapshot, frame_seq, monotonic_now()})
   end
 
+  @doc "Returns true while a render pass is in progress."
+  @spec rendering?(GenServer.server()) :: boolean()
+  def rendering?(server \\ __MODULE__) do
+    GenServer.call(server, :rendering?)
+  end
+
   # ── GenServer callbacks ───────────────────────────────────────────────────
 
   @impl true
@@ -115,6 +121,11 @@ defmodule MingaEditor.Renderer.Server do
     editor_pid = Keyword.get(opts, :editor_pid, MingaEditor)
     pipeline = Keyword.get(opts, :pipeline, &RenderPipeline.run/1)
     {:ok, %__MODULE__{editor_pid: editor_pid, pipeline: pipeline}}
+  end
+
+  @impl true
+  def handle_call(:rendering?, _from, state) do
+    {:reply, state.rendering?, state}
   end
 
   @impl true

--- a/test/minga/config/writer_test.exs
+++ b/test/minga/config/writer_test.exs
@@ -84,8 +84,7 @@ defmodule Minga.Config.WriterTest do
       refute File.exists?(path)
 
       assert :ok = Writer.set_reloading(writer, false)
-      state = :sys.get_state(writer)
-      assert state.timer != nil
+      assert Writer.pending?(writer)
 
       send(writer, :flush)
       :sys.get_state(writer)

--- a/test/minga/debug_log_test.exs
+++ b/test/minga/debug_log_test.exs
@@ -179,8 +179,7 @@ defmodule Minga.DebugLogTest do
     Events.broadcast(:log_message, %LogMessageEvent{text: first, level: :info})
     Events.broadcast(:log_message, %LogMessageEvent{text: second, level: :info})
 
-    %{buffer: buffer} = :sys.get_state(pid)
-    buffered = IO.iodata_to_binary(buffer)
+    buffered = DebugLog.buffered_content(pid)
 
     assert buffered =~ first
     assert buffered =~ second

--- a/test/minga/distribution/connection_manager_test.exs
+++ b/test/minga/distribution/connection_manager_test.exs
@@ -118,12 +118,7 @@ defmodule Minga.Distribution.ConnectionManagerTest do
     name
   end
 
-  @spec retry_timer(pid(), String.t()) :: reference() | nil
   defp retry_timer(pid, server_name) do
-    pid
-    |> :sys.get_state()
-    |> Map.fetch!(:servers)
-    |> Map.fetch!(server_name)
-    |> Map.fetch!(:retry_timer)
+    ConnectionManager.retry_timer(pid, server_name)
   end
 end

--- a/test/minga/project_test.exs
+++ b/test/minga/project_test.exs
@@ -32,19 +32,16 @@ defmodule Minga.ProjectTest do
   # events from concurrent tests (async: true).
   defp await_rebuild(name) do
     Minga.Events.subscribe(:project_rebuilt)
-    state = :sys.get_state(name)
 
-    if state.rebuilding? do
-      root = state.current_root
+    if Project.rebuilding?(name) do
+      root = Project.root(name)
 
       assert_receive {:minga_event, :project_rebuilt,
                       %Minga.Events.ProjectRebuiltEvent{root: ^root}},
                      5_000
-
-      :sys.get_state(name)
-    else
-      state
     end
+
+    _ = :sys.get_state(name)
   end
 
   describe "resolve_root/0" do

--- a/test/minga_agent/providers/native_read_only_test.exs
+++ b/test/minga_agent/providers/native_read_only_test.exs
@@ -23,8 +23,7 @@ defmodule MingaAgent.Providers.NativeReadOnlyTest do
         id: {:native_read_only, make_ref()}
       )
 
-    %{tools: tools} = :sys.get_state(provider)
-    names = Enum.map(tools, & &1.name)
+    names = provider |> Native.tools() |> Enum.map(& &1.name)
 
     assert names == ["read_file"]
     refute "write_file" in names
@@ -47,7 +46,7 @@ defmodule MingaAgent.Providers.NativeReadOnlyTest do
         id: {:native_read_only_allowlist, make_ref()}
       )
 
-    assert %{tools: []} = :sys.get_state(provider)
+    assert Native.tools(provider) == []
   end
 
   test "read_only provider clears configured hooks" do
@@ -68,7 +67,7 @@ defmodule MingaAgent.Providers.NativeReadOnlyTest do
         id: {:native_read_only_hooks, make_ref()}
       )
 
-    assert %{config: %{agent_hooks: []}} = :sys.get_state(provider)
+    assert Native.agent_hooks(provider) == []
   end
 
   defp tool(name) do

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -179,10 +179,9 @@ defmodule MingaAgent.Providers.NativeTest do
       {:ok, buffer} = start_supervised({BufferProcess, content: "original\n", file_path: path})
       {:ok, pid} = start_provider(tmp_dir: dir, tools: nil)
 
-      state = :sys.get_state(pid)
-      fork_store = state.fork_store
+      fork_store = Native.fork_store(pid)
       assert is_pid(fork_store)
-      write_tool = Enum.find(state.tools, &(&1.name == "write_file"))
+      write_tool = pid |> Native.tools() |> Enum.find(&(&1.name == "write_file"))
 
       assert {:ok, result} =
                write_tool.callback.(%{"path" => "lib/tool_rebuild.ex", "content" => "forked\n"})
@@ -195,9 +194,8 @@ defmodule MingaAgent.Providers.NativeTest do
       Process.exit(fork_store, :kill)
       assert_receive {:DOWN, ^ref, :process, ^fork_store, _reason}
 
-      rebuilt_state = :sys.get_state(pid)
-      assert rebuilt_state.fork_store == nil
-      rebuilt_write_tool = Enum.find(rebuilt_state.tools, &(&1.name == "write_file"))
+      assert Native.fork_store(pid) == nil
+      rebuilt_write_tool = pid |> Native.tools() |> Enum.find(&(&1.name == "write_file"))
 
       assert {:ok, result} =
                rebuilt_write_tool.callback.(%{
@@ -220,12 +218,11 @@ defmodule MingaAgent.Providers.NativeTest do
       {:ok, view} = ProjectView.overlay(dir)
       {:ok, pid} = start_provider(tmp_dir: dir, project_view: view, tools: nil)
 
-      state = :sys.get_state(pid)
-      assert state.project_view == view
-      assert state.fork_store == nil
-      assert state.changeset == nil
+      assert Native.project_view(pid) == view
+      assert Native.fork_store(pid) == nil
+      assert Native.changeset(pid) == nil
 
-      write_tool = Enum.find(state.tools, &(&1.name == "write_file"))
+      write_tool = pid |> Native.tools() |> Enum.find(&(&1.name == "write_file"))
 
       assert {:ok, result} =
                write_tool.callback.(%{"path" => "lib/view_draft.ex", "content" => "draft\n"})

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -462,7 +462,8 @@ defmodule MingaAgent.SessionTest do
           id: {:inline_hooks_disabled, make_ref()}
         )
 
-      assert %{persist?: false, hooks_enabled?: false} = :sys.get_state(session)
+      refute Session.persist?(session)
+      refute Session.hooks_enabled?(session)
     end
   end
 

--- a/test/minga_editor/commands/buffer_management_shutdown_test.exs
+++ b/test/minga_editor/commands/buffer_management_shutdown_test.exs
@@ -41,10 +41,9 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
       {editor, _buffer, _options} = start_editor("hello")
 
       type_string(editor, ":q\r")
-      state = :sys.get_state(editor)
-      assert state.pending_quit == :quit
-      assert state.shell_state.status_msg == "Quit Minga? (y/n)"
-      refute Enum.any?(state.shell_state.tab_bar.tabs, &String.starts_with?(&1.label, "[new"))
+      assert pending_quit(editor) == :quit
+      assert status_msg(editor) == "Quit Minga? (y/n)"
+      refute Enum.any?(tab_labels(editor), &String.starts_with?(&1, "[new"))
 
       send_key(editor, ?y)
 
@@ -132,4 +131,11 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
     GenServer.call(editor, :api_mode)
   end
+
+  defp get_editor_state(editor), do: :sys.get_state(editor)
+  defp pending_quit(editor), do: get_editor_state(editor).pending_quit
+  defp status_msg(editor), do: EditorState.status_msg(get_editor_state(editor))
+
+  defp tab_labels(editor),
+    do: Enum.map(get_editor_state(editor).shell_state.tab_bar.tabs, & &1.label)
 end

--- a/test/minga_editor/commands/git_branch_delete_test.exs
+++ b/test/minga_editor/commands/git_branch_delete_test.exs
@@ -87,14 +87,12 @@ defmodule MingaEditor.Commands.GitBranchDeleteTest do
   end
 
   defp await_project_rebuild(root) do
-    state = :sys.get_state(Minga.Project)
-
-    if state.rebuilding? do
+    if Minga.Project.rebuilding?() do
       assert_receive {:minga_event, :project_rebuilt,
                       %Minga.Events.ProjectRebuiltEvent{root: ^root}},
                      5_000
     end
 
-    :sys.get_state(Minga.Project)
+    _ = :sys.get_state(Minga.Project)
   end
 end

--- a/test/minga_editor/drop_open_directory_test.exs
+++ b/test/minga_editor/drop_open_directory_test.exs
@@ -36,14 +36,12 @@ defmodule MingaEditor.DropOpenDirectoryTest do
   end
 
   defp await_project_rebuild(root) do
-    state = :sys.get_state(Minga.Project)
-
-    if state.rebuilding? do
+    if Minga.Project.rebuilding?() do
       assert_receive {:minga_event, :project_rebuilt,
                       %Minga.Events.ProjectRebuiltEvent{root: ^root}},
                      5_000
     end
 
-    :sys.get_state(Minga.Project)
+    _ = :sys.get_state(Minga.Project)
   end
 end

--- a/test/minga_editor/file_change_test.exs
+++ b/test/minga_editor/file_change_test.exs
@@ -89,6 +89,4 @@ defmodule MingaEditor.FileChangeTest do
     sync_screen(ctx)
     :ok
   end
-
-  defp status_msg(ctx), do: MingaEditor.State.status_msg(editor_state(ctx))
 end

--- a/test/minga_editor/file_change_test.exs
+++ b/test/minga_editor/file_change_test.exs
@@ -89,4 +89,6 @@ defmodule MingaEditor.FileChangeTest do
     sync_screen(ctx)
     :ok
   end
+
+  defp status_msg(ctx), do: MingaEditor.State.status_msg(editor_state(ctx))
 end

--- a/test/minga_editor/integration/file_open_from_agent_tab_test.exs
+++ b/test/minga_editor/integration/file_open_from_agent_tab_test.exs
@@ -142,27 +142,24 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
 
       open_file_and_wait(ctx, file_path)
 
-      agent_state = :sys.get_state(ctx.editor)
-      agent_workspace_id = TabBar.active_workspace_id(agent_state.shell_state.tab_bar)
-      agent_file_tabs = TabBar.visible_file_tabs(agent_state.shell_state.tab_bar)
-      assert Enum.map(agent_file_tabs, & &1.group_id) == [agent_workspace_id]
+      agent_ws = active_workspace_id(ctx)
+      agent_file_tabs = visible_file_tabs(ctx, agent_ws)
+      assert Enum.map(agent_file_tabs, & &1.group_id) == [agent_ws]
 
       :sys.replace_state(ctx.editor, &EditorState.switch_tab(&1, 1))
       open_file_and_wait(ctx, file_path)
 
-      state = :sys.get_state(ctx.editor)
-      manual_tabs = TabBar.visible_file_tabs(state.shell_state.tab_bar, 0)
-      agent_tabs = TabBar.visible_file_tabs(state.shell_state.tab_bar, agent_workspace_id)
+      manual_tabs = visible_file_tabs(ctx, 0)
+      agent_tabs = visible_file_tabs(ctx, agent_ws)
 
       assert length(manual_tabs) == 2
       assert length(agent_tabs) == 1
       assert Enum.map(manual_tabs ++ agent_tabs, & &1.id) |> Enum.uniq() |> length() == 3
 
       :ok = MingaEditor.open_file(ctx.editor, file_path)
-      reopened_state = :sys.get_state(ctx.editor)
 
-      assert length(TabBar.visible_file_tabs(reopened_state.shell_state.tab_bar, 0)) == 2
-      assert TabBar.active_workspace_id(reopened_state.shell_state.tab_bar) == 0
+      assert length(visible_file_tabs(ctx, 0)) == 2
+      assert active_workspace_id(ctx) == 0
     end
   end
 end

--- a/test/minga_editor/picker_branch_delete_shortcut_test.exs
+++ b/test/minga_editor/picker_branch_delete_shortcut_test.exs
@@ -93,14 +93,12 @@ defmodule MingaEditor.PickerBranchDeleteShortcutTest do
   end
 
   defp await_project_rebuild(root) do
-    state = :sys.get_state(Minga.Project)
-
-    if state.rebuilding? do
+    if Minga.Project.rebuilding?() do
       assert_receive {:minga_event, :project_rebuilt,
                       %Minga.Events.ProjectRebuiltEvent{root: ^root}},
                      5_000
     end
 
-    :sys.get_state(Minga.Project)
+    _ = :sys.get_state(Minga.Project)
   end
 end

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -128,12 +128,10 @@ defmodule MingaEditor.Renderer.ServerTest do
   end
 
   defp renderer_busy?(renderer, attempts \\ 8)
-  defp renderer_busy?(renderer, 0), do: :sys.get_state(renderer).rendering?
+  defp renderer_busy?(renderer, 0), do: RendererServer.rendering?(renderer)
 
   defp renderer_busy?(renderer, attempts) do
-    state = :sys.get_state(renderer)
-
-    if state.rendering? do
+    if RendererServer.rendering?(renderer) do
       renderer_busy?(renderer, attempts - 1)
     else
       false

--- a/test/minga_editor/status_bar/data_test.exs
+++ b/test/minga_editor/status_bar/data_test.exs
@@ -260,7 +260,16 @@ defmodule MingaEditor.StatusBar.DataTest do
   end
 
   defp start_buffer(content, filetype) do
-    buf = start_supervised!({BufferProcess, [content: "", filetype: filetype]})
+    # Use an isolated events registry so edits don't broadcast to the global
+    # Git.Tracker, which would race with register_tracked_buffer and overwrite
+    # the GitBuffer's conflict state with the buffer's (conflict-free) content.
+    registry = :"data_test_events_#{System.unique_integer([:positive])}"
+
+    buf =
+      start_supervised!(
+        {BufferProcess, [content: "", filetype: filetype, events_registry: registry]}
+      )
+
     :ok = BufferProcess.insert_text(buf, content)
     buf
   end

--- a/test/minga_editor/ui/picker/command_source_frecency_test.exs
+++ b/test/minga_editor/ui/picker/command_source_frecency_test.exs
@@ -29,12 +29,12 @@ defmodule MingaEditor.UI.Picker.CommandSourceFrecencyTest do
     File.mkdir_p!(Path.join(config_home, "minga"))
     System.put_env("XDG_CONFIG_HOME", config_home)
 
-    previous_project = :sys.get_state(Project)
+    previous_command_frecency = Project.command_frecency()
     reset_global_command_frecency()
 
     on_exit(fn ->
       restore_xdg_config_home(previous_config_home)
-      restore_global_command_frecency(previous_project.command_frecency)
+      restore_global_command_frecency(previous_command_frecency)
     end)
 
     :ok

--- a/test/minga_editor/ui/picker/file_source_test.exs
+++ b/test/minga_editor/ui/picker/file_source_test.exs
@@ -279,16 +279,14 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
   end
 
   defp await_project_rebuild(root) do
-    state = :sys.get_state(Minga.Project)
-
-    if state.rebuilding? do
+    if Minga.Project.rebuilding?() do
       assert_receive {:minga_event, :project_rebuilt,
                       %Minga.Events.ProjectRebuiltEvent{root: ^root}},
                      5_000
     end
 
-    :sys.get_state(Minga.Project)
+    _ = :sys.get_state(Minga.Project)
   end
 
-  defp flush_project, do: :sys.get_state(Minga.Project)
+  defp flush_project, do: _ = :sys.get_state(Minga.Project)
 end

--- a/test/minga_editor/warnings_buffer_test.exs
+++ b/test/minga_editor/warnings_buffer_test.exs
@@ -60,8 +60,6 @@ defmodule MingaEditor.WarningsBufferTest do
     editor_state(ctx)
   end
 
-  defp bottom_panel(ctx), do: editor_state(ctx).shell_state.bottom_panel
-
   defp dismiss_bottom_panel(ctx) do
     :sys.replace_state(ctx.editor, fn state ->
       MingaEditor.State.set_bottom_panel(

--- a/test/minga_editor/warnings_buffer_test.exs
+++ b/test/minga_editor/warnings_buffer_test.exs
@@ -60,6 +60,8 @@ defmodule MingaEditor.WarningsBufferTest do
     editor_state(ctx)
   end
 
+  defp bottom_panel(ctx), do: editor_state(ctx).shell_state.bottom_panel
+
   defp dismiss_bottom_panel(ctx) do
     :sys.replace_state(ctx.editor, fn state ->
       MingaEditor.State.set_bottom_panel(

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -534,11 +534,18 @@ defmodule Minga.Test.EditorCase do
   end
 
   # ── State query helpers ──────────────────────────────────────────────────
+  # Use these helpers instead of :sys.get_state + field assertions.
   # :sys.get_state is valid as a synchronization barrier (ensuring messages
-  # are processed), but tests should not pattern-match on returned state
-  # fields. Helpers here return booleans that answer "is this happening?"
-  # without exposing the state path. For visible text (status messages,
-  # prompts), prefer screen helpers like minibuffer/1 and screen_row/2.
+  # are processed before asserting), but tests should not pattern-match on
+  # the returned state fields. When you need to assert on editor state,
+  # add a helper here that encapsulates the access path, so tests survive
+  # struct refactors.
+
+  @doc "Returns the active keymap scope."
+  @spec keymap_scope(editor_ctx()) :: atom()
+  def keymap_scope(%{editor: editor}) do
+    get_editor_state(editor).workspace.keymap_scope
+  end
 
   @doc "Returns true if a search pattern is active."
   @spec search_active?(editor_ctx()) :: boolean()
@@ -562,6 +569,18 @@ defmodule Minga.Test.EditorCase do
   @spec conflict_open?(editor_ctx()) :: boolean()
   def conflict_open?(%{editor: editor}) do
     MingaEditor.State.ModalOverlay.match(get_editor_state(editor).shell_state.modal, :conflict)
+  end
+
+  @doc "Returns the current status message."
+  @spec status_msg(editor_ctx()) :: String.t() | nil
+  def status_msg(%{editor: editor}) do
+    MingaEditor.State.status_msg(get_editor_state(editor))
+  end
+
+  @doc "Returns the bottom panel state."
+  @spec bottom_panel(editor_ctx()) :: MingaEditor.BottomPanel.t()
+  def bottom_panel(%{editor: editor}) do
+    get_editor_state(editor).shell_state.bottom_panel
   end
 
   @doc "Returns the picker payload (ModalOverlay.Picker) when a picker is open, or nil."

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -564,6 +564,39 @@ defmodule Minga.Test.EditorCase do
     MingaEditor.State.ModalOverlay.match(get_editor_state(editor).shell_state.modal, :conflict)
   end
 
+  @doc "Returns the pending quit mode (:quit | :quit_all | nil)."
+  @spec pending_quit(editor_ctx()) :: :quit | :quit_all | nil
+  def pending_quit(%{editor: editor}) do
+    get_editor_state(editor).pending_quit
+  end
+
+  @doc "Returns the current status/command message."
+  @spec status_msg(editor_ctx()) :: String.t() | nil
+  def status_msg(%{editor: editor}) do
+    MingaEditor.State.status_msg(get_editor_state(editor))
+  end
+
+  @doc "Returns the tab bar labels."
+  @spec tab_labels(editor_ctx()) :: [String.t()]
+  def tab_labels(%{editor: editor}) do
+    Enum.map(get_editor_state(editor).shell_state.tab_bar.tabs, & &1.label)
+  end
+
+  @doc "Returns the active workspace ID."
+  @spec active_workspace_id(editor_ctx()) :: non_neg_integer()
+  def active_workspace_id(%{editor: editor}) do
+    MingaEditor.State.TabBar.active_workspace_id(get_editor_state(editor).shell_state.tab_bar)
+  end
+
+  @doc "Returns visible file tabs for the given workspace ID."
+  @spec visible_file_tabs(editor_ctx(), non_neg_integer()) :: [map()]
+  def visible_file_tabs(%{editor: editor}, workspace_id) do
+    MingaEditor.State.TabBar.visible_file_tabs(
+      get_editor_state(editor).shell_state.tab_bar,
+      workspace_id
+    )
+  end
+
   @doc "Returns the picker payload (ModalOverlay.Picker) when a picker is open, or nil."
   @spec modal_picker(editor_ctx()) :: MingaEditor.State.ModalOverlay.Picker.t() | nil
   def modal_picker(%{editor: editor}) do

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -534,18 +534,11 @@ defmodule Minga.Test.EditorCase do
   end
 
   # ── State query helpers ──────────────────────────────────────────────────
-  # Use these helpers instead of :sys.get_state + field assertions.
   # :sys.get_state is valid as a synchronization barrier (ensuring messages
-  # are processed before asserting), but tests should not pattern-match on
-  # the returned state fields. When you need to assert on editor state,
-  # add a helper here that encapsulates the access path, so tests survive
-  # struct refactors.
-
-  @doc "Returns the active keymap scope."
-  @spec keymap_scope(editor_ctx()) :: atom()
-  def keymap_scope(%{editor: editor}) do
-    get_editor_state(editor).workspace.keymap_scope
-  end
+  # are processed), but tests should not pattern-match on returned state
+  # fields. Helpers here return booleans that answer "is this happening?"
+  # without exposing the state path. For visible text (status messages,
+  # prompts), prefer screen helpers like minibuffer/1 and screen_row/2.
 
   @doc "Returns true if a search pattern is active."
   @spec search_active?(editor_ctx()) :: boolean()
@@ -569,18 +562,6 @@ defmodule Minga.Test.EditorCase do
   @spec conflict_open?(editor_ctx()) :: boolean()
   def conflict_open?(%{editor: editor}) do
     MingaEditor.State.ModalOverlay.match(get_editor_state(editor).shell_state.modal, :conflict)
-  end
-
-  @doc "Returns the current status message."
-  @spec status_msg(editor_ctx()) :: String.t() | nil
-  def status_msg(%{editor: editor}) do
-    MingaEditor.State.status_msg(get_editor_state(editor))
-  end
-
-  @doc "Returns the bottom panel state."
-  @spec bottom_panel(editor_ctx()) :: MingaEditor.BottomPanel.t()
-  def bottom_panel(%{editor: editor}) do
-    get_editor_state(editor).shell_state.bottom_panel
   end
 
   @doc "Returns the picker payload (ModalOverlay.Picker) when a picker is open, or nil."


### PR DESCRIPTION
## Summary

- Add public query functions to 7 GenServer modules (`Project`, `Native`, `Session`, `Writer`, `DebugLog`, `ConnectionManager`, `Renderer.Server`) so tests assert through the module's public API instead of peeking at internal state via `:sys.get_state` pattern-match.
- Add 5 EditorCase query helpers (`pending_quit/1`, `status_msg/1`, `tab_labels/1`, `active_workspace_id/1`, `visible_file_tabs/2`) that wrap the existing `get_editor_state` sync barrier.
- Migrate 20 field assertions across 14 test files to use the new public APIs.
- Zero remaining `:sys.get_state` calls that bind the return value for field assertions. Sync barriers and `:sys.replace_state` for test setup are unchanged.

Closes #1928

## Test plan

- [x] `mix test.llm`: 8588 tests, 0 failures
- [x] `make lint`: exit 0 (format, credo, dialyzer)
- [x] Verification grep returns 0 results: `grep -rn ':sys.get_state' test/ | grep -v '_ =' | grep -v 'defp flush\|defp sync\|defp get_editor_state' | grep -E '(= :sys\.get_state|assert.*:sys\.get_state)'`


🤖 Generated with [Claude Code](https://claude.com/claude-code)