### PR TITLE
feat(agent): run independent tool calls concurrently

### DIFF
--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -51,11 +51,10 @@ defmodule MingaAgent.Providers.Native do
   alias MingaAgent.MCP.Registry, as: MCPRegistry
   alias MingaAgent.MCP.ServerConfig, as: MCPServerConfig
   alias MingaAgent.Memory
-  alias MingaAgent.ProjectView
-  alias MingaAgent.ToolRouter
   alias MingaAgent.ModelCatalog
   alias MingaAgent.ModelLimits
   alias MingaAgent.ProjectView
+  alias MingaAgent.ToolRouter
   alias MingaAgent.Retry
   alias MingaAgent.Session
   alias MingaAgent.Skills
@@ -184,7 +183,8 @@ defmodule MingaAgent.Providers.Native do
           mcp_enabled_override: boolean() | nil,
           mcp_errors: %{String.t() => String.t()},
           mcp_registry: MCPRegistry.t() | nil,
-          read_only?: boolean()
+          read_only?: boolean(),
+          tool_workers: %{reference() => pid()}
         }
 
   # ── Provider callbacks ──────────────────────────────────────────────────────
@@ -429,7 +429,8 @@ defmodule MingaAgent.Providers.Native do
       mcp_enabled_override: mcp_enabled_override,
       mcp_errors: %{},
       mcp_registry: mcp_registry,
-      read_only?: read_only?
+      read_only?: read_only?,
+      tool_workers: %{}
     }
 
     Minga.Log.info(:agent, "[Agent.Native] started with model=#{model} root=#{project_root}")
@@ -518,7 +519,8 @@ defmodule MingaAgent.Providers.Native do
   end
 
   def handle_call(:abort, _from, %{task: nil} = state) do
-    {:reply, :ok, state}
+    stop_registered_tool_workers(state.tool_workers)
+    {:reply, :ok, %{state | tool_workers: %{}}}
   end
 
   def handle_call(:abort, _from, state) do
@@ -526,8 +528,9 @@ defmodule MingaAgent.Providers.Native do
     # (which traps exits) can terminate cleanly via its terminate/2
     # callback. :brutal_kill sends an untrappable :kill signal that
     # causes OTP to log the StreamServer's state as an [error].
+    stop_registered_tool_workers(state.tool_workers)
     Task.shutdown(state.task, 150)
-    state = %{state | task: nil, streaming: false}
+    state = %{state | task: nil, streaming: false, tool_workers: %{}}
     Minga.Log.info(:agent, "[Agent.Native] aborted current operation")
     {:reply, :ok, state}
   end
@@ -619,7 +622,9 @@ defmodule MingaAgent.Providers.Native do
   end
 
   def handle_call(:new_session, _from, state) do
-    # Gracefully stop any running task (see :abort handler comment)
+    # Gracefully stop any running task and registered workers (see :abort handler comment)
+    stop_registered_tool_workers(state.tool_workers)
+
     if state.task do
       Task.shutdown(state.task, 150)
     end
@@ -627,7 +632,15 @@ defmodule MingaAgent.Providers.Native do
     system_prompt = build_system_prompt(state.project_root, state.active_skills)
     context = Context.new([Context.system(system_prompt)])
 
-    state = %{state | context: context, task: nil, streaming: false, session_cost: 0.0}
+    state = %{
+      state
+      | context: context,
+        task: nil,
+        streaming: false,
+        session_cost: 0.0,
+        tool_workers: %{}
+    }
+
     Minga.Log.info(:agent, "[Agent.Native] new session started")
 
     {:reply, :ok, state}
@@ -814,6 +827,15 @@ defmodule MingaAgent.Providers.Native do
     {:reply, {:ok, budget}, state}
   end
 
+  def handle_call({:register_tool_workers, workers}, _from, state) when is_list(workers) do
+    tool_workers =
+      Enum.reduce(workers, state.tool_workers, fn {monitor_ref, pid}, acc ->
+        Map.put(acc, monitor_ref, pid)
+      end)
+
+    {:reply, :ok, %{state | tool_workers: tool_workers}}
+  end
+
   def handle_call({:set_max_cost, amount}, _from, state) when is_number(amount) and amount > 0 do
     Minga.Log.info(:agent, "[Agent.Native] cost budget set to $#{Float.round(amount + 0.0, 2)}")
     {:reply, :ok, %{state | max_cost: amount + 0.0}}
@@ -844,44 +866,53 @@ defmodule MingaAgent.Providers.Native do
     {:noreply, %{state | interrupted: true}}
   end
 
+  def handle_info({:unregister_tool_workers, monitor_refs}, state) when is_list(monitor_refs) do
+    {:noreply, %{state | tool_workers: Map.drop(state.tool_workers, monitor_refs)}}
+  end
+
   def handle_info({ref, :ok}, %{task: %Task{ref: ref}} = state) do
     # Task completed normally
     Process.demonitor(ref, [:flush])
-    {:noreply, %{state | task: nil, streaming: false}}
+    {:noreply, %{state | task: nil, streaming: false, tool_workers: %{}}}
   end
 
   def handle_info({ref, {:error, :stream_interrupted}}, %{task: %Task{ref: ref}} = state) do
     # Stream was interrupted but partial response was preserved
     Process.demonitor(ref, [:flush])
-    {:noreply, %{state | task: nil, streaming: false, interrupted: true}}
+    stop_registered_tool_workers(state.tool_workers)
+    {:noreply, %{state | task: nil, streaming: false, interrupted: true, tool_workers: %{}}}
   end
 
   def handle_info({ref, {:error, :turn_limit_reached}}, %{task: %Task{ref: ref}} = state) do
     Process.demonitor(ref, [:flush])
