### PR TITLE
feat(agent): broker remote session control

### DIFF
--- a/lib/minga_agent/remote_api.ex
+++ b/lib/minga_agent/remote_api.ex
@@ -1,0 +1,118 @@
+defmodule MingaAgent.RemoteAPI do
+  @moduledoc """
+  Brokered control boundary for remote agent sessions.
+
+  Remote clients may use Erlang distribution as the transport for the MVP, but they should call only this module across the node boundary. The public contract is the verb set here, not arbitrary `:erpc` into `SessionManager`, `Session`, or other internals.
+
+  The trust model is deliberately explicit. The Erlang cookie gates trusted node membership and is all-or-nothing: any cookie holder can bypass this broker with raw distribution. The per-session token checked here is defense in depth for Minga's own clients and the seam for a future socket transport; it is not isolation from an untrusted cookie holder.
+  """
+
+  alias MingaAgent.RemoteAPI.AttachResult
+  alias MingaAgent.RemoteAPI.SessionInfo
+  alias MingaAgent.Session
+  alias MingaAgent.SessionManager
+
+  @typedoc "Remote attachment role."
+  @type role :: :driver | :viewer
+
+  @typedoc "Public session record returned by the broker."
+  @type session_info :: SessionInfo.t()
+
+  @typedoc "Attach result returned by the broker."
+  @type attach_result :: AttachResult.t()
+
+  @doc "Starts a new session through the broker."
+  @spec start_session(keyword()) :: {:ok, session_info()} | {:error, term()}
+  def start_session(opts \\ []) do
+    with {:ok, session_id, pid} <- SessionManager.start_session(opts),
+         {:ok, token} <- SessionManager.session_token(session_id) do
+      {:ok, session_info(session_id, pid, token)}
+    end
+  end
+
+  @doc "Starts or returns the stable session for a server-side working directory."
+  @spec start_or_get_for_workdir(String.t(), keyword()) ::
+          {:ok, session_info()} | {:error, term()}
+  def start_or_get_for_workdir(workdir, opts \\ []) when is_binary(workdir) do
+    session_id = SessionManager.stable_session_id_for_workdir(workdir)
+    opts = Keyword.put(opts, :session_id, session_id)
+
+    with {:ok, ^session_id, pid} <- SessionManager.start_or_get_session(session_id, opts),
+         {:ok, token} <- SessionManager.session_token(session_id) do
+      {:ok, session_info(session_id, pid, token)}
+    end
+  end
+
+  @doc "Lists live sessions through the broker."
+  @spec list_sessions() :: [session_info()]
+  def list_sessions do
+    SessionManager.list_sessions()
+    |> Enum.map(fn {session_id, pid, _metadata} ->
+      {:ok, token} = SessionManager.session_token(session_id)
+      session_info(session_id, pid, token)
+    end)
+  end
+
+  @doc "Attaches a client process to a session as driver or viewer."
+  @spec attach(String.t(), String.t(), pid(), keyword()) ::
+          {:ok, attach_result()} | {:error, term()}
+  def attach(session_id, token, subscriber_pid, opts \\ [])
+      when is_binary(session_id) and is_binary(token) and is_pid(subscriber_pid) do
+    role = Keyword.get(opts, :role, :viewer)
+
+    with :ok <- authorize(session_id, token),
+         {:ok, pid} <- SessionManager.get_session(session_id),
+         :ok <- Session.subscribe(pid, subscriber_pid, role: role) do
+      info = session_info(session_id, pid, token)
+      role = Session.subscriber_role(pid, subscriber_pid) || :viewer
+      {:ok, AttachResult.new(info, role, Session.messages(pid), Session.editor_snapshot(pid))}
+    end
+  end
+
+  @doc "Sends a prompt as an attached driver."
+  @spec send_prompt(String.t(), String.t(), pid(), String.t() | [ReqLLM.Message.ContentPart.t()]) ::
+          :ok | {:queued, :steering} | {:error, term()}
+  def send_prompt(session_id, token, client_pid, prompt)
+      when is_binary(session_id) and is_binary(token) and is_pid(client_pid) and
+             (is_binary(prompt) or is_list(prompt)) do
+    with :ok <- authorize(session_id, token),
+         {:ok, pid} <- SessionManager.get_session(session_id) do
+      Session.send_prompt_as(pid, client_pid, prompt)
+    end
+  end
+
+  @doc "Responds to a tool approval as an attached driver."
+  @spec approve(String.t(), String.t(), pid(), Session.approval_decision()) ::
+          :ok | {:error, term()}
+  def approve(session_id, token, client_pid, decision)
+      when is_binary(session_id) and is_binary(token) and is_pid(client_pid) and
+             decision in [:approve, :approve_session, :approve_turn, :reject] do
+    with :ok <- authorize(session_id, token),
+         {:ok, pid} <- SessionManager.get_session(session_id) do
+      Session.respond_to_approval_as(pid, client_pid, decision)
+    end
+  end
+
+  @doc "Stops a session through the broker."
+  @spec stop_session(String.t(), String.t()) :: :ok | {:error, term()}
+  def stop_session(session_id, token) when is_binary(session_id) and is_binary(token) do
+    with :ok <- authorize(session_id, token) do
+      SessionManager.stop_session(session_id)
+    end
+  end
+
+  @doc "Authorizes a broker call with the per-session token."
+  @spec authorize(String.t(), String.t()) :: :ok | {:error, :unauthorized | :not_found}
+  def authorize(session_id, token) when is_binary(session_id) and is_binary(token) do
+    case SessionManager.session_token(session_id) do
+      {:ok, ^token} -> :ok
+      {:ok, _other} -> {:error, :unauthorized}
+      {:error, :not_found} -> {:error, :not_found}
+    end
+  end
+
+  @spec session_info(String.t(), pid(), String.t()) :: session_info()
+  defp session_info(session_id, pid, token) do
+    SessionInfo.new(session_id, pid, token, Session.metadata(pid))
+  end
+end

--- a/lib/minga_agent/remote_api/attach_result.ex
+++ b/lib/minga_agent/remote_api/attach_result.ex
@@ -1,0 +1,37 @@
+defmodule MingaAgent.RemoteAPI.AttachResult do
+  @moduledoc "Attach result returned by the remote API broker."
+
+  alias MingaAgent.RemoteAPI.SessionInfo
+  alias MingaAgent.Session
+  alias MingaAgent.SessionMetadata
+
+  @type role :: :driver | :viewer
+
+  @enforce_keys [:session_id, :pid, :token, :role, :messages, :snapshot, :metadata]
+  defstruct [:session_id, :pid, :token, :role, :messages, :snapshot, :metadata]
+
+  @type t :: %__MODULE__{
+          session_id: String.t(),
+          pid: pid(),
+          token: String.t(),
+          role: role(),
+          messages: [MingaAgent.Message.t()],
+          snapshot: Session.editor_snapshot(),
+          metadata: SessionMetadata.t()
+        }
+
+  @doc "Creates an attach result from session info and snapshot data."
+  @spec new(SessionInfo.t(), role(), [MingaAgent.Message.t()], Session.editor_snapshot()) :: t()
+  def new(%SessionInfo{} = info, role, messages, snapshot)
+      when role in [:driver, :viewer] and is_list(messages) and is_map(snapshot) do
+    %__MODULE__{
+      session_id: info.session_id,
+      pid: info.pid,
+      token: info.token,
+      role: role,
+      messages: messages,
+      snapshot: snapshot,
+      metadata: info.metadata
+    }
+  end
+end

--- a/lib/minga_agent/remote_api/session_info.ex
+++ b/lib/minga_agent/remote_api/session_info.ex
@@ -1,0 +1,22 @@
+defmodule MingaAgent.RemoteAPI.SessionInfo do
+  @moduledoc "Session record returned by the remote API broker."
+
+  alias MingaAgent.SessionMetadata
+
+  @enforce_keys [:session_id, :pid, :token, :metadata]
+  defstruct [:session_id, :pid, :token, :metadata]
+
+  @type t :: %__MODULE__{
+          session_id: String.t(),
+          pid: pid(),
+          token: String.t(),
+          metadata: SessionMetadata.t()
+        }
+
+  @doc "Creates a session info record."
+  @spec new(String.t(), pid(), String.t(), SessionMetadata.t()) :: t()
+  def new(session_id, pid, token, %SessionMetadata{} = metadata)
+      when is_binary(session_id) and is_pid(pid) and is_binary(token) do
+    %__MODULE__{session_id: session_id, pid: pid, token: token, metadata: metadata}
+  end
+end

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -2100,62 +2100,64 @@ defmodule MingaAgent.Session do
   # vetoes, turn/cost limits) are passed through unchanged.
   @spec humanize_error(String.t()) :: String.t()
   defp humanize_error(message) when is_binary(message) do
-    humanize_error(
-      message,
-      provider_rejected_key?(message),
-      rate_limited?(message),
-      auth_failed?(message),
-      provider_unreachable?(message),
-      raw_struct_dump?(message)
-    )
+    humanize_error_kind(classify_error(message), message)
   end
 
   defp humanize_error(message), do: humanize_error(inspect(message))
 
