### PR TITLE
fix(agent): graceful first-run experience with no provider configured

### DIFF
--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -895,8 +895,17 @@ defmodule MingaAgent.Providers.Native do
     {:noreply, %{state | task: nil, streaming: false, tool_workers: %{}}}
   end
 
+  def handle_info({ref, {:error, {:reported, _reason}}}, %{task: %Task{ref: ref}} = state) do
+    # The agent loop already logged this error and emitted Error + AgentEnd via
+    # reported_error/3. Just clean up; re-emitting here would show the error
+    # twice in the transcript.
+    Process.demonitor(ref, [:flush])
+    stop_registered_tool_workers(state.tool_workers)
+    {:noreply, %{state | task: nil, streaming: false, tool_workers: %{}}}
+  end
+
   def handle_info({ref, {:error, reason}}, %{task: %Task{ref: ref}} = state) do
-    # Task completed with an error
+    # Safety net: an error reached the Task without the loop reporting it.
     Process.demonitor(ref, [:flush])
     stop_registered_tool_workers(state.tool_workers)
     formatted = format_error(reason)
@@ -1379,9 +1388,7 @@ defmodule MingaAgent.Providers.Native do
           ~s|Expected "provider:model" (e.g., "anthropic:#{lctx.model}"). | <>
           "Check :agent_model in your config."
 
-      Minga.Log.error(:agent, "[Agent.Native] #{message}")
-      emit_error_and_end(lctx.provider_pid, message)
-      {:error, :invalid_format}
+      reported_error(lctx.provider_pid, message, :invalid_format)
     else
       do_agent_loop_validated(lctx, context)
     end
@@ -1423,19 +1430,16 @@ defmodule MingaAgent.Providers.Native do
         process_and_continue(lctx, context, stream_response)
 
       {:error, reason} ->
-        emit_error_and_end(lctx.provider_pid, format_error(reason))
-        {:error, reason}
+        reported_error(lctx.provider_pid, format_error(reason), reason)
     end
   rescue
     e ->
-      emit_error_and_end(lctx.provider_pid, Exception.message(e))
-      {:error, Exception.message(e)}
+      reported_error(lctx.provider_pid, Exception.message(e), e)
   catch
     # HTTP client or session process may die mid-stream. Targeted catch
     # per AGENTS.md rule 4.
     :exit, reason ->
-      emit_error_and_end(lctx.provider_pid, inspect(reason))
-      {:error, reason}
+      reported_error(lctx.provider_pid, inspect(reason), reason)
   end
 
   # Processes a stream response and decides whether to continue (tool calls) or finish.
@@ -1514,8 +1518,7 @@ defmodule MingaAgent.Providers.Native do
 
       {:error, :stream_interrupted}
     else
-      emit_error_and_end(lctx.provider_pid, format_error(reason))
-      {:error, reason}
+      reported_error(lctx.provider_pid, format_error(reason), reason)
     end
   end
 
@@ -3024,6 +3027,18 @@ defmodule MingaAgent.Providers.Native do
     send(provider_pid, {:agent_event, %Event.Error{message: message}})
     send(provider_pid, {:agent_event, %Event.AgentEnd{usage: nil}})
     :ok
+  end
+
+  # Reports an error that occurred inside the agent loop: logs the raw detail
+  # for the Messages panel, emits Error + AgentEnd to the UI, and returns a
+  # `{:reported, reason}` sentinel. The Task-completion handler matches that
+  # sentinel and skips re-emitting, so a single failure surfaces exactly once
+  # in the transcript instead of twice.
+  @spec reported_error(pid(), String.t(), term()) :: {:error, {:reported, term()}}
+  defp reported_error(provider_pid, message, reason) do
+    Minga.Log.error(:agent, "[Agent.Native] agent loop error: #{message}")
+    emit_error_and_end(provider_pid, message)
+    {:error, {:reported, reason}}
   end
 
   @spec extract_tool_calls(ReqLLM.Response.t()) :: [map()]

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -99,7 +99,8 @@ defmodule MingaAgent.Session do
           steering_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
           follow_up_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
           touched_files: %{String.t() => file_touch()},
