### PR TITLE
fix(session): bound event history by default

### DIFF
--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -123,6 +123,8 @@ defmodule Minga.Config.Options do
           | :log_level_distribution
           | :parser_tree_ttl
           | :event_retention_days
+          | :event_persist_all
+          | :event_size_cap_mb
           | :default_shell
           | :file_find_excludes
           | :picker_backdrop
@@ -372,6 +374,10 @@ defmodule Minga.Config.Options do
     {:parser_tree_ttl, :integer, 300, "Seconds to keep cached parser trees alive."},
     {:event_retention_days, :pos_integer, 90,
      "Number of days to keep persisted event log entries."},
+    {:event_persist_all, :boolean, false,
+     "Whether all event types are persisted, including high-volume buffer and mode changes."},
+    {:event_size_cap_mb, :pos_integer, 128,
+     "Hard size cap in MiB for the event database including WAL and shared-memory files."},
     {:default_shell, {:enum, [:traditional, :board]}, :traditional,
      "Shell implementation opened by default."},
     {:file_find_excludes, :string_list,

--- a/lib/minga/session/event_recorder.ex
+++ b/lib/minga/session/event_recorder.ex
@@ -252,6 +252,21 @@ defmodule Minga.Session.EventRecorder do
     end
   end
 
+  def handle_info(:deferred_vacuum, state) do
+    case Store.vacuum(state.db) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Minga.Log.warning(
+          :editor,
+          "[EventRecorder] VACUUM failed: #{inspect(reason)}"
+        )
+    end
+
+    {:noreply, state}
+  end
+
   def handle_info(_msg, state) do
     {:noreply, state}
   end
@@ -302,21 +317,29 @@ defmodule Minga.Session.EventRecorder do
 
   @spec enforce_size_cap(State.t(), non_neg_integer()) :: :ok
   defp enforce_size_cap(state, total) do
-    target = trunc(state.size_cap_bytes * 0.75)
+    target = div(state.size_cap_bytes * 3, 4)
 
-    with {:ok, row_count} <- Store.count(state.db),
-         keep = max(div(row_count * target, total), 100),
-         {:ok, deleted} <- Store.delete_oldest(state.db, keep) do
-      if deleted > 0 do
-        Minga.Log.info(
-          :editor,
-          "[EventRecorder] size cap pruned #{deleted} events (#{format_mb(total)} -> target #{format_mb(target)})"
-        )
+    with {:ok, row_count} <- Store.count(state.db) do
+      keep = max(div(row_count * target, total), 100)
 
-        Store.vacuum(state.db)
+      case Store.delete_oldest(state.db, keep) do
+        {:ok, deleted} when deleted > 0 ->
+          Minga.Log.info(
+            :editor,
+            "[EventRecorder] size cap pruned #{deleted} events (#{format_mb(total)} -> target #{format_mb(target)})"
+          )
+
+          send(self(), :deferred_vacuum)
+
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Minga.Log.warning(
+            :editor,
+            "[EventRecorder] size cap enforcement failed: #{inspect(reason)}"
+          )
       end
-
-      :ok
     else
       {:error, reason} ->
         Minga.Log.warning(

--- a/lib/minga/session/event_recorder.ex
+++ b/lib/minga/session/event_recorder.ex
@@ -310,37 +310,37 @@ defmodule Minga.Session.EventRecorder do
 
     if total > state.size_cap_bytes do
       enforce_size_cap(state, total)
-    else
-      :ok
+      send(self(), :deferred_vacuum)
     end
+
+    :ok
   end
 
   @spec enforce_size_cap(State.t(), non_neg_integer()) :: :ok
   defp enforce_size_cap(state, total) do
     target = div(state.size_cap_bytes * 3, 4)
 
-    with {:ok, row_count} <- Store.count(state.db) do
-      keep = max(div(row_count * target, total), 100)
+    case Store.count(state.db) do
+      {:ok, row_count} ->
+        keep = max(div(row_count * target, total), 100)
 
-      case Store.delete_oldest(state.db, keep) do
-        {:ok, deleted} when deleted > 0 ->
-          Minga.Log.info(
-            :editor,
-            "[EventRecorder] size cap pruned #{deleted} events (#{format_mb(total)} -> target #{format_mb(target)})"
-          )
+        case Store.delete_oldest(state.db, keep) do
+          {:ok, deleted} when deleted > 0 ->
+            Minga.Log.info(
+              :editor,
+              "[EventRecorder] size cap pruned #{deleted} events (#{format_mb(total)} -> target #{format_mb(target)})"
+            )
 
-          send(self(), :deferred_vacuum)
+          {:ok, _} ->
+            :ok
 
-        {:ok, _} ->
-          :ok
+          {:error, reason} ->
+            Minga.Log.warning(
+              :editor,
+              "[EventRecorder] size cap enforcement failed: #{inspect(reason)}"
+            )
+        end
 
-        {:error, reason} ->
-          Minga.Log.warning(
-            :editor,
-            "[EventRecorder] size cap enforcement failed: #{inspect(reason)}"
-          )
-      end
-    else
       {:error, reason} ->
         Minga.Log.warning(
           :editor,

--- a/lib/minga/session/event_recorder.ex
+++ b/lib/minga/session/event_recorder.ex
@@ -2,10 +2,15 @@ defmodule Minga.Session.EventRecorder do
   @moduledoc """
   Persistent event recorder for the editor's event stream.
 
-  Subscribes to `Minga.Events` topics and writes every event to an
+  Subscribes to `Minga.Events` topics and writes selected events to an
   append-only SQLite database via exqlite. The recorder is a write-only
   GenServer: it receives events via cast (never blocking the broadcaster)
   and writes them to the database synchronously within its own process.
+
+  By default only low-volume lifecycle events are persisted (see
+  `@default_persisted_topics`). High-volume events like `:buffer_changed`
+  and `:mode_changed` are still broadcast normally but not written to
+  SQLite. Set `:event_persist_all` to persist everything for diagnostics.
 
   Downstream features query the database through `Minga.Session.EventRecorder.Store`
   using separate read connections, which WAL mode supports without blocking
@@ -14,9 +19,10 @@ defmodule Minga.Session.EventRecorder do
   ## Retention
 
   A periodic sweep deletes events older than the configured retention
-  window (`:event_retention_days`). The first sweep runs a few seconds
-  after boot so even short-lived CLI invocations get a chance to prune;
-  subsequent sweeps run once per hour.
+  window (`:event_retention_days`) and enforces the `:event_size_cap_mb`
+  hard size limit. The first sweep runs a few seconds after boot so even
+  short-lived CLI invocations get a chance to prune; subsequent sweeps
+  run once per hour.
 
   ## Startup and health checks
 
@@ -59,18 +65,29 @@ defmodule Minga.Session.EventRecorder do
     :command_done
   ]
 
+  @default_persisted_topics [
+    :buffer_saved,
+    :buffer_opened,
+    :buffer_closed,
+    :git_status_changed,
+    :project_rebuilt,
+    :command_done
+  ]
+
   # ── State ─────────────────────────────────────────────────────────────
 
   defmodule State do
     @moduledoc false
     @enforce_keys [:db, :path]
-    defstruct [:db, :path, :retention_days, :sweep_ref]
+    defstruct [:db, :path, :retention_days, :sweep_ref, persist_all: false, size_cap_bytes: 0]
 
     @type t :: %__MODULE__{
             db: Exqlite.Sqlite3.db(),
             path: String.t(),
             retention_days: pos_integer(),
-            sweep_ref: reference() | nil
+            sweep_ref: reference() | nil,
+            persist_all: boolean(),
+            size_cap_bytes: non_neg_integer()
           }
   end
 
@@ -123,6 +140,16 @@ defmodule Minga.Session.EventRecorder do
         Minga.Config.get(:event_retention_days)
       end)
 
+    persist_all =
+      Keyword.get_lazy(opts, :persist_all, fn ->
+        Minga.Config.get(:event_persist_all)
+      end)
+
+    size_cap_mb =
+      Keyword.get_lazy(opts, :size_cap_mb, fn ->
+        Minga.Config.get(:event_size_cap_mb)
+      end)
+
     path = Path.join(db_dir, @db_filename)
 
     case open_or_recreate(path) do
@@ -138,7 +165,9 @@ defmodule Minga.Session.EventRecorder do
            db: db,
            path: path,
            retention_days: retention_days,
-           sweep_ref: sweep_ref
+           sweep_ref: sweep_ref,
+           persist_all: persist_all,
+           size_cap_bytes: size_cap_mb * 1_048_576
          }}
 
       {:error, reason} ->
@@ -149,38 +178,27 @@ defmodule Minga.Session.EventRecorder do
 
   @impl true
   def handle_info({:minga_event, topic, payload}, state) do
-    record = build_record(topic, payload)
+    if persist_event?(topic, state) do
+      record = build_record(topic, payload)
 
-    case Store.insert(state.db, record) do
-      :ok ->
-        :ok
+      case Store.insert(state.db, record) do
+        :ok ->
+          :ok
 
-      {:error, reason} ->
-        Minga.Log.warning(
-          :editor,
-          "[EventRecorder] failed to write event: #{inspect(reason)}"
-        )
+        {:error, reason} ->
+          Minga.Log.warning(
+            :editor,
+            "[EventRecorder] failed to write event: #{inspect(reason)}"
+          )
+      end
     end
 
     {:noreply, state}
   end
 
   def handle_info(:retention_sweep, state) do
-    cutoff = DateTime.add(DateTime.utc_now(), -state.retention_days, :day)
-
-    case Store.delete_before(state.db, cutoff) do
-      {:ok, 0} ->
-        :ok
-
-      {:ok, count} ->
-        Minga.Log.info(:editor, "[EventRecorder] retention sweep deleted #{count} events")
-
-      {:error, reason} ->
-        Minga.Log.warning(
-          :editor,
-          "[EventRecorder] retention sweep failed: #{inspect(reason)}"
-        )
-    end
+    run_time_retention(state)
+    run_size_cap_enforcement(state)
 
     sweep_ref = schedule_retention_sweep()
     {:noreply, %{state | sweep_ref: sweep_ref}}
@@ -245,6 +263,71 @@ defmodule Minga.Session.EventRecorder do
   end
 
   # ── Private helpers ───────────────────────────────────────────────────
+
+  @spec persist_event?(Events.topic(), State.t()) :: boolean()
+  defp persist_event?(_topic, %State{persist_all: true}), do: true
+  defp persist_event?(topic, _state), do: topic in @default_persisted_topics
+
+  @spec run_time_retention(State.t()) :: :ok
+  defp run_time_retention(state) do
+    cutoff = DateTime.add(DateTime.utc_now(), -state.retention_days, :day)
+
+    case Store.delete_before(state.db, cutoff) do
+      {:ok, 0} ->
+        :ok
+
+      {:ok, count} ->
+        Minga.Log.info(:editor, "[EventRecorder] retention sweep deleted #{count} events")
+
+      {:error, reason} ->
+        Minga.Log.warning(
+          :editor,
+          "[EventRecorder] retention sweep failed: #{inspect(reason)}"
+        )
+    end
+  end
+
+  @spec run_size_cap_enforcement(State.t()) :: :ok
+  defp run_size_cap_enforcement(%State{size_cap_bytes: 0}), do: :ok
+
+  defp run_size_cap_enforcement(state) do
+    total = Store.total_file_size(state.path)
+
+    if total > state.size_cap_bytes do
+      enforce_size_cap(state, total)
+    else
+      :ok
+    end
+  end
+
+  @spec enforce_size_cap(State.t(), non_neg_integer()) :: :ok
+  defp enforce_size_cap(state, total) do
+    target = trunc(state.size_cap_bytes * 0.75)
+
+    with {:ok, row_count} <- Store.count(state.db),
+         keep = max(div(row_count * target, total), 100),
+         {:ok, deleted} <- Store.delete_oldest(state.db, keep) do
+      if deleted > 0 do
+        Minga.Log.info(
+          :editor,
+          "[EventRecorder] size cap pruned #{deleted} events (#{format_mb(total)} -> target #{format_mb(target)})"
+        )
+
+        Store.vacuum(state.db)
+      end
+
+      :ok
+    else
+      {:error, reason} ->
+        Minga.Log.warning(
+          :editor,
+          "[EventRecorder] size cap enforcement failed: #{inspect(reason)}"
+        )
+    end
+  end
+
+  @spec format_mb(non_neg_integer()) :: String.t()
+  defp format_mb(bytes), do: "#{Float.round(bytes / 1_048_576, 1)} MiB"
 
   @spec subscribe_to_events() :: :ok
   defp subscribe_to_events do

--- a/lib/minga/session/event_recorder/store.ex
+++ b/lib/minga/session/event_recorder/store.ex
@@ -507,7 +507,13 @@ defmodule Minga.Session.EventRecorder.Store do
          :ok <- Exqlite.Sqlite3.release(db, stmt) do
       count
     else
-      _ -> 0
+      error ->
+        Minga.Log.warning(
+          :editor,
+          "[EventRecorder.Store] SELECT changes() failed: #{inspect(error)}"
+        )
+
+        0
     end
   end
 

--- a/lib/minga/session/event_recorder/store.ex
+++ b/lib/minga/session/event_recorder/store.ex
@@ -258,6 +258,55 @@ defmodule Minga.Session.EventRecorder.Store do
   end
 
   @doc """
+  Deletes all but the newest `keep` events.
+
+  Returns the number of deleted rows.
+  """
+  @spec delete_oldest(db(), non_neg_integer()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def delete_oldest(db, keep) when is_integer(keep) and keep >= 0 do
+    sql = """
+    DELETE FROM events WHERE id NOT IN (
+      SELECT id FROM events ORDER BY wall_clock DESC, id DESC LIMIT ?1
+    )
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [keep]),
+         :done <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      {:ok, changes(db)}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Returns the total file size of the database and its WAL/SHM companions.
+  """
+  @spec total_file_size(String.t()) :: non_neg_integer()
+  def total_file_size(db_path) do
+    [db_path, db_path <> "-wal", db_path <> "-shm"]
+    |> Enum.map(&file_size/1)
+    |> Enum.sum()
+  end
+
+  @spec file_size(String.t()) :: non_neg_integer()
+  defp file_size(path) do
+    case File.stat(path) do
+      {:ok, %{size: size}} -> size
+      {:error, _} -> 0
+    end
+  end
+
+  @doc """
+  Runs VACUUM to reclaim disk space after large deletes.
+  """
+  @spec vacuum(db()) :: :ok | {:error, term()}
+  def vacuum(db) do
+    execute(db, "VACUUM")
+  end
+
+  @doc """
   Runs an integrity check and returns the result.
 
   `mode` selects the SQLite pragma:

--- a/lib/minga/session/event_recorder/store.ex
+++ b/lib/minga/session/event_recorder/store.ex
@@ -299,11 +299,15 @@ defmodule Minga.Session.EventRecorder.Store do
   end
 
   @doc """
-  Runs VACUUM to reclaim disk space after large deletes.
+  Runs VACUUM to reclaim disk space after large deletes, then
+  truncates the WAL file so `total_file_size/1` reflects the
+  compacted size.
   """
   @spec vacuum(db()) :: :ok | {:error, term()}
   def vacuum(db) do
-    execute(db, "VACUUM")
+    with :ok <- execute(db, "VACUUM") do
+      execute(db, "PRAGMA wal_checkpoint(TRUNCATE)")
+    end
   end
 
   @doc """

--- a/test/minga/session/event_recorder/store_test.exs
+++ b/test/minga/session/event_recorder/store_test.exs
@@ -201,6 +201,56 @@ defmodule Minga.Session.EventRecorder.StoreTest do
     end
   end
 
+  describe "delete_oldest/2" do
+    test "keeps only the newest events", %{db: db} do
+      for i <- 1..10 do
+        t = DateTime.add(~U[2025-01-01 00:00:00Z], i, :hour)
+        :ok = Store.insert(db, make_record(%{wall_clock: t, payload: %{"n" => i}}))
+      end
+
+      {:ok, deleted} = Store.delete_oldest(db, 3)
+      assert deleted == 7
+
+      {:ok, remaining} = Store.count(db)
+      assert remaining == 3
+    end
+
+    test "returns 0 when keep exceeds row count", %{db: db} do
+      :ok = Store.insert(db, make_record())
+      {:ok, deleted} = Store.delete_oldest(db, 100)
+      assert deleted == 0
+    end
+  end
+
+  describe "total_file_size/1" do
+    test "returns the combined size of db, wal, and shm files" do
+      path = Path.join(System.tmp_dir!(), "store_size_#{:erlang.unique_integer([:positive])}.db")
+      on_exit(fn -> Enum.each([path, path <> "-wal", path <> "-shm"], &File.rm/1) end)
+
+      {:ok, db} = Store.open(path)
+      :ok = Store.insert(db, make_record())
+      Store.close(db)
+
+      size = Store.total_file_size(path)
+      assert size > 0
+    end
+
+    test "returns 0 for nonexistent files" do
+      assert Store.total_file_size("/tmp/nonexistent_db_#{:rand.uniform(999_999)}.db") == 0
+    end
+  end
+
+  describe "vacuum/1" do
+    test "reclaims space after deletes", %{db: db} do
+      # In-memory DB: vacuum succeeds but size isn't measurable on disk
+      for _ <- 1..50, do: :ok = Store.insert(db, make_record())
+      {:ok, _} = Store.delete_oldest(db, 5)
+      assert :ok = Store.vacuum(db)
+      {:ok, count} = Store.count(db)
+      assert count == 5
+    end
+  end
+
   describe "integrity_check/2" do
     test "reports healthy for a valid database (full)", %{db: db} do
       assert {:ok, :healthy} = Store.integrity_check(db)

--- a/test/minga/session/event_recorder_test.exs
+++ b/test/minga/session/event_recorder_test.exs
@@ -69,7 +69,7 @@ defmodule Minga.Session.EventRecorderTest do
       assert event.payload["path"] == "/tmp/opened.ex"
     end
 
-    test "records mode_changed events with old/new in payload", %{
+    test "does not persist mode_changed events by default", %{
       recorder: recorder,
       db_dir: db_dir
     } do
@@ -81,14 +81,13 @@ defmodule Minga.Session.EventRecorderTest do
       wait_for_processing(recorder)
 
       db = open_db(db_dir)
-      {:ok, [event]} = Store.events_by_type(db, :mode_changed)
+      {:ok, events} = Store.events_by_type(db, :mode_changed)
       Store.close(db)
 
-      assert event.payload["old"] == "normal"
-      assert event.payload["new"] == "insert"
+      assert events == []
     end
 
-    test "records buffer_changed events with source identity", %{
+    test "does not persist buffer_changed events by default", %{
       recorder: recorder,
       db_dir: db_dir
     } do
@@ -101,10 +100,10 @@ defmodule Minga.Session.EventRecorderTest do
       wait_for_processing(recorder)
 
       db = open_db(db_dir)
-      {:ok, [event]} = Store.events_by_type(db, :buffer_changed)
+      {:ok, events} = Store.events_by_type(db, :buffer_changed)
       Store.close(db)
 
-      assert event.source == "user"
+      assert events == []
     end
 
     test "records command_done events with command and exit code", %{
@@ -152,7 +151,7 @@ defmodule Minga.Session.EventRecorderTest do
       assert event.payload["branch"] == "main"
     end
 
-    test "records multiple events in chronological order", %{
+    test "records multiple whitelisted events in chronological order", %{
       recorder: recorder,
       db_dir: db_dir
     } do
@@ -163,7 +162,7 @@ defmodule Minga.Session.EventRecorderTest do
 
       send(
         recorder,
-        {:minga_event, :mode_changed, %Events.ModeEvent{old: :normal, new: :insert}}
+        {:minga_event, :buffer_opened, %Events.BufferEvent{buffer: self(), path: "/tmp/b.ex"}}
       )
 
       send(
@@ -372,6 +371,174 @@ defmodule Minga.Session.EventRecorderTest do
       paths = Enum.map(events, & &1.payload["path"])
       assert "/tmp/before.ex" in paths
       assert "/tmp/after.ex" in paths
+    end
+  end
+
+  describe "persist_all opt-in" do
+    test "persists buffer_changed when persist_all is true" do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "minga_persist_all_#{:erlang.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      unique = :erlang.unique_integer([:positive])
+
+      recorder =
+        start_supervised!(
+          Supervisor.child_spec(
+            {EventRecorder,
+             name: :"recorder_persist_#{unique}",
+             db_dir: tmp_dir,
+             subscribe: false,
+             persist_all: true},
+            id: :"recorder_persist_#{unique}"
+          )
+        )
+
+      send(
+        recorder,
+        {:minga_event, :buffer_changed,
+         %Events.BufferChangedEvent{buffer: self(), source: Minga.Buffer.EditSource.user()}}
+      )
+
+      wait_for_processing(recorder)
+
+      db = open_db(tmp_dir)
+      {:ok, [event]} = Store.events_by_type(db, :buffer_changed)
+      Store.close(db)
+
+      assert event.source == "user"
+    end
+
+    test "persists mode_changed when persist_all is true" do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "minga_persist_mode_#{:erlang.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      unique = :erlang.unique_integer([:positive])
+
+      recorder =
+        start_supervised!(
+          Supervisor.child_spec(
+            {EventRecorder,
+             name: :"recorder_mode_#{unique}",
+             db_dir: tmp_dir,
+             subscribe: false,
+             persist_all: true},
+            id: :"recorder_mode_#{unique}"
+          )
+        )
+
+      send(
+        recorder,
+        {:minga_event, :mode_changed, %Events.ModeEvent{old: :normal, new: :insert}}
+      )
+
+      wait_for_processing(recorder)
+
+      db = open_db(tmp_dir)
+      {:ok, [event]} = Store.events_by_type(db, :mode_changed)
+      Store.close(db)
+
+      assert event.payload["old"] == "normal"
+      assert event.payload["new"] == "insert"
+    end
+  end
+
+  describe "size cap enforcement" do
+    test "does not prune when database is under the configured cap" do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "minga_cap_#{:erlang.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      unique = :erlang.unique_integer([:positive])
+
+      recorder =
+        start_supervised!(
+          Supervisor.child_spec(
+            {EventRecorder,
+             name: :"recorder_cap_#{unique}",
+             db_dir: tmp_dir,
+             subscribe: false,
+             retention_days: 90,
+             size_cap_mb: 128,
+             initial_sweep_delay_ms: :timer.hours(1)},
+            id: :"recorder_cap_#{unique}"
+          )
+        )
+
+      for i <- 1..200 do
+        send(
+          recorder,
+          {:minga_event, :buffer_saved,
+           %Events.BufferEvent{buffer: self(), path: "/tmp/file_#{i}.ex"}}
+        )
+      end
+
+      wait_for_processing(recorder)
+
+      db = open_db(tmp_dir)
+      {:ok, count_before} = Store.count(db)
+      Store.close(db)
+
+      assert count_before == 200
+
+      send(recorder, :retention_sweep)
+      wait_for_processing(recorder)
+
+      db2 = open_db(tmp_dir)
+      {:ok, count_after} = Store.count(db2)
+      Store.close(db2)
+
+      assert count_after == 200
+    end
+
+    test "prunes oldest events and vacuums when over cap" do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "minga_capforce_#{:erlang.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      db_path = EventRecorder.db_path(db_dir: tmp_dir)
+      {:ok, db} = Store.open(db_path)
+
+      for i <- 1..500 do
+        record = %Minga.Session.EventRecorder.EventRecord{
+          timestamp: i,
+          wall_clock: DateTime.add(~U[2025-01-01 00:00:00Z], i, :second),
+          source: "user",
+          scope: :global,
+          event_type: :buffer_saved,
+          payload: %{"path" => "/tmp/file_#{i}.ex", "data" => String.duplicate("x", 200)}
+        }
+
+        :ok = Store.insert(db, record)
+      end
+
+      Store.close(db)
+
+      total_before = Store.total_file_size(db_path)
+
+      {:ok, db2} = Store.open(db_path)
+      {:ok, 500} = Store.count(db2)
+
+      {:ok, deleted} = Store.delete_oldest(db2, 100)
+      assert deleted == 400
+
+      {:ok, remaining} = Store.count(db2)
+      assert remaining == 100
+
+      :ok = Store.vacuum(db2)
+      Store.close(db2)
+
+      total_after = Store.total_file_size(db_path)
+      assert total_after < total_before
     end
   end
 


### PR DESCRIPTION
## Summary

- EventRecorder now persists only low-volume lifecycle events by default, excluding `buffer_changed` (88% of rows) and `mode_changed` (10%) from SQLite
- Added `event_persist_all` config option to re-enable full recording for diagnostics
- Added `event_size_cap_mb` config option (default 128 MiB) with automatic pruning and VACUUM enforcement across `.db`, `-wal`, and `-shm` files
- All events are still broadcast normally via `Minga.Events`; only persistence is filtered

Closes #2022

## Test plan

- [x] Default row suppression: `buffer_changed` and `mode_changed` events produce zero rows
- [x] Opt-in raw persistence: `persist_all: true` persists all event types including buffer/mode changes
- [x] Size cap enforcement: `Store.delete_oldest/2` + `Store.vacuum/1` prune and compact oversized databases
- [x] Lifecycle events (buffer_saved, buffer_opened, buffer_closed, git_status_changed, project_rebuilt, command_done) still persisted by default
- [x] `make lint` passes, `mix test.llm` passes (9090 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)