### PR TITLE
test(agent): add isolated tests for Subagent receive-loop state machine

### DIFF
--- a/lib/minga_agent/tools/subagent.ex
+++ b/lib/minga_agent/tools/subagent.ex
@@ -112,14 +112,16 @@ defmodule MingaAgent.Tools.Subagent do
     end
   end
 
+  @doc false
   @spec collect_response(pid()) :: {:ok, String.t()} | {:error, String.t()}
-  defp collect_response(session_pid) do
+  def collect_response(session_pid) do
     collect_response_loop(session_pid, "", @subagent_timeout_ms)
   end
 
+  @doc false
   @spec collect_response_loop(pid(), String.t(), non_neg_integer()) ::
           {:ok, String.t()} | {:error, String.t()}
-  defp collect_response_loop(session_pid, text_acc, timeout) do
+  def collect_response_loop(session_pid, text_acc, timeout) do
     receive do
       {:agent_event, ^session_pid, {:text_delta, delta}} ->
         collect_response_loop(session_pid, text_acc <> delta, timeout)

--- a/test/minga_agent/tools/subagent_receive_loop_test.exs
+++ b/test/minga_agent/tools/subagent_receive_loop_test.exs
@@ -1,0 +1,65 @@
+defmodule MingaAgent.Tools.SubagentReceiveLoopTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Tools.Subagent
+
+  setup do
+    fake_session = spawn(fn -> Process.sleep(:infinity) end)
+    on_exit(fn -> Process.exit(fake_session, :kill) end)
+    %{fake_session: fake_session}
+  end
+
+  test "accumulates multiple text deltas and returns concatenated text on idle", %{
+    fake_session: fake_session
+  } do
+    task = Task.async(fn -> Subagent.collect_response(fake_session) end)
+
+    send(task.pid, {:agent_event, fake_session, {:text_delta, "hello"}})
+    send(task.pid, {:agent_event, fake_session, {:text_delta, " "}})
+    send(task.pid, {:agent_event, fake_session, {:text_delta, "world"}})
+    send(task.pid, {:agent_event, fake_session, {:status_changed, :idle}})
+
+    assert {:ok, "hello world"} = Task.await(task)
+  end
+
+  test "returns placeholder message when idle arrives with no prior deltas", %{
+    fake_session: fake_session
+  } do
+    task = Task.async(fn -> Subagent.collect_response(fake_session) end)
+
+    send(task.pid, {:agent_event, fake_session, {:status_changed, :idle}})
+
+    assert {:ok, "(subagent completed with no text output)"} = Task.await(task)
+  end
+
+  test "returns error tuple when error event arrives", %{fake_session: fake_session} do
+    task = Task.async(fn -> Subagent.collect_response(fake_session) end)
+
+    send(task.pid, {:agent_event, fake_session, {:text_delta, "partial"}})
+    send(task.pid, {:agent_event, fake_session, {:error, "something broke"}})
+
+    assert {:error, "Subagent error: something broke"} = Task.await(task)
+  end
+
+  test "ignores non-text events without affecting accumulated text", %{
+    fake_session: fake_session
+  } do
+    task = Task.async(fn -> Subagent.collect_response(fake_session) end)
+
+    send(task.pid, {:agent_event, fake_session, {:tool_start, %{}}})
+    send(task.pid, {:agent_event, fake_session, {:text_delta, "result"}})
+    send(task.pid, {:agent_event, fake_session, {:thinking, "hmm"}})
+    send(task.pid, {:agent_event, fake_session, {:unknown_event_type, :data}})
+    send(task.pid, {:agent_event, fake_session, {:status_changed, :idle}})
+
+    assert {:ok, "result"} = Task.await(task)
+  end
+
+  test "returns timeout error when no terminal event arrives within the timeout", %{
+    fake_session: fake_session
+  } do
+    task = Task.async(fn -> Subagent.collect_response_loop(fake_session, "", 100) end)
+
+    assert {:error, "Subagent timed out after 300 seconds"} = Task.await(task, 1_000)
+  end
+end


### PR DESCRIPTION
## Summary

- Promotes `collect_response/1` and `collect_response_loop/3` from `defp` to `@doc false def` for direct testability
- Adds 5 isolated tests covering all branches of the receive-loop state machine: text delta accumulation, empty output placeholder, error propagation, non-text event filtering, and timeout behavior
- Tests use `Task.async` + message sending pattern, no Agent.Session or LLM provider infrastructure needed

## Test plan

- [x] `mix test.debug test/minga_agent/tools/subagent_receive_loop_test.exs` — 5 passed
- [x] `make lint` — clean (all warnings pre-existing)
- [x] `mix test.llm` — 8,656 tests, 0 failures

Closes #1281

🤖 Generated with [Claude Code](https://claude.com/claude-code)