### PR TITLE
fix(zig): restore macOS TUI snapshots

### DIFF
--- a/scripts/tui-snapshot.sh
+++ b/scripts/tui-snapshot.sh
@@ -2,7 +2,7 @@
 # Generates a TUI snapshot PNG from a pre-recorded render command stream.
 #
 # Usage:
-#   scripts/tui-snapshot.sh <snapshot_name> [--cols N] [--rows N] [--font NAME] [--size N]
+#   scripts/tui-snapshot.sh <snapshot_name> [--cols N] [--rows N] [--font NAME_OR_PATH] [--size N]
 #
 # The script:
 #   1. Builds minga-snapshot (if needed)
@@ -10,8 +10,9 @@
 #   3. Writes the output PNG to zig/tests/snapshots/<name>.png
 #
 # Prerequisites:
-#   - macOS (CoreText is required for font rasterization)
+#   - macOS or Linux
 #   - Zig 0.16+ installed
+#   - Linux only: pkg-config and freetype2 development files
 #   - Fixtures generated via: mix run scripts/generate_snapshot_fixtures.exs
 
 set -euo pipefail
@@ -22,7 +23,7 @@ FIXTURES_DIR="$ZIG_DIR/tests/fixtures"
 SNAPSHOTS_DIR="$ZIG_DIR/tests/snapshots"
 
 if [ $# -lt 1 ]; then
-    echo "Usage: $0 <snapshot_name> [--cols N] [--rows N] [--font NAME] [--size N]"
+    echo "Usage: $0 <snapshot_name> [--cols N] [--rows N] [--font NAME_OR_PATH] [--size N]"
     echo ""
     echo "Available fixtures:"
     ls "$FIXTURES_DIR"/*.bin 2>/dev/null | xargs -I{} basename {} .bin || echo "  (none, run: mix run scripts/generate_snapshot_fixtures.exs)"
@@ -41,15 +42,37 @@ fi
 
 mkdir -p "$SNAPSHOTS_DIR"
 
+OS_NAME="$(uname -s)"
+case "$OS_NAME" in
+    Darwin)
+        ;;
+    Linux)
+        if ! command -v pkg-config >/dev/null 2>&1; then
+            echo "error: pkg-config is required for Linux TUI snapshots"
+            echo "Install pkg-config and freetype2 development files, then retry."
+            exit 1
+        fi
+        if ! pkg-config --exists freetype2; then
+            echo "error: freetype2 development files are required for Linux TUI snapshots"
+            echo "Install freetype2 via your package manager, then retry."
+            exit 1
+        fi
+        ;;
+    *)
+        echo "error: TUI snapshots are supported on macOS and Linux only (found $OS_NAME)"
+        exit 1
+        ;;
+esac
+
 # Build minga-snapshot
 echo "Building minga-snapshot..."
 cd "$ZIG_DIR"
-zig build 2>&1
+zig build -Dsnapshot=true 2>&1
 
 SNAPSHOT_BIN="$ZIG_DIR/zig-out/bin/minga-snapshot"
 if [ ! -x "$SNAPSHOT_BIN" ]; then
     echo "error: minga-snapshot binary not found at $SNAPSHOT_BIN"
-    echo "This tool requires macOS (CoreText font rasterization)."
+    echo "This tool requires macOS or Linux with freetype2 development files."
     exit 1
 fi
 

--- a/zig/AGENTS.md
+++ b/zig/AGENTS.md
@@ -71,7 +71,8 @@ zig/
     font/
       main.zig                     # Font face abstraction
       atlas.zig                    # Glyph atlas (for future GPU backend)
-      coretext.zig                 # CoreText font loader (macOS only)
+      coretext.zig                 # CoreText font loader (macOS snapshots)
+      freetype.zig                 # FreeType font loader (Linux snapshots)
 
   vendor/grammars/                 # Vendored tree-sitter grammar sources
     {lang}/src/parser.c            # Each grammar has parser.c + optional scanner.c

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -14,8 +14,7 @@ fn ensureGeneratedProtocolArtifacts(b: *std.Build) void {
     var missing_count: usize = 0;
 
     for (generated_protocol_files) |path| {
-        if (b.build_root.handle.access(b.graph.io, path, .{})) |_| {
-        } else |err| switch (err) {
+        if (b.build_root.handle.access(b.graph.io, path, .{})) |_| {} else |err| switch (err) {
             error.FileNotFound => {
                 missing[missing_count] = path;
                 missing_count += 1;
@@ -40,6 +39,7 @@ pub fn build(b: *std.Build) void {
     ensureGeneratedProtocolArtifacts(b);
 
     const backend = b.option(BackendOption, "backend", "Rendering backend (default: tui)") orelse .tui;
+    const snapshot = b.option(bool, "snapshot", "Build minga-snapshot and snapshot tests (requires host font libraries)") orelse false;
 
     const vaxis = b.dependency("vaxis", .{
         .target = target,
@@ -170,10 +170,9 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(parser_exe);
 
     // ── Snapshot executable (cell-grid rasterizer for Claude Code) ───────
-    // Native macOS only: CoreText @cImport needs the system SDK, which
-    // Zig does not provide when cross-compiling (explicit -Dtarget).
-    const native_macos = target.result.os.tag == .macos and target.query.os_tag == null;
-    if (native_macos) {
+    // Native only: the font rasterizers link against host system font libraries.
+    const native_snapshot = snapshot and target.query.os_tag == null and (target.result.os.tag == .macos or target.result.os.tag == .linux);
+    if (native_snapshot) {
         const snapshot_exe = b.addExecutable(.{
             .name = "minga-snapshot",
             .root_module = b.createModule(.{
@@ -184,6 +183,7 @@ pub fn build(b: *std.Build) void {
         });
         snapshot_exe.root_module.addImport("vaxis", vaxis.module("vaxis"));
         snapshot_exe.root_module.link_libc = true;
+        configureSnapshotFonts(snapshot_exe.root_module, target.result.os.tag);
         b.installArtifact(snapshot_exe);
     }
 
@@ -254,8 +254,8 @@ pub fn build(b: *std.Build) void {
     const run_hook_runner_tests = b.addRunArtifact(hook_runner_tests);
     test_step.dependOn(&run_hook_runner_tests.step);
 
-    // Snapshot tests — native macOS only (same SDK constraint as the exe).
-    if (native_macos) {
+    // Snapshot tests — native only (same system font library constraint as the exe).
+    if (native_snapshot) {
         const snapshot_tests = b.addTest(.{
             .root_module = b.createModule(.{
                 .root_source_file = b.path("src/snapshot_main.zig"),
@@ -265,6 +265,7 @@ pub fn build(b: *std.Build) void {
         });
         snapshot_tests.root_module.addImport("vaxis", vaxis.module("vaxis"));
         snapshot_tests.root_module.link_libc = true;
+        configureSnapshotFonts(snapshot_tests.root_module, target.result.os.tag);
 
         const run_snapshot_tests = b.addRunArtifact(snapshot_tests);
         test_step.dependOn(&run_snapshot_tests.step);
@@ -289,6 +290,20 @@ pub fn build(b: *std.Build) void {
     const run_highlight_bench = b.addRunArtifact(highlight_bench);
     const highlight_bench_step = b.step("highlight-bench", "Run tree-sitter highlight benchmark");
     highlight_bench_step.dependOn(&run_highlight_bench.step);
+}
+
+fn configureSnapshotFonts(module: *std.Build.Module, os_tag: std.Target.Os.Tag) void {
+    switch (os_tag) {
+        .macos => {
+            module.linkFramework("CoreFoundation", .{});
+            module.linkFramework("CoreGraphics", .{});
+            module.linkFramework("CoreText", .{});
+        },
+        .linux => {
+            module.linkSystemLibrary("freetype2", .{ .use_pkg_config = .force });
+        },
+        else => {},
+    }
 }
 
 /// Build a static library for a tree-sitter grammar.

--- a/zig/src/font/atlas.zig
+++ b/zig/src/font/atlas.zig
@@ -70,7 +70,7 @@ pub fn init(alloc: Allocator, size: u32, format: Format) !Atlas {
         .data = try alloc.alloc(u8, @as(usize, size) * size * format.depth()),
         .size = size,
         .format = format,
-        .nodes = .{},
+        .nodes = .empty,
     };
     errdefer result.deinit(alloc);
 

--- a/zig/src/font/coretext.zig
+++ b/zig/src/font/coretext.zig
@@ -1,6 +1,6 @@
 /// CoreText font loader — loads fonts and rasterizes glyphs on macOS.
 ///
-/// Uses Apple's CoreText framework via @cImport to:
+/// Uses a narrow manual CoreText/CoreGraphics binding to:
 ///   1. Load a named font (e.g. "Menlo") at a given size
 ///   2. Extract cell metrics (width, height, ascent, descent)
 ///   3. Rasterize individual glyphs into alpha bitmaps
@@ -10,11 +10,82 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Atlas = @import("atlas.zig");
 
-const c = @cImport({
-    @cInclude("CoreFoundation/CoreFoundation.h");
-    @cInclude("CoreGraphics/CoreGraphics.h");
-    @cInclude("CoreText/CoreText.h");
-});
+const c = struct {
+    pub const Boolean = u8;
+    pub const CFIndex = c_long;
+    pub const CFStringEncoding = u32;
+    pub const CFTypeRef = *const anyopaque;
+    pub const CFAllocatorRef = ?*const anyopaque;
+    pub const CFStringRef = *const anyopaque;
+    pub const CFDataRef = *const anyopaque;
+    pub const CTFontRef = *const anyopaque;
+    pub const CTFontUIFontType = u32;
+    pub const CTFontOrientation = u32;
+    pub const CTFontTableTag = u32;
+    pub const CTFontTableOptions = u32;
+    pub const CGGlyph = u16;
+    pub const CGFloat = f64;
+    pub const CGBitmapInfo = u32;
+    pub const CGColorSpaceRef = *anyopaque;
+    pub const CGContextRef = *anyopaque;
+
+    pub const CGPoint = extern struct {
+        x: CGFloat,
+        y: CGFloat,
+    };
+
+    pub const CGSize = extern struct {
+        width: CGFloat,
+        height: CGFloat,
+    };
+
+    pub const CGRect = extern struct {
+        origin: CGPoint,
+        size: CGSize,
+    };
+
+    pub const CFRange = extern struct {
+        location: CFIndex,
+        length: CFIndex,
+    };
+
+    pub const kCFStringEncodingUTF8: CFStringEncoding = 0x08000100;
+    pub const kCTFontUIFontUserFixedPitch: CTFontUIFontType = 1;
+    pub const kCTFontOrientationDefault: CTFontOrientation = 0;
+    pub const kCTFontTableOptionNoOptions: CTFontTableOptions = 0;
+    pub const kCGImageAlphaPremultipliedLast: CGBitmapInfo = 1;
+
+    pub extern "c" fn CFRelease(cf: CFTypeRef) void;
+    pub extern "c" fn CFStringCreateWithBytes(alloc: CFAllocatorRef, bytes: [*c]const u8, numBytes: CFIndex, encoding: CFStringEncoding, isExternalRepresentation: Boolean) ?CFStringRef;
+    pub extern "c" fn CFStringCreateWithCharacters(alloc: CFAllocatorRef, chars: [*c]const u16, numChars: CFIndex) ?CFStringRef;
+
+    pub extern "c" fn CTFontCreateWithName(name: CFStringRef, size: CGFloat, matrix: ?*const anyopaque) ?CTFontRef;
+    pub extern "c" fn CTFontCreateUIFontForLanguage(uiType: CTFontUIFontType, size: CGFloat, language: ?CFStringRef) ?CTFontRef;
+    pub extern "c" fn CTFontCreateForString(currentFont: CTFontRef, string: CFStringRef, range: CFRange) ?CTFontRef;
+    pub extern "c" fn CTFontGetAscent(font: CTFontRef) CGFloat;
+    pub extern "c" fn CTFontGetDescent(font: CTFontRef) CGFloat;
+    pub extern "c" fn CTFontGetLeading(font: CTFontRef) CGFloat;
+    pub extern "c" fn CTFontGetGlyphsForCharacters(font: CTFontRef, characters: [*c]const u16, glyphs: [*c]CGGlyph, count: CFIndex) bool;
+    pub extern "c" fn CTFontGetBoundingRectsForGlyphs(font: CTFontRef, orientation: CTFontOrientation, glyphs: [*c]const CGGlyph, boundingRects: [*c]CGRect, count: CFIndex) CGRect;
+    pub extern "c" fn CTFontGetAdvancesForGlyphs(font: CTFontRef, orientation: CTFontOrientation, glyphs: [*c]const CGGlyph, advances: [*c]CGSize, count: CFIndex) f64;
+    pub extern "c" fn CTFontCopyTable(font: CTFontRef, table: CTFontTableTag, options: CTFontTableOptions) ?CFDataRef;
+    pub extern "c" fn CTFontDrawGlyphs(font: CTFontRef, glyphs: [*c]const CGGlyph, positions: [*c]const CGPoint, count: usize, context: CGContextRef) void;
+
+    pub extern "c" fn CGColorSpaceCreateDeviceRGB() ?CGColorSpaceRef;
+    pub extern "c" fn CGColorSpaceRelease(space: ?CGColorSpaceRef) void;
+    pub extern "c" fn CGBitmapContextCreate(data: ?*anyopaque, width: usize, height: usize, bitsPerComponent: usize, bytesPerRow: usize, space: ?CGColorSpaceRef, bitmapInfo: CGBitmapInfo) ?CGContextRef;
+    pub extern "c" fn CGContextRelease(ctx: ?CGContextRef) void;
+    pub extern "c" fn CGContextScaleCTM(ctx: ?CGContextRef, sx: CGFloat, sy: CGFloat) void;
+    pub extern "c" fn CGContextSetAllowsFontSmoothing(ctx: ?CGContextRef, allowsFontSmoothing: bool) void;
+    pub extern "c" fn CGContextSetShouldSmoothFonts(ctx: ?CGContextRef, shouldSmoothFonts: bool) void;
+    pub extern "c" fn CGContextSetAllowsAntialiasing(ctx: ?CGContextRef, allowsAntialiasing: bool) void;
+    pub extern "c" fn CGContextSetShouldAntialias(ctx: ?CGContextRef, shouldAntialias: bool) void;
+    pub extern "c" fn CGContextSetAllowsFontSubpixelPositioning(ctx: ?CGContextRef, allowsFontSubpixelPositioning: bool) void;
+    pub extern "c" fn CGContextSetShouldSubpixelPositionFonts(ctx: ?CGContextRef, shouldSubpixelPositionFonts: bool) void;
+    pub extern "c" fn CGContextSetAllowsFontSubpixelQuantization(ctx: ?CGContextRef, allowsFontSubpixelQuantization: bool) void;
+    pub extern "c" fn CGContextSetShouldSubpixelQuantizeFonts(ctx: ?CGContextRef, shouldSubpixelQuantizeFonts: bool) void;
+    pub extern "c" fn CGContextSetRGBFillColor(ctx: ?CGContextRef, red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) void;
+};
 
 const CoreTextFont = @This();
 
@@ -207,7 +278,7 @@ pub fn rasterizeGlyph(self: *CoreTextFont, atlas: *Atlas, alloc: Allocator, code
     defer alloc.free(rgba_buf);
     @memset(rgba_buf, 0);
 
-    const color_space = c.CGColorSpaceCreateDeviceRGB();
+    const color_space = c.CGColorSpaceCreateDeviceRGB() orelse return error.ColorSpaceCreationFailed;
     defer c.CGColorSpaceRelease(color_space);
 
     const ctx = c.CGBitmapContextCreate(

--- a/zig/src/font/freetype.zig
+++ b/zig/src/font/freetype.zig
@@ -1,0 +1,232 @@
+/// FreeType font loader, loads and rasterizes glyphs on Linux.
+///
+/// The snapshot renderer only needs a narrow subset of FreeType: open a
+/// monospace font, read cell metrics, and rasterize individual codepoints into
+/// alpha bitmaps. Font discovery is intentionally simple and deterministic so
+/// snapshots do not depend on fontconfig match results.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Atlas = @import("atlas.zig");
+
+const c = @cImport({
+    @cInclude("unistd.h");
+    @cInclude("ft2build.h");
+    @cInclude("freetype/freetype.h");
+});
+
+const FreeTypeFont = @This();
+
+library: c.FT_Library,
+face: c.FT_Face,
+cell_width: u32,
+cell_height: u32,
+ascent: f64,
+descent: f64,
+leading: f64,
+scale: f64,
+alloc: Allocator,
+
+/// Glyph information stored after rasterization.
+pub const GlyphInfo = struct {
+    /// Region in the atlas where this glyph's bitmap lives.
+    atlas_x: u32,
+    atlas_y: u32,
+    width: u32,
+    height: u32,
+
+    /// Bearing offsets for positioning relative to the cell origin.
+    offset_x: f64,
+    offset_y: f64,
+
+    /// FreeType path stores text glyphs as alpha masks, not color glyphs.
+    is_color: bool,
+};
+
+/// Load a font for Linux snapshots. `name` may be an absolute font file path.
+/// Otherwise the loader falls back to common monospace font paths available on
+/// Debian, Ubuntu, Fedora, and Arch-based systems.
+pub fn init(alloc: Allocator, name: []const u8, size: f64, scale: f64) !FreeTypeFont {
+    var library: c.FT_Library = undefined;
+    if (c.FT_Init_FreeType(&library) != 0) return error.FreeTypeInitFailed;
+    errdefer _ = c.FT_Done_FreeType(library);
+
+    const font_path = try resolveFontPath(name);
+    const font_path_z = try alloc.dupeZ(u8, font_path);
+    defer alloc.free(font_path_z);
+
+    var face: c.FT_Face = undefined;
+    if (c.FT_New_Face(library, font_path_z.ptr, 0, &face) != 0) return error.FontNotFound;
+    errdefer _ = c.FT_Done_Face(face);
+
+    const pixel_size: c.FT_UInt = @intFromFloat(@ceil(size * scale));
+    if (c.FT_Set_Pixel_Sizes(face, 0, pixel_size) != 0) return error.FontSizeFailed;
+
+    const metrics = face.*.size.*.metrics;
+    const ascent = fixed26Dot6ToFloat(metrics.ascender);
+    const descent = -fixed26Dot6ToFloat(metrics.descender);
+    const height = fixed26Dot6ToFloat(metrics.height);
+    const leading = @max(0.0, height - ascent - descent);
+    const advance = try monospaceAdvance(face);
+
+    return .{
+        .library = library,
+        .face = face,
+        .cell_width = @max(1, @as(u32, @intFromFloat(@ceil(advance)))),
+        .cell_height = @max(1, @as(u32, @intFromFloat(@ceil(height)))),
+        .ascent = ascent,
+        .descent = descent,
+        .leading = leading,
+        .scale = scale,
+        .alloc = alloc,
+    };
+}
+
+pub fn deinit(self: *FreeTypeFont) void {
+    _ = c.FT_Done_Face(self.face);
+    _ = c.FT_Done_FreeType(self.library);
+    self.* = undefined;
+}
+
+/// Rasterize a single codepoint into the atlas. FreeType gives us an 8-bit
+/// coverage bitmap, which the snapshot surface consumes through the BGRA atlas
+/// alpha channel.
+pub fn rasterizeGlyph(self: *FreeTypeFont, atlas: *Atlas, alloc: Allocator, codepoint: u32) !GlyphInfo {
+    const flags = c.FT_LOAD_RENDER | c.FT_LOAD_TARGET_NORMAL;
+    if (c.FT_Load_Char(self.face, codepoint, flags) != 0) return error.GlyphLoadFailed;
+
+    const glyph = self.face.*.glyph;
+    const bitmap = glyph.*.bitmap;
+    const render_width: u32 = @intCast(bitmap.width);
+    const render_height: u32 = @intCast(bitmap.rows);
+
+    if (render_width == 0 or render_height == 0) {
+        return .{
+            .atlas_x = 0,
+            .atlas_y = 0,
+            .width = 0,
+            .height = 0,
+            .offset_x = @floatFromInt(glyph.*.bitmap_left),
+            .offset_y = self.ascent - @as(f64, @floatFromInt(glyph.*.bitmap_top)),
+            .is_color = false,
+        };
+    }
+
+    const pad: u32 = 1;
+    const padded_width = render_width + pad * 2;
+    const padded_height = render_height + pad * 2;
+    const region = try atlas.reserve(alloc, padded_width, padded_height);
+
+    const bgra_size = @as(usize, render_width) * render_height * 4;
+    const bgra_buf = try alloc.alloc(u8, bgra_size);
+    defer alloc.free(bgra_buf);
+    @memset(bgra_buf, 0);
+
+    const pitch_abs: usize = @intCast(@abs(bitmap.pitch));
+    const pitch_negative = bitmap.pitch < 0;
+
+    for (0..render_height) |row| {
+        const source_row = if (pitch_negative) render_height - 1 - row else row;
+        const row_start = @as(usize, source_row) * pitch_abs;
+        for (0..render_width) |col| {
+            const alpha = bitmap.buffer[row_start + col];
+            const off = (row * @as(usize, render_width) + col) * 4;
+            bgra_buf[off + 0] = 255;
+            bgra_buf[off + 1] = 255;
+            bgra_buf[off + 2] = 255;
+            bgra_buf[off + 3] = alpha;
+        }
+    }
+
+    const glyph_region = Atlas.Region{
+        .x = region.x + pad,
+        .y = region.y + pad,
+        .width = render_width,
+        .height = render_height,
+    };
+    atlas.set(glyph_region, bgra_buf);
+
+    return .{
+        .atlas_x = glyph_region.x,
+        .atlas_y = glyph_region.y,
+        .width = render_width,
+        .height = render_height,
+        .offset_x = @floatFromInt(glyph.*.bitmap_left),
+        .offset_y = self.ascent - @as(f64, @floatFromInt(glyph.*.bitmap_top)),
+        .is_color = false,
+    };
+}
+
+fn monospaceAdvance(face: c.FT_Face) !f64 {
+    if (c.FT_Load_Char(face, 'M', c.FT_LOAD_DEFAULT) != 0) return error.GlyphLoadFailed;
+    return fixed26Dot6ToFloat(face.*.glyph.*.advance.x);
+}
+
+fn fixed26Dot6ToFloat(value: c.FT_Pos) f64 {
+    return @as(f64, @floatFromInt(value)) / 64.0;
+}
+
+fn resolveFontPath(name: []const u8) ![]const u8 {
+    if (std.mem.indexOfScalar(u8, name, '/') != null and fileExists(name)) return name;
+
+    const candidates = [_][]const u8{
+        "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+        "/usr/share/fonts/dejavu-sans-mono-fonts/DejaVuSansMono.ttf",
+        "/usr/share/fonts/TTF/DejaVuSansMono.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+        "/usr/share/fonts/liberation/LiberationMono-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansMono-Regular.ttf",
+        "/usr/share/fonts/noto/NotoSansMono-Regular.ttf",
+    };
+
+    for (candidates) |path| {
+        if (fileExists(path)) return path;
+    }
+
+    return error.FontNotFound;
+}
+
+fn fileExists(path: []const u8) bool {
+    var path_buf: [std.fs.max_path_bytes:0]u8 = undefined;
+    if (path.len >= path_buf.len) return false;
+    @memcpy(path_buf[0..path.len], path);
+    path_buf[path.len] = 0;
+    return c.access(&path_buf, c.F_OK) == 0;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "load fallback monospace font" {
+    var font = try FreeTypeFont.init(std.testing.allocator, "Menlo", 14.0, 1.0);
+    defer font.deinit();
+
+    try std.testing.expect(font.cell_width > 0);
+    try std.testing.expect(font.cell_height > 0);
+    try std.testing.expect(font.ascent > 0);
+    try std.testing.expect(font.descent >= 0);
+}
+
+test "rasterize ASCII A produces non-zero pixels" {
+    var font = try FreeTypeFont.init(std.testing.allocator, "Menlo", 14.0, 1.0);
+    defer font.deinit();
+
+    var atlas = try Atlas.init(std.testing.allocator, 256, .bgra);
+    defer atlas.deinit(std.testing.allocator);
+
+    const info = try font.rasterizeGlyph(&atlas, std.testing.allocator, 'A');
+    try std.testing.expect(info.width > 0);
+    try std.testing.expect(info.height > 0);
+
+    const depth = atlas.format.depth();
+    var has_nonzero = false;
+    for (0..info.height) |row| {
+        const start = ((info.atlas_y + @as(u32, @intCast(row))) * atlas.size + info.atlas_x) * depth;
+        for (atlas.data[start..][0 .. info.width * depth]) |byte| {
+            if (byte != 0) {
+                has_nonzero = true;
+                break;
+            }
+        }
+        if (has_nonzero) break;
+    }
+    try std.testing.expect(has_nonzero);
+}

--- a/zig/src/font/main.zig
+++ b/zig/src/font/main.zig
@@ -1,14 +1,18 @@
 /// Font — top-level font module providing glyph caching and atlas management.
 ///
-/// Wraps the platform-specific font loader (CoreText on macOS) and the
-/// texture atlas, adding a glyph cache that maps codepoints → GlyphInfo.
+/// Wraps the platform-specific font loader (CoreText on macOS, FreeType on Linux)
+/// and the texture atlas, adding a glyph cache that maps codepoints → GlyphInfo.
 /// New glyphs are rasterized on demand when first requested.
 const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 
 pub const Atlas = @import("atlas.zig");
-pub const CoreTextFont = if (builtin.os.tag == .macos) @import("coretext.zig") else struct {};
+const PlatformFont = switch (builtin.os.tag) {
+    .macos => @import("coretext.zig"),
+    .linux => @import("freetype.zig"),
+    else => struct {},
+};
 
 /// Glyph cache entry with atlas coordinates and metrics.
 pub const Glyph = struct {
@@ -30,7 +34,7 @@ pub const Glyph = struct {
 /// Font face with glyph cache. Thread-safe for concurrent lookups
 /// (cache is populated lazily with a mutex).
 pub const Face = struct {
-    loader: CoreTextFont,
+    loader: PlatformFont,
     atlas: Atlas,
     cache: std.AutoHashMapUnmanaged(u32, Glyph),
     alloc: Allocator,
@@ -44,7 +48,7 @@ pub const Face = struct {
     /// `scale` is the backing scale factor (2.0 for Retina) — glyph bitmaps
     /// are rasterized at this multiple for crisp rendering on HiDPI displays.
     pub fn init(alloc: Allocator, name: []const u8, size: f64, scale: f64) !Face {
-        var loader = try CoreTextFont.init(alloc, name, size, scale);
+        var loader = try PlatformFont.init(alloc, name, size, scale);
         errdefer loader.deinit();
 
         // Start with a 512×512 BGRA atlas — supports both text (white+alpha)
@@ -93,7 +97,7 @@ pub const Face = struct {
         return glyph;
     }
 
-    fn glyphFromInfo(info: CoreTextFont.GlyphInfo) Glyph {
+    fn glyphFromInfo(info: PlatformFont.GlyphInfo) Glyph {
         return .{
             .atlas_x = info.atlas_x,
             .atlas_y = info.atlas_y,
@@ -149,7 +153,7 @@ test "Face preloadAscii succeeds" {
 
 test {
     _ = Atlas;
-    if (builtin.os.tag == .macos) {
-        _ = CoreTextFont;
+    if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
+        _ = PlatformFont;
     }
 }

--- a/zig/src/snapshot_main.zig
+++ b/zig/src/snapshot_main.zig
@@ -2,8 +2,8 @@
 ///
 /// Reads {:packet, 4} framed binary render commands from stdin (same
 /// protocol as minga-renderer), renders them to an in-memory pixel
-/// buffer using CoreText font rasterization, and writes the result
-/// as a PNG file.
+/// buffer using platform font rasterization (CoreText on macOS, FreeType on Linux),
+/// and writes the result as a PNG file.
 ///
 /// Usage:
 ///   cat fixture.bin | minga-snapshot --output snapshot.png [--cols 80] [--rows 24] [--font Menlo] [--size 14]


### PR DESCRIPTION
# TL;DR
TUI PNG snapshots now build and run on macOS and Linux. macOS uses the existing CoreText rasterizer, while Linux uses a new FreeType rasterizer behind an explicit snapshot build flag so normal Linux CI does not require FreeType headers.

## Context
`scripts/tui-snapshot.sh` needs to work for developers and CI on both supported desktop platforms. The snapshot path is native-only because it links against host font libraries, so the build now selects the right font backend for the host OS when snapshot support is explicitly requested.

## Changes
- Replaced the broad macOS `@cImport` with explicit CoreFoundation/CoreGraphics/CoreText extern declarations so current Apple SDK headers no longer break Zig translation.
- Added a Linux FreeType font loader for `minga-snapshot`, including deterministic fallback monospace font paths.
- Added `-Dsnapshot=true` to opt into building `minga-snapshot` and its tests, keeping default Linux `zig build test` free of optional FreeType dependencies.
- Enabled native snapshot builds and tests on macOS and Linux when `-Dsnapshot=true` is set, linking CoreText frameworks or FreeType via `pkg-config` by platform.
- Updated `scripts/tui-snapshot.sh` to support macOS and Linux, with Linux preflight checks for `pkg-config` and `freetype2` development files.
- Updated Zig developer docs/comments to describe both snapshot font backends.

## Verification
- `mix zig.lint`
- `scripts/tui-snapshot.sh status_bar`, generated `zig/tests/snapshots/status_bar.png` on macOS
- `cd zig && zig build -Dsnapshot=true test`
- `cd zig && zig test src/font/freetype.zig --test-no-exec -lc $(pkg-config --cflags --libs freetype2)`, compile-checks the FreeType loader against local FreeType headers
