### PR TITLE
fix(macos): stabilize split pane rendering

### DIFF
--- a/docs/RETAINED_GUI_RENDERING_SPEC.md
+++ b/docs/RETAINED_GUI_RENDERING_SPEC.md
@@ -30,7 +30,7 @@ The remediation has four goals:
 
 1. Replace pre-encoded UI payloads with semantic core models.
 2. Make `Minga.RenderModel` a real top-level frame model, not separate `ui_model` and `window_models` values carried through `emit_gui/4`.
-3. Finish the GUI window model contract: wrapped visual rows, non-buffer window surfaces, agent ownership boundaries, content epochs, and reset semantics.
+3. Finish the GUI window model contract: wrapped visual rows, pane geometry, input hit regions, non-buffer window surfaces, agent ownership boundaries, content epochs, and reset semantics.
 4. Start retained rendering only after model ownership is fixed, using stable row IDs and epochs rather than display-row cache keys.
 
 ### Non-negotiable rules
@@ -42,6 +42,7 @@ These rules prevent the same compromise from repeating:
 - A core GUI encoder must accept a semantic model and return bytes. It must not call `Buffer`, `Options`, `Language`, `MingaEditor`, or any process.
 - A component is not migrated until the old `ProtocolGUI.encode_gui_*` function is deleted or moved to a core protocol module with a semantic-model interface.
 - Adapter caches may store fingerprints and last encoded state. They must not become the visible model.
+- Pane rendering and input routing must be window-scoped. No GUI renderer or input path may use active-window gutter geometry, global frame width, or row-only cursorline state for pane-local drawing or hit testing.
 - No new delta protocol work starts until content epochs and full reset behavior exist.
 
 ### Remediation stack
@@ -80,17 +81,25 @@ Acceptance criteria:
 - `emit_gui/4` no longer separately threads `window_models`, `ui_model`, `metal_ui_cmds`, and `adapter_cmds` as independent render truths.
 - Existing wire format remains unchanged.
 
-#### 2. Finish the GUI window model contract
+#### 2. Finish the GUI window model, pane geometry, and hit-region contract
 
-`Minga.RenderModel.Window` is the best current data shape, but it is not finished.
+`Minga.RenderModel.Window` is the best current data shape, but it is not finished. Every GUI window needs one BEAM-authored pane geometry model derived from `Layout.get/1` and `WindowTree`. It must include the window id, total rect, content rect, text rect, gutter rect and metrics, clip rect, viewport summary, and input hit regions for text, gutter and fold controls, status/modeline targets, and split dividers. Swift may convert points to pixels and render native effects, but it must not infer pane ownership from active-window state, frame width, or global gutter fields.
 
 Acceptance criteria:
 
 - Wrapped lines produce multiple `Row` structs with `row_type: :wrap_continuation`, correct text slices, correct spans, correct cursor display coordinates, and tests with long ASCII, Unicode, tabs, and virtual text.
+- `RenderModel.Window` carries BEAM-authored pane geometry: `window_id`, total/content/text/gutter rects, clip rect, viewport, gutter metrics, and divider/hit-region metadata.
+- The GUI adapter sends enough window-scoped geometry for Swift to build one authoritative `PaneGeometry` per `window_id`; stale geometry is cleared on window destruction, split close, buffer switch, resize, frontend ready, and protocol recovery.
+- `CoreTextMetalRenderer` clips text, overlays, cursorline, gutters, indent guides, diagnostics, and selections to the owning pane rect. It no longer uses global `frameState.cols`, viewport width, or global `gutterCol` for pane-local drawing.
+- Cursorline is window-scoped, not row-only. In side-by-side splits, the active pane cursorline is clipped to that pane and never spans another pane.
+- `EditorNSView` hit testing resolves through the same pane geometry used for rendering. Pixel-to-cell conversion, gutter hover, fold chevrons, scroll targeting, and divider detection use clicked-pane geometry, not active/global gutter state.
+- Divider hover, press, drag, and release use one shared hit-region contract. If hover shows a resize cursor, the subsequent drag routes as split resize, not text selection.
+- Smooth scroll fractional offset is bound to the gesture's initial `window_id` until the gesture ends. Pointer movement or focus changes during the gesture must not transfer the offset to another pane.
+- BEAM mouse handling uses clicked-window targets for fold gutter, buffer content, resize, and scroll actions. Regression coverage includes inactive-pane gutter clicks, split close stale geometry, side-by-side clipping, cursorline pane clipping, divider drag, and smooth scroll across focus transitions.
 - `RenderModel.Window` gets `content_epoch` and reset triggers for frontend ready, window creation, window destruction, buffer switch, resize, font change, theme change, fold or wrap mode change, parser reset, and protocol recovery.
 - `full_refresh` is tied to epoch/reset semantics instead of being a loose flag that is always true.
 - Non-buffer window content is either encoded as first-class `content_kind` models or explicitly excluded from the GUI adapter with a tracked follow-up and no misleading `additional_window_models` path.
