### PR TITLE
feat(keymap): align SPC p project leader menu with Doom Emacs

### DIFF
--- a/docs/PROJECTS.md
+++ b/docs/PROJECTS.md
@@ -31,13 +31,16 @@ The file is plain text, one absolute path per line. You can edit it manually if 
 
 ## Keybindings
 
-All project commands live under the `SPC p` prefix:
+All project commands live under the `SPC p` prefix. These bindings are aligned with Doom Emacs:
 
 | Binding | Command | What it does |
 |---------|---------|-------------|
-| `SPC p f` | Find file in project | Opens the file finder scoped to the current project root |
+| `SPC SPC` | Find file in project | Opens the file finder scoped to the current project root |
+| `SPC p f` | Find file in project | Same as `SPC SPC` |
 | `SPC p p` | Switch project | Shows all known projects; selecting one switches the root and opens the file finder |
-| `SPC p R` | Recent files | Shows recently opened files in the current project, most recent first |
+| `SPC p r` | Recent files | Shows recently opened files in the current project, most recent first |
+| `SPC p .` | Browse project | Opens or focuses the file tree for the current project |
+| `SPC p T` | Test project | Runs the project test command if a test runner is detected |
 | `SPC p i` | Invalidate cache | Clears the cached file list and rebuilds it from disk |
 | `SPC p a` | Add project | Adds the current project root to the known-projects list |
 | `SPC p d` | Remove project | Removes the current project root from the known-projects list |
@@ -46,7 +49,7 @@ All project commands live under the `SPC p` prefix:
 
 ## Recent files
 
-Every file you open gets recorded in a per-project recent files list. `SPC p R` shows this list with the most recently opened file at the top. Recent files are scoped per project, so switching projects shows a different list.
+Every file you open gets recorded in a per-project recent files list. `SPC p r` shows this list with the most recently opened file at the top. Recent files are scoped per project, so switching projects shows a different list.
 
 By default, recent file history is persisted to `~/.config/minga/recent-files` so it survives editor restarts. The file format is tab-separated: one `root<TAB>relative_path` per line.
 
@@ -106,10 +109,14 @@ Minga's project system covers the core projectile workflow but doesn't implement
 |---------|--------|
 | Auto-detect project root | ✅ |
 | Persist known projects | ✅ |
-| `SPC p f` (find file) | ✅ |
+| `SPC SPC` / `SPC p f` (find file) | ✅ |
 | `SPC p p` (switch project) | ✅ |
+| `SPC p r` (recent files in project) | ✅ |
+| `SPC p .` (browse project) | ✅ |
+| `SPC p T` (test project) | ✅ |
 | `SPC p i` (invalidate cache) | ✅ |
-| `SPC p !` (run command in root) | Planned (needs terminal integration) |
-| `SPC p t` (terminal in root) | Planned (needs terminal emulator) |
-| `SPC p R` (recent files in project) | ✅ |
+| `SPC p !` / `SPC p &` (run command in root) | Planned (needs terminal integration) |
+| `SPC p c` (compile project) | Planned (needs compile abstraction) |
+| `SPC p k` (kill project buffers) | Planned |
+| `SPC p s` (save project buffers) | Planned |
 | Per-project file cache | Current project only; switching rebuilds |

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -116,12 +116,15 @@ defmodule Minga.Keymap.Defaults do
     {~k(c l I), :tool_manage, "Manage tools"},
 
     # ── Project ────────────────────────────────────────────────────────────────
+    {~k(SPC), :project_find_file, "Find file in project"},
     {~k(p f), :project_find_file, "Find file in project"},
     {~k(p p), :project_switch, "Switch project"},
     {~k(p i), :project_invalidate, "Invalidate project cache"},
     {~k(p a), :project_add, "Add known project"},
     {~k(p d), :project_remove, "Remove known project"},
-    {~k(p R), :project_recent_files, "Recent files in project"},
+    {~k(p r), :project_recent_files, "Recent files in project"},
+    {~k(p .), :project_browse, "Browse project"},
+    {~k(p T), :test_all, "Test project"},
 
     # ── Open ──────────────────────────────────────────────────────────────────
     {~k(o b), :toggle_beam_observatory, "BEAM observatory"},

--- a/lib/minga/mode/normal.ex
+++ b/lib/minga/mode/normal.ex
@@ -162,10 +162,24 @@ defmodule Minga.Mode.Normal do
     {:execute, {:leader_start, state.leader_trie}, new_state}
   end
 
