### PR TITLE
feat(agent): manage detached remote sessions

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -40,6 +40,7 @@ That's it. Save the file and restart Minga. Your options take effect immediately
 | `:agent_tool_approval` | `:destructive`, `:all`, `:none` | `:destructive` | When to prompt before executing agent tools |
 | `:agent_destructive_tools` | list of strings | `["write_file", "edit_file", "multi_edit_file", "apply_diff", "delete_file", "shell", "git_stage", "git_commit", "rename"]` | Which tools are classified as destructive |
 | `:agent_session_retention_days` | positive integer | `30` | Days to keep saved agent sessions before auto-pruning |
+| `:agent_session_idle_timeout_ms` | non-negative integer | `14_400_000` | Milliseconds before an idle detached remote agent session is reclaimed; `0` disables idle reclamation |
 | `:startup_view` | `:agent` or `:editor` | `:agent` | Which view to show on startup (see [Startup view](#startup-view) below) |
 | `:agent_auto_context` | boolean | `true` | Load CLI file as agent preview context on startup |
 | `:agent_mcp_servers` | list of maps | `[]` | MCP servers to launch for native agent sessions (see [MCP servers](MCP.md)) |

--- a/docs/REMOTE_AGENTS.md
+++ b/docs/REMOTE_AGENTS.md
@@ -1,0 +1,53 @@
+# Remote Agents
+
+Remote agents let a headless Minga process keep working after every editor window disconnects. The model is closer to tmux than SSH foreground jobs: the server owns provider credentials, configuration, durable session state, and running agent work. Clients attach, catch up, drive or observe the session, and detach without stopping the work.
+
+## Run the headless daemon
+
+Start the daemon with `minga --headless`. In headless mode Minga starts the runtime, distribution, services, and agent supervisor without opening a frontend port.
+
+### Linux systemd user service
+
+Copy `rel/systemd/minga-headless.service` to `~/.config/systemd/user/minga-headless.service`, edit `ExecStart`, `WorkingDirectory`, `MINGA_COOKIE`, and provider environment variables, then run:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now minga-headless.service
+loginctl enable-linger "$USER"
+```
+
+`loginctl enable-linger` is what lets the user service keep running across logout and login. Without linger, most Linux systems stop user services when the last login session exits.
+
+### macOS launchd agent
+
+Copy `rel/launchd/com.minga.headless.plist` to `~/Library/LaunchAgents/com.minga.headless.plist`, edit the absolute binary path, working directory, cookie, and provider environment variables, then run:
+
+```sh
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.minga.headless.plist
+launchctl enable gui/$(id -u)/com.minga.headless
+launchctl kickstart -k gui/$(id -u)/com.minga.headless
+```
+
+Use `launchctl bootout gui/$(id -u)/com.minga.headless` to stop the agent.
+
+## Network and trust boundary
+
+Remote control uses Erlang distribution. Set a long random `MINGA_COOKIE` on the daemon and every trusted client that needs to connect. Treat the cookie like a password: any node with the cookie can reach the trusted broker API.
+
+Bind the server on a private network such as Tailscale or a locked-down LAN. Do not expose Erlang distribution ports directly to the public internet.
+
+Provider credentials live on the server. Put keys in the systemd `Environment=` lines, the launchd `EnvironmentVariables` dictionary, or the server user's normal secret-management setup. Attaching clients do not push provider credentials or config into the daemon.
+
+## Detach, reconnect, and end
+
+Detaching only removes the client subscriber. It records a `user_disconnected` event in the durable event log and leaves the agent turn running. If the laptop closes while a tool is running, the server keeps the session alive and the next attach catches up from the client's last seen event id.
+
+Use the brokered remote API to end a session deliberately. `MingaAgent.RemoteAPI.stop_session/2` validates the session token and stops that session on the server. The CLI attach UX will expose this as a user-facing command in the attach slice.
+
+## Idle reclamation policy
+
+Detached sessions are reclaimed by `:agent_session_idle_timeout_ms`. The default is four hours (`14_400_000` ms). Set it to `0` to disable idle reclamation on hosts where sessions should remain until explicitly ended.
+
+The reclaimer only stops sessions with no attached clients and no active agent work. A session that is thinking, executing a tool, or waiting on a pending approval is never reclaimed out from under the user. When the active turn returns to idle and there are still no subscribers, the timeout starts again.
+
+Saved session files and the durable event log are still subject to their own retention settings, such as `:agent_session_retention_days` and `:event_retention_days`.

--- a/extensions/board/lib/minga_board/shell.ex
+++ b/extensions/board/lib/minga_board/shell.ex
@@ -28,6 +28,7 @@ defmodule MingaBoard.Shell do
   @behaviour MingaEditor.Shell.TabQueries
 
   alias Minga.RenderModel.UI
+  alias MingaAgent.Session, as: AgentSession
   alias MingaAgent.Subagent.Handle
   alias MingaEditor.DisplayList
   alias MingaEditor.DisplayList.{Cursor, Frame}
@@ -43,6 +44,7 @@ defmodule MingaBoard.Shell do
   alias MingaBoard.Shell.Card
   alias MingaBoard.Shell.SessionLifecycle
   alias MingaBoard.Shell.State, as: BoardState
+  alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.Session.State, as: SessionState
 
   @impl true
@@ -622,6 +624,36 @@ defmodule MingaBoard.Shell do
     end
   end
 
+  @doc "Refreshes a card after SessionManager restarts its agent session."
+  @spec handle_agent_session_restarted(BoardState.t(), pid(), pid(), term()) ::
+          {BoardState.t(), boolean()}
+  def handle_agent_session_restarted(%BoardState{} = shell_state, old_pid, new_pid, reason) do
+    active_session = active_session(shell_state)
+    snapshot_result = safe_agent_snapshot(new_pid)
+
+    case Enum.find(shell_state.cards, fn {_id, card} -> card.session == old_pid end) do
+      {card_id, _card} ->
+        board =
+          BoardState.update_card(
+            shell_state,
+            card_id,
+            &refresh_restarted_card(&1, old_pid, new_pid, snapshot_result)
+          )
+
+        board =
+          if active_session == old_pid do
+            refresh_restarted_agent_cache(board, snapshot_result, new_pid, old_pid, reason)
+          else
+            board
+          end
+
+        {board, true}
+
+      nil ->
+        {shell_state, false}
+    end
+  end
+
   @doc "Marks a card's remote agent connection as disconnected."
   @spec handle_remote_session_disconnected(BoardState.t(), pid()) :: {BoardState.t(), boolean()}
   def handle_remote_session_disconnected(%BoardState{} = shell_state, session_pid) do
@@ -756,6 +788,67 @@ defmodule MingaBoard.Shell do
       nil ->
         shell_state
     end
+  end
+
+  @spec refresh_restarted_card(Card.t(), pid(), pid(), {:ok, map()} | {:error, term()}) ::
+          Card.t()
+  defp refresh_restarted_card(card, old_pid, new_pid, {:ok, snapshot}) do
+    card
+    |> Card.refresh_session_pid(old_pid, new_pid)
+    |> Card.set_status(Card.from_agent_status(snapshot.status))
+  end
+
+  defp refresh_restarted_card(card, old_pid, new_pid, {:error, _reason}) do
+    card
+    |> Card.refresh_session_pid(old_pid, new_pid)
+    |> Card.set_status(:errored)
+  end
+
+  @spec refresh_restarted_agent_cache(
+          BoardState.t(),
+          {:ok, map()} | {:error, term()},
+          pid(),
+          pid(),
+          term()
+        ) :: BoardState.t()
+  defp refresh_restarted_agent_cache(shell_state, {:ok, snapshot}, _new_pid, _old_pid, _reason) do
+    BoardState.set_agent(shell_state, apply_agent_snapshot(shell_state.agent, snapshot))
+  end
+
+  defp refresh_restarted_agent_cache(
+         shell_state,
+         {:error, snapshot_reason},
+         new_pid,
+         old_pid,
+         reason
+       ) do
+    Minga.Log.warning(
+      :agent,
+      "Board: failed to refresh restarted session #{inspect(old_pid)} -> #{inspect(new_pid)} (#{inspect(reason)}): #{inspect(snapshot_reason)}"
+    )
+
+    BoardState.set_agent(
+      shell_state,
+      AgentState.set_error(shell_state.agent, "Agent session unavailable")
+    )
+  end
+
+  @spec safe_agent_snapshot(pid()) :: {:ok, map()} | {:error, term()}
+  defp safe_agent_snapshot(session_pid) do
+    {:ok, AgentSession.editor_snapshot(session_pid)}
+  catch
+    :exit, reason -> {:error, {:exit, reason}}
+  end
+
+  @spec apply_agent_snapshot(MingaEditor.State.Agent.t(), map()) :: MingaEditor.State.Agent.t()
+  defp apply_agent_snapshot(agent, snapshot) do
+    AgentState.apply_session_snapshot(
+      agent,
+      snapshot.status,
+      snapshot.pending_approval,
+      snapshot.error,
+      Map.get(snapshot, :active_tool_name)
+    )
   end
 
   # Zoom out from a card: store the live workspace on the card, restore the grid workspace.

--- a/extensions/board/lib/minga_board/shell/card.ex
+++ b/extensions/board/lib/minga_board/shell/card.ex
@@ -140,6 +140,15 @@ defmodule MingaBoard.Shell.Card do
     %{card | session: nil}
   end
 
+  @doc "Refreshes the attached session PID after a managed restart."
+  @spec refresh_session_pid(t(), pid(), pid()) :: t()
+  def refresh_session_pid(%__MODULE__{session: session} = card, old_pid, new_pid)
+      when session == old_pid and is_pid(new_pid) do
+    %{card | session: new_pid}
+  end
+
+  def refresh_session_pid(%__MODULE__{} = card, _old_pid, _new_pid), do: card
+
   @doc "Stores a workspace snapshot on the card."
   @spec store_workspace(t(), workspace_snapshot() | TabContext.legacy()) :: t()
   def store_workspace(%__MODULE__{} = card, workspace) when is_map(workspace) do

--- a/extensions/board/lib/minga_board/shell/state.ex
+++ b/extensions/board/lib/minga_board/shell/state.ex
@@ -112,6 +112,12 @@ defmodule MingaBoard.Shell.State do
     %{ss | modal: modal}
   end
 
+  @doc "Replaces the cached agent UI state."
+  @spec set_agent(t(), MingaEditor.State.Agent.t()) :: t()
+  def set_agent(%__MODULE__{} = ss, agent) do
+    %{ss | agent: agent}
+  end
+
   @doc """
   Creates a new card and adds it to the board.
 

--- a/extensions/board/test/minga_board/shell/board/session_lifecycle_test.exs
+++ b/extensions/board/test/minga_board/shell/board/session_lifecycle_test.exs
@@ -4,8 +4,11 @@ defmodule MingaBoard.Shell.SessionLifecycleTest do
 
   import ExUnit.CaptureLog
 
+  alias Minga.Test.StubProvider
+  alias MingaAgent.Session
   alias MingaAgent.SessionManager
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.Viewport
   alias MingaBoard.Shell
   alias MingaBoard.Shell.Input, as: BoardInput
@@ -169,6 +172,81 @@ defmodule MingaBoard.Shell.SessionLifecycleTest do
       updated_card = new_board.cards[card.id]
       assert updated_card.session == nil
       assert updated_card.status == :errored
+    end
+  end
+
+  describe "handle_agent_session_restarted/4" do
+    test "refreshes the active card session pid and agent cache" do
+      old_pid =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      on_exit(fn -> Process.exit(old_pid, :kill) end)
+
+      new_pid =
+        start_supervised!(
+          {Session,
+           [
+             provider: StubProvider,
+             provider_opts: [],
+             session_id: "board-restart-test-#{System.unique_integer([:positive])}"
+           ]}
+        )
+
+      board = %{BoardState.new() | agent: AgentState.set_error(%AgentState{}, "stale cache")}
+
+      {board, card} =
+        BoardState.create_card(board, task: "Fix bug", session: old_pid, status: :working)
+
+      board = %{board | zoomed_into: card.id}
+
+      {updated_board, handled?} =
+        Shell.handle_agent_session_restarted(board, old_pid, new_pid, :killed)
+
+      assert handled?
+      assert updated_board.cards[card.id].session == new_pid
+      assert updated_board.cards[card.id].status == :done
+      assert AgentState.status(updated_board.agent) == Session.status(new_pid)
+      assert updated_board.agent.error == nil
+    end
+
+    test "refreshes a background card without touching the active agent cache" do
+      old_pid =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      on_exit(fn -> Process.exit(old_pid, :kill) end)
+
+      new_pid =
+        start_supervised!(
+          {Session,
+           [
+             provider: StubProvider,
+             provider_opts: [],
+             session_id: "board-bg-restart-test-#{System.unique_integer([:positive])}"
+           ]}
+        )
+
+      stale_agent = AgentState.set_error(%AgentState{}, "stale cache")
+      board = %{BoardState.new() | agent: stale_agent}
+
+      {board, card} =
+        BoardState.create_card(board, task: "Background bug", session: old_pid, status: :working)
+
+      {updated_board, handled?} =
+        Shell.handle_agent_session_restarted(board, old_pid, new_pid, :killed)
+
+      assert handled?
+      assert updated_board.cards[card.id].session == new_pid
+      assert updated_board.cards[card.id].status == :done
+      assert updated_board.agent == stale_agent
+      refute updated_board.zoomed_into == card.id
     end
   end
 end

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -74,6 +74,7 @@ defmodule Minga.Config.Options do
           | :agent_tool_permissions
           | :agent_hooks
           | :agent_session_retention_days
+          | :agent_session_idle_timeout_ms
           | :agent_panel_split
           | :startup_view
           | :agent_auto_context
@@ -290,6 +291,8 @@ defmodule Minga.Config.Options do
     {:agent_hooks, :any, [], "Agent lifecycle hook declarations loaded from config."},
     {:agent_session_retention_days, :pos_integer, 30,
      "Number of days to retain persisted agent sessions."},
+    {:agent_session_idle_timeout_ms, :non_neg_integer, 14_400_000,
+     "Milliseconds before an idle detached agent session is reclaimed; 0 disables idle reclamation."},
     {:agent_panel_split, :pos_integer, 65,
      "Percentage of available width assigned to the agent panel."},
     {:startup_view, {:enum, [:agent, :editor]}, :editor, "Initial view shown when Minga starts."},

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -41,6 +41,7 @@ defmodule Minga.Events do
   | `:log_message`     | `LogMessageEvent`     | `text: String.t(), level: :info \| :warning \| :error` |
   | `:agent_hook`      | `AgentHookEvent`        | `event, phase, tool_name, tool_call_id, tool_pattern` |
   | `:face_overrides_changed` | `FaceOverridesChangedEvent` | `buffer: pid(), overrides: map()` |
+  | `:agent_session_restarted` | `MingaAgent.SessionManager.SessionRestartedEvent` | `session_id, old_pid, new_pid, reason` |
   | `:background_subagent_started` | `MingaAgent.Subagent.Handle` | `session_id: String.t(), pid: pid(), task: String.t()` |
   | `:node_connected` | `Minga.Distribution.Events.NodeConnectedEvent` | `server_name, node, connected_at` |
   | `:node_disconnected` | `Minga.Distribution.Events.NodeDisconnectedEvent` | `server_name, node, reason, disconnected_at` |
@@ -297,6 +298,7 @@ defmodule Minga.Events do
           | :log_message
           | :face_overrides_changed
           | :agent_session_stopped
+          | :agent_session_restarted
           | :agent_hook
           | :background_subagent_started
           | :node_connected
@@ -452,6 +454,8 @@ defmodule Minga.Events do
   @spec broadcast(:power_thermal_state_changed, PowerThermalStateEvent.t()) :: :ok
   @spec broadcast(:face_overrides_changed, FaceOverridesChangedEvent.t()) :: :ok
   @spec broadcast(:agent_session_stopped, MingaAgent.SessionManager.SessionStoppedEvent.t()) ::
+          :ok
+  @spec broadcast(:agent_session_restarted, MingaAgent.SessionManager.SessionRestartedEvent.t()) ::
           :ok
   @spec broadcast(:background_subagent_started, MingaAgent.Subagent.Handle.t()) :: :ok
   @spec broadcast(:node_connected, Minga.Distribution.Events.NodeConnectedEvent.t()) :: :ok

--- a/lib/minga_agent/event_log/event_record.ex
+++ b/lib/minga_agent/event_log/event_record.ex
@@ -7,6 +7,7 @@ defmodule MingaAgent.EventLog.EventRecord do
   @type event_type ::
           :session_started
           | :session_stopped
+          | :user_disconnected
           | :user_message
           | :assistant_delta
           | :thinking_delta

--- a/lib/minga_agent/event_log/taxonomy.ex
+++ b/lib/minga_agent/event_log/taxonomy.ex
@@ -6,6 +6,7 @@ defmodule MingaAgent.EventLog.Taxonomy do
   @events [
     :session_started,
     :session_stopped,
+    :user_disconnected,
     :user_message,
     :assistant_delta,
     :thinking_delta,

--- a/lib/minga_agent/gateway/event_stream.ex
+++ b/lib/minga_agent/gateway/event_stream.ex
@@ -13,6 +13,7 @@ defmodule MingaAgent.Gateway.EventStream do
 
   @topics [
     :agent_session_stopped,
+    :agent_session_restarted,
     :buffer_saved,
     :buffer_changed,
     :log_message
@@ -50,6 +51,15 @@ defmodule MingaAgent.Gateway.EventStream do
   defp encode_event(:agent_session_stopped, payload) do
     %{
       session_id: Map.get(payload, :session_id),
+      reason: inspect(Map.get(payload, :reason))
+    }
+  end
+
+  defp encode_event(:agent_session_restarted, payload) do
+    %{
+      session_id: Map.get(payload, :session_id),
+      old_pid: inspect(Map.get(payload, :old_pid)),
+      new_pid: inspect(Map.get(payload, :new_pid)),
       reason: inspect(Map.get(payload, :reason))
     }
   end

--- a/lib/minga_agent/remote_api.ex
+++ b/lib/minga_agent/remote_api.ex
@@ -48,9 +48,11 @@ defmodule MingaAgent.RemoteAPI do
   @spec list_sessions() :: [session_info()]
   def list_sessions do
     SessionManager.list_sessions()
-    |> Enum.map(fn {session_id, pid, _metadata} ->
-      {:ok, token} = SessionManager.session_token(session_id)
-      session_info(session_id, pid, token)
+    |> Enum.flat_map(fn {session_id, pid, _metadata} ->
+      case SessionManager.session_token(session_id) do
+        {:ok, token} -> [session_info(session_id, pid, token)]
+        {:error, _reason} -> []
+      end
     end)
   end
 

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -21,6 +21,7 @@ defmodule MingaAgent.Session do
 
   use GenServer
 
+  alias Minga.Config.Options
   alias MingaAgent.Branch
   alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.Credentials
@@ -84,6 +85,8 @@ defmodule MingaAgent.Session do
           subscribers: MapSet.t(pid()),
           subscriber_roles: %{pid() => attachment_role()},
           driver: pid() | nil,
+          idle_gc_timeout_ms: non_neg_integer(),
+          idle_gc_timer: {timer_ref :: reference(), token :: reference()} | nil,
           total_usage: Event.token_usage(),
           error_message: String.t() | nil,
           pending_thinking_level: String.t() | nil,
@@ -112,6 +115,18 @@ defmodule MingaAgent.Session do
         }
 
   # ── Public API ──────────────────────────────────────────────────────────────
+
+  @doc false
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: Keyword.get(opts, :id, __MODULE__),
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :transient,
+      shutdown: 5_000,
+      type: :worker
+    }
+  end
 
   @doc "Starts a new agent session."
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -318,7 +333,13 @@ defmodule MingaAgent.Session do
   @doc "Unsubscribes the calling process from session events."
   @spec unsubscribe(GenServer.server()) :: :ok
   def unsubscribe(session) do
-    GenServer.call(session, {:unsubscribe, self()})
+    unsubscribe(session, self())
+  end
+
+  @doc "Unsubscribes the given process from session events."
+  @spec unsubscribe(GenServer.server(), pid()) :: :ok
+  def unsubscribe(session, pid) when is_pid(pid) do
+    GenServer.call(session, {:unsubscribe, pid})
   end
 
   @doc "Manually triggers context compaction on the provider."
@@ -627,6 +648,8 @@ defmodule MingaAgent.Session do
       subscribers: MapSet.new(),
       subscriber_roles: %{},
       driver: nil,
+      idle_gc_timeout_ms: Keyword.get_lazy(opts, :idle_gc_timeout_ms, &idle_gc_timeout_ms/0),
+      idle_gc_timer: nil,
       total_usage: TurnUsage.new(),
       error_message: nil,
       pending_thinking_level: initial_thinking_level,
@@ -1012,7 +1035,7 @@ defmodule MingaAgent.Session do
   def handle_call({:subscribe, pid, opts}, _from, state) do
     Process.monitor(pid)
     role = Keyword.get(opts, :role, default_subscriber_role(state))
-    state = put_subscriber(state, pid, role)
+    state = state |> cancel_idle_gc_timer() |> put_subscriber(pid, role)
     {:reply, :ok, state}
   end
 
@@ -1028,7 +1051,7 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call({:unsubscribe, pid}, _from, state) do
-    {:reply, :ok, remove_subscriber(state, pid)}
+    {:reply, :ok, remove_subscriber(state, pid, :detached)}
   end
 
   def handle_call(:compact, _from, %{provider: nil} = state) do
@@ -1270,9 +1293,29 @@ defmodule MingaAgent.Session do
     {:noreply, state}
   end
 
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
     # A subscriber died, remove it and vacate the driver role if needed.
-    {:noreply, remove_subscriber(state, pid)}
+    {:noreply, remove_subscriber(state, pid, reason)}
+  end
+
+  def handle_info({:idle_gc_timeout, token}, %{idle_gc_timer: {_timer_ref, token}} = state) do
+    case idle_gc_reclaimable?(state) do
+      true ->
+        Minga.Log.info(
+          :agent,
+          "[Agent.Session] reclaiming idle detached session #{state.session_id}"
+        )
+
+        save_to_disk(state)
+        {:stop, :normal, %{state | idle_gc_timer: nil}}
+
+      false ->
+        {:noreply, maybe_schedule_idle_gc(%{state | idle_gc_timer: nil})}
+    end
+  end
+
+  def handle_info({:idle_gc_timeout, _token}, state) do
+    {:noreply, state}
   end
 
   def handle_info(:save_session, state) do
@@ -1796,7 +1839,7 @@ defmodule MingaAgent.Session do
 
     state = clear_turn_trust_for_status(state, new_status)
     broadcast(state, {:status_changed, new_status})
-    state
+    maybe_schedule_idle_gc(state)
   end
 
   @spec clear_turn_trust_for_status(state(), status()) :: state()
@@ -1941,16 +1984,79 @@ defmodule MingaAgent.Session do
     state
   end
 
-  @spec remove_subscriber(state(), pid()) :: state()
-  defp remove_subscriber(state, pid) do
+  @spec remove_subscriber(state(), pid(), term()) :: state()
+  defp remove_subscriber(state, pid, reason) do
+    was_subscribed? = MapSet.member?(state.subscribers, pid)
+    role = Map.get(state.subscriber_roles, pid)
     driver = if state.driver == pid, do: nil, else: state.driver
 
-    %{
+    state = %{
       state
       | subscribers: MapSet.delete(state.subscribers, pid),
         subscriber_roles: Map.delete(state.subscriber_roles, pid),
         driver: driver
     }
+
+    if was_subscribed? do
+      record_user_disconnected(state, pid, role, reason)
+    end
+
+    maybe_schedule_idle_gc(state)
+  end
+
+  @spec record_user_disconnected(state(), pid(), attachment_role() | nil, term()) :: :ok
+  defp record_user_disconnected(state, pid, role, reason) do
+    EventLog.record(
+      state.session_id,
+      :user_disconnected,
+      %{pid: inspect(pid), role: role, reason: inspect(reason)},
+      state.event_log_server
+    )
+  end
+
+  @spec maybe_schedule_idle_gc(state()) :: state()
+  defp maybe_schedule_idle_gc(state) do
+    schedule_idle_gc(
+      state,
+      idle_gc_reclaimable?(state),
+      state.idle_gc_timer,
+      state.idle_gc_timeout_ms
+    )
+  end
+
+  @spec schedule_idle_gc(
+          state(),
+          boolean(),
+          {timer_ref :: reference(), token :: reference()} | nil,
+          non_neg_integer()
+        ) :: state()
+  defp schedule_idle_gc(state, true, nil, timeout_ms) when timeout_ms > 0 do
+    token = make_ref()
+    timer_ref = Process.send_after(self(), {:idle_gc_timeout, token}, timeout_ms)
+    %{state | idle_gc_timer: {timer_ref, token}}
+  end
+
+  defp schedule_idle_gc(state, true, _timer, _timeout_ms), do: state
+  defp schedule_idle_gc(state, false, _timer, _timeout_ms), do: cancel_idle_gc_timer(state)
+
+  @spec cancel_idle_gc_timer(state()) :: state()
+  defp cancel_idle_gc_timer(%{idle_gc_timer: nil} = state), do: state
+
+  defp cancel_idle_gc_timer(state) do
+    {timer_ref, _token} = state.idle_gc_timer
+    Process.cancel_timer(timer_ref)
+    %{state | idle_gc_timer: nil}
+  end
+
+  @spec idle_gc_reclaimable?(state()) :: boolean()
+  defp idle_gc_reclaimable?(state) do
+    MapSet.size(state.subscribers) == 0 and state.status in [:idle, :plan, :error] and
+      state.pending_approval == nil and state.active_tool_calls == []
+  end
+
+  @spec idle_gc_timeout_ms() :: non_neg_integer()
+  defp idle_gc_timeout_ms do
+    Options.get(:agent_session_idle_timeout_ms)
   end
 
   @spec driver_allowed?(state(), pid()) :: boolean()

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -698,7 +698,7 @@ defmodule MingaAgent.Session do
     # Start provider asynchronously so init doesn't block
     send(self(), :start_provider)
 
-    {:ok, state}
+    {:ok, maybe_schedule_idle_gc(state)}
   end
 
   @impl GenServer
@@ -2082,7 +2082,16 @@ defmodule MingaAgent.Session do
       MingaAgent.EventLog.Store.close(db)
       record_interrupted_work(state, events)
     else
-      _ -> :ok
+      {:error, :database_not_found} ->
+        :ok
+
+      {:error, reason} ->
+        Minga.Log.warning(
+          :agent,
+          "[Session] mark_interrupted_work failed for #{state.session_id}: #{inspect(reason)}"
+        )
+
+        :ok
     end
   end
 

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -93,6 +93,7 @@ defmodule MingaAgent.Session do
           pending_approval: pending_approval() | nil,
           active_tool_calls: [active_tool_call()],
           active_tool_name: String.t() | nil,
+          turn_active?: boolean(),
           trust_levels: %{String.t() => trust_scope()},
           pending_auto_approvals: %{String.t() => trust_scope()},
           model_name: String.t(),
@@ -103,6 +104,7 @@ defmodule MingaAgent.Session do
           hooks_enabled?: boolean(),
           session_start_hook_enabled?: boolean(),
           save_timer: reference() | nil,
+          save_retry_count: non_neg_integer(),
           session_store_dir: String.t() | nil,
           created_at: DateTime.t(),
           last_message_at: DateTime.t(),
@@ -122,7 +124,7 @@ defmodule MingaAgent.Session do
     %{
       id: Keyword.get(opts, :id, __MODULE__),
       start: {__MODULE__, :start_link, [opts]},
-      restart: :transient,
+      restart: :temporary,
       shutdown: 5_000,
       type: :worker
     }
@@ -656,6 +658,7 @@ defmodule MingaAgent.Session do
       pending_approval: nil,
       active_tool_calls: [],
       active_tool_name: nil,
+      turn_active?: false,
       trust_levels: %{},
       pending_auto_approvals: %{},
       model_name: model_name,
@@ -667,6 +670,7 @@ defmodule MingaAgent.Session do
       session_start_hook_enabled?:
         Keyword.get(opts, :session_start_hook_enabled?, Keyword.get(opts, :hooks_enabled?, true)),
       save_timer: nil,
+      save_retry_count: 0,
       session_store_dir: Keyword.get(opts, :session_store_dir),
       created_at: now,
       last_message_at: now,
@@ -698,7 +702,7 @@ defmodule MingaAgent.Session do
     # Start provider asynchronously so init doesn't block
     send(self(), :start_provider)
 
-    {:ok, maybe_schedule_idle_gc(state)}
+    {:ok, schedule_idle_gc(state, state.idle_gc_timeout_ms > 0, nil, state.idle_gc_timeout_ms)}
   end
 
   @impl GenServer
@@ -876,6 +880,7 @@ defmodule MingaAgent.Session do
         pending_approval: nil,
         active_tool_calls: [],
         active_tool_name: nil,
+        turn_active?: false,
         created_at: now,
         last_message_at: now,
         steering_queue: [],
@@ -1284,7 +1289,7 @@ defmodule MingaAgent.Session do
 
   def handle_info({:DOWN, _ref, :process, pid, reason}, %{provider: pid} = state) do
     Minga.Log.warning(:agent, "[Agent.Session] provider process died: #{inspect(reason)}")
-    state = %{state | provider: nil, error_message: "Agent provider crashed"}
+    state = %{state | provider: nil, error_message: "Agent provider crashed", turn_active?: false}
     state = set_error_status(state)
     broadcast(state, {:error, state.error_message})
 
@@ -1306,8 +1311,18 @@ defmodule MingaAgent.Session do
           "[Agent.Session] reclaiming idle detached session #{state.session_id}"
         )
 
-        save_to_disk(state)
-        {:stop, :normal, %{state | idle_gc_timer: nil}}
+        case save_to_disk(state) do
+          :ok ->
+            {:stop, :normal, %{state | idle_gc_timer: nil}}
+
+          {:error, reason} ->
+            Minga.Log.error(
+              :agent,
+              "[Agent.Session] failed to reclaim idle detached session #{state.session_id}: #{inspect(reason)}"
+            )
+
+            {:noreply, maybe_schedule_idle_gc(%{state | idle_gc_timer: nil})}
+        end
 
       false ->
         {:noreply, maybe_schedule_idle_gc(%{state | idle_gc_timer: nil})}
@@ -1320,8 +1335,19 @@ defmodule MingaAgent.Session do
 
   def handle_info(:save_session, state) do
     state = %{state | save_timer: nil}
-    save_to_disk(state)
-    {:noreply, state}
+
+    case save_to_disk(state) do
+      :ok ->
+        {:noreply, %{state | save_retry_count: 0}}
+
+      {:error, reason} ->
+        Minga.Log.error(
+          :agent,
+          "[Agent.Session] failed to save session #{state.session_id} to disk: #{inspect(reason)}"
+        )
+
+        {:noreply, schedule_save_retry(state)}
+    end
   end
 
   def handle_info(_msg, state) do
@@ -1410,12 +1436,19 @@ defmodule MingaAgent.Session do
         state = append_msg(state, user_msg)
         record_user_message(state, user_msg)
         state = notify_messages_changed(state)
+        state = %{state | turn_active?: true}
 
         case state.provider_module.send_prompt(state.provider, send_content) do
           :ok ->
             {:reply, :ok, state}
 
           {:error, _} = err ->
+            state =
+              state
+              |> cancel_idle_gc_timer()
+              |> Map.put(:turn_active?, false)
+              |> maybe_schedule_idle_gc()
+
             {:reply, err, state}
         end
 
@@ -1428,11 +1461,12 @@ defmodule MingaAgent.Session do
 
   @spec handle_provider_event(Event.t(), state()) :: state()
   defp handle_provider_event(%Event.AgentStart{}, state) do
-    state = %{state | pending_approval: nil}
+    state = %{state | pending_approval: nil, turn_active?: true}
     set_working_status(state, :thinking)
   end
 
   defp handle_provider_event(%Event.AgentEnd{usage: usage}, state) do
+    state = %{state | turn_active?: false}
     notify(state, :complete, completion_notification(state))
 
     state =
@@ -1864,12 +1898,16 @@ defmodule MingaAgent.Session do
   defp set_working_status(state, new_status), do: set_status(state, new_status)
 
   @spec set_idle_or_plan(state()) :: state()
-  defp set_idle_or_plan(%{status: :plan} = state), do: state
-  defp set_idle_or_plan(state), do: set_status(state, :idle)
+  defp set_idle_or_plan(%{status: :plan} = state),
+    do: maybe_schedule_idle_gc(%{state | turn_active?: false})
+
+  defp set_idle_or_plan(state), do: set_status(%{state | turn_active?: false}, :idle)
 
   @spec set_error_status(state()) :: state()
-  defp set_error_status(%{status: :plan} = state), do: state
-  defp set_error_status(state), do: set_status(state, :error)
+  defp set_error_status(%{status: :plan} = state),
+    do: maybe_schedule_idle_gc(%{state | turn_active?: false})
+
+  defp set_error_status(state), do: set_status(%{state | turn_active?: false}, :error)
 
   @spec track_active_tool_start(state(), String.t(), String.t()) :: state()
   defp track_active_tool_start(state, tool_call_id, name) do
@@ -2014,7 +2052,7 @@ defmodule MingaAgent.Session do
     )
   end
 
-  @spec maybe_schedule_idle_gc(state()) :: state()
+  @spec maybe_schedule_idle_gc(map()) :: map()
   defp maybe_schedule_idle_gc(state) do
     schedule_idle_gc(
       state,
@@ -2025,11 +2063,11 @@ defmodule MingaAgent.Session do
   end
 
   @spec schedule_idle_gc(
-          state(),
+          map(),
           boolean(),
           {timer_ref :: reference(), token :: reference()} | nil,
           non_neg_integer()
-        ) :: state()
+        ) :: map()
   defp schedule_idle_gc(state, true, nil, timeout_ms) when timeout_ms > 0 do
     token = make_ref()
     timer_ref = Process.send_after(self(), {:idle_gc_timeout, token}, timeout_ms)
@@ -2039,7 +2077,7 @@ defmodule MingaAgent.Session do
   defp schedule_idle_gc(state, true, _timer, _timeout_ms), do: state
   defp schedule_idle_gc(state, false, _timer, _timeout_ms), do: cancel_idle_gc_timer(state)
 
-  @spec cancel_idle_gc_timer(state()) :: state()
+  @spec cancel_idle_gc_timer(map()) :: map()
   defp cancel_idle_gc_timer(%{idle_gc_timer: nil} = state), do: state
 
   defp cancel_idle_gc_timer(state) do
@@ -2048,10 +2086,11 @@ defmodule MingaAgent.Session do
     %{state | idle_gc_timer: nil}
   end
 
-  @spec idle_gc_reclaimable?(state()) :: boolean()
+  @spec idle_gc_reclaimable?(map()) :: boolean()
   defp idle_gc_reclaimable?(state) do
     MapSet.size(state.subscribers) == 0 and state.status in [:idle, :plan, :error] and
-      state.pending_approval == nil and state.active_tool_calls == []
+      state.pending_approval == nil and state.active_tool_calls == [] and not state.turn_active? and
+      state.steering_queue == [] and state.follow_up_queue == []
   end
 
   @spec idle_gc_timeout_ms() :: non_neg_integer()
@@ -2077,11 +2116,25 @@ defmodule MingaAgent.Session do
 
   @spec mark_interrupted_work(state()) :: :ok
   defp mark_interrupted_work(state) do
-    with {:ok, db} <- EventLog.open_read_connection(),
-         {:ok, events} <- all_event_log_events(db, state.session_id) do
-      MingaAgent.EventLog.Store.close(db)
-      record_interrupted_work(state, events)
-    else
+    case EventLog.open_read_connection() do
+      {:ok, db} ->
+        try do
+          case all_event_log_events(db, state.session_id) do
+            {:ok, events} ->
+              record_interrupted_work(state, events)
+
+            {:error, reason} ->
+              Minga.Log.warning(
+                :agent,
+                "[Session] mark_interrupted_work failed for #{state.session_id}: #{inspect(reason)}"
+              )
+
+              :ok
+          end
+        after
+          MingaAgent.EventLog.Store.close(db)
+        end
+
       {:error, :database_not_found} ->
         :ok
 
@@ -2598,7 +2651,7 @@ defmodule MingaAgent.Session do
   defp schedule_save(state) do
     state = cancel_save_timer(state)
     ref = Process.send_after(self(), :save_session, @save_debounce_ms)
-    %{state | save_timer: ref}
+    %{state | save_timer: ref, save_retry_count: 0}
   end
 
   @spec cancel_save_timer(state()) :: state()
@@ -2609,7 +2662,12 @@ defmodule MingaAgent.Session do
     %{state | save_timer: nil}
   end
 
+  @save_retry_base_ms 5_000
+  @save_retry_max_ms 60_000
+
   @spec save_to_disk(state()) :: :ok | {:error, term()}
+  defp save_to_disk(%{persist?: false}), do: :ok
+
   defp save_to_disk(state) do
     now = DateTime.to_iso8601(DateTime.utc_now())
     last_message_at = DateTime.to_iso8601(state.last_message_at)
@@ -2629,6 +2687,22 @@ defmodule MingaAgent.Session do
     }
 
     SessionStore.save(data, state.session_store_dir)
+  end
+
+  @spec schedule_save_retry(state()) :: state()
+  defp schedule_save_retry(state) do
+    retry_count = state.save_retry_count + 1
+    delay_ms = retry_delay_ms(retry_count)
+    ref = Process.send_after(self(), :save_session, delay_ms)
+    %{state | save_timer: ref, save_retry_count: retry_count}
+  end
+
+  @spec retry_delay_ms(non_neg_integer()) :: non_neg_integer()
+  defp retry_delay_ms(retry_count) when retry_count <= 1, do: @save_retry_base_ms
+
+  defp retry_delay_ms(retry_count) do
+    exponential = @save_retry_base_ms * round(:math.pow(2, retry_count - 1))
+    min(exponential, @save_retry_max_ms)
   end
 
   @spec restore_loaded_session(state(), SessionStore.session_data()) ::
@@ -2675,7 +2749,10 @@ defmodule MingaAgent.Session do
   defp finish_loaded_session_restore(state, data) do
     case restore_memory_snapshot_if_recorded(state, data) do
       :ok ->
-        state = reset_messages(state, data.messages)
+        state =
+          state
+          |> reset_messages(data.messages)
+          |> seed_provider_messages(data.messages)
 
         broadcast(state, {:status_changed, :idle})
         broadcast(state, :messages_changed)

--- a/lib/minga_agent/session_manager.ex
+++ b/lib/minga_agent/session_manager.ex
@@ -6,15 +6,16 @@ defmodule MingaAgent.SessionManager do
   human-readable generated IDs (e.g., `"session-1"`), while remote attach sessions
   pass a deterministic `:session_id` derived from their server-side working directory.
   Sessions are started via `MingaAgent.Supervisor` (DynamicSupervisor) and
-  monitored here. When a session dies, the manager broadcasts an
-  `:agent_session_stopped` event so the Editor (or any subscriber) can
-  react without monitoring PIDs directly.
+  monitored here. When a session dies or restarts, the manager broadcasts
+  lifecycle events so the Editor (or any subscriber) can react without
+  monitoring PIDs directly.
   """
 
   use GenServer
 
   alias MingaAgent.Session
   alias MingaAgent.SessionMetadata
+  alias MingaAgent.SessionStore
   alias MingaAgent.Subagent.Handle
 
   # ── Types ──────────────────────────────────────────────────────────────────
@@ -26,11 +27,23 @@ defmodule MingaAgent.SessionManager do
           next_id: pos_integer()
         }
 
+  @typedoc "Restart bookkeeping for a managed session that is being recovered."
+  @type restart_state :: %{
+          attempts: pos_integer(),
+          window_started_at_ms: integer(),
+          timer_ref: reference() | nil,
+          timer_token: reference() | nil,
+          old_pid: pid(),
+          reason: term()
+        }
+
   @typedoc "An entry in the sessions map."
   @type session_entry :: %{
           pid: pid(),
-          monitor_ref: reference(),
-          token: String.t()
+          monitor_ref: reference() | nil,
+          token: String.t(),
+          restart_opts: keyword(),
+          restart_state: restart_state() | nil
         }
 
   # ── Event payload ──────────────────────────────────────────────────────────
@@ -46,6 +59,24 @@ defmodule MingaAgent.SessionManager do
             reason: term()
           }
   end
+
+  defmodule SessionRestartedEvent do
+    @moduledoc "Payload for `:agent_session_restarted` events."
+    @enforce_keys [:session_id, :old_pid, :new_pid, :reason]
+    defstruct [:session_id, :old_pid, :new_pid, :reason]
+
+    @type t :: %__MODULE__{
+            session_id: String.t(),
+            old_pid: pid(),
+            new_pid: pid(),
+            reason: term()
+          }
+  end
+
+  @restart_default_base_delay_ms 10
+  @restart_default_max_delay_ms 100
+  @restart_default_max_attempts 3
+  @restart_default_window_ms 60_000
 
   # ── Public API ─────────────────────────────────────────────────────────────
 
@@ -276,13 +307,14 @@ defmodule MingaAgent.SessionManager do
 
   def handle_call({:stop_session, session_id}, _from, state) do
     case Map.fetch(state.sessions, session_id) do
-      {:ok, %{pid: pid, monitor_ref: ref}} ->
+      {:ok, %{monitor_ref: ref, pid: pid}} when is_reference(ref) ->
         Process.demonitor(ref, [:flush])
         MingaAgent.Supervisor.stop_session(pid)
-        sessions = Map.delete(state.sessions, session_id)
-        background_subagents = Map.delete(state.background_subagents, session_id)
-        Minga.Log.info(:agent, "[SessionManager] Stopped session #{session_id}")
-        {:reply, :ok, %{state | sessions: sessions, background_subagents: background_subagents}}
+        {:reply, :ok, remove_session(state, session_id)}
+
+      {:ok, %{monitor_ref: nil, restart_state: %{timer_ref: timer_ref}}} ->
+        Process.cancel_timer(timer_ref)
+        {:reply, :ok, remove_session(state, session_id)}
 
       :error ->
         {:reply, {:error, :not_found}, state}
@@ -291,29 +323,31 @@ defmodule MingaAgent.SessionManager do
 
   def handle_call({:send_prompt, session_id, prompt}, _from, state) do
     case Map.fetch(state.sessions, session_id) do
-      {:ok, %{pid: pid}} ->
+      {:ok, %{monitor_ref: ref, pid: pid}} when is_reference(ref) ->
         result = Session.send_prompt(pid, prompt)
         {:reply, result, state}
 
-      :error ->
+      _ ->
         {:reply, {:error, :not_found}, state}
     end
   end
 
   def handle_call({:abort, session_id}, _from, state) do
     case Map.fetch(state.sessions, session_id) do
-      {:ok, %{pid: pid}} ->
+      {:ok, %{monitor_ref: ref, pid: pid}} when is_reference(ref) ->
         Session.abort(pid)
         {:reply, :ok, state}
 
-      :error ->
+      _ ->
         {:reply, {:error, :not_found}, state}
     end
   end
 
   def handle_call(:list_sessions, _from, state) do
     entries =
-      Enum.map(state.sessions, fn {session_id, %{pid: pid}} ->
+      state.sessions
+      |> Enum.filter(fn {_session_id, entry} -> active_session_entry?(entry) end)
+      |> Enum.map(fn {session_id, %{pid: pid}} ->
         metadata = safe_metadata(pid)
         {session_id, pid, metadata}
       end)
@@ -323,15 +357,18 @@ defmodule MingaAgent.SessionManager do
 
   def handle_call({:get_session, session_id}, _from, state) do
     case Map.fetch(state.sessions, session_id) do
-      {:ok, %{pid: pid}} -> {:reply, {:ok, pid}, state}
-      :error -> {:reply, {:error, :not_found}, state}
+      {:ok, %{monitor_ref: ref, pid: pid}} when is_reference(ref) -> {:reply, {:ok, pid}, state}
+      _ -> {:reply, {:error, :not_found}, state}
     end
   end
 
   def handle_call({:session_token, session_id}, _from, state) do
     case Map.fetch(state.sessions, session_id) do
-      {:ok, %{token: token}} -> {:reply, {:ok, token}, state}
-      :error -> {:reply, {:error, :not_found}, state}
+      {:ok, %{monitor_ref: ref, token: token}} when is_reference(ref) ->
+        {:reply, {:ok, token}, state}
+
+      _ ->
+        {:reply, {:error, :not_found}, state}
     end
   end
 
@@ -340,10 +377,7 @@ defmodule MingaAgent.SessionManager do
       {session_id, %{monitor_ref: ref}} ->
         Process.demonitor(ref, [:flush])
         MingaAgent.Supervisor.stop_session(pid)
-        sessions = Map.delete(state.sessions, session_id)
-        background_subagents = Map.delete(state.background_subagents, session_id)
-        Minga.Log.info(:agent, "[SessionManager] Stopped session #{session_id} (by pid)")
-        {:reply, :ok, %{state | sessions: sessions, background_subagents: background_subagents}}
+        {:reply, :ok, remove_session(state, session_id)}
 
       nil ->
         {:reply, {:error, :not_found}, state}
@@ -353,7 +387,7 @@ defmodule MingaAgent.SessionManager do
   def handle_call({:session_id_for_pid, pid}, _from, state) do
     result =
       Enum.find_value(state.sessions, {:error, :not_found}, fn
-        {session_id, %{pid: ^pid}} -> {:ok, session_id}
+        {session_id, %{monitor_ref: ref, pid: ^pid}} when is_reference(ref) -> {:ok, session_id}
         _ -> nil
       end)
 
@@ -363,18 +397,30 @@ defmodule MingaAgent.SessionManager do
   @impl GenServer
   def handle_info({:DOWN, ref, :process, pid, reason}, state) do
     case find_session_by_ref(state.sessions, ref) do
-      {session_id, _entry} ->
-        Minga.Log.info(
-          :agent,
-          "[SessionManager] Session #{session_id} (#{inspect(pid)}) stopped: #{inspect(reason)}"
-        )
+      {session_id, entry} ->
+        if should_restart_session?(reason) do
+          handle_session_restart_down(state, session_id, entry, pid, reason)
+        else
+          Minga.Log.info(
+            :agent,
+            "[SessionManager] Session #{session_id} (#{inspect(pid)}) stopped: #{inspect(reason)}"
+          )
 
-        broadcast_session_stopped(session_id, pid, reason)
-        sessions = Map.delete(state.sessions, session_id)
-        background_subagents = Map.delete(state.background_subagents, session_id)
-        {:noreply, %{state | sessions: sessions, background_subagents: background_subagents}}
+          broadcast_session_stopped(session_id, pid, reason)
+          {:noreply, remove_session(state, session_id)}
+        end
 
       nil ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:restart_session, session_id, timer_token}, state) do
+    case Map.fetch(state.sessions, session_id) do
+      {:ok, %{restart_state: %{timer_token: ^timer_token}} = entry} ->
+        handle_session_restart_timeout(state, session_id, entry)
+
+      _ ->
         {:noreply, state}
     end
   end
@@ -439,8 +485,11 @@ defmodule MingaAgent.SessionManager do
     session_id = Keyword.get(opts, :session_id, "session-#{state.next_id}")
 
     case Map.fetch(state.sessions, session_id) do
-      {:ok, %{pid: pid}} ->
+      {:ok, %{monitor_ref: ref, pid: pid}} when is_reference(ref) ->
         {:existing, session_id, pid, state}
+
+      {:ok, %{monitor_ref: nil}} ->
+        {:error, :restart_pending}
 
       :error ->
         do_start_managed_session(state, Keyword.put(opts, :session_id, session_id), session_id)
@@ -456,7 +505,15 @@ defmodule MingaAgent.SessionManager do
     case MingaAgent.Supervisor.start_session(opts) do
       {:ok, pid} ->
         ref = Process.monitor(pid)
-        entry = %{pid: pid, monitor_ref: ref, token: token}
+
+        entry = %{
+          pid: pid,
+          monitor_ref: ref,
+          token: token,
+          restart_opts: opts,
+          restart_state: nil
+        }
+
         sessions = Map.put(state.sessions, session_id, entry)
         next_id = next_id_after_start(state, session_id)
         new_state = %{state | sessions: sessions, next_id: next_id}
@@ -475,22 +532,327 @@ defmodule MingaAgent.SessionManager do
 
   @spec session_token_for_start(String.t(), keyword()) :: String.t()
   defp session_token_for_start(session_id, opts) do
-    Keyword.get(opts, :remote_token) || stored_session_token(session_id, opts) || generate_token()
+    case Keyword.get(opts, :remote_token) do
+      token when is_binary(token) ->
+        token
+
+      _ ->
+        case stored_session_token(session_id, opts) do
+          {:ok, token} ->
+            token
+
+          :missing ->
+            generate_token()
+
+          {:error, reason} ->
+            log_session_store_load_error(session_id, resolved_session_store_dir(opts), reason)
+            generate_token()
+        end
+    end
   end
 
-  @spec stored_session_token(String.t(), keyword()) :: String.t() | nil
+  @spec stored_session_token(String.t(), keyword()) ::
+          {:ok, String.t()} | :missing | {:error, term()}
   defp stored_session_token(session_id, opts) do
     session_store_dir = Keyword.get(opts, :session_store_dir)
 
-    case MingaAgent.SessionStore.load(session_id, session_store_dir) do
-      {:ok, data} -> Map.get(data, :remote_token)
-      {:error, _reason} -> nil
+    case SessionStore.load(session_id, session_store_dir) do
+      {:ok, data} ->
+        case Map.get(data, :remote_token) do
+          token when is_binary(token) -> {:ok, token}
+          _ -> :missing
+        end
+
+      {:error, :enoent} ->
+        :missing
+
+      {:error, reason} ->
+        {:error, reason}
     end
+  end
+
+  @spec log_session_store_load_error(String.t(), String.t() | nil, term()) :: :ok
+  defp log_session_store_load_error(session_id, session_store_dir, reason) do
+    message =
+      "[SessionManager] Failed to load persisted remote token for session #{session_id} from #{inspect(session_store_dir)}: #{inspect(reason)}"
+
+    case reason do
+      :enoent -> Minga.Log.warning(:agent, message)
+      _ -> Minga.Log.error(:agent, message)
+    end
+
+    :ok
   end
 
   @spec generate_token() :: String.t()
   defp generate_token do
     32 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
+  end
+
+  @spec active_session_entry?(session_entry()) :: boolean()
+  defp active_session_entry?(%{monitor_ref: ref}) when is_reference(ref), do: true
+  defp active_session_entry?(_entry), do: false
+
+  @spec handle_session_restart_down(state(), String.t(), session_entry(), pid(), term()) ::
+          {:noreply, state()}
+  defp handle_session_restart_down(state, session_id, entry, old_pid, reason) do
+    case next_restart_attempt(entry, old_pid, reason) do
+      {:ok, entry, delay_ms} ->
+        timer_token = make_ref()
+
+        timer_ref =
+          Process.send_after(
+            self(),
+            {:restart_session, session_id, timer_token},
+            delay_ms
+          )
+
+        entry = entry |> put_restart_timer(timer_ref, timer_token) |> Map.put(:monitor_ref, nil)
+        {:noreply, put_session_entry(state, session_id, entry)}
+
+      :exhausted ->
+        Minga.Log.error(
+          :agent,
+          "[SessionManager] Exhausted restart attempts for session #{session_id} after #{inspect(reason)}"
+        )
+
+        broadcast_session_stopped(session_id, old_pid, {:restart_exhausted, reason})
+        {:noreply, remove_session(state, session_id)}
+    end
+  end
+
+  @spec handle_session_restart_timeout(state(), String.t(), session_entry()) ::
+          {:noreply, state()}
+  defp handle_session_restart_timeout(state, session_id, entry) do
+    restart_state = entry.restart_state
+
+    case restart_managed_session(state, session_id, entry) do
+      {:ok, new_state, new_pid} ->
+        new_state = restore_restarted_session_state(new_state, session_id, new_pid, entry)
+
+        broadcast_session_restarted(
+          session_id,
+          restart_state.old_pid,
+          new_pid,
+          restart_state.reason
+        )
+
+        {:noreply, new_state}
+
+      {:error, restart_reason, new_state} ->
+        Minga.Log.error(
+          :agent,
+          "[SessionManager] Failed to restart session #{session_id} after #{inspect(restart_state.reason)}: #{inspect(restart_reason)}"
+        )
+
+        case next_restart_attempt(
+               %{entry | restart_state: %{restart_state | timer_ref: nil, timer_token: nil}},
+               restart_state.old_pid,
+               {:restart_failed, restart_reason}
+             ) do
+          {:ok, retry_entry, delay_ms} ->
+            timer_token = make_ref()
+
+            timer_ref =
+              Process.send_after(
+                self(),
+                {:restart_session, session_id, timer_token},
+                delay_ms
+              )
+
+            retry_entry = put_restart_timer(retry_entry, timer_ref, timer_token)
+            {:noreply, put_session_entry(new_state, session_id, retry_entry)}
+
+          :exhausted ->
+            Minga.Log.error(
+              :agent,
+              "[SessionManager] Exhausted restart attempts for session #{session_id} while recovering: #{inspect(restart_reason)}"
+            )
+
+            broadcast_session_stopped(
+              session_id,
+              restart_state.old_pid,
+              {:restart_exhausted, restart_reason}
+            )
+
+            {:noreply, remove_session(new_state, session_id)}
+        end
+    end
+  end
+
+  @spec next_restart_attempt(session_entry(), pid(), term()) ::
+          {:ok, session_entry(), non_neg_integer()} | :exhausted
+  defp next_restart_attempt(%{restart_opts: opts} = entry, old_pid, reason) do
+    now_ms = System.monotonic_time(:millisecond)
+    policy = restart_policy(opts)
+    current = entry.restart_state
+
+    {attempts, window_started_at_ms} =
+      case current do
+        %{window_started_at_ms: window_started_at_ms, attempts: attempts}
+        when now_ms - window_started_at_ms <= policy.window_ms ->
+          {attempts + 1, window_started_at_ms}
+
+        _ ->
+          {1, now_ms}
+      end
+
+    if attempts > policy.max_attempts do
+      :exhausted
+    else
+      restart_state = %{
+        attempts: attempts,
+        window_started_at_ms: window_started_at_ms,
+        timer_ref: nil,
+        timer_token: nil,
+        old_pid: old_pid,
+        reason: reason
+      }
+
+      {:ok, %{entry | restart_state: restart_state}, restart_delay_ms(policy, attempts)}
+    end
+  end
+
+  @spec put_restart_timer(session_entry(), reference(), reference()) :: session_entry()
+  defp put_restart_timer(entry, timer_ref, timer_token) do
+    %{
+      entry
+      | restart_state: %{entry.restart_state | timer_ref: timer_ref, timer_token: timer_token}
+    }
+  end
+
+  @spec put_session_entry(state(), String.t(), session_entry()) :: state()
+  defp put_session_entry(state, session_id, entry) do
+    %{state | sessions: Map.put(state.sessions, session_id, entry)}
+  end
+
+  @spec remove_session(state(), String.t()) :: state()
+  defp remove_session(state, session_id) do
+    case Map.fetch(state.sessions, session_id) do
+      {:ok, %{restart_state: %{timer_ref: timer_ref}}} when is_reference(timer_ref) ->
+        Process.cancel_timer(timer_ref)
+
+      _ ->
+        :ok
+    end
+
+    sessions = Map.delete(state.sessions, session_id)
+    background_subagents = Map.delete(state.background_subagents, session_id)
+    %{state | sessions: sessions, background_subagents: background_subagents}
+  end
+
+  @spec restart_policy(keyword()) :: %{
+          base_delay_ms: pos_integer(),
+          max_attempts: pos_integer(),
+          max_delay_ms: pos_integer(),
+          window_ms: non_neg_integer()
+        }
+  defp restart_policy(opts) do
+    %{
+      base_delay_ms: Keyword.get(opts, :restart_backoff_base_ms, @restart_default_base_delay_ms),
+      max_attempts: Keyword.get(opts, :restart_max_attempts, @restart_default_max_attempts),
+      max_delay_ms: Keyword.get(opts, :restart_backoff_max_ms, @restart_default_max_delay_ms),
+      window_ms: Keyword.get(opts, :restart_window_ms, @restart_default_window_ms)
+    }
+  end
+
+  @spec restart_delay_ms(
+          %{
+            base_delay_ms: pos_integer(),
+            max_attempts: pos_integer(),
+            max_delay_ms: pos_integer(),
+            window_ms: non_neg_integer()
+          },
+          pos_integer()
+        ) :: pos_integer()
+  defp restart_delay_ms(%{base_delay_ms: base_delay_ms, max_delay_ms: max_delay_ms}, attempts) do
+    exponential = base_delay_ms * round(:math.pow(2, attempts - 1))
+    min(exponential, max_delay_ms)
+  end
+
+  @spec restore_restarted_session_state(state(), String.t(), pid(), session_entry()) :: state()
+  defp restore_restarted_session_state(state, session_id, new_pid, entry) do
+    restart_state = %{entry.restart_state | timer_ref: nil, timer_token: nil}
+
+    entry = %{
+      entry
+      | pid: new_pid,
+        monitor_ref: Process.monitor(new_pid),
+        restart_state: restart_state
+    }
+
+    state = put_session_entry(state, session_id, entry)
+
+    background_subagents =
+      state.background_subagents
+      |> update_background_subagent_pid(session_id, new_pid)
+      |> update_background_subagent_parent_pid(restart_state.old_pid, new_pid)
+
+    state = %{state | background_subagents: background_subagents}
+
+    case maybe_restore_persisted_restart(new_pid, session_id, entry.restart_opts) do
+      :restored ->
+        Minga.Log.info(
+          :agent,
+          "[SessionManager] Restored persisted state for restarted session #{session_id}"
+        )
+
+        state
+
+      :skipped ->
+        state
+
+      {:degraded, reason} ->
+        log_restart_restore_failure(session_id, entry.restart_opts, reason)
+        Session.add_system_message(new_pid, restart_restore_warning_message(reason), :error)
+        state
+    end
+  end
+
+  @spec maybe_restore_persisted_restart(pid(), String.t(), keyword()) ::
+          :restored | :skipped | {:degraded, term()}
+  defp maybe_restore_persisted_restart(pid, session_id, opts) do
+    if Keyword.get(opts, :persist?, true) do
+      case Session.load_session(pid, session_id) do
+        :ok ->
+          :restored
+
+        {:error, reason} ->
+          {:degraded, reason}
+      end
+    else
+      Minga.Log.debug(
+        :agent,
+        "[SessionManager] Restarted session #{session_id} without persisted state (persist?: false)"
+      )
+
+      :skipped
+    end
+  end
+
+  @spec log_restart_restore_failure(String.t(), keyword(), term()) :: :ok
+  defp log_restart_restore_failure(session_id, opts, reason) do
+    session_store_dir = resolved_session_store_dir(opts)
+
+    message =
+      "[SessionManager] Restarted session #{session_id} from #{inspect(session_store_dir)} could not restore prior context: #{inspect(reason)}"
+
+    case reason do
+      :enoent -> Minga.Log.warning(:agent, message)
+      _ -> Minga.Log.error(:agent, message)
+    end
+
+    :ok
+  end
+
+  @spec restart_restore_warning_message(term()) :: String.t()
+  defp restart_restore_warning_message(reason) do
+    "Session restarted after crash, but prior context could not be restored: #{inspect(reason)}"
+  end
+
+  @spec resolved_session_store_dir(keyword()) :: String.t()
+  defp resolved_session_store_dir(opts) do
+    SessionStore.sessions_dir(Keyword.get(opts, :session_store_dir))
   end
 
   @background_prompt_retry_ms 10
@@ -499,17 +861,16 @@ defmodule MingaAgent.SessionManager do
   @spec send_background_prompt(state(), String.t(), pid(), String.t(), non_neg_integer()) ::
           state()
   defp send_background_prompt(state, session_id, pid, task, attempt) do
-    case Session.send_prompt(pid, task) do
+    case safe_send_prompt(pid, task) do
       :ok ->
         state
 
       {:error, :provider_not_ready} when attempt < @background_prompt_max_attempts ->
-        Process.send_after(
-          self(),
-          {:send_background_prompt, session_id, task, attempt + 1},
-          @background_prompt_retry_ms
-        )
+        schedule_background_prompt_retry(session_id, task, attempt)
+        state
 
+      {:exit, _reason} when attempt < @background_prompt_max_attempts ->
+        schedule_background_prompt_retry(session_id, task, attempt)
         state
 
       {:error, reason} ->
@@ -520,7 +881,39 @@ defmodule MingaAgent.SessionManager do
         )
 
         state
+
+      {:exit, reason} ->
+        log_background_prompt_failure(session_id, pid, attempt, reason)
+        state
     end
+  end
+
+  @spec schedule_background_prompt_retry(String.t(), String.t(), non_neg_integer()) :: :ok
+  defp schedule_background_prompt_retry(session_id, task, attempt) do
+    Process.send_after(
+      self(),
+      {:send_background_prompt, session_id, task, attempt + 1},
+      @background_prompt_retry_ms
+    )
+
+    :ok
+  end
+
+  @spec safe_send_prompt(pid(), String.t()) :: :ok | {:error, term()} | {:exit, term()}
+  defp safe_send_prompt(pid, task) do
+    Session.send_prompt(pid, task)
+  catch
+    :exit, reason -> {:exit, reason}
+  end
+
+  @spec log_background_prompt_failure(String.t(), pid(), non_neg_integer(), term()) :: :ok
+  defp log_background_prompt_failure(session_id, pid, attempt, reason) do
+    Minga.Log.error(
+      :agent,
+      "[SessionManager] Background sub-agent #{session_id} (#{inspect(pid)}) failed to accept prompt after #{attempt + 1} attempts: #{inspect(reason)}"
+    )
+
+    :ok
   end
 
   @spec parent_session_id(state(), pid() | nil) :: String.t() | nil
@@ -547,6 +940,39 @@ defmodule MingaAgent.SessionManager do
     Enum.filter(handles, &(&1.parent_pid == parent_pid))
   end
 
+  @spec restart_managed_session(state(), String.t(), session_entry()) ::
+          {:ok, state(), pid()} | {:error, term(), state()}
+  defp restart_managed_session(state, _session_id, %{restart_opts: restart_opts}) do
+    case MingaAgent.Supervisor.start_session(restart_opts) do
+      {:ok, pid} ->
+        {:ok, state, pid}
+
+      {:error, restart_reason} ->
+        {:error, restart_reason, state}
+    end
+  end
+
+  @spec update_background_subagent_pid(%{String.t() => Handle.t()}, String.t(), pid()) ::
+          %{String.t() => Handle.t()}
+  defp update_background_subagent_pid(background_subagents, session_id, pid) do
+    case Map.fetch(background_subagents, session_id) do
+      {:ok, handle} -> Map.put(background_subagents, session_id, Handle.with_pid(handle, pid))
+      :error -> background_subagents
+    end
+  end
+
+  @spec update_background_subagent_parent_pid(%{String.t() => Handle.t()}, pid(), pid()) ::
+          %{String.t() => Handle.t()}
+  defp update_background_subagent_parent_pid(background_subagents, old_parent_pid, new_parent_pid) do
+    Enum.reduce(background_subagents, background_subagents, fn
+      {session_id, %Handle{parent_pid: ^old_parent_pid} = handle}, acc ->
+        Map.put(acc, session_id, Handle.with_parent_pid(handle, new_parent_pid))
+
+      _entry, acc ->
+        acc
+    end)
+  end
+
   @spec broadcast_background_subagent_started(Handle.t()) :: :ok
   defp broadcast_background_subagent_started(%Handle{} = handle) do
     Minga.Events.broadcast(:background_subagent_started, handle)
@@ -561,14 +987,35 @@ defmodule MingaAgent.SessionManager do
   @spec find_session_by_pid(%{String.t() => session_entry()}, pid()) ::
           {String.t(), session_entry()} | nil
   defp find_session_by_pid(sessions, pid) do
-    Enum.find(sessions, fn {_id, entry} -> entry.pid == pid end)
+    Enum.find(sessions, fn {_id, entry} ->
+      entry.pid == pid and is_reference(entry.monitor_ref)
+    end)
   end
+
+  @spec should_restart_session?(term()) :: boolean()
+  defp should_restart_session?(:normal), do: false
+  defp should_restart_session?(:shutdown), do: false
+  defp should_restart_session?({:shutdown, _}), do: false
+  defp should_restart_session?(_reason), do: true
 
   @spec broadcast_session_stopped(String.t(), pid(), term()) :: :ok
   defp broadcast_session_stopped(session_id, pid, reason) do
     Minga.Events.broadcast(
       :agent_session_stopped,
       %SessionStoppedEvent{session_id: session_id, pid: pid, reason: reason}
+    )
+  end
+
+  @spec broadcast_session_restarted(String.t(), pid(), pid(), term()) :: :ok
+  defp broadcast_session_restarted(session_id, old_pid, new_pid, reason) do
+    Minga.Events.broadcast(
+      :agent_session_restarted,
+      %SessionRestartedEvent{
+        session_id: session_id,
+        old_pid: old_pid,
+        new_pid: new_pid,
+        reason: reason
+      }
     )
   end
 

--- a/lib/minga_agent/subagent/handle.ex
+++ b/lib/minga_agent/subagent/handle.ex
@@ -56,6 +56,19 @@ defmodule MingaAgent.Subagent.Handle do
     end
   end
 
+  @doc "Returns a copy of the handle with a different pid."
+  @spec with_pid(t(), pid()) :: t()
+  def with_pid(%__MODULE__{} = handle, pid) when is_pid(pid) do
+    %{handle | pid: pid}
+  end
+
+  @doc "Returns a copy of the handle with a different parent pid."
+  @spec with_parent_pid(t(), pid() | nil) :: t()
+  def with_parent_pid(%__MODULE__{} = handle, parent_pid)
+      when is_pid(parent_pid) or is_nil(parent_pid) do
+    %{handle | parent_pid: parent_pid}
+  end
+
   @spec truncate(String.t(), pos_integer()) :: String.t()
   defp truncate(text, max_len) do
     if String.length(text) > max_len do

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -222,6 +222,7 @@ defmodule MingaEditor do
     Minga.Events.subscribe(:log_message, events_registry)
     Minga.Events.subscribe(:face_overrides_changed, events_registry)
     Minga.Events.subscribe(:agent_session_stopped, events_registry)
+    Minga.Events.subscribe(:agent_session_restarted, events_registry)
     Minga.Events.subscribe(:background_subagent_started, events_registry)
     Minga.Events.subscribe(:node_connected, events_registry)
     Minga.Events.subscribe(:node_disconnected, events_registry)

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -1076,6 +1076,53 @@ defmodule MingaEditor.Commands.BufferManagement do
     end
   end
 
+  @doc false
+  @spec agent_session_restart_owned?(state(), pid()) :: boolean()
+  def agent_session_restart_owned?(state, old_pid) when is_pid(old_pid) do
+    shell_owned? = shell_state_restart_owned?(state.shell_state, old_pid)
+    stash_owned? = stashed_shell_restart_owned?(state.shell_state_stash, old_pid)
+    shell_owned? or stash_owned?
+  end
+
+  @doc "Refreshes editor state after SessionManager restarts a managed session."
+  @spec handle_agent_session_restarted(state(), String.t(), pid(), pid(), term()) :: state()
+  def handle_agent_session_restarted(state, session_id, old_pid, new_pid, reason) do
+    state = update_active_shell_session_restarted(state, session_id, old_pid, new_pid, reason)
+    state = update_stashed_shell_session_restarted(state, session_id, old_pid, new_pid, reason)
+    maybe_rebuild_active_agent_after_restart(state, new_pid)
+  end
+
+  @spec shell_state_restart_owned?(term(), pid()) :: boolean()
+  defp shell_state_restart_owned?(%{cards: cards} = shell_state, old_pid) when is_map(cards) do
+    card_owned? = Enum.any?(cards, fn {_card_id, card} -> Map.get(card, :session) == old_pid end)
+
+    tab_owned? =
+      case Map.get(shell_state, :tab_bar) do
+        %TabBar{} = tb ->
+          not is_nil(TabBar.find_by_session(tb, old_pid)) or
+            not is_nil(TabBar.find_workspace_by_session(tb, old_pid))
+
+        _ ->
+          false
+      end
+
+    card_owned? or tab_owned?
+  end
+
+  defp shell_state_restart_owned?(%{tab_bar: %TabBar{} = tb}, old_pid) do
+    not is_nil(TabBar.find_by_session(tb, old_pid)) or
+      not is_nil(TabBar.find_workspace_by_session(tb, old_pid))
+  end
+
+  defp shell_state_restart_owned?(_shell_state, _old_pid), do: false
+
+  @spec stashed_shell_restart_owned?(EditorState.shell_state_stash(), pid()) :: boolean()
+  defp stashed_shell_restart_owned?(stash, old_pid) do
+    Enum.any?(stash, fn {_shell_id, %StateStash{state: shell_state}} ->
+      shell_state_restart_owned?(shell_state, old_pid)
+    end)
+  end
+
   @spec update_active_shell_session_down(state(), pid(), term()) :: {state(), boolean()}
   defp update_active_shell_session_down(state, session_pid, reason) do
     shell = EditorState.active_shell_module(state)
@@ -1088,6 +1135,48 @@ defmodule MingaEditor.Commands.BufferManagement do
       {EditorState.update_shell_state(state, fn _ -> shell_state end), owned?}
     else
       {state, false}
+    end
+  end
+
+  @spec update_active_shell_session_restarted(state(), String.t(), pid(), pid(), term()) ::
+          state()
+  defp update_active_shell_session_restarted(state, _session_id, old_pid, new_pid, reason) do
+    shell = EditorState.active_shell_module(state)
+
+    if function_exported?(shell, :handle_agent_session_restarted, 4) do
+      {shell_state, handled?} =
+        shell.handle_agent_session_restarted(state.shell_state, old_pid, new_pid, reason)
+
+      shell_state = maybe_persist_owned_shell_state(shell, shell_state, handled?)
+      EditorState.update_shell_state(state, fn _ -> shell_state end)
+    else
+      state
+    end
+  end
+
+  @spec update_stashed_shell_session_restarted(state(), String.t(), pid(), pid(), term()) ::
+          state()
+  defp update_stashed_shell_session_restarted(state, _session_id, old_pid, new_pid, reason) do
+    {state, _handled?} =
+      update_stashed_shell_for_session(state, :handle_agent_session_restarted, [
+        old_pid,
+        new_pid,
+        reason
+      ])
+
+    state
+  end
+
+  @spec maybe_rebuild_active_agent_after_restart(state(), pid()) :: state()
+  defp maybe_rebuild_active_agent_after_restart(state, new_pid) do
+    shell = EditorState.active_shell_module(state)
+
+    case function_exported?(shell, :active_tab, 1) && shell.active_tab(state.shell_state) do
+      %Tab{kind: :agent, session: ^new_pid} = tab ->
+        EditorState.rebuild_agent_from_session(state, tab)
+
+      _ ->
+        state
     end
   end
 

--- a/lib/minga_editor/handlers/event_dispatcher.ex
+++ b/lib/minga_editor/handlers/event_dispatcher.ex
@@ -223,6 +223,18 @@ defmodule MingaEditor.Handlers.EventDispatcher do
 
   def dispatch(
         state,
+        :agent_session_restarted,
+        %SessionManager.SessionRestartedEvent{} = event,
+        _msg
+      ) do
+    case handle_agent_session_restarted(state, event) do
+      {:ok, state} -> MingaEditor.schedule_render(state, 16)
+      {:stale, state} -> state
+    end
+  end
+
+  def dispatch(
+        state,
         :agent_session_stopped,
         %SessionManager.SessionStoppedEvent{pid: pid, reason: reason},
         _msg
@@ -268,6 +280,69 @@ defmodule MingaEditor.Handlers.EventDispatcher do
   end
 
   def dispatch(state, _event, _payload, _msg), do: state
+
+  @spec handle_agent_session_restarted(
+          EditorState.t(),
+          SessionManager.SessionRestartedEvent.t()
+        ) :: {:ok, EditorState.t()} | {:stale, EditorState.t()}
+  defp handle_agent_session_restarted(state, %SessionManager.SessionRestartedEvent{} = event) do
+    new_pid = event.new_pid
+
+    with {:ok, ^new_pid} <- safe_session_lookup(event.session_id),
+         true <- Commands.BufferManagement.agent_session_restart_owned?(state, event.old_pid),
+         :ok <- subscribe_to_restarted_session(event) do
+      {:ok,
+       Commands.BufferManagement.handle_agent_session_restarted(
+         state,
+         event.session_id,
+         event.old_pid,
+         new_pid,
+         event.reason
+       )}
+    else
+      {:ok, current_pid} ->
+        log_stale_agent_session_restart(event, {:current_pid, current_pid})
+        {:stale, state}
+
+      false ->
+        log_stale_agent_session_restart(event, :unowned_old_pid)
+        {:stale, state}
+
+      {:error, reason} ->
+        log_stale_agent_session_restart(event, reason)
+        {:stale, state}
+
+      :stale ->
+        {:stale, state}
+    end
+  end
+
+  @spec safe_session_lookup(String.t()) :: {:ok, pid()} | {:error, term()}
+  defp safe_session_lookup(session_id) do
+    SessionManager.get_session(session_id)
+  catch
+    :exit, reason -> {:error, {:exit, reason}}
+  end
+
+  @spec subscribe_to_restarted_session(SessionManager.SessionRestartedEvent.t()) :: :ok | :stale
+  defp subscribe_to_restarted_session(%SessionManager.SessionRestartedEvent{} = event) do
+    AgentSession.subscribe(event.new_pid, self())
+    :ok
+  catch
+    :exit, reason ->
+      log_stale_agent_session_restart(event, {:subscribe_failed, reason})
+      :stale
+  end
+
+  @spec log_stale_agent_session_restart(SessionManager.SessionRestartedEvent.t(), term()) :: :ok
+  defp log_stale_agent_session_restart(%SessionManager.SessionRestartedEvent{} = event, reason) do
+    Minga.Log.warning(
+      :agent,
+      "[Agent] Ignored restart for session #{event.session_id} (#{inspect(event.old_pid)} -> #{inspect(event.new_pid)}) after #{inspect(event.reason)}: #{inspect(reason)}"
+    )
+
+    :ok
+  end
 
   # ── Private helpers ──────────────────────────────────────────────────────────
 

--- a/lib/minga_editor/handlers/event_dispatcher.ex
+++ b/lib/minga_editor/handlers/event_dispatcher.ex
@@ -206,19 +206,28 @@ defmodule MingaEditor.Handlers.EventDispatcher do
         %Subagent.Handle{} = handle,
         _msg
       ) do
-    AgentSession.subscribe(handle.pid, self())
+    case subscribe_to_session(handle.pid) do
+      :ok ->
+        state = EditorState.ensure_shell_available(state)
 
-    state = EditorState.ensure_shell_available(state)
+        {shell_state, workspace} =
+          EditorState.active_shell_module(state).handle_event(
+            state.shell_state,
+            state.workspace,
+            {:background_subagent_started, handle}
+          )
 
-    {shell_state, workspace} =
-      EditorState.active_shell_module(state).handle_event(
-        state.shell_state,
-        state.workspace,
-        {:background_subagent_started, handle}
-      )
+        state = %{state | shell_state: shell_state, workspace: workspace}
+        MingaEditor.schedule_render(state, 16)
 
-    state = %{state | shell_state: shell_state, workspace: workspace}
-    MingaEditor.schedule_render(state, 16)
+      {:error, reason} ->
+        Minga.Log.warning(
+          :agent,
+          "[Agent] Ignored background sub-agent #{handle.session_id} (#{inspect(handle.pid)}): #{inspect(reason)}"
+        )
+
+        state
+    end
   end
 
   def dispatch(
@@ -326,12 +335,21 @@ defmodule MingaEditor.Handlers.EventDispatcher do
 
   @spec subscribe_to_restarted_session(SessionManager.SessionRestartedEvent.t()) :: :ok | :stale
   defp subscribe_to_restarted_session(%SessionManager.SessionRestartedEvent{} = event) do
-    AgentSession.subscribe(event.new_pid, self())
-    :ok
+    case subscribe_to_session(event.new_pid) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        log_stale_agent_session_restart(event, {:subscribe_failed, reason})
+        :stale
+    end
+  end
+
+  @spec subscribe_to_session(pid()) :: :ok | {:error, term()}
+  defp subscribe_to_session(pid) do
+    AgentSession.subscribe(pid, self())
   catch
-    :exit, reason ->
-      log_stale_agent_session_restart(event, {:subscribe_failed, reason})
-      :stale
+    :exit, reason -> {:error, reason}
   end
 
   @spec log_stale_agent_session_restart(SessionManager.SessionRestartedEvent.t(), term()) :: :ok

--- a/lib/minga_editor/shell/buffer_lifecycle.ex
+++ b/lib/minga_editor/shell/buffer_lifecycle.ex
@@ -50,4 +50,12 @@ defmodule MingaEditor.Shell.BufferLifecycle do
               session_pid :: pid(),
               event :: term()
             ) :: {shell_state(), workspace(), [MingaEditor.effect()]}
+
+  @doc "A managed agent session restarted and the shell should refresh pid references."
+  @callback handle_agent_session_restarted(
+              shell_state(),
+              old_session_pid :: pid(),
+              new_session_pid :: pid(),
+              reason :: term()
+            ) :: {shell_state(), boolean()}
 end

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -43,6 +43,7 @@ defmodule MingaEditor.Shell.Traditional do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
+  alias MingaAgent.Subagent.Handle
   alias MingaEditor.State.Windows
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
@@ -402,6 +403,100 @@ defmodule MingaEditor.Shell.Traditional do
   def on_agent_event(shell_state, workspace, _session_pid, _event) do
     {shell_state, workspace, []}
   end
+
+  @impl true
+  @spec handle_agent_session_restarted(ShellState.t(), pid(), pid(), term()) ::
+          {ShellState.t(), boolean()}
+  def handle_agent_session_restarted(
+        %ShellState{tab_bar: nil} = shell_state,
+        _old_pid,
+        _new_pid,
+        _reason
+      ) do
+    {shell_state, false}
+  end
+
+  def handle_agent_session_restarted(
+        %ShellState{tab_bar: %TabBar{} = tb} = shell_state,
+        old_pid,
+        new_pid,
+        _reason
+      ) do
+    status = restarted_session_status(new_pid)
+    updated_tb = update_restarted_session_tab_bar(tb, old_pid, new_pid, status)
+    {ShellState.set_tab_bar(shell_state, updated_tb), updated_tb != tb}
+  end
+
+  @spec update_restarted_session_tab_bar(TabBar.t(), pid(), pid(), Tab.agent_status()) ::
+          TabBar.t()
+  defp update_restarted_session_tab_bar(%TabBar{} = tb, old_pid, new_pid, status) do
+    tb
+    |> update_restarted_session_tabs(old_pid, new_pid, status)
+    |> update_restarted_session_workspaces(old_pid, new_pid, status)
+  end
+
+  @spec update_restarted_session_tabs(TabBar.t(), pid(), pid(), Tab.agent_status()) :: TabBar.t()
+  defp update_restarted_session_tabs(%TabBar{} = tb, old_pid, new_pid, status) do
+    Enum.reduce(tb.tabs, tb, fn
+      %Tab{id: id, session: ^old_pid}, acc ->
+        TabBar.update_tab(acc, id, fn tab ->
+          tab
+          |> Tab.refresh_session_pid(old_pid, new_pid)
+          |> maybe_set_tab_agent_status(status)
+        end)
+
+      %Tab{id: id, background_subagent: %Handle{pid: ^old_pid}}, acc ->
+        TabBar.update_tab(acc, id, fn tab ->
+          tab
+          |> Tab.refresh_session_pid(old_pid, new_pid)
+          |> maybe_set_tab_agent_status(status)
+        end)
+
+      %Tab{id: id, background_subagent: %Handle{parent_pid: ^old_pid}}, acc ->
+        TabBar.update_tab(acc, id, fn tab ->
+          tab
+          |> Tab.refresh_session_pid(old_pid, new_pid)
+          |> maybe_set_tab_agent_status(status)
+        end)
+
+      _tab, acc ->
+        acc
+    end)
+  end
+
+  @spec update_restarted_session_workspaces(TabBar.t(), pid(), pid(), Tab.agent_status()) ::
+          TabBar.t()
+  defp update_restarted_session_workspaces(%TabBar{} = tb, old_pid, new_pid, status) do
+    Enum.reduce(tb.workspaces, tb, fn
+      %Workspace{id: id, session: ^old_pid}, acc ->
+        TabBar.update_workspace(acc, id, fn workspace ->
+          workspace
+          |> Workspace.refresh_session_pid(old_pid, new_pid)
+          |> maybe_set_workspace_agent_status(status)
+        end)
+
+      _workspace, acc ->
+        acc
+    end)
+  end
+
+  @spec restarted_session_status(pid()) :: Tab.agent_status()
+  defp restarted_session_status(new_pid) do
+    %{status: status} = MingaAgent.Session.editor_snapshot(new_pid)
+    status
+  catch
+    :exit, _reason -> nil
+  end
+
+  @spec maybe_set_tab_agent_status(Tab.t(), Tab.agent_status()) :: Tab.t()
+  defp maybe_set_tab_agent_status(tab, nil), do: tab
+  defp maybe_set_tab_agent_status(tab, status), do: Tab.set_agent_status(tab, status)
+
+  @spec maybe_set_workspace_agent_status(Workspace.t(), Tab.agent_status()) :: Workspace.t()
+  defp maybe_set_workspace_agent_status(workspace, nil), do: workspace
+
+  defp maybe_set_workspace_agent_status(workspace, status),
+    do: Workspace.set_agent_status(workspace, status)
 
   # -------------------------------------------------------------------
   # Tab query/mutation delegates

--- a/lib/minga_editor/state/tab.ex
+++ b/lib/minga_editor/state/tab.ex
@@ -16,6 +16,7 @@ defmodule MingaEditor.State.Tab do
   alias MingaEditor.FeatureState
   alias MingaEditor.State.Tab.Context
   alias MingaEditor.State.Workspace.RemoteSession
+  alias MingaAgent.Subagent.Handle
 
   @typedoc "Unique tab identifier."
   @type id :: pos_integer()
@@ -131,6 +132,56 @@ defmodule MingaEditor.State.Tab do
   def set_session(%__MODULE__{} = tab, pid) do
     %{tab | session: pid}
   end
+
+  @doc "Refreshes any session pid references after a managed restart."
+  @spec refresh_session_pid(t(), pid(), pid()) :: t()
+  def refresh_session_pid(%__MODULE__{} = tab, old_pid, new_pid)
+      when is_pid(old_pid) and is_pid(new_pid) do
+    tab
+    |> refresh_tab_session(old_pid, new_pid)
+    |> refresh_background_subagent(old_pid, new_pid)
+  end
+
+  @spec refresh_tab_session(t(), pid(), pid()) :: t()
+  defp refresh_tab_session(%__MODULE__{session: session} = tab, old_pid, new_pid)
+       when session == old_pid do
+    %{tab | session: new_pid}
+  end
+
+  defp refresh_tab_session(%__MODULE__{} = tab, _old_pid, _new_pid), do: tab
+
+  @spec refresh_background_subagent(t(), pid(), pid()) :: t()
+  defp refresh_background_subagent(
+         %__MODULE__{background_subagent: %Handle{} = handle} = tab,
+         old_pid,
+         new_pid
+       ) do
+    handle = refresh_background_subagent_pid(handle, old_pid, new_pid)
+    handle = refresh_background_subagent_parent_pid(handle, old_pid, new_pid)
+    %{tab | background_subagent: handle}
+  end
+
+  defp refresh_background_subagent(%__MODULE__{} = tab, _old_pid, _new_pid), do: tab
+
+  @spec refresh_background_subagent_pid(Handle.t(), pid(), pid()) :: Handle.t()
+  defp refresh_background_subagent_pid(%Handle{pid: pid} = handle, old_pid, new_pid)
+       when pid == old_pid do
+    Handle.with_pid(handle, new_pid)
+  end
+
+  defp refresh_background_subagent_pid(%Handle{} = handle, _old_pid, _new_pid), do: handle
+
+  @spec refresh_background_subagent_parent_pid(Handle.t(), pid(), pid()) :: Handle.t()
+  defp refresh_background_subagent_parent_pid(
+         %Handle{parent_pid: parent_pid} = handle,
+         old_pid,
+         new_pid
+       )
+       when parent_pid == old_pid do
+    Handle.with_parent_pid(handle, new_pid)
+  end
+
+  defp refresh_background_subagent_parent_pid(%Handle{} = handle, _old_pid, _new_pid), do: handle
 
   @doc "Marks the tab as backed by a remote agent session."
   @spec set_remote_session(t(), String.t(), String.t(), pid()) :: t()

--- a/lib/minga_editor/state/workspace.ex
+++ b/lib/minga_editor/state/workspace.ex
@@ -138,6 +138,15 @@ defmodule MingaEditor.State.Workspace do
     %{workspace | session: session}
   end
 
+  @doc "Refreshes the workspace session pid after a managed restart."
+  @spec refresh_session_pid(t(), pid(), pid()) :: t()
+  def refresh_session_pid(%__MODULE__{session: session} = workspace, old_pid, new_pid)
+      when session == old_pid and is_pid(new_pid) do
+    %{workspace | session: new_pid}
+  end
+
+  def refresh_session_pid(%__MODULE__{} = workspace, _old_pid, _new_pid), do: workspace
+
   @doc "Clears the live agent session pid and returns the workspace to idle lifecycle status. Durable remote identity is preserved."
   @spec clear_session(t()) :: t()
   def clear_session(%__MODULE__{} = workspace) do

--- a/rel/launchd/com.minga.headless.plist
+++ b/rel/launchd/com.minga.headless.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.minga.headless</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/YOUR_USER/.local/bin/minga</string>
+    <string>--headless</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/YOUR_USER</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>MIX_ENV</key>
+    <string>prod</string>
+    <key>MINGA_COOKIE</key>
+    <string>replace-with-a-long-random-cookie</string>
+  </dict>
+  <key>KeepAlive</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/minga-headless.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/minga-headless.err.log</string>
+</dict>
+</plist>

--- a/rel/systemd/minga-headless.service
+++ b/rel/systemd/minga-headless.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Minga headless agent daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/minga --headless
+WorkingDirectory=%h
+Restart=on-failure
+RestartSec=5
+Environment=MIX_ENV=prod
+# Set a stable cookie shared only with trusted clients.
+Environment=MINGA_COOKIE=replace-with-a-long-random-cookie
+# Optional provider credentials live on the server, not on attaching clients.
+# Environment=ANTHROPIC_API_KEY=...
+# Environment=OPENAI_API_KEY=...
+
+[Install]
+WantedBy=default.target

--- a/test/minga_agent/event_log/session_integration_test.exs
+++ b/test/minga_agent/event_log/session_integration_test.exs
@@ -150,6 +150,47 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
     :ok = Store.close(db)
   end
 
+  test "subscriber disconnects are durably recorded", %{tmp_dir: tmp_dir} do
+    log_name = unique_name("disconnect-log")
+
+    log_pid =
+      start_supervised!(
+        {EventLog, name: log_name, db_dir: tmp_dir, retention_sweep?: false, health_check: :none}
+      )
+
+    session =
+      start_supervised!(
+        {Session,
+         session_id: "disconnect-session",
+         provider: ReplayProvider,
+         event_log_server: log_name,
+         persist?: false,
+         hooks_enabled?: false,
+         idle_gc_timeout_ms: 0}
+      )
+
+    client =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> Process.exit(client, :kill) end)
+
+    assert :ok = Session.subscribe(session, client, role: :driver)
+    assert :ok = Session.unsubscribe(session, client)
+
+    {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
+    events = wait_for_event(db, "disconnect-session", :user_disconnected, session, log_pid)
+    disconnected = Enum.find(events, &(&1.event_type == :user_disconnected))
+
+    assert disconnected.payload["role"] == "driver"
+    assert disconnected.payload["reason"] == ":detached"
+    assert Session.status(session) == :idle
+    :ok = Store.close(db)
+  end
+
   test "dequeued steering prompts are recorded with content", %{tmp_dir: tmp_dir} do
     log_name = unique_name("steering-log")
 

--- a/test/minga_agent/gateway/event_stream_test.exs
+++ b/test/minga_agent/gateway/event_stream_test.exs
@@ -18,6 +18,32 @@ defmodule MingaAgent.Gateway.EventStreamTest do
       refute Map.has_key?(decoded, "id")
     end
 
+    test "formats agent_session_restarted event" do
+      old_pid = self()
+
+      new_pid =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      on_exit(fn -> Process.exit(new_pid, :kill) end)
+
+      event =
+        {:minga_event, :agent_session_restarted,
+         %{session_id: "session-1", old_pid: old_pid, new_pid: new_pid, reason: :killed}}
+
+      {:ok, json} = EventStream.format_notification(event)
+      decoded = JSON.decode!(json)
+
+      assert decoded["method"] == "event.agent_session_restarted"
+      assert decoded["params"]["session_id"] == "session-1"
+      assert decoded["params"]["old_pid"] == inspect(old_pid)
+      assert decoded["params"]["new_pid"] == inspect(new_pid)
+      assert decoded["params"]["reason"] == ":killed"
+    end
+
     test "formats log_message event" do
       event =
         {:minga_event, :log_message, %{text: "LSP connected", level: :info}}

--- a/test/minga_agent/remote_api_test.exs
+++ b/test/minga_agent/remote_api_test.exs
@@ -69,6 +69,15 @@ defmodule MingaAgent.RemoteAPITest do
     assert Enum.all?(reattach_events, &(&1.id > attach_latest))
   end
 
+  test "stop_session ends a remote session and removes it from the list" do
+    assert {:ok, %{session_id: session_id, token: token}} = RemoteAPI.start_session([])
+    assert Enum.any?(RemoteAPI.list_sessions(), &(&1.session_id == session_id))
+
+    assert :ok = RemoteAPI.stop_session(session_id, token)
+    refute Enum.any?(RemoteAPI.list_sessions(), &(&1.session_id == session_id))
+    assert {:error, :not_found} = SessionManager.get_session(session_id)
+  end
+
   test "start_or_get_for_workdir reuses the deterministic session" do
     workdir = Path.join(System.tmp_dir!(), "remote-api-workdir")
 

--- a/test/minga_agent/session_manager_test.exs
+++ b/test/minga_agent/session_manager_test.exs
@@ -1,8 +1,14 @@
 defmodule MingaAgent.SessionManagerTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
+  alias MingaAgent.Providers.RecordingProvider
   alias MingaAgent.SessionManager
+  alias MingaAgent.SessionManager.SessionRestartedEvent
   alias MingaAgent.SessionManager.SessionStoppedEvent
+  alias MingaAgent.SessionStore
+  alias MingaAgent.Subagent.Handle
 
   setup do
     # Start an isolated SessionManager with a unique name per test.
@@ -82,6 +88,40 @@ defmodule MingaAgent.SessionManagerTest do
         SessionManager.start_or_get_session(manager, "workdir-stable", session_store_dir: dir)
 
       assert {:ok, "persisted-token"} = SessionManager.session_token(manager, "workdir-stable")
+    end
+
+    test "logs and mints a new token when persisted remote token file is corrupt", %{
+      manager: manager
+    } do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "session-manager-token-corrupt-#{System.unique_integer([:positive])}"
+        )
+
+      session_id = "token-corrupt-#{System.unique_integer([:positive])}"
+      sessions_dir = SessionStore.sessions_dir(dir)
+      File.mkdir_p!(sessions_dir)
+      File.write!(Path.join(sessions_dir, "#{session_id}.json"), "{not json")
+
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, ^session_id, pid} =
+                   SessionManager.start_session(manager,
+                     session_id: session_id,
+                     session_store_dir: dir
+                   )
+
+          assert {:ok, token} = SessionManager.session_token(manager, session_id)
+          assert is_binary(token)
+          assert Process.alive?(pid)
+        end)
+
+      assert log =~ "Failed to load persisted remote token"
+      assert log =~ session_id
+      assert log =~ dir
     end
   end
 
@@ -166,31 +206,409 @@ defmodule MingaAgent.SessionManagerTest do
   end
 
   describe "session DOWN monitoring" do
-    test "removes session from registry when it dies", %{manager: manager} do
-      {:ok, session_id, pid} = SessionManager.start_session(manager, [])
-
-      Process.exit(pid, :kill)
-
-      :timer.sleep(50)
-
-      assert {:error, :not_found} = SessionManager.get_session(manager, session_id)
-      assert [] = SessionManager.list_sessions(manager)
-    end
-
-    test "broadcasts :agent_session_stopped event when session dies", %{manager: manager} do
+    test "restarts a crashed session, refreshes child handles, and keeps the registry consistent",
+         %{manager: manager} do
+      Minga.Events.subscribe(:agent_session_restarted)
       Minga.Events.subscribe(:agent_session_stopped)
 
-      {:ok, session_id, pid} = SessionManager.start_session(manager, [])
+      session_id = "restart-#{System.unique_integer([:positive])}"
 
-      Process.exit(pid, :kill)
+      assert {:ok, ^session_id, pid} =
+               SessionManager.start_session(manager, session_id: session_id)
 
-      assert_receive {:minga_event, :agent_session_stopped,
-                      %SessionStoppedEvent{
-                        session_id: ^session_id,
-                        pid: ^pid,
-                        reason: :killed
-                      }},
+      assert {:ok, token} = SessionManager.session_token(manager, session_id)
+
+      assert {:ok, %Handle{} = child_handle} =
+               SessionManager.start_background_subagent(manager, pid, "child work",
+                 session_opts: []
+               )
+
+      assert child_handle.parent_pid == pid
+      assert [^child_handle] = SessionManager.list_background_subagents(manager, pid)
+
+      :sys.get_state(manager)
+      assert MingaAgent.Session.status(child_handle.pid) in [:idle, :thinking]
+
+      new_pid = crash_and_wait_for_restart(manager, session_id, pid)
+
+      assert_receive {
+                       :minga_event,
+                       :agent_session_restarted,
+                       %SessionRestartedEvent{
+                         session_id: ^session_id,
+                         old_pid: ^pid,
+                         new_pid: ^new_pid,
+                         reason: :killed
+                       }
+                     },
                      1000
+
+      assert {:ok, ^new_pid} = SessionManager.get_session(manager, session_id)
+      assert {:ok, ^session_id} = SessionManager.session_id_for_pid(manager, new_pid)
+      assert {:ok, ^token} = SessionManager.session_token(manager, session_id)
+
+      sessions = SessionManager.list_sessions(manager)
+
+      assert Enum.any?(sessions, fn {listed_id, listed_pid, _metadata} ->
+               listed_id == session_id and listed_pid == new_pid
+             end)
+
+      refute Enum.any?(sessions, fn {listed_id, listed_pid, _metadata} ->
+               listed_id == session_id and listed_pid == pid
+             end)
+
+      assert [updated_child_handle] = SessionManager.list_background_subagents(manager, new_pid)
+      assert updated_child_handle.session_id == child_handle.session_id
+      assert updated_child_handle.pid == child_handle.pid
+      assert updated_child_handle.parent_pid == new_pid
+      assert [] = SessionManager.list_background_subagents(manager, pid)
+
+      refute_receive {:minga_event, :agent_session_stopped,
+                      %SessionStoppedEvent{session_id: ^session_id, pid: ^pid, reason: :killed}},
+                     50
+    end
+
+    test "restarts a background subagent and refreshes its pid in listings", %{manager: manager} do
+      Minga.Events.subscribe(:agent_session_restarted)
+
+      assert {:ok, %Handle{} = handle} =
+               SessionManager.start_background_subagent(manager, nil, "child work",
+                 session_opts: []
+               )
+
+      old_pid = handle.pid
+      session_id = handle.session_id
+      new_pid = crash_and_wait_for_restart(manager, session_id, old_pid)
+
+      assert_receive {
+                       :minga_event,
+                       :agent_session_restarted,
+                       %SessionRestartedEvent{
+                         session_id: ^session_id,
+                         old_pid: ^old_pid,
+                         new_pid: ^new_pid,
+                         reason: :killed
+                       }
+                     },
+                     1000
+
+      [updated_handle] = SessionManager.list_background_subagents(manager, nil)
+      assert updated_handle.session_id == handle.session_id
+      assert updated_handle.pid == new_pid
+      assert updated_handle.parent_pid == nil
+      refute_receive {:minga_event, :agent_session_stopped, _}, 50
+    end
+  end
+
+  test "idle GC shutdown stops a managed session without restart", %{manager: manager} do
+    Minga.Events.subscribe(:agent_session_stopped)
+
+    {:ok, session_id, pid} = SessionManager.start_session(manager, idle_gc_timeout_ms: 1)
+
+    assert :ok = MingaAgent.Session.subscribe(pid)
+
+    ref = Process.monitor(pid)
+    assert :ok = MingaAgent.Session.unsubscribe(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
+
+    assert_receive {
+                     :minga_event,
+                     :agent_session_stopped,
+                     %SessionStoppedEvent{session_id: ^session_id, pid: ^pid, reason: :normal}
+                   },
+                   1000
+
+    refute_receive {:minga_event, :agent_session_restarted, _}, 50
+    assert {:error, :not_found} = SessionManager.get_session(manager, session_id)
+  end
+
+  test "repeated crash restarts eventually exhaust and stop terminally", %{manager: manager} do
+    Minga.Events.subscribe(:agent_session_restarted)
+    Minga.Events.subscribe(:agent_session_stopped)
+
+    {:ok, session_id, pid} =
+      SessionManager.start_session(manager,
+        restart_max_attempts: 2,
+        restart_backoff_base_ms: 1,
+        restart_backoff_max_ms: 1,
+        restart_window_ms: 60_000
+      )
+
+    first_restart = crash_and_wait_for_restart(manager, session_id, pid)
+
+    assert_receive {
+                     :minga_event,
+                     :agent_session_restarted,
+                     %SessionRestartedEvent{
+                       session_id: ^session_id,
+                       old_pid: ^pid,
+                       new_pid: ^first_restart,
+                       reason: :killed
+                     }
+                   },
+                   1000
+
+    second_restart = crash_and_wait_for_restart(manager, session_id, first_restart)
+
+    assert_receive {
+                     :minga_event,
+                     :agent_session_restarted,
+                     %SessionRestartedEvent{
+                       session_id: ^session_id,
+                       old_pid: ^first_restart,
+                       new_pid: ^second_restart,
+                       reason: :killed
+                     }
+                   },
+                   1000
+
+    ref = Process.monitor(second_restart)
+    Process.exit(second_restart, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^second_restart, :killed}, 1000
+
+    assert_receive {
+                     :minga_event,
+                     :agent_session_stopped,
+                     %SessionStoppedEvent{
+                       session_id: ^session_id,
+                       pid: ^second_restart,
+                       reason: {:restart_exhausted, :killed}
+                     }
+                   },
+                   1000
+
+    refute_receive {:minga_event, :agent_session_restarted, _}, 50
+    assert {:error, :not_found} = SessionManager.get_session(manager, session_id)
+  end
+
+  test "restart attempt counters reset after the window expires", %{manager: manager} do
+    Minga.Events.subscribe(:agent_session_restarted)
+
+    {:ok, session_id, pid} =
+      SessionManager.start_session(manager,
+        restart_max_attempts: 1,
+        restart_backoff_base_ms: 1,
+        restart_backoff_max_ms: 1,
+        restart_window_ms: 1
+      )
+
+    first_restart = crash_and_wait_for_restart(manager, session_id, pid)
+
+    assert_receive {
+                     :minga_event,
+                     :agent_session_restarted,
+                     %SessionRestartedEvent{
+                       session_id: ^session_id,
+                       old_pid: ^pid,
+                       new_pid: ^first_restart,
+                       reason: :killed
+                     }
+                   },
+                   1000
+
+    receive do
+    after
+      10 -> :ok
+    end
+
+    second_restart = crash_and_wait_for_restart(manager, session_id, first_restart)
+
+    assert_receive {
+                     :minga_event,
+                     :agent_session_restarted,
+                     %SessionRestartedEvent{
+                       session_id: ^session_id,
+                       old_pid: ^first_restart,
+                       new_pid: ^second_restart,
+                       reason: :killed
+                     }
+                   },
+                   1000
+  end
+
+  test "managed restarts restore persisted state before broadcasting", %{manager: manager} do
+    Minga.Events.subscribe(:agent_session_restarted)
+
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "session-manager-restore-#{System.unique_integer([:positive])}"
+      )
+
+    session_id = "restore-#{System.unique_integer([:positive])}"
+
+    on_exit(fn -> File.rm_rf(dir) end)
+
+    :ok =
+      SessionStore.save(
+        %{
+          id: session_id,
+          timestamp: DateTime.to_iso8601(DateTime.utc_now()),
+          model_name: "test-model",
+          messages: [{:user, "restored"}, {:assistant, "reply"}],
+          usage: MingaAgent.TurnUsage.new()
+        },
+        dir
+      )
+
+    {:ok, ^session_id, pid} =
+      SessionManager.start_session(manager,
+        session_id: session_id,
+        provider: RecordingProvider,
+        provider_opts: [],
+        session_store_dir: dir
+      )
+
+    new_pid = crash_and_wait_for_restart(manager, session_id, pid)
+
+    assert_receive {
+                     :minga_event,
+                     :agent_session_restarted,
+                     %SessionRestartedEvent{
+                       session_id: ^session_id,
+                       old_pid: ^pid,
+                       new_pid: ^new_pid
+                     }
+                   },
+                   1000
+
+    assert Enum.any?(MingaAgent.Session.messages(new_pid), fn
+             {:user, "restored"} -> true
+             _ -> false
+           end)
+
+    provider = MingaAgent.Session.get_provider(new_pid)
+    assert {:ok, %{seeded_messages: seeded_messages}} = RecordingProvider.get_state(provider)
+
+    assert Enum.any?(seeded_messages, fn
+             {:user, "restored"} -> true
+             _ -> false
+           end)
+  end
+
+  test "managed restarts surface degraded restore when prior context is missing", %{
+    manager: manager
+  } do
+    Minga.Events.subscribe(:agent_session_restarted)
+
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "session-manager-restore-missing-#{System.unique_integer([:positive])}"
+      )
+
+    session_id = "restore-missing-#{System.unique_integer([:positive])}"
+
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf(dir) end)
+
+    log =
+      capture_log(fn ->
+        {:ok, ^session_id, pid} =
+          SessionManager.start_session(manager,
+            session_id: session_id,
+            session_store_dir: dir
+          )
+
+        new_pid = crash_and_wait_for_restart(manager, session_id, pid)
+
+        assert_receive {
+                         :minga_event,
+                         :agent_session_restarted,
+                         %SessionRestartedEvent{
+                           session_id: ^session_id,
+                           old_pid: ^pid,
+                           new_pid: ^new_pid
+                         }
+                       },
+                       1000
+
+        :sys.get_state(new_pid)
+
+        assert Enum.any?(MingaAgent.Session.messages(new_pid), fn
+                 {:system, text, level} ->
+                   level == :error and text =~ "prior context could not be restored"
+
+                 _ ->
+                   false
+               end)
+      end)
+
+    assert log =~ session_id
+    assert log =~ dir
+    assert log =~ "could not restore prior context"
+  end
+
+  describe "background prompt retry logging" do
+    test "logs an actionable error when retries exhaust after an exit", %{manager: manager} do
+      {:ok, session_id, _live_pid} =
+        SessionManager.start_session(manager,
+          provider: Minga.Test.StubProvider,
+          provider_opts: []
+        )
+
+      dead_pid =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      ref = Process.monitor(dead_pid)
+      send(dead_pid, :stop)
+      assert_receive {:DOWN, ^ref, :process, ^dead_pid, :normal}
+
+      :sys.replace_state(manager, fn state ->
+        %{state | sessions: Map.update!(state.sessions, session_id, &%{&1 | pid: dead_pid})}
+      end)
+
+      log =
+        capture_log(fn ->
+          send(manager, {:send_background_prompt, session_id, "child work", 100})
+          :sys.get_state(manager)
+        end)
+
+      assert log =~ session_id
+      assert log =~ inspect(dead_pid)
+      assert log =~ "after 101 attempts"
+      assert log =~ "failed to accept prompt"
+    end
+  end
+
+  @spec crash_and_wait_for_restart(GenServer.server(), String.t(), pid()) :: pid()
+  defp crash_and_wait_for_restart(manager, session_id, pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 1000
+    wait_until_restarted_session(manager, session_id, pid)
+  end
+
+  @spec wait_until_restarted_session(GenServer.server(), String.t(), pid(), non_neg_integer()) ::
+          pid()
+  defp wait_until_restarted_session(manager, session_id, old_pid, attempts \\ 100)
+
+  defp wait_until_restarted_session(_manager, session_id, old_pid, 0) do
+    flunk("session #{session_id} did not restart after #{inspect(old_pid)} crashed")
+  end
+
+  defp wait_until_restarted_session(manager, session_id, old_pid, attempts) do
+    :sys.get_state(manager)
+
+    case SessionManager.get_session(manager, session_id) do
+      {:ok, ^old_pid} ->
+        receive do
+        after
+          10 -> wait_until_restarted_session(manager, session_id, old_pid, attempts - 1)
+        end
+
+      {:ok, pid} ->
+        pid
+
+      {:error, :not_found} ->
+        receive do
+        after
+          10 -> wait_until_restarted_session(manager, session_id, old_pid, attempts - 1)
+        end
     end
   end
 end

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -435,6 +435,59 @@ defmodule MingaAgent.SessionTest do
     end
   end
 
+  describe "detached session lifecycle" do
+    test "supervised sessions restart after crashes but not normal idle reclamation" do
+      spec = Session.child_spec(provider: MockProvider, provider_opts: [])
+
+      assert spec.restart == :transient
+    end
+
+    test "idle detached sessions are reclaimed after the configured timeout" do
+      {:ok, session} =
+        Session.start_link(provider: MockProvider, provider_opts: [], idle_gc_timeout_ms: 1)
+
+      client = idle_process()
+
+      on_exit(fn -> Process.exit(client, :kill) end)
+
+      assert :ok = Session.subscribe(session, client)
+
+      ref = Process.monitor(session)
+      assert :ok = Session.unsubscribe(session, client)
+      assert_receive {:DOWN, ^ref, :process, ^session, :normal}, @event_timeout
+    end
+
+    test "active detached sessions are not reclaimed" do
+      {:ok, session} =
+        Session.start_link(provider: SlowMockProvider, provider_opts: [], idle_gc_timeout_ms: 1)
+
+      on_exit(fn -> Process.exit(session, :kill) end)
+
+      assert :ok = Session.subscribe(session)
+      assert :ok = Session.send_prompt(session, "keep working")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
+      assert :ok = Session.unsubscribe(session)
+
+      send(session, {:idle_gc_timeout, make_ref()})
+      assert Session.status(session) == :thinking
+    end
+
+    test "stale idle GC messages are ignored after a client reconnects" do
+      {:ok, session} =
+        Session.start_link(provider: MockProvider, provider_opts: [], idle_gc_timeout_ms: 60_000)
+
+      on_exit(fn -> Process.exit(session, :kill) end)
+
+      assert :ok = Session.subscribe(session)
+      assert :ok = Session.unsubscribe(session)
+      {_timer_ref, stale_token} = :sys.get_state(session).idle_gc_timer
+      assert :ok = Session.subscribe(session)
+
+      send(session, {:idle_gc_timeout, stale_token})
+      assert Session.status(session) == :idle
+    end
+  end
+
   describe "plan mode" do
     test "enter_plan sets status, broadcasts, and writes a system message", %{session: session} do
       assert :ok = Session.enter_plan(session)

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -77,6 +77,77 @@ defmodule MingaAgent.SessionTest do
     def handle_cast(:new_session, state), do: {:noreply, state}
   end
 
+  defmodule DeferredMockProvider do
+    @behaviour MingaAgent.Provider
+
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl MingaAgent.Provider
+    def send_prompt(pid, text) do
+      GenServer.cast(pid, {:prompt, text})
+      :ok
+    end
+
+    @impl MingaAgent.Provider
+    def abort(pid), do: GenServer.cast(pid, :abort)
+
+    @impl MingaAgent.Provider
+    def new_session(pid), do: GenServer.cast(pid, :new_session)
+
+    @impl MingaAgent.Provider
+    def seed_messages(_pid, _messages), do: :ok
+
+    @impl MingaAgent.Provider
+    def get_state(_pid), do: {:ok, %{model: nil, is_streaming: false, token_usage: nil}}
+
+    @doc false
+    @spec release_start(GenServer.server()) :: :ok
+    def release_start(pid), do: GenServer.cast(pid, :release_start)
+
+    @doc false
+    @spec release_end(GenServer.server()) :: :ok
+    def release_end(pid), do: GenServer.cast(pid, :release_end)
+
+    @impl GenServer
+    def init(opts) do
+      subscriber = Keyword.fetch!(opts, :subscriber)
+      {:ok, %{subscriber: subscriber, pending_prompt: nil, started?: false}}
+    end
+
+    @impl GenServer
+    def handle_cast({:prompt, text}, state) do
+      {:noreply, %{state | pending_prompt: text}}
+    end
+
+    def handle_cast(:release_start, %{pending_prompt: text, started?: false} = state)
+        when is_binary(text) do
+      send(state.subscriber, {:agent_provider_event, %Event.AgentStart{}})
+      {:noreply, %{state | started?: true}}
+    end
+
+    def handle_cast(:release_start, state), do: {:noreply, state}
+
+    def handle_cast(:release_end, %{started?: true} = state) do
+      usage = %MingaAgent.TurnUsage{
+        input: 10,
+        output: 5,
+        cache_read: 0,
+        cache_write: 0,
+        cost: 0.001
+      }
+
+      send(state.subscriber, {:agent_provider_event, %Event.AgentEnd{usage: usage}})
+      {:noreply, state}
+    end
+
+    def handle_cast(:release_end, state), do: {:noreply, state}
+    def handle_cast(:abort, state), do: {:noreply, state}
+    def handle_cast(:new_session, state), do: {:noreply, state}
+  end
+
   defmodule MockProvider do
     @behaviour MingaAgent.Provider
 
@@ -436,10 +507,10 @@ defmodule MingaAgent.SessionTest do
   end
 
   describe "detached session lifecycle" do
-    test "supervised sessions restart after crashes but not normal idle reclamation" do
+    test "supervised sessions defer crash recovery to SessionManager" do
       spec = Session.child_spec(provider: MockProvider, provider_opts: [])
 
-      assert spec.restart == :transient
+      assert spec.restart == :temporary
     end
 
     test "idle detached sessions are reclaimed after the configured timeout" do
@@ -457,6 +528,105 @@ defmodule MingaAgent.SessionTest do
       assert_receive {:DOWN, ^ref, :process, ^session, :normal}, @event_timeout
     end
 
+    test "idle detached sessions with persist?: false exit normally without writing", %{
+      tmp_dir: dir
+    } do
+      bad_store_dir = Path.join(dir, "blocked-store")
+      File.write!(bad_store_dir, "not a directory")
+
+      {:ok, session} =
+        Session.start_link(
+          provider: MockProvider,
+          provider_opts: [],
+          persist?: false,
+          session_store_dir: bad_store_dir,
+          idle_gc_timeout_ms: 1
+        )
+
+      client = idle_process()
+
+      on_exit(fn -> Process.exit(client, :kill) end)
+
+      assert :ok = Session.subscribe(session, client)
+
+      ref = Process.monitor(session)
+      assert :ok = Session.unsubscribe(session, client)
+      assert_receive {:DOWN, ^ref, :process, ^session, :normal}, @event_timeout
+    end
+
+    test "sending a prompt while the idle timer is pending keeps the session alive", %{
+      tmp_dir: dir
+    } do
+      session_store_dir = Path.join(dir, "idle-race")
+
+      {:ok, session} =
+        Session.start_link(
+          provider: DeferredMockProvider,
+          provider_opts: [],
+          session_store_dir: session_store_dir,
+          idle_gc_timeout_ms: 60_000
+        )
+
+      client = idle_process()
+
+      on_exit(fn ->
+        Process.exit(client, :kill)
+        Process.exit(session, :kill)
+      end)
+
+      assert :ok = Session.subscribe(session, client)
+      assert :ok = Session.unsubscribe(session, client)
+      {_timer_ref, token} = :sys.get_state(session).idle_gc_timer
+      ref = Process.monitor(session)
+
+      assert :ok = Session.send_prompt(session, "keep working")
+      :sys.get_state(Session.get_provider(session))
+      send(session, {:idle_gc_timeout, token})
+      :sys.get_state(session)
+
+      assert Session.status(session) == :idle
+      assert Process.alive?(session)
+
+      DeferredMockProvider.release_start(Session.get_provider(session))
+      :sys.get_state(session)
+      assert Session.status(session) == :thinking
+
+      DeferredMockProvider.release_end(Session.get_provider(session))
+      :sys.get_state(session)
+
+      assert Session.status(session) == :idle
+      refute_receive {:DOWN, ^ref, :process, ^session, :normal}, 50
+    end
+
+    test "active plan-mode turns reschedule idle GC after finishing", %{
+      tmp_dir: dir
+    } do
+      session_store_dir = Path.join(dir, "plan-race")
+
+      {:ok, session} =
+        Session.start_link(
+          provider: Minga.Test.StubProvider,
+          provider_opts: [],
+          session_store_dir: session_store_dir,
+          idle_gc_timeout_ms: 1
+        )
+
+      on_exit(fn -> Process.exit(session, :kill) end)
+
+      assert :ok = Session.enter_plan(session)
+      send(session, {:agent_provider_event, %Event.AgentStart{}})
+      :sys.get_state(session)
+
+      {_timer_ref, _token} = :sys.get_state(session).idle_gc_timer
+      _ref = Process.monitor(session)
+
+      send(session, {:agent_provider_event, %Event.AgentEnd{usage: nil}})
+      :sys.get_state(session)
+
+      assert Session.status(session) == :plan
+      assert :sys.get_state(session).idle_gc_timer != nil
+    end
+
     test "active detached sessions are not reclaimed" do
       {:ok, session} =
         Session.start_link(provider: SlowMockProvider, provider_opts: [], idle_gc_timeout_ms: 1)
@@ -472,6 +642,28 @@ defmodule MingaAgent.SessionTest do
       assert Session.status(session) == :thinking
     end
 
+    test "active plan-mode turns are not reclaimed" do
+      {:ok, session} =
+        Session.start_link(
+          provider: Minga.Test.StubProvider,
+          provider_opts: [],
+          idle_gc_timeout_ms: 60_000
+        )
+
+      on_exit(fn -> Process.exit(session, :kill) end)
+
+      assert :ok = Session.enter_plan(session)
+      send(session, {:agent_provider_event, %Event.AgentStart{}})
+      :sys.get_state(session)
+
+      {_timer_ref, token} = :sys.get_state(session).idle_gc_timer
+      ref = Process.monitor(session)
+
+      send(session, {:idle_gc_timeout, token})
+      assert Session.status(session) == :plan
+      refute_receive {:DOWN, ^ref, :process, ^session, :normal}, 50
+    end
+
     test "stale idle GC messages are ignored after a client reconnects" do
       {:ok, session} =
         Session.start_link(provider: MockProvider, provider_opts: [], idle_gc_timeout_ms: 60_000)
@@ -485,6 +677,56 @@ defmodule MingaAgent.SessionTest do
 
       send(session, {:idle_gc_timeout, stale_token})
       assert Session.status(session) == :idle
+    end
+
+    test "save_session failures are logged and retried with backoff", %{tmp_dir: dir} do
+      bad_store_dir = Path.join(dir, "blocked-store")
+      File.write!(bad_store_dir, "not a directory")
+
+      {:ok, session} =
+        Session.start_link(
+          provider: MockProvider,
+          provider_opts: [],
+          session_store_dir: bad_store_dir,
+          idle_gc_timeout_ms: 60_000
+        )
+
+      on_exit(fn -> Process.exit(session, :kill) end)
+
+      ref = Process.monitor(session)
+
+      send(session, :save_session)
+      state = :sys.get_state(session)
+
+      assert state.save_timer != nil
+      assert state.save_retry_count == 1
+      refute_receive {:DOWN, ^ref, :process, ^session, _}, 50
+    end
+
+    test "idle detached sessions stay alive when persistence fails", %{tmp_dir: dir} do
+      bad_store_dir = Path.join(dir, "blocked-store")
+      File.write!(bad_store_dir, "not a directory")
+
+      {:ok, session} =
+        Session.start_link(
+          provider: MockProvider,
+          provider_opts: [],
+          session_store_dir: bad_store_dir,
+          idle_gc_timeout_ms: 60_000
+        )
+
+      on_exit(fn -> Process.exit(session, :kill) end)
+
+      {_timer_ref, token} = :sys.get_state(session).idle_gc_timer
+      ref = Process.monitor(session)
+
+      send(session, {:idle_gc_timeout, token})
+      state = :sys.get_state(session)
+
+      assert state.idle_gc_timer != nil
+      assert Session.status(session) == :idle
+      assert is_pid(Session.get_provider(session))
+      refute_receive {:DOWN, ^ref, :process, ^session, _}, 50
     end
   end
 

--- a/test/minga_editor/commands/agent_session_restarted_test.exs
+++ b/test/minga_editor/commands/agent_session_restarted_test.exs
@@ -1,0 +1,286 @@
+defmodule MingaEditor.Commands.AgentSessionRestartedTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Minga.Test.StubProvider
+  alias MingaAgent.Session
+  alias MingaAgent.SessionManager
+  alias MingaAgent.SessionManager.SessionRestartedEvent
+  alias MingaAgent.Subagent.Handle
+  alias MingaEditor.Handlers.EventDispatcher
+  alias MingaEditor.Session.State, as: WorkspaceState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace, as: WorkspaceModel
+  alias MingaEditor.Viewport
+
+  defp build_state(old_pid, child_pid) do
+    state = %EditorState{
+      port_manager: nil,
+      workspace: %WorkspaceState{viewport: Viewport.new(80, 24)}
+    }
+
+    {tb, workspace} =
+      TabBar.add_workspace(TabBar.new(Tab.new_file(1, "scratch")), "Agent", old_pid)
+
+    {tb, agent_tab} = TabBar.add(tb, :agent, "Agent")
+
+    handle =
+      Handle.new(
+        session_id: "bg-session",
+        pid: child_pid,
+        parent_session_id: "parent-session",
+        parent_pid: old_pid,
+        task: "child task",
+        started_at: DateTime.utc_now()
+      )
+
+    tb =
+      tb
+      |> TabBar.update_tab(agent_tab.id, &Tab.set_session(&1, old_pid))
+      |> TabBar.update_tab(agent_tab.id, &Tab.set_agent_status(&1, :thinking))
+      |> TabBar.update_tab(agent_tab.id, &Tab.set_group(&1, workspace.id))
+      |> TabBar.update_tab(agent_tab.id, &Tab.mark_background_subagent(&1, handle))
+      |> TabBar.update_workspace(workspace.id, fn workspace ->
+        workspace
+        |> WorkspaceModel.set_session(old_pid)
+        |> WorkspaceModel.set_agent_status(:thinking)
+      end)
+
+    EditorState.set_tab_bar(state, tb)
+  end
+
+  test "restarts re-subscribe, refreshes session refs, and updates background handles" do
+    old_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    child_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn ->
+      Process.exit(old_pid, :kill)
+      Process.exit(child_pid, :kill)
+    end)
+
+    session_id = "session-#{System.unique_integer([:positive])}"
+
+    {:ok, ^session_id, new_pid} =
+      SessionManager.start_session(
+        session_id: session_id,
+        provider: StubProvider,
+        provider_opts: []
+      )
+
+    state = build_state(old_pid, child_pid)
+
+    payload = %SessionRestartedEvent{
+      session_id: session_id,
+      old_pid: old_pid,
+      new_pid: new_pid,
+      reason: :killed
+    }
+
+    assert Session.subscriber_role(new_pid, self()) == nil
+
+    updated = EventDispatcher.dispatch(state, :agent_session_restarted, payload, :message)
+
+    assert Session.subscriber_role(new_pid, self()) == :driver
+
+    active_tab = TabBar.active(updated.shell_state.tab_bar)
+    assert active_tab.session == new_pid
+    assert active_tab.agent_status == :idle
+    assert active_tab.background_subagent.pid == child_pid
+    assert active_tab.background_subagent.parent_pid == new_pid
+
+    workspace = TabBar.find_workspace_by_session(updated.shell_state.tab_bar, new_pid)
+    assert workspace.session == new_pid
+    assert workspace.agent_status == :idle
+    refute TabBar.find_workspace_by_session(updated.shell_state.tab_bar, old_pid)
+    refute_receive {:minga_event, :agent_session_stopped, _}, 50
+  end
+
+  test "ignores stale restart events when SessionManager points to a different live pid" do
+    owned_old_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    child_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn ->
+      Process.exit(owned_old_pid, :kill)
+      Process.exit(child_pid, :kill)
+    end)
+
+    session_id = "session-#{System.unique_integer([:positive])}"
+
+    {:ok, ^session_id, live_pid_b} =
+      SessionManager.start_session(
+        session_id: session_id,
+        provider: StubProvider,
+        provider_opts: []
+      )
+
+    {:ok, _other_session_id, live_pid_a} =
+      SessionManager.start_session(
+        session_id: "other-live-#{System.unique_integer([:positive])}",
+        provider: StubProvider,
+        provider_opts: []
+      )
+
+    on_exit(fn ->
+      Process.exit(live_pid_a, :kill)
+      Process.exit(live_pid_b, :kill)
+    end)
+
+    state = build_state(owned_old_pid, child_pid)
+
+    payload = %SessionRestartedEvent{
+      session_id: session_id,
+      old_pid: owned_old_pid,
+      new_pid: live_pid_a,
+      reason: :killed
+    }
+
+    log =
+      capture_log(fn ->
+        updated = EventDispatcher.dispatch(state, :agent_session_restarted, payload, :message)
+        assert updated == state
+      end)
+
+    assert Session.subscriber_role(live_pid_a, self()) == nil
+    assert Session.subscriber_role(live_pid_b, self()) == nil
+    assert log =~ session_id
+    assert log =~ inspect(owned_old_pid)
+    assert log =~ inspect(live_pid_a)
+    assert log =~ "current_pid"
+  end
+
+  test "ignores unowned restart events without subscribing the new pid" do
+    owned_old_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    child_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    unowned_old_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn ->
+      Process.exit(owned_old_pid, :kill)
+      Process.exit(child_pid, :kill)
+      Process.exit(unowned_old_pid, :kill)
+    end)
+
+    session_id = "session-#{System.unique_integer([:positive])}"
+
+    {:ok, ^session_id, new_pid} =
+      SessionManager.start_session(
+        session_id: session_id,
+        provider: StubProvider,
+        provider_opts: []
+      )
+
+    state = build_state(owned_old_pid, child_pid)
+
+    payload = %SessionRestartedEvent{
+      session_id: session_id,
+      old_pid: unowned_old_pid,
+      new_pid: new_pid,
+      reason: :killed
+    }
+
+    log =
+      capture_log(fn ->
+        updated = EventDispatcher.dispatch(state, :agent_session_restarted, payload, :message)
+        assert updated == state
+      end)
+
+    assert Session.subscriber_role(new_pid, self()) == nil
+    assert log =~ inspect(unowned_old_pid)
+    assert log =~ inspect(new_pid)
+    assert log =~ "unowned_old_pid"
+  end
+
+  test "ignores stale restart events when the replacement pid is already dead" do
+    old_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    child_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn ->
+      Process.exit(old_pid, :kill)
+      Process.exit(child_pid, :kill)
+    end)
+
+    dead_new_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    ref = Process.monitor(dead_new_pid)
+    send(dead_new_pid, :stop)
+    assert_receive {:DOWN, ^ref, :process, ^dead_new_pid, :normal}
+
+    state = build_state(old_pid, child_pid)
+    session_id = "session-#{System.unique_integer([:positive])}"
+
+    payload = %SessionRestartedEvent{
+      session_id: session_id,
+      old_pid: old_pid,
+      new_pid: dead_new_pid,
+      reason: :killed
+    }
+
+    log =
+      capture_log(fn ->
+        updated = EventDispatcher.dispatch(state, :agent_session_restarted, payload, :message)
+        assert updated == state
+      end)
+
+    assert log =~ session_id
+    assert log =~ inspect(old_pid)
+    assert log =~ inspect(dead_new_pid)
+    assert log =~ "not_found"
+  end
+end

--- a/test/support/fake_shell.ex
+++ b/test/support/fake_shell.ex
@@ -96,6 +96,11 @@ defmodule MingaEditor.Test.FakeShell do
   def on_agent_event(shell_state, workspace, _session, _event), do: {shell_state, workspace, []}
 
   @impl true
+  @spec handle_agent_session_restarted(map(), pid(), pid(), term()) :: {map(), boolean()}
+  def handle_agent_session_restarted(shell_state, _old_pid, _new_pid, _reason),
+    do: {shell_state, false}
+
+  @impl true
   @spec active_tab(map()) :: nil
   def active_tab(_shell_state), do: nil
 

--- a/test/support/fake_shell_alt.ex
+++ b/test/support/fake_shell_alt.ex
@@ -87,6 +87,11 @@ defmodule MingaEditor.Test.FakeShellAlt do
   def on_agent_event(shell_state, workspace, _session, _event), do: {shell_state, workspace, []}
 
   @impl true
+  @spec handle_agent_session_restarted(map(), pid(), pid(), term()) :: {map(), boolean()}
+  def handle_agent_session_restarted(shell_state, _old_pid, _new_pid, _reason),
+    do: {shell_state, false}
+
+  @impl true
   @spec active_tab(map()) :: nil
   def active_tab(_shell_state), do: nil
 

--- a/test/support/minga_agent/providers/recording_provider.ex
+++ b/test/support/minga_agent/providers/recording_provider.ex
@@ -25,18 +25,11 @@ defmodule MingaAgent.Providers.RecordingProvider do
 
   @impl MingaAgent.Provider
   @spec seed_messages(GenServer.server(), [MingaAgent.Message.t()]) :: :ok | {:error, term()}
-  def seed_messages(_pid, _messages), do: :ok
+  def seed_messages(pid, messages), do: GenServer.call(pid, {:seed_messages, messages})
 
   @impl MingaAgent.Provider
   @spec get_state(GenServer.server()) :: {:ok, map()} | {:error, term()}
-  def get_state(_pid) do
-    {:ok,
-     %{
-       model: %{id: "test-model", name: "Test Model", provider: "test"},
-       is_streaming: false,
-       token_usage: nil
-     }}
-  end
+  def get_state(pid), do: GenServer.call(pid, :get_state)
 
   @impl MingaAgent.Provider
   @spec get_available_models(GenServer.server()) :: {:ok, [map()]} | {:error, term()}
@@ -69,13 +62,28 @@ defmodule MingaAgent.Providers.RecordingProvider do
     subscriber = Keyword.get(opts, :subscriber)
 
     if is_pid(subscriber), do: Process.monitor(subscriber)
-    {:ok, %{test_pid: test_pid, project_root: project_root, refreshes: []}}
+    {:ok, %{test_pid: test_pid, project_root: project_root, refreshes: [], seeded_messages: []}}
   end
 
   @impl GenServer
   def handle_call({:refresh_project_view, project_view}, _from, state) do
     if is_pid(state.test_pid), do: send(state.test_pid, {:provider_refresh, project_view})
     {:reply, :ok, %{state | refreshes: [project_view | state.refreshes]}}
+  end
+
+  def handle_call({:seed_messages, messages}, _from, state) do
+    {:reply, :ok, %{state | seeded_messages: messages}}
+  end
+
+  def handle_call(:get_state, _from, state) do
+    {:reply,
+     {:ok,
+      %{
+        model: %{id: "test-model", name: "Test Model", provider: "test"},
+        is_streaming: false,
+        token_usage: nil,
+        seeded_messages: state.seeded_messages
+      }}, state}
   end
 
   def handle_call(_msg, _from, state), do: {:reply, :ok, state}


### PR DESCRIPTION
# TL;DR
Remote agent sessions now have an operational daemon lifecycle: documented headless services, explicit detach eventing, configurable idle reclamation, and brokered stop/list verification.

Closes #2052

## Context
This builds on the stable remote broker and reconnect/event-log work. The goal is to make the server behave like a managed background service that clients attach to and detach from, not a foreground process tied to one client.

## Changes
- Added Linux systemd user service and macOS launchd templates for `minga --headless`.
- Added `docs/REMOTE_AGENTS.md` covering daemon setup, Tailscale/cookie trust boundary, server-side credentials, detach/reconnect/end semantics, and idle reclamation.
- Added `:agent_session_idle_timeout_ms`, defaulting to four hours, with `0` disabling idle reclamation.
- Added durable `:user_disconnected` event logging when a subscriber explicitly detaches or drops.
- Added idle detached session reclamation that only runs when there are no subscribers and no active work or pending approval.
- Tokenized idle-GC timers so stale timeout messages cannot reclaim after reconnect.
- Set `MingaAgent.Session.child_spec/1` to `restart: :transient` so crashes still restart but normal idle reclamation does not.
- Added broker API test coverage for explicitly stopping a session and confirming it disappears from the session list.

## Verification
- `make lint`
- `mix test.llm` (56 doctests, 91 properties, 9106 tests, 0 failures, 292 excluded)
- `git diff --check`
- Focused lifecycle/event-log/RemoteAPI tests
- Bug-hunt pass found two idle-GC issues, both fixed; targeted re-check PASS
- Final reviewer gate PASS

## Acceptance Criteria Addressed
- Persistent background daemon setup documented for Linux systemd user services and macOS launchd agents ✅
- Detach/drop keeps sessions running and records disconnect events ✅
- Configurable idle reclamation policy documented; active work is not reclaimed ✅
- Explicit brokered stop removes a session from the session list ✅
- Finished/idle detached sessions are bounded by idle reclamation ✅
