### PR TITLE
Refactor GUI rendering around retained render model

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -684,6 +684,7 @@ One 0x80 message is sent per buffer window per frame. Agent chat windows do not 
 | 0x06 | DocumentHighlights | highlight_count + highlights |
 | 0x07 | LineAnnotations | annotation_count + annotations |
 | 0x08 | PaneGeometry | window-scoped pane geometry, viewport summary, gutter metrics, and hit regions |
+| 0x09 | Cursorline | window-local cursorline row and background color |
 
 ```
 opcode(1) + section_count(1) + sections...
@@ -693,6 +694,7 @@ Header section:
 
 Flags:
   bit 0: full_refresh (1 = all rows changed, 0 = incremental)
+  bit 1: cursor_visible (1 = show cursor, 0 = hide cursor)
 
 Cursor shape: 0 = block, 1 = beam, 2 = underline
 
@@ -743,6 +745,9 @@ Line annotations section:
   The frontend renders inline_pill as rounded-rect pills, inline_text as styled
   text after line content, and gutter_icon in the sign column.
 
+Cursorline section:
+  local_row(2) + r(1) + g(1) + b(1)
+
 Pane geometry section:
   window_id(2)
   total_rect(8) + content_rect(8) + text_rect(8) + gutter_rect(8) + clip_rect(8)
@@ -750,14 +755,14 @@ Pane geometry section:
   line_number_width(2) + sign_col_width(2) + hit_region_count(1)
   Per hit region: kind(1) + rect(8) + window_id(2)
 
-Rects are cell-space tuples encoded as row(2), col(2), width(2), height(2). Hit region kinds are 1=text, 2=gutter, 3=fold_control, 4=modeline, 5=divider. Swift converts these rects to pixels, but pane ownership and input targets come from the BEAM-authored geometry.
+Rects are cell-space tuples encoded as row(2), col(2), width(2), height(2). Hit region kinds are 1=text, 2=gutter, 3=fold_control, 4=modeline, 5=divider, 6=status_bar. Swift converts these rects to pixels, but pane ownership and input targets come from the BEAM-authored geometry.
 ```
 
 The frontend renders selection and search matches as Metal quads behind text (not baked into line textures). This enables zero re-rasterization when the selection changes. Diagnostic underlines are rendered as quads after text.
 
 `content_hash` is a per-row hash computed by the BEAM. The frontend uses it for CTLine texture cache invalidation: if the hash matches, the cached texture is reused without re-rasterization.
 
-When `gui_window_content` is present for a window, the BEAM does not send draw_text commands for that window's buffer content. Overlays (hover popups, signature help) have dedicated GUI opcodes (0x81, 0x82) and are rendered natively by SwiftUI. Gutter data (0x7B), cursorline (0x7A), and cursor position continue through their existing opcodes.
+When `gui_window_content` is present for a window, the BEAM does not send draw_text commands for that window's buffer content. Overlays (hover popups, signature help) have dedicated GUI opcodes (0x81, 0x82) and are rendered natively by SwiftUI. Gutter data (0x7B) and cursor position continue through their existing opcodes, while window-local cursorline is carried in gui_window_content section 0x09.
 
 ### 0x81 — gui_hover_popup
 

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -676,16 +676,20 @@ One 0x80 message is sent per buffer window per frame. Agent chat windows do not 
 
 | Section ID | Name | Content |
 |-----------|------|--------|
-| 0x01 | Header | window_id, flags, cursor_row, cursor_col, cursor_shape, scroll_left |
+| 0x01 | Header | window_id, flags, cursor_row, cursor_col, cursor_shape, scroll_left, content_epoch |
 | 0x02 | Rows | row_count + rows (positional per row with spans) |
 | 0x03 | Selection | selection_type + coordinates |
 | 0x04 | SearchMatches | match_count + matches |
 | 0x05 | Diagnostics | range_count + diagnostic ranges |
 | 0x06 | DocumentHighlights | highlight_count + highlights |
 | 0x07 | LineAnnotations | annotation_count + annotations |
+| 0x08 | PaneGeometry | window-scoped pane geometry, viewport summary, gutter metrics, and hit regions |
 
 ```
-opcode(1) + window_id(2) + flags(1) + cursor_row(2) + cursor_col(2) + cursor_shape(1) + scroll_left(2) + visible_row_count(2) + rows... + selection + search_matches + diagnostic_ranges
+opcode(1) + section_count(1) + sections...
+
+Header section:
+  window_id(2) + flags(1) + cursor_row(2) + cursor_col(2) + cursor_shape(1) + scroll_left(2) + content_epoch(4)
 
 Flags:
   bit 0: full_refresh (1 = all rows changed, 0 = incremental)
@@ -695,6 +699,8 @@ Cursor shape: 0 = block, 1 = beam, 2 = underline
 scroll_left: horizontal scroll offset in display columns. When > 0, the frontend
 shifts line textures and overlay quads left by scroll_left * cell_width so that
 content past the viewport's left edge becomes visible. The gutter stays fixed.
+
+content_epoch: BEAM-authored version for retained frontend resources owned by this window. A frontend must discard retained row state for a window when the epoch changes or when `full_refresh` is set.
 
 Per visual row:
   row_type(1) + buf_line(4) + content_hash(4) + text_len(4) + text(text_len) + span_count(2) + spans...
@@ -736,6 +742,15 @@ Line annotations section:
   fg/bg are 24-bit RGB. text is UTF-8, text_len is byte length.
   The frontend renders inline_pill as rounded-rect pills, inline_text as styled
   text after line content, and gutter_icon in the sign column.
+
+Pane geometry section:
+  window_id(2)
+  total_rect(8) + content_rect(8) + text_rect(8) + gutter_rect(8) + clip_rect(8)
+  viewport_top(4) + viewport_left(2) + viewport_rows(2) + viewport_cols(2) + total_lines(4) + visual_row_offset(2) + total_visual_rows(4)
+  line_number_width(2) + sign_col_width(2) + hit_region_count(1)
+  Per hit region: kind(1) + rect(8) + window_id(2)
+
+Rects are cell-space tuples encoded as row(2), col(2), width(2), height(2). Hit region kinds are 1=text, 2=gutter, 3=fold_control, 4=modeline, 5=divider. Swift converts these rects to pixels, but pane ownership and input targets come from the BEAM-authored geometry.
 ```
 
 The frontend renders selection and search matches as Metal quads behind text (not baked into line textures). This enables zero re-rasterization when the selection changes. Diagnostic underlines are rendered as quads after text.

--- a/lib/minga/frontend/adapter/gui.ex
+++ b/lib/minga/frontend/adapter/gui.ex
@@ -103,7 +103,6 @@ defmodule Minga.Frontend.Adapter.GUI do
   def encode_windows_with_metrics(windows, %Caches{} = caches) when is_list(windows) do
     {cmds, caches, metrics} =
       windows
-      |> Enum.filter(&buffer_window?/1)
       |> Enum.reduce({[], caches, empty_window_metrics()}, fn window,
                                                               {cmds_acc, caches_acc, metrics_acc} ->
         {cmds, caches, metrics} = encode_window_with_metrics(window, cmds_acc, caches_acc)
@@ -133,10 +132,6 @@ defmodule Minga.Frontend.Adapter.GUI do
 
     {Enum.reverse(cmds), caches}
   end
-
-  @spec buffer_window?(term()) :: boolean()
-  defp buffer_window?(%RenderModel.Window{content_kind: :buffer}), do: true
-  defp buffer_window?(_window), do: false
 
   @spec encode_window_with_metrics(RenderModel.Window.t(), [binary()], Caches.t()) ::
           {[binary()], Caches.t(), window_metrics()}

--- a/lib/minga/frontend/adapter/gui.ex
+++ b/lib/minga/frontend/adapter/gui.ex
@@ -10,6 +10,7 @@ defmodule Minga.Frontend.Adapter.GUI do
   alias Minga.Frontend.Adapter.GUI.ChangeSummaryEncoder
   alias Minga.Frontend.Adapter.GUI.CompletionEncoder
   alias Minga.Frontend.Adapter.GUI.EditTimelineEncoder
+  alias Minga.Frontend.Adapter.GUI.EncodedFrame
   alias Minga.Frontend.Adapter.GUI.ExtensionOverlayEncoder
   alias Minga.Frontend.Adapter.GUI.ExtensionPanelEncoder
   alias Minga.Frontend.Adapter.GUI.FileTreeEncoder
@@ -70,6 +71,26 @@ defmodule Minga.Frontend.Adapter.GUI do
   ]
 
   @type window_metrics :: WindowEncoder.metrics()
+
+  @doc "Encodes a full GUI render model into Metal-critical and SwiftUI chrome command groups."
+  @spec encode(RenderModel.t(), Caches.t()) :: EncodedFrame.t()
+  def encode(%RenderModel{} = model, %Caches{} = caches) do
+    {window_content_cmds, caches, window_metrics} =
+      encode_windows_with_metrics(model.windows, caches)
+
+    {metal_ui_cmds, caches} = encode_metal_ui(model.ui, caches)
+    {chrome_cmds, caches} = encode_ui(model.ui, caches)
+
+    metal_commands = window_content_cmds ++ metal_ui_cmds
+
+    metrics = %{
+      window: window_metrics,
+      metal_ui_bytes: IO.iodata_length(metal_ui_cmds),
+      chrome_bytes: IO.iodata_length(chrome_cmds)
+    }
+
+    EncodedFrame.new(metal_commands, chrome_cmds, caches, metrics)
+  end
 
   @spec encode_windows([RenderModel.Window.t()], Caches.t()) :: {[binary()], Caches.t()}
   def encode_windows(windows, %Caches{} = caches) when is_list(windows) do

--- a/lib/minga/frontend/adapter/gui/encoded_frame.ex
+++ b/lib/minga/frontend/adapter/gui/encoded_frame.ex
@@ -1,0 +1,51 @@
+defmodule Minga.Frontend.Adapter.GUI.EncodedFrame do
+  @moduledoc """
+  GUI adapter output for one render model.
+
+  Metal-critical commands are sent in the frame batch before `batch_end`. SwiftUI chrome commands are sent separately because they do not participate in the Metal render pass. Keeping the split in the adapter makes command ordering an adapter concern instead of an emit-stage concern.
+  """
+
+  alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.WindowEncoder
+
+  @type metrics :: %{
+          window: WindowEncoder.metrics(),
+          metal_ui_bytes: non_neg_integer(),
+          chrome_bytes: non_neg_integer()
+        }
+
+  @enforce_keys [:metal_commands, :chrome_commands, :caches, :metrics]
+  defstruct metal_commands: [],
+            chrome_commands: [],
+            caches: Caches.new(),
+            metrics: %{
+              window: %{
+                row_bytes: 0,
+                overlay_bytes: 0,
+                gutter_bytes: 0,
+                annotation_bytes: 0,
+                metadata_bytes: 0
+              },
+              metal_ui_bytes: 0,
+              chrome_bytes: 0
+            }
+
+  @type t :: %__MODULE__{
+          metal_commands: [binary()],
+          chrome_commands: [binary()],
+          caches: Caches.t(),
+          metrics: metrics()
+        }
+
+  @doc "Creates encoded GUI frame output."
+  @spec new([binary()], [binary()], Caches.t(), metrics()) :: t()
+  def new(metal_commands, chrome_commands, %Caches{} = caches, metrics)
+      when is_list(metal_commands) and is_list(chrome_commands) do
+    %__MODULE__{
+      metal_commands: metal_commands,
+      chrome_commands: chrome_commands,
+      caches: caches,
+      metrics: metrics
+    }
+  end
+end

--- a/lib/minga/frontend/adapter/gui/window_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/window_encoder.ex
@@ -81,7 +81,6 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   alias Minga.Protocol.Opcodes
 
   @op_gui_window_content Opcodes.gui_window_content()
-  @op_gui_cursorline Opcodes.gui_cursorline()
   @op_gui_gutter Opcodes.gui_gutter()
   @op_gui_indent_guides Opcodes.gui_indent_guides()
 
@@ -94,6 +93,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   @section_wc_highlights 0x06
   @section_wc_annotations 0x07
   @section_wc_geometry 0x08
+  @section_wc_cursorline 0x09
 
   @section_gutter_window 0x01
   @section_gutter_config 0x02
@@ -166,6 +166,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
     highlight_payload = IO.iodata_to_binary(encode_document_highlights(sw.document_highlights))
     annotation_payload = IO.iodata_to_binary(encode_annotations(sw.annotations))
     geometry_payload = encode_geometry(sw.geometry)
+    cursorline_payload = encode_cursorline_section(sw.cursorline, sw.rect)
 
     header_section = encode_section(@section_wc_header, header_payload)
     rows_section = encode_section(@section_wc_rows, rows_payload)
@@ -175,6 +176,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
     highlight_section = encode_section(@section_wc_highlights, highlight_payload)
     annotation_section = encode_section(@section_wc_annotations, annotation_payload)
     geometry_sections = geometry_sections(geometry_payload)
+    cursorline_sections = cursorline_sections(cursorline_payload)
 
     sections =
       [
@@ -185,7 +187,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
         diagnostic_section,
         highlight_section,
         annotation_section
-      ] ++ geometry_sections
+      ] ++ geometry_sections ++ cursorline_sections
 
     binary = IO.iodata_to_binary([<<@op_gui_window_content, length(sections)::8>> | sections])
 
@@ -196,7 +198,9 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
           byte_size(highlight_section),
       gutter_bytes: 0,
       annotation_bytes: byte_size(annotation_section),
-      metadata_bytes: 2 + byte_size(header_section) + IO.iodata_length(geometry_sections)
+      metadata_bytes:
+        2 + byte_size(header_section) + IO.iodata_length(geometry_sections) +
+          IO.iodata_length(cursorline_sections)
     }
 
     {binary, metrics}
@@ -215,6 +219,10 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   @spec geometry_sections(binary() | nil) :: [binary()]
   defp geometry_sections(nil), do: []
   defp geometry_sections(payload), do: [encode_section(@section_wc_geometry, payload)]
+
+  @spec cursorline_sections(binary() | nil) :: [binary()]
+  defp cursorline_sections(nil), do: []
+  defp cursorline_sections(payload), do: [encode_section(@section_wc_cursorline, payload)]
 
   @spec encode_geometry(PaneGeometry.t() | nil) :: binary() | nil
   defp encode_geometry(nil), do: nil
@@ -256,6 +264,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   defp encode_hit_kind(:fold_control), do: 3
   defp encode_hit_kind(:modeline), do: 4
   defp encode_hit_kind(:divider), do: 5
+  defp encode_hit_kind(:status_bar), do: 6
 
   @doc """
   Returns the opcode constant for gui_window_content.
@@ -491,10 +500,19 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   # ── Cursorline ─────────────────────────────────────────────────────────
 
   @spec encode_cursorline(Cursorline.t() | nil) :: [binary()]
-  defp encode_cursorline(nil), do: []
+  defp encode_cursorline(_cursorline), do: []
 
-  defp encode_cursorline(%Cursorline{row: row, bg_rgb: bg_rgb}) do
-    [<<@op_gui_cursorline, row::16, red(bg_rgb)::8, green(bg_rgb)::8, blue(bg_rgb)::8>>]
+  @spec encode_cursorline_section(Cursorline.t() | nil, RenderWindow.rect()) :: binary() | nil
+  defp encode_cursorline_section(nil, _rect), do: nil
+  defp encode_cursorline_section(%Cursorline{bg_rgb: 0}, _rect), do: nil
+  defp encode_cursorline_section(%Cursorline{row: 0xFFFF}, _rect), do: nil
+
+  defp encode_cursorline_section(
+         %Cursorline{row: row, bg_rgb: bg_rgb},
+         {rect_row, _col, _width, height}
+       ) do
+    local_row = row |> Kernel.-(rect_row) |> max(0) |> min(max(height - 1, 0))
+    <<local_row::16, red(bg_rgb)::8, green(bg_rgb)::8, blue(bg_rgb)::8>>
   end
 
   # ── Indent guides ──────────────────────────────────────────────────────

--- a/lib/minga/frontend/adapter/gui/window_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/window_encoder.ex
@@ -70,7 +70,9 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   alias Minga.RenderModel.Window.DocumentHighlight
   alias Minga.RenderModel.Window.Gutter
   alias Minga.RenderModel.Window.GutterEntry
+  alias Minga.RenderModel.Window.HitRegion
   alias Minga.RenderModel.Window.IndentGuides
+  alias Minga.RenderModel.Window.PaneGeometry
   alias Minga.RenderModel.Window.Row
   alias Minga.RenderModel.Window.SearchMatch
   alias Minga.RenderModel.Window.Selection
@@ -91,6 +93,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   @section_wc_diagnostics 0x05
   @section_wc_highlights 0x06
   @section_wc_annotations 0x07
+  @section_wc_geometry 0x08
 
   @section_gutter_window 0x01
   @section_gutter_config 0x02
@@ -154,7 +157,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
 
     header_payload =
       <<sw.window_id::16, flags::8, sw.cursor_row::16, sw.cursor_col::16, cursor_shape::8,
-        sw.scroll_left::16>>
+        sw.scroll_left::16, sw.content_epoch::32>>
 
     rows_payload = IO.iodata_to_binary([<<row_count::16>> | encode_rows(sw.rows)])
     selection_payload = IO.iodata_to_binary(encode_selection(sw.selection))
@@ -162,6 +165,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
     diag_payload = IO.iodata_to_binary(encode_diagnostic_ranges(sw.diagnostic_ranges))
     highlight_payload = IO.iodata_to_binary(encode_document_highlights(sw.document_highlights))
     annotation_payload = IO.iodata_to_binary(encode_annotations(sw.annotations))
+    geometry_payload = encode_geometry(sw.geometry)
 
     header_section = encode_section(@section_wc_header, header_payload)
     rows_section = encode_section(@section_wc_rows, rows_payload)
@@ -170,16 +174,18 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
     diagnostic_section = encode_section(@section_wc_diagnostics, diag_payload)
     highlight_section = encode_section(@section_wc_highlights, highlight_payload)
     annotation_section = encode_section(@section_wc_annotations, annotation_payload)
+    geometry_sections = geometry_sections(geometry_payload)
 
-    sections = [
-      header_section,
-      rows_section,
-      selection_section,
-      search_section,
-      diagnostic_section,
-      highlight_section,
-      annotation_section
-    ]
+    sections =
+      [
+        header_section,
+        rows_section,
+        selection_section,
+        search_section,
+        diagnostic_section,
+        highlight_section,
+        annotation_section
+      ] ++ geometry_sections
 
     binary = IO.iodata_to_binary([<<@op_gui_window_content, length(sections)::8>> | sections])
 
@@ -190,7 +196,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
           byte_size(highlight_section),
       gutter_bytes: 0,
       annotation_bytes: byte_size(annotation_section),
-      metadata_bytes: 2 + byte_size(header_section)
+      metadata_bytes: 2 + byte_size(header_section) + IO.iodata_length(geometry_sections)
     }
 
     {binary, metrics}
@@ -205,6 +211,51 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   defp encode_section(section_id, payload) do
     <<section_id::8, byte_size(payload)::16, payload::binary>>
   end
+
+  @spec geometry_sections(binary() | nil) :: [binary()]
+  defp geometry_sections(nil), do: []
+  defp geometry_sections(payload), do: [encode_section(@section_wc_geometry, payload)]
+
+  @spec encode_geometry(PaneGeometry.t() | nil) :: binary() | nil
+  defp encode_geometry(nil), do: nil
+
+  defp encode_geometry(%PaneGeometry{} = geometry) do
+    hit_regions = encode_hit_regions(geometry.hit_regions)
+
+    IO.iodata_to_binary([
+      <<geometry.window_id::16>>,
+      encode_rect(geometry.total_rect),
+      encode_rect(geometry.content_rect),
+      encode_rect(geometry.text_rect),
+      encode_rect(geometry.gutter_rect),
+      encode_rect(geometry.clip_rect),
+      <<geometry.viewport.top::32, geometry.viewport.left::16, geometry.viewport.rows::16,
+        geometry.viewport.cols::16, geometry.viewport.total_lines::32,
+        geometry.viewport.visual_row_offset::16, geometry.viewport.total_visual_rows::32,
+        geometry.gutter_metrics.line_number_width::16, geometry.gutter_metrics.sign_col_width::16,
+        length(geometry.hit_regions)::8>>,
+      hit_regions
+    ])
+  end
+
+  @spec encode_rect(PaneGeometry.rect()) :: binary()
+  defp encode_rect({row, col, width, height}) do
+    <<row::16, col::16, width::16, height::16>>
+  end
+
+  @spec encode_hit_regions([HitRegion.t()]) :: iodata()
+  defp encode_hit_regions(hit_regions) do
+    Enum.map(hit_regions, fn %HitRegion{} = region ->
+      [<<encode_hit_kind(region.kind)::8>>, encode_rect(region.rect), <<region.window_id::16>>]
+    end)
+  end
+
+  @spec encode_hit_kind(HitRegion.kind()) :: non_neg_integer()
+  defp encode_hit_kind(:text), do: 1
+  defp encode_hit_kind(:gutter), do: 2
+  defp encode_hit_kind(:fold_control), do: 3
+  defp encode_hit_kind(:modeline), do: 4
+  defp encode_hit_kind(:divider), do: 5
 
   @doc """
   Returns the opcode constant for gui_window_content.

--- a/lib/minga/render_model.ex
+++ b/lib/minga/render_model.ex
@@ -1,0 +1,33 @@
+defmodule Minga.RenderModel do
+  @moduledoc """
+  Top-level visible model for one rendered frame.
+
+  Products such as `MingaEditor` derive this struct from their own state, then frontend adapters translate it to protocol commands. The struct is pure data and lives in core so adapters can consume one visible truth instead of parallel window, chrome, cursor, and side-channel payloads.
+  """
+
+  alias Minga.RenderModel.Cursor
+  alias Minga.RenderModel.UI
+  alias Minga.RenderModel.Window
+
+  @enforce_keys [:windows, :ui, :cursor]
+  defstruct windows: [],
+            ui: %UI{},
+            cursor: nil,
+            title: nil,
+            window_bg: nil
+
+  @type t :: %__MODULE__{
+          windows: [Window.t()],
+          ui: UI.t(),
+          cursor: Cursor.t(),
+          title: String.t() | nil,
+          window_bg: non_neg_integer() | nil
+        }
+
+  @doc "Creates a top-level frame render model."
+  @spec new([Window.t()], UI.t(), Cursor.t(), String.t() | nil, non_neg_integer() | nil) :: t()
+  def new(windows, %UI{} = ui, %Cursor{} = cursor, title \\ nil, window_bg \\ nil)
+      when is_list(windows) do
+    %__MODULE__{windows: windows, ui: ui, cursor: cursor, title: title, window_bg: window_bg}
+  end
+end

--- a/lib/minga/render_model/cursor.ex
+++ b/lib/minga/render_model/cursor.ex
@@ -1,0 +1,28 @@
+defmodule Minga.RenderModel.Cursor do
+  @moduledoc """
+  Cursor state for one rendered frame.
+
+  The editor owns cursor semantics. The render model carries the resolved cursor position and shape so frontend adapters can encode or draw it without reaching back into editor state.
+  """
+
+  @type shape :: :block | :beam | :underline
+
+  @enforce_keys [:row, :col, :shape]
+  defstruct row: 0,
+            col: 0,
+            shape: :block
+
+  @type t :: %__MODULE__{
+          row: non_neg_integer(),
+          col: non_neg_integer(),
+          shape: shape()
+        }
+
+  @doc "Creates a cursor model."
+  @spec new(non_neg_integer(), non_neg_integer(), shape()) :: t()
+  def new(row, col, shape)
+      when is_integer(row) and row >= 0 and is_integer(col) and col >= 0 and
+             shape in [:block, :beam, :underline] do
+    %__MODULE__{row: row, col: col, shape: shape}
+  end
+end

--- a/lib/minga/render_model/window.ex
+++ b/lib/minga/render_model/window.ex
@@ -12,6 +12,7 @@ defmodule Minga.RenderModel.Window do
     DocumentHighlight,
     Gutter,
     IndentGuides,
+    PaneGeometry,
     Row,
     SearchMatch,
     Selection
@@ -41,6 +42,8 @@ defmodule Minga.RenderModel.Window do
             gutter: nil,
             cursorline: nil,
             indent_guides: nil,
+            geometry: nil,
+            content_epoch: 0,
             full_refresh: true
 
   @type t :: %__MODULE__{
@@ -61,6 +64,8 @@ defmodule Minga.RenderModel.Window do
           gutter: Gutter.t() | nil,
           cursorline: Cursorline.t() | nil,
           indent_guides: IndentGuides.t() | nil,
+          geometry: PaneGeometry.t() | nil,
+          content_epoch: non_neg_integer(),
           full_refresh: boolean()
         }
 end

--- a/lib/minga/render_model/window/gutter_metrics.ex
+++ b/lib/minga/render_model/window/gutter_metrics.ex
@@ -1,0 +1,20 @@
+defmodule Minga.RenderModel.Window.GutterMetrics do
+  @moduledoc """
+  Window-scoped gutter sizing in terminal cell columns.
+  """
+
+  @enforce_keys [:line_number_width, :sign_col_width]
+  defstruct line_number_width: 0,
+            sign_col_width: 0
+
+  @type t :: %__MODULE__{
+          line_number_width: non_neg_integer(),
+          sign_col_width: non_neg_integer()
+        }
+
+  @doc "Returns the total gutter width in cells."
+  @spec total_width(t()) :: non_neg_integer()
+  def total_width(%__MODULE__{} = metrics) do
+    metrics.line_number_width + metrics.sign_col_width
+  end
+end

--- a/lib/minga/render_model/window/hit_region.ex
+++ b/lib/minga/render_model/window/hit_region.ex
@@ -1,0 +1,23 @@
+defmodule Minga.RenderModel.Window.HitRegion do
+  @moduledoc """
+  Window-scoped input hit region authored by the BEAM.
+  """
+
+  @type kind :: :text | :gutter | :fold_control | :modeline | :divider
+  @type rect ::
+          {row :: non_neg_integer(), col :: non_neg_integer(), width :: non_neg_integer(),
+           height :: non_neg_integer()}
+
+  @enforce_keys [:kind, :rect, :window_id]
+  defstruct kind: :text,
+            rect: {0, 0, 0, 0},
+            window_id: 0,
+            target: nil
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          rect: rect(),
+          window_id: non_neg_integer(),
+          target: term()
+        }
+end

