### PR TITLE
Render themed semantic picker in Rust TUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,50 @@ jobs:
       - name: Run Zig tests
         run: cd zig && zig build test
 
+  test-rust-tui:
+    name: Test (Rust TUI)
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+
+      - name: Cache deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: rust-tui-deps-${{ runner.os }}-${{ hashFiles('.tool-versions') }}-${{ hashFiles('mix.lock') }}
+          restore-keys: rust-tui-deps-${{ runner.os }}-${{ hashFiles('.tool-versions') }}-
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/tui/target
+          key: rust-tui-cargo-${{ runner.os }}-${{ hashFiles('rust/tui/Cargo.lock') }}
+          restore-keys: rust-tui-cargo-${{ runner.os }}-
+
+      - run: mix deps.get
+      - run: mix protocol.gen
+
+      - name: Check Rust formatting
+        run: cargo fmt --manifest-path rust/tui/Cargo.toml --check
+
+      - name: Run Rust tests
+        run: cargo test --manifest-path rust/tui/Cargo.toml
+
+      - name: Run Rust clippy
+        run: cargo clippy --manifest-path rust/tui/Cargo.toml -- -D warnings
+
   test-go-tui:
     name: Test (Go TUI)
     runs-on: ubuntu-latest

--- a/rust/tui/src/renderer.rs
+++ b/rust/tui/src/renderer.rs
@@ -398,13 +398,20 @@ impl Renderer {
         }
 
         let first_row = row.saturating_sub(candidate_count as u16);
+        let selected_index = minibuffer.selected_index as usize;
+        let start_index = selected_index
+            .saturating_add(1)
+            .saturating_sub(candidate_count)
+            .min(minibuffer.candidates.len().saturating_sub(candidate_count));
         for (index, candidate) in minibuffer
             .candidates
             .iter()
