### PR TITLE
feat(agent): enforce dependency levels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,8 @@ The practical rule: **prefer the entry-point module when one exists**, because i
 
 Minga uses three namespaces that enforce dependency direction: `Minga.*` (Layer 0), `MingaAgent.*` (Layer 1), `MingaEditor.*` (Layer 2). Dependencies flow downward only. A credo check enforces this at compile time. See `docs/ARCHITECTURE.md` for the full rationale.
 
+MingaAgent also has internal Agent Level 0/1/2 rules from epic #2075. Agent Level 0 contains pure contracts, value types, and safety interfaces; Agent Level 1 contains runtime services, source-owned registries, credentials, approval, `ToolRouter`, changesets, buffer forks, and edit boundaries; Agent Level 2 contains bundled integrations, adapters, and agent presentation surfaces. `Minga.Credo.DependencyDirectionCheck` enforces that Agent Level 0 cannot depend on Levels 1 or 2 and Agent Level 1 cannot depend on Level 2. See `docs/ARCHITECTURE.md#mingaagent-internal-levels` for the current module classification.
+
 #### Layer 0: `lib/minga/` (Minga.*)
 
 | Directory | Entry point | What lives here |

--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -43,11 +43,16 @@ defmodule Minga.Credo.DependencyDirectionCheck do
   # Individual modules from mixed directories (buffer/, editing/) are listed explicitly.
   @layer_0_prefixes [
     "Minga.Buffer.ChangeLog",
+    "Minga.Buffer.Cursor",
     "Minga.Buffer.Document",
     "Minga.Buffer.EditDelta",
     "Minga.Buffer.EditSource",
+    "Minga.Buffer.Lines",
+    "Minga.Buffer.Position",
     "Minga.Buffer.RenderSnapshot",
     "Minga.Buffer.SaveState",
+    "Minga.Buffer.Selection",
+    "Minga.Buffer.Span",
     "Minga.Buffer.State",
     "Minga.Buffer.UndoHistory",
     "Minga.Buffer.UndoPatch",
@@ -127,6 +132,59 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     # - Theme loading → Events broadcast
   }
 
+  # MingaAgent internal levels. These are intentionally separate from the
+  # top-level Minga/MingaAgent/MingaEditor layers above. The broad Level 1
+  # fallback reflects the current codebase; later extraction tickets can move
+  # specific bundled integrations to Level 2 as registry boundaries land.
+  @agent_level_0_prefixes [
+    "Minga.Extension.Agent",
+    "MingaAgent.Branch",
+    "MingaAgent.Changeset.BudgetExhaustedEvent",
+    "MingaAgent.Changeset.MergedEvent",
+    "MingaAgent.CostCalculator",
+    "MingaAgent.EditBoundary",
+    "MingaAgent.Event",
+    "MingaAgent.EventLog.EventRecord",
+    "MingaAgent.EventLog.Taxonomy",
+    "MingaAgent.Hooks.Hook",
+    "MingaAgent.Hooks.NotificationPayload",
+    "MingaAgent.Hooks.PostToolUsePayload",
+    "MingaAgent.Hooks.PreCompactPayload",
+    "MingaAgent.Hooks.PreToolUsePayload",
+    "MingaAgent.Hooks.Result",
+    "MingaAgent.Hooks.SessionEndPayload",
+    "MingaAgent.Hooks.SessionStartPayload",
+    "MingaAgent.Hooks.StopPayload",
+    "MingaAgent.Hooks.UserPromptSubmitPayload",
+    "MingaAgent.Instruction",
+    "MingaAgent.InternalState",
+    "MingaAgent.MCP.ServerConfig",
+    "MingaAgent.MCP.Tool",
+    "MingaAgent.MCP.Transport",
+    "MingaAgent.Message",
+    "MingaAgent.ModelLimits",
+    "MingaAgent.OAuth.PendingFlow.Entry",
+    "MingaAgent.Provider",
+    "MingaAgent.RuntimeState",
+    "MingaAgent.Subagent.Handle",
+    "MingaAgent.TodoItem",
+    "MingaAgent.TokenEstimator",
+    "MingaAgent.Tool.Spec",
+    "MingaAgent.ToolApproval.Preview",
+    "MingaAgent.ToolCall",
+    "MingaAgent.TurnUsage",
+    "MingaEditor.Agent.SlashCommand.Command"
+  ]
+
+  @agent_level_1_prefixes [
+    "Minga.Extension.AgentAPI",
+    "MingaAgent"
+  ]
+
+  @agent_level_2_prefixes [
+    "MingaEditor"
+  ]
+
   # Cross-cutting modules allowed everywhere.
   @cross_cutting [
     "Minga.Events",
@@ -136,6 +194,7 @@ defmodule Minga.Credo.DependencyDirectionCheck do
   ]
 
   @impl true
+  @spec run(SourceFile.t(), keyword()) :: [Credo.Issue.t()]
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
     filename = source_file.filename
@@ -144,11 +203,106 @@ defmodule Minga.Credo.DependencyDirectionCheck do
       []
     else
       source_layer = layer_for_file(filename)
-      source_module = file_to_module_name(filename)
+      source_module = source_file_to_module_name(source_file)
 
       source_file
       |> Credo.Code.prewalk(&find_violations(&1, &2, source_layer, source_module, issue_meta))
       |> Enum.filter(&is_map/1)
