### PR TITLE
Make native frontend builds opt in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,6 @@ jobs:
           version-file: .tool-versions
           version-type: strict
 
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
-
       - name: Cache deps
         uses: actions/cache@v4
         with:
@@ -77,6 +73,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: scripts/check_protocol_generated_edits "${{ github.event.pull_request.base.sha }}"
       - run: mix protocol.gen --check
+      - run: mix native.build.support
       - run: mix test --warnings-as-errors --exclude system_clipboard --exclude conformance
 
   conformance:
@@ -113,6 +110,7 @@ jobs:
 
       - run: mix deps.get
       - run: nvim --version
+      - run: mix native.build.support
       - run: mix conformance
 
   test-zig:
@@ -323,10 +321,6 @@ jobs:
           version-file: .tool-versions
           version-type: strict
 
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
-
       # Separate cache from test jobs: dialyzer needs _build/dev, not _build/test.
       # The PLT and compiled deps are both under _build/dev.
       - name: Cache deps & PLT
@@ -361,10 +355,6 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
 
       - name: Cache deps
         uses: actions/cache@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: help lint lint.format lint.credo lint.compile lint.dialyzer lint.fix test test.llm \
+       native.support native.tui native.rust-tui native.go-tui \
        release release-tui release-mac install install-tui install-mac uninstall
 
 .DEFAULT_GOAL := help
@@ -15,8 +16,13 @@ help:
 	@printf "\033[1;36mQuality checks\033[0m\n"
 	@printf "  \033[1mmake lint\033[0m          Format, credo, compile, and dialyzer\n"
 	@printf "  \033[1mmake lint.fix\033[0m      Run format and strict credo\n"
-	@printf "  \033[1mmake test\033[0m          Run the full ExUnit suite\n"
-	@printf "  \033[1mmake test.llm\033[0m      Run the LLM-friendly test output\n\n"
+	@printf "  \033[1mmake test\033[0m          Build parser support and run the full ExUnit suite\n"
+	@printf "  \033[1mmake test.llm\033[0m      Build parser support and run LLM-friendly tests\n\n"
+	@printf "\033[1;36mNative builds\033[0m\n"
+	@printf "  \033[1mmake native.support\033[0m Build parser and hook-runner support binaries\n"
+	@printf "  \033[1mmake native.tui\033[0m     Build the default Zig TUI binaries\n"
+	@printf "  \033[1mmake native.rust-tui\033[0m Build the experimental Rust TUI renderer\n"
+	@printf "  \033[1mmake native.go-tui\033[0m  Build the experimental Go TUI renderer\n\n"
 	@printf "\033[1;36mBuild and install\033[0m\n"
 	@printf "  \033[1mmake release\033[0m       Build release artifacts for this platform\n"
 	@printf "  \033[1mmake release-tui\033[0m   Build the TUI release\n"
@@ -93,17 +99,32 @@ lint.fix:
 
 # ── Test ────────────────────────────────────────────────────────────────
 
-test:
+test: native.support
 	mix test
 
-test.llm:
+test.llm: native.support
 	mix test.llm
+
+# ── Native builds ───────────────────────────────────────────────────────
+
+native.support:
+	mix native.build.support
+
+native.tui:
+	mix native.build.tui
+
+native.rust-tui:
+	mix native.build.rust_tui
+
+native.go-tui:
+	mix native.build.go_tui
 
 # ── Release (build without installing) ─────────────────────────────────
 
 release-tui:
 	@echo "Building TUI release for $(BURRITO_TARGET)..."
 	MIX_ENV=prod mix deps.get --only prod
+	MIX_ENV=prod mix native.build.tui
 	MIX_ENV=prod mix release minga --overwrite
 	@scripts/check-release-contents _build/prod/rel/minga
 	@echo "\033[32mTUI binary: burrito_out/$(BURRITO_TARGET)\033[0m"

--- a/bin/minga
+++ b/bin/minga
@@ -10,6 +10,16 @@
 
 set -euo pipefail
 
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ "${MINGA_SKIP_NATIVE_LAUNCH_BUILD:-}" != "1" ]; then
+  if [ "${1:-}" = "+gui" ]; then
+    (cd "$PROJECT_DIR" && mix native.build.support)
+  else
+    (cd "$PROJECT_DIR" && mix native.build.tui)
+  fi
+fi
+
 # Editor-tuned VM flags (see rel/vm.args.eex for rationale).
 # ERL_FLAGS set by the caller are appended, so they can override.
 MINGA_ERL_FLAGS="+A 4 +sbwt none +sbwtdcpu none +sbwtdio none +swt very_low +swtdcpu very_low +swtdio very_low +MBas aobf +Mea min +MBacul 0 +hmbs 32768"

