### PR TITLE
feat(agent): support headless OAuth login

### DIFF
--- a/docs/REMOTE_AGENTS.md
+++ b/docs/REMOTE_AGENTS.md
@@ -40,6 +40,12 @@ Bind the server on a private network such as Tailscale or a locked-down LAN. Do 
 
 Provider credentials live on the server. For a quick local setup you can put keys in the systemd `Environment=` lines or the launchd `EnvironmentVariables` dictionary, but prefer a `0600` systemd `EnvironmentFile`, systemd credentials, macOS Keychain, or another local secret manager on shared machines. Attaching clients do not push provider credentials or config into the daemon.
 
+## Sign in on a headless server
+
+Use `minga login --manual` on the server when OAuth needs a browser but the daemon host has none. Minga prints an authorize URL, waits for one pasted value, and writes the resulting tokens to the server's `oauth.json`. Open the URL on your laptop, approve the request, then paste either the full failed redirect URL, the bare authorization code, or the `code#state` value back into the terminal.
+
+From an attached GUI, use `/login --manual`. The server creates the PKCE verifier and returns only the authorize URL and flow ref through `MingaAgent.RemoteAPI`. After approval, paste the redirect back with `/login --complete <ref> <redirect-url-or-code>`. The PKCE verifier never leaves the server.
+
 ## Attach, list, detach, and end
 
 Use `minga attach ssh://devbox/work/app` to connect to the agent session anchored to `/work/app` on `devbox`. The path is a server-side checkout or worktree. Minga does not copy source code to the client.

--- a/lib/minga/cli.ex
+++ b/lib/minga/cli.ex
@@ -26,6 +26,7 @@ defmodule Minga.CLI do
           | {:sessions, url :: String.t(), flags()}
           | {:detach, flags()}
           | {:kill_session, url :: String.t(), flags()}
+          | {:login, flags()}
           | {:error, String.t()}
 
   @typedoc "Startup view mode requested by CLI flags."
@@ -119,6 +120,15 @@ defmodule Minga.CLI do
           {:error, message} -> abort_startup(message)
         end
 
+      {:login, flags} ->
+        with :ok <- maybe_start_debug_log(flags),
+             :ok <- MingaAgent.OAuth.ManualCLI.run() do
+          System.stop(0)
+          :ok
+        else
+          {:error, message} -> abort_startup(message)
+        end
+
       {:error, message} ->
         IO.puts(:stderr, message)
         System.stop(1)
@@ -166,6 +176,12 @@ defmodule Minga.CLI do
     |> terminal_command_token?()
   end
 
+  @doc "Returns true when args request a terminal-only remote command after parsing flags."
+  @spec terminal_command_args?([String.t()]) :: boolean()
+  def terminal_command_args?(args) do
+    terminal_command?(args)
+  end
+
   @spec first_command_token([String.t()]) :: String.t() | nil
   defp first_command_token([]), do: nil
 
@@ -193,6 +209,7 @@ defmodule Minga.CLI do
   defp terminal_command_token?("sessions"), do: true
   defp terminal_command_token?("detach"), do: true
   defp terminal_command_token?("kill-session"), do: true
+  defp terminal_command_token?("login"), do: true
   defp terminal_command_token?(_token), do: false
 
   @doc """
@@ -308,6 +325,14 @@ defmodule Minga.CLI do
 
   defp parse_args(["kill-session" | _rest], _file, _flags) do
     {:error, "kill-session requires an ssh://host/path URL\n\n#{usage()}"}
+  end
+
+  defp parse_args(["login", "--manual" | rest], nil, flags) do
+    parse_remote_subcommand(rest, {:login, flags})
+  end
+
+  defp parse_args(["login" | _rest], _file, _flags) do
+    {:error, "login currently requires --manual outside the editor\n\n#{usage()}"}
   end
 
   defp parse_args(["--help" | _], _file, _flags), do: {:error, usage()}
@@ -997,6 +1022,7 @@ defmodule Minga.CLI do
            minga sessions ssh://[user@]host[:port]
            minga detach
            minga kill-session ssh://[user@]host[:port]/path
+           minga login --manual
 
     Options:
       -h, --help             Show this help message
@@ -1023,6 +1049,7 @@ defmodule Minga.CLI do
       minga attach ssh://devbox/work/app  Attach to a remote server-side checkout
       minga sessions ssh://devbox         List remote sessions without launching the editor
       minga kill-session ssh://devbox/work/app  Stop the remote session for that checkout
+      minga login --manual             Sign in on a headless server by pasting the browser redirect
       MINGA_COOKIE=$(openssl rand -base64 32 | tr -d '/+=') minga --headless   Start detachable agent server
       minga --config ~/minimal.exs       Use a custom config profile
       minga --safe                       Start with defaults and no user config

--- a/lib/minga/remote/control_endpoint.ex
+++ b/lib/minga/remote/control_endpoint.ex
@@ -103,9 +103,9 @@ defmodule Minga.Remote.ControlEndpoint do
 
   @spec current_uid() :: non_neg_integer() | nil
   defp current_uid do
-    case System.get_env("UID") do
-      nil -> nil
-      uid -> String.to_integer(uid)
+    case System.cmd("id", ["-u"], stderr_to_stdout: true) do
+      {uid, 0} -> uid |> String.trim() |> String.to_integer()
+      _other -> nil
     end
   rescue
     _error -> nil

--- a/lib/minga/services/independent.ex
+++ b/lib/minga/services/independent.ex
@@ -45,6 +45,7 @@ defmodule Minga.Services.Independent do
       Minga.Diagnostics,
       Minga.Session.EventRecorder,
       MingaAgent.EventLog,
+      MingaAgent.OAuth.PendingFlow,
       Minga.Tool.Manager
     ]
 

--- a/lib/minga_agent/oauth/callback_handler.ex
+++ b/lib/minga_agent/oauth/callback_handler.ex
@@ -46,20 +46,24 @@ defmodule MingaAgent.OAuth.CallbackHandler do
     end
   end
 
-  defp callback_event(%{"code" => code, "state" => state}) when is_binary(code) and code != "" do
+  @doc false
+  @spec callback_event(map()) ::
+          {:oauth_callback, String.t(), String.t() | nil}
+          | {:oauth_callback_error, {:provider_error, String.t()} | :missing_code}
+  def callback_event(%{"code" => code, "state" => state}) when is_binary(code) and code != "" do
     {:oauth_callback, code, state}
   end
 
-  defp callback_event(%{"code" => code}) when is_binary(code) and code != "" do
+  def callback_event(%{"code" => code}) when is_binary(code) and code != "" do
     {:oauth_callback, code, nil}
   end
 
-  defp callback_event(%{"error" => error} = params) when is_binary(error) and error != "" do
+  def callback_event(%{"error" => error} = params) when is_binary(error) and error != "" do
     description = Map.get(params, "error_description")
     {:oauth_callback_error, {:provider_error, provider_error_message(error, description)}}
   end
 
-  defp callback_event(_params), do: {:oauth_callback_error, :missing_code}
+  def callback_event(_params), do: {:oauth_callback_error, :missing_code}
 
   defp notify_flow(event) do
     case Process.whereis(:minga_oauth_flow) do

--- a/lib/minga_agent/oauth/flow.ex
+++ b/lib/minga_agent/oauth/flow.ex
@@ -9,21 +9,30 @@ defmodule MingaAgent.OAuth.Flow do
   """
 
   alias MingaAgent.OAuth
+  alias MingaAgent.OAuth.CallbackHandler
+  alias MingaAgent.OAuth.PendingFlow
 
   @flow_timeout_ms 120_000
+
+  @type run_result ::
+          {:ok, :openai} | {:manual_required, String.t(), String.t()} | {:error, String.t()}
+  @type complete_result :: {:ok, :openai} | {:error, String.t()}
+  @type exchange_fun :: (String.t(), String.t(), pos_integer() ->
+                           {:ok, OAuth.token_response()} | {:error, String.t()})
+  @type write_fun :: (OAuth.token_response() -> :ok | {:error, String.t()})
 
   @doc """
   Runs the full OAuth acquisition flow synchronously.
 
   Returns:
   - `{:ok, :openai}` on success (tokens written to oauth.json)
-  - `{:browser_failed, url}` if the browser could not be opened
+  - `{:manual_required, url, ref}` if the browser could not be opened and the server is waiting for paste-back completion
   - `{:error, reason}` on any failure
 
   The caller is responsible for wrapping this in a Task if async
   execution is needed.
   """
