### PR TITLE
perf: faster, quieter editor startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,18 @@ PREFIX  ?= $(HOME)/.local
 BINDIR   = $(PREFIX)/bin
 APP_DIR ?= /Applications
 
+# Burrito unpacks the binary's payload into a versioned cache dir named
+# <app>_erts-<ertsver>_<appver> and only re-extracts when that dir is absent.
+# The app version rarely changes during local dev, so a fresh `make install`
+# would otherwise keep running the previously extracted code. We clear minga's
+# extraction on install to force a re-unpack of the new payload.
+ifeq ($(OS),Darwin)
+  BURRITO_INSTALL_DIR := $(HOME)/Library/Application Support/.burrito
+else
+  XDG_DATA_HOME ?= $(HOME)/.local/share
+  BURRITO_INSTALL_DIR := $(XDG_DATA_HOME)/.burrito
+endif
+
 # ── Lint ────────────────────────────────────────────────────────────────
 
 # Run all lint checks. Each step runs independently so dialyzer always
@@ -94,6 +106,8 @@ install-tui: release-tui
 	@mkdir -p "$(BINDIR)"
 	cp "burrito_out/$(BURRITO_TARGET)" "$(BINDIR)/minga"
 	chmod +x "$(BINDIR)/minga"
+	@# Force Burrito to re-extract the new payload (see BURRITO_INSTALL_DIR above).
+	@rm -rf "$(BURRITO_INSTALL_DIR)"/minga_erts-*
 	@echo "\033[32mInstalled minga to $(BINDIR)/minga\033[0m"
 	@"$(BINDIR)/minga" --version || true
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -17,24 +17,33 @@ port_mode =
 
 config :minga, port_mode: port_mode
 
-# Connected mode means the GUI app spawned us. Start the editor with
-# the GUI backend so the supervision tree boots Port.Manager, Editor,
-# and the parser. Without this, the BEAM process sits idle and the
-# Swift frontend sees only its default (empty) SwiftUI state.
+# The default Erlang logger handler writes to :standard_io (stdout). For
+# both of these modes, stdout is NOT a safe place for log text, so we redirect
+# the default handler to the Minga log file from the very start of boot:
 #
-# The default Erlang logger handler writes to :standard_io (stdout).
-# In connected mode, stdout is the binary protocol pipe to the Swift
-# frontend. Unframed log text would corrupt the {:packet, 4} protocol
-# stream, causing unknownOpcode decode errors on the Swift side.
+#   - connected mode: stdout is the {:packet, 4} binary protocol pipe to the
+#     Swift GUI. Unframed log text corrupts the stream (unknownOpcode errors).
+#   - standalone TUI: stdout is the user's terminal. Boot logs (EventRecorder,
+#     extensions, watchdog, ...) would print over the editor UI.
 #
-# Redirect the default handler to the Minga log file. This matches
-# what LoggerHandler.install() does later during Editor.init, but
-# covers the startup window before the Editor is running.
-if port_mode == :connected do
-  config :minga, start_editor: true, backend: :gui
+# This matches what LoggerHandler.install/0 does later during Editor.init, but
+# covers the startup window before the Editor is running. Headless and `mix`
+# invocations are intentionally excluded so they keep stdout/stderr logging.
+standalone_tui? =
+  System.get_env("__BURRITO") != nil and
+    "--headless" not in Enum.map(:init.get_plain_arguments(), &to_string/1)
 
+if port_mode == :connected or standalone_tui? do
   log_dir = Path.expand("~/.local/share/minga")
   File.mkdir_p!(log_dir)
   log_path = Path.join(log_dir, "minga.log")
   config :logger, :default_handler, config: [type: {:file, String.to_charlist(log_path)}]
+end
+
+# Connected mode means the GUI app spawned us. Start the editor with
+# the GUI backend so the supervision tree boots Port.Manager, Editor,
+# and the parser. Without this, the BEAM process sits idle and the
+# Swift frontend sees only its default (empty) SwiftUI state.
+if port_mode == :connected do
+  config :minga, start_editor: true, backend: :gui
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -39,6 +39,12 @@ config :minga, infer_startup_project_root: false
 # Session GenServer lifecycle.
 config :minga, test_provider_module: Minga.Test.StubProvider
 
+# Isolate the extension compile cache so tests never read from or write to the
+# developer's real cache dir under ~/.local/share/minga.
+config :minga,
+  extension_compile_cache_dir:
+    Path.join(System.tmp_dir!(), "minga-test-ext-cache-#{System.unique_integer([:positive])}")
+
 # Disable user extension loading so tests are deterministic regardless
 # of which extensions the developer has installed locally.
 config :minga, load_extensions: false

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -63,6 +63,11 @@ defmodule Minga.Application do
   @impl true
   @spec start(Application.start_type(), term()) :: {:ok, pid()} | {:error, term()}
   def start(_type, _args) do