-  @spec humanize_error(String.t(), boolean(), boolean(), boolean(), boolean(), boolean()) ::
-          String.t()
-  defp humanize_error(_message, true, _rate_limited?, _auth_failed?, _unreachable?, _raw_dump?) do
-    "The provider rejected your API key. Update it with /auth <provider> <key>, then try again."
+  @type error_kind ::
+          :rejected_key | :rate_limited | :auth_failed | :unreachable | :raw_dump | :passthrough
+
+  @spec classify_error(String.t()) :: error_kind()
+  defp classify_error(message) do
+    classify_error_checks([
+      {:rejected_key,
+       String.match?(message, ~r/\b401\b/) or
+         String.contains?(message, ["unauthorized", "Unauthorized", "invalid_api_key"])},
+      {:rate_limited,
+       String.match?(message, ~r/\b429\b/) or String.contains?(message, "rate limit")},
+      {:auth_failed,
+       String.contains?(message, [
+         "api_key",
+         "API_KEY",
+         "provider_build_failed",
+         "Failed to build"
+       ])},
+      {:unreachable,
+       String.contains?(message, [
+         "http_streaming_failed",
+         "econnrefused",
+         "nxdomain",
+         "timed out"
+       ])},
+      {:raw_dump, raw_struct_dump?(message)}
+    ])
   end
 
-  defp humanize_error(_message, false, true, _auth_failed?, _unreachable?, _raw_dump?) do
-    "Rate limited by the provider. Wait a moment and try again."
-  end
+  @spec classify_error_checks([{error_kind(), boolean()}]) :: error_kind()
+  defp classify_error_checks([{kind, true} | _rest]), do: kind
+  defp classify_error_checks([{_kind, false} | rest]), do: classify_error_checks(rest)
+  defp classify_error_checks([]), do: :passthrough
 
-  defp humanize_error(_message, false, false, true, _unreachable?, _raw_dump?) do
-    "Couldn't authenticate with the model provider. Check your API key with /auth, then try again."
-  end
+  @spec humanize_error_kind(error_kind(), String.t()) :: String.t()
+  defp humanize_error_kind(:rejected_key, _message),
+    do:
+      "The provider rejected your API key. Update it with /auth <provider> <key>, then try again."
 
-  defp humanize_error(_message, false, false, false, true, _raw_dump?) do
-    "Couldn't reach the model provider. Check your network connection and try again."
-  end
+  defp humanize_error_kind(:rate_limited, _message),
+    do: "Rate limited by the provider. Wait a moment and try again."
 
-  defp humanize_error(_message, false, false, false, false, true) do
-    "Something went wrong talking to the model provider. Open the Messages panel for details."
-  end
+  defp humanize_error_kind(:auth_failed, _message),
+    do:
+      "Couldn't authenticate with the model provider. Check your API key with /auth, then try again."
 
-  defp humanize_error(message, false, false, false, false, false), do: message
+  defp humanize_error_kind(:unreachable, _message),
+    do: "Couldn't reach the model provider. Check your network connection and try again."
 
-  @spec provider_rejected_key?(String.t()) :: boolean()
-  defp provider_rejected_key?(message) do
-    String.match?(message, ~r/\b401\b/) or
-      String.contains?(message, ["unauthorized", "Unauthorized", "invalid_api_key"])
-  end
+  defp humanize_error_kind(:raw_dump, _message),
+    do: "Something went wrong talking to the model provider. Open the Messages panel for details."
 
-  @spec rate_limited?(String.t()) :: boolean()
-  defp rate_limited?(message) do
-    String.match?(message, ~r/\b429\b/) or String.contains?(message, "rate limit")
-  end
-
-  @spec auth_failed?(String.t()) :: boolean()
-  defp auth_failed?(message) do
-    String.contains?(message, ["api_key", "API_KEY", "provider_build_failed", "Failed to build"])
-  end
-
-  @spec provider_unreachable?(String.t()) :: boolean()
-  defp provider_unreachable?(message) do
-    String.contains?(message, ["http_streaming_failed", "econnrefused", "nxdomain", "timed out"])
-  end
+  defp humanize_error_kind(:passthrough, message), do: message
 
   # Detects an inspected Elixir struct/exception leaking into the message, so
   # we never show a raw `%ReqLLM.Error{...}`-style dump in the transcript.

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -65,9 +65,13 @@ defmodule MingaAgent.Session do
   @typedoc "Active tool call tracked while the provider is executing tools."
   @type active_tool_call :: {tool_call_id :: String.t(), name :: String.t()}
 
+  @typedoc "Remote attachment role."
+  @type attachment_role :: :driver | :viewer
+
   @typedoc "Internal session state."
   @type state :: %{
           session_id: String.t(),
+          remote_token: String.t() | nil,
           provider: pid() | nil,
           provider_module: module(),
           provider_opts: keyword(),
@@ -76,6 +80,8 @@ defmodule MingaAgent.Session do
           message_ids: [pos_integer()],
           next_message_id: pos_integer(),
           subscribers: MapSet.t(pid()),
+          subscriber_roles: %{pid() => attachment_role()},
+          driver: pid() | nil,
           total_usage: Event.token_usage(),
           error_message: String.t() | nil,
           pending_thinking_level: String.t() | nil,
@@ -265,9 +271,37 @@ defmodule MingaAgent.Session do
   end
 
   @doc "Subscribes the given process to session events."
-  @spec subscribe(GenServer.server(), pid()) :: :ok
-  def subscribe(session, pid) when is_pid(pid) do
-    GenServer.call(session, {:subscribe, pid})
+  @spec subscribe(GenServer.server(), pid(), keyword()) :: :ok
+  def subscribe(session, pid, opts \\ []) when is_pid(pid) do
+    GenServer.call(session, {:subscribe, pid, opts})
+  end
+
+  @doc "Returns the current remote attachment role for a subscriber."
+  @spec subscriber_role(GenServer.server(), pid()) :: attachment_role() | nil
+  def subscriber_role(session, pid) when is_pid(pid) do
+    GenServer.call(session, {:subscriber_role, pid})
+  end
+
+  @doc "Claims the driver role for a subscribed client when the role is vacant."
+  @spec claim_driver(GenServer.server(), pid()) :: :ok | {:error, :driver_taken | :not_subscribed}
+  def claim_driver(session, pid) when is_pid(pid) do
+    GenServer.call(session, {:claim_driver, pid})
+  end
+
+  @doc "Sends a user prompt as an attached remote client."
+  @spec send_prompt_as(GenServer.server(), pid(), String.t() | [ReqLLM.Message.ContentPart.t()]) ::
+          :ok | {:queued, :steering} | {:error, term()}
+  def send_prompt_as(session, client_pid, content)
+      when is_pid(client_pid) and (is_binary(content) or is_list(content)) do
+    GenServer.call(session, {:send_prompt_as, client_pid, content})
+  end
+
+  @doc "Responds to a pending tool approval as an attached remote client."
+  @spec respond_to_approval_as(GenServer.server(), pid(), approval_decision()) ::
+          :ok | {:error, :no_pending_approval | :not_driver}
+  def respond_to_approval_as(session, client_pid, decision)
+      when is_pid(client_pid) and decision in [:approve, :approve_session, :approve_turn, :reject] do
+    GenServer.call(session, {:respond_to_approval_as, client_pid, decision})
   end
 
   @doc "Unsubscribes the calling process from session events."
@@ -568,6 +602,7 @@ defmodule MingaAgent.Session do
 
     state = %{
       session_id: session_id,
+      remote_token: Keyword.get(opts, :remote_token),
       provider: nil,
       provider_module: provider_module,
       provider_opts: provider_opts,
@@ -578,6 +613,8 @@ defmodule MingaAgent.Session do
       message_ids: [1],
       next_message_id: 2,
       subscribers: MapSet.new(),
+      subscriber_roles: %{},
+      driver: nil,
       total_usage: TurnUsage.new(),
       error_message: nil,
       pending_thinking_level: initial_thinking_level,
@@ -627,52 +664,15 @@ defmodule MingaAgent.Session do
     {:reply, :ok, state}
   end
 
-  def handle_call({:send_prompt, _text}, _from, %{provider: nil} = state) do
-    {:reply, {:error, :provider_not_ready}, state}
-  end
-
-  def handle_call({:send_prompt, content}, _from, %{status: status} = state)
-      when status in [:thinking, :tool_executing] do
-    # Agent is busy: queue the message as a steering prompt. It will be injected
-    # into the agent's context between tool calls.
-    state = %{state | steering_queue: state.steering_queue ++ [content]}
-    broadcast(state, {:prompt_queued, content, :steering})
-    {:reply, {:queued, :steering}, state}
-  end
-
-  def handle_call({:send_prompt, content}, _from, %{credentials_configured: false} = state) do
-    # No usable provider yet. Show the user's message followed by a gentle
-    # setup nudge instead of attempting a call that would fail with a raw
-    # provider error. Reply :ok so the input clears like a normal submit.
-    {user_msg, _send_content} = build_user_message(content)
-
-    state =
-      state
-      |> append_msg(user_msg)
-      |> append_system_message(auth_required_message(), :info)
-      |> notify_messages_changed()
-
-    {:reply, :ok, state}
+  def handle_call({:send_prompt_as, client_pid, content}, _from, state) do
+    case driver_allowed?(state, client_pid) do
+      true -> handle_send_prompt(content, state)
+      false -> {:reply, {:error, :not_driver}, state}
+    end
   end
 
   def handle_call({:send_prompt, content}, _from, state) do
-    case dispatch_user_prompt_submit(state, content) do
-      :ok ->
-        {user_msg, send_content} = build_user_message(content)
-        state = append_msg(state, user_msg)
-        state = notify_messages_changed(state)
-
-        case state.provider_module.send_prompt(state.provider, send_content) do
-          :ok ->
-            {:reply, :ok, state}
-
-          {:error, _} = err ->
-            {:reply, err, state}
-        end
-
-      {:error, %HookResult{} = result} ->
-        {:reply, {:error, {:hook_veto, HookResult.message(result)}}, state}
-    end
+    handle_send_prompt(content, state)
   end
 
   def handle_call({:send_follow_up, _content}, _from, %{provider: nil} = state) do
@@ -937,23 +937,15 @@ defmodule MingaAgent.Session do
     {:reply, meta, state}
   end
 
-  def handle_call({:respond_to_approval, _decision}, _from, %{pending_approval: nil} = state) do
-    Minga.Log.warning(:agent, "[Session] respond_to_approval called with no pending approval")
-    {:reply, {:error, :no_pending_approval}, state}
+  def handle_call({:respond_to_approval_as, client_pid, decision}, _from, state) do
+    case driver_allowed?(state, client_pid) do
+      true -> handle_approval_response(decision, state)
+      false -> {:reply, {:error, :not_driver}, state}
+    end
   end
 
   def handle_call({:respond_to_approval, decision}, _from, state) do
-    %{tool_call_id: tool_call_id, reply_to: reply_to} = approval = state.pending_approval
-    state = maybe_set_trust_for_decision(state, approval.name, decision)
-
-    # Send the execution decision directly to the blocked Task process.
-    send(reply_to, {:tool_approval_response, tool_call_id, execution_decision(decision)})
-
-    state = maybe_record_rejection(state, approval, decision)
-    state = %{state | pending_approval: nil}
-    state = notify_messages_changed(state)
-    broadcast(state, {:approval_resolved, decision})
-    {:reply, :ok, state}
+    handle_approval_response(decision, state)
   end
 
   def handle_call({:set_tool_trust, name, scope}, _from, state) do
@@ -972,13 +964,26 @@ defmodule MingaAgent.Session do
     {:reply, state.trust_levels, state}
   end
 
-  def handle_call({:subscribe, pid}, _from, state) do
+  def handle_call({:subscribe, pid, opts}, _from, state) do
     Process.monitor(pid)
-    {:reply, :ok, %{state | subscribers: MapSet.put(state.subscribers, pid)}}
+    role = Keyword.get(opts, :role, default_subscriber_role(state))
+    state = put_subscriber(state, pid, role)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:subscriber_role, pid}, _from, state) do
+    {:reply, Map.get(state.subscriber_roles, pid), state}
+  end
+
+  def handle_call({:claim_driver, pid}, _from, state) do
+    case claim_driver_role(state, pid) do
+      {:ok, state} -> {:reply, :ok, state}
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
   end
 
   def handle_call({:unsubscribe, pid}, _from, state) do