+    end
+  end
+
+  defp find_violations(
+         {{:., meta, [{:__aliases__, _, ref_parts}, function]}, _, _args} = ast,
+         issues,
+         source_layer,
+         source_module,
+         issue_meta
+       )
+       when source_layer != nil and function != :{} do
+    if Enum.all?(ref_parts, &is_atom/1) do
+      ref_name = Enum.map_join(ref_parts, ".", &Atom.to_string/1)
+      issues = check_agent_ref_violations(ast, issues, source_module, ref_name, meta, issue_meta)
+      {ast, issues}
+    else
+      {ast, issues}
+    end
+  end
+
+  defp find_violations(
+         {form, meta, _args} = ast,
+         issues,
+         source_layer,
+         source_module,
+         issue_meta
+       )
+       when source_layer != nil and form in [:def, :defp, :defmacro, :defmacrop] do
+    issues = check_direct_alias_refs(ast, issues, source_layer, source_module, meta, issue_meta)
+    {ast, issues}
+  end
+
+  defp find_violations(
+         {:%, meta, [{:__aliases__, _, ref_parts} | _]} = ast,
+         issues,
+         source_layer,
+         source_module,
+         issue_meta
+       )
+       when source_layer != nil do
+    if Enum.all?(ref_parts, &is_atom/1) do
+      ref_name = Enum.map_join(ref_parts, ".", &Atom.to_string/1)
+      issues = check_agent_ref_violations(ast, issues, source_module, ref_name, meta, issue_meta)
+      {ast, issues}
+    else
+      {ast, issues}
+    end
+  end
+
+  defp find_violations(
+         {form, meta, _args} = ast,
+         issues,
+         source_layer,
+         source_module,
+         issue_meta
+       )
+       when source_layer != nil and form in [:@, :defstruct] do
+    issues = check_direct_alias_refs(ast, issues, source_layer, source_module, meta, issue_meta)
+    {ast, issues}
+  end
+
+  defp find_violations(
+         {form, meta,
+          [
+            {{:., _, [{:__aliases__, _, base_parts}, :{}]}, _, grouped_refs}
+          ]} = ast,
+         issues,
+         source_layer,
+         source_module,
+         issue_meta
+       )
+       when form in @reference_forms and source_layer != nil do
+    if Enum.all?(base_parts, &is_atom/1) do
+      issues =
+        Enum.reduce(grouped_refs, issues, fn
+          {:__aliases__, _, ref_parts}, acc when is_list(ref_parts) ->
+            ref_name = Enum.map_join(base_parts ++ ref_parts, ".", &Atom.to_string/1)
+
+            check_ref_violations(
+              ast,
+              acc,
+              source_layer,
+              source_module,
+              ref_name,
+              meta,
+              issue_meta
+            )
+
+          _grouped_ref, acc ->
+            acc
+        end)
+
+      {ast, issues}
+    else
+      {ast, issues}
     end
   end
 
@@ -163,11 +317,75 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     if Enum.all?(ref_parts, &is_atom/1) do
       ref_name = Enum.map_join(ref_parts, ".", &Atom.to_string/1)
 
-      if cross_cutting?(ref_name) || not minga_module?(ref_name) do
-        {ast, issues}
-      else
-        target_layer = layer_for_module(ref_name)
+      issues =
+        check_ref_violations(ast, issues, source_layer, source_module, ref_name, meta, issue_meta)
 
+      {ast, issues}
+    else
+      {ast, issues}
+    end
+  end
+
+  defp find_violations(ast, issues, _source_layer, _source_module, _issue_meta),
+    do: {ast, issues}
+
+  defp check_direct_alias_refs(ast, issues, _source_layer, source_module, meta, issue_meta) do
+    ast
+    |> direct_alias_refs()
+    |> Enum.reduce(issues, fn {ref_parts, ref_meta}, acc ->
+      ref_name = Enum.map_join(ref_parts, ".", &Atom.to_string/1)
+      check_agent_ref_violations(ast, acc, source_module, ref_name, ref_meta || meta, issue_meta)
+    end)
+  end
+
+  defp direct_alias_refs(
+         {{:., _meta, [{:__aliases__, _alias_meta, _ref_parts}, _function]}, _call_meta, _args}
+       ),
+       do: []
+
+  defp direct_alias_refs({:%, _meta, [{:__aliases__, _alias_meta, _ref_parts} | _args]}), do: []
+
+  defp direct_alias_refs({:__aliases__, meta, ref_parts}) when length(ref_parts) >= 2 do
+    if Enum.all?(ref_parts, &is_atom/1), do: [{ref_parts, meta}], else: []
+  end
+
+  defp direct_alias_refs(tuple) when is_tuple(tuple),
+    do: tuple |> Tuple.to_list() |> direct_alias_refs()
+
+  defp direct_alias_refs(list) when is_list(list), do: Enum.flat_map(list, &direct_alias_refs/1)
+  defp direct_alias_refs(_), do: []
+
+  defp check_agent_ref_violations(_ast, issues, source_module, ref_name, meta, issue_meta) do
+    if cross_cutting?(ref_name) || not minga_module?(ref_name) do
+      issues
+    else
+      source_agent_level = agent_level_for_module(source_module)
+      target_agent_level = agent_level_for_module(ref_name)
+
+      case agent_level_violation(source_agent_level, target_agent_level, ref_name) do
+        {:violation, message} ->
+          issue =
+            format_issue(issue_meta,
+              message: message,
+              trigger: ref_name,
+              line_no: meta[:line]
+            )
+
+          [issue | issues]
+
+        :ok ->
+          issues
+      end
+    end
+  end
+
+  defp check_ref_violations(ast, issues, source_layer, source_module, ref_name, meta, issue_meta) do
+    if cross_cutting?(ref_name) || not minga_module?(ref_name) do
+      issues
+    else
+      target_layer = layer_for_module(ref_name)
+
+      {_ast, issues} =
         check_violation(
           ast,
           issues,
@@ -178,14 +396,10 @@ defmodule Minga.Credo.DependencyDirectionCheck do
           meta,
           issue_meta
         )
-      end
-    else
-      {ast, issues}
+
+      issues
     end
   end
-
-  defp find_violations(ast, issues, _source_layer, _source_module, _issue_meta),
-    do: {ast, issues}
 
   defp check_violation(
          ast,
@@ -197,42 +411,120 @@ defmodule Minga.Credo.DependencyDirectionCheck do
          meta,
          issue_meta
        ) do
-    cond do
-      target_layer == nil ->
-        # Unknown module, skip
-        {ast, issues}
+    source_agent_level = agent_level_for_module(source_module)
+    target_agent_level = agent_level_for_module(ref_name)
 