+    # Info-only flags (--version/--help) must not boot the supervision tree.
+    # Booting it spins up the event recorder, extensions, and watchdog just to
+    # print a string, which can add seconds of startup. Short-circuit first.
+    maybe_print_info_and_halt()
+
     # Create the log buffer ETS table owned by the supervisor process.
     # This table survives process crashes so LoggerHandler can queue messages
     # before Minga.Log.MessagesBuffer subscribes and drains it on init.
@@ -175,6 +180,25 @@ defmodule Minga.Application do
     end
 
     :ok
+  end
+
+  @spec maybe_print_info_and_halt() :: :ok
+  defp maybe_print_info_and_halt do
+    if Burrito.Util.running_standalone?() do
+      case Minga.CLI.info_flag_output(Burrito.Util.Args.argv()) do
+        {:ok, message} ->
+          IO.puts(message)
+          System.halt(0)
+
+        :none ->
+          :ok
+      end
+    else
+      :ok
+    end
+  rescue
+    # Never let argument inspection break startup; fall through to normal boot.
+    _ -> :ok
   end
 
   @spec start_editor?() :: boolean()

--- a/lib/minga/cli.ex
+++ b/lib/minga/cli.ex
@@ -114,6 +114,22 @@ defmodule Minga.CLI do
     Enum.member?(args, "--safe") or Enum.member?(args, "-Q")
   end
 
+  @doc """
+  Returns the output for info-only flags (`--version`/`-v`, `--help`/`-h`).
+
+  These flags should print and exit without booting the supervision tree,
+  so the application start path can short-circuit before doing any work.
+  Returns `:none` when the args don't request info-only output.
+  """
+  @spec info_flag_output([String.t()]) :: {:ok, String.t()} | :none
+  def info_flag_output(args) when is_list(args) do
+    cond do
+      "--version" in args or "-v" in args -> {:ok, "minga #{Minga.version()}"}
+      "--help" in args or "-h" in args -> {:ok, usage()}
+      true -> :none
+    end
+  end
+
   @doc "Returns the startup flags stored by the CLI, or defaults if none were set."
   @spec startup_flags() :: flags()
   def startup_flags do