-    {:reply, :ok, %{state | subscribers: MapSet.delete(state.subscribers, pid)}}
+    {:reply, :ok, remove_subscriber(state, pid)}
   end
 
   def handle_call(:compact, _from, %{provider: nil} = state) do
@@ -1221,8 +1226,8 @@ defmodule MingaAgent.Session do
   end
 
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    # A subscriber died, remove it
-    {:noreply, %{state | subscribers: MapSet.delete(state.subscribers, pid)}}
+    # A subscriber died, remove it and vacate the driver role if needed.
+    {:noreply, remove_subscriber(state, pid)}
   end
 
   def handle_info(:save_session, state) do
@@ -1233,6 +1238,77 @@ defmodule MingaAgent.Session do
 
   def handle_info(_msg, state) do
     {:noreply, state}
+  end
+
+  @spec handle_approval_response(approval_decision(), state()) ::
+          {:reply, :ok | {:error, :no_pending_approval}, state()}
+  defp handle_approval_response(_decision, %{pending_approval: nil} = state) do
+    Minga.Log.warning(:agent, "[Session] respond_to_approval called with no pending approval")
+    {:reply, {:error, :no_pending_approval}, state}
+  end
+
+  defp handle_approval_response(decision, state) do
+    %{tool_call_id: tool_call_id, reply_to: reply_to} = approval = state.pending_approval
+    state = maybe_set_trust_for_decision(state, approval.name, decision)
+
+    # Send the execution decision directly to the blocked Task process.
+    send(reply_to, {:tool_approval_response, tool_call_id, execution_decision(decision)})
+
+    state = maybe_record_rejection(state, approval, decision)
+    state = %{state | pending_approval: nil}
+    state = notify_messages_changed(state)
+    broadcast(state, {:approval_resolved, decision})
+    {:reply, :ok, state}
+  end
+
+  @spec handle_send_prompt(String.t() | [ReqLLM.Message.ContentPart.t()], state()) ::
+          {:reply, :ok | {:queued, :steering} | {:error, term()}, state()}
+  defp handle_send_prompt(_text, %{provider: nil} = state) do
+    {:reply, {:error, :provider_not_ready}, state}
+  end
+
+  defp handle_send_prompt(content, %{status: status} = state)
+       when status in [:thinking, :tool_executing] do
+    # Agent is busy: queue the message as a steering prompt. It will be injected
+    # into the agent's context between tool calls.
+    state = %{state | steering_queue: state.steering_queue ++ [content]}
+    broadcast(state, {:prompt_queued, content, :steering})
+    {:reply, {:queued, :steering}, state}
+  end
+
+  defp handle_send_prompt(content, %{credentials_configured: false} = state) do
+    # No usable provider yet. Show the user's message followed by a gentle
+    # setup nudge instead of attempting a call that would fail with a raw
+    # provider error. Reply :ok so the input clears like a normal submit.
+    {user_msg, _send_content} = build_user_message(content)
+
+    state =
+      state
+      |> append_msg(user_msg)
+      |> append_system_message(auth_required_message(), :info)
+      |> notify_messages_changed()
+
+    {:reply, :ok, state}
+  end
+
+  defp handle_send_prompt(content, state) do
+    case dispatch_user_prompt_submit(state, content) do
+      :ok ->
+        {user_msg, send_content} = build_user_message(content)
+        state = append_msg(state, user_msg)
+        state = notify_messages_changed(state)
+
+        case state.provider_module.send_prompt(state.provider, send_content) do
+          :ok ->
+            {:reply, :ok, state}
+
+          {:error, _} = err ->
+            {:reply, err, state}
+        end
+
+      {:error, %HookResult{} = result} ->
+        {:reply, {:error, {:hook_veto, HookResult.message(result)}}, state}
+    end
   end
 
   # ── Event handling ──────────────────────────────────────────────────────────
@@ -1712,6 +1788,81 @@ defmodule MingaAgent.Session do
     "Execution mode enabled. Destructive tools can run again after normal approval checks. Use /plan to return to planning."
   end
 
+  # ── Remote attachment roles ────────────────────────────────────────────────
+
+  @spec default_subscriber_role(state()) :: attachment_role()
+  defp default_subscriber_role(%{driver: nil}), do: :driver
+  defp default_subscriber_role(_state), do: :viewer
+
+  @spec put_subscriber(state(), pid(), attachment_role()) :: state()
+  defp put_subscriber(state, pid, :driver) do
+    state = %{state | subscribers: MapSet.put(state.subscribers, pid)}
+
+    case state.driver do
+      nil -> set_driver(state, pid)
+      ^pid -> set_driver(state, pid)
+      _other -> put_subscriber(state, pid, :viewer)
+    end
+  end
+
+  defp put_subscriber(state, pid, :viewer) do
+    %{
+      state
+      | subscribers: MapSet.put(state.subscribers, pid),
+        subscriber_roles: Map.put(state.subscriber_roles, pid, :viewer)
+    }
+  end
+
+  @spec claim_driver_role(state(), pid()) ::
+          {:ok, state()} | {:error, :driver_taken | :not_subscribed}
+  defp claim_driver_role(state, pid) do
+    claim_driver_role(state, pid, MapSet.member?(state.subscribers, pid), state.driver)
+  end
+
+  @spec claim_driver_role(state(), pid(), boolean(), pid() | nil) ::
+          {:ok, state()} | {:error, :driver_taken | :not_subscribed}
+  defp claim_driver_role(_state, _pid, false, _driver), do: {:error, :not_subscribed}
+  defp claim_driver_role(state, pid, true, nil), do: {:ok, set_driver(state, pid)}
+  defp claim_driver_role(state, pid, true, pid), do: {:ok, set_driver(state, pid)}
+  defp claim_driver_role(_state, _pid, true, _driver), do: {:error, :driver_taken}
+
+  @spec set_driver(state(), pid()) :: state()
+  defp set_driver(%{driver: nil, subscriber_roles: roles} = state, pid)
+       when map_size(roles) == 0 do
+    %{
+      state
+      | driver: pid,
+        subscriber_roles: Map.put(state.subscriber_roles, pid, :driver)
+    }
+  end
+
+  defp set_driver(state, pid) do
+    state = %{
+      state
+      | driver: pid,
+        subscriber_roles: Map.put(state.subscriber_roles, pid, :driver)
+    }
+
+    broadcast(state, {:driver_changed, pid})
+    state
+  end
+
+  @spec remove_subscriber(state(), pid()) :: state()
+  defp remove_subscriber(state, pid) do
+    driver = if state.driver == pid, do: nil, else: state.driver
+
+    %{
+      state
+      | subscribers: MapSet.delete(state.subscribers, pid),
+        subscriber_roles: Map.delete(state.subscriber_roles, pid),
+        driver: driver
+    }
+  end
+
+  @spec driver_allowed?(state(), pid()) :: boolean()
+  defp driver_allowed?(%{driver: pid}, pid) when is_pid(pid), do: true
+  defp driver_allowed?(_state, _pid), do: false
+
   # ── Broadcasting ────────────────────────────────────────────────────────────
 
   @spec broadcast(state(), term()) :: :ok
