### PR TITLE
feat(macos): add PreviewHost target for SwiftUI chrome view snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ tmp/
 test/tmp/
 macos/build/
 macos/DerivedData/
+macos/Tests/Snapshots/
 
 # Minga project-local state
 .minga/workspaces/

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -10,20 +10,25 @@
 		0089154318A4683A07D2918C /* BlinkingCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3927622EC3475A69EE524899 /* BlinkingCursor.swift */; };
 		00BFD5EFCCE2F178469BBA9E /* ToolManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64B96EAA100E627F4E8E0A1 /* ToolManagerState.swift */; };
 		03FDC63893F3CAA82BCE2A49 /* TabBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */; };
+		03FEC8AC31DA3A2806822AA6 /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D6B3C68CFF37BC4303933A /* ThemeColors.swift */; };
+		04DCD757C3C296EDE15973C8 /* ExtensionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BB136A9D180CCAD371E51 /* ExtensionPanelView.swift */; };
 		058481A528AFB6C7225A067D /* MouseInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */; };
 		05EC70C811170EE160C5E4D9 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
 		067369CB702835E93D254606 /* PipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */; };
 		06D57AD02306EA08C458CC11 /* WorkspaceIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */; };
 		0704C24443A8A7455BE7853E /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
+		077AF22C34E2851B1F975C78 /* PreviewHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9978FBBB4E1BC671AF1C49F5 /* PreviewHostApp.swift */; };
 		07C32C28178AE5675ACF4539 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
 		07C6F28E3CD1A55ABD5344AA /* SlotAllocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */; };
 		084A4F7680D533CDACEC729A /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
 		0B68D79FFC2E1BC94D2B8F9F /* ChangeSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2812AE57C17D25D125076FA3 /* ChangeSummaryView.swift */; };
 		0BCDFB56E8397D739F52ED34 /* StateLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5634B25BE5BB945A83E30FAD /* StateLifecycleTests.swift */; };
+		0BFC2F3292E5954F350C5BA8 /* FloatPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C47F406747CA6DD924A1AB /* FloatPopupOverlay.swift */; };
 		0CD5CD798BFF116A03DFFB16 /* EditTimelineState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2E999D82FCC18364568E8B /* EditTimelineState.swift */; };
 		0D5DFD181E86D51707D3A59E /* AgentChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD14027C8C7BD17057DE820B /* AgentChatView.swift */; };
 		0D8C5FFA3F7BE723E50A58B6 /* BoardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F80894B4E875FD2C66F14CC /* BoardState.swift */; };
 		0E10D47CFF85000F62B5AB9A /* TextHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA1A468192F9DE2BBF374DD /* TextHighlighting.swift */; };
+		107A3231D5F372CB917A07C0 /* EditorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9448826AA38AB5FC0CEB79 /* EditorSettingsView.swift */; };
 		10DCD0BD58EEB5D10454DE22 /* SettingsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BBC8154E1D48CE215F2F25 /* SettingsState.swift */; };
 		119048334DAF989E5BA568EA /* ActivityBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80457F318D9322F416DA291 /* ActivityBar.swift */; };
 		1309895DD1E560D133E0A932 /* BoardTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C874A0099721763D5109D99 /* BoardTypes.swift */; };
@@ -32,11 +37,15 @@
 		1631D7B76B33CD897C48F263 /* IMECompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */; };
 		16B6B2060971E871478C57A8 /* BoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D2EC281455699168DA872 /* BoardView.swift */; };
 		17338247D6D83DAF4DE5B9EA /* SidebarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452AAEF9518FDDF1FF8F51B0 /* SidebarContainer.swift */; };
+		17C035AC7105BA405786AE3E /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
 		18F0DDA03D08C0B4302DCCF4 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
 		1965FE752C77D2EB386EC4D8 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */; };
 		19BF036E1B3A3CF589C5F578 /* SidebarHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */; };
 		19E561E5F7841B2CF1ABB085 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
+		1BED638F0EE72345B63FA3E2 /* BottomPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */; };
+		1D2AE6CCA8AEE36DA0731D7B /* GitStatusState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B5F67DE84B139C6F8F3C9F /* GitStatusState.swift */; };
 		1E77051711F9373850137201 /* ObservatoryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1421FF1F017E45A031AF18 /* ObservatoryState.swift */; };
+		1F5CF0197B6C4F28D6169DA2 /* ChangeSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2812AE57C17D25D125076FA3 /* ChangeSummaryView.swift */; };
 		1F9F7B302A2A8598C1391FA0 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
 		20DE27562883B504C119A22F /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
 		22315F71081A55C37A2DDC60 /* NotificationCenterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FC35125B6A0561FE9B5B231 /* NotificationCenterState.swift */; };
@@ -45,29 +54,39 @@
 		23DA463A92D1EC2F7BFA5B5A /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
 		26DAAF2C2CCC2713AD30C539 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
+		279CEBE1AD001C3AFD74E285 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */; };
 		28F3D7BFADCE4A2509D66C2B /* CommandDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470991E7B3850B1AADFD46FD /* CommandDispatcherTests.swift */; };
+		29F85C6901F01EF4E93DFC72 /* AgentChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD14027C8C7BD17057DE820B /* AgentChatView.swift */; };
 		2A5DCAC8284B11CD4F8625A5 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */; };
 		2BA99A1851D0FF01436D5FF8 /* ToolManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64B96EAA100E627F4E8E0A1 /* ToolManagerState.swift */; };
 		2C176B25F957ABFA236A1F31 /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
 		2CB47C7E5221C260DE6EE77F /* ToolManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */; };
 		2F5F89DAEB979F0B5ACB9E7F /* AgentContextBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D15FC229A7AAA6AD493D1F /* AgentContextBarState.swift */; };
+		2FD4D85B9612CA458246F06E /* SignatureHelpOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0070B497768FE68A63F5F114 /* SignatureHelpOverlay.swift */; };
 		30E31170A79F30413D15D858 /* GUIChromeDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */; };
 		31B993BFA99DD58462B8924B /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9958CDCF40B9580E12AD1A81 /* SparklineView.swift */; };
 		31E0D1C2347322703DA6CC71 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
 		32171233224FC90E1E956631 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C0836F0D4150126F181C05 /* PickerState.swift */; };
+		333C467F77C10315777C85D2 /* HoverPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE5B840DF73BAC1A97CB7E6 /* HoverPopupOverlay.swift */; };
+		345C57CB549A765B0F788C4B /* BoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D2EC281455699168DA872 /* BoardView.swift */; };
+		348D61FC49B7A42CE6CFEC21 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912C5F808709BABFF3126DEE /* AppearanceSettingsView.swift */; };
 		3576D476C304CBAEA792D86A /* AgentContextBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D15FC229A7AAA6AD493D1F /* AgentContextBarState.swift */; };
 		364C48575BB95C9CA535A9C8 /* ProtocolReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */; };
 		364F7DD64DD5E3AF11361F9B /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9958CDCF40B9580E12AD1A81 /* SparklineView.swift */; };
 		36E0C059965477465E15CC02 /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
 		3756AD45E2913D656D1D7255 /* EditTimelineState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2E999D82FCC18364568E8B /* EditTimelineState.swift */; };
 		3767C83415B32C31B33EFFFB /* MinibufferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2D3B0C9A042E9A5C485E1 /* MinibufferState.swift */; };
+		3897BF151EA81DDF38B85047 /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
 		393F9EE9CE5F6691781C8CF7 /* MinibufferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DDF3EED1B486C4639A06FF /* MinibufferView.swift */; };
 		3943C8DF3827347B61E6B725 /* MinibufferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DDF3EED1B486C4639A06FF /* MinibufferView.swift */; };
+		3B7E389A35ADF448C5588469 /* FileTreeHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */; };
 		3CD49A10C9BA962BBCB00CA8 /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
 		3CE45B5FDE5CB6612B7942F4 /* SettingsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BBC8154E1D48CE215F2F25 /* SettingsState.swift */; };
+		3DB25E7E934FAAD7A7B51084 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
 		4019E8D2F5CD3BA51C29FD62 /* NotificationCenterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BC213C5FAF120260716363 /* NotificationCenterView.swift */; };
 		41DCC27275D0E8E903EAA061 /* SidebarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */; };
 		42E4FAA9F204D88F8D19EFF6 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */; };
+		4451B7F61D8FB50D964406A0 /* ProtocolReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */; };
 		44D48DF33203C53ACC3BA1AA /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		4515011E135C9FAE8D843610 /* ProtocolTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */; };
 		4699A67786955024F156446F /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
@@ -84,36 +103,56 @@
 		5311F1060367B40B4077309F /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
 		53736DA2E4420D55D3D4E0A4 /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
 		545597C675EA0D630D24A4C8 /* WorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */; };
+		55399D2B1E4C5EBE632D7EBC /* PickerOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F606681DE9AA9D502A42AA /* PickerOverlay.swift */; };
+		57FEBE6C32520DFD357D0B94 /* ObservatoryGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCD60250752188DDE054B12 /* ObservatoryGraphView.swift */; };
 		58D1135E113BF3A33EF7815F /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		59546703C9DBB4BA6E15DE28 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */; };
 		5BEEC2FD4D95EBA70FE036E7 /* BottomPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */; };
+		5C92C1B998EE5612AC84FBF5 /* NotificationCenterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FC35125B6A0561FE9B5B231 /* NotificationCenterState.swift */; };
 		5CADBD593C49EE44EBBD854E /* PortLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E23DC6E0ACB156F21293E87 /* PortLogger.swift */; };
+		5CD18EDFFAE3324309FD507B /* AgentContextBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D15FC229A7AAA6AD493D1F /* AgentContextBarState.swift */; };
 		5E6F3B6E3BDA7B6CC3965F96 /* DispatchSheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4322CD8BEEFC8C2FB832438 /* DispatchSheetState.swift */; };
 		5FC076D7FA45C7F1829213AA /* GitStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5F52D925D26A6D8919A0CB /* GitStatusView.swift */; };
 		5FDD7CBBCB910BDC63276AA7 /* WhichKeyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5765529645C5D860576B7 /* WhichKeyState.swift */; };
 		6131983A64CD5FE094D2430E /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2EC7DA888E31E55CE0D715 /* AgentContextBar.swift */; };
