### PR TITLE
fix(ci): harden Neovim install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,10 @@ jobs:
           version: 0.16.0
 
       - name: Install Neovim
+        env:
+          NEOVIM_VERSION: v0.12.2
         run: |
-          curl -LO https://github.com/neovim/neovim/releases/download/v0.12.2/nvim-linux-x86_64.tar.gz
+          curl --fail --location --retry 5 --retry-delay 10 --retry-all-errors --output nvim-linux-x86_64.tar.gz "https://github.com/neovim/neovim/releases/download/${NEOVIM_VERSION}/nvim-linux-x86_64.tar.gz"
           tar xzf nvim-linux-x86_64.tar.gz
           echo "$PWD/nvim-linux-x86_64/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
# TL;DR
Harden the Neovim Conformance install step so transient GitHub release download errors fail fast and retry instead of passing an HTML error page to `tar`.

Refs #1693

## Context
The latest main CI failure was in the Neovim Conformance job. `curl -LO` downloaded a 1523-byte non-gzip response for the Neovim tarball, then `tar` failed with `gzip: stdin: not in gzip format`.

## Changes
- Move the pinned Neovim release into a `NEOVIM_VERSION` env var for the install step.
- Replace `curl -LO` with `curl --fail --location --retry 5 --retry-delay 10 --retry-all-errors --output ...`.
- Keep the existing extraction path and `GITHUB_PATH` wiring unchanged.

## Verification
- Downloaded `v0.12.2` locally with the new command and verified `tar xzf nvim-linux-x86_64.tar.gz` extracts successfully.
- Confirmed the workflow contains the hardened command with a Python snippet.
- Final reviewer gate: PASS.

## Acceptance Criteria Addressed
- CI no longer silently treats a GitHub release error response as a tarball ✅
- Neovim Conformance keeps using the same pinned Neovim version and PATH setup ✅