-          boundaries: %{String.t() => EditBoundary.t()}
+          boundaries: %{String.t() => EditBoundary.t()},
+          credentials_configured: boolean()
         }
 
   # ── Public API ──────────────────────────────────────────────────────────────
@@ -385,6 +386,17 @@ defmodule MingaAgent.Session do
   end
 
   @doc """
+  Re-checks whether any provider credential is now configured.
+
+  Call after `/auth` or `/login` so the current session stops gating prompts
+  and the UI's "not configured" state clears without a restart.
+  """
+  @spec refresh_credentials(GenServer.server()) :: :ok
+  def refresh_credentials(session) do
+    GenServer.cast(session, :refresh_credentials)
+  end
+
+  @doc """
   Queues a message as a steering prompt (injected between tool calls on the next turn).
 
   When the agent is idle, behaves identically to `send_prompt/2`.
@@ -590,7 +602,12 @@ defmodule MingaAgent.Session do
       steering_queue: [],
       follow_up_queue: [],
       touched_files: %{},
-      boundaries: %{}
+      boundaries: %{},
+      # Whether any usable provider credential exists. Computed once when the
+      # provider starts (the Ollama probe can block briefly) and refreshed when
+      # the user runs /auth or /login. Gates send_prompt and drives the UI's
+      # "not configured" state so we never advertise a model we can't call.
+      credentials_configured: true
     }
 
     # Start provider asynchronously so init doesn't block
@@ -621,6 +638,21 @@ defmodule MingaAgent.Session do
     state = %{state | steering_queue: state.steering_queue ++ [content]}
     broadcast(state, {:prompt_queued, content, :steering})
     {:reply, {:queued, :steering}, state}
+  end
+
+  def handle_call({:send_prompt, content}, _from, %{credentials_configured: false} = state) do
+    # No usable provider yet. Show the user's message followed by a gentle
+    # setup nudge instead of attempting a call that would fail with a raw
+    # provider error. Reply :ok so the input clears like a normal submit.
+    {user_msg, _send_content} = build_user_message(content)
+
+    state =
+      state
+      |> append_msg(user_msg)
+      |> append_system_message(auth_required_message(), :info)
+      |> notify_messages_changed()
+
+    {:reply, :ok, state}
   end
 
   def handle_call({:send_prompt, content}, _from, state) do
@@ -1146,6 +1178,10 @@ defmodule MingaAgent.Session do
     {:noreply, state}
   end
 
+  def handle_cast(:refresh_credentials, state) do
+    {:noreply, refresh_credentials_state(state)}
+  end
+
   @impl GenServer
   def handle_info(:start_provider, state) do
     case start_provider(state) do
@@ -1154,6 +1190,7 @@ defmodule MingaAgent.Session do
         state = %{state | provider: pid}
         state = seed_provider_messages(state, state.messages)
         state = apply_pending_thinking_level(state)
+        state = refresh_credentials_state(state)
         state = maybe_show_auth_onboarding(state)
         dispatch_session_start(state)
         {:noreply, state}
@@ -1375,11 +1412,14 @@ defmodule MingaAgent.Session do
   end
 
   defp handle_provider_event(%Event.Error{message: message}, state) do
-    notify(state, :error, message)
+    # Show one human-readable line in the transcript. The raw error is already
+    # logged to the Messages panel by the provider, so we don't repeat it here.
+    friendly = humanize_error(message)
+    notify(state, :error, friendly)
     state = set_error_status(state)
-    state = %{state | error_message: message}
-    state = append_system_message(state, "Error: #{message}", :error)
-    broadcast(state, {:error, message})
+    state = %{state | error_message: friendly}
+    state = append_system_message(state, friendly, :error)
+    broadcast(state, {:error, friendly})
     state
   end
 
@@ -1830,18 +1870,33 @@ defmodule MingaAgent.Session do
   defp format_error({:spawn_failed, msg}), do: "Failed to start agent: #{msg}"
   defp format_error(reason), do: inspect(reason)
 
-  @spec apply_pending_thinking_level(state()) :: state()
-  # Shows an onboarding message when no API keys are configured and the
-  # native provider is active. Only fires once per session.
-  @spec maybe_show_auth_onboarding(map()) :: map()
-  defp maybe_show_auth_onboarding(state) do
-    if state.provider_module == MingaAgent.Providers.Native and not Credentials.any_configured?() do
-      msg =
-        "No credentials configured.\n\n" <>
-          "  /login        Sign in with your ChatGPT subscription (browser)\n" <>
-          "  /auth <provider> <key>  Add an API key (Anthropic, OpenAI, Google, etc.)\n\n" <>
-          "Run `/auth` to see status for all providers."
+  # Recomputes whether any provider credential is configured, stores it, and
+  # tells subscribers so the UI can reflect a truthful "not configured" state.
+  # `Credentials.any_configured?/0` may block briefly (Ollama probe) so this
+  # runs in the session process, off the render path.
+  @spec refresh_credentials_state(state()) :: state()
+  defp refresh_credentials_state(state) do
+    # Only the native provider resolves its own credentials from the
+    # environment. Custom providers, and any caller that injects its own
+    # `:llm_client` (tests, embedded transports), manage their own auth, so
+    # treat them as always ready.
+    configured? =
+      state.provider_module != MingaAgent.Providers.Native or
+        Keyword.has_key?(state.provider_opts, :llm_client) or
+        Credentials.any_configured?()
 
+    state = %{state | credentials_configured: configured?}
+    broadcast(state, {:credentials_status, configured?})
+    state
+  end
+
+  # Shows an onboarding message when no credentials are configured and the
+  # native provider is active. Only fires once per session. Relies on the
+  # `credentials_configured` flag set by `refresh_credentials_state/1`.
+  @spec maybe_show_auth_onboarding(state()) :: state()
+  defp maybe_show_auth_onboarding(state) do
+    if state.provider_module == MingaAgent.Providers.Native and not state.credentials_configured do
+      msg = onboarding_message()
       state = append_msg(state, Message.system(msg))
       broadcast(state, {:system_message, msg, :info})
       state
@@ -1850,6 +1905,82 @@ defmodule MingaAgent.Session do
     end
   end
 
+  @spec onboarding_message() :: String.t()
+  defp onboarding_message do
+    """
+    Welcome to Minga. Set up a provider to get started.
+
+    Add an API key (works with any supported provider):
+
+      /auth anthropic <key>     Anthropic Claude
+      /auth openai <key>        OpenAI GPT
+      /auth google <key>        Google Gemini
+      /auth openrouter <key>    OpenRouter (many models)
+      /auth groq <key>          Groq
+      /auth deepseek <key>      DeepSeek
+
+    Or sign in with a ChatGPT subscription (OpenAI accounts only):
+
+      /login                    Sign in via browser, no key needed
+
+    Ollama is detected automatically if it's running locally.
+    Run /auth to see status for all providers.\
+    """
+  end
+
+  # Shown when the user submits a prompt before any provider is configured.
+  @spec auth_required_message() :: String.t()
+  defp auth_required_message do
+    """
+    No provider is configured yet, so there's nothing to send your message to.
+
+    Set one up to get started:
+
+      /auth anthropic <key>     add an API key (most common)
+      /login                    ChatGPT subscription (OpenAI only)
+
+    Run /auth to see all providers and options.\
+    """
+  end
+
+  # Turns a raw provider error (the ugly ReqLLM struct dump) into one human
+  # line for the transcript. The full detail is still logged to the Messages
+  # panel by the provider. Already human-readable messages (MCP notices, hook
+  # vetoes, turn/cost limits) are passed through unchanged.
+  @spec humanize_error(String.t()) :: String.t()
+  defp humanize_error(message) when is_binary(message) do
+    cond do
+      String.match?(message, ~r/\b401\b/) or
+          String.contains?(message, ["unauthorized", "Unauthorized", "invalid_api_key"]) ->
+        "The provider rejected your API key. Update it with /auth <provider> <key>, then try again."
+
+      String.match?(message, ~r/\b429\b/) or String.contains?(message, "rate limit") ->
+        "Rate limited by the provider. Wait a moment and try again."
+
+      String.contains?(message, ["api_key", "API_KEY", "provider_build_failed", "Failed to build"]) ->
+        "Couldn't authenticate with the model provider. Check your API key with /auth, then try again."
+
+      String.contains?(message, ["http_streaming_failed", "econnrefused", "nxdomain", "timed out"]) ->
+        "Couldn't reach the model provider. Check your network connection and try again."
+
+      raw_struct_dump?(message) ->
+        "Something went wrong talking to the model provider. Open the Messages panel for details."
+
+      true ->
+        message
+    end
+  end
+
+  defp humanize_error(message), do: humanize_error(inspect(message))
+
+  # Detects an inspected Elixir struct/exception leaking into the message, so
+  # we never show a raw `%ReqLLM.Error{...}`-style dump in the transcript.
+  @spec raw_struct_dump?(String.t()) :: boolean()
+  defp raw_struct_dump?(message) do
+    String.contains?(message, ["%ReqLLM.", "Splode", "bread_crumbs", "stacktrace:", "#PID<"])
+  end
+
+  @spec apply_pending_thinking_level(state()) :: state()
   defp apply_pending_thinking_level(%{pending_thinking_level: nil} = state), do: state
 
   defp apply_pending_thinking_level(%{pending_thinking_level: level} = state) do

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -237,8 +237,16 @@ defmodule MingaEditor.Agent.Events do
   end
 
   def handle(state, {:error, message}) do
+    # The session already surfaced this in the transcript and the provider
+    # logged the raw detail to the Messages panel, so we only update status
+    # here. Re-logging would double the Messages entry and force-open the panel.
     state = AgentAccess.update_agent(state, &AgentState.set_error(&1, message))
-    {state, [:render, {:log_warning, "Agent error: #{message}"}]}
+    {state, [:render]}
+  end
+
+  def handle(state, {:credentials_status, configured?}) do
+    state = AgentAccess.update_panel(state, &Panel.set_credentials_configured(&1, configured?))
+    {state, [:render]}
   end
 
   def handle(state, :spinner_tick) do

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -450,9 +450,11 @@ defmodule MingaEditor.Agent.SlashCommand do
   defp do_auth_store(state, provider, key) do
     case validate_and_store(provider, key) do
       :ok ->
+        Session.refresh_credentials(AgentAccess.session(state))
+
         emit_system_message(
           state,
-          "✓ #{String.capitalize(provider)} API key saved. It will be used for new sessions."
+          "✓ #{String.capitalize(provider)} API key saved."
         )
 
       {:error, :unknown_provider} ->
@@ -551,6 +553,7 @@ defmodule MingaEditor.Agent.SlashCommand do
 
       case result do
         {:ok, :openai} ->
+          Session.refresh_credentials(session)
           Session.add_system_message(session, "ChatGPT subscription connected.")
 
         {:browser_failed, url} ->

--- a/lib/minga_editor/agent/ui_state/panel.ex
+++ b/lib/minga_editor/agent/ui_state/panel.ex
@@ -36,7 +36,8 @@ defmodule MingaEditor.Agent.UIState.Panel do
           pasted_blocks: [paste_block()],
           cached_line_index: [{non_neg_integer(), MingaEditor.Agent.BufferSync.line_type()}],
           cached_styled_messages: [MingaEditor.Agent.MarkdownHighlight.styled_lines()] | nil,
-          message_version: non_neg_integer()
+          message_version: non_neg_integer(),
+          credentials_configured: boolean()
         }
 
   defstruct visible: false,
@@ -54,11 +55,20 @@ defmodule MingaEditor.Agent.UIState.Panel do
             pasted_blocks: [],
             cached_line_index: [],
             cached_styled_messages: nil,
-            message_version: 0
+            message_version: 0,
+            # Assume configured until the session reports otherwise, so the
+            # common (authed) case never flashes a "not configured" indicator.
+            credentials_configured: true
 
   @doc "Creates a new panel state with defaults."
   @spec new() :: t()
   def new, do: %__MODULE__{}
+
+  @doc "Sets whether any provider credential is configured (drives the model indicator)."
+  @spec set_credentials_configured(t(), boolean()) :: t()
+  def set_credentials_configured(%__MODULE__{} = panel, configured?) do
+    %{panel | credentials_configured: configured?}
+  end
 
   @doc "Clears the active file mention completion."
   @spec clear_mention_completion(t()) :: t()

--- a/lib/minga_editor/agent/view/dashboard_renderer.ex
+++ b/lib/minga_editor/agent/view/dashboard_renderer.ex
@@ -186,19 +186,31 @@ defmodule MingaEditor.Agent.View.DashboardRenderer do
     # ── Model section ──
     thinking = if panel.thinking_level != "", do: " (#{panel.thinking_level})", else: ""
 
-    model_lines = [
-      dashboard_text(
-        " Model",
-        width,
-        Face.new(fg: at.dashboard_label, bg: at.panel_bg, bold: true)
-      ),
-      dashboard_text(
-        "  #{bare_model}#{thinking}",
-        width,
-        Face.new(fg: at.text_fg, bg: at.panel_bg)
-      ),
-      dashboard_blank(width, at)
-    ]
+    model_value_lines =
+      if panel.credentials_configured do
+        [
+          dashboard_text(
+            "  #{bare_model}#{thinking}",
+            width,
+            Face.new(fg: at.text_fg, bg: at.panel_bg)
+          )
+        ]
+      else
+        # No usable provider: show a setup hint instead of a model we can't call.
+        [
+          dashboard_text("  Not configured", width, Face.new(fg: at.hint_fg, bg: at.panel_bg)),
+          dashboard_text("  /auth or /login", width, Face.new(fg: at.hint_fg, bg: at.panel_bg))
+        ]
+      end
+
+    model_lines =
+      [
+        dashboard_text(
+          " Model",
+          width,
+          Face.new(fg: at.dashboard_label, bg: at.panel_bg, bold: true)
+        )
+      ] ++ model_value_lines ++ [dashboard_blank(width, at)]
 
     # ── LSP section ──
     lsp_lines = dashboard_lsp_section(input.lsp_servers, width, at)

--- a/lib/minga_editor/agent/view/prompt_renderer.ex
+++ b/lib/minga_editor/agent/view/prompt_renderer.ex
@@ -181,7 +181,12 @@ defmodule MingaEditor.Agent.View.PromptRenderer do
 
     line_cmds =
       if is_empty do
-        placeholder = String.slice("Type a message, Enter to send", 0, inner_width)
+        placeholder_text =
+          if panel.credentials_configured,
+            do: "Type a message, Enter to send",
+            else: "Type /auth <provider> <key> to get started"
+
+        placeholder = String.slice(placeholder_text, 0, inner_width)
         padded = String.pad_trailing(placeholder, inner_width)
         inner = left_pad <> padded <> right_pad
         fill = String.pad_trailing(inner, max(width - 2, 0))
@@ -247,6 +252,11 @@ defmodule MingaEditor.Agent.View.PromptRenderer do
   end
 
   @spec model_info_text(RenderInput.t()) :: String.t()
+  defp model_info_text(%{panel: %{credentials_configured: false}}) do
+    # No usable provider: don't advertise a model we can't call.
+    "Not configured · /auth or /login"
+  end
+
   defp model_info_text(input) do
     panel = input.panel
     model = panel.model_name |> AgentConfig.strip_provider_prefix() |> titleize()

--- a/lib/minga_editor/agent/view/render_input.ex
+++ b/lib/minga_editor/agent/view/render_input.ex
@@ -52,6 +52,7 @@ defmodule MingaEditor.Agent.View.RenderInput do
           model_name: String.t(),
           provider_name: String.t(),
           thinking_level: String.t(),
+          credentials_configured: boolean(),
           display_start_index: non_neg_integer(),
           mention_completion: MingaAgent.FileMention.completion() | nil,
           pasted_blocks: [UIState.paste_block()]
@@ -116,6 +117,7 @@ defmodule MingaEditor.Agent.View.RenderInput do
         model_name: panel.model_name,
         provider_name: panel.provider_name,
         thinking_level: panel.thinking_level,
+        credentials_configured: panel.credentials_configured,
         display_start_index: panel.display_start_index,
         mention_completion: panel.mention_completion,
         pasted_blocks: panel.pasted_blocks

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -1291,6 +1291,24 @@ defmodule MingaAgent.Providers.NativeTest do
       agent_end = Enum.find(events, &match?(%Event.AgentEnd{}, &1))
       assert agent_end != nil
     end
+
+    test "surfaces a single failure exactly once", %{tmp_dir: dir} do
+      # Regression: the agent loop emitted the error, and the Task-completion
+      # handler emitted it again, so a single failure showed up twice in the
+      # transcript. collect_events/1 stops at the first AgentEnd, so we drain
+      # afterward to prove no second Error (or AgentEnd) follows.
+      client = fake_error_client("boom once")
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, max_retries: 0)
+
+      assert :ok = Native.send_prompt(pid, "Hello")
+
+      assert_receive {:agent_provider_event, %Event.Error{message: msg}}, 1_000
+      assert msg =~ "boom once"
+      assert_receive {:agent_provider_event, %Event.AgentEnd{}}, 1_000
+
+      refute_receive {:agent_provider_event, %Event.Error{}}, 200
+      refute_receive {:agent_provider_event, %Event.AgentEnd{}}, 50
+    end
   end
 
   describe "abort" do

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -1645,4 +1645,34 @@ defmodule MingaAgent.SessionTest do
              end)
     end
   end
+
+  describe "provider error presentation" do
+    test "raw provider errors are humanized in the transcript", %{tmp_dir: dir} do
+      # A custom llm_client counts as "configured", so the prompt reaches the
+      # provider, fails, and the session must show one human line instead of
+      # the raw error string.
+      client = fn _model, _messages, _opts ->
+        {:error, "provider_build_failed: missing api_key option"}
+      end
+
+      session =
+        start_subscribed_session(Native,
+          project_root: dir,
+          llm_client: client,
+          max_retries: 0,
+          config: agent_config(tool_approval: :none)
+        )
+
+      assert :ok = Session.send_prompt(session, "hey")
+
+      assert_receive {:agent_event, ^session, {:error, message}}, @event_timeout
+      refute message =~ "provider_build_failed"
+      assert message =~ "API key"
+
+      assert Enum.any?(Session.messages(session), fn
+               {:system, text, :error} -> text == message
+               _ -> false
+             end)
+    end
+  end
 end

--- a/test/minga_agent/tools/subagent_test.exs
+++ b/test/minga_agent/tools/subagent_test.exs
@@ -373,7 +373,7 @@ defmodule MingaAgent.Tools.SubagentTest do
     refute_receive {:notified, :error, _}, 50
 
     assert Session.status(handle.pid) == :error
-    assert Enum.any?(Session.messages(handle.pid), &(&1 == {:system, "Error: boom", :error}))
+    assert Enum.any?(Session.messages(handle.pid), &(&1 == {:system, "boom", :error}))
   end
 
   test "background child completion notifies once", %{manager: manager} do

--- a/test/minga_editor/agent/view/dashboard_renderer_test.exs
+++ b/test/minga_editor/agent/view/dashboard_renderer_test.exs
@@ -47,6 +47,7 @@ defmodule MingaEditor.Agent.View.DashboardRendererTest do
       panel: %UIState.Panel{
         visible: true,
         input_focused: Keyword.get(opts, :input_focused, false),
+        credentials_configured: Keyword.get(opts, :credentials_configured, true),
         prompt_buffer: prompt_buf
       },
       view: %UIState.View{
@@ -102,6 +103,18 @@ defmodule MingaEditor.Agent.View.DashboardRendererTest do
       # The model section should show bare model name, not the prefixed spec
       assert Enum.any?(texts, &String.contains?(&1, "claude-sonnet-4"))
       refute Enum.any?(texts, &String.contains?(&1, "anthropic:claude-sonnet-4"))
+    end
+
+    test "model section shows a setup hint instead of a model when no credentials" do
+      state = base_state(credentials_configured: false)
+      ctx = ViewContext.from_editor_state(state)
+      commands = DashboardRenderer.render(ctx, {0, 80, 40, 30})
+      texts = Enum.map(commands, fn d -> elem(d, 2) end)
+
+      assert Enum.any?(texts, &String.contains?(&1, "Model"))
+      assert Enum.any?(texts, &String.contains?(&1, "Not configured"))
+      assert Enum.any?(texts, &String.contains?(&1, "/auth or /login"))
+      refute Enum.any?(texts, &String.contains?(&1, "claude-sonnet-4"))
     end
   end
 

--- a/test/minga_editor/agent/view/prompt_renderer_test.exs
+++ b/test/minga_editor/agent/view/prompt_renderer_test.exs
@@ -39,6 +39,7 @@ defmodule MingaEditor.Agent.View.PromptRendererTest do
       panel: %UIState.Panel{
         visible: true,
         input_focused: Keyword.get(opts, :input_focused, false),
+        credentials_configured: Keyword.get(opts, :credentials_configured, true),
         prompt_buffer: prompt_buf
       },
       view: %UIState.View{
@@ -159,6 +160,31 @@ defmodule MingaEditor.Agent.View.PromptRendererTest do
       assert Enum.any?(texts, fn text ->
                String.starts_with?(text, "╰─") and String.contains?(text, "Claude Sonnet 4")
              end)
+    end
+
+    test "bottom border shows a setup hint instead of a model when no credentials" do
+      state = base_state(credentials_configured: false)
+      ctx = ViewContext.from_editor_state(state)
+      commands = PromptRenderer.render(ctx, {30, 0, 80, 5})
+      texts = Enum.map(commands, fn d -> elem(d, 2) end)
+
+      bottom_border = Enum.find(texts, &String.starts_with?(&1, "╰─"))
+
+      assert bottom_border != nil
+      assert String.contains?(bottom_border, "Not configured")
+      assert String.contains?(bottom_border, "/auth")
+      # Never advertise a model the user cannot call.
+      refute String.contains?(bottom_border, "Claude Sonnet 4")
+    end
+
+    test "empty-input placeholder guides setup when no credentials" do
+      state = base_state(credentials_configured: false)
+      ctx = ViewContext.from_editor_state(state)
+      commands = PromptRenderer.render(ctx, {30, 0, 80, 5})
+      texts = Enum.map(commands, fn d -> elem(d, 2) end)
+
+      assert Enum.any?(texts, &String.contains?(&1, "/auth <provider> <key>"))
+      refute Enum.any?(texts, &String.contains?(&1, "Type a message"))
     end
 
     test "placeholder uses readable text color" do

--- a/test/minga_editor/state/event_routing_test.exs
+++ b/test/minga_editor/state/event_routing_test.exs
@@ -98,13 +98,32 @@ defmodule MingaEditor.State.EventRoutingTest do
   end
 
   describe "Agent.Events.handle/2 — errors" do
-    test "error updates agent error state and logs" do
+    test "error updates agent error state and re-renders without re-logging" do
       %{state: state} = make_state()
 
       {new_state, effects} = AgentEvents.handle(state, {:error, "something broke"})
 
       assert AgentAccess.agent(new_state).error == "something broke"
-      assert {:log_warning, "Agent error: something broke"} in effects
+      assert :render in effects
+      # The session already surfaced this in the transcript and the provider
+      # logged the raw detail to the Messages panel; re-logging here would
+      # duplicate the Messages entry and force-open the panel.
+      refute Enum.any?(effects, &match?({:log_warning, _}, &1))
+    end
+  end
+
+  describe "Agent.Events.handle/2 — credentials status" do
+    test "credentials_status updates the panel flag and re-renders" do
+      %{state: state} = make_state()
+      assert AgentAccess.panel(state).credentials_configured == true
+
+      {new_state, effects} = AgentEvents.handle(state, {:credentials_status, false})
+
+      assert AgentAccess.panel(new_state).credentials_configured == false
+      assert :render in effects
+
+      {restored, _effects} = AgentEvents.handle(new_state, {:credentials_status, true})
+      assert AgentAccess.panel(restored).credentials_configured == true
     end
   end
 


### PR DESCRIPTION
## Problem

When you launch the agent with no provider configured and type a message, you get a wall of failure: a raw `%ReqLLM.Error{...splode...stacktrace...}` dumped **twice** in red in the transcript, the Messages panel spamming the same error three times and force-opening itself, and a model selector that confidently reads `claude-sonnet-4` even though there's no key to call it with.

Typing before auth is a normal first action. It should get a gentle nudge, not a stacktrace.

## What changed

**The model indicator tells the truth.** The session computes a `credentials_configured` flag (only the native provider resolves env credentials; custom/injected clients are always "ready"). When nothing is usable:
- Input bottom border: `Not configured · /auth or /login` (instead of advertising a model)
- Dashboard Model section: `Not configured` / `/auth or /login` in dim hint color
- Empty-input placeholder: `Type /auth <provider> <key> to get started`

It flips back to the real model the moment a key is added — no restart.

**Sending before auth is gated.** `send_prompt` short-circuits when no provider is usable: it shows your message followed by a setup nudge instead of attempting a doomed call. The input still clears like a normal submit.

**One failure surfaces once.** Root cause of the duplicate body error: a failure inside the agent loop emitted `Event.Error`, then the Task-completion handler emitted it again. A `{:reported, reason}` sentinel lets the Task handler skip the re-emit while staying a safety net for genuinely unreported errors.

**Errors are human, raw detail stays in Messages.** `handle_provider_event` humanizes provider errors for the transcript (bad key, rate limit, network, struct-dump fallback) and passes already-friendly messages (MCP notices, hook vetoes) through unchanged. The redundant `{:log_warning}` that double-wrote the Messages panel and force-opened it is gone — the raw line is logged once by the provider.

**Onboarding rewritten.** API keys first (universal), `/login` second labeled "OpenAI accounts only", Ollama auto-detect noted. `/auth` and `/login` now refresh the running session so a saved key works immediately.

## Tests

All 5441 pass, formatted, no warnings. New/updated coverage:
- `native_test`: a single failure emits exactly one `Event.Error` (drains past the first `AgentEnd`, which is why the old test missed the double-emit)
- `session_test`: raw provider errors are humanized in the transcript
- `event_routing_test`: `{:credentials_status, _}` updates the panel and no longer emits `{:log_warning}`
- `prompt_renderer_test` / `dashboard_renderer_test`: the "Not configured" indicator and pre-auth placeholder

## Follow-up (deferred)

`credentials_configured` is a single "any provider usable" flag. The mixed case — you have one key but switch to a model whose provider isn't authed — still shows the model name and produces a humanized auth error on send, rather than a per-provider `No key` badge. Easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)