### PR TITLE
feat(tui): use Charm terminal packages

### DIFF
--- a/go/tui/cmd/minga-renderer-go/main.go
+++ b/go/tui/cmd/minga-renderer-go/main.go
@@ -27,7 +27,7 @@ func run() error {
 	}
 	defer tty.Close()
 
-	width, height := terminal.Size()
+	width, height := terminal.Size(tty)
 	if err := protocol.WritePacket(os.Stdout, protocol.EncodeReady(width, height)); err != nil {
 		return err
 	}

--- a/go/tui/go.mod
+++ b/go/tui/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.8.0
+	github.com/charmbracelet/x/term v0.2.1
 )
 
 require (
@@ -14,7 +15,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
-	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go/tui/go.mod
+++ b/go/tui/go.mod
@@ -7,14 +7,15 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.8.0
+	github.com/charmbracelet/x/cellbuf v0.0.13
 	github.com/charmbracelet/x/term v0.2.1
+	github.com/rivo/uniseg v0.4.7
 )
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -23,7 +24,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.13.0 // indirect

--- a/go/tui/internal/terminal/terminal.go
+++ b/go/tui/internal/terminal/terminal.go
@@ -3,6 +3,8 @@ package terminal
 import (
 	"os"
 	"strconv"
+
+	"github.com/charmbracelet/x/term"
 )
 
 func OpenTTY() (*os.File, error) {
@@ -13,10 +15,29 @@ func OpenTTY() (*os.File, error) {
 	return os.OpenFile(path, os.O_RDWR, 0)
 }
 
-func Size() (uint16, uint16) {
-	cols := envUint16("COLUMNS", 80)
-	rows := envUint16("LINES", 24)
+func Size(tty *os.File) (uint16, uint16) {
+	if tty != nil && term.IsTerminal(tty.Fd()) {
+		width, height, err := term.GetSize(tty.Fd())
+		if err == nil && width > 0 && height > 0 {
+			return clampUint16(width), clampUint16(height)
+		}
+	}
+
+	cols := envUint16("COLUMNS", defaultCols)
+	rows := envUint16("LINES", defaultRows)
 	return cols, rows
+}
+
+const (
+	defaultCols uint16 = 80
+	defaultRows uint16 = 24
+)
+
+func clampUint16(value int) uint16 {
+	if value > int(^uint16(0)) {
+		return ^uint16(0)
+	}
+	return uint16(value)
 }
 
 func envUint16(name string, fallback uint16) uint16 {

--- a/go/tui/internal/terminal/terminal_test.go
+++ b/go/tui/internal/terminal/terminal_test.go
@@ -1,0 +1,62 @@
+package terminal
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSizeFallsBackToEnvironmentForNonTTY(t *testing.T) {
+	file := tempFile(t)
+	t.Setenv("COLUMNS", "132")
+	t.Setenv("LINES", "43")
+
+	width, height := Size(file)
+
+	if width != 132 || height != 43 {
+		t.Fatalf("Size() = %dx%d, want 132x43", width, height)
+	}
+}
+
+func TestSizeFallsBackToDefaultsForInvalidEnvironment(t *testing.T) {
+	file := tempFile(t)
+	t.Setenv("COLUMNS", "0")
+	t.Setenv("LINES", "not-a-number")
+
+	width, height := Size(file)
+
+	if width != defaultCols || height != defaultRows {
+		t.Fatalf("Size() = %dx%d, want %dx%d", width, height, defaultCols, defaultRows)
+	}
+}
+
+func TestSizeFallsBackToDefaultsWithoutTTYOrEnvironment(t *testing.T) {
+	t.Setenv("COLUMNS", "")
+	t.Setenv("LINES", "")
+
+	width, height := Size(nil)
+
+	if width != defaultCols || height != defaultRows {
+		t.Fatalf("Size() = %dx%d, want %dx%d", width, height, defaultCols, defaultRows)
+	}
+}
+
+func TestClampUint16(t *testing.T) {
+	if got := clampUint16(70000); got != ^uint16(0) {
+		t.Fatalf("clampUint16(70000) = %d, want %d", got, ^uint16(0))
+	}
+}
+
+func tempFile(t *testing.T) *os.File {
+	t.Helper()
+
+	file, err := os.CreateTemp(t.TempDir(), "terminal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := file.Close(); err != nil {
+			t.Fatalf("failed to close temp file: %v", err)
+		}
+	})
+	return file
+}

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -27,6 +27,7 @@ type Model struct {
 	windowOrder []uint16
 	chrome      map[byte]protocol.ChromePayload
 	cells       map[position]cell
+	drawSeq     uint64
 	cursorRow   uint16
 	cursorCol   uint16
 	cursorShape byte
@@ -45,6 +46,9 @@ type cell struct {
 	fg    uint32
 	bg    uint32
 	attrs uint16
+	// seq records the draw-command order so overlapping cells replay
+	// deterministically, instead of in Go's randomized map order.
+	seq uint64
 }
 
 func New(width, height uint16, out chan<- []byte) Model {
@@ -116,6 +120,7 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 			m.windows = map[uint16]protocol.WindowContent{}
 			m.windowOrder = nil
 			m.cells = map[position]cell{}
+			m.drawSeq = 0
 		case protocol.CommandDrawText:
 			m.applyDraw(command.Draw)
 		case protocol.CommandSetCursor:
@@ -140,7 +145,8 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 }
 
 func (m *Model) applyDraw(draw protocol.DrawText) {
-	m.cells[position{row: draw.Row, col: draw.Col}] = cell{text: draw.Text, fg: draw.FG, bg: draw.BG, attrs: draw.Attrs}
+	m.drawSeq++
+	m.cells[position{row: draw.Row, col: draw.Col}] = cell{text: draw.Text, fg: draw.FG, bg: draw.BG, attrs: draw.Attrs, seq: m.drawSeq}
 }
 
 func (m *Model) putWindow(window protocol.WindowContent) {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -147,6 +147,25 @@ func TestCellLinesAdvanceByGraphemeWidth(t *testing.T) {
 	}
 }
 
+func TestCellLinesPreserveDrawOrderForOverlappingClearThenContent(t *testing.T) {
+	// The scroll-redraw path sends a full-row space clear and then the
+	// replacement content for that row. The clear must render before the
+	// content, otherwise it blanks the freshly drawn row. Because m.cells is a
+	// Go map, replaying it in iteration order is nondeterministic, so this drives
+	// the real applyDraw path (which records draw order) and asserts the content
+	// survives. Run repeatedly to defeat any accidental iteration-order reliance.
+	for attempt := 0; attempt < 50; attempt++ {
+		model := New(20, 5, nil)
+		model.applyDraw(protocol.DrawText{Row: 0, Col: 0, Text: strings.Repeat(" ", 20)})
+		model.applyDraw(protocol.DrawText{Row: 0, Col: 2, Text: "HELLO"})
+
+		stripped := ansi.Strip(model.cellLines()[0])
+		if !strings.Contains(stripped, "HELLO") {
+			t.Fatalf("attempt %d: clear blanked redrawn content: %q", attempt, stripped)
+		}
+	}
+}
+
 func TestCellbufStyleMapsProtocolAttrs(t *testing.T) {
 	style := cellbufStyle(cell{fg: 0x112233, bg: 0x445566, attrs: 0x01 | 0x02 | 0x04 | 0x08 | 0x10})
 

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/cellbuf"
 	"github.com/jsmestad/minga/go/tui/internal/generated"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
 )
@@ -126,5 +128,35 @@ func TestCursorShapeSequenceTracksProtocolShape(t *testing.T) {
 	model.cursorShape = 2
 	if got := model.cursorStyleSequence(); got != "\x1b[4 q" {
 		t.Fatalf("underline cursor sequence = %q", got)
+	}
+}
+
+func TestCellLinesAdvanceByGraphemeWidth(t *testing.T) {
+	model := New(8, 5, nil)
+	model.cells[position{row: 0, col: 0}] = cell{text: "👍🏼x"}
+	model.cells[position{row: 0, col: 3}] = cell{text: "z"}
+
+	rendered := model.cellLines()
+	stripped := ansi.Strip(rendered[0])
+
+	if !strings.HasPrefix(stripped, "👍🏼xz") {
+		t.Fatalf("cell line = %q, want grapheme-width placement prefix %q", stripped, "👍🏼xz")
+	}
+	if width := ansi.StringWidthWc(stripped); width != 8 {
+		t.Fatalf("cell line width = %d, want 8 for %q", width, stripped)
+	}
+}
+
+func TestCellbufStyleMapsProtocolAttrs(t *testing.T) {
+	style := cellbufStyle(cell{fg: 0x112233, bg: 0x445566, attrs: 0x01 | 0x02 | 0x04 | 0x08 | 0x10})
+
+	if style.Fg == nil || style.Bg == nil {
+		t.Fatalf("style should carry foreground and background: %+v", style)
+	}
+	if !style.Attrs.Contains(cellbuf.BoldAttr) || !style.Attrs.Contains(cellbuf.ItalicAttr) || !style.Attrs.Contains(cellbuf.ReverseAttr) || !style.Attrs.Contains(cellbuf.StrikethroughAttr) {
+		t.Fatalf("style attrs not mapped: %+v", style.Attrs)
+	}
+	if style.UlStyle != cellbuf.SingleUnderline {
+		t.Fatalf("underline style = %v, want single underline", style.UlStyle)
 	}
 }

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -50,8 +51,8 @@ func (m Model) renderRow(row protocol.WindowRow) string {
 
 func (m Model) cellLines() []string {
 	buffer := cellbuf.NewBuffer(max(m.width, 1), max(m.height-2, 1))
-	for pos, cell := range m.cells {
-		writeCellText(buffer, int(pos.col), int(pos.row), cell)
+	for _, draw := range m.orderedCells() {
+		writeCellText(buffer, int(draw.pos.col), int(draw.pos.row), draw.cell)
 	}
 
 	rendered := make([]string, buffer.Height())
@@ -60,6 +61,25 @@ func (m Model) cellLines() []string {
 		rendered[i] = m.editorStyle().Render(fitStyled(line, m.width))
 	}
 	return rendered
+}
+
+type orderedCell struct {
+	pos  position
+	cell cell
+}
+
+// orderedCells returns the fallback draws sorted by draw-command order. Go map
+// iteration is randomized, so replaying m.cells directly lets a later wide draw
+// (for example a full-row space clear) blank earlier content depending on
+// iteration order. Sorting by seq replays draws in the order they arrived, which
+// keeps overlaps deterministic.
+func (m Model) orderedCells() []orderedCell {
+	draws := make([]orderedCell, 0, len(m.cells))
+	for pos, c := range m.cells {
+		draws = append(draws, orderedCell{pos: pos, cell: c})
+	}
+	sort.Slice(draws, func(i, j int) bool { return draws[i].cell.seq < draws[j].cell.seq })
+	return draws
 }
 
 func writeCellText(buffer *cellbuf.Buffer, col int, row int, fallback cell) {

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/cellbuf"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
+	"github.com/rivo/uniseg"
 )
 
 func (m Model) content() string {
@@ -46,25 +49,56 @@ func (m Model) renderRow(row protocol.WindowRow) string {
 }
 
 func (m Model) cellLines() []string {
-	rows := make([][]string, max(m.height-2, 1))
-	for i := range rows {
-		rows[i] = make([]string, max(m.width, 1))
-		for j := range rows[i] {
-			rows[i][j] = " "
-		}
-	}
-
+	buffer := cellbuf.NewBuffer(max(m.width, 1), max(m.height-2, 1))
 	for pos, cell := range m.cells {
-		if int(pos.row) < len(rows) && int(pos.col) < len(rows[pos.row]) {
-			rows[pos.row][pos.col] = m.styleForEditorSpan(protocol.Span{FG: cell.fg, BG: cell.bg, Attrs: byte(cell.attrs)}).Render(cell.text)
-		}
+		writeCellText(buffer, int(pos.col), int(pos.row), cell)
 	}
 
-	rendered := make([]string, len(rows))
-	for i, row := range rows {
-		rendered[i] = m.editorStyle().Render(fitStyled(strings.Join(row, ""), m.width))
+	rendered := make([]string, buffer.Height())
+	for i := range rendered {
+		_, line := cellbuf.RenderLine(buffer, i)
+		rendered[i] = m.editorStyle().Render(fitStyled(line, m.width))
 	}
 	return rendered
+}
+
+func writeCellText(buffer *cellbuf.Buffer, col int, row int, fallback cell) {
+	style := cellbufStyle(fallback)
+	graphemes := uniseg.NewGraphemes(fallback.text)
+	for graphemes.Next() {
+		c := cellbuf.NewGraphemeCell(graphemes.Str())
+		c.Style = style
+		if !buffer.SetCell(col, row, c) {
+			return
+		}
+		col += max(c.Width, 1)
+	}
+}
+
+func cellbufStyle(fallback cell) cellbuf.Style {
+	style := cellbuf.Style{}
+	if fallback.fg != 0 {
+		style.Fg = xansi.TrueColor(fallback.fg)
+	}
+	if fallback.bg != 0 {
+		style.Bg = xansi.TrueColor(fallback.bg)
+	}
+	if fallback.attrs&0x01 != 0 {
+		style.Attrs |= cellbuf.BoldAttr
+	}
+	if fallback.attrs&0x02 != 0 {
+		style.UlStyle = cellbuf.SingleUnderline
+	}
+	if fallback.attrs&0x04 != 0 {
+		style.Attrs |= cellbuf.ItalicAttr
+	}
+	if fallback.attrs&0x08 != 0 {
+		style.Attrs |= cellbuf.ReverseAttr
+	}
+	if fallback.attrs&0x10 != 0 {
+		style.Attrs |= cellbuf.StrikethroughAttr
+	}
+	return style
 }
 
 func (m Model) fillBody(lines []string) []string {


### PR DESCRIPTION
## Summary

- Use `github.com/charmbracelet/x/term` directly for the Go TUI startup terminal size.
- Read width/height from the opened TTY when available, with existing env/default fallbacks for non-TTY paths.
- Use `github.com/charmbracelet/x/cellbuf` for the legacy `DrawText` fallback grid so grapheme/wide-cell placement is handled by Charm's cell model.
- Use `github.com/rivo/uniseg` directly to split fallback draw payloads into grapheme clusters before writing them to `cellbuf`.
- Add focused tests for terminal size fallback/clamping and fallback cell rendering/style mapping.

## Validation

- `go test ./...` from `go/tui`
- `mix compile --warnings-as-errors`
- `git diff --check`