### PR TITLE
feat(config): add safe mode startup

### DIFF
--- a/bin/minga-mac
+++ b/bin/minga-mac
@@ -22,5 +22,5 @@ xcodebuild -project "$XCODEPROJ" -scheme Minga -configuration Debug \
 echo "Build complete."
 
 exec elixir -S mix run --no-halt --no-start \
-  -e 'Application.put_env(:minga, :start_editor, true); Application.put_env(:minga, :backend, :gui); Application.ensure_all_started(:minga); Minga.CLI.main(System.argv())' \
+  -e 'safe_mode = Minga.CLI.safe_args?(System.argv()); Minga.SafeMode.put(safe_mode); Application.put_env(:minga, :start_editor, true); Application.put_env(:minga, :backend, :gui); Application.ensure_all_started(:minga); Minga.CLI.main(System.argv())' \
   -- "$@"

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -304,7 +304,9 @@ opcode(1) + section_count(1) + [section_id(1) + section_len(2) + payload(section
 
 Mode values: 0=normal, 1=insert, 2=visual, 3=command, 4=operator_pending, 5=search, 6=replace
 
-Flags bits: bit 0=has_lsp, bit 1=has_git, bit 2=is_dirty
+Flags bits: bit 0=has_lsp, bit 1=has_git, bit 2=is_dirty, bit 3=safe_mode
+
+When bit 3 is set, the frontend should surface safe mode in the native status bar, for example with a small `[SAFE]` badge next to the mode indicator.
 
 LSP status: 0=none, 1=ready, 2=initializing, 3=starting, 4=error
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -927,7 +927,7 @@ Total size: 7 + (40 + text_len) per edit.
 
 Native GUI frontends (SwiftUI, GTK4) receive additional structured data opcodes for chrome elements like tab bars, file trees, status bars, and popups. These opcodes start at 0x70 and are sent only when the frontend reports `frontend_type = native_gui` in its capabilities. The GUI status bar opcode carries structured status fields, including readable agent/tool labels, plus named configured modeline segments so native frontends can keep platform styling while honoring modeline order and visibility.
 
-See [GUI_PROTOCOL.md](GUI_PROTOCOL.md) for the complete specification of GUI chrome opcodes, gui_action input events, theme color slots, and the behavioral contract for GUI frontends. The sectioned `gui_status_bar` opcode (`0x76`) is specified there, including the indent section (`0x0A`), named modeline segment section (`0x0B`), and selection section (`0x0C`).
+See [GUI_PROTOCOL.md](GUI_PROTOCOL.md) for the complete specification of GUI chrome opcodes, gui_action input events, theme color slots, and the behavioral contract for GUI frontends. The sectioned `gui_status_bar` opcode (`0x76`) is specified there, including the identity flags (with safe mode), the indent section (`0x0A`), named modeline segment section (`0x0B`), and selection section (`0x0C`).
 
 ---
 

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -87,6 +87,7 @@ defmodule Minga.Application do
     # tree starts so headless and pre-editor logs reach Minga.Log.MessagesBuffer
     # via the same path as logs from a running editor.
     Minga.LoggerHandler.install_messages_handler()
+    store_startup_safe_mode()
 
     minimal? = minimal_mode?()
 
@@ -185,6 +186,17 @@ defmodule Minga.Application do
   @spec minimal_mode?() :: boolean()
   defp minimal_mode? do
     Application.get_env(:minga, :minimal_mode, false) or standalone_minimal?()
+  end
+
+  @spec store_startup_safe_mode() :: :ok
+  defp store_startup_safe_mode do
+    if Minga.SafeMode.active?() do
+      Minga.SafeMode.put(true)
+    end
+
+    :ok
+  rescue
+    _ -> :ok
   end
 
   @spec standalone_headless?() :: boolean()

--- a/lib/minga/cli.ex
+++ b/lib/minga/cli.ex
@@ -34,6 +34,7 @@ defmodule Minga.CLI do
           debug_log: String.t() | nil,
           headless: boolean(),
           minimal: boolean(),
+          safe_mode: boolean(),
           node_name: String.t() | nil,
           short_name: boolean(),
           cookie: String.t() | nil,
@@ -49,6 +50,7 @@ defmodule Minga.CLI do
     debug_log: nil,
     headless: false,
     minimal: false,
+    safe_mode: false,
     node_name: nil,
     short_name: false,
     cookie: nil,
@@ -104,6 +106,12 @@ defmodule Minga.CLI do
   @spec minimal_args?([String.t()]) :: boolean()
   def minimal_args?(args) do
     Enum.member?(args, "--minimal")
+  end
+
+  @doc "Returns true when args request safe mode."
+  @spec safe_args?([String.t()]) :: boolean()
+  def safe_args?(args) do
+    Enum.member?(args, "--safe") or Enum.member?(args, "-Q")
   end
 
   @doc "Returns the startup flags stored by the CLI, or defaults if none were set."
@@ -324,6 +332,14 @@ defmodule Minga.CLI do
 
   defp parse_args(["--minimal" | rest], file, flags) do
     parse_args(rest, file, %{flags | minimal: true})
+  end
+
+  defp parse_args(["--safe" | rest], file, flags) do
+    parse_args(rest, file, %{flags | safe_mode: true})
+  end
+
+  defp parse_args(["-Q" | rest], file, flags) do
+    parse_args(rest, file, %{flags | safe_mode: true})
   end
 
   defp parse_args([<<"--", _::binary>> = flag | _], _file, _flags) do
@@ -672,6 +688,7 @@ defmodule Minga.CLI do
     Application.put_env(:minga, :cli_startup_flags, effective)
     store_startup_project_root(file)
     store_debug_log_path(effective.debug_log)
+    Minga.SafeMode.put(effective.safe_mode)
     if effective.minimal, do: Application.put_env(:minga, :minimal_mode, true)
     :ok
   end
@@ -798,6 +815,7 @@ defmodule Minga.CLI do
       -D, --debug-log <path> Append *Messages* and *Warnings* entries to a crash-safe log
       --editor               Start in file editing mode (skip agentic view)
       --minimal              Minimal mode: editor-only, no services/agent (for GIT_EDITOR use)
+      -Q, --safe             Safe mode: skip user config, user modules, after hooks, and extensions
       --no-context           Keep agentic view and don't load the file as agent context
       --headless             Start services and agent runtime without a GUI frontend
       --name <name@host>     Distributed Erlang long node name
@@ -814,6 +832,7 @@ defmodule Minga.CLI do
       minga --editor README.md           Open file in traditional editor
       MINGA_COOKIE=$(openssl rand -base64 32 | tr -d '/+=') minga --headless   Start detachable agent server
       minga --config ~/minimal.exs       Use a custom config profile
+      minga --safe                       Start with defaults and no user config
       minga -D /tmp/minga-debug.log      Persist messages and warnings for crash forensics
     """
   end

--- a/lib/minga/command/parser.ex
+++ b/lib/minga/command/parser.ex
@@ -98,6 +98,7 @@ defmodule Minga.Command.Parser do
           | {:extension_update, []}
           | {:extension_update_all, []}
           | {:parser_restart, []}
+          | {:safe_mode_status, []}
           | {:describe_command, []}
           | {:describe_command_named, [String.t()]}
           | {:describe_option, []}
@@ -282,6 +283,8 @@ defmodule Minga.Command.Parser do
   defp do_parse("ExtUpdateAll"), do: {:extension_update_all, []}
   defp do_parse("parser-restart"), do: {:parser_restart, []}
   defp do_parse("ParserRestart"), do: {:parser_restart, []}
+  defp do_parse("safe-mode?"), do: {:safe_mode_status, []}
+  defp do_parse("safe-mode"), do: {:safe_mode_status, []}
   defp do_parse("agent-stop"), do: {:agent_abort, []}
   defp do_parse("agent-new"), do: {:agent_new_session, []}
   defp do_parse("agent-clear-history"), do: {:agent_clear_history, []}

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -88,7 +88,9 @@ defmodule Minga.Config.Loader do
       )
       |> Options.validate_server!()
 
-    Agent.start_link(fn -> load_all(keymap_server, options_server) end, name: name)
+    Agent.start_link(fn -> load_all(keymap_server, options_server, Minga.SafeMode.active?()) end,
+      name: name
+    )
   end
 
   @doc """
@@ -244,8 +246,9 @@ defmodule Minga.Config.Loader do
       PopupRegistry.clear()
       ModelineSegments.reset_warnings()
 
-      # Re-run the full load sequence (includes starting extensions)
-      new_state = load_all(keymap_server, options_server)
+      # Re-run the full load sequence (includes starting extensions).
+      # Reload deliberately ignores startup safe mode so fixed config can be loaded without restarting.
+      new_state = load_all(keymap_server, options_server, false)
       Agent.update(server, fn _ -> new_state end)
 
       # Return error if any stage had problems
@@ -275,8 +278,8 @@ defmodule Minga.Config.Loader do
   # callback) won't see this dict and will fall back to registered defaults.
   # Extensions are skipped in test mode, so this only affects long-lived runtime
   # callers.
-  @spec load_all(keymap_server(), options_server()) :: state()
-  defp load_all(keymap_server, options_server) do
+  @spec load_all(keymap_server(), options_server(), boolean()) :: state()
+  defp load_all(keymap_server, options_server, safe_mode?) when is_boolean(safe_mode?) do
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
     previous_options_server = Process.put(:minga_config_options, options_server)
     previous_lsp_settings = Process.put(:minga_config_lsp_settings, %{})
@@ -289,88 +292,110 @@ defmodule Minga.Config.Loader do
       # 0. Register default popup rules (before user config so overrides work)
       register_default_popup_rules()
 
-      # 1. Compile user modules
-      {loaded_modules, modules_errors} = compile_user_modules(config_dir)
+      if safe_mode? do
+        safe_mode_state(config_path, config_dir, keymap_server, options_server)
+      else
+        # 1. Compile user modules
+        {loaded_modules, modules_errors} = compile_user_modules(config_dir)
 
-      # 2. Load user themes (before config eval so `set :theme, :my_custom` works)
-      load_user_themes()
+        # 2. Load user themes (before config eval so `set :theme, :my_custom` works)
+        load_user_themes()
 
-      # 3. Eval global config
-      custom_config? = cli_config_file() != nil
+        # 3. Eval global config
+        custom_config? = cli_config_file() != nil
 
-      load_error =
-        case {custom_config?, File.exists?(config_path)} do
-          {true, false} ->
-            "Custom config not found: #{config_path} (using defaults)"
+        load_error =
+          case {custom_config?, File.exists?(config_path)} do
+            {true, false} ->
+              "Custom config not found: #{config_path} (using defaults)"
 
-          _ ->
-            eval_if_exists(config_path)
-        end
+            _ ->
+              eval_if_exists(config_path)
+          end
 
-      load_error =
-        if custom_config? and load_error == nil and not String.ends_with?(config_path, ".exs") do
-          "Custom config path does not end in .exs: #{config_path} (file was loaded, but may not be valid Elixir)"
-        else
-          load_error
-        end
+        load_error =
+          if custom_config? and load_error == nil and not String.ends_with?(config_path, ".exs") do
+            "Custom config path does not end in .exs: #{config_path} (file was loaded, but may not be valid Elixir)"
+          else
+            load_error
+          end
 
-      # 4. Eval project-local config
-      project_path = resolve_project_config_path()
-      project_config_error = eval_if_exists(project_path)
-      project_mcp_error = load_project_mcp_json()
+        # 4. Eval project-local config
+        project_path = resolve_project_config_path()
+        project_config_error = eval_if_exists(project_path)
+        project_mcp_error = load_project_mcp_json()
 
-      # 5. Eval generated GUI settings overlay
-      gui_settings_path = Path.join(config_dir, "gui_settings.exs")
+        # 5. Eval generated GUI settings overlay
+        gui_settings_path = Path.join(config_dir, "gui_settings.exs")
 
-      gui_settings_error =
-        with_config_source(:gui_settings, fn -> eval_if_exists(gui_settings_path) end)
+        gui_settings_error =
+          with_config_source(:gui_settings, fn -> eval_if_exists(gui_settings_path) end)
 
-      # 6. Eval after.exs
-      after_path = Path.join(config_dir, "after.exs")
-      after_error = eval_if_exists(after_path)
+        # 6. Eval after.exs
+        after_path = Path.join(config_dir, "after.exs")
+        after_error = eval_if_exists(after_path)
 
-      # 7. Apply log level from config
-      apply_log_level(options_server)
+        # 7. Apply log level from config
+        apply_log_level(options_server)
 
-      # 8. Register bundled extensions, then start extensions only after all config sources have had a chance
-      # to declare them.
-      register_bundled_extensions()
+        # 8. Register bundled extensions, then start extensions only after all config sources have had a chance
+        # to declare them.
+        register_bundled_extensions()
 
-      start_all_error =
-        if Process.whereis(Minga.Extension.Supervisor) != nil &&
-             Application.get_env(:minga, :load_extensions, true) do
-          start_all_extensions()
-        end
+        start_all_error =
+          if Process.whereis(Minga.Extension.Supervisor) != nil &&
+               Application.get_env(:minga, :load_extensions, true) do
+            start_all_extensions()
+          end
 
-      load_error =
-        merge_error_messages([
-          config_cleanup_error,
-          load_error,
-          project_mcp_error,
-          start_all_error
-        ])
+        load_error =
+          merge_error_messages([
+            config_cleanup_error,
+            load_error,
+            project_mcp_error,
+            start_all_error
+          ])
 
-      lsp_settings = Process.get(:minga_config_lsp_settings, %{})
+        lsp_settings = Process.get(:minga_config_lsp_settings, %{})
 
-      %{
-        config_path: config_path,
-        load_error: load_error,
-        loaded_modules: loaded_modules,
-        modules_errors: modules_errors,
-        project_config_path: project_path,
-        project_config_error: project_config_error,
-        gui_settings_path: gui_settings_path,
-        gui_settings_error: gui_settings_error,
-        after_error: after_error,
-        lsp_settings: lsp_settings,
-        keymap_server: keymap_server,
-        options_server: options_server
-      }
+        %{
+          config_path: config_path,
+          load_error: load_error,
+          loaded_modules: loaded_modules,
+          modules_errors: modules_errors,
+          project_config_path: project_path,
+          project_config_error: project_config_error,
+          gui_settings_path: gui_settings_path,
+          gui_settings_error: gui_settings_error,
+          after_error: after_error,
+          lsp_settings: lsp_settings,
+          keymap_server: keymap_server,
+          options_server: options_server
+        }
+      end
     after
       restore_pdict(:minga_config_keymap, previous_keymap_server)
       restore_pdict(:minga_config_options, previous_options_server)
       restore_pdict(:minga_config_lsp_settings, previous_lsp_settings)
     end
+  end
+
+  @spec safe_mode_state(String.t(), String.t(), keymap_server(), options_server()) :: state()
+  defp safe_mode_state(config_path, config_dir, keymap_server, options_server) do
+    %{
+      config_path: config_path,
+      load_error: nil,
+      loaded_modules: [],
+      modules_errors: [],
+      project_config_path: nil,
+      project_config_error: nil,
+      gui_settings_path: Path.join(config_dir, "gui_settings.exs"),
+      gui_settings_error: nil,
+      after_error: nil,
+      lsp_settings: %{},
+      keymap_server: keymap_server,
+      options_server: options_server
+    }
   end
 
   @spec register_bundled_extensions() :: :ok

--- a/lib/minga/safe_mode.ex
+++ b/lib/minga/safe_mode.ex
@@ -1,0 +1,67 @@
+defmodule Minga.SafeMode do
+  @moduledoc """
+  Tracks whether the current Minga process started in safe mode.
+
+  Safe mode is a startup recovery switch. When active, user config, user modules, project config, after hooks, and extensions are skipped during initial config loading so the editor can boot with defaults.
+
+  Startup can request safe mode through `MINGA_SAFE_MODE=1`, `--safe`/`-Q` in the raw argv, or by setting the application env before startup.
+  """
+
+  @env_key :safe_mode
+
+  @doc "Returns true when this process was started with safe mode enabled."
+  @spec active?() :: boolean()
+  def active? do
+    Application.get_env(:minga, @env_key, false) == true or startup_safe_mode?()
+  end
+
+  @doc "Returns true when startup env or argv requested safe mode."
+  @spec startup_safe_mode?() :: boolean()
+  def startup_safe_mode? do
+    startup_env_safe?() or startup_argv_safe?()
+  end
+
+  @doc "Stores the safe mode startup flag."
+  @spec put(boolean()) :: :ok
+  def put(true) do
+    Application.put_env(:minga, @env_key, true)
+    :ok
+  end
+
+  def put(false) do
+    Application.delete_env(:minga, @env_key)
+    :ok
+  end
+
+  @spec startup_env_safe?() :: boolean()
+  defp startup_env_safe? do
+    case System.get_env("MINGA_SAFE_MODE") do
+      "1" -> true
+      "true" -> true
+      _ -> false
+    end
+  end
+
+  @spec startup_argv_safe?() :: boolean()
+  defp startup_argv_safe? do
+    safe_args?(System.argv()) or burrito_safe_args?()
+  rescue
+    _ -> false
+  end
+
+  @spec burrito_safe_args?() :: boolean()
+  defp burrito_safe_args? do
+    if Burrito.Util.running_standalone?() do
+      safe_args?(Burrito.Util.Args.argv())
+    else
+      false
+    end
+  rescue
+    _ -> false
+  end
+
+  @spec safe_args?([String.t()]) :: boolean()
+  defp safe_args?(args) do
+    Enum.member?(args, "--safe") or Enum.member?(args, "-Q")
+  end
+end

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -568,6 +568,10 @@ defmodule MingaEditor.Commands do
       EditorState.set_status(state, "Parser restart failed: manager not available")
   end
 
+  def execute(state, {:execute_ex_command, {:safe_mode_status, []}}) do
+    EditorState.set_status(state, safe_mode_status_message())
+  end
+
   def execute(state, {:execute_ex_command, {:extensions, []}}) do
     ExtCommands.list(state)
   end
@@ -691,6 +695,15 @@ defmodule MingaEditor.Commands do
   @spec normalize_options_server(term() | nil) :: Minga.Config.Options.server()
   defp normalize_options_server(nil), do: Minga.Config.Options.default_server()
   defp normalize_options_server(server), do: Minga.Config.Options.validate_server!(server)
+
+  @spec safe_mode_status_message() :: String.t()
+  defp safe_mode_status_message do
+    if Minga.SafeMode.active?() do
+      "Safe mode is active: user config was not loaded at startup"
+    else
+      "Safe mode is inactive"
+    end
+  end
 
   @spec reopen_git_branch_picker(state()) :: state()
   defp reopen_git_branch_picker(state) do

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -2755,7 +2755,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     has_lsp = if d.lsp_status && d.lsp_status != :none, do: 1, else: 0
     has_git = if d.git_branch && d.git_branch != "", do: 1, else: 0
     is_dirty = if d.dirty, do: 1, else: 0
-    bor(has_lsp, bor(bsl(has_git, 1), bsl(is_dirty, 2)))
+    safe_mode = if Map.get(d, :safe_mode, false), do: 1, else: 0
+    bor(has_lsp, bor(bsl(has_git, 1), bor(bsl(is_dirty, 2), bsl(safe_mode, 3))))
   end
 
   @spec encode_agent_session_status(atom() | nil) :: non_neg_integer()

--- a/lib/minga_editor/shell/traditional/modeline.ex
+++ b/lib/minga_editor/shell/traditional/modeline.ex
@@ -33,6 +33,7 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
   @type modeline_data :: %{
           :mode => Mode.mode(),
           :mode_state => Mode.state() | nil,
+          optional(:safe_mode) => boolean(),
           :file_name => String.t(),
           :workspace_label => String.t(),
           :workspace_draft_count => non_neg_integer(),
@@ -712,8 +713,13 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
   @spec render_mode(context()) :: [render_segment()]
   defp render_mode(ctx) do
     badge = ctx.data[:mode_override] || mode_badge(ctx.data.mode, ctx.data.mode_state)
+    badge = safe_mode_badge(badge, Map.get(ctx.data, :safe_mode, false))
     [{" #{badge} ", ctx.mode_fg, ctx.mode_bg, [bold: true], nil}]
   end
+
+  @spec safe_mode_badge(String.t(), boolean()) :: String.t()
+  defp safe_mode_badge(badge, true), do: "[SAFE] #{badge}"
+  defp safe_mode_badge(badge, false), do: badge
 
   @spec render_workspace(context()) :: [render_segment()]
   defp render_workspace(ctx) do

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -67,6 +67,8 @@ defmodule MingaEditor.Startup do
 
     messages_buf = Minga.Log.messages_buffer()
 
+    log_safe_mode_startup()
+
     # Always ensure an active buffer exists. The editor's render pipeline,
     # command dispatch, and input routing all assume buffers.active is a
     # pid. The dashboard feature (which set active to nil) is disabled
@@ -189,6 +191,15 @@ defmodule MingaEditor.Startup do
     current_tb = EditorState.tab_bar(state)
     tb = TabBar.update_context(current_tb, current_tb.active_id, context)
     EditorState.set_tab_bar(state, tb)
+  end
+
+  @spec log_safe_mode_startup() :: :ok
+  defp log_safe_mode_startup do
+    if Minga.SafeMode.active?() do
+      Log.info(:editor, "Started in safe mode: user config not loaded")
+    end
+
+    :ok
   end
 
   @doc """

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -50,6 +50,7 @@ defmodule MingaEditor.StatusBar.Data do
           optional(:modeline_segments) => Modeline.gui_segments(),
           mode: Minga.Mode.mode(),
           mode_state: Minga.Mode.state() | nil,
+          safe_mode: boolean(),
           cursor_line: non_neg_integer(),
           cursor_col: non_neg_integer(),
           line_count: non_neg_integer(),
@@ -86,6 +87,7 @@ defmodule MingaEditor.StatusBar.Data do
           optional(:modeline_segments) => Modeline.gui_segments(),
           mode: Minga.Mode.mode(),
           mode_state: Minga.Mode.state() | nil,
+          safe_mode: boolean(),
           model_name: String.t(),
           session_status: AgentState.status(),
           message_count: non_neg_integer(),
@@ -185,6 +187,7 @@ defmodule MingaEditor.StatusBar.Data do
     %{
       mode: mode,
       mode_state: mode_state,
+      safe_mode: Minga.SafeMode.active?(),
       cursor_line: line,
       cursor_col: col,
       line_count: line_count,
@@ -341,6 +344,7 @@ defmodule MingaEditor.StatusBar.Data do
     %{
       mode: mode,
       mode_state: mode_state,
+      safe_mode: Minga.SafeMode.active?(),
       model_name: model_name,
       session_status: agent.runtime.status,
       message_count: message_count,
@@ -508,6 +512,7 @@ defmodule MingaEditor.StatusBar.Data do
     %{
       mode: d.mode,
       mode_state: d.mode_state,
+      safe_mode: Map.get(d, :safe_mode, false),
       file_name: d.file_name,
       filetype: d.filetype,
       dirty_marker: if(d.dirty, do: " ● ", else: ""),

--- a/lib/mix/tasks/minga.ex
+++ b/lib/mix/tasks/minga.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Minga do
 
       +gui        Launch the native macOS GUI instead of the TUI
       --headless  Launch services, agent runtime, and Gateway without an editor frontend
+      --safe/-Q   Start in safe mode before config loading
 
   The `+gui` flag uses a `+` prefix to avoid conflicts with Mix's built-in option parser.
   """
@@ -26,6 +27,9 @@ defmodule Mix.Tasks.Minga do
     {gui?, remaining_args} = extract_gui_flag(args)
     headless? = Minga.CLI.headless_args?(remaining_args)
     minimal? = Minga.CLI.minimal_args?(remaining_args)
+    safe? = Minga.CLI.safe_args?(remaining_args)
+
+    Minga.SafeMode.put(safe?)
 
     if minimal? do
       Application.put_env(:minga, :minimal_mode, true)

--- a/macos/Resources/bin/minga
+++ b/macos/Resources/bin/minga
@@ -64,6 +64,7 @@ Options:
   -v, --version          Show version
   --editor               Start in editor mode (skip agentic view)
   --no-context           Don't load the file as agent context
+  --safe, -Q             Start in safe mode before config loading
   --config <path>        Use a custom config file
 
 Examples:
@@ -137,7 +138,7 @@ for arg in "$@"; do
       flags+=("$arg")
       skip_next=true
       ;;
-    --editor|--no-context)
+    --editor|--no-context|--safe|-Q)
       flags+=("$arg")
       ;;
     -*)