--- a/lib/minga/extension/compile_cache.ex
+++ b/lib/minga/extension/compile_cache.ex
@@ -1,0 +1,230 @@
+defmodule Minga.Extension.CompileCache do
+  @moduledoc """
+  On-disk compile cache for path/git-sourced extensions.
+
+  Path and git extensions ship as `.ex` source and were recompiled from
+  scratch on every boot (`Kernel.ParallelCompiler`), costing hundreds of
+  milliseconds per extension on the startup critical path. This module
+  compiles each extension once, writes the resulting `.beam` files to a
+  cache keyed by a hash of the source plus the Elixir/ERTS versions, and on
+  later boots loads those beams directly (a few milliseconds) instead of
+  recompiling.
+
+  ## Invalidation
+
+  The cache key is derived from the *content* of every source file (and the
+  toolchain version), so editing an extension produces a new key and forces a
+  recompile. This keeps dev hot-reload correct: a changed file is a cache
+  miss. After a successful compile we prune the extension's other (stale) keys
+  so the cache holds one entry per extension.
+
+  Beams are toolchain-specific, so the key includes the Elixir and ERTS
+  versions: a runtime upgrade invalidates every entry automatically.
+
+  Caching can be disabled with `config :minga, extension_compile_cache: false`
+  (tests do this to stay hermetic), in which case compilation falls back to the
+  previous in-memory behaviour.
+  """
+
+  @type result ::
+          {:ok, %{modules: [module()], diagnostics: [map()], source: :cache | :compiled}}
+          | {:error, String.t()}
+
+  @doc """
+  Ensures the extension's modules are loaded, compiling and caching on a miss.
+
+  `root` is the extension directory; `files` are its sorted `.ex` paths.
+  Returns the loaded modules plus any compile diagnostics (empty on a cache
+  hit). The caller picks the module implementing the extension behaviour.
+  """
+  @spec load_or_compile(String.t(), [String.t()], keyword()) :: result()
+  def load_or_compile(root, files, opts \\ [])
+
+  def load_or_compile(_root, [], _opts), do: {:error, "no source files to compile"}
+
+  def load_or_compile(root, files, opts) when is_binary(root) and is_list(files) do
+    if Keyword.get(opts, :enabled, enabled?()) do
+      cache_root = Keyword.get(opts, :cache_dir, default_cache_dir())
+      ext_dir = Path.join(cache_root, ext_id(root))
+      dir = Path.join(ext_dir, content_key(root, files))
+
+      case load_from_cache(dir) do
+        {:ok, modules} ->
+          {:ok, %{modules: modules, diagnostics: [], source: :cache}}
+
+        :miss ->
+          compile_and_cache(files, ext_dir, dir)
+      end
+    else
+      compile_in_memory(files)
+    end
+  end
+
+  # ── Cache hit ─────────────────────────────────────────────────────────
+
+  @spec load_from_cache(String.t()) :: {:ok, [module()]} | :miss
+  defp load_from_cache(dir) do
+    beams = Path.wildcard(Path.join(dir, "*.beam"))
+
+    case beams do
+      [] ->
+        :miss
+
+      _ ->
+        load_beams(beams)
+    end
+  end
+
+  @spec load_beams([String.t()]) :: {:ok, [module()]} | :miss
+  defp load_beams(beams) do
+    Enum.reduce_while(beams, {:ok, []}, fn beam, {:ok, acc} ->
+      # Purge any already-loaded version first so the on-disk beam becomes the
+      # current code (matters for dev hot-reload, where an older version may
+      # still be loaded). load_abs takes the path without the .beam extension.
+      module = beam |> Path.basename() |> Path.rootname() |> String.to_atom()
+      :code.purge(module)
+      :code.delete(module)
+
+      case :code.load_abs(String.to_charlist(Path.rootname(beam))) do
+        {:module, loaded} -> {:cont, {:ok, [loaded | acc]}}
+        {:error, _reason} -> {:halt, :miss}
+      end
+    end)
+  end
+
+  # ── Cache miss: compile and persist ─────────────────────────────────────
+
+  @spec compile_and_cache([String.t()], String.t(), String.t()) :: result()
+  defp compile_and_cache(files, ext_dir, dir) do
+    File.mkdir_p!(dir)
+
+    {outcome, diagnostics} =
+      Code.with_diagnostics(fn ->
+        Kernel.ParallelCompiler.compile_to_path(files, dir, return_diagnostics: true)
+      end)
+
+    case outcome do
+      {:ok, _modules, _diag} ->
+        prune_stale_keys(ext_dir, dir)
+
+        # Load from the freshly written beams so the on-disk version is the
+        # one in memory. compile_to_path writes the beams but does not reload
+        # a module that was already loaded (e.g. a prior dev-reload version).
+        case load_from_cache(dir) do
+          {:ok, modules} ->
+            {:ok, %{modules: modules, diagnostics: diagnostics, source: :compiled}}
+
+          :miss ->
+            File.rm_rf(dir)
+            {:error, "compiled beams could not be loaded"}
+        end
+
+      {:error, _errors, _diag} ->
+        File.rm_rf(dir)
+        {:error, "extension compilation failed (see *Messages*)"}
+    end
+  rescue
+    e in [SyntaxError, TokenMissingError, CompileError] ->
+      File.rm_rf(dir)
+      {:error, "compile error: #{Exception.message(e)}"}
+
+    e ->
+      File.rm_rf(dir)
+      {:error, "error: #{Exception.message(e)}"}
+  catch
+    kind, reason ->
+      File.rm_rf(dir)
+      {:error, "error: #{inspect(kind)} #{inspect(reason)}"}
+  end
+
+  # Keep only the just-built key for this extension; remove older versions.
+  @spec prune_stale_keys(String.t(), String.t()) :: :ok
+  defp prune_stale_keys(ext_dir, keep_dir) do
+    keep = Path.basename(keep_dir)
+
+    case File.ls(ext_dir) do
+      {:ok, entries} ->
+        for entry <- entries, entry != keep do
+          File.rm_rf(Path.join(ext_dir, entry))
+        end
+
+        :ok
+
+      {:error, _} ->
+        :ok
+    end
+  end
+
+  # ── Caching disabled: previous in-memory behaviour ──────────────────────
+
+  @spec compile_in_memory([String.t()]) :: result()
+  defp compile_in_memory(files) do
+    {outcome, diagnostics} =
+      Code.with_diagnostics(fn ->
+        Kernel.ParallelCompiler.compile(files, return_diagnostics: true)
+      end)
+
+    case outcome do
+      {:ok, modules, _diag} ->
+        {:ok, %{modules: modules, diagnostics: diagnostics, source: :compiled}}
+
+      {:error, _errors, _diag} ->
+        {:error, "extension compilation failed (see *Messages*)"}
+    end
+  rescue
+    e in [SyntaxError, TokenMissingError, CompileError] ->
+      {:error, "compile error: #{Exception.message(e)}"}
+
+    e ->
+      {:error, "error: #{Exception.message(e)}"}
+  catch
+    kind, reason ->
+      {:error, "error: #{inspect(kind)} #{inspect(reason)}"}
+  end
+
+  # ── Keys and paths ──────────────────────────────────────────────────────
+
+  # Stable per-location id so we can prune an extension's old versions.
+  @spec ext_id(String.t()) :: String.t()
+  defp ext_id(root) do
+    :sha256
+    |> :crypto.hash(Path.expand(root))
+    |> Base.url_encode64(padding: false)
+    |> binary_part(0, 16)
+  end
+
+  # Content + toolchain hash. Relative paths keep the key stable regardless of
+  # where the extension dir lives on disk.
+  @spec content_key(String.t(), [String.t()]) :: String.t()
+  defp content_key(root, files) do
+    expanded_root = Path.expand(root)
+
+    payload =
+      files
+      |> Enum.sort()
+      |> Enum.flat_map(fn file ->
+        [Path.relative_to(file, expanded_root), "\0", File.read!(file), "\0"]
+      end)
+
+    :sha256
+    |> :crypto.hash([version_tag(), "\0" | payload])
+    |> Base.url_encode64(padding: false)
+  end
+
+  @spec version_tag() :: String.t()
+  defp version_tag do
+    "elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}"
+  end
+
+  @spec enabled?() :: boolean()
+  defp enabled?, do: Application.get_env(:minga, :extension_compile_cache, true)
+
+  @spec default_cache_dir() :: String.t()
+  defp default_cache_dir do
+    Application.get_env(
+      :minga,
+      :extension_compile_cache_dir,
+      Path.join(Path.expand("~/.local/share/minga"), "extension_cache")
+    )
+  end
+end

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -15,6 +15,7 @@ defmodule Minga.Extension.Supervisor do
 
   use DynamicSupervisor
 
