### PR TITLE
feat(extension): harden lifecycle contract

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1131,7 +1131,7 @@ extension :minga_snippets, git: "https://github.com/user/minga-snippets"
 extension :minga_tools, hex: "minga_tools", version: "~> 0.3"
 ```
 
-Exactly one of `path:`, `git:`, or `hex:` is required. Extra keyword options (everything except the source and its sub-options like `branch:` or `version:`) are passed to the extension as config. If the extension declares typed options with `option/3`, these values are validated at load time:
+Exactly one of `path:`, `git:`, or `hex:` is required. Extra keyword options (everything except the source and its sub-options like `branch:`, `version:`, or `app:`) are passed to the extension as config. If the extension declares typed options with `option/3`, these values are validated at load time:
 
 ```elixir
 # Config options are grouped right in the extension declaration
@@ -1177,16 +1177,19 @@ Omitting both `branch:` and `ref:` defaults to whatever the remote's default bra
 Hex extensions are fetched and compiled via `Mix.install/2`, the same mechanism Livebook uses for notebook dependencies. This handles dependency resolution (including transitive deps), downloading, compilation, and code path setup.
 
 ```elixir
-# Latest stable release
-extension :tools, hex: "minga_tools"
+# Latest stable release. The extension name is also the OTP app by default.
+extension :minga_tools, hex: "minga_tools"
 
 # Version constraint (standard Elixir/Hex semver syntax)
-extension :tools, hex: "minga_tools", version: "~> 0.3"
-extension :tools, hex: "minga_tools", version: ">= 1.0.0 and < 2.0.0"
-extension :tools, hex: "minga_tools", version: "== 0.3.1"
+extension :minga_tools, hex: "minga_tools", version: "~> 0.3"
+extension :minga_tools, hex: "minga_tools", version: ">= 1.0.0 and < 2.0.0"
+extension :minga_tools, hex: "minga_tools", version: "== 0.3.1"
+
+# Use app: when you want a shorter local name than the package's OTP app.
+extension :tools, hex: "minga_tools", app: :minga_tools
 ```
 
-Omitting `version:` fetches the latest stable release.
+Omitting `version:` fetches the latest stable release. The extension name defaults to the OTP application name. If you choose a local alias, pass `app:` so Minga can start the correct application without creating atoms from package strings.
 
 All hex extensions are installed in a single `Mix.install/2` call at startup. The results are cached (keyed on the dep list hash), so the second boot with the same extensions skips all network and compilation work. The cache lives at `~/.cache/mix/installs/`.
 
@@ -1311,7 +1314,7 @@ end
 # ── Extensions ───────────────────────────────────────────────────────
 extension :minga_todo, path: "~/code/minga_todo"
 extension :snippets, git: "https://github.com/user/minga-snippets", branch: "main"
-extension :tools, hex: "minga_tools", version: "~> 0.3"
+extension :minga_tools, hex: "minga_tools", version: "~> 0.3"
 ```
 
 ## Further reading

--- a/docs/EXTENSIBILITY.md
+++ b/docs/EXTENSIBILITY.md
@@ -391,6 +391,8 @@ Both macros accumulate metadata at compile time. When the extension loads, the f
 
 Minga's extension registries track who contributed each entry. The common source identifiers are `:builtin`, `:config`, and `{:extension, name}`. That source tag is what makes reload safe: stopping an extension removes only that extension's commands, keybindings, scopes, input handlers, language data, themes, tool recipes, and modeline segments.
 
+Cleanup is best-effort across every family. If command cleanup fails, keymaps, scopes, input handlers, language data, themes, tool recipes, and modeline segments still get their cleanup pass. Minga reports the cleanup failures instead of hiding them, because stale extension state is worse than a noisy reload.
+
 This ownership layer is the gate for large built-in feature extraction. Language packs, theme packs, tool recipe packs, Dired, FileTree, Git UI, Board, and Agent pieces should move out of core only after they can register through these source-owned paths. Without ownership, reloads leave stale commands or catalog entries behind.
 
 ### The imperative path (for runtime-dynamic contributions)
@@ -427,6 +429,8 @@ end
 ```
 
 These APIs write to hot-path ETS or persistent registries, so command dispatch, key resolution, rendering, and input routing keep reading cached data. They do not call extension callbacks on every keystroke or frame.
+
+That rule matters for GUI-first features. A rich sidebar or status surface should publish a semantic snapshot that Minga's render pipeline and native frontend adapters can encode centrally. Extensions should not emit raw GUI protocol bytes or raw terminal cells from input/render hot paths.
 
 The DSL is syntactic sugar over these APIs, not a replacement. Use whichever fits your extension's needs.
 

--- a/docs/EXTENSION_API.md
+++ b/docs/EXTENSION_API.md
@@ -2,7 +2,7 @@
 
 > **First time?** This is the API reference. For a guided walkthrough of building your first extension from scratch, see the [Extension Authoring Guide](https://github.com/jsmestad/minga/issues/212). For the conceptual foundation (why Elixir is Minga's Elisp, how the BEAM makes extensions safe), read [Extensibility](EXTENSIBILITY.md).
 
-Extensions are Elixir packages that run inside the editor. They have full access to the BEAM VM, the same way Emacs Lisp packages have full access to the Emacs runtime. Your extension's `init/1` callback is where everything happens: register commands, bind keys, hook into the advice system, declare config options.
+Extensions are Elixir packages that run inside the editor. They have full access to the BEAM VM, the same way Emacs Lisp packages have full access to the Emacs runtime. Declarative contributions are described at compile time, and runtime setup happens in `init/1`.
 
 This page covers every public API an extension can use, with copy-pasteable examples.
 
@@ -18,7 +18,7 @@ When a user writes `extension :my_ext, git: "..."` in their config, they're choo
 
 ## The Extension Behaviour
 
-Every extension implements four callbacks. `use Minga.Extension` gives you a default `child_spec/1` (an Agent holding your config), the `option/3` macro for declaring typed config options, and a generated `__option_schema__/0` function the framework reads at load time. Override `child_spec/1` if you need a custom GenServer or supervision tree.
+Every extension implements four callbacks. `use Minga.Extension` gives you a default `child_spec/1` (an Agent holding your validated config), declarative macros for contributions, and generated schema functions the framework reads at load time. Override `child_spec/1` if you need a custom GenServer, persistent runtime state, or a supervision tree.
 
 ```elixir
 defmodule MingaOrg do
@@ -59,9 +59,55 @@ end
 
 The `option` macro follows the same pattern as Ecto's `field`: you declare it at the module level, and `use Minga.Extension` generates a `__option_schema__/0` function from the accumulated declarations. You never write the introspection function yourself.
 
-**Lifecycle:** The user declares the extension in `config.exs`. Minga compiles it, validates config options against the schema, calls `init/1`, then starts `child_spec/1` under `Extension.Supervisor`. On config reload (`SPC h r`), all extensions stop and re-load from scratch.
+**Lifecycle:** The user declares the extension in `config.exs`. Minga compiles it, introspects its manifest, validates config options against the schema, calls `init/1`, then starts `child_spec/1` under `Extension.Supervisor`. On config reload (`SPC h r`), all extensions stop and re-load from scratch.
+
+`init/1` is setup-only. It may register runtime-dynamic source-owned contributions and return `{:ok, state}` to report success, but the default child process does not receive that returned state. The default child stores the validated config keyword list so existing extensions keep working. If your extension has runtime state, put that state in your own GenServer or supervision tree and return it from your custom `child_spec/1`.
 
 Each extension runs under a `DynamicSupervisor` with `:one_for_one` strategy. If your extension crashes, only your extension restarts. The editor and other extensions keep running.
+
+### Lifecycle ordering and cleanup
+
+The lifecycle contract is intentionally boring:
+
+1. **Load:** path and git extensions compile from their local source, hex extensions load from the installed application.
+2. **Manifest:** Minga records the extension name, version, source type, commands, keybindings, modeline segments, and declared capabilities before `init/1` runs.
+3. **Options:** declared options are validated and registered.
+4. **Init:** `init/1` runs. If it returns `{:error, reason}` or raises, startup fails.
+5. **Child start:** `child_spec/1` starts under the extension supervisor.
+6. **DSL registration:** declarative commands, keybindings, and modeline segments are registered with source `{:extension, name}`.
+
+Stop, failed start, and reload all run source-owned cleanup. Cleanup families are aggregated: a failure in one family is logged and returned, but later cleanup families still run. This prevents a bad command cleanup from leaving stale keymaps, themes, languages, tool recipes, or modeline segments behind.
+
+Reload is `stop -> cleanup -> load -> manifest -> options -> init -> child start -> DSL registration`. If stop cleanup reports an error, reload reports the error instead of pretending the extension restarted cleanly.
+
+### Manifest and capabilities
+
+Use the normal contribution macros to make declarations visible before runtime side effects run:
+
+```elixir
+command :org_cycle_todo, "Cycle TODO keyword", execute: {MingaOrg.Todo, :cycle}
+keybind :normal, "SPC m t", :org_cycle_todo, "Cycle TODO", filetype: :org
+modeline_segment :org_status, side: :right do
+  nil
+end
+capability :ui, [:modeline]
+```
+
+`Minga.Extension.manifest(MyExtension, :path)` returns a `%Minga.Extension.Manifest{}` with `:name`, `:description`, `:version`, `:source`, `:commands`, `:keybindings`, `:modeline_segments`, and `:capabilities`. The shape is append-only. Future Minga releases may add fields, but existing fields keep their meaning.
+
+### Lifecycle telemetry
+
+Minga emits lifecycle telemetry for extension load, init, child start, stop, reload, cleanup, and crash/restart count. Handlers should listen for `[:minga, :extension, :lifecycle, :stop]` span events and read `metadata.extension` and `metadata.phase`. Crash/restart count uses `[:minga, :extension, :lifecycle, :crash_restart_count]` with `%{count: count}`.
+
+Slow lifecycle phases are logged through `Minga.Log` with the extension name and phase. This gives users a path to answer "which extension slowed startup or reload?" without putting arbitrary extension callbacks in render or input hot paths.
+
+### Hot-path rule
+
+Extensions must publish cached data, snapshots, or declarative registrations. Input and render paths read registries and snapshots; they do not call arbitrary extension code per keystroke or frame.
+
+The current `modeline_segment/3` callback is the narrow compatibility exception: it runs from a render path, so it must be cheap and read cached state only. Stateful or slow modeline data should be computed by the extension process ahead of time and exposed as a cached value. Future richer status/sidebar APIs should publish semantic snapshots instead of render callbacks.
+
+Rich GUI features should publish semantic payloads that Minga's central protocol encoders and native frontend adapters understand, not raw GUI opcodes or raw terminal cells.
 
 ---
 

--- a/docs/EXTENSION_API.md
+++ b/docs/EXTENSION_API.md
@@ -93,7 +93,11 @@ end
 capability :ui, [:modeline]
 ```
 
-`Minga.Extension.manifest(MyExtension, :path)` returns a `%Minga.Extension.Manifest{}` with `:name`, `:description`, `:version`, `:source`, `:commands`, `:keybindings`, `:modeline_segments`, and `:capabilities`. The shape is append-only. Future Minga releases may add fields, but existing fields keep their meaning.
+Capabilities stay in declaration order. If you declare the same capability more than once, the manifest keeps every entry.
+
+`Minga.Extension.manifest(MyExtension, :path)` returns a `%Minga.Extension.Manifest{}` with `:name`, `:description`, `:version`, `:source`, `:commands`, `:keybindings`, `:modeline_segments`, and `:capabilities`. Capabilities are stored as an ordered list of `{family, value}` tuples, so duplicate declarations stay visible. The shape is append-only. Future Minga releases may add fields, but existing fields keep their meaning.
+
+`Minga.Extension.manifest/2` and `Minga.Extension.Manifest.from_module/2` call declaration callbacks directly, so callback failures can raise or exit. The extension supervisor catches those failures during startup and turns them into load errors instead.
 
 ### Lifecycle telemetry
 

--- a/lib/minga/config.ex
+++ b/lib/minga/config.ex
@@ -691,8 +691,9 @@ defmodule Minga.Config do
 
   ## Hex source (stable, published)
 
-      extension :snippets, hex: "minga_snippets", version: "~> 0.3"
-      extension :snippets, hex: "minga_snippets"
+      extension :minga_snippets, hex: "minga_snippets", version: "~> 0.3"
+      extension :minga_snippets, hex: "minga_snippets"
+      extension :snippets, hex: "minga_snippets", app: :minga_snippets
   """
   @spec extension(atom(), keyword()) :: :ok
   def extension(name, opts) when is_atom(name) and is_list(opts) do

--- a/lib/minga/extension.ex
+++ b/lib/minga/extension.ex
@@ -159,7 +159,13 @@ defmodule Minga.Extension do
   @typedoc "A declared runtime or UI capability: `{family, value}`."
   @type capability_spec :: {atom(), term()}
 
-  @doc "Builds a public manifest for a loaded extension module."
+  @doc """
+  Builds a public manifest for a loaded extension module.
+
+  This calls the extension's declaration callbacks directly, so callback
+  failures can raise or exit. Use `Minga.Extension.Supervisor.start_extension/5`
+  if you want those failures converted into load errors instead of propagating.
+  """
   @spec manifest(module(), Minga.Extension.Manifest.source_type()) :: Minga.Extension.Manifest.t()
   def manifest(module, source) when is_atom(module) and source in [:path, :git, :hex] do
     Minga.Extension.Manifest.from_module(module, source)

--- a/lib/minga/extension.ex
+++ b/lib/minga/extension.ex
@@ -102,10 +102,7 @@ defmodule Minga.Extension do
   @doc """
   Optional. Returns a child spec for the extension's supervision subtree.
 
-  The default implementation (provided by `use Minga.Extension`) starts
-  a simple Agent that holds the state returned by `init/1`. Override this
-  if your extension needs a custom GenServer, multiple processes, or a
-  full supervision tree.
+  The default implementation (provided by `use Minga.Extension`) starts a simple Agent that holds the validated config keyword list. The value returned by `init/1` is setup-only and is not handed to the default child process. Override this if your extension needs a custom GenServer, persisted runtime state, multiple processes, or a full supervision tree.
   """
   @callback child_spec(config :: keyword()) :: Supervisor.child_spec()
 
@@ -159,6 +156,15 @@ defmodule Minga.Extension do
   @typedoc "A modeline segment declaration: `{name, opts, {module, function}}`."
   @type modeline_segment_spec :: {atom(), keyword(), {module(), atom()}}
 
+  @typedoc "A declared runtime or UI capability: `{family, value}`."
+  @type capability_spec :: {atom(), term()}
+
+  @doc "Builds a public manifest for a loaded extension module."
+  @spec manifest(module(), Minga.Extension.Manifest.source_type()) :: Minga.Extension.Manifest.t()
+  def manifest(module, source) when is_atom(module) and source in [:path, :git, :hex] do
+    Minga.Extension.Manifest.from_module(module, source)
+  end
+
   @doc """
   Injects the `Minga.Extension` behaviour, DSL macros (`option/3`,
   `command/3`, `keybind/4`, `keybind/5`), and a default `child_spec/1`.
@@ -209,6 +215,7 @@ defmodule Minga.Extension do
       Module.register_attribute(__MODULE__, :__extension_commands__, accumulate: true)
       Module.register_attribute(__MODULE__, :__extension_keybinds__, accumulate: true)
       Module.register_attribute(__MODULE__, :__extension_modeline_segments__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__extension_capabilities__, accumulate: true)
       @before_compile Minga.Extension
 
       @doc false
@@ -231,7 +238,8 @@ defmodule Minga.Extension do
           keybind: 4,
           keybind: 5,
           modeline_segment: 2,
-          modeline_segment: 3
+          modeline_segment: 3,
+          capability: 2
         ]
     end
   end
@@ -329,6 +337,17 @@ defmodule Minga.Extension do
   end
 
   @doc """
+  Declares a runtime or UI capability this extension uses.
+
+  Capabilities are declarative and are available through `Minga.Extension.Manifest` before `init/1` runs. They should describe contribution surfaces or runtime needs, not perform side effects.
+  """
+  defmacro capability(family, value) do
+    quote do
+      @__extension_capabilities__ {unquote(family), unquote(value)}
+    end
+  end
+
+  @doc """
   Declares a keybinding this extension provides.
 
   Accumulated at compile time and exposed via `__keybind_schema__/0`.
@@ -360,11 +379,13 @@ defmodule Minga.Extension do
     commands = Module.get_attribute(env.module, :__extension_commands__) || []
     keybinds = Module.get_attribute(env.module, :__extension_keybinds__) || []
     modeline_segments = Module.get_attribute(env.module, :__extension_modeline_segments__) || []
+    capabilities = Module.get_attribute(env.module, :__extension_capabilities__) || []
     # Accumulated attributes are in reverse order; restore declaration order
     options = Enum.reverse(options)
     commands = Enum.reverse(commands)
     keybinds = Enum.reverse(keybinds)
     modeline_segments = Enum.reverse(modeline_segments)
+    capabilities = Enum.reverse(capabilities)
 
     quote do
       @doc false
@@ -382,6 +403,10 @@ defmodule Minga.Extension do
       @doc false
       @spec __modeline_segment_schema__() :: [Minga.Extension.modeline_segment_spec()]
       def __modeline_segment_schema__, do: unquote(Macro.escape(modeline_segments))
+
+      @doc false
+      @spec __capability_schema__() :: [Minga.Extension.capability_spec()]
+      def __capability_schema__, do: unquote(Macro.escape(capabilities))
     end
   end
 end

--- a/lib/minga/extension/agent_api.ex
+++ b/lib/minga/extension/agent_api.ex
@@ -21,8 +21,6 @@ defmodule Minga.Extension.AgentAPI do
       # subscribes calling process to agent lifecycle events
   """
 
-  require Logger
-
   @default_manager MingaAgent.SessionManager
 
   @typedoc "Agent session status."
@@ -75,7 +73,11 @@ defmodule Minga.Extension.AgentAPI do
       []
 
     :exit, reason ->
-      Logger.warning("AgentAPI.list_sessions/1 caught unexpected exit: #{inspect(reason)}")
+      Minga.Log.warning(
+        :agent,
+        "AgentAPI.list_sessions/1 caught unexpected exit: #{inspect(reason)}"
+      )
+
       []
   end
 
@@ -128,7 +130,11 @@ defmodule Minga.Extension.AgentAPI do
       {:error, :not_found}
 
     :exit, reason ->
-      Logger.warning("AgentAPI.session_info/2 caught unexpected exit: #{inspect(reason)}")
+      Minga.Log.warning(
+        :agent,
+        "AgentAPI.session_info/2 caught unexpected exit: #{inspect(reason)}"
+      )
+
       {:error, :not_found}
   end
 
@@ -203,7 +209,11 @@ defmodule Minga.Extension.AgentAPI do
       %{status: :error, pending_approval: nil, error: nil, active_tool_name: nil}
 
     :exit, reason ->
-      Logger.warning("AgentAPI.safe_editor_snapshot/1 caught unexpected exit: #{inspect(reason)}")
+      Minga.Log.warning(
+        :agent,
+        "AgentAPI.safe_editor_snapshot/1 caught unexpected exit: #{inspect(reason)}"
+      )
+
       %{status: :error, pending_approval: nil, error: nil, active_tool_name: nil}
   end
 end

--- a/lib/minga/extension/dev_reload.ex
+++ b/lib/minga/extension/dev_reload.ex
@@ -146,21 +146,7 @@ defmodule Minga.Extension.DevReload do
       {:ok, %{path: path, status: :running}} when is_binary(path) ->
         Minga.Log.info(:config, "Dev reload: recompiling #{ext_name}")
 
-        case recompile_extension(path) do
-          :ok ->
-            restart_result = restart_extension(ext_name)
-
-            broadcast_reload_result(ext_name, restart_result)
-
-          {:error, reason} ->
-            Minga.Events.broadcast(
-              :log_message,
-              %Minga.Events.LogMessageEvent{
-                text: "Extension #{ext_name} reload failed: #{inspect(reason)}",
-                level: :error
-              }
-            )
-        end
+        reload_recompiled_extension(ext_name, recompile_extension(path))
 
       _ ->
         :ok
@@ -168,6 +154,32 @@ defmodule Minga.Extension.DevReload do
   rescue
     e ->
       Minga.Log.error(:config, "Dev reload error for #{ext_name}: #{Exception.message(e)}")
+  end
+
+  @spec reload_recompiled_extension(atom(), :ok | {:error, term()}) :: :ok
+  defp reload_recompiled_extension(ext_name, :ok) do
+    ext_name
+    |> restart_extension_with_telemetry()
+    |> then(&broadcast_reload_result(ext_name, &1))
+  end
+
+  defp reload_recompiled_extension(ext_name, {:error, reason}) do
+    Minga.Events.broadcast(
+      :log_message,
+      %Minga.Events.LogMessageEvent{
+        text: "Extension #{ext_name} reload failed: #{inspect(reason)}",
+        level: :error
+      }
+    )
+  end
+
+  @spec restart_extension_with_telemetry(atom()) :: :ok | {:error, term()}
+  defp restart_extension_with_telemetry(ext_name) do
+    Minga.Telemetry.span(
+      [:minga, :extension, :lifecycle],
+      %{extension: ext_name, phase: :reload},
+      fn -> restart_extension(ext_name) end
+    )
   end
 
   @spec restart_extension(atom()) :: :ok | {:error, term()}

--- a/lib/minga/extension/dev_reload.ex
+++ b/lib/minga/extension/dev_reload.ex
@@ -19,7 +19,8 @@ defmodule Minga.Extension.DevReload do
           watcher_monitors: %{reference() => String.t()},
           extensions: %{String.t() => atom()},
           pending_timer: reference() | nil,
-          pending_paths: MapSet.t()
+          pending_paths: MapSet.t(),
+          recompiler: (String.t() -> :ok | {:error, term()})
         }
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -42,14 +43,15 @@ defmodule Minga.Extension.DevReload do
 
   @impl true
   @spec init(keyword()) :: {:ok, state()}
-  def init(_opts) do
+  def init(opts) do
     {:ok,
      %{
        watchers: %{},
        watcher_monitors: %{},
        extensions: %{},
        pending_timer: nil,
-       pending_paths: MapSet.new()
+       pending_paths: MapSet.new(),
+       recompiler: Keyword.get(opts, :recompiler, &recompile_extension/1)
      }}
   end
 
@@ -132,7 +134,7 @@ defmodule Minga.Extension.DevReload do
       |> Enum.uniq()
 
     for ext_name <- extensions_to_reload do
-      reload_extension(ext_name)
+      reload_extension(ext_name, state.recompiler)
     end
 
     {:noreply, %{state | pending_paths: MapSet.new(), pending_timer: nil}}
@@ -140,13 +142,13 @@ defmodule Minga.Extension.DevReload do
 
   def handle_info(_msg, state), do: {:noreply, state}
 
-  @spec reload_extension(atom()) :: :ok
-  defp reload_extension(ext_name) do
+  @spec reload_extension(atom(), (String.t() -> :ok | {:error, term()})) :: :ok
+  defp reload_extension(ext_name, recompiler) do
     case Minga.Extension.Registry.get(Minga.Extension.Registry, ext_name) do
       {:ok, %{path: path, status: :running}} when is_binary(path) ->
         Minga.Log.info(:config, "Dev reload: recompiling #{ext_name}")
 
