### PR TITLE
Render Rust TUI semantic chrome with Ratatui widgets

### DIFF
--- a/rust/tui/Cargo.lock
+++ b/rust/tui/Cargo.lock
@@ -3,14 +3,408 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown",
+ "thiserror",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "minga-renderer-rs"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "ratatui",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags",
+ "compact_str",
+ "hashbrown",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags",
+ "hashbrown",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"

--- a/rust/tui/Cargo.toml
+++ b/rust/tui/Cargo.toml
@@ -10,3 +10,4 @@ path = "src/main.rs"
 
 [dependencies]
 libc = "0.2.184"
+ratatui = { version = "0.30.0", default-features = false }

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -3,6 +3,10 @@ mod theme;
 use crate::protocol::{self, Command, DrawStyledText, DrawText, Region};
 use crate::semantic;
 use crate::terminal::{CellStyle, Terminal};
+use ratatui::buffer::Buffer as RatatuiBuffer;
+use ratatui::layout::Rect as RatatuiRect;
+use ratatui::style::{Color as RatatuiColor, Modifier, Style as RatatuiStyle};
+use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
 use std::collections::HashMap;
 use std::io::{self, Write};
 use theme::{SLOT_EDITOR_BG, ThemePalette};
@@ -53,10 +57,16 @@ pub struct Renderer {
     minibuffer: Option<semantic::Minibuffer>,
     completion: Option<semantic::Completion>,
     which_key: Option<semantic::WhichKey>,
+    signature_help: Option<semantic::SignatureHelp>,
+    float_popup: Option<semantic::FloatPopup>,
+    hover_popup: Option<semantic::HoverPopup>,
     picker_snapshot: Option<CellSnapshot>,
     minibuffer_snapshot: Option<CellSnapshot>,
     completion_snapshot: Option<CellSnapshot>,
     which_key_snapshot: Option<CellSnapshot>,
+    signature_help_snapshot: Option<CellSnapshot>,
+    float_popup_snapshot: Option<CellSnapshot>,
+    hover_popup_snapshot: Option<CellSnapshot>,
     theme: ThemePalette,
 }
 
@@ -80,10 +90,16 @@ impl Renderer {
             minibuffer: None,
             completion: None,
             which_key: None,
+            signature_help: None,
+            float_popup: None,
+            hover_popup: None,
             picker_snapshot: None,
             minibuffer_snapshot: None,
             completion_snapshot: None,
             which_key_snapshot: None,
+            signature_help_snapshot: None,
+            float_popup_snapshot: None,
+            hover_popup_snapshot: None,
             theme: ThemePalette::default(),
         }
     }
@@ -155,10 +171,16 @@ impl Renderer {
         self.minibuffer = None;
         self.completion = None;
         self.which_key = None;
+        self.signature_help = None;
+        self.float_popup = None;
+        self.hover_popup = None;
         self.picker_snapshot = None;
         self.minibuffer_snapshot = None;
         self.completion_snapshot = None;
         self.which_key_snapshot = None;
+        self.signature_help_snapshot = None;
+        self.float_popup_snapshot = None;
+        self.hover_popup_snapshot = None;
     }
 
     fn clear(&mut self) {
@@ -227,6 +249,11 @@ impl Renderer {
             semantic::Command::Breadcrumb(breadcrumb, _) => self.draw_breadcrumb(breadcrumb),
             semantic::Command::Completion(completion, _) => self.draw_completion(completion),
             semantic::Command::WhichKey(which_key, _) => self.draw_which_key(which_key),
+            semantic::Command::SignatureHelp(signature_help, _) => {
+                self.draw_signature_help(signature_help)
+            }
+            semantic::Command::FloatPopup(float_popup, _) => self.draw_float_popup(float_popup),
+            semantic::Command::HoverPopup(hover_popup, _) => self.draw_hover_popup(hover_popup),
             semantic::Command::Theme(theme, _) => self.apply_theme(theme),
             semantic::Command::Unsupported { .. } => {}
         }
@@ -425,6 +452,36 @@ impl Renderer {
         }
     }
 