+		619712AD984E8EA2ED68AE2C /* PreviewRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17B2A4D2BADE64E249073E1 /* PreviewRegistry.swift */; };
 		61CF67858355FFF4962D9D99 /* ThemeColorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */; };
+		6248B6BA1BF78DA0E364F9A3 /* WorkspaceIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */; };
+		630D7B1922CBCCF1335491C2 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
+		63AD77F5D54E43D9376810DC /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
 		63F3CF3A4746901FDF1C3356 /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
+		644651957542041BB07F6819 /* FileTreeView.png in Resources */ = {isa = PBXBuildFile; fileRef = 74F5BDC126D824CD2C499359 /* FileTreeView.png */; };
 		647346FE3161B2C2FC4A5436 /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
 		6474095F95F4DA480AFE91B7 /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
 		64A5A16E02B3E2694060F1A1 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
 		654E7E631260BE13502E1C32 /* FloatPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C47F406747CA6DD924A1AB /* FloatPopupOverlay.swift */; };
+		668FB5D322D50EAFD1C878F0 /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9958CDCF40B9580E12AD1A81 /* SparklineView.swift */; };
+		6691CAB367FB0BA9821C79E5 /* KeybindingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50661EF3472E892F77AF9C2 /* KeybindingsSettingsView.swift */; };
 		6700C63C4B7070D3388A7BD4 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		67BB06B6822104CDE37EDF83 /* BoardTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C874A0099721763D5109D99 /* BoardTypes.swift */; };
 		6860E9D6217B72EAA8AD71A5 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
 		686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F220A60775A252A728477659 /* ProtocolTests.swift */; };
+		6A52456182D34DA5C6D0525C /* GitStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5F52D925D26A6D8919A0CB /* GitStatusView.swift */; };
+		6AFA24DC3EE21023636C136A /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
 		6BA7D7FBA7A05CDEA428811D /* FileTreeHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */; };
 		6BE2E29A66DAA9D5B0B478C5 /* EditorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9448826AA38AB5FC0CEB79 /* EditorSettingsView.swift */; };
 		6E796E1FBD379D96E98C4DF7 /* EditorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9448826AA38AB5FC0CEB79 /* EditorSettingsView.swift */; };
 		6EE7C16703E92B31CC9CE9C0 /* NonBlockingEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3DDF1EB804D4E31EDFA519 /* NonBlockingEncoderTests.swift */; };
 		6F7F50CEC5067770E4865C2A /* CompletionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */; };
+		70BAD234EF40359C5703FAAA /* PortLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E23DC6E0ACB156F21293E87 /* PortLogger.swift */; };
+		719318748BDDAEBE10DFBB2E /* ProtocolTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */; };
 		726E3D5BE1E9DA98E17C92B9 /* WorkspaceHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */; };
+		72CC62FDCBD531FEFE4D07DF /* ProtocolDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */; };
 		73955B38CEFC09D29EADAD85 /* FloatPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C47F406747CA6DD924A1AB /* FloatPopupOverlay.swift */; };
+		73F8F631B3B7DF3EE9159913 /* EditTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9DA04BBCBA8D286E62C0EA /* EditTimelineView.swift */; };
 		74D29226F82E6ADE18E2E108 /* MinibufferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2D3B0C9A042E9A5C485E1 /* MinibufferState.swift */; };
+		75836AA3D1FB27575C00755A /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		7680EFD077E0B916411123FA /* SymbolsNerdFontMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FD66FBCBFC20D50D22A969C8 /* SymbolsNerdFontMono-Regular.ttf */; };
+		7710CE0EB136EB58DF5AC519 /* ChangeSummaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E3D96CF06FCC7F116AF4DC /* ChangeSummaryState.swift */; };
 		778C6A917140005C0C0643CB /* ProtocolEncoderBinaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BD56B7D6D195D236F9BF40 /* ProtocolEncoderBinaryTests.swift */; };
 		783AEDBA1B0D4557E0D1DD81 /* ChangeSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2812AE57C17D25D125076FA3 /* ChangeSummaryView.swift */; };
 		785A55B784A3EE17DC3E0AC6 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C0836F0D4150126F181C05 /* PickerState.swift */; };
+		78644398F50FDB9206F731CB /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
 		78F06B9BFB553B50D9BDD50F /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		793247C2AB95598A1AC4C6EC /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD30A2572AE2608F099407 /* ScrollAccumulator.swift */; };
 		79E8353F67F7638721A02A54 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
@@ -123,24 +162,36 @@
 		7D395895306A81736A98E8B9 /* ExtensionPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D54D0AA54F1EC07318AEA /* ExtensionPanelState.swift */; };
 		7DB249F526EB508249BE3964 /* ChangeSummaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E3D96CF06FCC7F116AF4DC /* ChangeSummaryState.swift */; };
 		7E2428F971A8835D3B42598B /* GitStatusState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B5F67DE84B139C6F8F3C9F /* GitStatusState.swift */; };
+		7F5AEBE16F765D8163F7D8A9 /* StatusBarView.png in Resources */ = {isa = PBXBuildFile; fileRef = 4DB8CFA9B73750AD34E77A0C /* StatusBarView.png */; };
+		806AF50CBA2A30F3DFCB10CF /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */; };
+		80EB118387A9EA307762F482 /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2EC7DA888E31E55CE0D715 /* AgentContextBar.swift */; };
 		810251CDDA9CB63F881D426C /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D6B3C68CFF37BC4303933A /* ThemeColors.swift */; };
+		82774DBCD8FBAC9FD32822F4 /* MinibufferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2D3B0C9A042E9A5C485E1 /* MinibufferState.swift */; };
 		82E444261F28262834866B20 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83165B89231936674C54B513 /* EditorNSView.swift */; };
+		8320D5A4779EE1EF37A54477 /* ExtensionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836BA390DF0C2A711D270D2C /* ExtensionOverlayView.swift */; };
 		834AE58B6A66336706780324 /* GitStatusState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B5F67DE84B139C6F8F3C9F /* GitStatusState.swift */; };
+		842216C3AEC642569725698F /* ToolManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64B96EAA100E627F4E8E0A1 /* ToolManagerState.swift */; };
 		854BCC1151B43E9A161C95B5 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */; };
+		870591324FCC1AD0BBCECCDA /* ObservatoryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1421FF1F017E45A031AF18 /* ObservatoryState.swift */; };
 		87C92A93D274184D1608DAC5 /* BlinkingCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3927622EC3475A69EE524899 /* BlinkingCursor.swift */; };
 		888A35D1348A7A3CAE935561 /* DecoderFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */; };
+		88A182018706D04CCE8973A6 /* SidebarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452AAEF9518FDDF1FF8F51B0 /* SidebarContainer.swift */; };
 		8A0B62C670C71DB327CE1A29 /* RecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A6769D066EC44A58791CFC /* RecoveryManager.swift */; };
 		8AB3B55F301192FA4F4A4E41 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
+		8B836B6CADA9E21721BAD96C /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C0836F0D4150126F181C05 /* PickerState.swift */; };
 		8B944E100C80DFF282D25D4C /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */; };
 		8C9C3976E598C7F553B003B6 /* WorkspaceHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */; };
 		8CB3E1EEDEA109F6C0183597 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */; };
 		8D55764B8CF042B4C48AA5D0 /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
 		8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
+		90DDED0067C36E07960445C9 /* TabBarView.png in Resources */ = {isa = PBXBuildFile; fileRef = E446B783B6308E4878B80018 /* TabBarView.png */; };
 		92AFB851C9873F6E26F069A3 /* TextHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA1A468192F9DE2BBF374DD /* TextHighlighting.swift */; };
+		9303B34232153C61D709B7D6 /* ActivityBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80457F318D9322F416DA291 /* ActivityBar.swift */; };
 		931A6127210D4ED441AC04B2 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */; };
 		939991DD65293C6C796EAA66 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
 		93E7D214A27256CF06571EFE /* ProtocolDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */; };
 		941C53DDBC488FE908656CD3 /* BottomPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */; };
+		9493C0265F69C3D588ACC37B /* TabBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */; };
 		94DCAF47E7E66035A1073E12 /* DispatchSheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4322CD8BEEFC8C2FB832438 /* DispatchSheetState.swift */; };
 		95F6DCD24E2D261CF64EC8EB /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		9758BF46BB0EC7FEEB14FBA3 /* SwiftUIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86478D5660213F165B7E1E35 /* SwiftUIViewTests.swift */; };
@@ -149,21 +200,30 @@
 		9CC563AE009A1EA1A0BE0D9F /* SettingsStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C02007D4036FC9C7D0FB71 /* SettingsStateTests.swift */; };
 		9CF8F6D3F114C40EB6A44881 /* ObservatoryGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCD60250752188DDE054B12 /* ObservatoryGraphView.swift */; };
 		A0351D1D024158F048BA1C25 /* WorkspaceIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */; };
+		A084A045EA71D390C188EB23 /* DispatchSheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4322CD8BEEFC8C2FB832438 /* DispatchSheetState.swift */; };
 		A1AFA4551E04034C5FF5D39B /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD30A2572AE2608F099407 /* ScrollAccumulator.swift */; };
+		A1F7FEEEDE79E743506763C7 /* FileTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */; };
+		A2248AB663ACECA334695D9C /* NotificationCenterView.png in Resources */ = {isa = PBXBuildFile; fileRef = 1D3FC97A5BF803712978AB67 /* NotificationCenterView.png */; };
 		A25FEFF01578CFA880BDC424 /* ExtensionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836BA390DF0C2A711D270D2C /* ExtensionOverlayView.swift */; };
 		A33FB24A0B21158461545E39 /* NotificationCenterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BC213C5FAF120260716363 /* NotificationCenterView.swift */; };
 		A3450933A22B691CDAA7277A /* ExtensionPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D54D0AA54F1EC07318AEA /* ExtensionPanelState.swift */; };
 		A409AE210CBAE48D4DCE47F7 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
