### PR TITLE
feat(rust): decode all semantic commands, eliminate Unsupported variant

### DIFF
--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -101,6 +101,7 @@ pub struct Renderer {
     git_status_snapshot: Option<CellSnapshot>,
     agent_context: Option<semantic::AgentContext>,
     agent_context_snapshot: Option<CellSnapshot>,
+    last_status_bar: Option<semantic::StatusBar>,
     search_state: Option<semantic::SearchState>,
     notifications: Option<semantic::Notifications>,
     notifications_snapshot: Option<CellSnapshot>,
@@ -163,6 +164,7 @@ impl Renderer {
             git_status_snapshot: None,
             agent_context: None,
             agent_context_snapshot: None,
+            last_status_bar: None,
             search_state: None,
             notifications: None,
             notifications_snapshot: None,
@@ -272,6 +274,7 @@ impl Renderer {
         self.git_status_snapshot = None;
         self.agent_context = None;
         self.agent_context_snapshot = None;
+        self.last_status_bar = None;
         self.search_state = None;
         self.notifications = None;
         self.notifications_snapshot = None;
@@ -829,6 +832,7 @@ impl Renderer {
             return;
         }
 
+        self.last_status_bar = Some(status.clone());
         let row = self.height - 1;
         self.clear_row(row);
 
@@ -909,6 +913,12 @@ impl Renderer {
         let paragraph =
             Paragraph::new(RatatuiLine::from(spans)).style(ratatui_style_from_cell(style));
         self.render_ratatui_widget(row, 0, self.width, 1, paragraph);
+    }
+
+    fn refresh_status_bar_indicators(&mut self) {
+        if let Some(status) = self.last_status_bar.clone() {
+            self.draw_status_bar(status);
+        }
     }
 
     fn draw_tab_bar(&mut self, tab_bar: semantic::TabBar) {
@@ -1926,9 +1936,10 @@ impl Renderer {
     fn draw_search_state(&mut self, state: semantic::SearchState) {
         if state.active == 0 {
             self.search_state = None;
-            return;
+        } else {
+            self.search_state = Some(state);
         }
-        self.search_state = Some(state);
+        self.refresh_status_bar_indicators();
     }
 
     fn draw_notifications(&mut self, notifs: semantic::Notifications) {
@@ -1989,25 +2000,28 @@ impl Renderer {
     fn draw_edit_timeline(&mut self, timeline: semantic::EditTimeline) {
         if timeline.visible == 0 {
             self.edit_timeline = None;
-            return;
+        } else {
+            self.edit_timeline = Some(timeline);
         }
-        self.edit_timeline = Some(timeline);
+        self.refresh_status_bar_indicators();
     }
 
     fn draw_workspaces(&mut self, ws: semantic::Workspaces) {
         if ws.visible == 0 {
             self.workspaces = None;
-            return;
+        } else {
+            self.workspaces = Some(ws);
         }
-        self.workspaces = Some(ws);
+        self.refresh_status_bar_indicators();
     }
 
     fn draw_sidebars(&mut self, sb: semantic::Sidebars) {
         if sb.visible == 0 {
             self.sidebars = None;
-            return;
+        } else {
+            self.sidebars = Some(sb);
         }
-        self.sidebars = Some(sb);
+        self.refresh_status_bar_indicators();
     }
 
     fn draw_extension_overlay(&mut self, overlay: semantic::ExtensionOverlay) {
@@ -2064,13 +2078,14 @@ impl Renderer {
     fn draw_extension_panel(&mut self, panel: semantic::ExtensionPanel) {
         if panel.panel_count == 0 {
             self.extension_panel = None;
-            return;
+        } else {
+            self.extension_panel = Some(panel);
         }
-        self.extension_panel = Some(panel);
+        self.refresh_status_bar_indicators();
     }
 
     fn draw_observatory(&mut self, obs: semantic::Observatory) {
-        if obs.payload.is_empty() {
+        if !obs.visible {
             self.restore_observatory_snapshot();
             self.observatory = None;
             return;
@@ -5471,6 +5486,7 @@ mod tests {
         let mut renderer = Renderer::new(70, 20);
 
         renderer.draw_observatory(semantic::Observatory {
+            visible: true,
             payload: vec![1, 2, 3, 4, 5],
         });
 
@@ -5478,6 +5494,7 @@ mod tests {
         assert!(renderer.observatory_snapshot.is_some());
 
         renderer.draw_observatory(semantic::Observatory {
+            visible: false,
             payload: vec![],
         });
 

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -99,6 +99,19 @@ pub struct Renderer {
     bottom_panel_snapshot: Option<CellSnapshot>,
     change_summary_snapshot: Option<CellSnapshot>,
     git_status_snapshot: Option<CellSnapshot>,
+    agent_context: Option<semantic::AgentContext>,
+    agent_context_snapshot: Option<CellSnapshot>,
+    search_state: Option<semantic::SearchState>,
+    notifications: Option<semantic::Notifications>,
+    notifications_snapshot: Option<CellSnapshot>,
+    edit_timeline: Option<semantic::EditTimeline>,
+    workspaces: Option<semantic::Workspaces>,
+    sidebars: Option<semantic::Sidebars>,
+    extension_overlay: Option<semantic::ExtensionOverlay>,
+    extension_overlay_snapshot: Option<CellSnapshot>,
+    extension_panel: Option<semantic::ExtensionPanel>,
+    observatory: Option<semantic::Observatory>,
+    observatory_snapshot: Option<CellSnapshot>,
     theme: ThemePalette,
 }
 
@@ -142,6 +155,19 @@ impl Renderer {
             bottom_panel_snapshot: None,
             change_summary_snapshot: None,
             git_status_snapshot: None,
+            agent_context: None,
+            agent_context_snapshot: None,
+            search_state: None,
+            notifications: None,
+            notifications_snapshot: None,
+            edit_timeline: None,
+            workspaces: None,
+            sidebars: None,
+            extension_overlay: None,
+            extension_overlay_snapshot: None,
+            extension_panel: None,
+            observatory: None,
+            observatory_snapshot: None,
             theme: ThemePalette::default(),
         }
     }
@@ -232,6 +258,19 @@ impl Renderer {
         self.bottom_panel_snapshot = None;
         self.change_summary_snapshot = None;
         self.git_status_snapshot = None;
+        self.agent_context = None;
+        self.agent_context_snapshot = None;
+        self.search_state = None;
+        self.notifications = None;
+        self.notifications_snapshot = None;
+        self.edit_timeline = None;
+        self.workspaces = None;
+        self.sidebars = None;
+        self.extension_overlay = None;
+        self.extension_overlay_snapshot = None;
+        self.extension_panel = None;
+        self.observatory = None;
+        self.observatory_snapshot = None;
         self.semantic_windows.clear();
         self.semantic_cursorline_snapshots.clear();
     }
@@ -333,16 +372,18 @@ impl Renderer {
             semantic::Command::LineSpacing(_, _) => {}
             semantic::Command::CursorAnimation(_, _) => {}
             semantic::Command::ConfigState(_, _) => {}
-            semantic::Command::AgentContext(_, _) => {}
+            semantic::Command::AgentContext(ctx, _) => self.draw_agent_context(ctx),
             semantic::Command::HoverAction(_, _) => {}
-            semantic::Command::SearchState(_, _) => {}
-            semantic::Command::Workspaces(_, _) => {}
-            semantic::Command::Notifications(_, _) => {}
-            semantic::Command::EditTimeline(_, _) => {}
-            semantic::Command::ExtensionOverlay(_, _) => {}
-            semantic::Command::ExtensionPanel(_, _) => {}
-            semantic::Command::Observatory(_, _) => {}
-            semantic::Command::Sidebars(_, _) => {}
+            semantic::Command::SearchState(state, _) => self.draw_search_state(state),
+            semantic::Command::Workspaces(ws, _) => self.draw_workspaces(ws),
+            semantic::Command::Notifications(notifs, _) => self.draw_notifications(notifs),
+            semantic::Command::EditTimeline(timeline, _) => self.draw_edit_timeline(timeline),
+            semantic::Command::ExtensionOverlay(overlay, _) => {
+                self.draw_extension_overlay(overlay)
+            }
+            semantic::Command::ExtensionPanel(panel, _) => self.draw_extension_panel(panel),
+            semantic::Command::Observatory(obs, _) => self.draw_observatory(obs),
+            semantic::Command::Sidebars(sb, _) => self.draw_sidebars(sb),
             semantic::Command::Board(_, _) => {}
             semantic::Command::AgentChat(_, _) => {}
             semantic::Command::ToolManager(_, _) => {}
@@ -779,11 +820,49 @@ impl Renderer {
             join_status_segments(&status.left_segments)
         };
 
-        let right = if status.right_segments.is_empty() {
+        let mut right = if status.right_segments.is_empty() {
             fallback_status_right(&status)
         } else {
             join_status_segments(&status.right_segments)
         };
+
+        let mut indicators = Vec::new();
+        if let Some(search) = &self.search_state {
+            if search.match_count > 0 {
+                indicators.push(format!(
+                    "Match {}/{}",
+                    search.current_index.saturating_add(1),
+                    search.match_count
+                ));
+            } else {
+                indicators.push("No matches".to_owned());
+            }
+        }
+        if let Some(timeline) = &self.edit_timeline {
+            indicators.push(format!(
+                "Undo {}/{}",
+                timeline.viewing_index, timeline.entry_count
+            ));
+        }
+        if let Some(ws) = &self.workspaces {
+            if ws.workspace_count > 1 {
+                indicators.push(format!("WS {}", ws.workspace_count));
+            }
+        }
+        if let Some(sb) = &self.sidebars {
+            if sb.sidebar_count > 0 {
+                indicators.push(format!("SB {}", sb.sidebar_count));
+            }
+        }
+        if let Some(ext) = &self.extension_panel {
+            if ext.panel_count > 0 {
+                indicators.push(format!("Ext {}", ext.panel_count));
+            }
+        }
+        if !indicators.is_empty() {
+            let suffix = format!(" [{}]", indicators.join(" | "));
+            right = format!("{}{}", right, suffix);
+        }
 
         let style = self.theme.status_bar_style();
         let left_width = text_width(&left).min(self.width);
@@ -1104,6 +1183,22 @@ impl Renderer {
         if let Some(git_status) = self.git_status.clone() {
             self.git_status_snapshot = None;
             self.render_git_status(&git_status);
+        }
+        if let Some(ctx) = self.agent_context.clone() {
+            self.agent_context_snapshot = None;
+            self.render_agent_context(&ctx);
+        }
+        if let Some(notifs) = self.notifications {
+            self.notifications_snapshot = None;
+            self.render_notifications(&notifs);
+        }
+        if let Some(overlay) = self.extension_overlay {
+            self.extension_overlay_snapshot = None;
+            self.render_extension_overlay(&overlay);
+        }
+        if let Some(obs) = self.observatory.clone() {
+            self.observatory_snapshot = None;
+            self.render_observatory(&obs);
         }
 
         if let Some(minibuffer) = self.minibuffer.clone() {
@@ -1675,6 +1770,235 @@ impl Renderer {
 
     fn restore_git_status_cells(&mut self) {
         if let Some(snapshot) = self.git_status_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn draw_agent_context(&mut self, ctx: semantic::AgentContext) {
+        if ctx.visible == 0 {
+            self.restore_agent_context_snapshot();
+            self.agent_context = None;
+            return;
+        }
+        self.agent_context = Some(ctx.clone());
+        self.render_agent_context(&ctx);
+    }
+
+    fn render_agent_context(&mut self, ctx: &semantic::AgentContext) {
+        self.restore_agent_context_cells();
+        if self.height < 3 || self.width < 20 {
+            return;
+        }
+
+        let row = self.height.saturating_sub(2);
+        let status_label = match ctx.status {
+            0 => "idle",
+            1 => "working",
+            2 => "iterating",
+            3 => "needs_you",
+            4 => "done",
+            5 => "errored",
+            _ => "unknown",
+        };
+        let task_display = if ctx.task.is_empty() {
+            String::new()
+        } else {
+            format!(" {}", ctx.task)
+        };
+        let elapsed = if ctx.timestamp > 0 {
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let delta = now_secs.saturating_sub(ctx.timestamp);
+            let mins = delta / 60;
+            let secs = delta % 60;
+            format!(" {}m{}s", mins, secs)
+        } else {
+            String::new()
+        };
+        let text = format!(" Agent: [{}]{}{} ", status_label, task_display, elapsed);
+        let style = self.theme.status_bar_style();
+
+        if self.agent_context_snapshot.is_none() {
+            self.agent_context_snapshot = Some(self.capture_rect(row, 0, self.width, 1));
+        }
+        self.write_run(row, 0, &pad_to_width(&text, self.width), style);
+    }
+
+    fn restore_agent_context_snapshot(&mut self) {
+        if let Some(snapshot) = self.agent_context_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_agent_context_cells(&mut self) {
+        if let Some(snapshot) = self.agent_context_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn draw_search_state(&mut self, state: semantic::SearchState) {
+        if state.active == 0 {
+            self.search_state = None;
+            return;
+        }
+        self.search_state = Some(state);
+    }
+
+    fn draw_notifications(&mut self, notifs: semantic::Notifications) {
+        if notifs.visible == 0 || notifs.notification_count == 0 {
+            self.restore_notifications_snapshot();
+            self.notifications = None;
+            return;
+        }
+        self.notifications = Some(notifs);
+        self.render_notifications(&notifs);
+    }
+
+    fn render_notifications(&mut self, notifs: &semantic::Notifications) {
+        self.restore_notifications_cells();
+        if self.width < 20 || self.height < 3 {
+            return;
+        }
+
+        let text = if notifs.notification_count == 1 {
+            " 1 notification ".to_owned()
+        } else {
+            format!(" {} notifications ", notifs.notification_count)
+        };
+        let width = text_width(&text).saturating_add(4).min(self.width);
+        let col = self.width.saturating_sub(width);
+        let row = 1_u16;
+        let height = 3_u16.min(self.height.saturating_sub(row));
+
+        if self.notifications_snapshot.is_none() {
+            self.notifications_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+        self.render_popup_panel(row, col, width, height, " Notifications ", text);
+    }
+
+    fn restore_notifications_snapshot(&mut self) {
+        if let Some(snapshot) = self.notifications_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_notifications_cells(&mut self) {
+        if let Some(snapshot) = self.notifications_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn draw_edit_timeline(&mut self, timeline: semantic::EditTimeline) {
+        if timeline.visible == 0 {
+            self.edit_timeline = None;
+            return;
+        }
+        self.edit_timeline = Some(timeline);
+    }
+
+    fn draw_workspaces(&mut self, ws: semantic::Workspaces) {
+        if ws.visible == 0 {
+            self.workspaces = None;
+            return;
+        }
+        self.workspaces = Some(ws);
+    }
+
+    fn draw_sidebars(&mut self, sb: semantic::Sidebars) {
+        if sb.visible == 0 {
+            self.sidebars = None;
+            return;
+        }
+        self.sidebars = Some(sb);
+    }
+
+    fn draw_extension_overlay(&mut self, overlay: semantic::ExtensionOverlay) {
+        if overlay.entry_count == 0 {
+            self.restore_extension_overlay_snapshot();
+            self.extension_overlay = None;
+            return;
+        }
+        self.extension_overlay = Some(overlay);
+        self.render_extension_overlay(&overlay);
+    }
+
+    fn render_extension_overlay(&mut self, overlay: &semantic::ExtensionOverlay) {
+        self.restore_extension_overlay_cells();
+        if self.width < 20 || self.height < 4 {
+            return;
+        }
+
+        let text = format!(" {} extension entries ", overlay.entry_count);
+        let width = text_width(&text).saturating_add(4).min(self.width);
+        let col = self.width.saturating_sub(width).saturating_div(2);
+        let row = self.height.saturating_div(3);
+        let height = 3_u16.min(self.height.saturating_sub(row));
+
+        if self.extension_overlay_snapshot.is_none() {
+            self.extension_overlay_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+        self.render_popup_panel(row, col, width, height, " Extension ", text);
+    }
+
+    fn restore_extension_overlay_snapshot(&mut self) {
+        if let Some(snapshot) = self.extension_overlay_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_extension_overlay_cells(&mut self) {
+        if let Some(snapshot) = self.extension_overlay_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn draw_extension_panel(&mut self, panel: semantic::ExtensionPanel) {
+        if panel.panel_count == 0 {
+            self.extension_panel = None;
+            return;
+        }
+        self.extension_panel = Some(panel);
+    }
+
+    fn draw_observatory(&mut self, obs: semantic::Observatory) {
+        if obs.payload.is_empty() {
+            self.restore_observatory_snapshot();
+            self.observatory = None;
+            return;
+        }
+        self.observatory = Some(obs.clone());
+        self.render_observatory(&obs);
+    }
+
+    fn render_observatory(&mut self, obs: &semantic::Observatory) {
+        self.restore_observatory_cells();
+        if self.width < 30 || self.height < 8 {
+            return;
+        }
+
+        let width = self.width.saturating_sub(4).clamp(30, 60);
+        let height = 6_u16.min(self.height.saturating_sub(4));
+        let row = 2;
+        let col = self.width.saturating_sub(width).saturating_div(2);
+
+        if self.observatory_snapshot.is_none() {
+            self.observatory_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+
+        let text = format!(" Process tree ({} bytes payload) ", obs.payload.len());
+        self.render_popup_panel(row, col, width, height, " Observatory ", text);
+    }
+
+    fn restore_observatory_snapshot(&mut self) {
+        if let Some(snapshot) = self.observatory_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_observatory_cells(&mut self) {
+        if let Some(snapshot) = self.observatory_snapshot.clone() {
             self.restore_snapshot(snapshot);
         }
     }
@@ -4678,5 +5002,296 @@ mod tests {
         assert_eq!(renderer.cells[renderer.index(0, 0).unwrap()].text, "界");
         assert_eq!(renderer.cells[renderer.index(1, 0).unwrap()].text, "");
         assert_eq!(renderer.cells[renderer.index(2, 0).unwrap()].text, "x");
+    }
+
+    #[test]
+    fn agent_context_renders_status_bar_and_restores_on_hide() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_agent_context(semantic::AgentContext {
+            visible: 1,
+            task: "Fix bug".to_owned(),
+            timestamp: 0,
+            status: 1,
+            can_approve: 0,
+        });
+
+        let row = renderer.height.saturating_sub(2);
+        assert_eq!(
+            renderer.cells[renderer.index(1, row).unwrap()].text,
+            "A"
+        );
+        assert_eq!(
+            renderer.cells[renderer.index(2, row).unwrap()].text,
+            "g"
+        );
+        assert!(renderer.agent_context.is_some());
+        assert!(renderer.agent_context_snapshot.is_some());
+
+        renderer.draw_agent_context(semantic::AgentContext {
+            visible: 0,
+            task: String::new(),
+            timestamp: 0,
+            status: 0,
+            can_approve: 0,
+        });
+
+        assert!(renderer.agent_context.is_none());
+        assert!(renderer.agent_context_snapshot.is_none());
+    }
+
+    #[test]
+    fn search_state_active_stores_state_and_inactive_clears() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_search_state(semantic::SearchState {
+            active: 1,
+            match_count: 42,
+            current_index: 2,
+            flags: 0,
+        });
+
+        assert!(renderer.search_state.is_some());
+        let state = renderer.search_state.as_ref().unwrap();
+        assert_eq!(state.match_count, 42);
+        assert_eq!(state.current_index, 2);
+
+        renderer.draw_search_state(semantic::SearchState {
+            active: 0,
+            match_count: 0,
+            current_index: 0,
+            flags: 0,
+        });
+
+        assert!(renderer.search_state.is_none());
+    }
+
+    #[test]
+    fn notifications_renders_popup_and_restores_on_hide() {
+        let mut renderer = Renderer::new(70, 20);
+
+        renderer.draw_notifications(semantic::Notifications {
+            visible: 1,
+            notification_count: 3,
+        });
+
+        assert!(renderer.notifications.is_some());
+        assert!(renderer.notifications_snapshot.is_some());
+
+        renderer.draw_notifications(semantic::Notifications {
+            visible: 0,
+            notification_count: 0,
+        });
+
+        assert!(renderer.notifications.is_none());
+        assert!(renderer.notifications_snapshot.is_none());
+    }
+
+    #[test]
+    fn edit_timeline_stores_state_and_clears_on_hide() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_edit_timeline(semantic::EditTimeline {
+            visible: 1,
+            viewing_index: 3,
+            entry_count: 10,
+        });
+
+        assert!(renderer.edit_timeline.is_some());
+        let timeline = renderer.edit_timeline.as_ref().unwrap();
+        assert_eq!(timeline.viewing_index, 3);
+        assert_eq!(timeline.entry_count, 10);
+
+        renderer.draw_edit_timeline(semantic::EditTimeline {
+            visible: 0,
+            viewing_index: 0,
+            entry_count: 0,
+        });
+
+        assert!(renderer.edit_timeline.is_none());
+    }
+
+    #[test]
+    fn workspaces_stores_state_and_clears_on_hide() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_workspaces(semantic::Workspaces {
+            visible: 1,
+            active_workspace_id: 2,
+            mode: 0,
+            flags: 0,
+            workspace_count: 3,
+        });
+
+        assert!(renderer.workspaces.is_some());
+        assert_eq!(renderer.workspaces.as_ref().unwrap().workspace_count, 3);
+
+        renderer.draw_workspaces(semantic::Workspaces {
+            visible: 0,
+            active_workspace_id: 0,
+            mode: 0,
+            flags: 0,
+            workspace_count: 0,
+        });
+
+        assert!(renderer.workspaces.is_none());
+    }
+
+    #[test]
+    fn sidebars_stores_state_and_clears_on_hide() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_sidebars(semantic::Sidebars {
+            visible: 1,
+            sidebar_count: 2,
+        });
+
+        assert!(renderer.sidebars.is_some());
+        assert_eq!(renderer.sidebars.as_ref().unwrap().sidebar_count, 2);
+
+        renderer.draw_sidebars(semantic::Sidebars {
+            visible: 0,
+            sidebar_count: 0,
+        });
+
+        assert!(renderer.sidebars.is_none());
+    }
+
+    #[test]
+    fn extension_overlay_renders_popup_and_restores_on_clear() {
+        let mut renderer = Renderer::new(70, 20);
+
+        renderer.draw_extension_overlay(semantic::ExtensionOverlay { entry_count: 5 });
+
+        assert!(renderer.extension_overlay.is_some());
+        assert!(renderer.extension_overlay_snapshot.is_some());
+
+        renderer.draw_extension_overlay(semantic::ExtensionOverlay { entry_count: 0 });
+
+        assert!(renderer.extension_overlay.is_none());
+        assert!(renderer.extension_overlay_snapshot.is_none());
+    }
+
+    #[test]
+    fn extension_panel_stores_state_and_clears_on_zero() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_extension_panel(semantic::ExtensionPanel { panel_count: 2 });
+
+        assert!(renderer.extension_panel.is_some());
+        assert_eq!(renderer.extension_panel.as_ref().unwrap().panel_count, 2);
+
+        renderer.draw_extension_panel(semantic::ExtensionPanel { panel_count: 0 });
+
+        assert!(renderer.extension_panel.is_none());
+    }
+
+    #[test]
+    fn observatory_renders_popup_and_restores_on_clear() {
+        let mut renderer = Renderer::new(70, 20);
+
+        renderer.draw_observatory(semantic::Observatory {
+            payload: vec![1, 2, 3, 4, 5],
+        });
+
+        assert!(renderer.observatory.is_some());
+        assert!(renderer.observatory_snapshot.is_some());
+
+        renderer.draw_observatory(semantic::Observatory {
+            payload: vec![],
+        });
+
+        assert!(renderer.observatory.is_none());
+        assert!(renderer.observatory_snapshot.is_none());
+    }
+
+    #[test]
+    fn status_bar_includes_search_and_timeline_indicators() {
+        let mut renderer = Renderer::new(120, 24);
+
+        renderer.draw_search_state(semantic::SearchState {
+            active: 1,
+            match_count: 42,
+            current_index: 2,
+            flags: 0,
+        });
+        renderer.draw_edit_timeline(semantic::EditTimeline {
+            visible: 1,
+            viewing_index: 3,
+            entry_count: 10,
+        });
+
+        renderer.draw_status_bar(semantic::StatusBar {
+            mode: 1,
+            flags: 0,
+            line: 1,
+            col: 1,
+            line_count: 100,
+            filename: "test.rs".to_owned(),
+            filetype: "rust".to_owned(),
+            branch: "main".to_owned(),
+            message: String::new(),
+            left_segments: vec![],
+            right_segments: vec![],
+        });
+
+        let row = renderer.height - 1;
+        let mut full_text = String::new();
+        for col in 0..renderer.width {
+            let cell = &renderer.cells[renderer.index(col, row).unwrap()];
+            full_text.push_str(&cell.text);
+        }
+
+        assert!(
+            full_text.contains("Match 3/42"),
+            "status bar should contain search indicator, got: {}",
+            full_text
+        );
+        assert!(
+            full_text.contains("Undo 3/10"),
+            "status bar should contain timeline indicator, got: {}",
+            full_text
+        );
+    }
+
+    #[test]
+    fn agent_context_retained_chrome_survives_window_redraw() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_agent_context(semantic::AgentContext {
+            visible: 1,
+            task: "Build".to_owned(),
+            timestamp: 0,
+            status: 1,
+            can_approve: 0,
+        });
+
+        let row = renderer.height.saturating_sub(2);
+        let cell_before = renderer.cells[renderer.index(1, row).unwrap()].text.clone();
+        assert_eq!(cell_before, "A");
+
+        renderer.draw_semantic_window(semantic::WindowContent {
+            window_id: 1,
+            text_width: 0,
+            text_height: 0,
+            origin_row: 0,
+            origin_col: 0,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_shape: 0,
+            content_epoch: 1,
+            rows: vec![semantic::Row {
+                text: "content".to_owned(),
+                spans: vec![],
+                ..Default::default()
+            }],
+            cursorline: None,
+        });
+
+        let cell_after = renderer.cells[renderer.index(1, row).unwrap()].text.clone();
+        assert_eq!(
+            cell_after, "A",
+            "agent context bar should survive window redraw via retained chrome"
+        );
     }
 }

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -185,7 +185,10 @@ impl Renderer {
                 let width = text_width(&text);
                 protocol::write_packet(output, &protocol::encode_text_width(request_id, width))?;
             }
-            Command::Semantic(command) => self.handle_semantic(command),
+            Command::Semantic(command) => {
+                self.handle_semantic_io(&command, terminal, output)?;
+                self.handle_semantic(command);
+            }
             Command::Noop(_) => {}
         }
 
@@ -326,8 +329,47 @@ impl Renderer {
             semantic::Command::WindowOverlayDelta(delta, _) => {
                 self.apply_window_overlay_delta(delta)
             }
-            semantic::Command::Unsupported { .. } => {}
+            semantic::Command::ClipboardWrite(_, _) => {}
+            semantic::Command::LineSpacing(_, _) => {}
+            semantic::Command::CursorAnimation(_, _) => {}
+            semantic::Command::ConfigState(_, _) => {}
+            semantic::Command::AgentContext(_, _) => {}
+            semantic::Command::HoverAction(_, _) => {}
+            semantic::Command::SearchState(_, _) => {}
+            semantic::Command::Workspaces(_, _) => {}
+            semantic::Command::Notifications(_, _) => {}
+            semantic::Command::EditTimeline(_, _) => {}
+            semantic::Command::ExtensionOverlay(_, _) => {}
+            semantic::Command::ExtensionPanel(_, _) => {}
+            semantic::Command::Observatory(_, _) => {}
+            semantic::Command::Sidebars(_, _) => {}
+            semantic::Command::Board(_, _) => {}
+            semantic::Command::AgentChat(_, _) => {}
+            semantic::Command::ToolManager(_, _) => {}
         }
+    }
+
+    fn handle_semantic_io(
+        &self,
+        command: &semantic::Command,
+        terminal: &mut Terminal,
+        _output: &mut impl Write,
+    ) -> io::Result<()> {
+        match command {
+            semantic::Command::ClipboardWrite(clip, _) => {
+                let encoded = base64_encode(clip.text.as_bytes());
+                terminal.write_raw(format!("\x1b]52;c;{}\x07", encoded).as_bytes())?;
+            }
+            semantic::Command::CursorAnimation(anim, _) => {
+                if anim.enabled != 0 {
+                    terminal.write_raw(b"\x1b[1 q")?;
+                } else {
+                    terminal.write_raw(b"\x1b[2 q")?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
     }
 
     fn draw_semantic_window(&mut self, window: semantic::WindowContent) {
@@ -2214,6 +2256,30 @@ impl Renderer {
             None
         }
     }
+}
+
+fn base64_encode(data: &[u8]) -> String {
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
+        let b2 = if chunk.len() > 2 { chunk[2] as u32 } else { 0 };
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        out.push(CHARS[((triple >> 18) & 0x3F) as usize] as char);
+        out.push(CHARS[((triple >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            out.push(CHARS[((triple >> 6) & 0x3F) as usize] as char);
+        } else {
+            out.push('=');
+        }
+        if chunk.len() > 2 {
+            out.push(CHARS[(triple & 0x3F) as usize] as char);
+        } else {
+            out.push('=');
+        }
+    }
+    out
 }
 
 fn text_width(text: &str) -> u16 {

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -1537,7 +1537,18 @@ impl Renderer {
             self.restore_signature_help_snapshot();
             self.signature_help_snapshot = Some(self.capture_rect(row, col, width, height));
         }
-        self.render_popup_panel(row, col, width, height, " Signature ", lines.join("\n"));
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let paragraph = Paragraph::new(lines.join("\n"))
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(" Signature ".to_owned()),
+            );
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn restore_signature_help_snapshot(&mut self) {
@@ -1571,14 +1582,18 @@ impl Renderer {
         } else {
             format!(" {} ", float_popup.title)
         };
-        self.render_popup_panel(
-            row,
-            col,
-            width,
-            height,
-            &title,
-            float_popup.lines.join("\n"),
-        );
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let paragraph = Paragraph::new(float_popup.lines.join("\n"))
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(title),
+            );
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn restore_float_popup_snapshot(&mut self) {
@@ -1632,7 +1647,18 @@ impl Renderer {
         if self.hover_popup_snapshot.is_none() {
             self.hover_popup_snapshot = Some(self.capture_rect(row, col, width, height));
         }
-        self.render_popup_panel(row, col, width, height, title, lines.join("\n"));
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let paragraph = Paragraph::new(lines.join("\n"))
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(title.to_owned()),
+            );
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn restore_hover_popup_snapshot(&mut self) {
@@ -1662,19 +1688,27 @@ impl Renderer {
         }
 
         let title = bottom_panel_title(bottom_panel);
-        let body = if bottom_panel.entries.is_empty() {
-            "No messages".to_owned()
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(border_style)
+            .title(title);
+
+        if bottom_panel.entries.is_empty() {
+            let paragraph = Paragraph::new("No messages").style(style).block(block);
+            self.render_ratatui_widget(row, 0, self.width, height, paragraph);
         } else {
-            bottom_panel
+            let items: Vec<ListItem> = bottom_panel
                 .entries
                 .iter()
                 .rev()
                 .take(height.saturating_sub(2) as usize)
-                .map(bottom_panel_entry_text)
-                .collect::<Vec<_>>()
-                .join("\n")
-        };
-        self.render_popup_panel(row, 0, self.width, height, &title, body);
+                .map(|entry| ListItem::new(bottom_panel_entry_text(entry)).style(style))
+                .collect();
+            let list = List::new(items).style(style).block(block);
+            self.render_ratatui_widget(row, 0, self.width, height, list);
+        }
     }
 
     fn restore_bottom_panel_snapshot(&mut self) {
@@ -1710,7 +1744,9 @@ impl Renderer {
             .saturating_add(1)
             .saturating_sub(visible_rows)
             .min(change_summary.entries.len().saturating_sub(visible_rows));
-        let body = change_summary
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let items: Vec<ListItem> = change_summary
             .entries
             .iter()
             .skip(start)
@@ -1719,17 +1755,23 @@ impl Renderer {
             .map(|(index, entry)| {
                 let absolute = start + index;
                 let marker = if absolute == selected { ">" } else { " " };
-                format!(
+                let text = format!(
                     "{marker} {} +{} -{} {}",
                     change_action_marker(entry.action),
                     entry.lines_added,
                     entry.lines_removed,
                     entry.path
-                )
+                );
+                ListItem::new(text).style(style)
             })
-            .collect::<Vec<_>>()
-            .join("\n");
-        self.render_popup_panel(row, col, width, height, " Changes ", body);
+            .collect();
+        let list = List::new(items).style(style).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(" Changes ".to_owned()),
+        );
+        self.render_ratatui_widget(row, col, width, height, list);
     }
 
     fn restore_change_summary_snapshot(&mut self) {
@@ -1789,7 +1831,19 @@ impl Renderer {
                     )
                 }),
         );
-        self.render_popup_panel(row, col, width, height, " Git ", lines.join("\n"));
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let items: Vec<ListItem> = lines
+            .into_iter()
+            .map(|line| ListItem::new(line).style(style))
+            .collect();
+        let list = List::new(items).style(style).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(" Git ".to_owned()),
+        );
+        self.render_ratatui_widget(row, col, width, height, list);
     }
 
     fn restore_git_status_snapshot(&mut self) {
@@ -1848,12 +1902,13 @@ impl Renderer {
             String::new()
         };
         let text = format!(" Agent: [{}]{}{} ", status_label, task_display, elapsed);
-        let style = self.theme.status_bar_style();
+        let style = ratatui_style_from_cell(self.theme.status_bar_style());
 
         if self.agent_context_snapshot.is_none() {
             self.agent_context_snapshot = Some(self.capture_rect(row, 0, self.width, 1));
         }
-        self.write_run(row, 0, &pad_to_width(&text, self.width), style);
+        let paragraph = Paragraph::new(pad_to_width(&text, self.width)).style(style);
+        self.render_ratatui_widget(row, 0, self.width, 1, paragraph);
     }
 
     fn restore_agent_context_snapshot(&mut self) {
@@ -1905,7 +1960,18 @@ impl Renderer {
         if self.notifications_snapshot.is_none() {
             self.notifications_snapshot = Some(self.capture_rect(row, col, width, height));
         }
-        self.render_popup_panel(row, col, width, height, " Notifications ", text);
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let paragraph = Paragraph::new(text)
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(" Notifications ".to_owned()),
+            );
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn restore_notifications_snapshot(&mut self) {
@@ -1969,7 +2035,18 @@ impl Renderer {
         if self.extension_overlay_snapshot.is_none() {
             self.extension_overlay_snapshot = Some(self.capture_rect(row, col, width, height));
         }
-        self.render_popup_panel(row, col, width, height, " Extension ", text);
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let paragraph = Paragraph::new(text)
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(" Extension ".to_owned()),
+            );
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn restore_extension_overlay_snapshot(&mut self) {
@@ -2018,7 +2095,18 @@ impl Renderer {
         }
 
         let text = format!(" Process tree ({} bytes payload) ", obs.payload.len());
-        self.render_popup_panel(row, col, width, height, " Observatory ", text);
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let paragraph = Paragraph::new(text)
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(" Observatory ".to_owned()),
+            );
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn restore_observatory_snapshot(&mut self) {
@@ -2077,7 +2165,18 @@ impl Renderer {
                 board.card_count, board.focused_card_id, filter
             )
         };
-        self.render_popup_panel(row, col, width, height, " Board ", status);
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let paragraph = Paragraph::new(status)
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(" Board ".to_owned()),
+            );
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn restore_board_snapshot(&mut self) {
@@ -2129,7 +2228,18 @@ impl Renderer {
         } else {
             format!(" {} messages{flags_desc}", chat.message_count)
         };
-        self.render_popup_panel(row, col, width, height, " Agent Chat ", status);
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let paragraph = Paragraph::new(status)
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(" Agent Chat ".to_owned()),
+            );
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn restore_agent_chat_snapshot(&mut self) {
@@ -2169,14 +2279,18 @@ impl Renderer {
             self.tool_manager_snapshot = Some(self.capture_rect(row, col, width, height));
         }
 
-        self.render_popup_panel(
-            row,
-            col,
-            width,
-            height,
-            " Tool Manager ",
-            " Tools loaded ".to_owned(),
-        );
+        let style = ratatui_style_from_cell(self.theme.picker_style(false));
+        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
+        let paragraph = Paragraph::new(" Tools loaded ")
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(" Tool Manager ".to_owned()),
+            );
+        self.render_ratatui_widget(row, col, width, height, paragraph);
     }
 
     fn restore_tool_manager_snapshot(&mut self) {
@@ -2191,28 +2305,6 @@ impl Renderer {
         }
     }
 
-    fn render_popup_panel(
-        &mut self,
-        row: u16,
-        col: u16,
-        width: u16,
-        height: u16,
-        title: &str,
-        body: String,
-    ) {
-        let style = ratatui_style_from_cell(self.theme.picker_style(false));
-        let border_style = ratatui_style_from_cell(self.theme.picker_header_style());
-        let paragraph = Paragraph::new(body)
-            .style(style)
-            .wrap(Wrap { trim: false })
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(border_style)
-                    .title(title.to_owned()),
-            );
-        self.render_ratatui_widget(row, col, width, height, paragraph);
-    }
 
     fn render_picker_items(
         &mut self,

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -112,6 +112,12 @@ pub struct Renderer {
     extension_panel: Option<semantic::ExtensionPanel>,
     observatory: Option<semantic::Observatory>,
     observatory_snapshot: Option<CellSnapshot>,
+    board: Option<semantic::Board>,
+    board_snapshot: Option<CellSnapshot>,
+    agent_chat: Option<semantic::AgentChat>,
+    agent_chat_snapshot: Option<CellSnapshot>,
+    tool_manager: Option<semantic::ToolManager>,
+    tool_manager_snapshot: Option<CellSnapshot>,
     theme: ThemePalette,
 }
 
@@ -168,6 +174,12 @@ impl Renderer {
             extension_panel: None,
             observatory: None,
             observatory_snapshot: None,
+            board: None,
+            board_snapshot: None,
+            agent_chat: None,
+            agent_chat_snapshot: None,
+            tool_manager: None,
+            tool_manager_snapshot: None,
             theme: ThemePalette::default(),
         }
     }
@@ -271,6 +283,12 @@ impl Renderer {
         self.extension_panel = None;
         self.observatory = None;
         self.observatory_snapshot = None;
+        self.board = None;
+        self.board_snapshot = None;
+        self.agent_chat = None;
+        self.agent_chat_snapshot = None;
+        self.tool_manager = None;
+        self.tool_manager_snapshot = None;
         self.semantic_windows.clear();
         self.semantic_cursorline_snapshots.clear();
     }
@@ -384,9 +402,9 @@ impl Renderer {
             semantic::Command::ExtensionPanel(panel, _) => self.draw_extension_panel(panel),
             semantic::Command::Observatory(obs, _) => self.draw_observatory(obs),
             semantic::Command::Sidebars(sb, _) => self.draw_sidebars(sb),
-            semantic::Command::Board(_, _) => {}
-            semantic::Command::AgentChat(_, _) => {}
-            semantic::Command::ToolManager(_, _) => {}
+            semantic::Command::Board(board, _) => self.draw_board(board),
+            semantic::Command::AgentChat(chat, _) => self.draw_agent_chat(chat),
+            semantic::Command::ToolManager(tm, _) => self.draw_tool_manager(tm),
         }
     }
 
@@ -1200,6 +1218,18 @@ impl Renderer {
             self.observatory_snapshot = None;
             self.render_observatory(&obs);
         }
+        if let Some(board) = self.board {
+            self.board_snapshot = None;
+            self.render_board(&board);
+        }
+        if let Some(chat) = self.agent_chat {
+            self.agent_chat_snapshot = None;
+            self.render_agent_chat(&chat);
+        }
+        if let Some(tm) = self.tool_manager {
+            self.tool_manager_snapshot = None;
+            self.render_tool_manager(&tm);
+        }
 
         if let Some(minibuffer) = self.minibuffer.clone() {
             self.minibuffer_snapshot = None;
@@ -1999,6 +2029,161 @@ impl Renderer {
 
     fn restore_observatory_cells(&mut self) {
         if let Some(snapshot) = self.observatory_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn draw_board(&mut self, board: semantic::Board) {
+        if board.visible == 0 {
+            self.restore_board_snapshot();
+            self.board = None;
+            return;
+        }
+        self.board = Some(board);
+        self.render_board(&board);
+    }
+
+    fn render_board(&mut self, board: &semantic::Board) {
+        self.restore_board_cells();
+        if self.width < 24 || self.height < 6 {
+            return;
+        }
+
+        let width = self.width.saturating_sub(4).clamp(24, 72);
+        let card_lines = (board.card_count as u16).saturating_mul(2).max(1);
+        let height = card_lines.saturating_add(2).clamp(4, self.height.saturating_sub(4));
+        let row = 2;
+        let col = self.width.saturating_sub(width).saturating_div(2);
+
+        if self.board_snapshot.is_none() {
+            self.board_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+
+        let filter = match board.filter_mode {
+            1 => " [filter: active]",
+            2 => " [filter: mine]",
+            _ => "",
+        };
+        let status = if board.card_count == 0 {
+            format!(" No cards{filter}")
+        } else if board.card_count == 1 {
+            format!(" 1 card  focused:{}{filter}", board.focused_card_id)
+        } else {
+            format!(
+                " {} cards  focused:{}{}",
+                board.card_count, board.focused_card_id, filter
+            )
+        };
+        self.render_popup_panel(row, col, width, height, " Board ", status);
+    }
+
+    fn restore_board_snapshot(&mut self) {
+        if let Some(snapshot) = self.board_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_board_cells(&mut self) {
+        if let Some(snapshot) = self.board_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn draw_agent_chat(&mut self, chat: semantic::AgentChat) {
+        if chat.visible == 0 {
+            self.restore_agent_chat_snapshot();
+            self.agent_chat = None;
+            return;
+        }
+        self.agent_chat = Some(chat);
+        self.render_agent_chat(&chat);
+    }
+
+    fn render_agent_chat(&mut self, chat: &semantic::AgentChat) {
+        self.restore_agent_chat_cells();
+        if self.width < 28 || self.height < 8 {
+            return;
+        }
+
+        let width = self.width.saturating_sub(4).clamp(28, 80);
+        let height = self.height.saturating_sub(4).clamp(6, 20);
+        let row = self.height.saturating_sub(height).saturating_div(2);
+        let col = self.width.saturating_sub(width).saturating_div(2);
+
+        if self.agent_chat_snapshot.is_none() {
+            self.agent_chat_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+
+        let flags_desc = if chat.flags & 0x01 != 0 {
+            " help"
+        } else {
+            ""
+        };
+        let status = if chat.message_count == 0 {
+            format!(" No messages{flags_desc}")
+        } else if chat.message_count == 1 {
+            format!(" 1 message{flags_desc}")
+        } else {
+            format!(" {} messages{flags_desc}", chat.message_count)
+        };
+        self.render_popup_panel(row, col, width, height, " Agent Chat ", status);
+    }
+
+    fn restore_agent_chat_snapshot(&mut self) {
+        if let Some(snapshot) = self.agent_chat_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_agent_chat_cells(&mut self) {
+        if let Some(snapshot) = self.agent_chat_snapshot.clone() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn draw_tool_manager(&mut self, tm: semantic::ToolManager) {
+        if tm.visible == 0 {
+            self.restore_tool_manager_snapshot();
+            self.tool_manager = None;
+            return;
+        }
+        self.tool_manager = Some(tm);
+        self.render_tool_manager(&tm);
+    }
+
+    fn render_tool_manager(&mut self, _tm: &semantic::ToolManager) {
+        self.restore_tool_manager_cells();
+        if self.width < 24 || self.height < 6 {
+            return;
+        }
+
+        let width = self.width.saturating_sub(4).clamp(24, 60);
+        let height = 6_u16.min(self.height.saturating_sub(4));
+        let row = self.height.saturating_sub(height).saturating_div(2);
+        let col = self.width.saturating_sub(width).saturating_div(2);
+
+        if self.tool_manager_snapshot.is_none() {
+            self.tool_manager_snapshot = Some(self.capture_rect(row, col, width, height));
+        }
+
+        self.render_popup_panel(
+            row,
+            col,
+            width,
+            height,
+            " Tool Manager ",
+            " Tools loaded ".to_owned(),
+        );
+    }
+
+    fn restore_tool_manager_snapshot(&mut self) {
+        if let Some(snapshot) = self.tool_manager_snapshot.take() {
+            self.restore_snapshot(snapshot);
+        }
+    }
+
+    fn restore_tool_manager_cells(&mut self) {
+        if let Some(snapshot) = self.tool_manager_snapshot.clone() {
             self.restore_snapshot(snapshot);
         }
     }
@@ -5294,4 +5479,245 @@ mod tests {
             "agent context bar should survive window redraw via retained chrome"
         );
     }
+
+    #[test]
+    fn board_renders_popup_and_restores_on_hide() {
+        let mut renderer = Renderer::new(80, 24);
+        renderer.draw_text(DrawText {
+            row: 4,
+            col: 20,
+            fg: 0x111111,
+            bg: 0x222222,
+            attrs: 0,
+            text: "under".to_owned(),
+        });
+
+        renderer.draw_board(semantic::Board {
+            visible: 1,
+            focused_card_id: 42,
+            card_count: 3,
+            filter_mode: 0,
+        });
+
+        assert!(renderer.board.is_some());
+        assert!(renderer.board_snapshot.is_some());
+        let board = renderer.board.as_ref().unwrap();
+        assert_eq!(board.card_count, 3);
+        assert_eq!(board.focused_card_id, 42);
+
+        renderer.draw_board(semantic::Board {
+            visible: 0,
+            focused_card_id: 0,
+            card_count: 0,
+            filter_mode: 0,
+        });
+
+        assert!(renderer.board.is_none());
+        assert!(renderer.board_snapshot.is_none());
+
+        let restored = &renderer.cells[renderer.index(20, 4).unwrap()];
+        assert_eq!(restored.text, "u");
+        assert_eq!(restored.style.fg, 0x111111);
+        assert_eq!(restored.style.bg, 0x222222);
+    }
+
+    #[test]
+    fn board_renders_card_count_and_filter_in_body() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_board(semantic::Board {
+            visible: 1,
+            focused_card_id: 7,
+            card_count: 5,
+            filter_mode: 1,
+        });
+
+        assert!(renderer.board.is_some());
+        assert!(renderer.board_snapshot.is_some());
+
+        let (row, col, width, _height) = board_geometry(renderer.width, renderer.height, 5);
+        let mut title_text = String::new();
+        for c in col..col.saturating_add(width).min(renderer.width) {
+            let cell = &renderer.cells[renderer.index(c, row).unwrap()];
+            title_text.push_str(&cell.text);
+        }
+        assert!(
+            title_text.contains("Board"),
+            "board panel should show title, got: {title_text}"
+        );
+    }
+
+    #[test]
+    fn agent_chat_renders_popup_and_restores_on_hide() {
+        let mut renderer = Renderer::new(80, 24);
+        renderer.draw_text(DrawText {
+            row: 10,
+            col: 30,
+            fg: 0x111111,
+            bg: 0x222222,
+            attrs: 0,
+            text: "under".to_owned(),
+        });
+
+        renderer.draw_agent_chat(semantic::AgentChat {
+            visible: 1,
+            flags: 0x01,
+            message_count: 12,
+        });
+
+        assert!(renderer.agent_chat.is_some());
+        assert!(renderer.agent_chat_snapshot.is_some());
+        let chat = renderer.agent_chat.as_ref().unwrap();
+        assert_eq!(chat.message_count, 12);
+        assert_eq!(chat.flags, 0x01);
+
+        renderer.draw_agent_chat(semantic::AgentChat {
+            visible: 0,
+            flags: 0,
+            message_count: 0,
+        });
+
+        assert!(renderer.agent_chat.is_none());
+        assert!(renderer.agent_chat_snapshot.is_none());
+
+        let restored = &renderer.cells[renderer.index(30, 10).unwrap()];
+        assert_eq!(restored.text, "u");
+        assert_eq!(restored.style.fg, 0x111111);
+        assert_eq!(restored.style.bg, 0x222222);
+    }
+
+    #[test]
+    fn agent_chat_renders_message_count_in_body() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_agent_chat(semantic::AgentChat {
+            visible: 1,
+            flags: 0,
+            message_count: 7,
+        });
+
+        assert!(renderer.agent_chat.is_some());
+        assert!(renderer.agent_chat_snapshot.is_some());
+
+        let width = renderer.width.saturating_sub(4).clamp(28, 80);
+        let height = renderer.height.saturating_sub(4).clamp(6, 20);
+        let row = renderer.height.saturating_sub(height).saturating_div(2);
+        let col = renderer.width.saturating_sub(width).saturating_div(2);
+
+        let mut top_text = String::new();
+        for c in col..col.saturating_add(width).min(renderer.width) {
+            let cell = &renderer.cells[renderer.index(c, row).unwrap()];
+            top_text.push_str(&cell.text);
+        }
+        assert!(
+            top_text.contains("Agent Chat"),
+            "agent chat panel should show title, got: {top_text}"
+        );
+    }
+
+    #[test]
+    fn tool_manager_renders_popup_and_restores_on_hide() {
+        let mut renderer = Renderer::new(80, 24);
+        renderer.draw_text(DrawText {
+            row: 10,
+            col: 30,
+            fg: 0x111111,
+            bg: 0x222222,
+            attrs: 0,
+            text: "under".to_owned(),
+        });
+
+        renderer.draw_tool_manager(semantic::ToolManager { visible: 1 });
+
+        assert!(renderer.tool_manager.is_some());
+        assert!(renderer.tool_manager_snapshot.is_some());
+
+        renderer.draw_tool_manager(semantic::ToolManager { visible: 0 });
+
+        assert!(renderer.tool_manager.is_none());
+        assert!(renderer.tool_manager_snapshot.is_none());
+
+        let restored = &renderer.cells[renderer.index(30, 10).unwrap()];
+        assert_eq!(restored.text, "u");
+        assert_eq!(restored.style.fg, 0x111111);
+        assert_eq!(restored.style.bg, 0x222222);
+    }
+
+    #[test]
+    fn tool_manager_renders_title_in_panel() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_tool_manager(semantic::ToolManager { visible: 1 });
+
+        assert!(renderer.tool_manager.is_some());
+        assert!(renderer.tool_manager_snapshot.is_some());
+
+        let width = renderer.width.saturating_sub(4).clamp(24, 60);
+        let height = 6_u16.min(renderer.height.saturating_sub(4));
+        let row = renderer.height.saturating_sub(height).saturating_div(2);
+        let col = renderer.width.saturating_sub(width).saturating_div(2);
+
+        let mut top_text = String::new();
+        for c in col..col.saturating_add(width).min(renderer.width) {
+            let cell = &renderer.cells[renderer.index(c, row).unwrap()];
+            top_text.push_str(&cell.text);
+        }
+        assert!(
+            top_text.contains("Tool Manager"),
+            "tool manager panel should show title, got: {top_text}"
+        );
+    }
+
+    #[test]
+    fn board_retained_chrome_survives_window_redraw() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_board(semantic::Board {
+            visible: 1,
+            focused_card_id: 1,
+            card_count: 2,
+            filter_mode: 0,
+        });
+
+        let (row, col, _, _) = board_geometry(renderer.width, renderer.height, 2);
+        let cell_before = renderer.cells[renderer.index(col.saturating_add(1), row).unwrap()]
+            .text
+            .clone();
+
+        renderer.draw_semantic_window(semantic::WindowContent {
+            window_id: 1,
+            text_width: 0,
+            text_height: 0,
+            origin_row: 0,
+            origin_col: 0,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_shape: 0,
+            content_epoch: 1,
+            rows: vec![semantic::Row {
+                text: "content".to_owned(),
+                spans: vec![],
+                ..Default::default()
+            }],
+            cursorline: None,
+        });
+
+        let cell_after = renderer.cells[renderer.index(col.saturating_add(1), row).unwrap()]
+            .text
+            .clone();
+        assert_eq!(
+            cell_after, cell_before,
+            "board panel should survive window redraw via retained chrome"
+        );
+    }
+}
+
+#[cfg(test)]
+fn board_geometry(width: u16, height: u16, card_count: u16) -> (u16, u16, u16, u16) {
+    let w = width.saturating_sub(4).clamp(24, 72);
+    let card_lines = card_count.saturating_mul(2).max(1);
+    let h = card_lines.saturating_add(2).clamp(4, height.saturating_sub(4));
+    let row = 2;
+    let col = width.saturating_sub(w).saturating_div(2);
+    (row, col, w, h)
 }

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -399,9 +399,7 @@ impl Renderer {
             semantic::Command::Workspaces(ws, _) => self.draw_workspaces(ws),
             semantic::Command::Notifications(notifs, _) => self.draw_notifications(notifs),
             semantic::Command::EditTimeline(timeline, _) => self.draw_edit_timeline(timeline),
-            semantic::Command::ExtensionOverlay(overlay, _) => {
-                self.draw_extension_overlay(overlay)
-            }
+            semantic::Command::ExtensionOverlay(overlay, _) => self.draw_extension_overlay(overlay),
             semantic::Command::ExtensionPanel(panel, _) => self.draw_extension_panel(panel),
             semantic::Command::Observatory(obs, _) => self.draw_observatory(obs),
             semantic::Command::Sidebars(sb, _) => self.draw_sidebars(sb),
@@ -2231,11 +2229,7 @@ impl Renderer {
             self.agent_chat_snapshot = Some(self.capture_rect(row, col, width, height));
         }
 
-        let flags_desc = if chat.flags & 0x01 != 0 {
-            " help"
-        } else {
-            ""
-        };
+        let flags_desc = if chat.flags & 0x01 != 0 { " help" } else { "" };
         let status = if chat.message_count == 0 {
             format!(" No messages{flags_desc}")
         } else if chat.message_count == 1 {
@@ -2319,7 +2313,6 @@ impl Renderer {
             self.restore_snapshot(snapshot);
         }
     }
-
 
     fn render_picker_items(
         &mut self,
@@ -5312,14 +5305,8 @@ mod tests {
         });
 
         let row = renderer.height.saturating_sub(2);
-        assert_eq!(
-            renderer.cells[renderer.index(1, row).unwrap()].text,
-            "A"
-        );
-        assert_eq!(
-            renderer.cells[renderer.index(2, row).unwrap()].text,
-            "g"
-        );
+        assert_eq!(renderer.cells[renderer.index(1, row).unwrap()].text, "A");
+        assert_eq!(renderer.cells[renderer.index(2, row).unwrap()].text, "g");
         assert!(renderer.agent_context.is_some());
         assert!(renderer.agent_context_snapshot.is_some());
 
@@ -5859,7 +5846,10 @@ mod tests {
 fn board_geometry(width: u16, height: u16, card_count: u16) -> (u16, u16, u16, u16) {
     let w = width.saturating_sub(4).clamp(24, 72);
     let card_lines = card_count.saturating_mul(2).max(1);
-    let h = card_lines.saturating_add(2).min(height.saturating_sub(4)).max(1);
+    let h = card_lines
+        .saturating_add(2)
+        .min(height.saturating_sub(4))
+        .max(1);
     let row = 2;
     let col = width.saturating_sub(w).saturating_div(2);
     (row, col, w, h)

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -864,20 +864,14 @@ impl Renderer {
                 timeline.viewing_index, timeline.entry_count
             ));
         }
-        if let Some(ws) = &self.workspaces {
-            if ws.workspace_count > 1 {
-                indicators.push(format!("WS {}", ws.workspace_count));
-            }
+        if let Some(ws) = &self.workspaces && ws.workspace_count > 1 {
+            indicators.push(format!("WS {}", ws.workspace_count));
         }
-        if let Some(sb) = &self.sidebars {
-            if sb.sidebar_count > 0 {
-                indicators.push(format!("SB {}", sb.sidebar_count));
-            }
+        if let Some(sb) = &self.sidebars && sb.sidebar_count > 0 {
+            indicators.push(format!("SB {}", sb.sidebar_count));
         }
-        if let Some(ext) = &self.extension_panel {
-            if ext.panel_count > 0 {
-                indicators.push(format!("Ext {}", ext.panel_count));
-            }
+        if let Some(ext) = &self.extension_panel && ext.panel_count > 0 {
+            indicators.push(format!("Ext {}", ext.panel_count));
         }
         if !indicators.is_empty() {
             let suffix = format!(" [{}]", indicators.join(" | "));
@@ -2151,7 +2145,7 @@ impl Renderer {
         }
 
         let width = self.width.saturating_sub(4).clamp(24, 72);
-        let card_lines = (board.card_count as u16).saturating_mul(2).max(1);
+        let card_lines = board.card_count.saturating_mul(2).max(1);
         let height = card_lines
             .saturating_add(2)
             .min(self.height.saturating_sub(4))
@@ -2221,7 +2215,7 @@ impl Renderer {
         }
 
         let width = self.width.saturating_sub(4).clamp(28, 80);
-        let height = self.height.saturating_sub(4).min(20).max(1);
+        let height = self.height.saturating_sub(4).clamp(1, 20);
         let row = self.height.saturating_sub(height).saturating_div(2);
         let col = self.width.saturating_sub(width).saturating_div(2);
 
@@ -2872,7 +2866,7 @@ impl Renderer {
 
 fn base64_encode(data: &[u8]) -> String {
     const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
     for chunk in data.chunks(3) {
         let b0 = chunk[0] as u32;
         let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -2045,13 +2045,16 @@ impl Renderer {
 
     fn render_board(&mut self, board: &semantic::Board) {
         self.restore_board_cells();
-        if self.width < 24 || self.height < 6 {
+        if self.width < 24 || self.height < 8 {
             return;
         }
 
         let width = self.width.saturating_sub(4).clamp(24, 72);
         let card_lines = (board.card_count as u16).saturating_mul(2).max(1);
-        let height = card_lines.saturating_add(2).clamp(4, self.height.saturating_sub(4));
+        let height = card_lines
+            .saturating_add(2)
+            .min(self.height.saturating_sub(4))
+            .max(1);
         let row = 2;
         let col = self.width.saturating_sub(width).saturating_div(2);
 
@@ -2101,12 +2104,12 @@ impl Renderer {
 
     fn render_agent_chat(&mut self, chat: &semantic::AgentChat) {
         self.restore_agent_chat_cells();
-        if self.width < 28 || self.height < 8 {
+        if self.width < 28 || self.height < 10 {
             return;
         }
 
         let width = self.width.saturating_sub(4).clamp(28, 80);
-        let height = self.height.saturating_sub(4).clamp(6, 20);
+        let height = self.height.saturating_sub(4).min(20).max(1);
         let row = self.height.saturating_sub(height).saturating_div(2);
         let col = self.width.saturating_sub(width).saturating_div(2);
 
@@ -5710,13 +5713,44 @@ mod tests {
             "board panel should survive window redraw via retained chrome"
         );
     }
+
+    #[test]
+    fn base64_encode_correctness() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"A"), "QQ==");
+        assert_eq!(base64_encode(b"Hi"), "SGk=");
+        assert_eq!(base64_encode(b"Hello"), "SGVsbG8=");
+        assert_eq!(base64_encode(b"Hello, World!"), "SGVsbG8sIFdvcmxkIQ==");
+    }
+
+    #[test]
+    fn notifications_hide_on_zero_count() {
+        let mut renderer = Renderer::new(80, 24);
+
+        renderer.draw_notifications(semantic::Notifications {
+            visible: 1,
+            notification_count: 3,
+        });
+        assert!(renderer.notifications.is_some());
+        assert!(renderer.notifications_snapshot.is_some());
+
+        renderer.draw_notifications(semantic::Notifications {
+            visible: 1,
+            notification_count: 0,
+        });
+        assert!(
+            renderer.notifications.is_none(),
+            "notifications should hide when count drops to zero"
+        );
+        assert!(renderer.notifications_snapshot.is_none());
+    }
 }
 
 #[cfg(test)]
 fn board_geometry(width: u16, height: u16, card_count: u16) -> (u16, u16, u16, u16) {
     let w = width.saturating_sub(4).clamp(24, 72);
     let card_lines = card_count.saturating_mul(2).max(1);
-    let h = card_lines.saturating_add(2).clamp(4, height.saturating_sub(4));
+    let h = card_lines.saturating_add(2).min(height.saturating_sub(4)).max(1);
     let row = 2;
     let col = width.saturating_sub(w).saturating_div(2);
     (row, col, w, h)

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -30,7 +30,23 @@ pub enum Command {
     SplitSeparators(SplitSeparators, usize),
     IndentGuides(IndentGuides, usize),
     WindowOverlayDelta(WindowOverlayDelta, usize),
-    Unsupported { opcode: u8, size: usize },
+    ClipboardWrite(ClipboardWrite, usize),
+    LineSpacing(LineSpacing, usize),
+    CursorAnimation(CursorAnimation, usize),
+    ConfigState(ConfigState, usize),
+    AgentContext(AgentContext, usize),
+    HoverAction(HoverAction, usize),
+    SearchState(SearchState, usize),
+    Workspaces(Workspaces, usize),
+    Notifications(Notifications, usize),
+    EditTimeline(EditTimeline, usize),
+    ExtensionOverlay(ExtensionOverlay, usize),
+    ExtensionPanel(ExtensionPanel, usize),
+    Observatory(Observatory, usize),
+    Sidebars(Sidebars, usize),
+    Board(Board, usize),
+    AgentChat(AgentChat, usize),
+    ToolManager(ToolManager, usize),
 }
 
 impl Command {
@@ -60,7 +76,23 @@ impl Command {
             Self::SplitSeparators(_, size) => *size,
             Self::IndentGuides(_, size) => *size,
             Self::WindowOverlayDelta(_, size) => *size,
-            Self::Unsupported { size, .. } => *size,
+            Self::ClipboardWrite(_, size) => *size,
+            Self::LineSpacing(_, size) => *size,
+            Self::CursorAnimation(_, size) => *size,
+            Self::ConfigState(_, size) => *size,
+            Self::AgentContext(_, size) => *size,
+            Self::HoverAction(_, size) => *size,
+            Self::SearchState(_, size) => *size,
+            Self::Workspaces(_, size) => *size,
+            Self::Notifications(_, size) => *size,
+            Self::EditTimeline(_, size) => *size,
+            Self::ExtensionOverlay(_, size) => *size,
+            Self::ExtensionPanel(_, size) => *size,
+            Self::Observatory(_, size) => *size,
+            Self::Sidebars(_, size) => *size,
+            Self::Board(_, size) => *size,
+            Self::AgentChat(_, size) => *size,
+            Self::ToolManager(_, size) => *size,
         }
     }
 }
@@ -463,6 +495,112 @@ pub struct WindowOverlayDelta {
     pub cursorline: Option<Cursorline>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClipboardWrite {
+    pub target: u8,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LineSpacing {
+    pub value: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CursorAnimation {
+    pub enabled: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigState {
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentContext {
+    pub visible: u8,
+    pub task: String,
+    pub timestamp: u64,
+    pub status: u8,
+    pub can_approve: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoverAction {
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SearchState {
+    pub active: u8,
+    pub match_count: u16,
+    pub current_index: u16,
+    pub flags: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Workspaces {
+    pub visible: u8,
+    pub active_workspace_id: u16,
+    pub mode: u8,
+    pub flags: u8,
+    pub workspace_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Notifications {
+    pub visible: u8,
+    pub notification_count: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EditTimeline {
+    pub visible: u8,
+    pub viewing_index: u16,
+    pub entry_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExtensionOverlay {
+    pub entry_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExtensionPanel {
+    pub panel_count: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Observatory {
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sidebars {
+    pub visible: u8,
+    pub sidebar_count: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Board {
+    pub visible: u8,
+    pub focused_card_id: u32,
+    pub card_count: u16,
+    pub filter_mode: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentChat {
+    pub visible: u8,
+    pub flags: u8,
+    pub message_count: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolManager {
+    pub visible: u8,
+}
+
 pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
     let opcode = *bytes.first().ok_or(DecodeError::Empty)?;
 
@@ -492,26 +630,24 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_INDENT_GUIDES => decode_indent_guides(bytes),
         opcodes::OP_GUI_WINDOW_OVERLAY_DELTA => decode_window_overlay_delta(bytes),
         opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA
-        | opcodes::OP_GUI_WINDOW_ROWS_DELTA
-        | opcodes::OP_CLIPBOARD_WRITE
-        | opcodes::OP_GUI_LINE_SPACING
-        | opcodes::OP_GUI_CURSOR_ANIMATION
-        | opcodes::OP_GUI_HOVER_ACTION
-        | opcodes::OP_GUI_WORKSPACES
-        | opcodes::OP_GUI_NOTIFICATIONS
-        | opcodes::OP_GUI_EDIT_TIMELINE
-        | opcodes::OP_GUI_EXTENSION_OVERLAY
-        | opcodes::OP_GUI_EXTENSION_PANEL
-        | opcodes::OP_GUI_SEARCH_STATE
-        | opcodes::OP_GUI_CONFIG_STATE
-        | opcodes::OP_GUI_OBSERVATORY
-        | opcodes::OP_GUI_SIDEBARS
-        | opcodes::OP_GUI_AGENT_CONTEXT
-        | opcodes::OP_GUI_BOARD
-        | opcodes::OP_GUI_AGENT_CHAT
-        | opcodes::OP_GUI_TOOL_MANAGER => {
-            semantic_size(bytes).map(|size| Command::Unsupported { opcode, size })
-        }
+        | opcodes::OP_GUI_WINDOW_ROWS_DELTA => decode_window_content(bytes),
+        opcodes::OP_CLIPBOARD_WRITE => decode_clipboard_write(bytes),
+        opcodes::OP_GUI_LINE_SPACING => decode_line_spacing(bytes),
+        opcodes::OP_GUI_CURSOR_ANIMATION => decode_cursor_animation(bytes),
+        opcodes::OP_GUI_CONFIG_STATE => decode_config_state(bytes),
+        opcodes::OP_GUI_AGENT_CONTEXT => decode_agent_context(bytes),
+        opcodes::OP_GUI_HOVER_ACTION => decode_hover_action(bytes),
+        opcodes::OP_GUI_SEARCH_STATE => decode_search_state(bytes),
+        opcodes::OP_GUI_WORKSPACES => decode_workspaces(bytes),
+        opcodes::OP_GUI_NOTIFICATIONS => decode_notifications(bytes),
+        opcodes::OP_GUI_EDIT_TIMELINE => decode_edit_timeline(bytes),
+        opcodes::OP_GUI_EXTENSION_OVERLAY => decode_extension_overlay(bytes),
+        opcodes::OP_GUI_EXTENSION_PANEL => decode_extension_panel(bytes),
+        opcodes::OP_GUI_OBSERVATORY => decode_observatory(bytes),
+        opcodes::OP_GUI_SIDEBARS => decode_sidebars(bytes),
+        opcodes::OP_GUI_BOARD => decode_board(bytes),
+        opcodes::OP_GUI_AGENT_CHAT => decode_agent_chat(bytes),
+        opcodes::OP_GUI_TOOL_MANAGER => decode_tool_manager(bytes),
         _ => Err(DecodeError::UnknownOpcode(opcode)),
     }
 }
@@ -1601,6 +1737,245 @@ fn decode_window_overlay_delta(bytes: &[u8]) -> Result<Command, DecodeError> {
     ))
 }
 
+fn len16_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 3, "len16 header")?;
+    Ok(3 + ((bytes[1] as usize) << 8 | bytes[2] as usize))
+}
+
+fn len32_size(bytes: &[u8]) -> Result<usize, DecodeError> {
+    require_len(bytes, 5, "len32 header")?;
+    Ok(5 + u32::from_be_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]) as usize)
+}
+
+fn decode_clipboard_write(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    require_len(bytes, 4, "clipboard write target")?;
+    let target = bytes[3];
+    let text = read_string(bytes, 4, size - 4)?;
+    Ok(Command::ClipboardWrite(ClipboardWrite { target, text }, size))
+}
+
+fn decode_line_spacing(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    require_len(bytes, 5, "line spacing value")?;
+    let value = read_u16(bytes, 3);
+    Ok(Command::LineSpacing(LineSpacing { value }, size))
+}
+
+fn decode_cursor_animation(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    require_len(bytes, 4, "cursor animation")?;
+    let enabled = bytes[3];
+    Ok(Command::CursorAnimation(CursorAnimation { enabled }, size))
+}
+
+fn decode_config_state(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    let payload = bytes[3..size].to_vec();
+    Ok(Command::ConfigState(ConfigState { payload }, size))
+}
+
+fn decode_agent_context(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = agent_context_size(bytes)?;
+    require_len(bytes, 2, "agent context visible")?;
+    let visible = bytes[1];
+    if visible == 0 {
+        return Ok(Command::AgentContext(
+            AgentContext {
+                visible: 0,
+                task: String::new(),
+                timestamp: 0,
+                status: 0,
+                can_approve: 0,
+            },
+            size,
+        ));
+    }
+    require_len(bytes, 4, "agent context task length")?;
+    let task_len = read_u16(bytes, 2) as usize;
+    let task = read_string(bytes, 4, task_len)?;
+    let body_offset = 4 + task_len;
+    require_len(bytes, body_offset + 10, "agent context body")?;
+    let timestamp = u64::from_be_bytes([
+        bytes[body_offset],
+        bytes[body_offset + 1],
+        bytes[body_offset + 2],
+        bytes[body_offset + 3],
+        bytes[body_offset + 4],
+        bytes[body_offset + 5],
+        bytes[body_offset + 6],
+        bytes[body_offset + 7],
+    ]);
+    let status = bytes[body_offset + 8];
+    let can_approve = bytes[body_offset + 9];
+    Ok(Command::AgentContext(
+        AgentContext {
+            visible,
+            task,
+            timestamp,
+            status,
+            can_approve,
+        },
+        size,
+    ))
+}
+
+fn decode_hover_action(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    let payload = bytes[3..size].to_vec();
+    Ok(Command::HoverAction(HoverAction { payload }, size))
+}
+
+fn decode_search_state(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    require_len(bytes, 9, "search state fields")?;
+    let active = bytes[3];
+    let match_count = read_u16(bytes, 4);
+    let current_index = read_u16(bytes, 6);
+    let flags = bytes[8];
+    Ok(Command::SearchState(
+        SearchState {
+            active,
+            match_count,
+            current_index,
+            flags,
+        },
+        size,
+    ))
+}
+
+fn decode_workspaces(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    require_len(bytes, 8, "workspaces fields")?;
+    Ok(Command::Workspaces(
+        Workspaces {
+            visible: bytes[3],
+            active_workspace_id: read_u16(bytes, 4),
+            mode: bytes[6],
+            flags: bytes[7],
+            workspace_count: if size > 8 { bytes[8] } else { 0 },
+        },
+        size,
+    ))
+}
+
+fn decode_notifications(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    require_len(bytes, 6, "notifications fields")?;
+    Ok(Command::Notifications(
+        Notifications {
+            visible: bytes[3],
+            notification_count: read_u16(bytes, 4),
+        },
+        size,
+    ))
+}
+
+fn decode_edit_timeline(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    require_len(bytes, 7, "edit timeline fields")?;
+    Ok(Command::EditTimeline(
+        EditTimeline {
+            visible: bytes[3],
+            viewing_index: read_u16(bytes, 4),
+            entry_count: bytes[6],
+        },
+        size,
+    ))
+}
+
+fn decode_extension_overlay(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    require_len(bytes, 4, "extension overlay fields")?;
+    Ok(Command::ExtensionOverlay(
+        ExtensionOverlay {
+            entry_count: bytes[3],
+        },
+        size,
+    ))
+}
+
+fn decode_extension_panel(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len16_size(bytes)?;
+    require_len(bytes, 4, "extension panel fields")?;
+    Ok(Command::ExtensionPanel(
+        ExtensionPanel {
+            panel_count: bytes[3],
+        },
+        size,
+    ))
+}
+
+fn decode_observatory(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len32_size(bytes)?;
+    let payload = bytes[5..size].to_vec();
+    Ok(Command::Observatory(Observatory { payload }, size))
+}
+
+fn decode_sidebars(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = len32_size(bytes)?;
+    require_len(bytes, 8, "sidebars fields")?;
+    Ok(Command::Sidebars(
+        Sidebars {
+            visible: bytes[5],
+            sidebar_count: read_u16(bytes, 6),
+        },
+        size,
+    ))
+}
+
+fn decode_board(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = board_size(bytes)?;
+    require_len(bytes, 2, "board visible")?;
+    if bytes[1] == 0 {
+        return Ok(Command::Board(
+            Board {
+                visible: 0,
+                focused_card_id: 0,
+                card_count: 0,
+                filter_mode: 0,
+            },
+            size,
+        ));
+    }
+    require_len(bytes, 9, "board fields")?;
+    Ok(Command::Board(
+        Board {
+            visible: bytes[1],
+            focused_card_id: read_u32(bytes, 2),
+            card_count: read_u16(bytes, 6),
+            filter_mode: bytes[8],
+        },
+        size,
+    ))
+}
+
+fn decode_agent_chat(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = sectioned_size(bytes, "agent chat")?;
+    require_len(bytes, 2, "agent chat header")?;
+    let section_count = bytes[1] as usize;
+    let visible = if section_count > 0 { 1 } else { 0 };
+    Ok(Command::AgentChat(
+        AgentChat {
+            visible,
+            flags: 0,
+            message_count: 0,
+        },
+        size,
+    ))
+}
+
+fn decode_tool_manager(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = tool_manager_size(bytes)?;
+    require_len(bytes, 2, "tool manager visible")?;
+    Ok(Command::ToolManager(
+        ToolManager {
+            visible: bytes[1],
+        },
+        size,
+    ))
+}
+
 fn decode_file_tree_row(bytes: &[u8]) -> Result<(FileTreeRow, usize), DecodeError> {
     require_len(bytes, 17, "file tree row header")?;
     let flags = read_u16(bytes, 4);
@@ -1682,29 +2057,12 @@ fn custom_semantic_size(bytes: &[u8]) -> Result<usize, DecodeError> {
         opcodes::OP_GUI_FLOAT_POPUP => float_popup_size(bytes),
         opcodes::OP_GUI_SPLIT_SEPARATORS => split_separators_size(bytes),
         opcodes::OP_GUI_GIT_STATUS => git_status_size(bytes),
-        opcodes::OP_GUI_BOARD => hidden_or_visible_size(bytes, "board", board_size),
-        opcodes::OP_GUI_AGENT_CONTEXT => {
-            hidden_or_visible_size(bytes, "agent context", agent_context_size)
-        }
+        opcodes::OP_GUI_BOARD => board_size(bytes),
+        opcodes::OP_GUI_AGENT_CONTEXT => agent_context_size(bytes),
         opcodes::OP_GUI_CHANGE_SUMMARY => change_summary_size(bytes),
-        opcodes::OP_GUI_TOOL_MANAGER => {
-            hidden_or_visible_size(bytes, "tool manager", tool_manager_size)
-        }
+        opcodes::OP_GUI_TOOL_MANAGER => tool_manager_size(bytes),
         opcodes::OP_GUI_WINDOW_OVERLAY_DELTA => overlay_delta_size(bytes),
         _ => Err(DecodeError::UnknownOpcode(opcode)),
-    }
-}
-
-fn hidden_or_visible_size(
-    bytes: &[u8],
-    name: &'static str,
-    visible_size: fn(&[u8]) -> Result<usize, DecodeError>,
-) -> Result<usize, DecodeError> {
-    require_len(bytes, 2, name)?;
-    if bytes[1] == 0 {
-        Ok(2)
-    } else {
-        visible_size(bytes)
     }
 }
 
@@ -1888,7 +2246,11 @@ fn hover_popup_size(bytes: &[u8]) -> Result<usize, DecodeError> {
 }
 
 fn agent_context_size(bytes: &[u8]) -> Result<usize, DecodeError> {
-    require_len(bytes, 4, "agent context")?;
+    require_len(bytes, 2, "agent context")?;
+    if bytes[1] == 0 {
+        return Ok(2);
+    }
+    require_len(bytes, 4, "agent context task length")?;
     let len = read_u16(bytes, 2) as usize;
     let offset = 4 + len;
     require_len(bytes, offset + 10, "agent context body")?;
@@ -1937,7 +2299,11 @@ fn change_summary_size(bytes: &[u8]) -> Result<usize, DecodeError> {
 }
 
 fn board_size(bytes: &[u8]) -> Result<usize, DecodeError> {
-    require_len(bytes, 11, "board")?;
+    require_len(bytes, 2, "board")?;
+    if bytes[1] == 0 {
+        return Ok(2);
+    }
+    require_len(bytes, 11, "board visible")?;
     let card_count = read_u16(bytes, 6) as usize;
     let mut offset = 9;
     skip_string16(bytes, &mut offset)?;
@@ -1984,7 +2350,11 @@ fn bottom_panel_size(bytes: &[u8]) -> Result<usize, DecodeError> {
 }
 
 fn tool_manager_size(bytes: &[u8]) -> Result<usize, DecodeError> {
-    require_len(bytes, 7, "tool manager")?;
+    require_len(bytes, 2, "tool manager")?;
+    if bytes[1] == 0 {
+        return Ok(2);
+    }
+    require_len(bytes, 7, "tool manager visible")?;
     let count = read_u16(bytes, 5) as usize;
     let mut offset = 7;
     for _ in 0..count {
@@ -2578,54 +2948,45 @@ mod tests {
     }
 
     #[test]
-    fn skips_remaining_visible_legacy_commands_without_consuming_following_commands() {
-        let cases = [
-            (
-                opcodes::OP_GUI_AGENT_CONTEXT,
-                vec![
-                    opcodes::OP_GUI_AGENT_CONTEXT,
-                    1,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                ],
-            ),
-            (
-                opcodes::OP_GUI_BOARD,
-                vec![opcodes::OP_GUI_BOARD, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            ),
-            (
-                opcodes::OP_GUI_AGENT_CHAT,
-                vec![opcodes::OP_GUI_AGENT_CHAT, 1, 1, 0, 0],
-            ),
-            (
-                opcodes::OP_GUI_TOOL_MANAGER,
-                vec![opcodes::OP_GUI_TOOL_MANAGER, 1, 0, 0, 0, 0, 0],
-            ),
+    fn decodes_visible_legacy_commands_without_consuming_following_commands() {
+        let agent_context = vec![
+            opcodes::OP_GUI_AGENT_CONTEXT,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
         ];
+        let packet = [agent_context, vec![opcodes::OP_BATCH_END]].concat();
+        let command = decode(&packet).unwrap();
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
+        assert!(matches!(command, Command::AgentContext(AgentContext { visible: 1, .. }, _)));
 
-        for (opcode, payload) in cases {
-            let packet = [payload.clone(), vec![opcodes::OP_BATCH_END]].concat();
-            let command = decode(&packet).unwrap();
+        let board = vec![opcodes::OP_GUI_BOARD, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let packet = [board, vec![opcodes::OP_BATCH_END]].concat();
+        let command = decode(&packet).unwrap();
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
+        assert!(matches!(command, Command::Board(Board { visible: 1, .. }, _)));
 
-            assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
-            assert!(matches!(
-                command,
-                Command::Unsupported {
-                    opcode: decoded,
-                    size
-                } if decoded == opcode && size == packet.len() - 1
-            ));
-        }
+        let agent_chat = vec![opcodes::OP_GUI_AGENT_CHAT, 1, 1, 0, 0];
+        let packet = [agent_chat, vec![opcodes::OP_BATCH_END]].concat();
+        let command = decode(&packet).unwrap();
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
+        assert!(matches!(command, Command::AgentChat(AgentChat { visible: 1, .. }, _)));
+
+        let tool_manager = vec![opcodes::OP_GUI_TOOL_MANAGER, 1, 0, 0, 0, 0, 0];
+        let packet = [tool_manager, vec![opcodes::OP_BATCH_END]].concat();
+        let command = decode(&packet).unwrap();
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
+        assert!(matches!(command, Command::ToolManager(ToolManager { visible: 1 }, _)));
     }
 
     #[test]
@@ -2862,7 +3223,7 @@ mod tests {
         assert_theme_tail(&packet, size);
     }
     #[test]
-    fn skips_hidden_tool_manager_without_consuming_following_commands() {
+    fn decodes_hidden_tool_manager_without_consuming_following_commands() {
         let packet = [
             vec![opcodes::OP_GUI_TOOL_MANAGER, 0],
             vec![opcodes::OP_GUI_THEME, 0],
@@ -2874,10 +3235,7 @@ mod tests {
         assert_eq!(size, 2);
         assert!(matches!(
             command,
-            Command::Unsupported {
-                opcode: opcodes::OP_GUI_TOOL_MANAGER,
-                size: 2
-            }
+            Command::ToolManager(ToolManager { visible: 0 }, 2)
         ));
         assert!(matches!(
             decode(&packet[size..]).unwrap(),
@@ -2886,51 +3244,55 @@ mod tests {
     }
 
     #[test]
-    fn skips_length_prefixed_config_state() {
+    fn decodes_config_state() {
         let bytes = [opcodes::OP_GUI_CONFIG_STATE, 0, 3, 1, 2, 3];
-        let _command = decode(&bytes).unwrap();
-
+        let command = decode(&bytes).unwrap();
         assert_eq!(semantic_size(&bytes).unwrap(), 6);
+        assert!(matches!(
+            command,
+            Command::ConfigState(ConfigState { ref payload }, 6) if payload == &[1, 2, 3]
+        ));
     }
 
     #[test]
-    fn skips_length_wrapped_semantic_commands() {
-        let bytes = [opcodes::OP_GUI_NOTIFICATIONS, 0, 3, 1, 2, 3];
-        let _command = decode(&bytes).unwrap();
-
+    fn decodes_notifications() {
+        let bytes = [opcodes::OP_GUI_NOTIFICATIONS, 0, 3, 1, 0, 5];
+        let command = decode(&bytes).unwrap();
         assert_eq!(semantic_size(&bytes).unwrap(), 6);
+        assert!(matches!(
+            command,
+            Command::Notifications(Notifications { visible: 1, notification_count: 5 }, 6)
+        ));
     }
 
     #[test]
-    fn skips_forward_compatible_gui_commands_without_consuming_following_commands() {
-        let cases = [
-            (
-                opcodes::OP_CLIPBOARD_WRITE,
-                vec![opcodes::OP_CLIPBOARD_WRITE, 0, 4, 0, 0, 1, b'x'],
-            ),
-            (
-                opcodes::OP_GUI_LINE_SPACING,
-                vec![opcodes::OP_GUI_LINE_SPACING, 0, 2, 0, 120],
-            ),
-            (
-                opcodes::OP_GUI_CURSOR_ANIMATION,
-                vec![opcodes::OP_GUI_CURSOR_ANIMATION, 0, 1, 1],
-            ),
-        ];
+    fn decodes_typed_gui_commands_without_consuming_following_commands() {
+        let clipboard_payload = vec![opcodes::OP_CLIPBOARD_WRITE, 0, 2, 0, b'x'];
+        let packet = [clipboard_payload, vec![opcodes::OP_BATCH_END]].concat();
+        let command = decode(&packet).unwrap();
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::ClipboardWrite(ClipboardWrite { target: 0, ref text }, _) if text == "x"
+        ));
 
-        for (opcode, payload) in cases {
-            let packet = [payload.clone(), vec![opcodes::OP_BATCH_END]].concat();
-            let command = decode(&packet).unwrap();
+        let spacing_payload = vec![opcodes::OP_GUI_LINE_SPACING, 0, 2, 0, 120];
+        let packet = [spacing_payload, vec![opcodes::OP_BATCH_END]].concat();
+        let command = decode(&packet).unwrap();
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::LineSpacing(LineSpacing { value: 120 }, _)
+        ));
 
-            assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
-            assert!(matches!(
-                command,
-                Command::Unsupported {
-                    opcode: decoded,
-                    size
-                } if decoded == opcode && size == packet.len() - 1
-            ));
-        }
+        let anim_payload = vec![opcodes::OP_GUI_CURSOR_ANIMATION, 0, 1, 1];
+        let packet = [anim_payload, vec![opcodes::OP_BATCH_END]].concat();
+        let command = decode(&packet).unwrap();
+        assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
+        assert!(matches!(
+            command,
+            Command::CursorAnimation(CursorAnimation { enabled: 1 }, _)
+        ));
     }
 
     fn section(id: u8, payload: &[u8]) -> Vec<u8> {

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -572,6 +572,7 @@ pub struct ExtensionPanel {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Observatory {
+    pub visible: bool,
     pub payload: Vec<u8>,
 }
 
@@ -1749,9 +1750,11 @@ fn len32_size(bytes: &[u8]) -> Result<usize, DecodeError> {
 
 fn decode_clipboard_write(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = len16_size(bytes)?;
-    require_len(bytes, 4, "clipboard write target")?;
+    require_len(bytes, 6, "clipboard write")?;
     let target = bytes[3];
-    let text = read_string(bytes, 4, size - 4)?;
+    let text_len = read_u16(bytes, 4) as usize;
+    require_len(bytes, 6 + text_len, "clipboard write text")?;
+    let text = read_string(bytes, 6, text_len)?;
     Ok(Command::ClipboardWrite(ClipboardWrite { target, text }, size))
 }
 
@@ -1900,7 +1903,8 @@ fn decode_observatory(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = len32_size(bytes)?;
     require_len(bytes, size, "observatory payload")?;
     let payload = bytes[5..size].to_vec();
-    Ok(Command::Observatory(Observatory { payload }, size))
+    let visible = payload.first().map_or(false, |&b| b != 0);
+    Ok(Command::Observatory(Observatory { visible, payload }, size))
 }
 
 fn decode_sidebars(bytes: &[u8]) -> Result<Command, DecodeError> {
@@ -1931,17 +1935,26 @@ fn decode_board(bytes: &[u8]) -> Result<Command, DecodeError> {
 
 fn decode_agent_chat(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = sectioned_size(bytes, "agent chat")?;
-    require_len(bytes, 2, "agent chat header")?;
-    let section_count = bytes[1] as usize;
-    let visible = if section_count > 0 { 1 } else { 0 };
-    Ok(Command::AgentChat(
-        AgentChat {
-            visible,
-            flags: 0,
-            message_count: 0,
-        },
-        size,
-    ))
+    let secs = sections(&bytes[..size])?;
+    let mut chat = AgentChat {
+        visible: 0,
+        flags: 0,
+        message_count: 0,
+    };
+
+    for (section_id, payload) in secs {
+        match section_id {
+            0x01 => {
+                let (header, _) = semantic_decode::decode_gui_agent_chat_header(payload, 0)?;
+                chat.visible = header.visible;
+                chat.flags = header.flags;
+                chat.message_count = header.message_count;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(Command::AgentChat(chat, size))
 }
 
 fn decode_tool_manager(bytes: &[u8]) -> Result<Command, DecodeError> {
@@ -2947,11 +2960,12 @@ mod tests {
         assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(command, Command::Board(Board { visible: 1, .. }, _)));
 
-        let agent_chat = vec![opcodes::OP_GUI_AGENT_CHAT, 1, 1, 0, 0];
+        // Agent chat: 1 section (0x01 header), payload: visible=1, flags=0, message_count=0
+        let agent_chat = vec![opcodes::OP_GUI_AGENT_CHAT, 1, 0x01, 0, 4, 1, 0, 0, 0];
         let packet = [agent_chat, vec![opcodes::OP_BATCH_END]].concat();
         let command = decode(&packet).unwrap();
         assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
-        assert!(matches!(command, Command::AgentChat(AgentChat { visible: 1, .. }, _)));
+        assert!(matches!(command, Command::AgentChat(AgentChat { visible: 1, flags: 0, message_count: 0 }, _)));
 
         let tool_manager = vec![opcodes::OP_GUI_TOOL_MANAGER, 1, 0, 0, 0, 0, 0];
         let packet = [tool_manager, vec![opcodes::OP_BATCH_END]].concat();
@@ -3238,7 +3252,7 @@ mod tests {
 
     #[test]
     fn decodes_typed_gui_commands_without_consuming_following_commands() {
-        let clipboard_payload = vec![opcodes::OP_CLIPBOARD_WRITE, 0, 2, 0, b'x'];
+        let clipboard_payload = vec![opcodes::OP_CLIPBOARD_WRITE, 0, 4, 0, 0, 1, b'x'];
         let packet = [clipboard_payload, vec![opcodes::OP_BATCH_END]].concat();
         let command = decode(&packet).unwrap();
         assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -630,8 +630,9 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_SPLIT_SEPARATORS => decode_split_separators(bytes),
         opcodes::OP_GUI_INDENT_GUIDES => decode_indent_guides(bytes),
         opcodes::OP_GUI_WINDOW_OVERLAY_DELTA => decode_window_overlay_delta(bytes),
-        opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA
-        | opcodes::OP_GUI_WINDOW_ROWS_DELTA => decode_window_content(bytes),
+        opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA | opcodes::OP_GUI_WINDOW_ROWS_DELTA => {
+            decode_window_content(bytes)
+        }
         opcodes::OP_CLIPBOARD_WRITE => decode_clipboard_write(bytes),
         opcodes::OP_GUI_LINE_SPACING => decode_line_spacing(bytes),
         opcodes::OP_GUI_CURSOR_ANIMATION => decode_cursor_animation(bytes),
@@ -1755,7 +1756,10 @@ fn decode_clipboard_write(bytes: &[u8]) -> Result<Command, DecodeError> {
     let text_len = read_u16(bytes, 4) as usize;
     require_len(bytes, 6 + text_len, "clipboard write text")?;
     let text = read_string(bytes, 6, text_len)?;
-    Ok(Command::ClipboardWrite(ClipboardWrite { target, text }, size))
+    Ok(Command::ClipboardWrite(
+        ClipboardWrite { target, text },
+        size,
+    ))
 }
 
 fn decode_line_spacing(bytes: &[u8]) -> Result<Command, DecodeError> {
@@ -1961,9 +1965,7 @@ fn decode_tool_manager(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = tool_manager_size(bytes)?;
     require_len(bytes, 2, "tool manager visible")?;
     Ok(Command::ToolManager(
-        ToolManager {
-            visible: bytes[1],
-        },
+        ToolManager { visible: bytes[1] },
         size,
     ))
 }
@@ -2952,26 +2954,45 @@ mod tests {
         let packet = [agent_context, vec![opcodes::OP_BATCH_END]].concat();
         let command = decode(&packet).unwrap();
         assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
-        assert!(matches!(command, Command::AgentContext(AgentContext { visible: 1, .. }, _)));
+        assert!(matches!(
+            command,
+            Command::AgentContext(AgentContext { visible: 1, .. }, _)
+        ));
 
         let board = vec![opcodes::OP_GUI_BOARD, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         let packet = [board, vec![opcodes::OP_BATCH_END]].concat();
         let command = decode(&packet).unwrap();
         assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
-        assert!(matches!(command, Command::Board(Board { visible: 1, .. }, _)));
+        assert!(matches!(
+            command,
+            Command::Board(Board { visible: 1, .. }, _)
+        ));
 
         // Agent chat: 1 section (0x01 header), payload: visible=1, flags=0, message_count=0
         let agent_chat = vec![opcodes::OP_GUI_AGENT_CHAT, 1, 0x01, 0, 4, 1, 0, 0, 0];
         let packet = [agent_chat, vec![opcodes::OP_BATCH_END]].concat();
         let command = decode(&packet).unwrap();
         assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
-        assert!(matches!(command, Command::AgentChat(AgentChat { visible: 1, flags: 0, message_count: 0 }, _)));
+        assert!(matches!(
+            command,
+            Command::AgentChat(
+                AgentChat {
+                    visible: 1,
+                    flags: 0,
+                    message_count: 0
+                },
+                _
+            )
+        ));
 
         let tool_manager = vec![opcodes::OP_GUI_TOOL_MANAGER, 1, 0, 0, 0, 0, 0];
         let packet = [tool_manager, vec![opcodes::OP_BATCH_END]].concat();
         let command = decode(&packet).unwrap();
         assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
-        assert!(matches!(command, Command::ToolManager(ToolManager { visible: 1 }, _)));
+        assert!(matches!(
+            command,
+            Command::ToolManager(ToolManager { visible: 1 }, _)
+        ));
     }
 
     #[test]
@@ -3246,7 +3267,13 @@ mod tests {
         assert_eq!(semantic_size(&bytes).unwrap(), 6);
         assert!(matches!(
             command,
-            Command::Notifications(Notifications { visible: 1, notification_count: 5 }, 6)
+            Command::Notifications(
+                Notifications {
+                    visible: 1,
+                    notification_count: 5
+                },
+                6
+            )
         ));
     }
 
@@ -3408,7 +3435,22 @@ mod tests {
     #[test]
     fn agent_context_size_visible_zero_regression() {
         // AgentContext hidden: opcode(1) + visible=0(1) + task_len=0(2) + timestamp(8) + status(1) + can_approve(1) = 14 bytes
-        let bytes = [opcodes::OP_GUI_AGENT_CONTEXT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let bytes = [
+            opcodes::OP_GUI_AGENT_CONTEXT,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ];
         assert_eq!(decode(&bytes).unwrap().custom_size(), 14);
     }
 
@@ -3468,9 +3510,22 @@ mod tests {
     fn decode_agent_context_visible_field_check() {
         // opcode(1) + visible=1(1) + task_len=2(2) + task="hi"(2) + timestamp(8) + status=3(1) + can_approve=1(1) = 16
         let bytes = [
-            opcodes::OP_GUI_AGENT_CONTEXT, 1, 0, 2, b'h', b'i',
-            0, 0, 0, 0, 0, 0, 0, 100, // timestamp = 100
-            3, 1, // status=3 (needs_you), can_approve=1
+            opcodes::OP_GUI_AGENT_CONTEXT,
+            1,
+            0,
+            2,
+            b'h',
+            b'i',
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            100, // timestamp = 100
+            3,
+            1, // status=3 (needs_you), can_approve=1
         ];
         match decode(&bytes).unwrap() {
             Command::AgentContext(a, 16) => {

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -581,7 +581,7 @@ pub struct Sidebars {
     pub sidebar_count: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Board {
     pub visible: u8,
     pub focused_card_id: u32,
@@ -589,7 +589,7 @@ pub struct Board {
     pub filter_mode: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AgentChat {
     pub visible: u8,
     pub flags: u8,

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -1771,6 +1771,7 @@ fn decode_cursor_animation(bytes: &[u8]) -> Result<Command, DecodeError> {
 
 fn decode_config_state(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = len16_size(bytes)?;
+    require_len(bytes, size, "config_state payload")?;
     let payload = bytes[3..size].to_vec();
     Ok(Command::ConfigState(ConfigState { payload }, size))
 }
@@ -1779,18 +1780,6 @@ fn decode_agent_context(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = agent_context_size(bytes)?;
     require_len(bytes, 2, "agent context visible")?;
     let visible = bytes[1];
-    if visible == 0 {
-        return Ok(Command::AgentContext(
-            AgentContext {
-                visible: 0,
-                task: String::new(),
-                timestamp: 0,
-                status: 0,
-                can_approve: 0,
-            },
-            size,
-        ));
-    }
     require_len(bytes, 4, "agent context task length")?;
     let task_len = read_u16(bytes, 2) as usize;
     let task = read_string(bytes, 4, task_len)?;
@@ -1822,6 +1811,7 @@ fn decode_agent_context(bytes: &[u8]) -> Result<Command, DecodeError> {
 
 fn decode_hover_action(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = len16_size(bytes)?;
+    require_len(bytes, size, "hover_action payload")?;
     let payload = bytes[3..size].to_vec();
     Ok(Command::HoverAction(HoverAction { payload }, size))
 }
@@ -1908,6 +1898,7 @@ fn decode_extension_panel(bytes: &[u8]) -> Result<Command, DecodeError> {
 
 fn decode_observatory(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = len32_size(bytes)?;
+    require_len(bytes, size, "observatory payload")?;
     let payload = bytes[5..size].to_vec();
     Ok(Command::Observatory(Observatory { payload }, size))
 }
@@ -1926,18 +1917,6 @@ fn decode_sidebars(bytes: &[u8]) -> Result<Command, DecodeError> {
 
 fn decode_board(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = board_size(bytes)?;
-    require_len(bytes, 2, "board visible")?;
-    if bytes[1] == 0 {
-        return Ok(Command::Board(
-            Board {
-                visible: 0,
-                focused_card_id: 0,
-                card_count: 0,
-                filter_mode: 0,
-            },
-            size,
-        ));
-    }
     require_len(bytes, 9, "board fields")?;
     Ok(Command::Board(
         Board {
@@ -2246,10 +2225,6 @@ fn hover_popup_size(bytes: &[u8]) -> Result<usize, DecodeError> {
 }
 
 fn agent_context_size(bytes: &[u8]) -> Result<usize, DecodeError> {
-    require_len(bytes, 2, "agent context")?;
-    if bytes[1] == 0 {
-        return Ok(2);
-    }
     require_len(bytes, 4, "agent context task length")?;
     let len = read_u16(bytes, 2) as usize;
     let offset = 4 + len;
@@ -2299,11 +2274,7 @@ fn change_summary_size(bytes: &[u8]) -> Result<usize, DecodeError> {
 }
 
 fn board_size(bytes: &[u8]) -> Result<usize, DecodeError> {
-    require_len(bytes, 2, "board")?;
-    if bytes[1] == 0 {
-        return Ok(2);
-    }
-    require_len(bytes, 11, "board visible")?;
+    require_len(bytes, 11, "board")?;
     let card_count = read_u16(bytes, 6) as usize;
     let mut offset = 9;
     skip_string16(bytes, &mut offset)?;
@@ -3411,5 +3382,91 @@ mod tests {
             decode(&packet[semantic_size(&packet).unwrap()..]).unwrap(),
             Command::Theme(Theme { slots }, _) if slots.is_empty()
         ));
+    }
+
+    #[test]
+    fn board_size_visible_zero_regression() {
+        // Board with visible=0: opcode(1) + visible=0(1) + focused_card_id(4) + card_count=0(2) + filter_mode(1) + filter_text_len=0(2) = 11 bytes
+        let bytes = [opcodes::OP_GUI_BOARD, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(decode(&bytes).unwrap().custom_size(), 11);
+    }
+
+    #[test]
+    fn agent_context_size_visible_zero_regression() {
+        // AgentContext hidden: opcode(1) + visible=0(1) + task_len=0(2) + timestamp(8) + status(1) + can_approve(1) = 14 bytes
+        let bytes = [opcodes::OP_GUI_AGENT_CONTEXT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(decode(&bytes).unwrap().custom_size(), 14);
+    }
+
+    #[test]
+    fn decode_search_state_field_check() {
+        let bytes = [opcodes::OP_GUI_SEARCH_STATE, 0, 6, 1, 0, 5, 0, 3, 0x42];
+        match decode(&bytes).unwrap() {
+            Command::SearchState(s, 9) => {
+                assert_eq!(s.active, 1);
+                assert_eq!(s.match_count, 5);
+                assert_eq!(s.current_index, 3);
+                assert_eq!(s.flags, 0x42);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn decode_edit_timeline_field_check() {
+        // len16: opcode(1) + len_hi(0) + len_lo(4) + visible(1) + viewing_index(2) + entry_count(1) = 7
+        let bytes = [opcodes::OP_GUI_EDIT_TIMELINE, 0, 4, 1, 0, 7, 3];
+        match decode(&bytes).unwrap() {
+            Command::EditTimeline(t, 7) => {
+                assert_eq!(t.visible, 1);
+                assert_eq!(t.viewing_index, 7);
+                assert_eq!(t.entry_count, 3);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn decode_notifications_field_check() {
+        let bytes = [opcodes::OP_GUI_NOTIFICATIONS, 0, 3, 1, 0, 12];
+        match decode(&bytes).unwrap() {
+            Command::Notifications(n, 6) => {
+                assert_eq!(n.visible, 1);
+                assert_eq!(n.notification_count, 12);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn decode_sidebars_field_check() {
+        let bytes = [opcodes::OP_GUI_SIDEBARS, 0, 0, 0, 3, 1, 0, 5];
+        match decode(&bytes).unwrap() {
+            Command::Sidebars(s, 8) => {
+                assert_eq!(s.visible, 1);
+                assert_eq!(s.sidebar_count, 5);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn decode_agent_context_visible_field_check() {
+        // opcode(1) + visible=1(1) + task_len=2(2) + task="hi"(2) + timestamp(8) + status=3(1) + can_approve=1(1) = 16
+        let bytes = [
+            opcodes::OP_GUI_AGENT_CONTEXT, 1, 0, 2, b'h', b'i',
+            0, 0, 0, 0, 0, 0, 0, 100, // timestamp = 100
+            3, 1, // status=3 (needs_you), can_approve=1
+        ];
+        match decode(&bytes).unwrap() {
+            Command::AgentContext(a, 16) => {
+                assert_eq!(a.visible, 1);
+                assert_eq!(a.task, "hi");
+                assert_eq!(a.timestamp, 100);
+                assert_eq!(a.status, 3);
+                assert_eq!(a.can_approve, 1);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
     }
 }

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -1907,7 +1907,7 @@ fn decode_observatory(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = len32_size(bytes)?;
     require_len(bytes, size, "observatory payload")?;
     let payload = bytes[5..size].to_vec();
-    let visible = payload.first().map_or(false, |&b| b != 0);
+    let visible = payload.first().is_some_and(|&b| b != 0);
     Ok(Command::Observatory(Observatory { visible, payload }, size))
 }
 
@@ -1947,14 +1947,11 @@ fn decode_agent_chat(bytes: &[u8]) -> Result<Command, DecodeError> {
     };
 
     for (section_id, payload) in secs {
-        match section_id {
-            0x01 => {
-                let (header, _) = semantic_decode::decode_gui_agent_chat_header(payload, 0)?;
-                chat.visible = header.visible;
-                chat.flags = header.flags;
-                chat.message_count = header.message_count;
-            }
-            _ => {}
+        if section_id == 0x01 {
+            let (header, _) = semantic_decode::decode_gui_agent_chat_header(payload, 0)?;
+            chat.visible = header.visible;
+            chat.flags = header.flags;
+            chat.message_count = header.message_count;
         }
     }
 

--- a/rust/tui/src/terminal.rs
+++ b/rust/tui/src/terminal.rs
@@ -169,6 +169,10 @@ impl Terminal {
         self.writer.write_all(b"\x1b[0m")
     }
 
+    pub fn write_raw(&mut self, data: &[u8]) -> io::Result<()> {
+        self.writer.write_all(data)
+    }
+
     pub fn flush(&mut self) -> io::Result<()> {
         self.writer.flush()
     }


### PR DESCRIPTION
## Summary

- Eliminates `Command::Unsupported` from the Rust TUI semantic decoder entirely
- All 17 previously unsupported opcodes now decode into typed `Command` variants with proper data structs
- ClipboardWrite implemented via OSC 52, CursorAnimation via DECSCUSR blink toggle
- Fixes `hidden_or_visible_size` bug (inlined hidden check, removed wrapper)
- Remaining 10 complex commands (Board, AgentChat, ToolManager, Sidebars, etc.) have decode + stub rendering, ready for Slices 2-3

Closes #2147 AC1 (zero Unsupported variants). Partial progress on AC2 (clipboard via OSC 52). Slices 2-3 will address ACs 3-8.

## Test plan

- [x] `cargo test -p minga-tui` — 99 tests pass
- [x] `cargo build --release` — zero warnings
- [x] Zero `Unsupported` in `grep Unsupported semantic.rs`
- [ ] Manual: `MINGA_DEBUG_INPUT=1 bin/minga-rust` — verify no `protocol size error` in Messages panel
- [ ] Manual: yank text in Rust TUI, paste in another app (OSC 52 clipboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)