### PR TITLE
feat(macos): V1 editor intelligence snapshot evidence

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -83,7 +83,6 @@
 		36E0C059965477465E15CC02 /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
 		3756AD45E2913D656D1D7255 /* EditTimelineState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2E999D82FCC18364568E8B /* EditTimelineState.swift */; };
 		3767C83415B32C31B33EFFFB /* MinibufferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2D3B0C9A042E9A5C485E1 /* MinibufferState.swift */; };
-		3786455FC273F48F85C0DE4A /* EditorChromeView.png in Resources */ = {isa = PBXBuildFile; fileRef = 0F8A2F94CAD4B77064FB9894 /* EditorChromeView.png */; };
 		3897BF151EA81DDF38B85047 /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
 		393F9EE9CE5F6691781C8CF7 /* MinibufferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DDF3EED1B486C4639A06FF /* MinibufferView.swift */; };
 		3943C8DF3827347B61E6B725 /* MinibufferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DDF3EED1B486C4639A06FF /* MinibufferView.swift */; };
@@ -136,7 +135,6 @@
 		630D7B1922CBCCF1335491C2 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
 		63AD77F5D54E43D9376810DC /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
 		63F3CF3A4746901FDF1C3356 /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
-		644651957542041BB07F6819 /* FileTreeView.png in Resources */ = {isa = PBXBuildFile; fileRef = 74F5BDC126D824CD2C499359 /* FileTreeView.png */; };
 		647346FE3161B2C2FC4A5436 /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
 		6474095F95F4DA480AFE91B7 /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
 		64A5A16E02B3E2694060F1A1 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
@@ -179,7 +177,6 @@
 		7D395895306A81736A98E8B9 /* ExtensionPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D54D0AA54F1EC07318AEA /* ExtensionPanelState.swift */; };
 		7DB249F526EB508249BE3964 /* ChangeSummaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E3D96CF06FCC7F116AF4DC /* ChangeSummaryState.swift */; };
 		7E2428F971A8835D3B42598B /* GitStatusState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B5F67DE84B139C6F8F3C9F /* GitStatusState.swift */; };
-		7F5AEBE16F765D8163F7D8A9 /* StatusBarView.png in Resources */ = {isa = PBXBuildFile; fileRef = 4DB8CFA9B73750AD34E77A0C /* StatusBarView.png */; };
 		7FE374C007A79192530A6B26 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		806AF50CBA2A30F3DFCB10CF /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */; };
 		80EB118387A9EA307762F482 /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2EC7DA888E31E55CE0D715 /* AgentContextBar.swift */; };
@@ -205,7 +202,6 @@
 		8D55764B8CF042B4C48AA5D0 /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
 		8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
 		8FB0DF76DEB5112AD590BB11 /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
-		90DDED0067C36E07960445C9 /* TabBarView.png in Resources */ = {isa = PBXBuildFile; fileRef = E446B783B6308E4878B80018 /* TabBarView.png */; };
 		92AFB851C9873F6E26F069A3 /* TextHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA1A468192F9DE2BBF374DD /* TextHighlighting.swift */; };
 		9303B34232153C61D709B7D6 /* ActivityBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80457F318D9322F416DA291 /* ActivityBar.swift */; };
 		931A6127210D4ED441AC04B2 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */; };
@@ -228,7 +224,6 @@
 		A084A045EA71D390C188EB23 /* DispatchSheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4322CD8BEEFC8C2FB832438 /* DispatchSheetState.swift */; };
 		A1AFA4551E04034C5FF5D39B /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD30A2572AE2608F099407 /* ScrollAccumulator.swift */; };
 		A1F7FEEEDE79E743506763C7 /* FileTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */; };
-		A2248AB663ACECA334695D9C /* NotificationCenterView.png in Resources */ = {isa = PBXBuildFile; fileRef = 1D3FC97A5BF803712978AB67 /* NotificationCenterView.png */; };
 		A25FEFF01578CFA880BDC424 /* ExtensionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836BA390DF0C2A711D270D2C /* ExtensionOverlayView.swift */; };
 		A29BB96B8F84AA489CBA0C5F /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
 		A33FB24A0B21158461545E39 /* NotificationCenterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BC213C5FAF120260716363 /* NotificationCenterView.swift */; };
