### PR TITLE
fix(go): render missing semantic TUI chrome

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -1153,6 +1153,9 @@ Mode color slots fall back to `modeline.bar_fg` / `modeline.bar_bg` when a mode 
 | 0x56 | git_added_fg | `git.added_fg` | Git added sign color |
 | 0x57 | git_modified_fg | `git.modified_fg` | Git modified sign color |
 | 0x58 | git_deleted_fg | `git.deleted_fg` | Git deleted sign color |
+| 0x59 | highlight_read_bg | `editor.highlight_read_bg` | Document highlight background for read references |
+| 0x5A | highlight_write_bg | `editor.highlight_write_bg` | Document highlight background for write references |
+| 0x5B | selection_bg | `editor.selection_bg` | Selection background and text highlight fallback |
 | 0x62 | gutter_fold_fg | `gutter.fold_fg` | Fold indicator color |
 
 ## Forward-Compatibility: Skip-Length for Unknown Opcodes

--- a/go/tui/go.mod
+++ b/go/tui/go.mod
@@ -9,13 +9,14 @@ require (
 	github.com/charmbracelet/x/ansi v0.8.0
 	github.com/charmbracelet/x/cellbuf v0.0.13
 	github.com/charmbracelet/x/term v0.2.1
+	github.com/lrstanley/bubblezone v1.0.0
 	github.com/rivo/uniseg v0.4.7
 )
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
+	github.com/charmbracelet/colorprofile v0.3.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go/tui/go.sum
+++ b/go/tui/go.sum
@@ -8,8 +8,8 @@ github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u
 github.com/charmbracelet/bubbles v0.21.0/go.mod h1:HF+v6QUR4HkEpz62dx7ym2xc71/KBHg+zKwJtMw+qtg=
 github.com/charmbracelet/bubbletea v1.3.4 h1:kCg7B+jSCFPLYRA52SDZjr51kG/fMUEoPoZrkaDHyoI=
 github.com/charmbracelet/bubbletea v1.3.4/go.mod h1:dtcUCyCGEX3g9tosuYiut3MXgY/Jsv9nKVdibKKRRXo=
-github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
-github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc/go.mod h1:X4/0JoqgTIPSFcRA/P6INZzIuyqdFY5rm8tb41s9okk=
+github.com/charmbracelet/colorprofile v0.3.1 h1:k8dTHMd7fgw4bnFd7jXTLZrSU/CQrKnL3m+AxCzDz40=
+github.com/charmbracelet/colorprofile v0.3.1/go.mod h1:/GkGusxNs8VB/RSOh3fu0TJmQ4ICMMPApIIVn0KszZ0=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
 github.com/charmbracelet/x/ansi v0.8.0 h1:9GTq3xq9caJW8ZrBTe0LIe2fvfLR/bYXKTx2llXn7xE=
@@ -24,6 +24,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/lrstanley/bubblezone v1.0.0 h1:bIpUaBilD42rAQwlg/4u5aTqVAt6DSRKYZuSdmkr8UA=
+github.com/lrstanley/bubblezone v1.0.0/go.mod h1:kcTekA8HE/0Ll2bWzqHlhA2c513KDNLW7uDfDP4Mly8=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/go/tui/internal/protocol/chrome_decode.go
+++ b/go/tui/internal/protocol/chrome_decode.go
@@ -65,8 +65,22 @@ func decodeChrome(payload []byte) ChromePayload {
 		chrome.Timeline, chrome.Summary, chrome.Bytes = decodeEditTimeline(payload)
 	case generated.OPGuiGutterSep:
 		chrome.Gutter, chrome.Summary, chrome.Bytes = decodeGutterSeparator(payload)
+	case generated.OPGuiCursorline:
+		chrome.CursorlineChrome, chrome.Summary, chrome.Bytes = decodeCursorlineChrome(payload)
 	case generated.OPGuiGutter:
 		chrome.WindowGutter, chrome.Summary, chrome.Bytes = decodeGutter(payload)
+	case generated.OPGuiToolManager:
+		chrome.ToolManager, chrome.Summary, chrome.Bytes = decodeToolManager(payload)
+	case generated.OPGuiIndentGuides:
+		chrome.IndentGuides, chrome.Summary, chrome.Bytes = decodeIndentGuides(payload)
+	case generated.OPGuiLineSpacing:
+		chrome.LineSpacing, chrome.Summary, chrome.Bytes = decodeLineSpacing(payload)
+	case generated.OPGuiFileTreeSelection:
+		chrome.FileTreeSelection, chrome.Summary, chrome.Bytes = decodeFileTreeSelection(payload)
+	case generated.OPGuiCursorAnimation:
+		chrome.CursorAnimation, chrome.Summary, chrome.Bytes = decodeCursorAnimation(payload)
+	case generated.OPGuiConfigState:
+		chrome.ConfigState, chrome.Summary, chrome.Bytes = decodeConfigState(payload)
 	case generated.OPGuiSplitSeparators:
 		chrome.Splits, chrome.Summary, chrome.Bytes = decodeSplitSeparators(payload)
 	default:

--- a/go/tui/internal/protocol/chrome_decode.go
+++ b/go/tui/internal/protocol/chrome_decode.go
@@ -65,6 +65,8 @@ func decodeChrome(payload []byte) ChromePayload {
 		chrome.Timeline, chrome.Summary, chrome.Bytes = decodeEditTimeline(payload)
 	case generated.OPGuiGutterSep:
 		chrome.Gutter, chrome.Summary, chrome.Bytes = decodeGutterSeparator(payload)
+	case generated.OPGuiGutter:
+		chrome.WindowGutter, chrome.Summary, chrome.Bytes = decodeGutter(payload)
 	case generated.OPGuiSplitSeparators:
 		chrome.Splits, chrome.Summary, chrome.Bytes = decodeSplitSeparators(payload)
 	default:

--- a/go/tui/internal/protocol/chrome_editor.go
+++ b/go/tui/internal/protocol/chrome_editor.go
@@ -321,10 +321,54 @@ func decodeStatus(payload []byte) (StatusBar, string, int) {
 				status.Message = message
 				parts = append(parts, message)
 			}
+		case 0x0B:
+			status.Left, status.Right = decodeStatusSegments(section)
 		}
 	}
 
 	return status, stringsJoin(parts, "  "), size
