### PR TITLE
Expand Rust TUI cargo integrations

### DIFF
--- a/rust/tui/Cargo.lock
+++ b/rust/tui/Cargo.lock
@@ -3,16 +3,173 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "castaway"
@@ -30,6 +187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +204,69 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -63,7 +289,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -74,8 +300,14 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -84,6 +316,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -99,10 +341,184 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -112,8 +528,14 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -122,10 +544,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "icy_sixel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85518b9086bf01117761b90e7691c0ef3236fa8adfb1fb44dd248fe5f87215d5"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indoc"
@@ -146,7 +615,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -165,14 +634,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
- "hashbrown",
- "thiserror",
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -181,13 +680,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "log"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
@@ -195,17 +712,120 @@ version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "micromath"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
 name = "minga-renderer-rs"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "mio",
  "ratatui",
+ "ratatui-image",
+ "signal-hook",
+ "tachyonfx",
+ "termwiz",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -215,10 +835,218 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "bytemuck",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -230,12 +1058,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quantette"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98fecda8b16396ff9adac67644a523dd1778c42b58606a29df5c31ca925d174"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "image",
+ "libm",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "palette",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rayon",
+ "ref-cast",
+ "wide",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -255,18 +1181,35 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "compact_str",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indoc",
  "itertools",
  "kasuari",
  "lru",
  "strum",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
+]
+
+[[package]]
+name = "ratatui-image"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535e2a5f434ea3308977e6664b4386c3d663951a222e338cb7480d8742fe7773"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.6",
+ "ratatui",
+ "rustix",
+ "self_cell",
+ "thiserror 1.0.69",
+ "windows",
 ]
 
 [[package]]
@@ -275,8 +1218,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags",
- "hashbrown",
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
@@ -286,6 +1229,88 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -299,6 +1324,119 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "static_assertions"
@@ -330,7 +1468,18 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -345,12 +1494,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "tachyonfx"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c144c687e9f3628c06add1b6db585a68d3cd285a9d7213b9bca836771e337592"
+dependencies = [
+ "bon",
+ "compact_str",
+ "micromath",
+ "ratatui-core",
+ "thiserror 2.0.18",
+ "unicode-width",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float 4.6.0",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -361,7 +1613,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -381,6 +1633,18 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -407,6 +1671,539 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float 4.6.0",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust/tui/Cargo.lock
+++ b/rust/tui/Cargo.lock
@@ -204,6 +204,8 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "ratatui",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]

--- a/rust/tui/Cargo.toml
+++ b/rust/tui/Cargo.toml
@@ -10,6 +10,11 @@ path = "src/main.rs"
 
 [dependencies]
 libc = "0.2.184"
+mio = { version = "1.0.4", features = ["os-ext", "os-poll"] }
 ratatui = { version = "0.30.0", default-features = false }
+ratatui-image = { version = "11.0.2", default-features = false }
+signal-hook = "0.3.18"
+tachyonfx = { version = "0.25.0", default-features = false }
+termwiz = "0.23.3"
 unicode-segmentation = "1.13.0"
-unicode-width = "0.2.2"
+unicode-width = "0.2.0"

--- a/rust/tui/Cargo.toml
+++ b/rust/tui/Cargo.toml
@@ -11,3 +11,5 @@ path = "src/main.rs"
 [dependencies]
 libc = "0.2.184"
 ratatui = { version = "0.30.0", default-features = false }
+unicode-segmentation = "1.13.0"
+unicode-width = "0.2.2"

--- a/rust/tui/src/animation.rs
+++ b/rust/tui/src/animation.rs
@@ -1,0 +1,52 @@
+use tachyonfx::{Duration, EffectTimer, Interpolation};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MotionCurve {
+    Standard,
+    Emphasized,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnimationSpec {
+    pub duration: Duration,
+    pub curve: MotionCurve,
+}
+
+impl AnimationSpec {
+    pub const fn new(milliseconds: u32, curve: MotionCurve) -> Self {
+        Self {
+            duration: Duration::from_millis(milliseconds),
+            curve,
+        }
+    }
+
+    pub fn timer(self) -> EffectTimer {
+        EffectTimer::new(self.duration, self.curve.interpolation())
+    }
+}
+
+impl MotionCurve {
+    pub fn interpolation(self) -> Interpolation {
+        match self {
+            Self::Standard => Interpolation::QuadOut,
+            Self::Emphasized => Interpolation::CubicOut,
+        }
+    }
+}
+
+pub const POPUP_REVEAL: AnimationSpec = AnimationSpec::new(90, MotionCurve::Standard);
+pub const RESIZE_SETTLE: AnimationSpec = AnimationSpec::new(120, MotionCurve::Emphasized);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn animation_specs_use_tachyonfx_timers() {
+        assert_eq!(POPUP_REVEAL.duration, Duration::from_millis(90));
+        assert_eq!(POPUP_REVEAL.curve.interpolation(), Interpolation::QuadOut);
+
+        let mut timer = RESIZE_SETTLE.timer();
+        assert_eq!(timer.process(Duration::from_millis(30)), None);
+    }
+}

