### PR TITLE
fix(agent): align OpenAI Codex OAuth login

### DIFF
--- a/lib/minga_agent/oauth.ex
+++ b/lib/minga_agent/oauth.ex
@@ -11,8 +11,10 @@ defmodule MingaAgent.OAuth do
   @authorize_url "https://auth.openai.com/oauth/authorize"
   @token_url "https://auth.openai.com/oauth/token"
   @callback_port 1455
-  @redirect_uri "http://localhost:#{@callback_port}/callback"
-  @scopes "openid offline_access"
+  @fallback_callback_port 1457
+  @callback_path "/auth/callback"
+  @scopes "openid profile email offline_access"
+  @originator "minga"
   @oauth_filename "oauth.json"
   @provider_key "openai-codex"
 
@@ -23,6 +25,18 @@ defmodule MingaAgent.OAuth do
           refresh: String.t() | nil,
           expires: integer() | nil,
           account_id: String.t() | nil
+        }
+
+  @type openai_config :: %{
+          port: pos_integer(),
+          fallback_port: pos_integer(),
+          authorize_url: String.t(),
+          token_url: String.t(),
+          client_id: String.t(),
+          scopes: String.t(),
+          redirect_uri: String.t(),
+          callback_path: String.t(),
+          originator: String.t()
         }
 
   @doc """
@@ -45,36 +59,51 @@ defmodule MingaAgent.OAuth do
   end
 
   @doc """
-  Builds the full OpenAI authorize URL with all required query params.
+  Builds the full OpenAI authorize URL with Codex CLI-compatible query params.
   """
-  @spec openai_authorize_url(String.t(), String.t()) :: String.t()
-  def openai_authorize_url(challenge, state) do
+  @spec openai_authorize_url(String.t(), String.t(), pos_integer()) :: String.t()
+  def openai_authorize_url(challenge, state, port \\ @callback_port)
+      when is_binary(challenge) and is_binary(state) and is_integer(port) and port > 0 do
     params =
-      URI.encode_query(%{
-        "client_id" => @client_id,
-        "redirect_uri" => @redirect_uri,
-        "response_type" => "code",
-        "scope" => @scopes,
-        "state" => state,
-        "code_challenge" => challenge,
-        "code_challenge_method" => "S256"
-      })
+      URI.encode_query([
+        {"response_type", "code"},
+        {"client_id", @client_id},
+        {"redirect_uri", redirect_uri(port)},
+        {"scope", @scopes},
+        {"code_challenge", challenge},
+        {"code_challenge_method", "S256"},
+        {"id_token_add_organizations", "true"},
+        {"codex_cli_simplified_flow", "true"},
+        {"state", state},
+        {"originator", @originator}
+      ])
 
     "#{@authorize_url}?#{params}"
   end
 
   @doc """
+  Returns the local redirect URI for an OpenAI OAuth callback port.
+  """
+  @spec redirect_uri(pos_integer()) :: String.t()
+  def redirect_uri(port \\ @callback_port) when is_integer(port) and port > 0 do
+    "http://localhost:#{port}#{@callback_path}"
+  end
+
+  @doc """
   Returns the static OpenAI OAuth configuration.
   """
-  @spec openai_config() :: map()
+  @spec openai_config() :: openai_config()
   def openai_config do
     %{
       port: @callback_port,
+      fallback_port: @fallback_callback_port,
       authorize_url: @authorize_url,
       token_url: @token_url,
       client_id: @client_id,
       scopes: @scopes,
-      redirect_uri: @redirect_uri
+      redirect_uri: redirect_uri(),
+      callback_path: @callback_path,
+      originator: @originator
     }
   end
 
@@ -83,15 +112,17 @@ defmodule MingaAgent.OAuth do
 
   Returns `{:ok, token_response}` on success or `{:error, reason}` on failure.
   """