+}
+
+func decodeStatusSegments(section []byte) ([]StatusSegment, []StatusSegment) {
+	if len(section) < 5 {
+		return nil, nil
+	}
+	offset := 1
+	leftCount := int(u16(section, offset))
+	offset += 2
+	rightCount := int(u16(section, offset))
+	offset += 2
+	left, offset := decodeStatusSegmentList(section, offset, leftCount)
+	right, _ := decodeStatusSegmentList(section, offset, rightCount)
+	return left, right
+}
+
+func decodeStatusSegmentList(section []byte, offset int, count int) ([]StatusSegment, int) {
+	segments := make([]StatusSegment, 0, count)
+	for i := 0; i < count; i++ {
+		segment, next, ok := decodeStatusSegment(section, offset)
+		if !ok {
+			break
+		}
+		segments = append(segments, segment)
+		offset = next
+	}
+	return segments, offset
+}
+
+func decodeStatusSegment(section []byte, offset int) (StatusSegment, int, bool) {
+	name, offset, ok := readString8(section, offset)
+	if !ok || len(section) < offset+7 {
+		return StatusSegment{}, offset, false
+	}
+	segment := StatusSegment{Name: name, FG: u24(section, offset), BG: u24(section, offset+3), Attrs: section[offset+6]}
+	offset += 7
+	segment.Text, offset, ok = readString16(section, offset)
+	if !ok {
+		return StatusSegment{}, offset, false
+	}
+	segment.Command, offset, ok = readString16(section, offset)
+	return segment, offset, ok
 }
 
 func statusFile(section []byte) (string, string, string, bool) {

--- a/go/tui/internal/protocol/chrome_gutter.go
+++ b/go/tui/internal/protocol/chrome_gutter.go
@@ -1,0 +1,95 @@
+package protocol
+
+import "fmt"
+
+func decodeGutter(payload []byte) (Gutter, string, int) {
+	if len(payload) < 2 {
+		return Gutter{}, "", len(payload)
+	}
+
+	gutter := Gutter{}
+	offset := 2
+	for i := 0; i < int(payload[1]); i++ {
+		if len(payload) < offset+3 {
+			return gutter, gutterSummary(gutter), len(payload)
+		}
+		sectionID := payload[offset]
+		sectionLen := int(u16(payload, offset+1))
+		offset += 3
+		if len(payload) < offset+sectionLen {
+			return gutter, gutterSummary(gutter), len(payload)
+		}
+		section := payload[offset : offset+sectionLen]
+		offset += sectionLen
+
+		switch sectionID {
+		case 0x01:
+			decodeGutterWindow(section, &gutter)
+		case 0x02:
+			decodeGutterConfig(section, &gutter)
+		case 0x03:
+			decodeGutterEntries(section, &gutter)
+		}
+	}
+
+	return gutter, gutterSummary(gutter), offset
+}
+
+func decodeGutterWindow(section []byte, gutter *Gutter) {
+	if len(section) < 11 {
+		return
+	}
+	gutter.WindowID = u16(section, 0)
+	gutter.ContentRow = u16(section, 2)
+	gutter.ContentCol = u16(section, 4)
+	gutter.ContentHeight = u16(section, 6)
+	gutter.Active = section[8] != 0
+	gutter.ContentWidth = u16(section, 9)
+}
+
+func decodeGutterConfig(section []byte, gutter *Gutter) {
+	if len(section) < 7 {
+		return
+	}
+	gutter.CursorLine = u32(section, 0)
+	gutter.LineNumberStyle = section[4]
+	gutter.LineNumberWidth = section[5]
+	gutter.SignColWidth = section[6]
+}
+
+func decodeGutterEntries(section []byte, gutter *Gutter) {
+	if len(section) < 2 {
+		return
+	}
+	count := int(u16(section, 0))
+	offset := 2
+	entries := make([]GutterEntry, 0, count)
+	for i := 0; i < count && len(section) >= offset+10; i++ {
+		entry := GutterEntry{
+			BufferLine:  u32(section, offset),
+			DisplayType: section[offset+4],
+			SignType:    section[offset+5],
+			FoldEndLine: u32(section, offset+6),
+		}
+		offset += 10
+		if entry.SignType == 8 && len(section) >= offset+4 {
+			entry.SignFG = u24(section, offset)
+			textLen := int(section[offset+3])
+			offset += 4
+			if len(section) < offset+textLen {
+				break
+			}
+			entry.SignText = string(section[offset : offset+textLen])
+			offset += textLen
+		}
+		entries = append(entries, entry)
+	}
+	gutter.Entries = entries
+}
+
+func gutterSummary(gutter Gutter) string {
+	if gutter.WindowID == 0 && len(gutter.Entries) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("window %d, %d rows", gutter.WindowID, len(gutter.Entries))
+}

--- a/go/tui/internal/protocol/chrome_misc.go
+++ b/go/tui/internal/protocol/chrome_misc.go
@@ -1,0 +1,190 @@
+package protocol
+
+type CursorlineChrome struct {
+	Visible bool
+	Row     uint16
+	BG      uint32
+}
+
+type IndentGuides struct {
+	WindowID       uint16
+	TabWidth       byte
+	ActiveGuideCol uint16
+	GuideCols      []uint16
+	IndentLevels   []byte
+}
+
+type FileTreeSelection struct {
+	Focused    bool
+	SelectedID string
+}
+
+type CursorAnimation struct {
+	Enabled bool
+}
+
+type LineSpacing struct {
+	SpacingX100 uint16
+}
+
+type ConfigState struct {
+	Present bool
+}
+
+type ToolManager struct {
+	Visible  bool
+	Filter   byte
+	Selected uint16
+	Tools    []ToolSummary
+}
+
+type ToolSummary struct {
+	Name   string
+	Label  string
+	Status byte
+}
+
+func decodeCursorlineChrome(payload []byte) (CursorlineChrome, string, int) {
+	if len(payload) < 6 {
+		return CursorlineChrome{}, "", len(payload)
+	}
+	row := u16(payload, 1)
+	if row == 0xFFFF {
+		return CursorlineChrome{}, "hidden", 6
+	}
+	return CursorlineChrome{Visible: true, Row: row, BG: u24(payload, 3)}, "visible", 6
+}
+
+func decodeIndentGuides(payload []byte) (IndentGuides, string, int) {
+	size := payloadLen16Size(payload)
+	if size == 0 {
+		return IndentGuides{}, "", len(payload)
+	}
+	body := payload[3:size]
+	if len(body) < 6 {
+		return IndentGuides{}, "", len(payload)
+	}
+	guides := IndentGuides{WindowID: u16(body, 0), TabWidth: body[2], ActiveGuideCol: u16(body, 3)}
+	count := int(body[5])
+	offset := 6
+	guides.GuideCols = make([]uint16, 0, count)
+	for i := 0; i < count && len(body) >= offset+2; i++ {
+		guides.GuideCols = append(guides.GuideCols, u16(body, offset))
+		offset += 2
+	}
+	if len(body) >= offset+2 {
+		levelCount := int(u16(body, offset))
+		offset += 2
+		if len(body) >= offset+levelCount {
+			guides.IndentLevels = append(guides.IndentLevels, body[offset:offset+levelCount]...)
+		}
+	}
+	return guides, "indent guides", size
+}
+
+func decodeFileTreeSelection(payload []byte) (FileTreeSelection, string, int) {
+	size := payloadLen16Size(payload)
+	if size == 0 || len(payload) < 6 {
+		return FileTreeSelection{}, "", len(payload)
+	}
+	selection := FileTreeSelection{Focused: payload[3]&0x01 != 0}
+	selected, _, ok := readString16(payload, 4)
+	if ok {
+		selection.SelectedID = selected
+	}
+	return selection, selected, size
+}
+
+func decodeCursorAnimation(payload []byte) (CursorAnimation, string, int) {
+	size := payloadLen16Size(payload)
+	if size == 0 || len(payload) < 4 {
+		return CursorAnimation{}, "", len(payload)
+	}
+	return CursorAnimation{Enabled: payload[3] != 0}, "tui no-op", size
+}
+
+func decodeLineSpacing(payload []byte) (LineSpacing, string, int) {
+	size := payloadLen16Size(payload)
+	if size == 0 || len(payload) < 5 {
+		return LineSpacing{}, "", len(payload)
+	}
+	return LineSpacing{SpacingX100: u16(payload, 3)}, "tui no-op", size
+}
+
+func decodeConfigState(payload []byte) (ConfigState, string, int) {
+	size := payloadLen16Size(payload)
+	if size == 0 {
+		return ConfigState{}, "", len(payload)
+	}
+	return ConfigState{Present: true}, "tui no-op", size
+}
+
+func decodeToolManager(payload []byte) (ToolManager, string, int) {
+	if len(payload) < 2 {
+		return ToolManager{}, "", len(payload)
+	}
+	if payload[1] == 0 {
+		return ToolManager{}, "hidden", 2
+	}
+	if len(payload) < 7 {
+		return ToolManager{Visible: true}, "visible", len(payload)
+	}
+	manager := ToolManager{Visible: true, Filter: payload[2], Selected: u16(payload, 3)}
+	count := int(u16(payload, 5))
+	offset := 7
+	manager.Tools = make([]ToolSummary, 0, count)
+	for i := 0; i < count; i++ {
+		tool, next, ok := decodeToolSummary(payload, offset)
+		if !ok {
+			break
+		}
+		manager.Tools = append(manager.Tools, tool)
+		offset = next
+	}
+	return manager, "tools", offset
+}
+
+func decodeToolSummary(payload []byte, offset int) (ToolSummary, int, bool) {
+	name, offset, ok := readString8(payload, offset)
+	if !ok {
+		return ToolSummary{}, offset, false
+	}
+	label, offset, ok := readString8(payload, offset)
+	if !ok {
+		return ToolSummary{}, offset, false
+	}
+	_, offset, ok = readString16(payload, offset)
+	if !ok || len(payload) < offset+4 {
+		return ToolSummary{}, offset, false
+	}
+	status := payload[offset+1]
+	offset += 4
+	langCount := int(payload[offset-1])
+	for i := 0; i < langCount; i++ {
+		_, offset, ok = readString8(payload, offset)
+		if !ok {
+			return ToolSummary{}, offset, false
+		}
+	}
+	_, offset, ok = readString8(payload, offset)
+	if !ok {
+		return ToolSummary{}, offset, false
+	}
+	_, offset, ok = readString16(payload, offset)
+	if !ok || len(payload) < offset+1 {
+		return ToolSummary{}, offset, false
+	}
+	providesCount := int(payload[offset])
+	offset++
+	for i := 0; i < providesCount; i++ {
+		_, offset, ok = readString8(payload, offset)
+		if !ok {
+			return ToolSummary{}, offset, false
+		}
+	}
+	_, offset, ok = readString16(payload, offset)
+	if !ok {
+		return ToolSummary{}, offset, false
+	}
+	return ToolSummary{Name: name, Label: label, Status: status}, offset, true
+}

--- a/go/tui/internal/protocol/chrome_types.go
+++ b/go/tui/internal/protocol/chrome_types.go
@@ -179,6 +179,17 @@ type StatusBar struct {
 	Filename    string
 	Filetype    string
 	Message     string
+	Left        []StatusSegment
+	Right       []StatusSegment
+}
+
+type StatusSegment struct {
+	Name    string
+	FG      uint32
+	BG      uint32
+	Attrs   byte
+	Text    string
+	Command string
 }
 
 type Theme struct {
@@ -449,6 +460,29 @@ type TimelineEntry struct {
 type GutterSeparator struct {
 	Col   uint16
 	Color uint32
+}
+
+type Gutter struct {
+	WindowID        uint16
+	ContentRow      uint16
+	ContentCol      uint16
+	ContentHeight   uint16
+	Active          bool
+	ContentWidth    uint16
+	CursorLine      uint32
+	LineNumberStyle byte
+	LineNumberWidth byte
+	SignColWidth    byte
+	Entries         []GutterEntry
+}
+
+type GutterEntry struct {
+	BufferLine  uint32
+	DisplayType byte
+	SignType    byte
+	FoldEndLine uint32
+	SignFG      uint32
+	SignText    string
 }
 
 type SplitSeparators struct {

--- a/go/tui/internal/protocol/commands.go
+++ b/go/tui/internal/protocol/commands.go
@@ -47,52 +47,71 @@ type DrawText struct {
 }
 
 type ChromePayload struct {
-	Opcode        byte
-	Name          string
-	Summary       string
-	Bytes         int
-	Tabs          TabBar
-	Spaces        WorkspaceBar
-	Mini          Minibuffer
-	Complete      Completion
-	Which         WhichKey
-	Picker        Picker
-	Preview       PickerPreview
-	Tree          FileTree
-	Status        StatusBar
-	Theme         Theme
-	Breadcrumb    Breadcrumb
-	Git           GitStatus
-	Search        SearchState
-	Change        ChangeSummary
-	Hover         HoverPopup
-	HoverAction   HoverAction
-	Signature     SignatureHelp
-	Float         FloatPopup
-	Overlay       ExtensionOverlay
-	Notifications Notifications
-	Bottom        BottomPanel
-	Extensions    ExtensionPanel
-	Sidebars      Sidebars
-	Observatory   Observatory
-	AgentContext  AgentContext
-	AgentChat     AgentChat
-	Board         Board
-	Timeline      EditTimeline
-	Gutter        GutterSeparator
-	WindowGutter  Gutter
-	Splits        SplitSeparators
+	Opcode            byte
+	Name              string
+	Summary           string
+	Bytes             int
+	Tabs              TabBar
+	Spaces            WorkspaceBar
+	Mini              Minibuffer
+	Complete          Completion
+	Which             WhichKey
+	Picker            Picker
+	Preview           PickerPreview
+	Tree              FileTree
+	Status            StatusBar
+	Theme             Theme
+	Breadcrumb        Breadcrumb
+	Git               GitStatus
+	Search            SearchState
+	Change            ChangeSummary
+	Hover             HoverPopup
+	HoverAction       HoverAction
+	Signature         SignatureHelp
+	Float             FloatPopup
+	Overlay           ExtensionOverlay
+	Notifications     Notifications
+	Bottom            BottomPanel
+	Extensions        ExtensionPanel
+	Sidebars          Sidebars
+	Observatory       Observatory
+	AgentContext      AgentContext
+	AgentChat         AgentChat
+	Board             Board
+	Timeline          EditTimeline
+	Gutter            GutterSeparator
+	CursorlineChrome  CursorlineChrome
+	WindowGutter      Gutter
+	IndentGuides      IndentGuides
+	LineSpacing       LineSpacing
+	FileTreeSelection FileTreeSelection
+	CursorAnimation   CursorAnimation
+	ConfigState       ConfigState
+	ToolManager       ToolManager
+	Splits            SplitSeparators
 }
 
 type WindowContent struct {
-	ID           uint16
-	CursorRow    uint16
-	CursorCol    uint16
-	CursorShape  byte
-	ScrollLeft   uint16
-	ContentEpoch uint32
-	Cursorline   Cursorline
-	Rows         []WindowRow
+	ID             uint16
+	CursorRow      uint16
+	CursorCol      uint16
+	CursorShape    byte
+	ScrollLeft     uint16
+	ContentEpoch   uint32
+	Cursorline     Cursorline
+	Selection      Selection
+	SearchMatches  []SearchMatch
+	Diagnostics    []DiagnosticRange
+	Highlights     []DocumentHighlight
+	Annotations    []LineAnnotation
+	Geometry       PaneGeometry
+	Rows           []WindowRow
+	SelectionSet   bool
+	SearchSet      bool
+	DiagnosticsSet bool
+	HighlightsSet  bool
+	AnnotationsSet bool
+	GeometrySet    bool
 }
 
 type Cursorline struct {
@@ -258,6 +277,18 @@ func decodeWindowContent(payload []byte) (Command, error) {
 			decodeWindowHeader(opcode, section, &window)
 		case 0x02:
 			decodeRows(section, &window, opcode != generated.OPGuiWindowContent)
+		case 0x03:
+			decodeSelection(section, &window)
+		case 0x04:
+			decodeSearchMatches(section, &window)
+		case 0x05:
+			decodeDiagnosticRanges(section, &window)
+		case 0x06:
+			decodeDocumentHighlights(section, &window)
+		case 0x07:
+			decodeLineAnnotations(section, &window)
+		case 0x08:
+			decodePaneGeometry(section, &window)
 		case 0x09:
 			decodeCursorline(section, &window)
 		}

--- a/go/tui/internal/protocol/commands.go
+++ b/go/tui/internal/protocol/commands.go
@@ -80,6 +80,7 @@ type ChromePayload struct {
 	Board         Board
 	Timeline      EditTimeline
 	Gutter        GutterSeparator
+	WindowGutter  Gutter
 	Splits        SplitSeparators
 }
 
@@ -90,7 +91,14 @@ type WindowContent struct {
 	CursorShape  byte
 	ScrollLeft   uint16
 	ContentEpoch uint32
+	Cursorline   Cursorline
 	Rows         []WindowRow
+}
+
+type Cursorline struct {
+	Visible bool
+	Row     uint16
+	BG      uint32
 }
 
 type WindowRow struct {
@@ -250,6 +258,8 @@ func decodeWindowContent(payload []byte) (Command, error) {
 			decodeWindowHeader(opcode, section, &window)
 		case 0x02:
 			decodeRows(section, &window, opcode != generated.OPGuiWindowContent)
+		case 0x09:
+			decodeCursorline(section, &window)
 		}
 	}
 
@@ -288,6 +298,7 @@ func decodeOverlayDelta(payload []byte) (Command, error) {
 		if len(payload) < size {
 			return Command{}, fmt.Errorf("short overlay delta cursorline")
 		}
+		window.Cursorline = Cursorline{Visible: true, Row: u16(payload, base), BG: u24(payload, base+2)}
 	}
 
 	return Command{Kind: CommandWindowDelta, Size: size, Window: window}, nil
@@ -316,6 +327,13 @@ func decodeWindowHeader(opcode byte, section []byte, window *WindowContent) {
 	window.CursorCol = u16(section, 9)
 	window.CursorShape = section[11]
 	window.ScrollLeft = u16(section, 12)
+}
+
+func decodeCursorline(section []byte, window *WindowContent) {
+	if len(section) < 5 {
+		return
+	}
+	window.Cursorline = Cursorline{Visible: true, Row: u16(section, 0), BG: u24(section, 2)}
 }
 
 func decodeRows(section []byte, window *WindowContent, delta bool) {

--- a/go/tui/internal/protocol/commands.go
+++ b/go/tui/internal/protocol/commands.go
@@ -97,6 +97,7 @@ type WindowContent struct {
 	CursorCol      uint16
 	CursorShape    byte
 	ScrollLeft     uint16
+	ScrollLeftSet  bool
 	ContentEpoch   uint32
 	Cursorline     Cursorline
 	Selection      Selection
@@ -345,11 +346,12 @@ func decodeWindowHeader(opcode byte, section []byte, window *WindowContent) {
 		window.CursorCol = u16(section, 5)
 		window.CursorShape = section[7]
 		window.ScrollLeft = u16(section, 8)
+		window.ScrollLeftSet = true
 		window.ContentEpoch = u32(section, 10)
 		return
 	}
 
-	if len(section) < 15 {
+	if len(section) < 14 {
 		return
 	}
 	window.ID = u16(section, 0)
@@ -358,6 +360,7 @@ func decodeWindowHeader(opcode byte, section []byte, window *WindowContent) {
 	window.CursorCol = u16(section, 9)
 	window.CursorShape = section[11]
 	window.ScrollLeft = u16(section, 12)
+	window.ScrollLeftSet = true
 }
 
 func decodeCursorline(section []byte, window *WindowContent) {

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -431,6 +431,69 @@ func TestDecodeStatusChrome(t *testing.T) {
 	}
 }
 
+func TestDecodeStatusModelineSegments(t *testing.T) {
+	left := []byte{2, 0, 1, 0, 1}
+	left = append(left, string8("mode")...)
+	left = append(left, 0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33, 1)
+	left = append(left, string16(" NORMAL ")...)
+	left = append(left, string16("set_mode")...)
+	right := []byte{}
+	right = append(right, string8("position")...)
+	right = append(right, 0, 0, 0, 0, 0, 0, 0)
+	right = append(right, string16("1:1 Top")...)
+	right = append(right, string16("")...)
+	packet := []byte{generated.OPGuiStatusBar, 1}
+	packet = append(packet, section(0x0B, append(left, right...))...)
+
+	command, err := DecodeCommand(packet)
+	if err != nil {
+		t.Fatalf("DecodeCommand returned error: %v", err)
+	}
+	status := command.Chrome.Status
+	if len(status.Left) != 1 || len(status.Right) != 1 || status.Left[0].Name != "mode" || status.Left[0].Text != " NORMAL " || status.Left[0].Command != "set_mode" || status.Right[0].Text != "1:1 Top" {
+		t.Fatalf("modeline segments decoded incorrectly: %+v", status)
+	}
+}
+
+func TestDecodeGutterChrome(t *testing.T) {
+	window := section(0x01, []byte{0, 7, 0, 1, 0, 2, 0, 3, 1, 0, 80})
+	config := section(0x02, []byte{0, 0, 0, 4, 0, 4, 2})
+	entriesPayload := []byte{0, 2}
+	entriesPayload = append(entriesPayload, 0, 0, 0, 4, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF)
+	entriesPayload = append(entriesPayload, 0, 0, 0, 5, 3, 0, 0xFF, 0xFF, 0xFF, 0xFF)
+	packet := []byte{generated.OPGuiGutter, 3}
+	packet = append(packet, window...)
+	packet = append(packet, config...)
+	packet = append(packet, section(0x03, entriesPayload)...)
+
+	command, err := DecodeCommand(packet)
+	if err != nil {
+		t.Fatalf("DecodeCommand returned error: %v", err)
+	}
+	gutter := command.Chrome.WindowGutter
+	if gutter.WindowID != 7 || gutter.ContentRow != 1 || gutter.ContentCol != 2 || gutter.CursorLine != 4 || gutter.LineNumberWidth != 4 || len(gutter.Entries) != 2 || gutter.Entries[1].DisplayType != 3 {
+		t.Fatalf("gutter decoded incorrectly: %+v", gutter)
+	}
+}
+
+func TestDecodeWindowCursorlineSection(t *testing.T) {
+	header := section(0x01, []byte{0, 7, 3, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 9})
+	rows := section(0x02, []byte{0, 0})
+	cursorline := section(0x09, []byte{0, 1, 0x11, 0x22, 0x33})
+	packet := []byte{generated.OPGuiWindowContent, 3}
+	packet = append(packet, header...)
+	packet = append(packet, rows...)
+	packet = append(packet, cursorline...)
+
+	command, err := DecodeCommand(packet)
+	if err != nil {
+		t.Fatalf("DecodeCommand returned error: %v", err)
+	}
+	if !command.Window.Cursorline.Visible || command.Window.Cursorline.Row != 1 || command.Window.Cursorline.BG != 0x112233 {
+		t.Fatalf("cursorline decoded incorrectly: %+v", command.Window.Cursorline)
+	}
+}
+
 func TestDecodeThemeAndEverydayChrome(t *testing.T) {
 	packet := []byte{generated.OPGuiTheme, 2, 0x40, 0x11, 0x22, 0x33, 0x30, 0x44, 0x55, 0x66, generated.OPBatchEnd}
 	first, err := DecodeCommand(packet)

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -62,30 +62,63 @@ func TestDecodeWindowContentRows(t *testing.T) {
 	}
 }
 
-func TestDecodeWindowRowsDeltaIncludesRowRefs(t *testing.T) {
+func TestDecodeWindowRowsAndViewportDeltasIncludeRowRefs(t *testing.T) {
 	ref := []byte{
 		0,
 		0, 0, 0, 0, 0, 0, 0, 9,
 		0, 0, 0, 5,
 	}
 	rowsPayload := append([]byte{0, 1}, ref...)
-	headerPayload := []byte{0, 7, 0, 0, 0, 12, 1, 0, 3, 0, 4, 1, 0, 0, 0}
-	packet := append([]byte{generated.OPGuiWindowRowsDelta, 2, 0x01, 0, byte(len(headerPayload))}, headerPayload...)
-	packet = append(packet, 0x02, byte(len(rowsPayload)>>8), byte(len(rowsPayload)))
-	packet = append(packet, rowsPayload...)
+	tests := []struct {
+		name       string
+		opcode     byte
+		header     []byte
+		wantID     uint16
+		wantEpoch  uint32
+		wantRow    uint16
+		wantCol    uint16
+		wantShape  byte
+		wantScroll uint16
+	}{
+		{name: "rows", opcode: generated.OPGuiWindowRowsDelta, header: []byte{0, 7, 0x12, 0x34, 0x56, 0x78, 0xAA, 0, 9, 0, 11, 2, 0, 13}, wantID: 7, wantEpoch: 0x12345678, wantRow: 9, wantCol: 11, wantShape: 2, wantScroll: 13},
+		{name: "viewport", opcode: generated.OPGuiWindowViewportDelta, header: []byte{0, 8, 0x22, 0x33, 0x44, 0x55, 0xBB, 0, 10, 0, 12, 3, 0, 14}, wantID: 8, wantEpoch: 0x22334455, wantRow: 10, wantCol: 12, wantShape: 3, wantScroll: 14},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packet := append([]byte{tt.opcode, 2, 0x01, 0, byte(len(tt.header))}, tt.header...)
+			packet = append(packet, 0x02, byte(len(rowsPayload)>>8), byte(len(rowsPayload)))
+			packet = append(packet, rowsPayload...)
+			packet = append(packet, generated.OPBatchEnd)
 
-	command, err := DecodeCommand(packet)
-	if err != nil {
-		t.Fatalf("DecodeCommand returned error: %v", err)
-	}
-	if command.Kind != CommandWindowDelta {
-		t.Fatalf("kind = %v, want window delta", command.Kind)
-	}
-	if len(command.Window.Rows) != 1 || !command.Window.Rows[0].Ref {
-		t.Fatalf("row ref decoded incorrectly: %+v", command.Window.Rows)
-	}
-	if command.Window.Rows[0].ID != 9 || command.Window.Rows[0].ContentHash != 5 {
-		t.Fatalf("row ref identity decoded incorrectly: %+v", command.Window.Rows[0])
+			command, err := DecodeCommand(packet)
+			if err != nil {
+				t.Fatalf("DecodeCommand returned error: %v", err)
+			}
+			if command.Kind != CommandWindowDelta {
+				t.Fatalf("kind = %v, want window delta", command.Kind)
+			}
+			window := command.Window
+			if !window.ScrollLeftSet {
+				t.Fatalf("scroll left should be marked present in delta header: %+v", window)
+			}
+			if window.ID != tt.wantID || window.ContentEpoch != tt.wantEpoch || window.CursorRow != tt.wantRow || window.CursorCol != tt.wantCol || window.CursorShape != tt.wantShape || window.ScrollLeft != tt.wantScroll {
+				t.Fatalf("header decoded incorrectly: %+v", window)
+			}
+			if len(window.Rows) != 1 || !window.Rows[0].Ref {
+				t.Fatalf("row ref decoded incorrectly: %+v", window.Rows)
+			}
+			if window.Rows[0].ID != 9 || window.Rows[0].ContentHash != 5 {
+				t.Fatalf("row ref identity decoded incorrectly: %+v", window.Rows[0])
+			}
+
+			second, err := DecodeCommand(packet[command.Size:])
+			if err != nil {
+				t.Fatalf("DecodeCommand batch returned error: %v", err)
+			}
+			if second.Kind != CommandBatchEnd {
+				t.Fatalf("second kind = %v, want batch end", second.Kind)
+			}
+		})
 	}
 }
 
@@ -787,6 +820,34 @@ func TestDecodePanelAndSidebarChrome(t *testing.T) {
 	}
 	if len(command.Chrome.Extensions.Panels) != 1 || command.Chrome.Extensions.Panels[0].Title != "Panel" || len(command.Chrome.Extensions.Panels[0].Blocks) != 1 {
 		t.Fatalf("extension panel decoded incorrectly: %+v", command.Chrome.Extensions)
+	}
+
+	tool := []byte{generated.OPGuiToolManager, 1, 0, 0, 0, 0, 1}
+	tool = append(tool, string8("elixir-ls")...)
+	tool = append(tool, string8("Elixir LS")...)
+	tool = append(tool, string16("Language server")...)
+	tool = append(tool, 0, 1, 0, 0)
+	tool = append(tool, string8("")...)
+	tool = append(tool, string16("")...)
+	tool = append(tool, 0)
+	tool = append(tool, string16("")...)
+	tool = append(tool, generated.OPBatchEnd)
+	command, err = DecodeCommand(tool)
+	if err != nil {
+		t.Fatalf("DecodeCommand tool manager returned error: %v", err)
+	}
+	if !command.Chrome.ToolManager.Visible || len(command.Chrome.ToolManager.Tools) != 1 || command.Chrome.ToolManager.Tools[0].Label != "Elixir LS" {
+		t.Fatalf("tool manager decoded incorrectly: %+v", command.Chrome.ToolManager)
+	}
+	if command.Size != len(tool)-1 {
+		t.Fatalf("tool manager size = %d, want %d", command.Size, len(tool)-1)
+	}
+	second, err := DecodeCommand(tool[command.Size:])
+	if err != nil {
+		t.Fatalf("DecodeCommand batch returned error: %v", err)
+	}
+	if second.Kind != CommandBatchEnd {
+		t.Fatalf("second kind = %v, want batch end", second.Kind)
 	}
 
 	node := string8("<0.1.0>")

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -476,6 +476,44 @@ func TestDecodeGutterChrome(t *testing.T) {
 	}
 }
 
+func TestDecodeWindowOverlaySections(t *testing.T) {
+	header := section(0x01, []byte{0, 7, 3, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 9})
+	rows := section(0x02, []byte{0, 0})
+	selection := section(0x03, []byte{1, 0, 0, 0, 1, 0, 0, 0, 4})
+	search := section(0x04, []byte{0, 1, 0, 0, 0, 2, 0, 5, 1})
+	diagnostics := section(0x05, []byte{0, 1, 0, 0, 0, 2, 0, 0, 0, 5, 0})
+	highlights := section(0x06, []byte{0, 1, 0, 0, 0, 3, 0, 0, 0, 6, 2})
+	annotationPayload := []byte{0, 1, 0, 0, 1, 0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33}
+	annotationPayload = append(annotationPayload, string16("note")...)
+	annotations := section(0x07, annotationPayload)
+	geometryPayload := make([]byte, 67)
+	geometryPayload[1] = 7
+	geometryPayload[63] = 3
+	geometryPayload[65] = 2
+	geometry := section(0x08, geometryPayload)
+	packet := []byte{generated.OPGuiWindowContent, 8}
+	packet = append(packet, header...)
+	packet = append(packet, rows...)
+	packet = append(packet, selection...)
+	packet = append(packet, search...)
+	packet = append(packet, diagnostics...)
+	packet = append(packet, highlights...)
+	packet = append(packet, annotations...)
+	packet = append(packet, geometry...)
+
+	command, err := DecodeCommand(packet)
+	if err != nil {
+		t.Fatalf("DecodeCommand returned error: %v", err)
+	}
+	window := command.Window
+	if window.Selection.Type != 1 || len(window.SearchMatches) != 1 || len(window.Diagnostics) != 1 || len(window.Highlights) != 1 || len(window.Annotations) != 1 || !window.GeometrySet {
+		t.Fatalf("overlay sections decoded incorrectly: %+v", window)
+	}
+	if window.Annotations[0].Text != "note" || window.Geometry.WindowID != 7 || window.Geometry.LineNumberWidth != 3 || window.Geometry.SignColWidth != 2 {
+		t.Fatalf("annotation/geometry decoded incorrectly: %+v", window)
+	}
+}
+
 func TestDecodeWindowCursorlineSection(t *testing.T) {
 	header := section(0x01, []byte{0, 7, 3, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 9})
 	rows := section(0x02, []byte{0, 0})
@@ -491,6 +529,74 @@ func TestDecodeWindowCursorlineSection(t *testing.T) {
 	}
 	if !command.Window.Cursorline.Visible || command.Window.Cursorline.Row != 1 || command.Window.Cursorline.BG != 0x112233 {
 		t.Fatalf("cursorline decoded incorrectly: %+v", command.Window.Cursorline)
+	}
+}
+
+func TestDecodeRemainingSemanticChrome(t *testing.T) {
+	cursorline := []byte{generated.OPGuiCursorline, 0, 4, 0x11, 0x22, 0x33}
+	command, err := DecodeCommand(cursorline)
+	if err != nil {
+		t.Fatalf("DecodeCommand cursorline returned error: %v", err)
+	}
+	if !command.Chrome.CursorlineChrome.Visible || command.Chrome.CursorlineChrome.Row != 4 || command.Chrome.CursorlineChrome.BG != 0x112233 {
+		t.Fatalf("cursorline decoded incorrectly: %+v", command.Chrome.CursorlineChrome)
+	}
+
+	indentPayload := []byte{0, 7, 2, 0xFF, 0xFF, 2, 0, 2, 0, 4, 0, 2, 1, 2}
+	indent := append([]byte{generated.OPGuiIndentGuides, 0, byte(len(indentPayload))}, indentPayload...)
+	command, err = DecodeCommand(indent)
+	if err != nil {
+		t.Fatalf("DecodeCommand indent guides returned error: %v", err)
+	}
+	if command.Chrome.IndentGuides.WindowID != 7 || len(command.Chrome.IndentGuides.GuideCols) != 2 || len(command.Chrome.IndentGuides.IndentLevels) != 2 {
+		t.Fatalf("indent guides decoded incorrectly: %+v", command.Chrome.IndentGuides)
+	}
+
+	emptyIndentPayload := []byte{0, 7, 2, 0xFF, 0xFF, 0}
+	emptyIndent := append([]byte{generated.OPGuiIndentGuides, 0, byte(len(emptyIndentPayload))}, emptyIndentPayload...)
+	command, err = DecodeCommand(emptyIndent)
+	if err != nil {
+		t.Fatalf("DecodeCommand empty indent guides returned error: %v", err)
+	}
+	if command.Chrome.IndentGuides.WindowID != 7 || len(command.Chrome.IndentGuides.GuideCols) != 0 {
+		t.Fatalf("empty indent guides decoded incorrectly: %+v", command.Chrome.IndentGuides)
+	}
+
+	selectionPayload := append([]byte{1}, string16("row-1")...)
+	selection := append([]byte{generated.OPGuiFileTreeSelection, 0, byte(len(selectionPayload))}, selectionPayload...)
+	command, err = DecodeCommand(selection)
+	if err != nil {
+		t.Fatalf("DecodeCommand file tree selection returned error: %v", err)
+	}
+	if !command.Chrome.FileTreeSelection.Focused || command.Chrome.FileTreeSelection.SelectedID != "row-1" {
+		t.Fatalf("file tree selection decoded incorrectly: %+v", command.Chrome.FileTreeSelection)
+	}
+
+	lineSpacing := []byte{generated.OPGuiLineSpacing, 0, 2, 0, 120}
+	command, err = DecodeCommand(lineSpacing)
+	if err != nil {
+		t.Fatalf("DecodeCommand line spacing returned error: %v", err)
+	}
+	if command.Chrome.LineSpacing.SpacingX100 != 120 {
+		t.Fatalf("line spacing decoded incorrectly: %+v", command.Chrome.LineSpacing)
+	}
+
+	cursorAnimation := []byte{generated.OPGuiCursorAnimation, 0, 1, 1}
+	command, err = DecodeCommand(cursorAnimation)
+	if err != nil {
+		t.Fatalf("DecodeCommand cursor animation returned error: %v", err)
+	}
+	if !command.Chrome.CursorAnimation.Enabled {
+		t.Fatalf("cursor animation decoded incorrectly: %+v", command.Chrome.CursorAnimation)
+	}
+
+	configState := []byte{generated.OPGuiConfigState, 0, 0}
+	command, err = DecodeCommand(configState)
+	if err != nil {
+		t.Fatalf("DecodeCommand config state returned error: %v", err)
+	}
+	if !command.Chrome.ConfigState.Present {
+		t.Fatalf("config state decoded incorrectly: %+v", command.Chrome.ConfigState)
 	}
 }
 

--- a/go/tui/internal/protocol/events.go
+++ b/go/tui/internal/protocol/events.go
@@ -68,6 +68,19 @@ func EncodeMouseEvent(row, col int16, button, mods, eventType, clickCount byte) 
 	}
 }
 
+func EncodeGUIFileTreeClick(index uint16) []byte {
+	return []byte{generated.OPGuiAction, generated.GUIActionFileTreeClick, byte(index >> 8), byte(index)}
+}
+
+func EncodeGUIExecuteCommand(command string) []byte {
+	payload := []byte(command)
+	if len(payload) > 65535 {
+		payload = payload[:65535]
+	}
+	out := []byte{generated.OPGuiAction, generated.GUIActionExecuteCommand, byte(len(payload) >> 8), byte(len(payload))}
+	return append(out, payload...)
+}
+
 func EncodePaste(text string) []byte {
 	payload := []byte(text)
 	if len(payload) > 65535 {

--- a/go/tui/internal/protocol/events_test.go
+++ b/go/tui/internal/protocol/events_test.go
@@ -1,0 +1,24 @@
+package protocol
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+)
+
+func TestEncodeGUIFileTreeClick(t *testing.T) {
+	got := EncodeGUIFileTreeClick(7)
+	want := []byte{generated.OPGuiAction, generated.GUIActionFileTreeClick, 0, 7}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("file tree click packet = %v, want %v", got, want)
+	}
+}
+
+func TestEncodeGUIExecuteCommand(t *testing.T) {
+	got := EncodeGUIExecuteCommand("write")
+	want := []byte{generated.OPGuiAction, generated.GUIActionExecuteCommand, 0, 5, 'w', 'r', 'i', 't', 'e'}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("execute command packet = %v, want %v", got, want)
+	}
+}

--- a/go/tui/internal/protocol/helpers.go
+++ b/go/tui/internal/protocol/helpers.go
@@ -144,6 +144,8 @@ func opcodeName(opcode byte) string {
 		return "edit timeline"
 	case generated.OPGuiGutterSep:
 		return "gutter separator"
+	case generated.OPGuiGutter:
+		return "gutter"
 	case generated.OPGuiSplitSeparators:
 		return "split separators"
 	default:

--- a/go/tui/internal/protocol/helpers.go
+++ b/go/tui/internal/protocol/helpers.go
@@ -144,8 +144,22 @@ func opcodeName(opcode byte) string {
 		return "edit timeline"
 	case generated.OPGuiGutterSep:
 		return "gutter separator"
+	case generated.OPGuiCursorline:
+		return "cursorline"
 	case generated.OPGuiGutter:
 		return "gutter"
+	case generated.OPGuiToolManager:
+		return "tool manager"
+	case generated.OPGuiIndentGuides:
+		return "indent guides"
+	case generated.OPGuiLineSpacing:
+		return "line spacing"
+	case generated.OPGuiFileTreeSelection:
+		return "file tree selection"
+	case generated.OPGuiCursorAnimation:
+		return "cursor animation"
+	case generated.OPGuiConfigState:
+		return "config state"
 	case generated.OPGuiSplitSeparators:
 		return "split separators"
 	default:

--- a/go/tui/internal/protocol/semantic_guardrail_test.go
+++ b/go/tui/internal/protocol/semantic_guardrail_test.go
@@ -7,6 +7,50 @@ import (
 )
 
 func TestSemanticFrontendOpcodesAreAccountedFor(t *testing.T) {
+	classifications := map[byte]string{
+		generated.OPGuiTabBar:              "rendered header",
+		generated.OPGuiWhichKey:            "rendered overlay",
+		generated.OPGuiCompletion:          "rendered overlay",
+		generated.OPGuiTheme:               "stateful renderer theme",
+		generated.OPGuiBreadcrumb:          "rendered fallback header",
+		generated.OPGuiStatusBar:           "rendered footer/modeline",
+		generated.OPGuiPicker:              "rendered overlay",
+		generated.OPGuiAgentChat:           "rendered overlay",
+		generated.OPGuiGutterSep:           "decoded compatibility chrome",
+		generated.OPGuiCursorline:          "rendered fallback cursorline",
+		generated.OPGuiGutter:              "rendered window gutter",
+		generated.OPGuiBottomPanel:         "rendered overlay",
+		generated.OPGuiPickerPreview:       "rendered picker sidecar",
+		generated.OPGuiToolManager:         "rendered overlay",
+		generated.OPGuiMinibuffer:          "rendered footer overlay",
+		generated.OPGuiWindowContent:       "rendered window content",
+		generated.OPGuiHoverPopup:          "rendered overlay",
+		generated.OPGuiSignatureHelp:       "rendered overlay",
+		generated.OPGuiFloatPopup:          "rendered overlay",
+		generated.OPGuiSplitSeparators:     "rendered content separators",
+		generated.OPGuiGitStatus:           "rendered header/status",
+		generated.OPGuiBoard:               "rendered overlay",
+		generated.OPGuiAgentContext:        "rendered overlay",
+		generated.OPGuiChangeSummary:       "rendered footer/overlay",
+		generated.OPGuiHoverAction:         "rendered hover sidecar",
+		generated.OPGuiConfigState:         "intentional TUI no-op state",
+		generated.OPGuiWorkspaces:          "rendered header",
+		generated.OPGuiNotifications:       "rendered overlay",
+		generated.OPGuiObservatory:         "rendered overlay",
+		generated.OPGuiEditTimeline:        "rendered overlay",
+		generated.OPGuiExtensionOverlay:    "rendered overlay",
+		generated.OPGuiExtensionPanel:      "rendered overlay",
+		generated.OPGuiSearchState:         "rendered footer status",
+		generated.OPGuiSidebars:            "rendered content sidebars",
+		generated.OPGuiWindowOverlayDelta:  "stateful window delta",
+		generated.OPGuiWindowViewportDelta: "stateful window delta",
+		generated.OPGuiWindowRowsDelta:     "stateful window delta",
+		generated.OPGuiIndentGuides:        "rendered window indent guides",
+		generated.OPGuiLineSpacing:         "intentional TUI no-op state",
+		generated.OPGuiFileTree:            "rendered content sidebar",
+		generated.OPGuiFileTreeSelection:   "stateful file tree selection",
+		generated.OPGuiCursorAnimation:     "intentional TUI no-op state",
+	}
 	payloads := map[byte][]byte{
 		generated.OPGuiTabBar:              {generated.OPGuiTabBar, 0, 0},
 		generated.OPGuiWhichKey:            {generated.OPGuiWhichKey, 0},
@@ -28,6 +72,7 @@ func TestSemanticFrontendOpcodesAreAccountedFor(t *testing.T) {
 		generated.OPGuiSignatureHelp:       {generated.OPGuiSignatureHelp, 0},
 		generated.OPGuiFloatPopup:          {generated.OPGuiFloatPopup, 0},
 		generated.OPGuiSplitSeparators:     {generated.OPGuiSplitSeparators, 0, 0, 0, 0},
+		generated.OPGuiGitStatus:           {generated.OPGuiGitStatus, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		generated.OPGuiBoard:               append([]byte{generated.OPGuiBoard, 0, 1}, []byte{0}...),
 		generated.OPGuiAgentContext:        {generated.OPGuiAgentContext, 0, 0},
 		generated.OPGuiChangeSummary:       {generated.OPGuiChangeSummary, 0},
@@ -49,6 +94,20 @@ func TestSemanticFrontendOpcodesAreAccountedFor(t *testing.T) {
 		generated.OPGuiFileTree:            {generated.OPGuiFileTree, 0, 0, 0, 0},
 		generated.OPGuiFileTreeSelection:   {generated.OPGuiFileTreeSelection, 0, 1, 0},
 		generated.OPGuiCursorAnimation:     {generated.OPGuiCursorAnimation, 0, 1, 0},
+	}
+
+	for opcode := range payloads {
+		if classifications[opcode] == "" {
+			t.Fatalf("opcode 0x%02X has payload coverage but no semantic parity classification", opcode)
+		}
+	}
+	for opcode, classification := range classifications {
+		if classification == "" {
+			t.Fatalf("opcode 0x%02X has empty semantic parity classification", opcode)
+		}
+		if _, ok := payloads[opcode]; !ok {
+			t.Fatalf("opcode 0x%02X has semantic parity classification but no decode payload", opcode)
+		}
 	}
 
 	for opcode, payload := range payloads {

--- a/go/tui/internal/protocol/semantic_guardrail_test.go
+++ b/go/tui/internal/protocol/semantic_guardrail_test.go
@@ -1,0 +1,65 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+)
+
+func TestSemanticFrontendOpcodesAreAccountedFor(t *testing.T) {
+	payloads := map[byte][]byte{
+		generated.OPGuiTabBar:              {generated.OPGuiTabBar, 0, 0},
+		generated.OPGuiWhichKey:            {generated.OPGuiWhichKey, 0},
+		generated.OPGuiCompletion:          {generated.OPGuiCompletion, 0},
+		generated.OPGuiTheme:               {generated.OPGuiTheme, 0},
+		generated.OPGuiBreadcrumb:          {generated.OPGuiBreadcrumb, 0},
+		generated.OPGuiStatusBar:           {generated.OPGuiStatusBar, 0},
+		generated.OPGuiPicker:              {generated.OPGuiPicker, 0},
+		generated.OPGuiAgentChat:           {generated.OPGuiAgentChat, 0},
+		generated.OPGuiGutterSep:           {generated.OPGuiGutterSep, 0, 0, 0, 0, 0},
+		generated.OPGuiCursorline:          {generated.OPGuiCursorline, 0xFF, 0xFF, 0, 0, 0},
+		generated.OPGuiGutter:              {generated.OPGuiGutter, 0},
+		generated.OPGuiBottomPanel:         {generated.OPGuiBottomPanel, 0},
+		generated.OPGuiPickerPreview:       {generated.OPGuiPickerPreview, 0},
+		generated.OPGuiToolManager:         {generated.OPGuiToolManager, 0},
+		generated.OPGuiMinibuffer:          {generated.OPGuiMinibuffer, 0},
+		generated.OPGuiWindowContent:       {generated.OPGuiWindowContent, 0},
+		generated.OPGuiHoverPopup:          {generated.OPGuiHoverPopup, 0},
+		generated.OPGuiSignatureHelp:       {generated.OPGuiSignatureHelp, 0},
+		generated.OPGuiFloatPopup:          {generated.OPGuiFloatPopup, 0},
+		generated.OPGuiSplitSeparators:     {generated.OPGuiSplitSeparators, 0, 0, 0, 0},
+		generated.OPGuiBoard:               append([]byte{generated.OPGuiBoard, 0, 1}, []byte{0}...),
+		generated.OPGuiAgentContext:        {generated.OPGuiAgentContext, 0, 0},
+		generated.OPGuiChangeSummary:       {generated.OPGuiChangeSummary, 0},
+		generated.OPGuiHoverAction:         {generated.OPGuiHoverAction, 0, 1, 0},
+		generated.OPGuiConfigState:         {generated.OPGuiConfigState, 0, 0},
+		generated.OPGuiWorkspaces:          {generated.OPGuiWorkspaces, 0, 6, 2, 0, 0, 0, 0, 0},
+		generated.OPGuiNotifications:       {generated.OPGuiNotifications, 0, 3, 0, 0, 0},
+		generated.OPGuiObservatory:         {generated.OPGuiObservatory, 0, 0, 0, 0, 0},
+		generated.OPGuiEditTimeline:        {generated.OPGuiEditTimeline, 0, 4, 0, 0, 0, 0},
+		generated.OPGuiExtensionOverlay:    {generated.OPGuiExtensionOverlay, 0, 2, 0, 0},
+		generated.OPGuiExtensionPanel:      {generated.OPGuiExtensionPanel, 0, 1, 0},
+		generated.OPGuiSearchState:         {generated.OPGuiSearchState, 0, 5, 0, 0, 0, 0, 0},
+		generated.OPGuiSidebars:            {generated.OPGuiSidebars, 0, 0, 0, 0, 0},
+		generated.OPGuiWindowOverlayDelta:  {generated.OPGuiWindowOverlayDelta, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0},
+		generated.OPGuiWindowViewportDelta: {generated.OPGuiWindowViewportDelta, 0},
+		generated.OPGuiWindowRowsDelta:     {generated.OPGuiWindowRowsDelta, 0},
+		generated.OPGuiIndentGuides:        {generated.OPGuiIndentGuides, 0, 6, 0, 1, 2, 0xFF, 0xFF, 0},
+		generated.OPGuiLineSpacing:         {generated.OPGuiLineSpacing, 0, 2, 0, 100},
+		generated.OPGuiFileTree:            {generated.OPGuiFileTree, 0, 0, 0, 0},
+		generated.OPGuiFileTreeSelection:   {generated.OPGuiFileTreeSelection, 0, 1, 0},
+		generated.OPGuiCursorAnimation:     {generated.OPGuiCursorAnimation, 0, 1, 0},
+	}
+
+	for opcode, payload := range payloads {
+		t.Run(opcodeName(opcode), func(t *testing.T) {
+			command, err := DecodeCommand(payload)
+			if err != nil {
+				t.Fatalf("DecodeCommand returned error: %v", err)
+			}
+			if command.Size <= 0 {
+				t.Fatalf("DecodeCommand returned non-positive size for opcode 0x%02X: %+v", opcode, command)
+			}
+		})
+	}
+}

--- a/go/tui/internal/protocol/window_overlays.go
+++ b/go/tui/internal/protocol/window_overlays.go
@@ -1,0 +1,209 @@
+package protocol
+
+import "unicode/utf8"
+
+type Selection struct {
+	Type     byte
+	StartRow uint16
+	StartCol uint16
+	EndRow   uint16
+	EndCol   uint16
+}
+
+type SearchMatch struct {
+	Row      uint16
+	StartCol uint16
+	EndCol   uint16
+	Current  bool
+}
+
+type DiagnosticRange struct {
+	StartRow uint16
+	StartCol uint16
+	EndRow   uint16
+	EndCol   uint16
+	Severity byte
+}
+
+type DocumentHighlight struct {
+	StartRow uint16
+	StartCol uint16
+	EndRow   uint16
+	EndCol   uint16
+	Kind     byte
+}
+
+type LineAnnotation struct {
+	Row  uint16
+	Kind byte
+	FG   uint32
+	BG   uint32
+	Text string
+}
+
+type Rect struct {
+	Row    uint16
+	Col    uint16
+	Width  uint16
+	Height uint16
+}
+
+type PaneGeometry struct {
+	WindowID        uint16
+	TotalRect       Rect
+	ContentRect     Rect
+	TextRect        Rect
+	GutterRect      Rect
+	ClipRect        Rect
+	ViewportTop     uint32
+	ViewportLeft    uint16
+	ViewportRows    uint16
+	ViewportCols    uint16
+	TotalLines      uint32
+	VisualRowOffset uint16
+	TotalVisualRows uint32
+	LineNumberWidth uint16
+	SignColWidth    uint16
+	HitRegions      []HitRegion
+}
+
+type HitRegion struct {
+	Kind     byte
+	Rect     Rect
+	WindowID uint16
+}
+
+func decodeSelection(section []byte, window *WindowContent) {
+	window.SelectionSet = true
+	if len(section) < 1 || section[0] == 0 {
+		window.Selection = Selection{}
+		return
+	}
+	if len(section) < 9 {
+		return
+	}
+	window.Selection = Selection{Type: section[0], StartRow: u16(section, 1), StartCol: u16(section, 3), EndRow: u16(section, 5), EndCol: u16(section, 7)}
+}
+
+func decodeSearchMatches(section []byte, window *WindowContent) {
+	window.SearchSet = true
+	if len(section) < 2 {
+		window.SearchMatches = nil
+		return
+	}
+	count := int(u16(section, 0))
+	offset := 2
+	matches := make([]SearchMatch, 0, count)
+	for i := 0; i < count && len(section) >= offset+7; i++ {
+		matches = append(matches, SearchMatch{Row: u16(section, offset), StartCol: u16(section, offset+2), EndCol: u16(section, offset+4), Current: section[offset+6] != 0})
+		offset += 7
+	}
+	window.SearchMatches = matches
+}
+
+func decodeDiagnosticRanges(section []byte, window *WindowContent) {
+	window.DiagnosticsSet = true
+	if len(section) < 2 {
+		window.Diagnostics = nil
+		return
+	}
+	count := int(u16(section, 0))
+	offset := 2
+	ranges := make([]DiagnosticRange, 0, count)
+	for i := 0; i < count && len(section) >= offset+9; i++ {
+		ranges = append(ranges, DiagnosticRange{StartRow: u16(section, offset), StartCol: u16(section, offset+2), EndRow: u16(section, offset+4), EndCol: u16(section, offset+6), Severity: section[offset+8]})
+		offset += 9
+	}
+	window.Diagnostics = ranges
+}
+
+func decodeDocumentHighlights(section []byte, window *WindowContent) {
+	window.HighlightsSet = true
+	if len(section) < 2 {
+		window.Highlights = nil
+		return
+	}
+	count := int(u16(section, 0))
+	offset := 2
+	highlights := make([]DocumentHighlight, 0, count)
+	for i := 0; i < count && len(section) >= offset+9; i++ {
+		highlights = append(highlights, DocumentHighlight{StartRow: u16(section, offset), StartCol: u16(section, offset+2), EndRow: u16(section, offset+4), EndCol: u16(section, offset+6), Kind: section[offset+8]})
+		offset += 9
+	}
+	window.Highlights = highlights
+}
+
+func decodeLineAnnotations(section []byte, window *WindowContent) {
+	window.AnnotationsSet = true
+	if len(section) < 2 {
+		window.Annotations = nil
+		return
+	}
+	count := int(u16(section, 0))
+	offset := 2
+	annotations := make([]LineAnnotation, 0, count)
+	for i := 0; i < count && len(section) >= offset+11; i++ {
+		annotation := LineAnnotation{Row: u16(section, offset), Kind: section[offset+2], FG: u24(section, offset+3), BG: u24(section, offset+6)}
+		textLen := int(u16(section, offset+9))
+		offset += 11
+		if len(section) < offset+textLen || !utf8.Valid(section[offset:offset+textLen]) {
+			break
+		}
+		annotation.Text = string(section[offset : offset+textLen])
+		offset += textLen
+		annotations = append(annotations, annotation)
+	}
+	window.Annotations = annotations
+}
+
+func decodePaneGeometry(section []byte, window *WindowContent) {
+	window.GeometrySet = true
+	const fixed = 67
+	if len(section) < fixed {
+		return
+	}
+	offset := 0
+	geometry := PaneGeometry{WindowID: u16(section, offset)}
+	offset += 2
+	geometry.TotalRect = decodeRect(section, offset)
+	offset += 8
+	geometry.ContentRect = decodeRect(section, offset)
+	offset += 8
+	geometry.TextRect = decodeRect(section, offset)
+	offset += 8
+	geometry.GutterRect = decodeRect(section, offset)
+	offset += 8
+	geometry.ClipRect = decodeRect(section, offset)
+	offset += 8
+	geometry.ViewportTop = u32(section, offset)
+	offset += 4
+	geometry.ViewportLeft = u16(section, offset)
+	offset += 2
+	geometry.ViewportRows = u16(section, offset)
+	offset += 2
+	geometry.ViewportCols = u16(section, offset)
+	offset += 2
+	geometry.TotalLines = u32(section, offset)
+	offset += 4
+	geometry.VisualRowOffset = u16(section, offset)
+	offset += 2
+	geometry.TotalVisualRows = u32(section, offset)
+	offset += 4
+	geometry.LineNumberWidth = u16(section, offset)
+	offset += 2
+	geometry.SignColWidth = u16(section, offset)
+	offset += 2
+	count := int(section[offset])
+	offset++
+	regions := make([]HitRegion, 0, count)
+	for i := 0; i < count && len(section) >= offset+11; i++ {
+		regions = append(regions, HitRegion{Kind: section[offset], Rect: decodeRect(section, offset+1), WindowID: u16(section, offset+9)})
+		offset += 11
+	}
+	geometry.HitRegions = regions
+	window.Geometry = geometry
+}
+
+func decodeRect(section []byte, offset int) Rect {
+	return Rect{Row: u16(section, offset), Col: u16(section, offset+2), Width: u16(section, offset+4), Height: u16(section, offset+6)}
+}

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jsmestad/minga/go/tui/internal/generated"
 	"github.com/jsmestad/minga/go/tui/internal/port"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
+	zone "github.com/lrstanley/bubblezone"
 )
 
 const (
@@ -20,22 +21,25 @@ const (
 )
 
 type Model struct {
-	width       int
-	height      int
-	out         chan<- []byte
-	viewport    viewport.Model
-	windows     map[uint16]protocol.WindowContent
-	windowOrder []uint16
-	chrome      map[byte]protocol.ChromePayload
-	gutters     map[uint16]protocol.Gutter
-	cells       map[position]cell
-	drawSeq     uint64
-	cursorRow   uint16
-	cursorCol   uint16
-	cursorShape byte
-	title       string
-	bg          uint32
-	lastError   string
+	width         int
+	height        int
+	out           chan<- []byte
+	viewport      viewport.Model
+	zones         *zone.Manager
+	windows       map[uint16]protocol.WindowContent
+	windowOrder   []uint16
+	chrome        map[byte]protocol.ChromePayload
+	activePalette palette
+	gutters       map[uint16]protocol.Gutter
+	indentGuides  map[uint16]protocol.IndentGuides
+	cells         map[position]cell
+	drawSeq       uint64
+	cursorRow     uint16
+	cursorCol     uint16
+	cursorShape   byte
+	title         string
+	bg            uint32
+	lastError     string
 }
 
 type position struct {
@@ -56,14 +60,17 @@ type cell struct {
 func New(width, height uint16, out chan<- []byte) Model {
 	vp := viewport.New(int(width), max(int(height)-3, 1))
 	return Model{
-		width:    int(width),
-		height:   int(height),
-		out:      out,
-		viewport: vp,
-		windows:  map[uint16]protocol.WindowContent{},
-		chrome:   map[byte]protocol.ChromePayload{},
-		gutters:  map[uint16]protocol.Gutter{},
-		cells:    map[position]cell{},
+		width:         int(width),
+		height:        int(height),
+		out:           out,
+		viewport:      vp,
+		zones:         zone.New(),
+		windows:       map[uint16]protocol.WindowContent{},
+		chrome:        map[byte]protocol.ChromePayload{},
+		activePalette: defaultPalette(),
+		gutters:       map[uint16]protocol.Gutter{},
+		indentGuides:  map[uint16]protocol.IndentGuides{},
+		cells:         map[position]cell{},
 	}
 }
 
@@ -84,7 +91,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.send(packet)
 		}
 	case tea.MouseMsg:
-		m.send(mousePacket(msg))
+		if packet, ok := m.semanticMousePacket(msg); ok {
+			m.send(packet)
+		} else {
+			m.send(mousePacket(msg))
+		}
 	case port.PacketMsg:
 		return m, m.applyCommands(msg.Commands)
 	case port.LogMsg:
@@ -105,7 +116,7 @@ func (m Model) View() string {
 	body := m.viewport.View()
 	parts := append(m.headerLines(), body)
 	parts = append(parts, m.footerLines()...)
-	return m.cursorStyleSequence() + lipgloss.JoinVertical(lipgloss.Left, parts...)
+	return m.cursorStyleSequence() + m.zones.Scan(lipgloss.JoinVertical(lipgloss.Left, parts...))
 }
 
 func (m Model) cursorStyleSequence() string {
@@ -128,6 +139,7 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 			m.windowOrder = nil
 			m.chrome = map[byte]protocol.ChromePayload{}
 			m.gutters = map[uint16]protocol.Gutter{}
+			m.indentGuides = map[uint16]protocol.IndentGuides{}
 			m.cells = map[position]cell{}
 			m.drawSeq = 0
 		case protocol.CommandDrawText:
@@ -148,8 +160,17 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 			m.applyWindowDelta(command.Window)
 		case protocol.CommandChrome:
 			m.chrome[command.Chrome.Opcode] = command.Chrome
+			if command.Chrome.Opcode == generated.OPGuiTheme {
+				m.activePalette = paletteFromTheme(command.Chrome.Theme)
+			}
 			if command.Chrome.Opcode == generated.OPGuiGutter {
 				m.gutters[command.Chrome.WindowGutter.WindowID] = command.Chrome.WindowGutter
+			}
+			if command.Chrome.Opcode == generated.OPGuiIndentGuides {
+				m.indentGuides[command.Chrome.IndentGuides.WindowID] = command.Chrome.IndentGuides
+			}
+			if command.Chrome.Opcode == generated.OPGuiFileTreeSelection {
+				m.applyFileTreeSelection(command.Chrome.FileTreeSelection)
 			}
 		}
 	}
@@ -185,6 +206,30 @@ func (m *Model) applyWindowDelta(delta protocol.WindowContent) {
 	window.ScrollLeft = delta.ScrollLeft
 	if delta.Cursorline.Visible {
 		window.Cursorline = delta.Cursorline
+	}
+	if delta.SelectionSet {
+		window.Selection = delta.Selection
+		window.SelectionSet = true
+	}
+	if delta.SearchSet {
+		window.SearchMatches = delta.SearchMatches
+		window.SearchSet = true
+	}
+	if delta.DiagnosticsSet {
+		window.Diagnostics = delta.Diagnostics
+		window.DiagnosticsSet = true
+	}
+	if delta.HighlightsSet {
+		window.Highlights = delta.Highlights
+		window.HighlightsSet = true
+	}
+	if delta.AnnotationsSet {
+		window.Annotations = delta.Annotations
+		window.AnnotationsSet = true
+	}
+	if delta.GeometrySet {
+		window.Geometry = delta.Geometry
+		window.GeometrySet = true
 	}
 	if len(delta.Rows) > 0 {
 		window.Rows = resolveWindowRows(window.Rows, delta.Rows)

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -21,25 +21,26 @@ const (
 )
 
 type Model struct {
-	width         int
-	height        int
-	out           chan<- []byte
-	viewport      viewport.Model
-	zones         *zone.Manager
-	windows       map[uint16]protocol.WindowContent
-	windowOrder   []uint16
-	chrome        map[byte]protocol.ChromePayload
-	activePalette palette
-	gutters       map[uint16]protocol.Gutter
-	indentGuides  map[uint16]protocol.IndentGuides
-	cells         map[position]cell
-	drawSeq       uint64
-	cursorRow     uint16
-	cursorCol     uint16
-	cursorShape   byte
-	title         string
-	bg            uint32
-	lastError     string
+	width            int
+	height           int
+	out              chan<- []byte
+	viewport         viewport.Model
+	zones            *zone.Manager
+	windows          map[uint16]protocol.WindowContent
+	windowOrder      []uint16
+	chrome           map[byte]protocol.ChromePayload
+	activePalette    palette
+	gutters          map[uint16]protocol.Gutter
+	indentGuides     map[uint16]protocol.IndentGuides
+	cells            map[position]cell
+	drawSeq          uint64
+	cursorRow        uint16
+	cursorCol        uint16
+	cursorShape      byte
+	title            string
+	bg               uint32
+	cursorlineChrome protocol.CursorlineChrome
+	lastError        string
 }
 
 type position struct {
@@ -140,6 +141,7 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 			m.chrome = map[byte]protocol.ChromePayload{}
 			m.gutters = map[uint16]protocol.Gutter{}
 			m.indentGuides = map[uint16]protocol.IndentGuides{}
+			m.cursorlineChrome = protocol.CursorlineChrome{}
 			m.cells = map[position]cell{}
 			m.drawSeq = 0
 		case protocol.CommandDrawText:
@@ -162,6 +164,9 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 			m.chrome[command.Chrome.Opcode] = command.Chrome
 			if command.Chrome.Opcode == generated.OPGuiTheme {
 				m.activePalette = paletteFromTheme(command.Chrome.Theme)
+			}
+			if command.Chrome.Opcode == generated.OPGuiCursorline {
+				m.cursorlineChrome = command.Chrome.CursorlineChrome
 			}
 			if command.Chrome.Opcode == generated.OPGuiGutter {
 				m.gutters[command.Chrome.WindowGutter.WindowID] = command.Chrome.WindowGutter

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/jsmestad/minga/go/tui/internal/generated"
 	"github.com/jsmestad/minga/go/tui/internal/port"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
 )
@@ -26,6 +27,7 @@ type Model struct {
 	windows     map[uint16]protocol.WindowContent
 	windowOrder []uint16
 	chrome      map[byte]protocol.ChromePayload
+	gutters     map[uint16]protocol.Gutter
 	cells       map[position]cell
 	drawSeq     uint64
 	cursorRow   uint16
@@ -60,6 +62,7 @@ func New(width, height uint16, out chan<- []byte) Model {
 		viewport: vp,
 		windows:  map[uint16]protocol.WindowContent{},
 		chrome:   map[byte]protocol.ChromePayload{},
+		gutters:  map[uint16]protocol.Gutter{},
 		cells:    map[position]cell{},
 	}
 }
@@ -123,6 +126,8 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 		case protocol.CommandClear:
 			m.windows = map[uint16]protocol.WindowContent{}
 			m.windowOrder = nil
+			m.chrome = map[byte]protocol.ChromePayload{}
+			m.gutters = map[uint16]protocol.Gutter{}
 			m.cells = map[position]cell{}
 			m.drawSeq = 0
 		case protocol.CommandDrawText:
@@ -143,6 +148,9 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 			m.applyWindowDelta(command.Window)
 		case protocol.CommandChrome:
 			m.chrome[command.Chrome.Opcode] = command.Chrome
+			if command.Chrome.Opcode == generated.OPGuiGutter {
+				m.gutters[command.Chrome.WindowGutter.WindowID] = command.Chrome.WindowGutter
+			}
 		}
 	}
 	return tea.Batch(cmds...)
@@ -175,6 +183,9 @@ func (m *Model) applyWindowDelta(delta protocol.WindowContent) {
 	window.CursorShape = delta.CursorShape
 	window.ContentEpoch = delta.ContentEpoch
 	window.ScrollLeft = delta.ScrollLeft
+	if delta.Cursorline.Visible {
+		window.Cursorline = delta.Cursorline
+	}
 	if len(delta.Rows) > 0 {
 		window.Rows = resolveWindowRows(window.Rows, delta.Rows)
 	}

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -162,19 +163,16 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 			m.applyWindowDelta(command.Window)
 		case protocol.CommandChrome:
 			m.chrome[command.Chrome.Opcode] = command.Chrome
-			if command.Chrome.Opcode == generated.OPGuiTheme {
+			switch command.Chrome.Opcode {
+			case generated.OPGuiTheme:
 				m.activePalette = paletteFromTheme(command.Chrome.Theme)
-			}
-			if command.Chrome.Opcode == generated.OPGuiCursorline {
+			case generated.OPGuiCursorline:
 				m.cursorlineChrome = command.Chrome.CursorlineChrome
-			}
-			if command.Chrome.Opcode == generated.OPGuiGutter {
+			case generated.OPGuiGutter:
 				m.gutters[command.Chrome.WindowGutter.WindowID] = command.Chrome.WindowGutter
-			}
-			if command.Chrome.Opcode == generated.OPGuiIndentGuides {
+			case generated.OPGuiIndentGuides:
 				m.indentGuides[command.Chrome.IndentGuides.WindowID] = command.Chrome.IndentGuides
-			}
-			if command.Chrome.Opcode == generated.OPGuiFileTreeSelection {
+			case generated.OPGuiFileTreeSelection:
 				m.applyFileTreeSelection(command.Chrome.FileTreeSelection)
 			}
 		}
@@ -200,18 +198,17 @@ func (m *Model) putWindow(window protocol.WindowContent) {
 
 func (m *Model) applyWindowDelta(delta protocol.WindowContent) {
 	window, ok := m.windows[delta.ID]
-	if !ok {
-		m.putWindow(delta)
+	if !ok || window.ContentEpoch != delta.ContentEpoch {
 		return
 	}
 	window.CursorRow = delta.CursorRow
 	window.CursorCol = delta.CursorCol
 	window.CursorShape = delta.CursorShape
 	window.ContentEpoch = delta.ContentEpoch
-	window.ScrollLeft = delta.ScrollLeft
-	if delta.Cursorline.Visible {
-		window.Cursorline = delta.Cursorline
+	if delta.ScrollLeftSet {
+		window.ScrollLeft = delta.ScrollLeft
 	}
+	window.Cursorline = delta.Cursorline
 	if delta.SelectionSet {
 		window.Selection = delta.Selection
 		window.SelectionSet = true
@@ -237,7 +234,12 @@ func (m *Model) applyWindowDelta(delta protocol.WindowContent) {
 		window.GeometrySet = true
 	}
 	if len(delta.Rows) > 0 {
-		window.Rows = resolveWindowRows(window.Rows, delta.Rows)
+		rows, err := resolveWindowRows(window.Rows, delta.Rows)
+		if err != nil {
+			m.removeWindow(delta.ID)
+			return
+		}
+		window.Rows = rows
 	}
 	m.windows[delta.ID] = window
 	m.cursorRow = delta.CursorRow
@@ -245,7 +247,7 @@ func (m *Model) applyWindowDelta(delta protocol.WindowContent) {
 	m.cursorShape = delta.CursorShape
 }
 
-func resolveWindowRows(previous []protocol.WindowRow, delta []protocol.WindowRow) []protocol.WindowRow {
+func resolveWindowRows(previous []protocol.WindowRow, delta []protocol.WindowRow) ([]protocol.WindowRow, error) {
 	byID := make(map[uint64]protocol.WindowRow, len(previous))
 	for _, row := range previous {
 		byID[row.ID] = row
@@ -253,14 +255,29 @@ func resolveWindowRows(previous []protocol.WindowRow, delta []protocol.WindowRow
 	rows := make([]protocol.WindowRow, 0, len(delta))
 	for _, row := range delta {
 		if row.Ref {
-			if existing, ok := byID[row.ID]; ok && existing.ContentHash == row.ContentHash {
-				rows = append(rows, existing)
+			existing, ok := byID[row.ID]
+			if !ok {
+				return nil, fmt.Errorf("missing retained row ref %d", row.ID)
 			}
+			if existing.ContentHash != row.ContentHash {
+				return nil, fmt.Errorf("retained row ref %d hash mismatch", row.ID)
+			}
+			rows = append(rows, existing)
 			continue
 		}
 		rows = append(rows, row)
 	}
-	return rows
+	return rows, nil
+}
+
+func (m *Model) removeWindow(id uint16) {
+	delete(m.windows, id)
+	for index, windowID := range m.windowOrder {
+		if windowID == id {
+			m.windowOrder = append(m.windowOrder[:index], m.windowOrder[index+1:]...)
+			return
+		}
+	}
 }
 
 func (m Model) bodyHeight() int {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1,14 +1,18 @@
 package ui
 
 import (
+	"bytes"
+	"runtime"
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/cellbuf"
 	"github.com/jsmestad/minga/go/tui/internal/generated"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
+	zone "github.com/lrstanley/bubblezone"
 )
 
 func TestFooterOverlayPrioritizesPickerOverCompletionWhichKeyAndMinibuffer(t *testing.T) {
@@ -94,7 +98,8 @@ func TestWidePickerPreviewRendersBesideList(t *testing.T) {
 func TestApplyWindowDeltaResolvesRefsAndReplacesRowSnapshot(t *testing.T) {
 	model := New(80, 24, nil)
 	model.putWindow(protocol.WindowContent{
-		ID: 7,
+		ID:           7,
+		ContentEpoch: 2,
 		Rows: []protocol.WindowRow{
 			{ID: 1, ContentHash: 11, Text: "old one"},
 			{ID: 2, ContentHash: 22, Text: "old two"},
@@ -120,6 +125,36 @@ func TestApplyWindowDeltaResolvesRefsAndReplacesRowSnapshot(t *testing.T) {
 	}
 }
 
+func TestApplyWindowDeltaInvalidatesMissingRetainedRowRef(t *testing.T) {
+	model := New(80, 24, nil)
+	model.putWindow(protocol.WindowContent{ID: 7, ContentEpoch: 2, Rows: []protocol.WindowRow{{ID: 1, ContentHash: 11, Text: "old one"}}})
+	model.putWindow(protocol.WindowContent{ID: 8, ContentEpoch: 3, Rows: []protocol.WindowRow{{Text: "other"}}})
+
+	model.applyWindowDelta(protocol.WindowContent{ID: 7, ContentEpoch: 2, Rows: []protocol.WindowRow{{Ref: true, ID: 99, ContentHash: 99}}})
+
+	if _, ok := model.windows[7]; ok {
+		t.Fatalf("window with missing retained row ref should be invalidated: %+v", model.windows[7])
+	}
+	if len(model.windowOrder) != 1 || model.windowOrder[0] != 8 {
+		t.Fatalf("window order should drop invalidated window: %+v", model.windowOrder)
+	}
+}
+
+func TestApplyWindowDeltaInvalidatesHashMismatchedRetainedRowRef(t *testing.T) {
+	model := New(80, 24, nil)
+	model.putWindow(protocol.WindowContent{ID: 7, ContentEpoch: 2, Rows: []protocol.WindowRow{{ID: 1, ContentHash: 11, Text: "old one"}}})
+	model.putWindow(protocol.WindowContent{ID: 8, ContentEpoch: 3, Rows: []protocol.WindowRow{{Text: "other"}}})
+
+	model.applyWindowDelta(protocol.WindowContent{ID: 7, ContentEpoch: 2, Rows: []protocol.WindowRow{{Ref: true, ID: 1, ContentHash: 99}}})
+
+	if _, ok := model.windows[7]; ok {
+		t.Fatalf("window with hash-mismatched retained row ref should be invalidated: %+v", model.windows[7])
+	}
+	if len(model.windowOrder) != 1 || model.windowOrder[0] != 8 {
+		t.Fatalf("window order should drop invalidated window: %+v", model.windowOrder)
+	}
+}
+
 func TestCursorShapeSequenceTracksProtocolShape(t *testing.T) {
 	model := New(80, 24, nil)
 	model.cursorShape = 1
@@ -134,23 +169,35 @@ func TestCursorShapeSequenceTracksProtocolShape(t *testing.T) {
 
 func TestThemeCommandUpdatesModelPalette(t *testing.T) {
 	model := New(20, 4, nil)
-	_ = model.applyCommands([]protocol.Command{{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiTheme, Theme: protocol.Theme{Colors: map[byte]uint32{themeEditorBG: 0x010203, themePopupSelBG: 0x112233}}}}})
+	_ = model.applyCommands([]protocol.Command{{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiTheme, Theme: protocol.Theme{Colors: map[byte]uint32{themeEditorBG: 0x010203, themeSelectionBG: 0x112233}}}}})
 
 	if got := model.activePalette.colors[themeEditorBG]; got != 0x010203 {
 		t.Fatalf("editor background slot = 0x%06X, want 0x010203", got)
 	}
-	if got := model.activePalette.colors[themePopupSelBG]; got != 0x112233 {
+	if got := model.activePalette.colors[themeSelectionBG]; got != 0x112233 {
 		t.Fatalf("selection slot = 0x%06X, want 0x112233", got)
 	}
 }
 
 func TestSemanticWindowUsesThemeForSelectionOverlay(t *testing.T) {
 	model := New(20, 4, nil)
-	model.activePalette = paletteFromTheme(protocol.Theme{Colors: map[byte]uint32{themePopupSelBG: 0x112233}})
+	model.activePalette = paletteFromTheme(protocol.Theme{Colors: map[byte]uint32{themeSelectionBG: 0x112233}})
 	style := model.applyWindowOverlays(lipgloss.NewStyle(), protocol.WindowContent{Selection: protocol.Selection{Type: 1, StartRow: 0, StartCol: 1, EndRow: 0, EndCol: 3}}, 0, 1)
 
 	if style.GetBackground() != model.palette().Selection() {
 		t.Fatalf("selection overlay should use theme selection color")
+	}
+}
+
+func TestSemanticWindowUsesKindSpecificDocumentHighlightTheme(t *testing.T) {
+	model := New(20, 4, nil)
+	model.activePalette = paletteFromTheme(protocol.Theme{Colors: map[byte]uint32{themeHighlightReadBG: 0x223344, themeHighlightWriteBG: 0x334455, themeSelectionBG: 0x445566}})
+	readStyle := model.applyWindowOverlays(lipgloss.NewStyle(), protocol.WindowContent{Highlights: []protocol.DocumentHighlight{{Kind: 2, StartRow: 0, StartCol: 0, EndRow: 0, EndCol: 1}}}, 0, 0)
+	writeStyle := model.applyWindowOverlays(lipgloss.NewStyle(), protocol.WindowContent{Highlights: []protocol.DocumentHighlight{{Kind: 3, StartRow: 0, StartCol: 0, EndRow: 0, EndCol: 1}}}, 0, 0)
+	textStyle := model.applyWindowOverlays(lipgloss.NewStyle(), protocol.WindowContent{Highlights: []protocol.DocumentHighlight{{Kind: 1, StartRow: 0, StartCol: 0, EndRow: 0, EndCol: 1}}}, 0, 0)
+
+	if readStyle.GetBackground() != lipgloss.Color("#223344") || writeStyle.GetBackground() != lipgloss.Color("#334455") || textStyle.GetBackground() != lipgloss.Color("#445566") {
+		t.Fatalf("document highlight colors should be kind-specific: read=%v write=%v text=%v", readStyle.GetBackground(), writeStyle.GetBackground(), textStyle.GetBackground())
 	}
 }
 
@@ -211,15 +258,110 @@ func TestOverlayLinesRenderRemainingSemanticSurfaces(t *testing.T) {
 
 func TestSplitSeparatorsRenderOnContent(t *testing.T) {
 	model := New(24, 6, nil)
-	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiSplitSeparators: {Splits: protocol.SplitSeparators{Verticals: []protocol.VerticalSeparator{{Col: 2, StartRow: 0, EndRow: 1}}, Horizontals: []protocol.HorizontalSeparator{{Row: 1, Col: 0, Width: 16, Filename: "main.ex"}}}}}
-	styled := "\x1b[1mabcd\x1b[0m"
-	lines := model.withSplitSeparators([]string{styled, "efghijklmnop"})
-	joined := ansi.Strip(strings.Join(lines, "\n"))
-	if !strings.Contains(joined, "│") || !strings.Contains(joined, "main.ex") {
-		t.Fatalf("split separators not rendered: %q", joined)
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiSplitSeparators: {Splits: protocol.SplitSeparators{Verticals: []protocol.VerticalSeparator{{Col: 2, StartRow: 1, EndRow: 1}}}}}
+	lines := model.withSplitSeparators([]string{"\x1b[1mabcd\x1b[0m", "efgh"})
+	if !strings.Contains(lines[0], "│") {
+		t.Fatalf("vertical replacement should render on visible content: %q", lines[0])
 	}
-	if !strings.Contains(lines[0], "\x1b[") || !strings.Contains(lines[0], "\x1b[1md") {
-		t.Fatalf("vertical replacement should preserve and resume existing ANSI styling: %q", lines[0])
+	if !strings.Contains(lines[0], "\x1b[1md") {
+		t.Fatalf("vertical replacement should resume existing ANSI styling after separator: %q", lines[0])
+	}
+}
+
+func TestSplitSeparatorsRenderOnBlankRow(t *testing.T) {
+	model := New(24, 6, nil)
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiSplitSeparators: {Splits: protocol.SplitSeparators{Horizontals: []protocol.HorizontalSeparator{{Row: 1, Col: 0, Width: 16, Filename: "main.ex"}}}}}
+	lines := model.withSplitSeparators([]string{"", ""})
+	if !strings.Contains(ansi.Strip(lines[0]), "main.ex") || !strings.Contains(ansi.Strip(lines[0]), "─") {
+		t.Fatalf("horizontal separator should render on blank row: %q", lines[0])
+	}
+}
+
+func TestSplitSeparatorsNormalizeAgainstHeaderAndFileTree(t *testing.T) {
+	model := New(80, 6, nil)
+	model.title = "Header"
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Width: 24, Rows: []protocol.FileTreeRow{{ID: "row-0", Name: "row-0"}}}},
+		generated.OPGuiSplitSeparators: {Splits: protocol.SplitSeparators{
+			Verticals:   []protocol.VerticalSeparator{{Col: 24, StartRow: 1, EndRow: 2}},
+			Horizontals: []protocol.HorizontalSeparator{{Row: 2, Col: 24, Width: 2}},
+		}},
+	}
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "body-0"}, {Text: "body-1"}, {Text: "body-2"}}})
+	model.viewport.SetContent(model.content())
+
+	lines := strings.Split(ansi.Strip(model.View()), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("unexpected view lines: %+v", lines)
+	}
+	if got := strings.Index(lines[1], "│"); got != 24 {
+		t.Fatalf("vertical separator should land at visible column 24 after normalization, got %d in %q", got, lines[1])
+	}
+	if got := strings.Index(lines[2], "─"); got != 24 {
+		t.Fatalf("horizontal separator should land at visible column 24 after normalization, got %d in %q", got, lines[2])
+	}
+}
+
+func TestFileTreeWidthRespectsProtocolGeometryAndSafetyClamp(t *testing.T) {
+	if got := fileTreeWidth(80, protocol.FileTree{Width: 18}); got != 18 {
+		t.Fatalf("file tree width = %d, want narrow protocol width 18", got)
+	}
+	if got := fileTreeWidth(80, protocol.FileTree{Width: 36}); got != 36 {
+		t.Fatalf("file tree width = %d, want protocol width 36", got)
+	}
+	if got := fileTreeWidth(80, protocol.FileTree{Width: 120}); got != 79 {
+		t.Fatalf("file tree width = %d, want terminal clamp 79", got)
+	}
+}
+
+func TestFileTreeReservesVisibleEmptyState(t *testing.T) {
+	model := New(80, 6, nil)
+	model.title = "Header"
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Status: 2, Width: 18, Root: "/repo"}}}
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 18, Width: 8, Height: 1}}})
+	model.viewport.SetContent(model.content())
+
+	lines := strings.Split(ansi.Strip(model.View()), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("visible empty file tree should render reserved sidebar: %+v", lines)
+	}
+	if !strings.Contains(lines[2], "No files") {
+		t.Fatalf("empty file tree should render status row: %q", lines[2])
+	}
+	if got := strings.Index(lines[1], "pane"); got != 18 {
+		t.Fatalf("empty file tree should reserve protocol width, got pane at %d in %q", got, lines[1])
+	}
+}
+
+func TestSemanticWindowsRespectProtocolFileTreeWidth(t *testing.T) {
+	model := New(80, 6, nil)
+	model.title = "Header"
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Width: 36, Rows: []protocol.FileTreeRow{{ID: "row-0", Name: "row-0"}}}}}
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 36, Width: 8, Height: 1}}})
+	model.viewport.SetContent(model.content())
+
+	lines := strings.Split(ansi.Strip(model.View()), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("semantic window should render with file tree width alignment: %+v", lines)
+	}
+	if got := strings.Index(lines[1], "pane"); got != 36 {
+		t.Fatalf("file tree width should follow protocol geometry without a gap, got %d in %q", got, lines[1])
+	}
+}
+
+func TestApplyWindowDeltaAppliesScrollLeftSetAndCropsRendering(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{ID: 7, ContentEpoch: 9, ScrollLeft: 0, Rows: []protocol.WindowRow{{Text: "abcdef"}}})
+
+	model.applyWindowDelta(protocol.WindowContent{ID: 7, ContentEpoch: 9, ScrollLeftSet: true, ScrollLeft: 2})
+
+	window := model.windows[7]
+	if window.ScrollLeft != 2 {
+		t.Fatalf("scroll left should update from matching-epoch delta, got %d", window.ScrollLeft)
+	}
+	rendered := ansi.Strip(model.renderSemanticContentRow(window, 0, 4))
+	if !strings.HasPrefix(rendered, "cdef") {
+		t.Fatalf("cropped rendering should start at the updated scroll offset, got %q", rendered)
 	}
 }
 
@@ -330,4 +472,180 @@ func TestCellbufStyleMapsProtocolAttrs(t *testing.T) {
 	if style.UlStyle != cellbuf.SingleUnderline {
 		t.Fatalf("underline style = %v, want single underline", style.UlStyle)
 	}
+}
+
+func TestSemanticWindowsUsePaneGeometryRects(t *testing.T) {
+	model := New(24, 6, nil)
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "left"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 0, Width: 10, Height: 1}}})
+	model.putWindow(protocol.WindowContent{ID: 2, Rows: []protocol.WindowRow{{Text: "right"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 12, Width: 10, Height: 1}}})
+
+	lines := ansi.Strip(strings.Join(model.semanticLines(), "\n"))
+	first := strings.Split(lines, "\n")[0]
+	if !strings.Contains(first, "left") || !strings.Contains(first, "right") {
+		t.Fatalf("semantic windows should compose into a body canvas: %q", first)
+	}
+	if got := strings.Index(first, "right"); got != 12 {
+		t.Fatalf("right window should start at column 12, got %d in %q", got, first)
+	}
+}
+
+func TestSemanticWindowsRespectHeaderRowOffset(t *testing.T) {
+	model := New(24, 6, nil)
+	model.title = "Header"
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 0, Width: 8, Height: 1}}})
+	model.viewport.SetContent(model.content())
+
+	lines := strings.Split(ansi.Strip(model.View()), "\n")
+	if len(lines) < 2 || !strings.Contains(lines[1], "pane") {
+		t.Fatalf("semantic window should render on first body row after header: %+v", lines)
+	}
+}
+
+func TestSemanticWindowsRespectFileTreeOffset(t *testing.T) {
+	model := New(80, 6, nil)
+	model.title = "Header"
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Width: 24, Rows: []protocol.FileTreeRow{{ID: "row-0", Name: "row-0"}}}}}
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 24, Width: 8, Height: 1}}})
+	model.viewport.SetContent(model.content())
+
+	lines := strings.Split(ansi.Strip(model.View()), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("semantic window should render with file tree offset: %+v", lines)
+	}
+	if got := strings.Index(lines[1], "pane"); got != 24 {
+		t.Fatalf("file tree offset should leave pane at column 24, got %d in %q", got, lines[1])
+	}
+}
+
+func TestSemanticWindowsRespectSidebarOffset(t *testing.T) {
+	model := New(80, 6, nil)
+	model.title = "Header"
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiSidebars: {Sidebars: protocol.Sidebars{Visible: true, Items: []protocol.Sidebar{{ID: "files", DisplayName: "Files", SemanticKind: "file_tree", PreferredWidth: 18, Visible: true}}}}}
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 18, Width: 8, Height: 1}}})
+	model.viewport.SetContent(model.content())
+
+	lines := strings.Split(ansi.Strip(model.View()), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("semantic window should render with sidebar offset: %+v", lines)
+	}
+	if got := strings.Index(lines[1], "pane"); got != 18 {
+		t.Fatalf("sidebar offset should leave pane at column 18, got %d in %q", got, lines[1])
+	}
+}
+
+func TestSemanticRowsRespectScrollLeftAndIndentGuides(t *testing.T) {
+	model := New(12, 6, nil)
+	model.indentGuides[7] = protocol.IndentGuides{WindowID: 7, TabWidth: 2, GuideCols: []uint16{2}}
+	window := protocol.WindowContent{ID: 7, ScrollLeft: 2, Rows: []protocol.WindowRow{{Text: "    x"}}}
+
+	rendered := ansi.Strip(model.renderSemanticContentRow(window, 0, 8))
+	if !strings.HasPrefix(rendered, "│ ") || !strings.Contains(rendered, "x") {
+		t.Fatalf("scroll-left rendering should keep display-column guides aligned: %q", rendered)
+	}
+}
+
+func TestOverlayDeltaPreservesExistingScrollLeft(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{ID: 7, ContentEpoch: 9, ScrollLeft: 4, Rows: []protocol.WindowRow{{Text: "hello"}}})
+
+	model.applyWindowDelta(protocol.WindowContent{ID: 7, ContentEpoch: 9, CursorRow: 1, CursorCol: 2, CursorShape: 1, Cursorline: protocol.Cursorline{Visible: true, Row: 0, BG: 0x123456}})
+
+	window := model.windows[7]
+	if window.ScrollLeft != 4 {
+		t.Fatalf("overlay delta should preserve scroll left, got %d", window.ScrollLeft)
+	}
+}
+
+func TestDeltaForMissingWindowIsIgnored(t *testing.T) {
+	model := New(20, 6, nil)
+	model.applyWindowDelta(protocol.WindowContent{ID: 99, ContentEpoch: 1, CursorRow: 1, CursorCol: 2, CursorShape: 1})
+
+	if len(model.windows) != 0 {
+		t.Fatalf("missing window delta should be ignored, got %+v", model.windows)
+	}
+}
+
+func TestStaleContentEpochDeltaIsIgnored(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{ID: 7, ContentEpoch: 9, ScrollLeft: 4, CursorRow: 3, CursorCol: 4, CursorShape: 1, Rows: []protocol.WindowRow{{Text: "hello"}}})
+
+	model.applyWindowDelta(protocol.WindowContent{ID: 7, ContentEpoch: 8, CursorRow: 1, CursorCol: 2, CursorShape: 2, ScrollLeft: 0, Rows: []protocol.WindowRow{{Text: "changed"}}})
+
+	window := model.windows[7]
+	if window.ContentEpoch != 9 || window.CursorRow != 3 || window.CursorCol != 4 || window.CursorShape != 1 || window.ScrollLeft != 4 || window.Rows[0].Text != "hello" {
+		t.Fatalf("stale delta should be ignored, got %+v", window)
+	}
+}
+
+func TestSemanticDeltaClearsStaleOverlaysAndCursorline(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{
+		ID:             7,
+		ContentEpoch:   4,
+		Cursorline:     protocol.Cursorline{Visible: true, Row: 0, BG: 0x123456},
+		Selection:      protocol.Selection{Type: 1, StartRow: 0, StartCol: 0, EndRow: 0, EndCol: 1},
+		SearchSet:      true,
+		SearchMatches:  []protocol.SearchMatch{{Row: 0, StartCol: 0, EndCol: 1, Current: true}},
+		DiagnosticsSet: true,
+		Diagnostics:    []protocol.DiagnosticRange{{StartRow: 0, StartCol: 0, EndRow: 0, EndCol: 1, Severity: 0}},
+		HighlightsSet:  true,
+		Highlights:     []protocol.DocumentHighlight{{StartRow: 0, StartCol: 0, EndRow: 0, EndCol: 1, Kind: 2}},
+		AnnotationsSet: true,
+		Annotations:    []protocol.LineAnnotation{{Row: 0, Kind: 1, Text: "note"}},
+		Rows:           []protocol.WindowRow{{Text: "hello"}},
+	})
+
+	before := model.applyWindowOverlays(lipgloss.NewStyle(), model.windows[7], 0, 0)
+	model.applyWindowDelta(protocol.WindowContent{ID: 7, ContentEpoch: 4, Cursorline: protocol.Cursorline{}, SelectionSet: true, Selection: protocol.Selection{}, SearchSet: true, SearchMatches: []protocol.SearchMatch{}, DiagnosticsSet: true, Diagnostics: []protocol.DiagnosticRange{}, HighlightsSet: true, Highlights: []protocol.DocumentHighlight{}, AnnotationsSet: true, Annotations: []protocol.LineAnnotation{}})
+	window := model.windows[7]
+	if window.Cursorline.Visible || window.Selection.Type != 0 || len(window.SearchMatches) != 0 || len(window.Diagnostics) != 0 || len(window.Highlights) != 0 || len(window.Annotations) != 0 {
+		t.Fatalf("stale overlay state should be cleared by empty deltas: %+v", window)
+	}
+	if got := strings.TrimSpace(model.renderRowAnnotations(window, 0)); got != "" {
+		t.Fatalf("annotations should no longer render after clear: %q", got)
+	}
+	after := model.applyWindowOverlays(lipgloss.NewStyle(), window, 0, 0)
+	if before.GetBackground() == after.GetBackground() {
+		t.Fatalf("selection/highlight overlays should stop affecting rendering after clear: before=%v after=%v", before.GetBackground(), after.GetBackground())
+	}
+}
+
+func TestSemanticMouseRoutesModelineAndFileTreeZones(t *testing.T) {
+	model := New(60, 12, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiStatusBar: {Status: protocol.StatusBar{Left: []protocol.StatusSegment{{Text: " save ", Command: "save"}}, Right: []protocol.StatusSegment{{Text: " quit", Command: "quit"}}}},
+		generated.OPGuiFileTree:  {Tree: protocol.FileTree{Visible: true, Width: 24, Rows: []protocol.FileTreeRow{{ID: "row-0", Name: "row-0"}, {ID: "row-1", Name: "row-1"}}}},
+	}
+	model.viewport.SetContent(model.content())
+	_ = model.View()
+
+	saveZone := waitForZone(t, model, zoneIDModelineCommand("save"))
+	cmd, ok := model.semanticMousePacket(tea.MouseMsg{Button: tea.MouseButtonLeft, Action: tea.MouseActionPress, X: saveZone.StartX + 1, Y: saveZone.StartY})
+	if !ok || !bytes.Equal(cmd, protocol.EncodeGUIExecuteCommand("save")) {
+		t.Fatalf("modeline click should route execute command, ok=%v packet=%v", ok, cmd)
+	}
+	if _, ok := model.semanticMousePacket(tea.MouseMsg{Button: tea.MouseButtonRight, Action: tea.MouseActionPress, X: saveZone.StartX + 1, Y: saveZone.StartY}); ok {
+		t.Fatalf("non-left clicks should fall back")
+	}
+
+	rowZone := waitForZone(t, model, zoneIDFileTreeRow(0))
+	cmd, ok = model.semanticMousePacket(tea.MouseMsg{Button: tea.MouseButtonLeft, Action: tea.MouseActionPress, X: rowZone.StartX + 1, Y: rowZone.StartY})
+	if !ok || !bytes.Equal(cmd, protocol.EncodeGUIFileTreeClick(0)) {
+		t.Fatalf("file-tree click should route file-tree packet, ok=%v packet=%v", ok, cmd)
+	}
+	if _, ok := model.semanticMousePacket(tea.MouseMsg{Button: tea.MouseButtonLeft, Action: tea.MouseActionPress, X: rowZone.EndX + 10, Y: rowZone.EndY + 10}); ok {
+		t.Fatalf("out-of-bounds clicks should fall back")
+	}
+}
+
+func waitForZone(t *testing.T, model Model, id string) *zone.ZoneInfo {
+	t.Helper()
+	for i := 0; i < 1000; i++ {
+		if info := model.zones.Get(id); info != nil {
+			return info
+		}
+		runtime.Gosched()
+	}
+	t.Fatalf("zone %q was not registered", id)
+	return nil
 }

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/cellbuf"
 	"github.com/jsmestad/minga/go/tui/internal/generated"
