### PR TITLE
GUI polish: tab legibility, faithful editor fixtures, spacing scale

### DIFF
--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -244,7 +244,11 @@ enum PreviewRegistry {
 
         if agentVisible {
             populateAgentChat(appState.gui.agentChatState)
-        } else {
+        } else if mode == .insert {
+            // Completion fires while typing, so show it in the insert-mode
+            // preview. The normal-mode editor stays clean so its snapshot
+            // shows the editor surface (cursorline, indent guides, diagnostics)
+            // rather than a popup covering the code.
             populateCompletion(appState.gui.completionState)
         }
 
@@ -288,6 +292,18 @@ enum PreviewRegistry {
         dispatcher.frameState.totalLineCount = 1250
         dispatcher.frameState.viewportTopLine = 38
         dispatcher.frameState.scrollIndicatorColor = 0x5C6370
+        // Indent guides for the visible window, matching previewEditorRows()
+        // (2-space Elixir indent). The cursor's enclosing level (col 2) is the
+        // active guide. Exercises the same render path the BEAM drives via the
+        // gui_indent_guides (0x91) opcode so the snapshot reflects the real
+        // editor surface rather than underselling it.
+        dispatcher.frameState.windowIndentGuides[1] = IndentGuideData(
+            windowId: 1,
+            tabWidth: 2,
+            activeGuideCol: 2,
+            guideCols: [0, 2],
+            lineIndentLevels: [0, 1, 1, 1, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        )
         dispatcher.frameState.windowGutters[1] = Wire.WindowGutter(
             windowId: 1,
             contentRow: 1,
@@ -295,7 +311,7 @@ enum PreviewRegistry {
             contentHeight: 22,
             isActive: true,
             contentWidth: 108,
-            cursorLine: 42,
+            cursorLine: 43,
             lineNumberStyle: .absolute,
             lineNumberWidth: 3,
             signColWidth: 1,
@@ -313,7 +329,11 @@ enum PreviewRegistry {
             searchMatches: [],
             diagnosticUnderlines: [GUIDiagnosticUnderline(startRow: 4, startCol: 20, endRow: 4, endCol: 31, severity: .warning)],
             documentHighlights: [GUIDocumentHighlight(startRow: 5, startCol: 4, endRow: 5, endCol: 10, kind: .read)],
-            lineAnnotations: []
+            lineAnnotations: [],
+            // Current-line band on the cursor row. The renderer reads the
+            // per-window cursorline (CoreTextMetalRenderer drawWindowedContent),
+            // not frameState, so it must be set here to render.
+            cursorline: GUICursorline(row: 5, bg: 0x2C323C)
         )
     }
 

--- a/macos/Sources/Views/MessagesContentView.swift
+++ b/macos/Sources/Views/MessagesContentView.swift
@@ -100,7 +100,7 @@ private struct MessagesFilterBar: View {
     let theme: ThemeColors
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: Spacing.sm) {
             // Level toggles
             levelToggles
 
@@ -139,15 +139,15 @@ private struct MessagesFilterBar: View {
                 .help("Reset all filters")
             }
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.xs)
         .background(theme.tabBg.opacity(0.5))
     }
 
     // MARK: - Level toggles
 
     private var levelToggles: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: Spacing.xs) {
             levelButton(level: 0, label: "D", color: .gray)
             levelButton(level: 1, label: "I", color: .green)
             levelButton(level: 2, label: "W", color: .yellow)
@@ -177,7 +177,7 @@ private struct MessagesFilterBar: View {
     // MARK: - Subsystem toggles
 
     private var subsystemToggles: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: Spacing.xs) {
             ForEach(Array(state.presentSubsystems).sorted(), id: \.self) { sub in
                 subsystemPill(sub: sub)
             }

--- a/macos/Sources/Views/ObservatoryView.swift
+++ b/macos/Sources/Views/ObservatoryView.swift
@@ -23,7 +23,7 @@ struct ObservatoryView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack {
                 Text("BEAM Observatory")
                     .font(.headline)
@@ -38,24 +38,24 @@ struct ObservatoryView: View {
                 .font(.caption)
                 .foregroundStyle(theme.treeFg.opacity(0.55))
         }
-        .padding(10)
+        .padding(Spacing.md)
     }
 
     private var treeList: some View {
         ScrollView {
-            LazyVStack(alignment: .leading, spacing: 2) {
+            LazyVStack(alignment: .leading, spacing: Spacing.hairline) {
                 ForEach(visibleTreeNodes()) { node in
                     row(node)
                 }
             }
-            .padding(.vertical, 6)
+            .padding(.vertical, Spacing.sm)
         }
         .focusable(false)
         .focusEffectDisabled()
     }
 
     private func row(_ node: ObservatoryNode) -> some View {
-        HStack(spacing: 6) {
+        HStack(spacing: Spacing.sm) {
             Button {
                 activateRow(node)
             } label: {
@@ -75,14 +75,17 @@ struct ObservatoryView: View {
             }
             .buttonStyle(.plain)
         }
-        .padding(.leading, CGFloat(node.depth) * 14 + 8)
-        .padding(.trailing, 8)
-        .padding(.vertical, 4)
+        // 12pt per depth level (down from 14) keeps deep nodes from starving
+        // the name column; the right-side memory/sparkline cluster is tightened
+        // in rowMainContent for the same reason.
+        .padding(.leading, CGFloat(node.depth) * Spacing.md + Spacing.sm)
+        .padding(.trailing, Spacing.sm)
+        .padding(.vertical, Spacing.xs)
         .background(selectedNodeId == node.id ? theme.treeSelectionBg.opacity(0.55) : Color.clear, in: RoundedRectangle(cornerRadius: 6))
     }
 
     private func rowMainContent(_ node: ObservatoryNode) -> some View {
-        HStack(spacing: 6) {
+        HStack(spacing: Spacing.xs) {
             if node.isSupervisor {
                 Image(systemName: disclosureIcon(node))
                     .font(.caption)
@@ -97,8 +100,8 @@ struct ObservatoryView: View {
                 .foregroundStyle(classColor(node))
                 .frame(width: 14)
 
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 4) {
+            VStack(alignment: .leading, spacing: Spacing.hairline) {
+                HStack(spacing: Spacing.xs) {
                     Circle()
                         .fill(statusColor(node))
                         .frame(width: 6, height: 6)
@@ -119,13 +122,13 @@ struct ObservatoryView: View {
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
                 .foregroundStyle(theme.treeFg.opacity(0.55))
-                .frame(minWidth: 52, alignment: .trailing)
-                .padding(.horizontal, 5)
-                .padding(.vertical, 2)
+                .frame(minWidth: 46, alignment: .trailing)
+                .padding(.horizontal, Spacing.xs)
+                .padding(.vertical, Spacing.hairline)
                 .background(theme.treeSelectionBg.opacity(0.35), in: Capsule())
 
             SparklineView(data: node.sparkline, color: statusColor(node))
-                .frame(width: 48, height: 16)
+                .frame(width: 40, height: 16)
         }
         .contentShape(Rectangle())
     }

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -508,11 +508,11 @@ struct TabBarView: View {
             if tab.isAgent {
                 Image(systemName: "cpu")
                     .font(.system(size: 11))
-                    .foregroundStyle(tab.isActive ? theme.tabActiveFg : theme.tabInactiveFg)
+                    .foregroundStyle(tab.isActive ? theme.tabActiveFg : theme.tabSecondaryFg)
             } else {
                 Text(tab.icon)
                     .font(.custom("Symbols Nerd Font Mono", size: 12))
-                    .foregroundStyle(tab.isActive ? theme.tabActiveFg : theme.tabInactiveFg)
+                    .foregroundStyle(tab.isActive ? theme.tabActiveFg : theme.tabSecondaryFg)
             }
 
             // Label: pinned and agent tabs stay compact; the tooltip carries the full name.
@@ -521,7 +521,7 @@ struct TabBarView: View {
                     .font(.system(size: 11.5))
                     .lineLimit(1)
                     .truncationMode(.middle)
-                    .foregroundStyle(tab.isActive ? theme.tabActiveFg : theme.tabInactiveFg)
+                    .foregroundStyle(tab.isActive ? theme.tabActiveFg : theme.tabSecondaryFg)
             }
 
             if !tab.isPinned {

--- a/macos/Sources/Views/ThemeColors.swift
+++ b/macos/Sources/Views/ThemeColors.swift
@@ -156,6 +156,11 @@ final class ThemeColors {
     var treeSecondaryFg: Color { treeFg.opacity(0.78) }
     var treeMutedFg: Color { treeFg.opacity(0.62) }
     var treeDisabledFg: Color { treeFg.opacity(0.42) }
+    // Inactive tab content derives from the active tab foreground so it stays
+    // legible and theme-correct. The active/inactive distinction is carried by
+    // the active tab's background fill and top accent bar, so the inactive
+    // label sits at the "secondary" tier rather than the darkest flat color.
+    var tabSecondaryFg: Color { tabActiveFg.opacity(0.78) }
     var agentSecondaryFg: Color { agentTextFg.opacity(0.78) }
     var agentMutedFg: Color { agentTextFg.opacity(0.62) }
     var agentDisabledFg: Color { agentTextFg.opacity(0.42) }
@@ -273,6 +278,30 @@ final class ThemeColors {
         }
     }
 
+}
+
+/// Shared spacing scale for SwiftUI chrome.
+///
+/// A 4pt modular grid. Reach for the nearest step instead of ad-hoc magic
+/// numbers so spacing rhythm stays consistent across views. A 4pt grid reads
+/// more evenly for dense UI layout than a literal golden-ratio scale (φ suits
+/// type and section rhythm better than control gaps), so the steps below are
+/// the de-facto 4pt system used by Apple, Material, and Tailwind.
+enum Spacing {
+    /// 2pt: hairline. Badge internals, dot-to-glyph.
+    static let hairline: CGFloat = 2
+    /// 4pt: tight inline groups (chips, toggles, icon-to-label).
+    static let xs: CGFloat = 4
+    /// 8pt: default control/element gap.
+    static let sm: CGFloat = 8
+    /// 12pt: row padding, label-to-content, comfortable rows.
+    static let md: CGFloat = 12
+    /// 16pt: separation between distinct groups.
+    static let lg: CGFloat = 16
+    /// 20pt: section/panel padding.
+    static let xl: CGFloat = 20
+    /// 32pt: major section breaks.
+    static let xxl: CGFloat = 32
 }
 
 /// File-private helper to create a Color from a 24-bit RGB integer.


### PR DESCRIPTION
A focused chrome polish pass. Three independent improvements, each verified against regenerated snapshots. Diff is small (78 insertions / 26 deletions across 5 files); snapshot PNGs are gitignored so there's no binary churn.

## 1. Inactive tab legibility
The tab bar was the only chrome family rendering its **primary** labels in the flat, darkest theme color (`tabInactiveFg` ≈ 2:1 contrast). Every other family (chrome/popup/modeline/tree/agent) uses a derived secondary/muted tier.

- Added the missing `tabSecondaryFg` tier (`tabActiveFg.opacity(0.78)`) and applied it to inactive tab labels + icons.
- Theme-correct: tracks the active foreground rather than a hardcoded value. The active/inactive distinction is still carried by the active tab's background fill + accent bar.

## 2. Faithful editor preview fixtures (preview-only, no production change)
The editor snapshots were *underselling* the editor — two features that exist in the renderer were never exercised, and a completion popup always covered the code.

- Inject the per-window **cursorline** band (the renderer reads `content.cursorline`, not `frameState`, which is why it never rendered) and **indent guides** (the `gui_indent_guides` path).
- Align the gutter current line to the cursor row.
- Show completion only in the **insert-mode** preview, so the normal-mode hero shot shows a clean editor surface. Insert-mode keeps completion-in-editor coverage.

Net effect: the editor snapshot now reflects and regression-tests the real surface (current-line highlight + indent guides), matching Zed/VS Code.

## 3. Shared spacing scale + spacing polish
- Introduced a `Spacing` enum: a documented 4pt modular grid (`hairline/xs/sm/md/lg/xl/xxl`) as the design token for chrome spacing. (4pt grid over literal golden-ratio — φ suits type/section rhythm, not dense control gaps.)
- **Observatory**: tightened inner column gaps, per-level indent (14→12), and the memory-pill/sparkline footprint so the starved process-name column gets its width back. `Minga.Editor.Supervisor` / `Minga.Buffer.Process` and most PIDs now display in full.
- **Messages filter toolbar**: loosened the crammed `spacing: 2` severity/subsystem pill clusters (→4) and group gaps (→8) so the pills breathe.

The scale is now available for the rest of the chrome to adopt; a full migration of remaining views is a deliberate follow-up rather than buried here.

## Verification
Regenerated and visually reviewed snapshots for `TabBarView`, `EditorChromeView`, `InsertModeEditorView`, `ObservatoryView`, and `BottomPanelView`.

## Follow-ups (not in this PR)
- Full migration of remaining views onto `Spacing.*`.
- Settings pane `.formStyle(.grouped)` to fix its ragged label alignment — needs real-app verification (the snapshot harness can't capture grouped forms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)