@@ -1949,29 +2100,62 @@ defmodule MingaAgent.Session do
   # vetoes, turn/cost limits) are passed through unchanged.
   @spec humanize_error(String.t()) :: String.t()
   defp humanize_error(message) when is_binary(message) do
-    cond do
-      String.match?(message, ~r/\b401\b/) or
-          String.contains?(message, ["unauthorized", "Unauthorized", "invalid_api_key"]) ->
-        "The provider rejected your API key. Update it with /auth <provider> <key>, then try again."
-
-      String.match?(message, ~r/\b429\b/) or String.contains?(message, "rate limit") ->
-        "Rate limited by the provider. Wait a moment and try again."
-
-      String.contains?(message, ["api_key", "API_KEY", "provider_build_failed", "Failed to build"]) ->
-        "Couldn't authenticate with the model provider. Check your API key with /auth, then try again."
-
-      String.contains?(message, ["http_streaming_failed", "econnrefused", "nxdomain", "timed out"]) ->
-        "Couldn't reach the model provider. Check your network connection and try again."
-
-      raw_struct_dump?(message) ->
-        "Something went wrong talking to the model provider. Open the Messages panel for details."
-
-      true ->
-        message
-    end
+    humanize_error(
+      message,
+      provider_rejected_key?(message),
+      rate_limited?(message),
+      auth_failed?(message),
+      provider_unreachable?(message),
+      raw_struct_dump?(message)
+    )
   end
 
   defp humanize_error(message), do: humanize_error(inspect(message))
+
+  @spec humanize_error(String.t(), boolean(), boolean(), boolean(), boolean(), boolean()) ::
+          String.t()
+  defp humanize_error(_message, true, _rate_limited?, _auth_failed?, _unreachable?, _raw_dump?) do
+    "The provider rejected your API key. Update it with /auth <provider> <key>, then try again."
+  end
+
+  defp humanize_error(_message, false, true, _auth_failed?, _unreachable?, _raw_dump?) do
+    "Rate limited by the provider. Wait a moment and try again."
+  end
+
+  defp humanize_error(_message, false, false, true, _unreachable?, _raw_dump?) do
+    "Couldn't authenticate with the model provider. Check your API key with /auth, then try again."
+  end
+
+  defp humanize_error(_message, false, false, false, true, _raw_dump?) do
+    "Couldn't reach the model provider. Check your network connection and try again."
+  end
+
+  defp humanize_error(_message, false, false, false, false, true) do
+    "Something went wrong talking to the model provider. Open the Messages panel for details."
+  end
+
+  defp humanize_error(message, false, false, false, false, false), do: message
+
+  @spec provider_rejected_key?(String.t()) :: boolean()
+  defp provider_rejected_key?(message) do
+    String.match?(message, ~r/\b401\b/) or
+      String.contains?(message, ["unauthorized", "Unauthorized", "invalid_api_key"])
+  end
+
+  @spec rate_limited?(String.t()) :: boolean()
+  defp rate_limited?(message) do
+    String.match?(message, ~r/\b429\b/) or String.contains?(message, "rate limit")
+  end
+
+  @spec auth_failed?(String.t()) :: boolean()
+  defp auth_failed?(message) do
+    String.contains?(message, ["api_key", "API_KEY", "provider_build_failed", "Failed to build"])
+  end
+
+  @spec provider_unreachable?(String.t()) :: boolean()
+  defp provider_unreachable?(message) do
+    String.contains?(message, ["http_streaming_failed", "econnrefused", "nxdomain", "timed out"])
+  end
 
   # Detects an inspected Elixir struct/exception leaking into the message, so
   # we never show a raw `%ReqLLM.Error{...}`-style dump in the transcript.