--- a/macos/Sources/BEAMProcessManager.swift
+++ b/macos/Sources/BEAMProcessManager.swift
@@ -73,6 +73,28 @@ final class BEAMProcessManager {
         beamExecutableURL() != nil
     }
 
+    /// Builds the BEAM argv from the macOS app argv, forwarding only supported Minga flags.
+    static func forwardedLaunchArguments(from appArguments: [String]) -> [String] {
+        var beamArgs = ["start"]
+        let mingaFlags: Set<String> = ["--editor", "--no-context", "--config", "--safe", "-Q"]
+        var skipNext = false
+
+        for arg in appArguments.dropFirst() {
+            if skipNext {
+                beamArgs.append(arg)
+                skipNext = false
+                continue
+            }
+
+            if mingaFlags.contains(arg) {
+                beamArgs.append(arg)
+                if arg == "--config" { skipNext = true }
+            }
+        }
+
+        return beamArgs
+    }
+
     /// Spawns the BEAM release as a child process with piped stdin/stdout.
     func start() {
         guard let execURL = Self.beamExecutableURL() else {
@@ -83,26 +105,8 @@ final class BEAMProcessManager {
         let proc = Process()
         proc.executableURL = execURL
 
-        // Forward CLI flags (--editor, --no-context, --config) to the BEAM.
-        // The CLI launcher script passes these via `open --args`, which puts
-        // them in ProcessInfo.processInfo.arguments. We forward all arguments
-        // that look like Minga CLI flags to the BEAM release's `start` command.
-        var beamArgs = ["start"]
-        let appArgs = ProcessInfo.processInfo.arguments.dropFirst() // skip argv[0]
-        let mingaFlags: Set<String> = ["--editor", "--no-context", "--config"]
-        var skipNext = false
-        for arg in appArgs {
-            if skipNext {
-                beamArgs.append(arg)
-                skipNext = false
-                continue
-            }
-            if mingaFlags.contains(arg) {
-                beamArgs.append(arg)
-                if arg == "--config" { skipNext = true }
-            }
-        }
-        proc.arguments = beamArgs
+        let launchArguments = Self.forwardedLaunchArguments(from: ProcessInfo.processInfo.arguments)
+        proc.arguments = launchArguments
 
         // Set up pipes for the port protocol.
         let stdinPipe = Pipe()
@@ -118,6 +122,10 @@ final class BEAMProcessManager {
         // Tell the BEAM to use connected mode (don't spawn a GUI).
         var env = ProcessInfo.processInfo.environment
         env["MINGA_PORT_MODE"] = "connected"
+
+        if launchArguments.contains("--safe") || launchArguments.contains("-Q") {
+            env["MINGA_SAFE_MODE"] = "1"
+        }
 
         // Set RELEASE_NODE to prevent the BEAM from trying to connect
         // to other BEAM nodes (which would fail in a sandboxed app).

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -40,6 +40,7 @@ struct StatusBarUpdate: Sendable {
     let cursorCol: UInt32
     let lineCount: UInt32
     let flags: UInt8
+    let safeMode: Bool
     let lspStatus: UInt8
     let gitBranch: String
     let message: String
@@ -80,6 +81,7 @@ struct StatusBarUpdate: Sendable {
         cursorCol: UInt32,
         lineCount: UInt32,
         flags: UInt8,
+        safeMode: Bool = false,
         lspStatus: UInt8,
         gitBranch: String,
         message: String,
@@ -119,6 +121,7 @@ struct StatusBarUpdate: Sendable {
         self.cursorCol = cursorCol
         self.lineCount = lineCount
         self.flags = flags
+        self.safeMode = safeMode
         self.lspStatus = lspStatus
         self.gitBranch = gitBranch
         self.message = message
@@ -1043,7 +1046,8 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         let update = StatusBarUpdate(
             contentKind: contentKind, mode: mode,
             cursorLine: cursorLine, cursorCol: cursorCol, lineCount: lineCount,
-            flags: flags, lspStatus: lspStatus, gitBranch: gitBranch,
+            flags: flags, safeMode: (flags & 0x08) != 0,
+            lspStatus: lspStatus, gitBranch: gitBranch,
             message: message, filetype: filetype,
             errorCount: errorCount, warningCount: warningCount,
             modelName: modelName, messageCount: messageCount, sessionStatus: sessionStatus,

--- a/macos/Sources/Views/StatusBarView.swift
+++ b/macos/Sources/Views/StatusBarView.swift
@@ -36,6 +36,7 @@ final class StatusBarState {
     var cursorCol: UInt32 = 1
     var lineCount: UInt32 = 1
     var flags: UInt8 = 0
+    var safeMode: Bool = false
     var lspStatus: UInt8 = 0
     var gitBranch: String = ""
     var message: String = ""
@@ -82,6 +83,7 @@ final class StatusBarState {
         if self.cursorCol != data.cursorCol { self.cursorCol = data.cursorCol }
         if self.lineCount != data.lineCount { self.lineCount = data.lineCount }
         if self.flags != data.flags { self.flags = data.flags }
+        if self.safeMode != data.safeMode { self.safeMode = data.safeMode }
         if self.lspStatus != data.lspStatus { self.lspStatus = data.lspStatus }
         if self.gitBranch != data.gitBranch { self.gitBranch = data.gitBranch }
         if self.message != data.message { self.message = data.message }
@@ -137,6 +139,7 @@ final class StatusBarState {
     var isRecordingMacro: Bool { macroRecording > 0 }
     var hasGitDiffStats: Bool { gitAdded > 0 || gitModified > 0 || gitDeleted > 0 }
     var hasRunningBackgroundSubagents: Bool { backgroundSubagentCount > 0 }
+    var isSafeMode: Bool { safeMode }
 
     /// The macro register character (a-z), or nil if not recording.
     var macroRegister: Character? {
@@ -233,11 +236,17 @@ struct StatusBarView: View {
     }
 
     private var rightModelineGroups: [StatusBarSegmentGroup] {
-        statusBarGroups(
+        var groups = statusBarGroups(
             from: state.modelineRightSegments,
             fallbackKinds: ["parser", "lsp", "indent", "filetype", "position", "mode"],
             side: "right"
         )
+
+        if state.isSafeMode && !groups.contains(where: { $0.kind == "mode" }) {
+            groups.insert(StatusBarSegmentGroup(id: "right-safe-mode", kind: "safe", segments: []), at: 0)
+        }
+
+        return groups
     }
 
     private func statusBarGroups(from segments: [Wire.StatusBarSegment], fallbackKinds: [String], side: String) -> [StatusBarSegmentGroup] {
@@ -343,6 +352,8 @@ struct StatusBarView: View {
         switch group.kind {
         case "mode":
             modeBadge
+        case "safe":
+            safeModeBadge
         case "filename":
             filenameSegment(group: group, command: command(in: group))
         case "git":
@@ -747,18 +758,39 @@ struct StatusBarView: View {
     }
 
     @ViewBuilder
-    private var modeBadge: some View {
-        let (bg, fg) = modeColors(state.mode)
-        Text(state.modeName)
+    private var safeModeBadge: some View {
+        Text("[SAFE]")
             .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(fg)
-            .padding(.horizontal, 8)
+            .foregroundStyle(theme.modelineInfoFg)
+            .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(bg)
+                    .fill(theme.modelineInfoBg)
             )
-            .help("\(state.modeName) mode")
+            .help("Safe mode enabled")
+            .accessibilityLabel("Safe mode enabled")
+    }
+
+    @ViewBuilder
+    private var modeBadge: some View {
+        let (bg, fg) = modeColors(state.mode)
+        HStack(spacing: 4) {
+            if state.isSafeMode {
+                safeModeBadge
+            }
+
+            Text(state.modeName)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(fg)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(bg)
+                )
+        }
+        .help(state.isSafeMode ? "Safe mode enabled, \(state.modeName) mode" : "\(state.modeName) mode")
     }
 
     private func modeColors(_ mode: UInt8) -> (Color, Color) {

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -107,6 +107,7 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
         result["cursor_col"] = Int(update.cursorCol)
         result["line_count"] = Int(update.lineCount)
         result["flags"] = Int(update.flags)
+        result["safe_mode"] = update.safeMode
         result["lsp_status"] = Int(update.lspStatus)
         result["git_branch"] = update.gitBranch
         result["message"] = update.message

--- a/macos/Tests/MingaTests/BEAMProcessManagerTests.swift
+++ b/macos/Tests/MingaTests/BEAMProcessManagerTests.swift
@@ -1,0 +1,31 @@
+import Testing
+
+@Suite("BEAMProcessManager Launch Arguments")
+struct BEAMProcessManagerLaunchArgumentsTests {
+    @Test("forwards safe mode and config flags to the BEAM child")
+    @MainActor func forwardsSafeModeFlags() {
+        let forwarded = BEAMProcessManager.forwardedLaunchArguments(
+            from: [
+                "/Applications/Minga.app/Contents/MacOS/Minga",
+                "--safe",
+                "-Q",
+                "--config",
+                "/tmp/minga.safe.exs",
+                "--editor",
+                "--no-context",
+                "--ignored",
+                "README.md"
+            ]
+        )
+
+        #expect(forwarded == [
+            "start",
+            "--safe",
+            "-Q",
+            "--config",
+            "/tmp/minga.safe.exs",
+            "--editor",
+            "--no-context"
+        ])
+    }
+}

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -381,11 +381,11 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.whichKeyState.visible == false)
     }
 
-    @Test("guiStatusBar updates statusBarState")
+    @Test("guiStatusBar updates statusBarState and clears safeMode")
     @MainActor func guiStatusBarRouting() {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.dispatch(.guiStatusBar(StatusBarUpdate(contentKind: 0, mode: 1, cursorLine: 42,
-                                           cursorCol: 9, lineCount: 500, flags: 0x03,
+                                           cursorCol: 9, lineCount: 500, flags: 0x0B, safeMode: true,
                                            lspStatus: 1, gitBranch: "main",
                                            message: "-- INSERT --", filetype: "elixir",
                                            errorCount: 3, warningCount: 7,
@@ -404,6 +404,7 @@ struct CommandDispatcherRoutingTests {
 
         #expect(gui.statusBarState.mode == 1)
         #expect(gui.statusBarState.cursorLine == 42)
+        #expect(gui.statusBarState.safeMode == true)
         #expect(gui.statusBarState.gitBranch == "main")
         #expect(gui.statusBarState.filetype == "elixir")
         #expect(gui.statusBarState.errorCount == 3)
@@ -414,6 +415,26 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.statusBarState.selection.mode == 2)
         #expect(gui.statusBarState.selection.size == 3)
         #expect(gui.statusBarState.activeToolName.isEmpty)
+
+        dispatcher.dispatch(.guiStatusBar(StatusBarUpdate(contentKind: 0, mode: 1, cursorLine: 42,
+                                           cursorCol: 9, lineCount: 500, flags: 0x03, safeMode: false,
+                                           lspStatus: 1, gitBranch: "main",
+                                           message: "-- INSERT --", filetype: "elixir",
+                                           errorCount: 3, warningCount: 7,
+                                           modelName: "", messageCount: 0, sessionStatus: 0,
+                                           infoCount: 1, hintCount: 2,
+                                           macroRecording: 0, parserStatus: 0, agentStatus: 0,
+                                           activeToolName: "",
+                                           gitAdded: 5, gitModified: 3, gitDeleted: 1,
+                                           icon: "", iconColorR: 0, iconColorG: 0, iconColorB: 0,
+                                           filename: "editor.ex", diagnosticHint: "",
+                                           backgroundSubagentCount: 0, backgroundSubagentLabel: "",
+                                           indent: .init(kind: 1, size: 4),
+                                           modelineLeftSegments: [Wire.StatusBarSegment(id: 0, text: " NORMAL ", fgColor: 0xFFFFFF, bgColor: 0x000000, attrs: 1, command: "")],
+                                           modelineRightSegments: [],
+                                           selection: .init(mode: 2, size: 3))))
+
+        #expect(gui.statusBarState.safeMode == false)
     }
 
     @Test("guiStatusBar agent variant populates background buffer fields")

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -400,7 +400,7 @@ struct GUIStatusBarDecoderTests {
         var identity = Data()
         identity.append(0) // contentKind = buffer
         identity.append(1) // mode = insert
-        identity.append(0x03) // flags
+        identity.append(0x0B) // flags: has_lsp + has_git + is_dirty + safe_mode
 
         var cursor = Data()
         appendU32(&cursor, 42) // cursorLine
@@ -481,7 +481,8 @@ struct GUIStatusBarDecoderTests {
         #expect(update.cursorLine == 42)
         #expect(update.cursorCol == 9)
         #expect(update.lineCount == 500)
-        #expect(update.flags == 0x03)
+        #expect(update.flags == 0x0B)
+        #expect(update.safeMode == true)
         #expect(update.lspStatus == 1)
         #expect(update.gitBranch == "main")
         #expect(update.message == "-- INSERT --")

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -169,12 +169,13 @@ struct StatusBarViewViewTests {
         leftSegments: [Wire.StatusBarSegment] = [],
         rightSegments: [Wire.StatusBarSegment] = [],
         agentStatus: UInt8 = 0,
-        activeToolName: String = ""
+        activeToolName: String = "",
+        safeMode: Bool = false
     ) -> StatusBarState {
         let state = StatusBarState()
         state.update(from: StatusBarUpdate(
             contentKind: 0, mode: 0, cursorLine: 42, cursorCol: 9,
-            lineCount: 500, flags: 0, lspStatus: 0, gitBranch: "",
+            lineCount: 500, flags: safeMode ? 0x08 : 0, safeMode: safeMode, lspStatus: 0, gitBranch: "",
             message: message, filetype: "elixir", errorCount: 0, warningCount: 0,
             modelName: "", messageCount: 0, sessionStatus: 0,
             infoCount: 0, hintCount: 0, macroRecording: 0, parserStatus: 0, agentStatus: agentStatus,
@@ -225,6 +226,25 @@ struct StatusBarViewViewTests {
         #expect(strings.contains("Elixir"))
         #expect(strings.contains("Ln 42, Col 9"))
         #expect(strings.contains("Spaces:2"))
+    }
+
+    @Test("Safe mode badge remains visible without the mode group")
+    @MainActor func safeModeBadgeRemainsVisibleWithoutModeGroup() throws {
+        let state = statusBarState(
+            rightSegments: [
+                segment(1, " Elixir ", kind: "filetype"),
+                segment(2, " Ln 42, Col 9 ", kind: "position")
+            ],
+            safeMode: true
+        )
+        let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: nil)
+        let body = try sut.inspect()
+        let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("[SAFE]"))
+        #expect(!strings.contains("NORMAL"))
+        #expect(strings.contains("Elixir"))
+        #expect(strings.contains("Ln 42, Col 9"))
     }
 
     @Test("Filename group uses BEAM modeline text for native rendering")

--- a/mix.exs
+++ b/mix.exs
@@ -294,6 +294,7 @@ defmodule Minga.MixProject do
             other -> {false, other}
           end
           if gui, do: Application.put_env(:minga, :backend, :gui)
+          Minga.SafeMode.put(Minga.CLI.safe_args?(argv))
           Application.put_env(:minga, :start_editor, true)
           Application.ensure_all_started(:minga)
           Minga.CLI.main(argv)

--- a/test/minga/cli_test.exs
+++ b/test/minga/cli_test.exs
@@ -128,6 +128,26 @@ defmodule Minga.CLITest do
       assert message =~ "--config"
     end
 
+    test "--safe enables safe mode" do
+      assert {:open, nil, %{safe_mode: true}} = CLI.parse_args(["--safe"])
+    end
+
+    test "-Q enables safe mode" do
+      assert {:open, nil, %{safe_mode: true}} = CLI.parse_args(["-Q"])
+    end
+
+    test "--safe flag appears in help output" do
+      assert {:error, message} = CLI.parse_args(["--help"])
+      assert message =~ "--safe"
+      assert message =~ "-Q"
+    end
+
+    test "safe_args?/1 detects long and short safe mode flags" do
+      assert CLI.safe_args?(["--safe"])
+      assert CLI.safe_args?(["-Q"])
+      refute CLI.safe_args?(["README.md"])
+    end
+
     test "--debug-log sets expanded debug log path" do
       assert {:open, nil, %{debug_log: path}} =
                CLI.parse_args(["--debug-log", "~/minga-debug.log"])

--- a/test/minga/command/parser_test.exs
+++ b/test/minga/command/parser_test.exs
@@ -106,6 +106,8 @@ defmodule Minga.Command.ParserTest do
         {"agent-new", {:agent_new_session, []}},
         {"parser-restart", {:parser_restart, []}},
         {"ParserRestart", {:parser_restart, []}},
+        {"safe-mode?", {:safe_mode_status, []}},
+        {"safe-mode", {:safe_mode_status, []}},
         {"terminal", {:terminal, []}},
         {"reload-highlights", {:reload_highlights, []}},
         {"rh", {:reload_highlights, []}}

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -1682,6 +1682,104 @@ defmodule Minga.Config.LoaderTest do
     end
   end
 
+  describe "safe mode" do
+    test "skips user modules and all config eval stages" do
+      {minga_dir, cleanup} =
+        make_config_dir("""
+        use Minga.Config
+        set :tab_width, 42
+        """)
+
+      modules_dir = Path.join(minga_dir, "modules")
+      File.mkdir_p!(modules_dir)
+
+      File.write!(
+        Path.join(modules_dir, "broken_module.ex"),
+        "raise \"module should not compile\""
+      )
+
+      File.write!(
+        Path.join(minga_dir, "gui_settings.exs"),
+        "use Minga.Config\nset :tab_width, 43\n"
+      )
+
+      File.write!(Path.join(minga_dir, "after.exs"), "use Minga.Config\nset :tab_width, 44\n")
+
+      project_dir =
+        Path.join(System.tmp_dir!(), "minga_safe_project_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(project_dir)
+      File.write!(Path.join(project_dir, ".minga.exs"), "use Minga.Config\nset :tab_width, 45\n")
+
+      previous_cwd = File.cwd!()
+      File.cd!(project_dir)
+      Minga.SafeMode.put(true)
+
+      on_exit(fn ->
+        Minga.SafeMode.put(false)
+        File.cd!(previous_cwd)
+        cleanup.()
+        File.rm_rf!(project_dir)
+      end)
+
+      name = :"loader_safe_#{System.unique_integer([:positive])}"
+      {:ok, pid} = Loader.start_link(name: name)
+
+      assert Options.get(test_options_server(), :tab_width) == 2
+      assert Loader.loaded_modules(pid) == []
+      assert Loader.modules_errors(pid) == []
+      assert Loader.load_error(pid) == nil
+      assert Loader.project_config_error(pid) == nil
+      assert Loader.gui_settings_error(pid) == nil
+      assert Loader.after_error(pid) == nil
+    end
+
+    test "skips bundled extension registration and startup" do
+      {_minga_dir, cleanup} = make_config_dir("use Minga.Config\n")
+      previous_load_extensions = Application.get_env(:minga, :load_extensions)
+      previous_load_board = Application.get_env(:minga, :load_board_extension)
+
+      Application.put_env(:minga, :load_extensions, true)
+      Application.put_env(:minga, :load_board_extension, true)
+      Minga.SafeMode.put(true)
+      ensure_extension_runtime()
+
+      on_exit(fn ->
+        Minga.SafeMode.put(false)
+        restore_application_env(:load_extensions, previous_load_extensions)
+        restore_application_env(:load_board_extension, previous_load_board)
+        cleanup.()
+      end)
+
+      name = :"loader_safe_extensions_#{System.unique_integer([:positive])}"
+      {:ok, _pid} = Loader.start_link(name: name)
+
+      assert ExtRegistry.all() == []
+    end
+
+    test "reload loads user config even when startup safe mode remains active" do
+      {_minga_dir, cleanup} =
+        make_config_dir("""
+        use Minga.Config
+        set :tab_width, 46
+        """)
+
+      Minga.SafeMode.put(true)
+
+      on_exit(fn ->
+        Minga.SafeMode.put(false)
+        cleanup.()
+      end)
+
+      name = :"loader_safe_reload_#{System.unique_integer([:positive])}"
+      {:ok, pid} = Loader.start_link(name: name)
+      assert Options.get(test_options_server(), :tab_width) == 2
+
+      assert :ok = Loader.reload(pid)
+      assert Options.get(test_options_server(), :tab_width) == 46
+    end
+  end
+
   # ── Helpers ─────────────────────────────────────────────────────────────────
 
   defp assert_error_fragments(error, {:any, fragments}) do

--- a/test/minga/safe_mode_test.exs
+++ b/test/minga/safe_mode_test.exs
@@ -1,0 +1,39 @@
+defmodule Minga.SafeModeTest do
+  @moduledoc false
+
+  # Mutates process-wide env vars and application env used during startup detection.
+  use ExUnit.Case, async: false
+
+  test "active? sees MINGA_SAFE_MODE before loader startup" do
+    previous_env = System.get_env("MINGA_SAFE_MODE")
+    previous_app_env = Application.get_env(:minga, :safe_mode)
+
+    on_exit(fn ->
+      restore_env("MINGA_SAFE_MODE", previous_env)
+      restore_app_env(previous_app_env)
+    end)
+
+    System.put_env("MINGA_SAFE_MODE", "1")
+    Minga.SafeMode.put(false)
+
+    assert Minga.SafeMode.startup_safe_mode?()
+    assert Minga.SafeMode.active?()
+  end
+
+  @spec restore_env(String.t(), String.t() | nil) :: :ok
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
+
+  @spec restore_app_env(boolean() | nil) :: :ok
+  defp restore_app_env(nil) do
+    Minga.SafeMode.put(false)
+  end
+
+  defp restore_app_env(true) do
+    Minga.SafeMode.put(true)
+  end
+
+  defp restore_app_env(false) do
+    Minga.SafeMode.put(false)
+  end
+end

--- a/test/minga_editor/commands/ex_dispatch_test.exs
+++ b/test/minga_editor/commands/ex_dispatch_test.exs
@@ -29,6 +29,24 @@ defmodule MingaEditor.Commands.ExDispatchTest do
     assert MingaEditor.State.AgentAccess.panel(new_state).model_name == "gpt-4o"
   end
 
+  test "safe mode ex command reports active state" do
+    Minga.SafeMode.put(true)
+    on_exit(fn -> Minga.SafeMode.put(false) end)
+
+    new_state = Commands.execute(state(), {:execute_ex_command, {:safe_mode_status, []}})
+
+    assert EditorState.status_msg(new_state) =~ "Safe mode is active"
+  end
+
+  test "safe mode ex command reports inactive state" do
+    Minga.SafeMode.put(false)
+    on_exit(fn -> Minga.SafeMode.put(false) end)
+
+    new_state = Commands.execute(state(), {:execute_ex_command, {:safe_mode_status, []}})
+
+    assert EditorState.status_msg(new_state) == "Safe mode is inactive"
+  end
+
   defp state do
     %EditorState{
       port_manager: nil,

--- a/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
+++ b/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
@@ -674,6 +674,16 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
       assert tool == "read_file"
     end
 
+    test "encodes safe mode in the identity section flags" do
+      data = Map.put(status_data(), :safe_mode, true)
+      binary = ProtocolGUI.encode_gui_status_bar({:buffer, data})
+      sections = status_sections(binary)
+
+      <<_content_kind::8, _mode::8, flags::8>> = Map.fetch!(sections, 0x01)
+
+      assert Bitwise.band(flags, 0x08) == 0x08
+    end
+
     test "encodes an empty active tool name when the field is nil" do
       data = Map.put(status_data(), :active_tool_name, nil)
       binary = ProtocolGUI.encode_gui_status_bar({:buffer, data})

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -104,6 +104,7 @@ defmodule Minga.Integration.GUIProtocolTest do
          %{
            mode: :normal,
            mode_state: nil,
+           safe_mode: true,
            cursor_line: 41,
            cursor_col: 9,
            line_count: 200,
@@ -141,6 +142,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       # content_kind 0 = buffer
       assert decoded["content_kind"] == 0
       assert decoded["mode"] == 0
+      assert decoded["safe_mode"] == true
       # 1-indexed in the wire format (cursor_line is 0-indexed internally, +1 encoded)
       assert decoded["cursor_line"] == 42
       assert decoded["cursor_col"] == 10
@@ -179,6 +181,7 @@ defmodule Minga.Integration.GUIProtocolTest do
          %{
            mode: :normal,
            mode_state: nil,
+           safe_mode: true,
            model_name: "claude-3-5-sonnet",
            session_status: :thinking,
            message_count: 7,
@@ -216,6 +219,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       # content_kind 1 = agent
       assert decoded["content_kind"] == 1
       assert decoded["mode"] == 0
+      assert decoded["safe_mode"] == true
       assert decoded["model_name"] == "claude-3-5-sonnet"
       assert decoded["message_count"] == 7
       # Background buffer fields are now populated

--- a/test/minga_editor/shell/traditional/modeline_test.exs
+++ b/test/minga_editor/shell/traditional/modeline_test.exs
@@ -51,6 +51,14 @@ defmodule MingaEditor.Shell.Traditional.ModelineTest do
              "Should not show OPERATOR badge in operator_pending mode"
     end
 
+    test "safe mode prepends a visible mode badge" do
+      data = Map.put(@base_data, :safe_mode, true)
+      {commands, _regions} = Modeline.render(0, 80, data)
+      text = Enum.map_join(commands, fn {_row, _col, segment, _opts} -> segment end)
+
+      assert String.contains?(text, "[SAFE] NORMAL")
+    end
+
     test "renders common file state variants" do
       for data <- [
             Map.put(@base_data, :dirty_marker, " ● "),

--- a/test/minga_editor/status_bar/data_safe_mode_test.exs
+++ b/test/minga_editor/status_bar/data_safe_mode_test.exs
@@ -1,0 +1,32 @@
+defmodule MingaEditor.StatusBar.DataSafeModeTest do
+  @moduledoc false
+
+  # Mutates global application env via Minga.SafeMode.
+  use ExUnit.Case, async: false
+
+  alias Minga.Config.Options
+  alias MingaEditor.StatusBar.Data
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Viewport
+
+  test "from_state to_modeline_data carries safe_mode true" do
+    Minga.SafeMode.put(true)
+    on_exit(fn -> Minga.SafeMode.put(false) end)
+
+    options = start_supervised!({Options, name: nil})
+
+    state = %EditorState{
+      port_manager: self(),
+      options_server: options,
+      workspace: %SessionState{viewport: Viewport.new(24, 80)},
+      shell_state: %MingaEditor.Shell.Traditional.State{}
+    }
+
+    {:buffer, buffer_data} = Data.from_state(state)
+    modeline_data = Data.to_modeline_data({:buffer, buffer_data})
+
+    assert buffer_data.safe_mode == true
+    assert modeline_data.safe_mode == true
+  end
+end


### PR DESCRIPTION
# TL;DR
Minga can now start in safe mode with `--safe` or `-Q`, skipping user config and extensions so a broken config no longer blocks editor startup. Safe mode is propagated before config loading in Mix, Burrito, and macOS GUI startup paths, and both TUI and native GUI status bars show a `[SAFE]` indicator.

Closes #143

## Context
Issue #143 adds a recovery path for broken user config, modules, project config, hooks, or extensions. Safe mode needs to be available before the config loader starts, so this PR stores the flag in every startup path before application services initialize.

## Changes
- Added `Minga.SafeMode` as the startup-safe-mode source of truth, including app env, `MINGA_SAFE_MODE`, raw argv, and Burrito argv detection.
- Added `--safe` and `-Q` parsing, help text, and early propagation through the active `mix minga` alias, `Mix.Tasks.Minga`, Burrito startup, dev macOS launcher, and packaged macOS GUI launcher.
- Short-circuited `Minga.Config.Loader` in safe mode before user modules, user themes, global config, project config, GUI settings, after hooks, bundled extensions, and declared extensions can run.
- Kept `Loader.reload/1` loading config normally, so users can fix config in safe mode and reload without restarting.
- Added a `[SAFE]` modeline badge for TUI and a native GUI safe-mode status flag/badge for Swift.
- Added `:safe-mode?` ex-command reporting.
- Updated GUI protocol docs for the safe-mode status flag.
- Added tests for CLI parsing, loader skip behavior, reload behavior, startup-safe-mode detection, ex-command parsing/dispatch, TUI modeline badge, GUI status protocol encoding, Swift decode/dispatch/render behavior, and macOS BEAM argument forwarding.

## Verification
- `bash -n bin/minga bin/minga-mac macos/Resources/bin/minga`
- `mix test.llm test/minga/safe_mode_test.exs test/minga/config/loader_test.exs test/minga_editor/status_bar/data_safe_mode_test.exs test/minga_editor/commands/ex_dispatch_test.exs test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs test/minga_editor/shell/traditional/modeline_test.exs`
- `make lint`
- `mix test.llm`
- `mix swift.build`, skipped because `xcodebuild` is not installed in this environment
- `git diff --check`

## Review Loop
- Round 1 found macOS GUI propagation and GUI status-surface gaps. Fixed.
- Round 2 found macOS plain OTP release propagation and native GUI badge visibility gaps. Fixed.
- Round 3 found no #143 blockers. Remaining feedback is optional or out of scope.

## Deferred
- `--config` handling in the embedded macOS release path is related to config override work and belongs with #144, not this safe-mode recovery PR.
- Additional shell-launcher and Swift toolchain validation should run in CI or a macOS environment with Xcode tools installed.

## Acceptance Criteria Addressed
- `--safe` and `-Q` start Minga with no user configuration loaded. ✅
- Safe mode skips user modules, global config, project-local config, after hook, and declared extensions. ✅
- Editor starts with default options, default keybindings, and no custom commands or advice. ✅
- Visible safe mode indicator is shown in TUI and native GUI status bars. ✅
- `:safe-mode?` reports whether safe mode is active. ✅
- `--help` documents `--safe` and `-Q`. ✅
