### PR TITLE
fix(macos): keep observatory from stealing focus

### DIFF
--- a/lib/minga_editor/sidebar/builtin_surfaces.ex
+++ b/lib/minga_editor/sidebar/builtin_surfaces.ex
@@ -52,7 +52,7 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
         description: "Runtime process tree",
         placement: :left,
         priority: 30,
-        preferred_width: 30,
+        preferred_width: 52,
         visible?: visible?,
         focused?: visible?,
         semantic_kind: "observatory",

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -125,7 +125,7 @@ struct StartupOverlay: View {
 struct ContentView: View {
     var appState: AppState
     @State private var rightPaneHeight: CGFloat = 600
-    @State private var sidebarWidth: CGFloat = 240
+    @State private var sidebarWidth: CGFloat = SidebarSizing.defaultWidth
     @State private var changeSummaryWidth: CGFloat = 280
 
     private let activityBarWidth: CGFloat = 32
@@ -189,8 +189,18 @@ struct ContentView: View {
         .ignoresSafeArea(.container, edges: .top)
         .preferredColorScheme(appState.windowBgIsDark ? .dark : .light)
         .onAppear {
-            sidebarWidth = CGFloat(appState.gui.fileTreeState.treeWidth) * 7.5
+            applyActiveSidebarPreferredWidth()
         }
+        .onChange(of: appState.gui.sidebarHostState.activeSidebar) { _, _ in
+            applyActiveSidebarPreferredWidth()
+        }
+    }
+
+    private func applyActiveSidebarPreferredWidth() {
+        sidebarWidth = SidebarSizing.widthByApplyingPreferred(
+            for: appState.gui.sidebarHostState.activeSidebar,
+            currentWidth: sidebarWidth
+        )
     }
 
     // MARK: - Unified Toolbar

--- a/macos/Sources/Views/ObservatoryView.swift
+++ b/macos/Sources/Views/ObservatoryView.swift
@@ -50,11 +50,8 @@ struct ObservatoryView: View {
             }
             .padding(.vertical, 6)
         }
-        .focusable()
-        .onKeyPress(.escape) {
-            dismissInspection()
-            return .handled
-        }
+        .focusable(false)
+        .focusEffectDisabled()
     }
 
     private func row(_ node: ObservatoryNode) -> some View {

--- a/macos/Sources/Views/ObservatoryView.swift
+++ b/macos/Sources/Views/ObservatoryView.swift
@@ -112,12 +112,14 @@ struct ObservatoryView: View {
                     .lineLimit(1)
                     .foregroundStyle(theme.treeFg.opacity(0.55))
             }
-
-            Spacer(minLength: 4)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             Text(formatBytes(UInt64(node.memory)))
                 .font(.caption2.monospacedDigit())
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
                 .foregroundStyle(theme.treeFg.opacity(0.55))
+                .frame(minWidth: 52, alignment: .trailing)
                 .padding(.horizontal, 5)
                 .padding(.vertical, 2)
                 .background(theme.treeSelectionBg.opacity(0.35), in: Capsule())

--- a/macos/Sources/Views/SidebarContainer.swift
+++ b/macos/Sources/Views/SidebarContainer.swift
@@ -4,6 +4,34 @@
 
 import SwiftUI
 
+enum SidebarSizing {
+    static let columnWidth: CGFloat = 8
+    static let defaultWidth: CGFloat = 240
+    static let minWidth: CGFloat = 180
+    static let baseMaxWidth: CGFloat = 360
+    static let maxExtraWidth: CGFloat = 144
+    static let hardMaxWidth: CGFloat = 560
+
+    static func preferredWidth(for item: SidebarItem?) -> CGFloat {
+        guard let item else { return defaultWidth }
+        return max(defaultWidth, CGFloat(item.preferredWidth) * columnWidth)
+    }
+
+    static func maxWidth(for item: SidebarItem?) -> CGFloat {
+        let preferred = preferredWidth(for: item)
+        guard preferred > defaultWidth else { return baseMaxWidth }
+        return min(max(baseMaxWidth, preferred + maxExtraWidth), hardMaxWidth)
+    }
+
+    static func clamp(_ width: CGFloat, for item: SidebarItem?) -> CGFloat {
+        min(max(width, minWidth), maxWidth(for: item))
+    }
+
+    static func widthByApplyingPreferred(for item: SidebarItem?, currentWidth: CGFloat) -> CGFloat {
+        clamp(max(currentWidth, preferredWidth(for: item)), for: item)
+    }
+}
+
 struct SidebarContainer: View {
     let guiState: GUIState
     let activeSidebar: SidebarItem
@@ -13,9 +41,6 @@ struct SidebarContainer: View {
     let gitBranch: String
     let leadingPadding: CGFloat
     @Binding var sidebarWidth: CGFloat
-
-    private let sidebarMinWidth: CGFloat = 180
-    private let sidebarMaxWidth: CGFloat = 360
 
     @State private var isDraggingResize: Bool = false
     @State private var dragStartWidth: CGFloat = 0
@@ -66,7 +91,7 @@ struct SidebarContainer: View {
                             dragStartWidth = sidebarWidth
                         }
                         let newWidth = dragStartWidth + value.translation.width
-                        sidebarWidth = min(max(newWidth, sidebarMinWidth), sidebarMaxWidth)
+                        sidebarWidth = SidebarSizing.clamp(newWidth, for: activeSidebar)
                     }
                     .onEnded { _ in
                         isDraggingResize = false

--- a/macos/Sources/Views/SidebarHostState.swift
+++ b/macos/Sources/Views/SidebarHostState.swift
@@ -105,7 +105,7 @@ final class SidebarHostState {
             order: 30,
             visible: false,
             focused: false,
-            preferredWidth: 30,
+            preferredWidth: 52,
             badgeCount: nil
         ))
     ]

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -78,7 +78,7 @@ struct ActivityBarViewTests {
         [
             Wire.SidebarMetadata(id: "file_tree", displayName: "File Tree", semanticKind: "file_tree", icon: "folder", order: 10, visible: true, focused: false, preferredWidth: 30, badgeCount: nil),
             Wire.SidebarMetadata(id: "git_status", displayName: "Git Status", semanticKind: "git_status", icon: "point.3.filled.connected.trianglepath.dotted", order: 20, visible: true, focused: false, preferredWidth: 30, badgeCount: gitBadgeCount),
-            Wire.SidebarMetadata(id: "observatory", displayName: "BEAM Observatory", semanticKind: "observatory", icon: "network", order: 30, visible: true, focused: false, preferredWidth: 30, badgeCount: nil)
+            Wire.SidebarMetadata(id: "observatory", displayName: "BEAM Observatory", semanticKind: "observatory", icon: "network", order: 30, visible: true, focused: false, preferredWidth: 52, badgeCount: nil)
         ]
     }
 }
