### PR TITLE
feat(test): conformance scenarios for registers, macros, and dot repeat

### DIFF
--- a/lib/minga_editor/macro_recorder.ex
+++ b/lib/minga_editor/macro_recorder.ex
@@ -54,6 +54,12 @@ defmodule MingaEditor.MacroRecorder do
 
   def stop_recording(%__MODULE__{} = rec), do: rec
 
+  @doc "Stores a pre-built key sequence in a register."
+  @spec put_macro(t(), String.t(), [key()]) :: t()
+  def put_macro(%__MODULE__{} = rec, register, keys) when is_binary(register) and is_list(keys) do
+    %{rec | registers: Map.put(rec.registers, register, keys)}
+  end
+
   @doc "Returns the stored key sequence for a register, or nil."
   @spec get_macro(t(), String.t()) :: [key()] | nil
   def get_macro(%__MODULE__{registers: regs}, register) do

--- a/test/conformance/dot_repeat_test.exs
+++ b/test/conformance/dot_repeat_test.exs
@@ -36,7 +36,8 @@ defmodule Minga.Conformance.DotRepeatTest do
       compare: @compare,
       tags: [:known_divergence],
       known_divergence: %{
-        reason: "Minga still changes the wrong trailing span for `cw`, compounding on dot repeat.",
+        reason:
+          "Minga still changes the wrong trailing span for `cw`, compounding on dot repeat.",
         failures: [:content, :cursor],
         actual: %{content: "hellowo hello", line: 0, col: 12}
       }
@@ -58,7 +59,8 @@ defmodule Minga.Conformance.DotRepeatTest do
       compare: @compare,
       tags: [:known_divergence],
       known_divergence: %{
-        reason: "Minga still deletes the wrong trailing span for `dw`, count override compounds the error.",
+        reason:
+          "Minga still deletes the wrong trailing span for `dw`, count override compounds the error.",
         failures: [:content],
         actual: %{content: "ive"}
       }
@@ -72,7 +74,8 @@ defmodule Minga.Conformance.DotRepeatTest do
       compare: @compare,
       tags: [:known_divergence],
       known_divergence: %{
-        reason: "Minga indents with 2 spaces instead of Neovim's default tab, and leaves the cursor shifted right.",
+        reason:
+          "Minga indents with 2 spaces instead of Neovim's default tab, and leaves the cursor shifted right.",
         failures: [:content, :cursor],
         actual: %{content: "  one\n  two\nthree", line: 1, col: 4}
       }
@@ -86,7 +89,8 @@ defmodule Minga.Conformance.DotRepeatTest do
       compare: @compare,
       tags: [:known_divergence],
       known_divergence: %{
-        reason: "Neovim inserts a tab on `.` with no prior change in a fresh buffer; Minga treats it as a no-op.",
+        reason:
+          "Neovim inserts a tab on `.` with no prior change in a fresh buffer; Minga treats it as a no-op.",
         failures: [:content],
         actual: %{content: "one two"}
       }

