### PR TITLE
fix(macos): polish Swift GUI chrome snapshots

### DIFF
--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -21,6 +21,10 @@ enum PreviewRegistry {
             tabBarPreview()
         case "NotificationCenterView":
             notificationPreview()
+        case "ObservatoryView":
+            observatoryPreview()
+        case "AgentChatView":
+            agentChatPreview()
         default:
             Text("Unknown view: \(name)")
                 .font(.title)
@@ -219,6 +223,69 @@ enum PreviewRegistry {
         return NotificationCenterView(state: state, theme: theme, encoder: nil, bottomInset: 40)
             .frame(width: 800, height: 600)
             .background(theme.editorBg)
+    }
+
+    // MARK: - ObservatoryView
+
+    private static func observatoryPreview() -> some View {
+        let state = ObservatoryState()
+        let theme = populatedTheme()
+        state.update(visible: true, rawNodes: [
+            Wire.ObservatoryNode(pid: "<0.100.0>", parentPid: "", name: "Elixir.Minga.Application", processClass: 0, depth: 0, memory: 184_320, messageQueueLen: 0, reductions: 91_204, sparkline: [0.12, 0.18, 0.13, 0.22, 0.19, 0.24]),
+            Wire.ObservatoryNode(pid: "<0.101.0>", parentPid: "<0.100.0>", name: "Elixir.Minga.Foundation.Supervisor", processClass: 0, depth: 1, memory: 96_448, messageQueueLen: 0, reductions: 40_112, sparkline: [0.10, 0.12, 0.09, 0.11, 0.10, 0.13]),
+            Wire.ObservatoryNode(pid: "<0.102.0>", parentPid: "<0.101.0>", name: "Elixir.Minga.Events", processClass: 4, depth: 2, memory: 58_912, messageQueueLen: 1, reductions: 18_901, sparkline: [0.08, 0.20, 0.12, 0.18, 0.16, 0.19]),
+            Wire.ObservatoryNode(pid: "<0.120.0>", parentPid: "<0.100.0>", name: "Elixir.Minga.Editor.Supervisor", processClass: 0, depth: 1, memory: 122_880, messageQueueLen: 0, reductions: 52_772, sparkline: [0.18, 0.16, 0.20, 0.21, 0.19, 0.24]),
+            Wire.ObservatoryNode(pid: "<0.121.0>", parentPid: "<0.120.0>", name: "Elixir.MingaEditor", processClass: 5, depth: 2, memory: 214_016, messageQueueLen: 7, reductions: 182_394, sparkline: [0.24, 0.42, 0.32, 0.54, 0.37, 0.49]),
+            Wire.ObservatoryNode(pid: "<0.122.0>", parentPid: "<0.120.0>", name: "Elixir.Minga.Buffer.Process", processClass: 1, depth: 2, memory: 73_728, messageQueueLen: 0, reductions: 22_140, sparkline: [0.10, 0.14, 0.11, 0.15, 0.12, 0.16]),
+            Wire.ObservatoryNode(pid: "<0.130.0>", parentPid: "<0.100.0>", name: "Elixir.MingaAgent.SessionManager", processClass: 2, depth: 1, memory: 308_224, messageQueueLen: 14, reductions: 241_006, sparkline: [0.38, 0.48, 0.62, 0.57, 0.72, 0.66]),
+            Wire.ObservatoryNode(pid: "<0.140.0>", parentPid: "<0.100.0>", name: "Elixir.Minga.LSP.Client", processClass: 3, depth: 1, memory: 155_648, messageQueueLen: 2, reductions: 88_440, sparkline: [0.16, 0.18, 0.26, 0.22, 0.28, 0.24]),
+        ])
+
+        return ObservatoryView(state: state, theme: theme, encoder: nil)
+            .frame(width: 320, height: 640)
+            .background(theme.treeBg)
+    }
+
+    // MARK: - AgentChatView
+
+    private static func agentChatPreview() -> some View {
+        let state = AgentChatState()
+        let theme = populatedTheme()
+        state.update(
+            visible: true,
+            status: 2,
+            model: "anthropic:claude-sonnet-4",
+            thinkingLevel: "medium",
+            prompt: "Make the notification card use the configured theme",
+            promptLineCount: 1,
+            promptCursorLine: 0,
+            promptCursorCol: 52,
+            promptVimMode: 1,
+            promptVisibleRows: 1,
+            promptCompletion: nil,
+            helpVisible: false,
+            helpGroups: [],
+            rawMessages: agentChatMessages()
+        )
+
+        return AgentChatView(state: state, theme: theme, isInsertMode: true, encoder: nil, cellHeight: 18)
+            .frame(width: 760, height: 600)
+            .background(theme.agentPanelBg)
+    }
+
+    private static func agentChatMessages() -> [Wire.ChatMessage] {
+        [
+            Wire.ChatMessage(beamId: 1, content: .user(text: "The notification card should use our configured theme.")),
+            Wire.ChatMessage(beamId: 2, content: .thinking(text: "Inspecting the SwiftUI chrome path and checking whether the notification background bypasses ThemeColors.", collapsed: false)),
+            Wire.ChatMessage(beamId: 3, content: .toolCall(name: "read", summary: "macos/Sources/Views/NotificationCenterView.swift", status: 1, isError: false, collapsed: false, autoApprovedScope: 0, durationMs: 148, result: "Found .ultraThinMaterial on the card background.")),
+            Wire.ChatMessage(beamId: 4, content: .assistant(text: "I’ll switch the card to theme.popupBg and keep severity as a themed border, so light and dark themes stay under BEAM control.")),
+            Wire.ChatMessage(beamId: 5, content: .styledToolCall(name: "edit", summary: "Apply notification theme polish", status: 1, isError: false, collapsed: false, autoApprovedScope: 0, durationMs: 93, resultLines: [[styledRun(".background(theme.popupBg", 0x98, 0xBE, 0x65, bold: true), styledRun(", in: RoundedRectangle(cornerRadius: 10))", 0xBB, 0xC2, 0xCF)]])),
+            Wire.ChatMessage(beamId: 6, content: .usage(input: 128_000, output: 3_840, cacheRead: 64_000, cacheWrite: 1_280, costMicros: 431_000)),
+        ]
+    }
+
+    private static func styledRun(_ text: String, _ r: UInt8, _ g: UInt8, _ b: UInt8, bold: Bool = false) -> Wire.StyledTextRun {
+        Wire.StyledTextRun(text: text, fgR: r, fgG: g, fgB: b, bgR: 0, bgG: 0, bgB: 0, bold: bold, italic: false, underline: false)
     }
 
     // MARK: - Helpers

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -141,7 +141,7 @@ struct AgentChatView: View {
 
             Text("·")
                 .font(.system(size: 11))
-                .foregroundStyle(theme.agentTextFg.opacity(0.35))
+                .foregroundStyle(theme.agentDisabledFg)
 
             thinkingLevelMenu
 
@@ -155,7 +155,7 @@ struct AgentChatView: View {
 
             Text(state.statusLabel)
                 .font(.system(size: 11))
-                .foregroundStyle(theme.agentTextFg.opacity(0.4))
+                .foregroundStyle(theme.agentMutedFg)
 
             Button {
                 // Send '?' to toggle help overlay
@@ -163,7 +163,7 @@ struct AgentChatView: View {
             } label: {
                 Image(systemName: "questionmark.circle")
                     .font(.system(size: 13))
-                    .foregroundStyle(state.helpVisible ? theme.agentHeaderFg : theme.agentTextFg.opacity(0.4))
+                    .foregroundStyle(state.helpVisible ? theme.agentHeaderFg : theme.agentMutedFg)
                     .padding(.horizontal, 4)
                     .padding(.vertical, 3)
                     .background(RoundedRectangle(cornerRadius: 4).fill(isHelpHovered ? theme.agentTextFg.opacity(0.06) : Color.clear))
@@ -197,7 +197,7 @@ struct AgentChatView: View {
                 Image(systemName: "chevron.up.chevron.down")
                     .font(.system(size: 9, weight: .semibold))
             }
-            .foregroundStyle(theme.agentHeaderFg.opacity(state.isThinking ? 0.45 : 1.0))
+            .foregroundStyle(state.isThinking ? theme.agentMutedFg : theme.agentHeaderFg)
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
             .background(RoundedRectangle(cornerRadius: 4).fill(isModelHovered && !state.isThinking ? theme.agentTextFg.opacity(0.06) : Color.clear))
@@ -238,7 +238,7 @@ struct AgentChatView: View {
                 Image(systemName: "chevron.down")
                     .font(.system(size: 8, weight: .semibold))
             }
-            .foregroundStyle(theme.agentHeaderFg.opacity(state.isThinking ? 0.45 : 0.9))
+            .foregroundStyle(state.isThinking ? theme.agentMutedFg : theme.agentHeaderFg.opacity(0.9))
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
             .background(RoundedRectangle(cornerRadius: 4).fill(isThinkingHovered && !state.isThinking ? theme.agentTextFg.opacity(0.06) : Color.clear))

--- a/macos/Sources/Views/CompletionOverlay.swift
+++ b/macos/Sources/Views/CompletionOverlay.swift
@@ -61,7 +61,7 @@ struct CompletionOverlay: View {
             // Label
             Text(item.label)
                 .font(.system(size: 12, design: .monospaced))
-                .foregroundStyle(isSelected ? theme.popupFg : theme.popupFg.opacity(0.9))
+                .foregroundStyle(isSelected ? theme.popupSelFg : theme.popupFg)
                 .lineLimit(1)
 
             Spacer(minLength: 4)
@@ -70,7 +70,7 @@ struct CompletionOverlay: View {
             if !item.detail.isEmpty {
                 Text(item.detail)
                     .font(.system(size: 11))
-                    .foregroundStyle(theme.popupFg.opacity(0.4))
+                    .foregroundStyle(isSelected ? theme.popupSelFg.opacity(0.72) : theme.popupMutedFg)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }

--- a/macos/Sources/Views/FileTreeRowView.swift
+++ b/macos/Sources/Views/FileTreeRowView.swift
@@ -1,7 +1,7 @@
 /// Visual row component for the semantic file tree.
 ///
 /// FileTreeView owns list behavior and action wiring. This view owns the row anatomy and visual layers:
-/// disclosure, icon, name, spacer, diagnostic marker, dirty marker, git marker, then background/accent layers.
+/// disclosure, icon, name, reserved status column, then background/accent layers.
 
 import SwiftUI
 
@@ -20,6 +20,8 @@ struct FileTreeRowView: View {
 
     @Environment(\.displayScale) private var displayScale
     @State private var isLocallyHovered = false
+
+    private let statusColumnWidth: CGFloat = 30
 
     private var effectiveHovered: Bool {
         isHovered || isLocallyHovered
@@ -84,12 +86,11 @@ struct FileTreeRowView: View {
                     .foregroundStyle(nameColor)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                    .layoutPriority(0)
-
-                Spacer(minLength: 0)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .layoutPriority(1)
 
                 statusCluster
-                    .fixedSize(horizontal: true, vertical: false)
+                    .frame(width: statusColumnWidth, alignment: .trailing)
                     .layoutPriority(2)
             }
         }
@@ -111,7 +112,7 @@ struct FileTreeRowView: View {
 
     @ViewBuilder
     private var statusCluster: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 4) {
             diagnosticMarker
             dirtyMarker
             gitStatusDot
@@ -124,7 +125,6 @@ struct FileTreeRowView: View {
             Text(text)
                 .font(.system(size: 9, weight: entry.highestDiagnosticSeverity == .hint ? .medium : .bold))
                 .foregroundStyle(color)
-                .padding(.trailing, 4)
         }
     }
 
@@ -166,7 +166,6 @@ struct FileTreeRowView: View {
             Text("●")
                 .font(.system(size: 9, weight: .bold))
                 .foregroundStyle(theme.treeGitModified)
-                .padding(.trailing, entry.showsGitMarker ? 4 : 2)
         }
     }
 
@@ -176,7 +175,6 @@ struct FileTreeRowView: View {
             Circle()
                 .fill(color)
                 .frame(width: entry.hasConflictStatus ? 7 : 6, height: entry.hasConflictStatus ? 7 : 6)
-                .padding(.trailing, 2)
         }
     }
 

--- a/macos/Sources/Views/GitStatusView.swift
+++ b/macos/Sources/Views/GitStatusView.swift
@@ -398,7 +398,7 @@ struct GitStatusView: View {
                     )) {
                         Text("Amend")
                             .font(.system(size: 11))
-                            .foregroundStyle(theme.treeFg.opacity(0.6))
+                            .foregroundStyle(theme.treeMutedFg)
                     }
                     .toggleStyle(.checkbox)
                     .controlSize(.small)
@@ -410,7 +410,7 @@ struct GitStatusView: View {
                     if state.commitMessage.isEmpty {
                         Text("Commit message\u{2026}")
                             .font(.system(size: 12))
-                            .foregroundStyle(theme.treeFg.opacity(0.3))
+                            .foregroundStyle(theme.treeDisabledFg)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 6)
                     }
@@ -471,10 +471,10 @@ struct GitStatusView: View {
                     }
                     .frame(maxWidth: .infinity)
                     .frame(height: 26)
-                    .foregroundStyle(commitButtonEnabled ? theme.treeBg : theme.treeFg.opacity(0.3))
+                    .foregroundStyle(commitButtonEnabled ? theme.treeBg : theme.treeDisabledFg)
                     .background(
                         RoundedRectangle(cornerRadius: 4)
-                            .fill(commitButtonEnabled ? theme.accent : theme.treeFg.opacity(0.08))
+                            .fill(commitButtonEnabled ? theme.accent : theme.treeFg.opacity(0.10))
                     )
                 }
                 .buttonStyle(.plain)
@@ -509,7 +509,7 @@ struct GitStatusView: View {
         if count >= 50 {
             return theme.gutterWarningFg
         }
-        return theme.treeFg.opacity(0.3)
+        return theme.treeDisabledFg
     }
 
     private var commitBorderColor: Color {
@@ -553,7 +553,7 @@ struct GitStatusView: View {
                 Text(label)
                     .font(.system(size: 11))
             }
-            .foregroundStyle(theme.treeFg.opacity(0.6))
+            .foregroundStyle(theme.treeMutedFg)
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
             .background(
@@ -620,13 +620,13 @@ struct GitStatusView: View {
 
     private func statusColor(_ status: GitFileStatus) -> Color {
         switch status {
-        case .unknown: theme.treeFg.opacity(0.45)
+        case .unknown: theme.treeDisabledFg
         case .modified: theme.gitModifiedFg
         case .added: theme.gitAddedFg
         case .deleted: theme.gitDeletedFg
         case .renamed: theme.gitModifiedFg
         case .copied: theme.gitAddedFg
-        case .untracked: theme.treeFg.opacity(0.5)
+        case .untracked: theme.treeMutedFg
         case .conflicted: theme.gutterErrorFg
         }
     }

--- a/macos/Sources/Views/NotificationCenterView.swift
+++ b/macos/Sources/Views/NotificationCenterView.swift
@@ -52,7 +52,7 @@ private struct NotificationCard: View {
                                     .font(.system(size: 10, weight: .bold))
                             }
                             .buttonStyle(.plain)
-                            .foregroundStyle(theme.popupFg.opacity(0.55))
+                            .foregroundStyle(theme.popupMutedFg)
                             .help("Dismiss notification")
                         }
                     }
@@ -64,7 +64,7 @@ private struct NotificationCard: View {
             if !notification.body.isEmpty {
                 Text(notification.body)
                     .font(.system(size: 12))
-                    .foregroundStyle(theme.popupFg.opacity(0.78))
+                    .foregroundStyle(theme.popupSecondaryFg)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -78,7 +78,7 @@ private struct NotificationCard: View {
                         .font(.system(size: 11, weight: .medium))
                         .padding(.horizontal, 9)
                         .padding(.vertical, 5)
-                        .background(theme.popupFg.opacity(0.08), in: RoundedRectangle(cornerRadius: 5))
+                        .background(theme.accent.opacity(0.14), in: RoundedRectangle(cornerRadius: 5))
                         .foregroundStyle(theme.accent)
                     }
                 }
@@ -86,12 +86,12 @@ private struct NotificationCard: View {
         }
         .padding(12)
         .frame(width: 360, alignment: .leading)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .background(theme.popupBg, in: RoundedRectangle(cornerRadius: 10))
         .overlay {
             RoundedRectangle(cornerRadius: 10)
-                .strokeBorder(severityColor.opacity(0.55), lineWidth: 1)
+                .strokeBorder(notificationBorderColor, lineWidth: 1)
         }
-        .shadow(color: .black.opacity(0.28), radius: 16, x: 0, y: 8)
+        .shadow(color: .black.opacity(0.32), radius: 16, x: 0, y: 8)
     }
 
     private var severityIcon: some View {
@@ -117,13 +117,17 @@ private struct NotificationCard: View {
             if !notification.source.isEmpty {
                 Text(notification.source)
                     .font(.system(size: 10))
-                    .foregroundStyle(theme.popupFg.opacity(0.55))
+                    .foregroundStyle(theme.popupMutedFg)
             }
 
             Text(notification.updatedAt, style: .relative)
                 .font(.system(size: 10))
-                .foregroundStyle(theme.popupFg.opacity(0.45))
+                .foregroundStyle(theme.popupDisabledFg)
         }
+    }
+
+    private var notificationBorderColor: Color {
+        severityColor.opacity(0.58)
     }
 
     private var severityColor: Color {

--- a/macos/Sources/Views/ObservatoryView.swift
+++ b/macos/Sources/Views/ObservatoryView.swift
@@ -49,6 +49,7 @@ struct ObservatoryView: View {
                         Text(mode.rawValue).tag(mode)
                     }
                 }
+                .labelsHidden()
                 .pickerStyle(.segmented)
                 .frame(width: 120)
             }

--- a/macos/Sources/Views/StatusBarView.swift
+++ b/macos/Sources/Views/StatusBarView.swift
@@ -191,8 +191,8 @@ struct StatusBarView: View {
     var gitSyncing: Bool = false
 
     private let barHeight: CGFloat = 24
-    private let sideSpacing: CGFloat = 8
-    private let leftFixedControlsWidth: CGFloat = 101
+    private let sideSpacing: CGFloat = 10
+    private let leftFixedControlsWidth: CGFloat = 106
     private let rightFixedControlsWidth: CGFloat = 34
     private let maxCenterStatusWidth: CGFloat = 320
 
@@ -783,7 +783,7 @@ struct StatusBarView: View {
 
     @ViewBuilder
     private var leftFixedControls: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: 6) {
             // File tree toggle
             StatusBarIconButton(
                 icon: "sidebar.leading",
@@ -824,7 +824,7 @@ struct StatusBarView: View {
             Rectangle()
                 .fill(theme.modelineBarFg.opacity(0.1))
                 .frame(width: 1, height: 14)
-                .padding(.horizontal, 4)
+                .padding(.horizontal, 6)
         }
     }
 
@@ -894,7 +894,7 @@ struct StatusBarView: View {
     }
 
     private func nativeModelineGroups(_ groups: [StatusBarSegmentGroup]) -> some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 10) {
             ForEach(groups) { group in
                 nativeModelineGroup(group)
             }

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -548,11 +548,22 @@ struct TabBarView: View {
         }
         .padding(.horizontal, tab.isPinned ? 8 : 12)
         .frame(width: tab.isPinned ? 28 : nil, height: barHeight)
-        .background(tab.isActive ? theme.tabActiveBg : Color.clear)
-        .overlay(alignment: .bottom) {
-            if let tint = tabTint(tab) {
+        .background {
+            RoundedRectangle(cornerRadius: 5)
+                .fill(tabBackgroundColor(tab, isHovering: isHovering))
+                .padding(.vertical, 4)
+        }
+        .overlay(alignment: .top) {
+            if tab.isActive {
                 Rectangle()
-                    .fill(tint)
+                    .fill(tabTint(tab) ?? theme.accent)
+                    .frame(height: 2)
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if let tint = tabTint(tab), !tab.isActive {
+                Rectangle()
+                    .fill(tint.opacity(0.75))
                     .frame(height: 2)
             }
         }
@@ -715,11 +726,21 @@ struct TabBarView: View {
             .padding(.horizontal, 3)
     }
 
+    private func tabBackgroundColor(_ tab: TabEntry, isHovering: Bool) -> Color {
+        if tab.isActive {
+            return theme.tabActiveBg
+        }
+        if isHovering {
+            return theme.tabInactiveFg.opacity(0.08)
+        }
+        return Color.clear
+    }
+
     private func tabTint(_ tab: TabEntry) -> Color? {
         if let tint = tab.tintColor {
             return tint
         }
-        return tab.isAgent ? Color.accentColor : nil
+        return tab.isAgent ? theme.accent : nil
     }
 
     private func pinnedBadgeColor(_ tab: TabEntry) -> Color? {

--- a/macos/Sources/Views/ThemeColors.swift
+++ b/macos/Sources/Views/ThemeColors.swift
@@ -143,6 +143,23 @@ final class ThemeColors {
     // ── Accent ──
     var accent: Color = color(0x51AFEF)
 
+    // ── Shared chrome contrast tokens ──
+    var chromeSecondaryFg: Color { editorFg.opacity(0.78) }
+    var chromeMutedFg: Color { editorFg.opacity(0.62) }
+    var chromeDisabledFg: Color { editorFg.opacity(0.42) }
+    var popupSecondaryFg: Color { popupFg.opacity(0.78) }
+    var popupMutedFg: Color { popupFg.opacity(0.62) }
+    var popupDisabledFg: Color { popupFg.opacity(0.42) }
+    var modelineSecondaryFg: Color { modelineBarFg.opacity(0.78) }
+    var modelineMutedFg: Color { modelineBarFg.opacity(0.62) }
+    var modelineDisabledFg: Color { modelineBarFg.opacity(0.42) }
+    var treeSecondaryFg: Color { treeFg.opacity(0.78) }
+    var treeMutedFg: Color { treeFg.opacity(0.62) }
+    var treeDisabledFg: Color { treeFg.opacity(0.42) }
+    var agentSecondaryFg: Color { agentTextFg.opacity(0.78) }
+    var agentMutedFg: Color { agentTextFg.opacity(0.62) }
+    var agentDisabledFg: Color { agentTextFg.opacity(0.42) }
+
     /// Apply a batch of color slot updates from the gui_theme protocol message.
     func applySlots(_ slots: [(UInt8, UInt8, UInt8, UInt8)]) {
         for (slotId, r, g, b) in slots {

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -4,7 +4,8 @@
 # Usage: scripts/preview.sh <ViewName>
 #
 # Available views: GitStatusView, FileTreeView, CompletionOverlay,
-#                  StatusBarView, TabBarView, NotificationCenterView
+#                  StatusBarView, TabBarView, NotificationCenterView,
+#                  ObservatoryView, AgentChatView
 #
 # The script builds the PreviewHost target (fast: no GPU rendering, no BEAM),
 # launches it with the view name, and the app self-captures its window


### PR DESCRIPTION
# TL;DR
Polishes the macOS GUI chrome so low-priority text, notification cards, file tree badges, tabs, and status controls use theme-derived colors with clearer spacing and hierarchy. Adds PreviewHost coverage for the BEAM Observatory and Agent Chat surfaces so these chrome paths can be snapshot-checked alongside the existing GUI previews.

## Context
This is a visual polish pass for the Swift GUI chrome. It keeps the existing limited theme palette model intact by deriving secondary, muted, and disabled colors from the theme slots instead of adding independent hardcoded colors.

## Changes
- Added semantic contrast aliases on `ThemeColors` for chrome, popup, modeline, file tree, and agent surfaces.
- Updated completion metadata, git placeholders, notification text, and agent header/model controls to use derived theme aliases instead of scattered opacity values.
- Changed notification cards from AppKit material styling to `theme.popupBg`, with severity expressed through themed borders and icons.
- Reserved a fixed trailing file-tree status column so names and dirty/git markers do not collide or shift between rows.
- Refined tab and status bars with clearer active tab treatment, hover backgrounds, accent tinting, and wider status control spacing.
- Added realistic PreviewHost fixtures for `ObservatoryView` and `AgentChatView`, and documented them in `scripts/preview.sh`.
- Rebased on the TUI snapshot fix from latest `main` and verified the restored TUI snapshot path still runs.

## Verification
- `mix swift.build`
- `mix swift.harness`
- `xcodebuild -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS' test`
- `scripts/preview.sh GitStatusView`
- `scripts/preview.sh FileTreeView`
- `scripts/preview.sh CompletionOverlay`
- `scripts/preview.sh StatusBarView`
- `scripts/preview.sh TabBarView`
- `scripts/preview.sh NotificationCenterView`
- `scripts/preview.sh ObservatoryView`
- `scripts/preview.sh AgentChatView`
- `scripts/tui-snapshot.sh file_tree`
- `scripts/tui-snapshot.sh status_bar`
- `scripts/tui-snapshot.sh syntax_highlight`

## Notes
Main editor content is still Metal-rendered and is not covered by the SwiftUI-only PreviewHost path. This PR only extends the chrome snapshot coverage that PreviewHost can render directly.
