### PR TITLE
FileTree UI state is feature-owned

### DIFF
--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -23,6 +23,7 @@ defmodule Minga.Application do
       ├── Minga.Buffer.Registry (Registry, :unique)
       ├── Minga.Buffer.Supervisor (DynamicSupervisor, one_for_one)
       ├── Minga.Log.MessagesBuffer           (singleton *Messages* buffer owner)
+      ├── MingaEditor.Extension.Sidebar      (source-owned sidebar registry)
       ├── Minga.Services.Supervisor (rest_for_one)
       │   ├── Minga.Services.Independent (one_for_one)
       │   │   ├── Minga.Git.Tracker
@@ -94,7 +95,8 @@ defmodule Minga.Application do
         Minga.Foundation.Supervisor,
         {Registry, keys: :unique, name: Minga.Buffer.Registry},
         {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},
-        Minga.Log.MessagesBuffer
+        Minga.Log.MessagesBuffer,
+        MingaEditor.Extension.Sidebar
       ] ++
         if minimal? do
           []

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -23,7 +23,6 @@ defmodule Minga.Application do
       ├── Minga.Buffer.Registry (Registry, :unique)
       ├── Minga.Buffer.Supervisor (DynamicSupervisor, one_for_one)
       ├── Minga.Log.MessagesBuffer           (singleton *Messages* buffer owner)
-      ├── MingaEditor.Extension.Sidebar      (source-owned sidebar registry)
       ├── Minga.Services.Supervisor (rest_for_one)
       │   ├── Minga.Services.Independent (one_for_one)
       │   │   ├── Minga.Git.Tracker
@@ -95,8 +94,7 @@ defmodule Minga.Application do
         Minga.Foundation.Supervisor,
         {Registry, keys: :unique, name: Minga.Buffer.Registry},
         {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},
-        Minga.Log.MessagesBuffer,
-        MingaEditor.Extension.Sidebar
+        Minga.Log.MessagesBuffer
       ] ++
         if minimal? do
           []

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -630,7 +630,7 @@ defmodule MingaEditor.Agent.Events do
   end
 
   @spec project_root(EditorState.t()) :: String.t() | nil
-  defp project_root(%{workspace: %{file_tree: %{project_root: root}}}), do: root
+  defp project_root(state), do: EditorState.file_tree_state(state).project_root
 
   @spec find_unassociated_file_tab(TabBar.t(), FileRef.t(), non_neg_integer(), EditorState.t()) ::
           Tab.t() | nil

--- a/lib/minga_editor/agent_activation.ex
+++ b/lib/minga_editor/agent_activation.ex
@@ -78,7 +78,7 @@ defmodule MingaEditor.AgentActivation do
       active_tab_id(state),
       state.workspace.buffers.active,
       state.workspace.windows,
-      state.workspace.file_tree,
+      EditorState.file_tree_state(state),
       state.workspace.keymap_scope,
       AgentAccess.input_focused?(state)
     )

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -737,7 +737,7 @@ defmodule MingaEditor.Commands do
   # is back in the file tree, not stuck in editor scope.
   @spec restore_file_tree_scope(EditorState.t()) :: EditorState.t()
   defp restore_file_tree_scope(state) do
-    if state.workspace.file_tree.tree != nil do
+    if EditorState.file_tree_state(state).tree != nil do
       EditorState.set_keymap_scope(state, :file_tree)
     else
       state

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -202,7 +202,7 @@ defmodule MingaEditor.Commands.Agent do
       active_tab_id,
       state.workspace.buffers.active,
       state.workspace.windows,
-      state.workspace.file_tree,
+      EditorState.file_tree_state(state),
       state.workspace.keymap_scope,
       AgentAccess.input_focused?(state)
     )

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -703,15 +703,18 @@ defmodule MingaEditor.Commands.AgentSession do
   defp session_project_view(state), do: project_view_from_root(state)
 
   @spec project_view_from_root(state()) :: {ProjectView.t() | nil, boolean()}
-  defp project_view_from_root(%{workspace: %{file_tree: %{project_root: root}}})
-       when is_binary(root) do
-    case ProjectView.overlay(root) do
-      {:ok, project_view} -> {project_view, true}
-      {:error, _reason} -> {nil, false}
+  defp project_view_from_root(state) do
+    case EditorState.file_tree_state(state).project_root do
+      root when is_binary(root) ->
+        case ProjectView.overlay(root) do
+          {:ok, project_view} -> {project_view, true}
+          {:error, _reason} -> {nil, false}
+        end
+
+      _ ->
+        {nil, false}
     end
   end
-
-  defp project_view_from_root(_state), do: {nil, false}
 
   @spec maybe_discard_project_view(ProjectView.t() | nil, boolean()) :: :ok
   defp maybe_discard_project_view(%ProjectView{} = project_view, true) do

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -25,6 +25,14 @@ defmodule MingaEditor.Commands.FileTree do
   @doc "Handles semantic sidebar actions from native frontends or generic sidebar input."
   @spec handle_sidebar_action(state(), String.t(), map()) :: state()
   def handle_sidebar_action(state, "toggle", _context), do: toggle(state)
+
+  def handle_sidebar_action(state, "activate", _context) do
+    case file_tree_state(state) |> FileTreeState.status() |> FileTreeState.visible_status?() do
+      true -> focus_visible_tree(state)
+      false -> toggle(state)
+    end
+  end
+
   def handle_sidebar_action(state, _action, _context), do: state
 
   @spec toggle(state()) :: state()
@@ -42,6 +50,16 @@ defmodule MingaEditor.Commands.FileTree do
         FileTreeFreshness.unwatch_expanded_dirs(tree)
         close_tree(state)
     end
+  end
+
+  @spec focus_visible_tree(state()) :: state()
+  defp focus_visible_tree(state) do
+    state
+    |> EditorState.update_file_tree(&FileTreeState.focus/1)
+    |> EditorState.set_keymap_scope(:file_tree)
+    |> EditorState.set_sidebar_active_id("file_tree")
+    |> Layout.invalidate()
+    |> EditorState.invalidate_all_windows()
   end
 
   @spec close_tree(state()) :: state()

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -22,36 +22,30 @@ defmodule MingaEditor.Commands.FileTree do
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
 
+  @doc "Handles semantic sidebar actions from native frontends or generic sidebar input."
+  @spec handle_sidebar_action(state(), String.t(), map()) :: state()
+  def handle_sidebar_action(state, "toggle", _context), do: toggle(state)
+  def handle_sidebar_action(state, _action, _context), do: state
+
   @spec toggle(state()) :: state()
-  def toggle(%{workspace: %{file_tree: %{tree: nil}}} = state), do: open(state)
-
-  def toggle(%{workspace: %{file_tree: %{tree: tree, buffer: buf}}} = state) when is_pid(buf) do
-    FileTreeFreshness.unwatch_expanded_dirs(tree)
-    GenServer.stop(buf, :normal)
-
-    scope = restore_scope(state)
-
-    state
-    |> EditorState.update_file_tree(&FileTreeState.close/1)
-    |> EditorState.set_keymap_scope(scope)
-    |> EditorState.set_sidebar_active_id(nil)
-    |> Layout.invalidate()
-    |> EditorState.invalidate_all_windows()
-  end
-
-  def toggle(%{workspace: %{file_tree: %{tree: %FileTree{} = tree}}} = state) do
-    FileTreeFreshness.unwatch_expanded_dirs(tree)
-    scope = restore_scope(state)
-
-    state
-    |> EditorState.update_file_tree(&FileTreeState.close/1)
-    |> EditorState.set_keymap_scope(scope)
-    |> EditorState.set_sidebar_active_id(nil)
-    |> Layout.invalidate()
-    |> EditorState.invalidate_all_windows()
-  end
-
   def toggle(state) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: nil} ->
+        open(state)
+
+      %FileTreeState{tree: tree, buffer: buf} when is_pid(buf) ->
+        FileTreeFreshness.unwatch_expanded_dirs(tree)
+        GenServer.stop(buf, :normal)
+        close_tree(state)
+
+      %FileTreeState{tree: %FileTree{} = tree} ->
+        FileTreeFreshness.unwatch_expanded_dirs(tree)
+        close_tree(state)
+    end
+  end
+
+  @spec close_tree(state()) :: state()
+  defp close_tree(state) do
     scope = restore_scope(state)
 
     state
@@ -65,6 +59,9 @@ defmodule MingaEditor.Commands.FileTree do
   @spec restore_scope(state()) :: atom()
   defp restore_scope(state), do: EditorState.scope_for_active_window(state)
 
+  @spec file_tree_state(state()) :: FileTreeState.t()
+  defp file_tree_state(state), do: EditorState.file_tree_state(state)
+
   @spec set_file_tree(state(), FileTreeState.t()) :: state()
   defp set_file_tree(state, file_tree) do
     EditorState.set_file_tree(state, file_tree)
@@ -76,79 +73,70 @@ defmodule MingaEditor.Commands.FileTree do
   end
 
   @spec open_or_toggle(state()) :: state()
-  def open_or_toggle(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+  def open_or_toggle(state) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: %FileTree{} = tree} ->
+        open_or_toggle_entry(state, tree, FileTree.selected_entry(tree))
 
