### PR TITLE
fix: add SDK macros module and resolve extension skill paths

### DIFF
--- a/lib/minga_agent/skills.ex
+++ b/lib/minga_agent/skills.ex
@@ -217,11 +217,11 @@ defmodule MingaAgent.Skills do
     end
   end
 
+  defp extract_manifest_skills(_entry), do: []
+
   defp resolve_skill_path(skill_path, root) do
     if Path.type(skill_path) == :absolute, do: skill_path, else: Path.join(root, skill_path)
   end
-
-  defp extract_manifest_skills(_entry), do: []
 
   @spec extension_root(map()) :: String.t() | nil
   defp extension_root(%{path: path}) when is_binary(path), do: path

--- a/lib/minga_agent/skills.ex
+++ b/lib/minga_agent/skills.ex
@@ -212,14 +212,13 @@ defmodule MingaAgent.Skills do
   @spec extract_manifest_skills({atom(), map()}) :: [String.t()]
   defp extract_manifest_skills({_name, %{manifest: %{skills: paths}} = entry}) when paths != [] do
     case extension_root(entry) do
-      nil ->
-        Enum.filter(paths, &(Path.type(&1) == :absolute))
-
-      root ->
-        Enum.map(paths, fn skill_path ->
-          if Path.type(skill_path) == :absolute, do: skill_path, else: Path.join(root, skill_path)
-        end)
+      nil -> Enum.filter(paths, &(Path.type(&1) == :absolute))
+      root -> Enum.map(paths, &resolve_skill_path(&1, root))
     end
+  end
+
+  defp resolve_skill_path(skill_path, root) do
+    if Path.type(skill_path) == :absolute, do: skill_path, else: Path.join(root, skill_path)
   end
 
   defp extract_manifest_skills(_entry), do: []

--- a/lib/minga_agent/skills.ex
+++ b/lib/minga_agent/skills.ex
@@ -210,6 +210,13 @@ defmodule MingaAgent.Skills do
   end
 
   @spec extract_manifest_skills({atom(), map()}) :: [String.t()]
+  defp extract_manifest_skills({_name, %{path: ext_path, manifest: %{skills: paths}}})
+       when paths != [] and is_binary(ext_path) do
+    Enum.map(paths, fn skill_path ->
+      if Path.type(skill_path) == :absolute, do: skill_path, else: Path.join(ext_path, skill_path)
+    end)
+  end
+
   defp extract_manifest_skills({_name, %{manifest: %{skills: paths}}}) when paths != [], do: paths
   defp extract_manifest_skills(_entry), do: []
 

--- a/lib/minga_agent/skills.ex
+++ b/lib/minga_agent/skills.ex
@@ -210,15 +210,41 @@ defmodule MingaAgent.Skills do
   end
 
   @spec extract_manifest_skills({atom(), map()}) :: [String.t()]
-  defp extract_manifest_skills({_name, %{path: ext_path, manifest: %{skills: paths}}})
-       when paths != [] and is_binary(ext_path) do
-    Enum.map(paths, fn skill_path ->
-      if Path.type(skill_path) == :absolute, do: skill_path, else: Path.join(ext_path, skill_path)
-    end)
+  defp extract_manifest_skills({_name, %{manifest: %{skills: paths}} = entry}) when paths != [] do
+    case extension_root(entry) do
+      nil ->
+        Enum.filter(paths, &(Path.type(&1) == :absolute))
+
+      root ->
+        Enum.map(paths, fn skill_path ->
+          if Path.type(skill_path) == :absolute, do: skill_path, else: Path.join(root, skill_path)
+        end)
+    end
   end
 
-  defp extract_manifest_skills({_name, %{manifest: %{skills: paths}}}) when paths != [], do: paths
   defp extract_manifest_skills(_entry), do: []
+
+  @spec extension_root(map()) :: String.t() | nil
+  defp extension_root(%{path: path}) when is_binary(path), do: path
+
+  defp extension_root(%{module: mod}) when is_atom(mod) and not is_nil(mod) do
+    case :code.which(mod) do
+      path when is_list(path) ->
+        path |> List.to_string() |> Path.dirname() |> Path.dirname()
+
+      _ ->
+        nil
+    end
+  end
+
+  defp extension_root(%{hex: %{app: app}}) when is_atom(app) do
+    case :code.lib_dir(app) do
+      path when is_list(path) -> List.to_string(path)
+      _ -> nil
+    end
+  end
+
+  defp extension_root(_entry), do: nil
 
   @spec discover_in(String.t(), :global | :project | :extension) :: [skill()]
   defp discover_in(dir, source) do

--- a/sdk/lib/minga/extension/macros.ex
+++ b/sdk/lib/minga/extension/macros.ex
@@ -1,0 +1,20 @@
+defmodule Minga.Extension.Macros do
+  @moduledoc false
+
+  @doc """
+  Declares a typed config option for this extension.
+
+  Shared between `Extension.Agent` and `Extension.Editor` so both surfaces
+  can declare options without import conflicts when used together.
+  """
+  defmacro option(name, type, opts) do
+    quote do
+      @__extension_options__ {
+        unquote(name),
+        unquote(type),
+        Keyword.fetch!(unquote(opts), :default),
+        Keyword.fetch!(unquote(opts), :description)
+      }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up fixes from open review comments on #2063 (merged):

- **P1: SDK missing `Minga.Extension.Macros`** — Both `Extension.Agent` and `Extension.Editor` in the SDK import `option/3` from `Minga.Extension.Macros`, but the module was never added to `sdk/lib/`. External extensions compiled against `minga_sdk` would fail with a missing module error. Added `sdk/lib/minga/extension/macros.ex`.

- **P2: Extension skill paths resolved against CWD** — `extract_manifest_skills/1` returned raw manifest paths (e.g. `skills/greet`) without resolving them against the extension's root directory. Bundled skills would only load if the editor happened to launch from the extension root. Added a clause that joins relative paths with `entry.path`.

## Test plan

- [ ] `mix compile --warnings-as-errors` passes in both root and `sdk/`
- [ ] Extension with relative skill path loads correctly when launched from a different directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)