### PR TITLE
fix(editor): isolate startup mode in dot-repeat tests

### DIFF
--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -328,6 +328,7 @@ defmodule Minga.Extension.Supervisor do
     cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
     keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
     mark_start_attempt(registry, name)
+    purge_recompilable_module(entry)
 
     with {:ok, module} <-
            run_lifecycle_phase(name, :load, opts, fn -> compile_extension(entry.path) end),
@@ -1372,6 +1373,16 @@ defmodule Minga.Extension.Supervisor do
         {:error, "application #{package_atom} not found after Mix.install"}
     end
   end
+
+  @spec purge_recompilable_module(ExtRegistry.entry()) :: :ok
+  defp purge_recompilable_module(%{source_type: source_type, module: module})
+       when source_type in [:path, :git] and is_atom(module) and module != nil do
+    :code.purge(module)
+    :code.delete(module)
+    :ok
+  end
+
+  defp purge_recompilable_module(_entry), do: :ok
 
   @spec compile_extension(String.t()) :: {:ok, module()} | {:error, String.t()}
   defp compile_extension(path) do

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -73,6 +73,7 @@ defmodule MingaEditor do
           | {:width, pos_integer()}
           | {:height, pos_integer()}
           | {:editing_model, :vim | :cua}
+          | {:view_mode, Minga.CLI.view_mode()}
           | {:shell, :traditional | :board | module()}
           | {:project_root, String.t() | nil}
           | {:swap_dir, String.t()}

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -95,7 +95,8 @@ defmodule MingaEditor.Startup do
     dashboard = nil
 
     # Decide mode FIRST, then create the right window type.
-    {keymap_scope, _agentic_state} = startup_view_state(backend)
+    {keymap_scope, agentic_state} =
+      startup_view_state(backend, Keyword.get(opts, :view_mode), options_server)
 
     initial_window_id = 1
 
@@ -134,7 +135,8 @@ defmodule MingaEditor.Startup do
           active: initial_window_id,
           next_id: initial_window_id + 1
         },
-        keymap_scope: keymap_scope
+        keymap_scope: keymap_scope,
+        agent_ui: agentic_state
       }
       |> MingaEditor.Session.State.set_file_tree(file_tree)
 
@@ -362,15 +364,27 @@ defmodule MingaEditor.Startup do
   @spec startup_view_state(EditorState.backend()) :: {atom(), UIState.t()}
   def startup_view_state(backend) do
     cli_flags = Minga.CLI.startup_flags()
-    startup_view_state(backend, cli_flags.view_mode)
+    startup_view_state(backend, cli_flags.view_mode, nil)
   end
 
-  @spec startup_view_state(EditorState.backend(), Minga.CLI.view_mode()) :: {atom(), UIState.t()}
-  defp startup_view_state(_backend, :editor), do: editor_view_state()
-  defp startup_view_state(_backend, :agentic), do: agent_view_state()
+  @spec startup_view_state(
+          EditorState.backend(),
+          Minga.CLI.view_mode() | nil,
+          Minga.Config.Options.server() | nil
+        ) :: {atom(), UIState.t()}
+  defp startup_view_state(backend, nil, options_server) do
+    cli_flags = Minga.CLI.startup_flags()
+    startup_view_state(backend, cli_flags.view_mode, options_server)
+  end
 
-  defp startup_view_state(_backend, :auto),
+  defp startup_view_state(_backend, :editor, _options_server), do: editor_view_state()
+  defp startup_view_state(_backend, :agentic, _options_server), do: agent_view_state()
+
+  defp startup_view_state(_backend, :auto, nil),
     do: startup_view_state_from_config(Config.get(:startup_view))
+
+  defp startup_view_state(_backend, :auto, options_server),
+    do: startup_view_state_from_config(Minga.Config.Options.get(options_server, :startup_view))
 
   @spec startup_view_state_from_config(atom()) :: {atom(), UIState.t()}
   defp startup_view_state_from_config(:agent), do: agent_view_state()

--- a/test/minga/dot_repeat_test.exs
+++ b/test/minga/dot_repeat_test.exs
@@ -8,6 +8,7 @@ defmodule Minga.DotRepeatTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Config.Options
   alias MingaEditor
 
   @escape 27
@@ -20,7 +21,18 @@ defmodule Minga.DotRepeatTest do
     events_registry = :"dot_repeat_events_#{id}"
     project_root = isolated_project_root(id)
     start_supervised!({Minga.Events, name: events_registry})