+		A4E838B0B19ED0B8F9CC4654 /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
 		A574FC420DE17918612DFA48 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7C3564C27A7E14D894539 /* TabBarView.swift */; };
 		A613934E53A1D3B8BAEB69FB /* SignatureHelpOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0070B497768FE68A63F5F114 /* SignatureHelpOverlay.swift */; };
 		A6327C6FAB3DCFD57327FBF4 /* DecoderRobustnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B35E8311966948B1BA7AEF /* DecoderRobustnessTests.swift */; };
+		A74761E8F6B3FD1D0CFA1521 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */; };
 		A78FBA1CD5BB02EEBA8ACB45 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
 		A860586A88D34A562CAC0CBF /* WorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */; };
+		A96BC7EA2756D8AB18D45970 /* FloatPopupState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EF5FFAD8310BD41CF784AC /* FloatPopupState.swift */; };
 		A9EE5F81AE818C176D03A6E3 /* RecoveryManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */; };
 		AA47831C0288E59E8B4DBEB5 /* KeybindingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50661EF3472E892F77AF9C2 /* KeybindingsSettingsView.swift */; };
+		AAB03F4B2310094FED82D15E /* NotificationCenterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BC213C5FAF120260716363 /* NotificationCenterView.swift */; };
 		AB200EDC2BD9693D8D52CE98 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
 		AB804A6366BEFE62E30C929B /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		AC0F67258603E07297F526CE /* EditTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9DA04BBCBA8D286E62C0EA /* EditTimelineView.swift */; };
+		AD9123932ACE42FBAB6B0DD7 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
+		AF0877EE13E581DD7B20FA39 /* CompletionOverlay.png in Resources */ = {isa = PBXBuildFile; fileRef = F9437DDA1ADDABFCEAF93E1B /* CompletionOverlay.png */; };
 		AFE31388980EE451C8F734A3 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
 		B0A5712B943D48F8F72C1DDA /* KeyboardInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */; };
 		B0DFAD8D1AF624C9EA6D1940 /* ExtensionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BB136A9D180CCAD371E51 /* ExtensionPanelView.swift */; };
@@ -172,14 +232,20 @@
 		B1BBEE768697348E5BC59F18 /* ForceDirectedLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F9B461894B21D3A7BDE13D /* ForceDirectedLayout.swift */; };
 		B2063C405BABC6C1D394C3AF /* CompletionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA9C2BB0C840BE88B0FEA52 /* CompletionState.swift */; };
 		B2A775BF99630C067DEBE2DD /* ObservatoryGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCD60250752188DDE054B12 /* ObservatoryGraphView.swift */; };
+		B33F3F024CB62AFB86A64504 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */; };
+		B4AA8AEC6D3ED269B8860786 /* GitStatusHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */; };
 		B52CC06DF924153EAA3BADBE /* SidebarHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */; };
 		B6295F0247ADE2D1D0133DCB /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D6B3C68CFF37BC4303933A /* ThemeColors.swift */; };
 		B7203DF9CF85663B0A266580 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
+		B7CC10FD96E51A293C3D4920 /* WhichKeyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5765529645C5D860576B7 /* WhichKeyState.swift */; };
 		B8A6959AD515E3C283B42665 /* BoardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F80894B4E875FD2C66F14CC /* BoardState.swift */; };
 		B96A987BD563834EAA59F6A1 /* DispatchSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5A488C20326CCE3A7FC46E /* DispatchSheetView.swift */; };
+		B9AC7DFF11C810A393597F9F /* WorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */; };
 		BA72343308BCD0E078452868 /* PowerThermalPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E27E6D9ACEB7DCD7F98FB0F /* PowerThermalPolicyTests.swift */; };
+		BB1ABD615278289735DE85E9 /* InlineEditField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC5F0D37085813890268537 /* InlineEditField.swift */; };
 		BB743A0A803E3A1609DD6D59 /* KeybindingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50661EF3472E892F77AF9C2 /* KeybindingsSettingsView.swift */; };
 		BBB00DAC44161274B154C350 /* SignatureHelpOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0070B497768FE68A63F5F114 /* SignatureHelpOverlay.swift */; };
+		BF0E0A565CC791E8C2C8AC74 /* MinibufferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DDF3EED1B486C4639A06FF /* MinibufferView.swift */; };
 		BF41C04B7AF7C400A4DC1474 /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
 		BF4E98B0BE647893CB5DA85C /* PipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */; };
 		BF89605C029E1F2F4EE328EA /* CoreTextMetalRendererCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BA668E827BD6B77C72E9D6 /* CoreTextMetalRendererCursorTests.swift */; };
@@ -188,6 +254,7 @@
 		C028B986AC51F3180074F8C7 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B982679577E3DBD4E7A69D /* SettingsView.swift */; };
 		C07AF84A6E689758D100A251 /* InlineEditField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC5F0D37085813890268537 /* InlineEditField.swift */; };
 		C134E5115725A3A85492FF51 /* TabBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */; };
+		C2B552F09F4C033A34651A89 /* GitStatusView.png in Resources */ = {isa = PBXBuildFile; fileRef = E8BEF10DDD749FBA592D2D0E /* GitStatusView.png */; };
 		C3E6CE94BD471AC7BA0FB4BB /* DispatchSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5A488C20326CCE3A7FC46E /* DispatchSheetView.swift */; };
 		C44D9CF03C49E7BCA39A76A9 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
 		C607CC562920162A87010EA9 /* CompletionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA9C2BB0C840BE88B0FEA52 /* CompletionState.swift */; };
@@ -197,22 +264,33 @@
 		C8FAD7BE37506758A1DBF8F6 /* FileTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */; };
 		CA45D5770C1B334A821D3338 /* GitStatusHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */; };
 		CC72FE91F267AA744D4A6F1D /* GitStatusHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */; };
+		CC8B2D0174D3E5839980702C /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
 		CD2952CCEB2FD594B269A75D /* GUIActionEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */; };
 		CE2F1915565DB90F4A7FC04C /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		CF09E23141DB0E6D9B65826A /* WhichKeyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5765529645C5D860576B7 /* WhichKeyState.swift */; };
 		CF7CD0983161E8EFF1C296C1 /* EditTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9DA04BBCBA8D286E62C0EA /* EditTimelineView.swift */; };
+		D02E680B4D50D6ABA6264D8F /* BlinkingCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3927622EC3475A69EE524899 /* BlinkingCursor.swift */; };
+		D0CB0737618AFEEE2EC8CE60 /* SettingsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BBC8154E1D48CE215F2F25 /* SettingsState.swift */; };
 		D1EEFBDAE315F717373F82BD /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83165B89231936674C54B513 /* EditorNSView.swift */; };
 		D21259951FF33B28994B2E44 /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */; };
 		D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */; };
+		D4B0BBB40180CD15FEB0FB75 /* ExtensionOverlayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F88438F21DF56F11861F9 /* ExtensionOverlayState.swift */; };
 		D7E2C642D5119FDF8D0F2158 /* ForceDirectedLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F9B461894B21D3A7BDE13D /* ForceDirectedLayout.swift */; };
 		D946EB891A72053F283BF971 /* GitStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5F52D925D26A6D8919A0CB /* GitStatusView.swift */; };
 		DB83E9F1763A0D2E7BD7F7D3 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = BD2531C0969FD21CC18D2FDB /* ViewInspector */; };
+		DBB1CFFF8301A15D950AD07F /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD30A2572AE2608F099407 /* ScrollAccumulator.swift */; };
+		DC3640DCFB66764CEEA3D503 /* BoardTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C874A0099721763D5109D99 /* BoardTypes.swift */; };
 		DD0B958D8ACEFFEF3C1A50AE /* ViewModelComputedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22420E1CC772DAFB9A5043C2 /* ViewModelComputedTests.swift */; };
+		DD78E8B97A78A84587C0F461 /* DispatchSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5A488C20326CCE3A7FC46E /* DispatchSheetView.swift */; };
+		DE495CCFC92C702B2A3243A0 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7C3564C27A7E14D894539 /* TabBarView.swift */; };
 		DE6C77896ED3E1E885216DC3 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
 		DF3B2A645C089F616B9DBD1B /* ProtocolEncoderDisconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */; };
+		DF9EDB44B49C0D61E40D149B /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
+		E04DBE4F6644C93F14AA2300 /* ForceDirectedLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F9B461894B21D3A7BDE13D /* ForceDirectedLayout.swift */; };
 		E04EB44BCBE0CEB501618F1A /* FileTreeHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */; };
 		E073657EE87B3F145830B7C7 /* FileTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */; };
 		E2BC69E1121328310B830E45 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
+		E43FF0E92AD9F55B2D8015F1 /* BoardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F80894B4E875FD2C66F14CC /* BoardState.swift */; };
 		E480C69FBC5BB4A7B8474928 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */; };
 		E48B681F8D87180834B92C57 /* InlineEditField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC5F0D37085813890268537 /* InlineEditField.swift */; };
 		E4A2887CDB5EDB64080E5096 /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
@@ -220,26 +298,36 @@
 		E531C3FF51386D03BCE33EC7 /* FloatPopupState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EF5FFAD8310BD41CF784AC /* FloatPopupState.swift */; };
 		E5CE1B3EBAABD914418D892F /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C26E064D810299C0302F439 /* EditorView.swift */; };
 		E6B945D114487F6BD18ADD31 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
+		E875D0158B461B4B2FA4BEF7 /* CompletionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */; };
+		E93CE7A76DFFE33E52603B3A /* CompletionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA9C2BB0C840BE88B0FEA52 /* CompletionState.swift */; };
 		E9EB891ABF924F99E6418BF7 /* ExtensionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836BA390DF0C2A711D270D2C /* ExtensionOverlayView.swift */; };
