### PR TITLE
test(extension): isolate cleanup callback tests

### DIFF
--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -54,7 +54,8 @@ defmodule Minga.Config.Loader do
           after_error: String.t() | nil,
           lsp_settings: %{atom() => map()},
           keymap_server: keymap_server(),
-          options_server: options_server()
+          options_server: options_server(),
+          cleanup_callbacks: %{atom() => ContributionCleanup.cleanup_fun()} | nil
         }
 
   # ── Client API ──────────────────────────────────────────────────────────────
@@ -88,7 +89,12 @@ defmodule Minga.Config.Loader do
       )
       |> Options.validate_server!()
 
-    Agent.start_link(fn -> load_all(keymap_server, options_server, Minga.SafeMode.active?()) end,
+    cleanup_callbacks = Keyword.get(opts, :cleanup_callbacks)
+
+    Agent.start_link(
+      fn ->
+        load_all(keymap_server, options_server, Minga.SafeMode.active?(), cleanup_callbacks)
+      end,
       name: name
     )
   end
@@ -201,7 +207,8 @@ defmodule Minga.Config.Loader do
     # Stop all running extensions first. If that fails, do not tear down
     # registries or start a new load, because the old extension tree is still
     # partially live and a reset would orphan it.
-    stop_all_error = stop_all_extensions()
+    cleanup_callbacks = Agent.get(server, &Map.get(&1, :cleanup_callbacks))
+    stop_all_error = stop_all_extensions(cleanup_callbacks)
 
     if stop_all_error do
       Agent.update(server, fn state -> %{state | load_error: stop_all_error} end)
@@ -248,7 +255,7 @@ defmodule Minga.Config.Loader do
 
       # Re-run the full load sequence (includes starting extensions).
       # Reload deliberately ignores startup safe mode so fixed config can be loaded without restarting.
-      new_state = load_all(keymap_server, options_server, false)
+      new_state = load_all(keymap_server, options_server, false, cleanup_callbacks)
       Agent.update(server, fn _ -> new_state end)
 
       # Return error if any stage had problems
@@ -278,14 +285,22 @@ defmodule Minga.Config.Loader do
   # callback) won't see this dict and will fall back to registered defaults.
   # Extensions are skipped in test mode, so this only affects long-lived runtime
   # callers.
-  @spec load_all(keymap_server(), options_server(), boolean()) :: state()
-  defp load_all(keymap_server, options_server, safe_mode?) when is_boolean(safe_mode?) do
+  @spec load_all(
+          keymap_server(),
+          options_server(),
+          boolean(),
+          %{atom() => ContributionCleanup.cleanup_fun()} | nil
+        ) :: state()
+  defp load_all(keymap_server, options_server, safe_mode?, cleanup_callbacks)
+       when is_boolean(safe_mode?) do
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
     previous_options_server = Process.put(:minga_config_options, options_server)
     previous_lsp_settings = Process.put(:minga_config_lsp_settings, %{})
 
     try do
-      config_cleanup_error = cleanup_source_owned_config_contributions(keymap_server)
+      config_cleanup_error =
+        cleanup_source_owned_config_contributions(keymap_server, cleanup_callbacks)
+
       config_path = resolve_config_path()
       config_dir = Path.dirname(config_path)
 
@@ -293,7 +308,7 @@ defmodule Minga.Config.Loader do
       register_default_popup_rules()
 
       if safe_mode? do
-        safe_mode_state(config_path, config_dir, keymap_server, options_server)
+        safe_mode_state(config_path, config_dir, keymap_server, options_server, cleanup_callbacks)
       else
         # 1. Compile user modules
         {loaded_modules, modules_errors} = compile_user_modules(config_dir)
@@ -345,7 +360,7 @@ defmodule Minga.Config.Loader do
         start_all_error =
           if Process.whereis(Minga.Extension.Supervisor) != nil &&
                Application.get_env(:minga, :load_extensions, true) do
-            start_all_extensions()
+            start_all_extensions(cleanup_callbacks)
           end
 
         load_error =
@@ -370,7 +385,8 @@ defmodule Minga.Config.Loader do
           after_error: after_error,
           lsp_settings: lsp_settings,
           keymap_server: keymap_server,
-          options_server: options_server
+          options_server: options_server,
+          cleanup_callbacks: cleanup_callbacks
         }
       end
     after