--- a/rust/tui/src/images.rs
+++ b/rust/tui/src/images.rs
@@ -1,0 +1,41 @@
+use ratatui_image::picker::{Picker, ProtocolType};
+
+#[derive(Debug, Clone, Copy)]
+pub struct ImageSupport {
+    protocol: ProtocolType,
+}
+
+impl ImageSupport {
+    pub fn fallback() -> Self {
+        let picker = Picker::halfblocks();
+        Self {
+            protocol: picker.protocol_type(),
+        }
+    }
+
+    pub fn capability_code(self) -> u8 {
+        match self.protocol {
+            ProtocolType::Kitty => 1,
+            ProtocolType::Sixel => 2,
+            ProtocolType::Iterm2 | ProtocolType::Halfblocks => 0,
+        }
+    }
+}
+
+impl Default for ImageSupport {
+    fn default() -> Self {
+        Self::fallback()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_image_support_uses_halfblocks_without_stdio_queries() {
+        let support = ImageSupport::fallback();
+
+        assert_eq!(support.capability_code(), 0);
+    }
+}

--- a/rust/tui/src/input.rs
+++ b/rust/tui/src/input.rs
@@ -1,9 +1,7 @@
 use crate::protocol;
+use termwiz::input::{InputEvent as TermwizInputEvent, InputParser, KeyCode, KeyEvent, Modifiers};
 
 const ESC: u8 = 0x1B;
-const PASTE_START: &[u8] = b"\x1b[200~";
-const PASTE_END: &[u8] = b"\x1b[201~";
-
 const ARROW_LEFT: u32 = 57_350;
 const ARROW_RIGHT: u32 = 57_351;
 const ARROW_UP: u32 = 57_352;
@@ -17,239 +15,71 @@ pub enum Event {
 
 #[derive(Debug, Default)]
 pub struct Parser {
-    pending: Vec<u8>,
-    paste: Vec<u8>,
-    in_paste: bool,
+    inner: InputParser,
 }
 
 impl Parser {
     pub fn push(&mut self, bytes: &[u8]) -> Vec<Event> {
-        self.pending.extend_from_slice(bytes);
-        self.drain(false)
+        self.inner
+            .parse_as_vec(bytes, true)
+            .into_iter()
+            .filter_map(map_termwiz_event)
+            .collect()
     }
 
     pub fn flush_escape(&mut self) -> Vec<Event> {
-        self.drain(true)
-    }
-
-    fn drain(&mut self, flush_escape: bool) -> Vec<Event> {
-        let mut events = Vec::new();
-
-        loop {
-            if self.in_paste {
-                match find_bytes(&self.pending, PASTE_END) {
-                    Some(pos) => {
-                        self.paste.extend_from_slice(&self.pending[..pos]);
-                        self.pending.drain(..pos + PASTE_END.len());
-                        if !self.paste.is_empty() {
-                            events.push(Event::Paste(std::mem::take(&mut self.paste)));
-                        }
-                        self.in_paste = false;
-                    }
-                    None => {
-                        let keep = paste_end_prefix_suffix(&self.pending);
-                        let paste_len = self.pending.len().saturating_sub(keep);
-                        self.paste.extend_from_slice(&self.pending[..paste_len]);
-                        self.pending.drain(..paste_len);
-                        break;
-                    }
-                }
-                continue;
-            }
-
-            if self.pending.is_empty() {
-                break;
-            }
-
-            if self.pending.starts_with(PASTE_START) {
-                self.pending.drain(..PASTE_START.len());
-                self.paste.clear();
-                self.in_paste = true;
-                continue;
-            }
-
-            if self.pending[0] == ESC {
-                match parse_escape(&self.pending, flush_escape) {
-                    ParseResult::Event(event, used) => {
-                        self.pending.drain(..used);
-                        events.push(event);
-                    }
-                    ParseResult::NeedMore => break,
-                    ParseResult::Ignore(used) => {
-                        self.pending.drain(..used);
-                    }
-                }
-                continue;
-            }
-
-            let byte = self.pending[0];
-            match std::str::from_utf8(&self.pending) {
-                Ok(text) => {
-                    if let Some(ch) = text.chars().next() {
-                        let len = ch.len_utf8();
-                        self.pending.drain(..len);
-                        events.push(Event::Key {
-                            codepoint: ch as u32,
-                            modifiers: 0,
-                        });
-                    } else {
-                        break;
-                    }
-                }
-                Err(error) if error.valid_up_to() > 0 => {
-                    let valid = error.valid_up_to();
-                    let first = std::str::from_utf8(&self.pending[..valid])
-                        .ok()
-                        .and_then(|text| text.chars().next());
-                    if let Some(ch) = first {
-                        let len = ch.len_utf8();
-                        self.pending.drain(..len);
-                        events.push(Event::Key {
-                            codepoint: ch as u32,
-                            modifiers: 0,
-                        });
-                    } else {
-                        self.pending.drain(..valid);
-                    }
-                }
-                Err(error) if error.error_len().is_none() => break,
-                Err(_) => {
-                    self.pending.drain(..1);
-                    events.push(Event::Key {
-                        codepoint: byte as u32,
-                        modifiers: 0,
-                    });
-                }
-            }
-        }
-
-        events
+        self.inner
+            .parse_as_vec(&[], false)
+            .into_iter()
+            .filter_map(map_termwiz_event)
+            .collect()
     }
 }
 
-enum ParseResult {
-    Event(Event, usize),
-    NeedMore,
-    Ignore(usize),
-}
-
-fn parse_escape(bytes: &[u8], flush_escape: bool) -> ParseResult {
-    if bytes.len() == 1 {
-        if flush_escape {
-            return ParseResult::Event(
-                Event::Key {
-                    codepoint: ESC as u32,
-                    modifiers: 0,
-                },
-                1,
-            );
-        }
-        return ParseResult::NeedMore;
-    }
-
-    match bytes[1] {
-        b'[' => parse_csi(bytes),
-        b'O' => parse_ss3(bytes),
-        _ => ParseResult::Event(
-            Event::Key {
-                codepoint: bytes[1] as u32,
-                modifiers: protocol::MOD_ALT,
-            },
-            2,
-        ),
+fn map_termwiz_event(event: TermwizInputEvent) -> Option<Event> {
+    match event {
+        TermwizInputEvent::Key(key) => map_key_event(key),
+        TermwizInputEvent::Paste(text) => Some(Event::Paste(text.into_bytes())),
+        _ => None,
     }
 }
 
-fn parse_csi(bytes: &[u8]) -> ParseResult {
-    let Some(relative_end) = bytes[2..]
-        .iter()
-        .position(|byte| (0x40..=0x7E).contains(byte))
-    else {
-        return ParseResult::NeedMore;
-    };
-    let end = relative_end + 2;
-    let final_byte = bytes[end];
-    let params = std::str::from_utf8(&bytes[2..end]).unwrap_or("");
-    let modifiers = csi_modifiers(params);
-
-    let codepoint = match final_byte {
-        b'A' => ARROW_UP,
-        b'B' => ARROW_DOWN,
-        b'C' => ARROW_RIGHT,
-        b'D' => ARROW_LEFT,
-        b'~' => match params.split(';').next().unwrap_or("") {
-            "1" | "7" => ARROW_UP,
-            "4" | "8" => ARROW_DOWN,
-            _ => return ParseResult::Ignore(end + 1),
-        },
-        _ => return ParseResult::Ignore(end + 1),
+fn map_key_event(event: KeyEvent) -> Option<Event> {
+    let codepoint = match event.key {
+        KeyCode::Char(ch) => ch as u32,
+        KeyCode::Escape => ESC as u32,
+        KeyCode::Backspace => 127,
+        KeyCode::Enter => 13,
+        KeyCode::Tab => 9,
+        KeyCode::LeftArrow | KeyCode::ApplicationLeftArrow => ARROW_LEFT,
+        KeyCode::RightArrow | KeyCode::ApplicationRightArrow => ARROW_RIGHT,
+        KeyCode::UpArrow | KeyCode::ApplicationUpArrow => ARROW_UP,
+        KeyCode::DownArrow | KeyCode::ApplicationDownArrow => ARROW_DOWN,
+        KeyCode::Home => ARROW_UP,
+        KeyCode::End => ARROW_DOWN,
+        _ => return None,
     };
 
-    ParseResult::Event(
-        Event::Key {
-            codepoint,
-            modifiers,
-        },
-        end + 1,
-    )
+    Some(Event::Key {
+        codepoint,
+        modifiers: map_modifiers(event.modifiers),
+    })
 }
 
-fn parse_ss3(bytes: &[u8]) -> ParseResult {
-    if bytes.len() < 3 {
-        return ParseResult::NeedMore;
-    }
-
-    let codepoint = match bytes[2] {
-        b'A' => ARROW_UP,
-        b'B' => ARROW_DOWN,
-        b'C' => ARROW_RIGHT,
-        b'D' => ARROW_LEFT,
-        _ => return ParseResult::Ignore(3),
-    };
-
-    ParseResult::Event(
-        Event::Key {
-            codepoint,
-            modifiers: 0,
-        },
-        3,
-    )
-}
-
-fn csi_modifiers(params: &str) -> u8 {
-    let raw = params
-        .split(';')
-        .filter_map(|part| part.parse::<u8>().ok())
-        .next_back()
-        .unwrap_or(1);
-    let bits = raw.saturating_sub(1);
+fn map_modifiers(termwiz: Modifiers) -> u8 {
     let mut modifiers = 0;
 
-    if bits & 0x01 != 0 {
+    if termwiz.contains(Modifiers::SHIFT) {
         modifiers |= protocol::MOD_SHIFT;
     }
-    if bits & 0x02 != 0 {
+    if termwiz.contains(Modifiers::ALT) {
         modifiers |= protocol::MOD_ALT;
     }
-    if bits & 0x04 != 0 {
+    if termwiz.contains(Modifiers::CTRL) {
         modifiers |= protocol::MOD_CTRL;
     }
 
     modifiers
-}
-
-fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
-}
-
-fn paste_end_prefix_suffix(bytes: &[u8]) -> usize {
-    let max = bytes.len().min(PASTE_END.len().saturating_sub(1));
-    (1..=max)
-        .rev()
-        .find(|len| bytes[bytes.len() - len..] == PASTE_END[..*len])
-        .unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/rust/tui/src/main.rs
+++ b/rust/tui/src/main.rs
@@ -1,10 +1,20 @@
+mod animation;
+mod images;
 mod input;
 mod protocol;
 mod renderer;
 mod semantic;
+mod signals;
 mod terminal;
 
+use mio::unix::SourceFd;
+use mio::{Events, Interest, Poll, Token};
 use std::io::{self, Read, Write};
+use std::os::fd::RawFd;
+use std::time::Duration;
+
+const STDIN_TOKEN: Token = Token(0);
+const TTY_TOKEN: Token = Token(1);
 
 fn main() {
     if let Err(error) = run() {
@@ -17,15 +27,24 @@ fn run() -> io::Result<()> {
     let mut terminal = terminal::Terminal::open()?;
     let (cols, rows) = terminal.size();
     let mut stdout = io::stdout().lock();
-    protocol::write_packet(&mut stdout, &protocol::encode_ready_with_caps(cols, rows))?;
+    let image_support = images::ImageSupport::default();
+    protocol::write_packet(
+        &mut stdout,
+        &protocol::encode_ready_with_caps(cols, rows, image_support.capability_code()),
+    )?;
 
     let mut renderer = renderer::Renderer::new(cols, rows);
     let mut stdin = io::stdin().lock();
     let mut input = input::Parser::default();
     let mut tty_read_buf = [0_u8; 4096];
+    let resize_signal = signals::ResizeSignal::install().ok();
+    let mut input_poll = match terminal.fd() {
+        Some(tty_fd) => Some(InputPoll::new(libc::STDIN_FILENO, tty_fd)?),
+        None => None,
+    };
 
     loop {
-        let Some(tty_fd) = terminal.fd() else {
+        if terminal.fd().is_none() {
             match read_packet(&mut stdin)? {
                 Some(packet) => handle_packet(&packet, &mut renderer, &mut terminal, &mut stdout)?,
                 None => break,
@@ -33,49 +52,36 @@ fn run() -> io::Result<()> {
             continue;
         };
 
-        let mut pollfds = [
-            libc::pollfd {
-                fd: libc::STDIN_FILENO,
-                events: libc::POLLIN,
-                revents: 0,
-            },
-            libc::pollfd {
-                fd: tty_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
-        ];
-        let poll_result =
-            unsafe { libc::poll(pollfds.as_mut_ptr(), pollfds.len() as libc::nfds_t, 100) };
+        let ready = input_poll
+            .as_mut()
+            .expect("terminal fd implies input poll")
+            .poll(Duration::from_millis(100))?;
 
-        if poll_result < 0 {
-            let error = io::Error::last_os_error();
-            if error.kind() == io::ErrorKind::Interrupted {
-                continue;
-            }
-            return Err(error);
-        }
-
-        if let Some((width, height)) = terminal.poll_size()? {
+        if resize_signal
+            .as_ref()
+            .is_some_and(signals::ResizeSignal::take)
+        {
+            publish_resize(&mut terminal, &mut renderer, &mut stdout)?;
+        } else if let Some((width, height)) = terminal.poll_size()? {
             renderer.resize(width, height);
             protocol::write_packet(&mut stdout, &protocol::encode_resize(width, height))?;
         }
 
-        if poll_result == 0 {
+        if !ready.any() {
             for event in input.flush_escape() {
                 write_input_event(event, &mut stdout)?;
             }
             continue;
         }
 
-        if pollfds[0].revents & libc::POLLIN != 0 {
+        if ready.stdin {
             match read_packet(&mut stdin)? {
                 Some(packet) => handle_packet(&packet, &mut renderer, &mut terminal, &mut stdout)?,
                 None => break,
             }
         }
 
-        if pollfds[1].revents & libc::POLLIN != 0 {
+        if ready.tty {
             let read = terminal.read_input(&mut tty_read_buf)?;
             if read == 0 {
                 break;
@@ -85,13 +91,87 @@ fn run() -> io::Result<()> {
             }
         }
 
-        let hup_mask = libc::POLLHUP | libc::POLLERR | libc::POLLNVAL;
-        if pollfds[0].revents & hup_mask != 0 || pollfds[1].revents & hup_mask != 0 {
+        if ready.disconnected {
             break;
         }
     }
 
     terminal.finish()
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct InputReady {
+    stdin: bool,
+    tty: bool,
+    disconnected: bool,
+}
+
+impl InputReady {
+    fn any(self) -> bool {
+        self.stdin || self.tty || self.disconnected
+    }
+}
+
+struct InputPoll {
+    poll: Poll,
+    events: Events,
+}
+
+impl InputPoll {
+    fn new(stdin_fd: RawFd, tty_fd: RawFd) -> io::Result<Self> {
+        let poll = Poll::new()?;
+        let mut stdin_source = SourceFd(&stdin_fd);
+        let mut tty_source = SourceFd(&tty_fd);
+
+        poll.registry()
+            .register(&mut stdin_source, STDIN_TOKEN, Interest::READABLE)?;
+        poll.registry()
+            .register(&mut tty_source, TTY_TOKEN, Interest::READABLE)?;
+
+        Ok(Self {
+            poll,
+            events: Events::with_capacity(16),
+        })
+    }
+
+    fn poll(&mut self, timeout: Duration) -> io::Result<InputReady> {
+        loop {
+            match self.poll.poll(&mut self.events, Some(timeout)) {
+                Ok(()) => break,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(error) => return Err(error),
+            }
+        }
+
+        let mut ready = InputReady::default();
+        for event in self.events.iter() {
+            match event.token() {
+                STDIN_TOKEN => {
+                    ready.stdin |= event.is_readable();
+                    ready.disconnected |= event.is_read_closed() || event.is_error();
+                }
+                TTY_TOKEN => {
+                    ready.tty |= event.is_readable();
+                    ready.disconnected |= event.is_read_closed() || event.is_error();
+                }
+                _ => {}
+            }
+        }
+        Ok(ready)
+    }
+}
+
+fn publish_resize(
+    terminal: &mut terminal::Terminal,
+    renderer: &mut renderer::Renderer,
+    output: &mut impl Write,
+) -> io::Result<()> {
+    if let Some((width, height)) = terminal.poll_size()? {
+        let _timer = animation::RESIZE_SETTLE.timer();
+        renderer.resize(width, height);
+        protocol::write_packet(output, &protocol::encode_resize(width, height))?;
+    }
+    Ok(())
 }
 
 fn handle_packet(

--- a/rust/tui/src/protocol.rs
+++ b/rust/tui/src/protocol.rs
@@ -219,7 +219,7 @@ pub fn write_packet(writer: &mut impl Write, payload: &[u8]) -> io::Result<()> {
     writer.flush()
 }
 
-pub fn encode_ready_with_caps(width: u16, height: u16) -> [u8; 14] {
+pub fn encode_ready_with_caps(width: u16, height: u16, image_support: u8) -> [u8; 14] {
     [
         opcodes::OP_READY,
         (width >> 8) as u8,
@@ -231,7 +231,7 @@ pub fn encode_ready_with_caps(width: u16, height: u16) -> [u8; 14] {
         0,
         2,
         0,
-        0,
+        image_support,
         0,
         0,
         1,
@@ -462,7 +462,7 @@ mod tests {
     #[test]
     fn encodes_extended_ready() {
         assert_eq!(
-            encode_ready_with_caps(80, 24),
+            encode_ready_with_caps(80, 24, 0),
             [opcodes::OP_READY, 0, 80, 0, 24, 1, 7, 0, 2, 0, 0, 0, 0, 1]
         );
     }

--- a/rust/tui/src/protocol.rs
+++ b/rust/tui/src/protocol.rs
@@ -188,6 +188,23 @@ pub fn decode_command(bytes: &[u8]) -> Result<Command, DecodeError> {
             let text = read_string(bytes, 7, len)?;
             Ok(Command::MeasureText { request_id, text })
         }
+        opcodes::OP_SET_LANGUAGE => skip_len_at(bytes, 5),
+        opcodes::OP_PARSE_BUFFER => skip_len32_at(bytes, 9),
+        opcodes::OP_SET_HIGHLIGHT_QUERY
+        | opcodes::OP_SET_INJECTION_QUERY
+        | opcodes::OP_SET_FOLD_QUERY
+        | opcodes::OP_SET_INDENT_QUERY
+        | opcodes::OP_SET_TEXTOBJECT_QUERY
+        | opcodes::OP_SET_TAGS_QUERY => skip_len32_at(bytes, 5),
+        opcodes::OP_LOAD_GRAMMAR => skip_load_grammar(bytes),
+        opcodes::OP_QUERY_LANGUAGE_AT | opcodes::OP_REQUEST_INDENT => {
+            fixed_noop(bytes, 13, "fixed parser request")
+        }
+        opcodes::OP_REQUEST_TEXTOBJECT => skip_len_at(bytes, 17),
+        opcodes::OP_CLOSE_BUFFER => fixed_noop(bytes, 5, "close_buffer"),
+        opcodes::OP_REQUEST_MATCH_ITEM => fixed_noop(bytes, 17, "request_match_item"),
+        opcodes::OP_REQUEST_STRUCTURAL_NAV => fixed_noop(bytes, 18, "request_structural_nav"),
+        opcodes::OP_EDIT_BUFFER => skip_edit_buffer(bytes),
         opcodes::OP_SET_FONT => skip_len_at(bytes, 5),
         opcodes::OP_SET_FONT_FALLBACK => skip_font_fallback(bytes),
         opcodes::OP_REGISTER_FONT => skip_len_at(bytes, 2),
@@ -307,6 +324,22 @@ fn skip_len_at(bytes: &[u8], len_offset: usize) -> Result<Command, DecodeError> 
     Ok(Command::Noop(len_offset + 2 + len))
 }
 
+fn skip_len32_at(bytes: &[u8], len_offset: usize) -> Result<Command, DecodeError> {
+    require_len(bytes, len_offset + 4, "length32-prefixed command header")?;
+    let len = read_u32(bytes, len_offset) as usize;
+    require_len(
+        bytes,
+        len_offset + 4 + len,
+        "length32-prefixed command body",
+    )?;
+    Ok(Command::Noop(len_offset + 4 + len))
+}
+
+fn fixed_noop(bytes: &[u8], size: usize, name: &'static str) -> Result<Command, DecodeError> {
+    require_len(bytes, size, name)?;
+    Ok(Command::Noop(size))
+}
+
 fn skip_font_fallback(bytes: &[u8]) -> Result<Command, DecodeError> {
     require_len(bytes, 2, "font fallback header")?;
     let count = bytes[1] as usize;
@@ -318,6 +351,33 @@ fn skip_font_fallback(bytes: &[u8]) -> Result<Command, DecodeError> {
         offset += 2;
         require_len(bytes, offset + len, "font fallback entry body")?;
         offset += len;
+    }
+
+    Ok(Command::Noop(offset))
+}
+
+fn skip_load_grammar(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 3, "load_grammar name header")?;
+    let name_len = read_u16(bytes, 1) as usize;
+    let mut offset = 3 + name_len;
+    require_len(bytes, offset + 2, "load_grammar path header")?;
+    let path_len = read_u16(bytes, offset) as usize;
+    offset += 2;
+    require_len(bytes, offset + path_len, "load_grammar path body")?;
+    Ok(Command::Noop(offset + path_len))
+}
+
+fn skip_edit_buffer(bytes: &[u8]) -> Result<Command, DecodeError> {
+    require_len(bytes, 11, "edit_buffer header")?;
+    let edit_count = read_u16(bytes, 9) as usize;
+    let mut offset = 11;
+
+    for _ in 0..edit_count {
+        require_len(bytes, offset + 40, "edit_buffer edit header")?;
+        let text_len = read_u32(bytes, offset + 36) as usize;
+        offset += 40;
+        require_len(bytes, offset + text_len, "edit_buffer edit text")?;
+        offset += text_len;
     }
 
     Ok(Command::Noop(offset))
@@ -489,6 +549,44 @@ mod tests {
         assert_eq!(
             encode_paste_event(b"hello"),
             vec![opcodes::OP_PASTE_EVENT, 0, 5, b'h', b'e', b'l', b'l', b'o']
+        );
+    }
+
+    #[test]
+    fn skips_parser_commands_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_SET_LANGUAGE, 0, 0, 0, 7, 0, 6],
+            b"elixir".to_vec(),
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+        let command = decode_command(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(command, Command::Noop(_)));
+        assert_eq!(
+            decode_command(&packet[command.size()..]).unwrap(),
+            Command::BatchEnd
+        );
+    }
+
+    #[test]
+    fn skips_edit_buffer_without_consuming_following_commands() {
+        let packet = [
+            vec![opcodes::OP_EDIT_BUFFER, 0, 0, 0, 7, 0, 0, 0, 9, 0, 1],
+            vec![0; 36],
+            vec![0, 0, 0, 3],
+            b"abc".to_vec(),
+            vec![opcodes::OP_BATCH_END],
+        ]
+        .concat();
+        let command = decode_command(&packet).unwrap();
+
+        assert_eq!(command.size(), packet.len() - 1);
+        assert!(matches!(command, Command::Noop(_)));
+        assert_eq!(
+            decode_command(&packet[command.size()..]).unwrap(),
+            Command::BatchEnd
         );
     }
 }

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -1656,22 +1656,7 @@ impl Renderer {
         let mut buffer = RatatuiBuffer::empty(area);
         widget.render(area, &mut buffer);
 
-        for y in 0..height {
-            for x in 0..width {
-                let target_row = row.saturating_add(y);
-                let target_col = col.saturating_add(x);
-                let Some(target_index) = self.index(target_col, target_row) else {
-                    continue;
-                };
-                let Some(source) = buffer.cell((x, y)) else {
-                    continue;
-                };
-                self.cells[target_index] = Cell {
-                    text: source.symbol().to_owned(),
-                    style: cell_style_from_ratatui(source),
-                };
-            }
-        }
+        self.copy_ratatui_buffer(row, col, width, height, &buffer);
     }
 
     fn render_ratatui_stateful_widget<W: StatefulWidget>(
@@ -1691,7 +1676,19 @@ impl Renderer {
         let mut buffer = RatatuiBuffer::empty(area);
         widget.render(area, &mut buffer, state);
 
+        self.copy_ratatui_buffer(row, col, width, height, &buffer);
+    }
+
+    fn copy_ratatui_buffer(
+        &mut self,
+        row: u16,
+        col: u16,
+        width: u16,
+        height: u16,
+        buffer: &RatatuiBuffer,
+    ) {
         for y in 0..height {
+            let mut pending_continuations = 0_u16;
             for x in 0..width {
                 let target_row = row.saturating_add(y);
                 let target_col = col.saturating_add(x);
@@ -1701,8 +1698,21 @@ impl Renderer {
                 let Some(source) = buffer.cell((x, y)) else {
                     continue;
                 };
+
+                if pending_continuations > 0 && source.symbol() == " " {
+                    self.cells[target_index] = Cell {
+                        text: String::new(),
+                        style: cell_style_from_ratatui(source),
+                    };
+                    pending_continuations = pending_continuations.saturating_sub(1);
+                    continue;
+                }
+
+                let symbol = source.symbol().to_owned();
+                let symbol_width = text_width(&symbol);
+                pending_continuations = symbol_width.saturating_sub(1);
                 self.cells[target_index] = Cell {
-                    text: source.symbol().to_owned(),
+                    text: symbol,
                     style: cell_style_from_ratatui(source),
                 };
             }
@@ -3319,5 +3329,17 @@ mod tests {
 
         assert_eq!(renderer.previous[renderer.index(0, 0).unwrap()].text, "界");
         assert_eq!(renderer.previous[renderer.index(1, 0).unwrap()].text, "");
+    }
+
+    #[test]
+    fn ratatui_widget_copy_preserves_wide_grapheme_continuation_cells() {
+        let mut renderer = Renderer::new(4, 1);
+        let paragraph = Paragraph::new("界x");
+
+        renderer.render_ratatui_widget(0, 0, 4, 1, paragraph);
+
+        assert_eq!(renderer.cells[renderer.index(0, 0).unwrap()].text, "界");
+        assert_eq!(renderer.cells[renderer.index(1, 0).unwrap()].text, "");
+        assert_eq!(renderer.cells[renderer.index(2, 0).unwrap()].text, "x");
     }
 }

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -7,6 +7,7 @@ use crate::terminal::{CellStyle, Terminal};
 use ratatui::buffer::Buffer as RatatuiBuffer;
 use ratatui::layout::Rect as RatatuiRect;
 use ratatui::style::{Color as RatatuiColor, Modifier, Style as RatatuiStyle};
+use ratatui::text::{Line as RatatuiLine, Span as RatatuiSpan};
 use ratatui::widgets::{
     Block, Borders, List, ListItem, ListState, Paragraph, StatefulWidget, Widget, Wrap,
 };
@@ -379,22 +380,24 @@ impl Renderer {
             return;
         }
 
-        self.clear_row(0);
-        let mut col = 0;
+        let spans = tab_bar
+            .tabs
+            .iter()
+            .map(|tab| {
+                let label = if tab.dirty {
+                    format!(" {} * ", tab.label)
+                } else {
+                    format!(" {} ", tab.label)
+                };
+                RatatuiSpan::styled(
+                    label,
+                    ratatui_style_from_cell(self.theme.tab_style(tab.active, tab.tint)),
+                )
+            })
+            .collect::<Vec<_>>();
 
-        for tab in tab_bar.tabs {
-            if col >= self.width {
-                break;
-            }
-
-            let label = if tab.dirty {
-                format!(" {} * ", tab.label)
-            } else {
-                format!(" {} ", tab.label)
-            };
-            self.write_run(0, col, &label, self.theme.tab_style(tab.active, tab.tint));
-            col = col.saturating_add(text_width(&label));
-        }
+        let paragraph = Paragraph::new(RatatuiLine::from(spans));
+        self.render_ratatui_widget(0, 0, self.width, 1, paragraph);
     }
 
     fn draw_file_tree(&mut self, tree: semantic::FileTree) {
@@ -593,34 +596,35 @@ impl Renderer {
             .saturating_add(1)
             .saturating_sub(candidate_count)
             .min(minibuffer.candidates.len().saturating_sub(candidate_count));
-        for (index, candidate) in minibuffer
+        let items = minibuffer
             .candidates
             .iter()
             .skip(start_index)
             .take(candidate_count)
             .enumerate()
-        {
-            let candidate_index = start_index + index;
-            let selected = candidate_index == selected_index;
-            let annotation = if candidate.annotation.is_empty() {
-                String::new()
-            } else {
-                format!("  {}", candidate.annotation)
-            };
-            let description = if candidate.description.is_empty() {
-                String::new()
-            } else {
-                format!(" - {}", candidate.description)
-            };
-            let marker = if selected { ">" } else { " " };
-            let text = format!("{marker} {}{}{}", candidate.label, annotation, description);
-            self.write_run(
-                first_row + index as u16,
-                0,
-                &pad_to_width(&text, self.width),
-                self.theme.minibuffer_style(selected),
-            );
-        }
+            .map(|(index, candidate)| {
+                let candidate_index = start_index + index;
+                let selected = candidate_index == selected_index;
+                let annotation = if candidate.annotation.is_empty() {
+                    String::new()
+                } else {
+                    format!("  {}", candidate.annotation)
+                };
+                let description = if candidate.description.is_empty() {
+                    String::new()
+                } else {
+                    format!(" - {}", candidate.description)
+                };
+                let marker = if selected { ">" } else { " " };
+                let text = format!("{marker} {}{}{}", candidate.label, annotation, description);
+                ListItem::new(pad_to_width(&text, self.width)).style(ratatui_style_from_cell(
+                    self.theme.minibuffer_style(selected),
+                ))
+            })
+            .collect::<Vec<_>>();
+        let list =
+            List::new(items).style(ratatui_style_from_cell(self.theme.minibuffer_style(false)));
+        self.render_ratatui_widget(first_row, 0, self.width, candidate_count as u16, list);
     }
 
     fn redraw_retained_chrome(&mut self) {
@@ -1257,12 +1261,9 @@ impl Renderer {
         }
 
         if picker.load_status == 1 {
-            self.write_run(
-                row,
-                col,
-                &pad_to_width(" Loading...", width),
-                self.theme.picker_style(false),
-            );
+            let paragraph = Paragraph::new(" Loading...")
+                .style(ratatui_style_from_cell(self.theme.picker_style(false)));
+            self.render_ratatui_widget(row, col, width, height, paragraph);
             return;
         }
         if picker.load_status == 2 {
@@ -1271,62 +1272,55 @@ impl Renderer {
             } else {
                 format!(" {}", picker.load_error)
             };
-            self.write_run(
-                row,
-                col,
-                &pad_to_width(&message, width),
-                self.theme.picker_style(false),
-            );
+            let paragraph = Paragraph::new(message)
+                .style(ratatui_style_from_cell(self.theme.picker_style(false)));
+            self.render_ratatui_widget(row, col, width, height, paragraph);
             return;
         }
 
         if picker.items.is_empty() {
-            self.write_run(
-                row,
-                col,
-                &pad_to_width(" No matches", width),
-                self.theme.picker_style(false),
-            );
+            let paragraph = Paragraph::new(" No matches")
+                .style(ratatui_style_from_cell(self.theme.picker_style(false)));
+            self.render_ratatui_widget(row, col, width, height, paragraph);
             return;
         }
 
         let visible_rows = height as usize;
-        let selected = picker.selected_index as usize;
-        let start = selected.saturating_sub(visible_rows.saturating_sub(1));
-        for (screen_index, item) in picker
+        let selected_index = picker.selected_index as usize;
+        let start = selected_index.saturating_sub(visible_rows.saturating_sub(1));
+        let items = picker
             .items
             .iter()
             .skip(start)
             .take(visible_rows)
             .enumerate()
-        {
-            let item_index = start + screen_index;
-            let selected = item_index == selected;
-            let marker = if item.marked {
-                "*"
-            } else if selected {
-                ">"
-            } else {
-                " "
-            };
-            let annotation = if item.annotation.is_empty() {
-                String::new()
-            } else {
-                format!(" {}", item.annotation)
-            };
-            let description = if item.description.is_empty() {
-                String::new()
-            } else {
-                format!("  {}", item.description)
-            };
-            let line = format!("{marker} {}{}{}", item.label, annotation, description);
-            self.write_run(
-                row + screen_index as u16,
-                col,
-                &pad_to_width(&line, width),
-                self.theme.picker_style(selected),
-            );
-        }
+            .map(|(screen_index, item)| {
+                let item_index = start + screen_index;
+                let selected = item_index == selected_index;
+                let marker = if item.marked {
+                    "*"
+                } else if selected {
+                    ">"
+                } else {
+                    " "
+                };
+                let annotation = if item.annotation.is_empty() {
+                    String::new()
+                } else {
+                    format!(" {}", item.annotation)
+                };
+                let description = if item.description.is_empty() {
+                    String::new()
+                } else {
+                    format!("  {}", item.description)
+                };
+                let line = format!("{marker} {}{}{}", item.label, annotation, description);
+                ListItem::new(pad_to_width(&line, width))
+                    .style(ratatui_style_from_cell(self.theme.picker_style(selected)))
+            })
+            .collect::<Vec<_>>();
+        let list = List::new(items).style(ratatui_style_from_cell(self.theme.picker_style(false)));
+        self.render_ratatui_widget(row, col, width, height, list);
     }
 
     fn render_picker_preview(
@@ -1337,32 +1331,36 @@ impl Renderer {
         height: u16,
         preview: &semantic::PickerPreview,
     ) {
-        self.fill_rect(
-            row,
-            col,
-            width,
-            height,
-            self.theme.picker_preview_style(false, 0),
-        );
-
-        for (line_index, segments) in preview.lines.iter().take(height as usize).enumerate() {
-            let mut current_col = col.saturating_add(1);
-            for segment in segments {
-                if current_col >= col.saturating_add(width) {
-                    break;
+        let lines = preview
+            .lines
+            .iter()
+            .take(height as usize)
+            .map(|segments| {
+                let mut spans = Vec::new();
+                let mut used_width = 1_u16;
+                spans.push(RatatuiSpan::raw(" "));
+                for segment in segments {
+                    if used_width >= width {
+                        break;
+                    }
+                    let remaining = width.saturating_sub(used_width);
+                    let text = slice_chars(&segment.text, 0, remaining);
+                    let segment_width = text_width(&text);
+                    spans.push(RatatuiSpan::styled(
+                        text,
+                        ratatui_style_from_cell(
+                            self.theme.picker_preview_style(segment.bold, segment.fg),
+                        ),
+                    ));
+                    used_width = used_width.saturating_add(segment_width);
                 }
-                let remaining = col.saturating_add(width).saturating_sub(current_col);
-                let text = slice_chars(&segment.text, 0, remaining);
-                let segment_width = text_width(&text);
-                self.write_run(
-                    row + line_index as u16,
-                    current_col,
-                    &text,
-                    self.theme.picker_preview_style(segment.bold, segment.fg),
-                );
-                current_col = current_col.saturating_add(segment_width);
-            }
-        }
+                RatatuiLine::from(spans)
+            })
+            .collect::<Vec<_>>();
+        let paragraph = Paragraph::new(lines).style(ratatui_style_from_cell(
+            self.theme.picker_preview_style(false, 0),
+        ));
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn render_file_tree(&mut self) {
@@ -1374,89 +1372,103 @@ impl Renderer {
         }
 
         let width = tree.width.min(self.width);
-        for row in 1..self.height - 1 {
-            self.write_run(
-                row,
-                0,
-                &" ".repeat(width as usize),
-                self.theme.file_tree_style(false, tree.focused),
-            );
-        }
+        let row = 1;
+        let height = self.height.saturating_sub(2);
 
         match tree.status {
-            1 => self.write_run(
-                1,
-                0,
-                " Loading...",
-                self.theme.file_tree_style(false, tree.focused),
-            ),
-            2 => self.write_run(
-                1,
-                0,
-                " Empty",
-                self.theme.file_tree_style(false, tree.focused),
-            ),
+            1 => {
+                let paragraph = Paragraph::new(" Loading...").style(ratatui_style_from_cell(
+                    self.theme.file_tree_style(false, tree.focused),
+                ));
+                self.render_ratatui_widget(row, 0, width, height, paragraph);
+            }
+            2 => {
+                let paragraph = Paragraph::new(" Empty").style(ratatui_style_from_cell(
+                    self.theme.file_tree_style(false, tree.focused),
+                ));
+                self.render_ratatui_widget(row, 0, width, height, paragraph);
+            }
             4 => {
                 let message = if tree.error.is_empty() {
                     " File tree error".to_owned()
                 } else {
                     format!(" {}", tree.error)
                 };
-                self.write_run(
-                    1,
-                    0,
-                    &message,
+                let paragraph = Paragraph::new(message).style(ratatui_style_from_cell(
                     self.theme.file_tree_style(false, tree.focused),
-                );
+                ));
+                self.render_ratatui_widget(row, 0, width, height, paragraph);
             }
             _ => {
-                let visible_rows = self.height.saturating_sub(2) as usize;
-                for (index, row) in tree.rows.iter().take(visible_rows).enumerate() {
-                    self.render_file_tree_row(
-                        index as u16 + 1,
-                        width,
-                        tree.focused,
-                        row,
-                        &tree.selected_id,
-                    );
-                }
+                self.render_file_tree_rows(
+                    row,
+                    width,
+                    height,
+                    tree.focused,
+                    &tree.rows,
+                    &tree.selected_id,
+                );
             }
         }
     }
 
-    fn render_file_tree_row(
+    fn render_file_tree_rows(
         &mut self,
-        screen_row: u16,
+        row: u16,
         width: u16,
+        height: u16,
         focused: bool,
-        row: &semantic::FileTreeRow,
+        rows: &[semantic::FileTreeRow],
         selected_id: &str,
     ) {
-        let selected = row.id == selected_id;
-        let indent = "  ".repeat(row.depth as usize);
-        let marker = if row.flags & 0x01 != 0 {
-            if row.flags & 0x02 != 0 { "v " } else { "> " }
-        } else {
-            "  "
-        };
-        let dirty = if row.flags & 0x20 != 0 { " *" } else { "" };
-        let git = git_marker(row.git_status);
-        let diag = diagnostic_marker(row.diagnostics);
-        let label = if row.editing_text.is_empty() {
-            format!(
-                " {indent}{marker}{} {}{dirty}{git}{diag}",
-                row.icon, row.name
-            )
-        } else {
-            format!(" {indent}{marker}{} {}", row.icon, row.editing_text)
-        };
+        if width == 0 || height == 0 {
+            return;
+        }
 
-        self.write_run(
-            screen_row,
-            0,
-            &pad_to_width(&label, width),
-            self.theme.file_tree_style(selected, focused),
-        );
+        let visible_rows = height as usize;
+        let selected_index = rows
+            .iter()
+            .position(|row| row.id == selected_id)
+            .unwrap_or(0);
+        let start = selected_index.saturating_sub(visible_rows.saturating_sub(1));
+        let items = rows
+            .iter()
+            .skip(start)
+            .take(visible_rows)
+            .map(|row| {
+                let indent = "  ".repeat(row.depth as usize);
+                let marker = if row.flags & 0x01 != 0 {
+                    if row.flags & 0x02 != 0 { "v " } else { "> " }
+                } else {
+                    "  "
+                };
+                let dirty = if row.flags & 0x20 != 0 { " *" } else { "" };
+                let git = git_marker(row.git_status);
+                let diag = diagnostic_marker(row.diagnostics);
+                let label = if row.editing_text.is_empty() {
+                    format!(
+                        " {indent}{marker}{} {}{dirty}{git}{diag}",
+                        row.icon, row.name
+                    )
+                } else {
+                    format!(" {indent}{marker}{} {}", row.icon, row.editing_text)
+                };
+
+                ListItem::new(pad_to_width(&label, width)).style(ratatui_style_from_cell(
+                    self.theme.file_tree_style(false, focused),
+                ))
+            })
+            .collect::<Vec<_>>();
+        let mut state =
+            ListState::default().with_selected(Some(selected_index.saturating_sub(start)));
+        let list = List::new(items)
+            .style(ratatui_style_from_cell(
+                self.theme.file_tree_style(false, focused),
+            ))
+            .highlight_style(ratatui_style_from_cell(
+                self.theme.file_tree_style(true, focused),
+            ));
+        self.render_ratatui_stateful_widget(row, 0, width, height, list, &mut state);
     }
 
     fn write_run(&mut self, row: u16, col: u16, text: &str, mut style: CellStyle) {

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -10,6 +10,8 @@ use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
 use std::collections::HashMap;
 use std::io::{self, Write};
 use theme::{SLOT_EDITOR_BG, ThemePalette};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 #[cfg(test)]
 use theme::{
@@ -1463,19 +1465,27 @@ impl Renderer {
             style.bg = self.default_bg;
         }
 
-        for ch in text.chars() {
+        for grapheme in text.graphemes(true) {
             if col >= max_col {
+                break;
+            }
+
+            let width = grapheme_width(grapheme);
+            if width == 0 {
+                continue;
+            }
+            if col.saturating_add(width) > max_col {
                 break;
             }
 
             if let Some(index) = self.index(col, row) {
                 self.cells[index] = Cell {
-                    text: ch.to_string(),
+                    text: grapheme.to_owned(),
                     style,
                 };
             }
 
-            col = col.saturating_add(char_width(ch));
+            col = col.saturating_add(width);
         }
     }
 
@@ -1682,14 +1692,11 @@ impl Renderer {
 }
 
 fn text_width(text: &str) -> u16 {
-    text.chars()
-        .map(char_width)
-        .fold(0_u16, u16::saturating_add)
+    UnicodeWidthStr::width(text).min(u16::MAX as usize) as u16
 }
 
-fn char_width(ch: char) -> u16 {
-    let _ = ch;
-    1
+fn grapheme_width(grapheme: &str) -> u16 {
+    UnicodeWidthStr::width(grapheme).min(u16::MAX as usize) as u16
 }
 
 fn picker_geometry(width: u16, height: u16) -> (u16, u16, u16, u16) {
@@ -2050,9 +2057,32 @@ fn pad_to_width(text: &str, width: u16) -> String {
 }
 
 fn slice_chars(text: &str, start_col: u16, end_col: u16) -> String {
-    let start = start_col as usize;
-    let len = end_col.saturating_sub(start_col) as usize;
-    text.chars().skip(start).take(len).collect()
+    let mut out = String::new();
+    let mut col = 0_u16;
+
+    for grapheme in text.graphemes(true) {
+        let width = grapheme_width(grapheme);
+        if width == 0 {
+            continue;
+        }
+
+        let next_col = col.saturating_add(width);
+        if next_col <= start_col {
+            col = next_col;
+            continue;
+        }
+        if col >= end_col {
+            break;
+        }
+        if col >= start_col && next_col <= end_col {
+            out.push_str(grapheme);
+        } else {
+            break;
+        }
+        col = next_col;
+    }
+
+    out
 }
 
 #[cfg(test)]
@@ -3139,5 +3169,35 @@ mod tests {
             renderer.cells[renderer.index(0, 9).unwrap()].style.bg,
             0x040506
         );
+    }
+
+    #[test]
+    fn text_helpers_use_display_width_and_grapheme_boundaries() {
+        assert_eq!(text_width("abc"), 3);
+        assert_eq!(text_width("界x"), 3);
+        assert_eq!(text_width("e\u{301}x"), 2);
+
+        assert_eq!(pad_to_width("界x", 2), "界");
+        assert_eq!(pad_to_width("e\u{301}x", 1), "e\u{301}");
+        assert_eq!(slice_chars("界x", 0, 2), "界");
+        assert_eq!(slice_chars("界x", 0, 3), "界x");
+        assert_eq!(slice_chars("e\u{301}x", 0, 1), "e\u{301}");
+    }
+
+    #[test]
+    fn write_run_advances_by_grapheme_display_width() {
+        let mut renderer = Renderer::new(8, 2);
+
+        renderer.write_run(0, 0, "界x", CellStyle::default());
+        assert_eq!(renderer.cells[renderer.index(0, 0).unwrap()].text, "界");
+        assert_eq!(renderer.cells[renderer.index(1, 0).unwrap()].text, " ");
+        assert_eq!(renderer.cells[renderer.index(2, 0).unwrap()].text, "x");
+
+        renderer.write_run(1, 0, "e\u{301}x", CellStyle::default());
+        assert_eq!(
+            renderer.cells[renderer.index(0, 1).unwrap()].text,
+            "e\u{301}"
+        );
+        assert_eq!(renderer.cells[renderer.index(1, 1).unwrap()].text, "x");
     }
 }

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -1,12 +1,15 @@
 mod theme;
 
+use crate::animation;
 use crate::protocol::{self, Command, DrawStyledText, DrawText, Region};
 use crate::semantic;
 use crate::terminal::{CellStyle, Terminal};
 use ratatui::buffer::Buffer as RatatuiBuffer;
 use ratatui::layout::Rect as RatatuiRect;
 use ratatui::style::{Color as RatatuiColor, Modifier, Style as RatatuiStyle};
-use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
+use ratatui::widgets::{
+    Block, Borders, List, ListItem, ListState, Paragraph, StatefulWidget, Widget, Wrap,
+};
 use std::collections::HashMap;
 use std::io::{self, Write};
 use theme::{SLOT_EDITOR_BG, ThemePalette};
@@ -797,41 +800,41 @@ impl Renderer {
             self.completion_snapshot = Some(self.capture_rect(row, col, width, height));
         }
 
-        self.fill_rect(row, col, width, height, self.theme.completion_style(false));
-
         let selected_index = completion.selected_index as usize;
         let visible_rows = height as usize;
         let start = selected_index
             .saturating_add(1)
             .saturating_sub(visible_rows)
             .min(completion.items.len().saturating_sub(visible_rows));
-        for (screen_index, item) in completion
+        let items = completion
             .items
             .iter()
             .skip(start)
             .take(visible_rows)
-            .enumerate()
-        {
-            let item_index = start + screen_index;
-            let selected = item_index == selected_index;
-            let detail = if item.detail.is_empty() {
-                String::new()
-            } else {
-                format!("  {}", item.detail)
-            };
-            let line = format!(
-                "{} {}{}",
-                completion_kind_marker(item.kind),
-                item.label,
-                detail
-            );
-            self.write_run(
-                row + screen_index as u16,
-                col,
-                &pad_to_width(&line, width),
-                self.theme.completion_style(selected),
-            );
-        }
+            .map(|item| {
+                let detail = if item.detail.is_empty() {
+                    String::new()
+                } else {
+                    format!("  {}", item.detail)
+                };
+                let line = format!(
+                    "{} {}{}",
+                    completion_kind_marker(item.kind),
+                    item.label,
+                    detail
+                );
+                ListItem::new(pad_to_width(&line, width))
+                    .style(ratatui_style_from_cell(self.theme.completion_style(false)))
+            })
+            .collect::<Vec<_>>();
+        let mut state =
+            ListState::default().with_selected(Some(selected_index.saturating_sub(start)));
+        let list = List::new(items)
+            .style(ratatui_style_from_cell(self.theme.completion_style(false)))
+            .highlight_style(ratatui_style_from_cell(self.theme.completion_style(true)));
+
+        let _timer = animation::POPUP_REVEAL.timer();
+        self.render_ratatui_stateful_widget(row, col, width, height, list, &mut state);
     }
 
     fn restore_completion_snapshot(&mut self) {
@@ -862,7 +865,6 @@ impl Renderer {
             self.which_key_snapshot = Some(self.capture_rect(row, col, width, height));
         }
 
-        self.fill_rect(row, col, width, height, self.theme.which_key_style(false));
         let page = if which_key.page_count > 1 {
             format!(
                 "  {}/{}",
@@ -880,25 +882,27 @@ impl Renderer {
             self.theme.which_key_header_style(),
         );
 
-        for (index, binding) in which_key
+        let items = which_key
             .bindings
             .iter()
             .take(height.saturating_sub(1) as usize)
-            .enumerate()
-        {
-            let icon = if binding.icon.is_empty() {
-                if binding.kind == 1 { ">" } else { " " }
-            } else {
-                binding.icon.as_str()
-            };
-            let text = format!(" {icon} {:<8} {}", binding.key, binding.description);
-            self.write_run(
-                row + 1 + index as u16,
-                col,
-                &pad_to_width(&text, width),
-                self.theme.which_key_style(binding.kind == 1),
-            );
-        }
+            .map(|binding| {
+                let icon = if binding.icon.is_empty() {
+                    if binding.kind == 1 { ">" } else { " " }
+                } else {
+                    binding.icon.as_str()
+                };
+                let text = format!(" {icon} {:<8} {}", binding.key, binding.description);
+                ListItem::new(pad_to_width(&text, width)).style(ratatui_style_from_cell(
+                    self.theme.which_key_style(binding.kind == 1),
+                ))
+            })
+            .collect::<Vec<_>>();
+        let list =
+            List::new(items).style(ratatui_style_from_cell(self.theme.which_key_style(false)));
+
+        let _timer = animation::POPUP_REVEAL.timer();
+        self.render_ratatui_widget(row + 1, col, width, height.saturating_sub(1), list);
     }
 
     fn restore_which_key_snapshot(&mut self) {
@@ -1596,6 +1600,41 @@ impl Renderer {
         let area = RatatuiRect::new(0, 0, width, height);
         let mut buffer = RatatuiBuffer::empty(area);
         widget.render(area, &mut buffer);
+
+        for y in 0..height {
+            for x in 0..width {
+                let target_row = row.saturating_add(y);
+                let target_col = col.saturating_add(x);
+                let Some(target_index) = self.index(target_col, target_row) else {
+                    continue;
+                };
+                let Some(source) = buffer.cell((x, y)) else {
+                    continue;
+                };
+                self.cells[target_index] = Cell {
+                    text: source.symbol().to_owned(),
+                    style: cell_style_from_ratatui(source),
+                };
+            }
+        }
+    }
+
+    fn render_ratatui_stateful_widget<W: StatefulWidget>(
+        &mut self,
+        row: u16,
+        col: u16,
+        width: u16,
+        height: u16,
+        widget: W,
+        state: &mut W::State,
+    ) {
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        let area = RatatuiRect::new(0, 0, width, height);
+        let mut buffer = RatatuiBuffer::empty(area);
+        widget.render(area, &mut buffer, state);
 
         for y in 0..height {
             for x in 0..width {

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -366,13 +366,32 @@ impl Renderer {
         };
 
         let style = self.theme.status_bar_style();
-
-        self.write_run(row, 0, &pad_to_width(&left, self.width), style);
-
+        let left_width = text_width(&left).min(self.width);
         let right_width = text_width(&right);
+        let spacer_width = if right_width < self.width {
+            self.width
+                .saturating_sub(left_width)
+                .saturating_sub(right_width)
+        } else {
+            self.width.saturating_sub(left_width)
+        };
+        let mut spans = vec![
+            RatatuiSpan::styled(
+                slice_chars(&left, 0, self.width),
+                ratatui_style_from_cell(style),
+            ),
+            RatatuiSpan::styled(
+                " ".repeat(spacer_width as usize),
+                ratatui_style_from_cell(style),
+            ),
+        ];
         if right_width < self.width {
-            self.write_run(row, self.width - right_width, &right, style);
+            spans.push(RatatuiSpan::styled(right, ratatui_style_from_cell(style)));
         }
+
+        let paragraph =
+            Paragraph::new(RatatuiLine::from(spans)).style(ratatui_style_from_cell(style));
+        self.render_ratatui_widget(row, 0, self.width, 1, paragraph);
     }
 
     fn draw_tab_bar(&mut self, tab_bar: semantic::TabBar) {
@@ -460,19 +479,17 @@ impl Renderer {
         }
 
         if breadcrumb.segments.is_empty() {
-            self.write_run(row, col, &" ".repeat(width as usize), CellStyle::default());
+            let paragraph = Paragraph::new(" ".repeat(width as usize));
+            self.render_ratatui_widget(row, col, width, 1, paragraph);
             self.breadcrumb = None;
             return;
         }
 
         self.breadcrumb = Some(breadcrumb.clone());
         let text = format!(" {}", breadcrumb.segments.join(" / "));
-        self.write_run(
-            row,
-            col,
-            &pad_to_width(&text, width),
-            self.theme.breadcrumb_style(),
-        );
+        let paragraph = Paragraph::new(pad_to_width(&text, width))
+            .style(ratatui_style_from_cell(self.theme.breadcrumb_style()));
+        self.render_ratatui_widget(row, col, width, 1, paragraph);
     }
 
     fn draw_completion(&mut self, completion: semantic::Completion) {
@@ -695,38 +712,55 @@ impl Renderer {
         } else {
             format!("{} {}", picker.mode_prefix, picker.title)
         };
-        self.write_run(
-            row,
-            col,
-            &pad_to_width(&title, width),
-            self.theme.picker_header_style(),
-        );
-
         let count = if picker.total_count == 0 {
             String::new()
         } else {
             format!("{} / {}", picker.filtered_count, picker.total_count)
         };
+        let title_width = text_width(&title).min(width);
         let count_width = text_width(&count);
-        if count_width > 0 && count_width < width {
-            self.write_run(
-                row,
-                col + width - count_width - 1,
-                &count,
-                self.theme.picker_header_style(),
-            );
+        let header_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let mut header_spans = vec![RatatuiSpan::styled(
+            slice_chars(&title, 0, width),
+            header_style,
+        )];
+        if count_width > 0 && count_width < width && title_width.saturating_add(count_width) < width
+        {
+            let spacer = width
+                .saturating_sub(title_width)
+                .saturating_sub(count_width)
+                .saturating_sub(1);
+            header_spans.push(RatatuiSpan::styled(
+                " ".repeat(spacer as usize),
+                header_style,
+            ));
+            header_spans.push(RatatuiSpan::styled(count, header_style));
+        } else if title_width < width {
+            header_spans.push(RatatuiSpan::styled(
+                " ".repeat(width.saturating_sub(title_width) as usize),
+                header_style,
+            ));
         }
+        self.render_ratatui_widget(
+            row,
+            col,
+            width,
+            1,
+            Paragraph::new(RatatuiLine::from(header_spans)).style(header_style),
+        );
 
         let query = if picker.query.is_empty() {
             "> ".to_owned()
         } else {
             format!("> {}", picker.query)
         };
-        self.write_run(
+        let query_style = ratatui_style_from_cell(self.theme.picker_query_style());
+        self.render_ratatui_widget(
             row + 1,
             col,
-            &pad_to_width(&query, width),
-            self.theme.picker_query_style(),
+            width,
+            1,
+            Paragraph::new(pad_to_width(&query, width)).style(query_style),
         );
 
         let body_row = row + 2;

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -1489,6 +1489,15 @@ impl Renderer {
                 };
             }
 
+            for continuation_col in col.saturating_add(1)..col.saturating_add(width) {
+                if let Some(index) = self.index(continuation_col, row) {
+                    self.cells[index] = Cell {
+                        text: String::new(),
+                        style,
+                    };
+                }
+            }
+
             col = col.saturating_add(width);
         }
     }
@@ -1703,6 +1712,11 @@ impl Renderer {
                 let Some(index) = self.index(col, row) else {
                     continue;
                 };
+
+                if self.cells[index].text.is_empty() {
+                    self.previous[index] = self.cells[index].clone();
+                    continue;
+                }
 
                 if self.cells[index] != self.previous[index] {
                     terminal.write_cell(
@@ -2089,7 +2103,12 @@ fn fallback_status_right(status: &semantic::StatusBar) -> String {
 fn pad_to_width(text: &str, width: u16) -> String {
     let current = text_width(text);
     if current >= width {
-        return slice_chars(text, 0, width);
+        let sliced = slice_chars(text, 0, width);
+        let sliced_width = text_width(&sliced);
+        return format!(
+            "{sliced}{}",
+            " ".repeat(width.saturating_sub(sliced_width) as usize)
+        );
     }
 
     format!("{text}{}", " ".repeat((width - current) as usize))
@@ -3217,6 +3236,7 @@ mod tests {
         assert_eq!(text_width("e\u{301}x"), 2);
 
         assert_eq!(pad_to_width("界x", 2), "界");
+        assert_eq!(pad_to_width("a界", 2), "a ");
         assert_eq!(pad_to_width("e\u{301}x", 1), "e\u{301}");
         assert_eq!(slice_chars("界x", 0, 2), "界");
         assert_eq!(slice_chars("界x", 0, 3), "界x");
@@ -3229,7 +3249,7 @@ mod tests {
 
         renderer.write_run(0, 0, "界x", CellStyle::default());
         assert_eq!(renderer.cells[renderer.index(0, 0).unwrap()].text, "界");
-        assert_eq!(renderer.cells[renderer.index(1, 0).unwrap()].text, " ");
+        assert_eq!(renderer.cells[renderer.index(1, 0).unwrap()].text, "");
         assert_eq!(renderer.cells[renderer.index(2, 0).unwrap()].text, "x");
 
         renderer.write_run(1, 0, "e\u{301}x", CellStyle::default());
@@ -3238,5 +3258,20 @@ mod tests {
             "e\u{301}"
         );
         assert_eq!(renderer.cells[renderer.index(1, 1).unwrap()].text, "x");
+    }
+
+    #[test]
+    fn render_skips_wide_grapheme_continuation_cells() {
+        let mut renderer = Renderer::new(4, 1);
+        let mut terminal = Terminal::memory(4, 1);
+
+        renderer.write_run(0, 0, "ab", CellStyle::default());
+        renderer.render(&mut terminal).unwrap();
+        renderer.clear();
+        renderer.write_run(0, 0, "界", CellStyle::default());
+        renderer.render(&mut terminal).unwrap();
+
+        assert_eq!(renderer.previous[renderer.index(0, 0).unwrap()].text, "界");
+        assert_eq!(renderer.previous[renderer.index(1, 0).unwrap()].text, "");
     }
 }

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -405,6 +405,13 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         }
         opcodes::OP_GUI_GUTTER => sectioned_size(bytes, "semantic sectioned command")
             .map(|size| Command::Unsupported { opcode, size }),
+        opcodes::OP_GUI_CURSORLINE => {
+            fixed_size(bytes, 6, "cursorline").map(|size| Command::Unsupported { opcode, size })
+        }
+        opcodes::OP_CLIPBOARD_WRITE
+        | opcodes::OP_GUI_LINE_SPACING
+        | opcodes::OP_GUI_CURSOR_ANIMATION => len16_size(bytes, "forward-compatible gui command")
+            .map(|size| Command::Unsupported { opcode, size }),
         opcodes::OP_GUI_INDENT_GUIDES
         | opcodes::OP_GUI_HOVER_ACTION
         | opcodes::OP_GUI_WORKSPACES
@@ -2324,6 +2331,42 @@ mod tests {
         let command = decode(&[opcodes::OP_GUI_NOTIFICATIONS, 0, 3, 1, 2, 3]).unwrap();
 
         assert_eq!(command.size(), 6);
+    }
+
+    #[test]
+    fn skips_forward_compatible_gui_commands_without_consuming_following_commands() {
+        let cases = [
+            (
+                opcodes::OP_CLIPBOARD_WRITE,
+                vec![opcodes::OP_CLIPBOARD_WRITE, 0, 4, 0, 0, 1, b'x'],
+            ),
+            (
+                opcodes::OP_GUI_LINE_SPACING,
+                vec![opcodes::OP_GUI_LINE_SPACING, 0, 2, 0, 120],
+            ),
+            (
+                opcodes::OP_GUI_CURSOR_ANIMATION,
+                vec![opcodes::OP_GUI_CURSOR_ANIMATION, 0, 1, 1],
+            ),
+            (
+                opcodes::OP_GUI_CURSORLINE,
+                vec![opcodes::OP_GUI_CURSORLINE, 0, 9, 0x11, 0x22, 0x33],
+            ),
+        ];
+
+        for (opcode, payload) in cases {
+            let packet = [payload.clone(), vec![opcodes::OP_BATCH_END]].concat();
+            let command = decode(&packet).unwrap();
+
+            assert_eq!(command.size(), packet.len() - 1);
+            assert!(matches!(
+                command,
+                Command::Unsupported {
+                    opcode: decoded,
+                    size
+                } if decoded == opcode && size == packet.len() - 1
+            ));
+        }
     }
 
     fn section(id: u8, payload: &[u8]) -> Vec<u8> {

--- a/rust/tui/src/signals.rs
+++ b/rust/tui/src/signals.rs
@@ -1,0 +1,35 @@
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Debug, Clone)]
+pub struct ResizeSignal {
+    pending: Arc<AtomicBool>,
+}
+
+impl ResizeSignal {
+    pub fn install() -> io::Result<Self> {
+        let pending = Arc::new(AtomicBool::new(false));
+        signal_hook::flag::register(signal_hook::consts::SIGWINCH, Arc::clone(&pending))?;
+        Ok(Self { pending })
+    }
+
+    pub fn take(&self) -> bool {
+        self.pending.swap(false, Ordering::AcqRel)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn take_clears_pending_resize_flag() {
+        let signal = ResizeSignal {
+            pending: Arc::new(AtomicBool::new(true)),
+        };
+
+        assert!(signal.take());
+        assert!(!signal.take());
+    }
+}


### PR DESCRIPTION
## Summary

- Add direct `unicode-width` and `unicode-segmentation` dependencies for the Rust TUI renderer instead of relying on homegrown width/slicing logic.
- Render and truncate by grapheme cluster boundaries so wide glyphs and combining marks do not split or advance the grid incorrectly.
- Keep the Rust TUI decoder aligned when it receives skipped parser/config/forward-compatible GUI commands, preventing `unknown opcode 0x00` warnings after unsupported packets.
- Replace the homegrown terminal input parser with `termwiz` while preserving Minga key/paste protocol events.
- Replace raw `libc::poll` input readiness with a `mio` poll wrapper and add `signal-hook` SIGWINCH resize detection.
- Move structured chrome onto Ratatui widgets where they fit: completion, which-key, picker header/query/rows/preview, minibuffer candidates, file tree rows/status, popup panels, breadcrumb, status bar, and tab bar rendering now use Ratatui widget primitives backed by theme-derived styles.
- Add TachyonFX animation specs for popup reveal and resize settle timing, and use Ratatui Image protocol selection in the ready capability handshake.
- Fix wide-grapheme continuation cells and post-truncation padding so display-width layout does not leave stale cells or erase trailing columns.

## Validation

- `cargo fmt --manifest-path rust/tui/Cargo.toml`
- `cargo test --manifest-path rust/tui/Cargo.toml`
- `cargo clippy --manifest-path rust/tui/Cargo.toml -- -D warnings`
- `mix protocol.gen --check`
- `mix compile --warnings-as-errors`
- `git diff --check -- rust/tui/Cargo.toml rust/tui/Cargo.lock rust/tui/src`