-  @spec run() :: {:ok, :openai} | {:browser_failed, String.t()} | {:error, String.t()}
+  @spec run() :: run_result()
   def run do
     pkce = OAuth.generate_pkce()
     state = generate_state()
@@ -32,6 +41,48 @@ defmodule MingaAgent.OAuth.Flow do
     case register_flow() do
       :ok -> run_registered_flow(pkce, state, config)
       {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Begins a manual paste-back OAuth flow without starting a local callback server."
+  @spec begin_manual(keyword()) :: {:ok, String.t(), String.t()} | {:error, String.t()}
+  def begin_manual(opts \\ []) do
+    pkce = OAuth.generate_pkce()
+    state = generate_state()
+    config = OAuth.openai_config()
+    port = Keyword.get(opts, :port, config.port)
+    timeout_ms = Keyword.get(opts, :timeout_ms, @flow_timeout_ms)
+    url = OAuth.openai_authorize_url(pkce.challenge, state, port)
+    owner_session_id = Keyword.get(opts, :session_id)
+    owner_client_pid = Keyword.get(opts, :client_pid)
+
+    begin_manual_flow(
+      url,
+      pkce.verifier,
+      state,
+      port,
+      timeout_ms,
+      owner_session_id,
+      owner_client_pid
+    )
+  end
+
+  @doc "Completes a manual paste-back OAuth flow from a pasted redirect value."
+  @spec complete_manual(String.t(), String.t(), keyword()) :: complete_result()
+  def complete_manual(ref, pasted, opts \\ []) when is_binary(ref) and is_binary(pasted) do
+    exchange_fun = Keyword.get(opts, :exchange_fun, &OAuth.exchange_code/3)
+    write_fun = Keyword.get(opts, :write_fun, &OAuth.write_oauth_file/1)
+
+    with {:ok, event} <- parse_manual_callback(pasted),
+         {:ok, pending} <- pending_flow(ref),
+         :ok <-
+           validate_pending_owner(
+             pending,
+             Keyword.get(opts, :session_id),
+             Keyword.get(opts, :client_pid)
+           ),
+         {:ok, code} <- validate_manual_event(event, pending) do
+      exchange_and_persist(code, pending.verifier, pending.port, exchange_fun, write_fun)
     end
   end
 
@@ -53,7 +104,10 @@ defmodule MingaAgent.OAuth.Flow do
               await_and_exchange(state, pkce.verifier, port)
 
             {:error, _reason} ->
-              {:browser_failed, url}
+              case begin_manual_flow(url, pkce.verifier, state, port, @flow_timeout_ms, nil, nil) do
+                {:ok, manual_url, ref} -> {:manual_required, manual_url, ref}
+                {:error, reason} -> {:error, reason}
+              end
           end
         after
           stop_server(bandit_pid)
@@ -151,10 +205,164 @@ defmodule MingaAgent.OAuth.Flow do
     e in [ErlangError] -> {:error, "Failed to open browser: #{Exception.message(e)}"}
   end
 
+  @spec begin_manual_flow(
+          String.t(),
+          String.t(),
+          String.t(),
+          pos_integer(),
+          pos_integer(),
+          String.t() | nil,
+          pid() | nil
+        ) :: {:ok, String.t(), String.t()} | {:error, String.t()}
+  defp begin_manual_flow(
+         url,
+         verifier,
+         state,
+         port,
+         timeout_ms,
+         owner_session_id,
+         owner_client_pid
+       ) do
+    flow = PendingFlow.Entry.new(verifier, state, port, owner_session_id, owner_client_pid)
+
+    case PendingFlow.put(flow, timeout_ms) do
+      {:ok, ref} -> {:ok, url, ref}
+      {:error, reason} -> {:error, "Could not start manual OAuth flow: #{inspect(reason)}"}
+    end
+  end
+
+  @spec parse_manual_callback(String.t()) ::
+          {:ok,
+           {:oauth_callback, String.t(), String.t() | nil}
+           | {:oauth_callback_error, {:provider_error, String.t()} | :missing_code}}
+          | {:error, String.t()}
+  defp parse_manual_callback(pasted) do
+    pasted
+    |> String.trim()
+    |> parse_manual_callback_value()
+  end
+
+  @spec parse_manual_callback_value(String.t()) ::
+          {:ok,
+           {:oauth_callback, String.t(), String.t() | nil}
+           | {:oauth_callback_error, {:provider_error, String.t()} | :missing_code}}
+          | {:error, String.t()}
+  defp parse_manual_callback_value(""),
+    do: {:error, "No redirect value was provided. Run /login --manual to try again."}
+
+  defp parse_manual_callback_value(value) do
+    value
+    |> URI.parse()
+    |> parse_manual_uri(value)
+  end
+
+  @spec parse_manual_uri(URI.t(), String.t()) ::
+          {:ok,
+           {:oauth_callback, String.t(), String.t() | nil}
+           | {:oauth_callback_error, {:provider_error, String.t()} | :missing_code}}
+          | {:error, String.t()}
+  defp parse_manual_uri(%URI{query: query}, _value) when is_binary(query) and query != "" do
+    query
+    |> URI.decode_query()
+    |> CallbackHandler.callback_event()
+    |> then(&{:ok, &1})
+  end
+
+  defp parse_manual_uri(_uri, value), do: parse_manual_blob(value)
+
+  @spec parse_manual_blob(String.t()) ::
+          {:ok,
+           {:oauth_callback, String.t(), String.t() | nil}
+           | {:oauth_callback_error, {:provider_error, String.t()} | :missing_code}}
+          | {:error, String.t()}
+  defp parse_manual_blob(value) do
+    value
+    |> split_manual_blob()
+    |> CallbackHandler.callback_event()
+    |> then(&{:ok, &1})
+  end
+
+  @spec split_manual_blob(String.t()) :: map()
+  defp split_manual_blob(value) do
+    case String.split(value, "#", parts: 2) do
+      [code, state] -> %{"code" => code, "state" => state}
+      [_single] -> split_ampersand_blob(value)
+    end
+  end
+
+  @spec split_ampersand_blob(String.t()) :: map()
+  defp split_ampersand_blob(value) do
+    case String.split(value, "&", parts: 2) do
+      [code, state] -> %{"code" => code, "state" => state}
+      [code] -> %{"code" => code}
+    end
+  end
+
+  @spec pending_flow(String.t()) :: {:ok, PendingFlow.flow()} | {:error, String.t()}
+  defp pending_flow(ref) do
+    case PendingFlow.take(ref) do
+      {:ok, pending} -> {:ok, pending}
+      {:error, :expired_flow} -> {:error, "OAuth flow expired. Run /login --manual to try again."}
+      {:error, :unknown_flow} -> {:error, "Unknown OAuth flow. Run /login --manual to try again."}
+      {:error, reason} -> {:error, "Could not read OAuth flow: #{inspect(reason)}"}
+    end
+  end
+
+  @spec validate_pending_owner(PendingFlow.flow(), String.t() | nil, pid() | nil) ::
+          :ok | {:error, String.t()}
+  defp validate_pending_owner(
+         %{owner_session_id: nil, owner_client_pid: nil},
+         _session_id,
+         _client_pid
+       ),
+       do: :ok
+
+  defp validate_pending_owner(
+         %{owner_session_id: session_id, owner_client_pid: client_pid},
+         session_id,
+         client_pid
+       ),
+       do: :ok
+
+  defp validate_pending_owner(_pending, _session_id, _client_pid) do
+    {:error,
+     "OAuth flow belongs to a different remote session. Run /login --manual to try again."}
+  end
+
+  @spec validate_manual_event(
+          {:oauth_callback, String.t(), String.t() | nil}
+          | {:oauth_callback_error, {:provider_error, String.t()} | :missing_code},
+          PendingFlow.flow()
+        ) :: {:ok, String.t()} | {:error, String.t()}
+  defp validate_manual_event({:oauth_callback, code, state}, pending)
+       when state == pending.state do
+    {:ok, code}
+  end
+
+  defp validate_manual_event({:oauth_callback, code, nil}, _pending), do: {:ok, code}
+
+  defp validate_manual_event({:oauth_callback, _code, _wrong_state}, _pending) do
+    {:error, "OAuth state mismatch (possible CSRF). Run /login --manual to try again."}
+  end
+
+  defp validate_manual_event({:oauth_callback_error, {:provider_error, message}}, _pending) do
+    {:error, "Authorization failed: #{message}. Run /login --manual to try again."}
+  end
+
+  defp validate_manual_event({:oauth_callback_error, :missing_code}, _pending) do
+    {:error, "Authorization was denied or failed. Run /login --manual to try again."}
+  end
+
   defp await_and_exchange(expected_state, verifier, port) do
     receive do
       {:oauth_callback, code, state} when is_binary(code) and state == expected_state ->
-        exchange_and_persist(code, verifier, port)
+        exchange_and_persist(
+          code,
+          verifier,
+          port,
+          &OAuth.exchange_code/3,
+          &OAuth.write_oauth_file/1
+        )
 
       {:oauth_callback, _code, nil} ->
         {:error, "OAuth redirect was missing the state parameter. Run /login to try again."}
@@ -174,9 +382,11 @@ defmodule MingaAgent.OAuth.Flow do
     end
   end
 
-  defp exchange_and_persist(code, verifier, port) do
-    with {:ok, tokens} <- OAuth.exchange_code(code, verifier, port),
-         :ok <- OAuth.write_oauth_file(tokens) do
+  @spec exchange_and_persist(String.t(), String.t(), pos_integer(), exchange_fun(), write_fun()) ::
+          complete_result()
+  defp exchange_and_persist(code, verifier, port, exchange_fun, write_fun) do
+    with {:ok, tokens} <- exchange_fun.(code, verifier, port),
+         :ok <- write_fun.(tokens) do
       {:ok, :openai}
     end
   end

--- a/lib/minga_agent/oauth/manual_cli.ex
+++ b/lib/minga_agent/oauth/manual_cli.ex
@@ -1,0 +1,63 @@
+defmodule MingaAgent.OAuth.ManualCLI do
+  @moduledoc """
+  Runs the headless OAuth paste-back flow from a terminal.
+
+  This path does not start the editor. It prints the authorize URL, reads one pasted redirect value from stdin, and completes the token exchange on the server.
+  """
+
+  alias MingaAgent.OAuth.Flow
+
+  @type input_fun :: (String.t() -> String.t() | nil)
+  @type output_fun :: (String.t() -> term())
+  @type begin_fun :: (-> {:ok, String.t(), String.t()} | {:error, String.t()})
+  @type complete_fun :: (String.t(), String.t() -> {:ok, :openai} | {:error, String.t()})
+
+  @doc "Runs the manual OAuth CLI flow."
+  @spec run(keyword()) :: :ok | {:error, String.t()}
+  def run(opts \\ []) do
+    input_fun = Keyword.get(opts, :input_fun, &IO.gets/1)
+    output_fun = Keyword.get(opts, :output_fun, &IO.puts/1)
+    begin_fun = Keyword.get(opts, :begin_fun, &Flow.begin_manual/0)
+    complete_fun = Keyword.get(opts, :complete_fun, &Flow.complete_manual/2)
+
+    with {:ok, url, ref} <- begin_fun.(),
+         {:ok, pasted} <- prompt_for_redirect(input_fun, output_fun, url, ref),
+         {:ok, :openai} <- complete_fun.(ref, pasted) do
+      output_fun.("ChatGPT subscription connected. Tokens were written to the server oauth.json.")
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec prompt_for_redirect(input_fun(), output_fun(), String.t(), String.t()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp prompt_for_redirect(input_fun, output_fun, url, ref) do
+    output_fun.("Open this URL in your browser to sign in:")
+    output_fun.(url)
+    output_fun.("Flow ref: #{ref}")
+
+    output_fun.(
+      "After approving, paste the full redirect URL, bare code, or code#state value below."
+    )
+
+    input_fun.("Paste redirect value: ")
+    |> normalize_input()
+  end
+
+  @spec normalize_input(String.t() | nil) :: {:ok, String.t()} | {:error, String.t()}
+  defp normalize_input(nil),
+    do: {:error, "No redirect value was provided. Run minga login --manual to try again."}
+
+  defp normalize_input(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> normalize_trimmed_input()
+  end
+
+  @spec normalize_trimmed_input(String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp normalize_trimmed_input(""),
+    do: {:error, "No redirect value was provided. Run minga login --manual to try again."}
+
+  defp normalize_trimmed_input(value), do: {:ok, value}
+end

--- a/lib/minga_agent/oauth/pending_flow.ex
+++ b/lib/minga_agent/oauth/pending_flow.ex
@@ -1,0 +1,150 @@
+defmodule MingaAgent.OAuth.PendingFlow do
+  @moduledoc """
+  Stores short-lived manual OAuth flows on the server.
+
+  The PKCE verifier stays in this process. Clients only receive the authorize URL and opaque ref, then paste back the single-use authorization result so the server can exchange it.
+  """
+
+  use GenServer
+
+  @type ref :: String.t()
+  alias MingaAgent.OAuth.PendingFlow.Entry
+
+  @type flow :: Entry.t()
+  @type entry :: %{flow: flow() | nil, timer: reference() | nil, expired?: boolean()}
+  @type state :: %{optional(ref()) => entry()}
+
+  @max_pending_flows 32
+  @expired_tombstone_ms 60_000
+
+  @doc "Starts the pending-flow store."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, %{}, name: name)
+  end
+
+  @doc "Stores a pending OAuth flow and returns its opaque ref."
+  @spec put(flow(), pos_integer()) :: {:ok, ref()} | {:error, term()}
+  def put(%Entry{} = flow, timeout_ms) when is_integer(timeout_ms) and timeout_ms > 0 do
+    with {:ok, _pid} <- ensure_started() do
+      GenServer.call(__MODULE__, {:put, flow, timeout_ms})
+    end
+  end
+
+  @doc "Consumes a pending OAuth flow by ref."
+  @spec take(ref()) :: {:ok, flow()} | {:error, :unknown_flow | :expired_flow | term()}
+  def take(ref) when is_binary(ref) do
+    with {:ok, _pid} <- ensure_started() do
+      GenServer.call(__MODULE__, {:take, ref})
+    end
+  end
+
+  @doc false
+  @spec expire(ref()) :: :ok | {:error, term()}
+  def expire(ref) when is_binary(ref) do
+    with {:ok, _pid} <- ensure_started() do
+      GenServer.call(__MODULE__, {:expire, ref})
+    end
+  end
+
+  @impl GenServer
+  @spec init(state()) :: {:ok, state()}
+  def init(state), do: {:ok, state}
+
+  @impl GenServer
+  def handle_call({:put, %Entry{} = flow, timeout_ms}, _from, state) do
+    if active_count(state) >= @max_pending_flows do
+      {:reply, {:error, :too_many_pending_flows}, state}
+    else
+      ref = new_ref()
+      timer = Process.send_after(self(), {:expire, ref}, timeout_ms)
+      entry = %{flow: flow, timer: timer, expired?: false}
+      {:reply, {:ok, ref}, Map.put(state, ref, entry)}
+    end
+  end
+
+  def handle_call({:take, ref}, _from, state) do
+    {entry, state} = Map.pop(state, ref)
+    {reply, state} = take_reply(entry, state)
+    {:reply, reply, state}
+  end
+
+  def handle_call({:expire, ref}, _from, state) do
+    {:reply, :ok, expire_ref(state, ref)}
+  end
+
+  @impl GenServer
+  def handle_info({:expire, ref}, state) do
+    {:noreply, expire_ref(state, ref)}
+  end
+
+  def handle_info({:purge, ref}, state) do
+    {:noreply, Map.delete(state, ref)}
+  end
+
+  @spec ensure_started() :: {:ok, pid()} | {:error, term()}
+  defp ensure_started do
+    case Process.whereis(__MODULE__) do
+      pid when is_pid(pid) -> {:ok, pid}
+      nil -> start_or_reuse()
+    end
+  end
+
+  @spec start_or_reuse() :: {:ok, pid()} | {:error, term()}
+  defp start_or_reuse do
+    case start_link() do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec take_reply(entry() | nil, state()) ::
+          {{:ok, flow()} | {:error, :unknown_flow | :expired_flow}, state()}
+  defp take_reply(nil, state), do: {{:error, :unknown_flow}, state}
+
+  defp take_reply(%{expired?: true}, state), do: {{:error, :expired_flow}, state}
+
+  defp take_reply(%{flow: flow, timer: timer}, state) when is_map(flow) and is_reference(timer) do
+    Process.cancel_timer(timer)
+    {{:ok, flow}, state}
+  end
+
+  @spec expire_ref(state(), ref()) :: state()
+  defp expire_ref(state, ref) do
+    state =
+      state
+      |> Map.update(ref, nil, &expire_entry/1)
+      |> drop_nil_entry(ref)
+
+    Process.send_after(self(), {:purge, ref}, @expired_tombstone_ms)
+    state
+  end
+
+  @spec expire_entry(entry() | nil) :: entry() | nil
+  defp expire_entry(nil), do: nil
+
+  defp expire_entry(entry) do
+    %{entry | flow: nil, timer: nil, expired?: true}
+  end
+
+  @spec active_count(state()) :: non_neg_integer()
+  defp active_count(state) do
+    Enum.count(state, fn {_ref, entry} -> entry.flow != nil and not entry.expired? end)
+  end
+
+  @spec drop_nil_entry(state(), ref()) :: state()
+  defp drop_nil_entry(state, ref) do
+    case Map.fetch(state, ref) do
+      {:ok, nil} -> Map.delete(state, ref)
+      _other -> state
+    end
+  end
+
+  @spec new_ref() :: ref()
+  defp new_ref do
+    :crypto.strong_rand_bytes(16)
+    |> Base.url_encode64(padding: false)
+  end
+end

--- a/lib/minga_agent/oauth/pending_flow/entry.ex
+++ b/lib/minga_agent/oauth/pending_flow/entry.ex
@@ -1,0 +1,29 @@
+defmodule MingaAgent.OAuth.PendingFlow.Entry do
+  @moduledoc false
+
+  @enforce_keys [:verifier, :state, :port, :owner_session_id, :owner_client_pid]
+  defstruct [:verifier, :state, :port, :owner_session_id, :owner_client_pid]
+
+  @type t :: %__MODULE__{
+          verifier: String.t(),
+          state: String.t(),
+          port: pos_integer(),
+          owner_session_id: String.t() | nil,
+          owner_client_pid: pid() | nil
+        }
+
+  @doc "Creates a pending OAuth flow entry."
+  @spec new(String.t(), String.t(), pos_integer(), String.t() | nil, pid() | nil) :: t()
+  def new(verifier, state, port, owner_session_id, owner_client_pid)
+      when is_binary(verifier) and is_binary(state) and is_integer(port) and port > 0 and
+             (is_binary(owner_session_id) or is_nil(owner_session_id)) and
+             (is_pid(owner_client_pid) or is_nil(owner_client_pid)) do
+    %__MODULE__{
+      verifier: verifier,
+      state: state,
+      port: port,
+      owner_session_id: owner_session_id,
+      owner_client_pid: owner_client_pid
+    }
+  end
+end

--- a/lib/minga_agent/remote_api.ex
+++ b/lib/minga_agent/remote_api.ex
@@ -8,6 +8,7 @@ defmodule MingaAgent.RemoteAPI do
   """
 
   alias MingaAgent.EventLog
+  alias MingaAgent.OAuth.Flow, as: OAuthFlow
   alias MingaAgent.RemoteAPI.AttachResult
   alias MingaAgent.RemoteAPI.SessionInfo
   alias MingaAgent.Session
@@ -85,6 +86,40 @@ defmodule MingaAgent.RemoteAPI do
     with :ok <- authorize(session_id, token),
          {:ok, pid} <- SessionManager.get_session(session_id) do
       Session.unsubscribe(pid, client_pid)
+    end
+  end
+
+  @doc "Begins a server-side manual OAuth flow through the broker."
+  @spec begin_oauth(String.t(), String.t(), pid()) ::
+          {:ok, String.t(), String.t()} | {:error, term()}
+  def begin_oauth(session_id, token, client_pid)
+      when is_binary(session_id) and is_binary(token) and is_pid(client_pid) do
+    with :ok <- authorize_driver(session_id, token, client_pid) do
+      OAuthFlow.begin_manual(session_id: session_id, client_pid: client_pid)
+    end
+  end
+
+  @doc "Completes a server-side manual OAuth flow through the broker."
+  @spec complete_oauth(String.t(), String.t(), pid(), String.t(), String.t()) ::
+          {:ok, :openai} | {:error, term()}
+  def complete_oauth(session_id, token, client_pid, ref, pasted)
+      when is_binary(session_id) and is_binary(token) and is_pid(client_pid) and is_binary(ref) and
+             is_binary(pasted) do
+    with :ok <- authorize_driver(session_id, token, client_pid) do
+      complete_authorized_oauth(session_id, client_pid, ref, pasted)
+    end
+  end
+
+  @doc "Adds a system message to a session through the broker."
+  @spec add_system_message(String.t(), String.t(), pid(), String.t(), :info | :error) ::
+          :ok | {:error, term()}
+  def add_system_message(session_id, token, client_pid, message, level \\ :info)
+      when is_binary(session_id) and is_binary(token) and is_pid(client_pid) and
+             is_binary(message) and
+             level in [:info, :error] do
+    with :ok <- authorize_driver(session_id, token, client_pid),
+         {:ok, pid} <- SessionManager.get_session(session_id) do
+      Session.add_system_message(pid, message, level)
     end
   end
 
@@ -166,6 +201,33 @@ defmodule MingaAgent.RemoteAPI do
     end
   end
 
+  @spec authorize_driver(String.t(), String.t(), pid()) ::
+          :ok | {:error, :unauthorized | :not_found | :not_driver}
+  defp authorize_driver(session_id, token, client_pid) do
+    with :ok <- authorize(session_id, token),
+         {:ok, pid} <- SessionManager.get_session(session_id),
+         :driver <- Session.subscriber_role(pid, client_pid) do
+      :ok
+    else
+      nil -> {:error, :not_driver}
+      :viewer -> {:error, :not_driver}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec complete_authorized_oauth(String.t(), pid(), String.t(), String.t()) ::
+          {:ok, :openai} | {:error, String.t()}
+  defp complete_authorized_oauth(session_id, client_pid, ref, pasted) do
+    case OAuthFlow.complete_manual(ref, pasted, session_id: session_id, client_pid: client_pid) do
+      {:ok, :openai} ->
+        refresh_all_session_credentials()
+        {:ok, :openai}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   @spec event_catchup(String.t(), non_neg_integer()) ::
           {:ok, [EventLog.EventRecord.t()], non_neg_integer()} | {:error, term()}
   defp event_catchup(session_id, last_seen_event_id)
@@ -206,10 +268,16 @@ defmodule MingaAgent.RemoteAPI do
   defp session_info_if_live({session_id, pid, _metadata}) do
     case SessionManager.session_token(session_id) do
       {:ok, token} -> [session_info(session_id, pid, token)]
-      {:error, :not_found} -> []
+      {:error, _reason} -> []
     end
   catch
     :exit, _reason -> []
+  end
+
+  @spec refresh_all_session_credentials() :: :ok
+  defp refresh_all_session_credentials do
+    SessionManager.list_sessions()
+    |> Enum.each(fn {_session_id, pid, _metadata} -> Session.refresh_credentials(pid) end)
   end
 
   @spec session_info(String.t(), pid(), String.t()) :: session_info()

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -2431,6 +2431,7 @@ defmodule MingaAgent.Session do
     Or sign in with a ChatGPT subscription (OpenAI accounts only):
 
       /login                    Sign in via browser, no key needed
+      /login --manual           Sign in by pasting a browser redirect
 
     Ollama is detected automatically if it's running locally.
     Run /auth to see status for all providers.\
@@ -2447,6 +2448,7 @@ defmodule MingaAgent.Session do
 
       /auth anthropic <key>     add an API key (most common)
       /login                    ChatGPT subscription (OpenAI only)
+      /login --manual           ChatGPT subscription on a headless server
 
     Run /auth to see all providers and options.\
     """

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -151,7 +151,9 @@ defmodule MingaEditor.Agent.SlashCommand do
   @spec sensitive_auth_args?(String.t()) :: boolean()
   defp sensitive_auth_args?(args) do
     case String.split(String.trim(args), " ", parts: 3, trim: true) do
-      ["revoke" | _] -> false
+      ["revoke"] -> false
+      ["revoke", _provider] -> false
+      ["revoke", _provider, _extra] -> true
       [_provider] -> false
       [_provider, _key | _rest] -> true
       [] -> false

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -91,7 +91,8 @@ defmodule MingaEditor.Agent.SlashCommand do
     %Command{name: "switch", description: "Switch to a branch: /switch <branch_number>"},
     %Command{
       name: "login",
-      description: "Sign in with ChatGPT (OpenAI) via browser"
+      description:
+        "Sign in with ChatGPT (OpenAI): /login, /login --manual, /login --complete <ref> <value>"
     }
   ]
 
@@ -126,6 +127,36 @@ defmodule MingaEditor.Agent.SlashCommand do
   @spec slash_command?(String.t()) :: boolean()
   def slash_command?("/" <> _), do: true
   def slash_command?(_), do: false
+
+  @doc "Returns true when a slash command may contain secrets and must not enter prompt history."
+  @spec sensitive_command?(String.t()) :: boolean()
+  def sensitive_command?("/" <> rest) do
+    {cmd, args} = parse_command(rest)
+    sensitive_parsed_command?(cmd, args)
+  end
+
+  def sensitive_command?(_text), do: false
+
+  @spec sensitive_parsed_command?(String.t(), String.t()) :: boolean()
+  defp sensitive_parsed_command?("login", args) do
+    String.contains?(String.downcase(args), "--complete")
+  end
+
+  defp sensitive_parsed_command?("auth", args) do
+    sensitive_auth_args?(args)
+  end
+
+  defp sensitive_parsed_command?(_cmd, _args), do: false
+
+  @spec sensitive_auth_args?(String.t()) :: boolean()
+  defp sensitive_auth_args?(args) do
+    case String.split(String.trim(args), " ", parts: 3, trim: true) do
+      ["revoke" | _] -> false
+      [_provider] -> false
+      [_provider, _key | _rest] -> true
+      [] -> false
+    end
+  end
 
   # ── Command dispatch ────────────────────────────────────────────────────────
 
@@ -530,16 +561,35 @@ defmodule MingaEditor.Agent.SlashCommand do
 
   @spec do_login(state(), String.t()) :: state()
   defp do_login(state, args) do
-    provider = String.trim(args)
+    args
+    |> login_args()
+    |> do_login_args(state)
+  end
 
-    if provider == "" or provider == "openai" do
-      start_oauth_flow(state)
-    else
-      emit_system_message(
-        state,
-        "Only OpenAI is supported for /login. Other providers use /auth <provider> <key>."
-      )
-    end
+  @spec login_args(String.t()) :: [String.t()]
+  defp login_args(args) do
+    args
+    |> String.trim()
+    |> String.split(" ", parts: 4, trim: true)
+  end
+
+  @spec do_login_args([String.t()], state()) :: state()
+  defp do_login_args([], state), do: start_oauth_flow(state)
+  defp do_login_args(["openai"], state), do: start_oauth_flow(state)
+  defp do_login_args(["--manual"], state), do: start_manual_oauth_flow(state)
+  defp do_login_args(["openai", "--manual"], state), do: start_manual_oauth_flow(state)
+
+  defp do_login_args(["--complete", ref, pasted], state),
+    do: complete_manual_oauth_flow(state, ref, pasted)
+
+  defp do_login_args(["openai", "--complete", ref, pasted], state),
+    do: complete_manual_oauth_flow(state, ref, pasted)
+
+  defp do_login_args(_args, state) do
+    emit_system_message(
+      state,
+      "Usage: /login, /login --manual, or /login --complete <ref> <redirect-url-or-code>. Only OpenAI is supported."
+    )
   end
 
   @spec start_oauth_flow(state()) :: state()
@@ -556,10 +606,10 @@ defmodule MingaEditor.Agent.SlashCommand do
           Session.refresh_credentials(session)
           Session.add_system_message(session, "ChatGPT subscription connected.")
 
-        {:browser_failed, url} ->
+        {:manual_required, url, ref} ->
           Session.add_system_message(
             session,
-            "Could not open browser. Open this URL to sign in:\n#{url}"
+            manual_login_message(url, ref)
           )
 
         {:error, reason} ->
@@ -568,6 +618,151 @@ defmodule MingaEditor.Agent.SlashCommand do
     end)
 
     state
+  end
+
+  @spec start_manual_oauth_flow(state()) :: state()
+  defp start_manual_oauth_flow(state) do
+    state = MingaEditor.State.set_status(state, "Starting manual ChatGPT sign-in...")
+    session = AgentAccess.session(state)
+    client_pid = self()
+
+    Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
+      case begin_manual_oauth_for_session(session, client_pid) do
+        {:ok, url, ref} ->
+          deliver_oauth_system_message(session, client_pid, manual_login_message(url, ref), :info)
+
+        {:error, reason} ->
+          deliver_oauth_system_message(session, client_pid, "Login failed: #{reason}", :error)
+      end
+    end)
+
+    state
+  end
+
+  @spec complete_manual_oauth_flow(state(), String.t(), String.t()) :: state()
+  defp complete_manual_oauth_flow(state, ref, pasted) do
+    state = MingaEditor.State.set_status(state, "Completing manual ChatGPT sign-in...")
+    session = AgentAccess.session(state)
+    client_pid = self()
+
+    Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
+      case complete_manual_oauth_for_session(session, client_pid, ref, pasted) do
+        {:ok, :openai} ->
+          deliver_oauth_system_message(
+            session,
+            client_pid,
+            "ChatGPT subscription connected.",
+            :info
+          )
+
+        {:error, reason} ->
+          deliver_oauth_system_message(session, client_pid, "Login failed: #{reason}", :error)
+      end
+    end)
+
+    state
+  end
+
+  @spec begin_manual_oauth_for_session(pid() | nil, pid()) ::
+          {:ok, String.t(), String.t()} | {:error, term()}
+  defp begin_manual_oauth_for_session(session, client_pid)
+       when is_pid(session) and node(session) != node() do
+    with {:ok, session_id, token} <- remote_session_credentials(session) do
+      :erpc.call(
+        node(session),
+        MingaAgent.RemoteAPI,
+        :begin_oauth,
+        [session_id, token, client_pid],
+        10_000
+      )
+    end
+  catch
+    :exit, reason -> {:error, "Remote OAuth flow failed to start: #{inspect(reason)}"}
+  end
+
+  defp begin_manual_oauth_for_session(_session, _client_pid),
+    do: MingaAgent.OAuth.Flow.begin_manual()
+
+  @spec complete_manual_oauth_for_session(pid() | nil, pid(), String.t(), String.t()) ::
+          {:ok, :openai} | {:error, term()}
+  defp complete_manual_oauth_for_session(session, client_pid, ref, pasted)
+       when is_pid(session) and node(session) != node() do
+    with {:ok, session_id, token} <- remote_session_credentials(session) do
+      :erpc.call(
+        node(session),
+        MingaAgent.RemoteAPI,
+        :complete_oauth,
+        [session_id, token, client_pid, ref, pasted],
+        15_000
+      )
+    end
+  catch
+    :exit, reason -> {:error, "Remote OAuth flow failed to complete: #{inspect(reason)}"}
+  end
+
+  defp complete_manual_oauth_for_session(session, _client_pid, ref, pasted) do
+    case MingaAgent.OAuth.Flow.complete_manual(ref, pasted) do
+      {:ok, :openai} ->
+        refresh_local_session_credentials(session)
+        {:ok, :openai}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @spec deliver_oauth_system_message(pid() | nil, pid(), String.t(), :info | :error) :: :ok
+  defp deliver_oauth_system_message(session, client_pid, message, level)
+       when is_pid(session) and node(session) != node() do
+    with {:ok, session_id, token} <- remote_session_credentials(session) do
+      :erpc.call(
+        node(session),
+        MingaAgent.RemoteAPI,
+        :add_system_message,
+        [session_id, token, client_pid, message, level],
+        5_000
+      )
+    end
+
+    :ok
+  catch
+    :exit, _reason -> :ok
+  end
+
+  defp deliver_oauth_system_message(session, _client_pid, message, level) when is_pid(session) do
+    Session.add_system_message(session, message, level)
+  end
+
+  defp deliver_oauth_system_message(_session, _client_pid, _message, _level), do: :ok
+
+  @spec remote_session_credentials(pid()) :: {:ok, String.t(), String.t()} | {:error, term()}
+  defp remote_session_credentials(session) when is_pid(session) do
+    case :erpc.call(node(session), MingaAgent.RemoteAPI, :list_sessions, [], 5_000) do
+      sessions when is_list(sessions) -> remote_session_credentials_from_list(sessions, session)
+      other -> {:error, other}
+    end
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  @spec remote_session_credentials_from_list([map()], pid()) ::
+          {:ok, String.t(), String.t()} | {:error, :not_found}
+  defp remote_session_credentials_from_list(sessions, session) do
+    Enum.find_value(sessions, {:error, :not_found}, fn
+      %{session_id: session_id, token: token, pid: ^session} -> {:ok, session_id, token}
+      _session -> nil
+    end)
+  end
+
+  @spec refresh_local_session_credentials(pid() | nil) :: :ok
+  defp refresh_local_session_credentials(session) when is_pid(session),
+    do: Session.refresh_credentials(session)
+
+  defp refresh_local_session_credentials(_session), do: :ok
+
+  @spec manual_login_message(String.t(), String.t()) :: String.t()
+  defp manual_login_message(url, ref) do
+    "Open this URL to sign in:\n#{url}\n\nAfter approving, paste the redirect back with:\n/login --complete #{ref} <redirect-url-or-code>"
   end
 
   @spec do_instructions(state()) :: state()