+  alias Minga.Extension.CompileCache
   alias Minga.Extension.Git, as: ExtGit
   alias Minga.Extension.Hex, as: ExtHex
   alias Minga.Extension.Manifest
@@ -1408,41 +1409,17 @@ defmodule Minga.Extension.Supervisor do
         {:error, "no .ex files found in #{expanded}"}
 
       _ ->
-        compile_and_find_extension(files)
-    end
-  end
+        # The compile cache loads precompiled beams on a hit and recompiles
+        # (writing fresh beams) on a miss, so editing extension source still
+        # hot-reloads via a changed content hash.
+        case CompileCache.load_or_compile(expanded, files) do
+          {:ok, %{modules: modules, diagnostics: diagnostics}} ->
+            log_diagnostics(diagnostics)
+            find_extension_in_compiled(modules)
 
-  @spec compile_and_find_extension([String.t()]) :: {:ok, module()} | {:error, String.t()}
-  defp compile_and_find_extension(files) do
-    {result, diagnostics} = compile_quietly(files)
-    log_diagnostics(diagnostics)
-    result
-  rescue
-    e in [SyntaxError, TokenMissingError, CompileError] ->
-      {:error, "compile error: #{Exception.message(e)}"}
-
-    e ->
-      {:error, "error: #{Exception.message(e)}"}
-  catch
-    kind, reason ->
-      {:error, "error: #{inspect(kind)} #{inspect(reason)}"}
-  end
-
-  # Compiles extension files using ParallelCompiler so cross-module references resolve.
-  # Diagnostics go through Code.with_diagnostics, not global :standard_error mutation.
-  @spec compile_quietly([String.t()]) :: {{:ok, module()} | {:error, String.t()}, [map()]}
-  defp compile_quietly(files) do
-    Code.with_diagnostics(fn -> parallel_compile_and_find(files) end)
-  end
-
-  @spec parallel_compile_and_find([String.t()]) :: {:ok, module()} | {:error, String.t()}
-  defp parallel_compile_and_find(files) do
-    case Kernel.ParallelCompiler.compile(files, return_diagnostics: true) do
-      {:ok, modules, _diag_map} ->
-        find_extension_in_compiled(modules)
-
-      {:error, _errors, _diag_map} ->
-        {:error, "extension compilation failed (see *Messages*)"}
+          {:error, reason} ->
+            {:error, reason}
+        end
     end
   end
 

--- a/lib/minga/session/event_recorder.ex
+++ b/lib/minga/session/event_recorder.ex
@@ -14,7 +14,19 @@ defmodule Minga.Session.EventRecorder do
   ## Retention
 
   A periodic sweep deletes events older than the configured retention
-  window (default: 7 days). The sweep runs once per hour.
+  window (`:event_retention_days`). The first sweep runs a few seconds
+  after boot so even short-lived CLI invocations get a chance to prune;
+  subsequent sweeps run once per hour.
+
+  ## Startup and health checks
+
+  The database is a side-car: opening it is the only synchronous step in
+  `init/1`, and that is O(1) (it only reads the file header). A structural
+  integrity check is O(database size) and must never sit on the startup
+  path, so it runs asynchronously a few seconds after boot on a separate
+  connection. If the async check reports corruption, the recorder recreates
+  the database. The check defaults to `:quick` (see
+  `Store.integrity_check/2`) and can be disabled with `health_check: :none`.
 
   ## Supervision
 
@@ -32,6 +44,9 @@ defmodule Minga.Session.EventRecorder do
   @default_db_dir Path.expand("~/.local/share/minga")
   @db_filename "events.db"
   @retention_sweep_interval_ms :timer.hours(1)