-      allowed_reference?(source_module, ref_name) ->
-        {ast, issues}
-
-      source_layer == 0 and target_layer > 0 ->
+    case agent_level_violation(source_agent_level, target_agent_level, ref_name) do
+      {:violation, message} ->
         issue =
           format_issue(issue_meta,
-            message:
-              "Layer violation: Layer 0 module references Layer #{target_layer} module #{ref_name}. " <>
-                "Layer 0 (pure) modules must not depend on stateful services or orchestration.",
+            message: message,
             trigger: ref_name,
             line_no: meta[:line]
           )
 
         {ast, [issue | issues]}
 
-      source_layer == 1 and target_layer == 2 ->
-        issue =
-          format_issue(issue_meta,
-            message:
-              "Layer violation: Layer 1 module references Layer 2 module #{ref_name}. " <>
-                "Services must not depend on orchestration/presentation. Pass data as arguments instead.",
-            trigger: ref_name,
-            line_no: meta[:line]
-          )
-
-        {ast, [issue | issues]}
-
-      true ->
-        {ast, issues}
+      :ok ->
+        check_top_level_violation(
+          ast,
+          issues,
+          source_layer,
+          source_module,
+          target_layer,
+          ref_name,
+          meta,
+          issue_meta
+        )
     end
   end
+
+  defp check_top_level_violation(
+         ast,
+         issues,
+         _source_layer,
+         _source_module,
+         nil,
+         _ref_name,
+         _meta,
+         _issue_meta
+       ), do: {ast, issues}
+
+  defp check_top_level_violation(
+         ast,
+         issues,
+         source_layer,
+         source_module,
+         target_layer,
+         ref_name,
+         meta,
+         issue_meta
+       ) do
+    if allowed_reference?(source_module, ref_name) do
+      {ast, issues}
+    else
+      check_top_level_direction(
+        ast,
+        issues,
+        source_layer,
+        target_layer,
+        ref_name,
+        meta,
+        issue_meta
+      )
+    end
+  end
+
+  defp check_top_level_direction(ast, issues, 0, target_layer, ref_name, meta, issue_meta)
+       when target_layer > 0 do
+    issue =
+      format_issue(issue_meta,
+        message:
+          "Layer violation: Layer 0 module references Layer #{target_layer} module #{ref_name}. " <>
+            "Layer 0 (pure) modules must not depend on stateful services or orchestration.",
+        trigger: ref_name,
+        line_no: meta[:line]
+      )
+
+    {ast, [issue | issues]}
+  end
+
+  defp check_top_level_direction(ast, issues, 1, 2, ref_name, meta, issue_meta) do
+    issue =
+      format_issue(issue_meta,
+        message:
+          "Layer violation: Layer 1 module references Layer 2 module #{ref_name}. " <>
+            "Services must not depend on orchestration/presentation. Pass data as arguments instead.",
+        trigger: ref_name,
+        line_no: meta[:line]
+      )
+
+    {ast, [issue | issues]}
+  end
+
+  defp check_top_level_direction(
+         ast,
+         issues,
+         _source_layer,
+         _target_layer,
+         _ref_name,
+         _meta,
+         _issue_meta
+       ), do: {ast, issues}
+
+  defp agent_level_violation(0, target_level, ref_name) when target_level in [1, 2] do
+    {:violation,
+     "Agent level violation: Agent Level 0 module references Agent Level #{target_level} module #{ref_name}. " <>
+       "Agent Level 0 modules are pure contracts, value types, and safety interfaces; pass data in instead of depending on runtime services or UI integrations."}
+  end
+
+  defp agent_level_violation(1, 2, ref_name) do
+    {:violation,
+     "Agent level violation: Agent Level 1 module references Agent Level 2 module #{ref_name}. " <>
+       "Agent runtime services and registries must not depend on bundled integrations or presentation modules."}
+  end
+
+  defp agent_level_violation(_source_level, _target_level, _ref_name), do: :ok
 
   defp test_file?(filename) do
     String.contains?(Path.expand(filename), "/test/")
@@ -240,14 +532,29 @@ defmodule Minga.Credo.DependencyDirectionCheck do
 
   @spec layer_for_file(String.t()) :: 0 | 1 | 2 | nil
   defp layer_for_file(filename) do
-    expanded = Path.expand(filename)
+    filename
+    |> Path.expand()
+    |> layer_for_expanded_file()
+  end
 
-    cond do
-      layer_0_file?(expanded) -> 0
-      layer_2_file?(expanded) -> 2
-      String.contains?(expanded, "/minga_agent/") -> 1
-      String.contains?(expanded, "/minga/") -> 1
-      true -> nil
+  defp layer_for_expanded_file(path) do
+    case layer_0_file?(path) do
+      true -> 0
+      false -> layer_for_non_layer_0_file(path)
+    end
+  end
+
+  defp layer_for_non_layer_0_file(path) do
+    case layer_2_file?(path) do
+      true -> 2
+      false -> layer_for_service_file(path)
+    end
+  end
+
+  defp layer_for_service_file(path) do
+    case String.contains?(path, "/minga_agent/") or String.contains?(path, "/minga/") do
+      true -> 1
+      false -> nil
     end
   end
 
@@ -268,12 +575,23 @@ defmodule Minga.Credo.DependencyDirectionCheck do
 
   @spec layer_for_module(String.t()) :: 0 | 1 | 2 | nil
   defp layer_for_module(ref_name) do
-    cond do
-      layer_0_module?(ref_name) -> 0
-      layer_2_module?(ref_name) -> 2
-      String.starts_with?(ref_name, "MingaAgent.") -> 1
-      String.starts_with?(ref_name, "Minga.") -> 1
-      true -> nil
+    case layer_0_module?(ref_name) do
+      true -> 0
+      false -> layer_for_non_layer_0_module(ref_name)
+    end
+  end
+
+  defp layer_for_non_layer_0_module(ref_name) do
+    case layer_2_module?(ref_name) do
+      true -> 2
+      false -> layer_for_service_module(ref_name)
+    end
+  end
+
+  defp layer_for_service_module(ref_name) do
+    case String.starts_with?(ref_name, "MingaAgent.") or String.starts_with?(ref_name, "Minga.") do
+      true -> 1
+      false -> nil
     end
   end
 