--- a/lib/minga_editor/agent/ui_state.ex
+++ b/lib/minga_editor/agent/ui_state.ex
@@ -222,6 +222,16 @@ defmodule MingaEditor.Agent.UIState do
 
   def set_prompt_text(%__MODULE__{} = state, _text), do: state
 
+  @doc "Clears the input without saving it to history. Use this for sensitive slash-command values."
+  @spec clear_input_without_history(t()) :: t()
+  def clear_input_without_history(%__MODULE__{} = state) do
+    if is_pid(state.panel.prompt_buffer) do
+      Buffer.replace_content(state.panel.prompt_buffer, "")
+    end
+
+    %{state | panel: %{state.panel | history_index: -1, pasted_blocks: []}}
+  end
+
   @doc "Clears the input (after submission). Saves current text to history first."
   @spec clear_input(t()) :: t()
   def clear_input(%__MODULE__{} = state) do
@@ -467,6 +477,12 @@ defmodule MingaEditor.Agent.UIState do
   @spec clear_input_and_scroll(t()) :: t()
   def clear_input_and_scroll(%__MODULE__{} = state) do
     state |> clear_input() |> scroll_to_bottom()
+  end
+
+  @doc "Clears the input without history and scrolls to the latest agent message."
+  @spec clear_input_without_history_and_scroll(t()) :: t()
+  def clear_input_without_history_and_scroll(%__MODULE__{} = state) do
+    state |> clear_input_without_history() |> scroll_to_bottom()
   end
 
   # ── Model/provider config ──────────────────────────────────────────────────

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -356,24 +356,43 @@ defmodule MingaEditor.Commands.Agent do
   @spec submit_prompt(state()) :: state()
   def submit_prompt(state) do
     panel = AgentAccess.panel(state)
