### PR TITLE
feat(tui): show fold indicators contextually on cursor/hover

### DIFF
--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -176,10 +176,20 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       indent_guide_active_face:
         Face.new(fg: state.theme.editor.indent_guide_active_fg || state.theme.gutter.current_fg),
       hl_todo_faces: MingaEditor.UI.Theme.hl_todo_faces(state.theme),
-      cursor_col: Map.get(params, :cursor_col, cursor_display_col(lines, cursor, first_line))
+      cursor_col: Map.get(params, :cursor_col, cursor_display_col(lines, cursor, first_line)),
+      hover_row: extract_hover_row(state),
+      fold_ranges: window.fold_ranges
     }
 
     {ctx, state}
+  end
+
+  @spec extract_hover_row(state()) :: non_neg_integer() | nil
+  defp extract_hover_row(state) do
+    case state.workspace.mouse.hover_pos do
+      {row, _col} when is_integer(row) -> row
+      _ -> nil
+    end
   end
 
   # ── Line rendering ────────────────────────────────────────────────────────
@@ -224,6 +234,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
     max_rows = length(lines)
     dirty_rows = dirty_screen_rows(lines, first_line, window)
     fold_start_lines = fold_start_lines(window.fold_ranges)
+    fold_viz = %{cursor_line: cursor_line, hover_row: ctx.hover_row, fold_ranges: ctx.fold_ranges}
 
     highlight_segments_list =
       if ctx.highlight do
@@ -275,7 +286,8 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
                 fold_indicator_pos(screen_row, row_off, col_off, gutter_w, ctx),
                 ctx.gutter_colors,
                 fold_start_lines,
-                buf_line
+                buf_line,
+                fold_viz
               )
 
             g_cmds = g_cmds ++ fold_g
@@ -335,6 +347,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
     sign_ctx = SignContext.from_render_context(ctx)
     max_rows = length(lines)
     fold_start_lines = fold_start_lines(window.fold_ranges)
+    fold_viz = %{cursor_line: cursor_line, hover_row: ctx.hover_row, fold_ranges: ctx.fold_ranges}
 
     # Pre-compute highlight segments for all visible lines in one O(N) pass.
     highlight_segments_list =
@@ -385,7 +398,8 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
                 fold_indicator_pos(screen_row, row_off, col_off, gutter_w, ctx),
                 ctx.gutter_colors,
                 fold_start_lines,
-                buf_line
+                buf_line,
+                fold_viz
               )
 
             g_cmds = fold_g ++ g_cmds
@@ -480,7 +494,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
             fold_render_pos = fold_indicator_pos(screen_row, row_off, col_off, gutter_w, ctx)
 
             fold_g =
-              fold_gutter_indicator(fold_info, fold_render_pos, ctx.gutter_colors, %{}, nil)
+              fold_gutter_indicator(fold_info, fold_render_pos, ctx.gutter_colors, %{}, nil, %{})
 
             segments = placeholder.(fold.start_line, fold.end_line, ctx.content_w)
             c_cmds = render_placeholder_segments(segments, content_render_pos)
@@ -564,35 +578,65 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
           RenderPosition.t(),
           MingaEditor.UI.Theme.Gutter.t(),
           %{non_neg_integer() => true},
-          non_neg_integer() | nil
+          non_neg_integer() | nil,
+          map()
         ) :: [DisplayList.draw()]
-  defp fold_gutter_indicator({:fold_start, _}, %RenderPosition{} = pos, colors, _starts, _line) do
+  defp fold_gutter_indicator({:fold_start, _}, %RenderPosition{} = pos, colors, _starts, _line, _viz) do
     fold_indicator_draw(pos, "▶", colors)
   end
 
-  defp fold_gutter_indicator(:normal, %RenderPosition{} = pos, colors, starts, buf_line)
+  defp fold_gutter_indicator(:normal, %RenderPosition{} = pos, colors, starts, buf_line, viz)
        when is_integer(buf_line) do
     if Map.has_key?(starts, buf_line) do
