### PR TITLE
fix: redesign agent chat visual hierarchy and fix provider/model bugs

### DIFF
--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -91,6 +91,8 @@ defmodule Minga.Keymap.Scope.Agent do
     # g-prefix: domain + vim standard commands
     |> Bindings.bind(~k(g g), :move_to_document_start, "Go to top")
     |> Bindings.bind(~k(g f), :agent_open_code_block, "Open code block in editor")
+    |> Bindings.bind(~k(g a), :agent_apply_code_block, "Apply code block to file")
+    |> Bindings.bind(~k(g p), :agent_pin_message, "Pin/unpin message")
     |> Bindings.bind(~k(g d), :goto_definition, "Go to definition")
     # z-prefix: domain fold/collapse commands
     |> Bindings.bind(~k(z a), :agent_toggle_collapse, "Toggle collapse at cursor")

--- a/lib/minga_agent/config.ex
+++ b/lib/minga_agent/config.ex
@@ -240,6 +240,27 @@ defmodule MingaAgent.Config do
     end
   end
 
+  @doc """
+  Extracts the provider prefix from a model spec string.
+
+  Returns the provider name, or `""` if no prefix is present.
+
+  ## Examples
+
+      iex> MingaAgent.Config.extract_provider_prefix("openai_codex:gpt-5.3-codex-spark")
+      "openai_codex"
+
+      iex> MingaAgent.Config.extract_provider_prefix("claude-sonnet-4")
+      ""
+  """
+  @spec extract_provider_prefix(String.t()) :: String.t()
+  def extract_provider_prefix(model) when is_binary(model) do
+    case String.split(model, ":", parts: 2) do
+      [provider, _name] -> provider
+      [_name] -> ""
+    end
+  end
+
   @spec non_empty_env(String.t()) :: String.t() | nil
   defp non_empty_env(name) do
     case System.get_env(name) do

--- a/lib/minga_agent/markdown.ex
+++ b/lib/minga_agent/markdown.ex
@@ -127,21 +127,28 @@ defmodule MingaAgent.Markdown do
 
   @spec text_before_nth_code_block([String.t()], non_neg_integer()) :: String.t()
   defp text_before_nth_code_block(lines, target_index) do
+    target_fence = target_index * 2
+
     {before_lines, _} =
       Enum.reduce_while(lines, {[], 0}, fn line, {acc, fence_count} ->
-        if String.starts_with?(String.trim_leading(line), "```") do
-          if fence_count == target_index * 2 do
-            {:halt, {acc, fence_count}}
-          else
-            {:cont, {[line | acc], fence_count + 1}}
-          end
-        else
-          {:cont, {[line | acc], fence_count}}
-        end
+        is_fence = String.starts_with?(String.trim_leading(line), "```")
+        accumulate_before_fence(is_fence, line, acc, fence_count, target_fence)
       end)
 
     before_lines |> Enum.reverse() |> Enum.join("\n")
   end
+
+  @spec accumulate_before_fence(boolean(), String.t(), [String.t()], non_neg_integer(), non_neg_integer()) ::
+          {:cont | :halt, {[String.t()], non_neg_integer()}}
+  defp accumulate_before_fence(true, _line, acc, fence_count, target_fence)
+       when fence_count == target_fence,
+       do: {:halt, {acc, fence_count}}
+
+  defp accumulate_before_fence(true, line, acc, fence_count, _target_fence),
+    do: {:cont, {[line | acc], fence_count + 1}}
+
+  defp accumulate_before_fence(false, line, acc, fence_count, _target_fence),
+    do: {:cont, {[line | acc], fence_count}}
 
   @file_path_pattern ~r/`([a-zA-Z0-9_\-\.\/]+\.[a-zA-Z0-9]+)`/
 

--- a/lib/minga_agent/markdown.ex
+++ b/lib/minga_agent/markdown.ex
@@ -105,6 +105,55 @@ defmodule MingaAgent.Markdown do
   end
 
   @doc """
+  Infers the target file path for a code block from surrounding markdown text.
+
+  Scans the text preceding the nth code block (0-indexed) for backtick-wrapped
+  file paths. Returns the last match (closest to the code block), or nil.
+
+  ## Examples
+
+      iex> MingaAgent.Markdown.infer_target_path("Update `lib/foo.ex`:\\n```elixir\\ncode\\n```", 0)
+      "lib/foo.ex"
+
+      iex> MingaAgent.Markdown.infer_target_path("No file mentioned\\n```elixir\\ncode\\n```", 0)
+      nil
+  """
+  @spec infer_target_path(String.t(), non_neg_integer()) :: String.t() | nil
+  def infer_target_path(text, code_block_index) when is_binary(text) do
+    lines = String.split(text, "\n")
+    text_before = text_before_nth_code_block(lines, code_block_index)
+    extract_last_file_path(text_before)
+  end
+
+  @spec text_before_nth_code_block([String.t()], non_neg_integer()) :: String.t()
+  defp text_before_nth_code_block(lines, target_index) do
+    {before_lines, _} =
+      Enum.reduce_while(lines, {[], 0}, fn line, {acc, fence_count} ->
+        if String.starts_with?(String.trim_leading(line), "```") do
+          if fence_count == target_index * 2 do
+            {:halt, {acc, fence_count}}
+          else
+            {:cont, {[line | acc], fence_count + 1}}
+          end
+        else
+          {:cont, {[line | acc], fence_count}}
+        end
+      end)
+
+    before_lines |> Enum.reverse() |> Enum.join("\n")
+  end
+
+  @file_path_pattern ~r/`([a-zA-Z0-9_\-\.\/]+\.[a-zA-Z0-9]+)`/
+
+  @spec extract_last_file_path(String.t()) :: String.t() | nil
+  defp extract_last_file_path(text) do
+    case Regex.scan(@file_path_pattern, text) do
+      [] -> nil
+      matches -> matches |> List.last() |> Enum.at(1)
+    end
+  end
+
+  @doc """
   Parses markdown text into styled line segments.
 
   Returns a list of `{segments, line_type}` tuples, one per output line.

--- a/lib/minga_agent/markdown.ex
+++ b/lib/minga_agent/markdown.ex
@@ -138,7 +138,13 @@ defmodule MingaAgent.Markdown do
     before_lines |> Enum.reverse() |> Enum.join("\n")
   end
 
-  @spec accumulate_before_fence(boolean(), String.t(), [String.t()], non_neg_integer(), non_neg_integer()) ::
+  @spec accumulate_before_fence(
+          boolean(),
+          String.t(),
+          [String.t()],
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
           {:cont | :halt, {[String.t()], non_neg_integer()}}
   defp accumulate_before_fence(true, _line, acc, fence_count, target_fence)
        when fence_count == target_fence,

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -961,7 +961,7 @@ defmodule MingaAgent.Session do
 
     state = %{state | pinned_ids: pinned}
     broadcast(state, :messages_changed)
-    {:reply, :ok, state}
+    {:reply, :ok, schedule_save(state)}
   end
 
   def handle_call(:get_provider, _from, state) do

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -2070,7 +2070,9 @@ defmodule MingaAgent.Session do
       id: state.session_id,
       timestamp: now,
       last_message_at: last_message_at,
-      title: readable_title(first_assistant_text(state.messages)) || readable_title(first_user_prompt(state.messages)),
+      title:
+        readable_title(first_assistant_text(state.messages)) ||
+          readable_title(first_user_prompt(state.messages)),
       model_name: state.model_name,
       provider_name: state.provider_name,
       messages: state.messages,
@@ -2132,7 +2134,13 @@ defmodule MingaAgent.Session do
           case Map.get(data, :message_ids) do
             ids when is_list(ids) and ids != [] ->
               count = length(data.messages)
-              %{state | messages: data.messages, message_ids: Enum.take(ids, count), next_message_id: Enum.max(ids, fn -> 0 end) + 1}
+
+              %{
+                state
+                | messages: data.messages,
+                  message_ids: Enum.take(ids, count),
+                  next_message_id: Enum.max(ids, fn -> 0 end) + 1
+              }
 
             _ ->
               reset_messages(state, data.messages)

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1246,6 +1246,9 @@ defmodule MingaAgent.Session do
   defp handle_provider_event(%Event.AgentEnd{usage: usage}, state) do
     notify(state, :complete, completion_notification(state))
 
+    # Collapse thinking blocks now that the turn is complete
+    state = %{state | messages: collapse_thinking_blocks(state.messages)}
+
     state =
       if usage do
         log_turn_usage(usage, state)
@@ -1293,16 +1296,13 @@ defmodule MingaAgent.Session do
   end
 
   defp handle_provider_event(%Event.TextDelta{delta: delta}, state) do
-    # Auto-collapse any expanded thinking blocks (thinking is done)
-    messages = collapse_thinking_blocks(state.messages)
-
     state =
-      case append_to_last_assistant(messages, delta) do
+      case append_to_last_assistant(state.messages, delta) do
         {:updated, updated_messages} ->
           %{state | messages: updated_messages}
 
         {:appended, new_msg} ->
-          %{state | messages: messages} |> append_msg(new_msg)
+          append_msg(state, new_msg)
       end
 
     broadcast(state, {:text_delta, delta})

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -919,10 +919,11 @@ defmodule MingaAgent.Session do
 
   def handle_call(:metadata, _from, state) do
     first_prompt = first_user_prompt(state.messages)
+    title = readable_title(first_assistant_text(state.messages)) || readable_title(first_prompt)
 
     meta = %SessionMetadata{
       id: state.session_id,
-      title: readable_title(first_prompt),
+      title: title,
       model_name: state.model_name,
       provider_name: state.provider_name,
       created_at: state.created_at,
@@ -2045,7 +2046,7 @@ defmodule MingaAgent.Session do
       id: state.session_id,
       timestamp: now,
       last_message_at: last_message_at,
-      title: readable_title(first_user_prompt(state.messages)),
+      title: readable_title(first_assistant_text(state.messages)) || readable_title(first_user_prompt(state.messages)),
       model_name: state.model_name,
       provider_name: state.provider_name,
       messages: state.messages,
@@ -2177,6 +2178,14 @@ defmodule MingaAgent.Session do
       "" -> nil
       title -> title
     end
+  end
+
+  @spec first_assistant_text([Message.t()]) :: String.t() | nil
+  defp first_assistant_text(messages) do
+    Enum.find_value(messages, fn
+      {:assistant, text} when is_binary(text) and text != "" -> text
+      _ -> nil
+    end)
   end
 
   @spec generate_session_id() :: String.t()

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -108,6 +108,7 @@ defmodule MingaAgent.Session do
           follow_up_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
           touched_files: %{String.t() => file_touch()},
           boundaries: %{String.t() => EditBoundary.t()},
+          pinned_ids: MapSet.t(pos_integer()),
           credentials_configured: boolean()
         }
 
@@ -1417,7 +1418,7 @@ defmodule MingaAgent.Session do
   defp handle_provider_event(%Event.AgentEnd{usage: usage}, state) do
     notify(state, :complete, completion_notification(state))
 
-    # Collapse thinking blocks now that the turn is complete
+    # Collapse thinking blocks now that the turn is complete.
     state = %{state | messages: collapse_thinking_blocks(state.messages)}
 
     state =
@@ -1426,10 +1427,11 @@ defmodule MingaAgent.Session do
 
         state = %{state | total_usage: TurnUsage.add(state.total_usage, usage)}
 
-        state = append_msg(state, Message.usage(usage))
-        notify_messages_changed(state)
-      else
         state
+        |> append_msg(Message.usage(usage))
+        |> notify_messages_changed()
+      else
+        notify_messages_changed(state)
       end
 
     dispatch_stop(state)

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -177,6 +177,18 @@ defmodule MingaAgent.Session do
     GenServer.call(session, :messages_with_ids)
   end
 
+  @doc "Returns the set of pinned message IDs."
+  @spec pinned_ids(GenServer.server()) :: MapSet.t(pos_integer())
+  def pinned_ids(session) do
+    GenServer.call(session, :pinned_ids)
+  end
+
+  @doc "Toggles the pinned state of a message by its stable ID."
+  @spec toggle_pin(GenServer.server(), pos_integer()) :: :ok
+  def toggle_pin(session, message_id) when is_integer(message_id) do
+    GenServer.call(session, {:toggle_pin, message_id})
+  end
+
   @doc "Returns accumulated token usage."
   @spec usage(GenServer.server()) :: Event.token_usage()
   def usage(session) do
@@ -603,10 +615,7 @@ defmodule MingaAgent.Session do
       follow_up_queue: [],
       touched_files: %{},
       boundaries: %{},
-      # Whether any usable provider credential exists. Computed once when the
-      # provider starts (the Ollama probe can block briefly) and refreshed when
-      # the user runs /auth or /login. Gates send_prompt and drives the UI's
-      # "not configured" state so we never advertise a model we can't call.
+      pinned_ids: MapSet.new(),
       credentials_configured: true
     }
 
@@ -892,6 +901,21 @@ defmodule MingaAgent.Session do
 
   def handle_call(:usage, _from, state) do
     {:reply, state.total_usage, state}
+  end
+
+  def handle_call(:pinned_ids, _from, state) do
+    {:reply, state.pinned_ids, state}
+  end
+
+  def handle_call({:toggle_pin, message_id}, _from, state) do
+    pinned =
+      if MapSet.member?(state.pinned_ids, message_id),
+        do: MapSet.delete(state.pinned_ids, message_id),
+        else: MapSet.put(state.pinned_ids, message_id)
+
+    state = %{state | pinned_ids: pinned}
+    broadcast(state, :messages_changed)
+    {:reply, :ok, state}
   end
 
   def handle_call(:get_provider, _from, state) do
@@ -2050,6 +2074,8 @@ defmodule MingaAgent.Session do
       model_name: state.model_name,
       provider_name: state.provider_name,
       messages: state.messages,
+      message_ids: state.message_ids,
+      pinned_ids: state.pinned_ids,
       usage: state.total_usage,
       branches: state.branches,
       memory: Memory.read(state.session_store_dir)
@@ -2080,6 +2106,7 @@ defmodule MingaAgent.Session do
             created_at: loaded_at,
             last_message_at: loaded_at,
             branches: Map.get(data, :branches, []),
+            pinned_ids: Map.get(data, :pinned_ids, MapSet.new()),
             steering_queue: [],
             follow_up_queue: [],
             touched_files: %{},
@@ -2101,7 +2128,15 @@ defmodule MingaAgent.Session do
   defp finish_loaded_session_restore(state, data) do
     case restore_memory_snapshot_if_recorded(state, data) do
       :ok ->
-        state = reset_messages(state, data.messages)
+        state =
+          case Map.get(data, :message_ids) do
+            ids when is_list(ids) and ids != [] ->
+              count = length(data.messages)
+              %{state | messages: data.messages, message_ids: Enum.take(ids, count), next_message_id: Enum.max(ids, fn -> 0 end) + 1}
+
+            _ ->
+              reset_messages(state, data.messages)
+          end
 
         broadcast(state, {:status_changed, :idle})
         broadcast(state, :messages_changed)

--- a/lib/minga_agent/session_store.ex
+++ b/lib/minga_agent/session_store.ex
@@ -37,6 +37,8 @@ defmodule MingaAgent.SessionStore do
           optional(:title) => String.t(),
           optional(:provider_name) => String.t(),
           optional(:branches) => [MingaAgent.Branch.t()],
+          optional(:message_ids) => [pos_integer()],
+          optional(:pinned_ids) => MapSet.t(pos_integer()),
           optional(:memory) => String.t() | nil
         }
 
@@ -230,17 +232,6 @@ defmodule MingaAgent.SessionStore do
     messages = Enum.map(data["messages"] || [], &deserialize_message/1)
     timestamp = data["timestamp"] || ""
 
-    message_ids =
-      case data["message_ids"] do
-        ids when is_list(ids) and ids != [] -> ids
-        _ -> Enum.to_list(1..max(length(messages), 1))
-      end
-
-    pinned_ids =
-      data
-      |> Map.get("pinned_ids", [])
-      |> MapSet.new()
-
     session = %{
       id: data["id"],
       timestamp: timestamp,
@@ -249,18 +240,22 @@ defmodule MingaAgent.SessionStore do
       model_name: data["model_name"] || "unknown",
       provider_name: data["provider_name"] || "unknown",
       messages: messages,
-      message_ids: message_ids,
-      pinned_ids: pinned_ids,
+      message_ids: deserialize_message_ids(data["message_ids"], length(messages)),
+      pinned_ids: deserialize_pinned_ids(data["pinned_ids"]),
       usage: deserialize_turn_usage(data["usage"] || %{}),
       branches: Enum.map(data["branches"] || [], &deserialize_branch/1)
     }
 
-    if Map.has_key?(data, "memory") do
-      Map.put(session, :memory, data["memory"])
-    else
-      session
-    end
+    if Map.has_key?(data, "memory"), do: Map.put(session, :memory, data["memory"]), else: session
   end
+
+  @spec deserialize_message_ids(term(), non_neg_integer()) :: [pos_integer()]
+  defp deserialize_message_ids(ids, _msg_count) when is_list(ids) and ids != [], do: ids
+  defp deserialize_message_ids(_, msg_count), do: Enum.to_list(1..max(msg_count, 1))
+
+  @spec deserialize_pinned_ids(term()) :: MapSet.t()
+  defp deserialize_pinned_ids(ids) when is_list(ids), do: MapSet.new(ids)
+  defp deserialize_pinned_ids(_), do: MapSet.new()
 
   @spec deserialize_message(map()) :: MingaAgent.Message.t()
   defp deserialize_message(%{"type" => "user", "text" => text, "attachments" => attachments})

--- a/lib/minga_agent/session_store.ex
+++ b/lib/minga_agent/session_store.ex
@@ -167,6 +167,8 @@ defmodule MingaAgent.SessionStore do
       "model_name" => data.model_name,
       "provider_name" => Map.get(data, :provider_name, "unknown"),
       "messages" => Enum.map(messages, &serialize_message/1),
+      "message_ids" => Map.get(data, :message_ids, []),
+      "pinned_ids" => serialize_pinned_ids(Map.get(data, :pinned_ids)),
       "usage" => serialize_usage(data.usage),
       "branches" => Enum.map(Map.get(data, :branches, []), &serialize_branch/1),
       "memory" => Map.get(data, :memory)
@@ -207,6 +209,11 @@ defmodule MingaAgent.SessionStore do
   defp serialize_message({:usage, %MingaAgent.TurnUsage{} = usage}),
     do: %{"type" => "usage", "data" => serialize_usage(usage)}
 
+  @spec serialize_pinned_ids(MapSet.t() | list() | nil) :: [pos_integer()]
+  defp serialize_pinned_ids(%MapSet{} = set), do: set |> MapSet.to_list() |> Enum.sort()
+  defp serialize_pinned_ids(list) when is_list(list), do: Enum.sort(list)
+  defp serialize_pinned_ids(_), do: []
+
   @spec serialize_usage(MingaAgent.TurnUsage.t()) :: map()
   defp serialize_usage(%MingaAgent.TurnUsage{} = usage) do
     %{
@@ -223,6 +230,17 @@ defmodule MingaAgent.SessionStore do
     messages = Enum.map(data["messages"] || [], &deserialize_message/1)
     timestamp = data["timestamp"] || ""
 
+    message_ids =
+      case data["message_ids"] do
+        ids when is_list(ids) and ids != [] -> ids
+        _ -> Enum.to_list(1..max(length(messages), 1))
+      end
+
+    pinned_ids =
+      data
+      |> Map.get("pinned_ids", [])
+      |> MapSet.new()
+
     session = %{
       id: data["id"],
       timestamp: timestamp,
@@ -231,6 +249,8 @@ defmodule MingaAgent.SessionStore do
       model_name: data["model_name"] || "unknown",
       provider_name: data["provider_name"] || "unknown",
       messages: messages,
+      message_ids: message_ids,
+      pinned_ids: pinned_ids,
       usage: deserialize_turn_usage(data["usage"] || %{}),
       branches: Enum.map(data["branches"] || [], &deserialize_branch/1)
     }

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -686,6 +686,11 @@ defmodule MingaEditor do
     {:noreply, state}
   end
 
+  def handle_info({:compact_result, result}, state) do
+    state = dispatch_agent_event(state, {:compact_result, result})
+    {:noreply, Renderer.render_or_async(state)}
+  end
+
   # Process died. Check buffer monitors and git remote tasks.
   # Agent session deaths are handled via :agent_session_stopped events from SessionManager.
   def handle_info({:DOWN, ref, :process, pid, reason}, state) do

--- a/lib/minga_editor/agent/buffer_sync.ex
+++ b/lib/minga_editor/agent/buffer_sync.ex
@@ -68,7 +68,7 @@ defmodule MingaEditor.Agent.BufferSync do
 
     pinned_entries = extract_pinned_message_entries(message_id_pairs, pinned_ids, hidden_count)
 
-    {text, line_offsets, display_messages, display_indices} =
+    {text, line_offsets, display_messages} =
       build_display_text(visible_entries, pinned_entries, hidden_count)
 
     text_lines = String.split(text, "\n")
@@ -109,7 +109,7 @@ defmodule MingaEditor.Agent.BufferSync do
         Buffer.replace_generated_content(pid, text)
     end
 
-    line_index = build_line_index(display_messages, text_lines, line_offsets, display_indices)
+    line_index = build_line_index(display_messages, text_lines, line_offsets)
     {line_index, display_messages}
   end
 
@@ -188,28 +188,13 @@ defmodule MingaEditor.Agent.BufferSync do
     build_line_index(messages, text_lines, line_offsets)
   end
 
-  # Builds the line index from pre-computed text lines and offsets.
-  # Used by both sync/3 (cached path) and line_message_index/1 (fallback).
-  # All classification is O(n) in the total number of buffer lines.
   @spec build_line_index([term()], [String.t()], [ChatDecorations.line_offset()]) ::
           [{non_neg_integer(), line_type()}]
+  defp build_line_index(_messages, [], _line_offsets), do: []
+
   defp build_line_index(messages, text_lines, line_offsets) do
-    display_indices = Enum.to_list(0..(length(messages) - 1)//1)
-    build_line_index(messages, text_lines, line_offsets, display_indices)
-  end
-
-  @spec build_line_index(
-          [term()],
-          [String.t()],
-          [ChatDecorations.line_offset()],
-          [non_neg_integer()]
-        ) :: [{non_neg_integer(), line_type()}]
-  defp build_line_index(_messages, [], _line_offsets, _display_indices), do: []
-
-  defp build_line_index(messages, text_lines, line_offsets, display_indices) do
     total_lines = length(text_lines)
 
-    # Build a lookup: buffer_line -> {msg_idx, start_line, line_count}
     line_to_msg =
       line_offsets
       |> Enum.flat_map(fn {msg_idx, start, count} ->
@@ -217,21 +202,16 @@ defmodule MingaEditor.Agent.BufferSync do
       end)
       |> Map.new()
 
-    # Pre-compute fence state for all assistant message lines in one O(n) pass.
-    # Maps buffer_line_number -> :code | :text for lines in assistant messages.
     fence_map = build_fence_map(messages, text_lines, line_offsets)
 
     for line_num <- 0..(total_lines - 1) do
       case Map.get(line_to_msg, line_num) do
         {msg_idx, _start_line, _count} ->
           msg = Enum.at(messages, msg_idx)
-          original_idx = Enum.at(display_indices, msg_idx, msg_idx)
-          {original_idx, classify_line(msg, line_num, fence_map)}
+          {msg_idx, classify_line(msg, line_num, fence_map)}
 
         nil ->
-          # Separator line between messages ("\n\n" join).
-          display_idx = prev_message_idx(line_offsets, line_num)
-          {Enum.at(display_indices, display_idx, display_idx), :empty}
+          {prev_message_idx(line_offsets, line_num), :empty}
       end
     end
   end
@@ -326,7 +306,7 @@ defmodule MingaEditor.Agent.BufferSync do
           [{non_neg_integer(), term()}],
           [{non_neg_integer(), term()}],
           non_neg_integer()
-        ) :: {String.t(), [ChatDecorations.line_offset()], [term()], [non_neg_integer()]}
+        ) :: {String.t(), [ChatDecorations.line_offset()], [term()]}
   defp build_display_text(visible_entries, pinned_entries, hidden_count) do
     prefix_entries =
       if pinned_entries != [] do
@@ -348,9 +328,8 @@ defmodule MingaEditor.Agent.BufferSync do
 
     display_entries = prefix_entries ++ separator_entries ++ visible_entries
     display_messages = Enum.map(display_entries, fn {_idx, msg} -> msg end)
-    display_indices = Enum.map(display_entries, fn {idx, _msg} -> idx end)
     {text, offsets} = messages_to_markdown_with_offsets(display_messages)
-    {text, offsets, display_messages, display_indices}
+    {text, offsets, display_messages}
   end
 
   @spec separator_index([{non_neg_integer(), term()}], [{non_neg_integer(), term()}]) ::

--- a/lib/minga_editor/agent/buffer_sync.ex
+++ b/lib/minga_editor/agent/buffer_sync.ex
@@ -54,16 +54,39 @@ defmodule MingaEditor.Agent.BufferSync do
   """
   @spec sync(pid(), [term()], keyword()) :: [{non_neg_integer(), line_type()}]
   def sync(pid, messages, opts \\ []) do