--- a/test/conformance/dot_repeat_test.exs
+++ b/test/conformance/dot_repeat_test.exs
@@ -1,0 +1,109 @@
+defmodule Minga.Conformance.DotRepeatTest do
+  # Conformance tests invoke nvim as an OS process, so they run serially to avoid erl_child_setup EPIPE races.
+  use Minga.Test.ConformanceCase, async: false
+
+  @compare [:content, :cursor, :mode]
+
+  @scenarios [
+    %{
+      name: "dot repeats dw",
+      type: :operator,
+      content: "one two three four",
+      cursor: %{line: 0, col: 0},
+      keys: "dw.",
+      compare: @compare,
+      tags: [:known_divergence],
+      known_divergence: %{
+        reason: "Minga still deletes the wrong trailing span for `dw`, compounding on repeat.",
+        failures: [:content],
+        actual: %{content: "hree four"}
+      }
+    },
+    %{
+      name: "dot repeats dd",
+      type: :operator,
+      content: "one\ntwo\nthree",
+      cursor: %{line: 0, col: 0},
+      keys: "dd.",
+      compare: @compare
+    },
+    %{
+      name: "dot repeats cw with replacement text",
+      type: :operator,
+      content: "one two three",
+      cursor: %{line: 0, col: 0},
+      keys: "cwhello<Esc>w.",
+      compare: @compare,
+      tags: [:known_divergence],
+      known_divergence: %{
+        reason: "Minga still changes the wrong trailing span for `cw`, compounding on dot repeat.",
+        failures: [:content, :cursor],
+        actual: %{content: "hellowo hello", line: 0, col: 12}
+      }
+    },
+    %{
+      name: "dot repeats insert",
+      type: :operator,
+      content: "hello",
+      cursor: %{line: 0, col: 0},
+      keys: "itext<Esc>.",
+      compare: @compare
+    },
+    %{
+      name: "dot with count override",
+      type: :operator,
+      content: "one two three four five",
+      cursor: %{line: 0, col: 0},
+      keys: "dw3.",
+      compare: @compare,
+      tags: [:known_divergence],
+      known_divergence: %{
+        reason: "Minga still deletes the wrong trailing span for `dw`, count override compounds the error.",
+        failures: [:content],
+        actual: %{content: "ive"}
+      }
+    },
+    %{
+      name: "dot repeats right shift",
+      type: :operator,
+      content: "one\ntwo\nthree",
+      cursor: %{line: 0, col: 0},
+      keys: ">>j.",
+      compare: @compare,
+      tags: [:known_divergence],
+      known_divergence: %{
+        reason: "Minga indents with 2 spaces instead of Neovim's default tab, and leaves the cursor shifted right.",
+        failures: [:content, :cursor],
+        actual: %{content: "  one\n  two\nthree", line: 1, col: 4}
+      }
+    },
+    %{
+      name: "dot with no previous change is no-op",
+      type: :operator,
+      content: "one two",
+      cursor: %{line: 0, col: 0},
+      keys: ".",
+      compare: @compare,
+      tags: [:known_divergence],
+      known_divergence: %{
+        reason: "Neovim inserts a tab on `.` with no prior change in a fresh buffer; Minga treats it as a no-op.",
+        failures: [:content],
+        actual: %{content: "one two"}
+      }
+    }
+  ]
+
+  @spec scenarios() :: [Minga.Test.NeovimOracle.scenario()]
+  def scenarios, do: @scenarios
+
+  for scenario <- @scenarios do
+    if :known_divergence in Map.get(scenario, :tags, []) do
+      @tag :known_divergence
+    end
+
+    @tag scenario: scenario.name
+    test scenario.name, %{oracle_results: oracle_results} do
+      assert_conforms(unquote(Macro.escape(scenario)), oracle_results)
+    end
+  end
+end