-  # SPC pressed while already in leader mode → cancel and restart.
-  def handle_key({@space, 0}, %ModeState{leader_node: _node} = state) do
-    new_state = %{state | leader_node: state.leader_trie, leader_keys: ["SPC"]}
-    {:execute, [:leader_cancel, {:leader_start, state.leader_trie}], new_state}
+  # SPC pressed while already in leader mode: if the current node has a
+  # space binding, execute it (enables SPC SPC); otherwise cancel and restart.
+  def handle_key({@space, 0}, %ModeState{leader_node: node} = state) when is_map(node) do
+    case Bindings.lookup(node, {@space, 0}) do
+      {:command, command} ->
+        new_state = %{state | leader_node: nil, leader_keys: []}
+        {:execute, [command, :leader_cancel], new_state}
+
+      {:prefix, sub_node} ->
+        formatted = Bindings.format_key({@space, 0})
+        new_keys = [formatted | state.leader_keys]
+        new_state = %{state | leader_node: sub_node, leader_keys: new_keys}
+        {:execute, {:leader_progress, sub_node}, new_state}
+
+      :not_found ->
+        new_state = %{state | leader_node: state.leader_trie, leader_keys: ["SPC"]}
+        {:execute, [:leader_cancel, {:leader_start, state.leader_trie}], new_state}
+    end
   end
 
   # Ctrl+D / Ctrl+U while in leader mode → paginate which-key popup.

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -90,6 +90,14 @@ defmodule MingaEditor.Commands.FileTree do
     EditorState.update_file_tree(state, fun)
   end
 
+  @spec project_browse(state()) :: state()
+  def project_browse(state) do
+    case file_tree_state(state) |> FileTreeState.status() |> FileTreeState.visible_status?() do
+      true -> focus_visible_tree(state)
+      false -> open(state)
+    end
+  end
+
   @spec open_or_toggle(state()) :: state()
   def open_or_toggle(state) do
     case file_tree_state(state) do
@@ -1466,5 +1474,10 @@ defmodule MingaEditor.Commands.FileTree do
   command(:tree_duplicate, "Duplicate file or folder in tree",
     requires_buffer: false,
     execute: &duplicate/1
+  )
+
+  command(:project_browse, "Browse project",
+    requires_buffer: false,
+    execute: &project_browse/1
   )
 end

--- a/lib/minga_editor/commands/testing.ex
+++ b/lib/minga_editor/commands/testing.ex
@@ -148,7 +148,7 @@ defmodule MingaEditor.Commands.Testing do
   end
 
   command(:test_file, "Run tests for current file", requires_buffer: true, execute: &test_file/1)
-  command(:test_all, "Run all tests", requires_buffer: true, execute: &test_all/1)
+  command(:test_all, "Run all tests", requires_buffer: false, execute: &test_all/1)
   command(:test_at_point, "Run test at cursor", requires_buffer: true, execute: &test_at_point/1)
   command(:test_rerun, "Rerun last test", requires_buffer: true, execute: &test_rerun/1)
   command(:test_output, "Show test output", requires_buffer: true, execute: &test_output/1)

--- a/test/minga/keymap/defaults_test.exs
+++ b/test/minga/keymap/defaults_test.exs
@@ -272,6 +272,17 @@ defmodule Minga.Keymap.DefaultsTest do
       assert {:command, :test_all} = Bindings.lookup(p_node, {?T, 0})
     end
 
+    test "existing project bindings still resolve to their current commands" do
+      trie = Defaults.leader_trie()
+      {:prefix, p_node} = Bindings.lookup(trie, {?p, 0})
+
+      assert {:command, :project_find_file} = Bindings.lookup(p_node, {?f, 0})
+      assert {:command, :project_switch} = Bindings.lookup(p_node, {?p, 0})
+      assert {:command, :project_add} = Bindings.lookup(p_node, {?a, 0})
+      assert {:command, :project_remove} = Bindings.lookup(p_node, {?d, 0})
+      assert {:command, :project_invalidate} = Bindings.lookup(p_node, {?i, 0})
+    end
+
     # ── Search bindings ─────────────────────────────────────────────────────────
 
     test "SPC s s → :search_buffer" do

--- a/test/minga/keymap/defaults_test.exs
+++ b/test/minga/keymap/defaults_test.exs
@@ -247,6 +247,31 @@ defmodule Minga.Keymap.DefaultsTest do
       assert duplicates == []
     end
 