+    fn draw_signature_help(&mut self, signature_help: semantic::SignatureHelp) {
+        if signature_help.visible {
+            self.signature_help = Some(signature_help.clone());
+            self.render_signature_help(&signature_help);
+        } else {
+            self.restore_signature_help_snapshot();
+            self.signature_help = None;
+        }
+    }
+
+    fn draw_float_popup(&mut self, float_popup: semantic::FloatPopup) {
+        if float_popup.visible {
+            self.float_popup = Some(float_popup.clone());
+            self.render_float_popup(&float_popup);
+        } else {
+            self.restore_float_popup_snapshot();
+            self.float_popup = None;
+        }
+    }
+
+    fn draw_hover_popup(&mut self, hover_popup: semantic::HoverPopup) {
+        if hover_popup.visible {
+            self.hover_popup = Some(hover_popup.clone());
+            self.render_hover_popup(&hover_popup);
+        } else {
+            self.restore_hover_popup_snapshot();
+            self.hover_popup = None;
+        }
+    }
+
     fn render_minibuffer(&mut self, minibuffer: &semantic::Minibuffer) {
         self.capture_minibuffer_snapshot();
         self.restore_minibuffer_cells();
@@ -511,6 +568,19 @@ impl Renderer {
         if let Some(which_key) = self.which_key.clone() {
             self.which_key_snapshot = None;
             self.render_which_key(&which_key);
+        }
+
+        if let Some(signature_help) = self.signature_help.clone() {
+            self.signature_help_snapshot = None;
+            self.render_signature_help(&signature_help);
+        }
+        if let Some(float_popup) = self.float_popup.clone() {
+            self.float_popup_snapshot = None;
+            self.render_float_popup(&float_popup);
+        }
+        if let Some(hover_popup) = self.hover_popup.clone() {
+            self.hover_popup_snapshot = None;
+            self.render_hover_popup(&hover_popup);
         }
 
         if let Some(minibuffer) = self.minibuffer.clone() {
@@ -752,6 +822,175 @@ impl Renderer {
         if let Some(snapshot) = self.which_key_snapshot.clone() {
             self.restore_snapshot(snapshot);
         }
+    }
+
+    fn render_signature_help(&mut self, signature_help: &semantic::SignatureHelp) {
+        self.restore_signature_help_cells();
+        let Some(signature) = signature_help
+            .signatures
+            .get(signature_help.active_signature as usize)
+            .or_else(|| signature_help.signatures.first())
+        else {
+            return;
+        };
+
+        let mut lines = vec![highlight_signature_label(
+            signature,
+            signature_help.active_parameter as usize,
+        )];
+        if !signature.documentation.is_empty() {
+            lines.push(signature.documentation.clone());
+        }
+        if let Some(parameter) = signature
+            .parameters
+            .get(signature_help.active_parameter as usize)
+            && !parameter.documentation.is_empty()
+        {
+            lines.push(format!("{}: {}", parameter.label, parameter.documentation));
+        }
+
+        let (row, col, width, height) = anchored_popup_geometry(
+            self.width,
+            self.height,
+            signature_help.anchor_row,
+            signature_help.anchor_col,
+            lines.iter().map(String::as_str),
+            "Signature",
+        );
+        if self.signature_help_snapshot.is_none() {
+            self.signature_help_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+        self.render_popup_panel(row, col, width, height, " Signature ", lines.join("\n"));
+    }
+
+    fn restore_signature_help_snapshot(&mut self) {
+        if let Some(snapshot) = self.signature_help_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_signature_help_cells(&mut self) {
+        if let Some(snapshot) = self.signature_help_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn render_float_popup(&mut self, float_popup: &semantic::FloatPopup) {
+        self.restore_float_popup_cells();
+        if float_popup.width == 0 || float_popup.height == 0 {
+            return;
+        }
+
+        let width = float_popup.width.min(self.width).max(12);
+        let height = float_popup.height.min(self.height).max(3);
+        let row = self.height.saturating_sub(height) / 2;
+        let col = self.width.saturating_sub(width) / 2;
+        if self.float_popup_snapshot.is_none() {
+            self.float_popup_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+
+        let title = if float_popup.title.is_empty() {
+            " Popup ".to_owned()
+        } else {
+            format!(" {} ", float_popup.title)
+        };
+        self.render_popup_panel(
+            row,
+            col,
+            width,
+            height,
+            &title,
+            float_popup.lines.join("\n"),
+        );
+    }
+
+    fn restore_float_popup_snapshot(&mut self) {
+        if let Some(snapshot) = self.float_popup_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_float_popup_cells(&mut self) {
+        if let Some(snapshot) = self.float_popup_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn render_hover_popup(&mut self, hover_popup: &semantic::HoverPopup) {
+        self.restore_hover_popup_cells();
+        if hover_popup.lines.is_empty() {
+            return;
+        }
+
+        let lines: Vec<String> = hover_popup
+            .lines
+            .iter()
+            .skip(hover_popup.scroll_offset as usize)
+            .map(|line| {
+                let text = line
+                    .segments
+                    .iter()
+                    .map(|segment| segment.text.as_str())
+                    .collect::<String>();
+                if line.line_type == 1 {
+                    format!("  {text}")
+                } else {
+                    text
+                }
+            })
+            .collect();
+        let title = if hover_popup.focused {
+            " Hover * "
+        } else {
+            " Hover "
+        };
+        let (row, col, width, height) = anchored_popup_geometry(
+            self.width,
+            self.height,
+            hover_popup.anchor_row,
+            hover_popup.anchor_col,
+            lines.iter().map(String::as_str),
+            title,
+        );
+        if self.hover_popup_snapshot.is_none() {
+            self.hover_popup_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+        self.render_popup_panel(row, col, width, height, title, lines.join("\n"));
+    }
+
+    fn restore_hover_popup_snapshot(&mut self) {
+        if let Some(snapshot) = self.hover_popup_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_hover_popup_cells(&mut self) {
+        if let Some(snapshot) = self.hover_popup_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn render_popup_panel(
+        &mut self,
+        row: u16,
+        col: u16,
+        width: u16,
+        height: u16,
+        title: &str,
+        body: String,
+    ) {
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let paragraph = Paragraph::new(body)
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(title.to_owned()),
+            );
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn render_picker_items(
@@ -1087,6 +1326,40 @@ impl Renderer {
         }
     }
 
+    fn render_ratatui_widget<W: Widget>(
+        &mut self,
+        row: u16,
+        col: u16,
+        width: u16,
+        height: u16,
+        widget: W,
+    ) {
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        let area = RatatuiRect::new(0, 0, width, height);
+        let mut buffer = RatatuiBuffer::empty(area);
+        widget.render(area, &mut buffer);
+
+        for y in 0..height {
+            for x in 0..width {
+                let target_row = row.saturating_add(y);
+                let target_col = col.saturating_add(x);
+                let Some(target_index) = self.index(target_col, target_row) else {
+                    continue;
+                };
+                let Some(source) = buffer.cell((x, y)) else {
+                    continue;
+                };
+                self.cells[target_index] = Cell {
+                    text: source.symbol().to_owned(),
+                    style: cell_style_from_ratatui(source),
+                };
+            }
+        }
+    }
+
     fn capture_rect(&self, row: u16, col: u16, width: u16, height: u16) -> CellSnapshot {
         let max_row = row.saturating_add(height).min(self.height);
         let max_col = col.saturating_add(width).min(self.width);
@@ -1191,6 +1464,46 @@ fn picker_geometry(width: u16, height: u16) -> (u16, u16, u16, u16) {
     )
 }
 
+fn anchored_popup_geometry<'a>(
+    screen_width: u16,
+    screen_height: u16,
+    anchor_row: u16,
+    anchor_col: u16,
+    lines: impl Iterator<Item = &'a str>,
+    title: &str,
+) -> (u16, u16, u16, u16) {
+    let mut max_width = text_width(title);
+    let mut line_count = 0_u16;
+    for line in lines {
+        max_width = max_width.max(text_width(line));
+        line_count = line_count.saturating_add(1);
+    }
+
+    let width = max_width.saturating_add(4).clamp(18, 72).min(screen_width);
+    let height = line_count.saturating_add(2).clamp(3, 12).min(screen_height);
+    let below_row = anchor_row.saturating_add(1);
+    let row = if below_row.saturating_add(height) <= screen_height {
+        below_row
+    } else {
+        anchor_row.saturating_sub(height)
+    };
+    let col = anchor_col.min(screen_width.saturating_sub(width));
+    (row, col, width, height)
+}
+
+fn highlight_signature_label(signature: &semantic::Signature, active_parameter: usize) -> String {
+    let Some(parameter) = signature.parameters.get(active_parameter) else {
+        return signature.label.clone();
+    };
+    if parameter.label.is_empty() {
+        signature.label.clone()
+    } else {
+        signature
+            .label
+            .replace(&parameter.label, &format!("[{}]", parameter.label))
+    }
+}
+
 fn completion_width(completion: &semantic::Completion) -> u16 {
     completion
         .items
@@ -1222,6 +1535,93 @@ fn completion_kind_marker(kind: u8) -> &'static str {
         12 => "en",
         _ => "tx",
     }
+}
+
+fn ratatui_style_from_cell(style: CellStyle) -> RatatuiStyle {
+    let mut out = RatatuiStyle::default();
+    if style.fg != 0 {
+        out = out.fg(ratatui_color_from_rgb(style.fg));
+    }
+    if style.bg != 0 {
+        out = out.bg(ratatui_color_from_rgb(style.bg));
+    }
+    if style.attrs & protocol::ATTR_BOLD != 0 {
+        out = out.add_modifier(Modifier::BOLD);
+    }
+    if style.attrs & protocol::ATTR_ITALIC != 0 {
+        out = out.add_modifier(Modifier::ITALIC);
+    }
+    if style.attrs & protocol::ATTR_UNDERLINE != 0 {
+        out = out.add_modifier(Modifier::UNDERLINED);
+    }
+    if style.attrs & protocol::ATTR_REVERSE != 0 {
+        out = out.add_modifier(Modifier::REVERSED);
+    }
+    if style.attrs & protocol::ATTR_STRIKETHROUGH != 0 {
+        out = out.add_modifier(Modifier::CROSSED_OUT);
+    }
+    out
+}
+
+fn ratatui_color_from_rgb(rgb: u32) -> RatatuiColor {
+    RatatuiColor::Rgb(
+        ((rgb >> 16) & 0xFF) as u8,
+        ((rgb >> 8) & 0xFF) as u8,
+        (rgb & 0xFF) as u8,
+    )
+}
+
+fn cell_style_from_ratatui(cell: &ratatui::buffer::Cell) -> CellStyle {
+    CellStyle {
+        fg: rgb_from_ratatui(cell.fg),
+        bg: rgb_from_ratatui(cell.bg),
+        attrs: attrs_from_modifier(cell.modifier),
+        ul_color: 0,
+        blend: 100,
+    }
+}
+
+fn rgb_from_ratatui(color: RatatuiColor) -> u32 {
+    match color {
+        RatatuiColor::Rgb(r, g, b) => ((r as u32) << 16) | ((g as u32) << 8) | b as u32,
+        RatatuiColor::Black => 0x000000,
+        RatatuiColor::Red => 0xFF5555,
+        RatatuiColor::Green => 0x50FA7B,
+        RatatuiColor::Yellow => 0xF1FA8C,
+        RatatuiColor::Blue => 0xBD93F9,
+        RatatuiColor::Magenta => 0xFF79C6,
+        RatatuiColor::Cyan => 0x8BE9FD,
+        RatatuiColor::Gray => 0x808080,
+        RatatuiColor::DarkGray => 0x404040,
+        RatatuiColor::LightRed => 0xFF6E6E,
+        RatatuiColor::LightGreen => 0x69FF94,
+        RatatuiColor::LightYellow => 0xFFFFA5,
+        RatatuiColor::LightBlue => 0xD6ACFF,
+        RatatuiColor::LightMagenta => 0xFF92DF,
+        RatatuiColor::LightCyan => 0xA4FFFF,
+        RatatuiColor::White => 0xFFFFFF,
+        _ => 0,
+    }
+}
+
+fn attrs_from_modifier(modifier: Modifier) -> u16 {
+    let mut attrs = 0;
+    if modifier.contains(Modifier::BOLD) {
+        attrs |= protocol::ATTR_BOLD;
+    }
+    if modifier.contains(Modifier::ITALIC) {
+        attrs |= protocol::ATTR_ITALIC;
+    }
+    if modifier.contains(Modifier::UNDERLINED) {
+        attrs |= protocol::ATTR_UNDERLINE;
+    }
+    if modifier.contains(Modifier::REVERSED) {
+        attrs |= protocol::ATTR_REVERSE;
+    }
+    if modifier.contains(Modifier::CROSSED_OUT) {
+        attrs |= protocol::ATTR_STRIKETHROUGH;
+    }
+    attrs
 }
 
 fn git_marker(status: u8) -> &'static str {
@@ -1949,6 +2349,71 @@ mod tests {
         assert_eq!(renderer.cells[renderer.index(4, 5).unwrap()].text, "f");
         assert_eq!(renderer.cells[renderer.index(3, 13).unwrap()].text, "S");
         assert_eq!(renderer.cells[renderer.index(5, 14).unwrap()].text, "f");
+    }
+
+    #[test]
+    fn semantic_popups_render_with_ratatui_and_restore() {
+        let mut renderer = Renderer::new(60, 16);
+        renderer.draw_text(DrawText {
+            row: 4,
+            col: 5,
+            fg: 0x111111,
+            bg: 0x222222,
+            attrs: 0,
+            text: "under".to_owned(),
+        });
+
+        renderer.draw_signature_help(semantic::SignatureHelp {
+            visible: true,
+            anchor_row: 2,
+            anchor_col: 4,
+            active_signature: 0,
+            active_parameter: 0,
+            signatures: vec![semantic::Signature {
+                label: "open(path)".to_owned(),
+                documentation: "Open file".to_owned(),
+                parameters: vec![semantic::SignatureParameter {
+                    label: "path".to_owned(),
+                    documentation: "File path".to_owned(),
+                }],
+            }],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(5, 4).unwrap()].text, "o");
+
+        renderer.draw_signature_help(semantic::SignatureHelp::default());
+
+        let restored = &renderer.cells[renderer.index(5, 4).unwrap()];
+        assert_eq!(restored.text, "u");
+        assert_eq!(restored.style.fg, 0x111111);
+        assert_eq!(restored.style.bg, 0x222222);
+
+        renderer.draw_float_popup(semantic::FloatPopup {
+            visible: true,
+            width: 24,
+            height: 5,
+            title: "Docs".to_owned(),
+            lines: vec!["alpha".to_owned(), "beta".to_owned()],
+        });
+        assert_eq!(renderer.cells[renderer.index(19, 6).unwrap()].text, "a");
+
+        renderer.draw_hover_popup(semantic::HoverPopup {
+            visible: true,
+            anchor_row: 1,
+            anchor_col: 8,
+            focused: true,
+            scroll_offset: 0,
+            lines: vec![semantic::HoverLine {
+                line_type: 0,
+                segments: vec![semantic::HoverSegment {
+                    style: 0,
+                    fg: 0,
+                    flags: 0,
+                    text: "hover docs".to_owned(),
+                }],
+            }],
+        });
+        assert_eq!(renderer.cells[renderer.index(9, 3).unwrap()].text, "h");
     }
 
     #[test]

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -40,6 +40,12 @@ impl Default for Cell {
     }
 }
 
+impl CellSnapshot {
+    fn matches_rect(&self, row: u16, col: u16, width: u16, height: u16) -> bool {
+        self.row == row && self.col == col && self.width == width && self.height == height
+    }
+}
+
 pub struct Renderer {
     width: u16,
     height: u16,
@@ -439,8 +445,14 @@ impl Renderer {
         }
 
         let row = 1;
+        let col = self.visible_file_tree_width();
+        let width = self.width.saturating_sub(col);
+        if width == 0 {
+            return;
+        }
+
         if breadcrumb.segments.is_empty() {
-            self.clear_row(row);
+            self.write_run(row, col, &" ".repeat(width as usize), CellStyle::default());
             self.breadcrumb = None;
             return;
         }
@@ -449,8 +461,8 @@ impl Renderer {
         let text = format!(" {}", breadcrumb.segments.join(" / "));
         self.write_run(
             row,
-            0,
-            &pad_to_width(&text, self.width),
+            col,
+            &pad_to_width(&text, width),
             self.theme.breadcrumb_style(),
         );
     }
@@ -756,6 +768,14 @@ impl Renderer {
         }
     }
 
+    fn visible_file_tree_width(&self) -> u16 {
+        self.file_tree
+            .as_ref()
+            .filter(|tree| tree.visible)
+            .map(|tree| tree.width.min(self.width))
+            .unwrap_or(0)
+    }
+
     fn render_completion(&mut self, completion: &semantic::Completion) {
         self.restore_completion_cells();
         if completion.items.is_empty() || self.width == 0 || self.height == 0 {
@@ -770,7 +790,8 @@ impl Renderer {
             .min(self.height.saturating_sub(height));
         let col = completion.anchor_col.min(self.width.saturating_sub(width));
 
-        if self.completion_snapshot.is_none() {
+        if !snapshot_matches(&self.completion_snapshot, row, col, width, height) {
+            self.restore_completion_snapshot();
             self.completion_snapshot = Some(self.capture_rect(row, col, width, height));
         }
 
@@ -834,7 +855,8 @@ impl Renderer {
         let row = self.height.saturating_sub(height + 1);
         let col = self.width.saturating_sub(width) / 2;
 
-        if self.which_key_snapshot.is_none() {
+        if !snapshot_matches(&self.which_key_snapshot, row, col, width, height) {
+            self.restore_which_key_snapshot();
             self.which_key_snapshot = Some(self.capture_rect(row, col, width, height));
         }
 
@@ -922,7 +944,8 @@ impl Renderer {
             lines.iter().map(String::as_str),
             "Signature",
         );
-        if self.signature_help_snapshot.is_none() {
+        if !snapshot_matches(&self.signature_help_snapshot, row, col, width, height) {
+            self.restore_signature_help_snapshot();
             self.signature_help_snapshot = Some(self.capture_rect(row, col, width, height));
         }
         self.render_popup_panel(row, col, width, height, " Signature ", lines.join("\n"));
@@ -1713,6 +1736,18 @@ fn anchored_popup_geometry<'a>(
     (row, col, width, height)
 }
 
+fn snapshot_matches(
+    snapshot: &Option<CellSnapshot>,
+    row: u16,
+    col: u16,
+    width: u16,
+    height: u16,
+) -> bool {
+    snapshot
+        .as_ref()
+        .is_some_and(|snapshot| snapshot.matches_rect(row, col, width, height))
+}
+
 fn highlight_signature_label(signature: &semantic::Signature, active_parameter: usize) -> String {
     let Some(parameter) = signature.parameters.get(active_parameter) else {
         return signature.label.clone();
@@ -2197,6 +2232,38 @@ mod tests {
     }
 
     #[test]
+    fn semantic_breadcrumb_preserves_visible_file_tree_rows() {
+        let mut renderer = Renderer::new(32, 6);
+
+        renderer.draw_file_tree(semantic::FileTree {
+            visible: true,
+            focused: true,
+            status: 3,
+            selected_id: "a".to_owned(),
+            root_path: "/tmp".to_owned(),
+            width: 12,
+            error: String::new(),
+            rows: vec![semantic::FileTreeRow {
+                id: "a".to_owned(),
+                name: "src".to_owned(),
+                icon: "D".to_owned(),
+                depth: 0,
+                flags: 0x17,
+                git_status: 0,
+                diagnostics: (0, 0, 0, 0),
+                editing_text: String::new(),
+            }],
+        });
+
+        renderer.draw_breadcrumb(semantic::Breadcrumb {
+            segments: vec!["lib".to_owned(), "minga".to_owned()],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(1, 1).unwrap()].text, "v");
+        assert_eq!(renderer.cells[renderer.index(13, 1).unwrap()].text, "l");
+    }
+
+    #[test]
     fn semantic_picker_draws_split_overlay() {
         let mut renderer = Renderer::new(80, 20);
 
@@ -2612,6 +2679,65 @@ mod tests {
     }
 
     #[test]
+    fn semantic_completion_recaptures_snapshot_when_geometry_changes() {
+        let mut renderer = Renderer::new(60, 16);
+        renderer.draw_text(DrawText {
+            row: 4,
+            col: 5,
+            fg: 0x111111,
+            bg: 0x222222,
+            attrs: 0,
+            text: "old-under".to_owned(),
+        });
+        renderer.draw_text(DrawText {
+            row: 10,
+            col: 20,
+            fg: 0x333333,
+            bg: 0x444444,
+            attrs: 0,
+            text: "new-under".to_owned(),
+        });
+
+        renderer.draw_completion(semantic::Completion {
+            visible: true,
+            anchor_row: 3,
+            anchor_col: 5,
+            selected_index: 0,
+            items: vec![semantic::CompletionItem {
+                kind: 1,
+                label: "write".to_owned(),
+                detail: String::new(),
+            }],
+        });
+        renderer.draw_completion(semantic::Completion {
+            visible: true,
+            anchor_row: 9,
+            anchor_col: 20,
+            selected_index: 0,
+            items: vec![semantic::CompletionItem {
+                kind: 1,
+                label: "read".to_owned(),
+                detail: "second".to_owned(),
+            }],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(5, 4).unwrap()].text, "o");
+        assert_eq!(renderer.cells[renderer.index(20, 10).unwrap()].text, "f");
+
+        renderer.draw_completion(semantic::Completion::default());
+
+        let old_cell = &renderer.cells[renderer.index(5, 4).unwrap()];
+        assert_eq!(old_cell.text, "o");
+        assert_eq!(old_cell.style.fg, 0x111111);
+        assert_eq!(old_cell.style.bg, 0x222222);
+
+        let new_cell = &renderer.cells[renderer.index(20, 10).unwrap()];
+        assert_eq!(new_cell.text, "n");
+        assert_eq!(new_cell.style.fg, 0x333333);
+        assert_eq!(new_cell.style.bg, 0x444444);
+    }
+
+    #[test]
     fn semantic_window_redraw_replays_retained_completion_and_which_key() {
         let mut renderer = Renderer::new(60, 16);
 
@@ -2654,6 +2780,68 @@ mod tests {
         assert_eq!(renderer.cells[renderer.index(4, 5).unwrap()].text, "f");
         assert_eq!(renderer.cells[renderer.index(3, 13).unwrap()].text, "S");
         assert_eq!(renderer.cells[renderer.index(5, 14).unwrap()].text, "f");
+    }
+
+    #[test]
+    fn semantic_which_key_recaptures_snapshot_when_height_changes() {
+        let mut renderer = Renderer::new(60, 16);
+        renderer.draw_text(DrawText {
+            row: 13,
+            col: 3,
+            fg: 0x111111,
+            bg: 0x222222,
+            attrs: 0,
+            text: "old-row".to_owned(),
+        });
+        renderer.draw_text(DrawText {
+            row: 10,
+            col: 3,
+            fg: 0x333333,
+            bg: 0x444444,
+            attrs: 0,
+            text: "new-row".to_owned(),
+        });
+
+        renderer.draw_which_key(semantic::WhichKey {
+            visible: true,
+            prefix: "SPC".to_owned(),
+            page: 0,
+            page_count: 1,
+            bindings: vec![semantic::WhichKeyBinding {
+                kind: 0,
+                key: "f".to_owned(),
+                description: "Find file".to_owned(),
+                icon: String::new(),
+            }],
+        });
+        renderer.draw_which_key(semantic::WhichKey {
+            visible: true,
+            prefix: "SPC".to_owned(),
+            page: 0,
+            page_count: 1,
+            bindings: (0..4)
+                .map(|index| semantic::WhichKeyBinding {
+                    kind: 0,
+                    key: format!("k{index}"),
+                    description: format!("Binding {index}"),
+                    icon: String::new(),
+                })
+                .collect(),
+        });
+
+        assert_eq!(renderer.cells[renderer.index(3, 10).unwrap()].text, "S");
+
+        renderer.draw_which_key(semantic::WhichKey::default());
+
+        let old_cell = &renderer.cells[renderer.index(3, 13).unwrap()];
+        assert_eq!(old_cell.text, "o");
+        assert_eq!(old_cell.style.fg, 0x111111);
+        assert_eq!(old_cell.style.bg, 0x222222);
+
+        let new_cell = &renderer.cells[renderer.index(3, 10).unwrap()];
+        assert_eq!(new_cell.text, "n");
+        assert_eq!(new_cell.style.fg, 0x333333);
+        assert_eq!(new_cell.style.bg, 0x444444);
     }
 
     #[test]
@@ -2719,6 +2907,67 @@ mod tests {
             }],
         });
         assert_eq!(renderer.cells[renderer.index(9, 3).unwrap()].text, "h");
+    }
+
+    #[test]
+    fn semantic_signature_help_recaptures_snapshot_when_geometry_changes() {
+        let mut renderer = Renderer::new(60, 16);
+        renderer.draw_text(DrawText {
+            row: 4,
+            col: 5,
+            fg: 0x111111,
+            bg: 0x222222,
+            attrs: 0,
+            text: "old-under".to_owned(),
+        });
+        renderer.draw_text(DrawText {
+            row: 10,
+            col: 20,
+            fg: 0x333333,
+            bg: 0x444444,
+            attrs: 0,
+            text: "new-under".to_owned(),
+        });
+
+        let signature = semantic::Signature {
+            label: "open(path)".to_owned(),
+            documentation: "Open file".to_owned(),
+            parameters: vec![semantic::SignatureParameter {
+                label: "path".to_owned(),
+                documentation: "File path".to_owned(),
+            }],
+        };
+        renderer.draw_signature_help(semantic::SignatureHelp {
+            visible: true,
+            anchor_row: 2,
+            anchor_col: 4,
+            active_signature: 0,
+            active_parameter: 0,
+            signatures: vec![signature.clone()],
+        });
+        renderer.draw_signature_help(semantic::SignatureHelp {
+            visible: true,
+            anchor_row: 8,
+            anchor_col: 19,
+            active_signature: 0,
+            active_parameter: 0,
+            signatures: vec![signature],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(5, 4).unwrap()].text, "o");
+        assert_eq!(renderer.cells[renderer.index(20, 10).unwrap()].text, "o");
+
+        renderer.draw_signature_help(semantic::SignatureHelp::default());
+
+        let old_cell = &renderer.cells[renderer.index(5, 4).unwrap()];
+        assert_eq!(old_cell.text, "o");
+        assert_eq!(old_cell.style.fg, 0x111111);
+        assert_eq!(old_cell.style.bg, 0x222222);
+
+        let new_cell = &renderer.cells[renderer.index(20, 10).unwrap()];
+        assert_eq!(new_cell.text, "n");
+        assert_eq!(new_cell.style.fg, 0x333333);
+        assert_eq!(new_cell.style.bg, 0x444444);
     }
 
     #[test]

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -1,18 +1,21 @@
+mod theme;
+
 use crate::protocol::{self, Command, DrawStyledText, DrawText, Region};
 use crate::semantic;
 use crate::terminal::{CellStyle, Terminal};
 use std::collections::HashMap;
 use std::io::{self, Write};
+use theme::{SLOT_EDITOR_BG, ThemePalette};
+
+#[cfg(test)]
+use theme::{
+    SLOT_MODELINE_BAR_BG, SLOT_POPUP_BG, SLOT_POPUP_FG, SLOT_POPUP_SEL_BG, SLOT_POPUP_SEL_FG,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct Cell {
     text: String,
     style: CellStyle,
-}
-
-#[derive(Debug, Clone, Default)]
-struct ThemePalette {
-    slots: HashMap<u8, u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -44,11 +47,16 @@ pub struct Renderer {
     regions: HashMap<u16, Region>,
     active_region: Option<Region>,
     file_tree: Option<semantic::FileTree>,
+    breadcrumb: Option<semantic::Breadcrumb>,
     picker: Option<semantic::Picker>,
     picker_preview: Option<semantic::PickerPreview>,
     minibuffer: Option<semantic::Minibuffer>,
+    completion: Option<semantic::Completion>,
+    which_key: Option<semantic::WhichKey>,
     picker_snapshot: Option<CellSnapshot>,
     minibuffer_snapshot: Option<CellSnapshot>,
+    completion_snapshot: Option<CellSnapshot>,
+    which_key_snapshot: Option<CellSnapshot>,
     theme: ThemePalette,
 }
 
@@ -66,11 +74,16 @@ impl Renderer {
             regions: HashMap::new(),
             active_region: None,
             file_tree: None,
+            breadcrumb: None,
             picker: None,
             picker_preview: None,
             minibuffer: None,
+            completion: None,
+            which_key: None,
             picker_snapshot: None,
             minibuffer_snapshot: None,
+            completion_snapshot: None,
+            which_key_snapshot: None,
             theme: ThemePalette::default(),
         }
     }
@@ -136,11 +149,16 @@ impl Renderer {
         self.regions.clear();
         self.active_region = None;
         self.file_tree = None;
+        self.breadcrumb = None;
         self.picker = None;
         self.picker_preview = None;
         self.minibuffer = None;
+        self.completion = None;
+        self.which_key = None;
         self.picker_snapshot = None;
         self.minibuffer_snapshot = None;
+        self.completion_snapshot = None;
+        self.which_key_snapshot = None;
     }
 
     fn clear(&mut self) {
@@ -206,6 +224,9 @@ impl Renderer {
             semantic::Command::Picker(picker, _) => self.draw_picker(picker),
             semantic::Command::PickerPreview(preview, _) => self.draw_picker_preview(preview),
             semantic::Command::Minibuffer(minibuffer, _) => self.draw_minibuffer(minibuffer),
+            semantic::Command::Breadcrumb(breadcrumb, _) => self.draw_breadcrumb(breadcrumb),
+            semantic::Command::Completion(completion, _) => self.draw_completion(completion),
+            semantic::Command::WhichKey(which_key, _) => self.draw_which_key(which_key),
             semantic::Command::Theme(theme, _) => self.apply_theme(theme),
             semantic::Command::Unsupported { .. } => {}
         }
@@ -362,6 +383,48 @@ impl Renderer {
         self.render_minibuffer(&minibuffer);
     }
 
+    fn draw_breadcrumb(&mut self, breadcrumb: semantic::Breadcrumb) {
+        if self.width == 0 || self.height < 3 {
+            return;
+        }
+
+        let row = 1;
+        if breadcrumb.segments.is_empty() {
+            self.clear_row(row);
+            self.breadcrumb = None;
+            return;
+        }
+
+        self.breadcrumb = Some(breadcrumb.clone());
+        let text = format!(" {}", breadcrumb.segments.join(" / "));
+        self.write_run(
+            row,
+            0,
+            &pad_to_width(&text, self.width),
+            self.theme.breadcrumb_style(),
+        );
+    }
+
+    fn draw_completion(&mut self, completion: semantic::Completion) {
+        if completion.visible {
+            self.completion = Some(completion.clone());
+            self.render_completion(&completion);
+        } else {
+            self.restore_completion_snapshot();
+            self.completion = None;
+        }
+    }
+
+    fn draw_which_key(&mut self, which_key: semantic::WhichKey) {
+        if which_key.visible {
+            self.which_key = Some(which_key.clone());
+            self.render_which_key(&which_key);
+        } else {
+            self.restore_which_key_snapshot();
+            self.which_key = None;
+        }
+    }
+
     fn render_minibuffer(&mut self, minibuffer: &semantic::Minibuffer) {
         self.capture_minibuffer_snapshot();
         self.restore_minibuffer_cells();
@@ -435,8 +498,20 @@ impl Renderer {
 
     fn redraw_retained_chrome(&mut self) {
         self.render_file_tree();
+        if let Some(breadcrumb) = self.breadcrumb.clone() {
+            self.draw_breadcrumb(breadcrumb);
+        }
+        if let Some(completion) = self.completion.clone() {
+            self.completion_snapshot = None;
+            self.render_completion(&completion);
+        }
         self.picker_snapshot = None;
         self.render_picker();
+
+        if let Some(which_key) = self.which_key.clone() {
+            self.which_key_snapshot = None;
+            self.render_which_key(&which_key);
+        }
 
         if let Some(minibuffer) = self.minibuffer.clone() {
             self.minibuffer_snapshot = None;
@@ -542,6 +617,139 @@ impl Renderer {
 
     fn restore_minibuffer_cells(&mut self) {
         if let Some(snapshot) = self.minibuffer_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn render_completion(&mut self, completion: &semantic::Completion) {
+        self.restore_completion_cells();
+        if completion.items.is_empty() || self.width == 0 || self.height == 0 {
+            return;
+        }
+
+        let height = completion.items.len().min(8) as u16;
+        let width = completion_width(completion).min(self.width).max(18);
+        let row = completion
+            .anchor_row
+            .saturating_add(1)
+            .min(self.height.saturating_sub(height));
+        let col = completion.anchor_col.min(self.width.saturating_sub(width));
+
+        if self.completion_snapshot.is_none() {
+            self.completion_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+
+        self.fill_rect(row, col, width, height, self.theme.completion_style(false));
+
+        let selected_index = completion.selected_index as usize;
+        let visible_rows = height as usize;
+        let start = selected_index
+            .saturating_add(1)
+            .saturating_sub(visible_rows)
+            .min(completion.items.len().saturating_sub(visible_rows));
+        for (screen_index, item) in completion
+            .items
+            .iter()
+            .skip(start)
+            .take(visible_rows)
+            .enumerate()
+        {
+            let item_index = start + screen_index;
+            let selected = item_index == selected_index;
+            let detail = if item.detail.is_empty() {
+                String::new()
+            } else {
+                format!("  {}", item.detail)
+            };
+            let line = format!(
+                "{} {}{}",
+                completion_kind_marker(item.kind),
+                item.label,
+                detail
+            );
+            self.write_run(
+                row + screen_index as u16,
+                col,
+                &pad_to_width(&line, width),
+                self.theme.completion_style(selected),
+            );
+        }
+    }
+
+    fn restore_completion_snapshot(&mut self) {
+        if let Some(snapshot) = self.completion_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_completion_cells(&mut self) {
+        if let Some(snapshot) = self.completion_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn render_which_key(&mut self, which_key: &semantic::WhichKey) {
+        self.restore_which_key_cells();
+        if which_key.bindings.is_empty() || self.width < 24 || self.height < 4 {
+            return;
+        }
+
+        let width = self.width.saturating_sub(4).clamp(24, 92);
+        let height = which_key.bindings.len().min(8) as u16 + 1;
+        let row = self.height.saturating_sub(height + 1);
+        let col = self.width.saturating_sub(width) / 2;
+
+        if self.which_key_snapshot.is_none() {
+            self.which_key_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+
+        self.fill_rect(row, col, width, height, self.theme.which_key_style(false));
+        let page = if which_key.page_count > 1 {
+            format!(
+                "  {}/{}",
+                which_key.page.saturating_add(1),
+                which_key.page_count
+            )
+        } else {
+            String::new()
+        };
+        let title = format!(" {}{}", which_key.prefix, page);
+        self.write_run(
+            row,
+            col,
+            &pad_to_width(&title, width),
+            self.theme.which_key_header_style(),
+        );
+
+        for (index, binding) in which_key
+            .bindings
+            .iter()
+            .take(height.saturating_sub(1) as usize)
+            .enumerate()
+        {
+            let icon = if binding.icon.is_empty() {
+                if binding.kind == 1 { ">" } else { " " }
+            } else {
+                binding.icon.as_str()
+            };
+            let text = format!(" {icon} {:<8} {}", binding.key, binding.description);
+            self.write_run(
+                row + 1 + index as u16,
+                col,
+                &pad_to_width(&text, width),
+                self.theme.which_key_style(binding.kind == 1),
+            );
+        }
+    }
+
+    fn restore_which_key_snapshot(&mut self) {
+        if let Some(snapshot) = self.which_key_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_which_key_cells(&mut self) {
+        if let Some(snapshot) = self.which_key_snapshot.clone() {
             self.restore_snapshot(snapshot);
         }
     }
@@ -983,168 +1191,36 @@ fn picker_geometry(width: u16, height: u16) -> (u16, u16, u16, u16) {
     )
 }
 
-const SLOT_EDITOR_BG: u8 = 0x01;
-const SLOT_EDITOR_FG: u8 = 0x02;
-const SLOT_TREE_BG: u8 = 0x03;
-const SLOT_TREE_FG: u8 = 0x04;
-const SLOT_TREE_SELECTION_BG: u8 = 0x05;
-const SLOT_TREE_ACTIVE_FG: u8 = 0x07;
-const SLOT_TAB_BG: u8 = 0x10;
-const SLOT_TAB_ACTIVE_BG: u8 = 0x11;
-const SLOT_TAB_ACTIVE_FG: u8 = 0x12;
-const SLOT_TAB_INACTIVE_FG: u8 = 0x13;
-const SLOT_POPUP_BG: u8 = 0x20;
-const SLOT_POPUP_FG: u8 = 0x21;
-const SLOT_POPUP_BORDER: u8 = 0x22;
-const SLOT_POPUP_SEL_BG: u8 = 0x23;
-const SLOT_POPUP_DESC_FG: u8 = 0x26;
-const SLOT_POPUP_SEL_FG: u8 = 0x2A;
-const SLOT_MODELINE_BAR_BG: u8 = 0x30;
-const SLOT_MODELINE_BAR_FG: u8 = 0x31;
+fn completion_width(completion: &semantic::Completion) -> u16 {
+    completion
+        .items
+        .iter()
+        .map(|item| {
+            text_width(&format!(
+                "{} {}  {}",
+                completion_kind_marker(item.kind),
+                item.label,
+                item.detail
+            ))
+        })
+        .max()
+        .unwrap_or(18)
+        .saturating_add(2)
+}
 
-impl ThemePalette {
-    fn from_theme(theme: semantic::Theme) -> Self {
-        let slots = theme
-            .slots
-            .into_iter()
-            .map(|slot| (slot.id, slot.rgb))
-            .collect();
-        Self { slots }
-    }
-
-    fn color(&self, slot: u8, fallback: u32) -> u32 {
-        self.slots.get(&slot).copied().unwrap_or(fallback)
-    }
-
-    fn status_bar_style(&self) -> CellStyle {
-        CellStyle {
-            fg: self.color(SLOT_MODELINE_BAR_FG, 0xD8DEE9),
-            bg: self.color(SLOT_MODELINE_BAR_BG, 0x2E3440),
-            attrs: protocol::ATTR_BOLD,
-            ul_color: 0,
-            blend: 100,
-        }
-    }
-
-    fn tab_style(&self, active: bool, tint: u32) -> CellStyle {
-        CellStyle {
-            fg: if tint != 0 {
-                tint & 0x00FF_FFFF
-            } else if active {
-                self.color(SLOT_TAB_ACTIVE_FG, 0xD8DEE9)
-            } else {
-                self.color(SLOT_TAB_INACTIVE_FG, 0xC7CED9)
-            },
-            bg: if active {
-                self.color(SLOT_TAB_ACTIVE_BG, 0x3B4252)
-            } else {
-                self.color(SLOT_TAB_BG, 0x242933)
-            },
-            attrs: if active { protocol::ATTR_BOLD } else { 0 },
-            ul_color: 0,
-            blend: 100,
-        }
-    }
-
-    fn file_tree_style(&self, selected: bool, focused: bool) -> CellStyle {
-        CellStyle {
-            fg: if selected {
-                self.color(SLOT_TREE_ACTIVE_FG, 0xECEFF4)
-            } else {
-                self.color(SLOT_TREE_FG, 0xC7CED9)
-            },
-            bg: if selected {
-                self.color(
-                    SLOT_TREE_SELECTION_BG,
-                    if focused { 0x4C566A } else { 0x3B4252 },
-                )
-            } else {
-                self.color(SLOT_TREE_BG, 0x20242D)
-            },
-            attrs: if selected { protocol::ATTR_BOLD } else { 0 },
-            ul_color: 0,
-            blend: 100,
-        }
-    }
-
-    fn picker_style(&self, selected: bool) -> CellStyle {
-        CellStyle {
-            fg: if selected {
-                self.color(SLOT_POPUP_SEL_FG, 0xECEFF4)
-            } else {
-                self.color(SLOT_POPUP_FG, 0xD8DEE9)
-            },
-            bg: if selected {
-                self.color(SLOT_POPUP_SEL_BG, 0x3B4252)
-            } else {
-                self.color(SLOT_POPUP_BG, 0x151A21)
-            },
-            attrs: if selected { protocol::ATTR_BOLD } else { 0 },
-            ul_color: 0,
-            blend: 100,
-        }
-    }
-
-    fn picker_header_style(&self) -> CellStyle {
-        CellStyle {
-            fg: self.color(SLOT_POPUP_BORDER, 0xF8FAFC),
-            bg: self.color(SLOT_POPUP_BG, 0x273142),
-            attrs: protocol::ATTR_BOLD,
-            ul_color: 0,
-            blend: 100,
-        }
-    }
-
-    fn picker_query_style(&self) -> CellStyle {
-        CellStyle {
-            fg: self.color(SLOT_POPUP_DESC_FG, 0xB7C7E3),
-            bg: self.color(SLOT_POPUP_BG, 0x1F2632),
-            attrs: 0,
-            ul_color: 0,
-            blend: 100,
-        }
-    }
-
-    fn picker_preview_style(&self, bold: bool, fg: u32) -> CellStyle {
-        CellStyle {
-            fg: if fg == 0 {
-                self.color(SLOT_POPUP_FG, 0xCAD3DF)
-            } else {
-                fg
-            },
-            bg: self.color(SLOT_EDITOR_BG, 0x11161D),
-            attrs: if bold { protocol::ATTR_BOLD } else { 0 },
-            ul_color: 0,
-            blend: 100,
-        }
-    }
-
-    fn minibuffer_style(&self, selected: bool) -> CellStyle {
-        CellStyle {
-            fg: if selected {
-                self.color(SLOT_POPUP_SEL_FG, 0xF8FAFC)
-            } else {
-                self.color(SLOT_EDITOR_FG, 0xD8DEE9)
-            },
-            bg: if selected {
-                self.color(SLOT_POPUP_SEL_BG, 0x4C566A)
-            } else {
-                self.color(SLOT_MODELINE_BAR_BG, 0x20242D)
-            },
-            attrs: if selected { protocol::ATTR_BOLD } else { 0 },
-            ul_color: 0,
-            blend: 100,
-        }
-    }
-
-    fn minibuffer_context_style(&self) -> CellStyle {
-        CellStyle {
-            fg: self.color(SLOT_POPUP_DESC_FG, 0x9AA7B5),
-            bg: self.color(SLOT_MODELINE_BAR_BG, 0x1A1F28),
-            attrs: 0,
-            ul_color: 0,
-            blend: 100,
-        }
+fn completion_kind_marker(kind: u8) -> &'static str {
+    match kind {
+        1 => "fn",
+        2 => "me",
+        3 => "var",
+        4 => "fld",
+        5 => "mod",
+        7 => "kw",
+        8 => "sn",
+        9 => "cn",
+        11 => "st",
+        12 => "en",
+        _ => "tx",
     }
 }
 
@@ -1782,6 +1858,97 @@ mod tests {
         renderer.draw_minibuffer(semantic::Minibuffer::default());
 
         assert_eq!(renderer.cells[renderer.index(0, 8).unwrap()].text, "u");
+    }
+
+    #[test]
+    fn semantic_completion_draws_and_restores_overlay() {
+        let mut renderer = Renderer::new(40, 10);
+        renderer.draw_text(DrawText {
+            row: 4,
+            col: 5,
+            fg: 0x111111,
+            bg: 0x222222,
+            attrs: 0,
+            text: "under".to_owned(),
+        });
+
+        renderer.draw_completion(semantic::Completion {
+            visible: true,
+            anchor_row: 3,
+            anchor_col: 5,
+            selected_index: 1,
+            items: vec![
+                semantic::CompletionItem {
+                    kind: 1,
+                    label: "write".to_owned(),
+                    detail: "Save file".to_owned(),
+                },
+                semantic::CompletionItem {
+                    kind: 5,
+                    label: "Minga".to_owned(),
+                    detail: "module".to_owned(),
+                },
+            ],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(5, 4).unwrap()].text, "f");
+        assert_eq!(renderer.cells[renderer.index(9, 5).unwrap()].text, "M");
+        assert_eq!(
+            renderer.cells[renderer.index(5, 5).unwrap()].style.bg,
+            0x3B4252
+        );
+
+        renderer.draw_completion(semantic::Completion::default());
+
+        let restored = &renderer.cells[renderer.index(5, 4).unwrap()];
+        assert_eq!(restored.text, "u");
+        assert_eq!(restored.style.fg, 0x111111);
+        assert_eq!(restored.style.bg, 0x222222);
+    }
+
+    #[test]
+    fn semantic_window_redraw_replays_retained_completion_and_which_key() {
+        let mut renderer = Renderer::new(60, 16);
+
+        renderer.draw_completion(semantic::Completion {
+            visible: true,
+            anchor_row: 4,
+            anchor_col: 4,
+            selected_index: 0,
+            items: vec![semantic::CompletionItem {
+                kind: 1,
+                label: "write".to_owned(),
+                detail: String::new(),
+            }],
+        });
+        renderer.draw_which_key(semantic::WhichKey {
+            visible: true,
+            prefix: "SPC".to_owned(),
+            page: 0,
+            page_count: 1,
+            bindings: vec![semantic::WhichKeyBinding {
+                kind: 0,
+                key: "f".to_owned(),
+                description: "Find file".to_owned(),
+                icon: String::new(),
+            }],
+        });
+
+        renderer.draw_semantic_window(semantic::WindowContent {
+            origin_row: 5,
+            origin_col: 4,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_shape: 0,
+            rows: vec![semantic::Row {
+                text: "under completion".to_owned(),
+                spans: vec![],
+            }],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(4, 5).unwrap()].text, "f");
+        assert_eq!(renderer.cells[renderer.index(3, 13).unwrap()].text, "S");
+        assert_eq!(renderer.cells[renderer.index(5, 14).unwrap()].text, "f");
     }
 
     #[test]

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -60,6 +60,9 @@ pub struct Renderer {
     signature_help: Option<semantic::SignatureHelp>,
     float_popup: Option<semantic::FloatPopup>,
     hover_popup: Option<semantic::HoverPopup>,
+    bottom_panel: Option<semantic::BottomPanel>,
+    change_summary: Option<semantic::ChangeSummary>,
+    git_status: Option<semantic::GitStatus>,
     picker_snapshot: Option<CellSnapshot>,
     minibuffer_snapshot: Option<CellSnapshot>,
     completion_snapshot: Option<CellSnapshot>,
@@ -67,6 +70,9 @@ pub struct Renderer {
     signature_help_snapshot: Option<CellSnapshot>,
     float_popup_snapshot: Option<CellSnapshot>,
     hover_popup_snapshot: Option<CellSnapshot>,
+    bottom_panel_snapshot: Option<CellSnapshot>,
+    change_summary_snapshot: Option<CellSnapshot>,
+    git_status_snapshot: Option<CellSnapshot>,
     theme: ThemePalette,
 }
 
@@ -93,6 +99,9 @@ impl Renderer {
             signature_help: None,
             float_popup: None,
             hover_popup: None,
+            bottom_panel: None,
+            change_summary: None,
+            git_status: None,
             picker_snapshot: None,
             minibuffer_snapshot: None,
             completion_snapshot: None,
@@ -100,6 +109,9 @@ impl Renderer {
             signature_help_snapshot: None,
             float_popup_snapshot: None,
             hover_popup_snapshot: None,
+            bottom_panel_snapshot: None,
+            change_summary_snapshot: None,
+            git_status_snapshot: None,
             theme: ThemePalette::default(),
         }
     }
@@ -174,6 +186,9 @@ impl Renderer {
         self.signature_help = None;
         self.float_popup = None;
         self.hover_popup = None;
+        self.bottom_panel = None;
+        self.change_summary = None;
+        self.git_status = None;
         self.picker_snapshot = None;
         self.minibuffer_snapshot = None;
         self.completion_snapshot = None;
@@ -181,6 +196,9 @@ impl Renderer {
         self.signature_help_snapshot = None;
         self.float_popup_snapshot = None;
         self.hover_popup_snapshot = None;
+        self.bottom_panel_snapshot = None;
+        self.change_summary_snapshot = None;
+        self.git_status_snapshot = None;
     }
 
     fn clear(&mut self) {
@@ -254,6 +272,11 @@ impl Renderer {
             }
             semantic::Command::FloatPopup(float_popup, _) => self.draw_float_popup(float_popup),
             semantic::Command::HoverPopup(hover_popup, _) => self.draw_hover_popup(hover_popup),
+            semantic::Command::BottomPanel(bottom_panel, _) => self.draw_bottom_panel(bottom_panel),
+            semantic::Command::ChangeSummary(change_summary, _) => {
+                self.draw_change_summary(change_summary)
+            }
+            semantic::Command::GitStatus(git_status, _) => self.draw_git_status(git_status),
             semantic::Command::Theme(theme, _) => self.apply_theme(theme),
             semantic::Command::Unsupported { .. } => {}
         }
@@ -482,6 +505,36 @@ impl Renderer {
         }
     }
 
+    fn draw_bottom_panel(&mut self, bottom_panel: semantic::BottomPanel) {
+        if bottom_panel.visible {
+            self.bottom_panel = Some(bottom_panel.clone());
+            self.render_bottom_panel(&bottom_panel);
+        } else {
+            self.restore_bottom_panel_snapshot();
+            self.bottom_panel = None;
+        }
+    }
+
+    fn draw_change_summary(&mut self, change_summary: semantic::ChangeSummary) {
+        if change_summary.visible && !change_summary.entries.is_empty() {
+            self.change_summary = Some(change_summary.clone());
+            self.render_change_summary(&change_summary);
+        } else {
+            self.restore_change_summary_snapshot();
+            self.change_summary = None;
+        }
+    }
+
+    fn draw_git_status(&mut self, git_status: semantic::GitStatus) {
+        if git_status.repo_state == 1 {
+            self.restore_git_status_snapshot();
+            self.git_status = None;
+        } else {
+            self.git_status = Some(git_status.clone());
+            self.render_git_status(&git_status);
+        }
+    }
+
     fn render_minibuffer(&mut self, minibuffer: &semantic::Minibuffer) {
         self.capture_minibuffer_snapshot();
         self.restore_minibuffer_cells();
@@ -581,6 +634,18 @@ impl Renderer {
         if let Some(hover_popup) = self.hover_popup.clone() {
             self.hover_popup_snapshot = None;
             self.render_hover_popup(&hover_popup);
+        }
+        if let Some(bottom_panel) = self.bottom_panel.clone() {
+            self.bottom_panel_snapshot = None;
+            self.render_bottom_panel(&bottom_panel);
+        }
+        if let Some(change_summary) = self.change_summary.clone() {
+            self.change_summary_snapshot = None;
+            self.render_change_summary(&change_summary);
+        }
+        if let Some(git_status) = self.git_status.clone() {
+            self.git_status_snapshot = None;
+            self.render_git_status(&git_status);
         }
 
         if let Some(minibuffer) = self.minibuffer.clone() {
@@ -966,6 +1031,163 @@ impl Renderer {
 
     fn restore_hover_popup_cells(&mut self) {
         if let Some(snapshot) = self.hover_popup_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn render_bottom_panel(&mut self, bottom_panel: &semantic::BottomPanel) {
+        self.restore_bottom_panel_cells();
+        if self.width < 20 || self.height < 6 {
+            return;
+        }
+
+        let percent = bottom_panel.height_percent.clamp(10, 80) as u32;
+        let height = ((self.height as u32 * percent).div_ceil(100) as u16)
+            .clamp(3, self.height.saturating_sub(1));
+        let row = self.height.saturating_sub(height);
+        if self.bottom_panel_snapshot.is_none() {
+            self.bottom_panel_snapshot = Some(self.capture_rect(row, 0, self.width, height));
+        }
+
+        let title = bottom_panel_title(bottom_panel);
+        let body = if bottom_panel.entries.is_empty() {
+            "No messages".to_owned()
+        } else {
+            bottom_panel
+                .entries
+                .iter()
+                .rev()
+                .take(height.saturating_sub(2) as usize)
+                .map(bottom_panel_entry_text)
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        self.render_popup_panel(row, 0, self.width, height, &title, body);
+    }
+
+    fn restore_bottom_panel_snapshot(&mut self) {
+        if let Some(snapshot) = self.bottom_panel_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_bottom_panel_cells(&mut self) {
+        if let Some(snapshot) = self.bottom_panel_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn render_change_summary(&mut self, change_summary: &semantic::ChangeSummary) {
+        self.restore_change_summary_cells();
+        if self.width < 28 || self.height < 8 {
+            return;
+        }
+
+        let width = self.width.saturating_sub(4).clamp(28, 56);
+        let height = change_summary.entries.len().min(10).saturating_add(2) as u16;
+        let height = height.min(self.height.saturating_sub(2)).max(3);
+        let row = 2;
+        let col = self.width.saturating_sub(width);
+        if self.change_summary_snapshot.is_none() {
+            self.change_summary_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+
+        let selected = change_summary.selected_index as usize;
+        let visible_rows = height.saturating_sub(2) as usize;
+        let start = selected
+            .saturating_add(1)
+            .saturating_sub(visible_rows)
+            .min(change_summary.entries.len().saturating_sub(visible_rows));
+        let body = change_summary
+            .entries
+            .iter()
+            .skip(start)
+            .take(visible_rows)
+            .enumerate()
+            .map(|(index, entry)| {
+                let absolute = start + index;
+                let marker = if absolute == selected { ">" } else { " " };
+                format!(
+                    "{marker} {} +{} -{} {}",
+                    change_action_marker(entry.action),
+                    entry.lines_added,
+                    entry.lines_removed,
+                    entry.path
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        self.render_popup_panel(row, col, width, height, " Changes ", body);
+    }
+
+    fn restore_change_summary_snapshot(&mut self) {
+        if let Some(snapshot) = self.change_summary_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_change_summary_cells(&mut self) {
+        if let Some(snapshot) = self.change_summary_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn render_git_status(&mut self, git_status: &semantic::GitStatus) {
+        self.restore_git_status_cells();
+        if self.width < 28 || self.height < 8 {
+            return;
+        }
+
+        let width = self.width.saturating_sub(4).clamp(28, 52);
+        let height = git_status.entries.len().min(8).saturating_add(4) as u16;
+        let height = height.min(self.height.saturating_sub(2)).max(4);
+        let row = 2;
+        let col = 0;
+        if self.git_status_snapshot.is_none() {
+            self.git_status_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+
+        let mut lines = Vec::new();
+        let sync = if git_status.syncing { " syncing" } else { "" };
+        lines.push(format!(
+            "{}{} +{} -{} stash:{}",
+            git_status.branch, sync, git_status.ahead, git_status.behind, git_status.stash_count
+        ));
+        if !git_status.last_commit_message.is_empty() {
+            lines.push(format!("last: {}", git_status.last_commit_message));
+        }
+        if let Some(toast) = &git_status.toast {
+            lines.push(format!(
+                "{}: {}",
+                git_toast_level(toast.level),
+                toast.message
+            ));
+        }
+        lines.extend(
+            git_status
+                .entries
+                .iter()
+                .take(height.saturating_sub(3) as usize)
+                .map(|entry| {
+                    format!(
+                        "{} {} {}",
+                        git_section_marker(entry.section),
+                        git_status_marker(entry.status),
+                        entry.path
+                    )
+                }),
+        );
+        self.render_popup_panel(row, col, width, height, " Git ", lines.join("\n"));
+    }
+
+    fn restore_git_status_snapshot(&mut self) {
+        if let Some(snapshot) = self.git_status_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_git_status_cells(&mut self) {
+        if let Some(snapshot) = self.git_status_snapshot.clone() {
             self.restore_snapshot(snapshot);
         }
     }
@@ -1501,6 +1723,89 @@ fn highlight_signature_label(signature: &semantic::Signature, active_parameter: 
         signature
             .label
             .replace(&parameter.label, &format!("[{}]", parameter.label))
+    }
+}
+
+fn bottom_panel_title(panel: &semantic::BottomPanel) -> String {
+    let tabs = panel
+        .tabs
+        .iter()
+        .enumerate()
+        .map(|(index, tab)| {
+            if index == panel.active_tab_index as usize {
+                format!("[{}]", tab.name)
+            } else {
+                tab.name.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    if tabs.is_empty() {
+        " Messages ".to_owned()
+    } else {
+        format!(" {tabs} ")
+    }
+}
+
+fn bottom_panel_entry_text(entry: &semantic::BottomPanelEntry) -> String {
+    let path = if entry.file_path.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", entry.file_path)
+    };
+    format!(
+        "{} {}{}",
+        bottom_panel_level_marker(entry.level),
+        entry.text,
+        path
+    )
+}
+
+fn bottom_panel_level_marker(level: u8) -> &'static str {
+    match level {
+        1 => "debug",
+        2 => "info",
+        3 => "warn",
+        4 => "error",
+        _ => "msg",
+    }
+}
+
+fn change_action_marker(action: u8) -> &'static str {
+    match action {
+        1 => "A",
+        2 => "D",
+        3 => "R",
+        _ => "M",
+    }
+}
+
+fn git_section_marker(section: u8) -> &'static str {
+    match section {
+        0 => "staged",
+        2 => "new",
+        3 => "conflict",
+        _ => "work",
+    }
+}
+
+fn git_status_marker(status: u8) -> &'static str {
+    match status {
+        1 => "M",
+        2 => "A",
+        3 => "D",
+        4 => "R",
+        5 => "C",
+        6 => "?",
+        7 => "!",
+        _ => "-",
+    }
+}
+
+fn git_toast_level(level: u8) -> &'static str {
+    match level {
+        1 => "error",
+        _ => "ok",
     }
 }
 
@@ -2414,6 +2719,95 @@ mod tests {
             }],
         });
         assert_eq!(renderer.cells[renderer.index(9, 3).unwrap()].text, "h");
+    }
+
+    #[test]
+    fn semantic_bottom_panel_and_change_summary_render_with_ratatui() {
+        let mut renderer = Renderer::new(70, 20);
+
+        renderer.draw_bottom_panel(semantic::BottomPanel {
+            visible: true,
+            active_tab_index: 0,
+            height_percent: 25,
+            filter: 0,
+            tabs: vec![semantic::BottomPanelTab {
+                tab_type: 0,
+                name: "Logs".to_owned(),
+            }],
+            entries: vec![semantic::BottomPanelEntry {
+                id: 1,
+                level: 4,
+                subsystem: 2,
+                timestamp_secs: 42,
+                file_path: "lib/minga.ex".to_owned(),
+                text: "failed to compile".to_owned(),
+            }],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(1, 16).unwrap()].text, "e");
+
+        renderer.draw_change_summary(semantic::ChangeSummary {
+            visible: true,
+            selected_index: 1,
+            entries: vec![
+                semantic::ChangeSummaryEntry {
+                    path: "lib/a.ex".to_owned(),
+                    action: 0,
+                    lines_added: 12,
+                    lines_removed: 3,
+                },
+                semantic::ChangeSummaryEntry {
+                    path: "lib/b.ex".to_owned(),
+                    action: 1,
+                    lines_added: 5,
+                    lines_removed: 0,
+                },
+            ],
+        });
+
+        assert_eq!(renderer.cells[renderer.index(15, 4).unwrap()].text, ">");
+        assert_eq!(renderer.cells[renderer.index(17, 4).unwrap()].text, "A");
+
+        renderer.draw_change_summary(semantic::ChangeSummary::default());
+
+        assert_eq!(renderer.cells[renderer.index(15, 4).unwrap()].text, " ");
+    }
+
+    #[test]
+    fn semantic_git_status_renders_with_ratatui() {
+        let mut renderer = Renderer::new(70, 20);
+
+        renderer.draw_git_status(semantic::GitStatus {
+            repo_state: 0,
+            syncing: true,
+            ahead: 2,
+            behind: 1,
+            branch: "main".to_owned(),
+            entries: vec![semantic::GitStatusEntry {
+                path_hash: 0x12345678,
+                section: 1,
+                status: 1,
+                path: "lib/minga.ex".to_owned(),
+            }],
+            toast: Some(semantic::GitToast {
+                level: 0,
+                action: 0,
+                message: "Pulled".to_owned(),
+            }),
+            entry_base_path: "lib".to_owned(),
+            last_commit_message: "Initial commit".to_owned(),
+            stash_count: 3,
+        });
+
+        assert_eq!(renderer.cells[renderer.index(1, 3).unwrap()].text, "m");
+        assert_eq!(renderer.cells[renderer.index(1, 5).unwrap()].text, "o");
+
+        renderer.draw_git_status(semantic::GitStatus {
+            repo_state: 1,
+            ..semantic::GitStatus::default()
+        });
+
+        assert_eq!(renderer.cells[renderer.index(1, 3).unwrap()].text, " ");
     }
 
     #[test]

--- a/rust/tui/src/renderer/theme.rs
+++ b/rust/tui/src/renderer/theme.rs
@@ -1,0 +1,229 @@
+use crate::protocol;
+use crate::semantic;
+use crate::terminal::CellStyle;
+use std::collections::HashMap;
+
+pub(super) const SLOT_EDITOR_BG: u8 = 0x01;
+const SLOT_EDITOR_FG: u8 = 0x02;
+const SLOT_TREE_BG: u8 = 0x03;
+const SLOT_TREE_FG: u8 = 0x04;
+const SLOT_TREE_SELECTION_BG: u8 = 0x05;
+const SLOT_TREE_ACTIVE_FG: u8 = 0x07;
+const SLOT_TAB_BG: u8 = 0x10;
+const SLOT_TAB_ACTIVE_BG: u8 = 0x11;
+const SLOT_TAB_ACTIVE_FG: u8 = 0x12;
+const SLOT_TAB_INACTIVE_FG: u8 = 0x13;
+pub(super) const SLOT_POPUP_BG: u8 = 0x20;
+pub(super) const SLOT_POPUP_FG: u8 = 0x21;
+const SLOT_POPUP_BORDER: u8 = 0x22;
+pub(super) const SLOT_POPUP_SEL_BG: u8 = 0x23;
+const SLOT_POPUP_DESC_FG: u8 = 0x26;
+const SLOT_BREADCRUMB_BG: u8 = 0x27;
+const SLOT_BREADCRUMB_FG: u8 = 0x28;
+const SLOT_BREADCRUMB_SEPARATOR_FG: u8 = 0x29;
+pub(super) const SLOT_POPUP_SEL_FG: u8 = 0x2A;
+pub(super) const SLOT_MODELINE_BAR_BG: u8 = 0x30;
+const SLOT_MODELINE_BAR_FG: u8 = 0x31;
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct ThemePalette {
+    slots: HashMap<u8, u32>,
+}
+
+impl ThemePalette {
+    pub(super) fn from_theme(theme: semantic::Theme) -> Self {
+        let slots = theme
+            .slots
+            .into_iter()
+            .map(|slot| (slot.id, slot.rgb))
+            .collect();
+        Self { slots }
+    }
+
+    pub(super) fn color(&self, slot: u8, fallback: u32) -> u32 {
+        self.slots.get(&slot).copied().unwrap_or(fallback)
+    }
+
+    pub(super) fn status_bar_style(&self) -> CellStyle {
+        CellStyle {
+            fg: self.color(SLOT_MODELINE_BAR_FG, 0xD8DEE9),
+            bg: self.color(SLOT_MODELINE_BAR_BG, 0x2E3440),
+            attrs: protocol::ATTR_BOLD,
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn tab_style(&self, active: bool, tint: u32) -> CellStyle {
+        CellStyle {
+            fg: if tint != 0 {
+                tint & 0x00FF_FFFF
+            } else if active {
+                self.color(SLOT_TAB_ACTIVE_FG, 0xD8DEE9)
+            } else {
+                self.color(SLOT_TAB_INACTIVE_FG, 0xC7CED9)
+            },
+            bg: if active {
+                self.color(SLOT_TAB_ACTIVE_BG, 0x3B4252)
+            } else {
+                self.color(SLOT_TAB_BG, 0x242933)
+            },
+            attrs: if active { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn file_tree_style(&self, selected: bool, focused: bool) -> CellStyle {
+        CellStyle {
+            fg: if selected {
+                self.color(SLOT_TREE_ACTIVE_FG, 0xECEFF4)
+            } else {
+                self.color(SLOT_TREE_FG, 0xC7CED9)
+            },
+            bg: if selected {
+                self.color(
+                    SLOT_TREE_SELECTION_BG,
+                    if focused { 0x4C566A } else { 0x3B4252 },
+                )
+            } else {
+                self.color(SLOT_TREE_BG, 0x20242D)
+            },
+            attrs: if selected { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn picker_style(&self, selected: bool) -> CellStyle {
+        CellStyle {
+            fg: if selected {
+                self.color(SLOT_POPUP_SEL_FG, 0xECEFF4)
+            } else {
+                self.color(SLOT_POPUP_FG, 0xD8DEE9)
+            },
+            bg: if selected {
+                self.color(SLOT_POPUP_SEL_BG, 0x3B4252)
+            } else {
+                self.color(SLOT_POPUP_BG, 0x151A21)
+            },
+            attrs: if selected { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn picker_header_style(&self) -> CellStyle {
+        CellStyle {
+            fg: self.color(SLOT_POPUP_BORDER, 0xF8FAFC),
+            bg: self.color(SLOT_POPUP_BG, 0x273142),
+            attrs: protocol::ATTR_BOLD,
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn picker_query_style(&self) -> CellStyle {
+        CellStyle {
+            fg: self.color(SLOT_POPUP_DESC_FG, 0xB7C7E3),
+            bg: self.color(SLOT_POPUP_BG, 0x1F2632),
+            attrs: 0,
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn picker_preview_style(&self, bold: bool, fg: u32) -> CellStyle {
+        CellStyle {
+            fg: if fg == 0 {
+                self.color(SLOT_POPUP_FG, 0xCAD3DF)
+            } else {
+                fg
+            },
+            bg: self.color(SLOT_EDITOR_BG, 0x11161D),
+            attrs: if bold { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn minibuffer_style(&self, selected: bool) -> CellStyle {
+        CellStyle {
+            fg: if selected {
+                self.color(SLOT_POPUP_SEL_FG, 0xF8FAFC)
+            } else {
+                self.color(SLOT_EDITOR_FG, 0xD8DEE9)
+            },
+            bg: if selected {
+                self.color(SLOT_POPUP_SEL_BG, 0x4C566A)
+            } else {
+                self.color(SLOT_MODELINE_BAR_BG, 0x20242D)
+            },
+            attrs: if selected { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn minibuffer_context_style(&self) -> CellStyle {
+        CellStyle {
+            fg: self.color(SLOT_POPUP_DESC_FG, 0x9AA7B5),
+            bg: self.color(SLOT_MODELINE_BAR_BG, 0x1A1F28),
+            attrs: 0,
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn breadcrumb_style(&self) -> CellStyle {
+        CellStyle {
+            fg: self.color(SLOT_BREADCRUMB_FG, 0xBBC2CF),
+            bg: self.color(SLOT_BREADCRUMB_BG, 0x21242B),
+            attrs: 0,
+            ul_color: self.color(SLOT_BREADCRUMB_SEPARATOR_FG, 0x3F444A),
+            blend: 100,
+        }
+    }
+
+    pub(super) fn completion_style(&self, selected: bool) -> CellStyle {
+        CellStyle {
+            fg: if selected {
+                self.color(SLOT_POPUP_SEL_FG, 0xF8FAFC)
+            } else {
+                self.color(SLOT_POPUP_FG, 0xD8DEE9)
+            },
+            bg: if selected {
+                self.color(SLOT_POPUP_SEL_BG, 0x3B4252)
+            } else {
+                self.color(SLOT_POPUP_BG, 0x151A21)
+            },
+            attrs: if selected { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn which_key_style(&self, group: bool) -> CellStyle {
+        CellStyle {
+            fg: if group {
+                self.color(SLOT_POPUP_BORDER, 0xF8FAFC)
+            } else {
+                self.color(SLOT_POPUP_FG, 0xD8DEE9)
+            },
+            bg: self.color(SLOT_POPUP_BG, 0x151A21),
+            attrs: if group { protocol::ATTR_BOLD } else { 0 },
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+
+    pub(super) fn which_key_header_style(&self) -> CellStyle {
+        CellStyle {
+            fg: self.color(SLOT_POPUP_DESC_FG, 0xB7C7E3),
+            bg: self.color(SLOT_POPUP_BG, 0x1F2632),
+            attrs: protocol::ATTR_BOLD,
+            ul_color: 0,
+            blend: 100,
+        }
+    }
+}

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -10,6 +10,9 @@ pub enum Command {
     Picker(Picker, usize),
     PickerPreview(PickerPreview, usize),
     Minibuffer(Minibuffer, usize),
+    Breadcrumb(Breadcrumb, usize),
+    Completion(Completion, usize),
+    WhichKey(WhichKey, usize),
     Theme(Theme, usize),
     Unsupported { opcode: u8, size: usize },
 }
@@ -25,6 +28,9 @@ impl Command {
             Self::Picker(_, size) => *size,
             Self::PickerPreview(_, size) => *size,
             Self::Minibuffer(_, size) => *size,
+            Self::Breadcrumb(_, size) => *size,
+            Self::Completion(_, size) => *size,
+            Self::WhichKey(_, size) => *size,
             Self::Theme(_, size) => *size,
             Self::Unsupported { size, .. } => *size,
         }
@@ -181,6 +187,44 @@ pub struct MinibufferCandidate {
     pub annotation: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Breadcrumb {
+    pub segments: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Completion {
+    pub visible: bool,
+    pub anchor_row: u16,
+    pub anchor_col: u16,
+    pub selected_index: u16,
+    pub items: Vec<CompletionItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletionItem {
+    pub kind: u8,
+    pub label: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct WhichKey {
+    pub visible: bool,
+    pub prefix: String,
+    pub page: u8,
+    pub page_count: u8,
+    pub bindings: Vec<WhichKeyBinding>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhichKeyBinding {
+    pub kind: u8,
+    pub key: String,
+    pub description: String,
+    pub icon: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Theme {
     pub slots: Vec<ThemeSlot>,
@@ -204,6 +248,9 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_PICKER => decode_picker(bytes),
         opcodes::OP_GUI_PICKER_PREVIEW => decode_picker_preview(bytes),
         opcodes::OP_GUI_MINIBUFFER => decode_minibuffer(bytes),
+        opcodes::OP_GUI_BREADCRUMB => decode_breadcrumb(bytes),
+        opcodes::OP_GUI_COMPLETION => decode_completion(bytes),
+        opcodes::OP_GUI_WHICH_KEY => decode_which_key(bytes),
         opcodes::OP_GUI_THEME => decode_theme(bytes),
         opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA | opcodes::OP_GUI_WINDOW_ROWS_DELTA => {
             sectioned_size(bytes, "semantic row delta")
@@ -212,10 +259,8 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_WINDOW_OVERLAY_DELTA => {
             overlay_delta_size(bytes).map(|size| Command::Unsupported { opcode, size })
         }
-        opcodes::OP_GUI_GUTTER | opcodes::OP_GUI_WHICH_KEY => {
-            sectioned_size(bytes, "semantic sectioned command")
-                .map(|size| Command::Unsupported { opcode, size })
-        }
+        opcodes::OP_GUI_GUTTER => sectioned_size(bytes, "semantic sectioned command")
+            .map(|size| Command::Unsupported { opcode, size }),
         opcodes::OP_GUI_INDENT_GUIDES
         | opcodes::OP_GUI_HOVER_ACTION
         | opcodes::OP_GUI_WORKSPACES
@@ -235,9 +280,7 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_SPLIT_SEPARATORS => {
             split_separators_size(bytes).map(|size| Command::Unsupported { opcode, size })
         }
-        opcodes::OP_GUI_BREADCRUMB
-        | opcodes::OP_GUI_COMPLETION
-        | opcodes::OP_GUI_SIGNATURE_HELP
+        opcodes::OP_GUI_SIGNATURE_HELP
         | opcodes::OP_GUI_FLOAT_POPUP
         | opcodes::OP_GUI_HOVER_POPUP
         | opcodes::OP_GUI_AGENT_CONTEXT
@@ -668,6 +711,101 @@ fn decode_minibuffer_candidate(bytes: &[u8]) -> Result<(MinibufferCandidate, usi
     ))
 }
 
+fn decode_breadcrumb(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = breadcrumb_size(bytes)?;
+    let count = bytes[1] as usize;
+    let mut offset = 2;
+    let mut segments = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        segments.push(read_string16(bytes, &mut offset)?);
+    }
+
+    Ok(Command::Breadcrumb(Breadcrumb { segments }, size))
+}
+
+fn decode_completion(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 2, "completion header")?;
+    if bytes[1] == 0 {
+        return Ok(Command::Completion(Completion::default(), 2));
+    }
+
+    let size = completion_size(bytes)?;
+    let anchor_row = read_u16(bytes, 2);
+    let anchor_col = read_u16(bytes, 4);
+    let selected_index = read_u16(bytes, 6);
+    let count = read_u16(bytes, 8) as usize;
+    let mut offset = 10;
+    let mut items = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        require_len(bytes, offset + 1, "completion item kind")?;
+        let kind = bytes[offset];
+        offset += 1;
+        let label = read_string16(bytes, &mut offset)?;
+        let detail = read_string16(bytes, &mut offset)?;
+        items.push(CompletionItem {
+            kind,
+            label,
+            detail,
+        });
+    }
+
+    Ok(Command::Completion(
+        Completion {
+            visible: true,
+            anchor_row,
+            anchor_col,
+            selected_index,
+            items,
+        },
+        size,
+    ))
+}
+
+fn decode_which_key(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 2, "which-key header")?;
+    if bytes[1] == 0 {
+        return Ok(Command::WhichKey(WhichKey::default(), 2));
+    }
+
+    let size = which_key_size(bytes)?;
+    let mut offset = 2;
+    let prefix = read_string16(bytes, &mut offset)?;
+    require_len(bytes, offset + 4, "which-key metadata")?;
+    let page = bytes[offset];
+    let page_count = bytes[offset + 1];
+    let count = read_u16(bytes, offset + 2) as usize;
+    offset += 4;
+    let mut bindings = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        require_len(bytes, offset + 2, "which-key binding header")?;
+        let kind = bytes[offset];
+        offset += 1;
+        let key = read_string8(bytes, &mut offset)?;
+        let description = read_string16(bytes, &mut offset)?;
+        let icon = read_string8(bytes, &mut offset)?;
+        bindings.push(WhichKeyBinding {
+            kind,
+            key,
+            description,
+            icon,
+        });
+    }
+
+    Ok(Command::WhichKey(
+        WhichKey {
+            visible: true,
+            prefix,
+            page,
+            page_count,
+            bindings,
+        },
+        size,
+    ))
+}
+
 fn decode_theme(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = theme_size(bytes)?;
     let count = bytes[1] as usize;
@@ -913,6 +1051,27 @@ fn breadcrumb_size(bytes: &[u8]) -> Result<usize, DecodeError> {
     let mut offset = 2;
     for _ in 0..count {
         skip_string16(bytes, &mut offset)?;
+    }
+    Ok(offset)
+}
+
+fn which_key_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 2, "which-key")?;
+    if bytes[1] == 0 {
+        return Ok(2);
+    }
+
+    let mut offset = 2;
+    skip_string16(bytes, &mut offset)?;
+    require_len(bytes, offset + 4, "which-key metadata")?;
+    let count = read_u16(bytes, offset + 2) as usize;
+    offset += 4;
+    for _ in 0..count {
+        require_len(bytes, offset + 1, "which-key binding kind")?;
+        offset += 1;
+        skip_string8(bytes, &mut offset)?;
+        skip_string16(bytes, &mut offset)?;
+        skip_string8(bytes, &mut offset)?;
     }
     Ok(offset)
 }
@@ -1401,6 +1560,77 @@ mod tests {
     }
 
     #[test]
+    fn decodes_breadcrumb_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_GUI_BREADCRUMB, 3],
+            string16("lib"),
+            string16("minga"),
+            string16("editor.ex"),
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+
+        let command = decode(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::Breadcrumb(Breadcrumb { segments }, _) if segments == vec!["lib", "minga", "editor.ex"]
+        ));
+    }
+
+    #[test]
+    fn decodes_completion_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_GUI_COMPLETION, 1, 0, 4, 0, 12, 0, 1, 0, 2],
+            vec![1],
+            string16("write"),
+            string16("Save file"),
+            vec![5],
+            string16("Minga"),
+            string16("module"),
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+
+        let command = decode(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::Completion(Completion { visible: true, anchor_row: 4, anchor_col: 12, selected_index: 1, items }, _)
+                if items[0].kind == 1 && items[0].label == "write" && items[1].detail == "module"
+        ));
+    }
+
+    #[test]
+    fn decodes_which_key_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_GUI_WHICH_KEY, 1],
+            string16("SPC"),
+            vec![0, 2, 0, 2, 0],
+            string8("f"),
+            string16("Find file"),
+            string8(""),
+            vec![1],
+            string8("b"),
+            string16("Buffers"),
+            string8(">"),
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+
+        let command = decode(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::WhichKey(WhichKey { visible: true, prefix, page: 0, page_count: 2, bindings }, _)
+                if prefix == "SPC" && bindings[0].key == "f" && bindings[1].kind == 1
+        ));
+    }
+
+    #[test]
     fn decodes_theme_slots() {
         let packet = vec![
             opcodes::OP_GUI_THEME,
@@ -1424,25 +1654,97 @@ mod tests {
     }
 
     #[test]
-    fn skips_visible_completion_without_consuming_following_commands() {
-        let packet = [
-            vec![opcodes::OP_GUI_COMPLETION, 1, 0, 4, 0, 12, 0, 1, 0, 1, 2],
-            string16("write"),
-            string16("Save file"),
-            vec![opcodes::OP_BATCH_END],
-        ]
-        .concat();
+    fn skips_remaining_visible_legacy_commands_without_consuming_following_commands() {
+        let cases = [
+            (
+                opcodes::OP_GUI_SIGNATURE_HELP,
+                vec![opcodes::OP_GUI_SIGNATURE_HELP, 1, 0, 0, 0, 0, 0, 0, 0],
+            ),
+            (
+                opcodes::OP_GUI_FLOAT_POPUP,
+                vec![opcodes::OP_GUI_FLOAT_POPUP, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+            ),
+            (
+                opcodes::OP_GUI_HOVER_POPUP,
+                vec![opcodes::OP_GUI_HOVER_POPUP, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ),
+            (
+                opcodes::OP_GUI_AGENT_CONTEXT,
+                vec![
+                    opcodes::OP_GUI_AGENT_CONTEXT,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+            ),
+            (
+                opcodes::OP_GUI_GIT_STATUS,
+                vec![
+                    opcodes::OP_GUI_GIT_STATUS,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+            ),
+            (
+                opcodes::OP_GUI_CHANGE_SUMMARY,
+                vec![opcodes::OP_GUI_CHANGE_SUMMARY, 1, 0, 0, 0],
+            ),
+            (
+                opcodes::OP_GUI_BOARD,
+                vec![opcodes::OP_GUI_BOARD, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ),
+            (
+                opcodes::OP_GUI_AGENT_CHAT,
+                vec![opcodes::OP_GUI_AGENT_CHAT, 1, 1, 0, 0],
+            ),
+            (
+                opcodes::OP_GUI_BOTTOM_PANEL,
+                vec![opcodes::OP_GUI_BOTTOM_PANEL, 1, 0, 0, 0, 0, 0, 0],
+            ),
+            (
+                opcodes::OP_GUI_TOOL_MANAGER,
+                vec![opcodes::OP_GUI_TOOL_MANAGER, 1, 0, 0, 0, 0, 0],
+            ),
+        ];
 
-        let command = decode(&packet).unwrap();
+        for (opcode, payload) in cases {
+            let packet = [payload.clone(), vec![opcodes::OP_BATCH_END]].concat();
+            let command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
-        assert!(matches!(
-            command,
-            Command::Unsupported {
-                opcode,
-                size
-            } if opcode == opcodes::OP_GUI_COMPLETION && size == packet.len() - 1
-        ));
+            assert_eq!(command.size(), packet.len() - 1);
+            assert!(matches!(
+                command,
+                Command::Unsupported {
+                    opcode: decoded,
+                    size
+                } if decoded == opcode && size == packet.len() - 1
+            ));
+        }
     }
 
     #[test]

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -16,6 +16,9 @@ pub enum Command {
     SignatureHelp(SignatureHelp, usize),
     FloatPopup(FloatPopup, usize),
     HoverPopup(HoverPopup, usize),
+    BottomPanel(BottomPanel, usize),
+    ChangeSummary(ChangeSummary, usize),
+    GitStatus(GitStatus, usize),
     Theme(Theme, usize),
     Unsupported { opcode: u8, size: usize },
 }
@@ -37,6 +40,9 @@ impl Command {
             Self::SignatureHelp(_, size) => *size,
             Self::FloatPopup(_, size) => *size,
             Self::HoverPopup(_, size) => *size,
+            Self::BottomPanel(_, size) => *size,
+            Self::ChangeSummary(_, size) => *size,
+            Self::GitStatus(_, size) => *size,
             Self::Theme(_, size) => *size,
             Self::Unsupported { size, .. } => *size,
         }
@@ -287,6 +293,76 @@ pub struct HoverSegment {
     pub text: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BottomPanel {
+    pub visible: bool,
+    pub active_tab_index: u8,
+    pub height_percent: u8,
+    pub filter: u8,
+    pub tabs: Vec<BottomPanelTab>,
+    pub entries: Vec<BottomPanelEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BottomPanelTab {
+    pub tab_type: u8,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BottomPanelEntry {
+    pub id: u32,
+    pub level: u8,
+    pub subsystem: u8,
+    pub timestamp_secs: u32,
+    pub file_path: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ChangeSummary {
+    pub visible: bool,
+    pub selected_index: u16,
+    pub entries: Vec<ChangeSummaryEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeSummaryEntry {
+    pub path: String,
+    pub action: u8,
+    pub lines_added: u32,
+    pub lines_removed: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GitStatus {
+    pub repo_state: u8,
+    pub syncing: bool,
+    pub ahead: u16,
+    pub behind: u16,
+    pub branch: String,
+    pub entries: Vec<GitStatusEntry>,
+    pub toast: Option<GitToast>,
+    pub entry_base_path: String,
+    pub last_commit_message: String,
+    pub stash_count: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitStatusEntry {
+    pub path_hash: u32,
+    pub section: u8,
+    pub status: u8,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitToast {
+    pub level: u8,
+    pub action: u8,
+    pub message: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Theme {
     pub slots: Vec<ThemeSlot>,
@@ -316,6 +392,9 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_SIGNATURE_HELP => decode_signature_help(bytes),
         opcodes::OP_GUI_FLOAT_POPUP => decode_float_popup(bytes),
         opcodes::OP_GUI_HOVER_POPUP => decode_hover_popup(bytes),
+        opcodes::OP_GUI_BOTTOM_PANEL => decode_bottom_panel(bytes),
+        opcodes::OP_GUI_CHANGE_SUMMARY => decode_change_summary(bytes),
+        opcodes::OP_GUI_GIT_STATUS => decode_git_status(bytes),
         opcodes::OP_GUI_THEME => decode_theme(bytes),
         opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA | opcodes::OP_GUI_WINDOW_ROWS_DELTA => {
             sectioned_size(bytes, "semantic row delta")
@@ -346,11 +425,8 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
             split_separators_size(bytes).map(|size| Command::Unsupported { opcode, size })
         }
         opcodes::OP_GUI_AGENT_CONTEXT
-        | opcodes::OP_GUI_GIT_STATUS
-        | opcodes::OP_GUI_CHANGE_SUMMARY
         | opcodes::OP_GUI_BOARD
         | opcodes::OP_GUI_AGENT_CHAT
-        | opcodes::OP_GUI_BOTTOM_PANEL
         | opcodes::OP_GUI_TOOL_MANAGER => {
             legacy_visible_size(bytes).map(|size| Command::Unsupported { opcode, size })
         }
@@ -1016,6 +1092,170 @@ fn decode_hover_popup(bytes: &[u8]) -> Result<Command, DecodeError> {
     ))
 }
 
+fn decode_bottom_panel(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 2, "bottom panel header")?;
+    if bytes[1] == 0 {
+        return Ok(Command::BottomPanel(BottomPanel::default(), 2));
+    }
+
+    let size = bottom_panel_size(bytes)?;
+    require_len(bytes, 6, "bottom panel visible header")?;
+    let active_tab_index = bytes[2];
+    let height_percent = bytes[3];
+    let filter = bytes[4];
+    let tab_count = bytes[5] as usize;
+    let mut offset = 6;
+    let mut tabs = Vec::with_capacity(tab_count);
+
+    for _ in 0..tab_count {
+        require_len(bytes, offset + 1, "bottom panel tab type")?;
+        let tab_type = bytes[offset];
+        offset += 1;
+        let name = read_string8(bytes, &mut offset)?;
+        tabs.push(BottomPanelTab { tab_type, name });
+    }
+
+    require_len(bytes, offset + 2, "bottom panel entry count")?;
+    let entry_count = read_u16(bytes, offset) as usize;
+    offset += 2;
+    let mut entries = Vec::with_capacity(entry_count);
+
+    for _ in 0..entry_count {
+        require_len(bytes, offset + 10, "bottom panel entry")?;
+        let id = read_u32(bytes, offset);
+        let level = bytes[offset + 4];
+        let subsystem = bytes[offset + 5];
+        let timestamp_secs = read_u32(bytes, offset + 6);
+        offset += 10;
+        let file_path = read_string16(bytes, &mut offset)?;
+        let text = read_string16(bytes, &mut offset)?;
+        entries.push(BottomPanelEntry {
+            id,
+            level,
+            subsystem,
+            timestamp_secs,
+            file_path,
+            text,
+        });
+    }
+
+    Ok(Command::BottomPanel(
+        BottomPanel {
+            visible: true,
+            active_tab_index,
+            height_percent,
+            filter,
+            tabs,
+            entries,
+        },
+        size,
+    ))
+}
+
+fn decode_change_summary(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = change_summary_size(bytes)?;
+    require_len(bytes, 5, "change summary header")?;
+    let visible = bytes[1] != 0;
+    let selected_index = read_u16(bytes, 2);
+    let count = read_u16(bytes, 4) as usize;
+    let mut offset = 6;
+    let mut entries = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        let path = read_string16(bytes, &mut offset)?;
+        require_len(bytes, offset + 9, "change summary entry")?;
+        let action = bytes[offset];
+        let lines_added = read_u32(bytes, offset + 1);
+        let lines_removed = read_u32(bytes, offset + 5);
+        offset += 9;
+        entries.push(ChangeSummaryEntry {
+            path,
+            action,
+            lines_added,
+            lines_removed,
+        });
+    }
+
+    Ok(Command::ChangeSummary(
+        ChangeSummary {
+            visible,
+            selected_index,
+            entries,
+        },
+        size,
+    ))
+}
+
+fn decode_git_status(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = git_status_size(bytes)?;
+    require_len(bytes, 9, "git status header")?;
+    let repo_state = bytes[1];
+    let syncing = bytes[2] != 0;
+    let ahead = read_u16(bytes, 3);
+    let behind = read_u16(bytes, 5);
+    let mut offset = 7;
+    let branch = read_string16(bytes, &mut offset)?;
+    require_len(bytes, offset + 2, "git status entry count")?;
+    let count = read_u16(bytes, offset) as usize;
+    offset += 2;
+    let mut entries = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        require_len(bytes, offset + 6, "git status entry")?;
+        let path_hash = read_u32(bytes, offset);
+        let section = bytes[offset + 4];
+        let status = bytes[offset + 5];
+        offset += 6;
+        let path = read_string16(bytes, &mut offset)?;
+        entries.push(GitStatusEntry {
+            path_hash,
+            section,
+            status,
+            path,
+        });
+    }
+
+    require_len(bytes, offset + 1, "git toast visibility")?;
+    let toast = if bytes[offset] == 0 {
+        offset += 1;
+        None
+    } else {
+        require_len(bytes, offset + 5, "git toast")?;
+        let level = bytes[offset + 1];
+        let action = bytes[offset + 2];
+        let len = read_u16(bytes, offset + 3) as usize;
+        offset += 5;
+        let message = read_string(bytes, offset, len)?;
+        offset += len;
+        Some(GitToast {
+            level,
+            action,
+            message,
+        })
+    };
+
+    let entry_base_path = read_string16(bytes, &mut offset)?;
+    let last_commit_message = read_string16(bytes, &mut offset)?;
+    require_len(bytes, offset + 2, "git stash count")?;
+    let stash_count = read_u16(bytes, offset);
+
+    Ok(Command::GitStatus(
+        GitStatus {
+            repo_state,
+            syncing,
+            ahead,
+            behind,
+            branch,
+            entries,
+            toast,
+            entry_base_path,
+            last_commit_message,
+            stash_count,
+        },
+        size,
+    ))
+}
+
 fn decode_theme(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = theme_size(bytes)?;
     let count = bytes[1] as usize;
@@ -1393,9 +1633,9 @@ fn git_status_size(bytes: &[u8]) -> Result<usize, DecodeError> {
 }
 
 fn change_summary_size(bytes: &[u8]) -> Result<usize, DecodeError> {
-    require_len(bytes, 5, "change summary")?;
-    let count = read_u16(bytes, 3) as usize;
-    let mut offset = 5;
+    require_len(bytes, 6, "change summary")?;
+    let count = read_u16(bytes, 4) as usize;
+    let mut offset = 6;
     for _ in 0..count {
         skip_string16(bytes, &mut offset)?;
         require_len(bytes, offset + 9, "change summary entry")?;
@@ -1913,6 +2153,92 @@ mod tests {
     }
 
     #[test]
+    fn decodes_bottom_panel_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_GUI_BOTTOM_PANEL, 1, 1, 30, 2, 2],
+            vec![0],
+            string8("Logs"),
+            vec![1],
+            string8("Tasks"),
+            vec![0, 1],
+            vec![0, 0, 0, 7, 4, 2, 0, 0, 0, 42],
+            string16("lib/minga.ex"),
+            string16("failed to compile"),
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+
+        let command = decode(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::BottomPanel(BottomPanel { visible: true, active_tab_index: 1, height_percent: 30, filter: 2, tabs, entries }, _)
+                if tabs[0].name == "Logs"
+                    && tabs[1].tab_type == 1
+                    && entries[0].id == 7
+                    && entries[0].text == "failed to compile"
+        ));
+    }
+
+    #[test]
+    fn decodes_change_summary_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_GUI_CHANGE_SUMMARY, 1, 0, 1, 0, 2],
+            string16("lib/a.ex"),
+            vec![0, 0, 0, 0, 12, 0, 0, 0, 3],
+            string16("lib/b.ex"),
+            vec![1, 0, 0, 0, 5, 0, 0, 0, 0],
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+
+        let command = decode(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::ChangeSummary(ChangeSummary { visible: true, selected_index: 1, entries }, _)
+                if entries[0].path == "lib/a.ex"
+                    && entries[0].lines_added == 12
+                    && entries[1].action == 1
+        ));
+    }
+
+    #[test]
+    fn decodes_git_status_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_GUI_GIT_STATUS, 0, 1, 0, 2, 0, 1],
+            string16("main"),
+            vec![0, 1],
+            vec![0x12, 0x34, 0x56, 0x78, 1, 1],
+            string16("lib/minga.ex"),
+            vec![1, 0, 0],
+            string16("Pulled"),
+            string16("lib"),
+            string16("Initial commit"),
+            vec![0, 3],
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+
+        let command = decode(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::GitStatus(GitStatus { repo_state: 0, syncing: true, ahead: 2, behind: 1, branch, entries, toast: Some(toast), entry_base_path, last_commit_message, stash_count }, _)
+                if branch == "main"
+                    && entries[0].path_hash == 0x12345678
+                    && entries[0].path == "lib/minga.ex"
+                    && toast.message == "Pulled"
+                    && entry_base_path == "lib"
+                    && last_commit_message == "Initial commit"
+                    && stash_count == 3
+        ));
+    }
+
+    #[test]
     fn decodes_theme_slots() {
         let packet = vec![
             opcodes::OP_GUI_THEME,
@@ -1958,43 +2284,12 @@ mod tests {
                 ],
             ),
             (
-                opcodes::OP_GUI_GIT_STATUS,
-                vec![
-                    opcodes::OP_GUI_GIT_STATUS,
-                    1,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                ],
-            ),
-            (
-                opcodes::OP_GUI_CHANGE_SUMMARY,
-                vec![opcodes::OP_GUI_CHANGE_SUMMARY, 1, 0, 0, 0],
-            ),
-            (
                 opcodes::OP_GUI_BOARD,
                 vec![opcodes::OP_GUI_BOARD, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             ),
             (
                 opcodes::OP_GUI_AGENT_CHAT,
                 vec![opcodes::OP_GUI_AGENT_CHAT, 1, 1, 0, 0],
-            ),
-            (
-                opcodes::OP_GUI_BOTTOM_PANEL,
-                vec![opcodes::OP_GUI_BOTTOM_PANEL, 1, 0, 0, 0, 0, 0, 0],
             ),
             (
                 opcodes::OP_GUI_TOOL_MANAGER,

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -13,6 +13,9 @@ pub enum Command {
     Breadcrumb(Breadcrumb, usize),
     Completion(Completion, usize),
     WhichKey(WhichKey, usize),
+    SignatureHelp(SignatureHelp, usize),
+    FloatPopup(FloatPopup, usize),
+    HoverPopup(HoverPopup, usize),
     Theme(Theme, usize),
     Unsupported { opcode: u8, size: usize },
 }
@@ -31,6 +34,9 @@ impl Command {
             Self::Breadcrumb(_, size) => *size,
             Self::Completion(_, size) => *size,
             Self::WhichKey(_, size) => *size,
+            Self::SignatureHelp(_, size) => *size,
+            Self::FloatPopup(_, size) => *size,
+            Self::HoverPopup(_, size) => *size,
             Self::Theme(_, size) => *size,
             Self::Unsupported { size, .. } => *size,
         }
@@ -225,6 +231,62 @@ pub struct WhichKeyBinding {
     pub icon: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SignatureHelp {
+    pub visible: bool,
+    pub anchor_row: u16,
+    pub anchor_col: u16,
+    pub active_signature: u8,
+    pub active_parameter: u8,
+    pub signatures: Vec<Signature>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signature {
+    pub label: String,
+    pub documentation: String,
+    pub parameters: Vec<SignatureParameter>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureParameter {
+    pub label: String,
+    pub documentation: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FloatPopup {
+    pub visible: bool,
+    pub width: u16,
+    pub height: u16,
+    pub title: String,
+    pub lines: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HoverPopup {
+    pub visible: bool,
+    pub anchor_row: u16,
+    pub anchor_col: u16,
+    pub focused: bool,
+    pub scroll_offset: u16,
+    pub lines: Vec<HoverLine>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoverLine {
+    pub line_type: u8,
+    pub segments: Vec<HoverSegment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoverSegment {
+    pub style: u8,
+    pub fg: u32,
+    pub flags: u8,
+    pub text: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Theme {
     pub slots: Vec<ThemeSlot>,
@@ -251,6 +313,9 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_BREADCRUMB => decode_breadcrumb(bytes),
         opcodes::OP_GUI_COMPLETION => decode_completion(bytes),
         opcodes::OP_GUI_WHICH_KEY => decode_which_key(bytes),
+        opcodes::OP_GUI_SIGNATURE_HELP => decode_signature_help(bytes),
+        opcodes::OP_GUI_FLOAT_POPUP => decode_float_popup(bytes),
+        opcodes::OP_GUI_HOVER_POPUP => decode_hover_popup(bytes),
         opcodes::OP_GUI_THEME => decode_theme(bytes),
         opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA | opcodes::OP_GUI_WINDOW_ROWS_DELTA => {
             sectioned_size(bytes, "semantic row delta")
@@ -280,10 +345,7 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_SPLIT_SEPARATORS => {
             split_separators_size(bytes).map(|size| Command::Unsupported { opcode, size })
         }
-        opcodes::OP_GUI_SIGNATURE_HELP
-        | opcodes::OP_GUI_FLOAT_POPUP
-        | opcodes::OP_GUI_HOVER_POPUP
-        | opcodes::OP_GUI_AGENT_CONTEXT
+        opcodes::OP_GUI_AGENT_CONTEXT
         | opcodes::OP_GUI_GIT_STATUS
         | opcodes::OP_GUI_CHANGE_SUMMARY
         | opcodes::OP_GUI_BOARD
@@ -801,6 +863,154 @@ fn decode_which_key(bytes: &[u8]) -> Result<Command, DecodeError> {
             page,
             page_count,
             bindings,
+        },
+        size,
+    ))
+}
+
+fn decode_signature_help(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 2, "signature help header")?;
+    if bytes[1] == 0 {
+        return Ok(Command::SignatureHelp(SignatureHelp::default(), 2));
+    }
+
+    let size = signature_help_size(bytes)?;
+    let anchor_row = read_u16(bytes, 2);
+    let anchor_col = read_u16(bytes, 4);
+    let active_signature = bytes[6];
+    let active_parameter = bytes[7];
+    let count = bytes[8] as usize;
+    let mut offset = 9;
+    let mut signatures = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        let label = read_string16(bytes, &mut offset)?;
+        let documentation = read_string16(bytes, &mut offset)?;
+        require_len(bytes, offset + 1, "signature parameter count")?;
+        let parameter_count = bytes[offset] as usize;
+        offset += 1;
+        let mut parameters = Vec::with_capacity(parameter_count);
+        for _ in 0..parameter_count {
+            parameters.push(SignatureParameter {
+                label: read_string16(bytes, &mut offset)?,
+                documentation: read_string16(bytes, &mut offset)?,
+            });
+        }
+        signatures.push(Signature {
+            label,
+            documentation,
+            parameters,
+        });
+    }
+
+    Ok(Command::SignatureHelp(
+        SignatureHelp {
+            visible: true,
+            anchor_row,
+            anchor_col,
+            active_signature,
+            active_parameter,
+            signatures,
+        },
+        size,
+    ))
+}
+
+fn decode_float_popup(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 2, "float popup header")?;
+    if bytes[1] == 0 {
+        return Ok(Command::FloatPopup(FloatPopup::default(), 2));
+    }
+
+    let size = float_popup_size(bytes)?;
+    let width = read_u16(bytes, 2);
+    let height = read_u16(bytes, 4);
+    let mut offset = 6;
+    let title = read_string16(bytes, &mut offset)?;
+    require_len(bytes, offset + 2, "float popup line count")?;
+    let count = read_u16(bytes, offset) as usize;
+    offset += 2;
+    let mut lines = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        lines.push(read_string16(bytes, &mut offset)?);
+    }
+
+    Ok(Command::FloatPopup(
+        FloatPopup {
+            visible: true,
+            width,
+            height,
+            title,
+            lines,
+        },
+        size,
+    ))
+}
+
+fn decode_hover_popup(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 2, "hover popup header")?;
+    if bytes[1] == 0 {
+        return Ok(Command::HoverPopup(HoverPopup::default(), 2));
+    }
+
+    let size = hover_popup_size(bytes)?;
+    let anchor_row = read_u16(bytes, 2);
+    let anchor_col = read_u16(bytes, 4);
+    let focused = bytes[6] != 0;
+    let scroll_offset = read_u16(bytes, 7);
+    let count = read_u16(bytes, 9) as usize;
+    let mut offset = 11;
+    let mut lines = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        require_len(bytes, offset + 3, "hover line")?;
+        let line_type = bytes[offset];
+        let segment_count = read_u16(bytes, offset + 1) as usize;
+        offset += 3;
+        let mut segments = Vec::with_capacity(segment_count);
+        for _ in 0..segment_count {
+            require_len(bytes, offset + 1, "hover segment style")?;
+            let style = bytes[offset];
+            offset += 1;
+            let (fg, flags, text) = if style == 13 {
+                require_len(bytes, offset + 6, "hover syntax segment")?;
+                let fg = read_u24(bytes, offset);
+                let flags = bytes[offset + 3];
+                let len = read_u16(bytes, offset + 4) as usize;
+                offset += 6;
+                let text = read_string(bytes, offset, len)?;
+                offset += len;
+                (fg, flags, text)
+            } else {
+                require_len(bytes, offset + 2, "hover segment")?;
+                let len = read_u16(bytes, offset) as usize;
+                offset += 2;
+                let text = read_string(bytes, offset, len)?;
+                offset += len;
+                (0, 0, text)
+            };
+            segments.push(HoverSegment {
+                style,
+                fg,
+                flags,
+                text,
+            });
+        }
+        lines.push(HoverLine {
+            line_type,
+            segments,
+        });
+    }
+
+    Ok(Command::HoverPopup(
+        HoverPopup {
+            visible: true,
+            anchor_row,
+            anchor_col,
+            focused,
+            scroll_offset,
+            lines,
         },
         size,
     ))
@@ -1631,6 +1841,78 @@ mod tests {
     }
 
     #[test]
+    fn decodes_signature_help_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_GUI_SIGNATURE_HELP, 1, 0, 8, 0, 12, 0, 1, 1],
+            string16("open(path, opts)"),
+            string16("Open a file"),
+            vec![2],
+            string16("path"),
+            string16("File path"),
+            string16("opts"),
+            string16("Options"),
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+
+        let command = decode(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::SignatureHelp(SignatureHelp { visible: true, anchor_row: 8, anchor_col: 12, active_parameter: 1, signatures, .. }, _)
+                if signatures[0].label == "open(path, opts)" && signatures[0].parameters[1].label == "opts"
+        ));
+    }
+
+    #[test]
+    fn decodes_float_popup_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_GUI_FLOAT_POPUP, 1, 0, 24, 0, 5],
+            string16("Docs"),
+            vec![0, 2],
+            string16("line one"),
+            string16("line two"),
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+
+        let command = decode(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::FloatPopup(FloatPopup { visible: true, width: 24, height: 5, title, lines }, _)
+                if title == "Docs" && lines == vec!["line one", "line two"]
+        ));
+    }
+
+    #[test]
+    fn decodes_hover_popup_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_GUI_HOVER_POPUP, 1, 0, 3, 0, 9, 1, 0, 2, 0, 1],
+            vec![0, 0, 2],
+            vec![0],
+            string16("plain"),
+            vec![13, 0xAA, 0xBB, 0xCC, 0x05],
+            string16("syntax"),
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+
+        let command = decode(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::HoverPopup(HoverPopup { visible: true, anchor_row: 3, anchor_col: 9, focused: true, scroll_offset: 2, lines }, _)
+                if lines[0].segments[0].text == "plain"
+                    && lines[0].segments[1].fg == 0xAABBCC
+                    && lines[0].segments[1].flags == 0x05
+        ));
+    }
+
+    #[test]
     fn decodes_theme_slots() {
         let packet = vec![
             opcodes::OP_GUI_THEME,
@@ -1656,18 +1938,6 @@ mod tests {
     #[test]
     fn skips_remaining_visible_legacy_commands_without_consuming_following_commands() {
         let cases = [
-            (
-                opcodes::OP_GUI_SIGNATURE_HELP,
-                vec![opcodes::OP_GUI_SIGNATURE_HELP, 1, 0, 0, 0, 0, 0, 0, 0],
-            ),
-            (
-                opcodes::OP_GUI_FLOAT_POPUP,
-                vec![opcodes::OP_GUI_FLOAT_POPUP, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-            ),
-            (
-                opcodes::OP_GUI_HOVER_POPUP,
-                vec![opcodes::OP_GUI_HOVER_POPUP, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            ),
             (
                 opcodes::OP_GUI_AGENT_CONTEXT,
                 vec![


### PR DESCRIPTION
## Summary

- Decode semantic breadcrumb, completion, which-key, signature help, float popup, hover popup, bottom panel, change summary, and git status packets into typed Rust TUI commands instead of skip-only commands.
- Render breadcrumb, completion popup, which-key overlay, signature help, float popup, hover popup, bottom panel, change summary, and git status with retained redraw/restore behavior.
- Add Ratatui as the Rust TUI widget layer and bridge Ratatui buffers into Minga's existing diffed terminal cell grid.
- Add stream-alignment regression coverage for the newly decoded packets plus remaining visible legacy skip-stub opcodes.
- Split Rust TUI renderer into `renderer/mod.rs` and `renderer/theme.rs` so theme slot/style ownership is no longer buried in one large renderer file.

Refs #2115.

## Validation

- `cargo fmt --manifest-path rust/tui/Cargo.toml --check`
- `cargo test --manifest-path rust/tui/Cargo.toml`
- `cargo clippy --manifest-path rust/tui/Cargo.toml -- -D warnings`
- `mix protocol.gen --check`
- `git diff --check -- rust/tui/Cargo.toml rust/tui/Cargo.lock rust/tui/src/semantic.rs rust/tui/src/renderer/mod.rs rust/tui/src/renderer/theme.rs`
- `mix compile --warnings-as-errors`