### PR TITLE
chore(cli): add TUI launcher shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,29 @@
-.PHONY: lint lint.format lint.credo lint.compile lint.dialyzer lint.fix test test.llm \
+.PHONY: help lint lint.format lint.credo lint.compile lint.dialyzer lint.fix test test.llm \
        release release-tui release-mac install install-tui install-mac uninstall
+
+.DEFAULT_GOAL := help
+
+help:
+	@printf "\n\033[1;35m╭────────────────────────────────────────────╮\033[0m\n"
+	@printf "\033[1;35m│\033[0m  \033[1mMinga developer commands\033[0m                 \033[1;35m│\033[0m\n"
+	@printf "\033[1;35m╰────────────────────────────────────────────╯\033[0m\n\n"
+	@printf "\033[1;36mRun the editor\033[0m\n"
+	@printf "  \033[1mbin/minga\033[0m          Launch the default Zig TUI\n"
+	@printf "  \033[1mbin/minga-go\033[0m       Launch the Go/Charm TUI\n"
+	@printf "  \033[1mbin/minga-rust\033[0m     Launch the Rust TUI\n"
+	@printf "  \033[1mbin/minga +gui\033[0m     Launch the native macOS GUI\n\n"
+	@printf "\033[1;36mQuality checks\033[0m\n"
+	@printf "  \033[1mmake lint\033[0m          Format, credo, compile, and dialyzer\n"
+	@printf "  \033[1mmake lint.fix\033[0m      Run format and strict credo\n"
+	@printf "  \033[1mmake test\033[0m          Run the full ExUnit suite\n"
+	@printf "  \033[1mmake test.llm\033[0m      Run the LLM-friendly test output\n\n"
+	@printf "\033[1;36mBuild and install\033[0m\n"
+	@printf "  \033[1mmake release\033[0m       Build release artifacts for this platform\n"
+	@printf "  \033[1mmake release-tui\033[0m   Build the TUI release\n"
+	@printf "  \033[1mmake release-mac\033[0m   Build the macOS GUI app\n"
+	@printf "  \033[1mmake install\033[0m       Install available local artifacts\n"
+	@printf "  \033[1mmake uninstall\033[0m     Remove installed local artifacts\n\n"
+	@printf "\033[2mTip: pass a file to a launcher, for example \033[0m\033[1mbin/minga-go README.md\033[0m\n\n"
 
 # ── Platform detection ──────────────────────────────────────────────────
 OS       := $(shell uname -s)

--- a/bin/minga-go
+++ b/bin/minga-go
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Development launcher for Minga with the Go/Charm TUI renderer.
+#
+# Usage:
+#   bin/minga-go [filename]
+#
+# Equivalent to:
+#   MINGA_TUI_IMPL=go bin/minga [filename]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+export MINGA_TUI_IMPL=go
+
+exec "$SCRIPT_DIR/minga" "$@"

--- a/bin/minga-rust
+++ b/bin/minga-rust
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Development launcher for Minga with the Rust TUI renderer.
+#
+# Usage:
+#   bin/minga-rust [filename]
+#
+# Equivalent to:
+#   MINGA_TUI_IMPL=rust bin/minga [filename]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+export MINGA_TUI_IMPL=rust
+
+exec "$SCRIPT_DIR/minga" "$@"


### PR DESCRIPTION
# TL;DR
Adds development launchers for the Go/Charm and Rust TUI renderers, and makes plain `make` show a styled help screen by default.

## Context
The default Zig TUI already has `bin/minga`. The experimental Go and Rust TUI renderers can be selected through `MINGA_TUI_IMPL`, but that is easy to forget. This PR adds direct launcher scripts and makes the Makefile easier to discover from a cold start.

## Changes
- Adds `bin/minga-go`, which sets `MINGA_TUI_IMPL=go` and delegates to `bin/minga`.
- Adds `bin/minga-rust`, which sets `MINGA_TUI_IMPL=rust` and delegates to `bin/minga`.
- Adds `make help` as the default Makefile target via `.DEFAULT_GOAL := help`.
- Adds a styled help output covering editor launchers, quality checks, and build/install targets.

## Verification
- `make` prints the help output with no target.
- `make help` prints the same help output.
- `bash -n bin/minga bin/minga-go bin/minga-rust bin/minga-mac`
- `git diff --check`
