### PR TITLE
fix(macos): separate Observatory fold and inspect actions

### DIFF
--- a/lib/minga_editor/input/observatory.ex
+++ b/lib/minga_editor/input/observatory.ex
@@ -14,6 +14,10 @@ defmodule MingaEditor.Input.Observatory do
 
   @doc "Inspects a process selected in the BEAM Observatory."
   @spec inspect_process(state(), String.t()) :: state()
+  def inspect_process(state, "") do
+    EditorState.set_observatory_inspection(state, nil)
+  end
+
   def inspect_process(state, pid_string) when is_binary(pid_string) do
     inspection =
       pid_string

--- a/macos/Sources/Views/Observatory/ObservatoryGraphView.swift
+++ b/macos/Sources/Views/Observatory/ObservatoryGraphView.swift
@@ -64,7 +64,7 @@ struct ObservatoryGraphView: View {
         .contentShape(Capsule())
         .onTapGesture {
             selectedNodeId = node.id
-            encoder?.sendObservatoryInspect(pid: node.pid)
+            encoder?.sendObservatoryInspect(pid: "")
         }
     }
 

--- a/macos/Sources/Views/ObservatoryView.swift
+++ b/macos/Sources/Views/ObservatoryView.swift
@@ -66,20 +66,47 @@ struct ObservatoryView: View {
             }
             .padding(.vertical, 6)
         }
+        .focusable()
+        .onKeyPress(.escape) {
+            dismissInspection()
+            return .handled
+        }
     }
 
     private func row(_ node: ObservatoryNode) -> some View {
         HStack(spacing: 6) {
+            Button {
+                activateRow(node)
+            } label: {
+                rowMainContent(node)
+            }
+            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button {
+                selectedNodeId = node.id
+                encoder?.sendObservatoryInspect(pid: node.pid)
+            } label: {
+                Image(systemName: "info.circle")
+                    .font(.caption)
+                    .foregroundStyle(theme.treeFg.opacity(0.55))
+                    .frame(width: 16)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.leading, CGFloat(node.depth) * 14 + 8)
+        .padding(.trailing, 8)
+        .padding(.vertical, 4)
+        .background(selectedNodeId == node.id ? theme.treeSelectionBg.opacity(0.55) : Color.clear, in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func rowMainContent(_ node: ObservatoryNode) -> some View {
+        HStack(spacing: 6) {
             if node.isSupervisor {
-                Button {
-                    toggleExpanded(node.id)
-                } label: {
-                    Image(systemName: disclosureIcon(node))
-                        .font(.caption)
-                        .frame(width: 12)
-                        .foregroundStyle(theme.treeFg.opacity(0.55))
-                }
-                .buttonStyle(.plain)
+                Image(systemName: disclosureIcon(node))
+                    .font(.caption)
+                    .frame(width: 12)
+                    .foregroundStyle(theme.treeFg.opacity(0.55))
             } else {
                 Color.clear.frame(width: 12).allowsHitTesting(false)
             }
@@ -117,15 +144,7 @@ struct ObservatoryView: View {
             SparklineView(data: node.sparkline, color: statusColor(node))
                 .frame(width: 48, height: 16)
         }
-        .padding(.leading, CGFloat(node.depth) * 14 + 8)
-        .padding(.trailing, 8)
-        .padding(.vertical, 4)
-        .background(selectedNodeId == node.id ? theme.treeSelectionBg.opacity(0.55) : Color.clear, in: RoundedRectangle(cornerRadius: 6))
         .contentShape(Rectangle())
-        .onTapGesture {
-            selectedNodeId = node.id
-            encoder?.sendObservatoryInspect(pid: node.pid)
-        }
     }
 
     private func disclosureIcon(_ node: ObservatoryNode) -> String {
@@ -166,6 +185,18 @@ struct ObservatoryView: View {
         if state.nodes.isEmpty {
             hasInitializedExpansion = false
         }
+    }
+
+    private func activateRow(_ node: ObservatoryNode) {
+        selectedNodeId = node.id
+        dismissInspection()
+        if node.isSupervisor {
+            toggleExpanded(node.id)
+        }
+    }
+
+    private func dismissInspection() {
+        encoder?.sendObservatoryInspect(pid: "")
     }
 
     private func toggleExpanded(_ id: String) {

--- a/test/minga_editor/input/observatory_test.exs
+++ b/test/minga_editor/input/observatory_test.exs
@@ -29,6 +29,13 @@ defmodule MingaEditor.Input.ObservatoryTest do
                state.shell_state.observatory_inspection
     end
 
+    test "empty PID dismisses the inspection popup" do
+      state = Observatory.inspect_process(base_state(), "not-a-pid")
+      state = Observatory.inspect_process(state, "")
+
+      assert state.shell_state.observatory_inspection == nil
+    end
+
     test "falls back to process info when GenServer state is unavailable" do
       pid = spawn(fn -> :ok end)
       ref = Process.monitor(pid)


### PR DESCRIPTION
# TL;DR
BEAM Observatory tree rows now fold instead of immediately opening process inspection. Process details moved to an explicit info button, and the inspection popup can be dismissed from the tree.

## Context
The macOS BEAM Observatory sidebar had two interaction issues: clicking a tree row opened the process inspection popup instead of toggling supervisor expansion, and the inspection popup had no clear dismiss path once opened.

## Changes
- Split tree row activation from process inspection: row clicks now select and fold supervisor nodes, while the info button opens process details.
- Added popup dismissal paths for Observatory inspection by sending an empty inspect action from the GUI and clearing the BEAM-side inspection state.
- Kept graph view selection lightweight by dismissing inspection on click while preserving Return-to-inspect behavior.
- Added a regression test for clearing Observatory inspection state.

## Verification
- `mix test.llm test/minga_editor/input/observatory_test.exs`
- `mix swift.build`

## Manual verification
1. Open the macOS app and show BEAM Observatory.
2. Click a supervisor row in Tree mode.
3. Verify the row expands or collapses and no inspection popup opens.
4. Click the row's info button.
5. Verify the inspection popup opens.
6. Press Escape or click a tree row.
7. Verify the inspection popup dismisses.
