### PR TITLE
fix(buffer): run motions inside buffer process

### DIFF
--- a/bench/motion_process_bench.exs
+++ b/bench/motion_process_bench.exs
@@ -1,0 +1,62 @@
+defmodule Minga.Bench.MotionProcess do
+  @moduledoc false
+
+  alias Minga.Buffer.Document
+  alias Minga.Buffer.Process, as: BufferProcess
+
+  @line "alpha beta gamma delta epsilon zeta eta theta iota kappa\n"
+  @iterations 1_000
+  @warmup 50
+
+  @spec run() :: :ok
+  def run do
+    content = String.duplicate(@line, 50_000)
+    {:ok, legacy_buf} = BufferProcess.start_link(content: content)
+    {:ok, new_buf} = BufferProcess.start_link(content: content)
+
+    legacy_motion = fn ->
+      doc = BufferProcess.snapshot(legacy_buf)
+      pos = Minga.Editing.word_forward(doc, Document.cursor(doc))
+      BufferProcess.move_to(legacy_buf, pos)
+    end
+
+    buffer_process_motion = fn ->
+      BufferProcess.apply_motion(new_buf, &Minga.Editing.word_forward/2)
+    end
+
+    {legacy_us, legacy_growth} = measure(:legacy, legacy_motion)
+    {new_us, new_growth} = measure(:buffer_process, buffer_process_motion)
+
+    IO.puts("METRIC legacy_motion_us=#{Float.round(legacy_us, 2)}")
+    IO.puts("METRIC buffer_process_motion_us=#{Float.round(new_us, 2)}")
+    IO.puts("METRIC motion_speedup_x=#{Float.round(legacy_us / new_us, 2)}")
+    IO.puts("METRIC legacy_caller_heap_growth_bytes=#{legacy_growth}")
+    IO.puts("METRIC buffer_process_caller_heap_growth_bytes=#{new_growth}")
+  end
+
+  defp measure(label, fun) do
+    parent = self()
+
+    spawn(fn ->
+      Enum.each(1..@warmup, fn _ -> fun.() end)
+      :erlang.garbage_collect(self())
+      {:memory, before_bytes} = Process.info(self(), :memory)
+
+      {total_us, _} =
+        :timer.tc(fn ->
+          Enum.each(1..@iterations, fn _ -> fun.() end)
+        end)
+
+      {:memory, after_bytes} = Process.info(self(), :memory)
+      send(parent, {label, total_us / @iterations, max(after_bytes - before_bytes, 0)})
+    end)
+
+    receive do
+      {^label, avg_us, caller_growth_bytes} -> {avg_us, caller_growth_bytes}
+    after
+      30_000 -> raise "benchmark timed out for #{label}"
+    end
+  end
+end
+
+Minga.Bench.MotionProcess.run()

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -15,6 +15,7 @@ The following optimizations have been completed (see commit `8beec9d`):
 - **Motion: binary pattern matching for char classification** `classify_char/1` with guards replaces `word_char?` regex. Hot helpers inlined with `@compile {:inline, ...}`.
 - **Motion: multi-clause functions replacing `cond`** `advance_word_forward/4`, `advance_word_end/4`, bracket scan helpers extracted as multi-clause functions.
 - **Editor: `content_and_cursor/1`** 12 separate `content()` + `cursor()` GenServer call pairs replaced with single round-trip.
+- **Motion: `Buffer.Process.apply_motion/2`** cursor-only motion functions now run inside the buffer process, so word, line, paragraph, find-char, visual-line, and page motions avoid returning a `Document` snapshot to the Editor before moving the cursor.
 - **Git: in-memory diffing** `Git.Buffer` caches HEAD content and diffs against current buffer using `List.myers_difference/2` in pure Elixir. No `git diff` subprocess spawned on edits. Git commands only run at buffer open and explicit stage operations.
 - **BEAM VM tuning** (see below)
 
@@ -245,15 +246,15 @@ end
 
 ## 4. Motion Module: Avoid Temporary Document + Content Copies
 
+**Status: Implemented in #1887.**
+
 ### Problem
 
