### PR TITLE
fix(protocol): use generated command sizing in frontends

### DIFF
--- a/lib/mix/tasks/swift_harness.ex
+++ b/lib/mix/tasks/swift_harness.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Swift.Harness do
 
     sources = [
       "macos/.generated/protocol/ProtocolOpcodes.generated.swift",
+      "macos/.generated/protocol/ProtocolCommandSize.generated.swift",
       "macos/Sources/Protocol/ProtocolConstants.swift",
       "macos/Sources/Protocol/ProtocolTypes.swift",
       "macos/Sources/Protocol/ProtocolDecoder.swift",

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -256,6 +256,29 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         throw ProtocolDecodeError.insufficientData
     }
 
+    let payload = Array(data[offset...])
+    switch commandSize(payload) {
+    case .sized(let size):
+        do {
+            let (command, _) = try decodeCommandForRendering(data: data, offset: offset)
+            return (command, size)
+        } catch ProtocolDecodeError.unknownOpcode(_) {
+            return (nil, size)
+        }
+    case .custom:
+        return try decodeCommandForRendering(data: data, offset: offset)
+    case .incomplete:
+        throw ProtocolDecodeError.insufficientData
+    case .unknown:
+        throw ProtocolDecodeError.unknownOpcode(data[offset])
+    }
+}
+
+private func decodeCommandForRendering(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
+    guard offset < data.count else {
+        throw ProtocolDecodeError.insufficientData
+    }
+
     let opcode = data[offset]
     let rest = offset + 1
 

--- a/macos/Tests/MingaTests/ProtocolCommandSizeTests.swift
+++ b/macos/Tests/MingaTests/ProtocolCommandSizeTests.swift
@@ -41,6 +41,10 @@ struct ProtocolCommandSizeTests {
             commands.append(command)
         }
 
-        #expect(commands == [.batchEnd])
+        #expect(commands.count == 1)
+        guard case .batchEnd = commands.first else {
+            Issue.record("Expected .batchEnd but got \(String(describing: commands.first))")
+            return
+        }
     }
 }

--- a/macos/Tests/MingaTests/ProtocolCommandSizeTests.swift
+++ b/macos/Tests/MingaTests/ProtocolCommandSizeTests.swift
@@ -5,6 +5,7 @@
 /// the regression that desynced the Go renderer when an opcode was sized by
 /// guesswork instead of its declared framing.
 
