### PR TITLE
feat(project): SPC p a opens path prompt with Tab completion

### DIFF
--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -118,6 +118,22 @@ defmodule Minga.Project do
     :exit, _ -> File.cwd!()
   end
 
+  @doc """
+  Replaces the home directory prefix with `~` for display.
+
+  Handles both `$HOME/...` paths and `$HOME` exactly.
+  """
+  @spec collapse_home(String.t()) :: String.t()
+  def collapse_home(path) when is_binary(path) do
+    home = Path.expand("~")
+    String.replace_prefix(path, home, "~")
+  end
+
+  @doc "Expands a leading `~` to the home directory without normalizing the rest of the path."
+  @spec expand_home(String.t()) :: String.t()
+  def expand_home("~" <> rest), do: Path.expand("~") <> rest
+  def expand_home(path) when is_binary(path), do: path
+
   @doc "Returns the cached file list for the current project."
   @spec files(GenServer.server()) :: [String.t()]
   def files(server \\ __MODULE__) do

--- a/lib/minga_editor/commands/project.ex
+++ b/lib/minga_editor/commands/project.ex
@@ -45,7 +45,7 @@ defmodule MingaEditor.Commands.Project do
   end
 
   def execute(state, :project_add) do
-    default = Project.resolve_root() |> collapse_home()
+    default = Project.resolve_root() |> Project.collapse_home()
     PromptUI.open(state, MingaEditor.UI.Prompt.ProjectAdd, default: default)
   end
 
@@ -69,12 +69,6 @@ defmodule MingaEditor.Commands.Project do
     Project.root()
   catch
     :exit, _ -> nil
-  end
-
-  @spec collapse_home(String.t()) :: String.t()
-  defp collapse_home(path) do
-    home = Path.expand("~")
-    if String.starts_with?(path, home <> "/"), do: "~" <> String.trim_leading(path, home), else: path
   end
 
   commands(@command_specs)

--- a/lib/minga_editor/commands/project.ex
+++ b/lib/minga_editor/commands/project.ex
@@ -7,6 +7,7 @@ defmodule MingaEditor.Commands.Project do
   use MingaEditor.Commands.Provider
 
   alias MingaEditor.PickerUI
+  alias MingaEditor.PromptUI
   alias MingaEditor.State, as: EditorState
   alias Minga.Mode
   alias Minga.Project