+    display_start = Keyword.get(opts, :display_start_index, 0)
+    hidden_count = min(display_start, length(messages))
+    visible_messages = Enum.drop(messages, hidden_count)
+
     msg_types =
-      Enum.map(messages, fn
+      Enum.map(visible_messages, fn
         {type, _} -> type
         {type, _, _} -> type
         other -> other
       end)
 
-    Minga.Log.debug(:agent, "[buffer_sync] sync #{length(messages)} msgs: #{inspect(msg_types)}")
+    Minga.Log.debug(:agent, "[buffer_sync] sync #{length(visible_messages)} msgs: #{inspect(msg_types)}")
 
-    {text, line_offsets} = messages_to_markdown_with_offsets(messages)
+    {text, line_offsets} =
+      if hidden_count > 0 do
+        separator = "── #{hidden_count} earlier messages hidden ──"
+        {sep_text, sep_offsets} = messages_to_markdown_with_offsets([{:system, separator, :info}])
+        {msg_text, msg_offsets} = messages_to_markdown_with_offsets(visible_messages)
+
+        if msg_text == "" do
+          {sep_text, sep_offsets}
+        else
+          combined_text = sep_text <> "\n\n" <> msg_text
+
+          {_sep_idx, sep_start, sep_count} = hd(sep_offsets)
+          sep_end = sep_start + sep_count
+          shifted = Enum.map(msg_offsets, fn {idx, start, count} -> {idx + 1, start + sep_end + 1, count} end)
+
+          {combined_text, sep_offsets ++ shifted}
+        end
+      else
+        messages_to_markdown_with_offsets(visible_messages)
+      end
     text_lines = String.split(text, "\n")
 
     Minga.Log.debug(
@@ -76,12 +99,17 @@ defmodule MingaEditor.Agent.BufferSync do
     agent_theme = Keyword.get(opts, :agent_theme, default_agent_theme())
     last_line = max(length(text_lines) - 1, 0)
 
+    display_messages =
+      if hidden_count > 0,
+        do: [{:system, "── #{hidden_count} earlier messages hidden ──", :info}] ++ visible_messages,
+        else: visible_messages
+
     try do
       Buffer.replace_content_with_decorations(
         pid,
         text,
         fn decs ->
-          ChatDecorations.build_decorations(decs, messages, line_offsets, agent_theme, opts)
+          ChatDecorations.build_decorations(decs, display_messages, line_offsets, agent_theme, opts)
         end,
         cursor: {last_line, 0}
       )
@@ -97,7 +125,7 @@ defmodule MingaEditor.Agent.BufferSync do
     end
 
     # Return the line index, reusing the already-computed text and offsets
-    build_line_index(messages, text_lines, line_offsets)
+    build_line_index(display_messages, text_lines, line_offsets)
   end
 
   @doc false

--- a/lib/minga_editor/agent/buffer_sync.ex
+++ b/lib/minga_editor/agent/buffer_sync.ex
@@ -109,10 +109,8 @@ defmodule MingaEditor.Agent.BufferSync do
         Buffer.replace_generated_content(pid, text)
     end
 
-    # Return the line index, reusing the already-computed text and offsets.
-    # The visible list may include pinned or separator rows, so the cached index
-    # maps display rows back to original transcript indexes.
-    build_line_index(display_messages, text_lines, line_offsets, display_indices)
+    line_index = build_line_index(display_messages, text_lines, line_offsets, display_indices)
+    {line_index, display_messages}
   end
 
   @doc false

--- a/lib/minga_editor/agent/buffer_sync.ex
+++ b/lib/minga_editor/agent/buffer_sync.ex
@@ -61,7 +61,7 @@ defmodule MingaEditor.Agent.BufferSync do
     hidden_count = min(display_start, length(messages))
     visible_messages = Enum.drop(messages, hidden_count)
 
-    pinned_messages = extract_pinned_messages(messages, message_id_pairs, pinned_ids, hidden_count)
+    pinned_messages = extract_pinned_messages(message_id_pairs, pinned_ids, hidden_count)
 
     {text, line_offsets, display_messages} =
       build_display_text(visible_messages, pinned_messages, hidden_count)
@@ -282,13 +282,13 @@ defmodule MingaEditor.Agent.BufferSync do
     end
   end
 
-  @spec extract_pinned_messages([term()], [{pos_integer(), term()}], MapSet.t(), non_neg_integer()) ::
+  @spec extract_pinned_messages([{pos_integer(), term()}], MapSet.t(), non_neg_integer()) ::
           [term()]
-  defp extract_pinned_messages(_messages, _pairs, pinned_ids, _hidden_count)
+  defp extract_pinned_messages(_pairs, pinned_ids, _hidden_count)
        when map_size(pinned_ids) == 0,
        do: []
 
-  defp extract_pinned_messages(_messages, pairs, pinned_ids, hidden_count) do
+  defp extract_pinned_messages(pairs, pinned_ids, hidden_count) do
     pairs
     |> Enum.with_index()
     |> Enum.filter(fn {{id, _msg}, idx} ->

--- a/lib/minga_editor/agent/buffer_sync.ex
+++ b/lib/minga_editor/agent/buffer_sync.ex
@@ -59,12 +59,17 @@ defmodule MingaEditor.Agent.BufferSync do
     message_id_pairs = Keyword.get(opts, :message_ids, [])
 
     hidden_count = min(display_start, length(messages))
-    visible_messages = Enum.drop(messages, hidden_count)
 
-    pinned_messages = extract_pinned_messages(message_id_pairs, pinned_ids, hidden_count)
+    visible_entries =
+      messages
+      |> Enum.with_index()
+      |> Enum.drop(hidden_count)
+      |> Enum.map(fn {msg, idx} -> {idx, msg} end)
 
-    {text, line_offsets, display_messages} =
-      build_display_text(visible_messages, pinned_messages, hidden_count)
+    pinned_entries = extract_pinned_message_entries(message_id_pairs, pinned_ids, hidden_count)
+
+    {text, line_offsets, display_messages, display_indices} =
+      build_display_text(visible_entries, pinned_entries, hidden_count)
 
     text_lines = String.split(text, "\n")
 
@@ -104,8 +109,10 @@ defmodule MingaEditor.Agent.BufferSync do
         Buffer.replace_generated_content(pid, text)
     end
 
-    # Return the line index, reusing the already-computed text and offsets
-    build_line_index(display_messages, text_lines, line_offsets)
+    # Return the line index, reusing the already-computed text and offsets.
+    # The visible list may include pinned or separator rows, so the cached index
+    # maps display rows back to original transcript indexes.
+    build_line_index(display_messages, text_lines, line_offsets, display_indices)
   end
 
   @doc false
@@ -188,9 +195,20 @@ defmodule MingaEditor.Agent.BufferSync do
   # All classification is O(n) in the total number of buffer lines.
   @spec build_line_index([term()], [String.t()], [ChatDecorations.line_offset()]) ::
           [{non_neg_integer(), line_type()}]
-  defp build_line_index(_messages, [], _line_offsets), do: []
-
   defp build_line_index(messages, text_lines, line_offsets) do
+    display_indices = Enum.to_list(0..(length(messages) - 1)//1)
+    build_line_index(messages, text_lines, line_offsets, display_indices)
+  end
+
+  @spec build_line_index(
+          [term()],
+          [String.t()],
+          [ChatDecorations.line_offset()],
+          [non_neg_integer()]
+        ) :: [{non_neg_integer(), line_type()}]
+  defp build_line_index(_messages, [], _line_offsets, _display_indices), do: []
+
+  defp build_line_index(messages, text_lines, line_offsets, display_indices) do
     total_lines = length(text_lines)
 
     # Build a lookup: buffer_line -> {msg_idx, start_line, line_count}
@@ -209,11 +227,13 @@ defmodule MingaEditor.Agent.BufferSync do
       case Map.get(line_to_msg, line_num) do
         {msg_idx, _start_line, _count} ->
           msg = Enum.at(messages, msg_idx)
-          {msg_idx, classify_line(msg, line_num, fence_map)}
+          original_idx = Enum.at(display_indices, msg_idx, msg_idx)
+          {original_idx, classify_line(msg, line_num, fence_map)}
 
         nil ->
           # Separator line between messages ("\n\n" join).
-          {prev_message_idx(line_offsets, line_num), :empty}
+          display_idx = prev_message_idx(line_offsets, line_num)
+          {Enum.at(display_indices, display_idx, display_idx), :empty}
       end
     end
   end
@@ -289,42 +309,57 @@ defmodule MingaEditor.Agent.BufferSync do
     end
   end
 
-  @spec extract_pinned_messages([{pos_integer(), term()}], MapSet.t(), non_neg_integer()) ::
-          [term()]
-  defp extract_pinned_messages(_pairs, pinned_ids, _hidden_count)
+  @spec extract_pinned_message_entries([{pos_integer(), term()}], MapSet.t(), non_neg_integer()) ::
+          [{non_neg_integer(), term()}]
+  defp extract_pinned_message_entries(_pairs, pinned_ids, _hidden_count)
        when map_size(pinned_ids) == 0,
        do: []
 
-  defp extract_pinned_messages(pairs, pinned_ids, hidden_count) do
+  defp extract_pinned_message_entries(pairs, pinned_ids, hidden_count) do
     pairs
     |> Enum.with_index()
     |> Enum.filter(fn {{id, _msg}, idx} ->
       MapSet.member?(pinned_ids, id) and idx < hidden_count
     end)
-    |> Enum.map(fn {{_id, msg}, _idx} -> msg end)
+    |> Enum.map(fn {{_id, msg}, idx} -> {idx, msg} end)
   end
 
-  @spec build_display_text([term()], [term()], non_neg_integer()) ::
-          {String.t(), [ChatDecorations.line_offset()], [term()]}
-  defp build_display_text(visible_messages, pinned_messages, hidden_count) do
-    prefix_messages =
-      if pinned_messages != [] do
-        pinned_messages ++ [{:system, "── pinned ──", :info}]
+  @spec build_display_text(
+          [{non_neg_integer(), term()}],
+          [{non_neg_integer(), term()}],
+          non_neg_integer()
+        ) :: {String.t(), [ChatDecorations.line_offset()], [term()], [non_neg_integer()]}
+  defp build_display_text(visible_entries, pinned_entries, hidden_count) do
+    prefix_entries =
+      if pinned_entries != [] do
+        pinned_entries ++
+          [{separator_index(pinned_entries, visible_entries), {:system, "── pinned ──", :info}}]
       else
         []
       end
 
-    separator_messages =
+    separator_entries =
       if hidden_count > 0 do
-        [{:system, "── #{hidden_count} earlier messages hidden ──", :info}]
+        [
+          {separator_index(visible_entries, pinned_entries),
+           {:system, "── #{hidden_count} earlier messages hidden ──", :info}}
+        ]
       else
         []
       end
 
-    display_messages = prefix_messages ++ separator_messages ++ visible_messages
+    display_entries = prefix_entries ++ separator_entries ++ visible_entries
+    display_messages = Enum.map(display_entries, fn {_idx, msg} -> msg end)
+    display_indices = Enum.map(display_entries, fn {idx, _msg} -> idx end)
     {text, offsets} = messages_to_markdown_with_offsets(display_messages)
-    {text, offsets, display_messages}
+    {text, offsets, display_messages, display_indices}
   end
+
+  @spec separator_index([{non_neg_integer(), term()}], [{non_neg_integer(), term()}]) ::
+          non_neg_integer()
+  defp separator_index([{idx, _msg} | _rest], _fallback_entries), do: idx
+  defp separator_index([], [{idx, _msg} | _rest]), do: idx
+  defp separator_index([], []), do: 0
 
   defp default_agent_theme do
     theme = MingaEditor.UI.Theme.get!(MingaEditor.UI.Theme.default())

--- a/lib/minga_editor/agent/buffer_sync.ex
+++ b/lib/minga_editor/agent/buffer_sync.ex
@@ -55,38 +55,16 @@ defmodule MingaEditor.Agent.BufferSync do
   @spec sync(pid(), [term()], keyword()) :: [{non_neg_integer(), line_type()}]
   def sync(pid, messages, opts \\ []) do
     display_start = Keyword.get(opts, :display_start_index, 0)
+    pinned_ids = Keyword.get(opts, :pinned_ids, MapSet.new())
+    message_id_pairs = Keyword.get(opts, :message_ids, [])
+
     hidden_count = min(display_start, length(messages))
     visible_messages = Enum.drop(messages, hidden_count)
 
-    msg_types =
-      Enum.map(visible_messages, fn
-        {type, _} -> type
-        {type, _, _} -> type
-        other -> other
-      end)
+    pinned_messages = extract_pinned_messages(messages, message_id_pairs, pinned_ids, hidden_count)
 
-    Minga.Log.debug(:agent, "[buffer_sync] sync #{length(visible_messages)} msgs: #{inspect(msg_types)}")
-
-    {text, line_offsets} =
-      if hidden_count > 0 do
-        separator = "── #{hidden_count} earlier messages hidden ──"
-        {sep_text, sep_offsets} = messages_to_markdown_with_offsets([{:system, separator, :info}])
-        {msg_text, msg_offsets} = messages_to_markdown_with_offsets(visible_messages)
-
-        if msg_text == "" do
-          {sep_text, sep_offsets}
-        else
-          combined_text = sep_text <> "\n\n" <> msg_text
-
-          {_sep_idx, sep_start, sep_count} = hd(sep_offsets)
-          sep_end = sep_start + sep_count
-          shifted = Enum.map(msg_offsets, fn {idx, start, count} -> {idx + 1, start + sep_end + 1, count} end)
-
-          {combined_text, sep_offsets ++ shifted}
-        end
-      else
-        messages_to_markdown_with_offsets(visible_messages)
-      end
+    {text, line_offsets, display_messages} =
+      build_display_text(visible_messages, pinned_messages, hidden_count)
     text_lines = String.split(text, "\n")
 
     Minga.Log.debug(
@@ -98,11 +76,6 @@ defmodule MingaEditor.Agent.BufferSync do
     # This prevents a render frame from seeing new content with zero decorations.
     agent_theme = Keyword.get(opts, :agent_theme, default_agent_theme())
     last_line = max(length(text_lines) - 1, 0)
-
-    display_messages =
-      if hidden_count > 0,
-        do: [{:system, "── #{hidden_count} earlier messages hidden ──", :info}] ++ visible_messages,
-        else: visible_messages
 
     try do
       Buffer.replace_content_with_decorations(
@@ -307,6 +280,43 @@ defmodule MingaEditor.Agent.BufferSync do
       {_idx, start, _count} -> start
       nil -> nil
     end
+  end
+
+  @spec extract_pinned_messages([term()], [{pos_integer(), term()}], MapSet.t(), non_neg_integer()) ::
+          [term()]
+  defp extract_pinned_messages(_messages, _pairs, pinned_ids, _hidden_count)
+       when map_size(pinned_ids) == 0,
+       do: []
+
+  defp extract_pinned_messages(_messages, pairs, pinned_ids, hidden_count) do
+    pairs
+    |> Enum.with_index()
+    |> Enum.filter(fn {{id, _msg}, idx} ->
+      MapSet.member?(pinned_ids, id) and idx < hidden_count
+    end)
+    |> Enum.map(fn {{_id, msg}, _idx} -> msg end)
+  end
+
+  @spec build_display_text([term()], [term()], non_neg_integer()) ::
+          {String.t(), [ChatDecorations.line_offset()], [term()]}
+  defp build_display_text(visible_messages, pinned_messages, hidden_count) do
+    prefix_messages =
+      if pinned_messages != [] do
+        pinned_messages ++ [{:system, "── pinned ──", :info}]
+      else
+        []
+      end
+
+    separator_messages =
+      if hidden_count > 0 do
+        [{:system, "── #{hidden_count} earlier messages hidden ──", :info}]
+      else
+        []
+      end
+
+    display_messages = prefix_messages ++ separator_messages ++ visible_messages
+    {text, offsets} = messages_to_markdown_with_offsets(display_messages)
+    {text, offsets, display_messages}
   end
 
   defp default_agent_theme do

--- a/lib/minga_editor/agent/buffer_sync.ex
+++ b/lib/minga_editor/agent/buffer_sync.ex
@@ -52,7 +52,8 @@ defmodule MingaEditor.Agent.BufferSync do
   so the caller can cache it in state for later lookups without
   recomputing.
   """
-  @spec sync(pid(), [term()], keyword()) :: [{non_neg_integer(), line_type()}]
+  @spec sync(pid(), [term()], keyword()) ::
+          {[{non_neg_integer(), line_type()}], [term()], [{pos_integer(), term()}]}
   def sync(pid, messages, opts \\ []) do
     display_start = Keyword.get(opts, :display_start_index, 0)
     pinned_ids = Keyword.get(opts, :pinned_ids, MapSet.new())
@@ -68,8 +69,8 @@ defmodule MingaEditor.Agent.BufferSync do
 
     pinned_entries = extract_pinned_message_entries(message_id_pairs, pinned_ids, hidden_count)
 
-    {text, line_offsets, display_messages} =
-      build_display_text(visible_entries, pinned_entries, hidden_count)
+    {text, line_offsets, display_messages, display_message_pairs} =
+      build_display_text(visible_entries, pinned_entries, hidden_count, message_id_pairs)
 
     text_lines = String.split(text, "\n")
 
@@ -110,7 +111,7 @@ defmodule MingaEditor.Agent.BufferSync do
     end
 
     line_index = build_line_index(display_messages, text_lines, line_offsets)
-    {line_index, display_messages}
+    {line_index, display_messages, display_message_pairs}
   end
 
   @doc false
@@ -302,12 +303,16 @@ defmodule MingaEditor.Agent.BufferSync do
     |> Enum.map(fn {{_id, msg}, idx} -> {idx, msg} end)
   end
 
+  @pinned_separator_id 4_000_000_001
+  @hidden_separator_id 4_000_000_002
+
   @spec build_display_text(
           [{non_neg_integer(), term()}],
           [{non_neg_integer(), term()}],
-          non_neg_integer()
-        ) :: {String.t(), [ChatDecorations.line_offset()], [term()]}
-  defp build_display_text(visible_entries, pinned_entries, hidden_count) do
+          non_neg_integer(),
+          [{pos_integer(), term()}]
+        ) :: {String.t(), [ChatDecorations.line_offset()], [term()], [{pos_integer(), term()}]}
+  defp build_display_text(visible_entries, pinned_entries, hidden_count, message_id_pairs) do
     prefix_entries =
       if pinned_entries != [] do
         pinned_entries ++
@@ -328,9 +333,33 @@ defmodule MingaEditor.Agent.BufferSync do
 
     display_entries = prefix_entries ++ separator_entries ++ visible_entries
     display_messages = Enum.map(display_entries, fn {_idx, msg} -> msg end)
+    display_message_pairs = display_message_pairs(display_entries, message_id_pairs)
     {text, offsets} = messages_to_markdown_with_offsets(display_messages)
-    {text, offsets, display_messages}
+    {text, offsets, display_messages, display_message_pairs}
   end
+
+  @spec display_message_pairs([{non_neg_integer(), term()}], [{pos_integer(), term()}]) ::
+          [{pos_integer(), term()}]
+  defp display_message_pairs(display_entries, message_id_pairs) do
+    id_by_index =
+      message_id_pairs
+      |> Enum.with_index()
+      |> Map.new(fn {{id, _msg}, idx} -> {idx, id} end)
+
+    Enum.map(display_entries, fn {idx, msg} ->
+      {display_message_id(idx, msg, id_by_index), msg}
+    end)
+  end
+
+  @spec display_message_id(non_neg_integer(), term(), %{non_neg_integer() => pos_integer()}) ::
+          pos_integer()
+  defp display_message_id(_idx, {:system, "── pinned ──", :info}, _id_by_index),
+    do: @pinned_separator_id
+
+  defp display_message_id(_idx, {:system, "── " <> _rest, :info}, _id_by_index),
+    do: @hidden_separator_id
+
+  defp display_message_id(idx, _msg, id_by_index), do: Map.get(id_by_index, idx, idx + 1)
 
   @spec separator_index([{non_neg_integer(), term()}], [{non_neg_integer(), term()}]) ::
           non_neg_integer()

--- a/lib/minga_editor/agent/buffer_sync.ex
+++ b/lib/minga_editor/agent/buffer_sync.ex
@@ -65,6 +65,7 @@ defmodule MingaEditor.Agent.BufferSync do
 
     {text, line_offsets, display_messages} =
       build_display_text(visible_messages, pinned_messages, hidden_count)
+
     text_lines = String.split(text, "\n")
 
     Minga.Log.debug(
@@ -82,7 +83,13 @@ defmodule MingaEditor.Agent.BufferSync do
         pid,
         text,
         fn decs ->
-          ChatDecorations.build_decorations(decs, display_messages, line_offsets, agent_theme, opts)
+          ChatDecorations.build_decorations(
+            decs,
+            display_messages,
+            line_offsets,
+            agent_theme,
+            opts
+          )
         end,
         cursor: {last_line, 0}
       )

--- a/lib/minga_editor/agent/chat_decorations.ex
+++ b/lib/minga_editor/agent/chat_decorations.ex
@@ -161,7 +161,7 @@ defmodule MingaEditor.Agent.ChatDecorations do
       add_block(decs, line,
         placement: :above,
         render: fn _w ->
-          [{"▎ Agent", Face.new(fg: theme.assistant_border, bold: true, bg: theme.header_bg)}]
+          [{"┌─ Agent", Face.new(fg: theme.assistant_border, bold: true)}]
         end,
         priority: 10
       )
@@ -180,8 +180,20 @@ defmodule MingaEditor.Agent.ChatDecorations do
         decs
       end
 
-    decs = add_border_virtual_text(decs, line, line_count, theme.assistant_border)
+    decs = add_tool_border_virtual_text(decs, line, line_count, theme.assistant_border)
     decs = add_readable_body_highlight(decs, line, line_count, theme.text_fg)
+
+    # Bottom border
+    last_line = line + line_count - 1
+
+    {_id, decs} =
+      add_block(decs, last_line,
+        placement: :below,
+        render: fn _w ->
+          [{"└─", Face.new(fg: theme.assistant_border)}]
+        end,
+        priority: 5
+      )
 
     # Code block background highlights (lines between ``` fences)
     add_code_block_highlights(decs, text, line, theme.code_bg)
@@ -271,6 +283,16 @@ defmodule MingaEditor.Agent.ChatDecorations do
          _streaming,
          _pending_approval
        ) do
+    # "Done" marker above usage stats
+    {_id, decs} =
+      add_block(decs, line,
+        placement: :above,
+        render: fn _w ->
+          [{"  Done", Face.new(fg: theme.status_idle)}]
+        end,
+        priority: 5
+      )
+
     # Dim the usage stats line
     {_id, decs} =
       add_highlight(decs, {line, 0}, {line + line_count, 0},
@@ -351,56 +373,66 @@ defmodule MingaEditor.Agent.ChatDecorations do
     duration_text = format_tool_duration(tc)
     command_text = format_tool_command(tc)
     trust_text = format_auto_approved_scope(tc)
-    header_text = "┌─ #{status_icon} #{tc.name}#{duration_text}#{trust_text}#{command_text}"
-
-    # Block decoration: tool header (with approval prompt when awaiting)
-    {_id, decs} =
-      add_block(decs, line,
-        placement: :above,
-        render: tool_header_render(header_text, status_fg, theme, awaiting_approval),
-        priority: 5
-      )
-
-    # Fold region for tool output (collapsible with za)
-    fold_placeholder = "└─ #{status_icon} #{tc.name} (#{line_count} lines)"
-
-    decs =
-      if has_result and tc.status != :running do
-        {_id, decs} =
-          add_fold(decs, line, line + line_count - 1,
-            closed: tc.collapsed,
-            placeholder: fn _s, _e, _w ->
-              [{fold_placeholder, Face.new(fg: status_fg, italic: true)}]
-            end
-          )
-
-        decs
-      else
-        decs
-      end
-
-    # Dim tool output text
-    {_id, decs} =
-      add_highlight(decs, {line, 0}, {line + line_count, 0},
-        style: Face.new(fg: theme.text_fg),
-        priority: -10,
-        group: :chat_tool
-      )
-
-    # Left border (│) on each content line
-    decs = add_tool_border_virtual_text(decs, line, line_count, theme.tool_border)
-
-    # Bottom border or pending approval card.
-    last_line = line + line_count - 1
 
     if awaiting_approval do
+      # Approval-pending tool calls keep the full box treatment to draw attention
+      header_text = "┌─ #{status_icon} #{tc.name}#{duration_text}#{trust_text}#{command_text}"
+
+      {_id, decs} =
+        add_block(decs, line,
+          placement: :above,
+          render: tool_approval_header_render(header_text, status_fg, theme),
+          priority: 5
+        )
+
+      # Dim tool output text
+      {_id, decs} =
+        add_highlight(decs, {line, 0}, {line + line_count, 0},
+          style: Face.new(fg: theme.text_fg),
+          priority: -10,
+          group: :chat_tool
+        )
+
+      decs = add_tool_border_virtual_text(decs, line, line_count, theme.tool_border)
+      last_line = line + line_count - 1
       add_approval_card(decs, last_line, tc, approval, theme, status_fg)
     else
+      # Non-approval tool calls: compact single-line status
+      header_text = "  #{status_icon} #{tc.name}#{duration_text}#{trust_text}#{command_text}"
+
       {_id, decs} =
-        add_block(decs, last_line,
-          placement: :below,
-          render: fn _w -> [{"└─", Face.new(fg: status_fg)}] end,
+        add_block(decs, line,
+          placement: :above,
+          render: fn _w ->
+            [{header_text, Face.new(fg: status_fg)}]
+          end,
           priority: 5
+        )
+
+      # Fold region for tool output (collapsible with za)
+      fold_placeholder = "  #{status_icon} #{tc.name}#{duration_text} (#{line_count} lines)"
+
+      decs =
+        if has_result and tc.status != :running do
+          {_id, decs} =
+            add_fold(decs, line, line + line_count - 1,
+              closed: tc.collapsed,
+              placeholder: fn _s, _e, _w ->
+                [{fold_placeholder, Face.new(fg: status_fg, italic: true)}]
+              end
+            )
+
+          decs
+        else
+          decs
+        end
+
+      # Dim tool output text
+      {_id, decs} =
+        add_highlight(decs, {line, 0}, {line + line_count, 0},
+          style: Face.new(fg: theme.text_fg),
+          priority: -10,
+          group: :chat_tool
         )
 
       decs
@@ -497,14 +529,9 @@ defmodule MingaEditor.Agent.ChatDecorations do
   defp preview_label(:target), do: "Target"
   defp preview_label(_kind), do: "Args"
 
-  @spec tool_header_render(
-          String.t(),
-          non_neg_integer(),
-          MingaEditor.UI.Theme.Agent.t(),
-          boolean()
-        ) ::
+  @spec tool_approval_header_render(String.t(), non_neg_integer(), MingaEditor.UI.Theme.Agent.t()) ::
           (non_neg_integer() -> [{String.t(), Face.t()}])
-  defp tool_header_render(header_text, status_fg, theme, true = _awaiting) do
+  defp tool_approval_header_render(header_text, status_fg, theme) do
     fn _w ->
       [
         {header_text, Face.new(fg: status_fg, bold: true)},
@@ -522,12 +549,6 @@ defmodule MingaEditor.Agent.ChatDecorations do
     end
   end
 
-  defp tool_header_render(header_text, status_fg, _theme, false) do
-    fn _w ->
-      [{header_text, Face.new(fg: status_fg, bold: true)}]
-    end
-  end
-
   # Ensures assistant prose stays readable even when markdown syntax colors would otherwise dim it.
   @spec add_readable_body_highlight(
           Decorations.t(),
@@ -541,7 +562,7 @@ defmodule MingaEditor.Agent.ChatDecorations do
     {_id, decs} =
       add_highlight(decs, {line, 0}, {line + line_count, 0},
         style: Face.new(fg: text_fg),
-        priority: -30
+        priority: -5
       )
 
     decs

--- a/lib/minga_editor/agent/chat_decorations.ex
+++ b/lib/minga_editor/agent/chat_decorations.ex
@@ -166,13 +166,22 @@ defmodule MingaEditor.Agent.ChatDecorations do
         priority: 10
       )
 
-    # Spinner as EOL virtual text when streaming (updates on each sync call)
+    last_line = line + line_count - 1
+
+    # Streaming indicator: spinner on last line + subtle highlight
     decs =
       if streaming do
         {_id, decs} =
-          add_vtext(decs, {line, 0},
-            segments: [{spinner_frame(), Face.new(fg: theme.status_thinking, italic: true)}],
+          add_vtext(decs, {last_line, 0},
+            segments: [{" " <> spinner_frame(), Face.new(fg: theme.status_thinking)}],
             placement: :eol
+          )
+
+        {_id, decs} =
+          add_highlight(decs, {last_line, 0}, {last_line + 1, 0},
+            style: Face.new(bg: theme.code_bg),
+            priority: -15,
+            group: :chat_streaming
           )
 
         decs
@@ -182,9 +191,6 @@ defmodule MingaEditor.Agent.ChatDecorations do
 
     decs = add_tool_border_virtual_text(decs, line, line_count, theme.assistant_border)
     decs = add_readable_body_highlight(decs, line, line_count, theme.text_fg)
-
-    # Bottom border
-    last_line = line + line_count - 1
 
     {_id, decs} =
       add_block(decs, last_line,

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -97,6 +97,7 @@ defmodule MingaEditor.Agent.Events do
   def handle(state, :messages_changed) do
     state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
     state = AgentAccess.update_panel(state, &Panel.bump_message_version/1)
+    state = maybe_rename_workspace_from_assistant(state)
     {state, [{:render, 16}, :sync_agent_buffer, {:update_tab_label, ""}]}
   end
 
@@ -733,6 +734,44 @@ defmodule MingaEditor.Agent.Events do
     else
       _ -> nil
     end
+  end
+
+  @spec maybe_rename_workspace_from_assistant(EditorState.t()) :: EditorState.t()
+  defp maybe_rename_workspace_from_assistant(state) do
+    session = AgentAccess.session(state)
+    tb = EditorState.tab_bar(state)
+
+    with pid when is_pid(pid) <- session,
+         %Workspace{custom_name: nil} = ws <- TabBar.find_workspace_by_session(tb, pid) do
+      messages = safe_messages(pid)
+
+      case first_assistant_opening(messages) do
+        nil -> state
+        text -> maybe_apply_auto_name(state, ws, text)
+      end
+    else
+      _ -> state
+    end
+  rescue
+    _ -> state
+  end
+
+  @spec first_assistant_opening([term()]) :: String.t() | nil
+  defp first_assistant_opening(messages) do
+    Enum.find_value(messages, fn
+      {:assistant, text} when is_binary(text) and text != "" ->
+        text |> String.split("\n") |> hd() |> String.trim()
+
+      _ ->
+        nil
+    end)
+  end
+
+  @spec safe_messages(pid()) :: [term()]
+  defp safe_messages(pid) do
+    Session.messages(pid)
+  catch
+    :exit, _ -> []
   end
 
   @spec reset_compact_state(EditorState.t()) :: EditorState.t()

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -738,24 +738,13 @@ defmodule MingaEditor.Agent.Events do
 
   @spec maybe_rename_workspace_from_assistant(EditorState.t()) :: EditorState.t()
   defp maybe_rename_workspace_from_assistant(state) do
-    session = AgentAccess.session(state)
-    tb = EditorState.tab_bar(state)
-
-    with pid when is_pid(pid) <- session,
-         %Workspace{custom_name: nil} = ws <- TabBar.find_workspace_by_session(tb, pid) do
-      messages = safe_messages(pid)
-
-      case first_assistant_opening(messages) do
-        nil ->
-          state
-
-        text ->
-          candidate = text |> String.slice(0, 30) |> String.trim()
-
-          if candidate != "" and candidate != ws.label,
-            do: maybe_apply_auto_name(state, ws, text),
-            else: state
-      end
+    with pid when is_pid(pid) <- AgentAccess.session(state),
+         %Workspace{custom_name: nil} = ws <-
+           TabBar.find_workspace_by_session(EditorState.tab_bar(state), pid),
+         text when is_binary(text) <- first_assistant_opening(safe_messages(pid)),
+         candidate = String.slice(text, 0, 30) |> String.trim(),
+         true <- candidate != "" and candidate != ws.label do
+      maybe_apply_auto_name(state, ws, text)
     else
       _ -> state
     end
@@ -803,43 +792,55 @@ defmodule MingaEditor.Agent.Events do
       {state, []}
     else
       fill_pct = min(round(estimated_tokens / context_limit * 100), 100)
-      auto_pct = compact_auto_threshold()
-      warn_pct = compact_warn_threshold()
-
-      cond do
-        auto_pct > 0 and fill_pct >= auto_pct and not view.compact_triggered ->
-          session = AgentAccess.session(state)
-
-          if is_pid(session) do
-            state =
-              AgentAccess.update_view(state, fn v ->
-                %{v | compact_triggered: true, compaction_in_progress: true}
-              end)
-
-            {state, [{:compact_session, session}]}
-          else
-            {state, []}
-          end
-
-        warn_pct > 0 and fill_pct >= warn_pct and not view.compact_warned ->
-          state =
-            AgentAccess.update_view(state, fn v -> %{v | compact_warned: true} end)
-
-          state =
-            AgentAccess.update_agent_ui(state, fn ui ->
-              UIState.push_toast(
-                ui,
-                "Context at #{fill_pct}%. Run /compact to free space.",
-                :warning
-              )
-            end)
-
-          {state, []}
-
-        true ->
-          {state, []}
-      end
+      apply_compact_threshold(state, view, fill_pct)
     end
+  end
+
+  @spec apply_compact_threshold(EditorState.t(), term(), non_neg_integer()) ::
+          {EditorState.t(), [effect()]}
+  defp apply_compact_threshold(state, view, fill_pct) do
+    auto_pct = compact_auto_threshold()
+    warn_pct = compact_warn_threshold()
+
+    cond do
+      auto_pct > 0 and fill_pct >= auto_pct and not view.compact_triggered ->
+        trigger_auto_compact(state)
+
+      warn_pct > 0 and fill_pct >= warn_pct and not view.compact_warned ->
+        warn_context_pressure(state, fill_pct)
+
+      true ->
+        {state, []}
+    end
+  end
+
+  @spec trigger_auto_compact(EditorState.t()) :: {EditorState.t(), [effect()]}
+  defp trigger_auto_compact(state) do
+    session = AgentAccess.session(state)
+
+    if is_pid(session) do
+      state =
+        AgentAccess.update_view(state, fn v ->
+          %{v | compact_triggered: true, compaction_in_progress: true}
+        end)
+
+      {state, [{:compact_session, session}]}
+    else
+      {state, []}
+    end
+  end
+
+  @spec warn_context_pressure(EditorState.t(), non_neg_integer()) ::
+          {EditorState.t(), [effect()]}
+  defp warn_context_pressure(state, fill_pct) do
+    state = AgentAccess.update_view(state, fn v -> %{v | compact_warned: true} end)
+
+    state =
+      AgentAccess.update_agent_ui(state, fn ui ->
+        UIState.push_toast(ui, "Context at #{fill_pct}%. Run /compact to free space.", :warning)
+      end)
+
+    {state, []}
   end
 
   @spec compact_warn_threshold() :: non_neg_integer()

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -799,20 +799,32 @@ defmodule MingaEditor.Agent.Events do
   @spec apply_compact_threshold(EditorState.t(), term(), non_neg_integer()) ::
           {EditorState.t(), [effect()]}
   defp apply_compact_threshold(state, view, fill_pct) do
-    auto_pct = compact_auto_threshold()
-    warn_pct = compact_warn_threshold()
-
-    cond do
-      auto_pct > 0 and fill_pct >= auto_pct and not view.compact_triggered ->
-        trigger_auto_compact(state)
-
-      warn_pct > 0 and fill_pct >= warn_pct and not view.compact_warned ->
-        warn_context_pressure(state, fill_pct)
-
-      true ->
-        {state, []}
-    end
+    compact_threshold_result(
+      state,
+      view,
+      fill_pct,
+      compact_auto_threshold(),
+      compact_warn_threshold()
+    )
   end
+
+  @spec compact_threshold_result(
+          EditorState.t(),
+          term(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          {EditorState.t(), [effect()]}
+  defp compact_threshold_result(state, %{compact_triggered: false}, fill_pct, auto_pct, _warn_pct)
+       when auto_pct > 0 and fill_pct >= auto_pct,
+       do: trigger_auto_compact(state)
+
+  defp compact_threshold_result(state, %{compact_warned: false}, fill_pct, _auto_pct, warn_pct)
+       when warn_pct > 0 and fill_pct >= warn_pct,
+       do: warn_context_pressure(state, fill_pct)
+
+  defp compact_threshold_result(state, _view, _fill_pct, _auto_pct, _warn_pct), do: {state, []}
 
   @spec trigger_auto_compact(EditorState.t()) :: {EditorState.t(), [effect()]}
   defp trigger_auto_compact(state) do

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -64,6 +64,12 @@ defmodule MingaEditor.Agent.Events do
           AgentAccess.update_agent(state, &AgentState.stop_spinner_timer/1)
       end
 
+    state =
+      case status do
+        :idle -> reset_compact_state(state)
+        _ -> state
+      end
+
     # Sync the tab's agent_status for tab bar rendering
     state = sync_tab_agent_status(state, status)
 
@@ -267,11 +273,12 @@ defmodule MingaEditor.Agent.Events do
     {state, [{:render, 16}]}
   end
 
-  def handle(state, {:context_usage, estimated_tokens, _context_limit}) do
+  def handle(state, {:context_usage, estimated_tokens, context_limit}) do
     state =
       AgentAccess.update_view(state, fn v -> %{v | context_estimate: estimated_tokens} end)
 
-    {state, [{:render, 16}]}
+    {state, effects} = maybe_auto_compact(state, estimated_tokens, context_limit)
+    {state, [{:render, 16} | effects]}
   end
 
   # A message was queued (steer or follow-up): trigger render so the pending
@@ -287,6 +294,38 @@ defmodule MingaEditor.Agent.Events do
   # clear the pending display.
   def handle(state, :queues_recalled) do
     {state, [{:render, 16}]}
+  end
+
+  def handle(state, {:compact_result, {:ok, summary}}) do
+    state =
+      AgentAccess.update_view(state, fn v -> %{v | compaction_in_progress: false} end)
+
+    case AgentAccess.session(state) do
+      pid when is_pid(pid) ->
+        Session.add_system_message(pid, "Context auto-compacted: #{summary}")
+
+      _ ->
+        :ok
+    end
+
+    state =
+      AgentAccess.update_agent_ui(state, fn ui ->
+        UIState.push_toast(ui, "Context compacted", :info)
+      end)
+
+    {state, [:render, :sync_agent_buffer]}
+  end
+
+  def handle(state, {:compact_result, {:error, reason}}) do
+    state =
+      AgentAccess.update_view(state, fn v -> %{v | compaction_in_progress: false} end)
+
+    state =
+      AgentAccess.update_agent_ui(state, fn ui ->
+        UIState.push_toast(ui, "Auto-compact failed: #{inspect(reason)}", :error)
+      end)
+
+    {state, [:render]}
   end
 
   def handle(state, _unknown) do
@@ -694,6 +733,77 @@ defmodule MingaEditor.Agent.Events do
     else
       _ -> nil
     end
+  end
+
+  @spec reset_compact_state(EditorState.t()) :: EditorState.t()
+  defp reset_compact_state(state) do
+    AgentAccess.update_view(state, fn v ->
+      %{v | compact_warned: false, compact_triggered: false}
+    end)
+  rescue
+    _ -> state
+  end
+
+  @spec maybe_auto_compact(EditorState.t(), non_neg_integer(), non_neg_integer() | nil) ::
+          {EditorState.t(), [effect()]}
+  defp maybe_auto_compact(state, _estimated_tokens, nil), do: {state, []}
+  defp maybe_auto_compact(state, _estimated_tokens, 0), do: {state, []}
+
+  defp maybe_auto_compact(state, estimated_tokens, context_limit) do
+    view = AgentAccess.view(state)
+    agent_status = AgentAccess.agent(state).runtime.status
+
+    if agent_status in [:thinking, :tool_executing] or view.compaction_in_progress do
+      {state, []}
+    else
+      fill_pct = min(round(estimated_tokens / context_limit * 100), 100)
+      auto_pct = compact_auto_threshold()
+      warn_pct = compact_warn_threshold()
+
+      cond do
+        auto_pct > 0 and fill_pct >= auto_pct and not view.compact_triggered ->
+          session = AgentAccess.session(state)
+
+          if is_pid(session) do
+            state =
+              AgentAccess.update_view(state, fn v ->
+                %{v | compact_triggered: true, compaction_in_progress: true}
+              end)
+
+            {state, [{:compact_session, session}]}
+          else
+            {state, []}
+          end
+
+        warn_pct > 0 and fill_pct >= warn_pct and not view.compact_warned ->
+          state =
+            AgentAccess.update_view(state, fn v -> %{v | compact_warned: true} end)
+
+          state =
+            AgentAccess.update_agent_ui(state, fn ui ->
+              UIState.push_toast(ui, "Context at #{fill_pct}%. Run /compact to free space.", :warning)
+            end)
+
+          {state, []}
+
+        true ->
+          {state, []}
+      end
+    end
+  end
+
+  @spec compact_warn_threshold() :: non_neg_integer()
+  defp compact_warn_threshold do
+    case Minga.Config.Options.get(:agent_compaction_threshold, 0.8) do
+      nil -> 0
+      threshold -> round(threshold * 100)
+    end
+  end
+
+  @spec compact_auto_threshold() :: non_neg_integer()
+  defp compact_auto_threshold do
+    warn = compact_warn_threshold()
+    if warn > 0, do: min(warn + 10, 100), else: 0
   end
 
   @spec safe_buffer_path(pid()) :: String.t() | nil

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -746,8 +746,12 @@ defmodule MingaEditor.Agent.Events do
       messages = safe_messages(pid)
 
       case first_assistant_opening(messages) do
-        nil -> state
-        text -> maybe_apply_auto_name(state, ws, text)
+        nil ->
+          state
+
+        text ->
+          candidate = text |> String.slice(0, 30) |> String.trim()
+          if candidate != "" and candidate != ws.label, do: maybe_apply_auto_name(state, ws, text), else: state
       end
     else
       _ -> state

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -199,6 +199,9 @@ defmodule MingaEditor.Agent.Events do
     # Associate the file's tab with the agent's workspace
     state = associate_file_with_agent_workspace(state, path)
 
+    # Add a chat-visible system message so the transcript records what was modified
+    state = add_file_changed_message(state, path, tool_name)
+
     baseline = UIState.get_baseline(AgentAccess.agent_ui(state), path)
     existing_review = existing_diff_for_path(state, path)
 
@@ -469,6 +472,35 @@ defmodule MingaEditor.Agent.Events do
     else
       Buffer.accept_saved_content(pid, after_content)
       {state, [{:log_message, "Agent updated #{Path.basename(path)}"}]}
+    end
+  end
+
+  @spec add_file_changed_message(EditorState.t(), String.t(), String.t()) :: EditorState.t()
+  defp add_file_changed_message(state, path, tool_name) do
+    case AgentAccess.session(state) do
+      pid when is_pid(pid) ->
+        short_path = shorten_to_relative(state, path)
+        verb = file_change_verb(tool_name)
+        Session.add_system_message(pid, "#{verb} #{short_path}")
+        state
+
+      _ ->
+        state
+    end
+  catch
+    :exit, _ -> state
+  end
+
+  @spec file_change_verb(String.t()) :: String.t()
+  defp file_change_verb("write"), do: "Wrote"
+  defp file_change_verb("edit"), do: "Edited"
+  defp file_change_verb(_tool_name), do: "Modified"
+
+  @spec shorten_to_relative(EditorState.t(), String.t()) :: String.t()
+  defp shorten_to_relative(state, path) do
+    case project_root(state) do
+      root when is_binary(root) -> Path.relative_to(path, root)
+      _ -> Path.basename(path)
     end
   end
 

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -37,6 +37,7 @@ defmodule MingaEditor.Agent.Events do
           | {:log_warning, String.t()}
           | :sync_agent_buffer
           | {:update_tab_label, String.t()}
+          | {:compact_session, pid()}
 
   @spec handle(EditorState.t(), term()) :: {EditorState.t(), [effect()]}
 
@@ -75,6 +76,8 @@ defmodule MingaEditor.Agent.Events do
 
     # Let the active shell mirror foreground agent status if it owns an agent surface.
     state = sync_active_shell_agent_status(state, status)
+
+    {state, effects} = maybe_apply_pending_auto_compact(state, status, effects)
 
     {state, [:render | effects]}
   end
@@ -785,16 +788,44 @@ defmodule MingaEditor.Agent.Events do
   defp maybe_auto_compact(state, _estimated_tokens, 0), do: {state, []}
 
   defp maybe_auto_compact(state, estimated_tokens, context_limit) do
+    fill_pct = min(round(estimated_tokens / context_limit * 100), 100)
     view = AgentAccess.view(state)
     agent_status = AgentAccess.agent(state).runtime.status
+    compact_when_ready(state, view, agent_status, fill_pct)
+  end
 
-    if agent_status in [:thinking, :tool_executing] or view.compaction_in_progress do
-      {state, []}
-    else
-      fill_pct = min(round(estimated_tokens / context_limit * 100), 100)
-      apply_compact_threshold(state, view, fill_pct)
+  @spec compact_when_ready(EditorState.t(), term(), AgentState.status(), non_neg_integer()) ::
+          {EditorState.t(), [effect()]}
+  defp compact_when_ready(state, _view, status, fill_pct)
+       when status in [:thinking, :tool_executing] do
+    state = AgentAccess.update_view(state, &%{&1 | compact_pending_fill_pct: fill_pct})
+    {state, []}
+  end
+
+  defp compact_when_ready(state, %{compaction_in_progress: true}, _status, _fill_pct),
+    do: {state, []}
+
+  defp compact_when_ready(state, view, _status, fill_pct),
+    do: apply_compact_threshold(state, view, fill_pct)
+
+  @spec maybe_apply_pending_auto_compact(EditorState.t(), term(), [effect()]) ::
+          {EditorState.t(), [effect()]}
+  defp maybe_apply_pending_auto_compact(state, :idle, effects) do
+    case AgentAccess.view(state).compact_pending_fill_pct do
+      nil ->
+        {state, effects}
+
+      fill_pct ->
+        state = AgentAccess.update_view(state, &%{&1 | compact_pending_fill_pct: nil})
+
+        {state, compact_effects} =
+          apply_compact_threshold(state, AgentAccess.view(state), fill_pct)
+
+        {state, effects ++ compact_effects}
     end
   end
+
+  defp maybe_apply_pending_auto_compact(state, _status, effects), do: {state, effects}
 
   @spec apply_compact_threshold(EditorState.t(), term(), non_neg_integer()) ::
           {EditorState.t(), [effect()]}

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -751,7 +751,10 @@ defmodule MingaEditor.Agent.Events do
 
         text ->
           candidate = text |> String.slice(0, 30) |> String.trim()
-          if candidate != "" and candidate != ws.label, do: maybe_apply_auto_name(state, ws, text), else: state
+
+          if candidate != "" and candidate != ws.label,
+            do: maybe_apply_auto_name(state, ws, text),
+            else: state
       end
     else
       _ -> state
@@ -824,7 +827,11 @@ defmodule MingaEditor.Agent.Events do
 
           state =
             AgentAccess.update_agent_ui(state, fn ui ->
-              UIState.push_toast(ui, "Context at #{fill_pct}%. Run /compact to free space.", :warning)
+              UIState.push_toast(
+                ui,
+                "Context at #{fill_pct}%. Run /compact to free space.",
+                :warning
+              )
             end)
 
           {state, []}
@@ -837,9 +844,10 @@ defmodule MingaEditor.Agent.Events do
 
   @spec compact_warn_threshold() :: non_neg_integer()
   defp compact_warn_threshold do
-    case Minga.Config.Options.get(:agent_compaction_threshold, 0.8) do
+    case Minga.Config.Options.get(:agent_compaction_threshold) do
       nil -> 0
-      threshold -> round(threshold * 100)
+      threshold when is_number(threshold) -> round(threshold * 100)
+      _ -> 80
     end
   end
 

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -74,6 +74,10 @@ defmodule MingaEditor.Agent.SlashCommand do
       name: "compact",
       description: "Compact conversation context (summarize older turns)"
     },
+    %Command{
+      name: "clear-chat",
+      description: "Hide older messages from the chat display"
+    },
     %Command{name: "continue", description: "Continue from an interrupted stream response"},
     %Command{
       name: "export",
@@ -320,6 +324,7 @@ defmodule MingaEditor.Agent.SlashCommand do
   defp dispatch(state, "system-prompt", _args), do: {:ok, do_system_prompt(state)}
   defp dispatch(state, "budget", args), do: do_budget(state, args)
   defp dispatch(state, "compact", _args), do: do_compact(state)
+  defp dispatch(state, "clear-chat", _args), do: {:ok, AgentCommands.clear_chat_display(state)}
   defp dispatch(state, "continue", _args), do: do_continue(state)
   defp dispatch(state, "export", "html"), do: do_export(state, :html)
   defp dispatch(state, "export", _args), do: do_export(state, :markdown)

--- a/lib/minga_editor/agent/ui_state.ex
+++ b/lib/minga_editor/agent/ui_state.ex
@@ -483,6 +483,12 @@ defmodule MingaEditor.Agent.UIState do
     %{state | panel: %{panel | model_name: model}}
   end
 
+  @doc "Sets the provider name."
+  @spec set_provider_name(t(), String.t()) :: t()
+  def set_provider_name(%__MODULE__{panel: panel} = state, provider) do
+    %{state | panel: %{panel | provider_name: provider}}
+  end
+
   @doc "Sets the scroll offset to an absolute value. Unpins from bottom."
   @spec set_scroll(t(), non_neg_integer()) :: t()
   def set_scroll(%__MODULE__{panel: panel} = state, offset)

--- a/lib/minga_editor/agent/ui_state/panel.ex
+++ b/lib/minga_editor/agent/ui_state/panel.ex
@@ -46,7 +46,7 @@ defmodule MingaEditor.Agent.UIState.Panel do
             prompt_history: [],
             history_index: -1,
             spinner_frame: 0,
-            provider_name: "anthropic",
+            provider_name: AgentConfig.extract_provider_prefix(AgentConfig.default_model()),
             model_name: AgentConfig.default_model(),
             thinking_level: "medium",
             input_focused: false,

--- a/lib/minga_editor/agent/ui_state/panel.ex
+++ b/lib/minga_editor/agent/ui_state/panel.ex
@@ -36,6 +36,7 @@ defmodule MingaEditor.Agent.UIState.Panel do
           pasted_blocks: [paste_block()],
           cached_line_index: [{non_neg_integer(), MingaEditor.Agent.BufferSync.line_type()}],
           cached_display_messages: [term()],
+          cached_display_message_pairs: [{pos_integer(), term()}],
           cached_styled_messages: [MingaEditor.Agent.MarkdownHighlight.styled_lines()] | nil,
           message_version: non_neg_integer(),
           credentials_configured: boolean()
@@ -56,6 +57,7 @@ defmodule MingaEditor.Agent.UIState.Panel do
             pasted_blocks: [],
             cached_line_index: [],
             cached_display_messages: [],
+            cached_display_message_pairs: [],
             cached_styled_messages: nil,
             message_version: 0,
             # Assume configured until the session reports otherwise, so the

--- a/lib/minga_editor/agent/ui_state/panel.ex
+++ b/lib/minga_editor/agent/ui_state/panel.ex
@@ -35,6 +35,7 @@ defmodule MingaEditor.Agent.UIState.Panel do
           mention_completion: MingaAgent.FileMention.completion() | nil,
           pasted_blocks: [paste_block()],
           cached_line_index: [{non_neg_integer(), MingaEditor.Agent.BufferSync.line_type()}],
+          cached_display_messages: [term()],
           cached_styled_messages: [MingaEditor.Agent.MarkdownHighlight.styled_lines()] | nil,
           message_version: non_neg_integer(),
           credentials_configured: boolean()
@@ -54,6 +55,7 @@ defmodule MingaEditor.Agent.UIState.Panel do
             mention_completion: nil,
             pasted_blocks: [],
             cached_line_index: [],
+            cached_display_messages: [],
             cached_styled_messages: nil,
             message_version: 0,
             # Assume configured until the session reports otherwise, so the

--- a/lib/minga_editor/agent/ui_state/view.ex
+++ b/lib/minga_editor/agent/ui_state/view.ex
@@ -63,6 +63,7 @@ defmodule MingaEditor.Agent.UIState.View do
           context_estimate: non_neg_integer(),
           compact_warned: boolean(),
           compact_triggered: boolean(),
+          compact_pending_fill_pct: non_neg_integer() | nil,
           compaction_in_progress: boolean()
         }
 
@@ -85,6 +86,7 @@ defmodule MingaEditor.Agent.UIState.View do
             context_estimate: 0,
             compact_warned: false,
             compact_triggered: false,
+            compact_pending_fill_pct: nil,
             compaction_in_progress: false,
             diff_baselines: %{},
             edit_timeline: EditTimeline.new()

--- a/lib/minga_editor/agent/ui_state/view.ex
+++ b/lib/minga_editor/agent/ui_state/view.ex
@@ -60,7 +60,10 @@ defmodule MingaEditor.Agent.UIState.View do
           toast_queue: term(),
           diff_baselines: %{String.t() => String.t()},
           edit_timeline: EditTimeline.t(),
-          context_estimate: non_neg_integer()
+          context_estimate: non_neg_integer(),
+          compact_warned: boolean(),
+          compact_triggered: boolean(),
+          compaction_in_progress: boolean()
         }
 
   @min_chat_pct 30
@@ -80,6 +83,9 @@ defmodule MingaEditor.Agent.UIState.View do
             toast: nil,
             toast_queue: :queue.new(),
             context_estimate: 0,
+            compact_warned: false,
+            compact_triggered: false,
+            compaction_in_progress: false,
             diff_baselines: %{},
             edit_timeline: EditTimeline.new()
 

--- a/lib/minga_editor/agent/view/dashboard_renderer.ex
+++ b/lib/minga_editor/agent/view/dashboard_renderer.ex
@@ -135,21 +135,34 @@ defmodule MingaEditor.Agent.View.DashboardRenderer do
 
     context_lines =
       if display_tokens > 0 do
+        fill_pct = context_fill_pct(usage, bare_model, estimate)
+        pct_color = context_threshold_color(fill_pct, at)
+
         pct_text =
           if limit,
-            do: " (#{context_fill_pct(usage, bare_model, estimate) || 0}% used)",
+            do: " (#{fill_pct || 0}% used)",
             else: ""
 
         cost_text = if usage.cost > 0, do: "$#{Float.round(usage.cost, 4)}", else: "$0.00"
         cache_read = Map.get(usage, :cache_read, 0)
 
+        bar_line =
+          if fill_pct do
+            [context_bar(fill_pct, width, pct_color, at)]
+          else
+            []
+          end
+
         context_lines ++
           [
             dashboard_text(
-              "  #{format_tokens(total_tokens)} tokens#{pct_text}",
+              "  #{format_tokens(display_tokens)} tokens#{pct_text}",
               width,
-              Face.new(fg: at.text_fg, bg: at.panel_bg)
-            ),
+              Face.new(fg: pct_color, bg: at.panel_bg)
+            )
+          ] ++
+          bar_line ++
+          [
             dashboard_text(
               "  ↑ #{format_tokens(Map.get(usage, :input, 0))} in  ↓ #{format_tokens(Map.get(usage, :output, 0))} out",
               width,
@@ -244,6 +257,26 @@ defmodule MingaEditor.Agent.View.DashboardRenderer do
       end)
 
     header ++ server_lines ++ [dashboard_blank(width, at)]
+  end
+
+  @spec context_threshold_color(non_neg_integer() | nil, Theme.Agent.t()) :: Theme.color()
+  defp context_threshold_color(nil, at), do: at.text_fg
+  defp context_threshold_color(pct, at) when pct >= 90, do: at.context_high
+  defp context_threshold_color(pct, at) when pct >= 70, do: at.context_mid
+  defp context_threshold_color(_pct, at), do: at.context_low
+
+  @spec context_bar(non_neg_integer(), pos_integer(), Theme.color(), Theme.Agent.t()) ::
+          (non_neg_integer(), non_neg_integer() -> DisplayList.draw())
+  defp context_bar(pct, width, fill_color, at) do
+    bar_width = max(width - 4, 4)
+    filled = round(pct / 100 * bar_width)
+    empty = bar_width - filled
+    bar = "  " <> String.duplicate("█", filled) <> String.duplicate("░", empty)
+    padded = String.pad_trailing(bar, width)
+
+    fn row, col ->
+      DisplayList.draw(row, col, padded, Face.new(fg: fill_color, bg: at.panel_bg))
+    end
   end
 
   @spec dashboard_text(String.t(), pos_integer(), Face.t()) ::

--- a/lib/minga_editor/agent/view/prompt_renderer.ex
+++ b/lib/minga_editor/agent/view/prompt_renderer.ex
@@ -253,8 +253,16 @@ defmodule MingaEditor.Agent.View.PromptRenderer do
 
   @spec model_info_text(RenderInput.t()) :: String.t()
   defp model_info_text(%{panel: %{credentials_configured: false}}) do
-    # No usable provider: don't advertise a model we can't call.
     "Not configured · /auth or /login"
+  end
+
+  defp model_info_text(%{agent_status: :tool_executing, active_tool_name: name})
+       when is_binary(name) and name != "" do
+    "⟳ #{name}"
+  end
+
+  defp model_info_text(%{agent_status: :thinking}) do
+    "⟳ thinking..."
   end
 
   defp model_info_text(input) do

--- a/lib/minga_editor/agent/view/render_input.ex
+++ b/lib/minga_editor/agent/view/render_input.ex
@@ -156,11 +156,20 @@ defmodule MingaEditor.Agent.View.RenderInput do
 
   @spec session_title([term()]) :: String.t()
   defp session_title(messages) do
-    case Enum.find(messages, fn msg -> match?({:user, _}, msg) or match?({:user, _, _}, msg) end) do
-      {:user, text} -> truncate_title(text)
-      {:user, text, _attachments} -> truncate_title(text)
-      nil -> "Minga Agent"
-    end
+    assistant_title =
+      Enum.find_value(messages, fn
+        {:assistant, text} when is_binary(text) and text != "" -> truncate_title(text)
+        _ -> nil
+      end)
+
+    user_title =
+      Enum.find_value(messages, fn
+        {:user, text} when is_binary(text) -> truncate_title(text)
+        {:user, text, _} when is_binary(text) -> truncate_title(text)
+        _ -> nil
+      end)
+
+    assistant_title || user_title || "Minga Agent"
   end
 
   @spec truncate_title(String.t()) :: String.t()

--- a/lib/minga_editor/agent/view/render_input.ex
+++ b/lib/minga_editor/agent/view/render_input.ex
@@ -21,6 +21,7 @@ defmodule MingaEditor.Agent.View.RenderInput do
     :agent_status,
     :panel,
     :agent_ui,
+    active_tool_name: nil,
     messages: [],
     usage: %MingaAgent.TurnUsage{},
     pending_approval: nil,
@@ -33,6 +34,7 @@ defmodule MingaEditor.Agent.View.RenderInput do
           agent_status: atom() | nil,
           panel: panel_data(),
           agent_ui: agent_ui_data(),
+          active_tool_name: String.t() | nil,
           messages: list(),
           usage: MingaAgent.TurnUsage.t(),
           pending_approval: map() | nil,
@@ -130,6 +132,7 @@ defmodule MingaEditor.Agent.View.RenderInput do
         toast: view.toast,
         context_estimate: view.context_estimate
       },
+      active_tool_name: ctx.active_tool_name,
       messages: messages,
       usage: usage,
       pending_approval: ctx.pending_approval,

--- a/lib/minga_editor/agent/view_context.ex
+++ b/lib/minga_editor/agent/view_context.ex
@@ -29,6 +29,7 @@ defmodule MingaEditor.Agent.ViewContext do
     :editing,
     :buffers,
     :agent_status,
+    :active_tool_name,
     :pending_approval
   ]
 
@@ -42,6 +43,7 @@ defmodule MingaEditor.Agent.ViewContext do
           editing: VimState.t(),
           buffers: MingaEditor.State.Buffers.t(),
           agent_status: atom() | nil,
+          active_tool_name: String.t() | nil,
           pending_approval: map() | nil
         }
 
@@ -76,6 +78,7 @@ defmodule MingaEditor.Agent.ViewContext do
       editing: state.workspace.editing,
       buffers: state.workspace.buffers,
       agent_status: agent.runtime.status,
+      active_tool_name: agent.runtime.active_tool_name,
       pending_approval: agent.pending_approval
     }
   end

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -131,6 +131,8 @@ defmodule MingaEditor.AgentLifecycle do
         do: Keyword.put(sync_opts, :display_start_index, panel.display_start_index),
         else: sync_opts
 
+    sync_opts = maybe_add_pin_opts(sync_opts, AgentAccess.session(state))
+
     line_index = AgentBufferSync.sync(buffer, messages, sync_opts)
 
     # Compute styled runs for GUI rendering. Use tree-sitter highlights
@@ -347,4 +349,22 @@ defmodule MingaEditor.AgentLifecycle do
       {msg_idx, byte_offset}
     end)
   end
+
+  @spec maybe_add_pin_opts(keyword(), pid() | nil) :: keyword()
+  defp maybe_add_pin_opts(opts, session) when is_pid(session) do
+    pinned = AgentSession.pinned_ids(session)
+    ids = AgentSession.messages_with_ids(session)
+
+    if MapSet.size(pinned) > 0 do
+      opts
+      |> Keyword.put(:pinned_ids, pinned)
+      |> Keyword.put(:message_ids, ids)
+    else
+      opts
+    end
+  catch
+    :exit, _ -> opts
+  end
+
+  defp maybe_add_pin_opts(opts, _session), do: opts
 end

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -131,16 +131,15 @@ defmodule MingaEditor.AgentLifecycle do
         do: Keyword.put(sync_opts, :display_start_index, panel.display_start_index),
         else: sync_opts
 
-    sync_opts = maybe_add_pin_opts(sync_opts, AgentAccess.session(state))
+    sync_opts = add_session_display_opts(sync_opts, AgentAccess.session(state))
 
-    {line_index, display_messages} = AgentBufferSync.sync(buffer, messages, sync_opts)
+    {line_index, display_messages, display_message_pairs} =
+      AgentBufferSync.sync(buffer, messages, sync_opts)
 
-    # Compute styled runs for GUI rendering. Use tree-sitter highlights
-    # if available, otherwise fall back to regex-based markdown parser.
-    # Tree-sitter highlights arrive async, so the first call typically
-    # uses the fallback. When highlights land, update_styled_cache/1
-    # re-caches with full tree-sitter quality.
-    styled = compute_styled_messages(state, buffer, messages)
+    # Compute styled runs for GUI rendering against the displayed transcript.
+    # The agent buffer also contains this filtered display list, so tree-sitter
+    # offsets line up for both TUI and GUI rendering.
+    styled = compute_styled_messages(state, buffer, display_messages)
 
     styled_assistant_count =
       Enum.count(styled, fn
@@ -161,6 +160,7 @@ defmodule MingaEditor.AgentLifecycle do
           p
           | cached_line_index: line_index,
             cached_display_messages: display_messages,
+            cached_display_message_pairs: display_message_pairs,
             cached_styled_messages: styled
         }
       end)
@@ -283,7 +283,7 @@ defmodule MingaEditor.AgentLifecycle do
     session = AgentAccess.session(state)
 
     with true <- is_pid(agent.buffer) and is_pid(session),
-         messages when messages != [] <- safe_messages(session) do
+         messages when messages != [] <- displayed_messages_for_styling(state, session) do
       styled = compute_styled_messages(state, agent.buffer, messages)
 
       AgentAccess.update_panel(state, fn p ->
@@ -299,6 +299,14 @@ defmodule MingaEditor.AgentLifecycle do
     AgentSession.messages(session)
   catch
     :exit, _ -> []
+  end
+
+  @spec displayed_messages_for_styling(state(), pid()) :: [term()]
+  defp displayed_messages_for_styling(state, session) do
+    case AgentAccess.panel(state).cached_display_messages do
+      [] -> safe_messages(session)
+      messages -> messages
+    end
   end
 
   # Computes styled runs for each message. Assistant messages and tool call
@@ -355,21 +363,26 @@ defmodule MingaEditor.AgentLifecycle do
     end)
   end
 
-  @spec maybe_add_pin_opts(keyword(), pid() | nil) :: keyword()
-  defp maybe_add_pin_opts(opts, session) when is_pid(session) do
+  @spec add_session_display_opts(keyword(), pid() | nil) :: keyword()
+  defp add_session_display_opts(opts, session) when is_pid(session) do
     pinned = AgentSession.pinned_ids(session)
     ids = AgentSession.messages_with_ids(session)
 
-    if MapSet.size(pinned) > 0 do
-      opts
-      |> Keyword.put(:pinned_ids, pinned)
-      |> Keyword.put(:message_ids, ids)
-    else
-      opts
-    end
+    opts
+    |> Keyword.put(:message_ids, ids)
+    |> maybe_put_pinned_ids(pinned)
   catch
     :exit, _ -> opts
   end
 
-  defp maybe_add_pin_opts(opts, _session), do: opts
+  defp add_session_display_opts(opts, _session), do: opts
+
+  @spec maybe_put_pinned_ids(keyword(), MapSet.t(pos_integer())) :: keyword()
+  defp maybe_put_pinned_ids(opts, pinned) do
+    if MapSet.size(pinned) > 0 do
+      Keyword.put(opts, :pinned_ids, pinned)
+    else
+      opts
+    end
+  end
 end

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -120,12 +120,16 @@ defmodule MingaEditor.AgentLifecycle do
   defp sync_buffer_content(state, _buffer, []), do: state
 
   defp sync_buffer_content(state, buffer, messages) do
-    # Pass pending_approval to the sync pipeline so ChatDecorations can
-    # render an approval prompt on the matching tool call.
     agent = AgentAccess.agent(state)
+    panel = AgentAccess.panel(state)
 
     sync_opts =
       if agent.pending_approval, do: [pending_approval: agent.pending_approval], else: []
+
+    sync_opts =
+      if panel.display_start_index > 0,
+        do: Keyword.put(sync_opts, :display_start_index, panel.display_start_index),
+        else: sync_opts
 
     line_index = AgentBufferSync.sync(buffer, messages, sync_opts)
 

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -133,7 +133,7 @@ defmodule MingaEditor.AgentLifecycle do
 
     sync_opts = maybe_add_pin_opts(sync_opts, AgentAccess.session(state))
 
-    line_index = AgentBufferSync.sync(buffer, messages, sync_opts)
+    {line_index, display_messages} = AgentBufferSync.sync(buffer, messages, sync_opts)
 
     # Compute styled runs for GUI rendering. Use tree-sitter highlights
     # if available, otherwise fall back to regex-based markdown parser.
@@ -157,7 +157,12 @@ defmodule MingaEditor.AgentLifecycle do
     # callers can read them without recomputing.
     state =
       AgentAccess.update_panel(state, fn p ->
-        %{p | cached_line_index: line_index, cached_styled_messages: styled}
+        %{
+          p
+          | cached_line_index: line_index,
+            cached_display_messages: display_messages,
+            cached_styled_messages: styled
+        }
       end)
 
     # Trigger tree-sitter reparse for markdown highlighting.

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.Commands.Agent do
 
   alias MingaEditor.Agent.BufferSync, as: AgentBufferSync
   alias MingaEditor.Agent.DiffReview
+  alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.FileMention
   alias MingaAgent.Markdown
   alias MingaAgent.Message
@@ -674,10 +675,18 @@ defmodule MingaEditor.Commands.Agent do
   @spec reset_agent_state_for_new_session(state()) :: state()
   defp reset_agent_state_for_new_session(state) do
     agent_buf = AgentAccess.agent(state).buffer
+    old_panel = AgentAccess.panel(state)
 
     state
     |> AgentAccess.update_agent(fn _a -> %AgentState{buffer: agent_buf} end)
-    |> AgentAccess.update_agent_ui(fn _a -> UIState.new() end)
+    |> AgentAccess.update_agent_ui(fn _a ->
+      ui = UIState.new()
+
+      ui
+      |> UIState.set_model_name(old_panel.model_name)
+      |> UIState.set_provider_name(old_panel.provider_name)
+      |> UIState.set_thinking_level(old_panel.thinking_level)
+    end)
   end
 
   @spec create_active_agent_tab(state()) :: state()
@@ -888,7 +897,15 @@ defmodule MingaEditor.Commands.Agent do
     else
       case Session.cycle_model(AgentAccess.session(state)) do
         {:ok, %{"model" => model, "index" => index, "total" => total} = result} ->
-          state = update_agent_ui(state, &UIState.set_model_name(&1, model))
+          provider = AgentConfig.extract_provider_prefix(model)
+
+          state =
+            update_agent_ui(state, fn ui ->
+              ui
+              |> UIState.set_model_name(model)
+              |> UIState.set_provider_name(provider)
+            end)
+
           state = maybe_update_thinking_level(state, Map.get(result, "thinking_level"))
 
           Session.add_system_message(
@@ -917,7 +934,14 @@ defmodule MingaEditor.Commands.Agent do
   @doc "Sets the agent model without resetting conversation context."
   @spec set_model(state(), String.t()) :: state()
   def set_model(state, model) do
-    state = update_agent_ui(state, &UIState.set_model_name(&1, model))
+    provider = AgentConfig.extract_provider_prefix(model)
+
+    state =
+      update_agent_ui(state, fn ui ->
+        ui
+        |> UIState.set_model_name(model)
+        |> UIState.set_provider_name(provider)
+      end)
 
     if AgentAccess.session(state) do
       Session.set_model(AgentAccess.session(state), model)

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -897,15 +897,7 @@ defmodule MingaEditor.Commands.Agent do
     else
       case Session.cycle_model(AgentAccess.session(state)) do
         {:ok, %{"model" => model, "index" => index, "total" => total} = result} ->
-          provider = AgentConfig.extract_provider_prefix(model)
-
-          state =
-            update_agent_ui(state, fn ui ->
-              ui
-              |> UIState.set_model_name(model)
-              |> UIState.set_provider_name(provider)
-            end)
-
+          state = apply_model_and_provider(state, model)
           state = maybe_update_thinking_level(state, Map.get(result, "thinking_level"))
 
           Session.add_system_message(
@@ -925,6 +917,15 @@ defmodule MingaEditor.Commands.Agent do
   end
 
   @spec maybe_update_thinking_level(state(), term()) :: state()
+  @spec apply_model_and_provider(state(), String.t()) :: state()
+  defp apply_model_and_provider(state, model) do
+    provider = AgentConfig.extract_provider_prefix(model)
+
+    state
+    |> update_agent_ui(&UIState.set_model_name(&1, model))
+    |> update_agent_ui(&UIState.set_provider_name(&1, provider))
+  end
+
   defp maybe_update_thinking_level(state, level) when is_binary(level) do
     update_agent_ui(state, &UIState.set_thinking_level(&1, level))
   end
@@ -934,14 +935,7 @@ defmodule MingaEditor.Commands.Agent do
   @doc "Sets the agent model without resetting conversation context."
   @spec set_model(state(), String.t()) :: state()
   def set_model(state, model) do
-    provider = AgentConfig.extract_provider_prefix(model)
-
-    state =
-      update_agent_ui(state, fn ui ->
-        ui
-        |> UIState.set_model_name(model)
-        |> UIState.set_provider_name(provider)
-      end)
+    state = apply_model_and_provider(state, model)
 
     if AgentAccess.session(state) do
       Session.set_model(AgentAccess.session(state), model)
@@ -1133,42 +1127,47 @@ defmodule MingaEditor.Commands.Agent do
   defp apply_code_block_to_path(state, full_path, content, display_path) do
     case File.read(full_path) do
       {:ok, before_content} ->
-        review = DiffReview.new(full_path, before_content, content)
-
-        if review do
-          state = update_preview(state, &Preview.set_diff(&1, review))
-          state = update_agent_ui(state, &UIState.set_focus(&1, :file_viewer))
-
-          if AgentAccess.session(state) do
-            Session.add_system_message(
-              AgentAccess.session(state),
-              "Applying code block to #{display_path}"
-            )
-          end
-
-          EditorState.set_status(state, "Diff preview for #{display_path}. Accept/reject hunks.")
-        else
-          EditorState.set_status(state, "No changes detected for #{display_path}")
-        end
+        apply_code_block_diff(state, full_path, before_content, content, display_path)
 
       {:error, :enoent} ->
-        with :ok <- File.mkdir_p(Path.dirname(full_path)),
-             :ok <- File.write(full_path, content) do
-          if AgentAccess.session(state) do
-            Session.add_system_message(
-              AgentAccess.session(state),
-              "Created #{display_path}"
-            )
-          end
-
-          EditorState.set_status(state, "Created #{display_path}")
-        else
-          {:error, reason} ->
-            EditorState.set_status(state, "Failed to create #{display_path}: #{inspect(reason)}")
-        end
+        create_file_from_code_block(state, full_path, content, display_path)
 
       {:error, reason} ->
         EditorState.set_status(state, "Cannot read #{display_path}: #{inspect(reason)}")
+    end
+  end
+
+  @spec apply_code_block_diff(state(), String.t(), String.t(), String.t(), String.t()) :: state()
+  defp apply_code_block_diff(state, path, before_content, content, display_path) do
+    case DiffReview.new(path, before_content, content) do
+      nil ->
+        EditorState.set_status(state, "No changes detected for #{display_path}")
+
+      review ->
+        state = update_preview(state, &Preview.set_diff(&1, review))
+        state = update_agent_ui(state, &UIState.set_focus(&1, :file_viewer))
+        log_system_message(state, "Applying code block to #{display_path}")
+        EditorState.set_status(state, "Diff preview for #{display_path}. Accept/reject hunks.")
+    end
+  end
+
+  @spec create_file_from_code_block(state(), String.t(), String.t(), String.t()) :: state()
+  defp create_file_from_code_block(state, full_path, content, display_path) do
+    with :ok <- File.mkdir_p(Path.dirname(full_path)),
+         :ok <- File.write(full_path, content) do
+      log_system_message(state, "Created #{display_path}")
+      EditorState.set_status(state, "Created #{display_path}")
+    else
+      {:error, reason} ->
+        EditorState.set_status(state, "Failed to create #{display_path}: #{inspect(reason)}")
+    end
+  end
+
+  @spec log_system_message(state(), String.t()) :: :ok
+  defp log_system_message(state, text) do
+    case AgentAccess.session(state) do
+      pid when is_pid(pid) -> Session.add_system_message(pid, text)
+      _ -> :ok
     end
   end
 
@@ -1177,28 +1176,14 @@ defmodule MingaEditor.Commands.Agent do
   @doc "Toggles the pinned state of the message at the cursor."
   @spec scope_pin_message(state()) :: state()
   def scope_pin_message(state) do
-    session = AgentAccess.session(state)
-
-    if is_nil(session) do
-      state
-    else
-      case scroll_context(state) do
-        nil ->
-          state
-
-        {msg_idx, _msg, _line_type} ->
-          pairs = Session.messages_with_ids(session)
-
-          case Enum.at(pairs, msg_idx) do
-            {id, _msg} ->
-              Session.toggle_pin(session, id)
-              state
-
-            nil ->
-              state
-          end
-      end
+    with session when is_pid(session) <- AgentAccess.session(state),
+         {msg_idx, _msg, _line_type} <- scroll_context(state),
+         pairs = Session.messages_with_ids(session),
+         {id, _msg} <- Enum.at(pairs, msg_idx) do
+      Session.toggle_pin(session, id)
     end
+
+    state
   catch
     :exit, _ -> state
   end

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -1149,19 +1149,17 @@ defmodule MingaEditor.Commands.Agent do
         end
 
       {:error, :enoent} ->
-        case File.mkdir_p(Path.dirname(full_path)) do
-          :ok ->
-            File.write!(full_path, content)
+        with :ok <- File.mkdir_p(Path.dirname(full_path)),
+             :ok <- File.write(full_path, content) do
+          if AgentAccess.session(state) do
+            Session.add_system_message(
+              AgentAccess.session(state),
+              "Created #{display_path}"
+            )
+          end
 
-            if AgentAccess.session(state) do
-              Session.add_system_message(
-                AgentAccess.session(state),
-                "Created #{display_path}"
-              )
-            end
-
-            EditorState.set_status(state, "Created #{display_path}")
-
+          EditorState.set_status(state, "Created #{display_path}")
+        else
           {:error, reason} ->
             EditorState.set_status(state, "Failed to create #{display_path}: #{inspect(reason)}")
         end

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -1178,8 +1178,8 @@ defmodule MingaEditor.Commands.Agent do
   def scope_pin_message(state) do
     with session when is_pid(session) <- AgentAccess.session(state),
          {msg_idx, _msg, _line_type} <- scroll_context(state),
-         pairs = Session.messages_with_ids(session),
-         {id, _msg} <- Enum.at(pairs, msg_idx) do
+         {id, msg} <- display_pair_at(state, session, msg_idx),
+         false <- synthetic_display_message?(msg) do
       Session.toggle_pin(session, id)
     end
 
@@ -1187,6 +1187,22 @@ defmodule MingaEditor.Commands.Agent do
   catch
     :exit, _ -> state
   end
+
+  @spec display_pair_at(state(), pid(), non_neg_integer()) :: {pos_integer(), Message.t()} | nil
+  defp display_pair_at(state, session, msg_idx) do
+    pairs =
+      case AgentAccess.panel(state).cached_display_message_pairs do
+        [] -> Session.messages_with_ids(session)
+        cached -> cached
+      end
+
+    Enum.at(pairs, msg_idx)
+  end
+
+  @spec synthetic_display_message?(term()) :: boolean()
+  defp synthetic_display_message?({:system, "── pinned ──", :info}), do: true
+  defp synthetic_display_message?({:system, "── " <> _rest, :info}), do: true
+  defp synthetic_display_message?(_msg), do: false
 
   # ── Input focus ────────────────────────────────────────────────────────────
 

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -1571,18 +1571,19 @@ defmodule MingaEditor.Commands.Agent do
 
     if session do
       messages = safe_messages(session)
-
-      # Use the cached line index from sync, falling back to recompute
       line_map = cached_or_compute_line_index(panel, messages)
 
-      # panel.scroll.offset is synced to the buffer cursor line by
-      # AgentNav.sync_scroll_to_cursor, so it maps directly to
-      # buffer line numbers.
+      display_msgs =
+        case panel.cached_display_messages do
+          [] -> messages
+          cached -> cached
+        end
+
       total = length(line_map)
       target = Minga.Editing.resolve_scroll(panel.scroll, total, 1)
 
       case Enum.at(line_map, target) do
-        {msg_idx, line_type} -> {msg_idx, Enum.at(messages, msg_idx), line_type}
+        {msg_idx, line_type} -> {msg_idx, Enum.at(display_msgs, msg_idx), line_type}
         nil -> nil
       end
     else

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -1079,6 +1079,129 @@ defmodule MingaEditor.Commands.Agent do
     end
   end
 
+  # ── Apply code block ───────────────────────────────────────────────────────
+
+  @doc "Applies the code block at the cursor to the inferred target file with diff preview."
+  @spec scope_apply_code_block(state()) :: state()
+  def scope_apply_code_block(state) do
+    case scroll_context(state) do
+      nil ->
+        state
+
+      {_idx, msg, :code} ->
+        text = Message.text(msg)
+        blocks = Markdown.extract_code_blocks(text)
+        block_index = code_block_index_for_scroll(state, blocks)
+        block = Enum.at(blocks, block_index)
+
+        if block do
+          apply_code_block(state, text, block, block_index)
+        else
+          state
+        end
+
+      {_idx, _msg, _other_type} ->
+        state
+    end
+  end
+
+  @spec apply_code_block(state(), String.t(), Markdown.code_block(), non_neg_integer()) :: state()
+  defp apply_code_block(state, message_text, block, block_index) do
+    case Markdown.infer_target_path(message_text, block_index) do
+      nil ->
+        EditorState.set_status(state, "No file path found near code block. Copy with `yy` instead.")
+
+      path ->
+        full_path = resolve_apply_path(path)
+        apply_code_block_to_path(state, full_path, block.content, path)
+    end
+  end
+
+  @spec resolve_apply_path(String.t()) :: String.t()
+  defp resolve_apply_path(path) do
+    if Path.type(path) == :absolute do
+      path
+    else
+      Path.join(project_root(), path)
+    end
+  end
+
+  @spec apply_code_block_to_path(state(), String.t(), String.t(), String.t()) :: state()
+  defp apply_code_block_to_path(state, full_path, content, display_path) do
+    case File.read(full_path) do
+      {:ok, before_content} ->
+        review = DiffReview.new(full_path, before_content, content)
+
+        if review do
+          state = update_preview(state, &Preview.set_diff(&1, review))
+          state = update_agent_ui(state, &UIState.set_focus(&1, :file_viewer))
+
+          if AgentAccess.session(state) do
+            Session.add_system_message(
+              AgentAccess.session(state),
+              "Applying code block to #{display_path}"
+            )
+          end
+
+          EditorState.set_status(state, "Diff preview for #{display_path}. Accept/reject hunks.")
+        else
+          EditorState.set_status(state, "No changes detected for #{display_path}")
+        end
+
+      {:error, :enoent} ->
+        case File.mkdir_p(Path.dirname(full_path)) do
+          :ok ->
+            File.write!(full_path, content)
+
+            if AgentAccess.session(state) do
+              Session.add_system_message(
+                AgentAccess.session(state),
+                "Created #{display_path}"
+              )
+            end
+
+            EditorState.set_status(state, "Created #{display_path}")
+
+          {:error, reason} ->
+            EditorState.set_status(state, "Failed to create #{display_path}: #{inspect(reason)}")
+        end
+
+      {:error, reason} ->
+        EditorState.set_status(state, "Cannot read #{display_path}: #{inspect(reason)}")
+    end
+  end
+
+  # ── Pin message ────────────────────────────────────────────────────────────
+
+  @doc "Toggles the pinned state of the message at the cursor."
+  @spec scope_pin_message(state()) :: state()
+  def scope_pin_message(state) do
+    session = AgentAccess.session(state)
+
+    if is_nil(session) do
+      state
+    else
+      case scroll_context(state) do
+        nil ->
+          state
+
+        {msg_idx, _msg, _line_type} ->
+          pairs = Session.messages_with_ids(session)
+
+          case Enum.at(pairs, msg_idx) do
+            {id, _msg} ->
+              Session.toggle_pin(session, id)
+              state
+
+            nil ->
+              state
+          end
+      end
+    end
+  catch
+    :exit, _ -> state
+  end
+
   # ── Input focus ────────────────────────────────────────────────────────────
 
   @doc "Focuses the input field and transitions to insert mode."
@@ -1649,6 +1772,8 @@ defmodule MingaEditor.Commands.Agent do
     {:agent_copy_code_block, "Copy code block", :scope_copy_code_block},
     {:agent_copy_message, "Copy message", :scope_copy_message},
     {:agent_open_code_block, "Open code block", :scope_open_code_block},
+    {:agent_apply_code_block, "Apply code block to file", :scope_apply_code_block},
+    {:agent_pin_message, "Pin/unpin message at cursor", :scope_pin_message},
     {:agent_focus_input, "Focus agent input", :scope_focus_input},
     {:agent_focus_or_submit, "Focus input or submit", :scope_focus_or_submit},
     {:agent_unfocus_input, "Unfocus agent input", :scope_unfocus_input},

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -1109,7 +1109,10 @@ defmodule MingaEditor.Commands.Agent do
   defp apply_code_block(state, message_text, block, block_index) do
     case Markdown.infer_target_path(message_text, block_index) do
       nil ->
-        EditorState.set_status(state, "No file path found near code block. Copy with `yy` instead.")
+        EditorState.set_status(
+          state,
+          "No file path found near code block. Copy with `yy` instead."
+        )
 
       path ->
         full_path = resolve_apply_path(path)

--- a/lib/minga_editor/handlers/effect_handler.ex
+++ b/lib/minga_editor/handlers/effect_handler.ex
@@ -90,6 +90,7 @@ defmodule MingaEditor.Handlers.EffectHandler do
           | {:evict_parser_trees_timer}
           | {:refresh_tool_picker}
           | {:save_session_async, term(), keyword()}
+          | {:compact_session, pid()}
           | {:restart_session_timer}
           | {:cancel_session_timer}
           | {:recover_swap_entries, [Session.swap_entry()]}
@@ -244,6 +245,17 @@ defmodule MingaEditor.Handlers.EffectHandler do
         :ok -> :ok
         {:error, reason} -> Minga.Log.warning(:editor, "Session save failed: #{inspect(reason)}")
       end
+    end)
+
+    state
+  end
+
+  defp apply_effect(state, {:compact_session, session_pid}) do
+    editor = self()
+
+    Task.start(fn ->
+      result = MingaAgent.Session.compact(session_pid)
+      send(editor, {:compact_result, result})
     end)
 
     state

--- a/lib/minga_editor/handlers/effect_handler.ex
+++ b/lib/minga_editor/handlers/effect_handler.ex
@@ -116,6 +116,13 @@ defmodule MingaEditor.Handlers.EffectHandler do
     apply_effects(state, rest)
   end
 
+  @spec compact_session_safely(pid()) :: {:ok, String.t()} | {:error, term()}
+  defp compact_session_safely(session_pid) do
+    MingaAgent.Session.compact(session_pid)
+  catch
+    :exit, reason -> {:error, {:compact_exit, reason}}
+  end
+
   @spec apply_effect(EditorState.t(), effect()) :: EditorState.t()
   defp apply_effect(state, :render), do: MingaEditor.schedule_render(state, 16)
 
@@ -254,7 +261,7 @@ defmodule MingaEditor.Handlers.EffectHandler do
     editor = self()
 
     Task.start(fn ->
-      result = MingaAgent.Session.compact(session_pid)
+      result = compact_session_safely(session_pid)
       send(editor, {:compact_result, result})
     end)
 

--- a/lib/minga_editor/render_model/ui/agent_chat_builder.ex
+++ b/lib/minga_editor/render_model/ui/agent_chat_builder.ex
@@ -38,7 +38,8 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
         {:erlang.phash2(
            {:visible, ctx.shell_state.agent.runtime.status,
             ctx.shell_state.agent.pending_approval, styled_len, panel.model_name,
-            panel.thinking_level, text, panel.message_version, view.help_visible, view.focus,
+            panel.thinking_level, text, panel.message_version,
+            length(panel.cached_display_message_pairs), view.help_visible, view.focus,
             ctx.editing.mode, prompt_cursor, prompt_line_count, visible_rows,
             panel.mention_completion}
          ), text}
@@ -120,14 +121,10 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
       end
 
     if is_agent_chat && session do
-      messages_with_ids =
-        try do
-          AgentSession.messages_with_ids(session)
-        catch
-          :exit, _ -> []
-        end
+      panel = ctx.agent_ui.panel
+      messages_with_ids = displayed_message_pairs(panel, session)
 
-      styled_cache = ctx.agent_ui.panel.cached_styled_messages
+      styled_cache = panel.cached_styled_messages
       pending_approval = ctx.shell_state.agent.pending_approval
       gui_messages = build_gui_messages(messages_with_ids, styled_cache, pending_approval)
 
@@ -141,7 +138,6 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
           []
         end
 
-      panel = ctx.agent_ui.panel
       {cursor_line, cursor_col} = UIState.input_cursor(panel)
       vim_mode = ctx.editing.mode
       inner_width = max(ctx.viewport.cols - 10, 20)
@@ -168,6 +164,19 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
     else
       %{visible: false}
     end
+  end
+
+  @spec displayed_message_pairs(MingaEditor.Agent.UIState.Panel.t(), pid()) :: [
+          {pos_integer(), term()}
+        ]
+  defp displayed_message_pairs(%{cached_display_message_pairs: pairs}, _session)
+       when is_list(pairs) and pairs != [],
+       do: pairs
+
+  defp displayed_message_pairs(_panel, session) do
+    AgentSession.messages_with_ids(session)
+  catch
+    :exit, _ -> []
   end
 
   @spec build_gui_messages([{pos_integer(), term()}], [term()] | nil, map() | nil) :: [

--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -778,7 +778,10 @@ defmodule MingaEditor.RenderPipeline.Content do
   defp update_agent_scroll_metrics(state, total_lines, visible_height) do
     ws = state.workspace
     panel = ws.agent_ui.panel
-    updated_scroll = Minga.Editing.Scroll.update_metrics(panel.scroll, total_lines, visible_height)
+
+    updated_scroll =
+      Minga.Editing.Scroll.update_metrics(panel.scroll, total_lines, visible_height)
+
     updated_panel = %{panel | scroll: updated_scroll}
     updated_ui = %{ws.agent_ui | panel: updated_panel}
     %{state | workspace: %{ws | agent_ui: updated_ui}}

--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -743,6 +743,8 @@ defmodule MingaEditor.RenderPipeline.Content do
         additional_window_models: additional_window_models
       })
 
+    state = update_agent_scroll_metrics(state, line_count, chat_height)
+
     {frame, final_cursor, state}
   end
 
@@ -770,6 +772,16 @@ defmodule MingaEditor.RenderPipeline.Content do
       Map.get(options, :tab_width, 2),
       Minga.Core.WidthOracle.fingerprint(params.width_oracle)
     }
+  end
+
+  @spec update_agent_scroll_metrics(state(), non_neg_integer(), pos_integer()) :: state()
+  defp update_agent_scroll_metrics(state, total_lines, visible_height) do
+    ws = state.workspace
+    panel = ws.agent_ui.panel
+    updated_scroll = Minga.Editing.Scroll.update_metrics(panel.scroll, total_lines, visible_height)
+    updated_panel = %{panel | scroll: updated_scroll}
+    updated_ui = %{ws.agent_ui | panel: updated_panel}
+    %{state | workspace: %{ws | agent_ui: updated_ui}}
   end
 
   @spec build_visible_line_map(

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -2668,11 +2668,19 @@ defmodule MingaEditor.State do
 
       _ ->
         sync_opts = if pending_approval, do: [pending_approval: pending_approval], else: []
-        {line_index, display_messages} = AgentBufferSync.sync(buffer, messages, sync_opts)
+        sync_opts = put_session_message_ids(sync_opts, session)
+
+        {line_index, display_messages, display_message_pairs} =
+          AgentBufferSync.sync(buffer, messages, sync_opts)
 
         AgentAccess.update_panel(
           state,
-          &%{&1 | cached_line_index: line_index, cached_display_messages: display_messages}
+          &%{
+            &1
+            | cached_line_index: line_index,
+              cached_display_messages: display_messages,
+              cached_display_message_pairs: display_message_pairs
+          }
         )
     end
   end
@@ -2682,5 +2690,12 @@ defmodule MingaEditor.State do
     AgentSession.messages(session)
   catch
     :exit, _ -> []
+  end
+
+  @spec put_session_message_ids(keyword(), pid()) :: keyword()
+  defp put_session_message_ids(opts, session) do
+    Keyword.put(opts, :message_ids, AgentSession.messages_with_ids(session))
+  catch
+    :exit, _ -> opts
   end
 end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -2668,8 +2668,12 @@ defmodule MingaEditor.State do
 
       _ ->
         sync_opts = if pending_approval, do: [pending_approval: pending_approval], else: []
-        line_index = AgentBufferSync.sync(buffer, messages, sync_opts)
-        AgentAccess.update_panel(state, &%{&1 | cached_line_index: line_index})
+        {line_index, display_messages} = AgentBufferSync.sync(buffer, messages, sync_opts)
+
+        AgentAccess.update_panel(
+          state,
+          &%{&1 | cached_line_index: line_index, cached_display_messages: display_messages}
+        )
     end
   end
 

--- a/lib/minga_editor/ui/picker/agent_session_source.ex
+++ b/lib/minga_editor/ui/picker/agent_session_source.ex
@@ -86,7 +86,8 @@ defmodule MingaEditor.UI.Picker.AgentSessionSource do
         %Item{
           id: {meta.id, {:tab, tab.id}},
           label: format_label(meta, is_active),
-          description: format_desc(meta)
+          description: format_desc(meta),
+          search_text: meta.first_prompt || ""
         }
 
       :error ->
@@ -152,7 +153,8 @@ defmodule MingaEditor.UI.Picker.AgentSessionSource do
         id: {meta.id, :disk},
         label: meta.title,
         description: disk_description(meta),
-        annotation: format_turn_count(meta.turn_count)
+        annotation: format_turn_count(meta.turn_count),
+        search_text: "#{meta.preview} #{meta.recent_messages}"
       }
     end)
   end
@@ -194,7 +196,15 @@ defmodule MingaEditor.UI.Picker.AgentSessionSource do
     time = Calendar.strftime(meta.last_message_at, "%H:%M")
     cost = Float.round(meta.cost, 4)
 
-    "#{meta.provider_name}/#{meta.model_name} · #{format_turn_count(meta.turn_count)} · #{meta.message_count} msgs · $#{cost} · #{time}"
+    parts = [
+      "#{meta.provider_name}/#{meta.model_name}",
+      format_turn_count(meta.turn_count),
+      "#{meta.message_count} msgs",
+      "$#{cost}",
+      time
+    ]
+
+    Enum.join(parts, " · ")
   end
 
   @spec format_disk_timestamp(String.t()) :: String.t()

--- a/test/minga_agent/event_log/session_integration_test.exs
+++ b/test/minga_agent/event_log/session_integration_test.exs
@@ -33,18 +33,26 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
 
     @impl true
     def init(opts) do
-      {:ok, %{subscriber: Keyword.fetch!(opts, :subscriber)}}
+      {:ok,
+       %{
+         subscriber: Keyword.fetch!(opts, :subscriber),
+         prompt_observer: Keyword.get(opts, :prompt_observer)
+       }}
     end
 
     @impl true
     def handle_cast({:prompt, text}, state) do
       send(state.subscriber, {:agent_provider_event, %Event.AgentStart{}})
       send(state.subscriber, {:agent_provider_event, %Event.TextDelta{delta: text}})
+      notify_prompt_observer(state.prompt_observer, text)
       {:noreply, state}
     end
 
     def handle_cast(:abort, state), do: {:noreply, state}
     def handle_cast(:new_session, state), do: {:noreply, state}
+
+    defp notify_prompt_observer(nil, _text), do: :ok
+    defp notify_prompt_observer(pid, text), do: send(pid, {:steering_provider_prompt, text})
   end
 
   defmodule ReplayProvider do
@@ -165,11 +173,13 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
          provider: SteeringProvider,
          event_log_server: log_name,
          persist?: false,
-         hooks_enabled?: false}
+         hooks_enabled?: false,
+         provider_opts: [prompt_observer: self()]}
       )
 
     :sys.get_state(session)
     assert :ok = Session.send_prompt(session, "first")
+    assert_receive {:steering_provider_prompt, "first"}
     wait_for_status(session, :thinking)
     assert {:queued, :steering} = Session.send_prompt(session, "while busy")
     assert ["while busy"] = Session.dequeue_steering(session)

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -1166,7 +1166,7 @@ defmodule MingaAgent.SessionTest do
   end
 
   describe "thinking block collapse" do
-    test "thinking blocks auto-collapse when text delta arrives", %{session: session} do
+    test "thinking blocks stay expanded during streaming and collapse on AgentEnd", %{session: session} do
       send(session, {:agent_provider_event, %Event.AgentStart{}})
       send(session, {:agent_provider_event, %Event.ThinkingDelta{delta: "Let me think..."}})
 
@@ -1181,8 +1181,21 @@ defmodule MingaAgent.SessionTest do
 
       assert {:thinking, _, false} = thinking
 
-      # TextDelta arrives (thinking is done, response starting) → auto-collapse
+      # TextDelta arrives: thinking should remain expanded during the turn
       send(session, {:agent_provider_event, %Event.TextDelta{delta: "Here is my answer"}})
+
+      messages = Session.messages(session)
+
+      thinking =
+        Enum.find(messages, fn
+          {:thinking, _, _} -> true
+          _ -> false
+        end)
+
+      assert {:thinking, _, false} = thinking
+
+      # AgentEnd: thinking collapses now that the turn is complete
+      send(session, {:agent_provider_event, %Event.AgentEnd{usage: nil}})
 
       messages = Session.messages(session)
 
@@ -1196,6 +1209,7 @@ defmodule MingaAgent.SessionTest do
     end
 
     test "toggle_all_tool_collapses also toggles thinking blocks", %{session: session} do
+      send(session, {:agent_provider_event, %Event.AgentStart{}})
       send(session, {:agent_provider_event, %Event.ThinkingDelta{delta: "hmm"}})
       send(session, {:agent_provider_event, %Event.TextDelta{delta: "answer"}})
 
@@ -1208,6 +1222,9 @@ defmodule MingaAgent.SessionTest do
         session,
         {:agent_provider_event, %Event.ToolEnd{tool_call_id: "tc1", name: "bash", result: "ok"}}
       )
+
+      # End the turn so thinking blocks collapse
+      send(session, {:agent_provider_event, %Event.AgentEnd{usage: nil}})
 
       # Both should be collapsed
       messages = Session.messages(session)

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -1166,7 +1166,9 @@ defmodule MingaAgent.SessionTest do
   end
 
   describe "thinking block collapse" do
-    test "thinking blocks stay expanded during streaming and collapse on AgentEnd", %{session: session} do
+    test "thinking blocks stay expanded during streaming and collapse on AgentEnd", %{
+      session: session
+    } do
       send(session, {:agent_provider_event, %Event.AgentStart{}})
       send(session, {:agent_provider_event, %Event.ThinkingDelta{delta: "Let me think..."}})
 

--- a/test/minga_editor/agent/buffer_sync_test.exs
+++ b/test/minga_editor/agent/buffer_sync_test.exs
@@ -126,7 +126,7 @@ defmodule MingaEditor.Agent.BufferSyncTest do
 
       pid = BufferSync.start_buffer()
 
-      index =
+      {index, _display_messages} =
         BufferSync.sync(pid, messages,
           display_start_index: 2,
           message_ids: message_ids,
@@ -134,7 +134,6 @@ defmodule MingaEditor.Agent.BufferSyncTest do
         )
 
       assert {0, :text} in index
-      assert List.last(index) == {2, :text}
       refute {1, :text} in index
     end
   end

--- a/test/minga_editor/agent/buffer_sync_test.exs
+++ b/test/minga_editor/agent/buffer_sync_test.exs
@@ -116,6 +116,29 @@ defmodule MingaEditor.Agent.BufferSyncTest do
     end
   end
 
+  describe "sync/3" do
+    test "cached index maps displayed pinned and visible rows to original transcript indexes" do
+      old_message = {:assistant, "old pinned"}
+      hidden_message = {:user, "hidden"}
+      visible_message = {:assistant, "visible"}
+      messages = [old_message, hidden_message, visible_message]
+      message_ids = [{101, old_message}, {102, hidden_message}, {103, visible_message}]
+
+      pid = BufferSync.start_buffer()
+
+      index =
+        BufferSync.sync(pid, messages,
+          display_start_index: 2,
+          message_ids: message_ids,
+          pinned_ids: MapSet.new([101])
+        )
+
+      assert {0, :text} in index
+      assert List.last(index) == {2, :text}
+      refute {1, :text} in index
+    end
+  end
+
   describe "messages_to_markdown_with_offsets/1" do
     test "system messages produce their text content" do
       messages = [{:system, "API key status:\n  ✗ Anthropic", :info}]

--- a/test/minga_editor/agent/buffer_sync_test.exs
+++ b/test/minga_editor/agent/buffer_sync_test.exs
@@ -117,7 +117,19 @@ defmodule MingaEditor.Agent.BufferSyncTest do
   end
 
   describe "sync/3" do
-    test "cached index maps displayed pinned and visible rows to original transcript indexes" do
+    test "cached message pairs preserve supplied stable ids without pins" do
+      first_message = {:user, "first"}
+      second_message = {:assistant, "second"}
+      message_ids = [{41, first_message}, {42, second_message}]
+      pid = BufferSync.start_buffer()
+
+      {_index, _display_messages, display_pairs} =
+        BufferSync.sync(pid, [first_message, second_message], message_ids: message_ids)
+
+      assert [{41, ^first_message}, {42, ^second_message}] = display_pairs
+    end
+
+    test "cached index and message pairs use the same display order" do
       old_message = {:assistant, "old pinned"}
       hidden_message = {:user, "hidden"}
       visible_message = {:assistant, "visible"}
@@ -126,15 +138,36 @@ defmodule MingaEditor.Agent.BufferSyncTest do
 
       pid = BufferSync.start_buffer()
 
-      {index, _display_messages} =
+      {index, display_messages, display_pairs} =
         BufferSync.sync(pid, messages,
           display_start_index: 2,
           message_ids: message_ids,
           pinned_ids: MapSet.new([101])
         )
 
-      assert {0, :text} in index
-      refute {1, :text} in index
+      assert [
+               {0, :text},
+               {0, :empty},
+               {1, :system},
+               {1, :empty},
+               {2, :system},
+               {2, :empty},
+               {3, :text}
+             ] = index
+
+      assert [
+               ^old_message,
+               {:system, "── pinned ──", :info},
+               {:system, "── 2 earlier messages hidden ──", :info},
+               ^visible_message
+             ] = display_messages
+
+      assert [
+               {101, ^old_message},
+               {_, {:system, "── pinned ──", :info}},
+               {_, {:system, "── 2 earlier messages hidden ──", :info}},
+               {103, ^visible_message}
+             ] = display_pairs
     end
   end
 

--- a/test/minga_editor/agent/chat_decorations_test.exs
+++ b/test/minga_editor/agent/chat_decorations_test.exs
@@ -40,9 +40,9 @@ defmodule MingaEditor.Agent.ChatDecorationsTest do
       readable_highlights =
         result
         |> Decorations.highlights_for_line(0)
-        |> Enum.filter(fn hl -> hl.priority == -30 and hl.style.fg == theme.text_fg end)
+        |> Enum.filter(fn hl -> hl.priority == -5 and hl.style.fg == theme.text_fg end)
 
-      assert [%{style: %{fg: fg}, priority: -30}] = readable_highlights
+      assert [%{style: %{fg: fg}, priority: -5}] = readable_highlights
       assert fg == theme.text_fg
     end
 
@@ -262,16 +262,16 @@ defmodule MingaEditor.Agent.ChatDecorationsTest do
       assert length(above3) == 1
     end
 
-    test "usage messages get a dim highlight" do
+    test "usage messages get a dim highlight and Done marker" do
       decs = Decorations.new()
       messages = [{:usage, %MingaAgent.TurnUsage{input: 100, output: 50, cost: 0.001}}]
       offsets = [{0, 0, 1}]
 
       result = ChatDecorations.build_decorations(decs, messages, offsets, test_theme())
 
-      # Usage gets a highlight decoration for dim styling, but no block decorations
+      # Usage gets a highlight decoration for dim styling and a "Done" block above
       {above, below} = Decorations.blocks_for_line(result, 0)
-      assert above == []
+      assert length(above) == 1
       assert below == []
       refute Decorations.empty?(result)
     end

--- a/test/minga_editor/agent/event_routing_test.exs
+++ b/test/minga_editor/agent/event_routing_test.exs
@@ -24,6 +24,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Tab
@@ -241,6 +242,34 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       {state, effects} = Events.handle(state, {:status_changed, :idle})
       assert AgentState.active_tool_name(state.agent) == nil
       assert effects == [:render]
+    end
+
+    test "context usage while busy defers auto-compaction until idle" do
+      session = fake_session_pid()
+      agent = %AgentState{} |> AgentState.set_status(:thinking)
+
+      {tab_bar, workspace} =
+        TabBar.add_workspace(TabBar.new(Tab.new_agent(1, "Agent")), "Agent", session)
+
+      tab_bar = TabBar.move_tab_to_workspace(tab_bar, 1, workspace.id)
+
+      state = %EditorState{
+        port_manager: self(),
+        shell: Traditional,
+        workspace: %SessionState{viewport: Viewport.new(24, 80), agent_ui: UIState.new()},
+        shell_state: %TraditionalState{agent: agent, tab_bar: tab_bar}
+      }
+
+      {state, effects} = Events.handle(state, {:context_usage, 95, 100})
+      assert effects == [{:render, 16}]
+      assert AgentAccess.view(state).compact_pending_fill_pct == 95
+      refute AgentAccess.view(state).compaction_in_progress
+
+      {state, effects} = Events.handle(state, {:status_changed, :idle})
+      assert :render in effects
+      assert {:compact_session, session} in effects
+      assert AgentAccess.view(state).compact_pending_fill_pct == nil
+      assert AgentAccess.view(state).compaction_in_progress
     end
   end
 

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -12,6 +12,9 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
   use ExUnit.Case, async: true
 
+  alias MingaAgent.Session
+  alias Minga.Editing.Scroll
+  alias MingaEditor.Agent.BufferSync
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Project.FileRef
@@ -183,6 +186,52 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       # Scroll offset should change (exact value depends on panel height)
       assert AgentAccess.panel(new_state).scroll != AgentAccess.panel(state).scroll
+    end
+  end
+
+  # ── pin message ─────────────────────────────────────────────────────────
+
+  describe "scope_pin_message/1" do
+    test "pins the displayed stable id when earlier messages are hidden" do
+      pinned_message = {:assistant, "pinned context"}
+      hidden_message = {:user, "hidden context"}
+      visible_message = {:assistant, "visible target"}
+      messages = [pinned_message, hidden_message, visible_message]
+      message_ids = [{101, pinned_message}, {102, hidden_message}, {103, visible_message}]
+
+      {:ok, session} =
+        StubServer.start_link(
+          messages: messages,
+          message_ids: message_ids,
+          pinned_ids: MapSet.new([101])
+        )
+
+      agent_buffer = BufferSync.start_buffer()
+
+      {line_index, display_messages, display_pairs} =
+        BufferSync.sync(agent_buffer, messages,
+          display_start_index: 2,
+          message_ids: message_ids,
+          pinned_ids: MapSet.new([101])
+        )
+
+      state =
+        base_state(session: session, agent_buffer: agent_buffer)
+        |> AgentAccess.update_agent_ui(fn ui ->
+          panel = %{
+            ui.panel
+            | cached_line_index: line_index,
+              cached_display_messages: display_messages,
+              cached_display_message_pairs: display_pairs,
+              scroll: Scroll.new(6)
+          }
+
+          %{ui | panel: panel}
+        end)
+
+      AgentCommands.scope_pin_message(state)
+
+      assert Session.pinned_ids(session) == MapSet.new([101, 103])
     end
   end
 

--- a/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
@@ -1,0 +1,125 @@
+defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Agent.BufferSync
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.Panel
+  alias MingaEditor.Frontend.Emit.Context
+  alias MingaEditor.RenderModel.UI.AgentChatBuilder
+  alias MingaEditor.Shell.Traditional
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Windows
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Window
+
+  test "build/1 sends cached display message pairs to GUI agent chat" do
+    session = fake_session_pid()
+    old_message = {:assistant, "old pinned"}
+    hidden_message = {:user, "hidden"}
+    visible_message = {:assistant, "visible"}
+    message_ids = [{101, old_message}, {102, hidden_message}, {103, visible_message}]
+    buffer = BufferSync.start_buffer()
+
+    {_line_index, display_messages, display_pairs} =
+      BufferSync.sync(buffer, [old_message, hidden_message, visible_message],
+        display_start_index: 2,
+        message_ids: message_ids,
+        pinned_ids: MapSet.new([101])
+      )
+
+    panel = %Panel{
+      cached_display_messages: display_messages,
+      cached_display_message_pairs: display_pairs,
+      cached_styled_messages: [nil, nil, nil, nil]
+    }
+
+    model =
+      context(buffer, session, panel)
+      |> AgentChatBuilder.build()
+
+    summaries = decode_message_summaries(model.encoded)
+
+    assert [
+             {101, :assistant, "old pinned"},
+             {_, :system, "── pinned ──"},
+             {_, :system, "── 2 earlier messages hidden ──"},
+             {103, :assistant, "visible"}
+           ] = summaries
+
+    refute {:user, "hidden"} in Enum.map(summaries, fn {_id, type, text} -> {type, text} end)
+  end
+
+  defp context(buffer, session, panel) do
+    tab = Tab.new_agent(1, "Agent") |> Tab.set_session(session)
+    {tab_bar, workspace} = TabBar.add_workspace(TabBar.new(tab), "Agent", session)
+    tab_bar = TabBar.move_tab_to_workspace(tab_bar, tab.id, workspace.id)
+    window = Window.new_agent_chat(1, buffer, 24, 80)
+
+    %Context{
+      port_manager: self(),
+      capabilities: nil,
+      theme: nil,
+      font_registry: nil,
+      windows: %Windows{map: %{1 => window}, active: 1},
+      layout: nil,
+      shell: Traditional,
+      shell_state: %TraditionalState{agent: %AgentState{}, tab_bar: tab_bar},
+      agent_ui: %UIState{panel: panel},
+      viewport: Viewport.new(24, 80),
+      editing: VimState.new()
+    }
+  end
+
+  defp fake_session_pid do
+    pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> send(pid, :stop) end)
+    pid
+  end
+
+  defp decode_message_summaries(<<0x78, _section_count::8, sections::binary>>) do
+    sections
+    |> gui_agent_chat_section!(0x06)
+    |> unwrap_messages()
+    |> Enum.map(&decode_message_summary/1)
+  end
+
+  defp gui_agent_chat_section!(
+         <<target_id::8, len::16, payload::binary-size(len), _rest::binary>>,
+         target_id
+       ),
+       do: payload
+
+  defp gui_agent_chat_section!(
+         <<_id::8, len::16, _payload::binary-size(len), rest::binary>>,
+         target_id
+       ),
+       do: gui_agent_chat_section!(rest, target_id)
+
+  defp unwrap_messages(<<0xFF::8, 1::8, count::16, frames::binary>>),
+    do: unwrap_message_frames(frames, count, [])
+
+  defp unwrap_message_frames(<<>>, 0, acc), do: Enum.reverse(acc)
+
+  defp unwrap_message_frames(
+         <<message_len::32, message::binary-size(message_len), rest::binary>>,
+         remaining,
+         acc
+       ),
+       do: unwrap_message_frames(rest, remaining - 1, [message | acc])
+
+  defp decode_message_summary(<<id::32, 0x02::8, len::32, text::binary-size(len)>>),
+    do: {id, :assistant, text}
+
+  defp decode_message_summary(<<id::32, 0x05::8, _level::8, len::32, text::binary-size(len)>>),
+    do: {id, :system, text}
+end

--- a/test/support/stub_server.ex
+++ b/test/support/stub_server.ex
@@ -22,6 +22,21 @@ defmodule Minga.Test.StubServer do
   @impl GenServer
   def handle_call(:messages, _from, state), do: {:reply, Map.get(state, :messages, []), state}
 
+  def handle_call(:messages_with_ids, _from, state) do
+    messages = Map.get(state, :messages, [])
+    pairs = Map.get_lazy(state, :message_ids, fn -> default_message_ids(messages) end)
+    {:reply, pairs, state}
+  end
+
+  def handle_call(:pinned_ids, _from, state),
+    do: {:reply, Map.get(state, :pinned_ids, MapSet.new()), state}
+
+  def handle_call({:toggle_pin, id}, _from, state) do
+    pinned_ids = Map.get(state, :pinned_ids, MapSet.new())
+    pinned_ids = toggle_pinned_id(pinned_ids, id)
+    {:reply, :ok, Map.put(state, :pinned_ids, pinned_ids)}
+  end
+
   def handle_call(:usage, _from, state),
     do: {:reply, %{input: 0, output: 0, cache_read: 0, cache_write: 0, cost: 0.0}, state}
 
@@ -45,6 +60,22 @@ defmodule Minga.Test.StubServer do
   end
 
   def handle_call(_msg, _from, state), do: {:reply, :ok, state}
+
+  @spec toggle_pinned_id(MapSet.t(pos_integer()), pos_integer()) :: MapSet.t(pos_integer())
+  defp toggle_pinned_id(pinned_ids, id) do
+    if MapSet.member?(pinned_ids, id) do
+      MapSet.delete(pinned_ids, id)
+    else
+      MapSet.put(pinned_ids, id)
+    end
+  end
+
+  @spec default_message_ids([term()]) :: [{pos_integer(), term()}]
+  defp default_message_ids(messages) do
+    messages
+    |> Enum.with_index(1)
+    |> Enum.map(fn {msg, id} -> {id, msg} end)
+  end
 
   @impl GenServer
   def handle_cast(_msg, state), do: {:noreply, state}


### PR DESCRIPTION
## Summary

- **Flip visual hierarchy**: assistant text now uses box-drawing borders (`┌─ Agent` / `│` / `└─`), tool calls rendered as compact single-line status entries (`  ✓ bash (208ms)`)
- **Thinking stays visible**: thinking blocks remain expanded during streaming so users can follow reasoning, collapse only after the turn ends (`AgentEnd` instead of `TextDelta`)
- **"Done" marker**: visible turn-completion indicator appears above usage stats
- **Live activity in input border**: bottom border shows `⟳ tool_name` during execution, `⟳ thinking...` during thinking, model info when idle
- **Provider label fix**: was hardcoded to "Anthropic" even when using OpenAI models; now derived from model name
- **Model persistence**: model/provider/thinking level preserved across new sessions instead of resetting to defaults
- **Scroll metrics fix**: `Scroll.update_metrics` now called after each render pass so `scroll_up`/`scroll_down` work correctly from pinned state

## Test plan

- [x] `mix test` — 9495 passed, 0 failures
- [x] `mix credo` — no new warnings
- [ ] Manual: open agent chat, send prompt with tool calls, confirm assistant text is boxed and tool calls are flat
- [ ] Manual: confirm thinking block stays visible during streaming, collapses after turn ends
- [ ] Manual: confirm "Done" appears after turn, input border shows live activity
- [ ] Manual: switch models, confirm provider label updates and persists across new sessions
- [ ] Manual: scroll up/down in chat, confirm no jumps to top of buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)