+import Foundation
 import Testing
 
 struct ProtocolCommandSizeTests {
@@ -30,5 +31,16 @@ struct ProtocolCommandSizeTests {
     @Test func reportsTruncatedPayload() {
         #expect(commandSize([OP_GUI_INDENT_GUIDES, 0x00]) == .incomplete)
         #expect(commandSize([]) == .incomplete)
+    }
+
+    @Test func decodeCommandsSkipsGeneratedSizedUnrenderedOpcode() throws {
+        let payload = Data([0xB7, 0x00, 0x02, 0xAA, 0xBB, OP_BATCH_END])
+        var commands: [RenderCommand] = []
+
+        try decodeCommands(from: payload) { command in
+            commands.append(command)
+        }
+
+        #expect(commands == [.batchEnd])
     }
 }

--- a/rust/tui/src/main.rs
+++ b/rust/tui/src/main.rs
@@ -188,10 +188,7 @@ fn handle_packet(
         let command_size = match protocol::command_byte_size(&packet[offset..]) {
             Ok(size) => size,
             Err(error) => {
-                log_warn(
-                    output,
-                    &format!("protocol size error at {offset}: {error}"),
-                );
+                log_warn(output, &format!("protocol size error at {offset}: {error}"));
                 break;
             }
         };

--- a/rust/tui/src/main.rs
+++ b/rust/tui/src/main.rs
@@ -185,6 +185,17 @@ fn handle_packet(
     let mut offset = 0;
 
     while offset < packet.len() {
+        let command_size = match protocol::command_byte_size(&packet[offset..]) {
+            Ok(size) => size,
+            Err(error) => {
+                log_warn(
+                    output,
+                    &format!("protocol size error at {offset}: {error}"),
+                );
+                break;
+            }
+        };
+
         let command = match protocol::decode_command(&packet[offset..]) {
             Ok(command) => command,
             Err(error) => {
@@ -196,7 +207,7 @@ fn handle_packet(
             }
         };
 
-        offset += command.size();
+        offset += command_size;
 
         if let Err(error) = renderer.handle(command, terminal, output) {
             log_warn(output, &format!("render error: {error}"));

--- a/rust/tui/src/protocol.rs
+++ b/rust/tui/src/protocol.rs
@@ -17,6 +17,7 @@ pub mod command_size {
 }
 
 use crate::semantic;
+use command_size::CommandSize;
 use std::fmt;
 use std::io::{self, Write};
 
@@ -57,22 +58,41 @@ pub enum Command {
 }
 
 impl Command {
-    pub fn size(&self) -> usize {
+    pub fn custom_size(&self) -> usize {
         match self {
-            Self::Clear | Self::BatchEnd => 1,
             Self::DrawText(draw) => 14 + draw.text.len(),
             Self::DrawStyledText(draw) => 21 + draw.text.len(),
-            Self::SetCursor { .. } => 5,
-            Self::SetCursorShape(_) => 2,
-            Self::SetTitle(title) => 3 + title.len(),
-            Self::SetWindowBg(_) => 4,
-            Self::DefineRegion(_) => 15,
-            Self::ClearRegion(_) | Self::DestroyRegion(_) | Self::SetActiveRegion(_) => 3,
-            Self::ScrollRegion { .. } => 7,
             Self::MeasureText { text, .. } => 7 + text.len(),
-            Self::Semantic(command) => command.size(),
+            Self::Semantic(command) => command.custom_size(),
             Self::Noop(size) => *size,
+            Self::Clear
+            | Self::BatchEnd
+            | Self::SetCursor { .. }
+            | Self::SetCursorShape(_)
+            | Self::SetTitle(_)
+            | Self::SetWindowBg(_)
+            | Self::DefineRegion(_)
+            | Self::ClearRegion(_)
+            | Self::DestroyRegion(_)
+            | Self::SetActiveRegion(_)
+            | Self::ScrollRegion { .. } => 0,
         }
+    }
+}
+
+pub fn command_byte_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    match generated_command_byte_size(bytes)? {
+        Some(size) => Ok(size),
+        None => decode_command(bytes).map(|command| command.custom_size()),
+    }
+}
+
+fn generated_command_byte_size(bytes: &[u8]) -> Result<Option<usize>, DecodeError> {
+    match command_size::command_size(bytes) {
+        CommandSize::Sized(size) => Ok(Some(size)),
+        CommandSize::Custom => Ok(None),
+        CommandSize::Incomplete => Err(DecodeError::Malformed("incomplete command")),
+        CommandSize::Unknown => Ok(None),
     }
 }
 
@@ -217,7 +237,14 @@ pub fn decode_command(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_SET_FONT => skip_len_at(bytes, 5),
         opcodes::OP_SET_FONT_FALLBACK => skip_font_fallback(bytes),
         opcodes::OP_REGISTER_FONT => skip_len_at(bytes, 2),
-        _ if opcode >= 0x70 => semantic::decode(bytes).map(Command::Semantic),
+        _ if opcode >= 0x70 => match semantic::decode(bytes) {
+            Ok(command) => Ok(Command::Semantic(command)),
+            Err(DecodeError::UnknownOpcode(_)) => match generated_command_byte_size(bytes)? {
+                Some(size) => Ok(Command::Noop(size)),
+                None => Err(DecodeError::UnknownOpcode(opcode)),
+            },
+            Err(error) => Err(error),
+        },
         _ => Err(DecodeError::UnknownOpcode(opcode)),
     }
 }
@@ -480,7 +507,7 @@ mod tests {
                 text: "hi".to_owned(),
             })
         );
-        assert_eq!(command.size(), bytes.len());
+        assert_eq!(command_byte_size(&bytes).unwrap(), bytes.len());
     }
 
     #[test]
@@ -520,7 +547,7 @@ mod tests {
         ];
         let command = decode_command(&bytes).unwrap();
 
-        assert_eq!(command.size(), bytes.len());
+        assert_eq!(command_byte_size(&bytes).unwrap(), bytes.len());
         assert!(
             matches!(command, Command::DrawStyledText(DrawStyledText { font_id: 7, text, .. }) if text == "hi")
         );
@@ -547,7 +574,7 @@ mod tests {
         ];
         let command = decode_command(&bytes).unwrap();
 
-        assert_eq!(command.size(), bytes.len());
+        assert_eq!(command_byte_size(&bytes).unwrap(), bytes.len());
         assert!(matches!(
             command,
             Command::DefineRegion(Region {
@@ -586,12 +613,10 @@ mod tests {
         .concat();
         let command = decode_command(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        let size = command_byte_size(&packet).unwrap();
+        assert_eq!(size, packet.len() - 1);
         assert!(matches!(command, Command::Noop(_)));
-        assert_eq!(
-            decode_command(&packet[command.size()..]).unwrap(),
-            Command::BatchEnd
-        );
+        assert_eq!(decode_command(&packet[size..]).unwrap(), Command::BatchEnd);
     }
 
     #[test]
@@ -606,24 +631,32 @@ mod tests {
         .concat();
         let command = decode_command(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        let size = command_byte_size(&packet).unwrap();
+        assert_eq!(size, packet.len() - 1);
         assert!(matches!(command, Command::Noop(_)));
-        assert_eq!(
-            decode_command(&packet[command.size()..]).unwrap(),
-            Command::BatchEnd
-        );
+        assert_eq!(decode_command(&packet[size..]).unwrap(), Command::BatchEnd);
+    }
+
+    #[test]
+    fn skips_generated_sized_unrendered_opcode_without_consuming_following_commands() {
+        let packet = [vec![0xB7, 0, 2, 0xAA, 0xBB], vec![opcodes::OP_BATCH_END]].concat();
+        let command = decode_command(&packet).unwrap();
+
+        let size = command_byte_size(&packet).unwrap();
+        assert_eq!(size, packet.len() - 1);
+        assert!(matches!(command, Command::Noop(_)));
+        assert_eq!(decode_command(&packet[size..]).unwrap(), Command::BatchEnd);
     }
 }
 
 #[cfg(test)]
 mod command_size_conformance {
     use super::command_size::{CommandSize, command_size};
-    use super::{decode_command, opcodes};
+    use super::{command_byte_size, decode_command, opcodes};
 
-    // Each case is a fully framed command. We assert the schema-generated
-    // command_size agrees with the hand-written decoder's consumed size, so the
-    // generated sizer can never drift from the real wire format. The
-    // indent_guides (0x91) case is the regression that desynced the Go reader.
+    // Each case is a fully framed command. The generated command_size is the
+    // reader's authority for schema-framed opcodes. The indent_guides (0x91)
+    // case is the regression that desynced the Go reader.
     #[test]
     fn generated_size_matches_decoder() {
         let cases: &[(Vec<u8>, usize)] = &[
@@ -651,11 +684,11 @@ mod command_size_conformance {
                 "command_size mismatch for opcode 0x{:02X}",
                 bytes[0]
             );
-            let decoded = decode_command(bytes).expect("decoder accepts framed command");
+            let _decoded = decode_command(bytes).expect("decoder accepts framed command");
             assert_eq!(
-                decoded.size(),
+                command_byte_size(bytes).unwrap(),
                 *expected,
-                "decoder size disagrees with command_size for opcode 0x{:02X}",
+                "reader size disagrees with command_size for opcode 0x{:02X}",
                 bytes[0]
             );
         }

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -424,8 +424,9 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         | opcodes::OP_GUI_AGENT_CONTEXT
         | opcodes::OP_GUI_BOARD
         | opcodes::OP_GUI_AGENT_CHAT
-        | opcodes::OP_GUI_TOOL_MANAGER => semantic_size(bytes)
-            .map(|size| Command::Unsupported { opcode, size }),
+        | opcodes::OP_GUI_TOOL_MANAGER => {
+            semantic_size(bytes).map(|size| Command::Unsupported { opcode, size })
+        }
         _ => Err(DecodeError::UnknownOpcode(opcode)),
     }
 }
@@ -1401,9 +1402,13 @@ fn custom_semantic_size(bytes: &[u8]) -> Result<usize, DecodeError> {
         opcodes::OP_GUI_SPLIT_SEPARATORS => split_separators_size(bytes),
         opcodes::OP_GUI_GIT_STATUS => git_status_size(bytes),
         opcodes::OP_GUI_BOARD => hidden_or_visible_size(bytes, "board", board_size),
-        opcodes::OP_GUI_AGENT_CONTEXT => hidden_or_visible_size(bytes, "agent context", agent_context_size),
+        opcodes::OP_GUI_AGENT_CONTEXT => {
+            hidden_or_visible_size(bytes, "agent context", agent_context_size)
+        }
         opcodes::OP_GUI_CHANGE_SUMMARY => change_summary_size(bytes),
-        opcodes::OP_GUI_TOOL_MANAGER => hidden_or_visible_size(bytes, "tool manager", tool_manager_size),
+        opcodes::OP_GUI_TOOL_MANAGER => {
+            hidden_or_visible_size(bytes, "tool manager", tool_manager_size)
+        }
         opcodes::OP_GUI_WINDOW_OVERLAY_DELTA => overlay_delta_size(bytes),
         _ => Err(DecodeError::UnknownOpcode(opcode)),
     }
@@ -2320,7 +2325,11 @@ mod tests {
 
     #[test]
     fn skips_hidden_tool_manager_without_consuming_following_commands() {
-        let packet = [vec![opcodes::OP_GUI_TOOL_MANAGER, 0], vec![opcodes::OP_GUI_THEME, 0]].concat();
+        let packet = [
+            vec![opcodes::OP_GUI_TOOL_MANAGER, 0],
+            vec![opcodes::OP_GUI_THEME, 0],
+        ]
+        .concat();
         let command = decode(&packet).unwrap();
         let size = semantic_size(&packet).unwrap();
 

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -1,4 +1,8 @@
-use crate::protocol::{DecodeError, opcodes};
+use crate::protocol::{
+    DecodeError,
+    command_size::{self, CommandSize},
+    opcodes,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
@@ -24,7 +28,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub fn size(&self) -> usize {
+    pub fn custom_size(&self) -> usize {
         match self {
             Self::WindowContent(_, size) => *size,
             Self::StatusBar(_, size) => *size,
@@ -396,23 +400,15 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_CHANGE_SUMMARY => decode_change_summary(bytes),
         opcodes::OP_GUI_GIT_STATUS => decode_git_status(bytes),
         opcodes::OP_GUI_THEME => decode_theme(bytes),
-        opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA | opcodes::OP_GUI_WINDOW_ROWS_DELTA => {
-            sectioned_size(bytes, "semantic row delta")
-                .map(|size| Command::Unsupported { opcode, size })
-        }
-        opcodes::OP_GUI_WINDOW_OVERLAY_DELTA => {
-            overlay_delta_size(bytes).map(|size| Command::Unsupported { opcode, size })
-        }
-        opcodes::OP_GUI_GUTTER => sectioned_size(bytes, "semantic sectioned command")
-            .map(|size| Command::Unsupported { opcode, size }),
-        opcodes::OP_GUI_CURSORLINE => {
-            fixed_size(bytes, 6, "cursorline").map(|size| Command::Unsupported { opcode, size })
-        }
-        opcodes::OP_CLIPBOARD_WRITE
+        opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA
+        | opcodes::OP_GUI_WINDOW_ROWS_DELTA
+        | opcodes::OP_GUI_WINDOW_OVERLAY_DELTA
+        | opcodes::OP_GUI_GUTTER
+        | opcodes::OP_GUI_CURSORLINE
+        | opcodes::OP_CLIPBOARD_WRITE
         | opcodes::OP_GUI_LINE_SPACING
-        | opcodes::OP_GUI_CURSOR_ANIMATION => len16_size(bytes, "forward-compatible gui command")
-            .map(|size| Command::Unsupported { opcode, size }),
-        opcodes::OP_GUI_INDENT_GUIDES
+        | opcodes::OP_GUI_CURSOR_ANIMATION
+        | opcodes::OP_GUI_INDENT_GUIDES
         | opcodes::OP_GUI_HOVER_ACTION
         | opcodes::OP_GUI_WORKSPACES
         | opcodes::OP_GUI_NOTIFICATIONS
@@ -420,29 +416,34 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         | opcodes::OP_GUI_EXTENSION_OVERLAY
         | opcodes::OP_GUI_EXTENSION_PANEL
         | opcodes::OP_GUI_SEARCH_STATE
-        | opcodes::OP_GUI_CONFIG_STATE => len16_size(bytes, "semantic length16 command")
-            .map(|size| Command::Unsupported { opcode, size }),
-        opcodes::OP_GUI_OBSERVATORY | opcodes::OP_GUI_SIDEBARS => {
-            len32_size(bytes, "semantic length32 command")
-                .map(|size| Command::Unsupported { opcode, size })
-        }
-        opcodes::OP_GUI_GUTTER_SEP => fixed_size(bytes, 6, "gutter separator")
-            .map(|size| Command::Unsupported { opcode, size }),
-        opcodes::OP_GUI_SPLIT_SEPARATORS => {
-            split_separators_size(bytes).map(|size| Command::Unsupported { opcode, size })
-        }
-        opcodes::OP_GUI_AGENT_CONTEXT
+        | opcodes::OP_GUI_CONFIG_STATE
+        | opcodes::OP_GUI_OBSERVATORY
+        | opcodes::OP_GUI_SIDEBARS
+        | opcodes::OP_GUI_GUTTER_SEP
+        | opcodes::OP_GUI_SPLIT_SEPARATORS
+        | opcodes::OP_GUI_AGENT_CONTEXT
         | opcodes::OP_GUI_BOARD
         | opcodes::OP_GUI_AGENT_CHAT
-        | opcodes::OP_GUI_TOOL_MANAGER => {
-            legacy_visible_size(bytes).map(|size| Command::Unsupported { opcode, size })
-        }
+        | opcodes::OP_GUI_TOOL_MANAGER => semantic_size(bytes)
+            .map(|size| Command::Unsupported { opcode, size }),
         _ => Err(DecodeError::UnknownOpcode(opcode)),
     }
 }
 
+fn semantic_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    match command_size::command_size(bytes) {
+        CommandSize::Sized(size) => Ok(size),
+        CommandSize::Custom => custom_semantic_size(bytes),
+        CommandSize::Incomplete => Err(DecodeError::Malformed("incomplete semantic command")),
+        CommandSize::Unknown => match bytes.first() {
+            Some(opcode) => Err(DecodeError::UnknownOpcode(*opcode)),
+            None => Err(DecodeError::Empty),
+        },
+    }
+}
+
 fn decode_window_content(bytes: &[u8]) -> Result<Command, DecodeError> {
-    let size = sectioned_size(bytes, "window content")?;
+    let size = semantic_size(bytes)?;
     let sections = sections(&bytes[..size])?;
     let mut cursor_row = 0;
     let mut cursor_col = 0;
@@ -482,7 +483,7 @@ fn decode_window_content(bytes: &[u8]) -> Result<Command, DecodeError> {
 }
 
 fn decode_status_bar(bytes: &[u8]) -> Result<Command, DecodeError> {
-    let size = sectioned_size(bytes, "status bar")?;
+    let size = semantic_size(bytes)?;
     let sections = sections(&bytes[..size])?;
     let mut status = StatusBar::default();
 
@@ -584,7 +585,7 @@ fn decode_status_segment(bytes: &[u8]) -> Result<(StatusSegment, usize), DecodeE
 }
 
 fn decode_tab_bar(bytes: &[u8]) -> Result<Command, DecodeError> {
-    let size = tab_bar_size(bytes)?;
+    let size = semantic_size(bytes)?;
     require_len(bytes, 3, "tab bar header")?;
     let active_index = bytes[1];
     let count = bytes[2] as usize;
@@ -613,7 +614,7 @@ fn decode_tab_bar(bytes: &[u8]) -> Result<Command, DecodeError> {
 }
 
 fn decode_file_tree(bytes: &[u8]) -> Result<Command, DecodeError> {
-    let size = len32_size(bytes, "file tree")?;
+    let size = semantic_size(bytes)?;
     let payload = &bytes[5..size];
     require_len(payload, 3, "file tree header")?;
     let flags = payload[1];
@@ -650,7 +651,7 @@ fn decode_file_tree(bytes: &[u8]) -> Result<Command, DecodeError> {
 }
 
 fn decode_file_tree_selection(bytes: &[u8]) -> Result<Command, DecodeError> {
-    let size = len16_size(bytes, "file tree selection")?;
+    let size = semantic_size(bytes)?;
     let payload = &bytes[3..size];
     require_len(payload, 1, "file tree selection flags")?;
     let mut offset = 1;
@@ -671,7 +672,7 @@ fn decode_picker(bytes: &[u8]) -> Result<Command, DecodeError> {
         return Ok(Command::Picker(Picker::default(), 2));
     }
 
-    let size = sectioned_size(bytes, "picker")?;
+    let size = semantic_size(bytes)?;
     let sections = sections(&bytes[..size])?;
     let mut picker = Picker {
         visible: true,
@@ -857,7 +858,7 @@ fn decode_minibuffer_candidate(bytes: &[u8]) -> Result<(MinibufferCandidate, usi
 }
 
 fn decode_breadcrumb(bytes: &[u8]) -> Result<Command, DecodeError> {
-    let size = breadcrumb_size(bytes)?;
+    let size = semantic_size(bytes)?;
     let count = bytes[1] as usize;
     let mut offset = 2;
     let mut segments = Vec::with_capacity(count);
@@ -875,7 +876,7 @@ fn decode_completion(bytes: &[u8]) -> Result<Command, DecodeError> {
         return Ok(Command::Completion(Completion::default(), 2));
     }
 
-    let size = completion_size(bytes)?;
+    let size = semantic_size(bytes)?;
     let anchor_row = read_u16(bytes, 2);
     let anchor_col = read_u16(bytes, 4);
     let selected_index = read_u16(bytes, 6);
@@ -914,7 +915,7 @@ fn decode_which_key(bytes: &[u8]) -> Result<Command, DecodeError> {
         return Ok(Command::WhichKey(WhichKey::default(), 2));
     }
 
-    let size = which_key_size(bytes)?;
+    let size = semantic_size(bytes)?;
     let mut offset = 2;
     let prefix = read_string16(bytes, &mut offset)?;
     require_len(bytes, offset + 4, "which-key metadata")?;
@@ -957,7 +958,7 @@ fn decode_signature_help(bytes: &[u8]) -> Result<Command, DecodeError> {
         return Ok(Command::SignatureHelp(SignatureHelp::default(), 2));
     }
 
-    let size = signature_help_size(bytes)?;
+    let size = semantic_size(bytes)?;
     let anchor_row = read_u16(bytes, 2);
     let anchor_col = read_u16(bytes, 4);
     let active_signature = bytes[6];
@@ -1005,7 +1006,7 @@ fn decode_float_popup(bytes: &[u8]) -> Result<Command, DecodeError> {
         return Ok(Command::FloatPopup(FloatPopup::default(), 2));
     }
 
-    let size = float_popup_size(bytes)?;
+    let size = semantic_size(bytes)?;
     let width = read_u16(bytes, 2);
     let height = read_u16(bytes, 4);
     let mut offset = 6;
@@ -1037,7 +1038,7 @@ fn decode_hover_popup(bytes: &[u8]) -> Result<Command, DecodeError> {
         return Ok(Command::HoverPopup(HoverPopup::default(), 2));
     }
 
-    let size = hover_popup_size(bytes)?;
+    let size = semantic_size(bytes)?;
     let anchor_row = read_u16(bytes, 2);
     let anchor_col = read_u16(bytes, 4);
     let focused = bytes[6] != 0;
@@ -1105,7 +1106,7 @@ fn decode_bottom_panel(bytes: &[u8]) -> Result<Command, DecodeError> {
         return Ok(Command::BottomPanel(BottomPanel::default(), 2));
     }
 
-    let size = bottom_panel_size(bytes)?;
+    let size = semantic_size(bytes)?;
     require_len(bytes, 6, "bottom panel visible header")?;
     let active_tab_index = bytes[2];
     let height_percent = bytes[3];
@@ -1160,7 +1161,7 @@ fn decode_bottom_panel(bytes: &[u8]) -> Result<Command, DecodeError> {
 }
 
 fn decode_change_summary(bytes: &[u8]) -> Result<Command, DecodeError> {
-    let size = change_summary_size(bytes)?;
+    let size = semantic_size(bytes)?;
     require_len(bytes, 5, "change summary header")?;
     let visible = bytes[1] != 0;
     let selected_index = read_u16(bytes, 2);
@@ -1194,7 +1195,7 @@ fn decode_change_summary(bytes: &[u8]) -> Result<Command, DecodeError> {
 }
 
 fn decode_git_status(bytes: &[u8]) -> Result<Command, DecodeError> {
-    let size = git_status_size(bytes)?;
+    let size = semantic_size(bytes)?;
     require_len(bytes, 9, "git status header")?;
     let repo_state = bytes[1];
     let syncing = bytes[2] != 0;
@@ -1264,7 +1265,7 @@ fn decode_git_status(bytes: &[u8]) -> Result<Command, DecodeError> {
 }
 
 fn decode_theme(bytes: &[u8]) -> Result<Command, DecodeError> {
-    let size = theme_size(bytes)?;
+    let size = semantic_size(bytes)?;
     let count = bytes[1] as usize;
     let mut slots = Vec::with_capacity(count);
     let mut offset = 2;
@@ -1380,6 +1381,47 @@ fn sections(bytes: &[u8]) -> Result<Vec<(u8, &[u8])>, DecodeError> {
     Ok(sections)
 }
 
+fn custom_semantic_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    let opcode = *bytes.first().ok_or(DecodeError::Empty)?;
+
+    match opcode {
+        opcodes::OP_GUI_TAB_BAR => tab_bar_size(bytes),
+        opcodes::OP_GUI_WHICH_KEY => which_key_size(bytes),
+        opcodes::OP_GUI_COMPLETION => completion_size(bytes),
+        opcodes::OP_GUI_THEME => theme_size(bytes),
+        opcodes::OP_GUI_BREADCRUMB => breadcrumb_size(bytes),
+        opcodes::OP_GUI_PICKER => sectioned_size(bytes, "picker"),
+        opcodes::OP_GUI_AGENT_CHAT => sectioned_size(bytes, "agent chat"),
+        opcodes::OP_GUI_BOTTOM_PANEL => bottom_panel_size(bytes),
+        opcodes::OP_GUI_PICKER_PREVIEW => sectioned_size(bytes, "picker preview"),
+        opcodes::OP_GUI_MINIBUFFER => sectioned_size(bytes, "minibuffer"),
+        opcodes::OP_GUI_HOVER_POPUP => hover_popup_size(bytes),
+        opcodes::OP_GUI_SIGNATURE_HELP => signature_help_size(bytes),
+        opcodes::OP_GUI_FLOAT_POPUP => float_popup_size(bytes),
+        opcodes::OP_GUI_SPLIT_SEPARATORS => split_separators_size(bytes),
+        opcodes::OP_GUI_GIT_STATUS => git_status_size(bytes),
+        opcodes::OP_GUI_BOARD => hidden_or_visible_size(bytes, "board", board_size),
+        opcodes::OP_GUI_AGENT_CONTEXT => hidden_or_visible_size(bytes, "agent context", agent_context_size),
+        opcodes::OP_GUI_CHANGE_SUMMARY => change_summary_size(bytes),
+        opcodes::OP_GUI_TOOL_MANAGER => hidden_or_visible_size(bytes, "tool manager", tool_manager_size),
+        opcodes::OP_GUI_WINDOW_OVERLAY_DELTA => overlay_delta_size(bytes),
+        _ => Err(DecodeError::UnknownOpcode(opcode)),
+    }
+}
+
+fn hidden_or_visible_size(
+    bytes: &[u8],
+    name: &'static str,
+    visible_size: fn(&[u8]) -> Result<usize, DecodeError>,
+) -> Result<usize, DecodeError> {
+    require_len(bytes, 2, name)?;
+    if bytes[1] == 0 {
+        Ok(2)
+    } else {
+        visible_size(bytes)
+    }
+}
+
 fn sectioned_size(bytes: &[u8], name: &'static str) -> Result<usize, DecodeError> {
     require_len(bytes, 2, name)?;
     let count = bytes[1] as usize;
@@ -1407,20 +1449,6 @@ fn overlay_delta_size(bytes: &[u8]) -> Result<usize, DecodeError> {
     }
 
     Ok(offset)
-}
-
-fn len16_size(bytes: &[u8], name: &'static str) -> Result<usize, DecodeError> {
-    require_len(bytes, 3, name)?;
-    let len = read_u16(bytes, 1) as usize;
-    require_len(bytes, 3 + len, name)?;
-    Ok(3 + len)
-}
-
-fn len32_size(bytes: &[u8], name: &'static str) -> Result<usize, DecodeError> {
-    require_len(bytes, 5, name)?;
-    let len = read_u32(bytes, 1) as usize;
-    require_len(bytes, 5 + len, name)?;
-    Ok(5 + len)
 }
 
 fn fixed_size(bytes: &[u8], size: usize, name: &'static str) -> Result<usize, DecodeError> {
@@ -1471,32 +1499,6 @@ fn split_separators_size(bytes: &[u8]) -> Result<usize, DecodeError> {
     }
 
     Ok(offset)
-}
-
-fn legacy_visible_size(bytes: &[u8]) -> Result<usize, DecodeError> {
-    require_len(bytes, 2, "legacy semantic visibility")?;
-
-    if bytes[1] == 0 {
-        return Ok(2);
-    }
-
-    match bytes[0] {
-        opcodes::OP_GUI_BREADCRUMB => breadcrumb_size(bytes),
-        opcodes::OP_GUI_COMPLETION => completion_size(bytes),
-        opcodes::OP_GUI_SIGNATURE_HELP => signature_help_size(bytes),
-        opcodes::OP_GUI_FLOAT_POPUP => float_popup_size(bytes),
-        opcodes::OP_GUI_HOVER_POPUP => hover_popup_size(bytes),
-        opcodes::OP_GUI_AGENT_CONTEXT => agent_context_size(bytes),
-        opcodes::OP_GUI_GIT_STATUS => git_status_size(bytes),
-        opcodes::OP_GUI_CHANGE_SUMMARY => change_summary_size(bytes),
-        opcodes::OP_GUI_BOARD => board_size(bytes),
-        opcodes::OP_GUI_AGENT_CHAT => sectioned_size(bytes, "agent chat"),
-        opcodes::OP_GUI_BOTTOM_PANEL => bottom_panel_size(bytes),
-        opcodes::OP_GUI_TOOL_MANAGER => tool_manager_size(bytes),
-        _ => Err(DecodeError::Malformed(
-            "unsupported legacy semantic command",
-        )),
-    }
 }
 
 fn breadcrumb_size(bytes: &[u8]) -> Result<usize, DecodeError> {
@@ -1811,7 +1813,7 @@ mod tests {
 
         let command = decode(&payload).unwrap();
 
-        assert_eq!(command.size(), payload.len());
+        assert_eq!(semantic_size(&payload).unwrap(), payload.len());
         assert!(matches!(
             command,
             Command::WindowContent(WindowContent {
@@ -2026,7 +2028,7 @@ mod tests {
 
         let command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(
             command,
             Command::Breadcrumb(Breadcrumb { segments }, _) if segments == vec!["lib", "minga", "editor.ex"]
@@ -2049,7 +2051,7 @@ mod tests {
 
         let command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(
             command,
             Command::Completion(Completion { visible: true, anchor_row: 4, anchor_col: 12, selected_index: 1, items }, _)
@@ -2076,7 +2078,7 @@ mod tests {
 
         let command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(
             command,
             Command::WhichKey(WhichKey { visible: true, prefix, page: 0, page_count: 2, bindings }, _)
@@ -2101,7 +2103,7 @@ mod tests {
 
         let command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(
             command,
             Command::SignatureHelp(SignatureHelp { visible: true, anchor_row: 8, anchor_col: 12, active_parameter: 1, signatures, .. }, _)
@@ -2123,7 +2125,7 @@ mod tests {
 
         let command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(
             command,
             Command::FloatPopup(FloatPopup { visible: true, width: 24, height: 5, title, lines }, _)
@@ -2146,7 +2148,7 @@ mod tests {
 
         let command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(
             command,
             Command::HoverPopup(HoverPopup { visible: true, anchor_row: 3, anchor_col: 9, focused: true, scroll_offset: 2, lines }, _)
@@ -2174,7 +2176,7 @@ mod tests {
 
         let command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(
             command,
             Command::BottomPanel(BottomPanel { visible: true, active_tab_index: 1, height_percent: 30, filter: 2, tabs, entries }, _)
@@ -2199,7 +2201,7 @@ mod tests {
 
         let command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(
             command,
             Command::ChangeSummary(ChangeSummary { visible: true, selected_index: 1, entries }, _)
@@ -2228,7 +2230,7 @@ mod tests {
 
         let command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), packet.len() - 1);
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(
             command,
             Command::GitStatus(GitStatus { repo_state: 0, syncing: true, ahead: 2, behind: 1, branch, entries, toast: Some(toast), entry_base_path, last_commit_message, stash_count }, _)
@@ -2305,7 +2307,7 @@ mod tests {
             let packet = [payload.clone(), vec![opcodes::OP_BATCH_END]].concat();
             let command = decode(&packet).unwrap();
 
-            assert_eq!(command.size(), packet.len() - 1);
+            assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
             assert!(matches!(
                 command,
                 Command::Unsupported {
@@ -2317,17 +2319,39 @@ mod tests {
     }
 
     #[test]
-    fn skips_length_prefixed_config_state() {
-        let command = decode(&[opcodes::OP_GUI_CONFIG_STATE, 0, 3, 1, 2, 3]).unwrap();
+    fn skips_hidden_tool_manager_without_consuming_following_commands() {
+        let packet = [vec![opcodes::OP_GUI_TOOL_MANAGER, 0], vec![opcodes::OP_GUI_THEME, 0]].concat();
+        let command = decode(&packet).unwrap();
+        let size = semantic_size(&packet).unwrap();
 
-        assert_eq!(command.size(), 6);
+        assert_eq!(size, 2);
+        assert!(matches!(
+            command,
+            Command::Unsupported {
+                opcode: opcodes::OP_GUI_TOOL_MANAGER,
+                size: 2
+            }
+        ));
+        assert!(matches!(
+            decode(&packet[size..]).unwrap(),
+            Command::Theme(Theme { slots }, _) if slots.is_empty()
+        ));
+    }
+
+    #[test]
+    fn skips_length_prefixed_config_state() {
+        let bytes = [opcodes::OP_GUI_CONFIG_STATE, 0, 3, 1, 2, 3];
+        let _command = decode(&bytes).unwrap();
+
+        assert_eq!(semantic_size(&bytes).unwrap(), 6);
     }
 
     #[test]
     fn skips_length_wrapped_semantic_commands() {
-        let command = decode(&[opcodes::OP_GUI_NOTIFICATIONS, 0, 3, 1, 2, 3]).unwrap();
+        let bytes = [opcodes::OP_GUI_NOTIFICATIONS, 0, 3, 1, 2, 3];
+        let _command = decode(&bytes).unwrap();
 
-        assert_eq!(command.size(), 6);
+        assert_eq!(semantic_size(&bytes).unwrap(), 6);
     }
 
     #[test]
@@ -2355,7 +2379,7 @@ mod tests {
             let packet = [payload.clone(), vec![opcodes::OP_BATCH_END]].concat();
             let command = decode(&packet).unwrap();
 
-            assert_eq!(command.size(), packet.len() - 1);
+            assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
             assert!(matches!(
                 command,
                 Command::Unsupported {
@@ -2422,9 +2446,9 @@ mod tests {
             1,
         ];
 
-        let command = decode(&bytes).unwrap();
+        let _command = decode(&bytes).unwrap();
 
-        assert_eq!(command.size(), 13);
+        assert_eq!(semantic_size(&bytes).unwrap(), 13);
     }
 
     #[test]
@@ -2454,11 +2478,11 @@ mod tests {
         ]
         .concat();
 
-        let command = decode(&packet).unwrap();
+        let _command = decode(&packet).unwrap();
 
-        assert_eq!(command.size(), 18);
+        assert_eq!(semantic_size(&packet).unwrap(), 18);
         assert!(matches!(
-            decode(&packet[command.size()..]).unwrap(),
+            decode(&packet[semantic_size(&packet).unwrap()..]).unwrap(),
             Command::Theme(Theme { slots }, _) if slots.is_empty()
         ));
     }

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -21,6 +21,7 @@
 const std = @import("std");
 
 const opcodes = @import("generated/protocol_opcodes.zig");
+const generated_command_size = @import("generated/protocol_command_size.zig");
 
 // BEGIN GENERATED OPCODE EXPORTS. Regenerate with `mix protocol.gen`. Do not edit by hand.
 // Input
@@ -1173,20 +1174,10 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
             // TUI ignores font fallback.
             return .noop;
         },
-        else => {
-            if (data[0] == OP_GUI_FILE_TREE or data[0] == OP_GUI_OBSERVATORY or data[0] == OP_GUI_SIDEBARS) {
-                if (rest.len < 4) return error.Malformed;
-                const payload_len: usize = std.mem.readInt(u32, rest[0..4], .big);
-                if (rest.len < 4 + payload_len) return error.Malformed;
-                return .noop;
-            }
-            if (data[0] >= 0x90 and data[0] <= 0x9F) {
-                if (rest.len < 2) return error.Malformed;
-                const payload_len: usize = std.mem.readInt(u16, rest[0..2], .big);
-                if (rest.len < 2 + payload_len) return error.Malformed;
-                return .noop;
-            }
-            return error.UnknownOpcode;
+        else => switch (generated_command_size.commandSize(data).status) {
+            .sized => return .noop,
+            .incomplete => return error.Malformed,
+            .unknown, .custom => return error.UnknownOpcode,
         },
     }
 }
@@ -1215,17 +1206,63 @@ fn decodeStructuralNavAction(action: u8) !StructuralNavAction {
 ///   0x10 draw_text:       14 bytes + text_len
 pub fn commandSize(payload: []const u8) usize {
     if (payload.len == 0) return 0;
+
+    const generated = generated_command_size.commandSize(payload);
+    return switch (generated.status) {
+        .sized => generated.size,
+        .custom => customCommandSize(payload),
+        .incomplete => payload.len,
+        .unknown => parserCommandSize(payload) orelse 1,
+    };
+}
+
+fn customCommandSize(payload: []const u8) usize {
+    if (payload.len == 0) return 0;
     const decoded_size = switch (payload[0]) {
-        OP_CLEAR => 1,
-        OP_BATCH_END => 1,
-        OP_SET_CURSOR => 5,
-        OP_SET_CURSOR_SHAPE => 2,
         OP_DRAW_TEXT => blk: {
             // opcode(1) + row(2) + col(2) + fg(3) + bg(3) + attrs(1) + text_len(2) = 14 fixed bytes
             if (payload.len < 14) break :blk payload.len;
             const text_len: usize = std.mem.readInt(u16, payload[12..14], .big);
             break :blk 14 + text_len;
         },
+        OP_DRAW_STYLED_TEXT => blk: {
+            if (payload.len < 21) break :blk payload.len;
+            const text_len: usize = std.mem.readInt(u16, payload[19..21], .big);
+            break :blk 21 + text_len;
+        },
+        OP_SET_FONT => blk: {
+            // opcode(1) + size(2) + weight(1) + ligatures(1) + name_len(2) + name
+            if (payload.len < 7) break :blk payload.len;
+            const name_len: usize = std.mem.readInt(u16, payload[5..7], .big);
+            break :blk 7 + name_len;
+        },
+        OP_REGISTER_FONT => blk: {
+            // opcode(1) + font_id(1) + name_len(2) + name
+            if (payload.len < 4) break :blk payload.len;
+            const name_len: usize = std.mem.readInt(u16, payload[2..4], .big);
+            break :blk 4 + name_len;
+        },
+        OP_SET_FONT_FALLBACK => blk: {
+            // opcode(1) + count(1), then count * (name_len:2, name:bytes)
+            if (payload.len < 2) break :blk payload.len;
+            const count = payload[1];
+            var offset: usize = 2;
+            var i: u8 = 0;
+            while (i < count) : (i += 1) {
+                if (payload.len < offset + 2) break :blk payload.len;
+                const name_len: usize = std.mem.readInt(u16, payload[offset..][0..2], .big);
+                offset += 2 + name_len;
+            }
+            break :blk offset;
+        },
+        else => parserCommandSize(payload) orelse 1,
+    };
+    return @min(decoded_size, payload.len);
+}
+
+fn parserCommandSize(payload: []const u8) ?usize {
+    if (payload.len == 0) return 0;
+    const decoded_size = switch (payload[0]) {
         OP_SET_LANGUAGE => blk: {
             // opcode(1) + buffer_id(4) + name_len(2) + name
             if (payload.len < 7) break :blk payload.len;
@@ -1251,11 +1288,6 @@ pub fn commandSize(payload: []const u8) usize {
             if (payload.len < path_off + 2) break :blk payload.len;
             const path_len: usize = std.mem.readInt(u16, payload[path_off..][0..2], .big);
             break :blk path_off + 2 + path_len;
-        },
-        OP_SET_TITLE => blk: {
-            if (payload.len < 3) break :blk payload.len;
-            const title_len: usize = std.mem.readInt(u16, payload[1..3], .big);
-            break :blk 3 + title_len;
         },
         OP_QUERY_LANGUAGE_AT => 13, // opcode(1) + buffer_id(4) + request_id(4) + byte_offset(4)
         OP_REQUEST_INDENT => 13, // opcode(1) + buffer_id(4) + request_id(4) + line(4)
@@ -1286,52 +1318,7 @@ pub fn commandSize(payload: []const u8) usize {
             const text_len: usize = std.mem.readInt(u16, payload[5..7], .big);
             break :blk 7 + text_len;
         },
-        OP_SET_WINDOW_BG => 4, // opcode(1) + r(1) + g(1) + b(1)
-        OP_DEFINE_REGION => 15, // opcode(1) + id(2) + parent_id(2) + role(1) + row(2) + col(2) + width(2) + height(2) + z_order(1)
-        OP_CLEAR_REGION => 3, // opcode(1) + id(2)
-        OP_DESTROY_REGION => 3, // opcode(1) + id(2)
-        OP_SET_ACTIVE_REGION => 3, // opcode(1) + id(2)
-        OP_SCROLL_REGION => 7, // opcode(1) + top_row(2) + bottom_row(2) + delta(2)
-        OP_SET_FONT => blk: {
-            // opcode(1) + size(2) + weight(1) + ligatures(1) + name_len(2) + name
-            if (payload.len < 7) break :blk payload.len;
-            const name_len: usize = std.mem.readInt(u16, payload[5..7], .big);
-            break :blk 7 + name_len;
-        },
-        OP_REGISTER_FONT => blk: {
-            // opcode(1) + font_id(1) + name_len(2) + name
-            if (payload.len < 4) break :blk payload.len;
-            const name_len: usize = std.mem.readInt(u16, payload[2..4], .big);
-            break :blk 4 + name_len;
-        },
-        OP_SET_FONT_FALLBACK => blk: {
-            // opcode(1) + count(1), then count * (name_len:2, name:bytes)
-            if (payload.len < 2) break :blk payload.len;
-            const count = payload[1];
-            var offset: usize = 2;
-            var i: u8 = 0;
-            while (i < count) : (i += 1) {
-                if (payload.len < offset + 2) break :blk payload.len;
-                const name_len: usize = std.mem.readInt(u16, payload[offset..][0..2], .big);
-                offset += 2 + name_len;
-            }
-            break :blk offset;
-        },
-        OP_GUI_FILE_TREE, OP_GUI_OBSERVATORY, OP_GUI_SIDEBARS => blk: {
-            if (payload.len < 5) break :blk payload.len;
-            const payload_len: usize = std.mem.readInt(u32, payload[1..5], .big);
-            break :blk 5 + payload_len;
-        },
-        // Forward-compatible GUI opcodes use opcode(1) + payload_len(2) + payload, except large-payload opcodes handled above.
-        else => blk: {
-            if (payload[0] >= 0x90 and payload[0] <= 0x9F) {
-                if (payload.len < 3) break :blk payload.len;
-                const payload_len: usize = std.mem.readInt(u16, payload[1..3], .big);
-                break :blk 3 + payload_len;
-            }
-            // Unknown legacy opcode: skip 1 byte so the loop always makes progress.
-            break :blk 1;
-        },
+        else => return null,
     };
     return @min(decoded_size, payload.len);
 }
@@ -1737,7 +1724,7 @@ test "decode truncated gui_sidebars returns malformed" {
 }
 
 test "decode unknown opcode returns error" {
-    const data = [_]u8{0xFF};
+    const data = [_]u8{0x6F};
     const result = decodeCommand(&data);
     try std.testing.expectError(error.UnknownOpcode, result);
 }
@@ -2867,12 +2854,7 @@ test {
     _ = @import("generated/protocol_schema_test.zig");
 }
 
-// Conformance: the schema-generated commandSize must agree with this module's
-// mature, hand-written commandSize. The corpus is limited to opcodes the Zig
-// renderer actually receives and sizes (render/config plus the 0x90+ forward-
-// compatible range); chrome opcodes 0x71-0x8F never reach the legacy Zig path,
-// so it deliberately skips them. The indent_guides (0x91) case is the
-// regression that desynced the Go reader.
+// Conformance: schema-framed commands are sized by the generated commandSize authority. The corpus includes the indent_guides (0x91) regression that desynced the Go reader.
 test "generated commandSize matches protocol.commandSize" {
     const generated_size = @import("generated/protocol_command_size.zig");
 
@@ -2888,5 +2870,23 @@ test "generated commandSize matches protocol.commandSize" {
         const result = generated_size.commandSize(payload);
         try std.testing.expectEqual(generated_size.Status.sized, result.status);
         try std.testing.expectEqual(commandSize(payload), result.size);
+    }
+}
+
+test "generated-sized unrendered opcode does not consume following command" {
+    const cases = [_][]const u8{
+        &[_]u8{ opcodes.OP_GUI_INDENT_GUIDES, 0x00, 0x06, 1, 2, 3, 4, 5, 6, OP_BATCH_END },
+        &[_]u8{ 0xB7, 0x00, 0x02, 0xAA, 0xBB, OP_BATCH_END },
+    };
+
+    for (cases) |packet| {
+        var offset: usize = 0;
+
+        const first = try decodeCommand(packet[offset..]);
+        try std.testing.expect(first == .noop);
+        offset += commandSize(packet[offset..]);
+
+        const second = try decodeCommand(packet[offset..]);
+        try std.testing.expect(second == .batch_end);
     }
 }


### PR DESCRIPTION
# TL;DR
Frontend batch readers now use the generated protocol command-size authority instead of parallel hand-maintained sizing tables. This closes the drift risk that caused generated-size GUI opcodes like `gui_indent_guides` to desync a frame batch.

Closes #2137

## Context
#2136 added generated command-size helpers for Rust, Zig, Swift, and Go, then wired Go to use them. Rust, Zig, and Swift still advanced through batched protocol commands with local sizing logic, so schema framing could drift from frontend readers.

## Changes
- Updated the Rust TUI batch reader to compute command advancement from generated `command_size`, with decoder-owned fallback only for schema-custom opcodes.
- Updated Rust semantic sizing so schema-framed GUI opcodes use generated framing, while custom GUI payloads still validate their bespoke wire shapes.
- Updated Zig `protocol.commandSize` to delegate schema-framed commands to `generated/protocol_command_size.zig`, with fallback only for parser commands and schema-custom render/config commands.
- Updated Swift `decodeCommand` so generated `commandSize(_:)` is the batch-advance authority, while per-opcode decoding still validates and renders payload content.
- Added regressions for generated-sized unrendered opcodes and the hidden Rust `gui_tool_manager` custom payload so skipped commands do not drop following batch commands.

## Verification
- `cd rust/tui && cargo test` passed, 70 tests.
- `cd zig && zig build test` passed.
- `mix zig.lint` passed.
- `git diff --check` passed.
- Focused bug-hunting found a Zig generated-sized unknown opcode issue. Fixed and targeted re-review passed.
- Final review found a Rust hidden `gui_tool_manager` custom sizing issue. Fixed and targeted re-review passed.

Swift validation could not run locally because this environment does not have `xcodebuild` or `swiftc`; `mix swift.build` and `mix swift.harness` both skip for that reason, and there is no `mix swift.test` task in this checkout. CI or a macOS machine with Xcode should run the Swift build/test target.

## Acceptance Criteria Addressed
- Rust TUI reader advances between batched commands using generated `command_size`, and hand-written size dispatch is no longer the reader authority. ✅
- Zig renderer advances using generated `commandSize`, with duplicated per-opcode sizing reduced to generated sizing plus parser/custom fallback. ✅
- Swift GUI decoder advances using generated `commandSize`, with per-opcode consumed-byte bookkeeping no longer serving as the batch authority. ✅
- Unrendered generated-sized semantic/GUI opcodes do not drop subsequent commands. ✅
- Existing frontend test suites pass where local tooling is available. ✅ for Rust and Zig; Swift blocked locally by missing Xcode/Swift tooling.
- Schema framing is the only authority for schema-framed command sizing. ✅