@@ -16,7 +17,7 @@ defmodule MingaEditor.Commands.Project do
   @command_specs [
     {:project_find_file, "Find file in project", true},
     {:project_invalidate, "Invalidate project cache", true},
-    {:project_add, "Add project", true},
+    {:project_add, "Add project", false},
     {:project_remove, "Remove project", true},
     {:project_switch, "Switch project", false},
     {:project_recent_files, "Recent files", false}
@@ -44,18 +45,8 @@ defmodule MingaEditor.Commands.Project do
   end
 
   def execute(state, :project_add) do
-    root = project_root()
-
-    case root do
-      nil ->
-        EditorState.set_status(state, "No project root detected")
-
-      path ->
-        Project.add(path)
-        EditorState.set_status(state, "Added project: #{Path.basename(path)}")
-    end
-  catch
-    :exit, _ -> state
+    default = Project.resolve_root() |> collapse_home()
+    PromptUI.open(state, MingaEditor.UI.Prompt.ProjectAdd, default: default)
   end
 
   def execute(state, :project_remove) do
@@ -78,6 +69,12 @@ defmodule MingaEditor.Commands.Project do
     Project.root()
   catch
     :exit, _ -> nil
+  end
+
+  @spec collapse_home(String.t()) :: String.t()
+  defp collapse_home(path) do
+    home = Path.expand("~")
+    if String.starts_with?(path, home <> "/"), do: "~" <> String.trim_leading(path, home), else: path
   end
 
   commands(@command_specs)

--- a/lib/minga_editor/prompt_ui.ex
+++ b/lib/minga_editor/prompt_ui.ex
@@ -215,10 +215,15 @@ defmodule MingaEditor.PromptUI do
   defp do_tab(state, prompt) do
     handler = prompt.handler
 
-    if Code.ensure_loaded?(handler) and function_exported?(handler, :on_tab, 1) do
+    if function_exported?(handler, :on_tab, 1) do
       new_text = handler.on_tab(prompt.text)
-      new_cursor = String.length(new_text)
-      update_prompt(state, &%{&1 | text: new_text, cursor: new_cursor})
+
+      if new_text == prompt.text do
+        state
+      else
+        new_cursor = String.length(new_text)
+        update_prompt(state, &%{&1 | text: new_text, cursor: new_cursor})
+      end
     else
       state
     end

--- a/lib/minga_editor/prompt_ui.ex
+++ b/lib/minga_editor/prompt_ui.ex
@@ -27,6 +27,7 @@ defmodule MingaEditor.PromptUI do
 
   @escape 27
   @enter 13
+  @tab 9
   @backspace 127
   @arrow_left 57_350
   @arrow_right 57_351
@@ -102,6 +103,9 @@ defmodule MingaEditor.PromptUI do
       @enter ->
         new_state = prompt.handler.on_submit(prompt.text, state)
         {close(new_state), nil}
+
+      @tab ->
+        {do_tab(state, prompt), nil}
 
       @backspace ->
         {do_backspace(state, prompt), nil}
@@ -205,6 +209,19 @@ defmodule MingaEditor.PromptUI do
     cursor_pos = {row, label_len + prompt.cursor}
 
     {draws, cursor_pos}
+  end
+
+  @spec do_tab(state(), PromptState.t()) :: state()
+  defp do_tab(state, prompt) do
+    handler = prompt.handler
+
+    if Code.ensure_loaded?(handler) and function_exported?(handler, :on_tab, 1) do
+      new_text = handler.on_tab(prompt.text)
+      new_cursor = String.length(new_text)
+      update_prompt(state, &%{&1 | text: new_text, cursor: new_cursor})
+    else
+      state
+    end
   end
 
   @spec do_backspace(state(), PromptState.t()) :: state()

--- a/lib/minga_editor/ui/prompt/handler.ex
+++ b/lib/minga_editor/ui/prompt/handler.ex
@@ -46,4 +46,14 @@ defmodule MingaEditor.UI.Prompt.Handler do
 
   @doc "Called when the user presses Escape. Receives the editor state."
   @callback on_cancel(state :: EditorState.t()) :: EditorState.t()
+
+  @doc """
+  Called when the user presses Tab. Returns the completed text.
+
+  Optional. When not implemented, Tab is a no-op. Use for shell-style
+  path completion, symbol completion, etc.
+  """
+  @callback on_tab(text :: String.t()) :: String.t()
+
+  @optional_callbacks [on_tab: 1]
 end

--- a/lib/minga_editor/ui/prompt/project_add.ex
+++ b/lib/minga_editor/ui/prompt/project_add.ex
@@ -18,18 +18,19 @@ defmodule MingaEditor.UI.Prompt.ProjectAdd do
   @impl true
   @spec on_submit(String.t(), EditorState.t()) :: EditorState.t()
   def on_submit(text, state) do
-    path = text |> String.trim() |> expand_home() |> Path.expand()
+    trimmed = String.trim(text)
 
-    cond do
-      path == "" ->
-        EditorState.set_status(state, "No path given")
+    if trimmed == "" do
+      EditorState.set_status(state, "No path given")
+    else
+      path = trimmed |> Project.expand_home() |> Path.expand()
 
-      not File.dir?(path) ->
-        EditorState.set_status(state, "Not a directory: #{path}")
-
-      true ->
+      if File.dir?(path) do
         Project.add(path)
         EditorState.set_status(state, "Added project: #{path}")
+      else
+        EditorState.set_status(state, "Not a directory: #{path}")
+      end
     end
   end
 
@@ -40,7 +41,7 @@ defmodule MingaEditor.UI.Prompt.ProjectAdd do
   @impl true
   @spec on_tab(String.t()) :: String.t()
   def on_tab(text) do
-    expanded = expand_home(text)
+    expanded = Project.expand_home(text)
     dir = Path.dirname(expanded)
     prefix = Path.basename(expanded)
 
@@ -49,7 +50,7 @@ defmodule MingaEditor.UI.Prompt.ProjectAdd do
     else
       complete_in_dir(dir, prefix)
     end
-    |> collapse_home()
+    |> Project.collapse_home()
   end
 
   # ── Private ──────────────────────────────────────────────────────────────────
@@ -88,18 +89,4 @@ defmodule MingaEditor.UI.Prompt.ProjectAdd do
     end)
   end
 
-  @spec expand_home(String.t()) :: String.t()
-  defp expand_home("~" <> rest), do: Path.expand("~") <> rest
-  defp expand_home(path), do: path
-
-  @spec collapse_home(String.t()) :: String.t()
-  defp collapse_home(path) do
-    home = Path.expand("~")
-
-    if String.starts_with?(path, home <> "/") do
-      "~" <> String.trim_leading(path, home)
-    else
-      path
-    end
-  end
 end

