### PR TITLE
feat(agent): add optional MCP extension

### DIFF
--- a/lib/minga/config.ex
+++ b/lib/minga/config.ex
@@ -672,9 +672,21 @@ defmodule Minga.Config do
   end
 
   @doc """
+  Declares a built-in extension module to load.
+
+  Built-in optional extensions are already on Minga's code path and do not need a path, git URL, or Hex package.
+
+  ## Examples
+
+      extension Minga.Extensions.MCP
+  """
+  @spec extension(module()) :: :ok
+  def extension(module) when is_atom(module), do: extension(module, [])
+
+  @doc """
   Declares an extension to load.
 
-  Exactly one source must be provided: `path:`, `git:`, or `hex:`.
+  Exactly one source must be provided: `path:`, `git:`, or `hex:`. Built-in extension modules may omit a source.
   Extra keyword options (beyond the source and its options) are passed
   to the extension's `init/1` callback as config.
 
@@ -703,17 +715,27 @@ defmodule Minga.Config do
 
     source_count = Enum.count([has_path, has_git, has_hex], & &1)
 
-    if source_count == 0 do
-      raise ArgumentError,
-            "extension #{name}: one of :path, :git, or :hex is required"
-    end
-
     if source_count > 1 do
       raise ArgumentError,
             "extension #{name}: only one of :path, :git, or :hex can be specified"
     end
 
-    register_extension_source(name, opts, {has_path, has_git, has_hex})
+    case source_count do
+      0 -> register_module_extension(name, opts)
+      1 -> register_extension_source(name, opts, {has_path, has_git, has_hex})
+    end
+  end
+
+  @spec register_module_extension(module(), keyword()) :: :ok
+  defp register_module_extension(module, opts) when is_atom(module) and is_list(opts) do
+    with {:module, ^module} <- Code.ensure_loaded(module),
+         true <- function_exported?(module, :name, 0) do
+      ExtRegistry.register_module(module.name(), module, opts)
+    else
+      _other ->
+        raise ArgumentError,
+              "extension #{inspect(module)}: one of :path, :git, or :hex is required unless the argument is a loaded Minga.Extension module"
+    end
   end
 
   @spec register_extension_source(atom(), keyword(), {boolean(), boolean(), boolean()}) :: :ok
@@ -756,6 +778,40 @@ defmodule Minga.Config do
       {:error, {:invalid_hex_app, app}} ->
         raise ArgumentError,
               "extension #{name}: :app must be a non-nil atom, got: #{inspect(app)}"
+    end
+  end
+
+  @doc """
+  Declares an MCP stdio server for the optional MCP extension.
+
+  The declaration is inert unless `extension Minga.Extensions.MCP` is also enabled. Servers are normalized later by the agent provider and start lazily only when the agent uses an MCP meta-tool.
+
+  ## Examples
+
+      mcp_server "github", command: "npx", args: ["-y", "@modelcontextprotocol/server-github"], env: %{"GITHUB_TOKEN" => "..."}
+  """
+  @spec mcp_server(String.t(), keyword()) :: :ok
+  def mcp_server(name, opts) when is_binary(name) and is_list(opts) do
+    server = options_server()
+    command = Keyword.get(opts, :command)
+
+    unless is_binary(command) and command != "" do
+      raise ArgumentError, "mcp_server #{inspect(name)}: :command must be a non-empty string"
+    end
+
+    config = %{
+      name: name,
+      command: command,
+      args: Keyword.get(opts, :args, []),
+      env: Keyword.get(opts, :env, %{}),
+      enabled: Keyword.get(opts, :enabled, true)
+    }
+
+    current = Options.get(server, :agent_mcp_servers)
+
+    case Options.set(server, :agent_mcp_servers, current ++ [config]) do
+      {:ok, _servers} -> :ok
+      {:error, message} -> raise ArgumentError, "mcp_server #{inspect(name)}: #{message}"
     end
   end
 

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -317,6 +317,7 @@ defmodule Minga.Config.Loader do
       # 4. Eval project-local config
       project_path = resolve_project_config_path()
       project_config_error = eval_if_exists(project_path)
+      project_mcp_error = load_project_mcp_json()
 
       # 5. Eval generated GUI settings overlay
       gui_settings_path = Path.join(config_dir, "gui_settings.exs")
@@ -341,7 +342,13 @@ defmodule Minga.Config.Loader do
           start_all_extensions()
         end
 
-      load_error = merge_error_messages([config_cleanup_error, load_error, start_all_error])
+      load_error =
+        merge_error_messages([
+          config_cleanup_error,
+          load_error,
+          project_mcp_error,
+          start_all_error
+        ])
 
       lsp_settings = Process.get(:minga_config_lsp_settings, %{})
 
@@ -652,6 +659,80 @@ defmodule Minga.Config.Loader do
       end
 
     Path.join([base, "minga", "config.exs"])
+  end
+
+  @spec load_project_mcp_json() :: String.t() | nil
+  defp load_project_mcp_json do
+    path = Path.join([File.cwd!(), ".minga", "mcp.json"])
+
+    if File.exists?(path) do
+      path
+      |> File.read()
+      |> parse_project_mcp_json(path)
+    end
+  end
+
+  @spec parse_project_mcp_json({:ok, String.t()} | {:error, term()}, String.t()) ::
+          String.t() | nil
+  defp parse_project_mcp_json({:ok, content}, path) do
+    case JSON.decode(content) do
+      {:ok, decoded} -> register_project_mcp_servers(decoded)
+      {:error, reason} -> "#{path}: invalid JSON: #{inspect(reason)}"
+    end
+  end
+
+  defp parse_project_mcp_json({:error, reason}, path), do: "#{path}: #{inspect(reason)}"
+
+  @spec register_project_mcp_servers(term()) :: String.t() | nil
+  defp register_project_mcp_servers(%{"mcpServers" => servers}) when is_map(servers) do
+    case normalize_project_mcp_server_entries(servers) do
+      {:ok, entries} -> append_project_mcp_servers(entries)
+      {:error, reason} -> reason
+    end
+  end
+
+  defp register_project_mcp_servers(%{"servers" => servers}) when is_list(servers),
+    do: append_project_mcp_servers(servers)
+
+  defp register_project_mcp_servers(servers) when is_list(servers),
+    do: append_project_mcp_servers(servers)
+
+  defp register_project_mcp_servers(_decoded) do
+    ".minga/mcp.json must contain a mcpServers object, servers list, or server list"
+  end
+
+  @spec normalize_project_mcp_server_entries(map()) :: {:ok, [map()]} | {:error, String.t()}
+  defp normalize_project_mcp_server_entries(servers) when is_map(servers) do
+    Enum.reduce_while(servers, {:ok, []}, fn {name, config}, {:ok, acc} ->
+      if is_map(config) do
+        {:cont, {:ok, [Map.put(config, "name", name) | acc]}}
+      else
+        {:halt,
+         {:error, ".minga/mcp.json mcpServers.#{name} must be a map, got: #{inspect(config)}"}}
+      end
+    end)
+    |> case do
+      {:ok, entries} -> {:ok, Enum.reverse(entries)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec append_project_mcp_servers([map()]) :: String.t() | nil
+  defp append_project_mcp_servers(servers) do
+    case MingaAgent.MCP.ServerConfig.normalize_list(servers) do
+      {:ok, normalized} ->
+        server = Process.get(:minga_config_options, Options.default_server())
+        existing = Options.get(server, :agent_mcp_servers)
+        configs = Enum.map(normalized, &Map.from_struct/1)
+
+        case Options.set(server, :agent_mcp_servers, existing ++ configs) do
+          {:ok, _servers} -> nil
+          {:error, message} -> message
+        end
+
+      {:error, reason} ->
+        reason
+    end
   end
 
   @spec resolve_project_config_path() :: String.t() | nil

--- a/lib/minga/extension.ex
+++ b/lib/minga/extension.ex
@@ -167,7 +167,7 @@ defmodule Minga.Extension do
   if you want those failures converted into load errors instead of propagating.
   """
   @spec manifest(module(), Minga.Extension.Manifest.source_type()) :: Minga.Extension.Manifest.t()
-  def manifest(module, source) when is_atom(module) and source in [:path, :git, :hex] do
+  def manifest(module, source) when is_atom(module) and source in [:path, :git, :hex, :module] do
     Minga.Extension.Manifest.from_module(module, source)
   end
 

--- a/lib/minga/extension/entry.ex
+++ b/lib/minga/extension/entry.ex
@@ -9,7 +9,7 @@ defmodule Minga.Extension.Entry do
   alias Minga.Extension
 
   @typedoc "How the extension source code is obtained."
