### PR TITLE
fix: address review findings on boot-speed (DB safety, cache invalidation)

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,3 +6,10 @@ config :logger, level: :warning
 
 # Development checkouts load bundled extensions directly from the source tree when priv copies are not present yet.
 config :minga, allow_source_extension_fallback: true
+
+# Always recompile extensions in dev. The compile cache keys on extension source
+# + toolchain + minga version, so editing minga's own modules (which extensions
+# compile against) would otherwise serve a stale extension beam until the
+# extension's own source changes. Fresh compiles keep hot-reload correct; the
+# cache stays on for prod releases where boot speed matters.
+config :minga, extension_compile_cache: false

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -197,8 +197,11 @@ defmodule Minga.Application do
       :ok
     end
   rescue
-    # Never let argument inspection break startup; fall through to normal boot.
-    _ -> :ok
+    # Never let argument inspection break startup; fall through to normal boot,
+    # but leave a breadcrumb in case this ever misfires.
+    error ->
+      Minga.Log.debug(:editor, "info-flag short-circuit skipped: #{inspect(error)}")
+      :ok
   end
 
   @spec start_editor?() :: boolean()

--- a/lib/minga/extension/compile_cache.ex
+++ b/lib/minga/extension/compile_cache.ex
@@ -49,22 +49,23 @@ defmodule Minga.Extension.CompileCache do
 
   def load_or_compile(root, files, opts) when is_binary(root) and is_list(files) do
     if Keyword.get(opts, :enabled, enabled?()) do
-      case content_key(root, files) do
-        {:ok, key} ->
-          cache_root = Keyword.get(opts, :cache_dir, default_cache_dir())
-          ext_dir = Path.join(cache_root, ext_id(root))
-          dir = Path.join(ext_dir, key)
-
-          case load_from_cache(dir) do
-            {:ok, modules} -> {:ok, %{modules: modules, diagnostics: [], source: :cache}}
-            :miss -> compile_and_cache(files, ext_dir, dir)
-          end
-
-        {:error, reason} ->
-          {:error, reason}
-      end
+      load_cached(root, files, opts)
     else
       compile_in_memory(files)
+    end
+  end
+
+  @spec load_cached(String.t(), [String.t()], keyword()) :: result()
+  defp load_cached(root, files, opts) do
+    with {:ok, key} <- content_key(root, files) do
+      cache_root = Keyword.get(opts, :cache_dir, default_cache_dir())
+      ext_dir = Path.join(cache_root, ext_id(root))
+      dir = Path.join(ext_dir, key)
+
+      case load_from_cache(dir) do
+        {:ok, modules} -> {:ok, %{modules: modules, diagnostics: [], source: :cache}}
+        :miss -> compile_and_cache(files, ext_dir, dir)
+      end
     end
   end
 

--- a/lib/minga/extension/compile_cache.ex
+++ b/lib/minga/extension/compile_cache.ex
@@ -49,16 +49,19 @@ defmodule Minga.Extension.CompileCache do
 
   def load_or_compile(root, files, opts) when is_binary(root) and is_list(files) do
     if Keyword.get(opts, :enabled, enabled?()) do
-      cache_root = Keyword.get(opts, :cache_dir, default_cache_dir())
-      ext_dir = Path.join(cache_root, ext_id(root))
-      dir = Path.join(ext_dir, content_key(root, files))
+      case content_key(root, files) do
+        {:ok, key} ->
+          cache_root = Keyword.get(opts, :cache_dir, default_cache_dir())
+          ext_dir = Path.join(cache_root, ext_id(root))
+          dir = Path.join(ext_dir, key)
 
-      case load_from_cache(dir) do
-        {:ok, modules} ->
-          {:ok, %{modules: modules, diagnostics: [], source: :cache}}
+          case load_from_cache(dir) do
+            {:ok, modules} -> {:ok, %{modules: modules, diagnostics: [], source: :cache}}
+            :miss -> compile_and_cache(files, ext_dir, dir)
+          end
 