@@ -285,6 +603,36 @@ defmodule Minga.Credo.DependencyDirectionCheck do
 
   defp layer_2_module?(ref_name) do
     Enum.any?(@layer_2_prefixes, fn prefix ->
+      ref_name == prefix || String.starts_with?(ref_name, prefix <> ".")
+    end)
+  end
+
+  @spec agent_level_for_module(String.t() | nil) :: 0 | 1 | 2 | nil
+  defp agent_level_for_module(nil), do: nil
+
+  defp agent_level_for_module(ref_name) do
+    case agent_level_prefix_match(ref_name, @agent_level_0_prefixes) do
+      true -> 0
+      false -> agent_level_1_or_2_for_module(ref_name)
+    end
+  end
+
+  defp agent_level_1_or_2_for_module(ref_name) do
+    case agent_level_prefix_match(ref_name, @agent_level_2_prefixes) do
+      true -> 2
+      false -> agent_level_1_for_module(ref_name)
+    end
+  end
+
+  defp agent_level_1_for_module(ref_name) do
+    case agent_level_prefix_match(ref_name, @agent_level_1_prefixes) do
+      true -> 1
+      false -> nil
+    end
+  end
+
+  defp agent_level_prefix_match(ref_name, prefixes) do
+    Enum.any?(prefixes, fn prefix ->
       ref_name == prefix || String.starts_with?(ref_name, prefix <> ".")
     end)
   end
@@ -317,8 +665,33 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     end
   end
 
+  # Prefer the declared module over path reconstruction so acronym modules like
+  # RemoteAPI, MCP, and OAuth keep their exact casing for classification.
+  defp source_file_to_module_name(%SourceFile{} = source_file) do
+    source_file
+    |> SourceFile.ast()
+    |> ast_to_module_name()
+    |> case do
+      nil -> file_to_module_name(source_file.filename)
+      module_name -> module_name
+    end
+  end
+
+  defp ast_to_module_name(ast) do
+    {_ast, module_name} =
+      Macro.prewalk(ast, nil, fn
+        {:defmodule, _meta, [{:__aliases__, _, parts} | _]} = node, nil ->
+          {node, Enum.map_join(parts, ".", &Atom.to_string/1)}
+
+        node, module_name ->
+          {node, module_name}
+      end)
+
+    module_name
+  end
+
   # Convert a file path like "lib/minga/frontend/protocol.ex" to a module
-  # name like "MingaEditor.Frontend.Protocol". Used for @allowed_references lookup.
+  # name like "MingaEditor.Frontend.Protocol". Used only as a fallback.
   defp file_to_module_name(filename) do
     filename
     |> Path.expand()

--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -156,7 +156,10 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     # Diagnostics decoration maps severities to presentation gutter faces.
     "Minga.Diagnostics.Decorations" => ["MingaEditor.UI.Theme.Gutter"],
     # Buffer state uses typed config option aliases while the option registry remains stateful.
-    "Minga.Buffer.State" => ["Minga.Config.Options"]
+    "Minga.Buffer.State" => ["Minga.Config.Options"],
+    # CLI/API are public entry-point bridges that call the running editor process.
+    "Minga.CLI" => ["MingaEditor"],
+    "Minga.API" => ["MingaEditor"]
     # All pre-existing cross-layer violations from #1368 have been resolved
     # in Wave 6 Track B. Modules were moved to their correct layers:
     # - Devicon → Minga.Language.Devicon
@@ -394,7 +397,7 @@ defmodule Minga.Credo.DependencyDirectionCheck do
 
   defp direct_alias_refs({:%, _meta, [{:__aliases__, _alias_meta, _ref_parts} | _args]}), do: []
 
-  defp direct_alias_refs({:__aliases__, meta, ref_parts}) when length(ref_parts) >= 2 do
+  defp direct_alias_refs({:__aliases__, meta, ref_parts}) when length(ref_parts) >= 1 do
     if Enum.all?(ref_parts, &is_atom/1), do: [{ref_parts, meta}], else: []
   end
 
@@ -616,7 +619,8 @@ defmodule Minga.Credo.DependencyDirectionCheck do
   end
 
   defp layer_for_service_module(ref_name) do
-    case String.starts_with?(ref_name, "MingaAgent.") or String.starts_with?(ref_name, "Minga.") do
+    case ref_name in ["Minga", "MingaAgent"] or String.starts_with?(ref_name, "MingaAgent.") or
+           String.starts_with?(ref_name, "Minga.") do
       true -> 1
       false -> nil
     end
@@ -671,7 +675,8 @@ defmodule Minga.Credo.DependencyDirectionCheck do
   end
 
   defp minga_module?(ref_name) do
-    String.starts_with?(ref_name, "Minga.") ||
+    ref_name in ["Minga", "MingaEditor", "MingaAgent"] ||
+      String.starts_with?(ref_name, "Minga.") ||
       String.starts_with?(ref_name, "MingaEditor.") ||
       String.starts_with?(ref_name, "MingaAgent.")
   end

--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -70,8 +70,11 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     "Minga.Core",
     "Minga.Mode",
     "Minga.RenderModel",
+    "Minga.Diagnostics.Diagnostic",
+    "Minga.Language.Highlight.InjectionRange",
     "Minga.Command.Parser",
     "Minga.Keymap.Bindings",
+    "Minga.Keymap.SharedGroups",
     "Minga.Keymap.KeyParser",
     "Minga.Keymap.NormalPrefixes",
     "Minga.Keymap.Sigil",
@@ -127,7 +130,11 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     # The command modules own execution, while the registry only indexes providers.
     "Minga.Command.Registry" => ["MingaEditor.Commands"],
     # Runtime supervisors assemble the editor process tree at the OTP boundary.