@@ -131,6 +132,28 @@ func TestCursorShapeSequenceTracksProtocolShape(t *testing.T) {
 	}
 }
 
+func TestThemeCommandUpdatesModelPalette(t *testing.T) {
+	model := New(20, 4, nil)
+	_ = model.applyCommands([]protocol.Command{{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiTheme, Theme: protocol.Theme{Colors: map[byte]uint32{themeEditorBG: 0x010203, themePopupSelBG: 0x112233}}}}})
+
+	if got := model.activePalette.colors[themeEditorBG]; got != 0x010203 {
+		t.Fatalf("editor background slot = 0x%06X, want 0x010203", got)
+	}
+	if got := model.activePalette.colors[themePopupSelBG]; got != 0x112233 {
+		t.Fatalf("selection slot = 0x%06X, want 0x112233", got)
+	}
+}
+
+func TestSemanticWindowUsesThemeForSelectionOverlay(t *testing.T) {
+	model := New(20, 4, nil)
+	model.activePalette = paletteFromTheme(protocol.Theme{Colors: map[byte]uint32{themePopupSelBG: 0x112233}})
+	style := model.applyWindowOverlays(lipgloss.NewStyle(), protocol.WindowContent{Selection: protocol.Selection{Type: 1, StartRow: 0, StartCol: 1, EndRow: 0, EndCol: 3}}, 0, 1)
+
+	if style.GetBackground() != model.palette().Selection() {
+		t.Fatalf("selection overlay should use theme selection color")
+	}
+}
+
 func TestSemanticWindowRendersGutterCursorlineTildesAndModeline(t *testing.T) {
 	model := New(30, 6, nil)
 	model.gutters = map[uint16]protocol.Gutter{
@@ -170,6 +193,27 @@ func TestSemanticWindowRendersGutterCursorlineTildesAndModeline(t *testing.T) {
 	}
 	if !strings.Contains(view, " NORMAL ") || !strings.Contains(view, "1:1 Top") {
 		t.Fatalf("semantic view should render modeline segments: %q", view)
+	}
+}
+
+func TestApplyCommandsStoresIndentGuidesByWindow(t *testing.T) {
+	model := New(30, 6, nil)
+	_ = model.applyCommands([]protocol.Command{{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiIndentGuides, IndentGuides: protocol.IndentGuides{WindowID: 7, TabWidth: 2, GuideCols: []uint16{2}, IndentLevels: []byte{2}}}}})
+
+	guides, ok := model.indentGuides[7]
+	if !ok || len(guides.GuideCols) != 1 || guides.GuideCols[0] != 2 {
+		t.Fatalf("indent guides should be retained per window: %+v", model.indentGuides)
+	}
+}
+
+func TestFileTreeSelectionUpdatesExistingTree(t *testing.T) {
+	model := New(30, 6, nil)
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Rows: []protocol.FileTreeRow{{ID: "a", Name: "a"}, {ID: "b", Name: "b"}}}}}
+	model.applyFileTreeSelection(protocol.FileTreeSelection{Focused: true, SelectedID: "b"})
+
+	tree := model.chrome[generated.OPGuiFileTree].Tree
+	if tree.Selected != "b" || !tree.Focused || tree.Rows[0].Selected || !tree.Rows[1].Selected || !tree.Rows[1].Focused {
+		t.Fatalf("file tree selection not applied: %+v", tree)
 	}
 }
 

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -196,6 +196,42 @@ func TestSemanticWindowRendersGutterCursorlineTildesAndModeline(t *testing.T) {
 	}
 }
 