--- a/test/conformance/macros_test.exs
+++ b/test/conformance/macros_test.exs
@@ -1,0 +1,102 @@
+defmodule Minga.Conformance.MacrosTest do
+  # Conformance tests invoke nvim as an OS process, so they run serially to avoid erl_child_setup EPIPE races.
+  use Minga.Test.ConformanceCase, async: false
+
+  # Neovim's headless APIs (feedkeys, :normal!, :source!) cannot record macros
+  # to registers. All macro scenarios pre-populate the register and test replay
+  # conformance. Minga's macro recording is tested separately in unit tests.
+
+  @compare [:content, :cursor, :mode]
+
+  @scenarios [
+    %{
+      name: "replay simple delete macro",
+      type: :macro,
+      content: "abcd\nabcd",
+      cursor: %{line: 0, col: 0},
+      register_setup: %{"a" => "0x$x"},
+      keys: "@aj@a",
+      compare: @compare,
+      tags: [:known_divergence],
+      known_divergence: %{
+        reason: "Minga still leaves the cursor one column too far right after `$x`.",
+        failures: [:cursor],
+        actual: %{line: 1, col: 2}
+      }
+    },
+    %{
+      name: "replay macro with insert mode content",
+      type: :macro,
+      content: "one\ntwo\nthree",
+      cursor: %{line: 0, col: 0},
+      register_setup: %{"a" => "I-- \x1b"},
+      keys: "@aj@a",
+      compare: @compare
+    },
+    %{
+      name: "replay macro with count",
+      type: :macro,
+      content: "one\ntwo\nthree\nfour",
+      cursor: %{line: 0, col: 0},
+      register_setup: %{"a" => "I-- \x1bj"},
+      keys: "3@a",
+      compare: @compare
+    },
+    %{
+      name: "replay last macro with @@",
+      type: :macro,
+      content: "one\ntwo\nthree",
+      cursor: %{line: 0, col: 0},
+      register_setup: %{"a" => "I-- \x1b"},
+      keys: "@aj@@",
+      compare: @compare
+    },
+    %{
+      name: "replay yank and paste macro",
+      type: :macro,
+      content: "hello\nworld",
+      cursor: %{line: 0, col: 0},
+      register_setup: %{"a" => "yyp"},
+      keys: "@a",
+      compare: @compare
+    },
+    %{
+      name: "empty macro replay is no-op",
+      type: :macro,
+      content: "one\ntwo",
+      cursor: %{line: 0, col: 0},
+      register_setup: %{"a" => ""},
+      keys: "@a",
+      compare: @compare
+    },
+    %{
+      name: "macro replay on last line does not crash",
+      type: :macro,
+      content: "one\ntwo",
+      cursor: %{line: 1, col: 0},
+      register_setup: %{"a" => "0x$x"},
+      keys: "@a",
+      compare: @compare,
+      tags: [:known_divergence],
+      known_divergence: %{
+        reason: "Minga still leaves the cursor one column too far right after `$x`.",
+        failures: [:cursor],
+        actual: %{line: 1, col: 1}
+      }
+    }
+  ]
+
+  @spec scenarios() :: [Minga.Test.NeovimOracle.scenario()]
+  def scenarios, do: @scenarios
+
+  for scenario <- @scenarios do
+    if :known_divergence in Map.get(scenario, :tags, []) do
+      @tag :known_divergence
+    end
+
+    @tag scenario: scenario.name
+    test scenario.name, %{oracle_results: oracle_results} do
+      assert_conforms(unquote(Macro.escape(scenario)), oracle_results)
+    end
+  end
+end

--- a/test/conformance/macros_test.exs
+++ b/test/conformance/macros_test.exs
@@ -2,9 +2,8 @@ defmodule Minga.Conformance.MacrosTest do
   # Conformance tests invoke nvim as an OS process, so they run serially to avoid erl_child_setup EPIPE races.
   use Minga.Test.ConformanceCase, async: false
 
-  # Neovim's headless APIs (feedkeys, :normal!, :source!) cannot record macros
-  # to registers. All macro scenarios pre-populate the register and test replay
-  # conformance. Minga's macro recording is tested separately in unit tests.
+  # nvim_feedkeys with the "n" flag does not record to macro registers, so all
+  # scenarios pre-populate the register and test replay only.
 
   @compare [:content, :cursor, :mode]
 

--- a/test/conformance/oracle.lua
+++ b/test/conformance/oracle.lua
@@ -214,6 +214,9 @@ local function run_scenario(scenario)
     for i = string.byte("a"), string.byte("z") do
       vim.fn.setreg(string.char(i), "")
     end
+    for i = 1, 9 do
+      vim.fn.setreg(tostring(i), "")
+    end
     if scenario.register_setup then
       for name, content in pairs(scenario.register_setup) do
         vim.fn.setreg(name, content)