-  @type source_type :: :path | :git | :hex
+  @type source_type :: :path | :git | :hex | :module
 
   @typedoc "Git-specific source options."
   @type git_opts :: %{
@@ -56,6 +56,12 @@ defmodule Minga.Extension.Entry do
   @spec from_path(String.t(), keyword()) :: t()
   def from_path(path, config) when is_binary(path) and is_list(config) do
     %__MODULE__{source_type: :path, path: path, config: config}
+  end
+
+  @doc "Creates a module-sourced entry for a bundled extension already on the code path."
+  @spec from_module(module(), keyword()) :: t()
+  def from_module(module, config) when is_atom(module) and is_list(config) do
+    %__MODULE__{source_type: :module, module: module, config: config}
   end
 
   @doc "Creates a git-sourced entry."

--- a/lib/minga/extension/manifest.ex
+++ b/lib/minga/extension/manifest.ex
@@ -11,7 +11,7 @@ defmodule Minga.Extension.Manifest do
   @type capabilities :: [Extension.capability_spec()]
 
   @typedoc "How the extension source code is obtained."
-  @type source_type :: :path | :git | :hex
+  @type source_type :: :path | :git | :hex | :module
 
   @enforce_keys [:name, :version, :source]
   defstruct [
@@ -44,7 +44,8 @@ defmodule Minga.Extension.Manifest do
   and turns them into load errors during startup.
   """
   @spec from_module(module(), source_type()) :: t()
-  def from_module(module, source) when is_atom(module) and source in [:path, :git, :hex] do
+  def from_module(module, source)
+      when is_atom(module) and source in [:path, :git, :hex, :module] do
     %__MODULE__{
       name: module.name(),
       description: safe_description(module),

--- a/lib/minga/extension/registry.ex
+++ b/lib/minga/extension/registry.ex
@@ -44,6 +44,22 @@ defmodule Minga.Extension.Registry do
   end
 
   @doc """
+  Registers a module-based built-in extension declaration.
+
+  Called by the config DSL when `extension Minga.Extensions.SomeFeature` is evaluated.
+  The module is already on the Minga code path, so no source compilation is needed.
+  """
+  @spec register_module(atom(), module(), keyword()) :: :ok
+  @spec register_module(GenServer.server(), atom(), module(), keyword()) :: :ok
+  def register_module(name, module, config) when is_atom(name) and is_atom(module),
+    do: register_module(__MODULE__, name, module, config)
+
+  def register_module(server, name, module, config)
+      when is_atom(name) and is_atom(module) and is_list(config) do
+    Agent.update(server, &Map.put(&1, name, Entry.from_module(module, config)))
+  end
+
+  @doc """
   Registers a git-based extension declaration.
 
   Called by the config DSL when `extension :name, git: "..."` is evaluated.

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -252,8 +252,64 @@ defmodule Minga.Extension.Supervisor do
     find_and_start_hex_extension_locked(supervisor, registry, name, entry, opts)
   end
 
+  defp start_current_entry_locked(
+         supervisor,
+         registry,
+         name,
+         %{source_type: :module} = entry,
+         opts
+       ) do
+    start_from_module_locked(supervisor, registry, name, entry, opts)
+  end
+
   defp start_current_entry_locked(supervisor, registry, name, entry, opts) do
     start_from_path_locked(supervisor, registry, name, entry, opts)
+  end
+
+  @spec start_from_module_locked(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts()
+        ) ::
+          {:ok, pid()} | {:error, term()}
+  defp start_from_module_locked(supervisor, registry, name, entry, opts) do
+    cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
+    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
+    module = entry.module
+    mark_start_attempt(registry, name)
+
+    with {:module, ^module} <- Code.ensure_loaded(module),
+         :ok <- validate_behaviour(module, name),
+         :ok <- record_extension_manifest(registry, name, module, entry.source_type),
+         :ok <- register_and_validate_options(name, module, entry.config),
+         {:ok, _state} <-
+           run_lifecycle_phase(name, :init, opts, fn -> call_init(module, entry.config) end) do
+      finalize_extension_start(
+        start_loaded_extension(
+          supervisor,
+          registry,
+          name,
+          module,
+          entry.config,
+          cmd_registry,
+          keymap,
+          opts
+        ),
+        registry,
+        name,
+        cmd_registry,
+        keymap,
+        opts
+      )
+    else
+      {:error, reason} ->
+        msg = "Extension #{name} load error: #{inspect(reason)}"
+        Minga.Log.warning(:config, msg)
+        ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
+        wrap_start_failure(name, reason, cmd_registry, keymap, opts)
+    end
   end
 
   @spec start_from_path_locked(
@@ -1508,17 +1564,21 @@ defmodule Minga.Extension.Supervisor do
 
   @spec finalize_stopped_extension(GenServer.server(), atom(), ExtRegistry.entry()) :: :ok
   defp finalize_stopped_extension(registry, name, entry) do
-    if entry.module do
+    if entry.source_type != :module and entry.module do
       :code.purge(entry.module)
       :code.delete(entry.module)
     end
 
-    ExtRegistry.update(registry, name,
-      status: :stopped,
-      pid: nil,
-      module: nil,
-      lifecycle_ref: nil
-    )
+    update_fields = [status: :stopped, pid: nil, lifecycle_ref: nil]
+
+    update_fields =
+      if entry.source_type == :module do
+        update_fields
+      else
+        [{:module, nil} | update_fields]
+      end
+
+    ExtRegistry.update(registry, name, update_fields)
 
     :ok
   end

--- a/lib/minga/extensions/mcp.ex
+++ b/lib/minga/extensions/mcp.ex
@@ -1,0 +1,49 @@
+defmodule Minga.Extensions.MCP do
+  @moduledoc """
+  Optional MCP extension marker and lifecycle hook.
+
+  MCP support is intentionally opt-in. User config enables this extension with `extension Minga.Extensions.MCP`, then declares stdio servers with `mcp_server/2`. The native agent provider only exposes the lightweight MCP meta-tools while this extension is running, so users who do not enable MCP get no extra tools, no extra prompt text, and no server processes.
+  """
+
+  use Minga.Extension
+
+  @impl true
+  @spec name() :: atom()
+  def name, do: :minga_mcp
+
+  @impl true
+  @spec description() :: String.t()
+  def description, do: "MCP tool server integration"
+
+  @impl true
+  @spec version() :: String.t()
+  def version, do: "0.1.0"
+
+  @impl true
+  @spec init(keyword()) :: {:ok, map()} | {:error, term()}
+  def init(_config), do: {:ok, %{}}
+
+  @impl true
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(_config) do
+    %{
+      id: __MODULE__.Supervisor,
+      start: {__MODULE__.Supervisor, :start_link, [[]]},
+      restart: :permanent,
+      type: :supervisor
+    }
+  end
+
+  @doc "Returns true when the optional MCP extension is currently running."
+  @spec enabled?() :: boolean()
+  def enabled? do
+    case Minga.Extension.Registry.get(name()) do
+      {:ok, %{status: :running}} -> true
+      _other -> false
+    end
+  catch
+    :exit, reason ->
+      Minga.Log.warning(:agent, "MCP extension status unavailable: #{inspect(reason)}")
+      false
+  end
+end

--- a/lib/minga/extensions/mcp/supervisor.ex
+++ b/lib/minga/extensions/mcp/supervisor.ex
@@ -1,0 +1,35 @@
+defmodule Minga.Extensions.MCP.Supervisor do
+  @moduledoc """
+  Dynamic supervisor for MCP clients owned by the optional MCP extension.
+
+  MCP clients are session-scoped, but their processes run under this extension-owned supervisor so server crashes stay isolated and extension shutdown has a single cleanup point.
+  """
+
+  use DynamicSupervisor
+
+  @doc "Starts the MCP client supervisor."
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    DynamicSupervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc "Starts a supervised MCP client."
+  @spec start_client(keyword(), GenServer.server()) :: DynamicSupervisor.on_start_child()
+  def start_client(client_opts, supervisor \\ __MODULE__) when is_list(client_opts) do
+    child_spec = %{
+      id: {MingaAgent.MCP.Client, System.unique_integer([:positive])},
+      start: {MingaAgent.MCP.Client, :start_link, [client_opts]},
+      restart: :temporary,
+      type: :worker
+    }
+
+    DynamicSupervisor.start_child(supervisor, child_spec)
+  end
+
+  @impl DynamicSupervisor
+  @spec init(keyword()) :: {:ok, DynamicSupervisor.sup_flags()}
+  def init(_opts) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/lib/minga_agent/mcp/client.ex
+++ b/lib/minga_agent/mcp/client.ex
@@ -74,7 +74,7 @@ defmodule MingaAgent.MCP.Client do
   @doc "Calls an MCP tool by its original server-declared name."
   @spec call_tool(GenServer.server(), String.t(), map()) :: {:ok, term()} | {:error, term()}
   def call_tool(client, original_name, args) when is_binary(original_name) and is_map(args) do
-    safe_call(client, {:call_tool, original_name, args}, 30_000)
+    safe_call(client, {:call_tool, original_name, args}, :infinity)
   end
 
   @impl GenServer

--- a/lib/minga_agent/mcp/registry.ex
+++ b/lib/minga_agent/mcp/registry.ex
@@ -38,6 +38,7 @@ defmodule MingaAgent.MCP.Registry do
           | {:request_timeout, timeout()}
           | {:notify_pid, pid()}
           | {:reserved_tool_names, [tool_name()]}
+          | {:supervisor, GenServer.server() | nil}
 
   @doc "Starts all enabled MCP servers and returns the registry, tools, and startup failure messages."
   @spec start_all([ServerConfig.t()], pid(), [start_opt()]) :: {t(), [Tool.t()], [String.t()]}
@@ -65,6 +66,45 @@ defmodule MingaAgent.MCP.Registry do
   @spec new() :: t()
   def new, do: %__MODULE__{clients: %{}}
 
+  @doc "Starts one MCP server if needed and returns the client pid."
+  @spec ensure_server(t(), ServerConfig.t(), pid(), [start_opt()]) ::
+          {:ok, t(), pid()} | {:error, String.t()}
+  def ensure_server(
+        %__MODULE__{} = registry,
+        %ServerConfig{name: server_name} = config,
+        subscriber,
+        opts \\ []
+      )
+      when is_pid(subscriber) do
+    case client_for_server(registry, server_name) do
+      {:ok, pid} ->
+        {:ok, registry, pid}
+
+      :error ->
+        case start_one(config, subscriber, opts) do
+          {:ok, client, client_tools} ->
+            {registry, _client_tools, _seen} =
+              add_client(registry, config.name, client, client_tools, MapSet.new())
+
+            {:ok, registry, client}
+
+          {:error, message} ->
+            {:error, message}
+        end
+    end
+  end
+
+  @doc "Returns the client pid for a started MCP server."
+  @spec client_for_server(t() | nil, String.t()) :: {:ok, pid()} | :error
+  def client_for_server(nil, _server_name), do: :error
+
+  def client_for_server(%__MODULE__{} = registry, server_name) when is_binary(server_name) do
+    case Map.fetch(registry.clients, server_name) do
+      {:ok, %{pid: pid}} -> {:ok, pid}
+      :error -> :error
+    end
+  end
+
   @doc "Returns the server name for a monitored client pid."
   @spec server_for_pid(t() | nil, pid()) :: String.t() | nil
   def server_for_pid(nil, _pid), do: nil
@@ -86,7 +126,7 @@ defmodule MingaAgent.MCP.Registry do
 
       {%{pid: pid, ref: ref, tool_names: tool_names}, clients} ->
         Process.demonitor(ref, [:flush])
-        stop_client(pid)
+        stop_client(pid, server_name)
         {%{registry | clients: clients}, tool_names}
     end
   end
@@ -96,9 +136,9 @@ defmodule MingaAgent.MCP.Registry do
   def stop_all(nil), do: :ok
 
   def stop_all(%__MODULE__{} = registry) do
-    Enum.each(registry.clients, fn {_server_name, %{pid: pid, ref: ref}} ->
+    Enum.each(registry.clients, fn {server_name, %{pid: pid, ref: ref}} ->
       Process.demonitor(ref, [:flush])
-      stop_client(pid)
+      stop_client(pid, server_name)
     end)
 
     :ok
@@ -163,12 +203,26 @@ defmodule MingaAgent.MCP.Registry do
       request_timeout: Keyword.get(opts, :request_timeout, 5_000)
     ]
 
-    case MCPClient.start(client_opts) do
+    case start_client(
+           client_opts,
+           Keyword.get(opts, :supervisor, Minga.Extensions.MCP.Supervisor)
+         ) do
       {:ok, client} ->
         tools_for_started_client(client, config, subscriber)
 
       {:error, reason} ->
         {:error, notify_start_failure(subscriber, config.name, reason)}
+    end
+  end
+
+  @spec start_client(keyword(), GenServer.server() | nil) :: GenServer.on_start()
+  defp start_client(client_opts, nil), do: MCPClient.start(client_opts)
+
+  defp start_client(client_opts, supervisor) do
+    if is_atom(supervisor) and Process.whereis(supervisor) == nil do
+      MCPClient.start(client_opts)
+    else
+      Minga.Extensions.MCP.Supervisor.start_client(client_opts, supervisor)
     end
   end
 
@@ -180,7 +234,7 @@ defmodule MingaAgent.MCP.Registry do
         {:ok, client, tools}
 
       {:error, reason} ->
-        stop_client(client)
+        stop_client(client, config.name)
         {:error, notify_start_failure(subscriber, config.name, reason)}
     end
   end
@@ -195,12 +249,18 @@ defmodule MingaAgent.MCP.Registry do
     message
   end
 
-  @spec stop_client(pid()) :: :ok
-  defp stop_client(pid) when is_pid(pid) do
+  @spec stop_client(pid(), String.t() | nil) :: :ok
+  defp stop_client(pid, server_name) when is_pid(pid) do
     GenServer.stop(pid, :normal, 1_000)
     :ok
   catch
-    :exit, _ -> :ok
+    :exit, reason ->
+      Minga.Log.warning(
+        :agent,
+        "MCP server #{server_name || inspect(pid)} stop failed: #{inspect(reason)}"
+      )
+
+      :ok
   end
 
   @spec format_error(term()) :: String.t()

--- a/lib/minga_agent/mcp/stdio_transport.ex
+++ b/lib/minga_agent/mcp/stdio_transport.ex
@@ -15,6 +15,9 @@ defmodule MingaAgent.MCP.StdioTransport do
   defstruct [:port]
 
   @type t :: %__MODULE__{port: port()}
+  @typep env_value :: charlist() | false
+  @typep env_entry :: {charlist(), env_value()}
+  @allowlisted_env_keys ~w(PATH HOME LANG LANGUAGE LC_ALL SSL_CERT_FILE SSL_CERT_DIR TMPDIR TEMP TMP XDG_RUNTIME_DIR)
 
   @impl MingaAgent.MCP.Transport
   @spec start(ServerConfig.t(), pid(), keyword()) :: {:ok, t()} | {:error, term()}
@@ -26,7 +29,7 @@ defmodule MingaAgent.MCP.StdioTransport do
         :use_stdio,
         {:line, 65_536},
         {:args, config.args},
-        {:env, env_to_charlists(config.env)}
+        {:env, port_env(config)}
       ]
 
       {:ok, %__MODULE__{port: Port.open({:spawn_executable, executable}, port_opts)}}
@@ -79,10 +82,47 @@ defmodule MingaAgent.MCP.StdioTransport do
     end
   end
 
-  @spec env_to_charlists(%{String.t() => String.t()}) :: [{charlist(), charlist()}]
-  defp env_to_charlists(env) do
-    Enum.map(env, fn {key, value} -> {String.to_charlist(key), String.to_charlist(value)} end)
+  @doc false
+  @spec port_env(ServerConfig.t()) :: [env_entry()]
+  def port_env(%ServerConfig{} = config), do: port_env(config, System.get_env())
+
+  @doc false
+  @spec port_env(ServerConfig.t(), %{String.t() => String.t()}) :: [env_entry()]
+  def port_env(%ServerConfig{env: env}, inherited_env) when is_map(inherited_env) do
+    explicit_env = Map.new(env)
+
+    inherited_allowlist =
+      inherited_env
+      |> Enum.filter(fn {key, _value} -> allowlisted_env_key?(key) end)
+      |> Map.new()
+
+    merged_env = Map.merge(inherited_allowlist, explicit_env)
+    unallowed_inherited = disallowed_inherited_env(inherited_env, explicit_env)
+
+    merged_env
+    |> Enum.map(&to_env_entry/1)
+    |> Kernel.++(unallowed_inherited)
+    |> Enum.sort_by(&elem(&1, 0))
   end
+
+  @spec disallowed_inherited_env(%{String.t() => String.t()}, %{String.t() => String.t()}) :: [
+          env_entry()
+        ]
+  defp disallowed_inherited_env(inherited_env, explicit_env) do
+    inherited_env
+    |> Enum.reject(fn {key, _value} ->
+      allowlisted_env_key?(key) or Map.has_key?(explicit_env, key)
+    end)
+    |> Enum.map(fn {key, _value} -> {String.to_charlist(key), false} end)
+  end
+
+  @spec allowlisted_env_key?(String.t()) :: boolean()
+  defp allowlisted_env_key?(key) do
+    key in @allowlisted_env_keys or String.starts_with?(key, "LC_")
+  end
+
+  @spec to_env_entry({String.t(), String.t()}) :: env_entry()
+  defp to_env_entry({key, value}), do: {String.to_charlist(key), String.to_charlist(value)}
 
   @spec write_message(port(), map()) :: :ok | {:error, term()}
   defp write_message(port, message) do

--- a/lib/minga_agent/provider.ex
+++ b/lib/minga_agent/provider.ex
@@ -49,6 +49,7 @@ defmodule MingaAgent.Provider do
           optional(:thinking_level) => String.t() | nil,
           optional(:active_skill_names) => [String.t()],
           optional(:project_root) => String.t() | nil,
+          optional(:mcp_status) => [map()],
           model: model_info() | String.t() | nil,
           is_streaming: boolean(),
           token_usage: Event.token_usage() | nil

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -171,6 +171,10 @@ defmodule MingaAgent.Providers.Native do
           mcp_tools: [term()],
           internal_tools: [term()],
           custom_tools?: boolean(),
+          mcp_configs: [MCPServerConfig.t()],
+          mcp_client_opts: keyword(),
+          mcp_enabled_override: boolean() | nil,
+          mcp_errors: %{String.t() => String.t()},
           mcp_registry: MCPRegistry.t() | nil,
           read_only?: boolean()
         }
@@ -363,14 +367,11 @@ defmodule MingaAgent.Providers.Native do
     custom_tools? = Keyword.has_key?(opts, :tools)
     active_skills = load_active_skills(project_root, Keyword.get(opts, :active_skill_names, []))
     internal_tools = if read_only?, do: [], else: build_internal_tools(provider_pid)
-    reserved_tool_names = Enum.map(base_tools ++ internal_tools, & &1.name)
-
-    {mcp_registry, mcp_tools} =
-      if read_only? do
-        {nil, []}
-      else
-        start_mcp_servers(opts, config, subscriber, reserved_tool_names)
-      end
+    mcp_configs = configured_mcp_servers(opts, config, subscriber, read_only?)
+    mcp_client_opts = mcp_client_opts(opts)
+    mcp_enabled_override = Keyword.get(opts, :mcp_enabled?, nil)
+    mcp_registry = mcp_registry_for(mcp_configs)
+    mcp_tools = mcp_meta_tools_for(mcp_configs, provider_pid)
 
     tools =
       (base_tools ++ mcp_tools ++ internal_tools)
@@ -415,6 +416,10 @@ defmodule MingaAgent.Providers.Native do
       mcp_tools: mcp_tools,
       internal_tools: internal_tools,
       custom_tools?: custom_tools?,
+      mcp_configs: mcp_configs,
+      mcp_client_opts: mcp_client_opts,
+      mcp_enabled_override: mcp_enabled_override,
+      mcp_errors: %{},
       mcp_registry: mcp_registry,
       read_only?: read_only?
     }
