### PR TITLE
fix(macos): keep picker matches inline

### DIFF
--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -492,12 +492,12 @@ defmodule Minga.Project do
 
   @spec add_to_known(t(), String.t()) :: t()
   defp add_to_known(state, root) do
-    if root in state.known_projects do
-      state
-    else
+    if persistable_known_project?(root) and root not in state.known_projects do
       new_known = [root | state.known_projects]
       if persist_known_projects?(), do: persist_known_projects(new_known)
       %{state | known_projects: new_known}
+    else
+      state
     end
   end
 
@@ -534,12 +534,32 @@ defmodule Minga.Project do
       {:ok, content} ->
         content
         |> String.split("\n", trim: true)
-        |> Enum.filter(&File.dir?/1)
+        |> Enum.filter(&(File.dir?(&1) and persistable_known_project?(&1)))
 
       {:error, _} ->
         []
     end
   end
+
+  @spec persistable_known_project?(String.t()) :: boolean()
+  defp persistable_known_project?(root) when is_binary(root) do
+    root
+    |> Path.split()
+    |> test_fixture_project_segments?()
+    |> Kernel.not()
+  end
+
+  @spec test_fixture_project_segments?([String.t()]) :: boolean()
+  defp test_fixture_project_segments?(["tmp", module_dir | rest]) do
+    test_fixture_module_dir?(module_dir) or test_fixture_project_segments?([module_dir | rest])
+  end
+
+  defp test_fixture_project_segments?([_head | rest]), do: test_fixture_project_segments?(rest)
+  defp test_fixture_project_segments?([]), do: false
+
+  @spec test_fixture_module_dir?(String.t()) :: boolean()
+  defp test_fixture_module_dir?("MingaEditor." <> _rest), do: true
+  defp test_fixture_module_dir?(_module_dir), do: false
 
   @spec make_relative(String.t(), String.t()) :: String.t() | nil
   defp make_relative(abs_path, root) do

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -254,10 +254,12 @@ struct PickerOverlay: View {
 
     @ViewBuilder
     private func itemIcon(_ item: PickerItem) -> some View {
-        Text(item.icon)
-            .font(.custom("Symbols Nerd Font Mono", size: 13))
-            .foregroundStyle(iconColor(item.iconColor))
-            .frame(width: 18, alignment: .center)
+        if item.hasLeadingIcon {
+            Text(item.icon)
+                .font(.custom("Symbols Nerd Font Mono", size: 13))
+                .foregroundStyle(iconColor(item.iconColor))
+                .frame(width: 18, alignment: .center)
+        }
     }
 
     @ViewBuilder

--- a/macos/Sources/Views/PickerState.swift
+++ b/macos/Sources/Views/PickerState.swift
@@ -16,25 +16,36 @@ struct PickerItem: Identifiable {
     let isTwoLine: Bool
     let isMarked: Bool
 
-    /// Extract the first character as the icon (Nerd Font devicon).
+    /// Whether the label starts with a separate icon glyph.
+    var hasLeadingIcon: Bool {
+        guard let first = label.first else { return false }
+        return first.isPrivateUseScalar
+    }
+
+    /// Extract the leading icon glyph when the label intentionally includes one.
     var icon: String {
-        guard let first = label.first else { return "" }
+        guard hasLeadingIcon, let first = label.first else { return "" }
         return String(first)
     }
 
-    /// The label text without the leading icon character.
+    /// The label text without the leading icon glyph and its spacer.
     var displayLabel: String {
-        guard label.count > 1 else { return label }
-        return String(label.dropFirst())
+        String(label.dropFirst(displayPrefixLength))
     }
 
-    /// Match positions adjusted for the display label (offset by -1 to skip icon).
+    /// Match positions adjusted for the visible label after removing an icon prefix.
     /// Only includes positions that fall within the display label range.
     var displayMatchPositions: Set<Int> {
         Set(matchPositions.compactMap { pos in
-            let adjusted = Int(pos) - 1  // Skip icon character
+            let adjusted = Int(pos) - displayPrefixLength
             return adjusted >= 0 && adjusted < displayLabel.count ? adjusted : nil
         })
+    }
+
+    private var displayPrefixLength: Int {
+        guard hasLeadingIcon else { return 0 }
+        let afterIcon = label.dropFirst()
+        return afterIcon.first == " " ? 2 : 1
     }
 }
 
@@ -136,5 +147,16 @@ final class PickerState {
         hasPreview = false
         loadStatus = .ready
         actionMenu = nil
+    }
+}
+
+private extension Character {
+    var isPrivateUseScalar: Bool {
+        unicodeScalars.contains { scalar in
+            let value = scalar.value
+            return (value >= 0xE000 && value <= 0xF8FF) ||
+                (value >= 0xF0000 && value <= 0xFFFFD) ||
+                (value >= 0x100000 && value <= 0x10FFFD)
+        }
     }
 }