+  @initial_retention_sweep_delay_ms :timer.seconds(5)
+  @health_check_delay_ms :timer.seconds(10)
+  @default_health_check :quick
 
   @subscribed_topics [
     :buffer_saved,
@@ -48,11 +63,12 @@ defmodule Minga.Session.EventRecorder do
 
   defmodule State do
     @moduledoc false
-    @enforce_keys [:db]
-    defstruct [:db, :retention_days, :sweep_ref]
+    @enforce_keys [:db, :path]
+    defstruct [:db, :path, :retention_days, :sweep_ref]
 
     @type t :: %__MODULE__{
             db: Exqlite.Sqlite3.db(),
+            path: String.t(),
             retention_days: pos_integer(),
             sweep_ref: reference() | nil
           }
@@ -112,13 +128,15 @@ defmodule Minga.Session.EventRecorder do
     case open_or_recreate(path) do
       {:ok, db} ->
         if Keyword.get(opts, :subscribe, true), do: subscribe_to_events()
-        sweep_ref = schedule_retention_sweep()
+        sweep_ref = schedule_initial_retention_sweep(opts)
+        schedule_health_check(Keyword.get(opts, :health_check, @default_health_check), opts)
 
         Minga.Log.info(:editor, "[EventRecorder] started, logging to #{path}")
 
         {:ok,
          %State{
            db: db,
+           path: path,
            retention_days: retention_days,
            sweep_ref: sweep_ref
          }}
@@ -168,6 +186,40 @@ defmodule Minga.Session.EventRecorder do
     {:noreply, %{state | sweep_ref: sweep_ref}}
   end
 
+  # Run the integrity check off the recorder process on its own connection so
+  # a multi-second check on a large database never blocks event writes.
+  def handle_info({:run_health_check, mode}, state) do
+    parent = self()
+    path = state.path
+
+    Task.start(fn ->
+      send(parent, {:health_check_result, run_health_check(path, mode)})
+    end)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:health_check_result, :healthy}, state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:health_check_result, {:corrupt, messages}}, state) do
+    Minga.Log.warning(
+      :editor,
+      "[EventRecorder] integrity check failed: #{inspect(messages)}, recreating database"
+    )
+
+    Store.close(state.db)
+
+    case recreate(state.path) do
+      {:ok, db} ->
+        {:noreply, %{state | db: db}}
+
+      {:error, reason} ->
+        {:stop, reason, state}
+    end
+  end
+
   def handle_info(_msg, state) do
     {:noreply, state}
   end
@@ -185,33 +237,54 @@ defmodule Minga.Session.EventRecorder do
     Enum.each(@subscribed_topics, &Events.subscribe/1)
   end
 
+  @spec schedule_initial_retention_sweep(keyword()) :: reference()
+  defp schedule_initial_retention_sweep(opts) do
+    delay = Keyword.get(opts, :initial_sweep_delay_ms, @initial_retention_sweep_delay_ms)
+    Process.send_after(self(), :retention_sweep, delay)
+  end
+
   @spec schedule_retention_sweep() :: reference()
   defp schedule_retention_sweep do
     Process.send_after(self(), :retention_sweep, @retention_sweep_interval_ms)
+  end
+
+  @spec schedule_health_check(:quick | :full | :none, keyword()) :: reference() | :ok
+  defp schedule_health_check(:none, _opts), do: :ok
+
+  defp schedule_health_check(mode, opts) when mode in [:quick, :full] do
+    delay = Keyword.get(opts, :health_check_delay_ms, @health_check_delay_ms)
+    Process.send_after(self(), {:run_health_check, mode}, delay)
+  end
+
+  @spec run_health_check(String.t(), :quick | :full) :: :healthy | {:corrupt, [String.t()]}
+  defp run_health_check(path, mode) do
+    case Store.open(path) do
+      {:ok, db} ->
+        result = Store.integrity_check(db, mode)
+        Store.close(db)
+
+        case result do
+          {:ok, :healthy} -> :healthy
+          {:error, messages} -> {:corrupt, messages}
+        end
+
+      {:error, reason} ->
+        {:corrupt, [inspect(reason)]}
+    end
   end
 
   @spec open_or_recreate(String.t()) :: {:ok, Store.db()} | {:error, term()}
   defp open_or_recreate(path) do
     case Store.open(path) do
       {:ok, db} ->
-        case Store.integrity_check(db) do
-          {:ok, :healthy} ->
-            {:ok, db}
+        {:ok, db}
 
-          {:error, messages} ->
-            Minga.Log.warning(
-              :editor,
-              "[EventRecorder] database corrupt: #{inspect(messages)}, recreating"
-            )
-
-            Store.close(db)
-            recreate(path)
-        end
-
-      {:error, reason} when is_binary(path) ->
+      {:error, reason} ->
         # The file exists but can't be opened (e.g., garbage data that