@@ -2043,6 +2227,7 @@ defmodule MingaAgent.Session do
 
     data = %{
       id: state.session_id,
+      remote_token: state.remote_token,
       timestamp: now,
       last_message_at: last_message_at,
       title: readable_title(first_user_prompt(state.messages)),
@@ -2068,6 +2253,7 @@ defmodule MingaAgent.Session do
         state = %{
           state
           | session_id: data.id,
+            remote_token: Map.get(data, :remote_token, state.remote_token),
             total_usage: data.usage,
             model_name: data.model_name,
             provider_name: Map.get(data, :provider_name, state.provider_name),

--- a/lib/minga_agent/session_manager.ex
+++ b/lib/minga_agent/session_manager.ex
@@ -2,7 +2,9 @@ defmodule MingaAgent.SessionManager do
   @moduledoc """
   Owns agent session lifecycle independently of any UI.
 
-  Maps human-readable session IDs (e.g., `"session-1"`) to session PIDs.
+  Maps stable session IDs to session PIDs. Local scratch sessions still use
+  human-readable generated IDs (e.g., `"session-1"`), while remote attach sessions
+  pass a deterministic `:session_id` derived from their server-side working directory.
   Sessions are started via `MingaAgent.Supervisor` (DynamicSupervisor) and
   monitored here. When a session dies, the manager broadcasts an
   `:agent_session_stopped` event so the Editor (or any subscriber) can
@@ -27,7 +29,8 @@ defmodule MingaAgent.SessionManager do
   @typedoc "An entry in the sessions map."
   @type session_entry :: %{
           pid: pid(),
-          monitor_ref: reference()
+          monitor_ref: reference(),
+          token: String.t()
         }
 
   # ── Event payload ──────────────────────────────────────────────────────────
@@ -68,6 +71,27 @@ defmodule MingaAgent.SessionManager do
           {:ok, String.t(), pid()} | {:error, term()}
   def start_session(manager, opts) do
     GenServer.call(manager, {:start_session, opts})
+  end
+
+  @doc "Starts or returns the stable session with the given ID."
+  @spec start_or_get_session(String.t(), keyword()) :: {:ok, String.t(), pid()} | {:error, term()}
+  def start_or_get_session(session_id, opts \\ []) when is_binary(session_id) do
+    start_or_get_session(__MODULE__, session_id, opts)
+  end
+
+  @doc "Starts or returns the stable session with the given ID through the given manager."
+  @spec start_or_get_session(GenServer.server(), String.t(), keyword()) ::
+          {:ok, String.t(), pid()} | {:error, term()}
+  def start_or_get_session(manager, session_id, opts) when is_binary(session_id) do
+    GenServer.call(manager, {:start_or_get_session, session_id, opts})
+  end
+
+  @doc "Builds the deterministic session ID used for a server-side working directory."
+  @spec stable_session_id_for_workdir(String.t()) :: String.t()
+  def stable_session_id_for_workdir(path) when is_binary(path) do
+    expanded = Path.expand(path)
+    digest = :crypto.hash(:sha256, expanded) |> Base.encode16(case: :lower) |> binary_part(0, 16)
+    "workdir-#{digest}"
   end
 
   @doc "Starts a background sub-agent, sends it the task asynchronously, and returns a stable handle."
@@ -157,6 +181,18 @@ defmodule MingaAgent.SessionManager do
     GenServer.call(manager, {:get_session, session_id})
   end
 
+  @doc "Returns the broker token for a live session. Used by the remote API bootstrap path."
+  @spec session_token(String.t()) :: {:ok, String.t()} | {:error, :not_found}
+  def session_token(session_id) when is_binary(session_id) do
+    session_token(__MODULE__, session_id)
+  end
+
+  @doc "Returns the broker token for a live session through the given manager."
+  @spec session_token(GenServer.server(), String.t()) :: {:ok, String.t()} | {:error, :not_found}
+  def session_token(manager, session_id) when is_binary(session_id) do
+    GenServer.call(manager, {:session_token, session_id})
+  end
+
   @doc "Looks up the session ID for a PID."
   @spec session_id_for_pid(pid()) :: {:ok, String.t()} | {:error, :not_found}
   def session_id_for_pid(pid) when is_pid(pid) do
@@ -192,6 +228,24 @@ defmodule MingaAgent.SessionManager do
   @impl GenServer
   def handle_call({:start_session, opts}, _from, state) do
     case start_managed_session(state, opts) do
+      {:existing, session_id, pid, state} ->
+        {:reply, {:ok, session_id, pid}, state}
+
+      {:ok, session_id, pid, new_state} ->
+        {:reply, {:ok, session_id, pid}, new_state}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call({:start_or_get_session, session_id, opts}, _from, state) do
+    opts = Keyword.put(opts, :session_id, session_id)
+
+    case start_managed_session(state, opts) do
+      {:existing, session_id, pid, state} ->
+        {:reply, {:ok, session_id, pid}, state}
+
       {:ok, session_id, pid, new_state} ->
         {:reply, {:ok, session_id, pid}, new_state}
 
@@ -274,6 +328,13 @@ defmodule MingaAgent.SessionManager do
     end
   end
 
+  def handle_call({:session_token, session_id}, _from, state) do
+    case Map.fetch(state.sessions, session_id) do
+      {:ok, %{token: token}} -> {:reply, {:ok, token}, state}
+      :error -> {:reply, {:error, :not_found}, state}
+    end
+  end
+
   def handle_call({:stop_session_by_pid, pid}, _from, state) do
     case find_session_by_pid(state.sessions, pid) do
       {session_id, %{monitor_ref: ref}} ->
@@ -341,6 +402,9 @@ defmodule MingaAgent.SessionManager do
     session_opts = Keyword.put(session_opts, :background_subagent, true)
 
     case start_managed_session(state, session_opts) do
+      {:existing, _session_id, _pid, _state} ->
+        {:reply, {:error, :session_already_exists}, state}
+
       {:ok, session_id, pid, new_state} ->
         handle =
           Handle.new(
@@ -368,17 +432,34 @@ defmodule MingaAgent.SessionManager do
   end
 
   @spec start_managed_session(state(), keyword()) ::
-          {:ok, String.t(), pid(), state()} | {:error, term()}
+          {:ok, String.t(), pid(), state()}
+          | {:existing, String.t(), pid(), state()}
+          | {:error, term()}
   defp start_managed_session(state, opts) do
-    session_id = "session-#{state.next_id}"
-    opts = Keyword.put_new(opts, :session_id, session_id)
+    session_id = Keyword.get(opts, :session_id, "session-#{state.next_id}")
+
+    case Map.fetch(state.sessions, session_id) do
+      {:ok, %{pid: pid}} ->
+        {:existing, session_id, pid, state}
+
+      :error ->
+        do_start_managed_session(state, Keyword.put(opts, :session_id, session_id), session_id)
+    end
+  end
+
+  @spec do_start_managed_session(state(), keyword(), String.t()) ::
+          {:ok, String.t(), pid(), state()} | {:error, term()}
+  defp do_start_managed_session(state, opts, session_id) do
+    token = session_token_for_start(session_id, opts)
+    opts = Keyword.put(opts, :remote_token, token)
 
     case MingaAgent.Supervisor.start_session(opts) do
       {:ok, pid} ->
         ref = Process.monitor(pid)
-        entry = %{pid: pid, monitor_ref: ref}
+        entry = %{pid: pid, monitor_ref: ref, token: token}
         sessions = Map.put(state.sessions, session_id, entry)
-        new_state = %{state | sessions: sessions, next_id: state.next_id + 1}
+        next_id = next_id_after_start(state, session_id)
+        new_state = %{state | sessions: sessions, next_id: next_id}
 
         Minga.Log.info(:agent, "[SessionManager] Started session #{session_id} (#{inspect(pid)})")
         {:ok, session_id, pid, new_state}
@@ -386,6 +467,30 @@ defmodule MingaAgent.SessionManager do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  @spec next_id_after_start(state(), String.t()) :: pos_integer()
+  defp next_id_after_start(state, "session-" <> _suffix), do: state.next_id + 1
+  defp next_id_after_start(state, _session_id), do: state.next_id
+
+  @spec session_token_for_start(String.t(), keyword()) :: String.t()
+  defp session_token_for_start(session_id, opts) do
+    Keyword.get(opts, :remote_token) || stored_session_token(session_id, opts) || generate_token()
+  end
+
+  @spec stored_session_token(String.t(), keyword()) :: String.t() | nil
+  defp stored_session_token(session_id, opts) do
+    session_store_dir = Keyword.get(opts, :session_store_dir)
+
+    case MingaAgent.SessionStore.load(session_id, session_store_dir) do
+      {:ok, data} -> Map.get(data, :remote_token)
+      {:error, _reason} -> nil
+    end
+  end
+
+  @spec generate_token() :: String.t()
+  defp generate_token do
+    32 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
   end
 
   @background_prompt_retry_ms 10

--- a/lib/minga_agent/session_store.ex
+++ b/lib/minga_agent/session_store.ex
@@ -35,6 +35,7 @@ defmodule MingaAgent.SessionStore do
           required(:usage) => MingaAgent.TurnUsage.t(),
           optional(:last_message_at) => String.t(),
           optional(:title) => String.t(),
+          optional(:remote_token) => String.t() | nil,
           optional(:provider_name) => String.t(),
           optional(:branches) => [MingaAgent.Branch.t()],
           optional(:memory) => String.t() | nil
@@ -161,6 +162,7 @@ defmodule MingaAgent.SessionStore do
 
     %{
       "id" => data.id,
+      "remote_token" => Map.get(data, :remote_token),
       "timestamp" => timestamp,
       "last_message_at" => Map.get(data, :last_message_at, timestamp),
       "title" => Map.get(data, :title) || title_from_messages(messages),
@@ -225,6 +227,7 @@ defmodule MingaAgent.SessionStore do
 
     session = %{
       id: data["id"],
+      remote_token: data["remote_token"],
       timestamp: timestamp,
       last_message_at: data["last_message_at"] || timestamp,
       title: data["title"] || title_from_messages(messages),

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -347,9 +347,9 @@ defmodule MingaEditor.Commands.Agent do
   end
 
   @doc "Connects to an existing remote session from the session picker."
-  @spec connect_remote_session(state(), String.t(), String.t(), pid()) :: state()
-  def connect_remote_session(state, server_name, session_id, remote_pid) do
-    AgentSession.connect_remote_session(state, server_name, session_id, remote_pid)
+  @spec connect_remote_session(state(), String.t(), String.t(), pid(), String.t()) :: state()
+  def connect_remote_session(state, server_name, session_id, remote_pid, token) do
+    AgentSession.connect_remote_session(state, server_name, session_id, remote_pid, token)
   end
 
   @doc "Submits the current input text as a prompt."
@@ -419,7 +419,7 @@ defmodule MingaEditor.Commands.Agent do
   # Sends the resolved content to the LLM and handles steering queue feedback.
   @spec deliver_prompt(state(), String.t() | [ReqLLM.Message.ContentPart.t()]) :: state()
   defp deliver_prompt(state, resolved) do
-    case Session.send_prompt(AgentAccess.session(state), resolved) do
+    case AgentSession.send_prompt_pid(AgentAccess.session(state), resolved) do
       :ok ->
         state
 

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -184,8 +184,7 @@ defmodule MingaEditor.Commands.AgentSession do
   end
 
   def send_prompt_pid(session, prompt) when is_pid(session) do
-    with {:ok, session_id} <- remote_session_id_for_pid(node(session), session),
-         {:ok, token} <- remote_session_token(node(session), session_id) do
+    with {:ok, session_id, token} <- remote_session_info_for_pid(node(session), session) do
       :erpc.call(
         node(session),
         MingaAgent.RemoteAPI,
@@ -206,8 +205,7 @@ defmodule MingaEditor.Commands.AgentSession do
   end
 
   def respond_to_approval_pid(session, decision) when is_pid(session) do
-    with {:ok, session_id} <- remote_session_id_for_pid(node(session), session),
-         {:ok, token} <- remote_session_token(node(session), session_id) do
+    with {:ok, session_id, token} <- remote_session_info_for_pid(node(session), session) do
       :erpc.call(
         node(session),
         MingaAgent.RemoteAPI,
@@ -229,8 +227,7 @@ defmodule MingaEditor.Commands.AgentSession do
   end
 
   def stop_session_pid(session) when is_pid(session) do
-    with {:ok, session_id} <- remote_session_id_for_pid(node(session), session),
-         {:ok, token} <- remote_session_token(node(session), session_id) do
+    with {:ok, session_id, token} <- remote_session_info_for_pid(node(session), session) do
       :erpc.call(node(session), MingaAgent.RemoteAPI, :stop_session, [session_id, token], 5_000)
     end
   catch
@@ -545,12 +542,13 @@ defmodule MingaEditor.Commands.AgentSession do
 
   defp stop_remote_session(state, _session), do: state
 
-  @spec remote_session_id_for_pid(node(), pid()) :: {:ok, String.t()} | {:error, term()}
-  defp remote_session_id_for_pid(remote_node, remote_pid) do
+  @spec remote_session_info_for_pid(node(), pid()) ::
+          {:ok, String.t(), String.t()} | {:error, term()}
+  defp remote_session_info_for_pid(remote_node, remote_pid) do
     case :erpc.call(remote_node, MingaAgent.RemoteAPI, :list_sessions, [], 5_000) do
       sessions when is_list(sessions) ->
         Enum.find_value(sessions, {:error, :not_found}, fn
-          %{session_id: session_id, pid: ^remote_pid} -> {:ok, session_id}
+          %{session_id: session_id, pid: ^remote_pid, token: token} -> {:ok, session_id, token}
           _session -> nil
         end)
 
@@ -563,21 +561,21 @@ defmodule MingaEditor.Commands.AgentSession do
 
   @spec stop_remote_session_by_id(node(), String.t()) :: :ok | {:error, term()}
   defp stop_remote_session_by_id(remote_node, session_id) do
-    with {:ok, token} <- remote_session_token(remote_node, session_id) do
-      :erpc.call(remote_node, MingaAgent.RemoteAPI, :stop_session, [session_id, token], 5_000)
-    end
-  catch
-    :exit, reason -> {:error, reason}
-  end
-
-  @spec remote_session_token(node(), String.t()) :: {:ok, String.t()} | {:error, term()}
-  defp remote_session_token(remote_node, session_id) do
     case :erpc.call(remote_node, MingaAgent.RemoteAPI, :list_sessions, [], 5_000) do
       sessions when is_list(sessions) ->
-        Enum.find_value(sessions, {:error, :not_found}, fn
-          %{session_id: ^session_id, token: token} -> {:ok, token}
-          _session -> nil
-        end)
+        case Enum.find(sessions, &(&1.session_id == session_id)) do
+          %{token: token} ->
+            :erpc.call(
+              remote_node,
+              MingaAgent.RemoteAPI,
+              :stop_session,
+              [session_id, token],
+              5_000
+            )
+
+          nil ->
+            {:error, :not_found}
+        end
 
       other ->
         {:error, other}

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -138,10 +138,11 @@ defmodule MingaEditor.Commands.AgentSession do
   end
 
   @doc "Connects the local GUI to an existing remote agent session."
-  @spec connect_remote_session(state(), String.t(), String.t(), pid()) :: state()
-  def connect_remote_session(state, server_name, session_id, remote_pid)
-      when is_binary(server_name) and is_binary(session_id) and is_pid(remote_pid) do
-    case subscribe_and_snapshot(remote_pid) do
+  @spec connect_remote_session(state(), String.t(), String.t(), pid(), String.t()) :: state()
+  def connect_remote_session(state, server_name, session_id, remote_pid, token)
+      when is_binary(server_name) and is_binary(session_id) and is_pid(remote_pid) and
+             is_binary(token) do
+    case remote_attach(remote_pid, session_id, token) do
       {:ok, messages, snapshot} ->
         {state, tab_id, buffer} = create_remote_agent_tab(state, server_name)
         AgentBufferSync.sync(buffer, messages)
@@ -175,6 +176,50 @@ defmodule MingaEditor.Commands.AgentSession do
     end
   end
 
+  @doc "Sends a prompt to a local or remote session, enforcing the remote broker boundary."
+  @spec send_prompt_pid(pid(), String.t() | [ReqLLM.Message.ContentPart.t()]) ::
+          :ok | {:queued, :steering} | {:error, term()}
+  def send_prompt_pid(session, prompt) when is_pid(session) and node(session) == node() do
+    Session.send_prompt(session, prompt)
+  end
+
+  def send_prompt_pid(session, prompt) when is_pid(session) do
+    with {:ok, session_id} <- remote_session_id_for_pid(node(session), session),
+         {:ok, token} <- remote_session_token(node(session), session_id) do
+      :erpc.call(
+        node(session),
+        MingaAgent.RemoteAPI,
+        :send_prompt,
+        [session_id, token, self(), prompt],
+        10_000
+      )
+    end
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  @doc "Responds to a tool approval on a local or remote session, enforcing the remote broker boundary."
+  @spec respond_to_approval_pid(pid(), Session.approval_decision()) :: :ok | {:error, term()}
+  def respond_to_approval_pid(session, decision)
+      when is_pid(session) and node(session) == node() do
+    Session.respond_to_approval(session, decision)
+  end
+
+  def respond_to_approval_pid(session, decision) when is_pid(session) do
+    with {:ok, session_id} <- remote_session_id_for_pid(node(session), session),
+         {:ok, token} <- remote_session_token(node(session), session_id) do
+      :erpc.call(
+        node(session),
+        MingaAgent.RemoteAPI,
+        :approve,
+        [session_id, token, self(), decision],
+        10_000
+      )
+    end
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
   @doc "Stops a session pid, routing remote pids to their owning node."
   @spec stop_session_pid(pid()) :: :ok | {:error, term()}
   def stop_session_pid(session) when is_pid(session) and node(session) == node() do
@@ -184,16 +229,9 @@ defmodule MingaEditor.Commands.AgentSession do
   end
 
   def stop_session_pid(session) when is_pid(session) do
-    case :erpc.call(
-           node(session),
-           MingaAgent.SessionManager,
-           :stop_session_by_pid,
-           [session],
-           5_000
-         ) do
-      :ok -> :ok
-      {:error, _reason} = error -> error
-      other -> {:error, other}
+    with {:ok, session_id} <- remote_session_id_for_pid(node(session), session),
+         {:ok, token} <- remote_session_token(node(session), session_id) do
+      :erpc.call(node(session), MingaAgent.RemoteAPI, :stop_session, [session_id, token], 5_000)
     end
   catch
     :exit, reason -> {:error, reason}
@@ -308,8 +346,8 @@ defmodule MingaEditor.Commands.AgentSession do
   @spec start_remote_session_on_node(state(), String.t(), node()) :: state()
   defp start_remote_session_on_node(state, server_name, remote_node) do
     case remote_start_session(remote_node, remote_session_opts(state)) do
-      {:ok, session_id, remote_pid} ->
-        connect_remote_session(state, server_name, session_id, remote_pid)
+      {:ok, session_id, remote_pid, token} ->
+        connect_remote_session(state, server_name, session_id, remote_pid, token)
 
       {:error, reason} ->
         EditorState.set_status(state, "Failed to start remote session: #{inspect(reason)}")
@@ -322,19 +360,32 @@ defmodule MingaEditor.Commands.AgentSession do
     [thinking_level: panel.thinking_level]
   end
 
-  @spec remote_start_session(node(), keyword()) :: {:ok, String.t(), pid()} | {:error, term()}
+  @spec remote_start_session(node(), keyword()) ::
+          {:ok, String.t(), pid(), String.t()} | {:error, term()}
   defp remote_start_session(remote_node, opts) do
-    :erpc.call(remote_node, MingaAgent.SessionManager, :start_session, [opts], 10_000)
+    case :erpc.call(remote_node, MingaAgent.RemoteAPI, :start_session, [opts], 10_000) do
+      {:ok, %{session_id: session_id, pid: pid, token: token}} -> {:ok, session_id, pid, token}
+      {:error, _reason} = error -> error
+      other -> {:error, other}
+    end
   catch
     :exit, reason -> {:error, {:remote_unavailable, reason}}
   end
 
-  @spec subscribe_and_snapshot(pid()) :: {:ok, [term()], map()} | {:error, term()}
-  defp subscribe_and_snapshot(remote_pid) do
-    Session.subscribe(remote_pid, self())
-    messages = Session.messages(remote_pid)
-    snapshot = Session.editor_snapshot(remote_pid)
-    {:ok, messages, snapshot}
+  @spec remote_attach(pid(), String.t(), String.t()) :: {:ok, [term()], map()} | {:error, term()}
+  defp remote_attach(remote_pid, session_id, token) do
+    case :erpc.call(
+           node(remote_pid),
+           MingaAgent.RemoteAPI,
+           :attach,
+           [session_id, token, self(), [role: :driver]],
+           10_000
+         ) do
+      {:ok, %{role: :driver, messages: messages, snapshot: snapshot}} -> {:ok, messages, snapshot}
+      {:ok, %{role: :viewer}} -> {:error, :not_driver}
+      {:error, _reason} = error -> error
+      other -> {:error, other}
+    end
   catch
     :exit, reason -> {:error, reason}
   end
@@ -476,13 +527,7 @@ defmodule MingaEditor.Commands.AgentSession do
   defp stop_remote_session(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, session) do
     case TabBar.find_by_session(tb, session) do
       %Tab{remote_session_id: session_id} when is_binary(session_id) ->
-        case :erpc.call(
-               node(session),
-               MingaAgent.SessionManager,
-               :stop_session,
-               [session_id],
-               5_000
-             ) do
+        case stop_remote_session_by_id(node(session), session_id) do
           :ok ->
             state
 
@@ -499,6 +544,47 @@ defmodule MingaEditor.Commands.AgentSession do
   end
 
   defp stop_remote_session(state, _session), do: state
+
+  @spec remote_session_id_for_pid(node(), pid()) :: {:ok, String.t()} | {:error, term()}
+  defp remote_session_id_for_pid(remote_node, remote_pid) do
+    case :erpc.call(remote_node, MingaAgent.RemoteAPI, :list_sessions, [], 5_000) do
+      sessions when is_list(sessions) ->
+        Enum.find_value(sessions, {:error, :not_found}, fn
+          %{session_id: session_id, pid: ^remote_pid} -> {:ok, session_id}
+          _session -> nil
+        end)
+
+      other ->
+        {:error, other}
+    end
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  @spec stop_remote_session_by_id(node(), String.t()) :: :ok | {:error, term()}
+  defp stop_remote_session_by_id(remote_node, session_id) do
+    with {:ok, token} <- remote_session_token(remote_node, session_id) do
+      :erpc.call(remote_node, MingaAgent.RemoteAPI, :stop_session, [session_id, token], 5_000)
+    end
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  @spec remote_session_token(node(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  defp remote_session_token(remote_node, session_id) do
+    case :erpc.call(remote_node, MingaAgent.RemoteAPI, :list_sessions, [], 5_000) do
+      sessions when is_list(sessions) ->
+        Enum.find_value(sessions, {:error, :not_found}, fn
+          %{session_id: ^session_id, token: token} -> {:ok, token}
+          _session -> nil
+        end)
+
+      other ->
+        {:error, other}
+    end
+  catch
+    :exit, reason -> {:error, reason}
+  end
 
   @spec buffer_name_for_language(String.t()) :: String.t()
   defp buffer_name_for_language(""), do: "*Agent: text*"

--- a/lib/minga_editor/commands/agent_sub_states.ex
+++ b/lib/minga_editor/commands/agent_sub_states.ex
@@ -16,6 +16,7 @@ defmodule MingaEditor.Commands.AgentSubStates do
   alias MingaEditor.Agent.View.Preview
   alias Minga.Buffer
   alias MingaEditor.Commands.Agent, as: AgentCommands
+  alias MingaEditor.Commands.AgentSession
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -279,7 +280,7 @@ defmodule MingaEditor.Commands.AgentSubStates do
     approval = agent.pending_approval
 
     if is_pid(session) and is_map(approval) do
-      Session.respond_to_approval(session, decision)
+      AgentSession.respond_to_approval_pid(session, decision)
       update_agent(state, &AgentState.clear_pending_approval/1)
     else
       state

--- a/lib/minga_editor/handlers/event_dispatcher.ex
+++ b/lib/minga_editor/handlers/event_dispatcher.ex
@@ -320,7 +320,11 @@ defmodule MingaEditor.Handlers.EventDispatcher do
 
   @spec discover_remote_sessions(node(), String.t()) :: [Remote.remote_session_entry()]
   defp discover_remote_sessions(remote_node, server_name) do
-    :erpc.call(remote_node, MingaAgent.SessionManager, :list_sessions, [], 5_000)
+    remote_node
+    |> remote_api_list_sessions()
+    |> Enum.map(fn %{session_id: session_id, pid: pid, metadata: metadata} ->
+      {session_id, pid, metadata}
+    end)
   catch
     :exit, reason ->
       Minga.Log.warning(
@@ -375,9 +379,19 @@ defmodule MingaEditor.Handlers.EventDispatcher do
 
   @spec remote_session_pid(node(), String.t()) :: {:ok, pid()} | {:error, term()}
   defp remote_session_pid(remote_node, session_id) do
-    :erpc.call(remote_node, MingaAgent.SessionManager, :get_session, [session_id], 5_000)
+    remote_node
+    |> remote_api_list_sessions()
+    |> Enum.find_value({:error, :not_found}, fn
+      %{session_id: ^session_id, pid: pid} -> {:ok, pid}
+      _session -> nil
+    end)
   catch
     :exit, reason -> {:error, {:remote_unavailable, reason}}
+  end
+
+  @spec remote_api_list_sessions(node()) :: [MingaAgent.RemoteAPI.session_info()]
+  defp remote_api_list_sessions(remote_node) do
+    :erpc.call(remote_node, MingaAgent.RemoteAPI, :list_sessions, [], 5_000)
   end
 
   @spec restore_remote_session_from_store(EditorState.t(), Workspace.t(), node(), String.t()) ::

--- a/lib/minga_editor/ui/picker/agent_session_source.ex
+++ b/lib/minga_editor/ui/picker/agent_session_source.ex
@@ -51,8 +51,8 @@ defmodule MingaEditor.UI.Picker.AgentSessionSource do
     EditorState.switch_tab(state, tab_id)
   end
 
-  def on_select(%Item{id: {_id, {:remote, server_name, session_id, remote_pid}}}, state) do
-    Agent.connect_remote_session(state, server_name, session_id, remote_pid)
+  def on_select(%Item{id: {_id, {:remote, server_name, session_id, remote_pid, token}}}, state) do
+    Agent.connect_remote_session(state, server_name, session_id, remote_pid, token)
   end
 
   def on_select(%Item{id: {session_id, :disk}}, state) do
@@ -113,7 +113,7 @@ defmodule MingaEditor.UI.Picker.AgentSessionSource do
 
   @spec remote_sessions_for_node({String.t(), node(), atom()}) :: [Item.t()]
   defp remote_sessions_for_node({server_name, remote_node, _status}) do
-    case :erpc.call(remote_node, MingaAgent.SessionManager, :list_sessions, [], 5_000) do
+    case :erpc.call(remote_node, MingaAgent.RemoteAPI, :list_sessions, [], 5_000) do
       sessions -> Enum.map(sessions, &remote_session_item(server_name, &1))
     end
   catch
@@ -126,10 +126,17 @@ defmodule MingaEditor.UI.Picker.AgentSessionSource do
       []
   end
 
-  @spec remote_session_item(String.t(), {String.t(), pid(), Session.metadata()}) :: Item.t()
-  defp remote_session_item(server_name, {session_id, remote_pid, meta}) do
+  @spec remote_session_item(String.t(), MingaAgent.RemoteAPI.session_info()) :: Item.t()
+  defp remote_session_item(server_name, %{
+         session_id: session_id,
+         pid: remote_pid,
+         token: token,
+         metadata: meta
+       }) do
     %Item{
-      id: {{:remote, server_name, session_id}, {:remote, server_name, session_id, remote_pid}},
+      id:
+        {{:remote, server_name, session_id},
+         {:remote, server_name, session_id, remote_pid, token}},
       label: "[#{server_name}] #{truncate_prompt(meta.title || meta.first_prompt || session_id)}",
       description: remote_description(meta),
       annotation: Atom.to_string(meta.status)

--- a/test/minga/distribution/remote_session_e2e_test.exs
+++ b/test/minga/distribution/remote_session_e2e_test.exs
@@ -18,8 +18,10 @@ defmodule Minga.Distribution.RemoteSessionE2ETest do
 
       mix test --include distributed test/minga/distribution/remote_session_e2e_test.exs
   """
+  # Boots real peer nodes and uses epmd, both global OS/distribution resources.
   use Minga.Test.DistributedCase, async: false
 
+  alias MingaAgent.RemoteAPI
   alias MingaAgent.Session
   alias MingaAgent.SessionManager
 
@@ -124,6 +126,43 @@ defmodule Minga.Distribution.RemoteSessionE2ETest do
     # ...and is still enumerable for a reconnecting GUI to find.
     sessions = :erpc.call(server, SessionManager, :list_sessions, [])
     assert Enum.any?(sessions, fn {id, pid, _meta} -> id == session_id and pid == remote_pid end)
+  end
+
+  test "brokered attach enforces one driver while viewers still receive events", %{server: server} do
+    {:ok, %{session_id: session_id, pid: remote_pid, token: token}} =
+      :erpc.call(server, RemoteAPI, :start_session, [[provider: @stub]])
+
+    assert {:ok, %{role: :driver}} =
+             :erpc.call(server, RemoteAPI, :attach, [session_id, token, self(), [role: :driver]])
+
+    test_pid = self()
+
+    viewer =
+      spawn(fn ->
+        :erpc.call(server, RemoteAPI, :attach, [session_id, token, self(), [role: :driver]])
+        send(test_pid, :viewer_attached)
+
+        receive do
+          {:agent_event, ^remote_pid, event} -> send(test_pid, {:viewer_event, event})
+          :stop -> :ok
+        end
+      end)
+
+    assert_receive :viewer_attached, 1_000
+
+    assert {:error, :not_driver} =
+             :erpc.call(server, RemoteAPI, :send_prompt, [
+               session_id,
+               token,
+               viewer,
+               "viewer prompt"
+             ])
+
+    Session.add_system_message(remote_pid, "event visible to all clients")
+    assert_receive {:agent_event, ^remote_pid, :messages_changed}, 2_000
+    assert_receive {:viewer_event, :messages_changed}, 2_000
+
+    Process.exit(viewer, :kill)
   end
 
   test "reattach after disconnect sees preserved state (AC4)", %{server: server} do

--- a/test/minga_agent/remote_api_test.exs
+++ b/test/minga_agent/remote_api_test.exs
@@ -1,0 +1,72 @@
+defmodule MingaAgent.RemoteAPITest do
+  # Uses the global MingaAgent.SessionManager broker boundary.
+  use ExUnit.Case, async: false
+
+  alias MingaAgent.RemoteAPI
+  alias MingaAgent.SessionManager
+
+  setup do
+    started = []
+
+    on_exit(fn ->
+      Enum.each(started, fn session_id -> SessionManager.stop_session(session_id) end)
+    end)
+
+    %{started: started}
+  end
+
+  test "start_session returns a broker token and rejects the wrong token", %{started: started} do
+    assert {:ok, %{session_id: session_id, pid: pid, token: token}} = RemoteAPI.start_session([])
+    started = [session_id | started]
+
+    assert is_pid(pid)
+    assert is_binary(token)
+    assert :ok = RemoteAPI.authorize(session_id, token)
+    assert {:error, :unauthorized} = RemoteAPI.authorize(session_id, "wrong-token")
+
+    Enum.each(started, fn id -> SessionManager.stop_session(id) end)
+  end
+
+  test "attach assigns one driver and refuses viewer mutations" do
+    assert {:ok, %{session_id: session_id, token: token}} = RemoteAPI.start_session([])
+    on_exit(fn -> SessionManager.stop_session(session_id) end)
+
+    driver = idle_process()
+    viewer = idle_process()
+
+    on_exit(fn ->
+      Process.exit(driver, :kill)
+      Process.exit(viewer, :kill)
+    end)
+
+    assert {:ok, %{role: :driver, messages: messages, snapshot: snapshot}} =
+             RemoteAPI.attach(session_id, token, driver, role: :driver)
+
+    assert is_list(messages)
+    assert is_map(snapshot)
+
+    assert {:ok, %{role: :viewer}} = RemoteAPI.attach(session_id, token, viewer, role: :driver)
+    assert {:error, :not_driver} = RemoteAPI.send_prompt(session_id, token, viewer, "not allowed")
+  end
+
+  test "start_or_get_for_workdir reuses the deterministic session" do
+    workdir = Path.join(System.tmp_dir!(), "remote-api-workdir")
+
+    assert {:ok, %{session_id: session_id, pid: pid}} =
+             RemoteAPI.start_or_get_for_workdir(workdir)
+
+    on_exit(fn -> SessionManager.stop_session(session_id) end)
+
+    assert {:ok, %{session_id: ^session_id, pid: ^pid}} =
+             RemoteAPI.start_or_get_for_workdir(workdir)
+  end
+
+  @spec idle_process() :: pid()
+  defp idle_process do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      end
+    end)
+  end
+end

--- a/test/minga_agent/remote_api_test.exs
+++ b/test/minga_agent/remote_api_test.exs
@@ -5,26 +5,14 @@ defmodule MingaAgent.RemoteAPITest do
   alias MingaAgent.RemoteAPI
   alias MingaAgent.SessionManager
 
-  setup do
-    started = []
-
-    on_exit(fn ->
-      Enum.each(started, fn session_id -> SessionManager.stop_session(session_id) end)
-    end)
-
-    %{started: started}
-  end
-
-  test "start_session returns a broker token and rejects the wrong token", %{started: started} do
+  test "start_session returns a broker token and rejects the wrong token" do
     assert {:ok, %{session_id: session_id, pid: pid, token: token}} = RemoteAPI.start_session([])
-    started = [session_id | started]
+    on_exit(fn -> SessionManager.stop_session(session_id) end)
 
     assert is_pid(pid)
     assert is_binary(token)
     assert :ok = RemoteAPI.authorize(session_id, token)
     assert {:error, :unauthorized} = RemoteAPI.authorize(session_id, "wrong-token")
-
-    Enum.each(started, fn id -> SessionManager.stop_session(id) end)
   end
 
   test "attach assigns one driver and refuses viewer mutations" do

--- a/test/minga_agent/session_manager_test.exs
+++ b/test/minga_agent/session_manager_test.exs
@@ -27,6 +27,62 @@ defmodule MingaAgent.SessionManagerTest do
       {:ok, "session-2", _pid2} = SessionManager.start_session(manager, [])
       {:ok, "session-3", _pid3} = SessionManager.start_session(manager, [])
     end
+
+    test "honors a supplied stable session id", %{manager: manager} do
+      assert {:ok, "workdir-stable", pid} =
+               SessionManager.start_session(manager, session_id: "workdir-stable")
+
+      assert {:ok, ^pid} = SessionManager.get_session(manager, "workdir-stable")
+    end
+
+    test "start_or_get_session reuses an existing stable session", %{manager: manager} do
+      assert {:ok, "workdir-stable", pid} =
+               SessionManager.start_or_get_session(manager, "workdir-stable", [])
+
+      assert {:ok, "workdir-stable", ^pid} =
+               SessionManager.start_or_get_session(manager, "workdir-stable", [])
+    end
+
+    test "stable_session_id_for_workdir is deterministic" do
+      id = SessionManager.stable_session_id_for_workdir("/tmp/my-project")
+      assert id == SessionManager.stable_session_id_for_workdir("/tmp/my-project")
+      assert String.starts_with?(id, "workdir-")
+    end
+
+    test "mints a token for brokered remote control", %{manager: manager} do
+      {:ok, session_id, _pid} = SessionManager.start_session(manager, [])
+      assert {:ok, token} = SessionManager.session_token(manager, session_id)
+      assert is_binary(token)
+      assert byte_size(token) > 20
+    end
+
+    test "reuses a persisted remote token for a stable session", %{manager: manager} do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "session-manager-token-#{System.unique_integer([:positive])}"
+        )
+
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      :ok =
+        MingaAgent.SessionStore.save(
+          %{
+            id: "workdir-stable",
+            remote_token: "persisted-token",
+            timestamp: DateTime.to_iso8601(DateTime.utc_now()),
+            model_name: "test",
+            messages: [],
+            usage: MingaAgent.TurnUsage.new()
+          },
+          dir
+        )
+
+      {:ok, "workdir-stable", _pid} =
+        SessionManager.start_or_get_session(manager, "workdir-stable", session_store_dir: dir)
+
+      assert {:ok, "persisted-token"} = SessionManager.session_token(manager, "workdir-stable")
+    end
   end
 
   describe "stop_session/2" do

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -351,6 +351,15 @@ defmodule MingaAgent.SessionTest do
     %{session: session}
   end
 