-    "Minga.Runtime.Supervisor" => ["MingaEditor.Supervisor", "MingaEditor.Watchdog"],
+    "Minga.Runtime.Supervisor" => [
+      "MingaEditor.Supervisor",
+      "MingaEditor.Watchdog",
+      "MingaEditor.Frontend.Manager"
+    ],
     # Services.Supervisor starts extension contribution registries and built-in extension surfaces.
     "Minga.Services.Supervisor" => ["MingaEditor.Extension.Sidebar"],
     # SystemObserver displays the editor supervisor tree as process topology data.
@@ -135,7 +142,21 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     # Built-in theme packs register concrete presentation theme modules as data.
     "Minga.Extensions.ThemePacks.Catppuccin" => ["MingaEditor.UI.Theme"],
     "Minga.Extensions.ThemePacks.Doom" => ["MingaEditor.UI.Theme"],
-    "Minga.Extensions.ThemePacks.One" => ["MingaEditor.UI.Theme"]
+    "Minga.Extensions.ThemePacks.One" => ["MingaEditor.UI.Theme"],
+    # Editing operators call the Buffer facade for existing edit operations; Buffer.Process remains separately blocked.
+    "Minga.Editing.Operator" => ["Minga.Buffer"],
+    # Mode exposes recipe labels through the existing recipe registry bridge.
+    "Minga.Mode" => ["Minga.Tool.Recipe.Registry"],
+    # Editing facade preserves existing macro-recorder helpers until that UI state moves behind a lower-level query.
+    "Minga.Editing" => ["MingaEditor.MacroRecorder"],
+    # Application supervisor starts shell registry at the OTP boundary.
+    "Minga.Application" => ["MingaEditor.Shell.Registry"],
+    # Session persistence currently references the editor state snapshot type.
+    "Minga.Session" => ["MingaEditor.State"],
+    # Diagnostics decoration maps severities to presentation gutter faces.
+    "Minga.Diagnostics.Decorations" => ["MingaEditor.UI.Theme.Gutter"],
+    # Buffer state uses typed config option aliases while the option registry remains stateful.
+    "Minga.Buffer.State" => ["Minga.Config.Options"]
     # All pre-existing cross-layer violations from #1368 have been resolved
     # in Wave 6 Track B. Modules were moved to their correct layers:
     # - Devicon → Minga.Language.Devicon
@@ -234,7 +255,10 @@ defmodule Minga.Credo.DependencyDirectionCheck do
        when source_layer != nil and function != :{} do
     if Enum.all?(ref_parts, &is_atom/1) do
       ref_name = Enum.map_join(ref_parts, ".", &Atom.to_string/1)
-      issues = check_agent_ref_violations(ast, issues, source_module, ref_name, meta, issue_meta)
+
+      issues =
+        check_ref_violations(ast, issues, source_layer, source_module, ref_name, meta, issue_meta)
+
       {ast, issues}
     else
       {ast, issues}
@@ -263,7 +287,10 @@ defmodule Minga.Credo.DependencyDirectionCheck do
        when source_layer != nil do
     if Enum.all?(ref_parts, &is_atom/1) do
       ref_name = Enum.map_join(ref_parts, ".", &Atom.to_string/1)
-      issues = check_agent_ref_violations(ast, issues, source_module, ref_name, meta, issue_meta)
+
+      issues =
+        check_ref_violations(ast, issues, source_layer, source_module, ref_name, meta, issue_meta)
+
       {ast, issues}
     else
       {ast, issues}
@@ -376,30 +403,6 @@ defmodule Minga.Credo.DependencyDirectionCheck do
 
   defp direct_alias_refs(list) when is_list(list), do: Enum.flat_map(list, &direct_alias_refs/1)
   defp direct_alias_refs(_), do: []
-
-  defp check_agent_ref_violations(_ast, issues, source_module, ref_name, meta, issue_meta) do
-    if cross_cutting?(ref_name) || not minga_module?(ref_name) do
-      issues
-    else
-      source_agent_level = agent_level_for_module(source_module)
-      target_agent_level = agent_level_for_module(ref_name)
-
-      case agent_level_violation(source_agent_level, target_agent_level, ref_name) do
-        {:violation, message} ->
-          issue =
-            format_issue(issue_meta,
-              message: message,
-              trigger: ref_name,
-              line_no: meta[:line]
-            )
-
-          [issue | issues]
-
-        :ok ->
-          issues
-      end
-    end
-  end
 
   defp check_ref_violations(ast, issues, source_layer, source_module, ref_name, meta, issue_meta) do
     if cross_cutting?(ref_name) || not minga_module?(ref_name) do

--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -122,7 +122,20 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     "MingaEditor.Frontend.Protocol" => ["MingaEditor.Frontend.Protocol.GUI"],
     # Frontend facade calls Protocol.GUI for GUI-specific config encoding
     # (line spacing, etc.). Same structural dispatch pattern.
-    "MingaEditor.Frontend" => ["MingaEditor.Frontend.Protocol.GUI"]
+    "MingaEditor.Frontend" => ["MingaEditor.Frontend.Protocol.GUI"],
+    # Command.Registry keeps the compile-time command provider module list.
+    # The command modules own execution, while the registry only indexes providers.
+    "Minga.Command.Registry" => ["MingaEditor.Commands"],
+    # Runtime supervisors assemble the editor process tree at the OTP boundary.
+    "Minga.Runtime.Supervisor" => ["MingaEditor.Supervisor", "MingaEditor.Watchdog"],
+    # Services.Supervisor starts extension contribution registries and built-in extension surfaces.
+    "Minga.Services.Supervisor" => ["MingaEditor.Extension.Sidebar"],
+    # SystemObserver displays the editor supervisor tree as process topology data.
+    "Minga.SystemObserver" => ["MingaEditor.Supervisor"],
+    # Built-in theme packs register concrete presentation theme modules as data.
+    "Minga.Extensions.ThemePacks.Catppuccin" => ["MingaEditor.UI.Theme"],
+    "Minga.Extensions.ThemePacks.Doom" => ["MingaEditor.UI.Theme"],
+    "Minga.Extensions.ThemePacks.One" => ["MingaEditor.UI.Theme"]
     # All pre-existing cross-layer violations from #1368 have been resolved
     # in Wave 6 Track B. Modules were moved to their correct layers:
     # - Devicon → Minga.Language.Devicon