+		EAB3B23E6209C12EE042F2DE /* ExtensionPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D54D0AA54F1EC07318AEA /* ExtensionPanelState.swift */; };
 		EACCC33CD56D244D5A8B30B3 /* FloatPopupState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EF5FFAD8310BD41CF784AC /* FloatPopupState.swift */; };
 		EAD04948D33D0D96FBEC823B /* ExtensionOverlayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F88438F21DF56F11861F9 /* ExtensionOverlayState.swift */; };
 		ECE870F634AC4B097DA300AC /* PortLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E23DC6E0ACB156F21293E87 /* PortLogger.swift */; };
 		ED8D3D1F950A66E95AA3093F /* SidebarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452AAEF9518FDDF1FF8F51B0 /* SidebarContainer.swift */; };
 		EDBFAF45FE82A4C26D697C3A /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912C5F808709BABFF3126DEE /* AppearanceSettingsView.swift */; };
+		EDF324B672242133466CDF07 /* ObservatoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB89E1589D78EC2BACA5D892 /* ObservatoryView.swift */; };
 		EE84DA1BF4952359DD0DC343 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
 		F0A2BCCA095F1CA4FBE9BE3F /* ProtocolSchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */; };
+		F0E9AA2B588208E262850DBE /* TextHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA1A468192F9DE2BBF374DD /* TextHighlighting.swift */; };
 		F10D75F20F483BDE7DC2A9B3 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912C5F808709BABFF3126DEE /* AppearanceSettingsView.swift */; };
 		F12D6284209D6D32037E6644 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
 		F1378E2C42C8B6151925EB62 /* ObservatoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB89E1589D78EC2BACA5D892 /* ObservatoryView.swift */; };
 		F16FDEC1BFC1776B1109622E /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7C3564C27A7E14D894539 /* TabBarView.swift */; };
+		F318B2BFA81A36DFBED83F72 /* WorkspaceHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */; };
 		F3BB64E36F257BD7FACEA5D6 /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
 		F560D385A1FB0A46824F7B1F /* PickerOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F606681DE9AA9D502A42AA /* PickerOverlay.swift */; };
 		F5DA741E5CBCF22184C6C712 /* ProtocolTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */; };
 		F6F56719C285CB9C3EA62A57 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5647A59C841B3C408994CC7 /* Assets.xcassets */; };
+		F73BC19318B2FB4D1BBC01CB /* SidebarHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */; };
 		FA582944CD6B90BCABC13FCE /* ProtocolReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */; };
 		FA9C31900696A16D89169788 /* PickerOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F606681DE9AA9D502A42AA /* PickerOverlay.swift */; };
+		FB4751A388688E9EE9660F73 /* EditTimelineState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2E999D82FCC18364568E8B /* EditTimelineState.swift */; };
 		FEA7FDF0B8C5551790872FCA /* WindowContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */; };
+		FEB87AA6E7F2A85E3501428E /* ToolManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */; };
 		FEFCEFCDC21C5AA5456036D0 /* SystemColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B00002D020FED57D265C74 /* SystemColorTests.swift */; };
+		FF130EAE4EE79572E838C1C9 /* HoverPopupState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66E4E27BE182768B01E5F64 /* HoverPopupState.swift */; };
 		FFA8B5D73FABC2792F4A3589 /* ProtocolDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */; };
 		FFD7846D402AD24F56BDC5A0 /* ObservatoryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1421FF1F017E45A031AF18 /* ObservatoryState.swift */; };
 /* End PBXBuildFile section */
@@ -263,10 +351,12 @@
 		1AC5F0D37085813890268537 /* InlineEditField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineEditField.swift; sourceTree = "<group>"; };
 		1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewTests.swift; sourceTree = "<group>"; };
 		1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderButton.swift; sourceTree = "<group>"; };
+		1D3FC97A5BF803712978AB67 /* NotificationCenterView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = NotificationCenterView.png; sourceTree = "<group>"; };
 		211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollAccumulatorTests.swift; sourceTree = "<group>"; };
 		22420E1CC772DAFB9A5043C2 /* ViewModelComputedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelComputedTests.swift; sourceTree = "<group>"; };
 		23EF5FFAD8310BD41CF784AC /* FloatPopupState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatPopupState.swift; sourceTree = "<group>"; };
 		25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolOpcodes.generated.swift; sourceTree = "<group>"; };
+		26134C841A15020D9C61E4F9 /* PreviewHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PreviewHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		26C02007D4036FC9C7D0FB71 /* SettingsStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStateTests.swift; sourceTree = "<group>"; };
 		2812AE57C17D25D125076FA3 /* ChangeSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryView.swift; sourceTree = "<group>"; };
 		2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMEComposition.swift; sourceTree = "<group>"; };
@@ -295,6 +385,7 @@
 		4BC98120D82BD7548347875E /* FontFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFace.swift; sourceTree = "<group>"; };
 		4C874A0099721763D5109D99 /* BoardTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTypes.swift; sourceTree = "<group>"; };
 		4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MingaWindow.swift; sourceTree = "<group>"; };
+		4DB8CFA9B73750AD34E77A0C /* StatusBarView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = StatusBarView.png; sourceTree = "<group>"; };
 		52F606681DE9AA9D502A42AA /* PickerOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerOverlay.swift; sourceTree = "<group>"; };
 		53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Instrumentation.swift; sourceTree = "<group>"; };
 		5458552EC58E44C7CD15A98A /* FileTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeView.swift; sourceTree = "<group>"; };
@@ -313,6 +404,7 @@
 		6BCD60250752188DDE054B12 /* ObservatoryGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservatoryGraphView.swift; sourceTree = "<group>"; };
 		70D5765529645C5D860576B7 /* WhichKeyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyState.swift; sourceTree = "<group>"; };
 		73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceIconPicker.swift; sourceTree = "<group>"; };
+		74F5BDC126D824CD2C499359 /* FileTreeView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = FileTreeView.png; sourceTree = "<group>"; };
 		754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIChromeDecoderTests.swift; sourceTree = "<group>"; };
 		77BBC8154E1D48CE215F2F25 /* SettingsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsState.swift; sourceTree = "<group>"; };
 		790F7E20F30FEEFC552B3685 /* WindowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContent.swift; sourceTree = "<group>"; };
@@ -328,6 +420,7 @@
 		912C5F808709BABFF3126DEE /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		92C0836F0D4150126F181C05 /* PickerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerState.swift; sourceTree = "<group>"; };
 		9958CDCF40B9580E12AD1A81 /* SparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparklineView.swift; sourceTree = "<group>"; };
+		9978FBBB4E1BC671AF1C49F5 /* PreviewHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHostApp.swift; sourceTree = "<group>"; };
 		9B1421FF1F017E45A031AF18 /* ObservatoryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservatoryState.swift; sourceTree = "<group>"; };
 		9E27E6D9ACEB7DCD7F98FB0F /* PowerThermalPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerThermalPolicyTests.swift; sourceTree = "<group>"; };
 		9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotAllocatorTests.swift; sourceTree = "<group>"; };
@@ -363,6 +456,7 @@
 		CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyOverlay.swift; sourceTree = "<group>"; };
 		CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbBar.swift; sourceTree = "<group>"; };
 		D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusHeaderContent.swift; sourceTree = "<group>"; };
+		D17B2A4D2BADE64E249073E1 /* PreviewRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewRegistry.swift; sourceTree = "<group>"; };
 		D2D59D9EEB390C8DF351D595 /* FrameState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameState.swift; sourceTree = "<group>"; };
 		D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowView.swift; sourceTree = "<group>"; };
 		DD14027C8C7BD17057DE820B /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
@@ -370,7 +464,9 @@
 		E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryManagerTests.swift; sourceTree = "<group>"; };
 		E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatState.swift; sourceTree = "<group>"; };
 		E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIActionEncoderTests.swift; sourceTree = "<group>"; };
+		E446B783B6308E4878B80018 /* TabBarView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TabBarView.png; sourceTree = "<group>"; };
 		E892F827AFBE959F9DF25C05 /* StatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarView.swift; sourceTree = "<group>"; };
+		E8BEF10DDD749FBA592D2D0E /* GitStatusView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = GitStatusView.png; sourceTree = "<group>"; };
 		ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolManagerView.swift; sourceTree = "<group>"; };
 		EF3D54D0AA54F1EC07318AEA /* ExtensionPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPanelState.swift; sourceTree = "<group>"; };
 		F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorsTests.swift; sourceTree = "<group>"; };
@@ -379,6 +475,7 @@
 		F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceState.swift; sourceTree = "<group>"; };
 		F5647A59C841B3C408994CC7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMECompositionTests.swift; sourceTree = "<group>"; };
+		F9437DDA1ADDABFCEAF93E1B /* CompletionOverlay.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CompletionOverlay.png; sourceTree = "<group>"; };
 		FD66FBCBFC20D50D22A969C8 /* SymbolsNerdFontMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SymbolsNerdFontMono-Regular.ttf"; sourceTree = "<group>"; };
 		FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -467,6 +564,7 @@
 			isa = PBXGroup;
 			children = (
 				EF010AC81BF7F66D126A242B /* MingaTests */,
+				F2B8C36C4AA18B066018A6D0 /* Snapshots */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -586,6 +684,8 @@
 				53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */,
 				4A647814918768E62822D4A1 /* MingaApp.swift */,
 				B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */,
+				9978FBBB4E1BC671AF1C49F5 /* PreviewHostApp.swift */,
+				D17B2A4D2BADE64E249073E1 /* PreviewRegistry.swift */,
 				4AACF7C989E8FDB12B3EC840 /* Font */,
 				BE05074760AA9D5983E99402 /* Protocol */,
 				0AA3147316DFBDDC375B279C /* Recovery */,
