### PR TITLE
fix(buffer): avoid full content undo patch materialization

### DIFF
--- a/lib/minga/buffer/document.ex
+++ b/lib/minga/buffer/document.ex
@@ -136,6 +136,28 @@ defmodule Minga.Buffer.Document do
   @spec cursor_offset(t()) :: non_neg_integer()
   def cursor_offset(%__MODULE__{before: before}), do: byte_size(before)
 
+  @doc "Returns the total byte size of the document without materializing full content."
+  @spec content_byte_size(t()) :: non_neg_integer()
+  def content_byte_size(%__MODULE__{before: before, after: after_}) do
+    Kernel.byte_size(before) + Kernel.byte_size(after_)
+  end
+
+  @doc "Returns one byte from the document without materializing full content."
+  @spec byte_at(t(), non_neg_integer()) :: byte()
+  def byte_at(%__MODULE__{before: before, after: after_} = doc, offset)
+      when offset >= 0 do
+    gap = Kernel.byte_size(before)
+    do_byte_at(before, after_, offset, gap, content_byte_size(doc))
+  end
+
+  @doc "Returns a byte range from the document without materializing full content."
+  @spec slice_byte_range(t(), non_neg_integer(), non_neg_integer()) :: binary()
+  def slice_byte_range(%__MODULE__{} = doc, start_byte, byte_count)
+      when start_byte >= 0 and byte_count >= 0 do
+    :ok = validate_byte_range(start_byte, byte_count, content_byte_size(doc))
+    do_slice_byte_range(doc, start_byte, byte_count)
+  end
+
   # ── Mutations ──
 
   @doc """
@@ -354,6 +376,39 @@ defmodule Minga.Buffer.Document do
   end
 
   # ── Private helpers ──
+
+  @spec do_byte_at(binary(), binary(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          byte()
+  defp do_byte_at(before, _after, offset, gap, _size) when offset < gap do
+    :binary.at(before, offset)
+  end
+
+  defp do_byte_at(_before, after_, offset, gap, size) when offset < size do
+    :binary.at(after_, offset - gap)
+  end
+
+  defp do_byte_at(_before, _after, offset, _gap, size) do
+    raise ArgumentError, "byte offset out of bounds: offset=#{offset}, byte_size=#{size}"
+  end
+
+  @spec do_slice_byte_range(t(), non_neg_integer(), non_neg_integer()) :: binary()
+  defp do_slice_byte_range(%__MODULE__{}, _start_byte, 0), do: ""
+
+  defp do_slice_byte_range(%__MODULE__{before: before}, start_byte, byte_count)
+       when start_byte + byte_count <= Kernel.byte_size(before) do
+    binary_part(before, start_byte, byte_count)
+  end
+
+  defp do_slice_byte_range(%__MODULE__{before: before, after: after_}, start_byte, byte_count)
+       when start_byte >= Kernel.byte_size(before) do
+    binary_part(after_, start_byte - Kernel.byte_size(before), byte_count)
+  end
+
+  defp do_slice_byte_range(%__MODULE__{before: before, after: after_}, start_byte, byte_count) do
+    before_count = Kernel.byte_size(before) - start_byte
+    after_count = byte_count - before_count
+    binary_part(before, start_byte, before_count) <> binary_part(after_, 0, after_count)
+  end
 
   @spec validate_byte_range(non_neg_integer(), non_neg_integer(), non_neg_integer()) :: :ok
   defp validate_byte_range(start_byte, bytes_to_remove, content_size)

--- a/lib/minga/buffer/operation.ex
+++ b/lib/minga/buffer/operation.ex
@@ -5,8 +5,10 @@ defmodule Minga.Buffer.Operation do
   `Document` owns the gap-buffer data structure. This module owns domain edits that need both the updated document and the sync delta describing the change. `Buffer.Process` wraps these operations with process concerns like read-only checks, undo, dirty tracking, events, and persistence.
   """
 
+  alias Minga.Buffer.Cursor
   alias Minga.Buffer.Document
   alias Minga.Buffer.EditDelta
+  alias Minga.Buffer.Lines
   alias Minga.Buffer.Position
   alias Minga.Buffer.Selection
   alias Minga.Buffer.Span
@@ -95,6 +97,22 @@ defmodule Minga.Buffer.Operation do
     end
   end
 
