### PR TITLE
fix(project): restore project prompt UX

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -667,6 +667,7 @@ Mode values:
 | 7 | describe_key | `"Press key: "` | no | (accumulated keys) |
 | 8 | delete_confirm | `"Delete 'file.txt'? (y/n)"` | no | (empty) |
 | 9 | branch_delete_confirm | `"Delete branch feature? (y/n)"` | no | (empty) |
+| 10 | text_prompt | `"Add project: "` | yes | (empty) |
 
 `cursor_pos` is the 0-indexed character position within `input` for the beam cursor. `0xFFFF` means no cursor (prompt-only modes 5-9). `context` is right-aligned supplementary text. `match_score` is 0-255 fuzzy match quality. `candidate_count == 0` naturally represents "input visible, no completions."
 

--- a/lib/minga/frontend/adapter/gui/minibuffer_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/minibuffer_encoder.ex
@@ -58,6 +58,7 @@ defmodule Minga.Frontend.Adapter.GUI.MinibufferEncoder do
   defp encode_mode(:describe_key), do: 7
   defp encode_mode(:delete_confirm), do: 8
   defp encode_mode(:branch_delete_confirm), do: 9
+  defp encode_mode(:text_prompt), do: 10
   defp encode_mode(:unknown), do: 0
 
   @spec encode_cursor_pos(non_neg_integer() | nil) :: non_neg_integer()

--- a/lib/minga/render_model/ui/minibuffer.ex
+++ b/lib/minga/render_model/ui/minibuffer.ex
@@ -16,6 +16,7 @@ defmodule Minga.RenderModel.UI.Minibuffer do
           | :describe_key
           | :delete_confirm
           | :branch_delete_confirm
+          | :text_prompt
           | :unknown
 
   @type t :: %__MODULE__{

--- a/lib/minga_editor/commands/project.ex
+++ b/lib/minga_editor/commands/project.ex
@@ -18,7 +18,7 @@ defmodule MingaEditor.Commands.Project do
     {:project_find_file, "Find file in project", true},
     {:project_invalidate, "Invalidate project cache", true},
     {:project_add, "Add project", false},
-    {:project_remove, "Remove project", true},
+    {:project_remove, "Remove project", false},
     {:project_switch, "Switch project", false},
     {:project_recent_files, "Recent files", false}
   ]
@@ -50,25 +50,7 @@ defmodule MingaEditor.Commands.Project do
   end
 
   def execute(state, :project_remove) do
-    root = project_root()
-
-    case root do
-      nil ->
-        EditorState.set_status(state, "No project root detected")
-
-      path ->
-        Project.remove(path)
-        EditorState.set_status(state, "Removed project: #{Path.basename(path)}")
-    end
-  catch
-    :exit, _ -> state
-  end
-
-  @spec project_root() :: String.t() | nil
-  defp project_root do
-    Project.root()
-  catch
-    :exit, _ -> nil
+    PickerUI.open(state, MingaEditor.UI.Picker.ProjectRemoveSource)
   end
 
   commands(@command_specs)

--- a/lib/minga_editor/minibuffer_data.ex
+++ b/lib/minga_editor/minibuffer_data.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.MinibufferData do
 
   alias Minga.Command
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Prompt, as: PromptState
   alias Minga.Keymap
   alias MingaEditor.UI.WhichKey
 
@@ -62,6 +63,7 @@ defmodule MingaEditor.MinibufferData do
   @mode_describe_key 7
   @mode_delete_confirm 8
   @mode_branch_delete_confirm 9
+  @mode_text_prompt 10
 
   # Maximum candidates to send (keep the list manageable)
   @max_candidates 15