@@ -329,12 +342,21 @@ defmodule Minga.Credo.DependencyDirectionCheck do
   defp find_violations(ast, issues, _source_layer, _source_module, _issue_meta),
     do: {ast, issues}
 
-  defp check_direct_alias_refs(ast, issues, _source_layer, source_module, meta, issue_meta) do
+  defp check_direct_alias_refs(ast, issues, source_layer, source_module, meta, issue_meta) do
     ast
     |> direct_alias_refs()
     |> Enum.reduce(issues, fn {ref_parts, ref_meta}, acc ->
       ref_name = Enum.map_join(ref_parts, ".", &Atom.to_string/1)
-      check_agent_ref_violations(ast, acc, source_module, ref_name, ref_meta || meta, issue_meta)
+
+      check_ref_violations(
+        ast,
+        acc,
+        source_layer,
+        source_module,
+        ref_name,
+        ref_meta || meta,
+        issue_meta
+      )
     end)
   end
 
@@ -448,7 +470,8 @@ defmodule Minga.Credo.DependencyDirectionCheck do
          _ref_name,
          _meta,
          _issue_meta
-       ), do: {ast, issues}
+       ),
+       do: {ast, issues}
 
   defp check_top_level_violation(
          ast,
@@ -510,7 +533,8 @@ defmodule Minga.Credo.DependencyDirectionCheck do
          _ref_name,
          _meta,
          _issue_meta
-       ), do: {ast, issues}
+       ),
+       do: {ast, issues}
 
   defp agent_level_violation(0, target_level, ref_name) when target_level in [1, 2] do
     {:violation,

--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -235,7 +235,7 @@ defmodule Minga.Credo.DependencyDirectionCheck do
          source_module,
          issue_meta
        )
-       when source_layer != nil and form in [:def, :defp, :defmacro, :defmacrop] do
+       when source_layer != nil and form in [:def, :defp, :defmacro, :defmacrop, :defdelegate] do
     issues = check_direct_alias_refs(ast, issues, source_layer, source_module, meta, issue_meta)
     {ast, issues}
   end

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -719,6 +719,28 @@ This isn't just organization for readability. A credo check (`Minga.Credo.Depend
 
 The practical benefit: `Minga.Runtime.start/1` boots Layers 0 and 1 without any frontend. Agent sessions run, tools execute, buffers exist, all without a single pixel rendered. External clients connect through the API gateway and interact with a fully functional runtime.
 