-  def open_or_toggle(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    case FileTree.selected_entry(tree) do
-      %{dir?: true} ->
-        new_tree = FileTree.toggle_expand(tree)
-        sync_and_update(state, new_tree)
-
-      %{dir?: false, path: path} ->
-        state = update_file_tree(state, &FileTreeState.unfocus/1)
-        # Opening a file buffer always uses :editor scope (not restore_scope)
-        # because the new buffer becomes the active window content.
-        state = EditorState.set_keymap_scope(state, :editor)
-        open_file_from_tree(state, path, tree)
-
-      nil ->
+      %FileTreeState{} ->
         state
     end
   end
 
-  @spec toggle_directory(state()) :: state()
-  def toggle_directory(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-
-  def toggle_directory(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    sync_and_update(state, FileTree.toggle_expand(tree))
+  @spec open_or_toggle_entry(state(), FileTree.t(), FileTree.entry() | nil) :: state()
+  defp open_or_toggle_entry(state, tree, %{dir?: true}) do
+    new_tree = FileTree.toggle_expand(tree)
+    sync_and_update(state, new_tree)
   end
+
+  defp open_or_toggle_entry(state, tree, %{dir?: false, path: path}) do
+    state = update_file_tree(state, &FileTreeState.unfocus/1)
+    # Opening a file buffer always uses :editor scope (not restore_scope)
+    # because the new buffer becomes the active window content.
+    state = EditorState.set_keymap_scope(state, :editor)
+    open_file_from_tree(state, path, tree)
+  end
+
+  defp open_or_toggle_entry(state, _tree, nil), do: state
+
+  @spec toggle_directory(state()) :: state()
+  def toggle_directory(state), do: with_tree(state, &FileTree.toggle_expand/1)
 
   @spec expand(state()) :: state()
-  def expand(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-
-  def expand(%{workspace: %{file_tree: %{tree: tree}}} = state),
-    do: sync_and_update(state, FileTree.expand(tree))
+  def expand(state), do: with_tree(state, &FileTree.expand/1)
 
   @spec collapse(state()) :: state()
-  def collapse(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-
-  def collapse(%{workspace: %{file_tree: %{tree: tree}}} = state),
-    do: sync_and_update(state, FileTree.collapse(tree))
+  def collapse(state), do: with_tree(state, &FileTree.collapse/1)
 
   @spec toggle_hidden(state()) :: state()
-  def toggle_hidden(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-
-  def toggle_hidden(%{workspace: %{file_tree: %{tree: tree}}} = state),
-    do: sync_and_update(state, FileTree.toggle_hidden(tree))
+  def toggle_hidden(state), do: with_tree(state, &FileTree.toggle_hidden/1)
 
   @spec collapse_all(state()) :: state()
-  def collapse_all(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-
-  def collapse_all(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    sync_and_update(state, FileTree.collapse_all(tree))
-  end
+  def collapse_all(state), do: with_tree(state, &FileTree.collapse_all/1)
 
   @spec refresh(state()) :: state()
-  def refresh(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+  def refresh(state) do
+    with_tree(state, fn tree -> tree |> FileTree.refresh() |> FileTree.refresh_git_status() end)
+  end
 
-  def refresh(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    tree = tree |> FileTree.refresh() |> FileTree.refresh_git_status()
-    sync_and_update(state, tree)
+  @spec with_tree(state(), (FileTree.t() -> FileTree.t())) :: state()
+  defp with_tree(state, fun) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: %FileTree{} = tree} -> sync_and_update(state, fun.(tree))
+      %FileTreeState{} -> state
+    end
   end
 
   @doc "Copies the selected entry's absolute path to the system clipboard."
   @spec copy_path(state()) :: state()
-  def copy_path(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-
-  def copy_path(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    case FileTree.selected_entry(tree) do
-      nil ->
-        state
-
-      %{path: path} ->
-        state
-        |> Helpers.force_clipboard_sync(Path.expand(path))
-        |> EditorState.set_status("Copied #{Path.expand(path)}")
+  def copy_path(state) do
+    with %FileTreeState{tree: %FileTree{} = tree} <- file_tree_state(state),
+         %{path: path} <- FileTree.selected_entry(tree) do
+      state
+      |> Helpers.force_clipboard_sync(Path.expand(path))
+      |> EditorState.set_status("Copied #{Path.expand(path)}")
+    else
+      _ -> state
     end
   end
 
@@ -162,58 +150,60 @@ defmodule MingaEditor.Commands.FileTree do
 
   @doc "Pastes the marked copy or move entry into the selected directory or file parent."
   @spec paste(state()) :: state()
-  def paste(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+  def paste(state) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: nil} ->
+        state
 
-  def paste(%{workspace: %{file_tree: %{clipboard_mark: nil}}} = state),
-    do: EditorState.set_status(state, "No file tree copy or move is pending")
+      %FileTreeState{clipboard_mark: nil} ->
+        EditorState.set_status(state, "No file tree copy or move is pending")
 
-  def paste(%{workspace: %{file_tree: %{clipboard_mark: mark, tree: tree}}} = state) do
-    target_dir = selected_target_dir(tree)
-    destination = Path.join(target_dir, mark.name)
-    paste_marked_entry(state, mark, destination)
+      %FileTreeState{clipboard_mark: mark, tree: tree} ->
+        target_dir = selected_target_dir(tree)
+        destination = Path.join(target_dir, mark.name)
+        paste_marked_entry(state, mark, destination)
+    end
   end
 
   @doc "Changes the tree root to the parent directory of the current root."
   @spec root_parent(state()) :: state()
-  def root_parent(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+  def root_parent(state) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: %FileTree{root: root}} ->
+        parent = Path.dirname(root)
+        if parent == root, do: state, else: reroot(state, parent)
 
-  def root_parent(%{workspace: %{file_tree: %{tree: %FileTree{root: root}}}} = state) do
-    parent = Path.dirname(root)
-
-    if parent == root do
-      state
-    else
-      reroot(state, parent)
+      %FileTreeState{} ->
+        state
     end
   end
 
   @doc "Changes the tree root to the selected directory."
   @spec root_selected(state()) :: state()
-  def root_selected(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+  def root_selected(state) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: %FileTree{} = tree} ->
+        case FileTree.selected_entry(tree) do
+          %{dir?: true, path: path} -> reroot(state, path)
+          %{dir?: false} -> state
+          nil -> state
+        end
 
-  def root_selected(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    case FileTree.selected_entry(tree) do
-      %{dir?: true, path: path} -> reroot(state, path)
-      %{dir?: false} -> state
-      nil -> state
+      %FileTreeState{} ->
+        state
     end
   end
 
   @doc "Restores the tree root to the original project directory."
   @spec root_original(state()) :: state()
-  def root_original(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-
-  def root_original(%{workspace: %{file_tree: %{original_root: root}}} = state)
-      when is_binary(root) do
-    reroot(state, root)
+  def root_original(state) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: nil} -> state
+      %FileTreeState{original_root: root} when is_binary(root) -> reroot(state, root)
+      %FileTreeState{project_root: root} when is_binary(root) -> reroot(state, root)
+      %FileTreeState{} -> state
+    end
   end
-
-  def root_original(%{workspace: %{file_tree: %{project_root: root}}} = state)
-      when is_binary(root) do
-    reroot(state, root)
-  end
-
-  def root_original(state), do: state
 
   @doc "Starts inline file tree filtering."
   @spec filter(state()) :: state()
@@ -241,19 +231,7 @@ defmodule MingaEditor.Commands.FileTree do
   file, the new file appears as a sibling in the same directory.
   """
   @spec new_file(state()) :: state()
-  def new_file(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-
-  def new_file(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    {index, tree} = editing_insertion_index(tree)
-
-    ft =
-      state.workspace.file_tree
-      |> FileTreeState.start_editing(index, :new_file)
-      |> FileTreeState.replace_tree(tree)
-
-    state = set_file_tree(state, ft)
-    sync_buffer(state)
-  end
+  def new_file(state), do: start_new_entry_edit(state, :new_file)
 
   @doc """
   Enters inline editing mode to create a new folder.
@@ -261,18 +239,25 @@ defmodule MingaEditor.Commands.FileTree do
   Same positioning logic as `new_file/1`.
   """
   @spec new_folder(state()) :: state()
-  def new_folder(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+  def new_folder(state), do: start_new_entry_edit(state, :new_folder)
 
-  def new_folder(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    {index, tree} = editing_insertion_index(tree)
+  @spec start_new_entry_edit(state(), :new_file | :new_folder) :: state()
+  defp start_new_entry_edit(state, type) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: nil} ->
+        state
 
-    ft =
-      state.workspace.file_tree
-      |> FileTreeState.start_editing(index, :new_folder)
-      |> FileTreeState.replace_tree(tree)
+      %FileTreeState{tree: tree} ->
+        {index, tree} = editing_insertion_index(tree)
 
-    state = set_file_tree(state, ft)
-    sync_buffer(state)
+        ft =
+          file_tree_state(state)
+          |> FileTreeState.start_editing(index, type)
+          |> FileTreeState.replace_tree(tree)
+
+        state = set_file_tree(state, ft)
+        sync_buffer(state)
+    end
   end
 
   @doc """
@@ -281,23 +266,27 @@ defmodule MingaEditor.Commands.FileTree do
   Pre-fills the input with the current entry name.
   """
   @spec rename(state()) :: state()
-  def rename(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-
-  def rename(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    case FileTree.selected_entry(tree) do
-      nil ->
+  def rename(state) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: nil} ->
         state
 
-      entry ->
-        ft =
-          FileTreeState.start_editing(
-            state.workspace.file_tree,
-            tree.cursor,
-            :rename,
-            entry.name
-          )
+      %FileTreeState{tree: tree} ->
+        case FileTree.selected_entry(tree) do
+          nil ->
+            state
 
-        set_file_tree(state, ft)
+          entry ->
+            ft =
+              FileTreeState.start_editing(
+                file_tree_state(state),
+                tree.cursor,
+                :rename,
+                entry.name
+              )
+
+            set_file_tree(state, ft)
+        end
     end
   end
 
@@ -310,16 +299,18 @@ defmodule MingaEditor.Commands.FileTree do
   - `:rename` renames the file/directory and updates any open buffer.
   """
   @spec confirm_editing(state()) :: state()
-  def confirm_editing(%{workspace: %{file_tree: %{editing: nil}}} = state), do: state
-
-  def confirm_editing(%{workspace: %{file_tree: %{editing: %{text: text}}}} = state)
-      when text == "" do
-    cancel_editing(state)
+  def confirm_editing(state) do
+    case file_tree_state(state).editing do
+      nil -> state
+      %{text: ""} -> cancel_editing(state)
+      %{type: :new_file} = editing -> confirm_new_file(state, editing)
+      %{type: :new_folder} = editing -> confirm_new_folder(state, editing)
+      %{type: :rename} -> confirm_rename(state)
+    end
   end
 
-  def confirm_editing(
-        %{workspace: %{file_tree: %{editing: %{type: :new_file} = editing}}} = state
-      ) do
+  @spec confirm_new_file(state(), map()) :: state()
+  defp confirm_new_file(state, editing) do
     parent_dir = editing_parent_dir(state)
     full_path = Path.join(parent_dir, editing.text)
 
@@ -330,7 +321,7 @@ defmodule MingaEditor.Commands.FileTree do
 
     case Commands.start_buffer(full_path, EditorState.options_server(state)) do
       {:ok, pid} ->
-        BufferRegistry.do_file_tree_open(state, pid, full_path, state.workspace.file_tree.tree)
+        BufferRegistry.do_file_tree_open(state, pid, full_path, file_tree_state(state).tree)
 
       {:error, reason} ->
         MingaEditor.log_to_messages("[file-tree] Failed to open #{full_path}: #{inspect(reason)}")
@@ -339,9 +330,8 @@ defmodule MingaEditor.Commands.FileTree do
     end
   end
 
-  def confirm_editing(
-        %{workspace: %{file_tree: %{editing: %{type: :new_folder} = editing}}} = state
-      ) do
+  @spec confirm_new_folder(state(), map()) :: state()
+  defp confirm_new_folder(state, editing) do
     parent_dir = editing_parent_dir(state)
     full_path = Path.join(parent_dir, editing.text)
 
@@ -357,12 +347,17 @@ defmodule MingaEditor.Commands.FileTree do
     end
   end
 
-  def confirm_editing(
-        %{workspace: %{file_tree: %{editing: %{type: :rename} = _editing, tree: tree}}} = state
-      ) do
-    case FileTree.selected_entry(tree) do
-      nil -> cancel_editing(state)
-      entry -> do_rename(state, entry, state.workspace.file_tree.editing.text)
+  @spec confirm_rename(state()) :: state()
+  defp confirm_rename(state) do
+    case file_tree_state(state).tree do
+      %FileTree{} = tree ->
+        case FileTree.selected_entry(tree) do
+          nil -> cancel_editing(state)
+          entry -> do_rename(state, entry, file_tree_state(state).editing.text)
+        end
+
+      nil ->
+        cancel_editing(state)
     end
   end
 
@@ -373,61 +368,59 @@ defmodule MingaEditor.Commands.FileTree do
   For directories, includes a child count in the prompt.
   """
   @spec delete(state()) :: state()
-  def delete(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-
-  def delete(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    case FileTree.selected_entry(tree) do
-      nil ->
-        state
-
-      entry ->
-        child_count = if entry.dir?, do: count_children(entry.path), else: 0
-        ms = DeleteConfirmState.new(entry.path, entry.name, entry.dir?, child_count)
-        EditorState.transition_mode(state, :delete_confirm, ms)
+  def delete(state) do
+    with %FileTreeState{tree: %FileTree{} = tree} <- file_tree_state(state),
+         %{} = entry <- FileTree.selected_entry(tree) do
+      child_count = if entry.dir?, do: count_children(entry.path), else: 0
+      ms = DeleteConfirmState.new(entry.path, entry.name, entry.dir?, child_count)
+      EditorState.transition_mode(state, :delete_confirm, ms)
+    else
+      _ -> state
     end
   end
 
   @doc "Duplicates the selected file or directory with a \" copy\" suffix."
   @spec duplicate(state()) :: state()
-  def duplicate(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+  def duplicate(state) do
+    with %FileTreeState{tree: %FileTree{} = tree} <- file_tree_state(state),
+         %{} = entry <- FileTree.selected_entry(tree) do
+      dest = unique_copy_path(entry.path)
 
-  def duplicate(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    case FileTree.selected_entry(tree) do
-      nil ->
+      result =
+        if entry.dir?,
+          do: File.cp_r(entry.path, dest),
+          else: File.cp(entry.path, dest)
+
+      handle_duplicate_result(state, entry, dest, result)
+    else
+      _ -> state
+    end
+  end
+
+  @spec handle_duplicate_result(state(), map(), String.t(), term()) :: state()
+  defp handle_duplicate_result(state, entry, dest, result) do
+    case result do
+      :ok ->
+        log_duplicate_success(entry, dest)
+        refresh(state)
+
+      {:ok, _} ->
+        log_duplicate_success(entry, dest)
+        refresh(state)
+
+      {:error, reason, _} ->
+        MingaEditor.log_to_messages("[file-tree] Duplicate failed: #{inspect(reason)}")
         state
 
-      entry ->
-        dest = unique_copy_path(entry.path)
-
-        result =
-          if entry.dir?,
-            do: File.cp_r(entry.path, dest),
-            else: File.cp(entry.path, dest)
-
-        case result do
-          :ok ->
-            MingaEditor.log_to_messages(
-              "[file-tree] Duplicated: #{entry.name} → #{Path.basename(dest)}"
-            )
-
-            refresh(state)
-
-          {:ok, _} ->
-            MingaEditor.log_to_messages(
-              "[file-tree] Duplicated: #{entry.name} → #{Path.basename(dest)}"
-            )
-
-            refresh(state)
-
-          {:error, reason, _} ->
-            MingaEditor.log_to_messages("[file-tree] Duplicate failed: #{inspect(reason)}")
-            state
-
-          {:error, reason} ->
-            MingaEditor.log_to_messages("[file-tree] Duplicate failed: #{inspect(reason)}")
-            state
-        end
+      {:error, reason} ->
+        MingaEditor.log_to_messages("[file-tree] Duplicate failed: #{inspect(reason)}")
+        state
     end
+  end
+
+  @spec log_duplicate_success(map(), String.t()) :: :ok
+  defp log_duplicate_success(entry, dest) do
+    MingaEditor.log_to_messages("[file-tree] Duplicated: #{entry.name} → #{Path.basename(dest)}")
   end
 
   @doc """
@@ -436,9 +429,18 @@ defmodule MingaEditor.Commands.FileTree do
   If the target is not a directory, uses its parent directory.
   """
   @spec move(state(), non_neg_integer(), non_neg_integer()) :: state()
-  def move(%{workspace: %{file_tree: %{tree: nil}}} = state, _source, _target), do: state
+  def move(state, source_index, target_dir_index) do
+    case file_tree_state(state).tree do
+      nil -> move_without_tree(state)
+      tree -> move_with_tree(state, tree, source_index, target_dir_index)
+    end
+  end
 
-  def move(%{workspace: %{file_tree: %{tree: tree}}} = state, source_index, target_dir_index) do
+  @spec move_without_tree(state()) :: state()
+  defp move_without_tree(state), do: state
+
+  @spec move_with_tree(state(), FileTree.t(), non_neg_integer(), non_neg_integer()) :: state()
+  defp move_with_tree(state, tree, source_index, target_dir_index) do
     entries = FileTree.visible_entries(tree)
     source = Enum.at(entries, source_index)
     target = Enum.at(entries, target_dir_index)
@@ -465,12 +467,19 @@ defmodule MingaEditor.Commands.FileTree do
   @doc "Handles a native GUI file-tree drop intent with BEAM-owned filesystem operations."
   @spec drop(state(), DropIntent.t()) :: state()
 
-  def drop(%{workspace: %{file_tree: %{tree: nil}}} = state, %DropIntent{}) do
-    MingaEditor.log_to_messages("[file-tree] Drop rejected: file tree is unavailable")
-    state
+  def drop(state, %DropIntent{} = intent) do
+    case file_tree_state(state).tree do
+      nil ->
+        MingaEditor.log_to_messages("[file-tree] Drop rejected: file tree is unavailable")
+        state
+
+      tree ->
+        drop_with_tree(state, tree, intent)
+    end
   end
 
-  def drop(%{workspace: %{file_tree: %{tree: tree}}} = state, %DropIntent{} = intent) do
+  @spec drop_with_tree(state(), FileTree.t(), DropIntent.t()) :: state()
+  defp drop_with_tree(state, tree, %DropIntent{} = intent) do
     entries = FileTree.visible_entries(tree)
 
     case drop_target_dir(entries, intent) do
@@ -488,11 +497,11 @@ defmodule MingaEditor.Commands.FileTree do
 
   @doc "Cancels the current inline edit without making changes."
   @spec cancel_editing(state()) :: state()
-  def cancel_editing(%{workspace: %{file_tree: %{editing: nil}}} = state), do: state
-
   def cancel_editing(state) do
-    ft = FileTreeState.cancel_editing(state.workspace.file_tree)
-    set_file_tree(state, ft)
+    case file_tree_state(state).editing do
+      nil -> state
+      _editing -> set_file_tree(state, FileTreeState.cancel_editing(file_tree_state(state)))
+    end
   end
 
   @doc """
@@ -513,7 +522,7 @@ defmodule MingaEditor.Commands.FileTree do
 
       path ->
         state = ensure_tree_open(state)
-        tree = FileTree.reveal(state.workspace.file_tree.tree, path)
+        tree = FileTree.reveal(file_tree_state(state).tree, path)
         state = sync_and_update(state, tree)
         state = update_file_tree(state, &FileTreeState.focus/1)
 
@@ -534,18 +543,12 @@ defmodule MingaEditor.Commands.FileTree do
   end
 
   @spec close(state()) :: state()
-  def close(%{workspace: %{file_tree: %{buffer: buf}}} = state) when is_pid(buf) do
-    GenServer.stop(buf, :normal)
-
-    scope = restore_scope(state)
-
-    state
-    |> EditorState.update_file_tree(&FileTreeState.close/1)
-    |> EditorState.set_keymap_scope(scope)
-    |> EditorState.set_sidebar_active_id(nil)
-  end
-
   def close(state) do
+    case file_tree_state(state).buffer do
+      buf when is_pid(buf) -> GenServer.stop(buf, :normal)
+      _ -> :ok
+    end
+
     scope = restore_scope(state)
 
     state
@@ -557,12 +560,12 @@ defmodule MingaEditor.Commands.FileTree do
   # ── Private helpers ───────────────────────────────────────────────────────
 
   @spec mark_for_paste(state(), FileTreeState.clipboard_operation()) :: state()
-  defp mark_for_paste(%{workspace: %{file_tree: %{tree: nil}}} = state, _operation), do: state
-
-  defp mark_for_paste(%{workspace: %{file_tree: %{tree: tree}}} = state, operation) do
-    case FileTree.selected_entry(tree) do
-      nil -> state
-      entry -> store_clipboard_mark(state, entry, operation)
+  defp mark_for_paste(state, operation) do
+    with %FileTreeState{tree: %FileTree{} = tree} <- file_tree_state(state),
+         %{} = entry <- FileTree.selected_entry(tree) do
+      store_clipboard_mark(state, entry, operation)
+    else
+      _ -> state
     end
   end
 
@@ -752,16 +755,22 @@ defmodule MingaEditor.Commands.FileTree do
   end
 
   @spec reroot(state(), String.t()) :: state()
-  defp reroot(%{workspace: %{file_tree: %{tree: %FileTree{} = tree}}} = state, root) do
-    FileTreeFreshness.unwatch_expanded_dirs(tree)
+  defp reroot(state, root) do
+    case file_tree_state(state).tree do
+      %FileTree{} = tree ->
+        FileTreeFreshness.unwatch_expanded_dirs(tree)
 
-    new_tree =
-      tree
-      |> FileTree.reroot(root)
-      |> FileTree.refresh_git_status()
+        new_tree =
+          tree
+          |> FileTree.reroot(root)
+          |> FileTree.refresh_git_status()
 
-    FileTreeFreshness.watch_expanded_dirs(new_tree)
-    sync_and_update(state, new_tree)
+        FileTreeFreshness.watch_expanded_dirs(new_tree)
+        sync_and_update(state, new_tree)
+
+      nil ->
+        state
+    end
   end
 
   # Mutual exclusivity: close git status panel when opening file tree.
@@ -810,14 +819,18 @@ defmodule MingaEditor.Commands.FileTree do
   # Opens the tree if not already open. Used by reveal_active_file to
   # ensure the tree exists before calling FileTree.reveal.
   @spec ensure_tree_open(state()) :: state()
-  defp ensure_tree_open(%{workspace: %{file_tree: %{tree: %FileTree{}}}} = state), do: state
-  defp ensure_tree_open(state), do: open(state)
+  defp ensure_tree_open(state) do
+    case file_tree_state(state).tree do
+      %FileTree{} -> state
+      nil -> open(state)
+    end
+  end
 
   @spec open(state()) :: state()
   defp open(state) do
     state = close_git_status_if_open(state)
 
-    root = state.workspace.file_tree.project_root || Minga.Project.root() || File.cwd!()
+    root = file_tree_state(state).project_root || Minga.Project.root() || File.cwd!()
     tree = FileTree.new(root)
     tree = FileTree.refresh_git_status(tree)
     tree = reveal_active(tree, state.workspace.buffers.active)
@@ -843,16 +856,13 @@ defmodule MingaEditor.Commands.FileTree do
   end
 
   @spec sync_and_update(state(), FileTree.t()) :: state()
-  defp sync_and_update(%{workspace: %{file_tree: %{buffer: buf}}} = state, new_tree)
-       when is_pid(buf) do
-    FileTreeFreshness.watch_expanded_dirs(new_tree)
-    BufferSync.sync(buf, new_tree)
-
-    update_file_tree(state, &FileTreeState.set_tree(&1, new_tree))
-  end
-
   defp sync_and_update(state, new_tree) do
     FileTreeFreshness.watch_expanded_dirs(new_tree)
+
+    case file_tree_state(state).buffer do
+      buf when is_pid(buf) -> BufferSync.sync(buf, new_tree)
+      _ -> :ok
+    end
 
     update_file_tree(state, &FileTreeState.set_tree(&1, new_tree))
   end
@@ -882,7 +892,8 @@ defmodule MingaEditor.Commands.FileTree do
 
   # Determines the parent directory path for the current editing operation.
   @spec editing_parent_dir(state()) :: String.t()
-  defp editing_parent_dir(%{workspace: %{file_tree: %{editing: editing, tree: tree}}}) do
+  defp editing_parent_dir(state) do
+    %{editing: editing, tree: tree} = file_tree_state(state)
     entries = FileTree.visible_entries(tree)
 
     case editing.type do
@@ -1134,20 +1145,21 @@ defmodule MingaEditor.Commands.FileTree do
 
   @spec clear_editing_and_refresh(state()) :: state()
   defp clear_editing_and_refresh(state) do
-    ft = FileTreeState.cancel_editing(state.workspace.file_tree)
+    ft = FileTreeState.cancel_editing(file_tree_state(state))
     state = set_file_tree(state, ft)
     refresh(state)
   end
 
   # Syncs the buffer after editing state changes.
   @spec sync_buffer(state()) :: state()
-  defp sync_buffer(%{workspace: %{file_tree: %{buffer: buf, tree: tree}}} = state)
-       when is_pid(buf) do
-    BufferSync.sync(buf, tree)
+  defp sync_buffer(state) do
+    case file_tree_state(state) do
+      %FileTreeState{buffer: buf, tree: tree} when is_pid(buf) -> BufferSync.sync(buf, tree)
+      %FileTreeState{} -> :ok
+    end
+
     state
   end
-
-  defp sync_buffer(state), do: state
 
   @spec do_rename(state(), FileTree.entry(), String.t()) :: state()
   defp do_rename(state, entry, new_name) do

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -485,8 +485,13 @@ defmodule MingaEditor.Commands.Git do
 
   # Mutual exclusivity: close file tree when opening git status.
   @spec close_file_tree_if_open(state()) :: state()
-  defp close_file_tree_if_open(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
-  defp close_file_tree_if_open(state), do: Commands.FileTree.close(state)
+  defp close_file_tree_if_open(state) do
+    if EditorState.file_tree_state(state).tree == nil do
+      state
+    else
+      Commands.FileTree.close(state)
+    end
+  end
 
   @doc """
   Opens a diff view for a file specified by path.

--- a/lib/minga_editor/commands/inline_ask.ex
+++ b/lib/minga_editor/commands/inline_ask.ex
@@ -209,13 +209,10 @@ defmodule MingaEditor.Commands.InlineAsk do
   end
 
   @spec project_root(state()) :: String.t()
-  defp project_root(%{workspace: %{file_tree: %{project_root: root}}}) when is_binary(root),
-    do: root
-
-  defp project_root(%{workspace: %{file_tree: %{original_root: root}}}) when is_binary(root),
-    do: root
-
-  defp project_root(_state), do: File.cwd!()
+  defp project_root(state) do
+    file_tree = EditorState.file_tree_state(state)
+    file_tree.project_root || file_tree.original_root || File.cwd!()
+  end
 
   @spec anchor_line(state(), non_neg_integer()) :: non_neg_integer()
   defp anchor_line(state, fallback_line) do

--- a/lib/minga_editor/commands/inline_edit.ex
+++ b/lib/minga_editor/commands/inline_edit.ex
@@ -126,13 +126,10 @@ defmodule MingaEditor.Commands.InlineEdit do
   end
 
   @spec project_root(state()) :: String.t()
-  defp project_root(%{workspace: %{file_tree: %{project_root: root}}}) when is_binary(root),
-    do: root
-
-  defp project_root(%{workspace: %{file_tree: %{original_root: root}}}) when is_binary(root),
-    do: root
-
-  defp project_root(_state), do: File.cwd!()
+  defp project_root(state) do
+    file_tree = EditorState.file_tree_state(state)
+    file_tree.project_root || file_tree.original_root || File.cwd!()
+  end
 
   @spec replacement_text(pid(), non_neg_integer(), String.t()) :: String.t()
   defp replacement_text(_buffer_pid, _last, ""), do: ""

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -558,13 +558,22 @@ defmodule MingaEditor.Commands.Movement do
 
   # When file tree is focused, navigating right unfocuses the tree
   # and restores the scope based on the active window's content type.
-  defp navigate_window(%{workspace: %{file_tree: %{focused: true}}} = state, :right) do
-    state = update_file_tree(state, &FileTreeState.unfocus/1)
-    scope = EditorState.scope_for_active_window(state)
-    EditorState.set_keymap_scope(state, scope)
+  defp navigate_window(state, :right) do
+    if EditorState.file_tree_state(state).focused do
+      state = update_file_tree(state, &FileTreeState.unfocus/1)
+      scope = EditorState.scope_for_active_window(state)
+      EditorState.set_keymap_scope(state, scope)
+    else
+      navigate_window_to_neighbor(state, :right)
+    end
   end
 
   defp navigate_window(state, direction) do
+    navigate_window_to_neighbor(state, direction)
+  end
+
+  @spec navigate_window_to_neighbor(state(), WindowTree.nav_direction()) :: state()
+  defp navigate_window_to_neighbor(state, direction) do
     screen = Layout.get(state).editor_area
 
     case WindowTree.focus_neighbor(
@@ -583,12 +592,13 @@ defmodule MingaEditor.Commands.Movement do
   end
 
   @spec maybe_focus_file_tree(state(), :left | :right | :up | :down) :: state()
-  defp maybe_focus_file_tree(
-         %{workspace: %{file_tree: %{tree: %Minga.Project.FileTree{}}}} = state,
-         :left
-       ) do
-    state = update_file_tree(state, &FileTreeState.focus/1)
-    EditorState.set_keymap_scope(state, :file_tree)
+  defp maybe_focus_file_tree(state, :left) do
+    if match?(%Minga.Project.FileTree{}, EditorState.file_tree_state(state).tree) do
+      state = update_file_tree(state, &FileTreeState.focus/1)
+      EditorState.set_keymap_scope(state, :file_tree)
+    else
+      state
+    end
   end
 
   defp maybe_focus_file_tree(state, _direction), do: state

--- a/lib/minga_editor/commands/workspace.ex
+++ b/lib/minga_editor/commands/workspace.ex
@@ -238,10 +238,9 @@ defmodule MingaEditor.Commands.Workspace do
     do: EditorState.set_status(state, "No workspace tab bar")
 
   @spec active_file_ref(state(), TabBar.t()) :: {:ok, FileRef.t()} | {:error, String.t()}
-  defp active_file_ref(
-         %{workspace: %{buffers: %{active: active}, file_tree: file_tree}},
-         %TabBar{} = tb
-       ) do
+  defp active_file_ref(%{workspace: %{buffers: %{active: active}}} = state, %TabBar{} = tb) do
+    file_tree = EditorState.file_tree_state(state)
+
     case TabBar.active(tb) do
       %{kind: :file, file_ref: %FileRef{} = file_ref} -> {:ok, file_ref}
       %{kind: :file} -> active_buffer_file_ref(active, file_tree.project_root)

--- a/lib/minga_editor/file_tree/feature.ex
+++ b/lib/minga_editor/file_tree/feature.ex
@@ -1,0 +1,61 @@
+defmodule MingaEditor.FileTree.Feature do
+  @moduledoc """
+  FileTree feature ownership adapter.
+
+  FileTree is still implemented in core, but its UI state, input handler, and sidebar contribution are registered through the same source-owned paths that a bundled extension will use after extraction.
+  """
+
+  alias MingaEditor.Extension.Sidebar
+  alias MingaEditor.Input
+  alias MingaEditor.Input.FileTreeHandler
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  @source :builtin
+  @input_source {:extension, :file_tree}
+  @feature_id :file_tree
+  @sidebar_id "file_tree"
+
+  @doc "Contribution source used while FileTree remains a bundled core feature."
+  @spec source() :: :builtin
+  def source, do: @source
+
+  @doc "Contribution source used for FileTree's dynamically registered input handler."
+  @spec input_source() :: {:extension, :file_tree}
+  def input_source, do: @input_source
+
+  @doc "Feature-state id used for FileTree UI state."
+  @spec feature_id() :: :file_tree
+  def feature_id, do: @feature_id
+
+  @doc "Stable sidebar id for FileTree."
+  @spec sidebar_id() :: String.t()
+  def sidebar_id, do: @sidebar_id
+
+  @doc "Registers FileTree's dynamic input handler and sidebar contribution."
+  @spec register_contributions(FileTreeState.t()) :: :ok
+  def register_contributions(%FileTreeState{} = file_tree \\ %FileTreeState{}) do
+    :ok = Input.register_handler(@input_source, FileTreeHandler, priority: 50)
+    sync_sidebar(file_tree)
+  end
+
+  @doc "Synchronizes the global sidebar contribution from the current FileTree state."
+  @spec sync_sidebar(FileTreeState.t()) :: :ok
+  def sync_sidebar(%FileTreeState{} = file_tree) do
+    status = FileTreeState.status(file_tree)
+
+    Sidebar.register(@source, %{
+      id: @sidebar_id,
+      display_name: "File Tree",
+      description: "Project files",
+      placement: :left,
+      priority: 10,
+      preferred_width: FileTreeState.width(file_tree),
+      visible?: FileTreeState.visible_status?(status),
+      focused?: FileTreeState.focused?(file_tree),
+      semantic_kind: "file_tree",
+      icon: "folder",
+      input_handler: FileTreeHandler,
+      action_handler: {MingaEditor.Commands.FileTree, :handle_sidebar_action}
+    })
+  end
+end

--- a/lib/minga_editor/file_tree/feature.ex
+++ b/lib/minga_editor/file_tree/feature.ex
@@ -11,7 +11,7 @@ defmodule MingaEditor.FileTree.Feature do
   alias MingaEditor.State.FileTree, as: FileTreeState
 
   @source :builtin
-  @input_source {:extension, :file_tree}
+  @input_source :builtin
   @feature_id :file_tree
   @sidebar_id "file_tree"
 
@@ -20,7 +20,7 @@ defmodule MingaEditor.FileTree.Feature do
   def source, do: @source
 
   @doc "Contribution source used for FileTree's dynamically registered input handler."
-  @spec input_source() :: {:extension, :file_tree}
+  @spec input_source() :: :builtin
   def input_source, do: @input_source
 
   @doc "Feature-state id used for FileTree UI state."
@@ -32,14 +32,14 @@ defmodule MingaEditor.FileTree.Feature do
   def sidebar_id, do: @sidebar_id
 
   @doc "Registers FileTree's dynamic input handler and sidebar contribution."
-  @spec register_contributions(FileTreeState.t()) :: :ok
+  @spec register_contributions(FileTreeState.t()) :: :ok | {:error, term()}
   def register_contributions(%FileTreeState{} = file_tree \\ %FileTreeState{}) do
     :ok = Input.register_handler(@input_source, FileTreeHandler, priority: 50)
     sync_sidebar(file_tree)
   end
 
   @doc "Synchronizes the global sidebar contribution from the current FileTree state."
-  @spec sync_sidebar(FileTreeState.t()) :: :ok
+  @spec sync_sidebar(FileTreeState.t()) :: :ok | {:error, term()}
   def sync_sidebar(%FileTreeState{} = file_tree) do
     status = FileTreeState.status(file_tree)
 

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -222,5 +222,6 @@ defmodule MingaEditor.FileTree.Freshness do
   end
 
   @spec path_under_root?(String.t(), String.t()) :: boolean()
+  defp path_under_root?(path, "/"), do: String.starts_with?(path, "/")
   defp path_under_root?(path, root), do: path == root or String.starts_with?(path, root <> "/")
 end

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -17,24 +17,23 @@ defmodule MingaEditor.FileTree.Freshness do
 
   @doc "Returns true when the file tree is open."
   @spec open?(state()) :: boolean()
-  def open?(%{workspace: %{file_tree: %FileTreeState{tree: %FileTree{}}}}), do: true
-  def open?(_state), do: false
+  def open?(state), do: match?(%FileTreeState{tree: %FileTree{}}, file_tree_state(state))
 
   @doc "Returns true when the path is under the current tree root."
   @spec path_under_tree?(state(), String.t() | nil) :: boolean()
   def path_under_tree?(_state, nil), do: false
 
-  def path_under_tree?(
-        %{workspace: %{file_tree: %FileTreeState{tree: %FileTree{root: root}}}},
-        path
-      )
-      when is_binary(path) do
-    path_under_root?(Path.expand(path), Path.expand(root))
-  end
+  def path_under_tree?(state, path) when is_binary(path) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: %FileTree{root: root}} ->
+        path_under_root?(Path.expand(path), Path.expand(root))
 
-  def path_under_tree?(%{workspace: %{file_tree: %FileTreeState{project_root: root}}}, path)
-      when is_binary(root) and is_binary(path) do
-    path_under_root?(Path.expand(path), Path.expand(root))
+      %FileTreeState{project_root: root} when is_binary(root) ->
+        path_under_root?(Path.expand(path), Path.expand(root))
+
+      %FileTreeState{} ->
+        false
+    end
   end
 
   def path_under_tree?(_state, _path), do: false
@@ -57,82 +56,80 @@ defmodule MingaEditor.FileTree.Freshness do
 
   @doc "Marks a debounced filesystem refresh as scheduled."
   @spec schedule_refresh(state(), reference()) :: state()
-  def schedule_refresh(%{workspace: %{file_tree: %FileTreeState{} = file_tree}} = state, ref)
-      when is_reference(ref) do
-    set_file_tree(state, FileTreeState.schedule_refresh(file_tree, ref))
+  def schedule_refresh(state, ref) when is_reference(ref) do
+    set_file_tree(state, FileTreeState.schedule_refresh(file_tree_state(state), ref))
   end
 
   @doc "Returns true when a filesystem refresh timer is already pending."
   @spec refresh_scheduled?(state()) :: boolean()
-  def refresh_scheduled?(%{workspace: %{file_tree: %FileTreeState{} = file_tree}}) do
-    FileTreeState.refresh_scheduled?(file_tree)
+  def refresh_scheduled?(state) do
+    state
+    |> file_tree_state()
+    |> FileTreeState.refresh_scheduled?()
   end
-
-  def refresh_scheduled?(_state), do: false
 
   @doc "Refreshes cached filesystem entries after the debounce timer fires."
   @spec flush_refresh(state()) :: state()
-  def flush_refresh(%{workspace: %{file_tree: %FileTreeState{tree: nil} = file_tree}} = state) do
-    set_file_tree(state, FileTreeState.clear_refresh(file_tree))
+  def flush_refresh(state) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: nil} = file_tree ->
+        set_file_tree(state, FileTreeState.clear_refresh(file_tree))
+
+      %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
+        refreshed_tree = tree |> FileTree.refresh() |> FileTree.refresh_git_status()
+        watch_expanded_dirs(refreshed_tree)
+
+        file_tree =
+          file_tree
+          |> FileTreeState.clear_refresh()
+          |> FileTreeState.replace_tree(refreshed_tree)
+
+        state
+        |> set_file_tree(file_tree)
+        |> sync_buffer(refreshed_tree)
+    end
   end
-
-  def flush_refresh(
-        %{workspace: %{file_tree: %FileTreeState{tree: %FileTree{} = tree} = file_tree}} = state
-      ) do
-    refreshed_tree = tree |> FileTree.refresh() |> FileTree.refresh_git_status()
-    watch_expanded_dirs(refreshed_tree)
-
-    file_tree =
-      file_tree
-      |> FileTreeState.clear_refresh()
-      |> FileTreeState.replace_tree(refreshed_tree)
-
-    state
-    |> set_file_tree(file_tree)
-    |> sync_buffer(refreshed_tree)
-  end
-
-  def flush_refresh(state), do: state
 
   @doc "Updates tree git badges from an already-fetched git status event."
   @spec refresh_git_status(state(), Minga.Events.GitStatusEvent.t()) :: state()
-  def refresh_git_status(%{workspace: %{file_tree: %FileTreeState{tree: nil}}} = state, _event),
-    do: state
+  def refresh_git_status(state, %Minga.Events.GitStatusEvent{git_root: git_root, entries: entries}) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: nil} ->
+        state
 
-  def refresh_git_status(
-        %{workspace: %{file_tree: %FileTreeState{tree: %FileTree{} = tree} = file_tree}} = state,
-        %Minga.Events.GitStatusEvent{git_root: git_root, entries: entries}
-      ) do
-    status = GitStatus.from_entries(entries, git_root, tree.root)
-    updated_tree = FileTree.replace_git_status(tree, status)
-    file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
+      %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
+        status = GitStatus.from_entries(entries, git_root, tree.root)
+        updated_tree = FileTree.replace_git_status(tree, status)
+        file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
 
-    state
-    |> set_file_tree(file_tree)
-    |> sync_buffer(updated_tree)
+        state
+        |> set_file_tree(file_tree)
+        |> sync_buffer(updated_tree)
+    end
   end
 
   @doc "Refreshes tree git badges by querying the current git backend."
   @spec refresh_git_status_from_disk(state()) :: state()
-  def refresh_git_status_from_disk(%{workspace: %{file_tree: %FileTreeState{tree: nil}}} = state),
-    do: state
+  def refresh_git_status_from_disk(state) do
+    case file_tree_state(state) do
+      %FileTreeState{tree: nil} ->
+        state
 
-  def refresh_git_status_from_disk(
-        %{workspace: %{file_tree: %FileTreeState{tree: %FileTree{} = tree} = file_tree}} = state
-      ) do
-    updated_tree = FileTree.refresh_git_status(tree)
-    file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
+      %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
+        updated_tree = FileTree.refresh_git_status(tree)
+        file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
 
-    state
-    |> set_file_tree(file_tree)
-    |> sync_buffer(updated_tree)
+        state
+        |> set_file_tree(file_tree)
+        |> sync_buffer(updated_tree)
+    end
   end
 
   @doc "Updates the remembered project root and replaces visible stale tree entries when the project changes."
   @spec update_project_root(state(), String.t()) :: state()
-  def update_project_root(%{workspace: %{file_tree: %FileTreeState{} = file_tree}} = state, root)
-      when is_binary(root) do
+  def update_project_root(state, root) when is_binary(root) do
     expanded_root = Path.expand(root)
+    file_tree = file_tree_state(state)
 
     case file_tree.tree do
       %FileTree{root: ^expanded_root} ->
@@ -175,10 +172,15 @@ defmodule MingaEditor.FileTree.Freshness do
   end
 
   @spec sync_buffer(state(), FileTree.t()) :: state()
-  defp sync_buffer(%{workspace: %{file_tree: %FileTreeState{buffer: buffer}}} = state, tree)
-       when is_pid(buffer) do
-    BufferSync.sync(buffer, tree)
-    state
+  defp sync_buffer(state, tree) do
+    case file_tree_state(state).buffer do
+      buffer when is_pid(buffer) ->
+        BufferSync.sync(buffer, tree)
+        state
+
+      _ ->
+        state
+    end
   catch
     :exit, reason ->
       Minga.Log.warning(
@@ -189,7 +191,8 @@ defmodule MingaEditor.FileTree.Freshness do
       state
   end
 
-  defp sync_buffer(state, _tree), do: state
+  @spec file_tree_state(state()) :: FileTreeState.t()
+  defp file_tree_state(state), do: EditorState.file_tree_state(state)
 
   @spec set_file_tree(state(), FileTreeState.t()) :: state()
   defp set_file_tree(%EditorState{} = state, %FileTreeState{} = file_tree) do
@@ -219,11 +222,5 @@ defmodule MingaEditor.FileTree.Freshness do
   end
 
   @spec path_under_root?(String.t(), String.t()) :: boolean()
-  defp path_under_root?(path, root) do
-    path == root or String.starts_with?(path, path_prefix(root))
-  end
-
-  @spec path_prefix(String.t()) :: String.t()
-  defp path_prefix("/"), do: "/"
-  defp path_prefix(root), do: root <> "/"
+  defp path_under_root?(path, root), do: path == root or String.starts_with?(path, root <> "/")
 end

--- a/lib/minga_editor/file_tree/rows.ex
+++ b/lib/minga_editor/file_tree/rows.ex
@@ -50,20 +50,22 @@ defmodule MingaEditor.FileTree.Rows do
 
   @doc "Builds semantic rows from editor state when the file tree is open."
   @spec from_state(EditorState.t() | map()) :: [Row.t()]
-  def from_state(%{workspace: %{file_tree: %{tree: nil}}}), do: []
+  def from_state(state) do
+    case EditorState.file_tree_state(state) do
+      %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
+        from_tree(tree,
+          active_path: active_buffer_path(state),
+          dirty_paths: dirty_paths(state),
+          editing: file_tree.editing,
+          focused: file_tree.focused,
+          git_status: tree.git_status,
+          selected_index: tree.cursor
+        )
 
-  def from_state(%{workspace: %{file_tree: %{tree: %FileTree{} = tree} = file_tree}} = state) do
-    from_tree(tree,
-      active_path: active_buffer_path(state),
-      dirty_paths: dirty_paths(state),
-      editing: Map.get(file_tree, :editing),
-      focused: Map.get(file_tree, :focused, false),
-      git_status: tree.git_status,
-      selected_index: tree.cursor
-    )
+      %FileTreeState{} ->
+        []
+    end
   end
-
-  def from_state(_state), do: []
 
   @spec row_context(FileTree.t(), options()) :: map()
   defp row_context(%FileTree{} = tree, opts) do

--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -15,6 +15,7 @@ defmodule MingaEditor.FocusTree do
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Layout
   alias MingaEditor.Renderer.Gutter
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.UI.Picker, as: PickerData
   alias MingaEditor.Viewport
@@ -37,7 +38,7 @@ defmodule MingaEditor.FocusTree do
     layout = Layout.get(state)
 
     layout
-    |> build_base(window_map(state), Input.editing_dispatch_handler(state))
+    |> build_base(window_map(state), Input.editing_dispatch_handler(state), state)
     |> add_modal_overlays(state, layout)
     |> link_tree()
   end
@@ -46,7 +47,7 @@ defmodule MingaEditor.FocusTree do
   @spec from_layout(Layout.t()) :: t()
   def from_layout(%Layout{} = layout) do
     layout
-    |> build_base(%{}, Input.ModeFSM)
+    |> build_base(%{}, Input.ModeFSM, nil)
     |> link_tree()
   end
 
@@ -152,15 +153,15 @@ defmodule MingaEditor.FocusTree do
   defp window_map(%{workspace: %{windows: %{map: map}}}) when is_map(map), do: map
   defp window_map(_state), do: %{}
 
-  @spec build_base(Layout.t(), map(), module()) :: t()
-  defp build_base(%Layout{} = layout, window_map, bottom_handler) do
+  @spec build_base(Layout.t(), map(), module(), map() | nil) :: t()
+  defp build_base(%Layout{} = layout, window_map, bottom_handler, state) do
     {tr, tc, tw, th} = layout.terminal
 
     children =
       []
       |> maybe_add(layout.tab_bar, &TreeNode.new(:tab_bar, &1, handler: bottom_handler))
       |> Kernel.++([editor_area_node(layout, window_map, bottom_handler)])
-      |> maybe_add(layout.file_tree, &file_tree_node/1)
+      |> maybe_add(layout.file_tree, &file_tree_node(&1, state))
       |> maybe_add(layout.agent_panel, &agent_panel_node/1)
       |> maybe_add(layout.status_bar, &TreeNode.new(:status_bar, &1, handler: bottom_handler))
       |> Kernel.++([TreeNode.new(:minibuffer, layout.minibuffer, handler: bottom_handler)])
@@ -176,9 +177,18 @@ defmodule MingaEditor.FocusTree do
     }
   end
 
-  @spec file_tree_node(Layout.rect()) :: TreeNode.t()
-  defp file_tree_node(rect) do
-    case Sidebar.active_left() do
+  @spec file_tree_node(Layout.rect(), map() | nil) :: TreeNode.t()
+  defp file_tree_node(rect, state) do
+    case active_left_sidebar(state) do
+      %{id: "file_tree", input_handler: handler} ->
+        TreeNode.new(:file_tree, rect,
+          id: {:sidebar, "file_tree"},
+          ref: "file_tree",
+          handler: handler || Input.FileTreeHandler,
+          scrollable?: true,
+          focusable?: true
+        )
+
       %{id: id, input_handler: handler} ->
         TreeNode.new({:custom, :sidebar}, rect,
           id: {:sidebar, id},
@@ -196,6 +206,30 @@ defmodule MingaEditor.FocusTree do
         )
     end
   end
+
+  @spec active_left_sidebar(map() | nil) :: Sidebar.entry() | nil
+  defp active_left_sidebar(nil) do
+    Sidebar.visible()
+    |> Enum.reject(&(&1.id == "file_tree"))
+    |> Enum.filter(&(&1.placement == :left))
+    |> Enum.sort_by(&{not &1.focused?, &1.priority, &1.id})
+    |> List.first()
+  end
+
+  defp active_left_sidebar(state) do
+    Sidebar.visible()
+    |> Enum.filter(&(&1.placement == :left))
+    |> Enum.reject(&stale_file_tree_sidebar?(state, &1))
+    |> Enum.sort_by(&{not &1.focused?, &1.priority, &1.id})
+    |> List.first()
+  end
+
+  @spec stale_file_tree_sidebar?(map(), Sidebar.entry()) :: boolean()
+  defp stale_file_tree_sidebar?(state, %{id: "file_tree"}) do
+    EditorState.file_tree_state(state).tree == nil
+  end
+
+  defp stale_file_tree_sidebar?(_state, _sidebar), do: false
 
   @spec agent_panel_node(Layout.rect()) :: TreeNode.t()
   defp agent_panel_node(rect) do

--- a/lib/minga_editor/frontend/emit/context.ex
+++ b/lib/minga_editor/frontend/emit/context.ex
@@ -94,7 +94,7 @@ defmodule MingaEditor.Frontend.Emit.Context do
       tab_bar: Map.get(state.shell_state, :tab_bar),
       buffers: state.workspace.buffers,
       viewport: state.terminal_viewport,
-      file_tree: state.workspace.file_tree,
+      file_tree: MingaEditor.State.file_tree_state(state),
       highlight: state.workspace.highlight,
       agent_ui: state.workspace.agent_ui,
       completion: MingaEditor.State.ModalOverlay.completion(state),

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -356,15 +356,19 @@ defmodule MingaEditor.Frontend.Emit.GUI do
 
   @spec sidebar_metadata(ctx(), Sidebar.entry() | nil) :: [ProtocolGUI.sidebar_metadata()]
   defp sidebar_metadata(ctx, registered_active) do
+    registered = registered_sidebar_metadata()
+    registered_ids = MapSet.new(registered, & &1.id)
+
     built_in =
       [
         file_tree_sidebar_metadata(ctx),
         git_status_sidebar_metadata(ctx),
         observatory_sidebar_metadata(ctx)
       ]
+      |> Enum.reject(&MapSet.member?(registered_ids, &1.id))
       |> maybe_suppress_builtin_sidebar_visibility(registered_active)
 
-    (built_in ++ registered_sidebar_metadata())
+    (built_in ++ registered)
     |> Enum.sort_by(&{&1.order, &1.id})
   end
 
@@ -382,6 +386,7 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   @spec registered_sidebar_metadata() :: [ProtocolGUI.sidebar_metadata()]
   defp registered_sidebar_metadata do
     Sidebar.all()
+    |> Enum.reject(&(&1.id == "file_tree"))
     |> Enum.map(fn sidebar ->
       %{
         id: sidebar.id,

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -389,7 +389,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   defp dispatch_action(state, {:sidebar_action, sidebar_id, kind, action}) do
     case Sidebar.get(sidebar_id) do
-      nil -> dispatch_sidebar_action(state, sidebar_id, kind, action)
+      nil -> dispatch_missing_registered_sidebar_action(state, sidebar_id, kind, action)
       _sidebar -> Sidebar.dispatch_action(state, sidebar_id, action, %{kind: kind})
     end
   end
@@ -827,6 +827,30 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     state
   end
 
+  @spec dispatch_missing_registered_sidebar_action(
+          EditorState.t(),
+          String.t(),
+          String.t(),
+          String.t()
+        ) ::
+          EditorState.t()
+  defp dispatch_missing_registered_sidebar_action(state, sidebar_id, kind, action) do
+    if builtin_sidebar_id?(sidebar_id) do
+      Minga.Log.warning(
+        :editor,
+        "Sidebar registry missing #{sidebar_id}; using built-in #{action} fallback"
+      )
+
+      dispatch_sidebar_action(state, sidebar_id, kind, action)
+    else
+      ignored_sidebar_action(state, sidebar_id, kind, action)
+    end
+  end
+
+  @spec builtin_sidebar_id?(String.t()) :: boolean()
+  defp builtin_sidebar_id?(sidebar_id),
+    do: sidebar_id in ["file_tree", "git_status", "observatory"]
+
   @spec dispatch_sidebar_action(EditorState.t(), String.t(), String.t(), String.t()) ::
           EditorState.t()
   defp dispatch_sidebar_action(state, sidebar_id, kind, "toggle") do
@@ -917,8 +941,11 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   end
 
   @spec sidebar_visible?(EditorState.t(), String.t()) :: boolean()
-  defp sidebar_visible?(%{workspace: %{file_tree: %FileTreeState{} = file_tree}}, "file_tree") do
-    file_tree |> FileTreeState.status() |> FileTreeState.visible_status?()
+  defp sidebar_visible?(state, "file_tree") do
+    state
+    |> EditorState.file_tree_state()
+    |> FileTreeState.status()
+    |> FileTreeState.visible_status?()
   end
 
   defp sidebar_visible?(state, "git_status"), do: EditorState.git_status_panel(state) != nil

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -200,7 +200,10 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     {shell_state, workspace} =
       MingaEditor.Shell.Board.handle_gui_action(state.shell_state, state.workspace, action)
 
-    state = %{state | shell_state: shell_state, workspace: workspace}
+    state =
+      state
+      |> EditorState.update_shell_state(fn _ -> shell_state end)
+      |> EditorState.set_workspace(workspace)
 
     # After Board zoom into an agent card, atomically activate the
     # agent view (session, scope, window content, prompt focus).
@@ -260,7 +263,10 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     {shell_state, workspace} =
       state.shell.handle_gui_action(state.shell_state, state.workspace, {:close_tab, id})
 
-    state = %{state | shell_state: shell_state, workspace: workspace}
+    state =
+      state
+      |> EditorState.update_shell_state(fn _ -> shell_state end)
+      |> EditorState.set_workspace(workspace)
 
     # Only close the buffer when the shell has a tab bar.
     # EditorState.active_tab/1 returns nil when there are no tabs.
@@ -294,16 +300,13 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   end
 
   defp dispatch_action(state, {:file_tree_edit_confirm, text}) do
-    case state.workspace.file_tree.editing do
+    case EditorState.file_tree_state(state).editing do
       nil ->
         state
 
       %{} ->
-        ft = FileTreeState.update_editing_text(state.workspace.file_tree, text)
-
-        state =
-          EditorState.set_file_tree(state, ft)
-
+        ft = FileTreeState.update_editing_text(EditorState.file_tree_state(state), text)
+        state = EditorState.set_file_tree(state, ft)
         Commands.FileTree.confirm_editing(state)
     end
   end
@@ -579,14 +582,18 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     {shell_state, workspace} =
       state.shell.handle_gui_action(state.shell_state, state.workspace, action)
 
-    %{state | shell_state: shell_state, workspace: workspace}
+    state
+    |> EditorState.update_shell_state(fn _shell_state -> shell_state end)
+    |> EditorState.set_workspace(workspace)
   end
 
   defp dispatch_action(state, {:workspace_set_icon, _ws_id, _icon} = action) do
     {shell_state, workspace} =
       state.shell.handle_gui_action(state.shell_state, state.workspace, action)
 
-    %{state | shell_state: shell_state, workspace: workspace}
+    state
+    |> EditorState.update_shell_state(fn _shell_state -> shell_state end)
+    |> EditorState.set_workspace(workspace)
   end
 
   defp dispatch_action(state, {:space_leader_chord, codepoint, modifiers}) do
@@ -1115,20 +1122,30 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   # Moves the tree cursor to a specific index (used by GUI context menu / header actions).
   @spec move_tree_cursor(state(), non_neg_integer()) :: state()
-  defp move_tree_cursor(%{workspace: %{file_tree: %{tree: nil}}} = state, _index), do: state
-
   defp move_tree_cursor(state, index) do
-    EditorState.update_file_tree(state, fn file_tree ->
-      FileTreeState.set_tree(file_tree, FileTree.select(file_tree.tree, index))
-    end)
+    case EditorState.file_tree_state(state).tree do
+      nil ->
+        state
+
+      tree ->
+        EditorState.update_file_tree(state, fn file_tree ->
+          FileTreeState.set_tree(file_tree, FileTree.select(tree, index))
+        end)
+    end
   end
 
   # Moves the file tree cursor to the given index and performs the action.
   @spec gui_tree_action(state(), non_neg_integer(), :click | :toggle) :: state()
-  defp gui_tree_action(%{workspace: %{file_tree: %{tree: nil}}} = state, _index, _action),
-    do: state
-
   defp gui_tree_action(state, index, action) do
+    if EditorState.file_tree_state(state).tree == nil do
+      state
+    else
+      do_gui_tree_action(state, index, action)
+    end
+  end
+
+  @spec do_gui_tree_action(state(), non_neg_integer(), :click | :toggle) :: state()
+  defp do_gui_tree_action(state, index, action) do
     state = move_tree_cursor(state, index)
 
     case action do
@@ -1138,17 +1155,22 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   end
 
   @spec open_file_tree_entry_in_split(state(), non_neg_integer()) :: state()
-  defp open_file_tree_entry_in_split(%{workspace: %{file_tree: %{tree: nil}}} = state, _index) do
-    state
+  defp open_file_tree_entry_in_split(state, index) do
+    if EditorState.file_tree_state(state).tree == nil do
+      state
+    else
+      do_open_file_tree_entry_in_split(state, index)
+    end
   end
 
-  defp open_file_tree_entry_in_split(state, index) do
+  @spec do_open_file_tree_entry_in_split(state(), non_neg_integer()) :: state()
+  defp do_open_file_tree_entry_in_split(state, index) do
     state =
       state
       |> move_tree_cursor(index)
       |> unfocus_file_tree_for_split()
 
-    case FileTree.selected_entry(state.workspace.file_tree.tree) do
+    case FileTree.selected_entry(EditorState.file_tree_state(state).tree) do
       %{dir?: false, path: path} ->
         state
         |> Commands.Movement.execute(:split_vertical)

--- a/lib/minga_editor/input.ex
+++ b/lib/minga_editor/input.ex
@@ -26,7 +26,6 @@ defmodule MingaEditor.Input do
   alias MingaEditor.Input.Dashboard
   alias MingaEditor.Input.DiffReview
   alias MingaEditor.Input.Dired
-  alias MingaEditor.Input.FileTreeHandler
   alias MingaEditor.Input.GitStatus
   alias MingaEditor.Input.GlobalBindings
   alias MingaEditor.Input.Hover
@@ -59,7 +58,6 @@ defmodule MingaEditor.Input do
     {DiffReview, 30},
     {AgentPanel, 40},
     {Sidebar, 45},
-    {FileTreeHandler, 50},
     {GitStatus, 60},
     {Dired, 70},
     {Popup, 80},
@@ -147,6 +145,11 @@ defmodule MingaEditor.Input do
 
   @doc "Removes every input handler contributed by a source."
   @spec unregister_source(contribution_source()) :: :ok
+  def unregister_source(:builtin) do
+    ensure_handler_registry!()
+    :ok
+  end
+
   def unregister_source(source) do
     ensure_handler_registry!()
 

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -27,50 +27,46 @@ defmodule MingaEditor.Input.FileTreeHandler do
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
 
-  # Help overlay active: capture keys so Escape closes help instead of closing the tree.
-  def handle_key(
-        %{workspace: %{keymap_scope: :file_tree, file_tree: %{help_visible: true}}} = state,
-        cp,
-        mods
-      ) do
-    {:handled, handle_help_key(state, cp, mods)}
-  end
-
-  # Inline editing active: capture all keys before they reach the mode FSM or scope trie
-  def handle_key(
-        %{workspace: %{keymap_scope: :file_tree, file_tree: %{editing: %{} = _editing}}} = state,
-        cp,
-        mods
-      ) do
-    {:handled, handle_inline_edit_key(state, cp, mods)}
-  end
-
-  # Filter input active: capture text before it reaches vim search.
-  def handle_key(
-        %{workspace: %{keymap_scope: :file_tree, file_tree: %{filtering: true}}} = state,
-        cp,
-        mods
-      ) do
-    {:handled, handle_filter_key(state, cp, mods)}
-  end
-
-  # File tree scope with tree focused
-  def handle_key(
-        %{workspace: %{keymap_scope: :file_tree, file_tree: %{tree: %FileTree{}, focused: true}}} =
-          state,
-        cp,
-        mods
-      ) do
-    handle_file_tree_key(state, cp, mods)
-  end
-
-  # File tree scope but not focused
-  def handle_key(%{workspace: %{keymap_scope: :file_tree}} = state, _cp, _mods) do
-    {:passthrough, state}
+  def handle_key(%{workspace: %{keymap_scope: :file_tree}} = state, cp, mods) do
+    state
+    |> file_tree_state()
+    |> handle_file_tree_scoped_key(state, cp, mods)
   end
 
   # Not file tree scope
   def handle_key(state, _cp, _mods), do: {:passthrough, state}
+
+  @spec handle_file_tree_scoped_key(
+          FileTreeState.t(),
+          state(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: MingaEditor.Input.Handler.result()
+  defp handle_file_tree_scoped_key(%FileTreeState{help_visible: true}, state, cp, mods) do
+    {:handled, handle_help_key(state, cp, mods)}
+  end
+
+  defp handle_file_tree_scoped_key(%FileTreeState{editing: editing}, state, cp, mods)
+       when editing != nil do
+    {:handled, handle_inline_edit_key(state, cp, mods)}
+  end
+
+  defp handle_file_tree_scoped_key(%FileTreeState{filtering: true}, state, cp, mods) do
+    {:handled, handle_filter_key(state, cp, mods)}
+  end
+
+  defp handle_file_tree_scoped_key(
+         %FileTreeState{tree: %FileTree{}, focused: true},
+         state,
+         cp,
+         mods
+       ) do
+    handle_file_tree_key(state, cp, mods)
+  end
+
+  defp handle_file_tree_scoped_key(%FileTreeState{}, state, _cp, _mods) do
+    {:passthrough, state}
+  end
 
   @impl true
   @spec handle_mouse(
@@ -107,7 +103,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
 
   # File tree: left click opens file/toggles dir, scroll wheel scrolls tree.
   def handle_mouse_at_node(
-        %{workspace: %{file_tree: %{tree: %FileTree{} = tree}}} = state,
+        state,
         %FocusNode{content_type: :file_tree, rect: {ft_row, _ft_col, _ft_width, ft_height}},
         row,
         _col,
@@ -116,8 +112,16 @@ defmodule MingaEditor.Input.FileTreeHandler do
         :press,
         click_count
       ) do
-    state = focus_file_tree_for_mouse(state, button)
-    {:handled, handle_file_tree_click(state, tree, row, ft_row, ft_height, button, click_count)}
+    case file_tree_state(state).tree do
+      %FileTree{} = tree ->
+        state = focus_file_tree_for_mouse(state, button)
+
+        {:handled,
+         handle_file_tree_click(state, tree, row, ft_row, ft_height, button, click_count)}
+
+      nil ->
+        {:passthrough, state}
+    end
   end
 
   def handle_mouse_at_node(state, _node, _row, _col, _button, _mods, _event_type, _cc) do
@@ -183,36 +187,35 @@ defmodule MingaEditor.Input.FileTreeHandler do
           non_neg_integer()
         ) ::
           EditorState.t()
-  defp delegate_to_mode_fsm_with_tree_buffer(
-         %{workspace: %{file_tree: %{buffer: buf}}} = state,
-         cp,
-         mods
-       )
-       when is_pid(buf) do
-    real_active = state.workspace.buffers.active
-    state = set_active_buffer_override(state, buf)
-    state = MingaEditor.do_handle_key(state, cp, mods)
+  defp delegate_to_mode_fsm_with_tree_buffer(state, cp, mods) do
+    case file_tree_state(state).buffer do
+      buf when is_pid(buf) ->
+        real_active = state.workspace.buffers.active
+        state = set_active_buffer_override(state, buf)
+        state = MingaEditor.do_handle_key(state, cp, mods)
 
-    state =
-      if Minga.Editing.mode(state) != :normal do
-        EditorState.transition_mode(state, :normal)
-      else
+        state =
+          if Minga.Editing.mode(state) != :normal do
+            EditorState.transition_mode(state, :normal)
+          else
+            state
+          end
+
+        state = set_active_buffer_override(state, real_active)
+
+        case file_tree_state(state).tree do
+          nil -> state
+          %FileTree{} -> sync_tree_cursor_from_buffer(state, buf)
+        end
+
+      _ ->
         state
-      end
-
-    state = set_active_buffer_override(state, real_active)
-
-    if state.workspace.file_tree.tree == nil do
-      state
-    else
-      sync_tree_cursor_from_buffer(state, buf)
     end
   end
 
-  defp delegate_to_mode_fsm_with_tree_buffer(state, _cp, _mods), do: state
-
   @spec sync_tree_cursor_from_buffer(EditorState.t(), pid()) :: EditorState.t()
-  defp sync_tree_cursor_from_buffer(%{workspace: %{file_tree: %{tree: tree}}} = state, buf) do
+  defp sync_tree_cursor_from_buffer(state, buf) do
+    tree = file_tree_state(state).tree
     {cursor_line, _col} = Buffer.cursor(buf)
 
     update_file_tree(state, &FileTreeState.set_tree(&1, FileTree.select(tree, cursor_line)))
@@ -302,7 +305,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
   end
 
   defp handle_inline_edit_key(state, @backspace, 0) do
-    editing = state.workspace.file_tree.editing
+    editing = file_tree_state(state).editing
 
     if editing.text == "" do
       Commands.FileTree.cancel_editing(state)
@@ -310,7 +313,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
       # Delete the last grapheme from the editing text.
       # Use String.slice/3 (start, length) to avoid negative index issues.
       new_text = String.slice(editing.text, 0, max(String.length(editing.text) - 1, 0))
-      ft = FileTreeState.update_editing_text(state.workspace.file_tree, new_text)
+      ft = FileTreeState.update_editing_text(file_tree_state(state), new_text)
       set_file_tree(state, ft)
     end
   end
@@ -318,9 +321,9 @@ defmodule MingaEditor.Input.FileTreeHandler do
   # Printable characters: append to editing text
   defp handle_inline_edit_key(state, cp, mods) when printable_text_key?(cp, mods) do
     char = <<cp::utf8>>
-    editing = state.workspace.file_tree.editing
+    editing = file_tree_state(state).editing
     new_text = editing.text <> char
-    ft = FileTreeState.update_editing_text(state.workspace.file_tree, new_text)
+    ft = FileTreeState.update_editing_text(file_tree_state(state), new_text)
     set_file_tree(state, ft)
   end
 
@@ -338,11 +341,11 @@ defmodule MingaEditor.Input.FileTreeHandler do
   @spec handle_filter_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           EditorState.t()
   defp handle_filter_key(state, @enter, 0) do
-    set_file_tree(state, FileTreeState.accept_filter(state.workspace.file_tree))
+    set_file_tree(state, FileTreeState.accept_filter(file_tree_state(state)))
   end
 
   defp handle_filter_key(state, @escape, 0) do
-    set_file_tree(state, FileTreeState.clear_filter(state.workspace.file_tree))
+    set_file_tree(state, FileTreeState.clear_filter(file_tree_state(state)))
   end
 
   defp handle_filter_key(state, ??, 0), do: Commands.FileTree.toggle_help(state)
@@ -351,27 +354,32 @@ defmodule MingaEditor.Input.FileTreeHandler do
     text = current_filter_text(state)
 
     if text == "" do
-      set_file_tree(state, FileTreeState.clear_filter(state.workspace.file_tree))
+      set_file_tree(state, FileTreeState.clear_filter(file_tree_state(state)))
     else
       new_text = String.slice(text, 0, max(String.length(text) - 1, 0))
-      set_file_tree(state, FileTreeState.update_filter(state.workspace.file_tree, new_text))
+      set_file_tree(state, FileTreeState.update_filter(file_tree_state(state), new_text))
     end
   end
 
   defp handle_filter_key(state, cp, mods) when printable_text_key?(cp, mods) do
     new_text = current_filter_text(state) <> <<cp::utf8>>
-    set_file_tree(state, FileTreeState.update_filter(state.workspace.file_tree, new_text))
+    set_file_tree(state, FileTreeState.update_filter(file_tree_state(state), new_text))
   end
 
   defp handle_filter_key(state, _cp, _mods), do: state
 
   @spec current_filter_text(EditorState.t()) :: String.t()
-  defp current_filter_text(%{workspace: %{file_tree: %{tree: %FileTree{filter: filter}}}})
-       when is_binary(filter), do: filter
-
-  defp current_filter_text(_state), do: ""
+  defp current_filter_text(state) do
+    case file_tree_state(state).tree do
+      %FileTree{filter: filter} when is_binary(filter) -> filter
+      _ -> ""
+    end
+  end
 
   # ── Shared helpers ──────────────────────────────────────────────────────
+
+  @spec file_tree_state(EditorState.t()) :: FileTreeState.t()
+  defp file_tree_state(state), do: EditorState.file_tree_state(state)
 
   @spec set_active_buffer_override(EditorState.t(), pid() | nil) :: EditorState.t()
   defp set_active_buffer_override(state, pid) do

--- a/lib/minga_editor/input/inline_ask.ex
+++ b/lib/minga_editor/input/inline_ask.ex
@@ -125,11 +125,8 @@ defmodule MingaEditor.Input.InlineAsk do
   end
 
   @spec project_root(state()) :: String.t()
-  defp project_root(%{workspace: %{file_tree: %{project_root: root}}}) when is_binary(root),
-    do: root
-
-  defp project_root(%{workspace: %{file_tree: %{original_root: root}}}) when is_binary(root),
-    do: root
-
-  defp project_root(_state), do: File.cwd!()
+  defp project_root(state) do
+    file_tree = EditorState.file_tree_state(state)
+    file_tree.project_root || file_tree.original_root || File.cwd!()
+  end
 end

--- a/lib/minga_editor/input/inline_edit.ex
+++ b/lib/minga_editor/input/inline_edit.ex
@@ -98,11 +98,8 @@ defmodule MingaEditor.Input.InlineEdit do
   end
 
   @spec project_root(state()) :: String.t()
-  defp project_root(%{workspace: %{file_tree: %{project_root: root}}}) when is_binary(root),
-    do: root
-
-  defp project_root(%{workspace: %{file_tree: %{original_root: root}}}) when is_binary(root),
-    do: root
-
-  defp project_root(_state), do: File.cwd!()
+  defp project_root(state) do
+    file_tree = EditorState.file_tree_state(state)
+    file_tree.project_root || file_tree.original_root || File.cwd!()
+  end
 end

--- a/lib/minga_editor/input/sidebar.ex
+++ b/lib/minga_editor/input/sidebar.ex
@@ -15,7 +15,7 @@ defmodule MingaEditor.Input.Sidebar do
   @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
   def handle_key(state, codepoint, modifiers) do
-    case active_sidebar_id() do
+    case active_sidebar_id(state) do
       nil ->
         {:passthrough, state}
 
@@ -66,11 +66,17 @@ defmodule MingaEditor.Input.Sidebar do
     {:passthrough, state}
   end
 
-  @spec active_sidebar_id() :: String.t() | nil
-  defp active_sidebar_id do
-    case Sidebar.active_left() do
-      %{id: id, focused?: true} -> id
-      _ -> nil
-    end
+  @spec active_sidebar_id(EditorState.t()) :: String.t() | nil
+  defp active_sidebar_id(_state) do
+    Sidebar.visible()
+    |> Enum.reject(&(&1.id == "file_tree"))
+    |> Enum.filter(&(&1.placement == :left))
+    |> Enum.sort_by(&{not &1.focused?, &1.priority, &1.id})
+    |> List.first()
+    |> focused_sidebar_id()
   end
+
+  @spec focused_sidebar_id(Sidebar.entry() | nil) :: String.t() | nil
+  defp focused_sidebar_id(%{id: id, focused?: true}), do: id
+  defp focused_sidebar_id(_sidebar), do: nil
 end

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -30,7 +30,7 @@ defmodule MingaEditor.RenderPipeline.Input do
   before it runs the pipeline.
 
   **From `state.workspace` (per-tab editing context, stored as `workspace` map):**
-  `windows`, `buffers`, `viewport`, `file_tree`, `highlight`,
+  `windows`, `buffers`, `viewport`, `file_tree` (FileTree feature state), `highlight`,
   `agent_ui`, `editing`, `document_highlights`,
   `search`, `keymap_scope`
 
@@ -42,7 +42,7 @@ defmodule MingaEditor.RenderPipeline.Input do
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Layout
   alias MingaEditor.State.Buffers
-  alias MingaEditor.State.FileTree
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Highlighting
   alias MingaEditor.State.Mouse
   alias MingaEditor.State.Search
@@ -101,7 +101,7 @@ defmodule MingaEditor.RenderPipeline.Input do
           windows: Windows.t(),
           buffers: Buffers.t(),
           viewport: Viewport.t(),
-          file_tree: FileTree.t(),
+          file_tree: FileTreeState.t(),
           highlight: Highlighting.t(),
           agent_ui: UIState.t(),
           editing: VimState.t(),
@@ -180,11 +180,11 @@ defmodule MingaEditor.RenderPipeline.Input do
   end
 
   @doc "Returns the FileTree snapshot carried by this render input."
-  @spec file_tree_state(t()) :: FileTree.t()
-  def file_tree_state(%__MODULE__{workspace: %{file_tree: %FileTree{} = file_tree}}),
+  @spec file_tree_state(t()) :: FileTreeState.t()
+  def file_tree_state(%__MODULE__{workspace: %{file_tree: %FileTreeState{} = file_tree}}),
     do: file_tree
 
-  def file_tree_state(%__MODULE__{}), do: %FileTree{}
+  def file_tree_state(%__MODULE__{}), do: %FileTreeState{}
 
   @doc "Returns a copy of the render input with the renderer-owned font registry attached."
   @spec with_font_registry(t(), FontRegistry.t()) :: t()

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -166,7 +166,7 @@ defmodule MingaEditor.RenderPipeline.Input do
         windows: ws.windows,
         buffers: ws.buffers,
         viewport: ws.viewport,
-        file_tree: ws.file_tree,
+        file_tree: MingaEditor.Session.State.file_tree_state(ws),
         highlight: ws.highlight,
         agent_ui: ws.agent_ui,
         editing: ws.editing,
@@ -178,6 +178,13 @@ defmodule MingaEditor.RenderPipeline.Input do
     }
     |> sync_active_window_cursor()
   end
+
+  @doc "Returns the FileTree snapshot carried by this render input."
+  @spec file_tree_state(t()) :: FileTree.t()
+  def file_tree_state(%__MODULE__{workspace: %{file_tree: %FileTree{} = file_tree}}),
+    do: file_tree
+
+  def file_tree_state(%__MODULE__{}), do: %FileTree{}
 
   @doc "Returns a copy of the render input with the renderer-owned font registry attached."
   @spec with_font_registry(t(), FontRegistry.t()) :: t()

--- a/lib/minga_editor/session/chrome_state.ex
+++ b/lib/minga_editor/session/chrome_state.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.Session.ChromeState do
   alias Minga.Buffer
   alias Minga.Language
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Workspace
   alias MingaEditor.State.WorkspaceReview
   alias MingaEditor.State.Buffers
@@ -133,6 +134,17 @@ defmodule MingaEditor.Session.ChromeState do
   defp manual_workspace_label(%{workspace: %{custom_name: custom_name}}, _workspace)
        when is_binary(custom_name) and custom_name != "" do
     custom_name
+  end
+
+  defp manual_workspace_label(
+         %{workspace: %{file_tree: %FileTreeState{} = file_tree}},
+         _workspace
+       ) do
+    file_tree |> Map.get(:project_root) |> project_label()
+  end
+
+  defp manual_workspace_label(%{file_tree: %FileTreeState{} = file_tree}, _workspace) do
+    file_tree |> Map.get(:project_root) |> project_label()
   end
 
   defp manual_workspace_label(%{workspace: %SessionState{} = session}, _workspace) do

--- a/lib/minga_editor/session/chrome_state.ex
+++ b/lib/minga_editor/session/chrome_state.ex
@@ -7,10 +7,10 @@ defmodule MingaEditor.Session.ChromeState do
 
   alias Minga.Buffer
   alias Minga.Language
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State.Workspace
   alias MingaEditor.State.WorkspaceReview
   alias MingaEditor.State.Buffers
-  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
@@ -135,15 +135,12 @@ defmodule MingaEditor.Session.ChromeState do
     custom_name
   end
 
-  defp manual_workspace_label(
-         %{workspace: %{file_tree: %FileTreeState{project_root: root}}},
-         _workspace
-       ) do
-    project_label(root)
+  defp manual_workspace_label(%{workspace: %SessionState{} = session}, _workspace) do
+    session |> SessionState.file_tree_state() |> Map.get(:project_root) |> project_label()
   end
 
-  defp manual_workspace_label(%{file_tree: %FileTreeState{project_root: root}}, _workspace) do
-    project_label(root)
+  defp manual_workspace_label(%SessionState{} = session, _workspace) do
+    session |> SessionState.file_tree_state() |> Map.get(:project_root) |> project_label()
   end
 
   defp manual_workspace_label(_state, %Workspace{label: label})

--- a/lib/minga_editor/session/state.ex
+++ b/lib/minga_editor/session/state.ex
@@ -16,6 +16,7 @@ defmodule MingaEditor.Session.State do
   alias MingaEditor.FeatureState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Dired, as: DiredState
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Highlighting
   alias MingaEditor.State.Mouse
@@ -33,7 +34,6 @@ defmodule MingaEditor.Session.State do
           keymap_scope: Scope.scope_name(),
           buffers: Buffers.t(),
           windows: Windows.t(),
-          file_tree: FileTreeState.t(),
           dired: DiredState.t(),
           viewport: Viewport.t(),
           mouse: Mouse.t(),
@@ -51,7 +51,6 @@ defmodule MingaEditor.Session.State do
   defstruct keymap_scope: :editor,
             buffers: %Buffers{},
             windows: %Windows{},
-            file_tree: %FileTreeState{},
             dired: %DiredState{},
             viewport: nil,
             mouse: %Mouse{},
@@ -228,10 +227,31 @@ defmodule MingaEditor.Session.State do
     %{wspace | keymap_scope: scope}
   end
 
-  @doc "Replaces the file-tree sub-struct."
+  @doc "Returns FileTree UI state from source-owned feature state, falling back to the legacy field during migration."
+  @spec file_tree_state(t()) :: FileTreeState.t()
+  def file_tree_state(%__MODULE__{} = wspace) do
+    case get_feature_state(wspace, FileTreeFeature.source(), FileTreeFeature.feature_id()) do
+      %FileTreeState{} = file_tree -> file_tree
+      _missing -> %FileTreeState{}
+    end
+  end
+
+  @doc "Replaces the FileTree feature-owned UI state."
   @spec set_file_tree(t(), FileTreeState.t()) :: t()
   def set_file_tree(%__MODULE__{} = wspace, %FileTreeState{} = file_tree) do
-    %{wspace | file_tree: file_tree}
+    put_feature_state(wspace, FileTreeFeature.source(), FileTreeFeature.feature_id(), file_tree)
+  end
+
+  @doc "Updates the FileTree feature-owned UI state."
+  @spec update_file_tree(t(), (FileTreeState.t() -> FileTreeState.t())) :: t()
+  def update_file_tree(%__MODULE__{} = wspace, fun) when is_function(fun, 1) do
+    set_file_tree(wspace, fun.(file_tree_state(wspace)))
+  end
+
+  @doc "Drops FileTree feature-owned UI state and clears the legacy compatibility field."
+  @spec drop_file_tree(t()) :: t()
+  def drop_file_tree(%__MODULE__{} = wspace) do
+    drop_feature_state(wspace, FileTreeFeature.source(), FileTreeFeature.feature_id())
   end
 
   @doc "Replaces the dired sub-struct."

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -119,7 +119,8 @@ defmodule MingaEditor.Shell.Traditional do
         {:close_tab, id}
       ) do
     if tb.active_id != id do
-      switch_to_buffer_tab(shell_state, workspace, id)
+      {shell_state, workspace, _effects} = switch_to_buffer_tab(shell_state, workspace, id)
+      {shell_state, workspace}
     else
       {shell_state, workspace}
     end
@@ -703,7 +704,8 @@ defmodule MingaEditor.Shell.Traditional do
   end
 
   @spec project_root(SessionState.t()) :: String.t() | nil
-  defp project_root(%SessionState{file_tree: %{project_root: root}}), do: root
+  defp project_root(%SessionState{} = workspace),
+    do: SessionState.file_tree_state(workspace).project_root
 
   @spec buffer_path(pid()) :: String.t() | nil
   defp buffer_path(pid) when is_pid(pid) do

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -19,6 +19,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
   alias MingaEditor.RenderPipeline.Chrome
   alias MingaEditor.RenderPipeline.Scroll.WindowScroll
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Shell.Traditional.Chrome.Helpers, as: ChromeHelpers
@@ -136,9 +137,15 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
 
   @spec sidebar_draws(state(), Layout.t()) :: [DisplayList.draw()]
   defp sidebar_draws(state, layout) do
-    case SidebarRenderer.active_sidebar() do
-      nil -> legacy_sidebar_draws(state, layout)
-      sidebar -> SidebarRenderer.render(state, layout.file_tree, sidebar)
+    file_tree = EditorState.file_tree_state(state)
+
+    if FileTreeState.visible_status?(FileTreeState.status(file_tree)) do
+      TreeRenderer.render(state)
+    else
+      case SidebarRenderer.active_sidebar(state) do
+        nil -> legacy_sidebar_draws(state, layout)
+        sidebar -> SidebarRenderer.render(state, layout.file_tree, sidebar)
+      end
     end
   end
 
@@ -157,7 +164,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
       layout.minibuffer,
       layout.status_bar,
       state.workspace.windows.tree,
-      state.workspace.file_tree,
+      EditorState.file_tree_state(state),
       state.workspace.keymap_scope,
       ChromeState.from_editor_state(state),
       state.shell_state |> Map.get(:git_status_panel),

--- a/lib/minga_editor/shell/traditional/layout/tui.ex
+++ b/lib/minga_editor/shell/traditional/layout/tui.ex
@@ -7,7 +7,6 @@ defmodule MingaEditor.Shell.Traditional.Layout.TUI do
   agent panel, modeline, and minibuffer.
   """
 
-  alias Minga.Project.FileTree
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
@@ -189,25 +188,30 @@ defmodule MingaEditor.Shell.Traditional.Layout.TUI do
   @spec file_tree_layout(EditorState.t(), pos_integer(), non_neg_integer()) ::
           {Layout.rect() | nil, non_neg_integer(), pos_integer()}
   defp file_tree_layout(state, total_cols, content_start) do
-    case Sidebar.active_left() do
-      %{preferred_width: width} ->
-        sidebar_layout(state, total_cols, width, content_start)
-
-      nil ->
-        legacy_sidebar_layout(state, total_cols, content_start)
+    case active_left_sidebar(state) do
+      %{preferred_width: width} -> sidebar_layout(state, total_cols, width, content_start)
+      nil -> legacy_sidebar_layout(state, total_cols, content_start)
     end
   end
 
-  @spec legacy_sidebar_layout(EditorState.t(), pos_integer(), non_neg_integer()) ::
-          {Layout.rect() | nil, non_neg_integer(), pos_integer()}
-  defp legacy_sidebar_layout(
-         %{workspace: %{file_tree: %{tree: %FileTree{width: tw}}}} = state,
-         total_cols,
-         content_start
-       ) do
-    sidebar_layout(state, total_cols, tw, content_start)
+  @spec active_left_sidebar(EditorState.t()) :: Sidebar.entry() | nil
+  defp active_left_sidebar(state) do
+    Sidebar.visible()
+    |> Enum.filter(&(&1.placement == :left))
+    |> Enum.reject(&stale_file_tree_sidebar?(state, &1))
+    |> Enum.sort_by(&{not &1.focused?, &1.priority, &1.id})
+    |> List.first()
   end
 
+  @spec stale_file_tree_sidebar?(EditorState.t(), Sidebar.entry()) :: boolean()
+  defp stale_file_tree_sidebar?(state, %{id: "file_tree"}) do
+    EditorState.file_tree_state(state).tree == nil
+  end
+
+  defp stale_file_tree_sidebar?(_state, _sidebar), do: false
+
+  @spec legacy_sidebar_layout(EditorState.t(), pos_integer(), non_neg_integer()) ::
+          {Layout.rect() | nil, non_neg_integer(), pos_integer()}
   defp legacy_sidebar_layout(
          %{shell_state: %{git_status_panel: %{} = _panel}} = state,
          total_cols,

--- a/lib/minga_editor/shell/traditional/sidebar_renderer.ex
+++ b/lib/minga_editor/shell/traditional/sidebar_renderer.ex
@@ -11,18 +11,35 @@ defmodule MingaEditor.Shell.Traditional.SidebarRenderer do
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Extension.Sidebar.Snapshot
   alias MingaEditor.Layout
+  alias MingaEditor.State, as: EditorState
 
   @typedoc "Editor or render-pipeline state with theme data."
   @type state :: map()
 
-  @doc "Returns the first visible registered left sidebar, if any."
-  @spec active_sidebar() :: Sidebar.entry() | nil
-  def active_sidebar, do: Sidebar.active_left()
+  @doc "Returns the first visible registered left sidebar for the given state, if any."
+  @spec active_sidebar(state()) :: Sidebar.entry() | nil
+  def active_sidebar(state), do: active_left_sidebar(state)
 
   @doc "Renders a registered sidebar entry into the given rect."
   @spec render(state(), Layout.rect() | nil, Sidebar.entry()) :: [DisplayList.draw()]
   def render(_state, nil, _sidebar), do: []
   def render(state, rect, sidebar), do: render_sidebar(state, rect, sidebar)
+
+  @spec active_left_sidebar(state()) :: Sidebar.entry() | nil
+  defp active_left_sidebar(state) do
+    Sidebar.visible()
+    |> Enum.filter(&(&1.placement == :left))
+    |> Enum.reject(&stale_file_tree_sidebar?(state, &1))
+    |> Enum.sort_by(&{not &1.focused?, &1.priority, &1.id})
+    |> List.first()
+  end
+
+  @spec stale_file_tree_sidebar?(state(), Sidebar.entry()) :: boolean()
+  defp stale_file_tree_sidebar?(state, %{id: "file_tree"}) do
+    EditorState.file_tree_state(state).tree == nil
+  end
+
+  defp stale_file_tree_sidebar?(_state, _sidebar), do: false
 
   @spec render_sidebar(state(), Layout.rect(), Sidebar.entry()) :: [DisplayList.draw()]
   defp render_sidebar(state, {row, col, width, height}, %{

--- a/lib/minga_editor/shell/traditional/tree_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tree_renderer.ex
@@ -92,26 +92,16 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   end
 
   @spec render(EditorState.t() | map()) :: [DisplayList.draw()]
-  def render(%EditorState{workspace: %{file_tree: %{tree: nil}}}), do: []
-  def render(%{workspace: %{file_tree: %{tree: nil}}}), do: []
-
-  def render(%EditorState{} = state) do
-    render_from_workspace(state.workspace, state.theme, state)
+  def render(state) do
+    case EditorState.file_tree_state(state) do
+      %FileTreeState{tree: nil} -> []
+      %FileTreeState{tree: _tree} = file_tree -> render_from_file_tree(file_tree, state)
+    end
   end
 
-  def render(%{workspace: %{file_tree: %{tree: _tree}}} = state) do
-    render_from_workspace(state.workspace, state.theme, state)
-  end
-
-  def render(_state), do: []
-
-  @spec render_from_workspace(map(), MingaEditor.UI.Theme.t(), map()) :: [DisplayList.draw()]
-  defp render_from_workspace(
-         %{file_tree: %{tree: tree, focused: focused} = file_tree} = _ws,
-         _theme,
-         state
-       ) do
-    rect = tree_rect_from_workspace(state.workspace)
+  @spec render_from_file_tree(FileTreeState.t(), map()) :: [DisplayList.draw()]
+  defp render_from_file_tree(%FileTreeState{tree: tree, focused: focused} = file_tree, state) do
+    rect = tree_rect_from_workspace(state.workspace, file_tree)
 
     input = %RenderInput{
       tree: tree,
@@ -120,11 +110,11 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
       theme: state.theme,
       active_path: active_buffer_path(state),
       dirty_paths: dirty_paths(state),
-      editing: Map.get(file_tree, :editing),
+      editing: file_tree.editing,
       filter_text: Map.get(tree, :filter),
-      filtering?: Map.get(file_tree, :filtering, false),
+      filtering?: file_tree.filtering,
       git_status: tree.git_status,
-      help_visible?: Map.get(file_tree, :help_visible, false),
+      help_visible?: file_tree.help_visible,
       status: status_from_file_tree(file_tree)
     }
 
@@ -349,9 +339,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     " #{@folder_open} #{project_name}/"
   end
 
-  @spec status_from_file_tree(FileTreeState.t() | map()) :: FileTreeState.tree_status()
+  @spec status_from_file_tree(FileTreeState.t()) :: FileTreeState.tree_status()
   defp status_from_file_tree(%FileTreeState{} = file_tree), do: FileTreeState.status(file_tree)
-  defp status_from_file_tree(_file_tree), do: :ready
 
   @spec active_buffer_path(EditorState.t() | map()) :: String.t() | nil
   defp active_buffer_path(%{workspace: %{buffers: %{active: nil}}}), do: nil
@@ -1109,13 +1098,12 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   end
 
   # Computes the tree rect from workspace data without requiring EditorState.
-  @spec tree_rect_from_workspace(map()) :: MingaEditor.WindowTree.rect() | nil
-  defp tree_rect_from_workspace(%{file_tree: %{tree: nil}}), do: nil
-
-  defp tree_rect_from_workspace(%{
-         viewport: %{rows: rows},
-         file_tree: %{tree: %Minga.Project.FileTree{width: tw}}
+  @spec tree_rect_from_workspace(map(), FileTreeState.t()) :: MingaEditor.WindowTree.rect() | nil
+  defp tree_rect_from_workspace(%{viewport: %{rows: rows}}, %FileTreeState{
+         tree: %Minga.Project.FileTree{width: tw}
        }) do
     {1, 0, tw, rows - 2}
   end
+
+  defp tree_rect_from_workspace(_workspace, %FileTreeState{}), do: nil
 end

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.Startup do
   alias MingaEditor.Agent.BufferSync, as: AgentBufferSync
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer
+  alias Minga.Log
   alias Minga.Config
   alias MingaEditor.Commands
   alias MingaEditor.FileTree.Feature, as: FileTreeFeature
@@ -107,7 +108,14 @@ defmodule MingaEditor.Startup do
     project_root = project_root_from_opts(opts)
 
     file_tree = %MingaEditor.State.FileTree{project_root: project_root}
-    FileTreeFeature.register_contributions(file_tree)
+
+    case FileTreeFeature.register_contributions(file_tree) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Log.warning(:editor, "FileTree contribution registration failed: #{inspect(reason)}")
+    end
 
     workspace =
       %MingaEditor.Session.State{

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -15,6 +15,7 @@ defmodule MingaEditor.Startup do
   alias Minga.Buffer
   alias Minga.Config
   alias MingaEditor.Commands
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.FileWatcherHelpers
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
@@ -105,24 +106,28 @@ defmodule MingaEditor.Startup do
 
     project_root = project_root_from_opts(opts)
 
-    workspace = %MingaEditor.Session.State{
-      buffers: %Buffers{
-        active: active_buf,
-        list: buffers,
-        active_index: 0,
-        messages: messages_buf
-      },
-      viewport: Viewport.new(height, width),
-      editing: VimState.new(),
-      windows: %Windows{
-        tree: WindowTree.new(initial_window_id),
-        map: windows,
-        active: initial_window_id,
-        next_id: initial_window_id + 1
-      },
-      keymap_scope: keymap_scope,
-      file_tree: %MingaEditor.State.FileTree{project_root: project_root}
-    }
+    file_tree = %MingaEditor.State.FileTree{project_root: project_root}
+    FileTreeFeature.register_contributions(file_tree)
+
+    workspace =
+      %MingaEditor.Session.State{
+        buffers: %Buffers{
+          active: active_buf,
+          list: buffers,
+          active_index: 0,
+          messages: messages_buf
+        },
+        viewport: Viewport.new(height, width),
+        editing: VimState.new(),
+        windows: %Windows{
+          tree: WindowTree.new(initial_window_id),
+          map: windows,
+          active: initial_window_id,
+          next_id: initial_window_id + 1
+        },
+        keymap_scope: keymap_scope
+      }
+      |> MingaEditor.Session.State.set_file_tree(file_tree)
 
     editing_model =
       Keyword.get_lazy(opts, :editing_model, fn ->

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -35,6 +35,7 @@ defmodule MingaEditor.State do
 
   alias MingaEditor.BottomPanel
   alias MingaEditor.KeystrokeHistory
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Dired, as: DiredState
@@ -247,7 +248,15 @@ defmodule MingaEditor.State do
   @doc "Replaces the active workspace."
   @spec set_workspace(t(), SessionState.t()) :: t()
   def set_workspace(%__MODULE__{} = state, %SessionState{} = workspace) do
+    sync_file_tree_sidebar(workspace)
     %{state | workspace: workspace}
+  end
+
+  @spec sync_file_tree_sidebar(SessionState.t()) :: :ok
+  defp sync_file_tree_sidebar(%SessionState{} = workspace) do
+    workspace
+    |> SessionState.file_tree_state()
+    |> FileTreeFeature.sync_sidebar()
   end
 
   @doc "Returns source-owned feature state from the active workspace, or nil when inactive."
@@ -314,18 +323,40 @@ defmodule MingaEditor.State do
     update_workspace(state, &SessionState.set_keymap_scope(&1, scope))
   end
 
-  @doc "Replaces the active workspace file-tree state."
+  @doc "Returns the active workspace FileTree feature state."
+  @spec file_tree_state(t() | map()) :: FileTreeState.t()
+  def file_tree_state(%__MODULE__{workspace: workspace}) do
+    SessionState.file_tree_state(workspace)
+  end
+
+  def file_tree_state(%{workspace: %SessionState{} = workspace}) do
+    SessionState.file_tree_state(workspace)
+  end
+
+  def file_tree_state(%{__struct__: MingaEditor.RenderPipeline.Input} = input) do
+    MingaEditor.RenderPipeline.Input.file_tree_state(input)
+  end
+
+  def file_tree_state(_state), do: %FileTreeState{}
+
+  @doc "Replaces the active workspace FileTree feature state."
   @spec set_file_tree(t(), FileTreeState.t()) :: t()
   def set_file_tree(%__MODULE__{} = state, %FileTreeState{} = file_tree) do
+    FileTreeFeature.sync_sidebar(file_tree)
     update_workspace(state, &SessionState.set_file_tree(&1, file_tree))
   end
 
-  @doc "Updates the active workspace file-tree state."
+  @doc "Updates the active workspace FileTree feature state."
   @spec update_file_tree(t(), (FileTreeState.t() -> FileTreeState.t())) :: t()
   def update_file_tree(%__MODULE__{} = state, fun) when is_function(fun, 1) do
-    update_workspace(state, fn workspace ->
-      SessionState.set_file_tree(workspace, fun.(workspace.file_tree))
-    end)
+    set_file_tree(state, fun.(file_tree_state(state)))
+  end
+
+  @doc "Drops the active workspace FileTree feature state."
+  @spec drop_file_tree(t()) :: t()
+  def drop_file_tree(%__MODULE__{} = state) do
+    FileTreeFeature.sync_sidebar(%FileTreeState{})
+    update_workspace(state, &SessionState.drop_file_tree/1)
   end
 
   @doc "Replaces the active workspace buffer state."
@@ -1287,31 +1318,31 @@ defmodule MingaEditor.State do
   minibuffer row and reserving space for the file tree panel when open.
   """
   @spec screen_rect(t()) :: WindowTree.rect()
-  def screen_rect(%__MODULE__{terminal_viewport: vp, workspace: %{file_tree: %{tree: nil}}}) do
-    {0, 0, vp.cols, vp.rows - 1}
-  end
+  def screen_rect(%__MODULE__{terminal_viewport: vp} = state) do
+    case file_tree_state(state).tree do
+      %FileTree{width: tw} ->
+        # Tree occupies columns 0..tw-1, separator at column tw,
+        # editor content starts at column tw+1.
+        editor_col = tw + 1
+        editor_width = max(vp.cols - editor_col, 1)
+        {0, editor_col, editor_width, vp.rows - 1}
 
-  def screen_rect(%__MODULE__{
-        terminal_viewport: vp,
-        workspace: %{file_tree: %{tree: %FileTree{width: tw}}}
-      }) do
-    # Tree occupies columns 0..tw-1, separator at column tw,
-    # editor content starts at column tw+1.
-    editor_col = tw + 1
-    editor_width = max(vp.cols - editor_col, 1)
-    {0, editor_col, editor_width, vp.rows - 1}
+      nil ->
+        {0, 0, vp.cols, vp.rows - 1}
+    end
   end
 
   @doc "Returns the screen rect for the file tree panel, or nil if closed."
   @spec tree_rect(t()) :: WindowTree.rect() | nil
-  def tree_rect(%__MODULE__{workspace: %{file_tree: %{tree: nil}}}), do: nil
+  def tree_rect(%__MODULE__{terminal_viewport: vp} = state) do
+    case file_tree_state(state).tree do
+      %FileTree{width: tw} ->
+        # Row 0 is the tab bar; file tree starts at row 1.
+        {1, 0, tw, vp.rows - 2}
 
-  def tree_rect(%__MODULE__{
-        terminal_viewport: vp,
-        workspace: %{file_tree: %{tree: %FileTree{width: tw}}}
-      }) do
-    # Row 0 is the tab bar; file tree starts at row 1.
-    {1, 0, tw, vp.rows - 2}
+      nil ->
+        nil
+    end
   end
 
   # ── Cross-cutting window + buffer helpers ─────────────────────────────────
@@ -1432,7 +1463,7 @@ defmodule MingaEditor.State do
 
   @spec buffer_file_ref(pid(), SessionState.t()) :: FileRef.t() | nil
   defp buffer_file_ref(buffer_pid, %SessionState{} = workspace) do
-    case {buffer_path(buffer_pid), workspace.file_tree.project_root} do
+    case {buffer_path(buffer_pid), SessionState.file_tree_state(workspace).project_root} do
       {path, root} when is_binary(path) and is_binary(root) ->
         case FileRef.from_path(root, path) do
           {:ok, file_ref} -> file_ref
@@ -1507,7 +1538,11 @@ defmodule MingaEditor.State do
         context
       )
 
-    state = %{state | shell_state: shell_state, workspace: workspace, buffer_add_context: :open}
+    state =
+      state
+      |> update_shell_state(fn _ -> shell_state end)
+      |> set_workspace(workspace)
+      |> Map.put(:buffer_add_context, :open)
 
     effects = if already_pooled, do: [], else: [{:monitor, pid}]
     {state, effects ++ shell_effects}
@@ -1544,7 +1579,11 @@ defmodule MingaEditor.State do
         {shell_state, workspace, shell_effects} =
           state.shell.on_buffer_switched(state.shell_state, state.workspace)
 
-        state = %{state | shell_state: shell_state, workspace: workspace}
+        state =
+          state
+          |> update_shell_state(fn _ -> shell_state end)
+          |> set_workspace(workspace)
+
         apply_buffer_effects(state, shell_effects)
     end
   end
@@ -1707,7 +1746,7 @@ defmodule MingaEditor.State do
       end
 
     state
-    |> Map.put(:workspace, SessionState.restore_tab_context(state.workspace, context))
+    |> set_workspace(SessionState.restore_tab_context(state.workspace, context))
     |> sync_agent_ui_from_active_workspace()
   end
 
@@ -1770,7 +1809,6 @@ defmodule MingaEditor.State do
         active_index: state.workspace.buffers.active_index
       },
       windows: windows,
-      file_tree: %FileTreeState{project_root: state.workspace.file_tree.project_root},
       dired: %DiredState{},
       viewport: state.terminal_viewport,
       mouse: %Mouse{},
@@ -1799,7 +1837,6 @@ defmodule MingaEditor.State do
         active_index: 0
       },
       windows: windows,
-      file_tree: %FileTreeState{project_root: state.workspace.file_tree.project_root},
       dired: %DiredState{},
       viewport: state.terminal_viewport,
       mouse: %Mouse{},
@@ -1969,7 +2006,7 @@ defmodule MingaEditor.State do
          %__MODULE__{workspace: %{keymap_scope: :agent} = workspace},
          agent_ui
        ) do
-    UIState.activate(agent_ui, workspace.windows, workspace.file_tree)
+    UIState.activate(agent_ui, workspace.windows, SessionState.file_tree_state(workspace))
   end
 
   defp maybe_activate_synced_agent_ui(%__MODULE__{}, agent_ui) do

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -248,15 +248,16 @@ defmodule MingaEditor.State do
   @doc "Replaces the active workspace."
   @spec set_workspace(t(), SessionState.t()) :: t()
   def set_workspace(%__MODULE__{} = state, %SessionState{} = workspace) do
-    sync_file_tree_sidebar(workspace)
+    workspace |> SessionState.file_tree_state() |> sync_file_tree_sidebar()
     %{state | workspace: workspace}
   end
 
-  @spec sync_file_tree_sidebar(SessionState.t()) :: :ok
-  defp sync_file_tree_sidebar(%SessionState{} = workspace) do
-    workspace
-    |> SessionState.file_tree_state()
-    |> FileTreeFeature.sync_sidebar()
+  @spec sync_file_tree_sidebar(FileTreeState.t()) :: :ok
+  defp sync_file_tree_sidebar(%FileTreeState{} = file_tree) do
+    case FileTreeFeature.sync_sidebar(file_tree) do
+      :ok -> :ok
+      {:error, reason} -> Log.warning(:editor, "FileTree sidebar sync failed: #{inspect(reason)}")
+    end
   end
 
   @doc "Returns source-owned feature state from the active workspace, or nil when inactive."
@@ -342,7 +343,7 @@ defmodule MingaEditor.State do
   @doc "Replaces the active workspace FileTree feature state."
   @spec set_file_tree(t(), FileTreeState.t()) :: t()
   def set_file_tree(%__MODULE__{} = state, %FileTreeState{} = file_tree) do
-    FileTreeFeature.sync_sidebar(file_tree)
+    sync_file_tree_sidebar(file_tree)
     update_workspace(state, &SessionState.set_file_tree(&1, file_tree))
   end
 
@@ -355,7 +356,7 @@ defmodule MingaEditor.State do
   @doc "Drops the active workspace FileTree feature state."
   @spec drop_file_tree(t()) :: t()
   def drop_file_tree(%__MODULE__{} = state) do
-    FileTreeFeature.sync_sidebar(%FileTreeState{})
+    sync_file_tree_sidebar(%FileTreeState{})
     update_workspace(state, &SessionState.drop_file_tree/1)
   end
 
@@ -1815,7 +1816,7 @@ defmodule MingaEditor.State do
       lsp_pending: %{},
       search: %Search{},
       editing: VimState.new(),
-      feature_state: FeatureState.new(),
+      feature_state: feature_state_with_file_tree_root(state),
       document_highlights: nil
     })
   end
@@ -1843,7 +1844,7 @@ defmodule MingaEditor.State do
       lsp_pending: %{},
       search: %Search{},
       editing: VimState.new(),
-      feature_state: FeatureState.new(),
+      feature_state: feature_state_with_file_tree_root(state),
       document_highlights: nil
     })
   end
@@ -1882,6 +1883,18 @@ defmodule MingaEditor.State do
   end
 
   defp build_agent_card_windows(_agent_buf, _rows, _cols), do: %Windows{}
+
+  @spec feature_state_with_file_tree_root(t()) :: FeatureState.t()
+  defp feature_state_with_file_tree_root(%__MODULE__{} = state) do
+    project_root = file_tree_state(state).project_root
+
+    FeatureState.put(
+      FeatureState.new(),
+      FileTreeFeature.source(),
+      FileTreeFeature.feature_id(),
+      %FileTreeState{project_root: project_root}
+    )
+  end
 
   @spec log_switch_tab(TabBar.t(), Tab.id(), Tab.id()) :: :ok
   defp log_switch_tab(tb, current_id, target_id) do

--- a/lib/minga_editor/state/tab/context.ex
+++ b/lib/minga_editor/state/tab/context.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.State.Tab.Context do
   alias Minga.Keymap.Scope
   alias MingaEditor.Agent.UIState
   alias MingaEditor.FeatureState
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Dired, as: DiredState
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -25,7 +26,6 @@ defmodule MingaEditor.State.Tab.Context do
     :keymap_scope,
     :buffers,
     :windows,
-    :file_tree,
     :dired,
     :viewport,
     :mouse,
@@ -45,7 +45,6 @@ defmodule MingaEditor.State.Tab.Context do
           :keymap_scope
           | :buffers
           | :windows
-          | :file_tree
           | :dired
           | :viewport
           | :mouse
@@ -70,7 +69,6 @@ defmodule MingaEditor.State.Tab.Context do
           keymap_scope: Scope.scope_name() | nil,
           buffers: Buffers.t() | nil,
           windows: Windows.t() | nil,
-          file_tree: FileTreeState.t() | nil,
           dired: DiredState.t() | nil,
           viewport: Viewport.t() | nil,
           mouse: Mouse.t() | nil,
@@ -89,7 +87,6 @@ defmodule MingaEditor.State.Tab.Context do
             keymap_scope: nil,
             buffers: nil,
             windows: nil,
-            file_tree: nil,
             dired: nil,
             viewport: nil,
             mouse: nil,
@@ -131,7 +128,6 @@ defmodule MingaEditor.State.Tab.Context do
       keymap_scope: ws.keymap_scope,
       buffers: ws.buffers,
       windows: ws.windows,
-      file_tree: ws.file_tree,
       dired: ws.dired,
       viewport: ws.viewport,
       mouse: ws.mouse,
@@ -157,12 +153,14 @@ defmodule MingaEditor.State.Tab.Context do
     context = %__MODULE__{version: fetch_version(map)}
     fields = filter_snapshot_fields(fetch_present_fields(map) || @snapshot_fields)
 
-    Enum.reduce(fields, context, fn field, acc ->
+    fields
+    |> Enum.reduce(context, fn field, acc ->
       case fetch_field(map, field) do
         {:ok, value} -> put_valid_field(acc, field, value)
         :error -> acc
       end
     end)
+    |> migrate_legacy_file_tree(map)
   end
 
   @doc "Returns a context with valid workspace field overrides applied."
@@ -209,6 +207,22 @@ defmodule MingaEditor.State.Tab.Context do
 
   defp scrub_context_buffer(%__MODULE__{} = context, _pid), do: context
 
+  @spec migrate_legacy_file_tree(t(), map()) :: t()
+  defp migrate_legacy_file_tree(%__MODULE__{} = context, map) do
+    case fetch_legacy_file_tree(map) do
+      {:ok, %FileTreeState{} = file_tree} ->
+        feature_state =
+          context.feature_state
+          |> Kernel.||(%FeatureState{})
+          |> FeatureState.put(FileTreeFeature.source(), FileTreeFeature.feature_id(), file_tree)
+
+        put_valid_field(context, :feature_state, feature_state)
+
+      _ ->
+        context
+    end
+  end
+
   @spec put_valid_field(t(), field_name(), term()) :: t()
   defp put_valid_field(%__MODULE__{} = context, field, value) do
     if valid_field?(field, value), do: put_field(context, field, value), else: context
@@ -237,7 +251,6 @@ defmodule MingaEditor.State.Tab.Context do
   defp valid_field?(:keymap_scope, _value), do: false
   defp valid_field?(:buffers, %Buffers{}), do: true
   defp valid_field?(:windows, %Windows{}), do: true
-  defp valid_field?(:file_tree, %FileTreeState{}), do: true
   defp valid_field?(:dired, %DiredState{}), do: true
   defp valid_field?(:viewport, %Viewport{}), do: true
   defp valid_field?(:mouse, %Mouse{}), do: true
@@ -295,6 +308,9 @@ defmodule MingaEditor.State.Tab.Context do
   @spec fetch_field(map(), field_name()) :: {:ok, term()} | :error
   defp fetch_field(map, :editing), do: fetch_any(map, [:editing, "editing", :vim, "vim"])
   defp fetch_field(map, field), do: fetch_any(map, [field, Atom.to_string(field)])
+
+  @spec fetch_legacy_file_tree(map()) :: {:ok, term()} | :error
+  defp fetch_legacy_file_tree(map), do: fetch_any(map, [:file_tree, "file_tree"])
 
   @spec fetch_any(map(), [atom() | String.t()]) :: {:ok, term()} | :error
   defp fetch_any(map, [key | rest]) do

--- a/lib/minga_editor/ui/picker/context.ex
+++ b/lib/minga_editor/ui/picker/context.ex
@@ -92,7 +92,7 @@ defmodule MingaEditor.UI.Picker.Context do
     %__MODULE__{
       buffers: state.workspace.buffers,
       editing: state.workspace.editing,
-      file_tree: Map.get(state.workspace, :file_tree),
+      file_tree: State.file_tree_state(state),
       search: state.workspace.search,
       viewport: state.terminal_viewport,
       tab_bar: state.shell_state.tab_bar,

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -258,9 +258,12 @@ defmodule MingaEditor.UI.Picker.FileSource do
   defp project_root(%Context{picker_ui: %{context: %{project_root: root}}}) when is_binary(root),
     do: root
 
-  defp project_root(%EditorState{workspace: %{file_tree: %{project_root: root}}})
-       when is_binary(root),
-       do: root
+  defp project_root(%EditorState{} = state) do
+    case EditorState.file_tree_state(state).project_root do
+      root when is_binary(root) -> root
+      _ -> Minga.Project.resolve_root()
+    end
+  end
 
   defp project_root(_ctx), do: Minga.Project.resolve_root()
 end

--- a/test/minga_editor/agent/event_routing_test.exs
+++ b/test/minga_editor/agent/event_routing_test.exs
@@ -268,10 +268,9 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       state = %EditorState{
         port_manager: self(),
         shell: Traditional,
-        workspace: %SessionState{
-          viewport: Viewport.new(24, 80),
-          file_tree: %FileTreeState{project_root: root}
-        },
+        workspace:
+          %SessionState{viewport: Viewport.new(24, 80)}
+          |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
         shell_state: %TraditionalState{agent: %AgentState{}, tab_bar: tb}
       }
 
@@ -317,10 +316,9 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       state = %EditorState{
         port_manager: self(),
         shell: Traditional,
-        workspace: %SessionState{
-          viewport: Viewport.new(24, 80),
-          file_tree: %FileTreeState{project_root: root}
-        },
+        workspace:
+          %SessionState{viewport: Viewport.new(24, 80)}
+          |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
         shell_state: %TraditionalState{agent: %AgentState{}, tab_bar: tb}
       }
 
@@ -362,10 +360,9 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       state = %EditorState{
         port_manager: self(),
         shell: Traditional,
-        workspace: %SessionState{
-          viewport: Viewport.new(24, 80),
-          file_tree: %FileTreeState{project_root: root}
-        },
+        workspace:
+          %SessionState{viewport: Viewport.new(24, 80)}
+          |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
         shell_state: %TraditionalState{agent: %AgentState{}, tab_bar: tb}
       }
 
@@ -393,10 +390,9 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       state = %EditorState{
         port_manager: self(),
         shell: Traditional,
-        workspace: %SessionState{
-          viewport: Viewport.new(24, 80),
-          file_tree: %FileTreeState{project_root: root}
-        },
+        workspace:
+          %SessionState{viewport: Viewport.new(24, 80)}
+          |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
         shell_state: %TraditionalState{agent: %AgentState{}, tab_bar: tb}
       }
 

--- a/test/minga_editor/agent_activation_test.exs
+++ b/test/minga_editor/agent_activation_test.exs
@@ -150,7 +150,7 @@ defmodule MingaEditor.AgentActivationTest do
       result = AgentActivation.deactivate(state)
 
       assert result.workspace.windows == windows
-      assert result.workspace.file_tree == file_tree
+      assert EditorState.file_tree_state(result) == file_tree
       assert result.workspace.keymap_scope == :file_tree
       assert AgentAccess.input_focused?(result) == true
     end

--- a/test/minga_editor/commands/file_tree_drop_test.exs
+++ b/test/minga_editor/commands/file_tree_drop_test.exs
@@ -37,12 +37,12 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       on_exit(fn -> File.rm_rf(external_root) end)
 
       state = open_file_tree(dir, events_registry)
-      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [external_file])
+      intent = drop_intent(ft(state).tree, target_dir, [external_file])
 
       state = Commands.FileTree.drop(state, intent)
 
       assert File.read!(Path.join(target_dir, "external.txt")) == "external"
-      assert state.workspace.file_tree.tree != nil
+      assert ft(state).tree != nil
     end
 
     test "copies an external file to the parent directory when dropped onto a file", %{
@@ -55,7 +55,7 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       on_exit(fn -> File.rm_rf(external_root) end)
 
       state = open_file_tree(dir, events_registry)
-      intent = drop_intent(state.workspace.file_tree.tree, target_file, [external_file])
+      intent = drop_intent(ft(state).tree, target_file, [external_file])
 
       _state = Commands.FileTree.drop(state, intent)
 
@@ -72,7 +72,7 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       File.mkdir_p!(target_dir)
 
       state = open_file_tree(dir, events_registry)
-      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [source_file])
+      intent = drop_intent(ft(state).tree, target_dir, [source_file])
 
       _state = Commands.FileTree.drop(state, intent)
 
@@ -92,7 +92,7 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       File.ln_s!(external_file, symlink_path)
 
       state = open_file_tree(dir, events_registry)
-      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [symlink_path])
+      intent = drop_intent(ft(state).tree, target_dir, [symlink_path])
 
       _state = Commands.FileTree.drop(state, intent)
 
@@ -113,7 +113,7 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       File.write!(target_file, "main")
 
       state = open_file_tree(dir, events_registry, target_file)
-      intent = drop_intent(state.workspace.file_tree.tree, target_file, [source_file])
+      intent = drop_intent(ft(state).tree, target_file, [source_file])
 
       _state = Commands.FileTree.drop(state, intent)
 
@@ -135,7 +135,7 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       state = open_file_tree(dir, events_registry)
 
       intent =
-        state.workspace.file_tree.tree
+        ft(state).tree
         |> drop_intent(target_dir, [external_file])
         |> Map.put(:target_id, "/project/stale-target")
 
@@ -156,7 +156,7 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       File.write!(existing_dest, "existing")
 
       state = open_file_tree(dir, events_registry)
-      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [source_file])
+      intent = drop_intent(ft(state).tree, target_dir, [source_file])
 
       _state = Commands.FileTree.drop(state, intent)
 
@@ -176,7 +176,7 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       File.ln_s!("missing.txt", dangling_dest)
 
       state = open_file_tree(dir, events_registry)
-      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [source_file])
+      intent = drop_intent(ft(state).tree, target_dir, [source_file])
 
       _state = Commands.FileTree.drop(state, intent)
 
@@ -197,7 +197,7 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       on_exit(fn -> File.rm_rf(external_root) end)
 
       state = open_file_tree(dir, events_registry)
-      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [external_file])
+      intent = drop_intent(ft(state).tree, target_dir, [external_file])
 
       _state = Commands.FileTree.drop(state, intent)
 
@@ -218,7 +218,7 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       File.write!(active_file, "main")
 
       state = open_file_tree(dir, events_registry, active_file)
-      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [source_dir])
+      intent = drop_intent(ft(state).tree, target_dir, [source_dir])
 
       _state = Commands.FileTree.drop(state, intent)
 
@@ -228,6 +228,8 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
     end
   end
 
+  defp ft(state), do: EditorState.file_tree_state(state)
+
   defp open_file_tree(dir, events_registry, active_file \\ nil) do
     tree = reveal_active_file(FileTree.new(dir), active_file)
     buffers = buffers_for_active_file(active_file, events_registry)
@@ -235,12 +237,9 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
     %EditorState{
       port_manager: self(),
       events_registry: events_registry,
-      workspace: %SessionState{
-        viewport: Viewport.new(24, 80),
-        buffers: buffers,
-        file_tree: FileTreeState.open(%FileTreeState{}, tree, nil),
-        keymap_scope: :file_tree
-      }
+      workspace:
+        %SessionState{viewport: Viewport.new(24, 80), buffers: buffers, keymap_scope: :file_tree}
+        |> SessionState.set_file_tree(FileTreeState.open(%FileTreeState{}, tree, nil))
     }
   end
 

--- a/test/minga_editor/commands/file_tree_editing_integration_test.exs
+++ b/test/minga_editor/commands/file_tree_editing_integration_test.exs
@@ -20,7 +20,7 @@ defmodule MingaEditor.Commands.FileTreeEditingIntegrationTest do
       _state = send_keys_sync(ctx, "a")
       state = send_keys_sync(ctx, "newfile.txt<Enter>")
 
-      assert state.workspace.file_tree.editing == nil
+      assert MingaEditor.State.file_tree_state(state).editing == nil
 
       expected = Path.join(dir, "newfile.txt")
       assert File.exists?(expected), "Expected newfile.txt to exist at #{expected}"
@@ -35,11 +35,11 @@ defmodule MingaEditor.Commands.FileTreeEditingIntegrationTest do
       _state = send_keys_sync(ctx, "<SPC>op")
       state = send_keys_sync(ctx, "A")
 
-      assert state.workspace.file_tree.editing.type == :new_folder
+      assert MingaEditor.State.file_tree_state(state).editing.type == :new_folder
 
       state = send_keys_sync(ctx, "newfolder<Enter>")
 
-      assert state.workspace.file_tree.editing == nil
+      assert MingaEditor.State.file_tree_state(state).editing == nil
 
       expected = Path.join(dir, "newfolder")
       assert File.dir?(expected), "Expected newfolder to exist at #{expected}"
@@ -53,10 +53,16 @@ defmodule MingaEditor.Commands.FileTreeEditingIntegrationTest do
 
       _state = send_keys_sync(ctx, "<SPC>op")
       state = send_keys_sync(ctx, "R")
-      backspaces = String.duplicate("<BS>", String.length(state.workspace.file_tree.editing.text))
+
+      backspaces =
+        String.duplicate(
+          "<BS>",
+          String.length(MingaEditor.State.file_tree_state(state).editing.text)
+        )
+
       state = send_keys_sync(ctx, "#{backspaces}renamed.txt<Enter>")
 
-      assert state.workspace.file_tree.editing == nil
+      assert MingaEditor.State.file_tree_state(state).editing == nil
 
       new_path = Path.join(dir, "renamed.txt")
       assert File.exists?(new_path), "Expected renamed.txt to exist"

--- a/test/minga_editor/commands/file_tree_editing_test.exs
+++ b/test/minga_editor/commands/file_tree_editing_test.exs
@@ -39,9 +39,9 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.new_file(state)
 
-      assert state.workspace.file_tree.editing != nil
-      assert state.workspace.file_tree.editing.type == :new_file
-      assert state.workspace.file_tree.editing.text == ""
+      assert ft(state).editing != nil
+      assert ft(state).editing.type == :new_file
+      assert ft(state).editing.text == ""
     end
 
     test "creates file on disk after confirming a typed name", %{
@@ -59,7 +59,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.confirm_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
 
       assert File.exists?(expected), "Expected newfile.txt to exist at #{expected}"
     end
@@ -71,8 +71,8 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.new_folder(state)
 
-      assert state.workspace.file_tree.editing != nil
-      assert state.workspace.file_tree.editing.type == :new_folder
+      assert ft(state).editing != nil
+      assert ft(state).editing.type == :new_folder
     end
 
     test "creates directory on disk after confirming a typed name", %{
@@ -87,7 +87,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.confirm_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
 
       expected = Path.join(dir, "newfolder")
       assert File.dir?(expected), "Expected newfolder to exist at #{expected}"
@@ -106,10 +106,10 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.rename(state)
 
-      assert state.workspace.file_tree.editing != nil
-      assert state.workspace.file_tree.editing.type == :rename
-      assert state.workspace.file_tree.editing.text == "target.txt"
-      assert state.workspace.file_tree.editing.original_name == "target.txt"
+      assert ft(state).editing != nil
+      assert ft(state).editing.type == :rename
+      assert ft(state).editing.text == "target.txt"
+      assert ft(state).editing.original_name == "target.txt"
     end
 
     test "renames file on disk after changing name", %{
@@ -128,7 +128,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.confirm_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
 
       new_path = Path.join(dir, "renamed.txt")
       assert File.exists?(new_path), "Expected renamed.txt to exist"
@@ -153,7 +153,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.confirm_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
       assert File.read!(file) == "content"
       assert File.read!(existing) == "existing"
     end
@@ -183,7 +183,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.confirm_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
       assert Buffer.file_path(buffer) == renamed
       assert Buffer.dirty?(buffer)
       assert File.read!(renamed) == "content"
@@ -252,12 +252,14 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
       state = %EditorState{
         port_manager: self(),
         events_registry: events_registry,
-        workspace: %SessionState{
-          viewport: Viewport.new(24, 80),
-          buffers: %Buffers{active: active_buffer, list: [active_buffer], active_index: 0},
-          file_tree:
+        workspace:
+          %SessionState{
+            viewport: Viewport.new(24, 80),
+            buffers: %Buffers{active: active_buffer, list: [active_buffer], active_index: 0}
+          }
+          |> SessionState.set_file_tree(
             FileTreeState.open(%FileTreeState{}, FileTree.new(dir) |> FileTree.refresh(), nil)
-        },
+          ),
         shell_state: %ShellState{tab_bar: tab_bar},
         focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
       }
@@ -270,7 +272,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.confirm_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
       assert Buffer.file_path(target_buffer) == renamed
       assert TabBar.active(state.shell_state.tab_bar).id == active_tab.id
       assert TabBar.get(state.shell_state.tab_bar, inactive_tab.id).file_ref == new_ref
@@ -302,7 +304,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.confirm_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
       assert File.exists?(renamed)
       refute File.exists?(file)
     end
@@ -329,7 +331,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.confirm_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
       assert Buffer.file_path(buffer) == file
       assert Buffer.dirty?(buffer)
       assert File.read!(file) == "content"
@@ -350,7 +352,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.cancel_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
 
       refute File.exists?(Path.join(dir, "partial")),
              "No file should be created when editing is cancelled"
@@ -361,7 +363,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.confirm_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
     end
 
     test "Backspace on empty text cancels editing through the file-tree input handler", %{
@@ -372,7 +374,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
     end
   end
 
@@ -392,7 +394,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       state = Commands.FileTree.confirm_editing(state)
 
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
       assert File.exists?(file), "File should still exist unchanged"
     end
   end
@@ -400,12 +402,13 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
   defp make_state(dir, events_registry, active_buffer \\ nil) do
     tree = FileTree.new(dir)
 
-    workspace = %SessionState{
-      viewport: Viewport.new(24, 80),
-      buffers: buffers_for_active_buffer(active_buffer),
-      file_tree: FileTreeState.open(%FileTreeState{}, tree, nil),
-      keymap_scope: :file_tree
-    }
+    workspace =
+      %SessionState{
+        viewport: Viewport.new(24, 80),
+        buffers: buffers_for_active_buffer(active_buffer),
+        keymap_scope: :file_tree
+      }
+      |> SessionState.set_file_tree(FileTreeState.open(%FileTreeState{}, tree, nil))
 
     {workspace, shell_state} =
       case active_buffer do
@@ -467,13 +470,15 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
   defp buffers_for_active_buffer(nil), do: %Buffers{}
   defp buffers_for_active_buffer(buffer) when is_pid(buffer), do: Buffers.add(%Buffers{}, buffer)
 
+  defp ft(state), do: EditorState.file_tree_state(state)
+
   defp replace_editing_text(%EditorState{} = state, text) when is_binary(text) do
-    ft = FileTreeState.update_editing_text(state.workspace.file_tree, text)
+    ft = FileTreeState.update_editing_text(ft(state), text)
     EditorState.set_file_tree(state, ft)
   end
 
   defp select_entry(%EditorState{} = state, name) when is_binary(name) do
-    tree = state.workspace.file_tree.tree
+    tree = ft(state).tree
     entries = FileTree.visible_entries(tree)
     index = Enum.find_index(entries, &(&1.name == name))
     assert index != nil, "Expected #{name} to be visible in the file tree"
@@ -482,7 +487,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
   end
 
   defp replace_tree(%EditorState{} = state, %FileTree{} = tree) do
-    ft = FileTreeState.replace_tree(state.workspace.file_tree, tree)
+    ft = FileTreeState.replace_tree(ft(state), tree)
     EditorState.set_file_tree(state, ft)
   end
 end

--- a/test/minga_editor/commands/file_tree_neo_bindings_test.exs
+++ b/test/minga_editor/commands/file_tree_neo_bindings_test.exs
@@ -63,7 +63,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
       state = state |> select_entry("dest") |> FileTreeCommands.paste()
 
       assert File.read!(Path.join(target_dir, "alpha.txt")) == "alpha"
-      assert state.workspace.file_tree.clipboard_mark.operation == :copy
+      assert ft(state).clipboard_mark.operation == :copy
     end
 
     @tag :tmp_dir
@@ -80,7 +80,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
       refute File.exists?(source)
       assert File.read!(Path.join(target_dir, "alpha.txt")) == "alpha"
-      assert state.workspace.file_tree.clipboard_mark == nil
+      assert ft(state).clipboard_mark == nil
     end
 
     @tag :tmp_dir
@@ -112,7 +112,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
       assert :ok = BufferProcess.save(buffer)
       assert File.read!(target) == "dirty"
-      assert state.workspace.file_tree.clipboard_mark == nil
+      assert ft(state).clipboard_mark == nil
     end
 
     @tag :tmp_dir
@@ -203,7 +203,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
       assert File.read!(source) == "source"
       assert File.read!(target) == "existing"
-      assert state.workspace.file_tree.clipboard_mark.operation == :move
+      assert ft(state).clipboard_mark.operation == :move
     end
 
     @tag :tmp_dir
@@ -224,7 +224,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
       refute File.exists?(Path.join(child_dir, "src"))
       assert File.exists?(source_dir)
-      assert state.workspace.file_tree.clipboard_mark.operation == :move
+      assert ft(state).clipboard_mark.operation == :move
     end
 
     @tag :tmp_dir
@@ -277,7 +277,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
       state = state |> select_entry("dest") |> FileTreeCommands.paste()
 
-      assert state.workspace.file_tree.clipboard_mark.operation == :move
+      assert ft(state).clipboard_mark.operation == :move
     end
 
     @tag :tmp_dir
@@ -297,7 +297,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
       state = state |> select_entry("child") |> FileTreeCommands.paste()
 
       refute File.exists?(Path.join(child_dir, "src"))
-      assert state.workspace.file_tree.clipboard_mark.operation == :copy
+      assert ft(state).clipboard_mark.operation == :copy
     end
 
     @tag :tmp_dir
@@ -353,7 +353,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
       assert :ok = BufferProcess.save(buffer)
       assert File.read!(target_file) == "dirty"
-      assert state.workspace.file_tree.clipboard_mark == nil
+      assert ft(state).clipboard_mark == nil
     end
 
     @tag :tmp_dir
@@ -395,8 +395,8 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
       state = FileTreeCommands.root_parent(state)
 
-      assert state.workspace.file_tree.tree.root == Path.expand(tmp_dir)
-      assert state.workspace.file_tree.original_root == Path.expand(child)
+      assert ft(state).tree.root == Path.expand(tmp_dir)
+      assert ft(state).original_root == Path.expand(child)
     end
 
     @tag :tmp_dir
@@ -410,10 +410,10 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
       state =
         tmp_dir |> build_state() |> select_entry("child") |> FileTreeCommands.root_selected()
 
-      assert state.workspace.file_tree.tree.root == Path.expand(child)
+      assert ft(state).tree.root == Path.expand(child)
 
       state = FileTreeCommands.root_original(state)
-      assert state.workspace.file_tree.tree.root == Path.expand(tmp_dir)
+      assert ft(state).tree.root == Path.expand(tmp_dir)
     end
   end
 
@@ -424,7 +424,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
       File.write!(Path.join(tmp_dir, "beta.txt"), "beta")
 
       state = tmp_dir |> build_state() |> FileTreeCommands.filter()
-      file_tree = FileTreeState.update_filter(state.workspace.file_tree, "alpha")
+      file_tree = FileTreeState.update_filter(ft(state), "alpha")
 
       assert file_tree.filtering == true
       assert Enum.map(FileTree.visible_entries(file_tree.tree), & &1.name) == ["alpha.txt"]
@@ -435,10 +435,10 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
       state = build_state(tmp_dir)
 
       state = FileTreeCommands.toggle_help(state)
-      assert state.workspace.file_tree.help_visible == true
+      assert ft(state).help_visible == true
 
       state = FileTreeCommands.toggle_help(state)
-      assert state.workspace.file_tree.help_visible == false
+      assert ft(state).help_visible == false
     end
   end
 
@@ -460,27 +460,27 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
     %EditorState{
       port_manager: nil,
-      workspace: %SessionState{
-        buffers: buffers,
-        viewport: Viewport.new(24, 80),
-        file_tree: FileTreeState.open(%FileTreeState{}, tree, nil)
-      }
+      workspace:
+        %SessionState{buffers: buffers, viewport: Viewport.new(24, 80)}
+        |> SessionState.set_file_tree(FileTreeState.open(%FileTreeState{}, tree, nil))
     }
   end
 
+  defp ft(state), do: EditorState.file_tree_state(state)
+
   defp expand_path(state, path) do
-    tree = FileTree.expand_path(state.workspace.file_tree.tree, path)
-    file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
+    tree = FileTree.expand_path(ft(state).tree, path)
+    file_tree = FileTreeState.replace_tree(ft(state), tree)
     EditorState.set_file_tree(state, file_tree)
   end
 
   defp select_entry(state, name) do
-    entries = FileTree.visible_entries(state.workspace.file_tree.tree)
+    entries = FileTree.visible_entries(ft(state).tree)
     index = Enum.find_index(entries, &(&1.name == name))
     refute index == nil
 
-    tree = FileTree.select(state.workspace.file_tree.tree, index)
-    file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
+    tree = FileTree.select(ft(state).tree, index)
+    file_tree = FileTreeState.replace_tree(ft(state), tree)
     EditorState.set_file_tree(state, file_tree)
   end
 end

--- a/test/minga_editor/commands/file_tree_reveal_test.exs
+++ b/test/minga_editor/commands/file_tree_reveal_test.exs
@@ -28,7 +28,7 @@ defmodule MingaEditor.Commands.FileTreeRevealTest do
   # can point to a different entry if concurrent tests create/delete
   # files that shift the sort order before this assertion runs.
   defp assert_file_visible(state, file_path) do
-    tree = state.workspace.file_tree.tree
+    tree = MingaEditor.State.file_tree_state(state).tree
     expanded_path = Path.expand(file_path)
     entries = FileTree.visible_entries(tree)
 
@@ -81,7 +81,9 @@ defmodule MingaEditor.Commands.FileTreeRevealTest do
       # Check cursor integer directly (no filesystem rescan) to verify
       # gg worked before testing reveal.
       state = send_keys_sync(ctx, "gg")
-      assert state.workspace.file_tree.tree.cursor == 0, "gg should move cursor to top"
+
+      assert MingaEditor.State.file_tree_state(state).tree.cursor == 0,
+             "gg should move cursor to top"
 
       # Reveal without closing: this exercises the ensure_tree_open pass-through
       state = send_keys_sync(ctx, "<SPC>or")

--- a/test/minga_editor/commands/inline_ask_test.exs
+++ b/test/minga_editor/commands/inline_ask_test.exs
@@ -184,17 +184,18 @@ defmodule MingaEditor.Commands.InlineAskTest do
 
     state = %EditorState{
       port_manager: self(),
-      workspace: %SessionState{
-        viewport: Viewport.new(24, 80),
-        file_tree: %FileTreeState{project_root: root},
-        buffers: %Buffers{active: buffer, list: [buffer], active_index: 0},
-        windows: %Windows{
-          tree: WindowTree.new(1),
-          map: %{1 => Window.new(1, buffer, 24, 80)},
-          active: 1,
-          next_id: 2
+      workspace:
+        %SessionState{
+          viewport: Viewport.new(24, 80),
+          buffers: %Buffers{active: buffer, list: [buffer], active_index: 0},
+          windows: %Windows{
+            tree: WindowTree.new(1),
+            map: %{1 => Window.new(1, buffer, 24, 80)},
+            active: 1,
+            next_id: 2
+          }
         }
-      },
+        |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
       shell_state: %TraditionalState{
         tab_bar: TabBar.new(Tab.new_file(1, Path.basename(rel_path)), root)
       }

--- a/test/minga_editor/commands/inline_edit_test.exs
+++ b/test/minga_editor/commands/inline_edit_test.exs
@@ -181,17 +181,18 @@ defmodule MingaEditor.Commands.InlineEditTest do
 
     state = %EditorState{
       port_manager: self(),
-      workspace: %SessionState{
-        viewport: Viewport.new(24, 80),
-        file_tree: %FileTreeState{project_root: root},
-        buffers: %Buffers{active: buffer, list: [buffer], active_index: 0},
-        windows: %Windows{
-          tree: WindowTree.new(1),
-          map: %{1 => Window.new(1, buffer, 24, 80)},
-          active: 1,
-          next_id: 2
+      workspace:
+        %SessionState{
+          viewport: Viewport.new(24, 80),
+          buffers: %Buffers{active: buffer, list: [buffer], active_index: 0},
+          windows: %Windows{
+            tree: WindowTree.new(1),
+            map: %{1 => Window.new(1, buffer, 24, 80)},
+            active: 1,
+            next_id: 2
+          }
         }
-      },
+        |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
       shell_state: %TraditionalState{
         tab_bar: TabBar.new(Tab.new_file(1, Path.basename(rel_path)), root)
       }

--- a/test/minga_editor/extension/sidebar_gui_emit_test.exs
+++ b/test/minga_editor/extension/sidebar_gui_emit_test.exs
@@ -4,9 +4,11 @@ defmodule MingaEditor.Extension.SidebarGUIEmitTest do
 
   alias Minga.Project.FileTree
   alias MingaEditor.Extension.Sidebar
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.Frontend.Emit.GUI, as: EmitGUI
   alias MingaEditor.Renderer.Caches
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.StatusBar.Data, as: StatusBarData
 
@@ -24,7 +26,8 @@ defmodule MingaEditor.Extension.SidebarGUIEmitTest do
     File.write!(Path.join(root, "a.ex"), "")
 
     file_tree = FileTreeState.open(%FileTreeState{}, FileTree.new(root, width: 32), nil)
-    state = gui_state() |> put_in([Access.key(:workspace), Access.key(:file_tree)], file_tree)
+    state = gui_state() |> EditorState.set_file_tree(file_tree)
+    FileTreeFeature.sync_sidebar(%FileTreeState{})
 
     assert :ok =
              Sidebar.register({:extension, :outline}, %{
@@ -115,5 +118,6 @@ defmodule MingaEditor.Extension.SidebarGUIEmitTest do
 
   defp reset_default_sidebar_table do
     Sidebar.unregister_source({:extension, :outline})
+    Sidebar.unregister_source(:builtin)
   end
 end

--- a/test/minga_editor/extension/sidebar_integration_test.exs
+++ b/test/minga_editor/extension/sidebar_integration_test.exs
@@ -158,7 +158,7 @@ defmodule MingaEditor.Extension.SidebarIntegrationTest do
                ]
              })
 
-    sidebar = SidebarRenderer.active_sidebar()
+    sidebar = SidebarRenderer.active_sidebar(state)
     draws = SidebarRenderer.render(state, {1, 0, 25, 10}, sidebar)
     texts = Enum.map(draws, fn {_row, _col, text, _face} -> String.trim(text) end)
 

--- a/test/minga_editor/file_tree/feature_test.exs
+++ b/test/minga_editor/file_tree/feature_test.exs
@@ -13,6 +13,13 @@ defmodule MingaEditor.FileTree.FeatureTest do
   import MingaEditor.RenderPipeline.TestHelpers
 
   setup do
+    Sidebar.unregister_source(:builtin)
+
+    on_exit(fn ->
+      Sidebar.unregister_source(:builtin)
+      Input.reset_handlers()
+    end)
+
     :ok
   end
 
@@ -28,22 +35,21 @@ defmodule MingaEditor.FileTree.FeatureTest do
              file_tree
   end
 
-  test "FileTree dynamic handler uses an extension-owned source that can unregister safely" do
-    source = {:extension, :file_tree_feature_test}
+  test "FileTree dynamic handler uses a built-in source that extension cleanup cannot remove" do
+    Input.reset_handlers()
+    :ok = FileTreeFeature.register_contributions(%FileTreeState{})
 
-    before_handlers = Input.surface_handlers(%{editing_model: Minga.Editing.Model.Vim})
-    before_count = Enum.count(before_handlers, &(&1 == MingaEditor.Input.FileTreeHandler))
-
-    :ok = Input.register_handler(source, MingaEditor.Input.FileTreeHandler, priority: 50)
     handlers = Input.surface_handlers(%{editing_model: Minga.Editing.Model.Vim})
 
-    assert FileTreeFeature.input_source() == {:extension, :file_tree}
-    assert Enum.count(handlers, &(&1 == MingaEditor.Input.FileTreeHandler)) == before_count + 1
+    assert FileTreeFeature.input_source() == :builtin
+    assert Enum.count(handlers, &(&1 == MingaEditor.Input.FileTreeHandler)) == 1
 
-    :ok = Input.unregister_source(source)
+    :ok = Input.unregister_source({:extension, :file_tree})
     handlers = Input.surface_handlers(%{editing_model: Minga.Editing.Model.Vim})
 
-    assert Enum.count(handlers, &(&1 == MingaEditor.Input.FileTreeHandler)) == before_count
+    assert Enum.count(handlers, &(&1 == MingaEditor.Input.FileTreeHandler)) == 1
+  after
+    Input.reset_handlers()
   end
 
   test "layout uses FileTree sidebar registry visibility and width" do

--- a/test/minga_editor/file_tree/feature_test.exs
+++ b/test/minga_editor/file_tree/feature_test.exs
@@ -1,0 +1,90 @@
+defmodule MingaEditor.FileTree.FeatureTest do
+  # Mutates global input/sidebar registries.
+  use ExUnit.Case, async: false
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.Extension.Sidebar
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
+  alias MingaEditor.Input
+  alias MingaEditor.Shell.Traditional.Layout.TUI, as: LayoutTUI
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  setup do
+    :ok
+  end
+
+  test "FileTree state is stored through feature-state accessors" do
+    workspace = %MingaEditor.Session.State{viewport: MingaEditor.Viewport.new(24, 80)}
+    file_tree = %FileTreeState{project_root: "/tmp/project"}
+
+    workspace = MingaEditor.Session.State.set_file_tree(workspace, file_tree)
+
+    assert MingaEditor.Session.State.file_tree_state(workspace) == file_tree
+
+    assert MingaEditor.Session.State.get_feature_state(workspace, :builtin, :file_tree) ==
+             file_tree
+  end
+
+  test "FileTree dynamic handler uses an extension-owned source that can unregister safely" do
+    source = {:extension, :file_tree_feature_test}
+
+    before_handlers = Input.surface_handlers(%{editing_model: Minga.Editing.Model.Vim})
+    before_count = Enum.count(before_handlers, &(&1 == MingaEditor.Input.FileTreeHandler))
+
+    :ok = Input.register_handler(source, MingaEditor.Input.FileTreeHandler, priority: 50)
+    handlers = Input.surface_handlers(%{editing_model: Minga.Editing.Model.Vim})
+
+    assert FileTreeFeature.input_source() == {:extension, :file_tree}
+    assert Enum.count(handlers, &(&1 == MingaEditor.Input.FileTreeHandler)) == before_count + 1
+
+    :ok = Input.unregister_source(source)
+    handlers = Input.surface_handlers(%{editing_model: Minga.Editing.Model.Vim})
+
+    assert Enum.count(handlers, &(&1 == MingaEditor.Input.FileTreeHandler)) == before_count
+  end
+
+  test "layout uses FileTree sidebar registry visibility and width" do
+    state = base_state(cols: 80, rows: 24)
+    tree = FileTree.new(File.cwd!(), width: 26)
+    file_tree = %FileTreeState{} |> FileTreeState.open(tree, nil)
+
+    state = EditorState.set_file_tree(state, file_tree)
+    layout = LayoutTUI.compute(state)
+
+    assert {1, 0, 26, 21} = layout.file_tree
+    assert {1, 27, 53, 21} = layout.editor_area
+
+    state = EditorState.set_file_tree(state, FileTreeState.close(file_tree))
+    assert LayoutTUI.compute(state).file_tree == nil
+  end
+
+  test "workspace replacement re-syncs the active FileTree sidebar" do
+    state = base_state(cols: 80, rows: 24)
+    open_tree = %FileTreeState{} |> FileTreeState.open(FileTree.new(File.cwd!(), width: 24), nil)
+    open_workspace = MingaEditor.Session.State.set_file_tree(state.workspace, open_tree)
+
+    state = EditorState.set_workspace(state, open_workspace)
+    assert %{id: "file_tree", visible?: true, preferred_width: 24} = Sidebar.get("file_tree")
+
+    closed_workspace =
+      MingaEditor.Session.State.set_file_tree(state.workspace, FileTreeState.close(open_tree))
+
+    _state = EditorState.set_workspace(state, closed_workspace)
+    assert %{id: "file_tree", visible?: false} = Sidebar.get("file_tree")
+  end
+
+  test "dropping FileTree feature state is safe and toggle recreates it" do
+    state = base_state(cols: 80, rows: 24)
+    state = EditorState.set_file_tree(state, %FileTreeState{project_root: File.cwd!()})
+    state = EditorState.drop_file_tree(state)
+
+    assert EditorState.file_tree_state(state).tree == nil
+
+    state = MingaEditor.Commands.FileTree.toggle(state)
+
+    assert %FileTree{} = EditorState.file_tree_state(state).tree
+  end
+end

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -13,6 +13,7 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
   alias MingaEditor.MinibufferData
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Shell.Board.State, as: BoardState
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
@@ -116,10 +117,7 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
 
       first_state =
         gui_state()
-        |> put_in(
-          [Access.key(:workspace), Access.key(:file_tree), Access.key(:project_root)],
-          first_root
-        )
+        |> EditorState.update_file_tree(&%{&1 | project_root: first_root})
 
       {_ctx, caches, first_cmds} = sync_chrome(first_state)
       assert Enum.any?(first_cmds, &hidden_tree_cmd_for_root?(&1, first_root))
@@ -127,10 +125,7 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
 
       second_state =
         gui_state()
-        |> put_in(
-          [Access.key(:workspace), Access.key(:file_tree), Access.key(:project_root)],
-          second_root
-        )
+        |> EditorState.update_file_tree(&%{&1 | project_root: second_root})
 
       {_ctx, caches2, second_cmds} = sync_chrome(second_state, caches)
 
@@ -150,8 +145,8 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
       refute has_opcode?(cached_cmds, 0x93)
 
       moved_state =
-        put_in(
-          state.workspace.file_tree,
+        EditorState.set_file_tree(
+          state,
           FileTreeState.replace_tree(file_tree, FileTree.select(file_tree.tree, 42))
         )
 
@@ -437,7 +432,7 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
 
     file_path = Path.join(root, "file_001.ex")
     file_tree = FileTreeState.open(%FileTreeState{}, FileTree.new(root, width: 32), nil)
-    state = gui_state() |> put_in([Access.key(:workspace), Access.key(:file_tree)], file_tree)
+    state = gui_state() |> EditorState.set_file_tree(file_tree)
     {state, file_tree, file_path}
   end
 

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -162,7 +162,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
 
       {new_state, effects} = FileEventHandler.handle(state, event)
 
-      assert new_state.workspace.file_tree.tree.git_status[file_path] == :modified
+      assert ft(new_state).tree.git_status[file_path] == :modified
       assert {:render, 16} in effects
     end
   end
@@ -224,7 +224,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
           {:schedule_file_tree_refresh, 1_000}
         ])
 
-      first_ref = first_state.workspace.file_tree.refresh_timer
+      first_ref = ft(first_state).refresh_timer
 
       second_state =
         MingaEditor.Handlers.EffectHandler.apply_effects(first_state, [
@@ -232,7 +232,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
         ])
 
       assert is_reference(first_ref)
-      assert second_state.workspace.file_tree.refresh_timer == first_ref
+      assert ft(second_state).refresh_timer == first_ref
       Process.cancel_timer(first_ref)
     end
 
@@ -249,7 +249,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       {new_state, effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
 
       names =
-        new_state.workspace.file_tree.tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
+        ft(new_state).tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
 
       assert "beta.ex" in names
       refute FileTreeFreshness.refresh_scheduled?(new_state)
@@ -341,9 +341,9 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
         })
 
       names =
-        new_state.workspace.file_tree.tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
+        ft(new_state).tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
 
-      assert new_state.workspace.file_tree.project_root == Path.expand(new_root)
+      assert ft(new_state).project_root == Path.expand(new_root)
       assert "new.ex" in names
       refute "old.ex" in names
       assert {:render, 16} in effects
@@ -368,11 +368,12 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       old_ref = FileRef.from_buffer(buffer)
       {:ok, new_ref} = FileRef.from_path(root, path)
 
-      workspace = %SessionState{
-        viewport: Viewport.new(24, 80),
-        buffers: %Buffers{active: buffer, list: [buffer], active_index: 0},
-        file_tree: %FileTreeState{project_root: root}
-      }
+      workspace =
+        %SessionState{
+          viewport: Viewport.new(24, 80),
+          buffers: %Buffers{active: buffer, list: [buffer], active_index: 0}
+        }
+        |> SessionState.set_file_tree(%FileTreeState{project_root: root})
 
       tab =
         Tab.new_file(1, "scratch")
@@ -463,11 +464,12 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
 
       state = %EditorState{
         port_manager: self(),
-        workspace: %SessionState{
-          viewport: Viewport.new(24, 80),
-          file_tree: %FileTreeState{project_root: root},
-          buffers: %Buffers{active: active_buffer, list: [active_buffer], active_index: 0}
-        }
+        workspace:
+          %SessionState{
+            viewport: Viewport.new(24, 80),
+            buffers: %Buffers{active: active_buffer, list: [active_buffer], active_index: 0}
+          }
+          |> SessionState.set_file_tree(%FileTreeState{project_root: root})
       }
 
       state = EditorState.update_shell_state(state, fn _ -> %ShellState{tab_bar: tab_bar} end)
@@ -547,6 +549,8 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       assert effects == []
     end
   end
+
+  defp ft(state), do: EditorState.file_tree_state(state)
 
   defp state_with_tree(root) do
     tree = FileTree.new(root)

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -11,6 +11,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
   alias Minga.Events
   alias MingaEditor.Commands
   alias MingaEditor.Extension.Sidebar
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Handlers.GuiActionHandler
   alias MingaEditor.RenderPipeline.TestHelpers
@@ -23,7 +24,13 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
   setup do
     Sidebar.unregister_source({:extension, :gui_action_test})
-    on_exit(fn -> Sidebar.unregister_source({:extension, :gui_action_test}) end)
+    Sidebar.unregister_source(:builtin)
+
+    on_exit(fn ->
+      Sidebar.unregister_source({:extension, :gui_action_test})
+      Sidebar.unregister_source(:builtin)
+    end)
+
     :ok
   end
 
@@ -64,7 +71,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
     file_tree_active =
       GuiActionHandler.dispatch(state, {:sidebar_action, "file_tree", "renamed_kind", "activate"})
 
-    assert file_tree_active.workspace.file_tree.focused
+    assert EditorState.file_tree_state(file_tree_active).focused
     assert file_tree_active.workspace.keymap_scope == :file_tree
     assert EditorState.sidebar_active_id(file_tree_active) == "file_tree"
 
@@ -90,9 +97,37 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
         {:sidebar_action, "observatory", "observatory", "activate"}
       )
 
-    refute observatory_active.workspace.file_tree.focused
+    refute EditorState.file_tree_state(observatory_active).focused
     assert observatory_active.workspace.keymap_scope == :editor
     assert EditorState.sidebar_active_id(observatory_active) == "observatory"
+  end
+
+  test "native GUI file tree sidebar actions use the registered FileTree action handler" do
+    assert :ok = FileTreeFeature.register_contributions(%FileTreeState{})
+    state = TestHelpers.base_state()
+
+    opened =
+      GuiActionHandler.dispatch(state, {:sidebar_action, "file_tree", "file_tree", "toggle"})
+
+    assert EditorState.file_tree_state(opened).tree != nil
+    assert EditorState.file_tree_state(opened).focused
+    assert EditorState.sidebar_active_id(opened) == "file_tree"
+
+    focused =
+      GuiActionHandler.dispatch(
+        %{opened | workspace: %{opened.workspace | keymap_scope: :editor}},
+        {:sidebar_action, "file_tree", "file_tree", "activate"}
+      )
+
+    assert EditorState.file_tree_state(focused).focused
+    assert focused.workspace.keymap_scope == :file_tree
+    assert EditorState.sidebar_active_id(focused) == "file_tree"
+
+    closed =
+      GuiActionHandler.dispatch(focused, {:sidebar_action, "file_tree", "file_tree", "toggle"})
+
+    assert EditorState.file_tree_state(closed).tree == nil
+    assert EditorState.sidebar_active_id(closed) == nil
   end
 
   test "native GUI sidebar actions route to extension-owned sidebars" do
@@ -143,7 +178,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
     assert EditorState.sidebar_active_id(new_state) == "observatory"
     assert EditorState.observatory_visible?(new_state)
-    refute new_state.workspace.file_tree.focused
+    refute EditorState.file_tree_state(new_state).focused
     assert new_state.workspace.keymap_scope == :editor
   end
 

--- a/test/minga_editor/input/file_tree_editing_input_test.exs
+++ b/test/minga_editor/input/file_tree_editing_input_test.exs
@@ -14,6 +14,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
   @moduletag :tmp_dir
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.Viewport
@@ -34,23 +35,23 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
 
     %EditorState{
       port_manager: self(),
-      workspace: %MingaEditor.Session.State{
-        viewport: Viewport.new(24, 80),
-        file_tree: %FileTreeState{} |> FileTreeState.open(tree, buf),
-        keymap_scope: :file_tree
-      },
+      workspace:
+        %SessionState{viewport: Viewport.new(24, 80), keymap_scope: :file_tree}
+        |> SessionState.set_file_tree(%FileTreeState{} |> FileTreeState.open(tree, buf)),
       focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
     }
   end
+
+  defp ft(state), do: EditorState.file_tree_state(state)
 
   defp make_editing_state(tmp_dir, opts \\ []) do
     state = make_state(tmp_dir)
     type = Keyword.get(opts, :type, :new_file)
     text = Keyword.get(opts, :text, "")
-    index = state.workspace.file_tree.tree.cursor
+    index = ft(state).tree.cursor
 
-    ft = FileTreeState.start_editing(state.workspace.file_tree, index, type, text)
-    put_in(state.workspace.file_tree, ft)
+    file_tree = FileTreeState.start_editing(ft(state), index, type, text)
+    EditorState.set_file_tree(state, file_tree)
   end
 
   describe "printable character input" do
@@ -58,20 +59,20 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       state = make_editing_state(dir)
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?h, 0)
-      assert state.workspace.file_tree.editing.text == "h"
+      assert ft(state).editing.text == "h"
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?e, 0)
-      assert state.workspace.file_tree.editing.text == "he"
+      assert ft(state).editing.text == "he"
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?l, 0)
-      assert state.workspace.file_tree.editing.text == "hel"
+      assert ft(state).editing.text == "hel"
     end
 
     test "handles unicode codepoints", %{tmp_dir: dir} do
       state = make_editing_state(dir)
 
       {:handled, state} = FileTreeHandler.handle_key(state, 0x00E9, 0)
-      assert state.workspace.file_tree.editing.text == "é"
+      assert ft(state).editing.text == "é"
     end
   end
 
@@ -80,7 +81,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       state = make_editing_state(dir, text: "test.txt")
 
       {:handled, state} = FileTreeHandler.handle_key(state, @enter, 0)
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
     end
   end
 
@@ -89,7 +90,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       state = make_editing_state(dir, text: "partial")
 
       {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
     end
   end
 
@@ -98,21 +99,21 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       state = make_editing_state(dir, text: "abc")
 
       {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
-      assert state.workspace.file_tree.editing.text == "ab"
+      assert ft(state).editing.text == "ab"
     end
 
     test "cancels editing when text is empty", %{tmp_dir: dir} do
       state = make_editing_state(dir, text: "")
 
       {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
-      assert state.workspace.file_tree.editing == nil
+      assert ft(state).editing == nil
     end
 
     test "handles multi-byte unicode correctly", %{tmp_dir: dir} do
       state = make_editing_state(dir, text: "café")
 
       {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
-      assert state.workspace.file_tree.editing.text == "caf"
+      assert ft(state).editing.text == "caf"
     end
   end
 
@@ -133,10 +134,10 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       state = make_state(dir) |> select_entry("subdir")
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?., 0)
-      assert state.workspace.file_tree.tree.root == Path.join(dir, "subdir")
+      assert ft(state).tree.root == Path.join(dir, "subdir")
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?~, 0)
-      assert state.workspace.file_tree.tree.root == Path.expand(dir)
+      assert ft(state).tree.root == Path.expand(dir)
     end
   end
 
@@ -147,62 +148,62 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       state = make_state(dir)
       File.write!(Path.join(dir, "alpha.txt"), "alpha")
       File.write!(Path.join(dir, "beta.txt"), "beta")
-      tree = FileTree.refresh(state.workspace.file_tree.tree)
-      file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
+      tree = FileTree.refresh(ft(state).tree)
+      file_tree = FileTreeState.replace_tree(ft(state), tree)
 
       state =
         EditorState.set_file_tree(state, file_tree)
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
-      assert state.workspace.file_tree.filtering == true
+      assert ft(state).filtering == true
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?a, 0)
       {:handled, state} = FileTreeHandler.handle_key(state, ?l, 0)
-      assert state.workspace.file_tree.tree.filter == "al"
-      assert BufferProcess.content(state.workspace.file_tree.buffer) =~ "alpha.txt"
-      refute BufferProcess.content(state.workspace.file_tree.buffer) =~ "beta.txt"
+      assert ft(state).tree.filter == "al"
+      assert BufferProcess.content(ft(state).buffer) =~ "alpha.txt"
+      refute BufferProcess.content(ft(state).buffer) =~ "beta.txt"
 
-      assert Enum.map(FileTree.visible_entries(state.workspace.file_tree.tree), & &1.name) == [
+      assert Enum.map(FileTree.visible_entries(ft(state).tree), & &1.name) == [
                "alpha.txt"
              ]
 
       {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
-      assert state.workspace.file_tree.tree.filter == "a"
+      assert ft(state).tree.filter == "a"
 
       {:handled, state} = FileTreeHandler.handle_key(state, @enter, 0)
-      assert state.workspace.file_tree.filtering == false
-      assert state.workspace.file_tree.tree.filter == "a"
+      assert ft(state).filtering == false
+      assert ft(state).tree.filter == "a"
 
-      file_tree = FileTreeState.start_filtering(state.workspace.file_tree)
+      file_tree = FileTreeState.start_filtering(ft(state))
 
       state =
         EditorState.set_file_tree(state, file_tree)
 
       {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
-      assert state.workspace.file_tree.filtering == false
-      assert state.workspace.file_tree.tree.filter == nil
+      assert ft(state).filtering == false
+      assert ft(state).tree.filter == nil
     end
 
     test "/ while help is open starts filtering and hides help", %{tmp_dir: dir} do
       state = make_state(dir)
 
       {:handled, state} = FileTreeHandler.handle_key(state, ??, 0)
-      assert state.workspace.file_tree.help_visible == true
+      assert ft(state).help_visible == true
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
-      assert state.workspace.file_tree.help_visible == false
-      assert state.workspace.file_tree.filtering == true
+      assert ft(state).help_visible == false
+      assert ft(state).filtering == true
     end
 
     test "question mark while filtering shows help and exits filtering", %{tmp_dir: dir} do
       state = make_state(dir)
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
-      assert state.workspace.file_tree.filtering == true
+      assert ft(state).filtering == true
 
       {:handled, state} = FileTreeHandler.handle_key(state, ??, 0)
-      assert state.workspace.file_tree.help_visible == true
-      refute state.workspace.file_tree.filtering
+      assert ft(state).help_visible == true
+      refute ft(state).filtering
     end
   end
 
@@ -211,22 +212,22 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       state = make_state(dir)
 
       {:handled, state} = FileTreeHandler.handle_key(state, ??, 0)
-      assert state.workspace.file_tree.help_visible == true
+      assert ft(state).help_visible == true
 
       {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
-      assert state.workspace.file_tree.help_visible == false
-      assert state.workspace.file_tree.tree != nil
+      assert ft(state).help_visible == false
+      assert ft(state).tree != nil
     end
   end
 
   @spec select_entry(EditorState.t(), String.t()) :: EditorState.t()
   defp select_entry(state, name) do
-    entries = FileTree.visible_entries(state.workspace.file_tree.tree)
+    entries = FileTree.visible_entries(ft(state).tree)
     index = Enum.find_index(entries, &(&1.name == name))
     refute index == nil
 
-    tree = FileTree.select(state.workspace.file_tree.tree, index)
-    file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
+    tree = FileTree.select(ft(state).tree, index)
+    file_tree = FileTreeState.replace_tree(ft(state), tree)
 
     EditorState.set_file_tree(state, file_tree)
   end
@@ -236,7 +237,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       state = make_editing_state(dir, text: "test")
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?a, 0x02)
-      assert state.workspace.file_tree.editing.text == "test"
+      assert ft(state).editing.text == "test"
     end
 
     test "protocol special keys are swallowed during inline editing", %{tmp_dir: dir} do
@@ -258,8 +259,8 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
             0xF728
           ] do
         {:handled, state} = FileTreeHandler.handle_key(state, code, 0)
-        assert state.workspace.file_tree.editing.text == "test"
-        assert state.workspace.file_tree.editing.type == :new_file
+        assert ft(state).editing.text == "test"
+        assert ft(state).editing.type == :new_file
       end
     end
 
@@ -267,7 +268,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       state = make_state(dir)
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
-      assert state.workspace.file_tree.filtering == true
+      assert ft(state).filtering == true
 
       for code <- [
             57_348,
@@ -285,8 +286,8 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
             0xF728
           ] do
         {:handled, state} = FileTreeHandler.handle_key(state, code, 0)
-        assert state.workspace.file_tree.tree.filter == ""
-        assert state.workspace.file_tree.filtering == true
+        assert ft(state).tree.filter == ""
+        assert ft(state).filtering == true
       end
     end
 
@@ -294,43 +295,43 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       state = make_editing_state(dir, text: "test")
 
       {:handled, state} = FileTreeHandler.handle_key(state, 9, 0)
-      assert state.workspace.file_tree.editing.text == "test"
+      assert ft(state).editing.text == "test"
     end
 
     test "vim navigation keys append as text instead of moving cursor", %{tmp_dir: dir} do
       state = make_editing_state(dir)
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?j, 0)
-      assert state.workspace.file_tree.editing.text == "j"
+      assert ft(state).editing.text == "j"
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?k, 0)
-      assert state.workspace.file_tree.editing.text == "jk"
+      assert ft(state).editing.text == "jk"
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?d, 0)
-      assert state.workspace.file_tree.editing.text == "jkd"
+      assert ft(state).editing.text == "jkd"
     end
 
     test "help-visible navigation keys are swallowed without moving the buffer cursor", %{
       tmp_dir: dir
     } do
       state = make_state(dir)
-      buffer = state.workspace.file_tree.buffer
+      buffer = ft(state).buffer
       before = BufferProcess.cursor(buffer)
 
       {:handled, state} = FileTreeHandler.handle_key(state, ??, 0)
       {:handled, state} = FileTreeHandler.handle_key(state, ?j, 0)
 
-      assert state.workspace.file_tree.help_visible == true
+      assert ft(state).help_visible == true
       assert BufferProcess.cursor(buffer) == before
-      assert state.workspace.file_tree.tree.cursor == 0
+      assert ft(state).tree.cursor == 0
     end
 
     test "q appends to text instead of closing tree", %{tmp_dir: dir} do
       state = make_editing_state(dir)
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?q, 0)
-      assert state.workspace.file_tree.editing.text == "q"
-      assert state.workspace.file_tree.tree != nil
+      assert ft(state).editing.text == "q"
+      assert ft(state).tree != nil
     end
   end
 end

--- a/test/minga_editor/input/file_tree_nav_test.exs
+++ b/test/minga_editor/input/file_tree_nav_test.exs
@@ -4,12 +4,19 @@ defmodule MingaEditor.Input.FileTreeNavTest do
   @moduletag :tmp_dir
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.Viewport
   alias MingaEditor.Input.FileTreeHandler
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
+
+  setup do
+    FileTreeFeature.register_contributions()
+    :ok
+  end
 
   defp walk_surface_handlers(state, cp, mods) do
     Enum.reduce_while(MingaEditor.Input.surface_handlers(), {:passthrough, state}, fn handler,
@@ -30,27 +37,29 @@ defmodule MingaEditor.Input.FileTreeNavTest do
     tree = FileTree.new(tmp_dir)
     buf = BufferSync.start_buffer(tree)
 
+    workspace =
+      %SessionState{viewport: Viewport.new(24, 80), keymap_scope: :file_tree}
+      |> SessionState.set_file_tree(%FileTreeState{tree: tree, focused: true, buffer: buf})
+
     %EditorState{
       port_manager: self(),
-      workspace: %MingaEditor.Session.State{
-        viewport: Viewport.new(24, 80),
-        file_tree: %FileTreeState{tree: tree, focused: true, buffer: buf},
-        keymap_scope: :file_tree
-      },
+      workspace: workspace,
       focus_stack: [Scoped, MingaEditor.Input.ModeFSM]
     }
   end
 
+  defp ft(state), do: EditorState.file_tree_state(state)
+
   describe "vim navigation in file tree (via Scoped)" do
     test "j moves tree cursor down", %{tmp_dir: tmp_dir} do
       state = make_state(tmp_dir)
-      assert state.workspace.file_tree.tree.cursor == 0
+      assert ft(state).tree.cursor == 0
 
       {:handled, state} = walk_surface_handlers(state, ?j, 0)
-      assert state.workspace.file_tree.tree.cursor == 1
+      assert ft(state).tree.cursor == 1
 
       {:handled, state} = walk_surface_handlers(state, ?j, 0)
-      assert state.workspace.file_tree.tree.cursor == 2
+      assert ft(state).tree.cursor == 2
     end
 
     test "k moves tree cursor up", %{tmp_dir: tmp_dir} do
@@ -58,36 +67,36 @@ defmodule MingaEditor.Input.FileTreeNavTest do
       # Move down first
       {:handled, state} = walk_surface_handlers(state, ?j, 0)
       {:handled, state} = walk_surface_handlers(state, ?j, 0)
-      assert state.workspace.file_tree.tree.cursor == 2
+      assert ft(state).tree.cursor == 2
 
       {:handled, state} = walk_surface_handlers(state, ?k, 0)
-      assert state.workspace.file_tree.tree.cursor == 1
+      assert ft(state).tree.cursor == 1
     end
 
     test "q closes the file tree via scope resolution", %{tmp_dir: tmp_dir} do
       state = make_state(tmp_dir)
       {:handled, state} = walk_surface_handlers(state, ?q, 0)
-      assert state.workspace.file_tree.tree == nil
-      assert state.workspace.file_tree.focused == false
+      assert ft(state).tree == nil
+      assert ft(state).focused == false
       assert state.workspace.keymap_scope == :editor
     end
 
     test "Escape closes the file tree", %{tmp_dir: tmp_dir} do
       state = make_state(tmp_dir)
       {:handled, state} = walk_surface_handlers(state, 27, 0)
-      assert state.workspace.file_tree.tree == nil
+      assert ft(state).tree == nil
       assert state.workspace.keymap_scope == :editor
     end
 
     test "passthrough when tree not focused", %{tmp_dir: tmp_dir} do
       state = make_state(tmp_dir)
-      state = put_in(state.workspace.file_tree.focused, false)
+      state = EditorState.set_file_tree(state, %{ft(state) | focused: false})
       {:passthrough, _state} = FileTreeHandler.handle_key(state, ?j, 0)
     end
 
     test "tree cursor stays in bounds", %{tmp_dir: tmp_dir} do
       state = make_state(tmp_dir, 3)
-      entries = FileTree.visible_entries(state.workspace.file_tree.tree)
+      entries = FileTree.visible_entries(ft(state).tree)
       max_idx = length(entries) - 1
 
       # Move down past the end
@@ -97,18 +106,18 @@ defmodule MingaEditor.Input.FileTreeNavTest do
           new_acc
         end)
 
-      assert state.workspace.file_tree.tree.cursor <= max_idx
+      assert ft(state).tree.cursor <= max_idx
     end
 
     test "buffer cursor syncs with tree cursor after j/k", %{tmp_dir: tmp_dir} do
       state = make_state(tmp_dir)
-      buf = state.workspace.file_tree.buffer
+      buf = ft(state).buffer
 
       {:handled, state} = walk_surface_handlers(state, ?j, 0)
       {:handled, state} = walk_surface_handlers(state, ?j, 0)
 
       {buf_line, _col} = BufferProcess.cursor(buf)
-      assert buf_line == state.workspace.file_tree.tree.cursor
+      assert buf_line == ft(state).tree.cursor
     end
   end
 end

--- a/test/minga_editor/input/registry_test.exs
+++ b/test/minga_editor/input/registry_test.exs
@@ -47,6 +47,14 @@ defmodule MingaEditor.Input.RegistryTest do
              Enum.find_index(handlers, &(&1 == MingaEditor.Input.Dashboard))
   end
 
+  test "unregister_source(:builtin) preserves seeded built-in handlers" do
+    before = Input.surface_handlers(%{editing_model: Minga.Editing.Model.Vim})
+    assert :ok = Input.unregister_source(:builtin)
+    after_handlers = Input.surface_handlers(%{editing_model: Minga.Editing.Model.Vim})
+
+    assert after_handlers == before
+  end
+
   test "unregister_source removes extension-owned handlers without removing built-ins" do
     source = {:extension, :input_registry_test}
 

--- a/test/minga_editor/input/scoped_test.exs
+++ b/test/minga_editor/input/scoped_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.Input.ScopedTest do
   alias Minga.Buffer.Process, as: BufferProcess
 
   alias MingaEditor.Commands.Agent, as: AgentCommands
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.State, as: EditorState
   alias MingaAgent.RuntimeState
   alias MingaEditor.State.Agent, as: AgentState
@@ -25,6 +26,11 @@ defmodule MingaEditor.Input.ScopedTest do
   alias Minga.Mode
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
+
+  setup do
+    FileTreeFeature.register_contributions()
+    :ok
+  end
 
   defp base_state(opts) do
     {:ok, buf} = BufferProcess.start_link(content: "hello world")
@@ -540,14 +546,14 @@ defmodule MingaEditor.Input.ScopedTest do
       state = make_tree_state(tmp_dir)
       {:handled, new_state} = walk_surface_handlers(state, ?q, 0)
       assert new_state.workspace.keymap_scope == :editor
-      assert new_state.workspace.file_tree.tree == nil
+      assert ft(new_state).tree == nil
     end
 
     test "unbound key delegates to mode FSM for vim nav", %{tmp_dir: tmp_dir} do
       state = make_tree_state(tmp_dir)
       # j is not bound in file_tree scope (handled by mode FSM delegation)
       {:handled, new_state} = walk_surface_handlers(state, ?j, 0)
-      assert new_state.workspace.file_tree.tree.cursor == 1
+      assert ft(new_state).tree.cursor == 1
     end
 
     test "leader sequence in progress delegates to mode FSM", %{tmp_dir: tmp_dir} do
@@ -574,9 +580,9 @@ defmodule MingaEditor.Input.ScopedTest do
       File.write!(Path.join(tmp_dir, ".hidden"), "")
       state = make_tree_state(tmp_dir, 0)
 
-      entries_before = length(FileTree.visible_entries(state.workspace.file_tree.tree))
+      entries_before = length(FileTree.visible_entries(ft(state).tree))
       {:handled, new_state} = walk_surface_handlers(state, ?H, 0)
-      entries_after = length(FileTree.visible_entries(new_state.workspace.file_tree.tree))
+      entries_after = length(FileTree.visible_entries(ft(new_state).tree))
 
       assert entries_after != entries_before
     end
@@ -594,7 +600,7 @@ defmodule MingaEditor.Input.ScopedTest do
 
     test "file_tree scope with tree not focused passes through", %{tmp_dir: tmp_dir} do
       state = make_tree_state(tmp_dir)
-      state = put_in(state.workspace.file_tree.focused, false)
+      state = EditorState.set_file_tree(state, %{ft(state) | focused: false})
       assert {:passthrough, _} = FileTreeHandler.handle_key(state, ?q, 0)
     end
   end
@@ -838,6 +844,8 @@ defmodule MingaEditor.Input.ScopedTest do
     end)
   end
 
+  defp ft(state), do: EditorState.file_tree_state(state)
+
   defp walk_surface_mouse(state, row, col, button, mods, event_type, cc) do
     handlers =
       MingaEditor.Input.surface_handlers()
@@ -865,6 +873,6 @@ defmodule MingaEditor.Input.ScopedTest do
     buf = BufferSync.start_buffer(tree)
 
     state = base_state(keymap_scope: :file_tree)
-    put_in(state.workspace.file_tree, %FileTreeState{tree: tree, focused: true, buffer: buf})
+    EditorState.set_file_tree(state, %FileTreeState{tree: tree, focused: true, buffer: buf})
   end
 end

--- a/test/minga_editor/input/vim_nav_integration_test.exs
+++ b/test/minga_editor/input/vim_nav_integration_test.exs
@@ -15,7 +15,9 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
   @moduletag :tmp_dir
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.Viewport
   alias Minga.Project.FileTree
@@ -24,6 +26,8 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
   setup :verify_on_exit!
 
   setup do
+    FileTreeFeature.register_contributions()
+
     test_pid = self()
 
     stub(Minga.Clipboard.Mock, :write, fn text ->
@@ -46,6 +50,8 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
     end)
   end
 
+  defp ft(state), do: EditorState.file_tree_state(state)
+
   defp make_tree_state(tmp_dir, file_count \\ 10) do
     if file_count > 0 do
       for i <- 1..file_count do
@@ -61,11 +67,9 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
 
     %EditorState{
       port_manager: self(),
-      workspace: %MingaEditor.Session.State{
-        viewport: Viewport.new(24, 80),
-        file_tree: %FileTreeState{tree: tree, focused: true, buffer: buf},
-        keymap_scope: :file_tree
-      },
+      workspace:
+        %SessionState{viewport: Viewport.new(24, 80), keymap_scope: :file_tree}
+        |> SessionState.set_file_tree(%FileTreeState{tree: tree, focused: true, buffer: buf}),
       focus_stack: [Scoped, MingaEditor.Input.ModeFSM]
     }
   end
@@ -73,11 +77,11 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
   describe "file tree: gg and G motions" do
     test "G moves cursor to the last entry", %{tmp_dir: tmp_dir} do
       state = make_tree_state(tmp_dir)
-      entries = FileTree.visible_entries(state.workspace.file_tree.tree)
+      entries = FileTree.visible_entries(ft(state).tree)
       max_idx = length(entries) - 1
 
       {:handled, state} = walk_surface_handlers(state, ?G, 0)
-      assert state.workspace.file_tree.tree.cursor == max_idx
+      assert ft(state).tree.cursor == max_idx
     end
 
     test "gg moves cursor to the first entry", %{tmp_dir: tmp_dir} do
@@ -85,24 +89,24 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
 
       # First move to bottom
       {:handled, state} = walk_surface_handlers(state, ?G, 0)
-      assert state.workspace.file_tree.tree.cursor > 0
+      assert ft(state).tree.cursor > 0
 
       # Then gg to top (g enters prefix trie, second g triggers)
       {:handled, state} = walk_surface_handlers(state, ?g, 0)
       {:handled, state} = walk_surface_handlers(state, ?g, 0)
-      assert state.workspace.file_tree.tree.cursor == 0
+      assert ft(state).tree.cursor == 0
     end
   end
 
   describe "file tree: count prefix" do
     test "3j moves cursor down 3 entries", %{tmp_dir: tmp_dir} do
       state = make_tree_state(tmp_dir)
-      assert state.workspace.file_tree.tree.cursor == 0
+      assert ft(state).tree.cursor == 0
 
       # Type 3j
       {:handled, state} = walk_surface_handlers(state, ?3, 0)
       {:handled, state} = walk_surface_handlers(state, ?j, 0)
-      assert state.workspace.file_tree.tree.cursor == 3
+      assert ft(state).tree.cursor == 3
     end
   end
 
@@ -111,9 +115,9 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
       tmp_dir: tmp_dir
     } do
       state = make_tree_state(tmp_dir)
-      buf = state.workspace.file_tree.buffer
+      buf = ft(state).buffer
       content_before = BufferProcess.content(buf)
-      selected_path = FileTree.selected_entry(state.workspace.file_tree.tree).path
+      selected_path = FileTree.selected_entry(ft(state).tree).path
 
       {:handled, _state} = walk_surface_handlers(state, ?y, 0)
 
@@ -153,7 +157,7 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
       File.write!(Path.join(tmp_dir, "subdir/inner.txt"), "")
 
       state = make_tree_state(tmp_dir, 0)
-      tree = state.workspace.file_tree.tree
+      tree = ft(state).tree
       entries = FileTree.visible_entries(tree)
 
       # Find subdir entry
@@ -172,9 +176,9 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
           end
 
         # Press Tab to expand
-        entries_before = length(FileTree.visible_entries(state.workspace.file_tree.tree))
+        entries_before = length(FileTree.visible_entries(ft(state).tree))
         {:handled, state} = walk_surface_handlers(state, 9, 0)
-        entries_after = length(FileTree.visible_entries(state.workspace.file_tree.tree))
+        entries_after = length(FileTree.visible_entries(ft(state).tree))
 
         # Should have more entries after expanding
         assert entries_after > entries_before
@@ -186,10 +190,10 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
       File.write!(Path.join(tmp_dir, "visible.txt"), "")
 
       state = make_tree_state(tmp_dir, 0)
-      entries_default = FileTree.visible_entries(state.workspace.file_tree.tree)
+      entries_default = FileTree.visible_entries(ft(state).tree)
 
       {:handled, state} = walk_surface_handlers(state, ?H, 0)
-      entries_with_hidden = FileTree.visible_entries(state.workspace.file_tree.tree)
+      entries_with_hidden = FileTree.visible_entries(ft(state).tree)
 
       # Toggling hidden should change the entry count
       assert length(entries_with_hidden) != length(entries_default)
@@ -199,8 +203,8 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
       state = make_tree_state(tmp_dir)
 
       {:handled, state} = walk_surface_handlers(state, ?q, 0)
-      assert state.workspace.file_tree.tree == nil
-      assert state.workspace.file_tree.focused == false
+      assert ft(state).tree == nil
+      assert ft(state).focused == false
     end
   end
 
@@ -211,7 +215,7 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
       # Move down first so we can verify gg works
       {:handled, state} = walk_surface_handlers(state, ?j, 0)
       {:handled, state} = walk_surface_handlers(state, ?j, 0)
-      assert state.workspace.file_tree.tree.cursor == 2
+      assert ft(state).tree.cursor == 2
 
       # g should delegate to mode FSM (prefix trie)
       {:handled, state} = walk_surface_handlers(state, ?g, 0)
@@ -219,7 +223,7 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
 
       # second g should trigger gg (go to top)
       {:handled, state} = walk_surface_handlers(state, ?g, 0)
-      assert state.workspace.file_tree.tree.cursor == 0
+      assert ft(state).tree.cursor == 0
     end
   end
 end

--- a/test/minga_editor/integration/file_tree_test.exs
+++ b/test/minga_editor/integration/file_tree_test.exs
@@ -4,7 +4,8 @@ defmodule Minga.Integration.FileTreeTest do
 
   File tree data structure behavior belongs in lower-level project tests. This file keeps only the behavior that needs a live Editor, key routing, GUI actions, and a rendered screen.
   """
-  use Minga.Test.EditorCase, async: true
+  # Mutates the global built-in FileTree sidebar registry while rendering through live editors.
+  use Minga.Test.EditorCase, async: false
 
   alias Minga.Test.HeadlessPort
 

--- a/test/minga_editor/integration/mouse_test.exs
+++ b/test/minga_editor/integration/mouse_test.exs
@@ -4,7 +4,8 @@ defmodule Minga.Integration.MouseTest do
 
   Gesture details live in `MingaEditor.MouseTest` and `MingaEditor.MouseMultiClickTest`. This file keeps only the cases that need the full input router, shell state, renderer, or GUI action path.
   """
-  use Minga.Test.EditorCase, async: true
+  # Mutates the global built-in FileTree sidebar registry while rendering through live editors.
+  use Minga.Test.EditorCase, async: false
 
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree
@@ -79,7 +80,8 @@ defmodule Minga.Integration.MouseTest do
       send_mouse(ctx, 5, max(tree_sep - 2, 0), :left)
       state = editor_state(ctx)
 
-      assert FileTree.focused?(state.workspace.file_tree), "clicking file tree should focus it"
+      assert FileTree.focused?(EditorState.file_tree_state(state)),
+             "clicking file tree should focus it"
     end
   end
 

--- a/test/minga_editor/layout_invalidation_test.exs
+++ b/test/minga_editor/layout_invalidation_test.exs
@@ -10,7 +10,8 @@ defmodule MingaEditor.LayoutInvalidationTest do
   render after toggling the tree because the window's cached draws still
   had the old col_off=0 coordinates.
   """
-  use ExUnit.Case, async: true
+  # Mutates the global built-in FileTree sidebar registration while computing layout.
+  use ExUnit.Case, async: false
 
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
@@ -55,8 +56,14 @@ defmodule MingaEditor.LayoutInvalidationTest do
   end
 
   defp with_file_tree(state, width \\ 30) do
-    tree = %FileTree{root: "/tmp", width: width}
-    put_in(state.workspace.file_tree.tree, tree)
+    file_tree =
+      MingaEditor.State.FileTree.open(
+        %MingaEditor.State.FileTree{},
+        %FileTree{root: "/tmp", width: width},
+        nil
+      )
+
+    EditorState.set_file_tree(state, file_tree)
   end
 
   # ── Unit tests: invalidate_all_windows ─────────────────────────────────────
@@ -171,7 +178,8 @@ defmodule MingaEditor.LayoutInvalidationTest do
       assert col == 21
 
       # Close file tree and invalidate
-      state = put_in(state.workspace.file_tree.tree, nil) |> Layout.invalidate()
+      state =
+        EditorState.set_file_tree(state, %MingaEditor.State.FileTree{}) |> Layout.invalidate()
 
       layout = Layout.compute(state)
       assert layout.file_tree == nil

--- a/test/minga_editor/layout_test.exs
+++ b/test/minga_editor/layout_test.exs
@@ -1,5 +1,6 @@
 defmodule MingaEditor.LayoutTest do
-  use ExUnit.Case, async: true
+  # Mutates the global built-in FileTree sidebar registration while computing layout.
+  use ExUnit.Case, async: false
   use ExUnitProperties
 
   alias MingaEditor.Agent.UIState
@@ -45,8 +46,14 @@ defmodule MingaEditor.LayoutTest do
   end
 
   defp with_file_tree(state, width) do
-    tree = %FileTree{root: "/tmp", width: width}
-    put_in(state.workspace.file_tree.tree, tree)
+    file_tree =
+      MingaEditor.State.FileTree.open(
+        %MingaEditor.State.FileTree{},
+        %FileTree{root: "/tmp", width: width},
+        nil
+      )
+
+    EditorState.set_file_tree(state, file_tree)
   end
 
   defp with_agent_workspace(state) do

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -19,7 +19,7 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       assert input.workspace.viewport == state.workspace.viewport
       assert input.workspace.editing == state.workspace.editing
       assert input.workspace.highlight == state.workspace.highlight
-      assert input.workspace.file_tree == state.workspace.file_tree
+      assert input.workspace.file_tree == EditorState.file_tree_state(state)
       assert input.workspace.agent_ui == state.workspace.agent_ui
       assert input.workspace.document_highlights == state.workspace.document_highlights
       assert input.workspace.search == state.workspace.search

--- a/test/minga_editor/session/chrome_state_test.exs
+++ b/test/minga_editor/session/chrome_state_test.exs
@@ -183,12 +183,13 @@ defmodule MingaEditor.Session.ChromeStateTest do
     active_buffer = Keyword.get(opts, :active_buffer) || buffer_for_tab(TabBar.active(tb))
 
     %{
-      workspace: %SessionState{
-        viewport: Viewport.new(24, 80),
-        keymap_scope: :editor,
-        file_tree: %FileTreeState{project_root: project_root},
-        buffers: %Buffers{active: active_buffer, list: List.wrap(active_buffer)}
-      },
+      workspace:
+        %SessionState{
+          viewport: Viewport.new(24, 80),
+          keymap_scope: :editor,
+          buffers: %Buffers{active: active_buffer, list: List.wrap(active_buffer)}
+        }
+        |> SessionState.set_file_tree(%FileTreeState{project_root: project_root}),
       shell_state: %{tab_bar: tb}
     }
   end

--- a/test/minga_editor/shell/traditional/on_buffer_added_test.exs
+++ b/test/minga_editor/shell/traditional/on_buffer_added_test.exs
@@ -30,6 +30,27 @@ defmodule MingaEditor.Shell.Traditional.OnBufferAddedTest do
     %SessionState{viewport: Viewport.new(24, 80)}
   end
 
+  defp elem_insert(%TabBar{} = tab_bar, kind, label) do
+    {tab_bar, _tab} = TabBar.insert(tab_bar, kind, label)
+    tab_bar
+  end
+
+  describe "GUI tab actions" do
+    test "closing an inactive tab returns the two-tuple shell action contract" do
+      workspace = blank_workspace()
+
+      tab_bar =
+        TabBar.new(Tab.new_file(1, "one"), nil)
+        |> elem_insert(:file, "two")
+        |> TabBar.update_context(2, SessionState.to_tab_context(workspace))
+
+      shell_state = %ShellState{tab_bar: tab_bar}
+
+      assert {%ShellState{}, %SessionState{}} =
+               Traditional.handle_gui_action(shell_state, workspace, {:close_tab, 2})
+    end
+  end
+
   describe "file refs" do
     test "populates file refs when opening file tabs" do
       root = Path.join(System.tmp_dir!(), "minga-on-buffer-added")
@@ -38,11 +59,9 @@ defmodule MingaEditor.Shell.Traditional.OnBufferAddedTest do
       File.write!(path, "hello")
       buf = start_supervised!({BufferProcess, file_path: path})
 
-      workspace = %SessionState{
-        viewport: Viewport.new(24, 80),
-        buffers: %Buffers{active: buf, list: [buf]},
-        file_tree: %FileTreeState{project_root: root}
-      }
+      workspace =
+        %SessionState{viewport: Viewport.new(24, 80), buffers: %Buffers{active: buf, list: [buf]}}
+        |> SessionState.set_file_tree(%FileTreeState{project_root: root})
 
       shell_state = %ShellState{tab_bar: TabBar.new(Tab.new_file(1, "initial.ex"), root)}
 
@@ -60,11 +79,9 @@ defmodule MingaEditor.Shell.Traditional.OnBufferAddedTest do
       buf = start_supervised!({BufferProcess, content: "scratch", buffer_name: "*scratch*"})
       expected_ref = FileRef.from_buffer(buf)
 
-      workspace = %SessionState{
-        viewport: Viewport.new(24, 80),
-        buffers: %Buffers{active: buf, list: [buf]},
-        file_tree: %FileTreeState{project_root: root}
-      }
+      workspace =
+        %SessionState{viewport: Viewport.new(24, 80), buffers: %Buffers{active: buf, list: [buf]}}
+        |> SessionState.set_file_tree(%FileTreeState{project_root: root})
 
       shell_state = %ShellState{tab_bar: TabBar.new(Tab.new_file(1, "initial.ex"), root)}
 
@@ -87,11 +104,9 @@ defmodule MingaEditor.Shell.Traditional.OnBufferAddedTest do
       buf = start_supervised!({BufferProcess, file_path: path})
       expected_ref = FileRef.from_buffer(buf)
 
-      workspace = %SessionState{
-        viewport: Viewport.new(24, 80),
-        buffers: %Buffers{active: buf, list: [buf]},
-        file_tree: %FileTreeState{project_root: root}
-      }
+      workspace =
+        %SessionState{viewport: Viewport.new(24, 80), buffers: %Buffers{active: buf, list: [buf]}}
+        |> SessionState.set_file_tree(%FileTreeState{project_root: root})
 
       shell_state = %ShellState{tab_bar: TabBar.new(Tab.new_file(1, "initial.ex"), root)}
 

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -8,6 +8,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
   alias Minga.Project.FileTree
   alias MingaEditor.FileTree.Diagnostics, as: RowDiagnostics
   alias MingaEditor.FileTree.Row
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.Shell.Traditional.TreeRenderer
@@ -145,8 +147,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
 
       state =
         gui_state(rows: 10, cols: 80)
-        |> put_in(
-          [Access.key(:workspace), Access.key(:file_tree)],
+        |> EditorState.set_file_tree(
           FileTreeState.open(%FileTreeState{}, FileTree.new(tmp_dir, width: 32), nil)
         )
         |> put_in([Access.key(:workspace), Access.key(:buffers)], %Buffers{
@@ -463,11 +464,12 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
     cols = Keyword.fetch!(opts, :cols)
 
     %{
-      workspace: %{
-        file_tree: file_tree,
-        viewport: %{rows: rows, cols: cols},
-        buffers: %{active: nil, list: [], active_index: 0}
-      },
+      workspace:
+        %SessionState{
+          viewport: %{rows: rows, cols: cols},
+          buffers: %{active: nil, list: [], active_index: 0}
+        }
+        |> SessionState.set_file_tree(file_tree),
       theme: Theme.get!(:doom_one)
     }
   end

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -7,8 +7,10 @@ defmodule MingaEditor.StartupTest do
   alias Minga.Project.FileRef
   alias Minga.Test.RecordingFrontend
   alias MingaEditor.Commands.AgentSession
+  alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Input
+  alias MingaEditor.Input.FileTreeHandler
   alias MingaEditor.LayoutPreset
   alias MingaEditor.Startup
   alias MingaEditor.State, as: EditorState
@@ -166,6 +168,30 @@ defmodule MingaEditor.StartupTest do
   end
 
   describe "build_initial_state/1" do
+    test "registers FileTree dynamic sidebar and input contributions" do
+      Input.reset_handlers()
+      Sidebar.unregister_source(:builtin)
+
+      state =
+        Startup.build_initial_state(
+          backend: :headless,
+          port_manager: nil,
+          parser_manager: nil,
+          options_server: nil,
+          width: 80,
+          height: 24
+        )
+
+      assert %{id: "file_tree", input_handler: FileTreeHandler, visible?: false} =
+               Sidebar.get("file_tree")
+
+      handlers = Input.surface_handlers(state)
+      assert Enum.count(handlers, &(&1 == FileTreeHandler)) == 1
+    after
+      Input.reset_handlers()
+      Sidebar.unregister_source(:builtin)
+    end
+
     test "normalizes nil and supplied options servers" do
       default_state =
         Startup.build_initial_state(

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -219,7 +219,7 @@ defmodule MingaEditor.StartupTest do
 
       tab_bar = EditorState.tab_bar(state)
 
-      assert state.workspace.file_tree.project_root == dir
+      assert EditorState.file_tree_state(state).project_root == dir
       assert %Workspace{label: "Persisted Agent"} = TabBar.get_workspace(tab_bar, 2)
       assert tab_bar |> TabBar.switch_to_workspace(2) |> TabBar.active_workspace_id() == 2
     after
@@ -252,7 +252,7 @@ defmodule MingaEditor.StartupTest do
 
       tab_bar = EditorState.tab_bar(state)
 
-      assert state.workspace.file_tree.project_root == dir
+      assert EditorState.file_tree_state(state).project_root == dir
       assert %Workspace{label: "Argv Agent"} = TabBar.get_workspace(tab_bar, 2)
     after
       Application.delete_env(:minga, :cli_startup_project_root)
@@ -281,7 +281,7 @@ defmodule MingaEditor.StartupTest do
 
       tab_bar = EditorState.tab_bar(state)
 
-      assert state.workspace.file_tree.project_root == invalid_root
+      assert EditorState.file_tree_state(state).project_root == invalid_root
       refute TabBar.get_workspace(tab_bar, 2)
     after
       Application.delete_env(:minga, :cli_startup_project_root)

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -393,7 +393,7 @@ defmodule MingaEditor.State.SnapshotTest do
       assert new_map == old_map
     end
 
-    test "round-trips through to_workspace_map preserving all fields" do
+    test "round-trips through to_workspace_map preserving snapshot fields" do
       {:ok, buf} = BufferProcess.start_link(content: "round-trip")
       pending = %{make_ref() => {:semantic_tokens, buf}}
 
@@ -417,8 +417,8 @@ defmodule MingaEditor.State.SnapshotTest do
       assert restored_map.search == ws.search
       assert restored_map.lsp_pending == pending
 
-      assert restored_map.highlight == ws.highlight
-      assert restored_map.injection_ranges == ws.injection_ranges
+      refute Map.has_key?(restored_map, :highlight)
+      refute Map.has_key?(restored_map, :injection_ranges)
     end
 
     test "normalises transient vim state" do

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -373,7 +373,7 @@ defmodule MingaEditor.State.SnapshotTest do
       assert new_ctx.keymap_scope == old_ctx.keymap_scope
       assert new_ctx.buffers == old_ctx.buffers
       assert new_ctx.windows == old_ctx.windows
-      assert new_ctx.file_tree == old_ctx.file_tree
+      assert new_ctx.feature_state == old_ctx.feature_state
       assert new_ctx.dired == old_ctx.dired
       assert new_ctx.viewport == old_ctx.viewport
       assert new_ctx.mouse == old_ctx.mouse

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -417,9 +417,8 @@ defmodule MingaEditor.State.SnapshotTest do
       assert restored_map.search == ws.search
       assert restored_map.lsp_pending == pending
 
-      # PID/process-keyed highlight and injection cache state stays out of the round-trip.
-      refute Map.has_key?(restored_map, :highlight)
-      refute Map.has_key?(restored_map, :injection_ranges)
+      assert restored_map.highlight == ws.highlight
+      assert restored_map.injection_ranges == ws.injection_ranges
     end
 
     test "normalises transient vim state" do

--- a/test/minga_editor/state_test.exs
+++ b/test/minga_editor/state_test.exs
@@ -240,10 +240,9 @@ defmodule MingaEditor.StateTest do
 
       state = %EditorState{
         port_manager: self(),
-        workspace: %SessionState{
-          viewport: Viewport.new(24, 80),
-          file_tree: %FileTreeState{project_root: root}
-        },
+        workspace:
+          %SessionState{viewport: Viewport.new(24, 80)}
+          |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
         shell_state: %ShellState{tab_bar: tab_bar}
       }
 
@@ -327,11 +326,12 @@ defmodule MingaEditor.StateTest do
 
       state = %EditorState{
         port_manager: self(),
-        workspace: %SessionState{
-          viewport: Viewport.new(24, 80),
-          file_tree: %FileTreeState{project_root: root},
-          buffers: %Buffers{active: active_buffer, list: [active_buffer], active_index: 0}
-        },
+        workspace:
+          %SessionState{
+            viewport: Viewport.new(24, 80),
+            buffers: %Buffers{active: active_buffer, list: [active_buffer], active_index: 0}
+          }
+          |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
         shell_state: %ShellState{tab_bar: tab_bar}
       }
 

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -549,7 +549,10 @@ defmodule Minga.Test.EditorCase do
   @doc "Returns true if the file tree is open."
   @spec file_tree_open?(editor_ctx()) :: boolean()
   def file_tree_open?(%{editor: editor}) do
-    MingaEditor.State.FileTree.open?(get_editor_state(editor).workspace.file_tree)
+    editor
+    |> get_editor_state()
+    |> MingaEditor.State.file_tree_state()
+    |> MingaEditor.State.FileTree.open?()
   end
 
   @doc "Returns true if the completion menu is visible."


### PR DESCRIPTION
## Summary

- Moves FileTree UI state into feature-owned state with FileTree-specific accessors instead of dedicated `Session.State.file_tree` storage.
- Registers FileTree sidebar and input contributions dynamically so layout, focus, and input flow through the same extension-owned paths as other sidebars.
- Keeps existing FileTree rendering and behavior intact, including safe fallbacks when FileTree state or stale sidebar registry entries are missing.

## Validation

- `git diff --check`
- `make lint`
- `mix test.llm`
- `mix test.llm test/minga_editor/extension/sidebar_integration_test.exs test/minga_editor/extension/sidebar_gui_emit_test.exs test/minga_editor/file_tree/feature_test.exs`

Swift validation was not run locally because this Linux environment does not provide `swift` or `xcodebuild`; this branch does not change Swift files.

Closes #1941