+    submit_prompt(state, panel, UIState.input_empty?(panel), AgentAccess.session(state))
+  end
 
-    cond do
-      UIState.input_empty?(panel) ->
-        state
+  @spec submit_prompt(state(), Panel.t(), boolean(), pid() | nil) :: state()
+  defp submit_prompt(state, _panel, true, _session), do: state
 
-      AgentAccess.session(state) == nil ->
-        EditorState.set_status(state, "No agent session, try closing and reopening the panel")
+  defp submit_prompt(state, _panel, false, nil) do
+    EditorState.set_status(state, "No agent session, try closing and reopening the panel")
+  end
 
-      true ->
-        text = UIState.prompt_text(panel)
+  defp submit_prompt(state, panel, false, _session) do
+    text = UIState.prompt_text(panel)
+    submit_prompt_text(state, text, SlashCommand.slash_command?(text))
+  end
 
-        if SlashCommand.slash_command?(text) do
-          state = update_agent_ui(state, &UIState.clear_input_and_scroll/1)
-          execute_slash_command(state, text)
-        else
-          send_prompt_to_llm(state, text)
-        end
-    end
+  @spec submit_prompt_text(state(), String.t(), boolean()) :: state()
+  defp submit_prompt_text(state, text, true) do
+    state = clear_submitted_slash_input(state, text)
+    execute_slash_command(state, text)
+  end
+
+  defp submit_prompt_text(state, text, false) do
+    send_prompt_to_llm(state, text)
+  end
+
+  @spec clear_submitted_slash_input(state(), String.t()) :: state()
+  defp clear_submitted_slash_input(state, text) do
+    clear_submitted_slash_input_for_sensitivity(state, SlashCommand.sensitive_command?(text))
+  end
+
+  @spec clear_submitted_slash_input_for_sensitivity(state(), boolean()) :: state()
+  defp clear_submitted_slash_input_for_sensitivity(state, true) do
+    update_agent_ui(state, &UIState.clear_input_without_history_and_scroll/1)
+  end
+
+  defp clear_submitted_slash_input_for_sensitivity(state, false) do
+    update_agent_ui(state, &UIState.clear_input_and_scroll/1)
   end
 
   @spec execute_slash_command(state(), String.t()) :: state()