@@ -249,7 +244,6 @@
 		AB804A6366BEFE62E30C929B /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		AC0F67258603E07297F526CE /* EditTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9DA04BBCBA8D286E62C0EA /* EditTimelineView.swift */; };
 		AD9123932ACE42FBAB6B0DD7 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
-		AF0877EE13E581DD7B20FA39 /* CompletionOverlay.png in Resources */ = {isa = PBXBuildFile; fileRef = F9437DDA1ADDABFCEAF93E1B /* CompletionOverlay.png */; };
 		AFE31388980EE451C8F734A3 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
 		B0A5712B943D48F8F72C1DDA /* KeyboardInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */; };
 		B0DFAD8D1AF624C9EA6D1940 /* ExtensionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BB136A9D180CCAD371E51 /* ExtensionPanelView.swift */; };
@@ -281,7 +275,6 @@
 		C028B986AC51F3180074F8C7 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B982679577E3DBD4E7A69D /* SettingsView.swift */; };
 		C07AF84A6E689758D100A251 /* InlineEditField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC5F0D37085813890268537 /* InlineEditField.swift */; };
 		C134E5115725A3A85492FF51 /* TabBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */; };
-		C2B552F09F4C033A34651A89 /* GitStatusView.png in Resources */ = {isa = PBXBuildFile; fileRef = E8BEF10DDD749FBA592D2D0E /* GitStatusView.png */; };
 		C3E6CE94BD471AC7BA0FB4BB /* DispatchSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5A488C20326CCE3A7FC46E /* DispatchSheetView.swift */; };
 		C44D9CF03C49E7BCA39A76A9 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
 		C584795C157090A25C15518B /* SearchToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48E4A7CE35A41F8198B7AE4 /* SearchToolbar.swift */; };
@@ -313,7 +306,6 @@
 		DD78E8B97A78A84587C0F461 /* DispatchSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5A488C20326CCE3A7FC46E /* DispatchSheetView.swift */; };
 		DE495CCFC92C702B2A3243A0 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7C3564C27A7E14D894539 /* TabBarView.swift */; };
 		DE6C77896ED3E1E885216DC3 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
-		DECD646B250DF38B1F4C688D /* ObservatoryView.png in Resources */ = {isa = PBXBuildFile; fileRef = B4BFCE1FA1C25A2AF0D78F90 /* ObservatoryView.png */; };
 		DF3B2A645C089F616B9DBD1B /* ProtocolEncoderDisconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */; };
 		DF3C7F2962B4563C54D82C8C /* PreviewSnapshotPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100F1DE1D6A8C5A2065AC582 /* PreviewSnapshotPolicyTests.swift */; };
 		DF9EDB44B49C0D61E40D149B /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
@@ -334,7 +326,6 @@
 		E875D0158B461B4B2FA4BEF7 /* CompletionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */; };
 		E93CE7A76DFFE33E52603B3A /* CompletionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA9C2BB0C840BE88B0FEA52 /* CompletionState.swift */; };
 		E9EB891ABF924F99E6418BF7 /* ExtensionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836BA390DF0C2A711D270D2C /* ExtensionOverlayView.swift */; };
-		EA05D17A333275729155DCB1 /* AgentChromeView.png in Resources */ = {isa = PBXBuildFile; fileRef = 5C15B295136BB21BA042ADED /* AgentChromeView.png */; };
 		EAB3B23E6209C12EE042F2DE /* ExtensionPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D54D0AA54F1EC07318AEA /* ExtensionPanelState.swift */; };
 		EACCC33CD56D244D5A8B30B3 /* FloatPopupState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EF5FFAD8310BD41CF784AC /* FloatPopupState.swift */; };
 		EAD04948D33D0D96FBEC823B /* ExtensionOverlayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F88438F21DF56F11861F9 /* ExtensionOverlayState.swift */; };
@@ -355,7 +346,6 @@
 		F5DA741E5CBCF22184C6C712 /* ProtocolTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */; };
 		F6F56719C285CB9C3EA62A57 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5647A59C841B3C408994CC7 /* Assets.xcassets */; };
 		F73BC19318B2FB4D1BBC01CB /* SidebarHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */; };