+func TestOverlayLinesRenderRemainingSemanticSurfaces(t *testing.T) {
+	model := New(60, 12, nil)
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentContext: {AgentContext: protocol.AgentContext{Visible: true, Task: "Review diff", Status: 1, CanApprove: true}}}
+	if got := strings.Join(model.overlayLines(), "\n"); !strings.Contains(got, "Review diff") {
+		t.Fatalf("agent context overlay missing content: %q", got)
+	}
+
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiToolManager: {ToolManager: protocol.ToolManager{Visible: true, Tools: []protocol.ToolSummary{{Name: "elixir-ls", Label: "Elixir LS", Status: 1}}}}}
+	if got := strings.Join(model.overlayLines(), "\n"); !strings.Contains(got, "Elixir LS") || !strings.Contains(got, "installed") {
+		t.Fatalf("tool manager overlay missing content: %q", got)
+	}
+}
+
+func TestSplitSeparatorsRenderOnContent(t *testing.T) {
+	model := New(24, 6, nil)
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiSplitSeparators: {Splits: protocol.SplitSeparators{Verticals: []protocol.VerticalSeparator{{Col: 2, StartRow: 0, EndRow: 1}}, Horizontals: []protocol.HorizontalSeparator{{Row: 1, Col: 0, Width: 16, Filename: "main.ex"}}}}}
+	styled := "\x1b[1mabcd\x1b[0m"
+	lines := model.withSplitSeparators([]string{styled, "efghijklmnop"})
+	joined := ansi.Strip(strings.Join(lines, "\n"))
+	if !strings.Contains(joined, "│") || !strings.Contains(joined, "main.ex") {
+		t.Fatalf("split separators not rendered: %q", joined)
+	}
+	if !strings.Contains(lines[0], "\x1b[") || !strings.Contains(lines[0], "\x1b[1md") {
+		t.Fatalf("vertical replacement should preserve and resume existing ANSI styling: %q", lines[0])
+	}
+}
+
+func TestLegacyCursorlineAppliesToCellFallback(t *testing.T) {
+	model := New(10, 4, nil)
+	model.cursorlineChrome = protocol.CursorlineChrome{Visible: true, Row: 0, BG: 0x112233}
+	lines := model.withLegacyCursorline([]string{"hello     "})
+	if len(lines) != 1 || ansi.Strip(lines[0]) == "" {
+		t.Fatalf("legacy cursorline should preserve row content: %+v", lines)
+	}
+}
+
 func TestApplyCommandsStoresIndentGuidesByWindow(t *testing.T) {
 	model := New(30, 6, nil)
 	_ = model.applyCommands([]protocol.Command{{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiIndentGuides, IndentGuides: protocol.IndentGuides{WindowID: 7, TabWidth: 2, GuideCols: []uint16{2}, IndentLevels: []byte{2}}}}})

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -131,6 +131,78 @@ func TestCursorShapeSequenceTracksProtocolShape(t *testing.T) {
 	}
 }
 
