### PR TITLE
fix(macos): clean up chrome and file tree leader routing

### DIFF
--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -155,6 +155,16 @@ defmodule MingaEditor.Input.FileTreeHandler do
   @spec handle_file_tree_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
   defp handle_file_tree_key(state, cp, mods) do
+    if Minga.Editing.in_leader?(state) do
+      {:handled, delegate_leader_to_mode_fsm(state, cp, mods)}
+    else
+      handle_non_leader_file_tree_key(state, cp, mods)
+    end
+  end
+
+  @spec handle_non_leader_file_tree_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          MingaEditor.Input.Handler.result()
+  defp handle_non_leader_file_tree_key(state, cp, mods) do
     if Input.key_sequence_pending?(state) do
       {:handled, delegate_to_mode_fsm_with_tree_buffer(state, cp, mods)}
     else
@@ -181,6 +191,21 @@ defmodule MingaEditor.Input.FileTreeHandler do
     end
   end
 
+  @spec delegate_leader_to_mode_fsm(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          EditorState.t()
+  defp delegate_leader_to_mode_fsm(state, cp, mods) do
+    real_active = state.workspace.buffers.active
+    state = MingaEditor.do_handle_key(state, cp, mods)
+
+    if state.workspace.buffers.active != real_active do
+      state
+      |> update_file_tree(&FileTreeState.unfocus/1)
+      |> EditorState.set_keymap_scope(:editor)
+    else
+      state
+    end
+  end
+
   @spec delegate_to_mode_fsm_with_tree_buffer(
           EditorState.t(),
           non_neg_integer(),
@@ -201,7 +226,12 @@ defmodule MingaEditor.Input.FileTreeHandler do
             state
           end
 
-        state = set_active_buffer_override(state, real_active)
+        state =
+          if state.workspace.buffers.active == buf do
+            set_active_buffer_override(state, real_active)
+          else
+            state
+          end
 
         case file_tree_state(state).tree do
           nil -> state

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -144,6 +144,10 @@ struct ContentView: View {
         appState.isFullScreen ? 10 : 84
     }
 
+    private var sidebarHeaderLeadingPadding: CGFloat {
+        appState.isFullScreen ? 12 : 36
+    }
+
     private var projectName: String {
         if !appState.gui.fileTreeState.projectRoot.isEmpty {
             return (appState.gui.fileTreeState.projectRoot as NSString).lastPathComponent
@@ -196,8 +200,12 @@ struct ContentView: View {
     private let contentHeight: CGFloat = 28
     private let workspaceHeaderHeight: CGFloat = 30
 
+    private var showsWorkspaceHeader: Bool {
+        appState.gui.workspaceState.shouldShowHeader
+    }
+
     private var toolbarContentHeight: CGFloat {
-        appState.gui.workspaceState.hasCanonicalPayload ? contentHeight + workspaceHeaderHeight : contentHeight
+        showsWorkspaceHeader ? contentHeight + workspaceHeaderHeight : contentHeight
     }
 
     private var toolbarTopPadding: CGFloat {
@@ -226,7 +234,7 @@ struct ContentView: View {
                 }
 
                 VStack(spacing: 0) {
-                    if appState.gui.workspaceState.hasCanonicalPayload {
+                    if showsWorkspaceHeader {
                         WorkspaceHeaderView(
                             workspaceState: appState.gui.workspaceState,
                             theme: theme,
@@ -280,7 +288,7 @@ struct ContentView: View {
             encoder: appState.encoder,
             projectName: projectName,
             gitBranch: gitBranch,
-            leadingPadding: titleBarLeadingPadding
+            leadingPadding: sidebarHeaderLeadingPadding
         )
     }
 

--- a/macos/Sources/Views/FileTreeHeaderContent.swift
+++ b/macos/Sources/Views/FileTreeHeaderContent.swift
@@ -70,44 +70,59 @@ struct FileTreeHeaderContent: View {
     @ViewBuilder
     private var secondaryContext: some View {
         if !branchName.isEmpty {
-            badge(icon: "\u{E725}", label: branchName)
+            secondaryLabel(icon: "\u{E725}", label: branchName)
         } else if let stateLabel = treeStateLabel {
-            badge(icon: treeStateIcon, label: stateLabel)
+            secondaryLabel(icon: treeStateIcon, label: stateLabel)
         }
     }
 
-    private func badge(icon: String, label: String) -> some View {
+    private func secondaryLabel(icon: String, label: String) -> some View {
         HStack(spacing: 4) {
             Text(icon)
                 .font(.custom("Symbols Nerd Font Mono", size: 11))
-                .foregroundStyle(theme.treeDirFg.opacity(0.55))
+                .foregroundStyle(theme.treeDirFg.opacity(0.48))
 
             Text(label)
                 .font(.system(size: 11, weight: .regular))
-                .foregroundStyle(theme.tabActiveFg.opacity(0.62))
+                .foregroundStyle(theme.tabActiveFg.opacity(0.56))
                 .lineLimit(1)
                 .truncationMode(.middle)
         }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 2)
-        .background(theme.treeHeaderFg.opacity(0.08), in: Capsule())
     }
 
     private var actionButtons: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: 0) {
             headerButton(systemName: "doc.badge.plus", tooltip: "New File…") {
                 encoder?.sendFileTreeNewFile(parentIndex: UInt16(fileTreeState.selectedIndex))
             }
-            headerButton(systemName: "folder.badge.plus", tooltip: "New Folder…") {
+
+            overflowMenu
+        }
+    }
+
+    private var overflowMenu: some View {
+        Menu {
+            Button("New Folder…") {
                 encoder?.sendFileTreeNewFolder(parentIndex: UInt16(fileTreeState.selectedIndex))
             }
-            headerButton(systemName: "arrow.clockwise", tooltip: "Refresh") {
+            Button("Refresh") {
                 encoder?.sendFileTreeRefresh()
             }
-            headerButton(systemName: "arrow.down.right.and.arrow.up.left", tooltip: "Collapse All") {
+            Button("Collapse All") {
                 encoder?.sendFileTreeCollapseAll()
             }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 10.5, weight: .medium))
+                .foregroundStyle(theme.tabInactiveFg.opacity(0.55))
+                .frame(width: 28, height: 34)
+                .contentShape(Rectangle())
         }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(width: 28)
+        .help("More file tree actions")
+        .accessibilityLabel("More file tree actions")
     }
 
     @ViewBuilder

--- a/macos/Sources/Views/WorkspaceHeaderView.swift
+++ b/macos/Sources/Views/WorkspaceHeaderView.swift
@@ -11,14 +11,16 @@ struct WorkspaceHeaderView: View {
     @State private var showIconPicker = false
     @FocusState private var renameFieldFocused: Bool
 
-    private let rowHeight: CGFloat = 30
+    private let rowHeight: CGFloat = 26
 
     var body: some View {
         HStack(spacing: 8) {
             if let activeWorkspace = workspaceState.activeWorkspace {
                 activeWorkspacePill(activeWorkspace)
 
-                workspaceSwitcher
+                if workspaceState.workspaces.count > 1 {
+                    workspaceSwitcher
+                }
 
                 if activeWorkspace.isAgent {
                     agentStatusButton(activeWorkspace)
@@ -44,25 +46,20 @@ struct WorkspaceHeaderView: View {
         .background(theme.tabBg)
         .overlay(alignment: .bottom) {
             Rectangle()
-                .fill(theme.tabSeparatorFg.opacity(0.25))
+                .fill(theme.tabSeparatorFg.opacity(0.16))
                 .frame(height: 1)
         }
         .accessibilityIdentifier("workspace-header")
     }
 
     private func activeWorkspacePill(_ workspace: WorkspaceSummaryEntry) -> some View {
-        let pillBackground = Capsule().fill(workspace.color.opacity(0.18))
-        let pillBorder = Capsule().stroke(workspace.color.opacity(0.55), lineWidth: 1)
-
-        return HStack(spacing: 6) {
+        HStack(spacing: 6) {
             workspaceIcon(workspace)
             workspaceTitle(workspace)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 4)
-        .background(pillBackground)
-        .overlay(pillBorder)
-        .accessibilityIdentifier("workspace-pill-\(workspace.id)")
+        .padding(.horizontal, 4)
+        .frame(height: rowHeight)
+        .accessibilityIdentifier("workspace-label-\(workspace.id)")
         .accessibilityLabel("Workspace \(workspace.label)")
         .accessibilityValue(workspaceValue(workspace))
         .contextMenu {

--- a/macos/Sources/Views/WorkspaceState.swift
+++ b/macos/Sources/Views/WorkspaceState.swift
@@ -57,6 +57,24 @@ final class WorkspaceState {
         flags & 0x01 != 0 || workspaces.contains(where: { $0.hasAttention })
     }
 
+    var shouldShowHeader: Bool {
+        guard hasCanonicalPayload else { return false }
+        guard let activeWorkspace else { return false }
+
+        return workspaces.count > 1 ||
+            activeWorkspace.isAgent ||
+            activeWorkspace.isCloseable ||
+            activeWorkspace.hasAttention ||
+            activeWorkspace.draftCount > 0 ||
+            activeWorkspace.conflictCount > 0 ||
+            activeWorkspace.runningBackgroundCount > 0 ||
+            backgroundRunningCount > 0 ||
+            backgroundDraftCount > 0 ||
+            backgroundConflictCount > 0 ||
+            backgroundAttentionCount > 0 ||
+            backgroundErrorCount > 0
+    }
+
     var backgroundWorkspaces: [WorkspaceSummaryEntry] {
         workspaces.filter { $0.id != activeWorkspaceId }
     }

--- a/test/minga/buffer_management_test.exs
+++ b/test/minga/buffer_management_test.exs
@@ -134,6 +134,36 @@ defmodule Minga.BufferManagementTest do
       assert active_content(ctx) == "some text"
     end
 
+    test "SPC b d closes the active scratch buffer when multiple scratch buffers are open" do
+      ctx = start_editor("")
+      send_keys_sync(ctx, "<SPC>bN")
+      send_keys_sync(ctx, "iHey there<Esc>")
+
+      assert active_content(ctx) == "Hey there"
+
+      send_keys_sync(ctx, "<SPC>bd")
+
+      assert active_content(ctx) == ""
+      refute status_msg(ctx) == "Cannot close the last window"
+    end
+
+    @tag :tmp_dir
+    test "SPC b d closes the active scratch buffer while the file tree is visible", %{
+      tmp_dir: tmp_dir
+    } do
+      ctx = start_editor("", project_root: tmp_dir)
+      send_keys_sync(ctx, "<SPC>op")
+      send_keys_sync(ctx, "<SPC>bN")
+      send_keys_sync(ctx, "iHey there<Esc>")
+
+      assert active_content(ctx) == "Hey there"
+
+      send_keys_sync(ctx, "<SPC>bd")
+
+      assert active_content(ctx) == ""
+      refute status_msg(ctx) == "Cannot close the last window"
+    end
+
     test "SPC b N creates an empty buffer" do
       ctx = start_editor("hello")
       send_keys_sync(ctx, "<SPC>bN")

--- a/test/support/render_pipeline_test_helpers.ex
+++ b/test/support/render_pipeline_test_helpers.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.RenderPipeline.TestHelpers do
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.DisplayList
   alias MingaEditor.DisplayList.{Cursor, Frame, WindowFrame}
+  alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Layout
   alias MingaEditor.RenderPipeline.Input, as: PipelineInput
   alias MingaEditor.Shell.Identity, as: ShellIdentity
@@ -39,8 +40,7 @@ defmodule MingaEditor.RenderPipeline.TestHelpers do
     content = Keyword.get(opts, :content, "line one\nline two\nline three")
     filetype = Keyword.get(opts, :filetype, :elixir)
 
-    sidebar_registry =
-      Keyword.get(opts, :sidebar_registry, MingaEditor.Extension.Sidebar.default_table())
+    sidebar_registry = Keyword.get_lazy(opts, :sidebar_registry, &private_sidebar_registry/0)
 
     {:ok, buf} = BufferProcess.start_link(content: content, filetype: filetype)
 
@@ -71,6 +71,13 @@ defmodule MingaEditor.RenderPipeline.TestHelpers do
       shell_identity: ShellIdentity.new(shell_entry),
       theme: Theme.get!(:doom_one)
     }
+  end
+
+  @spec private_sidebar_registry() :: Sidebar.table()
+  defp private_sidebar_registry do
+    table = Module.concat(__MODULE__, "Sidebar#{System.unique_integer([:positive])}")
+    {:ok, _pid} = Sidebar.start_link(name: table, notify: false)
+    table
   end
 
   @doc """


### PR DESCRIPTION
# TL;DR
Clean up the macOS editor chrome so the top bar feels calmer and fix file-tree leader routing so buffer commands like `SPC b d` act on the editor buffer, not the file tree buffer.

## Context
This started from visual feedback on the macOS chrome: the project name floated in the title area, the workspace chip looked overdesigned, and the file tree had duplicate affordances. After the chrome cleanup, `SPC b d` exposed a related focus bug when the file tree was visible: leader commands could run through the file-tree buffer swap path and restore the wrong active buffer.

CI then exposed an existing order-dependent render-pipeline test isolation issue: pipeline test helpers used the shared production sidebar registry by default, so async sidebar tests could make TUI emit tests see a sidebar and fall back to full redraw. This PR isolates those helpers with a private sidebar registry unless a test explicitly passes one.

## Changes
- Hide the workspace header for a single plain manual workspace so routine editor sessions keep one quiet top chrome row.
- Replace the workspace pill with a flat workspace label for cases where the workspace header is actually needed.
- Anchor the sidebar header to the sidebar instead of reserving full traffic-light padding.
- Simplify the file-tree header by making branch/state secondary text and moving extra file-tree actions behind an overflow menu.
- Route file-tree leader sequences through the real editor buffer so commands like `SPC b N` and `SPC b d` can legitimately change the active buffer.
- Isolate render-pipeline test helpers from the shared sidebar registry by default.
- Add regression coverage for closing scratch buffers with and without the file tree visible.

## Verification
- `make lint` passed, with existing large-struct Credo warnings only.
- `MIX_ENV=test mix test --warnings-as-errors --exclude system_clipboard --exclude conformance --seed 857800 --max-cases 8` passed, 8961 tests.
- `mix test.llm test/minga/buffer_management_test.exs test/minga_editor/input/scoped_test.exs test/minga_editor/input/vim_nav_integration_test.exs test/minga_editor/input/file_tree_nav_test.exs test/minga_editor/frontend/emit/tui_test.exs test/minga_editor/integration/agent_cursor_test.exs` passed, 109 tests.
- `mix swift.build` passed.
- `mix swift.harness` passed.
- Captured and inspected `minga-snapshot` previews for `EditorChromeView`, `TabBarView`, and `FileTreeView`.