@@ -88,6 +90,25 @@ defmodule MingaEditor.MinibufferData do
   `MingaEditor.Frontend.Protocol.GUI.encode_gui_minibuffer/1`.
   """
   @spec from_state(EditorState.t()) :: t()
+
+  def from_state(%{
+        shell_state: %{
+          modal: {:prompt, %{prompt_ui: %PromptState{handler: handler} = prompt_state}}
+        }
+      })
+      when handler != nil do
+    %__MODULE__{
+      visible: true,
+      mode: @mode_text_prompt,
+      cursor_pos: prompt_state.cursor,
+      prompt: prompt_state.label,
+      input: prompt_state.text,
+      context: "",
+      selected_index: 0,
+      candidates: [],
+      total_candidates: 0
+    }
+  end
 
   def from_state(%{workspace: %{editing: %{mode: :command, mode_state: ms}}}) do
     input = ms.input

--- a/lib/minga_editor/prompt_ui.ex
+++ b/lib/minga_editor/prompt_ui.ex
@@ -53,12 +53,13 @@ defmodule MingaEditor.PromptUI do
 
   - `:default` — pre-filled text (default: `""`)
   - `:context` — arbitrary map passed through to the handler (default: `nil`)
+  - `:label` — prompt label override (default: `handler_module.label()`)
   """
   @spec open(state(), module(), keyword()) :: state()
   def open(state, handler_module, opts \\ []) do
     default_text = Keyword.get(opts, :default, "")
     context = Keyword.get(opts, :context)