-      fold_indicator_draw(pos, "▼", colors)
+      if fold_indicator_visible?(buf_line, pos, viz) do
+        fold_indicator_draw(pos, "▼", colors)
+      else
+        []
+      end
     else
       []
     end
   end
 
-  defp fold_gutter_indicator(:normal, _pos, _colors, _starts, _line), do: []
+  defp fold_gutter_indicator(:normal, _pos, _colors, _starts, _line, _viz), do: []
 
   defp fold_gutter_indicator(
          {:decoration_fold, _},
          %RenderPosition{} = pos,
          colors,
          _starts,
-         _line
+         _line,
+         _viz
        ) do
     fold_indicator_draw(pos, "▶", colors)
   end
 
-  defp fold_gutter_indicator({:virtual_line, _}, _pos, _colors, _starts, _line), do: []
-  defp fold_gutter_indicator({:block, _, _}, _pos, _colors, _starts, _line), do: []
+  defp fold_gutter_indicator({:virtual_line, _}, _pos, _colors, _starts, _line, _viz), do: []
+  defp fold_gutter_indicator({:block, _, _}, _pos, _colors, _starts, _line, _viz), do: []
+
+  @spec fold_indicator_visible?(non_neg_integer(), RenderPosition.t(), map()) :: boolean()
+  defp fold_indicator_visible?(buf_line, pos, viz) do
+    cursor_line = Map.get(viz, :cursor_line)
+    hover_row = Map.get(viz, :hover_row)
+    fold_ranges = Map.get(viz, :fold_ranges, [])
+
+    cursor_in_fold_range?(cursor_line, buf_line, fold_ranges) or
+      hover_on_row?(hover_row, pos)
+  end
+
+  @spec cursor_in_fold_range?(non_neg_integer() | nil, non_neg_integer(), [FoldRange.t()]) ::
+          boolean()
+  defp cursor_in_fold_range?(nil, _buf_line, _ranges), do: false
+
+  defp cursor_in_fold_range?(cursor_line, buf_line, ranges) do
+    Enum.any?(ranges, fn %FoldRange{start_line: s, end_line: e} ->
+      s == buf_line and cursor_line >= s and cursor_line <= e
+    end)
+  end
+
+  @spec hover_on_row?(non_neg_integer() | nil, RenderPosition.t()) :: boolean()
+  defp hover_on_row?(nil, _pos), do: false
+  defp hover_on_row?(hover_row, pos), do: hover_row == pos.screen_row + pos.row_off
 
   @spec fold_indicator_draw(RenderPosition.t(), String.t(), MingaEditor.UI.Theme.Gutter.t()) ::
           [DisplayList.draw()]
@@ -669,13 +713,20 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
           render_opts.ctx
         )
 
+      fold_viz = %{
+        cursor_line: render_opts.cursor_line,
+        hover_row: render_opts.ctx.hover_row,
+        fold_ranges: render_opts.ctx.fold_ranges
+      }
+
       fold_g =
         fold_gutter_indicator(
           fold_info,
           fold_render_pos,
           render_opts.ctx.gutter_colors,
           render_opts.fold_start_lines,
-          buf_line
+          buf_line,
+          fold_viz
         )
 
       {g_cmds, c_cmds, _rows} =
@@ -738,6 +789,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
     sign_w = Gutter.sign_column_width()
     sign_ctx = SignContext.from_render_context(ctx)
     fold_start_lines = fold_start_lines(opts.window.fold_ranges)
+    fold_viz = %{cursor_line: cursor_line, hover_row: ctx.hover_row, fold_ranges: ctx.fold_ranges}
 
     {gutters, contents, screen_row, _byte_off} =
       lines
@@ -775,7 +827,8 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
               fold_indicator_pos(sr, row_off, col_off, gutter_w, ctx),
               ctx.gutter_colors,
               fold_start_lines,
-              buf_line
+              buf_line,
+              fold_viz
             )
 
           g2 = fold_g ++ g2

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -581,7 +581,14 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
           non_neg_integer() | nil,
           map()
         ) :: [DisplayList.draw()]