--- a/macos/Tests/MingaTests/ViewModelComputedTests.swift
+++ b/macos/Tests/MingaTests/ViewModelComputedTests.swift
@@ -13,12 +13,13 @@ import Foundation
 @Suite("PickerItem Computed Properties")
 struct PickerItemComputedTests {
 
-    @Test("icon extracts first character of label")
-    func iconExtraction() {
+    @Test("icon is empty for plain labels")
+    func iconPlainLabel() {
         let item = PickerItem(id: 0, iconColor: 0, label: "editor.ex",
                              description: "", annotation: "",
                              matchPositions: [], isTwoLine: false, isMarked: false)
-        #expect(item.icon == "e")
+        #expect(item.hasLeadingIcon == false)
+        #expect(item.icon == "")
     }
 
     @Test("icon returns empty string for empty label")
@@ -35,15 +36,33 @@ struct PickerItemComputedTests {
         let item = PickerItem(id: 0, iconColor: 0, label: "\u{F024B}lib",
                              description: "", annotation: "",
                              matchPositions: [], isTwoLine: false, isMarked: false)
+        #expect(item.hasLeadingIcon == true)
         #expect(item.icon == "\u{F024B}")
     }
 
-    @Test("displayLabel drops first character (icon)")
-    func displayLabel() {
+    @Test("displayLabel keeps plain labels intact")
+    func displayLabelPlainText() {
         let item = PickerItem(id: 0, iconColor: 0, label: "editor.ex",
                              description: "", annotation: "",
                              matchPositions: [], isTwoLine: false, isMarked: false)
-        #expect(item.displayLabel == "ditor.ex")
+        #expect(item.displayLabel == "editor.ex")
+    }
+
+    @Test("displayLabel keeps colored plain labels intact")
+    func displayLabelColoredPlainText() {
+        let item = PickerItem(id: 0, iconColor: 0x51AFEF, label: "Workspace",
+                             description: "", annotation: "",
+                             matchPositions: [], isTwoLine: false, isMarked: false)
+        #expect(item.hasLeadingIcon == false)
+        #expect(item.displayLabel == "Workspace")
+    }
+
+    @Test("displayLabel drops icon and spacer")
+    func displayLabelWithIconAndSpacer() {
+        let item = PickerItem(id: 0, iconColor: 0x51AFEF, label: "\u{F024B} lib",
+                             description: "", annotation: "",
+                             matchPositions: [], isTwoLine: false, isMarked: false)
+        #expect(item.displayLabel == "lib")
     }
 
     @Test("displayLabel returns full label when single character")
@@ -54,16 +73,22 @@ struct PickerItemComputedTests {
         #expect(item.displayLabel == "x")
     }
 
-    @Test("displayMatchPositions adjusts by -1 and filters negatives")
-    func matchPositionAdjustment() {
-        // Label: "editor.ex" -> icon='e', displayLabel="ditor.ex"
-        // Match at position 0 (the icon) should be filtered out (adjusted to -1)
-        // Match at position 1 ('d') should become 0
-        // Match at position 4 ('o') should become 3
+    @Test("displayMatchPositions keeps plain label positions")
+    func matchPositionPlainLabel() {
         let item = PickerItem(id: 0, iconColor: 0, label: "editor.ex",
                              description: "", annotation: "",
                              matchPositions: [0, 1, 4], isTwoLine: false, isMarked: false)
-        #expect(item.displayMatchPositions == Set([0, 3]))
+        #expect(item.displayMatchPositions == Set([0, 1, 4]))
+    }
+
+    @Test("displayMatchPositions adjusts for icon and spacer")
+    func matchPositionIconAdjustment() {
+        // Label: "icon lib" -> displayLabel="lib"
+        // Match positions in the removed icon/spacer prefix are filtered out.
+        let item = PickerItem(id: 0, iconColor: 0x51AFEF, label: "\u{F024B} lib",
+                             description: "", annotation: "",
+                             matchPositions: [0, 2, 4], isTwoLine: false, isMarked: false)
+        #expect(item.displayMatchPositions == Set([0, 2]))
     }
 
     @Test("displayMatchPositions with no matches returns empty set")
@@ -76,8 +101,6 @@ struct PickerItemComputedTests {
 
     @Test("displayMatchPositions filters positions beyond label range")
     func matchPositionOutOfRange() {
-        // Label: "ab" -> displayLabel="b" (length 1)
-        // Match at position 5 -> adjusted to 4, which is >= displayLabel.count
         let item = PickerItem(id: 0, iconColor: 0, label: "ab",
                              description: "", annotation: "",
                              matchPositions: [5], isTwoLine: false, isMarked: false)

--- a/test/minga/project_test.exs
+++ b/test/minga/project_test.exs
@@ -188,6 +188,26 @@ defmodule Minga.ProjectTest do
 
       assert project in Project.known_projects(name)
     end
+
+    test "does not add test fixture tmp projects to known projects", %{tmp_dir: tmp} do
+      project =
+        Path.join([
+          tmp,
+          "tmp",
+          "MingaEditor.UI.Picker.FileSourceTest",
+          "test-files-opened",
+          "frecency_picker_project_123"
+        ])
+
+      File.mkdir_p!(project)
+
+      {_pid, name} = start_project!()
+      Project.switch(name, project)
+      flush(name)
+
+      assert Project.root(name) == project
+      refute project in Project.known_projects(name)
+    end
   end
 
   describe "invalidate/1" do
@@ -238,6 +258,25 @@ defmodule Minga.ProjectTest do
       flush(name)
 
       refute bogus in Project.known_projects(name)
+    end
+
+    test "add ignores test fixture tmp projects", %{tmp_dir: tmp} do
+      project =
+        Path.join([
+          tmp,
+          "tmp",
+          "MingaEditor.DropOpenDirectoryTest",
+          "test-dropping-a-directory",
+          "project"
+        ])
+
+      File.mkdir_p!(project)
+
+      {_pid, name} = start_project!()
+      Project.add(name, project)
+      flush(name)
+
+      refute project in Project.known_projects(name)
     end
   end
 


### PR DESCRIPTION
# TL;DR
Fixes the macOS picker row model so plain project names stay intact and fuzzy-match highlights remain inline. Also prevents MingaEditor test fixture projects under worktree `tmp/` directories from showing up in the persisted project switcher.

## Context
The project picker was visually splitting the first character of plain labels into the icon slot. That made entries like `frecency_select_project_83682` render as a standalone `f` plus the rest of the label, which looked like unexplained metadata instead of fuzzy-match highlighting.

The same picker also exposed persisted temp projects created by integration tests because known projects were loaded directly from `~/.config/minga/known-projects` as long as the directories still existed.

## Changes
- Only treat a picker label as having a leading icon when the first character is a private-use glyph, which matches Nerd Font/devicon labels.
- Keep plain labels unchanged, including colored plain labels, so fuzzy-match positions stay inline with the visible project name.
- Render the macOS picker icon slot only when an item actually has a leading icon.
- Filter known projects on load so `tmp/MingaEditor.*` test fixture project roots are hidden even if they are already present in the local persisted file.
- Refuse to add those test fixture roots to known projects through `Project.switch/2` or `Project.add/2`.
- Add Swift view-model tests and Elixir project tests for the new behavior.

## Verification
- `make lint`
- `mix test.llm test/minga/project_test.exs`
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -only-testing:MingaTests/PickerItemComputedTests test`
- `mix swift.build`

## Manual QA
- Open the macOS project picker and search for a project whose first character matches the query.
- Verify the project name renders as one continuous label, for example `frecency_select_project_83682`, with the match highlighted inline instead of separated into an icon-like column.
- Restart Minga and open the project picker.
- Verify persisted `tmp/MingaEditor.*` fixture projects no longer appear in the switcher.