+    # ── Project bindings (Doom-aligned) ──────────────────────────────────────────
+
+    test "SPC SPC → :project_find_file" do
+      trie = Defaults.leader_trie()
+      assert {:command, :project_find_file} = Bindings.lookup(trie, {32, 0})
+    end
+
+    test "SPC p r → :project_recent_files" do
+      trie = Defaults.leader_trie()
+      {:prefix, p_node} = Bindings.lookup(trie, {?p, 0})
+      assert {:command, :project_recent_files} = Bindings.lookup(p_node, {?r, 0})
+    end
+
+    test "SPC p . → :project_browse" do
+      trie = Defaults.leader_trie()
+      {:prefix, p_node} = Bindings.lookup(trie, {?p, 0})
+      assert {:command, :project_browse} = Bindings.lookup(p_node, {?., 0})
+    end
+
+    test "SPC p T → :test_all" do
+      trie = Defaults.leader_trie()
+      {:prefix, p_node} = Bindings.lookup(trie, {?p, 0})
+      assert {:command, :test_all} = Bindings.lookup(p_node, {?T, 0})
+    end
+
     # ── Search bindings ─────────────────────────────────────────────────────────
 
     test "SPC s s → :search_buffer" do
@@ -268,6 +293,13 @@ defmodule Minga.Keymap.DefaultsTest do
     end
 
     # ── Negative cases ─────────────────────────────────────────────────────────
+
+    test "SPC p R does not resolve to :project_recent_files" do
+      trie = Defaults.leader_trie()
+      {:prefix, p_node} = Bindings.lookup(trie, {?p, 0})
+      result = Bindings.lookup(p_node, {?R, 0})
+      refute match?({:command, :project_recent_files}, result)
+    end
 
     test "unknown leader prefix returns :not_found" do
       trie = Defaults.leader_trie()

--- a/test/minga/mode/normal_test.exs
+++ b/test/minga/mode/normal_test.exs
@@ -152,15 +152,10 @@ defmodule Minga.Mode.NormalTest do
   end
 
   describe "leader key sequences" do
-    test "space starts leader mode, progress advances, repeated space restarts, and invalid keys cancel" do
+    test "space starts leader mode, progress advances, and invalid keys cancel" do
       {:execute, {:leader_start, node}, leader_state} = handle({32, 0})
       assert leader_state.leader_node == node
       assert leader_state.leader_keys == ["SPC"]
-
-      {:execute, repeated_commands, repeated_state} = handle({32, 0}, leader_state)
-      assert is_list(repeated_commands)
-      assert :leader_cancel in repeated_commands
-      assert repeated_state.leader_keys == ["SPC"]
 
       case handle({?f, 0}, leader_state) do
         {:execute, {:leader_progress, sub_node}, progressed} ->
@@ -183,6 +178,28 @@ defmodule Minga.Mode.NormalTest do
         assert cancelled.leader_keys == []
         assert cancelled.count == nil
       end
+    end
+
+    test "SPC SPC executes :project_find_file" do
+      {:execute, {:leader_start, _node}, leader_state} = handle({32, 0})
+      {:execute, commands, finished_state} = handle({32, 0}, leader_state)
+      assert is_list(commands)
+      assert :project_find_file in commands
+      assert :leader_cancel in commands
+      assert finished_state.leader_node == nil
+      assert finished_state.leader_keys == []
+    end
+
+    test "repeated space restarts leader when space is not bound at the current node" do
+      {:execute, {:leader_start, _node}, leader_state} = handle({32, 0})
+      {:execute, {:leader_progress, p_node}, p_state} = handle({?p, 0}, leader_state)
+      assert p_state.leader_node == p_node
+
+      {:execute, result, restarted} = handle({32, 0}, p_state)
+      assert is_list(result)
+      assert :leader_cancel in result
+      assert restarted.leader_keys == ["SPC"]
+      assert restarted.leader_node == leader_state.leader_node
     end
 
     test "which-key pagination keeps leader state" do


### PR DESCRIPTION
## Summary

- Aligns `SPC p` project leader bindings with Doom Emacs: `SPC p r` for recent files (was `SPC p R`), `SPC SPC` for project file finding, `SPC p .` for project browsing, `SPC p T` for test-all.
- Updates normal-mode leader handling so `SPC SPC` dispatches the bound command instead of always restarting the leader sequence. Preserves restart behavior at leader nodes that don't bind space.
- Adds `:project_browse` command (opens/focuses file tree without toggling it closed) and changes `:test_all` to `requires_buffer: false`.

## Test plan

- [x] `mix test.llm test/minga/keymap/defaults_test.exs` (55 tests, 0 failures)
- [x] `mix test.llm test/minga/mode/normal_test.exs` (10 tests, 0 failures)
- [x] `mix test.llm test/minga/command/registry_test.exs` (25 tests, 0 failures)
- [x] `mix test.llm` (9073 tests, 0 failures)
- [x] `make lint` (credo clean, dialyzer clean)
- [ ] Manual: verify `SPC SPC`, `SPC p r`, `SPC p .`, `SPC p T` in GUI

Closes #2048

🤖 Generated with [Claude Code](https://claude.com/claude-code)