@@ -615,7 +634,7 @@ defmodule MingaEditor.Commands.Agent do
         text = UIState.prompt_text(panel)
 
         if SlashCommand.slash_command?(text) do
-          state = update_agent_ui(state, &UIState.clear_input_and_scroll/1)
+          state = clear_submitted_slash_input(state, text)
           execute_slash_command(state, text)
         else
           send_follow_up_to_llm(state, text)

--- a/lib/mix/tasks/minga.ex
+++ b/lib/mix/tasks/minga.ex
@@ -26,6 +26,7 @@ defmodule Mix.Tasks.Minga do
   def run(args) do
     {gui?, remaining_args} = extract_gui_flag(args)
     headless? = Minga.CLI.headless_args?(remaining_args)
+    terminal_command? = Minga.CLI.terminal_command_args?(remaining_args)
     minimal? = Minga.CLI.minimal_args?(remaining_args)
     safe? = Minga.CLI.safe_args?(remaining_args)
 
@@ -35,18 +36,18 @@ defmodule Mix.Tasks.Minga do
       Application.put_env(:minga, :minimal_mode, true)
     end
 
-    unless headless? or Minga.CLI.terminal_command?(remaining_args) do
+    unless headless? or terminal_command? do
       Application.put_env(:minga, :start_editor, true)
     end
 