@@ -380,8 +396,14 @@ defmodule Minga.Config.Loader do
     end
   end
 
-  @spec safe_mode_state(String.t(), String.t(), keymap_server(), options_server()) :: state()
-  defp safe_mode_state(config_path, config_dir, keymap_server, options_server) do
+  @spec safe_mode_state(
+          String.t(),
+          String.t(),
+          keymap_server(),
+          options_server(),
+          %{atom() => ContributionCleanup.cleanup_fun()} | nil
+        ) :: state()
+  defp safe_mode_state(config_path, config_dir, keymap_server, options_server, cleanup_callbacks) do
     %{
       config_path: config_path,
       load_error: nil,
@@ -394,7 +416,8 @@ defmodule Minga.Config.Loader do
       after_error: nil,
       lsp_settings: %{},
       keymap_server: keymap_server,
-      options_server: options_server
+      options_server: options_server,
+      cleanup_callbacks: cleanup_callbacks
     }
   end
 
@@ -479,9 +502,14 @@ defmodule Minga.Config.Loader do
     :ok
   end
 
-  @spec start_all_extensions() :: String.t() | nil
-  defp start_all_extensions do
-    case ExtSupervisor.start_all() do
+  @spec start_all_extensions(%{atom() => ContributionCleanup.cleanup_fun()} | nil) ::
+          String.t() | nil
+  defp start_all_extensions(cleanup_callbacks) do
+    case ExtSupervisor.start_all(
+           Minga.Extension.Supervisor,
+           Minga.Extension.Registry,
+           cleanup_opts(cleanup_callbacks)
+         ) do
       :ok ->
         nil
 
@@ -492,9 +520,14 @@ defmodule Minga.Config.Loader do
     end
   end
 
-  @spec stop_all_extensions() :: String.t() | nil
-  defp stop_all_extensions do
-    case ExtSupervisor.stop_all() do
+  @spec stop_all_extensions(%{atom() => ContributionCleanup.cleanup_fun()} | nil) ::
+          String.t() | nil
+  defp stop_all_extensions(cleanup_callbacks) do
+    case ExtSupervisor.stop_all(
+           Minga.Extension.Supervisor,
+           Minga.Extension.Registry,
+           cleanup_opts(cleanup_callbacks)
+         ) do
       :ok ->
         nil
 
@@ -505,9 +538,14 @@ defmodule Minga.Config.Loader do
     end
   end
 
-  @spec cleanup_source_owned_config_contributions(keymap_server()) :: String.t() | nil
-  defp cleanup_source_owned_config_contributions(keymap_server) do
-    case ContributionCleanup.unregister_source(:config, keymap: keymap_server) do
+  @spec cleanup_source_owned_config_contributions(
+          keymap_server(),
+          %{atom() => ContributionCleanup.cleanup_fun()} | nil
+        ) :: String.t() | nil
+  defp cleanup_source_owned_config_contributions(keymap_server, cleanup_callbacks) do
+    cleanup_opts = Keyword.merge([keymap: keymap_server], cleanup_opts(cleanup_callbacks))
+
+    case ContributionCleanup.unregister_source(:config, cleanup_opts) do
       :ok ->
         nil
 
@@ -517,6 +555,10 @@ defmodule Minga.Config.Loader do
         msg
     end
   end
