### PR TITLE
fix(test): isolate registries in agent-tab open test to kill a CI flake

### DIFF
--- a/test/minga_editor/integration/file_open_from_agent_tab_test.exs
+++ b/test/minga_editor/integration/file_open_from_agent_tab_test.exs
@@ -26,11 +26,28 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
     height = Keyword.get(opts, :height, 24)
     id = :erlang.unique_integer([:positive])
 
+    # Isolate the event and sidebar registries per test. Without this the agent
+    # editor falls back to the global default registry (subscribing to ~25 event
+    # types) and shares sidebar state with every other async test. Under load,
+    # concurrent broadcasts (renders, buffer/option events) are delivered to this
+    # editor and interleave with the keystrokes below, intermittently dropping
+    # the edit. This mirrors the isolation the standard `start_editor` helper does.
+    events_registry = :"minga_events_agent_#{id}"
+    start_supervised!({Minga.Events, name: events_registry})
+
+    sidebar_registry = :"minga_sidebars_agent_#{id}"
+    start_supervised!({MingaEditor.Extension.Sidebar, name: sidebar_registry, notify: false})
+
     {:ok, port} = HeadlessPort.start_link(width: width, height: height)
     agent_buf = AgentBufferSync.start_buffer()
     assert is_pid(agent_buf), "Failed to start agent buffer"
 
-    {:ok, file_buf} = BufferProcess.start_link(content: "", buffer_name: "unnamed")
+    {:ok, file_buf} =
+      BufferProcess.start_link(
+        content: "",
+        buffer_name: "unnamed",
+        events_registry: events_registry
+      )
 
     {:ok, editor} =
       MingaEditor.start_link(
@@ -39,7 +56,9 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
         buffer: file_buf,
         width: width,
         height: height,
-        editing_model: :vim
+        editing_model: :vim,
+        events_registry: events_registry,
+        sidebar_registry: sidebar_registry
       )
 
     {:ok, fake_session} = StubServer.start_link()


### PR DESCRIPTION
## What

`Minga.Integration.FileOpenFromAgentTabTest` intermittently fails on CI: after opening a file from the agent tab, the `i# <Esc>` insert doesn't land and the assertion sees the un-commented line. It passes in isolation and only fails under concurrent load.

## Root cause

Test isolation, not a product bug. `start_editor_in_agent_mode/1` started the editor **without** an `events_registry` or `sidebar_registry`, so `EditorState` fell back to `Minga.Events.default_registry()` (global) and the global sidebar table. The editor subscribes to ~25 global event types (`:buffer_changed`, `:option_changed`, `:log_message`, renders, …), so under load, broadcasts from other async tests were delivered into this editor and interleaved with the keystrokes, dropping the edit. The co-occurring `DiredTest` render crash (`Cell.new(0, -39, …)`) seen in the same job is the same shared-state contamination from another angle.

The standard `start_editor` helper already isolates both registries per test; the agent-mode helper didn't.

## Fix

Isolate the event and sidebar registries per test in `start_editor_in_agent_mode`, mirroring `start_editor`, and thread the events registry into the file buffer. No production code changes — the production behavior is correct; the test harness was sharing global state.

## Validation

- Both tests in the file pass in isolation.
- Confirmed under load: with CPU saturation (`yes` × cores), the full integration suite at `--max-cases 16` passed (85 tests), no agent-tab failure, and the Dired render crash did not recur.

Surfaced while running CI for #2136 (which carries the same fix so its own checks stay green); extracted here so it can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)