-    if gui? and not headless? and not Minga.CLI.terminal_command?(remaining_args) do
+    if gui? and not headless? and not terminal_command? do
       Application.put_env(:minga, :backend, :gui)
     end
 
     Mix.Task.run("app.start")
     Minga.CLI.main(remaining_args)
 
-    unless help_args?(args) or Minga.CLI.terminal_command?(remaining_args) do
+    unless help_args?(args) or terminal_command? do
       receive do
       end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -292,9 +292,10 @@ defmodule Minga.MixProject do
             [\"+gui\" | rest] -> {true, rest}
             other -> {false, other}
           end
-          if gui, do: Application.put_env(:minga, :backend, :gui)
+          terminal_command = Minga.CLI.terminal_command_args?(argv)
+          if gui and not terminal_command, do: Application.put_env(:minga, :backend, :gui)
           Minga.SafeMode.put(Minga.CLI.safe_args?(argv))
-          Application.put_env(:minga, :start_editor, true)
+          if not terminal_command, do: Application.put_env(:minga, :start_editor, true)
           Application.ensure_all_started(:minga)
           Minga.CLI.main(argv)
         '"

--- a/test/minga/cli_test.exs
+++ b/test/minga/cli_test.exs
@@ -71,12 +71,36 @@ defmodule Minga.CLITest do
       assert CLI.terminal_command?(["sessions", "ssh://devbox"])
       assert CLI.terminal_command?(["detach"])
       assert CLI.terminal_command?(["kill-session", "ssh://devbox/work/app"])
+      assert CLI.terminal_command?(["login"])
+      assert CLI.terminal_command?(["login", "--manual"])
       assert CLI.terminal_command?(["--cookie", "abc", "sessions"])
       assert CLI.terminal_command?(["sessions"])
       assert CLI.terminal_command?(["kill-session"])
       assert CLI.terminal_command?(["detach", "unexpected"])
       refute CLI.terminal_command?(["attach", "ssh://devbox/work/app"])
       refute CLI.terminal_command?(["README.md"])
+    end
+
+    test "manual login subcommand returns login action" do
+      assert {:login, %{view_mode: :auto}} = CLI.parse_args(["login", "--manual"])
+    end
+
+    test "login without manual flag returns usage error" do
+      assert {:error, message} = CLI.parse_args(["login"])
+      assert message =~ "login currently requires --manual"
+    end
+
+    test "manual login appears in help output" do
+      assert {:error, message} = CLI.parse_args(["--help"])
+      assert message =~ "minga login --manual"
+    end
+
+    test "terminal-only commands do not request editor startup" do
+      assert CLI.terminal_command_args?(["login", "--manual"])
+      assert CLI.terminal_command_args?(["sessions", "ssh://devbox"])
+      assert CLI.terminal_command_args?(["login"])
+      refute CLI.terminal_command_args?(["attach", "ssh://devbox/work/app"])
+      refute CLI.terminal_command_args?(["README.md"])
     end
 
     test "file argument with extra non-flag args takes the last file" do

--- a/test/minga_agent/oauth/flow_test.exs
+++ b/test/minga_agent/oauth/flow_test.exs
@@ -1,6 +1,110 @@
 defmodule MingaAgent.OAuth.FlowTest do
-  # Uses the global registered process name :minga_oauth_flow, so tests must serialize.
+  # Uses global registered flow processes, so tests must serialize.
   use ExUnit.Case, async: false
+
+  alias MingaAgent.OAuth.Flow
+  alias MingaAgent.OAuth.PendingFlow
+
+  describe "manual paste-back flow" do
+    test "complete_manual succeeds with a full redirect URL and reuses the authorize port" do
+      {:ok, url, ref} = Flow.begin_manual(timeout_ms: 60_000)
+
+      state =
+        url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query() |> Map.fetch!("state")
+
+      pasted = "http://localhost:1455/auth/callback?code=full_code&state=#{state}"
+      parent = self()
+
+      exchange_fun = fn code, verifier, port ->
+        send(parent, {:exchange, code, verifier, port})
+        {:ok, %{access: "access", refresh: nil, expires: nil, account_id: nil}}
+      end
+
+      write_fun = fn tokens ->
+        send(parent, {:write, tokens})
+        :ok
+      end
+
+      assert {:ok, :openai} =
+               Flow.complete_manual(ref, pasted, exchange_fun: exchange_fun, write_fun: write_fun)
+
+      assert_receive {:exchange, "full_code", verifier, 1455}
+      assert is_binary(verifier)
+      assert_receive {:write, %{access: "access"}}
+    end
+
+    test "complete_manual accepts a bare authorization code" do
+      {:ok, _url, ref} = Flow.begin_manual(timeout_ms: 60_000)
+
+      assert {:ok, :openai} =
+               Flow.complete_manual(ref, "bare_code",
+                 exchange_fun: token_exchange(self()),
+                 write_fun: token_writer(self())
+               )
+
+      assert_receive {:exchange_code, "bare_code"}
+    end
+
+    test "complete_manual accepts code#state and code&state blobs" do
+      assert_manual_blob_complete("hash_code#")
+      assert_manual_blob_complete("amp_code&")
+    end
+
+    test "complete_manual rejects a state mismatch" do
+      {:ok, _url, ref} = Flow.begin_manual(timeout_ms: 60_000)
+
+      assert {:error, message} = Flow.complete_manual(ref, "code#wrong-state")
+      assert message =~ "state mismatch"
+      assert message =~ "possible CSRF"
+    end
+
+    test "complete_manual rejects remote owner mismatches" do
+      owner = self()
+      other = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Process.exit(other, :kill) end)
+
+      {:ok, _url, ref} =
+        Flow.begin_manual(session_id: "session-a", client_pid: owner, timeout_ms: 60_000)
+
+      assert {:error, message} =
+               Flow.complete_manual(ref, "code", session_id: "session-a", client_pid: other)
+
+      assert message =~ "different remote session"
+    end
+
+    test "complete_manual rejects expired and unknown flow refs clearly" do
+      {:ok, _url, ref} = Flow.begin_manual(timeout_ms: 60_000)
+      assert :ok = PendingFlow.expire(ref)
+
+      assert {:error, expired} = Flow.complete_manual(ref, "code")
+      assert expired =~ "expired"
+
+      assert {:error, unknown} = Flow.complete_manual("missing-ref", "code")
+      assert unknown =~ "Unknown OAuth flow"
+    end
+
+    test "pending flow entries remain typed structs through put and take" do
+      entry = PendingFlow.Entry.new("verifier", "state", 1455, "session-a", self())
+
+      assert {:ok, ref} = PendingFlow.put(entry, 60_000)
+      assert {:ok, stored} = PendingFlow.take(ref)
+      assert %PendingFlow.Entry{} = stored
+      assert stored.verifier == "verifier"
+      assert stored.state == "state"
+      assert stored.port == 1455
+      assert stored.owner_session_id == "session-a"
+      assert stored.owner_client_pid == self()
+    end
+
+    test "complete_manual reports denied authorization" do
+      {:ok, _url, ref} = Flow.begin_manual(timeout_ms: 60_000)
+      pasted = "http://localhost:1455/auth/callback?error=access_denied&error_description=Nope"
+
+      assert {:error, message} = Flow.complete_manual(ref, pasted)
+      assert message =~ "Authorization failed"
+      assert message =~ "Nope"
+    end
+  end
 
   describe "registration" do
     test "only one flow can register at a time" do
