### PR TITLE
Add stable GUI row identity for retained rendering

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -705,7 +705,7 @@ content past the viewport's left edge becomes visible. The gutter stays fixed.
 content_epoch: BEAM-authored version for retained frontend resources owned by this window. A frontend must discard retained row state for a window when the epoch changes or when `full_refresh` is set.
 
 Per visual row:
-  row_type(1) + buf_line(4) + content_hash(4) + text_len(4) + text(text_len) + span_count(2) + spans...
+  row_type(1) + row_id(8) + buf_line(4) + content_hash(4) + text_len(4) + text(text_len) + span_count(2) + spans...
 
 Row types:
   0 = normal, 1 = fold_start, 2 = virtual_line, 3 = block_decoration, 4 = wrap_continuation
@@ -760,7 +760,7 @@ Rects are cell-space tuples encoded as row(2), col(2), width(2), height(2). Hit 
 
 The frontend renders selection and search matches as Metal quads behind text (not baked into line textures). This enables zero re-rasterization when the selection changes. Diagnostic underlines are rendered as quads after text.
 
-`content_hash` is a per-row hash computed by the BEAM. The frontend uses it for CTLine texture cache invalidation: if the hash matches, the cached texture is reused without re-rasterization.
+`row_id` is a BEAM-authored stable identity for the durable visual row, and each row ID must be unique within a window frame. `content_hash` is a per-row hash computed by the BEAM. The frontend keys retained CTLine textures by `window_id + content_epoch + row_id + content_hash`, so scrolling can reuse the same logical row even when its display row changes.
 
 When `gui_window_content` is present for a window, the BEAM does not send draw_text commands for that window's buffer content. Overlays (hover popups, signature help) have dedicated GUI opcodes (0x81, 0x82) and are rendered natively by SwiftUI. Gutter data (0x7B) and cursor position continue through their existing opcodes, while window-local cursorline is carried in gui_window_content section 0x09.
 

--- a/docs/RETAINED_GUI_RENDERING_SPEC.md
+++ b/docs/RETAINED_GUI_RENDERING_SPEC.md
@@ -4,7 +4,7 @@ The rendering pipeline has too many parts, too many lines of code, and is unnece
 
 ## Status
 
-Phases 1, 2, and 3 moved the architecture in the right direction, but the implementation stopped short of the full data-shape goal. Phase 1 unified the GUI chrome path, Phase 2 introduced `Minga.RenderModel.Window` for GUI buffer windows, and Phase 3 added instrumentation. The remaining debt is explicit now: several UI models still carry pre-encoded protocol binaries, there is no top-level `%Minga.RenderModel{}` frame object yet, row identity and content epochs are not implemented, and Swift still keys retained row textures by display row.
+Phases 1, 2, 3, and the full-frame part of Phase 4 moved the architecture in the right direction, but the implementation stopped short of the full data-shape goal. Phase 1 unified the GUI chrome path, Phase 2 introduced `Minga.RenderModel.Window` for GUI buffer windows, Phase 3 added instrumentation, and Phase 4 added BEAM-authored row IDs with Swift atlas reuse keyed by stable row identity instead of display row. The remaining debt is explicit now: some ownership boundaries are still editor-heavy, reset semantics need a full audit before delta protocol work, and the TUI still needs to move behind the shared render model adapter.
 
 The remediation plan below is the source of truth for completing the simplification work before starting delta protocol work.
 
@@ -204,7 +204,7 @@ Acceptance criteria:
 
 #### 6. Add stable row identity and content epochs
 
-This is where retained rendering becomes real. The current Swift atlas keys buffer rows by display row, which means scrolling changes the key even when the same logical row is still visible.
+This is where retained rendering becomes real. Before Phase 4, the Swift atlas keyed buffer rows by display row, which meant scrolling changed the key even when the same logical row was still visible.
 
 Target row shape:
 
@@ -301,7 +301,7 @@ Emit
 Swift
     ├─ GUIWindowContent state
     ├─ CoreText line rasterization