-    {:ok, buffer} = BufferProcess.start_link(content: content, events_registry: events_registry)
+
+    options_server =
+      start_supervised!({Options, name: nil, events_registry: events_registry},
+        id: {:dot_repeat_options, id}
+      )
+
+    {:ok, buffer} =
+      BufferProcess.start_link(
+        content: content,
+        events_registry: events_registry,
+        options_server: options_server
+      )
 
     {:ok, editor} =
       MingaEditor.start_link(
@@ -30,6 +42,8 @@ defmodule Minga.DotRepeatTest do
         width: 80,
         height: 24,
         editing_model: :vim,
+        view_mode: :editor,
+        options_server: options_server,
         events_registry: events_registry,
         project_root: project_root,
         suppress_tool_prompts: true

--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -1910,13 +1910,21 @@ defmodule Minga.Extension.LifecycleContractTest do
 
     assert_receive {:stale_monitor_terminal_exit_blocked, monitor_pid}
 
-    assert {:ok, pid_b} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :stale_monitor_race,
-               entry
-             )
+    restart_log =
+      capture_log(fn ->
+        result =
+          ExtSupervisor.start_extension(
+            ctx.supervisor,
+            ctx.registry,
+            :stale_monitor_race,
+            entry
+          )
+
+        send(test_pid, {:stale_monitor_restart_result, result})
+      end)
+
+    assert_receive {:stale_monitor_restart_result, {:ok, pid_b}}
+    refute restart_log =~ "redefining module Minga.TestExtensions.StaleMonitorRace"
 
     assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
                     %{count: 0}, %{extension: :stale_monitor_race, phase: :crash_restart_count}}

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -170,6 +170,51 @@ defmodule MingaEditor.StartupTest do
   end
 
   describe "build_initial_state/1" do
+    test "uses supplied options server for automatic startup view" do
+      options_server = start_supervised!({Options, name: nil})
+      {:ok, :agent} = Options.set(options_server, :startup_view, :agent)
+      Application.put_env(:minga, :cli_startup_flags, %{view_mode: :auto, no_context: false})
+
+      state =
+        Startup.build_initial_state(
+          backend: :headless,
+          port_manager: nil,
+          parser_manager: nil,
+          options_server: options_server,
+          width: 80,
+          height: 24,
+          sidebar_registry: private_sidebar_registry()
+        )
+
+      assert state.workspace.keymap_scope == :agent
+      assert state.workspace.agent_ui.view.active
+    after
+      Application.delete_env(:minga, :cli_startup_flags)
+    end
+
+    test "explicit view_mode overrides configured startup view" do
+      options_server = start_supervised!({Options, name: nil})
+      {:ok, :agent} = Options.set(options_server, :startup_view, :agent)
+      Application.put_env(:minga, :cli_startup_flags, %{view_mode: :auto, no_context: false})
+
+      state =
+        Startup.build_initial_state(
+          backend: :headless,
+          port_manager: nil,
+          parser_manager: nil,
+          options_server: options_server,
+          view_mode: :editor,
+          width: 80,
+          height: 24,
+          sidebar_registry: private_sidebar_registry()
+        )
+
+      assert state.workspace.keymap_scope == :editor
+      refute state.workspace.agent_ui.view.active
+    after
+      Application.delete_env(:minga, :cli_startup_flags)
+    end
+
     test "registers FileTree dynamic sidebar and input contributions" do
       Input.reset_handlers()
       sidebar_registry = private_sidebar_registry()


### PR DESCRIPTION
# TL;DR
Fixes the dot-repeat indent flake by making editor startup mode test-local instead of reading leaked global startup state. Also purges known path/git extension modules before recompiling so restart-race tests do not emit stale module redefinition warnings.

## Context
`Minga.DotRepeatTest` could intermittently start in the agent keymap scope when another test leaked startup view state. In that scope, `>` did not reach the buffer indentation path, so `>>` could leave the buffer as `hello`. The extension lifecycle stale monitor test also recompiled the same generated module during a restart race while the old module was still loaded, producing a noisy `redefining module` warning.

## Changes
- Added explicit `view_mode` startup opts for `MingaEditor` and threaded them through `Startup.build_initial_state/1`.
- Made `:auto` startup view read from the supplied options server when present, preserving per-editor and per-test config isolation.
- Preserved the selected agent UI state in the initial workspace when startup mode is agent.
- Updated `Minga.DotRepeatTest` to use a private options server and force `view_mode: :editor`.
- Purged known path/git extension modules before recompiling path extensions.
- Added regression coverage for local startup-view resolution, explicit view-mode overrides, and warning-free stale monitor restart.

## Verification
- `mix test.llm test/minga/dot_repeat_test.exs test/minga_editor/startup_test.exs test/minga/extension/lifecycle_contract_test.exs`
- 20-seed stress loop for `test/minga/dot_repeat_test.exs:172`
- `mix format --check-formatted`
- `git diff --check`
- `make lint`
- `mix test.llm`
- `prtk-code-reviewer`: no high-confidence blockers
- `reviewer`: PASS

## Acceptance Criteria Addressed
- `Minga.DotRepeatTest` `>> then . indents twice` no longer depends on global startup state. ✅
- `Minga.TestExtensions.StaleMonitorRace` restart no longer emits the stale module redefinition warning. ✅