@@ -21,6 +125,38 @@ defmodule MingaAgent.OAuth.FlowTest do
       rescue
         ArgumentError -> :ok
       end
+    end
+  end
+
+  @spec assert_manual_blob_complete(String.t()) :: :ok
+  defp assert_manual_blob_complete(blob_prefix) do
+    {:ok, url, ref} = Flow.begin_manual(timeout_ms: 60_000)
+    state = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query() |> Map.fetch!("state")
+    blob = blob_prefix <> state
+
+    assert {:ok, :openai} =
+             Flow.complete_manual(ref, blob,
+               exchange_fun: token_exchange(self()),
+               write_fun: token_writer(self())
+             )
+
+    :ok
+  end
+
+  @spec token_exchange(pid()) ::
+          (String.t(), String.t(), pos_integer() -> {:ok, MingaAgent.OAuth.token_response()})
+  defp token_exchange(parent) do
+    fn code, _verifier, _port ->
+      send(parent, {:exchange_code, code})
+      {:ok, %{access: "access", refresh: nil, expires: nil, account_id: nil}}
+    end
+  end
+
+  @spec token_writer(pid()) :: (MingaAgent.OAuth.token_response() -> :ok)
+  defp token_writer(parent) do
+    fn tokens ->
+      send(parent, {:write_tokens, tokens})
+      :ok
     end
   end
 end