-Every motion function receives a `Document.t()` and calls `Document.content/1` (binary concat), then `String.graphemes/1` (tuple allocation), then `String.split/2` (another list). The Editor's `apply_motion/2` creates a temporary `Document.new(content)`, so the content is still materialized and copied into a throwaway struct.
-
-While `content_and_cursor/1` reduced GenServer round-trips from 3 to 2, the temporary Document allocation and content copy remain.
+Cursor-only motions used to run outside `Buffer.Process`: the Editor requested a document snapshot, computed a target cursor, then sent a second call to move there. Older versions did this with `content_and_cursor/1` plus `Document.new(content)`, and the later snapshot path still returned the live document struct to the Editor process before every motion.
 
 ### Fix
 
-**Move motion execution into the Buffer.Process process** via an `apply_motion/2` GenServer call. The motion function runs inside the server where the gap buffer already lives (zero copies):
+Motion execution now happens inside `Buffer.Process` via an `apply_motion/2` GenServer call. The motion function runs inside the server where the gap buffer already lives:
 
 ```elixir
 # In Buffer.Process
@@ -264,11 +265,11 @@ def handle_call({:apply_motion, motion_fn}, _from, state) do
 end
 ```
 
-This eliminates the content copy, the temporary Document, and reduces the remaining 2 GenServer calls to 1.
+This eliminates the temporary external document snapshot and reduces the remaining 2 GenServer calls to 1 for cursor-only motions. Reproduce the timing and allocation comparison with `mix run bench/motion_process_bench.exs`, which prints `legacy_motion_us`, `buffer_process_motion_us`, `motion_speedup_x`, and caller heap growth metrics for the 50,000-line word-motion case.
 
 ### Impact
 
-**High.** Eliminates all temporary allocations per motion. For a 50,000-line file, that's ~3 MB saved per keystroke.
+**High.** Eliminates most caller-side temporary allocation per cursor motion and keeps motion work next to the buffer data.
 
 ---
 
@@ -497,6 +498,7 @@ The keystroke-to-render critical path is instrumented with `:telemetry` spans. S
 
 ### Tools
 
+- **`mix run bench/motion_process_bench.exs`** reproducible before/after timing and allocation comparison for `Buffer.Process.apply_motion/2`
 - **`Benchee`** micro-benchmarks for individual functions
 - **`:timer.tc/1`** quick timing in IEx
 - **`:erlang.statistics(:reductions)`** BEAM work units (proxy for CPU)
@@ -522,6 +524,8 @@ The project already has `test/perf/document_perf_test.exs`. Extend this with ben
 - Render cycle with full viewport
 - Picker filtering with 5000 candidates
 - 1000 sequential inserts (typing simulation)
+
+The motion benchmark in `bench/motion_process_bench.exs` is the reproducible artifact for the `Buffer.Process.apply_motion/2` comparison in section 4.
 
 ### Priority Order
 

--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -19,6 +19,7 @@ defmodule Minga.Buffer do
   @type position :: {line :: non_neg_integer(), col :: non_neg_integer()}
   @type direction :: :left | :right | :up | :down
   @type document :: Document.t()
+  @type motion_fun :: BufferProcess.motion_fun()
   @type text_edit :: BufferProcess.text_edit()
   @type boundary :: BufferProcess.boundary()
   @type replace_edit :: BufferProcess.replace_edit()
@@ -143,6 +144,10 @@ defmodule Minga.Buffer do
   @doc "Move the cursor to an exact position."
   @spec move_to(t(), position()) :: :ok
   defdelegate move_to(server, pos), to: BufferProcess
+
+  @doc "Apply a cursor motion inside the buffer process."
+  @spec apply_motion(t(), motion_fun()) :: :ok
+  defdelegate apply_motion(server, motion_fn), to: BufferProcess
 
   @doc "Move the cursor one step in a direction."
   @spec move(t(), direction()) :: :ok

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -61,6 +61,7 @@ defmodule Minga.Buffer.Process do
   @typedoc "Internal state of the buffer server."
   @type state :: BufState.t()
   @type edit_delta_update :: {:ok, [EditDelta.t()]} | :reset_required
+  @type motion_fun :: (Document.t(), Document.position() -> Document.position())
 
   # ── Child Spec ──
 