-        reload_recompiled_extension(ext_name, recompile_extension(path))
+        reload_recompiled_extension(ext_name, recompiler.(path))
 
       _ ->
         :ok
@@ -244,9 +246,9 @@ defmodule Minga.Extension.DevReload do
     if ex_files == [] do
       {:error, :no_source_files}
     else
-      case Kernel.ParallelCompiler.compile(ex_files) do
-        {:ok, _modules, _warnings} -> :ok
-        {:error, errors, _warnings} -> {:error, errors}
+      case Kernel.ParallelCompiler.compile(ex_files, return_diagnostics: true) do
+        {:ok, _modules, _diag_map} -> :ok
+        {:error, errors, _diag_map} -> {:error, errors}
       end
     end
   rescue

--- a/lib/minga/extension/entry.ex
+++ b/lib/minga/extension/entry.ex
@@ -32,6 +32,7 @@ defmodule Minga.Extension.Entry do
     :hex,
     :module,
     :pid,
+    :manifest,
     config: [],
     status: :stopped
   ]
@@ -43,6 +44,7 @@ defmodule Minga.Extension.Entry do
           hex: hex_opts() | nil,
           module: module() | nil,
           pid: pid() | nil,
+          manifest: Extension.Manifest.t() | nil,
           config: keyword(),
           status: Extension.extension_status()
         }

--- a/lib/minga/extension/entry.ex
+++ b/lib/minga/extension/entry.ex
@@ -33,6 +33,7 @@ defmodule Minga.Extension.Entry do
     :module,
     :pid,
     :manifest,
+    lifecycle_ref: nil,
     config: [],
     status: :stopped
   ]
@@ -45,6 +46,7 @@ defmodule Minga.Extension.Entry do
           module: module() | nil,
           pid: pid() | nil,
           manifest: Extension.Manifest.t() | nil,
+          lifecycle_ref: reference() | nil,
           config: keyword(),
           status: Extension.extension_status()
         }

--- a/lib/minga/extension/entry.ex
+++ b/lib/minga/extension/entry.ex
@@ -21,7 +21,8 @@ defmodule Minga.Extension.Entry do
   @typedoc "Hex-specific source options."
   @type hex_opts :: %{
           package: String.t(),
-          version: String.t() | nil
+          version: String.t() | nil,
+          app: atom() | nil
         }
 
   @enforce_keys [:source_type]
@@ -73,11 +74,19 @@ defmodule Minga.Extension.Entry do
   @doc "Creates a hex-sourced entry."
   @spec from_hex(String.t(), keyword()) :: t()
   def from_hex(package, opts) when is_binary(package) and is_list(opts) do
-    {version, config} = Keyword.pop(opts, :version)
+    {version, opts} = Keyword.pop(opts, :version)
+    {app, config} = Keyword.pop(opts, :app)
+
+    app =
+      case app do
+        nil -> nil
+        app when is_atom(app) -> app
+        _ -> raise ArgumentError, "hex app must be an atom when provided"
+      end
 
     %__MODULE__{
       source_type: :hex,
-      hex: %{package: package, version: version},
+      hex: %{package: package, version: version, app: app},
       config: config
     }
   end

--- a/lib/minga/extension/hex.ex
+++ b/lib/minga/extension/hex.ex
@@ -75,7 +75,7 @@ defmodule Minga.Extension.Hex do
   @doc """
   Collects hex deps from the registry as Mix.install-compatible tuples.
 
-  Returns a list like `[{:minga_snippets, "~> 0.3"}, {:other_ext, ">= 0.0.0"}]`.
+  Returns a list like `[{:snippets, "~> 0.3", hex: "minga_snippets"}]`.
   Extensions without a version constraint default to `">= 0.0.0"` (latest).
   """
   @spec collect_hex_deps(GenServer.server()) :: [mix_dep()]
@@ -83,7 +83,7 @@ defmodule Minga.Extension.Hex do
     registry
     |> ExtRegistry.all()
     |> Enum.filter(fn {_name, entry} -> entry.source_type == :hex end)
-    |> Enum.map(fn {_name, %Entry{hex: hex}} -> to_mix_dep(hex) end)
+    |> Enum.map(fn {name, %Entry{hex: hex}} -> to_mix_dep(name, hex) end)
   end
 
   # ── Private ─────────────────────────────────────────────────────────────────
@@ -106,12 +106,21 @@ defmodule Minga.Extension.Hex do
       {:error, msg}
   end
 
-  @spec to_mix_dep(%{package: String.t(), version: String.t() | nil}) :: mix_dep()
-  defp to_mix_dep(%{package: package, version: nil}) do
-    {String.to_atom(package), ">= 0.0.0"}
+  @spec to_mix_dep(atom(), %{package: String.t(), version: String.t() | nil, app: atom() | nil}) ::
+          mix_dep()
+  defp to_mix_dep(name, %{app: nil, package: package, version: nil}) do
+    {name, ">= 0.0.0", hex: package}
   end
 
-  defp to_mix_dep(%{package: package, version: version}) do
-    {String.to_atom(package), version}
+  defp to_mix_dep(name, %{app: nil, package: package, version: version}) do
+    {name, version, hex: package}
+  end
+
+  defp to_mix_dep(_name, %{app: app, package: package, version: nil}) when is_atom(app) do
+    {app, ">= 0.0.0", hex: package}
+  end
+
+  defp to_mix_dep(_name, %{app: app, package: package, version: version}) when is_atom(app) do
+    {app, version, hex: package}
   end
 end

--- a/lib/minga/extension/manifest.ex
+++ b/lib/minga/extension/manifest.ex
@@ -7,8 +7,8 @@ defmodule Minga.Extension.Manifest do
 
   alias Minga.Extension
 
-  @typedoc "Declared runtime/UI capability map. Keys are capability families and values are capability-specific terms."
-  @type capabilities :: %{optional(atom()) => term()}
+  @typedoc "Declared runtime/UI capabilities in declaration order. Duplicate entries are preserved."
+  @type capabilities :: [Extension.capability_spec()]
 
   @typedoc "How the extension source code is obtained."
   @type source_type :: :path | :git | :hex
@@ -22,7 +22,7 @@ defmodule Minga.Extension.Manifest do
     commands: [],
     keybindings: [],
     modeline_segments: [],
-    capabilities: %{}
+    capabilities: []
   ]
 
   @type t :: %__MODULE__{
@@ -36,7 +36,13 @@ defmodule Minga.Extension.Manifest do
           capabilities: capabilities()
         }
 
-  @doc "Builds a manifest from an extension module and source type."
+  @doc """
+  Builds a manifest from an extension module and source type.
+
+  This calls the extension's declaration callbacks directly, so callback
+  failures can raise or exit. The extension supervisor rescues those failures
+  and turns them into load errors during startup.
+  """
   @spec from_module(module(), source_type()) :: t()
   def from_module(module, source) when is_atom(module) and source in [:path, :git, :hex] do
     %__MODULE__{
@@ -64,7 +70,7 @@ defmodule Minga.Extension.Manifest do
   @spec safe_capabilities(module()) :: capabilities()
   defp safe_capabilities(module) do
     if function_exported?(module, :__capability_schema__, 0),
-      do: Map.new(module.__capability_schema__()),
-      else: %{}
+      do: module.__capability_schema__(),
+      else: []
   end
 end

--- a/lib/minga/extension/manifest.ex
+++ b/lib/minga/extension/manifest.ex
@@ -1,0 +1,70 @@
+defmodule Minga.Extension.Manifest do
+  @moduledoc """
+  Public declaration snapshot for an extension before runtime side effects run.
+
+  Manifests are append-only data contracts. Callers can inspect what an extension declares, which source it came from, and which runtime capabilities it says it uses without invoking extension code beyond static callback/schema functions.
+  """
+
+  alias Minga.Extension
+
+  @typedoc "Declared runtime/UI capability map. Keys are capability families and values are capability-specific terms."
+  @type capabilities :: %{optional(atom()) => term()}
+
+  @typedoc "How the extension source code is obtained."
+  @type source_type :: :path | :git | :hex
+
+  @enforce_keys [:name, :version, :source]
+  defstruct [
+    :name,
+    :description,
+    :version,
+    :source,
+    commands: [],
+    keybindings: [],
+    modeline_segments: [],
+    capabilities: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          description: String.t() | nil,
+          version: String.t(),
+          source: source_type(),
+          commands: [Extension.command_spec()],
+          keybindings: [Extension.keybind_spec()],
+          modeline_segments: [Extension.modeline_segment_spec()],
+          capabilities: capabilities()
+        }
+
+  @doc "Builds a manifest from an extension module and source type."
+  @spec from_module(module(), source_type()) :: t()
+  def from_module(module, source) when is_atom(module) and source in [:path, :git, :hex] do
+    %__MODULE__{
+      name: module.name(),
+      description: safe_description(module),
+      version: module.version(),
+      source: source,
+      commands: safe_schema(module, :__command_schema__),
+      keybindings: safe_schema(module, :__keybind_schema__),
+      modeline_segments: safe_schema(module, :__modeline_segment_schema__),
+      capabilities: safe_capabilities(module)
+    }
+  end
+
+  @spec safe_description(module()) :: String.t() | nil
+  defp safe_description(module) do
+    if function_exported?(module, :description, 0), do: module.description(), else: nil
+  end
+
+  @spec safe_schema(module(), atom()) :: list()
+  defp safe_schema(module, fun) do
+    if function_exported?(module, fun, 0), do: apply(module, fun, []), else: []
+  end
+
+  @spec safe_capabilities(module()) :: capabilities()
+  defp safe_capabilities(module) do
+    if function_exported?(module, :__capability_schema__, 0),
+      do: Map.new(module.__capability_schema__()),
+      else: %{}
+  end
+end

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -462,7 +462,7 @@ defmodule Minga.Extension.Supervisor do
     case run_lifecycle_phase(name, :child_start, opts, fn ->
            start_extension_child(supervisor, module, config)
          end) do
-      {:ok, pid} ->
+      {:ok, {pid, restart}} ->
         ExtRegistry.update(
           registry,
           name,
@@ -483,6 +483,7 @@ defmodule Minga.Extension.Supervisor do
             lifecycle_ref: lifecycle_ref,
             cmd_registry: cmd_registry,
             keymap: keymap,
+            restart: restart,
             opts: opts
           },
           pid
@@ -685,7 +686,7 @@ defmodule Minga.Extension.Supervisor do
   defp canonical_registry_id(registry), do: registry
 
   @spec current_start_entry(GenServer.server(), GenServer.server(), atom()) ::
-          {:ok, ExtRegistry.entry() | {:running, pid()}} | {:error, :not_registered}
+          {:ok, ExtRegistry.entry() | {:running, pid()}} | {:error, term()}
   defp current_start_entry(supervisor, registry, name) do
     case ExtRegistry.get(registry, name) do
       {:ok, %{status: :running, pid: pid} = entry} when is_pid(pid) ->
@@ -705,7 +706,7 @@ defmodule Minga.Extension.Supervisor do
           atom(),
           pid(),
           ExtRegistry.entry()
-        ) :: {:ok, {:running, pid()} | ExtRegistry.entry()}
+        ) :: {:ok, {:running, pid()} | ExtRegistry.entry()} | {:error, term()}
   defp current_running_or_restartable_entry(supervisor, registry, name, pid, entry) do
     case Process.alive?(pid) do
       true ->
@@ -722,16 +723,25 @@ defmodule Minga.Extension.Supervisor do
           atom(),
           ExtRegistry.entry()
         ) ::
-          {:ok, {:running, pid()} | ExtRegistry.entry()}
+          {:ok, {:running, pid()} | ExtRegistry.entry()} | {:error, term()}
   defp reconcile_dead_running_entry(supervisor, registry, name, %{module: module} = entry)
        when is_atom(module) and not is_nil(module) do
     case extension_child_pid(supervisor, module) do
-      pid when is_pid(pid) ->
+      {:ok, pid} ->
         ExtRegistry.update(registry, name, pid: pid)
         {:ok, {:running, pid}}
 
-      nil ->
+      :not_found ->
         {:ok, entry}
+
+      {:error, reason} ->
+        Minga.Log.warning(
+          :config,
+          "Extension #{name} restart reconciliation failed: #{inspect(reason)}"
+        )
+
+        mark_start_load_error(registry, name)
+        {:error, {:restart_lookup_failed, reason}}
     end
   end
 
@@ -839,10 +849,15 @@ defmodule Minga.Extension.Supervisor do
   end
 
   @spec start_extension_child(GenServer.server(), module(), keyword()) ::
-          {:ok, pid()} | {:error, term()}
+          {:ok, {pid(), child_restart()}} | {:error, term()}
   defp start_extension_child(supervisor, module, config) do
     child_spec = normalize_child_spec(module, config)
-    DynamicSupervisor.start_child(supervisor, child_spec)
+    restart = Map.get(child_spec, :restart, :permanent)
+
+    case DynamicSupervisor.start_child(supervisor, child_spec) do
+      {:ok, pid} -> {:ok, {pid, restart}}
+      {:error, _reason} = error -> error
+    end
   rescue
     e -> {:error, {:child_spec_failed, Exception.message(e)}}
   catch
@@ -878,10 +893,13 @@ defmodule Minga.Extension.Supervisor do
 
   defp terminate_extension_process_by_module(supervisor, module) do
     case extension_child_pid(supervisor, module) do
-      pid when is_pid(pid) -> terminate_extension_child(supervisor, pid)
-      nil -> {:error, :not_found}
+      {:ok, pid} -> terminate_extension_child(supervisor, pid)
+      :not_found -> {:error, :not_found}
+      {:error, reason} -> {:error, {:restart_lookup_failed, reason}}
     end
   end
+
+  @typep child_restart :: :permanent | :transient | :temporary
 
   @typep restart_monitor :: %{
            supervisor: GenServer.server(),
@@ -891,6 +909,7 @@ defmodule Minga.Extension.Supervisor do
            lifecycle_ref: reference(),
            cmd_registry: GenServer.server(),
            keymap: GenServer.server(),
+           restart: child_restart(),
            opts: start_opts()
          }
 
@@ -906,13 +925,13 @@ defmodule Minga.Extension.Supervisor do
     ref = Process.monitor(pid)
 
     receive do
-      {:DOWN, ^ref, :process, ^pid, reason} -> handle_child_down(monitor, reason, count)
+      {:DOWN, ^ref, :process, ^pid, reason} -> handle_child_down(monitor, pid, reason, count)
     end
   end
 
-  @spec handle_child_down(restart_monitor(), term(), non_neg_integer()) :: :ok
-  defp handle_child_down(monitor, reason, count) do
-    wait_for_restarted_child(monitor, reason, count + 1, 0)
+  @spec handle_child_down(restart_monitor(), pid(), term(), non_neg_integer()) :: :ok
+  defp handle_child_down(monitor, pid, reason, count) do
+    wait_for_restarted_child(monitor, pid, reason, count + 1, 0)
   end
 
   @spec lifecycle_monitor_active?(GenServer.server(), atom(), reference()) :: boolean()
@@ -929,9 +948,77 @@ defmodule Minga.Extension.Supervisor do
   defp crash_reason?({:shutdown, _reason}), do: false
   defp crash_reason?(_reason), do: true
 