+  @spec idle_process() :: pid()
+  defp idle_process do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      end
+    end)
+  end
+
   describe "initial state" do
     test "starts idle with a system message and zero usage", %{session: session} do
       assert Session.status(session) == :idle
@@ -361,6 +370,45 @@ defmodule MingaAgent.SessionTest do
       assert usage.input == 0
       assert usage.output == 0
       assert usage.cost == 0.0
+    end
+  end
+
+  describe "remote attachment roles" do
+    test "first subscriber is driver and later subscribers are viewers", %{session: session} do
+      viewer = idle_process()
+      on_exit(fn -> Process.exit(viewer, :kill) end)
+
+      assert Session.subscriber_role(session, self()) == :driver
+      assert :ok = Session.subscribe(session, viewer)
+      assert Session.subscriber_role(session, viewer) == :viewer
+    end
+
+    test "viewer cannot send prompts while driver can", %{session: session} do
+      viewer = idle_process()
+      on_exit(fn -> Process.exit(viewer, :kill) end)
+
+      assert :ok = Session.subscribe(session, viewer, role: :viewer)
+      assert {:error, :not_driver} = Session.send_prompt_as(session, viewer, "nope")
+    end
+
+    test "driver role is vacated when the driver process dies" do
+      {:ok, session} = Session.start_link(provider: MockProvider, provider_opts: [])
+      driver = idle_process()
+      viewer = idle_process()
+
+      on_exit(fn ->
+        Process.exit(driver, :kill)
+        Process.exit(viewer, :kill)
+      end)
+
+      assert :ok = Session.subscribe(session, driver, role: :driver)
+      assert :ok = Session.subscribe(session, viewer, role: :viewer)
+
+      Process.exit(driver, :kill)
+      :sys.get_state(session)
+
+      assert :ok = Session.claim_driver(session, viewer)
+      assert Session.subscriber_role(session, viewer) == :driver
     end
   end
 