-		F777AD7AB01B7E0707001CDF /* AgentChatView.png in Resources */ = {isa = PBXBuildFile; fileRef = D2EA86C38C62F66C404B85AE /* AgentChatView.png */; };
 		F99ACADC9C8BF572A3E6115F /* PreviewSnapshotPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1D0E05FBEEC550591460C7 /* PreviewSnapshotPolicy.swift */; };
 		F9F3F732BC6DBB9ACDD4399D /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83165B89231936674C54B513 /* EditorNSView.swift */; };
 		FA582944CD6B90BCABC13FCE /* ProtocolReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */; };
@@ -383,7 +373,6 @@
 		0C26E064D810299C0302F439 /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
 		0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedLineTexture.swift; sourceTree = "<group>"; };
 		0E2EC7DA888E31E55CE0D715 /* AgentContextBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentContextBar.swift; sourceTree = "<group>"; };
-		0F8A2F94CAD4B77064FB9894 /* EditorChromeView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EditorChromeView.png; sourceTree = "<group>"; };
 		0FC35125B6A0561FE9B5B231 /* NotificationCenterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterState.swift; sourceTree = "<group>"; };
 		100F1DE1D6A8C5A2065AC582 /* PreviewSnapshotPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSnapshotPolicyTests.swift; sourceTree = "<group>"; };
 		16B5F67DE84B139C6F8F3C9F /* GitStatusState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusState.swift; sourceTree = "<group>"; };
@@ -391,7 +380,6 @@
 		1AC5F0D37085813890268537 /* InlineEditField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineEditField.swift; sourceTree = "<group>"; };
 		1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewTests.swift; sourceTree = "<group>"; };
 		1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderButton.swift; sourceTree = "<group>"; };
-		1D3FC97A5BF803712978AB67 /* NotificationCenterView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = NotificationCenterView.png; sourceTree = "<group>"; };
 		211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollAccumulatorTests.swift; sourceTree = "<group>"; };
 		22420E1CC772DAFB9A5043C2 /* ViewModelComputedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelComputedTests.swift; sourceTree = "<group>"; };
 		23EF5FFAD8310BD41CF784AC /* FloatPopupState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatPopupState.swift; sourceTree = "<group>"; };
@@ -425,7 +413,6 @@
 		4BC98120D82BD7548347875E /* FontFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFace.swift; sourceTree = "<group>"; };
 		4C874A0099721763D5109D99 /* BoardTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTypes.swift; sourceTree = "<group>"; };
 		4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MingaWindow.swift; sourceTree = "<group>"; };
-		4DB8CFA9B73750AD34E77A0C /* StatusBarView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = StatusBarView.png; sourceTree = "<group>"; };
 		52F606681DE9AA9D502A42AA /* PickerOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerOverlay.swift; sourceTree = "<group>"; };
 		53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Instrumentation.swift; sourceTree = "<group>"; };
 		5458552EC58E44C7CD15A98A /* FileTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeView.swift; sourceTree = "<group>"; };
@@ -435,7 +422,6 @@
 		56B00002D020FED57D265C74 /* SystemColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemColorTests.swift; sourceTree = "<group>"; };
 		57B35E8311966948B1BA7AEF /* DecoderRobustnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderRobustnessTests.swift; sourceTree = "<group>"; };
 		59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeHeaderContent.swift; sourceTree = "<group>"; };
-		5C15B295136BB21BA042ADED /* AgentChromeView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AgentChromeView.png; sourceTree = "<group>"; };
 		5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTextMetalRenderer.swift; sourceTree = "<group>"; };
 		620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentRendererTests.swift; sourceTree = "<group>"; };
 		638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelState.swift; sourceTree = "<group>"; };
@@ -445,7 +431,6 @@
 		6BCD60250752188DDE054B12 /* ObservatoryGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservatoryGraphView.swift; sourceTree = "<group>"; };
 		70D5765529645C5D860576B7 /* WhichKeyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyState.swift; sourceTree = "<group>"; };
 		73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceIconPicker.swift; sourceTree = "<group>"; };
-		74F5BDC126D824CD2C499359 /* FileTreeView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = FileTreeView.png; sourceTree = "<group>"; };
 		754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIChromeDecoderTests.swift; sourceTree = "<group>"; };
 		77BBC8154E1D48CE215F2F25 /* SettingsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsState.swift; sourceTree = "<group>"; };
 		790F7E20F30FEEFC552B3685 /* WindowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContent.swift; sourceTree = "<group>"; };
@@ -475,7 +460,6 @@
 		AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseInputTests.swift; sourceTree = "<group>"; };
 		AB89E1589D78EC2BACA5D892 /* ObservatoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservatoryView.swift; sourceTree = "<group>"; };
 		AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentView.swift; sourceTree = "<group>"; };
-		B4BFCE1FA1C25A2AF0D78F90 /* ObservatoryView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ObservatoryView.png; sourceTree = "<group>"; };
 		B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerThermalPolicy.swift; sourceTree = "<group>"; };
 		B66E4E27BE182768B01E5F64 /* HoverPopupState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverPopupState.swift; sourceTree = "<group>"; };
 		B7BC213C5FAF120260716363 /* NotificationCenterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterView.swift; sourceTree = "<group>"; };
@@ -503,7 +487,6 @@
 		D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusHeaderContent.swift; sourceTree = "<group>"; };
 		D17B2A4D2BADE64E249073E1 /* PreviewRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewRegistry.swift; sourceTree = "<group>"; };
 		D2D59D9EEB390C8DF351D595 /* FrameState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameState.swift; sourceTree = "<group>"; };
-		D2EA86C38C62F66C404B85AE /* AgentChatView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AgentChatView.png; sourceTree = "<group>"; };
 		D48E4A7CE35A41F8198B7AE4 /* SearchToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchToolbar.swift; sourceTree = "<group>"; };
 		D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowView.swift; sourceTree = "<group>"; };
 		DD14027C8C7BD17057DE820B /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
@@ -511,9 +494,7 @@
 		E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryManagerTests.swift; sourceTree = "<group>"; };
 		E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatState.swift; sourceTree = "<group>"; };
 		E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIActionEncoderTests.swift; sourceTree = "<group>"; };
-		E446B783B6308E4878B80018 /* TabBarView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TabBarView.png; sourceTree = "<group>"; };
 		E892F827AFBE959F9DF25C05 /* StatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarView.swift; sourceTree = "<group>"; };
-		E8BEF10DDD749FBA592D2D0E /* GitStatusView.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = GitStatusView.png; sourceTree = "<group>"; };
 		ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolManagerView.swift; sourceTree = "<group>"; };
 		EF3D54D0AA54F1EC07318AEA /* ExtensionPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPanelState.swift; sourceTree = "<group>"; };
 		F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorsTests.swift; sourceTree = "<group>"; };
@@ -522,7 +503,6 @@
 		F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceState.swift; sourceTree = "<group>"; };
 		F5647A59C841B3C408994CC7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMECompositionTests.swift; sourceTree = "<group>"; };
-		F9437DDA1ADDABFCEAF93E1B /* CompletionOverlay.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CompletionOverlay.png; sourceTree = "<group>"; };
 		FD66FBCBFC20D50D22A969C8 /* SymbolsNerdFontMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SymbolsNerdFontMono-Regular.ttf"; sourceTree = "<group>"; };
 		FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -611,7 +591,6 @@
 			isa = PBXGroup;
 			children = (
 				EF010AC81BF7F66D126A242B /* MingaTests */,