@@ -648,7 +653,8 @@ defmodule MingaAgent.Providers.Native do
       system_prompt: system_prompt,
       thinking_level: state.thinking_level,
       active_skill_names: Enum.map(state.active_skills, & &1.name),
-      project_root: state.project_root
+      project_root: state.project_root,
+      mcp_status: mcp_status(state)
     }
 
     {:reply, {:ok, session_state}, state}
@@ -755,6 +761,18 @@ defmodule MingaAgent.Providers.Native do
   def handle_call({:set_model, model}, _from, state) do
     Minga.Log.info(:agent, "[Agent.Native] model set to #{model}")
     {:reply, :ok, %{state | model: model}}
+  end
+
+  def handle_call(:list_mcp_tools, _from, state) do
+    {reply, state} = with_enabled_mcp(state, &list_mcp_tools_for_agent/1)
+    {:reply, reply, state}
+  end
+
+  def handle_call({:call_mcp_tool, server_name, tool_name, args}, _from, state) do
+    {reply, state} =
+      with_enabled_mcp(state, &call_mcp_tool_for_agent(&1, server_name, tool_name, args || %{}))
+
+    {:reply, reply, state}
   end
 
   def handle_call({:refresh_project_view, project_view}, _from, state) do
@@ -916,40 +934,255 @@ defmodule MingaAgent.Providers.Native do
     :exit, _ -> :ok
   end
 