-  @spec wait_for_restarted_child(restart_monitor(), term(), non_neg_integer(), non_neg_integer()) ::
+  @spec wait_for_restarted_child(
+          restart_monitor(),
+          pid(),
+          term(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
           :ok
-  defp wait_for_restarted_child(monitor, reason, _count, 5) do
+  defp wait_for_restarted_child(monitor, excluded_pid, reason, count, attempts) do
+    case lifecycle_monitor_active?(monitor.registry, monitor.name, monitor.lifecycle_ref) do
+      true -> wait_for_active_monitor_child(monitor, excluded_pid, reason, count, attempts)
+      false -> :ok
+    end
+  end
+
+  @spec wait_for_active_monitor_child(
+          restart_monitor(),
+          pid(),
+          term(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: :ok
+  defp wait_for_active_monitor_child(monitor, excluded_pid, reason, count, attempts) do
+    case extension_child_pid(monitor.supervisor, monitor.module, excluded_pid) do
+      {:ok, pid} ->
+        handle_restarted_child(monitor, pid, count)
+
+      :not_found ->
+        wait_for_missing_restarted_child(monitor, excluded_pid, reason, count, attempts)
+
+      {:error, lookup_reason} ->
+        Minga.Log.warning(
+          :config,
+          "Extension #{monitor.name} restart reconciliation failed: #{inspect(lookup_reason)}"
+        )
+
+        finalize_terminal_child_exit(monitor, reason)
+    end
+  end
+
+  @spec wait_for_missing_restarted_child(
+          restart_monitor(),
+          pid(),
+          term(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: :ok
+  defp wait_for_missing_restarted_child(monitor, excluded_pid, reason, count, attempts) do
+    case restart_terminal_exit?(monitor.restart, reason) do
+      true ->
+        finalize_terminal_child_exit(monitor, reason)
+
+      false ->
+        if attempts >= restart_reconcile_attempt_limit() do
+          Minga.Log.warning(
+            :config,
+            "Extension #{monitor.name} restart reconciliation timed out after #{attempts} attempt(s)"
+          )
+
+          finalize_terminal_child_exit(monitor, reason)
+        else
+          receive do
+          after
+            10 -> wait_for_restarted_child(monitor, excluded_pid, reason, count, attempts + 1)
+          end
+        end
+    end
+  end
+
+  @spec finalize_terminal_child_exit(restart_monitor(), term()) :: :ok
+  defp finalize_terminal_child_exit(monitor, reason) do
     run_test_hook(monitor.opts, :before_terminal_child_exit)
 
     mark_terminal_child_exit(
@@ -945,25 +1032,14 @@ defmodule Minga.Extension.Supervisor do
     )
   end
 
-  defp wait_for_restarted_child(monitor, reason, count, attempts) do
-    case lifecycle_monitor_active?(monitor.registry, monitor.name, monitor.lifecycle_ref) do
-      true -> wait_for_active_monitor_child(monitor, reason, count, attempts)
-      false -> :ok
-    end
-  end
+  @spec restart_terminal_exit?(child_restart(), term()) :: boolean()
+  defp restart_terminal_exit?(:temporary, _reason), do: true
+  defp restart_terminal_exit?(:transient, reason), do: not crash_reason?(reason)
+  defp restart_terminal_exit?(:permanent, _reason), do: false
 
-  @spec wait_for_active_monitor_child(
-          restart_monitor(),
-          term(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: :ok
-  defp wait_for_active_monitor_child(monitor, reason, count, attempts) do
-    case extension_child_pid(monitor.supervisor, monitor.module) do
-      pid when is_pid(pid) -> handle_restarted_child(monitor, pid, count)
-      nil -> retry_restarted_child_wait(monitor, reason, count, attempts)
-    end
-  end
+  @restart_reconcile_attempt_limit 50
+  @spec restart_reconcile_attempt_limit() :: non_neg_integer()
+  defp restart_reconcile_attempt_limit, do: @restart_reconcile_attempt_limit
 
   @spec handle_restarted_child(restart_monitor(), pid(), non_neg_integer()) :: :ok
   defp handle_restarted_child(monitor, pid, count) do
@@ -989,20 +1065,6 @@ defmodule Minga.Extension.Supervisor do
           :stale
       end
     end)
-  end
-
-  @spec retry_restarted_child_wait(
-          restart_monitor(),
-          term(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) ::
-          :ok
-  defp retry_restarted_child_wait(monitor, reason, count, attempts) do
-    receive do
-    after
-      10 -> wait_for_restarted_child(monitor, reason, count, attempts + 1)
-    end
   end
 
   @spec mark_terminal_child_exit(
@@ -1114,16 +1176,21 @@ defmodule Minga.Extension.Supervisor do
     :ok
   end
 
-  @spec extension_child_pid(GenServer.server(), module()) :: pid() | nil
-  defp extension_child_pid(supervisor, module) do
+  @spec extension_child_pid(GenServer.server(), module()) ::
+          {:ok, pid()} | :not_found | {:error, term()}
+  defp extension_child_pid(supervisor, module), do: extension_child_pid(supervisor, module, nil)
+
+  @spec extension_child_pid(GenServer.server(), module(), pid() | nil) ::
+          {:ok, pid()} | :not_found | {:error, term()}
+  defp extension_child_pid(supervisor, module, excluded_pid) do
     supervisor
     |> DynamicSupervisor.which_children()
-    |> Enum.find_value(fn
-      {:undefined, pid, _type, [^module]} when is_pid(pid) -> pid
-      _child -> nil
+    |> Enum.find_value(:not_found, fn
+      {:undefined, pid, _type, [^module]} when is_pid(pid) and pid != excluded_pid -> {:ok, pid}
+      _child -> false
     end)
   catch
-    :exit, _reason -> nil
+    :exit, reason -> {:error, {:which_children_failed, reason}}
   end
 
   @spec resolve_git_extensions(GenServer.server()) :: [start_failure()]
@@ -1164,12 +1231,12 @@ defmodule Minga.Extension.Supervisor do
     keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
     mark_start_attempt(registry, name)
 
-    with {:ok, package_atom} <- hex_package_application(entry.hex.package),
+    with {:ok, app_atom} <- hex_application_name(name, entry.hex),
          :ok <-
            run_lifecycle_phase(name, :load, opts, fn ->
-             ensure_hex_application_started(package_atom)
+             ensure_hex_application_started(app_atom)
            end),
-         {:ok, module} <- find_extension_module(package_atom),
+         {:ok, module} <- find_extension_module(app_atom),
          :ok <- validate_behaviour(module, name),
          :ok <- record_extension_manifest(registry, name, module, entry.source_type),
          :ok <- register_and_validate_options(name, module, entry.config),
@@ -1435,15 +1502,10 @@ defmodule Minga.Extension.Supervisor do
     :ok
   end
 
-  @spec hex_package_application(String.t()) :: {:ok, atom()} | {:error, term()}
-  defp hex_package_application(package) when is_binary(package) do
-    package
-    |> String.replace("-", "_")
-    |> String.to_existing_atom()
-    |> then(&{:ok, &1})
-  rescue
-    ArgumentError -> {:error, {:unknown_hex_application, package}}
-  end
+  @spec hex_application_name(atom(), Minga.Extension.Entry.hex_opts()) ::
+          {:ok, atom()} | {:error, term()}
+  defp hex_application_name(_name, %{app: app}) when is_atom(app) and app != nil, do: {:ok, app}
+  defp hex_application_name(name, %{app: nil}), do: {:ok, name}
 
   @spec ensure_hex_application_started(atom()) :: :ok | {:error, term()}
   defp ensure_hex_application_started(package_atom) do

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -213,7 +213,7 @@ defmodule Minga.Extension.Supervisor do
           {:ok, pid()} | {:error, term()}
   def start_extension(supervisor, registry, name, _entry, opts \\ []) do
     with_lifecycle_lock(registry, name, fn ->
-      case current_start_entry(registry, name) do
+      case current_start_entry(supervisor, registry, name) do
         {:ok, {:running, pid}} ->
           {:ok, pid}
 
@@ -235,13 +235,14 @@ defmodule Minga.Extension.Supervisor do
         ) :: {:ok, pid()} | {:error, term()}
   defp start_current_entry_locked(
          _supervisor,
-         _registry,
-         _name,
+         registry,
+         name,
          %{source_type: :git, path: nil},
          _opts
        ) do
     # Git extensions are resolved to a local path in resolve_git_extensions/1.
     # If the current registry entry has no path, the clone failed.
+    mark_start_load_error(registry, name)
     {:error, :clone_failed}
   end
 
@@ -266,6 +267,7 @@ defmodule Minga.Extension.Supervisor do
   defp start_from_path_locked(supervisor, registry, name, entry, opts) do
     cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
     keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
+    mark_start_attempt(registry, name)
 
     with {:ok, module} <-
            run_lifecycle_phase(name, :load, opts, fn -> compile_extension(entry.path) end),
@@ -551,23 +553,8 @@ defmodule Minga.Extension.Supervisor do
         terminate_extension_process(supervisor, entry)
       end)
 
-    finalize_stopped_extension(registry, name, entry)
-
     cleanup_result = cleanup_extension_contributions(name, cmd_registry, keymap, opts)
-
-    case {termination_result, cleanup_result} do
-      {:ok, :ok} ->
-        :ok
-
-      {:ok, {:error, failures}} ->
-        {:error, {:cleanup_failed, failures}}
-
-      {{:error, reason}, :ok} ->
-        {:error, reason}
-
-      {{:error, reason}, {:error, failures}} ->
-        {:error, {:cleanup_failed, reason, failures}}
-    end
+    finalize_explicit_stop_result(termination_result, cleanup_result, registry, name, entry)
   end
 
   @doc """
@@ -612,6 +599,21 @@ defmodule Minga.Extension.Supervisor do
 
   # ── Private ────────────────────────────────────────────────────────────────
 
+  @spec mark_start_attempt(GenServer.server(), atom()) :: :ok
+  defp mark_start_attempt(registry, name) do
+    ExtRegistry.update(registry, name, manifest: nil)
+  end
+
+  @spec mark_start_load_error(GenServer.server(), atom()) :: :ok
+  defp mark_start_load_error(registry, name) do
+    ExtRegistry.update(registry, name,
+      status: :load_error,
+      pid: nil,
+      lifecycle_ref: nil,
+      manifest: nil
+    )
+  end
+
   @spec record_extension_manifest(GenServer.server(), atom(), module(), Manifest.source_type()) ::
           :ok | {:error, term()}
   defp record_extension_manifest(registry, name, module, source) do
@@ -639,18 +641,17 @@ defmodule Minga.Extension.Supervisor do
   @spec run_lifecycle_phase(atom(), atom(), start_opts(), (-> result)) :: result when result: var
   defp run_lifecycle_phase(name, phase, opts, fun)
        when is_atom(name) and is_atom(phase) and is_function(fun, 0) do
-    start_time = System.monotonic_time()
+    handler_id = attach_slow_lifecycle_handler(name, phase, opts)
 
-    result =
+    try do
       Minga.Telemetry.span(
         [:minga, :extension, :lifecycle],
         %{extension: name, phase: phase},
         fun
       )
-
-    duration = System.monotonic_time() - start_time
-    maybe_log_slow_lifecycle_phase(name, phase, duration, opts)
-    result
+    after
+      detach_slow_lifecycle_handler(handler_id)
+    end
   end
 
   @spec with_lifecycle_lock(GenServer.server(), atom(), (-> result)) :: result when result: var
@@ -683,12 +684,12 @@ defmodule Minga.Extension.Supervisor do
   defp canonical_registry_id({:via, module, name}), do: {:via, module, name}
   defp canonical_registry_id(registry), do: registry
 
-  @spec current_start_entry(GenServer.server(), atom()) ::
+  @spec current_start_entry(GenServer.server(), GenServer.server(), atom()) ::
           {:ok, ExtRegistry.entry() | {:running, pid()}} | {:error, :not_registered}
-  defp current_start_entry(registry, name) do
+  defp current_start_entry(supervisor, registry, name) do
     case ExtRegistry.get(registry, name) do
       {:ok, %{status: :running, pid: pid} = entry} when is_pid(pid) ->
-        current_running_or_restartable_entry(pid, entry)
+        current_running_or_restartable_entry(supervisor, registry, name, pid, entry)
 
       {:ok, entry} ->
         {:ok, entry}
@@ -698,14 +699,43 @@ defmodule Minga.Extension.Supervisor do
     end
   end
 
-  @spec current_running_or_restartable_entry(pid(), ExtRegistry.entry()) ::
-          {:ok, {:running, pid()} | ExtRegistry.entry()}
-  defp current_running_or_restartable_entry(pid, entry) do
+  @spec current_running_or_restartable_entry(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          pid(),
+          ExtRegistry.entry()
+        ) :: {:ok, {:running, pid()} | ExtRegistry.entry()}
+  defp current_running_or_restartable_entry(supervisor, registry, name, pid, entry) do
     case Process.alive?(pid) do
-      true -> {:ok, {:running, pid}}
-      false -> {:ok, entry}
+      true ->
+        {:ok, {:running, pid}}
+
+      false ->
+        reconcile_dead_running_entry(supervisor, registry, name, entry)
     end
   end
+
+  @spec reconcile_dead_running_entry(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry()
+        ) ::
+          {:ok, {:running, pid()} | ExtRegistry.entry()}
+  defp reconcile_dead_running_entry(supervisor, registry, name, %{module: module} = entry)
+       when is_atom(module) and not is_nil(module) do
+    case extension_child_pid(supervisor, module) do
+      pid when is_pid(pid) ->
+        ExtRegistry.update(registry, name, pid: pid)
+        {:ok, {:running, pid}}
+
+      nil ->
+        {:ok, entry}
+    end
+  end
+
+  defp reconcile_dead_running_entry(_supervisor, _registry, _name, entry), do: {:ok, entry}
 
   @spec current_stop_entry(GenServer.server(), atom(), ExtRegistry.entry()) ::
           {:ok, ExtRegistry.entry()} | :stale | :not_registered
@@ -741,9 +771,42 @@ defmodule Minga.Extension.Supervisor do
 
   defp current_stop_entry_for_request(_requested_entry, _current_entry), do: :stale
 
-  @spec maybe_log_slow_lifecycle_phase(atom(), atom(), integer(), start_opts()) :: :ok
-  defp maybe_log_slow_lifecycle_phase(name, phase, duration, opts) do
+  @spec attach_slow_lifecycle_handler(atom(), atom(), start_opts()) :: term()
+  defp attach_slow_lifecycle_handler(name, phase, opts) do
     threshold_ms = Keyword.get(opts, :slow_lifecycle_threshold_ms, 50)
+    handler_id = {__MODULE__, :slow_lifecycle, self(), make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:minga, :extension, :lifecycle, :stop],
+      &__MODULE__.handle_slow_lifecycle_event/4,
+      %{extension: name, phase: phase, threshold_ms: threshold_ms}
+    )
+
+    handler_id
+  end
+
+  @spec detach_slow_lifecycle_handler(term()) :: :ok
+  defp detach_slow_lifecycle_handler(handler_id) do
+    :telemetry.detach(handler_id)
+    :ok
+  end
+
+  @doc false
+  @spec handle_slow_lifecycle_event([atom()], map(), map(), map()) :: :ok
+  def handle_slow_lifecycle_event(
+        _event,
+        %{duration: duration},
+        %{extension: extension, phase: phase},
+        %{extension: extension, phase: phase, threshold_ms: threshold_ms}
+      ) do
+    maybe_log_slow_lifecycle_phase(extension, phase, duration, threshold_ms)
+  end
+
+  def handle_slow_lifecycle_event(_event, _measurements, _metadata, _config), do: :ok
+
+  @spec maybe_log_slow_lifecycle_phase(atom(), atom(), integer(), non_neg_integer()) :: :ok
+  defp maybe_log_slow_lifecycle_phase(name, phase, duration, threshold_ms) do
     duration_ms = System.convert_time_unit(duration, :native, :millisecond)
 
     case duration_ms >= threshold_ms do
@@ -904,15 +967,28 @@ defmodule Minga.Extension.Supervisor do
 
   @spec handle_restarted_child(restart_monitor(), pid(), non_neg_integer()) :: :ok
   defp handle_restarted_child(monitor, pid, count) do
-    case lifecycle_monitor_active?(monitor.registry, monitor.name, monitor.lifecycle_ref) do
-      true ->
-        ExtRegistry.update(monitor.registry, monitor.name, pid: pid)
-        emit_restart_count(monitor.name, count)
-        monitor_child_restarts(monitor, pid, count)
+    run_test_hook(monitor.opts, :before_restart_reconcile)
 
-      false ->
-        :ok
+    case reconcile_restarted_child(monitor, pid, count) do
+      :monitor -> monitor_child_restarts(monitor, pid, count)
+      :stale -> :ok
     end
+  end
+
+  @spec reconcile_restarted_child(restart_monitor(), pid(), non_neg_integer()) ::
+          :monitor | :stale
+  defp reconcile_restarted_child(monitor, pid, count) do
+    with_lifecycle_lock(monitor.registry, monitor.name, fn ->
+      case lifecycle_monitor_active?(monitor.registry, monitor.name, monitor.lifecycle_ref) do
+        true ->
+          ExtRegistry.update(monitor.registry, monitor.name, pid: pid)
+          emit_restart_count(monitor.name, count)
+          :monitor
+
+        false ->
+          :stale
+      end
+    end)
   end
 
   @spec retry_restarted_child_wait(
@@ -1069,7 +1145,7 @@ defmodule Minga.Extension.Supervisor do
 
       {:error, reason} ->
         Minga.Log.warning(:config, "Extension #{name}: #{reason}")
-        ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
+        mark_start_load_error(registry, name)
         [%{extension: name, reason: reason} | failures]
     end
   end
@@ -1086,9 +1162,10 @@ defmodule Minga.Extension.Supervisor do
   defp find_and_start_hex_extension_locked(supervisor, registry, name, entry, opts) do
     cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
     keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
-    package_atom = String.to_atom(entry.hex.package)
+    mark_start_attempt(registry, name)
 
-    with :ok <-
+    with {:ok, package_atom} <- hex_package_application(entry.hex.package),
+         :ok <-
            run_lifecycle_phase(name, :load, opts, fn ->
              ensure_hex_application_started(package_atom)
            end),
@@ -1306,6 +1383,32 @@ defmodule Minga.Extension.Supervisor do
     end
   end
 
+  @spec finalize_explicit_stop_result(
+          :ok | {:error, term()},
+          :ok | {:error, [map()]},
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry()
+        ) :: :ok | {:error, term()}
+  defp finalize_explicit_stop_result(:ok, :ok, registry, name, entry) do
+    finalize_stopped_extension(registry, name, entry)
+  end
+
+  defp finalize_explicit_stop_result(:ok, {:error, failures}, registry, name, _entry) do
+    ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
+    {:error, {:cleanup_failed, failures}}
+  end
+
+  defp finalize_explicit_stop_result({:error, reason}, :ok, registry, name, entry) do
+    finalize_stopped_extension(registry, name, entry)
+    {:error, reason}
+  end
+
+  defp finalize_explicit_stop_result({:error, reason}, {:error, failures}, registry, name, _entry) do
+    ExtRegistry.update(registry, name, status: :load_error, lifecycle_ref: nil)
+    {:error, {:cleanup_failed, reason, failures}}
+  end
+
   @spec finalize_stopped_extension(GenServer.server(), atom(), ExtRegistry.entry()) :: :ok
   defp finalize_stopped_extension(registry, name, entry) do
     if entry.module do
@@ -1326,10 +1429,20 @@ defmodule Minga.Extension.Supervisor do
   @spec mark_hex_entries_load_error(GenServer.server()) :: :ok
   defp mark_hex_entries_load_error(registry) do
     for {name, entry} <- ExtRegistry.all(registry), entry.source_type == :hex do
-      ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
+      mark_start_load_error(registry, name)
     end
 
     :ok
+  end
+
+  @spec hex_package_application(String.t()) :: {:ok, atom()} | {:error, term()}
+  defp hex_package_application(package) when is_binary(package) do
+    package
+    |> String.replace("-", "_")
+    |> String.to_existing_atom()
+    |> then(&{:ok, &1})
+  rescue
+    ArgumentError -> {:error, {:unknown_hex_application, package}}
   end
 
   @spec ensure_hex_application_started(atom()) :: :ok | {:error, term()}

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -197,7 +197,8 @@ defmodule Minga.Extension.Supervisor do
           command_registry: GenServer.server(),
           keymap: GenServer.server(),
           callbacks: %{atom() => Minga.Extension.ContributionCleanup.cleanup_fun()},
-          slow_lifecycle_threshold_ms: non_neg_integer()
+          slow_lifecycle_threshold_ms: non_neg_integer(),
+          test_hooks: map()
         ]
 
   @spec start_extension(GenServer.server(), GenServer.server(), atom(), ExtRegistry.entry()) ::
@@ -210,30 +211,51 @@ defmodule Minga.Extension.Supervisor do
           start_opts()
         ) ::
           {:ok, pid()} | {:error, term()}
-  def start_extension(supervisor, registry, name, entry, opts \\ [])
+  def start_extension(supervisor, registry, name, _entry, opts \\ []) do
+    with_lifecycle_lock(registry, name, fn ->
+      case current_start_entry(registry, name) do
+        {:ok, {:running, pid}} ->
+          {:ok, pid}
 
-  def start_extension(supervisor, registry, name, %{source_type: :git} = entry, opts) do
+        {:ok, entry} ->
+          start_current_entry_locked(supervisor, registry, name, entry, opts)
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end)
+  end
+
+  @spec start_current_entry_locked(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts()
+        ) :: {:ok, pid()} | {:error, term()}
+  defp start_current_entry_locked(
+         _supervisor,
+         _registry,
+         _name,
+         %{source_type: :git, path: nil},
+         _opts
+       ) do
     # Git extensions are resolved to a local path in resolve_git_extensions/1.
-    # If the path was set, compile from there. Otherwise it failed to clone.
-    if entry.path do
-      start_from_path(supervisor, registry, name, entry, opts)
-    else
-      {:error, :clone_failed}
-    end
+    # If the current registry entry has no path, the clone failed.
+    {:error, :clone_failed}
   end
 
-  def start_extension(supervisor, registry, name, %{source_type: :hex} = entry, opts) do
+  defp start_current_entry_locked(supervisor, registry, name, %{source_type: :hex} = entry, opts) do
     # Hex extensions are loaded via Mix.install in start_all/2.
-    # Find the module implementing the Extension behaviour from the
-    # newly available code paths.
-    find_and_start_hex_extension(supervisor, registry, name, entry, opts)
+    # Find the module implementing the Extension behaviour from the newly available code paths.
+    find_and_start_hex_extension_locked(supervisor, registry, name, entry, opts)
   end
 
-  def start_extension(supervisor, registry, name, entry, opts) do
-    start_from_path(supervisor, registry, name, entry, opts)
+  defp start_current_entry_locked(supervisor, registry, name, entry, opts) do
+    start_from_path_locked(supervisor, registry, name, entry, opts)
   end
 
-  @spec start_from_path(
+  @spec start_from_path_locked(
           GenServer.server(),
           GenServer.server(),
           atom(),
@@ -241,7 +263,7 @@ defmodule Minga.Extension.Supervisor do
           start_opts()
         ) ::
           {:ok, pid()} | {:error, term()}
-  defp start_from_path(supervisor, registry, name, entry, opts) do
+  defp start_from_path_locked(supervisor, registry, name, entry, opts) do
     cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
     keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
 
@@ -273,7 +295,7 @@ defmodule Minga.Extension.Supervisor do
       {:error, reason} ->
         msg = "Extension #{name} load error: #{inspect(reason)}"
         Minga.Log.warning(:config, msg)
-        ExtRegistry.update(registry, name, status: :load_error, pid: nil)
+        ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
         wrap_start_failure(name, reason, cmd_registry, keymap, opts)
     end
   end
@@ -336,7 +358,7 @@ defmodule Minga.Extension.Supervisor do
          keymap,
          opts
        ) do
-    case start_child(supervisor, registry, name, module, config, opts) do
+    case start_child(supervisor, registry, name, module, config, cmd_registry, keymap, opts) do
       {:ok, pid} ->
         register_dsl_for_started_child(supervisor, pid, module, name, cmd_registry, keymap)
 
@@ -412,7 +434,7 @@ defmodule Minga.Extension.Supervisor do
     cleanup_result = cleanup_extension_contributions(name, cmd_registry, keymap, opts)
     msg = "Extension #{name} load error: #{inspect(reason)}"
     Minga.Log.warning(:config, msg)
-    ExtRegistry.update(registry, name, status: :load_error, pid: nil)
+    ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
 
     case cleanup_result do
       :ok -> {:error, reason}
@@ -426,24 +448,60 @@ defmodule Minga.Extension.Supervisor do
           atom(),
           module(),
           keyword(),
+          GenServer.server(),
+          GenServer.server(),
           start_opts()
         ) ::
           {:ok, pid()} | {:error, term()}
-  defp start_child(supervisor, registry, name, module, config, opts) do
+  defp start_child(supervisor, registry, name, module, config, cmd_registry, keymap, opts) do
+    lifecycle_ref = make_ref()
+    ExtRegistry.update(registry, name, lifecycle_ref: lifecycle_ref)
+
     case run_lifecycle_phase(name, :child_start, opts, fn ->
            start_extension_child(supervisor, module, config)
          end) do
       {:ok, pid} ->
-        ExtRegistry.update(registry, name, module: module, status: :running, pid: pid)
+        ExtRegistry.update(
+          registry,
+          name,
+          module: module,
+          status: :running,
+          pid: pid,
+          lifecycle_ref: lifecycle_ref
+        )
+
         emit_restart_count(name, 0)
-        start_child_restart_monitor(supervisor, registry, name, module, pid)
+
+        start_child_restart_monitor(
+          %{
+            supervisor: supervisor,
+            registry: registry,
+            name: name,
+            module: module,
+            lifecycle_ref: lifecycle_ref,
+            cmd_registry: cmd_registry,
+            keymap: keymap,
+            opts: opts
+          },
+          pid
+        )
+
         Minga.Log.info(:config, "Extension #{name} started (#{module})")
         {:ok, pid}
 
       {:error, reason} ->
         msg = "Extension #{name} failed to start: #{inspect(reason)}"
         Minga.Log.warning(:config, msg)
-        ExtRegistry.update(registry, name, module: module, status: :load_error, pid: nil)
+
+        ExtRegistry.update(
+          registry,
+          name,
+          module: module,
+          status: :load_error,
+          pid: nil,
+          lifecycle_ref: nil
+        )
+
         {:error, reason}
     end
   end
@@ -461,8 +519,32 @@ defmodule Minga.Extension.Supervisor do
           start_opts()
         ) :: :ok | {:error, term()}
   def stop_extension(supervisor, registry, name, entry, opts \\ []) do
+    with_lifecycle_lock(registry, name, fn ->
+      case current_stop_entry(registry, name, entry) do
+        {:ok, current_entry} ->
+          stop_current_extension(supervisor, registry, name, current_entry, opts)
+
+        :stale ->
+          :ok
+
+        :not_registered ->
+          :ok
+      end
+    end)
+  end
+
+  @spec stop_current_extension(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts()
+        ) :: :ok | {:error, term()}
+  defp stop_current_extension(supervisor, registry, name, entry, opts) do
     cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
     keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
+
+    ExtRegistry.update(registry, name, lifecycle_ref: nil)
 
     termination_result =
       run_lifecycle_phase(name, :stop, opts, fn ->
@@ -533,11 +615,25 @@ defmodule Minga.Extension.Supervisor do
   @spec record_extension_manifest(GenServer.server(), atom(), module(), Manifest.source_type()) ::
           :ok | {:error, term()}
   defp record_extension_manifest(registry, name, module, source) do
-    manifest = Manifest.from_module(module, source)
-    ExtRegistry.update(registry, name, manifest: manifest)
-    :ok
+    case safe_record_extension_manifest(module, source) do
+      {:ok, manifest} ->
+        ExtRegistry.update(registry, name, manifest: manifest)
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @spec safe_record_extension_manifest(module(), Manifest.source_type()) ::
+          {:ok, Manifest.t()} | {:error, term()}
+  defp safe_record_extension_manifest(module, source) do
+    {:ok, Manifest.from_module(module, source)}
   rescue
     e -> {:error, "manifest introspection failed: #{Exception.message(e)}"}
+  catch
+    kind, reason ->
+      {:error, "manifest introspection failed: #{inspect(kind)} #{inspect(reason)}"}
   end
 
   @spec run_lifecycle_phase(atom(), atom(), start_opts(), (-> result)) :: result when result: var
@@ -556,6 +652,94 @@ defmodule Minga.Extension.Supervisor do
     maybe_log_slow_lifecycle_phase(name, phase, duration, opts)
     result
   end
+
+  @spec with_lifecycle_lock(GenServer.server(), atom(), (-> result)) :: result when result: var
+  defp with_lifecycle_lock(registry, name, fun) when is_atom(name) and is_function(fun, 0) do
+    # The resource id identifies the extension lifecycle stream to serialize.
+    # The requester id identifies this caller for :global.trans/4 reentrancy bookkeeping.
+    # Restricting nodes to [node()] keeps the lock local to this editor VM.
+    resource_id = {__MODULE__, :lifecycle, canonical_registry_id(registry), name}
+    requester_id = self()
+
+    :global.trans({resource_id, requester_id}, fun, [node()], :infinity)
+  end
+
+  @spec canonical_registry_id(GenServer.server()) :: term()
+  defp canonical_registry_id(registry) when is_pid(registry) do
+    case Process.info(registry, :registered_name) do
+      {:registered_name, name} when is_atom(name) -> {:local_name, name}
+      _other -> {:pid, registry}
+    end
+  end
+
+  defp canonical_registry_id(registry) when is_atom(registry) do
+    case Process.whereis(registry) do
+      pid when is_pid(pid) -> canonical_registry_id(pid)
+      nil -> {:local_name, registry}
+    end
+  end
+
+  defp canonical_registry_id({:global, name}), do: {:global_name, name}
+  defp canonical_registry_id({:via, module, name}), do: {:via, module, name}
+  defp canonical_registry_id(registry), do: registry
+
+  @spec current_start_entry(GenServer.server(), atom()) ::
+          {:ok, ExtRegistry.entry() | {:running, pid()}} | {:error, :not_registered}
+  defp current_start_entry(registry, name) do
+    case ExtRegistry.get(registry, name) do
+      {:ok, %{status: :running, pid: pid} = entry} when is_pid(pid) ->
+        current_running_or_restartable_entry(pid, entry)
+
+      {:ok, entry} ->
+        {:ok, entry}
+
+      :error ->
+        {:error, :not_registered}
+    end
+  end
+
+  @spec current_running_or_restartable_entry(pid(), ExtRegistry.entry()) ::
+          {:ok, {:running, pid()} | ExtRegistry.entry()}
+  defp current_running_or_restartable_entry(pid, entry) do
+    case Process.alive?(pid) do
+      true -> {:ok, {:running, pid}}
+      false -> {:ok, entry}
+    end
+  end
+
+  @spec current_stop_entry(GenServer.server(), atom(), ExtRegistry.entry()) ::
+          {:ok, ExtRegistry.entry()} | :stale | :not_registered
+  defp current_stop_entry(registry, name, requested_entry) do
+    case ExtRegistry.get(registry, name) do
+      {:ok, current_entry} -> current_stop_entry_for_request(requested_entry, current_entry)
+      :error -> :not_registered
+    end
+  end
+
+  @spec current_stop_entry_for_request(ExtRegistry.entry(), ExtRegistry.entry()) ::
+          {:ok, ExtRegistry.entry()} | :stale
+  defp current_stop_entry_for_request(
+         %{status: :running, lifecycle_ref: requested_ref},
+         %{status: :running, lifecycle_ref: requested_ref} = current_entry
+       )
+       when is_reference(requested_ref),
+       do: {:ok, current_entry}
+
+  defp current_stop_entry_for_request(
+         %{status: :running, pid: requested_pid, lifecycle_ref: nil},
+         %{status: :running, pid: requested_pid, lifecycle_ref: nil} = current_entry
+       )
+       when is_pid(requested_pid),
+       do: {:ok, current_entry}
+
+  defp current_stop_entry_for_request(
+         %{status: requested_status, pid: nil, lifecycle_ref: nil},
+         %{status: requested_status, pid: nil, lifecycle_ref: nil} = current_entry
+       )
+       when requested_status != :running,
+       do: {:ok, current_entry}
+
+  defp current_stop_entry_for_request(_requested_entry, _current_entry), do: :stale
 
   @spec maybe_log_slow_lifecycle_phase(atom(), atom(), integer(), start_opts()) :: :ok
   defp maybe_log_slow_lifecycle_phase(name, phase, duration, opts) do
@@ -581,6 +765,14 @@ defmodule Minga.Extension.Supervisor do
       %{count: count},
       %{extension: name, phase: :crash_restart_count}
     )
+  end
+
+  @spec run_test_hook(start_opts(), atom()) :: :ok
+  defp run_test_hook(opts, hook_name) do
+    case Keyword.get(opts, :test_hooks, %{}) do
+      %{^hook_name => hook} when is_function(hook, 0) -> hook.()
+      _ -> :ok
+    end
   end
 
   @spec start_extension_child(GenServer.server(), module(), keyword()) ::
@@ -628,45 +820,44 @@ defmodule Minga.Extension.Supervisor do
     end
   end
 
-  @spec start_child_restart_monitor(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          module(),
-          pid()
-        ) :: :ok
-  defp start_child_restart_monitor(supervisor, registry, name, module, pid) do
-    spawn(fn -> monitor_child_restarts(supervisor, registry, name, module, pid, 0) end)
+  @typep restart_monitor :: %{
+           supervisor: GenServer.server(),
+           registry: GenServer.server(),
+           name: atom(),
+           module: module(),
+           lifecycle_ref: reference(),
+           cmd_registry: GenServer.server(),
+           keymap: GenServer.server(),
+           opts: start_opts()
+         }
+
+  @spec start_child_restart_monitor(restart_monitor(), pid()) :: :ok
+  defp start_child_restart_monitor(monitor, pid) do
+    spawn(fn -> monitor_child_restarts(monitor, pid, 0) end)
+
     :ok
   end
 
-  @spec monitor_child_restarts(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          module(),
-          pid(),
-          non_neg_integer()
-        ) :: :ok
-  defp monitor_child_restarts(supervisor, registry, name, module, pid, count) do
+  @spec monitor_child_restarts(restart_monitor(), pid(), non_neg_integer()) :: :ok
+  defp monitor_child_restarts(monitor, pid, count) do
     ref = Process.monitor(pid)
 
     receive do
-      {:DOWN, ^ref, :process, ^pid, reason} ->
-        handle_child_down(supervisor, registry, name, module, reason, count)
+      {:DOWN, ^ref, :process, ^pid, reason} -> handle_child_down(monitor, reason, count)
     end
   end
 
-  @spec handle_child_down(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          module(),
-          term(),
-          non_neg_integer()
-        ) :: :ok
-  defp handle_child_down(supervisor, registry, name, module, reason, count) do
-    wait_for_restarted_child(supervisor, registry, name, module, reason, count + 1, 0)
+  @spec handle_child_down(restart_monitor(), term(), non_neg_integer()) :: :ok
+  defp handle_child_down(monitor, reason, count) do
+    wait_for_restarted_child(monitor, reason, count + 1, 0)
+  end
+
+  @spec lifecycle_monitor_active?(GenServer.server(), atom(), reference()) :: boolean()
+  defp lifecycle_monitor_active?(registry, name, lifecycle_ref) do
+    case ExtRegistry.get(registry, name) do
+      {:ok, %{lifecycle_ref: ^lifecycle_ref, status: :running}} -> true
+      _ -> false
+    end
   end
 
   @spec crash_reason?(term()) :: boolean()
@@ -675,49 +866,176 @@ defmodule Minga.Extension.Supervisor do
   defp crash_reason?({:shutdown, _reason}), do: false
   defp crash_reason?(_reason), do: true
 
-  @spec wait_for_restarted_child(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          module(),
+  @spec wait_for_restarted_child(restart_monitor(), term(), non_neg_integer(), non_neg_integer()) ::
+          :ok
+  defp wait_for_restarted_child(monitor, reason, _count, 5) do
+    run_test_hook(monitor.opts, :before_terminal_child_exit)
+
+    mark_terminal_child_exit(
+      monitor.registry,
+      monitor.name,
+      monitor.lifecycle_ref,
+      monitor.cmd_registry,
+      monitor.keymap,
+      monitor.opts,
+      reason
+    )
+  end
+
+  defp wait_for_restarted_child(monitor, reason, count, attempts) do
+    case lifecycle_monitor_active?(monitor.registry, monitor.name, monitor.lifecycle_ref) do
+      true -> wait_for_active_monitor_child(monitor, reason, count, attempts)
+      false -> :ok
+    end
+  end
+
+  @spec wait_for_active_monitor_child(
+          restart_monitor(),
           term(),
           non_neg_integer(),
           non_neg_integer()
         ) :: :ok
-  defp wait_for_restarted_child(_supervisor, registry, name, _module, reason, _count, 5) do
-    mark_crashed_without_replacement(registry, name, reason)
-  end
-
-  defp wait_for_restarted_child(supervisor, registry, name, module, reason, count, attempts) do
-    case extension_child_pid(supervisor, module) do
-      pid when is_pid(pid) ->
-        ExtRegistry.update(registry, name, pid: pid)
-        emit_restart_count(name, count)
-        monitor_child_restarts(supervisor, registry, name, module, pid, count)
-
-      nil ->
-        receive do
-        after
-          10 ->
-            wait_for_restarted_child(
-              supervisor,
-              registry,
-              name,
-              module,
-              reason,
-              count,
-              attempts + 1
-            )
-        end
+  defp wait_for_active_monitor_child(monitor, reason, count, attempts) do
+    case extension_child_pid(monitor.supervisor, monitor.module) do
+      pid when is_pid(pid) -> handle_restarted_child(monitor, pid, count)
+      nil -> retry_restarted_child_wait(monitor, reason, count, attempts)
     end
   end
 
-  @spec mark_crashed_without_replacement(GenServer.server(), atom(), term()) :: :ok
-  defp mark_crashed_without_replacement(registry, name, reason) do
-    case crash_reason?(reason) do
-      true -> ExtRegistry.update(registry, name, status: :crashed, pid: nil)
-      false -> :ok
+  @spec handle_restarted_child(restart_monitor(), pid(), non_neg_integer()) :: :ok
+  defp handle_restarted_child(monitor, pid, count) do
+    case lifecycle_monitor_active?(monitor.registry, monitor.name, monitor.lifecycle_ref) do
+      true ->
+        ExtRegistry.update(monitor.registry, monitor.name, pid: pid)
+        emit_restart_count(monitor.name, count)
+        monitor_child_restarts(monitor, pid, count)
+
+      false ->
+        :ok
     end
+  end
+
+  @spec retry_restarted_child_wait(
+          restart_monitor(),
+          term(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          :ok
+  defp retry_restarted_child_wait(monitor, reason, count, attempts) do
+    receive do
+    after
+      10 -> wait_for_restarted_child(monitor, reason, count, attempts + 1)
+    end
+  end
+
+  @spec mark_terminal_child_exit(
+          GenServer.server(),
+          atom(),
+          reference(),
+          GenServer.server(),
+          GenServer.server(),
+          start_opts(),
+          term()
+        ) :: :ok
+  defp mark_terminal_child_exit(registry, name, lifecycle_ref, cmd_registry, keymap, opts, reason) do
+    with_lifecycle_lock(registry, name, fn ->
+      case crash_reason?(reason) do
+        true ->
+          mark_crashed_without_replacement(registry, name, lifecycle_ref)
+
+        false ->
+          mark_stopped_without_replacement(
+            registry,
+            name,
+            lifecycle_ref,
+            cmd_registry,
+            keymap,
+            opts
+          )
+      end
+    end)
+  end
+
+  @spec mark_crashed_without_replacement(GenServer.server(), atom(), reference()) :: :ok
+  defp mark_crashed_without_replacement(registry, name, lifecycle_ref) do
+    if lifecycle_monitor_active?(registry, name, lifecycle_ref) do
+      ExtRegistry.update(registry, name, status: :crashed, pid: nil, lifecycle_ref: nil)
+    end
+
+    :ok
+  end
+
+  @spec mark_stopped_without_replacement(
+          GenServer.server(),
+          atom(),
+          reference(),
+          GenServer.server(),
+          GenServer.server(),
+          start_opts()
+        ) :: :ok
+  defp mark_stopped_without_replacement(registry, name, lifecycle_ref, cmd_registry, keymap, opts) do
+    finalize_stopped_lifecycle_exit(registry, name, lifecycle_ref, cmd_registry, keymap, opts)
+    :ok
+  end
+
+  @spec finalize_stopped_lifecycle_exit(
+          GenServer.server(),
+          atom(),
+          reference(),
+          GenServer.server(),
+          GenServer.server(),
+          start_opts()
+        ) :: :ok
+  defp finalize_stopped_lifecycle_exit(registry, name, lifecycle_ref, cmd_registry, keymap, opts) do
+    if lifecycle_monitor_active?(registry, name, lifecycle_ref) do
+      case ExtRegistry.get(registry, name) do
+        {:ok, entry} ->
+          cleanup_result = cleanup_extension_contributions(name, cmd_registry, keymap, opts)
+
+          finalize_terminal_cleanup_result(
+            cleanup_result,
+            registry,
+            name,
+            lifecycle_ref,
+            entry
+          )
+
+        :error ->
+          :ok
+      end
+    end
+
+    :ok
+  end
+
+  @spec finalize_terminal_cleanup_result(
+          :ok | {:error, [map()]},
+          GenServer.server(),
+          atom(),
+          reference(),
+          ExtRegistry.entry()
+        ) :: :ok
+  defp finalize_terminal_cleanup_result(:ok, registry, name, lifecycle_ref, entry) do
+    if lifecycle_monitor_active?(registry, name, lifecycle_ref) do
+      finalize_stopped_extension(registry, name, entry)
+    end
+
+    :ok
+  end
+
+  defp finalize_terminal_cleanup_result(
+         {:error, _failures},
+         registry,
+         name,
+         lifecycle_ref,
+         _entry
+       ) do
+    if lifecycle_monitor_active?(registry, name, lifecycle_ref) do
+      ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
+    end
+
+    :ok
   end
 
   @spec extension_child_pid(GenServer.server(), module()) :: pid() | nil
@@ -751,21 +1069,21 @@ defmodule Minga.Extension.Supervisor do
 
       {:error, reason} ->
         Minga.Log.warning(:config, "Extension #{name}: #{reason}")
-        ExtRegistry.update(registry, name, status: :load_error, pid: nil)
+        ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
         [%{extension: name, reason: reason} | failures]
     end
   end
 
   defp resolve_git_extension(_registry, _name, _entry, failures), do: failures
 
-  @spec find_and_start_hex_extension(
+  @spec find_and_start_hex_extension_locked(
           GenServer.server(),
           GenServer.server(),
           atom(),
           ExtRegistry.entry(),
           start_opts()
         ) :: {:ok, pid()} | {:error, term()}
-  defp find_and_start_hex_extension(supervisor, registry, name, entry, opts) do
+  defp find_and_start_hex_extension_locked(supervisor, registry, name, entry, opts) do
     cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
     keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
     package_atom = String.to_atom(entry.hex.package)
@@ -801,7 +1119,7 @@ defmodule Minga.Extension.Supervisor do
       {:error, reason} ->
         msg = "Extension #{name} load error: #{inspect(reason)}"
         Minga.Log.warning(:config, msg)
-        ExtRegistry.update(registry, name, status: :load_error, pid: nil)
+        ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
         wrap_start_failure(name, reason, cmd_registry, keymap, opts)
     end
   end
@@ -995,14 +1313,20 @@ defmodule Minga.Extension.Supervisor do
       :code.delete(entry.module)
     end
 
-    ExtRegistry.update(registry, name, status: :stopped, pid: nil, module: nil)
+    ExtRegistry.update(registry, name,
+      status: :stopped,
+      pid: nil,
+      module: nil,
+      lifecycle_ref: nil
+    )
+
     :ok
   end
 
   @spec mark_hex_entries_load_error(GenServer.server()) :: :ok
   defp mark_hex_entries_load_error(registry) do
     for {name, entry} <- ExtRegistry.all(registry), entry.source_type == :hex do
-      ExtRegistry.update(registry, name, status: :load_error, pid: nil)
+      ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
     end
 
     :ok

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -17,6 +17,7 @@ defmodule Minga.Extension.Supervisor do
 
   alias Minga.Extension.Git, as: ExtGit
   alias Minga.Extension.Hex, as: ExtHex
+  alias Minga.Extension.Manifest
   alias Minga.Extension.Registry, as: ExtRegistry
 
   # ── Client API ──────────────────────────────────────────────────────────────
@@ -195,7 +196,8 @@ defmodule Minga.Extension.Supervisor do
   @type start_opts :: [
           command_registry: GenServer.server(),
           keymap: GenServer.server(),
-          callbacks: %{atom() => Minga.Extension.ContributionCleanup.cleanup_fun()}
+          callbacks: %{atom() => Minga.Extension.ContributionCleanup.cleanup_fun()},
+          slow_lifecycle_threshold_ms: non_neg_integer()
         ]
 
   @spec start_extension(GenServer.server(), GenServer.server(), atom(), ExtRegistry.entry()) ::
@@ -243,10 +245,13 @@ defmodule Minga.Extension.Supervisor do
     cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
     keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
 
-    with {:ok, module} <- compile_extension(entry.path),
+    with {:ok, module} <-
+           run_lifecycle_phase(name, :load, opts, fn -> compile_extension(entry.path) end),
          :ok <- validate_behaviour(module, name),
+         :ok <- record_extension_manifest(registry, name, module, entry.source_type),
          :ok <- register_and_validate_options(name, module, entry.config),
-         {:ok, _state} <- call_init(module, entry.config) do
+         {:ok, _state} <-
+           run_lifecycle_phase(name, :init, opts, fn -> call_init(module, entry.config) end) do
       finalize_extension_start(
         start_loaded_extension(
           supervisor,
@@ -255,7 +260,8 @@ defmodule Minga.Extension.Supervisor do
           module,
           entry.config,
           cmd_registry,
-          keymap
+          keymap,
+          opts
         ),
         registry,
         name,
@@ -279,9 +285,19 @@ defmodule Minga.Extension.Supervisor do
           module(),
           keyword(),
           GenServer.server(),
-          GenServer.server()
+          GenServer.server(),
+          start_opts()
         ) :: {:ok, pid()} | {:error, term()}
-  defp start_loaded_extension(supervisor, registry, name, module, config, cmd_registry, keymap) do
+  defp start_loaded_extension(
+         supervisor,
+         registry,
+         name,
+         module,
+         config,
+         cmd_registry,
+         keymap,
+         opts
+       ) do
     case register_extension_modeline_segments(module, name) do
       :ok ->
         start_child_then_register_dsl(
@@ -291,7 +307,8 @@ defmodule Minga.Extension.Supervisor do
           module,
           config,
           cmd_registry,
-          keymap
+          keymap,
+          opts
         )
 
       {:error, _reason} = error ->
@@ -306,7 +323,8 @@ defmodule Minga.Extension.Supervisor do
           module(),
           keyword(),
           GenServer.server(),
-          GenServer.server()
+          GenServer.server(),
+          start_opts()
         ) :: {:ok, pid()} | {:error, term()}
   defp start_child_then_register_dsl(
          supervisor,
@@ -315,9 +333,10 @@ defmodule Minga.Extension.Supervisor do
          module,
          config,
          cmd_registry,
-         keymap
+         keymap,
+         opts
        ) do
-    case start_child(supervisor, registry, name, module, config) do
+    case start_child(supervisor, registry, name, module, config, opts) do
       {:ok, pid} ->
         register_dsl_for_started_child(supervisor, pid, module, name, cmd_registry, keymap)
 
@@ -401,14 +420,23 @@ defmodule Minga.Extension.Supervisor do
     end
   end
 
-  @spec start_child(GenServer.server(), GenServer.server(), atom(), module(), keyword()) ::
+  @spec start_child(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          module(),
+          keyword(),
+          start_opts()
+        ) ::
           {:ok, pid()} | {:error, term()}
-  defp start_child(supervisor, registry, name, module, config) do
-    child_spec = module.child_spec(config)
-
-    case DynamicSupervisor.start_child(supervisor, child_spec) do
+  defp start_child(supervisor, registry, name, module, config, opts) do
+    case run_lifecycle_phase(name, :child_start, opts, fn ->
+           start_extension_child(supervisor, module, config)
+         end) do
       {:ok, pid} ->
         ExtRegistry.update(registry, name, module: module, status: :running, pid: pid)
+        emit_restart_count(name, 0)
+        start_child_restart_monitor(supervisor, registry, name, module, pid)
         Minga.Log.info(:config, "Extension #{name} started (#{module})")
         {:ok, pid}
 
@@ -437,11 +465,9 @@ defmodule Minga.Extension.Supervisor do
     keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
 
     termination_result =
-      if is_pid(entry.pid) do
-        terminate_extension_child(supervisor, entry.pid)
-      else
-        :ok
-      end
+      run_lifecycle_phase(name, :stop, opts, fn ->
+        terminate_extension_process(supervisor, entry)
+      end)
 
     finalize_stopped_extension(registry, name, entry)
 
@@ -504,6 +530,208 @@ defmodule Minga.Extension.Supervisor do
 
   # ── Private ────────────────────────────────────────────────────────────────
 
+  @spec record_extension_manifest(GenServer.server(), atom(), module(), Manifest.source_type()) ::
+          :ok | {:error, term()}
+  defp record_extension_manifest(registry, name, module, source) do
+    manifest = Manifest.from_module(module, source)
+    ExtRegistry.update(registry, name, manifest: manifest)
+    :ok
+  rescue
+    e -> {:error, "manifest introspection failed: #{Exception.message(e)}"}
+  end
+
+  @spec run_lifecycle_phase(atom(), atom(), start_opts(), (-> result)) :: result when result: var
+  defp run_lifecycle_phase(name, phase, opts, fun)
+       when is_atom(name) and is_atom(phase) and is_function(fun, 0) do
+    start_time = System.monotonic_time()
+
+    result =
+      Minga.Telemetry.span(
+        [:minga, :extension, :lifecycle],
+        %{extension: name, phase: phase},
+        fun
+      )
+
+    duration = System.monotonic_time() - start_time
+    maybe_log_slow_lifecycle_phase(name, phase, duration, opts)
+    result
+  end
+
+  @spec maybe_log_slow_lifecycle_phase(atom(), atom(), integer(), start_opts()) :: :ok
+  defp maybe_log_slow_lifecycle_phase(name, phase, duration, opts) do
+    threshold_ms = Keyword.get(opts, :slow_lifecycle_threshold_ms, 50)
+    duration_ms = System.convert_time_unit(duration, :native, :millisecond)
+
+    case duration_ms >= threshold_ms do
+      true ->
+        Minga.Log.warning(
+          :config,
+          "Extension #{name} lifecycle phase #{phase} took #{duration_ms}ms"
+        )
+
+      false ->
+        :ok
+    end
+  end
+
+  @spec emit_restart_count(atom(), non_neg_integer()) :: :ok
+  defp emit_restart_count(name, count) do
+    Minga.Telemetry.execute(
+      [:minga, :extension, :lifecycle, :crash_restart_count],
+      %{count: count},
+      %{extension: name, phase: :crash_restart_count}
+    )
+  end
+
+  @spec start_extension_child(GenServer.server(), module(), keyword()) ::
+          {:ok, pid()} | {:error, term()}
+  defp start_extension_child(supervisor, module, config) do
+    child_spec = normalize_child_spec(module, config)
+    DynamicSupervisor.start_child(supervisor, child_spec)
+  rescue
+    e -> {:error, {:child_spec_failed, Exception.message(e)}}
+  catch
+    kind, reason -> {:error, {:child_spec_failed, {kind, reason}}}
+  end
+
+  @spec normalize_child_spec(module(), keyword()) :: Supervisor.child_spec()
+  defp normalize_child_spec(module, config) do
+    module.child_spec(config)
+    |> Supervisor.child_spec([])
+    |> Map.put(:modules, [module])
+  end
+
+  @spec terminate_extension_process(GenServer.server(), ExtRegistry.entry()) ::
+          :ok | {:error, term()}
+  defp terminate_extension_process(supervisor, %{pid: pid} = entry) when is_pid(pid) do
+    case terminate_extension_child(supervisor, pid) do
+      {:error, :not_found} -> terminate_extension_process_by_module(supervisor, entry.module)
+      result -> result
+    end
+  end
+
+  defp terminate_extension_process(supervisor, %{module: module, status: :running})
+       when is_atom(module) and not is_nil(module) do
+    terminate_extension_process_by_module(supervisor, module)
+  end
+
+  defp terminate_extension_process(_supervisor, _entry), do: :ok
+
+  @spec terminate_extension_process_by_module(GenServer.server(), module() | nil) ::
+          :ok | {:error, term()}
+  defp terminate_extension_process_by_module(_supervisor, nil), do: {:error, :not_found}
+
+  defp terminate_extension_process_by_module(supervisor, module) do
+    case extension_child_pid(supervisor, module) do
+      pid when is_pid(pid) -> terminate_extension_child(supervisor, pid)
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @spec start_child_restart_monitor(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          module(),
+          pid()
+        ) :: :ok
+  defp start_child_restart_monitor(supervisor, registry, name, module, pid) do
+    spawn(fn -> monitor_child_restarts(supervisor, registry, name, module, pid, 0) end)
+    :ok
+  end
+
+  @spec monitor_child_restarts(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          module(),
+          pid(),
+          non_neg_integer()
+        ) :: :ok
+  defp monitor_child_restarts(supervisor, registry, name, module, pid, count) do
+    ref = Process.monitor(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, reason} ->
+        handle_child_down(supervisor, registry, name, module, reason, count)
+    end
+  end
+
+  @spec handle_child_down(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          module(),
+          term(),
+          non_neg_integer()
+        ) :: :ok
+  defp handle_child_down(supervisor, registry, name, module, reason, count) do
+    wait_for_restarted_child(supervisor, registry, name, module, reason, count + 1, 0)
+  end
+
+  @spec crash_reason?(term()) :: boolean()
+  defp crash_reason?(:normal), do: false
+  defp crash_reason?(:shutdown), do: false
+  defp crash_reason?({:shutdown, _reason}), do: false
+  defp crash_reason?(_reason), do: true
+
+  @spec wait_for_restarted_child(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          module(),
+          term(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: :ok
+  defp wait_for_restarted_child(_supervisor, registry, name, _module, reason, _count, 5) do
+    mark_crashed_without_replacement(registry, name, reason)
+  end
+
+  defp wait_for_restarted_child(supervisor, registry, name, module, reason, count, attempts) do
+    case extension_child_pid(supervisor, module) do
+      pid when is_pid(pid) ->
+        ExtRegistry.update(registry, name, pid: pid)
+        emit_restart_count(name, count)
+        monitor_child_restarts(supervisor, registry, name, module, pid, count)
+
+      nil ->
+        receive do
+        after
+          10 ->
+            wait_for_restarted_child(
+              supervisor,
+              registry,
+              name,
+              module,
+              reason,
+              count,
+              attempts + 1
+            )
+        end
+    end
+  end
+
+  @spec mark_crashed_without_replacement(GenServer.server(), atom(), term()) :: :ok
+  defp mark_crashed_without_replacement(registry, name, reason) do
+    case crash_reason?(reason) do
+      true -> ExtRegistry.update(registry, name, status: :crashed, pid: nil)
+      false -> :ok
+    end
+  end
+
+  @spec extension_child_pid(GenServer.server(), module()) :: pid() | nil
+  defp extension_child_pid(supervisor, module) do
+    supervisor
+    |> DynamicSupervisor.which_children()
+    |> Enum.find_value(fn
+      {:undefined, pid, _type, [^module]} when is_pid(pid) -> pid
+      _child -> nil
+    end)
+  catch
+    :exit, _reason -> nil
+  end
+
   @spec resolve_git_extensions(GenServer.server()) :: [start_failure()]
   defp resolve_git_extensions(registry) do
     ExtRegistry.all(registry)
@@ -542,11 +770,16 @@ defmodule Minga.Extension.Supervisor do
     keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
     package_atom = String.to_atom(entry.hex.package)
 
-    with :ok <- ensure_hex_application_started(package_atom),
+    with :ok <-
+           run_lifecycle_phase(name, :load, opts, fn ->
+             ensure_hex_application_started(package_atom)
+           end),
          {:ok, module} <- find_extension_module(package_atom),
          :ok <- validate_behaviour(module, name),
+         :ok <- record_extension_manifest(registry, name, module, entry.source_type),
          :ok <- register_and_validate_options(name, module, entry.config),
-         {:ok, _state} <- call_init(module, entry.config) do
+         {:ok, _state} <-
+           run_lifecycle_phase(name, :init, opts, fn -> call_init(module, entry.config) end) do
       finalize_extension_start(
         start_loaded_extension(
           supervisor,
@@ -555,7 +788,8 @@ defmodule Minga.Extension.Supervisor do
           module,
           entry.config,
           cmd_registry,
-          keymap
+          keymap,
+          opts
         ),
         registry,
         name,
@@ -729,7 +963,9 @@ defmodule Minga.Extension.Supervisor do
       [command_registry: cmd_registry, keymap: keymap]
       |> Keyword.merge(Keyword.take(opts, [:callbacks]))
 
-    case Minga.Extension.ContributionCleanup.unregister_source(source, cleanup_opts) do
+    case run_lifecycle_phase(name, :cleanup, opts, fn ->
+           Minga.Extension.ContributionCleanup.unregister_source(source, cleanup_opts)
+         end) do
       :ok ->
         :ok
 

--- a/sdk/lib/minga/extension.ex
+++ b/sdk/lib/minga/extension.ex
@@ -159,7 +159,13 @@ defmodule Minga.Extension do
   @typedoc "A declared runtime or UI capability: `{family, value}`."
   @type capability_spec :: {atom(), term()}
 
-  @doc "Builds a public manifest for a loaded extension module."
+  @doc """
+  Builds a public manifest for a loaded extension module.
+
+  This calls the extension's declaration callbacks directly, so callback
+  failures can raise or exit. Use `Minga.Extension.Supervisor.start_extension/5`
+  if you want those failures converted into load errors instead of propagating.
+  """
   @spec manifest(module(), Minga.Extension.Manifest.source_type()) :: Minga.Extension.Manifest.t()
   def manifest(module, source) when is_atom(module) and source in [:path, :git, :hex] do
     Minga.Extension.Manifest.from_module(module, source)

--- a/sdk/lib/minga/extension.ex
+++ b/sdk/lib/minga/extension.ex
@@ -102,10 +102,7 @@ defmodule Minga.Extension do
   @doc """
   Optional. Returns a child spec for the extension's supervision subtree.
 
-  The default implementation (provided by `use Minga.Extension`) starts
-  a simple Agent that holds the state returned by `init/1`. Override this
-  if your extension needs a custom GenServer, multiple processes, or a
-  full supervision tree.
+  The default implementation (provided by `use Minga.Extension`) starts a simple Agent that holds the validated config keyword list. The value returned by `init/1` is setup-only and is not handed to the default child process. Override this if your extension needs a custom GenServer, persisted runtime state, multiple processes, or a full supervision tree.
   """
   @callback child_spec(config :: keyword()) :: Supervisor.child_spec()
 
@@ -159,6 +156,15 @@ defmodule Minga.Extension do
   @typedoc "A modeline segment declaration: `{name, opts, {module, function}}`."
   @type modeline_segment_spec :: {atom(), keyword(), {module(), atom()}}
 
+  @typedoc "A declared runtime or UI capability: `{family, value}`."
+  @type capability_spec :: {atom(), term()}
+
+  @doc "Builds a public manifest for a loaded extension module."
+  @spec manifest(module(), Minga.Extension.Manifest.source_type()) :: Minga.Extension.Manifest.t()
+  def manifest(module, source) when is_atom(module) and source in [:path, :git, :hex] do
+    Minga.Extension.Manifest.from_module(module, source)
+  end
+
   @doc """
   Injects the `Minga.Extension` behaviour, DSL macros (`option/3`,
   `command/3`, `keybind/4`, `keybind/5`), and a default `child_spec/1`.
@@ -209,6 +215,7 @@ defmodule Minga.Extension do
       Module.register_attribute(__MODULE__, :__extension_commands__, accumulate: true)
       Module.register_attribute(__MODULE__, :__extension_keybinds__, accumulate: true)
       Module.register_attribute(__MODULE__, :__extension_modeline_segments__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__extension_capabilities__, accumulate: true)
       @before_compile Minga.Extension
 
       @doc false
@@ -231,7 +238,8 @@ defmodule Minga.Extension do
           keybind: 4,
           keybind: 5,
           modeline_segment: 2,
-          modeline_segment: 3
+          modeline_segment: 3,
+          capability: 2
         ]
     end
   end
@@ -329,6 +337,17 @@ defmodule Minga.Extension do
   end
 
   @doc """
+  Declares a runtime or UI capability this extension uses.
+
+  Capabilities are declarative and are available through `Minga.Extension.Manifest` before `init/1` runs. They should describe contribution surfaces or runtime needs, not perform side effects.
+  """
+  defmacro capability(family, value) do
+    quote do
+      @__extension_capabilities__ {unquote(family), unquote(value)}
+    end
+  end
+
+  @doc """
   Declares a keybinding this extension provides.
 
   Accumulated at compile time and exposed via `__keybind_schema__/0`.
@@ -360,11 +379,13 @@ defmodule Minga.Extension do
     commands = Module.get_attribute(env.module, :__extension_commands__) || []
     keybinds = Module.get_attribute(env.module, :__extension_keybinds__) || []
     modeline_segments = Module.get_attribute(env.module, :__extension_modeline_segments__) || []
+    capabilities = Module.get_attribute(env.module, :__extension_capabilities__) || []
     # Accumulated attributes are in reverse order; restore declaration order
     options = Enum.reverse(options)
     commands = Enum.reverse(commands)
     keybinds = Enum.reverse(keybinds)
     modeline_segments = Enum.reverse(modeline_segments)
+    capabilities = Enum.reverse(capabilities)
 
     quote do
       @doc false
@@ -382,6 +403,10 @@ defmodule Minga.Extension do
       @doc false
       @spec __modeline_segment_schema__() :: [Minga.Extension.modeline_segment_spec()]
       def __modeline_segment_schema__, do: unquote(Macro.escape(modeline_segments))
+
+      @doc false
+      @spec __capability_schema__() :: [Minga.Extension.capability_spec()]
+      def __capability_schema__, do: unquote(Macro.escape(capabilities))
     end
   end
 end

--- a/sdk/lib/minga/extension/manifest.ex
+++ b/sdk/lib/minga/extension/manifest.ex
@@ -7,8 +7,8 @@ defmodule Minga.Extension.Manifest do
 
   alias Minga.Extension
 
-  @typedoc "Declared runtime/UI capability map. Keys are capability families and values are capability-specific terms."
-  @type capabilities :: %{optional(atom()) => term()}
+  @typedoc "Declared runtime/UI capabilities in declaration order. Duplicate entries are preserved."
+  @type capabilities :: [Extension.capability_spec()]
 
   @typedoc "How the extension source code is obtained."
   @type source_type :: :path | :git | :hex
@@ -22,7 +22,7 @@ defmodule Minga.Extension.Manifest do
     commands: [],
     keybindings: [],
     modeline_segments: [],
-    capabilities: %{}
+    capabilities: []
   ]
 
   @type t :: %__MODULE__{
@@ -36,7 +36,13 @@ defmodule Minga.Extension.Manifest do
           capabilities: capabilities()
         }
 
-  @doc "Builds a manifest from an extension module and source type."
+  @doc """
+  Builds a manifest from an extension module and source type.
+
+  This calls the extension's declaration callbacks directly, so callback
+  failures can raise or exit. The extension supervisor rescues those failures
+  and turns them into load errors during startup.
+  """
   @spec from_module(module(), source_type()) :: t()
   def from_module(module, source) when is_atom(module) and source in [:path, :git, :hex] do
     %__MODULE__{
@@ -64,7 +70,7 @@ defmodule Minga.Extension.Manifest do
   @spec safe_capabilities(module()) :: capabilities()
   defp safe_capabilities(module) do
     if function_exported?(module, :__capability_schema__, 0),
-      do: Map.new(module.__capability_schema__()),
-      else: %{}
+      do: module.__capability_schema__(),
+      else: []
   end
 end

--- a/sdk/lib/minga/extension/manifest.ex
+++ b/sdk/lib/minga/extension/manifest.ex
@@ -1,0 +1,70 @@
+defmodule Minga.Extension.Manifest do
+  @moduledoc """
+  Public declaration snapshot for an extension before runtime side effects run.
+
+  Manifests are append-only data contracts. Callers can inspect what an extension declares, which source it came from, and which runtime capabilities it says it uses without invoking extension code beyond static callback/schema functions.
+  """
+
+  alias Minga.Extension
+
+  @typedoc "Declared runtime/UI capability map. Keys are capability families and values are capability-specific terms."
+  @type capabilities :: %{optional(atom()) => term()}
+
+  @typedoc "How the extension source code is obtained."
+  @type source_type :: :path | :git | :hex
+
+  @enforce_keys [:name, :version, :source]
+  defstruct [
+    :name,
+    :description,
+    :version,
+    :source,
+    commands: [],
+    keybindings: [],
+    modeline_segments: [],
+    capabilities: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          description: String.t() | nil,
+          version: String.t(),
+          source: source_type(),
+          commands: [Extension.command_spec()],
+          keybindings: [Extension.keybind_spec()],
+          modeline_segments: [Extension.modeline_segment_spec()],
+          capabilities: capabilities()
+        }
+
+  @doc "Builds a manifest from an extension module and source type."
+  @spec from_module(module(), source_type()) :: t()
+  def from_module(module, source) when is_atom(module) and source in [:path, :git, :hex] do
+    %__MODULE__{
+      name: module.name(),
+      description: safe_description(module),
+      version: module.version(),
+      source: source,
+      commands: safe_schema(module, :__command_schema__),
+      keybindings: safe_schema(module, :__keybind_schema__),
+      modeline_segments: safe_schema(module, :__modeline_segment_schema__),
+      capabilities: safe_capabilities(module)
+    }
+  end
+
+  @spec safe_description(module()) :: String.t() | nil
+  defp safe_description(module) do
+    if function_exported?(module, :description, 0), do: module.description(), else: nil
+  end
+
+  @spec safe_schema(module(), atom()) :: list()
+  defp safe_schema(module, fun) do
+    if function_exported?(module, fun, 0), do: apply(module, fun, []), else: []
+  end
+
+  @spec safe_capabilities(module()) :: capabilities()
+  defp safe_capabilities(module) do
+    if function_exported?(module, :__capability_schema__, 0),
+      do: Map.new(module.__capability_schema__()),
+      else: %{}
+  end
+end

--- a/test/minga/extension/dev_reload_test.exs
+++ b/test/minga/extension/dev_reload_test.exs
@@ -1,7 +1,32 @@
 defmodule Minga.Extension.DevReloadTest do
-  use ExUnit.Case, async: true
+  # Uses global extension registry/supervisor because DevReload targets singleton servers.
+  use ExUnit.Case, async: false
 
   alias Minga.Extension.DevReload
+  alias Minga.Extension.Registry, as: ExtRegistry
+  alias Minga.Extension.Supervisor, as: ExtSupervisor
+
+  setup do
+    ensure_named_process(ExtRegistry, {ExtRegistry, name: ExtRegistry})
+    ensure_named_process(ExtSupervisor, {ExtSupervisor, name: ExtSupervisor})
+    :ok = ExtRegistry.unregister(ExtRegistry, :dev_reload_contract)
+
+    on_exit(fn ->
+      case ExtRegistry.get(ExtRegistry, :dev_reload_contract) do
+        {:ok, entry} ->
+          ExtSupervisor.stop_extension(ExtSupervisor, ExtRegistry, :dev_reload_contract, entry)
+
+        :error ->
+          :ok
+      end
+
+      ExtRegistry.unregister(ExtRegistry, :dev_reload_contract)
+      :code.purge(Minga.TestExtensions.DevReloadContract)
+      :code.delete(Minga.TestExtensions.DevReloadContract)
+    end)
+
+    :ok
+  end
 
   test "starts without error" do
     pid = start_supervised!(DevReload)
@@ -15,10 +40,129 @@ defmodule Minga.Extension.DevReloadTest do
     assert :ok = DevReload.unwatch(:test_ext)
   end
 
-  test "debounce timer fires without crash" do
+  test "debounced reload with no pending paths is a no-op" do
     pid = start_supervised!(DevReload)
     send(pid, :debounced_reload)
-    Process.sleep(10)
-    assert Process.alive?(pid)
+    state = :sys.get_state(pid)
+    assert state.pending_paths == MapSet.new()
+  end
+
+  test "debounced reload emits reload telemetry and restarts the extension in order" do
+    test_pid = self()
+
+    pid =
+      start_supervised!(
+        {DevReload,
+         recompiler: fn path ->
+           send(test_pid, {:reload_event, {:recompiled, path}})
+           :ok
+         end}
+      )
+
+    telemetry_id = {__MODULE__, self(), :dev_reload_contract}
+
+    {path, cleanup} = make_reload_extension()
+    on_exit(cleanup)
+
+    :ok = ExtRegistry.register(ExtRegistry, :dev_reload_contract, path, [])
+    {:ok, entry} = ExtRegistry.get(ExtRegistry, :dev_reload_contract)
+
+    assert {:ok, old_pid} =
+             ExtSupervisor.start_extension(
+               ExtSupervisor,
+               ExtRegistry,
+               :dev_reload_contract,
+               entry
+             )
+
+    :telemetry.attach(
+      telemetry_id,
+      [:minga, :extension, :lifecycle, :stop],
+      fn _event, _measurements, metadata, test_pid ->
+        case metadata do
+          %{extension: :dev_reload_contract, phase: phase} ->
+            send(test_pid, {:reload_event, phase})
+
+          _other ->
+            :ok
+        end
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+
+    lib_path = Path.join(path, "lib")
+    source_file = Path.join(lib_path, "extension.ex")
+
+    :sys.replace_state(pid, fn state ->
+      %{
+        state
+        | extensions: Map.put(state.extensions, lib_path, :dev_reload_contract),
+          pending_paths: MapSet.new([source_file]),
+          pending_timer: nil
+      }
+    end)
+
+    send(pid, :debounced_reload)
+
+    assert_reload_event({:recompiled, path})
+    assert_reload_event(:stop)
+    assert_reload_event(:cleanup)
+    assert_reload_event(:load)
+    assert_reload_event(:init)
+    assert_reload_event(:child_start)
+    assert_reload_event(:reload)
+
+    {:ok, reloaded_entry} = ExtRegistry.get(ExtRegistry, :dev_reload_contract)
+    assert reloaded_entry.status == :running
+    assert is_pid(reloaded_entry.pid)
+    assert reloaded_entry.pid != old_pid
+  end
+
+  @spec assert_reload_event(atom() | {:recompiled, String.t()}) ::
+          atom() | {:recompiled, String.t()}
+  defp assert_reload_event(expected) do
+    receive do
+      {:reload_event, ^expected} -> expected
+      other -> flunk("expected reload event #{inspect(expected)}, got #{inspect(other)}")
+    after
+      1_000 -> flunk("expected reload event #{inspect(expected)}")
+    end
+  end
+
+  @spec ensure_named_process(atom(), Supervisor.child_spec()) :: :ok
+  defp ensure_named_process(name, child_spec) do
+    case Process.whereis(name) do
+      pid when is_pid(pid) -> :ok
+      nil -> start_supervised!(child_spec) && :ok
+    end
+  end
+
+  @spec make_reload_extension() :: {String.t(), (-> :ok)}
+  defp make_reload_extension do
+    dir = Path.join(System.tmp_dir!(), "minga_dev_reload_#{System.unique_integer([:positive])}")
+    lib_dir = Path.join(dir, "lib")
+    File.mkdir_p!(lib_dir)
+
+    File.write!(Path.join(lib_dir, "extension.ex"), """
+    defmodule Minga.TestExtensions.DevReloadContract do
+      use Minga.Extension
+
+      @impl true
+      def name, do: :dev_reload_contract
+
+      @impl true
+      def description, do: "Dev reload contract"
+
+      @impl true
+      def version, do: "1.0.0"
+
+      @impl true
+      def init(_config), do: {:ok, %{}}
+    end
+    """)
+
+    {dir, fn -> File.rm_rf!(dir) end}
   end
 end

--- a/test/minga/extension/entry_test.exs
+++ b/test/minga/extension/entry_test.exs
@@ -69,7 +69,7 @@ defmodule Minga.Extension.EntryTest do
 
       assert %Entry{} = entry
       assert entry.source_type == :hex
-      assert entry.hex == %{package: "minga_snippets", version: "~> 0.3"}
+      assert entry.hex == %{package: "minga_snippets", version: "~> 0.3", app: nil}
       assert entry.path == nil
       assert entry.git == nil
       assert entry.config == []
@@ -80,6 +80,7 @@ defmodule Minga.Extension.EntryTest do
 
       assert entry.hex.package == "minga_snippets"
       assert entry.hex.version == nil
+      assert entry.hex.app == nil
     end
 
     test "separates version from extension config" do

--- a/test/minga/extension/hex_test.exs
+++ b/test/minga/extension/hex_test.exs
@@ -23,8 +23,8 @@ defmodule Minga.Extension.HexTest do
       deps = ExtHex.collect_hex_deps(r) |> Enum.sort()
 
       assert deps == [
-               {:minga_snippets, "~> 0.3"},
-               {:minga_tools, ">= 1.0.0"}
+               {:snippets, "~> 0.3", hex: "minga_snippets"},
+               {:tools, ">= 1.0.0", hex: "minga_tools"}
              ]
     end
 
@@ -32,7 +32,14 @@ defmodule Minga.Extension.HexTest do
       ExtRegistry.register_hex(r, :snippets, "minga_snippets", [])
 
       deps = ExtHex.collect_hex_deps(r)
-      assert deps == [{:minga_snippets, ">= 0.0.0"}]
+      assert deps == [{:snippets, ">= 0.0.0", hex: "minga_snippets"}]
+    end
+
+    test "uses an explicit app atom when provided", %{registry: r} do
+      ExtRegistry.register_hex(r, :snippets, "minga_snippets", app: :minga_snippets)
+
+      deps = ExtHex.collect_hex_deps(r)
+      assert deps == [{:minga_snippets, ">= 0.0.0", hex: "minga_snippets"}]
     end
 
     test "ignores path and git extensions", %{registry: r} do
@@ -41,7 +48,7 @@ defmodule Minga.Extension.HexTest do
       ExtRegistry.register_hex(r, :hex_ext, "minga_snippets", version: "~> 0.3")
 
       deps = ExtHex.collect_hex_deps(r)
-      assert deps == [{:minga_snippets, "~> 0.3"}]
+      assert deps == [{:hex_ext, "~> 0.3", hex: "minga_snippets"}]
     end
   end
 

--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -1,0 +1,583 @@
+defmodule Minga.Extension.LifecycleContractTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Minga.Command.Registry, as: CommandRegistry
+  alias Minga.Extension.Registry, as: ExtRegistry
+  alias Minga.Extension.Supervisor, as: ExtSupervisor
+  alias Minga.Keymap.Active, as: KeymapActive
+
+  setup do
+    reg_name = :"ext_lifecycle_reg_#{System.unique_integer([:positive])}"
+    sup_name = :"ext_lifecycle_sup_#{System.unique_integer([:positive])}"
+    cmd_reg_name = :"ext_lifecycle_cmd_#{System.unique_integer([:positive])}"
+    keymap_name = :"ext_lifecycle_keymap_#{System.unique_integer([:positive])}"
+
+    {:ok, _} = ExtRegistry.start_link(name: reg_name)
+    {:ok, _} = ExtSupervisor.start_link(name: sup_name)
+    {:ok, _} = CommandRegistry.start_link(name: cmd_reg_name)
+    {:ok, _} = KeymapActive.start_link(name: keymap_name)
+
+    {:ok,
+     registry: reg_name, supervisor: sup_name, command_registry: cmd_reg_name, keymap: keymap_name}
+  end
+
+  test "default child stores config and init return is setup-only", ctx do
+    {path, cleanup} =
+      make_extension("DefaultChildState", """
+      defmodule Minga.TestExtensions.DefaultChildState do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :default_child_state
+
+        @impl true
+        def description, do: "Default child state contract"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{runtime_state: true}}
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.DefaultChildState)
+      :code.delete(Minga.TestExtensions.DefaultChildState)
+    end)
+
+    :ok = ExtRegistry.register(ctx.registry, :default_child_state, path, greeting: "hello")
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :default_child_state)
+
+    assert {:ok, pid} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :default_child_state,
+               entry
+             )
+
+    assert Agent.get(pid, & &1) == [greeting: "hello"]
+  end
+
+  test "manifest is recorded before init side effects can fail", ctx do
+    {path, cleanup} =
+      make_extension("ManifestBeforeInit", """
+      defmodule Minga.TestExtensions.ManifestBeforeInit do
+        use Minga.Extension
+
+        command :manifest_before_init_cmd, "Manifest command", execute: {__MODULE__, :noop}
+        keybind :normal, "SPC m i", :manifest_before_init_cmd, "Manifest keybind"
+        modeline_segment :manifest_before_init_segment, side: :right do
+          _ = ctx
+          nil
+        end
+        capability :ui, [:modeline]
+
+        @impl true
+        def name, do: :manifest_before_init
+
+        @impl true
+        def description, do: "Manifest before init"
+
+        @impl true
+        def version, do: "1.2.3"
+
+        @impl true
+        def init(_config), do: {:error, :intentional_failure}
+
+        @spec noop(map()) :: map()
+        def noop(state), do: state
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.ManifestBeforeInit)
+      :code.delete(Minga.TestExtensions.ManifestBeforeInit)
+    end)
+
+    :ok = ExtRegistry.register(ctx.registry, :manifest_before_init, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :manifest_before_init)
+
+    assert {:error, _reason} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :manifest_before_init,
+               entry,
+               command_registry: ctx.command_registry,
+               keymap: ctx.keymap
+             )
+
+    {:ok, failed_entry} = ExtRegistry.get(ctx.registry, :manifest_before_init)
+    assert failed_entry.status == :load_error
+    assert failed_entry.manifest.name == :manifest_before_init
+    assert failed_entry.manifest.version == "1.2.3"
+    assert failed_entry.manifest.source == :path
+
+    assert [{:manifest_before_init_cmd, "Manifest command", _opts}] =
+             failed_entry.manifest.commands
+
+    assert [{:normal, "SPC m i", :manifest_before_init_cmd, "Manifest keybind", []}] =
+             failed_entry.manifest.keybindings
+
+    assert [{:manifest_before_init_segment, [side: :right], _mfa}] =
+             failed_entry.manifest.modeline_segments
+
+    assert failed_entry.manifest.capabilities == %{ui: [:modeline]}
+  end
+
+  test "failed child start removes contributions registered during init", ctx do
+    {path, cleanup} =
+      make_extension("FailedChildStart", """
+      defmodule Minga.TestExtensions.FailedChildStart do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :failed_child_start
+
+        @impl true
+        def description, do: "Failed child start"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(config) do
+          source = {:extension, :failed_child_start}
+          command_registry = Keyword.fetch!(config, :command_registry)
+          command = %Minga.Command{name: :failed_child_start_cmd, description: "Failed child command", execute: &__MODULE__.noop/1}
+          :ok = Minga.Command.Registry.register_command(command_registry, source, command)
+          {:ok, %{}}
+        end
+
+        @impl true
+        def child_spec(_config) do
+          %{id: __MODULE__, start: {__MODULE__, :start_link, []}, restart: :permanent, type: :worker}
+        end
+
+        @spec start_link() :: {:error, atom()}
+        def start_link, do: {:error, :intentional_child_failure}
+
+        @spec noop(map()) :: map()
+        def noop(state), do: state
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.FailedChildStart)
+      :code.delete(Minga.TestExtensions.FailedChildStart)
+    end)
+
+    config = [command_registry: ctx.command_registry, keymap: ctx.keymap]
+    :ok = ExtRegistry.register(ctx.registry, :failed_child_start, path, config)
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :failed_child_start)
+
+    assert {:error, :intentional_child_failure} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :failed_child_start,
+               entry,
+               command_registry: ctx.command_registry,
+               keymap: ctx.keymap
+             )
+
+    assert :error = CommandRegistry.lookup(ctx.command_registry, :failed_child_start_cmd)
+
+    assert {:ok, failed_entry = %{status: :load_error, pid: nil}} =
+             ExtRegistry.get(ctx.registry, :failed_child_start)
+
+    assert :ok =
+             ExtSupervisor.stop_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :failed_child_start,
+               failed_entry,
+               command_registry: ctx.command_registry,
+               keymap: ctx.keymap
+             )
+  end
+
+  test "child_spec exceptions clean contributions registered during init", ctx do
+    {path, cleanup} =
+      make_extension("ChildSpecRaises", """
+      defmodule Minga.TestExtensions.ChildSpecRaises do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :child_spec_raises
+
+        @impl true
+        def description, do: "Child spec raises"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(config) do
+          source = {:extension, :child_spec_raises}
+          command_registry = Keyword.fetch!(config, :command_registry)
+          command = %Minga.Command{name: :child_spec_raises_cmd, description: "Child spec raises command", execute: &__MODULE__.noop/1}
+          :ok = Minga.Command.Registry.register_command(command_registry, source, command)
+          {:ok, %{}}
+        end
+
+        @impl true
+        def child_spec(_config), do: raise("boom")
+
+        @spec noop(map()) :: map()
+        def noop(state), do: state
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.ChildSpecRaises)
+      :code.delete(Minga.TestExtensions.ChildSpecRaises)
+    end)
+
+    config = [command_registry: ctx.command_registry, keymap: ctx.keymap]
+    :ok = ExtRegistry.register(ctx.registry, :child_spec_raises, path, config)
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :child_spec_raises)
+
+    assert {:error, {:child_spec_failed, "boom"}} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :child_spec_raises,
+               entry,
+               command_registry: ctx.command_registry,
+               keymap: ctx.keymap
+             )
+
+    assert :error = CommandRegistry.lookup(ctx.command_registry, :child_spec_raises_cmd)
+
+    assert {:ok, %{status: :load_error, pid: nil}} =
+             ExtRegistry.get(ctx.registry, :child_spec_raises)
+  end
+
+  test "reload order cleans old source-owned contributions before restart", ctx do
+    {path, cleanup} =
+      make_extension("ReloadOrder", """
+      defmodule Minga.TestExtensions.ReloadOrder do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :reload_order
+
+        @impl true
+        def description, do: "Reload order"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(config) do
+          source = {:extension, :reload_order}
+          command_registry = Keyword.fetch!(config, :command_registry)
+          command = %Minga.Command{name: :reload_order_cmd, description: "Reload order command", execute: &__MODULE__.noop/1}
+          :ok = Minga.Command.Registry.register_command(command_registry, source, command)
+          {:ok, %{}}
+        end
+
+        @spec noop(map()) :: map()
+        def noop(state), do: state
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.ReloadOrder)
+      :code.delete(Minga.TestExtensions.ReloadOrder)
+    end)
+
+    config = [command_registry: ctx.command_registry, keymap: ctx.keymap]
+    :ok = ExtRegistry.register(ctx.registry, :reload_order, path, config)
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :reload_order)
+
+    assert {:ok, _pid} =
+             ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, :reload_order, entry,
+               command_registry: ctx.command_registry,
+               keymap: ctx.keymap
+             )
+
+    assert {:ok, _} = CommandRegistry.lookup(ctx.command_registry, :reload_order_cmd)
+
+    {:ok, running_entry} = ExtRegistry.get(ctx.registry, :reload_order)
+
+    assert :ok =
+             ExtSupervisor.stop_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :reload_order,
+               running_entry,
+               command_registry: ctx.command_registry,
+               keymap: ctx.keymap
+             )
+
+    assert :error = CommandRegistry.lookup(ctx.command_registry, :reload_order_cmd)
+
+    {:ok, stopped_entry} = ExtRegistry.get(ctx.registry, :reload_order)
+
+    assert {:ok, _pid} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :reload_order,
+               stopped_entry,
+               command_registry: ctx.command_registry,
+               keymap: ctx.keymap
+             )
+
+    assert {:ok, _} = CommandRegistry.lookup(ctx.command_registry, :reload_order_cmd)
+  end
+
+  test "tuple child specs are normalized before monitoring", ctx do
+    {path, cleanup} =
+      make_extension("TupleChildSpec", """
+      defmodule Minga.TestExtensions.TupleChildSpec do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :tuple_child_spec
+
+        @impl true
+        def description, do: "Tuple child spec"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+
+        @impl true
+        def child_spec(_config), do: {Agent, fn -> :tuple_child_spec end}
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.TupleChildSpec)
+      :code.delete(Minga.TestExtensions.TupleChildSpec)
+    end)
+
+    :ok = ExtRegistry.register(ctx.registry, :tuple_child_spec, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :tuple_child_spec)
+
+    assert {:ok, pid} =
+             ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, :tuple_child_spec, entry)
+
+    assert Agent.get(pid, & &1) == :tuple_child_spec
+  end
+
+  test "lifecycle telemetry covers start, stop, cleanup, and restart count", ctx do
+    telemetry_id = {__MODULE__, self(), :telemetry}
+
+    :telemetry.attach_many(
+      telemetry_id,
+      [
+        [:minga, :extension, :lifecycle, :stop],
+        [:minga, :extension, :lifecycle, :crash_restart_count]
+      ],
+      fn event, measurements, metadata, test_pid ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+
+    {path, cleanup} =
+      make_extension("TelemetryExt", """
+      defmodule Minga.TestExtensions.TelemetryExt do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :telemetry_ext
+
+        @impl true
+        def description, do: "Telemetry extension"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.TelemetryExt)
+      :code.delete(Minga.TestExtensions.TelemetryExt)
+    end)
+
+    :ok = ExtRegistry.register(ctx.registry, :telemetry_ext, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :telemetry_ext)
+
+    assert {:ok, _pid} =
+             ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, :telemetry_ext, entry)
+
+    {:ok, running_entry} = ExtRegistry.get(ctx.registry, :telemetry_ext)
+
+    assert :ok =
+             ExtSupervisor.stop_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :telemetry_ext,
+               running_entry
+             )
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: duration},
+                    %{extension: :telemetry_ext, phase: :load}}
+
+    assert is_integer(duration)
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
+                    %{extension: :telemetry_ext, phase: :init}}
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
+                    %{extension: :telemetry_ext, phase: :child_start}}
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 0}, %{extension: :telemetry_ext, phase: :crash_restart_count}}
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
+                    %{extension: :telemetry_ext, phase: :stop}}
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
+                    %{extension: :telemetry_ext, phase: :cleanup}}
+  end
+
+  test "crash restart telemetry increments when a supervised extension child restarts", ctx do
+    telemetry_id = {__MODULE__, self(), :restart_telemetry}
+
+    :telemetry.attach_many(
+      telemetry_id,
+      [[:minga, :extension, :lifecycle, :crash_restart_count]],
+      fn event, measurements, metadata, test_pid ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+
+    {path, cleanup} =
+      make_extension("RestartTelemetry", """
+      defmodule Minga.TestExtensions.RestartTelemetry do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :restart_telemetry
+
+        @impl true
+        def description, do: "Restart telemetry"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.RestartTelemetry)
+      :code.delete(Minga.TestExtensions.RestartTelemetry)
+    end)
+
+    :ok = ExtRegistry.register(ctx.registry, :restart_telemetry, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :restart_telemetry)
+
+    assert {:ok, pid} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :restart_telemetry,
+               entry
+             )
+
+    Process.exit(pid, :kill)
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 0}, %{extension: :restart_telemetry, phase: :crash_restart_count}}
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 1}, %{extension: :restart_telemetry, phase: :crash_restart_count}}
+
+    {:ok, restarted_entry} = ExtRegistry.get(ctx.registry, :restart_telemetry)
+    assert restarted_entry.pid != pid
+
+    assert :ok =
+             ExtSupervisor.stop_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :restart_telemetry,
+               restarted_entry
+             )
+
+    assert DynamicSupervisor.count_children(ctx.supervisor).active == 0
+  end
+
+  test "slow lifecycle phases are logged with extension and phase", ctx do
+    {path, cleanup} =
+      make_extension("SlowLifecycle", """
+      defmodule Minga.TestExtensions.SlowLifecycle do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :slow_lifecycle
+
+        @impl true
+        def description, do: "Slow lifecycle log test"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.SlowLifecycle)
+      :code.delete(Minga.TestExtensions.SlowLifecycle)
+    end)
+
+    :ok = ExtRegistry.register(ctx.registry, :slow_lifecycle, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :slow_lifecycle)
+
+    log =
+      capture_log(fn ->
+        assert {:ok, _pid} =
+                 ExtSupervisor.start_extension(
+                   ctx.supervisor,
+                   ctx.registry,
+                   :slow_lifecycle,
+                   entry,
+                   slow_lifecycle_threshold_ms: 0
+                 )
+      end)
+
+    assert log =~ "Extension slow_lifecycle lifecycle phase load took"
+  end
+
+  @spec make_extension(String.t(), String.t()) :: {String.t(), (-> :ok)}
+  defp make_extension(dir_name, source) do
+    dir =
+      Path.join(System.tmp_dir!(), "minga_ext_#{dir_name}_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "extension.ex"), source)
+    {dir, fn -> File.rm_rf!(dir) end}
+  end
+end

--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -1521,9 +1521,82 @@ defmodule Minga.Extension.LifecycleContractTest do
     assert crashed_entry.pid == nil
   end
 
-  test "start during pending crash restart reuses the supervisor replacement", ctx do
+  test "transient exits with normal or shutdown reasons stop without restart", ctx do
+    for {module, module_name, ext_name, exit_reason} <- [
+          {Minga.TestExtensions.TransientExitNormal, "TransientExitNormal",
+           :transient_exit_normal, :normal},
+          {Minga.TestExtensions.TransientExitShutdown, "TransientExitShutdown",
+           :transient_exit_shutdown, {:shutdown, :planned}}
+        ] do
+      {path, cleanup} =
+        make_extension(module_name, """
+        defmodule #{inspect(module)} do
+          use Minga.Extension
+
+          @impl true
+          def name, do: #{inspect(ext_name)}
+
+          @impl true
+          def description, do: "Transient exit #{module_name}"
+
+          @impl true
+          def version, do: "1.0.0"
+
+          @impl true
+          def init(_config), do: {:ok, %{}}
+
+          @impl true
+          def child_spec(_config) do
+            %{
+              id: __MODULE__,
+              start: {__MODULE__, :start_link, []},
+              restart: :transient,
+              type: :worker
+            }
+          end
+
+          @spec start_link() :: {:ok, pid()}
+          def start_link do
+            {:ok, spawn_link(fn -> loop() end)}
+          end
+
+          defp loop do
+            receive do
+              {:stop, reason} -> exit(reason)
+              _ -> loop()
+            end
+          end
+        end
+        """)
+
+      on_exit(fn ->
+        cleanup.()
+        :code.purge(module)
+        :code.delete(module)
+      end)
+
+      :ok = ExtRegistry.register(ctx.registry, ext_name, path, [])
+      {:ok, entry} = ExtRegistry.get(ctx.registry, ext_name)
+
+      assert {:ok, pid} =
+               ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, ext_name, entry)
+
+      send(pid, {:stop, exit_reason})
+
+      refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                      %{count: 1}, %{extension: ^ext_name, phase: :crash_restart_count}},
+                     150
+
+      stopped_entry = wait_for_entry_status(ctx.registry, ext_name, :stopped, 40)
+      assert stopped_entry.pid == nil
+      assert stopped_entry.status == :stopped
+    end
+  end
+
+  test "delayed crash restart does not mark the lifecycle crashed before replacement starts",
+       ctx do
     telemetry_id = {__MODULE__, self(), :restart_start_race_telemetry}