-  @spec exchange_code(String.t(), String.t()) :: {:ok, token_response()} | {:error, String.t()}
-  def exchange_code(code, verifier) do
+  @spec exchange_code(String.t(), String.t(), pos_integer()) ::
+          {:ok, token_response()} | {:error, String.t()}
+  def exchange_code(code, verifier, port \\ @callback_port)
+      when is_binary(code) and is_binary(verifier) and is_integer(port) and port > 0 do
     body =
       URI.encode_query(%{
         "grant_type" => "authorization_code",
         "code" => code,
         "code_verifier" => verifier,
         "client_id" => @client_id,
-        "redirect_uri" => @redirect_uri
+        "redirect_uri" => redirect_uri(port)
       })
 
     case Req.post(@token_url,
@@ -178,40 +209,93 @@ defmodule MingaAgent.OAuth do
   @spec provider_key() :: String.t()
   def provider_key, do: @provider_key
 
+  @doc "Extracts the ChatGPT account id from an OpenAI OAuth JWT when present."
+  @spec account_id_from_token(String.t() | nil) :: String.t() | nil
+  def account_id_from_token(nil), do: nil
+
+  def account_id_from_token(jwt) when is_binary(jwt) do
+    case decode_jwt_claims(jwt) do
+      {:ok, claims} -> account_id_from_claims(claims)
+      :error -> nil
+    end
+  end
+
   # ── Private ──────────────────────────────────────────────────────────────────
 
   defp parse_token_response(resp) do
-    expires_in = resp["expires_in"]
-
-    expires_ms =
-      if is_integer(expires_in) and expires_in > 0 do
-        System.system_time(:millisecond) + expires_in * 1000
-      end
+    access_token = resp["access_token"]
+    id_token = resp["id_token"]
 
     %{
-      access: resp["access_token"],
+      access: access_token,
       refresh: resp["refresh_token"],
-      expires: expires_ms,
-      account_id: extract_account_id(resp["access_token"])
+      expires: expires_ms(resp["expires_in"], access_token, id_token),
+      account_id: account_id_from_token(access_token) || account_id_from_token(id_token)
     }
   end
 
-  defp extract_account_id(nil), do: nil
+  defp expires_ms(expires_in, _access_token, _id_token)
+       when is_integer(expires_in) and expires_in > 0 do
+    System.system_time(:millisecond) + expires_in * 1000
+  end
 
-  defp extract_account_id(jwt) when is_binary(jwt) do
+  defp expires_ms(_expires_in, access_token, id_token) do
+    expires_at_from_token(access_token) || expires_at_from_token(id_token)
+  end
+
+  defp expires_at_from_token(nil), do: nil
+
+  defp expires_at_from_token(jwt) when is_binary(jwt) do
+    with {:ok, claims} <- decode_jwt_claims(jwt),
+         exp when is_integer(exp) and exp > 0 <- Map.get(claims, "exp") do
+      exp * 1000
+    else
+      _ -> nil
+    end
+  end
+
+  defp account_id_from_claims(claims) when is_map(claims) do
+    auth_claims = Map.get(claims, "https://api.openai.com/auth")
+
+    account_id_from_auth_claims(auth_claims) ||
+      string_field(claims, "chatgpt_account_id") ||
+      string_field(claims, "chatgpt-account-id")
+  end
+
+  defp account_id_from_auth_claims(claims) when is_map(claims) do
+    string_field(claims, "chatgpt_account_id") ||
+      string_field(claims, "chatgpt-account-id")
+  end
+
+  defp account_id_from_auth_claims(_claims), do: nil
+
+  defp string_field(map, key) when is_map(map) do
+    case Map.get(map, key) do
+      value when is_binary(value) and value != "" -> value
+      _ -> nil
+    end
+  end
+
+  defp decode_jwt_claims(jwt) when is_binary(jwt) do
     case String.split(jwt, ".") do
-      [_header, payload, _sig | _] ->
-        with {:ok, decoded} <- Base.url_decode64(payload, padding: false),
-             {:ok, claims} <- JSON.decode(decoded) do
-          claims["https://api.openai.com/auth"]["user_id"] ||
-            claims["chatgpt-account-id"] ||
-            claims["sub"]
-        else
-          _ -> nil
-        end
+      [_header, payload, _signature] -> decode_jwt_payload(payload)
+      _ -> :error
+    end
+  end
 
-      _ ->
-        nil
+  defp decode_jwt_payload(payload) do
+    with {:ok, decoded} <- decode_base64url(payload),
+         {:ok, claims} when is_map(claims) <- JSON.decode(decoded) do
+      {:ok, claims}
+    else
+      _ -> :error
+    end
+  end
+
+  defp decode_base64url(payload) do
+    case Base.url_decode64(payload, padding: false) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> Base.url_decode64(payload, padding: true)
     end
   end
 

--- a/lib/minga_agent/oauth/callback_handler.ex
+++ b/lib/minga_agent/oauth/callback_handler.ex
@@ -11,33 +11,69 @@ defmodule MingaAgent.OAuth.CallbackHandler do
   plug(:match)
   plug(:dispatch)
 
+  get "/auth/callback" do
+    handle_callback(conn)
+  end
+
   get "/callback" do
-    conn = Plug.Conn.fetch_query_params(conn)
-    code = conn.query_params["code"]
-    state = conn.query_params["state"]
-
-    has_code = is_binary(code) and code != ""
-
-    case Process.whereis(:minga_oauth_flow) do
-      pid when is_pid(pid) and has_code -> send(pid, {:oauth_callback, code, state})
-      pid when is_pid(pid) -> send(pid, {:oauth_callback_error, :missing_code})
-      nil -> :ok
-    end
-
-    if has_code do
-      conn
-      |> put_resp_content_type("text/html")
-      |> send_resp(200, success_html())
-    else
-      conn
-      |> put_resp_content_type("text/html")
-      |> send_resp(400, error_html())
-    end
+    handle_callback(conn)
   end
 
   match _ do
     send_resp(conn, 404, "")
   end
+
+  defp handle_callback(conn) do
+    conn = Plug.Conn.fetch_query_params(conn)
+    event = callback_event(conn.query_params)
+    notify_flow(event)
+
+    case event do
+      {:oauth_callback, _code, _state} ->
+        conn
+        |> put_resp_content_type("text/html")
+        |> send_resp(200, success_html())
+
+      {:oauth_callback_error, {:provider_error, message}} ->
+        conn
+        |> put_resp_content_type("text/html")
+        |> send_resp(400, error_html(message))
+
+      {:oauth_callback_error, :missing_code} ->
+        conn
+        |> put_resp_content_type("text/html")
+        |> send_resp(400, error_html("Missing authorization code. Please try again."))
+    end
+  end
+
+  defp callback_event(%{"code" => code, "state" => state}) when is_binary(code) and code != "" do
+    {:oauth_callback, code, state}
+  end
+
+  defp callback_event(%{"code" => code}) when is_binary(code) and code != "" do
+    {:oauth_callback, code, nil}
+  end
+
+  defp callback_event(%{"error" => error} = params) when is_binary(error) and error != "" do
+    description = Map.get(params, "error_description")
+    {:oauth_callback_error, {:provider_error, provider_error_message(error, description)}}
+  end
+
+  defp callback_event(_params), do: {:oauth_callback_error, :missing_code}
+
+  defp notify_flow(event) do
+    case Process.whereis(:minga_oauth_flow) do
+      pid when is_pid(pid) -> send(pid, event)
+      nil -> :ok
+    end
+  end
+
+  defp provider_error_message(error, description)
+       when is_binary(description) and description != "" do
+    "#{error}: #{description}"
+  end
+
+  defp provider_error_message(error, _description), do: error
 
   defp success_html do
     """
@@ -55,7 +91,9 @@ defmodule MingaAgent.OAuth.CallbackHandler do
     """
   end
 
-  defp error_html do
+  defp error_html(message) do
+    escaped_message = html_escape(message)
+
     """
     <!DOCTYPE html>
     <html>
@@ -63,10 +101,19 @@ defmodule MingaAgent.OAuth.CallbackHandler do
     <body style="font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;">
       <div style="text-align: center;">
         <h2>Authentication failed</h2>
-        <p>Missing authorization code. Please try again.</p>
+        <p>#{escaped_message}</p>
       </div>
     </body>
     </html>
     """
+  end
+
+  defp html_escape(text) do
+    text
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("'", "&#39;")
   end
 end

--- a/lib/minga_agent/oauth/flow.ex
+++ b/lib/minga_agent/oauth/flow.ex
@@ -29,22 +29,9 @@ defmodule MingaAgent.OAuth.Flow do
     state = generate_state()
     config = OAuth.openai_config()
 
-    with :ok <- register_flow(),
-         {:ok, bandit_pid} <- start_server(config.port) do
-      try do
-        url = OAuth.openai_authorize_url(pkce.challenge, state)
-
-        case open_browser(url) do
-          :ok ->
-            await_and_exchange(state, pkce.verifier)
-
-          {:error, _reason} ->
-            {:browser_failed, url}
-        end
-      after
-        stop_server(bandit_pid)
-        unregister_flow()
-      end
+    case register_flow() do
+      :ok -> run_registered_flow(pkce, state, config)
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -53,6 +40,30 @@ defmodule MingaAgent.OAuth.Flow do
   defp generate_state do
     :crypto.strong_rand_bytes(16)
     |> Base.url_encode64(padding: false)
+  end
+
+  defp run_registered_flow(pkce, state, config) do
+    case start_server(config.port, config.fallback_port) do
+      {:ok, bandit_pid, port} ->
+        try do
+          url = OAuth.openai_authorize_url(pkce.challenge, state, port)
+
+          case open_browser(url) do
+            :ok ->
+              await_and_exchange(state, pkce.verifier, port)
+
+            {:error, _reason} ->
+              {:browser_failed, url}
+          end
+        after
+          stop_server(bandit_pid)
+          unregister_flow()
+        end
+
+      {:error, reason} ->
+        unregister_flow()
+        {:error, reason}
+    end
   end
 
   defp register_flow do
@@ -74,7 +85,29 @@ defmodule MingaAgent.OAuth.Flow do
     ArgumentError -> :ok
   end
 
-  defp start_server(port) do
+  defp start_server(port, fallback_port) do
+    case start_server_on_port(port) do
+      {:ok, pid} -> {:ok, pid, port}
+      {:error, :eaddrinuse} -> start_fallback_server(port, fallback_port)
+      {:error, {:start_failed, reason}} -> {:error, start_failed_message(port, reason)}
+    end
+  end
+
+  defp start_fallback_server(port, fallback_port) do
+    case start_server_on_port(fallback_port) do
+      {:ok, pid} ->
+        {:ok, pid, fallback_port}
+
+      {:error, :eaddrinuse} ->
+        {:error,
+         "Ports #{port} and #{fallback_port} are already in use. Free one of those ports or use /auth with an API key instead."}
+
+      {:error, {:start_failed, reason}} ->
+        {:error, start_failed_message(fallback_port, reason)}
+    end
+  end
+
+  defp start_server_on_port(port) do
     case Bandit.start_link(
            plug: MingaAgent.OAuth.CallbackHandler,
            port: port,
@@ -85,13 +118,15 @@ defmodule MingaAgent.OAuth.Flow do
         {:ok, pid}
 
       {:error, {:shutdown, {:failed_to_start_child, :listener, {:listen, :eaddrinuse}}}} ->
-        {:error,
-         "Port #{port} is already in use. Free the port or use /auth with an API key instead."}
+        {:error, :eaddrinuse}
 
       {:error, reason} ->
-        {:error,
-         "Could not start callback server on port #{port}: #{inspect(reason)}. Free the port or use /auth with an API key instead."}
+        {:error, {:start_failed, reason}}
     end
+  end
+
+  defp start_failed_message(port, reason) do
+    "Could not start callback server on port #{port}: #{inspect(reason)}. Free the port or use /auth with an API key instead."
   end
 
   defp stop_server(pid) when is_pid(pid) do
@@ -116,16 +151,19 @@ defmodule MingaAgent.OAuth.Flow do
     e in [ErlangError] -> {:error, "Failed to open browser: #{Exception.message(e)}"}
   end
 
-  defp await_and_exchange(expected_state, verifier) do
+  defp await_and_exchange(expected_state, verifier, port) do
     receive do
       {:oauth_callback, code, state} when is_binary(code) and state == expected_state ->
-        exchange_and_persist(code, verifier)
+        exchange_and_persist(code, verifier, port)
 
       {:oauth_callback, _code, nil} ->
         {:error, "OAuth redirect was missing the state parameter. Run /login to try again."}
 
       {:oauth_callback, _code, _wrong_state} ->
         {:error, "OAuth state mismatch (possible CSRF). Run /login to try again."}
+
+      {:oauth_callback_error, {:provider_error, message}} ->
+        {:error, "Authorization failed: #{message}. Run /login to try again."}
 
       {:oauth_callback_error, :missing_code} ->
         {:error, "Authorization was denied or failed. Run /login to try again."}
@@ -136,8 +174,8 @@ defmodule MingaAgent.OAuth.Flow do
     end
   end
 
-  defp exchange_and_persist(code, verifier) do
-    with {:ok, tokens} <- OAuth.exchange_code(code, verifier),
+  defp exchange_and_persist(code, verifier, port) do
+    with {:ok, tokens} <- OAuth.exchange_code(code, verifier, port),
          :ok <- OAuth.write_oauth_file(tokens) do
       {:ok, :openai}
     end

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -2554,6 +2554,7 @@ defmodule MingaAgent.Providers.Native do
           Keyword.get(opts, :provider_options, [])
           |> Keyword.put(:auth_mode, :oauth)
           |> Keyword.put(:oauth_file, Credentials.oauth_path())
+          |> Keyword.put(:codex_originator, "minga")
 
         Keyword.put(opts, :provider_options, provider_options)
       else

--- a/test/minga_agent/oauth/callback_handler_test.exs
+++ b/test/minga_agent/oauth/callback_handler_test.exs
@@ -1,16 +1,17 @@
 defmodule MingaAgent.OAuth.CallbackHandlerTest do
+  # Uses the global registered process name :minga_oauth_flow, so tests must serialize.
   use ExUnit.Case, async: false
 
   import Plug.Test
 
   alias MingaAgent.OAuth.CallbackHandler
 
-  describe "GET /callback" do
+  describe "GET /auth/callback" do
     test "sends code and state to registered flow process" do
       Process.register(self(), :minga_oauth_flow)
 
       conn =
-        conn(:get, "/callback?code=test_code&state=test_state")
+        conn(:get, "/auth/callback?code=test_code&state=test_state")
         |> CallbackHandler.call(CallbackHandler.init([]))
 
       assert conn.status == 200
@@ -24,7 +25,7 @@ defmodule MingaAgent.OAuth.CallbackHandlerTest do
       Process.register(self(), :minga_oauth_flow)
 
       conn =
-        conn(:get, "/callback?state=test_state")
+        conn(:get, "/auth/callback?state=test_state")
         |> CallbackHandler.call(CallbackHandler.init([]))
 
       assert conn.status == 400
@@ -34,9 +35,24 @@ defmodule MingaAgent.OAuth.CallbackHandlerTest do
       safe_unregister(:minga_oauth_flow)
     end
 
+    test "sends provider error details when OpenAI redirects with an error" do
+      Process.register(self(), :minga_oauth_flow)
+
+      conn =
+        conn(:get, "/auth/callback?error=access_denied&error_description=Nope")
+        |> CallbackHandler.call(CallbackHandler.init([]))
+
+      assert conn.status == 400
+      assert conn.resp_body =~ "access_denied"
+      assert conn.resp_body =~ "Nope"
+      assert_receive {:oauth_callback_error, {:provider_error, "access_denied: Nope"}}, 1000
+    after
+      safe_unregister(:minga_oauth_flow)
+    end
+
     test "does not crash when no flow process is registered" do
       conn =
-        conn(:get, "/callback?code=orphan&state=orphan")
+        conn(:get, "/auth/callback?code=orphan&state=orphan")
         |> CallbackHandler.call(CallbackHandler.init([]))
 
       assert conn.status == 200
@@ -46,11 +62,26 @@ defmodule MingaAgent.OAuth.CallbackHandlerTest do
       Process.register(self(), :minga_oauth_flow)
 
       conn =
-        conn(:get, "/callback?code=the_code")
+        conn(:get, "/auth/callback?code=the_code")
         |> CallbackHandler.call(CallbackHandler.init([]))
 
       assert conn.status == 200
       assert_receive {:oauth_callback, "the_code", nil}, 1000
+    after
+      safe_unregister(:minga_oauth_flow)
+    end
+  end
+
+  describe "GET /callback" do
+    test "keeps the previous callback path as a compatibility alias" do
+      Process.register(self(), :minga_oauth_flow)
+
+      conn =
+        conn(:get, "/callback?code=legacy_code&state=legacy_state")
+        |> CallbackHandler.call(CallbackHandler.init([]))
+
+      assert conn.status == 200
+      assert_receive {:oauth_callback, "legacy_code", "legacy_state"}, 1000
     after
       safe_unregister(:minga_oauth_flow)
     end
@@ -81,7 +112,7 @@ defmodule MingaAgent.OAuth.CallbackHandlerTest do
       {:ok, {_ip, port}} = ThousandIsland.listener_info(pid)
 
       {:ok, resp} =
-        Req.get("http://127.0.0.1:#{port}/callback?code=http_code&state=http_state")
+        Req.get("http://127.0.0.1:#{port}/auth/callback?code=http_code&state=http_state")
 
       assert resp.status == 200
       assert resp.body =~ "Received"

--- a/test/minga_agent/oauth/flow_test.exs
+++ b/test/minga_agent/oauth/flow_test.exs
@@ -1,4 +1,5 @@
 defmodule MingaAgent.OAuth.FlowTest do
+  # Uses the global registered process name :minga_oauth_flow, so tests must serialize.
   use ExUnit.Case, async: false
 
   describe "registration" do

--- a/test/minga_agent/oauth_test.exs
+++ b/test/minga_agent/oauth_test.exs
@@ -33,8 +33,8 @@ defmodule MingaAgent.OAuthTest do
     end
   end
 
-  describe "openai_authorize_url/2" do
-    test "includes all required OAuth params" do
+  describe "openai_authorize_url/3" do
+    test "includes Codex-compatible OAuth params" do
       url = OAuth.openai_authorize_url("test_challenge", "test_state")
       uri = URI.parse(url)
       params = URI.decode_query(uri.query)
@@ -43,12 +43,30 @@ defmodule MingaAgent.OAuthTest do
       assert uri.host == "auth.openai.com"
       assert uri.path == "/oauth/authorize"
       assert params["client_id"] == "app_EMoamEEZ73f0CkXaXp7hrann"
-      assert params["redirect_uri"] == "http://localhost:1455/callback"
+      assert params["redirect_uri"] == "http://localhost:1455/auth/callback"
       assert params["response_type"] == "code"
       assert params["code_challenge"] == "test_challenge"
       assert params["code_challenge_method"] == "S256"
       assert params["state"] == "test_state"
-      assert is_binary(params["scope"])
+      assert params["id_token_add_organizations"] == "true"
+      assert params["codex_cli_simplified_flow"] == "true"
+      assert params["originator"] == "minga"
+
+      assert String.split(params["scope"], " ") == ~w(openid profile email offline_access)
+    end
+
+    test "uses the selected registered callback port" do
+      url = OAuth.openai_authorize_url("challenge", "state", 1457)
+      params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert params["redirect_uri"] == "http://localhost:1457/auth/callback"
+    end
+  end
+
+  describe "redirect_uri/1" do
+    test "returns the Codex allow-listed callback path" do
+      assert OAuth.redirect_uri() == "http://localhost:1455/auth/callback"
+      assert OAuth.redirect_uri(1457) == "http://localhost:1457/auth/callback"
     end
   end
 
@@ -56,11 +74,44 @@ defmodule MingaAgent.OAuthTest do
     test "returns expected static configuration" do
       config = OAuth.openai_config()
       assert config.port == 1455
+      assert config.fallback_port == 1457
       assert config.client_id == "app_EMoamEEZ73f0CkXaXp7hrann"
+      assert config.redirect_uri == "http://localhost:1455/auth/callback"
+      assert config.callback_path == "/auth/callback"
+      assert config.originator == "minga"
       assert is_binary(config.authorize_url)
       assert is_binary(config.token_url)
-      assert is_binary(config.redirect_uri)
       assert is_binary(config.scopes)
+    end
+  end
+
+  describe "account_id_from_token/1" do
+    test "prefers the ChatGPT account id from OpenAI auth claims" do
+      token =
+        jwt(%{
+          "https://api.openai.com/auth" => %{
+            "chatgpt_account_id" => "account_123",
+            "user_id" => "user_456"
+          },
+          "sub" => "sub_789"
+        })
+
+      assert OAuth.account_id_from_token(token) == "account_123"
+    end
+
+    test "ignores OIDC subject and user id when ChatGPT account id is absent" do
+      token =
+        jwt(%{
+          "https://api.openai.com/auth" => %{"user_id" => "user_456"},
+          "sub" => "sub_789"
+        })
+
+      assert OAuth.account_id_from_token(token) == nil
+    end
+
+    test "returns nil for malformed tokens" do
+      assert OAuth.account_id_from_token("not-a-jwt") == nil
+      assert OAuth.account_id_from_token(nil) == nil
     end
   end
 
@@ -143,5 +194,15 @@ defmodule MingaAgent.OAuthTest do
       assert :ok = OAuth.write_oauth_file(tokens, path)
       assert File.exists?(path)
     end
+  end
+
+  defp jwt(claims) do
+    header = %{"alg" => "none", "typ" => "JWT"}
+
+    Enum.map_join(
+      [header, claims, %{}],
+      ".",
+      &(&1 |> JSON.encode!() |> Base.url_encode64(padding: false))
+    )
   end
 end

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -266,7 +266,8 @@ defmodule MingaAgent.Providers.NativeTest do
         {"anthropic:claude-sonnet-4-20250514", "high", :high},
         {"openai:o4-mini", "medium", :medium},
         {"deepseek:deepseek-reasoner", "low", :low},
-        {"openai:o3-mini", "off", nil}
+        {"openai:o3-mini", "off", nil},
+        {"openai_codex:gpt-5.5", "high", :high}
       ]
 
       Enum.each(cases, fn {model, thinking_level, expected_effort} ->
@@ -297,6 +298,12 @@ defmodule MingaAgent.Providers.NativeTest do
 
         provider_options = Keyword.get(opts, :provider_options, [])
         refute Keyword.has_key?(provider_options, :additional_model_request_fields)
+
+        if String.starts_with?(model, "openai_codex:") do
+          assert provider_options[:auth_mode] == :oauth
+          assert provider_options[:oauth_file] == MingaAgent.Credentials.oauth_path()
+          assert provider_options[:codex_originator] == "minga"
+        end
 
         collect_events(500)
       end)


### PR DESCRIPTION
# TL;DR
Fixes Minga's `/login` OpenAI Codex OAuth flow by matching the current allow-listed callback path and Codex-compatible request parameters, then tagging Minga traffic with `originator=minga`.

## Context
Minga's old OpenAI OAuth URL used `http://localhost:1455/callback`, which OpenAI now rejects as an invalid authorize request. This updates the flow against the current OpenAI Codex and Pi OAuth patterns while keeping Minga-specific attribution.

## Changes
- Switch the browser OAuth redirect URI to `http://localhost:1455/auth/callback` and keep `/callback` as a compatibility alias.
- Add Codex-compatible authorize params, including `id_token_add_organizations`, `codex_cli_simplified_flow`, and `originator=minga`.
- Support the registered fallback callback port `1457` when `1455` is unavailable.
- Use the selected callback port for both the authorize URL and token exchange.
- Extract `chatgpt_account_id` from OpenAI OAuth JWT claims so `oauth.json` includes the account ID ReqLLM needs for Codex requests.
- Pass `codex_originator: "minga"` on `openai_codex:*` provider requests.
- Expand OAuth and native provider tests around callback routing, authorize params, account ID extraction, and Codex provider options.

## Verification
- `mix test.debug test/minga_agent/oauth_test.exs test/minga_agent/oauth/callback_handler_test.exs test/minga_agent/oauth/flow_test.exs`
- `mix test.debug test/minga_agent/providers/native_test.exs:264`
- `make lint`
- `mix test.llm`
- Security review: PASS with low-severity hardening notes only.
- Final reviewer targeted re-check: PASS.