-  @spec start_mcp_servers(keyword(), AgentConfig.t(), pid(), [String.t()]) ::
-          {MCPRegistry.t() | nil, [term()]}
-  defp start_mcp_servers(opts, config, subscriber, reserved_tool_names) do
-    server_configs = Keyword.get(opts, :mcp_servers, config.mcp_servers)
-
-    case MCPServerConfig.normalize_list(server_configs) do
-      {:ok, []} ->
-        {nil, []}
-
-      {:ok, normalized} ->
-        registry_opts = [
-          transport: Keyword.get(opts, :mcp_transport, MingaAgent.MCP.StdioTransport),
-          transport_opts: Keyword.get(opts, :mcp_transport_opts, []),
-          notify_pid: self(),
-          request_timeout: Keyword.get(opts, :mcp_request_timeout, 5_000),
-          reserved_tool_names: reserved_tool_names
+  @spec configured_mcp_servers(keyword(), AgentConfig.t(), pid(), boolean()) :: [
+          MCPServerConfig.t()
         ]
+  defp configured_mcp_servers(_opts, _config, _subscriber, true), do: []
 
-        {registry, tools, _failures} =
-          MCPRegistry.start_all(normalized, subscriber, registry_opts)
+  defp configured_mcp_servers(opts, config, subscriber, false) do
+    if mcp_extension_enabled?(opts) do
+      server_configs = Keyword.get(opts, :mcp_servers, config.mcp_servers)
 
-        {registry, tools}
+      case MCPServerConfig.normalize_list(server_configs) do
+        {:ok, normalized} ->
+          normalized
+
+        {:error, reason} ->
+          notify(subscriber, %Event.Error{message: "MCP config error: #{reason}"})
+          []
+      end
+    else
+      []
+    end
+  end
+
+  @spec mcp_extension_enabled?(keyword()) :: boolean()
+  defp mcp_extension_enabled?(opts) do
+    Keyword.get_lazy(opts, :mcp_enabled?, fn -> Minga.Extensions.MCP.enabled?() end)
+  end
+
+  @spec mcp_registry_for([MCPServerConfig.t()]) :: MCPRegistry.t() | nil
+  defp mcp_registry_for([]), do: nil
+  defp mcp_registry_for(_configs), do: MCPRegistry.new()
+
+  @spec mcp_meta_tools_for([MCPServerConfig.t()], pid()) :: [ReqLLM.Tool.t()]
+  defp mcp_meta_tools_for([], _provider_pid), do: []
+  defp mcp_meta_tools_for(_configs, provider_pid), do: build_mcp_meta_tools(provider_pid)
+
+  @spec mcp_status(map()) :: [map()]
+  defp mcp_status(state) do
+    Enum.map(state.mcp_configs, fn config ->
+      status = mcp_server_status(state, config.name)
+
+      %{
+        "name" => config.name,
+        "status" => Atom.to_string(status),
+        "error" => Map.get(state.mcp_errors, config.name)
+      }
+    end)
+  end
+
+  @spec mcp_server_status(map(), String.t()) :: :not_started | :running | :errored
+  defp mcp_server_status(state, server_name) do
+    case {Map.has_key?(state.mcp_errors, server_name),
+          MCPRegistry.client_for_server(state.mcp_registry, server_name)} do
+      {true, _client} -> :errored
+      {false, {:ok, _pid}} -> :running
+      {false, :error} -> :not_started
+    end
+  end
+
+  @spec mcp_client_opts(keyword()) :: keyword()
+  defp mcp_client_opts(opts) do
+    [
+      transport: Keyword.get(opts, :mcp_transport, MingaAgent.MCP.StdioTransport),
+      transport_opts: Keyword.get(opts, :mcp_transport_opts, []),
+      notify_pid: self(),
+      request_timeout: Keyword.get(opts, :mcp_request_timeout, 5_000)
+    ]
+  end
+
+  @spec build_mcp_meta_tools(pid()) :: [ReqLLM.Tool.t()]
+  defp build_mcp_meta_tools(provider_pid) when is_pid(provider_pid) do
+    [
+      ReqLLM.Tool.new!(
+        name: "list_mcp_tools",
+        description:
+          "List available tools from configured MCP servers on demand. Use this when built-in tools do not cover the capability you need. This starts MCP servers lazily and returns server names, tool names, and short descriptions without adding every MCP tool to the system prompt.",
+        parameter_schema: %{"type" => "object", "properties" => %{}},
+        callback: fn _args -> GenServer.call(provider_pid, :list_mcp_tools, :infinity) end
+      ),
+      ReqLLM.Tool.new!(
+        name: "call_mcp_tool",
+        description:
+          "Call a tool from a configured MCP server by server name and tool name. Use list_mcp_tools first if you do not know the available server and tool names. MCP tool calls use the same approval flow as other destructive tools and default to ask approval.",
+        parameter_schema: %{
+          "type" => "object",
+          "properties" => %{
+            "server" => %{"type" => "string", "description" => "Configured MCP server name"},
+            "tool" => %{
+              "type" => "string",
+              "description" => "Original MCP tool name from that server"
+            },
+            "arguments" => %{
+              "type" => "object",
+              "description" => "Arguments to pass to the MCP tool"
+            }
+          },
+          "required" => ["server", "tool"]
+        },
+        callback: fn args ->
+          GenServer.call(
+            provider_pid,
+            {:call_mcp_tool, args["server"], args["tool"], Map.get(args, "arguments", %{})},
+            :infinity
+          )
+        end
+      )
+    ]
+  end
+
+  @spec with_enabled_mcp(map(), (map() -> {{:ok, term()} | {:error, term()}, map()})) ::
+          {{:ok, term()} | {:error, term()}, map()}
+  defp with_enabled_mcp(state, fun) when is_function(fun, 1) do
+    if mcp_enabled_for_state?(state) do
+      fun.(state)
+    else
+      {{:error, "MCP extension is disabled"}, disable_mcp_in_state(state)}
+    end
+  end
+
+  @spec mcp_enabled_for_state?(map()) :: boolean()
+  defp mcp_enabled_for_state?(%{mcp_enabled_override: override}) when is_boolean(override),
+    do: override
+
+  defp mcp_enabled_for_state?(_state), do: Minga.Extensions.MCP.enabled?()
+
+  @spec disable_mcp_in_state(map()) :: map()
+  defp disable_mcp_in_state(state) do
+    cleanup_mcp(state.mcp_registry)
+
+    tools = Enum.reject(state.tools, &(&1.name in ["list_mcp_tools", "call_mcp_tool"]))
+
+    %{state | mcp_configs: [], mcp_registry: nil, mcp_tools: [], mcp_errors: %{}, tools: tools}
+  end
+
+  @spec list_mcp_tools_for_agent(map()) :: {{:ok, term()} | {:error, term()}, map()}
+  defp list_mcp_tools_for_agent(%{mcp_configs: []} = state), do: {{:ok, []}, state}
+
+  defp list_mcp_tools_for_agent(state) do
+    {servers, failures, state} = ensure_all_mcp_servers(state)
+
+    tool_entries =
+      Enum.flat_map(servers, fn {server_name, client} ->
+        list_mcp_client_tools(server_name, client)
+      end)
+
+    failure_entries =
+      Enum.map(failures, fn {server_name, reason} ->
+        %{"server" => server_name, "error" => reason}
+      end)
+
+    reply = list_mcp_tools_reply(tool_entries, failure_entries)
+
+    {reply, state}
+  end
+
+  @spec list_mcp_tools_reply([map()], [map()]) :: {:ok, term()} | {:error, String.t()}
+  defp list_mcp_tools_reply([], []), do: {:ok, "No MCP tools are available."}
+
+  defp list_mcp_tools_reply([], failures) do
+    message =
+      failures
+      |> Enum.map_join("; ", fn %{"server" => server_name, "error" => reason} ->
+        "#{server_name}: #{reason}"
+      end)
+
+    {:error, "MCP servers failed to start: #{message}"}
+  end
+
+  defp list_mcp_tools_reply(tools, failures), do: {:ok, failures ++ tools}
+
+  @spec list_mcp_client_tools(String.t(), pid()) :: [map()]
+  defp list_mcp_client_tools(server_name, client) do
+    case MingaAgent.MCP.Client.list_tools(client) do
+      {:ok, tools} ->
+        Enum.map(tools, fn tool ->
+          %{
+            "server" => server_name,
+            "name" => tool.name,
+            "description" => String.split(tool.description, "\n") |> List.first() || ""
+          }
+        end)
 
       {:error, reason} ->
-        notify(subscriber, %Event.Error{message: "MCP config error: #{reason}"})
-        {nil, []}
+        [%{"server" => server_name, "error" => format_error(reason)}]
+    end
+  end
+
+  @spec call_mcp_tool_for_agent(map(), term(), term(), term()) ::
+          {{:ok, term()} | {:error, term()}, map()}
+  defp call_mcp_tool_for_agent(state, server_name, tool_name, args)
+       when is_binary(server_name) and is_binary(tool_name) and is_map(args) do
+    case ensure_mcp_server(state, server_name) do
+      {{:ok, client}, state} ->
+        {MingaAgent.MCP.Client.call_tool(client, tool_name, args), state}
+
+      {{:error, reason}, state} ->
+        {{:error, reason}, state}
+    end
+  end
+
+  defp call_mcp_tool_for_agent(state, _server_name, _tool_name, _args) do
+    {{:error, "call_mcp_tool requires string server, string tool, and object arguments"}, state}
+  end
+
+  @spec ensure_all_mcp_servers(map()) ::
+          {[{String.t(), pid()}], [{String.t(), String.t()}], map()}
+  defp ensure_all_mcp_servers(state) do
+    Enum.reduce(state.mcp_configs, {[], [], state}, fn config, {servers, failures, state} ->
+      case ensure_mcp_server(state, config.name) do
+        {{:ok, client}, state} -> {[{config.name, client} | servers], failures, state}
+        {{:error, reason}, state} -> {servers, [{config.name, reason} | failures], state}
+      end
+    end)
+    |> then(fn {servers, failures, state} ->
+      {Enum.reverse(servers), Enum.reverse(failures), state}
+    end)
+  end
+
+  @spec ensure_mcp_server(map(), String.t()) :: {{:ok, pid()} | {:error, String.t()}, map()}
+  defp ensure_mcp_server(state, server_name) do
+    case Enum.find(state.mcp_configs, &(&1.name == server_name)) do
+      nil ->
+        {{:error, "Unknown MCP server #{server_name}"}, state}
+
+      config ->
+        case MCPRegistry.ensure_server(
+               state.mcp_registry || MCPRegistry.new(),
+               config,
+               state.subscriber,
+               state.mcp_client_opts
+             ) do
+          {:ok, registry, client} ->
+            errors = Map.delete(state.mcp_errors, config.name)
+            {{:ok, client}, %{state | mcp_registry: registry, mcp_errors: errors}}
+
+          {:error, reason} ->
+            {{:error, reason}, put_in(state, [:mcp_errors, config.name], reason)}
+        end
     end
   end
 
   @spec remove_mcp_server_tools(map(), String.t()) :: map()
   defp remove_mcp_server_tools(state, server_name) do
-    {registry, removed_tool_names} = MCPRegistry.remove_server(state.mcp_registry, server_name)
-    tools = Enum.reject(state.tools, &(&1.name in removed_tool_names))
-    %{state | tools: tools, mcp_registry: registry}
+    {registry, _removed_tool_names} = MCPRegistry.remove_server(state.mcp_registry, server_name)
+
+    %{
+      state
+      | mcp_registry: registry,
+        mcp_errors: Map.put(state.mcp_errors, server_name, "stopped")
+    }
   end
 
   @spec rebuild_tools(map()) :: map()

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -104,6 +104,8 @@ defmodule MingaAgent.Tools do
     args["apply"] != nil
   end
 
+  def destructive?("list_mcp_tools", _args, _destructive_list), do: true
+  def destructive?("call_mcp_tool", _args, _destructive_list), do: true
   def destructive?("mcp_" <> _rest, _args, _destructive_list), do: true
 
   def destructive?(name, _args, destructive_list) when is_list(destructive_list) do

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -40,6 +40,7 @@ defmodule MingaEditor.Agent.SlashCommand do
     },
     %Command{name: "model", description: "Set the model: /model <name>"},
     %Command{name: "trust", description: "Manage tool trust: /trust list|revoke <tool>|clear"},