@@ -232,6 +233,12 @@ defmodule Minga.Buffer.Process do
   @spec move_to(GenServer.server(), Document.position()) :: :ok
   def move_to(server, {line, col} = pos) when line >= 0 and col >= 0 do
     GenServer.call(server, {:move_to, pos})
+  end
+
+  @doc "Applies a cursor motion inside the buffer process."
+  @spec apply_motion(GenServer.server(), motion_fun()) :: :ok
+  def apply_motion(server, motion_fn) when is_function(motion_fn, 2) do
+    GenServer.call(server, {:apply_motion, motion_fn})
   end
 
   @file_io_call_timeout 30_000
@@ -1048,6 +1055,13 @@ defmodule Minga.Buffer.Process do
 
   def handle_call({:move_to, pos}, _from, state) do
     new_buf = Cursor.place(state.document, pos)
+    {:reply, :ok, %{state | document: new_buf}}
+  end
+
+  def handle_call({:apply_motion, motion_fn}, _from, state) when is_function(motion_fn, 2) do
+    cursor = Document.cursor(state.document)
+    new_pos = motion_fn.(state.document, cursor)
+    new_buf = Cursor.place(state.document, new_pos)
     {:reply, :ok, %{state | document: new_buf}}
   end
 

--- a/lib/minga/editing/motion.ex
+++ b/lib/minga/editing/motion.ex
@@ -3,9 +3,7 @@ defmodule Minga.Editing.Motion do
   Pure cursor-motion functions for the Minga editor.
 
   Each function takes a `Readable.t()` and a current `position()`, and
-  returns the new `position()` after applying the motion.  No buffer state
-  is mutated — the caller is responsible for moving the buffer cursor via
-  `Document.move_to/2` or `Buffer.move_to/2`.
+  returns the new `position()` after applying the motion. No buffer state is mutated, the caller is responsible for moving the buffer cursor via `Document.move_to/2`, `Buffer.move_to/2`, or `Buffer.apply_motion/2`.
 
   This module is a facade over focused sub-modules:
 

--- a/lib/minga_editor/commands/helpers.ex
+++ b/lib/minga_editor/commands/helpers.ex
@@ -367,14 +367,9 @@ defmodule MingaEditor.Commands.Helpers do
   # ── Motion application ──────────────────────────────────────────────────────
 
   @doc "Applies a `(buf, pos) -> new_pos` motion function to the buffer cursor."
-  @spec apply_motion(
-          pid(),
-          (Buffer.document(), Minga.Editing.Motion.position() -> Minga.Editing.Motion.position())
-        ) :: :ok
+  @spec apply_motion(pid(), Buffer.motion_fun()) :: :ok
   def apply_motion(buf, motion_fn) do
-    gb = Buffer.snapshot(buf)
-    new_pos = motion_fn.(gb, Document.cursor(gb))
-    Buffer.move_to(buf, new_pos)
+    Buffer.apply_motion(buf, motion_fn)
   end
 
   @doc "Sets up parser state only for motions that need tree-sitter."
@@ -489,9 +484,6 @@ defmodule MingaEditor.Commands.Helpers do
   @doc "Applies a find-char motion in the given direction."
   @spec apply_find_char(pid(), ModeState.find_direction(), String.t()) :: :ok
   def apply_find_char(buf, dir, char) do
-    gb = Buffer.snapshot(buf)
-    cursor = Document.cursor(gb)
-
     motion_fn =
       case dir do
         :f -> &Minga.Editing.find_char_forward/3
@@ -500,8 +492,7 @@ defmodule MingaEditor.Commands.Helpers do
         :T -> &Minga.Editing.till_char_backward/3
       end
 
-    new_pos = motion_fn.(gb, cursor, char)
-    Buffer.move_to(buf, new_pos)
+    Buffer.apply_motion(buf, fn doc, cursor -> motion_fn.(doc, cursor, char) end)
   end
 
   @doc "Reverses a find-char direction (`f`↔`F`, `t`↔`T`)."
@@ -708,21 +699,21 @@ defmodule MingaEditor.Commands.Helpers do
   @doc "Scrolls the buffer cursor by `delta` lines, clamping to bounds."
   @spec page_move(pid(), Viewport.t(), integer()) :: :ok
   def page_move(buf, _vp, delta) do
