### PR TITLE
fix(mode): insert tabs in insert mode

### DIFF
--- a/lib/minga/mode/insert.ex
+++ b/lib/minga/mode/insert.ex
@@ -10,6 +10,7 @@ defmodule Minga.Mode.Insert do
   | `Escape`  | Transition back to Normal mode      |
   | Backspace | Delete character before cursor      |
   | Enter     | Insert a newline                    |
+  | Tab       | Insert indentation at cursor        |
   | Arrow keys| Move cursor (without leaving Insert)|
   | Other     | Insert the UTF-8 character          |
   """
@@ -22,6 +23,7 @@ defmodule Minga.Mode.Insert do
   # Special codepoints
   @escape 27
   @enter 13
+  @tab 9
 
   # Arrow key codepoints sent by libvaxis
   @arrow_up 57_352
@@ -60,6 +62,11 @@ defmodule Minga.Mode.Insert do
   # Enter
   def handle_key({@enter, _mods}, state) do
     {:execute, :insert_newline, mark_insert_changed(state)}
+  end
+
+  # Tab
+  def handle_key({@tab, 0}, state) do
+    {:execute, :insert_tab, mark_insert_changed(state)}
   end
 
   # Arrow keys — allow cursor movement without leaving Insert mode

--- a/lib/minga_editor/commands/editing.ex
+++ b/lib/minga_editor/commands/editing.ex
@@ -27,6 +27,7 @@ defmodule MingaEditor.Commands.Editing do
     {:delete_before, "Delete character before cursor (backspace)", true},
     {:delete_at, "Delete character at cursor (delete)", true},
     {:insert_newline, "Insert a newline at cursor", true},
+    {:insert_tab, "Insert indentation at cursor", true},
     {:insert_line_below, "Insert line below", true},
     {:insert_line_above, "Insert line above", true},
     {:join_lines, "Join lines", true},
@@ -114,6 +115,11 @@ defmodule MingaEditor.Commands.Editing do
       Buffer.insert_char(buf, char)
     end
 
+    state
+  end
+
+  def execute(%{workspace: %{buffers: %{active: buf}}} = state, :insert_tab) do
+    Buffer.insert_text(buf, tab_text_at_cursor(buf))
     state
   end
 
@@ -1073,6 +1079,18 @@ defmodule MingaEditor.Commands.Editing do
   @spec do_count_leading_spaces(String.t(), non_neg_integer()) :: non_neg_integer()
   defp do_count_leading_spaces(<<" ", rest::binary>>, n), do: do_count_leading_spaces(rest, n + 1)
   defp do_count_leading_spaces(_, n), do: n
+
+  @spec tab_text_at_cursor(pid()) :: String.t()
+  defp tab_text_at_cursor(buf) do
+    if uses_tabs?(buf) do
+      "\t"
+    else
+      {_line, col} = Buffer.cursor(buf)
+      width = tab_width(buf)
+      spaces = width - rem(col, width)
+      String.duplicate(" ", spaces)
+    end
+  end
 
   # Returns {indent_string, byte_size} for one indent level.
   @spec indent_string(pid()) :: {String.t(), pos_integer()}

--- a/test/minga/mode/insert_test.exs
+++ b/test/minga/mode/insert_test.exs
@@ -42,6 +42,13 @@ defmodule Minga.Mode.InsertTest do
     end
   end
 
+  describe "Tab key" do
+    test "Tab (9) emits :insert_tab" do
+      assert {:execute, :insert_tab, %{insert_changed: true}} =
+               Insert.handle_key({9, 0}, fresh_state())
+    end
+  end
+
   describe "printable characters" do
     test "ASCII letter 'x' emits {:insert_char, \"x\"}" do
       assert {:execute, {:insert_char, "x"}, _} = Insert.handle_key({?x, 0}, fresh_state())

--- a/test/minga_editor/commands/editing_test.exs
+++ b/test/minga_editor/commands/editing_test.exs
@@ -105,6 +105,23 @@ defmodule MingaEditor.Commands.EditingTest do
       assert BufferProcess.cursor(buffer) == {0, 1}
     end
 
+    test "insert_tab inserts indentation at the cursor using buffer tab settings" do
+      spaces = start_buffer("ab")
+      BufferProcess.set_option(spaces, :tab_width, 4)
+      BufferProcess.set_option(spaces, :indent_with, :spaces)
+      BufferProcess.move_to(spaces, {0, 2})
+      Editing.execute(command_state(spaces), :insert_tab)
+      assert BufferProcess.content(spaces) == "ab  "
+      assert BufferProcess.cursor(spaces) == {0, 4}
+
+      tabs = start_buffer("ab")
+      BufferProcess.set_option(tabs, :indent_with, :tabs)
+      BufferProcess.move_to(tabs, {0, 2})
+      Editing.execute(command_state(tabs), :insert_tab)
+      assert BufferProcess.content(tabs) == "ab\t"
+      assert BufferProcess.cursor(tabs) == {0, 3}
+    end
+
     test "autopair pairs, deletes, skips closing delimiters, and suppresses pairing in comments or strings" do
       buffer = start_buffer("")
       BufferProcess.set_option(buffer, :autopair, true)


### PR DESCRIPTION
# TL;DR
Insert mode now handles Tab as an editing action instead of ignoring it. Pressing Tab inserts indentation at the cursor using the active buffer's tab settings.

## Context
The macOS GUI sends Tab as codepoint `9`, but Vim insert mode only self-inserted printable codepoints `>= 32`. That made Tab a no-op in insert mode.

## Changes
- Added explicit Tab handling in `Minga.Mode.Insert`, emitting `:insert_tab` and marking insert mode as changed.
- Added an `:insert_tab` editing command that inserts a real tab when `:indent_with` is `:tabs`.
- In spaces mode, Tab inserts enough spaces to reach the next configured tab stop.
- Added focused mode and command tests for Tab insertion behavior.

## Verification
- `make lint` passed with existing struct-size Credo warnings.
- `mix test.llm test/minga/mode/insert_test.exs test/minga_editor/commands/editing_test.exs` passed.
- `mix compile --warnings-as-errors` passed.
- Full `mix test.llm` exposed unrelated single-test failures on separate runs; each failed test passed when rerun directly with `mix test.debug`.
- Manual check: `Minga.Mode.Insert.handle_key({9, 0}, Minga.Mode.initial_state())` now returns `{:execute, :insert_tab, ...}`.
