### PR TITLE
test(agent): add MemoryWrite tool validation and error handling tests

### DIFF
--- a/lib/minga_agent/tools/memory_write.ex
+++ b/lib/minga_agent/tools/memory_write.ex
@@ -12,14 +12,14 @@ defmodule MingaAgent.Tools.MemoryWrite do
   @doc """
   Appends `text` to the persistent memory file with a timestamp.
   """
-  @spec execute(String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def execute(text) when is_binary(text) do
+  @spec execute(String.t(), String.t() | nil) :: {:ok, String.t()} | {:error, String.t()}
+  def execute(text, config_dir \\ nil) when is_binary(text) do
     text = String.trim(text)
 
     if text == "" do
       {:error, "Memory text cannot be empty"}
     else
-      case Memory.append(text) do
+      case Memory.append(text, config_dir) do
         :ok -> {:ok, "Saved to memory: #{text}"}
         {:error, reason} -> {:error, "Failed to save memory: #{inspect(reason)}"}
       end

--- a/test/minga_agent/tools/memory_write_test.exs
+++ b/test/minga_agent/tools/memory_write_test.exs
@@ -1,0 +1,37 @@
+defmodule MingaAgent.Tools.MemoryWriteTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Memory
+  alias MingaAgent.Tools.MemoryWrite
+
+  @moduletag :tmp_dir
+
+  describe "execute/2" do
+    test "rejects empty string", %{tmp_dir: dir} do
+      assert {:error, "Memory text cannot be empty"} = MemoryWrite.execute("", dir)
+    end
+
+    test "rejects whitespace-only input", %{tmp_dir: dir} do
+      assert {:error, "Memory text cannot be empty"} = MemoryWrite.execute("   \n\t  ", dir)
+    end
+
+    test "saves valid text and confirms it in the memory file", %{tmp_dir: dir} do
+      assert {:ok, "Saved to memory: user prefers tabs"} =
+               MemoryWrite.execute("user prefers tabs", dir)
+
+      content = Memory.read(dir)
+      assert content =~ "user prefers tabs"
+    end
+
+    test "wraps error when the underlying append fails", %{tmp_dir: dir} do
+      readonly_dir = Path.join(dir, "locked")
+      File.mkdir_p!(Path.join(readonly_dir, "minga"))
+      File.chmod!(Path.join(readonly_dir, "minga"), 0o444)
+
+      assert {:error, "Failed to save memory: " <> _reason} =
+               MemoryWrite.execute("should fail", readonly_dir)
+
+      File.chmod!(Path.join(readonly_dir, "minga"), 0o755)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add optional `config_dir` parameter to `MemoryWrite.execute/2` for filesystem isolation in tests, matching the pattern `Memory` already uses
- Add 4 tests covering all acceptance criteria: empty input rejection, whitespace trimming, successful persistence verification, and error wrapping on write failure

Closes #1282

## Test plan

- [x] `mix test.llm test/minga_agent/tools/memory_write_test.exs`: 4 tests, 0 failures
- [x] `mix test.llm test/minga_agent/memory_test.exs`: 11 tests, 0 failures (existing tests unaffected)
- [x] `mix format --check-formatted`: ok
- [x] `make lint`: no new warnings

🤖 Generated with [Claude Code](https://claude.ai/code)