+  @doc "Clears one line, returning the yanked text, new document, and delta."
+  @spec clear_line(Document.t(), non_neg_integer()) ::
+          :unchanged | {:edited, String.t(), Document.t(), EditDelta.t()}
+  def clear_line(%Document{} = doc, line) when line >= 0 do
+    case Lines.fetch(doc, line) do
+      nil ->
+        :unchanged
+
+      "" ->
+        clear_empty_line(doc, line)
+
+      text ->
+        clear_non_empty_line(doc, line, text)
+    end
+  end
+
   @doc "Deletes the character at the cursor."
   @spec delete_forward(Document.t()) :: result()
   def delete_forward(%Document{} = doc) do
@@ -144,77 +162,79 @@ defmodule Minga.Buffer.Operation do
   @spec delete_lines(Document.t(), non_neg_integer(), non_neg_integer()) :: result()
   def delete_lines(%Document{} = doc, start_line, end_line)
       when start_line >= 0 and end_line >= 0 do
-    new_doc = Document.delete_lines(doc, start_line, end_line)
+    selection = Selection.linewise(doc, start_line, end_line)
+    %Span{start: raw_start_byte, stop: old_end_byte} = selection.span
+    start_byte = effective_linewise_delete_start(doc, raw_start_byte, old_end_byte)
+    new_doc = Selection.delete(doc, selection)
 
     if new_doc == doc do
       :unchanged
     else
-      {:edited, new_doc, deletion_delta_from_documents(doc, new_doc)}
+      delta =
+        EditDelta.deletion(
+          start_byte,
+          old_end_byte,
+          Position.from_point(doc, start_byte),
+          Position.from_point(doc, old_end_byte)
+        )
+
+      {:edited, new_doc, delta}
     end
   end
 
-  @spec deletion_delta_from_documents(Document.t(), Document.t()) :: EditDelta.t()
-  defp deletion_delta_from_documents(%Document{} = old_doc, %Document{} = new_doc) do
-    old_content = Document.content(old_doc)
-    new_content = Document.content(new_doc)
-    start_byte = :binary.longest_common_prefix([old_content, new_content])
-    old_tail = byte_size(old_content) - start_byte
-    new_tail = byte_size(new_content) - start_byte
-    suffix_size = common_suffix_size(old_content, new_content, old_tail, new_tail)
-    old_end_byte = byte_size(old_content) - suffix_size
+  @spec clear_empty_line(Document.t(), non_neg_integer()) ::
+          {:edited, String.t(), Document.t(), EditDelta.t()} | :unchanged
+  defp clear_empty_line(%Document{} = doc, line) do
+    new_doc = Cursor.place(doc, {line, 0})
 
-    EditDelta.deletion(
-      start_byte,
-      old_end_byte,
-      Position.from_point(old_doc, start_byte),
-      Position.from_point(old_doc, old_end_byte)
-    )
+    if new_doc == doc do
+      :unchanged
+    else
+      start_byte = Position.point_for(doc, {line, 0})
+      delta = EditDelta.deletion(start_byte, start_byte, {line, 0}, {line, 0})
+      {:edited, "", new_doc, delta}
+    end
   end
 
-  @spec common_suffix_size(binary(), binary(), non_neg_integer(), non_neg_integer()) ::
+  @spec clear_non_empty_line(Document.t(), non_neg_integer(), String.t()) ::
+          {:edited, String.t(), Document.t(), EditDelta.t()}
+  defp clear_non_empty_line(%Document{} = doc, line, text) do
+    start_pos = {line, 0}
+    end_pos = {line, Position.last_character_on_line(text)}
+    selection = Selection.characterwise(doc, start_pos, end_pos)
+    %Span{start: start_byte, stop: old_end_byte} = selection.span
+    {yanked, new_doc} = Selection.clear_line(doc, line)
+
+    delta =
+      EditDelta.deletion(
+        start_byte,
+        old_end_byte,
+        Position.from_point(doc, start_byte),
+        Position.from_point(doc, old_end_byte)
+      )
+
+    {:edited, yanked, new_doc, delta}
+  end
+
+  @spec effective_linewise_delete_start(Document.t(), non_neg_integer(), non_neg_integer()) ::
           non_neg_integer()
-  defp common_suffix_size(left, right, left_tail, right_tail) do
-    left_suffix = binary_part(left, byte_size(left) - left_tail, left_tail)
-    right_suffix = binary_part(right, byte_size(right) - right_tail, right_tail)
-    do_common_suffix_size(left_suffix, right_suffix, left_tail, right_tail, 0)
+  defp effective_linewise_delete_start(%Document{} = doc, start_byte, old_end_byte)
+       when start_byte > 0 do
+    do_effective_linewise_delete_start(start_byte, old_end_byte, Document.content_byte_size(doc))
   end
 
