### PR TITLE
feat(macos): WhichKey multi-page snapshot

### DIFF
--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -101,6 +101,8 @@ enum PreviewRegistry {
             notificationOverflowPreview()
         case "FileTreeRename":
             fileTreeRenamePreview()
+        case "WhichKeyPaged":
+            whichKeyPagedPreview()
         default:
             Text("Unknown view: \(name)")
                 .font(.title)
@@ -1190,6 +1192,35 @@ enum PreviewRegistry {
                 Wire.WhichKeyBinding(kind: 1, key: "t", description: "+toggle", icon: ""),
                 Wire.WhichKeyBinding(kind: 1, key: "c", description: "+code", icon: ""),
                 Wire.WhichKeyBinding(kind: 0, key: "e", description: "file tree", icon: ""),
+            ]
+        )
+
+        return WhichKeyOverlay(state: state, theme: theme)
+            .frame(width: 520, height: 300)
+            .background(theme.editorBg)
+    }
+
+    // MARK: - WhichKeyPaged
+
+    private static func whichKeyPagedPreview() -> some View {
+        let theme = populatedTheme()
+        let state = WhichKeyState()
+        state.update(
+            visible: true,
+            prefix: "SPC g",
+            page: 1,
+            pageCount: 3,
+            rawBindings: [
+                Wire.WhichKeyBinding(kind: 0, key: "s", description: "stage file", icon: ""),
+                Wire.WhichKeyBinding(kind: 0, key: "u", description: "unstage file", icon: ""),
+                Wire.WhichKeyBinding(kind: 0, key: "c", description: "commit", icon: ""),
+                Wire.WhichKeyBinding(kind: 0, key: "p", description: "push", icon: ""),
+                Wire.WhichKeyBinding(kind: 0, key: "f", description: "fetch", icon: ""),
+                Wire.WhichKeyBinding(kind: 0, key: "d", description: "diff", icon: ""),
+                Wire.WhichKeyBinding(kind: 1, key: "b", description: "+branch", icon: ""),
+                Wire.WhichKeyBinding(kind: 1, key: "r", description: "+rebase", icon: ""),
+                Wire.WhichKeyBinding(kind: 0, key: "l", description: "log", icon: ""),
+                Wire.WhichKeyBinding(kind: 0, key: "z", description: "stash", icon: ""),
             ]
         )
 

--- a/macos/Sources/PreviewSnapshotPolicy.swift
+++ b/macos/Sources/PreviewSnapshotPolicy.swift
@@ -27,7 +27,7 @@ enum PreviewSnapshotPolicy {
         case "DispatchSheetView": CGSize(width: 600, height: 500)
         case "PickerOverlay": CGSize(width: 600, height: 400)
         case "MinibufferView": CGSize(width: 600, height: 140)
-        case "WhichKeyOverlay": CGSize(width: 520, height: 300)
+        case "WhichKeyOverlay", "WhichKeyPaged": CGSize(width: 520, height: 300)
         case "SearchToolbar": CGSize(width: 800, height: 40)
         case "HoverPopupOverlay": CGSize(width: 500, height: 300)
         case "SignatureHelpOverlay": CGSize(width: 500, height: 200)


### PR DESCRIPTION
## Summary
UX review gap fix: adds WhichKeyPaged fixture with page 2/3 and git-themed bindings to test pagination indicator rendering.

Two other gaps investigated and documented as not representable:
- **Git rebase state**: `GitRepoState` only has `normal/notARepo/loading`. No merge/rebase case exists.
- **Picker preview pane**: `PickerOverlay.swift` does not use `hasPreview`/`previewLines`. Preview renders in the editor area behind the picker, not as an inline pane.

Part of #1966

## Surfaces added
| View | Size | Key state |
|------|------|-----------|
| WhichKeyPaged | 520x300 | SPC g prefix, page 2/3, 10 git-themed bindings |

## Not representable (documented)
- GitStatusRebase: requires new `GitRepoState` enum case (product change)
- PickerPreview: `PickerOverlay.swift` has no inline preview pane rendering

## Test plan
- [ ] `cd macos && xcodegen generate` succeeds
- [ ] `mix swift.build` passes
- [ ] `scripts/preview.sh WhichKeyPaged` generates snapshot
- [ ] Visual inspection: page indicator "2/3" visible, binding layout

🤖 Generated with [Claude Code](https://claude.ai/code)