-    {:noreply, %{state | task: nil, streaming: false, interrupted: true}}
+    stop_registered_tool_workers(state.tool_workers)
+    {:noreply, %{state | task: nil, streaming: false, interrupted: true, tool_workers: %{}}}
   end
 
   def handle_info({ref, {:error, :cost_limit_reached}}, %{task: %Task{ref: ref}} = state) do
     Process.demonitor(ref, [:flush])
-    {:noreply, %{state | task: nil, streaming: false}}
+    stop_registered_tool_workers(state.tool_workers)
+    {:noreply, %{state | task: nil, streaming: false, tool_workers: %{}}}
   end
 
   def handle_info({ref, {:error, reason}}, %{task: %Task{ref: ref}} = state) do
     # Task completed with an error
     Process.demonitor(ref, [:flush])
+    stop_registered_tool_workers(state.tool_workers)
     formatted = format_error(reason)
     Minga.Log.error(:agent, "[Agent.Native] agent loop error: #{formatted}")
     notify(state.subscriber, %Event.Error{message: formatted})
     notify(state.subscriber, %Event.AgentEnd{usage: nil})
-    {:noreply, %{state | task: nil, streaming: false}}
+    {:noreply, %{state | task: nil, streaming: false, tool_workers: %{}}}
   end
 
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{task: %Task{ref: ref}} = state) do
     # Task crashed
+    stop_registered_tool_workers(state.tool_workers)
     Minga.Log.error(:agent, "[Agent.Native] agent task crashed: #{inspect(reason)}")
     notify(state.subscriber, %Event.Error{message: "Agent task crashed: #{inspect(reason)}"})
     notify(state.subscriber, %Event.AgentEnd{usage: nil})
-    {:noreply, %{state | task: nil, streaming: false}}
+    {:noreply, %{state | task: nil, streaming: false, tool_workers: %{}}}
   end
 
   def handle_info({:DOWN, _ref, :process, pid, _reason}, %{fork_store: pid} = state)
@@ -940,6 +971,7 @@ defmodule MingaAgent.Providers.Native do
 
   @impl true
   def terminate(reason, state) do
+    stop_registered_tool_workers(state.tool_workers)
     cleanup_fork_store(state.fork_store)
     cleanup_changeset(state.changeset, reason)
     cleanup_mcp(state.mcp_registry)
@@ -1568,48 +1600,278 @@ defmodule MingaAgent.Providers.Native do
   defp execute_tools(lctx, context, tool_calls, available_tools) do
     initial_mode = approval_mode(lctx.config)
 
