### PR TITLE
Fix visible split highlighting after parser eviction

### DIFF
--- a/lib/minga_editor/handlers/highlight_handler.ex
+++ b/lib/minga_editor/handlers/highlight_handler.ex
@@ -425,13 +425,11 @@ defmodule MingaEditor.Handlers.HighlightHandler do
   @spec handle_evict_parser_trees(EditorState.t()) :: {EditorState.t(), [highlight_effect()]}
   defp handle_evict_parser_trees(state) do
     ttl_seconds = Minga.Config.get(:parser_tree_ttl)
-    agent_buf = state |> AgentAccess.agent() |> Map.get(:buffer)
-    protected = if is_pid(agent_buf), do: [agent_buf], else: []
 
     new_state =
       HighlightSync.evict_inactive(state,
         ttl_ms: ttl_seconds * 1_000,
-        protected_pids: protected
+        protected_pids: parser_eviction_protected_pids(state)
       )
 
     effects =
@@ -442,6 +440,23 @@ defmodule MingaEditor.Handlers.HighlightHandler do
       end
 
     {new_state, effects}
+  end
+
+  @spec parser_eviction_protected_pids(EditorState.t()) :: [pid()]
+  defp parser_eviction_protected_pids(state) do
+    agent_buf = state |> AgentAccess.agent() |> Map.get(:buffer)
+
+    [agent_buf | visible_window_buffers(state)]
+    |> Enum.filter(&is_pid/1)
+    |> Enum.uniq()
+  end
+
+  @spec visible_window_buffers(EditorState.t()) :: [pid()]
+  defp visible_window_buffers(state) do
+    state.workspace.windows.map
+    |> Map.values()
+    |> Enum.map(& &1.buffer)
+    |> Enum.filter(&is_pid/1)
   end
 
   # Returns true if the given buffer PID is visible in any window.

--- a/lib/minga_editor/highlight_sync.ex
+++ b/lib/minga_editor/highlight_sync.ex
@@ -608,8 +608,12 @@ defmodule MingaEditor.HighlightSync do
   defp apply_evictions(state, [], _remaining_timestamps), do: state
 
   defp apply_evictions(state, evicted_ids, remaining_timestamps) do
-    # Action: send close_buffer commands to the Zig parser.
-    Enum.each(evicted_ids, fn {_pid, id} -> ParserManager.close_buffer(id) end)
+    # Action: close parser state and drop crash-recovery tracking.
+    # Hidden buffers stay evicted until they are shown again.
+    Enum.each(evicted_ids, fn {_pid, id} ->
+      ParserManager.close_buffer(id)
+      ParserManager.unregister_buffer(id)
+    end)
 
     Minga.Log.debug(
       :editor,

--- a/test/minga_editor/handlers/highlight_handler_test.exs
+++ b/test/minga_editor/handlers/highlight_handler_test.exs
@@ -43,6 +43,21 @@ defmodule MingaEditor.Handlers.HighlightHandlerTest do
     %{state | workspace: %{state.workspace | highlight: updated_hl}}
   end
 
+  @spec with_buffer_tracking(EditorState.t(), pid(), non_neg_integer(), non_neg_integer()) ::
+          EditorState.t()
+  defp with_buffer_tracking(state, pid, buffer_id, last_active_ms_ago) do
+    state = with_buffer_id(state, pid, buffer_id)
+    hl = state.workspace.highlight
+    now = System.monotonic_time(:millisecond)
+
+    updated_hl = %{
+      hl
+      | last_active_at: Map.put(hl.last_active_at, pid, now - last_active_ms_ago)
+    }
+
+    %{state | workspace: %{state.workspace | highlight: updated_hl}}
+  end
+
   describe "setup and parser lifecycle" do
     test "setup, parser status, eviction, and catch-all messages return the expected effects" do
       {_, setup_effects} = HighlightHandler.handle(base_state(), :setup_highlight)
@@ -92,6 +107,50 @@ defmodule MingaEditor.Handlers.HighlightHandlerTest do
 
       assert {^catch_all_state, []} =
                HighlightHandler.handle(catch_all_state, {:minga_highlight, :unknown_event})
+    end
+
+    test "parser tree eviction protects visible split buffers while evicting hidden buffers" do
+      state = base_state()
+      active = active_buffer(state)
+
+      visible_buf =
+        start_supervised!({Minga.Buffer.Process, content: "visible"},
+          id: {:highlight_handler_test_visible_buf, make_ref()}
+        )
+
+      hidden_buf =
+        start_supervised!({Minga.Buffer.Process, content: "hidden"},
+          id: {:highlight_handler_test_hidden_buf, make_ref()}
+        )
+
+      stale_ms = 10 * 60 * 1_000
+
+      visible_window = Window.new(2, visible_buf, 24, 80)
+
+      state =
+        state
+        |> with_buffer_tracking(active, 1, stale_ms)
+        |> with_buffer_tracking(visible_buf, 2, stale_ms)
+        |> with_buffer_tracking(hidden_buf, 3, stale_ms)
+
+      workspace = %{
+        state.workspace
+        | windows: %{
+            state.workspace.windows
+            | map: Map.put(state.workspace.windows.map, 2, visible_window),
+              next_id: 3
+          }
+      }
+
+      state = %{state | workspace: workspace}
+
+      {new_state, _effects} = HighlightHandler.handle(state, :evict_parser_trees)
+
+      assert Map.get(new_state.workspace.highlight.buffer_ids, active) == 1
+      assert Map.get(new_state.workspace.highlight.buffer_ids, visible_buf) == 2
+      refute Map.has_key?(new_state.workspace.highlight.buffer_ids, hidden_buf)
+      refute Map.has_key?(new_state.workspace.highlight.reverse_buffer_ids, 3)
+      refute Map.has_key?(new_state.workspace.highlight.last_active_at, hidden_buf)
     end
 
     test "grammar and port log messages are translated to log effects" do


### PR DESCRIPTION
# TL;DR
Visible split buffers keep their tree-sitter highlighting after parser-tree eviction runs. Hidden buffers still evict normally, so this fixes the idle/background highlighting loss without adding a new cache layer.

## Context
The parser-tree LRU cleanup protected the active buffer and agent buffer, but not other buffers currently visible in split panes. After enough idle time, a visible inactive split could lose its cached highlight state and render without syntax highlighting.

## Changes
- Protect buffers attached to visible windows during parser-tree eviction, in addition to the agent buffer.
- Keep hidden buffers eligible for eviction by deriving protection from `state.workspace.windows.map`, not open buffers, tabs, or history.
- Unregister evicted parser buffer IDs from crash-recovery tracking so hidden buffers stay evicted until they are shown again.
- Add regression coverage for visible split retention and hidden buffer eviction.

## Verification
- `make lint`
- `mix test.llm`
- `mix test.llm test/minga_editor/handlers/highlight_handler_test.exs test/minga_editor/highlight_sync_eviction_test.exs`
- `mix compile --warnings-as-errors`

## Acceptance Criteria Addressed
- Visible split buffers are protected from parser-tree eviction ✅
- Hidden buffers remain evictable ✅
- No new highlight cache layer is introduced ✅
