### PR TITLE
feat(agent): persist session event log

### DIFF
--- a/lib/minga/services/independent.ex
+++ b/lib/minga/services/independent.ex
@@ -17,7 +17,8 @@ defmodule Minga.Services.Independent do
       ├── Minga.Command.Registry         Named command lookup
       ├── Minga.Editing.Fold.Registry            Fold state
       ├── Minga.Diagnostics              ETS-backed diagnostics store
-      ├── Minga.Session.EventRecorder            Persistent event log (SQLite via exqlite)
+      ├── Minga.Session.EventRecorder            Persistent editor event log (SQLite via exqlite)
+      ├── MingaAgent.EventLog                    Persistent agent session event log
       └── Minga.Tool.Manager             Tool install/uninstall manager
   """
 
@@ -43,6 +44,7 @@ defmodule Minga.Services.Independent do
       Minga.Distribution.ConnectionManager,
       Minga.Diagnostics,
       Minga.Session.EventRecorder,
+      MingaAgent.EventLog,
       Minga.Tool.Manager
     ]
 

--- a/lib/minga_agent/event_log.ex
+++ b/lib/minga_agent/event_log.ex
@@ -1,0 +1,252 @@
+defmodule MingaAgent.EventLog do
+  @moduledoc """
+  Durable append-only event log for agent sessions.
+
+  Agent sessions call `record/3`, which is a cast to this writer process, so session execution never waits on SQLite I/O. Readers open their own connections through `open_read_connection/1` and query by cursor with `events_after/4`; WAL mode lets those reads proceed without blocking the writer.
+  """
+
+  use GenServer
+
+  alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.EventLog.Store
+
+  @default_db_dir Path.expand("~/.local/share/minga")
+  @db_filename "agent_events.db"
+  @retention_sweep_interval_ms :timer.hours(1)
+  @initial_retention_sweep_delay_ms :timer.seconds(5)
+  @health_check_delay_ms :timer.seconds(10)
+  @default_health_check :quick
+
+  defmodule State do
+    @moduledoc false
+    @enforce_keys [:db, :path, :retention_days]
+    defstruct [:db, :path, :retention_days, :sweep_ref]
+
+    @type t :: %__MODULE__{
+            db: Store.db(),
+            path: String.t(),
+            retention_days: pos_integer(),
+            sweep_ref: reference() | nil
+          }
+  end
+
+  @doc "Starts the event log writer."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc "Returns the configured event-log database path."
+  @spec db_path(keyword()) :: String.t()
+  def db_path(opts \\ []) do
+    dir = Keyword.get(opts, :db_dir, @default_db_dir)
+    Path.join(dir, @db_filename)
+  end
+
+  @doc "Opens a read connection to the agent event database."
+  @spec open_read_connection(keyword()) :: {:ok, Store.db()} | {:error, term()}
+  def open_read_connection(opts \\ []) do
+    path = db_path(opts)
+
+    if File.exists?(path) do
+      Store.open(path)
+    else
+      {:error, :database_not_found}
+    end
+  end
+
+  @doc "Records an agent event asynchronously."
+  @spec record(String.t(), EventRecord.event_type(), map(), GenServer.server()) :: :ok
+  def record(session_id, event_type, payload \\ %{}, server \\ __MODULE__)
+      when is_binary(session_id) and is_atom(event_type) and is_map(payload) do
+    GenServer.cast(server, {:record, session_id, event_type, sanitize_payload(payload)})
+  catch
+    :exit, _ -> :ok
+  end
+
+  @doc "Queries events for a session after the given cursor."
+  @spec events_after(Store.db(), String.t(), non_neg_integer(), pos_integer()) ::
+          {:ok, [EventRecord.t()]} | {:error, term()}
+  defdelegate events_after(db, session_id, last_id, limit \\ 1000), to: Store
+
+  @impl true
+  @spec init(keyword()) :: {:ok, State.t()} | {:stop, term()}
+  def init(opts) do
+    path = db_path(opts)
+
+    retention_days =
+      Keyword.get_lazy(opts, :retention_days, fn -> Minga.Config.get(:event_retention_days) end)
+
+    case open_or_recreate(path) do
+      {:ok, db} ->
+        sweep_ref = schedule_initial_retention_sweep(opts)
+        schedule_health_check(Keyword.get(opts, :health_check, @default_health_check), opts)
+        Minga.Log.info(:agent, "[AgentEventLog] started, logging to #{path}")
+        {:ok, %State{db: db, path: path, retention_days: retention_days, sweep_ref: sweep_ref}}
+
+      {:error, reason} ->
+        Minga.Log.warning(:agent, "[AgentEventLog] failed to open database: #{inspect(reason)}")
+        {:stop, reason}
+    end
+  end
+
+  @impl true
+  def handle_cast({:record, session_id, event_type, payload}, state) do
+    record = EventRecord.new(session_id, event_type, payload)
+
+    case Store.insert(state.db, record) do
+      {:ok, _id} ->
+        :ok
+
+      {:error, reason} ->
+        Minga.Log.warning(:agent, "[AgentEventLog] failed to write event: #{inspect(reason)}")
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:retention_sweep, state) do
+    cutoff = DateTime.add(DateTime.utc_now(), -state.retention_days, :day)
+
+    case Store.delete_before(state.db, cutoff) do
+      {:ok, 0} ->
+        :ok
+
+      {:ok, count} ->
+        Minga.Log.info(:agent, "[AgentEventLog] retention sweep deleted #{count} events")
+
+      {:error, reason} ->
+        Minga.Log.warning(:agent, "[AgentEventLog] retention sweep failed: #{inspect(reason)}")
+    end
+
+    {:noreply, %{state | sweep_ref: schedule_retention_sweep()}}
+  end
+
+  def handle_info({:health_check_result, result}, state) do
+    handle_health_check_result(result, state)
+  end
+
+  def handle_info({:run_health_check, parent, path, mode}, state) do
+    Task.start(fn -> send(parent, {:health_check_result, run_health_check(path, mode)}) end)
+    {:noreply, state}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    Store.close(state.db)
+    :ok
+  end
+
+  @spec open_or_recreate(String.t()) :: {:ok, Store.db()} | {:error, term()}
+  defp open_or_recreate(path) do
+    case Store.open(path) do
+      {:ok, db} -> {:ok, db}
+      {:error, _reason} -> recreate_database(path)
+    end
+  end
+
+  @spec recreate_database(String.t()) :: {:ok, Store.db()} | {:error, term()}
+  defp recreate_database(path) do
+    _ = File.rm(path)
+    _ = File.rm(path <> "-wal")
+    _ = File.rm(path <> "-shm")
+    Store.open(path)
+  end
+
+  @spec schedule_initial_retention_sweep(keyword()) :: reference() | nil
+  defp schedule_initial_retention_sweep(opts) do
+    if Keyword.get(opts, :retention_sweep?, true) do
+      Process.send_after(self(), :retention_sweep, @initial_retention_sweep_delay_ms)
+    end
+  end
+
+  @spec schedule_retention_sweep() :: reference()
+  defp schedule_retention_sweep do
+    Process.send_after(self(), :retention_sweep, @retention_sweep_interval_ms)
+  end
+
+  @spec schedule_health_check(:none | :quick | :full, keyword()) :: :ok
+  defp schedule_health_check(:none, _opts), do: :ok
+
+  defp schedule_health_check(mode, opts) when mode in [:quick, :full] do
+    parent = self()
+    path = db_path(opts)
+
+    Process.send_after(
+      self(),
+      {:run_health_check, parent, path, mode},
+      Keyword.get(opts, :health_check_delay_ms, @health_check_delay_ms)
+    )
+
+    :ok
+  end
+
+  @spec run_health_check(String.t(), :quick | :full) :: :ok | {:error, term()}
+  defp run_health_check(path, mode) do
+    with {:ok, db} <- Store.open(path),
+         result <- Store.integrity_check(db, mode),
+         :ok <- Store.close(db) do
+      case result do
+        {:ok, :healthy} -> :ok
+        {:error, messages} -> {:error, {:corrupt, messages}}
+      end
+    end
+  end
+
+  @spec handle_health_check_result(:ok | {:error, term()}, State.t()) :: {:noreply, State.t()}
+  defp handle_health_check_result(:ok, state), do: {:noreply, state}
+
+  defp handle_health_check_result({:error, reason}, state) do
+    Minga.Log.warning(:agent, "[AgentEventLog] health check failed: #{inspect(reason)}")
+    {:noreply, state}
+  end
+
+  @secret_keys MapSet.new(
+                 ~w(api_key apikey token access_token refresh_token secret password credential credentials authorization remote_token)
+               )
+
+  @spec sanitize_payload(term()) :: term()
+  defp sanitize_payload(%_{} = struct), do: sanitize_payload(Map.from_struct(struct))
+
+  defp sanitize_payload(map) when is_map(map) do
+    Map.new(map, fn {key, value} ->
+      string_key = to_string(key)
+      sanitized = if secret_key?(string_key), do: "[REDACTED]", else: sanitize_payload(value)
+      {string_key, sanitized}
+    end)
+  end
+
+  defp sanitize_payload(list) when is_list(list), do: Enum.map(list, &sanitize_payload/1)
+  defp sanitize_payload(pid) when is_pid(pid), do: "[PID]"
+  defp sanitize_payload(ref) when is_reference(ref), do: "[REFERENCE]"
+  defp sanitize_payload(boolean) when is_boolean(boolean), do: boolean
+  defp sanitize_payload(nil), do: nil
+  defp sanitize_payload(atom) when is_atom(atom), do: Atom.to_string(atom)
+  defp sanitize_payload(binary) when is_binary(binary), do: binary
+  defp sanitize_payload(number) when is_number(number), do: number
+  defp sanitize_payload(other), do: inspect(other)
+
+  @spec secret_key?(String.t()) :: boolean()
+  defp secret_key?(key) do
+    normalized = normalize_secret_key(key)
+
+    MapSet.member?(@secret_keys, normalized) or
+      String.ends_with?(normalized, "_token") or
+      String.ends_with?(normalized, "_secret") or
+      String.contains?(normalized, "api_key") or
+      String.contains?(normalized, "password") or
+      String.contains?(normalized, "credential") or
+      String.contains?(normalized, "authorization")
+  end
+
+  @spec normalize_secret_key(String.t()) :: String.t()
+  defp normalize_secret_key(key) do
+    key
+    |> Macro.underscore()
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "_")
+    |> String.trim("_")
+  end
+end

--- a/lib/minga_agent/event_log.ex
+++ b/lib/minga_agent/event_log.ex
@@ -142,8 +142,33 @@ defmodule MingaAgent.EventLog do
   @spec open_or_recreate(String.t()) :: {:ok, Store.db()} | {:error, term()}
   defp open_or_recreate(path) do
     case Store.open(path) do
-      {:ok, db} -> {:ok, db}
-      {:error, _reason} -> recreate_database(path)
+      {:ok, db} ->
+        {:ok, db}
+
+      {:error, reason} ->
+        if File.exists?(path) and corrupt?(path) do
+          Minga.Log.warning(
+            :agent,
+            "[AgentEventLog] corrupt database, recreating: #{inspect(reason)}"
+          )
+
+          recreate_database(path)
+        else
+          {:error, reason}
+        end
+    end
+  end
+
+  @spec corrupt?(String.t()) :: boolean()
+  defp corrupt?(path) do
+    case Exqlite.Sqlite3.open(path) do
+      {:ok, db} ->
+        result = Store.integrity_check(db, :quick)
+        Store.close(db)
+        match?({:error, _}, result)
+
+      {:error, _} ->
+        false
     end
   end
 

--- a/lib/minga_agent/event_log/event_record.ex
+++ b/lib/minga_agent/event_log/event_record.ex
@@ -1,0 +1,50 @@
+defmodule MingaAgent.EventLog.EventRecord do
+  @moduledoc "A durable, replay-safe agent session event."
+
+  @enforce_keys [:session_id, :event_type, :payload, :wall_clock, :monotonic_ts]
+  defstruct [:id, :session_id, :event_type, :payload, :wall_clock, :monotonic_ts]
+
+  @type event_type ::
+          :session_started
+          | :session_stopped
+          | :user_message
+          | :assistant_delta
+          | :thinking_delta
+          | :tool_call_started
+          | :tool_call_updated
+          | :tool_call_finished
+          | :file_edit_proposed
+          | :approval_requested
+          | :approval_resolved
+          | :system_message
+          | :status_changed
+          | :waiting_for_input
+          | :prompt_queued
+          | :message_changed
+          | :error
+          | :context_usage
+          | :turn_limit_reached
+          | :driver_changed
+
+  @type t :: %__MODULE__{
+          id: non_neg_integer() | nil,
+          session_id: String.t(),
+          event_type: event_type(),
+          payload: map(),
+          wall_clock: DateTime.t(),
+          monotonic_ts: integer()
+        }
+
+  @doc "Creates a new event record."
+  @spec new(String.t(), event_type(), map(), keyword()) :: t()
+  def new(session_id, event_type, payload, opts \\ [])
+      when is_binary(session_id) and is_atom(event_type) and is_map(payload) do
+    %__MODULE__{
+      session_id: session_id,
+      event_type: event_type,
+      payload: payload,
+      wall_clock: Keyword.get_lazy(opts, :wall_clock, &DateTime.utc_now/0),
+      monotonic_ts: Keyword.get_lazy(opts, :monotonic_ts, &System.monotonic_time/0)
+    }
+  end
+end

--- a/lib/minga_agent/event_log/store.ex
+++ b/lib/minga_agent/event_log/store.ex
@@ -1,0 +1,253 @@
+defmodule MingaAgent.EventLog.Store do
+  @moduledoc "SQLite storage backend for durable agent session events."
+
+  alias MingaAgent.EventLog.EventRecord
+
+  @type db :: Exqlite.Sqlite3.db()
+
+  @schema_version 1
+
+  @doc "Opens or creates the agent event database."
+  @spec open(String.t()) :: {:ok, db()} | {:error, term()}
+  def open(db_path) do
+    File.mkdir_p!(Path.dirname(db_path))
+
+    case Exqlite.Sqlite3.open(db_path) do
+      {:ok, db} -> setup_opened(db)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Opens an in-memory database for tests."
+  @spec open_memory() :: {:ok, db()} | {:error, term()}
+  def open_memory do
+    case Exqlite.Sqlite3.open(":memory:") do
+      {:ok, db} -> setup_opened(db)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Closes the database connection."
+  @spec close(db()) :: :ok | {:error, term()}
+  def close(db), do: Exqlite.Sqlite3.close(db)
+
+  @doc "Inserts an append-only event record."
+  @spec insert(db(), EventRecord.t()) :: {:ok, pos_integer()} | {:error, term()}
+  def insert(db, %EventRecord{} = record) do
+    sql = """
+    INSERT INTO events (session_id, event_type, payload, wall_clock, monotonic_ts)
+    VALUES (?1, ?2, ?3, ?4, ?5)
+    """
+
+    params = [
+      record.session_id,
+      Atom.to_string(record.event_type),
+      JSON.encode!(record.payload),
+      DateTime.to_iso8601(record.wall_clock),
+      record.monotonic_ts
+    ]
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         :ok <- Exqlite.Sqlite3.bind(stmt, params),
+         :done <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt),
+         {:ok, id} <- last_insert_rowid(db) do
+      {:ok, id}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Returns all events for a session with id greater than the cursor, ordered by id."
+  @spec events_after(db(), String.t(), non_neg_integer(), pos_integer()) ::
+          {:ok, [EventRecord.t()]} | {:error, term()}
+  def events_after(db, session_id, last_id, limit \\ 1000)
+      when is_binary(session_id) and is_integer(last_id) and last_id >= 0 and is_integer(limit) and
+             limit > 0 do
+    sql = """
+    SELECT id, session_id, event_type, payload, wall_clock, monotonic_ts
+    FROM events
+    WHERE session_id = ?1 AND id > ?2
+    ORDER BY id ASC
+    LIMIT ?3
+    """
+
+    query_events(db, sql, [session_id, last_id, limit])
+  end
+
+  @doc "Returns the total number of agent events."
+  @spec count(db()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def count(db) do
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, "SELECT COUNT(*) FROM events"),
+         {:row, [count]} <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      {:ok, count}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Deletes events older than the given wall-clock time."
+  @spec delete_before(db(), DateTime.t()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def delete_before(db, cutoff) do
+    sql = "DELETE FROM events WHERE wall_clock < ?1"
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [DateTime.to_iso8601(cutoff)]),
+         :done <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      {:ok, changes(db)}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Runs a SQLite integrity check."
+  @spec integrity_check(db(), :full | :quick) :: {:ok, :healthy} | {:error, [String.t()]}
+  def integrity_check(db, mode \\ :quick) do
+    sql = if mode == :full, do: "PRAGMA integrity_check", else: "PRAGMA quick_check"
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql) do
+      rows = collect_rows(db, stmt)
+      Exqlite.Sqlite3.release(db, stmt)
+
+      case rows do
+        [["ok"]] -> {:ok, :healthy}
+        other -> {:error, List.flatten(other)}
+      end
+    end
+  end
+
+  @spec setup_opened(db()) :: {:ok, db()} | {:error, term()}
+  defp setup_opened(db) do
+    case setup(db) do
+      :ok -> {:ok, db}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec setup(db()) :: :ok | {:error, term()}
+  defp setup(db) do
+    statements = [
+      "PRAGMA journal_mode=WAL",
+      "PRAGMA synchronous=NORMAL",
+      "PRAGMA cache_size=-8000",
+      "PRAGMA foreign_keys=ON",
+      """
+      CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        payload TEXT NOT NULL DEFAULT '{}',
+        wall_clock TEXT NOT NULL,
+        monotonic_ts INTEGER NOT NULL
+      )
+      """,
+      "CREATE INDEX IF NOT EXISTS idx_agent_events_session_id_id ON events(session_id, id)",
+      "CREATE INDEX IF NOT EXISTS idx_agent_events_event_type ON events(event_type)",
+      "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)"
+    ]
+
+    with :ok <- execute_all(db, statements), do: ensure_schema_version(db)
+  end
+
+  @spec ensure_schema_version(db()) :: :ok | {:error, term()}
+  defp ensure_schema_version(db) do
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, "SELECT version FROM schema_version LIMIT 1") do
+      result = Exqlite.Sqlite3.step(db, stmt)
+      Exqlite.Sqlite3.release(db, stmt)
+
+      case result do
+        :done -> execute(db, "INSERT INTO schema_version (version) VALUES (#{@schema_version})")
+        {:row, [@schema_version]} -> :ok
+        {:row, [_old_version]} -> :ok
+      end
+    end
+  end
+
+  @spec execute_all(db(), [String.t()]) :: :ok | {:error, term()}
+  defp execute_all(db, statements) do
+    Enum.reduce_while(statements, :ok, fn statement, :ok ->
+      case execute(db, statement) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  @spec execute(db(), String.t()) :: :ok | {:error, term()}
+  defp execute(db, sql) do
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         :done <- step_until_done(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec step_until_done(db(), Exqlite.Sqlite3.statement()) :: :done | {:error, term()}
+  defp step_until_done(db, stmt) do
+    case Exqlite.Sqlite3.step(db, stmt) do
+      :done -> :done
+      {:row, _row} -> step_until_done(db, stmt)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec query_events(db(), String.t(), [term()]) :: {:ok, [EventRecord.t()]} | {:error, term()}
+  defp query_events(db, sql, params) do
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         :ok <- Exqlite.Sqlite3.bind(stmt, params) do
+      rows = collect_rows(db, stmt)
+      Exqlite.Sqlite3.release(db, stmt)
+      {:ok, Enum.map(rows, &row_to_record/1)}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec collect_rows(db(), Exqlite.Sqlite3.statement()) :: [list()]
+  defp collect_rows(db, stmt) do
+    case Exqlite.Sqlite3.step(db, stmt) do
+      {:row, row} -> [row | collect_rows(db, stmt)]
+      :done -> []
+    end
+  end
+
+  @spec row_to_record([term()]) :: EventRecord.t()
+  defp row_to_record([id, session_id, event_type, payload_json, wall_clock_iso, monotonic_ts]) do
+    {:ok, wall_clock, _offset} = DateTime.from_iso8601(wall_clock_iso)
+
+    %EventRecord{
+      id: id,
+      session_id: session_id,
+      event_type: String.to_existing_atom(event_type),
+      payload: JSON.decode!(payload_json),
+      wall_clock: wall_clock,
+      monotonic_ts: monotonic_ts
+    }
+  end
+
+  @spec last_insert_rowid(db()) :: {:ok, pos_integer()} | {:error, term()}
+  defp last_insert_rowid(db) do
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, "SELECT last_insert_rowid()"),
+         {:row, [id]} <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      {:ok, id}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec changes(db()) :: non_neg_integer()
+  defp changes(db) do
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, "SELECT changes()"),
+         {:row, [count]} <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      count
+    else
+      _ -> 0
+    end
+  end
+end

--- a/lib/minga_agent/event_log/store.ex
+++ b/lib/minga_agent/event_log/store.ex
@@ -2,6 +2,7 @@ defmodule MingaAgent.EventLog.Store do
   @moduledoc "SQLite storage backend for durable agent session events."
 
   alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.EventLog.Taxonomy
 
   @type db :: Exqlite.Sqlite3.db()
 
@@ -47,14 +48,23 @@ defmodule MingaAgent.EventLog.Store do
       record.monotonic_ts
     ]
 
-    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
-         :ok <- Exqlite.Sqlite3.bind(stmt, params),
-         :done <- Exqlite.Sqlite3.step(db, stmt),
-         :ok <- Exqlite.Sqlite3.release(db, stmt),
-         {:ok, id} <- last_insert_rowid(db) do
-      {:ok, id}
-    else
-      {:error, reason} -> {:error, reason}
+    case Exqlite.Sqlite3.prepare(db, sql) do
+      {:ok, stmt} ->
+        result =
+          with :ok <- Exqlite.Sqlite3.bind(stmt, params),
+               :done <- Exqlite.Sqlite3.step(db, stmt) do
+            :ok
+          end
+
+        Exqlite.Sqlite3.release(db, stmt)
+
+        case result do
+          :ok -> last_insert_rowid(db)
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -78,12 +88,19 @@ defmodule MingaAgent.EventLog.Store do
   @doc "Returns the total number of agent events."
   @spec count(db()) :: {:ok, non_neg_integer()} | {:error, term()}
   def count(db) do
-    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, "SELECT COUNT(*) FROM events"),
-         {:row, [count]} <- Exqlite.Sqlite3.step(db, stmt),
-         :ok <- Exqlite.Sqlite3.release(db, stmt) do
-      {:ok, count}
-    else
-      {:error, reason} -> {:error, reason}
+    case Exqlite.Sqlite3.prepare(db, "SELECT COUNT(*) FROM events") do
+      {:ok, stmt} ->
+        result = Exqlite.Sqlite3.step(db, stmt)
+        Exqlite.Sqlite3.release(db, stmt)
+
+        case result do
+          {:row, [count]} -> {:ok, count}
+          {:error, reason} -> {:error, reason}
+          other -> {:error, {:unexpected_result, other}}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -92,13 +109,23 @@ defmodule MingaAgent.EventLog.Store do
   def delete_before(db, cutoff) do
     sql = "DELETE FROM events WHERE wall_clock < ?1"
 
-    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
-         :ok <- Exqlite.Sqlite3.bind(stmt, [DateTime.to_iso8601(cutoff)]),
-         :done <- Exqlite.Sqlite3.step(db, stmt),
-         :ok <- Exqlite.Sqlite3.release(db, stmt) do
-      {:ok, changes(db)}
-    else
-      {:error, reason} -> {:error, reason}
+    case Exqlite.Sqlite3.prepare(db, sql) do
+      {:ok, stmt} ->
+        result =
+          with :ok <- Exqlite.Sqlite3.bind(stmt, [DateTime.to_iso8601(cutoff)]),
+               :done <- Exqlite.Sqlite3.step(db, stmt) do
+            :ok
+          end
+
+        Exqlite.Sqlite3.release(db, stmt)
+
+        case result do
+          :ok -> changes(db)
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -177,12 +204,18 @@ defmodule MingaAgent.EventLog.Store do
 
   @spec execute(db(), String.t()) :: :ok | {:error, term()}
   defp execute(db, sql) do
-    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
-         :done <- step_until_done(db, stmt),
-         :ok <- Exqlite.Sqlite3.release(db, stmt) do
-      :ok
-    else
-      {:error, reason} -> {:error, reason}
+    case Exqlite.Sqlite3.prepare(db, sql) do
+      {:ok, stmt} ->
+        result = step_until_done(db, stmt)
+        Exqlite.Sqlite3.release(db, stmt)
+
+        case result do
+          :done -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -197,13 +230,23 @@ defmodule MingaAgent.EventLog.Store do
 
   @spec query_events(db(), String.t(), [term()]) :: {:ok, [EventRecord.t()]} | {:error, term()}
   defp query_events(db, sql, params) do
-    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
-         :ok <- Exqlite.Sqlite3.bind(stmt, params) do
-      rows = collect_rows(db, stmt)
-      Exqlite.Sqlite3.release(db, stmt)
-      {:ok, Enum.map(rows, &row_to_record/1)}
-    else
-      {:error, reason} -> {:error, reason}
+    case Exqlite.Sqlite3.prepare(db, sql) do
+      {:ok, stmt} ->
+        result =
+          case Exqlite.Sqlite3.bind(stmt, params) do
+            :ok -> {:ok, collect_rows(db, stmt)}
+            {:error, reason} -> {:error, reason}
+          end
+
+        Exqlite.Sqlite3.release(db, stmt)
+
+        case result do
+          {:ok, rows} -> {:ok, rows |> Enum.map(&row_to_record/1) |> Enum.reject(&is_nil/1)}
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -215,39 +258,59 @@ defmodule MingaAgent.EventLog.Store do
     end
   end
 
-  @spec row_to_record([term()]) :: EventRecord.t()
+  @spec row_to_record([term()]) :: EventRecord.t() | nil
   defp row_to_record([id, session_id, event_type, payload_json, wall_clock_iso, monotonic_ts]) do
-    {:ok, wall_clock, _offset} = DateTime.from_iso8601(wall_clock_iso)
+    case Taxonomy.from_string(event_type) do
+      {:ok, atom_type} ->
+        {:ok, wall_clock, _offset} = DateTime.from_iso8601(wall_clock_iso)
 
-    %EventRecord{
-      id: id,
-      session_id: session_id,
-      event_type: String.to_existing_atom(event_type),
-      payload: JSON.decode!(payload_json),
-      wall_clock: wall_clock,
-      monotonic_ts: monotonic_ts
-    }
+        %EventRecord{
+          id: id,
+          session_id: session_id,
+          event_type: atom_type,
+          payload: JSON.decode!(payload_json),
+          wall_clock: wall_clock,
+          monotonic_ts: monotonic_ts
+        }
+
+      :error ->
+        nil
+    end
   end
 
   @spec last_insert_rowid(db()) :: {:ok, pos_integer()} | {:error, term()}
   defp last_insert_rowid(db) do
-    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, "SELECT last_insert_rowid()"),
-         {:row, [id]} <- Exqlite.Sqlite3.step(db, stmt),
-         :ok <- Exqlite.Sqlite3.release(db, stmt) do
-      {:ok, id}
-    else
-      {:error, reason} -> {:error, reason}
+    case Exqlite.Sqlite3.prepare(db, "SELECT last_insert_rowid()") do
+      {:ok, stmt} ->
+        result = Exqlite.Sqlite3.step(db, stmt)
+        Exqlite.Sqlite3.release(db, stmt)
+
+        case result do
+          {:row, [id]} -> {:ok, id}
+          {:error, reason} -> {:error, reason}
+          other -> {:error, {:unexpected_result, other}}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  @spec changes(db()) :: non_neg_integer()
+  @spec changes(db()) :: {:ok, non_neg_integer()} | {:error, term()}
   defp changes(db) do
-    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, "SELECT changes()"),
-         {:row, [count]} <- Exqlite.Sqlite3.step(db, stmt),
-         :ok <- Exqlite.Sqlite3.release(db, stmt) do
-      count
-    else
-      _ -> 0
+    case Exqlite.Sqlite3.prepare(db, "SELECT changes()") do
+      {:ok, stmt} ->
+        result = Exqlite.Sqlite3.step(db, stmt)
+        Exqlite.Sqlite3.release(db, stmt)
+
+        case result do
+          {:row, [count]} -> {:ok, count}
+          {:error, reason} -> {:error, reason}
+          other -> {:error, {:unexpected_result, other}}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 end

--- a/lib/minga_agent/event_log/store.ex
+++ b/lib/minga_agent/event_log/store.ex
@@ -232,18 +232,10 @@ defmodule MingaAgent.EventLog.Store do
   defp query_events(db, sql, params) do
     case Exqlite.Sqlite3.prepare(db, sql) do
       {:ok, stmt} ->
-        result =
-          case Exqlite.Sqlite3.bind(stmt, params) do
-            :ok -> {:ok, collect_rows(db, stmt)}
-            {:error, reason} -> {:error, reason}
-          end
-
+        :ok = Exqlite.Sqlite3.bind(stmt, params)
+        rows = collect_rows(db, stmt)
         Exqlite.Sqlite3.release(db, stmt)
-
-        case result do
-          {:ok, rows} -> {:ok, rows |> Enum.map(&row_to_record/1) |> Enum.reject(&is_nil/1)}
-          {:error, reason} -> {:error, reason}
-        end
+        {:ok, rows |> Enum.map(&row_to_record/1) |> Enum.reject(&is_nil/1)}
 
       {:error, reason} ->
         {:error, reason}

--- a/lib/minga_agent/event_log/taxonomy.ex
+++ b/lib/minga_agent/event_log/taxonomy.ex
@@ -26,9 +26,16 @@ defmodule MingaAgent.EventLog.Taxonomy do
     :driver_changed
   ]
 
+  @event_type_map Map.new(@events, fn atom -> {Atom.to_string(atom), atom} end)
+
   @doc "Returns the canonical persisted event names."
   @spec events() :: [t()]
   def events, do: @events
+
+  @doc "Converts a stored event type string to its canonical atom, or `:error` for unknown types."
+  @spec from_string(String.t()) :: {:ok, t()} | :error
+  def from_string(type_string) when is_binary(type_string),
+    do: Map.fetch(@event_type_map, type_string)
 
   @doc "Returns true when an atom is part of the canonical taxonomy."
   @spec known?(atom()) :: boolean()

--- a/lib/minga_agent/event_log/taxonomy.ex
+++ b/lib/minga_agent/event_log/taxonomy.ex
@@ -1,0 +1,36 @@
+defmodule MingaAgent.EventLog.Taxonomy do
+  @moduledoc "Canonical event names persisted by the agent event log."
+
+  @type t :: MingaAgent.EventLog.EventRecord.event_type()
+
+  @events [
+    :session_started,
+    :session_stopped,
+    :user_message,
+    :assistant_delta,
+    :thinking_delta,
+    :tool_call_started,
+    :tool_call_updated,
+    :tool_call_finished,
+    :file_edit_proposed,
+    :approval_requested,
+    :approval_resolved,
+    :system_message,
+    :status_changed,
+    :waiting_for_input,
+    :prompt_queued,
+    :message_changed,
+    :error,
+    :context_usage,
+    :turn_limit_reached,
+    :driver_changed
+  ]
+
+  @doc "Returns the canonical persisted event names."
+  @spec events() :: [t()]
+  def events, do: @events
+
+  @doc "Returns true when an atom is part of the canonical taxonomy."
+  @spec known?(atom()) :: boolean()
+  def known?(event_type) when is_atom(event_type), do: event_type in @events
+end

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -25,6 +25,7 @@ defmodule MingaAgent.Session do
   alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.Credentials
   alias MingaAgent.Event
+  alias MingaAgent.EventLog
   alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
   alias MingaAgent.Hooks.SessionEndPayload
   alias MingaAgent.Hooks.SessionStartPayload
@@ -72,6 +73,7 @@ defmodule MingaAgent.Session do
   @type state :: %{
           session_id: String.t(),
           remote_token: String.t() | nil,
+          event_log_server: GenServer.server(),
           provider: pid() | nil,
           provider_module: module(),
           provider_opts: keyword(),
@@ -603,6 +605,7 @@ defmodule MingaAgent.Session do
     state = %{
       session_id: session_id,
       remote_token: Keyword.get(opts, :remote_token),
+      event_log_server: Keyword.get(opts, :event_log_server, EventLog),
       provider: nil,
       provider_module: provider_module,
       provider_opts: provider_opts,
@@ -646,6 +649,17 @@ defmodule MingaAgent.Session do
       # "not configured" state so we never advertise a model we can't call.
       credentials_configured: true
     }
+
+    EventLog.record(
+      state.session_id,
+      :session_started,
+      %{
+        model: state.model_name,
+        provider: state.provider_name,
+        background_subagent: state.background_subagent
+      },
+      state.event_log_server
+    )
 
     # Start provider asynchronously so init doesn't block
     send(self(), :start_provider)
@@ -691,6 +705,7 @@ defmodule MingaAgent.Session do
     # Agent is idle: treat follow-up as a regular prompt.
     {user_msg, send_content} = build_user_message(content)
     state = append_msg(state, user_msg)
+    record_user_message(state, user_msg)
     state = notify_messages_changed(state)
 
     case state.provider_module.send_prompt(state.provider, send_content) do
@@ -713,6 +728,7 @@ defmodule MingaAgent.Session do
         end)
 
       state = %{state | steering_queue: []}
+      Enum.each(new_msgs, &record_user_message(state, &1))
       state = append_msgs(state, new_msgs)
       state = notify_messages_changed(state)
       {:reply, steering, state}
@@ -1254,6 +1270,18 @@ defmodule MingaAgent.Session do
     # Send the execution decision directly to the blocked Task process.
     send(reply_to, {:tool_approval_response, tool_call_id, execution_decision(decision)})
 
+    EventLog.record(
+      state.session_id,
+      :approval_resolved,
+      %{
+        approval_id: tool_call_id,
+        tool_call_id: tool_call_id,
+        name: approval.name,
+        decision: decision
+      },
+      state.event_log_server
+    )
+
     state = maybe_record_rejection(state, approval, decision)
     state = %{state | pending_approval: nil}
     state = notify_messages_changed(state)
@@ -1282,9 +1310,11 @@ defmodule MingaAgent.Session do
     # provider error. Reply :ok so the input clears like a normal submit.
     {user_msg, _send_content} = build_user_message(content)
 
+    state = append_msg(state, user_msg)
+    record_user_message(state, user_msg)
+
     state =
       state
-      |> append_msg(user_msg)
       |> append_system_message(auth_required_message(), :info)
       |> notify_messages_changed()
 
@@ -1296,6 +1326,7 @@ defmodule MingaAgent.Session do
       :ok ->
         {user_msg, send_content} = build_user_message(content)
         state = append_msg(state, user_msg)
+        record_user_message(state, user_msg)
         state = notify_messages_changed(state)
 
         case state.provider_module.send_prompt(state.provider, send_content) do
@@ -1355,6 +1386,7 @@ defmodule MingaAgent.Session do
 
         state = %{state | steering_queue: [], follow_up_queue: []}
         state = append_msg(state, user_msg)
+        record_user_message(state, user_msg)
         state = notify_messages_changed(state)
 
         case state.provider_module.send_prompt(state.provider, send_content) do
@@ -1412,6 +1444,14 @@ defmodule MingaAgent.Session do
     state = append_msg(state, msg)
     state = track_active_tool_start(state, event.tool_call_id, event.name)
     state = set_working_status(state, :tool_executing)
+
+    EventLog.record(
+      state.session_id,
+      :tool_call_started,
+      %{tool_call_id: event.tool_call_id, name: event.name, args: event.args},
+      state.event_log_server
+    )
+
     broadcast(state, {:tool_started, event.name, event.args})
     notify_messages_changed(state)
   end
@@ -1473,6 +1513,14 @@ defmodule MingaAgent.Session do
 
     state = track_active_tool_end(state, event.tool_call_id)
     status = if event.is_error, do: :error, else: :done
+
+    EventLog.record(
+      state.session_id,
+      :tool_call_finished,
+      %{tool_call_id: event.tool_call_id, name: event.name, result: event.result, status: status},
+      state.event_log_server
+    )
+
     broadcast(state, {:tool_ended, event.name, event.result, status})
     notify_messages_changed(state)
   end
@@ -1867,12 +1915,90 @@ defmodule MingaAgent.Session do
 
   @spec broadcast(state(), term()) :: :ok
   defp broadcast(state, event) do
+    record_broadcast_event(state, event)
     session_pid = self()
 
     Enum.each(state.subscribers, fn pid ->
       send(pid, {:agent_event, session_pid, event})
     end)
   end
+
+  @spec record_broadcast_event(state(), term()) :: :ok
+  defp record_broadcast_event(state, event) do
+    case event_log_entry(event) do
+      {event_type, payload} ->
+        EventLog.record(state.session_id, event_type, payload, state.event_log_server)
+
+      nil ->
+        :ok
+    end
+  end
+
+  @spec event_log_entry(term()) :: {EventLog.EventRecord.event_type(), map()} | nil
+  defp event_log_entry({:text_delta, delta}), do: {:assistant_delta, %{delta: delta}}
+  defp event_log_entry({:thinking_delta, delta}), do: {:thinking_delta, %{delta: delta}}
+
+  defp event_log_entry({:tool_started, _name, _args}), do: nil
+
+  defp event_log_entry({:tool_update, tool_call_id, name, partial_result}),
+    do:
+      {:tool_call_updated,
+       %{tool_call_id: tool_call_id, name: name, partial_result: partial_result}}
+
+  defp event_log_entry({:tool_ended, _name, _result, _status}), do: nil
+
+  defp event_log_entry(
+         {:file_changed, path, before_content, after_content, tool_call_id, tool_name}
+       ),
+       do:
+         {:file_edit_proposed,
+          %{
+            path: path,
+            before_content: before_content,
+            after_content: after_content,
+            tool_call_id: tool_call_id,
+            tool_name: tool_name
+          }}
+
+  defp event_log_entry({:approval_pending, approval}),
+    do: {:approval_requested, Map.put(approval, :approval_id, approval.tool_call_id)}
+
+  defp event_log_entry({:approval_resolved, decision}),
+    do: {:approval_resolved, %{decision: decision}}
+
+  defp event_log_entry({:system_message, message, level}),
+    do: {:system_message, %{message: message, level: level}}
+
+  defp event_log_entry({:status_changed, :idle}), do: {:waiting_for_input, %{status: :idle}}
+  defp event_log_entry({:status_changed, status}), do: {:status_changed, %{status: status}}
+
+  defp event_log_entry({:prompt_queued, content, queue}),
+    do: {:prompt_queued, %{content: content, queue: queue}}
+
+  defp event_log_entry(:messages_changed), do: {:message_changed, %{changed: true}}
+  defp event_log_entry({:error, message}), do: {:error, %{message: message}}
+
+  defp event_log_entry({:context_usage, estimated_tokens, context_limit}),
+    do: {:context_usage, %{estimated_tokens: estimated_tokens, context_limit: context_limit}}
+
+  defp event_log_entry({:turn_limit_reached, current, limit}),
+    do: {:turn_limit_reached, %{current: current, limit: limit}}
+
+  defp event_log_entry({:driver_changed, pid}),
+    do: {:driver_changed, %{driver_present: is_pid(pid)}}
+
+  defp event_log_entry({:tool_auto_approved, tool_call_id, name, scope}),
+    do:
+      {:approval_resolved,
+       %{
+         approval_id: tool_call_id,
+         tool_call_id: tool_call_id,
+         name: name,
+         decision: :approve,
+         scope: scope
+       }}
+
+  defp event_log_entry(_event), do: nil
 
   # When content is a ContentPart list (images attached), extract the text
   # for the chat message and pass the full parts to the provider.
@@ -1898,6 +2024,25 @@ defmodule MingaAgent.Session do
       end)
 
     {Message.user(text, attachments), parts}
+  end
+
+  @spec record_user_message(state(), Message.t()) :: :ok
+  defp record_user_message(state, {:user, text}) do
+    EventLog.record(
+      state.session_id,
+      :user_message,
+      %{text: text, attachments: []},
+      state.event_log_server
+    )
+  end
+
+  defp record_user_message(state, {:user, text, attachments}) do
+    EventLog.record(
+      state.session_id,
+      :user_message,
+      %{text: text, attachments: attachments},
+      state.event_log_server
+    )
   end
 
   @spec parse_size_kb(String.t()) :: non_neg_integer()
@@ -2451,6 +2596,13 @@ defmodule MingaAgent.Session do
 
   @impl GenServer
   def terminate(reason, state) do
+    EventLog.record(
+      state.session_id,
+      :session_stopped,
+      %{reason: inspect(reason), status: state.status},
+      state.event_log_server
+    )
+
     dispatch_session_end(state, reason)
 
     case reason do

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -821,6 +821,13 @@ defmodule MingaAgent.Session do
       state.provider_module.new_session(state.provider)
     end
 
+    EventLog.record(
+      state.session_id,
+      :session_stopped,
+      %{reason: "new_session", status: state.status},
+      state.event_log_server
+    )
+
     now = DateTime.utc_now()
     timestamp = Calendar.strftime(now, "%H:%M:%S UTC")
 
@@ -846,6 +853,17 @@ defmodule MingaAgent.Session do
     }
 
     state = reset_messages(state, [Message.system("Session cleared · #{timestamp}")])
+
+    EventLog.record(
+      state.session_id,
+      :session_started,
+      %{
+        model: state.model_name,
+        provider: state.provider_name,
+        background_subagent: state.background_subagent
+      },
+      state.event_log_server
+    )
 
     broadcast(state, {:status_changed, :idle})
     state = notify_messages_changed(state)
@@ -1646,6 +1664,13 @@ defmodule MingaAgent.Session do
 
   @spec append_system_message(state(), String.t(), Message.system_level()) :: state()
   defp append_system_message(state, text, level) do
+    EventLog.record(
+      state.session_id,
+      :system_message,
+      %{message: text, level: level},
+      state.event_log_server
+    )
+
     msg = Message.system(text, level)
     append_msg(state, msg)
   end
@@ -1965,8 +1990,7 @@ defmodule MingaAgent.Session do
 
   defp event_log_entry({:approval_resolved, _decision}), do: nil
 
-  defp event_log_entry({:system_message, message, level}),
-    do: {:system_message, %{message: message, level: level}}
+  defp event_log_entry({:system_message, _message, _level}), do: nil
 
   defp event_log_entry({:status_changed, :idle}), do: {:waiting_for_input, %{status: :idle}}
   defp event_log_entry({:status_changed, status}), do: {:status_changed, %{status: status}}

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1963,8 +1963,7 @@ defmodule MingaAgent.Session do
   defp event_log_entry({:approval_pending, approval}),
     do: {:approval_requested, Map.put(approval, :approval_id, approval.tool_call_id)}
 
-  defp event_log_entry({:approval_resolved, decision}),
-    do: {:approval_resolved, %{decision: decision}}
+  defp event_log_entry({:approval_resolved, _decision}), do: nil
 
   defp event_log_entry({:system_message, message, level}),
     do: {:system_message, %{message: message, level: level}}
@@ -1975,7 +1974,7 @@ defmodule MingaAgent.Session do
   defp event_log_entry({:prompt_queued, content, queue}),
     do: {:prompt_queued, %{content: content, queue: queue}}
 
-  defp event_log_entry(:messages_changed), do: {:message_changed, %{changed: true}}
+  defp event_log_entry(:messages_changed), do: nil
   defp event_log_entry({:error, message}), do: {:error, %{message: message}}
 
   defp event_log_entry({:context_usage, estimated_tokens, context_limit}),

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -2216,7 +2216,7 @@ defmodule MingaAgent.Session do
   defp maybe_show_auth_onboarding(state) do
     if state.provider_module == MingaAgent.Providers.Native and not state.credentials_configured do
       msg = onboarding_message()
-      state = append_msg(state, Message.system(msg))
+      state = append_system_message(state, msg, :info)
       broadcast(state, {:system_message, msg, :info})
       state
     else

--- a/test/minga_agent/event_log/session_integration_test.exs
+++ b/test/minga_agent/event_log/session_integration_test.exs
@@ -1,0 +1,254 @@
+defmodule MingaAgent.EventLog.SessionIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Event
+  alias MingaAgent.EventLog
+  alias MingaAgent.EventLog.Store
+  alias MingaAgent.Session
+
+  @moduletag :tmp_dir
+
+  defmodule SteeringProvider do
+    @behaviour MingaAgent.Provider
+
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl MingaAgent.Provider
+    def send_prompt(pid, text), do: GenServer.cast(pid, {:prompt, text})
+
+    @impl MingaAgent.Provider
+    def abort(pid), do: GenServer.cast(pid, :abort)
+
+    @impl MingaAgent.Provider
+    def new_session(pid), do: GenServer.cast(pid, :new_session)
+
+    @impl MingaAgent.Provider
+    def seed_messages(_pid, _messages), do: :ok
+
+    @impl MingaAgent.Provider
+    def get_state(_pid), do: {:ok, %{model: "test", is_streaming: true, token_usage: nil}}
+
+    @impl true
+    def init(opts) do
+      {:ok, %{subscriber: Keyword.fetch!(opts, :subscriber)}}
+    end
+
+    @impl true
+    def handle_cast({:prompt, text}, state) do
+      send(state.subscriber, {:agent_provider_event, %Event.AgentStart{}})
+      send(state.subscriber, {:agent_provider_event, %Event.TextDelta{delta: text}})
+      {:noreply, state}
+    end
+
+    def handle_cast(:abort, state), do: {:noreply, state}
+    def handle_cast(:new_session, state), do: {:noreply, state}
+  end
+
+  defmodule ReplayProvider do
+    @behaviour MingaAgent.Provider
+
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl MingaAgent.Provider
+    def send_prompt(pid, text), do: GenServer.cast(pid, {:prompt, text})
+
+    @impl MingaAgent.Provider
+    def abort(pid), do: GenServer.cast(pid, :abort)
+
+    @impl MingaAgent.Provider
+    def new_session(pid), do: GenServer.cast(pid, :new_session)
+
+    @impl MingaAgent.Provider
+    def seed_messages(_pid, _messages), do: :ok
+
+    @impl MingaAgent.Provider
+    def get_state(_pid), do: {:ok, %{model: "test", is_streaming: false, token_usage: nil}}
+
+    @impl true
+    def init(opts) do
+      {:ok, %{subscriber: Keyword.fetch!(opts, :subscriber)}}
+    end
+
+    @impl true
+    def handle_cast({:prompt, text}, state) do
+      send(state.subscriber, {:agent_provider_event, %Event.AgentStart{}})
+      send(state.subscriber, {:agent_provider_event, %Event.TextDelta{delta: text}})
+
+      send(
+        state.subscriber,
+        {:agent_provider_event,
+         %Event.ToolStart{
+           tool_call_id: "tool-1",
+           name: "read_file",
+           args: %{path: "secret.txt", api_key: "nope"}
+         }}
+      )
+
+      send(
+        state.subscriber,
+        {:agent_provider_event,
+         %Event.ToolEnd{tool_call_id: "tool-1", name: "read_file", result: "ok", is_error: false}}
+      )
+
+      send(state.subscriber, {:agent_provider_event, %Event.AgentEnd{}})
+      {:noreply, state}
+    end
+
+    def handle_cast(:abort, state), do: {:noreply, state}
+    def handle_cast(:new_session, state), do: {:noreply, state}
+  end
+
+  test "session broadcasts are durably recorded for replay", %{tmp_dir: tmp_dir} do
+    log_name = unique_name("session-log")
+
+    log_pid =
+      start_supervised!(
+        {EventLog, name: log_name, db_dir: tmp_dir, retention_sweep?: false, health_check: :none}
+      )
+
+    session =
+      start_supervised!(
+        {Session,
+         session_id: "stable-session",
+         provider: ReplayProvider,
+         event_log_server: log_name,
+         persist?: false,
+         hooks_enabled?: false}
+      )
+
+    :sys.get_state(session)
+    assert :ok = Session.send_prompt(session, "hello")
+    :sys.get_state(session)
+    :sys.get_state(log_pid)
+
+    {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
+    events = wait_for_event(db, "stable-session", :waiting_for_input, session, log_pid)
+    event_types = Enum.map(events, & &1.event_type)
+
+    assert :session_started in event_types
+    assert :user_message in event_types
+    assert :assistant_delta in event_types
+    assert :tool_call_started in event_types
+    assert :tool_call_finished in event_types
+    assert :waiting_for_input in event_types
+
+    user_message = Enum.find(events, &(&1.event_type == :user_message))
+    assert user_message.payload["text"] == "hello"
+
+    tool_start = Enum.find(events, &(&1.event_type == :tool_call_started))
+    assert tool_start.payload["tool_call_id"] == "tool-1"
+    assert tool_start.payload["args"]["api_key"] == "[REDACTED]"
+
+    tool_end = Enum.find(events, &(&1.event_type == :tool_call_finished))
+    assert tool_end.payload["tool_call_id"] == "tool-1"
+    :ok = Store.close(db)
+  end
+
+  test "dequeued steering prompts are recorded with content", %{tmp_dir: tmp_dir} do
+    log_name = unique_name("steering-log")
+
+    log_pid =
+      start_supervised!(
+        {EventLog, name: log_name, db_dir: tmp_dir, retention_sweep?: false, health_check: :none}
+      )
+
+    session =
+      start_supervised!(
+        {Session,
+         session_id: "steering-session",
+         provider: SteeringProvider,
+         event_log_server: log_name,
+         persist?: false,
+         hooks_enabled?: false}
+      )
+
+    :sys.get_state(session)
+    assert :ok = Session.send_prompt(session, "first")
+    :sys.get_state(session)
+    assert {:queued, :steering} = Session.send_prompt(session, "while busy")
+    assert ["while busy"] = Session.dequeue_steering(session)
+    :sys.get_state(log_pid)
+
+    {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
+    assert {:ok, events} = EventLog.events_after(db, "steering-session", 0, 50)
+
+    user_texts =
+      events |> Enum.filter(&(&1.event_type == :user_message)) |> Enum.map(& &1.payload["text"])
+
+    assert "first" in user_texts
+    assert "while busy" in user_texts
+    :ok = Store.close(db)
+  end
+
+  test "history remains queryable after the session process dies", %{tmp_dir: tmp_dir} do
+    log_name = unique_name("crash-log")
+
+    log_pid =
+      start_supervised!(
+        {EventLog, name: log_name, db_dir: tmp_dir, retention_sweep?: false, health_check: :none}
+      )
+
+    session =
+      start_supervised!(
+        {Session,
+         session_id: "crash-session",
+         provider: ReplayProvider,
+         event_log_server: log_name,
+         persist?: false,
+         hooks_enabled?: false}
+      )
+
+    :sys.get_state(session)
+    Session.add_system_message(session, "before crash", :info)
+    :sys.get_state(session)
+    :sys.get_state(log_pid)
+
+    ref = Process.monitor(session)
+    Process.exit(session, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^session, :killed}
+
+    {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
+    assert {:ok, events} = EventLog.events_after(db, "crash-session", 0, 50)
+    assert Enum.any?(events, &(&1.event_type == :message_changed))
+    :ok = Store.close(db)
+  end
+
+  @spec wait_for_event(
+          Store.db(),
+          String.t(),
+          MingaAgent.EventLog.EventRecord.event_type(),
+          pid(),
+          pid(),
+          non_neg_integer()
+        ) :: [MingaAgent.EventLog.EventRecord.t()]
+  defp wait_for_event(db, session_id, event_type, session_pid, log_pid, attempts \\ 20)
+
+  defp wait_for_event(db, session_id, event_type, session_pid, log_pid, attempts)
+       when attempts > 0 do
+    :sys.get_state(session_pid)
+    :sys.get_state(log_pid)
+    {:ok, events} = EventLog.events_after(db, session_id, 0, 50)
+
+    if Enum.any?(events, &(&1.event_type == event_type)) do
+      events
+    else
+      wait_for_event(db, session_id, event_type, session_pid, log_pid, attempts - 1)
+    end
+  end
+
+  defp wait_for_event(db, session_id, _event_type, _session_pid, _log_pid, 0) do
+    {:ok, events} = EventLog.events_after(db, session_id, 0, 50)
+    events
+  end
+
+  @spec unique_name(String.t()) :: atom()
+  defp unique_name(prefix) do
+    String.to_atom("#{prefix}-#{System.unique_integer([:positive])}")
+  end
+end

--- a/test/minga_agent/event_log/session_integration_test.exs
+++ b/test/minga_agent/event_log/session_integration_test.exs
@@ -215,7 +215,7 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
 
     {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
     assert {:ok, events} = EventLog.events_after(db, "crash-session", 0, 50)
-    assert Enum.any?(events, &(&1.event_type == :message_changed))
+    assert Enum.any?(events, &(&1.event_type == :session_started))
     :ok = Store.close(db)
   end
 

--- a/test/minga_agent/event_log/store_test.exs
+++ b/test/minga_agent/event_log/store_test.exs
@@ -1,0 +1,54 @@
+defmodule MingaAgent.EventLog.StoreTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.EventLog.Store
+
+  @moduletag :tmp_dir
+
+  setup do
+    {:ok, db} = Store.open_memory()
+
+    on_exit(fn -> Store.close(db) end)
+
+    {:ok, db: db}
+  end
+
+  test "events_after returns a session cursor in id order", %{db: db} do
+    {:ok, first_id} =
+      Store.insert(db, EventRecord.new("session-a", :session_started, %{"n" => 1}))
+
+    {:ok, second_id} =
+      Store.insert(db, EventRecord.new("session-a", :assistant_delta, %{"delta" => "hi"}))
+
+    {:ok, _other_id} =
+      Store.insert(db, EventRecord.new("session-b", :session_started, %{"n" => 3}))
+
+    assert {:ok, [first, second]} = Store.events_after(db, "session-a", 0, 10)
+    assert first.id == first_id
+    assert second.id == second_id
+    assert Enum.map([first, second], & &1.event_type) == [:session_started, :assistant_delta]
+    assert {:ok, [^second]} = Store.events_after(db, "session-a", first_id, 10)
+    assert {:ok, []} = Store.events_after(db, "session-a", second_id, 10)
+  end
+
+  test "records survive reopening the database", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "agent_events.db")
+    {:ok, db} = Store.open(path)
+
+    {:ok, id} =
+      Store.insert(
+        db,
+        EventRecord.new("stable-session", :system_message, %{"message" => "hello"})
+      )
+
+    :ok = Store.close(db)
+
+    {:ok, reopened} = Store.open(path)
+
+    assert {:ok, [%{id: ^id, payload: %{"message" => "hello"}}]} =
+             Store.events_after(reopened, "stable-session", 0, 10)
+
+    :ok = Store.close(reopened)
+  end
+end

--- a/test/minga_agent/event_log_test.exs
+++ b/test/minga_agent/event_log_test.exs
@@ -1,0 +1,47 @@
+defmodule MingaAgent.EventLogTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.EventLog
+  alias MingaAgent.EventLog.Store
+
+  @moduletag :tmp_dir
+
+  test "record writes asynchronously and redacts secrets", %{tmp_dir: tmp_dir} do
+    name = unique_name("event-log")
+
+    pid =
+      start_supervised!(
+        {EventLog, name: name, db_dir: tmp_dir, retention_sweep?: false, health_check: :none}
+      )
+
+    :ok =
+      EventLog.record(
+        "session-1",
+        :tool_call_started,
+        %{
+          :api_key => "secret",
+          :accessToken => "camel",
+          "client-secret" => "hyphen",
+          :nested => %{refreshToken: "abc"},
+          :pid => self()
+        },
+        name
+      )
+
+    :sys.get_state(pid)
+
+    {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
+    assert {:ok, [record]} = EventLog.events_after(db, "session-1", 0, 10)
+    assert record.payload["api_key"] == "[REDACTED]"
+    assert record.payload["accessToken"] == "[REDACTED]"
+    assert record.payload["client-secret"] == "[REDACTED]"
+    assert record.payload["nested"]["refreshToken"] == "[REDACTED]"
+    assert record.payload["pid"] == "[PID]"
+    :ok = Store.close(db)
+  end
+
+  @spec unique_name(String.t()) :: atom()
+  defp unique_name(prefix) do
+    String.to_atom("#{prefix}-#{System.unique_integer([:positive])}")
+  end
+end


### PR DESCRIPTION
# TL;DR
Agent sessions now write a durable append-only event log for replay. The log records stable session events asynchronously, supports cursor reads by session, and redacts credential-like payload keys before SQLite persistence.

Closes #2050

## Context
This is the next detachable-agent-sessions slice after #2053. It gives reconnect and replay work a durable source of truth, so a detached client can later ask for events after its last seen id instead of relying on in-memory state.

## Changes
- Added `MingaAgent.EventLog`, a daemon-level GenServer writer supervised under `Minga.Services.Independent` so it runs in headless mode.
- Added an agent-specific SQLite store with WAL mode, append-only rows, schema versioning, retention sweep support, and `events_after/4` cursor reads.
- Added `EventRecord` and `Taxonomy` modules for the durable event shape and canonical event names.
- Wired `MingaAgent.Session` to record session start/stop, user prompts, assistant deltas, tool lifecycle, file edits, approvals, system messages, status changes, waiting-for-input, context, errors, and driver changes.
- Sanitized persisted payloads so credential-like keys, including camelCase and hyphenated variants, are redacted; PIDs and references are replaced with replay-safe placeholders.
- Added event-log tests for cursor ordering, durability after reopen, async recording, redaction, session broadcast recording, steering prompt replay, and history after a simulated session crash.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.debug test/minga_agent/event_log_test.exs test/minga_agent/event_log/store_test.exs test/minga_agent/event_log/session_integration_test.exs`
- `mix test.llm test/minga_agent/event_log_test.exs test/minga_agent/event_log test/minga_agent/session_test.exs`
- `make lint`
- `mix test.llm` (56 doctests, 91 properties, 9098 tests, 0 failures, 292 excluded)
- `git diff --check`
- Bug-hunt rechecks: PASS
- Final reviewer gate: PASS

## Acceptance Criteria Addressed
- Running sessions durably record append-only activity with monotonic ids, stable session ids, event type, payload, wall-clock timestamp, and monotonic timestamp ✅
- Readers can fetch events for a session with `id > N` in order without blocking the writer ✅
- Recording is asynchronous to the session process ✅
- The persisted taxonomy covers the session activity needed to reconstruct a session view ✅
- The log runs in headless mode through `Minga.Services.Independent` ✅
- History remains queryable after a simulated session crash ✅
- Credential-like values are redacted before persistence ✅
- Payloads are JSON/replay-safe and avoid process-local references ✅
