### PR TITLE
Schema covers all 34 GUI semantic commands (Phase 2-3)

### DIFF
--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -1185,6 +1185,14 @@ fields = [
   {name = "match_positions", type = "counted_array", count_type = "u8", element = "match_position"},
 ]
 
+# A single action-menu entry: wraps the action name string so it can be a
+# counted_array element (picker_encoder.ex encode_action_menu/1).
+[[structures]]
+name = "picker_action"
+fields = [
+  {name = "name", type = "string16"},
+]
+
 [[structures]]
 name = "which_key_binding"
 fields = [
@@ -1541,12 +1549,17 @@ element = "row"
 opcode = "gui_picker"
 id = 0x01
 name = "header"
+# picker_encoder.ex encode_picker/1: a constant marker byte (1), then the
+# counts, has_preview flag, title, and marked_count. The encoder writes
+# total_count as u16, not u32, and emits the title + marked_count tail.
 fields = [
   {name = "visible", type = "u8"},
   {name = "selected_index", type = "u16"},
-  {name = "item_count", type = "u16"},
-  {name = "total_count", type = "u32"},
-  {name = "flags", type = "u8"},
+  {name = "filtered_count", type = "u16"},
+  {name = "total_count", type = "u16"},
+  {name = "has_preview", type = "u8"},
+  {name = "title", type = "string16"},
+  {name = "marked_count", type = "u16"},
 ]
 
 [[sections]]
@@ -1555,7 +1568,6 @@ id = 0x02
 name = "query"
 fields = [
   {name = "text", type = "string16"},
-  {name = "cursor_pos", type = "u16"},
 ]
 
 [[sections]]
@@ -1570,11 +1582,16 @@ element = "picker_item"
 opcode = "gui_picker"
 id = 0x04
 name = "action_menu"
+# picker_encoder.ex encode_action_menu/1: hidden menus encode just the visible
+# byte (0); a visible menu adds selected_index plus a u8-counted list of action
+# name strings.
 fields = [
   {name = "visible", type = "u8"},
-  {name = "selected_index", type = "u8"},
-  {name = "item_count", type = "u8"},
 ]
+conditional_tail = {guard = "visible == 1", fields = [
+  {name = "selected_index", type = "u8"},
+  {name = "actions", type = "counted_array", count_type = "u8", element = "picker_action"},
+]}
 
 [[sections]]
 opcode = "gui_picker"
@@ -1588,10 +1605,14 @@ fields = [
 opcode = "gui_picker"
 id = 0x06
 name = "load_status"
+# picker_encoder.ex encode_load_status/1: :ready/:loading encode just the status
+# byte (0/1); {:error, reason} adds status 2 plus the message string.
 fields = [
   {name = "status", type = "u8"},
-  {name = "message", type = "string16"},
 ]
+conditional_tail = {guard = "status == 2", fields = [
+  {name = "message", type = "string16"},
+]}
 
 # gui_agent_chat (0x78) sections
 

--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -1138,6 +1138,59 @@ fields = [
   {name = "target", type = "string16"},
 ]
 
+[[structures]]
+name = "tab_entry"
+fields = [
+  {name = "flags", type = "u8"},
+  {name = "id", type = "u32"},
+  {name = "workspace_id", type = "u16"},
+  {name = "icon", type = "string8"},
+  {name = "label", type = "string16"},
+  {name = "tint_color", type = "u32"},
+]
+
+[[structures]]
+name = "theme_color"
+fields = [
+  {name = "slot", type = "u8"},
+  {name = "color", type = "rgb"},
+]
+
+[[structures]]
+name = "completion_item"
+fields = [
+  {name = "kind", type = "u8"},
+  {name = "label", type = "string16"},
+  {name = "detail", type = "string16"},
+]
+
+[[structures]]
+name = "which_key_binding"
+fields = [
+  {name = "kind", type = "u8"},
+  {name = "key", type = "string8"},
+  {name = "desc", type = "string16"},
+  {name = "icon", type = "string8"},
+]
+
+[[structures]]
+name = "change_summary_entry"
+fields = [
+  {name = "path", type = "string16"},
+  {name = "action", type = "u8"},
+  {name = "lines_added", type = "u32"},
+  {name = "lines_removed", type = "u32"},
+]
+
+[[structures]]
+name = "git_status_entry"
+fields = [
+  {name = "path_hash", type = "u32"},
+  {name = "section", type = "u8"},
+  {name = "status", type = "u8"},
+  {name = "path", type = "string16"},
+]
+
 # ── Section layouts for sectioned commands ────────────────────────────────
 #
 # Each [[sections]] entry describes one section within a sectioned opcode.
@@ -1412,3 +1465,314 @@ name = "entries"
 layout = "counted_array"
 count_type = "u16"
 element = "gutter_entry"
+
+# gui_window_viewport_delta (0xA1) sections
+
+[[sections]]
+opcode = "gui_window_viewport_delta"
+id = 0x01
+name = "header"
+fields = [
+  {name = "window_id", type = "u16"},
+  {name = "content_epoch", type = "u32"},
+  {name = "flags", type = "u8"},
+  {name = "cursor_row", type = "u16"},
+  {name = "cursor_col", type = "u16"},
+  {name = "cursor_shape", type = "u8"},
+  {name = "scroll_left", type = "u16"},
+]
+
+[[sections]]
+opcode = "gui_window_viewport_delta"
+id = 0x02
+name = "rows"
+layout = "counted_array"
+count_type = "u16"
+element = "row"
+
+# gui_window_rows_delta (0xA2) sections
+
+[[sections]]
+opcode = "gui_window_rows_delta"
+id = 0x01
+name = "header"
+fields = [
+  {name = "window_id", type = "u16"},
+  {name = "content_epoch", type = "u32"},
+  {name = "flags", type = "u8"},
+  {name = "cursor_row", type = "u16"},
+  {name = "cursor_col", type = "u16"},
+  {name = "cursor_shape", type = "u8"},
+  {name = "scroll_left", type = "u16"},
+]
+
+[[sections]]
+opcode = "gui_window_rows_delta"
+id = 0x02
+name = "rows"
+layout = "counted_array"
+count_type = "u16"
+element = "row"
+
+# gui_picker (0x77) sections
+
+[[sections]]
+opcode = "gui_picker"
+id = 0x01
+name = "header"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "selected_index", type = "u16"},
+  {name = "item_count", type = "u16"},
+  {name = "total_count", type = "u32"},
+  {name = "flags", type = "u8"},
+]
+
+[[sections]]
+opcode = "gui_picker"
+id = 0x02
+name = "query"
+fields = [
+  {name = "text", type = "string16"},
+  {name = "cursor_pos", type = "u16"},
+]
+
+[[sections]]
+opcode = "gui_picker"
+id = 0x04
+name = "action_menu"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "selected_index", type = "u8"},
+  {name = "item_count", type = "u8"},
+]
+
+[[sections]]
+opcode = "gui_picker"
+id = 0x05
+name = "mode_prefix"
+fields = [
+  {name = "text", type = "string16"},
+]
+
+[[sections]]
+opcode = "gui_picker"
+id = 0x06
+name = "load_status"
+fields = [
+  {name = "status", type = "u8"},
+  {name = "message", type = "string16"},
+]
+
+# gui_agent_chat (0x78) sections
+
+[[sections]]
+opcode = "gui_agent_chat"
+id = 0x01
+name = "header"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "flags", type = "u8"},
+  {name = "message_count", type = "u16"},
+]
+
+# gui_picker_preview (0x7D) sections
+
+[[sections]]
+opcode = "gui_picker_preview"
+id = 0x01
+name = "header"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "kind", type = "u8"},
+  {name = "title", type = "string16"},
+]
+
+# ── Command field layouts for custom-framed commands ───────────────────────
+#
+# Each [[command_fields]] entry describes the fixed/header fields of a
+# custom-framed opcode. The generator emits struct definitions and decode
+# functions that decode up to and including the last fixed-size field.
+# Variable-length tail content (counted arrays of complex items) is left
+# to hand-written decoders.
+
+[[command_fields]]
+opcode = "gui_tab_bar"
+fields = [
+  {name = "active_index", type = "u8"},
+  {name = "tab_count", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_theme"
+fields = [
+  {name = "color_count", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_breadcrumb"
+fields = [
+  {name = "segment_count", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_completion"
+fields = [
+  {name = "visible", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_which_key"
+fields = [
+  {name = "visible", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_minibuffer"
+fields = [
+  {name = "visible", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_hover_popup"
+fields = [
+  {name = "visible", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_signature_help"
+fields = [
+  {name = "visible", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_float_popup"
+fields = [
+  {name = "visible", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_split_separators"
+fields = [
+  {name = "bg", type = "rgb"},
+  {name = "vertical_count", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_git_status"
+fields = [
+  {name = "repo_state", type = "u8"},
+  {name = "syncing", type = "u8"},
+  {name = "ahead", type = "u16"},
+  {name = "behind", type = "u16"},
+]
+
+[[command_fields]]
+opcode = "gui_bottom_panel"
+fields = [
+  {name = "visible", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_change_summary"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "selected_index", type = "u16"},
+  {name = "entry_count", type = "u16"},
+]
+
+[[command_fields]]
+opcode = "gui_board"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "focused_card_id", type = "u32"},
+  {name = "card_count", type = "u16"},
+  {name = "filter_mode", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_agent_context"
+fields = [
+  {name = "visible", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_gutter_sep"
+fields = [
+  {name = "col", type = "u16"},
+  {name = "bg", type = "rgb"},
+]
+
+[[command_fields]]
+opcode = "gui_cursorline"
+fields = [
+  {name = "col", type = "u16"},
+  {name = "bg", type = "rgb"},
+]
+
+[[command_fields]]
+opcode = "gui_search_state"
+fields = [
+  {name = "active", type = "u8"},
+  {name = "match_count", type = "u16"},
+  {name = "current_index", type = "u16"},
+  {name = "flags", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_edit_timeline"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "viewing_index", type = "u16"},
+  {name = "entry_count", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_workspaces"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "active_workspace_id", type = "u16"},
+  {name = "mode", type = "u8"},
+  {name = "flags", type = "u8"},
+  {name = "workspace_count", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_notifications"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "notification_count", type = "u16"},
+]
+
+[[command_fields]]
+opcode = "gui_sidebars"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "sidebar_count", type = "u16"},
+]
+
+[[command_fields]]
+opcode = "gui_extension_overlay"
+fields = [
+  {name = "entry_count", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_extension_panel"
+fields = [
+  {name = "panel_count", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_file_tree"
+fields = [
+  {name = "visible", type = "u8"},
+  {name = "flags", type = "u8"},
+  {name = "status", type = "u8"},
+]
+
+[[command_fields]]
+opcode = "gui_tool_manager"
+fields = [
+  {name = "visible", type = "u8"},
+]

--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -1164,6 +1164,27 @@ fields = [
   {name = "detail", type = "string16"},
 ]
 
+# A single fuzzy-match highlight index inside a picker_item label. Wraps a bare
+# u16 so it can be used as a counted_array element (picker_encoder.ex encode_item/1).
+# The field is named `index` rather than `pos` because the generator reserves
+# `pos`/`offset`/`data`/`bytes`/`err` for decoder-internal locals.
+[[structures]]
+name = "match_position"
+fields = [
+  {name = "index", type = "u16"},
+]
+
+[[structures]]
+name = "picker_item"
+fields = [
+  {name = "icon_color", type = "u24"},
+  {name = "flags", type = "u8"},
+  {name = "label", type = "string16"},
+  {name = "description", type = "string16"},
+  {name = "annotation", type = "string16"},
+  {name = "match_positions", type = "counted_array", count_type = "u8", element = "match_position"},
+]
+
 [[structures]]
 name = "which_key_binding"
 fields = [
@@ -1539,6 +1560,14 @@ fields = [
 
 [[sections]]
 opcode = "gui_picker"
+id = 0x03
+name = "items"
+layout = "counted_array"
+count_type = "u16"
+element = "picker_item"
+
+[[sections]]
+opcode = "gui_picker"
 id = 0x04
 name = "action_menu"
 fields = [
@@ -1620,6 +1649,15 @@ opcode = "gui_completion"
 fields = [
   {name = "visible", type = "u8"},
 ]
+# When visible, the encoder emits the popup placement plus a u16-counted list of
+# items (completion_encoder.ex encode_command/1). When hidden, only the visible
+# byte is present.
+conditional_tail = {guard = "visible == 1", fields = [
+  {name = "cursor_row", type = "u16"},
+  {name = "cursor_col", type = "u16"},
+  {name = "selected_offset", type = "u16"},
+  {name = "items", type = "counted_array", count_type = "u16", element = "completion_item"},
+]}
 
 [[command_fields]]
 opcode = "gui_which_key"

--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -1164,16 +1164,6 @@ fields = [
   {name = "detail", type = "string16"},
 ]
 
-# A single fuzzy-match highlight index inside a picker_item label. Wraps a bare
-# u16 so it can be used as a counted_array element (picker_encoder.ex encode_item/1).
-# The field is named `index` rather than `pos` because the generator reserves
-# `pos`/`offset`/`data`/`bytes`/`err` for decoder-internal locals.
-[[structures]]
-name = "match_position"
-fields = [
-  {name = "index", type = "u16"},
-]
-
 [[structures]]
 name = "picker_item"
 fields = [
@@ -1182,15 +1172,8 @@ fields = [
   {name = "label", type = "string16"},
   {name = "description", type = "string16"},
   {name = "annotation", type = "string16"},
-  {name = "match_positions", type = "counted_array", count_type = "u8", element = "match_position"},
-]
-
-# A single action-menu entry: wraps the action name string so it can be a
-# counted_array element (picker_encoder.ex encode_action_menu/1).
-[[structures]]
-name = "picker_action"
-fields = [
-  {name = "name", type = "string16"},
+  # u8-counted list of u16 fuzzy-match highlight indices into the label.
+  {name = "match_positions", type = "counted_array", count_type = "u8", element = "u16"},
 ]
 
 [[structures]]
@@ -1590,7 +1573,7 @@ fields = [
 ]
 conditional_tail = {guard = "visible == 1", fields = [
   {name = "selected_index", type = "u8"},
-  {name = "actions", type = "counted_array", count_type = "u8", element = "picker_action"},
+  {name = "actions", type = "counted_array", count_type = "u8", element = "string16"},
 ]}
 
 [[sections]]

--- a/go/tui/internal/generated/semantic_decode.go
+++ b/go/tui/internal/generated/semantic_decode.go
@@ -525,18 +525,6 @@ func DecodeCompletionItem(data []byte, offset int) (CompletionItem, int, error) 
 	}, pos, nil
 }
 
-func DecodeMatchPosition(data []byte, offset int) (MatchPosition, int, error) {
-	pos := offset
-	if err := decodeRequireLen(data, pos+2, "index"); err != nil {
-		return MatchPosition{}, offset, err
-	}
-	index := decodeU16(data, pos)
-	pos += 2
-	return MatchPosition{
-		Index: index,
-	}, pos, nil
-}
-
 func DecodePickerItem(data []byte, offset int) (PickerItem, int, error) {
 	pos := offset
 	if err := decodeRequireLen(data, pos+3, "icon_color"); err != nil {
@@ -569,14 +557,10 @@ func DecodePickerItem(data []byte, offset int) (PickerItem, int, error) {
 	if err := decodeRequireLen(data, pos+matchPositionsCount*2, "match_positions"); err != nil {
 		return PickerItem{}, offset, err
 	}
-	matchPositions := make([]MatchPosition, 0, matchPositionsCount)
+	matchPositions := make([]uint16, 0, matchPositionsCount)
 	for i := 0; i < matchPositionsCount; i++ {
-		item, nextPos, err := DecodeMatchPosition(data, pos)
-		if err != nil {
-			return PickerItem{}, offset, err
-		}
-		pos = nextPos
-		matchPositions = append(matchPositions, item)
+		matchPositions = append(matchPositions, decodeU16(data, pos))
+		pos += 2
 	}
 	return PickerItem{
 		IconColor:      iconColor,
@@ -585,17 +569,6 @@ func DecodePickerItem(data []byte, offset int) (PickerItem, int, error) {
 		Description:    description,
 		Annotation:     annotation,
 		MatchPositions: matchPositions,
-	}, pos, nil
-}
-
-func DecodePickerAction(data []byte, offset int) (PickerAction, int, error) {
-	pos := offset
-	name, pos, err := decodeString16(data, pos)
-	if err != nil {
-		return PickerAction{}, offset, err
-	}
-	return PickerAction{
-		Name: name,
 	}, pos, nil
 }
 
@@ -791,7 +764,7 @@ func DecodeGuiGutterEntries(data []byte, offset int) ([]GutterEntry, int, error)
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]GutterEntry, 0, count)
+	items := make([]GutterEntry, 0, min(count, 1024))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodeGutterEntry(data, pos)
 		if err != nil {
@@ -870,7 +843,7 @@ func DecodeGuiPickerItems(data []byte, offset int) ([]PickerItem, int, error) {
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]PickerItem, 0, count)
+	items := make([]PickerItem, 0, min(count, 1024))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodePickerItem(data, pos)
 		if err != nil {
@@ -890,7 +863,7 @@ func DecodeGuiPickerActionMenu(data []byte, offset int) (GuiPickerActionMenu, in
 	visible := data[pos]
 	pos++
 	var selectedIndex uint8
-	var actions []PickerAction
+	var actions []string
 	if visible == 1 {
 		if err := decodeRequireLen(data, pos+1, "selected_index"); err != nil {
 			return GuiPickerActionMenu{}, offset, err
@@ -902,9 +875,9 @@ func DecodeGuiPickerActionMenu(data []byte, offset int) (GuiPickerActionMenu, in
 		}
 		actionsCount := int(data[pos])
 		pos += 1
-		actions = make([]PickerAction, 0, actionsCount)
+		actions = make([]string, 0, min(actionsCount, 1024))
 		for i := 0; i < actionsCount; i++ {
-			item, nextPos, err := DecodePickerAction(data, pos)
+			item, nextPos, err := decodeString16(data, pos)
 			if err != nil {
 				return GuiPickerActionMenu{}, offset, err
 			}
@@ -1188,7 +1161,7 @@ func DecodeGuiStatusBarModeline(data []byte, offset int) (GuiStatusBarModeline, 
 	}
 	leftSegmentsCount := int(decodeU16(data, pos))
 	pos += 2
-	leftSegments := make([]ModelineSegment, 0, leftSegmentsCount)
+	leftSegments := make([]ModelineSegment, 0, min(leftSegmentsCount, 1024))
 	for i := 0; i < leftSegmentsCount; i++ {
 		item, nextPos, err := DecodeModelineSegment(data, pos)
 		if err != nil {
@@ -1202,7 +1175,7 @@ func DecodeGuiStatusBarModeline(data []byte, offset int) (GuiStatusBarModeline, 
 	}
 	rightSegmentsCount := int(decodeU16(data, pos))
 	pos += 2
-	rightSegments := make([]ModelineSegment, 0, rightSegmentsCount)
+	rightSegments := make([]ModelineSegment, 0, min(rightSegmentsCount, 1024))
 	for i := 0; i < rightSegmentsCount; i++ {
 		item, nextPos, err := DecodeModelineSegment(data, pos)
 		if err != nil {
@@ -1357,7 +1330,7 @@ func DecodeGuiWindowContentRows(data []byte, offset int) ([]Row, int, error) {
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]Row, 0, count)
+	items := make([]Row, 0, min(count, 1024))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodeRow(data, pos)
 		if err != nil {
@@ -1484,7 +1457,7 @@ func DecodeGuiWindowContentAnnotations(data []byte, offset int) ([]Annotation, i
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]Annotation, 0, count)
+	items := make([]Annotation, 0, min(count, 1024))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodeAnnotation(data, pos)
 		if err != nil {
@@ -1680,7 +1653,7 @@ func DecodeGuiWindowRowsDeltaRows(data []byte, offset int) ([]Row, int, error) {
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]Row, 0, count)
+	items := make([]Row, 0, min(count, 1024))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodeRow(data, pos)
 		if err != nil {
@@ -1749,7 +1722,7 @@ func DecodeGuiWindowViewportDeltaRows(data []byte, offset int) ([]Row, int, erro
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]Row, 0, count)
+	items := make([]Row, 0, min(count, 1024))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodeRow(data, pos)
 		if err != nil {
@@ -1843,7 +1816,7 @@ func DecodeGuiCompletionFields(data []byte, offset int) (GuiCompletionFields, in
 		}
 		itemsCount := int(decodeU16(data, pos))
 		pos += 2
-		items = make([]CompletionItem, 0, itemsCount)
+		items = make([]CompletionItem, 0, min(itemsCount, 1024))
 		for i := 0; i < itemsCount; i++ {
 			item, nextPos, err := DecodeCompletionItem(data, pos)
 			if err != nil {

--- a/go/tui/internal/generated/semantic_decode.go
+++ b/go/tui/internal/generated/semantic_decode.go
@@ -445,6 +445,197 @@ func DecodeModelineSegment(data []byte, offset int) (ModelineSegment, int, error
 	}, pos, nil
 }
 
+func DecodeTabEntry(data []byte, offset int) (TabEntry, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "flags"); err != nil {
+		return TabEntry{}, offset, err
+	}
+	flags := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+4, "id"); err != nil {
+		return TabEntry{}, offset, err
+	}
+	id := decodeU32(data, pos)
+	pos += 4
+	if err := decodeRequireLen(data, pos+2, "workspace_id"); err != nil {
+		return TabEntry{}, offset, err
+	}
+	workspaceID := decodeU16(data, pos)
+	pos += 2
+	icon, pos, err := decodeString8(data, pos)
+	if err != nil {
+		return TabEntry{}, offset, err
+	}
+	label, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return TabEntry{}, offset, err
+	}
+	if err := decodeRequireLen(data, pos+4, "tint_color"); err != nil {
+		return TabEntry{}, offset, err
+	}
+	tintColor := decodeU32(data, pos)
+	pos += 4
+	return TabEntry{
+		Flags:       flags,
+		ID:          id,
+		WorkspaceID: workspaceID,
+		Icon:        icon,
+		Label:       label,
+		TintColor:   tintColor,
+	}, pos, nil
+}
+
+func DecodeThemeColor(data []byte, offset int) (ThemeColor, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "slot"); err != nil {
+		return ThemeColor{}, offset, err
+	}
+	slot := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+3, "color"); err != nil {
+		return ThemeColor{}, offset, err
+	}
+	color := decodeU24(data, pos)
+	pos += 3
+	return ThemeColor{
+		Slot:  slot,
+		Color: color,
+	}, pos, nil
+}
+
+func DecodeCompletionItem(data []byte, offset int) (CompletionItem, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "kind"); err != nil {
+		return CompletionItem{}, offset, err
+	}
+	kind := data[pos]
+	pos++
+	label, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return CompletionItem{}, offset, err
+	}
+	detail, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return CompletionItem{}, offset, err
+	}
+	return CompletionItem{
+		Kind:   kind,
+		Label:  label,
+		Detail: detail,
+	}, pos, nil
+}
+
+func DecodeWhichKeyBinding(data []byte, offset int) (WhichKeyBinding, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "kind"); err != nil {
+		return WhichKeyBinding{}, offset, err
+	}
+	kind := data[pos]
+	pos++
+	key, pos, err := decodeString8(data, pos)
+	if err != nil {
+		return WhichKeyBinding{}, offset, err
+	}
+	desc, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return WhichKeyBinding{}, offset, err
+	}
+	icon, pos, err := decodeString8(data, pos)
+	if err != nil {
+		return WhichKeyBinding{}, offset, err
+	}
+	return WhichKeyBinding{
+		Kind: kind,
+		Key:  key,
+		Desc: desc,
+		Icon: icon,
+	}, pos, nil
+}
+
+func DecodeChangeSummaryEntry(data []byte, offset int) (ChangeSummaryEntry, int, error) {
+	pos := offset
+	path, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return ChangeSummaryEntry{}, offset, err
+	}
+	if err := decodeRequireLen(data, pos+1, "action"); err != nil {
+		return ChangeSummaryEntry{}, offset, err
+	}
+	action := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+4, "lines_added"); err != nil {
+		return ChangeSummaryEntry{}, offset, err
+	}
+	linesAdded := decodeU32(data, pos)
+	pos += 4
+	if err := decodeRequireLen(data, pos+4, "lines_removed"); err != nil {
+		return ChangeSummaryEntry{}, offset, err
+	}
+	linesRemoved := decodeU32(data, pos)
+	pos += 4
+	return ChangeSummaryEntry{
+		Path:         path,
+		Action:       action,
+		LinesAdded:   linesAdded,
+		LinesRemoved: linesRemoved,
+	}, pos, nil
+}
+
+func DecodeGitStatusEntry(data []byte, offset int) (GitStatusEntry, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+4, "path_hash"); err != nil {
+		return GitStatusEntry{}, offset, err
+	}
+	pathHash := decodeU32(data, pos)
+	pos += 4
+	if err := decodeRequireLen(data, pos+1, "section"); err != nil {
+		return GitStatusEntry{}, offset, err
+	}
+	section := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "status"); err != nil {
+		return GitStatusEntry{}, offset, err
+	}
+	status := data[pos]
+	pos++
+	path, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return GitStatusEntry{}, offset, err
+	}
+	return GitStatusEntry{
+		PathHash: pathHash,
+		Section:  section,
+		Status:   status,
+		Path:     path,
+	}, pos, nil
+}
+
+// Section decoders for gui_agent_chat
+
+func DecodeGuiAgentChatHeader(data []byte, offset int) (GuiAgentChatHeader, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiAgentChatHeader{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "flags"); err != nil {
+		return GuiAgentChatHeader{}, offset, err
+	}
+	flags := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "message_count"); err != nil {
+		return GuiAgentChatHeader{}, offset, err
+	}
+	messageCount := decodeU16(data, pos)
+	pos += 2
+	return GuiAgentChatHeader{
+		Visible:      visible,
+		Flags:        flags,
+		MessageCount: messageCount,
+	}, pos, nil
+}
+
 // Section decoders for gui_gutter
 
 func DecodeGuiGutterWindow(data []byte, offset int) (GuiGutterWindow, int, error) {
@@ -536,6 +727,138 @@ func DecodeGuiGutterEntries(data []byte, offset int) ([]GutterEntry, int, error)
 		items = append(items, item)
 	}
 	return items, pos, nil
+}
+
+// Section decoders for gui_picker
+
+func DecodeGuiPickerHeader(data []byte, offset int) (GuiPickerHeader, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiPickerHeader{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "selected_index"); err != nil {
+		return GuiPickerHeader{}, offset, err
+	}
+	selectedIndex := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+2, "item_count"); err != nil {
+		return GuiPickerHeader{}, offset, err
+	}
+	itemCount := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+4, "total_count"); err != nil {
+		return GuiPickerHeader{}, offset, err
+	}
+	totalCount := decodeU32(data, pos)
+	pos += 4
+	if err := decodeRequireLen(data, pos+1, "flags"); err != nil {
+		return GuiPickerHeader{}, offset, err
+	}
+	flags := data[pos]
+	pos++
+	return GuiPickerHeader{
+		Visible:       visible,
+		SelectedIndex: selectedIndex,
+		ItemCount:     itemCount,
+		TotalCount:    totalCount,
+		Flags:         flags,
+	}, pos, nil
+}
+
+func DecodeGuiPickerQuery(data []byte, offset int) (GuiPickerQuery, int, error) {
+	pos := offset
+	text, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return GuiPickerQuery{}, offset, err
+	}
+	if err := decodeRequireLen(data, pos+2, "cursor_pos"); err != nil {
+		return GuiPickerQuery{}, offset, err
+	}
+	cursorPos := decodeU16(data, pos)
+	pos += 2
+	return GuiPickerQuery{
+		Text:      text,
+		CursorPos: cursorPos,
+	}, pos, nil
+}
+
+func DecodeGuiPickerActionMenu(data []byte, offset int) (GuiPickerActionMenu, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiPickerActionMenu{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "selected_index"); err != nil {
+		return GuiPickerActionMenu{}, offset, err
+	}
+	selectedIndex := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "item_count"); err != nil {
+		return GuiPickerActionMenu{}, offset, err
+	}
+	itemCount := data[pos]
+	pos++
+	return GuiPickerActionMenu{
+		Visible:       visible,
+		SelectedIndex: selectedIndex,
+		ItemCount:     itemCount,
+	}, pos, nil
+}
+
+func DecodeGuiPickerModePrefix(data []byte, offset int) (GuiPickerModePrefix, int, error) {
+	pos := offset
+	text, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return GuiPickerModePrefix{}, offset, err
+	}
+	return GuiPickerModePrefix{
+		Text: text,
+	}, pos, nil
+}
+
+func DecodeGuiPickerLoadStatus(data []byte, offset int) (GuiPickerLoadStatus, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "status"); err != nil {
+		return GuiPickerLoadStatus{}, offset, err
+	}
+	status := data[pos]
+	pos++
+	message, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return GuiPickerLoadStatus{}, offset, err
+	}
+	return GuiPickerLoadStatus{
+		Status:  status,
+		Message: message,
+	}, pos, nil
+}
+
+// Section decoders for gui_picker_preview
+
+func DecodeGuiPickerPreviewHeader(data []byte, offset int) (GuiPickerPreviewHeader, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiPickerPreviewHeader{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "kind"); err != nil {
+		return GuiPickerPreviewHeader{}, offset, err
+	}
+	kind := data[pos]
+	pos++
+	title, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return GuiPickerPreviewHeader{}, offset, err
+	}
+	return GuiPickerPreviewHeader{
+		Visible: visible,
+		Kind:    kind,
+		Title:   title,
+	}, pos, nil
 }
 
 // Section decoders for gui_status_bar
@@ -1182,5 +1505,657 @@ func DecodeGuiWindowContentCursorline(data []byte, offset int) (GuiWindowContent
 	return GuiWindowContentCursorline{
 		Row: row,
 		BG:  bg,
+	}, pos, nil
+}
+
+// Section decoders for gui_window_rows_delta
+
+func DecodeGuiWindowRowsDeltaHeader(data []byte, offset int) (GuiWindowRowsDeltaHeader, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+2, "window_id"); err != nil {
+		return GuiWindowRowsDeltaHeader{}, offset, err
+	}
+	windowID := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+4, "content_epoch"); err != nil {
+		return GuiWindowRowsDeltaHeader{}, offset, err
+	}
+	contentEpoch := decodeU32(data, pos)
+	pos += 4
+	if err := decodeRequireLen(data, pos+1, "flags"); err != nil {
+		return GuiWindowRowsDeltaHeader{}, offset, err
+	}
+	flags := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "cursor_row"); err != nil {
+		return GuiWindowRowsDeltaHeader{}, offset, err
+	}
+	cursorRow := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+2, "cursor_col"); err != nil {
+		return GuiWindowRowsDeltaHeader{}, offset, err
+	}
+	cursorCol := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+1, "cursor_shape"); err != nil {
+		return GuiWindowRowsDeltaHeader{}, offset, err
+	}
+	cursorShape := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "scroll_left"); err != nil {
+		return GuiWindowRowsDeltaHeader{}, offset, err
+	}
+	scrollLeft := decodeU16(data, pos)
+	pos += 2
+	return GuiWindowRowsDeltaHeader{
+		WindowID:     windowID,
+		ContentEpoch: contentEpoch,
+		Flags:        flags,
+		CursorRow:    cursorRow,
+		CursorCol:    cursorCol,
+		CursorShape:  cursorShape,
+		ScrollLeft:   scrollLeft,
+	}, pos, nil
+}
+
+func DecodeGuiWindowRowsDeltaRows(data []byte, offset int) ([]Row, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+2, "rows count"); err != nil {
+		return nil, offset, err
+	}
+	count := int(decodeU16(data, pos))
+	pos += 2
+	items := make([]Row, 0, count)
+	for i := 0; i < count; i++ {
+		item, nextPos, err := DecodeRow(data, pos)
+		if err != nil {
+			return nil, offset, err
+		}
+		pos = nextPos
+		items = append(items, item)
+	}
+	return items, pos, nil
+}
+
+// Section decoders for gui_window_viewport_delta
+
+func DecodeGuiWindowViewportDeltaHeader(data []byte, offset int) (GuiWindowViewportDeltaHeader, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+2, "window_id"); err != nil {
+		return GuiWindowViewportDeltaHeader{}, offset, err
+	}
+	windowID := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+4, "content_epoch"); err != nil {
+		return GuiWindowViewportDeltaHeader{}, offset, err
+	}
+	contentEpoch := decodeU32(data, pos)
+	pos += 4
+	if err := decodeRequireLen(data, pos+1, "flags"); err != nil {
+		return GuiWindowViewportDeltaHeader{}, offset, err
+	}
+	flags := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "cursor_row"); err != nil {
+		return GuiWindowViewportDeltaHeader{}, offset, err
+	}
+	cursorRow := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+2, "cursor_col"); err != nil {
+		return GuiWindowViewportDeltaHeader{}, offset, err
+	}
+	cursorCol := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+1, "cursor_shape"); err != nil {
+		return GuiWindowViewportDeltaHeader{}, offset, err
+	}
+	cursorShape := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "scroll_left"); err != nil {
+		return GuiWindowViewportDeltaHeader{}, offset, err
+	}
+	scrollLeft := decodeU16(data, pos)
+	pos += 2
+	return GuiWindowViewportDeltaHeader{
+		WindowID:     windowID,
+		ContentEpoch: contentEpoch,
+		Flags:        flags,
+		CursorRow:    cursorRow,
+		CursorCol:    cursorCol,
+		CursorShape:  cursorShape,
+		ScrollLeft:   scrollLeft,
+	}, pos, nil
+}
+
+func DecodeGuiWindowViewportDeltaRows(data []byte, offset int) ([]Row, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+2, "rows count"); err != nil {
+		return nil, offset, err
+	}
+	count := int(decodeU16(data, pos))
+	pos += 2
+	items := make([]Row, 0, count)
+	for i := 0; i < count; i++ {
+		item, nextPos, err := DecodeRow(data, pos)
+		if err != nil {
+			return nil, offset, err
+		}
+		pos = nextPos
+		items = append(items, item)
+	}
+	return items, pos, nil
+}
+
+// Command field decoder for gui_tab_bar
+
+func DecodeGuiTabBarFields(data []byte, offset int) (GuiTabBarFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "active_index"); err != nil {
+		return GuiTabBarFields{}, offset, err
+	}
+	activeIndex := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "tab_count"); err != nil {
+		return GuiTabBarFields{}, offset, err
+	}
+	tabCount := data[pos]
+	pos++
+	return GuiTabBarFields{
+		ActiveIndex: activeIndex,
+		TabCount:    tabCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_theme
+
+func DecodeGuiThemeFields(data []byte, offset int) (GuiThemeFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "color_count"); err != nil {
+		return GuiThemeFields{}, offset, err
+	}
+	colorCount := data[pos]
+	pos++
+	return GuiThemeFields{
+		ColorCount: colorCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_breadcrumb
+
+func DecodeGuiBreadcrumbFields(data []byte, offset int) (GuiBreadcrumbFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "segment_count"); err != nil {
+		return GuiBreadcrumbFields{}, offset, err
+	}
+	segmentCount := data[pos]
+	pos++
+	return GuiBreadcrumbFields{
+		SegmentCount: segmentCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_completion
+
+func DecodeGuiCompletionFields(data []byte, offset int) (GuiCompletionFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiCompletionFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	return GuiCompletionFields{
+		Visible: visible,
+	}, pos, nil
+}
+
+// Command field decoder for gui_which_key
+
+func DecodeGuiWhichKeyFields(data []byte, offset int) (GuiWhichKeyFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiWhichKeyFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	return GuiWhichKeyFields{
+		Visible: visible,
+	}, pos, nil
+}
+
+// Command field decoder for gui_minibuffer
+
+func DecodeGuiMinibufferFields(data []byte, offset int) (GuiMinibufferFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiMinibufferFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	return GuiMinibufferFields{
+		Visible: visible,
+	}, pos, nil
+}
+
+// Command field decoder for gui_hover_popup
+
+func DecodeGuiHoverPopupFields(data []byte, offset int) (GuiHoverPopupFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiHoverPopupFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	return GuiHoverPopupFields{
+		Visible: visible,
+	}, pos, nil
+}
+
+// Command field decoder for gui_signature_help
+
+func DecodeGuiSignatureHelpFields(data []byte, offset int) (GuiSignatureHelpFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiSignatureHelpFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	return GuiSignatureHelpFields{
+		Visible: visible,
+	}, pos, nil
+}
+
+// Command field decoder for gui_float_popup
+
+func DecodeGuiFloatPopupFields(data []byte, offset int) (GuiFloatPopupFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiFloatPopupFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	return GuiFloatPopupFields{
+		Visible: visible,
+	}, pos, nil
+}
+
+// Command field decoder for gui_split_separators
+
+func DecodeGuiSplitSeparatorsFields(data []byte, offset int) (GuiSplitSeparatorsFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+3, "bg"); err != nil {
+		return GuiSplitSeparatorsFields{}, offset, err
+	}
+	bg := decodeU24(data, pos)
+	pos += 3
+	if err := decodeRequireLen(data, pos+1, "vertical_count"); err != nil {
+		return GuiSplitSeparatorsFields{}, offset, err
+	}
+	verticalCount := data[pos]
+	pos++
+	return GuiSplitSeparatorsFields{
+		BG:            bg,
+		VerticalCount: verticalCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_git_status
+
+func DecodeGuiGitStatusFields(data []byte, offset int) (GuiGitStatusFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "repo_state"); err != nil {
+		return GuiGitStatusFields{}, offset, err
+	}
+	repoState := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "syncing"); err != nil {
+		return GuiGitStatusFields{}, offset, err
+	}
+	syncing := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "ahead"); err != nil {
+		return GuiGitStatusFields{}, offset, err
+	}
+	ahead := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+2, "behind"); err != nil {
+		return GuiGitStatusFields{}, offset, err
+	}
+	behind := decodeU16(data, pos)
+	pos += 2
+	return GuiGitStatusFields{
+		RepoState: repoState,
+		Syncing:   syncing,
+		Ahead:     ahead,
+		Behind:    behind,
+	}, pos, nil
+}
+
+// Command field decoder for gui_bottom_panel
+
+func DecodeGuiBottomPanelFields(data []byte, offset int) (GuiBottomPanelFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiBottomPanelFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	return GuiBottomPanelFields{
+		Visible: visible,
+	}, pos, nil
+}
+
+// Command field decoder for gui_change_summary
+
+func DecodeGuiChangeSummaryFields(data []byte, offset int) (GuiChangeSummaryFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiChangeSummaryFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "selected_index"); err != nil {
+		return GuiChangeSummaryFields{}, offset, err
+	}
+	selectedIndex := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+2, "entry_count"); err != nil {
+		return GuiChangeSummaryFields{}, offset, err
+	}
+	entryCount := decodeU16(data, pos)
+	pos += 2
+	return GuiChangeSummaryFields{
+		Visible:       visible,
+		SelectedIndex: selectedIndex,
+		EntryCount:    entryCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_board
+
+func DecodeGuiBoardFields(data []byte, offset int) (GuiBoardFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiBoardFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+4, "focused_card_id"); err != nil {
+		return GuiBoardFields{}, offset, err
+	}
+	focusedCardID := decodeU32(data, pos)
+	pos += 4
+	if err := decodeRequireLen(data, pos+2, "card_count"); err != nil {
+		return GuiBoardFields{}, offset, err
+	}
+	cardCount := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+1, "filter_mode"); err != nil {
+		return GuiBoardFields{}, offset, err
+	}
+	filterMode := data[pos]
+	pos++
+	return GuiBoardFields{
+		Visible:       visible,
+		FocusedCardID: focusedCardID,
+		CardCount:     cardCount,
+		FilterMode:    filterMode,
+	}, pos, nil
+}
+
+// Command field decoder for gui_agent_context
+
+func DecodeGuiAgentContextFields(data []byte, offset int) (GuiAgentContextFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiAgentContextFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	return GuiAgentContextFields{
+		Visible: visible,
+	}, pos, nil
+}
+
+// Command field decoder for gui_gutter_sep
+
+func DecodeGuiGutterSepFields(data []byte, offset int) (GuiGutterSepFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+2, "col"); err != nil {
+		return GuiGutterSepFields{}, offset, err
+	}
+	col := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+3, "bg"); err != nil {
+		return GuiGutterSepFields{}, offset, err
+	}
+	bg := decodeU24(data, pos)
+	pos += 3
+	return GuiGutterSepFields{
+		Col: col,
+		BG:  bg,
+	}, pos, nil
+}
+
+// Command field decoder for gui_cursorline
+
+func DecodeGuiCursorlineFields(data []byte, offset int) (GuiCursorlineFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+2, "col"); err != nil {
+		return GuiCursorlineFields{}, offset, err
+	}
+	col := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+3, "bg"); err != nil {
+		return GuiCursorlineFields{}, offset, err
+	}
+	bg := decodeU24(data, pos)
+	pos += 3
+	return GuiCursorlineFields{
+		Col: col,
+		BG:  bg,
+	}, pos, nil
+}
+
+// Command field decoder for gui_search_state
+
+func DecodeGuiSearchStateFields(data []byte, offset int) (GuiSearchStateFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "active"); err != nil {
+		return GuiSearchStateFields{}, offset, err
+	}
+	active := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "match_count"); err != nil {
+		return GuiSearchStateFields{}, offset, err
+	}
+	matchCount := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+2, "current_index"); err != nil {
+		return GuiSearchStateFields{}, offset, err
+	}
+	currentIndex := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+1, "flags"); err != nil {
+		return GuiSearchStateFields{}, offset, err
+	}
+	flags := data[pos]
+	pos++
+	return GuiSearchStateFields{
+		Active:       active,
+		MatchCount:   matchCount,
+		CurrentIndex: currentIndex,
+		Flags:        flags,
+	}, pos, nil
+}
+
+// Command field decoder for gui_edit_timeline
+
+func DecodeGuiEditTimelineFields(data []byte, offset int) (GuiEditTimelineFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiEditTimelineFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "viewing_index"); err != nil {
+		return GuiEditTimelineFields{}, offset, err
+	}
+	viewingIndex := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+1, "entry_count"); err != nil {
+		return GuiEditTimelineFields{}, offset, err
+	}
+	entryCount := data[pos]
+	pos++
+	return GuiEditTimelineFields{
+		Visible:      visible,
+		ViewingIndex: viewingIndex,
+		EntryCount:   entryCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_workspaces
+
+func DecodeGuiWorkspacesFields(data []byte, offset int) (GuiWorkspacesFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiWorkspacesFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "active_workspace_id"); err != nil {
+		return GuiWorkspacesFields{}, offset, err
+	}
+	activeWorkspaceID := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+1, "mode"); err != nil {
+		return GuiWorkspacesFields{}, offset, err
+	}
+	mode := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "flags"); err != nil {
+		return GuiWorkspacesFields{}, offset, err
+	}
+	flags := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "workspace_count"); err != nil {
+		return GuiWorkspacesFields{}, offset, err
+	}
+	workspaceCount := data[pos]
+	pos++
+	return GuiWorkspacesFields{
+		Visible:           visible,
+		ActiveWorkspaceID: activeWorkspaceID,
+		Mode:              mode,
+		Flags:             flags,
+		WorkspaceCount:    workspaceCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_notifications
+
+func DecodeGuiNotificationsFields(data []byte, offset int) (GuiNotificationsFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiNotificationsFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "notification_count"); err != nil {
+		return GuiNotificationsFields{}, offset, err
+	}
+	notificationCount := decodeU16(data, pos)
+	pos += 2
+	return GuiNotificationsFields{
+		Visible:           visible,
+		NotificationCount: notificationCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_sidebars
+
+func DecodeGuiSidebarsFields(data []byte, offset int) (GuiSidebarsFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiSidebarsFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+2, "sidebar_count"); err != nil {
+		return GuiSidebarsFields{}, offset, err
+	}
+	sidebarCount := decodeU16(data, pos)
+	pos += 2
+	return GuiSidebarsFields{
+		Visible:      visible,
+		SidebarCount: sidebarCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_extension_overlay
+
+func DecodeGuiExtensionOverlayFields(data []byte, offset int) (GuiExtensionOverlayFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "entry_count"); err != nil {
+		return GuiExtensionOverlayFields{}, offset, err
+	}
+	entryCount := data[pos]
+	pos++
+	return GuiExtensionOverlayFields{
+		EntryCount: entryCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_extension_panel
+
+func DecodeGuiExtensionPanelFields(data []byte, offset int) (GuiExtensionPanelFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "panel_count"); err != nil {
+		return GuiExtensionPanelFields{}, offset, err
+	}
+	panelCount := data[pos]
+	pos++
+	return GuiExtensionPanelFields{
+		PanelCount: panelCount,
+	}, pos, nil
+}
+
+// Command field decoder for gui_file_tree
+
+func DecodeGuiFileTreeFields(data []byte, offset int) (GuiFileTreeFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiFileTreeFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "flags"); err != nil {
+		return GuiFileTreeFields{}, offset, err
+	}
+	flags := data[pos]
+	pos++
+	if err := decodeRequireLen(data, pos+1, "status"); err != nil {
+		return GuiFileTreeFields{}, offset, err
+	}
+	status := data[pos]
+	pos++
+	return GuiFileTreeFields{
+		Visible: visible,
+		Flags:   flags,
+		Status:  status,
+	}, pos, nil
+}
+
+// Command field decoder for gui_tool_manager
+
+func DecodeGuiToolManagerFields(data []byte, offset int) (GuiToolManagerFields, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+1, "visible"); err != nil {
+		return GuiToolManagerFields{}, offset, err
+	}
+	visible := data[pos]
+	pos++
+	return GuiToolManagerFields{
+		Visible: visible,
 	}, pos, nil
 }

--- a/go/tui/internal/generated/semantic_decode.go
+++ b/go/tui/internal/generated/semantic_decode.go
@@ -764,7 +764,7 @@ func DecodeGuiGutterEntries(data []byte, offset int) ([]GutterEntry, int, error)
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]GutterEntry, 0, min(count, 1024))
+	items := make([]GutterEntry, 0, min(count, len(data)-pos))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodeGutterEntry(data, pos)
 		if err != nil {
@@ -843,7 +843,7 @@ func DecodeGuiPickerItems(data []byte, offset int) ([]PickerItem, int, error) {
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]PickerItem, 0, min(count, 1024))
+	items := make([]PickerItem, 0, min(count, len(data)-pos))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodePickerItem(data, pos)
 		if err != nil {
@@ -875,7 +875,7 @@ func DecodeGuiPickerActionMenu(data []byte, offset int) (GuiPickerActionMenu, in
 		}
 		actionsCount := int(data[pos])
 		pos += 1
-		actions = make([]string, 0, min(actionsCount, 1024))
+		actions = make([]string, 0, min(actionsCount, len(data)-pos))
 		for i := 0; i < actionsCount; i++ {
 			item, nextPos, err := decodeString16(data, pos)
 			if err != nil {
@@ -1161,7 +1161,7 @@ func DecodeGuiStatusBarModeline(data []byte, offset int) (GuiStatusBarModeline, 
 	}
 	leftSegmentsCount := int(decodeU16(data, pos))
 	pos += 2
-	leftSegments := make([]ModelineSegment, 0, min(leftSegmentsCount, 1024))
+	leftSegments := make([]ModelineSegment, 0, min(leftSegmentsCount, len(data)-pos))
 	for i := 0; i < leftSegmentsCount; i++ {
 		item, nextPos, err := DecodeModelineSegment(data, pos)
 		if err != nil {
@@ -1175,7 +1175,7 @@ func DecodeGuiStatusBarModeline(data []byte, offset int) (GuiStatusBarModeline, 
 	}
 	rightSegmentsCount := int(decodeU16(data, pos))
 	pos += 2
-	rightSegments := make([]ModelineSegment, 0, min(rightSegmentsCount, 1024))
+	rightSegments := make([]ModelineSegment, 0, min(rightSegmentsCount, len(data)-pos))
 	for i := 0; i < rightSegmentsCount; i++ {
 		item, nextPos, err := DecodeModelineSegment(data, pos)
 		if err != nil {
@@ -1330,7 +1330,7 @@ func DecodeGuiWindowContentRows(data []byte, offset int) ([]Row, int, error) {
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]Row, 0, min(count, 1024))
+	items := make([]Row, 0, min(count, len(data)-pos))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodeRow(data, pos)
 		if err != nil {
@@ -1457,7 +1457,7 @@ func DecodeGuiWindowContentAnnotations(data []byte, offset int) ([]Annotation, i
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]Annotation, 0, min(count, 1024))
+	items := make([]Annotation, 0, min(count, len(data)-pos))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodeAnnotation(data, pos)
 		if err != nil {
@@ -1653,7 +1653,7 @@ func DecodeGuiWindowRowsDeltaRows(data []byte, offset int) ([]Row, int, error) {
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]Row, 0, min(count, 1024))
+	items := make([]Row, 0, min(count, len(data)-pos))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodeRow(data, pos)
 		if err != nil {
@@ -1722,7 +1722,7 @@ func DecodeGuiWindowViewportDeltaRows(data []byte, offset int) ([]Row, int, erro
 	}
 	count := int(decodeU16(data, pos))
 	pos += 2
-	items := make([]Row, 0, min(count, 1024))
+	items := make([]Row, 0, min(count, len(data)-pos))
 	for i := 0; i < count; i++ {
 		item, nextPos, err := DecodeRow(data, pos)
 		if err != nil {
@@ -1816,7 +1816,7 @@ func DecodeGuiCompletionFields(data []byte, offset int) (GuiCompletionFields, in
 		}
 		itemsCount := int(decodeU16(data, pos))
 		pos += 2
-		items = make([]CompletionItem, 0, min(itemsCount, 1024))
+		items = make([]CompletionItem, 0, min(itemsCount, len(data)-pos))
 		for i := 0; i < itemsCount; i++ {
 			item, nextPos, err := DecodeCompletionItem(data, pos)
 			if err != nil {

--- a/go/tui/internal/generated/semantic_decode.go
+++ b/go/tui/internal/generated/semantic_decode.go
@@ -588,6 +588,17 @@ func DecodePickerItem(data []byte, offset int) (PickerItem, int, error) {
 	}, pos, nil
 }
 
+func DecodePickerAction(data []byte, offset int) (PickerAction, int, error) {
+	pos := offset
+	name, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return PickerAction{}, offset, err
+	}
+	return PickerAction{
+		Name: name,
+	}, pos, nil
+}
+
 func DecodeWhichKeyBinding(data []byte, offset int) (WhichKeyBinding, int, error) {
 	pos := offset
 	if err := decodeRequireLen(data, pos+1, "kind"); err != nil {
@@ -806,27 +817,38 @@ func DecodeGuiPickerHeader(data []byte, offset int) (GuiPickerHeader, int, error
 	}
 	selectedIndex := decodeU16(data, pos)
 	pos += 2
-	if err := decodeRequireLen(data, pos+2, "item_count"); err != nil {
+	if err := decodeRequireLen(data, pos+2, "filtered_count"); err != nil {
 		return GuiPickerHeader{}, offset, err
 	}
-	itemCount := decodeU16(data, pos)
+	filteredCount := decodeU16(data, pos)
 	pos += 2
-	if err := decodeRequireLen(data, pos+4, "total_count"); err != nil {
+	if err := decodeRequireLen(data, pos+2, "total_count"); err != nil {
 		return GuiPickerHeader{}, offset, err
 	}
-	totalCount := decodeU32(data, pos)
-	pos += 4
-	if err := decodeRequireLen(data, pos+1, "flags"); err != nil {
+	totalCount := decodeU16(data, pos)
+	pos += 2
+	if err := decodeRequireLen(data, pos+1, "has_preview"); err != nil {
 		return GuiPickerHeader{}, offset, err
 	}
-	flags := data[pos]
+	hasPreview := data[pos]
 	pos++
+	title, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return GuiPickerHeader{}, offset, err
+	}
+	if err := decodeRequireLen(data, pos+2, "marked_count"); err != nil {
+		return GuiPickerHeader{}, offset, err
+	}
+	markedCount := decodeU16(data, pos)
+	pos += 2
 	return GuiPickerHeader{
 		Visible:       visible,
 		SelectedIndex: selectedIndex,
-		ItemCount:     itemCount,
+		FilteredCount: filteredCount,
 		TotalCount:    totalCount,
-		Flags:         flags,
+		HasPreview:    hasPreview,
+		Title:         title,
+		MarkedCount:   markedCount,
 	}, pos, nil
 }
 
@@ -836,14 +858,8 @@ func DecodeGuiPickerQuery(data []byte, offset int) (GuiPickerQuery, int, error) 
 	if err != nil {
 		return GuiPickerQuery{}, offset, err
 	}
-	if err := decodeRequireLen(data, pos+2, "cursor_pos"); err != nil {
-		return GuiPickerQuery{}, offset, err
-	}
-	cursorPos := decodeU16(data, pos)
-	pos += 2
 	return GuiPickerQuery{
-		Text:      text,
-		CursorPos: cursorPos,
+		Text: text,
 	}, pos, nil
 }
 
@@ -873,20 +889,33 @@ func DecodeGuiPickerActionMenu(data []byte, offset int) (GuiPickerActionMenu, in
 	}
 	visible := data[pos]
 	pos++
-	if err := decodeRequireLen(data, pos+1, "selected_index"); err != nil {
-		return GuiPickerActionMenu{}, offset, err
+	var selectedIndex uint8
+	var actions []PickerAction
+	if visible == 1 {
+		if err := decodeRequireLen(data, pos+1, "selected_index"); err != nil {
+			return GuiPickerActionMenu{}, offset, err
+		}
+		selectedIndex = data[pos]
+		pos++
+		if err := decodeRequireLen(data, pos+1, "actions count"); err != nil {
+			return GuiPickerActionMenu{}, offset, err
+		}
+		actionsCount := int(data[pos])
+		pos += 1
+		actions = make([]PickerAction, 0, actionsCount)
+		for i := 0; i < actionsCount; i++ {
+			item, nextPos, err := DecodePickerAction(data, pos)
+			if err != nil {
+				return GuiPickerActionMenu{}, offset, err
+			}
+			pos = nextPos
+			actions = append(actions, item)
+		}
 	}
-	selectedIndex := data[pos]
-	pos++
-	if err := decodeRequireLen(data, pos+1, "item_count"); err != nil {
-		return GuiPickerActionMenu{}, offset, err
-	}
-	itemCount := data[pos]
-	pos++
 	return GuiPickerActionMenu{
 		Visible:       visible,
 		SelectedIndex: selectedIndex,
-		ItemCount:     itemCount,
+		Actions:       actions,
 	}, pos, nil
 }
 
@@ -908,9 +937,13 @@ func DecodeGuiPickerLoadStatus(data []byte, offset int) (GuiPickerLoadStatus, in
 	}
 	status := data[pos]
 	pos++
-	message, pos, err := decodeString16(data, pos)
-	if err != nil {
-		return GuiPickerLoadStatus{}, offset, err
+	var message string
+	if status == 2 {
+		var err error
+		message, pos, err = decodeString16(data, pos)
+		if err != nil {
+			return GuiPickerLoadStatus{}, offset, err
+		}
 	}
 	return GuiPickerLoadStatus{
 		Status:  status,

--- a/go/tui/internal/generated/semantic_decode.go
+++ b/go/tui/internal/generated/semantic_decode.go
@@ -525,6 +525,69 @@ func DecodeCompletionItem(data []byte, offset int) (CompletionItem, int, error) 
 	}, pos, nil
 }
 
+func DecodeMatchPosition(data []byte, offset int) (MatchPosition, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+2, "index"); err != nil {
+		return MatchPosition{}, offset, err
+	}
+	index := decodeU16(data, pos)
+	pos += 2
+	return MatchPosition{
+		Index: index,
+	}, pos, nil
+}
+
+func DecodePickerItem(data []byte, offset int) (PickerItem, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+3, "icon_color"); err != nil {
+		return PickerItem{}, offset, err
+	}
+	iconColor := decodeU24(data, pos)
+	pos += 3
+	if err := decodeRequireLen(data, pos+1, "flags"); err != nil {
+		return PickerItem{}, offset, err
+	}
+	flags := data[pos]
+	pos++
+	label, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return PickerItem{}, offset, err
+	}
+	description, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return PickerItem{}, offset, err
+	}
+	annotation, pos, err := decodeString16(data, pos)
+	if err != nil {
+		return PickerItem{}, offset, err
+	}
+	if err := decodeRequireLen(data, pos+1, "match_positions count"); err != nil {
+		return PickerItem{}, offset, err
+	}
+	matchPositionsCount := int(data[pos])
+	pos += 1
+	if err := decodeRequireLen(data, pos+matchPositionsCount*2, "match_positions"); err != nil {
+		return PickerItem{}, offset, err
+	}
+	matchPositions := make([]MatchPosition, 0, matchPositionsCount)
+	for i := 0; i < matchPositionsCount; i++ {
+		item, nextPos, err := DecodeMatchPosition(data, pos)
+		if err != nil {
+			return PickerItem{}, offset, err
+		}
+		pos = nextPos
+		matchPositions = append(matchPositions, item)
+	}
+	return PickerItem{
+		IconColor:      iconColor,
+		Flags:          flags,
+		Label:          label,
+		Description:    description,
+		Annotation:     annotation,
+		MatchPositions: matchPositions,
+	}, pos, nil
+}
+
 func DecodeWhichKeyBinding(data []byte, offset int) (WhichKeyBinding, int, error) {
 	pos := offset
 	if err := decodeRequireLen(data, pos+1, "kind"); err != nil {
@@ -782,6 +845,25 @@ func DecodeGuiPickerQuery(data []byte, offset int) (GuiPickerQuery, int, error) 
 		Text:      text,
 		CursorPos: cursorPos,
 	}, pos, nil
+}
+
+func DecodeGuiPickerItems(data []byte, offset int) ([]PickerItem, int, error) {
+	pos := offset
+	if err := decodeRequireLen(data, pos+2, "items count"); err != nil {
+		return nil, offset, err
+	}
+	count := int(decodeU16(data, pos))
+	pos += 2
+	items := make([]PickerItem, 0, count)
+	for i := 0; i < count; i++ {
+		item, nextPos, err := DecodePickerItem(data, pos)
+		if err != nil {
+			return nil, offset, err
+		}
+		pos = nextPos
+		items = append(items, item)
+	}
+	return items, pos, nil
 }
 
 func DecodeGuiPickerActionMenu(data []byte, offset int) (GuiPickerActionMenu, int, error) {
@@ -1703,8 +1785,47 @@ func DecodeGuiCompletionFields(data []byte, offset int) (GuiCompletionFields, in
 	}
 	visible := data[pos]
 	pos++
+	var cursorRow uint16
+	var cursorCol uint16
+	var selectedOffset uint16
+	var items []CompletionItem
+	if visible == 1 {
+		if err := decodeRequireLen(data, pos+2, "cursor_row"); err != nil {
+			return GuiCompletionFields{}, offset, err
+		}
+		cursorRow = decodeU16(data, pos)
+		pos += 2
+		if err := decodeRequireLen(data, pos+2, "cursor_col"); err != nil {
+			return GuiCompletionFields{}, offset, err
+		}
+		cursorCol = decodeU16(data, pos)
+		pos += 2
+		if err := decodeRequireLen(data, pos+2, "selected_offset"); err != nil {
+			return GuiCompletionFields{}, offset, err
+		}
+		selectedOffset = decodeU16(data, pos)
+		pos += 2
+		if err := decodeRequireLen(data, pos+2, "items count"); err != nil {
+			return GuiCompletionFields{}, offset, err
+		}
+		itemsCount := int(decodeU16(data, pos))
+		pos += 2
+		items = make([]CompletionItem, 0, itemsCount)
+		for i := 0; i < itemsCount; i++ {
+			item, nextPos, err := DecodeCompletionItem(data, pos)
+			if err != nil {
+				return GuiCompletionFields{}, offset, err
+			}
+			pos = nextPos
+			items = append(items, item)
+		}
+	}
 	return GuiCompletionFields{
-		Visible: visible,
+		Visible:        visible,
+		CursorRow:      cursorRow,
+		CursorCol:      cursorCol,
+		SelectedOffset: selectedOffset,
+		Items:          items,
 	}, pos, nil
 }
 

--- a/go/tui/internal/generated/semantic_decode_picker_test.go
+++ b/go/tui/internal/generated/semantic_decode_picker_test.go
@@ -1,0 +1,113 @@
+package generated
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Round-trip coverage for the schema-generated decoders. The byte fixtures here
+// are exactly what the Elixir encoders produce (the matching assertions live in
+// protocol_schema_validation_test.exs), so together they pin encoder and
+// generated decoder to the same wire format. They also exercise the primitive
+// ([]uint16) and string ([]string) counted_array element paths.
+
+func TestDecodeGuiCompletionFieldsWithItems(t *testing.T) {
+	bytes := []byte{1, 0, 3, 0, 7, 0, 1, 0, 1, 1, 0, 3, 'f', 'o', 'o', 0, 3, 'b', 'a', 'r'}
+	f, consumed, err := DecodeGuiCompletionFields(bytes, 0)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if consumed != len(bytes) {
+		t.Fatalf("consumed %d, want %d", consumed, len(bytes))
+	}
+	if f.Visible != 1 || f.CursorRow != 3 || f.CursorCol != 7 || f.SelectedOffset != 1 {
+		t.Fatalf("header mismatch: %+v", f)
+	}
+	if len(f.Items) != 1 || f.Items[0].Kind != 1 || f.Items[0].Label != "foo" || f.Items[0].Detail != "bar" {
+		t.Fatalf("items mismatch: %+v", f.Items)
+	}
+}
+
+func TestDecodeHiddenCompletionSkipsTail(t *testing.T) {
+	f, consumed, err := DecodeGuiCompletionFields([]byte{0}, 0)
+	if err != nil || consumed != 1 || f.Visible != 0 || len(f.Items) != 0 {
+		t.Fatalf("hidden completion: f=%+v consumed=%d err=%v", f, consumed, err)
+	}
+}
+
+func TestDecodePickerItemU16MatchPositions(t *testing.T) {
+	bytes := []byte{
+		0xAA, 0xBB, 0xCC, 0, 0, 7, 'f', 'i', 'l', 'e', '.', 'e', 'x', 0, 4, 'd', 'e',
+		's', 'c', 0, 3, 'a', 'n', 'n', 2, 0, 1, 0, 4,
+	}
+	item, consumed, err := DecodePickerItem(bytes, 0)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if consumed != len(bytes) {
+		t.Fatalf("consumed %d, want %d", consumed, len(bytes))
+	}
+	if item.IconColor != 0x00AABBCC || item.Label != "file.ex" || item.Description != "desc" || item.Annotation != "ann" {
+		t.Fatalf("item mismatch: %+v", item)
+	}
+	if !reflect.DeepEqual(item.MatchPositions, []uint16{1, 4}) {
+		t.Fatalf("match_positions: %v", item.MatchPositions)
+	}
+}
+
+func TestDecodePickerHeaderFullLayout(t *testing.T) {
+	bytes := []byte{1, 0, 2, 0, 10, 0, 100, 1, 0, 5, 'F', 'i', 'l', 'e', 's', 0, 3}
+	h, consumed, err := DecodeGuiPickerHeader(bytes, 0)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if consumed != len(bytes) {
+		t.Fatalf("consumed %d, want %d", consumed, len(bytes))
+	}
+	if h.SelectedIndex != 2 || h.FilteredCount != 10 || h.TotalCount != 100 || h.HasPreview != 1 || h.Title != "Files" || h.MarkedCount != 3 {
+		t.Fatalf("header mismatch: %+v", h)
+	}
+}
+
+func TestDecodeActionMenuStringActions(t *testing.T) {
+	bytes := []byte{1, 1, 2, 0, 4, 'O', 'p', 'e', 'n', 0, 6, 'D', 'e', 'l', 'e', 't', 'e'}
+	m, consumed, err := DecodeGuiPickerActionMenu(bytes, 0)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if consumed != len(bytes) {
+		t.Fatalf("consumed %d, want %d", consumed, len(bytes))
+	}
+	if m.Visible != 1 || m.SelectedIndex != 1 || !reflect.DeepEqual(m.Actions, []string{"Open", "Delete"}) {
+		t.Fatalf("action menu mismatch: %+v", m)
+	}
+}
+
+func TestDecodeHiddenActionMenuSkipsTail(t *testing.T) {
+	m, consumed, err := DecodeGuiPickerActionMenu([]byte{0}, 0)
+	if err != nil || consumed != 1 || m.Visible != 0 || len(m.Actions) != 0 {
+		t.Fatalf("hidden action menu: m=%+v consumed=%d err=%v", m, consumed, err)
+	}
+}
+
+func TestDecodeLoadStatusErrorTail(t *testing.T) {
+	s, consumed, err := DecodeGuiPickerLoadStatus([]byte{2, 0, 4, 'b', 'o', 'o', 'm'}, 0)
+	if err != nil || consumed != 7 || s.Status != 2 || s.Message != "boom" {
+		t.Fatalf("error load status: s=%+v consumed=%d err=%v", s, consumed, err)
+	}
+}
+
+func TestDecodeReadyLoadStatusSkipsTail(t *testing.T) {
+	s, consumed, err := DecodeGuiPickerLoadStatus([]byte{0}, 0)
+	if err != nil || consumed != 1 || s.Status != 0 || s.Message != "" {
+		t.Fatalf("ready load status: s=%+v consumed=%d err=%v", s, consumed, err)
+	}
+}
+
+func TestDecodeTruncatedPickerItemRejected(t *testing.T) {
+	// count claims 2 match positions but only 1 u16 follows.
+	bytes := []byte{0xAA, 0xBB, 0xCC, 0, 0, 1, 'x', 0, 0, 0, 0, 2, 0, 1}
+	if _, _, err := DecodePickerItem(bytes, 0); err == nil {
+		t.Fatal("expected error for truncated match_positions, got nil")
+	}
+}

--- a/go/tui/internal/generated/semantic_types.go
+++ b/go/tui/internal/generated/semantic_types.go
@@ -83,6 +83,47 @@ type ModelineSegment struct {
 	Target string
 }
 
+type TabEntry struct {
+	Flags       uint8
+	ID          uint32
+	WorkspaceID uint16
+	Icon        string
+	Label       string
+	TintColor   uint32
+}
+
+type ThemeColor struct {
+	Slot  uint8
+	Color uint32
+}
+
+type CompletionItem struct {
+	Kind   uint8
+	Label  string
+	Detail string
+}
+
+type WhichKeyBinding struct {
+	Kind uint8
+	Key  string
+	Desc string
+	Icon string
+}
+
+type ChangeSummaryEntry struct {
+	Path         string
+	Action       uint8
+	LinesAdded   uint32
+	LinesRemoved uint32
+}
+
+type GitStatusEntry struct {
+	PathHash uint32
+	Section  uint8
+	Status   uint8
+	Path     string
+}
+
 const (
 	RectSize              = 8
 	SpanSize              = 13
@@ -90,6 +131,7 @@ const (
 	DiagnosticRangeSize   = 9
 	DocumentHighlightSize = 9
 	HitRegionSize         = 11
+	ThemeColorSize        = 4
 )
 
 type GuiWindowContentHeader struct {
@@ -224,4 +266,193 @@ type GuiGutterConfig struct {
 	LineNumberStyle uint8
 	LineNumberWidth uint8
 	SignColWidth    uint8
+}
+
+type GuiWindowViewportDeltaHeader struct {
+	WindowID     uint16
+	ContentEpoch uint32
+	Flags        uint8
+	CursorRow    uint16
+	CursorCol    uint16
+	CursorShape  uint8
+	ScrollLeft   uint16
+}
+
+type GuiWindowRowsDeltaHeader struct {
+	WindowID     uint16
+	ContentEpoch uint32
+	Flags        uint8
+	CursorRow    uint16
+	CursorCol    uint16
+	CursorShape  uint8
+	ScrollLeft   uint16
+}
+
+type GuiPickerHeader struct {
+	Visible       uint8
+	SelectedIndex uint16
+	ItemCount     uint16
+	TotalCount    uint32
+	Flags         uint8
+}
+
+type GuiPickerQuery struct {
+	Text      string
+	CursorPos uint16
+}
+
+type GuiPickerActionMenu struct {
+	Visible       uint8
+	SelectedIndex uint8
+	ItemCount     uint8
+}
+
+type GuiPickerModePrefix struct {
+	Text string
+}
+
+type GuiPickerLoadStatus struct {
+	Status  uint8
+	Message string
+}
+
+type GuiAgentChatHeader struct {
+	Visible      uint8
+	Flags        uint8
+	MessageCount uint16
+}
+
+type GuiPickerPreviewHeader struct {
+	Visible uint8
+	Kind    uint8
+	Title   string
+}
+
+type GuiTabBarFields struct {
+	ActiveIndex uint8
+	TabCount    uint8
+}
+
+type GuiThemeFields struct {
+	ColorCount uint8
+}
+
+type GuiBreadcrumbFields struct {
+	SegmentCount uint8
+}
+
+type GuiCompletionFields struct {
+	Visible uint8
+}
+
+type GuiWhichKeyFields struct {
+	Visible uint8
+}
+
+type GuiMinibufferFields struct {
+	Visible uint8
+}
+
+type GuiHoverPopupFields struct {
+	Visible uint8
+}
+
+type GuiSignatureHelpFields struct {
+	Visible uint8
+}
+
+type GuiFloatPopupFields struct {
+	Visible uint8
+}
+
+type GuiSplitSeparatorsFields struct {
+	BG            uint32
+	VerticalCount uint8
+}
+
+type GuiGitStatusFields struct {
+	RepoState uint8
+	Syncing   uint8
+	Ahead     uint16
+	Behind    uint16
+}
+
+type GuiBottomPanelFields struct {
+	Visible uint8
+}
+
+type GuiChangeSummaryFields struct {
+	Visible       uint8
+	SelectedIndex uint16
+	EntryCount    uint16
+}
+
+type GuiBoardFields struct {
+	Visible       uint8
+	FocusedCardID uint32
+	CardCount     uint16
+	FilterMode    uint8
+}
+
+type GuiAgentContextFields struct {
+	Visible uint8
+}
+
+type GuiGutterSepFields struct {
+	Col uint16
+	BG  uint32
+}
+
+type GuiCursorlineFields struct {
+	Col uint16
+	BG  uint32
+}
+
+type GuiSearchStateFields struct {
+	Active       uint8
+	MatchCount   uint16
+	CurrentIndex uint16
+	Flags        uint8
+}
+
+type GuiEditTimelineFields struct {
+	Visible      uint8
+	ViewingIndex uint16
+	EntryCount   uint8
+}
+
+type GuiWorkspacesFields struct {
+	Visible           uint8
+	ActiveWorkspaceID uint16
+	Mode              uint8
+	Flags             uint8
+	WorkspaceCount    uint8
+}
+
+type GuiNotificationsFields struct {
+	Visible           uint8
+	NotificationCount uint16
+}
+
+type GuiSidebarsFields struct {
+	Visible      uint8
+	SidebarCount uint16
+}
+
+type GuiExtensionOverlayFields struct {
+	EntryCount uint8
+}
+
+type GuiExtensionPanelFields struct {
+	PanelCount uint8
+}
+
+type GuiFileTreeFields struct {
+	Visible uint8
+	Flags   uint8
+	Status  uint8
+}
+
+type GuiToolManagerFields struct {
+	Visible uint8
 }

--- a/go/tui/internal/generated/semantic_types.go
+++ b/go/tui/internal/generated/semantic_types.go
@@ -103,6 +103,19 @@ type CompletionItem struct {
 	Detail string
 }
 
+type MatchPosition struct {
+	Index uint16
+}
+
+type PickerItem struct {
+	IconColor      uint32
+	Flags          uint8
+	Label          string
+	Description    string
+	Annotation     string
+	MatchPositions []MatchPosition
+}
+
 type WhichKeyBinding struct {
 	Kind uint8
 	Key  string
@@ -132,6 +145,7 @@ const (
 	DocumentHighlightSize = 9
 	HitRegionSize         = 11
 	ThemeColorSize        = 4
+	MatchPositionSize     = 2
 )
 
 type GuiWindowContentHeader struct {
@@ -342,7 +356,11 @@ type GuiBreadcrumbFields struct {
 }
 
 type GuiCompletionFields struct {
-	Visible uint8
+	Visible        uint8
+	CursorRow      uint16
+	CursorCol      uint16
+	SelectedOffset uint16
+	Items          []CompletionItem
 }
 
 type GuiWhichKeyFields struct {

--- a/go/tui/internal/generated/semantic_types.go
+++ b/go/tui/internal/generated/semantic_types.go
@@ -103,21 +103,13 @@ type CompletionItem struct {
 	Detail string
 }
 
-type MatchPosition struct {
-	Index uint16
-}
-
 type PickerItem struct {
 	IconColor      uint32
 	Flags          uint8
 	Label          string
 	Description    string
 	Annotation     string
-	MatchPositions []MatchPosition
-}
-
-type PickerAction struct {
-	Name string
+	MatchPositions []uint16
 }
 
 type WhichKeyBinding struct {
@@ -149,7 +141,6 @@ const (
 	DocumentHighlightSize = 9
 	HitRegionSize         = 11
 	ThemeColorSize        = 4
-	MatchPositionSize     = 2
 )
 
 type GuiWindowContentHeader struct {
@@ -323,7 +314,7 @@ type GuiPickerQuery struct {
 type GuiPickerActionMenu struct {
 	Visible       uint8
 	SelectedIndex uint8
-	Actions       []PickerAction
+	Actions       []string
 }
 
 type GuiPickerModePrefix struct {

--- a/go/tui/internal/generated/semantic_types.go
+++ b/go/tui/internal/generated/semantic_types.go
@@ -116,6 +116,10 @@ type PickerItem struct {
 	MatchPositions []MatchPosition
 }
 
+type PickerAction struct {
+	Name string
+}
+
 type WhichKeyBinding struct {
 	Kind uint8
 	Key  string
@@ -305,20 +309,21 @@ type GuiWindowRowsDeltaHeader struct {
 type GuiPickerHeader struct {
 	Visible       uint8
 	SelectedIndex uint16
-	ItemCount     uint16
-	TotalCount    uint32
-	Flags         uint8
+	FilteredCount uint16
+	TotalCount    uint16
+	HasPreview    uint8
+	Title         string
+	MarkedCount   uint16
 }
 
 type GuiPickerQuery struct {
-	Text      string
-	CursorPos uint16
+	Text string
 }
 
 type GuiPickerActionMenu struct {
 	Visible       uint8
 	SelectedIndex uint8
-	ItemCount     uint8
+	Actions       []PickerAction
 }
 
 type GuiPickerModePrefix struct {

--- a/go/tui/internal/protocol/generated_decode_test.go
+++ b/go/tui/internal/protocol/generated_decode_test.go
@@ -1,8 +1,10 @@
-package generated
+package protocol
 
 import (
 	"reflect"
 	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
 )
 
 // Round-trip coverage for the schema-generated decoders. The byte fixtures here
@@ -10,10 +12,15 @@ import (
 // protocol_schema_validation_test.exs), so together they pin encoder and
 // generated decoder to the same wire format. They also exercise the primitive
 // ([]uint16) and string ([]string) counted_array element paths.
+//
+// This test lives in the protocol package (not internal/generated) so that
+// mix protocol.gen, which rewrites the generated/ directory, can never clobber
+// it. Keep the fixtures in sync with the Rust twins in rust/tui/src/protocol.rs
+// and the encoder assertions in protocol_schema_validation_test.exs.
 
 func TestDecodeGuiCompletionFieldsWithItems(t *testing.T) {
 	bytes := []byte{1, 0, 3, 0, 7, 0, 1, 0, 1, 1, 0, 3, 'f', 'o', 'o', 0, 3, 'b', 'a', 'r'}
-	f, consumed, err := DecodeGuiCompletionFields(bytes, 0)
+	f, consumed, err := generated.DecodeGuiCompletionFields(bytes, 0)
 	if err != nil {
 		t.Fatalf("decode error: %v", err)
 	}
@@ -29,7 +36,7 @@ func TestDecodeGuiCompletionFieldsWithItems(t *testing.T) {
 }
 
 func TestDecodeHiddenCompletionSkipsTail(t *testing.T) {
-	f, consumed, err := DecodeGuiCompletionFields([]byte{0}, 0)
+	f, consumed, err := generated.DecodeGuiCompletionFields([]byte{0}, 0)
 	if err != nil || consumed != 1 || f.Visible != 0 || len(f.Items) != 0 {
 		t.Fatalf("hidden completion: f=%+v consumed=%d err=%v", f, consumed, err)
 	}
@@ -40,7 +47,7 @@ func TestDecodePickerItemU16MatchPositions(t *testing.T) {
 		0xAA, 0xBB, 0xCC, 0, 0, 7, 'f', 'i', 'l', 'e', '.', 'e', 'x', 0, 4, 'd', 'e',
 		's', 'c', 0, 3, 'a', 'n', 'n', 2, 0, 1, 0, 4,
 	}
-	item, consumed, err := DecodePickerItem(bytes, 0)
+	item, consumed, err := generated.DecodePickerItem(bytes, 0)
 	if err != nil {
 		t.Fatalf("decode error: %v", err)
 	}
@@ -55,9 +62,25 @@ func TestDecodePickerItemU16MatchPositions(t *testing.T) {
 	}
 }
 
+func TestDecodePickerItemEmptyMatchPositions(t *testing.T) {
+	// match_positions present but count==0: icon(0), flags(0), label "x",
+	// empty desc/ann, count 0.
+	bytes := []byte{0, 0, 0, 0, 0, 1, 'x', 0, 0, 0, 0, 0}
+	item, consumed, err := generated.DecodePickerItem(bytes, 0)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if consumed != len(bytes) {
+		t.Fatalf("consumed %d, want %d", consumed, len(bytes))
+	}
+	if item.Label != "x" || len(item.MatchPositions) != 0 {
+		t.Fatalf("expected empty match_positions, got %+v", item)
+	}
+}
+
 func TestDecodePickerHeaderFullLayout(t *testing.T) {
 	bytes := []byte{1, 0, 2, 0, 10, 0, 100, 1, 0, 5, 'F', 'i', 'l', 'e', 's', 0, 3}
-	h, consumed, err := DecodeGuiPickerHeader(bytes, 0)
+	h, consumed, err := generated.DecodeGuiPickerHeader(bytes, 0)
 	if err != nil {
 		t.Fatalf("decode error: %v", err)
 	}
@@ -71,7 +94,7 @@ func TestDecodePickerHeaderFullLayout(t *testing.T) {
 
 func TestDecodeActionMenuStringActions(t *testing.T) {
 	bytes := []byte{1, 1, 2, 0, 4, 'O', 'p', 'e', 'n', 0, 6, 'D', 'e', 'l', 'e', 't', 'e'}
-	m, consumed, err := DecodeGuiPickerActionMenu(bytes, 0)
+	m, consumed, err := generated.DecodeGuiPickerActionMenu(bytes, 0)
 	if err != nil {
 		t.Fatalf("decode error: %v", err)
 	}
@@ -83,31 +106,49 @@ func TestDecodeActionMenuStringActions(t *testing.T) {
 	}
 }
 
+func TestDecodeActionMenuEmptyActions(t *testing.T) {
+	// visible with zero actions: the []string tail is present but empty.
+	m, consumed, err := generated.DecodeGuiPickerActionMenu([]byte{1, 5, 0}, 0)
+	if err != nil || consumed != 3 || m.Visible != 1 || m.SelectedIndex != 5 || len(m.Actions) != 0 {
+		t.Fatalf("empty action menu: m=%+v consumed=%d err=%v", m, consumed, err)
+	}
+}
+
 func TestDecodeHiddenActionMenuSkipsTail(t *testing.T) {
-	m, consumed, err := DecodeGuiPickerActionMenu([]byte{0}, 0)
+	m, consumed, err := generated.DecodeGuiPickerActionMenu([]byte{0}, 0)
 	if err != nil || consumed != 1 || m.Visible != 0 || len(m.Actions) != 0 {
 		t.Fatalf("hidden action menu: m=%+v consumed=%d err=%v", m, consumed, err)
 	}
 }
 
 func TestDecodeLoadStatusErrorTail(t *testing.T) {
-	s, consumed, err := DecodeGuiPickerLoadStatus([]byte{2, 0, 4, 'b', 'o', 'o', 'm'}, 0)
+	s, consumed, err := generated.DecodeGuiPickerLoadStatus([]byte{2, 0, 4, 'b', 'o', 'o', 'm'}, 0)
 	if err != nil || consumed != 7 || s.Status != 2 || s.Message != "boom" {
 		t.Fatalf("error load status: s=%+v consumed=%d err=%v", s, consumed, err)
 	}
 }
 
 func TestDecodeReadyLoadStatusSkipsTail(t *testing.T) {
-	s, consumed, err := DecodeGuiPickerLoadStatus([]byte{0}, 0)
+	s, consumed, err := generated.DecodeGuiPickerLoadStatus([]byte{0}, 0)
 	if err != nil || consumed != 1 || s.Status != 0 || s.Message != "" {
 		t.Fatalf("ready load status: s=%+v consumed=%d err=%v", s, consumed, err)
 	}
 }
 
-func TestDecodeTruncatedPickerItemRejected(t *testing.T) {
-	// count claims 2 match positions but only 1 u16 follows.
+func TestDecodeTruncatedPickerItemElementsRejected(t *testing.T) {
+	// count claims 2 match positions but only 1 u16 follows: the count*stride
+	// require_len fails.
 	bytes := []byte{0xAA, 0xBB, 0xCC, 0, 0, 1, 'x', 0, 0, 0, 0, 2, 0, 1}
-	if _, _, err := DecodePickerItem(bytes, 0); err == nil {
+	if _, _, err := generated.DecodePickerItem(bytes, 0); err == nil {
 		t.Fatal("expected error for truncated match_positions, got nil")
+	}
+}
+
+func TestDecodeTruncatedPickerItemCountByteRejected(t *testing.T) {
+	// Buffer ends exactly before the match_positions count byte: the
+	// count-prefix require_len (a separate bounds path) must reject it.
+	bytes := []byte{0xAA, 0xBB, 0xCC, 0, 0, 1, 'x', 0, 0, 0, 0}
+	if _, _, err := generated.DecodePickerItem(bytes, 0); err == nil {
+		t.Fatal("expected error for missing match_positions count byte, got nil")
 	}
 }

--- a/mix/protocol_generator.ex
+++ b/mix/protocol_generator.ex
@@ -94,10 +94,15 @@ defmodule Minga.Mix.ProtocolGenerator do
   end
 
   # A conditional_tail guard is decoded by substituting base-field names with
-  # their decoded locals (rust_guard_expression / go_guard_expression). An
-  # identifier that is not a base field would be emitted verbatim and fail to
-  # compile (or, worse, resolve to an unrelated tail local), so reject it here
-  # with a clear message instead.
+  # their decoded locals (rust_guard_expression / go_guard_expression). It must
+  # render identically in Rust, Go, and Elixir after substitution, so the legal
+  # grammar is the cross-language-common subset: base-field identifiers, integer
+  # literals, the boolean literals `true`/`false`, comparison operators
+  # (== != < > <= >=), and the connectives && / ||. Any other identifier (named
+  # constant, helper call, a language keyword like Go's `in`) is emitted verbatim
+  # and would not compile, so it is rejected here with a clear message instead.
+  @guard_literals ~w(true false)
+
   @spec validate_conditional_tail_guards!(schema()) :: :ok
   defp validate_conditional_tail_guards!(schema) do
     entries =
@@ -114,7 +119,7 @@ defmodule Minga.Mix.ProtocolGenerator do
 
         (conditional_tail_guard(entry) || "")
         |> guard_identifiers()
-        |> Enum.reject(&MapSet.member?(base, &1))
+        |> Enum.reject(&(MapSet.member?(base, &1) or &1 in @guard_literals))
         |> Enum.map(fn id -> "#{label} -> #{id}" end)
       end)
 
@@ -130,6 +135,7 @@ defmodule Minga.Mix.ProtocolGenerator do
     end
   end
 
+  @spec guard_identifiers(String.t()) :: [String.t()]
   @spec guard_identifiers(String.t()) :: [String.t()]
   defp guard_identifiers(guard) do
     ~r/[A-Za-z_][A-Za-z0-9_]*/
@@ -1408,6 +1414,40 @@ defmodule Minga.Mix.ProtocolGenerator do
     "rgb" => 3
   }
 
+  # Single source of truth for how each primitive wire type is read, shared by
+  # the scalar-field, conditional-tail, and counted_array-element decoders in
+  # both languages. Byte sizes come from @primitive_sizes so a width lives in
+  # exactly one place.
+  @rust_primitive_reads %{
+    "u8" => "bytes[pos]",
+    "u16" => "read_u16(bytes, pos)",
+    "u24" => "read_u24(bytes, pos)",
+    "rgb" => "read_u24(bytes, pos)",
+    "u32" => "read_u32(bytes, pos)",
+    "u64" => "read_u64(bytes, pos)"
+  }
+
+  @go_primitive_reads %{
+    "u8" => "data[pos]",
+    "u16" => "decodeU16(data, pos)",
+    "u24" => "decodeU24(data, pos)",
+    "rgb" => "decodeU24(data, pos)",
+    "u32" => "decodeU32(data, pos)",
+    "u64" => "decodeU64(data, pos)"
+  }
+
+  @rust_string_readers %{
+    "string8" => "read_string8",
+    "string16" => "read_string16",
+    "string32" => "read_string32"
+  }
+
+  @go_string_decoders %{
+    "string8" => "decodeString8",
+    "string16" => "decodeString16",
+    "string32" => "decodeString32"
+  }
+
   @spec fixed_type_size(String.t(), %{String.t() => structure()}) :: non_neg_integer() | nil
   defp fixed_type_size(type_name, _smap) when is_map_key(@primitive_sizes, type_name) do
     Map.fetch!(@primitive_sizes, type_name)
@@ -1527,77 +1567,25 @@ defmodule Minga.Mix.ProtocolGenerator do
     end
   end
 
+  # Go advances the cursor with `pos++` for a single byte and `pos += N`
+  # otherwise; preserved so single-byte reads regenerate byte-for-byte.
+  @spec go_pos_advance(non_neg_integer(), String.t()) :: String.t()
+  defp go_pos_advance(1, indent), do: "#{indent}pos++\n"
+  defp go_pos_advance(size, indent), do: "#{indent}pos += #{size}\n"
+
   @spec go_decode_field_assignment_statement(map(), %{String.t() => structure()}, String.t()) ::
           iodata()
-  defp go_decode_field_assignment_statement(%{"name" => name, "type" => "u8"}, _smap, zero) do
+  defp go_decode_field_assignment_statement(%{"name" => name, "type" => type}, _smap, zero)
+       when is_map_key(@go_primitive_reads, type) do
     local = go_local_name(name)
+    size = @primitive_sizes[type]
 
     [
-      "\t\tif err := decodeRequireLen(data, pos+1, \"#{name}\"); err != nil {\n",
+      "\t\tif err := decodeRequireLen(data, pos+#{size}, \"#{name}\"); err != nil {\n",
       "\t\t\treturn #{zero}, offset, err\n",
       "\t\t}\n",
-      "\t\t#{local} = data[pos]\n",
-      "\t\tpos++\n"
-    ]
-  end
-
-  defp go_decode_field_assignment_statement(%{"name" => name, "type" => "u16"}, _smap, zero) do
-    local = go_local_name(name)
-
-    [
-      "\t\tif err := decodeRequireLen(data, pos+2, \"#{name}\"); err != nil {\n",
-      "\t\t\treturn #{zero}, offset, err\n",
-      "\t\t}\n",
-      "\t\t#{local} = decodeU16(data, pos)\n",
-      "\t\tpos += 2\n"
-    ]
-  end
-
-  defp go_decode_field_assignment_statement(%{"name" => name, "type" => "u24"}, _smap, zero) do
-    local = go_local_name(name)
-
-    [
-      "\t\tif err := decodeRequireLen(data, pos+3, \"#{name}\"); err != nil {\n",
-      "\t\t\treturn #{zero}, offset, err\n",
-      "\t\t}\n",
-      "\t\t#{local} = decodeU24(data, pos)\n",
-      "\t\tpos += 3\n"
-    ]
-  end
-
-  defp go_decode_field_assignment_statement(%{"name" => name, "type" => "u32"}, _smap, zero) do
-    local = go_local_name(name)
-
-    [
-      "\t\tif err := decodeRequireLen(data, pos+4, \"#{name}\"); err != nil {\n",
-      "\t\t\treturn #{zero}, offset, err\n",
-      "\t\t}\n",
-      "\t\t#{local} = decodeU32(data, pos)\n",
-      "\t\tpos += 4\n"
-    ]
-  end
-
-  defp go_decode_field_assignment_statement(%{"name" => name, "type" => "u64"}, _smap, zero) do
-    local = go_local_name(name)
-
-    [
-      "\t\tif err := decodeRequireLen(data, pos+8, \"#{name}\"); err != nil {\n",
-      "\t\t\treturn #{zero}, offset, err\n",
-      "\t\t}\n",
-      "\t\t#{local} = decodeU64(data, pos)\n",
-      "\t\tpos += 8\n"
-    ]
-  end
-
-  defp go_decode_field_assignment_statement(%{"name" => name, "type" => "rgb"}, _smap, zero) do
-    local = go_local_name(name)
-
-    [
-      "\t\tif err := decodeRequireLen(data, pos+3, \"#{name}\"); err != nil {\n",
-      "\t\t\treturn #{zero}, offset, err\n",
-      "\t\t}\n",
-      "\t\t#{local} = decodeU24(data, pos)\n",
-      "\t\tpos += 3\n"
+      "\t\t#{local} = #{@go_primitive_reads[type]}\n",
+      go_pos_advance(size, "\t\t")
     ]
   end
 
@@ -1727,63 +1715,15 @@ defmodule Minga.Mix.ProtocolGenerator do
   end
 
   @spec rust_decode_field_assignment_statement(map(), %{String.t() => structure()}) :: iodata()
-  defp rust_decode_field_assignment_statement(%{"name" => name, "type" => "u8"}, _smap) do
+  defp rust_decode_field_assignment_statement(%{"name" => name, "type" => type}, _smap)
+       when is_map_key(@rust_primitive_reads, type) do
     local = rust_field_name(name)
+    size = @primitive_sizes[type]
 
     [
-      "        require_len(bytes, pos + 1, \"#{name}\")?;\n",
-      "        #{local} = bytes[pos];\n",
-      "        pos += 1;\n"
-    ]
-  end
-
-  defp rust_decode_field_assignment_statement(%{"name" => name, "type" => "u16"}, _smap) do
-    local = rust_field_name(name)
-
-    [
-      "        require_len(bytes, pos + 2, \"#{name}\")?;\n",
-      "        #{local} = read_u16(bytes, pos);\n",
-      "        pos += 2;\n"
-    ]
-  end
-
-  defp rust_decode_field_assignment_statement(%{"name" => name, "type" => "u24"}, _smap) do
-    local = rust_field_name(name)
-
-    [
-      "        require_len(bytes, pos + 3, \"#{name}\")?;\n",
-      "        #{local} = read_u24(bytes, pos);\n",
-      "        pos += 3;\n"
-    ]
-  end
-
-  defp rust_decode_field_assignment_statement(%{"name" => name, "type" => "u32"}, _smap) do
-    local = rust_field_name(name)
-
-    [
-      "        require_len(bytes, pos + 4, \"#{name}\")?;\n",
-      "        #{local} = read_u32(bytes, pos);\n",
-      "        pos += 4;\n"
-    ]
-  end
-
-  defp rust_decode_field_assignment_statement(%{"name" => name, "type" => "u64"}, _smap) do
-    local = rust_field_name(name)
-
-    [
-      "        require_len(bytes, pos + 8, \"#{name}\")?;\n",
-      "        #{local} = read_u64(bytes, pos);\n",
-      "        pos += 8;\n"
-    ]
-  end
-
-  defp rust_decode_field_assignment_statement(%{"name" => name, "type" => "rgb"}, _smap) do
-    local = rust_field_name(name)
-
-    [
-      "        require_len(bytes, pos + 3, \"#{name}\")?;\n",
-      "        #{local} = read_u24(bytes, pos);\n",
-      "        pos += 3;\n"
+      "        require_len(bytes, pos + #{size}, \"#{name}\")?;\n",
+      "        #{local} = #{@rust_primitive_reads[type]};\n",
+      "        pos += #{size};\n"
     ]
   end
 
@@ -2114,63 +2054,15 @@ defmodule Minga.Mix.ProtocolGenerator do
   end
 
   @spec rust_decode_field_statement(map(), %{String.t() => structure()}) :: iodata()
-  defp rust_decode_field_statement(%{"name" => name, "type" => "u8"}, _smap) do
+  defp rust_decode_field_statement(%{"name" => name, "type" => type}, _smap)
+       when is_map_key(@rust_primitive_reads, type) do
     rname = rust_field_name(name)
+    size = @primitive_sizes[type]
 
     [
-      "    require_len(bytes, pos + 1, \"#{name}\")?;\n",
-      "    let #{rname} = bytes[pos];\n",
-      "    pos += 1;\n"
-    ]
-  end
-
-  defp rust_decode_field_statement(%{"name" => name, "type" => "u16"}, _smap) do
-    rname = rust_field_name(name)
-
-    [
-      "    require_len(bytes, pos + 2, \"#{name}\")?;\n",
-      "    let #{rname} = read_u16(bytes, pos);\n",
-      "    pos += 2;\n"
-    ]
-  end
-
-  defp rust_decode_field_statement(%{"name" => name, "type" => "u24"}, _smap) do
-    rname = rust_field_name(name)
-
-    [
-      "    require_len(bytes, pos + 3, \"#{name}\")?;\n",
-      "    let #{rname} = read_u24(bytes, pos);\n",
-      "    pos += 3;\n"
-    ]
-  end
-
-  defp rust_decode_field_statement(%{"name" => name, "type" => "u32"}, _smap) do
-    rname = rust_field_name(name)
-
-    [
-      "    require_len(bytes, pos + 4, \"#{name}\")?;\n",
-      "    let #{rname} = read_u32(bytes, pos);\n",
-      "    pos += 4;\n"
-    ]
-  end
-
-  defp rust_decode_field_statement(%{"name" => name, "type" => "u64"}, _smap) do
-    rname = rust_field_name(name)
-
-    [
-      "    require_len(bytes, pos + 8, \"#{name}\")?;\n",
-      "    let #{rname} = read_u64(bytes, pos);\n",
-      "    pos += 8;\n"
-    ]
-  end
-
-  defp rust_decode_field_statement(%{"name" => name, "type" => "rgb"}, _smap) do
-    rname = rust_field_name(name)
-
-    [
-      "    require_len(bytes, pos + 3, \"#{name}\")?;\n",
-      "    let #{rname} = read_u24(bytes, pos);\n",
-      "    pos += 3;\n"
+      "    require_len(bytes, pos + #{size}, \"#{name}\")?;\n",
+      "    let #{rname} = #{@rust_primitive_reads[type]};\n",
+      "    pos += #{size};\n"
     ]
   end
 
@@ -2259,13 +2151,14 @@ defmodule Minga.Mix.ProtocolGenerator do
   # Fixed-size element arrays are already bounded by their `count * stride`
   # length check, so only variable-size element arrays (strings / structs with
   # strings) need a clamp to stop a bogus count from forcing a large speculative
-  # allocation before any element bytes are validated.
-  @max_array_prealloc 1024
-
+  # allocation before any element bytes are validated. Every element occupies at
+  # least one byte, so the remaining buffer length is a safe, self-scaling upper
+  # bound: tight for small buffers (DoS-safe) and unbounded for genuinely large
+  # payloads (no needless regrowth).
   @spec rust_prealloc(String.t(), String.t(), %{String.t() => structure()}) :: String.t()
   defp rust_prealloc(count_var, element, smap) do
     case element_fixed_byte_size(element, smap) do
-      nil -> "#{count_var}.min(#{@max_array_prealloc})"
+      nil -> "#{count_var}.min(bytes.len() - pos)"
       _ -> count_var
     end
   end
@@ -2273,19 +2166,10 @@ defmodule Minga.Mix.ProtocolGenerator do
   @spec go_prealloc(String.t(), String.t(), %{String.t() => structure()}) :: String.t()
   defp go_prealloc(count_var, element, smap) do
     case element_fixed_byte_size(element, smap) do
-      nil -> "min(#{count_var}, #{@max_array_prealloc})"
+      nil -> "min(#{count_var}, len(data)-pos)"
       _ -> count_var
     end
   end
-
-  @rust_primitive_reads %{
-    "u8" => {"bytes[pos]", 1},
-    "u16" => {"read_u16(bytes, pos)", 2},
-    "u24" => {"read_u24(bytes, pos)", 3},
-    "rgb" => {"read_u24(bytes, pos)", 3},
-    "u32" => {"read_u32(bytes, pos)", 4},
-    "u64" => {"read_u64(bytes, pos)", 8}
-  }
 
   # Decode one counted_array element at `pos` and push it onto `vec`, advancing
   # `pos`. Struct elements emit the same `(item, consumed)` form as before, so
@@ -2300,18 +2184,14 @@ defmodule Minga.Mix.ProtocolGenerator do
           "#{indent}#{vec}.push(item);\n"
         ]
 
-      %{"type" => "string8"} ->
-        ["#{indent}#{vec}.push(read_string8(bytes, &mut pos)?);\n"]
-
-      %{"type" => "string16"} ->
-        ["#{indent}#{vec}.push(read_string16(bytes, &mut pos)?);\n"]
-
-      %{"type" => "string32"} ->
-        ["#{indent}#{vec}.push(read_string32(bytes, &mut pos)?);\n"]
+      %{"type" => str} when is_map_key(@rust_string_readers, str) ->
+        ["#{indent}#{vec}.push(#{@rust_string_readers[str]}(bytes, &mut pos)?);\n"]
 
       %{"type" => prim} ->
-        {expr, size} = Map.fetch!(@rust_primitive_reads, prim)
-        ["#{indent}#{vec}.push(#{expr});\n", "#{indent}pos += #{size};\n"]
+        [
+          "#{indent}#{vec}.push(#{@rust_primitive_reads[prim]});\n",
+          "#{indent}pos += #{@primitive_sizes[prim]};\n"
+        ]
     end
   end
 
@@ -2675,75 +2555,17 @@ defmodule Minga.Mix.ProtocolGenerator do
   end
 
   @spec go_decode_field_statement(map(), %{String.t() => structure()}, String.t()) :: iodata()
-  defp go_decode_field_statement(%{"name" => name, "type" => "u8"}, _smap, zero) do
+  defp go_decode_field_statement(%{"name" => name, "type" => type}, _smap, zero)
+       when is_map_key(@go_primitive_reads, type) do
     local = go_local_name(name)
+    size = @primitive_sizes[type]
 
     [
-      "\tif err := decodeRequireLen(data, pos+1, \"#{name}\"); err != nil {\n",
+      "\tif err := decodeRequireLen(data, pos+#{size}, \"#{name}\"); err != nil {\n",
       "\t\treturn #{zero}, offset, err\n",
       "\t}\n",
-      "\t#{local} := data[pos]\n",
-      "\tpos++\n"
-    ]
-  end
-
-  defp go_decode_field_statement(%{"name" => name, "type" => "u16"}, _smap, zero) do
-    local = go_local_name(name)
-
-    [
-      "\tif err := decodeRequireLen(data, pos+2, \"#{name}\"); err != nil {\n",
-      "\t\treturn #{zero}, offset, err\n",
-      "\t}\n",
-      "\t#{local} := decodeU16(data, pos)\n",
-      "\tpos += 2\n"
-    ]
-  end
-
-  defp go_decode_field_statement(%{"name" => name, "type" => "u24"}, _smap, zero) do
-    local = go_local_name(name)
-
-    [
-      "\tif err := decodeRequireLen(data, pos+3, \"#{name}\"); err != nil {\n",
-      "\t\treturn #{zero}, offset, err\n",
-      "\t}\n",
-      "\t#{local} := decodeU24(data, pos)\n",
-      "\tpos += 3\n"
-    ]
-  end
-
-  defp go_decode_field_statement(%{"name" => name, "type" => "u32"}, _smap, zero) do
-    local = go_local_name(name)
-
-    [
-      "\tif err := decodeRequireLen(data, pos+4, \"#{name}\"); err != nil {\n",
-      "\t\treturn #{zero}, offset, err\n",
-      "\t}\n",
-      "\t#{local} := decodeU32(data, pos)\n",
-      "\tpos += 4\n"
-    ]
-  end
-
-  defp go_decode_field_statement(%{"name" => name, "type" => "u64"}, _smap, zero) do
-    local = go_local_name(name)
-
-    [
-      "\tif err := decodeRequireLen(data, pos+8, \"#{name}\"); err != nil {\n",
-      "\t\treturn #{zero}, offset, err\n",
-      "\t}\n",
-      "\t#{local} := decodeU64(data, pos)\n",
-      "\tpos += 8\n"
-    ]
-  end
-
-  defp go_decode_field_statement(%{"name" => name, "type" => "rgb"}, _smap, zero) do
-    local = go_local_name(name)
-
-    [
-      "\tif err := decodeRequireLen(data, pos+3, \"#{name}\"); err != nil {\n",
-      "\t\treturn #{zero}, offset, err\n",
-      "\t}\n",
-      "\t#{local} := decodeU24(data, pos)\n",
-      "\tpos += 3\n"
+      "\t#{local} := #{@go_primitive_reads[type]}\n",
+      go_pos_advance(size, "\t")
     ]
   end
 
@@ -2835,21 +2657,6 @@ defmodule Minga.Mix.ProtocolGenerator do
     ]
   end
 
-  @go_primitive_reads %{
-    "u8" => {"data[pos]", 1},
-    "u16" => {"decodeU16(data, pos)", 2},
-    "u24" => {"decodeU24(data, pos)", 3},
-    "rgb" => {"decodeU24(data, pos)", 3},
-    "u32" => {"decodeU32(data, pos)", 4},
-    "u64" => {"decodeU64(data, pos)", 8}
-  }
-
-  @go_string_decoders %{
-    "string8" => "decodeString8",
-    "string16" => "decodeString16",
-    "string32" => "decodeString32"
-  }
-
   # Decode one counted_array element at `pos`, append it onto `vec`, advance
   # `pos`. Struct elements emit the same `(item, nextPos, err)` form as before,
   # so existing struct arrays regenerate byte-for-byte.
@@ -2863,8 +2670,10 @@ defmodule Minga.Mix.ProtocolGenerator do
         go_decode_array_element_via("#{@go_string_decoders[str]}(data, pos)", vec, indent, zero)
 
       %{"type" => prim} ->
-        {expr, size} = Map.fetch!(@go_primitive_reads, prim)
-        ["#{indent}#{vec} = append(#{vec}, #{expr})\n", "#{indent}pos += #{size}\n"]
+        [
+          "#{indent}#{vec} = append(#{vec}, #{@go_primitive_reads[prim]})\n",
+          "#{indent}pos += #{@primitive_sizes[prim]}\n"
+        ]
     end
   end
 

--- a/mix/protocol_generator.ex
+++ b/mix/protocol_generator.ex
@@ -1328,10 +1328,10 @@ defmodule Minga.Mix.ProtocolGenerator do
         Mix.raise("command_fields reference unknown opcodes in #{@schema_path}: #{bad_opcodes}")
     end
 
-    # Validate struct/counted_array field references
+    # Validate struct/counted_array field references (base fields + conditional tail)
     bad_refs =
       command_fields
-      |> Enum.flat_map(fn cf -> Enum.map(cf["fields"] || [], &{cf, &1}) end)
+      |> Enum.flat_map(fn cf -> Enum.map(entry_fields(cf), &{cf, &1}) end)
       |> Enum.filter(fn {_cf, field} ->
         (field["type"] == "struct" or field["type"] == "counted_array") and
           is_binary(field["element"]) and not Map.has_key?(smap, field["element"])
@@ -1441,9 +1441,15 @@ defmodule Minga.Mix.ProtocolGenerator do
     )
   end
 
+  # Only fields whose conditional-tail assignment statement reuses the outer
+  # `err` variable (via `local, pos, err = ...`) need it declared. string/struct
+  # do; counted_array scopes its own `err :=` in the decode loop, and primitives
+  # scope theirs in `if err := decodeRequireLen(...)`. Listing counted_array here
+  # would emit an unused `var err error` for a counted_array-only tail, which is
+  # a Go compile error.
   @spec go_field_needs_error?(map()) :: boolean()
   defp go_field_needs_error?(%{"type" => type})
-       when type in ["string8", "string16", "string32", "struct", "counted_array"], do: true
+       when type in ["string8", "string16", "string32", "struct"], do: true
 
   defp go_field_needs_error?(_field), do: false
 
@@ -2846,7 +2852,7 @@ defmodule Minga.Mix.ProtocolGenerator do
     command_fields
     |> Enum.map(fn cf ->
       name = rust_struct_name(cf["opcode"]) <> "Fields"
-      fields = cf["fields"] || []
+      fields = entry_fields(cf)
       has_variable = Enum.any?(fields, fn f -> fixed_field_size(f, smap) == nil end)
 
       derive =
@@ -2879,8 +2885,9 @@ defmodule Minga.Mix.ProtocolGenerator do
         "pub fn #{fn_name}(bytes: &[u8], offset: usize) -> Result<(#{struct_name}, usize), DecodeError> {\n",
         "    let mut pos = offset;\n",
         Enum.map(fields, &rust_decode_field_statement(&1, smap)),
+        rust_decode_conditional_tail_block(cf, smap),
         "    Ok((#{struct_name} {\n",
-        Enum.map(fields, fn field -> "        #{rust_field_name(field["name"])},\n" end),
+        Enum.map(entry_fields(cf), fn field -> "        #{rust_field_name(field["name"])},\n" end),
         "    }, pos - offset))\n",
         "}\n\n"
       ]
@@ -2895,7 +2902,7 @@ defmodule Minga.Mix.ProtocolGenerator do
     command_fields
     |> Enum.map(fn cf ->
       name = go_struct_name(cf["opcode"]) <> "Fields"
-      fields = cf["fields"] || []
+      fields = entry_fields(cf)
 
       [
         "type #{name} struct {\n",
@@ -2922,8 +2929,9 @@ defmodule Minga.Mix.ProtocolGenerator do
         "func #{fn_name}(data []byte, offset int) (#{struct_name}, int, error) {\n",
         "\tpos := offset\n",
         Enum.map(fields, &go_decode_field_statement(&1, smap, zero)),
+        go_decode_conditional_tail_block(cf, smap, zero),
         "\treturn #{struct_name}{\n",
-        Enum.map(fields, fn field ->
+        Enum.map(entry_fields(cf), fn field ->
           "\t\t#{go_field_name(field["name"])}: #{go_local_name(field["name"])},\n"
         end),
         "\t}, pos, nil\n",

--- a/mix/protocol_generator.ex
+++ b/mix/protocol_generator.ex
@@ -88,6 +88,7 @@ defmodule Minga.Mix.ProtocolGenerator do
     validate_framing!(schema)
     validate_structures!(schema)
     validate_sections!(schema)
+    validate_command_fields!(schema)
     schema
   end
 
@@ -1185,6 +1186,11 @@ defmodule Minga.Mix.ProtocolGenerator do
     end
   end
 
+  @type command_fields :: %{String.t() => term()}
+
+  @spec command_fields_list(schema()) :: [command_fields()]
+  defp command_fields_list(schema), do: Map.get(schema, "command_fields", [])
+
   @spec validate_structures!(schema()) :: :ok
   defp validate_structures!(schema) do
     structures = Map.get(schema, "structures", [])
@@ -1299,6 +1305,47 @@ defmodule Minga.Mix.ProtocolGenerator do
     case bad do
       "" -> :ok
       _ -> Mix.raise("Section fields reference unknown structures in #{@schema_path}: #{bad}")
+    end
+  end
+
+  @spec validate_command_fields!(schema()) :: :ok
+  defp validate_command_fields!(schema) do
+    command_fields = command_fields_list(schema)
+    opcode_names = schema |> Map.fetch!("opcodes") |> MapSet.new(& &1["name"])
+    smap = structures_map(schema)
+
+    # All command_fields opcodes must reference existing opcodes
+    bad_opcodes =
+      command_fields
+      |> Enum.reject(&MapSet.member?(opcode_names, &1["opcode"]))
+      |> Enum.map_join(", ", & &1["opcode"])
+
+    case bad_opcodes do
+      "" ->
+        :ok
+
+      _ ->
+        Mix.raise("command_fields reference unknown opcodes in #{@schema_path}: #{bad_opcodes}")
+    end
+
+    # Validate struct/counted_array field references
+    bad_refs =
+      command_fields
+      |> Enum.flat_map(fn cf -> Enum.map(cf["fields"] || [], &{cf, &1}) end)
+      |> Enum.filter(fn {_cf, field} ->
+        (field["type"] == "struct" or field["type"] == "counted_array") and
+          is_binary(field["element"]) and not Map.has_key?(smap, field["element"])
+      end)
+      |> Enum.map_join(", ", fn {cf, field} ->
+        "#{cf["opcode"]}.#{field["name"]} -> #{field["element"]}"
+      end)
+
+    case bad_refs do
+      "" ->
+        :ok
+
+      _ ->
+        Mix.raise("command_fields reference unknown structures in #{@schema_path}: #{bad_refs}")
     end
   end
 
@@ -1807,6 +1854,7 @@ defmodule Minga.Mix.ProtocolGenerator do
   defp rust_semantic_types_file(schema) do
     structures = Map.get(schema, "structures", [])
     sections = sections_list(schema)
+    command_fields = command_fields_list(schema)
     smap = structures_map(schema)
 
     [
@@ -1817,7 +1865,8 @@ defmodule Minga.Mix.ProtocolGenerator do
       "\n",
       rust_size_constants(structures, smap),
       "\n",
-      rust_section_struct_definitions(sections, smap)
+      rust_section_struct_definitions(sections, smap),
+      rust_command_fields_struct_definitions(command_fields, smap)
     ]
     |> IO.iodata_to_binary()
   end
@@ -1902,6 +1951,7 @@ defmodule Minga.Mix.ProtocolGenerator do
   defp rust_semantic_decode_file(schema) do
     structures = Map.get(schema, "structures", [])
     sections = sections_list(schema)
+    command_fields = command_fields_list(schema)
     smap = structures_map(schema)
 
     [
@@ -1914,7 +1964,8 @@ defmodule Minga.Mix.ProtocolGenerator do
       "\n",
       Enum.map(structures, &rust_decode_structure(&1, smap)),
       "\n",
-      rust_decode_section_functions(sections, smap)
+      rust_decode_section_functions(sections, smap),
+      rust_decode_command_fields_functions(command_fields, smap)
     ]
     |> IO.iodata_to_binary()
   end
@@ -2320,6 +2371,7 @@ defmodule Minga.Mix.ProtocolGenerator do
   defp go_semantic_types_file(schema) do
     structures = Map.get(schema, "structures", [])
     sections = sections_list(schema)
+    command_fields = command_fields_list(schema)
     smap = structures_map(schema)
 
     [
@@ -2327,7 +2379,8 @@ defmodule Minga.Mix.ProtocolGenerator do
       "package generated\n\n",
       go_structure_definitions(structures, smap),
       go_size_constants(structures, smap),
-      go_section_struct_definitions(sections, smap)
+      go_section_struct_definitions(sections, smap),
+      go_command_fields_struct_definitions(command_fields, smap)
     ]
     |> IO.iodata_to_binary()
     |> format_generated_go_file()
@@ -2410,6 +2463,7 @@ defmodule Minga.Mix.ProtocolGenerator do
   defp go_semantic_decode_file(schema) do
     structures = Map.get(schema, "structures", [])
     sections = sections_list(schema)
+    command_fields = command_fields_list(schema)
     smap = structures_map(schema)
 
     [
@@ -2420,7 +2474,8 @@ defmodule Minga.Mix.ProtocolGenerator do
       "\n",
       Enum.map(structures, &go_decode_structure(&1, smap)),
       "\n",
-      go_decode_section_functions(sections, smap)
+      go_decode_section_functions(sections, smap),
+      go_decode_command_fields_functions(command_fields, smap)
     ]
     |> IO.iodata_to_binary()
     |> format_generated_go_file()
@@ -2781,6 +2836,100 @@ defmodule Minga.Mix.ProtocolGenerator do
       "\treturn items, pos, nil\n",
       "}\n\n"
     ]
+  end
+
+  # ── Rust: command_fields types & decode ────────────────────────────────
+
+  @spec rust_command_fields_struct_definitions([command_fields()], %{String.t() => structure()}) ::
+          iodata()
+  defp rust_command_fields_struct_definitions(command_fields, smap) do
+    command_fields
+    |> Enum.map(fn cf ->
+      name = rust_struct_name(cf["opcode"]) <> "Fields"
+      fields = cf["fields"] || []
+      has_variable = Enum.any?(fields, fn f -> fixed_field_size(f, smap) == nil end)
+
+      derive =
+        if has_variable,
+          do: "#[derive(Debug, Clone, PartialEq, Eq)]\n",
+          else: "#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n"
+
+      [
+        derive,
+        "pub struct #{name} {\n",
+        Enum.map(fields, fn field ->
+          "    pub #{rust_field_name(field["name"])}: #{rust_type(field, smap)},\n"
+        end),
+        "}\n\n"
+      ]
+    end)
+  end
+
+  @spec rust_decode_command_fields_functions([command_fields()], %{String.t() => structure()}) ::
+          iodata()
+  defp rust_decode_command_fields_functions(command_fields, smap) do
+    command_fields
+    |> Enum.map(fn cf ->
+      struct_name = rust_struct_name(cf["opcode"]) <> "Fields"
+      fn_name = "decode_#{cf["opcode"]}_fields"
+      fields = cf["fields"] || []
+
+      [
+        "// Command field decoder for #{cf["opcode"]}\n\n",
+        "pub fn #{fn_name}(bytes: &[u8], offset: usize) -> Result<(#{struct_name}, usize), DecodeError> {\n",
+        "    let mut pos = offset;\n",
+        Enum.map(fields, &rust_decode_field_statement(&1, smap)),
+        "    Ok((#{struct_name} {\n",
+        Enum.map(fields, fn field -> "        #{rust_field_name(field["name"])},\n" end),
+        "    }, pos - offset))\n",
+        "}\n\n"
+      ]
+    end)
+  end
+
+  # ── Go: command_fields types & decode ──────────────────────────────────
+
+  @spec go_command_fields_struct_definitions([command_fields()], %{String.t() => structure()}) ::
+          iodata()
+  defp go_command_fields_struct_definitions(command_fields, smap) do
+    command_fields
+    |> Enum.map(fn cf ->
+      name = go_struct_name(cf["opcode"]) <> "Fields"
+      fields = cf["fields"] || []
+
+      [
+        "type #{name} struct {\n",
+        Enum.map(fields, fn field ->
+          "\t#{go_field_name(field["name"])} #{go_type(field, smap)}\n"
+        end),
+        "}\n\n"
+      ]
+    end)
+  end
+
+  @spec go_decode_command_fields_functions([command_fields()], %{String.t() => structure()}) ::
+          iodata()
+  defp go_decode_command_fields_functions(command_fields, smap) do
+    command_fields
+    |> Enum.map(fn cf ->
+      struct_name = go_struct_name(cf["opcode"]) <> "Fields"
+      fn_name = "Decode#{struct_name}"
+      fields = cf["fields"] || []
+      zero = "#{struct_name}{}"
+
+      [
+        "// Command field decoder for #{cf["opcode"]}\n\n",
+        "func #{fn_name}(data []byte, offset int) (#{struct_name}, int, error) {\n",
+        "\tpos := offset\n",
+        Enum.map(fields, &go_decode_field_statement(&1, smap, zero)),
+        "\treturn #{struct_name}{\n",
+        Enum.map(fields, fn field ->
+          "\t\t#{go_field_name(field["name"])}: #{go_local_name(field["name"])},\n"
+        end),
+        "\t}, pos, nil\n",
+        "}\n\n"
+      ]
+    end)
   end
 
   @spec constant_name(String.t()) :: String.t()

--- a/mix/protocol_generator.ex
+++ b/mix/protocol_generator.ex
@@ -89,7 +89,52 @@ defmodule Minga.Mix.ProtocolGenerator do
     validate_structures!(schema)
     validate_sections!(schema)
     validate_command_fields!(schema)
+    validate_conditional_tail_guards!(schema)
     schema
+  end
+
+  # A conditional_tail guard is decoded by substituting base-field names with
+  # their decoded locals (rust_guard_expression / go_guard_expression). An
+  # identifier that is not a base field would be emitted verbatim and fail to
+  # compile (or, worse, resolve to an unrelated tail local), so reject it here
+  # with a clear message instead.
+  @spec validate_conditional_tail_guards!(schema()) :: :ok
+  defp validate_conditional_tail_guards!(schema) do
+    entries =
+      Map.get(schema, "structures", []) ++
+        Map.get(schema, "sections", []) ++
+        command_fields_list(schema)
+
+    bad =
+      entries
+      |> Enum.filter(&entry_conditional_tail/1)
+      |> Enum.flat_map(fn entry ->
+        base = Map.get(entry, "fields", []) |> MapSet.new(& &1["name"])
+        label = entry["name"] || entry["opcode"]
+
+        (conditional_tail_guard(entry) || "")
+        |> guard_identifiers()
+        |> Enum.reject(&MapSet.member?(base, &1))
+        |> Enum.map(fn id -> "#{label} -> #{id}" end)
+      end)
+
+    case bad do
+      [] ->
+        :ok
+
+      _ ->
+        Mix.raise(
+          "conditional_tail guards must reference only base fields in #{@schema_path}: " <>
+            Enum.join(bad, ", ")
+        )
+    end
+  end
+
+  @spec guard_identifiers(String.t()) :: [String.t()]
+  defp guard_identifiers(guard) do
+    ~r/[A-Za-z_][A-Za-z0-9_]*/
+    |> Regex.scan(guard)
+    |> List.flatten()
   end
 
   @spec generated_files(schema()) :: [generated_file()]
@@ -1218,7 +1263,8 @@ defmodule Minga.Mix.ProtocolGenerator do
       |> Enum.flat_map(fn s -> Enum.map(entry_fields(s), &{s["name"], &1}) end)
       |> Enum.filter(fn {_parent, field} ->
         (field["type"] == "struct" or field["type"] == "counted_array") and
-          is_binary(field["element"]) and not Map.has_key?(smap, field["element"])
+          is_binary(field["element"]) and
+          not element_resolves?(field["type"], field["element"], smap)
       end)
       |> Enum.map_join(", ", fn {parent, field} ->
         "#{parent}.#{field["name"]} -> #{field["element"]}"
@@ -1279,7 +1325,7 @@ defmodule Minga.Mix.ProtocolGenerator do
     bad =
       sections
       |> Enum.filter(fn s -> s["layout"] == "counted_array" and is_binary(s["element"]) end)
-      |> Enum.reject(fn s -> Map.has_key?(smap, s["element"]) end)
+      |> Enum.reject(fn s -> element_resolves?("counted_array", s["element"], smap) end)
       |> Enum.map_join(", ", fn s -> "#{s["opcode"]}/#{s["name"]} -> #{s["element"]}" end)
 
     case bad do
@@ -1296,7 +1342,8 @@ defmodule Minga.Mix.ProtocolGenerator do
       |> Enum.flat_map(fn s -> Enum.map(entry_fields(s), &{s, &1}) end)
       |> Enum.filter(fn {_s, field} ->
         (field["type"] == "struct" or field["type"] == "counted_array") and
-          is_binary(field["element"]) and not Map.has_key?(smap, field["element"])
+          is_binary(field["element"]) and
+          not element_resolves?(field["type"], field["element"], smap)
       end)
       |> Enum.map_join(", ", fn {s, field} ->
         "#{s["opcode"]}/#{s["name"]}.#{field["name"]} -> #{field["element"]}"
@@ -1334,7 +1381,8 @@ defmodule Minga.Mix.ProtocolGenerator do
       |> Enum.flat_map(fn cf -> Enum.map(entry_fields(cf), &{cf, &1}) end)
       |> Enum.filter(fn {_cf, field} ->
         (field["type"] == "struct" or field["type"] == "counted_array") and
-          is_binary(field["element"]) and not Map.has_key?(smap, field["element"])
+          is_binary(field["element"]) and
+          not element_resolves?(field["type"], field["element"], smap)
       end)
       |> Enum.map_join(", ", fn {cf, field} ->
         "#{cf["opcode"]}.#{field["name"]} -> #{field["element"]}"
@@ -1613,10 +1661,9 @@ defmodule Minga.Mix.ProtocolGenerator do
        ) do
     local = go_local_name(name)
     {count_read, count_size} = go_count_read(count_type)
-    element_fixed_size = fixed_structure_size(element, smap)
 
     stride_check =
-      case element_fixed_size do
+      case element_fixed_byte_size(element, smap) do
         nil ->
           []
 
@@ -1635,14 +1682,9 @@ defmodule Minga.Mix.ProtocolGenerator do
       "\t\t#{local}Count := int(#{count_read})\n",
       "\t\tpos += #{count_size}\n",
       stride_check,
-      "\t\t#{local} = make([]#{go_struct_name(element)}, 0, #{local}Count)\n",
+      "\t\t#{local} = make([]#{go_type(element_field(element), smap)}, 0, #{go_prealloc("#{local}Count", element, smap)})\n",
       "\t\tfor i := 0; i < #{local}Count; i++ {\n",
-      "\t\t\titem, nextPos, err := Decode#{go_struct_name(element)}(data, pos)\n",
-      "\t\t\tif err != nil {\n",
-      "\t\t\t\treturn #{zero}, offset, err\n",
-      "\t\t\t}\n",
-      "\t\t\tpos = nextPos\n",
-      "\t\t\t#{local} = append(#{local}, item)\n",
+      go_decode_array_element(element, local, "\t\t\t", zero),
       "\t\t}\n"
     ]
   end
@@ -1657,8 +1699,8 @@ defmodule Minga.Mix.ProtocolGenerator do
   defp rust_zero_value(%{"type" => "struct", "element" => element}, _smap),
     do: "#{rust_struct_name(element)}::default()"
 
-  defp rust_zero_value(%{"type" => "counted_array", "element" => element}, _smap),
-    do: "Vec::<#{rust_struct_name(element)}>::new()"
+  defp rust_zero_value(%{"type" => "counted_array", "element" => element}, smap),
+    do: "Vec::<#{rust_type(element_field(element), smap)}>::new()"
 
   defp rust_zero_value(_field, _smap), do: "Default::default()"
 
@@ -1793,17 +1835,14 @@ defmodule Minga.Mix.ProtocolGenerator do
        ) do
     local = rust_field_name(name)
     {count_read, count_size} = rust_count_read(count_type)
-    element_fixed_size = fixed_structure_size(element, smap)
 
     stride_check =
-      case element_fixed_size do
+      case element_fixed_byte_size(element, smap) do
         nil ->
           []
 
         stride ->
-          [
-            "        require_len(bytes, pos + #{local}_count * #{stride}, \"#{name}\")?;\n"
-          ]
+          ["        require_len(bytes, pos + #{local}_count * #{stride}, \"#{name}\")?;\n"]
       end
 
     [
@@ -1811,11 +1850,9 @@ defmodule Minga.Mix.ProtocolGenerator do
       "        let #{local}_count = #{count_read};\n",
       "        pos += #{count_size};\n",
       stride_check,
-      "        let mut #{local}_value = Vec::with_capacity(#{local}_count);\n",
+      "        let mut #{local}_value = Vec::with_capacity(#{rust_prealloc("#{local}_count", element, smap)});\n",
       "        for _ in 0..#{local}_count {\n",
-      "            let (item, consumed) = decode_#{element}(bytes, pos)?;\n",
-      "            pos += consumed;\n",
-      "            #{local}_value.push(item);\n",
+      rust_decode_array_element(element, "#{local}_value", "            "),
       "        }\n",
       "        #{local} = #{local}_value;\n"
     ]
@@ -1838,8 +1875,8 @@ defmodule Minga.Mix.ProtocolGenerator do
     rust_struct_name(element)
   end
 
-  defp rust_type(%{"type" => "counted_array", "element" => element}, _smap) do
-    "Vec<#{rust_struct_name(element)}>"
+  defp rust_type(%{"type" => "counted_array", "element" => element}, smap) do
+    "Vec<#{rust_type(element_field(element), smap)}>"
   end
 
   @spec rust_struct_name(String.t()) :: String.t()
@@ -1849,9 +1886,15 @@ defmodule Minga.Mix.ProtocolGenerator do
     |> Enum.map_join("", &String.capitalize/1)
   end
 
+  # Locals the generated decoders introduce themselves. A schema field whose
+  # name matches one of these would shadow the byte cursor, input slice, or loop
+  # temp and silently corrupt decoding (or fail to compile in Go), so field names
+  # that collide are suffixed. Kept in sync with the decode templates below.
+  @reserved_decoder_locals ~w(pos offset data bytes err item consumed next_pos count)
   @rust_keywords ~w(type self super crate mod fn struct enum impl trait pub use let mut const static ref match return if else for while loop break continue where as in move box dyn async await try macro yield)
   @spec rust_field_name(String.t()) :: String.t()
   defp rust_field_name(name) when name in @rust_keywords, do: "r##{name}"
+  defp rust_field_name(name) when name in @reserved_decoder_locals, do: "#{name}_"
   defp rust_field_name(name), do: name
 
   # ── Rust: semantic_types.rs ──────────────────────────────────────────────
@@ -2044,20 +2087,27 @@ defmodule Minga.Mix.ProtocolGenerator do
 
   @spec rust_decode_structure(structure(), %{String.t() => structure()}) :: iodata()
   defp rust_decode_structure(structure, smap) do
-    name = structure["name"]
-    struct_name = rust_struct_name(name)
-    fn_name = "decode_#{name}"
-    fields = structure["fields"] || []
+    rust_record_decoder(
+      "decode_#{structure["name"]}",
+      rust_struct_name(structure["name"]),
+      structure,
+      smap
+    )
+  end
 
+  # Emit a Rust decode function for any record (structure, inline section, or
+  # command_fields): base fields, then the conditional tail, then construct from
+  # the full field list. The three callers differ only in fn/struct name.
+  @spec rust_record_decoder(String.t(), String.t(), map(), %{String.t() => structure()}) ::
+          iodata()
+  defp rust_record_decoder(fn_name, struct_name, entry, smap) do
     [
       "pub fn #{fn_name}(bytes: &[u8], offset: usize) -> Result<(#{struct_name}, usize), DecodeError> {\n",
       "    let mut pos = offset;\n",
-      Enum.map(fields, &rust_decode_field_statement(&1, smap)),
-      rust_decode_conditional_tail_block(structure, smap),
+      Enum.map(entry["fields"] || [], &rust_decode_field_statement(&1, smap)),
+      rust_decode_conditional_tail_block(entry, smap),
       "    Ok((#{struct_name} {\n",
-      Enum.map(entry_fields(structure), fn field ->
-        "        #{rust_field_name(field["name"])},\n"
-      end),
+      Enum.map(entry_fields(entry), fn field -> "        #{rust_field_name(field["name"])},\n" end),
       "    }, pos - offset))\n",
       "}\n\n"
     ]
@@ -2162,41 +2212,107 @@ defmodule Minga.Mix.ProtocolGenerator do
        ) do
     rname = rust_field_name(name)
     {count_read, count_size} = rust_count_read(count_type)
-    element_fixed_size = fixed_structure_size(element, smap)
 
-    count_lines = [
-      "    require_len(bytes, pos + #{count_size}, \"#{name} count\")?;\n",
-      "    let #{rname}_count = #{count_read};\n",
-      "    pos += #{count_size};\n"
-    ]
-
-    decode_lines =
-      case element_fixed_size do
-        nil ->
-          # Variable-size elements: decode one by one
-          [
-            "    let mut #{rname} = Vec::with_capacity(#{rname}_count);\n",
-            "    for _ in 0..#{rname}_count {\n",
-            "        let (item, consumed) = decode_#{element}(bytes, pos)?;\n",
-            "        pos += consumed;\n",
-            "        #{rname}.push(item);\n",
-            "    }\n"
-          ]
-
-        stride ->
-          # Fixed-size elements: can validate upfront, still decode individually
-          [
-            "    require_len(bytes, pos + #{rname}_count * #{stride}, \"#{name}\")?;\n",
-            "    let mut #{rname} = Vec::with_capacity(#{rname}_count);\n",
-            "    for _ in 0..#{rname}_count {\n",
-            "        let (item, consumed) = decode_#{element}(bytes, pos)?;\n",
-            "        pos += consumed;\n",
-            "        #{rname}.push(item);\n",
-            "    }\n"
-          ]
+    stride_check =
+      case element_fixed_byte_size(element, smap) do
+        nil -> []
+        stride -> ["    require_len(bytes, pos + #{rname}_count * #{stride}, \"#{name}\")?;\n"]
       end
 
-    count_lines ++ decode_lines
+    [
+      "    require_len(bytes, pos + #{count_size}, \"#{name} count\")?;\n",
+      "    let #{rname}_count = #{count_read};\n",
+      "    pos += #{count_size};\n",
+      stride_check,
+      "    let mut #{rname} = Vec::with_capacity(#{rust_prealloc("#{rname}_count", element, smap)});\n",
+      "    for _ in 0..#{rname}_count {\n",
+      rust_decode_array_element(element, rname, "        "),
+      "    }\n"
+    ]
+  end
+
+  # A counted_array element is either a named structure or a bare wire type
+  # (primitive or string). This normalizes it to a field-shaped map so the
+  # existing type/size helpers apply, which lets counted_array hold primitives
+  # directly without a single-field wrapper structure.
+  @element_wire_types ~w(u8 u16 u24 u32 u64 rgb string8 string16 string32)
+  @spec element_field(String.t()) :: map()
+  defp element_field(element) when element in @element_wire_types, do: %{"type" => element}
+  defp element_field(element), do: %{"type" => "struct", "element" => element}
+
+  # Fixed byte size of one counted_array element (nil for variable-size:
+  # strings, or structures that contain strings/arrays).
+  @spec element_fixed_byte_size(String.t(), %{String.t() => structure()}) ::
+          non_neg_integer() | nil
+  defp element_fixed_byte_size(element, smap), do: fixed_field_size(element_field(element), smap)
+
+  # Whether a struct/counted_array element reference resolves: counted_array may
+  # name a bare wire type (primitive/string) or a structure; a struct field must
+  # name a defined structure.
+  @spec element_resolves?(String.t(), term(), %{String.t() => structure()}) :: boolean()
+  defp element_resolves?("counted_array", element, smap),
+    do: element in @element_wire_types or Map.has_key?(smap, element)
+
+  defp element_resolves?(_type, element, smap), do: Map.has_key?(smap, element)
+
+  # Upper bound on the capacity we pre-allocate from a wire-supplied count.
+  # Fixed-size element arrays are already bounded by their `count * stride`
+  # length check, so only variable-size element arrays (strings / structs with
+  # strings) need a clamp to stop a bogus count from forcing a large speculative
+  # allocation before any element bytes are validated.
+  @max_array_prealloc 1024
+
+  @spec rust_prealloc(String.t(), String.t(), %{String.t() => structure()}) :: String.t()
+  defp rust_prealloc(count_var, element, smap) do
+    case element_fixed_byte_size(element, smap) do
+      nil -> "#{count_var}.min(#{@max_array_prealloc})"
+      _ -> count_var
+    end
+  end
+
+  @spec go_prealloc(String.t(), String.t(), %{String.t() => structure()}) :: String.t()
+  defp go_prealloc(count_var, element, smap) do
+    case element_fixed_byte_size(element, smap) do
+      nil -> "min(#{count_var}, #{@max_array_prealloc})"
+      _ -> count_var
+    end
+  end
+
+  @rust_primitive_reads %{
+    "u8" => {"bytes[pos]", 1},
+    "u16" => {"read_u16(bytes, pos)", 2},
+    "u24" => {"read_u24(bytes, pos)", 3},
+    "rgb" => {"read_u24(bytes, pos)", 3},
+    "u32" => {"read_u32(bytes, pos)", 4},
+    "u64" => {"read_u64(bytes, pos)", 8}
+  }
+
+  # Decode one counted_array element at `pos` and push it onto `vec`, advancing
+  # `pos`. Struct elements emit the same `(item, consumed)` form as before, so
+  # existing struct arrays regenerate byte-for-byte.
+  @spec rust_decode_array_element(String.t(), String.t(), String.t()) :: iodata()
+  defp rust_decode_array_element(element, vec, indent) do
+    case element_field(element) do
+      %{"type" => "struct", "element" => el} ->
+        [
+          "#{indent}let (item, consumed) = decode_#{el}(bytes, pos)?;\n",
+          "#{indent}pos += consumed;\n",
+          "#{indent}#{vec}.push(item);\n"
+        ]
+
+      %{"type" => "string8"} ->
+        ["#{indent}#{vec}.push(read_string8(bytes, &mut pos)?);\n"]
+
+      %{"type" => "string16"} ->
+        ["#{indent}#{vec}.push(read_string16(bytes, &mut pos)?);\n"]
+
+      %{"type" => "string32"} ->
+        ["#{indent}#{vec}.push(read_string32(bytes, &mut pos)?);\n"]
+
+      %{"type" => prim} ->
+        {expr, size} = Map.fetch!(@rust_primitive_reads, prim)
+        ["#{indent}#{vec}.push(#{expr});\n", "#{indent}pos += #{size};\n"]
+    end
   end
 
   @spec rust_count_read(String.t()) :: {String.t(), non_neg_integer()}
@@ -2232,65 +2348,40 @@ defmodule Minga.Mix.ProtocolGenerator do
   @spec rust_decode_inline_section(String.t(), section(), %{String.t() => structure()}) ::
           iodata()
   defp rust_decode_inline_section(_opcode, section, smap) do
-    struct_name = rust_section_struct_name(section)
-    fn_name = "decode_#{section["opcode"]}_#{section["name"]}"
-    fields = section["fields"] || []
-
-    [
-      "pub fn #{fn_name}(bytes: &[u8], offset: usize) -> Result<(#{struct_name}, usize), DecodeError> {\n",
-      "    let mut pos = offset;\n",
-      Enum.map(fields, &rust_decode_field_statement(&1, smap)),
-      rust_decode_conditional_tail_block(section, smap),
-      "    Ok((#{struct_name} {\n",
-      Enum.map(entry_fields(section), fn field ->
-        "        #{rust_field_name(field["name"])},\n"
-      end),
-      "    }, pos - offset))\n",
-      "}\n\n"
-    ]
+    rust_record_decoder(
+      "decode_#{section["opcode"]}_#{section["name"]}",
+      rust_section_struct_name(section),
+      section,
+      smap
+    )
   end
 
   @spec rust_decode_counted_array_section(String.t(), section(), %{String.t() => structure()}) ::
           iodata()
   defp rust_decode_counted_array_section(_opcode, section, smap) do
     element = section["element"]
-    element_struct = rust_struct_name(element)
+    element_type = rust_type(element_field(element), smap)
     fn_name = "decode_#{section["opcode"]}_#{section["name"]}"
     count_type = section["count_type"] || "u16"
     {count_read, count_size} = rust_count_read(count_type)
-    element_fixed_size = fixed_structure_size(element, smap)
 
-    decode_loop =
-      case element_fixed_size do
-        nil ->
-          [
-            "    let mut items = Vec::with_capacity(count);\n",
-            "    for _ in 0..count {\n",
-            "        let (item, consumed) = decode_#{element}(bytes, pos)?;\n",
-            "        pos += consumed;\n",
-            "        items.push(item);\n",
-            "    }\n"
-          ]
-
-        stride ->
-          [
-            "    require_len(bytes, pos + count * #{stride}, \"#{section["name"]}\")?;\n",
-            "    let mut items = Vec::with_capacity(count);\n",
-            "    for _ in 0..count {\n",
-            "        let (item, consumed) = decode_#{element}(bytes, pos)?;\n",
-            "        pos += consumed;\n",
-            "        items.push(item);\n",
-            "    }\n"
-          ]
+    stride_check =
+      case element_fixed_byte_size(element, smap) do
+        nil -> []
+        stride -> ["    require_len(bytes, pos + count * #{stride}, \"#{section["name"]}\")?;\n"]
       end
 
     [
-      "pub fn #{fn_name}(bytes: &[u8], offset: usize) -> Result<(Vec<#{element_struct}>, usize), DecodeError> {\n",
+      "pub fn #{fn_name}(bytes: &[u8], offset: usize) -> Result<(Vec<#{element_type}>, usize), DecodeError> {\n",
       "    let mut pos = offset;\n",
       "    require_len(bytes, pos + #{count_size}, \"#{section["name"]} count\")?;\n",
       "    let count = #{count_read};\n",
       "    pos += #{count_size};\n",
-      decode_loop,
+      stride_check,
+      "    let mut items = Vec::with_capacity(#{rust_prealloc("count", element, smap)});\n",
+      "    for _ in 0..count {\n",
+      rust_decode_array_element(element, "items", "        "),
+      "    }\n",
       "    Ok((items, pos - offset))\n",
       "}\n\n"
     ]
@@ -2313,8 +2404,8 @@ defmodule Minga.Mix.ProtocolGenerator do
     go_struct_name(element)
   end
 
-  defp go_type(%{"type" => "counted_array", "element" => element}, _smap) do
-    "[]#{go_struct_name(element)}"
+  defp go_type(%{"type" => "counted_array", "element" => element}, smap) do
+    "[]#{go_type(element_field(element), smap)}"
   end
 
   @spec go_struct_name(String.t()) :: String.t()
@@ -2347,7 +2438,10 @@ defmodule Minga.Mix.ProtocolGenerator do
   @spec go_local_name(String.t()) :: String.t()
   defp go_local_name(name) do
     camel = go_camel_case(name)
-    if camel in @go_keywords, do: camel <> "Val", else: camel
+
+    if camel in @go_keywords or name in @reserved_decoder_locals,
+      do: camel <> "Val",
+      else: camel
   end
 
   @spec go_camel_case(String.t()) :: String.t()
@@ -2556,19 +2650,23 @@ defmodule Minga.Mix.ProtocolGenerator do
 
   @spec go_decode_structure(structure(), %{String.t() => structure()}) :: iodata()
   defp go_decode_structure(structure, smap) do
-    name = structure["name"]
-    struct_name = go_struct_name(name)
-    fn_name = "Decode#{struct_name}"
-    fields = structure["fields"] || []
+    struct_name = go_struct_name(structure["name"])
+    go_record_decoder("Decode#{struct_name}", struct_name, structure, smap)
+  end
+
+  # Emit a Go decode function for any record (structure, inline section, or
+  # command_fields). The three callers differ only in fn/struct name.
+  @spec go_record_decoder(String.t(), String.t(), map(), %{String.t() => structure()}) :: iodata()
+  defp go_record_decoder(fn_name, struct_name, entry, smap) do
     zero = "#{struct_name}{}"
 
     [
       "func #{fn_name}(data []byte, offset int) (#{struct_name}, int, error) {\n",
       "\tpos := offset\n",
-      Enum.map(fields, &go_decode_field_statement(&1, smap, zero)),
-      go_decode_conditional_tail_block(structure, smap, zero),
+      Enum.map(entry["fields"] || [], &go_decode_field_statement(&1, smap, zero)),
+      go_decode_conditional_tail_block(entry, smap, zero),
       "\treturn #{struct_name}{\n",
-      Enum.map(entry_fields(structure), fn field ->
+      Enum.map(entry_fields(entry), fn field ->
         "\t\t#{go_field_name(field["name"])}: #{go_local_name(field["name"])},\n"
       end),
       "\t}, pos, nil\n",
@@ -2709,18 +2807,9 @@ defmodule Minga.Mix.ProtocolGenerator do
        ) do
     local = go_local_name(name)
     {count_read, count_size} = go_count_read(count_type)
-    element_fixed_size = fixed_structure_size(element, smap)
-
-    count_lines = [
-      "\tif err := decodeRequireLen(data, pos+#{count_size}, \"#{name} count\"); err != nil {\n",
-      "\t\treturn #{zero}, offset, err\n",
-      "\t}\n",
-      "\t#{local}Count := int(#{count_read})\n",
-      "\tpos += #{count_size}\n"
-    ]
 
     stride_check =
-      case element_fixed_size do
+      case element_fixed_byte_size(element, smap) do
         nil ->
           []
 
@@ -2732,19 +2821,63 @@ defmodule Minga.Mix.ProtocolGenerator do
           ]
       end
 
-    decode_lines = [
-      "\t#{local} := make([]#{go_struct_name(element)}, 0, #{local}Count)\n",
+    [
+      "\tif err := decodeRequireLen(data, pos+#{count_size}, \"#{name} count\"); err != nil {\n",
+      "\t\treturn #{zero}, offset, err\n",
+      "\t}\n",
+      "\t#{local}Count := int(#{count_read})\n",
+      "\tpos += #{count_size}\n",
+      stride_check,
+      "\t#{local} := make([]#{go_type(element_field(element), smap)}, 0, #{go_prealloc("#{local}Count", element, smap)})\n",
       "\tfor i := 0; i < #{local}Count; i++ {\n",
-      "\t\titem, nextPos, err := Decode#{go_struct_name(element)}(data, pos)\n",
-      "\t\tif err != nil {\n",
-      "\t\t\treturn #{zero}, offset, err\n",
-      "\t\t}\n",
-      "\t\tpos = nextPos\n",
-      "\t\t#{local} = append(#{local}, item)\n",
+      go_decode_array_element(element, local, "\t\t", zero),
       "\t}\n"
     ]
+  end
 
-    count_lines ++ stride_check ++ decode_lines
+  @go_primitive_reads %{
+    "u8" => {"data[pos]", 1},
+    "u16" => {"decodeU16(data, pos)", 2},
+    "u24" => {"decodeU24(data, pos)", 3},
+    "rgb" => {"decodeU24(data, pos)", 3},
+    "u32" => {"decodeU32(data, pos)", 4},
+    "u64" => {"decodeU64(data, pos)", 8}
+  }
+
+  @go_string_decoders %{
+    "string8" => "decodeString8",
+    "string16" => "decodeString16",
+    "string32" => "decodeString32"
+  }
+
+  # Decode one counted_array element at `pos`, append it onto `vec`, advance
+  # `pos`. Struct elements emit the same `(item, nextPos, err)` form as before,
+  # so existing struct arrays regenerate byte-for-byte.
+  @spec go_decode_array_element(String.t(), String.t(), String.t(), String.t()) :: iodata()
+  defp go_decode_array_element(element, vec, indent, zero) do
+    case element_field(element) do
+      %{"type" => "struct", "element" => el} ->
+        go_decode_array_element_via("Decode#{go_struct_name(el)}(data, pos)", vec, indent, zero)
+
+      %{"type" => str} when is_map_key(@go_string_decoders, str) ->
+        go_decode_array_element_via("#{@go_string_decoders[str]}(data, pos)", vec, indent, zero)
+
+      %{"type" => prim} ->
+        {expr, size} = Map.fetch!(@go_primitive_reads, prim)
+        ["#{indent}#{vec} = append(#{vec}, #{expr})\n", "#{indent}pos += #{size}\n"]
+    end
+  end
+
+  @spec go_decode_array_element_via(String.t(), String.t(), String.t(), String.t()) :: iodata()
+  defp go_decode_array_element_via(call, vec, indent, zero) do
+    [
+      "#{indent}item, nextPos, err := #{call}\n",
+      "#{indent}if err != nil {\n",
+      "#{indent}\treturn #{zero}, offset, err\n",
+      "#{indent}}\n",
+      "#{indent}pos = nextPos\n",
+      "#{indent}#{vec} = append(#{vec}, item)\n"
+    ]
   end
 
   @spec go_count_read(String.t()) :: {String.t(), non_neg_integer()}
@@ -2779,37 +2912,21 @@ defmodule Minga.Mix.ProtocolGenerator do
 
   @spec go_decode_inline_section(String.t(), section(), %{String.t() => structure()}) :: iodata()
   defp go_decode_inline_section(_opcode, section, smap) do
-    struct_name = go_section_struct_name(section)
     fn_name = "Decode#{go_struct_name(section["opcode"])}#{go_struct_name(section["name"])}"
-    fields = section["fields"] || []
-    zero = "#{struct_name}{}"
-
-    [
-      "func #{fn_name}(data []byte, offset int) (#{struct_name}, int, error) {\n",
-      "\tpos := offset\n",
-      Enum.map(fields, &go_decode_field_statement(&1, smap, zero)),
-      go_decode_conditional_tail_block(section, smap, zero),
-      "\treturn #{struct_name}{\n",
-      Enum.map(entry_fields(section), fn field ->
-        "\t\t#{go_field_name(field["name"])}: #{go_local_name(field["name"])},\n"
-      end),
-      "\t}, pos, nil\n",
-      "}\n\n"
-    ]
+    go_record_decoder(fn_name, go_section_struct_name(section), section, smap)
   end
 
   @spec go_decode_counted_array_section(String.t(), section(), %{String.t() => structure()}) ::
           iodata()
   defp go_decode_counted_array_section(_opcode, section, smap) do
     element = section["element"]
-    element_struct = go_struct_name(element)
+    element_type = go_type(element_field(element), smap)
     fn_name = "Decode#{go_struct_name(section["opcode"])}#{go_struct_name(section["name"])}"
     count_type = section["count_type"] || "u16"
     {count_read, count_size} = go_count_read(count_type)
-    element_fixed_size = fixed_structure_size(element, smap)
 
     stride_check =
-      case element_fixed_size do
+      case element_fixed_byte_size(element, smap) do
         nil ->
           []
 
@@ -2822,7 +2939,7 @@ defmodule Minga.Mix.ProtocolGenerator do
       end
 
     [
-      "func #{fn_name}(data []byte, offset int) ([]#{element_struct}, int, error) {\n",
+      "func #{fn_name}(data []byte, offset int) ([]#{element_type}, int, error) {\n",
       "\tpos := offset\n",
       "\tif err := decodeRequireLen(data, pos+#{count_size}, \"#{section["name"]} count\"); err != nil {\n",
       "\t\treturn nil, offset, err\n",
@@ -2830,14 +2947,9 @@ defmodule Minga.Mix.ProtocolGenerator do
       "\tcount := int(#{count_read})\n",
       "\tpos += #{count_size}\n",
       stride_check,
-      "\titems := make([]#{element_struct}, 0, count)\n",
+      "\titems := make([]#{element_type}, 0, #{go_prealloc("count", element, smap)})\n",
       "\tfor i := 0; i < count; i++ {\n",
-      "\t\titem, nextPos, err := Decode#{element_struct}(data, pos)\n",
-      "\t\tif err != nil {\n",
-      "\t\t\treturn nil, offset, err\n",
-      "\t\t}\n",
-      "\t\tpos = nextPos\n",
-      "\t\titems = append(items, item)\n",
+      go_decode_array_element(element, "items", "\t\t", "nil"),
       "\t}\n",
       "\treturn items, pos, nil\n",
       "}\n\n"
@@ -2877,19 +2989,10 @@ defmodule Minga.Mix.ProtocolGenerator do
     command_fields
     |> Enum.map(fn cf ->
       struct_name = rust_struct_name(cf["opcode"]) <> "Fields"
-      fn_name = "decode_#{cf["opcode"]}_fields"
-      fields = cf["fields"] || []
 
       [
         "// Command field decoder for #{cf["opcode"]}\n\n",
-        "pub fn #{fn_name}(bytes: &[u8], offset: usize) -> Result<(#{struct_name}, usize), DecodeError> {\n",
-        "    let mut pos = offset;\n",
-        Enum.map(fields, &rust_decode_field_statement(&1, smap)),
-        rust_decode_conditional_tail_block(cf, smap),
-        "    Ok((#{struct_name} {\n",
-        Enum.map(entry_fields(cf), fn field -> "        #{rust_field_name(field["name"])},\n" end),
-        "    }, pos - offset))\n",
-        "}\n\n"
+        rust_record_decoder("decode_#{cf["opcode"]}_fields", struct_name, cf, smap)
       ]
     end)
   end
@@ -2920,22 +3023,10 @@ defmodule Minga.Mix.ProtocolGenerator do
     command_fields
     |> Enum.map(fn cf ->
       struct_name = go_struct_name(cf["opcode"]) <> "Fields"
-      fn_name = "Decode#{struct_name}"
-      fields = cf["fields"] || []
-      zero = "#{struct_name}{}"
 
       [
         "// Command field decoder for #{cf["opcode"]}\n\n",
-        "func #{fn_name}(data []byte, offset int) (#{struct_name}, int, error) {\n",
-        "\tpos := offset\n",
-        Enum.map(fields, &go_decode_field_statement(&1, smap, zero)),
-        go_decode_conditional_tail_block(cf, smap, zero),
-        "\treturn #{struct_name}{\n",
-        Enum.map(entry_fields(cf), fn field ->
-          "\t\t#{go_field_name(field["name"])}: #{go_local_name(field["name"])},\n"
-        end),
-        "\t}, pos, nil\n",
-        "}\n\n"
+        go_record_decoder("Decode#{struct_name}", struct_name, cf, smap)
       ]
     end)
   end

--- a/rust/tui/src/generated/semantic_decode.rs
+++ b/rust/tui/src/generated/semantic_decode.rs
@@ -382,16 +382,6 @@ pub fn decode_completion_item(bytes: &[u8], offset: usize) -> Result<(Completion
     }, pos - offset))
 }
 
-pub fn decode_match_position(bytes: &[u8], offset: usize) -> Result<(MatchPosition, usize), DecodeError> {
-    let mut pos = offset;
-    require_len(bytes, pos + 2, "index")?;
-    let index = read_u16(bytes, pos);
-    pos += 2;
-    Ok((MatchPosition {
-        index,
-    }, pos - offset))
-}
-
 pub fn decode_picker_item(bytes: &[u8], offset: usize) -> Result<(PickerItem, usize), DecodeError> {
     let mut pos = offset;
     require_len(bytes, pos + 3, "icon_color")?;
@@ -409,9 +399,8 @@ pub fn decode_picker_item(bytes: &[u8], offset: usize) -> Result<(PickerItem, us
     require_len(bytes, pos + match_positions_count * 2, "match_positions")?;
     let mut match_positions = Vec::with_capacity(match_positions_count);
     for _ in 0..match_positions_count {
-        let (item, consumed) = decode_match_position(bytes, pos)?;
-        pos += consumed;
-        match_positions.push(item);
+        match_positions.push(read_u16(bytes, pos));
+        pos += 2;
     }
     Ok((PickerItem {
         icon_color,
@@ -420,14 +409,6 @@ pub fn decode_picker_item(bytes: &[u8], offset: usize) -> Result<(PickerItem, us
         description,
         annotation,
         match_positions,
-    }, pos - offset))
-}
-
-pub fn decode_picker_action(bytes: &[u8], offset: usize) -> Result<(PickerAction, usize), DecodeError> {
-    let mut pos = offset;
-    let name = read_string16(bytes, &mut pos)?;
-    Ok((PickerAction {
-        name,
     }, pos - offset))
 }
 
@@ -567,7 +548,7 @@ pub fn decode_gui_gutter_entries(bytes: &[u8], offset: usize) -> Result<(Vec<Gut
     require_len(bytes, pos + 2, "entries count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count);
+    let mut items = Vec::with_capacity(count.min(1024));
     for _ in 0..count {
         let (item, consumed) = decode_gutter_entry(bytes, pos)?;
         pos += consumed;
@@ -623,7 +604,7 @@ pub fn decode_gui_picker_items(bytes: &[u8], offset: usize) -> Result<(Vec<Picke
     require_len(bytes, pos + 2, "items count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count);
+    let mut items = Vec::with_capacity(count.min(1024));
     for _ in 0..count {
         let (item, consumed) = decode_picker_item(bytes, pos)?;
         pos += consumed;
@@ -638,7 +619,7 @@ pub fn decode_gui_picker_action_menu(bytes: &[u8], offset: usize) -> Result<(Gui
     let visible = bytes[pos];
     pos += 1;
     let mut selected_index = 0;
-    let mut actions = Vec::<PickerAction>::new();
+    let mut actions = Vec::<String>::new();
     if visible == 1 {
         require_len(bytes, pos + 1, "selected_index")?;
         selected_index = bytes[pos];
@@ -646,11 +627,9 @@ pub fn decode_gui_picker_action_menu(bytes: &[u8], offset: usize) -> Result<(Gui
         require_len(bytes, pos + 1, "actions count")?;
         let actions_count = bytes[pos] as usize;
         pos += 1;
-        let mut actions_value = Vec::with_capacity(actions_count);
+        let mut actions_value = Vec::with_capacity(actions_count.min(1024));
         for _ in 0..actions_count {
-            let (item, consumed) = decode_picker_action(bytes, pos)?;
-            pos += consumed;
-            actions_value.push(item);
+            actions_value.push(read_string16(bytes, &mut pos)?);
         }
         actions = actions_value;
     }
@@ -854,7 +833,7 @@ pub fn decode_gui_status_bar_modeline(bytes: &[u8], offset: usize) -> Result<(Gu
     require_len(bytes, pos + 2, "left_segments count")?;
     let left_segments_count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut left_segments = Vec::with_capacity(left_segments_count);
+    let mut left_segments = Vec::with_capacity(left_segments_count.min(1024));
     for _ in 0..left_segments_count {
         let (item, consumed) = decode_modeline_segment(bytes, pos)?;
         pos += consumed;
@@ -863,7 +842,7 @@ pub fn decode_gui_status_bar_modeline(bytes: &[u8], offset: usize) -> Result<(Gu
     require_len(bytes, pos + 2, "right_segments count")?;
     let right_segments_count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut right_segments = Vec::with_capacity(right_segments_count);
+    let mut right_segments = Vec::with_capacity(right_segments_count.min(1024));
     for _ in 0..right_segments_count {
         let (item, consumed) = decode_modeline_segment(bytes, pos)?;
         pos += consumed;
@@ -973,7 +952,7 @@ pub fn decode_gui_window_content_rows(bytes: &[u8], offset: usize) -> Result<(Ve
     require_len(bytes, pos + 2, "rows count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count);
+    let mut items = Vec::with_capacity(count.min(1024));
     for _ in 0..count {
         let (item, consumed) = decode_row(bytes, pos)?;
         pos += consumed;
@@ -1064,7 +1043,7 @@ pub fn decode_gui_window_content_annotations(bytes: &[u8], offset: usize) -> Res
     require_len(bytes, pos + 2, "annotations count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count);
+    let mut items = Vec::with_capacity(count.min(1024));
     for _ in 0..count {
         let (item, consumed) = decode_annotation(bytes, pos)?;
         pos += consumed;
@@ -1200,7 +1179,7 @@ pub fn decode_gui_window_rows_delta_rows(bytes: &[u8], offset: usize) -> Result<
     require_len(bytes, pos + 2, "rows count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count);
+    let mut items = Vec::with_capacity(count.min(1024));
     for _ in 0..count {
         let (item, consumed) = decode_row(bytes, pos)?;
         pos += consumed;
@@ -1250,7 +1229,7 @@ pub fn decode_gui_window_viewport_delta_rows(bytes: &[u8], offset: usize) -> Res
     require_len(bytes, pos + 2, "rows count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count);
+    let mut items = Vec::with_capacity(count.min(1024));
     for _ in 0..count {
         let (item, consumed) = decode_row(bytes, pos)?;
         pos += consumed;
@@ -1323,7 +1302,7 @@ pub fn decode_gui_completion_fields(bytes: &[u8], offset: usize) -> Result<(GuiC
         require_len(bytes, pos + 2, "items count")?;
         let items_count = read_u16(bytes, pos) as usize;
         pos += 2;
-        let mut items_value = Vec::with_capacity(items_count);
+        let mut items_value = Vec::with_capacity(items_count.min(1024));
         for _ in 0..items_count {
             let (item, consumed) = decode_completion_item(bytes, pos)?;
             pos += consumed;

--- a/rust/tui/src/generated/semantic_decode.rs
+++ b/rust/tui/src/generated/semantic_decode.rs
@@ -382,6 +382,47 @@ pub fn decode_completion_item(bytes: &[u8], offset: usize) -> Result<(Completion
     }, pos - offset))
 }
 
+pub fn decode_match_position(bytes: &[u8], offset: usize) -> Result<(MatchPosition, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 2, "index")?;
+    let index = read_u16(bytes, pos);
+    pos += 2;
+    Ok((MatchPosition {
+        index,
+    }, pos - offset))
+}
+
+pub fn decode_picker_item(bytes: &[u8], offset: usize) -> Result<(PickerItem, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 3, "icon_color")?;
+    let icon_color = read_u24(bytes, pos);
+    pos += 3;
+    require_len(bytes, pos + 1, "flags")?;
+    let flags = bytes[pos];
+    pos += 1;
+    let label = read_string16(bytes, &mut pos)?;
+    let description = read_string16(bytes, &mut pos)?;
+    let annotation = read_string16(bytes, &mut pos)?;
+    require_len(bytes, pos + 1, "match_positions count")?;
+    let match_positions_count = bytes[pos] as usize;
+    pos += 1;
+    require_len(bytes, pos + match_positions_count * 2, "match_positions")?;
+    let mut match_positions = Vec::with_capacity(match_positions_count);
+    for _ in 0..match_positions_count {
+        let (item, consumed) = decode_match_position(bytes, pos)?;
+        pos += consumed;
+        match_positions.push(item);
+    }
+    Ok((PickerItem {
+        icon_color,
+        flags,
+        label,
+        description,
+        annotation,
+        match_positions,
+    }, pos - offset))
+}
+
 pub fn decode_which_key_binding(bytes: &[u8], offset: usize) -> Result<(WhichKeyBinding, usize), DecodeError> {
     let mut pos = offset;
     require_len(bytes, pos + 1, "kind")?;
@@ -565,6 +606,20 @@ pub fn decode_gui_picker_query(bytes: &[u8], offset: usize) -> Result<(GuiPicker
         text,
         cursor_pos,
     }, pos - offset))
+}
+
+pub fn decode_gui_picker_items(bytes: &[u8], offset: usize) -> Result<(Vec<PickerItem>, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 2, "items count")?;
+    let count = read_u16(bytes, pos) as usize;
+    pos += 2;
+    let mut items = Vec::with_capacity(count);
+    for _ in 0..count {
+        let (item, consumed) = decode_picker_item(bytes, pos)?;
+        pos += consumed;
+        items.push(item);
+    }
+    Ok((items, pos - offset))
 }
 
 pub fn decode_gui_picker_action_menu(bytes: &[u8], offset: usize) -> Result<(GuiPickerActionMenu, usize), DecodeError> {
@@ -1227,8 +1282,37 @@ pub fn decode_gui_completion_fields(bytes: &[u8], offset: usize) -> Result<(GuiC
     require_len(bytes, pos + 1, "visible")?;
     let visible = bytes[pos];
     pos += 1;
+    let mut cursor_row = 0;
+    let mut cursor_col = 0;
+    let mut selected_offset = 0;
+    let mut items = Vec::<CompletionItem>::new();
+    if visible == 1 {
+        require_len(bytes, pos + 2, "cursor_row")?;
+        cursor_row = read_u16(bytes, pos);
+        pos += 2;
+        require_len(bytes, pos + 2, "cursor_col")?;
+        cursor_col = read_u16(bytes, pos);
+        pos += 2;
+        require_len(bytes, pos + 2, "selected_offset")?;
+        selected_offset = read_u16(bytes, pos);
+        pos += 2;
+        require_len(bytes, pos + 2, "items count")?;
+        let items_count = read_u16(bytes, pos) as usize;
+        pos += 2;
+        let mut items_value = Vec::with_capacity(items_count);
+        for _ in 0..items_count {
+            let (item, consumed) = decode_completion_item(bytes, pos)?;
+            pos += consumed;
+            items_value.push(item);
+        }
+        items = items_value;
+    }
     Ok((GuiCompletionFields {
         visible,
+        cursor_row,
+        cursor_col,
+        selected_offset,
+        items,
     }, pos - offset))
 }
 

--- a/rust/tui/src/generated/semantic_decode.rs
+++ b/rust/tui/src/generated/semantic_decode.rs
@@ -423,6 +423,14 @@ pub fn decode_picker_item(bytes: &[u8], offset: usize) -> Result<(PickerItem, us
     }, pos - offset))
 }
 
+pub fn decode_picker_action(bytes: &[u8], offset: usize) -> Result<(PickerAction, usize), DecodeError> {
+    let mut pos = offset;
+    let name = read_string16(bytes, &mut pos)?;
+    Ok((PickerAction {
+        name,
+    }, pos - offset))
+}
+
 pub fn decode_which_key_binding(bytes: &[u8], offset: usize) -> Result<(WhichKeyBinding, usize), DecodeError> {
     let mut pos = offset;
     require_len(bytes, pos + 1, "kind")?;
@@ -578,33 +586,35 @@ pub fn decode_gui_picker_header(bytes: &[u8], offset: usize) -> Result<(GuiPicke
     require_len(bytes, pos + 2, "selected_index")?;
     let selected_index = read_u16(bytes, pos);
     pos += 2;
-    require_len(bytes, pos + 2, "item_count")?;
-    let item_count = read_u16(bytes, pos);
+    require_len(bytes, pos + 2, "filtered_count")?;
+    let filtered_count = read_u16(bytes, pos);
     pos += 2;
-    require_len(bytes, pos + 4, "total_count")?;
-    let total_count = read_u32(bytes, pos);
-    pos += 4;
-    require_len(bytes, pos + 1, "flags")?;
-    let flags = bytes[pos];
+    require_len(bytes, pos + 2, "total_count")?;
+    let total_count = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 1, "has_preview")?;
+    let has_preview = bytes[pos];
     pos += 1;
+    let title = read_string16(bytes, &mut pos)?;
+    require_len(bytes, pos + 2, "marked_count")?;
+    let marked_count = read_u16(bytes, pos);
+    pos += 2;
     Ok((GuiPickerHeader {
         visible,
         selected_index,
-        item_count,
+        filtered_count,
         total_count,
-        flags,
+        has_preview,
+        title,
+        marked_count,
     }, pos - offset))
 }
 
 pub fn decode_gui_picker_query(bytes: &[u8], offset: usize) -> Result<(GuiPickerQuery, usize), DecodeError> {
     let mut pos = offset;
     let text = read_string16(bytes, &mut pos)?;
-    require_len(bytes, pos + 2, "cursor_pos")?;
-    let cursor_pos = read_u16(bytes, pos);
-    pos += 2;
     Ok((GuiPickerQuery {
         text,
-        cursor_pos,
     }, pos - offset))
 }
 
@@ -627,16 +637,27 @@ pub fn decode_gui_picker_action_menu(bytes: &[u8], offset: usize) -> Result<(Gui
     require_len(bytes, pos + 1, "visible")?;
     let visible = bytes[pos];
     pos += 1;
-    require_len(bytes, pos + 1, "selected_index")?;
-    let selected_index = bytes[pos];
-    pos += 1;
-    require_len(bytes, pos + 1, "item_count")?;
-    let item_count = bytes[pos];
-    pos += 1;
+    let mut selected_index = 0;
+    let mut actions = Vec::<PickerAction>::new();
+    if visible == 1 {
+        require_len(bytes, pos + 1, "selected_index")?;
+        selected_index = bytes[pos];
+        pos += 1;
+        require_len(bytes, pos + 1, "actions count")?;
+        let actions_count = bytes[pos] as usize;
+        pos += 1;
+        let mut actions_value = Vec::with_capacity(actions_count);
+        for _ in 0..actions_count {
+            let (item, consumed) = decode_picker_action(bytes, pos)?;
+            pos += consumed;
+            actions_value.push(item);
+        }
+        actions = actions_value;
+    }
     Ok((GuiPickerActionMenu {
         visible,
         selected_index,
-        item_count,
+        actions,
     }, pos - offset))
 }
 
@@ -653,7 +674,10 @@ pub fn decode_gui_picker_load_status(bytes: &[u8], offset: usize) -> Result<(Gui
     require_len(bytes, pos + 1, "status")?;
     let status = bytes[pos];
     pos += 1;
-    let message = read_string16(bytes, &mut pos)?;
+    let mut message = String::new();
+    if status == 2 {
+        message = read_string16(bytes, &mut pos)?;
+    }
     Ok((GuiPickerLoadStatus {
         status,
         message,

--- a/rust/tui/src/generated/semantic_decode.rs
+++ b/rust/tui/src/generated/semantic_decode.rs
@@ -328,6 +328,136 @@ pub fn decode_modeline_segment(bytes: &[u8], offset: usize) -> Result<(ModelineS
     }, pos - offset))
 }
 
+pub fn decode_tab_entry(bytes: &[u8], offset: usize) -> Result<(TabEntry, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "flags")?;
+    let flags = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 4, "id")?;
+    let id = read_u32(bytes, pos);
+    pos += 4;
+    require_len(bytes, pos + 2, "workspace_id")?;
+    let workspace_id = read_u16(bytes, pos);
+    pos += 2;
+    let icon = read_string8(bytes, &mut pos)?;
+    let label = read_string16(bytes, &mut pos)?;
+    require_len(bytes, pos + 4, "tint_color")?;
+    let tint_color = read_u32(bytes, pos);
+    pos += 4;
+    Ok((TabEntry {
+        flags,
+        id,
+        workspace_id,
+        icon,
+        label,
+        tint_color,
+    }, pos - offset))
+}
+
+pub fn decode_theme_color(bytes: &[u8], offset: usize) -> Result<(ThemeColor, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "slot")?;
+    let slot = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 3, "color")?;
+    let color = read_u24(bytes, pos);
+    pos += 3;
+    Ok((ThemeColor {
+        slot,
+        color,
+    }, pos - offset))
+}
+
+pub fn decode_completion_item(bytes: &[u8], offset: usize) -> Result<(CompletionItem, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "kind")?;
+    let kind = bytes[pos];
+    pos += 1;
+    let label = read_string16(bytes, &mut pos)?;
+    let detail = read_string16(bytes, &mut pos)?;
+    Ok((CompletionItem {
+        kind,
+        label,
+        detail,
+    }, pos - offset))
+}
+
+pub fn decode_which_key_binding(bytes: &[u8], offset: usize) -> Result<(WhichKeyBinding, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "kind")?;
+    let kind = bytes[pos];
+    pos += 1;
+    let key = read_string8(bytes, &mut pos)?;
+    let desc = read_string16(bytes, &mut pos)?;
+    let icon = read_string8(bytes, &mut pos)?;
+    Ok((WhichKeyBinding {
+        kind,
+        key,
+        desc,
+        icon,
+    }, pos - offset))
+}
+
+pub fn decode_change_summary_entry(bytes: &[u8], offset: usize) -> Result<(ChangeSummaryEntry, usize), DecodeError> {
+    let mut pos = offset;
+    let path = read_string16(bytes, &mut pos)?;
+    require_len(bytes, pos + 1, "action")?;
+    let action = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 4, "lines_added")?;
+    let lines_added = read_u32(bytes, pos);
+    pos += 4;
+    require_len(bytes, pos + 4, "lines_removed")?;
+    let lines_removed = read_u32(bytes, pos);
+    pos += 4;
+    Ok((ChangeSummaryEntry {
+        path,
+        action,
+        lines_added,
+        lines_removed,
+    }, pos - offset))
+}
+
+pub fn decode_git_status_entry(bytes: &[u8], offset: usize) -> Result<(GitStatusEntry, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 4, "path_hash")?;
+    let path_hash = read_u32(bytes, pos);
+    pos += 4;
+    require_len(bytes, pos + 1, "section")?;
+    let section = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "status")?;
+    let status = bytes[pos];
+    pos += 1;
+    let path = read_string16(bytes, &mut pos)?;
+    Ok((GitStatusEntry {
+        path_hash,
+        section,
+        status,
+        path,
+    }, pos - offset))
+}
+
+
+// Section decoders for gui_agent_chat
+
+pub fn decode_gui_agent_chat_header(bytes: &[u8], offset: usize) -> Result<(GuiAgentChatHeader, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "flags")?;
+    let flags = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "message_count")?;
+    let message_count = read_u16(bytes, pos);
+    pos += 2;
+    Ok((GuiAgentChatHeader {
+        visible,
+        flags,
+        message_count,
+    }, pos - offset))
+}
 
 // Section decoders for gui_gutter
 
@@ -395,6 +525,102 @@ pub fn decode_gui_gutter_entries(bytes: &[u8], offset: usize) -> Result<(Vec<Gut
         items.push(item);
     }
     Ok((items, pos - offset))
+}
+
+// Section decoders for gui_picker
+
+pub fn decode_gui_picker_header(bytes: &[u8], offset: usize) -> Result<(GuiPickerHeader, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "selected_index")?;
+    let selected_index = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 2, "item_count")?;
+    let item_count = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 4, "total_count")?;
+    let total_count = read_u32(bytes, pos);
+    pos += 4;
+    require_len(bytes, pos + 1, "flags")?;
+    let flags = bytes[pos];
+    pos += 1;
+    Ok((GuiPickerHeader {
+        visible,
+        selected_index,
+        item_count,
+        total_count,
+        flags,
+    }, pos - offset))
+}
+
+pub fn decode_gui_picker_query(bytes: &[u8], offset: usize) -> Result<(GuiPickerQuery, usize), DecodeError> {
+    let mut pos = offset;
+    let text = read_string16(bytes, &mut pos)?;
+    require_len(bytes, pos + 2, "cursor_pos")?;
+    let cursor_pos = read_u16(bytes, pos);
+    pos += 2;
+    Ok((GuiPickerQuery {
+        text,
+        cursor_pos,
+    }, pos - offset))
+}
+
+pub fn decode_gui_picker_action_menu(bytes: &[u8], offset: usize) -> Result<(GuiPickerActionMenu, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "selected_index")?;
+    let selected_index = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "item_count")?;
+    let item_count = bytes[pos];
+    pos += 1;
+    Ok((GuiPickerActionMenu {
+        visible,
+        selected_index,
+        item_count,
+    }, pos - offset))
+}
+
+pub fn decode_gui_picker_mode_prefix(bytes: &[u8], offset: usize) -> Result<(GuiPickerModePrefix, usize), DecodeError> {
+    let mut pos = offset;
+    let text = read_string16(bytes, &mut pos)?;
+    Ok((GuiPickerModePrefix {
+        text,
+    }, pos - offset))
+}
+
+pub fn decode_gui_picker_load_status(bytes: &[u8], offset: usize) -> Result<(GuiPickerLoadStatus, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "status")?;
+    let status = bytes[pos];
+    pos += 1;
+    let message = read_string16(bytes, &mut pos)?;
+    Ok((GuiPickerLoadStatus {
+        status,
+        message,
+    }, pos - offset))
+}
+
+// Section decoders for gui_picker_preview
+
+pub fn decode_gui_picker_preview_header(bytes: &[u8], offset: usize) -> Result<(GuiPickerPreviewHeader, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "kind")?;
+    let kind = bytes[pos];
+    pos += 1;
+    let title = read_string16(bytes, &mut pos)?;
+    Ok((GuiPickerPreviewHeader {
+        visible,
+        kind,
+        title,
+    }, pos - offset))
 }
 
 // Section decoders for gui_status_bar
@@ -851,6 +1077,518 @@ pub fn decode_gui_window_content_cursorline(bytes: &[u8], offset: usize) -> Resu
     Ok((GuiWindowContentCursorline {
         row,
         bg,
+    }, pos - offset))
+}
+
+// Section decoders for gui_window_rows_delta
+
+pub fn decode_gui_window_rows_delta_header(bytes: &[u8], offset: usize) -> Result<(GuiWindowRowsDeltaHeader, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 2, "window_id")?;
+    let window_id = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 4, "content_epoch")?;
+    let content_epoch = read_u32(bytes, pos);
+    pos += 4;
+    require_len(bytes, pos + 1, "flags")?;
+    let flags = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "cursor_row")?;
+    let cursor_row = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 2, "cursor_col")?;
+    let cursor_col = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 1, "cursor_shape")?;
+    let cursor_shape = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "scroll_left")?;
+    let scroll_left = read_u16(bytes, pos);
+    pos += 2;
+    Ok((GuiWindowRowsDeltaHeader {
+        window_id,
+        content_epoch,
+        flags,
+        cursor_row,
+        cursor_col,
+        cursor_shape,
+        scroll_left,
+    }, pos - offset))
+}
+
+pub fn decode_gui_window_rows_delta_rows(bytes: &[u8], offset: usize) -> Result<(Vec<Row>, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 2, "rows count")?;
+    let count = read_u16(bytes, pos) as usize;
+    pos += 2;
+    let mut items = Vec::with_capacity(count);
+    for _ in 0..count {
+        let (item, consumed) = decode_row(bytes, pos)?;
+        pos += consumed;
+        items.push(item);
+    }
+    Ok((items, pos - offset))
+}
+
+// Section decoders for gui_window_viewport_delta
+
+pub fn decode_gui_window_viewport_delta_header(bytes: &[u8], offset: usize) -> Result<(GuiWindowViewportDeltaHeader, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 2, "window_id")?;
+    let window_id = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 4, "content_epoch")?;
+    let content_epoch = read_u32(bytes, pos);
+    pos += 4;
+    require_len(bytes, pos + 1, "flags")?;
+    let flags = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "cursor_row")?;
+    let cursor_row = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 2, "cursor_col")?;
+    let cursor_col = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 1, "cursor_shape")?;
+    let cursor_shape = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "scroll_left")?;
+    let scroll_left = read_u16(bytes, pos);
+    pos += 2;
+    Ok((GuiWindowViewportDeltaHeader {
+        window_id,
+        content_epoch,
+        flags,
+        cursor_row,
+        cursor_col,
+        cursor_shape,
+        scroll_left,
+    }, pos - offset))
+}
+
+pub fn decode_gui_window_viewport_delta_rows(bytes: &[u8], offset: usize) -> Result<(Vec<Row>, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 2, "rows count")?;
+    let count = read_u16(bytes, pos) as usize;
+    pos += 2;
+    let mut items = Vec::with_capacity(count);
+    for _ in 0..count {
+        let (item, consumed) = decode_row(bytes, pos)?;
+        pos += consumed;
+        items.push(item);
+    }
+    Ok((items, pos - offset))
+}
+
+// Command field decoder for gui_tab_bar
+
+pub fn decode_gui_tab_bar_fields(bytes: &[u8], offset: usize) -> Result<(GuiTabBarFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "active_index")?;
+    let active_index = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "tab_count")?;
+    let tab_count = bytes[pos];
+    pos += 1;
+    Ok((GuiTabBarFields {
+        active_index,
+        tab_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_theme
+
+pub fn decode_gui_theme_fields(bytes: &[u8], offset: usize) -> Result<(GuiThemeFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "color_count")?;
+    let color_count = bytes[pos];
+    pos += 1;
+    Ok((GuiThemeFields {
+        color_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_breadcrumb
+
+pub fn decode_gui_breadcrumb_fields(bytes: &[u8], offset: usize) -> Result<(GuiBreadcrumbFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "segment_count")?;
+    let segment_count = bytes[pos];
+    pos += 1;
+    Ok((GuiBreadcrumbFields {
+        segment_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_completion
+
+pub fn decode_gui_completion_fields(bytes: &[u8], offset: usize) -> Result<(GuiCompletionFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    Ok((GuiCompletionFields {
+        visible,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_which_key
+
+pub fn decode_gui_which_key_fields(bytes: &[u8], offset: usize) -> Result<(GuiWhichKeyFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    Ok((GuiWhichKeyFields {
+        visible,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_minibuffer
+
+pub fn decode_gui_minibuffer_fields(bytes: &[u8], offset: usize) -> Result<(GuiMinibufferFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    Ok((GuiMinibufferFields {
+        visible,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_hover_popup
+
+pub fn decode_gui_hover_popup_fields(bytes: &[u8], offset: usize) -> Result<(GuiHoverPopupFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    Ok((GuiHoverPopupFields {
+        visible,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_signature_help
+
+pub fn decode_gui_signature_help_fields(bytes: &[u8], offset: usize) -> Result<(GuiSignatureHelpFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    Ok((GuiSignatureHelpFields {
+        visible,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_float_popup
+
+pub fn decode_gui_float_popup_fields(bytes: &[u8], offset: usize) -> Result<(GuiFloatPopupFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    Ok((GuiFloatPopupFields {
+        visible,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_split_separators
+
+pub fn decode_gui_split_separators_fields(bytes: &[u8], offset: usize) -> Result<(GuiSplitSeparatorsFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 3, "bg")?;
+    let bg = read_u24(bytes, pos);
+    pos += 3;
+    require_len(bytes, pos + 1, "vertical_count")?;
+    let vertical_count = bytes[pos];
+    pos += 1;
+    Ok((GuiSplitSeparatorsFields {
+        bg,
+        vertical_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_git_status
+
+pub fn decode_gui_git_status_fields(bytes: &[u8], offset: usize) -> Result<(GuiGitStatusFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "repo_state")?;
+    let repo_state = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "syncing")?;
+    let syncing = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "ahead")?;
+    let ahead = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 2, "behind")?;
+    let behind = read_u16(bytes, pos);
+    pos += 2;
+    Ok((GuiGitStatusFields {
+        repo_state,
+        syncing,
+        ahead,
+        behind,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_bottom_panel
+
+pub fn decode_gui_bottom_panel_fields(bytes: &[u8], offset: usize) -> Result<(GuiBottomPanelFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    Ok((GuiBottomPanelFields {
+        visible,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_change_summary
+
+pub fn decode_gui_change_summary_fields(bytes: &[u8], offset: usize) -> Result<(GuiChangeSummaryFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "selected_index")?;
+    let selected_index = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 2, "entry_count")?;
+    let entry_count = read_u16(bytes, pos);
+    pos += 2;
+    Ok((GuiChangeSummaryFields {
+        visible,
+        selected_index,
+        entry_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_board
+
+pub fn decode_gui_board_fields(bytes: &[u8], offset: usize) -> Result<(GuiBoardFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 4, "focused_card_id")?;
+    let focused_card_id = read_u32(bytes, pos);
+    pos += 4;
+    require_len(bytes, pos + 2, "card_count")?;
+    let card_count = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 1, "filter_mode")?;
+    let filter_mode = bytes[pos];
+    pos += 1;
+    Ok((GuiBoardFields {
+        visible,
+        focused_card_id,
+        card_count,
+        filter_mode,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_agent_context
+
+pub fn decode_gui_agent_context_fields(bytes: &[u8], offset: usize) -> Result<(GuiAgentContextFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    Ok((GuiAgentContextFields {
+        visible,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_gutter_sep
+
+pub fn decode_gui_gutter_sep_fields(bytes: &[u8], offset: usize) -> Result<(GuiGutterSepFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 2, "col")?;
+    let col = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 3, "bg")?;
+    let bg = read_u24(bytes, pos);
+    pos += 3;
+    Ok((GuiGutterSepFields {
+        col,
+        bg,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_cursorline
+
+pub fn decode_gui_cursorline_fields(bytes: &[u8], offset: usize) -> Result<(GuiCursorlineFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 2, "col")?;
+    let col = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 3, "bg")?;
+    let bg = read_u24(bytes, pos);
+    pos += 3;
+    Ok((GuiCursorlineFields {
+        col,
+        bg,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_search_state
+
+pub fn decode_gui_search_state_fields(bytes: &[u8], offset: usize) -> Result<(GuiSearchStateFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "active")?;
+    let active = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "match_count")?;
+    let match_count = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 2, "current_index")?;
+    let current_index = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 1, "flags")?;
+    let flags = bytes[pos];
+    pos += 1;
+    Ok((GuiSearchStateFields {
+        active,
+        match_count,
+        current_index,
+        flags,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_edit_timeline
+
+pub fn decode_gui_edit_timeline_fields(bytes: &[u8], offset: usize) -> Result<(GuiEditTimelineFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "viewing_index")?;
+    let viewing_index = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 1, "entry_count")?;
+    let entry_count = bytes[pos];
+    pos += 1;
+    Ok((GuiEditTimelineFields {
+        visible,
+        viewing_index,
+        entry_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_workspaces
+
+pub fn decode_gui_workspaces_fields(bytes: &[u8], offset: usize) -> Result<(GuiWorkspacesFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "active_workspace_id")?;
+    let active_workspace_id = read_u16(bytes, pos);
+    pos += 2;
+    require_len(bytes, pos + 1, "mode")?;
+    let mode = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "flags")?;
+    let flags = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "workspace_count")?;
+    let workspace_count = bytes[pos];
+    pos += 1;
+    Ok((GuiWorkspacesFields {
+        visible,
+        active_workspace_id,
+        mode,
+        flags,
+        workspace_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_notifications
+
+pub fn decode_gui_notifications_fields(bytes: &[u8], offset: usize) -> Result<(GuiNotificationsFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "notification_count")?;
+    let notification_count = read_u16(bytes, pos);
+    pos += 2;
+    Ok((GuiNotificationsFields {
+        visible,
+        notification_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_sidebars
+
+pub fn decode_gui_sidebars_fields(bytes: &[u8], offset: usize) -> Result<(GuiSidebarsFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 2, "sidebar_count")?;
+    let sidebar_count = read_u16(bytes, pos);
+    pos += 2;
+    Ok((GuiSidebarsFields {
+        visible,
+        sidebar_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_extension_overlay
+
+pub fn decode_gui_extension_overlay_fields(bytes: &[u8], offset: usize) -> Result<(GuiExtensionOverlayFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "entry_count")?;
+    let entry_count = bytes[pos];
+    pos += 1;
+    Ok((GuiExtensionOverlayFields {
+        entry_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_extension_panel
+
+pub fn decode_gui_extension_panel_fields(bytes: &[u8], offset: usize) -> Result<(GuiExtensionPanelFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "panel_count")?;
+    let panel_count = bytes[pos];
+    pos += 1;
+    Ok((GuiExtensionPanelFields {
+        panel_count,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_file_tree
+
+pub fn decode_gui_file_tree_fields(bytes: &[u8], offset: usize) -> Result<(GuiFileTreeFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "flags")?;
+    let flags = bytes[pos];
+    pos += 1;
+    require_len(bytes, pos + 1, "status")?;
+    let status = bytes[pos];
+    pos += 1;
+    Ok((GuiFileTreeFields {
+        visible,
+        flags,
+        status,
+    }, pos - offset))
+}
+
+// Command field decoder for gui_tool_manager
+
+pub fn decode_gui_tool_manager_fields(bytes: &[u8], offset: usize) -> Result<(GuiToolManagerFields, usize), DecodeError> {
+    let mut pos = offset;
+    require_len(bytes, pos + 1, "visible")?;
+    let visible = bytes[pos];
+    pos += 1;
+    Ok((GuiToolManagerFields {
+        visible,
     }, pos - offset))
 }
 

--- a/rust/tui/src/generated/semantic_decode.rs
+++ b/rust/tui/src/generated/semantic_decode.rs
@@ -548,7 +548,7 @@ pub fn decode_gui_gutter_entries(bytes: &[u8], offset: usize) -> Result<(Vec<Gut
     require_len(bytes, pos + 2, "entries count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count.min(1024));
+    let mut items = Vec::with_capacity(count.min(bytes.len() - pos));
     for _ in 0..count {
         let (item, consumed) = decode_gutter_entry(bytes, pos)?;
         pos += consumed;
@@ -604,7 +604,7 @@ pub fn decode_gui_picker_items(bytes: &[u8], offset: usize) -> Result<(Vec<Picke
     require_len(bytes, pos + 2, "items count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count.min(1024));
+    let mut items = Vec::with_capacity(count.min(bytes.len() - pos));
     for _ in 0..count {
         let (item, consumed) = decode_picker_item(bytes, pos)?;
         pos += consumed;
@@ -627,7 +627,7 @@ pub fn decode_gui_picker_action_menu(bytes: &[u8], offset: usize) -> Result<(Gui
         require_len(bytes, pos + 1, "actions count")?;
         let actions_count = bytes[pos] as usize;
         pos += 1;
-        let mut actions_value = Vec::with_capacity(actions_count.min(1024));
+        let mut actions_value = Vec::with_capacity(actions_count.min(bytes.len() - pos));
         for _ in 0..actions_count {
             actions_value.push(read_string16(bytes, &mut pos)?);
         }
@@ -833,7 +833,7 @@ pub fn decode_gui_status_bar_modeline(bytes: &[u8], offset: usize) -> Result<(Gu
     require_len(bytes, pos + 2, "left_segments count")?;
     let left_segments_count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut left_segments = Vec::with_capacity(left_segments_count.min(1024));
+    let mut left_segments = Vec::with_capacity(left_segments_count.min(bytes.len() - pos));
     for _ in 0..left_segments_count {
         let (item, consumed) = decode_modeline_segment(bytes, pos)?;
         pos += consumed;
@@ -842,7 +842,7 @@ pub fn decode_gui_status_bar_modeline(bytes: &[u8], offset: usize) -> Result<(Gu
     require_len(bytes, pos + 2, "right_segments count")?;
     let right_segments_count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut right_segments = Vec::with_capacity(right_segments_count.min(1024));
+    let mut right_segments = Vec::with_capacity(right_segments_count.min(bytes.len() - pos));
     for _ in 0..right_segments_count {
         let (item, consumed) = decode_modeline_segment(bytes, pos)?;
         pos += consumed;
@@ -952,7 +952,7 @@ pub fn decode_gui_window_content_rows(bytes: &[u8], offset: usize) -> Result<(Ve
     require_len(bytes, pos + 2, "rows count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count.min(1024));
+    let mut items = Vec::with_capacity(count.min(bytes.len() - pos));
     for _ in 0..count {
         let (item, consumed) = decode_row(bytes, pos)?;
         pos += consumed;
@@ -1043,7 +1043,7 @@ pub fn decode_gui_window_content_annotations(bytes: &[u8], offset: usize) -> Res
     require_len(bytes, pos + 2, "annotations count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count.min(1024));
+    let mut items = Vec::with_capacity(count.min(bytes.len() - pos));
     for _ in 0..count {
         let (item, consumed) = decode_annotation(bytes, pos)?;
         pos += consumed;
@@ -1179,7 +1179,7 @@ pub fn decode_gui_window_rows_delta_rows(bytes: &[u8], offset: usize) -> Result<
     require_len(bytes, pos + 2, "rows count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count.min(1024));
+    let mut items = Vec::with_capacity(count.min(bytes.len() - pos));
     for _ in 0..count {
         let (item, consumed) = decode_row(bytes, pos)?;
         pos += consumed;
@@ -1229,7 +1229,7 @@ pub fn decode_gui_window_viewport_delta_rows(bytes: &[u8], offset: usize) -> Res
     require_len(bytes, pos + 2, "rows count")?;
     let count = read_u16(bytes, pos) as usize;
     pos += 2;
-    let mut items = Vec::with_capacity(count.min(1024));
+    let mut items = Vec::with_capacity(count.min(bytes.len() - pos));
     for _ in 0..count {
         let (item, consumed) = decode_row(bytes, pos)?;
         pos += consumed;
@@ -1302,7 +1302,7 @@ pub fn decode_gui_completion_fields(bytes: &[u8], offset: usize) -> Result<(GuiC
         require_len(bytes, pos + 2, "items count")?;
         let items_count = read_u16(bytes, pos) as usize;
         pos += 2;
-        let mut items_value = Vec::with_capacity(items_count.min(1024));
+        let mut items_value = Vec::with_capacity(items_count.min(bytes.len() - pos));
         for _ in 0..items_count {
             let (item, consumed) = decode_completion_item(bytes, pos)?;
             pos += consumed;

--- a/rust/tui/src/generated/semantic_types.rs
+++ b/rust/tui/src/generated/semantic_types.rs
@@ -116,6 +116,21 @@ pub struct CompletionItem {
     pub detail: String,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MatchPosition {
+    pub index: u16,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PickerItem {
+    pub icon_color: u32,
+    pub flags: u8,
+    pub label: String,
+    pub description: String,
+    pub annotation: String,
+    pub match_positions: Vec<MatchPosition>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WhichKeyBinding {
     pub kind: u8,
@@ -148,6 +163,7 @@ pub const DIAGNOSTIC_RANGE_SIZE: usize = 9;
 pub const DOCUMENT_HIGHLIGHT_SIZE: usize = 9;
 pub const HIT_REGION_SIZE: usize = 11;
 pub const THEME_COLOR_SIZE: usize = 4;
+pub const MATCH_POSITION_SIZE: usize = 2;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct GuiWindowContentHeader {
@@ -386,9 +402,13 @@ pub struct GuiBreadcrumbFields {
     pub segment_count: u8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GuiCompletionFields {
     pub visible: u8,
+    pub cursor_row: u16,
+    pub cursor_col: u16,
+    pub selected_offset: u16,
+    pub items: Vec<CompletionItem>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/tui/src/generated/semantic_types.rs
+++ b/rust/tui/src/generated/semantic_types.rs
@@ -93,6 +93,53 @@ pub struct ModelineSegment {
     pub target: String,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TabEntry {
+    pub flags: u8,
+    pub id: u32,
+    pub workspace_id: u16,
+    pub icon: String,
+    pub label: String,
+    pub tint_color: u32,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ThemeColor {
+    pub slot: u8,
+    pub color: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CompletionItem {
+    pub kind: u8,
+    pub label: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WhichKeyBinding {
+    pub kind: u8,
+    pub key: String,
+    pub desc: String,
+    pub icon: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ChangeSummaryEntry {
+    pub path: String,
+    pub action: u8,
+    pub lines_added: u32,
+    pub lines_removed: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GitStatusEntry {
+    pub path_hash: u32,
+    pub section: u8,
+    pub status: u8,
+    pub path: String,
+}
+
 
 pub const RECT_SIZE: usize = 8;
 pub const SPAN_SIZE: usize = 13;
@@ -100,6 +147,7 @@ pub const SEARCH_MATCH_SIZE: usize = 7;
 pub const DIAGNOSTIC_RANGE_SIZE: usize = 9;
 pub const DOCUMENT_HIGHLIGHT_SIZE: usize = 9;
 pub const HIT_REGION_SIZE: usize = 11;
+pub const THEME_COLOR_SIZE: usize = 4;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct GuiWindowContentHeader {
@@ -251,5 +299,229 @@ pub struct GuiGutterConfig {
     pub line_number_style: u8,
     pub line_number_width: u8,
     pub sign_col_width: u8,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GuiWindowViewportDeltaHeader {
+    pub window_id: u16,
+    pub content_epoch: u32,
+    pub flags: u8,
+    pub cursor_row: u16,
+    pub cursor_col: u16,
+    pub cursor_shape: u8,
+    pub scroll_left: u16,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GuiWindowRowsDeltaHeader {
+    pub window_id: u16,
+    pub content_epoch: u32,
+    pub flags: u8,
+    pub cursor_row: u16,
+    pub cursor_col: u16,
+    pub cursor_shape: u8,
+    pub scroll_left: u16,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GuiPickerHeader {
+    pub visible: u8,
+    pub selected_index: u16,
+    pub item_count: u16,
+    pub total_count: u32,
+    pub flags: u8,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GuiPickerQuery {
+    pub text: String,
+    pub cursor_pos: u16,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GuiPickerActionMenu {
+    pub visible: u8,
+    pub selected_index: u8,
+    pub item_count: u8,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GuiPickerModePrefix {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GuiPickerLoadStatus {
+    pub status: u8,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GuiAgentChatHeader {
+    pub visible: u8,
+    pub flags: u8,
+    pub message_count: u16,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GuiPickerPreviewHeader {
+    pub visible: u8,
+    pub kind: u8,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiTabBarFields {
+    pub active_index: u8,
+    pub tab_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiThemeFields {
+    pub color_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiBreadcrumbFields {
+    pub segment_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiCompletionFields {
+    pub visible: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiWhichKeyFields {
+    pub visible: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiMinibufferFields {
+    pub visible: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiHoverPopupFields {
+    pub visible: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiSignatureHelpFields {
+    pub visible: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiFloatPopupFields {
+    pub visible: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiSplitSeparatorsFields {
+    pub bg: u32,
+    pub vertical_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiGitStatusFields {
+    pub repo_state: u8,
+    pub syncing: u8,
+    pub ahead: u16,
+    pub behind: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiBottomPanelFields {
+    pub visible: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiChangeSummaryFields {
+    pub visible: u8,
+    pub selected_index: u16,
+    pub entry_count: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiBoardFields {
+    pub visible: u8,
+    pub focused_card_id: u32,
+    pub card_count: u16,
+    pub filter_mode: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiAgentContextFields {
+    pub visible: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiGutterSepFields {
+    pub col: u16,
+    pub bg: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiCursorlineFields {
+    pub col: u16,
+    pub bg: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiSearchStateFields {
+    pub active: u8,
+    pub match_count: u16,
+    pub current_index: u16,
+    pub flags: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiEditTimelineFields {
+    pub visible: u8,
+    pub viewing_index: u16,
+    pub entry_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiWorkspacesFields {
+    pub visible: u8,
+    pub active_workspace_id: u16,
+    pub mode: u8,
+    pub flags: u8,
+    pub workspace_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiNotificationsFields {
+    pub visible: u8,
+    pub notification_count: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiSidebarsFields {
+    pub visible: u8,
+    pub sidebar_count: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiExtensionOverlayFields {
+    pub entry_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiExtensionPanelFields {
+    pub panel_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiFileTreeFields {
+    pub visible: u8,
+    pub flags: u8,
+    pub status: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuiToolManagerFields {
+    pub visible: u8,
 }
 

--- a/rust/tui/src/generated/semantic_types.rs
+++ b/rust/tui/src/generated/semantic_types.rs
@@ -132,6 +132,11 @@ pub struct PickerItem {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PickerAction {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WhichKeyBinding {
     pub kind: u8,
     pub key: String,
@@ -339,26 +344,27 @@ pub struct GuiWindowRowsDeltaHeader {
     pub scroll_left: u16,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GuiPickerHeader {
     pub visible: u8,
     pub selected_index: u16,
-    pub item_count: u16,
-    pub total_count: u32,
-    pub flags: u8,
+    pub filtered_count: u16,
+    pub total_count: u16,
+    pub has_preview: u8,
+    pub title: String,
+    pub marked_count: u16,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GuiPickerQuery {
     pub text: String,
-    pub cursor_pos: u16,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GuiPickerActionMenu {
     pub visible: u8,
     pub selected_index: u8,
-    pub item_count: u8,
+    pub actions: Vec<PickerAction>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/rust/tui/src/generated/semantic_types.rs
+++ b/rust/tui/src/generated/semantic_types.rs
@@ -116,11 +116,6 @@ pub struct CompletionItem {
     pub detail: String,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct MatchPosition {
-    pub index: u16,
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PickerItem {
     pub icon_color: u32,
@@ -128,12 +123,7 @@ pub struct PickerItem {
     pub label: String,
     pub description: String,
     pub annotation: String,
-    pub match_positions: Vec<MatchPosition>,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct PickerAction {
-    pub name: String,
+    pub match_positions: Vec<u16>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -168,7 +158,6 @@ pub const DIAGNOSTIC_RANGE_SIZE: usize = 9;
 pub const DOCUMENT_HIGHLIGHT_SIZE: usize = 9;
 pub const HIT_REGION_SIZE: usize = 11;
 pub const THEME_COLOR_SIZE: usize = 4;
-pub const MATCH_POSITION_SIZE: usize = 2;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct GuiWindowContentHeader {
@@ -364,7 +353,7 @@ pub struct GuiPickerQuery {
 pub struct GuiPickerActionMenu {
     pub visible: u8,
     pub selected_index: u8,
-    pub actions: Vec<PickerAction>,
+    pub actions: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/rust/tui/src/protocol.rs
+++ b/rust/tui/src/protocol.rs
@@ -735,7 +735,9 @@ mod generated_decode_tests {
     //! Round-trip coverage for the schema-generated decoders. The byte fixtures
     //! here are exactly what the Elixir encoders produce (the matching
     //! assertions live in protocol_schema_validation_test.exs), so together they
-    //! pin encoder and generated decoder to the same wire format.
+    //! pin encoder and generated decoder to the same wire format. Keep these in
+    //! sync with the Go twins in
+    //! go/tui/internal/protocol/generated_decode_test.go.
     use super::semantic_decode::*;
 
     #[test]
@@ -831,11 +833,39 @@ mod generated_decode_tests {
     }
 
     #[test]
-    fn truncated_picker_item_is_rejected_not_panicking() {
-        // count claims 2 match positions but only 1 u16 follows.
+    fn truncated_picker_item_elements_rejected() {
+        // count claims 2 match positions but only 1 u16 follows (count*stride guard).
         let bytes = [
             0xAA, 0xBB, 0xCC, 0, 0, 1, b'x', 0, 0, 0, 0, 2, 0, 1,
         ];
         assert!(decode_picker_item(&bytes, 0).is_err());
+    }
+
+    #[test]
+    fn truncated_picker_item_count_byte_rejected() {
+        // Buffer ends exactly before the match_positions count byte: the
+        // count-prefix require_len (a distinct bounds path) must reject it.
+        let bytes = [0xAA, 0xBB, 0xCC, 0, 0, 1, b'x', 0, 0, 0, 0];
+        assert!(decode_picker_item(&bytes, 0).is_err());
+    }
+
+    #[test]
+    fn decodes_picker_item_empty_match_positions() {
+        // match_positions present but count==0.
+        let bytes = [0, 0, 0, 0, 0, 1, b'x', 0, 0, 0, 0, 0];
+        let (item, consumed) = decode_picker_item(&bytes, 0).unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(item.label, "x");
+        assert!(item.match_positions.is_empty());
+    }
+
+    #[test]
+    fn decodes_action_menu_empty_actions() {
+        // visible with zero actions: the Vec<String> tail is present but empty.
+        let (m, consumed) = decode_gui_picker_action_menu(&[1, 5, 0], 0).unwrap();
+        assert_eq!(consumed, 3);
+        assert_eq!(m.visible, 1);
+        assert_eq!(m.selected_index, 5);
+        assert!(m.actions.is_empty());
     }
 }

--- a/rust/tui/src/protocol.rs
+++ b/rust/tui/src/protocol.rs
@@ -729,3 +729,113 @@ mod command_size_conformance {
         );
     }
 }
+
+#[cfg(test)]
+mod generated_decode_tests {
+    //! Round-trip coverage for the schema-generated decoders. The byte fixtures
+    //! here are exactly what the Elixir encoders produce (the matching
+    //! assertions live in protocol_schema_validation_test.exs), so together they
+    //! pin encoder and generated decoder to the same wire format.
+    use super::semantic_decode::*;
+
+    #[test]
+    fn decodes_completion_fields_with_items() {
+        // visible(1) cursor_row(3) cursor_col(7) selected_offset(1) count(1)
+        // item: kind(1=:function) label("foo") detail("bar")
+        let bytes = [
+            1, 0, 3, 0, 7, 0, 1, 0, 1, 1, 0, 3, b'f', b'o', b'o', 0, 3, b'b', b'a', b'r',
+        ];
+        let (f, consumed) = decode_gui_completion_fields(&bytes, 0).unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!((f.visible, f.cursor_row, f.cursor_col, f.selected_offset), (1, 3, 7, 1));
+        assert_eq!(f.items.len(), 1);
+        assert_eq!(f.items[0].kind, 1);
+        assert_eq!(f.items[0].label, "foo");
+        assert_eq!(f.items[0].detail, "bar");
+    }
+
+    #[test]
+    fn hidden_completion_skips_the_tail() {
+        let (f, consumed) = decode_gui_completion_fields(&[0], 0).unwrap();
+        assert_eq!(consumed, 1);
+        assert_eq!(f.visible, 0);
+        assert!(f.items.is_empty());
+    }
+
+    #[test]
+    fn decodes_picker_item_with_u16_match_positions() {
+        // icon_color(0xAABBCC) flags(0) label("file.ex") desc("desc") ann("ann")
+        // match_positions: count(2) then u16 1, u16 4
+        let bytes = [
+            0xAA, 0xBB, 0xCC, 0, 0, 7, b'f', b'i', b'l', b'e', b'.', b'e', b'x', 0, 4, b'd', b'e',
+            b's', b'c', 0, 3, b'a', b'n', b'n', 2, 0, 1, 0, 4,
+        ];
+        let (item, consumed) = decode_picker_item(&bytes, 0).unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(item.icon_color, 0x00AA_BBCC);
+        assert_eq!(item.label, "file.ex");
+        assert_eq!(item.description, "desc");
+        assert_eq!(item.annotation, "ann");
+        assert_eq!(item.match_positions, vec![1u16, 4u16]);
+    }
+
+    #[test]
+    fn decodes_picker_header_full_layout() {
+        let bytes = [1, 0, 2, 0, 10, 0, 100, 1, 0, 5, b'F', b'i', b'l', b'e', b's', 0, 3];
+        let (h, consumed) = decode_gui_picker_header(&bytes, 0).unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(h.selected_index, 2);
+        assert_eq!(h.filtered_count, 10);
+        assert_eq!(h.total_count, 100);
+        assert_eq!(h.has_preview, 1);
+        assert_eq!(h.title, "Files");
+        assert_eq!(h.marked_count, 3);
+    }
+
+    #[test]
+    fn decodes_action_menu_with_string_actions() {
+        // visible(1) selected_index(1) count(2) "Open" "Delete"
+        let bytes = [
+            1, 1, 2, 0, 4, b'O', b'p', b'e', b'n', 0, 6, b'D', b'e', b'l', b'e', b't', b'e',
+        ];
+        let (m, consumed) = decode_gui_picker_action_menu(&bytes, 0).unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(m.visible, 1);
+        assert_eq!(m.selected_index, 1);
+        assert_eq!(m.actions, vec!["Open".to_string(), "Delete".to_string()]);
+    }
+
+    #[test]
+    fn hidden_action_menu_skips_the_tail() {
+        let (m, consumed) = decode_gui_picker_action_menu(&[0], 0).unwrap();
+        assert_eq!(consumed, 1);
+        assert_eq!(m.visible, 0);
+        assert!(m.actions.is_empty());
+    }
+
+    #[test]
+    fn decodes_load_status_error_tail() {
+        let bytes = [2, 0, 4, b'b', b'o', b'o', b'm'];
+        let (s, consumed) = decode_gui_picker_load_status(&bytes, 0).unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(s.status, 2);
+        assert_eq!(s.message, "boom");
+    }
+
+    #[test]
+    fn ready_load_status_skips_the_tail() {
+        let (s, consumed) = decode_gui_picker_load_status(&[0], 0).unwrap();
+        assert_eq!(consumed, 1);
+        assert_eq!(s.status, 0);
+        assert_eq!(s.message, "");
+    }
+
+    #[test]
+    fn truncated_picker_item_is_rejected_not_panicking() {
+        // count claims 2 match positions but only 1 u16 follows.
+        let bytes = [
+            0xAA, 0xBB, 0xCC, 0, 0, 1, b'x', 0, 0, 0, 0, 2, 0, 1,
+        ];
+        assert!(decode_picker_item(&bytes, 0).is_err());
+    }
+}

--- a/test/minga_editor/frontend/protocol_schema_validation_test.exs
+++ b/test/minga_editor/frontend/protocol_schema_validation_test.exs
@@ -348,6 +348,19 @@ defmodule MingaEditor.Frontend.ProtocolSchemaValidationTest do
                  "but encoder did not emit it. Actual IDs: #{inspect(Enum.map(actual_ids, &hex/1))}"
       end
     end
+
+    test "every encoder-emitted section has a schema entry", %{sections: sections} do
+      schema_ids = sections["gui_status_bar"] |> Enum.map(& &1["id"]) |> MapSet.new()
+
+      <<0x76, section_count::8, sections_binary::binary>> =
+        StatusBarEncoder.encode_command(full_status_bar_model())
+
+      for id <- extract_section_ids(sections_binary, section_count) do
+        assert MapSet.member?(schema_ids, id),
+               "encoder emits gui_status_bar section 0x#{Integer.to_string(id, 16)} " <>
+                 "but the schema has no entry for it"
+      end
+    end
   end
 
   describe "gui_gutter section IDs" do
@@ -384,6 +397,34 @@ defmodule MingaEditor.Frontend.ProtocolSchemaValidationTest do
         assert id in actual_ids,
                "schema declares gui_gutter section 0x#{Integer.to_string(id, 16)} (#{name}) " <>
                  "but encoder did not emit it. Actual IDs: #{inspect(Enum.map(actual_ids, &hex/1))}"
+      end
+    end
+
+    test "every encoder-emitted section has a schema entry", %{sections: sections} do
+      schema_ids = sections["gui_gutter"] |> Enum.map(& &1["id"]) |> MapSet.new()
+
+      gutter = %Gutter{
+        window_id: 1,
+        content_row: 0,
+        content_col: 0,
+        content_height: 10,
+        is_active: true,
+        content_width: 4,
+        cursor_line: 1,
+        line_number_style: :hybrid,
+        line_number_width: 4,
+        sign_col_width: 2,
+        entries: [%GutterEntry{buf_line: 1, display_type: :normal, sign_type: :none}]
+      }
+
+      commands = WindowEncoder.encode(minimal_render_window(gutter: gutter))
+      gutter_binary = Enum.find(commands, fn <<opcode, _::binary>> -> opcode == 0x7B end)
+      <<0x7B, section_count::8, sections_binary::binary>> = gutter_binary
+
+      for id <- extract_section_ids(sections_binary, section_count) do
+        assert MapSet.member?(schema_ids, id),
+               "encoder emits gui_gutter section 0x#{Integer.to_string(id, 16)} " <>
+                 "but the schema has no entry for it"
       end
     end
   end
@@ -458,6 +499,75 @@ defmodule MingaEditor.Frontend.ProtocolSchemaValidationTest do
                "encoder emits gui_picker section 0x#{Integer.to_string(id, 16)} " <>
                  "but the schema has no entry for it"
       end
+    end
+  end
+
+  describe "gui_picker variable sections match schema" do
+    test "header section encodes the full title/marked_count layout" do
+      model = %Picker{
+        visible?: true,
+        title: "Files",
+        selected_index: 2,
+        filtered_count: 10,
+        total_count: 100,
+        marked_count: 3,
+        has_preview?: true,
+        items: []
+      }
+
+      <<_opcode, section_count::8, sections_binary::binary>> =
+        PickerEncoder.encode_command(model)
+
+      header = extract_section_payload(sections_binary, section_count, 0x01)
+
+      # visible(u8=1), selected_index(u16), filtered_count(u16), total_count(u16),
+      # has_preview(u8), title(string16), marked_count(u16). total_count is u16.
+      assert header == <<1::8, 2::16, 10::16, 100::16, 1::8, 5::16, "Files", 3::16>>
+    end
+
+    test "query section encodes only the text string" do
+      <<_opcode, section_count::8, sections_binary::binary>> =
+        PickerEncoder.encode_command(%Picker{visible?: true, query: "hi", items: []})
+
+      assert extract_section_payload(sections_binary, section_count, 0x02) == <<2::16, "hi">>
+    end
+
+    test "action_menu section encodes the visible conditional tail" do
+      menu = %Picker.ActionMenu{selected_index: 1, actions: ["Open", "Delete"]}
+
+      <<_opcode, section_count::8, sections_binary::binary>> =
+        PickerEncoder.encode_command(%Picker{visible?: true, action_menu: menu, items: []})
+
+      payload = extract_section_payload(sections_binary, section_count, 0x04)
+
+      # visible(u8=1), then selected_index(u8), action count(u8), each action string16.
+      assert payload == <<1::8, 1::8, 2::8, 4::16, "Open", 6::16, "Delete">>
+    end
+
+    test "hidden action_menu encodes only the visible byte" do
+      <<_opcode, section_count::8, sections_binary::binary>> =
+        PickerEncoder.encode_command(%Picker{visible?: true, action_menu: nil, items: []})
+
+      assert extract_section_payload(sections_binary, section_count, 0x04) == <<0::8>>
+    end
+
+    test "load_status error encodes the status==2 message tail" do
+      <<_opcode, section_count::8, sections_binary::binary>> =
+        PickerEncoder.encode_command(%Picker{
+          visible?: true,
+          load_status: {:error, "boom"},
+          items: []
+        })
+
+      assert extract_section_payload(sections_binary, section_count, 0x06) ==
+               <<2::8, 4::16, "boom">>
+    end
+
+    test "load_status ready encodes only the status byte" do
+      <<_opcode, section_count::8, sections_binary::binary>> =
+        PickerEncoder.encode_command(%Picker{visible?: true, load_status: :ready, items: []})
+
+      assert extract_section_payload(sections_binary, section_count, 0x06) == <<0::8>>
     end
   end
 

--- a/test/minga_editor/frontend/protocol_schema_validation_test.exs
+++ b/test/minga_editor/frontend/protocol_schema_validation_test.exs
@@ -6,6 +6,12 @@ defmodule MingaEditor.Frontend.ProtocolSchemaValidationTest do
   This is the safety net that catches encoder/schema drift in CI. If someone
   adds a field to an encoder without updating the schema (or vice versa),
   these tests fail.
+
+  The exact byte layouts asserted here for picker/completion are decoded back by
+  the generated Rust/Go decoders in `rust/tui/src/protocol.rs` and
+  `go/tui/internal/protocol/generated_decode_test.go`. Those three fixtures must
+  stay in lockstep: a wire-format change has to be reflected in all three, or one
+  side silently tests a stale format.
   """
 
   use ExUnit.Case, async: true

--- a/test/minga_editor/frontend/protocol_schema_validation_test.exs
+++ b/test/minga_editor/frontend/protocol_schema_validation_test.exs
@@ -10,8 +10,12 @@ defmodule MingaEditor.Frontend.ProtocolSchemaValidationTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Frontend.Adapter.GUI.CompletionEncoder
+  alias Minga.Frontend.Adapter.GUI.PickerEncoder
   alias Minga.Frontend.Adapter.GUI.StatusBarEncoder
   alias Minga.Frontend.Adapter.GUI.WindowEncoder
+  alias Minga.RenderModel.UI.Completion
+  alias Minga.RenderModel.UI.Picker
   alias Minga.RenderModel.Window, as: RenderWindow
   alias Minga.RenderModel.Window.DiagnosticRange
   alias Minga.RenderModel.Window.DocumentHighlight
@@ -57,7 +61,12 @@ defmodule MingaEditor.Frontend.ProtocolSchemaValidationTest do
       "search_match" => 7,
       "diagnostic_range" => 9,
       "document_highlight" => 9,
-      "gutter_entry" => 10
+      "gutter_entry" => 10,
+      # hit_region.id is u16 on the wire (kind 1 + rect 8 + id 2). Pinning the
+      # schema-computed size here guards against the field silently widening to
+      # u32, which would desync the geometry section's hit_regions array.
+      "hit_region" => 11,
+      "match_position" => 2
     }
 
     for {name, expected_size} <- @expected_sizes do
@@ -261,6 +270,23 @@ defmodule MingaEditor.Frontend.ProtocolSchemaValidationTest do
                  "but encoder did not emit it. Actual IDs: #{inspect(Enum.map(actual_ids, &hex/1))}"
       end
     end
+
+    test "every encoder-emitted section has a schema entry", %{sections: sections} do
+      schema_ids = sections["gui_window_content"] |> Enum.map(& &1["id"]) |> MapSet.new()
+
+      window = full_render_window()
+      binary = WindowEncoder.encode_window_content(window)
+
+      <<0x80, section_count::8, sections_binary::binary>> = binary
+      actual_ids = extract_section_ids(sections_binary, section_count)
+
+      for id <- actual_ids do
+        assert MapSet.member?(schema_ids, id),
+               "encoder emits gui_window_content section 0x#{Integer.to_string(id, 16)} " <>
+                 "but the schema has no entry for it. Schema IDs: " <>
+                 "#{inspect(schema_ids |> MapSet.to_list() |> Enum.sort() |> Enum.map(&hex/1))}"
+      end
+    end
   end
 
   describe "gui_window_content selection encoding" do
@@ -358,6 +384,79 @@ defmodule MingaEditor.Frontend.ProtocolSchemaValidationTest do
         assert id in actual_ids,
                "schema declares gui_gutter section 0x#{Integer.to_string(id, 16)} (#{name}) " <>
                  "but encoder did not emit it. Actual IDs: #{inspect(Enum.map(actual_ids, &hex/1))}"
+      end
+    end
+  end
+
+  describe "gui_completion command fields match schema" do
+    test "visible completion encodes placement header and items per command_fields" do
+      item = %Completion.Item{kind: :function, label: "foo", detail: "bar"}
+
+      model = %Completion{
+        visible?: true,
+        cursor_row: 3,
+        cursor_col: 7,
+        selected_offset: 1,
+        items: [item]
+      }
+
+      # Schema command_fields: visible(u8), then a visible==1 tail of
+      # cursor_row(u16) + cursor_col(u16) + selected_offset(u16) +
+      # items(u16-counted completion_item).
+      <<_opcode, visible::8, cursor_row::16, cursor_col::16, selected_offset::16, item_count::16,
+        items::binary>> = CompletionEncoder.encode_command(model)
+
+      assert {visible, cursor_row, cursor_col, selected_offset, item_count} == {1, 3, 7, 1, 1}
+      # completion_item: kind(u8) + label(string16) + detail(string16). kind :function -> 1.
+      assert items == <<1::8, 3::16, "foo", 3::16, "bar">>
+    end
+
+    test "hidden completion encodes only the visible byte" do
+      assert <<_opcode, 0::8>> = CompletionEncoder.encode_command(%Completion{visible?: false})
+    end
+  end
+
+  describe "gui_picker items section matches schema" do
+    test "items section encodes picker_item fields per schema" do
+      item = %Picker.Item{
+        id: "1",
+        label: "file.ex",
+        description: "desc",
+        annotation: "ann",
+        icon_color: 0xAABBCC,
+        two_line?: false,
+        match_positions: [1, 4],
+        marked?: false
+      }
+
+      <<_opcode, section_count::8, sections_binary::binary>> =
+        PickerEncoder.encode_command(%Picker{visible?: true, items: [item]})
+
+      items_payload = extract_section_payload(sections_binary, section_count, 0x03)
+
+      # count(u16), then one picker_item: icon_color(u24) + flags(u8) +
+      # label(string16) + description(string16) + annotation(string16) +
+      # match_positions(u8-counted u16).
+      assert items_payload ==
+               <<1::16, 0xAA, 0xBB, 0xCC, 0::8, 7::16, "file.ex", 4::16, "desc", 3::16, "ann",
+                 2::8, 1::16, 4::16>>
+    end
+
+    test "schema models every section the picker encoder emits", %{sections: sections} do
+      schema_ids = sections["gui_picker"] |> Enum.map(& &1["id"]) |> MapSet.new()
+
+      <<_opcode, section_count::8, sections_binary::binary>> =
+        PickerEncoder.encode_command(%Picker{
+          visible?: true,
+          items: [%Picker.Item{id: "1", label: "x"}]
+        })
+
+      actual_ids = extract_section_ids(sections_binary, section_count)
+
+      for id <- actual_ids do
+        assert MapSet.member?(schema_ids, id),
+               "encoder emits gui_picker section 0x#{Integer.to_string(id, 16)} " <>
+                 "but the schema has no entry for it"
       end
     end
   end

--- a/test/minga_editor/frontend/protocol_schema_validation_test.exs
+++ b/test/minga_editor/frontend/protocol_schema_validation_test.exs
@@ -65,8 +65,7 @@ defmodule MingaEditor.Frontend.ProtocolSchemaValidationTest do
       # hit_region.id is u16 on the wire (kind 1 + rect 8 + id 2). Pinning the
       # schema-computed size here guards against the field silently widening to
       # u32, which would desync the geometry section's hit_regions array.
-      "hit_region" => 11,
-      "match_position" => 2
+      "hit_region" => 11
     }
 
     for {name, expected_size} <- @expected_sizes do
@@ -481,6 +480,24 @@ defmodule MingaEditor.Frontend.ProtocolSchemaValidationTest do
       assert items_payload ==
                <<1::16, 0xAA, 0xBB, 0xCC, 0::8, 7::16, "file.ex", 4::16, "desc", 3::16, "ann",
                  2::8, 1::16, 4::16>>
+    end
+
+    test "picker_item flags pack two_line (bit 0) and marked (bit 1)" do
+      item = %Picker.Item{
+        id: "1",
+        label: "x",
+        two_line?: true,
+        marked?: true,
+        match_positions: []
+      }
+
+      <<_opcode, section_count::8, sections_binary::binary>> =
+        PickerEncoder.encode_command(%Picker{visible?: true, items: [item]})
+
+      items_payload = extract_section_payload(sections_binary, section_count, 0x03)
+
+      # count(1), icon_color(0), flags(0b11 = 3), label "x", empty desc/ann, 0 positions.
+      assert items_payload == <<1::16, 0::24, 3::8, 1::16, "x", 0::16, 0::16, 0::8>>
     end
 
     test "schema models every section the picker encoder emits", %{sections: sections} do


### PR DESCRIPTION
## Summary

- Extends the protocol schema to cover ALL remaining GUI semantic commands beyond the initial 3
- Adds 6 new shared structures, 11 new section definitions, and 26 command field entries
- Generator now supports `[[command_fields]]` for custom-framed commands (non-sectioned)
- Total: 34 opcodes with field definitions, 16 shared structures, 35 sections

## What changed

**Schema**: 364 new lines in `protocol_schema.toml` covering every GUI semantic command. New shared structures: `tab_entry`, `theme_color`, `completion_item`, `which_key_binding`, `change_summary_entry`, `git_status_entry`. New sections for `gui_picker` (5 sections), `gui_agent_chat`, `gui_picker_preview`, `gui_window_viewport_delta` (2), `gui_window_rows_delta` (2).

**Generator**: New `[[command_fields]]` parsing, validation, and Rust/Go struct + decode generation. Custom-framed commands get header field definitions that the generator turns into type-safe decode functions.

**Generated code**: Rust and Go files regenerated with ~1,700 new lines of struct definitions and decode functions.

## Test plan

- [x] `mix protocol.gen --check` passes
- [x] `cargo test -p minga-tui` — 86 tests pass
- [x] `go build ./go/tui/...` and `go test ./go/tui/...` — 133 tests pass
- [x] Schema TOML validates (34 opcodes, 16 structures, 35 sections, 26 command_fields)

Stacks on #2143 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)