### PR TITLE
refactor(editor): store FileTree state directly

### DIFF
--- a/lib/minga_editor/file_tree/feature.ex
+++ b/lib/minga_editor/file_tree/feature.ex
@@ -2,7 +2,7 @@ defmodule MingaEditor.FileTree.Feature do
   @moduledoc """
   FileTree feature ownership adapter.
 
-  FileTree is still implemented in core, but its UI state, input handler, and sidebar contribution are registered through the same source-owned paths that a bundled extension will use after extraction.
+  FileTree is implemented in core, while its input handler and sidebar contribution are registered through the shared extension contribution registries.
   """
 
   alias MingaEditor.Extension.Sidebar
@@ -10,22 +10,12 @@ defmodule MingaEditor.FileTree.Feature do
   alias MingaEditor.Input.FileTreeHandler
   alias MingaEditor.State.FileTree, as: FileTreeState
 
-  @source :builtin
   @input_source :builtin
-  @feature_id :file_tree
   @sidebar_id "file_tree"
-
-  @doc "Contribution source used while FileTree remains a bundled core feature."
-  @spec source() :: :builtin
-  def source, do: @source
 
   @doc "Contribution source used for FileTree's dynamically registered input handler."
   @spec input_source() :: :builtin
   def input_source, do: @input_source
-
-  @doc "Feature-state id used for FileTree UI state."
-  @spec feature_id() :: :file_tree
-  def feature_id, do: @feature_id
 
   @doc "Stable sidebar id for FileTree."
   @spec sidebar_id() :: String.t()
@@ -43,7 +33,7 @@ defmodule MingaEditor.FileTree.Feature do
   def sync_sidebar(%FileTreeState{} = file_tree) do
     status = FileTreeState.status(file_tree)
 