--- a/lib/minga_editor/ui/prompt/project_add.ex
+++ b/lib/minga_editor/ui/prompt/project_add.ex
@@ -1,0 +1,105 @@
+defmodule MingaEditor.UI.Prompt.ProjectAdd do
+  @moduledoc """
+  Prompt handler for adding a directory to the known-projects list.
+
+  Opens a text input defaulting to the current working directory. Supports
+  shell-style Tab completion for directory paths and `~` expansion.
+  """
+
+  @behaviour MingaEditor.UI.Prompt.Handler
+
+  alias MingaEditor.State, as: EditorState
+  alias Minga.Project
+
+  @impl true
+  @spec label() :: String.t()
+  def label, do: "Add project: "
+
+  @impl true
+  @spec on_submit(String.t(), EditorState.t()) :: EditorState.t()
+  def on_submit(text, state) do
+    path = text |> String.trim() |> expand_home() |> Path.expand()
+
+    cond do
+      path == "" ->
+        EditorState.set_status(state, "No path given")
+
+      not File.dir?(path) ->
+        EditorState.set_status(state, "Not a directory: #{path}")
+
+      true ->
+        Project.add(path)
+        EditorState.set_status(state, "Added project: #{path}")
+    end
+  end
+
+  @impl true
+  @spec on_cancel(EditorState.t()) :: EditorState.t()
+  def on_cancel(state), do: state
+
+  @impl true
+  @spec on_tab(String.t()) :: String.t()
+  def on_tab(text) do
+    expanded = expand_home(text)
+    dir = Path.dirname(expanded)
+    prefix = Path.basename(expanded)
+
+    if expanded == "" or String.ends_with?(expanded, "/") do
+      complete_in_dir(expanded, "")
+    else
+      complete_in_dir(dir, prefix)
+    end
+    |> collapse_home()
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────────────
+
+  @spec complete_in_dir(String.t(), String.t()) :: String.t()
+  defp complete_in_dir(dir, prefix) do
+    abs_dir = Path.expand(dir)
+
+    case File.ls(abs_dir) do
+      {:ok, entries} ->
+        matches =
+          entries
+          |> Enum.filter(&String.starts_with?(&1, prefix))
+          |> Enum.map(&Path.join(abs_dir, &1))
+          |> Enum.filter(&File.dir?/1)
+
+        case matches do
+          [single] -> single <> "/"
+          [_ | _] -> longest_common_prefix(matches)
+          [] -> Path.join(abs_dir, prefix)
+        end
+
+      {:error, _} ->
+        Path.join(dir, prefix)
+    end
+  end
+
+  @spec longest_common_prefix([String.t()]) :: String.t()
+  defp longest_common_prefix([first | rest]) do
+    Enum.reduce(rest, first, fn str, acc ->
+      acc
+      |> String.graphemes()
+      |> Enum.zip(String.graphemes(str))
+      |> Enum.take_while(fn {a, b} -> a == b end)
+      |> Enum.map_join(&elem(&1, 0))
+    end)
+  end
+
+  @spec expand_home(String.t()) :: String.t()
+  defp expand_home("~" <> rest), do: Path.expand("~") <> rest
+  defp expand_home(path), do: path
+
+  @spec collapse_home(String.t()) :: String.t()
+  defp collapse_home(path) do
+    home = Path.expand("~")
+
+    if String.starts_with?(path, home <> "/") do
+      "~" <> String.trim_leading(path, home)
+    else
+      path
+    end
+  end
+end

--- a/lib/minga_editor/ui/prompt/project_add.ex
+++ b/lib/minga_editor/ui/prompt/project_add.ex
@@ -88,5 +88,4 @@ defmodule MingaEditor.UI.Prompt.ProjectAdd do
       |> Enum.map_join(&elem(&1, 0))
     end)
   end
-
 end


### PR DESCRIPTION
## Summary

- `SPC p a` now opens an interactive path prompt (like Doom Emacs's `projectile-add-known-project`) instead of failing with "No project root detected"
- Prompt defaults to the current project root or CWD, displayed with `~/` prefix
- Tab completes directory names: single match completes with trailing `/`, multiple matches complete the common prefix
- `~` expands to `$HOME` on both Tab and Enter
- Adds generic `on_tab/1` optional callback to the `Prompt.Handler` behaviour so any prompt can implement completion

## Test plan

- [ ] Launch Minga, press `SPC p a` before opening any file, verify prompt appears with CWD
- [ ] Type `~/` and press Tab, verify directory completion works
- [ ] Type `~` and press Tab, verify it expands to home and lists completions
- [ ] Complete a path to a real project directory, press Enter, verify "Added project:" status
- [ ] Press `SPC p p` and verify the added project appears in the list
- [ ] Submit a non-existent path, verify error message
- [ ] Press Escape to cancel, verify no side effects
- [ ] Verify existing prompt handlers (workspace rename) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)