-  defp fold_gutter_indicator({:fold_start, _}, %RenderPosition{} = pos, colors, _starts, _line, _viz) do
+  defp fold_gutter_indicator(
+         {:fold_start, _},
+         %RenderPosition{} = pos,
+         colors,
+         _starts,
+         _line,
+         _viz
+       ) do
     fold_indicator_draw(pos, "▶", colors)
   end
 

--- a/lib/minga_editor/renderer/context.ex
+++ b/lib/minga_editor/renderer/context.ex
@@ -62,7 +62,9 @@ defmodule MingaEditor.Renderer.Context do
             document_highlight_colors: nil,
             wrap_on: false,
             line_number_style: :absolute,
-            width_oracle: %Monospace{}
+            width_oracle: %Monospace{},
+            hover_row: nil,
+            fold_ranges: []
 
   @typedoc """
   Represents the bounds of a visual selection for rendering.
@@ -107,6 +109,8 @@ defmodule MingaEditor.Renderer.Context do
           document_highlight_colors: term(),
           wrap_on: boolean(),
           line_number_style: atom(),
-          width_oracle: WidthOracle.t()
+          width_oracle: WidthOracle.t(),
+          hover_row: non_neg_integer() | nil,
+          fold_ranges: [term()]
         }
 end

--- a/test/minga_editor/render_pipeline/content_helpers_test.exs
+++ b/test/minga_editor/render_pipeline/content_helpers_test.exs
@@ -318,12 +318,14 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
       %{buf: buf, ctx: ctx, window: window}
     end
 
-    test "expanded foldable lines render a down chevron in the gutter", %{
+    test "expanded foldable lines render a down chevron in the gutter when cursor is on fold start", %{
       ctx: ctx,
       window: window
     } do
       lines = ["defmodule Example do", "  def run, do: :ok", "end"]
-      window = Window.set_fold_ranges(window, [FoldRange.new!(0, 2)])
+      fold_range = FoldRange.new!(0, 2)
+      window = Window.set_fold_ranges(window, [fold_range])
+      ctx = %{ctx | fold_ranges: [fold_range]}
 
       opts = %{
         first_line: 0,
@@ -385,8 +387,9 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
 
     test "fold indicators do not overwrite diagnostic signs", %{ctx: ctx, window: window} do
       lines = ["defmodule Example do", "  def run, do: :ok", "end"]
-      window = Window.set_fold_ranges(window, [FoldRange.new!(0, 2)])
-      ctx = %{ctx | diagnostic_signs: %{0 => :error}}
+      fold_range = FoldRange.new!(0, 2)
+      window = Window.set_fold_ranges(window, [fold_range])
+      ctx = %{ctx | diagnostic_signs: %{0 => :error}, fold_ranges: [fold_range]}
 
       opts = %{
         first_line: 0,
@@ -411,6 +414,101 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
 
       assert {2, "▼", _fold_face} =
                Enum.find(row, fn {col, text, _face} -> col == 2 and text == "▼" end)
+    end
+
+    test "open fold indicator is hidden when cursor and hover are both elsewhere", %{
+      ctx: ctx,
+      window: window
+    } do
+      lines = ["defmodule Example do", "  def run, do: :ok", "end"]
+      fold_range = FoldRange.new!(0, 2)
+      window = Window.set_fold_ranges(window, [fold_range])
+      ctx = %{ctx | fold_ranges: [fold_range], hover_row: nil}
+
+      opts = %{
+        first_line: 0,
+        cursor_line: 10,
+        ctx: ctx,
+        ln_style: :absolute,
+        gutter_w: 6,
+        first_byte_off: 0,
+        row_off: 0,
+        col_off: 0,
+        window: window,
+        buffer: window.buffer
+      }
+
+      {gutter_layer, _content_layer, _rows, _window} =
+        ContentHelpers.render_lines_nowrap_layers(lines, opts)
+
+      row = Map.get(gutter_layer, 0, [])
+
+      refute Enum.any?(row, fn {_col, text, _face} -> text == "▼" end),
+             "open fold indicator should be hidden when cursor and hover are elsewhere"
+    end
+
+    test "open fold indicator appears when cursor is inside fold range", %{
+      ctx: ctx,
+      window: window
+    } do
+      lines = ["defmodule Example do", "  def run, do: :ok", "end"]
+      fold_range = FoldRange.new!(0, 2)
+      window = Window.set_fold_ranges(window, [fold_range])
+      ctx = %{ctx | fold_ranges: [fold_range], hover_row: nil}
+
+      opts = %{
+        first_line: 0,
+        cursor_line: 1,
+        ctx: ctx,
+        ln_style: :absolute,
+        gutter_w: 6,
+        first_byte_off: 0,
+        row_off: 0,
+        col_off: 0,
+        window: window,
+        buffer: window.buffer
+      }
+
+      {gutter_layer, _content_layer, _rows, _window} =
+        ContentHelpers.render_lines_nowrap_layers(lines, opts)
+
+      assert {col, "▼", face} =
+               Enum.find(Map.get(gutter_layer, 0), fn {_col, text, _face} -> text == "▼" end)
+
+      assert col == Gutter.fold_column_offset()
+      assert face.fg == ctx.gutter_colors.fold_fg
+    end
+
+    test "open fold indicator appears on mouse hover row", %{
+      ctx: ctx,
+      window: window
+    } do
+      lines = ["defmodule Example do", "  def run, do: :ok", "end"]
+      fold_range = FoldRange.new!(0, 2)
+      window = Window.set_fold_ranges(window, [fold_range])
+      ctx = %{ctx | fold_ranges: [fold_range], hover_row: 0}
+
+      opts = %{
+        first_line: 0,
+        cursor_line: 10,
+        ctx: ctx,
+        ln_style: :absolute,
+        gutter_w: 6,
+        first_byte_off: 0,
+        row_off: 0,
+        col_off: 0,
+        window: window,
+        buffer: window.buffer
+      }
+
+      {gutter_layer, _content_layer, _rows, _window} =
+        ContentHelpers.render_lines_nowrap_layers(lines, opts)
+
+      assert {col, "▼", face} =
+               Enum.find(Map.get(gutter_layer, 0), fn {_col, text, _face} -> text == "▼" end)
+
+      assert col == Gutter.fold_column_offset()
+      assert face.fg == ctx.gutter_colors.fold_fg
     end
 
     test "folded lines render a right chevron in the gutter", %{ctx: ctx, window: window} do

--- a/test/minga_editor/render_pipeline/content_helpers_test.exs
+++ b/test/minga_editor/render_pipeline/content_helpers_test.exs
@@ -318,10 +318,11 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
       %{buf: buf, ctx: ctx, window: window}
     end
 
-    test "expanded foldable lines render a down chevron in the gutter when cursor is on fold start", %{
-      ctx: ctx,
-      window: window
-    } do
+    test "expanded foldable lines render a down chevron in the gutter when cursor is on fold start",
+         %{
+           ctx: ctx,
+           window: window
+         } do
       lines = ["defmodule Example do", "  def run, do: :ok", "end"]
       fold_range = FoldRange.new!(0, 2)
       window = Window.set_fold_ranges(window, [fold_range])


### PR DESCRIPTION
## Summary

- Open fold indicators (▼) now only appear when the cursor is on or inside the fold range, or when the mouse hovers over the fold's opening line. Keeps the gutter clean by default.
- Collapsed fold indicators (▶) always show unconditionally since they hide content the user might not know about.
- Adds `hover_row` and `fold_ranges` to the render Context so the content stage can gate fold indicator visibility.

## Test plan

- [x] Existing fold indicator test updated: verifies ▼ appears when cursor is on fold start line
- [x] New test: ▼ hidden when cursor and hover are both outside fold range
- [x] New test: ▼ appears when cursor is inside fold range (not just on start line)
- [x] New test: ▼ appears on mouse hover row
- [x] Collapsed fold (▶) tests unchanged and passing
- [x] All 25 content helpers tests pass
- [x] All 4360 editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)