-    Sidebar.register(@source, %{
+    Sidebar.register(@input_source, %{
       id: @sidebar_id,
       display_name: "File Tree",
       description: "Project files",

--- a/lib/minga_editor/session/state.ex
+++ b/lib/minga_editor/session/state.ex
@@ -16,7 +16,6 @@ defmodule MingaEditor.Session.State do
   alias MingaEditor.FeatureState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Dired, as: DiredState
-  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Highlighting
   alias MingaEditor.State.Mouse
@@ -35,6 +34,7 @@ defmodule MingaEditor.Session.State do
           buffers: Buffers.t(),
           windows: Windows.t(),
           dired: DiredState.t(),
+          file_tree: FileTreeState.t(),
           viewport: Viewport.t(),
           mouse: Mouse.t(),
           highlight: Highlighting.t(),
@@ -52,6 +52,7 @@ defmodule MingaEditor.Session.State do
             buffers: %Buffers{},
             windows: %Windows{},
             dired: %DiredState{},
+            file_tree: %FileTreeState{},
             viewport: nil,
             mouse: %Mouse{},
             highlight: %Highlighting{},
@@ -227,31 +228,26 @@ defmodule MingaEditor.Session.State do
     %{wspace | keymap_scope: scope}
   end
 
-  @doc "Returns FileTree UI state from source-owned feature state, falling back to the legacy field during migration."
+  @doc "Returns FileTree UI state."
   @spec file_tree_state(t()) :: FileTreeState.t()
-  def file_tree_state(%__MODULE__{} = wspace) do
-    case get_feature_state(wspace, FileTreeFeature.source(), FileTreeFeature.feature_id()) do
-      %FileTreeState{} = file_tree -> file_tree
-      _missing -> %FileTreeState{}
-    end
-  end
+  def file_tree_state(%__MODULE__{file_tree: file_tree}), do: file_tree
 
-  @doc "Replaces the FileTree feature-owned UI state."
+  @doc "Replaces the FileTree UI state."
   @spec set_file_tree(t(), FileTreeState.t()) :: t()
   def set_file_tree(%__MODULE__{} = wspace, %FileTreeState{} = file_tree) do
-    put_feature_state(wspace, FileTreeFeature.source(), FileTreeFeature.feature_id(), file_tree)
+    %{wspace | file_tree: file_tree}
   end
 
-  @doc "Updates the FileTree feature-owned UI state."
+  @doc "Updates the FileTree UI state."
   @spec update_file_tree(t(), (FileTreeState.t() -> FileTreeState.t())) :: t()
   def update_file_tree(%__MODULE__{} = wspace, fun) when is_function(fun, 1) do
     set_file_tree(wspace, fun.(file_tree_state(wspace)))
   end
 
-  @doc "Drops FileTree feature-owned UI state and clears the legacy compatibility field."
+  @doc "Resets FileTree UI state."
   @spec drop_file_tree(t()) :: t()
   def drop_file_tree(%__MODULE__{} = wspace) do
-    drop_feature_state(wspace, FileTreeFeature.source(), FileTreeFeature.feature_id())
+    %{wspace | file_tree: %FileTreeState{}}
   end
 
   @doc "Replaces the dired sub-struct."

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -324,7 +324,7 @@ defmodule MingaEditor.State do
     update_workspace(state, &SessionState.set_keymap_scope(&1, scope))
   end
 
-  @doc "Returns the active workspace FileTree feature state."
+  @doc "Returns the active workspace FileTree state."
   @spec file_tree_state(t() | map()) :: FileTreeState.t()
   def file_tree_state(%__MODULE__{workspace: workspace}) do
     SessionState.file_tree_state(workspace)
@@ -340,20 +340,20 @@ defmodule MingaEditor.State do
 
   def file_tree_state(_state), do: %FileTreeState{}
 
-  @doc "Replaces the active workspace FileTree feature state."
+  @doc "Replaces the active workspace FileTree state."
   @spec set_file_tree(t(), FileTreeState.t()) :: t()
   def set_file_tree(%__MODULE__{} = state, %FileTreeState{} = file_tree) do
     sync_file_tree_sidebar(file_tree)
     update_workspace(state, &SessionState.set_file_tree(&1, file_tree))
   end
 
-  @doc "Updates the active workspace FileTree feature state."
+  @doc "Updates the active workspace FileTree state."
   @spec update_file_tree(t(), (FileTreeState.t() -> FileTreeState.t())) :: t()
   def update_file_tree(%__MODULE__{} = state, fun) when is_function(fun, 1) do
     set_file_tree(state, fun.(file_tree_state(state)))
   end
 
-  @doc "Drops the active workspace FileTree feature state."
+  @doc "Resets the active workspace FileTree state."
   @spec drop_file_tree(t()) :: t()
   def drop_file_tree(%__MODULE__{} = state) do
     sync_file_tree_sidebar(%FileTreeState{})
@@ -1816,7 +1816,8 @@ defmodule MingaEditor.State do
       lsp_pending: %{},
       search: %Search{},
       editing: VimState.new(),
-      feature_state: feature_state_with_file_tree_root(state),
+      file_tree: file_tree_with_current_root(state),
+      feature_state: FeatureState.new(),
       document_highlights: nil
     })
   end
@@ -1844,7 +1845,8 @@ defmodule MingaEditor.State do
       lsp_pending: %{},
       search: %Search{},
       editing: VimState.new(),
-      feature_state: feature_state_with_file_tree_root(state),
+      file_tree: file_tree_with_current_root(state),
+      feature_state: FeatureState.new(),
       document_highlights: nil
     })
   end
@@ -1884,16 +1886,9 @@ defmodule MingaEditor.State do
 
   defp build_agent_card_windows(_agent_buf, _rows, _cols), do: %Windows{}
 
-  @spec feature_state_with_file_tree_root(t()) :: FeatureState.t()
-  defp feature_state_with_file_tree_root(%__MODULE__{} = state) do
-    project_root = file_tree_state(state).project_root
-
-    FeatureState.put(
-      FeatureState.new(),
-      FileTreeFeature.source(),
-      FileTreeFeature.feature_id(),
-      %FileTreeState{project_root: project_root}
-    )
+  @spec file_tree_with_current_root(t()) :: FileTreeState.t()
+  defp file_tree_with_current_root(%__MODULE__{} = state) do
+    %FileTreeState{project_root: file_tree_state(state).project_root}
   end
 
   @spec log_switch_tab(TabBar.t(), Tab.id(), Tab.id()) :: :ok

