### PR TITLE
style(rust): rustfmt protocol.rs to fix Rust TUI CI on main

### DIFF
--- a/rust/tui/src/protocol.rs
+++ b/rust/tui/src/protocol.rs
@@ -749,7 +749,10 @@ mod generated_decode_tests {
         ];
         let (f, consumed) = decode_gui_completion_fields(&bytes, 0).unwrap();
         assert_eq!(consumed, bytes.len());
-        assert_eq!((f.visible, f.cursor_row, f.cursor_col, f.selected_offset), (1, 3, 7, 1));
+        assert_eq!(
+            (f.visible, f.cursor_row, f.cursor_col, f.selected_offset),
+            (1, 3, 7, 1)
+        );
         assert_eq!(f.items.len(), 1);
         assert_eq!(f.items[0].kind, 1);
         assert_eq!(f.items[0].label, "foo");
@@ -783,7 +786,9 @@ mod generated_decode_tests {
 
     #[test]
     fn decodes_picker_header_full_layout() {
-        let bytes = [1, 0, 2, 0, 10, 0, 100, 1, 0, 5, b'F', b'i', b'l', b'e', b's', 0, 3];
+        let bytes = [
+            1, 0, 2, 0, 10, 0, 100, 1, 0, 5, b'F', b'i', b'l', b'e', b's', 0, 3,
+        ];
         let (h, consumed) = decode_gui_picker_header(&bytes, 0).unwrap();
         assert_eq!(consumed, bytes.len());
         assert_eq!(h.selected_index, 2);
@@ -835,9 +840,7 @@ mod generated_decode_tests {
     #[test]
     fn truncated_picker_item_elements_rejected() {
         // count claims 2 match positions but only 1 u16 follows (count*stride guard).
-        let bytes = [
-            0xAA, 0xBB, 0xCC, 0, 0, 1, b'x', 0, 0, 0, 0, 2, 0, 1,
-        ];
+        let bytes = [0xAA, 0xBB, 0xCC, 0, 0, 1, b'x', 0, 0, 0, 0, 2, 0, 1];
         assert!(decode_picker_item(&bytes, 0).is_err());
     }
 


### PR DESCRIPTION
## What

`cargo fmt --check` in the **Test (Rust TUI)** CI job fails on `main`: the hand-written byte-array and `assert_eq!` layouts in the generated-decoder test module (added in #2144) aren't rustfmt-clean.

This applies `cargo fmt` to `rust/tui/src/protocol.rs`. No logic change (8 insertions / 5 deletions, pure formatting).

## Why it slipped through

The fix was committed on the #2144 branch (`0d62c284`) but landed **after** the PR squash-merged at `d7464a78`, so it never reached `main`.

## Verification

- [x] `cargo fmt --manifest-path rust/tui/Cargo.toml --check` passes
- [x] `cargo test` 99 pass, `cargo clippy -- -D warnings` clean (verified on the #2144 branch with the same change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)