-    gb = Buffer.snapshot(buf)
-    {line, col} = Document.cursor(gb)
-    total_lines = Document.line_count(gb)
-    target_line = max(0, min(line + delta, total_lines - 1))
+    Buffer.apply_motion(buf, fn doc, {line, col} ->
+      total_lines = Document.line_count(doc)
+      target_line = max(0, min(line + delta, total_lines - 1))
 
-    target_col =
-      case Document.lines(gb, target_line, 1) do
-        [text] when byte_size(text) > 0 ->
-          min(col, Unicode.last_grapheme_byte_offset(text))
+      target_col =
+        case Document.lines(doc, target_line, 1) do
+          [text] when byte_size(text) > 0 ->
+            min(col, Unicode.last_grapheme_byte_offset(text))
 
-        _ ->
-          0
-      end
+          _ ->
+            0
+        end
 
-    Buffer.move_to(buf, {target_line, target_col})
+      {target_line, target_col}
+    end)
   end
 
   @doc "Toggles the case of a single grapheme."

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -213,16 +213,12 @@ defmodule MingaEditor.Commands.Movement do
   end
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :move_to_document_start) do
-    gb = Buffer.snapshot(buf)
-    new_pos = Minga.Editing.document_start(gb)
-    Buffer.move_to(buf, new_pos)
+    Buffer.apply_motion(buf, fn doc, _cursor -> Minga.Editing.document_start(doc) end)
     state
   end
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :move_to_document_end) do
-    gb = Buffer.snapshot(buf)
-    new_pos = Minga.Editing.document_end(gb)
-    Buffer.move_to(buf, new_pos)
+    Buffer.apply_motion(buf, fn doc, _cursor -> Minga.Editing.document_end(doc) end)
     maybe_repin_agent_chat(state)
   end
 
@@ -233,21 +229,21 @@ defmodule MingaEditor.Commands.Movement do
   end
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :next_line_first_non_blank) do
-    gb = Buffer.snapshot(buf)
-    {line, _col} = Document.cursor(gb)
-    total = Document.line_count(gb)
-    next_line = min(line + 1, total - 1)
-    new_pos = Minga.Editing.first_non_blank(gb, {next_line, 0})
-    Buffer.move_to(buf, new_pos)
+    Buffer.apply_motion(buf, fn doc, {line, _col} ->
+      total = Document.line_count(doc)
+      next_line = min(line + 1, total - 1)
+      Minga.Editing.first_non_blank(doc, {next_line, 0})
+    end)
+
     state
   end
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :prev_line_first_non_blank) do
-    gb = Buffer.snapshot(buf)
-    {line, _col} = Document.cursor(gb)
-    prev_line = max(line - 1, 0)
-    new_pos = Minga.Editing.first_non_blank(gb, {prev_line, 0})
-    Buffer.move_to(buf, new_pos)
+    Buffer.apply_motion(buf, fn doc, {line, _col} ->
+      prev_line = max(line - 1, 0)
+      Minga.Editing.first_non_blank(doc, {prev_line, 0})
+    end)
+
     state
   end
 
@@ -285,10 +281,12 @@ defmodule MingaEditor.Commands.Movement do
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :match_bracket) do
     state = Helpers.setup_for_motion(state, :match_bracket)
     buffer_id = Helpers.buffer_id_for_motion(state, buf, :match_bracket)
+    {row, col} = Buffer.cursor(buf)
 
-    Helpers.apply_motion(buf, fn gb, cursor ->
-      Helpers.resolve_motion(gb, cursor, :match_bracket, buffer_id)
-    end)
+    case ParserManager.request_match_item(buffer_id, row, col) do
+      nil -> :ok
+      target -> Buffer.move_to(buf, target)
+    end
 
     state
   end
@@ -320,8 +318,7 @@ defmodule MingaEditor.Commands.Movement do
       ) do
     {first_line, _last_line} = Viewport.visible_range(vp)
     visible_rows = Viewport.content_rows(vp)
-    gb = Buffer.snapshot(buf)
-    total_lines = Document.line_count(gb)
+    total_lines = Buffer.line_count(buf)
 
     target_line =
       case position do
@@ -691,57 +688,50 @@ defmodule MingaEditor.Commands.Movement do
 
   @spec visual_line_move(GenServer.server(), state(), :up | :down) :: state()
   defp visual_line_move(buf, state, direction) do