--- a/test/minga_agent/oauth/manual_cli_test.exs
+++ b/test/minga_agent/oauth/manual_cli_test.exs
@@ -1,0 +1,48 @@
+defmodule MingaAgent.OAuth.ManualCLITest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.OAuth.ManualCLI
+
+  test "prints the authorize URL, reads pasted input, and completes the flow" do
+    parent = self()
+
+    begin_fun = fn -> {:ok, "https://auth.example/authorize", "flow-ref"} end
+
+    complete_fun = fn ref, pasted ->
+      send(parent, {:complete, ref, pasted})
+      {:ok, :openai}
+    end
+
+    input_fun = fn prompt ->
+      send(parent, {:prompt, prompt})
+      "pasted_code\n"
+    end
+
+    output_fun = fn message -> send(parent, {:output, message}) end
+
+    assert :ok =
+             ManualCLI.run(
+               begin_fun: begin_fun,
+               complete_fun: complete_fun,
+               input_fun: input_fun,
+               output_fun: output_fun
+             )
+
+    assert_receive {:output, "Open this URL in your browser to sign in:"}
+    assert_receive {:output, "https://auth.example/authorize"}
+    assert_receive {:output, "Flow ref: flow-ref"}
+    assert_receive {:prompt, "Paste redirect value: "}
+    assert_receive {:complete, "flow-ref", "pasted_code"}
+  end
+
+  test "returns a clear error when stdin closes" do
+    assert {:error, message} =
+             ManualCLI.run(
+               begin_fun: fn -> {:ok, "url", "ref"} end,
+               input_fun: fn _prompt -> nil end,
+               output_fun: fn _message -> :ok end
+             )
+
+    assert message =~ "No redirect value was provided"
+  end
+end

--- a/test/minga_agent/remote_api_test.exs
+++ b/test/minga_agent/remote_api_test.exs
@@ -64,6 +64,29 @@ defmodule MingaAgent.RemoteAPITest do
     assert {:ok, _pid} = SessionManager.get_session(session_id)
   end
 
+  test "broker starts OAuth flows only for the attached driver" do
+    assert {:ok, %{session_id: session_id, token: token}} = RemoteAPI.start_session([])
+    on_exit(fn -> SessionManager.stop_session(session_id) end)
+
+    driver = idle_process()
+    viewer = idle_process()
+    on_exit(fn -> Process.exit(driver, :kill) end)
+    on_exit(fn -> Process.exit(viewer, :kill) end)
+
+    assert {:ok, %{role: :driver}} = RemoteAPI.attach(session_id, token, driver, role: :driver)
+    assert {:ok, %{role: :viewer}} = RemoteAPI.attach(session_id, token, viewer, role: :viewer)
+    assert {:error, :not_driver} = RemoteAPI.begin_oauth(session_id, token, viewer)
+
+    assert {:ok, url, ref} = RemoteAPI.begin_oauth(session_id, token, driver)
+    assert is_binary(url)
+    assert is_binary(ref)
+
+    assert {:error, message} =
+             RemoteAPI.complete_oauth(session_id, token, driver, "missing-ref", "code")
+
+    assert message =~ "Unknown OAuth flow"
+  end
+
   test "attach returns cursor catch-up events" do
     session_id = "remote-api-catchup-#{System.unique_integer([:positive])}"
     assert {:ok, ^session_id, pid} = SessionManager.start_session(session_id: session_id)

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -86,7 +86,9 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       assert SlashCommand.sensitive_command?("/LOGIN --complete ref code")
       assert SlashCommand.sensitive_command?("/login   --complete ref code")
       assert SlashCommand.sensitive_command?("/login --complete")
+      refute SlashCommand.sensitive_command?("/auth revoke")
       refute SlashCommand.sensitive_command?("/auth revoke openai")
+      assert SlashCommand.sensitive_command?("/auth revoke openai extra-secret")
       refute SlashCommand.sensitive_command?("/login --manual")
       refute SlashCommand.sensitive_command?("/help")
     end

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -76,6 +76,22 @@ defmodule MingaEditor.Agent.SlashCommandTest do
     end
   end
 
+  describe "sensitive_command?/1" do
+    test "detects secret-bearing auth and login completion commands" do
+      assert SlashCommand.sensitive_command?("/auth openai sk-test-secret")
+      assert SlashCommand.sensitive_command?("/auth openai sk-test-secret extra")
+      assert SlashCommand.sensitive_command?("/login --complete ref code")
+      assert SlashCommand.sensitive_command?("/login openai --complete ref code")
+      assert SlashCommand.sensitive_command?("/login openai --COMPLETE ref code")
+      assert SlashCommand.sensitive_command?("/LOGIN --complete ref code")
+      assert SlashCommand.sensitive_command?("/login   --complete ref code")
+      assert SlashCommand.sensitive_command?("/login --complete")
+      refute SlashCommand.sensitive_command?("/auth revoke openai")
+      refute SlashCommand.sensitive_command?("/login --manual")
+      refute SlashCommand.sensitive_command?("/help")
+    end
+  end
+
   describe "commands/0" do
     test "returns a list of command maps" do
       cmds = SlashCommand.commands()

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -18,6 +18,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
   alias MingaEditor.Commands.Agent, as: AgentCommands
   alias MingaEditor.Commands.AgentSession
   alias MingaEditor.State, as: EditorState
+  alias MingaAgent.RuntimeState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -158,6 +158,17 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       assert AgentCommands.submit_prompt(state) == state
     end
 
+    test "sensitive slash commands do not enter history" do
+      state =
+        base_state()
+        |> AgentAccess.update_agent_ui(&UIState.set_prompt_text(&1, "/login --COMPLETE ref code"))
+
+      new_state = AgentCommands.submit_prompt(state)
+
+      assert AgentAccess.panel(new_state).prompt_history == []
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == ""
+    end
+
     test "sets error status when no session exists" do
       state = base_state(session: nil)
 
@@ -171,6 +182,29 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       new_state = AgentCommands.submit_prompt(state)
 
       assert new_state.shell_state.status_msg =~ "No agent session"
+    end
+  end
+
+  describe "scope_queue_follow_up/1" do
+    test "sensitive slash commands do not enter history when queued as follow-up" do
+      state = base_state()
+
+      state =
+        %{
+          state
+          | shell_state: %{
+              state.shell_state
+              | agent: %{state.shell_state.agent | runtime: %RuntimeState{status: :thinking}}
+            }
+        }
+        |> AgentAccess.update_agent_ui(
+          &UIState.set_prompt_text(&1, "/login openai --complete ref code")
+        )
+
+      new_state = AgentCommands.scope_queue_follow_up(state)
+
+      assert AgentAccess.panel(new_state).prompt_history == []
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == ""
     end
   end
 


### PR DESCRIPTION
## Summary
- add manual OAuth paste-back flows for headless servers, including a pending-flow store that keeps the PKCE verifier server-side
- add `minga login --manual` as a terminal-only CLI path that prints the authorize URL, accepts pasted redirect input, and writes server-side `oauth.json`
- add attached-GUI `/login --manual` and `/login --complete` support through brokered `MingaAgent.RemoteAPI` calls with driver authorization
- redact `/login --complete` inputs from prompt history and document headless sign-in in `docs/REMOTE_AGENTS.md`

## Validation
- `mix compile --warnings-as-errors`
- `mix test.llm test/minga_agent/oauth test/minga_agent/oauth_test.exs test/minga/cli_test.exs test/minga_agent/remote_api_test.exs test/minga_editor/agent/slash_command_test.exs`
- `mix test.llm test/minga_editor/commands/agent_commands_test.exs test/minga_editor/agent/slash_command_test.exs`
- `make lint`
- full `mix test.llm` passed: 56 doctests, 91 properties, 9133 tests, 0 failures, 292 excluded
- `git diff --check`

Closes #2056
