### PR TITLE
Redesign the Messages panel: cut noise, fix auto-scroll

### DIFF
--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -47,6 +47,8 @@ enum PreviewRegistry {
             notificationStackPreview()
         case "BottomPanelView":
             bottomPanelPreview()
+        case "MessagesContentView":
+            messagesContentPreview()
         case "BottomPanelEmpty":
             bottomPanelEmptyPreview()
         case "SettingsView":
@@ -1012,6 +1014,22 @@ enum PreviewRegistry {
         return BottomPanelView(state: state, theme: theme, encoder: nil, availableHeight: 600)
             .frame(width: 800, height: 250)
             .background(theme.editorBg)
+    }
+
+    private static func messagesContentPreview() -> some View {
+        let state = MessagesContentState()
+        let theme = populatedTheme()
+        populateMessages(state)
+
+        return MessagesContentView(
+            state: state,
+            theme: theme,
+            encoder: nil,
+            usesPreviewEagerLayout: PreviewSnapshotPolicy.shouldUseEagerLayout(for: "MessagesContentView")
+        )
+        .frame(width: 800, height: 360)
+        .background(theme.editorBg)
+        .preferredColorScheme(.dark)
     }
 
     private static func bottomPanelEmptyPreview() -> some View {

--- a/macos/Sources/PreviewSnapshotPolicy.swift
+++ b/macos/Sources/PreviewSnapshotPolicy.swift
@@ -5,7 +5,7 @@ import Foundation
 enum PreviewSnapshotPolicy {
     private static let fullShellViews: Set<String> = ["EditorChromeView", "AgentChromeView", "DiagnosticsEditorView", "InsertModeEditorView", "HoverEditorView", "SignatureHelpEditorView"]
     private static let renderedWindowViews = fullShellViews
-    private static let eagerLayoutViews: Set<String> = ["GitStatusView", "FileTreeView", "FileTreeEmpty", "FileTreeError", "FileTreeDeep", "GitStatusClean", "GitStatusConflict", "GitStatusDense", "FileTreeRename"]
+    private static let eagerLayoutViews: Set<String> = ["GitStatusView", "FileTreeView", "FileTreeEmpty", "FileTreeError", "FileTreeDeep", "GitStatusClean", "GitStatusConflict", "GitStatusDense", "FileTreeRename", "MessagesContentView"]
 
     static func size(named name: String) -> CGSize {
         switch name {
@@ -18,6 +18,7 @@ enum PreviewSnapshotPolicy {
         case "TabBarView": CGSize(width: 800, height: 36)
         case "NotificationCenterView", "NotificationStack": CGSize(width: 800, height: 600)
         case "BottomPanelView", "BottomPanelEmpty": CGSize(width: 800, height: 250)
+        case "MessagesContentView": CGSize(width: 800, height: 360)
         case "SettingsView": CGSize(width: 600, height: 480)
         case "ToolManagerView": CGSize(width: 800, height: 600)
         case "ObservatoryView": CGSize(width: 320, height: 640)

--- a/macos/Sources/Views/MessagesContentState.swift
+++ b/macos/Sources/Views/MessagesContentState.swift
@@ -64,6 +64,28 @@ struct MessageEntry: Identifiable, Equatable {
         Self.subsystemColor(for: subsystem)
     }
 
+    /// Static lookup for level color by ID (used by filter bar + severity summary).
+    static func levelColor(for level: UInt8) -> Color {
+        switch level {
+        case 0: return .gray
+        case 1: return .green
+        case 2: return .yellow
+        case 3: return .red
+        default: return .gray
+        }
+    }
+
+    /// Static lookup for a human-readable level name (used for tooltips).
+    static func levelName(for level: UInt8) -> String {
+        switch level {
+        case 0: return "Debug"
+        case 1: return "Info"
+        case 2: return "Warning"
+        case 3: return "Error"
+        default: return "Unknown"
+        }
+    }
+
     /// Static lookup for subsystem name by ID (used by filter bar).
     static func subsystemName(for sub: UInt8) -> String {
         switch sub {

--- a/macos/Sources/Views/MessagesContentState.swift
+++ b/macos/Sources/Views/MessagesContentState.swift
@@ -75,8 +75,10 @@ struct MessageEntry: Identifiable, Equatable {
         }
     }
 
-    /// Static lookup for a human-readable level name (used for tooltips).
-    static func levelName(for level: UInt8) -> String {
+    /// Title-case level name for tooltips. Distinct from the instance `levelName`,
+    /// which returns the uppercase badge form ("WARN"); the two formats serve
+    /// different surfaces, so they are intentionally separate.
+    static func levelTooltip(for level: UInt8) -> String {
         switch level {
         case 0: return "Debug"
         case 1: return "Info"

--- a/macos/Sources/Views/MessagesContentView.swift
+++ b/macos/Sources/Views/MessagesContentView.swift
@@ -1,10 +1,13 @@
-/// Native Messages tab content: structured log entries with level and subsystem badges.
+/// Native Messages tab content: structured log entries with a low-noise filter bar.
 ///
-/// Renders log entries as a scrollable list with color-coded level indicators,
-/// subsystem badges, timestamps, and clickable file paths. Auto-scrolls to
-/// the bottom when new entries arrive, with a "jump to latest" button when
-/// the user scrolls up. A filter bar at the top provides level, subsystem,
-/// and text search filtering.
+/// Renders log entries as a scrollable list with a level dot, timestamp, a muted
+/// subsystem label, the message, and an optional clickable file path. The filter
+/// bar keeps a small set of always-visible controls (level dots, a subsystems
+/// menu, search) and surfaces a live severity summary on the trailing side.
+///
+/// Auto-scroll follows the tail only while the user is at the bottom. Scrolling
+/// up pins the view in place; new entries surface a "jump to latest" affordance
+/// instead of yanking the viewport down.
 
 import SwiftUI
 
@@ -12,74 +15,103 @@ struct MessagesContentView: View {
     @Bindable var state: MessagesContentState
     let theme: ThemeColors
     let encoder: InputEncoder?
+    /// Snapshot-only: render the list as a plain, non-lazy stack so every row
+    /// lays out for capture. The live lazy ScrollView path renders blank in the
+    /// preview harness (same pattern as FileTreeView / GitStatusView).
+    var usesPreviewEagerLayout: Bool = false
 
     /// Tracks whether the bottom anchor is visible in the scroll viewport.
     @State private var bottomAnchorVisible: Bool = true
 
     var body: some View {
         VStack(spacing: 0) {
-            // Filter bar
             MessagesFilterBar(state: state, theme: theme)
+            entryList
+        }
+    }
 
-            // Entry list
-            ZStack(alignment: .bottomTrailing) {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        LazyVStack(alignment: .leading, spacing: 0) {
-                            ForEach(state.filteredEntries) { entry in
-                                MessageEntryRow(entry: entry, theme: theme, encoder: encoder)
-                                    .id(entry.id)
-                            }
-
-                            // Invisible anchor at the bottom to detect scroll position.
-                            Color.clear
-                                .frame(height: 1)
-                                .id("bottom-anchor")
-                                .onAppear { handleScrollToBottom() }
-                                .onDisappear { handleScrollUp() }
-                        }
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                    }
-                    .onChange(of: state.filteredEntries.count) { _, _ in
-                        if state.isAutoScrolling, let last = state.filteredEntries.last {
-                            withAnimation(.easeOut(duration: 0.15)) {
-                                proxy.scrollTo(last.id, anchor: .bottom)
-                            }
-                        }
-                    }
-                    .onChange(of: state.isAutoScrolling) { _, scrolling in
-                        if scrolling, let last = state.filteredEntries.last {
-                            withAnimation(.easeOut(duration: 0.15)) {
-                                proxy.scrollTo(last.id, anchor: .bottom)
-                            }
-                        }
-                    }
-                    .defaultScrollAnchor(.bottom)
-                }
-
-                // "Jump to latest" button
-                if state.hasNewEntries && !state.isAutoScrolling {
-                    Button(action: {
-                        state.jumpToLatest()
-                    }) {
-                        HStack(spacing: 4) {
-                            Image(systemName: "arrow.down")
-                                .font(.system(size: 9, weight: .bold))
-                            Text("New messages")
-                                .font(.system(size: 10, weight: .medium))
-                        }
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 5)
-                        .background(theme.accent.opacity(0.9))
-                        .foregroundStyle(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
-                    }
-                    .buttonStyle(.plain)
-                    .padding(12)
+    @ViewBuilder
+    private var entryList: some View {
+        if usesPreviewEagerLayout {
+            VStack(spacing: 0) {
+                ForEach(state.filteredEntries) { entry in
+                    MessageEntryRow(entry: entry, theme: theme, encoder: encoder)
                 }
             }
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.xs)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        } else {
+            liveEntryList
         }
+    }
+
+    private var liveEntryList: some View {
+        ZStack(alignment: .bottomTrailing) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(state.filteredEntries) { entry in
+                            MessageEntryRow(entry: entry, theme: theme, encoder: encoder)
+                                .id(entry.id)
+                        }
+
+                        // Invisible anchor at the bottom to detect scroll position.
+                        Color.clear
+                            .frame(height: 1)
+                            .id("bottom-anchor")
+                            .onAppear { handleScrollToBottom() }
+                            .onDisappear { handleScrollUp() }
+                    }
+                    .padding(.horizontal, Spacing.sm)
+                    .padding(.vertical, Spacing.xs)
+                }
+                // Start pinned to the newest entry. We intentionally do NOT use
+                // .defaultScrollAnchor(.bottom): that keeps the view pinned to the
+                // bottom on every content change, which yanks the user down while
+                // they read history. Tailing is handled explicitly below, gated on
+                // isAutoScrolling, so scrolling up stays put.
+                .onAppear {
+                    if state.isAutoScrolling, let last = state.filteredEntries.last {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+                .onChange(of: state.filteredEntries.count) { _, _ in
+                    guard state.isAutoScrolling, let last = state.filteredEntries.last else { return }
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+                .onChange(of: state.isAutoScrolling) { _, scrolling in
+                    guard scrolling, let last = state.filteredEntries.last else { return }
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+
+            if state.hasNewEntries && !state.isAutoScrolling {
+                jumpToLatestButton
+            }
+        }
+    }
+
+    private var jumpToLatestButton: some View {
+        Button(action: { state.jumpToLatest() }) {
+            HStack(spacing: Spacing.xs) {
+                Image(systemName: "arrow.down")
+                    .font(.system(size: 9, weight: .bold))
+                Text("New messages")
+                    .font(.system(size: 10, weight: .medium))
+            }
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, 5)
+            .background(theme.accent.opacity(0.9))
+            .foregroundStyle(.white)
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .padding(Spacing.md)
     }
 
     private func handleScrollToBottom() {
@@ -101,42 +133,16 @@ private struct MessagesFilterBar: View {
 
     var body: some View {
         HStack(spacing: Spacing.sm) {
-            // Level toggles
-            levelToggles
-
-            // Separator
-            Rectangle()
-                .fill(theme.treeSeparatorFg.opacity(0.3))
-                .frame(width: 1, height: 16)
-
-            // Subsystem toggles (only show subsystems that have entries)
-            subsystemToggles
-
-            // Separator
-            Rectangle()
-                .fill(theme.treeSeparatorFg.opacity(0.3))
-                .frame(width: 1, height: 16)
-
-            // "Warnings" preset button
-            warningsPreset
-
-            Spacer()
-
-            // Search field
+            levelDots
+            subsystemMenu
             searchField
+                .layoutPriority(1)
 
-            // Entry count
-            entryCount
+            Spacer(minLength: Spacing.sm)
 
-            // Reset button
+            severitySummary
             if state.isFiltering {
-                Button(action: { state.resetFilters() }) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 11))
-                        .foregroundStyle(theme.modelineBarFg.opacity(0.5))
-                }
-                .buttonStyle(.plain)
-                .help("Reset all filters")
+                resetButton
             }
         }
         .padding(.horizontal, Spacing.sm)
@@ -144,104 +150,101 @@ private struct MessagesFilterBar: View {
         .background(theme.tabBg.opacity(0.5))
     }
 
-    // MARK: - Level toggles
+    // MARK: Level dots
 
-    private var levelToggles: some View {
+    /// Severity is a small set, so dots-only (no D/I/W/E letters) keeps the bar
+    /// quiet. Inactive levels fade hard so "Debug is off" reads at a glance.
+    private var levelDots: some View {
         HStack(spacing: Spacing.xs) {
-            levelButton(level: 0, label: "D", color: .gray)
-            levelButton(level: 1, label: "I", color: .green)
-            levelButton(level: 2, label: "W", color: .yellow)
-            levelButton(level: 3, label: "E", color: .red)
+            ForEach([UInt8(0), 1, 2, 3], id: \.self) { level in
+                levelDot(level)
+            }
         }
     }
 
-    private func levelButton(level: UInt8, label: String, color: Color) -> some View {
+    private func levelDot(_ level: UInt8) -> some View {
         let isActive = state.activeLevels.contains(level)
+        let color = MessageEntry.levelColor(for: level)
         return Button(action: { state.toggleLevel(level) }) {
-            HStack(spacing: 3) {
-                Circle()
-                    .fill(isActive ? color : color.opacity(0.3))
-                    .frame(width: 6, height: 6)
-                Text(label)
-                    .font(.system(size: 9, weight: .medium, design: .monospaced))
-                    .foregroundStyle(isActive ? theme.editorFg : theme.modelineBarFg.opacity(0.4))
-            }
-            .padding(.horizontal, 5)
-            .padding(.vertical, 2)
-            .background(isActive ? color.opacity(0.15) : Color.clear)
-            .clipShape(RoundedRectangle(cornerRadius: 3))
+            Circle()
+                .fill(isActive ? color : color.opacity(0.2))
+                .frame(width: 8, height: 8)
+                .padding(Spacing.xs)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help(MessageEntry.levelName(for: level))
     }
 
-    // MARK: - Subsystem toggles
+    // MARK: Subsystems menu
 
-    private var subsystemToggles: some View {
-        HStack(spacing: Spacing.xs) {
+    /// Eight subsystems collapse into one menu so the bar isn't a wall of colored
+    /// pills. The label reflects state: all-on reads muted, a single selection
+    /// shows that subsystem in its color, otherwise a count.
+    private var subsystemMenu: some View {
+        Menu {
+            Button("All Subsystems") {
+                state.activeSubsystems = MessagesContentState.allSubsystems
+            }
+            Button("Warnings & Errors Only") {
+                state.activeLevels = [2, 3]
+                state.activeSubsystems = MessagesContentState.allSubsystems
+                state.searchText = ""
+            }
+            Divider()
             ForEach(Array(state.presentSubsystems).sorted(), id: \.self) { sub in
-                subsystemPill(sub: sub)
+                Button {
+                    state.toggleSubsystem(sub)
+                } label: {
+                    if state.activeSubsystems.contains(sub) {
+                        Label(MessageEntry.subsystemName(for: sub), systemImage: "checkmark")
+                    } else {
+                        Text(MessageEntry.subsystemName(for: sub))
+                    }
+                }
             }
+        } label: {
+            subsystemMenuLabel
         }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
     }
 
-    private func subsystemPill(sub: UInt8) -> some View {
-        let isActive = state.activeSubsystems.contains(sub)
-        let name = MessageEntry.subsystemName(for: sub)
-        let color = MessageEntry.subsystemColor(for: sub)
-
-        return Button(action: { state.toggleSubsystem(sub) }) {
-            Text(name)
-                .font(.system(size: 8, weight: .semibold))
-                .foregroundStyle(isActive ? .white : theme.modelineBarFg.opacity(0.4))
-                .padding(.horizontal, 5)
-                .padding(.vertical, 1)
-                .background(isActive ? color.opacity(0.7) : color.opacity(0.15))
-                .clipShape(RoundedRectangle(cornerRadius: 3))
-        }
-        .buttonStyle(.plain)
-    }
-
-    // MARK: - Warnings preset
-
-    private var warningsPreset: some View {
-        let isActive = state.activeLevels == [2, 3]
-            && state.activeSubsystems == MessagesContentState.allSubsystems
-            && state.searchText.isEmpty
-
-        return Button(action: {
-            state.activeLevels = [2, 3]
-            state.activeSubsystems = MessagesContentState.allSubsystems
-            state.searchText = ""
-        }) {
-            HStack(spacing: 3) {
-                Image(systemName: "exclamationmark.triangle")
-                    .font(.system(size: 8, weight: .bold))
-                Text("Warnings")
-                    .font(.system(size: 9, weight: .medium))
+    @ViewBuilder
+    private var subsystemMenuLabel: some View {
+        let active = state.activeSubsystems
+        HStack(spacing: Spacing.xs) {
+            if active == MessagesContentState.allSubsystems {
+                Text("Subsystems")
+                    .foregroundStyle(theme.modelineBarFg.opacity(0.6))
+            } else if active.count == 1, let only = active.first {
+                Text(MessageEntry.subsystemName(for: only))
+                    .foregroundStyle(MessageEntry.subsystemColor(for: only))
+            } else {
+                Text("Subsystems (\(active.count))")
+                    .foregroundStyle(theme.accent)
             }
-            .foregroundStyle(isActive ? .white : theme.modelineBarFg.opacity(0.6))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(isActive ? Color.orange.opacity(0.7) : Color.orange.opacity(0.15))
-            .clipShape(RoundedRectangle(cornerRadius: 3))
+            Image(systemName: "chevron.down")
+                .font(.system(size: 7, weight: .bold))
+                .foregroundStyle(theme.modelineBarFg.opacity(0.4))
         }
-        .buttonStyle(.plain)
-        .help("Show only warnings and errors")
+        .font(.system(size: 10, weight: .medium))
     }
 
-    // MARK: - Search
+    // MARK: Search
 
     private var searchField: some View {
-        HStack(spacing: 3) {
+        HStack(spacing: Spacing.xs) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 9))
                 .foregroundStyle(theme.modelineBarFg.opacity(0.4))
-            TextField("Filter...", text: $state.searchText)
+            TextField("Filter messages…", text: $state.searchText)
                 .font(.system(size: 10))
                 .textFieldStyle(.plain)
-                .frame(width: 100)
+                .frame(minWidth: 120, maxWidth: 220)
         }
-        .padding(.horizontal, 6)
+        .padding(.horizontal, Spacing.xs)
         .padding(.vertical, 3)
         .background(theme.editorBg.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 4))
@@ -251,15 +254,50 @@ private struct MessagesFilterBar: View {
         )
     }
 
-    // MARK: - Count
+    // MARK: Severity summary
 
-    private var entryCount: some View {
-        let filtered = state.filteredEntries.count
-        let total = state.entries.count
-        let text = state.isFiltering ? "\(filtered) of \(total)" : "\(total)"
-        return Text(text)
-            .font(.system(size: 9, design: .monospaced))
-            .foregroundStyle(theme.modelineBarFg.opacity(0.5))
+    /// A live count per severity (errors first) replaces the dead total. Color
+    /// carries meaning here, so a non-zero error count is visible at a glance.
+    private var severitySummary: some View {
+        HStack(spacing: Spacing.sm) {
+            ForEach(levelCounts(), id: \.level) { item in
+                HStack(spacing: 3) {
+                    Circle()
+                        .fill(MessageEntry.levelColor(for: item.level))
+                        .frame(width: 6, height: 6)
+                    Text("\(item.count)")
+                        .font(.system(size: 9, design: .monospaced))
+                        .foregroundStyle(MessageEntry.levelColor(for: item.level).opacity(0.85))
+                }
+            }
+            if state.isFiltering {
+                Text("filtered")
+                    .font(.system(size: 9))
+                    .foregroundStyle(theme.modelineBarFg.opacity(0.4))
+            }
+        }
+    }
+
+    /// Counts of the currently shown entries by severity, errors first. Levels
+    /// with no visible entries are omitted to avoid a row of zeros.
+    private func levelCounts() -> [(level: UInt8, count: Int)] {
+        var counts: [UInt8: Int] = [:]
+        for entry in state.filteredEntries {
+            counts[entry.level, default: 0] += 1
+        }
+        return [3, 2, 1, 0].compactMap { level in
+            counts[level].map { (level, $0) }
+        }
+    }
+
+    private var resetButton: some View {
+        Button(action: { state.resetFilters() }) {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 11))
+                .foregroundStyle(theme.modelineBarFg.opacity(0.5))
+        }
+        .buttonStyle(.plain)
+        .help("Reset all filters")
     }
 }
 
@@ -271,26 +309,24 @@ private struct MessageEntryRow: View {
     let encoder: InputEncoder?
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
             // Level dot
             Circle()
                 .fill(entry.levelColor)
                 .frame(width: 6, height: 6)
-                .padding(.top, 4)
+                .padding(.top, Spacing.xs)
 
             // Timestamp
             Text(entry.timestamp)
                 .font(.system(size: 10, design: .monospaced))
                 .foregroundStyle(theme.modelineBarFg.opacity(0.5))
 
-            // Subsystem badge
+            // Subsystem: muted colored text in a fixed column (not a filled badge)
+            // so it stays scannable without interrupting the message reading path.
             Text(entry.subsystemName)
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(.white)
-                .padding(.horizontal, 5)
-                .padding(.vertical, 1)
-                .background(entry.subsystemColor.opacity(0.7))
-                .clipShape(RoundedRectangle(cornerRadius: 3))
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(entry.subsystemColor.opacity(0.7))
+                .frame(width: 52, alignment: .leading)
 
             // Message text
             Text(entry.text)
@@ -314,6 +350,21 @@ private struct MessageEntryRow: View {
                 .buttonStyle(.plain)
             }
         }
-        .padding(.vertical, 2)
+        .padding(.horizontal, Spacing.xs)
+        .padding(.vertical, Spacing.hairline)
+        // Subtle full-row tint so warnings/errors are scannable in peripheral
+        // vision during a fast scroll. Info/debug stay untinted.
+        .background(rowTint)
+    }
+
+    @ViewBuilder
+    private var rowTint: some View {
+        if entry.level >= 3 {
+            Color.red.opacity(0.06)
+        } else if entry.level == 2 {
+            Color.yellow.opacity(0.045)
+        } else {
+            Color.clear
+        }
     }
 }

--- a/macos/Sources/Views/MessagesContentView.swift
+++ b/macos/Sources/Views/MessagesContentView.swift
@@ -20,9 +20,6 @@ struct MessagesContentView: View {
     /// preview harness (same pattern as FileTreeView / GitStatusView).
     var usesPreviewEagerLayout: Bool = false
 
-    /// Tracks whether the bottom anchor is visible in the scroll viewport.
-    @State private var bottomAnchorVisible: Bool = true
-
     var body: some View {
         VStack(spacing: 0) {
             MessagesFilterBar(state: state, theme: theme)
@@ -60,17 +57,18 @@ struct MessagesContentView: View {
                         Color.clear
                             .frame(height: 1)
                             .id("bottom-anchor")
-                            .onAppear { handleScrollToBottom() }
-                            .onDisappear { handleScrollUp() }
+                            .onAppear { state.scrolledToBottom() }
+                            .onDisappear { state.scrolledUp() }
                     }
                     .padding(.horizontal, Spacing.sm)
                     .padding(.vertical, Spacing.xs)
                 }
-                // Start pinned to the newest entry. We intentionally do NOT use
-                // .defaultScrollAnchor(.bottom): that keeps the view pinned to the
-                // bottom on every content change, which yanks the user down while
-                // they read history. Tailing is handled explicitly below, gated on
-                // isAutoScrolling, so scrolling up stays put.
+                // Position at the newest entry on open. Tailing is handled
+                // explicitly in the onChange handlers below, gated on
+                // isAutoScrolling, so new entries never move the viewport while
+                // the user has scrolled up to read history. We avoid
+                // .defaultScrollAnchor(.bottom) here: its bottom-pinning fought
+                // that gating and left the list blank in the snapshot harness.
                 .onAppear {
                     if state.isAutoScrolling, let last = state.filteredEntries.last {
                         proxy.scrollTo(last.id, anchor: .bottom)
@@ -113,16 +111,6 @@ struct MessagesContentView: View {
         .buttonStyle(.plain)
         .padding(Spacing.md)
     }
-
-    private func handleScrollToBottom() {
-        bottomAnchorVisible = true
-        state.scrolledToBottom()
-    }
-
-    private func handleScrollUp() {
-        bottomAnchorVisible = false
-        state.scrolledUp()
-    }
 }
 
 // MARK: - Filter bar
@@ -153,7 +141,7 @@ private struct MessagesFilterBar: View {
     // MARK: Level dots
 
     /// Severity is a small set, so dots-only (no D/I/W/E letters) keeps the bar
-    /// quiet. Inactive levels fade hard so "Debug is off" reads at a glance.
+    /// quiet. Inactive levels fade so "Debug is off" reads at a glance.
     private var levelDots: some View {
         HStack(spacing: Spacing.xs) {
             ForEach([UInt8(0), 1, 2, 3], id: \.self) { level in
@@ -173,12 +161,12 @@ private struct MessagesFilterBar: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help(MessageEntry.levelName(for: level))
+        .help(MessageEntry.levelTooltip(for: level))
     }
 
     // MARK: Subsystems menu
 
-    /// Eight subsystems collapse into one menu so the bar isn't a wall of colored
+    /// All subsystems collapse into one menu so the bar isn't a wall of colored
     /// pills. The label reflects state: all-on reads muted, a single selection
     /// shows that subsystem in its color, otherwise a count.
     private var subsystemMenu: some View {
@@ -208,28 +196,38 @@ private struct MessagesFilterBar: View {
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
+        // .borderlessButton otherwise renders the label at the default control
+        // font (~13pt), oversized next to the rest of the toolbar. controlSize
+        // + an explicit font pin it to match.
+        .controlSize(.small)
+        .font(.system(size: 11, weight: .medium))
         .fixedSize()
     }
 
     @ViewBuilder
     private var subsystemMenuLabel: some View {
-        let active = state.activeSubsystems
+        // The menu only lists subsystems that have entries (`presentSubsystems`),
+        // so the label must reflect those, not the full 8-subsystem domain.
+        // Otherwise toggling an absent subsystem would show a meaningless count
+        // like "(7)" next to a menu offering a single real subsystem.
+        let present = state.presentSubsystems
+        let shown = state.activeSubsystems.intersection(present)
         HStack(spacing: Spacing.xs) {
-            if active == MessagesContentState.allSubsystems {
+            if present.isEmpty || shown == present {
                 Text("Subsystems")
                     .foregroundStyle(theme.modelineBarFg.opacity(0.6))
-            } else if active.count == 1, let only = active.first {
+            } else if shown.count == 1, let only = shown.first {
                 Text(MessageEntry.subsystemName(for: only))
                     .foregroundStyle(MessageEntry.subsystemColor(for: only))
             } else {
-                Text("Subsystems (\(active.count))")
+                Text("Subsystems (\(shown.count)/\(present.count))")
                     .foregroundStyle(theme.accent)
             }
             Image(systemName: "chevron.down")
-                .font(.system(size: 7, weight: .bold))
+                .font(.system(size: 8, weight: .semibold))
                 .foregroundStyle(theme.modelineBarFg.opacity(0.4))
         }
-        .font(.system(size: 10, weight: .medium))
+        .font(.system(size: 11, weight: .medium))
     }
 
     // MARK: Search
@@ -240,7 +238,7 @@ private struct MessagesFilterBar: View {
                 .font(.system(size: 9))
                 .foregroundStyle(theme.modelineBarFg.opacity(0.4))
             TextField("Filter messages…", text: $state.searchText)
-                .font(.system(size: 10))
+                .font(.system(size: 11))
                 .textFieldStyle(.plain)
                 .frame(minWidth: 120, maxWidth: 220)
         }
@@ -266,20 +264,20 @@ private struct MessagesFilterBar: View {
                         .fill(MessageEntry.levelColor(for: item.level))
                         .frame(width: 6, height: 6)
                     Text("\(item.count)")
-                        .font(.system(size: 9, design: .monospaced))
+                        .font(.system(size: 10, design: .monospaced))
                         .foregroundStyle(MessageEntry.levelColor(for: item.level).opacity(0.85))
                 }
             }
             if state.isFiltering {
                 Text("filtered")
-                    .font(.system(size: 9))
+                    .font(.system(size: 10))
                     .foregroundStyle(theme.modelineBarFg.opacity(0.4))
             }
         }
     }
 
-    /// Counts of the currently shown entries by severity, errors first. Levels
-    /// with no visible entries are omitted to avoid a row of zeros.
+    /// Counts of the currently shown entries, ordered error → warning → info →
+    /// debug. Levels with no visible entries are omitted to avoid a row of zeros.
     private func levelCounts() -> [(level: UInt8, count: Int)] {
         var counts: [UInt8: Int] = [:]
         for entry in state.filteredEntries {

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -589,6 +589,59 @@ struct MessagesContentStateLifecycleTests {
         #expect(entry.levelName == "WARN")
         #expect(entry.subsystemName == "AGENT")
     }
+
+    @Test("appendEntries while tailing does not flag new entries")
+    @MainActor func appendWhileTailing() {
+        let state = MessagesContentState()
+        #expect(state.isAutoScrolling == true)
+
+        state.appendEntries([
+            Wire.MessageEntry(id: 0, level: 1, subsystem: 0, timestampSecs: 0,
+                           filePath: "", text: "tailing")
+        ])
+        // At the bottom, new entries follow the tail rather than raising the
+        // "jump to latest" affordance.
+        #expect(state.hasNewEntries == false)
+    }
+
+    @Test("scrolledToBottom re-enables auto-scroll and clears the indicator")
+    @MainActor func scrolledToBottomResets() {
+        let state = MessagesContentState()
+        state.scrolledUp()
+        state.appendEntries([
+            Wire.MessageEntry(id: 0, level: 1, subsystem: 0, timestampSecs: 0,
+                           filePath: "", text: "new")
+        ])
+        #expect(state.hasNewEntries == true)
+
+        state.scrolledToBottom()
+        #expect(state.isAutoScrolling == true)
+        #expect(state.hasNewEntries == false)
+    }
+
+    @Test("isFiltering reflects deviation from defaults")
+    @MainActor func isFilteringReflectsState() {
+        let state = MessagesContentState()
+        #expect(state.isFiltering == false)
+
+        state.toggleLevel(0) // enabling debug deviates from the default levels
+        #expect(state.isFiltering == true)
+
+        state.resetFilters()
+        #expect(state.isFiltering == false)
+    }
+
+    @Test("MessageEntry static level lookups")
+    @MainActor func staticLevelLookups() {
+        #expect(MessageEntry.levelColor(for: 1) == .green)
+        #expect(MessageEntry.levelColor(for: 2) == .yellow)
+        #expect(MessageEntry.levelColor(for: 3) == .red)
+        #expect(MessageEntry.levelColor(for: 99) == .gray)
+
+        #expect(MessageEntry.levelTooltip(for: 0) == "Debug")
+        #expect(MessageEntry.levelTooltip(for: 2) == "Warning")
+        #expect(MessageEntry.levelTooltip(for: 99) == "Unknown")
+    }
 }
 
 // MARK: - StatusBarState


### PR DESCRIPTION
The bottom-panel **Messages** tab read as a wall of color and had an auto-scroll bug. This reworks it after a `ux-designer` review. Uses the `Spacing` scale from #2026 (now merged).

## Problems
- Toolbar packed 12+ controls; eight filled subsystem pills read as a tag cloud before anything else.
- Every row repeated a saturated subsystem badge that interrupted the message text.
- New logs arriving while you were scrolled up **yanked the viewport to the bottom**, losing your place.

## Changes

**Toolbar**
- 8 subsystem pills → one `Subsystems ▾` menu; label reflects state (all-on muted, single selection in its color, else a count).
- Level filters → dots only (no D/I/W/E letters); inactive levels fade hard so "Debug is off" reads at a glance.
- Dead entry count → live **severity summary** (errors first), so a non-zero error count is always visible.
- "Warnings & Errors only" preset moved into the menu; toolbar reordered to `level · subsystems · search | summary · reset` with a wider search field.

**Rows**
- Subsystem is now muted colored text in an aligned column instead of a filled badge.
- Subtle full-row tint on warnings/errors for fast-scroll scannability.

**Auto-scroll (the bug)**
- Removed `.defaultScrollAnchor(.bottom)`, which re-pinned to the bottom on every append regardless of scroll position. Tailing is now gated on `isAutoScrolling` (follow the tail only when already at the bottom); scrolling up stays put and surfaces the existing "jump to latest" affordance.

**Snapshot fidelity (bonus)**
- The Messages list previously captured **blank** in snapshots (lazy `ScrollView` content never laid out). Added an eager-layout path (same pattern as `FileTreeView`/`GitStatusView`) and a dedicated `MessagesContentView` preview, so the list now renders in snapshots and is regression-testable. Removing `.defaultScrollAnchor` also fixed the blank list in the `BottomPanelView` snapshot.

## Verification
Regenerated `MessagesContentView` and `BottomPanelView` snapshots and reviewed them: toolbar reduced to dots + menu + search + summary; rows show demoted subsystem text and error/warning tints; severity counts correct (1 error, 2 warnings, 3 info; debug hidden by default). Auto-scroll behavior is runtime — verify live by scrolling up while logs stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)