--- a/lib/minga/render_model/window/hit_region.ex
+++ b/lib/minga/render_model/window/hit_region.ex
@@ -3,7 +3,7 @@ defmodule Minga.RenderModel.Window.HitRegion do
   Window-scoped input hit region authored by the BEAM.
   """
 
-  @type kind :: :text | :gutter | :fold_control | :modeline | :divider
+  @type kind :: :text | :gutter | :fold_control | :modeline | :status_bar | :divider
   @type rect ::
           {row :: non_neg_integer(), col :: non_neg_integer(), width :: non_neg_integer(),
            height :: non_neg_integer()}

--- a/lib/minga/render_model/window/pane_geometry.ex
+++ b/lib/minga/render_model/window/pane_geometry.ex
@@ -1,0 +1,48 @@
+defmodule Minga.RenderModel.Window.PaneGeometry do
+  @moduledoc """
+  BEAM-authored pane geometry for one render-model window.
+
+  Native GUI frontends use this as the authoritative source for pane ownership, clipping, and input hit testing. Pixel conversion remains frontend-owned, but the BEAM owns the cell-space rects and target regions.
+  """
+
+  alias Minga.RenderModel.Window.GutterMetrics
+  alias Minga.RenderModel.Window.HitRegion
+  alias Minga.RenderModel.Window.Viewport
+
+  @type rect ::
+          {row :: non_neg_integer(), col :: non_neg_integer(), width :: non_neg_integer(),
+           height :: non_neg_integer()}
+
+  @enforce_keys [
+    :window_id,
+    :total_rect,
+    :content_rect,
+    :text_rect,
+    :gutter_rect,
+    :clip_rect,
+    :viewport,
+    :gutter_metrics,
+    :hit_regions
+  ]
+  defstruct window_id: 0,
+            total_rect: {0, 0, 0, 0},
+            content_rect: {0, 0, 0, 0},
+            text_rect: {0, 0, 0, 0},
+            gutter_rect: {0, 0, 0, 0},
+            clip_rect: {0, 0, 0, 0},
+            viewport: nil,
+            gutter_metrics: nil,
+            hit_regions: []
+
+  @type t :: %__MODULE__{
+          window_id: non_neg_integer(),
+          total_rect: rect(),
+          content_rect: rect(),
+          text_rect: rect(),
+          gutter_rect: rect(),
+          clip_rect: rect(),
+          viewport: Viewport.t(),
+          gutter_metrics: GutterMetrics.t(),
+          hit_regions: [HitRegion.t()]
+        }
+end

--- a/lib/minga/render_model/window/row.ex
+++ b/lib/minga/render_model/window/row.ex
@@ -20,6 +20,7 @@ defmodule Minga.RenderModel.Window.Row do
   @enforce_keys [:row_type, :buf_line, :text, :spans]
   defstruct row_type: :normal,
             buf_line: 0,
+            visual_index: 0,
             text: "",
             spans: [],
             content_hash: 0
@@ -29,6 +30,7 @@ defmodule Minga.RenderModel.Window.Row do
   @type t :: %__MODULE__{
           row_type: row_type(),
           buf_line: non_neg_integer(),
+          visual_index: non_neg_integer(),
           text: String.t(),
           spans: [Span.t()],
           content_hash: non_neg_integer()

--- a/lib/minga/render_model/window/span.ex
+++ b/lib/minga/render_model/window/span.ex
@@ -42,6 +42,27 @@ defmodule Minga.RenderModel.Window.Span do
     }
   end
 
+  @doc "Clips a span to a source display-column range and rebases it into a visual row."
+  @spec rebase_to_visual_row(t(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: [
+          t()
+        ]
+  def rebase_to_visual_row(%__MODULE__{} = span, source_start, source_end, indent_width) do
+    start_col = max(span.start_col, source_start)
+    end_col = min(span.end_col, source_end)
+
+    if end_col > start_col do
+      [
+        %__MODULE__{
+          span
+          | start_col: start_col - source_start + indent_width,
+            end_col: end_col - source_start + indent_width
+        }
+      ]
+    else
+      []
+    end
+  end
+
   @spec encode_attrs(Face.t()) :: non_neg_integer()
   defp encode_attrs(%Face{} = face) do
     if(face.bold, do: 1, else: 0) |||

--- a/lib/minga/render_model/window/viewport.ex
+++ b/lib/minga/render_model/window/viewport.ex
@@ -1,0 +1,24 @@
+defmodule Minga.RenderModel.Window.Viewport do
+  @moduledoc """
+  Window-scoped viewport summary for GUI rendering and hit testing.
+  """
+
+  @enforce_keys [:top, :left, :rows, :cols, :total_lines]
+  defstruct top: 0,
+            left: 0,
+            rows: 0,
+            cols: 0,
+            total_lines: 0,
+            visual_row_offset: 0,
+            total_visual_rows: 0
+
+  @type t :: %__MODULE__{
+          top: non_neg_integer(),
+          left: non_neg_integer(),
+          rows: non_neg_integer(),
+          cols: non_neg_integer(),
+          total_lines: non_neg_integer(),
+          visual_row_offset: non_neg_integer(),
+          total_visual_rows: non_neg_integer()
+        }
+end

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -431,7 +431,8 @@ defmodule MingaEditor do
     new_state = %{
       (state
        |> EditorState.set_terminal_viewport(vp)
-       |> EditorState.set_viewport(vp))
+       |> EditorState.set_viewport(vp)
+       |> EditorState.reset_frontend_render_state())
       | capabilities: caps,
         layout: nil
     }

--- a/lib/minga_editor/agent/view/prompt_render_window.ex
+++ b/lib/minga_editor/agent/view/prompt_render_window.ex
@@ -18,10 +18,15 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
   alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Agent.ViewContext
   alias Minga.RenderModel.Window, as: RenderWindow
+  alias Minga.RenderModel.Window.Gutter
+  alias Minga.RenderModel.Window.GutterMetrics
+  alias Minga.RenderModel.Window.HitRegion
   alias Minga.RenderModel.Window.IndentGuides
+  alias Minga.RenderModel.Window.PaneGeometry
   alias Minga.RenderModel.Window.Row
   alias Minga.RenderModel.Window.Selection
   alias Minga.RenderModel.Window.Span
+  alias Minga.RenderModel.Window.Viewport, as: RenderViewport
   alias MingaEditor.Input.Wrap, as: InputWrap
   alias MingaEditor.UI.Theme
 
@@ -113,10 +118,13 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
     # Selection overlay
     selection = build_selection(mode, mode_state, cursor, scroll, inner_width, lines)
 
+    prompt_id = prompt_window_id()
+    rect = rect || {0, 0, inner_width, visible_count}
+
     %RenderWindow{
-      window_id: prompt_window_id(),
+      window_id: prompt_id,
       content_kind: :agent_prompt,
-      rect: rect || {0, 0, inner_width, visible_count},
+      rect: rect,
       rows: visual_rows,
       cursor_row: max(display_cursor_row, 0),
       cursor_col: max(display_cursor_col, 0),
@@ -127,8 +135,75 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
       diagnostic_ranges: [],
       document_highlights: [],
       annotations: [],
-      indent_guides: IndentGuides.empty(prompt_window_id()),
-      full_refresh: true
+      gutter: prompt_gutter(prompt_id, rect, panel.input_focused),
+      indent_guides: IndentGuides.empty(prompt_id),
+      geometry:
+        prompt_geometry(prompt_id, rect, inner_width, visible_count, total_visual, scroll),
+      content_epoch:
+        prompt_content_epoch(prompt_id, rect, inner_width, visible_count, total_visual),
+      full_refresh: false
+    }
+  end
+
+  @spec prompt_content_epoch(
+          pos_integer(),
+          RenderWindow.rect(),
+          pos_integer(),
+          pos_integer(),
+          non_neg_integer()
+        ) :: non_neg_integer()
+  defp prompt_content_epoch(window_id, rect, inner_width, visible_count, total_visual) do
+    :erlang.phash2({window_id, rect, inner_width, visible_count, total_visual})
+  end
+
+  @spec prompt_gutter(pos_integer(), RenderWindow.rect(), boolean()) :: Gutter.t()
+  defp prompt_gutter(window_id, {row, col, width, height}, active?) do
+    %Gutter{
+      window_id: window_id,
+      content_row: row,
+      content_col: col,
+      content_height: height,
+      is_active: active?,
+      content_width: width,
+      cursor_line: 0,
+      line_number_style: :none,
+      line_number_width: 0,
+      sign_col_width: 0,
+      entries: []
+    }
+  end
+
+  @spec prompt_geometry(
+          pos_integer(),
+          RenderWindow.rect(),
+          pos_integer(),
+          pos_integer(),
+          pos_integer(),
+          non_neg_integer()
+        ) :: PaneGeometry.t()
+  defp prompt_geometry(window_id, rect, inner_width, visible_count, total_visual, scroll) do
+    metrics = %GutterMetrics{line_number_width: 0, sign_col_width: 0}
+
+    %PaneGeometry{
+      window_id: window_id,
+      total_rect: rect,
+      content_rect: rect,
+      text_rect: rect,
+      gutter_rect: {elem(rect, 0), elem(rect, 1), 0, elem(rect, 3)},
+      clip_rect: rect,
+      viewport: %RenderViewport{
+        top: scroll,
+        left: 0,
+        rows: visible_count,
+        cols: inner_width,
+        total_lines: total_visual,
+        visual_row_offset: 0,
+        total_visual_rows: total_visual
+      },
+      gutter_metrics: metrics,
+      hit_regions: [
+        %HitRegion{kind: :text, rect: rect, window_id: window_id, target: %{window_id: window_id}}
+      ]
     }
   end
 

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.Frontend.Emit do
 
   alias MingaEditor.DisplayList
   alias MingaEditor.DisplayList.Frame
+  alias MingaEditor.RenderModel.Builder, as: RenderModelBuilder
   alias MingaEditor.RenderPipeline.Chrome
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.Frontend.Emit.TUI, as: EmitTUI
@@ -59,55 +60,39 @@ defmodule MingaEditor.Frontend.Emit do
     # Frame commands WITHOUT batch_end (we append it after model-driven GUI window commands)
     frame_cmds = DisplayList.to_commands(frame, batch_end: false)
 
-    window_models = gui_window_models(frame)
-    status_bar_data = chrome && chrome.status_bar_data
-    minibuffer_data = chrome && chrome.minibuffer_data
-
-    {ui_model, ctx} =
+    {render_model, ctx} =
       Telemetry.span([:minga, :render, :ui_model_build], %{}, fn ->
-        MingaEditor.RenderModel.UI.Builder.build_ui(ctx, status_bar_data, minibuffer_data)
+        RenderModelBuilder.build(frame, ctx, chrome)
       end)
 
-    {window_content_cmds, metal_ui_cmds, adapter_cmds, adapter_gui_caches} =
+    encoded_frame =
       Telemetry.span_with_stop_metadata([:minga, :render, :adapter_encode], %{}, fn ->
-        {window_content_cmds, adapter_gui_caches, window_metrics} =
-          Minga.Frontend.Adapter.GUI.encode_windows_with_metrics(
-            window_models,
-            caches.adapter_gui_caches
-          )
+        encoded_frame =
+          Minga.Frontend.Adapter.GUI.encode(render_model, caches.adapter_gui_caches)
 
-        {metal_ui_cmds, adapter_gui_caches} =
-          Minga.Frontend.Adapter.GUI.encode_metal_ui(ui_model, adapter_gui_caches)
+        metadata = adapter_encode_metadata(encoded_frame.metrics, frame_cmds)
 
-        {adapter_cmds, adapter_gui_caches} =
-          Minga.Frontend.Adapter.GUI.encode_ui(ui_model, adapter_gui_caches)
-
-        result = {window_content_cmds, metal_ui_cmds, adapter_cmds, adapter_gui_caches}
-
-        metadata =
-          adapter_encode_metadata(window_metrics, metal_ui_cmds, adapter_cmds, frame_cmds)
-
-        {result, metadata}
+        {encoded_frame, metadata}
       end)
 
-    caches = %{caches | adapter_gui_caches: adapter_gui_caches}
+    caches = %{caches | adapter_gui_caches: encoded_frame.caches}
 
     # Bundle everything into one atomic port message, with batch_end last
     all_metal =
-      frame_cmds ++ window_content_cmds ++ metal_ui_cmds ++ [Protocol.encode_batch_end()]
+      frame_cmds ++ encoded_frame.metal_commands ++ [Protocol.encode_batch_end()]
 
     all_metal = flush_font_registration_commands() ++ all_metal
     caches = update_tracking(ctx, caches)
 
-    byte_count = IO.iodata_length(all_metal) + IO.iodata_length(adapter_cmds)
+    byte_count = IO.iodata_length(all_metal) + IO.iodata_length(encoded_frame.chrome_commands)
 
     Telemetry.span([:minga, :render, :emit_prepare], %{byte_count: byte_count}, fn ->
       MingaEditor.Frontend.send_commands(ctx.port_manager, all_metal)
-      caches = send_title(ctx, caches)
-      caches = send_window_bg(ctx, caches)
+      caches = send_title(render_model, caches)
+      caches = send_window_bg(render_model, caches)
 
-      if adapter_cmds != [] do
-        MingaEditor.Frontend.send_commands(ctx.port_manager, adapter_cmds)
+      if encoded_frame.chrome_commands != [] do
+        MingaEditor.Frontend.send_commands(ctx.port_manager, encoded_frame.chrome_commands)
       end
 
       caches
@@ -130,21 +115,19 @@ defmodule MingaEditor.Frontend.Emit do
     end)
   end
 
-  @spec adapter_encode_metadata(
-          Minga.Frontend.Adapter.GUI.window_metrics(),
-          [binary()],
-          [binary()],
-          [binary()]
-        ) :: map()
-  defp adapter_encode_metadata(window_metrics, metal_ui_cmds, adapter_cmds, frame_cmds) do
+  @spec adapter_encode_metadata(Minga.Frontend.Adapter.GUI.EncodedFrame.metrics(), [binary()]) ::
+          map()
+  defp adapter_encode_metadata(metrics, frame_cmds) do
+    window_metrics = metrics.window
+
     %{
       window_row_bytes: window_metrics.row_bytes,
       window_overlay_bytes: window_metrics.overlay_bytes,
       window_gutter_bytes: window_metrics.gutter_bytes,
       window_annotation_bytes: window_metrics.annotation_bytes,
       window_metadata_bytes: window_metrics.metadata_bytes,
-      metal_ui_bytes: IO.iodata_length(metal_ui_cmds),
-      chrome_bytes: IO.iodata_length(adapter_cmds),
+      metal_ui_bytes: metrics.metal_ui_bytes,
+      chrome_bytes: metrics.chrome_bytes,
       frame_cmd_bytes: IO.iodata_length(frame_cmds)
     }
   end
@@ -223,22 +206,14 @@ defmodule MingaEditor.Frontend.Emit do
     }
   end
 
-  # ── GUI window models ───────────────────────────────────────────────────
-
-  @spec gui_window_models(Frame.t()) :: [Minga.RenderModel.Window.t()]
-  defp gui_window_models(%Frame{} = frame) do
-    Enum.flat_map(frame.windows, fn %DisplayList.WindowFrame{} = wf ->
-      [wf.window_model | wf.additional_window_models]
-      |> Enum.reject(&is_nil/1)
-    end)
-  end
-
   # ── Side-channel writes (shared) ─────────────────────────────────────────
 
-  @spec send_title(ctx(), Caches.t()) :: Caches.t()
-  defp send_title(ctx, caches) do
-    title = ctx.title
+  @spec send_title(Minga.RenderModel.t() | ctx(), Caches.t()) :: Caches.t()
+  defp send_title(%Minga.RenderModel{title: title}, caches), do: do_send_title(title, caches)
+  defp send_title(ctx, caches), do: do_send_title(ctx.title, caches)
 
+  @spec do_send_title(String.t(), Caches.t()) :: Caches.t()
+  defp do_send_title(title, caches) do
     if title != caches.last_title do
       MingaEditor.Frontend.set_title(title)
       %{caches | last_title: title}
@@ -247,10 +222,14 @@ defmodule MingaEditor.Frontend.Emit do
     end
   end
 
-  @spec send_window_bg(ctx(), Caches.t()) :: Caches.t()
-  defp send_window_bg(ctx, caches) do
-    bg = ctx.theme.editor.bg
+  @spec send_window_bg(Minga.RenderModel.t() | ctx(), Caches.t()) :: Caches.t()
+  defp send_window_bg(%Minga.RenderModel{window_bg: bg}, caches),
+    do: do_send_window_bg(bg, caches)
 
+  defp send_window_bg(ctx, caches), do: do_send_window_bg(ctx.theme.editor.bg, caches)
+
+  @spec do_send_window_bg(non_neg_integer(), Caches.t()) :: Caches.t()
+  defp do_send_window_bg(bg, caches) do
     if bg != caches.last_window_bg do
       MingaEditor.Frontend.set_window_bg(bg)
       %{caches | last_window_bg: bg}

--- a/lib/minga_editor/mouse/hit_test.ex
+++ b/lib/minga_editor/mouse/hit_test.ex
@@ -7,8 +7,12 @@ defmodule MingaEditor.Mouse.HitTest do
   alias MingaEditor.BufferDecorations
   alias MingaEditor.DisplayMap
   alias MingaEditor.FoldMap
+  alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Layout
   alias MingaEditor.Mouse.Target.Buffer, as: BufferTarget
+  alias MingaEditor.RenderModel.Window.Builder, as: WindowModelBuilder
+  alias MingaEditor.RenderPipeline.ContentHelpers
+  alias MingaEditor.Renderer.Context
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
@@ -131,17 +135,18 @@ defmodule MingaEditor.Mouse.HitTest do
     display_col = visible_col + viewport_left(window)
 
     first_line = display_map_scroll_top(fold_map, scroll_top)
+    text_width = content_text_width(buf, total_lines, content_w)
 
-    case DisplayMap.compute(
-           fold_map,
-           decs,
-           first_line,
-           win_h,
-           total_lines,
-           content_text_width(buf, total_lines, content_w)
-         ) do
+    case DisplayMap.compute(fold_map, decs, first_line, win_h, total_lines, text_width) do
       nil ->
-        direct_position(buf, local_row, win_h, local_row + scroll_top, display_col, total_lines)
+        direct_or_wrapped_position(state, buf, window, %{
+          local_row: local_row,
+          win_h: win_h,
+          scroll_top: scroll_top,
+          display_col: display_col,
+          text_width: text_width,
+          total_lines: total_lines
+        })
 
       %DisplayMap{} = display_map ->
         display_map_position(
@@ -271,6 +276,97 @@ defmodule MingaEditor.Mouse.HitTest do
     end
   end
 
+  @typep position_params :: %{
+           required(:local_row) => integer(),
+           required(:win_h) => pos_integer(),
+           required(:scroll_top) => non_neg_integer(),
+           required(:display_col) => non_neg_integer(),
+           required(:text_width) => pos_integer(),
+           required(:total_lines) => non_neg_integer()
+         }
+
+  @spec direct_or_wrapped_position(state() | nil, pid(), Window.t() | nil, position_params()) ::
+          position_result()
+  defp direct_or_wrapped_position(state, buf, %Window{} = window, params) do
+    if Buffer.get_option(buf, :wrap) do
+      wrapped_position(state, buf, window, params)
+    else
+      direct_position(
+        buf,
+        params.local_row,
+        params.win_h,
+        params.local_row + params.scroll_top,
+        params.display_col,
+        params.total_lines
+      )
+    end
+  end
+
+  defp direct_or_wrapped_position(_state, buf, _window, params) do
+    direct_position(
+      buf,
+      params.local_row,
+      params.win_h,
+      params.local_row + params.scroll_top,
+      params.display_col,
+      params.total_lines
+    )
+  end
+
+  @spec wrapped_position(state() | nil, pid(), Window.t(), position_params()) :: position_result()
+  defp wrapped_position(_state, _buf, _window, %{local_row: local_row, win_h: win_h})
+       when local_row < 0 or local_row >= win_h,
+       do: :miss
+
+  defp wrapped_position(state, buf, window, params) do
+    visual_row = window.viewport.visual_row_offset + params.local_row
+    fetch_count = max(params.win_h + window.viewport.visual_row_offset + 1, 1)
+    snapshot = Buffer.render_snapshot(buf, params.scroll_top, fetch_count)
+    ctx = wrapped_position_context(state, buf, window, snapshot, params.text_width)
+
+    case WindowModelBuilder.wrapped_source_position(
+           snapshot.lines,
+           params.scroll_top,
+           visual_row,
+           params.display_col,
+           ctx,
+           snapshot.options
+         ) do
+      {:ok, line, col} ->
+        buffer_position(buf, params.local_row, params.win_h, line, col, params.total_lines)
+
+      :error ->
+        :miss
+    end
+  end
+
+  @spec wrapped_position_context(
+          state() | nil,
+          pid(),
+          Window.t(),
+          Minga.Buffer.RenderSnapshot.t(),
+          pos_integer()
+        ) :: Context.t()
+  defp wrapped_position_context(state, buf, window, snapshot, text_width) do
+    decorations = ContentHelpers.window_decorations(state, window, snapshot.decorations)
+    options = snapshot.options
+
+    %Context{
+      viewport: window.viewport,
+      gutter_w: buffer_gutter_width(buf, snapshot.line_count),
+      content_w: text_width,
+      decorations: decorations,
+      tab_width: Map.get(options, :tab_width, 2),
+      show_invisible: Map.get(options, :show_invisible, false),
+      wrap_on: true,
+      width_oracle: width_oracle(state)
+    }
+  end
+
+  @spec width_oracle(state() | nil) :: Minga.Core.WidthOracle.t()
+  defp width_oracle(%{capabilities: capabilities}), do: Capabilities.width_oracle(capabilities)
+  defp width_oracle(_state), do: %Minga.Core.WidthOracle.Monospace{}
+
   defp direct_position(_buffer, row, visible_rows, _line, _col, _total_lines)
        when row < 0 or row >= visible_rows,
        do: :miss
@@ -279,9 +375,21 @@ defmodule MingaEditor.Mouse.HitTest do
        when target_line < 0 or target_line >= total_lines,
        do: :miss
 
-  defp direct_position(buffer, _row, _visible_rows, target_line, target_col, _total_lines) do
+  defp direct_position(buffer, row, visible_rows, target_line, target_col, total_lines) do
     adjusted_col = adjust_col_for_virtual_text(buffer, target_line, target_col)
-    {:position, {target_line, clamp_col_to_line(buffer, target_line, adjusted_col)}}
+    buffer_position(buffer, row, visible_rows, target_line, adjusted_col, total_lines)
+  end
+
+  defp buffer_position(_buffer, row, visible_rows, _line, _col, _total_lines)
+       when row < 0 or row >= visible_rows,
+       do: :miss
+
+  defp buffer_position(_buffer, _row, _visible_rows, target_line, _col, total_lines)
+       when target_line < 0 or target_line >= total_lines,
+       do: :miss
+
+  defp buffer_position(buffer, _row, _visible_rows, target_line, target_col, _total_lines) do
+    {:position, {target_line, clamp_col_to_line(buffer, target_line, target_col)}}
   end
 
   defp adjust_col_for_virtual_text(buffer, line, display_col) do

--- a/lib/minga_editor/render_model/builder.ex
+++ b/lib/minga_editor/render_model/builder.ex
@@ -1,0 +1,48 @@
+defmodule MingaEditor.RenderModel.Builder do
+  @moduledoc """
+  Builds the top-level `Minga.RenderModel` for the GUI emit path.
+
+  The render pipeline still produces a `DisplayList.Frame` for the TUI path during the migration. This builder extracts the semantic GUI window models already attached to that frame, builds UI chrome models, and returns one core render model that the GUI adapter can encode.
+  """
+
+  alias Minga.RenderModel
+  alias Minga.RenderModel.Cursor
+  alias MingaEditor.DisplayList
+  alias MingaEditor.DisplayList.Frame
+  alias MingaEditor.DisplayList.WindowFrame
+  alias MingaEditor.Frontend.Emit.Context
+  alias MingaEditor.RenderModel.UI.Builder, as: UIBuilder
+  alias MingaEditor.RenderPipeline.Chrome
+
+  @spec build(Frame.t(), Context.t(), Chrome.t() | nil) :: {RenderModel.t(), Context.t()}
+  def build(%Frame{} = frame, %Context{} = ctx, chrome \\ nil) do
+    status_bar_data = chrome && chrome.status_bar_data
+    minibuffer_data = chrome && chrome.minibuffer_data
+
+    {ui, ctx} = UIBuilder.build_ui(ctx, status_bar_data, minibuffer_data)
+
+    model =
+      RenderModel.new(
+        window_models(frame),
+        ui,
+        cursor_model(frame.cursor),
+        ctx.title,
+        ctx.theme.editor.bg
+      )
+
+    {model, ctx}
+  end
+
+  @spec window_models(Frame.t()) :: [RenderModel.Window.t()]
+  defp window_models(%Frame{} = frame) do
+    Enum.flat_map(frame.windows, fn %WindowFrame{} = wf ->
+      [wf.window_model | wf.additional_window_models]
+      |> Enum.reject(&is_nil/1)
+    end)
+  end
+
+  @spec cursor_model(DisplayList.Cursor.t()) :: Cursor.t()
+  defp cursor_model(%DisplayList.Cursor{row: row, col: col, shape: shape}) do
+    Cursor.new(row, col, shape)
+  end
+end

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -27,6 +27,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
   alias Minga.Diagnostics
   alias MingaEditor.DisplayMap
   alias MingaEditor.FoldMap
+  alias MingaEditor.Layout
   alias MingaEditor.RenderPipeline.Scroll.WindowScroll
   alias MingaEditor.Renderer.Composition
   alias MingaEditor.Renderer.Context
@@ -49,6 +50,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
   alias MingaEditor.Renderer.Gutter, as: EditorGutter
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
+  alias MingaEditor.WindowTree
   alias Minga.LSP.SyncServer
   alias MingaEditor.UI.Highlight
 
@@ -213,10 +215,52 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       gutter: build_gutter(scroll, ctx, content_kind),
       cursorline: build_cursorline(content_row, display_cursor_row, is_active, ctx),
       indent_guides: build_indent_guides(scroll, ctx, content_kind),
-      geometry: build_geometry(scroll, content_kind),
-      content_epoch: content_epoch(scroll, content_kind),
-      full_refresh: full_refresh?(scroll, content_kind)
+      geometry: build_geometry(state, scroll, content_kind),
+      content_epoch: scroll.content_epoch,
+      full_refresh: scroll.full_refresh
     }
+  end
+
+  @doc "Returns the source buffer position for a click in wrapped composed rows."
+  @spec wrapped_source_position(
+          [String.t()],
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          Context.t(),
+          map()
+        ) :: {:ok, non_neg_integer(), non_neg_integer()} | :error
+  def wrapped_source_position(
+        lines,
+        first_line,
+        visual_row,
+        display_col,
+        %Context{} = ctx,
+        options
+      )
+      when is_list(lines) and is_integer(first_line) and is_integer(visual_row) and
+             is_integer(display_col) and is_map(options) do
+    lines
+    |> build_visual_entries_wrapped(first_line, ctx, %{
+      first_line_byte_offset: 0,
+      options: options
+    })
+    |> Enum.at(visual_row)
+    |> source_position_from_visual_entry(display_col, ctx.decorations)
+  end
+
+  @spec source_position_from_visual_entry(
+          visual_row_entry() | nil,
+          non_neg_integer(),
+          Decorations.t()
+        ) ::
+          {:ok, non_neg_integer(), non_neg_integer()} | :error
+  defp source_position_from_visual_entry(nil, _display_col, _decorations), do: :error
+
+  defp source_position_from_visual_entry(entry, display_col, decorations) do
+    composed_col = entry.source_start_col + max(display_col - entry.indent_width, 0)
+    buffer_col = Decorations.display_col_to_buf_col(decorations, entry.buf_line, composed_col)
+    {:ok, entry.buf_line, buffer_col}
   end
 
   # ── Visual row building ────────────────────────────────────────────────
@@ -808,7 +852,8 @@ defmodule MingaEditor.RenderModel.Window.Builder do
 
   @spec build_gutter(WindowScroll.t(), Context.t(), RenderWindow.content_kind()) ::
           Gutter.t() | nil
-  defp build_gutter(%WindowScroll{} = scroll, %Context{} = ctx, :buffer) do
+  defp build_gutter(%WindowScroll{} = scroll, %Context{} = ctx, content_kind)
+       when content_kind in [:buffer, :agent_chat] do
     %WindowScroll{
       win_id: win_id,
       win_layout: %{content: {content_row, content_col, full_width, content_height}},
@@ -842,8 +887,8 @@ defmodule MingaEditor.RenderModel.Window.Builder do
 
   defp build_gutter(_scroll, _ctx, _content_kind), do: nil
 
-  @spec build_geometry(WindowScroll.t(), RenderWindow.content_kind()) :: PaneGeometry.t()
-  defp build_geometry(%WindowScroll{} = scroll, content_kind) do
+  @spec build_geometry(state(), WindowScroll.t(), RenderWindow.content_kind()) :: PaneGeometry.t()
+  defp build_geometry(state, %WindowScroll{} = scroll, content_kind) do
     metrics = gutter_metrics(scroll, content_kind)
     gutter_width = GutterMetrics.total_width(metrics)
     content_rect = scroll.win_layout.content
@@ -863,12 +908,13 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       clip_rect: text_rect,
       viewport: viewport_summary(scroll, text_width),
       gutter_metrics: metrics,
-      hit_regions: hit_regions(scroll.win_id, text_rect, gutter_rect, metrics)
+      hit_regions: hit_regions(state, scroll.win_id, text_rect, gutter_rect, metrics)
     }
   end
 
   @spec gutter_metrics(WindowScroll.t(), RenderWindow.content_kind()) :: GutterMetrics.t()
-  defp gutter_metrics(%WindowScroll{} = scroll, :buffer) do
+  defp gutter_metrics(%WindowScroll{} = scroll, content_kind)
+       when content_kind in [:buffer, :agent_chat] do
     line_count = max(scroll.snapshot.line_count, 0)
 
     line_number_width =
@@ -917,15 +963,18 @@ defmodule MingaEditor.RenderModel.Window.Builder do
   end
 
   @spec hit_regions(
+          state(),
           non_neg_integer(),
           PaneGeometry.rect(),
           PaneGeometry.rect(),
           GutterMetrics.t()
-        ) :: [
-          HitRegion.t()
-        ]
-  defp hit_regions(window_id, text_rect, gutter_rect, %GutterMetrics{} = metrics) do
-    [text_hit_region(window_id, text_rect)] ++ gutter_hit_regions(window_id, gutter_rect, metrics)
+        ) :: [HitRegion.t()]
+  defp hit_regions(state, window_id, text_rect, gutter_rect, %GutterMetrics{} = metrics) do
+    [text_hit_region(window_id, text_rect)] ++
+      gutter_hit_regions(window_id, gutter_rect, metrics) ++
+      modeline_hit_regions(state, window_id) ++
+      status_bar_hit_regions(state, window_id) ++
+      divider_hit_regions(state, window_id)
   end
 
   @spec text_hit_region(non_neg_integer(), PaneGeometry.rect()) :: HitRegion.t()
@@ -943,7 +992,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          {row, col, width, height} = gutter_rect,
          %GutterMetrics{} = metrics
        ) do
-    fold_col = col + max(metrics.line_number_width + metrics.sign_col_width - 1, 0)
+    fold_col = col + max(metrics.sign_col_width - 1, 0)
     fold_width = if metrics.sign_col_width > 0 and fold_col < col + width, do: 1, else: 0
 
     [
@@ -965,29 +1014,102 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     end)
   end
 
-  @spec content_epoch(WindowScroll.t(), RenderWindow.content_kind()) :: non_neg_integer()
-  defp content_epoch(%WindowScroll{} = scroll, :buffer) do
-    :erlang.phash2({
-      scroll.win_id,
-      scroll.buf_version,
-      scroll.snapshot.line_count,
-      scroll.content_w,
-      scroll.gutter_w,
-      scroll.wrap_on,
-      scroll.line_number_style
-    })
+  @spec modeline_hit_regions(state(), non_neg_integer()) :: [HitRegion.t()]
+  defp modeline_hit_regions(state, window_id) do
+    state
+    |> Layout.get()
+    |> Map.get(:window_layouts, %{})
+    |> Map.get(window_id)
+    |> modeline_hit_region(window_id)
   end
 
-  defp content_epoch(%WindowScroll{} = scroll, content_kind) do
-    :erlang.phash2({scroll.win_id, content_kind})
+  @spec modeline_hit_region(map() | nil, non_neg_integer()) :: [HitRegion.t()]
+  defp modeline_hit_region(%{modeline: {_row, _col, _width, 0}}, _window_id), do: []
+  defp modeline_hit_region(nil, _window_id), do: []
+
+  defp modeline_hit_region(%{modeline: rect}, window_id) do
+    [
+      %HitRegion{
+        kind: :modeline,
+        rect: rect,
+        window_id: window_id,
+        target: %{window_id: window_id}
+      }
+    ]
   end
 
-  @spec full_refresh?(WindowScroll.t(), RenderWindow.content_kind()) :: boolean()
-  defp full_refresh?(%WindowScroll{window: %{render_cache: %{dirty_lines: :all}}}, :buffer),
-    do: true
+  @spec status_bar_hit_regions(state(), non_neg_integer()) :: [HitRegion.t()]
+  defp status_bar_hit_regions(state, window_id) do
+    case Layout.get(state).status_bar do
+      nil ->
+        []
 
-  defp full_refresh?(%WindowScroll{}, :buffer), do: false
-  defp full_refresh?(_scroll, _content_kind), do: true
+      rect ->
+        [
+          %HitRegion{
+            kind: :status_bar,
+            rect: rect,
+            window_id: window_id,
+            target: %{window_id: window_id}
+          }
+        ]
+    end
+  end
+
+  @spec divider_hit_regions(state(), non_neg_integer()) :: [HitRegion.t()]
+  defp divider_hit_regions(state, window_id) do
+    layout = Layout.get(state)
+    windows = state.workspace.windows
+
+    verticals =
+      if windows.tree == nil do
+        []
+      else
+        collect_vertical_dividers(windows.tree, layout.editor_area)
+      end
+
+    horizontals =
+      Enum.map(layout.horizontal_separators, fn {row, col, width, _filename} ->
+        {row, col, width, 1}
+      end)
+
+    Enum.map(verticals ++ horizontals, fn rect ->
+      %HitRegion{
+        kind: :divider,
+        rect: rect,
+        window_id: window_id,
+        target: %{window_id: window_id}
+      }
+    end)
+  end
+
+  @spec collect_vertical_dividers(WindowTree.t(), Layout.rect()) :: [PaneGeometry.rect()]
+  defp collect_vertical_dividers({:leaf, _id}, _rect), do: []
+
+  defp collect_vertical_dividers(
+         {:split, :vertical, left, right, size},
+         {row, col, width, height}
+       ) do
+    usable = width - 1
+    left_width = WindowTree.clamp_size(size, usable)
+    right_width = max(usable - left_width, 1)
+    separator_col = col + left_width
+
+    [{row, separator_col, 1, height}] ++
+      collect_vertical_dividers(left, {row, col, left_width, height}) ++
+      collect_vertical_dividers(right, {row, separator_col + 1, right_width, height})
+  end
+
+  defp collect_vertical_dividers(
+         {:split, :horizontal, top, bottom, size},
+         {row, col, width, height}
+       ) do
+    top_height = WindowTree.clamp_size(size, height)
+    bottom_height = max(height - top_height, 1)
+
+    collect_vertical_dividers(top, {row, col, width, top_height}) ++
+      collect_vertical_dividers(bottom, {row + top_height, col, width, bottom_height})
+  end
 
   @spec build_gutter_entries(WindowScroll.t(), Context.t(), non_neg_integer()) :: [
           GutterEntry.t()
@@ -1471,9 +1593,9 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       %Selection{
         type: :char,
         start_row: start_entry.display_row,
-        start_col: visual_col_for_source_col(start_entry, start_col),
+        start_col: selection_visual_col(start_entry, start_col, :start),
         end_row: end_entry.display_row,
-        end_col: visual_col_for_source_col(end_entry, end_col)
+        end_col: selection_visual_col(end_entry, end_col, :end)
       }
     else
       _ -> nil
@@ -1634,6 +1756,17 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       []
     end
   end
+
+  @spec selection_visual_col(visual_row_entry(), non_neg_integer(), :start | :end) ::
+          non_neg_integer()
+  defp selection_visual_col(entry, source_col, :start) when source_col <= entry.source_start_col,
+    do: 0
+
+  defp selection_visual_col(entry, source_col, :end) when source_col >= entry.source_end_col,
+    do: entry.row_width
+
+  defp selection_visual_col(entry, source_col, _endpoint),
+    do: visual_col_for_source_col(entry, source_col)
 
   @spec visual_col_for_source_byte(visual_row_entry(), non_neg_integer()) :: non_neg_integer()
   defp visual_col_for_source_byte(entry, source_byte) do

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -23,6 +23,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
   alias Minga.Core.HlTodo
   alias Minga.Core.IndentGuide
   alias Minga.Core.Unicode
+  alias Minga.Core.WrapMap
   alias Minga.Diagnostics
   alias MingaEditor.DisplayMap
   alias MingaEditor.FoldMap
@@ -36,11 +37,15 @@ defmodule MingaEditor.RenderModel.Window.Builder do
   alias Minga.RenderModel.Window.DocumentHighlight
   alias Minga.RenderModel.Window.Gutter
   alias Minga.RenderModel.Window.GutterEntry
+  alias Minga.RenderModel.Window.GutterMetrics
+  alias Minga.RenderModel.Window.HitRegion
   alias Minga.RenderModel.Window.IndentGuides
+  alias Minga.RenderModel.Window.PaneGeometry
   alias Minga.RenderModel.Window.Row
   alias Minga.RenderModel.Window.SearchMatch
   alias Minga.RenderModel.Window.Selection
   alias Minga.RenderModel.Window.Span
+  alias Minga.RenderModel.Window.Viewport, as: RenderViewport
   alias MingaEditor.Renderer.Gutter, as: EditorGutter
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
@@ -48,6 +53,19 @@ defmodule MingaEditor.RenderModel.Window.Builder do
   alias MingaEditor.UI.Highlight
 
   @type state :: EditorState.t() | MingaEditor.RenderPipeline.Input.t()
+  @typep visual_row_entry :: %{
+           row: Row.t(),
+           buf_line: non_neg_integer(),
+           visual_index: non_neg_integer(),
+           display_row: non_neg_integer(),
+           source_text: String.t(),
+           source_start_byte: non_neg_integer(),
+           source_end_byte: non_neg_integer(),
+           source_start_col: non_neg_integer(),
+           source_end_col: non_neg_integer(),
+           indent_width: non_neg_integer(),
+           row_width: non_neg_integer()
+         }
 
   @doc """
   Builds a `RenderWindow` for one editor window.
