### PR TITLE
feat(agent): add apply_diff tool

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -38,7 +38,7 @@ That's it. Save the file and restart Minga. Your options take effect immediately
 | `:recent_files_limit` | positive integer | `200` | Max recent files tracked per project |
 | `:persist_recent_files` | boolean | `true` | Write recent file history to disk (see [Projects](PROJECTS.md)) |
 | `:agent_tool_approval` | `:destructive`, `:all`, `:none` | `:destructive` | When to prompt before executing agent tools |
-| `:agent_destructive_tools` | list of strings | `["write_file", "edit_file", "multi_edit_file", "shell", "git_stage", "git_commit", "rename"]` | Which tools are classified as destructive |
+| `:agent_destructive_tools` | list of strings | `["write_file", "edit_file", "multi_edit_file", "apply_diff", "delete_file", "shell", "git_stage", "git_commit", "rename"]` | Which tools are classified as destructive |
 | `:agent_session_retention_days` | positive integer | `30` | Days to keep saved agent sessions before auto-pruning |
 | `:startup_view` | `:agent` or `:editor` | `:agent` | Which view to show on startup (see [Startup view](#startup-view) below) |
 | `:agent_auto_context` | boolean | `true` | Load CLI file as agent preview context on startup |
@@ -223,13 +223,13 @@ The `:agent_destructive_tools` option controls which tools are classified as des
 
 ```elixir
 # Default
-set :agent_destructive_tools, ["write_file", "edit_file", "multi_edit_file", "shell", "git_stage", "git_commit", "rename"]
+set :agent_destructive_tools, ["write_file", "edit_file", "multi_edit_file", "apply_diff", "delete_file", "shell", "git_stage", "git_commit", "rename"]
 
 # Trust file edits, only prompt for shell commands
 set :agent_destructive_tools, ["shell"]
 
 # Add a custom tool to the list
-set :agent_destructive_tools, ["write_file", "edit_file", "multi_edit_file", "shell", "git_stage", "git_commit", "rename", "deploy"]
+set :agent_destructive_tools, ["write_file", "edit_file", "multi_edit_file", "apply_diff", "delete_file", "shell", "git_stage", "git_commit", "rename", "deploy"]
 
 # Empty list with :destructive mode = no prompts for built-in tools
 set :agent_destructive_tools, []
@@ -1271,7 +1271,7 @@ set :font_ligatures, true
 set :startup_view, :agent           # boot into agentic view (default)
 set :agent_auto_context, true       # load CLI file as preview context (default)
 set :agent_tool_approval, :destructive
-set :agent_destructive_tools, ["write_file", "edit_file", "multi_edit_file", "shell", "git_stage", "git_commit", "rename"]
+set :agent_destructive_tools, ["write_file", "edit_file", "multi_edit_file", "apply_diff", "delete_file", "shell", "git_stage", "git_commit", "rename"]
 
 # ── Per-language ─────────────────────────────────────────────────────
 for_filetype :elixir, format_on_save: true, trim_trailing_whitespace: true, insert_final_newline: true

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -276,6 +276,7 @@ defmodule Minga.Config.Options do
        "write_file",
        "edit_file",
        "multi_edit_file",
+       "apply_diff",
        "delete_file",
        "shell",
        "git_stage",

--- a/lib/minga_agent/config.ex
+++ b/lib/minga_agent/config.ex
@@ -39,7 +39,8 @@ defmodule MingaAgent.Config do
 
     # Tool approval and hooks
     tool_approval: :destructive,
-    destructive_tools: ~w(write_file edit_file multi_edit_file shell git_stage git_commit rename),
+    destructive_tools:
+      ~w(write_file edit_file multi_edit_file apply_diff delete_file shell git_stage git_commit rename),
     tool_permissions: nil,
     agent_hooks: [],
 
@@ -147,7 +148,7 @@ defmodule MingaAgent.Config do
       destructive_tools:
         get(
           :agent_destructive_tools,
-          ~w(write_file edit_file multi_edit_file shell git_stage git_commit rename)
+          ~w(write_file edit_file multi_edit_file apply_diff delete_file shell git_stage git_commit rename)
         ),
       tool_permissions: get(:agent_tool_permissions, nil),
       agent_hooks: normalize_hooks(get(:agent_hooks, [])),

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -33,6 +33,7 @@ defmodule MingaAgent.Providers.Native do
 
   use GenServer
 
+  alias Minga.Buffer
   alias MingaAgent.Compaction
   alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.ContextArtifact
@@ -51,6 +52,7 @@ defmodule MingaAgent.Providers.Native do
   alias MingaAgent.MCP.ServerConfig, as: MCPServerConfig
   alias MingaAgent.Memory
   alias MingaAgent.ProjectView
+  alias MingaAgent.ToolRouter
   alias MingaAgent.ModelCatalog
   alias MingaAgent.ModelLimits
   alias MingaAgent.ProjectView
@@ -101,6 +103,9 @@ defmodule MingaAgent.Providers.Native do
       :config,
       :tools,
       :project_root,
+      :project_view,
+      :fork_store,
+      :changeset,
       :thinking_level,
       :max_tokens,
       :max_retries,
@@ -119,6 +124,9 @@ defmodule MingaAgent.Providers.Native do
             config: MingaAgent.Config.t(),
             tools: [term()],
             project_root: String.t(),
+            project_view: ProjectView.t() | nil,
+            fork_store: pid() | nil,
+            changeset: pid() | nil,
             thinking_level: String.t(),
             max_tokens: pos_integer(),
             max_retries: non_neg_integer(),
@@ -480,6 +488,9 @@ defmodule MingaAgent.Providers.Native do
         config: state.config,
         tools: state.tools,
         project_root: state.project_root,
+        project_view: state.project_view,
+        fork_store: state.fork_store,
+        changeset: state.changeset,
         thinking_level: state.thinking_level,
         max_tokens: state.max_tokens,
         max_retries: state.max_retries,
@@ -541,6 +552,9 @@ defmodule MingaAgent.Providers.Native do
       config: state.config,
       tools: state.tools,
       project_root: state.project_root,
+      project_view: state.project_view,
+      fork_store: state.fork_store,
+      changeset: state.changeset,
       thinking_level: state.thinking_level,
       max_tokens: state.max_tokens,
       max_retries: state.max_retries,
@@ -1323,7 +1337,7 @@ defmodule MingaAgent.Providers.Native do
 
     {final_ctx, _mode} =
       Enum.reduce(tool_calls, {context, initial_mode}, fn tool_call, {ctx, approval_mode} ->
-        before_content = capture_file_before(tool_call, lctx.project_root)
+        before_content = capture_file_before(lctx, tool_call)
 
         {result_text, is_error, new_mode} =
           execute_with_approval(
@@ -1349,13 +1363,7 @@ defmodule MingaAgent.Providers.Native do
 
         dispatch_post_tool_use(tool_call, result_text, is_error, lctx.config)
 
-        maybe_emit_file_changed(
-          lctx.provider_pid,
-          tool_call,
-          before_content,
-          is_error,
-          lctx.project_root
-        )
+        maybe_emit_file_changed(lctx, tool_call, before_content, is_error)
 
         meta = if is_error, do: %{is_error: true}, else: %{}
 
@@ -1603,42 +1611,33 @@ defmodule MingaAgent.Providers.Native do
     end
   end
 
-  @file_tools ~w(edit_file multi_edit_file write_file delete_file)
+  @file_tools ~w(edit_file multi_edit_file apply_diff write_file delete_file)
 
-  @spec capture_file_before(map(), String.t()) :: String.t() | nil
-  defp capture_file_before(%{name: name, arguments: %{"path" => path}}, project_root)
+  @spec capture_file_before(loop_ctx(), map()) :: String.t() | nil
+  defp capture_file_before(%LoopCtx{} = lctx, %{name: name, arguments: %{"path" => path}})
        when name in @file_tools do
-    resolved_path = resolved_tool_path(project_root, path)
-
-    case File.read(resolved_path) do
+    case read_tool_file_content(lctx, path) do
       {:ok, content} -> content
       {:error, _} -> nil
     end
   end
 
-  defp capture_file_before(_tool_call, _project_root), do: nil
+  defp capture_file_before(_lctx, _tool_call), do: nil
 
-  @spec maybe_emit_file_changed(pid(), map(), String.t() | nil, boolean(), String.t()) :: :ok
+  @spec maybe_emit_file_changed(loop_ctx(), map(), String.t() | nil, boolean()) :: :ok
   defp maybe_emit_file_changed(
-         provider_pid,
+         %LoopCtx{} = lctx,
          %{name: "delete_file", arguments: %{"path" => path}} = tool_call,
          before_content,
-         false,
-         project_root
+         false
        )
        when is_binary(before_content) do
-    resolved_path = resolved_tool_path(project_root, path)
-
-    after_content =
-      case File.read(resolved_path) do
-        {:ok, content} -> content
-        {:error, :enoent} -> ""
-        {:error, _} -> nil
-      end
+    resolved_path = file_changed_path(lctx, path)
+    after_content = read_deleted_tool_content(lctx, path)
 
     if is_binary(after_content) and after_content != before_content do
       send(
-        provider_pid,
+        lctx.provider_pid,
         {:agent_event,
          %Event.ToolFileChanged{
            tool_call_id: tool_call.id,
@@ -1652,47 +1651,107 @@ defmodule MingaAgent.Providers.Native do
     :ok
   end
 
-  defp maybe_emit_file_changed(
-         provider_pid,
-         tool_call,
-         before_content,
-         false = _is_error,
-         project_root
-       )
+  defp maybe_emit_file_changed(%LoopCtx{} = lctx, tool_call, before_content, false)
        when is_binary(before_content) and tool_call.name in @file_tools do
     path = tool_call.arguments["path"]
-    resolved_path = resolved_tool_path(project_root, path)
+    resolved_path = file_changed_path(lctx, path)
 
-    after_content =
-      case File.read(resolved_path) do
-        {:ok, content} -> content
-        {:error, _} -> nil
-      end
+    case read_tool_file_content(lctx, path) do
+      {:ok, after_content} when after_content != before_content ->
+        send(
+          lctx.provider_pid,
+          {:agent_event,
+           %Event.ToolFileChanged{
+             tool_call_id: tool_call.id,
+             path: resolved_path,
+             before_content: before_content,
+             after_content: after_content
+           }}
+        )
 
-    if after_content && after_content != before_content do
-      send(
-        provider_pid,
-        {:agent_event,
-         %Event.ToolFileChanged{
-           tool_call_id: tool_call.id,
-           path: resolved_path,
-           before_content: before_content,
-           after_content: after_content
-         }}
-      )
+      _ ->
+        :ok
     end
-
-    :ok
   end
 
-  defp maybe_emit_file_changed(
-         _provider_pid,
-         _tool_call,
-         _before_content,
-         _is_error,
-         _project_root
-       ),
-       do: :ok
+  defp maybe_emit_file_changed(_lctx, _tool_call, _before_content, _is_error), do: :ok
+
+  @spec tool_routing_configured?(loop_ctx()) :: boolean()
+  defp tool_routing_configured?(%LoopCtx{} = lctx),
+    do: ToolRouter.routing_configured?(tool_router_context(lctx))
+
+  @spec tool_router_context(loop_ctx()) :: ToolRouter.context()
+  defp tool_router_context(%LoopCtx{
+         project_view: project_view,
+         fork_store: fork_store,
+         changeset: changeset
+       }) do
+    ToolRouter.context(project_view, fork_store, changeset)
+  end
+
+  @spec file_changed_path(loop_ctx(), String.t()) :: String.t()
+  defp file_changed_path(%LoopCtx{} = lctx, path) do
+    if lctx.project_view do
+      case ToolRouter.filesystem_path_result(tool_router_context(lctx), path) do
+        {:ok, filesystem_path} -> filesystem_path
+        {:error, _} -> resolved_tool_path(lctx.project_root, path)
+      end
+    else
+      resolved_tool_path(lctx.project_root, path)
+    end
+  end
+
+  @spec read_deleted_tool_content(loop_ctx(), String.t()) :: String.t() | nil
+  defp read_deleted_tool_content(%LoopCtx{} = lctx, path) do
+    if tool_routing_configured?(lctx) do
+      absolute_path = resolved_tool_path(lctx.project_root, path)
+
+      case ToolRouter.read_file(tool_router_context(lctx), absolute_path) do
+        {:ok, content} -> content
+        {:error, _} -> ""
+      end
+    else
+      read_deleted_tool_content(Path.expand(path, lctx.project_root))
+    end
+  end
+
+  @spec read_deleted_tool_content(String.t()) :: String.t() | nil
+  defp read_deleted_tool_content(path) do
+    case File.read(path) do
+      {:ok, content} -> content
+      {:error, :enoent} -> ""
+      {:error, _} -> nil
+    end
+  end
+
+  @spec read_tool_file_content(loop_ctx(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  defp read_tool_file_content(%LoopCtx{} = lctx, path) do
+    if tool_routing_configured?(lctx) do
+      absolute_path = resolved_tool_path(lctx.project_root, path)
+      ToolRouter.read_file(tool_router_context(lctx), absolute_path)
+    else
+      read_tool_file_content_direct(Path.expand(path, lctx.project_root))
+    end
+  end
+
+  @spec read_tool_file_content_direct(String.t()) :: {:ok, String.t()} | {:error, term()}
+  defp read_tool_file_content_direct(path) do
+    case Buffer.pid_for_path(path) do
+      {:ok, pid} -> {:ok, Buffer.content(pid)}
+      :not_found -> read_tool_file_content_from_disk(path)
+    end
+  catch
+    :exit, _ -> read_tool_file_content_from_disk(path)
+  end
+
+  @spec read_tool_file_content_from_disk(String.t()) :: {:ok, String.t()} | {:error, term()}
+  defp read_tool_file_content_from_disk(path) do
+    case File.read(path) do
+      {:ok, content} -> {:ok, content}
+      {:error, :enoent} -> {:error, :enoent}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
   @spec resolved_tool_path(String.t(), String.t()) :: String.t()
   defp resolved_tool_path(project_root, path), do: Path.expand(path, project_root)
@@ -2212,6 +2271,7 @@ defmodule MingaAgent.Providers.Native do
   read_file: Read file contents. Supports offset/limit for partial reads.
   write_file: Create/overwrite files. Auto-creates parent dirs.
   edit_file: Find-and-replace exact text. Read file first for exact match.
+  apply_diff: Apply unified diffs to a file. Use for large or multi-hunk edits.
   list_directory: List entries at a path.
   find: Find files by name/glob. Prefer over shell+find.
   grep: Search file contents by pattern. Prefer over shell+grep.
@@ -2222,7 +2282,8 @@ defmodule MingaAgent.Providers.Native do
 
   <rules>
   - Always read a file before editing it. old_text must match exactly.
-  - Prefer multi_edit_file when making several changes to the same file.
+  - Prefer apply_diff for large changes that are easiest to express as unified diff hunks.
+  - Prefer multi_edit_file when making several exact replacements in the same file.
   - Use find for file discovery, grep for content search.
   - Verify changes by reading the result or running tests.
   - Be concise. Show file paths clearly.

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -423,7 +423,7 @@ defmodule MingaAgent.Session do
   - `action`: `:created`, `:modified`, or `:deleted`
   - `timestamp`: monotonic timestamp of the last touch
 
-  Derived from tool call history (file_write, file_edit, multi_edit_file).
+  Derived from tool call history (file_write, file_edit, multi_edit_file, apply_diff).
   """
   @spec touched_files(GenServer.server()) :: [file_touch()]
   def touched_files(session) do

--- a/lib/minga_agent/tool/registry.ex
+++ b/lib/minga_agent/tool/registry.ex
@@ -176,6 +176,7 @@ defmodule MingaAgent.Tool.Registry do
   defp categorize("write_file"), do: :filesystem
   defp categorize("edit_file"), do: :filesystem
   defp categorize("multi_edit_file"), do: :filesystem
+  defp categorize("apply_diff"), do: :filesystem
   defp categorize("list_directory"), do: :filesystem
   defp categorize("find"), do: :filesystem
   defp categorize("grep"), do: :filesystem

--- a/lib/minga_agent/tool_approval.ex
+++ b/lib/minga_agent/tool_approval.ex
@@ -84,7 +84,7 @@ defmodule MingaAgent.ToolApproval do
   end
 
   defp do_build_preview(name, %{"path" => path} = args)
-       when name in ["edit_file", "multi_edit_file"] do
+       when name in ["edit_file", "multi_edit_file", "apply_diff"] do
     path = stringify_value(path)
 
     Preview.new(:target, path, preview_lines(["file: #{path}", edit_summary(name, args)]))
@@ -151,6 +151,12 @@ defmodule MingaAgent.ToolApproval do
     edits = Map.get(args, "edits", [])
     count = if is_list(edits), do: length(edits), else: 0
     "#{count} edit(s)"
+  end
+
+  defp edit_summary("apply_diff", args) do
+    diff = stringify_value(Map.get(args, "diff", ""))
+    hunk_count = diff |> String.split("\n") |> Enum.count(&String.starts_with?(&1, "@@"))
+    "#{hunk_count} diff hunk(s)"
   end
 
   @spec stringify_keys(map()) :: map()

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -15,6 +15,7 @@ defmodule MingaAgent.Tools do
   | `write_file`      | Write content to a file (creates or overwrites)      |
   | `edit_file`       | Replace exact text in a file                         |
   | `multi_edit_file` | Apply multiple edits to one file in a single call    |
+  | `apply_diff`      | Apply a unified diff to one file                     |
   | `delete_file`     | Delete a file                                        |
   | `list_directory`  | List files and directories at a path                 |
   | `find`            | Find files by name/glob pattern                      |
@@ -43,6 +44,7 @@ defmodule MingaAgent.Tools do
   alias MingaAgent.ProjectView
   alias MingaAgent.ToolRouter
   alias MingaAgent.Tools.DeleteFile
+  alias MingaAgent.Tools.ApplyDiff
   alias MingaAgent.Tools.DiagnosticFeedback
   alias MingaAgent.Tools.EditFile
   alias MingaAgent.Tools.Find
@@ -75,7 +77,7 @@ defmodule MingaAgent.Tools do
           parent_session: GenServer.server() | nil
         ]
 
-  @default_destructive_tools ~w(write_file edit_file multi_edit_file delete_file shell git_stage git_commit rename)
+  @default_destructive_tools ~w(write_file edit_file multi_edit_file apply_diff delete_file shell git_stage git_commit rename)
   @file_read_tools ~w(read_file list_directory find grep)
   @read_only_tools ~w(read_file list_directory find grep git_status git_diff git_log diagnostics definition references hover document_symbols workspace_symbols describe_runtime describe_tools produce_rewrite)
   @max_symlink_depth 40
@@ -138,6 +140,7 @@ defmodule MingaAgent.Tools do
       write_file(root, router_ctx),
       edit_file(root, router_ctx),
       multi_edit_file(root, router_ctx),
+      apply_diff(root, router_ctx),
       delete_file(root, router_ctx),
       list_directory(root, router_ctx),
       find(root, router_ctx),
@@ -396,6 +399,46 @@ defmodule MingaAgent.Tools do
           apply_multi_edit_via_router(router_ctx, path, edits)
         else
           case MultiEditFile.execute(path, edits) do
+            {:ok, msg} -> {:ok, maybe_append_diagnostics(path, msg)}
+            error -> error
+          end
+        end
+      end
+    )
+  end
+
+  @spec apply_diff(String.t(), MingaAgent.ToolRouter.context()) :: Tool.t()
+  defp apply_diff(root, router_ctx) do
+    Tool.new!(
+      name: "apply_diff",
+      description: """
+      Apply a unified diff to a single file. The diff must use standard
+      unified diff hunks (`@@ -start,count +start,count @@`) with context
+      lines. Context is validated against the current file content, with a
+      small fuzz window for hunks whose line numbers drifted by a few lines.
+      """,
+      parameter_schema: %{
+        "type" => "object",
+        "properties" => %{
+          "path" => %{
+            "type" => "string",
+            "description" => "Path to the file, relative to the project root"
+          },
+          "diff" => %{
+            "type" => "string",
+            "description" => "Unified diff content to apply to the file"
+          }
+        },
+        "required" => ["path", "diff"]
+      },
+      callback: fn args ->
+        path = resolve_and_validate_path!(root, args["path"])
+        diff = args["diff"] || ""
+
+        if ToolRouter.routing_configured?(router_ctx) do
+          apply_diff_via_router(router_ctx, path, diff)
+        else
+          case ApplyDiff.execute(path, diff) do
             {:ok, msg} -> {:ok, maybe_append_diagnostics(path, msg)}
             error -> error
           end
@@ -1469,6 +1512,50 @@ defmodule MingaAgent.Tools do
 
   # Applies multiple edits to a file through the tool router by reading,
   # applying each edit sequentially, then writing the result back.
+  @spec apply_diff_via_router(MingaAgent.ToolRouter.context(), String.t(), String.t()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp apply_diff_via_router(router_ctx, path, diff) do
+    case ToolRouter.read_file(router_ctx, path) do
+      {:ok, content} ->
+        commit_apply_diff(router_ctx, path, ApplyDiff.apply_to_content(content, diff))
+
+      {:error, reason} ->
+        {:error, "failed to read #{path}: #{inspect(reason)}"}
+    end
+  end
+
+  @spec commit_apply_diff(
+          ToolRouter.context(),
+          String.t(),
+          {:ok, ApplyDiff.apply_result()} | {:error, String.t()}
+        ) :: {:ok, String.t()} | {:error, String.t()}
+  defp commit_apply_diff(router_ctx, path, {:ok, %{content: final_content, hunks: hunk_count}}) do
+    case ToolRouter.write_file(router_ctx, path, final_content) do
+      :ok ->
+        msg =
+          append_workspace_context(
+            router_ctx,
+            "applied #{hunk_count} diff hunk(s) to #{path} (via #{route_name(router_ctx)})"
+          )
+
+        {:ok, maybe_append_diagnostics(path, msg)}
+
+      :passthrough ->
+        case WriteFile.execute(path, final_content) do
+          {:ok, _msg} ->
+            {:ok, maybe_append_diagnostics(path, "applied #{hunk_count} diff hunk(s) to #{path}")}
+
+          {:error, _message} = error ->
+            error
+        end
+
+      {:error, reason} ->
+        {:error, "failed to write #{path}: #{inspect(reason)}"}
+    end
+  end
+
+  defp commit_apply_diff(_router_ctx, _path, {:error, _message} = error), do: error
+
   @spec apply_multi_edit_via_router(MingaAgent.ToolRouter.context(), String.t(), [map()]) ::
           {:ok, String.t()} | {:error, String.t()}
   defp apply_multi_edit_via_router(router_ctx, path, edits) do

--- a/lib/minga_agent/tools/apply_diff.ex
+++ b/lib/minga_agent/tools/apply_diff.ex
@@ -1,0 +1,391 @@
+defmodule MingaAgent.Tools.ApplyDiff do
+  @moduledoc """
+  Applies unified diffs to a single file.
+
+  The tool parses standard unified diff hunks, validates context against the current file content, and writes the resulting content only when every hunk applies. Hunk matching starts at the line declared in the header and then searches a small nearby window so diffs survive minor line offset drift without accepting stale context.
+  """
+
+  alias Minga.Buffer
+  alias MingaAgent.Tools.WriteFile
+
+  @max_fuzz 5
+
+  @typedoc "A parsed unified diff operation."
+  @type operation :: {:context, String.t()} | {:remove, String.t()} | {:add, String.t()}
+
+  @typedoc "A parsed unified diff hunk."
+  @type hunk :: map()
+
+  @typedoc "Successful patch application metadata."
+  @type apply_result :: %{content: String.t(), hunks: pos_integer()}
+
+  @doc "Applies a unified diff to the file at `path`."
+  @spec execute(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def execute(path, diff) when is_binary(path) and is_binary(diff) do
+    with {:ok, content} <- read_current_content(path),
+         {:ok, %{content: new_content, hunks: hunk_count}} <- apply_to_content(content, diff),
+         {:ok, _message} <- WriteFile.execute(path, new_content) do
+      {:ok, "applied #{hunk_count} diff hunk(s) to #{path}"}
+    end
+  end
+
+  @doc "Applies a unified diff string to `content` without writing it."
+  @spec apply_to_content(String.t(), String.t()) :: {:ok, apply_result()} | {:error, String.t()}
+  def apply_to_content(content, diff) when is_binary(content) and is_binary(diff) do
+    with {:ok, hunks} <- parse(diff),
+         {:ok, patched_lines} <- apply_hunks(content_lines(content), hunks) do
+      {:ok, %{content: Enum.join(patched_lines, "\n"), hunks: length(hunks)}}
+    end
+  end
+
+  @doc "Parses unified diff hunks from a diff string."
+  @spec parse(String.t()) :: {:ok, [hunk()]} | {:error, String.t()}
+  def parse(diff) when is_binary(diff) do
+    diff
+    |> diff_lines()
+    |> parse_lines(1, [], nil)
+    |> finalize_parse()
+  end
+
+  @spec read_current_content(String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp read_current_content(path) do
+    expanded = Path.expand(path)
+
+    case Buffer.pid_for_path(expanded) do
+      {:ok, pid} -> read_buffer_content(pid, expanded)
+      :not_found -> read_file_content(expanded)
+    end
+  catch
+    :exit, _ -> read_file_content(Path.expand(path))
+  end
+
+  @spec read_buffer_content(pid(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp read_buffer_content(pid, path) do
+    {:ok, Buffer.content(pid)}
+  catch
+    :exit, _ -> {:error, "buffer process died for #{path}"}
+  end
+
+  @spec read_file_content(String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp read_file_content(path) do
+    case File.read(path) do
+      {:ok, content} -> {:ok, content}
+      {:error, :enoent} -> {:error, "file not found: #{path}"}
+      {:error, reason} -> {:error, "failed to read #{path}: #{reason}"}
+    end
+  end
+
+  @spec diff_lines(String.t()) :: [String.t()]
+  defp diff_lines(diff) do
+    diff
+    |> String.split("\n", trim: false)
+    |> drop_trailing_empty_line()
+  end
+
+  @spec drop_trailing_empty_line([String.t()]) :: [String.t()]
+  defp drop_trailing_empty_line([]), do: []
+
+  defp drop_trailing_empty_line(lines) do
+    if List.last(lines) == "" do
+      Enum.slice(lines, 0, length(lines) - 1)
+    else
+      lines
+    end
+  end
+
+  @spec parse_lines([String.t()], pos_integer(), [hunk()], hunk() | nil) ::
+          {:ok, [hunk()]} | {:error, String.t()} | {:pending, [hunk()], hunk() | nil}
+  defp parse_lines([], _line_no, parsed, current), do: {:pending, parsed, current}
+
+  defp parse_lines([line | rest], line_no, parsed, current) do
+    parse_line(line, rest, line_no, parsed, current)
+  end
+
+  @spec parse_line(String.t(), [String.t()], pos_integer(), [hunk()], hunk() | nil) ::
+          {:ok, [hunk()]} | {:error, String.t()} | {:pending, [hunk()], hunk() | nil}
+  defp parse_line(line, rest, line_no, parsed, current) do
+    if hunk_header?(line) do
+      parse_hunk_header(line, rest, line_no, parsed, current)
+    else
+      parse_non_header_line(line, rest, line_no, parsed, current)
+    end
+  end
+
+  @spec parse_hunk_header(String.t(), [String.t()], pos_integer(), [hunk()], hunk() | nil) ::
+          {:ok, [hunk()]} | {:error, String.t()} | {:pending, [hunk()], hunk() | nil}
+  defp parse_hunk_header(line, rest, line_no, parsed, current) do
+    with {:ok, hunk} <- new_hunk(line, line_no),
+         {:ok, parsed} <- push_current_hunk(parsed, current, line_no) do
+      parse_lines(rest, line_no + 1, parsed, hunk)
+    end
+  end
+
+  @spec parse_non_header_line(String.t(), [String.t()], pos_integer(), [hunk()], hunk() | nil) ::
+          {:ok, [hunk()]} | {:error, String.t()} | {:pending, [hunk()], hunk() | nil}
+  defp parse_non_header_line(line, rest, line_no, parsed, nil) do
+    if ignorable_header_line?(line) do
+      parse_lines(rest, line_no + 1, parsed, nil)
+    else
+      {:error, "malformed diff at line #{line_no}: expected hunk header, got #{inspect(line)}"}
+    end
+  end
+
+  defp parse_non_header_line(line, rest, line_no, parsed, current) do
+    case parse_operation(line, line_no) do
+      {:ok, operation} ->
+        parse_lines(rest, line_no + 1, parsed, add_operation(current, operation))
+
+      {:error, _message} = error ->
+        error
+    end
+  end
+
+  @spec hunk_header?(String.t()) :: boolean()
+  defp hunk_header?(line), do: String.starts_with?(line, "@@")
+
+  @spec ignorable_header_line?(String.t()) :: boolean()
+  defp ignorable_header_line?(""), do: true
+  defp ignorable_header_line?("---" <> _rest), do: true
+  defp ignorable_header_line?("+++" <> _rest), do: true
+  defp ignorable_header_line?("diff --git" <> _rest), do: true
+  defp ignorable_header_line?("index " <> _rest), do: true
+  defp ignorable_header_line?("new file mode " <> _rest), do: true
+  defp ignorable_header_line?("deleted file mode " <> _rest), do: true
+  defp ignorable_header_line?("old mode " <> _rest), do: true
+  defp ignorable_header_line?("new mode " <> _rest), do: true
+  defp ignorable_header_line?(_line), do: false
+
+  @spec new_hunk(String.t(), pos_integer()) :: {:ok, hunk()} | {:error, String.t()}
+  defp new_hunk(line, line_no) do
+    case Regex.named_captures(
+           ~r/^@@ -(?<old_start>\d+)(?:,(?<old_count>\d+))? \+(?<new_start>\d+)(?:,(?<new_count>\d+))? @@/,
+           line
+         ) do
+      %{
+        "old_start" => old_start,
+        "old_count" => old_count,
+        "new_start" => new_start,
+        "new_count" => new_count
+      } ->
+        {:ok,
+         %{
+           old_start: String.to_integer(old_start),
+           old_count: count_value(old_count),
+           new_start: String.to_integer(new_start),
+           new_count: count_value(new_count),
+           operations: []
+         }}
+
+      nil ->
+        {:error, "malformed diff at line #{line_no}: invalid hunk header #{inspect(line)}"}
+    end
+  end
+
+  @spec count_value(String.t() | nil) :: non_neg_integer()
+  defp count_value(nil), do: 1
+  defp count_value(""), do: 1
+  defp count_value(value), do: String.to_integer(value)
+
+  @spec parse_operation(String.t(), pos_integer()) :: {:ok, operation()} | {:error, String.t()}
+  defp parse_operation(" " <> text, _line_no), do: {:ok, {:context, text}}
+  defp parse_operation("-" <> text, _line_no), do: {:ok, {:remove, text}}
+  defp parse_operation("+" <> text, _line_no), do: {:ok, {:add, text}}
+
+  defp parse_operation("\\ No newline at end of file", _line_no) do
+    {:error, "unsupported diff: no-newline-at-EOF markers are not supported"}
+  end
+
+  defp parse_operation(line, line_no) do
+    {:error,
+     "malformed diff at line #{line_no}: expected hunk line prefix ' ', '+', or '-', got #{inspect(line)}"}
+  end
+
+  @spec add_operation(hunk(), operation()) :: hunk()
+  defp add_operation(hunk, operation), do: %{hunk | operations: [operation | hunk.operations]}
+
+  @spec push_current_hunk([hunk()], hunk() | nil, non_neg_integer()) ::
+          {:ok, [hunk()]} | {:error, String.t()}
+  defp push_current_hunk(parsed, nil, _line_no), do: {:ok, parsed}
+
+  defp push_current_hunk(parsed, current, line_no) do
+    current = %{current | operations: Enum.reverse(current.operations)}
+
+    case validate_hunk_counts(current, line_no) do
+      :ok -> {:ok, [current | parsed]}
+      {:error, _message} = error -> error
+    end
+  end
+
+  @spec finalize_parse({:pending, [hunk()], hunk() | nil} | {:error, String.t()}) ::
+          {:ok, [hunk()]} | {:error, String.t()}
+  defp finalize_parse({:error, _message} = error), do: error
+
+  defp finalize_parse({:pending, parsed, current}) do
+    with {:ok, parsed} <- push_current_hunk(parsed, current, 0) do
+      require_hunks(Enum.reverse(parsed))
+    end
+  end
+
+  @spec require_hunks([hunk()]) :: {:ok, [hunk()]} | {:error, String.t()}
+  defp require_hunks([]), do: {:error, "malformed diff: no hunks found"}
+  defp require_hunks(hunks), do: {:ok, hunks}
+
+  @spec validate_hunk_counts(hunk(), non_neg_integer()) :: :ok | {:error, String.t()}
+  defp validate_hunk_counts(hunk, line_no) do
+    old_seen = count_old_lines(hunk.operations)
+    new_seen = count_new_lines(hunk.operations)
+
+    case validate_line_count(:old, hunk.old_count, old_seen, line_no) do
+      :ok -> validate_line_count(:new, hunk.new_count, new_seen, line_no)
+      {:error, _message} = error -> error
+    end
+  end
+
+  @spec validate_line_count(:old | :new, non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          :ok | {:error, String.t()}
+  defp validate_line_count(_kind, expected, actual, _line_no) when expected == actual, do: :ok
+
+  defp validate_line_count(kind, expected, actual, 0) do
+    {:error, "malformed diff: #{kind} line count expected #{expected}, got #{actual}"}
+  end
+
+  defp validate_line_count(kind, expected, actual, line_no) do
+    {:error,
+     "malformed diff before line #{line_no}: #{kind} line count expected #{expected}, got #{actual}"}
+  end
+
+  @spec count_old_lines([operation()]) :: non_neg_integer()
+  defp count_old_lines(operations), do: Enum.count(operations, &old_line?/1)
+
+  @spec count_new_lines([operation()]) :: non_neg_integer()
+  defp count_new_lines(operations), do: Enum.count(operations, &new_line?/1)
+
+  @spec old_line?(operation()) :: boolean()
+  defp old_line?({:context, _text}), do: true
+  defp old_line?({:remove, _text}), do: true
+  defp old_line?({:add, _text}), do: false
+
+  @spec new_line?(operation()) :: boolean()
+  defp new_line?({:context, _text}), do: true
+  defp new_line?({:add, _text}), do: true
+  defp new_line?({:remove, _text}), do: false
+
+  @spec content_lines(String.t()) :: [String.t()]
+  defp content_lines(content), do: String.split(content, "\n", trim: false)
+
+  @spec apply_hunks([String.t()], [hunk()]) :: {:ok, [String.t()]} | {:error, String.t()}
+  defp apply_hunks(lines, hunks) do
+    hunks
+    |> Enum.with_index(1)
+    |> Enum.reduce_while({:ok, lines, 0}, &apply_hunk_step/2)
+    |> case do
+      {:ok, patched_lines, _delta} -> {:ok, patched_lines}
+      {:error, _message} = error -> error
+    end
+  end
+
+  @spec apply_hunk_step({hunk(), pos_integer()}, {:ok, [String.t()], integer()}) ::
+          {:cont, {:ok, [String.t()], integer()}} | {:halt, {:error, String.t()}}
+  defp apply_hunk_step({hunk, index}, {:ok, lines, delta}) do
+    case apply_hunk(lines, hunk, index, delta) do
+      {:ok, patched_lines, hunk_delta} -> {:cont, {:ok, patched_lines, delta + hunk_delta}}
+      {:error, _message} = error -> {:halt, error}
+    end
+  end
+
+  @spec apply_hunk([String.t()], hunk(), pos_integer(), integer()) ::
+          {:ok, [String.t()], integer()} | {:error, String.t()}
+  defp apply_hunk(lines, hunk, hunk_index, delta) do
+    old_lines = old_hunk_lines(hunk.operations)
+    new_lines = new_hunk_lines(hunk.operations)
+    expected_index = expected_index(hunk, delta)
+
+    case find_hunk_index(lines, old_lines, expected_index) do
+      {:ok, index} ->
+        patched = replace_slice(lines, index, length(old_lines), new_lines)
+        {:ok, patched, length(new_lines) - length(old_lines)}
+
+      :error ->
+        {:error,
+         "stale diff: hunk #{hunk_index} context did not match near original line #{hunk.old_start}"}
+    end
+  end
+
+  @spec expected_index(hunk(), integer()) :: non_neg_integer()
+  defp expected_index(%{old_count: 0, old_start: old_start}, delta), do: max(old_start + delta, 0)
+  defp expected_index(%{old_start: old_start}, delta), do: max(old_start - 1 + delta, 0)
+
+  @spec old_hunk_lines([operation()]) :: [String.t()]
+  defp old_hunk_lines(operations) do
+    operations
+    |> Enum.reject(&match?({:add, _text}, &1))
+    |> Enum.map(&operation_text/1)
+  end
+
+  @spec new_hunk_lines([operation()]) :: [String.t()]
+  defp new_hunk_lines(operations) do
+    operations
+    |> Enum.reject(&match?({:remove, _text}, &1))
+    |> Enum.map(&operation_text/1)
+  end
+
+  @spec operation_text(operation()) :: String.t()
+  defp operation_text({_kind, text}), do: text
+
+  @spec find_hunk_index([String.t()], [String.t()], non_neg_integer()) ::
+          {:ok, non_neg_integer()} | :error
+  defp find_hunk_index(lines, [], expected_index) do
+    if expected_index <= max_insert_index(lines) do
+      {:ok, expected_index}
+    else
+      :error
+    end
+  end
+
+  defp find_hunk_index(lines, old_lines, expected_index) do
+    candidates(expected_index)
+    |> Enum.find(&matches_at?(lines, old_lines, &1))
+    |> case do
+      nil -> :error
+      index -> {:ok, index}
+    end
+  end
+
+  @spec max_insert_index([String.t()]) :: non_neg_integer()
+  defp max_insert_index([]), do: 0
+
+  defp max_insert_index(lines) do
+    if List.last(lines) == "" do
+      length(lines) - 1
+    else
+      length(lines)
+    end
+  end
+
+  @spec candidates(non_neg_integer()) :: [non_neg_integer()]
+  defp candidates(expected_index) do
+    0..@max_fuzz
+    |> Enum.flat_map(&candidate_offsets(expected_index, &1))
+    |> Enum.filter(&(&1 >= 0))
+    |> Enum.uniq()
+  end
+
+  @spec candidate_offsets(non_neg_integer(), non_neg_integer()) :: [integer()]
+  defp candidate_offsets(expected, 0), do: [expected]
+  defp candidate_offsets(expected, distance), do: [expected - distance, expected + distance]
+
+  @spec matches_at?([String.t()], [String.t()], non_neg_integer()) :: boolean()
+  defp matches_at?(lines, old_lines, index) do
+    index <= length(lines) - length(old_lines) and
+      Enum.slice(lines, index, length(old_lines)) == old_lines
+  end
+
+  @spec replace_slice([String.t()], non_neg_integer(), non_neg_integer(), [String.t()]) :: [
+          String.t()
+        ]
+  defp replace_slice(lines, index, count, replacement) do
+    {prefix, rest} = Enum.split(lines, index)
+    {_removed, suffix} = Enum.split(rest, count)
+    prefix ++ replacement ++ suffix
+  end
+end

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -3158,6 +3158,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp summarize_tool_args("edit_file", %{path: path}), do: path
   defp summarize_tool_args("multi_edit_file", %{"path" => path}), do: path
   defp summarize_tool_args("multi_edit_file", %{path: path}), do: path
+  defp summarize_tool_args("apply_diff", %{"path" => path}), do: path
+  defp summarize_tool_args("apply_diff", %{path: path}), do: path
 
   defp summarize_tool_args("git_stage", %{"paths" => paths}) when is_list(paths),
     do: Enum.join(paths, ", ")

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -244,6 +244,7 @@ defmodule Minga.Config.OptionsTest do
         "write_file",
         "edit_file",
         "multi_edit_file",
+        "apply_diff",
         "delete_file",
         "shell",
         "git_stage",

--- a/test/minga_agent/config_test.exs
+++ b/test/minga_agent/config_test.exs
@@ -34,7 +34,7 @@ defmodule MingaAgent.ConfigTest do
       assert config.tool_approval == :destructive
 
       assert config.destructive_tools ==
-               ~w(write_file edit_file multi_edit_file delete_file shell git_stage git_commit rename)
+               ~w(write_file edit_file multi_edit_file apply_diff delete_file shell git_stage git_commit rename)
 
       assert config.agent_hooks == []
       assert config.prompt_cache == true

--- a/test/minga_agent/ephemeral_session_test.exs
+++ b/test/minga_agent/ephemeral_session_test.exs
@@ -68,6 +68,7 @@ defmodule MingaAgent.EphemeralSessionTest do
     refute "git_status" in names
     refute "write_file" in names
     refute "multi_edit_file" in names
+    refute "apply_diff" in names
     refute "shell" in names
     refute "delete_file" in names
   end

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -611,6 +611,62 @@ defmodule MingaAgent.Providers.NativeTest do
       refute File.exists?(absolute_path)
     end
 
+    test "tracks apply_diff as a file change through fork routing for an open buffer", %{
+      tmp_dir: dir
+    } do
+      path = Path.join(dir, "patch-me.txt")
+      absolute_path = path
+      File.write!(absolute_path, "one\ntwo\n")
+      buffer = start_supervised!({BufferProcess, file_path: absolute_path})
+      diff = "@@ -1,2 +1,2 @@\n one\n-two\n+TWO\n"
+      call_count = :counters.new(1, [:atomics])
+
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          if count == 0 do
+            [
+              ReqLLM.StreamChunk.tool_call("apply_diff", %{"path" => path, "diff" => diff}, %{
+                id: "tc_apply_diff",
+                index: 0
+              }),
+              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+            ]
+          else
+            [
+              ReqLLM.StreamChunk.text("patched"),
+              ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+            ]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: dir,
+          llm_client: client,
+          tools: nil,
+          config: agent_config(tool_approval: :none)
+        )
+
+      assert :ok = Native.send_prompt(pid, "Patch the file")
+      events = collect_events(1_000)
+
+      assert Enum.any?(events, &match?(%Event.ToolStart{name: "apply_diff"}, &1))
+      assert Enum.any?(events, &match?(%Event.ToolEnd{name: "apply_diff", is_error: false}, &1))
+
+      file_changed = Enum.find(events, &match?(%Event.ToolFileChanged{}, &1))
+      assert file_changed != nil
+      assert file_changed.path == absolute_path
+      assert file_changed.before_content == "one\ntwo\n"
+      assert file_changed.after_content == "one\nTWO\n"
+      assert BufferProcess.content(buffer) == "one\ntwo\n"
+      assert File.read!(absolute_path) == "one\ntwo\n"
+    end
+
     test "passes is_error metadata on tool result message when tool fails", %{tmp_dir: dir} do
       test_pid = self()
       call_count = :counters.new(1, [:atomics])

--- a/test/minga_agent/tool_approval_test.exs
+++ b/test/minga_agent/tool_approval_test.exs
@@ -78,6 +78,18 @@ defmodule MingaAgent.ToolApprovalTest do
       assert "2 edit(s)" in preview.lines
     end
 
+    test "builds hunk-count preview for apply_diff tools" do
+      preview =
+        ToolApproval.build_preview("apply_diff", %{
+          "path" => "lib/a.ex",
+          "diff" => "@@ -1,1 +1,1 @@\n-old\n+new\n"
+        })
+
+      assert preview.kind == :target
+      assert preview.summary == "lib/a.ex"
+      assert "1 diff hunk(s)" in preview.lines
+    end
+
     test "builds target preview for git_stage tools" do
       preview = ToolApproval.build_preview("git_stage", %{"paths" => ["lib/a.ex", "mix.exs"]})
 

--- a/test/minga_agent/tools/apply_diff_test.exs
+++ b/test/minga_agent/tools/apply_diff_test.exs
@@ -1,0 +1,220 @@
+defmodule MingaAgent.Tools.ApplyDiffTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaAgent.Tools
+  alias MingaAgent.Tools.ApplyDiff
+
+  @moduletag :tmp_dir
+
+  describe "apply/2" do
+    test "applies a unified diff hunk to content" do
+      diff = """
+      --- a/example.txt
+      +++ b/example.txt
+      @@ -1,3 +1,3 @@
+       one
+      -two
+      +TWO
+       three
+      """
+
+      assert {:ok, %{content: content, hunks: 1}} =
+               ApplyDiff.apply_to_content("one\ntwo\nthree\n", diff)
+
+      assert content == "one\nTWO\nthree\n"
+    end
+
+    test "applies multiple hunks sequentially" do
+      diff = """
+      @@ -1,2 +1,2 @@
+      -one
+      +ONE
+       two
+      @@ -4,2 +4,2 @@
+       four
+      -five
+      +FIVE
+      """
+
+      assert {:ok, %{content: content, hunks: 2}} =
+               ApplyDiff.apply_to_content("one\ntwo\nthree\nfour\nfive\n", diff)
+
+      assert content == "ONE\ntwo\nthree\nfour\nFIVE\n"
+    end
+
+    test "applies one-line hunks whose header omits explicit counts" do
+      diff = """
+      @@ -1 +1 @@
+      -old
+      +new
+      """
+
+      assert {:ok, %{content: content, hunks: 1}} = ApplyDiff.apply_to_content("old\n", diff)
+      assert content == "new\n"
+    end
+
+    test "returns a clear error for unsupported no-newline markers" do
+      diff = """
+      @@ -1,1 +1,1 @@
+      -old
+      \\ No newline at end of file
+      +new
+      \\ No newline at end of file
+      """
+
+      assert {:error, message} = ApplyDiff.apply_to_content("old", diff)
+      assert message =~ "unsupported diff"
+      assert message =~ "no-newline-at-EOF"
+    end
+
+    test "applies insertion-only hunks with zero-count headers" do
+      diff = """
+      @@ -1,0 +2,1 @@
+      +inserted
+      """
+
+      assert {:ok, %{content: content, hunks: 1}} =
+               ApplyDiff.apply_to_content("one\ntwo\nthree\n", diff)
+
+      assert content == "one\ninserted\ntwo\nthree\n"
+    end
+
+    test "applies deletion-only hunks with zero-count headers" do
+      diff = """
+      @@ -2,1 +2,0 @@
+      -two
+      """
+
+      assert {:ok, %{content: content, hunks: 1}} =
+               ApplyDiff.apply_to_content("one\ntwo\nthree\n", diff)
+
+      assert content == "one\nthree\n"
+    end
+
+    test "returns a clear error for malformed hunk counts" do
+      diff = """
+      @@ -1,2 +1,2 @@
+       one
+      -two
+      """
+
+      assert {:error, message} = ApplyDiff.apply_to_content("one\ntwo\n", diff)
+      assert message =~ "malformed diff"
+      assert message =~ "new line count"
+    end
+
+    test "rejects stale context without modifying content" do
+      diff = """
+      @@ -1,2 +1,2 @@
+       missing
+      -two
+      +TWO
+      """
+
+      assert {:error, message} = ApplyDiff.apply_to_content("one\ntwo\n", diff)
+      assert message =~ "stale diff"
+      assert message =~ "context did not match"
+    end
+
+    test "rejects stale hunks that are too far outside the fuzz window" do
+      diff = """
+      @@ -10,2 +10,2 @@
+       one
+      -two
+      +TWO
+      """
+
+      assert {:error, message} = ApplyDiff.apply_to_content("one\ntwo\nthree\n", diff)
+      assert message =~ "stale diff"
+      assert message =~ "context did not match"
+    end
+
+    test "rejects far-out insertion hunks against newline-terminated files" do
+      diff = """
+      @@ -3,0 +3,1 @@
+      +late
+      """
+
+      assert {:error, message} = ApplyDiff.apply_to_content("one\ntwo\n", diff)
+      assert message =~ "stale diff"
+      assert message =~ "context did not match"
+    end
+
+    test "supports fuzz matching when hunk line numbers drift" do
+      diff = """
+      @@ -1,2 +1,2 @@
+       one
+      -two
+      +TWO
+      """
+
+      assert {:ok, %{content: content}} =
+               ApplyDiff.apply_to_content("zero\none\ntwo\nthree\n", diff)
+
+      assert content == "zero\none\nTWO\nthree\n"
+    end
+
+    test "returns a clear error when no hunks are present" do
+      assert {:error, message} = ApplyDiff.apply_to_content("content\n", "not a diff")
+      assert message =~ "malformed diff"
+    end
+  end
+
+  describe "execute/2" do
+    test "writes the patched content to disk", %{tmp_dir: dir} do
+      path = Path.join(dir, "example.txt")
+      File.write!(path, "one\ntwo\nthree\n")
+
+      diff = """
+      @@ -1,3 +1,3 @@
+       one
+      -two
+      +TWO
+       three
+      """
+
+      assert {:ok, message} = ApplyDiff.execute(path, diff)
+      assert message =~ "applied 1 diff hunk"
+      assert File.read!(path) == "one\nTWO\nthree\n"
+    end
+
+    test "routes through an open buffer instead of writing disk directly", %{tmp_dir: dir} do
+      path = Path.join(dir, "buffered.txt")
+      File.write!(path, "one\ntwo\n")
+      buffer = start_supervised!({BufferProcess, file_path: path})
+
+      diff = """
+      @@ -1,2 +1,2 @@
+       one
+      -two
+      +TWO
+      """
+
+      assert {:ok, _message} = ApplyDiff.execute(path, diff)
+      assert BufferProcess.content(buffer) == "one\nTWO\n"
+      assert BufferProcess.dirty?(buffer)
+      assert File.read!(path) == "one\ntwo\n"
+    end
+  end
+
+  describe "Tools integration" do
+    test "registers an apply_diff tool callback", %{tmp_dir: dir} do
+      path = Path.join(dir, "tool.txt")
+      File.write!(path, "old\n")
+      tools = Tools.all(project_root: dir)
+      tool = Enum.find(tools, &(&1.name == "apply_diff"))
+
+      diff = """
+      @@ -1,1 +1,1 @@
+      -old
+      +new
+      """
+
+      assert tool != nil
+      assert {:ok, message} = tool.callback.(%{"path" => "tool.txt", "diff" => diff})
+      assert message =~ "applied 1 diff hunk"
+      assert File.read!(path) == "new\n"
+    end
+  end
+end

--- a/test/minga_agent/tools/project_view_routing_test.exs
+++ b/test/minga_agent/tools/project_view_routing_test.exs
@@ -75,6 +75,21 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     assert_receive {:project_view_call, {:read_file, "lib/file.txt"}}
     assert_receive {:project_view_call, {:write_file, "lib/file.txt", "multi text\n"}}
 
+    diff = """
+    @@ -1,1 +1,1 @@
+    -multi text
+    +diff text
+    """
+
+    assert {:ok, diff_result} =
+             call_tool(tools, "apply_diff", %{"path" => "lib/file.txt", "diff" => diff})
+
+    assert diff_result =~ "via ProjectView"
+    assert diff_result =~ "ProjectView workspace 42"
+    assert File.read!(Path.join(working_dir, "lib/file.txt")) == "diff text\n"
+    assert_receive {:project_view_call, {:read_file, "lib/file.txt"}}
+    assert_receive {:project_view_call, {:write_file, "lib/file.txt", "diff text\n"}}
+
     assert {:ok, delete_result} = call_tool(tools, "delete_file", %{"path" => "lib/new.txt"})
     assert delete_result =~ "ProjectView"
     refute File.exists?(Path.join(working_dir, "lib/new.txt"))
@@ -183,6 +198,11 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
              "path" => "lib/edit_target.txt",
              "edits" => [%{"old_text" => "editable", "new_text" => "changed"}]
            }, ":read_failed"},
+          {"apply_diff",
+           %{
+             "path" => "lib/edit_target.txt",
+             "diff" => "@@ -1,1 +1,1 @@\n-editable root text\n+changed\n"
+           }, ":read_failed"},
           {"list_directory", %{"path" => "lib"}, ":list_failed"}
         ] do
       assert {:error, message} = call_tool(tools, name, args)
@@ -223,6 +243,31 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     assert {:ok, changed} = Changeset.read_file(changeset, "lib/edit_target.txt")
     assert changed == "ONE TWO one\n"
     assert File.read!(target_path) == "one two one\n"
+  end
+
+  test "apply_diff through changeset applies unified diffs and leaves real files unchanged",
+       %{tmp_dir: root} do
+    File.mkdir_p!(Path.join(root, "lib"))
+    target_path = Path.join(root, "lib/diff_target.txt")
+    File.write!(target_path, "one\ntwo\n")
+
+    {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
+    tools = Tools.all(project_root: root, changeset: changeset)
+
+    diff = """
+    @@ -1,2 +1,2 @@
+     one
+    -two
+    +TWO
+    """
+
+    assert {:ok, result} =
+             call_tool(tools, "apply_diff", %{"path" => "lib/diff_target.txt", "diff" => diff})
+
+    assert result =~ "via changeset"
+    assert {:ok, changed} = Changeset.read_file(changeset, "lib/diff_target.txt")
+    assert changed == "one\nTWO\n"
+    assert File.read!(target_path) == "one\ntwo\n"
   end
 
   test "dead changeset multi_edit_file returns an unavailable error without mutating the project",

--- a/test/minga_agent/tools_read_only_test.exs
+++ b/test/minga_agent/tools_read_only_test.exs
@@ -13,6 +13,7 @@ defmodule MingaAgent.ToolsReadOnlyTest do
     refute "write_file" in names
     refute "edit_file" in names
     refute "multi_edit_file" in names
+    refute "apply_diff" in names
     refute "delete_file" in names
     refute "shell" in names
     refute "subagent" in names

--- a/test/minga_agent/tools_test.exs
+++ b/test/minga_agent/tools_test.exs
@@ -106,13 +106,14 @@ defmodule MingaAgent.ToolsTest do
   describe "all/1" do
     test "returns the expected number of tools", %{tmp_dir: dir} do
       tools = Tools.all(project_root: dir)
-      assert length(tools) == 26
+      assert length(tools) == 27
 
       names = Enum.map(tools, & &1.name)
       assert "read_file" in names
       assert "write_file" in names
       assert "edit_file" in names
       assert "multi_edit_file" in names
+      assert "apply_diff" in names
       assert "delete_file" in names
       assert "list_directory" in names
       assert "find" in names
@@ -177,6 +178,10 @@ defmodule MingaAgent.ToolsTest do
 
     test "delete_file is destructive by default" do
       assert Tools.destructive?("delete_file")
+    end
+
+    test "apply_diff is destructive by default" do
+      assert Tools.destructive?("apply_diff")
     end
 
     test "read_file is not destructive by default" do


### PR DESCRIPTION
# TL;DR
Adds a destructive `apply_diff` agent tool so large edits can be expressed as unified diffs instead of full-file rewrites or exact-text replacements.

Closes #513

## Context
Issue #513 asks for a native agent tool that accepts unified diff hunks, validates them against current file content, applies them safely, and participates in the existing approval and diff review flows.

## Changes
- Added `MingaAgent.Tools.ApplyDiff`, a unified diff parser and applier for one file at a time.
- Validates hunk counts and context lines before writing, rejects stale diffs, and supports a small fuzz window for nearby line-number drift.
- Handles insertion-only and deletion-only zero-count hunks, and rejects far-out add-only hunks instead of clamping them to EOF.
- Returns clear errors for malformed diffs and explicit unsupported errors for `\ No newline at end of file` markers instead of crashing or silently applying the wrong content.
- Routes through open buffers, ProjectView, changesets, fork stores, and normal filesystem writes using the same tool routing expectations as the other file-editing tools.
- Marks `apply_diff` destructive by default, excludes it from read-only sessions, and adds approval preview and GUI tool summary support.
- Updates Native provider file-change capture so routed file tools, including `apply_diff`, emit before/after content for diff review from the same draft layer the tool edited.

## Verification
- `mix test.debug test/minga_agent/tools/apply_diff_test.exs` PASS
- `mix test.debug test/minga_agent/providers/native_test.exs:615` PASS
- `mix test.llm test/minga_agent/tools test/minga_agent/tools_test.exs test/minga_agent/tools_read_only_test.exs test/minga_agent/tool_approval_test.exs test/minga_agent/config_test.exs test/minga/config/options_test.exs test/minga_agent/ephemeral_session_test.exs` PASS
- `make lint` PASS, with only existing struct-size Credo warnings plus the existing warning category for `Native.LoopCtx`
- `mix test.llm` PASS, 56 doctests, 94 properties, 8613 tests, 0 failures, 275 excluded

## Acceptance Criteria Addressed
- `apply_diff` accepts a file path and unified diff string ✅
- Applies the diff and produces the expected output ✅
- Malformed diffs return clear errors instead of crashes ✅
- Context lines are validated and stale diffs are rejected ✅
- Tool is classified as destructive by default ✅
- Fuzz matching supports nearby line offsets ✅
- Tool integrates with diff review through before/after capture ✅
