### PR TITLE
Tab bar context menu (right-click on tabs)

### DIFF
--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -60,6 +60,8 @@ defmodule Minga.Keymap.Defaults do
     {~k(b n), :buffer_next, "Next buffer"},
     {~k(b p), :buffer_prev, "Previous buffer"},
     {~k(b d), :kill_buffer, "Kill buffer"},
+    {~k(b D), :kill_other_buffers, "Close other tabs"},
+    {~k(b K), :kill_all_buffers, "Close all tabs"},
     {~k(b m), :view_messages, "View messages"},
     {~k(b W), :view_warnings, "View warnings"},
     {~k(b N), :new_buffer, "New buffer"},

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -1830,7 +1830,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp close_all_file_tabs(%{shell_state: %{tab_bar: %TabBar{}}} = state) do
     state
     |> close_other_tabs()
-    |> execute(:quit)
+    |> execute(:kill_buffer)
   end
 
   defp close_all_file_tabs(state), do: state

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -109,6 +109,9 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   def execute(state, :force_quit), do: close_tab_or_quit(state)
   def execute(state, :close_other_tabs), do: close_other_tabs(state)
+  def execute(state, :kill_other_buffers), do: close_other_tabs(state)
+  def execute(state, :close_tabs_to_right), do: close_tabs_to_right(state)
+  def execute(state, :kill_all_buffers), do: close_all_file_tabs(state)
   def execute(state, :quit_all), do: maybe_confirm_quit(state, :quit_all)
   def execute(state, :force_quit_all), do: shutdown_editor(state)
   def execute(state, :abort_quit), do: abort_quit_editor(state)
@@ -1800,6 +1803,49 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   defp close_other_tabs(state), do: state
 
