### PR TITLE
fix(macos): speed up cursor animation

### DIFF
--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -123,7 +123,7 @@ final class CoreTextMetalRenderer {
     private var targetCursorShape: CursorShape = .block
     private var targetCursorWindowId: UInt16?
     private var cursorAnimationStartTime: CFTimeInterval = 0
-    private let cursorAnimationDuration: CFTimeInterval = 0.08
+    private let cursorAnimationDuration: CFTimeInterval = 0.035
 
     /// Scroll indicator opacity (0.0 = hidden, 1.0 = fully visible).
     /// Set by EditorNSView based on scroll activity and fade timer.
@@ -1527,9 +1527,8 @@ final class CoreTextMetalRenderer {
         }
 
         let progress = CoreTextMetalRenderer.cursorAnimationProgress(now: now, startTime: cursorAnimationStartTime, duration: cursorAnimationDuration)
-        let eased = CoreTextMetalRenderer.easeOutCubic(progress)
-        currentCursorX = CoreTextMetalRenderer.lerp(startCursorX, targetCursorX, eased)
-        currentCursorY = CoreTextMetalRenderer.lerp(startCursorY, targetCursorY, eased)
+        currentCursorX = CoreTextMetalRenderer.lerp(startCursorX, targetCursorX, progress)
+        currentCursorY = CoreTextMetalRenderer.lerp(startCursorY, targetCursorY, progress)
 
         if progress >= 1.0 {
             cursorAnimating = false
@@ -1543,11 +1542,6 @@ final class CoreTextMetalRenderer {
     nonisolated static func cursorAnimationProgress(now: CFTimeInterval, startTime: CFTimeInterval, duration: CFTimeInterval) -> Float {
         guard duration > 0 else { return 1.0 }
         return min(max(Float((now - startTime) / duration), 0.0), 1.0)
-    }
-
-    nonisolated static func easeOutCubic(_ progress: Float) -> Float {
-        let clamped = min(max(progress, 0.0), 1.0)
-        return 1.0 - powf(1.0 - clamped, 3.0)
     }
 
     nonisolated static func lerp(_ start: Float, _ end: Float, _ progress: Float) -> Float {
@@ -1627,8 +1621,8 @@ final class CoreTextMetalRenderer {
     }
 
     nonisolated static func interpolateCursor(start: RenderCursor, target: RenderCursor, progress: Float) -> RenderCursor {
-        let eased = easeOutCubic(progress)
-        return RenderCursor(x: lerp(start.x, target.x, eased), y: lerp(start.y, target.y, eased), shape: target.shape, windowId: target.windowId)
+        let clamped = min(max(progress, 0.0), 1.0)
+        return RenderCursor(x: lerp(start.x, target.x, clamped), y: lerp(start.y, target.y, clamped), shape: target.shape, windowId: target.windowId)
     }
 
     private func snapCursorAnimationToTarget() {

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -227,13 +227,13 @@ struct CoreTextMetalRendererCursorTests {
 
     @Test("cursor animation progress clamps to timeline bounds")
     func cursorAnimationProgressClamps() {
-        #expect(CoreTextMetalRenderer.cursorAnimationProgress(now: 0.0, startTime: 1.0, duration: 0.08) == 0.0)
-        #expect(CoreTextMetalRenderer.cursorAnimationProgress(now: 1.04, startTime: 1.0, duration: 0.08) == 0.5)
-        #expect(CoreTextMetalRenderer.cursorAnimationProgress(now: 1.2, startTime: 1.0, duration: 0.08) == 1.0)
+        #expect(CoreTextMetalRenderer.cursorAnimationProgress(now: 0.0, startTime: 1.0, duration: 0.035) == 0.0)
+        #expect(abs(CoreTextMetalRenderer.cursorAnimationProgress(now: 1.0175, startTime: 1.0, duration: 0.035) - 0.5) < 0.001)
+        #expect(CoreTextMetalRenderer.cursorAnimationProgress(now: 1.2, startTime: 1.0, duration: 0.035) == 1.0)
     }
 
-    @Test("cursor animation uses cubic ease-out interpolation")
-    func cursorAnimationUsesCubicEaseOut() {
+    @Test("cursor animation uses linear interpolation")
+    func cursorAnimationUsesLinearInterpolation() {
         let start = RenderCursor(x: 0, y: 0, shape: .block)
         let target = RenderCursor(x: 100, y: 40, shape: .beam)
 
@@ -242,8 +242,8 @@ struct CoreTextMetalRendererCursorTests {
         let atEnd = CoreTextMetalRenderer.interpolateCursor(start: start, target: target, progress: 1)
 
         #expect(atStart == RenderCursor(x: 0, y: 0, shape: .beam))
-        #expect(abs(halfway.x - 87.5) < 0.001)
-        #expect(abs(halfway.y - 35.0) < 0.001)
+        #expect(abs(halfway.x - 50.0) < 0.001)
+        #expect(abs(halfway.y - 20.0) < 0.001)
         #expect(atEnd == target)
     }
 


### PR DESCRIPTION
# TL;DR
Cursor movement in the macOS GUI now feels more immediate while keeping a small amount of native polish. The animation is shorter and linear, so it no longer trails behind repeated cursor movement as much as the previous 80ms ease-out curve.

## Context
The current GUI cursor movement animation looked nice, but feedback was that it felt sluggish enough to make the editor feel laggy. Zed and Helix set a near-instant expectation for cursor response, so this PR keeps the animation subtle instead of decorative.

## Changes
- Reduced macOS cursor movement animation duration from 80ms to 35ms.
- Switched interpolation from cubic ease-out to linear movement.
- Kept the existing Reduce Motion behavior that snaps cursor movement when accessibility settings request less motion.
- Kept the existing long vertical jump teleport behavior.
- Updated cursor animation tests to assert the new linear interpolation behavior.

## Verification
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -only-testing:MingaTests/CoreTextMetalRendererCursorTests test`
- `mix swift.build`
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga test`
- `git diff --check`
- Project reviewer gate: PASS

## Acceptance Criteria Addressed
- Cursor movement animation feels faster and closer to instant editor responsiveness ✅
- GUI still retains a subtle movement animation instead of snapping by default ✅
- Reduce Motion and long-jump snap behavior remain intact ✅