-  @spec do_common_suffix_size(
-          binary(),
-          binary(),
+  defp effective_linewise_delete_start(%Document{}, start_byte, _old_end_byte), do: start_byte
+
+  @spec do_effective_linewise_delete_start(
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer()
         ) :: non_neg_integer()
-  defp do_common_suffix_size(_left, _right, 0, _right_tail, count), do: count
-  defp do_common_suffix_size(_left, _right, _left_tail, 0, count), do: count
-
-  defp do_common_suffix_size(left, right, left_tail, right_tail, count) do
-    left_byte = :binary.at(left, left_tail - 1)
-    right_byte = :binary.at(right, right_tail - 1)
-
-    continue_common_suffix_size(
-      left,
-      right,
-      left_tail,
-      right_tail,
-      count,
-      left_byte == right_byte
-    )
+  defp do_effective_linewise_delete_start(start_byte, document_size, document_size) do
+    start_byte - 1
   end
 
-  @spec continue_common_suffix_size(
-          binary(),
-          binary(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          boolean()
-        ) :: non_neg_integer()
-  defp continue_common_suffix_size(left, right, left_tail, right_tail, count, true) do
-    do_common_suffix_size(left, right, left_tail - 1, right_tail - 1, count + 1)
+  defp do_effective_linewise_delete_start(start_byte, _old_end_byte, _document_size) do
+    start_byte
   end
-
-  defp continue_common_suffix_size(_left, _right, _left_tail, _right_tail, count, false),
-    do: count
 end

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -973,10 +973,10 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call({:find_and_replace, old_text, new_text, boundary}, _from, state) do
-    case Replace.apply(state.document, old_text, new_text, boundary) do
-      {:ok, new_doc, msg} ->
+    case Replace.apply_with_delta(state.document, old_text, new_text, boundary) do
+      {:ok, new_doc, delta, msg} ->
         {:reply, {:ok, msg},
-         push_undo_force_full(state, new_doc, :agent)
+         push_undo_force(state, new_doc, :agent, delta)
          |> mark_dirty()
          |> clear_edits(EditSource.agent(self(), "unknown"))}
 
@@ -994,15 +994,18 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call({:find_and_replace_batch, edits, boundary}, _from, state) do
-    {final_doc, results, any_applied?} = Replace.apply_batch(state.document, edits, boundary)
+    {final_doc, results, patches} =
+      Replace.apply_batch_with_deltas(state.document, edits, boundary)
 
     new_state =
-      if any_applied? do
-        push_undo_force_full(state, final_doc, :agent)
-        |> mark_dirty()
-        |> clear_edits(EditSource.agent(self(), "unknown"))
-      else
-        state
+      case patches do
+        [] ->
+          state
+
+        [_patch | _rest] ->
+          push_undo_batch(state, final_doc, :agent, patches)
+          |> mark_dirty()
+          |> clear_edits(EditSource.agent(self(), "unknown"))
       end
 
     {:reply, {:ok, results}, new_state}
@@ -1499,12 +1502,12 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call({:clear_line, line}, _from, state) do
-    {yanked, new_buf} = Document.clear_line(state.document, line)
+    case Operation.clear_line(state.document, line) do
+      :unchanged ->
+        {:reply, {:ok, ""}, state}
 
-    if new_buf == state.document do
-      {:reply, {:ok, yanked}, state}
-    else
-      {:reply, {:ok, yanked}, push_undo_full(state, new_buf, :user) |> mark_dirty()}
+      {:edited, yanked, new_doc, delta} ->
+        {:reply, {:ok, yanked}, push_undo(state, new_doc, :user, delta) |> mark_dirty()}
     end
   end
 
@@ -1951,6 +1954,16 @@ defmodule Minga.Buffer.Process do
   defp push_undo_batch(state, new_buf, source, patches) do
     undo_history =
       UndoHistory.record_edit_batch(state.undo_history, BufState.version(state), patches, source)
+
+    %{state | document: new_buf, undo_history: undo_history}
+  end
+
+  @spec push_undo_force(state(), Document.t(), BufState.edit_source(), EditDelta.t()) :: state()
+  defp push_undo_force(state, new_buf, source, delta) do
+    patch = UndoPatch.from_delta(delta, state.document)
+
+    undo_history =
+      UndoHistory.record_edit_force(state.undo_history, BufState.version(state), patch, source)
 
     %{state | document: new_buf, undo_history: undo_history}
   end

--- a/lib/minga/buffer/replace.ex
+++ b/lib/minga/buffer/replace.ex
@@ -5,7 +5,7 @@ defmodule Minga.Buffer.Replace do
   This module owns the domain semantics for agent-style find-and-replace edits: the expected text must identify exactly one replacement target, optional line boundaries are enforced against that target, and batch replacements apply sequentially while preserving per-edit results. `Buffer.Process` and `Buffer.Fork` wrap these pure operations with their own process, undo, version, and merge concerns.
   """
 
-  alias Minga.Buffer.Document
+  alias Minga.Buffer.{Document, EditDelta, Position, UndoPatch}
 
   @typedoc "An edit boundary as `{start_line, end_line}` (both inclusive, 0-indexed), or nil for unbounded."
   @type boundary :: {non_neg_integer(), non_neg_integer()} | nil
@@ -19,32 +19,58 @@ defmodule Minga.Buffer.Replace do
   @typedoc "Result of applying a batch of replacement edits."
   @type batch_result :: {Document.t(), [result()], any_applied? :: boolean()}
 
+  @typedoc "Successful replacement with the edit delta that describes it."
+  @type delta_result :: {:ok, Document.t(), EditDelta.t(), String.t()} | {:error, String.t()}
+
   @doc "Applies a replacement when `old_text` identifies exactly one target in the document."
   @spec apply(Document.t(), String.t(), String.t(), boundary()) ::
           {:ok, Document.t(), String.t()} | {:error, String.t()}
   def apply(%Document{} = doc, old_text, new_text, boundary \\ nil)
       when is_binary(old_text) and is_binary(new_text) do
+    case apply_with_delta(doc, old_text, new_text, boundary) do
+      {:ok, new_doc, _delta, msg} -> {:ok, new_doc, msg}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc "Applies a replacement and returns the edit delta that describes the changed range."
+  @spec apply_with_delta(Document.t(), String.t(), String.t(), boundary()) :: delta_result()
+  def apply_with_delta(%Document{} = doc, old_text, new_text, boundary \\ nil)
+      when is_binary(old_text) and is_binary(new_text) do
     content = Document.content(doc)
 
     with {:ok, match} <- find_replacement_target(content, old_text),
          :ok <- check_boundary(content, match, boundary) do
-      {:ok, replace_match(content, match, new_text), "applied"}
+      new_doc = replace_match(content, match, new_text)
+      {:ok, new_doc, replacement_delta(doc, new_doc, match, new_text), "applied"}
     end
   end
 
   @doc "Applies replacements sequentially and returns the final document plus per-edit results."
   @spec apply_batch(Document.t(), [edit()], boundary()) :: batch_result()
   def apply_batch(%Document{} = doc, edits, boundary \\ nil) when is_list(edits) do
-    {final_doc, results_reversed} =
-      Enum.reduce(edits, {doc, []}, fn {old_text, new_text}, {current_doc, acc} ->
-        case apply(current_doc, old_text, new_text, boundary) do
-          {:ok, new_doc, msg} -> {new_doc, [{:ok, msg} | acc]}
-          {:error, _} = err -> {current_doc, [err | acc]}
+    {final_doc, results, _patches} = apply_batch_with_deltas(doc, edits, boundary)
+    {final_doc, results, Enum.any?(results, &match?({:ok, _}, &1))}
+  end
+
+  @doc "Applies replacements sequentially and returns the final document, per-edit results, and undo patches in newest-first order."
+  @spec apply_batch_with_deltas(Document.t(), [edit()], boundary()) ::
+          {Document.t(), [result()], [UndoPatch.t()]}
+  def apply_batch_with_deltas(%Document{} = doc, edits, boundary \\ nil) when is_list(edits) do
+    {final_doc, results_reversed, patches} =
+      Enum.reduce(edits, {doc, [], []}, fn {old_text, new_text},
+                                           {current_doc, results, patches} ->
+        case apply_with_delta(current_doc, old_text, new_text, boundary) do
+          {:ok, new_doc, delta, msg} ->
+            patch = UndoPatch.from_delta(delta, current_doc)
+            {new_doc, [{:ok, msg} | results], [patch | patches]}
+
+          {:error, _} = err ->
+            {current_doc, [err | results], patches}
         end
       end)
 
-    results = Enum.reverse(results_reversed)
-    {final_doc, results, Enum.any?(results, &match?({:ok, _}, &1))}
+    {final_doc, Enum.reverse(results_reversed), patches}
   end
 
   @spec find_replacement_target(String.t(), String.t()) ::
@@ -83,6 +109,24 @@ defmodule Minga.Buffer.Replace do
     binary
     |> :binary.matches("\n")
     |> length()
+  end
+
+  @spec replacement_delta(
+          Document.t(),
+          Document.t(),
+          {non_neg_integer(), pos_integer()},
+          String.t()
+        ) ::
+          EditDelta.t()
+  defp replacement_delta(%Document{} = doc, %Document{} = new_doc, {offset, len}, new_text) do
+    EditDelta.replacement(
+      offset,
+      offset + len,
+      Position.from_point(doc, offset),
+      Position.from_point(doc, offset + len),
+      new_text,
+      Position.from_point(new_doc, offset + byte_size(new_text))
+    )
   end
 
   @spec replace_match(String.t(), {non_neg_integer(), pos_integer()}, String.t()) :: Document.t()

--- a/lib/minga/buffer/undo_patch.ex
+++ b/lib/minga/buffer/undo_patch.ex
@@ -26,13 +26,13 @@ defmodule Minga.Buffer.UndoPatch do
   def from_delta(%EditDelta{} = delta, %Document{} = old_document) do
     old_text =
       old_document
-      |> Document.content()
-      |> binary_part(delta.start_byte, delta.old_end_byte - delta.start_byte)
+      |> Document.slice_byte_range(delta.start_byte, delta.old_end_byte - delta.start_byte)
+      |> own_binary()
 
     %__MODULE__{
       start_byte: delta.start_byte,
       old_text: old_text,
-      new_text: delta.inserted_text,
+      new_text: own_binary(delta.inserted_text),
       cursor: Document.cursor(old_document)
     }
   end
@@ -40,17 +40,25 @@ defmodule Minga.Buffer.UndoPatch do
   @doc "Builds a minimal byte-range patch from two document versions."
   @spec from_documents(Document.t(), Document.t()) :: t()
   def from_documents(%Document{} = old_document, %Document{} = new_document) do
-    old_text = Document.content(old_document)
-    new_text = Document.content(new_document)
-    start_byte = common_prefix_size(old_text, new_text)
-    old_tail = byte_size(old_text) - start_byte
-    new_tail = byte_size(new_text) - start_byte
-    suffix_size = common_suffix_size(old_text, new_text, old_tail, new_tail)
+    old_size = Document.content_byte_size(old_document)
+    new_size = Document.content_byte_size(new_document)
+    start_byte = common_prefix_size(old_document, new_document, min(old_size, new_size), 0)
+    old_tail = old_size - start_byte
+    new_tail = new_size - start_byte
+
+    suffix_size =
+      common_suffix_size(old_document, new_document, old_size, new_size, start_byte, 0)
 
     %__MODULE__{
       start_byte: start_byte,
-      old_text: binary_part(old_text, start_byte, old_tail - suffix_size),
-      new_text: binary_part(new_text, start_byte, new_tail - suffix_size),
+      old_text:
+        old_document
+        |> Document.slice_byte_range(start_byte, old_tail - suffix_size)
+        |> own_binary(),
+      new_text:
+        new_document
+        |> Document.slice_byte_range(start_byte, new_tail - suffix_size)
+        |> own_binary(),
       cursor: Document.cursor(old_document)
     }
   end
@@ -78,55 +86,89 @@ defmodule Minga.Buffer.UndoPatch do
     )
   end
 
-  @spec common_prefix_size(binary(), binary()) :: non_neg_integer()
-  defp common_prefix_size(left, right) do
-    :binary.longest_common_prefix([left, right])
-  end
+  @spec own_binary(binary()) :: binary()
+  defp own_binary(binary), do: :binary.copy(binary)
 
-  @spec common_suffix_size(binary(), binary(), non_neg_integer(), non_neg_integer()) ::
+  @spec common_prefix_size(Document.t(), Document.t(), non_neg_integer(), non_neg_integer()) ::
           non_neg_integer()
-  defp common_suffix_size(left, right, left_tail, right_tail) do
-    left_suffix = binary_part(left, byte_size(left) - left_tail, left_tail)
-    right_suffix = binary_part(right, byte_size(right) - right_tail, right_tail)
-    do_common_suffix_size(left_suffix, right_suffix, left_tail, right_tail, 0)
+  defp common_prefix_size(_left, _right, limit, count) when count == limit, do: count
+
+  defp common_prefix_size(left, right, limit, count) do
+    continue_common_prefix_size(
+      left,
+      right,
+      limit,
+      count,
+      Document.byte_at(left, count) == Document.byte_at(right, count)
+    )
   end
 
-  @spec do_common_suffix_size(
-          binary(),
-          binary(),
+  @spec continue_common_prefix_size(
+          Document.t(),
+          Document.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean()
+        ) ::
+          non_neg_integer()
+  defp continue_common_prefix_size(left, right, limit, count, true) do
+    common_prefix_size(left, right, limit, count + 1)
+  end
+
+  defp continue_common_prefix_size(_left, _right, _limit, count, false), do: count
+
+  @spec common_suffix_size(
+          Document.t(),
+          Document.t(),
+          non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer()
         ) :: non_neg_integer()
-  defp do_common_suffix_size(_left, _right, 0, _right_tail, count), do: count
-  defp do_common_suffix_size(_left, _right, _left_tail, 0, count), do: count
+  defp common_suffix_size(_left, _right, old_size, _new_size, start_byte, count)
+       when count == old_size - start_byte,
+       do: count
 
-  defp do_common_suffix_size(left, right, left_tail, right_tail, count) do
-    left_byte = :binary.at(left, left_tail - 1)
-    right_byte = :binary.at(right, right_tail - 1)
+  defp common_suffix_size(_left, _right, _old_size, new_size, start_byte, count)
+       when count == new_size - start_byte,
+       do: count
+
+  defp common_suffix_size(left, right, old_size, new_size, start_byte, count) do
+    old_byte = Document.byte_at(left, old_size - count - 1)
+    new_byte = Document.byte_at(right, new_size - count - 1)
 
     continue_common_suffix_size(
       left,
       right,
-      left_tail,
-      right_tail,
+      old_size,
+      new_size,
+      start_byte,
       count,
-      left_byte == right_byte
+      old_byte == new_byte
     )
   end
 
   @spec continue_common_suffix_size(
-          binary(),
-          binary(),
+          Document.t(),
+          Document.t(),
+          non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
           boolean()
         ) :: non_neg_integer()
-  defp continue_common_suffix_size(left, right, left_tail, right_tail, count, true) do
-    do_common_suffix_size(left, right, left_tail - 1, right_tail - 1, count + 1)
+  defp continue_common_suffix_size(left, right, old_size, new_size, start_byte, count, true) do
+    common_suffix_size(left, right, old_size, new_size, start_byte, count + 1)
   end
 
-  defp continue_common_suffix_size(_left, _right, _left_tail, _right_tail, count, false),
-    do: count
+  defp continue_common_suffix_size(
+         _left,
+         _right,
+         _old_size,
+         _new_size,
+         _start_byte,
+         count,
+         false
+       ),
+       do: count
 end

--- a/test/minga/buffer/document_test.exs
+++ b/test/minga/buffer/document_test.exs
@@ -40,6 +40,39 @@ defmodule Minga.Buffer.DocumentTest do
     end
   end
 
+  describe "byte range queries" do
+    test "byte_size counts both gap halves" do
+      doc = Document.new("hello") |> Document.move_to({0, 2})
+      assert Document.content_byte_size(doc) == 5
+    end
+
+    test "byte_at reads before and after the cursor gap" do
+      doc = Document.new("hello") |> Document.move_to({0, 2})
+      assert Document.byte_at(doc, 1) == ?e
+      assert Document.byte_at(doc, 2) == ?l
+    end
+
+    test "slice_byte_range reads before the gap" do
+      doc = Document.new("hello world") |> Document.move_to({0, 5})
+      assert Document.slice_byte_range(doc, 1, 3) == "ell"
+    end
+
+    test "slice_byte_range reads after the gap" do
+      doc = Document.new("hello world") |> Document.move_to({0, 5})
+      assert Document.slice_byte_range(doc, 6, 5) == "world"
+    end
+
+    test "slice_byte_range reads across the gap" do
+      doc = Document.new("hello world") |> Document.move_to({0, 5})
+      assert Document.slice_byte_range(doc, 3, 5) == "lo wo"
+    end
+
+    test "slice_byte_range preserves byte-level unicode fragments" do
+      doc = Document.new("aé日z") |> Document.move_to({0, 3})
+      assert Document.slice_byte_range(doc, 1, 5) == "é日"
+    end
+  end
+
   # ── Insertion ──
 
   describe "insert_text/2" do

--- a/test/minga/buffer/operation_test.exs
+++ b/test/minga/buffer/operation_test.exs
@@ -69,4 +69,21 @@ defmodule Minga.Buffer.OperationTest do
       assert delta.inserted_text == ""
     end
   end
+
+  describe "clear_line/2" do
+    test "returns yanked text and a deletion delta for a non-empty line" do
+      doc = Document.new("one\ntwø\nthree")
+
+      assert {:edited, yanked, new_doc, delta} = Operation.clear_line(doc, 1)
+      assert yanked == "twø"
+      assert Document.content(new_doc) == "one\n\nthree"
+      assert delta.start_byte == 4
+      assert delta.old_end_byte == 8
+      assert delta.new_end_byte == 4
+      assert delta.start_position == {1, 0}
+      assert delta.old_end_position == {1, 4}
+      assert delta.new_end_position == {1, 0}
+      assert delta.inserted_text == ""
+    end
+  end
 end

--- a/test/minga/buffer/process_test.exs
+++ b/test/minga/buffer/process_test.exs
@@ -721,6 +721,33 @@ defmodule Minga.Buffer.ProcessTest do
       assert BufferProcess.last_undo_source(pid) == :agent
     end
 
+    test "find_and_replace redo reapplies multiline replacements" do
+      pid = start_supervised!({BufferProcess, content: "alpha\nbeta\ngamma"})
+
+      assert {:ok, _} = BufferProcess.find_and_replace(pid, "beta", "one\ntwo")
+      assert BufferProcess.content(pid) == "alpha\none\ntwo\ngamma"
+
+      BufferProcess.undo(pid)
+      assert BufferProcess.content(pid) == "alpha\nbeta\ngamma"
+
+      BufferProcess.redo(pid)
+      assert BufferProcess.content(pid) == "alpha\none\ntwo\ngamma"
+    end
+
+    test "find_and_replace_batch redo reapplies unicode replacements" do
+      pid = start_supervised!({BufferProcess, content: "hello café world"})
+
+      assert {:ok, results} = BufferProcess.find_and_replace_batch(pid, [{"café", "茶"}])
+      assert Enum.all?(results, &match?({:ok, _}, &1))
+      assert BufferProcess.content(pid) == "hello 茶 world"
+
+      BufferProcess.undo(pid)
+      assert BufferProcess.content(pid) == "hello café world"
+
+      BufferProcess.redo(pid)
+      assert BufferProcess.content(pid) == "hello 茶 world"
+    end
+
     test "replace_content records explicit and default sources" do
       pid = start_supervised!({BufferProcess, content: "hello"})
       BufferProcess.replace_content(pid, "goodbye", :agent)
@@ -773,6 +800,37 @@ defmodule Minga.Buffer.ProcessTest do
       # Undo the agent edit; the user entry below should now be at the head.
       BufferProcess.undo(pid)
       assert BufferProcess.last_undo_source(pid) == :user
+    end
+  end
+
+  describe "clear_line/2" do
+    test "returns yanked text, changes content, and supports undo/redo" do
+      pid = start_supervised!({BufferProcess, content: "one\ntwo\nthree"})
+
+      assert {:ok, "two"} = BufferProcess.clear_line(pid, 1)
+      assert BufferProcess.content(pid) == "one\n\nthree"
+
+      BufferProcess.undo(pid)
+      assert BufferProcess.content(pid) == "one\ntwo\nthree"
+
+      BufferProcess.redo(pid)
+      assert BufferProcess.content(pid) == "one\n\nthree"
+    end
+  end
+
+  describe "undo patch memory" do
+    test "1000 small undo entries on a 1 MB file stay under 10 MB" do
+      content = String.duplicate("a", 1_000_000)
+      {:ok, pid} = BufferProcess.start_link(content: content)
+      BufferProcess.move_to(pid, {0, byte_size(content)})
+
+      for _ <- 1..1000 do
+        BufferProcess.break_undo_coalescing(pid)
+        BufferProcess.insert_char(pid, "x")
+      end
+
+      undo_bytes = :erlang.external_size(:sys.get_state(pid).undo_history)
+      assert undo_bytes < 10 * 1024 * 1024
     end
   end
 

--- a/test/minga/buffer/undo_patch_test.exs
+++ b/test/minga/buffer/undo_patch_test.exs
@@ -41,6 +41,30 @@ defmodule Minga.Buffer.UndoPatchTest do
       assert patch.new_text == "TWO"
       assert UndoPatch.apply(patch, new_doc) |> Document.content() == "one two three"
     end
+
+    test "captures deleted text across the cursor gap" do
+      old_doc = doc("abc def") |> Document.move_to({0, 4})
+      {:edited, new_doc, delta} = Operation.replace_range(old_doc, {0, 2}, {0, 4}, "X")
+
+      patch = UndoPatch.from_delta(delta, old_doc)
+
+      assert patch.old_text == "c d"
+      assert patch.new_text == "X"
+      assert UndoPatch.apply(patch, new_doc) |> Document.content() == "abc def"
+    end
+
+    test "owns deleted slices instead of retaining the original large document binary" do
+      prefix = String.duplicate("a", 1_000_000)
+      old_doc = doc(prefix <> "TARGET")
+
+      {:edited, _new_doc, delta} =
+        Operation.replace_range(old_doc, {0, byte_size(prefix)}, {0, byte_size(prefix) + 5}, "x")
+
+      patch = UndoPatch.from_delta(delta, old_doc)
+
+      assert patch.old_text == "TARGET"
+      assert :binary.referenced_byte_size(patch.old_text) == byte_size(patch.old_text)
+    end
   end
 
   describe "invert/2" do
@@ -88,6 +112,20 @@ defmodule Minga.Buffer.UndoPatchTest do
       assert patch.old_text == "old"
       assert patch.new_text == "new"
       assert byte_size(patch.old_text) + byte_size(patch.new_text) == 6
+    end
+
+    test "handles mid-buffer cursor gaps with unicode near the diff" do
+      old_doc = doc("αβγδ") |> Document.move_to({0, 4})
+      new_doc = doc("αβξδ") |> Document.move_to({0, 4})
+
+      patch = UndoPatch.from_documents(old_doc, new_doc)
+
+      assert patch.start_byte == 5
+      assert byte_size(patch.old_text) == 1
+      assert byte_size(patch.new_text) == 1
+      refute String.valid?(patch.old_text)
+      refute String.valid?(patch.new_text)
+      assert Document.content(UndoPatch.apply(patch, new_doc)) == "αβγδ"
     end
   end
 end


### PR DESCRIPTION
# TL;DR
Undo history now records small byte-range patches without flattening whole documents during patch construction. This keeps the existing `Document` + `EditDelta` + `UndoPatch` model, but adds gap-aware byte queries so undo can capture only the changed bytes.

Closes #1889

## Context
Issue #1889 identified that undo patch construction was still materializing full buffer content, even when an edit delta already identified the changed byte range. That made large-file edits allocate work proportional to file size instead of edit size.

This PR keeps the architecture vocabulary narrow: `Document` owns efficient access to gap-buffer storage, `EditDelta` describes the change, and `UndoPatch` derives the reversible patch from the delta plus the old document.

## Changes
- Added gap-aware `Document.content_byte_size/1`, `Document.byte_at/2`, and `Document.slice_byte_range/3` queries.
- Reworked `UndoPatch.from_delta/2` and `UndoPatch.from_documents/2` so patch construction no longer calls `Document.content/1`.
- Copied captured patch binaries with `:binary.copy/1` so small undo patches do not retain large source document binaries through sub-binary references.
- Changed find-and-replace undo recording to use delta-backed patches instead of forced full-document diff patches.
- Reworked line deletion and clear-line delta construction through `Minga.Buffer.Operation` instead of full old/new document content diffing.
- Moved batch replacement patch sequencing into `Minga.Buffer.Replace`, keeping replacement semantics out of the GenServer orchestration layer.
- Added regression coverage for gap-crossing slices, patch binary ownership, redo round trips, clear-line undo/redo, and the 1000-entry large-file memory target.

## Verification
- `mix test.llm test/minga/buffer/document_test.exs test/minga/buffer/undo_patch_test.exs test/minga/buffer/process_test.exs test/minga/buffer/operation_test.exs test/minga/buffer/replace_test.exs test/minga/buffer/delete_lines_test.exs test/minga/buffer/undo_test.exs` ✅
- `mix test.llm test/minga/buffer` ✅, 621 tests
- `make lint` ✅
- `mix test.llm` ✅, 8698 tests, 0 failures, 268 excluded
- Parent-orchestrated review loop: 2 rounds, final Round 2 PASS from correctness, test, and simplicity reviewers

## Acceptance Criteria Addressed
- No undo-related code path calls `Document.content/1` for patch computation ✅
- Undo patches are constructed from edit deltas or direct mutation context ✅
- Undo/redo behavior is unchanged, existing undo tests pass ✅
- Coalescing of rapid edits still works correctly ✅
- Memory usage for 1000 undo entries on a 1 MB file stays under 10 MB ✅