-    ├─ LineTextureAtlas (keyed by display row)
+    ├─ LineTextureAtlas (keyed by stable row identity)
     └─ Metal draw pass
 ```
 
@@ -600,6 +600,8 @@ Measure before optimizing. Add instrumentation for:
 This tells you whether row identity, protocol size, CoreText rasterization, or Metal uploads are the real bottleneck, and prevents optimizing the wrong thing.
 
 ### Phase 4: Stable row identity
+
+Implementation status: the full-frame GUI path now includes `row_id` on every `Minga.RenderModel.Window.Row`, encodes it in `gui_window_content`, decodes it in Swift, and keys buffer row atlas entries by `window_id + row_id` with `content_epoch + content_hash` as the invalidation hash. Full frames are still sent.
 
 Give durable rows a BEAM-generated stable identity. Change Swift to cache line textures by row identity plus content hash instead of display row.
 

--- a/lib/minga/frontend/adapter/gui/window_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/window_encoder.ex
@@ -21,6 +21,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   per visible row:
     row_type:           u8       (0=normal, 1=fold_start, 2=virtual_line,
                                   3=block, 4=wrap_continuation)
+    row_id:             u64      (stable retained-render identity)
     buf_line:           u32
     content_hash:       u32      (for CTLine cache invalidation)
     text_len:           u32
@@ -289,8 +290,8 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
     spans_binary = Enum.map(row.spans, &encode_span/1)
 
     IO.iodata_to_binary([
-      <<row_type::8, row.buf_line::32, row.content_hash::32, text_len::32, text_bytes::binary,
-        span_count::16>>
+      <<row_type::8, row.row_id::64, row.buf_line::32, row.content_hash::32, text_len::32,
+        text_bytes::binary, span_count::16>>
       | spans_binary
     ])
   end

--- a/lib/minga/render_model/window/row.ex
+++ b/lib/minga/render_model/window/row.ex
@@ -15,10 +15,21 @@ defmodule Minga.RenderModel.Window.Row do
   - `:wrap_continuation` — a continuation row from word wrapping
   """
 
+  import Bitwise
+
   alias Minga.RenderModel.Window.Span
 
+  @row_id_kind_shift 60
+  @row_id_line_shift 28
+  @row_id_visual_shift 12
+  @row_id_line_mask 0xFFFF_FFFF
+  @row_id_visual_mask 0xFFFF
+  @row_id_discriminator_mask 0x0FFF
+  @row_id_discriminator_range @row_id_discriminator_mask + 1
+
   @enforce_keys [:row_type, :buf_line, :text, :spans]
-  defstruct row_type: :normal,
+  defstruct row_id: 0,
+            row_type: :normal,
             buf_line: 0,
             visual_index: 0,
             text: "",
@@ -26,8 +37,10 @@ defmodule Minga.RenderModel.Window.Row do
             content_hash: 0
 
   @type row_type :: :normal | :fold_start | :virtual_line | :block | :wrap_continuation
+  @type row_id :: non_neg_integer()
 
   @type t :: %__MODULE__{
+          row_id: row_id(),
           row_type: row_type(),
           buf_line: non_neg_integer(),
           visual_index: non_neg_integer(),
@@ -36,9 +49,31 @@ defmodule Minga.RenderModel.Window.Row do
           content_hash: non_neg_integer()
         }
 
+  @doc "Builds a compact, deterministic row identity for retained GUI texture reuse."
+  @spec stable_id(row_type(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: row_id()
+  def stable_id(row_type, buf_line, visual_index \\ 0, discriminator \\ 0) do
+    kind_bits = row_type_tag(row_type) <<< @row_id_kind_shift
+    line_bits = (buf_line &&& @row_id_line_mask) <<< @row_id_line_shift
+    visual_bits = (visual_index &&& @row_id_visual_mask) <<< @row_id_visual_shift
+    discriminator_bits = discriminator &&& @row_id_discriminator_mask
+
+    kind_bits ||| line_bits ||| visual_bits ||| discriminator_bits
+  end
+
+  @doc "Returns a small discriminator suitable for the low bits of `stable_id/4`."
+  @spec discriminator(term()) :: non_neg_integer()
+  def discriminator(value), do: :erlang.phash2(value, @row_id_discriminator_range)
+
   @doc "Computes a content hash for cache invalidation."
   @spec compute_hash(String.t(), [Span.t()]) :: non_neg_integer()
   def compute_hash(text, spans) do
     :erlang.phash2({text, spans})
   end
+
+  @spec row_type_tag(row_type()) :: non_neg_integer()
+  defp row_type_tag(:normal), do: 1
+  defp row_type_tag(:fold_start), do: 2
+  defp row_type_tag(:virtual_line), do: 3
+  defp row_type_tag(:block), do: 4
+  defp row_type_tag(:wrap_continuation), do: 5
 end

--- a/lib/minga/render_model/window/row.ex
+++ b/lib/minga/render_model/window/row.ex
@@ -24,10 +24,12 @@ defmodule Minga.RenderModel.Window.Row do
   @row_id_visual_shift 12
   @row_id_line_mask 0xFFFF_FFFF
   @row_id_visual_mask 0xFFFF
+  @row_id_decoration_mask 0x0FFF_FFFF
   @row_id_discriminator_mask 0x0FFF
   @row_id_discriminator_range @row_id_discriminator_mask + 1
+  @row_id_decoration_range @row_id_decoration_mask + 1
 
-  @enforce_keys [:row_type, :buf_line, :text, :spans]
+  @enforce_keys [:row_id, :row_type, :buf_line, :text, :spans]
   defstruct row_id: 0,
             row_type: :normal,
             buf_line: 0,
@@ -63,6 +65,16 @@ defmodule Minga.RenderModel.Window.Row do
   @doc "Returns a small discriminator suitable for the low bits of `stable_id/4`."
   @spec discriminator(term()) :: non_neg_integer()
   def discriminator(value), do: :erlang.phash2(value, @row_id_discriminator_range)
+
+  @doc "Builds a stable row identity for decoration-driven rows."
+  @spec stable_decoration_id(row_type(), non_neg_integer(), term()) :: row_id()
+  def stable_decoration_id(row_type, buf_line, decoration_key) do
+    kind_bits = row_type_tag(row_type) <<< @row_id_kind_shift
+    line_bits = (buf_line &&& @row_id_line_mask) <<< @row_id_line_shift
+    decoration_bits = :erlang.phash2(decoration_key, @row_id_decoration_range)
+
+    kind_bits ||| line_bits ||| decoration_bits
+  end
 
   @doc "Computes a content hash for cache invalidation."
   @spec compute_hash(String.t(), [Span.t()]) :: non_neg_integer()

--- a/lib/minga_editor/agent/view/prompt_render_window.ex
+++ b/lib/minga_editor/agent/view/prompt_render_window.ex
@@ -215,7 +215,7 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
           Theme.Agent.t(),
           pos_integer()
         ) :: Row.t()
-  defp build_visual_row(vl, line_text, _logical_idx, panel, at, inner_width) do
+  defp build_visual_row(vl, line_text, logical_idx, panel, at, inner_width) do
     {display_text, fg_color, bg_color} =
       if UIState.paste_placeholder?(line_text) and vl.col_offset == 0 do
         case UIState.paste_block_index(line_text) do
@@ -256,8 +256,10 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
       end
 
     %Row{
+      row_id: Row.stable_id(:normal, logical_idx, vl.col_offset),
       row_type: :normal,
-      buf_line: 0,
+      buf_line: logical_idx,
+      visual_index: vl.col_offset,
       text: display_text,
       spans: spans,
       content_hash: Row.compute_hash(display_text, spans)

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -327,6 +327,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
         compose_line(line_text, hl_segments, ctx, buf_line, line_byte_offset)
 
       row = %Row{
+        row_id: Row.stable_id(:normal, buf_line),
         row_type: :normal,
         buf_line: buf_line,
         text: composed_text,
@@ -388,6 +389,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       indent_width = Map.get(visual_row, :indent_width, 0)
 
       row = %Row{
+        row_id: Row.stable_id(row_type, buf_line, visual_index),
         row_type: row_type,
         buf_line: buf_line,
         visual_index: visual_index,
@@ -520,28 +522,68 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     line_byte_offsets =
       build_line_byte_offsets(lines, first_line, snapshot.first_line_byte_offset)
 
-    Enum.map(visible_line_map, fn {buf_line, entry_type} ->
-      row =
-        build_visual_row_entry(buf_line, entry_type, lines, first_line, ctx, line_byte_offsets)
+    {entries, _counters} =
+      Enum.map_reduce(visible_line_map, %{}, fn {buf_line, entry_type}, counters ->
+        {visual_identity_index, counters} = next_visual_identity(buf_line, entry_type, counters)
 
-      visual_entry(row, 0, Unicode.display_width(row.text), 0)
-    end)
+        row =
+          build_visual_row_entry(
+            buf_line,
+            entry_type,
+            lines,
+            first_line,
+            ctx,
+            line_byte_offsets,
+            visual_identity_index
+          )
+
+        {visual_entry(row, 0, Unicode.display_width(row.text), 0), counters}
+      end)
+
+    entries
   end
+
+  @spec next_visual_identity(non_neg_integer(), term(), map()) :: {non_neg_integer(), map()}
+  defp next_visual_identity(buf_line, entry_type, counters) do
+    case visual_identity_key(buf_line, entry_type) do
+      nil ->
+        {0, counters}
+
+      key ->
+        index = Map.get(counters, key, 0)
+        {index, Map.put(counters, key, index + 1)}
+    end
+  end
+
+  @spec visual_identity_key(non_neg_integer(), term()) :: term() | nil
+  defp visual_identity_key(buf_line, {:virtual_line, _vt}), do: {buf_line, :virtual_line}
+  defp visual_identity_key(buf_line, {:block, _block, _line_idx}), do: {buf_line, :block}
+  defp visual_identity_key(_buf_line, _entry_type), do: nil
 
   @spec build_visual_row_entry(
           non_neg_integer(),
-          DisplayMap.entry() | atom(),
+          term(),
           [String.t()],
           non_neg_integer(),
           Context.t(),
-          %{non_neg_integer() => non_neg_integer()}
+          %{non_neg_integer() => non_neg_integer()},
+          non_neg_integer()
         ) :: Row.t()
-  defp build_visual_row_entry(buf_line, :normal, lines, first_line, ctx, line_byte_offsets) do
+  defp build_visual_row_entry(
+         buf_line,
+         :normal,
+         lines,
+         first_line,
+         ctx,
+         line_byte_offsets,
+         _index
+       ) do
     line_text = line_at(lines, buf_line, first_line)
     line_byte_offset = Map.get(line_byte_offsets, buf_line, 0)
     {composed, spans} = compose_line(line_text, nil, ctx, buf_line, line_byte_offset)
 
     %Row{
+      row_id: Row.stable_id(:normal, buf_line),
       row_type: :normal,
       buf_line: buf_line,
       text: composed,
@@ -556,7 +598,8 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          lines,
          first_line,
          ctx,
-         line_byte_offsets
+         line_byte_offsets,
+         _index
        ) do
     line_text = line_at(lines, buf_line, first_line)
     line_byte_offset = Map.get(line_byte_offsets, buf_line, 0)
@@ -564,6 +607,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     {composed, spans} = append_fold_summary(composed, spans, hidden_count, ctx)
 
     %Row{
+      row_id: Row.stable_id(:fold_start, buf_line, 0, hidden_count),
       row_type: :fold_start,
       buf_line: buf_line,
       text: composed,
@@ -578,16 +622,21 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          _lines,
          _first_line,
          _ctx,
-         _line_byte_offsets
+         _line_byte_offsets,
+         visual_identity_index
        ) do
     text = virtual_text_to_string(vt)
 
+    spans = virtual_text_spans(vt)
+
     %Row{
+      row_id: Row.stable_id(:virtual_line, buf_line, visual_identity_index),
       row_type: :virtual_line,
       buf_line: buf_line,
+      visual_index: visual_identity_index,
       text: text,
-      spans: virtual_text_spans(vt),
-      content_hash: Row.compute_hash(text, [])
+      spans: spans,
+      content_hash: Row.compute_hash(text, spans)
     }
   end
 
@@ -597,7 +646,8 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          _lines,
          _first_line,
          ctx,
-         _line_byte_offsets
+         _line_byte_offsets,
+         visual_identity_index
        ) do
     # Block decorations render via callback; capture the rendered text using the same text width as the draw path.
     rendered_lines = block.render.(ctx.content_w)
@@ -607,8 +657,10 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     spans = segments_to_spans(segments)
 
     %Row{
+      row_id: Row.stable_id(:block, buf_line, visual_identity_index),
       row_type: :block,
       buf_line: buf_line,
+      visual_index: visual_identity_index,
       text: text,
       spans: spans,
       content_hash: Row.compute_hash(text, spans)
@@ -621,12 +673,14 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          _lines,
          _first_line,
          _ctx,
-         _line_byte_offsets
+         _line_byte_offsets,
+         _index
        ) do
     hidden = FoldRegion.hidden_count(fold)
     text = " ··· #{hidden} lines"
 
     %Row{
+      row_id: Row.stable_id(:fold_start, buf_line, 0, Row.discriminator(fold.id)),
       row_type: :fold_start,
       buf_line: buf_line,
       text: text,

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -630,7 +630,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     spans = virtual_text_spans(vt)
 
     %Row{
-      row_id: Row.stable_id(:virtual_line, buf_line, visual_identity_index),
+      row_id: Row.stable_decoration_id(:virtual_line, buf_line, vt.id),
       row_type: :virtual_line,
       buf_line: buf_line,
       visual_index: visual_identity_index,
@@ -657,7 +657,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     spans = segments_to_spans(segments)
 
     %Row{
-      row_id: Row.stable_id(:block, buf_line, visual_identity_index),
+      row_id: Row.stable_decoration_id(:block, buf_line, {block.id, line_idx}),
       row_type: :block,
       buf_line: buf_line,
       visual_index: visual_identity_index,
@@ -680,7 +680,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     text = " ··· #{hidden} lines"
 
     %Row{
-      row_id: Row.stable_id(:fold_start, buf_line, 0, Row.discriminator(fold.id)),
+      row_id: Row.stable_decoration_id(:fold_start, buf_line, fold.id),
       row_type: :fold_start,
       buf_line: buf_line,
       text: text,

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -339,7 +339,9 @@ enum PreviewRegistry {
         ]
 
         return rows.enumerated().map { index, row in
-            GUIVisualRow(rowType: .normal, bufLine: UInt32(38 + index), contentHash: UInt32(index + 1), text: row.0, spans: row.1)
+            let bufLine = UInt32(38 + index)
+            let rowId = (UInt64(1) << 60) | (UInt64(bufLine) << 28)
+            return GUIVisualRow(rowType: .normal, rowId: rowId, bufLine: bufLine, contentHash: UInt32(index + 1), text: row.0, spans: row.1)
         }
     }
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1598,36 +1598,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 }
 
             case 0x02: // Rows: row_count(2) + rows...
-                guard wcSLen >= 2 else { break }
-                let rowCount = Int(readU16(data, wcSStart))
-                wcRows.reserveCapacity(rowCount)
-                var rp = wcSStart + 2
-                for _ in 0..<rowCount {
-                    guard rp + 21 <= wcSStart + wcSLen else { break }
-                    let rowType = GUIVisualRowType(rawValue: data[rp]) ?? .normal
-                    let rowId = readU64(data, rp + 1)
-                    let bufLine = readU32(data, rp + 9)
-                    let contentHash = readU32(data, rp + 13)
-                    let textLen = Int(readU32(data, rp + 17))
-                    rp += 21
-                    guard rp + textLen <= wcSStart + wcSLen else { break }
-                    let text = String(data: data[rp..<(rp + textLen)], encoding: .utf8) ?? ""
-                    rp += textLen
-                    guard rp + 2 <= wcSStart + wcSLen else { break }
-                    let spanCount = Int(readU16(data, rp)); rp += 2
-                    var spans: [GUIHighlightSpan] = []
-                    spans.reserveCapacity(spanCount)
-                    for _ in 0..<spanCount {
-                        guard rp + 13 <= wcSStart + wcSLen else { break }
-                        spans.append(GUIHighlightSpan(
-                            startCol: readU16(data, rp), endCol: readU16(data, rp + 2),
-                            fg: readU24(data, rp + 4), bg: readU24(data, rp + 7),
-                            attrs: data[rp + 10], fontWeight: data[rp + 11], fontId: data[rp + 12]
-                        ))
-                        rp += 13
-                    }
-                    wcRows.append(GUIVisualRow(rowType: rowType, rowId: rowId, bufLine: bufLine, contentHash: contentHash, text: text, spans: spans))
-                }
+                wcRows = try decodeWindowContentRows(data: data, start: wcSStart, end: wcSStart + wcSLen)
 
             case 0x03: // Selection: type(1), if != 0: start_row(2) + start_col(2) + end_row(2) + end_col(2)
                 guard wcSLen >= 1 else { break }
@@ -2966,6 +2937,55 @@ private func decodeStatusBarSegments(data: Data, pos: inout Int, count: Int, end
     }
 
     return segments
+}
+
+private func decodeWindowContentRows(data: Data, start: Int, end: Int) throws -> [GUIVisualRow] {
+    guard start + 2 <= end else { throw ProtocolDecodeError.malformed }
+    let rowCount = Int(readU16(data, start))
+    var pos = start + 2
+    var rows: [GUIVisualRow] = []
+    rows.reserveCapacity(rowCount)
+
+    for _ in 0..<rowCount {
+        let row = try decodeWindowContentRow(data: data, pos: &pos, end: end)
+        rows.append(row)
+    }
+
+    guard pos == end else { throw ProtocolDecodeError.malformed }
+    return rows
+}
+
+private func decodeWindowContentRow(data: Data, pos: inout Int, end: Int) throws -> GUIVisualRow {
+    guard pos + 21 <= end else { throw ProtocolDecodeError.malformed }
+    let rowType = GUIVisualRowType(rawValue: data[pos]) ?? .normal
+    let rowId = readU64(data, pos + 1)
+    let bufLine = readU32(data, pos + 9)
+    let contentHash = readU32(data, pos + 13)
+    let textLen = Int(readU32(data, pos + 17))
+    pos += 21
+
+    guard pos + textLen <= end else { throw ProtocolDecodeError.malformed }
+    let text = String(data: data[pos..<(pos + textLen)], encoding: .utf8) ?? ""
+    pos += textLen
+
+    guard pos + 2 <= end else { throw ProtocolDecodeError.malformed }
+    let spanCount = Int(readU16(data, pos))
+    pos += 2
+
+    var spans: [GUIHighlightSpan] = []
+    spans.reserveCapacity(spanCount)
+
+    for _ in 0..<spanCount {
+        guard pos + 13 <= end else { throw ProtocolDecodeError.malformed }
+        spans.append(GUIHighlightSpan(
+            startCol: readU16(data, pos), endCol: readU16(data, pos + 2),
+            fg: readU24(data, pos + 4), bg: readU24(data, pos + 7),
+            attrs: data[pos + 10], fontWeight: data[pos + 11], fontId: data[pos + 12]
+        ))
+        pos += 13
+    }
+
+    return GUIVisualRow(rowType: rowType, rowId: rowId, bufLine: bufLine, contentHash: contentHash, text: text, spans: spans)
 }
 
 private struct DecodedChatMessageCandidate {

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1603,12 +1603,13 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 wcRows.reserveCapacity(rowCount)
                 var rp = wcSStart + 2
                 for _ in 0..<rowCount {
-                    guard rp + 13 <= wcSStart + wcSLen else { break }
+                    guard rp + 21 <= wcSStart + wcSLen else { break }
                     let rowType = GUIVisualRowType(rawValue: data[rp]) ?? .normal
-                    let bufLine = readU32(data, rp + 1)
-                    let contentHash = readU32(data, rp + 5)
-                    let textLen = Int(readU32(data, rp + 9))
-                    rp += 13
+                    let rowId = readU64(data, rp + 1)
+                    let bufLine = readU32(data, rp + 9)
+                    let contentHash = readU32(data, rp + 13)
+                    let textLen = Int(readU32(data, rp + 17))
+                    rp += 21
                     guard rp + textLen <= wcSStart + wcSLen else { break }
                     let text = String(data: data[rp..<(rp + textLen)], encoding: .utf8) ?? ""
                     rp += textLen
@@ -1625,7 +1626,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                         ))
                         rp += 13
                     }
-                    wcRows.append(GUIVisualRow(rowType: rowType, bufLine: bufLine, contentHash: contentHash, text: text, spans: spans))
+                    wcRows.append(GUIVisualRow(rowType: rowType, rowId: rowId, bufLine: bufLine, contentHash: contentHash, text: text, spans: spans))
                 }
 
             case 0x03: // Selection: type(1), if != 0: start_row(2) + start_col(2) + end_row(2) + end_col(2)

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -343,9 +343,7 @@ final class CoreTextMetalRenderer {
             atlas.ensureCapacity(maxSlots: neededSlots, width: atlasPixelWidth)
             atlas.beginFrame()
 
-            for content in windowContents.values where content.fullRefresh {
-                atlas.invalidateWindow(content.windowId)
-            }
+            Self.invalidateFullRefreshWindows(in: atlas, windowContents: windowContents)
 
             if neededSlots > maxInstanceSlots {
                 maxInstanceSlots = neededSlots
@@ -1407,6 +1405,13 @@ final class CoreTextMetalRenderer {
     }
 
     /// Computes a conservative atlas slot count for all text textures that may be touched by the current frame.
+    @MainActor
+    static func invalidateFullRefreshWindows(in atlas: LineTextureAtlas, windowContents: [UInt16: GUIWindowContent]) {
+        for content in windowContents.values where content.fullRefresh {
+            atlas.invalidateWindow(content.windowId)
+        }
+    }
+
     nonisolated static func atlasSlotDemand(frameState: FrameState, windowContents: [UInt16: GUIWindowContent]) -> Int {
         let bufferRows = windowContents.values.reduce(0) { total, content in
             total + content.rows.count

--- a/macos/Sources/Renderer/SlotAllocator.swift
+++ b/macos/Sources/Renderer/SlotAllocator.swift
@@ -20,35 +20,35 @@ struct AtlasKey: Hashable, CustomStringConvertible {
 
     let namespace: Namespace
     let windowId: UInt16
-    let row: UInt16
+    let row: UInt64
     let subIndex: UInt16
 
     var description: String {
         "\(namespace.rawValue)(window: \(windowId), row: \(row), sub: \(subIndex))"
     }
 
-    static func bufferRow(windowId: UInt16, row: UInt16) -> AtlasKey {
-        AtlasKey(namespace: .bufferRow, windowId: windowId, row: row, subIndex: 0)
+    static func bufferRow(windowId: UInt16, rowId: UInt64) -> AtlasKey {
+        AtlasKey(namespace: .bufferRow, windowId: windowId, row: rowId, subIndex: 0)
     }
 
     static func gutterLineNumber(windowId: UInt16, row: UInt16) -> AtlasKey {
-        AtlasKey(namespace: .gutterLineNumber, windowId: windowId, row: row, subIndex: 0)
+        AtlasKey(namespace: .gutterLineNumber, windowId: windowId, row: UInt64(row), subIndex: 0)
     }
 
     static func diagnosticSign(windowId: UInt16, row: UInt16) -> AtlasKey {
-        AtlasKey(namespace: .diagnosticSign, windowId: windowId, row: row, subIndex: 0)
+        AtlasKey(namespace: .diagnosticSign, windowId: windowId, row: UInt64(row), subIndex: 0)
     }
 
     static func annotationIcon(windowId: UInt16, row: UInt16) -> AtlasKey {
-        AtlasKey(namespace: .annotationIcon, windowId: windowId, row: row, subIndex: 0)
+        AtlasKey(namespace: .annotationIcon, windowId: windowId, row: UInt64(row), subIndex: 0)
     }
 
     static func lineAnnotation(windowId: UInt16, row: UInt16, subIndex: UInt16) -> AtlasKey {
-        AtlasKey(namespace: .lineAnnotation, windowId: windowId, row: row, subIndex: subIndex)
+        AtlasKey(namespace: .lineAnnotation, windowId: windowId, row: UInt64(row), subIndex: subIndex)
     }
 
     static func splitLabel(row: UInt16, subIndex: UInt16) -> AtlasKey {
-        AtlasKey(namespace: .splitLabel, windowId: 0, row: row, subIndex: subIndex)
+        AtlasKey(namespace: .splitLabel, windowId: 0, row: UInt64(row), subIndex: subIndex)
     }
 }
 

--- a/macos/Sources/Renderer/WindowContent.swift
+++ b/macos/Sources/Renderer/WindowContent.swift
@@ -51,10 +51,20 @@ struct GUIHighlightSpan: Sendable, Equatable {
 /// and conceal ranges. The `text` field is the final composed UTF-8 string.
 struct GUIVisualRow: Sendable, Equatable {
     let rowType: GUIVisualRowType
+    let rowId: UInt64
     let bufLine: UInt32
     let contentHash: UInt32
     let text: String
     let spans: [GUIHighlightSpan]
+
+    init(rowType: GUIVisualRowType, rowId: UInt64 = 0, bufLine: UInt32, contentHash: UInt32, text: String, spans: [GUIHighlightSpan]) {
+        self.rowType = rowType
+        self.rowId = rowId
+        self.bufLine = bufLine
+        self.contentHash = contentHash
+        self.text = text
+        self.spans = spans
+    }
 }
 
 // MARK: - Selection overlay

--- a/macos/Sources/Renderer/WindowContent.swift
+++ b/macos/Sources/Renderer/WindowContent.swift
@@ -57,7 +57,7 @@ struct GUIVisualRow: Sendable, Equatable {
     let text: String
     let spans: [GUIHighlightSpan]
 
-    init(rowType: GUIVisualRowType, rowId: UInt64 = 0, bufLine: UInt32, contentHash: UInt32, text: String, spans: [GUIHighlightSpan]) {
+    init(rowType: GUIVisualRowType, rowId: UInt64, bufLine: UInt32, contentHash: UInt32, text: String, spans: [GUIHighlightSpan]) {
         self.rowType = rowType
         self.rowId = rowId
         self.bufLine = bufLine

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -18,7 +18,7 @@ import AppKit
 /// Renders `GUIWindowContent` rows into cached Metal line textures.
 ///
 /// Each row's text + spans produce an `NSAttributedString` → `CTLine` →
-/// bitmap → `MTLTexture`, cached by content hash.
+/// bitmap → `MTLTexture`, cached by stable row identity plus content hash.
 @MainActor
 final class WindowContentRenderer {
     /// Metal device for texture creation.
@@ -30,8 +30,8 @@ final class WindowContentRenderer {
     /// Shared pooled bitmap rasterizer.
     private let rasterizer: BitmapRasterizer
 
-    /// Per-row texture cache keyed by display row index.
-    private var lineCache: [UInt16: CachedLineTexture] = [:]
+    /// Per-row texture cache keyed by BEAM-authored row identity.
+    private var lineCache: [UInt64: CachedLineTexture] = [:]
 
     /// Frame counter for LRU eviction.
     private var frameCounter: UInt64 = 0
@@ -136,13 +136,14 @@ final class WindowContentRenderer {
     ///
     /// Returns the cached texture if the content hash matches, or
     /// rasterizes a new texture from the row's text + spans.
-    func renderRow(displayRow: UInt16, row: GUIVisualRow, contentEpoch: UInt32 = 0) -> CachedLineTexture? {
+    func renderRow(displayRow _: UInt16, row: GUIVisualRow, contentEpoch: UInt32 = 0) -> CachedLineTexture? {
         let hash = epochContentHash(row.contentHash, contentEpoch)
+        let key = row.rowId
 
         // Cache hit check.
-        if var cached = lineCache[displayRow], cached.contentHash == hash {
+        if var cached = lineCache[key], cached.contentHash == hash {
             cached.lastUsedFrame = frameCounter
-            lineCache[displayRow] = cached
+            lineCache[key] = cached
             return cached
         }
 
@@ -191,17 +192,17 @@ final class WindowContentRenderer {
             pixelWidth: pixelWidth,
             pixelHeight: pixelHeight
         )
-        lineCache[displayRow] = cached
+        lineCache[key] = cached
         return cached
     }
 
     /// Render a visual row into an atlas slot.
     ///
-    /// Checks the atlas cache first using a window-scoped buffer-row key. On miss, rasterizes and uploads.
-    func renderRowToAtlas(displayRow: UInt16, row: GUIVisualRow, windowId: UInt16, contentEpoch: UInt32 = 0,
+    /// Checks the atlas cache first using a window-scoped stable row key. On miss, rasterizes and uploads.
+    func renderRowToAtlas(displayRow _: UInt16, row: GUIVisualRow, windowId: UInt16, contentEpoch: UInt32 = 0,
                           atlas: LineTextureAtlas, metrics: inout FrameMetrics) -> AtlasEntry? {
         let hash = epochContentHash(row.contentHash, contentEpoch)
-        let key = AtlasKey.bufferRow(windowId: windowId, row: displayRow)
+        let key = AtlasKey.bufferRow(windowId: windowId, rowId: row.rowId)
 
         guard !row.text.isEmpty else { return nil }
         guard let lookup = atlas.lookupOrReserve(key: key, contentHash: hash) else { return nil }
@@ -424,7 +425,7 @@ final class WindowContentRenderer {
             let clipStart = min(scrollLeft, totalDisplayCols)
             let clipEnd = min(scrollLeft + viewportCols, totalDisplayCols)
             guard clipStart < clipEnd else {
-                return GUIVisualRow(rowType: row.rowType, bufLine: row.bufLine,
+                return GUIVisualRow(rowType: row.rowType, rowId: row.rowId, bufLine: row.bufLine,
                                    contentHash: scrollContentHash(row.contentHash, scrollLeft: scrollLeft),
                                    text: "", spans: [])
             }
@@ -437,7 +438,7 @@ final class WindowContentRenderer {
             let clipStart = min(scrollLeft, totalDisplayCols)
             let clipEnd = min(scrollLeft + viewportCols, totalDisplayCols)
             guard clipStart < clipEnd, clipEnd < columnMap.count else {
-                return GUIVisualRow(rowType: row.rowType, bufLine: row.bufLine,
+                return GUIVisualRow(rowType: row.rowType, rowId: row.rowId, bufLine: row.bufLine,
                                    contentHash: scrollContentHash(row.contentHash, scrollLeft: scrollLeft),
                                    text: "", spans: [])
             }
@@ -450,7 +451,7 @@ final class WindowContentRenderer {
         let newHash = scrollContentHash(row.contentHash, scrollLeft: scrollLeft)
 
         return GUIVisualRow(
-            rowType: row.rowType, bufLine: row.bufLine,
+            rowType: row.rowType, rowId: row.rowId, bufLine: row.bufLine,
             contentHash: newHash, text: clippedText, spans: clippedSpans
         )
     }

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -258,7 +258,7 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
                  "fg": Int(s.fg), "bg": Int(s.bg), "attrs": Int(s.attrs),
                  "font_weight": Int(s.fontWeight), "font_id": Int(s.fontId)]
             }
-            return ["row_type": Int(row.rowType.rawValue), "buf_line": Int(row.bufLine),
+            return ["row_type": Int(row.rowType.rawValue), "row_id": Int(row.rowId), "buf_line": Int(row.bufLine),
                     "content_hash": Int(row.contentHash), "text": row.text, "spans": spans]
         }
         var result: [String: Any] = [

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -157,7 +157,7 @@ struct CoreTextMetalRendererCursorTests {
         let content = GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 4, cursorShape: .block,
-            rows: [GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 1, text: "this", spans: [])],
+            rows: [GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 1, text: "this", spans: [])],
             selection: nil,
             searchMatches: [], diagnosticUnderlines: [],
             documentHighlights: []
@@ -171,7 +171,7 @@ struct CoreTextMetalRendererCursorTests {
         let content = GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 4, cursorShape: .beam,
-            rows: [GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 1, text: "this", spans: [])],
+            rows: [GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 1, text: "this", spans: [])],
             selection: nil,
             searchMatches: [], diagnosticUnderlines: [],
             documentHighlights: []
@@ -185,7 +185,7 @@ struct CoreTextMetalRendererCursorTests {
         let content = GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 2, cursorShape: .block,
-            rows: [GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 1, text: "界", spans: [])],
+            rows: [GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 1, text: "界", spans: [])],
             selection: nil,
             searchMatches: [], diagnosticUnderlines: [],
             documentHighlights: []

--- a/macos/Tests/MingaTests/DecoderRobustnessTests.swift
+++ b/macos/Tests/MingaTests/DecoderRobustnessTests.swift
@@ -277,6 +277,101 @@ struct DecoderTruncatedGUIChromeTests {
             try decodeCommand(data: data, offset: 0)
         }
     }
+
+    @Test("gui_window_content truncated advertised row payload")
+    func truncatedWindowContentRow() {
+        var rowBytes = Data()
+        rowBytes.append(0x00) // rowType = normal
+        appendU64(&rowBytes, 1)
+        appendU32(&rowBytes, 0)
+        appendU32(&rowBytes, 0x1234_5678)
+        appendU32(&rowBytes, 1)
+        rowBytes.append(0x61)
+        rowBytes.append(0x00) // only one byte of span_count
+
+        let data = windowContentData(rowsPayload: windowContentRowsPayload(rowBytes: rowBytes))
+        expectMalformedWindowContent(data)
+    }
+
+    @Test("gui_window_content truncated advertised span payload")
+    func truncatedWindowContentSpan() {
+        var rowBytes = Data()
+        rowBytes.append(0x00) // rowType = normal
+        appendU64(&rowBytes, 1)
+        appendU32(&rowBytes, 0)
+        appendU32(&rowBytes, 0x1234_5678)
+        appendU32(&rowBytes, 1)
+        rowBytes.append(0x61)
+        appendU16(&rowBytes, 1)
+        appendU16(&rowBytes, 0)
+        appendU16(&rowBytes, 1)
+        rowBytes.append(contentsOf: [0xFF, 0x00, 0x00])
+        rowBytes.append(contentsOf: [0x00, 0x00, 0x00])
+        rowBytes.append(0x00)
+        rowBytes.append(0x00) // missing the last byte of the span payload
+
+        let data = windowContentData(rowsPayload: windowContentRowsPayload(rowBytes: rowBytes))
+        expectMalformedWindowContent(data)
+    }
+}
+
+private func windowContentData(rowsPayload: Data) -> Data {
+    var headerPayload = Data()
+    appendU16(&headerPayload, 1)
+    headerPayload.append(0x03)
+    appendU16(&headerPayload, 0)
+    appendU16(&headerPayload, 0)
+    headerPayload.append(0x00)
+    appendU16(&headerPayload, 0)
+
+    var data = Data([OP_GUI_WINDOW_CONTENT, 2])
+    data.append(0x01)
+    appendU16(&data, UInt16(headerPayload.count))
+    data.append(headerPayload)
+    data.append(0x02)
+    appendU16(&data, UInt16(rowsPayload.count))
+    data.append(rowsPayload)
+    return data
+}
+
+private func windowContentRowsPayload(rowBytes: Data) -> Data {
+    var payload = Data()
+    appendU16(&payload, 1)
+    payload.append(rowBytes)
+    return payload
+}
+
+private func appendU16(_ data: inout Data, _ value: UInt16) {
+    data.append(UInt8(value >> 8))
+    data.append(UInt8(value & 0xFF))
+}
+
+private func appendU32(_ data: inout Data, _ value: UInt32) {
+    data.append(UInt8((value >> 24) & 0xFF))
+    data.append(UInt8((value >> 16) & 0xFF))
+    data.append(UInt8((value >> 8) & 0xFF))
+    data.append(UInt8(value & 0xFF))
+}
+
+private func appendU64(_ data: inout Data, _ value: UInt64) {
+    data.append(UInt8((value >> 56) & 0xFF))
+    data.append(UInt8((value >> 48) & 0xFF))
+    data.append(UInt8((value >> 40) & 0xFF))
+    data.append(UInt8((value >> 32) & 0xFF))
+    data.append(UInt8((value >> 24) & 0xFF))
+    data.append(UInt8((value >> 16) & 0xFF))
+    data.append(UInt8((value >> 8) & 0xFF))
+    data.append(UInt8(value & 0xFF))
+}
+
+private func expectMalformedWindowContent(_ data: Data) {
+    do {
+        _ = try decodeCommand(data: data, offset: 0)
+        Issue.record("Expected ProtocolDecodeError.malformed")
+    } catch ProtocolDecodeError.malformed {
+    } catch {
+        Issue.record("Expected ProtocolDecodeError.malformed, got \(error)")
+    }
 }
 
 // MARK: - Forward-compatible unknown opcodes (0x90+)

--- a/macos/Tests/MingaTests/SlotAllocatorTests.swift
+++ b/macos/Tests/MingaTests/SlotAllocatorTests.swift
@@ -5,7 +5,7 @@ import Testing
 import simd
 
 private func testKey(_ raw: UInt16) -> AtlasKey {
-    AtlasKey.bufferRow(windowId: 0, row: raw)
+    AtlasKey.bufferRow(windowId: 0, rowId: UInt64(raw))
 }
 
 @Suite("SlotAllocator — Allocation")
@@ -197,8 +197,8 @@ struct SlotAllocatorCapacityTests {
     func invalidateWindow() {
         var alloc = SlotAllocator()
         alloc.ensureCapacity(maxSlots: 4)
-        let win1 = AtlasKey.bufferRow(windowId: 1, row: 0)
-        let win2 = AtlasKey.bufferRow(windowId: 2, row: 0)
+        let win1 = AtlasKey.bufferRow(windowId: 1, rowId: 0)
+        let win2 = AtlasKey.bufferRow(windowId: 2, rowId: 0)
 
         guard case .reserved(let slot1, .newKey) = alloc.lookupOrReserve(key: win1, contentHash: 11) else { Issue.record("Expected win1 reserve"); return }
         alloc.markUploaded(slotIndex: slot1, contentHash: 11, pixelWidth: 100)

--- a/macos/Tests/MingaTests/WindowContentRendererTests.swift
+++ b/macos/Tests/MingaTests/WindowContentRendererTests.swift
@@ -152,7 +152,7 @@ struct WindowContentFrameMetricsTests {
     @Test("Buffer row metrics distinguish rasterized rows from reused rows")
     @MainActor func bufferRowMetrics() throws {
         guard let (renderer, atlas) = makeRendererAndAtlas() else { return }
-        let row = GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 42, text: "hello", spans: [])
+        let row = GUIVisualRow(rowType: .normal, rowId: 100, bufLine: 0, contentHash: 42, text: "hello", spans: [])
 
         atlas.beginFrame()
         var metrics = FrameMetrics()
@@ -172,11 +172,51 @@ struct WindowContentFrameMetricsTests {
         #expect(atlas.frameTextureUploads == 0)
     }
 
+    @Test("Same row identity reuses atlas slot after display row changes")
+    @MainActor func sameRowIdentityReusesAfterScroll() throws {
+        guard let (renderer, atlas) = makeRendererAndAtlas() else { return }
+        let row = GUIVisualRow(rowType: .normal, rowId: 200, bufLine: 10, contentHash: 42, text: "same", spans: [])
+
+        atlas.beginFrame()
+        var metrics = FrameMetrics()
+        let first = renderer.renderRowToAtlas(displayRow: 0, row: row, windowId: 1, atlas: atlas, metrics: &metrics)
+        #expect(first != nil)
+        #expect(metrics.bufferRowsRasterized == 1)
+
+        atlas.beginFrame()
+        metrics.reset()
+        let second = renderer.renderRowToAtlas(displayRow: 1, row: row, windowId: 1, atlas: atlas, metrics: &metrics)
+        #expect(second?.slotIndex == first?.slotIndex)
+        #expect(metrics.bufferRowsRasterized == 0)
+        #expect(metrics.bufferRowsReused == 1)
+        #expect(atlas.frameTextureUploads == 0)
+    }
+
+    @Test("Different row identity rasterizes even on the same display row")
+    @MainActor func differentRowIdentityMissesOnSameDisplayRow() throws {
+        guard let (renderer, atlas) = makeRendererAndAtlas() else { return }
+        let firstRow = GUIVisualRow(rowType: .normal, rowId: 300, bufLine: 0, contentHash: 42, text: "same", spans: [])
+        let secondRow = GUIVisualRow(rowType: .normal, rowId: 301, bufLine: 1, contentHash: 42, text: "same", spans: [])
+
+        atlas.beginFrame()
+        var metrics = FrameMetrics()
+        let first = renderer.renderRowToAtlas(displayRow: 0, row: firstRow, windowId: 1, atlas: atlas, metrics: &metrics)
+        #expect(first != nil)
+
+        atlas.beginFrame()
+        metrics.reset()
+        let second = renderer.renderRowToAtlas(displayRow: 0, row: secondRow, windowId: 1, atlas: atlas, metrics: &metrics)
+        #expect(second != nil)
+        #expect(second?.slotIndex != first?.slotIndex)
+        #expect(metrics.bufferRowsRasterized == 1)
+        #expect(metrics.atlasNewKeys == 1)
+    }
+
     @Test("Same display row in different windows uses distinct atlas slots")
     @MainActor func sameRowDifferentWindowsUsesDistinctSlots() throws {
         guard let (renderer, atlas) = makeRendererAndAtlas() else { return }
-        let left = GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 42, text: "left", spans: [])
-        let right = GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 99, text: "right", spans: [])
+        let left = GUIVisualRow(rowType: .normal, rowId: 400, bufLine: 0, contentHash: 42, text: "left", spans: [])
+        let right = GUIVisualRow(rowType: .normal, rowId: 400, bufLine: 0, contentHash: 99, text: "right", spans: [])
 
         atlas.beginFrame()
         var metrics = FrameMetrics()
@@ -193,8 +233,8 @@ struct WindowContentFrameMetricsTests {
     @Test("Changed row hash records hash-change miss reason")
     @MainActor func changedHashMetrics() throws {
         guard let (renderer, atlas) = makeRendererAndAtlas() else { return }
-        let original = GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 42, text: "hello", spans: [])
-        let changed = GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 43, text: "hello!", spans: [])
+        let original = GUIVisualRow(rowType: .normal, rowId: 500, bufLine: 0, contentHash: 42, text: "hello", spans: [])
+        let changed = GUIVisualRow(rowType: .normal, rowId: 500, bufLine: 0, contentHash: 43, text: "hello!", spans: [])
 
         atlas.beginFrame()
         var metrics = FrameMetrics()
@@ -210,7 +250,7 @@ struct WindowContentFrameMetricsTests {
     @Test("Changed content epoch rerasterizes a row with the same row hash")
     @MainActor func changedContentEpochMetrics() throws {
         guard let (renderer, atlas) = makeRendererAndAtlas() else { return }
-        let row = GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 42, text: "hello", spans: [])
+        let row = GUIVisualRow(rowType: .normal, rowId: 600, bufLine: 0, contentHash: 42, text: "hello", spans: [])
 
         atlas.beginFrame()
         var metrics = FrameMetrics()
@@ -223,9 +263,57 @@ struct WindowContentFrameMetricsTests {
         #expect(metrics.atlasHashChanges == 1)
     }
 
+    @Test("Full-refresh window content invalidates retained atlas rows")
+    @MainActor func fullRefreshWindowInvalidatesAtlasRows() throws {
+        guard let (renderer, atlas) = makeRendererAndAtlas() else { return }
+        let row = GUIVisualRow(rowType: .normal, rowId: 650, bufLine: 0, contentHash: 42, text: "hello", spans: [])
+
+        atlas.beginFrame()
+        var metrics = FrameMetrics()
+        let first = renderer.renderRowToAtlas(displayRow: 0, row: row, windowId: 1, atlas: atlas, metrics: &metrics)
+        #expect(first != nil)
+        #expect(metrics.bufferRowsRasterized == 1)
+
+        let content = GUIWindowContent(windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [row], selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
+        atlas.beginFrame()
+        CoreTextMetalRenderer.invalidateFullRefreshWindows(in: atlas, windowContents: [1: content])
+        metrics.reset()
+        let second = renderer.renderRowToAtlas(displayRow: 0, row: row, windowId: 1, atlas: atlas, metrics: &metrics)
+        #expect(second != nil)
+        #expect(metrics.bufferRowsRasterized == 1)
+        #expect(metrics.bufferRowsReused == 0)
+        #expect(metrics.atlasNewKeys == 1)
+    }
+
+    @Test("Horizontal scroll keeps row identity but changes the atlas hash")
+    @MainActor func horizontalScrollChangesAtlasHash() throws {
+        guard let (renderer, atlas) = makeRendererAndAtlas() else { return }
+        let row = GUIVisualRow(rowType: .normal, rowId: 675, bufLine: 0, contentHash: 42, text: "abcdef", spans: [])
+        let left = renderer.clipRowToViewport(row, scrollLeft: 0, viewportCols: 3)
+        let scrolled = renderer.clipRowToViewport(row, scrollLeft: 2, viewportCols: 3)
+
+        #expect(left.rowId == row.rowId)
+        #expect(scrolled.rowId == row.rowId)
+        #expect(left.text == "abc")
+        #expect(scrolled.text == "cde")
+        #expect(left.contentHash != scrolled.contentHash)
+
+        atlas.beginFrame()
+        var metrics = FrameMetrics()
+        _ = renderer.renderRowToAtlas(displayRow: 0, row: left, windowId: 1, atlas: atlas, metrics: &metrics)
+        #expect(metrics.bufferRowsRasterized == 1)
+
+        atlas.beginFrame()
+        metrics.reset()
+        _ = renderer.renderRowToAtlas(displayRow: 0, row: scrolled, windowId: 1, atlas: atlas, metrics: &metrics)
+        #expect(metrics.bufferRowsRasterized == 1)
+        #expect(metrics.bufferRowsReused == 0)
+        #expect(metrics.atlasHashChanges == 1)
+    }
+
     @Test("Atlas slot demand accounts for split-window texture entries")
     func atlasDemandCountsSplitWindows() {
-        let rows = [GUIVisualRow(rowType: .normal, bufLine: 0, contentHash: 1, text: "row", spans: [])]
+        let rows = [GUIVisualRow(rowType: .normal, rowId: 700, bufLine: 0, contentHash: 1, text: "row", spans: [])]
         let left = GUIWindowContent(windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: rows, selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [], lineAnnotations: [GUILineAnnotation(row: 0, kind: .inlineText, fg: 0xFFFFFF, bg: 0, text: "hint")])
         let right = GUIWindowContent(windowId: 2, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: rows, selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
 

--- a/macos/Tests/MingaTests/WindowContentTests.swift
+++ b/macos/Tests/MingaTests/WindowContentTests.swift
@@ -29,7 +29,7 @@ struct WindowContentBuilder {
 
     struct RowBuilder {
         var rowType: UInt8 = 0  // normal
-        var rowId: UInt64 = 0
+        var rowId: UInt64
         var bufLine: UInt32 = 0
         var contentHash: UInt32 = 12345
         var text: String = ""
@@ -376,11 +376,11 @@ struct WindowContentDecoderTests {
     func decodeRowTypes() throws {
         var builder = WindowContentBuilder()
         builder.rows = [
-            .init(rowType: 0, text: "normal"),
-            .init(rowType: 1, text: "fold"),
-            .init(rowType: 2, text: "virtual"),
-            .init(rowType: 3, text: "block"),
-            .init(rowType: 4, text: "wrap"),
+            .init(rowType: 0, rowId: 1, text: "normal"),
+            .init(rowType: 1, rowId: 2, text: "fold"),
+            .init(rowType: 2, rowId: 3, text: "virtual"),
+            .init(rowType: 3, rowId: 4, text: "block"),
+            .init(rowType: 4, rowId: 5, text: "wrap"),
         ]
 
         let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
@@ -398,7 +398,7 @@ struct WindowContentDecoderTests {
     @Test("Decode multi-byte UTF-8 text")
     func decodeUTF8() throws {
         var builder = WindowContentBuilder()
-        builder.rows = [.init(text: "🥨日本語héllo")]
+        builder.rows = [.init(rowId: 1, text: "🥨日本語héllo")]
 
         let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
         guard case .guiWindowContent(let content) = cmd else {
@@ -411,7 +411,7 @@ struct WindowContentDecoderTests {
     @Test("Decode content_hash")
     func decodeContentHash() throws {
         var builder = WindowContentBuilder()
-        builder.rows = [.init(contentHash: 0xDEADBEEF, text: "x")]
+        builder.rows = [.init(rowId: 1, contentHash: 0xDEADBEEF, text: "x")]
 
         let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
         guard case .guiWindowContent(let content) = cmd else {
@@ -431,7 +431,7 @@ struct WindowContentDecoderTests {
             attrs: 0x03,  // bold + italic
             fontWeight: 5, fontId: 2
         )
-        builder.rows = [.init(text: "hello world", spans: [span])]
+        builder.rows = [.init(rowId: 1, text: "hello world", spans: [span])]
 
         let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
         guard case .guiWindowContent(let content) = cmd else {
@@ -555,7 +555,7 @@ struct WindowContentDecoderTests {
     @Test("Decode consumes entire binary (no leftover bytes)")
     func decodeConsumesAllBytes() throws {
         var builder = WindowContentBuilder()
-        builder.rows = [.init(text: "hello", spans: [
+        builder.rows = [.init(rowId: 1, text: "hello", spans: [
             .init(startCol: 0, endCol: 5, fgR: 0xFF, fgG: 0, fgB: 0)
         ])]
         builder.selectionType = 1
@@ -573,11 +573,11 @@ struct WindowContentDecoderTests {
     func decodeCompleteWindow() throws {
         var builder = WindowContentBuilder(windowId: 7, cursorRow: 1, cursorCol: 3, cursorShape: 1)
         builder.rows = [
-            .init(rowType: 0, bufLine: 0, text: "def foo do", spans: [
+            .init(rowType: 0, rowId: 1, bufLine: 0, text: "def foo do", spans: [
                 .init(startCol: 0, endCol: 3, fgR: 0x51, fgG: 0xAF, fgB: 0xEF, attrs: 0x01),
                 .init(startCol: 4, endCol: 7, fgR: 0xEC, fgG: 0xBE, fgB: 0x7B),
             ]),
-            .init(rowType: 1, bufLine: 1, text: "  :ok ··· 3 lines"),
+            .init(rowType: 1, rowId: 2, bufLine: 1, text: "  :ok ··· 3 lines"),
         ]
         builder.selectionType = 1
         builder.selectionCoords = (0, 0, 0, 10)

--- a/macos/Tests/MingaTests/WindowContentTests.swift
+++ b/macos/Tests/MingaTests/WindowContentTests.swift
@@ -29,6 +29,7 @@ struct WindowContentBuilder {
 
     struct RowBuilder {
         var rowType: UInt8 = 0  // normal
+        var rowId: UInt64 = 0
         var bufLine: UInt32 = 0
         var contentHash: UInt32 = 12345
         var text: String = ""
@@ -62,6 +63,7 @@ struct WindowContentBuilder {
         appendU16(&rowsPayload, UInt16(rows.count))
         for row in rows {
             rowsPayload.append(row.rowType)
+            appendU64(&rowsPayload, row.rowId)
             appendU32(&rowsPayload, row.bufLine)
             appendU32(&rowsPayload, row.contentHash)
             let textBytes = Array(row.text.utf8)
@@ -211,6 +213,17 @@ struct WindowContentBuilder {
         data.append(UInt8((value >> 8) & 0xFF))
         data.append(UInt8(value & 0xFF))
     }
+
+    private func appendU64(_ data: inout Data, _ value: UInt64) {
+        data.append(UInt8((value >> 56) & 0xFF))
+        data.append(UInt8((value >> 48) & 0xFF))
+        data.append(UInt8((value >> 40) & 0xFF))
+        data.append(UInt8((value >> 32) & 0xFF))
+        data.append(UInt8((value >> 24) & 0xFF))
+        data.append(UInt8((value >> 16) & 0xFF))
+        data.append(UInt8((value >> 8) & 0xFF))
+        data.append(UInt8(value & 0xFF))
+    }
 }
 
 // MARK: - Tests
@@ -337,12 +350,12 @@ struct WindowContentDecoderTests {
         #expect(content.cursorline == GUICursorline(row: 3, bg: 0x112233))
     }
 
-    @Test("Decode rows with text and buf_line")
+    @Test("Decode rows with row_id, text, and buf_line")
     func decodeRows() throws {
         var builder = WindowContentBuilder()
         builder.rows = [
-            .init(rowType: 0, bufLine: 0, text: "hello"),
-            .init(rowType: 0, bufLine: 1, text: "world"),
+            .init(rowType: 0, rowId: 0x1000_0000_0000_0001, bufLine: 0, text: "hello"),
+            .init(rowType: 0, rowId: 0x1000_0001_0000_0000, bufLine: 1, text: "world"),
         ]
 
         let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
@@ -352,8 +365,10 @@ struct WindowContentDecoderTests {
 
         #expect(content.rows.count == 2)
         #expect(content.rows[0].text == "hello")
+        #expect(content.rows[0].rowId == 0x1000_0000_0000_0001)
         #expect(content.rows[0].bufLine == 0)
         #expect(content.rows[1].text == "world")
+        #expect(content.rows[1].rowId == 0x1000_0001_0000_0000)
         #expect(content.rows[1].bufLine == 1)
     }
 

--- a/test/minga/frontend/adapter/gui/window_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/window_encoder_test.exs
@@ -95,6 +95,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
 
   test "encodes window content from the core window model" do
     row = %Row{
+      row_id: Row.stable_id(:normal, 7),
       row_type: :normal,
       buf_line: 7,
       text: "hello",
@@ -111,6 +112,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
 
     assert decoded.window_id == 1
     assert hd(decoded.rows).text == "hello"
+    assert hd(decoded.rows).row_id == Row.stable_id(:normal, 7)
     assert hd(decoded.rows).buf_line == 7
     assert hd(decoded.rows).spans |> hd() |> Map.fetch!(:fg) == 0xFF0000
     assert decoded.selection.start_col == 1
@@ -118,6 +120,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
 
   test "encodes full window content overlays and cursor flags" do
     row = %Row{
+      row_id: Row.stable_id(:virtual_line, 11, 0, 4),
       row_type: :virtual_line,
       buf_line: 11,
       text: "héllo",
@@ -166,6 +169,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
     assert decoded.cursor_shape == :underline
     assert decoded.scroll_left == 2
     assert hd(decoded.rows).row_type == :virtual_line
+    assert hd(decoded.rows).row_id == Row.stable_id(:virtual_line, 11, 0, 4)
     assert hd(decoded.rows).text == "héllo"
 
     assert hd(decoded.rows).spans |> hd() |> Map.take([:attrs, :font_weight, :font_id]) == %{
@@ -273,6 +277,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
 
   test "adapter reports per-section byte metrics from emitted commands" do
     row = %Row{
+      row_id: Row.stable_id(:normal, 7),
       row_type: :normal,
       buf_line: 7,
       text: "hello",

--- a/test/minga/frontend/adapter/tui/window_adapter_test.exs
+++ b/test/minga/frontend/adapter/tui/window_adapter_test.exs
@@ -27,6 +27,7 @@ defmodule Minga.Frontend.Adapter.TUI.WindowAdapterTest do
       window(
         [
           %Row{
+            row_id: Row.stable_id(:normal, 0),
             row_type: :normal,
             buf_line: 0,
             text: "abcdef",
@@ -56,6 +57,7 @@ defmodule Minga.Frontend.Adapter.TUI.WindowAdapterTest do
       window(
         [
           %Row{
+            row_id: Row.stable_id(:normal, 0),
             row_type: :normal,
             buf_line: 0,
             text: "a日b",
@@ -79,6 +81,7 @@ defmodule Minga.Frontend.Adapter.TUI.WindowAdapterTest do
       window(
         [
           %Row{
+            row_id: Row.stable_id(:normal, 0),
             row_type: :normal,
             buf_line: 0,
             text: "\tb",
@@ -100,9 +103,30 @@ defmodule Minga.Frontend.Adapter.TUI.WindowAdapterTest do
     model =
       window(
         [
-          %Row{row_type: :normal, buf_line: 0, text: "abcd", spans: [], content_hash: 1},
-          %Row{row_type: :normal, buf_line: 1, text: "abcd", spans: [], content_hash: 2},
-          %Row{row_type: :normal, buf_line: 2, text: "abcd", spans: [], content_hash: 3}
+          %Row{
+            row_id: Row.stable_id(:normal, 0),
+            row_type: :normal,
+            buf_line: 0,
+            text: "abcd",
+            spans: [],
+            content_hash: 1
+          },
+          %Row{
+            row_id: Row.stable_id(:normal, 1),
+            row_type: :normal,
+            buf_line: 1,
+            text: "abcd",
+            spans: [],
+            content_hash: 2
+          },
+          %Row{
+            row_id: Row.stable_id(:normal, 2),
+            row_type: :normal,
+            buf_line: 2,
+            text: "abcd",
+            spans: [],
+            content_hash: 3
+          }
         ],
         selection: %Selection{type: :block, start_row: 0, start_col: 1, end_row: 2, end_col: 3}
       )

--- a/test/minga/render_model/window/row_test.exs
+++ b/test/minga/render_model/window/row_test.exs
@@ -1,0 +1,23 @@
+defmodule Minga.RenderModel.Window.RowTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.RenderModel.Window.Row
+
+  describe "stable_id/4" do
+    test "is deterministic for the same durable row inputs" do
+      assert Row.stable_id(:normal, 12, 0, 0) == Row.stable_id(:normal, 12, 0, 0)
+    end
+
+    test "distinguishes row kinds, wrapped continuations, and decoration discriminators" do
+      ids = [
+        Row.stable_id(:normal, 12, 0, 0),
+        Row.stable_id(:wrap_continuation, 12, 1, 0),
+        Row.stable_id(:fold_start, 12, 0, 0),
+        Row.stable_id(:virtual_line, 12, 0, 1),
+        Row.stable_id(:block, 12, 1, 2)
+      ]
+
+      assert Enum.uniq(ids) == ids
+    end
+  end
+end

--- a/test/minga/render_model/window/row_test.exs
+++ b/test/minga/render_model/window/row_test.exs
@@ -20,4 +20,23 @@ defmodule Minga.RenderModel.Window.RowTest do
       assert Enum.uniq(ids) == ids
     end
   end
+
+  describe "stable_decoration_id/3" do
+    test "is deterministic for virtual text and block decoration identities" do
+      vt_id = make_ref()
+      block_id = make_ref()
+
+      assert Row.stable_decoration_id(:virtual_line, 12, vt_id) ==
+               Row.stable_decoration_id(:virtual_line, 12, vt_id)
+
+      assert Row.stable_decoration_id(:virtual_line, 12, vt_id) !=
+               Row.stable_decoration_id(:virtual_line, 12, make_ref())
+
+      assert Row.stable_decoration_id(:block, 12, {block_id, 0}) !=
+               Row.stable_decoration_id(:block, 12, {block_id, 1})
+
+      assert Row.stable_decoration_id(:fold_start, 12, block_id) ==
+               Row.stable_decoration_id(:fold_start, 12, block_id)
+    end
+  end
 end

--- a/test/minga_editor/agent/view/prompt_render_window_test.exs
+++ b/test/minga_editor/agent/view/prompt_render_window_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.Agent.View.PromptRenderWindowTest do
   alias MingaEditor.Agent.ViewContext
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer
+  alias Minga.RenderModel.Window.Row
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.UI.Theme
   alias MingaEditor.VimState
@@ -64,18 +65,22 @@ defmodule MingaEditor.Agent.View.PromptRenderWindowTest do
       assert Enum.map(model.rows, & &1.text) == ["hello"]
     end
 
-    test "uses row hashes for prompt edits without forcing full refresh" do
+    test "uses row hashes and stable row IDs for prompt edits without forcing full refresh" do
       ctx = prompt_ctx("hello", input_focused: true, cursor: {0, 5}, mode: :insert)
       model = PromptRenderWindow.build(ctx, 40, {10, 2, 40, 3})
-      old_hash = hd(model.rows).content_hash
+      [row] = model.rows
+      old_hash = row.content_hash
+      old_row_id = row.row_id
 
       assert model.full_refresh == false
+      assert old_row_id == Row.stable_id(:normal, 0, 0)
 
       Buffer.insert_text(ctx.ui_state.panel.prompt_buffer, "!")
       updated = PromptRenderWindow.build(ctx, 40, {10, 2, 40, 3})
 
       assert updated.content_epoch == model.content_epoch
       assert updated.full_refresh == false
+      assert hd(updated.rows).row_id == old_row_id
       assert hd(updated.rows).content_hash != old_hash
     end
 

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -990,6 +990,7 @@ defmodule Minga.Integration.GUIProtocolTest do
         cursor_shape: :beam,
         rows: [
           %Row{
+            row_id: Row.stable_id(:normal, 0),
             row_type: :normal,
             buf_line: 0,
             text: "def foo do",
@@ -999,6 +1000,7 @@ defmodule Minga.Integration.GUIProtocolTest do
             ]
           },
           %Row{
+            row_id: Row.stable_id(:fold_start, 1),
             row_type: :fold_start,
             buf_line: 1,
             text: "  :ok",
@@ -1036,10 +1038,12 @@ defmodule Minga.Integration.GUIProtocolTest do
       [r1, r2] = decoded["rows"]
       assert r1["text"] == "def foo do"
       assert r1["row_type"] == 0
+      assert r1["row_id"] == Row.stable_id(:normal, 0)
       assert r1["buf_line"] == 0
       assert length(r1["spans"]) == 1
       assert hd(r1["spans"])["fg"] == 0x51AFEF
       assert r2["row_type"] == 1
+      assert r2["row_id"] == Row.stable_id(:fold_start, 1)
       assert r2["text"] == "  :ok"
 
       assert decoded["selection"]["type"] == 1

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Core.Face
   alias Minga.Editing.Search.Match
   alias MingaEditor.Layout
   alias MingaEditor.RenderModel.Window.Builder
@@ -14,6 +15,7 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
   alias MingaEditor.Window, as: EditorWindow
   alias MingaEditor.WindowTree
   alias Minga.RenderModel.Window
+  alias Minga.RenderModel.Window.Row
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -139,9 +141,69 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
 
       assert Enum.map(model.rows, & &1.row_type) == [:normal, :wrap_continuation]
       assert Enum.map(model.rows, & &1.visual_index) == [0, 1]
+
+      assert Enum.map(model.rows, & &1.row_id) == [
+               Row.stable_id(:normal, 0),
+               Row.stable_id(:wrap_continuation, 0, 1)
+             ]
+
       assert Enum.map(model.rows, & &1.text) == ["abcdefghijABCD", "EFGHIJ"]
       assert model.cursor_row == 0
       assert model.cursor_col == 12
+    end
+
+    test "virtual line rows use unique stable row IDs per anchor line" do
+      state = gui_state(content: "line\nnext")
+      buffer = state.workspace.buffers.active
+
+      BufferProcess.add_virtual_text(buffer, {0, 0},
+        segments: [{"first virtual", Face.new()}],
+        placement: :above,
+        priority: 0
+      )
+
+      BufferProcess.add_virtual_text(buffer, {0, 0},
+        segments: [{"second virtual", Face.new()}],
+        placement: :above,
+        priority: 1
+      )
+
+      {[wf], _cursor, _state} = build_content(state)
+
+      virtual_rows = Enum.filter(wf.window_model.rows, &(&1.row_type == :virtual_line))
+      assert Enum.map(virtual_rows, & &1.text) == ["first virtual", "second virtual"]
+
+      assert Enum.map(virtual_rows, & &1.row_id) == [
+               Row.stable_id(:virtual_line, 0, 0),
+               Row.stable_id(:virtual_line, 0, 1)
+             ]
+    end
+
+    test "block decoration rows use unique stable row IDs per anchor line" do
+      state = gui_state(content: "line\nnext")
+      buffer = state.workspace.buffers.active
+
+      BufferProcess.add_block_decoration(buffer, 0,
+        placement: :above,
+        render: fn _width -> [{"first block", Face.new()}] end,
+        priority: 0
+      )
+
+      BufferProcess.add_block_decoration(buffer, 0,
+        placement: :above,
+        render: fn _width -> [{"second block", Face.new()}] end,
+        priority: 1
+      )
+
+      {[wf], _cursor, _state} = build_content(state)
+
+      block_rows = Enum.filter(wf.window_model.rows, &(&1.row_type == :block))
+      assert Enum.map(block_rows, & &1.text) == ["first block", "second block"]
+
+      assert Enum.map(block_rows, & &1.row_id) == [
+               Row.stable_id(:block, 0, 0),
+               Row.stable_id(:block, 0, 1)
+             ]
     end
 
     test "wrapped geometry reports total visual rows for the whole buffer" do

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -2,7 +2,9 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Core.Decorations
   alias Minga.Core.Face
+  alias Minga.Editing.Fold.Range, as: FoldRange
   alias Minga.Editing.Search.Match
   alias MingaEditor.Layout
   alias MingaEditor.RenderModel.Window.Builder
@@ -152,21 +154,23 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       assert model.cursor_col == 12
     end
 
-    test "virtual line rows use unique stable row IDs per anchor line" do
+    test "virtual line row IDs stay stable when earlier siblings are removed" do
       state = gui_state(content: "line\nnext")
       buffer = state.workspace.buffers.active
 
-      BufferProcess.add_virtual_text(buffer, {0, 0},
-        segments: [{"first virtual", Face.new()}],
-        placement: :above,
-        priority: 0
-      )
+      first_id =
+        BufferProcess.add_virtual_text(buffer, {0, 0},
+          segments: [{"first virtual", Face.new()}],
+          placement: :above,
+          priority: 0
+        )
 
-      BufferProcess.add_virtual_text(buffer, {0, 0},
-        segments: [{"second virtual", Face.new()}],
-        placement: :above,
-        priority: 1
-      )
+      second_id =
+        BufferProcess.add_virtual_text(buffer, {0, 0},
+          segments: [{"second virtual", Face.new()}],
+          placement: :above,
+          priority: 1
+        )
 
       {[wf], _cursor, _state} = build_content(state)
 
@@ -174,26 +178,36 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       assert Enum.map(virtual_rows, & &1.text) == ["first virtual", "second virtual"]
 
       assert Enum.map(virtual_rows, & &1.row_id) == [
-               Row.stable_id(:virtual_line, 0, 0),
-               Row.stable_id(:virtual_line, 0, 1)
+               Row.stable_decoration_id(:virtual_line, 0, first_id),
+               Row.stable_decoration_id(:virtual_line, 0, second_id)
              ]
+
+      :ok = BufferProcess.remove_virtual_text(buffer, first_id)
+
+      {[wf], _cursor, _state} = build_content(state)
+
+      [remaining] = Enum.filter(wf.window_model.rows, &(&1.row_type == :virtual_line))
+      assert remaining.text == "second virtual"
+      assert remaining.row_id == Row.stable_decoration_id(:virtual_line, 0, second_id)
     end
 
-    test "block decoration rows use unique stable row IDs per anchor line" do
+    test "block decoration row IDs stay stable when earlier siblings are removed" do
       state = gui_state(content: "line\nnext")
       buffer = state.workspace.buffers.active
 
-      BufferProcess.add_block_decoration(buffer, 0,
-        placement: :above,
-        render: fn _width -> [{"first block", Face.new()}] end,
-        priority: 0
-      )
+      first_id =
+        BufferProcess.add_block_decoration(buffer, 0,
+          placement: :above,
+          render: fn _width -> [{"first block", Face.new()}] end,
+          priority: 0
+        )
 
-      BufferProcess.add_block_decoration(buffer, 0,
-        placement: :above,
-        render: fn _width -> [{"second block", Face.new()}] end,
-        priority: 1
-      )
+      second_id =
+        BufferProcess.add_block_decoration(buffer, 0,
+          placement: :above,
+          render: fn _width -> [{"second block", Face.new()}] end,
+          priority: 1
+        )
 
       {[wf], _cursor, _state} = build_content(state)
 
@@ -201,9 +215,55 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       assert Enum.map(block_rows, & &1.text) == ["first block", "second block"]
 
       assert Enum.map(block_rows, & &1.row_id) == [
-               Row.stable_id(:block, 0, 0),
-               Row.stable_id(:block, 0, 1)
+               Row.stable_decoration_id(:block, 0, {first_id, 0}),
+               Row.stable_decoration_id(:block, 0, {second_id, 0})
              ]
+
+      :ok = BufferProcess.remove_block_decoration(buffer, first_id)
+
+      {[wf], _cursor, _state} = build_content(state)
+
+      [remaining] = Enum.filter(wf.window_model.rows, &(&1.row_type == :block))
+      assert remaining.text == "second block"
+      assert remaining.row_id == Row.stable_decoration_id(:block, 0, {second_id, 0})
+    end
+
+    test "fold-start rows use stable ids for window folds" do
+      state = gui_state(content: "line 1\nline 2\nline 3")
+      window = Map.fetch!(state.workspace.windows.map, state.workspace.windows.active)
+      window = EditorWindow.set_fold_ranges(window, [FoldRange.new!(0, 2)])
+      window = EditorWindow.fold_at(window, 0)
+
+      windows =
+        Windows.set_map(
+          state.workspace.windows,
+          Map.put(state.workspace.windows.map, state.workspace.windows.active, window)
+        )
+
+      state = %{state | workspace: %{state.workspace | windows: windows}}
+
+      {[wf], _cursor, _state} = build_content(state)
+
+      [fold_row] = Enum.filter(wf.window_model.rows, &(&1.row_type == :fold_start))
+      assert fold_row.row_id == Row.stable_id(:fold_start, 0, 0, 2)
+    end
+
+    test "decoration fold rows use stable decoration ids" do
+      state = gui_state(content: "line 1\nline 2\nline 3")
+      buffer = state.workspace.buffers.active
+
+      :ok =
+        BufferProcess.batch_decorations(buffer, fn decs ->
+          {_id, decs} = Decorations.add_fold_region(decs, 0, 2, closed: true)
+          decs
+        end)
+
+      [fold] = BufferProcess.decorations(buffer).fold_regions
+
+      {[wf], _cursor, _state} = build_content(state)
+
+      [fold_row] = Enum.filter(wf.window_model.rows, &(&1.row_type == :fold_start))
+      assert fold_row.row_id == Row.stable_decoration_id(:fold_start, 0, fold.id)
     end
 
     test "wrapped geometry reports total visual rows for the whole buffer" do

--- a/test/support/gui_window_decoder.ex
+++ b/test/support/gui_window_decoder.ex
@@ -165,8 +165,8 @@ defmodule Minga.Test.GUIWindowDecoder do
   defp decode_rows(rest, 0, acc), do: {Enum.reverse(acc), rest}
 
   defp decode_rows(
-         <<row_type::8, buf_line::32, content_hash::32, text_len::32, text::binary-size(text_len),
-           span_count::16, rest::binary>>,
+         <<row_type::8, row_id::64, buf_line::32, content_hash::32, text_len::32,
+           text::binary-size(text_len), span_count::16, rest::binary>>,
          remaining,
          acc
        ) do
@@ -174,6 +174,7 @@ defmodule Minga.Test.GUIWindowDecoder do
 
     row = %{
       row_type: decode_row_type(row_type),
+      row_id: row_id,
       buf_line: buf_line,
       content_hash: content_hash,
       text: text,


### PR DESCRIPTION
# TL;DR
Adds BEAM-authored stable row IDs to the retained GUI window content path so Swift can reuse row textures across scrolls without keying by display row. Also documents the Phase 3 instrumentation audit and updates Phase 4 protocol docs and regression coverage.

## Context
This implements the Phase 3/4 slice from `docs/RETAINED_GUI_RENDERING_SPEC.md`. Phase 3 instrumentation was already present in the BEAM and Swift paths, so this PR records that status and focuses implementation work on Phase 4 stable row identity.

## Changes
- Added `row_id` to `Minga.RenderModel.Window.Row` with deterministic 64-bit IDs by row kind, buffer line, visual index, and a small discriminator where needed.
- Populated row IDs for normal rows, wrapped continuations, fold summaries, virtual lines, block decorations, and agent prompt rows.
- Extended `gui_window_content` row encoding with `row_id::64`, then updated Elixir test decoding, Swift protocol decoding, and the Swift test harness JSON output.
- Changed Swift retained row caches and atlas keys to use stable row identity instead of display row, with content epoch folded into the invalidation hash.
- Added per-frame row identity indexes for virtual and block decoration rows so multiple decoration rows on one buffer line do not collide.
- Added Swift coverage for reuse after vertical scroll, hash misses on horizontal scroll, epoch changes, and full-refresh atlas invalidation.
- Updated retained rendering and GUI protocol docs to reflect stable row identity semantics.

## Verification
- `make lint` ✅
- `mix compile --warnings-as-errors` ✅
- `mix test.llm --max-cases 1` ✅, 8959 tests, 0 failures, 285 excluded
- Focused Elixir tests ✅: `test/minga/render_model/window/row_test.exs`, `test/minga/frontend/adapter/gui/window_encoder_test.exs`, `test/minga_editor/render_model/window/builder_test.exs`, `test/minga_editor/agent/view/prompt_render_window_test.exs`, `test/minga/frontend/adapter/tui/window_adapter_test.exs`
- `mix swift.build` exits 0 but skipped locally because `xcodebuild` is not installed
- `mix swift.harness` exits 0 but skipped locally because `swiftc` is not installed

Note: default-concurrency `mix test.llm` exposed unrelated intermittent async/global-state failures in existing tests during local validation. The failing cases passed individually, and the full suite passed serially with `--max-cases 1`.

## Acceptance Criteria Addressed
- Phase 3 instrumentation audited and documented as already present ✅
- Stable row IDs added to the BEAM render model and GUI window-content wire format ✅
- Swift decoder and retained atlas keying use stable row identity ✅
- Virtual-line and block-decoration row IDs are unique within a window frame ✅
- Docs and regression tests updated for the new retained rendering identity contract ✅