--- a/lib/minga_editor/state/tab/context.ex
+++ b/lib/minga_editor/state/tab/context.ex
@@ -8,7 +8,6 @@ defmodule MingaEditor.State.Tab.Context do
   alias Minga.Keymap.Scope
   alias MingaEditor.Agent.UIState
   alias MingaEditor.FeatureState
-  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Dired, as: DiredState
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -27,6 +26,7 @@ defmodule MingaEditor.State.Tab.Context do
     :buffers,
     :windows,
     :dired,
+    :file_tree,
     :viewport,
     :mouse,
     :lsp_pending,
@@ -46,6 +46,7 @@ defmodule MingaEditor.State.Tab.Context do
           | :buffers
           | :windows
           | :dired
+          | :file_tree
           | :viewport
           | :mouse
           | :highlight
@@ -70,6 +71,7 @@ defmodule MingaEditor.State.Tab.Context do
           buffers: Buffers.t() | nil,
           windows: Windows.t() | nil,
           dired: DiredState.t() | nil,
+          file_tree: FileTreeState.t() | nil,
           viewport: Viewport.t() | nil,
           mouse: Mouse.t() | nil,
           highlight: Highlighting.t() | nil,
@@ -88,6 +90,7 @@ defmodule MingaEditor.State.Tab.Context do
             buffers: nil,
             windows: nil,
             dired: nil,
+            file_tree: nil,
             viewport: nil,
             mouse: nil,
             highlight: nil,
@@ -129,6 +132,7 @@ defmodule MingaEditor.State.Tab.Context do
       buffers: ws.buffers,
       windows: ws.windows,
       dired: ws.dired,
+      file_tree: ws.file_tree,
       viewport: ws.viewport,
       mouse: ws.mouse,
       lsp_pending: ws.lsp_pending,
@@ -209,19 +213,47 @@ defmodule MingaEditor.State.Tab.Context do
 
   @spec migrate_legacy_file_tree(t(), map()) :: t()
   defp migrate_legacy_file_tree(%__MODULE__{} = context, map) do
+    context
+    |> migrate_legacy_direct_file_tree(map)
+    |> migrate_legacy_feature_state_file_tree()
+    |> drop_legacy_feature_state_file_tree()
+  end
+
+  @spec migrate_legacy_direct_file_tree(t(), map()) :: t()
+  defp migrate_legacy_direct_file_tree(%__MODULE__{} = context, map) do
     case fetch_legacy_file_tree(map) do
-      {:ok, %FileTreeState{} = file_tree} ->
-        feature_state =
-          context.feature_state
-          |> Kernel.||(%FeatureState{})
-          |> FeatureState.put(FileTreeFeature.source(), FileTreeFeature.feature_id(), file_tree)
-
-        put_valid_field(context, :feature_state, feature_state)
-
-      _ ->
-        context
+      {:ok, %FileTreeState{} = file_tree} -> put_valid_field(context, :file_tree, file_tree)
+      _ -> context
     end
   end
+
+  @spec migrate_legacy_feature_state_file_tree(t()) :: t()
+  defp migrate_legacy_feature_state_file_tree(%__MODULE__{file_tree: %FileTreeState{}} = context),
+    do: context
+
+  defp migrate_legacy_feature_state_file_tree(
+         %__MODULE__{feature_state: %FeatureState{} = feature_state} = context
+       ) do
+    case FeatureState.fetch(feature_state, :builtin, :file_tree) do
+      {:ok, %FileTreeState{} = file_tree} -> put_valid_field(context, :file_tree, file_tree)
+      _ -> context
+    end
+  end
+
+  defp migrate_legacy_feature_state_file_tree(%__MODULE__{} = context), do: context
+
+  @spec drop_legacy_feature_state_file_tree(t()) :: t()
+  defp drop_legacy_feature_state_file_tree(
+         %__MODULE__{feature_state: %FeatureState{} = feature_state} = context
+       ) do
+    put_valid_field(
+      context,
+      :feature_state,
+      FeatureState.drop(feature_state, :builtin, :file_tree)
+    )
+  end
+
+  defp drop_legacy_feature_state_file_tree(%__MODULE__{} = context), do: context
 
   @spec put_valid_field(t(), field_name(), term()) :: t()
   defp put_valid_field(%__MODULE__{} = context, field, value) do