-    doc = Buffer.snapshot(buf)
-    pos = Document.cursor(doc)
     content_w = content_width(state)
     opts = wrap_opts(buf, width_oracle(state))
 
-    new_pos =
+    Buffer.apply_motion(buf, fn doc, pos ->
       case direction do
         :down -> Minga.Editing.visual_line_down(doc, pos, content_w, opts)
         :up -> Minga.Editing.visual_line_up(doc, pos, content_w, opts)
       end
+    end)
 
-    Buffer.move_to(buf, new_pos)
     state
   end
 
   @spec visual_line_edge(GenServer.server(), state(), :start | :end) :: state()
   defp visual_line_edge(buf, state, edge) do
-    doc = Buffer.snapshot(buf)
-    pos = Document.cursor(doc)
     content_w = content_width(state)
     opts = wrap_opts(buf, width_oracle(state))
 
-    new_pos =
+    Buffer.apply_motion(buf, fn doc, pos ->
       case edge do
         :start -> Minga.Editing.visual_line_start(doc, pos, content_w, opts)
         :end -> Minga.Editing.visual_line_end(doc, pos, content_w, opts)
       end
+    end)
 
-    Buffer.move_to(buf, new_pos)
     state
   end
 
   @spec logical_line_start(GenServer.server()) :: :ok
   defp logical_line_start(buf) do
-    gb = Buffer.snapshot(buf)
-    {line, _col} = Document.cursor(gb)
-    Buffer.move_to(buf, {line, 0})
+    Buffer.apply_motion(buf, fn _doc, {line, _col} -> {line, 0} end)
   end
 
   @spec logical_line_end(GenServer.server()) :: :ok
   defp logical_line_end(buf) do
-    gb = Buffer.snapshot(buf)
-    {line, _col} = Document.cursor(gb)
+    Buffer.apply_motion(buf, fn doc, {line, _col} ->
+      end_col =
+        case Document.lines(doc, line, 1) do
+          [text] when byte_size(text) > 0 -> Unicode.last_grapheme_byte_offset(text)
+          _ -> 0
+        end
 
-    end_col =
-      case Document.lines(gb, line, 1) do
-        [text] when byte_size(text) > 0 -> Unicode.last_grapheme_byte_offset(text)
-        _ -> 0
-      end
-
-    Buffer.move_to(buf, {line, end_col})
+      {line, end_col}
+    end)
   end
 
   @spec content_width(state()) :: pos_integer()

--- a/test/minga/buffer/process_test.exs
+++ b/test/minga/buffer/process_test.exs
@@ -218,6 +218,21 @@ defmodule Minga.Buffer.ProcessTest do
       refute BufferProcess.dirty?(pid)
     end
 
+    test "apply_motion runs the motion function inside the buffer process" do
+      parent = self()
+      pid = start_supervised!({BufferProcess, content: "alpha\nbeta"})
+
+      assert :ok =
+               BufferProcess.apply_motion(pid, fn doc, cursor ->
+                 send(parent, {:motion_context, self(), cursor, Document.line_count(doc)})
+                 {1, 2}
+               end)
+
+      assert_receive {:motion_context, ^pid, {0, 0}, 2}
+      assert BufferProcess.cursor(pid) == {1, 2}
+      refute BufferProcess.dirty?(pid)
+    end
+
     test "move_if_possible reports successful moves and boundaries" do
       pid = start_supervised!({BufferProcess, content: "ab"})
 