+
+  @spec cleanup_opts(%{atom() => ContributionCleanup.cleanup_fun()} | nil) :: keyword()
+  defp cleanup_opts(nil), do: []
+  defp cleanup_opts(callbacks) when is_map(callbacks), do: [callbacks: callbacks]
 
   @spec merge_error_messages([String.t() | nil]) :: String.t() | nil
   defp merge_error_messages(messages) do

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -157,13 +157,17 @@ defmodule Minga.Extension.Supervisor do
 
   @spec stop_all() :: :ok | {:error, [stop_failure()]}
   @spec stop_all(GenServer.server(), GenServer.server()) :: :ok | {:error, [stop_failure()]}
+  @spec stop_all(GenServer.server(), GenServer.server(), start_opts()) ::
+          :ok | {:error, [stop_failure()]}
   def stop_all, do: stop_all(__MODULE__, ExtRegistry)
 
-  def stop_all(supervisor, registry) do
+  def stop_all(supervisor, registry), do: stop_all(supervisor, registry, [])
+
+  def stop_all(supervisor, registry, opts) do
     failures =
       ExtRegistry.all(registry)
       |> Enum.reduce([], fn {name, entry}, failures ->
-        case stop_extension(supervisor, registry, name, entry) do
+        case stop_extension(supervisor, registry, name, entry, opts) do
           :ok -> failures
           {:error, reason} -> [%{extension: name, reason: reason} | failures]
         end

--- a/lib/minga_editor/feature_state.ex
+++ b/lib/minga_editor/feature_state.ex
@@ -133,21 +133,37 @@ defmodule MingaEditor.FeatureState do
 
   @doc "Cleanup callback bridge used by `Minga.Extension.ContributionCleanup`."
   @spec unregister_source(source()) :: :ok | {:error, term()}
-  def unregister_source(source) do
+  def unregister_source(source), do: unregister_source(source, MingaEditor)
+
+  @doc "Cleanup callback bridge against an explicit editor server. Useful for tests."
+  @spec unregister_source(source(), GenServer.server() | nil) :: :ok | {:error, term()}
+  def unregister_source(source, editor_server) do
     if valid_source?(source) do
-      unregister_valid_source(source)
+      unregister_valid_source(source, editor_server)
     else
       :ok
     end
   end
 
-  @spec unregister_valid_source(source()) :: :ok | {:error, term()}
-  defp unregister_valid_source(source) do
-    case Process.whereis(MingaEditor) do
+  @spec unregister_valid_source(source(), GenServer.server() | nil) :: :ok | {:error, term()}
+  defp unregister_valid_source(_source, nil), do: :ok
+
+  defp unregister_valid_source(source, pid) when is_pid(pid) do
+    unregister_from_editor_pid(source, pid)
+  end
+
+  defp unregister_valid_source(source, name) when is_atom(name) do
+    case Process.whereis(name) do
       nil -> :ok
-      pid when pid == self() -> unregister_from_editor_process(source)
-      pid -> GenServer.call(pid, {:cleanup_feature_state, source}, :infinity)
+      pid -> unregister_from_editor_pid(source, pid)
     end
+  end
+
+  @spec unregister_from_editor_pid(source(), pid()) :: :ok | {:error, term()}
+  defp unregister_from_editor_pid(source, pid) do
+    if pid == self(),
+      do: unregister_from_editor_process(source),
+      else: GenServer.call(pid, {:cleanup_feature_state, source}, :infinity)
   end
 
   @spec unregister_from_editor_process(source()) :: :ok

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -912,7 +912,10 @@ defmodule Minga.Config.LoaderTest do
 
     test "reload clears stale config-owned keybinds, themes, languages, recipes, and scopes",
          ctx do
-      ContributionCleanup.unregister_source(:config, keymap: ctx.keymap_server)
+      ContributionCleanup.unregister_source(:config,
+        keymap: ctx.keymap_server,
+        callbacks: %{themes: &Theme.unregister_source/1}
+      )
 
       {minga_dir, cleanup} =
         make_config_dir("""
@@ -951,7 +954,11 @@ defmodule Minga.Config.LoaderTest do
       on_exit(cleanup)
 
       on_exit(fn ->
-        ContributionCleanup.unregister_source(:config, keymap: ctx.keymap_server)
+        ContributionCleanup.unregister_source(:config,
+          keymap: ctx.keymap_server,
+          callbacks: %{themes: &Theme.unregister_source/1}
+        )
+
         Theme.unregister_source(:config)
       end)
 
@@ -1048,17 +1055,17 @@ defmodule Minga.Config.LoaderTest do
 
       on_exit(cleanup)
 
+      cleanup_callbacks = %{
+        loader_reload_cleanup_failure: fn
+          :config -> raise "cleanup failure"
+          _source -> :ok
+        end
+      }
+
       name = :"loader_reload_cleanup_failure_#{System.unique_integer([:positive])}"
       {:ok, pid} = Loader.start_link(name: name)
       assert Loader.load_error(pid) == nil
-
-      assert :ok =
-               ContributionCleanup.register(:loader_reload_cleanup_failure, fn
-                 :config -> raise "cleanup failure"
-                 _source -> :ok
-               end)
-
-      on_exit(fn -> ContributionCleanup.unregister(:loader_reload_cleanup_failure) end)
+      Agent.update(pid, &Map.put(&1, :cleanup_callbacks, cleanup_callbacks))
 
       assert {:error, msg} = Loader.reload(pid)
       assert msg =~ "Config reload cleanup for :config failed"
@@ -1213,11 +1220,18 @@ defmodule Minga.Config.LoaderTest do
         :code.delete(ext_module)
       end)
 
-      cleanup_family =
-        String.to_atom("loader_reload_start_all_cleanup_#{System.unique_integer([:positive])}")
+      cleanup_callbacks = %{
+        loader_reload_start_all_cleanup: fn
+          {:extension, :loader_start_all_failure} ->
+            raise "cleanup failure"
+
+          _source ->
+            :ok
+        end
+      }
 
       name = :"loader_reload_start_all_#{System.unique_integer([:positive])}"
-      {:ok, pid} = Loader.start_link(name: name)
+      {:ok, pid} = Loader.start_link(name: name, cleanup_callbacks: cleanup_callbacks)
       assert Loader.load_error(pid) == nil
 
       File.write!(
@@ -1227,17 +1241,6 @@ defmodule Minga.Config.LoaderTest do
         extension :loader_start_all_failure, path: #{inspect(ext_dir)}
         """
       )
-
-      assert :ok =
-               ContributionCleanup.register(cleanup_family, fn
-                 {:extension, :loader_start_all_failure} ->
-                   raise "cleanup failure"
-
-                 _source ->
-                   :ok
-               end)
-
-      on_exit(fn -> ContributionCleanup.unregister(cleanup_family) end)
 
       assert {:error, msg} = Loader.reload(pid)
       assert msg =~ "Extension start_all failed"

--- a/test/minga/extension/contribution_cleanup_test.exs
+++ b/test/minga/extension/contribution_cleanup_test.exs
@@ -1,5 +1,5 @@
 defmodule Minga.Extension.ContributionCleanupTest do
-  # Exercises global cleanup registries and persistent_term callback tables.
+  # Not async: uses process-global Minga.Language.Registry.
   use ExUnit.Case, async: false
 
   alias Minga.Extension.ContributionCleanup
@@ -12,7 +12,6 @@ defmodule Minga.Extension.ContributionCleanupTest do
     keymap = start_supervised!({KeymapActive, name: keymap_name})
 
     on_exit(fn ->
-      ContributionCleanup.unregister(:cleanup_followup)
       LanguageRegistry.unregister_source({:extension, :cleanup_test})
     end)
 
@@ -21,6 +20,7 @@ defmodule Minga.Extension.ContributionCleanupTest do
 
   test "continues cleanup after one family fails and reports the failure", %{keymap: keymap} do
     source = {:extension, :cleanup_test}
+    test_pid = self()
 
     assert :ok =
              LanguageRegistry.register(
@@ -33,16 +33,18 @@ defmodule Minga.Extension.ContributionCleanupTest do
                source
              )
 
-    assert :ok =
-             ContributionCleanup.register(:cleanup_followup, fn callback_source ->
-               send(self(), {:cleanup_followup, callback_source})
-               :ok
-             end)
+    callbacks = %{
+      cleanup_followup: fn callback_source ->
+        send(test_pid, {:cleanup_followup, callback_source})
+        :ok
+      end
+    }
 
     assert {:error, failures} =
              ContributionCleanup.unregister_source(source,
                command_registry: :missing_cleanup_registry,
-               keymap: keymap
+               keymap: keymap,
+               callbacks: callbacks
              )
 
     assert Enum.any?(failures, fn

--- a/test/minga/extension/source_cleanup_test.exs
+++ b/test/minga/extension/source_cleanup_test.exs
@@ -1,5 +1,5 @@
 defmodule Minga.Extension.SourceCleanupTest do
-  # Exercises global source-owned registries that use ETS or persistent_term.
+  # Not async: uses process-global language, theme, input, recipe, and modeline registries.
   use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
@@ -106,16 +106,7 @@ defmodule Minga.Extension.SourceCleanupTest do
 
   test "failed init reports cleanup failures and still runs later cleanup callbacks",
        ctx do
-    assert :ok =
-             ContributionCleanup.register(:aaa_cleanup_failure, fn _source ->
-               raise "cleanup failure"
-             end)
-
-    assert :ok =
-             ContributionCleanup.register(:zzz_cleanup_followup, fn source ->
-               send(self(), {:cleanup_followup, source})
-               :ok
-             end)
+    callbacks = cleanup_failure_callbacks(self(), followup?: true)
 
     {path, cleanup} =
       make_extension("CleanupFailure", """
@@ -148,8 +139,6 @@ defmodule Minga.Extension.SourceCleanupTest do
 
     on_exit(fn ->
       cleanup.()
-      ContributionCleanup.unregister(:aaa_cleanup_failure)
-      ContributionCleanup.unregister(:zzz_cleanup_followup)
       :code.purge(Minga.TestExtensions.CleanupFailure)
       :code.delete(Minga.TestExtensions.CleanupFailure)
     end)
@@ -167,7 +156,8 @@ defmodule Minga.Extension.SourceCleanupTest do
                    :cleanup_failure,
                    entry,
                    command_registry: ctx.command_registry,
-                   keymap: ctx.keymap
+                   keymap: ctx.keymap,
+                   callbacks: callbacks
                  )
 
         assert Enum.any?(failures, fn
@@ -401,12 +391,7 @@ defmodule Minga.Extension.SourceCleanupTest do
     assert :ok =
              Minga.Keymap.Active.bind(ctx.keymap, :insert, "C-j", :config_cmd, "Config binding")
 
-    assert :ok =
-             ContributionCleanup.register(:aaa_cleanup_failure, fn _source ->
-               raise "cleanup failure"
-             end)
-
-    on_exit(fn -> ContributionCleanup.unregister(:aaa_cleanup_failure) end)
+    callbacks = cleanup_failure_callbacks(self(), followup?: false)
 
     {path, cleanup} =
       make_extension("KeybindCleanupFailure", """
@@ -450,7 +435,8 @@ defmodule Minga.Extension.SourceCleanupTest do
                :keybind_cleanup_failure,
                entry,
                command_registry: ctx.command_registry,
-               keymap: ctx.keymap
+               keymap: ctx.keymap,
+               callbacks: callbacks
              )
 
     assert reason =~ "already"
@@ -534,7 +520,9 @@ defmodule Minga.Extension.SourceCleanupTest do
       )
 
     healthy_ref = Process.monitor(healthy_pid)
-    assert {:error, failures} = ExtSupervisor.stop_all(ctx.supervisor, ctx.registry)
+
+    assert {:error, failures} =
+             ExtSupervisor.stop_all(ctx.supervisor, ctx.registry, callbacks: %{})
 
     assert Enum.any?(failures, fn
              %{extension: :stop_all_broken, reason: reason} -> reason != nil
@@ -635,6 +623,7 @@ defmodule Minga.Extension.SourceCleanupTest do
              Minga.Config.ModelineSegments.lookup(:source_cleanup_segment)
 
     editor_pid = start_fake_editor(source_cleanup_editor_state())
+    callbacks = source_cleanup_callbacks(editor_pid)
 
     {:ok, running_entry} = ExtRegistry.get(ctx.registry, :source_cleanup)
 
@@ -645,8 +634,11 @@ defmodule Minga.Extension.SourceCleanupTest do
                :source_cleanup,
                running_entry,
                command_registry: ctx.command_registry,
-               keymap: ctx.keymap
+               keymap: ctx.keymap,
+               callbacks: callbacks
              )
+
+    assert_receive {:fake_editor_cleanup_feature_state, {:extension, :source_cleanup}}, 1_000
 
     cleaned_editor_state = fake_editor_state(editor_pid)
     stop_fake_editor(editor_pid)
@@ -679,6 +671,37 @@ defmodule Minga.Extension.SourceCleanupTest do
     assert :error = MingaEditor.UI.Theme.get(:source_cleanup_theme)
     assert Minga.Tool.Recipe.Registry.get(:source_cleanup_recipe) == nil
     assert Minga.Config.ModelineSegments.lookup(:source_cleanup_segment) == nil
+  end
+
+  @spec cleanup_failure_callbacks(pid(), keyword()) :: %{
+          atom() => ContributionCleanup.cleanup_fun()
+        }
+  defp cleanup_failure_callbacks(test_pid, opts) do
+    callbacks = %{
+      aaa_cleanup_failure: fn _source ->
+        raise "cleanup failure"
+      end
+    }
+
+    if Keyword.get(opts, :followup?, false) do
+      Map.put(callbacks, :zzz_cleanup_followup, fn source ->
+        send(test_pid, {:cleanup_followup, source})
+        :ok
+      end)
+    else
+      callbacks
+    end
+  end
+
+  @spec source_cleanup_callbacks(pid()) :: %{atom() => ContributionCleanup.cleanup_fun()}
+  defp source_cleanup_callbacks(editor_pid) do
+    %{
+      feature_state: fn source ->
+        GenServer.call(editor_pid, {:cleanup_feature_state, source}, :infinity)
+      end,
+      input_handlers: &MingaEditor.Input.unregister_source/1,
+      themes: &MingaEditor.UI.Theme.unregister_source/1
+    }
   end
 
   @spec source_cleanup_editor_state() :: EditorState.t()
@@ -726,9 +749,8 @@ defmodule Minga.Extension.SourceCleanupTest do
 
     pid =
       spawn_link(fn ->
-        Process.register(self(), MingaEditor)
         send(caller, :fake_editor_ready)
-        fake_editor_loop(state)
+        fake_editor_loop(state, caller)
       end)
 
     assert_receive :fake_editor_ready
@@ -750,19 +772,19 @@ defmodule Minga.Extension.SourceCleanupTest do
     :ok
   end
 
-  @spec fake_editor_loop(EditorState.t()) :: no_return()
-  defp fake_editor_loop(state) do
+  @spec fake_editor_loop(EditorState.t(), pid()) :: no_return()
+  defp fake_editor_loop(state, test_pid) do
     receive do
       {:"$gen_call", from, {:cleanup_feature_state, source}} ->
         GenServer.reply(from, :ok)
-        fake_editor_loop(EditorState.drop_feature_state_source(state, source))
+        send(test_pid, {:fake_editor_cleanup_feature_state, source})
+        fake_editor_loop(EditorState.drop_feature_state_source(state, source), test_pid)
 
       {:get_state, caller} ->
         send(caller, {:fake_editor_state, state})
-        fake_editor_loop(state)
+        fake_editor_loop(state, test_pid)
 
       :stop ->
-        Process.unregister(MingaEditor)
         exit(:normal)
     end
   end

--- a/test/minga_editor/feature_state_cleanup_test.exs
+++ b/test/minga_editor/feature_state_cleanup_test.exs
@@ -1,6 +1,5 @@
 defmodule MingaEditor.FeatureStateCleanupTest do
-  # Registers a temporary process under the global MingaEditor name.
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias MingaEditor.FeatureState
 
@@ -10,7 +9,7 @@ defmodule MingaEditor.FeatureStateCleanupTest do
     pid = start_fake_editor()
 
     try do
-      assert FeatureState.unregister_source(@source) == :ok
+      assert FeatureState.unregister_source(@source, pid) == :ok
       assert_received {:cleanup_finished, @source}
     after
       stop_fake_editor(pid)
@@ -61,7 +60,6 @@ defmodule MingaEditor.FeatureStateCleanupTest do
 
   @spec fake_editor_loop(pid()) :: no_return()
   defp fake_editor_loop(test_pid) do
-    Process.register(self(), MingaEditor)
     send(test_pid, :fake_editor_ready)
     fake_editor_receive(test_pid)
   end
@@ -75,11 +73,10 @@ defmodule MingaEditor.FeatureStateCleanupTest do
         fake_editor_receive(test_pid)
 
       {:run_self_cleanup, caller, source} ->
-        send(caller, {:self_cleanup_result, FeatureState.unregister_source(source)})
+        send(caller, {:self_cleanup_result, FeatureState.unregister_source(source, self())})
         fake_editor_receive(test_pid)
 
       :stop ->
-        Process.unregister(MingaEditor)
         exit(:normal)
     end
   end


### PR DESCRIPTION
# TL;DR
Extension cleanup tests no longer depend on the global `ContributionCleanup` callback table or a fake globally registered `MingaEditor` process. Cleanup collaborators can now be injected in tests, which removes the source-cleanup flake caused by persistent global callback state.

## Context
The flaky source cleanup assertion happened when feature-state cleanup was not registered in the process-global cleanup callback table. The test was relying on global persistent state created lazily by earlier code, so test order could decide whether extension-owned feature state was actually removed.

## Changes
- Adds cleanup callback injection through `Minga.Config.Loader` and `Minga.Extension.Supervisor.stop_all/3`.
- Adds `MingaEditor.FeatureState.unregister_source/2` so tests can target an explicit editor process instead of registering a fake process globally as `MingaEditor`.
- Updates extension cleanup tests to pass per-test callback maps instead of calling `ContributionCleanup.register/2` and `unregister/1`.
- Updates loader cleanup failure tests to inject callback failures through the loader state.
- Clarifies `async: false` comments with the exact process-global registries that require serialization.

## Verification
- `make lint`
- `mix test.llm` (`56 doctests, 91 properties, 8925 tests, 0 failures, 285 excluded`)
- Focused cleanup tests: `mix test.llm test/minga/config/loader_test.exs test/minga/extension/source_cleanup_test.exs test/minga/extension/contribution_cleanup_test.exs test/minga_editor/feature_state_cleanup_test.exs test/minga_editor/feature_state_test.exs`
- Focused source cleanup seed loop passed before the final full-suite run.
- Targeted reviewer re-check: PASS

## Acceptance Criteria Addressed
- Cleanup tests do not rely on global `ContributionCleanup` callback registration ✅
- Feature-state cleanup test does not register a fake global `MingaEditor` process ✅
- Flaky source cleanup test has explicit per-test cleanup callback injection ✅
- Full validation is green ✅