@@ -252,6 +284,7 @@ defmodule MingaEditor.State.Tab.Context do
   defp valid_field?(:buffers, %Buffers{}), do: true
   defp valid_field?(:windows, %Windows{}), do: true
   defp valid_field?(:dired, %DiredState{}), do: true
+  defp valid_field?(:file_tree, %FileTreeState{}), do: true
   defp valid_field?(:viewport, %Viewport{}), do: true
   defp valid_field?(:mouse, %Mouse{}), do: true
   defp valid_field?(:highlight, %Highlighting{}), do: true

--- a/test/minga_editor/file_tree/feature_test.exs
+++ b/test/minga_editor/file_tree/feature_test.exs
@@ -23,16 +23,15 @@ defmodule MingaEditor.FileTree.FeatureTest do
     :ok
   end
 
-  test "FileTree state is stored through feature-state accessors" do
+  test "FileTree state is stored as a direct workspace field" do
     workspace = %MingaEditor.Session.State{viewport: MingaEditor.Viewport.new(24, 80)}
     file_tree = %FileTreeState{project_root: "/tmp/project"}
 
     workspace = MingaEditor.Session.State.set_file_tree(workspace, file_tree)
 
+    assert workspace.file_tree == file_tree
     assert MingaEditor.Session.State.file_tree_state(workspace) == file_tree
-
-    assert MingaEditor.Session.State.get_feature_state(workspace, :builtin, :file_tree) ==
-             file_tree
+    assert MingaEditor.Session.State.get_feature_state(workspace, :builtin, :file_tree) == nil
   end
 
   test "FileTree dynamic handler uses a built-in source that extension cleanup cannot remove" do

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -2,8 +2,10 @@ defmodule MingaEditor.State.SnapshotTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.FeatureState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context
   alias MingaEditor.State.TabBar
@@ -172,6 +174,34 @@ defmodule MingaEditor.State.SnapshotTest do
       restored = EditorState.restore_tab_context(state, %{})
       assert restored.workspace.editing.mode == :normal
       assert restored.workspace.keymap_scope == :editor
+    end
+
+    test "synthesized file and agent tab defaults keep direct file_tree state" do
+      file_tree = %FileTreeState{project_root: "/tmp/project"}
+
+      file_state =
+        make_state(tab_bar: TabBar.new(Tab.new_file(1, "new.ex")))
+        |> EditorState.update_workspace(&MingaEditor.Session.State.set_file_tree(&1, file_tree))
+
+      file_restored = EditorState.restore_tab_context(file_state, %{})
+      file_ctx = TabBar.active(file_restored.shell_state.tab_bar).context
+
+      assert file_ctx.file_tree.project_root == file_tree.project_root
+      assert file_ctx.file_tree.tree == nil
+      refute file_ctx.file_tree.focused
+      assert FeatureState.empty?(file_ctx.feature_state)
+
+      agent_state =
+        make_state(tab_bar: TabBar.new(Tab.new_agent(1, "Agent")))
+        |> EditorState.update_workspace(&MingaEditor.Session.State.set_file_tree(&1, file_tree))
+
+      agent_restored = EditorState.restore_tab_context(agent_state, %{})
+      agent_ctx = TabBar.active(agent_restored.shell_state.tab_bar).context
+
+      assert agent_ctx.file_tree.project_root == file_tree.project_root
+      assert agent_ctx.file_tree.tree == nil
+      refute agent_ctx.file_tree.focused
+      assert FeatureState.empty?(agent_ctx.feature_state)
     end
 
     test "writes synthesized defaults back into the active tab on empty context" do
@@ -373,6 +403,7 @@ defmodule MingaEditor.State.SnapshotTest do
       assert new_ctx.keymap_scope == old_ctx.keymap_scope
       assert new_ctx.buffers == old_ctx.buffers
       assert new_ctx.windows == old_ctx.windows
+      assert new_ctx.file_tree == old_ctx.file_tree
       assert new_ctx.feature_state == old_ctx.feature_state
       assert new_ctx.dired == old_ctx.dired
       assert new_ctx.viewport == old_ctx.viewport