-        # isn't a valid SQLite header). Delete and try fresh.
-        if File.exists?(path) do
+        # isn't a valid SQLite header). Delete and try fresh. Structural
+        # corruption that only surfaces under a full scan is caught later
+        # by the async health check, off the startup path.
+        if is_binary(path) and File.exists?(path) do
           Minga.Log.warning(
             :editor,
             "[EventRecorder] database unreadable: #{inspect(reason)}, recreating"

--- a/lib/minga/session/event_recorder.ex
+++ b/lib/minga/session/event_recorder.ex
@@ -284,7 +284,7 @@ defmodule Minga.Session.EventRecorder do
         # isn't a valid SQLite header). Delete and try fresh. Structural
         # corruption that only surfaces under a full scan is caught later
         # by the async health check, off the startup path.
-        if is_binary(path) and File.exists?(path) do
+        if File.exists?(path) do
           Minga.Log.warning(
             :editor,
             "[EventRecorder] database unreadable: #{inspect(reason)}, recreating"

--- a/lib/minga/session/event_recorder/store.ex
+++ b/lib/minga/session/event_recorder/store.ex
@@ -246,14 +246,26 @@ defmodule Minga.Session.EventRecorder.Store do
   end
 
   @doc """
-  Runs `PRAGMA integrity_check` and returns the result.
+  Runs an integrity check and returns the result.
+
+  `mode` selects the SQLite pragma:
+
+  - `:full` (default) runs `PRAGMA integrity_check`, which walks every
+    page and index in the database. Cost is O(database size); on a large
+    database this takes many seconds, so never run it on a hot path.
+  - `:quick` runs `PRAGMA quick_check`, which skips the expensive index
+    consistency checks and is roughly an order of magnitude faster.
 
   Returns `{:ok, :healthy}` if the database is intact, or
-  `{:error, messages}` with the integrity check output.
+  `{:error, messages}` with the check output.
   """
-  @spec integrity_check(db()) :: {:ok, :healthy} | {:error, [String.t()]}
-  def integrity_check(db) do
-    sql = "PRAGMA integrity_check"
+  @spec integrity_check(db(), :full | :quick) :: {:ok, :healthy} | {:error, [String.t()]}
+  def integrity_check(db, mode \\ :full) do
+    sql =
+      case mode do
+        :quick -> "PRAGMA quick_check"
+        :full -> "PRAGMA integrity_check"
+      end
 
     with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql) do
       results = collect_rows(db, stmt)

--- a/test/minga/cli_test.exs
+++ b/test/minga/cli_test.exs
@@ -279,6 +279,35 @@ defmodule Minga.CLITest do
     end
   end
 
+  describe "info_flag_output/1" do
+    test "returns version output for --version and -v" do
+      assert {:ok, message} = CLI.info_flag_output(["--version"])
+      assert message =~ "minga"
+      assert message =~ Minga.version()
+
+      assert {:ok, message_v} = CLI.info_flag_output(["-v"])
+      assert message_v == message
+    end
+
+    test "returns usage output for --help and -h" do
+      assert {:ok, message} = CLI.info_flag_output(["--help"])
+      assert message =~ "Usage: minga"
+
+      assert {:ok, message_h} = CLI.info_flag_output(["-h"])
+      assert message_h == message
+    end
+
+    test "detects info flags even after other arguments" do
+      assert {:ok, _} = CLI.info_flag_output(["--editor", "--version"])
+    end
+
+    test "returns :none when no info flag is present" do
+      assert :none = CLI.info_flag_output([])
+      assert :none = CLI.info_flag_output(["README.md"])
+      assert :none = CLI.info_flag_output(["--headless"])
+    end
+  end
+
   describe "startup_project_root_from_args/1" do
     test "detects directory targets and files inside marked projects" do
       root = tmp_dir("cli-project-root")

--- a/test/minga/extension/compile_cache_test.exs
+++ b/test/minga/extension/compile_cache_test.exs
@@ -1,0 +1,145 @@
+defmodule Minga.Extension.CompileCacheTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Extension.CompileCache
+
+  setup do
+    cache_dir = Path.join(System.tmp_dir!(), "ext_cache_#{:erlang.unique_integer([:positive])}")
+    src_dir = Path.join(System.tmp_dir!(), "ext_src_#{:erlang.unique_integer([:positive])}")
+    File.mkdir_p!(src_dir)
+
+    on_exit(fn ->
+      File.rm_rf!(cache_dir)
+      File.rm_rf!(src_dir)
+    end)
+
+    %{cache_dir: cache_dir, src_dir: src_dir}
+  end
+
+  # Writes a single-module extension source and returns {root, files, module}.
+  defp write_extension(src_dir, body) do
+    module = :"Elixir.ExtFixture#{:erlang.unique_integer([:positive])}"
+    file = Path.join(src_dir, "ext.ex")
+
+    File.write!(file, """
+    defmodule #{inspect(module)} do
+      def marker, do: #{body}
+    end
+    """)
+
+    {src_dir, [file], module}
+  end
+
+  defp opts(cache_dir), do: [cache_dir: cache_dir, enabled: true]
+
+  describe "load_or_compile/3" do
+    test "compiles and writes beams on a miss", %{cache_dir: cache_dir, src_dir: src_dir} do
+      {root, files, module} = write_extension(src_dir, ":v1")
+
+      assert {:ok, %{modules: modules, source: :compiled, diagnostics: []}} =
+               CompileCache.load_or_compile(root, files, opts(cache_dir))
+
+      assert module in modules
+      assert module.marker() == :v1
+      # A .beam was persisted somewhere under the cache root.
+      assert Path.wildcard(Path.join(cache_dir, "**/*.beam")) != []
+    end
+
+    test "loads from cache on a hit without recompiling", %{
+      cache_dir: cache_dir,
+      src_dir: src_dir
+    } do
+      {root, files, module} = write_extension(src_dir, ":v1")
+
+      assert {:ok, %{source: :compiled}} =
+               CompileCache.load_or_compile(root, files, opts(cache_dir))
+
+      assert {:ok, %{modules: modules, source: :cache, diagnostics: []}} =
+               CompileCache.load_or_compile(root, files, opts(cache_dir))
+
+      assert module in modules
+      assert module.marker() == :v1
+    end
+
+    test "recompiles and prunes the old entry when source changes", %{
+      cache_dir: cache_dir,
+      src_dir: src_dir
+    } do
+      module = :"Elixir.ExtFixtureChange#{:erlang.unique_integer([:positive])}"
+      file = Path.join(src_dir, "ext.ex")
+
+      write = fn body ->
+        File.write!(file, "defmodule #{inspect(module)} do\n  def marker, do: #{body}\nend\n")
+      end
+
+      write.(":v1")
+
+      assert {:ok, %{source: :compiled}} =
+               CompileCache.load_or_compile(src_dir, [file], opts(cache_dir))
+
+      [ext_dir] = Path.wildcard(Path.join(cache_dir, "*"))
+      assert length(File.ls!(ext_dir)) == 1
+
+      write.(":v2")
+
+      assert {:ok, %{source: :compiled, modules: modules}} =
+               CompileCache.load_or_compile(src_dir, [file], opts(cache_dir))
+
+      assert module.marker() == :v2
+      # Old key pruned: still exactly one entry for this extension.
+      assert length(File.ls!(ext_dir)) == 1
+      assert module in modules
+    end
+
+    test "falls back to recompiling when a cached beam is corrupt", %{
+      cache_dir: cache_dir,
+      src_dir: src_dir
+    } do
+      {root, files, module} = write_extension(src_dir, ":v1")
+
+      assert {:ok, %{source: :compiled}} =
+               CompileCache.load_or_compile(root, files, opts(cache_dir))
+
+      # Corrupt every cached beam.
+      for beam <- Path.wildcard(Path.join(cache_dir, "**/*.beam")) do
+        File.write!(beam, "not a beam file")
+      end
+
+      assert {:ok, %{source: :compiled, modules: modules}} =
+               CompileCache.load_or_compile(root, files, opts(cache_dir))
+
+      assert module in modules
+      assert module.marker() == :v1
+    end
+
+    test "compiles in memory and writes nothing when disabled", %{
+      cache_dir: cache_dir,
+      src_dir: src_dir
+    } do
+      {root, files, module} = write_extension(src_dir, ":v1")
+
+      assert {:ok, %{modules: modules, source: :compiled}} =
+               CompileCache.load_or_compile(root, files, cache_dir: cache_dir, enabled: false)
+
+      assert module in modules
+      assert module.marker() == :v1
+      refute File.exists?(cache_dir)
+    end
+
+    test "returns an error for a syntax error and leaves no cache entry", %{
+      cache_dir: cache_dir,
+      src_dir: src_dir
+    } do
+      file = Path.join(src_dir, "broken.ex")
+      File.write!(file, "defmodule Broken do def oops(")
+
+      assert {:error, message} = CompileCache.load_or_compile(src_dir, [file], opts(cache_dir))
+      assert is_binary(message)
+      assert Path.wildcard(Path.join(cache_dir, "**/*.beam")) == []
+    end
+
+    test "returns an error when given no files", %{cache_dir: cache_dir} do
+      assert {:error, _} = CompileCache.load_or_compile("/tmp/whatever", [], opts(cache_dir))
+    end
+  end
+end

--- a/test/minga/session/event_recorder/store_test.exs
+++ b/test/minga/session/event_recorder/store_test.exs
@@ -201,9 +201,13 @@ defmodule Minga.Session.EventRecorder.StoreTest do
     end
   end
 
-  describe "integrity_check/1" do
-    test "reports healthy for a valid database", %{db: db} do
+  describe "integrity_check/2" do
+    test "reports healthy for a valid database (full)", %{db: db} do
       assert {:ok, :healthy} = Store.integrity_check(db)
+    end
+
+    test "reports healthy for a valid database (quick)", %{db: db} do
+      assert {:ok, :healthy} = Store.integrity_check(db, :quick)
     end
   end
 

--- a/test/minga/session/event_recorder_test.exs
+++ b/test/minga/session/event_recorder_test.exs
@@ -258,6 +258,89 @@ defmodule Minga.Session.EventRecorderTest do
       assert old_events == []
       assert [_ | _] = recent_events
     end
+
+    test "schedules an initial sweep far sooner than the hourly interval", %{recorder: recorder} do
+      # The first sweep must run shortly after boot (not an hour later), so
+      # short-lived sessions still prune. Assert a pending timer exists with a
+      # delay well under the recurring hour, deterministically and without sleeping.
+      state = :sys.get_state(recorder)
+      assert is_reference(state.sweep_ref)
+
+      remaining = Process.read_timer(state.sweep_ref)
+      assert is_integer(remaining)
+      assert remaining <= :timer.minutes(1)
+    end
+  end
+
+  describe "health check" do
+    test "records events normally while an async health check is enabled" do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "minga_health_#{:erlang.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      unique = :erlang.unique_integer([:positive])
+
+      recorder =
+        start_supervised!(
+          Supervisor.child_spec(
+            {EventRecorder,
+             name: :"recorder_health_#{unique}",
+             db_dir: tmp_dir,
+             subscribe: false,
+             health_check: :quick,
+             health_check_delay_ms: 0},
+            id: :"recorder_health_#{unique}"
+          )
+        )
+
+      send(
+        recorder,
+        {:minga_event, :buffer_saved, %Events.BufferEvent{buffer: self(), path: "/tmp/ok.ex"}}
+      )
+
+      wait_for_processing(recorder)
+
+      # The check runs on a healthy fresh database, so the recorder stays up
+      # and keeps recording.
+      assert Process.alive?(recorder)
+
+      db = open_db(tmp_dir)
+      {:ok, [event]} = Store.events_by_type(db, :buffer_saved)
+      Store.close(db)
+      assert event.payload["path"] == "/tmp/ok.ex"
+    end
+
+    test "recreates the database when the async check reports corruption", %{
+      recorder: recorder,
+      db_dir: db_dir
+    } do
+      send(
+        recorder,
+        {:minga_event, :buffer_saved, %Events.BufferEvent{buffer: self(), path: "/tmp/before.ex"}}
+      )
+
+      wait_for_processing(recorder)
+
+      # Simulate the async check finding corruption.
+      send(recorder, {:health_check_result, {:corrupt, ["forced"]}})
+      wait_for_processing(recorder)
+
+      send(
+        recorder,
+        {:minga_event, :buffer_saved, %Events.BufferEvent{buffer: self(), path: "/tmp/after.ex"}}
+      )
+
+      wait_for_processing(recorder)
+
+      db = open_db(db_dir)
+      {:ok, events} = Store.events_by_type(db, :buffer_saved)
+      Store.close(db)
+
+      paths = Enum.map(events, & &1.payload["path"])
+      assert paths == ["/tmp/after.ex"]
+    end
   end
 
   describe "resilience" do


### PR DESCRIPTION
## Summary

Startup was slow and noisy. This makes the editor launch faster and stops boot logs from printing over the terminal. Five focused changes:

1. **Event recorder no longer blocks startup.** `init/1` ran `PRAGMA integrity_check` synchronously, an O(database-size) scan that stalled boot for ~20s on a large `events.db`. The check now runs asynchronously (~10s after boot, `quick_check`, on a separate connection) and recreates the DB on corruption. The first retention sweep now runs 5s after boot instead of only hourly, so short-lived sessions actually prune and the DB stays bounded.
2. **`--version`/`--help` skip booting the app.** They short-circuit in `Application.start/2` before building the supervision tree, so they no longer spin up the event recorder, extensions, and watchdog just to print a string. `--version` now goes to stdout with exit 0.
3. **`make install` re-extracts the Burrito payload.** Burrito keys its extraction cache on app+erts+version, so with the version pinned at `0.1.0` a re-install kept running previously extracted code. `install-tui` now clears the extraction dir so the new payload always takes effect.
4. **TUI boot logs stay off the terminal.** The default logger handler wrote to stdout in standalone TUI mode, printing `EventRecorder`/extension/watchdog lines over the editor. They now go to the log file (mirroring connected/GUI mode); headless and `mix` runs keep stdout logging.
5. **Extension compile cache.** Path/git extensions were recompiled from source on every boot (~500ms each, on the critical path). `Minga.Extension.CompileCache` compiles once and caches the `.beam` keyed by source-content + Elixir/ERTS version, loading beams directly on later boots (~90ms vs ~500ms warm). Invalidates on source change (dev hot-reload intact), prunes stale entries, falls back to recompile on corrupt cache, disabled in tests.

## Measurements (aarch64 mac)

- Startup before fixes: ~20s (dominated by the integrity check on a 2.1 GB `events.db`).
- Extension load: ~500ms → ~90ms warm per extension (compile cache).
- `--version`: clean stdout output, no app boot.

## Testing

- `mix test test/minga/extension/ test/minga/session/event_recorder_test.exs test/minga/session/event_recorder/store_test.exs test/minga/cli_test.exs` — passing.
- New: `Minga.Extension.CompileCacheTest` (hit/miss/invalidation/corrupt-fallback/disabled), event-recorder async health-check + initial-sweep, `CLI.info_flag_output/1`.

## Follow-ups

Startup performance has two more levers, captured as their own tickets:
- #2041 — lazy/deferred extension loading (use-package style); this PR's compile cache is the foundation under it.
- #2042 — lazy BEAM code loading (interactive mode); measured ~0.7s win, needs a Burrito-fork launcher change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