--- a/test/conformance/oracle.lua
+++ b/test/conformance/oracle.lua
@@ -106,9 +106,23 @@ local function keys_exit_insert(keys)
   return keys:find("<Esc>", 1, true) ~= nil or keys:find("<C%-c>") ~= nil or keys:find("<C%-[>") ~= nil
 end
 
+local function capture_named_registers(scenario)
+  if not scenario.capture_registers then
+    return nil
+  end
+  local regs = {}
+  for _, name in ipairs(scenario.capture_registers) do
+    regs[name] = {
+      content = vim.fn.getreg(name),
+      type = vim.fn.getregtype(name),
+    }
+  end
+  return regs
+end
+
 local function capture_state(scenario, reported_mode)
   local cursor = vim.api.nvim_win_get_cursor(0)
-  return {
+  local state = {
     name = scenario.name,
     ok = true,
     line = cursor[1] - 1,
@@ -118,6 +132,11 @@ local function capture_state(scenario, reported_mode)
     register = vim.fn.getreg('"'),
     register_type = vim.fn.getregtype('"'),
   }
+  local regs = capture_named_registers(scenario)
+  if regs then
+    state.registers = regs
+  end
+  return state
 end
 
 local function run_keys(keys)
@@ -161,12 +180,24 @@ local function run_commands(scenario)
   return vim.api.nvim_get_mode().mode
 end
 
+local function run_macro_keys(keys)
+  -- Macro replay injects keys that may enter/exit insert mode.
+  -- The ModeChanged heuristic in run_keys misreports the final mode
+  -- because it checks the explicit keys for <Esc>, not the replayed
+  -- macro content. Use the actual mode after execution instead.
+  local termcoded = vim.api.nvim_replace_termcodes(keys, true, false, true)
+  vim.api.nvim_feedkeys(termcoded, "nx", false)
+  return vim.api.nvim_get_mode().mode
+end
+
 local runners = {
   motion = function(s) return run_keys(s.keys or "") end,
   operator = function(s) return run_keys(s.keys or "") end,
   text_object = function(s) return run_keys(s.keys or "") end,
   search = function(s) return run_search(s.keys or "") end,
   mark = run_commands,
+  register = function(s) return run_keys(s.keys or "") end,
+  macro = function(s) return run_macro_keys(s.keys or "") end,
 }
 
 local function run_scenario(scenario)
@@ -179,6 +210,15 @@ local function run_scenario(scenario)
     vim.cmd("setlocal buftype=")
     vim.cmd("setlocal modifiable")
     vim.fn.setreg('"', "")
+    vim.fn.setreg('0', "")
+    for i = string.byte("a"), string.byte("z") do
+      vim.fn.setreg(string.char(i), "")
+    end
+    if scenario.register_setup then
+      for name, content in pairs(scenario.register_setup) do
+        vim.fn.setreg(name, content)
+      end
+    end
     set_buffer_content(scenario.content or "")
     set_cursor(scenario.cursor or { line = 0, col = 0 })
     local runner = runners[scenario.type or "motion"]

--- a/test/conformance/registers_test.exs
+++ b/test/conformance/registers_test.exs
@@ -1,0 +1,101 @@
+defmodule Minga.Conformance.RegistersTest do
+  # Conformance tests invoke nvim as an OS process, so they run serially to avoid erl_child_setup EPIPE races.
+  use Minga.Test.ConformanceCase, async: false
+
+  @compare [:content, :cursor, :mode, :register, :register_type]
+
+  @scenarios [
+    %{
+      name: "yy populates default register with linewise content",
+      type: :register,
+      content: "one\ntwo",
+      cursor: %{line: 0, col: 0},
+      keys: "yy",
+      compare: @compare
+    },
+    %{
+      name: "yw populates default register with charwise word",
+      type: :register,
+      content: "one two",
+      cursor: %{line: 0, col: 0},
+      keys: "yw",
+      compare: @compare,
+      tags: [:known_divergence],
+      known_divergence: %{
+        reason: "Minga still yanks the wrong trailing span for `yw`.",
+        failures: [:register],
+        actual: %{register: "one t"}
+      }
+    },
+    %{
+      name: "named register ayy populates register a",
+      type: :register,
+      content: "one\ntwo",
+      cursor: %{line: 0, col: 0},
+      keys: "\"ayy",
+      capture_registers: ["a", ""],
+      compare: [:content, :cursor, :mode, :registers]
+    },
+    %{
+      name: "black hole register does not populate default register",
+      type: :register,
+      content: "one\ntwo\nthree",
+      cursor: %{line: 0, col: 0},
+      keys: "\"_dd",
+      compare: [:content, :cursor, :mode, :register]
+    },
+    %{
+      name: "dd then p pastes deleted line below",
+      type: :register,
+      content: "one\ntwo\nthree",
+      cursor: %{line: 0, col: 0},
+      keys: "ddp",
+      compare: @compare
+    },
+    %{
+      name: "dw then p pastes deleted word after cursor",
+      type: :register,
+      content: "one two three",
+      cursor: %{line: 0, col: 0},
+      keys: "dwp",
+      compare: @compare,
+      tags: [:known_divergence],
+      known_divergence: %{
+        reason: "Minga still deletes and pastes the wrong span for `dw` + `p`.",
+        failures: [:content, :cursor, :register],
+        actual: %{content: "wone to three", line: 0, col: 6, register: "one t"}
+      }
+    },
+    %{
+      name: "uppercase register appends to named register",
+      type: :register,
+      content: "first\nsecond\nthird",
+      cursor: %{line: 0, col: 0},
+      keys: "\"ayyj\"Ayy",
+      capture_registers: ["a"],
+      compare: [:content, :cursor, :mode, :registers]
+    },
+    %{
+      name: "yy overwrites previous default register content",
+      type: :register,
+      content: "first\nsecond",
+      cursor: %{line: 0, col: 0},
+      keys: "yyjyy",
+      compare: @compare
+    }
+  ]
+
+  @spec scenarios() :: [Minga.Test.NeovimOracle.scenario()]
+  def scenarios, do: @scenarios
+
+  for scenario <- @scenarios do
+    if :known_divergence in Map.get(scenario, :tags, []) do
+      @tag :known_divergence
+    end
+
+    @tag scenario: scenario.name
+    test scenario.name, %{oracle_results: oracle_results} do
+      assert_conforms(unquote(Macro.escape(scenario)), oracle_results)
+    end
+  end
+end

--- a/test/support/conformance_case.ex
+++ b/test/support/conformance_case.ex
@@ -78,13 +78,13 @@ defmodule Minga.Test.ConformanceCase do
 
     case {scenario.type, Map.get(scenario, :register_setup)} do
       {:macro, setup} when is_map(setup) ->
-        :sys.replace_state(ctx.editor, fn st ->
-          macro_rec = st.workspace.editing.macro_recorder
+        alias MingaEditor.MacroRecorder
 
+        :sys.replace_state(ctx.editor, fn st ->
           populated =
-            Enum.reduce(setup, macro_rec, fn {name, content}, acc ->
+            Enum.reduce(setup, st.workspace.editing.macro_recorder, fn {name, content}, acc ->
               keys = for <<cp::utf8 <- content>>, do: {cp, 0}
-              %{acc | registers: Map.put(acc.registers, name, keys)}
+              MacroRecorder.put_macro(acc, name, keys)
             end)
 
           put_in(st.workspace.editing.macro_recorder, populated)
@@ -205,7 +205,11 @@ defmodule Minga.Test.ConformanceCase do
   end
 
   defp field_failure(:registers, expected, actual) do
-    if Map.get(expected, :registers) == Map.get(actual, :registers), do: [], else: [:registers]
+    case {Map.get(expected, :registers), Map.get(actual, :registers)} do
+      {nil, nil} -> raise "compare: [:registers] requires capture_registers in the scenario"
+      {e, a} when e == a -> []
+      _ -> [:registers]
+    end
   end
 
   @spec assert_no_failures(scenario(), [atom()], NeovimOracle.result(), minga_result()) :: :ok

--- a/test/support/conformance_case.ex
+++ b/test/support/conformance_case.ex
@@ -133,12 +133,13 @@ defmodule Minga.Test.ConformanceCase do
         base
 
       names ->
-        named = Map.new(names, fn name ->
-          case Registers.get(reg_state, name) do
-            {text, type} -> {name, %{content: text, type: register_type_label(type)}}
-            nil -> {name, %{content: "", type: "v"}}
-          end
-        end)
+        named =
+          Map.new(names, fn name ->
+            case Registers.get(reg_state, name) do
+              {text, type} -> {name, %{content: text, type: register_type_label(type)}}
+              nil -> {name, %{content: "", type: "v"}}
+            end
+          end)
 
         Map.put(base, :registers, named)
     end

--- a/test/support/conformance_case.ex
+++ b/test/support/conformance_case.ex
@@ -21,7 +21,8 @@ defmodule Minga.Test.ConformanceCase do
           required(:content) => String.t(),
           required(:mode) => String.t(),
           required(:register) => String.t(),
-          required(:register_type) => String.t()
+          required(:register_type) => String.t(),
+          optional(:registers) => %{String.t() => %{content: String.t(), type: String.t()}}
         }
 
   using do
@@ -74,19 +75,51 @@ defmodule Minga.Test.ConformanceCase do
   @spec run_minga(scenario()) :: minga_result()
   defp run_minga(scenario) do
     ctx = EditorCase.start_editor(scenario.content, width: 120, height: 40)
+
+    case {scenario.type, Map.get(scenario, :register_setup)} do
+      {:macro, setup} when is_map(setup) ->
+        :sys.replace_state(ctx.editor, fn st ->
+          macro_rec = st.workspace.editing.macro_recorder
+
+          populated =
+            Enum.reduce(setup, macro_rec, fn {name, content}, acc ->
+              keys = for <<cp::utf8 <- content>>, do: {cp, 0}
+              %{acc | registers: Map.put(acc.registers, name, keys)}
+            end)
+
+          put_in(st.workspace.editing.macro_recorder, populated)
+        end)
+
+      {_, setup} when is_map(setup) ->
+        state = EditorCase.editor_state(ctx)
+        reg_state = MingaEditor.Editing.registers(state)
+
+        populated =
+          Enum.reduce(setup, reg_state, fn {name, content}, acc ->
+            Registers.put(acc, name, content)
+          end)
+
+        :sys.replace_state(ctx.editor, fn st ->
+          put_in(st.workspace.editing.reg, populated)
+        end)
+
+      _ ->
+        :ok
+    end
+
     :ok = BufferProcess.move_to(ctx.buffer, {scenario.cursor.line, scenario.cursor.col})
     run_minga_keys(ctx, scenario)
     state = EditorCase.editor_state(ctx)
     {line, col} = EditorCase.buffer_cursor(ctx)
-    register = MingaEditor.Editing.registers(state)
+    reg_state = MingaEditor.Editing.registers(state)
 
     {register_text, register_type} =
-      case Registers.get(register, "") do
+      case Registers.get(reg_state, "") do
         {text, type} -> {text, register_type_label(type)}
         nil -> {"", "v"}
       end
 
-    %{
+    base = %{
       line: line,
       col: col,
       content: EditorCase.buffer_content(ctx),
@@ -94,6 +127,21 @@ defmodule Minga.Test.ConformanceCase do
       register: register_text,
       register_type: register_type
     }
+
+    case Map.get(scenario, :capture_registers) do
+      nil ->
+        base
+
+      names ->
+        named = Map.new(names, fn name ->
+          case Registers.get(reg_state, name) do
+            {text, type} -> {name, %{content: text, type: register_type_label(type)}}
+            nil -> {name, %{content: "", type: "v"}}
+          end
+        end)
+
+        Map.put(base, :registers, named)
+    end
   end
 
   @spec run_minga_keys(map(), scenario()) :: :ok
@@ -123,6 +171,7 @@ defmodule Minga.Test.ConformanceCase do
   defp compare_fields(:mode), do: [:mode]
   defp compare_fields(:register), do: [:register]
   defp compare_fields(:register_type), do: [:register_type]
+  defp compare_fields(:registers), do: [:registers]
   defp compare_fields(:both), do: [:content, :cursor]
   defp compare_fields(fields) when is_list(fields), do: fields
 
@@ -153,6 +202,10 @@ defmodule Minga.Test.ConformanceCase do
 
   defp field_failure(:register_type, expected, actual) do
     if expected.register_type == actual.register_type, do: [], else: [:register_type]
+  end
+
+  defp field_failure(:registers, expected, actual) do
+    if Map.get(expected, :registers) == Map.get(actual, :registers), do: [], else: [:registers]
   end
 
   @spec assert_no_failures(scenario(), [atom()], NeovimOracle.result(), minga_result()) :: :ok
@@ -220,6 +273,7 @@ defmodule Minga.Test.ConformanceCase do
   defp actual_keys_for_failure(:mode), do: [:mode]
   defp actual_keys_for_failure(:register), do: [:register]
   defp actual_keys_for_failure(:register_type), do: [:register_type]
+  defp actual_keys_for_failure(:registers), do: [:registers]
 
   @spec actual_matches?(minga_result(), map()) :: boolean()
   defp actual_matches?(actual, expected_actual) when is_map(expected_actual) do
@@ -260,17 +314,32 @@ defmodule Minga.Test.ConformanceCase do
     Neovim expected:
       cursor: {#{expected.line}, #{expected.col}}
       mode: #{expected.mode}
-      register: #{inspect(expected.register)} (#{expected.register_type})
+      register: #{inspect(expected.register)} (#{expected.register_type})#{format_registers(Map.get(expected, :registers))}
       content:
     #{indent(expected.content)}
 
     Minga actual:
       cursor: {#{actual.line}, #{actual.col}}
       mode: #{actual.mode}
-      register: #{inspect(actual.register)} (#{actual.register_type})
+      register: #{inspect(actual.register)} (#{actual.register_type})#{format_registers(Map.get(actual, :registers))}
       content:
     #{indent(actual.content)}#{expected_actual_block}
     """
+  end
+
+  @spec format_registers(%{String.t() => %{content: String.t(), type: String.t()}} | nil) ::
+          String.t()
+  defp format_registers(nil), do: ""
+
+  defp format_registers(regs) when is_map(regs) do
+    entries =
+      regs
+      |> Enum.sort_by(fn {name, _} -> name end)
+      |> Enum.map_join(", ", fn {name, %{content: content, type: type}} ->
+        "\"#{name}\"=#{inspect(content)} (#{type})"
+      end)
+
+    "\n    registers: #{entries}"
   end
 
   @spec format_actual(map()) :: String.t()

--- a/test/support/neovim_oracle.ex
+++ b/test/support/neovim_oracle.ex
@@ -6,8 +6,9 @@ defmodule Minga.Test.NeovimOracle do
   """
 
   @type cursor :: %{required(:line) => non_neg_integer(), required(:col) => non_neg_integer()}
-  @type scenario_type :: :motion | :operator | :text_object | :search | :window | :mark
-  @type compare_field :: :content | :cursor | :mode | :register | :register_type
+  @type scenario_type ::
+          :motion | :operator | :text_object | :search | :window | :mark | :register | :macro
+  @type compare_field :: :content | :cursor | :mode | :register | :register_type | :registers
   @type window_compare_field :: :window_count | :active_window | :cursors | :buffers | :layout
   @type compare_target ::
           compare_field() | :both | :window_state | [compare_field() | window_compare_field()]
@@ -25,6 +26,8 @@ defmodule Minga.Test.NeovimOracle do
           optional(:commands) => [String.t()],
           optional(:minga_keys) => [String.t()],
           required(:compare) => compare_target(),
+          optional(:register_setup) => %{String.t() => String.t()},
+          optional(:capture_registers) => [String.t()],
           optional(:tags) => [atom()],
           optional(:known_divergence) => divergence()
         }
@@ -49,6 +52,7 @@ defmodule Minga.Test.NeovimOracle do
           optional(:register_type) => String.t(),
           optional(:window_count) => non_neg_integer(),
           optional(:windows) => [window_info()],
+          optional(:registers) => %{String.t() => %{content: String.t(), type: String.t()}},
           optional(:error) => String.t()
         }
   @type error ::
@@ -136,6 +140,16 @@ defmodule Minga.Test.NeovimOracle do
     |> then(fn m ->
       if scenario[:commands], do: Map.put(m, :commands, scenario.commands), else: m
     end)
+    |> then(fn m ->
+      if scenario[:register_setup],
+        do: Map.put(m, :register_setup, scenario.register_setup),
+        else: m
+    end)
+    |> then(fn m ->
+      if scenario[:capture_registers],
+        do: Map.put(m, :capture_registers, scenario.capture_registers),
+        else: m
+    end)
   end
 
   @spec invoke_nvim(String.t(), String.t(), pos_integer()) ::
@@ -207,7 +221,7 @@ defmodule Minga.Test.NeovimOracle do
 
   defp normalize_result(result) do
     result
-    |> Enum.map(fn {key, value} -> {result_key(key), value} end)
+    |> Enum.map(fn {key, value} -> {result_key(key), normalize_value(key, value)} end)
     |> Map.new()
   end
 
@@ -225,6 +239,15 @@ defmodule Minga.Test.NeovimOracle do
     }
   end
 
+  @spec normalize_value(String.t(), term()) :: term()
+  defp normalize_value("registers", regs) when is_map(regs) do
+    Map.new(regs, fn {name, %{"content" => content, "type" => type}} ->
+      {name, %{content: content, type: type}}
+    end)
+  end
+
+  defp normalize_value(_key, value), do: value
+
   @spec result_key(String.t()) :: atom()
   defp result_key("name"), do: :name
   defp result_key("ok"), do: :ok
@@ -235,5 +258,6 @@ defmodule Minga.Test.NeovimOracle do
   defp result_key("register"), do: :register
   defp result_key("register_type"), do: :register_type
   defp result_key("window_count"), do: :window_count
+  defp result_key("registers"), do: :registers
   defp result_key("error"), do: :error
 end


### PR DESCRIPTION
## Summary

Closes #101

- Adds 22 Neovim conformance scenarios: 8 register operations (default/named/black hole/append/linewise/charwise), 7 macro replay (simple/insert/count/@@/yank+paste/empty/boundary), and 7 dot repeat (operator/insert/count override/shift/no-op)
- Extends oracle Lua with register pre-population (`vim.fn.setreg`), named register capture (`capture_registers`), and a dedicated `run_macro_keys` runner that bypasses the ModeChanged insert heuristic
- Extends `ConformanceCase` with dual register setup (text registers via `Registers.put`, macro registers via `MacroRecorder` key tuples) and `capture_registers` comparison support
- Nine scenarios tagged as known divergences documenting existing Minga bugs: word motion boundary (`dw`/`cw`/`yw`), `$x` cursor overshoot, tab-vs-2space indent, and Neovim's fresh-buffer dot quirk

## Test plan

- [x] `mix test --include conformance test/conformance/registers_test.exs` passes (8 scenarios)
- [x] `mix test --include conformance test/conformance/macros_test.exs` passes (7 scenarios)
- [x] `mix test --include conformance test/conformance/dot_repeat_test.exs` passes (7 scenarios)
- [x] `mix test.llm` passes (8701 tests, 0 failures)
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)