@@ -413,12 +444,44 @@ defmodule MingaEditor.State.SnapshotTest do
       assert restored_map.buffers.active == buf
       assert restored_map.viewport == ws.viewport
       assert restored_map.windows == ws.windows
+      assert restored_map.file_tree == ws.file_tree
       assert restored_map.mouse == ws.mouse
       assert restored_map.search == ws.search
       assert restored_map.lsp_pending == pending
 
       refute Map.has_key?(restored_map, :highlight)
       refute Map.has_key?(restored_map, :injection_ranges)
+    end
+
+    test "migrates legacy file tree from feature state into direct field" do
+      file_tree = %FileTreeState{project_root: "/tmp/project"}
+
+      legacy_ctx =
+        Context.from_workspace_map(%{
+          viewport: Viewport.new(24, 80),
+          feature_state: FeatureState.put(FeatureState.new(), :builtin, :file_tree, file_tree)
+        })
+
+      assert legacy_ctx.file_tree == file_tree
+      assert FeatureState.get(legacy_ctx.feature_state, :builtin, :file_tree) == nil
+      assert Context.to_workspace_map(legacy_ctx).file_tree == file_tree
+    end
+
+    test "direct file tree wins when legacy feature state also exists" do
+      direct_file_tree = %FileTreeState{project_root: "/tmp/direct"}
+      legacy_file_tree = %FileTreeState{project_root: "/tmp/legacy"}
+
+      legacy_ctx =
+        Context.from_workspace_map(%{
+          viewport: Viewport.new(24, 80),
+          file_tree: direct_file_tree,
+          feature_state:
+            FeatureState.put(FeatureState.new(), :builtin, :file_tree, legacy_file_tree)
+        })
+
+      assert legacy_ctx.file_tree == direct_file_tree
+      assert FeatureState.get(legacy_ctx.feature_state, :builtin, :file_tree) == nil
+      assert Context.to_workspace_map(legacy_ctx).file_tree == direct_file_tree
     end
 
     test "normalises transient vim state" do


### PR DESCRIPTION
# TL;DR
FileTree state now lives directly on `SessionState` as typed workspace state instead of routing through `FeatureState`. This removes the core-state indirection while keeping the extension feature-state registry intact for real extensions.

Closes #1987

## Context
FileTree is permanent editor state, not a bundled extension that can be unloaded. This PR brings FileTree back in line with other core sub-states like dired, search, mouse, windows, buffers, editing, and agent UI.

## Changes
- Added `file_tree` as a typed field on `MingaEditor.Session.State` with direct accessor/update/reset helpers.
- Kept `EditorState` FileTree wrappers, but made them route through the direct workspace field and continue syncing the sidebar registry.
- Removed FileTree's `source/0` and `feature_id/0` FeatureState routing API while preserving input handler and sidebar registration.
- Added FileTree to `TabContext` as a normal snapshotted workspace field.
- Preserved legacy session compatibility by migrating old `feature_state[:builtin][:file_tree]` values into the direct `file_tree` field and removing the stale FeatureState entry.
- Kept `FeatureState` and extension cleanup plumbing unchanged for real extension-owned state.

## Verification
- `mix test.llm test/minga_editor/file_tree/feature_test.exs test/minga_editor/state/snapshot_test.exs test/minga_editor/state_test.exs` passed, 40 tests, 0 failures.
- `git diff --check` passed.
- `make lint` passed, with existing struct-size warnings only.
- `mix test.llm` passed, 8708 tests, 56 doctests, 99 properties, 0 failures, 246 excluded.

## Acceptance Criteria Addressed
- `SessionState` has a `file_tree` field of type `FileTreeState.t()`, accessed as workspace state ✅
- FileTree accessors no longer route through FeatureState; `EditorState` wrappers are thin direct-field helpers ✅
- `FileTree.Feature` keeps sidebar/input registration and no longer exports `source/0` or `feature_id/0` for FeatureState routing ✅
- `TabContext` snapshots/restores `file_tree` as a regular typed field and migrates legacy FeatureState snapshots ✅
- `FeatureState` module and extension plumbing remain intact for real extensions ✅
- Existing tests pass ✅
