### PR TITLE
fix(buffer): reject binary files instead of crashing the editor

### DIFF
--- a/lib/minga/buffer/persistence.ex
+++ b/lib/minga/buffer/persistence.ex
@@ -20,9 +20,18 @@ defmodule Minga.Buffer.Persistence do
 
   def load_content(storage, file_path, _initial_content) do
     case read_content(storage, file_path) do
-      {:ok, text} -> {:ok, text, file_path, file_metadata(storage, file_path)}
-      {:error, :enoent} -> {:ok, "", file_path, {nil, nil}}
-      {:error, reason} -> {:error, reason}
+      {:ok, text} ->
+        if String.valid?(text) do
+          {:ok, text, file_path, file_metadata(storage, file_path)}
+        else
+          {:error, :binary_file}
+        end
+
+      {:error, :enoent} ->
+        {:ok, "", file_path, {nil, nil}}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -899,25 +899,29 @@ defmodule Minga.Buffer.Process do
   @spec handle_call(term(), GenServer.from(), state()) :: {:reply, term(), state()}
   def handle_call({:open, file_path}, _from, state) do
     case Persistence.read_content(state, file_path) do
-      {:ok, text} ->
-        first_line = text |> String.split("\n", parts: 2) |> List.first("")
-        filetype = Language.detect_filetype_from_content(file_path, first_line)
+      {:ok, text} when is_binary(text) ->
+        if not String.valid?(text) do
+          {:reply, {:error, :binary_file}, state}
+        else
+          first_line = text |> String.split("\n", parts: 2) |> List.first("")
+          filetype = Language.detect_filetype_from_content(file_path, first_line)
 
-        {mtime, size} = Persistence.file_metadata(state, file_path)
+          {mtime, size} = Persistence.file_metadata(state, file_path)
 
-        new_state = %{
-          BufState.load_saved_content(state, file_path, {mtime, size}, text)
-          | document: Document.new(text),
-            file_path: file_path,
-            filetype: filetype,
-            options: reseed_options(state, filetype),
-            decorations: Decorations.new(),
-            undo_history: UndoHistory.clear(state.undo_history)
-        }
+          new_state = %{
+            BufState.load_saved_content(state, file_path, {mtime, size}, text)
+            | document: Document.new(text),
+              file_path: file_path,
+              filetype: filetype,
+              options: reseed_options(state, filetype),
+              decorations: Decorations.new(),
+              undo_history: UndoHistory.clear(state.undo_history)
+          }
 
-        unregister_path(state.file_path)
-        register_path(file_path)
-        {:reply, :ok, new_state}
+          unregister_path(state.file_path)
+          register_path(file_path)
+          {:reply, :ok, new_state}
+        end
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -900,9 +900,7 @@ defmodule Minga.Buffer.Process do
   def handle_call({:open, file_path}, _from, state) do
     case Persistence.read_content(state, file_path) do
       {:ok, text} when is_binary(text) ->
-        if not String.valid?(text) do
-          {:reply, {:error, :binary_file}, state}
-        else
+        if String.valid?(text) do
           first_line = text |> String.split("\n", parts: 2) |> List.first("")
           filetype = Language.detect_filetype_from_content(file_path, first_line)
 
@@ -921,6 +919,8 @@ defmodule Minga.Buffer.Process do
           unregister_path(state.file_path)
           register_path(file_path)
           {:reply, :ok, new_state}
+        else
+          {:reply, {:error, :binary_file}, state}
         end
 
       {:error, reason} ->

--- a/lib/minga_editor/commands/dired.ex
+++ b/lib/minga_editor/commands/dired.ex
@@ -209,8 +209,14 @@ defmodule MingaEditor.Commands.Dired do
     state = close_dired(state)
 
     case Commands.start_buffer(file_path, EditorState.options_server(state)) do
-      {:ok, pid} -> Commands.add_buffer(state, pid)
-      {:error, _} -> EditorState.set_status(state, "Cannot open: #{file_path}")
+      {:ok, pid} ->
+        Commands.add_buffer(state, pid)
+
+      {:error, :binary_file} ->
+        EditorState.set_status(state, "Cannot open binary file: #{Path.basename(file_path)}")
+
+      {:error, _} ->
+        EditorState.set_status(state, "Cannot open: #{file_path}")
     end
   end
 

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -813,8 +813,14 @@ defmodule MingaEditor.Commands.FileTree do
     case EditorState.find_buffer_by_path(state, path) do
       nil ->
         case Commands.start_buffer(path, EditorState.options_server(state)) do
-          {:ok, pid} -> BufferRegistry.do_file_tree_open(state, pid, path, tree)
-          {:error, _} -> state
+          {:ok, pid} ->
+            BufferRegistry.do_file_tree_open(state, pid, path, tree)
+
+          {:error, :binary_file} ->
+            EditorState.set_status(state, "Cannot open binary file: #{Path.basename(path)}")
+
+          {:error, _} ->
+            EditorState.set_status(state, "Cannot open: #{Path.basename(path)}")
         end
 
       idx ->

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -1459,8 +1459,14 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
       nil ->
         case Commands.start_buffer(abs_path, EditorState.options_server(state)) do
-          {:ok, pid} -> register_buffer_in_active_window(state, pid, abs_path)
-          {:error, _reason} -> EditorState.set_status(state, "Could not open #{abs_path}")
+          {:ok, pid} ->
+            register_buffer_in_active_window(state, pid, abs_path)
+
+          {:error, :binary_file} ->
+            EditorState.set_status(state, "Cannot open binary file: #{Path.basename(abs_path)}")
+
+          {:error, _reason} ->
+            EditorState.set_status(state, "Could not open #{abs_path}")
         end
     end
   end

--- a/test/minga/buffer/persistence_test.exs
+++ b/test/minga/buffer/persistence_test.exs
@@ -52,6 +52,20 @@ defmodule Minga.Buffer.PersistenceTest do
     assert Persistence.changed_since_saved?(state, mtime, size) == true
   end
 
+  test "load_content rejects binary (non-UTF-8) files", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "image.png")
+    File.write!(path, <<137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0>>)
+
+    assert Persistence.load_content(:local, path, "") == {:error, :binary_file}
+  end
+
+  test "load_content accepts valid UTF-8 files", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "valid.txt")
+    File.write!(path, "hello 🌍")
+
+    assert {:ok, "hello 🌍", ^path, {_mtime, _size}} = Persistence.load_content(:local, path, "")
+  end
+
   defp saved_state(path, content, mtime, size) do
     %BufState{
       document: Document.new(content),


### PR DESCRIPTION
## Summary

- Opening a binary file (PNG, JPEG, `.beam`, etc.) from the file tree crashed the TUI because `File.read/1` returns raw bytes that `Document.new/1` cannot handle
- Added a `String.valid?/1` guard in `Persistence.load_content/3` and `BufferProcess.handle_call(:open)` to return `{:error, :binary_file}` for non-UTF-8 content
- File tree, dired, and GUI callers now show "Cannot open binary file" in the status bar instead of crashing

## Test plan

- [x] New unit test: `Persistence.load_content/3` returns `{:error, :binary_file}` for a PNG-header blob
- [x] New unit test: valid UTF-8 content (including emoji) still loads normally
- [x] All 647 buffer tests pass
- [x] File tree and dired tests pass
- [ ] Manual: open a `.png` from the TUI file tree, confirm status bar message instead of crash
- [ ] Manual: open a `.beam` file from dired, confirm status bar message

🤖 Generated with [Claude Code](https://claude.com/claude-code)