-    label = handler_module.label()
+    label = Keyword.get(opts, :label, handler_module.label())
 
     prompt_state = %PromptState{
       handler: handler_module,
@@ -195,8 +196,8 @@ defmodule MingaEditor.PromptUI do
     text = prompt.text
     label_len = String.length(label)
 
-    label_face = Face.new(fg: pc.prompt_fg, bg: pc.prompt_bg)
-    input_face = Face.new(fg: pc.fg, bg: pc.bg)
+    label_face = Face.new(fg: pc.highlight_fg, bg: pc.prompt_bg)
+    input_face = Face.new(fg: pc.text_fg, bg: pc.bg)
 
     total_len = label_len + String.length(text)
     padding = String.duplicate(" ", max(0, viewport.cols - total_len))

--- a/lib/minga_editor/render_model/ui/minibuffer_builder.ex
+++ b/lib/minga_editor/render_model/ui/minibuffer_builder.ex
@@ -33,6 +33,7 @@ defmodule MingaEditor.RenderModel.UI.MinibufferBuilder do
   defp mode_model(7), do: :describe_key
   defp mode_model(8), do: :delete_confirm
   defp mode_model(9), do: :branch_delete_confirm
+  defp mode_model(10), do: :text_prompt
   defp mode_model(_mode), do: :unknown
 
   @spec cursor_pos_model(non_neg_integer()) :: non_neg_integer() | nil

--- a/lib/minga_editor/ui/picker/project_remove_source.ex
+++ b/lib/minga_editor/ui/picker/project_remove_source.ex
@@ -1,0 +1,97 @@
+defmodule MingaEditor.UI.Picker.ProjectRemoveSource do
+  @moduledoc """
+  Picker source for removing a known project.
+
+  Mirrors Doom Projectile's remove-known-project flow: pick a known project,
+  then confirm before deleting it from the known-projects list.
+  """
+
+  @behaviour MingaEditor.UI.Picker.Source
+
+  alias Minga.Project
+  alias MingaEditor.PromptUI
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.Item
+
+  @max_prompt_bytes 255
+  @remove_prefix "Remove "
+  @remove_suffix "? (y/n): "
+  @ellipsis "…"
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Remove project"
+
+  @impl true
+  @spec layout() :: MingaEditor.UI.Picker.Source.layout()
+  def layout, do: :centered
+
+  @impl true
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
+    Project.known_projects()
+    |> Enum.map(&item/1)
+  catch
+    :exit, _ -> []
+  end
+
+  @impl true
+  @spec on_select(Item.t(), term()) :: term()
+  def on_select(%Item{id: root_path}, state) when is_binary(root_path) do
+    label = confirmation_label(root_path)
+
+    PromptUI.open(state, MingaEditor.UI.Prompt.ProjectRemoveConfirm,
+      label: label,
+      context: %{path: root_path}
+    )
+  end
+
+  @doc false
+  @spec confirmation_label(String.t()) :: String.t()
+  def confirmation_label(root_path) when is_binary(root_path) do
+    name = truncate_for_prompt(Path.basename(root_path), available_name_bytes())
+    @remove_prefix <> name <> @remove_suffix
+  end
+
+  @impl true
+  @spec on_cancel(term()) :: term()
+  def on_cancel(state), do: state
+
+  @spec item(String.t()) :: Item.t()
+  defp item(root) do
+    %Item{id: root, label: Path.basename(root), description: root}
+  end
+
+  @spec available_name_bytes() :: pos_integer()
+  defp available_name_bytes do
+    @max_prompt_bytes - byte_size(@remove_prefix) - byte_size(@remove_suffix)
+  end
+
+  @spec truncate_for_prompt(String.t(), pos_integer()) :: String.t()
+  defp truncate_for_prompt(name, max_bytes) do
+    if byte_size(name) <= max_bytes do
+      name
+    else
+      do_truncate_for_prompt(name, max_bytes - byte_size(@ellipsis), "") <> @ellipsis
+    end
+  end
+
+  @spec do_truncate_for_prompt(String.t(), non_neg_integer(), String.t()) :: String.t()
+  defp do_truncate_for_prompt(_name, max_bytes, acc) when max_bytes <= 0, do: acc
+
+  defp do_truncate_for_prompt(name, max_bytes, acc) do
+    case String.next_grapheme(name) do
+      {grapheme, rest} ->
+        next = acc <> grapheme
+
+        if byte_size(next) <= max_bytes do
+          do_truncate_for_prompt(rest, max_bytes, next)
+        else
+          acc
+        end
+
+      nil ->
+        acc
+    end
+  end
+end

--- a/lib/minga_editor/ui/prompt/project_remove_confirm.ex
+++ b/lib/minga_editor/ui/prompt/project_remove_confirm.ex
@@ -1,0 +1,43 @@
+defmodule MingaEditor.UI.Prompt.ProjectRemoveConfirm do
+  @moduledoc """
+  Prompt handler for confirming removal of a known project.
+  """
+
+  @behaviour MingaEditor.UI.Prompt.Handler
+
+  alias Minga.Project
+  alias MingaEditor.State, as: EditorState
+
+  @impl true
+  @spec label() :: String.t()
+  def label, do: "Remove project? (y/n): "
+
+  @impl true
+  @spec on_submit(String.t(), EditorState.t()) :: EditorState.t()
+  def on_submit(text, state) do
+    answer = text |> String.trim() |> String.downcase()
+
+    case {answer, project_path(state)} do
+      {answer, path} when answer in ["y", "yes"] and is_binary(path) ->
+        Project.remove(path)
+        EditorState.set_status(state, "Removed project: #{path}")
+
+      {answer, _path} when answer in ["y", "yes"] ->
+        EditorState.set_status(state, "No project selected")
+
+      _ ->
+        EditorState.set_status(state, "Project removal cancelled")
+    end
+  end
+
+  @impl true
+  @spec on_cancel(EditorState.t()) :: EditorState.t()
+  def on_cancel(state), do: EditorState.set_status(state, "Project removal cancelled")
+
+  @spec project_path(EditorState.t()) :: String.t() | nil
+  defp project_path(%{shell_state: %{modal: {:prompt, %{prompt_ui: %{context: %{path: path}}}}}})
+       when is_binary(path),
+       do: path
+
+  defp project_path(_state), do: nil
+end

--- a/macos/Sources/Views/MinibufferState.swift
+++ b/macos/Sources/Views/MinibufferState.swift
@@ -29,6 +29,7 @@ enum MinibufferMode: UInt8 {
     case describeKey = 7
     case deleteConfirm = 8
     case branchDeleteConfirm = 9
+    case textPrompt = 10
 }
 
 @MainActor
@@ -54,7 +55,7 @@ final class MinibufferState {
 
     /// Whether the current mode accepts text input (shows a cursor).
     var isInputMode: Bool {
-        mode <= MinibufferMode.eval.rawValue
+        mode <= MinibufferMode.eval.rawValue || mode == MinibufferMode.textPrompt.rawValue
     }
 
     /// Whether to show a blinking cursor in the input field.
@@ -64,7 +65,7 @@ final class MinibufferState {
 
     /// Whether this is a prompt-only mode (no text input, shows action keys).
     var isPromptMode: Bool {
-        mode >= MinibufferMode.substituteConfirm.rawValue
+        mode >= MinibufferMode.substituteConfirm.rawValue && mode != MinibufferMode.textPrompt.rawValue
     }
 
     /// Whether completion candidates are present.

--- a/macos/Tests/MingaTests/MinibufferStateTests.swift
+++ b/macos/Tests/MingaTests/MinibufferStateTests.swift
@@ -1,0 +1,26 @@
+import Testing
+
+@Suite("MinibufferState Lifecycle")
+struct MinibufferStateLifecycleTests {
+    @Test("mode 10 text prompt reports input cursor and hides prompt actions")
+    @MainActor func textPromptModeShowsCursor() {
+        let state = MinibufferState()
+        state.update(
+            visible: true,
+            mode: MinibufferMode.textPrompt.rawValue,
+            cursorPos: 3,
+            prompt: "Add project: ",
+            input: "abc",
+            context: "",
+            selectedIndex: 0,
+            rawCandidates: []
+        )
+
+        #expect(state.visible == true)
+        #expect(state.mode == MinibufferMode.textPrompt.rawValue)
+        #expect(state.cursorPos == 3)
+        #expect(state.isInputMode == true)
+        #expect(state.isPromptMode == false)
+        #expect(state.showCursor == true)
+    }
+}

--- a/test/minga/frontend/adapter/gui/minibuffer_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/minibuffer_encoder_test.exs
@@ -90,6 +90,36 @@ defmodule Minga.Frontend.Adapter.GUI.MinibufferEncoderTest do
       assert annotation == "SPC f s"
     end
 
+    test "encodes text prompt mode" do
+      model = %Minibuffer{
+        visible?: true,
+        mode: :text_prompt,
+        cursor_pos: 6,
+        prompt: "Add project: ",
+        input: "~/code",
+        context: "",
+        selected_index: 0,
+        candidates: [],
+        total_candidates: 0
+      }
+
+      legacy = %MinibufferData{
+        visible: true,
+        mode: 10,
+        cursor_pos: 6,
+        prompt: "Add project: ",
+        input: "~/code",
+        context: "",
+        selected_index: 0,
+        candidates: [],
+        total_candidates: 0
+      }
+
+      {cmd, _caches} = MinibufferEncoder.encode(model, Caches.new())
+
+      assert cmd == ProtocolGUI.encode_gui_minibuffer(legacy)
+    end
+
     test "returns nil on second call with same semantic data" do
       model = %Minibuffer{}
 

--- a/test/minga_editor/commands/project_prompt_test.exs
+++ b/test/minga_editor/commands/project_prompt_test.exs
@@ -1,0 +1,172 @@
+defmodule MingaEditor.Commands.ProjectPromptTest do
+  # Mutates the global Minga.Project known-projects GenServer.
+  use Minga.Test.EditorCase, async: false
+
+  alias Minga.Project
+  alias MingaEditor.Commands
+  alias MingaEditor.MinibufferData
+  alias MingaEditor.PromptUI
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Prompt, as: PromptState
+  alias MingaEditor.UI.Prompt.ProjectRemoveConfirm
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+
+  defp temp_project_dir do
+    Path.join(
+      System.tmp_dir!(),
+      "minga-project-remove-#{System.unique_integer([:positive])}"
+    )
+  end
+
+  defp no_buffer_state do
+    %EditorState{
+      port_manager: nil,
+      workspace: %SessionState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{active: nil, list: []},
+        editing: VimState.new()
+      }
+    }
+  end
+
+  defp clear_editor_buffers(ctx) do
+    :sys.replace_state(ctx.editor, fn state ->
+      state
+      |> EditorState.set_buffers(%Buffers{active: nil, list: [], active_index: 0})
+      |> EditorState.sync_active_window_buffer()
+    end)
+
+    ctx
+  end
+
+  describe "SPC p d" do
+    setup do
+      project = temp_project_dir()
+      File.mkdir_p!(project)
+
+      on_exit(fn ->
+        Project.remove(project)
+        File.rm_rf(project)
+      end)
+
+      Project.add(project)
+      assert project in Project.known_projects()
+
+      %{project: project}
+    end
+
+    test "opens known projects picker and confirms removal", %{project: project} do
+      ctx = start_editor("")
+      state = send_keys_sync(ctx, "<SPC>pd<CR>")
+
+      assert %{
+               shell_state: %{
+                 modal:
+                   {:prompt,
+                    %{
+                      prompt_ui: %{
+                        handler: MingaEditor.UI.Prompt.ProjectRemoveConfirm,
+                        context: %{path: ^project}
+                      }
+                    }}
+               }
+             } = state
+
+      _state = send_keys_sync(ctx, "y<CR>")
+      refute project in Project.known_projects()
+    end
+
+    test "SPC p d opens the removal picker without an active buffer", %{project: project} do
+      ctx = start_editor("") |> clear_editor_buffers()
+
+      state = send_keys_sync(ctx, "<SPC>pd")
+
+      assert %{
+               shell_state: %{
+                 modal:
+                   {:picker,
+                    %{
+                      picker_ui: %{
+                        source: MingaEditor.UI.Picker.ProjectRemoveSource
+                      }
+                    }}
+               }
+             } = state
+
+      assert project in Project.known_projects()
+    end
+
+    test "project_remove command opens the removal picker without an active buffer", %{
+      project: project
+    } do
+      state = Commands.execute(no_buffer_state(), :project_remove)
+
+      assert %{
+               shell_state: %{
+                 modal:
+                   {:picker,
+                    %{
+                      picker_ui: %{
+                        source: MingaEditor.UI.Picker.ProjectRemoveSource
+                      }
+                    }}
+               }
+             } = state
+
+      assert project in Project.known_projects()
+    end
+
+    test "typing n cancels project removal and leaves the project intact", %{project: project} do
+      state =
+        no_buffer_state()
+        |> PromptUI.open(ProjectRemoveConfirm, context: %{path: project})
+
+      {state, nil} = PromptUI.handle_key(state, ?n, 0)
+      {state, nil} = PromptUI.handle_key(state, 13, 0)
+
+      assert state.shell_state.status_msg == "Project removal cancelled"
+      assert project in Project.known_projects()
+      refute PromptUI.open?(state)
+    end
+  end
+
+  describe "SPC p a" do
+    test "opens the add-project prompt from a leader sequence" do
+      ctx = start_editor("")
+
+      state = send_keys_sync(ctx, "<SPC>pa")
+
+      assert %{
+               shell_state: %{
+                 modal:
+                   {:prompt,
+                    %{prompt_ui: %PromptState{handler: MingaEditor.UI.Prompt.ProjectAdd}}}
+               }
+             } = state
+    end
+
+    test "renders the add-project prompt in the TUI minibuffer" do
+      ctx = start_editor("")
+
+      _state = send_keys_sync(ctx, "<SPC>pa")
+      sync_screen(ctx)
+
+      assert_minibuffer_contains(ctx, "Add project: ")
+    end
+
+    test "exposes the add-project prompt through GUI minibuffer data" do
+      ctx = start_editor("")
+
+      state = send_keys_sync(ctx, "<SPC>pa")
+      minibuffer = MinibufferData.from_state(state)
+
+      assert minibuffer.visible == true
+      assert minibuffer.mode == 10
+      assert minibuffer.prompt == "Add project: "
+      assert minibuffer.cursor_pos == String.length(minibuffer.input)
+    end
+  end
+end

--- a/test/minga_editor/frontend/gui_minibuffer_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_minibuffer_protocol_test.exs
@@ -96,6 +96,24 @@ defmodule MingaEditor.Frontend.GUIMinibufferProtocolTest do
                140, 2::16, "wq", 13::16, "Save and quit", 0::16, 1, 0::16>> = result
     end
 
+    test "generic text prompt mode encodes with cursor" do
+      data = %MinibufferData{
+        visible: true,
+        mode: 10,
+        cursor_pos: 6,
+        prompt: "Add project: ",
+        input: "~/code",
+        context: "",
+        selected_index: 0,
+        candidates: []
+      }
+
+      result = ProtocolGUI.encode_gui_minibuffer(data)
+
+      assert <<@op_gui_minibuffer, 1, 10, 6::16, 13, "Add project: ", 6::16, "~/code", 0::16, "",
+               0::16, 0::16, 0::16>> = result
+    end
+
     test "substitute confirm mode with no cursor" do
       data = %MinibufferData{
         visible: true,

--- a/test/minga_editor/minibuffer_data_test.exs
+++ b/test/minga_editor/minibuffer_data_test.exs
@@ -12,6 +12,7 @@ defmodule MingaEditor.MinibufferDataTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.MinibufferData
+  alias MingaEditor.State.Prompt, as: PromptState
 
   describe "clamp_index/2" do
     test "returns 0 for empty list" do
@@ -33,6 +34,35 @@ defmodule MingaEditor.MinibufferDataTest do
       assert MinibufferData.clamp_index(0, 5) == 0
       assert MinibufferData.clamp_index(2, 5) == 2
       assert MinibufferData.clamp_index(4, 5) == 4
+    end
+  end
+
+  describe "from_state/1 prompt modal" do
+    test "returns a visible text prompt for generic PromptUI overlays" do
+      state = %{
+        shell_state: %{
+          modal:
+            {:prompt,
+             %{
+               prompt_ui: %PromptState{
+                 handler: MingaEditor.UI.Prompt.ProjectAdd,
+                 label: "Add project: ",
+                 text: "~/code",
+                 cursor: 6
+               }
+             }}
+        },
+        workspace: %{editing: %{mode: :normal, mode_state: %{}}}
+      }
+
+      result = MinibufferData.from_state(state)
+
+      assert result.visible == true
+      assert result.mode == 10
+      assert result.prompt == "Add project: "
+      assert result.input == "~/code"
+      assert result.cursor_pos == 6
+      assert result.candidates == []
     end
   end
 

--- a/test/minga_editor/prompt_ui_test.exs
+++ b/test/minga_editor/prompt_ui_test.exs
@@ -259,6 +259,17 @@ defmodule MingaEditor.PromptUITest do
     end
   end
 
+  describe "render/2" do
+    test "renders prompt using current picker theme fields" do
+      state = base_state() |> PromptUI.open(TestHandler, default: "~/code")
+
+      {draws, cursor} = PromptUI.render(state, Viewport.new(24, 80))
+
+      assert length(draws) == 2
+      assert cursor == {23, String.length("Test prompt: ~/code")}
+    end
+  end
+
   describe "close/1" do
     test "clears prompt state" do
       state =

--- a/test/minga_editor/render_model/ui/minibuffer_builder_test.exs
+++ b/test/minga_editor/render_model/ui/minibuffer_builder_test.exs
@@ -47,6 +47,26 @@ defmodule MingaEditor.RenderModel.UI.MinibufferBuilderTest do
       assert [%Candidate{label: "write", annotation: "cmd"}] = model.candidates
     end
 
+    test "maps generic text prompt mode" do
+      data = %MinibufferData{
+        visible: true,
+        mode: 10,
+        cursor_pos: 6,
+        prompt: "Add project: ",
+        input: "~/code",
+        context: "",
+        selected_index: 0,
+        candidates: [],
+        total_candidates: 0
+      }
+
+      model = MinibufferBuilder.build(data)
+
+      assert %Minibuffer{visible?: true, mode: :text_prompt, cursor_pos: 6} = model
+      assert model.prompt == "Add project: "
+      assert model.input == "~/code"
+    end
+
     test "semantic model changes when input changes" do
       base = %MinibufferData{
         visible: true,

--- a/test/minga_editor/ui/picker/project_remove_source_test.exs
+++ b/test/minga_editor/ui/picker/project_remove_source_test.exs
@@ -1,0 +1,26 @@
+defmodule MingaEditor.UI.Picker.ProjectRemoveSourceTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.UI.Picker.ProjectRemoveSource
+
+  describe "confirmation_label/1" do
+    test "keeps the GUI minibuffer prompt within the protocol byte limit" do
+      long_name = String.duplicate("a", 255)
+      label = ProjectRemoveSource.confirmation_label(Path.join("/tmp", long_name))
+
+      assert byte_size(label) <= 255
+      assert String.starts_with?(label, "Remove ")
+      assert String.ends_with?(label, "? (y/n): ")
+      assert String.contains?(label, "…")
+    end
+
+    test "does not split multibyte graphemes when truncating" do
+      long_name = String.duplicate("界", 100)
+      label = ProjectRemoveSource.confirmation_label(Path.join("/tmp", long_name))
+
+      assert byte_size(label) <= 255
+      assert String.valid?(label)
+      assert String.contains?(label, "…")
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
Fixes the project prompt UX so `SPC p a` works in both TUI and macOS GUI, and changes `SPC p d` to mirror Doom-style known-project removal: pick a project, then confirm removal.

## Context
`SPC p a` was opening the generic prompt state, but the TUI prompt renderer referenced stale picker theme fields and the GUI minibuffer did not know how to render generic text prompts. `SPC p d` also removed only the currently detected project root, which made scratch buffers report "No project root detected" instead of letting the user choose a known project.

## Changes
- Fixed generic prompt rendering in the TUI by using the current picker theme fields.
- Added generic text prompt support to GUI minibuffer data, semantic render models, protocol docs, and macOS `MinibufferState` so prompts render with a cursor in the native GUI.
- Changed `SPC p d` to open a centered known-project picker, then show a `y/n` confirmation prompt before removing the selected known project.
- Made `project_remove` usable without an active buffer, so the known-project flow works from no-buffer/dashboard-style contexts.
- Added focused coverage for `SPC p a`, TUI prompt rendering, GUI minibuffer mode 10 data/protocol behavior, Swift mode 10 cursor semantics, the `SPC p d` select-and-confirm flow, no-active-buffer project removal, and cancellation safety.

## Verification
- `make lint` passed with existing struct-size Credo warnings only.
- `mix test.llm` passed before review-fix amendments.
- `mix test.llm test/minga_editor/commands/project_prompt_test.exs test/minga_editor/prompt_ui_test.exs test/minga_editor/minibuffer_data_test.exs test/minga_editor/render_model/ui/minibuffer_builder_test.exs test/minga_editor/frontend/gui_minibuffer_protocol_test.exs` passed, 86 tests.
- `mix compile --warnings-as-errors` passed.
- `mix swift.build` passed.
- `xcodebuild -quiet -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS' test -only-testing:MingaTests/MinibufferStateLifecycleTests` passed.
- `mix swift.harness` passed before review-fix amendments.

## Manual verification focus
- In the TUI, press `SPC p a` and verify the `Add project:` prompt appears and accepts text.
- In the macOS GUI, press `SPC p a` and verify the native minibuffer shows the `Add project:` prompt with a cursor.
- Press `SPC p d`, select a known project, confirm with `y`, and verify it is removed from the known-projects list.
- Press `SPC p d`, select a known project, cancel with `n`, and verify it remains in the known-projects list.
