### PR TITLE
feat: add autocomplete for slash model command

### DIFF
--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -162,7 +162,6 @@ defmodule MingaEditor.Agent.SlashCommand do
     state
     |> available_model_entries()
     |> filter_model_entries(prefix)
-    |> Enum.take(20)
     |> Enum.map(&model_completion_candidate/1)
   end
 

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.Agent.SlashCommand do
   alias MingaAgent.Credentials
   alias MingaAgent.Instructions
   alias MingaAgent.Memory
+  alias MingaAgent.ModelCatalog
   alias MingaAgent.Session
   alias MingaAgent.SessionExport
   alias MingaAgent.Skills
@@ -28,6 +29,13 @@ defmodule MingaEditor.Agent.SlashCommand do
 
   @typedoc "A registered slash command."
   @type command :: Command.t()
+
+  @typedoc "A completion candidate for agent slash input."
+  @type completion_candidate :: %{
+          label: String.t(),
+          insert: String.t(),
+          description: String.t()
+        }
 
   @commands [
     %Command{name: "clear", description: "Start a fresh session"},
@@ -106,6 +114,20 @@ defmodule MingaEditor.Agent.SlashCommand do
     Enum.filter(@commands, fn cmd -> String.starts_with?(cmd.name, clean) end)
   end
 
+  @doc "Returns completion candidates for the current slash input, without the leading slash."
+  @spec completion_candidates(state(), String.t()) :: [completion_candidate()]
+  def completion_candidates(state, input) when is_binary(input) do
+    if model_argument_input?(input) do
+      input
+      |> model_argument_prefix()
+      |> model_completion_candidates(state)
+    else
+      input
+      |> completions()
+      |> Enum.map(&command_completion_candidate/1)
+    end
+  end
+
   @doc """
   Parses and executes a slash command from raw input text.
 
@@ -119,6 +141,154 @@ defmodule MingaEditor.Agent.SlashCommand do
   end
 
   def execute(_state, _text), do: {:error, "Not a slash command"}
+
+  @spec command_completion_candidate(command()) :: completion_candidate()
+  defp command_completion_candidate(%Command{name: name, description: description}) do
+    %{label: name, insert: name, description: description}
+  end
+
+  @spec model_argument_input?(String.t()) :: boolean()
+  defp model_argument_input?(input), do: String.match?(input, ~r/^model\s+/)
+
+  @spec model_argument_prefix(String.t()) :: String.t()
+  defp model_argument_prefix(input) do
+    input
+    |> String.replace_prefix("model", "")
+    |> String.trim_leading()
+  end
+
+  @spec model_completion_candidates(String.t(), state()) :: [completion_candidate()]
+  defp model_completion_candidates(prefix, state) do
+    state
+    |> available_model_entries()
+    |> filter_model_entries(prefix)
+    |> Enum.take(20)
+    |> Enum.map(&model_completion_candidate/1)
+  end
+
+  @spec available_model_entries(state()) :: [map()]
+  defp available_model_entries(state) do
+    current_model = current_model(state)
+
+    session_models =
+      case AgentAccess.session(state) do
+        session when is_pid(session) -> safe_session_models(session)
+        _ -> []
+      end
+
+    configured_model_entries()
+    |> Kernel.++(session_models)
+    |> Kernel.++(ModelCatalog.available_models(current_model))
+    |> uniq_model_entries()
+  end
+
+  @spec safe_session_models(pid()) :: [map()]
+  defp safe_session_models(session) do
+    case Session.get_available_models(session) do
+      {:ok, models} when is_list(models) -> models
+      _ -> []
+    end
+  catch
+    :exit, _ -> []
+  end
+
+  @spec configured_model_entries() :: [map()]
+  defp configured_model_entries do
+    :agent_models
+    |> Config.get()
+    |> List.wrap()
+    |> Enum.filter(&is_binary/1)
+    |> Enum.map(&configured_model_entry/1)
+  end
+
+  @spec configured_model_entry(String.t()) :: map()
+  defp configured_model_entry(entry) do
+    model = entry |> String.split("|", parts: 2) |> hd() |> String.trim()
+
+    %{
+      "id" => model,
+      "name" => model,
+      "provider" => provider_label(model),
+      "context_window" => nil,
+      "cost" => nil
+    }
+  end
+
+  @spec current_model(state()) :: String.t()
+  defp current_model(state) do
+    AgentAccess.panel(state).model_name
+  end
+
+  @spec provider_label(String.t()) :: String.t()
+  defp provider_label(model) do
+    case String.split(model, ":", parts: 2) do
+      [provider, _] -> provider
+      [_] -> "custom"
+    end
+  end
+
+  @spec uniq_model_entries([map()]) :: [map()]
+  defp uniq_model_entries(entries) do
+    entries
+    |> Enum.reject(&(model_id(&1) == ""))
+    |> Enum.uniq_by(&model_id/1)
+  end
+
+  @spec filter_model_entries([map()], String.t()) :: [map()]
+  defp filter_model_entries(entries, ""), do: entries
+
+  defp filter_model_entries(entries, prefix) do
+    lower = String.downcase(prefix)
+
+    entries
+    |> Enum.filter(fn model ->
+      [model_id(model), model_name(model), model_provider(model)]
+      |> Enum.any?(&String.contains?(String.downcase(&1), lower))
+    end)
+    |> Enum.sort_by(fn model ->
+      id = model_id(model) |> String.downcase()
+      name = model_name(model) |> String.downcase()
+
+      case {String.starts_with?(id, lower), String.starts_with?(name, lower)} do
+        {true, _} -> {0, id}
+        {_, true} -> {1, id}
+        _ -> {2, id}
+      end
+    end)
+  end
+
+  @spec model_completion_candidate(map()) :: completion_candidate()
+  defp model_completion_candidate(model) do
+    id = model_id(model)
+
+    %{
+      label: id,
+      insert: "model #{id}",
+      description: model_description(model)
+    }
+  end
+
+  @spec model_description(map()) :: String.t()
+  defp model_description(model) do
+    [model_name(model), model_provider(model), model_context(model)]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("  ")
+  end
+
+  @spec model_id(map()) :: String.t()
+  defp model_id(model), do: model |> Map.get("id", "") |> to_string()
+
+  @spec model_name(map()) :: String.t()
+  defp model_name(model), do: model |> Map.get("name", model_id(model)) |> to_string()
+
+  @spec model_provider(map()) :: String.t()
+  defp model_provider(model), do: model |> Map.get("provider", "") |> to_string()
+
+  @spec model_context(map()) :: String.t()
+  defp model_context(%{"context_window" => ctx}) when is_integer(ctx) and ctx >= 1000,
+    do: "#{div(ctx, 1000)}k ctx"
+
+  defp model_context(_model), do: ""
 
   @doc """
   Returns true if the given text is a slash command (starts with /).
@@ -209,7 +379,9 @@ defmodule MingaEditor.Agent.SlashCommand do
   end
 
   @spec do_model(state(), String.t()) :: {:ok, state()} | {:error, String.t()}
-  defp do_model(_state, ""), do: {:error, "Usage: /model <name>"}
+  defp do_model(state, "") do
+    {:ok, PickerUI.open(state, MingaEditor.UI.Picker.AgentModelSource)}
+  end
 
   defp do_model(state, model) do
     model = String.trim(model)

--- a/lib/minga_editor/commands/agent_sub_states.ex
+++ b/lib/minga_editor/commands/agent_sub_states.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.Commands.AgentSubStates do
   alias MingaEditor.Agent.DiffReview
   alias MingaAgent.FileMention
   alias MingaAgent.Session
+  alias MingaEditor.Agent.SlashCommand
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Agent.View.Preview
@@ -107,7 +108,7 @@ defmodule MingaEditor.Commands.AgentSubStates do
     end
   end
 
-  def handle_mention_key(state, 13, _mods), do: accept_mention_completion(state)
+  def handle_mention_key(state, 13, _mods), do: accept_completion(state)
 
   def handle_mention_key(state, 27, _mods) do
     update_panel(state, fn p -> %{p | mention_completion: nil} end)
@@ -116,22 +117,22 @@ defmodule MingaEditor.Commands.AgentSubStates do
   def handle_mention_key(state, 127, _mods) do
     comp = AgentAccess.panel(state).mention_completion
 
-    if comp.prefix == "" do
-      state = AgentCommands.input_backspace(state)
-      update_panel(state, fn p -> %{p | mention_completion: nil} end)
+    if slash_completion?(comp) do
+      slash_backspace(state, comp)
     else
-      state = AgentCommands.input_backspace(state)
-      new_prefix = String.slice(comp.prefix, 0..-2//1)
-
-      update_panel(state, fn p ->
-        %{p | mention_completion: FileMention.update_prefix(comp, new_prefix)}
-      end)
+      mention_backspace(state, comp)
     end
   end
 
   def handle_mention_key(state, cp, mods)
       when cp >= 32 and band(mods, 0x02) == 0 and band(mods, 0x04) == 0 do
-    mention_insert_char(state, <<cp::utf8>>)
+    comp = AgentAccess.panel(state).mention_completion
+
+    if slash_completion?(comp) do
+      slash_insert_char(state, comp, <<cp::utf8>>)
+    else
+      mention_insert_char(state, <<cp::utf8>>)
+    end
   end
 
   def handle_mention_key(state, _cp, _mods), do: state
@@ -150,28 +151,8 @@ defmodule MingaEditor.Commands.AgentSubStates do
   @doc "Triggers /slash command completion when / is typed at position (0, 0)."
   @spec trigger_slash_completion(state()) :: state()
   def trigger_slash_completion(state) do
-    commands = MingaEditor.Agent.SlashCommand.completions("")
-
-    candidates =
-      Enum.map(commands, fn cmd ->
-        {cmd.name, cmd.description}
-      end)
-
-    if candidates != [] do
-      comp = %{
-        prefix: "",
-        all_files: [],
-        candidates: Enum.map(candidates, fn {name, _} -> name end),
-        selected: 0,
-        anchor_line: 0,
-        anchor_col: 0,
-        slash_candidates: candidates
-      }
-
-      update_panel(state, fn p -> %{p | mention_completion: comp} end)
-    else
-      state
-    end
+    slash_completion_state(state, "")
+    |> update_slash_completion(state)
   end
 
   # ── Diff review commands ───────────────────────────────────────────────────
@@ -287,6 +268,137 @@ defmodule MingaEditor.Commands.AgentSubStates do
   end
 
   # ── Private helpers ────────────────────────────────────────────────────────
+
+  @spec slash_completion?(map() | nil) :: boolean()
+  defp slash_completion?(comp), do: is_map(comp) and Map.has_key?(comp, :slash_candidates)
+
+  @spec accept_completion(state()) :: state()
+  defp accept_completion(state) do
+    comp = AgentAccess.panel(state).mention_completion
+
+    if slash_completion?(comp) do
+      accept_slash_completion(state, comp)
+    else
+      accept_mention_completion(state)
+    end
+  end
+
+  @spec mention_backspace(state(), map()) :: state()
+  defp mention_backspace(state, comp) do
+    if comp.prefix == "" do
+      state = AgentCommands.input_backspace(state)
+      update_panel(state, fn p -> %{p | mention_completion: nil} end)
+    else
+      state = AgentCommands.input_backspace(state)
+      new_prefix = String.slice(comp.prefix, 0..-2//1)
+
+      update_panel(state, fn p ->
+        %{p | mention_completion: FileMention.update_prefix(comp, new_prefix)}
+      end)
+    end
+  end
+
+  @spec slash_backspace(state(), map()) :: state()
+  defp slash_backspace(state, %{prefix: ""}) do
+    state = AgentCommands.input_backspace(state)
+    update_panel(state, fn p -> %{p | mention_completion: nil} end)
+  end
+
+  defp slash_backspace(state, comp) do
+    state = AgentCommands.input_backspace(state)
+    new_input = trim_last_grapheme(comp.prefix)
+
+    slash_completion_state(state, new_input)
+    |> update_slash_completion(state)
+  end
+
+  @spec slash_insert_char(state(), map(), String.t()) :: state()
+  defp slash_insert_char(state, comp, char) do
+    state = AgentCommands.input_char(state, char)
+    new_input = comp.prefix <> char
+
+    slash_completion_state(state, new_input)
+    |> update_slash_completion(state)
+  end
+
+  @spec trim_last_grapheme(String.t()) :: String.t()
+  defp trim_last_grapheme(""), do: ""
+
+  defp trim_last_grapheme(text) do
+    text
+    |> String.graphemes()
+    |> Enum.drop(-1)
+    |> Enum.join()
+  end
+
+  @spec slash_completion_state(state(), String.t()) :: map() | nil
+  defp slash_completion_state(state, input) do
+    candidates = SlashCommand.completion_candidates(state, input)
+
+    if candidates == [] do
+      nil
+    else
+      labels = Enum.map(candidates, & &1.label)
+
+      %{
+        prefix: input,
+        all_files: [],
+        candidates: labels,
+        selected: 0,
+        anchor_line: 0,
+        anchor_col: 0,
+        slash_candidates: Enum.map(candidates, &{&1.label, &1.description}),
+        slash_insertions: Map.new(candidates, &{&1.label, &1.insert})
+      }
+    end
+  end
+
+  @spec update_slash_completion(map() | nil, state()) :: state()
+  defp update_slash_completion(nil, state) do
+    update_panel(state, fn p -> %{p | mention_completion: nil} end)
+  end
+
+  defp update_slash_completion(comp, state) do
+    update_panel(state, fn p -> %{p | mention_completion: comp} end)
+  end
+
+  @spec accept_slash_completion(state(), map()) :: state()
+  defp accept_slash_completion(state, comp) do
+    case Enum.at(comp.candidates, comp.selected) do
+      nil ->
+        update_panel(state, fn p -> %{p | mention_completion: nil} end)
+
+      label ->
+        insert = Map.get(Map.get(comp, :slash_insertions, %{}), label, label)
+        replace_slash_input(state, comp, insert)
+    end
+  end
+
+  @spec replace_slash_input(state(), map(), String.t()) :: state()
+  defp replace_slash_input(state, comp, insert) do
+    panel = AgentAccess.panel(state)
+    {line, _col} = UIState.input_cursor(panel)
+    lines = UIState.input_lines(panel)
+    current = Enum.at(lines, line, "")
+    anchor_col = comp.anchor_col
+
+    before = String.slice(current, 0, anchor_col)
+
+    after_prefix =
+      String.slice(
+        current,
+        anchor_col + 1 + String.length(comp.prefix),
+        String.length(current)
+      )
+
+    new_line = before <> "/" <> insert <> " " <> after_prefix
+    new_col = anchor_col + 1 + String.length(insert) + 1
+    new_lines = List.replace_at(lines, line, new_line)
+    new_content = Enum.join(new_lines, "\n")
+
+    state = sync_mention_to_buffer(state, new_content, line, new_col)
+    update_panel(state, fn p -> %{p | mention_completion: nil} end)
+  end
 
   @spec mention_insert_char(state(), String.t()) :: state()
   defp mention_insert_char(state, " ") do

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -2802,10 +2802,11 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     type_byte = if type == :slash, do: 1, else: 0
     anchor_line = comp[:anchor_line] || 0
     anchor_col = comp[:anchor_col] || 0
+    candidate_count = min(length(candidates), 255)
 
     candidate_bins =
       candidates
-      |> Enum.take(10)
+      |> Enum.take(candidate_count)
       |> Enum.map(fn
         {name, desc} ->
           n = :erlang.iolist_to_binary([name])
@@ -2819,7 +2820,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
     IO.iodata_to_binary([
       <<1::8, type_byte::8, min(selected, 255)::8, anchor_line::16, anchor_col::16,
-        min(length(candidates), 10)::8>>
+        candidate_count::8>>
       | candidate_bins
     ])
   end

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -991,10 +991,9 @@ struct AgentChatView: View {
     @ViewBuilder
     private func promptCompletionPopup(_ completion: Wire.PromptCompletion) -> some View {
         let isSlash = completion.type == 1
-        let maxVisible = min(completion.candidates.count, 10)
 
         VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(completion.candidates.prefix(10).enumerated()), id: \.offset) { index, candidate in
+            ForEach(Array(completion.candidates.enumerated()), id: \.offset) { index, candidate in
                 HStack(spacing: 6) {
                     Image(systemName: isSlash ? "command" : "doc")
                         .font(.system(size: 10))
@@ -1021,7 +1020,7 @@ struct AgentChatView: View {
             }
         }
         .frame(maxWidth: 400)
-        .frame(maxHeight: CGFloat(maxVisible) * 24)
+        .frame(maxHeight: CGFloat(completion.candidates.count) * 24)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(theme.agentCodeBg)

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -168,6 +168,29 @@ defmodule MingaEditor.Agent.SlashCommandTest do
         Minga.Config.set_option(:agent_models, [])
       end
     end
+
+    test "renders all configured model entries when many are available" do
+      models =
+        1..25
+        |> Enum.map(fn index ->
+          index
+          |> Integer.to_string()
+          |> String.pad_leading(2, "0")
+          |> then(&"zz-#{&1}")
+        end)
+
+      Minga.Config.set_option(:agent_models, models)
+
+      try do
+        labels =
+          SlashCommand.completion_candidates(mock_state(), "model zz") |> Enum.map(& &1.label)
+
+        assert length(labels) == 25
+        assert MapSet.new(labels) == MapSet.new(models)
+      after
+        Minga.Config.set_option(:agent_models, [])
+      end
+    end
   end
 
   describe "execute/2" do

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -39,6 +39,33 @@ defmodule MingaEditor.Agent.SlashCommandTest do
     @impl MingaAgent.Provider
     def get_state(_pid), do: {:ok, %{model: nil, is_streaming: false, token_usage: nil}}
 
+    @impl MingaAgent.Provider
+    def get_available_models(_pid) do
+      {:ok,
+       [
+         %{
+           "id" => "anthropic:claude-sonnet-4",
+           "name" => "Claude Sonnet 4",
+           "provider" => "anthropic",
+           "context_window" => 200_000,
+           "cost" => nil
+         },
+         %{
+           "id" => "openai:gpt-4o",
+           "name" => "GPT-4o",
+           "provider" => "openai",
+           "context_window" => 128_000,
+           "cost" => nil
+         }
+       ]}
+    end
+
+    @impl MingaAgent.Provider
+    def cycle_model(_pid), do: {:ok, %{"model" => "openai:gpt-4o", "index" => 1, "total" => 1}}
+
+    @impl MingaAgent.Provider
+    def set_model(_pid, _model), do: :ok
+
     @impl GenServer
     def init(_opts), do: {:ok, %{}}
   end
@@ -124,6 +151,25 @@ defmodule MingaEditor.Agent.SlashCommandTest do
     end
   end
 
+  describe "completion_candidates/2" do
+    test "returns slash command candidates before an argument" do
+      labels = SlashCommand.completion_candidates(mock_state(), "mo") |> Enum.map(& &1.label)
+      assert "model" in labels
+      refute "help" in labels
+    end
+
+    test "returns configured model candidates after model and a space" do
+      Minga.Config.set_option(:agent_models, ["anthropic:claude-sonnet-4", "openai:gpt-4o"])
+
+      try do
+        candidates = SlashCommand.completion_candidates(mock_state(), "model gpt")
+        assert [%{label: "openai:gpt-4o", insert: "model openai:gpt-4o"}] = candidates
+      after
+        Minga.Config.set_option(:agent_models, [])
+      end
+    end
+  end
+
   describe "execute/2" do
     # Build a minimal state that the slash commands can work with
     defp mock_state(opts \\ []) do
@@ -200,8 +246,10 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       assert state.shell_state.status_msg == "No agent session"
     end
 
-    test "/model without name returns error" do
-      assert {:error, "Usage: /model <name>"} = SlashCommand.execute(mock_state(), "/model")
+    test "/model without name opens the model picker" do
+      {:ok, state} = SlashCommand.execute(mock_state(session: start_session()), "/model")
+      assert {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+      assert picker_ui.source == MingaEditor.UI.Picker.AgentModelSource
     end
 
     test "/model with name sets model (triggers restart)" do

--- a/test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
@@ -52,6 +52,18 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
     unwrap_message_frames(rest, remaining - 1, [message | acc])
   end
 
+  defp parse_prompt_candidates(<<>>, 0, acc), do: Enum.reverse(acc)
+
+  defp parse_prompt_candidates(
+         <<name_len::16, name::binary-size(name_len), desc_len::16, _desc::binary-size(desc_len),
+           rest::binary>>,
+         remaining,
+         acc
+       )
+       when remaining > 0 do
+    parse_prompt_candidates(rest, remaining - 1, [name | acc])
+  end
+
   describe "decode_gui_action for agent_tool_toggle" do
     test "decodes a valid agent_tool_toggle action" do
       assert {:ok, {:agent_tool_toggle, 7}} ==
@@ -74,6 +86,41 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
 
     test "returns error for empty payload" do
       assert :error == ProtocolGUI.decode_gui_action(0x15, <<>>)
+    end
+  end
+
+  describe "prompt completion encoding" do
+    test "encodes all prompt completion candidates" do
+      candidates =
+        for index <- 1..25 do
+          name = "candidate-#{Integer.to_string(index) |> String.pad_leading(2, "0")}."
+          {name, "desc #{index}"}
+        end
+
+      data = %{
+        visible: true,
+        messages: [],
+        status: :idle,
+        model: "test",
+        prompt: "",
+        prompt_completion: %{
+          type: 1,
+          selected: 0,
+          anchor_line: 0,
+          anchor_col: 0,
+          candidates: candidates
+        },
+        pending_approval: nil
+      }
+
+      binary = ProtocolGUI.encode_gui_agent_chat(data)
+      completion_payload = extract_section(binary, 0x07)
+
+      <<1::8, _type::8, _selected::8, _line::16, _col::16, count::8, rest::binary>> =
+        completion_payload
+
+      assert count == 25
+      assert parse_prompt_candidates(rest, count, []) == Enum.map(candidates, &elem(&1, 0))
     end
   end
 

--- a/test/minga_editor/input/scoped_test.exs
+++ b/test/minga_editor/input/scoped_test.exs
@@ -682,6 +682,22 @@ defmodule MingaEditor.Input.ScopedTest do
     end
   end
 
+  describe "editor panel — slash command completion sub-state" do
+    test "filters commands and accepts without inserting an @ mention" do
+      state = base_state(keymap_scope: :editor, panel_visible: true, input_focused: true)
+
+      {:handled, state} = walk_surface_handlers(state, ?/, 0)
+      {:handled, state} = walk_surface_handlers(state, ?m, 0)
+      {:handled, state} = walk_surface_handlers(state, ?o, 0)
+      comp = AgentAccess.panel(state).mention_completion
+      assert comp.slash_candidates == [{"model", "Set the model: /model <name>"}]
+
+      {:handled, state} = walk_surface_handlers(state, 13, 0)
+      assert Minga.Buffer.content(AgentAccess.panel(state).prompt_buffer) == "/model "
+      assert AgentAccess.panel(state).mention_completion == nil
+    end
+  end
+
   describe "editor scope — panel mention completion" do
     setup do
       {:ok, agent_buf} = BufferProcess.start_link(content: "chat")


### PR DESCRIPTION
## Summary
- Add slash completion support for `/model` so typing `/model` shows discoverable model options.
- Reuse existing picker path so `/model` with no argument now opens model picker.
- Extend slash completion handling so accepted slash candidates insert full slash command text without `@` mention completion behavior.
- Add completion candidates from configured models, active session models, and provider catalog models.
- Render all model completion entries in slash completion lists instead of truncating to a fixed limit.

## Validation
- mix compile --warnings-as-errors
- mix test.llm test/minga_editor/agent/slash_command_test.exs test/minga_editor/input/scoped_test.exs test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
- make lint