+## MingaAgent Internal Levels
+
+Epic [#2075](https://github.com/jsmestad/minga/issues/2075) adds a second dependency map inside the agent platform. The top-level namespace rule still applies: `MingaAgent.*` must not depend on `MingaEditor.*`. The internal rule answers a more specific question: when provider, tool, MCP, and UI integrations become optional packs, which agent modules are safe to import from which other agent modules?
+
+Dependencies flow downward only:
+
+```
+Agent Level 0: contracts, value types, and safety interfaces
+Agent Level 1: runtime services, registries, and core safety execution
+Agent Level 2: bundled integrations, adapters, and agent presentation surfaces
+```
+
+**Agent Level 0** contains pure contracts and payloads. These modules define shapes and safety interfaces but do not start processes, look up extension contributions, read credentials, execute tools, or render UI. Current examples: `MingaAgent.Provider`, `MingaAgent.Tool.Spec`, `MingaAgent.Event`, `MingaAgent.Message`, `MingaAgent.ToolCall`, `MingaAgent.TurnUsage`, `MingaAgent.Hooks.*Payload`, `MingaAgent.MCP.ServerConfig`, `MingaAgent.MCP.Tool`, `MingaAgent.RuntimeState`, `MingaAgent.Subagent.Handle`, `MingaAgent.ToolApproval.Preview`, `MingaEditor.Agent.SlashCommand.Command`, and the compile-time declaration DSL in `Minga.Extension.Agent`.
+
+**Agent Level 1** contains core runtime services and source-owned safety boundaries. These modules may depend on Level 0, but they must not depend on bundled packs or presentation modules. Current examples: `MingaAgent.Session`, `MingaAgent.SessionManager`, `MingaAgent.SessionMetadata`, `MingaAgent.SubagentContext`, `MingaAgent.Supervisor`, `MingaAgent.Runtime`, `MingaAgent.Config`, `MingaAgent.ContextArtifact`, `MingaAgent.Retry`, `MingaAgent.Tool.Registry`, `MingaAgent.Tool.Executor`, `MingaAgent.ToolRouter`, `MingaAgent.ProjectView`, `MingaAgent.Changeset`, `MingaAgent.Credentials`, `MingaAgent.Hooks.Dispatcher`, `MingaAgent.MCP.Registry`, `MingaAgent.EventLog`, `MingaAgent.Gateway.*`, `MingaAgent.RemoteAPI`, and the extension-facing runtime facade `Minga.Extension.AgentAPI`.
+
+**Agent Level 2** contains code that adapts the core runtime into a concrete integration or user-facing agent surface. Current presentation examples live under `MingaEditor.Agent.*`, including `MingaEditor.Agent.UIState`, `MingaEditor.Agent.Events`, `MingaEditor.Agent.View.*`, `MingaEditor.Agent.DiffReview`, `MingaEditor.Agent.DiffRenderer`, and `MingaEditor.Agent.SlashCommand`. Provider adapters, read-only tool packs, LSP/Git/MCP packs, and semantic agent UI packs are target Level 2 modules as they are extracted by later #2075 child tickets. Today, several native providers and built-in tools remain Level 1 because the registry and context-bound execution boundaries they need have not landed yet.
+
+The custom Credo check `Minga.Credo.DependencyDirectionCheck` enforces both maps. It flags Agent Level 0 references to Level 1 or 2 and Agent Level 1 references to Level 2. The check intentionally uses prefix lists so later extraction tickets can move a module group from Level 1 to Level 2 without rewriting the check.
+
+Safety-critical ownership does not move to optional packs. Credentials, approval, plan-mode refusal, retry, cost, compaction, session orchestration, event and message types, `MingaAgent.ToolRouter`, changesets, buffer forks, and edit boundaries stay in Level 0 or Level 1.
+
 ---
 
 ## State Scope: Daemon-Singleton vs Per-Editor

--- a/test/minga/credo/dependency_direction_check_test.exs
+++ b/test/minga/credo/dependency_direction_check_test.exs
@@ -101,6 +101,196 @@ defmodule Minga.Credo.DependencyDirectionCheckTest do
     end
   end
 
+  describe "MingaAgent internal level violations" do
+    test "flags Agent Level 0 contracts depending on Agent Level 1 runtime services" do
+      """
+      defmodule MingaAgent.Tool.Spec do
+        alias MingaAgent.Tool.Registry
+      end
+      """
+      |> check("lib/minga_agent/tool/spec.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 1"
+      end)
+    end
+
+    test "flags Agent Level 0 extension payloads depending on Agent Level 2 presentation" do
+      """
+      defmodule MingaEditor.Agent.SlashCommand.Command do
+        alias MingaEditor.Agent.UIState
+      end
+      """
+      |> check("lib/minga_editor/agent/slash_command/command.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 2"
+      end)
+    end
+
+    test "flags Agent Level 1 runtime services depending on Agent Level 2 presentation" do
+      """
+      defmodule MingaAgent.Session do
+        alias MingaEditor.Agent.UIState
+      end
+      """
+      |> check("lib/minga_agent/session.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 1"
+        assert issue.message =~ "Agent Level 2"
+      end)
+    end
+
+    test "uses declared acronym module names for source classification" do
+      """
+      defmodule MingaAgent.MCP.Tool do
+        alias MingaAgent.MCP.Registry
+      end
+      """
+      |> check("lib/minga_agent/mcp/tool.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 1"
+      end)
+    end
+
+    test "flags grouped aliases that cross Agent levels" do
+      """
+      defmodule MingaAgent.Tool.Spec do
+        alias MingaAgent.Tool.{Registry, Spec}
+      end
+      """
+      |> check("lib/minga_agent/tool/spec.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 1"
+      end)
+    end
+
+    test "flags direct remote calls that cross Agent levels" do
+      """
+      defmodule MingaAgent.Event do
+        @type t :: %{status: MingaAgent.Session.status()}
+      end
+      """
+      |> check("lib/minga_agent/event.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 1"
+      end)
+    end
+
+    test "flags direct module literals that cross Agent levels" do
+      """
+      defmodule MingaAgent.Event do
+        @default_provider MingaAgent.Providers.Native
+      end
+      """
+      |> check("lib/minga_agent/event.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 1"
+      end)
+    end
+
+    test "flags two-segment direct module literals that cross Agent levels" do
+      """
+      defmodule MingaAgent.Event do
+        @config MingaAgent.Config
+      end
+      """
+      |> check("lib/minga_agent/event.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 1"
+      end)
+    end
+
+    test "flags direct struct literals that cross Agent levels" do
+      """
+      defmodule MingaAgent.Event do
+        def new_config, do: %MingaAgent.Config{}
+      end
+      """
+      |> check("lib/minga_agent/event.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 1"
+      end)
+    end
+
+    test "flags bare module literals in function bodies that cross Agent levels" do
+      """
+      defmodule MingaAgent.Event do
+        def default_provider, do: MingaAgent.Providers.Native
+      end
+      """
+      |> check("lib/minga_agent/event.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 1"
+      end)
+    end
+
+    test "reports struct types in attributes only once" do
+      """
+      defmodule MingaAgent.Event do
+        @type t :: %MingaAgent.Config{}
+      end
+      """
+      |> check("lib/minga_agent/event.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 1"
+      end)
+    end
+
+    test "flags Level 0 editor payloads depending on non-agent editor presentation" do
+      """
+      defmodule MingaEditor.Agent.SlashCommand.Command do
+        alias MingaEditor.State
+      end
+      """
+      |> check("lib/minga_editor/agent/slash_command/command.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 2"
+      end)
+    end
+  end
+
+  describe "MingaAgent valid internal dependencies" do
+    test "Agent Level 1 runtime services may depend on Agent Level 0 contracts" do
+      """
+      defmodule MingaAgent.Tool.Registry do
+        alias MingaAgent.Tool.Spec
+      end
+      """
+      |> check("lib/minga_agent/tool/registry.ex")
+      |> refute_issues()
+    end
+
+    test "Agent Level 2 presentation may depend on Agent Level 1 runtime services" do
+      """
+      defmodule MingaEditor.Agent.Events do
+        alias MingaAgent.Session
+      end
+      """
+      |> check("lib/minga_editor/agent/events.ex")
+      |> refute_issues()
+    end
+
+    test "Agent Level 0 contracts may depend on Agent Level 0 value types" do
+      """
+      defmodule MingaAgent.Event do
+        alias MingaAgent.TurnUsage
+      end
+      """
+      |> check("lib/minga_agent/event.ex")
+      |> refute_issues()
+    end
+  end
+
   describe "valid downward dependencies" do
     test "Layer 2 may depend on Layer 1" do
       """

--- a/test/minga/credo/dependency_direction_check_test.exs
+++ b/test/minga/credo/dependency_direction_check_test.exs
@@ -140,6 +140,34 @@ defmodule Minga.Credo.DependencyDirectionCheckTest do
       end)
     end
 
+    test "flags root module literals that cross top-level layers" do
+      """
+      defmodule Minga.Buffer.Document do
+        @editor MingaEditor
+      end
+      """
+      |> check("lib/minga/buffer/document.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Layer 0"
+        assert issue.message =~ "Layer 2"
+        assert issue.trigger == "MingaEditor"
+      end)
+    end
+
+    test "flags root module defdelegate targets that cross top-level layers" do
+      """
+      defmodule Minga.Buffer.Document do
+        defdelegate start_link(opts), to: MingaEditor
+      end
+      """
+      |> check("lib/minga/buffer/document.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Layer 0"
+        assert issue.message =~ "Layer 2"
+        assert issue.trigger == "MingaEditor"
+      end)
+    end
+
     test "flags Git module depending on Input handler" do
       """
       defmodule Minga.Git.Tracker do

--- a/test/minga/credo/dependency_direction_check_test.exs
+++ b/test/minga/credo/dependency_direction_check_test.exs
@@ -167,6 +167,34 @@ defmodule Minga.Credo.DependencyDirectionCheckTest do
       end)
     end
 