-    test_pid = self()
+    parent_pid = self()
 
     :telemetry.attach_many(
       telemetry_id,
@@ -1535,16 +1608,6 @@ defmodule Minga.Extension.LifecycleContractTest do
     )
 
     on_exit(fn -> :telemetry.detach(telemetry_id) end)
-
-    restart_gate = fn ->
-      send(test_pid, {:restart_reconcile_blocked, self()})
-
-      receive do
-        :release_restart_reconcile -> :ok
-      after
-        5_000 -> raise "timed out waiting to release restart reconciliation"
-      end
-    end
 
     {path, cleanup} =
       make_extension("RestartStartRace", """
@@ -1565,6 +1628,27 @@ defmodule Minga.Extension.LifecycleContractTest do
         @impl true
         def init(_config), do: {:ok, %{}}
 
+        @impl true
+        def child_spec(config) do
+          %{
+            id: __MODULE__,
+            start: {__MODULE__, :start_link, [Keyword.fetch!(config, :parent_gate)]},
+            restart: :permanent,
+            type: :worker
+          }
+        end
+
+        @spec start_link(pid()) :: {:ok, pid()} | {:error, term()}
+        def start_link(parent_gate) do
+          send(parent_gate, {:restart_child_start_blocked, self()})
+
+          receive do
+            :release_restart_child_start -> Agent.start_link(fn -> :restart_start_race end)
+          after
+            5_000 -> {:error, :restart_child_start_timeout}
+          end
+        end
+
         @spec noop(map()) :: map()
         def noop(state), do: state
       end
@@ -1576,23 +1660,24 @@ defmodule Minga.Extension.LifecycleContractTest do
       :code.delete(Minga.TestExtensions.RestartStartRace)
     end)
 
-    opts = [
-      command_registry: ctx.command_registry,
-      keymap: ctx.keymap,
-      test_hooks: %{before_restart_reconcile: restart_gate}
-    ]
-
-    :ok = ExtRegistry.register(ctx.registry, :restart_start_race, path, [])
+    :ok = ExtRegistry.register(ctx.registry, :restart_start_race, path, parent_gate: parent_pid)
     {:ok, entry} = ExtRegistry.get(ctx.registry, :restart_start_race)
 
-    assert {:ok, pid_a} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :restart_start_race,
-               entry,
-               opts
-             )
+    start_task =
+      Task.async(fn ->
+        ExtSupervisor.start_extension(
+          ctx.supervisor,
+          ctx.registry,
+          :restart_start_race,
+          entry,
+          command_registry: ctx.command_registry,
+          keymap: ctx.keymap
+        )
+      end)
+
+    assert_receive {:restart_child_start_blocked, start_supervisor_pid}, 1_000
+    send(start_supervisor_pid, :release_restart_child_start)
+    assert {:ok, pid_a} = Task.await(start_task)
 
     assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
                     %{count: 0}, %{extension: :restart_start_race, phase: :crash_restart_count}}
@@ -1600,24 +1685,19 @@ defmodule Minga.Extension.LifecycleContractTest do
     pid_a_ref = Process.monitor(pid_a)
     Process.exit(pid_a, :kill)
     assert_receive {:DOWN, ^pid_a_ref, :process, ^pid_a, _reason}, 1_000
-    assert_receive {:restart_reconcile_blocked, monitor_pid}, 1_000
+    assert_receive {:restart_child_start_blocked, restart_supervisor_pid}, 1_000
 
-    pid_b = wait_for_child_pid(ctx.supervisor, Minga.TestExtensions.RestartStartRace, pid_a)
     {:ok, stale_running_entry} = ExtRegistry.get(ctx.registry, :restart_start_race)
+    assert stale_running_entry.status == :running
     assert stale_running_entry.pid == pid_a
 
-    assert {:ok, ^pid_b} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :restart_start_race,
-               stale_running_entry,
-               opts
-             )
+    refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 1}, %{extension: :restart_start_race, phase: :crash_restart_count}},
+                   150
 
-    assert {:ok, _command} = CommandRegistry.lookup(ctx.command_registry, :restart_start_race_cmd)
+    send(restart_supervisor_pid, :release_restart_child_start)
 
-    send(monitor_pid, :release_restart_reconcile)
+    pid_b = wait_for_child_pid(ctx.supervisor, Minga.TestExtensions.RestartStartRace, pid_a)
 
     assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
                     %{count: 1}, %{extension: :restart_start_race, phase: :crash_restart_count}}
@@ -1626,6 +1706,120 @@ defmodule Minga.Extension.LifecycleContractTest do
     assert final_entry.status == :running
     assert final_entry.pid == pid_b
     assert 1 == count_children(ctx.supervisor, Minga.TestExtensions.RestartStartRace)
+    assert {:ok, _command} = CommandRegistry.lookup(ctx.command_registry, :restart_start_race_cmd)
+  end
+
+  test "restart reconciliation handles a dead supervisor without leaving stale state", ctx do
+    telemetry_id = {__MODULE__, self(), :restart_missing_replacement_telemetry}
+    parent_pid = self()
+
+    :telemetry.attach_many(
+      telemetry_id,
+      [[:minga, :extension, :lifecycle, :crash_restart_count]],
+      fn event, measurements, metadata, test_pid ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+
+    {path, cleanup} =
+      make_extension("RestartMissingReplacement", """
+      defmodule Minga.TestExtensions.RestartMissingReplacement do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :restart_missing_replacement
+
+        @impl true
+        def description, do: "Restart missing replacement"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+
+        @impl true
+        def child_spec(config) do
+          %{
+            id: __MODULE__,
+            start: {__MODULE__, :start_link, [Keyword.fetch!(config, :parent_gate)]},
+            restart: :permanent,
+            type: :worker
+          }
+        end
+
+        @spec start_link(pid()) :: {:ok, pid()} | {:error, term()}
+        def start_link(parent_gate) do
+          send(parent_gate, {:restart_missing_replacement_blocked, self()})
+
+          receive do
+            :release_restart_missing_replacement ->
+              Agent.start_link(fn -> :restart_missing_replacement end)
+
+            :fail_restart_missing_replacement ->
+              {:error, :restart_missing_replacement_failed}
+          after
+            5_000 -> {:error, :restart_missing_replacement_timeout}
+          end
+        end
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.RestartMissingReplacement)
+      :code.delete(Minga.TestExtensions.RestartMissingReplacement)
+    end)
+
+    :ok =
+      ExtRegistry.register(ctx.registry, :restart_missing_replacement, path,
+        parent_gate: parent_pid
+      )
+
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :restart_missing_replacement)
+
+    start_task =
+      Task.async(fn ->
+        ExtSupervisor.start_extension(
+          ctx.supervisor,
+          ctx.registry,
+          :restart_missing_replacement,
+          entry,
+          command_registry: ctx.command_registry,
+          keymap: ctx.keymap
+        )
+      end)
+
+    assert_receive {:restart_missing_replacement_blocked, start_supervisor_pid}, 1_000
+    send(start_supervisor_pid, :release_restart_missing_replacement)
+    assert {:ok, pid} = Task.await(start_task)
+
+    pid_ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^pid_ref, :process, ^pid, _reason}, 1_000
+    assert_receive {:restart_missing_replacement_blocked, _replacement_supervisor_pid}, 1_000
+    previous_trap_exit = Process.flag(:trap_exit, true)
+    Process.exit(Process.whereis(ctx.supervisor), :kill)
+    assert_receive {:EXIT, _supervisor_pid, :killed}, 1_000
+    Process.flag(:trap_exit, previous_trap_exit)
+
+    {:ok, running_entry} = ExtRegistry.get(ctx.registry, :restart_missing_replacement)
+    assert running_entry.status == :running
+    assert running_entry.pid == pid
+
+    refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 1},
+                    %{extension: :restart_missing_replacement, phase: :crash_restart_count}},
+                   150
+
+    crashed_entry =
+      wait_for_entry_status(ctx.registry, :restart_missing_replacement, :crashed, 20)
+
+    assert crashed_entry.pid == nil
+    assert crashed_entry.lifecycle_ref == nil
   end
 
   test "stale crash monitor does not overwrite a newer lifecycle", ctx do