@@ -62,6 +80,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       is_active: is_active,
       viewport: viewport,
       cursor_line: cursor_line,
+      cursor_byte_col: _cursor_byte_col,
       cursor_col: cursor_col,
       first_line: first_line,
       lines: lines,
@@ -72,21 +91,19 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       wrap_on: wrap_on
     } = scroll
 
-    visible_rows = Viewport.content_rows(viewport)
+    visible_row_count = Viewport.content_rows(viewport)
     content_kind = Keyword.get(opts, :content_kind, :buffer)
     rect = win_layout.content
     {content_row, _content_col, _content_width, _content_height} = rect
 
-    # Build visual rows from the same data the draw path uses
-    visual_rows =
-      build_visual_rows(
-        lines,
-        first_line,
-        visible_line_map,
-        wrap_on,
-        ctx,
-        snapshot
-      )
+    # Build visual rows from the same data the draw path uses.
+    visual_entries =
+      lines
+      |> build_visual_entries(first_line, visible_line_map, wrap_on, ctx, snapshot)
+      |> trim_visual_entries(viewport.visual_row_offset, visible_row_count)
+
+    visual_rows = Enum.map(visual_entries, & &1.row)
+    wrapped_coordinates? = wrap_on and visible_line_map == nil
 
     # Cursor in display coordinates
     {display_cursor_row, display_cursor_col} =
@@ -95,7 +112,9 @@ defmodule MingaEditor.RenderModel.Window.Builder do
         cursor_col,
         viewport,
         window.fold_map,
-        ctx.decorations
+        ctx.decorations,
+        visual_entries,
+        wrapped_coordinates?
       )
 
     cursor_shape =
@@ -125,39 +144,56 @@ defmodule MingaEditor.RenderModel.Window.Builder do
 
     # Selection in display coordinates
     selection =
