### PR TITLE
De-flake FetchUrl wall-clock timeout test

### DIFF
--- a/test/minga_agent/tools/fetch_url_test.exs
+++ b/test/minga_agent/tools/fetch_url_test.exs
@@ -69,31 +69,32 @@ defmodule MingaAgent.Tools.FetchUrlTest do
   end
 
   test "enforces a wall-clock timeout when the fetcher blocks" do
-    parent = self()
-
+    # The fetcher blocks forever: it waits for a message that is never sent.
+    # There is deliberately no start/release coordination with the test process,
+    # so nothing races the deadline kill — the spawned fetcher is always still
+    # blocked when the timeout fires. The only thing observed is the public
+    # contract: the timeout error tuple. (If execute failed to enforce the
+    # timeout, this test would hang and ExUnit's own per-test timeout would fail
+    # it, so no separate wall-clock bound is needed.)
     fetcher = fn _url, _opts ->
-      send(parent, :fetch_started)
-
       receive do
-        :release -> {:ok, %{status: 200, headers: %{"content-type" => "text/plain"}, body: "ok"}}
+        :never_sent ->
+          {:ok, %{status: 200, headers: %{"content-type" => "text/plain"}, body: "ok"}}
       end
     end
 
     resolver = fn _host -> {:ok, [{93, 184, 216, 34}]} end
+    timeout_ms = 50
 
-    start = System.monotonic_time(:millisecond)
+    result =
+      FetchUrl.execute(
+        %{"url" => "https://example.test", "timeout_ms" => timeout_ms},
+        fetcher,
+        resolver
+      )
 
-    assert {:error, "failed to fetch https://example.test: request timed out after 200ms"} =
-             FetchUrl.execute(
-               %{"url" => "https://example.test", "timeout_ms" => 200},
-               fetcher,
-               resolver
-             )
-
-    elapsed = System.monotonic_time(:millisecond) - start
-    assert elapsed < 1_000
-    assert_receive :fetch_started, 500
-    refute_receive :release, 50
+    expected = "failed to fetch https://example.test: request timed out after #{timeout_ms}ms"
+    assert result == {:error, expected}
   end
 
   test "resolver exceptions are contained and redacted" do


### PR DESCRIPTION
## Problem
`MingaAgent.Tools.FetchUrlTest` "enforces a wall-clock timeout when the fetcher blocks" fails intermittently in CI:

```
test/minga_agent/tools/fetch_url_test.exs
Assertion failed, no matching message after 100ms
code: assert_receive :fetch_started
```

## Root cause
The flake was in the **test's coordination**, not the timeout. The fetcher sent `:fetch_started` as its first line and the test did `assert_receive :fetch_started`. But `FetchUrl.run_with_deadline/3` runs the fetcher in a `spawn_monitor`'d process and, on timeout, kills it with `Process.exit(pid, :kill)`. Under load the process could be **killed before it was ever scheduled** to run that `send`, so the message never arrived. Raising the timeout only narrows the window — it doesn't remove the race.

## Fix (deterministic, reviewed with test-advisor)
Remove the start/release coordination entirely:
- The fetcher now **blocks forever** on a message that is never sent, so nothing races the deadline kill — the fetcher is always still blocked when the timeout fires.
- The test asserts **only the public contract** (the timeout error tuple). No `assert_receive`, no `:release` message, no shared/global state, no reliance on scheduler timing.
- Dropped the wall-clock `elapsed < 500` check: if `execute` failed to enforce the timeout, the test would hang and ExUnit's per-test timeout would fail it, so the bound proved nothing.

No production code changed — test-only. The `after timeout_ms` firing on a forever-blocked fetcher is deterministic (nothing competes with it).

## Verification
Ran the single test **8×** and the full `fetch_url_test.exs` (13 tests) with `--warnings-as-errors`; all green every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)