+  @spec close_tabs_to_right(state()) :: state()
+  defp close_tabs_to_right(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+    visible = TabBar.visible_file_tabs(tb)
+
+    case Enum.find_index(visible, &(&1.id == tb.active_id)) do
+      nil ->
+        state
+
+      idx ->
+        right_tabs = Enum.drop(visible, idx + 1)
+
+        if right_tabs == [] do
+          EditorState.set_status(state, "No tabs to the right")
+        else
+          tb = remove_tabs(tb, right_tabs)
+          MingaEditor.log_to_messages("Closed tabs to the right")
+          EditorState.set_tab_bar(state, tb)
+        end
+    end
+  end
+
+  defp close_tabs_to_right(state), do: state
+
+  @spec close_all_file_tabs(state()) :: state()
+  defp close_all_file_tabs(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+    active_id = tb.active_id
+    file_tabs = TabBar.visible_file_tabs(tb)
+    others = Enum.reject(file_tabs, &(&1.id == active_id))
+
+    case others do
+      [] ->
+        state
+
+      _ ->
+        tb = remove_tabs(tb, others)
+        MingaEditor.log_to_messages("Closed all tabs")
+        state = EditorState.set_tab_bar(state, tb)
+        execute(state, :force_quit)
+    end
+  end
+
+  defp close_all_file_tabs(state), do: state
+
   @spec remove_tabs(TabBar.t(), [Tab.t()]) :: TabBar.t()
   defp remove_tabs(tb, tabs) do
     Enum.reduce(tabs, tb, fn tab, acc ->
@@ -2301,6 +2347,13 @@ defmodule MingaEditor.Commands.BufferManagement do
   command(:quit, "Close tab or quit", requires_buffer: true)
   command(:force_quit, "Force close tab or quit", requires_buffer: true)
   command(:close_other_tabs, "Close all tabs except the active tab", requires_buffer: true)
+  command(:kill_other_buffers, "Close all tabs except the active tab", requires_buffer: true)
+
+  command(:close_tabs_to_right, "Close all tabs to the right of the active tab",
+    requires_buffer: true
+  )
+
+  command(:kill_all_buffers, "Close all file tabs", requires_buffer: true)
   command(:quit_all, "Quit the editor (all tabs)", requires_buffer: true)
   command(:force_quit_all, "Force quit the editor (all tabs)", requires_buffer: true)
   command(:abort_quit, "Abort and quit with error exit code", requires_buffer: false)

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -1809,7 +1809,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
     case Enum.find_index(visible, &(&1.id == tb.active_id)) do
       nil ->
-        state
+        EditorState.set_status(state, "Active tab not found in visible tabs")
 
       idx ->
         right_tabs = Enum.drop(visible, idx + 1)
@@ -1827,21 +1827,10 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp close_tabs_to_right(state), do: state
 
   @spec close_all_file_tabs(state()) :: state()
-  defp close_all_file_tabs(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
-    active_id = tb.active_id
-    file_tabs = TabBar.visible_file_tabs(tb)
-    others = Enum.reject(file_tabs, &(&1.id == active_id))
-
-    case others do
-      [] ->
-        state
-
-      _ ->
-        tb = remove_tabs(tb, others)
-        MingaEditor.log_to_messages("Closed all tabs")
-        state = EditorState.set_tab_bar(state, tb)
-        execute(state, :force_quit)
-    end
+  defp close_all_file_tabs(%{shell_state: %{tab_bar: %TabBar{}}} = state) do
+    state
+    |> close_other_tabs()
+    |> execute(:quit)
   end
 
   defp close_all_file_tabs(state), do: state

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -609,32 +609,77 @@ struct TabBarView: View {
         .accessibilityValue(tabAccessibilityValue(tab))
         .help(tab.label)
         .contextMenu {
-            Button(tab.isPinned ? "Unpin Tab" : "Pin Tab") {
-                performTabContextMenuAction(tab.isPinned ? .unpin : .pin, for: tab)
+            tabContextMenu(for: tab)
+        }
+    }
+
+    // MARK: - Tab context menu
+
+    @ViewBuilder
+    private func tabContextMenu(for tab: TabEntry) -> some View {
+        if tab.isAgent {
+            agentTabContextMenu(for: tab)
+        } else {
+            fileTabContextMenu(for: tab)
+        }
+    }
+
+    @ViewBuilder
+    private func agentTabContextMenu(for tab: TabEntry) -> some View {
+        Button("Close") {
+            encoder?.sendCloseTab(id: tab.id)
+        }
+        Button("Close Others") {
+            encoder?.sendSelectTab(id: tab.id)
+            encoder?.sendExecuteCommand(name: "close_other_tabs")
+        }
+        Button("Close All") {
+            encoder?.sendSelectTab(id: tab.id)
+            encoder?.sendExecuteCommand(name: "kill_all_buffers")
+        }
+    }
+
+    @ViewBuilder
+    private func fileTabContextMenu(for tab: TabEntry) -> some View {
+        Button("Close") {
+            encoder?.sendCloseTab(id: tab.id)
+        }
+        Button("Close Others") {
+            encoder?.sendSelectTab(id: tab.id)
+            encoder?.sendExecuteCommand(name: "close_other_tabs")
+        }
+        Button("Close All") {
+            encoder?.sendSelectTab(id: tab.id)
+            encoder?.sendExecuteCommand(name: "kill_all_buffers")
+        }
+        Button("Close to the Right") {
+            encoder?.sendSelectTab(id: tab.id)
+            encoder?.sendExecuteCommand(name: "close_tabs_to_right")
+        }
+
+        Divider()
+
+        Button("Copy Path") {
+            encoder?.sendTabCopyPath(id: tab.id)
+        }
+
+        Divider()
+
+        Button("Reveal in File Tree") {
+            encoder?.sendSelectTab(id: tab.id)
+            encoder?.sendExecuteCommand(name: "tree_reveal_active")
+        }
+
+        Divider()
+
+        Button(tab.isPinned ? "Unpin Tab" : "Pin Tab") {
+            performTabContextMenuAction(tab.isPinned ? .unpin : .pin, for: tab)
+        }
+        ForEach(tabContextMenuMoveItems(for: tab)) { item in
+            Button(item.title) {
+                performTabContextMenuAction(item.id, for: tab)
             }
-            Divider()
-            ForEach(tabContextMenuMoveItems(for: tab)) { item in
-                Button(item.title) {
-                    performTabContextMenuAction(item.id, for: tab)
-                }
-                .disabled(item.isDisabled)
-            }
-            Divider()
-            Button("Close") {
-                encoder?.sendCloseTab(id: tab.id)
-            }
-            Button("Close Others") {
-                encoder?.sendSelectTab(id: tab.id)
-                encoder?.sendExecuteCommand(name: "close_other_tabs")
-            }
-            Button("Close All") {
-                encoder?.sendExecuteCommand(name: "quit_all")
-            }
-            Divider()
-            Button("Copy Path") {
-                encoder?.sendTabCopyPath(id: tab.id)
-            }
-            .disabled(tab.isAgent)
+            .disabled(item.isDisabled)
         }
     }
 

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -625,7 +625,7 @@ struct TabBarView: View {
     }
 
     @ViewBuilder
-    private func agentTabContextMenu(for tab: TabEntry) -> some View {
+    private func closeTabMenuItems(for tab: TabEntry) -> some View {
         Button("Close") {
             encoder?.sendCloseTab(id: tab.id)
         }
@@ -640,18 +640,13 @@ struct TabBarView: View {
     }
 
     @ViewBuilder
+    private func agentTabContextMenu(for tab: TabEntry) -> some View {
+        closeTabMenuItems(for: tab)
+    }
+
+    @ViewBuilder
     private func fileTabContextMenu(for tab: TabEntry) -> some View {
-        Button("Close") {
-            encoder?.sendCloseTab(id: tab.id)
-        }
-        Button("Close Others") {
-            encoder?.sendSelectTab(id: tab.id)
-            encoder?.sendExecuteCommand(name: "close_other_tabs")
-        }
-        Button("Close All") {
-            encoder?.sendSelectTab(id: tab.id)
-            encoder?.sendExecuteCommand(name: "kill_all_buffers")
-        }
+        closeTabMenuItems(for: tab)
         Button("Close to the Right") {
             encoder?.sendSelectTab(id: tab.id)
             encoder?.sendExecuteCommand(name: "close_tabs_to_right")


### PR DESCRIPTION
## Summary

- Right-clicking a tab shows a context menu with tab management actions matching standard editor conventions (VS Code, Zed, Xcode)
- File tabs: Close, Close Others, Close All, Close to the Right, Copy Path, Reveal in File Tree, pin/move items
- Agent tabs: reduced menu with Close, Close Others, Close All only
- New commands: `:kill_other_buffers` (SPC b D), `:kill_all_buffers` (SPC b K), `:close_tabs_to_right` (context-menu-only)
- "Close All" now closes all file tabs without exiting the editor (previously used `quit_all` which shut down the app)
- Copy Relative Path and Reveal in Finder are intentionally omitted pending #1002

Closes #1005

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes (pre-existing warnings only)
- [x] `mix dialyzer` passes
- [x] `mix test.llm` passes (9110 tests, 0 failures)
- [x] `mix swift.build` passes
- [ ] Manual: right-click a file tab, verify all menu items appear and work
- [ ] Manual: right-click an agent tab, verify reduced menu (Close, Close Others, Close All)
- [ ] Manual: verify SPC b D closes other tabs, SPC b K closes all tabs
- [ ] Manual: verify Close to the Right closes tabs to the right of the clicked tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)