-        :miss ->
-          compile_and_cache(files, ext_dir, dir)
+        {:error, reason} ->
+          {:error, reason}
       end
     else
       compile_in_memory(files)
@@ -199,8 +202,9 @@ defmodule Minga.Extension.CompileCache do
   end
 
   # Content + toolchain hash. Relative paths keep the key stable regardless of
-  # where the extension dir lives on disk.
-  @spec content_key(String.t(), [String.t()]) :: String.t()
+  # where the extension dir lives on disk. Returns an error (rather than raising)
+  # if a source file vanished between globbing and reading.
+  @spec content_key(String.t(), [String.t()]) :: {:ok, String.t()} | {:error, String.t()}
   defp content_key(root, files) do
     expanded_root = Path.expand(root)
 
@@ -208,12 +212,17 @@ defmodule Minga.Extension.CompileCache do
       files
       |> Enum.sort()
       |> Enum.flat_map(fn file ->
-        [Path.relative_to(file, expanded_root), "\0", File.read!(file), "\0"]
+        case File.read(file) do
+          {:ok, content} -> [Path.relative_to(file, expanded_root), "\0", content, "\0"]
+          {:error, reason} -> throw({:read_error, file, reason})
+        end
       end)
 
-    :sha256
-    |> :crypto.hash([version_tag(), "\0" | payload])
-    |> Base.url_encode64(padding: false)
+    digest = :crypto.hash(:sha256, [version_tag(), "\0" | payload])
+    {:ok, Base.url_encode64(digest, padding: false)}
+  catch
+    {:read_error, file, reason} ->
+      {:error, "could not read extension source #{file}: #{inspect(reason)}"}
   end
 
   # Beams are tied to the toolchain *and* to minga itself: an extension compiles

--- a/lib/minga/extension/compile_cache.ex
+++ b/lib/minga/extension/compile_cache.ex
@@ -18,12 +18,17 @@ defmodule Minga.Extension.CompileCache do
   miss. After a successful compile we prune the extension's other (stale) keys
   so the cache holds one entry per extension.
 