+    %Command{name: "mcp", description: "Show configured MCP servers and lazy status"},
     %Command{name: "help", description: "Show available slash commands"},
     %Command{name: "plan", description: "Enter plan mode (destructive tools blocked)"},
     %Command{name: "exec", description: "Leave plan mode and allow execution"},
@@ -132,6 +133,7 @@ defmodule MingaEditor.Agent.SlashCommand do
   defp dispatch(state, "thinking", args), do: {:ok, do_thinking(state, args)}
   defp dispatch(state, "model", args), do: do_model(state, args)
   defp dispatch(state, "trust", args), do: do_trust(state, args)
+  defp dispatch(state, "mcp", _args), do: {:ok, do_mcp(state)}
   defp dispatch(state, "help", _args), do: {:ok, do_help(state)}
   defp dispatch(state, "?", _args), do: {:ok, do_help(state)}
   defp dispatch(state, "plan", _args), do: do_plan(state)
@@ -209,6 +211,79 @@ defmodule MingaEditor.Agent.SlashCommand do
     state = AgentCommands.set_model(state, model)
     {:ok, state}
   end
+
+  @spec do_mcp(state()) :: state()
+  defp do_mcp(state) do
+    emit_system_message(state, mcp_status_message(state))
+  end
+
+  @spec mcp_status_message(state()) :: String.t()
+  defp mcp_status_message(state) do
+    enabled = Minga.Extensions.MCP.enabled?()
+
+    case MingaAgent.MCP.ServerConfig.normalize_list(Config.get(:agent_mcp_servers)) do
+      {:ok, []} ->
+        "MCP extension: #{mcp_enabled_label(enabled)}\nNo MCP servers configured."
+
+      {:ok, servers} ->
+        lines = Enum.map(mcp_live_or_configured_status(state, servers), &mcp_server_status_line/1)
+        "MCP extension: #{mcp_enabled_label(enabled)}\n" <> Enum.join(lines, "\n")
+
+      {:error, reason} ->
+        "MCP extension: #{mcp_enabled_label(enabled)}\nConfig error: #{reason}"
+    end
+  rescue
+    error ->
+      message = "MCP status unavailable: #{Exception.message(error)}"
+      Minga.Log.warning(:agent, message)
+      message
+  catch
+    :exit, reason ->
+      message = "MCP status unavailable: #{inspect(reason)}"
+      Minga.Log.warning(:agent, message)
+      message
+  end
+
+  @spec mcp_enabled_label(boolean()) :: String.t()
+  defp mcp_enabled_label(true), do: "enabled"
+  defp mcp_enabled_label(false), do: "disabled"
+
+  @spec mcp_live_or_configured_status(state(), [MingaAgent.MCP.ServerConfig.t()]) :: [map()]
+  defp mcp_live_or_configured_status(state, servers) do
+    case active_provider_mcp_status(state) do
+      {:ok, statuses} ->
+        statuses
+
+      :error ->
+        Enum.map(servers, &%{"name" => &1.name, "status" => "not_started", "error" => nil})
+    end
+  end
+
+  @spec active_provider_mcp_status(state()) :: {:ok, [map()]} | :error
+  defp active_provider_mcp_status(state) do
+    with {:ok, session} <- require_session(state),
+         provider when is_pid(provider) <- Session.get_provider(session),
+         {:ok, %{mcp_status: status}} <- MingaAgent.Providers.Native.get_state(provider) do
+      {:ok, status}
+    else
+      _other -> :error
+    end
+  catch
+    :exit, _ -> :error
+  end
+
+  @spec mcp_server_status_line(map()) :: String.t()
+  defp mcp_server_status_line(%{"name" => name, "status" => "errored", "error" => error}) do
+    "- #{name}: errored#{mcp_error_suffix(error)}"
+  end
+
+  defp mcp_server_status_line(%{"name" => name, "status" => status}) do
+    "- #{name}: #{status}"
+  end
+
+  @spec mcp_error_suffix(String.t() | nil) :: String.t()
+  defp mcp_error_suffix(nil), do: ""
+  defp mcp_error_suffix(error), do: " (#{error})"
 
   @spec do_trust(state(), String.t()) :: {:ok, state()} | {:error, String.t()}
   defp do_trust(state, args) do

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -105,6 +105,30 @@ defmodule Minga.Config.LoaderTest do
       assert Options.get(test_options_server(), :tab_width) == 4
       assert Options.get(test_options_server(), :line_numbers) == :relative
     end
+
+    test "loads the built-in MCP extension and mcp_server DSL" do
+      {_dir, cleanup} =
+        make_config_dir("""
+        use Minga.Config
+
+        extension Minga.Extensions.MCP
+        mcp_server "github", command: "npx", args: ["-y", "@modelcontextprotocol/server-github"], env: %{"GITHUB_TOKEN" => "token"}
+        """)
+
+      on_exit(cleanup)
+
+      name = :"loader_mcp_#{System.unique_integer([:positive])}"
+      {:ok, pid} = Loader.start_link(name: name)
+
+      assert Loader.load_error(pid) == nil
+      assert {:ok, entry} = ExtRegistry.get(:minga_mcp)
+      assert entry.source_type == :module
+      assert entry.module == Minga.Extensions.MCP
+
+      assert [server] = Options.get(test_options_server(), :agent_mcp_servers)
+      assert (Map.get(server, :name) || Map.get(server, "name")) == "github"
+      assert (Map.get(server, :command) || Map.get(server, "command")) == "npx"
+    end
   end
 
   test "registers bundled Board extension from packaged priv path" do
@@ -509,6 +533,66 @@ defmodule Minga.Config.LoaderTest do
 
       assert Loader.project_config_error(pid) == nil
       assert Options.get(test_options_server(), :tab_width) == 8
+    end
+
+    test "loads project-local .minga/mcp.json" do
+      {_dir, cleanup} = make_config_dir("use Minga.Config\n")
+
+      project_dir =
+        Path.join(System.tmp_dir!(), "minga_mcp_json_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(Path.join(project_dir, ".minga"))
+
+      File.write!(
+        Path.join([project_dir, ".minga", "mcp.json"]),
+        ~s({"mcpServers":{"github":{"command":"npx","args":["-y","@modelcontextprotocol/server-github"],"env":{"GITHUB_TOKEN":"token"}}}})
+      )
+
+      original_cwd = File.cwd!()
+      File.cd!(project_dir)
+
+      on_exit(fn ->
+        File.cd!(original_cwd)
+        cleanup.()
+        File.rm_rf!(project_dir)
+      end)
+
+      name = :"loader_project_mcp_#{System.unique_integer([:positive])}"
+      {:ok, pid} = Loader.start_link(name: name)
+
+      assert Loader.load_error(pid) == nil
+      assert [server] = Options.get(test_options_server(), :agent_mcp_servers)
+      assert (Map.get(server, :name) || Map.get(server, "name")) == "github"
+      assert (Map.get(server, :command) || Map.get(server, "command")) == "npx"
+    end
+
+    test "reports a clear error when mcpServers contains a non-map value" do
+      {_dir, cleanup} = make_config_dir("use Minga.Config\n")
+
+      project_dir =
+        Path.join(System.tmp_dir!(), "minga_mcp_json_bad_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(Path.join(project_dir, ".minga"))
+
+      File.write!(
+        Path.join([project_dir, ".minga", "mcp.json"]),
+        ~s({"mcpServers":{"github":42}})
+      )
+
+      original_cwd = File.cwd!()
+      File.cd!(project_dir)
+
+      on_exit(fn ->
+        File.cd!(original_cwd)
+        cleanup.()
+        File.rm_rf!(project_dir)
+      end)
+
+      name = :"loader_project_mcp_bad_#{System.unique_integer([:positive])}"
+      {:ok, pid} = Loader.start_link(name: name)
+
+      assert Loader.load_error(pid) =~ ".minga/mcp.json mcpServers.github must be a map, got: 42"
+      assert Options.get(test_options_server(), :agent_mcp_servers) == []
     end
 
     test "no error when .minga.exs does not exist" do

--- a/test/minga/extension/registry_test.exs
+++ b/test/minga/extension/registry_test.exs
@@ -38,6 +38,20 @@ defmodule Minga.Extension.RegistryTest do
     end
   end
 
+  describe "register_module/4" do
+    test "registers a built-in module extension", %{registry: r} do
+      :ok = Registry.register_module(r, :minga_mcp, Minga.Extensions.MCP, [])
+
+      assert {:ok, %Entry{} = entry} = Registry.get(r, :minga_mcp)
+      assert entry.source_type == :module
+      assert entry.module == Minga.Extensions.MCP
+      assert entry.config == []
+      assert entry.path == nil
+      assert entry.git == nil
+      assert entry.hex == nil
+    end
+  end
+
   describe "register_git/4" do
     test "registers a git extension with defaults", %{registry: r} do
       :ok = Registry.register_git(r, :my_ext, "https://github.com/user/repo", [])

--- a/test/minga/extension/supervisor_test.exs
+++ b/test/minga/extension/supervisor_test.exs
@@ -471,6 +471,34 @@ defmodule Minga.Extension.SupervisorTest do
       assert stopped.pid == nil
       assert stopped.module == nil
     end
+
+    test "stops a module-sourced extension without purging its module", ctx do
+      :ok = ExtRegistry.register_module(ctx.registry, :minga_mcp, Minga.Extensions.MCP, [])
+      {:ok, entry} = ExtRegistry.get(ctx.registry, :minga_mcp)
+
+      assert {:ok, pid} =
+               ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, :minga_mcp, entry)
+
+      assert Process.alive?(pid)
+      assert :code.is_loaded(Minga.Extensions.MCP) != false
+
+      {:ok, running_entry} = ExtRegistry.get(ctx.registry, :minga_mcp)
+      :ok = ExtSupervisor.stop_extension(ctx.supervisor, ctx.registry, :minga_mcp, running_entry)
+
+      refute Process.alive?(pid)
+
+      {:ok, stopped} = ExtRegistry.get(ctx.registry, :minga_mcp)
+      assert stopped.status == :stopped
+      assert stopped.pid == nil
+      assert stopped.module == Minga.Extensions.MCP
+      assert :code.is_loaded(Minga.Extensions.MCP) != false
+
+      assert {:ok, restarted_pid} =
+               ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, :minga_mcp, stopped)
+
+      assert restarted_pid != pid
+      refute restarted_pid == nil
+    end
   end
 
   describe "start_all/2 and stop_all/2" do