+            .skip(start_index)
             .take(candidate_count)
             .enumerate()
         {
-            let selected = index as u16 == minibuffer.selected_index;
+            let candidate_index = start_index + index;
+            let selected = candidate_index == selected_index;
             let annotation = if candidate.annotation.is_empty() {
                 String::new()
             } else {
@@ -1593,6 +1600,38 @@ mod tests {
         assert_eq!(renderer.cursor, (2, 8));
         assert_eq!(renderer.cells[renderer.index(0, 7).unwrap()].text, ">");
         assert_eq!(renderer.cells[renderer.index(2, 7).unwrap()].text, "w");
+        assert_eq!(
+            renderer.cells[renderer.index(0, 7).unwrap()].style.bg,
+            0x4C566A
+        );
+    }
+
+    #[test]
+    fn semantic_minibuffer_scrolls_candidates_to_selection() {
+        let mut renderer = Renderer::new(40, 10);
+
+        renderer.draw_minibuffer(semantic::Minibuffer {
+            visible: true,
+            mode: 0,
+            cursor_pos: 1,
+            prompt: ":".to_owned(),
+            input: "b".to_owned(),
+            context: String::new(),
+            selected_index: 5,
+            total_candidates: 6,
+            candidates: (0..6)
+                .map(|index| semantic::MinibufferCandidate {
+                    label: format!("command-{index}"),
+                    description: String::new(),
+                    annotation: String::new(),
+                })
+                .collect(),
+        });
+
+        assert_eq!(renderer.cells[renderer.index(2, 3).unwrap()].text, "c");
+        assert_eq!(renderer.cells[renderer.index(10, 3).unwrap()].text, "1");
+        assert_eq!(renderer.cells[renderer.index(0, 7).unwrap()].text, ">");
+        assert_eq!(renderer.cells[renderer.index(10, 7).unwrap()].text, "5");
         assert_eq!(
             renderer.cells[renderer.index(0, 7).unwrap()].style.bg,
             0x4C566A

--- a/rust/tui/src/renderer.rs
+++ b/rust/tui/src/renderer.rs
@@ -10,6 +10,11 @@ struct Cell {
     style: CellStyle,
 }
 
+#[derive(Debug, Clone, Default)]
+struct ThemePalette {
+    slots: HashMap<u8, u32>,
+}
+
 impl Default for Cell {
     fn default() -> Self {
         Self {
@@ -30,6 +35,9 @@ pub struct Renderer {
     regions: HashMap<u16, Region>,
     active_region: Option<Region>,
     file_tree: Option<semantic::FileTree>,
+    picker: Option<semantic::Picker>,
+    picker_preview: Option<semantic::PickerPreview>,
+    theme: ThemePalette,
 }
 
 impl Renderer {
@@ -46,6 +54,9 @@ impl Renderer {
             regions: HashMap::new(),
             active_region: None,
             file_tree: None,
+            picker: None,
+            picker_preview: None,
+            theme: ThemePalette::default(),
         }
     }
 
@@ -110,6 +121,8 @@ impl Renderer {
         self.regions.clear();
         self.active_region = None;
         self.file_tree = None;
+        self.picker = None;
+        self.picker_preview = None;
     }
 
     fn clear(&mut self) {
@@ -172,6 +185,10 @@ impl Renderer {
             semantic::Command::FileTreeSelection(selection, _) => {
                 self.update_file_tree_selection(selection)
             }
+            semantic::Command::Picker(picker, _) => self.draw_picker(picker),
+            semantic::Command::PickerPreview(preview, _) => self.draw_picker_preview(preview),
+            semantic::Command::Minibuffer(minibuffer, _) => self.draw_minibuffer(minibuffer),
+            semantic::Command::Theme(theme, _) => self.apply_theme(theme),
             semantic::Command::Unsupported { .. } => {}
         }
     }
@@ -219,6 +236,12 @@ impl Renderer {
         }
     }
 
+    fn apply_theme(&mut self, theme: semantic::Theme) {
+        self.theme = ThemePalette::from_theme(theme);
+        self.default_bg = self.theme.color(SLOT_EDITOR_BG, self.default_bg);
+        self.fill_bg(self.default_bg);
+    }
+
     fn draw_status_bar(&mut self, status: semantic::StatusBar) {
         if self.height == 0 {
             return;
@@ -239,13 +262,7 @@ impl Renderer {
             join_status_segments(&status.right_segments)
         };
 
-        let style = CellStyle {
-            fg: 0xD8DEE9,
-            bg: 0x2E3440,
-            attrs: protocol::ATTR_BOLD,
-            ul_color: 0,
-            blend: 100,
-        };
+        let style = self.theme.status_bar_style();
 
         self.write_run(row, 0, &pad_to_width(&left, self.width), style);
 
@@ -273,24 +290,7 @@ impl Renderer {
             } else {
                 format!(" {} ", tab.label)
             };
-            let bg = if tab.active { 0x3B4252 } else { 0x242933 };
-            let fg = if tab.tint == 0 {
-                0xD8DEE9
-            } else {
-                tab.tint & 0x00FF_FFFF
-            };
-            self.write_run(
-                0,
-                col,
-                &label,
-                CellStyle {
-                    fg,
-                    bg,
-                    attrs: if tab.active { protocol::ATTR_BOLD } else { 0 },
-                    ul_color: 0,
-                    blend: 100,
-                },
-            );
+            self.write_run(0, col, &label, self.theme.tab_style(tab.active, tab.tint));
             col = col.saturating_add(text_width(&label));
         }
     }
@@ -308,6 +308,277 @@ impl Renderer {
         self.render_file_tree();
     }
 
+    fn draw_picker(&mut self, picker: semantic::Picker) {
+        if picker.visible {
+            self.picker = Some(picker);
+            self.render_picker();
+        } else {
+            self.picker = None;
+            self.picker_preview = None;
+        }
+    }
+
+    fn draw_picker_preview(&mut self, preview: semantic::PickerPreview) {
+        if preview.visible {
+            self.picker_preview = Some(preview);
+        } else {
+            self.picker_preview = None;
+        }
+        self.render_picker();
+    }
+
+    fn draw_minibuffer(&mut self, minibuffer: semantic::Minibuffer) {
+        if !minibuffer.visible || self.height < 2 || self.width == 0 {
+            return;
+        }
+
+        let row = self.height.saturating_sub(2);
+        let prompt = format!("{}{}", minibuffer.prompt, minibuffer.input);
+        self.write_run(
+            row,
+            0,
+            &pad_to_width(&prompt, self.width),
+            self.theme.minibuffer_style(false),
+        );
+        self.cursor = (
+            text_width(&minibuffer.prompt).saturating_add(minibuffer.cursor_pos),
+            row,
+        );
+
+        if !minibuffer.context.is_empty() && row > 0 {
+            self.write_run(
+                row - 1,
+                0,
+                &pad_to_width(&format!(" {}", minibuffer.context), self.width),
+                self.theme.minibuffer_context_style(),
+            );
+        }
+
+        let candidate_count = minibuffer.candidates.len().min(5);
+        if candidate_count == 0 || row == 0 {
+            return;
+        }
+
+        let first_row = row.saturating_sub(candidate_count as u16);
+        for (index, candidate) in minibuffer
+            .candidates
+            .iter()
+            .take(candidate_count)
+            .enumerate()
+        {
+            let selected = index as u16 == minibuffer.selected_index;
+            let annotation = if candidate.annotation.is_empty() {
+                String::new()
+            } else {
+                format!("  {}", candidate.annotation)
+            };
+            let description = if candidate.description.is_empty() {
+                String::new()
+            } else {
+                format!(" - {}", candidate.description)
+            };
+            let marker = if selected { ">" } else { " " };
+            let text = format!("{marker} {}{}{}", candidate.label, annotation, description);
+            self.write_run(
+                first_row + index as u16,
+                0,
+                &pad_to_width(&text, self.width),
+                self.theme.minibuffer_style(selected),
+            );
+        }
+    }
+
+    fn render_picker(&mut self) {
+        let Some(picker) = self.picker.clone() else {
+            return;
+        };
+        if !picker.visible || self.width < 24 || self.height < 8 {
+            return;
+        }
+
+        let preview = self.picker_preview.clone();
+        let (row, col, width, height) = picker_geometry(self.width, self.height);
+        self.fill_rect(row, col, width, height, self.theme.picker_style(false));
+
+        let title = if picker.mode_prefix.is_empty() {
+            picker.title.clone()
+        } else {
+            format!("{} {}", picker.mode_prefix, picker.title)
+        };
+        self.write_run(
+            row,
+            col,
+            &pad_to_width(&title, width),
+            self.theme.picker_header_style(),
+        );
+
+        let count = if picker.total_count == 0 {
+            String::new()
+        } else {
+            format!("{} / {}", picker.filtered_count, picker.total_count)
+        };
+        let count_width = text_width(&count);
+        if count_width > 0 && count_width < width {
+            self.write_run(
+                row,
+                col + width - count_width - 1,
+                &count,
+                self.theme.picker_header_style(),
+            );
+        }
+
+        let query = if picker.query.is_empty() {
+            "> ".to_owned()
+        } else {
+            format!("> {}", picker.query)
+        };
+        self.write_run(
+            row + 1,
+            col,
+            &pad_to_width(&query, width),
+            self.theme.picker_query_style(),
+        );
+
+        let body_row = row + 2;
+        let body_height = height.saturating_sub(2);
+        let wants_preview = picker.has_preview && preview.as_ref().is_some_and(|p| p.visible);
+        let preview_width = if wants_preview { width / 2 } else { 0 };
+        let item_width = width.saturating_sub(preview_width);
+
+        self.render_picker_items(body_row, col, item_width, body_height, &picker);
+
+        if wants_preview && preview_width > 8 {
+            self.render_picker_preview(
+                body_row,
+                col + item_width,
+                preview_width,
+                body_height,
+                preview.as_ref().unwrap(),
+            );
+        }
+    }
+
+    fn render_picker_items(
+        &mut self,
+        row: u16,
+        col: u16,
+        width: u16,
+        height: u16,
+        picker: &semantic::Picker,
+    ) {
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        if picker.load_status == 1 {
+            self.write_run(
+                row,
+                col,
+                &pad_to_width(" Loading...", width),
+                self.theme.picker_style(false),
+            );
+            return;
+        }
+        if picker.load_status == 2 {
+            let message = if picker.load_error.is_empty() {
+                " Picker failed".to_owned()
+            } else {
+                format!(" {}", picker.load_error)
+            };
+            self.write_run(
+                row,
+                col,
+                &pad_to_width(&message, width),
+                self.theme.picker_style(false),
+            );
+            return;
+        }
+
+        if picker.items.is_empty() {
+            self.write_run(
+                row,
+                col,
+                &pad_to_width(" No matches", width),
+                self.theme.picker_style(false),
+            );
+            return;
+        }
+
+        let visible_rows = height as usize;
+        let selected = picker.selected_index as usize;
+        let start = selected.saturating_sub(visible_rows.saturating_sub(1));
+        for (screen_index, item) in picker
+            .items
+            .iter()
+            .skip(start)
+            .take(visible_rows)
+            .enumerate()
+        {
+            let item_index = start + screen_index;
+            let selected = item_index == selected;
+            let marker = if item.marked {
+                "*"
+            } else if selected {
+                ">"
+            } else {
+                " "
+            };
+            let annotation = if item.annotation.is_empty() {
+                String::new()
+            } else {
+                format!(" {}", item.annotation)
+            };
+            let description = if item.description.is_empty() {
+                String::new()
+            } else {
+                format!("  {}", item.description)
+            };
+            let line = format!("{marker} {}{}{}", item.label, annotation, description);
+            self.write_run(
+                row + screen_index as u16,
+                col,
+                &pad_to_width(&line, width),
+                self.theme.picker_style(selected),
+            );
+        }
+    }
+
+    fn render_picker_preview(
+        &mut self,
+        row: u16,
+        col: u16,
+        width: u16,
+        height: u16,
+        preview: &semantic::PickerPreview,
+    ) {
+        self.fill_rect(
+            row,
+            col,
+            width,
+            height,
+            self.theme.picker_preview_style(false, 0),
+        );
+
+        for (line_index, segments) in preview.lines.iter().take(height as usize).enumerate() {
+            let mut current_col = col.saturating_add(1);
+            for segment in segments {
+                if current_col >= col.saturating_add(width) {
+                    break;
+                }
+                let remaining = col.saturating_add(width).saturating_sub(current_col);
+                let text = slice_chars(&segment.text, 0, remaining);
+                let segment_width = text_width(&text);
+                self.write_run(
+                    row + line_index as u16,
+                    current_col,
+                    &text,
+                    self.theme.picker_preview_style(segment.bold, segment.fg),
+                );
+                current_col = current_col.saturating_add(segment_width);
+            }
+        }
+    }
+
     fn render_file_tree(&mut self) {
         let Some(tree) = self.file_tree.clone() else {
             return;
@@ -322,20 +593,35 @@ impl Renderer {
                 row,
                 0,
                 &" ".repeat(width as usize),
-                file_tree_style(false, tree.focused),
+                self.theme.file_tree_style(false, tree.focused),
             );
         }
 
         match tree.status {
-            1 => self.write_run(1, 0, " Loading...", file_tree_style(false, tree.focused)),
-            2 => self.write_run(1, 0, " Empty", file_tree_style(false, tree.focused)),
+            1 => self.write_run(
+                1,
+                0,
+                " Loading...",
+                self.theme.file_tree_style(false, tree.focused),
+            ),
+            2 => self.write_run(
+                1,
+                0,
+                " Empty",
+                self.theme.file_tree_style(false, tree.focused),
+            ),
             4 => {
                 let message = if tree.error.is_empty() {
                     " File tree error".to_owned()
                 } else {
                     format!(" {}", tree.error)
                 };
-                self.write_run(1, 0, &message, file_tree_style(false, tree.focused));
+                self.write_run(
+                    1,
+                    0,
+                    &message,
+                    self.theme.file_tree_style(false, tree.focused),
+                );
             }
             _ => {
                 let visible_rows = self.height.saturating_sub(2) as usize;
@@ -383,7 +669,7 @@ impl Renderer {
             screen_row,
             0,
             &pad_to_width(&label, width),
-            file_tree_style(selected, focused),
+            self.theme.file_tree_style(selected, focused),
         );
     }
 
@@ -498,6 +784,13 @@ impl Renderer {
         }
     }
 
+    fn fill_rect(&mut self, row: u16, col: u16, width: u16, height: u16, style: CellStyle) {
+        let line = " ".repeat(width as usize);
+        for y in row..row.saturating_add(height).min(self.height) {
+            self.write_run(y, col, &line, style);
+        }
+    }
+
     fn render(&mut self, terminal: &mut Terminal) -> io::Result<()> {
         for row in 0..self.height {
             for col in 0..self.width {
@@ -542,17 +835,185 @@ fn char_width(ch: char) -> u16 {
     1
 }
 
-fn file_tree_style(selected: bool, focused: bool) -> CellStyle {
-    CellStyle {
-        fg: if selected { 0xECEFF4 } else { 0xC7CED9 },
-        bg: match (selected, focused) {
-            (true, true) => 0x4C566A,
-            (true, false) => 0x3B4252,
-            (false, _) => 0x20242D,
-        },
-        attrs: if selected { protocol::ATTR_BOLD } else { 0 },
-        ul_color: 0,
-        blend: 100,
+fn picker_geometry(width: u16, height: u16) -> (u16, u16, u16, u16) {
+    let overlay_width = width.saturating_sub(4).clamp(24, 96);
+    let overlay_height = height.saturating_sub(4).clamp(8, 18);
+    let row = if height > overlay_height {
+        (height - overlay_height) / 3 + 1
+    } else {
+        0
+    };
+    let col = width.saturating_sub(overlay_width) / 2;
+    (
+        row,
+        col,
+        overlay_width.min(width),
+        overlay_height.min(height),
+    )
+}
+
+const SLOT_EDITOR_BG: u8 = 0x01;
+const SLOT_EDITOR_FG: u8 = 0x02;
+const SLOT_TREE_BG: u8 = 0x03;
+const SLOT_TREE_FG: u8 = 0x04;
+const SLOT_TREE_SELECTION_BG: u8 = 0x05;
+const SLOT_TREE_ACTIVE_FG: u8 = 0x07;
+const SLOT_TAB_BG: u8 = 0x10;
+const SLOT_TAB_ACTIVE_BG: u8 = 0x11;
+const SLOT_TAB_ACTIVE_FG: u8 = 0x12;
+const SLOT_TAB_INACTIVE_FG: u8 = 0x13;
+const SLOT_POPUP_BG: u8 = 0x20;
+const SLOT_POPUP_FG: u8 = 0x21;
+const SLOT_POPUP_BORDER: u8 = 0x22;
+const SLOT_POPUP_SEL_BG: u8 = 0x23;
+const SLOT_POPUP_DESC_FG: u8 = 0x26;
+const SLOT_POPUP_SEL_FG: u8 = 0x2A;
+const SLOT_MODELINE_BAR_BG: u8 = 0x30;
+const SLOT_MODELINE_BAR_FG: u8 = 0x31;
+
+impl ThemePalette {
+    fn from_theme(theme: semantic::Theme) -> Self {
+        let slots = theme
+            .slots
+            .into_iter()
+            .map(|slot| (slot.id, slot.rgb))
+            .collect();
+        Self { slots }
+    }
+
+    fn color(&self, slot: u8, fallback: u32) -> u32 {
+        self.slots.get(&slot).copied().unwrap_or(fallback)
+    }
+
+    fn status_bar_style(&self) -> CellStyle {
+        CellStyle {
+            fg: self.color(SLOT_MODELINE_BAR_FG, 0xD8DEE9),
+            bg: self.color(SLOT_MODELINE_BAR_BG, 0x2E3440),
+            attrs: protocol::ATTR_BOLD,
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    fn tab_style(&self, active: bool, tint: u32) -> CellStyle {
+        CellStyle {
+            fg: if tint != 0 {
+                tint & 0x00FF_FFFF
+            } else if active {
+                self.color(SLOT_TAB_ACTIVE_FG, 0xD8DEE9)
+            } else {
+                self.color(SLOT_TAB_INACTIVE_FG, 0xC7CED9)
+            },
+            bg: if active {
+                self.color(SLOT_TAB_ACTIVE_BG, 0x3B4252)
+            } else {
+                self.color(SLOT_TAB_BG, 0x242933)
+            },
+            attrs: if active { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    fn file_tree_style(&self, selected: bool, focused: bool) -> CellStyle {
+        CellStyle {
+            fg: if selected {
+                self.color(SLOT_TREE_ACTIVE_FG, 0xECEFF4)
+            } else {
+                self.color(SLOT_TREE_FG, 0xC7CED9)
+            },
+            bg: if selected {
+                self.color(
+                    SLOT_TREE_SELECTION_BG,
+                    if focused { 0x4C566A } else { 0x3B4252 },
+                )
+            } else {
+                self.color(SLOT_TREE_BG, 0x20242D)
+            },
+            attrs: if selected { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    fn picker_style(&self, selected: bool) -> CellStyle {
+        CellStyle {
+            fg: if selected {
+                self.color(SLOT_POPUP_SEL_FG, 0xECEFF4)
+            } else {
+                self.color(SLOT_POPUP_FG, 0xD8DEE9)
+            },
+            bg: if selected {
+                self.color(SLOT_POPUP_SEL_BG, 0x3B4252)
+            } else {
+                self.color(SLOT_POPUP_BG, 0x151A21)
+            },
+            attrs: if selected { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    fn picker_header_style(&self) -> CellStyle {
+        CellStyle {
+            fg: self.color(SLOT_POPUP_BORDER, 0xF8FAFC),
+            bg: self.color(SLOT_POPUP_BG, 0x273142),
+            attrs: protocol::ATTR_BOLD,
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    fn picker_query_style(&self) -> CellStyle {
+        CellStyle {
+            fg: self.color(SLOT_POPUP_DESC_FG, 0xB7C7E3),
+            bg: self.color(SLOT_POPUP_BG, 0x1F2632),
+            attrs: 0,
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    fn picker_preview_style(&self, bold: bool, fg: u32) -> CellStyle {
+        CellStyle {
+            fg: if fg == 0 {
+                self.color(SLOT_POPUP_FG, 0xCAD3DF)
+            } else {
+                fg
+            },
+            bg: self.color(SLOT_EDITOR_BG, 0x11161D),
+            attrs: if bold { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    fn minibuffer_style(&self, selected: bool) -> CellStyle {
+        CellStyle {
+            fg: if selected {
+                self.color(SLOT_POPUP_SEL_FG, 0xF8FAFC)
+            } else {
+                self.color(SLOT_EDITOR_FG, 0xD8DEE9)
+            },
+            bg: if selected {
+                self.color(SLOT_POPUP_SEL_BG, 0x4C566A)
+            } else {
+                self.color(SLOT_MODELINE_BAR_BG, 0x20242D)
+            },
+            attrs: if selected { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    fn minibuffer_context_style(&self) -> CellStyle {
+        CellStyle {
+            fg: self.color(SLOT_POPUP_DESC_FG, 0x9AA7B5),
+            bg: self.color(SLOT_MODELINE_BAR_BG, 0x1A1F28),
+            attrs: 0,
+            ul_color: 0,
+            blend: 100,
+        }
     }
 }
 
@@ -821,5 +1282,181 @@ mod tests {
             selected_bg
         );
         assert_eq!(renderer.cells[renderer.index(5, 2).unwrap()].text, "R");
+    }
+
+    #[test]
+    fn semantic_picker_draws_split_overlay() {
+        let mut renderer = Renderer::new(80, 20);
+
+        renderer.draw_picker(semantic::Picker {
+            visible: true,
+            selected_index: 1,
+            filtered_count: 2,
+            total_count: 9,
+            marked_count: 0,
+            has_preview: true,
+            title: "Files".to_owned(),
+            query: "lib".to_owned(),
+            mode_prefix: ">".to_owned(),
+            load_status: 0,
+            load_error: String::new(),
+            items: vec![
+                semantic::PickerItem {
+                    label: "mix.exs".to_owned(),
+                    description: ".".to_owned(),
+                    annotation: "root".to_owned(),
+                    icon_color: 0,
+                    marked: false,
+                },
+                semantic::PickerItem {
+                    label: "lib.ex".to_owned(),
+                    description: "lib/minga".to_owned(),
+                    annotation: "modified".to_owned(),
+                    icon_color: 0,
+                    marked: false,
+                },
+            ],
+        });
+        renderer.draw_picker_preview(semantic::PickerPreview {
+            visible: true,
+            lines: vec![vec![semantic::PreviewSegment {
+                text: "defmodule Minga".to_owned(),
+                fg: 0xAABBCC,
+                bold: true,
+            }]],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(2, 2).unwrap()].text, ">");
+        assert_eq!(renderer.cells[renderer.index(4, 3).unwrap()].text, "l");
+        assert_eq!(renderer.cells[renderer.index(4, 5).unwrap()].text, "l");
+        assert_eq!(
+            renderer.cells[renderer.index(4, 5).unwrap()].style.bg,
+            0x3B4252
+        );
+        assert_eq!(renderer.cells[renderer.index(41, 4).unwrap()].text, "d");
+        assert_eq!(
+            renderer.cells[renderer.index(41, 4).unwrap()].style.fg,
+            0xAABBCC
+        );
+    }
+
+    #[test]
+    fn semantic_minibuffer_draws_prompt_candidates_and_cursor() {
+        let mut renderer = Renderer::new(40, 10);
+
+        renderer.draw_minibuffer(semantic::Minibuffer {
+            visible: true,
+            mode: 0,
+            cursor_pos: 1,
+            prompt: ":".to_owned(),
+            input: "w".to_owned(),
+            context: String::new(),
+            selected_index: 1,
+            total_candidates: 2,
+            candidates: vec![
+                semantic::MinibufferCandidate {
+                    label: "write".to_owned(),
+                    description: "Save file".to_owned(),
+                    annotation: ":w".to_owned(),
+                },
+                semantic::MinibufferCandidate {
+                    label: "write-quit".to_owned(),
+                    description: "Save and quit".to_owned(),
+                    annotation: ":wq".to_owned(),
+                },
+            ],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(0, 8).unwrap()].text, ":");
+        assert_eq!(renderer.cells[renderer.index(1, 8).unwrap()].text, "w");
+        assert_eq!(renderer.cursor, (2, 8));
+        assert_eq!(renderer.cells[renderer.index(0, 7).unwrap()].text, ">");
+        assert_eq!(renderer.cells[renderer.index(2, 7).unwrap()].text, "w");
+        assert_eq!(
+            renderer.cells[renderer.index(0, 7).unwrap()].style.bg,
+            0x4C566A
+        );
+    }
+
+    #[test]
+    fn semantic_theme_drives_picker_and_minibuffer_colors() {
+        let mut renderer = Renderer::new(40, 12);
+
+        renderer.apply_theme(semantic::Theme {
+            slots: vec![
+                semantic::ThemeSlot {
+                    id: SLOT_POPUP_BG,
+                    rgb: 0x010203,
+                },
+                semantic::ThemeSlot {
+                    id: SLOT_POPUP_SEL_BG,
+                    rgb: 0x040506,
+                },
+                semantic::ThemeSlot {
+                    id: SLOT_POPUP_FG,
+                    rgb: 0x070809,
+                },
+                semantic::ThemeSlot {
+                    id: SLOT_POPUP_SEL_FG,
+                    rgb: 0x0A0B0C,
+                },
+                semantic::ThemeSlot {
+                    id: SLOT_MODELINE_BAR_BG,
+                    rgb: 0x0D0E0F,
+                },
+            ],
+        });
+        renderer.draw_picker(semantic::Picker {
+            visible: true,
+            selected_index: 0,
+            filtered_count: 1,
+            total_count: 1,
+            marked_count: 0,
+            has_preview: false,
+            title: "Files".to_owned(),
+            query: String::new(),
+            mode_prefix: String::new(),
+            load_status: 0,
+            load_error: String::new(),
+            items: vec![semantic::PickerItem {
+                label: "main.ex".to_owned(),
+                description: String::new(),
+                annotation: String::new(),
+                icon_color: 0,
+                marked: false,
+            }],
+        });
+        renderer.draw_minibuffer(semantic::Minibuffer {
+            visible: true,
+            mode: 0,
+            cursor_pos: 0,
+            prompt: ":".to_owned(),
+            input: String::new(),
+            context: String::new(),
+            selected_index: 0,
+            total_candidates: 1,
+            candidates: vec![semantic::MinibufferCandidate {
+                label: "write".to_owned(),
+                description: String::new(),
+                annotation: String::new(),
+            }],
+        });
+
+        assert_eq!(
+            renderer.cells[renderer.index(2, 4).unwrap()].style.bg,
+            0x040506
+        );
+        assert_eq!(
+            renderer.cells[renderer.index(2, 4).unwrap()].style.fg,
+            0x0A0B0C
+        );
+        assert_eq!(
+            renderer.cells[renderer.index(0, 10).unwrap()].style.bg,
+            0x0D0E0F
+        );
+        assert_eq!(
+            renderer.cells[renderer.index(0, 9).unwrap()].style.bg,
+            0x040506
+        );
     }
 }

--- a/rust/tui/src/renderer.rs
+++ b/rust/tui/src/renderer.rs
@@ -15,6 +15,15 @@ struct ThemePalette {
     slots: HashMap<u8, u32>,
 }
 
+#[derive(Debug, Clone)]
+struct CellSnapshot {
+    row: u16,
+    col: u16,
+    width: u16,
+    height: u16,
+    cells: Vec<Cell>,
+}
+
 impl Default for Cell {
     fn default() -> Self {
         Self {
@@ -37,6 +46,8 @@ pub struct Renderer {
     file_tree: Option<semantic::FileTree>,
     picker: Option<semantic::Picker>,
     picker_preview: Option<semantic::PickerPreview>,
+    picker_snapshot: Option<CellSnapshot>,
+    minibuffer_snapshot: Option<CellSnapshot>,
     theme: ThemePalette,
 }
 
@@ -56,6 +67,8 @@ impl Renderer {
             file_tree: None,
             picker: None,
             picker_preview: None,
+            picker_snapshot: None,
+            minibuffer_snapshot: None,
             theme: ThemePalette::default(),
         }
     }
@@ -123,6 +136,8 @@ impl Renderer {
         self.file_tree = None;
         self.picker = None;
         self.picker_preview = None;
+        self.picker_snapshot = None;
+        self.minibuffer_snapshot = None;
     }
 
     fn clear(&mut self) {
@@ -313,6 +328,7 @@ impl Renderer {
             self.picker = Some(picker);
             self.render_picker();
         } else {
+            self.restore_picker_snapshot();
             self.picker = None;
             self.picker_preview = None;
         }
@@ -328,9 +344,15 @@ impl Renderer {
     }
 
     fn draw_minibuffer(&mut self, minibuffer: semantic::Minibuffer) {
-        if !minibuffer.visible || self.height < 2 || self.width == 0 {
+        if !minibuffer.visible {
+            self.restore_minibuffer_snapshot();
             return;
         }
+        if self.height < 2 || self.width == 0 {
+            return;
+        }
+
+        self.capture_minibuffer_snapshot();
 
         let row = self.height.saturating_sub(2);
         let prompt = format!("{}{}", minibuffer.prompt, minibuffer.input);
@@ -398,6 +420,9 @@ impl Renderer {
 
         let preview = self.picker_preview.clone();
         let (row, col, width, height) = picker_geometry(self.width, self.height);
+        if self.picker_snapshot.is_none() {
+            self.picker_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
         self.fill_rect(row, col, width, height, self.theme.picker_style(false));
 
         let title = if picker.mode_prefix.is_empty() {
@@ -455,6 +480,29 @@ impl Renderer {
                 body_height,
                 preview.as_ref().unwrap(),
             );
+        }
+    }
+
+    fn restore_picker_snapshot(&mut self) {
+        if let Some(snapshot) = self.picker_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn capture_minibuffer_snapshot(&mut self) {
+        if self.minibuffer_snapshot.is_some() || self.height < 2 || self.width == 0 {
+            return;
+        }
+
+        let prompt_row = self.height.saturating_sub(2);
+        let first_row = prompt_row.saturating_sub(5);
+        let height = prompt_row.saturating_sub(first_row).saturating_add(1);
+        self.minibuffer_snapshot = Some(self.capture_rect(first_row, 0, self.width, height));
+    }
+
+    fn restore_minibuffer_snapshot(&mut self) {
+        if let Some(snapshot) = self.minibuffer_snapshot.take() {
+            self.restore_snapshot(snapshot);
         }
     }
 
@@ -788,6 +836,49 @@ impl Renderer {
         let line = " ".repeat(width as usize);
         for y in row..row.saturating_add(height).min(self.height) {
             self.write_run(y, col, &line, style);
+        }
+    }
+
+    fn capture_rect(&self, row: u16, col: u16, width: u16, height: u16) -> CellSnapshot {
+        let max_row = row.saturating_add(height).min(self.height);
+        let max_col = col.saturating_add(width).min(self.width);
+        let mut cells = Vec::with_capacity(
+            max_row.saturating_sub(row) as usize * max_col.saturating_sub(col) as usize,
+        );
+
+        for y in row..max_row {
+            for x in col..max_col {
+                if let Some(index) = self.index(x, y) {
+                    cells.push(self.cells[index].clone());
+                }
+            }
+        }
+
+        CellSnapshot {
+            row,
+            col,
+            width: max_col.saturating_sub(col),
+            height: max_row.saturating_sub(row),
+            cells,
+        }
+    }
+
+    fn restore_snapshot(&mut self, snapshot: CellSnapshot) {
+        let mut snapshot_index = 0;
+        for y in snapshot.row
+            ..snapshot
+                .row
+                .saturating_add(snapshot.height)
+                .min(self.height)
+        {
+            for x in snapshot.col..snapshot.col.saturating_add(snapshot.width).min(self.width) {
+                if let Some(index) = self.index(x, y)
+                    && let Some(cell) = snapshot.cells.get(snapshot_index)
+                {
+                    self.cells[index] = cell.clone();
+                }
+                snapshot_index += 1;
+            }
         }
     }
 
@@ -1341,6 +1432,48 @@ mod tests {
     }
 
     #[test]
+    fn semantic_picker_hide_restores_underlying_cells() {
+        let mut renderer = Renderer::new(80, 20);
+        renderer.draw_text(DrawText {
+            row: 4,
+            col: 4,
+            fg: 0x111111,
+            bg: 0x222222,
+            attrs: 0,
+            text: "under".to_owned(),
+        });
+
+        renderer.draw_picker(semantic::Picker {
+            visible: true,
+            selected_index: 0,
+            filtered_count: 1,
+            total_count: 1,
+            marked_count: 0,
+            has_preview: false,
+            title: "Files".to_owned(),
+            query: String::new(),
+            mode_prefix: String::new(),
+            load_status: 0,
+            load_error: String::new(),
+            items: vec![semantic::PickerItem {
+                label: "main.ex".to_owned(),
+                description: String::new(),
+                annotation: String::new(),
+                icon_color: 0,
+                marked: false,
+            }],
+        });
+        assert_ne!(renderer.cells[renderer.index(4, 4).unwrap()].text, "u");
+
+        renderer.draw_picker(semantic::Picker::default());
+
+        let restored = &renderer.cells[renderer.index(4, 4).unwrap()];
+        assert_eq!(restored.text, "u");
+        assert_eq!(restored.style.fg, 0x111111);
+        assert_eq!(restored.style.bg, 0x222222);
+    }
+
+    #[test]
     fn semantic_minibuffer_draws_prompt_candidates_and_cursor() {
         let mut renderer = Renderer::new(40, 10);
 
@@ -1376,6 +1509,57 @@ mod tests {
             renderer.cells[renderer.index(0, 7).unwrap()].style.bg,
             0x4C566A
         );
+    }
+
+    #[test]
+    fn semantic_minibuffer_hide_restores_owned_rows() {
+        let mut renderer = Renderer::new(40, 10);
+        renderer.draw_text(DrawText {
+            row: 8,
+            col: 0,
+            fg: 0x111111,
+            bg: 0x222222,
+            attrs: 0,
+            text: "status".to_owned(),
+        });
+        renderer.draw_text(DrawText {
+            row: 7,
+            col: 0,
+            fg: 0x333333,
+            bg: 0x444444,
+            attrs: 0,
+            text: "candidate".to_owned(),
+        });
+
+        renderer.draw_minibuffer(semantic::Minibuffer {
+            visible: true,
+            mode: 0,
+            cursor_pos: 1,
+            prompt: ":".to_owned(),
+            input: "w".to_owned(),
+            context: String::new(),
+            selected_index: 0,
+            total_candidates: 1,
+            candidates: vec![semantic::MinibufferCandidate {
+                label: "write".to_owned(),
+                description: "Save file".to_owned(),
+                annotation: ":w".to_owned(),
+            }],
+        });
+        assert_eq!(renderer.cells[renderer.index(0, 8).unwrap()].text, ":");
+        assert_eq!(renderer.cells[renderer.index(0, 7).unwrap()].text, ">");
+
+        renderer.draw_minibuffer(semantic::Minibuffer::default());
+
+        let prompt = &renderer.cells[renderer.index(0, 8).unwrap()];
+        assert_eq!(prompt.text, "s");
+        assert_eq!(prompt.style.fg, 0x111111);
+        assert_eq!(prompt.style.bg, 0x222222);
+
+        let candidate = &renderer.cells[renderer.index(0, 7).unwrap()];
+        assert_eq!(candidate.text, "c");
+        assert_eq!(candidate.style.fg, 0x333333);
+        assert_eq!(candidate.style.bg, 0x444444);
     }
 
     #[test]

--- a/rust/tui/src/renderer.rs
+++ b/rust/tui/src/renderer.rs
@@ -46,6 +46,7 @@ pub struct Renderer {
     file_tree: Option<semantic::FileTree>,
     picker: Option<semantic::Picker>,
     picker_preview: Option<semantic::PickerPreview>,
+    minibuffer: Option<semantic::Minibuffer>,
     picker_snapshot: Option<CellSnapshot>,
     minibuffer_snapshot: Option<CellSnapshot>,
     theme: ThemePalette,
@@ -67,6 +68,7 @@ impl Renderer {
             file_tree: None,
             picker: None,
             picker_preview: None,
+            minibuffer: None,
             picker_snapshot: None,
             minibuffer_snapshot: None,
             theme: ThemePalette::default(),
@@ -136,6 +138,7 @@ impl Renderer {
         self.file_tree = None;
         self.picker = None;
         self.picker_preview = None;
+        self.minibuffer = None;
         self.picker_snapshot = None;
         self.minibuffer_snapshot = None;
     }
@@ -222,6 +225,8 @@ impl Renderer {
                 .saturating_add(row.min(u16::MAX as usize) as u16);
             self.draw_semantic_row(row, window.origin_col, content);
         }
+
+        self.redraw_retained_chrome();
     }
 
     fn draw_semantic_row(&mut self, row: u16, origin_col: u16, content: semantic::Row) {
@@ -346,12 +351,18 @@ impl Renderer {
     fn draw_minibuffer(&mut self, minibuffer: semantic::Minibuffer) {
         if !minibuffer.visible {
             self.restore_minibuffer_snapshot();
+            self.minibuffer = None;
             return;
         }
         if self.height < 2 || self.width == 0 {
             return;
         }
 
+        self.minibuffer = Some(minibuffer.clone());
+        self.render_minibuffer(&minibuffer);
+    }
+
+    fn render_minibuffer(&mut self, minibuffer: &semantic::Minibuffer) {
         self.capture_minibuffer_snapshot();
         self.restore_minibuffer_cells();
 
@@ -412,6 +423,17 @@ impl Renderer {
                 &pad_to_width(&text, self.width),
                 self.theme.minibuffer_style(selected),
             );
+        }
+    }
+
+    fn redraw_retained_chrome(&mut self) {
+        self.render_file_tree();
+        self.picker_snapshot = None;
+        self.render_picker();
+
+        if let Some(minibuffer) = self.minibuffer.clone() {
+            self.minibuffer_snapshot = None;
+            self.render_minibuffer(&minibuffer);
         }
     }
 
@@ -1485,6 +1507,61 @@ mod tests {
     }
 
     #[test]
+    fn semantic_window_redraw_replays_retained_picker() {
+        let mut renderer = Renderer::new(80, 20);
+
+        renderer.draw_semantic_window(semantic::WindowContent {
+            origin_row: 4,
+            origin_col: 4,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_shape: 0,
+            rows: vec![semantic::Row {
+                text: "old".to_owned(),
+                spans: vec![],
+            }],
+        });
+        renderer.draw_picker(semantic::Picker {
+            visible: true,
+            selected_index: 0,
+            filtered_count: 1,
+            total_count: 1,
+            marked_count: 0,
+            has_preview: false,
+            title: "Files".to_owned(),
+            query: String::new(),
+            mode_prefix: String::new(),
+            load_status: 0,
+            load_error: String::new(),
+            items: vec![semantic::PickerItem {
+                label: "main.ex".to_owned(),
+                description: String::new(),
+                annotation: String::new(),
+                icon_color: 0,
+                marked: false,
+            }],
+        });
+
+        renderer.draw_semantic_window(semantic::WindowContent {
+            origin_row: 4,
+            origin_col: 4,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_shape: 0,
+            rows: vec![semantic::Row {
+                text: "new".to_owned(),
+                spans: vec![],
+            }],
+        });
+
+        assert_ne!(renderer.cells[renderer.index(4, 4).unwrap()].text, "n");
+
+        renderer.draw_picker(semantic::Picker::default());
+
+        assert_eq!(renderer.cells[renderer.index(4, 4).unwrap()].text, "n");
+    }
+
+    #[test]
     fn semantic_minibuffer_draws_prompt_candidates_and_cursor() {
         let mut renderer = Renderer::new(40, 10);
 
@@ -1631,6 +1708,41 @@ mod tests {
 
         assert_eq!(renderer.cursor, (12, 3));
         assert_eq!(renderer.cells[renderer.index(0, 8).unwrap()].text, "C");
+    }
+
+    #[test]
+    fn semantic_window_redraw_replays_retained_minibuffer() {
+        let mut renderer = Renderer::new(40, 10);
+
+        renderer.draw_minibuffer(semantic::Minibuffer {
+            visible: true,
+            mode: 0,
+            cursor_pos: 1,
+            prompt: ":".to_owned(),
+            input: "w".to_owned(),
+            context: String::new(),
+            selected_index: 0,
+            total_candidates: 0,
+            candidates: vec![],
+        });
+
+        renderer.draw_semantic_window(semantic::WindowContent {
+            origin_row: 8,
+            origin_col: 0,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_shape: 0,
+            rows: vec![semantic::Row {
+                text: "under".to_owned(),
+                spans: vec![],
+            }],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(0, 8).unwrap()].text, ":");
+
+        renderer.draw_minibuffer(semantic::Minibuffer::default());
+
+        assert_eq!(renderer.cells[renderer.index(0, 8).unwrap()].text, "u");
     }
 
     #[test]

--- a/rust/tui/src/renderer.rs
+++ b/rust/tui/src/renderer.rs
@@ -353,6 +353,7 @@ impl Renderer {
         }
 
         self.capture_minibuffer_snapshot();
+        self.restore_minibuffer_cells();
 
         let row = self.height.saturating_sub(2);
         let prompt = format!("{}{}", minibuffer.prompt, minibuffer.input);
@@ -362,10 +363,14 @@ impl Renderer {
             &pad_to_width(&prompt, self.width),
             self.theme.minibuffer_style(false),
         );
-        self.cursor = (
-            text_width(&minibuffer.prompt).saturating_add(minibuffer.cursor_pos),
-            row,
-        );
+        if minibuffer.cursor_pos != u16::MAX {
+            self.cursor = (
+                text_width(&minibuffer.prompt)
+                    .saturating_add(minibuffer.cursor_pos)
+                    .min(self.width.saturating_sub(1)),
+                row,
+            );
+        }
 
         if !minibuffer.context.is_empty() && row > 0 {
             self.write_run(
@@ -502,6 +507,12 @@ impl Renderer {
 
     fn restore_minibuffer_snapshot(&mut self) {
         if let Some(snapshot) = self.minibuffer_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_minibuffer_cells(&mut self) {
+        if let Some(snapshot) = self.minibuffer_snapshot.clone() {
             self.restore_snapshot(snapshot);
         }
     }
@@ -1560,6 +1571,66 @@ mod tests {
         assert_eq!(candidate.text, "c");
         assert_eq!(candidate.style.fg, 0x333333);
         assert_eq!(candidate.style.bg, 0x444444);
+    }
+
+    #[test]
+    fn semantic_minibuffer_visible_update_clears_stale_candidates() {
+        let mut renderer = Renderer::new(40, 10);
+
+        renderer.draw_minibuffer(semantic::Minibuffer {
+            visible: true,
+            mode: 0,
+            cursor_pos: 1,
+            prompt: ":".to_owned(),
+            input: "w".to_owned(),
+            context: String::new(),
+            selected_index: 0,
+            total_candidates: 1,
+            candidates: vec![semantic::MinibufferCandidate {
+                label: "write".to_owned(),
+                description: "Save file".to_owned(),
+                annotation: ":w".to_owned(),
+            }],
+        });
+        assert_eq!(renderer.cells[renderer.index(0, 7).unwrap()].text, ">");
+
+        renderer.draw_minibuffer(semantic::Minibuffer {
+            visible: true,
+            mode: 0,
+            cursor_pos: 2,
+            prompt: ":".to_owned(),
+            input: "zz".to_owned(),
+            context: String::new(),
+            selected_index: 0,
+            total_candidates: 0,
+            candidates: vec![],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(0, 7).unwrap()].text, " ");
+        assert_eq!(renderer.cells[renderer.index(2, 7).unwrap()].text, " ");
+        assert_eq!(renderer.cells[renderer.index(0, 8).unwrap()].text, ":");
+        assert_eq!(renderer.cells[renderer.index(1, 8).unwrap()].text, "z");
+    }
+
+    #[test]
+    fn semantic_minibuffer_no_cursor_sentinel_preserves_existing_cursor() {
+        let mut renderer = Renderer::new(40, 10);
+        renderer.cursor = (12, 3);
+
+        renderer.draw_minibuffer(semantic::Minibuffer {
+            visible: true,
+            mode: 0,
+            cursor_pos: u16::MAX,
+            prompt: "Confirm?".to_owned(),
+            input: String::new(),
+            context: String::new(),
+            selected_index: 0,
+            total_candidates: 0,
+            candidates: vec![],
+        });
+
+        assert_eq!(renderer.cursor, (12, 3));
+        assert_eq!(renderer.cells[renderer.index(0, 8).unwrap()].text, "C");
     }
 
     #[test]

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -223,7 +223,8 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         | opcodes::OP_GUI_EDIT_TIMELINE
         | opcodes::OP_GUI_EXTENSION_OVERLAY
         | opcodes::OP_GUI_EXTENSION_PANEL
-        | opcodes::OP_GUI_SEARCH_STATE => len16_size(bytes, "semantic length16 command")
+        | opcodes::OP_GUI_SEARCH_STATE
+        | opcodes::OP_GUI_CONFIG_STATE => len16_size(bytes, "semantic length16 command")
             .map(|size| Command::Unsupported { opcode, size }),
         opcodes::OP_GUI_OBSERVATORY | opcodes::OP_GUI_SIDEBARS => {
             len32_size(bytes, "semantic length32 command")
@@ -245,8 +246,7 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         | opcodes::OP_GUI_BOARD
         | opcodes::OP_GUI_AGENT_CHAT
         | opcodes::OP_GUI_BOTTOM_PANEL
-        | opcodes::OP_GUI_TOOL_MANAGER
-        | opcodes::OP_GUI_CONFIG_STATE => {
+        | opcodes::OP_GUI_TOOL_MANAGER => {
             legacy_visible_size(bytes).map(|size| Command::Unsupported { opcode, size })
         }
         _ => Err(DecodeError::UnknownOpcode(opcode)),
@@ -883,12 +883,249 @@ fn split_separators_size(bytes: &[u8]) -> Result<usize, DecodeError> {
 
 fn legacy_visible_size(bytes: &[u8]) -> Result<usize, DecodeError> {
     require_len(bytes, 2, "legacy semantic visibility")?;
-    match bytes[1] {
-        0 => Ok(2),
+
+    if bytes[1] == 0 {
+        return Ok(2);
+    }
+
+    match bytes[0] {
+        opcodes::OP_GUI_BREADCRUMB => breadcrumb_size(bytes),
+        opcodes::OP_GUI_COMPLETION => completion_size(bytes),
+        opcodes::OP_GUI_SIGNATURE_HELP => signature_help_size(bytes),
+        opcodes::OP_GUI_FLOAT_POPUP => float_popup_size(bytes),
+        opcodes::OP_GUI_HOVER_POPUP => hover_popup_size(bytes),
+        opcodes::OP_GUI_AGENT_CONTEXT => agent_context_size(bytes),
+        opcodes::OP_GUI_GIT_STATUS => git_status_size(bytes),
+        opcodes::OP_GUI_CHANGE_SUMMARY => change_summary_size(bytes),
+        opcodes::OP_GUI_BOARD => board_size(bytes),
+        opcodes::OP_GUI_AGENT_CHAT => sectioned_size(bytes, "agent chat"),
+        opcodes::OP_GUI_BOTTOM_PANEL => bottom_panel_size(bytes),
+        opcodes::OP_GUI_TOOL_MANAGER => tool_manager_size(bytes),
         _ => Err(DecodeError::Malformed(
             "unsupported legacy semantic command",
         )),
     }
+}
+
+fn breadcrumb_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 2, "breadcrumb")?;
+    let count = bytes[1] as usize;
+    let mut offset = 2;
+    for _ in 0..count {
+        skip_string16(bytes, &mut offset)?;
+    }
+    Ok(offset)
+}
+
+fn completion_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 10, "completion")?;
+    let count = read_u16(bytes, 8) as usize;
+    let mut offset = 10;
+    for _ in 0..count {
+        require_len(bytes, offset + 1, "completion item kind")?;
+        offset += 1;
+        skip_string16(bytes, &mut offset)?;
+        skip_string16(bytes, &mut offset)?;
+    }
+    Ok(offset)
+}
+
+fn signature_help_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 9, "signature help")?;
+    let count = bytes[8] as usize;
+    let mut offset = 9;
+    for _ in 0..count {
+        skip_string16(bytes, &mut offset)?;
+        skip_string16(bytes, &mut offset)?;
+        require_len(bytes, offset + 1, "signature parameter count")?;
+        let parameter_count = bytes[offset] as usize;
+        offset += 1;
+        for _ in 0..parameter_count {
+            skip_string16(bytes, &mut offset)?;
+            skip_string16(bytes, &mut offset)?;
+        }
+    }
+    Ok(offset)
+}
+
+fn float_popup_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 8, "float popup")?;
+    let mut offset = 6;
+    skip_string16(bytes, &mut offset)?;
+    require_len(bytes, offset + 2, "float popup line count")?;
+    let line_count = read_u16(bytes, offset) as usize;
+    offset += 2;
+    for _ in 0..line_count {
+        skip_string16(bytes, &mut offset)?;
+    }
+    Ok(offset)
+}
+
+fn hover_popup_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 11, "hover popup")?;
+    let line_count = read_u16(bytes, 9) as usize;
+    let mut offset = 11;
+    for _ in 0..line_count {
+        require_len(bytes, offset + 3, "hover line")?;
+        let segment_count = read_u16(bytes, offset + 1) as usize;
+        offset += 3;
+        for _ in 0..segment_count {
+            require_len(bytes, offset + 1, "hover segment style")?;
+            if bytes[offset] == 13 {
+                require_len(bytes, offset + 7, "hover syntax segment")?;
+                let len = read_u16(bytes, offset + 5) as usize;
+                offset += 7;
+                require_len(bytes, offset + len, "hover syntax segment text")?;
+                offset += len;
+            } else {
+                offset += 1;
+                skip_string16(bytes, &mut offset)?;
+            }
+        }
+    }
+    Ok(offset)
+}
+
+fn agent_context_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 4, "agent context")?;
+    let len = read_u16(bytes, 2) as usize;
+    let offset = 4 + len;
+    require_len(bytes, offset + 10, "agent context body")?;
+    Ok(offset + 10)
+}
+
+fn git_status_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 9, "git status")?;
+    let mut offset = 7;
+    skip_string16(bytes, &mut offset)?;
+    require_len(bytes, offset + 2, "git entry count")?;
+    let entry_count = read_u16(bytes, offset) as usize;
+    offset += 2;
+    for _ in 0..entry_count {
+        require_len(bytes, offset + 6, "git entry")?;
+        offset += 6;
+        skip_string16(bytes, &mut offset)?;
+    }
+    require_len(bytes, offset + 1, "git toast visibility")?;
+    match bytes[offset] {
+        0 => offset += 1,
+        _ => {
+            require_len(bytes, offset + 5, "git toast")?;
+            let len = read_u16(bytes, offset + 3) as usize;
+            offset += 5;
+            require_len(bytes, offset + len, "git toast message")?;
+            offset += len;
+        }
+    }
+    skip_string16(bytes, &mut offset)?;
+    skip_string16(bytes, &mut offset)?;
+    require_len(bytes, offset + 2, "git stash count")?;
+    Ok(offset + 2)
+}
+
+fn change_summary_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 5, "change summary")?;
+    let count = read_u16(bytes, 3) as usize;
+    let mut offset = 5;
+    for _ in 0..count {
+        skip_string16(bytes, &mut offset)?;
+        require_len(bytes, offset + 9, "change summary entry")?;
+        offset += 9;
+    }
+    Ok(offset)
+}
+
+fn board_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 11, "board")?;
+    let card_count = read_u16(bytes, 6) as usize;
+    let mut offset = 9;
+    skip_string16(bytes, &mut offset)?;
+    for _ in 0..card_count {
+        require_len(bytes, offset + 6, "board card")?;
+        offset += 6;
+        skip_string16(bytes, &mut offset)?;
+        skip_string8(bytes, &mut offset)?;
+        require_len(bytes, offset + 5, "board card timestamp and recent files")?;
+        offset += 4;
+        let recent_count = bytes[offset] as usize;
+        offset += 1;
+        for _ in 0..recent_count {
+            skip_string16(bytes, &mut offset)?;
+        }
+        require_len(bytes, offset + 1, "board sparkline count")?;
+        let sparkline_count = bytes[offset] as usize;
+        offset += 1;
+        require_len(bytes, offset + sparkline_count * 2, "board sparkline")?;
+        offset += sparkline_count * 2;
+    }
+    Ok(offset)
+}
+
+fn bottom_panel_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 6, "bottom panel")?;
+    let tab_count = bytes[5] as usize;
+    let mut offset = 6;
+    for _ in 0..tab_count {
+        require_len(bytes, offset + 2, "bottom panel tab")?;
+        offset += 1;
+        skip_string8(bytes, &mut offset)?;
+    }
+    require_len(bytes, offset + 2, "bottom panel entry count")?;
+    let entry_count = read_u16(bytes, offset) as usize;
+    offset += 2;
+    for _ in 0..entry_count {
+        require_len(bytes, offset + 10, "bottom panel entry")?;
+        offset += 10;
+        skip_string16(bytes, &mut offset)?;
+        skip_string16(bytes, &mut offset)?;
+    }
+    Ok(offset)
+}
+
+fn tool_manager_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 7, "tool manager")?;
+    let count = read_u16(bytes, 5) as usize;
+    let mut offset = 7;
+    for _ in 0..count {
+        skip_string8(bytes, &mut offset)?;
+        skip_string8(bytes, &mut offset)?;
+        skip_string16(bytes, &mut offset)?;
+        require_len(bytes, offset + 4, "tool metadata")?;
+        offset += 3;
+        let language_count = bytes[offset] as usize;
+        offset += 1;
+        for _ in 0..language_count {
+            skip_string8(bytes, &mut offset)?;
+        }
+        skip_string8(bytes, &mut offset)?;
+        skip_string16(bytes, &mut offset)?;
+        require_len(bytes, offset + 1, "tool provides count")?;
+        let provides_count = bytes[offset] as usize;
+        offset += 1;
+        for _ in 0..provides_count {
+            skip_string8(bytes, &mut offset)?;
+        }
+        skip_string16(bytes, &mut offset)?;
+    }
+    Ok(offset)
+}
+
+fn skip_string8(bytes: &[u8], offset: &mut usize) -> Result<(), DecodeError> {
+    require_len(bytes, *offset + 1, "string8 header")?;
+    let len = bytes[*offset] as usize;
+    *offset += 1;
+    require_len(bytes, *offset + len, "string8 body")?;
+    *offset += len;
+    Ok(())
+}
+
+fn skip_string16(bytes: &[u8], offset: &mut usize) -> Result<(), DecodeError> {
+    require_len(bytes, *offset + 2, "string16 header")?;
+    let len = read_u16(bytes, *offset) as usize;
+    *offset += 2;
+    require_len(bytes, *offset + len, "string16 body")?;
+    *offset += len;
+    Ok(())
 }
 
 fn require_len(bytes: &[u8], needed: usize, message: &'static str) -> Result<(), DecodeError> {
@@ -1184,6 +1421,35 @@ mod tests {
                 if slots[0] == ThemeSlot { id: 0x20, rgb: 0x112233 }
                     && slots[1] == ThemeSlot { id: 0x23, rgb: 0xAABBCC }
         ));
+    }
+
+    #[test]
+    fn skips_visible_completion_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_GUI_COMPLETION, 1, 0, 4, 0, 12, 0, 1, 0, 1, 2],
+            string16("write"),
+            string16("Save file"),
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+
+        let command = decode(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::Unsupported {
+                opcode,
+                size
+            } if opcode == opcodes::OP_GUI_COMPLETION && size == packet.len() - 1
+        ));
+    }
+
+    #[test]
+    fn skips_length_prefixed_config_state() {
+        let command = decode(&[opcodes::OP_GUI_CONFIG_STATE, 0, 3, 1, 2, 3]).unwrap();
+
+        assert_eq!(command.size(), 6);
     }
 
     #[test]

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -7,6 +7,10 @@ pub enum Command {
     TabBar(TabBar, usize),
     FileTree(FileTree, usize),
     FileTreeSelection(FileTreeSelection, usize),
+    Picker(Picker, usize),
+    PickerPreview(PickerPreview, usize),
+    Minibuffer(Minibuffer, usize),
+    Theme(Theme, usize),
     Unsupported { opcode: u8, size: usize },
 }
 
@@ -18,6 +22,10 @@ impl Command {
             Self::TabBar(_, size) => *size,
             Self::FileTree(_, size) => *size,
             Self::FileTreeSelection(_, size) => *size,
+            Self::Picker(_, size) => *size,
+            Self::PickerPreview(_, size) => *size,
+            Self::Minibuffer(_, size) => *size,
+            Self::Theme(_, size) => *size,
             Self::Unsupported { size, .. } => *size,
         }
     }
@@ -115,6 +123,75 @@ pub struct FileTreeSelection {
     pub selected_id: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Picker {
+    pub visible: bool,
+    pub selected_index: u16,
+    pub filtered_count: u16,
+    pub total_count: u16,
+    pub marked_count: u16,
+    pub has_preview: bool,
+    pub title: String,
+    pub query: String,
+    pub mode_prefix: String,
+    pub load_status: u8,
+    pub load_error: String,
+    pub items: Vec<PickerItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PickerItem {
+    pub label: String,
+    pub description: String,
+    pub annotation: String,
+    pub icon_color: u32,
+    pub marked: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PickerPreview {
+    pub visible: bool,
+    pub lines: Vec<Vec<PreviewSegment>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreviewSegment {
+    pub text: String,
+    pub fg: u32,
+    pub bold: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Minibuffer {
+    pub visible: bool,
+    pub mode: u8,
+    pub cursor_pos: u16,
+    pub prompt: String,
+    pub input: String,
+    pub context: String,
+    pub selected_index: u16,
+    pub total_candidates: u16,
+    pub candidates: Vec<MinibufferCandidate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MinibufferCandidate {
+    pub label: String,
+    pub description: String,
+    pub annotation: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Theme {
+    pub slots: Vec<ThemeSlot>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThemeSlot {
+    pub id: u8,
+    pub rgb: u32,
+}
+
 pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
     let opcode = *bytes.first().ok_or(DecodeError::Empty)?;
 
@@ -124,6 +201,10 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_TAB_BAR => decode_tab_bar(bytes),
         opcodes::OP_GUI_FILE_TREE => decode_file_tree(bytes),
         opcodes::OP_GUI_FILE_TREE_SELECTION => decode_file_tree_selection(bytes),
+        opcodes::OP_GUI_PICKER => decode_picker(bytes),
+        opcodes::OP_GUI_PICKER_PREVIEW => decode_picker_preview(bytes),
+        opcodes::OP_GUI_MINIBUFFER => decode_minibuffer(bytes),
+        opcodes::OP_GUI_THEME => decode_theme(bytes),
         opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA | opcodes::OP_GUI_WINDOW_ROWS_DELTA => {
             sectioned_size(bytes, "semantic row delta")
                 .map(|size| Command::Unsupported { opcode, size })
@@ -131,7 +212,7 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_WINDOW_OVERLAY_DELTA => {
             overlay_delta_size(bytes).map(|size| Command::Unsupported { opcode, size })
         }
-        opcodes::OP_GUI_GUTTER | opcodes::OP_GUI_PICKER | opcodes::OP_GUI_WHICH_KEY => {
+        opcodes::OP_GUI_GUTTER | opcodes::OP_GUI_WHICH_KEY => {
             sectioned_size(bytes, "semantic sectioned command")
                 .map(|size| Command::Unsupported { opcode, size })
         }
@@ -153,14 +234,10 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_SPLIT_SEPARATORS => {
             split_separators_size(bytes).map(|size| Command::Unsupported { opcode, size })
         }
-        opcodes::OP_GUI_THEME => {
-            theme_size(bytes).map(|size| Command::Unsupported { opcode, size })
-        }
         opcodes::OP_GUI_BREADCRUMB
         | opcodes::OP_GUI_COMPLETION
         | opcodes::OP_GUI_SIGNATURE_HELP
         | opcodes::OP_GUI_FLOAT_POPUP
-        | opcodes::OP_GUI_MINIBUFFER
         | opcodes::OP_GUI_HOVER_POPUP
         | opcodes::OP_GUI_AGENT_CONTEXT
         | opcodes::OP_GUI_GIT_STATUS
@@ -168,7 +245,6 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         | opcodes::OP_GUI_BOARD
         | opcodes::OP_GUI_AGENT_CHAT
         | opcodes::OP_GUI_BOTTOM_PANEL
-        | opcodes::OP_GUI_PICKER_PREVIEW
         | opcodes::OP_GUI_TOOL_MANAGER
         | opcodes::OP_GUI_CONFIG_STATE => {
             legacy_visible_size(bytes).map(|size| Command::Unsupported { opcode, size })
@@ -399,6 +475,214 @@ fn decode_file_tree_selection(bytes: &[u8]) -> Result<Command, DecodeError> {
         },
         size,
     ))
+}
+
+fn decode_picker(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 2, "picker header")?;
+    if bytes[1] == 0 {
+        return Ok(Command::Picker(Picker::default(), 2));
+    }
+
+    let size = sectioned_size(bytes, "picker")?;
+    let sections = sections(&bytes[..size])?;
+    let mut picker = Picker {
+        visible: true,
+        ..Picker::default()
+    };
+
+    for (section_id, payload) in sections {
+        match section_id {
+            0x01 => decode_picker_header(payload, &mut picker)?,
+            0x02 => {
+                let mut offset = 0;
+                picker.query = read_string16(payload, &mut offset)?;
+            }
+            0x03 => picker.items = decode_picker_items(payload)?,
+            0x05 => {
+                let mut offset = 0;
+                picker.mode_prefix = read_string16(payload, &mut offset)?;
+            }
+            0x06 => decode_picker_load_status(payload, &mut picker)?,
+            _ => {}
+        }
+    }
+
+    Ok(Command::Picker(picker, size))
+}
+
+fn decode_picker_header(payload: &[u8], picker: &mut Picker) -> Result<(), DecodeError> {
+    require_len(payload, 10, "picker header section")?;
+    picker.selected_index = read_u16(payload, 1);
+    picker.filtered_count = read_u16(payload, 3);
+    picker.total_count = read_u16(payload, 5);
+    picker.has_preview = payload[7] != 0;
+    let title_len = read_u16(payload, 8) as usize;
+    picker.title = read_string(payload, 10, title_len)?;
+    require_len(payload, 10 + title_len + 2, "picker marked count")?;
+    picker.marked_count = read_u16(payload, 10 + title_len);
+    Ok(())
+}
+
+fn decode_picker_items(payload: &[u8]) -> Result<Vec<PickerItem>, DecodeError> {
+    require_len(payload, 2, "picker item count")?;
+    let count = read_u16(payload, 0) as usize;
+    let mut offset = 2;
+    let mut items = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        require_len(payload, offset + 4, "picker item header")?;
+        let icon_color = read_u24(payload, offset);
+        let flags = payload[offset + 3];
+        offset += 4;
+        let label = read_string16(payload, &mut offset)?;
+        let description = read_string16(payload, &mut offset)?;
+        let annotation = read_string16(payload, &mut offset)?;
+        require_len(payload, offset + 1, "picker match count")?;
+        let match_count = payload[offset] as usize;
+        offset += 1 + match_count * 2;
+        require_len(payload, offset, "picker match positions")?;
+        items.push(PickerItem {
+            label,
+            description,
+            annotation,
+            icon_color,
+            marked: flags & 0x02 != 0,
+        });
+    }
+
+    Ok(items)
+}
+
+fn decode_picker_load_status(payload: &[u8], picker: &mut Picker) -> Result<(), DecodeError> {
+    require_len(payload, 1, "picker load status")?;
+    picker.load_status = payload[0];
+    if payload[0] == 2 {
+        let mut offset = 1;
+        picker.load_error = read_string16(payload, &mut offset)?;
+    }
+    Ok(())
+}
+
+fn decode_picker_preview(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 2, "picker preview header")?;
+    if bytes[1] == 0 {
+        return Ok(Command::PickerPreview(PickerPreview::default(), 2));
+    }
+
+    require_len(bytes, 4, "picker preview visible header")?;
+    let line_count = read_u16(bytes, 2) as usize;
+    let mut offset = 4;
+    let mut lines = Vec::with_capacity(line_count);
+
+    for _ in 0..line_count {
+        require_len(bytes, offset + 1, "picker preview segment count")?;
+        let segment_count = bytes[offset] as usize;
+        offset += 1;
+        let mut segments = Vec::with_capacity(segment_count);
+
+        for _ in 0..segment_count {
+            require_len(bytes, offset + 6, "picker preview segment")?;
+            let fg = read_u24(bytes, offset);
+            let bold = bytes[offset + 3] & 0x01 != 0;
+            let len = read_u16(bytes, offset + 4) as usize;
+            offset += 6;
+            let text = read_string(bytes, offset, len)?;
+            offset += len;
+            segments.push(PreviewSegment { text, fg, bold });
+        }
+
+        lines.push(segments);
+    }
+
+    Ok(Command::PickerPreview(
+        PickerPreview {
+            visible: true,
+            lines,
+        },
+        offset,
+    ))
+}
+
+fn decode_minibuffer(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 2, "minibuffer header")?;
+    if bytes[1] == 0 {
+        return Ok(Command::Minibuffer(Minibuffer::default(), 2));
+    }
+
+    require_len(bytes, 8, "minibuffer visible header")?;
+    let mut offset = 2;
+    let mode = bytes[offset];
+    offset += 1;
+    let cursor_pos = read_u16(bytes, offset);
+    offset += 2;
+    let prompt = read_string8(bytes, &mut offset)?;
+    let input = read_string16(bytes, &mut offset)?;
+    let context = read_string16(bytes, &mut offset)?;
+    require_len(bytes, offset + 6, "minibuffer candidate header")?;
+    let selected_index = read_u16(bytes, offset);
+    let candidate_count = read_u16(bytes, offset + 2) as usize;
+    let total_candidates = read_u16(bytes, offset + 4);
+    offset += 6;
+    let mut candidates = Vec::with_capacity(candidate_count);
+
+    for _ in 0..candidate_count {
+        let (candidate, used) = decode_minibuffer_candidate(&bytes[offset..])?;
+        offset += used;
+        candidates.push(candidate);
+    }
+
+    Ok(Command::Minibuffer(
+        Minibuffer {
+            visible: true,
+            mode,
+            cursor_pos,
+            prompt,
+            input,
+            context,
+            selected_index,
+            total_candidates,
+            candidates,
+        },
+        offset,
+    ))
+}
+
+fn decode_minibuffer_candidate(bytes: &[u8]) -> Result<(MinibufferCandidate, usize), DecodeError> {
+    require_len(bytes, 1, "minibuffer candidate score")?;
+    let mut offset = 1;
+    let label = read_string16(bytes, &mut offset)?;
+    let description = read_string16(bytes, &mut offset)?;
+    let annotation = read_string16(bytes, &mut offset)?;
+    require_len(bytes, offset + 1, "minibuffer candidate match count")?;
+    let match_count = bytes[offset] as usize;
+    offset += 1 + match_count * 2;
+    require_len(bytes, offset, "minibuffer candidate matches")?;
+
+    Ok((
+        MinibufferCandidate {
+            label,
+            description,
+            annotation,
+        },
+        offset,
+    ))
+}
+
+fn decode_theme(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = theme_size(bytes)?;
+    let count = bytes[1] as usize;
+    let mut slots = Vec::with_capacity(count);
+    let mut offset = 2;
+
+    for _ in 0..count {
+        slots.push(ThemeSlot {
+            id: bytes[offset],
+            rgb: read_u24(bytes, offset + 1),
+        });
+        offset += 4;
+    }
+
+    Ok(Command::Theme(Theme { slots }, size))
 }
 
 fn decode_file_tree_row(bytes: &[u8]) -> Result<(FileTreeRow, usize), DecodeError> {
@@ -792,6 +1076,113 @@ mod tests {
             decode(&selection).unwrap(),
             Command::FileTreeSelection(FileTreeSelection { focused: true, selected_id }, _)
                 if selected_id == "id-2"
+        ));
+    }
+
+    #[test]
+    fn decodes_picker_and_preview() {
+        let header = section(
+            0x01,
+            &[vec![1, 0, 1, 0, 4, 0, 9, 1], string16("Files"), vec![0, 2]].concat(),
+        );
+        let query = section(0x02, &string16("src"));
+        let item = [
+            vec![0xAA, 0xBB, 0xCC, 0x02],
+            string16("main.ex"),
+            string16("lib/minga"),
+            string16("modified"),
+            vec![0],
+        ]
+        .concat();
+        let items = section(0x03, &[vec![0, 1], item].concat());
+        let mode_prefix = section(0x05, &string16(">"));
+        let load = section(0x06, &[0]);
+        let packet = [
+            vec![opcodes::OP_GUI_PICKER, 5],
+            header,
+            query,
+            items,
+            mode_prefix,
+            load,
+        ]
+        .concat();
+
+        assert!(matches!(
+            decode(&packet).unwrap(),
+            Command::Picker(Picker { visible: true, selected_index: 1, title, query, marked_count: 2, items, .. }, _)
+                if title == "Files" && query == "src" && items[0].marked
+        ));
+
+        let preview = [
+            vec![
+                opcodes::OP_GUI_PICKER_PREVIEW,
+                1,
+                0,
+                1,
+                1,
+                0x11,
+                0x22,
+                0x33,
+                1,
+            ],
+            string16("preview"),
+        ]
+        .concat();
+
+        assert!(matches!(
+            decode(&preview).unwrap(),
+            Command::PickerPreview(PickerPreview { visible: true, lines }, _)
+                if lines[0][0].text == "preview" && lines[0][0].bold
+        ));
+    }
+
+    #[test]
+    fn decodes_minibuffer() {
+        let candidate = [
+            vec![42],
+            string16("write"),
+            string16("Save file"),
+            string16(":w"),
+            vec![0],
+        ]
+        .concat();
+        let packet = [
+            vec![opcodes::OP_GUI_MINIBUFFER, 1, 0, 0, 2],
+            string8(":"),
+            string16("w"),
+            string16("command"),
+            vec![0, 0, 0, 1, 0, 4],
+            candidate,
+        ]
+        .concat();
+
+        assert!(matches!(
+            decode(&packet).unwrap(),
+            Command::Minibuffer(Minibuffer { visible: true, prompt, input, candidates, total_candidates: 4, .. }, _)
+                if prompt == ":" && input == "w" && candidates[0].label == "write"
+        ));
+    }
+
+    #[test]
+    fn decodes_theme_slots() {
+        let packet = vec![
+            opcodes::OP_GUI_THEME,
+            2,
+            0x20,
+            0x11,
+            0x22,
+            0x33,
+            0x23,
+            0xAA,
+            0xBB,
+            0xCC,
+        ];
+
+        assert!(matches!(
+            decode(&packet).unwrap(),
+            Command::Theme(Theme { slots }, 10)
+                if slots[0] == ThemeSlot { id: 0x20, rgb: 0x112233 }
+                    && slots[1] == ThemeSlot { id: 0x23, rgb: 0xAABBCC }
         ));
     }
 


### PR DESCRIPTION
## Summary

- Decode semantic picker, picker preview, minibuffer, and theme packets in the Rust TUI path.
- Render picker as a retained semantic overlay with query, selected rows, counts, loading/error states, and split preview.
- Render minibuffer prompt and candidates using terminal cells.
- Apply active Minga theme slots to Rust TUI chrome instead of hardcoded colors, with fallbacks before the first theme packet.
- Add a dedicated `Test (Rust TUI)` CI job that runs Rust formatting, tests, and clippy for `rust/tui`.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'`
- `cargo fmt --manifest-path rust/tui/Cargo.toml --check`
- `cargo test --manifest-path rust/tui/Cargo.toml`
- `cargo clippy --manifest-path rust/tui/Cargo.toml -- -D warnings`
- `mix protocol.gen --check`
- `git diff --check -- rust/tui/src/semantic.rs rust/tui/src/renderer.rs`
- `mix compile --warnings-as-errors`