--- a/test/minga_editor/commands/match_bracket_command_test.exs
+++ b/test/minga_editor/commands/match_bracket_command_test.exs
@@ -1,0 +1,51 @@
+defmodule MingaEditor.Commands.MatchBracketCommandTest do
+  @moduledoc """
+  Command-level coverage for `:match_bracket`.
+
+  Uses the real parser Port so the command path gets direct match-found and no-match evidence without booting the full editor UI.
+  """
+
+  # Starts the real parser Port under its global production name, so these tests must not run concurrently.
+  use ExUnit.Case, async: false
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Parser.Manager, as: ParserManager
+  alias MingaEditor.Commands.Movement
+  alias MingaEditor.HighlightSync
+  alias MingaEditor.RenderPipeline.TestHelpers
+
+  @moduletag timeout: 15_000
+
+  setup do
+    if Process.whereis(Minga.Parser.Manager) == nil do
+      start_supervised!({ParserManager, []})
+    end
+
+    :ok
+  end
+
+  describe ":match_bracket command path" do
+    test "jumps from an opening delimiter to the matching end" do
+      {state, buffer} = prepared_state("def foo do\n  :ok\nend\n", :elixir)
+      BufferProcess.move_to(buffer, {0, 0})
+
+      _ = Movement.execute(state, :match_bracket)
+
+      assert BufferProcess.cursor(buffer) == {2, 0}
+    end
+
+    test "is a no-op when the parser has no matching item" do
+      {state, buffer} = prepared_state("word\n", :elixir)
+      BufferProcess.move_to(buffer, {0, 0})
+
+      _ = Movement.execute(state, :match_bracket)
+
+      assert BufferProcess.cursor(buffer) == {0, 0}
+    end
+  end
+
+  defp prepared_state(content, filetype) do
+    state = TestHelpers.base_state(content: content, filetype: filetype)
+    {HighlightSync.setup_for_buffer(state), state.workspace.buffers.active}
+  end
+end


### PR DESCRIPTION
# TL;DR
Cursor-only motions now run inside `Buffer.Process`, so common movement commands no longer pull a document snapshot into the Editor before moving the cursor. This keeps motion work next to the gap buffer and reduces caller-side allocation on large files.

Closes #1887

## Context
Issue #1887 called out that normal cursor motions still crossed the process boundary twice: once to read buffer state and once to move the cursor. This PR adds a buffer-level motion API so word, paragraph, line, find-char, visual-line, and page motions can compute and apply their cursor target in one GenServer call.

## Changes
- Added `Minga.Buffer.Process.apply_motion/2` and a `Minga.Buffer.apply_motion/2` facade that executes a motion function against `state.document` inside the buffer GenServer.
- Updated movement helpers and command paths to use the in-process motion API for cursor-only motions.
- Kept parser-backed bracket matching outside the buffer GenServer so tree-sitter calls do not block the buffer process.
- Added buffer-process test coverage proving the motion function runs in the buffer process and does not mark the buffer dirty.
- Added direct `:match_bracket` command-path regression tests for match-found and no-match cases.
- Added `bench/motion_process_bench.exs` as a reproducible before/after timing and caller heap growth benchmark.
- Updated `docs/PERFORMANCE.md` with the completed optimization and benchmark command.

## Verification
- `mix test.llm test/minga/buffer/process_test.exs test/minga_editor/commands/movement_command_test.exs test/minga/editing/motion/`
- `mix test.llm test/minga_editor/commands/structural_navigation_test.exs test/minga_editor/commands/scroll_commands_test.exs test/minga_editor/commands/visual_test.exs test/minga_editor/commands/operators_test.exs`
- `mix test.llm test/minga_editor/commands/match_bracket_command_test.exs test/minga_editor/integration/match_item_test.exs test/minga/buffer/process_test.exs test/minga_editor/commands/movement_command_test.exs test/minga/editing/motion/`
- `mix run bench/motion_process_bench.exs`: latest run printed `legacy_motion_us=1437.73`, `buffer_process_motion_us=65.96`, `motion_speedup_x=21.8`, `legacy_caller_heap_growth_bytes=2543904`, `buffer_process_caller_heap_growth_bytes=6024`
- `mix test.llm` (latest full run: 8598 tests, 94 properties, 56 doctests, 0 failures)
- `make lint` (passed; Credo printed existing struct-size warnings)
- `git diff --check`
- Focused bug-hunting review: `prtk-code-reviewer` found no high-confidence issues
- Final reviewer gate: PASS
- Parent-orchestrated review loop: 2 rounds, stopped after round 2 reviewers found no fixes worth doing now and validation passed

## Acceptance Criteria Addressed
- `apply_motion/2` no longer calls `Document.new(content)` outside Buffer.Process ✅
- Motion execution happens inside the Buffer.Process GenServer, keeping content in-process ✅
- No regression in motion behavior for word, paragraph, bracket, and line motions ✅
- Measurable reduction in per-keystroke allocation on a large buffer ✅