### PR DESCRIPTION
# TL;DR
Remote agent sessions now have stable identities and a brokered control boundary. Remote editor flows go through `MingaAgent.RemoteAPI`, with per-session tokens and driver/viewer role enforcement.

Closes #2053

## Context
This is the first implementation slice for the detachable-agent-sessions epic (#955). It gives later durable replay, reconnect, daemon, attach, and headless-auth work a stable session name and a fixed remote control surface instead of raw remote PID calls into internals.

## Changes
- Added `MingaAgent.RemoteAPI` as the brokered remote session API for start, stable workdir start-or-get, list, attach, prompt, approval, and stop operations.
- Added `SessionInfo` and `AttachResult` structs for broker payloads so cross-module return shapes are explicit.
- Added per-session remote control tokens, persisted through `SessionStore`, and checked by broker mutations.
- Added deterministic workdir session IDs through `SessionManager.stable_session_id_for_workdir/1` and `start_or_get_session/3`, including safe reuse when the same logical session already exists.
- Added driver/viewer attachment roles in `MingaAgent.Session`: one driver may mutate, viewers are read-only, and the driver role is released when the driver process exits.
- Moved editor remote session control, picker discovery, and event-dispatcher paths to call the broker API instead of raw `:erpc` into `SessionManager` or `Session`.
- Extended distributed and unit coverage for broker authorization, stable identity, token reuse, driver/viewer enforcement, and live viewer events.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.debug test/minga_editor/merge_conflict/render_test.exs:88 test/minga_agent/remote_api_test.exs test/minga/distribution/remote_session_e2e_test.exs`
- `make lint`
- `mix test.llm` (56 doctests, 91 properties, 9092 tests, 0 failures, 292 excluded)
- `git diff --check`
- Final reviewer gate: PASS after targeted re-review of prior blockers

## Acceptance Criteria Addressed
- Stable session identity survives reconnect/restart paths via explicit stable IDs, deterministic workdir IDs, and persisted token reuse ✅
- Remote clients control sessions through `MingaAgent.RemoteAPI`; editor remote control paths no longer call raw remote internals ✅
- Broker requires a per-session token and documents the Erlang cookie versus broker-token trust model ✅
- Multiple clients can attach with exactly one driver; viewers are read-only and driver handoff after `:DOWN` is defined ✅
- Viewers still receive live session history and events while mutation remains gated ✅