--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -139,6 +139,71 @@ defmodule Minga.Extension.LifecycleContractTest do
            ]
   end
 
+  test "failed start before manifest recording clears stale manifests", ctx do
+    {path, cleanup} =
+      make_extension("StaleManifestCleared", """
+      defmodule Minga.TestExtensions.StaleManifestCleared do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :stale_manifest_cleared
+
+        @impl true
+        def description, do: "Stale manifest cleared"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.StaleManifestCleared)
+      :code.delete(Minga.TestExtensions.StaleManifestCleared)
+    end)
+
+    :ok = ExtRegistry.register(ctx.registry, :stale_manifest_cleared, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :stale_manifest_cleared)
+
+    assert {:ok, _pid} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stale_manifest_cleared,
+               entry
+             )
+
+    {:ok, running_entry} = ExtRegistry.get(ctx.registry, :stale_manifest_cleared)
+    assert running_entry.manifest.name == :stale_manifest_cleared
+
+    assert :ok =
+             ExtSupervisor.stop_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stale_manifest_cleared,
+               running_entry
+             )
+
+    File.rm!(Path.join(path, "extension.ex"))
+
+    {:ok, stopped_entry} = ExtRegistry.get(ctx.registry, :stale_manifest_cleared)
+
+    assert {:error, _reason} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stale_manifest_cleared,
+               stopped_entry
+             )
+
+    {:ok, failed_entry} = ExtRegistry.get(ctx.registry, :stale_manifest_cleared)
+    assert failed_entry.status == :load_error
+    assert failed_entry.manifest == nil
+  end
+
   test "manifest introspection failures become load errors", ctx do
     cases = [
       {"ManifestNameRaise", :name, "raise(\"name boom\")", :manifest_name_raise},
@@ -291,6 +356,86 @@ defmodule Minga.Extension.LifecycleContractTest do
 
     assert catch_exit(Minga.Extension.manifest(Minga.TestExtensions.ManifestDirectExit, :path)) ==
              :direct_manifest_version_boom
+  end
+
+  test "direct manifest construction propagates thrown declaration failures", _ctx do
+    {path, cleanup} =
+      make_extension("ManifestDirectThrow", """
+      defmodule Minga.TestExtensions.ManifestDirectThrow do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :manifest_direct_throw
+
+        @impl true
+        def description, do: throw(:direct_manifest_description_boom)
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+      """)
+
+    Code.compile_file(Path.join(path, "extension.ex"))
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.ManifestDirectThrow)
+      :code.delete(Minga.TestExtensions.ManifestDirectThrow)
+    end)
+
+    assert catch_throw(Minga.Extension.manifest(Minga.TestExtensions.ManifestDirectThrow, :path)) ==
+             :direct_manifest_description_boom
+  end
+
+  test "legacy behavior-only extensions receive default manifest schemas", ctx do
+    {path, cleanup} =
+      make_extension("LegacyManifestDefaults", """
+      defmodule Minga.TestExtensions.LegacyManifestDefaults do
+        @spec name() :: atom()
+        def name, do: :legacy_manifest_defaults
+
+        @spec description() :: String.t()
+        def description, do: "Legacy manifest defaults"
+
+        @spec version() :: String.t()
+        def version, do: "1.0.0"
+
+        @spec init(keyword()) :: {:ok, map()}
+        def init(_config), do: {:ok, %{}}
+
+        @spec child_spec(keyword()) :: Supervisor.child_spec()
+        def child_spec(config) do
+          %{id: __MODULE__, start: {Agent, :start_link, [fn -> config end]}, restart: :permanent, type: :worker}
+        end
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.LegacyManifestDefaults)
+      :code.delete(Minga.TestExtensions.LegacyManifestDefaults)
+    end)
+
+    :ok = ExtRegistry.register(ctx.registry, :legacy_manifest_defaults, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :legacy_manifest_defaults)
+
+    assert {:ok, _pid} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :legacy_manifest_defaults,
+               entry
+             )
+
+    {:ok, started_entry} = ExtRegistry.get(ctx.registry, :legacy_manifest_defaults)
+    assert started_entry.manifest.name == :legacy_manifest_defaults
+    assert started_entry.manifest.commands == []
+    assert started_entry.manifest.keybindings == []
+    assert started_entry.manifest.modeline_segments == []
+    assert started_entry.manifest.capabilities == []
   end
 
   test "failed child start removes contributions registered during init", ctx do