-      Selection.from_visual_selection(
+      build_selection(
         ctx.visual_selection,
-        viewport.top,
-        visible_rows,
-        viewport.left,
-        viewport.cols
+        viewport,
+        visible_row_count,
+        visual_entries,
+        wrapped_coordinates?
       )
 
     # Search matches in display coordinates
-    viewport_bottom = viewport.top + visible_rows
+    viewport_bottom = viewport.top + visible_row_count
 
     search_matches =
-      SearchMatch.from_context_matches(
+      build_search_matches(
         ctx.search_matches,
         ctx.confirm_match,
-        viewport.top,
-        viewport_bottom
+        viewport,
+        viewport_bottom,
+        visual_entries,
+        wrapped_coordinates?
       )
 
     # Diagnostic inline ranges in display coordinates
-    diagnostic_ranges = build_diagnostic_ranges(snapshot.file_path, viewport, visible_rows)
+    diagnostic_ranges =
+      build_diagnostic_ranges(
+        snapshot.file_path,
+        viewport,
+        visible_row_count,
+        visual_entries,
+        wrapped_coordinates?
+      )
 
     # Document highlights in display coordinates
     doc_highlights =
       build_document_highlights(
         state.workspace.document_highlights,
-        viewport.top,
-        viewport_bottom
+        viewport,
+        viewport_bottom,
+        visual_entries,
+        wrapped_coordinates?
       )
 
     # Line annotations in display coordinates
     annotations =
-      build_annotations(ctx.decorations, viewport.top, viewport_bottom)
+      build_annotations(
+        ctx.decorations,
+        viewport.top,
+        viewport_bottom,
+        visual_entries,
+        wrapped_coordinates?
+      )
 
     %RenderWindow{
       window_id: win_id,
@@ -177,41 +213,59 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       gutter: build_gutter(scroll, ctx, content_kind),
       cursorline: build_cursorline(content_row, display_cursor_row, is_active, ctx),
       indent_guides: build_indent_guides(scroll, ctx, content_kind),
-      full_refresh: true
+      geometry: build_geometry(scroll, content_kind),
+      content_epoch: content_epoch(scroll, content_kind),
+      full_refresh: full_refresh?(scroll, content_kind)
     }
   end
 
   # ── Visual row building ────────────────────────────────────────────────
 
-  @spec build_visual_rows(
+  @spec build_visual_entries(
           [String.t()],
           non_neg_integer(),
           [DisplayMap.entry()] | nil,
           boolean(),
           Context.t(),
           map()
-        ) :: [Row.t()]
-  defp build_visual_rows(lines, first_line, visible_line_map, _wrap_on, ctx, snapshot) do
-    if visible_line_map != nil do
-      build_visual_rows_folded(lines, first_line, visible_line_map, ctx, snapshot)
-    else
-      build_visual_rows_sequential(lines, first_line, ctx, snapshot)
-    end
+        ) :: [visual_row_entry()]
+  defp build_visual_entries(lines, first_line, visible_line_map, wrap_on, ctx, snapshot) do
+    build_visual_entries_for_mode(lines, first_line, visible_line_map, wrap_on, ctx, snapshot)
   end
 
-  # Sequential path (no folds): one visual row per line
-  @spec build_visual_rows_sequential(
+  @spec build_visual_entries_for_mode(
+          [String.t()],
+          non_neg_integer(),
+          [DisplayMap.entry()] | nil,
+          boolean(),
+          Context.t(),
+          map()
+        ) :: [visual_row_entry()]
+  defp build_visual_entries_for_mode(lines, first_line, visible_line_map, _wrap_on, ctx, snapshot)
+       when is_list(visible_line_map) do
+    build_visual_entries_folded(lines, first_line, visible_line_map, ctx, snapshot)
+  end
+
+  defp build_visual_entries_for_mode(lines, first_line, nil, true, ctx, snapshot) do
+    build_visual_entries_wrapped(lines, first_line, ctx, snapshot)
+  end
+
+  defp build_visual_entries_for_mode(lines, first_line, nil, false, ctx, snapshot) do
+    build_visual_entries_sequential(lines, first_line, ctx, snapshot)
+  end
+
+  # Sequential path (no folds): one visual row per line.
+  @spec build_visual_entries_sequential(
           [String.t()],
           non_neg_integer(),
           Context.t(),
           map()
-        ) :: [Row.t()]
-  defp build_visual_rows_sequential(lines, first_line, ctx, snapshot) do
+        ) :: [visual_row_entry()]
+  defp build_visual_entries_sequential(lines, first_line, ctx, snapshot) do
     first_byte_off = snapshot.first_line_byte_offset
 
     lines_with_offsets = build_lines_with_offsets(lines, first_byte_off)
 
-    # Pre-compute highlight segments for all visible lines
     highlight_segments_list =
       if ctx.highlight do
         Highlight.styles_for_visible_lines(ctx.highlight, lines_with_offsets)
@@ -228,30 +282,205 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       {composed_text, spans} =
         compose_line(line_text, hl_segments, ctx, buf_line, line_byte_offset)
 
-      %Row{
+      row = %Row{
         row_type: :normal,
         buf_line: buf_line,
         text: composed_text,
         spans: spans,
         content_hash: Row.compute_hash(composed_text, spans)
       }
+
+      visual_entry(row, 0, Unicode.display_width(composed_text), 0)
     end)
   end
 
-  # Fold-aware path: walks visible_line_map entries
-  @spec build_visual_rows_folded(
+  @spec build_visual_entries_wrapped([String.t()], non_neg_integer(), Context.t(), map()) :: [
+          visual_row_entry()
+        ]
+  defp build_visual_entries_wrapped(lines, first_line, ctx, snapshot) do
+    first_byte_off = snapshot.first_line_byte_offset
+    lines_with_offsets = build_lines_with_offsets(lines, first_byte_off)
+
+    highlight_segments_list =
+      if ctx.highlight do
+        Highlight.styles_for_visible_lines(ctx.highlight, lines_with_offsets)
+      else
+        List.duplicate(nil, length(lines))
+      end
+
+    lines_with_offsets
+    |> Enum.zip(highlight_segments_list)
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {{{line_text, line_byte_offset}, hl_segments}, idx} ->
+      buf_line = first_line + idx
+
+      {composed_text, spans} =
+        compose_line(line_text, hl_segments, ctx, buf_line, line_byte_offset)
+
+      wrap_composed_entries(composed_text, spans, buf_line, wrap_options(ctx, snapshot.options))
+    end)
+  end
+
+  @spec wrap_composed_entries(String.t(), [Span.t()], non_neg_integer(), keyword()) :: [
+          visual_row_entry()
+        ]
+  defp wrap_composed_entries(composed_text, spans, buf_line, opts) do
+    [visual_rows] = WrapMap.compute([composed_text], Keyword.fetch!(opts, :content_width), opts)
+
+    visual_rows
+    |> Enum.with_index()
+    |> Enum.map(fn {visual_row, visual_index} ->
+      text = WrapMap.display_text(visual_row)
+      row_type = if visual_index == 0, do: :normal, else: :wrap_continuation
+      row_spans = spans_for_visual_row(spans, composed_text, visual_row)
+      source_start = visual_row_source_start(composed_text, visual_row)
+      source_end = visual_row_source_end(source_start, visual_row)
+      source_start_byte = Map.get(visual_row, :byte_offset, 0)
+
+      source_end_byte =
+        source_start_byte +
+          byte_size(Map.get(visual_row, :source_text, Map.get(visual_row, :text, "")))
+
+      indent_width = Map.get(visual_row, :indent_width, 0)
+
+      row = %Row{
+        row_type: row_type,
+        buf_line: buf_line,
+        visual_index: visual_index,
+        text: text,
+        spans: row_spans,
+        content_hash: Row.compute_hash(text, row_spans)
+      }
+
+      visual_entry(
+        row,
+        composed_text,
+        source_start,
+        source_end,
+        source_start_byte,
+        source_end_byte,
+        indent_width
+      )
+    end)
+  end
+
+  @spec wrap_options(Context.t(), map()) :: keyword()
+  defp wrap_options(%Context{} = ctx, options) do
+    [
+      content_width: max(ctx.content_w, 1),
+      breakindent: Map.get(options, :breakindent, true),
+      linebreak: Map.get(options, :linebreak, true),
+      oracle: ctx.width_oracle,
+      tab_width: ctx.tab_width
+    ]
+  end
+
+  @spec trim_visual_entries([visual_row_entry()], non_neg_integer(), non_neg_integer()) :: [
+          visual_row_entry()
+        ]
+  defp trim_visual_entries(entries, offset, row_count) do
+    entries
+    |> drop_visual_entry_offset(offset)
+    |> Enum.take(row_count)
+    |> Enum.with_index()
+    |> Enum.map(fn {entry, display_row} -> %{entry | display_row: display_row} end)
+  end
+
+  @spec drop_visual_entry_offset([visual_row_entry()], non_neg_integer()) :: [visual_row_entry()]
+  defp drop_visual_entry_offset(entries, 0), do: entries
+
+  defp drop_visual_entry_offset(entries, offset) do
+    case Enum.drop(entries, offset) do
+      [] -> entries |> List.last() |> List.wrap()
+      visible -> visible
+    end
+  end
+
+  @spec visual_entry(Row.t(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          visual_row_entry()
+  defp visual_entry(%Row{} = row, source_start_col, source_end_col, indent_width) do
+    visual_entry(
+      row,
+      row.text,
+      source_start_col,
+      source_end_col,
+      0,
+      byte_size(row.text),
+      indent_width
+    )
+  end
+
+  @spec visual_entry(
+          Row.t(),
+          String.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: visual_row_entry()
+  defp visual_entry(
+         %Row{} = row,
+         source_text,
+         source_start_col,
+         source_end_col,
+         source_start_byte,
+         source_end_byte,
+         indent_width
+       ) do
+    %{
+      row: row,
+      buf_line: row.buf_line,
+      visual_index: row.visual_index,
+      display_row: 0,
+      source_text: source_text,
+      source_start_byte: source_start_byte,
+      source_end_byte: source_end_byte,
+      source_start_col: source_start_col,
+      source_end_col: source_end_col,
+      indent_width: indent_width,
+      row_width: Unicode.display_width(row.text)
+    }
+  end
+
+  @spec spans_for_visual_row([Span.t()], String.t(), WrapMap.visual_row()) :: [Span.t()]
+  defp spans_for_visual_row(spans, composed_text, visual_row) do
+    source_start = visual_row_source_start(composed_text, visual_row)
+    source_end = visual_row_source_end(source_start, visual_row)
+    indent_width = Map.get(visual_row, :indent_width, 0)
+
+    spans
+    |> Enum.flat_map(&Span.rebase_to_visual_row(&1, source_start, source_end, indent_width))
+  end
+
+  @spec visual_row_source_start(String.t(), WrapMap.visual_row()) :: non_neg_integer()
+  defp visual_row_source_start(composed_text, visual_row) do
+    Unicode.display_col(composed_text, Map.get(visual_row, :byte_offset, 0))
+  end
+
+  @spec visual_row_source_end(non_neg_integer(), WrapMap.visual_row()) :: non_neg_integer()
+  defp visual_row_source_end(source_start, visual_row) do
+    source_text = Map.get(visual_row, :source_text, Map.get(visual_row, :text, ""))
+    source_start + Unicode.display_width(source_text)
+  end
+
+  # Fold-aware path: walks visible_line_map entries.
+  @spec build_visual_entries_folded(
           [String.t()],
           non_neg_integer(),
           [DisplayMap.entry()],
           Context.t(),
           map()
-        ) :: [Row.t()]
-  defp build_visual_rows_folded(lines, first_line, visible_line_map, ctx, snapshot) do
+        ) :: [visual_row_entry()]
+  defp build_visual_entries_folded(lines, first_line, visible_line_map, ctx, snapshot) do
     line_byte_offsets =
       build_line_byte_offsets(lines, first_line, snapshot.first_line_byte_offset)
 
     Enum.map(visible_line_map, fn {buf_line, entry_type} ->
-      build_visual_row_entry(buf_line, entry_type, lines, first_line, ctx, line_byte_offsets)
+      row =
+        build_visual_row_entry(buf_line, entry_type, lines, first_line, ctx, line_byte_offsets)
+
+      visual_entry(row, 0, Unicode.display_width(row.text), 0)
     end)
   end
 
@@ -482,9 +711,31 @@ defmodule MingaEditor.RenderModel.Window.Builder do
           non_neg_integer(),
           Viewport.t(),
           FoldMap.t(),
-          Decorations.t()
+          Decorations.t(),
+          [visual_row_entry()],
+          boolean()
         ) :: {non_neg_integer(), non_neg_integer()}
-  defp compute_display_cursor(cursor_line, cursor_col, viewport, fold_map, decorations) do
+  defp compute_display_cursor(
+         cursor_line,
+         cursor_col,
+         _viewport,
+         _fold_map,
+         decorations,
+         visual_entries,
+         true
+       ) do
+    compute_wrapped_display_cursor(cursor_line, cursor_col, decorations, visual_entries)
+  end
+
+  defp compute_display_cursor(
+         cursor_line,
+         cursor_col,
+         viewport,
+         fold_map,
+         decorations,
+         _visual_entries,
+         false
+       ) do
     visible_cursor =
       if FoldMap.empty?(fold_map) do
         cursor_line
@@ -495,6 +746,40 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     row = max(visible_cursor - viewport.top, 0)
     col = Decorations.buf_col_to_display_col(decorations, cursor_line, cursor_col)
     {row, col}
+  end
+
+  @spec compute_wrapped_display_cursor(
+          non_neg_integer(),
+          non_neg_integer(),
+          Decorations.t(),
+          [visual_row_entry()]
+        ) :: {non_neg_integer(), non_neg_integer()}
+  defp compute_wrapped_display_cursor(cursor_line, cursor_col, decorations, visual_entries) do
+    cursor_display_col = Decorations.buf_col_to_display_col(decorations, cursor_line, cursor_col)
+
+    visual_entries
+    |> Enum.filter(&(&1.buf_line == cursor_line))
+    |> visual_entry_for_source_col(cursor_display_col)
+    |> cursor_position_from_visual_entry(cursor_display_col)
+  end
+
+  @spec visual_entry_for_source_col([visual_row_entry()], non_neg_integer()) ::
+          visual_row_entry() | nil
+  defp visual_entry_for_source_col([], _cursor_display_col), do: nil
+
+  defp visual_entry_for_source_col(entries, cursor_display_col) do
+    Enum.find(entries, fn entry ->
+      cursor_display_col >= entry.source_start_col and cursor_display_col < entry.source_end_col
+    end) || List.last(entries)
+  end
+
+  @spec cursor_position_from_visual_entry(visual_row_entry() | nil, non_neg_integer()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp cursor_position_from_visual_entry(nil, cursor_display_col), do: {0, cursor_display_col}
+
+  defp cursor_position_from_visual_entry(entry, cursor_display_col) do
+    col = max(cursor_display_col - entry.source_start_col + entry.indent_width, 0)
+    {entry.display_row, col}
   end
 
   @spec adjust_cursor_col_for_shape(
@@ -536,10 +821,9 @@ defmodule MingaEditor.RenderModel.Window.Builder do
 
     line_count = max(snapshot.line_count, 0)
 
-    line_number_width =
-      if line_number_style == :none, do: 0, else: Viewport.gutter_width(line_count)
-
-    sign_col_width = EditorGutter.sign_column_width() + EditorGutter.fold_column_width()
+    metrics = gutter_metrics(scroll, :buffer)
+    line_number_width = metrics.line_number_width
+    sign_col_width = metrics.sign_col_width
 
     %Gutter{
       window_id: win_id,
@@ -558,13 +842,160 @@ defmodule MingaEditor.RenderModel.Window.Builder do
 
   defp build_gutter(_scroll, _ctx, _content_kind), do: nil
 
+  @spec build_geometry(WindowScroll.t(), RenderWindow.content_kind()) :: PaneGeometry.t()
+  defp build_geometry(%WindowScroll{} = scroll, content_kind) do
+    metrics = gutter_metrics(scroll, content_kind)
+    gutter_width = GutterMetrics.total_width(metrics)
+    content_rect = scroll.win_layout.content
+    total_rect = Map.get(scroll.win_layout, :total, content_rect)
+    {row, col, width, height} = content_rect
+    gutter_rect = {row, col, min(gutter_width, width), height}
+    text_col = col + min(gutter_width, width)
+    text_width = max(width - gutter_width, 0)
+    text_rect = {row, text_col, text_width, height}
+
+    %PaneGeometry{
+      window_id: scroll.win_id,
+      total_rect: total_rect,
+      content_rect: content_rect,
+      text_rect: text_rect,
+      gutter_rect: gutter_rect,
+      clip_rect: text_rect,
+      viewport: viewport_summary(scroll, text_width),
+      gutter_metrics: metrics,
+      hit_regions: hit_regions(scroll.win_id, text_rect, gutter_rect, metrics)
+    }
+  end
+
+  @spec gutter_metrics(WindowScroll.t(), RenderWindow.content_kind()) :: GutterMetrics.t()
+  defp gutter_metrics(%WindowScroll{} = scroll, :buffer) do
+    line_count = max(scroll.snapshot.line_count, 0)
+
+    line_number_width =
+      if scroll.line_number_style == :none, do: 0, else: Viewport.gutter_width(line_count)
+
+    %GutterMetrics{
+      line_number_width: line_number_width,
+      sign_col_width: EditorGutter.sign_column_width() + EditorGutter.fold_column_width()
+    }
+  end
+
+  defp gutter_metrics(_scroll, _content_kind) do
+    %GutterMetrics{line_number_width: 0, sign_col_width: 0}
+  end
+
+  @spec viewport_summary(WindowScroll.t(), non_neg_integer()) :: RenderViewport.t()
+  defp viewport_summary(%WindowScroll{} = scroll, text_width) do
+    %RenderViewport{
+      top: scroll.viewport.top,
+      left: scroll.viewport.left,
+      rows: Viewport.content_rows(scroll.viewport),
+      cols: text_width,
+      total_lines: max(scroll.snapshot.line_count, 0),
+      visual_row_offset: scroll.viewport.visual_row_offset,
+      total_visual_rows: total_visual_rows(scroll)
+    }
+  end
+
+  @spec total_visual_rows(WindowScroll.t()) :: non_neg_integer()
+  defp total_visual_rows(%WindowScroll{total_visual_rows: total})
+       when is_integer(total) and total > 0,
+       do: total
+
+  defp total_visual_rows(%WindowScroll{wrap_on: false, snapshot: snapshot}),
+    do: max(snapshot.line_count, 0)
+
+  defp total_visual_rows(%WindowScroll{} = scroll) do
+    scroll.lines
+    |> WrapMap.compute(max(scroll.content_w, 1),
+      breakindent: Map.get(scroll.snapshot.options, :breakindent, true),
+      linebreak: Map.get(scroll.snapshot.options, :linebreak, true),
+      oracle: scroll.width_oracle,
+      tab_width: Map.get(scroll.snapshot.options, :tab_width, 2)
+    )
+    |> WrapMap.visual_row_count()
+  end
+
+  @spec hit_regions(
+          non_neg_integer(),
+          PaneGeometry.rect(),
+          PaneGeometry.rect(),
+          GutterMetrics.t()
+        ) :: [
+          HitRegion.t()
+        ]
+  defp hit_regions(window_id, text_rect, gutter_rect, %GutterMetrics{} = metrics) do
+    [text_hit_region(window_id, text_rect)] ++ gutter_hit_regions(window_id, gutter_rect, metrics)
+  end
+
+  @spec text_hit_region(non_neg_integer(), PaneGeometry.rect()) :: HitRegion.t()
+  defp text_hit_region(window_id, rect) do
+    %HitRegion{kind: :text, rect: rect, window_id: window_id, target: %{window_id: window_id}}
+  end
+
+  @spec gutter_hit_regions(non_neg_integer(), PaneGeometry.rect(), GutterMetrics.t()) :: [
+          HitRegion.t()
+        ]
+  defp gutter_hit_regions(_window_id, {_row, _col, 0, _height}, _metrics), do: []
+
+  defp gutter_hit_regions(
+         window_id,
+         {row, col, width, height} = gutter_rect,
+         %GutterMetrics{} = metrics
+       ) do
+    fold_col = col + max(metrics.line_number_width + metrics.sign_col_width - 1, 0)
+    fold_width = if metrics.sign_col_width > 0 and fold_col < col + width, do: 1, else: 0
+
+    [
+      %HitRegion{
+        kind: :gutter,
+        rect: gutter_rect,
+        window_id: window_id,
+        target: %{window_id: window_id}
+      },
+      %HitRegion{
+        kind: :fold_control,
+        rect: {row, fold_col, fold_width, height},
+        window_id: window_id,
+        target: %{window_id: window_id}
+      }
+    ]
+    |> Enum.reject(fn %HitRegion{rect: {_row, _col, region_width, region_height}} ->
+      region_width == 0 or region_height == 0
+    end)
+  end
+
+  @spec content_epoch(WindowScroll.t(), RenderWindow.content_kind()) :: non_neg_integer()
+  defp content_epoch(%WindowScroll{} = scroll, :buffer) do
+    :erlang.phash2({
+      scroll.win_id,
+      scroll.buf_version,
+      scroll.snapshot.line_count,
+      scroll.content_w,
+      scroll.gutter_w,
+      scroll.wrap_on,
+      scroll.line_number_style
+    })
+  end
+
+  defp content_epoch(%WindowScroll{} = scroll, content_kind) do
+    :erlang.phash2({scroll.win_id, content_kind})
+  end
+
+  @spec full_refresh?(WindowScroll.t(), RenderWindow.content_kind()) :: boolean()
+  defp full_refresh?(%WindowScroll{window: %{render_cache: %{dirty_lines: :all}}}, :buffer),
+    do: true
+
+  defp full_refresh?(%WindowScroll{}, :buffer), do: false
+  defp full_refresh?(_scroll, _content_kind), do: true
+
   @spec build_gutter_entries(WindowScroll.t(), Context.t(), non_neg_integer()) :: [
           GutterEntry.t()
         ]
   defp build_gutter_entries(_scroll, _ctx, 0), do: []
 
   defp build_gutter_entries(%WindowScroll{} = scroll, %Context{} = ctx, line_count) do
-    fold_ranges = scroll.window.fold_ranges || []
+    fold_ranges = scroll.window.fold_ranges
     fold_start_lines = MapSet.new(fold_ranges, & &1.start_line)
     fold_end_by_start = Map.new(fold_ranges, fn range -> {range.start_line, range.end_line} end)
 
@@ -779,53 +1210,207 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     }
   end
 
-  # ── Diagnostics ────────────────────────────────────────────────────────
+  # ── Overlays ───────────────────────────────────────────────────────────
 
-  @spec build_diagnostic_ranges(String.t() | nil, Viewport.t(), pos_integer()) :: [
-          DiagnosticRange.t()
-        ]
-  defp build_diagnostic_ranges(nil, _viewport, _visible_rows), do: []
+  @spec build_selection(
+          Selection.visual_selection(),
+          Viewport.t(),
+          pos_integer(),
+          [visual_row_entry()],
+          boolean()
+        ) :: Selection.t() | nil
+  defp build_selection(selection, viewport, visible_rows, _visual_entries, false) do
+    Selection.from_visual_selection(
+      selection,
+      viewport.top,
+      visible_rows,
+      viewport.left,
+      viewport.cols
+    )
+  end
 
-  defp build_diagnostic_ranges(path, viewport, visible_rows) when is_binary(path) do
+  defp build_selection(nil, _viewport, _visible_rows, _visual_entries, true), do: nil
+
+  defp build_selection(
+         {:char, {sl, sc}, {el, ec}},
+         _viewport,
+         _visible_rows,
+         visual_entries,
+         true
+       ) do
+    build_wrapped_char_selection(sl, sc, el, ec, visual_entries)
+  end
+
+  defp build_selection(
+         {:line, start_line, end_line},
+         _viewport,
+         _visible_rows,
+         visual_entries,
+         true
+       ) do
+    build_wrapped_line_selection(start_line, end_line, visual_entries)
+  end
+
+  @spec build_search_matches(
+          [Minga.Editing.Search.Match.t()],
+          Minga.Editing.Search.Match.t() | nil,
+          Viewport.t(),
+          non_neg_integer(),
+          [visual_row_entry()],
+          boolean()
+        ) :: [SearchMatch.t()]
+  defp build_search_matches(
+         matches,
+         confirm_match,
+         viewport,
+         viewport_bottom,
+         _visual_entries,
+         false
+       ) do
+    SearchMatch.from_context_matches(matches, confirm_match, viewport.top, viewport_bottom)
+  end
+
+  defp build_search_matches(
+         matches,
+         confirm_match,
+         _viewport,
+         _viewport_bottom,
+         visual_entries,
+         true
+       ) do
+    Enum.flat_map(matches, fn %{line: line, col: col, length: len} = match ->
+      project_byte_range(line, col, line, col + len, visual_entries, fn row,
+                                                                        start_col,
+                                                                        _end_row,
+                                                                        end_col ->
+        %SearchMatch{
+          row: row,
+          start_col: start_col,
+          end_col: end_col,
+          is_current: confirm_match != nil and match == confirm_match
+        }
+      end)
+    end)
+  end
+
+  @spec build_diagnostic_ranges(
+          String.t() | nil,
+          Viewport.t(),
+          pos_integer(),
+          [visual_row_entry()],
+          boolean()
+        ) :: [DiagnosticRange.t()]
+  defp build_diagnostic_ranges(nil, _viewport, _visible_rows, _visual_entries, _wrapped?), do: []
+
+  defp build_diagnostic_ranges(path, viewport, visible_rows, visual_entries, wrapped?)
+       when is_binary(path) do
     uri = SyncServer.path_to_uri(path)
     diagnostics = Diagnostics.for_uri(uri)
     viewport_bottom = viewport.top + visible_rows
-    DiagnosticRange.from_diagnostics(diagnostics, viewport.top, viewport_bottom)
+
+    if wrapped? do
+      Enum.flat_map(diagnostics, &diagnostic_to_wrapped_ranges(&1, visual_entries))
+    else
+      DiagnosticRange.from_diagnostics(diagnostics, viewport.top, viewport_bottom)
+    end
+  end
+
+  @spec diagnostic_to_wrapped_ranges(Diagnostics.Diagnostic.t(), [visual_row_entry()]) :: [
+          DiagnosticRange.t()
+        ]
+  defp diagnostic_to_wrapped_ranges(%{range: range, severity: severity}, visual_entries) do
+    project_byte_range(
+      range.start_line,
+      range.start_col,
+      range.end_line,
+      range.end_col,
+      visual_entries,
+      fn start_row, start_col, end_row, end_col ->
+        %DiagnosticRange{
+          start_row: start_row,
+          start_col: start_col,
+          end_row: end_row,
+          end_col: end_col,
+          severity: severity
+        }
+      end
+    )
   end
 
   # ── Document highlights ─────────────────────────────────────────────────
 
   @spec build_document_highlights(
           [Minga.LSP.DocumentHighlight.t()] | nil,
+          Viewport.t(),
           non_neg_integer(),
-          non_neg_integer()
+          [visual_row_entry()],
+          boolean()
         ) :: [DocumentHighlight.t()]
-  defp build_document_highlights(nil, _top, _bottom), do: []
-  defp build_document_highlights([], _top, _bottom), do: []
+  defp build_document_highlights(nil, _viewport, _bottom, _visual_entries, _wrapped?), do: []
+  defp build_document_highlights([], _viewport, _bottom, _visual_entries, _wrapped?), do: []
 
-  defp build_document_highlights(highlights, viewport_top, viewport_bottom) do
+  defp build_document_highlights(highlights, viewport, viewport_bottom, _visual_entries, false) do
     highlights
     |> Enum.filter(fn hl ->
-      hl.start_line < viewport_bottom and hl.end_line >= viewport_top
+      hl.start_line < viewport_bottom and hl.end_line >= viewport.top
     end)
     |> Enum.map(fn hl ->
       %DocumentHighlight{
-        start_row: hl.start_line - viewport_top,
+        start_row: hl.start_line - viewport.top,
         start_col: hl.start_col,
-        end_row: hl.end_line - viewport_top,
+        end_row: hl.end_line - viewport.top,
         end_col: hl.end_col,
         kind: hl.kind
       }
     end)
   end
 
+  defp build_document_highlights(highlights, _viewport, _viewport_bottom, visual_entries, true) do
+    Enum.flat_map(highlights, fn hl ->
+      project_range(
+        hl.start_line,
+        hl.start_col,
+        hl.end_line,
+        hl.end_col,
+        visual_entries,
+        fn start_row, start_col, end_row, end_col ->
+          %DocumentHighlight{
+            start_row: start_row,
+            start_col: start_col,
+            end_row: end_row,
+            end_col: end_col,
+            kind: hl.kind
+          }
+        end
+      )
+    end)
+  end
+
   # ── Line annotations ──────────────────────────────────────────────────
 
-  @spec build_annotations(Decorations.t(), non_neg_integer(), non_neg_integer()) ::
-          [Annotation.t()]
-  defp build_annotations(%Decorations{annotations: []}, _top, _bottom), do: []
+  @spec build_annotations(
+          Decorations.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          [visual_row_entry()],
+          boolean()
+        ) :: [Annotation.t()]
+  defp build_annotations(
+         %Decorations{annotations: []},
+         _top,
+         _bottom,
+         _visual_entries,
+         _wrapped?
+       ),
+       do: []
 
-  defp build_annotations(%Decorations{} = decorations, viewport_top, viewport_bottom) do
+  defp build_annotations(
+         %Decorations{} = decorations,
+         viewport_top,
+         viewport_bottom,
+         _visual_entries,
+         false
+       ) do
     decorations.annotations
     |> Enum.filter(fn ann ->
       ann.line >= viewport_top and ann.line < viewport_bottom
@@ -840,6 +1425,229 @@ defmodule MingaEditor.RenderModel.Window.Builder do
         text: ann.text
       }
     end)
+  end
+
+  defp build_annotations(
+         %Decorations{} = decorations,
+         _viewport_top,
+         _viewport_bottom,
+         visual_entries,
+         true
+       ) do
+    decorations.annotations
+    |> Enum.sort_by(fn ann -> {ann.line, ann.priority} end)
+    |> Enum.flat_map(fn ann ->
+      case first_visual_entry_for_line(visual_entries, ann.line) do
+        nil ->
+          []
+
+        entry ->
+          [
+            %Annotation{
+              row: entry.display_row,
+              kind: ann.kind,
+              fg: ann.fg,
+              bg: ann.bg,
+              text: ann.text
+            }
+          ]
+      end
+    end)
+  end
+
+  @spec build_wrapped_char_selection(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          [visual_row_entry()]
+        ) :: Selection.t() | nil
+  defp build_wrapped_char_selection(start_line, start_col, end_line, end_col, visual_entries) do
+    selected_entries = visual_entries_for_line_range(visual_entries, start_line, end_line)
+
+    with [_ | _] <- selected_entries,
+         start_entry <- selection_endpoint_entry(selected_entries, start_line, start_col, :first),
+         end_entry <- selection_endpoint_entry(selected_entries, end_line, end_col, :last) do
+      %Selection{
+        type: :char,
+        start_row: start_entry.display_row,
+        start_col: visual_col_for_source_col(start_entry, start_col),
+        end_row: end_entry.display_row,
+        end_col: visual_col_for_source_col(end_entry, end_col)
+      }
+    else
+      _ -> nil
+    end
+  end
+
+  @spec build_wrapped_line_selection(non_neg_integer(), non_neg_integer(), [visual_row_entry()]) ::
+          Selection.t() | nil
+  defp build_wrapped_line_selection(start_line, end_line, visual_entries) do
+    case visual_entries_for_line_range(visual_entries, start_line, end_line) do
+      [] ->
+        nil
+
+      entries ->
+        start_entry = hd(entries)
+        end_entry = List.last(entries)
+
+        %Selection{
+          type: :line,
+          start_row: start_entry.display_row,
+          start_col: 0,
+          end_row: end_entry.display_row,
+          end_col: 0
+        }
+    end
+  end
+
+  @spec selection_endpoint_entry(
+          [visual_row_entry()],
+          non_neg_integer(),
+          non_neg_integer(),
+          :first | :last
+        ) :: visual_row_entry()
+  defp selection_endpoint_entry(entries, line, col, fallback) do
+    line_entries = Enum.filter(entries, &(&1.buf_line == line))
+
+    if line_entries == [] do
+      endpoint_fallback(entries, fallback)
+    else
+      visual_entry_for_source_col(line_entries, col) || endpoint_fallback(entries, fallback)
+    end
+  end
+
+  @spec endpoint_fallback([visual_row_entry()], :first | :last) :: visual_row_entry()
+  defp endpoint_fallback(entries, :first), do: hd(entries)
+  defp endpoint_fallback(entries, :last), do: List.last(entries)
+
+  @spec visual_entries_for_line_range([visual_row_entry()], non_neg_integer(), non_neg_integer()) ::
+          [
+            visual_row_entry()
+          ]
+  defp visual_entries_for_line_range(visual_entries, start_line, end_line) do
+    Enum.filter(visual_entries, fn entry ->
+      entry.buf_line >= start_line and entry.buf_line <= end_line
+    end)
+  end
+
+  @spec first_visual_entry_for_line([visual_row_entry()], non_neg_integer()) ::
+          visual_row_entry() | nil
+  defp first_visual_entry_for_line(visual_entries, line) do
+    Enum.find(visual_entries, &(&1.buf_line == line))
+  end
+
+  @spec project_range(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          [visual_row_entry()],
+          (non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer() -> term())
+        ) :: [term()]
+  defp project_range(start_line, start_col, end_line, end_col, visual_entries, build_range) do
+    visual_entries
+    |> visual_entries_for_line_range(start_line, end_line)
+    |> Enum.flat_map(
+      &project_entry_range(&1, start_line, start_col, end_line, end_col, build_range)
+    )
+  end
+
+  @spec project_entry_range(
+          visual_row_entry(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          (non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer() -> term())
+        ) :: [term()]
+  defp project_entry_range(entry, start_line, start_col, end_line, end_col, build_range) do
+    range_start =
+      if entry.buf_line == start_line,
+        do: max(start_col, entry.source_start_col),
+        else: entry.source_start_col
+
+    range_end =
+      if entry.buf_line == end_line,
+        do: min(end_col, entry.source_end_col),
+        else: entry.source_end_col
+
+    if range_end > range_start do
+      [
+        build_range.(
+          entry.display_row,
+          visual_col_for_source_col(entry, range_start),
+          entry.display_row,
+          visual_col_for_source_col(entry, range_end)
+        )
+      ]
+    else
+      []
+    end
+  end
+
+  @spec project_byte_range(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          [visual_row_entry()],
+          (non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer() -> term())
+        ) :: [term()]
+  defp project_byte_range(start_line, start_byte, end_line, end_byte, visual_entries, build_range) do
+    visual_entries
+    |> visual_entries_for_line_range(start_line, end_line)
+    |> Enum.flat_map(
+      &project_entry_byte_range(&1, start_line, start_byte, end_line, end_byte, build_range)
+    )
+  end
+
+  @spec project_entry_byte_range(
+          visual_row_entry(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          (non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer() -> term())
+        ) :: [term()]
+  defp project_entry_byte_range(entry, start_line, start_byte, end_line, end_byte, build_range) do
+    range_start =
+      if entry.buf_line == start_line,
+        do: max(start_byte, entry.source_start_byte),
+        else: entry.source_start_byte
+
+    range_end =
+      if entry.buf_line == end_line,
+        do: min(end_byte, entry.source_end_byte),
+        else: entry.source_end_byte
+
+    if range_end > range_start do
+      [
+        build_range.(
+          entry.display_row,
+          visual_col_for_source_byte(entry, range_start),
+          entry.display_row,
+          visual_col_for_source_byte(entry, range_end)
+        )
+      ]
+    else
+      []
+    end
+  end
+
+  @spec visual_col_for_source_byte(visual_row_entry(), non_neg_integer()) :: non_neg_integer()
+  defp visual_col_for_source_byte(entry, source_byte) do
+    source_col = Unicode.display_col(entry.source_text, source_byte)
+    visual_col_for_source_col(entry, source_col)
+  end
+
+  @spec visual_col_for_source_col(visual_row_entry(), non_neg_integer()) :: non_neg_integer()
+  defp visual_col_for_source_col(entry, source_col) do
+    source_col
+    |> min(entry.source_end_col)
+    |> max(entry.source_start_col)
+    |> Kernel.-(entry.source_start_col)
+    |> Kernel.+(entry.indent_width)
   end
 
   # ── Helpers ────────────────────────────────────────────────────────────

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   alias Minga.Buffer
   alias Minga.Core.Decorations
   alias Minga.Core.Unicode
+  alias Minga.Core.WidthOracle
   alias Minga.Core.WrapMap
   alias MingaEditor.DisplayMap
   alias MingaEditor.FoldMap
@@ -232,7 +233,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
 
       {:ok, scroll} ->
         updated_window =
-          window
+          scroll.window
           |> Window.set_viewport(scroll.viewport)
           |> Window.detect_invalidation(
             scroll.viewport.top,
@@ -250,7 +251,16 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
             scroll.line_number_style
           )
 
-        scroll = %{scroll | window: updated_window}
+        {updated_window, content_epoch, full_refresh?} =
+          Window.prepare_render_epoch(updated_window, render_reset_fingerprint(scroll))
+
+        scroll = %{
+          scroll
+          | window: updated_window,
+            content_epoch: content_epoch,
+            full_refresh: full_refresh?
+        }
+
         new_map = Map.put(st.workspace.windows.map, win_id, updated_window)
 
         windows = Windows.set_map(st.workspace.windows, new_map)
@@ -422,14 +432,15 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         {lines, []}
       end
 
-    total_visual_rows =
+    {total_visual_rows, window} =
       total_visual_rows_for_frontend(
         state,
-        window.buffer,
+        window,
         wrap_on,
         visible_line_map,
         content_w,
-        width_oracle
+        width_oracle,
+        snapshot
       )
 
     %WindowScroll{
@@ -460,29 +471,81 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
 
   @spec total_visual_rows_for_frontend(
           state(),
-          pid(),
+          Window.t(),
           boolean(),
           [VisibleLines.line_entry()] | [DisplayMap.entry()] | nil,
           pos_integer(),
-          Minga.Core.WidthOracle.t()
-        ) :: non_neg_integer() | nil
-  defp total_visual_rows_for_frontend(state, buf, true, nil, content_w, oracle) do
+          Minga.Core.WidthOracle.t(),
+          Minga.Buffer.RenderSnapshot.t()
+        ) :: {non_neg_integer() | nil, Window.t()}
+  defp total_visual_rows_for_frontend(state, window, true, nil, content_w, oracle, snapshot) do
     if Capabilities.gui?(state.capabilities) do
-      visual_rows_to_eof(buf, 0, content_w, oracle)
+      key = total_visual_rows_cache_key(snapshot, content_w, oracle)
+
+      case Window.cached_total_visual_rows(window, key) do
+        nil ->
+          total = visual_rows_to_eof(window.buffer, 0, content_w, oracle)
+          {total, Window.put_total_visual_rows(window, key, total)}
+
+        total ->
+          {total, window}
+      end
     else
-      nil
+      {nil, window}
     end
   end
 
   defp total_visual_rows_for_frontend(
          _state,
-         _buf,
+         window,
          _wrap_on,
          _visible_line_map,
          _content_w,
-         _oracle
+         _oracle,
+         _snapshot
        ),
-       do: nil
+       do: {nil, window}
+
+  @spec total_visual_rows_cache_key(
+          Minga.Buffer.RenderSnapshot.t(),
+          pos_integer(),
+          Minga.Core.WidthOracle.t()
+        ) :: term()
+  defp total_visual_rows_cache_key(snapshot, content_w, oracle) do
+    options = snapshot.options
+
+    {
+      snapshot.version,
+      content_w,
+      Map.get(options, :breakindent, true),
+      Map.get(options, :linebreak, true),
+      Map.get(options, :tab_width, 2),
+      WidthOracle.fingerprint(oracle)
+    }
+  end
+
+  @spec render_reset_fingerprint(WindowScroll.t()) :: term()
+  defp render_reset_fingerprint(%WindowScroll{} = scroll) do
+    options = scroll.snapshot.options
+
+    {
+      scroll.win_id,
+      scroll.window.buffer,
+      scroll.win_layout.total,
+      scroll.win_layout.content,
+      scroll.content_w,
+      scroll.gutter_w,
+      scroll.wrap_on,
+      scroll.line_number_style,
+      scroll.viewport.rows,
+      scroll.viewport.cols,
+      scroll.window.fold_map,
+      Map.get(options, :breakindent, true),
+      Map.get(options, :linebreak, true),
+      Map.get(options, :tab_width, 2),
+      WidthOracle.fingerprint(scroll.width_oracle)
+    }
+  end
 
   @spec maybe_adjust_wrapped_viewport(map()) ::
           {Viewport.t(), non_neg_integer(), map(), [String.t()], String.t(), non_neg_integer()}

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -422,6 +422,16 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         {lines, []}
       end
 
+    total_visual_rows =
+      total_visual_rows_for_frontend(
+        state,
+        window.buffer,
+        wrap_on,
+        visible_line_map,
+        content_w,
+        width_oracle
+      )
+
     %WindowScroll{
       win_id: win_id,
       window: window,
@@ -443,9 +453,36 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
       buf_version: snapshot.version,
       width_oracle: width_oracle,
       git_signs: ContentHelpers.signs_for_window(state, window),
-      visible_line_map: visible_line_map
+      visible_line_map: visible_line_map,
+      total_visual_rows: total_visual_rows
     }
   end
+
+  @spec total_visual_rows_for_frontend(
+          state(),
+          pid(),
+          boolean(),
+          [VisibleLines.line_entry()] | [DisplayMap.entry()] | nil,
+          pos_integer(),
+          Minga.Core.WidthOracle.t()
+        ) :: non_neg_integer() | nil
+  defp total_visual_rows_for_frontend(state, buf, true, nil, content_w, oracle) do
+    if Capabilities.gui?(state.capabilities) do
+      visual_rows_to_eof(buf, 0, content_w, oracle)
+    else
+      nil
+    end
+  end
+
+  defp total_visual_rows_for_frontend(
+         _state,
+         _buf,
+         _wrap_on,
+         _visible_line_map,
+         _content_w,
+         _oracle
+       ),
+       do: nil
 
   @spec maybe_adjust_wrapped_viewport(map()) ::
           {Viewport.t(), non_neg_integer(), map(), [String.t()], String.t(), non_neg_integer()}

--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -708,7 +708,10 @@ defmodule MingaEditor.RenderPipeline.Content do
       buf_version: buf_version,
       width_oracle: MingaEditor.Frontend.Capabilities.width_oracle(state.capabilities),
       git_signs: %{},
-      visible_line_map: visible_line_map
+      visible_line_map: visible_line_map,
+      content_epoch:
+        :erlang.phash2({win_id, :agent_chat, chat_width, chat_height, line_number_style}),
+      full_refresh: false
     }
 
     {window_model, additional_window_models} =
@@ -832,8 +835,14 @@ defmodule MingaEditor.RenderPipeline.Content do
       )
 
     inner_width = PromptRenderer.input_inner_width(PromptRenderer.input_box_width(chat_width))
-    prompt_window_model = PromptRenderWindow.build(ctx, inner_width, prompt_rect)
-    {window_model, [prompt_window_model]}
+
+    additional_window_models =
+      case PromptRenderWindow.build(ctx, inner_width, prompt_rect) do
+        nil -> []
+        prompt_window_model -> [prompt_window_model]
+      end
+
+    {window_model, additional_window_models}
   end
 
   @spec agent_window_frame(boolean(), map()) :: WindowFrame.t()

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -68,7 +68,9 @@ defmodule MingaEditor.RenderPipeline.Scroll do
       :width_oracle,
       git_signs: %{},
       visible_line_map: nil,
-      total_visual_rows: nil
+      total_visual_rows: nil,
+      content_epoch: 0,
+      full_refresh: true
     ]
 
     @type t :: %__MODULE__{
@@ -94,7 +96,9 @@ defmodule MingaEditor.RenderPipeline.Scroll do
             git_signs: %{non_neg_integer() => atom()},
             visible_line_map:
               [VisibleLines.line_entry()] | [MingaEditor.DisplayMap.entry()] | nil,
-            total_visual_rows: non_neg_integer() | nil
+            total_visual_rows: non_neg_integer() | nil,
+            content_epoch: non_neg_integer(),
+            full_refresh: boolean()
           }
   end
 

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -67,7 +67,8 @@ defmodule MingaEditor.RenderPipeline.Scroll do
       :buf_version,
       :width_oracle,
       git_signs: %{},
-      visible_line_map: nil
+      visible_line_map: nil,
+      total_visual_rows: nil
     ]
 
     @type t :: %__MODULE__{
@@ -91,7 +92,9 @@ defmodule MingaEditor.RenderPipeline.Scroll do
             buf_version: non_neg_integer(),
             width_oracle: Minga.Core.WidthOracle.t(),
             git_signs: %{non_neg_integer() => atom()},
-            visible_line_map: [VisibleLines.line_entry()] | [MingaEditor.DisplayMap.entry()] | nil
+            visible_line_map:
+              [VisibleLines.line_entry()] | [MingaEditor.DisplayMap.entry()] | nil,
+            total_visual_rows: non_neg_integer() | nil
           }
   end
 

--- a/lib/minga_editor/renderer/caches.ex
+++ b/lib/minga_editor/renderer/caches.ex
@@ -62,4 +62,15 @@ defmodule MingaEditor.Renderer.Caches do
   @doc "Creates a fresh Caches struct with first-frame defaults."
   @spec new() :: t()
   def new, do: %__MODULE__{}
+
+  @doc "Clears frontend-retained state tracking after the frontend reports ready again."
+  @spec reset_frontend_state(t()) :: t()
+  def reset_frontend_state(%__MODULE__{} = caches) do
+    %{
+      caches
+      | adapter_gui_caches: Minga.Frontend.Adapter.GUI.Caches.new(),
+        last_title: nil,
+        last_window_bg: nil
+    }
+  end
 end

--- a/lib/minga_editor/session/state.ex
+++ b/lib/minga_editor/session/state.ex
@@ -128,12 +128,22 @@ defmodule MingaEditor.Session.State do
   """
   @spec invalidate_all_windows(t()) :: t()
   def invalidate_all_windows(%__MODULE__{windows: ws} = wspace) do
-    windows =
-      Enum.reduce(ws.map, ws, fn {id, _window}, acc ->
-        Windows.update(acc, id, &Window.invalidate/1)
-      end)
-
+    windows = update_all_windows(ws, &Window.invalidate/1)
     %{wspace | windows: windows}
+  end
+
+  @doc "Marks all window retained-GUI render caches reset-pending after frontend state loss."
+  @spec mark_frontend_reset_pending(t()) :: t()
+  def mark_frontend_reset_pending(%__MODULE__{windows: ws} = wspace) do
+    windows = update_all_windows(ws, &Window.mark_frontend_reset_pending/1)
+    %{wspace | windows: windows}
+  end
+
+  @spec update_all_windows(Windows.t(), (Window.t() -> Window.t())) :: Windows.t()
+  defp update_all_windows(ws, fun) do
+    Enum.reduce(ws.map, ws, fn {id, _window}, acc ->
+      Windows.update(acc, id, fun)
+    end)
   end
 
   @doc """

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -1624,6 +1624,16 @@ defmodule MingaEditor.State do
     update_workspace(state, &SessionState.invalidate_all_windows/1)
   end
 
+  @doc "Clears frontend-retained render state after a frontend ready/recovery event."
+  @spec reset_frontend_render_state(t()) :: t()
+  def reset_frontend_render_state(%__MODULE__{} = state) do
+    state
+    |> update_workspace(&SessionState.mark_frontend_reset_pending/1)
+    |> then(fn state ->
+      %{state | caches: MingaEditor.Renderer.Caches.reset_frontend_state(state.caches)}
+    end)
+  end
+
   @doc """
   Returns the terminal-level viewport: total screen rows/cols reported by
   the frontend on resize. Used for screen-spanning chrome (picker,

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -394,8 +394,8 @@ defmodule MingaEditor.Window do
   invalid.
   """
   @spec invalidate(t()) :: t()
-  def invalidate(%__MODULE__{} = window) do
-    %{window | render_cache: RenderCache.reset()}
+  def invalidate(%__MODULE__{render_cache: cache} = window) do
+    %{window | render_cache: RenderCache.reset(cache)}
   end
 
   @doc """
@@ -514,6 +514,31 @@ defmodule MingaEditor.Window do
   @spec detect_context_change(t(), RenderCache.context_fingerprint()) :: t()
   def detect_context_change(%__MODULE__{render_cache: cache} = window, fingerprint) do
     %{window | render_cache: RenderCache.detect_context_change(cache, fingerprint)}
+  end
+
+  @doc "Marks the next retained GUI frame as a frontend-state reset without discarding TUI draw caches."
+  @spec mark_frontend_reset_pending(t()) :: t()
+  def mark_frontend_reset_pending(%__MODULE__{render_cache: cache} = window) do
+    %{window | render_cache: RenderCache.mark_reset_pending(cache)}
+  end
+
+  @doc "Prepares the retained GUI content epoch for the current frame."
+  @spec prepare_render_epoch(t(), term()) :: {t(), non_neg_integer(), boolean()}
+  def prepare_render_epoch(%__MODULE__{render_cache: cache} = window, reset_fingerprint) do
+    {cache, epoch, full_refresh?} = RenderCache.prepare_epoch(cache, reset_fingerprint)
+    {%{window | render_cache: cache}, epoch, full_refresh?}
+  end
+
+  @doc "Returns a cached wrapped visual row total when the key matches."
+  @spec cached_total_visual_rows(t(), term()) :: non_neg_integer() | nil
+  def cached_total_visual_rows(%__MODULE__{render_cache: cache}, key) do
+    RenderCache.cached_total_visual_rows(cache, key)
+  end
+
+  @doc "Stores the wrapped visual row total for the current cache key."
+  @spec put_total_visual_rows(t(), term(), non_neg_integer()) :: t()
+  def put_total_visual_rows(%__MODULE__{render_cache: cache} = window, key, total) do
+    %{window | render_cache: RenderCache.put_total_visual_rows(cache, key, total)}
   end
 
   @doc """

--- a/lib/minga_editor/window/render_cache.ex
+++ b/lib/minga_editor/window/render_cache.ex
@@ -56,7 +56,11 @@ defmodule MingaEditor.Window.RenderCache do
           last_line_count: integer(),
           last_cursor_line: integer(),
           last_buf_version: integer(),
-          last_context_fingerprint: context_fingerprint()
+          last_context_fingerprint: context_fingerprint(),
+          content_epoch: non_neg_integer(),
+          reset_pending: boolean(),
+          last_reset_fingerprint: term(),
+          total_visual_rows_cache: {term(), non_neg_integer()} | nil
         }
 
   defstruct dirty_lines: %{},
@@ -68,7 +72,11 @@ defmodule MingaEditor.Window.RenderCache do
             last_line_count: -1,
             last_cursor_line: -1,
             last_buf_version: -1,
-            last_context_fingerprint: nil
+            last_context_fingerprint: nil,
+            content_epoch: 0,
+            reset_pending: true,
+            last_reset_fingerprint: nil,
+            total_visual_rows_cache: nil
 
   @doc """
   Returns a fresh cache with all lines dirty and no cached draws.
@@ -78,7 +86,27 @@ defmodule MingaEditor.Window.RenderCache do
   """
   @spec reset() :: t()
   def reset do
-    %__MODULE__{dirty_lines: :all}
+    %__MODULE__{dirty_lines: :all, reset_pending: true}
+  end
+
+  @doc "Returns a fresh cache invalidation while preserving retained-render epoch state."
+  @spec reset(t()) :: t()
+  def reset(%__MODULE__{} = cache) do
+    %{
+      cache
+      | dirty_lines: :all,
+        cached_gutter: %{},
+        cached_content: %{},
+        last_viewport_top: -1,
+        last_viewport_cache_key: -1,
+        last_gutter_w: -1,
+        last_line_count: -1,
+        last_cursor_line: -1,
+        last_buf_version: -1,
+        last_context_fingerprint: nil,
+        reset_pending: true,
+        total_visual_rows_cache: nil
+    }
   end
 
   @doc """
@@ -109,8 +137,10 @@ defmodule MingaEditor.Window.RenderCache do
   Checks current frame parameters against last-frame tracking fields
   and marks all lines dirty if anything requiring a full redraw has changed.
 
-  Structural triggers: viewport scroll, gutter width, line count, buffer
-  version, first frame (sentinel values).
+  Structural redraw triggers: viewport scroll, gutter width, line count, buffer
+  version, first frame (sentinel values). Only first frame and gutter-width
+  geometry changes request a retained-GUI epoch reset; ordinary text edits and
+  line-count changes use row hashes without bumping the content epoch.
   """
   @spec detect_invalidation(
           t(),
@@ -178,14 +208,16 @@ defmodule MingaEditor.Window.RenderCache do
       ) do
     first_frame = cache.last_buf_version < 0
 
+    geometry_reset = first_frame or cache.last_gutter_w != gutter_w
+
     needs_full =
-      first_frame or
+      geometry_reset or
         cache.last_viewport_top != viewport_top or
         cache.last_viewport_cache_key != viewport_cache_key or
-        cache.last_gutter_w != gutter_w or
         cache.last_line_count != line_count
 
     cache = if needs_full, do: %{cache | dirty_lines: :all}, else: cache
+    cache = if geometry_reset, do: %{cache | reset_pending: true}, else: cache
 
     if cache.last_buf_version != buf_version and cache.last_buf_version >= 0 do
       %{cache | dirty_lines: :all}
@@ -209,6 +241,37 @@ defmodule MingaEditor.Window.RenderCache do
     else
       cache
     end
+  end
+
+  @doc "Marks the next retained GUI frame as a frontend-state reset."
+  @spec mark_reset_pending(t()) :: t()
+  def mark_reset_pending(%__MODULE__{} = cache) do
+    %{cache | reset_pending: true}
+  end
+
+  @doc "Prepares the retained GUI content epoch for the current frame."
+  @spec prepare_epoch(t(), term()) :: {t(), non_neg_integer(), boolean()}
+  def prepare_epoch(%__MODULE__{} = cache, reset_fingerprint) do
+    reset? = cache.reset_pending or cache.last_reset_fingerprint != reset_fingerprint
+    epoch = if reset?, do: cache.content_epoch + 1, else: cache.content_epoch
+
+    {%{
+       cache
+       | content_epoch: epoch,
+         reset_pending: false,
+         last_reset_fingerprint: reset_fingerprint
+     }, epoch, reset?}
+  end
+
+  @doc "Returns a cached wrapped visual row total when the key matches."
+  @spec cached_total_visual_rows(t(), term()) :: non_neg_integer() | nil
+  def cached_total_visual_rows(%__MODULE__{total_visual_rows_cache: {key, total}}, key), do: total
+  def cached_total_visual_rows(%__MODULE__{}, _key), do: nil
+
+  @doc "Stores the wrapped visual row total for the current cache key."
+  @spec put_total_visual_rows(t(), term(), non_neg_integer()) :: t()
+  def put_total_visual_rows(%__MODULE__{} = cache, key, total) when is_integer(total) do
+    %{cache | total_visual_rows_cache: {key, total}}
   end
 
   @doc """

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1575,6 +1575,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         var wcHighlights: [GUIDocumentHighlight] = []
         var wcAnnotations: [GUILineAnnotation] = []
         var wcPaneGeometry: GUIPaneGeometry?
+        var wcCursorline: GUICursorline?
 
         for _ in 0..<wcSectionCount {
             guard data.count >= wcPos + 3 else { throw ProtocolDecodeError.malformed }
@@ -1704,6 +1705,10 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             case 0x08:
                 wcPaneGeometry = try decodePaneGeometry(data: data, start: wcSStart, end: wcSStart + wcSLen)
 
+            case 0x09:
+                guard wcSLen >= 5 else { break }
+                wcCursorline = GUICursorline(row: readU16(data, wcSStart), bg: readU24(data, wcSStart + 2))
+
             default: break
             }
 
@@ -1725,7 +1730,8 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             diagnosticUnderlines: wcDiags,
             documentHighlights: wcHighlights,
             lineAnnotations: wcAnnotations,
-            paneGeometry: wcPaneGeometry
+            paneGeometry: wcPaneGeometry,
+            cursorline: wcCursorline
         )
         return (.guiWindowContent(data: content), wcPos - offset)
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1567,12 +1567,14 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         var wcCursorCol: UInt16 = 0
         var wcCursorShape: CursorShape = .block
         var wcScrollLeft: UInt16 = 0
+        var wcContentEpoch: UInt32 = 0
         var wcRows: [GUIVisualRow] = []
         var wcSelection: GUISelectionOverlay? = nil
         var wcMatches: [GUISearchMatch] = []
         var wcDiags: [GUIDiagnosticUnderline] = []
         var wcHighlights: [GUIDocumentHighlight] = []
         var wcAnnotations: [GUILineAnnotation] = []
+        var wcPaneGeometry: GUIPaneGeometry?
 
         for _ in 0..<wcSectionCount {
             guard data.count >= wcPos + 3 else { throw ProtocolDecodeError.malformed }
@@ -1582,7 +1584,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             guard data.count >= wcSStart + wcSLen else { throw ProtocolDecodeError.malformed }
 
             switch wcSId {
-            case 0x01: // Header: window_id(2) + flags(1) + cursor_row(2) + cursor_col(2) + cursor_shape(1) + scroll_left(2)
+            case 0x01: // Header: window_id(2) + flags(1) + cursor_row(2) + cursor_col(2) + cursor_shape(1) + scroll_left(2) + optional content_epoch(4)
                 guard wcSLen >= 10 else { break }
                 wcWindowId = readU16(data, wcSStart)
                 wcFlags = data[wcSStart + 2]
@@ -1590,6 +1592,9 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 wcCursorCol = readU16(data, wcSStart + 5)
                 wcCursorShape = CursorShape(rawValue: data[wcSStart + 7]) ?? .block
                 wcScrollLeft = readU16(data, wcSStart + 8)
+                if wcSLen >= 14 {
+                    wcContentEpoch = readU32(data, wcSStart + 10)
+                }
 
             case 0x02: // Rows: row_count(2) + rows...
                 guard wcSLen >= 2 else { break }
@@ -1696,6 +1701,9 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                     wcAnnotations.append(GUILineAnnotation(row: annRow, kind: annKind, fg: annFg, bg: annBg, text: annText))
                 }
 
+            case 0x08:
+                wcPaneGeometry = try decodePaneGeometry(data: data, start: wcSStart, end: wcSStart + wcSLen)
+
             default: break
             }
 
@@ -1705,6 +1713,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         let content = GUIWindowContent(
             windowId: wcWindowId,
             fullRefresh: (wcFlags & 0x01) != 0,
+            contentEpoch: wcContentEpoch,
             cursorVisible: (wcFlags & 0x02) != 0,
             cursorRow: wcCursorRow,
             cursorCol: wcCursorCol,
@@ -1715,7 +1724,8 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             searchMatches: wcMatches,
             diagnosticUnderlines: wcDiags,
             documentHighlights: wcHighlights,
-            lineAnnotations: wcAnnotations
+            lineAnnotations: wcAnnotations,
+            paneGeometry: wcPaneGeometry
         )
         return (.guiWindowContent(data: content), wcPos - offset)
 
@@ -3223,6 +3233,74 @@ private func decodeChatMessageCandidates(data: Data, start: Int, end: Int) throw
     default:
         throw ProtocolDecodeError.malformed
     }
+}
+
+private func decodePaneGeometry(data: Data, start: Int, end: Int) throws -> GUIPaneGeometry {
+    var pos = start
+    guard pos + 2 <= end else { throw ProtocolDecodeError.malformed }
+    let windowId = readU16(data, pos)
+    pos += 2
+
+    let totalRect = try readCellRect(data, pos, end)
+    pos += 8
+    let contentRect = try readCellRect(data, pos, end)
+    pos += 8
+    let textRect = try readCellRect(data, pos, end)
+    pos += 8
+    let gutterRect = try readCellRect(data, pos, end)
+    pos += 8
+    let clipRect = try readCellRect(data, pos, end)
+    pos += 8
+
+    guard pos + 20 <= end else { throw ProtocolDecodeError.malformed }
+    let viewport = GUIViewportSummary(
+        top: readU32(data, pos),
+        left: readU16(data, pos + 4),
+        rows: readU16(data, pos + 6),
+        cols: readU16(data, pos + 8),
+        totalLines: readU32(data, pos + 10),
+        visualRowOffset: readU16(data, pos + 14),
+        totalVisualRows: readU32(data, pos + 16)
+    )
+    pos += 20
+
+    guard pos + 5 <= end else { throw ProtocolDecodeError.malformed }
+    let metrics = GUIGutterMetrics(lineNumberWidth: readU16(data, pos), signColWidth: readU16(data, pos + 2))
+    let hitCount = Int(data[pos + 4])
+    pos += 5
+
+    var hitRegions: [GUIHitRegion] = []
+    hitRegions.reserveCapacity(hitCount)
+    for _ in 0..<hitCount {
+        guard pos + 11 <= end else { throw ProtocolDecodeError.malformed }
+        let kind = GUIHitRegion.Kind(rawValue: data[pos]) ?? .text
+        let rect = try readCellRect(data, pos + 1, end)
+        let regionWindowId = readU16(data, pos + 9)
+        hitRegions.append(GUIHitRegion(kind: kind, rect: rect, windowId: regionWindowId))
+        pos += 11
+    }
+
+    return GUIPaneGeometry(
+        windowId: windowId,
+        totalRect: totalRect,
+        contentRect: contentRect,
+        textRect: textRect,
+        gutterRect: gutterRect,
+        clipRect: clipRect,
+        viewport: viewport,
+        gutterMetrics: metrics,
+        hitRegions: hitRegions
+    )
+}
+
+private func readCellRect(_ data: Data, _ offset: Int, _ end: Int) throws -> GUICellRect {
+    guard offset + 8 <= end else { throw ProtocolDecodeError.malformed }
+    return GUICellRect(
+        row: readU16(data, offset),
+        col: readU16(data, offset + 2),
+        width: readU16(data, offset + 4),
+        height: readU16(data, offset + 6)
+    )
 }
 
 private func readU16(_ data: Data, _ offset: Int) -> UInt16 {

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -75,8 +75,12 @@ final class CommandDispatcher {
     let guiState: GUIState
 
     /// Window ids that arrived in the current frame batch. Used for input hit testing so stale
-    /// retained gutter data can still render without being clickable.
-    private(set) var currentFrameGutterWindowIds: Set<UInt16> = []
+    /// retained pane geometry can still render without being clickable.
+    private(set) var currentFrameWindowIds: Set<UInt16> = []
+
+    /// True after a protocol clear starts a real render frame. Metadata-only updates that do not
+    /// start with clear must not prune retained window geometry.
+    private var frameHasClear: Bool = false
 
     init(cols: UInt16, rows: UInt16, guiState: GUIState) {
         self.frameState = FrameState(cols: cols, rows: rows)
@@ -89,7 +93,8 @@ final class CommandDispatcher {
         case .clear:
             frameState.beginFrame()
             guiState.beginFrame()
-            currentFrameGutterWindowIds.removeAll(keepingCapacity: true)
+            currentFrameWindowIds.removeAll(keepingCapacity: true)
+            frameHasClear = true
 
         case .drawText, .drawStyledText:
             // Legacy cell-grid text rendering. All content now flows through
@@ -313,7 +318,7 @@ final class CommandDispatcher {
 
         case .guiGutter(let data):
             frameState.windowGutters[data.windowId] = data
-            currentFrameGutterWindowIds.insert(data.windowId)
+            currentFrameWindowIds.insert(data.windowId)
             if data.isActive {
                 frameState.gutterCol = UInt16(data.lineNumberWidth) + UInt16(data.signColWidth)
                 // Derive viewport top from the first gutter entry's buffer line.
@@ -325,6 +330,7 @@ final class CommandDispatcher {
 
         case .guiWindowContent(let data):
             guiState.windowContents[data.windowId] = data
+            currentFrameWindowIds.insert(data.windowId)
             // BEAM controls cursor visibility per window. When the minibuffer
             // or other overlay has focus, cursor_visible is false.
             frameState.cursorVisible = data.cursorVisible
@@ -521,10 +527,17 @@ final class CommandDispatcher {
     }
 
     private func pruneStaleWindowGeometry() {
-        guard !currentFrameGutterWindowIds.isEmpty else { return }
-        let liveWindowIds = currentFrameGutterWindowIds
+        guard frameHasClear else { return }
+        defer { frameHasClear = false }
+
+        let liveWindowIds = currentFrameWindowIds
         frameState.windowGutters = frameState.windowGutters.filter { liveWindowIds.contains($0.key) }
         frameState.windowIndentGuides = frameState.windowIndentGuides.filter { liveWindowIds.contains($0.key) }
         guiState.windowContents = guiState.windowContents.filter { liveWindowIds.contains($0.key) }
+
+        if liveWindowIds.isEmpty {
+            frameState.verticalSeparators.removeAll(keepingCapacity: true)
+            frameState.horizontalSeparators.removeAll(keepingCapacity: true)
+        }
     }
 }

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -343,6 +343,11 @@ final class CoreTextMetalRenderer {
             atlas.ensureCapacity(maxSlots: neededSlots, width: atlasPixelWidth)
             atlas.beginFrame()
 
+            if windowContents.values.contains(where: { $0.fullRefresh }) {
+                atlas.invalidateAll()
+                windowContentRenderer?.invalidateAll()
+            }
+
             if neededSlots > maxInstanceSlots {
                 maxInstanceSlots = neededSlots
                 instanceBuffer = device.makeBuffer(
@@ -431,16 +436,19 @@ final class CoreTextMetalRenderer {
                     continue
                 }
 
+                let paneGeometry = content.paneGeometry
                 let windowScrollOffsetPx = CoreTextMetalRenderer.smoothScrollOffset(
                     for: content.windowId,
                     targetWindowId: scrollTargetWindowId,
                     scrollOffsetPx: smoothScrollOffsetPx
                 )
-                let windowRowOffset = Float(gutter.contentRow) * displayCellH * scale
+                let windowRowOffset = Float(paneGeometry?.textRect.row ?? gutter.contentRow) * displayCellH * scale
                 let scrollableWindowRowOffset = windowRowOffset - windowScrollOffsetPx.y
-                let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
-                let contentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
+                let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
+                let textCol = Float(paneGeometry?.textRect.col ?? fallbackTextCol)
+                let contentColOffset = textCol * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
                 let windowBounds = CoreTextMetalRenderer.windowHorizontalBounds(
+                    geometry: paneGeometry,
                     gutter: gutter,
                     frameCols: frameState.cols,
                     cellW: cellW,
@@ -454,6 +462,7 @@ final class CoreTextMetalRenderer {
                 let scrollLeftInt = Int(content.scrollLeft)
                 let hScrollPx = Float(scrollLeftInt) * cellW * scale
                 let contentCols = CoreTextMetalRenderer.visibleTextCols(
+                    geometry: paneGeometry,
                     gutter: gutter,
                     frameCols: frameState.cols,
                     cellW: cellW,
@@ -480,6 +489,7 @@ final class CoreTextMetalRenderer {
                 // Document highlight overlay quads (drawn before search matches,
                 // so search matches paint over them when they overlap).
                 for highlight in content.documentHighlights {
+                    guard highlight.endCol > highlight.startCol else { continue }
                     // Document highlights are typically single-line (one identifier).
                     // Draw on startRow only; multi-row highlights are rare for this feature.
                     let hlY = scrollableWindowRowOffset + Float(highlight.startRow) * displayCellH * scale
@@ -503,6 +513,7 @@ final class CoreTextMetalRenderer {
 
                 // Search match overlay quads (drawn before text).
                 for match in content.searchMatches {
+                    guard match.endCol > match.startCol else { continue }
                     let matchY = scrollableWindowRowOffset + Float(match.row) * displayCellH * scale
                     let rawMatchX = contentColOffset + Float(match.startCol) * cellW * scale - hScrollPx
                     let rawMatchRight = rawMatchX + Float(match.endCol - match.startCol) * cellW * scale
@@ -537,7 +548,7 @@ final class CoreTextMetalRenderer {
                 var rowEntriesByRow: [UInt16: AtlasEntry] = [:]
                 for (rowIdx, clippedRow) in clippedRows.enumerated() {
                     let displayRow = UInt16(rowIdx)
-                    if let atlas, let entry = wcr.renderRowToAtlas(displayRow: displayRow, row: clippedRow, windowId: content.windowId, atlas: atlas, metrics: &frameMetrics) {
+                    if let atlas, let entry = wcr.renderRowToAtlas(displayRow: displayRow, row: clippedRow, windowId: content.windowId, contentEpoch: content.contentEpoch, atlas: atlas, metrics: &frameMetrics) {
                         rowEntriesByRow[displayRow] = entry
                         let yPos = scrollableWindowRowOffset + Float(rowIdx) * displayCellH * scale
                         let textYOffset = (displayCellH - cellH) * scale * 0.5
@@ -591,6 +602,7 @@ final class CoreTextMetalRenderer {
 
                 // Diagnostic underline quads (drawn after text).
                 for diag in content.diagnosticUnderlines {
+                    guard diag.endCol > diag.startCol else { continue }
                     let diagColor: SIMD3<Float> = switch diag.severity {
                     case .error:   SIMD3<Float>(1.0, 0.42, 0.42)   // red
                     case .warning: SIMD3<Float>(0.93, 0.75, 0.48)  // yellow
@@ -673,9 +685,11 @@ final class CoreTextMetalRenderer {
             guard !guideData.guideCols.isEmpty else { continue }
 
             guard let gutter = frameState.windowGutters[guideData.windowId] else { continue }
-            let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
-            let windowContentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
+            let paneGeometry = windowContents[guideData.windowId]?.paneGeometry
+            let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
+            let windowContentColOffset = Float(paneGeometry?.textRect.col ?? fallbackTextCol) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
             let windowBounds = CoreTextMetalRenderer.windowHorizontalBounds(
+                geometry: paneGeometry,
                 gutter: gutter,
                 frameCols: frameState.cols,
                 cellW: cellW,
@@ -983,7 +997,7 @@ final class CoreTextMetalRenderer {
         let viewportTop = frameState.viewportTopLine
 
         if totalLines > visibleRows && viewportTop != 0xFFFF_FFFF && scrollIndicatorAlpha > 0 {
-            let viewportH = Float(viewportSize.height) * scale
+            let viewportH = Float(viewportSize.height)
             let indicatorWidth: Float = 6.0 * scale
             let indicatorMargin: Float = 2.0 * scale
             let trackHeight = viewportH
@@ -994,7 +1008,7 @@ final class CoreTextMetalRenderer {
             let maxTop = Float(max(Int64(totalLines) - Int64(visibleRows), 1))
             let thumbY = (Float(viewportTop) / maxTop) * (trackHeight - thumbHeight)
 
-            let thumbX = Float(viewportSize.width) * scale - indicatorWidth - indicatorMargin
+            let thumbX = Float(viewportSize.width) - indicatorWidth - indicatorMargin
 
             var scrollQuad = QuadGPU()
             scrollQuad.position = SIMD2<Float>(thumbX, thumbY)
@@ -1568,6 +1582,7 @@ final class CoreTextMetalRenderer {
     }
 
     nonisolated static func visibleTextCols(
+        geometry: GUIPaneGeometry?,
         gutter: Wire.WindowGutter,
         frameCols: UInt16,
         cellW: Float,
@@ -1575,6 +1590,12 @@ final class CoreTextMetalRenderer {
         gutterLeftMarginPx: Float,
         gutterPaddingPx: Float
     ) -> Int {
+        if let geometry {
+            let cellWidthPx = max(cellW * scale, 1)
+            let paddingCols = Int(ceil((gutterLeftMarginPx + gutterPaddingPx) / cellWidthPx))
+            return max(Int(geometry.textRect.width) - paddingCols, 1)
+        }
+
         let gutterCols = Int(gutter.lineNumberWidth) + Int(gutter.signColWidth)
         let availableCols = max(windowWidthCols(gutter: gutter, frameCols: frameCols) - gutterCols, 1)
         let cellWidthPx = max(cellW * scale, 1)
@@ -1583,12 +1604,19 @@ final class CoreTextMetalRenderer {
     }
 
     nonisolated static func windowHorizontalBounds(
+        geometry: GUIPaneGeometry?,
         gutter: Wire.WindowGutter,
         frameCols: UInt16,
         cellW: Float,
         scale: Float,
         viewportWidth: Float
     ) -> (x: Float, width: Float) {
+        if let geometry {
+            let left = Float(geometry.clipRect.col) * cellW * scale
+            let right = min(left + Float(geometry.clipRect.width) * cellW * scale, viewportWidth)
+            return (x: left, width: max(right - left, 0))
+        }
+
         let left = Float(gutter.contentCol) * cellW * scale
         let right = min(left + Float(windowWidthCols(gutter: gutter, frameCols: frameCols)) * cellW * scale, viewportWidth)
         return (x: left, width: max(right - left, 0))
@@ -1618,6 +1646,7 @@ final class CoreTextMetalRenderer {
         }
 
         return windowHorizontalBounds(
+            geometry: nil,
             gutter: matchingGutter,
             frameCols: frameCols,
             cellW: cellW,
@@ -1666,12 +1695,13 @@ final class CoreTextMetalRenderer {
             guard let content = windowContents[windowId] else { continue }
             guard content.cursorVisible else { return nil }
 
-            let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
-            let contentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
+            let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
+            let contentColOffset = Float(content.paneGeometry?.textRect.col ?? fallbackTextCol) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
             let hScrollPx = Float(content.scrollLeft) * cellW * scale
             let cursorCol = resolvedSemanticCursorCol(content)
             let x = contentColOffset + Float(cursorCol) * cellW * scale - hScrollPx
-            let y = (Float(gutter.contentRow) + Float(content.cursorRow)) * displayCellH * scale
+            let textRow = content.paneGeometry?.textRect.row ?? gutter.contentRow
+            let y = (Float(textRow) + Float(content.cursorRow)) * displayCellH * scale
             return RenderCursor(x: x, y: y, shape: content.cursorShape, windowId: windowId)
         }
 

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -343,9 +343,8 @@ final class CoreTextMetalRenderer {
             atlas.ensureCapacity(maxSlots: neededSlots, width: atlasPixelWidth)
             atlas.beginFrame()
 
-            if windowContents.values.contains(where: { $0.fullRefresh }) {
-                atlas.invalidateAll()
-                windowContentRenderer?.invalidateAll()
+            for content in windowContents.values where content.fullRefresh {
+                atlas.invalidateWindow(content.windowId)
             }
 
             if neededSlots > maxInstanceSlots {
@@ -401,27 +400,6 @@ final class CoreTextMetalRenderer {
         var bgQuads: [QuadGPU] = []
         var lineInstances: [LineGPU] = []
 
-        // Cursorline: draw only inside the active split pane. The protocol currently carries a global screen row without a window id, so infer the pane from the active gutter geometry.
-        if frameState.cursorlineRow != 0xFFFF && frameState.cursorlineBg != 0 {
-            // In side-by-side splits, row-only matching can apply one pane's fractional trackpad offset to another pane's cursorline. Keep the cursorline snapped until the protocol exposes an owning window id.
-            let cursorlineOffsetY: Float = 0
-            let yPos = Float(frameState.cursorlineRow) * displayCellH * scale - cursorlineOffsetY
-            let bounds = CoreTextMetalRenderer.cursorlineHorizontalBounds(
-                row: frameState.cursorlineRow,
-                gutters: frameState.windowGutters,
-                frameCols: frameState.cols,
-                cellW: cellW,
-                scale: scale,
-                viewportWidth: Float(viewportSize.width)
-            )
-            var clQuad = QuadGPU()
-            clQuad.position = SIMD2<Float>(bounds.x, yPos)
-            clQuad.size = SIMD2<Float>(bounds.width, displayCellH * scale)
-            clQuad.color = colorFromU24(frameState.cursorlineBg, default: defaultBg)
-            clQuad.alpha = 1.0
-            bgQuads.append(clQuad)
-        }
-
         // Semantic window content rendering (from 0x80 opcode).
         // Buffer windows with semantic content rendered via WindowContentRenderer;
         // their line textures come from WindowContentRenderer instead.
@@ -456,6 +434,16 @@ final class CoreTextMetalRenderer {
                     viewportWidth: Float(viewportSize.width)
                 )
                 let contentRightPx = windowBounds.x + windowBounds.width
+
+                if let cursorline = content.cursorline, cursorline.bg != 0 {
+                    let yPos = scrollableWindowRowOffset + Float(cursorline.row) * displayCellH * scale
+                    var clQuad = QuadGPU()
+                    clQuad.position = SIMD2<Float>(windowBounds.x, yPos)
+                    clQuad.size = SIMD2<Float>(windowBounds.width, displayCellH * scale)
+                    clQuad.color = colorFromU24(cursorline.bg, default: defaultBg)
+                    clQuad.alpha = 1.0
+                    bgQuads.append(clQuad)
+                }
 
                 // Horizontal scroll: shift line textures and overlays left by scrollLeft columns.
                 // The gutter stays fixed; only content past the gutter edge scrolls.
@@ -1691,9 +1679,11 @@ final class CoreTextMetalRenderer {
         gutterLeftMarginPx: Float,
         gutterPaddingPx: Float
     ) -> RenderCursor? {
-        for (windowId, gutter) in frameState.windowGutters where gutter.isActive {
-            guard let content = windowContents[windowId] else { continue }
-            guard content.cursorVisible else { return nil }
+        var sawActiveSemanticCursorOwner = false
+        for windowId in semanticCursorWindowIds(frameState.windowGutters) {
+            guard let gutter = frameState.windowGutters[windowId], let content = windowContents[windowId] else { continue }
+            sawActiveSemanticCursorOwner = true
+            guard content.cursorVisible else { continue }
 
             let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
             let contentColOffset = Float(content.paneGeometry?.textRect.col ?? fallbackTextCol) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
@@ -1705,6 +1695,7 @@ final class CoreTextMetalRenderer {
             return RenderCursor(x: x, y: y, shape: content.cursorShape, windowId: windowId)
         }
 
+        if sawActiveSemanticCursorOwner { return nil }
         guard frameState.cursorVisible else { return nil }
 
         let cursorPadding: Float = (frameState.gutterCol > 0 && frameState.cursorCol >= frameState.gutterCol)
@@ -1712,6 +1703,23 @@ final class CoreTextMetalRenderer {
         let x = Float(frameState.cursorCol) * cellW * scale + cursorPadding
         let y = Float(frameState.cursorRow) * displayCellH * scale
         return RenderCursor(x: x, y: y, shape: frameState.cursorShape)
+    }
+
+    /// Returns active semantic cursor owners in deterministic priority order. The agent prompt uses a reserved window id and must win over the retained chat content when both are active during focus transitions.
+    nonisolated static func semanticCursorWindowIds(_ gutters: [UInt16: Wire.WindowGutter]) -> [UInt16] {
+        gutters.values
+            .filter(\.isActive)
+            .map(\.windowId)
+            .sorted { lhs, rhs in
+                let leftPriority = semanticCursorPriority(windowId: lhs)
+                let rightPriority = semanticCursorPriority(windowId: rhs)
+                if leftPriority == rightPriority { return lhs < rhs }
+                return leftPriority < rightPriority
+            }
+    }
+
+    nonisolated static func semanticCursorPriority(windowId: UInt16) -> Int {
+        windowId == 65_534 ? 0 : 1
     }
 
     /// Converts the semantic cursor column into the rendered column for the active cursor shape.

--- a/macos/Sources/Renderer/FrameState.swift
+++ b/macos/Sources/Renderer/FrameState.swift
@@ -87,6 +87,8 @@ struct FrameState {
     /// Does NOT clear windowGutters (prevents blank-gutter flash).
     mutating func beginFrame() {
         dirty = true
+        cursorlineRow = 0xFFFF
+        cursorlineBg = 0
     }
 
     /// Resize the grid. Marks dirty.

--- a/macos/Sources/Renderer/LineTextureAtlas.swift
+++ b/macos/Sources/Renderer/LineTextureAtlas.swift
@@ -143,4 +143,8 @@ final class LineTextureAtlas {
     func invalidateAll() {
         allocator.invalidateAll()
     }
+
+    func invalidateWindow(_ windowId: UInt16) {
+        allocator.invalidateWindow(windowId)
+    }
 }

--- a/macos/Sources/Renderer/SlotAllocator.swift
+++ b/macos/Sources/Renderer/SlotAllocator.swift
@@ -194,6 +194,22 @@ struct SlotAllocator {
         freeSlots = Array((0..<capacity).reversed())
     }
 
+    /// Clear slots belonging to one window. Capacity and unrelated window slots are preserved.
+    mutating func invalidateWindow(_ windowId: UInt16) {
+        let removed = keyToSlot.filter { key, _slotIndex in key.windowId == windowId }
+        guard !removed.isEmpty else { return }
+
+        for (_key, slotIndex) in removed {
+            slots[slotIndex].contentHash = 0
+            slots[slotIndex].pixelWidth = 0
+            freeSlots.append(slotIndex)
+        }
+
+        for key in removed.keys {
+            keyToSlot.removeValue(forKey: key)
+        }
+    }
+
     // MARK: - Private
 
     private mutating func evictOldest() -> (index: Int, key: AtlasKey)? {

--- a/macos/Sources/Renderer/WindowContent.swift
+++ b/macos/Sources/Renderer/WindowContent.swift
@@ -144,6 +144,56 @@ struct GUILineAnnotation: Sendable, Equatable {
     let text: String
 }
 
+// MARK: - Pane geometry
+
+struct GUICellRect: Sendable, Equatable {
+    let row: UInt16
+    let col: UInt16
+    let width: UInt16
+    let height: UInt16
+}
+
+struct GUIViewportSummary: Sendable, Equatable {
+    let top: UInt32
+    let left: UInt16
+    let rows: UInt16
+    let cols: UInt16
+    let totalLines: UInt32
+    let visualRowOffset: UInt16
+    let totalVisualRows: UInt32
+}
+
+struct GUIGutterMetrics: Sendable, Equatable {
+    let lineNumberWidth: UInt16
+    let signColWidth: UInt16
+}
+
+struct GUIHitRegion: Sendable, Equatable {
+    enum Kind: UInt8, Sendable {
+        case text = 1
+        case gutter = 2
+        case foldControl = 3
+        case modeline = 4
+        case divider = 5
+    }
+
+    let kind: Kind
+    let rect: GUICellRect
+    let windowId: UInt16
+}
+
+struct GUIPaneGeometry: Sendable, Equatable {
+    let windowId: UInt16
+    let totalRect: GUICellRect
+    let contentRect: GUICellRect
+    let textRect: GUICellRect
+    let gutterRect: GUICellRect
+    let clipRect: GUICellRect
+    let viewport: GUIViewportSummary
+    let gutterMetrics: GUIGutterMetrics
+    let hitRegions: [GUIHitRegion]
+}
+
 // MARK: - Window content
 
 /// Complete semantic content for one editor window.
@@ -154,6 +204,7 @@ struct GUILineAnnotation: Sendable, Equatable {
 final class GUIWindowContent: Sendable {
     let windowId: UInt16
     let fullRefresh: Bool
+    let contentEpoch: UInt32
     /// Whether the BEAM wants the cursor visible in this window.
     /// False when the minibuffer or other overlay has focus.
     let cursorVisible: Bool
@@ -170,17 +221,20 @@ final class GUIWindowContent: Sendable {
     let diagnosticUnderlines: [GUIDiagnosticUnderline]
     let documentHighlights: [GUIDocumentHighlight]
     let lineAnnotations: [GUILineAnnotation]
+    let paneGeometry: GUIPaneGeometry?
 
-    init(windowId: UInt16, fullRefresh: Bool, cursorVisible: Bool = true,
+    init(windowId: UInt16, fullRefresh: Bool, contentEpoch: UInt32 = 0, cursorVisible: Bool = true,
          cursorRow: UInt16, cursorCol: UInt16, cursorShape: CursorShape,
          scrollLeft: UInt16 = 0,
          rows: [GUIVisualRow], selection: GUISelectionOverlay?,
          searchMatches: [GUISearchMatch],
          diagnosticUnderlines: [GUIDiagnosticUnderline],
          documentHighlights: [GUIDocumentHighlight],
-         lineAnnotations: [GUILineAnnotation] = []) {
+         lineAnnotations: [GUILineAnnotation] = [],
+         paneGeometry: GUIPaneGeometry? = nil) {
         self.windowId = windowId
         self.fullRefresh = fullRefresh
+        self.contentEpoch = contentEpoch
         self.cursorVisible = cursorVisible
         self.cursorRow = cursorRow
         self.cursorCol = cursorCol
@@ -192,5 +246,6 @@ final class GUIWindowContent: Sendable {
         self.diagnosticUnderlines = diagnosticUnderlines
         self.documentHighlights = documentHighlights
         self.lineAnnotations = lineAnnotations
+        self.paneGeometry = paneGeometry
     }
 }

--- a/macos/Sources/Renderer/WindowContent.swift
+++ b/macos/Sources/Renderer/WindowContent.swift
@@ -175,11 +175,17 @@ struct GUIHitRegion: Sendable, Equatable {
         case foldControl = 3
         case modeline = 4
         case divider = 5
+        case statusBar = 6
     }
 
     let kind: Kind
     let rect: GUICellRect
     let windowId: UInt16
+}
+
+struct GUICursorline: Sendable, Equatable {
+    let row: UInt16
+    let bg: UInt32
 }
 
 struct GUIPaneGeometry: Sendable, Equatable {
@@ -222,6 +228,7 @@ final class GUIWindowContent: Sendable {
     let documentHighlights: [GUIDocumentHighlight]
     let lineAnnotations: [GUILineAnnotation]
     let paneGeometry: GUIPaneGeometry?
+    let cursorline: GUICursorline?
 
     init(windowId: UInt16, fullRefresh: Bool, contentEpoch: UInt32 = 0, cursorVisible: Bool = true,
          cursorRow: UInt16, cursorCol: UInt16, cursorShape: CursorShape,
@@ -231,7 +238,8 @@ final class GUIWindowContent: Sendable {
          diagnosticUnderlines: [GUIDiagnosticUnderline],
          documentHighlights: [GUIDocumentHighlight],
          lineAnnotations: [GUILineAnnotation] = [],
-         paneGeometry: GUIPaneGeometry? = nil) {
+         paneGeometry: GUIPaneGeometry? = nil,
+         cursorline: GUICursorline? = nil) {
         self.windowId = windowId
         self.fullRefresh = fullRefresh
         self.contentEpoch = contentEpoch
@@ -247,5 +255,6 @@ final class GUIWindowContent: Sendable {
         self.documentHighlights = documentHighlights
         self.lineAnnotations = lineAnnotations
         self.paneGeometry = paneGeometry
+        self.cursorline = cursorline
     }
 }

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -136,8 +136,8 @@ final class WindowContentRenderer {
     ///
     /// Returns the cached texture if the content hash matches, or
     /// rasterizes a new texture from the row's text + spans.
-    func renderRow(displayRow: UInt16, row: GUIVisualRow) -> CachedLineTexture? {
-        let hash = Int(row.contentHash)
+    func renderRow(displayRow: UInt16, row: GUIVisualRow, contentEpoch: UInt32 = 0) -> CachedLineTexture? {
+        let hash = epochContentHash(row.contentHash, contentEpoch)
 
         // Cache hit check.
         if var cached = lineCache[displayRow], cached.contentHash == hash {
@@ -198,9 +198,9 @@ final class WindowContentRenderer {
     /// Render a visual row into an atlas slot.
     ///
     /// Checks the atlas cache first using a window-scoped buffer-row key. On miss, rasterizes and uploads.
-    func renderRowToAtlas(displayRow: UInt16, row: GUIVisualRow, windowId: UInt16,
+    func renderRowToAtlas(displayRow: UInt16, row: GUIVisualRow, windowId: UInt16, contentEpoch: UInt32 = 0,
                           atlas: LineTextureAtlas, metrics: inout FrameMetrics) -> AtlasEntry? {
-        let hash = Int(row.contentHash)
+        let hash = epochContentHash(row.contentHash, contentEpoch)
         let key = AtlasKey.bufferRow(windowId: windowId, row: displayRow)
 
         guard !row.text.isEmpty else { return nil }
@@ -213,6 +213,10 @@ final class WindowContentRenderer {
         case .reserved(let reservation):
             return rasterizeRowToAtlas(row: row, reservation: reservation, atlas: atlas, metrics: &metrics)
         }
+    }
+
+    private func epochContentHash(_ contentHash: UInt32, _ contentEpoch: UInt32) -> Int {
+        Int(contentHash) &* 31 &+ Int(contentEpoch)
     }
 
     private func rasterizeRowToAtlas(row: GUIVisualRow, reservation: Reservation,

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -336,6 +336,10 @@ final class EditorNSView: MTKView {
     /// Nil means the event location did not resolve to a scrollable editor window, so fractional offset is disabled instead of shifting every pane.
     private var scrollTargetWindowId: UInt16?
 
+    /// Cell position that owns the current precise scroll gesture.
+    /// Nil means the gesture has not latched onto a scroll target yet.
+    private var scrollTargetCellPosition: (row: Int16, col: Int16)?
+
     /// Schedule a render on the next vsync. Multiple calls between vsyncs
     /// are coalesced by MTKView into a single draw() call.
     func renderFrame() {
@@ -373,7 +377,7 @@ final class EditorNSView: MTKView {
         }
 
         let validGutterHoverWindowId = gutterHoverWindowId.flatMap { windowId in
-            dispatcher.currentFrameGutterWindowIds.contains(windowId) ? windowId : nil
+            dispatcher.currentFrameWindowIds.contains(windowId) ? windowId : nil
         }
         let validGutterHoverRow = validGutterHoverWindowId == nil ? nil : gutterHoverRow
         let validMouseInGutter = isMouseInGutter && validGutterHoverWindowId != nil
@@ -1318,16 +1322,18 @@ final class EditorNSView: MTKView {
     private func handleTrackpadScroll(event: NSEvent, row: Int16, col: Int16, mods: UInt8) {
         if event.phase == .began {
             scrollAccumulator.reset()
-            scrollTargetWindowId = smoothScrollTargetWindowId(row: row, col: col)
-        } else if scrollTargetWindowId == nil {
-            scrollTargetWindowId = smoothScrollTargetWindowId(row: row, col: col)
+            scrollTargetWindowId = nil
+            scrollTargetCellPosition = nil
         }
+
+        establishSmoothScrollTargetIfNeeded(row: row, col: col)
+        let targetCell = Self.smoothScrollEventCellPosition(targetCell: scrollTargetCellPosition, row: row, col: col)
 
         // Vertical: smooth sub-line pixel offset
         let vEvents = scrollAccumulator.accumulateVertical(
             deltaY: event.scrollingDeltaY, cellHeight: effectiveCellHeight)
         for e in vEvents {
-            sendScrollEvent(e, row: row, col: col, mods: mods)
+            sendScrollEvent(e, row: targetCell.row, col: targetCell.col, mods: mods)
         }
         scrollPixelOffset = scrollTargetWindowId == nil ? 0 : scrollAccumulator.pixelOffsetY
 
@@ -1335,7 +1341,7 @@ final class EditorNSView: MTKView {
         let hEvents = scrollAccumulator.accumulateHorizontal(
             deltaX: event.scrollingDeltaX, cellWidth: cellWidth)
         for e in hEvents {
-            sendScrollEvent(e, row: row, col: col, mods: mods)
+            sendScrollEvent(e, row: targetCell.row, col: targetCell.col, mods: mods)
         }
 
         // Snap to zero when gesture/momentum ends
@@ -1355,10 +1361,35 @@ final class EditorNSView: MTKView {
         scrollAccumulator.reset()
         scrollPixelOffset = 0
         scrollTargetWindowId = nil
+        scrollTargetCellPosition = nil
+    }
+
+    private func establishSmoothScrollTargetIfNeeded(row: Int16, col: Int16) {
+        if scrollTargetWindowId == nil {
+            scrollTargetWindowId = smoothScrollTargetWindowId(row: row, col: col)
+        }
+
+        if scrollTargetWindowId != nil && scrollTargetCellPosition == nil {
+            scrollTargetCellPosition = (row, col)
+        }
+    }
+
+    nonisolated static func smoothScrollEventCellPosition(targetCell: (row: Int16, col: Int16)?, row: Int16, col: Int16) -> (row: Int16, col: Int16) {
+        targetCell ?? (row, col)
     }
 
     private func smoothScrollTargetWindowId(row: Int16, col: Int16) -> UInt16? {
-        EditorNSView.smoothScrollTargetWindowId(row: row, col: col, windowGutters: dispatcher.frameState.windowGutters)
+        if let contents = guiState?.windowContents {
+            let rowValue = Int(row)
+            let colValue = Int(col)
+            let geometry = contents.values
+                .compactMap(\.paneGeometry)
+                .filter { rowColInCellRect(row: rowValue, col: colValue, rect: $0.contentRect) }
+                .max { lhs, rhs in lhs.contentRect.col < rhs.contentRect.col }
+            if let geometry { return geometry.windowId }
+        }
+
+        return EditorNSView.smoothScrollTargetWindowId(row: row, col: col, windowGutters: dispatcher.frameState.windowGutters)
     }
 
     private func clearSmoothScrollOffsetIfPointerLeftTarget(row: Int16, col: Int16) {
@@ -1600,28 +1631,12 @@ final class EditorNSView: MTKView {
     }
 
     private func dividerHitState(at point: NSPoint) -> DividerCursorState {
-        let fs = dispatcher.frameState
-        let hitHalfTolerance = dividerHitHalfTolerance
-        let displayCellH = effectiveCellHeight
-
-        for vertical in fs.verticalSeparators {
-            let x = CGFloat(vertical.col) * cellWidth
-            let startY = CGFloat(vertical.startRow) * displayCellH
-            let endY = CGFloat(Int(vertical.endRow) + 1) * displayCellH
-            if abs(point.x - x) <= hitHalfTolerance && point.y >= startY && point.y < endY {
-                return .vertical
-            }
+        if let region = dividerHitRegion(at: point) {
+            return region.rect.height > region.rect.width ? .vertical : .horizontal
         }
 
-        for horizontal in fs.horizontalSeparators {
-            let x = CGFloat(horizontal.col) * cellWidth
-            let y = CGFloat(horizontal.row) * displayCellH + (displayCellH * 0.5) - (0.5 / (window?.backingScaleFactor ?? 1.0))
-            let width = CGFloat(horizontal.width) * cellWidth
-            if abs(point.y - y) <= hitHalfTolerance && point.x >= x && point.x < x + width {
-                return .horizontal
-            }
-        }
-
+        if verticalSeparatorColFromFrameState(at: point) != nil { return .vertical }
+        if horizontalSeparatorRowFromFrameState(at: point) != nil { return .horizontal }
         return .none
     }
 
@@ -1699,7 +1714,7 @@ final class EditorNSView: MTKView {
             return (gutter, screenRow - Int(geometry.gutterRect.row))
         }
 
-        for windowId in dispatcher.currentFrameGutterWindowIds {
+        for windowId in dispatcher.currentFrameWindowIds {
             guard let gutter = dispatcher.frameState.windowGutters[windowId] else { continue }
             let startRow = Int(gutter.contentRow)
             let endRow = startRow + Int(gutter.contentHeight)
@@ -1745,37 +1760,17 @@ final class EditorNSView: MTKView {
     }
 
     private func verticalSeparatorCol(at point: NSPoint) -> UInt16? {
-        let fs = dispatcher.frameState
-        let hitHalfTolerance = dividerHitHalfTolerance
-        let displayCellH = effectiveCellHeight
-
-        for vertical in fs.verticalSeparators {
-            let x = CGFloat(vertical.col) * cellWidth
-            let startY = CGFloat(vertical.startRow) * displayCellH
-            let endY = CGFloat(Int(vertical.endRow) + 1) * displayCellH
-            if abs(point.x - x) <= hitHalfTolerance && point.y >= startY && point.y < endY {
-                return vertical.col
-            }
+        if let region = dividerHitRegion(at: point), region.rect.height > region.rect.width {
+            return region.rect.col
         }
-
-        return nil
+        return verticalSeparatorColFromFrameState(at: point)
     }
 
     private func horizontalSeparatorRow(at point: NSPoint) -> UInt16? {
-        let fs = dispatcher.frameState
-        let hitHalfTolerance = dividerHitHalfTolerance
-        let displayCellH = effectiveCellHeight
-
-        for horizontal in fs.horizontalSeparators {
-            let x = CGFloat(horizontal.col) * cellWidth
-            let y = CGFloat(horizontal.row) * displayCellH + (displayCellH * 0.5) - (0.5 / (window?.backingScaleFactor ?? 1.0))
-            let width = CGFloat(horizontal.width) * cellWidth
-            if abs(point.y - y) <= hitHalfTolerance && point.x >= x && point.x < x + width {
-                return horizontal.row
-            }
+        if let region = dividerHitRegion(at: point), region.rect.width >= region.rect.height {
+            return region.rect.row
         }
-
-        return nil
+        return horizontalSeparatorRowFromFrameState(at: point)
     }
 
     private func cellColumn(at point: NSPoint, row: Int16) -> Int16 {
@@ -1804,7 +1799,7 @@ final class EditorNSView: MTKView {
             return gutter
         }
 
-        let windowIds = dispatcher.currentFrameGutterWindowIds.isEmpty ? Set(frameState.windowGutters.keys) : dispatcher.currentFrameGutterWindowIds
+        let windowIds = dispatcher.currentFrameWindowIds.isEmpty ? Set(frameState.windowGutters.keys) : dispatcher.currentFrameWindowIds
 
         return windowIds.compactMap { frameState.windowGutters[$0] }
             .filter { gutter in
@@ -1820,7 +1815,9 @@ final class EditorNSView: MTKView {
     private func paneGeometryGutterHit(at point: NSPoint, screenRow: Int) -> GUIPaneGeometry? {
         paneGeometries(at: point, screenRow: screenRow)
             .filter { geometry in
-                pointInCellRect(point, screenRow: screenRow, rect: geometry.gutterRect)
+                geometry.hitRegions.contains { region in
+                    (region.kind == .gutter || region.kind == .foldControl) && pointInCellRect(point, screenRow: screenRow, rect: region.rect)
+                }
             }
             .max { lhs, rhs in lhs.gutterRect.col < rhs.gutterRect.col }
     }
@@ -1837,6 +1834,74 @@ final class EditorNSView: MTKView {
         return contents.values.compactMap(\.paneGeometry).filter { geometry in
             rowColInCellRect(row: screenRow, col: rawCol, rect: geometry.totalRect)
         }
+    }
+
+    private func hitRegion(at point: NSPoint, kind: GUIHitRegion.Kind) -> GUIHitRegion? {
+        guard let contents = guiState?.windowContents else { return nil }
+        let screenRow = Int(point.y / effectiveCellHeight)
+        let rawCol = Int(point.x / cellWidth)
+
+        return contents.values
+            .compactMap(\.paneGeometry)
+            .flatMap(\.hitRegions)
+            .filter { region in
+                region.kind == kind && rowColInCellRect(row: screenRow, col: rawCol, rect: region.rect)
+            }
+            .max { lhs, rhs in lhs.rect.col < rhs.rect.col }
+    }
+
+    private func dividerHitRegion(at point: NSPoint) -> GUIHitRegion? {
+        guard let contents = guiState?.windowContents else { return nil }
+        let screenRow = Int(point.y / effectiveCellHeight)
+        let rawCol = Int(point.x / cellWidth)
+
+        return contents.values
+            .compactMap(\.paneGeometry)
+            .flatMap(\.hitRegions)
+            .filter { region in
+                region.kind == .divider && pointInDividerHitBounds(point, screenRow: screenRow, rawCol: rawCol, region: region)
+            }
+            .max { lhs, rhs in lhs.rect.col < rhs.rect.col }
+    }
+
+    private func pointInDividerHitBounds(_ point: NSPoint, screenRow: Int, rawCol: Int, region: GUIHitRegion) -> Bool {
+        if region.rect.height > region.rect.width {
+            let startRow = Int(region.rect.row)
+            let endRow = startRow + Int(region.rect.height)
+            return screenRow >= startRow && screenRow < endRow && pointInDividerLineTolerance(point, region: region)
+        }
+
+        let startCol = Int(region.rect.col)
+        let endCol = startCol + Int(region.rect.width)
+        return rawCol >= startCol && rawCol < endCol && pointInDividerLineTolerance(point, region: region)
+    }
+
+    private func pointInDividerLineTolerance(_ point: NSPoint, region: GUIHitRegion) -> Bool {
+        if region.rect.height > region.rect.width {
+            let lineX = CGFloat(region.rect.col) * cellWidth
+            return abs(point.x - lineX) <= dividerHitHalfTolerance
+        }
+
+        let lineY = CGFloat(region.rect.row) * effectiveCellHeight + effectiveCellHeight * 0.5
+        return abs(point.y - lineY) <= dividerHitHalfTolerance
+    }
+
+    private func verticalSeparatorColFromFrameState(at point: NSPoint) -> UInt16? {
+        let screenRow = Int(point.y / effectiveCellHeight)
+        return dispatcher.frameState.verticalSeparators.first { separator in
+            let lineX = CGFloat(separator.col) * cellWidth
+            return screenRow >= Int(separator.startRow) && screenRow <= Int(separator.endRow) && abs(point.x - lineX) <= dividerHitHalfTolerance
+        }?.col
+    }
+
+    private func horizontalSeparatorRowFromFrameState(at point: NSPoint) -> UInt16? {
+        let rawCol = Int(point.x / cellWidth)
+        return dispatcher.frameState.horizontalSeparators.first { separator in
+            let lineY = CGFloat(separator.row) * effectiveCellHeight + effectiveCellHeight * 0.5
+            let startCol = Int(separator.col)
+            let endCol = startCol + Int(separator.width)
+            return rawCol >= startCol && rawCol < endCol && abs(point.y - lineY) <= dividerHitHalfTolerance
+        }?.row
     }
 
     private func pointInCellRect(_ point: NSPoint, screenRow: Int, rect: GUICellRect) -> Bool {

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -1694,6 +1694,11 @@ final class EditorNSView: MTKView {
     private func gutterHit(at point: NSPoint) -> (gutter: Wire.WindowGutter, rowIndex: Int)? {
         let screenRow = Int(point.y / effectiveCellHeight)
 
+        if let geometry = paneGeometryGutterHit(at: point, screenRow: screenRow),
+           let gutter = dispatcher.frameState.windowGutters[geometry.windowId] {
+            return (gutter, screenRow - Int(geometry.gutterRect.row))
+        }
+
         for windowId in dispatcher.currentFrameGutterWindowIds {
             guard let gutter = dispatcher.frameState.windowGutters[windowId] else { continue }
             let startRow = Int(gutter.contentRow)
@@ -1793,6 +1798,12 @@ final class EditorNSView: MTKView {
         guard row >= 0 else { return nil }
         let rowValue = Int(row)
         let frameState = dispatcher.frameState
+
+        if let geometry = paneGeometryHit(at: point, screenRow: rowValue),
+           let gutter = frameState.windowGutters[geometry.windowId] {
+            return gutter
+        }
+
         let windowIds = dispatcher.currentFrameGutterWindowIds.isEmpty ? Set(frameState.windowGutters.keys) : dispatcher.currentFrameGutterWindowIds
 
         return windowIds.compactMap { frameState.windowGutters[$0] }
@@ -1804,6 +1815,41 @@ final class EditorNSView: MTKView {
                 return rowValue >= startRow && rowValue < endRow && point.x >= startX && point.x < endX
             }
             .max { lhs, rhs in lhs.contentCol < rhs.contentCol }
+    }
+
+    private func paneGeometryGutterHit(at point: NSPoint, screenRow: Int) -> GUIPaneGeometry? {
+        paneGeometries(at: point, screenRow: screenRow)
+            .filter { geometry in
+                pointInCellRect(point, screenRow: screenRow, rect: geometry.gutterRect)
+            }
+            .max { lhs, rhs in lhs.gutterRect.col < rhs.gutterRect.col }
+    }
+
+    private func paneGeometryHit(at point: NSPoint, screenRow: Int) -> GUIPaneGeometry? {
+        paneGeometries(at: point, screenRow: screenRow)
+            .max { lhs, rhs in lhs.totalRect.col < rhs.totalRect.col }
+    }
+
+    private func paneGeometries(at point: NSPoint, screenRow: Int) -> [GUIPaneGeometry] {
+        guard let contents = guiState?.windowContents else { return [] }
+        let rawCol = Int(point.x / cellWidth)
+
+        return contents.values.compactMap(\.paneGeometry).filter { geometry in
+            rowColInCellRect(row: screenRow, col: rawCol, rect: geometry.totalRect)
+        }
+    }
+
+    private func pointInCellRect(_ point: NSPoint, screenRow: Int, rect: GUICellRect) -> Bool {
+        let rawCol = Int(point.x / cellWidth)
+        return rowColInCellRect(row: screenRow, col: rawCol, rect: rect)
+    }
+
+    private func rowColInCellRect(row: Int, col: Int, rect: GUICellRect) -> Bool {
+        let startRow = Int(rect.row)
+        let endRow = startRow + Int(rect.height)
+        let startCol = Int(rect.col)
+        let endCol = startCol + Int(rect.width)
+        return row >= startRow && row < endRow && col >= startCol && col < endCol
     }
 
     private func fallbackCellColumn(at point: NSPoint) -> Int16 {

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -50,7 +50,50 @@ struct CommandDispatcherRoutingTests {
         // windowGutters persists through clear (gutter positions are
         // stable between frames, only change on resize/split)
         #expect(dispatcher.frameState.windowGutters[1] != nil)
-        #expect(dispatcher.currentFrameGutterWindowIds.isEmpty)
+        #expect(dispatcher.currentFrameWindowIds.isEmpty)
+    }
+
+    @Test("clear plus batchEnd prunes retained windows when frame has no live window ids")
+    @MainActor func clearBatchEndPrunesEmptyFrame() {
+        let (dispatcher, gui) = makeDispatcher()
+        gui.windowContents[1] = GUIWindowContent(
+            windowId: 1, fullRefresh: false,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+        dispatcher.frameState.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 10,
+            isActive: true, contentWidth: 40, cursorLine: 0, lineNumberStyle: .absolute,
+            lineNumberWidth: 2, signColWidth: 1, entries: []
+        )
+        dispatcher.frameState.windowIndentGuides[1] = IndentGuideData(windowId: 1, tabWidth: 2, activeGuideCol: 0xFFFF, guideCols: [], lineIndentLevels: [])
+        dispatcher.frameState.verticalSeparators = [Wire.VerticalSeparator(col: 20, startRow: 0, endRow: 9)]
+
+        dispatcher.dispatch(.clear)
+        dispatcher.dispatch(.batchEnd)
+
+        #expect(gui.windowContents.isEmpty)
+        #expect(dispatcher.frameState.windowGutters.isEmpty)
+        #expect(dispatcher.frameState.windowIndentGuides.isEmpty)
+        #expect(dispatcher.frameState.verticalSeparators.isEmpty)
+    }
+
+    @Test("metadata-only batchEnd without clear preserves retained windows")
+    @MainActor func metadataOnlyBatchEndPreservesRetainedWindows() {
+        let (dispatcher, gui) = makeDispatcher()
+        gui.windowContents[1] = GUIWindowContent(
+            windowId: 1, fullRefresh: false,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+
+        dispatcher.dispatch(.batchEnd)
+
+        #expect(gui.windowContents[1] != nil)
     }
 
     @Test("setCursor updates frameState cursor position")
@@ -635,7 +678,7 @@ struct CommandDispatcherRoutingTests {
         dispatcher.dispatch(.guiGutter(data: gutter))
 
         #expect(dispatcher.frameState.windowGutters[1] != nil)
-        #expect(dispatcher.currentFrameGutterWindowIds.contains(1))
+        #expect(dispatcher.currentFrameWindowIds.contains(1))
         // Active window gutter syncs gutterCol
         #expect(dispatcher.frameState.gutterCol == 5) // 4 + 1
     }

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -326,6 +326,51 @@ struct CoreTextMetalRendererCursorTests {
         #expect(renderer.cursorAnimationGeneration == 0)
     }
 
+    @Test("hidden active semantic cursor is skipped so visible prompt cursor wins")
+    func hiddenActiveSemanticCursorIsSkippedSoPromptWins() {
+        var frameState = FrameState(cols: 80, rows: 24)
+        frameState.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
+            isActive: true, contentWidth: 80, cursorLine: 1, lineNumberStyle: .none,
+            lineNumberWidth: 0, signColWidth: 0, entries: []
+        )
+        frameState.windowGutters[65_534] = Wire.WindowGutter(
+            windowId: 65_534, contentRow: 21, contentCol: 2, contentHeight: 2,
+            isActive: true, contentWidth: 40, cursorLine: 0, lineNumberStyle: .none,
+            lineNumberWidth: 0, signColWidth: 0, entries: []
+        )
+
+        let hiddenChat = GUIWindowContent(
+            windowId: 1, fullRefresh: true, cursorVisible: false,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+        let visiblePrompt = GUIWindowContent(
+            windowId: 65_534, fullRefresh: true, cursorVisible: true,
+            cursorRow: 0, cursorCol: 3, cursorShape: .beam,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+
+        let cursor = CoreTextMetalRenderer.resolveCursor(
+            frameState: frameState,
+            windowContents: [1: hiddenChat, 65_534: visiblePrompt],
+            cellW: 8,
+            displayCellH: 16,
+            scale: 1,
+            gutterLeftMarginPx: 0,
+            gutterPaddingPx: 0
+        )
+
+        #expect(cursor?.windowId == 65_534)
+        #expect(cursor?.shape == .beam)
+        #expect(cursor?.x == 40)
+        #expect(cursor?.y == 336)
+    }
+
     @Test("hidden semantic cursor suppresses legacy fallback after dispatcher sync")
     @MainActor func hiddenSemanticCursorSuppressesFallback() {
         let gui = GUIState()

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -79,6 +79,7 @@ struct CoreTextMetalRendererCursorTests {
         )
 
         #expect(CoreTextMetalRenderer.visibleTextCols(
+            geometry: nil,
             gutter: gutter,
             frameCols: 100,
             cellW: 8,

--- a/macos/Tests/MingaTests/MouseInputTests.swift
+++ b/macos/Tests/MingaTests/MouseInputTests.swift
@@ -28,6 +28,7 @@ struct MouseInputTests {
         ctRenderer.setupRenderers(fontManager: fm)
         let view = EditorNSView(encoder: spy, fontFace: face, dispatcher: disp,
                                 coreTextRenderer: ctRenderer, fontManager: fm)
+        view.guiState = guiState
         // Give the view a real frame so cellPosition math works.
         // Without a window, convert(_:from:) returns the point unchanged,
         // so locationInWindow IS the local point.
@@ -35,6 +36,32 @@ struct MouseInputTests {
                            width: CGFloat(face.cellWidth) * 80,
                            height: CGFloat(face.cellHeight) * 24)
         return view
+    }
+
+    @MainActor
+    private func installPaneGeometryDivider(view: EditorNSView, dividerCol: UInt16) {
+        let geometry = GUIPaneGeometry(
+            windowId: 1,
+            totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            contentRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            textRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            gutterRect: GUICellRect(row: 0, col: 0, width: 0, height: 24),
+            clipRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            viewport: GUIViewportSummary(top: 0, left: 0, rows: 24, cols: 80, totalLines: 24, visualRowOffset: 0, totalVisualRows: 24),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 0, signColWidth: 0),
+            hitRegions: [
+                GUIHitRegion(kind: .divider, rect: GUICellRect(row: 0, col: dividerCol, width: 0, height: 24), windowId: 1)
+            ]
+        )
+
+        view.guiState?.windowContents[1] = GUIWindowContent(
+            windowId: 1, fullRefresh: true,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [],
+            paneGeometry: geometry
+        )
     }
 
     /// Creates a mouse event at the given pixel position.
@@ -99,6 +126,47 @@ struct MouseInputTests {
         #expect(spy.mouseEventCalls.count == 1)
         #expect(spy.mouseEventCalls[0].row == 5)
         #expect(spy.mouseEventCalls[0].col == 40)
+    }
+
+    @Test("mouseDown outside divider pixel tolerance uses normal cell coordinates")
+    @MainActor func leftMouseDownOutsideVerticalDividerToleranceDoesNotSnap() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy) else { return }
+        let cw = view.cellWidth
+        let ch = view.cellHeight
+
+        view.dispatcher.dispatch(.guiSplitSeparators(
+            borderColor: 0x555555,
+            verticals: [Wire.VerticalSeparator(col: 40, startRow: 0, endRow: 23)],
+            horizontals: []
+        ))
+
+        guard let event = mouseEvent(type: .leftMouseDown, location: NSPoint(x: cw * 40 - cw * 0.75, y: ch * 5.5)) else { return }
+        view.mouseDown(with: event)
+
+        #expect(spy.mouseEventCalls.count == 1)
+        #expect(spy.mouseEventCalls[0].row == 5)
+        #expect(spy.mouseEventCalls[0].col == 39)
+    }
+
+    @Test("mouseDown uses paneGeometry divider tolerance without guiSplitSeparators")
+    @MainActor func leftMouseDownUsesPaneGeometryDividerTolerance() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy) else { return }
+        let cw = view.cellWidth
+        let ch = view.cellHeight
+        installPaneGeometryDivider(view: view, dividerCol: 40)
+
+        guard let leftEvent = mouseEvent(type: .leftMouseDown, location: NSPoint(x: cw * 40 - 1, y: ch * 5.5)) else { return }
+        view.mouseDown(with: leftEvent)
+        guard let rightEvent = mouseEvent(type: .leftMouseDown, location: NSPoint(x: cw * 40 + 1, y: ch * 6.5)) else { return }
+        view.mouseDown(with: rightEvent)
+
+        #expect(spy.mouseEventCalls.count == 2)
+        #expect(spy.mouseEventCalls[0].row == 5)
+        #expect(spy.mouseEventCalls[0].col == 40)
+        #expect(spy.mouseEventCalls[1].row == 6)
+        #expect(spy.mouseEventCalls[1].col == 40)
     }
 
     @Test("mouseDown maps split pane content with per-window gutter padding")
@@ -284,6 +352,17 @@ struct MouseInputTests {
         #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 1, pixelOffset: 4) == false)
         #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 2, pixelOffset: 0) == false)
         #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: nil, pointerWindowId: 2, pixelOffset: 4) == false)
+    }
+
+    @Test("smooth scroll routing keeps the gesture target cell after the pointer moves")
+    func smoothScrollRoutingKeepsGestureTargetCell() {
+        let routedTarget = EditorNSView.smoothScrollEventCellPosition(targetCell: (row: 5, col: 12), row: 5, col: 40)
+        #expect(routedTarget.row == 5)
+        #expect(routedTarget.col == 12)
+
+        let fallbackTarget = EditorNSView.smoothScrollEventCellPosition(targetCell: nil, row: 5, col: 40)
+        #expect(fallbackTarget.row == 5)
+        #expect(fallbackTarget.col == 40)
     }
 
     @Test("mouseMoved sends motion event")

--- a/macos/Tests/MingaTests/SlotAllocatorTests.swift
+++ b/macos/Tests/MingaTests/SlotAllocatorTests.swift
@@ -192,6 +192,26 @@ struct SlotAllocatorCapacityTests {
             Issue.record("Expected .reserved(.newKey) after invalidate, got \(r)"); return
         }
     }
+
+    @Test("invalidateWindow clears only slots for that window")
+    func invalidateWindow() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 4)
+        let win1 = AtlasKey.bufferRow(windowId: 1, row: 0)
+        let win2 = AtlasKey.bufferRow(windowId: 2, row: 0)
+
+        guard case .reserved(let slot1, .newKey) = alloc.lookupOrReserve(key: win1, contentHash: 11) else { Issue.record("Expected win1 reserve"); return }
+        alloc.markUploaded(slotIndex: slot1, contentHash: 11, pixelWidth: 100)
+        guard case .reserved(let slot2, .newKey) = alloc.lookupOrReserve(key: win2, contentHash: 22) else { Issue.record("Expected win2 reserve"); return }
+        alloc.markUploaded(slotIndex: slot2, contentHash: 22, pixelWidth: 100)
+
+        alloc.invalidateWindow(1)
+
+        #expect(alloc.lookupOrReserve(key: win2, contentHash: 22) == .hit(slotIndex: slot2))
+        guard case .reserved(_, .newKey) = alloc.lookupOrReserve(key: win1, contentHash: 11) else {
+            Issue.record("Expected win1 to be evicted by window invalidation"); return
+        }
+    }
 }
 
 @Suite("SlotAllocator — UV Computation")

--- a/macos/Tests/MingaTests/WindowContentRendererTests.swift
+++ b/macos/Tests/MingaTests/WindowContentRendererTests.swift
@@ -207,6 +207,22 @@ struct WindowContentFrameMetricsTests {
         #expect(metrics.atlasHashChanges == 1)
     }
 
+    @Test("Changed content epoch rerasterizes a row with the same row hash")
+    @MainActor func changedContentEpochMetrics() throws {
+        guard let (renderer, atlas) = makeRendererAndAtlas() else { return }
+        let row = GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 42, text: "hello", spans: [])
+
+        atlas.beginFrame()
+        var metrics = FrameMetrics()
+        _ = renderer.renderRowToAtlas(displayRow: 0, row: row, windowId: 1, contentEpoch: 10, atlas: atlas, metrics: &metrics)
+
+        atlas.beginFrame()
+        metrics.reset()
+        _ = renderer.renderRowToAtlas(displayRow: 0, row: row, windowId: 1, contentEpoch: 11, atlas: atlas, metrics: &metrics)
+        #expect(metrics.bufferRowsRasterized == 1)
+        #expect(metrics.atlasHashChanges == 1)
+    }
+
     @Test("Atlas slot demand accounts for split-window texture entries")
     func atlasDemandCountsSplitWindows() {
         let rows = [GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 1, text: "row", spans: [])]

--- a/macos/Tests/MingaTests/WindowContentTests.swift
+++ b/macos/Tests/MingaTests/WindowContentTests.swift
@@ -17,12 +17,14 @@ struct WindowContentBuilder {
     var cursorCol: UInt16 = 0
     var cursorShape: UInt8 = 0  // block
     var scrollLeft: UInt16 = 0
+    var contentEpoch: UInt32?
     var rows: [RowBuilder] = []
     var selectionType: UInt8 = 0
     var selectionCoords: (UInt16, UInt16, UInt16, UInt16)?
     var searchMatches: [(row: UInt16, startCol: UInt16, endCol: UInt16, isCurrent: UInt8)] = []
     var diagnosticRanges: [(startRow: UInt16, startCol: UInt16, endRow: UInt16, endCol: UInt16, severity: UInt8)] = []
     var documentHighlights: [(startRow: UInt16, startCol: UInt16, endRow: UInt16, endCol: UInt16, kind: UInt8)] = []
+    var paneGeometryPayload: Data?
 
     struct RowBuilder {
         var rowType: UInt8 = 0  // normal
@@ -51,6 +53,9 @@ struct WindowContentBuilder {
         appendU16(&headerPayload, cursorCol)
         headerPayload.append(cursorShape)
         appendU16(&headerPayload, scrollLeft)
+        if let contentEpoch {
+            appendU32(&headerPayload, contentEpoch)
+        }
 
         var rowsPayload = Data()
         appendU16(&rowsPayload, UInt16(rows.count))
@@ -112,17 +117,72 @@ struct WindowContentBuilder {
         }
 
         // Build sections
+        var sections: [Data] = [
+            buildSection(0x01, headerPayload),
+            buildSection(0x02, rowsPayload),
+            buildSection(0x03, selPayload),
+            buildSection(0x04, matchPayload),
+            buildSection(0x05, diagPayload),
+            buildSection(0x06, highlightPayload),
+            buildSection(0x07, Data()) // empty annotations
+        ]
+        if let paneGeometryPayload {
+            sections.append(buildSection(0x08, paneGeometryPayload))
+        }
+
         var data = Data()
         data.append(OP_GUI_WINDOW_CONTENT)
-        data.append(7) // section_count
-        data.append(contentsOf: buildSection(0x01, headerPayload))
-        data.append(contentsOf: buildSection(0x02, rowsPayload))
-        data.append(contentsOf: buildSection(0x03, selPayload))
-        data.append(contentsOf: buildSection(0x04, matchPayload))
-        data.append(contentsOf: buildSection(0x05, diagPayload))
-        data.append(contentsOf: buildSection(0x06, highlightPayload))
-        data.append(contentsOf: buildSection(0x07, Data())) // empty annotations
+        data.append(UInt8(sections.count))
+        for section in sections {
+            data.append(contentsOf: section)
+        }
         return data
+    }
+
+    static func samplePaneGeometryPayload(windowId: UInt16 = 7) -> Data {
+        var data = Data()
+        appendU16(&data, windowId)
+        appendRect(&data, row: 1, col: 2, width: 40, height: 12)
+        appendRect(&data, row: 2, col: 3, width: 38, height: 10)
+        appendRect(&data, row: 2, col: 8, width: 33, height: 10)
+        appendRect(&data, row: 2, col: 3, width: 5, height: 10)
+        appendRect(&data, row: 2, col: 8, width: 33, height: 10)
+        appendU32(&data, 5)
+        appendU16(&data, 2)
+        appendU16(&data, 10)
+        appendU16(&data, 33)
+        appendU32(&data, 200)
+        appendU16(&data, 0)
+        appendU32(&data, 20)
+        appendU16(&data, 2)
+        appendU16(&data, 3)
+        data.append(2)
+        data.append(1)
+        appendRect(&data, row: 2, col: 8, width: 33, height: 10)
+        appendU16(&data, windowId)
+        data.append(3)
+        appendRect(&data, row: 2, col: 7, width: 1, height: 10)
+        appendU16(&data, windowId)
+        return data
+    }
+
+    private static func appendRect(_ data: inout Data, row: UInt16, col: UInt16, width: UInt16, height: UInt16) {
+        appendU16(&data, row)
+        appendU16(&data, col)
+        appendU16(&data, width)
+        appendU16(&data, height)
+    }
+
+    private static func appendU16(_ data: inout Data, _ value: UInt16) {
+        data.append(UInt8(value >> 8))
+        data.append(UInt8(value & 0xFF))
+    }
+
+    private static func appendU32(_ data: inout Data, _ value: UInt32) {
+        data.append(UInt8((value >> 24) & 0xFF))
+        data.append(UInt8((value >> 16) & 0xFF))
+        data.append(UInt8((value >> 8) & 0xFF))
+        data.append(UInt8(value & 0xFF))
     }
 
     private func buildSection(_ id: UInt8, _ payload: Data) -> Data {
@@ -229,6 +289,32 @@ struct WindowContentDecoderTests {
         }
         #expect(content3.fullRefresh == false)
         #expect(content3.cursorVisible == true)
+    }
+
+    @Test("Decode content epoch and pane geometry")
+    func decodeContentEpochAndPaneGeometry() throws {
+        var builder = WindowContentBuilder(windowId: 7)
+        builder.contentEpoch = 42
+        builder.paneGeometryPayload = WindowContentBuilder.samplePaneGeometryPayload(windowId: 7)
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.contentEpoch == 42)
+        guard let geometry = content.paneGeometry else {
+            Issue.record("Expected pane geometry"); return
+        }
+
+        #expect(geometry.windowId == 7)
+        #expect(geometry.totalRect == GUICellRect(row: 1, col: 2, width: 40, height: 12))
+        #expect(geometry.textRect == GUICellRect(row: 2, col: 8, width: 33, height: 10))
+        #expect(geometry.viewport.top == 5)
+        #expect(geometry.viewport.totalLines == 200)
+        #expect(geometry.gutterMetrics.lineNumberWidth == 2)
+        #expect(geometry.gutterMetrics.signColWidth == 3)
+        #expect(geometry.hitRegions.map(\.kind) == [.text, .foldControl])
     }
 
     @Test("Decode rows with text and buf_line")

--- a/macos/Tests/MingaTests/WindowContentTests.swift
+++ b/macos/Tests/MingaTests/WindowContentTests.swift
@@ -25,6 +25,7 @@ struct WindowContentBuilder {
     var diagnosticRanges: [(startRow: UInt16, startCol: UInt16, endRow: UInt16, endCol: UInt16, severity: UInt8)] = []
     var documentHighlights: [(startRow: UInt16, startCol: UInt16, endRow: UInt16, endCol: UInt16, kind: UInt8)] = []
     var paneGeometryPayload: Data?
+    var cursorline: (row: UInt16, r: UInt8, g: UInt8, b: UInt8)?
 
     struct RowBuilder {
         var rowType: UInt8 = 0  // normal
@@ -128,6 +129,12 @@ struct WindowContentBuilder {
         ]
         if let paneGeometryPayload {
             sections.append(buildSection(0x08, paneGeometryPayload))
+        }
+        if let cursorline {
+            var payload = Data()
+            appendU16(&payload, cursorline.row)
+            payload.append(contentsOf: [cursorline.r, cursorline.g, cursorline.b])
+            sections.append(buildSection(0x09, payload))
         }
 
         var data = Data()
@@ -315,6 +322,19 @@ struct WindowContentDecoderTests {
         #expect(geometry.gutterMetrics.lineNumberWidth == 2)
         #expect(geometry.gutterMetrics.signColWidth == 3)
         #expect(geometry.hitRegions.map(\.kind) == [.text, .foldControl])
+    }
+
+    @Test("Decode pane-local cursorline")
+    func decodePaneLocalCursorline() throws {
+        var builder = WindowContentBuilder(windowId: 7)
+        builder.cursorline = (row: 3, r: 0x11, g: 0x22, b: 0x33)
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.cursorline == GUICursorline(row: 3, bg: 0x112233))
     }
 
     @Test("Decode rows with text and buf_line")

--- a/test/minga/frontend/adapter/gui/window_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/window_encoder_test.exs
@@ -12,11 +12,15 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
   alias Minga.RenderModel.Window.DocumentHighlight
   alias Minga.RenderModel.Window.Gutter
   alias Minga.RenderModel.Window.GutterEntry
+  alias Minga.RenderModel.Window.GutterMetrics
+  alias Minga.RenderModel.Window.HitRegion
   alias Minga.RenderModel.Window.IndentGuides
+  alias Minga.RenderModel.Window.PaneGeometry
   alias Minga.RenderModel.Window.Row
   alias Minga.RenderModel.Window.SearchMatch
   alias Minga.RenderModel.Window.Selection
   alias Minga.RenderModel.Window.Span
+  alias Minga.RenderModel.Window.Viewport
   alias Minga.Test.GUIWindowDecoder
 
   defp window(opts) do
@@ -38,7 +42,27 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
       gutter: Keyword.get(opts, :gutter, nil),
       cursorline: Keyword.get(opts, :cursorline, nil),
       indent_guides: Keyword.get(opts, :indent_guides, nil),
+      geometry: Keyword.get(opts, :geometry, nil),
+      content_epoch: Keyword.get(opts, :content_epoch, 0),
       full_refresh: Keyword.get(opts, :full_refresh, true)
+    }
+  end
+
+  defp geometry_model do
+    %PaneGeometry{
+      window_id: 1,
+      total_rect: {1, 2, 40, 12},
+      content_rect: {2, 3, 38, 10},
+      text_rect: {2, 8, 33, 10},
+      gutter_rect: {2, 3, 5, 10},
+      clip_rect: {2, 8, 33, 10},
+      viewport: %Viewport{top: 5, left: 2, rows: 10, cols: 33, total_lines: 200},
+      gutter_metrics: %GutterMetrics{line_number_width: 2, sign_col_width: 3},
+      hit_regions: [
+        %HitRegion{kind: :text, rect: {2, 8, 33, 10}, window_id: 1},
+        %HitRegion{kind: :gutter, rect: {2, 3, 5, 10}, window_id: 1},
+        %HitRegion{kind: :fold_control, rect: {2, 7, 1, 10}, window_id: 1}
+      ]
     }
   end
 
@@ -153,6 +177,22 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
     assert hd(decoded.diagnostic_ranges).severity == :warning
     assert hd(decoded.document_highlights).kind == :write
     assert hd(decoded.annotations).text == "hint"
+  end
+
+  test "encodes content epoch and pane geometry" do
+    decoded =
+      window(content_epoch: 42, geometry: geometry_model())
+      |> WindowEncoder.encode_window_content()
+      |> GUIWindowDecoder.decode()
+
+    assert decoded.content_epoch == 42
+    assert decoded.geometry.window_id == 1
+    assert decoded.geometry.total_rect == {1, 2, 40, 12}
+    assert decoded.geometry.text_rect == {2, 8, 33, 10}
+    assert decoded.geometry.viewport.top == 5
+    assert decoded.geometry.viewport.cols == 33
+    assert decoded.geometry.gutter_metrics == %{line_number_width: 2, sign_col_width: 3}
+    assert Enum.map(decoded.geometry.hit_regions, & &1.kind) == [:text, :gutter, :fold_control]
   end
 
   test "encodes every selection type" do

--- a/test/minga/frontend/adapter/gui/window_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/window_encoder_test.exs
@@ -61,7 +61,9 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
       hit_regions: [
         %HitRegion{kind: :text, rect: {2, 8, 33, 10}, window_id: 1},
         %HitRegion{kind: :gutter, rect: {2, 3, 5, 10}, window_id: 1},
-        %HitRegion{kind: :fold_control, rect: {2, 7, 1, 10}, window_id: 1}
+        %HitRegion{kind: :fold_control, rect: {2, 7, 1, 10}, window_id: 1},
+        %HitRegion{kind: :divider, rect: {0, 41, 1, 20}, window_id: 1},
+        %HitRegion{kind: :status_bar, rect: {23, 0, 80, 1}, window_id: 1}
       ]
     }
   end
@@ -192,7 +194,14 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
     assert decoded.geometry.viewport.top == 5
     assert decoded.geometry.viewport.cols == 33
     assert decoded.geometry.gutter_metrics == %{line_number_width: 2, sign_col_width: 3}
-    assert Enum.map(decoded.geometry.hit_regions, & &1.kind) == [:text, :gutter, :fold_control]
+
+    assert Enum.map(decoded.geometry.hit_regions, & &1.kind) == [
+             :text,
+             :gutter,
+             :fold_control,
+             :divider,
+             :status_bar
+           ]
   end
 
   test "encodes every selection type" do
@@ -230,9 +239,11 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
     assert opcodes == [
              Opcodes.gui_window_content(),
              Opcodes.gui_gutter(),
-             Opcodes.gui_cursorline(),
              Opcodes.gui_indent_guides()
            ]
+
+    decoded = commands |> hd() |> GUIWindowDecoder.decode()
+    assert decoded.cursorline == %{row: 6, bg_rgb: 0x112233}
   end
 
   test "adapter re-emits per-frame gutter metadata when window content is cached" do
@@ -243,6 +254,21 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
 
     assert opcodes(first_commands) == [Opcodes.gui_window_content(), Opcodes.gui_gutter()]
     assert opcodes(second_commands) == [Opcodes.gui_gutter()]
+  end
+
+  test "adapter cache reset re-emits unchanged window content after frontend recovery" do
+    model = window(gutter: gutter_model(), content_epoch: 7, full_refresh: true)
+
+    {_first_commands, caches} = AdapterGUI.encode_windows([model], Caches.new())
+    {cached_commands, _caches} = AdapterGUI.encode_windows([model], caches)
+    {recovered_commands, _caches} = AdapterGUI.encode_windows([model], Caches.new())
+
+    assert opcodes(cached_commands) == [Opcodes.gui_gutter()]
+    assert opcodes(recovered_commands) == [Opcodes.gui_window_content(), Opcodes.gui_gutter()]
+
+    recovered_window = recovered_commands |> hd() |> GUIWindowDecoder.decode()
+    assert recovered_window.full_refresh == true
+    assert recovered_window.content_epoch == 7
   end
 
   test "adapter reports per-section byte metrics from emitted commands" do
@@ -287,9 +313,12 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
              cached_metrics.gutter_bytes + cached_metrics.metadata_bytes
   end
 
-  test "adapter skips non-buffer window models until the GUI protocol carries their rect" do
+  test "adapter encodes first-class non-buffer window models" do
     model = window(content_kind: :agent_prompt, window_id: 65_534)
 
-    assert {[], %Caches{}} = AdapterGUI.encode_windows([model], Caches.new())
+    {commands, _caches} = AdapterGUI.encode_windows([model], Caches.new())
+
+    assert opcodes(commands) == [Opcodes.gui_window_content()]
+    assert commands |> hd() |> GUIWindowDecoder.decode() |> Map.fetch!(:window_id) == 65_534
   end
 end

--- a/test/minga/frontend/adapter/gui_test.exs
+++ b/test/minga/frontend/adapter/gui_test.exs
@@ -3,7 +3,47 @@ defmodule Minga.Frontend.Adapter.GUITest do
 
   alias Minga.Frontend.Adapter.GUI
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.WindowEncoder
   alias Minga.RenderModel
+  alias Minga.RenderModel.Cursor
+  alias Minga.RenderModel.UI.GutterSeparator
+  alias Minga.RenderModel.UI.Theme
+  alias Minga.RenderModel.Window
+
+  describe "encode/2" do
+    test "encodes one render model into ordered metal and chrome command groups" do
+      window = %Window{
+        window_id: 1,
+        content_kind: :buffer,
+        rect: {0, 0, 80, 20},
+        rows: [],
+        cursor_row: 0,
+        cursor_col: 0,
+        cursor_shape: :block
+      }
+
+      ui = %RenderModel.UI{
+        theme: %Theme{name: :test, color_slots: [{0x01, 0xFF0000}]},
+        gutter_separator: %GutterSeparator{col: 4, color_rgb: 0x333333}
+      }
+
+      model = RenderModel.new([window], ui, Cursor.new(0, 0, :block), "Minga", 0x101010)
+      encoded = GUI.encode(model, Caches.new())
+
+      assert Enum.map(encoded.metal_commands, &opcode/1) == [
+               WindowEncoder.opcode(),
+               Minga.Protocol.Opcodes.gui_gutter_sep()
+             ]
+
+      assert Enum.map(encoded.chrome_commands, &opcode/1) == [Minga.Protocol.Opcodes.gui_theme()]
+      assert encoded.metrics.window.row_bytes > 0
+      assert encoded.metrics.metal_ui_bytes > 0
+      assert encoded.metrics.chrome_bytes > 0
+      assert encoded.caches.last_window_fps[1] != nil
+      assert encoded.caches.last_gutter_separator_fp != nil
+      assert encoded.caches.last_theme_fp != nil
+    end
+  end
 
   describe "encode_ui/2" do
     test "returns empty commands and unchanged caches for nil theme" do
@@ -14,7 +54,7 @@ defmodule Minga.Frontend.Adapter.GUITest do
     end
 
     test "encodes theme when present" do
-      model = %Minga.RenderModel.UI.Theme{
+      model = %Theme{
         name: :test,
         color_slots: [{0x01, 0xFF0000}]
       }
@@ -29,7 +69,7 @@ defmodule Minga.Frontend.Adapter.GUITest do
     end
 
     test "skips theme on second call with unchanged model" do
-      model = %Minga.RenderModel.UI.Theme{
+      model = %Theme{
         name: :test,
         color_slots: [{0x01, 0xFF0000}]
       }
@@ -43,4 +83,6 @@ defmodule Minga.Frontend.Adapter.GUITest do
       assert cmds == []
     end
   end
+
+  defp opcode(<<opcode, _rest::binary>>), do: opcode
 end

--- a/test/minga_editor/agent/view/prompt_render_window_test.exs
+++ b/test/minga_editor/agent/view/prompt_render_window_test.exs
@@ -64,6 +64,30 @@ defmodule MingaEditor.Agent.View.PromptRenderWindowTest do
       assert Enum.map(model.rows, & &1.text) == ["hello"]
     end
 
+    test "uses row hashes for prompt edits without forcing full refresh" do
+      ctx = prompt_ctx("hello", input_focused: true, cursor: {0, 5}, mode: :insert)
+      model = PromptRenderWindow.build(ctx, 40, {10, 2, 40, 3})
+      old_hash = hd(model.rows).content_hash
+
+      assert model.full_refresh == false
+
+      Buffer.insert_text(ctx.ui_state.panel.prompt_buffer, "!")
+      updated = PromptRenderWindow.build(ctx, 40, {10, 2, 40, 3})
+
+      assert updated.content_epoch == model.content_epoch
+      assert updated.full_refresh == false
+      assert hd(updated.rows).content_hash != old_hash
+    end
+
+    test "bumps prompt content epoch when geometry reset fingerprint changes" do
+      ctx = prompt_ctx("hello", input_focused: true, cursor: {0, 5}, mode: :insert)
+      model = PromptRenderWindow.build(ctx, 40, {10, 2, 40, 3})
+      resized = PromptRenderWindow.build(ctx, 32, {10, 2, 32, 3})
+
+      assert resized.content_epoch != model.content_epoch
+      assert resized.full_refresh == false
+    end
+
     test "maps visual selection into prompt display coordinates" do
       ctx =
         prompt_ctx("abcdef",

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -113,6 +113,82 @@ defmodule MingaEditor.MouseTest do
       assert BufferProcess.cursor(buffer) == {1, 2}
     end
 
+    test "wrapped visual row offset maps top-screen clicks into the visible continuation row" do
+      {state, buffer} = start_mouse_state(String.duplicate("a", 120), width: 20)
+      assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
+      assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
+
+      state =
+        EditorState.update_window(state, state.workspace.windows.active, fn window ->
+          viewport = MingaEditor.Viewport.put_top_visual(window.viewport, 0, 1, 3)
+          Window.set_viewport(window, viewport)
+        end)
+
+      {content_row, content_col} = active_content_origin(state)
+
+      gutter_width =
+        MingaEditor.Mouse.HitTest.buffer_gutter_width(buffer, BufferProcess.line_count(buffer))
+
+      target =
+        MingaEditor.Mouse.HitTest.resolve_buffer(
+          state,
+          content_row,
+          content_col + gutter_width + 2
+        )
+
+      assert {:buffer, target} = target
+      assert MingaEditor.Mouse.Target.Buffer.position(target) == {0, 76}
+
+      state = mouse(state, content_row, content_col + gutter_width + 2, :left, :press)
+
+      assert BufferProcess.cursor(buffer) == {0, 76}
+      assert active_viewport(state).visual_row_offset == 1
+    end
+
+    test "wrapped mouse hit testing uses composed inline virtual text wrap boundaries" do
+      {state, buffer} = start_mouse_state(String.duplicate("a", 100))
+      assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
+      assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
+      assert {:ok, :none} = BufferProcess.set_option(buffer, :line_numbers, :none)
+
+      BufferProcess.add_virtual_text(buffer, {0, 70},
+        placement: :inline,
+        segments: [{String.duplicate("V", 20), Minga.Core.Face.new()}]
+      )
+
+      {content_row, content_col} = active_content_origin(state)
+
+      target = MingaEditor.Mouse.HitTest.resolve_buffer(state, content_row + 1, content_col)
+
+      assert {:buffer, target} = target
+      assert MingaEditor.Mouse.Target.Buffer.position(target) == {0, 70}
+    end
+
+    test "wrapped mouse hit testing does not adjust inline virtual text twice" do
+      {state, buffer} = start_mouse_state(String.duplicate("a", 100))
+      assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
+      assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
+      assert {:ok, :none} = BufferProcess.set_option(buffer, :line_numbers, :none)
+
+      BufferProcess.add_virtual_text(buffer, {0, 70},
+        placement: :inline,
+        segments: [{String.duplicate("V", 20), Minga.Core.Face.new()}]
+      )
+
+      {content_row, content_col} = active_content_origin(state)
+      click_col_after_virtual_text = content_col + 25
+
+      target =
+        MingaEditor.Mouse.HitTest.resolve_buffer(
+          state,
+          content_row + 1,
+          click_col_after_virtual_text
+        )
+
+      assert {:buffer, target} = target
+      assert MingaEditor.Mouse.Target.Buffer.position(target) == {0, 79}
+    end
+
     test "native GUI Ctrl-left click positions the cursor without TUI goto-definition feedback" do
       {state, buffer} = start_mouse_state("hello\nworld\nfoo bar baz")
       state = set_capabilities(state, :native_gui)

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -9,6 +9,10 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
   alias MingaEditor.RenderPipeline.Scroll
   alias MingaEditor.Renderer.Context
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Windows
+  alias MingaEditor.Viewport
+  alias MingaEditor.Window, as: EditorWindow
+  alias MingaEditor.WindowTree
   alias Minga.RenderModel.Window
 
   import MingaEditor.RenderPipeline.TestHelpers
@@ -74,9 +78,53 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       assert model.geometry.viewport.rows == 23
       assert model.geometry.gutter_metrics.line_number_width == 3
       assert model.geometry.gutter_metrics.sign_col_width == 3
+
+      assert Enum.find(model.geometry.hit_regions, &(&1.kind == :fold_control)).rect ==
+               {0, 2, 1, 23}
+
       assert Enum.map(model.geometry.hit_regions, & &1.kind) == [:text, :gutter, :fold_control]
       assert is_integer(model.content_epoch)
       assert model.full_refresh == true
+    end
+
+    test "split pane geometry includes divider hit regions" do
+      state = gui_state(content: "left\nright")
+      buffer = state.workspace.buffers.active
+      {:ok, tree} = WindowTree.split(state.workspace.windows.tree, 1, :vertical, 2)
+      second = EditorWindow.new(2, buffer, 24, 80)
+
+      windows = %Windows{
+        state.workspace.windows
+        | tree: tree,
+          map: Map.put(state.workspace.windows.map, 2, second),
+          next_id: 3
+      }
+
+      state = %{state | workspace: %{state.workspace | windows: windows}}
+
+      {[left, right], _cursor, _state} = build_content(state)
+
+      divider_regions =
+        [left.window_model, right.window_model]
+        |> Enum.flat_map(& &1.geometry.hit_regions)
+        |> Enum.filter(&(&1.kind == :divider))
+
+      assert Enum.any?(divider_regions, &(&1.rect == {0, 39, 1, 23}))
+    end
+
+    test "ordinary buffer edits change row hashes without bumping content epoch or forcing refresh" do
+      state = gui_state(content: "hello")
+      {[wf], _cursor, state} = build_content(state)
+      epoch = wf.window_model.content_epoch
+      old_hash = hd(wf.window_model.rows).content_hash
+      assert wf.window_model.full_refresh == true
+
+      :ok = BufferProcess.insert_text(state.workspace.buffers.active, "!")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert wf.window_model.content_epoch == epoch
+      assert wf.window_model.full_refresh == false
+      assert hd(wf.window_model.rows).content_hash != old_hash
     end
 
     test "wrapped lines produce continuation rows and cursor coordinates inside the visual row" do
@@ -106,6 +154,37 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       {[wf], _cursor, _state} = build_content(state)
 
       assert wf.window_model.geometry.viewport.total_visual_rows == 20
+    end
+
+    test "wrapped selection starts at the pane edge when visual row offset hides its start" do
+      content = "\tabcdef界ghijABCDEFGHIJ"
+      state = gui_state(rows: 3, cols: 18, content: content)
+      buffer = state.workspace.buffers.active
+      assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
+      assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
+      assert {:ok, 4} = BufferProcess.set_option(buffer, :tab_width, 4)
+      :ok = BufferProcess.move_to(buffer, {0, 16})
+
+      win_id = state.workspace.windows.active
+      window = Map.fetch!(state.workspace.windows.map, win_id)
+      viewport = Viewport.put_top_visual(window.viewport, 0, 1, 3)
+      window = EditorWindow.set_viewport(window, viewport)
+
+      windows =
+        Windows.set_map(
+          state.workspace.windows,
+          Map.put(state.workspace.windows.map, win_id, window)
+        )
+
+      state = %{state | workspace: %{state.workspace | windows: windows}}
+
+      model = build_window_model(state, visual_selection: {:char, {0, 0}, {0, 17}})
+
+      assert hd(model.rows).row_type == :wrap_continuation
+      assert model.selection.start_row == 0
+      assert model.selection.start_col == 0
+      assert model.selection.end_row >= 0
+      assert model.selection.end_col > model.selection.start_col
     end
 
     test "wrapped overlay coordinates use visual rows and byte columns after previous wraps" do

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -1,9 +1,13 @@
 defmodule MingaEditor.RenderModel.Window.BuilderTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Editing.Search.Match
   alias MingaEditor.Layout
+  alias MingaEditor.RenderModel.Window.Builder
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Scroll
+  alias MingaEditor.Renderer.Context
   alias MingaEditor.State, as: EditorState
   alias Minga.RenderModel.Window
 
@@ -17,6 +21,33 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
     Content.build_content(state, scrolls)
   end
 
+  defp build_window_model(state, ctx_overrides) do
+    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+    scroll = scrolls |> Map.values() |> hd()
+
+    ctx =
+      struct!(
+        Context,
+        Keyword.merge(
+          [
+            viewport: scroll.viewport,
+            gutter_w: scroll.gutter_w,
+            content_w: scroll.content_w,
+            is_gui: true,
+            wrap_on: scroll.wrap_on,
+            line_number_style: scroll.line_number_style,
+            width_oracle: scroll.width_oracle
+          ],
+          ctx_overrides
+        )
+      )
+
+    Builder.build(state, scroll, ctx)
+  end
+
   describe "GUI content stage" do
     test "builds a canonical window model and no GUI draw layers" do
       state = gui_state(content: "hello\nworld")
@@ -28,6 +59,73 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       assert wf.gutter == %{}
       assert wf.lines == %{}
       assert wf.tilde_lines == %{}
+    end
+
+    test "includes pane geometry and content epoch for GUI windows" do
+      state = gui_state(content: "hello\nworld")
+      {[wf], _cursor, _state} = build_content(state)
+      model = wf.window_model
+
+      assert model.geometry.window_id == state.workspace.windows.active
+      assert model.geometry.total_rect == {0, 0, 80, 23}
+      assert model.geometry.content_rect == {0, 0, 80, 23}
+      assert model.geometry.gutter_rect == {0, 0, 6, 23}
+      assert model.geometry.text_rect == {0, 6, 74, 23}
+      assert model.geometry.viewport.rows == 23
+      assert model.geometry.gutter_metrics.line_number_width == 3
+      assert model.geometry.gutter_metrics.sign_col_width == 3
+      assert Enum.map(model.geometry.hit_regions, & &1.kind) == [:text, :gutter, :fold_control]
+      assert is_integer(model.content_epoch)
+      assert model.full_refresh == true
+    end
+
+    test "wrapped lines produce continuation rows and cursor coordinates inside the visual row" do
+      state = gui_state(cols: 20, content: "abcdefghijABCDEFGHIJ")
+      buffer = state.workspace.buffers.active
+      assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
+      assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
+      :ok = BufferProcess.move_to(buffer, {0, 12})
+
+      {[wf], _cursor, _state} = build_content(state)
+      model = wf.window_model
+
+      assert Enum.map(model.rows, & &1.row_type) == [:normal, :wrap_continuation]
+      assert Enum.map(model.rows, & &1.visual_index) == [0, 1]
+      assert Enum.map(model.rows, & &1.text) == ["abcdefghijABCD", "EFGHIJ"]
+      assert model.cursor_row == 0
+      assert model.cursor_col == 12
+    end
+
+    test "wrapped geometry reports total visual rows for the whole buffer" do
+      content = Enum.map_join(1..10, "\n", fn _idx -> "abcdefghijABCDEFGHIJ" end)
+      state = gui_state(rows: 4, cols: 20, content: content)
+      buffer = state.workspace.buffers.active
+      assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
+      assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
+
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert wf.window_model.geometry.viewport.total_visual_rows == 20
+    end
+
+    test "wrapped overlay coordinates use visual rows and byte columns after previous wraps" do
+      state = gui_state(cols: 20, content: "abcdefghijABCDEFGHIJ\nétarget")
+      buffer = state.workspace.buffers.active
+      assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
+      assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
+
+      model =
+        build_window_model(
+          state,
+          search_matches: [Match.new(1, 2, 6)],
+          visual_selection: {:char, {1, 0}, {1, 7}}
+        )
+
+      assert Enum.map(model.rows, & &1.text) == ["abcdefghijABCD", "EFGHIJ", "étarget"]
+      assert [%{row: 2, start_col: 1, end_col: 7}] = model.search_matches
+      assert model.selection.start_row == 2
+      assert model.selection.end_row == 2
+      assert model.selection.end_col == 7
     end
 
     test "includes gutter and indent guide models built from current-frame data" do

--- a/test/minga_editor/render_pipeline/scroll_test.exs
+++ b/test/minga_editor/render_pipeline/scroll_test.exs
@@ -69,6 +69,19 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
       assert "gamma" in scroll.lines
     end
 
+    test "wrapped total visual rows cache is persisted on the returned window state" do
+      content = Enum.map_join(1..10, "\n", fn _idx -> "abcdefghijklmnopqrstuv" end)
+      state = gui_state(rows: 4, cols: 20, content: content)
+      buffer = state.workspace.buffers.active
+      assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
+      assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
+
+      {_scrolls, state, _layout} = run_through_scroll(state)
+      window = Map.fetch!(state.workspace.windows.map, state.workspace.windows.active)
+
+      assert {_cache_key, 20} = window.render_cache.total_visual_rows_cache
+    end
+
     test "scroll result has correct cursor at line 0" do
       state = base_state()
       {scrolls, _state, _layout} = run_through_scroll(state)

--- a/test/minga_editor/window/render_cache_test.exs
+++ b/test/minga_editor/window/render_cache_test.exs
@@ -35,5 +35,67 @@ defmodule MingaEditor.Window.RenderCacheTest do
 
       assert cache.dirty_lines == :all
     end
+
+    test "line count changes dirty rows without requesting retained epoch reset" do
+      {cache, epoch, _full_refresh?} =
+        RenderCache.reset()
+        |> RenderCache.prepare_epoch({:window, 1, :geometry})
+
+      cache =
+        cache
+        |> RenderCache.snapshot(0, 0, 4, 3, 1, 1, :ctx)
+        |> RenderCache.detect_invalidation(0, 0, 4, 4, 2, 1)
+
+      assert cache.dirty_lines == :all
+
+      {_cache, next_epoch, full_refresh?} =
+        RenderCache.prepare_epoch(cache, {:window, 1, :geometry})
+
+      assert next_epoch == epoch
+      assert full_refresh? == false
+    end
+  end
+
+  describe "prepare_epoch/2" do
+    test "keeps epoch stable and full_refresh false when reset fingerprint is unchanged" do
+      {cache, epoch, full_refresh?} =
+        RenderCache.reset()
+        |> RenderCache.prepare_epoch({:window, 1, :geometry})
+
+      assert epoch == 1
+      assert full_refresh? == true
+
+      {_cache, next_epoch, next_full_refresh?} =
+        RenderCache.prepare_epoch(cache, {:window, 1, :geometry})
+
+      assert next_epoch == epoch
+      assert next_full_refresh? == false
+    end
+
+    test "bumps epoch and full_refresh when reset fingerprint changes" do
+      {cache, epoch, _full_refresh?} =
+        RenderCache.reset()
+        |> RenderCache.prepare_epoch({:window, 1, :geometry})
+
+      {_cache, next_epoch, next_full_refresh?} =
+        RenderCache.prepare_epoch(cache, {:window, 1, :resized})
+
+      assert next_epoch == epoch + 1
+      assert next_full_refresh? == true
+    end
+
+    test "frontend reset marker bumps epoch and requests a full refresh for unchanged geometry" do
+      {cache, epoch, _full_refresh?} =
+        RenderCache.reset()
+        |> RenderCache.prepare_epoch({:window, 1, :geometry})
+
+      cache = RenderCache.mark_reset_pending(cache)
+
+      {_cache, next_epoch, full_refresh?} =
+        RenderCache.prepare_epoch(cache, {:window, 1, :geometry})
+
+      assert next_epoch == epoch + 1
+      assert full_refresh? == true
+    end
   end
 end

--- a/test/support/gui_window_decoder.ex
+++ b/test/support/gui_window_decoder.ex
@@ -28,7 +28,8 @@ defmodule Minga.Test.GUIWindowDecoder do
       diagnostic_ranges: [],
       document_highlights: [],
       annotations: [],
-      geometry: nil
+      geometry: nil,
+      cursorline: nil
     }
 
     {result, <<>>} = decode_sections(rest, section_count, result)
@@ -98,6 +99,10 @@ defmodule Minga.Test.GUIWindowDecoder do
     %{result | geometry: geometry}
   end
 
+  defp decode_section(0x09, <<row::16, r::8, g::8, b::8>>, result) do
+    %{result | cursorline: %{row: row, bg_rgb: r <<< 16 ||| g <<< 8 ||| b}}
+  end
+
   defp decode_section(_unknown, _payload, result), do: result
 
   defp decode_content_epoch(<<content_epoch::32, _rest::binary>>), do: content_epoch
@@ -153,6 +158,7 @@ defmodule Minga.Test.GUIWindowDecoder do
   defp decode_hit_kind(3), do: :fold_control
   defp decode_hit_kind(4), do: :modeline
   defp decode_hit_kind(5), do: :divider
+  defp decode_hit_kind(6), do: :status_bar
 
   # ── Rows ─────────────────────────────────────────────────────────────────
 

--- a/test/support/gui_window_decoder.ex
+++ b/test/support/gui_window_decoder.ex
@@ -21,12 +21,14 @@ defmodule Minga.Test.GUIWindowDecoder do
       cursor_col: 0,
       cursor_shape: :block,
       scroll_left: 0,
+      content_epoch: 0,
       rows: [],
       selection: nil,
       search_matches: [],
       diagnostic_ranges: [],
       document_highlights: [],
-      annotations: []
+      annotations: [],
+      geometry: nil
     }
 
     {result, <<>>} = decode_sections(rest, section_count, result)
@@ -45,8 +47,8 @@ defmodule Minga.Test.GUIWindowDecoder do
   end
 
   defp decode_section(0x01, payload, result) do
-    <<window_id::16, flags::8, cursor_row::16, cursor_col::16, cursor_shape::8, scroll_left::16>> =
-      payload
+    <<window_id::16, flags::8, cursor_row::16, cursor_col::16, cursor_shape::8, scroll_left::16,
+      rest::binary>> = payload
 
     %{
       result
@@ -56,7 +58,8 @@ defmodule Minga.Test.GUIWindowDecoder do
         cursor_row: cursor_row,
         cursor_col: cursor_col,
         cursor_shape: decode_cursor_shape(cursor_shape),
-        scroll_left: scroll_left
+        scroll_left: scroll_left,
+        content_epoch: decode_content_epoch(rest)
     }
   end
 
@@ -90,7 +93,66 @@ defmodule Minga.Test.GUIWindowDecoder do
     %{result | annotations: annotations}
   end
 
+  defp decode_section(0x08, payload, result) do
+    {geometry, <<>>} = decode_geometry(payload)
+    %{result | geometry: geometry}
+  end
+
   defp decode_section(_unknown, _payload, result), do: result
+
+  defp decode_content_epoch(<<content_epoch::32, _rest::binary>>), do: content_epoch
+  defp decode_content_epoch(_rest), do: 0
+
+  defp decode_geometry(
+         <<window_id::16, total::binary-size(8), content::binary-size(8), text::binary-size(8),
+           gutter::binary-size(8), clip::binary-size(8), viewport_top::32, viewport_left::16,
+           viewport_rows::16, viewport_cols::16, total_lines::32, visual_row_offset::16,
+           total_visual_rows::32, line_number_width::16, sign_col_width::16, hit_count::8,
+           rest::binary>>
+       ) do
+    {hit_regions, rest} = decode_hit_regions(rest, hit_count, [])
+
+    geometry = %{
+      window_id: window_id,
+      total_rect: decode_rect(total),
+      content_rect: decode_rect(content),
+      text_rect: decode_rect(text),
+      gutter_rect: decode_rect(gutter),
+      clip_rect: decode_rect(clip),
+      viewport: %{
+        top: viewport_top,
+        left: viewport_left,
+        rows: viewport_rows,
+        cols: viewport_cols,
+        total_lines: total_lines,
+        visual_row_offset: visual_row_offset,
+        total_visual_rows: total_visual_rows
+      },
+      gutter_metrics: %{line_number_width: line_number_width, sign_col_width: sign_col_width},
+      hit_regions: hit_regions
+    }
+
+    {geometry, rest}
+  end
+
+  defp decode_rect(<<row::16, col::16, width::16, height::16>>), do: {row, col, width, height}
+
+  defp decode_hit_regions(rest, 0, acc), do: {Enum.reverse(acc), rest}
+
+  defp decode_hit_regions(
+         <<kind::8, rect::binary-size(8), window_id::16, rest::binary>>,
+         remaining,
+         acc
+       ) do
+    region = %{kind: decode_hit_kind(kind), rect: decode_rect(rect), window_id: window_id}
+    decode_hit_regions(rest, remaining - 1, [region | acc])
+  end
+
+  defp decode_hit_kind(1), do: :text
+  defp decode_hit_kind(2), do: :gutter
+  defp decode_hit_kind(3), do: :fold_control
+  defp decode_hit_kind(4), do: :modeline
+  defp decode_hit_kind(5), do: :divider
 
   # ── Rows ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
# TL;DR
This implements Phase 1 and Phase 2 of `docs/RETAINED_GUI_RENDERING_SPEC.md`. The GUI emit path now builds one retained render model and encodes window content, chrome, pane geometry, wrapping, and retained-resource epochs from that model.

## Context
Phase 0 already moved the legacy GUI emit path toward semantic GUI commands. This PR completes the next two phases: one BEAM-owned render model feeds the GUI adapter, and buffer, agent, and prompt windows now carry enough retained geometry for Swift to render and hit-test panes without relying on parallel layout inference.

Phase 3 semantic UI model migration is intentionally deferred. This PR keeps that debt isolated unless it directly affects Phase 1 or Phase 2 correctness.

## Changes
- Added the top-level `Minga.RenderModel` and cursor/window geometry structs for GUI adapters.
- Added `MingaEditor.RenderModel.Builder` so GUI emission uses one render model instead of separate window and UI adapter paths.
- Added `Minga.Frontend.Adapter.GUI.EncodedFrame` so encoded Metal-critical commands and SwiftUI chrome commands keep an explicit order and cache contract.
- Extended `Minga.RenderModel.Window` with pane geometry, hit regions, content epochs, full-refresh flags, wrapped visual row indexes, and whole-buffer wrapped visual row counts.
- Updated the `gui_window_content` encoder and decoder with `content_epoch`, pane geometry section `0x08`, and pane-local cursorline section `0x09`.
- Reset retained GUI state on frontend ready/protocol recovery so Swift does not reuse stale retained resources across reconnects.
- Updated BEAM mouse hit testing to use composed/decorated wrapped rows, including inline virtual text, before mapping clicks back to buffer columns.
- Added first-class prompt render-window metadata so Swift cursor ownership is deterministic for agent chat plus prompt content.
- Updated Swift pane-geometry hit testing, divider pixel tolerance, smooth-scroll gesture routing, CoreText/Metal text rects, clip bounds, cursor placement, scroll indicator sizing, stale geometry pruning, and retained atlas invalidation.
- Aligned fold-control hit regions with the sign/fold gutter column used by the renderer.
- Added regression coverage for geometry round trips, wrapped rows, virtual-text mouse mapping, protocol recovery resets, prompt cursor priority, pane-local cursorline rendering, smooth-scroll target routing, fold-control geometry, and stale retained geometry pruning.

## Verification
- `git diff --check` passed.
- `make lint` passed.
- `mix test.llm` passed: 8954 tests, 56 doctests, 91 properties, 0 failures, 285 excluded.
- Focused retained-render tests passed: 87 tests, 0 failures.
- Round-loop focused tests passed: 19 tests, 0 failures.
- `mix protocol.gen --check` passed.
- `mix swift.build` skipped because `xcodebuild` is not available in this environment.
- `mix swift.harness` skipped because `swiftc` is not available in this environment.
- Final reviewer gate passed.
- Parent-orchestrated review loop reached PASS in round 2; the remaining round-2 item was a docs wording fix, validated by the parent without another material review round.

## Acceptance Criteria Addressed
- Phase 1 GUI emit path builds and encodes from one retained render model. ✅
- Phase 2 GUI window model includes pane geometry, content epochs, wrapped visual rows, retained reset boundaries, and Swift-side geometry consumers. ✅
- Retained GUI protocol docs and encode/decode tests cover the new wire fields. ✅