-    {final_ctx, _mode} =
-      Enum.reduce(tool_calls, {context, initial_mode}, fn tool_call, {ctx, approval_mode} ->
-        before_content = capture_file_before(lctx, tool_call)
+    baselines = capture_tool_baselines(tool_calls, lctx)
 
-        {result_text, is_error, new_mode} =
-          execute_with_approval(
-            lctx.provider_pid,
-            lctx.session_pid,
-            tool_call,
-            available_tools,
-            approval_mode,
-            lctx.config,
-            lctx.hook_runner
-          )
-
-        send(
-          lctx.provider_pid,
-          {:agent_event,
-           %Event.ToolEnd{
-             tool_call_id: tool_call.id,
-             name: tool_call.name,
-             result: result_text,
-             is_error: is_error
-           }}
-        )
-
-        dispatch_post_tool_use(tool_call, result_text, is_error, lctx.config)
-
-        maybe_emit_file_changed(lctx, tool_call, before_content, is_error)
-
-        meta = if is_error, do: %{is_error: true}, else: %{}
-
-        tool_result_msg =
-          Context.tool_result_message(tool_call.name, tool_call.id, result_text, meta)
-
-        {Context.append(ctx, tool_result_msg), new_mode}
+    {approval_baselines, concurrent_baselines} =
+      Enum.split_with(baselines, fn {_index, tool_call, _before_content} ->
+        tool_requires_approval?(tool_call, lctx.config, initial_mode)
       end)
 
-    final_ctx
+    concurrent_tasks =
+      start_concurrent_tool_tasks(lctx, concurrent_baselines, available_tools, initial_mode)
+
+    try do
+      approval_results =
+        Enum.map(approval_baselines, fn {index, tool_call, before_content} ->
+          {index,
+           execute_tool_call(lctx, tool_call, before_content, available_tools, initial_mode)}
+        end)
+
+      concurrent_results = await_concurrent_tool_tasks(lctx.provider_pid, concurrent_tasks)
+
+      (approval_results ++ concurrent_results)
+      |> Enum.sort_by(fn {index, _result} -> index end)
+      |> Enum.reduce(context, fn {_index, result}, ctx ->
+        Context.append(ctx, tool_result_message(result))
+      end)
+    after
+      cleanup_concurrent_tool_tasks(lctx.provider_pid, concurrent_tasks)
+    end
   end
 
   @typep approval_mode :: :none | :ask | :ask_all
+  @typep tool_baseline :: {non_neg_integer(), map(), String.t() | nil}
+  @typep unstarted_tool_task ::
+           {non_neg_integer(), map(), pid(), reference(), reference(), reference()}
+  @typep tool_task :: {non_neg_integer(), map(), pid(), reference(), reference()}
+  @typep tool_execution_result :: %{
+           required(:tool_call) => map(),
+           required(:result_text) => String.t(),
+           required(:is_error) => boolean()
+         }
+
+  @spec capture_tool_baselines([map()], loop_ctx()) :: [tool_baseline()]
+  defp capture_tool_baselines(tool_calls, lctx) do
+    tool_calls
+    |> Enum.with_index()
+    |> Enum.map(fn {tool_call, index} ->
+      {index, tool_call, capture_file_before(lctx, tool_call)}
+    end)
+  end
+
+  @spec start_concurrent_tool_tasks(
+          loop_ctx(),
+          [tool_baseline()],
+          [ReqLLM.Tool.t()],
+          approval_mode()
+        ) :: [tool_task()]
+  defp start_concurrent_tool_tasks(lctx, baselines, available_tools, approval_mode) do
+    parent = self()
+
+    tasks =
+      Enum.map(baselines, fn {index, tool_call, before_content} ->
+        result_ref = make_ref()
+        start_ref = make_ref()
+
+        pid =
+          spawn_link(fn ->
+            receive do
+              {^start_ref, :run} ->
+                result =
+                  execute_tool_call(
+                    lctx,
+                    tool_call,
+                    before_content,
+                    available_tools,
+                    approval_mode
+                  )
+
+                send(parent, {result_ref, :tool_result, result})
+            end
+          end)
+
+        monitor_ref = Process.monitor(pid)
+
+        {index, tool_call, pid, monitor_ref, result_ref, start_ref}
+      end)
+
+    start_registered_tool_tasks(lctx.provider_pid, tasks)
+  end
+
+  @spec start_registered_tool_tasks(pid(), [unstarted_tool_task()]) :: [tool_task()]
+  defp start_registered_tool_tasks(provider_pid, tasks) do
+    case register_tool_workers(provider_pid, tasks) do
+      :ok ->
+        Enum.map(tasks, fn {index, tool_call, pid, monitor_ref, result_ref, start_ref} ->
+          Process.unlink(pid)
+          send(pid, {start_ref, :run})
+          {index, tool_call, pid, monitor_ref, result_ref}
+        end)
+
+      {:error, reason} ->
+        cleanup_unstarted_tool_tasks(provider_pid, tasks)
+        exit({:tool_worker_registration_failed, reason})
+    end
+  catch
+    kind, reason ->
+      cleanup_unstarted_tool_tasks(provider_pid, tasks)
+      :erlang.raise(kind, reason, __STACKTRACE__)
+  end
+
+  @spec await_concurrent_tool_tasks(pid(), [tool_task()]) :: [
+          {non_neg_integer(), tool_execution_result()}
+        ]
+  defp await_concurrent_tool_tasks(provider_pid, tasks) do
+    Enum.map(tasks, fn {index, tool_call, _pid, monitor_ref, result_ref} ->
+      {index, await_tool_process(provider_pid, tool_call, monitor_ref, result_ref)}
+    end)
+  end
+
+  @spec register_tool_workers(pid(), [unstarted_tool_task()]) :: :ok | {:error, term()}
+  defp register_tool_workers(provider_pid, tasks) do
+    workers =
+      Enum.map(tasks, fn {_index, _tool_call, pid, monitor_ref, _result_ref, _start_ref} ->
+        {monitor_ref, pid}
+      end)
+
+    GenServer.call(provider_pid, {:register_tool_workers, workers})
+  catch
+    :exit, reason -> {:error, {:exit, reason}}
+  end
+
+  @spec cleanup_unstarted_tool_tasks(pid(), [unstarted_tool_task()]) :: :ok
+  defp cleanup_unstarted_tool_tasks(provider_pid, tasks) do
+    monitor_refs =
+      Enum.map(tasks, fn {_index, _tool_call, pid, monitor_ref, _result_ref, _start_ref} ->
+        Process.unlink(pid)
+        Process.demonitor(monitor_ref, [:flush])
+        stop_tool_worker(pid)
+        monitor_ref
+      end)
+
+    unregister_tool_workers(provider_pid, monitor_refs)
+    :ok
+  end
+
+  @spec cleanup_concurrent_tool_tasks(pid(), [tool_task()]) :: :ok
+  defp cleanup_concurrent_tool_tasks(provider_pid, tasks) do
+    monitor_refs =
+      Enum.map(tasks, fn {_index, _tool_call, pid, monitor_ref, _result_ref} ->
+        Process.unlink(pid)
+        Process.demonitor(monitor_ref, [:flush])
+        stop_tool_worker(pid)
+        monitor_ref
+      end)
+
+    unregister_tool_workers(provider_pid, monitor_refs)
+    :ok
+  end
+
+  @spec unregister_tool_workers(pid(), [reference()]) :: :ok
+  defp unregister_tool_workers(_provider_pid, []), do: :ok
+
+  defp unregister_tool_workers(provider_pid, monitor_refs) do
+    send(provider_pid, {:unregister_tool_workers, monitor_refs})
+    :ok
+  end
+
+  @spec stop_registered_tool_workers(%{reference() => pid()}) :: :ok
+  defp stop_registered_tool_workers(tool_workers) when is_map(tool_workers) do
+    Enum.each(tool_workers, fn {_monitor_ref, pid} ->
+      stop_tool_worker(pid)
+    end)
+
+    :ok
+  end
+
+  @spec stop_tool_worker(pid()) :: :ok
+  defp stop_tool_worker(pid) when is_pid(pid) do
+    if Process.alive?(pid) do
+      Process.exit(pid, :kill)
+    end
+
+    :ok
+  end
+
+  @spec await_tool_process(pid(), map(), reference(), reference()) :: tool_execution_result()
+  defp await_tool_process(provider_pid, tool_call, monitor_ref, result_ref) do
+    receive do
+      {^result_ref, :tool_result, result} ->
+        Process.demonitor(monitor_ref, [:flush])
+        result
+
+      {:DOWN, ^monitor_ref, :process, _pid, reason} ->
+        receive_tool_result_after_down(provider_pid, tool_call, result_ref, reason)
+    end
+  end
+
+  @spec receive_tool_result_after_down(pid(), map(), reference(), term()) ::
+          tool_execution_result()
+  defp receive_tool_result_after_down(provider_pid, tool_call, result_ref, reason) do
+    receive do
+      {^result_ref, :tool_result, result} ->
+        result
+    after
+      0 ->
+        tool_task_failed(provider_pid, tool_call, reason)
+    end
+  end
+
+  @spec tool_task_failed(pid(), map(), term()) :: tool_execution_result()
+  defp tool_task_failed(provider_pid, tool_call, reason) do
+    result_text = "Tool task failed: #{inspect(reason)}"
+    emit_tool_end(provider_pid, tool_call, result_text, true)
+    %{tool_call: tool_call, result_text: result_text, is_error: true}
+  end
+
+  @spec execute_tool_call(
+          loop_ctx(),
+          map(),
+          String.t() | nil,
+          [ReqLLM.Tool.t()],
+          approval_mode()
+        ) :: tool_execution_result()
+  defp execute_tool_call(lctx, tool_call, before_content, available_tools, approval_mode) do
+    {result_text, is_error, _new_mode} =
+      execute_with_approval(
+        lctx.provider_pid,
+        lctx.session_pid,
+        tool_call,
+        available_tools,
+        approval_mode,
+        lctx.config,
+        lctx.hook_runner
+      )
+
+    emit_tool_end(lctx.provider_pid, tool_call, result_text, is_error)
+    dispatch_post_tool_use(tool_call, result_text, is_error, lctx.config)
+
+    maybe_emit_file_changed(lctx, tool_call, before_content, is_error)
+
+    %{tool_call: tool_call, result_text: result_text, is_error: is_error}
+  rescue
+    e ->
+      result_text = "Tool '#{tool_call.name}' crashed: #{Exception.message(e)}"
+      emit_tool_end(lctx.provider_pid, tool_call, result_text, true)
+      %{tool_call: tool_call, result_text: result_text, is_error: true}
+  catch
+    kind, reason ->
+      result_text = "Tool '#{tool_call.name}' failed: #{inspect({kind, reason})}"
+      emit_tool_end(lctx.provider_pid, tool_call, result_text, true)
+      %{tool_call: tool_call, result_text: result_text, is_error: true}
+  end
+
+  @spec emit_tool_end(pid(), map(), String.t(), boolean()) :: :ok
+  defp emit_tool_end(provider_pid, tool_call, result_text, is_error) do
+    send(
+      provider_pid,
+      {:agent_event,
+       %Event.ToolEnd{
+         tool_call_id: tool_call.id,
+         name: tool_call.name,
+         result: result_text,
+         is_error: is_error
+       }}
+    )
+
+    :ok
+  end
+
+  @spec tool_result_message(tool_execution_result()) :: ReqLLM.Message.t()
+  defp tool_result_message(%{tool_call: tool_call, result_text: result_text, is_error: is_error}) do
+    meta = if is_error, do: %{is_error: true}, else: %{}
+    Context.tool_result_message(tool_call.name, tool_call.id, result_text, meta)
+  end
 
   @spec execute_with_approval(
           pid(),
@@ -1758,6 +2020,24 @@ defmodule MingaAgent.Providers.Native do
 
       {result, is_error, :ask}
     end
+  end
+
+  @spec tool_requires_approval?(map(), AgentConfig.t(), approval_mode()) :: boolean()
+  defp tool_requires_approval?(tool_call, config, mode) do
+    case tool_permission(tool_call.name, config) do
+      :ask -> true
+      :allow -> false
+      :deny -> false
+      nil -> global_mode_requires_approval?(tool_call, mode)
+    end
+  end
+
+  @spec global_mode_requires_approval?(map(), approval_mode()) :: boolean()
+  defp global_mode_requires_approval?(_tool_call, :none), do: false
+  defp global_mode_requires_approval?(_tool_call, :ask_all), do: true
+
+  defp global_mode_requires_approval?(tool_call, :ask) do
+    Tools.destructive?(tool_call.name, tool_call.arguments || %{})
   end
 
   # Looks up per-tool permission from config. Returns :allow, :deny, :ask, or nil

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -128,6 +128,26 @@ defmodule MingaAgent.Providers.NativeTest do
     end
   end
 
+  defp tool_message_text(message) do
+    Enum.map_join(message.content, "", & &1.text)
+  end
+
+  defp collect_spawned_processes(parent, count) do
+    collect_spawned_processes(parent, count, [])
+  end
+
+  defp collect_spawned_processes(_parent, 0, acc), do: Enum.reverse(acc)
+
+  defp collect_spawned_processes(parent, count, acc) do
+    receive do
+      {:trace, ^parent, :spawn, pid, _mfa} ->
+        collect_spawned_processes(parent, count - 1, [pid | acc])
+    after
+      1_000 ->
+        flunk("expected #{count} more spawned process(es) from #{inspect(parent)}")
+    end
+  end
+
   # ── Lifecycle tests ─────────────────────────────────────────────────────────
 
   describe "init, context, and thinking level" do
@@ -417,6 +437,553 @@ defmodule MingaAgent.Providers.NativeTest do
       # Should eventually get a text response and AgentEnd
       assert Enum.any?(events, &match?(%Event.TextDelta{}, &1))
       assert Enum.any?(events, &match?(%Event.AgentEnd{}, &1))
+    end
+
+    test "executes independent tool calls concurrently and appends results in call order", %{
+      tmp_dir: dir
+    } do
+      test_pid = self()
+      release_ref = make_ref()
+      messages_ref = make_ref()
+      call_count = :counters.new(1, [:atomics])
+
+      slow_tool =
+        ReqLLM.Tool.new!(
+          name: "slow_tool",
+          description: "Blocks until the test releases it",
+          parameter_schema: [],
+          callback: fn _args ->
+            send(test_pid, {:tool_started, "slow_tool", self()})
+
+            receive do
+              {^release_ref, :release} -> {:ok, "slow result"}
+            after
+              1_000 -> {:error, "slow tool timed out"}
+            end
+          end
+        )
+
+      failing_tool =
+        ReqLLM.Tool.new!(
+          name: "failing_tool",
+          description: "Fails immediately",
+          parameter_schema: [],
+          callback: fn _args ->
+            send(test_pid, {:tool_started, "failing_tool", self()})
+            {:error, "boom"}
+          end
+        )
+
+      client = fn _model, messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call("slow_tool", %{}, %{id: "tc_slow", index: 0}),
+                ReqLLM.StreamChunk.tool_call("failing_tool", %{}, %{id: "tc_fail", index: 1}),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              send(test_pid, {messages_ref, messages})
+              [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} =
+        start_provider(tmp_dir: dir, llm_client: client, tools: [slow_tool, failing_tool])
+
+      assert :ok = Native.send_prompt(pid, "Run both tools")
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+      assert_receive {:tool_started, "slow_tool", slow_pid}, 1_000
+      assert_receive {:tool_started, "failing_tool", _failing_pid}, 1_000
+
+      send(slow_pid, {release_ref, :release})
+      events = collect_events(1_000)
+
+      assert Enum.any?(events, &match?(%Event.ToolEnd{name: "slow_tool", is_error: false}, &1))
+      assert Enum.any?(events, &match?(%Event.ToolEnd{name: "failing_tool", is_error: true}, &1))
+
+      assert_received {^messages_ref, messages}
+      tool_messages = Enum.filter(messages, fn message -> message.role == :tool end)
+      assert Enum.map(tool_messages, & &1.tool_call_id) == ["tc_slow", "tc_fail"]
+      assert Enum.map(tool_messages, &tool_message_text/1) == ["slow result", "boom"]
+      assert Enum.map(tool_messages, & &1.metadata[:is_error]) == [nil, true]
+    end
+
+    test "abnormal concurrent tool exit becomes an error while a sibling completes", %{
+      tmp_dir: dir
+    } do
+      test_pid = self()
+      release_ref = make_ref()
+      messages_ref = make_ref()
+      call_count = :counters.new(1, [:atomics])
+
+      crashing_tool =
+        ReqLLM.Tool.new!(
+          name: "crashing_tool",
+          description: "Exits abnormally",
+          parameter_schema: [],
+          callback: fn _args ->
+            send(test_pid, {:tool_started, "crashing_tool"})
+            Process.exit(self(), :kill)
+          end
+        )
+
+      sibling_tool =
+        ReqLLM.Tool.new!(
+          name: "sibling_tool",
+          description: "Completes after the crashing sibling exits",
+          parameter_schema: [],
+          callback: fn _args ->
+            send(test_pid, {:tool_started, "sibling_tool", self()})
+
+            receive do
+              {^release_ref, :release} -> {:ok, "sibling result"}
+            after
+              1_000 -> {:error, "sibling tool timed out"}
+            end
+          end
+        )
+
+      client = fn _model, messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call("crashing_tool", %{}, %{id: "tc_crash", index: 0}),
+                ReqLLM.StreamChunk.tool_call("sibling_tool", %{}, %{id: "tc_sibling", index: 1}),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              send(test_pid, {messages_ref, messages})
+              [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} =
+        start_provider(tmp_dir: dir, llm_client: client, tools: [crashing_tool, sibling_tool])
+
+      assert :ok = Native.send_prompt(pid, "Run both tools")
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+      assert_receive {:tool_started, "crashing_tool"}, 1_000
+      assert_receive {:tool_started, "sibling_tool", sibling_pid}, 1_000
+
+      send(sibling_pid, {release_ref, :release})
+      events = collect_events(1_000)
+
+      crash_end = Enum.find(events, &match?(%Event.ToolEnd{name: "crashing_tool"}, &1))
+      assert crash_end != nil
+      assert crash_end.is_error == true
+      assert crash_end.result =~ "killed"
+      assert Enum.any?(events, &match?(%Event.ToolEnd{name: "sibling_tool", is_error: false}, &1))
+      assert Enum.any?(events, &match?(%Event.AgentEnd{}, &1))
+
+      assert_received {^messages_ref, messages}
+      tool_messages = Enum.filter(messages, fn message -> message.role == :tool end)
+      assert Enum.map(tool_messages, & &1.tool_call_id) == ["tc_crash", "tc_sibling"]
+
+      assert Enum.map(tool_messages, &tool_message_text/1) == [
+               "Tool task failed: :killed",
+               "sibling result"
+             ]
+
+      assert Enum.map(tool_messages, & &1.metadata[:is_error]) == [true, nil]
+    end
+
+    test "concurrent tool update events keep streaming while sibling tools run", %{tmp_dir: dir} do
+      test_pid = self()
+      release_ref = make_ref()
+      messages_ref = make_ref()
+      provider_holder = start_supervised!({Agent, fn -> nil end})
+      call_count = :counters.new(1, [:atomics])
+
+      # The real shell tool spawns an OS process, which is unsafe in this async provider test.
+      # This custom tool covers the same provider event path by emitting ToolUpdate from a
+      # concurrent tool process without starting a shell.
+      streaming_tool =
+        ReqLLM.Tool.new!(
+          name: "streaming_tool",
+          description: "Emits ToolUpdate events without spawning an OS shell",
+          parameter_schema: [],
+          callback: fn _args ->
+            provider_pid = Agent.get(provider_holder, & &1)
+
+            send(
+              provider_pid,
+              {:agent_event,
+               %Event.ToolUpdate{
+                 tool_call_id: "tc_stream",
+                 name: "shell",
+                 partial_result: "stream chunk\n"
+               }}
+            )
+
+            {:ok, "stream result"}
+          end
+        )
+
+      sibling_tool =
+        ReqLLM.Tool.new!(
+          name: "stream_sibling_tool",
+          description: "Completes after the update has streamed",
+          parameter_schema: [],
+          callback: fn _args ->
+            send(test_pid, {:tool_started, "stream_sibling_tool", self()})
+
+            receive do
+              {^release_ref, :release} -> {:ok, "sibling result"}
+            after
+              1_000 -> {:error, "sibling tool timed out"}
+            end
+          end
+        )
+
+      client = fn _model, messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call("streaming_tool", %{}, %{id: "tc_stream", index: 0}),
+                ReqLLM.StreamChunk.tool_call("stream_sibling_tool", %{}, %{
+                  id: "tc_stream_sibling",
+                  index: 1
+                }),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              send(test_pid, {messages_ref, messages})
+              [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} =
+        start_provider(tmp_dir: dir, llm_client: client, tools: [streaming_tool, sibling_tool])
+
+      Agent.update(provider_holder, fn _ -> pid end)
+
+      assert :ok = Native.send_prompt(pid, "Run both tools")
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolUpdate{
+                        tool_call_id: "tc_stream",
+                        name: "shell",
+                        partial_result: "stream chunk\n"
+                      }},
+                     1_000
+
+      assert_receive {:tool_started, "stream_sibling_tool", sibling_pid}, 1_000
+      send(sibling_pid, {release_ref, :release})
+      events = collect_events(1_000)
+
+      assert Enum.any?(
+               events,
+               &match?(%Event.ToolEnd{name: "streaming_tool", is_error: false}, &1)
+             )
+
+      assert Enum.any?(
+               events,
+               &match?(%Event.ToolEnd{name: "stream_sibling_tool", is_error: false}, &1)
+             )
+
+      assert_received {^messages_ref, messages}
+      tool_messages = Enum.filter(messages, fn message -> message.role == :tool end)
+      assert Enum.map(tool_messages, & &1.tool_call_id) == ["tc_stream", "tc_stream_sibling"]
+    end
+
+    test "registration failure cleans up unstarted concurrent tool workers", %{tmp_dir: dir} do
+      previous_trap = Process.flag(:trap_exit, true)
+
+      try do
+        test_pid = self()
+        release_ref = make_ref()
+        marker_one = Path.join(dir, "registration-worker-one-ran.txt")
+        marker_two = Path.join(dir, "registration-worker-two-ran.txt")
+
+        tool_one =
+          ReqLLM.Tool.new!(
+            name: "registration_cleanup_one",
+            description: "Should never run after registration failure",
+            parameter_schema: [],
+            callback: fn _args ->
+              File.write!(marker_one, "ran")
+              send(test_pid, :registration_cleanup_one_ran)
+              {:ok, "ran one"}
+            end
+          )
+
+        tool_two =
+          ReqLLM.Tool.new!(
+            name: "registration_cleanup_two",
+            description: "Should never run after registration failure",
+            parameter_schema: [],
+            callback: fn _args ->
+              File.write!(marker_two, "ran")
+              send(test_pid, :registration_cleanup_two_ran)
+              {:ok, "ran two"}
+            end
+          )
+
+        response =
+          build_stream_response([
+            ReqLLM.StreamChunk.tool_call("registration_cleanup_one", %{}, %{
+              id: "tc_registration_one",
+              index: 0
+            }),
+            ReqLLM.StreamChunk.tool_call("registration_cleanup_two", %{}, %{
+              id: "tc_registration_two",
+              index: 1
+            }),
+            ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+          ])
+
+        client = fn _model, _messages, _opts ->
+          send(test_pid, {:registration_cleanup_client_waiting, release_ref})
+
+          receive do
+            {^release_ref, :release} -> response
+          end
+        end
+
+        {:ok, pid} =
+          start_provider(tmp_dir: dir, llm_client: client, tools: [tool_one, tool_two])
+
+        assert :ok = Native.send_prompt(pid, "Run both tools")
+        assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+        assert_receive {:registration_cleanup_client_waiting, ^release_ref}, 1_000
+
+        %{task: %Task{pid: task_pid}} = :sys.get_state(pid)
+        :erlang.trace(task_pid, true, [:procs])
+        :sys.suspend(pid)
+
+        send(task_pid, {release_ref, :release})
+        worker_pids = collect_spawned_processes(task_pid, 2)
+        :erlang.trace(task_pid, false, [:procs])
+        worker_refs = Enum.map(worker_pids, &Process.monitor/1)
+
+        for {worker_ref, worker_pid} <- Enum.zip(worker_refs, worker_pids) do
+          assert_receive {:DOWN, ^worker_ref, :process, ^worker_pid, _reason}, 7_000
+        end
+
+        if Process.alive?(pid) do
+          :sys.resume(pid)
+
+          try do
+            Native.get_state(pid)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+
+        refute_receive :registration_cleanup_one_ran, 50
+        refute_receive :registration_cleanup_two_ran, 50
+        refute File.exists?(marker_one)
+        refute File.exists?(marker_two)
+      after
+        Process.flag(:trap_exit, previous_trap)
+      end
+    end
+
+    test "approval-required tools wait while allowed tools continue", %{tmp_dir: dir} do
+      test_pid = self()
+      release_ref = make_ref()
+      messages_ref = make_ref()
+      call_count = :counters.new(1, [:atomics])
+
+      ask_tool =
+        ReqLLM.Tool.new!(
+          name: "ask_tool",
+          description: "Requires approval before running",
+          parameter_schema: [],
+          callback: fn _args -> {:ok, "approved result"} end
+        )
+
+      allowed_tool =
+        ReqLLM.Tool.new!(
+          name: "allowed_tool",
+          description: "Runs without approval",
+          parameter_schema: [],
+          callback: fn _args ->
+            send(test_pid, {:tool_started, "allowed_tool", self()})
+
+            receive do
+              {^release_ref, :release} -> {:ok, "allowed result"}
+            after
+              1_000 -> {:error, "allowed tool timed out"}
+            end
+          end
+        )
+
+      client = fn _model, messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call("ask_tool", %{}, %{id: "tc_ask", index: 0}),
+                ReqLLM.StreamChunk.tool_call("allowed_tool", %{}, %{id: "tc_allowed", index: 1}),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              send(test_pid, {messages_ref, messages})
+              [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: dir,
+          llm_client: client,
+          tools: [ask_tool, allowed_tool],
+          config: agent_config(tool_permissions: %{"ask_tool" => :ask, "allowed_tool" => :allow})
+        )
+
+      assert :ok = Native.send_prompt(pid, "Run both tools")
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolApproval{tool_call_id: "tc_ask", reply_to: reply_to}},
+                     1_000
+
+      assert_receive {:tool_started, "allowed_tool", allowed_pid}, 1_000
+      send(reply_to, {:tool_approval_response, "tc_ask", :approve})
+      send(allowed_pid, {release_ref, :release})
+      events = collect_events(1_000)
+
+      assert Enum.any?(events, &match?(%Event.ToolEnd{name: "ask_tool", is_error: false}, &1))
+      assert Enum.any?(events, &match?(%Event.ToolEnd{name: "allowed_tool", is_error: false}, &1))
+
+      assert_received {^messages_ref, messages}
+      tool_messages = Enum.filter(messages, fn message -> message.role == :tool end)
+      assert Enum.map(tool_messages, & &1.tool_call_id) == ["tc_ask", "tc_allowed"]
+    end
+
+    test "rejected approval-required tool does not prevent an allowed sibling from finishing", %{
+      tmp_dir: dir
+    } do
+      test_pid = self()
+      release_ref = make_ref()
+      messages_ref = make_ref()
+      call_count = :counters.new(1, [:atomics])
+
+      ask_tool =
+        ReqLLM.Tool.new!(
+          name: "reject_ask_tool",
+          description: "Requires approval before running",
+          parameter_schema: [],
+          callback: fn _args ->
+            send(test_pid, :rejected_approval_tool_ran)
+            {:ok, "should not run"}
+          end
+        )
+
+      allowed_tool =
+        ReqLLM.Tool.new!(
+          name: "reject_allowed_tool",
+          description: "Runs without approval",
+          parameter_schema: [],
+          callback: fn _args ->
+            send(test_pid, {:tool_started, "reject_allowed_tool", self()})
+
+            receive do
+              {^release_ref, :release} -> {:ok, "allowed result"}
+            after
+              1_000 -> {:error, "allowed tool timed out"}
+            end
+          end
+        )
+
+      client = fn _model, messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call("reject_ask_tool", %{}, %{id: "tc_reject", index: 0}),
+                ReqLLM.StreamChunk.tool_call("reject_allowed_tool", %{}, %{
+                  id: "tc_allowed",
+                  index: 1
+                }),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              send(test_pid, {messages_ref, messages})
+              [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: dir,
+          llm_client: client,
+          tools: [ask_tool, allowed_tool],
+          config:
+            agent_config(
+              tool_permissions: %{"reject_ask_tool" => :ask, "reject_allowed_tool" => :allow}
+            )
+        )
+
+      assert :ok = Native.send_prompt(pid, "Run both tools")
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolApproval{tool_call_id: "tc_reject", reply_to: reply_to}},
+                     1_000
+
+      assert_receive {:tool_started, "reject_allowed_tool", allowed_pid}, 1_000
+      send(reply_to, {:tool_approval_response, "tc_reject", :reject})
+      send(allowed_pid, {release_ref, :release})
+      events = collect_events(1_000)
+
+      rejected_end = Enum.find(events, &match?(%Event.ToolEnd{name: "reject_ask_tool"}, &1))
+      assert rejected_end != nil
+      assert rejected_end.is_error == true
+      assert rejected_end.result == "Tool rejected by user"
+
+      assert Enum.any?(
+               events,
+               &match?(%Event.ToolEnd{name: "reject_allowed_tool", is_error: false}, &1)
+             )
+
+      assert_received {^messages_ref, messages}
+      tool_messages = Enum.filter(messages, fn message -> message.role == :tool end)
+      assert Enum.map(tool_messages, & &1.tool_call_id) == ["tc_reject", "tc_allowed"]
+
+      assert Enum.map(tool_messages, &tool_message_text/1) == [
+               "Tool rejected by user",
+               "allowed result"
+             ]
+
+      assert Enum.map(tool_messages, & &1.metadata[:is_error]) == [true, nil]
+      refute_receive :rejected_approval_tool_ran, 50
     end
 
     test "tool approval mode :all preserves the batch prompt after per-tool ask overrides", %{
@@ -737,6 +1304,160 @@ defmodule MingaAgent.Providers.NativeTest do
 
       assert :ok = Native.abort(pid)
       assert {:ok, %{is_streaming: false}} = Native.get_state(pid)
+    end
+
+    test "stops concurrent tool workers when aborted", %{tmp_dir: dir} do
+      test_pid = self()
+      marker_path = Path.join(dir, "abort-worker-continued.txt")
+      release_ref = make_ref()
+      call_count = :counters.new(1, [:atomics])
+
+      blocking_tool =
+        ReqLLM.Tool.new!(
+          name: "abort_blocking_tool",
+          description: "Blocks until the test releases it",
+          parameter_schema: [],
+          callback: fn _args ->
+            send(test_pid, {:abort_blocking_tool_started, self()})
+
+            receive do
+              {^release_ref, :release} ->
+                File.write!(marker_path, "continued")
+                send(test_pid, :abort_blocking_tool_continued)
+                {:ok, "continued"}
+            after
+              5_000 ->
+                {:error, "blocking tool timed out"}
+            end
+          end
+        )
+
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call("abort_blocking_tool", %{}, %{
+                  id: "tc_abort_blocking",
+                  index: 0
+                }),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, tools: [blocking_tool])
+
+      assert :ok = Native.send_prompt(pid, "Run the blocking tool")
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+      assert_receive {:abort_blocking_tool_started, worker_pid}, 1_000
+      worker_ref = Process.monitor(worker_pid)
+
+      assert :ok = Native.abort(pid)
+      assert {:ok, %{is_streaming: false}} = Native.get_state(pid)
+      assert_receive {:DOWN, ^worker_ref, :process, ^worker_pid, _reason}, 1_000
+
+      send(worker_pid, {release_ref, :release})
+      refute_receive :abort_blocking_tool_continued, 50
+      refute File.exists?(marker_path)
+    end
+
+    test "aborting with no active task still stops registered tool workers", %{tmp_dir: dir} do
+      marker_path = Path.join(dir, "abort-nil-task-worker-continued.txt")
+      test_pid = self()
+      release_ref = make_ref()
+
+      worker_pid =
+        spawn(fn ->
+          receive do
+            {^release_ref, :release} ->
+              File.write!(marker_path, "continued")
+              send(test_pid, :abort_nil_task_worker_continued)
+          end
+        end)
+
+      worker_ref = Process.monitor(worker_pid)
+      {:ok, pid} = start_provider(tmp_dir: dir)
+      :ok = GenServer.call(pid, {:register_tool_workers, [{make_ref(), worker_pid}]})
+
+      assert :ok = Native.abort(pid)
+      assert_receive {:DOWN, ^worker_ref, :process, ^worker_pid, _reason}, 1_000
+
+      send(worker_pid, {release_ref, :release})
+      refute_receive :abort_nil_task_worker_continued, 50
+      refute File.exists?(marker_path)
+    end
+
+    test "new_session stops concurrent tool workers", %{tmp_dir: dir} do
+      test_pid = self()
+      marker_path = Path.join(dir, "new-session-worker-continued.txt")
+      release_ref = make_ref()
+      call_count = :counters.new(1, [:atomics])
+
+      blocking_tool =
+        ReqLLM.Tool.new!(
+          name: "new_session_blocking_tool",
+          description: "Blocks until the test releases it",
+          parameter_schema: [],
+          callback: fn _args ->
+            send(test_pid, {:new_session_blocking_tool_started, self()})
+
+            receive do
+              {^release_ref, :release} ->
+                File.write!(marker_path, "continued")
+                send(test_pid, :new_session_blocking_tool_continued)
+                {:ok, "continued"}
+            after
+              5_000 ->
+                {:error, "blocking tool timed out"}
+            end
+          end
+        )
+
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call("new_session_blocking_tool", %{}, %{
+                  id: "tc_new_session_blocking",
+                  index: 0
+                }),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, tools: [blocking_tool])
+
+      assert :ok = Native.send_prompt(pid, "Run the blocking tool")
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+      assert_receive {:new_session_blocking_tool_started, worker_pid}, 1_000
+      worker_ref = Process.monitor(worker_pid)
+
+      assert :ok = Native.new_session(pid)
+      assert {:ok, %{is_streaming: false}} = Native.get_state(pid)
+      assert_receive {:DOWN, ^worker_ref, :process, ^worker_pid, _reason}, 1_000
+
+      send(worker_pid, {release_ref, :release})
+      refute_receive :new_session_blocking_tool_continued, 50
+      refute File.exists?(marker_path)
     end
   end
 