@@ -1376,6 +1521,113 @@ defmodule Minga.Extension.LifecycleContractTest do
     assert crashed_entry.pid == nil
   end
 
+  test "start during pending crash restart reuses the supervisor replacement", ctx do
+    telemetry_id = {__MODULE__, self(), :restart_start_race_telemetry}
+    test_pid = self()
+
+    :telemetry.attach_many(
+      telemetry_id,
+      [[:minga, :extension, :lifecycle, :crash_restart_count]],
+      fn event, measurements, metadata, test_pid ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+
+    restart_gate = fn ->
+      send(test_pid, {:restart_reconcile_blocked, self()})
+
+      receive do
+        :release_restart_reconcile -> :ok
+      after
+        5_000 -> raise "timed out waiting to release restart reconciliation"
+      end
+    end
+
+    {path, cleanup} =
+      make_extension("RestartStartRace", """
+      defmodule Minga.TestExtensions.RestartStartRace do
+        use Minga.Extension
+
+        command :restart_start_race_cmd, "Restart start race command", execute: {__MODULE__, :noop}
+
+        @impl true
+        def name, do: :restart_start_race
+
+        @impl true
+        def description, do: "Restart/start race"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+
+        @spec noop(map()) :: map()
+        def noop(state), do: state
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.RestartStartRace)
+      :code.delete(Minga.TestExtensions.RestartStartRace)
+    end)
+
+    opts = [
+      command_registry: ctx.command_registry,
+      keymap: ctx.keymap,
+      test_hooks: %{before_restart_reconcile: restart_gate}
+    ]
+
+    :ok = ExtRegistry.register(ctx.registry, :restart_start_race, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :restart_start_race)
+
+    assert {:ok, pid_a} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :restart_start_race,
+               entry,
+               opts
+             )
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 0}, %{extension: :restart_start_race, phase: :crash_restart_count}}
+
+    pid_a_ref = Process.monitor(pid_a)
+    Process.exit(pid_a, :kill)
+    assert_receive {:DOWN, ^pid_a_ref, :process, ^pid_a, _reason}, 1_000
+    assert_receive {:restart_reconcile_blocked, monitor_pid}, 1_000
+
+    pid_b = wait_for_child_pid(ctx.supervisor, Minga.TestExtensions.RestartStartRace, pid_a)
+    {:ok, stale_running_entry} = ExtRegistry.get(ctx.registry, :restart_start_race)
+    assert stale_running_entry.pid == pid_a
+
+    assert {:ok, ^pid_b} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :restart_start_race,
+               stale_running_entry,
+               opts
+             )
+
+    assert {:ok, _command} = CommandRegistry.lookup(ctx.command_registry, :restart_start_race_cmd)
+
+    send(monitor_pid, :release_restart_reconcile)
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 1}, %{extension: :restart_start_race, phase: :crash_restart_count}}
+
+    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :restart_start_race)
+    assert final_entry.status == :running
+    assert final_entry.pid == pid_b
+    assert 1 == count_children(ctx.supervisor, Minga.TestExtensions.RestartStartRace)
+  end
+
   test "stale crash monitor does not overwrite a newer lifecycle", ctx do
     telemetry_id = {__MODULE__, self(), :stale_monitor_race_telemetry}
     test_pid = self()
@@ -1530,6 +1782,47 @@ defmodule Minga.Extension.LifecycleContractTest do
   @spec terminal_cleanup_key(:normal | :shutdown) :: String.t()
   defp terminal_cleanup_key(:normal), do: "C-t"
   defp terminal_cleanup_key(:shutdown), do: "C-y"
+
+  @spec wait_for_child_pid(GenServer.server(), module(), pid() | nil) :: pid()
+  defp wait_for_child_pid(supervisor, module, excluded_pid),
+    do: wait_for_child_pid(supervisor, module, excluded_pid, 50)
+
+  @spec wait_for_child_pid(GenServer.server(), module(), pid() | nil, non_neg_integer()) :: pid()
+  defp wait_for_child_pid(supervisor, module, excluded_pid, attempts_left) do
+    case child_pid(supervisor, module, excluded_pid) do
+      pid when is_pid(pid) ->
+        pid
+
+      nil when attempts_left > 0 ->
+        receive do
+        after
+          10 -> wait_for_child_pid(supervisor, module, excluded_pid, attempts_left - 1)
+        end
+
+      nil ->
+        flunk("expected #{inspect(module)} child to start")
+    end
+  end
+
+  @spec child_pid(GenServer.server(), module(), pid() | nil) :: pid() | nil
+  defp child_pid(supervisor, module, excluded_pid) do
+    supervisor
+    |> DynamicSupervisor.which_children()
+    |> Enum.find_value(fn
+      {_id, pid, _type, [^module]} when is_pid(pid) and pid != excluded_pid -> pid
+      _child -> nil
+    end)
+  end
+
+  @spec count_children(GenServer.server(), module()) :: non_neg_integer()
+  defp count_children(supervisor, module) do
+    supervisor
+    |> DynamicSupervisor.which_children()
+    |> Enum.count(fn
+      {_id, pid, _type, [^module]} when is_pid(pid) -> true
+      _child -> false
+    end)
+  end
 
   @spec wait_for_entry_status(GenServer.server(), atom(), Minga.Extension.extension_status()) ::
           ExtRegistry.entry()

--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -7,6 +7,8 @@ defmodule Minga.Extension.LifecycleContractTest do
   alias Minga.Extension.Registry, as: ExtRegistry
   alias Minga.Extension.Supervisor, as: ExtSupervisor
   alias Minga.Keymap.Active, as: KeymapActive
+  alias Minga.Keymap.Bindings
+  alias Minga.Keymap.KeyParser
 
   setup do
     reg_name = :"ext_lifecycle_reg_#{System.unique_integer([:positive])}"
@@ -76,6 +78,8 @@ defmodule Minga.Extension.LifecycleContractTest do
           nil
         end
         capability :ui, [:modeline]
+        capability :ui, [:sidebar]
+        capability :ui, [:modeline]
 
         @impl true
         def name, do: :manifest_before_init
@@ -128,7 +132,165 @@ defmodule Minga.Extension.LifecycleContractTest do
     assert [{:manifest_before_init_segment, [side: :right], _mfa}] =
              failed_entry.manifest.modeline_segments
 
-    assert failed_entry.manifest.capabilities == %{ui: [:modeline]}
+    assert failed_entry.manifest.capabilities == [
+             ui: [:modeline],
+             ui: [:sidebar],
+             ui: [:modeline]
+           ]
+  end
+
+  test "manifest introspection failures become load errors", ctx do
+    cases = [
+      {"ManifestNameRaise", :name, "raise(\"name boom\")", :manifest_name_raise},
+      {"ManifestVersionExit", :version, "exit(:version_boom)", :manifest_version_exit},
+      {"ManifestDescriptionThrow", :description, "throw(:description_boom)",
+       :manifest_description_throw}
+    ]
+
+    for {module_name, callback, body, ext_name} <- cases do
+      source =
+        case callback do
+          :name ->
+            """
+            defmodule Minga.TestExtensions.#{module_name} do
+              use Minga.Extension
+
+              @impl true
+              def name, do: #{body}
+
+              @impl true
+              def description, do: "Manifest failure #{module_name}"
+
+              @impl true
+              def version, do: "1.0.0"
+
+              @impl true
+              def init(_config), do: {:ok, %{}}
+            end
+            """
+
+          :version ->
+            """
+            defmodule Minga.TestExtensions.#{module_name} do
+              use Minga.Extension
+
+              @impl true
+              def name, do: :#{ext_name}
+
+              @impl true
+              def description, do: "Manifest failure #{module_name}"
+
+              @impl true
+              def version, do: #{body}
+
+              @impl true
+              def init(_config), do: {:ok, %{}}
+            end
+            """
+
+          :description ->
+            """
+            defmodule Minga.TestExtensions.#{module_name} do
+              use Minga.Extension
+
+              @impl true
+              def name, do: :#{ext_name}
+
+              @impl true
+              def description, do: #{body}
+
+              @impl true
+              def version, do: "1.0.0"
+
+              @impl true
+              def init(_config), do: {:ok, %{}}
+            end
+            """
+        end
+
+      {path, cleanup} = make_extension(module_name, source)
+
+      on_exit(fn ->
+        cleanup.()
+        :code.purge(Module.concat(Minga.TestExtensions, String.to_atom(module_name)))
+        :code.delete(Module.concat(Minga.TestExtensions, String.to_atom(module_name)))
+      end)
+
+      :ok = ExtRegistry.register(ctx.registry, ext_name, path, [])
+      {:ok, entry} = ExtRegistry.get(ctx.registry, ext_name)
+
+      assert {:error, reason} =
+               ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, ext_name, entry)
+
+      assert reason =~ "manifest introspection failed"
+
+      assert {:ok, %{status: :load_error, pid: nil}} = ExtRegistry.get(ctx.registry, ext_name)
+    end
+  end
+
+  test "direct manifest construction propagates raised declaration failures", _ctx do
+    {path, cleanup} =
+      make_extension("ManifestDirectRaise", """
+      defmodule Minga.TestExtensions.ManifestDirectRaise do
+        use Minga.Extension
+
+        @impl true
+        def name, do: raise("direct manifest name boom")
+
+        @impl true
+        def description, do: "Direct manifest raise"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+      """)
+
+    Code.compile_file(Path.join(path, "extension.ex"))
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.ManifestDirectRaise)
+      :code.delete(Minga.TestExtensions.ManifestDirectRaise)
+    end)
+
+    assert_raise RuntimeError, "direct manifest name boom", fn ->
+      Minga.Extension.manifest(Minga.TestExtensions.ManifestDirectRaise, :path)
+    end
+  end
+
+  test "direct manifest construction propagates exit declaration failures", _ctx do
+    {path, cleanup} =
+      make_extension("ManifestDirectExit", """
+      defmodule Minga.TestExtensions.ManifestDirectExit do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :manifest_direct_exit
+
+        @impl true
+        def description, do: "Direct manifest exit"
+
+        @impl true
+        def version, do: exit(:direct_manifest_version_boom)
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+      """)
+
+    Code.compile_file(Path.join(path, "extension.ex"))
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.ManifestDirectExit)
+      :code.delete(Minga.TestExtensions.ManifestDirectExit)
+    end)
+
+    assert catch_exit(Minga.Extension.manifest(Minga.TestExtensions.ManifestDirectExit, :path)) ==
+             :direct_manifest_version_boom
   end
 
   test "failed child start removes contributions registered during init", ctx do
@@ -527,6 +689,800 @@ defmodule Minga.Extension.LifecycleContractTest do
     assert DynamicSupervisor.count_children(ctx.supervisor).active == 0
   end
 
+  test "intentional stop and restart do not emit crash restart telemetry", ctx do
+    telemetry_id = {__MODULE__, self(), :stop_restart_telemetry}
+
+    :telemetry.attach_many(
+      telemetry_id,
+      [[:minga, :extension, :lifecycle, :crash_restart_count]],
+      fn event, measurements, metadata, test_pid ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+
+    {path, cleanup} =
+      make_extension("StopRestartTelemetry", """
+      defmodule Minga.TestExtensions.StopRestartTelemetry do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :stop_restart_telemetry
+
+        @impl true
+        def description, do: "Stop/restart telemetry"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.StopRestartTelemetry)
+      :code.delete(Minga.TestExtensions.StopRestartTelemetry)
+    end)
+
+    :ok = ExtRegistry.register(ctx.registry, :stop_restart_telemetry, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :stop_restart_telemetry)
+
+    assert {:ok, pid1} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stop_restart_telemetry,
+               entry
+             )
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 0},
+                    %{extension: :stop_restart_telemetry, phase: :crash_restart_count}}
+
+    {:ok, running_entry} = ExtRegistry.get(ctx.registry, :stop_restart_telemetry)
+
+    assert :ok =
+             ExtSupervisor.stop_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stop_restart_telemetry,
+               running_entry
+             )
+
+    {:ok, stopped_entry} = ExtRegistry.get(ctx.registry, :stop_restart_telemetry)
+
+    assert {:ok, pid2} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stop_restart_telemetry,
+               stopped_entry
+             )
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 0},
+                    %{extension: :stop_restart_telemetry, phase: :crash_restart_count}}
+
+    refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 1},
+                    %{extension: :stop_restart_telemetry, phase: :crash_restart_count}},
+                   150
+
+    {:ok, restarted_entry} = ExtRegistry.get(ctx.registry, :stop_restart_telemetry)
+    assert restarted_entry.pid == pid2
+    assert restarted_entry.pid != pid1
+    assert restarted_entry.status == :running
+  end
+
+  test "start uses current registry source type after lifecycle lock", ctx do
+    {path, cleanup} =
+      make_extension("CurrentSourceTypeWins", """
+      defmodule Minga.TestExtensions.CurrentSourceTypeWins do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :current_source_type_wins
+
+        @impl true
+        def description, do: "Current source type wins"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.CurrentSourceTypeWins)
+      :code.delete(Minga.TestExtensions.CurrentSourceTypeWins)
+    end)
+
+    :ok = ExtRegistry.register_hex(ctx.registry, :current_source_type_wins, "not_installed", [])
+    {:ok, stale_hex_entry} = ExtRegistry.get(ctx.registry, :current_source_type_wins)
+    assert stale_hex_entry.source_type == :hex
+
+    :ok = ExtRegistry.register(ctx.registry, :current_source_type_wins, path, [])
+
+    assert {:ok, pid} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :current_source_type_wins,
+               stale_hex_entry
+             )
+
+    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :current_source_type_wins)
+    assert final_entry.source_type == :path
+    assert final_entry.status == :running
+    assert final_entry.pid == pid
+    assert final_entry.module == Minga.TestExtensions.CurrentSourceTypeWins
+    assert final_entry.manifest.source == :path
+  end
+
+  test "concurrent double start with the same stale stopped entry is idempotent", ctx do
+    gate_name = :"concurrent_double_start_gate_#{System.unique_integer([:positive])}"
+    true = Process.register(self(), gate_name)
+
+    {path, cleanup} =
+      make_extension("ConcurrentDoubleStart", """
+      defmodule Minga.TestExtensions.ConcurrentDoubleStart do
+        use Minga.Extension
+
+        command :concurrent_double_start_cmd, "Concurrent double start command",
+          execute: {__MODULE__, :noop}
+
+        @impl true
+        def name, do: :concurrent_double_start
+
+        @impl true
+        def description, do: "Concurrent double start"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config) do
+          send(Process.whereis(#{inspect(gate_name)}), {:concurrent_double_start_init_entered, self()})
+
+          receive do
+            :release_concurrent_double_start_init -> {:ok, %{}}
+          after
+            5_000 -> {:error, :concurrent_double_start_timeout}
+          end
+        end
+
+        @spec noop(map()) :: map()
+        def noop(state), do: state
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.ConcurrentDoubleStart)
+      :code.delete(Minga.TestExtensions.ConcurrentDoubleStart)
+    end)
+
+    opts = [command_registry: ctx.command_registry, keymap: ctx.keymap]
+
+    :ok = ExtRegistry.register(ctx.registry, :concurrent_double_start, path, [])
+    {:ok, stale_stopped_entry} = ExtRegistry.get(ctx.registry, :concurrent_double_start)
+
+    task_a =
+      Task.async(fn ->
+        ExtSupervisor.start_extension(
+          ctx.supervisor,
+          ctx.registry,
+          :concurrent_double_start,
+          stale_stopped_entry,
+          opts
+        )
+      end)
+
+    assert_receive {:concurrent_double_start_init_entered, init_pid}, 1_000
+
+    task_b =
+      Task.async(fn ->
+        send(Process.whereis(gate_name), {:concurrent_double_start_caller_ready, self()})
+
+        ExtSupervisor.start_extension(
+          ctx.supervisor,
+          ctx.registry,
+          :concurrent_double_start,
+          stale_stopped_entry,
+          opts
+        )
+      end)
+
+    assert_receive {:concurrent_double_start_caller_ready, task_b_pid}, 1_000
+    assert task_b_pid == task_b.pid
+    refute Task.yield(task_b, 50)
+    refute_receive {:concurrent_double_start_init_entered, _second_init_pid}, 50
+
+    send(init_pid, :release_concurrent_double_start_init)
+
+    assert [{:ok, pid_a}, {:ok, pid_b}] = [Task.await(task_a), Task.await(task_b)]
+    assert pid_a == pid_b
+    pid = pid_a
+
+    refute_receive {:concurrent_double_start_init_entered, _second_init_pid}, 50
+    assert {:ok, _} = CommandRegistry.lookup(ctx.command_registry, :concurrent_double_start_cmd)
+
+    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :concurrent_double_start)
+    assert final_entry.status == :running
+    assert final_entry.pid == pid
+    assert is_reference(final_entry.lifecycle_ref)
+
+    children = DynamicSupervisor.which_children(ctx.supervisor)
+
+    assert 1 ==
+             Enum.count(children, fn
+               {_id, child_pid, _type, [Minga.TestExtensions.ConcurrentDoubleStart]} ->
+                 child_pid == pid
+
+               _child ->
+                 false
+             end)
+  end
+
+  test "stale stopped-entry stop does not stop or clean a newer lifecycle", ctx do
+    {path, cleanup} =
+      make_extension("StaleStoppedStop", """
+      defmodule Minga.TestExtensions.StaleStoppedStop do
+        use Minga.Extension
+
+        command :stale_stopped_stop_cmd, "Stale stopped stop command",
+          execute: {__MODULE__, :noop}
+
+        @impl true
+        def name, do: :stale_stopped_stop
+
+        @impl true
+        def description, do: "Stale stopped stop"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+
+        @spec noop(map()) :: map()
+        def noop(state), do: state
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.StaleStoppedStop)
+      :code.delete(Minga.TestExtensions.StaleStoppedStop)
+    end)
+
+    opts = [command_registry: ctx.command_registry, keymap: ctx.keymap]
+
+    :ok = ExtRegistry.register(ctx.registry, :stale_stopped_stop, path, [])
+    {:ok, stale_stopped_entry} = ExtRegistry.get(ctx.registry, :stale_stopped_stop)
+
+    assert {:ok, pid} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stale_stopped_stop,
+               stale_stopped_entry,
+               opts
+             )
+
+    assert :ok =
+             ExtSupervisor.stop_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stale_stopped_stop,
+               stale_stopped_entry,
+               opts
+             )
+
+    assert {:ok, _} = CommandRegistry.lookup(ctx.command_registry, :stale_stopped_stop_cmd)
+
+    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :stale_stopped_stop)
+    assert final_entry.status == :running
+    assert final_entry.pid == pid
+    assert is_reference(final_entry.lifecycle_ref)
+  end
+
+  test "terminal child exits clean up source-owned contributions without crash telemetry", ctx do
+    for reason <- [:normal, :shutdown] do
+      telemetry_id = {__MODULE__, self(), {:terminal_child_cleanup, reason}}
+
+      :telemetry.attach_many(
+        telemetry_id,
+        [
+          [:minga, :extension, :lifecycle, :stop],
+          [:minga, :extension, :lifecycle, :crash_restart_count]
+        ],
+        fn event, measurements, metadata, test_pid ->
+          send(test_pid, {:telemetry, event, measurements, metadata})
+        end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(telemetry_id) end)
+
+      label = Atom.to_string(reason)
+      module_name = "TerminalChildCleanup#{String.capitalize(label)}"
+      extension_name = String.to_atom("terminal_child_cleanup_#{label}")
+      command_name = String.to_atom("terminal_child_cleanup_#{label}_cmd")
+      key_str = terminal_cleanup_key(reason)
+
+      {path, cleanup} =
+        make_extension(module_name, """
+        defmodule Minga.TestExtensions.#{module_name} do
+          use Minga.Extension
+
+          command #{inspect(command_name)}, "Terminal child cleanup command",
+            execute: {__MODULE__, :noop}
+
+          keybind :insert, #{inspect(key_str)}, #{inspect(command_name)},
+            "Terminal child cleanup keybind"
+
+          @impl true
+          def name, do: #{inspect(extension_name)}
+
+          @impl true
+          def description, do: "Terminal child cleanup #{label}"
+
+          @impl true
+          def version, do: "1.0.0"
+
+          @impl true
+          def init(_config), do: {:ok, %{}}
+
+          @impl true
+          def child_spec(_config) do
+            %{
+              id: __MODULE__,
+              start: {Agent, :start_link, [fn -> #{inspect(reason)} end]},
+              restart: :temporary,
+              type: :worker
+            }
+          end
+
+          @spec noop(map()) :: map()
+          def noop(state), do: state
+        end
+        """)
+
+      on_exit(fn ->
+        cleanup.()
+        module = Module.concat(Minga.TestExtensions, String.to_atom(module_name))
+        :code.purge(module)
+        :code.delete(module)
+      end)
+
+      :ok = ExtRegistry.register(ctx.registry, extension_name, path, [])
+      {:ok, entry} = ExtRegistry.get(ctx.registry, extension_name)
+
+      assert {:ok, pid} =
+               ExtSupervisor.start_extension(
+                 ctx.supervisor,
+                 ctx.registry,
+                 extension_name,
+                 entry,
+                 command_registry: ctx.command_registry,
+                 keymap: ctx.keymap
+               )
+
+      assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                      %{count: 0}, %{extension: ^extension_name, phase: :crash_restart_count}}
+
+      assert {:ok, _} = CommandRegistry.lookup(ctx.command_registry, command_name)
+      {:ok, key_sequence} = KeyParser.parse(key_str)
+
+      assert {:command, ^command_name, _description} =
+               ctx.keymap
+               |> KeymapActive.mode_trie(:insert)
+               |> Bindings.lookup_sequence(key_sequence)
+
+      assert :ok = Agent.stop(pid, reason)
+
+      stopped_entry = wait_for_entry_status(ctx.registry, extension_name, :stopped)
+
+      assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
+                      %{extension: ^extension_name, phase: :cleanup}}
+
+      refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                      %{count: 1}, %{extension: ^extension_name, phase: :crash_restart_count}},
+                     200
+
+      assert stopped_entry.pid == nil
+      assert stopped_entry.lifecycle_ref == nil
+      assert stopped_entry.module == nil
+      assert :error = CommandRegistry.lookup(ctx.command_registry, command_name)
+
+      assert :not_found =
+               ctx.keymap
+               |> KeymapActive.mode_trie(:insert)
+               |> Bindings.lookup_sequence(key_sequence)
+    end
+  end
+
+  test "stale terminal cleanup cannot remove newer lifecycle contributions", ctx do
+    test_pid = self()
+
+    {path, cleanup} =
+      make_extension("StaleTerminalCleanupRace", """
+      defmodule Minga.TestExtensions.StaleTerminalCleanupRace do
+        use Minga.Extension
+
+        command :stale_terminal_cleanup_race_cmd, "Stale terminal cleanup race command",
+          execute: {__MODULE__, :noop}
+
+        @impl true
+        def name, do: :stale_terminal_cleanup_race
+
+        @impl true
+        def description, do: "Stale terminal cleanup race"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+
+        @impl true
+        def child_spec(_config) do
+          %{
+            id: __MODULE__,
+            start: {Agent, :start_link, [fn -> :stale_terminal_cleanup_race end]},
+            restart: :temporary,
+            type: :worker
+          }
+        end
+
+        @spec noop(map()) :: map()
+        def noop(state), do: state
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.StaleTerminalCleanupRace)
+      :code.delete(Minga.TestExtensions.StaleTerminalCleanupRace)
+    end)
+
+    callbacks = %{
+      blocking_cleanup: fn source ->
+        send(test_pid, {:cleanup_started, self(), source})
+
+        receive do
+          :release_cleanup -> :ok
+        end
+      end
+    }
+
+    opts = [command_registry: ctx.command_registry, keymap: ctx.keymap, callbacks: callbacks]
+
+    :ok = ExtRegistry.register(ctx.registry, :stale_terminal_cleanup_race, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :stale_terminal_cleanup_race)
+
+    assert {:ok, pid_a} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stale_terminal_cleanup_race,
+               entry,
+               opts
+             )
+
+    assert {:ok, _} =
+             CommandRegistry.lookup(ctx.command_registry, :stale_terminal_cleanup_race_cmd)
+
+    assert :ok = Agent.stop(pid_a, :normal)
+
+    assert_receive {:cleanup_started, cleanup_pid, {:extension, :stale_terminal_cleanup_race}}
+
+    start_task =
+      Task.async(fn ->
+        {:ok, current_entry} = ExtRegistry.get(ctx.registry, :stale_terminal_cleanup_race)
+
+        result =
+          ExtSupervisor.start_extension(
+            ctx.supervisor,
+            ctx.registry,
+            :stale_terminal_cleanup_race,
+            current_entry,
+            opts
+          )
+
+        send(test_pid, {:new_lifecycle_started, result})
+        result
+      end)
+
+    refute_receive {:new_lifecycle_started, _result}, 100
+
+    send(cleanup_pid, :release_cleanup)
+    assert {:ok, pid_b} = Task.await(start_task)
+    assert_receive {:new_lifecycle_started, {:ok, ^pid_b}}
+
+    assert {:ok, _} =
+             CommandRegistry.lookup(ctx.command_registry, :stale_terminal_cleanup_race_cmd)
+
+    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :stale_terminal_cleanup_race)
+    assert final_entry.pid == pid_b
+    assert final_entry.pid != pid_a
+    assert final_entry.status == :running
+    assert is_reference(final_entry.lifecycle_ref)
+  end
+
+  test "terminal cleanup failure is surfaced without clean stopped finalization", ctx do
+    telemetry_id = {__MODULE__, self(), :terminal_cleanup_failure_telemetry}
+
+    :telemetry.attach_many(
+      telemetry_id,
+      [[:minga, :extension, :lifecycle, :stop]],
+      fn event, measurements, metadata, test_pid ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+
+    {path, cleanup} =
+      make_extension("TerminalCleanupFailure", """
+      defmodule Minga.TestExtensions.TerminalCleanupFailure do
+        use Minga.Extension
+
+        command :terminal_cleanup_failure_cmd, "Terminal cleanup failure command",
+          execute: {__MODULE__, :noop}
+
+        @impl true
+        def name, do: :terminal_cleanup_failure
+
+        @impl true
+        def description, do: "Terminal cleanup failure"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+
+        @impl true
+        def child_spec(_config) do
+          %{
+            id: __MODULE__,
+            start: {Agent, :start_link, [fn -> :terminal_cleanup_failure end]},
+            restart: :temporary,
+            type: :worker
+          }
+        end
+
+        @spec noop(map()) :: map()
+        def noop(state), do: state
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.TerminalCleanupFailure)
+      :code.delete(Minga.TestExtensions.TerminalCleanupFailure)
+    end)
+
+    callbacks = %{failing_cleanup: fn _source -> {:error, :intentional_cleanup_failure} end}
+
+    :ok = ExtRegistry.register(ctx.registry, :terminal_cleanup_failure, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :terminal_cleanup_failure)
+
+    assert {:ok, pid} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :terminal_cleanup_failure,
+               entry,
+               command_registry: ctx.command_registry,
+               keymap: ctx.keymap,
+               callbacks: callbacks
+             )
+
+    assert :ok = Agent.stop(pid, :normal)
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
+                    %{extension: :terminal_cleanup_failure, phase: :cleanup}}
+
+    failed_entry = wait_for_entry_status(ctx.registry, :terminal_cleanup_failure, :load_error)
+    assert failed_entry.pid == nil
+    assert failed_entry.lifecycle_ref == nil
+    assert failed_entry.module == Minga.TestExtensions.TerminalCleanupFailure
+  end
+
+  test "crashed child without replacement marks the registry crashed", ctx do
+    telemetry_id = {__MODULE__, self(), :crash_without_replacement_telemetry}
+
+    :telemetry.attach_many(
+      telemetry_id,
+      [[:minga, :extension, :lifecycle, :crash_restart_count]],
+      fn event, measurements, metadata, test_pid ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+
+    {path, cleanup} =
+      make_extension("CrashWithoutReplacement", """
+      defmodule Minga.TestExtensions.CrashWithoutReplacement do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :crash_without_replacement
+
+        @impl true
+        def description, do: "Crash without replacement"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+
+        @impl true
+        def child_spec(_config) do
+          %{
+            id: __MODULE__,
+            start: {Agent, :start_link, [fn -> :crash_without_replacement end]},
+            restart: :temporary,
+            type: :worker
+          }
+        end
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.CrashWithoutReplacement)
+      :code.delete(Minga.TestExtensions.CrashWithoutReplacement)
+    end)
+
+    :ok = ExtRegistry.register(ctx.registry, :crash_without_replacement, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :crash_without_replacement)
+
+    assert {:ok, pid} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :crash_without_replacement,
+               entry
+             )
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 0},
+                    %{extension: :crash_without_replacement, phase: :crash_restart_count}}
+
+    Process.exit(pid, :kill)
+
+    refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 1},
+                    %{extension: :crash_without_replacement, phase: :crash_restart_count}},
+                   150
+
+    {:ok, crashed_entry} = ExtRegistry.get(ctx.registry, :crash_without_replacement)
+    assert crashed_entry.status == :crashed
+    assert crashed_entry.pid == nil
+  end
+
+  test "stale crash monitor does not overwrite a newer lifecycle", ctx do
+    telemetry_id = {__MODULE__, self(), :stale_monitor_race_telemetry}
+    test_pid = self()
+
+    :telemetry.attach_many(
+      telemetry_id,
+      [[:minga, :extension, :lifecycle, :crash_restart_count]],
+      fn event, measurements, metadata, test_pid ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+
+    stale_monitor_gate = fn ->
+      send(test_pid, {:stale_monitor_terminal_exit_blocked, self()})
+
+      receive do
+        :release_stale_monitor_terminal_exit -> :ok
+      after
+        1_000 -> raise "timed out waiting to release stale monitor terminal exit"
+      end
+
+      send(test_pid, {:stale_monitor_terminal_exit_released, self()})
+      :ok
+    end
+
+    {path, cleanup} =
+      make_extension("StaleMonitorRace", """
+      defmodule Minga.TestExtensions.StaleMonitorRace do
+        use Minga.Extension
+
+        @impl true
+        def name, do: :stale_monitor_race
+
+        @impl true
+        def description, do: "Stale monitor race"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+
+        @impl true
+        def child_spec(_config) do
+          %{
+            id: __MODULE__,
+            start: {Agent, :start_link, [fn -> :stale_monitor_race end]},
+            restart: :temporary,
+            type: :worker
+          }
+        end
+      end
+      """)
+
+    on_exit(fn ->
+      cleanup.()
+      :code.purge(Minga.TestExtensions.StaleMonitorRace)
+      :code.delete(Minga.TestExtensions.StaleMonitorRace)
+    end)
+
+    opts = [test_hooks: %{before_terminal_child_exit: stale_monitor_gate}]
+
+    :ok = ExtRegistry.register(ctx.registry, :stale_monitor_race, path, [])
+    {:ok, entry} = ExtRegistry.get(ctx.registry, :stale_monitor_race)
+
+    assert {:ok, pid_a} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stale_monitor_race,
+               entry,
+               opts
+             )
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 0}, %{extension: :stale_monitor_race, phase: :crash_restart_count}}
+
+    Process.exit(pid_a, :kill)
+
+    assert_receive {:stale_monitor_terminal_exit_blocked, monitor_pid}
+
+    assert {:ok, pid_b} =
+             ExtSupervisor.start_extension(
+               ctx.supervisor,
+               ctx.registry,
+               :stale_monitor_race,
+               entry
+             )
+
+    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 0}, %{extension: :stale_monitor_race, phase: :crash_restart_count}}
+
+    send(monitor_pid, :release_stale_monitor_terminal_exit)
+    assert_receive {:stale_monitor_terminal_exit_released, ^monitor_pid}
+
+    refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 1}, %{extension: :stale_monitor_race, phase: :crash_restart_count}},
+                   200
+
+    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :stale_monitor_race)
+    assert final_entry.pid == pid_b
+    assert final_entry.status == :running
+  end
+
   test "slow lifecycle phases are logged with extension and phase", ctx do
     {path, cleanup} =
       make_extension("SlowLifecycle", """
@@ -569,6 +1525,38 @@ defmodule Minga.Extension.LifecycleContractTest do
       end)
 
     assert log =~ "Extension slow_lifecycle lifecycle phase load took"
+  end
+
+  @spec terminal_cleanup_key(:normal | :shutdown) :: String.t()
+  defp terminal_cleanup_key(:normal), do: "C-t"
+  defp terminal_cleanup_key(:shutdown), do: "C-y"
+
+  @spec wait_for_entry_status(GenServer.server(), atom(), Minga.Extension.extension_status()) ::
+          ExtRegistry.entry()
+  defp wait_for_entry_status(registry, name, status),
+    do: wait_for_entry_status(registry, name, status, 20)
+
+  @spec wait_for_entry_status(
+          GenServer.server(),
+          atom(),
+          Minga.Extension.extension_status(),
+          non_neg_integer()
+        ) ::
+          ExtRegistry.entry()
+  defp wait_for_entry_status(registry, name, status, attempts_left) do
+    case ExtRegistry.get(registry, name) do
+      {:ok, %{status: ^status} = entry} ->
+        entry
+
+      _other when attempts_left > 0 ->
+        receive do
+        after
+          10 -> wait_for_entry_status(registry, name, status, attempts_left - 1)
+        end
+
+      other ->
+        flunk("expected #{inspect(name)} to reach #{inspect(status)}, got #{inspect(other)}")
+    end
   end
 
   @spec make_extension(String.t(), String.t()) :: {String.t(), (-> :ok)}

--- a/test/minga/extension/registry_test.exs
+++ b/test/minga/extension/registry_test.exs
@@ -85,7 +85,7 @@ defmodule Minga.Extension.RegistryTest do
 
       assert {:ok, %Entry{} = entry} = Registry.get(r, :my_ext)
       assert entry.source_type == :hex
-      assert entry.hex == %{package: "minga_snippets", version: "~> 0.3"}
+      assert entry.hex == %{package: "minga_snippets", version: "~> 0.3", app: nil}
       assert entry.path == nil
       assert entry.git == nil
       assert entry.config == []

--- a/test/minga/extension/source_cleanup_test.exs
+++ b/test/minga/extension/source_cleanup_test.exs
@@ -299,10 +299,10 @@ defmodule Minga.Extension.SourceCleanupTest do
         end
       end)
 
+    ref = Process.monitor(pid)
     on_exit(fn -> Process.exit(bogus_pid, :kill) end)
-    on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
 
-    assert {:error, :not_found} =
+    assert :ok =
              ExtSupervisor.stop_extension(
                ctx.supervisor,
                ctx.registry,
@@ -318,7 +318,7 @@ defmodule Minga.Extension.SourceCleanupTest do
     assert stopped_entry.module == nil
     assert :error = CommandRegistry.lookup(ctx.command_registry, :stop_aggregate_failure_cmd)
     assert Minga.Language.Registry.get(:stop_aggregate_failure_lang) == nil
-    assert Process.alive?(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
   end
 
   test "command registration failure stops keybind registration and marks the extension failed",

--- a/test/minga/extension/source_cleanup_test.exs
+++ b/test/minga/extension/source_cleanup_test.exs
@@ -211,6 +211,8 @@ defmodule Minga.Extension.SourceCleanupTest do
 
     {:ok, running_entry} = ExtRegistry.get(ctx.registry, :stop_cleanup_failure)
 
+    pid_ref = Process.monitor(pid)
+
     assert {:error, {:cleanup_failed, failures}} =
              ExtSupervisor.stop_extension(
                ctx.supervisor,
@@ -226,12 +228,12 @@ defmodule Minga.Extension.SourceCleanupTest do
              _ -> false
            end)
 
-    refute Process.alive?(pid)
+    assert_receive {:DOWN, ^pid_ref, :process, ^pid, _reason}, 1_000
 
     {:ok, stopped_entry} = ExtRegistry.get(ctx.registry, :stop_cleanup_failure)
-    assert stopped_entry.status == :stopped
+    assert stopped_entry.status == :load_error
     assert stopped_entry.pid == nil
-    assert stopped_entry.module == nil
+    assert stopped_entry.module == Minga.TestExtensions.StopCleanupFailure
   end
 
   test "stop_extension cleans source-owned contributions even when the pid is stale", ctx do
@@ -525,6 +527,7 @@ defmodule Minga.Extension.SourceCleanupTest do
         status: :running
       )
 
+    healthy_ref = Process.monitor(healthy_pid)
     assert {:error, failures} = ExtSupervisor.stop_all(ctx.supervisor, ctx.registry)
 
     assert Enum.any?(failures, fn
@@ -535,7 +538,7 @@ defmodule Minga.Extension.SourceCleanupTest do
     {:ok, healthy_stopped} = ExtRegistry.get(ctx.registry, :stop_all_healthy)
     assert healthy_stopped.status == :stopped
     assert healthy_stopped.pid == nil
-    refute Process.alive?(healthy_pid)
+    assert_receive {:DOWN, ^healthy_ref, :process, ^healthy_pid, _reason}, 1_000
 
     {:ok, broken_entry} = ExtRegistry.get(ctx.registry, :stop_all_broken)
     assert broken_entry.status == :stopped

--- a/test/minga/extension/supervisor_dsl_test.exs
+++ b/test/minga/extension/supervisor_dsl_test.exs
@@ -1,5 +1,7 @@
 defmodule Minga.Extension.SupervisorDslTest do
-  use ExUnit.Case, async: true
+  # Uses the global modeline segment registry.
+  # Keep serialized so snapshot tests do not see temporary DSL segments.
+  use ExUnit.Case, async: false
 
   alias Minga.Command.Registry, as: CommandRegistry
   alias Minga.Extension.Registry, as: ExtRegistry

--- a/test/minga/extension/supervisor_test.exs
+++ b/test/minga/extension/supervisor_test.exs
@@ -128,19 +128,100 @@ defmodule Minga.Extension.SupervisorTest do
       assert updated.status == :load_error
     end
 
-    test "records load_error when a hex application cannot start", ctx do
-      package = "missing_hex_app_#{System.unique_integer([:positive])}"
-      package_atom = String.to_atom(package)
+    test "records load_error for an unknown hex application without interning it", ctx do
+      package = "missing-hex-app-#{System.unique_integer([:positive])}"
+      normalized = String.replace(package, "-", "_")
+
+      assert_raise ArgumentError, fn -> String.to_existing_atom(normalized) end
 
       :ok = ExtRegistry.register_hex(ctx.registry, :hex_start_fail, package, [])
       {:ok, entry} = ExtRegistry.get(ctx.registry, :hex_start_fail)
 
-      assert {:error, {:hex_application_start_failed, ^package_atom, _reason}} =
+      assert {:error, {:hex_application_start_failed, :hex_start_fail, _reason}} =
                ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, :hex_start_fail, entry)
 
       {:ok, updated} = ExtRegistry.get(ctx.registry, :hex_start_fail)
       assert updated.status == :load_error
       assert updated.pid == nil
+      assert updated.manifest == nil
+      assert_raise ArgumentError, fn -> String.to_existing_atom(normalized) end
+    end
+
+    test "starts a hex extension when package alias and explicit app atom differ", ctx do
+      app_atom = :minga_hex_runtime_explicit_app
+      app_module = Minga.Extension.SupervisorTest.HexRuntimeApp
+      extension_module = Minga.TestExtensions.HexRuntimeExplicitApp
+
+      Code.compile_quoted(
+        quote do
+          defmodule unquote(app_module) do
+            @moduledoc false
+            use Application
+
+            @impl true
+            def start(_type, _args), do: Supervisor.start_link([], strategy: :one_for_one)
+          end
+
+          defmodule unquote(extension_module) do
+            use Minga.Extension
+
+            @impl true
+            def name, do: :hex_runtime_alias
+
+            @impl true
+            def description, do: "Hex runtime explicit app"
+
+            @impl true
+            def version, do: "1.0.0"
+
+            @impl true
+            def init(_config), do: {:ok, %{}}
+          end
+        end,
+        __ENV__.file
+      )
+
+      on_exit(fn ->
+        :application.stop(app_atom)
+        :application.unload(app_atom)
+        :code.purge(extension_module)
+        :code.delete(extension_module)
+        :code.purge(app_module)
+        :code.delete(app_module)
+      end)
+
+      :ok =
+        :application.load(
+          {:application, app_atom,
+           [
+             description: ~c"Hex runtime explicit app",
+             vsn: ~c"1.0.0",
+             applications: [:kernel, :stdlib],
+             modules: [app_module, extension_module],
+             registered: [],
+             mod: {app_module, []}
+           ]}
+        )
+
+      :ok =
+        ExtRegistry.register_hex(ctx.registry, :hex_runtime_alias, "minga-hex-runtime-package",
+          app: app_atom
+        )
+
+      {:ok, entry} = ExtRegistry.get(ctx.registry, :hex_runtime_alias)
+
+      assert {:ok, pid} =
+               ExtSupervisor.start_extension(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :hex_runtime_alias,
+                 entry
+               )
+
+      {:ok, updated} = ExtRegistry.get(ctx.registry, :hex_runtime_alias)
+      assert updated.status == :running
+      assert updated.pid == pid
+      assert updated.module == extension_module
     end
 
     test "passes config to init/1", ctx do


### PR DESCRIPTION
# TL;DR
Stateful extensions now have a documented, tested lifecycle contract for init state, cleanup, manifest introspection, telemetry, reload, and crash restarts. This hardens the SDK foundation before stateful bundled UI features move out of core.

Closes #1943

## Context
This PR is the extension lifecycle hardening slice from the extension API roadmap in #1747. It keeps FileTree, Git UI, Board, Dired, and Agent code in core for now, and focuses on making extension startup, stop, reload, cleanup, and observability predictable before those features depend on the SDK boundary.

## Changes
- Clarified the `init/1` state contract: the default child stores validated config, while `init/1` return state is setup-only unless an extension provides its own stateful child.
- Added `%Minga.Extension.Manifest{}` and `capability/2` so extension declarations can be introspected before runtime side effects run.
- Recorded manifests before `init/1`, including extension name, version, source, commands, keybindings, modeline segments, and capabilities.
- Hardened start/stop failure paths so failed init, failed child start, `child_spec/1` exceptions, stale pids, crash restarts, and reloads clean source-owned contributions consistently.
- Added lifecycle telemetry spans for load, init, child start, stop, reload, and cleanup, plus crash/restart count events and slow lifecycle logging.
- Documented lifecycle ordering, cleanup aggregation, manifest/capability introspection, telemetry, and the hot-path cached-data rule.
- Fixed a test isolation issue by serializing the DSL supervisor test file because it touches the global modeline segment registry.

## Verification
- `git diff --check`
- `make lint`
- `mix test.llm`
- `mix test.debug test/minga_editor/renderer/line_test.exs:150`
- `mix test.llm test/minga_editor/renderer/line_test.exs`
- `mix test.llm test/minga/extension/supervisor_dsl_test.exs test/minga_editor/integration/snapshot_test.exs`
- `cd extensions/ghost_cursors && mix test`

## Acceptance Criteria Addressed
- Lifecycle docs and implementation agree on `init/1` state handoff ✅
- Start, stop, failed start, crash restart, and reload ordering are documented and tested ✅
- Source-owned contributions are removed on stop, failed start, and reload, with cleanup failure aggregation ✅
- Extension declarations expose manifest/capability introspection before runtime side effects ✅
- Lifecycle telemetry exists for load, init, child start, stop, reload, cleanup, and crash/restart count ✅
- Slow lifecycle phases log with extension name and phase ✅
- Hot-path cached-data rule is documented, including the current modeline compatibility exception ✅
- Existing path, git, hex, and Ghost Cursors loading behavior remains compatible ✅