-				F2B8C36C4AA18B066018A6D0 /* Snapshots */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -826,23 +805,6 @@
 			path = MingaTests;
 			sourceTree = "<group>";
 		};
-		F2B8C36C4AA18B066018A6D0 /* Snapshots */ = {
-			isa = PBXGroup;
-			children = (
-				D2EA86C38C62F66C404B85AE /* AgentChatView.png */,
-				5C15B295136BB21BA042ADED /* AgentChromeView.png */,
-				F9437DDA1ADDABFCEAF93E1B /* CompletionOverlay.png */,
-				0F8A2F94CAD4B77064FB9894 /* EditorChromeView.png */,
-				74F5BDC126D824CD2C499359 /* FileTreeView.png */,
-				E8BEF10DDD749FBA592D2D0E /* GitStatusView.png */,
-				1D3FC97A5BF803712978AB67 /* NotificationCenterView.png */,
-				B4BFCE1FA1C25A2AF0D78F90 /* ObservatoryView.png */,
-				4DB8CFA9B73750AD34E77A0C /* StatusBarView.png */,
-				E446B783B6308E4878B80018 /* TabBarView.png */,
-			);
-			path = Snapshots;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -852,7 +814,6 @@
 			buildPhases = (
 				77AE57735A00C26BF1B3675A /* Generate protocol opcodes */,
 				C8F3C47EE52117DADE97B9F9 /* Sources */,
-				AC030320698C86167111D422 /* Resources */,
 				055B5DD060ABF986C99376D6 /* Frameworks */,
 			);
 			buildRules = (
@@ -942,23 +903,6 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		AC030320698C86167111D422 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F777AD7AB01B7E0707001CDF /* AgentChatView.png in Resources */,
-				EA05D17A333275729155DCB1 /* AgentChromeView.png in Resources */,
-				AF0877EE13E581DD7B20FA39 /* CompletionOverlay.png in Resources */,
-				3786455FC273F48F85C0DE4A /* EditorChromeView.png in Resources */,
-				644651957542041BB07F6819 /* FileTreeView.png in Resources */,
-				C2B552F09F4C033A34651A89 /* GitStatusView.png in Resources */,
-				A2248AB663ACECA334695D9C /* NotificationCenterView.png in Resources */,
-				DECD646B250DF38B1F4C688D /* ObservatoryView.png in Resources */,
-				7F5AEBE16F765D8163F7D8A9 /* StatusBarView.png in Resources */,
-				90DDED0067C36E07960445C9 /* TabBarView.png in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		F708F0C1577DD5141846EFB7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -43,6 +43,14 @@ enum PreviewRegistry {
             whichKeyPreview()
         case "SearchToolbar":
             searchToolbarPreview()
+        case "HoverPopupOverlay":
+            hoverPopupPreview()
+        case "SignatureHelpOverlay":
+            signatureHelpPreview()
+        case "DiagnosticsEditorView":
+            diagnosticsEditorPreview()
+        case "TabBarOverflow":
+            tabBarOverflowPreview()
         default:
             Text("Unknown view: \(name)")
                 .font(.title)
@@ -699,6 +707,224 @@ enum PreviewRegistry {
 
         return SearchToolbar(searchState: state, theme: theme, encoder: nil)
             .frame(width: 800, height: 40)
+            .background(theme.editorBg)
+    }
+
+    // MARK: - HoverPopupOverlay
+
+    private static func hoverPopupPreview() -> some View {
+        let theme = populatedTheme()
+        let state = HoverPopupState()
+        state.update(
+            visible: true, anchorRow: 8, anchorCol: 4,
+            focused: false, scrollOffset: 0,
+            rawLines: [
+                Wire.HoverLine(lineType: .header, segments: [
+                    Wire.HoverSegment(style: .header2, fgColor: nil, flags: 0, text: "Buffer.open/1"),
+                ]),
+                Wire.HoverLine(lineType: .empty, segments: []),
+                Wire.HoverLine(lineType: .text, segments: [
+                    Wire.HoverSegment(style: .plain, fgColor: nil, flags: 0, text: "Opens a file from disk and returns a managed buffer process."),
+                ]),
+                Wire.HoverLine(lineType: .text, segments: [
+                    Wire.HoverSegment(style: .plain, fgColor: nil, flags: 0, text: "The buffer is registered under the given path and will be reused"),
+                ]),
+                Wire.HoverLine(lineType: .text, segments: [
+                    Wire.HoverSegment(style: .plain, fgColor: nil, flags: 0, text: "on subsequent calls with the same path."),
+                ]),
+                Wire.HoverLine(lineType: .empty, segments: []),
+                Wire.HoverLine(lineType: .codeHeader, segments: [
+                    Wire.HoverSegment(style: .codeBlock, fgColor: nil, flags: 0, text: "elixir"),
+                ]),
+                Wire.HoverLine(lineType: .code, segments: [
+                    Wire.HoverSegment(style: .syntaxHighlighted, fgColor: 0xC678DD, flags: 1, text: "@spec "),
+                    Wire.HoverSegment(style: .syntaxHighlighted, fgColor: 0x61AFEF, flags: 0, text: "open"),
+                    Wire.HoverSegment(style: .syntaxHighlighted, fgColor: 0xBBC2CF, flags: 0, text: "("),
+                    Wire.HoverSegment(style: .syntaxHighlighted, fgColor: 0xE5C07B, flags: 0, text: "String.t()"),
+                    Wire.HoverSegment(style: .syntaxHighlighted, fgColor: 0xBBC2CF, flags: 0, text: ") :: "),
+                    Wire.HoverSegment(style: .syntaxHighlighted, fgColor: 0xE5C07B, flags: 0, text: "{:ok, pid()}"),
+                ]),
+                Wire.HoverLine(lineType: .empty, segments: []),
+                Wire.HoverLine(lineType: .blockquote, segments: [
+                    Wire.HoverSegment(style: .blockquote, fgColor: nil, flags: 0, text: "Since: v0.4.0"),
+                ]),
+            ]
+        )
+
+        return HoverPopupOverlay(state: state, theme: theme, cellWidth: 8, cellHeight: 18, viewportHeight: 300, viewportWidth: 500, encoder: nil)
+            .frame(width: 500, height: 300)
+            .background(theme.editorBg)
+    }
+
+    // MARK: - SignatureHelpOverlay
+
+    private static func signatureHelpPreview() -> some View {
+        let theme = populatedTheme()
+        let state = SignatureHelpState()
+        state.update(
+            visible: true, anchorRow: 8, anchorCol: 6,
+            activeSignature: 0, activeParameter: 1,
+            rawSignatures: [
+                Wire.Signature(
+                    label: "GenServer.start_link(module, init_arg, options)",
+                    documentation: "Starts a GenServer process linked to the current process.",
+                    parameters: [
+                        Wire.SignatureParameter(label: "module", documentation: "The module implementing the GenServer callbacks."),
+                        Wire.SignatureParameter(label: "init_arg", documentation: "The argument passed to init/1."),
+                        Wire.SignatureParameter(label: "options", documentation: "Options such as :name, :timeout, and :hibernate_after."),
+                    ]
+                ),
+            ]
+        )
+
+        return SignatureHelpOverlay(state: state, theme: theme, cellWidth: 8, cellHeight: 18, viewportHeight: 200, viewportWidth: 500)
+            .frame(width: 500, height: 200)
+            .background(theme.editorBg)
+    }
+
+    // MARK: - DiagnosticsEditorView
+
+    private static func diagnosticsEditorPreview() -> some View {
+        previewDiagnosticsChromeView(failureMessage: "DiagnosticsEditorView could not initialize the production editor renderer.")
+    }
+
+    @ViewBuilder
+    private static func previewDiagnosticsChromeView(failureMessage: String) -> some View {
+        let size = PreviewSnapshotPolicy.size(named: "DiagnosticsEditorView")
+
+        if let appState = diagnosticsPreviewAppState() {
+            ContentView(appState: appState)
+                .frame(width: size.width, height: size.height)
+        } else {
+            previewFailureView(message: failureMessage)
+                .frame(width: size.width, height: size.height)
+        }
+    }
+
+    private static func diagnosticsPreviewAppState() -> AppState? {
+        let appState = AppState()
+        appState.windowTitle = "Minga"
+        appState.windowBgIsDark = true
+        appState.hasReceivedFirstFrame = true
+        appState.trafficLightMidY = 14
+
+        let encoder = previewEncoder()
+        appState.encoder = encoder
+        appState.gui.settingsState.encoder = encoder
+
+        populateFileTree(appState.gui.fileTreeState)
+        populateGitStatus(appState.gui.gitStatusState)
+        appState.gui.gitStatusState.hide()
+        populateTabBar(appState.gui.tabBarState)
+        appState.gui.breadcrumbState.update(segments: ["lib", "minga", "editor.ex"])
+        appState.gui.statusBarState.update(from: previewStatusBarUpdate(agentVisible: false))
+
+        guard let editorNSView = previewDiagnosticsEditorNSView(appState: appState, encoder: encoder) else { return nil }
+        appState.editorNSView = editorNSView
+        return appState
+    }
+
+    private static func previewDiagnosticsEditorNSView(appState: AppState, encoder: ProtocolEncoder) -> EditorNSView? {
+        let scale = NSScreen.main?.backingScaleFactor ?? 2.0
+        let fontFace = FontFace(name: "Menlo", size: 13, scale: scale)
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: scale)
+        guard let renderer = CoreTextMetalRenderer() else { return nil }
+        renderer.setupRenderers(fontManager: fontManager)
+
+        let dispatcher = CommandDispatcher(cols: 112, rows: 36, guiState: appState.gui)
+        dispatcher.fontManager = fontManager
+        populateDiagnosticsEditorFrame(dispatcher: dispatcher, guiState: appState.gui)
+
+        let nsView = EditorNSView(encoder: encoder, fontFace: fontFace, dispatcher: dispatcher, coreTextRenderer: renderer, fontManager: fontManager)
+        nsView.guiState = appState.gui
+        nsView.statusBarState = appState.gui.statusBarState
+        nsView.renderFrame()
+        return nsView
+    }
+
+    private static func populateDiagnosticsEditorFrame(dispatcher: CommandDispatcher, guiState: GUIState) {
+        dispatcher.frameState.defaultBg = 0x282C34
+        dispatcher.frameState.gutterCol = 4
+        dispatcher.frameState.gutterSeparatorColor = 0x3E4452
+        dispatcher.frameState.cursorRow = 5
+        dispatcher.frameState.cursorCol = 12
+        dispatcher.frameState.cursorShape = .beam
+        dispatcher.frameState.cursorlineRow = 5
+        dispatcher.frameState.cursorlineBg = 0x2C323C
+        dispatcher.frameState.totalLineCount = 1250
+        dispatcher.frameState.viewportTopLine = 38
+        dispatcher.frameState.scrollIndicatorColor = 0x5C6370
+        dispatcher.frameState.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1,
+            contentRow: 1,
+            contentCol: 0,
+            contentHeight: 22,
+            isActive: true,
+            contentWidth: 108,
+            cursorLine: 42,
+            lineNumberStyle: .absolute,
+            lineNumberWidth: 3,
+            signColWidth: 1,
+            entries: previewDiagnosticsGutterEntries()
+        )
+        guiState.windowContents[1] = GUIWindowContent(
+            windowId: 1,
+            fullRefresh: true,
+            cursorVisible: true,
+            cursorRow: 5,
+            cursorCol: 12,
+            cursorShape: .beam,
+            rows: previewEditorRows(),
+            selection: nil,
+            searchMatches: [],
+            diagnosticUnderlines: [
+                GUIDiagnosticUnderline(startRow: 4, startCol: 20, endRow: 4, endCol: 31, severity: .error),
+                GUIDiagnosticUnderline(startRow: 5, startCol: 4, endRow: 5, endCol: 10, severity: .warning),
+                GUIDiagnosticUnderline(startRow: 1, startCol: 8, endRow: 1, endCol: 20, severity: .info),
+            ],
+            documentHighlights: [],
+            lineAnnotations: []
+        )
+    }
+
+    private static func previewDiagnosticsGutterEntries() -> [Wire.GutterEntry] {
+        (38...59).map { line in
+            let sign: Wire.GutterSignType
+            switch line {
+            case 42: sign = .diagError
+            case 43: sign = .diagWarning
+            case 39: sign = .diagInfo
+            case 47: sign = .gitModified
+            default: sign = .none
+            }
+            return Wire.GutterEntry(bufLine: UInt32(line), displayType: .normal, signType: sign)
+        }
+    }
+
+    // MARK: - TabBarOverflow
+
+    private static func tabBarOverflowPreview() -> some View {
+        tabBarOverflowView(width: 1200)
+    }
+
+    private static func tabBarOverflowView(width: CGFloat) -> some View {
+        let state = TabBarState()
+        let theme = populatedTheme()
+        state.update(activeIndex: 3, entries: [
+            Wire.TabEntry(id: 1, groupId: 0, isActive: false, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: true, tintColorRGB: 0, icon: "", label: "editor.ex"),
+            Wire.TabEntry(id: 2, groupId: 0, isActive: false, isDirty: true, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "buffer.ex"),
+            Wire.TabEntry(id: 3, groupId: 0, isActive: false, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "document.ex"),
+            Wire.TabEntry(id: 4, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "render_pipeline_integration_test.exs"),
+            Wire.TabEntry(id: 5, groupId: 0, isActive: false, isDirty: true, isAgent: false, hasAttention: true, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "protocol_decoder_compatibility_test.exs"),
+            Wire.TabEntry(id: 6, groupId: 0, isActive: false, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "mode.ex"),
+            Wire.TabEntry(id: 7, groupId: 0, isActive: false, isDirty: false, isAgent: true, hasAttention: false, agentStatus: 2, isPinned: false, tintColorRGB: 0, icon: "", label: "Agent"),
+            Wire.TabEntry(id: 8, groupId: 0, isActive: false, isDirty: true, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "core_text_metal_renderer.swift"),
+            Wire.TabEntry(id: 9, groupId: 0, isActive: false, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "preview_snapshot_policy.swift"),
+            Wire.TabEntry(id: 10, groupId: 0, isActive: false, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "application_supervisor_configuration.ex"),
+        ])
+
+        return TabBarView(tabBarState: state, theme: theme, encoder: nil)
+            .frame(width: width, height: 36)
             .background(theme.editorBg)
     }
 

--- a/macos/Sources/PreviewSnapshotPolicy.swift
+++ b/macos/Sources/PreviewSnapshotPolicy.swift
@@ -3,8 +3,8 @@ import Foundation
 
 /// Shared policy for preview screenshots and snapshot-fixture layout.
 enum PreviewSnapshotPolicy {
-    private static let fullShellViews: Set<String> = ["EditorChromeView", "AgentChromeView"]
-    private static let renderedWindowViews: Set<String> = ["EditorChromeView", "AgentChromeView", "GitStatusView", "FileTreeView"]
+    private static let fullShellViews: Set<String> = ["EditorChromeView", "AgentChromeView", "DiagnosticsEditorView"]
+    private static let renderedWindowViews: Set<String> = ["EditorChromeView", "AgentChromeView", "DiagnosticsEditorView", "GitStatusView", "FileTreeView"]
     private static let eagerLayoutViews: Set<String> = ["GitStatusView", "FileTreeView"]
 
     static func size(named name: String) -> CGSize {
@@ -21,6 +21,10 @@ enum PreviewSnapshotPolicy {
         case "MinibufferView": CGSize(width: 600, height: 140)
         case "WhichKeyOverlay": CGSize(width: 520, height: 300)
         case "SearchToolbar": CGSize(width: 800, height: 40)
+        case "HoverPopupOverlay": CGSize(width: 500, height: 300)
+        case "SignatureHelpOverlay": CGSize(width: 500, height: 200)
+        case "DiagnosticsEditorView": CGSize(width: 1200, height: 704)
+        case "TabBarOverflow": CGSize(width: 1200, height: 36)
         default: CGSize(width: 400, height: 200)
         }
     }

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -6,7 +6,9 @@
 # Available views: EditorChromeView, AgentChromeView, GitStatusView,
 #                  FileTreeView, CompletionOverlay, StatusBarView, TabBarView,
 #                  NotificationCenterView, ObservatoryView, AgentChatView,
-#                  PickerOverlay, MinibufferView, WhichKeyOverlay, SearchToolbar
+#                  PickerOverlay, MinibufferView, WhichKeyOverlay, SearchToolbar,
+#                  HoverPopupOverlay, SignatureHelpOverlay, DiagnosticsEditorView,
+#                  TabBarOverflow
 #
 # The script builds the PreviewHost target, launches it with the view name,
 # and the app self-captures its window to a PNG before exiting. Full-shell


### PR DESCRIPTION
## Summary
- Add preview entries for HoverPopupOverlay, SignatureHelpOverlay, DiagnosticsEditorView (full-shell), and TabBarOverflow
- DiagnosticsEditorView enriches the existing editor with error/warning/info underlines and gutter signs
- Dirty buffer indicators already covered by existing EditorChromeView
- Split layout deferred: requires multi-window gutter + separator wiring in the renderer, a follow-up ticket

Closes #1968
Part of #1966

## Surfaces covered
| View | Size | Key mock state |
|------|------|----------------|
| HoverPopupOverlay | 500x300 | Multiline docs with header, code block, blockquote |
| SignatureHelpOverlay | 500x200 | `GenServer.start_link/3` with active parameter highlighted |
| DiagnosticsEditorView | 1200x704 | Full production renderer with error/warning/info gutter signs |
| TabBarOverflow | 1200x36 | 10 tabs with long labels, mixed dirty/pinned/agent states |

## Deferrals
- **Split layout**: renderer-level construct requiring multiple `windowGutters` and `Wire.VerticalSeparator`. Follow-up ticket needed.

## Test plan
- [ ] `cd macos && xcodegen generate` succeeds
- [ ] `mix swift.build` passes
- [ ] `scripts/preview.sh HoverPopupOverlay` generates snapshot
- [ ] `scripts/preview.sh SignatureHelpOverlay` generates snapshot
- [ ] `scripts/preview.sh DiagnosticsEditorView` generates snapshot
- [ ] `scripts/preview.sh TabBarOverflow` generates snapshot
- [ ] Visual inspection for diagnostic contrast, gutter alignment, tab truncation

🤖 Generated with [Claude Code](https://claude.ai/code)