@@ -87,6 +87,24 @@ struct ActivityBarViewTests {
 
 @Suite("SidebarContainer View Structure")
 struct SidebarContainerViewTests {
+    @Test("Observatory preferred width expands initial and maximum sidebar width")
+    @MainActor func observatoryPreferredWidthExpandsSidebarWidth() {
+        let item = SidebarItem(Wire.SidebarMetadata(id: "observatory", displayName: "BEAM Observatory", semanticKind: "observatory", icon: "network", order: 30, visible: true, focused: true, preferredWidth: 52, badgeCount: nil))
+
+        #expect(SidebarSizing.preferredWidth(for: item) == 416)
+        #expect(SidebarSizing.maxWidth(for: item) == 560)
+        #expect(SidebarSizing.widthByApplyingPreferred(for: item, currentWidth: 240) == 416)
+    }
+
+    @Test("Default-width sidebars keep compact maximum width")
+    @MainActor func defaultWidthSidebarsKeepCompactMaximumWidth() {
+        let item = SidebarItem(Wire.SidebarMetadata(id: "file_tree", displayName: "File Tree", semanticKind: "file_tree", icon: "folder", order: 10, visible: true, focused: true, preferredWidth: 30, badgeCount: nil))
+
+        #expect(SidebarSizing.preferredWidth(for: item) == 240)
+        #expect(SidebarSizing.maxWidth(for: item) == 360)
+        #expect(SidebarSizing.widthByApplyingPreferred(for: item, currentWidth: 240) == 240)
+    }
+
     @Test("Unknown visible sidebar renders generic fallback")
     @MainActor func unknownSidebarFallback() throws {
         let guiState = GUIState()

--- a/test/minga_editor/extension/sidebar_gui_emit_test.exs
+++ b/test/minga_editor/extension/sidebar_gui_emit_test.exs
@@ -50,6 +50,9 @@ defmodule MingaEditor.Extension.SidebarGUIEmitTest do
 
     assert Enum.map(entries, & &1.id) == ["file_tree", "git_status", "observatory"]
     assert Enum.all?(entries, &(not &1.visible?))
+
+    observatory = Enum.find(entries, &(&1.id == "observatory"))
+    assert observatory.preferred_width == 52
   end
 
   test "registered git status sidebar metadata carries visibility and badge count", %{


### PR DESCRIPTION
# TL;DR
BEAM Observatory no longer steals keyboard focus from the main editor, and its sidebar now opens at a readable width. With Observatory open, `SPC` leader chords and typing should still reach the BEAM, and process rows should no longer look smashed on first render.

## Context
The Observatory sidebar had two macOS GUI issues. First, its SwiftUI scroll view could take keyboard focus, bypassing the normal `EditorNSView.keyDown` input path. Second, it advertised the same compact sidebar width as the file tree/git panels, and the macOS host was not applying active sidebar preferred widths, so the process tree rendered cramped and memory badges wrapped.

## Changes
- Changed the Observatory tree scroll view to opt out of SwiftUI focus.
- Removed the Observatory SwiftUI Escape key handler so keyboard input stays routed through the editor input pipeline.
- Added shared macOS sidebar sizing logic that applies the active sidebar preferred width.
- Raised Observatory preferred width to 52 columns.
- Let wide sidebars resize up to 560pt while keeping default sidebars capped at 360pt.
- Kept Observatory memory badges on one line with a stable minimum width.
- Added Swift and Elixir tests for the new sizing behavior and emitted preferred width.

## Verification
- `mix format lib/minga_editor/sidebar/builtin_surfaces.ex test/minga_editor/extension/sidebar_gui_emit_test.exs`
- `mix test.llm test/minga_editor/extension/sidebar_gui_emit_test.exs`
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -only-testing:MingaTests/NativeSidebarRegistryTests -only-testing:MingaTests/SidebarViewTests -only-testing:MingaTests/CommandDispatcherTests test`
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -only-testing:MingaTests/SidebarContainerViewTests -only-testing:MingaTests/ActivityBarViewTests -only-testing:MingaTests/NativeSidebarRegistryTests test`
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga test`
- `mix swift.build`
- `make lint`
- `mix test.llm`
- `git diff --check`
- Focused bug-hunting pass: no issues found
- Project reviewer gate: PASS

## Acceptance Criteria Addressed
- Opening BEAM Observatory does not prevent `SPC` leader handling in the main editor ✅
- Opening BEAM Observatory does not prevent normal typing from reaching the BEAM ✅
- Observatory remains visible and clickable as a sidebar, without participating in keyboard focus ✅
- Observatory opens at a readable width instead of the compact file-tree width ✅
- Observatory can be resized wider than before when the process tree needs room ✅
- Memory badges no longer wrap into crushed multi-line pills ✅