--- a/test/minga_agent/mcp/registry_test.exs
+++ b/test/minga_agent/mcp/registry_test.exs
@@ -48,6 +48,27 @@ defmodule MingaAgent.MCP.RegistryTest do
     Registry.stop_all(registry)
   end
 
+  test "starts clients under the optional MCP supervisor when available" do
+    supervisor = start_supervised!({Minga.Extensions.MCP.Supervisor, name: nil})
+
+    {registry, tools, failures} =
+      Registry.start_all([config("Alpha")], self(),
+        transport: FakeTransport,
+        transport_opts: [tools: [tool("echo-text")], test_pid: self()],
+        notify_pid: self(),
+        supervisor: supervisor
+      )
+
+    assert failures == []
+    assert [_tool] = tools
+    assert {:ok, client} = Registry.client_for_server(registry, "Alpha")
+
+    children = DynamicSupervisor.which_children(supervisor)
+    assert Enum.any?(children, fn {_id, pid, _type, _modules} -> pid == client end)
+
+    Registry.stop_all(registry)
+  end
+
   test "renames cross-server tool collisions and keeps callbacks routed to the owning server" do
     {registry, tools, failures} =
       Registry.start_all([config("Alpha Tools"), config("Alpha_Tools")], self(),

--- a/test/minga_agent/mcp/stdio_transport_test.exs
+++ b/test/minga_agent/mcp/stdio_transport_test.exs
@@ -1,0 +1,67 @@
+defmodule MingaAgent.MCP.StdioTransportTest do
+  # Spawns a real /bin/sh child to verify process-boundary env isolation.
+  # OS process tests must not run concurrently because of BEAM child setup races.
+  use ExUnit.Case, async: false
+
+  alias MingaAgent.MCP.StdioTransport
+  alias MingaAgent.MCP.ServerConfig
+
+  test "port_env preserves explicit env, allows startup vars, and unsets disallowed inheritance" do
+    config = %ServerConfig{
+      name: "Alpha",
+      command: "node",
+      env: %{
+        "EXTRA" => "override",
+        "HOME" => "/custom/home",
+        "MINGA_COOKIE" => "intentional-cookie"
+      }
+    }
+
+    inherited_env = %{
+      "ANTHROPIC_API_KEY" => "secret-anthropic",
+      "MINGA_GATEWAY_TOKEN" => "secret-gateway",
+      "MINGA_COOKIE" => "secret-cookie",
+      "HOME" => "/should-not-win",
+      "PATH" => "/usr/bin",
+      "CUSTOM" => "value"
+    }
+
+    assert StdioTransport.port_env(config, inherited_env) ==
+             [
+               {~c"ANTHROPIC_API_KEY", false},
+               {~c"CUSTOM", false},
+               {~c"EXTRA", ~c"override"},
+               {~c"HOME", ~c"/custom/home"},
+               {~c"MINGA_COOKIE", ~c"intentional-cookie"},
+               {~c"MINGA_GATEWAY_TOKEN", false},
+               {~c"PATH", ~c"/usr/bin"}
+             ]
+  end
+
+  test "a spawned child cannot see inherited secrets once the sanitized env is applied" do
+    config = %ServerConfig{
+      name: "Alpha",
+      command: "/bin/sh",
+      args: [
+        "-c",
+        "if [ \"${MCP_SECRET-}\" = \"top-secret\" ]; then printf 'leaked\\n'; else printf 'masked\\n'; fi"
+      ],
+      env: %{}
+    }
+
+    env = StdioTransport.port_env(config, %{"MCP_SECRET" => "top-secret", "PATH" => "/usr/bin"})
+
+    port =
+      Port.open({:spawn_executable, "/bin/sh"}, [
+        :binary,
+        :exit_status,
+        :use_stdio,
+        {:line, 65_536},
+        {:args, config.args},
+        {:env, env}
+      ])
+
+    assert_receive {^port, {:data, {:eol, "masked"}}}, 1_000
+    assert_receive {^port, {:exit_status, 0}}, 1_000
+  end
+end

--- a/test/minga_agent/providers/native_mcp_test.exs
+++ b/test/minga_agent/providers/native_mcp_test.exs
@@ -47,8 +47,10 @@ defmodule MingaAgent.Providers.NativeMCPTest do
       project_root: opts[:tmp_dir] || System.tmp_dir!(),
       tools: [builtin_tool()],
       config: agent_config(),
+      mcp_enabled?: true,
       mcp_transport: FakeTransport,
-      mcp_transport_opts: [tools: [mcp_tool_def()], test_pid: self()]
+      mcp_transport_opts: [tools: [mcp_tool_def()], test_pid: self()],
+      skip_api_key_env: true
     ]
 
     Native.start_link(Keyword.merge(defaults, opts))
@@ -80,16 +82,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     end
   end
 
-  defp drain_llm_tools_messages do
-    receive do
-      {:llm_tools_before_call_failure, _tool_names} -> drain_llm_tools_messages()
-      {:llm_tools_after_call_failure, _tool_names} -> drain_llm_tools_messages()
-    after
-      0 -> :ok
-    end
-  end
-
-  test "passes MCP tools and builtins to the LLM", %{tmp_dir: dir} do
+  test "enabled MCP exposes only lightweight meta-tools to the LLM", %{tmp_dir: dir} do
     test_pid = self()
 
     client = fn _model, _messages, opts ->
@@ -105,116 +98,129 @@ defmodule MingaAgent.Providers.NativeMCPTest do
 
     assert_receive {:llm_tools, tool_names}, @receive_timeout
     assert "builtin_echo" in tool_names