### PR DESCRIPTION
# TL;DR
Independent native agent tool calls now run concurrently while preserving deterministic tool-result ordering, the existing approval flow, and safe cleanup on abort or session reset.

Closes #508

## Context
Issue #508 tracks unnecessary latency in the native agent loop when a model returns multiple tool calls in one response. Previously `execute_tools/4` ran the whole batch sequentially, so unrelated reads or shell commands waited on each other.

## Changes
- Captures file baselines for the whole tool-call batch before any tool starts, so diff review still compares against the pre-batch state.
- Runs non-approval tool calls concurrently with monitored worker processes.
- Keeps approval-required tool calls sequential because the session UI has one pending approval slot. Already-started non-approval calls can continue while an approval prompt waits for user input.
- Sorts all tool results by original tool-call index before appending them to the ReqLLM context.
- Converts per-tool crashes or worker exits into error tool results so one failed branch does not abort sibling tools.
- Tracks concurrent tool workers in provider state and stops them on abort, new session, task errors, task crashes, stream interruption, turn/cost limits, and provider termination.
- Cleans up workers if registration/startup fails before they are allowed to run.
- Adds native provider tests for concurrent execution, result ordering, abnormal exits, branch failure isolation, ToolUpdate event forwarding, mixed approval/allowed behavior, approval rejection, abort cleanup, new-session cleanup, nil-task abort cleanup, and registration failure cleanup.

## Verification
- `mix test.debug test/minga_agent/providers/native_test.exs` passed, 38 tests.
- `make lint` passed.
- `mix test.llm` passed, 56 doctests, 94 properties, 8595 tests, 0 failures, 283 excluded.
- `git diff --check` passed.
- Parent-orchestrated review loop ran 4 rounds plus one focused coverage fix. Reviewers found and verified fixes for approval-slot races, linked-task sibling failures, orphaned worker cleanup, new-session cleanup, nil-task abort cleanup, spawn/register/start cleanup, and registration-failure test coverage.
- Final acceptance reviewer passed.

## Acceptance Criteria Addressed
- When the model returns N tool calls in a single response, independent calls execute concurrently ✅
- Tool results are collected and appended to context in the original order ✅
- Destructive tools that require approval still block on user input, approval flow is unchanged ✅
- A tool failure in one concurrent branch does not abort sibling tools ✅
- Shell streaming output (`ToolUpdate` events) still works correctly for concurrent shell invocations ✅
- No change to the external behavior visible to the LLM, same tool result messages and same ordering ✅