+func TestSemanticWindowRendersGutterCursorlineTildesAndModeline(t *testing.T) {
+	model := New(30, 6, nil)
+	model.gutters = map[uint16]protocol.Gutter{
+		7: {
+			WindowID:        7,
+			ContentHeight:   3,
+			CursorLine:      0,
+			LineNumberStyle: 0,
+			LineNumberWidth: 3,
+			SignColWidth:    2,
+			Entries: []protocol.GutterEntry{
+				{BufferLine: 0},
+				{BufferLine: 1},
+				{BufferLine: 2, DisplayType: 5},
+			},
+		},
+	}
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiStatusBar: {
+			Status: protocol.StatusBar{
+				Left:  []protocol.StatusSegment{{Text: " NORMAL "}},
+				Right: []protocol.StatusSegment{{Text: "1:1 Top"}},
+			},
+		},
+	}
+	model.putWindow(protocol.WindowContent{
+		ID:         7,
+		Cursorline: protocol.Cursorline{Visible: true, Row: 0, BG: 0x333333},
+		Rows:       []protocol.WindowRow{{BufferLine: 0, Text: "hello"}},
+	})
+	model.viewport.SetContent(model.content())
+
+	view := ansi.Strip(model.View())
+
+	if !strings.Contains(view, "1 hello") || !strings.Contains(view, "~") {
+		t.Fatalf("semantic view should include gutter line number, content, and tilde filler: %q", view)
+	}
+	if !strings.Contains(view, " NORMAL ") || !strings.Contains(view, "1:1 Top") {
+		t.Fatalf("semantic view should render modeline segments: %q", view)
+	}
+}
+
+func TestApplyCommandsStoresSemanticGuttersByWindow(t *testing.T) {
+	model := New(30, 6, nil)
+	_ = model.applyCommands([]protocol.Command{
+		{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiGutter, WindowGutter: protocol.Gutter{WindowID: 1, LineNumberWidth: 3, Entries: []protocol.GutterEntry{{BufferLine: 0}}}}},
+		{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiGutter, WindowGutter: protocol.Gutter{WindowID: 2, LineNumberWidth: 3, Entries: []protocol.GutterEntry{{BufferLine: 9}}}}},
+	})
+
+	first, firstOK := model.windowGutter(1)
+	second, secondOK := model.windowGutter(2)
+	if !firstOK || !secondOK || first.Entries[0].BufferLine != 0 || second.Entries[0].BufferLine != 9 {
+		t.Fatalf("gutters should be retained per window: first=%+v second=%+v", first, second)
+	}
+}
+
+func TestSemanticWindowsUsePerWindowHeights(t *testing.T) {
+	model := New(40, 8, nil)
+	model.gutters = map[uint16]protocol.Gutter{
+		1: {WindowID: 1, ContentHeight: 1, LineNumberWidth: 3, Entries: []protocol.GutterEntry{{BufferLine: 0}}},
+		2: {WindowID: 2, ContentHeight: 1, LineNumberWidth: 3, Entries: []protocol.GutterEntry{{BufferLine: 10}}},
+	}
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "first"}}})
+	model.putWindow(protocol.WindowContent{ID: 2, Rows: []protocol.WindowRow{{Text: "second"}}})
+
+	lines := model.semanticLines()
+	joined := ansi.Strip(strings.Join(lines, "\n"))
+	if len(lines) != 2 || !strings.Contains(joined, "first") || !strings.Contains(joined, "second") {
+		t.Fatalf("semantic windows should not pad the first window over later windows: lines=%d %q", len(lines), joined)
+	}
+}
+
 func TestCellLinesAdvanceByGraphemeWidth(t *testing.T) {
 	model := New(8, 5, nil)
 	model.cells[position{row: 0, col: 0}] = cell{text: "👍🏼x"}

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -9,17 +9,7 @@ import (
 )
 
 func (m Model) headerLines() []string {
-	title := m.title
-	if title == "" {
-		title = "Minga"
-	}
-	if crumb, ok := m.breadcrumb(); ok && len(crumb.Segments) > 0 {
-		title += "  " + strings.Join(crumb.Segments, " / ")
-	}
-
-	lines := []string{
-		lipgloss.NewStyle().Bold(true).Foreground(m.palette().Accent()).Background(m.palette().Surface()).Width(m.width).Render(title),
-	}
+	lines := []string{}
 	if spaces, ok := m.workspaceBar(); ok && len(spaces.Spaces) > 0 {
 		lines = append(lines, m.renderWorkspaces(spaces))
 	}
@@ -28,6 +18,16 @@ func (m Model) headerLines() []string {
 	}
 	if git, ok := m.gitStatus(); ok && git.Branch != "" {
 		lines = append(lines, m.renderGitStatus(git))
+	}
+	if len(lines) == 0 {
+		title := m.title
+		if title == "" {
+			title = "Minga"
+		}
+		if crumb, ok := m.breadcrumb(); ok && len(crumb.Segments) > 0 {
+			title += "  " + strings.Join(crumb.Segments, " / ")
+		}
+		lines = append(lines, lipgloss.NewStyle().Bold(true).Foreground(m.palette().Accent()).Background(m.palette().Surface()).Width(m.width).Render(title))
 	}
 	return lines
 }
@@ -89,10 +89,14 @@ func (m Model) renderTabs(tabBar protocol.TabBar) string {
 
 func (m Model) footerLines() []string {
 	status := fmt.Sprintf("row %d col %d", m.cursorRow+1, m.cursorCol+1)
-	if chromeStatus, ok := m.statusBar(); ok && chromeStatus.Filename != "" {
-		status = fmt.Sprintf("%s  %d:%d", chromeStatus.Filename, chromeStatus.Line, chromeStatus.Column)
-		if chromeStatus.Message != "" {
-			status += "  " + chromeStatus.Message
+	if chromeStatus, ok := m.statusBar(); ok {
+		if len(chromeStatus.Left) > 0 || len(chromeStatus.Right) > 0 {
+			status = m.renderStatusSegments(chromeStatus)
+		} else if chromeStatus.Filename != "" {
+			status = fmt.Sprintf("%s  %d:%d", chromeStatus.Filename, chromeStatus.Line, chromeStatus.Column)
+			if chromeStatus.Message != "" {
+				status += "  " + chromeStatus.Message
+			}
 		}
 	}
 	if m.lastError != "" {
@@ -105,7 +109,7 @@ func (m Model) footerLines() []string {
 		status += fmt.Sprintf("  changes %d", len(changes.Entries))
 	}
 	lines := []string{
-		lipgloss.NewStyle().Foreground(m.palette().Muted()).Background(m.palette().Base()).Width(m.width).Render(status),
+		lipgloss.NewStyle().Foreground(m.palette().Muted()).Background(m.palette().Base()).Width(m.width).Render(fitStyled(status, m.width)),
 	}
 	overlay := m.overlayLines()
 	if len(overlay) > 0 {
@@ -114,6 +118,43 @@ func (m Model) footerLines() []string {
 		lines = append(lines, m.renderMinibuffer(mini))
 	}
 	return lines
+}
+
+func (m Model) renderStatusSegments(status protocol.StatusBar) string {
+	left := m.renderSegmentList(status.Left)
+	right := m.renderSegmentList(status.Right)
+	leftWidth := lipgloss.Width(left)
+	rightWidth := lipgloss.Width(right)
+	spacer := strings.Repeat(" ", max(m.width-leftWidth-rightWidth, 1))
+	return left + lipgloss.NewStyle().Background(m.palette().Base()).Render(spacer) + right
+}
+
+func (m Model) renderSegmentList(segments []protocol.StatusSegment) string {
+	parts := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		text := segment.Text
+		if text == "" {
+			continue
+		}
+		style := lipgloss.NewStyle().Foreground(m.palette().Muted()).Background(m.palette().Base())
+		if segment.FG != 0 {
+			style = style.Foreground(lipgloss.Color(fmt.Sprintf("#%06X", segment.FG)))
+		}
+		if segment.BG != 0 {
+			style = style.Background(lipgloss.Color(fmt.Sprintf("#%06X", segment.BG)))
+		}
+		if segment.Attrs&0x01 != 0 {
+			style = style.Bold(true)
+		}
+		if segment.Attrs&0x02 != 0 {
+			style = style.Underline(true)
+		}
+		if segment.Attrs&0x04 != 0 {
+			style = style.Italic(true)
+		}
+		parts = append(parts, style.Render(text))
+	}
+	return strings.Join(parts, "")
 }
 
 func (m Model) renderGitStatus(git protocol.GitStatus) string {

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -152,7 +152,11 @@ func (m Model) renderSegmentList(segments []protocol.StatusSegment) string {
 		if segment.Attrs&0x04 != 0 {
 			style = style.Italic(true)
 		}
-		parts = append(parts, style.Render(text))
+		rendered := style.Render(text)
+		if segment.Command != "" {
+			rendered = m.zones.Mark(zoneIDModelineCommand(segment.Command), rendered)
+		}
+		parts = append(parts, rendered)
 	}
 	return strings.Join(parts, "")
 }

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -20,6 +20,12 @@ func (m Model) content() string {
 }
 
 func (m Model) semanticLines() []string {
+	if lines, ok := m.composedSemanticLines(); ok {
+		if len(lines) == 0 {
+			return nil
+		}
+		return lines
+	}
 	lines := make([]string, 0, m.bodyHeight())
 	for _, id := range m.windowOrder {
 		window := m.windows[id]
@@ -31,10 +37,149 @@ func (m Model) semanticLines() []string {
 	return lines
 }
 
+func (m Model) composedSemanticLines() ([]string, bool) {
+	segmentsByRow := map[int][]semanticLineSegment{}
+	fallback := make([]string, 0, len(m.windowOrder))
+	maxRow := 0
+	hasGeometry := false
+	for _, id := range m.windowOrder {
+		window := m.windows[id]
+		placement, ok := m.semanticWindowPlacement(window)
+		if !ok {
+			fallback = append(fallback, m.renderWindowRows(window)...)
+			continue
+		}
+		hasGeometry = true
+		rendered := m.renderWindowRows(window)
+		for rowOffset, line := range rendered {
+			row := placement.row + rowOffset
+			if row < 0 {
+				continue
+			}
+			segmentsByRow[row] = append(segmentsByRow[row], semanticLineSegment{col: placement.col, text: line})
+			maxRow = max(maxRow, row+1)
+		}
+	}
+	if !hasGeometry {
+		return fallback, false
+	}
+	headHeight := max(maxRow, m.bodyHeight())
+	lines := make([]string, headHeight)
+	for row, segments := range segmentsByRow {
+		sort.SliceStable(segments, func(i, j int) bool { return segments[i].col < segments[j].col })
+		lines[row] = composeSemanticLine(segments)
+	}
+	if len(fallback) > 0 {
+		lines = append(lines, fallback...)
+	}
+	return lines, true
+}
+
+type semanticLineSegment struct {
+	col  int
+	text string
+}
+
+type semanticWindowPlacement struct {
+	row    int
+	col    int
+	width  int
+	height int
+}
+
+func composeSemanticLine(segments []semanticLineSegment) string {
+	var builder strings.Builder
+	visibleCol := 0
+	for _, segment := range segments {
+		if segment.col > visibleCol {
+			builder.WriteString(strings.Repeat(" ", segment.col-visibleCol))
+			visibleCol = segment.col
+		}
+		builder.WriteString(segment.text)
+		visibleCol += displayWidth(xansi.Strip(segment.text))
+	}
+	return builder.String()
+}
+
+func (m Model) semanticWindowPlacement(window protocol.WindowContent) (semanticWindowPlacement, bool) {
+	if !window.GeometrySet {
+		return semanticWindowPlacement{}, false
+	}
+	rect := window.Geometry.ContentRect
+	if rect == (protocol.Rect{}) {
+		rect = window.Geometry.TotalRect
+	}
+	if rect == (protocol.Rect{}) {
+		return semanticWindowPlacement{}, false
+	}
+	row, col := m.normalizeSemanticGeometry(int(rect.Row), int(rect.Col))
+	return semanticWindowPlacement{
+		row:    row,
+		col:    col,
+		width:  int(rect.Width),
+		height: int(rect.Height),
+	}, true
+}
+
+// Protocol geometry is absolute screen geometry, while Bubble Tea renders the body after header and left chrome are already consumed.
+func (m Model) normalizeSemanticGeometry(row int, col int) (int, int) {
+	rowOffset, colOffset := m.semanticContentOffsets()
+	return row - rowOffset, col - colOffset
+}
+
+func (m Model) semanticContentOffsets() (int, int) {
+	return len(m.headerLines()), m.leftChromeWidth()
+}
+
+func (m Model) leftChromeWidth() int {
+	if tree, ok := m.fileTree(); ok && tree.Visible && tree.Width > 0 && m.width >= 50 {
+		return fileTreeWidth(m.width, tree)
+	}
+	if sidebars, ok := m.sidebars(); ok && len(sidebars.Items) > 0 && m.width >= 60 {
+		return semanticSidebarWidth(m.width, sidebars)
+	}
+	return 0
+}
+
+func fileTreeWidth(totalWidth int, tree protocol.FileTree) int {
+	desired := 24
+	if tree.Width > 0 {
+		desired = int(tree.Width)
+	}
+	maxWidth := max(totalWidth-1, 1)
+	return min(max(desired, 1), maxWidth)
+}
+
+func semanticSidebarWidth(totalWidth int, sidebars protocol.Sidebars) int {
+	visible := visibleSidebars(sidebars)
+	if len(visible) == 0 {
+		return 0
+	}
+	return min(max(int(visible[0].PreferredWidth), 18), max(totalWidth/4, 18))
+}
+
+func visibleSidebars(sidebars protocol.Sidebars) []protocol.Sidebar {
+	visible := make([]protocol.Sidebar, 0, len(sidebars.Items))
+	for _, item := range sidebars.Items {
+		if item.Visible {
+			visible = append(visible, item)
+		}
+	}
+	return visible
+}
+
 func (m Model) renderWindowRows(window protocol.WindowContent) []string {
 	gutter, hasGutter := m.windowGutter(window.ID)
 	height := len(window.Rows)
-	if window.GeometrySet && window.Geometry.ViewportRows > 0 {
+	width := m.width
+	if placement, ok := m.semanticWindowPlacement(window); ok {
+		if placement.width > 0 {
+			width = placement.width
+		}
+		if placement.height > 0 {
+			height = placement.height
+		}
+	} else if window.GeometrySet && window.Geometry.ViewportRows > 0 {
 		height = int(window.Geometry.ViewportRows)
 	} else if hasGutter && gutter.ContentHeight > 0 {
 		height = int(gutter.ContentHeight)
@@ -43,11 +188,11 @@ func (m Model) renderWindowRows(window protocol.WindowContent) []string {
 	}
 	lines := make([]string, 0, height)
 	for rowIndex := 0; rowIndex < height; rowIndex++ {
-		contentWidth := m.width
+		contentWidth := width
 		gutterText := ""
 		if hasGutter {
 			gutterText = m.renderGutterEntry(gutter, rowIndex)
-			contentWidth = max(m.width-lipgloss.Width(gutterText), 1)
+			contentWidth = max(width-lipgloss.Width(gutterText), 1)
 		}
 
 		content := m.renderSemanticContentRow(window, rowIndex, contentWidth)
@@ -79,10 +224,16 @@ func (m Model) renderRow(window protocol.WindowContent, row protocol.WindowRow, 
 	}
 
 	var builder strings.Builder
+	scrollLeft := int(window.ScrollLeft)
 	col := 0
 	for graphemes := uniseg.NewGraphemes(row.Text); graphemes.Next(); {
 		text := graphemes.Str()
 		span := spanAt(row.Spans, uint16(col))
+		spanWidth := max(displayWidth(text), 1)
+		if col+spanWidth <= scrollLeft {
+			col += spanWidth
+			continue
+		}
 		style := m.styleForEditorSpan(span)
 		if cursorline && span.BG == 0 && cursorlineBG != 0 {
 			style = style.Background(lipgloss.Color(fmt.Sprintf("#%06X", cursorlineBG)))
@@ -90,7 +241,7 @@ func (m Model) renderRow(window protocol.WindowContent, row protocol.WindowRow, 
 		style = m.applyWindowOverlays(style, window, rowIndex, col)
 		style, text = m.applyIndentGuide(window, style, rowIndex, col, text)
 		builder.WriteString(style.Render(text))
-		col += max(displayWidth(text), 1)
+		col += spanWidth
 	}
 	if annotation := m.renderRowAnnotations(window, rowIndex); annotation != "" {
 		builder.WriteString(annotation)
@@ -106,7 +257,7 @@ func (m Model) applyWindowOverlays(style lipgloss.Style, window protocol.WindowC
 	}
 	for _, highlight := range window.Highlights {
 		if rangeContains(highlight.StartRow, highlight.StartCol, highlight.EndRow, highlight.EndCol, row, column) {
-			style = style.Background(m.palette().DocumentHighlight())
+			style = style.Background(m.palette().DocumentHighlight(highlight.Kind))
 			break
 		}
 	}
@@ -277,21 +428,39 @@ func (m Model) withSplitSeparators(lines []string) []string {
 		style = style.Foreground(lipgloss.Color(fmt.Sprintf("#%06X", splits.Color)))
 	}
 	for _, vertical := range splits.Verticals {
-		for row := int(vertical.StartRow); row <= int(vertical.EndRow) && row < len(out); row++ {
-			out[row] = replaceVisibleCell(out[row], int(vertical.Col), style.Render("│"))
+		startRow, col := m.normalizeSemanticGeometry(int(vertical.StartRow), int(vertical.Col))
+		endRow, _ := m.normalizeSemanticGeometry(int(vertical.EndRow), int(vertical.Col))
+		if col < 0 || endRow < 0 {
+			continue
+		}
+		for row := max(startRow, 0); row <= endRow && row < len(out); row++ {
+			out[row] = extendVisibleWidth(out[row], col+1)
+			out[row] = replaceVisibleCell(out[row], col, style.Render("│"))
 		}
 	}
 	for _, horizontal := range splits.Horizontals {
-		row := int(horizontal.Row)
+		row, col := m.normalizeSemanticGeometry(int(horizontal.Row), int(horizontal.Col))
 		if row < 0 || row >= len(out) {
 			continue
 		}
 		text := horizontalSeparatorText(int(horizontal.Width), horizontal.Filename)
 		for offset, part := range splitGraphemes(text) {
-			out[row] = replaceVisibleCell(out[row], int(horizontal.Col)+offset, style.Render(part))
+			partWidth := max(displayWidth(part), 1)
+			out[row] = extendVisibleWidth(out[row], col+offset+partWidth)
+			out[row] = replaceVisibleCell(out[row], col+offset, style.Render(part))
 		}
 	}
 	return out
+}
+
+func extendVisibleWidth(line string, width int) string {
+	if width <= 0 {
+		return line
+	}
+	if displayWidth(xansi.Strip(line)) >= width {
+		return line
+	}
+	return fitStyled(line, width)
 }
 
 func replaceVisibleCell(line string, col int, replacement string) string {
@@ -399,11 +568,11 @@ func splitGraphemes(value string) []string {
 
 func (m Model) withFileTree(mainLines []string) []string {
 	tree, ok := m.fileTree()
-	if !ok || !tree.Visible || len(tree.Rows) == 0 || m.width < 50 {
+	if !ok || !tree.Visible || tree.Width == 0 || m.width < 50 {
 		return m.withSemanticSidebars(mainLines)
 	}
 
-	sidebarWidth := min(max(int(tree.Width), 24), max(m.width/3, 24))
+	sidebarWidth := fileTreeWidth(m.width, tree)
 	sidebar := m.renderFileTree(tree, sidebarWidth, max(len(mainLines), m.bodyHeight()))
 	lines := make([]string, max(len(mainLines), len(sidebar)))
 	for i := range lines {
@@ -425,16 +594,11 @@ func (m Model) withSemanticSidebars(mainLines []string) []string {
 	if !ok || len(sidebars.Items) == 0 || m.width < 60 {
 		return mainLines
 	}
-	visible := make([]protocol.Sidebar, 0, len(sidebars.Items))
-	for _, item := range sidebars.Items {
-		if item.Visible {
-			visible = append(visible, item)
-		}
-	}
+	visible := visibleSidebars(sidebars)
 	if len(visible) == 0 {
 		return mainLines
 	}
-	width := min(max(int(visible[0].PreferredWidth), 18), max(m.width/4, 18))
+	width := semanticSidebarWidth(m.width, sidebars)
 	theme := m.palette()
 	style := lipgloss.NewStyle().Foreground(theme.Muted()).Background(theme.Surface()).Width(width)
 	activeStyle := style.Bold(true).Foreground(theme.Text()).Background(theme.Selection())
@@ -516,6 +680,11 @@ func (m Model) renderFileTree(tree protocol.FileTree, width int, height int) []s
 	selectedStyle := style.Foreground(theme.Text()).Background(theme.TreeSelection()).Bold(true)
 	header := style.Bold(true).Foreground(theme.TreeHeaderText()).Background(theme.TreeHeader()).Render(fit("Files  "+tree.Root, width))
 	lines := []string{header}
+	if len(tree.Rows) == 0 {
+		if status := fileTreeStatusText(tree); status != "" && len(lines) < height {
+			lines = append(lines, style.Render(fit(status, width)))
+		}
+	}
 	for rowIndex, row := range tree.Rows {
 		prefix := strings.Repeat("  ", int(row.Depth))
 		marker := " "
@@ -542,6 +711,22 @@ func (m Model) renderFileTree(tree protocol.FileTree, width int, height int) []s
 		lines = append(lines, style.Render(strings.Repeat(" ", width)))
 	}
 	return lines
+}
+
+func fileTreeStatusText(tree protocol.FileTree) string {
+	switch tree.Status {
+	case 1:
+		return "Loading files..."
+	case 2:
+		return "No files"
+	case 4:
+		if strings.TrimSpace(tree.Error) != "" {
+			return tree.Error
+		}
+		return "File tree error"
+	default:
+		return ""
+	}
 }
 
 func spanAt(spans []protocol.Span, col uint16) protocol.Span {

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -14,9 +14,9 @@ import (
 
 func (m Model) content() string {
 	if len(m.windows) > 0 {
-		return strings.Join(m.fillBody(m.withFileTree(m.semanticLines())), "\n")
+		return strings.Join(m.fillBody(m.withFileTree(m.withSplitSeparators(m.semanticLines()))), "\n")
 	}
-	return strings.Join(m.fillBody(m.withFileTree(m.cellLines())), "\n")
+	return strings.Join(m.fillBody(m.withFileTree(m.withSplitSeparators(m.withLegacyCursorline(m.cellLines())))), "\n")
 }
 
 func (m Model) semanticLines() []string {
@@ -250,6 +250,151 @@ func fitStyled(value string, width int) string {
 		return value
 	}
 	return value + strings.Repeat(" ", width-visible)
+}
+
+func (m Model) withLegacyCursorline(lines []string) []string {
+	if !m.cursorlineChrome.Visible || int(m.cursorlineChrome.Row) >= len(lines) {
+		return lines
+	}
+	out := append([]string(nil), lines...)
+	style := m.editorStyle()
+	if m.cursorlineChrome.BG != 0 {
+		style = style.Background(lipgloss.Color(fmt.Sprintf("#%06X", m.cursorlineChrome.BG)))
+	}
+	row := int(m.cursorlineChrome.Row)
+	out[row] = style.Render(fitStyled(out[row], m.width))
+	return out
+}
+
+func (m Model) withSplitSeparators(lines []string) []string {
+	splits, ok := m.splitSeparators()
+	if !ok || len(lines) == 0 {
+		return lines
+	}
+	out := append([]string(nil), lines...)
+	style := lipgloss.NewStyle().Foreground(m.palette().PopupBorder()).Background(m.editorBackground())
+	if splits.Color != 0 {
+		style = style.Foreground(lipgloss.Color(fmt.Sprintf("#%06X", splits.Color)))
+	}
+	for _, vertical := range splits.Verticals {
+		for row := int(vertical.StartRow); row <= int(vertical.EndRow) && row < len(out); row++ {
+			out[row] = replaceVisibleCell(out[row], int(vertical.Col), style.Render("│"))
+		}
+	}
+	for _, horizontal := range splits.Horizontals {
+		row := int(horizontal.Row)
+		if row < 0 || row >= len(out) {
+			continue
+		}
+		text := horizontalSeparatorText(int(horizontal.Width), horizontal.Filename)
+		for offset, part := range splitGraphemes(text) {
+			out[row] = replaceVisibleCell(out[row], int(horizontal.Col)+offset, style.Render(part))
+		}
+	}
+	return out
+}
+
+func replaceVisibleCell(line string, col int, replacement string) string {
+	if col < 0 || col >= displayWidth(xansi.Strip(line)) {
+		return line
+	}
+	var builder strings.Builder
+	activeSGR := ""
+	visibleCol := 0
+	for index := 0; index < len(line); {
+		if line[index] == '\x1b' {
+			next := ansiSequenceEnd(line, index)
+			sequence := line[index:next]
+			activeSGR = updateActiveSGR(activeSGR, sequence)
+			builder.WriteString(sequence)
+			index = next
+			continue
+		}
+		graphemes := uniseg.NewGraphemes(line[index:])
+		if !graphemes.Next() {
+			break
+		}
+		text := graphemes.Str()
+		width := max(displayWidth(text), 1)
+		if visibleCol == col {
+			builder.WriteString(replacement)
+			builder.WriteString(activeSGR)
+		} else {
+			builder.WriteString(text)
+		}
+		visibleCol += width
+		index += len(text)
+	}
+	return builder.String()
+}
+
+func updateActiveSGR(active string, sequence string) string {
+	if !strings.HasSuffix(sequence, "m") {
+		return active
+	}
+	if strings.Contains(sequence, "[0m") || strings.Contains(sequence, "[m") {
+		return ""
+	}
+	return sequence
+}
+
+func ansiSequenceEnd(value string, start int) int {
+	if start+1 >= len(value) {
+		return len(value)
+	}
+	if value[start+1] == '[' {
+		for index := start + 2; index < len(value); index++ {
+			if value[index] >= 0x40 && value[index] <= 0x7E {
+				return index + 1
+			}
+		}
+		return len(value)
+	}
+	if value[start+1] == ']' {
+		for index := start + 2; index < len(value); index++ {
+			if value[index] == '\a' {
+				return index + 1
+			}
+			if value[index] == '\x1b' && index+1 < len(value) && value[index+1] == '\\' {
+				return index + 2
+			}
+		}
+		return len(value)
+	}
+	return min(start+2, len(value))
+}
+
+func horizontalSeparatorText(width int, filename string) string {
+	if width <= 0 {
+		return ""
+	}
+	line := strings.Repeat("─", width)
+	label := strings.TrimSpace(filename)
+	if label == "" || width < 4 {
+		return line
+	}
+	label = " " + label + " "
+	if displayWidth(label) > width {
+		label = fit(label, width)
+	}
+	start := max((width-displayWidth(label))/2, 0)
+	parts := splitGraphemes(line)
+	for offset, part := range splitGraphemes(label) {
+		if start+offset >= len(parts) {
+			break
+		}
+		parts[start+offset] = part
+	}
+	return strings.Join(parts, "")
+}
+
+func splitGraphemes(value string) []string {
+	parts := []string{}
+	graphemes := uniseg.NewGraphemes(value)
+	for graphemes.Next() {
+		parts = append(parts, graphemes.Str())
+	}
+	return parts
 }
 
 func (m Model) withFileTree(mainLines []string) []string {

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -34,7 +34,9 @@ func (m Model) semanticLines() []string {
 func (m Model) renderWindowRows(window protocol.WindowContent) []string {
 	gutter, hasGutter := m.windowGutter(window.ID)
 	height := len(window.Rows)
-	if hasGutter && gutter.ContentHeight > 0 {
+	if window.GeometrySet && window.Geometry.ViewportRows > 0 {
+		height = int(window.Geometry.ViewportRows)
+	} else if hasGutter && gutter.ContentHeight > 0 {
 		height = int(gutter.ContentHeight)
 	} else if len(m.windowOrder) <= 1 {
 		height = max(height, m.bodyHeight())
@@ -59,7 +61,7 @@ func (m Model) renderSemanticContentRow(window protocol.WindowContent, rowIndex 
 	if rowIndex >= len(window.Rows) {
 		return m.renderTildeRow(width, cursorline, window.Cursorline.BG)
 	}
-	return m.renderRow(window.Rows[rowIndex], width, cursorline, window.Cursorline.BG)
+	return m.renderRow(window, window.Rows[rowIndex], rowIndex, width, cursorline, window.Cursorline.BG)
 }
 
 func (m Model) renderTildeRow(width int, cursorline bool, cursorlineBG uint32) string {
@@ -70,27 +72,88 @@ func (m Model) renderTildeRow(width int, cursorline bool, cursorlineBG uint32) s
 	return style.Render(fit("~", width))
 }
 
-func (m Model) renderRow(row protocol.WindowRow, width int, cursorline bool, cursorlineBG uint32) string {
+func (m Model) renderRow(window protocol.WindowContent, row protocol.WindowRow, rowIndex int, width int, cursorline bool, cursorlineBG uint32) string {
 	base := m.editorStyle().Width(width)
 	if cursorline && cursorlineBG != 0 {
 		base = base.Background(lipgloss.Color(fmt.Sprintf("#%06X", cursorlineBG)))
 	}
-	if len(row.Spans) == 0 {
-		return base.Render(fit(row.Text, width))
-	}
 
 	var builder strings.Builder
 	col := 0
-	for _, r := range row.Text {
+	for graphemes := uniseg.NewGraphemes(row.Text); graphemes.Next(); {
+		text := graphemes.Str()
 		span := spanAt(row.Spans, uint16(col))
 		style := m.styleForEditorSpan(span)
 		if cursorline && span.BG == 0 && cursorlineBG != 0 {
 			style = style.Background(lipgloss.Color(fmt.Sprintf("#%06X", cursorlineBG)))
 		}
-		builder.WriteString(style.Render(string(r)))
-		col++
+		style = m.applyWindowOverlays(style, window, rowIndex, col)
+		style, text = m.applyIndentGuide(window, style, rowIndex, col, text)
+		builder.WriteString(style.Render(text))
+		col += max(displayWidth(text), 1)
+	}
+	if annotation := m.renderRowAnnotations(window, rowIndex); annotation != "" {
+		builder.WriteString(annotation)
 	}
 	return base.Render(fitStyled(builder.String(), width))
+}
+
+func (m Model) applyWindowOverlays(style lipgloss.Style, window protocol.WindowContent, rowIndex int, col int) lipgloss.Style {
+	row := uint16(rowIndex)
+	column := uint16(col)
+	if window.Selection.Type != 0 && rangeContains(window.Selection.StartRow, window.Selection.StartCol, window.Selection.EndRow, window.Selection.EndCol, row, column) {
+		style = style.Background(m.palette().Selection())
+	}
+	for _, highlight := range window.Highlights {
+		if rangeContains(highlight.StartRow, highlight.StartCol, highlight.EndRow, highlight.EndCol, row, column) {
+			style = style.Background(m.palette().DocumentHighlight())
+			break
+		}
+	}
+	for _, match := range window.SearchMatches {
+		if match.Row == row && column >= match.StartCol && column < match.EndCol {
+			style = style.Background(m.palette().SearchMatch(match.Current))
+			break
+		}
+	}
+	for _, diagnostic := range window.Diagnostics {
+		if rangeContains(diagnostic.StartRow, diagnostic.StartCol, diagnostic.EndRow, diagnostic.EndCol, row, column) {
+			style = style.Underline(true).Foreground(m.palette().Diagnostic(diagnostic.Severity))
+			break
+		}
+	}
+	return style
+}
+
+func (m Model) renderRowAnnotations(window protocol.WindowContent, rowIndex int) string {
+	parts := make([]string, 0, 1)
+	for _, annotation := range window.Annotations {
+		if annotation.Row != uint16(rowIndex) || annotation.Text == "" || annotation.Kind == 2 {
+			continue
+		}
+		style := lipgloss.NewStyle().Foreground(m.palette().Accent()).Background(m.editorBackground())
+		if annotation.FG != 0 {
+			style = style.Foreground(lipgloss.Color(fmt.Sprintf("#%06X", annotation.FG)))
+		}
+		if annotation.BG != 0 {
+			style = style.Background(lipgloss.Color(fmt.Sprintf("#%06X", annotation.BG)))
+		}
+		parts = append(parts, style.Render(" "+annotation.Text))
+	}
+	return strings.Join(parts, "")
+}
+
+func rangeContains(startRow uint16, startCol uint16, endRow uint16, endCol uint16, row uint16, col uint16) bool {
+	if row < startRow || row > endRow {
+		return false
+	}
+	if row == startRow && col < startCol {
+		return false
+	}
+	if row == endRow && col >= endCol {
+		return false
+	}
+	return true
 }
 
 func (m Model) cellLines() []string {
@@ -308,7 +371,7 @@ func (m Model) renderFileTree(tree protocol.FileTree, width int, height int) []s
 	selectedStyle := style.Foreground(theme.Text()).Background(theme.TreeSelection()).Bold(true)
 	header := style.Bold(true).Foreground(theme.TreeHeaderText()).Background(theme.TreeHeader()).Render(fit("Files  "+tree.Root, width))
 	lines := []string{header}
-	for _, row := range tree.Rows {
+	for rowIndex, row := range tree.Rows {
 		prefix := strings.Repeat("  ", int(row.Depth))
 		marker := " "
 		if row.Directory && row.Expanded {
@@ -321,11 +384,11 @@ func (m Model) renderFileTree(tree protocol.FileTree, width int, height int) []s
 			dirty = " *"
 		}
 		text := fit(fmt.Sprintf("%s%s %s %s%s", prefix, marker, row.Icon, row.Name, dirty), width)
+		rendered := style.Render(text)
 		if row.Selected {
-			lines = append(lines, selectedStyle.Render(text))
-		} else {
-			lines = append(lines, style.Render(text))
+			rendered = selectedStyle.Render(text)
 		}
+		lines = append(lines, m.zones.Mark(zoneIDFileTreeRow(rowIndex), rendered))
 		if len(lines) >= height {
 			return lines
 		}

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -23,9 +23,7 @@ func (m Model) semanticLines() []string {
 	lines := make([]string, 0, m.bodyHeight())
 	for _, id := range m.windowOrder {
 		window := m.windows[id]
-		for _, row := range window.Rows {
-			lines = append(lines, m.renderRow(row))
-		}
+		lines = append(lines, m.renderWindowRows(window)...)
 	}
 	if len(lines) == 0 {
 		return nil
@@ -33,9 +31,52 @@ func (m Model) semanticLines() []string {
 	return lines
 }
 
-func (m Model) renderRow(row protocol.WindowRow) string {
+func (m Model) renderWindowRows(window protocol.WindowContent) []string {
+	gutter, hasGutter := m.windowGutter(window.ID)
+	height := len(window.Rows)
+	if hasGutter && gutter.ContentHeight > 0 {
+		height = int(gutter.ContentHeight)
+	} else if len(m.windowOrder) <= 1 {
+		height = max(height, m.bodyHeight())
+	}
+	lines := make([]string, 0, height)
+	for rowIndex := 0; rowIndex < height; rowIndex++ {
+		contentWidth := m.width
+		gutterText := ""
+		if hasGutter {
+			gutterText = m.renderGutterEntry(gutter, rowIndex)
+			contentWidth = max(m.width-lipgloss.Width(gutterText), 1)
+		}
+
+		content := m.renderSemanticContentRow(window, rowIndex, contentWidth)
+		lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, gutterText, content))
+	}
+	return lines
+}
+
+func (m Model) renderSemanticContentRow(window protocol.WindowContent, rowIndex int, width int) string {
+	cursorline := window.Cursorline.Visible && rowIndex == int(window.Cursorline.Row)
+	if rowIndex >= len(window.Rows) {
+		return m.renderTildeRow(width, cursorline, window.Cursorline.BG)
+	}
+	return m.renderRow(window.Rows[rowIndex], width, cursorline, window.Cursorline.BG)
+}
+
+func (m Model) renderTildeRow(width int, cursorline bool, cursorlineBG uint32) string {
+	style := m.editorStyle().Width(width).Foreground(m.palette().Muted())
+	if cursorline && cursorlineBG != 0 {
+		style = style.Background(lipgloss.Color(fmt.Sprintf("#%06X", cursorlineBG)))
+	}
+	return style.Render(fit("~", width))
+}
+
+func (m Model) renderRow(row protocol.WindowRow, width int, cursorline bool, cursorlineBG uint32) string {
+	base := m.editorStyle().Width(width)
+	if cursorline && cursorlineBG != 0 {
+		base = base.Background(lipgloss.Color(fmt.Sprintf("#%06X", cursorlineBG)))
+	}
 	if len(row.Spans) == 0 {
-		return m.editorStyle().Render(fit(row.Text, m.width))
+		return base.Render(fit(row.Text, width))
 	}
 
 	var builder strings.Builder
@@ -43,10 +84,13 @@ func (m Model) renderRow(row protocol.WindowRow) string {
 	for _, r := range row.Text {
 		span := spanAt(row.Spans, uint16(col))
 		style := m.styleForEditorSpan(span)
+		if cursorline && span.BG == 0 && cursorlineBG != 0 {
+			style = style.Background(lipgloss.Color(fmt.Sprintf("#%06X", cursorlineBG)))
+		}
 		builder.WriteString(style.Render(string(r)))
 		col++
 	}
-	return m.editorStyle().Render(fitStyled(builder.String(), m.width))
+	return base.Render(fitStyled(builder.String(), width))
 }
 
 func (m Model) cellLines() []string {
@@ -205,6 +249,59 @@ func (m Model) withSemanticSidebars(mainLines []string) []string {
 	return lines
 }
 
+func (m Model) renderGutterEntry(gutter protocol.Gutter, rowIndex int) string {
+	width := int(gutter.SignColWidth) + max(int(gutter.LineNumberWidth)-1, 0) + 1
+	if width <= 1 {
+		return ""
+	}
+	style := lipgloss.NewStyle().Foreground(m.palette().GutterText()).Background(m.editorBackground()).Width(width)
+	if rowIndex >= len(gutter.Entries) {
+		return style.Render(strings.Repeat(" ", width))
+	}
+	entry := gutter.Entries[rowIndex]
+	if entry.BufferLine == gutter.CursorLine && gutter.LineNumberStyle != 2 {
+		style = style.Foreground(m.palette().GutterCurrentText()).Bold(true)
+	}
+	sign := m.gutterSign(entry)
+	number := m.gutterLineNumber(gutter, entry)
+	return style.Render(fit(sign+number+" ", width))
+}
+
+func (m Model) gutterLineNumber(gutter protocol.Gutter, entry protocol.GutterEntry) string {
+	width := max(int(gutter.LineNumberWidth)-1, 0)
+	if width == 0 || gutter.LineNumberStyle == 3 || entry.DisplayType == 3 || entry.DisplayType == 5 {
+		return strings.Repeat(" ", width)
+	}
+	value := int(entry.BufferLine) + 1
+	if gutter.LineNumberStyle == 2 || (gutter.LineNumberStyle == 0 && entry.BufferLine != gutter.CursorLine) {
+		value = abs(int(entry.BufferLine) - int(gutter.CursorLine))
+	}
+	text := fmt.Sprintf("%d", value)
+	if len(text) > width {
+		return text[len(text)-width:]
+	}
+	return strings.Repeat(" ", width-len(text)) + text
+}
+
+func (m Model) gutterSign(entry protocol.GutterEntry) string {
+	if entry.SignType == 8 && entry.SignText != "" {
+		return fit(entry.SignText, 2)
+	}
+	if entry.SignType == 9 {
+		return "- "
+	}
+	if entry.SignType != 0 {
+		return "│ "
+	}
+	if entry.DisplayType == 1 {
+		return "▸ "
+	}
+	if entry.DisplayType == 4 {
+		return "▾ "
+	}
+	return "  "
+}
+
 func (m Model) renderFileTree(tree protocol.FileTree, width int, height int) []string {
 	theme := m.palette()
 	style := lipgloss.NewStyle().Foreground(theme.TreeText()).Background(theme.TreeSurface()).Width(width)
@@ -260,15 +357,12 @@ func (m Model) styleForEditorSpan(span protocol.Span) lipgloss.Style {
 		style = style.Bold(true)
 	}
 	if span.Attrs&0x02 != 0 {
-		style = style.Underline(true)
-	}
-	if span.Attrs&0x04 != 0 {
 		style = style.Italic(true)
 	}
-	if span.Attrs&0x08 != 0 {
-		style = style.Reverse(true)
+	if span.Attrs&0x04 != 0 {
+		style = style.Underline(true)
 	}
-	if span.Attrs&0x10 != 0 {
+	if span.Attrs&0x08 != 0 {
 		style = style.Strikethrough(true)
 	}
 	return style

--- a/go/tui/internal/ui/render_surfaces.go
+++ b/go/tui/internal/ui/render_surfaces.go
@@ -28,8 +28,14 @@ func (m Model) overlayLines() []string {
 	if float, ok := m.floatPopup(); ok && float.Visible {
 		return m.renderFloat(float)
 	}
+	if context, ok := m.agentContext(); ok && context.Visible {
+		return m.renderAgentContext(context)
+	}
 	if chat, ok := m.agentChat(); ok && chat.Visible {
 		return m.renderAgentChat(chat)
+	}
+	if tools, ok := m.toolManager(); ok && tools.Visible {
+		return m.renderToolManager(tools)
 	}
 	if board, ok := m.board(); ok && board.Visible {
 		return m.renderBoard(board)
@@ -98,6 +104,14 @@ func (m Model) renderFloat(float protocol.FloatPopup) []string {
 	return lines
 }
 
+func (m Model) renderAgentContext(context protocol.AgentContext) []string {
+	items := []componentItem{{title: statusName(context.Status), description: context.Task}}
+	if context.CanApprove {
+		items = append(items, componentItem{title: "approval", description: "approve or request changes"})
+	}
+	return takeLines(m.charmList("Agent context", items, 0, m.maxOverlayHeight(), true), m.maxOverlayHeight())
+}
+
 func (m Model) renderAgentChat(chat protocol.AgentChat) []string {
 	style := m.panelStyle()
 	title := "Agent"
@@ -122,6 +136,33 @@ func (m Model) renderAgentChat(chat protocol.AgentChat) []string {
 		return []string{style.Bold(true).Foreground(m.palette().Accent()).Render(fit(title, m.width))}
 	}
 	return takeLines(m.charmList(title, items, len(items)-1, m.maxOverlayHeight(), true), m.maxOverlayHeight())
+}
+
+func (m Model) renderToolManager(tools protocol.ToolManager) []string {
+	items := make([]componentItem, 0, len(tools.Tools))
+	selected := min(int(tools.Selected), max(len(tools.Tools)-1, 0))
+	for _, tool := range tools.Tools {
+		items = append(items, componentItem{title: tool.Label, description: strings.TrimSpace(tool.Name + " " + toolStatusName(tool.Status))})
+	}
+	if len(items) == 0 {
+		items = append(items, componentItem{title: "No tools", description: "No matching tools"})
+	}
+	return takeLines(m.charmList("Tool manager", items, selected, m.maxOverlayHeight(), true), m.maxOverlayHeight())
+}
+
+func toolStatusName(status byte) string {
+	switch status {
+	case 1:
+		return "installed"
+	case 2:
+		return "installing"
+	case 3:
+		return "update available"
+	case 4:
+		return "failed"
+	default:
+		return "not installed"
+	}
 }
 
 func (m Model) renderBoard(board protocol.Board) []string {

--- a/go/tui/internal/ui/selectors.go
+++ b/go/tui/internal/ui/selectors.go
@@ -76,11 +76,19 @@ func (m Model) fileTree() (protocol.FileTree, bool) {
 
 func (m Model) statusBar() (protocol.StatusBar, bool) {
 	for _, payload := range m.chrome {
-		if payload.Status.Filename != "" || payload.Status.Message != "" || payload.Status.Line != 0 {
+		if payload.Status.Filename != "" || payload.Status.Message != "" || payload.Status.Line != 0 || len(payload.Status.Left) > 0 || len(payload.Status.Right) > 0 {
 			return payload.Status, true
 		}
 	}
 	return protocol.StatusBar{}, false
+}
+
+func (m Model) windowGutter(windowID uint16) (protocol.Gutter, bool) {
+	gutter, ok := m.gutters[windowID]
+	if ok && (len(gutter.Entries) > 0 || gutter.LineNumberWidth > 0 || gutter.SignColWidth > 0) {
+		return gutter, true
+	}
+	return protocol.Gutter{}, false
 }
 
 func (m Model) breadcrumb() (protocol.Breadcrumb, bool) {

--- a/go/tui/internal/ui/selectors.go
+++ b/go/tui/internal/ui/selectors.go
@@ -217,6 +217,15 @@ func (m Model) observatory() (protocol.Observatory, bool) {
 	return protocol.Observatory{}, false
 }
 
+func (m Model) agentContext() (protocol.AgentContext, bool) {
+	for _, payload := range m.chrome {
+		if payload.AgentContext.Visible || payload.AgentContext.Task != "" {
+			return payload.AgentContext, true
+		}
+	}
+	return protocol.AgentContext{}, false
+}
+
 func (m Model) agentChat() (protocol.AgentChat, bool) {
 	for _, payload := range m.chrome {
 		if payload.AgentChat.Visible {
@@ -242,4 +251,22 @@ func (m Model) editTimeline() (protocol.EditTimeline, bool) {
 		}
 	}
 	return protocol.EditTimeline{}, false
+}
+
+func (m Model) toolManager() (protocol.ToolManager, bool) {
+	for _, payload := range m.chrome {
+		if payload.ToolManager.Visible {
+			return payload.ToolManager, true
+		}
+	}
+	return protocol.ToolManager{}, false
+}
+
+func (m Model) splitSeparators() (protocol.SplitSeparators, bool) {
+	for _, payload := range m.chrome {
+		if len(payload.Splits.Verticals) > 0 || len(payload.Splits.Horizontals) > 0 {
+			return payload.Splits, true
+		}
+	}
+	return protocol.SplitSeparators{}, false
 }

--- a/go/tui/internal/ui/semantic_mouse.go
+++ b/go/tui/internal/ui/semantic_mouse.go
@@ -3,8 +3,6 @@ package ui
 import (
 	"fmt"
 	"net/url"
-	"strconv"
-	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
@@ -41,7 +39,10 @@ func (m Model) modelineMousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	if !ok {
 		return nil, false
 	}
-	for _, segment := range append(status.Left, status.Right...) {
+	segments := make([]protocol.StatusSegment, 0, len(status.Left)+len(status.Right))
+	segments = append(segments, status.Left...)
+	segments = append(segments, status.Right...)
+	for _, segment := range segments {
 		if segment.Command == "" {
 			continue
 		}
@@ -65,13 +66,4 @@ func (m Model) fileTreeMousePacket(msg tea.MouseMsg) ([]byte, bool) {
 		}
 	}
 	return nil, false
-}
-
-func parseFileTreeZoneID(id string) (int, bool) {
-	value, ok := strings.CutPrefix(id, zonePrefixFileTreeRow)
-	if !ok {
-		return 0, false
-	}
-	index, err := strconv.Atoi(value)
-	return index, err == nil
 }

--- a/go/tui/internal/ui/semantic_mouse.go
+++ b/go/tui/internal/ui/semantic_mouse.go
@@ -1,0 +1,77 @@
+package ui
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+const (
+	zonePrefixFileTreeRow     = "file-tree:row:"
+	zonePrefixModelineCommand = "modeline:command:"
+)
+
+func zoneIDFileTreeRow(index int) string {
+	return fmt.Sprintf("%s%d", zonePrefixFileTreeRow, index)
+}
+
+func zoneIDModelineCommand(command string) string {
+	return zonePrefixModelineCommand + url.QueryEscape(command)
+}
+
+func (m Model) semanticMousePacket(msg tea.MouseMsg) ([]byte, bool) {
+	if msg.Button != tea.MouseButtonLeft || msg.Action != tea.MouseActionPress {
+		return nil, false
+	}
+	if packet, ok := m.modelineMousePacket(msg); ok {
+		return packet, true
+	}
+	if packet, ok := m.fileTreeMousePacket(msg); ok {
+		return packet, true
+	}
+	return nil, false
+}
+
+func (m Model) modelineMousePacket(msg tea.MouseMsg) ([]byte, bool) {
+	status, ok := m.statusBar()
+	if !ok {
+		return nil, false
+	}
+	for _, segment := range append(status.Left, status.Right...) {
+		if segment.Command == "" {
+			continue
+		}
+		zoneInfo := m.zones.Get(zoneIDModelineCommand(segment.Command))
+		if zoneInfo != nil && zoneInfo.InBounds(msg) {
+			return protocol.EncodeGUIExecuteCommand(segment.Command), true
+		}
+	}
+	return nil, false
+}
+
+func (m Model) fileTreeMousePacket(msg tea.MouseMsg) ([]byte, bool) {
+	tree, ok := m.fileTree()
+	if !ok || !tree.Visible {
+		return nil, false
+	}
+	for index := range tree.Rows {
+		zoneInfo := m.zones.Get(zoneIDFileTreeRow(index))
+		if zoneInfo != nil && zoneInfo.InBounds(msg) {
+			return protocol.EncodeGUIFileTreeClick(uint16(index)), true
+		}
+	}
+	return nil, false
+}
+
+func parseFileTreeZoneID(id string) (int, bool) {
+	value, ok := strings.CutPrefix(id, zonePrefixFileTreeRow)
+	if !ok {
+		return 0, false
+	}
+	index, err := strconv.Atoi(value)
+	return index, err == nil
+}

--- a/go/tui/internal/ui/semantic_state.go
+++ b/go/tui/internal/ui/semantic_state.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+func (m *Model) applyFileTreeSelection(selection protocol.FileTreeSelection) {
+	payload, ok := m.chrome[generated.OPGuiFileTree]
+	if !ok || len(payload.Tree.Rows) == 0 {
+		return
+	}
+	payload.Tree.Focused = selection.Focused
+	payload.Tree.Selected = selection.SelectedID
+	for i := range payload.Tree.Rows {
+		selected := payload.Tree.Rows[i].ID == selection.SelectedID
+		payload.Tree.Rows[i].Selected = selected
+		payload.Tree.Rows[i].Focused = selected && selection.Focused
+	}
+	m.chrome[generated.OPGuiFileTree] = payload
+}
+
+func (m Model) applyIndentGuide(window protocol.WindowContent, style lipgloss.Style, rowIndex int, col int, text string) (lipgloss.Style, string) {
+	guides, ok := m.indentGuides[window.ID]
+	if !ok || text != " " || !guideColumnVisible(guides, col) || !guideEnabledOnRow(guides, rowIndex, col) {
+		return style, text
+	}
+	guideStyle := style.Foreground(m.palette().GutterText())
+	if uint16(col) == guides.ActiveGuideCol {
+		guideStyle = guideStyle.Foreground(m.palette().Accent()).Bold(true)
+	}
+	return guideStyle, "│"
+}
+
+func guideColumnVisible(guides protocol.IndentGuides, col int) bool {
+	for _, guideCol := range guides.GuideCols {
+		if int(guideCol) == col {
+			return true
+		}
+	}
+	return false
+}
+
+func guideEnabledOnRow(guides protocol.IndentGuides, rowIndex int, col int) bool {
+	if len(guides.IndentLevels) == 0 || rowIndex >= len(guides.IndentLevels) || guides.TabWidth == 0 {
+		return true
+	}
+	return int(guides.IndentLevels[rowIndex]) > col/int(guides.TabWidth)
+}
+
+func isWhitespace(value string) bool {
+	return strings.TrimSpace(value) == ""
+}

--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -32,20 +32,55 @@ const (
 	themeAccent          byte = 0x40
 	themeGutterFG        byte = 0x50
 	themeGutterCurrentFG byte = 0x51
+	themeDiagnosticError byte = 0x52
 	themeWarningFG       byte = 0x53
+	themeDiagnosticInfo  byte = 0x54
+	themeDiagnosticHint  byte = 0x55
 )
 
 type palette struct {
 	colors map[byte]uint32
 }
 
-func paletteFrom(chrome map[byte]protocol.ChromePayload) palette {
-	for _, payload := range chrome {
-		if payload.Theme.Colors != nil {
-			return palette{colors: payload.Theme.Colors}
-		}
+func defaultPalette() palette {
+	return palette{colors: map[byte]uint32{
+		themeEditorBG:        0x282C34,
+		themeEditorFG:        0xBBC2CF,
+		themeTreeBG:          0x21242B,
+		themeTreeFG:          0xBBC2CF,
+		themeTreeSelectBG:    0x3E4451,
+		themeTreeHeaderBG:    0x282C34,
+		themeTreeHeaderFG:    0xBBC2CF,
+		themeTabBG:           0x282C34,
+		themeTabActiveBG:     0x3E4451,
+		themeTabActiveFG:     0xFFFFFF,
+		themeTabInactiveFG:   0x5B6268,
+		themeTabModifiedFG:   0xFF6C6B,
+		themeTabAttentionFG:  0xECBE7B,
+		themePopupBG:         0x21242B,
+		themePopupFG:         0xBBC2CF,
+		themePopupBorder:     0x5B6268,
+		themePopupSelBG:      0x3E4451,
+		themePopupSelFG:      0xFFFFFF,
+		themeBreadcrumbBG:    0x21242B,
+		themeModelineBG:      0x22252D,
+		themeModelineFG:      0xBBC2CF,
+		themeAccent:          0x51AFEF,
+		themeGutterFG:        0x5B6268,
+		themeGutterCurrentFG: 0xBBC2CF,
+		themeDiagnosticError: 0xFF6C6B,
+		themeWarningFG:       0xECBE7B,
+		themeDiagnosticInfo:  0x51AFEF,
+		themeDiagnosticHint:  0x98BE65,
+	}}
+}
+
+func paletteFromTheme(theme protocol.Theme) palette {
+	base := defaultPalette()
+	for slot, rgb := range theme.Colors {
+		base.colors[slot] = rgb
 	}
-	return palette{}
+	return base
 }
 
 func (p palette) Base() lipgloss.TerminalColor {
@@ -82,6 +117,32 @@ func (p palette) Selection() lipgloss.TerminalColor {
 
 func (p palette) SelectionText() lipgloss.TerminalColor {
 	return p.slot(themePopupSelFG)
+}
+
+func (p palette) SearchMatch(current bool) lipgloss.TerminalColor {
+	if current {
+		return p.slot(themeTreeSelectBG)
+	}
+	return p.slot(themeBreadcrumbBG)
+}
+
+func (p palette) DocumentHighlight() lipgloss.TerminalColor {
+	return p.slot(themePopupBorder)
+}
+
+func (p palette) Diagnostic(severity byte) lipgloss.TerminalColor {
+	switch severity {
+	case 0:
+		return p.slot(themeDiagnosticError)
+	case 1:
+		return p.slot(themeWarningFG)
+	case 2:
+		return p.slot(themeDiagnosticInfo)
+	case 3:
+		return p.slot(themeDiagnosticHint)
+	default:
+		return p.slot(themeWarningFG)
+	}
 }
 
 func (p palette) Warning() lipgloss.TerminalColor {
@@ -149,16 +210,14 @@ func (p palette) PopupBorder() lipgloss.TerminalColor {
 }
 
 func (p palette) slot(slot byte) lipgloss.TerminalColor {
-	if p.colors != nil {
-		if rgb, ok := p.colors[slot]; ok {
-			return lipgloss.Color(fmt.Sprintf("#%06X", rgb))
-		}
+	if rgb, ok := p.colors[slot]; ok {
+		return lipgloss.Color(fmt.Sprintf("#%06X", rgb))
 	}
 	return lipgloss.NoColor{}
 }
 
 func (m Model) palette() palette {
-	return paletteFrom(m.chrome)
+	return m.activePalette
 }
 
 func (m Model) editorBackground() lipgloss.TerminalColor {

--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -8,34 +8,37 @@ import (
 )
 
 const (
-	themeEditorBG        byte = 0x01
-	themeEditorFG        byte = 0x02
-	themeTreeBG          byte = 0x03
-	themeTreeFG          byte = 0x04
-	themeTreeSelectBG    byte = 0x05
-	themeTreeHeaderBG    byte = 0x08
-	themeTreeHeaderFG    byte = 0x09
-	themeTabBG           byte = 0x10
-	themeTabActiveBG     byte = 0x11
-	themeTabActiveFG     byte = 0x12
-	themeTabInactiveFG   byte = 0x13
-	themeTabModifiedFG   byte = 0x14
-	themeTabAttentionFG  byte = 0x17
-	themePopupBG         byte = 0x20
-	themePopupFG         byte = 0x21
-	themePopupBorder     byte = 0x22
-	themePopupSelBG      byte = 0x23
-	themePopupSelFG      byte = 0x2A
-	themeBreadcrumbBG    byte = 0x27
-	themeModelineBG      byte = 0x30
-	themeModelineFG      byte = 0x31
-	themeAccent          byte = 0x40
-	themeGutterFG        byte = 0x50
-	themeGutterCurrentFG byte = 0x51
-	themeDiagnosticError byte = 0x52
-	themeWarningFG       byte = 0x53
-	themeDiagnosticInfo  byte = 0x54
-	themeDiagnosticHint  byte = 0x55
+	themeEditorBG         byte = 0x01
+	themeEditorFG         byte = 0x02
+	themeTreeBG           byte = 0x03
+	themeTreeFG           byte = 0x04
+	themeTreeSelectBG     byte = 0x05
+	themeTreeHeaderBG     byte = 0x08
+	themeTreeHeaderFG     byte = 0x09
+	themeTabBG            byte = 0x10
+	themeTabActiveBG      byte = 0x11
+	themeTabActiveFG      byte = 0x12
+	themeTabInactiveFG    byte = 0x13
+	themeTabModifiedFG    byte = 0x14
+	themeTabAttentionFG   byte = 0x17
+	themePopupBG          byte = 0x20
+	themePopupFG          byte = 0x21
+	themePopupBorder      byte = 0x22
+	themePopupSelBG       byte = 0x23
+	themePopupSelFG       byte = 0x2A
+	themeBreadcrumbBG     byte = 0x27
+	themeHighlightReadBG  byte = 0x59
+	themeHighlightWriteBG byte = 0x5A
+	themeSelectionBG      byte = 0x5B
+	themeModelineBG       byte = 0x30
+	themeModelineFG       byte = 0x31
+	themeAccent           byte = 0x40
+	themeGutterFG         byte = 0x50
+	themeGutterCurrentFG  byte = 0x51
+	themeDiagnosticError  byte = 0x52
+	themeWarningFG        byte = 0x53
+	themeDiagnosticInfo   byte = 0x54
+	themeDiagnosticHint   byte = 0x55
 )
 
 type palette struct {
@@ -44,34 +47,37 @@ type palette struct {
 
 func defaultPalette() palette {
 	return palette{colors: map[byte]uint32{
-		themeEditorBG:        0x282C34,
-		themeEditorFG:        0xBBC2CF,
-		themeTreeBG:          0x21242B,
-		themeTreeFG:          0xBBC2CF,
-		themeTreeSelectBG:    0x3E4451,
-		themeTreeHeaderBG:    0x282C34,
-		themeTreeHeaderFG:    0xBBC2CF,
-		themeTabBG:           0x282C34,
-		themeTabActiveBG:     0x3E4451,
-		themeTabActiveFG:     0xFFFFFF,
-		themeTabInactiveFG:   0x5B6268,
-		themeTabModifiedFG:   0xFF6C6B,
-		themeTabAttentionFG:  0xECBE7B,
-		themePopupBG:         0x21242B,
-		themePopupFG:         0xBBC2CF,
-		themePopupBorder:     0x5B6268,
-		themePopupSelBG:      0x3E4451,
-		themePopupSelFG:      0xFFFFFF,
-		themeBreadcrumbBG:    0x21242B,
-		themeModelineBG:      0x22252D,
-		themeModelineFG:      0xBBC2CF,
-		themeAccent:          0x51AFEF,
-		themeGutterFG:        0x5B6268,
-		themeGutterCurrentFG: 0xBBC2CF,
-		themeDiagnosticError: 0xFF6C6B,
-		themeWarningFG:       0xECBE7B,
-		themeDiagnosticInfo:  0x51AFEF,
-		themeDiagnosticHint:  0x98BE65,
+		themeEditorBG:         0x282C34,
+		themeEditorFG:         0xBBC2CF,
+		themeTreeBG:           0x21242B,
+		themeTreeFG:           0xBBC2CF,
+		themeTreeSelectBG:     0x3E4451,
+		themeTreeHeaderBG:     0x282C34,
+		themeTreeHeaderFG:     0xBBC2CF,
+		themeTabBG:            0x282C34,
+		themeTabActiveBG:      0x3E4451,
+		themeTabActiveFG:      0xFFFFFF,
+		themeTabInactiveFG:    0x5B6268,
+		themeTabModifiedFG:    0xFF6C6B,
+		themeTabAttentionFG:   0xECBE7B,
+		themePopupBG:          0x21242B,
+		themePopupFG:          0xBBC2CF,
+		themePopupBorder:      0x5B6268,
+		themePopupSelBG:       0x3E4451,
+		themePopupSelFG:       0xFFFFFF,
+		themeBreadcrumbBG:     0x21242B,
+		themeModelineBG:       0x22252D,
+		themeModelineFG:       0xBBC2CF,
+		themeAccent:           0x51AFEF,
+		themeGutterFG:         0x5B6268,
+		themeGutterCurrentFG:  0xBBC2CF,
+		themeDiagnosticError:  0xFF6C6B,
+		themeWarningFG:        0xECBE7B,
+		themeDiagnosticInfo:   0x51AFEF,
+		themeDiagnosticHint:   0x98BE65,
+		themeHighlightReadBG:  0x3A3F4B,
+		themeHighlightWriteBG: 0x4A3F2B,
+		themeSelectionBG:      0x264F78,
 	}}
 }
 
@@ -112,7 +118,7 @@ func (p palette) Accent() lipgloss.TerminalColor {
 }
 
 func (p palette) Selection() lipgloss.TerminalColor {
-	return p.slot(themePopupSelBG)
+	return p.slot(themeSelectionBG)
 }
 
 func (p palette) SelectionText() lipgloss.TerminalColor {
@@ -126,8 +132,15 @@ func (p palette) SearchMatch(current bool) lipgloss.TerminalColor {
 	return p.slot(themeBreadcrumbBG)
 }
 
-func (p palette) DocumentHighlight() lipgloss.TerminalColor {
-	return p.slot(themePopupBorder)
+func (p palette) DocumentHighlight(kind byte) lipgloss.TerminalColor {
+	switch kind {
+	case 3:
+		return p.slot(themeHighlightWriteBG)
+	case 2:
+		return p.slot(themeHighlightReadBG)
+	default:
+		return p.slot(themeSelectionBG)
+	}
 }
 
 func (p palette) Diagnostic(severity byte) lipgloss.TerminalColor {

--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -8,29 +8,31 @@ import (
 )
 
 const (
-	themeEditorBG       byte = 0x01
-	themeEditorFG       byte = 0x02
-	themeTreeBG         byte = 0x03
-	themeTreeFG         byte = 0x04
-	themeTreeSelectBG   byte = 0x05
-	themeTreeHeaderBG   byte = 0x08
-	themeTreeHeaderFG   byte = 0x09
-	themeTabBG          byte = 0x10
-	themeTabActiveBG    byte = 0x11
-	themeTabActiveFG    byte = 0x12
-	themeTabInactiveFG  byte = 0x13
-	themeTabModifiedFG  byte = 0x14
-	themeTabAttentionFG byte = 0x17
-	themePopupBG        byte = 0x20
-	themePopupFG        byte = 0x21
-	themePopupBorder    byte = 0x22
-	themePopupSelBG     byte = 0x23
-	themePopupSelFG     byte = 0x2A
-	themeBreadcrumbBG   byte = 0x27
-	themeModelineBG     byte = 0x30
-	themeModelineFG     byte = 0x31
-	themeAccent         byte = 0x40
-	themeWarningFG      byte = 0x53
+	themeEditorBG        byte = 0x01
+	themeEditorFG        byte = 0x02
+	themeTreeBG          byte = 0x03
+	themeTreeFG          byte = 0x04
+	themeTreeSelectBG    byte = 0x05
+	themeTreeHeaderBG    byte = 0x08
+	themeTreeHeaderFG    byte = 0x09
+	themeTabBG           byte = 0x10
+	themeTabActiveBG     byte = 0x11
+	themeTabActiveFG     byte = 0x12
+	themeTabInactiveFG   byte = 0x13
+	themeTabModifiedFG   byte = 0x14
+	themeTabAttentionFG  byte = 0x17
+	themePopupBG         byte = 0x20
+	themePopupFG         byte = 0x21
+	themePopupBorder     byte = 0x22
+	themePopupSelBG      byte = 0x23
+	themePopupSelFG      byte = 0x2A
+	themeBreadcrumbBG    byte = 0x27
+	themeModelineBG      byte = 0x30
+	themeModelineFG      byte = 0x31
+	themeAccent          byte = 0x40
+	themeGutterFG        byte = 0x50
+	themeGutterCurrentFG byte = 0x51
+	themeWarningFG       byte = 0x53
 )
 
 type palette struct {
@@ -84,6 +86,14 @@ func (p palette) SelectionText() lipgloss.TerminalColor {
 
 func (p palette) Warning() lipgloss.TerminalColor {
 	return p.slot(themeWarningFG)
+}
+
+func (p palette) GutterText() lipgloss.TerminalColor {
+	return p.slot(themeGutterFG)
+}
+
+func (p palette) GutterCurrentText() lipgloss.TerminalColor {
+	return p.slot(themeGutterCurrentFG)
 }
 
 func (p palette) TreeSurface() lipgloss.TerminalColor {

--- a/go/tui/internal/ui/util.go
+++ b/go/tui/internal/ui/util.go
@@ -95,6 +95,13 @@ func min(a, b int) int {
 	return b
 }
 
+func abs(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
 func fit(value string, width int) string {
 	if width <= 0 {
 		return ""


### PR DESCRIPTION
# TL;DR
`bin/minga-go` now renders the missing Semantic UI pieces instead of falling back to legacy cell-grid output. The Go Bubble Tea renderer decodes, stores, renders, or explicitly no-ops every current semantic/chrome payload so it better reflects the intended semantic TUI path.

## Context
The Go TUI was already trying to live in the semantic future, but several semantic payloads were not decoded, stored, or rendered yet. That made it look almost empty compared with the default TUI and the Rust renderer, which still benefits from a framebuffer-style compatibility layer.

## Changes
- Decode `gui_gutter` into per-window gutter state keyed by `window_id`.
- Decode cursorline data from `gui_window_content`, overlay cursorline deltas, and legacy cursorline chrome.
- Decode status bar `ModelineSegments` and render left/right semantic modeline segments.
- Decode and render semantic window overlays: selection, search matches, diagnostics, document highlights, annotations, and pane geometry height hints.
- Store `Minga.Theme` as first-class renderer state and use theme slots for semantic styling fallbacks.
- Decode remaining semantic/no-op state: indent guides, line spacing, file tree selection, cursor animation, config state, and tool manager.
- Render semantic indent guides, split separators, legacy cursorline fallback, agent context, tool manager, and file-tree selection deltas.
- Normalize semantic geometry from absolute protocol coordinates into Bubble Tea body/sidebar coordinates.
- Preserve retained window invariants: stale or unresolved row deltas invalidate retained state instead of rendering partial rows.
- Respect `scroll_left` and preserve it across overlay-only deltas.
- Use `bubblezone` to attach mouse hit zones to rendered semantic modeline segments and file tree rows, then send `gui_action` packets for command/file-tree clicks.
- Avoid adding the generic title header when semantic workspace/tab chrome is already present.
- Fix semantic editor span attribute mapping to match the documented `gui_window_content` bits.
- Add regression coverage and a semantic opcode guardrail so every generated semantic opcode is decoded and classified as rendered, stateful, or intentionally TUI no-op.

## Verification
- `cd go/tui && go test ./...` passed, 133 tests.
- `cd macos && xcodebuild test -scheme Minga -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO` passed.
- `git diff --check` passed.
- Targeted review of CI and PR-feedback fixes found no remaining blockers.

## Notes for reviewers
This intentionally keeps Go semantic-first. It does not restore the temporary legacy-cell fallback, because the goal is to finish the missing Semantic UI path rather than hide migration gaps.

The previous Swift CI failure was on the older pushed commit. The current branch passes the CI-equivalent Swift test locally, including the `OP_SET_LANGUAGE` skip path.