-- GUI window content tests cover folds, wraps, virtual lines, block decorations, diagnostic overlays, document highlights, search overlays, cursor visibility, and horizontal scroll.
+- GUI window content tests cover folds, wraps, virtual lines, block decorations, diagnostic overlays, document highlights, search overlays, cursor visibility, horizontal scroll, pane-local hit testing, and divider resizing.
 
 #### 3. Replace pre-encoded UI models with semantic models
 

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -111,6 +111,7 @@ final class CommandDispatcher {
             frameState.cursorShape = shape
 
         case .batchEnd:
+            pruneStaleWindowGeometry()
             if let firstRender = onFirstRender {
                 firstRender()
                 onFirstRender = nil
@@ -517,5 +518,13 @@ final class CommandDispatcher {
         }
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
+    }
+
+    private func pruneStaleWindowGeometry() {
+        guard !currentFrameGutterWindowIds.isEmpty else { return }
+        let liveWindowIds = currentFrameGutterWindowIds
+        frameState.windowGutters = frameState.windowGutters.filter { liveWindowIds.contains($0.key) }
+        frameState.windowIndentGuides = frameState.windowIndentGuides.filter { liveWindowIds.contains($0.key) }
+        guiState.windowContents = guiState.windowContents.filter { liveWindowIds.contains($0.key) }
     }
 }

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -396,16 +396,22 @@ final class CoreTextMetalRenderer {
         var bgQuads: [QuadGPU] = []
         var lineInstances: [LineGPU] = []
 
-        // Cursorline: draw a full-width bg fill on the cursor row.
+        // Cursorline: draw only inside the active split pane. The protocol currently carries a global screen row without a window id, so infer the pane from the active gutter geometry.
         if frameState.cursorlineRow != 0xFFFF && frameState.cursorlineBg != 0 {
-            // gui_cursorline currently carries only a global screen row, not the owning window id.
-            // In side-by-side splits, row-only matching can apply one pane's fractional trackpad offset to another pane's cursorline.
-            // Keep the cursorline snapped until the protocol exposes an owning window id.
+            // In side-by-side splits, row-only matching can apply one pane's fractional trackpad offset to another pane's cursorline. Keep the cursorline snapped until the protocol exposes an owning window id.
             let cursorlineOffsetY: Float = 0
             let yPos = Float(frameState.cursorlineRow) * displayCellH * scale - cursorlineOffsetY
+            let bounds = CoreTextMetalRenderer.cursorlineHorizontalBounds(
+                row: frameState.cursorlineRow,
+                gutters: frameState.windowGutters,
+                frameCols: frameState.cols,
+                cellW: cellW,
+                scale: scale,
+                viewportWidth: Float(viewportSize.width)
+            )
             var clQuad = QuadGPU()
-            clQuad.position = SIMD2<Float>(0, yPos)
-            clQuad.size = SIMD2<Float>(Float(viewportSize.width), displayCellH * scale)
+            clQuad.position = SIMD2<Float>(bounds.x, yPos)
+            clQuad.size = SIMD2<Float>(bounds.width, displayCellH * scale)
             clQuad.color = colorFromU24(frameState.cursorlineBg, default: defaultBg)
             clQuad.alpha = 1.0
             bgQuads.append(clQuad)
@@ -434,12 +440,27 @@ final class CoreTextMetalRenderer {
                 let scrollableWindowRowOffset = windowRowOffset - windowScrollOffsetPx.y
                 let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
                 let contentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
+                let windowBounds = CoreTextMetalRenderer.windowHorizontalBounds(
+                    gutter: gutter,
+                    frameCols: frameState.cols,
+                    cellW: cellW,
+                    scale: scale,
+                    viewportWidth: Float(viewportSize.width)
+                )
+                let contentRightPx = windowBounds.x + windowBounds.width
 
                 // Horizontal scroll: shift line textures and overlays left by scrollLeft columns.
                 // The gutter stays fixed; only content past the gutter edge scrolls.
                 let scrollLeftInt = Int(content.scrollLeft)
                 let hScrollPx = Float(scrollLeftInt) * cellW * scale
-                let contentCols = max(Int(frameState.cols) - Int(gutter.lineNumberWidth) - Int(gutter.signColWidth), 1)
+                let contentCols = CoreTextMetalRenderer.visibleTextCols(
+                    gutter: gutter,
+                    frameCols: frameState.cols,
+                    cellW: cellW,
+                    scale: scale,
+                    gutterLeftMarginPx: gutterLeftMarginPx,
+                    gutterPaddingPx: gutterPaddingPx
+                )
 
                 // Selection overlay quads (drawn before text).
                 if let sel = content.selection {
@@ -451,7 +472,7 @@ final class CoreTextMetalRenderer {
                         visibleRows: content.rows.count,
                         visibleCols: contentCols,
                         cellW: cellW, cellH: displayCellH, scale: scale,
-                        viewportWidth: Float(viewportSize.width),
+                        viewportWidth: contentRightPx,
                         quads: &semanticOverlayQuads
                     )
                 }
@@ -462,12 +483,15 @@ final class CoreTextMetalRenderer {
                     // Document highlights are typically single-line (one identifier).
                     // Draw on startRow only; multi-row highlights are rare for this feature.
                     let hlY = scrollableWindowRowOffset + Float(highlight.startRow) * displayCellH * scale
-                    let hlX = contentColOffset + Float(highlight.startCol) * cellW * scale - hScrollPx
-                    let hlW = Float(highlight.endCol - highlight.startCol) * cellW * scale
+                    let rawHlX = contentColOffset + Float(highlight.startCol) * cellW * scale - hScrollPx
+                    let rawHlRight = rawHlX + Float(highlight.endCol - highlight.startCol) * cellW * scale
+                    let hlX = max(rawHlX, contentColOffset)
+                    let hlRight = min(rawHlRight, contentRightPx)
+                    guard hlRight > hlX else { continue }
 
                     var quad = QuadGPU()
                     quad.position = SIMD2<Float>(hlX, hlY)
-                    quad.size = SIMD2<Float>(hlW, displayCellH * scale)
+                    quad.size = SIMD2<Float>(hlRight - hlX, displayCellH * scale)
                     // Write references get a warmer amber tint; read/text get a subtle blue-gray.
                     // Colors are driven by the theme via ThemeColors slots 0x59/0x5A.
                     quad.color = highlight.kind == .write
@@ -480,12 +504,15 @@ final class CoreTextMetalRenderer {
                 // Search match overlay quads (drawn before text).
                 for match in content.searchMatches {
                     let matchY = scrollableWindowRowOffset + Float(match.row) * displayCellH * scale
-                    let matchX = contentColOffset + Float(match.startCol) * cellW * scale - hScrollPx
-                    let matchW = Float(match.endCol - match.startCol) * cellW * scale
+                    let rawMatchX = contentColOffset + Float(match.startCol) * cellW * scale - hScrollPx
+                    let rawMatchRight = rawMatchX + Float(match.endCol - match.startCol) * cellW * scale
+                    let matchX = max(rawMatchX, contentColOffset)
+                    let matchRight = min(rawMatchRight, contentRightPx)
+                    guard matchRight > matchX else { continue }
 
                     var quad = QuadGPU()
                     quad.position = SIMD2<Float>(matchX, matchY)
-                    quad.size = SIMD2<Float>(matchW, displayCellH * scale)
+                    quad.size = SIMD2<Float>(matchRight - matchX, displayCellH * scale)
                     quad.color = match.isCurrent
                         ? SIMD3<Float>(0.95, 0.75, 0.0)    // current match: gold
                         : SIMD3<Float>(0.35, 0.35, 0.15)   // other matches: dim gold
@@ -546,12 +573,15 @@ final class CoreTextMetalRenderer {
                             ) else { continue }
 
                             let (uvOrigin, uvSize) = atlas.uvForSlot(annEntry.slotIndex, pixelWidth: annEntry.pixelWidth)
+                            let visiblePixelWidth = min(Float(annEntry.pixelWidth), contentRightPx - cursorX)
+                            guard visiblePixelWidth > 0 else { continue }
+                            let visibleUVWidth = uvSize.x * visiblePixelWidth / Float(annEntry.pixelWidth)
 
                             var lineGPU = LineGPU()
                             lineGPU.position = SIMD2<Float>(cursorX, rowY)
-                            lineGPU.size = SIMD2<Float>(Float(annEntry.pixelWidth), Float(annEntry.pixelHeight))
+                            lineGPU.size = SIMD2<Float>(visiblePixelWidth, Float(annEntry.pixelHeight))
                             lineGPU.uvOrigin = uvOrigin
-                            lineGPU.uvSize = uvSize
+                            lineGPU.uvSize = SIMD2<Float>(visibleUVWidth, uvSize.y)
                             lineInstances.append(lineGPU)
 
                             cursorX += Float(annEntry.pixelWidth) + Float(wcr.annotationSpacing) * scale
@@ -569,12 +599,15 @@ final class CoreTextMetalRenderer {
                     }
 
                     let diagY = scrollableWindowRowOffset + Float(diag.startRow) * displayCellH * scale + displayCellH * scale - 2.0 * scale
-                    let diagX = contentColOffset + Float(diag.startCol) * cellW * scale - hScrollPx
-                    let diagW = Float(diag.endCol - diag.startCol) * cellW * scale
+                    let rawDiagX = contentColOffset + Float(diag.startCol) * cellW * scale - hScrollPx
+                    let rawDiagRight = rawDiagX + Float(diag.endCol - diag.startCol) * cellW * scale
+                    let diagX = max(rawDiagX, contentColOffset)
+                    let diagRight = min(rawDiagRight, contentRightPx)
+                    guard diagRight > diagX else { continue }
 
                     var quad = QuadGPU()
                     quad.position = SIMD2<Float>(diagX, diagY)
-                    quad.size = SIMD2<Float>(diagW, 2.0 * scale)
+                    quad.size = SIMD2<Float>(diagRight - diagX, 2.0 * scale)
                     quad.color = diagColor
                     quad.alpha = 1.0
                     diagnosticQuads.append(quad)
@@ -642,6 +675,14 @@ final class CoreTextMetalRenderer {
             guard let gutter = frameState.windowGutters[guideData.windowId] else { continue }
             let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
             let windowContentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
+            let windowBounds = CoreTextMetalRenderer.windowHorizontalBounds(
+                gutter: gutter,
+                frameCols: frameState.cols,
+                cellW: cellW,
+                scale: scale,
+                viewportWidth: Float(viewportSize.width)
+            )
+            let contentRightPx = windowBounds.x + windowBounds.width
             let guideScrollOffsetY = CoreTextMetalRenderer.smoothScrollOffset(
                 for: guideData.windowId,
                 targetWindowId: scrollTargetWindowId,
@@ -660,10 +701,12 @@ final class CoreTextMetalRenderer {
                 guideQuads.reserveCapacity(guideData.guideCols.count)
                 for col in guideData.guideCols {
                     let guideX = windowContentColOffset + Float(col) * cellW * scale
+                    let guideWidth = min(1.0 * scale, contentRightPx - guideX)
+                    guard guideWidth > 0 else { continue }
                     let isActive = col == guideData.activeGuideCol
                     var quad = QuadGPU()
                     quad.position = SIMD2<Float>(guideX, contentTopY)
-                    quad.size = SIMD2<Float>(1.0 * scale, contentHeightPx)
+                    quad.size = SIMD2<Float>(guideWidth, contentHeightPx)
                     quad.color = inactiveFg
                     quad.alpha = isActive ? 0.4 : 0.15
                     guideQuads.append(quad)
@@ -677,10 +720,12 @@ final class CoreTextMetalRenderer {
                         // Strict < so guides appear only in whitespace, not at the text-start column.
                         guard guideLevel < level else { continue }
                         let guideX = windowContentColOffset + Float(col) * cellW * scale
+                        let guideWidth = min(1.0 * scale, contentRightPx - guideX)
+                        guard guideWidth > 0 else { continue }
                         let isActive = col == guideData.activeGuideCol
                         var quad = QuadGPU()
                         quad.position = SIMD2<Float>(guideX, lineY)
-                        quad.size = SIMD2<Float>(1.0 * scale, lineCellH)
+                        quad.size = SIMD2<Float>(guideWidth, lineCellH)
                         quad.color = inactiveFg
                         quad.alpha = isActive ? 0.4 : 0.15
                         guideQuads.append(quad)
@@ -873,14 +918,21 @@ final class CoreTextMetalRenderer {
                         encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
                         encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
 
-                        // Render the label texture
+                        // Render the label texture immediately. The main line texture pass has already run by the time split separators are drawn, so queuing this into lineInstances would leave only the background gap visible.
                         let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
                         var lineGPU = LineGPU()
                         lineGPU.position = SIMD2<Float>(centerX, labelY)
                         lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
                         lineGPU.uvOrigin = uvOrigin
                         lineGPU.uvSize = uvSize
-                        lineInstances.append(lineGPU)
+
+                        if let atlasTexture = atlas.texture {
+                            encoder.setRenderPipelineState(linePipeline)
+                            encoder.setVertexBytes(&lineGPU, length: MemoryLayout<LineGPU>.stride, index: 0)
+                            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+                            encoder.setFragmentTexture(atlasTexture, index: 0)
+                            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+                        }
                     }
                 }
             }
@@ -1505,6 +1557,73 @@ final class CoreTextMetalRenderer {
     nonisolated static func smoothScrollOffset(for windowId: UInt16?, targetWindowId: UInt16?, scrollOffsetPx: SIMD2<Float>) -> SIMD2<Float> {
         guard let windowId, let targetWindowId, windowId == targetWindowId else { return .zero }
         return scrollOffsetPx
+    }
+
+    nonisolated static func windowWidthCols(gutter: Wire.WindowGutter, frameCols: UInt16) -> Int {
+        if gutter.contentWidth > 0 {
+            return Int(gutter.contentWidth)
+        }
+
+        return max(Int(frameCols) - Int(gutter.contentCol), 1)
+    }
+
+    nonisolated static func visibleTextCols(
+        gutter: Wire.WindowGutter,
+        frameCols: UInt16,
+        cellW: Float,
+        scale: Float,
+        gutterLeftMarginPx: Float,
+        gutterPaddingPx: Float
+    ) -> Int {
+        let gutterCols = Int(gutter.lineNumberWidth) + Int(gutter.signColWidth)
+        let availableCols = max(windowWidthCols(gutter: gutter, frameCols: frameCols) - gutterCols, 1)
+        let cellWidthPx = max(cellW * scale, 1)
+        let paddingCols = Int(ceil((gutterLeftMarginPx + gutterPaddingPx) / cellWidthPx))
+        return max(availableCols - paddingCols, 1)
+    }
+
+    nonisolated static func windowHorizontalBounds(
+        gutter: Wire.WindowGutter,
+        frameCols: UInt16,
+        cellW: Float,
+        scale: Float,
+        viewportWidth: Float
+    ) -> (x: Float, width: Float) {
+        let left = Float(gutter.contentCol) * cellW * scale
+        let right = min(left + Float(windowWidthCols(gutter: gutter, frameCols: frameCols)) * cellW * scale, viewportWidth)
+        return (x: left, width: max(right - left, 0))
+    }
+
+    nonisolated static func cursorlineHorizontalBounds(
+        row: UInt16,
+        gutters: [UInt16: Wire.WindowGutter],
+        frameCols: UInt16,
+        cellW: Float,
+        scale: Float,
+        viewportWidth: Float
+    ) -> (x: Float, width: Float) {
+        let rowIndex = Int(row)
+        let matchingGutter = gutters.values.first { gutter in
+            let start = Int(gutter.contentRow)
+            let end = start + Int(gutter.contentHeight)
+            return gutter.isActive && rowIndex >= start && rowIndex < end
+        } ?? gutters.values.first { gutter in
+            let start = Int(gutter.contentRow)
+            let end = start + Int(gutter.contentHeight)
+            return rowIndex >= start && rowIndex < end
+        }
+
+        guard let matchingGutter else {
+            return (x: 0, width: viewportWidth)
+        }
+
+        return windowHorizontalBounds(
+            gutter: matchingGutter,
+            frameCols: frameCols,
+            cellW: cellW,
+            scale: scale,
+            viewportWidth: viewportWidth
+        )
     }
 
     nonisolated static func interpolateCursor(start: RenderCursor, target: RenderCursor, progress: Float) -> RenderCursor {

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -1072,7 +1072,7 @@ final class EditorNSView: MTKView {
         if dividerDragState != .none {
             setDividerCursorState(dividerDragState)
         }
-        let (row, col) = cellPosition(from: event)
+        let (row, col) = dividerDragState == .none ? cellPosition(from: event) : dividerPressCellPosition(at: point, state: dividerDragState)
         let cc = UInt8(clamping: event.clickCount)
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_LEFT,
                                modifiers: modifierBits(from: event.modifierFlags),
@@ -1087,7 +1087,7 @@ final class EditorNSView: MTKView {
         }
 
         let point = convert(event.locationInWindow, from: nil)
-        let (row, col) = cellPosition(from: event)
+        let (row, col) = dividerDragState == .none ? cellPosition(from: event) : rawCellPosition(at: point)
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_LEFT,
                                modifiers: modifierBits(from: event.modifierFlags),
                                eventType: MOUSE_RELEASE)
@@ -1193,12 +1193,13 @@ final class EditorNSView: MTKView {
             return
         }
 
+        let point = convert(event.locationInWindow, from: nil)
         if dividerDragState != .none {
             setDividerCursorState(dividerDragState)
         } else if !shouldSendTextDrag(for: event) {
             return
         }
-        let (row, col) = cellPosition(from: event)
+        let (row, col) = dividerDragState == .none ? cellPosition(from: event) : rawCellPosition(at: point)
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_LEFT,
                                modifiers: modifierBits(from: event.modifierFlags),
                                eventType: MOUSE_DRAG)
@@ -1209,6 +1210,7 @@ final class EditorNSView: MTKView {
         setDividerCursorState(dividerHitState(at: point))
         updateGutterHover(at: point)
         let (row, col) = cellPosition(from: event)
+        clearSmoothScrollOffsetIfPointerLeftTarget(row: row, col: col)
         guard row != lastMoveRow || col != lastMoveCol else { return }
         lastMoveRow = row
         lastMoveCol = col
@@ -1357,6 +1359,29 @@ final class EditorNSView: MTKView {
 
     private func smoothScrollTargetWindowId(row: Int16, col: Int16) -> UInt16? {
         EditorNSView.smoothScrollTargetWindowId(row: row, col: col, windowGutters: dispatcher.frameState.windowGutters)
+    }
+
+    private func clearSmoothScrollOffsetIfPointerLeftTarget(row: Int16, col: Int16) {
+        let pointerWindowId = smoothScrollTargetWindowId(row: row, col: col)
+        guard Self.shouldResetSmoothScrollTarget(
+            currentTargetWindowId: scrollTargetWindowId,
+            pointerWindowId: pointerWindowId,
+            pixelOffset: scrollPixelOffset
+        ) else { return }
+
+        resetSmoothScrollOffsetPreservingTarget()
+        needsDisplay = true
+    }
+
+    private func resetSmoothScrollOffsetPreservingTarget() {
+        scrollAccumulator.reset()
+        scrollPixelOffset = 0
+    }
+
+    nonisolated static func shouldResetSmoothScrollTarget(currentTargetWindowId: UInt16?, pointerWindowId: UInt16?, pixelOffset: CGFloat) -> Bool {
+        guard pixelOffset != 0 else { return false }
+        guard let currentTargetWindowId else { return false }
+        return pointerWindowId != currentTargetWindowId
     }
 
     nonisolated static func smoothScrollTargetWindowId(row: Int16, col: Int16, windowGutters: [UInt16: Wire.WindowGutter]) -> UInt16? {
@@ -1689,20 +1714,117 @@ final class EditorNSView: MTKView {
     private func cellPosition(from event: NSEvent) -> (row: Int16, col: Int16) {
         let point = convert(event.locationInWindow, from: nil)
         let row = Int16(point.y / effectiveCellHeight)
+        let col = cellColumn(at: point, row: row)
+        return (row, col)
+    }
+
+    private func rawCellPosition(at point: NSPoint) -> (row: Int16, col: Int16) {
+        let row = max(0, Int16(point.y / effectiveCellHeight))
+        let col = max(0, Int16(point.x / cellWidth))
+        return (row, col)
+    }
+
+    private func dividerPressCellPosition(at point: NSPoint, state: DividerCursorState) -> (row: Int16, col: Int16) {
+        let raw = rawCellPosition(at: point)
+
+        switch state {
+        case .vertical:
+            guard let separatorCol = verticalSeparatorCol(at: point) else { return raw }
+            return (raw.row, Int16(separatorCol))
+        case .horizontal:
+            guard let separatorRow = horizontalSeparatorRow(at: point) else { return raw }
+            return (Int16(separatorRow), raw.col)
+        case .none:
+            return raw
+        }
+    }
+
+    private func verticalSeparatorCol(at point: NSPoint) -> UInt16? {
+        let fs = dispatcher.frameState
+        let hitHalfTolerance = dividerHitHalfTolerance
+        let displayCellH = effectiveCellHeight
+
+        for vertical in fs.verticalSeparators {
+            let x = CGFloat(vertical.col) * cellWidth
+            let startY = CGFloat(vertical.startRow) * displayCellH
+            let endY = CGFloat(Int(vertical.endRow) + 1) * displayCellH
+            if abs(point.x - x) <= hitHalfTolerance && point.y >= startY && point.y < endY {
+                return vertical.col
+            }
+        }
+
+        return nil
+    }
+
+    private func horizontalSeparatorRow(at point: NSPoint) -> UInt16? {
+        let fs = dispatcher.frameState
+        let hitHalfTolerance = dividerHitHalfTolerance
+        let displayCellH = effectiveCellHeight
+
+        for horizontal in fs.horizontalSeparators {
+            let x = CGFloat(horizontal.col) * cellWidth
+            let y = CGFloat(horizontal.row) * displayCellH + (displayCellH * 0.5) - (0.5 / (window?.backingScaleFactor ?? 1.0))
+            let width = CGFloat(horizontal.width) * cellWidth
+            if abs(point.y - y) <= hitHalfTolerance && point.x >= x && point.x < x + width {
+                return horizontal.row
+            }
+        }
+
+        return nil
+    }
+
+    private func cellColumn(at point: NSPoint, row: Int16) -> Int16 {
+        guard let gutter = gutterForCellPosition(at: point, row: row) else {
+            return fallbackCellColumn(at: point)
+        }
+
+        let windowLeft = CGFloat(gutter.contentCol) * cellWidth
+        let localX = point.x - windowLeft
+        let gutterCols = CGFloat(gutter.lineNumberWidth) + CGFloat(gutter.signColWidth)
+        guard gutterCols > 0 else {
+            return max(0, Int16(point.x / cellWidth))
+        }
+
+        let localCol = localCellColumn(at: localX, gutterCols: gutterCols)
+        return max(0, Int16(gutter.contentCol) + localCol)
+    }
+
+    private func gutterForCellPosition(at point: NSPoint, row: Int16) -> Wire.WindowGutter? {
+        guard row >= 0 else { return nil }
+        let rowValue = Int(row)
+        let frameState = dispatcher.frameState
+        let windowIds = dispatcher.currentFrameGutterWindowIds.isEmpty ? Set(frameState.windowGutters.keys) : dispatcher.currentFrameGutterWindowIds
+
+        return windowIds.compactMap { frameState.windowGutters[$0] }
+            .filter { gutter in
+                let startRow = Int(gutter.contentRow)
+                let endRow = startRow + Int(gutter.contentHeight)
+                let startX = CGFloat(gutter.contentCol) * cellWidth
+                let endX = startX + CGFloat(CoreTextMetalRenderer.windowWidthCols(gutter: gutter, frameCols: frameState.cols)) * cellWidth
+                return rowValue >= startRow && rowValue < endRow && point.x >= startX && point.x < endX
+            }
+            .max { lhs, rhs in lhs.contentCol < rhs.contentCol }
+    }
+
+    private func fallbackCellColumn(at point: NSPoint) -> Int16 {
         let gutterCols = CGFloat(dispatcher.frameState.gutterCol)
         guard gutterCols > 0 else {
-            return (row, max(0, Int16(point.x / cellWidth)))
+            return max(0, Int16(point.x / cellWidth))
         }
+
+        return localCellColumn(at: point.x, gutterCols: gutterCols)
+    }
+
+    private func localCellColumn(at localX: CGFloat, gutterCols: CGFloat) -> Int16 {
         let leftMargin = CoreTextMetalRenderer.gutterLeftMarginPt
         let rightGap = CoreTextMetalRenderer.gutterRightGapPt
         let gutterPixelEnd = leftMargin + gutterCols * cellWidth
-        let col: Int16
-        if point.x < gutterPixelEnd {
-            col = max(0, Int16((point.x - leftMargin) / cellWidth))
-        } else {
-            col = max(0, Int16((point.x - leftMargin - rightGap) / cellWidth))
+
+        if localX < gutterPixelEnd {
+            return max(0, Int16((localX - leftMargin) / cellWidth))
         }
-        return (row, col)
+
+        return max(0, Int16((localX - leftMargin - rightGap) / cellWidth))
     }
 }
 

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -658,6 +658,52 @@ struct CommandDispatcherRoutingTests {
 
     // MARK: - Batch lifecycle
 
+    @Test("batchEnd prunes stale window geometry when a new gutter frame arrives")
+    @MainActor func batchEndPrunesStaleWindowGeometry() {
+        let (dispatcher, gui) = makeDispatcher()
+        let liveContent = GUIWindowContent(
+            windowId: 1, fullRefresh: true,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+        let staleContent = GUIWindowContent(
+            windowId: 2, fullRefresh: true,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+        let liveGutter = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 24,
+            isActive: true, contentWidth: 80, cursorLine: 10, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 1, entries: []
+        )
+        let staleGutter = Wire.WindowGutter(
+            windowId: 2, contentRow: 12, contentCol: 0, contentHeight: 12,
+            isActive: false, contentWidth: 80, cursorLine: 10, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 1, entries: []
+        )
+
+        gui.windowContents[1] = liveContent
+        gui.windowContents[2] = staleContent
+        dispatcher.frameState.windowGutters[1] = liveGutter
+        dispatcher.frameState.windowGutters[2] = staleGutter
+        dispatcher.frameState.windowIndentGuides[2] = IndentGuideData(windowId: 2, tabWidth: 2, activeGuideCol: 0xFFFF, guideCols: [], lineIndentLevels: [])
+
+        dispatcher.dispatch(.clear)
+        dispatcher.dispatch(.guiGutter(data: liveGutter))
+        dispatcher.dispatch(.guiWindowContent(data: liveContent))
+        dispatcher.dispatch(.batchEnd)
+
+        #expect(dispatcher.frameState.windowGutters[1] != nil)
+        #expect(dispatcher.frameState.windowGutters[2] == nil)
+        #expect(gui.windowContents[1] === liveContent)
+        #expect(gui.windowContents[2] == nil)
+        #expect(dispatcher.frameState.windowIndentGuides[2] == nil)
+    }
+
     @Test("batchEnd fires onFirstRender once then clears it")
     @MainActor func batchEndFiresFirstRenderOnce() {
         let (dispatcher, _) = makeDispatcher()

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -70,6 +70,52 @@ struct CoreTextMetalRendererCursorTests {
         #expect(CoreTextMetalRenderer.smoothScrollOffset(for: nil, targetWindowId: 1, scrollOffsetPx: offset) == .zero)
     }
 
+    @Test("split panes use per-window text width for semantic clipping")
+    func splitPanesUsePerWindowTextWidthForSemanticClipping() {
+        let gutter = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
+            isActive: true, contentWidth: 40, cursorLine: 3, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 1, entries: []
+        )
+
+        #expect(CoreTextMetalRenderer.visibleTextCols(
+            gutter: gutter,
+            frameCols: 100,
+            cellW: 8,
+            scale: 2,
+            gutterLeftMarginPx: 0,
+            gutterPaddingPx: 0
+        ) == 35)
+    }
+
+    @Test("cursorline is clipped to the active split pane")
+    func cursorlineIsClippedToActiveSplitPane() {
+        let gutters: [UInt16: Wire.WindowGutter] = [
+            1: Wire.WindowGutter(
+                windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
+                isActive: true, contentWidth: 40, cursorLine: 3, lineNumberStyle: .hybrid,
+                lineNumberWidth: 4, signColWidth: 1, entries: []
+            ),
+            2: Wire.WindowGutter(
+                windowId: 2, contentRow: 0, contentCol: 41, contentHeight: 20,
+                isActive: false, contentWidth: 39, cursorLine: 3, lineNumberStyle: .hybrid,
+                lineNumberWidth: 4, signColWidth: 1, entries: []
+            )
+        ]
+
+        let bounds = CoreTextMetalRenderer.cursorlineHorizontalBounds(
+            row: 5,
+            gutters: gutters,
+            frameCols: 80,
+            cellW: 8,
+            scale: 2,
+            viewportWidth: 1_600
+        )
+
+        #expect(bounds.x == 0)
+        #expect(bounds.width == 640)
+    }
+
     @Test("smooth scroll target requires content column even for one row match")
     func smoothScrollTargetRequiresContentColumnForSingleRowMatch() {
         let gutters: [UInt16: Wire.WindowGutter] = [

--- a/macos/Tests/MingaTests/MouseInputTests.swift
+++ b/macos/Tests/MingaTests/MouseInputTests.swift
@@ -80,6 +80,56 @@ struct MouseInputTests {
         #expect(call.clickCount == 1)
     }
 
+    @Test("mouseDown snaps vertical divider press to separator column")
+    @MainActor func leftMouseDownSnapsVerticalDividerPress() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy) else { return }
+        let cw = view.cellWidth
+        let ch = view.cellHeight
+
+        view.dispatcher.dispatch(.guiSplitSeparators(
+            borderColor: 0x555555,
+            verticals: [Wire.VerticalSeparator(col: 40, startRow: 0, endRow: 23)],
+            horizontals: []
+        ))
+
+        guard let event = mouseEvent(type: .leftMouseDown, location: NSPoint(x: cw * 40 - 1, y: ch * 5.5)) else { return }
+        view.mouseDown(with: event)
+
+        #expect(spy.mouseEventCalls.count == 1)
+        #expect(spy.mouseEventCalls[0].row == 5)
+        #expect(spy.mouseEventCalls[0].col == 40)
+    }
+
+    @Test("mouseDown maps split pane content with per-window gutter padding")
+    @MainActor func leftMouseDownUsesPaneGutter() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy) else { return }
+        let cw = view.cellWidth
+        let ch = view.cellHeight
+
+        let clickedGutter = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 12,
+            isActive: false, contentWidth: 40, cursorLine: 3, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 1, entries: []
+        )
+        let activeWideGutter = Wire.WindowGutter(
+            windowId: 2, contentRow: 0, contentCol: 41, contentHeight: 24,
+            isActive: true, contentWidth: 39, cursorLine: 3, lineNumberStyle: .hybrid,
+            lineNumberWidth: 8, signColWidth: 1, entries: []
+        )
+        view.dispatcher.dispatch(.guiGutter(data: clickedGutter))
+        view.dispatcher.dispatch(.guiGutter(data: activeWideGutter))
+
+        let firstTextColX = CoreTextMetalRenderer.gutterLeftMarginPt + CGFloat(clickedGutter.lineNumberWidth + clickedGutter.signColWidth) * cw + CoreTextMetalRenderer.gutterRightGapPt + cw * 0.2
+        guard let event = mouseEvent(type: .leftMouseDown, location: NSPoint(x: firstTextColX, y: ch * 2.5)) else { return }
+        view.mouseDown(with: event)
+
+        #expect(spy.mouseEventCalls.count == 1)
+        #expect(spy.mouseEventCalls[0].row == 2)
+        #expect(spy.mouseEventCalls[0].col == 5)
+    }
+
     @Test("mouseUp sends left button release")
     @MainActor func leftMouseUp() throws {
         let spy = SpyEncoder()
@@ -226,6 +276,15 @@ struct MouseInputTests {
     }
 
     // MARK: - Mouse move (deduplication)
+
+    @Test("smooth scroll target resets when pointer leaves target pane")
+    func smoothScrollTargetResetsWhenPointerLeavesTargetPane() {
+        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 2, pixelOffset: 4) == true)
+        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: nil, pixelOffset: 4) == true)
+        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 1, pixelOffset: 4) == false)
+        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 2, pixelOffset: 0) == false)
+        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: nil, pointerWindowId: 2, pixelOffset: 4) == false)
+    }
 
     @Test("mouseMoved sends motion event")
     @MainActor func mouseMove() throws {


### PR DESCRIPTION
# TL;DR
Stabilizes macOS split-pane rendering and input by making pane-local geometry explicit in the Swift render/input paths. This fixes split overdraw, stale panes after close, misaligned clicks, smooth-scroll movement across panes, and divider drag routing.

## Context
The macOS GUI was rendering and hit-testing split panes with a mix of global frame metrics, active-window gutter state, and per-window geometry. Split layouts exposed those mismatches: panes overpainted each other, cursorlines spanned across panes, clicks landed in the wrong buffer position, closing splits left stale content, and divider drags could be interpreted as text selection.

## Changes
- Clips semantic window text, overlays, cursorline, diagnostics, selections, and highlights to each pane's owning geometry.
- Prunes stale window content, gutter, and indent-guide state at frame boundaries after split close or window removal.
- Makes macOS mouse hit-testing use clicked-pane gutter geometry instead of active/global gutter values.
- Keeps smooth-scroll fractional offsets bound to the gesture's target pane and clears them when the pointer leaves that pane.
- Routes divider press/drag/release through raw separator coordinates so a resize cursor consistently starts split resizing.
- Renders horizontal split separator labels immediately in the Metal pass instead of queuing them after the line-text pass.
- Updates `docs/RETAINED_GUI_RENDERING_SPEC.md` with the pane geometry and hit-region contract needed to prevent this class of bugs.

## Verification
- `mix swift.build`
- `xcodebuild test -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS' -only-testing:MingaTests/MouseInputTests -only-testing:MingaTests/CommandDispatcherRoutingTests -only-testing:MingaTests/CoreTextMetalRendererCursorTests`
- Manual visual checks in the macOS GUI for vertical splits, horizontal splits, split close, pane click placement, smooth-scroll pane transitions, horizontal separator labels, and vertical divider resizing.

## Acceptance Criteria Addressed
- Split panes render without content overdraw across pane boundaries ✅
- Horizontal split labels render correctly ✅
- Clicking inside split panes places the cursor where clicked ✅
- Closing a split removes stale pane content ✅
- Moving between panes does not shift visible content unexpectedly ✅
- Vertical divider resize starts when the resize cursor is shown ✅