--- a/bin/minga-go
+++ b/bin/minga-go
@@ -10,7 +10,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+(cd "$PROJECT_DIR" && mix native.build.support && mix native.build.go_tui)
 
 export MINGA_TUI_IMPL=go
+export MINGA_SKIP_NATIVE_LAUNCH_BUILD=1
 
 exec "$SCRIPT_DIR/minga" "$@"

--- a/bin/minga-mac
+++ b/bin/minga-mac
@@ -13,6 +13,8 @@ set -e
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 XCODEPROJ="$PROJECT_DIR/macos/Minga.xcodeproj"
 
+(cd "$PROJECT_DIR" && mix native.build.support)
+
 # Build the macOS renderer if needed.
 ARCH=$(uname -m)
 echo "Building Minga.app..."

--- a/bin/minga-rust
+++ b/bin/minga-rust
@@ -10,7 +10,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+(cd "$PROJECT_DIR" && mix native.build.support && mix native.build.rust_tui)
 
 export MINGA_TUI_IMPL=rust
+export MINGA_SKIP_NATIVE_LAUNCH_BUILD=1
 
 exec "$SCRIPT_DIR/minga" "$@"

--- a/lib/mix/tasks/app.assemble.ex
+++ b/lib/mix/tasks/app.assemble.ex
@@ -98,6 +98,8 @@ defmodule Mix.Tasks.App.Assemble do
   end
 
   defp build_beam_release(false) do
+    Mix.shell().info("Building native support binaries for the macOS release...")
+    Mix.Task.run("native.build.support", [])
     Mix.shell().info("Building BEAM release (minga_macos)...")
     Mix.Task.run("release", ["minga_macos", "--overwrite"])
     Path.join([Mix.Project.build_path(), "rel", "minga_macos"])
@@ -200,7 +202,7 @@ defmodule Mix.Tasks.App.Assemble do
 
     priv_dirs = Path.wildcard(priv_glob)
 
-    tui_binaries = ["minga-renderer", "minga-renderer-rs", "minga-renderer-gui"]
+    tui_binaries = ["minga-renderer", "minga-renderer-rs", "minga-renderer-go"]
 
     for priv_dir <- priv_dirs, binary_name <- tui_binaries do
       path = Path.join(priv_dir, binary_name)

--- a/mix.exs
+++ b/mix.exs
@@ -1,9 +1,15 @@
 Code.require_file("mix/protocol_generator.ex", __DIR__)
 Code.require_file("mix/compilers/protocol_gen.ex", __DIR__)
 Code.require_file("mix/compilers/minga_bundled_extensions.ex", __DIR__)
-Code.require_file("mix/tasks/protocol.gen.ex", __DIR__)
+Code.require_file("mix/compilers/minga_zig.ex", __DIR__)
 Code.require_file("mix/compilers/minga_rust_tui.ex", __DIR__)
 Code.require_file("mix/compilers/minga_go_tui.ex", __DIR__)
+Code.require_file("mix/tasks/protocol.gen.ex", __DIR__)
+Code.require_file("mix/tasks/native_build/result.ex", __DIR__)
+Code.require_file("mix/tasks/native_build_support.ex", __DIR__)
+Code.require_file("mix/tasks/native_build_tui.ex", __DIR__)
+Code.require_file("mix/tasks/native_build_rust_tui.ex", __DIR__)
+Code.require_file("mix/tasks/native_build_go_tui.ex", __DIR__)
 
 defmodule Minga.MixProject do
   use Mix.Project
