### PR TITLE
fix(extension): update stale type aliases and logging calls

### DIFF
--- a/extensions/board/lib/minga_board/shell.ex
+++ b/extensions/board/lib/minga_board/shell.ex
@@ -35,8 +35,8 @@ defmodule MingaBoard.Shell do
   alias MingaEditor.RenderModel.UI.BoardBuilder
   alias MingaEditor.RenderPipeline.Chrome
   alias MingaEditor.Renderer.Regions
-  alias MingaEditor.Frontend.Protocol.GUI.BoardCardPayload
-  alias MingaEditor.Frontend.Protocol.GUI.BoardPayload
+  alias Minga.RenderModel.UI.Board, as: BoardPayload
+  alias Minga.RenderModel.UI.Board.Card, as: BoardCardPayload
   alias MingaBoard.AgentActivation
   alias MingaBoard.Shell.AgentDeactivation
   alias MingaEditor.State, as: EditorState

--- a/extensions/git_porcelain/lib/minga_git_porcelain/input/git_status.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/input/git_status.ex
@@ -179,7 +179,7 @@ defmodule MingaGitPorcelain.Input.GitStatus do
 
             {:error, reason} ->
               msg = "Discard failed: #{reason}"
-              MingaEditor.log_to_messages(msg)
+              Log.warning(:ext, msg)
               msg
           end
 
@@ -340,7 +340,7 @@ defmodule MingaGitPorcelain.Input.GitStatus do
 
       {:error, reason} ->
         error_msg = "#{error_prefix}: #{reason}"
-        MingaEditor.log_to_messages(error_msg)
+        Log.warning(:ext, error_msg)
         EditorState.set_status(state, error_msg)
     end
   end

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -122,6 +122,7 @@ defmodule Minga.Config.Options do
           | :log_level_config
           | :log_level_port
           | :log_level_distribution
+          | :log_level_ext
           | :parser_tree_ttl
           | :event_retention_days
           | :event_persist_all
@@ -375,6 +376,8 @@ defmodule Minga.Config.Options do
      "Port protocol subsystem log verbosity override."},
     {:log_level_distribution, {:enum, [:default, :debug, :info, :warning, :error, :none]},
      :default, "Distribution subsystem log verbosity override."},
+    {:log_level_ext, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default,
+     "Extension subsystem log verbosity override."},
     {:parser_tree_ttl, :integer, 300, "Seconds to keep cached parser trees alive."},
     {:event_retention_days, :pos_integer, 90,
      "Number of days to keep persisted event log entries."},

--- a/lib/minga/log.ex
+++ b/lib/minga/log.ex
@@ -37,7 +37,7 @@ defmodule Minga.Log do
 
   require Logger
 
-  @type subsystem :: :render | :lsp | :agent | :editor | :config | :port | :distribution
+  @type subsystem :: :render | :lsp | :agent | :editor | :config | :port | :distribution | :ext
 
   @type level :: :debug | :info | :warning | :error
 
@@ -63,7 +63,8 @@ defmodule Minga.Log do
     editor: :log_level_editor,
     config: :log_level_config,
     port: :log_level_port,
-    distribution: :log_level_distribution
+    distribution: :log_level_distribution,
+    ext: :log_level_ext
   }
 
   @doc "Returns the pid of the BEAM-wide singleton `*Messages*` buffer."


### PR DESCRIPTION
## Summary

- **Board extension**: `shell.ex` aliased the deleted `MingaEditor.Frontend.Protocol.GUI.BoardPayload`/`BoardCardPayload` types. #2111 moved these to `Minga.RenderModel.UI.Board`/`Board.Card` but didn't update the extension, causing a compilation error at startup that prevented `minga_board` from loading.
- **Git porcelain extension**: `git_status.ex` called `MingaEditor.log_to_messages/1` which was never added to main. Replaced with `Minga.Log.warning(:ext, ...)` which is already aliased in the file and is the proper logging API.

## Test plan

- [x] `mix compile --warnings-as-errors` passes cleanly
- [ ] `bin/minga-go` starts without the `BoardPayload` compilation error or `log_to_messages` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)