-    assert "mcp_local_tools__echo_text" in tool_names
-    assert "todo_write" in tool_names
-  end
-
-  test "passes tools from two healthy MCP servers to the LLM", %{tmp_dir: dir} do
-    test_pid = self()
-
-    client = fn _model, _messages, opts ->
-      send(test_pid, {:llm_tools_two_servers, Enum.map(opts[:tools], & &1.name)})
-
-      [ReqLLM.StreamChunk.text("ok"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
-      |> build_stream_response()
-    end
-
-    {:ok, provider} =
-      start_provider(
-        tmp_dir: dir,
-        llm_client: client,
-        config: agent_config([server_config("Alpha"), server_config("Beta")]),
-        mcp_transport_opts: [
-          tools_by_server: %{
-            "Alpha" => [mcp_tool_def("echo-text")],
-            "Beta" => [mcp_tool_def("search-code")]
-          },
-          test_pid: self()
-        ]
-      )
-
-    assert :ok = Native.send_prompt(provider, "hello")
-    _events = collect_until_end()
-
-    assert_receive {:llm_tools_two_servers, tool_names}, @receive_timeout
-    assert "builtin_echo" in tool_names
-    assert "mcp_alpha__echo_text" in tool_names
-    assert "mcp_beta__search_code" in tool_names
-    assert "todo_write" in tool_names
-  end
-
-  test "renames MCP tools that collide with built-in tool names before LLM calls", %{tmp_dir: dir} do
-    test_pid = self()
-
-    conflicting_builtin =
-      ReqLLM.Tool.new!(
-        name: "mcp_local_tools__echo_text",
-        description: "Existing tool with MCP-shaped name",
-        parameter_schema: %{"type" => "object", "properties" => %{}},
-        callback: fn _args -> {:ok, "builtin wins"} end
-      )
-
-    client = fn _model, _messages, opts ->
-      send(test_pid, {:llm_tools_with_reserved_collision, Enum.map(opts[:tools], & &1.name)})
-
-      [ReqLLM.StreamChunk.text("ok"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
-      |> build_stream_response()
-    end
-
-    {:ok, provider} =
-      start_provider(
-        tmp_dir: dir,
-        llm_client: client,
-        tools: [conflicting_builtin]
-      )
-
-    assert :ok = Native.send_prompt(provider, "hello")
-    _events = collect_until_end()
-
-    assert_receive {:llm_tools_with_reserved_collision, tool_names}, @receive_timeout
-    assert "mcp_local_tools__echo_text" in tool_names
-    assert "mcp_local_tools__echo_text_2" in tool_names
-    assert length(tool_names) == length(Enum.uniq(tool_names))
-  end
-
-  test "invalid MCP config reports an error and keeps builtins available", %{tmp_dir: dir} do
-    test_pid = self()
-
-    client = fn _model, _messages, opts ->
-      send(test_pid, {:llm_tools_with_invalid_mcp, Enum.map(opts[:tools], & &1.name)})
-
-      [ReqLLM.StreamChunk.text("ok"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
-      |> build_stream_response()
-    end
-
-    {:ok, provider} =
-      start_provider(
-        tmp_dir: dir,
-        llm_client: client,
-        config: %AgentConfig{mcp_servers: [%{name: "Local Tools"}], tool_approval: :none}
-      )
-
-    assert_receive {:agent_provider_event, %Event.Error{message: message}}, @receive_timeout
-    assert message =~ "MCP config error"
-    assert message =~ "command is required"
-
-    assert :ok = Native.send_prompt(provider, "hello")
-    _events = collect_until_end()
-
-    assert_receive {:llm_tools_with_invalid_mcp, tool_names}, @receive_timeout
-    assert "builtin_echo" in tool_names
+    assert "list_mcp_tools" in tool_names
+    assert "call_mcp_tool" in tool_names
     refute "mcp_local_tools__echo_text" in tool_names
     assert "todo_write" in tool_names
+    refute_receive {:mcp_transport_started, "Local Tools", _transport}, 50
   end
 
-  test "one failed MCP server leaves a healthy server and builtins available", %{tmp_dir: dir} do
+  test "disabled MCP extension exposes no MCP tools", %{tmp_dir: dir} do
     test_pid = self()
 
     client = fn _model, _messages, opts ->
-      send(test_pid, {:llm_tools_with_failed_server, Enum.map(opts[:tools], & &1.name)})
+      send(test_pid, {:llm_tools, Enum.map(opts[:tools], & &1.name)})
 
       [ReqLLM.StreamChunk.text("ok"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
       |> build_stream_response()
+    end
+
+    {:ok, provider} = start_provider(tmp_dir: dir, llm_client: client, mcp_enabled?: false)
+    assert :ok = Native.send_prompt(provider, "hello")
+    _events = collect_until_end()
+
+    assert_receive {:llm_tools, tool_names}, @receive_timeout
+    refute "list_mcp_tools" in tool_names
+    refute "call_mcp_tool" in tool_names
+    refute_receive {:mcp_transport_started, "Local Tools", _transport}, 50
+  end
+
+  test "list_mcp_tools starts servers lazily and returns one-line descriptions", %{tmp_dir: dir} do
+    call_count = :counters.new(1, [:atomics])
+
+    client = fn _model, _messages, _opts ->
+      count = :counters.get(call_count, 1)
+      :counters.add(call_count, 1, 1)
+
+      chunks =
+        if count == 0 do
+          [
+            ReqLLM.StreamChunk.tool_call("list_mcp_tools", %{}, %{id: "tc_list", index: 0}),
+            ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+          ]
+        else
+          [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+        end
+
+      build_stream_response(chunks)
+    end
+
+    {:ok, provider} = start_provider(tmp_dir: dir, llm_client: client)
+    assert :ok = Native.send_prompt(provider, "discover mcp")
+    events = collect_until_end()
+
+    assert_receive {:mcp_transport_started, "Local Tools", _transport}, @receive_timeout
+
+    assert {:ok, %{mcp_status: [%{"name" => "Local Tools", "status" => "running"}]}} =
+             Native.get_state(provider)
+
+    assert Enum.any?(events, fn
+             %Event.ToolEnd{name: "list_mcp_tools", result: result, is_error: false} ->
+               result =~ "echo-text" and result =~ "MCP tool echo-text"
+
+             _event ->
+               false
+           end)
+  end
+
+  test "call_mcp_tool starts the selected server lazily and round-trips", %{tmp_dir: dir} do
+    call_count = :counters.new(1, [:atomics])
+
+    client = fn _model, _messages, _opts ->
+      count = :counters.get(call_count, 1)
+      :counters.add(call_count, 1, 1)
+
+      chunks =
+        if count == 0 do
+          [
+            ReqLLM.StreamChunk.tool_call(
+              "call_mcp_tool",
+              %{
+                "server" => "Local Tools",
+                "tool" => "echo-text",
+                "arguments" => %{"text" => "hi"}
+              },
+              %{id: "tc_call", index: 0}
+            ),
+            ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+          ]
+        else
+          [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+        end
+
+      build_stream_response(chunks)
+    end
+
+    {:ok, provider} = start_provider(tmp_dir: dir, llm_client: client)
+    assert :ok = Native.send_prompt(provider, "use mcp")
+    events = collect_until_end()
+
+    assert_receive {:mcp_transport_started, "Local Tools", _transport}, @receive_timeout
+
+    assert_receive {:mcp_tool_call, "Local Tools", "echo-text", %{"text" => "hi"}},
+                   @receive_timeout
+
+    assert Enum.any?(events, &match?(%Event.ToolEnd{name: "call_mcp_tool", is_error: false}, &1))
+  end
+
+  test "one failed server does not prevent healthy server discovery", %{tmp_dir: dir} do
+    call_count = :counters.new(1, [:atomics])
+
+    client = fn _model, _messages, _opts ->
+      count = :counters.get(call_count, 1)
+      :counters.add(call_count, 1, 1)
+
+      chunks =
+        if count == 0 do
+          [
+            ReqLLM.StreamChunk.tool_call("list_mcp_tools", %{}, %{id: "tc_list", index: 0}),
+            ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+          ]
+        else
+          [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+        end
+
+      build_stream_response(chunks)
     end
 
     {:ok, provider} =
@@ -229,20 +235,26 @@ defmodule MingaAgent.Providers.NativeMCPTest do
         ]
       )
 
-    assert_receive {:agent_provider_event, %Event.Error{message: message}}, @receive_timeout
-    assert message =~ "MCP server Broken failed to start"
+    assert :ok = Native.send_prompt(provider, "discover mcp")
+    events = collect_until_end()
 
-    assert :ok = Native.send_prompt(provider, "hello")
-    _events = collect_until_end()
+    assert Enum.any?(events, fn
+             %Event.Error{message: message} -> message =~ "MCP server Broken failed to start"
+             _event -> false
+           end)
 
-    assert_receive {:llm_tools_with_failed_server, tool_names}, @receive_timeout
-    assert "builtin_echo" in tool_names
-    assert "mcp_healthy__echo_text" in tool_names
-    refute "mcp_broken__echo_text" in tool_names
-    assert "todo_write" in tool_names
+    assert_receive {:mcp_transport_started, "Healthy", _transport}, @receive_timeout
+
+    assert Enum.any?(events, fn
+             %Event.ToolEnd{name: "list_mcp_tools", result: result, is_error: false} ->
+               result =~ "echo-text"
+
+             _event ->
+               false
+           end)
   end
 
-  test "MCP tool call round-trips to the server", %{tmp_dir: dir} do
+  test "list_mcp_tools returns a tool error when every configured server fails", %{tmp_dir: dir} do
     call_count = :counters.new(1, [:atomics])
 
     client = fn _model, _messages, _opts ->
@@ -252,10 +264,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
       chunks =
         if count == 0 do
           [
-            ReqLLM.StreamChunk.tool_call("mcp_local_tools__echo_text", %{"text" => "hi"}, %{
-              id: "tc_1",
-              index: 0
-            }),
+            ReqLLM.StreamChunk.tool_call("list_mcp_tools", %{}, %{id: "tc_list", index: 0}),
             ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
           ]
         else
@@ -265,61 +274,58 @@ defmodule MingaAgent.Providers.NativeMCPTest do
       build_stream_response(chunks)
     end
 
-    {:ok, provider} = start_provider(tmp_dir: dir, llm_client: client)
-    assert :ok = Native.send_prompt(provider, "use mcp")
+    {:ok, provider} =
+      start_provider(
+        tmp_dir: dir,
+        llm_client: client,
+        config: agent_config([server_config("Broken")]),
+        mcp_transport_opts: [
+          request_errors_by_server: %{"Broken" => %{"tools/list" => :boom}},
+          test_pid: self()
+        ]
+      )
+
+    assert :ok = Native.send_prompt(provider, "discover mcp")
     events = collect_until_end()
 
-    assert_receive {:mcp_tool_call, "echo-text", %{"text" => "hi"}}, @receive_timeout
+    assert Enum.any?(events, fn
+             %Event.ToolEnd{name: "list_mcp_tools", result: result, is_error: true} ->
+               result =~ "MCP servers failed to start" and result =~ "Broken"
 
-    assert Enum.any?(
-             events,
-             &match?(%Event.ToolEnd{name: "mcp_local_tools__echo_text", is_error: false}, &1)
-           )
+             _event ->
+               false
+           end)
+
+    assert {:ok, %{mcp_status: [%{"name" => "Broken", "status" => "errored", "error" => error}]}} =
+             Native.get_state(provider)
+
+    assert error =~ "MCP server Broken failed to start"
   end
 
-  test "MCP failure reports an error and leaves builtins available", %{tmp_dir: dir} do
-    test_pid = self()
+  test "provider shutdown stops lazily started MCP transports", %{tmp_dir: dir} do
     call_count = :counters.new(1, [:atomics])
 
-    client = fn _model, _messages, opts ->
-      send(test_pid, {:llm_tools_after_crash, Enum.map(opts[:tools], & &1.name)})
+    client = fn _model, _messages, _opts ->
       count = :counters.get(call_count, 1)
       :counters.add(call_count, 1, 1)
 
       chunks =
         if count == 0 do
           [
-            ReqLLM.StreamChunk.tool_call("builtin_echo", %{}, %{id: "tc_builtin", index: 0}),
+            ReqLLM.StreamChunk.tool_call("list_mcp_tools", %{}, %{id: "tc_list", index: 0}),
             ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
           ]
         else
-          [ReqLLM.StreamChunk.text("ok"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
         end
 
       build_stream_response(chunks)
     end
 
-    {:ok, provider} = start_provider(tmp_dir: dir, llm_client: client)
-    assert_receive {:mcp_transport_started, "Local Tools", transport}, @receive_timeout
-    FakeTransport.crash(transport)
-
-    assert_receive {:agent_provider_event, %Event.Error{message: message}}, @receive_timeout
-    assert message =~ "MCP server Local Tools stopped"
-
-    :sys.get_state(provider)
-    assert :ok = Native.send_prompt(provider, "still works")
-    events = collect_until_end()
-
-    assert_receive {:llm_tools_after_crash, tool_names}, @receive_timeout
-    assert "builtin_echo" in tool_names
-    refute "mcp_local_tools__echo_text" in tool_names
-    assert Enum.any?(events, &match?(%Event.ToolEnd{name: "builtin_echo", is_error: false}, &1))
-  end
-
-  test "provider shutdown stops all MCP transports", %{tmp_dir: dir} do
     {:ok, provider} =
       start_provider(
         tmp_dir: dir,
+        llm_client: client,
         config: agent_config([server_config("Alpha"), server_config("Beta")]),
         mcp_transport_opts: [
           tools_by_server: %{
@@ -330,6 +336,8 @@ defmodule MingaAgent.Providers.NativeMCPTest do
         ]
       )
 
+    assert :ok = Native.send_prompt(provider, "discover mcp")
+    _events = collect_until_end()
     assert_receive {:mcp_transport_started, "Alpha", alpha_transport}, @receive_timeout
     assert_receive {:mcp_transport_started, "Beta", beta_transport}, @receive_timeout
 
@@ -339,140 +347,5 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     assert_receive {:DOWN, ^provider_ref, :process, ^provider, :normal}, @receive_timeout
     assert_receive {:mcp_transport_stopped, "Alpha", ^alpha_transport}, @receive_timeout
     assert_receive {:mcp_transport_stopped, "Beta", ^beta_transport}, @receive_timeout
-  end
-
-  test "MCP tool failure during a call reports an error and keeps provider usable", %{
-    tmp_dir: dir
-  } do
-    test_pid = self()
-    call_count = :counters.new(1, [:atomics])
-
-    client = fn _model, _messages, opts ->
-      count = :counters.get(call_count, 1)
-      :counters.add(call_count, 1, 1)
-
-      label =
-        if count == 0, do: :llm_tools_before_call_failure, else: :llm_tools_after_call_failure
-
-      send(test_pid, {label, Enum.map(opts[:tools], & &1.name)})
-
-      chunks =
-        case count do
-          0 ->
-            [
-              ReqLLM.StreamChunk.tool_call("mcp_local_tools__echo_text", %{"text" => "hi"}, %{
-                id: "tc_mcp",
-                index: 0
-              }),
-              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
-            ]
-
-          1 ->
-            [
-              ReqLLM.StreamChunk.tool_call("builtin_echo", %{}, %{id: "tc_builtin", index: 0}),
-              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
-            ]
-
-          _done ->
-            [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
-        end
-
-      build_stream_response(chunks)
-    end
-
-    {:ok, provider} =
-      start_provider(
-        tmp_dir: dir,
-        llm_client: client,
-        mcp_transport_opts: [
-          tools: [mcp_tool_def()],
-          request_errors: %{"echo-text" => :closed},
-          test_pid: self()
-        ]
-      )
-
-    assert :ok = Native.send_prompt(provider, "use failing mcp")
-    events = collect_until_end()
-
-    assert Enum.any?(
-             events,
-             &match?(%Event.ToolEnd{name: "mcp_local_tools__echo_text", is_error: true}, &1)
-           )
-
-    assert Enum.any?(events, fn
-             %Event.Error{message: message} -> message =~ "MCP server Local Tools stopped"
-             _event -> false
-           end)
-
-    :sys.get_state(provider)
-    drain_llm_tools_messages()
-    assert :ok = Native.send_prompt(provider, "still works")
-    events = collect_until_end()
-
-    assert_receive {:llm_tools_after_call_failure, tool_names}, @receive_timeout
-    assert "builtin_echo" in tool_names
-    refute "mcp_local_tools__echo_text" in tool_names
-    assert Enum.any?(events, &match?(%Event.AgentEnd{}, &1))
-  end
-
-  test "mid-session crash removes only the crashed server tools", %{tmp_dir: dir} do
-    test_pid = self()
-    call_count = :counters.new(1, [:atomics])
-
-    client = fn _model, _messages, opts ->
-      send(test_pid, {:llm_tools_after_one_server_crash, Enum.map(opts[:tools], & &1.name)})
-      count = :counters.get(call_count, 1)
-      :counters.add(call_count, 1, 1)
-
-      chunks =
-        if count == 0 do
-          [
-            ReqLLM.StreamChunk.tool_call("mcp_beta__search_code", %{"text" => "hi"}, %{
-              id: "tc_beta",
-              index: 0
-            }),
-            ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
-          ]
-        else
-          [ReqLLM.StreamChunk.text("ok"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
-        end
-
-      build_stream_response(chunks)
-    end
-
-    {:ok, provider} =
-      start_provider(
-        tmp_dir: dir,
-        llm_client: client,
-        config: agent_config([server_config("Alpha"), server_config("Beta")]),
-        mcp_transport_opts: [
-          tools_by_server: %{
-            "Alpha" => [mcp_tool_def("echo-text")],
-            "Beta" => [mcp_tool_def("search-code")]
-          },
-          test_pid: self()
-        ]
-      )
-
-    assert_receive {:mcp_transport_started, "Alpha", alpha_transport}, @receive_timeout
-    FakeTransport.crash(alpha_transport)
-
-    assert_receive {:agent_provider_event, %Event.Error{message: message}}, @receive_timeout
-    assert message =~ "MCP server Alpha stopped"
-
-    :sys.get_state(provider)
-    assert :ok = Native.send_prompt(provider, "still works")
-    events = collect_until_end()
-
-    assert_receive {:llm_tools_after_one_server_crash, tool_names}, @receive_timeout
-    assert "builtin_echo" in tool_names
-    refute "mcp_alpha__echo_text" in tool_names
-    assert "mcp_beta__search_code" in tool_names
-    assert_receive {:mcp_tool_call, "Beta", "search-code", %{"text" => "hi"}}, @receive_timeout
-
-    assert Enum.any?(
-             events,
-             &match?(%Event.ToolEnd{name: "mcp_beta__search_code", is_error: false}, &1)
-           )
   end
 end

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -1568,16 +1568,30 @@ defmodule MingaAgent.SessionTest do
         :counters.add(call_count, 1, 1)
 
         chunks =
-          if count == 0 do
-            [
-              ReqLLM.StreamChunk.tool_call("builtin_echo", %{}, %{id: "tc_builtin", index: 0}),
-              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
-            ]
-          else
-            [
-              ReqLLM.StreamChunk.text("still works"),
-              ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
-            ]
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call("list_mcp_tools", %{}, %{id: "tc_list", index: 0}),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            1 ->
+              [
+                ReqLLM.StreamChunk.text("listed"),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+              ]
+
+            2 ->
+              [
+                ReqLLM.StreamChunk.tool_call("builtin_echo", %{}, %{id: "tc_builtin", index: 0}),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _done ->
+              [
+                ReqLLM.StreamChunk.text("still works"),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+              ]
           end
 
         mcp_session_stream(chunks)
@@ -1594,6 +1608,7 @@ defmodule MingaAgent.SessionTest do
               mcp_servers: [%ServerConfig{name: "Local Tools", command: "ignored"}],
               tool_approval: :none
             },
+            mcp_enabled?: true,
             mcp_transport: FakeTransport,
             mcp_transport_opts: [
               tools: [%{"name" => "echo-text", "inputSchema" => %{"type" => "object"}}],
@@ -1605,7 +1620,11 @@ defmodule MingaAgent.SessionTest do
 
       Session.subscribe(session)
       _provider = Session.get_provider(session)
-      assert_receive {:mcp_transport_started, "Local Tools", transport}
+
+      assert :ok = Session.send_prompt(session, "discover mcp")
+      assert_receive {:mcp_transport_started, "Local Tools", transport}, @event_timeout
+      await_turn_complete()
+
       FakeTransport.crash(transport)
 
       assert_receive {:agent_event, ^session, {:error, message}}, @event_timeout
@@ -1616,6 +1635,8 @@ defmodule MingaAgent.SessionTest do
       await_turn_complete()
       assert_receive {:session_mcp_tools, tool_names}, @event_timeout
       assert "builtin_echo" in tool_names
+      assert "list_mcp_tools" in tool_names
+      assert "call_mcp_tool" in tool_names
       refute "mcp_local_tools__echo_text" in tool_names
 
       assert Enum.any?(Session.messages(session), fn

--- a/test/minga_agent/tools_test.exs
+++ b/test/minga_agent/tools_test.exs
@@ -223,6 +223,14 @@ defmodule MingaAgent.ToolsTest do
       assert Tools.destructive?("mcp_workspace__lookup", %{}, [])
     end
 
+    test "list_mcp_tools is destructive because it starts MCP servers lazily" do
+      assert Tools.destructive?("list_mcp_tools", %{}, [])
+    end
+
+    test "call_mcp_tool is destructive because it invokes remote side effects" do
+      assert Tools.destructive?("call_mcp_tool", %{}, [])
+    end
+
     test "accepts a custom destructive list" do
       assert Tools.destructive?("read_file", %{}, ["read_file", "shell"])
       refute Tools.destructive?("write_file", %{}, ["read_file", "shell"])


### PR DESCRIPTION
# TL;DR
MCP is now an opt-in Minga extension with lazy server startup, supervised clients, approval-gated meta-tools, and sanitized stdio process environments, so users who do not enable MCP keep zero extra tools, processes, or prompt bloat.

Closes #286

## Context
Issue #286 scopes MCP as optional extension infrastructure rather than core provider behavior. The goal is to support existing MCP server ecosystems without paying the usual up-front context cost from injecting every MCP tool description.

## Changes
- Added the built-in optional `Minga.Extensions.MCP` extension and an extension-owned `Minga.Extensions.MCP.Supervisor` for supervised MCP clients.
- Added module-sourced extension registration so config can enable built-in optional extensions with `extension Minga.Extensions.MCP`.
- Added `mcp_server/2` config DSL and `.minga/mcp.json` loading for Claude/Cursor-style project-local server declarations, including clear errors for invalid project MCP schemas.
- Changed native provider MCP integration to expose only `list_mcp_tools` and `call_mcp_tool`, start server clients lazily, report startup/call failures as tool errors, and clean up session-owned clients.
- Marked both MCP meta-tools as destructive because listing tools can start external MCP server processes.
- Sanitized MCP stdio child process environments with an allowlist plus explicit unsets for inherited variables, while preserving intentionally configured server env values.
- Added runtime MCP status to provider state and `/mcp`, including `not_started`, `running`, and `errored` states.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.llm test/minga_agent/mcp/stdio_transport_test.exs test/minga_agent/tools_test.exs test/minga_agent/mcp test/minga_agent/providers/native_mcp_test.exs test/minga/config/loader_test.exs test/minga/extension/registry_test.exs test/minga_editor/agent/slash_command_test.exs`
- `mix test.llm test/minga/extension/supervisor_test.exs --include heavy`
- `make lint`
- `git diff --check`

## Acceptance Criteria Addressed
- MCP support ships as a `Minga.Extension`, not core-only provider wiring. ✅
- Users can enable MCP in config and declare servers with `mcp_server/2`. ✅
- MCP servers start lazily on meta-tool use. ✅
- MCP tool descriptions are discovered through lightweight meta-tools instead of prompt injection. ✅
- First MCP tool interaction initializes the server and caches/list tools for the session. ✅
- MCP calls flow through the same tool execution and approval path, with MCP calls defaulting to ask/destructive handling. ✅
- Server errors are reported without crashing the session. ✅
- `/mcp` shows configured server status. ✅
- Server clients run under the MCP extension supervisor and are cleaned when sessions end. ✅
- Project-local `.minga/mcp.json` compatibility is supported. ✅
- Users who do not enable MCP see no extra tools, tokens, or processes. ✅