@@ -20,9 +26,7 @@ defmodule Minga.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),
-      compilers:
-        [:protocol_gen, :minga_bundled_extensions] ++
-          Mix.compilers() ++ [:minga_zig, :minga_rust_tui, :minga_go_tui],
+      compilers: [:protocol_gen, :minga_bundled_extensions] ++ Mix.compilers(),
       dialyzer: [
         plt_add_deps: :apps_direct,
         # Keep the PLT lean for dev/agent loops: include only direct runtime deps by default, then add transitive apps that Minga source references directly.
@@ -247,7 +251,7 @@ defmodule Minga.MixProject do
     [
       # TUI release: Burrito-wrapped standalone binary (macOS + Linux)
       minga: [
-        steps: [:assemble, &Burrito.wrap/1],
+        steps: [:assemble, &ensure_tui_release_artifacts/1, &Burrito.wrap/1],
         burrito: [
           targets: burrito_targets(),
           debug: Mix.env() != :prod,
@@ -260,11 +264,50 @@ defmodule Minga.MixProject do
       minga_macos: [
         include_erts: true,
         cookie: "minga_app_cookie",
-        steps: [:assemble],
+        steps: [:assemble, &ensure_support_release_artifacts/1],
         rel_templates_path: "rel",
         strip_beams: Mix.env() == :prod
       ]
     ]
+  end
+
+  @spec ensure_tui_release_artifacts(Mix.Release.t()) :: Mix.Release.t()
+  defp ensure_tui_release_artifacts(release) do
+    ensure_release_artifacts!(
+      release,
+      ["minga-renderer", "minga-parser", "minga-hook-runner"],
+      "Run `MIX_ENV=prod mix native.build.tui` before `mix release minga`."
+    )
+  end
+
+  @spec ensure_support_release_artifacts(Mix.Release.t()) :: Mix.Release.t()
+  defp ensure_support_release_artifacts(release) do
+    ensure_release_artifacts!(
+      release,
+      ["minga-parser", "minga-hook-runner"],
+      "Run `MIX_ENV=prod mix native.build.support` before `mix release minga_macos`."
+    )
+  end
+
+  @spec ensure_release_artifacts!(Mix.Release.t(), [String.t()], String.t()) :: Mix.Release.t()
+  defp ensure_release_artifacts!(release, artifact_names, instruction) do
+    priv_dirs = Path.wildcard(Path.join([release.path, "lib", "minga-*", "priv"]))
+    missing = missing_release_artifacts(priv_dirs, artifact_names)
+
+    if missing == [] do
+      release
+    else
+      Mix.raise("Missing native release artifacts: #{Enum.join(missing, ", ")}\n#{instruction}")
+    end
+  end
+
+  @spec missing_release_artifacts([String.t()], [String.t()]) :: [String.t()]
+  defp missing_release_artifacts([], artifact_names), do: artifact_names
+
+  defp missing_release_artifacts(priv_dirs, artifact_names) do
+    Enum.reject(artifact_names, fn artifact_name ->
+      Enum.any?(priv_dirs, fn priv_dir -> File.exists?(Path.join(priv_dir, artifact_name)) end)
+    end)
   end
 
   defp burrito_targets do

--- a/mix/compilers/minga_zig.ex
+++ b/mix/compilers/minga_zig.ex
@@ -1,10 +1,8 @@
 defmodule Mix.Tasks.Compile.MingaZig do
   @moduledoc """
-  Custom Mix compiler that builds the Zig renderer binary.
+  Opt-in Mix task that builds Zig support binaries and the default TUI renderer.
 
-  Registered as `:minga_zig` in the project's compiler list.
-  Runs `zig build` in the `zig/` directory when Zig source files
-  are present.
+  This task is intentionally not registered in the project's compiler list. Native binaries are built by explicit Makefile and CI steps, not by every `mix compile`.
   """
 
   use Mix.Task.Compiler
@@ -18,16 +16,19 @@ defmodule Mix.Tasks.Compile.MingaZig do
   # File extensions that should trigger a Zig rebuild when modified.
   @zig_source_extensions ~w(.zig .zon .c .h .scm)
 
+  @typep build_profile :: :full | :support
+
   @impl true
   @spec run(keyword()) :: {:ok, []} | {:error, []}
-  def run(_opts) do
+  def run(opts) do
     Mix.Task.run("protocol.gen", [])
 
     if File.dir?(@zig_dir) do
-      outputs = required_outputs()
+      profile = build_profile(opts)
+      outputs = required_outputs(profile)
 
       if needs_rebuild?(outputs) do
-        compile_zig_backend("tui")
+        compile_zig_backend(profile)
       else
         {:ok, []}
       end
@@ -36,9 +37,18 @@ defmodule Mix.Tasks.Compile.MingaZig do
     end
   end
 
-  @spec required_outputs() :: [String.t()]
-  defp required_outputs do
+  @spec build_profile(keyword()) :: build_profile()
+  defp build_profile(opts) do
+    Keyword.get(opts, :profile, :full)
+  end
+
+  @spec required_outputs(build_profile()) :: [String.t()]
+  defp required_outputs(:full) do
     Enum.map([@renderer_name, @parser_name, @hook_runner_name], &Path.join(@priv_dir, &1))
+  end
+
+  defp required_outputs(:support) do
+    Enum.map([@parser_name, @hook_runner_name], &Path.join(@priv_dir, &1))
   end
 
   @spec needs_rebuild?([String.t()]) :: boolean()
@@ -82,24 +92,30 @@ defmodule Mix.Tasks.Compile.MingaZig do
     end)
   end
 
-  @spec compile_zig_backend(String.t()) :: {:ok, []} | {:error, []}
-  defp compile_zig_backend(backend) do
-    Mix.shell().info("Compiling Zig binaries (#{backend})...")
+  @spec compile_zig_backend(build_profile()) :: {:ok, []} | {:error, []}
+  defp compile_zig_backend(:full) do
+    compile_zig_backend("tui", [], [@renderer_name, @parser_name, @hook_runner_name])
+  end
 
-    args =
-      ["build"] ++
-        zig_target_args() ++ if(backend != "tui", do: ["-Dbackend=#{backend}"], else: [])
+  defp compile_zig_backend(:support) do
+    Mix.shell().info("Building Zig support binaries without the TUI renderer")
+    compile_zig_backend("support", ["-Drenderer=false"], [@parser_name, @hook_runner_name])
+  end
+
+  @spec compile_zig_backend(String.t(), [String.t()], [String.t()]) :: {:ok, []} | {:error, []}
+  defp compile_zig_backend(label, extra_args, outputs) do
+    Mix.shell().info("Compiling Zig binaries (#{label})...")
+
+    args = ["build"] ++ zig_target_args() ++ extra_args
 
     case System.cmd("zig", args, cd: @zig_dir, stderr_to_stdout: true) do
       {_output, 0} ->
-        Mix.shell().info("Zig binaries (#{backend}) compiled successfully")
-        copy_to_priv(@renderer_name)
-        copy_to_priv(@parser_name)
-        copy_to_priv(@hook_runner_name)
+        Mix.shell().info("Zig binaries (#{label}) compiled successfully")
+        Enum.each(outputs, &copy_to_priv/1)
         {:ok, []}
 
       {output, _code} ->
-        Mix.shell().error("Zig compilation (#{backend}) failed:\n#{output}")
+        Mix.shell().error("Zig compilation (#{label}) failed:\n#{output}")
         {:error, []}
     end
   end

--- a/mix/tasks/native_build/result.ex
+++ b/mix/tasks/native_build/result.ex
@@ -1,0 +1,7 @@
+defmodule Mix.Tasks.Native.Build.Result do
+  @moduledoc false
+
+  @spec raise_on_error({:ok, []} | {:error, []}, String.t()) :: :ok
+  def raise_on_error({:ok, []}, _message), do: :ok
+  def raise_on_error({:error, []}, message), do: Mix.raise(message)
+end

--- a/mix/tasks/native_build_go_tui.ex
+++ b/mix/tasks/native_build_go_tui.ex
@@ -1,0 +1,18 @@
+defmodule Mix.Tasks.Native.Build.GoTui do
+  @moduledoc """
+  Builds the experimental Go TUI renderer.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Builds the experimental Go TUI renderer"
+
+  @impl Mix.Task
+  @spec run([String.t()]) :: :ok
+  def run(_args) do
+    Mix.Tasks.Native.Build.Result.raise_on_error(
+      Mix.Tasks.Compile.MingaGoTui.run([]),
+      "Go TUI build failed"
+    )
+  end
+end

--- a/mix/tasks/native_build_rust_tui.ex
+++ b/mix/tasks/native_build_rust_tui.ex
@@ -1,0 +1,18 @@
+defmodule Mix.Tasks.Native.Build.RustTui do
+  @moduledoc """
+  Builds the experimental Rust TUI renderer.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Builds the experimental Rust TUI renderer"
+
+  @impl Mix.Task
+  @spec run([String.t()]) :: :ok
+  def run(_args) do
+    Mix.Tasks.Native.Build.Result.raise_on_error(
+      Mix.Tasks.Compile.MingaRustTui.run([]),
+      "Rust TUI build failed"
+    )
+  end
+end

--- a/mix/tasks/native_build_support.ex
+++ b/mix/tasks/native_build_support.ex
@@ -1,0 +1,20 @@
+defmodule Mix.Tasks.Native.Build.Support do
+  @moduledoc """
+  Builds native support binaries required by BEAM tests and GUI packaging.
+
+  This builds the Zig parser and hook runner without building the TUI renderer. It is the explicit replacement for the old implicit native build hidden inside `mix compile`.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Builds native parser and hook-runner support binaries"
+
+  @impl Mix.Task
+  @spec run([String.t()]) :: :ok
+  def run(_args) do
+    Mix.Tasks.Native.Build.Result.raise_on_error(
+      Mix.Tasks.Compile.MingaZig.run(profile: :support),
+      "native support build failed"
+    )
+  end
+end

--- a/mix/tasks/native_build_tui.ex
+++ b/mix/tasks/native_build_tui.ex
@@ -1,0 +1,20 @@
+defmodule Mix.Tasks.Native.Build.Tui do
+  @moduledoc """
+  Builds native binaries required by the default TUI release.
+
+  The default packaged TUI uses the Zig renderer, parser, and hook runner. Experimental Rust and Go renderers have their own opt-in tasks.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Builds native binaries for the default TUI release"
+
+  @impl Mix.Task
+  @spec run([String.t()]) :: :ok
+  def run(_args) do
+    Mix.Tasks.Native.Build.Result.raise_on_error(
+      Mix.Tasks.Compile.MingaZig.run(profile: :full),
+      "native TUI build failed"
+    )
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -28,15 +28,9 @@ unless System.get_env("XDG_CONFIG_HOME") do
   System.put_env("XDG_CONFIG_HOME", test_config_home)
 end
 
-# Auto-build the Swift test harness on macOS if swiftc is available.
-# On Linux (CI), the harness tests are excluded automatically.
+# Swift protocol coverage runs through the dedicated `mix swift.harness` job.
+# Ordinary ExUnit starts should never build GUI artifacts as a side effect.
 harness_path = Path.join(:code.priv_dir(:minga), "minga-test-harness")
-
-case System.find_executable("swiftc") do
-  nil -> :noop
-  _swiftc -> Mix.Task.run("swift.harness")
-end
-
 swift_exclude = if File.exists?(harness_path), do: [], else: [:swift_harness]
 
 # `:distributed` tests boot a real peer node (Erlang distribution / epmd) and

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -39,6 +39,7 @@ pub fn build(b: *std.Build) void {
     ensureGeneratedProtocolArtifacts(b);
 
     const backend = b.option(BackendOption, "backend", "Rendering backend (default: tui)") orelse .tui;
+    const renderer = b.option(bool, "renderer", "Build the TUI renderer frontend binary") orelse true;
     const snapshot = b.option(bool, "snapshot", "Build minga-snapshot and snapshot tests (requires host font libraries)") orelse false;
 
     const vaxis = b.dependency("vaxis", .{
@@ -137,21 +138,49 @@ pub fn build(b: *std.Build) void {
         grammar_libs[i] = addGrammar(b, target, c_optimize, g.name, g.has_scanner, g.scanner_extra_flags);
     }
 
-    // Main executable
-    const exe = b.addExecutable(.{
-        .name = "minga-renderer",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/main.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
-    });
-    exe.root_module.addImport("vaxis", vaxis.module("vaxis"));
-    exe.root_module.addImport("build_options", build_options.createModule());
-    exe.root_module.link_libc = true;
-    // Note: tree-sitter and grammars are linked only to minga-parser, not the renderer.
+    const test_step = b.step("test", "Run unit tests");
 
-    b.installArtifact(exe);
+    if (renderer) {
+        // Main executable
+        const exe = b.addExecutable(.{
+            .name = "minga-renderer",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/main.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        exe.root_module.addImport("vaxis", vaxis.module("vaxis"));
+        exe.root_module.addImport("build_options", build_options.createModule());
+        exe.root_module.link_libc = true;
+        // Note: tree-sitter and grammars are linked only to minga-parser, not the renderer.
+
+        b.installArtifact(exe);
+
+        // Run step
+        const run_cmd = b.addRunArtifact(exe);
+        run_cmd.step.dependOn(b.getInstallStep());
+        if (b.args) |args| {
+            run_cmd.addArgs(args);
+        }
+        const run_step = b.step("run", "Run the renderer");
+        run_step.dependOn(&run_cmd.step);
+
+        // Renderer tests
+        const tests = b.addTest(.{
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/main.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        tests.root_module.addImport("vaxis", vaxis.module("vaxis"));
+        tests.root_module.addImport("build_options", build_options.createModule());
+        tests.root_module.link_libc = true;
+
+        const run_tests = b.addRunArtifact(tests);
+        test_step.dependOn(&run_tests.step);
+    }
 
     // ── Parser executable (tree-sitter only, no renderer/libvaxis) ────────
     const parser_exe = b.addExecutable(.{
@@ -198,31 +227,6 @@ pub fn build(b: *std.Build) void {
     });
     hook_runner_exe.root_module.link_libc = true;
     b.installArtifact(hook_runner_exe);
-
-    // Run step
-    const run_cmd = b.addRunArtifact(exe);
-    run_cmd.step.dependOn(b.getInstallStep());
-    if (b.args) |args| {
-        run_cmd.addArgs(args);
-    }
-    const run_step = b.step("run", "Run the renderer");
-    run_step.dependOn(&run_cmd.step);
-
-    // Tests
-    const tests = b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/main.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
-    });
-    tests.root_module.addImport("vaxis", vaxis.module("vaxis"));
-    tests.root_module.addImport("build_options", build_options.createModule());
-    tests.root_module.link_libc = true;
-
-    const run_tests = b.addRunArtifact(tests);
-    const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&run_tests.step);
 
     // Parser tests (highlighter, predicates, posix_regex)
     const parser_tests = b.addTest(.{


### PR DESCRIPTION
# TL;DR
Native frontend builds are now explicit opt-in steps instead of side effects of `mix compile`. BEAM-only CI jobs compile, lint, test, and run Dialyzer without building TUI/GUI artifacts, while test/release paths that need native support build it deliberately.

## Context
`mix compile`, Elixir CI tests, Dialyzer, and docs should not need to compile Zig/Rust/Go/Swift frontend artifacts. This PR moves native build orchestration into explicit Mix tasks and Makefile/CI steps so release packaging remains correct without slowing unrelated BEAM workflows.

## Changes
- Removed Zig/Rust/Go native compiler tasks from the default Mix compiler list.
- Added explicit native build tasks:
  - `mix native.build.support` for parser + hook runner, without the TUI renderer.
  - `mix native.build.tui` for the default Zig renderer + parser + hook runner.
  - `mix native.build.rust_tui` and `mix native.build.go_tui` for experimental renderers.
- Updated `make test` and `make test.llm` to build native parser support before ExUnit.
- Updated `make release-tui` and `make install` paths to build native TUI artifacts before Burrito release packaging.
- Updated developer launchers so `bin/minga`, `bin/minga-go`, `bin/minga-rust`, and `bin/minga-mac` build their respective native targets before launching.
- Updated CI so Elixir/conformance jobs explicitly build parser support, while lint, Dialyzer, and docs no longer install Zig or build native artifacts.
- Removed Swift harness auto-build from `test/test_helper.exs`; Swift protocol integration remains explicit through `mix swift.harness`.
- Added release artifact checks so Burrito/macOS release assembly fails with a clear instruction if required native artifacts are missing.
- Added `zig build -Drenderer=false` support for parser/hook-runner-only builds.

## Verification
- `mix compile --warnings-as-errors --force` passed and did not build native frontend artifacts.
- `mix native.build.support` built `priv/minga-parser` and `priv/minga-hook-runner` without `priv/minga-renderer`.
- `mix native.build.tui` built `priv/minga-renderer`, `priv/minga-parser`, and `priv/minga-hook-runner`.
- `cd zig && zig build -Drenderer=false` passed.
- `cd zig && zig build test -Drenderer=false` passed.
- `cd zig && zig build` passed.
- `mix test --warnings-as-errors --exclude system_clipboard --exclude conformance` passed: 9670 passed, 183 excluded.
- `MIX_ENV=dev mix dialyzer` passed.
- `MIX_ENV=prod mix native.build.support && MIX_ENV=prod mix release minga_macos --overwrite` passed.
- `MIX_ENV=prod mix native.build.tui && MIX_ENV=prod mix release minga --overwrite` passed the new native artifact gate and reached Burrito wrapping with required native artifacts present. Burrito wrapping then failed in Burrito's Zig 0.16 wrapper code with `std.c.private` missing `stat`, which appears independent of this PR.
- `scripts/check-release-contents _build/prod/rel/minga` passed.
- `make -n install` showed `release-tui` runs `MIX_ENV=prod mix native.build.tui` before Burrito packaging and install copy steps.
- `bash -n bin/minga bin/minga-go bin/minga-rust bin/minga-mac` passed.
- `mix format --check-formatted` passed.
- `git diff --check` passed.

## Notes
The final reviewer subagent could not run in this harness because the configured default model/provider was unavailable. Local validation above is included for review.