@@ -633,6 +733,7 @@
 			children = (
 				B9B4DF5FEB6C8DFCA427A692 /* Minga.app */,
 				64CEFB02A774E5E8EF19029F /* MingaTests.xctest */,
+				26134C841A15020D9C61E4F9 /* PreviewHost.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -673,6 +774,19 @@
 			path = MingaTests;
 			sourceTree = "<group>";
 		};
+		F2B8C36C4AA18B066018A6D0 /* Snapshots */ = {
+			isa = PBXGroup;
+			children = (
+				F9437DDA1ADDABFCEAF93E1B /* CompletionOverlay.png */,
+				74F5BDC126D824CD2C499359 /* FileTreeView.png */,
+				E8BEF10DDD749FBA592D2D0E /* GitStatusView.png */,
+				1D3FC97A5BF803712978AB67 /* NotificationCenterView.png */,
+				4DB8CFA9B73750AD34E77A0C /* StatusBarView.png */,
+				E446B783B6308E4878B80018 /* TabBarView.png */,
+			);
+			path = Snapshots;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -682,6 +796,7 @@
 			buildPhases = (
 				77AE57735A00C26BF1B3675A /* Generate protocol opcodes */,
 				C8F3C47EE52117DADE97B9F9 /* Sources */,
+				AC030320698C86167111D422 /* Resources */,
 				055B5DD060ABF986C99376D6 /* Frameworks */,
 			);
 			buildRules = (
@@ -695,6 +810,24 @@
 			productName = MingaTests;
 			productReference = 64CEFB02A774E5E8EF19029F /* MingaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		AD057EA18D39D4B97E8AE743 /* PreviewHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F541977CFF8D668ECB697168 /* Build configuration list for PBXNativeTarget "PreviewHost" */;
+			buildPhases = (
+				32E4BD311DB3937B26DEE906 /* Generate protocol opcodes */,
+				3B2D9C9C9EC032BA12E6F535 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PreviewHost;
+			packageProductDependencies = (
+			);
+			productName = PreviewHost;
+			productReference = 26134C841A15020D9C61E4F9 /* PreviewHost.app */;
+			productType = "com.apple.product-type.application";
 		};
 		D96277718552247F338DD197 /* Minga */ = {
 			isa = PBXNativeTarget;
@@ -747,11 +880,25 @@
 			targets = (
 				D96277718552247F338DD197 /* Minga */,
 				2734C1C657DD572768745C3F /* MingaTests */,
+				AD057EA18D39D4B97E8AE743 /* PreviewHost */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		AC030320698C86167111D422 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AF0877EE13E581DD7B20FA39 /* CompletionOverlay.png in Resources */,
+				644651957542041BB07F6819 /* FileTreeView.png in Resources */,
+				C2B552F09F4C033A34651A89 /* GitStatusView.png in Resources */,
+				A2248AB663ACECA334695D9C /* NotificationCenterView.png in Resources */,
+				7F5AEBE16F765D8163F7D8A9 /* StatusBarView.png in Resources */,
+				90DDED0067C36E07960445C9 /* TabBarView.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F708F0C1577DD5141846EFB7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -764,6 +911,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		32E4BD311DB3937B26DEE906 /* Generate protocol opcodes */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Generate protocol opcodes";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/.generated/protocol/ProtocolOpcodes.generated.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd \"${SRCROOT}/..\"\nif ! command -v mix >/dev/null 2>&1; then\n  echo \"error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen\"\n  exit 1\nfi\nmix protocol.gen\n";
+		};
 		658E1AB9C3D7AAE877712688 /* Generate protocol opcodes */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -952,6 +1119,95 @@
 				8C9C3976E598C7F553B003B6 /* WorkspaceHeaderView.swift in Sources */,
 				A0351D1D024158F048BA1C25 /* WorkspaceIconPicker.swift in Sources */,
 				A860586A88D34A562CAC0CBF /* WorkspaceState.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3B2D9C9C9EC032BA12E6F535 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9303B34232153C61D709B7D6 /* ActivityBar.swift in Sources */,
+				AD9123932ACE42FBAB6B0DD7 /* AgentChatState.swift in Sources */,
+				29F85C6901F01EF4E93DFC72 /* AgentChatView.swift in Sources */,
+				80EB118387A9EA307762F482 /* AgentContextBar.swift in Sources */,
+				5CD18EDFFAE3324309FD507B /* AgentContextBarState.swift in Sources */,
+				348D61FC49B7A42CE6CFEC21 /* AppearanceSettingsView.swift in Sources */,
+				D02E680B4D50D6ABA6264D8F /* BlinkingCursor.swift in Sources */,
+				E43FF0E92AD9F55B2D8015F1 /* BoardState.swift in Sources */,
+				DC3640DCFB66764CEEA3D503 /* BoardTypes.swift in Sources */,
+				345C57CB549A765B0F788C4B /* BoardView.swift in Sources */,
+				1BED638F0EE72345B63FA3E2 /* BottomPanelState.swift in Sources */,
+				279CEBE1AD001C3AFD74E285 /* BottomPanelView.swift in Sources */,
+				3DB25E7E934FAAD7A7B51084 /* BreadcrumbBar.swift in Sources */,
+				7710CE0EB136EB58DF5AC519 /* ChangeSummaryState.swift in Sources */,
+				1F5CF0197B6C4F28D6169DA2 /* ChangeSummaryView.swift in Sources */,
+				E875D0158B461B4B2FA4BEF7 /* CompletionOverlay.swift in Sources */,
+				E93CE7A76DFFE33E52603B3A /* CompletionState.swift in Sources */,
+				A084A045EA71D390C188EB23 /* DispatchSheetState.swift in Sources */,
+				DD78E8B97A78A84587C0F461 /* DispatchSheetView.swift in Sources */,
+				FB4751A388688E9EE9660F73 /* EditTimelineState.swift in Sources */,
+				73F8F631B3B7DF3EE9159913 /* EditTimelineView.swift in Sources */,
+				107A3231D5F372CB917A07C0 /* EditorSettingsView.swift in Sources */,
+				D4B0BBB40180CD15FEB0FB75 /* ExtensionOverlayState.swift in Sources */,
+				8320D5A4779EE1EF37A54477 /* ExtensionOverlayView.swift in Sources */,
+				EAB3B23E6209C12EE042F2DE /* ExtensionPanelState.swift in Sources */,
+				04DCD757C3C296EDE15973C8 /* ExtensionPanelView.swift in Sources */,
+				3B7E389A35ADF448C5588469 /* FileTreeHeaderContent.swift in Sources */,
+				CC8B2D0174D3E5839980702C /* FileTreeRowView.swift in Sources */,
+				A1F7FEEEDE79E743506763C7 /* FileTreeState.swift in Sources */,
+				630D7B1922CBCCF1335491C2 /* FileTreeView.swift in Sources */,
+				0BFC2F3292E5954F350C5BA8 /* FloatPopupOverlay.swift in Sources */,
+				A96BC7EA2756D8AB18D45970 /* FloatPopupState.swift in Sources */,
+				E04DBE4F6644C93F14AA2300 /* ForceDirectedLayout.swift in Sources */,
+				3897BF151EA81DDF38B85047 /* GUIState.swift in Sources */,
+				B4AA8AEC6D3ED269B8860786 /* GitStatusHeaderContent.swift in Sources */,
+				1D2AE6CCA8AEE36DA0731D7B /* GitStatusState.swift in Sources */,
+				6A52456182D34DA5C6D0525C /* GitStatusView.swift in Sources */,
+				333C467F77C10315777C85D2 /* HoverPopupOverlay.swift in Sources */,
+				FF130EAE4EE79572E838C1C9 /* HoverPopupState.swift in Sources */,
+				806AF50CBA2A30F3DFCB10CF /* IMEComposition.swift in Sources */,
+				BB1ABD615278289735DE85E9 /* InlineEditField.swift in Sources */,
+				6691CAB367FB0BA9821C79E5 /* KeybindingsSettingsView.swift in Sources */,
+				63AD77F5D54E43D9376810DC /* MessagesContentState.swift in Sources */,
+				B33F3F024CB62AFB86A64504 /* MessagesContentView.swift in Sources */,
+				82774DBCD8FBAC9FD32822F4 /* MinibufferState.swift in Sources */,
+				BF0E0A565CC791E8C2C8AC74 /* MinibufferView.swift in Sources */,
+				5C92C1B998EE5612AC84FBF5 /* NotificationCenterState.swift in Sources */,
+				AAB03F4B2310094FED82D15E /* NotificationCenterView.swift in Sources */,
+				57FEBE6C32520DFD357D0B94 /* ObservatoryGraphView.swift in Sources */,
+				870591324FCC1AD0BBCECCDA /* ObservatoryState.swift in Sources */,
+				EDF324B672242133466CDF07 /* ObservatoryView.swift in Sources */,
+				55399D2B1E4C5EBE632D7EBC /* PickerOverlay.swift in Sources */,
+				8B836B6CADA9E21721BAD96C /* PickerState.swift in Sources */,
+				70BAD234EF40359C5703FAAA /* PortLogger.swift in Sources */,
+				077AF22C34E2851B1F975C78 /* PreviewHostApp.swift in Sources */,
+				619712AD984E8EA2ED68AE2C /* PreviewRegistry.swift in Sources */,
+				78644398F50FDB9206F731CB /* ProtocolConstants.swift in Sources */,
+				72CC62FDCBD531FEFE4D07DF /* ProtocolDecoder.swift in Sources */,
+				A4E838B0B19ED0B8F9CC4654 /* ProtocolEncoder.swift in Sources */,
+				6AFA24DC3EE21023636C136A /* ProtocolOpcodes.generated.swift in Sources */,
+				4451B7F61D8FB50D964406A0 /* ProtocolReader.swift in Sources */,
+				719318748BDDAEBE10DFBB2E /* ProtocolTypes.swift in Sources */,
+				DBB1CFFF8301A15D950AD07F /* ScrollAccumulator.swift in Sources */,
+				D0CB0737618AFEEE2EC8CE60 /* SettingsState.swift in Sources */,
+				88A182018706D04CCE8973A6 /* SidebarContainer.swift in Sources */,
+				F73BC19318B2FB4D1BBC01CB /* SidebarHeaderButton.swift in Sources */,
+				2FD4D85B9612CA458246F06E /* SignatureHelpOverlay.swift in Sources */,
+				A74761E8F6B3FD1D0CFA1521 /* SignatureHelpState.swift in Sources */,
+				668FB5D322D50EAFD1C878F0 /* SparklineView.swift in Sources */,
+				DF9EDB44B49C0D61E40D149B /* StatusBarView.swift in Sources */,
+				9493C0265F69C3D588ACC37B /* TabBarState.swift in Sources */,
+				DE495CCFC92C702B2A3243A0 /* TabBarView.swift in Sources */,
+				F0E9AA2B588208E262850DBE /* TextHighlighting.swift in Sources */,
+				03FEC8AC31DA3A2806822AA6 /* ThemeColors.swift in Sources */,
+				842216C3AEC642569725698F /* ToolManagerState.swift in Sources */,
+				FEB87AA6E7F2A85E3501428E /* ToolManagerView.swift in Sources */,
+				17C035AC7105BA405786AE3E /* WhichKeyOverlay.swift in Sources */,
+				B7CC10FD96E51A293C3D4920 /* WhichKeyState.swift in Sources */,
+				75836AA3D1FB27575C00755A /* WindowContent.swift in Sources */,
+				F318B2BFA81A36DFBED83F72 /* WorkspaceHeaderView.swift in Sources */,
+				6248B6BA1BF78DA0E364F9A3 /* WorkspaceIconPicker.swift in Sources */,
+				B9AC7DFF11C810A393597F9F /* WorkspaceState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1270,6 +1526,40 @@
 			};
 			name = Debug;
 		};
+		C5B502E3F40C86CA7B214228 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.minga.preview-host";
+				PRODUCT_NAME = PreviewHost;
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		EAD90A4CDF900B7020964411 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.minga.preview-host";
+				PRODUCT_NAME = PreviewHost;
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Release;
+		};
 		EFFA4244638F481E66EE8F95 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1316,6 +1606,15 @@
 			buildConfigurations = (
 				9DD36755A82F358FF8E42F34 /* Debug */,
 				3DFDCCCABE804CEC45ADD300 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		F541977CFF8D668ECB697168 /* Build configuration list for PBXNativeTarget "PreviewHost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C5B502E3F40C86CA7B214228 /* Debug */,
+				EAD90A4CDF900B7020964411 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/macos/Minga.xcodeproj/xcshareddata/xcschemes/PreviewHost.xcscheme
+++ b/macos/Minga.xcodeproj/xcshareddata/xcschemes/PreviewHost.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AD057EA18D39D4B97E8AE743"
+               BuildableName = "PreviewHost.app"
+               BlueprintName = "PreviewHost"
+               ReferencedContainer = "container:Minga.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AD057EA18D39D4B97E8AE743"
+            BuildableName = "PreviewHost.app"
+            BlueprintName = "PreviewHost"
+            ReferencedContainer = "container:Minga.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AD057EA18D39D4B97E8AE743"
+            BuildableName = "PreviewHost.app"
+            BlueprintName = "PreviewHost"
+            ReferencedContainer = "container:Minga.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AD057EA18D39D4B97E8AE743"
+            BuildableName = "PreviewHost.app"
+            BlueprintName = "PreviewHost"
+            ReferencedContainer = "container:Minga.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/macos/Sources/PreviewHostApp.swift
+++ b/macos/Sources/PreviewHostApp.swift
@@ -1,0 +1,80 @@
+/// Minimal macOS app that renders one SwiftUI chrome view to a PNG screenshot and exits.
+///
+/// Used by Claude Code to get visual feedback on SwiftUI chrome views
+/// without the BEAM process, Metal renderer, or protocol stack.
+
+import AppKit
+import SwiftUI
+
+@main
+struct PreviewHostApp: App {
+    @NSApplicationDelegateAdaptor(PreviewHostDelegate.self) var delegate
+
+    var body: some Scene {
+        WindowGroup {
+            previewContent()
+                .frame(width: 800, height: 600)
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        delegate.captureAndExit()
+                    }
+                }
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+    }
+
+    @MainActor
+    func previewContent() -> some View {
+        let viewName = ProcessInfo.processInfo.environment["PREVIEW_VIEW"] ?? "StatusBarView"
+        return PreviewRegistry.view(named: viewName)
+    }
+}
+
+@MainActor
+final class PreviewHostDelegate: NSObject, NSApplicationDelegate {
+    func captureAndExit() {
+        guard let window = NSApplication.shared.windows.first,
+              let contentView = window.contentView else {
+            fputs("error: no window or content view found\n", stderr)
+            NSApplication.shared.terminate(nil)
+            return
+        }
+
+        window.orderFrontRegardless()
+        contentView.layoutSubtreeIfNeeded()
+        contentView.display()
+
+        let outputDir = ProcessInfo.processInfo.environment["PREVIEW_OUTPUT_DIR"]
+            ?? "macos/Tests/Snapshots"
+        let viewName = ProcessInfo.processInfo.environment["PREVIEW_VIEW"] ?? "StatusBarView"
+        let outputPath = "\(outputDir)/\(viewName).png"
+
+        let dirURL = URL(fileURLWithPath: outputDir, isDirectory: true)
+        try? FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+
+        let bounds = contentView.bounds
+        guard let bitmap = contentView.bitmapImageRepForCachingDisplay(in: bounds) else {
+            fputs("error: bitmapImageRepForCachingDisplay returned nil\n", stderr)
+            NSApplication.shared.terminate(nil)
+            return
+        }
+        contentView.cacheDisplay(in: bounds, to: bitmap)
+
+        guard let pngData = bitmap.representation(using: .png, properties: [:]) else {
+            fputs("error: PNG encoding failed\n", stderr)
+            NSApplication.shared.terminate(nil)
+            return
+        }
+
+        let outputURL = URL(fileURLWithPath: outputPath)
+        do {
+            try pngData.write(to: outputURL)
+            print(outputPath)
+        } catch {
+            fputs("error: failed to write PNG: \(error)\n", stderr)
+        }
+
+        NSApplication.shared.terminate(nil)
+    }
+}

--- a/macos/Sources/PreviewHostApp.swift
+++ b/macos/Sources/PreviewHostApp.swift
@@ -15,7 +15,9 @@ struct PreviewHostApp: App {
             previewContent()
                 .frame(width: 800, height: 600)
                 .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    // Wait for SwiftUI to finish layout before capturing the window bitmap.
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(500))
                         delegate.captureAndExit()
                     }
                 }
@@ -33,12 +35,15 @@ struct PreviewHostApp: App {
 
 @MainActor
 final class PreviewHostDelegate: NSObject, NSApplicationDelegate {
+    private func fail(_ message: String) -> Never {
+        fputs("error: \(message)\n", stderr)
+        exit(1)
+    }
+
     func captureAndExit() {
         guard let window = NSApplication.shared.windows.first,
               let contentView = window.contentView else {
-            fputs("error: no window or content view found\n", stderr)
-            NSApplication.shared.terminate(nil)
-            return
+            fail("no window or content view found")
         }
 
         window.orderFrontRegardless()
@@ -51,20 +56,20 @@ final class PreviewHostDelegate: NSObject, NSApplicationDelegate {
         let outputPath = "\(outputDir)/\(viewName).png"
 
         let dirURL = URL(fileURLWithPath: outputDir, isDirectory: true)
-        try? FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+        } catch {
+            fail("cannot create output directory: \(error)")
+        }
 
         let bounds = contentView.bounds
         guard let bitmap = contentView.bitmapImageRepForCachingDisplay(in: bounds) else {
-            fputs("error: bitmapImageRepForCachingDisplay returned nil\n", stderr)
-            NSApplication.shared.terminate(nil)
-            return
+            fail("bitmapImageRepForCachingDisplay returned nil")
         }
         contentView.cacheDisplay(in: bounds, to: bitmap)
 
         guard let pngData = bitmap.representation(using: .png, properties: [:]) else {
-            fputs("error: PNG encoding failed\n", stderr)
-            NSApplication.shared.terminate(nil)
-            return
+            fail("PNG encoding failed")
         }
 
         let outputURL = URL(fileURLWithPath: outputPath)
@@ -72,7 +77,7 @@ final class PreviewHostDelegate: NSObject, NSApplicationDelegate {
             try pngData.write(to: outputURL)
             print(outputPath)
         } catch {
-            fputs("error: failed to write PNG: \(error)\n", stderr)
+            fail("failed to write PNG: \(error)")
         }
 
         NSApplication.shared.terminate(nil)

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -1,7 +1,4 @@
 /// Maps view names to constructed SwiftUI chrome views with mock state.
-///
-/// Each preview builds its state using the same patterns proven in
-/// SwiftUIViewTests.swift and SidebarViewTests.swift.
 
 import SwiftUI
 
@@ -201,13 +198,14 @@ enum PreviewRegistry {
     private static func notificationPreview() -> some View {
         let state = NotificationCenterState()
         let theme = populatedTheme()
+        let now = UInt64(Date().timeIntervalSince1970)
         state.update(rawNotifications: [
             Wire.EditorNotification(
                 id: "notif-1",
                 level: .info,
                 flags: 0x01,
-                createdAt: UInt64(Date().timeIntervalSince1970),
-                updatedAt: UInt64(Date().timeIntervalSince1970),
+                createdAt: now,
+                updatedAt: now,
                 autoDismissMs: nil,
                 title: "Extension loaded",
                 body: "org-mode v0.3.0 activated for .org files",

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -1,0 +1,274 @@
+/// Maps view names to constructed SwiftUI chrome views with mock state.
+///
+/// Each preview builds its state using the same patterns proven in
+/// SwiftUIViewTests.swift and SidebarViewTests.swift.
+
+import SwiftUI
+
+@MainActor
+enum PreviewRegistry {
+
+    /// Returns a preview for the named view, or an error label for unknown names.
+    @ViewBuilder
+    static func view(named name: String) -> some View {
+        switch name {
+        case "GitStatusView":
+            gitStatusPreview()
+        case "FileTreeView":
+            fileTreePreview()
+        case "CompletionOverlay":
+            completionPreview()
+        case "StatusBarView":
+            statusBarPreview()
+        case "TabBarView":
+            tabBarPreview()
+        case "NotificationCenterView":
+            notificationPreview()
+        default:
+            Text("Unknown view: \(name)")
+                .font(.title)
+                .foregroundStyle(.red)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // MARK: - GitStatusView
+
+    private static func gitStatusPreview() -> some View {
+        let state = GitStatusState()
+        let theme = populatedTheme()
+        state.update(
+            repoState: .normal,
+            branchName: "feat/preview-host",
+            ahead: 2,
+            behind: 0,
+            syncing: false,
+            entries: [
+                GitStatusEntry(pathHash: 1, section: .staged, status: .modified, path: "lib/minga/editor.ex"),
+                GitStatusEntry(pathHash: 2, section: .staged, status: .added, path: "lib/minga/preview.ex"),
+                GitStatusEntry(pathHash: 3, section: .staged, status: .deleted, path: "lib/minga/old_module.ex"),
+                GitStatusEntry(pathHash: 4, section: .changed, status: .modified, path: "lib/minga/buffer/document.ex"),
+                GitStatusEntry(pathHash: 5, section: .changed, status: .modified, path: "test/minga/editor_test.exs"),
+                GitStatusEntry(pathHash: 6, section: .untracked, status: .untracked, path: "lib/minga/new_feature.ex"),
+            ],
+            toast: nil,
+            entryBasePath: "/Users/dev/code/minga",
+            lastCommitMessage: "feat(editor): add preview host target",
+            stashCount: 1
+        )
+
+        return GitStatusView(state: state, theme: theme, encoder: nil)
+            .frame(width: 280, height: 600)
+            .background(theme.treeBg)
+    }
+
+    // MARK: - FileTreeView
+
+    private static func fileTreePreview() -> some View {
+        let theme = populatedTheme()
+        let entries = fileTreeEntries()
+
+        // Render FileTreeRowView directly in a VStack instead of through
+        // FileTreeView, because FileTreeView uses LazyVStack inside ScrollView
+        // which renders zero rows in offscreen/ImageRenderer capture.
+        return VStack(spacing: 0) {
+            ForEach(entries) { entry in
+                FileTreeRowView(
+                    entry: entry,
+                    theme: theme,
+                    rowHeight: 22,
+                    indentWidth: 14,
+                    chevronWidth: 12,
+                    isHovered: false,
+                    isDropTarget: false,
+                    animDuration: 0,
+                    onActivate: {},
+                    onEditCommit: { _ in },
+                    onEditCancel: {}
+                )
+            }
+            Spacer()
+        }
+        .frame(width: 280, height: 600)
+        .background(theme.treeBg)
+    }
+
+    private static func fileTreeEntries() -> [FileTreeEntry] {
+        let raw = [
+            wireFileEntry(id: "lib", name: "lib", path: "/Users/dev/code/minga/lib", relPath: "lib", isDir: true, isExpanded: true, depth: 0, icon: ""),
+            wireFileEntry(id: "lib/minga", name: "minga", path: "/Users/dev/code/minga/lib/minga", relPath: "lib/minga", isDir: true, isExpanded: true, depth: 1, icon: ""),
+            wireFileEntry(id: "lib/minga/editor.ex", name: "editor.ex", path: "/Users/dev/code/minga/lib/minga/editor.ex", relPath: "lib/minga/editor.ex", isDir: false, depth: 2, icon: "", isActive: true, gitStatus: 1),
+            wireFileEntry(id: "lib/minga/buffer.ex", name: "buffer.ex", path: "/Users/dev/code/minga/lib/minga/buffer.ex", relPath: "lib/minga/buffer.ex", isDir: false, depth: 2, icon: "", isDirty: true),
+            wireFileEntry(id: "lib/minga/mode", name: "mode", path: "/Users/dev/code/minga/lib/minga/mode", relPath: "lib/minga/mode", isDir: true, isExpanded: false, depth: 2, icon: ""),
+            wireFileEntry(id: "test", name: "test", path: "/Users/dev/code/minga/test", relPath: "test", isDir: true, isExpanded: false, depth: 0, icon: "", isLastChild: true),
+        ]
+        return raw.enumerated().map { index, wire in
+            FileTreeEntry(
+                id: wire.id, pathHash: wire.pathHash, index: index,
+                isDir: wire.isDir, isExpanded: wire.isExpanded,
+                isSelected: wire.isSelected, isFocused: wire.isFocused,
+                isActive: wire.isActive, isDirty: wire.isDirty,
+                isEditing: wire.isEditing, isLastChild: wire.isLastChild,
+                depth: Int(wire.depth), gitStatus: wire.gitStatus,
+                diagnosticErrorCount: wire.diagnosticErrorCount,
+                diagnosticWarningCount: wire.diagnosticWarningCount,
+                diagnosticInfoCount: wire.diagnosticInfoCount,
+                diagnosticHintCount: wire.diagnosticHintCount,
+                guides: wire.guides, icon: wire.icon,
+                name: wire.name, relPath: wire.relPath, path: wire.path,
+                editingType: wire.editingType, editingText: wire.editingText
+            )
+        }
+    }
+
+    // MARK: - CompletionOverlay
+
+    private static func completionPreview() -> some View {
+        let state = CompletionState()
+        let theme = populatedTheme()
+        state.update(
+            visible: true, anchorRow: 5, anchorCol: 10, selectedIndex: 1,
+            rawItems: [
+                Wire.CompletionItem(kind: 6, label: "defmodule", detail: "keyword"),
+                Wire.CompletionItem(kind: 6, label: "defstruct", detail: "keyword"),
+                Wire.CompletionItem(kind: 6, label: "defdelegate", detail: "keyword"),
+                Wire.CompletionItem(kind: 2, label: "def", detail: "keyword"),
+                Wire.CompletionItem(kind: 1, label: "Document", detail: "Minga.Buffer.Document"),
+            ]
+        )
+
+        return CompletionOverlay(state: state, theme: theme, encoder: nil)
+            .frame(width: 400, height: 300)
+            .background(theme.editorBg)
+    }
+
+    // MARK: - StatusBarView
+
+    private static func statusBarPreview() -> some View {
+        let state = StatusBarState()
+        let theme = populatedTheme()
+
+        let leftSegments = [
+            Wire.StatusBarSegment(id: 0, kind: "mode", text: " NORMAL ", fgColor: 0x000000, bgColor: 0x7AA2F7, attrs: 1, command: ""),
+            Wire.StatusBarSegment(id: 1, kind: "git", text: " main ", fgColor: 0xBB9AF7, bgColor: 0x000000, attrs: 0, command: "git_branch_picker"),
+            Wire.StatusBarSegment(id: 2, kind: "filename", text: " editor.ex [+] ", fgColor: 0xC0CAF5, bgColor: 0x000000, attrs: 0, command: "buffer_list"),
+        ]
+        let rightSegments = [
+            Wire.StatusBarSegment(id: 0, kind: "diagnostics", text: " 0 ", fgColor: 0xF7768E, bgColor: 0x000000, attrs: 0, command: "diagnostic_list"),
+            Wire.StatusBarSegment(id: 1, kind: "diagnostics", text: " 2 ", fgColor: 0xE0AF68, bgColor: 0x000000, attrs: 0, command: "diagnostic_list"),
+            Wire.StatusBarSegment(id: 2, kind: "filetype", text: " Elixir ", fgColor: 0xC0CAF5, bgColor: 0x000000, attrs: 0, command: "set_language"),
+            Wire.StatusBarSegment(id: 3, kind: "position", text: " Ln 42, Col 9 ", fgColor: 0xC0CAF5, bgColor: 0x000000, attrs: 0, command: "goto_line"),
+        ]
+
+        state.update(from: StatusBarUpdate(
+            contentKind: 0, mode: 0, cursorLine: 42, cursorCol: 9,
+            lineCount: 1250, flags: 0x02, lspStatus: 1, gitBranch: "main",
+            message: "", filetype: "elixir", errorCount: 0, warningCount: 2,
+            modelName: "", messageCount: 0, sessionStatus: 0,
+            infoCount: 0, hintCount: 0, macroRecording: 0, parserStatus: 1, agentStatus: 0,
+            activeToolName: "",
+            gitAdded: 0, gitModified: 0, gitDeleted: 0,
+            icon: "", iconColorR: 0x88, iconColorG: 0x57, iconColorB: 0xA6, filename: "editor.ex", diagnosticHint: "",
+            backgroundSubagentCount: 0, backgroundSubagentLabel: "",
+            modelineLeftSegments: leftSegments,
+            modelineRightSegments: rightSegments
+        ))
+
+        return StatusBarView(state: state, theme: theme, encoder: nil)
+            .frame(width: 800, height: 28)
+            .background(theme.editorBg)
+    }
+
+    // MARK: - TabBarView
+
+    private static func tabBarPreview() -> some View {
+        let state = TabBarState()
+        let theme = populatedTheme()
+        state.update(activeIndex: 1, entries: [
+            Wire.TabEntry(id: 1, groupId: 0, isActive: false, isDirty: true, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: true, tintColorRGB: 0, icon: "", label: "editor.ex"),
+            Wire.TabEntry(id: 2, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "buffer.ex"),
+            Wire.TabEntry(id: 3, groupId: 0, isActive: false, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "document.ex"),
+            Wire.TabEntry(id: 4, groupId: 0, isActive: false, isDirty: true, isAgent: false, hasAttention: true, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "mode.ex"),
+        ])
+
+        return TabBarView(tabBarState: state, theme: theme, encoder: nil)
+            .frame(width: 800, height: 36)
+            .background(theme.editorBg)
+    }
+
+    // MARK: - NotificationCenterView
+
+    private static func notificationPreview() -> some View {
+        let state = NotificationCenterState()
+        let theme = populatedTheme()
+        state.update(rawNotifications: [
+            Wire.EditorNotification(
+                id: "notif-1",
+                level: .info,
+                flags: 0x01,
+                createdAt: UInt64(Date().timeIntervalSince1970),
+                updatedAt: UInt64(Date().timeIntervalSince1970),
+                autoDismissMs: nil,
+                title: "Extension loaded",
+                body: "org-mode v0.3.0 activated for .org files",
+                source: "Extensions",
+                actions: [
+                    Wire.NotificationAction(id: "configure", label: "Configure"),
+                ]
+            ),
+        ])
+
+        return NotificationCenterView(state: state, theme: theme, encoder: nil, bottomInset: 40)
+            .frame(width: 800, height: 600)
+            .background(theme.editorBg)
+    }
+
+    // MARK: - Helpers
+
+    /// ThemeColors() already initializes with Doom One defaults, which look
+    /// representative for preview screenshots without any BEAM theme push.
+    private static func populatedTheme() -> ThemeColors {
+        ThemeColors()
+    }
+
+    private static func wireFileEntry(
+        id: String,
+        name: String,
+        path: String,
+        relPath: String,
+        isDir: Bool,
+        isExpanded: Bool = false,
+        depth: UInt8,
+        icon: String,
+        isActive: Bool = false,
+        isDirty: Bool = false,
+        isLastChild: Bool = false,
+        gitStatus: UInt8 = 0
+    ) -> Wire.FileTreeEntry {
+        Wire.FileTreeEntry(
+            pathHash: UInt32(id.hashValue & 0x7FFFFFFF),
+            id: id,
+            path: path,
+            isDir: isDir,
+            isExpanded: isExpanded,
+            isSelected: isActive,
+            isFocused: false,
+            isActive: isActive,
+            isDirty: isDirty,
+            isEditing: false,
+            isLastChild: isLastChild,
+            depth: depth,
+            gitStatus: gitStatus,
+            diagnosticErrorCount: 0,
+            diagnosticWarningCount: 0,
+            diagnosticInfoCount: 0,
+            diagnosticHintCount: 0,
+            guides: Array(repeating: false, count: Int(depth)),
+            icon: icon,
+            name: name,
+            relPath: relPath,
+            editingType: 255,
+            editingText: ""
+        )
+    }
+}

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -26,6 +26,9 @@ targets:
     sources:
       - path: Sources
         type: group
+        excludes:
+          - "PreviewHostApp.swift"
+          - "PreviewRegistry.swift"
       - path: .generated/protocol/ProtocolOpcodes.generated.swift
         name: ProtocolOpcodes.generated.swift
         type: file
@@ -82,6 +85,8 @@ targets:
         type: group
         excludes:
           - "MingaApp.swift"
+          - "PreviewHostApp.swift"
+          - "PreviewRegistry.swift"
       - path: .generated/protocol/ProtocolOpcodes.generated.swift
         name: ProtocolOpcodes.generated.swift
         type: file
@@ -102,6 +107,48 @@ targets:
           mix protocol.gen
         basedOnDependencyAnalysis: false
 
+  PreviewHost:
+    type: application
+    platform: macOS
+    sources:
+      - path: Sources/Views
+        type: group
+        excludes:
+          - "EditorNSView.swift"
+          - "EditorView.swift"
+          - "MingaWindow.swift"
+          - "Settings/SettingsView.swift"
+      - path: Sources/Protocol
+        type: group
+      - path: Sources/PreviewHostApp.swift
+        type: file
+      - path: Sources/PreviewRegistry.swift
+        type: file
+      - path: Sources/Renderer/WindowContent.swift
+        type: file
+      - path: .generated/protocol/ProtocolOpcodes.generated.swift
+        name: ProtocolOpcodes.generated.swift
+        type: file
+    settings:
+      base:
+        PRODUCT_NAME: PreviewHost
+        PRODUCT_BUNDLE_IDENTIFIER: com.minga.preview-host
+        GENERATE_INFOPLIST_FILE: "YES"
+        SWIFT_OPTIMIZATION_LEVEL: "-Onone"
+    dependencies: []
+    preBuildScripts:
+      - name: Generate protocol opcodes
+        script: |
+          cd "${SRCROOT}/.."
+          if ! command -v mix >/dev/null 2>&1; then
+            echo "error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen"
+            exit 1
+          fi
+          mix protocol.gen
+        basedOnDependencyAnalysis: false
+        outputFiles:
+          - $(SRCROOT)/.generated/protocol/ProtocolOpcodes.generated.swift
+
 schemes:
   Minga:
     build:
@@ -111,3 +158,7 @@ schemes:
     test:
       targets:
         - MingaTests
+  PreviewHost:
+    build:
+      targets:
+        PreviewHost: all

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -6,7 +6,7 @@
 # Available views: GitStatusView, FileTreeView, CompletionOverlay,
 #                  StatusBarView, TabBarView, NotificationCenterView
 #
-# The script builds the PreviewHost target (fast: no Metal, no BEAM),
+# The script builds the PreviewHost target (fast: no GPU rendering, no BEAM),
 # launches it with the view name, and the app self-captures its window
 # to a PNG before exiting.
 #
@@ -23,7 +23,9 @@ cd "$PROJECT_ROOT"
 
 # Ensure protocol opcodes are generated
 if command -v mix >/dev/null 2>&1; then
-    mix protocol.gen 2>/dev/null || true
+    if ! mix protocol.gen 2>/dev/null; then
+        echo "warning: mix protocol.gen failed; build may use stale opcodes" >&2
+    fi
 fi
 
 # Regenerate Xcode project from project.yml
@@ -31,13 +33,13 @@ cd macos
 xcodegen generate --quiet 2>/dev/null || xcodegen generate
 cd "$PROJECT_ROOT"
 
-# Build PreviewHost (no Metal renderer, no BEAM, fast)
+# Build PreviewHost (no GPU rendering, no BEAM, fast)
 xcodebuild build \
     -project macos/Minga.xcodeproj \
     -scheme PreviewHost \
     -configuration Debug \
     -quiet \
-    2>&1 | grep -v "^$" || true
+    2>&1 | grep -v "^$"
 
 # Find the built app
 BUILD_DIR=$(xcodebuild -project macos/Minga.xcodeproj -scheme PreviewHost -configuration Debug -showBuildSettings 2>/dev/null | grep "^\s*BUILT_PRODUCTS_DIR = " | sed 's/.*= //')
@@ -52,7 +54,7 @@ mkdir -p "$OUTPUT_DIR"
 
 # Launch directly (not via `open`) so environment variables reach the process.
 # The app self-captures its window and exits.
-PREVIEW_VIEW="$VIEW_NAME" PREVIEW_OUTPUT_DIR="$OUTPUT_DIR" "$APP_PATH/Contents/MacOS/PreviewHost" 2>/dev/null || true
+PREVIEW_VIEW="$VIEW_NAME" PREVIEW_OUTPUT_DIR="$OUTPUT_DIR" "$APP_PATH/Contents/MacOS/PreviewHost"
 
 OUTPUT_PATH="$OUTPUT_DIR/${VIEW_NAME}.png"
 

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Renders a single SwiftUI chrome view to a PNG screenshot.
+#
+# Usage: scripts/preview.sh <ViewName>
+#
+# Available views: GitStatusView, FileTreeView, CompletionOverlay,
+#                  StatusBarView, TabBarView, NotificationCenterView
+#
+# The script builds the PreviewHost target (fast: no Metal, no BEAM),
+# launches it with the view name, and the app self-captures its window
+# to a PNG before exiting.
+#
+# Output: macos/Tests/Snapshots/<ViewName>.png
+
+set -euo pipefail
+
+VIEW_NAME="${1:?Usage: scripts/preview.sh <ViewName>}"
+OUTPUT_DIR="macos/Tests/Snapshots"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+# Ensure protocol opcodes are generated
+if command -v mix >/dev/null 2>&1; then
+    mix protocol.gen 2>/dev/null || true
+fi
+
+# Regenerate Xcode project from project.yml
+cd macos
+xcodegen generate --quiet 2>/dev/null || xcodegen generate
+cd "$PROJECT_ROOT"
+
+# Build PreviewHost (no Metal renderer, no BEAM, fast)
+xcodebuild build \
+    -project macos/Minga.xcodeproj \
+    -scheme PreviewHost \
+    -configuration Debug \
+    -quiet \
+    2>&1 | grep -v "^$" || true
+
+# Find the built app
+BUILD_DIR=$(xcodebuild -project macos/Minga.xcodeproj -scheme PreviewHost -configuration Debug -showBuildSettings 2>/dev/null | grep "^\s*BUILT_PRODUCTS_DIR = " | sed 's/.*= //')
+APP_PATH="$BUILD_DIR/PreviewHost.app"
+
+if [ ! -d "$APP_PATH" ]; then
+    echo "error: PreviewHost.app not found at $APP_PATH" >&2
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+# Launch directly (not via `open`) so environment variables reach the process.
+# The app self-captures its window and exits.
+PREVIEW_VIEW="$VIEW_NAME" PREVIEW_OUTPUT_DIR="$OUTPUT_DIR" "$APP_PATH/Contents/MacOS/PreviewHost" 2>/dev/null || true
+
+OUTPUT_PATH="$OUTPUT_DIR/${VIEW_NAME}.png"
+
+if [ -f "$OUTPUT_PATH" ]; then
+    echo "$OUTPUT_PATH"
+else
+    echo "error: screenshot not produced at $OUTPUT_PATH" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds a `PreviewHost` macOS app target in `project.yml` that builds SwiftUI chrome views without BEAM, Metal, or protocol stack
- Adds `scripts/preview.sh` that builds, launches, captures a view as PNG, and outputs the path
- Includes 6 preview configurations: GitStatusView, FileTreeView, CompletionOverlay, StatusBarView, TabBarView, NotificationCenterView
- Claude Code can invoke `scripts/preview.sh <ViewName>` and read the resulting PNG for visual feedback

## Design notes

- Uses NSView `bitmapImageRepForCachingDisplay`/`cacheDisplay` for window capture (CGWindowListCreateImage is unavailable on macOS 26 SDK)
- FileTreeView preview renders `FileTreeRowView` directly in a `VStack` instead of through `FileTreeView`, because `FileTreeView`'s `LazyVStack` inside `ScrollView` renders zero rows in offscreen bitmap capture
- PreviewHost target selectively includes `Sources/Views`, `Sources/Protocol`, and `Sources/Renderer/WindowContent.swift`, excluding files that depend on Metal, AppState, or FontManager

## Test plan

- [x] `xcodebuild build -scheme PreviewHost` succeeds
- [x] `xcodebuild build -scheme Minga` succeeds
- [x] `mix swift.build` succeeds
- [x] All 6 preview views render correct PNGs
- [x] `make lint` passes
- [x] `mix test.llm` passes (8651 tests, 0 failures)

Closes #1931

🤖 Generated with [Claude Code](https://claude.com/claude-code)