+    test "flags defdelegate targets that cross Agent Level 0 to Level 1" do
+      """
+      defmodule MingaAgent.Event do
+        defdelegate start_session(opts), to: MingaAgent.Session
+      end
+      """
+      |> check("lib/minga_agent/event.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 0"
+        assert issue.message =~ "Agent Level 1"
+        assert issue.trigger == "MingaAgent.Session"
+      end)
+    end
+
+    test "flags defdelegate targets that cross Agent Level 1 to Level 2" do
+      """
+      defmodule MingaAgent.Session do
+        defdelegate render(state), to: MingaEditor.Agent.UIState
+      end
+      """
+      |> check("lib/minga_agent/session.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Agent Level 1"
+        assert issue.message =~ "Agent Level 2"
+        assert issue.trigger == "MingaEditor.Agent.UIState"
+      end)
+    end
+
     test "flags direct remote calls that cross Agent levels" do
       """
       defmodule MingaAgent.Event do

--- a/test/minga/credo/dependency_direction_check_test.exs
+++ b/test/minga/credo/dependency_direction_check_test.exs
@@ -80,6 +80,34 @@ defmodule Minga.Credo.DependencyDirectionCheckTest do
       end)
     end
 
+    test "flags pure Layer 0 modules delegating to Layer 1 process modules" do
+      """
+      defmodule Minga.Buffer.Document do
+        defdelegate start_link(opts), to: Minga.Buffer.Process
+      end
+      """
+      |> check("lib/minga/buffer/document.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Layer 0"
+        assert issue.message =~ "Layer 1"
+        assert issue.trigger == "Minga.Buffer.Process"
+      end)
+    end
+
+    test "flags direct module literals that cross top-level layers" do
+      """
+      defmodule Minga.Buffer.Document do
+        @default_state MingaEditor.State
+      end
+      """
+      |> check("lib/minga/buffer/document.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Layer 0"
+        assert issue.message =~ "Layer 2"
+        assert issue.trigger == "MingaEditor.State"
+      end)
+    end
+
     test "flags Git module depending on Input handler" do
       """
       defmodule Minga.Git.Tracker do

--- a/test/minga/credo/dependency_direction_check_test.exs
+++ b/test/minga/credo/dependency_direction_check_test.exs
@@ -108,6 +108,38 @@ defmodule Minga.Credo.DependencyDirectionCheckTest do
       end)
     end
 
+    test "flags direct remote calls that cross top-level layers" do
+      """
+      defmodule Minga.Buffer.Document do
+        def render(state) do
+          MingaEditor.State.render(state)
+        end
+      end
+      """
+      |> check("lib/minga/buffer/document.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Layer 0"
+        assert issue.message =~ "Layer 2"
+        assert issue.trigger == "MingaEditor.State"
+      end)
+    end
+
+    test "flags struct literals that cross top-level layers" do
+      """
+      defmodule Minga.Buffer.Document do
+        def new_state do
+          %MingaEditor.State{}
+        end
+      end
+      """
+      |> check("lib/minga/buffer/document.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Layer 0"
+        assert issue.message =~ "Layer 2"
+        assert issue.trigger == "MingaEditor.State"
+      end)
+    end
+
     test "flags Git module depending on Input handler" do
       """
       defmodule Minga.Git.Tracker do


### PR DESCRIPTION
# TL;DR
This PR makes the MingaAgent Level 0/1/2 dependency model enforceable before any optional integration extraction starts. It documents the current classification and extends the existing custom Credo check so upward dependencies fail with focused regression coverage.

Closes #2076

## Context
This is the first child ticket for #2075. The goal is to establish enforceable boundaries before later tickets introduce source-owned registries, code leases, provider/tool extraction, and optional packs.

## Changes
- Added the MingaAgent internal Level 0/1/2 model to `AGENTS.md` and `docs/ARCHITECTURE.md`, with the current module-prefix classification for agent contracts, runtime services, and bundled/presentation surfaces.
- Extended `Minga.Credo.DependencyDirectionCheck` with agent-specific level checks in addition to the existing top-level `Minga.*`, `MingaAgent.*`, and `MingaEditor.*` layering.
- Switched the check to derive source modules from the parsed AST so acronym modules such as `MCP`, `OAuth`, and `RemoteAPI` classify correctly.
- Added coverage for allowed and disallowed agent dependencies, grouped aliases, direct remote calls, module literals, struct literals, acronym module names, and `MingaEditor.*` Level 2 behavior.
- Kept current built-in providers and tools mostly classified as Level 1 for now. Later child tickets can tighten the map as registry boundaries and optional packs land.

## Verification
- `mix test.debug test/minga/credo/dependency_direction_check_test.exs`
- `mix credo --strict --checks Minga.Credo.DependencyDirectionCheck`
- `mix test.debug test/minga_editor/merge_conflict/render_test.exs:114`
- `mix test.llm test/minga_editor/merge_conflict/render_test.exs`
- `make lint`
- `mix test.llm`
- Final targeted reviewer gate: PASS

## Acceptance Criteria Addressed
- MingaAgent Level 0, Level 1, and Level 2 model is documented in the repo and linked back to #2075. ✅
- Current agent-related modules are classified into levels, including `MingaAgent.*`, relevant `MingaEditor.Agent.*`, and extension-facing agent modules. ✅
- A custom Credo check prevents upward dependencies for the classified namespaces. ✅
- The check has focused validation coverage proving allowed and disallowed dependency examples. ✅
- `make lint` passes. ✅