-  Beams are toolchain-specific, so the key includes the Elixir and ERTS
-  versions: a runtime upgrade invalidates every entry automatically.
+  Beams are toolchain- and minga-specific, so the key also includes the Elixir
+  and ERTS versions and minga's own application version. A runtime upgrade or a
+  minga release (which bumps `:minga`'s version) invalidates every entry
+  automatically, so an extension compiled against an older minga API is never
+  loaded against a newer one.
 
-  Caching can be disabled with `config :minga, extension_compile_cache: false`
-  (tests do this to stay hermetic), in which case compilation falls back to the
-  previous in-memory behaviour.
+  Caching can be disabled with `config :minga, extension_compile_cache: false`,
+  which falls back to the previous in-memory behaviour. Dev and test disable it:
+  dev so that in-progress edits to minga's own modules always recompile
+  extensions (no stale-beam surprises during hot-reload), and test for
+  hermeticity.
   """
 
   @type result ::
@@ -211,9 +216,15 @@ defmodule Minga.Extension.CompileCache do
     |> Base.url_encode64(padding: false)
   end
 
+  # Beams are tied to the toolchain *and* to minga itself: an extension compiles
+  # against minga's modules, so a minga build that changes an extension-facing API
+  # must invalidate cached extension beams even when the extension source is
+  # unchanged. Releases bump :minga's version, which busts the cache here. (Dev
+  # disables the cache entirely so in-progress minga edits always recompile.)
   @spec version_tag() :: String.t()
   defp version_tag do
-    "elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}"
+    minga_vsn = to_string(Application.spec(:minga, :vsn) || "0")
+    "minga-#{minga_vsn}-elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}"
   end
 
   @spec enabled?() :: boolean()

--- a/lib/minga/session/event_recorder.ex
+++ b/lib/minga/session/event_recorder.ex
@@ -203,6 +203,20 @@ defmodule Minga.Session.EventRecorder do
     {:noreply, state}
   end
 
+  # The check ran on a separate connection that failed to open. The writer's
+  # own connection is still valid, so this is almost always transient (e.g. an
+  # fd limit), not corruption. Log and leave the database intact: recreating
+  # here on a false positive would delete the user's event history.
+  def handle_info({:health_check_result, {:check_failed, reason}}, state) do
+    Minga.Log.warning(
+      :editor,
+      "[EventRecorder] health check could not open a read connection: " <>
+        "#{inspect(reason)} (leaving database intact)"
+    )
+
+    {:noreply, state}
+  end
+
   def handle_info({:health_check_result, {:corrupt, messages}}, state) do
     Minga.Log.warning(
       :editor,
@@ -256,7 +270,8 @@ defmodule Minga.Session.EventRecorder do
     Process.send_after(self(), {:run_health_check, mode}, delay)
   end
 
-  @spec run_health_check(String.t(), :quick | :full) :: :healthy | {:corrupt, [String.t()]}
+  @spec run_health_check(String.t(), :quick | :full) ::
+          :healthy | {:corrupt, [String.t()]} | {:check_failed, term()}
   defp run_health_check(path, mode) do
     case Store.open(path) do
       {:ok, db} ->
@@ -264,12 +279,15 @@ defmodule Minga.Session.EventRecorder do
         Store.close(db)
 
         case result do
+          # Only an actual integrity-check failure means corruption. Failing to
+          # open the connection is reported separately so we never recreate the
+          # database on a transient open error.
           {:ok, :healthy} -> :healthy
           {:error, messages} -> {:corrupt, messages}
         end
 
       {:error, reason} ->
-        {:corrupt, [inspect(reason)]}
+        {:check_failed, reason}
     end
   end
 

--- a/lib/minga/session/event_recorder.ex
+++ b/lib/minga/session/event_recorder.ex
@@ -273,7 +273,7 @@ defmodule Minga.Session.EventRecorder do
   @spec run_health_check(String.t(), :quick | :full) ::
           :healthy | {:corrupt, [String.t()]} | {:check_failed, term()}
   defp run_health_check(path, mode) do
-    case Store.open(path) do
+    case Store.open_readonly(path) do
       {:ok, db} ->
         result = Store.integrity_check(db, mode)
         Store.close(db)

--- a/lib/minga/session/event_recorder/store.ex
+++ b/lib/minga/session/event_recorder/store.ex
@@ -42,6 +42,18 @@ defmodule Minga.Session.EventRecorder.Store do
   end
 
   @doc """
+  Opens a read-only connection to an existing database.
+
+  Skips `setup/0`: a read-only handle can't run the pragmas or `CREATE TABLE`
+  statements, and an existing database doesn't need them. Use for read-only
+  work such as integrity checks so the check can never mutate the database.
+  """
+  @spec open_readonly(String.t()) :: {:ok, db()} | {:error, term()}
+  def open_readonly(db_path) do
+    Exqlite.Sqlite3.open(db_path, mode: :readonly)
+  end
+
+  @doc """
   Opens an in-memory database for testing.
   """
   @spec open_memory() :: {:ok, db()} | {:error, term()}

--- a/test/minga/extension/compile_cache_test.exs
+++ b/test/minga/extension/compile_cache_test.exs
@@ -141,5 +141,16 @@ defmodule Minga.Extension.CompileCacheTest do
     test "returns an error when given no files", %{cache_dir: cache_dir} do
       assert {:error, _} = CompileCache.load_or_compile("/tmp/whatever", [], opts(cache_dir))
     end
+
+    test "returns an error (no crash) when a source file is missing", %{
+      cache_dir: cache_dir,
+      src_dir: src_dir
+    } do
+      ghost = Path.join(src_dir, "ghost.ex")
+
+      assert {:error, message} = CompileCache.load_or_compile(src_dir, [ghost], opts(cache_dir))
+      assert message =~ "ghost.ex"
+      assert Path.wildcard(Path.join(cache_dir, "**/*.beam")) == []
+    end
   end
 end

--- a/test/minga/session/event_recorder/store_test.exs
+++ b/test/minga/session/event_recorder/store_test.exs
@@ -211,6 +211,27 @@ defmodule Minga.Session.EventRecorder.StoreTest do
     end
   end
 
+  describe "open_readonly/1" do
+    test "opens an existing database read-only for checks, and rejects writes" do
+      path = Path.join(System.tmp_dir!(), "store_ro_#{:erlang.unique_integer([:positive])}.db")
+      on_exit(fn -> Enum.each([path, path <> "-wal", path <> "-shm"], &File.rm/1) end)
+
+      {:ok, rw} = Store.open(path)
+      :ok = Store.insert(rw, make_record())
+      Store.close(rw)
+
+      {:ok, ro} = Store.open_readonly(path)
+      assert {:ok, :healthy} = Store.integrity_check(ro, :quick)
+      assert {:error, _} = Store.insert(ro, make_record())
+      Store.close(ro)
+    end
+
+    test "returns an error for a missing database" do
+      missing = Path.join(System.tmp_dir!(), "nope_#{:erlang.unique_integer([:positive])}.db")
+      assert {:error, _} = Store.open_readonly(missing)
+    end
+  end
+
   describe "schema" do
     test "indexes exist", %{db: db} do
       {:ok, stmt} =

--- a/test/minga/session/event_recorder_test.exs
+++ b/test/minga/session/event_recorder_test.exs
@@ -341,6 +341,38 @@ defmodule Minga.Session.EventRecorderTest do
       paths = Enum.map(events, & &1.payload["path"])
       assert paths == ["/tmp/after.ex"]
     end
+
+    test "leaves the database intact when the async check cannot open a connection", %{
+      recorder: recorder,
+      db_dir: db_dir
+    } do
+      send(
+        recorder,
+        {:minga_event, :buffer_saved, %Events.BufferEvent{buffer: self(), path: "/tmp/before.ex"}}
+      )
+
+      wait_for_processing(recorder)
+
+      # A failure to open the health-check connection is transient, not
+      # corruption: the database must NOT be recreated (that would wipe history).
+      send(recorder, {:health_check_result, {:check_failed, :enoent}})
+      wait_for_processing(recorder)
+
+      send(
+        recorder,
+        {:minga_event, :buffer_saved, %Events.BufferEvent{buffer: self(), path: "/tmp/after.ex"}}
+      )
+
+      wait_for_processing(recorder)
+
+      db = open_db(db_dir)
+      {:ok, events} = Store.events_by_type(db, :buffer_saved)
+      Store.close(db)
+
+      paths = Enum.map(events, & &1.payload["path"])
+      assert "/tmp/before.ex" in paths
+      assert "/tmp/after.ex" in paths
+    end
   end
 
   describe "resilience" do


### PR DESCRIPTION
Follow-up to #2043 (now merged), addressing the two review findings.

## Fixes

1. **Event recorder no longer wipes the DB on a transient health-check failure.** The async integrity check runs on a second connection; any failure to *open* it was mapped to `{:corrupt, ...}`, which calls `recreate/1` and deletes `events.db`. A transient open failure (fd limit, momentary lock) while the writer's own connection is valid would destroy event history on a false positive. Now only an actual integrity-check failure recreates; an open failure is logged and the database is left intact. Regression test added.

2. **Compile cache invalidates when minga itself changes.** The key was Elixir + ERTS versions only, so a minga build that changed an extension-facing API but left extension source unchanged would load a stale extension beam (silent staleness, or a runtime `UndefinedFunctionError` on a renamed function). The key now includes minga's app version (releases bust it), and the cache is disabled in dev so in-progress edits to minga's own modules always recompile extensions.

## Testing
- `mix test test/minga/session/event_recorder_test.exs test/minga/extension/compile_cache_test.exs` — 23 passing.
- `mix dialyzer` — passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)