### PR TITLE
feat(rust): move TUI renderer to crossterm

### DIFF
--- a/rust/tui/Cargo.lock
+++ b/rust/tui/Cargo.lock
@@ -9,46 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -59,27 +29,6 @@ dependencies = [
  "outref",
  "vsimd",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -97,15 +46,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -130,14 +70,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "bumpalo"
-version = "3.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "by_address"
@@ -162,7 +96,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -187,12 +121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,12 +135,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "convert_case"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
- "libc",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -250,23 +178,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
+name = "crossterm"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "generic-array",
- "typenum",
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "filedescriptor",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
 ]
 
 [[package]]
-name = "csscolorparser"
-version = "0.6.2"
+name = "crossterm_winapi"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
- "lab",
- "phf",
+ "winapi",
 ]
 
 [[package]]
@@ -289,7 +226,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -300,14 +237,8 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "deltae"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -319,13 +250,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
+name = "derive_more"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -348,25 +300,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "euclid"
-version = "0.22.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
 ]
 
 [[package]]
@@ -396,18 +329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "finl_unicode"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,18 +337,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -448,34 +357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,40 +368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,26 +375,14 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "icy_sixel"
@@ -558,12 +393,6 @@ dependencies = [
  "quantette",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -585,18 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,7 +432,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -634,44 +451,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "js-sys"
-version = "0.3.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
-dependencies = [
- "cfg-if",
- "futures-util",
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown",
+ "portable-atomic",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "lab"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -691,7 +479,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -699,6 +487,27 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -712,38 +521,7 @@ version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "mac_address"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
-dependencies = [
- "nix",
- "winapi",
-]
-
-[[package]]
-name = "memchr"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
-
-[[package]]
-name = "memmem"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -756,22 +534,14 @@ checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 name = "minga-renderer-rs"
 version = "0.1.0"
 dependencies = [
- "libc",
- "mio",
+ "crossterm",
  "ratatui",
  "ratatui-image",
  "signal-hook",
  "tachyonfx",
- "termwiz",
  "unicode-segmentation",
  "unicode-width",
 ]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -806,44 +576,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "num-traits"
@@ -856,18 +592,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.4"
+name = "num_threads"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
- "num-traits",
+ "libc",
 ]
 
 [[package]]
@@ -906,109 +636,31 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
-name = "pest"
-version = "2.8.6"
+name = "parking_lot"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
- "memchr",
- "ucd-trie",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
-name = "pest_derive"
-version = "2.8.6"
+name = "parking_lot_core"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "pest",
- "pest_generator",
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "png"
@@ -1016,12 +668,18 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"
@@ -1045,7 +703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1074,7 +732,7 @@ dependencies = [
  "image",
  "libm",
  "num-traits",
- "ordered-float 5.3.0",
+ "ordered-float",
  "palette",
  "rand 0.9.4",
  "rand_xoshiro",
@@ -1091,18 +749,6 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -1146,7 +792,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom",
 ]
 
 [[package]]
@@ -1172,6 +818,7 @@ checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
 dependencies = [
  "instability",
  "ratatui-core",
+ "ratatui-crossterm",
  "ratatui-widgets",
 ]
 
@@ -1181,9 +828,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "compact_str",
- "hashbrown 0.16.1",
+ "hashbrown",
  "indoc",
  "itertools",
  "kasuari",
@@ -1193,6 +840,18 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
 ]
 
 [[package]]
@@ -1206,7 +865,7 @@ dependencies = [
  "image",
  "rand 0.8.6",
  "ratatui",
- "rustix",
+ "rustix 0.38.44",
  "self_cell",
  "thiserror 1.0.69",
  "windows",
@@ -1218,8 +877,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "bitflags",
+ "hashbrown",
  "indoc",
  "instability",
  "itertools",
@@ -1252,6 +911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,37 +936,17 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
+ "semver",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
@@ -1306,11 +954,24 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1335,6 +996,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "self_cell"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,16 +1012,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
 
 [[package]]
 name = "serde_core"
@@ -1373,31 +1030,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.150"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
+ "syn",
 ]
 
 [[package]]
@@ -1408,6 +1041,17 @@ checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
 ]
 
 [[package]]
@@ -1427,16 +1071,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "siphasher"
-version = "1.0.3"
+name = "smallvec"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "static_assertions"
@@ -1468,18 +1106,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -1514,69 +1141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "terminfo"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
-dependencies = [
- "fnv",
- "nom",
- "phf",
- "phf_codegen",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "termwiz"
-version = "0.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
-dependencies = [
- "anyhow",
- "base64",
- "bitflags 2.11.1",
- "fancy-regex",
- "filedescriptor",
- "finl_unicode",
- "fixedbitset",
- "hex",
- "lazy_static",
- "libc",
- "log",
- "memmem",
- "nix",
- "num-derive",
- "num-traits",
- "ordered-float 4.6.0",
- "pest",
- "pest_derive",
- "phf",
- "sha2",
- "signal-hook",
- "siphasher",
- "terminfo",
- "termios",
- "thiserror 1.0.69",
- "ucd-trie",
- "unicode-segmentation",
- "vtparse",
- "wezterm-bidi",
- "wezterm-blob-leases",
- "wezterm-color-types",
- "wezterm-dynamic",
- "wezterm-input-types",
- "winapi",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,7 +1166,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1613,7 +1177,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1623,8 +1187,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
+ "serde_core",
  "time-core",
 ]
 
@@ -1633,18 +1200,6 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -1676,224 +1231,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
-dependencies = [
- "atomic",
- "getrandom 0.4.2",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
-name = "vtparse"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.122"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.122"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.122"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.122"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wezterm-bidi"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
-dependencies = [
- "log",
- "wezterm-dynamic",
-]
-
-[[package]]
-name = "wezterm-blob-leases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
-dependencies = [
- "getrandom 0.3.4",
- "mac_address",
- "sha2",
- "thiserror 1.0.69",
- "uuid",
-]
-
-[[package]]
-name = "wezterm-color-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
-dependencies = [
- "csscolorparser",
- "deltae",
- "lazy_static",
- "wezterm-dynamic",
-]
-
-[[package]]
-name = "wezterm-dynamic"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
-dependencies = [
- "log",
- "ordered-float 4.6.0",
- "strsim",
- "thiserror 1.0.69",
- "wezterm-dynamic-derive",
-]
-
-[[package]]
-name = "wezterm-dynamic-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "wezterm-input-types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
-dependencies = [
- "bitflags 1.3.2",
- "euclid",
- "lazy_static",
- "serde",
- "wezterm-dynamic",
-]
 
 [[package]]
 name = "wide"
@@ -1958,7 +1305,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1969,7 +1316,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2080,100 +1427,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,11 +1452,5 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust/tui/Cargo.toml
+++ b/rust/tui/Cargo.toml
@@ -9,12 +9,10 @@ name = "minga-renderer-rs"
 path = "src/main.rs"
 
 [dependencies]
-libc = "0.2.184"
-mio = { version = "1.0.4", features = ["os-ext", "os-poll"] }
-ratatui = { version = "0.30.0", default-features = false }
+crossterm = { version = "0.29.0", features = ["bracketed-paste", "event-stream", "use-dev-tty"] }
+ratatui = { version = "0.30.0", default-features = false, features = ["crossterm"] }
 ratatui-image = { version = "11.0.2", default-features = false }
 signal-hook = "0.3.18"
 tachyonfx = { version = "0.25.0", default-features = false }
-termwiz = "0.23.3"
 unicode-segmentation = "1.13.0"
 unicode-width = "0.2.0"

--- a/rust/tui/src/input.rs
+++ b/rust/tui/src/input.rs
@@ -1,82 +1,74 @@
 use crate::protocol;
-use termwiz::input::{InputEvent as TermwizInputEvent, InputParser, KeyCode, KeyEvent, Modifiers};
+use crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers};
 
 const ESC: u8 = 0x1B;
 const ARROW_LEFT: u32 = 57_350;
 const ARROW_RIGHT: u32 = 57_351;
 const ARROW_UP: u32 = 57_352;
 const ARROW_DOWN: u32 = 57_353;
+const FORWARD_DELETE: u32 = 0xF728;
+const HOME: u32 = 0xF729;
+const END: u32 = 0xF72B;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
     Key { codepoint: u32, modifiers: u8 },
     Paste(Vec<u8>),
+    Resize { cols: u16, rows: u16 },
 }
 
-#[derive(Debug, Default)]
-pub struct Parser {
-    inner: InputParser,
-}
-
-impl Parser {
-    pub fn push(&mut self, bytes: &[u8]) -> Vec<Event> {
-        self.inner
-            .parse_as_vec(bytes, true)
-            .into_iter()
-            .filter_map(map_termwiz_event)
-            .collect()
-    }
-
-    pub fn flush_escape(&mut self) -> Vec<Event> {
-        self.inner
-            .parse_as_vec(&[], false)
-            .into_iter()
-            .filter_map(map_termwiz_event)
-            .collect()
-    }
-}
-
-fn map_termwiz_event(event: TermwizInputEvent) -> Option<Event> {
+pub fn map_crossterm_event(event: CrosstermEvent) -> Option<Event> {
     match event {
-        TermwizInputEvent::Key(key) => map_key_event(key),
-        TermwizInputEvent::Paste(text) => Some(Event::Paste(text.into_bytes())),
+        CrosstermEvent::Key(key) => map_key_event(key),
+        CrosstermEvent::Paste(text) => Some(Event::Paste(text.into_bytes())),
+        CrosstermEvent::Resize(cols, rows) => Some(Event::Resize { cols, rows }),
         _ => None,
     }
 }
 
 fn map_key_event(event: KeyEvent) -> Option<Event> {
-    let codepoint = match event.key {
+    let codepoint = match event.code {
         KeyCode::Char(ch) => ch as u32,
-        KeyCode::Escape => ESC as u32,
+        KeyCode::Esc => ESC as u32,
         KeyCode::Backspace => 127,
         KeyCode::Enter => 13,
         KeyCode::Tab => 9,
-        KeyCode::LeftArrow | KeyCode::ApplicationLeftArrow => ARROW_LEFT,
-        KeyCode::RightArrow | KeyCode::ApplicationRightArrow => ARROW_RIGHT,
-        KeyCode::UpArrow | KeyCode::ApplicationUpArrow => ARROW_UP,
-        KeyCode::DownArrow | KeyCode::ApplicationDownArrow => ARROW_DOWN,
-        KeyCode::Home => ARROW_UP,
-        KeyCode::End => ARROW_DOWN,
+        KeyCode::BackTab => 9,
+        KeyCode::Left => ARROW_LEFT,
+        KeyCode::Right => ARROW_RIGHT,
+        KeyCode::Up => ARROW_UP,
+        KeyCode::Down => ARROW_DOWN,
+        KeyCode::Home => HOME,
+        KeyCode::End => END,
+        KeyCode::Delete => FORWARD_DELETE,
         _ => return None,
     };
 
+    let mut modifiers = map_modifiers(event.modifiers);
+    if matches!(event.code, KeyCode::BackTab) {
+        modifiers |= protocol::MOD_SHIFT;
+    }
+
     Some(Event::Key {
         codepoint,
-        modifiers: map_modifiers(event.modifiers),
+        modifiers,
     })
 }
 
-fn map_modifiers(termwiz: Modifiers) -> u8 {
+fn map_modifiers(crossterm: KeyModifiers) -> u8 {
     let mut modifiers = 0;
 
-    if termwiz.contains(Modifiers::SHIFT) {
+    if crossterm.contains(KeyModifiers::SHIFT) {
         modifiers |= protocol::MOD_SHIFT;
     }
-    if termwiz.contains(Modifiers::ALT) {
+    if crossterm.contains(KeyModifiers::ALT) {
         modifiers |= protocol::MOD_ALT;
     }
-    if termwiz.contains(Modifiers::CTRL) {
+    if crossterm.contains(KeyModifiers::CONTROL) {
         modifiers |= protocol::MOD_CTRL;
+    }
+    if crossterm.contains(KeyModifiers::SUPER) {
+        modifiers |= protocol::MOD_SUPER;
     }
 
     modifiers
@@ -86,80 +78,90 @@ fn map_modifiers(termwiz: Modifiers) -> u8 {
 mod tests {
     use super::*;
 
-    #[test]
-    fn parses_plain_utf8_keys() {
-        let mut parser = Parser::default();
-
-        assert_eq!(
-            parser.push("a©".as_bytes()),
-            vec![
-                Event::Key {
-                    codepoint: b'a' as u32,
-                    modifiers: 0
-                },
-                Event::Key {
-                    codepoint: '©' as u32,
-                    modifiers: 0
-                }
-            ]
-        );
+    fn key(code: KeyCode, modifiers: KeyModifiers) -> Option<Event> {
+        map_crossterm_event(CrosstermEvent::Key(KeyEvent::new(code, modifiers)))
     }
 
     #[test]
-    fn parses_arrow_keys_and_modifiers() {
-        let mut parser = Parser::default();
-
+    fn maps_plain_utf8_keys() {
         assert_eq!(
-            parser.push(b"\x1b[A\x1b[1;5B"),
-            vec![
-                Event::Key {
-                    codepoint: ARROW_UP,
-                    modifiers: 0
-                },
-                Event::Key {
-                    codepoint: ARROW_DOWN,
-                    modifiers: protocol::MOD_CTRL
-                }
-            ]
-        );
-    }
-
-    #[test]
-    fn accumulates_bracketed_paste_across_chunks() {
-        let mut parser = Parser::default();
-
-        assert_eq!(parser.push(b"\x1b[200~hello"), Vec::<Event>::new());
-        assert_eq!(
-            parser.push(b" world\x1b[201~a"),
-            vec![
-                Event::Paste(b"hello world".to_vec()),
-                Event::Key {
-                    codepoint: b'a' as u32,
-                    modifiers: 0
-                }
-            ]
-        );
-    }
-
-    #[test]
-    fn recognizes_paste_end_split_across_chunks() {
-        let mut parser = Parser::default();
-
-        assert_eq!(parser.push(b"\x1b[200~hello\x1b[20"), Vec::<Event>::new());
-        assert_eq!(parser.push(b"1~"), vec![Event::Paste(b"hello".to_vec())]);
-    }
-
-    #[test]
-    fn flushes_standalone_escape_after_timeout() {
-        let mut parser = Parser::default();
-
-        assert_eq!(parser.push(b"\x1b"), Vec::<Event>::new());
-        assert_eq!(
-            parser.flush_escape(),
-            vec![Event::Key {
-                codepoint: ESC as u32,
+            key(KeyCode::Char('a'), KeyModifiers::empty()),
+            Some(Event::Key {
+                codepoint: b'a' as u32,
                 modifiers: 0
-            }]
+            })
+        );
+        assert_eq!(
+            key(KeyCode::Char('©'), KeyModifiers::empty()),
+            Some(Event::Key {
+                codepoint: '©' as u32,
+                modifiers: 0
+            })
+        );
+    }
+
+    #[test]
+    fn maps_arrow_keys_and_modifiers() {
+        assert_eq!(
+            key(KeyCode::Up, KeyModifiers::empty()),
+            Some(Event::Key {
+                codepoint: ARROW_UP,
+                modifiers: 0
+            })
+        );
+        assert_eq!(
+            key(KeyCode::Down, KeyModifiers::CONTROL),
+            Some(Event::Key {
+                codepoint: ARROW_DOWN,
+                modifiers: protocol::MOD_CTRL
+            })
+        );
+    }
+
+    #[test]
+    fn maps_home_and_end_to_line_navigation_codepoints() {
+        assert_eq!(
+            key(KeyCode::Home, KeyModifiers::empty()),
+            Some(Event::Key {
+                codepoint: HOME,
+                modifiers: 0
+            })
+        );
+        assert_eq!(
+            key(KeyCode::End, KeyModifiers::SHIFT),
+            Some(Event::Key {
+                codepoint: END,
+                modifiers: protocol::MOD_SHIFT
+            })
+        );
+    }
+
+    #[test]
+    fn maps_tab_enter_delete_and_paste() {
+        assert_eq!(
+            key(KeyCode::Tab, KeyModifiers::empty()),
+            Some(Event::Key {
+                codepoint: 9,
+                modifiers: 0
+            })
+        );
+        assert_eq!(
+            key(KeyCode::Enter, KeyModifiers::ALT),
+            Some(Event::Key {
+                codepoint: 13,
+                modifiers: protocol::MOD_ALT
+            })
+        );
+        assert_eq!(
+            key(KeyCode::Delete, KeyModifiers::empty()),
+            Some(Event::Key {
+                codepoint: FORWARD_DELETE,
+                modifiers: 0
+            })
+        );
+        assert_eq!(
+            map_crossterm_event(CrosstermEvent::Paste("hello".to_owned())),
+            Some(Event::Paste(b"hello".to_vec()))
         );
     }
 }

--- a/rust/tui/src/main.rs
+++ b/rust/tui/src/main.rs
@@ -7,14 +7,11 @@ mod semantic;
 mod signals;
 mod terminal;
 
-use mio::unix::SourceFd;
-use mio::{Events, Interest, Poll, Token};
+use crossterm::event;
 use std::io::{self, Read, Write};
-use std::os::fd::RawFd;
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::thread;
 use std::time::Duration;
-
-const STDIN_TOKEN: Token = Token(0);
-const TTY_TOKEN: Token = Token(1);
 
 fn main() {
     if let Err(error) = run() {
@@ -36,131 +33,80 @@ fn run() -> io::Result<()> {
     log_info(&mut stdout, &format!("started size={cols}x{rows}"));
 
     let mut renderer = renderer::Renderer::new(cols, rows);
-    let mut stdin = io::stdin().lock();
-    let mut input = input::Parser::default();
-    let mut tty_read_buf = [0_u8; 4096];
     let resize_signal = signals::ResizeSignal::install().ok();
-    let mut input_poll = match terminal.fd() {
-        Some(tty_fd) => Some(InputPoll::new(libc::STDIN_FILENO, tty_fd)?),
-        None => None,
-    };
+    let (events_tx, events_rx) = mpsc::channel();
+    spawn_packet_reader(events_tx.clone());
+    spawn_input_reader(events_tx);
 
     loop {
-        if terminal.fd().is_none() {
-            match read_packet(&mut stdin)? {
-                Some(packet) => handle_packet(&packet, &mut renderer, &mut terminal, &mut stdout)?,
-                None => break,
-            }
-            continue;
-        };
-
-        let ready = input_poll
-            .as_mut()
-            .expect("terminal fd implies input poll")
-            .poll(Duration::from_millis(100))?;
-
         if resize_signal
             .as_ref()
             .is_some_and(signals::ResizeSignal::take)
         {
             publish_resize(&mut terminal, &mut renderer, &mut stdout)?;
-        } else if let Some((width, height)) = terminal.poll_size()? {
-            renderer.resize(width, height);
-            protocol::write_packet(&mut stdout, &protocol::encode_resize(width, height))?;
         }
 
-        if !ready.any() {
-            for event in input.flush_escape() {
-                write_input_event(event, &mut stdout)?;
+        match events_rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(LoopEvent::Packet(packet)) => {
+                handle_packet(&packet, &mut renderer, &mut terminal, &mut stdout)?;
             }
-            continue;
-        }
-
-        if ready.stdin {
-            match read_packet(&mut stdin)? {
-                Some(packet) => handle_packet(&packet, &mut renderer, &mut terminal, &mut stdout)?,
-                None => break,
+            Ok(LoopEvent::Input(event)) => {
+                handle_input_event(event, &mut terminal, &mut renderer, &mut stdout)?;
             }
-        }
-
-        if ready.tty {
-            let read = terminal.read_input(&mut tty_read_buf)?;
-            if read == 0 {
-                break;
+            Ok(LoopEvent::BackendClosed) => break,
+            Err(RecvTimeoutError::Timeout) => {
+                if let Some((width, height)) = terminal.poll_size()? {
+                    renderer.resize(width, height);
+                    protocol::write_packet(&mut stdout, &protocol::encode_resize(width, height))?;
+                }
             }
-            for event in input.push(&tty_read_buf[..read]) {
-                write_input_event(event, &mut stdout)?;
-            }
-        }
-
-        if ready.disconnected {
-            break;
+            Err(RecvTimeoutError::Disconnected) => break,
         }
     }
 
     terminal.finish()
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-struct InputReady {
-    stdin: bool,
-    tty: bool,
-    disconnected: bool,
+#[derive(Debug)]
+enum LoopEvent {
+    Packet(Vec<u8>),
+    Input(input::Event),
+    BackendClosed,
 }
 
-impl InputReady {
-    fn any(self) -> bool {
-        self.stdin || self.tty || self.disconnected
-    }
-}
-
-struct InputPoll {
-    poll: Poll,
-    events: Events,
-}
-
-impl InputPoll {
-    fn new(stdin_fd: RawFd, tty_fd: RawFd) -> io::Result<Self> {
-        let poll = Poll::new()?;
-        let mut stdin_source = SourceFd(&stdin_fd);
-        let mut tty_source = SourceFd(&tty_fd);
-
-        poll.registry()
-            .register(&mut stdin_source, STDIN_TOKEN, Interest::READABLE)?;
-        poll.registry()
-            .register(&mut tty_source, TTY_TOKEN, Interest::READABLE)?;
-
-        Ok(Self {
-            poll,
-            events: Events::with_capacity(16),
-        })
-    }
-
-    fn poll(&mut self, timeout: Duration) -> io::Result<InputReady> {
+fn spawn_packet_reader(events_tx: Sender<LoopEvent>) {
+    thread::spawn(move || {
+        let mut stdin = io::stdin().lock();
         loop {
-            match self.poll.poll(&mut self.events, Some(timeout)) {
-                Ok(()) => break,
-                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
-                Err(error) => return Err(error),
+            match read_packet(&mut stdin) {
+                Ok(Some(packet)) => {
+                    if events_tx.send(LoopEvent::Packet(packet)).is_err() {
+                        break;
+                    }
+                }
+                Ok(None) => {
+                    let _ = events_tx.send(LoopEvent::BackendClosed);
+                    break;
+                }
+                Err(_) => {
+                    let _ = events_tx.send(LoopEvent::BackendClosed);
+                    break;
+                }
             }
         }
+    });
+}
 
-        let mut ready = InputReady::default();
-        for event in self.events.iter() {
-            match event.token() {
-                STDIN_TOKEN => {
-                    ready.stdin |= event.is_readable();
-                    ready.disconnected |= event.is_read_closed() || event.is_error();
-                }
-                TTY_TOKEN => {
-                    ready.tty |= event.is_readable();
-                    ready.disconnected |= event.is_read_closed() || event.is_error();
-                }
-                _ => {}
+fn spawn_input_reader(events_tx: Sender<LoopEvent>) {
+    thread::spawn(move || {
+        while let Ok(event) = event::read() {
+            if let Some(event) = input::map_crossterm_event(event)
+                && events_tx.send(LoopEvent::Input(event)).is_err()
+            {
+                break;
             }
         }
-        Ok(ready)
-    }
+    });
 }
 
 fn publish_resize(
@@ -174,6 +120,25 @@ fn publish_resize(
         protocol::write_packet(output, &protocol::encode_resize(width, height))?;
     }
     Ok(())
+}
+
+fn handle_input_event(
+    event: input::Event,
+    terminal: &mut terminal::Terminal,
+    renderer: &mut renderer::Renderer,
+    output: &mut impl Write,
+) -> io::Result<()> {
+    match event {
+        input::Event::Resize { cols, rows } => {
+            renderer.resize(cols, rows);
+            protocol::write_packet(output, &protocol::encode_resize(cols, rows))?;
+            if let Some((width, height)) = terminal.poll_size()? {
+                renderer.resize(width, height);
+            }
+            Ok(())
+        }
+        input::Event::Key { .. } | input::Event::Paste(_) => write_input_event(event, output),
+    }
 }
 
 fn handle_packet(
@@ -241,6 +206,7 @@ fn write_input_event(event: input::Event, output: &mut impl Write) -> io::Result
                 protocol::write_packet(output, &protocol::encode_paste_event(&text))
             }
         }
+        input::Event::Resize { .. } => Ok(()),
     }
 }
 

--- a/rust/tui/src/protocol.rs
+++ b/rust/tui/src/protocol.rs
@@ -53,6 +53,7 @@ pub const ATTR_UNDERLINE: u16 = 0x02;
 pub const ATTR_ITALIC: u16 = 0x04;
 pub const ATTR_REVERSE: u16 = 0x08;
 pub const ATTR_STRIKETHROUGH: u16 = 0x10;
+#[allow(dead_code)]
 pub const UL_STYLE_SHIFT: u16 = 5;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/tui/src/renderer/mod.rs
+++ b/rust/tui/src/renderer/mod.rs
@@ -43,7 +43,7 @@ struct SemanticWindowState {
     origin_col: u16,
     width: u16,
     height: u16,
-    row_texts: Vec<String>,
+    rows: Vec<semantic::Row>,
     content_epoch: u32,
 }
 
@@ -66,7 +66,6 @@ pub struct Renderer {
     width: u16,
     height: u16,
     cells: Vec<Cell>,
-    previous: Vec<Cell>,
     cursor: (u16, u16),
     cursor_shape: u8,
     default_bg: u32,
@@ -109,7 +108,6 @@ impl Renderer {
             width,
             height,
             cells: vec![Cell::default(); len],
-            previous: vec![Cell::default(); len],
             cursor: (0, 0),
             cursor_shape: 0,
             default_bg: 0,
@@ -178,7 +176,7 @@ impl Renderer {
             Command::SetActiveRegion(0) => self.active_region = None,
             Command::SetActiveRegion(id) => self.active_region = self.regions.get(&id).copied(),
             Command::ScrollRegion { top, bottom, delta } => {
-                terminal.scroll_region(top, bottom, delta)?;
+                let _ = terminal;
                 self.sync_after_scroll(top, bottom, delta);
             }
             Command::MeasureText { request_id, text } => {
@@ -196,13 +194,6 @@ impl Renderer {
         self.width = width;
         self.height = height;
         self.cells = vec![Cell::default(); width as usize * height as usize];
-        self.previous = vec![
-            Cell {
-                text: "\0".to_owned(),
-                style: CellStyle::default()
-            };
-            width as usize * height as usize
-        ];
         self.cursor = (0, 0);
         self.regions.clear();
         self.active_region = None;
@@ -326,8 +317,8 @@ impl Renderer {
             semantic::Command::WindowOverlayDelta(delta, _) => {
                 self.apply_window_overlay_delta(delta)
             }
-            semantic::Command::WindowDelta(..)
-            | semantic::Command::ClipboardWrite(..)
+            semantic::Command::WindowRowsDelta(delta, _) => self.apply_window_rows_delta(delta),
+            semantic::Command::ClipboardWrite(..)
             | semantic::Command::LineSpacing(..)
             | semantic::Command::CursorAnimation(..)
             | semantic::Command::ConfigState(..)
@@ -371,7 +362,7 @@ impl Renderer {
                 origin_col: window.origin_col,
                 width,
                 height,
-                row_texts,
+                rows: window.rows.clone(),
                 content_epoch: window.content_epoch,
             },
         );
@@ -664,7 +655,7 @@ impl Renderer {
         let origin_row = window.origin_row;
         let origin_col = window.origin_col;
         let height = window.height;
-        let row_texts = window.row_texts.clone();
+        let row_texts: Vec<String> = window.rows.iter().map(|row| row.text.clone()).collect();
         let tab_width = u16::from(guides.tab_width.max(1));
 
         for (row_offset, line_level) in guides.line_indent_levels.into_iter().enumerate() {
@@ -738,6 +729,60 @@ impl Renderer {
         } else {
             self.clear_semantic_cursorline(delta.window_id);
         }
+    }
+
+    fn apply_window_rows_delta(&mut self, delta: semantic::WindowRowsDelta) {
+        let Some(mut window) = self.semantic_windows.get(&delta.window_id).cloned() else {
+            return;
+        };
+        if window.content_epoch != delta.content_epoch {
+            return;
+        }
+
+        self.semantic_cursorline_snapshots.remove(&delta.window_id);
+        self.clear_rect(
+            window.origin_row,
+            window.origin_col,
+            window.width,
+            window.height,
+        );
+
+        let Some(rows) = resolve_delta_rows(&window.rows, delta.rows) else {
+            self.semantic_windows.remove(&delta.window_id);
+            self.redraw_retained_chrome();
+            return;
+        };
+        window.rows = rows;
+
+        for (row, content) in window.rows.clone().into_iter().enumerate() {
+            let row = window
+                .origin_row
+                .saturating_add(row.min(u16::MAX as usize) as u16);
+            self.draw_semantic_row(row, window.origin_col, content);
+        }
+
+        if delta.cursor_visible {
+            self.cursor = (
+                window.origin_col.saturating_add(delta.cursor_col),
+                window.origin_row.saturating_add(delta.cursor_row),
+            );
+            self.cursor_shape = delta.cursor_shape;
+        }
+
+        if let Some(cursorline) = delta.cursorline {
+            self.draw_semantic_cursorline(
+                delta.window_id,
+                semantic::Cursorline {
+                    row: window.origin_row.saturating_add(cursorline.row),
+                    bg: cursorline.bg,
+                },
+            );
+        } else {
+            self.clear_semantic_cursorline(delta.window_id);
+        }
+
+        self.semantic_windows.insert(delta.window_id, window);
+        self.redraw_retained_chrome();
     }
 
     fn draw_status_bar(&mut self, status: semantic::StatusBar) {
@@ -2025,7 +2070,6 @@ impl Renderer {
             for row in top..=bottom {
                 self.clear_row(row);
             }
-            self.previous.clone_from(&self.cells);
             return;
         }
 
@@ -2044,8 +2088,6 @@ impl Renderer {
                 self.clear_row(row);
             }
         }
-
-        self.previous.clone_from(&self.cells);
     }
 
     fn copy_row(&mut self, source: u16, target: u16) {
@@ -2196,31 +2238,32 @@ impl Renderer {
     }
 
     fn render(&mut self, terminal: &mut Terminal) -> io::Result<()> {
-        for row in 0..self.height {
-            for col in 0..self.width {
-                let Some(index) = self.index(col, row) else {
-                    continue;
-                };
-
-                if self.cells[index].text.is_empty() {
-                    self.previous[index] = self.cells[index].clone();
-                    continue;
-                }
-
-                if self.cells[index] != self.previous[index] {
-                    terminal.write_cell(
-                        col,
-                        row,
-                        &self.cells[index].text,
-                        self.cells[index].style,
-                    )?;
-                    self.previous[index] = self.cells[index].clone();
-                }
-            }
-        }
+        let width = self.width;
+        let height = self.height;
+        let cursor = self.cursor;
+        let cells = self.cells.clone();
 
         terminal.set_cursor_shape(self.cursor_shape)?;
-        terminal.show_cursor(self.cursor.0, self.cursor.1)?;
+        terminal.draw(|frame| {
+            let buffer = frame.buffer_mut();
+            for row in 0..height {
+                for col in 0..width {
+                    let index = row as usize * width as usize + col as usize;
+                    let Some(cell) = cells.get(index) else {
+                        continue;
+                    };
+                    let symbol = if cell.text.is_empty() {
+                        " "
+                    } else {
+                        &cell.text
+                    };
+                    buffer[(col, row)]
+                        .set_symbol(symbol)
+                        .set_style(ratatui_style_from_cell(cell.style));
+                }
+            }
+            frame.set_cursor_position((cursor.0, cursor.1));
+        })?;
         terminal.flush()
     }
 
@@ -2231,6 +2274,30 @@ impl Renderer {
             None
         }
     }
+}
+
+fn resolve_delta_rows(
+    retained_rows: &[semantic::Row],
+    delta_rows: Vec<semantic::WindowDeltaRow>,
+) -> Option<Vec<semantic::Row>> {
+    let mut rows = Vec::with_capacity(delta_rows.len());
+
+    for entry in delta_rows {
+        match entry {
+            semantic::WindowDeltaRow::Full(row) => rows.push(row),
+            semantic::WindowDeltaRow::Ref {
+                row_id,
+                content_hash,
+            } => {
+                let row = retained_rows
+                    .iter()
+                    .find(|row| row.row_id == row_id && row.content_hash == content_hash)?;
+                rows.push(row.clone());
+            }
+        }
+    }
+
+    Some(rows)
 }
 
 fn text_width(text: &str) -> u16 {
@@ -2448,6 +2515,9 @@ fn ratatui_style_from_cell(style: CellStyle) -> RatatuiStyle {
     }
     if style.attrs & protocol::ATTR_STRIKETHROUGH != 0 {
         out = out.add_modifier(Modifier::CROSSED_OUT);
+    }
+    if style.blend < 50 {
+        out = out.add_modifier(Modifier::DIM);
     }
     out
 }
@@ -3238,6 +3308,102 @@ mod tests {
         assert_eq!(cell.text, "h");
         assert_eq!(cell.style.fg, 0xAABBCC);
         assert_eq!(cell.style.bg, 0x112233);
+    }
+
+    #[test]
+    fn semantic_window_rows_delta_updates_retained_rows_with_epoch_guard() {
+        let mut renderer = Renderer::new(16, 4);
+
+        renderer.draw_semantic_window(semantic::WindowContent {
+            window_id: 1,
+            text_width: 8,
+            text_height: 2,
+            origin_row: 1,
+            origin_col: 2,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_shape: 0,
+            content_epoch: 7,
+            rows: vec![
+                semantic::Row {
+                    row_id: 11,
+                    content_hash: 0xAAAA,
+                    text: "alpha".to_owned(),
+                    spans: vec![],
+                    ..Default::default()
+                },
+                semantic::Row {
+                    row_id: 12,
+                    content_hash: 0xBBBB,
+                    text: "beta".to_owned(),
+                    spans: vec![],
+                    ..Default::default()
+                },
+            ],
+            cursorline: None,
+        });
+
+        renderer.apply_window_rows_delta(semantic::WindowRowsDelta {
+            window_id: 1,
+            content_epoch: 6,
+            cursor_visible: true,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_shape: 0,
+            rows: vec![semantic::WindowDeltaRow::Full(semantic::Row {
+                text: "stale".to_owned(),
+                spans: vec![],
+                ..Default::default()
+            })],
+            cursorline: None,
+        });
+        assert_eq!(renderer.cells[renderer.index(2, 1).unwrap()].text, "a");
+
+        renderer.apply_window_rows_delta(semantic::WindowRowsDelta {
+            window_id: 1,
+            content_epoch: 7,
+            cursor_visible: true,
+            cursor_row: 1,
+            cursor_col: 3,
+            cursor_shape: 2,
+            rows: vec![
+                semantic::WindowDeltaRow::Ref {
+                    row_id: 11,
+                    content_hash: 0xAAAA,
+                },
+                semantic::WindowDeltaRow::Full(semantic::Row {
+                    text: "delta".to_owned(),
+                    spans: vec![],
+                    ..Default::default()
+                }),
+            ],
+            cursorline: Some(semantic::Cursorline {
+                row: 1,
+                bg: 0x123456,
+            }),
+        });
+
+        assert_eq!(renderer.cells[renderer.index(2, 1).unwrap()].text, "a");
+        assert_eq!(renderer.cells[renderer.index(2, 2).unwrap()].text, "d");
+        assert_eq!(renderer.cursor, (5, 2));
+        assert_eq!(renderer.cursor_shape, 2);
+        assert_eq!(
+            renderer.cells[renderer.index(2, 2).unwrap()].style.bg,
+            0x123456
+        );
+
+        renderer.apply_window_rows_delta(semantic::WindowRowsDelta {
+            window_id: 1,
+            content_epoch: 7,
+            cursor_visible: false,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_shape: 0,
+            rows: vec![],
+            cursorline: None,
+        });
+        assert_eq!(renderer.cells[renderer.index(2, 1).unwrap()].text, " ");
+        assert_eq!(renderer.cells[renderer.index(2, 2).unwrap()].text, " ");
     }
 
     #[test]
@@ -4615,8 +4781,8 @@ mod tests {
         renderer.write_run(0, 0, "界", CellStyle::default());
         renderer.render(&mut terminal).unwrap();
 
-        assert_eq!(renderer.previous[renderer.index(0, 0).unwrap()].text, "界");
-        assert_eq!(renderer.previous[renderer.index(1, 0).unwrap()].text, "");
+        assert_eq!(renderer.cells[renderer.index(0, 0).unwrap()].text, "界");
+        assert_eq!(renderer.cells[renderer.index(1, 0).unwrap()].text, "");
     }
 
     #[test]

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -30,7 +30,7 @@ pub enum Command {
     SplitSeparators(SplitSeparators, usize),
     IndentGuides(IndentGuides, usize),
     WindowOverlayDelta(WindowOverlayDelta, usize),
-    WindowDelta(WindowDelta, usize),
+    WindowRowsDelta(WindowRowsDelta, usize),
     ClipboardWrite(ClipboardWrite, usize),
     LineSpacing(LineSpacing, usize),
     CursorAnimation(CursorAnimation, usize),
@@ -77,7 +77,7 @@ impl Command {
             Self::SplitSeparators(_, size) => *size,
             Self::IndentGuides(_, size) => *size,
             Self::WindowOverlayDelta(_, size) => *size,
-            Self::WindowDelta(_, size) => *size,
+            Self::WindowRowsDelta(_, size) => *size,
             Self::ClipboardWrite(_, size) => *size,
             Self::LineSpacing(_, size) => *size,
             Self::CursorAnimation(_, size) => *size,
@@ -497,10 +497,22 @@ pub struct WindowOverlayDelta {
     pub cursorline: Option<Cursorline>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WindowDelta {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowRowsDelta {
     pub window_id: u16,
     pub content_epoch: u32,
+    pub cursor_visible: bool,
+    pub cursor_row: u16,
+    pub cursor_col: u16,
+    pub cursor_shape: u8,
+    pub rows: Vec<WindowDeltaRow>,
+    pub cursorline: Option<Cursorline>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WindowDeltaRow {
+    Ref { row_id: u64, content_hash: u32 },
+    Full(Row),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -639,7 +651,7 @@ pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
         opcodes::OP_GUI_INDENT_GUIDES => decode_indent_guides(bytes),
         opcodes::OP_GUI_WINDOW_OVERLAY_DELTA => decode_window_overlay_delta(bytes),
         opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA | opcodes::OP_GUI_WINDOW_ROWS_DELTA => {
-            decode_window_delta(bytes)
+            decode_window_rows_delta(bytes)
         }
         opcodes::OP_CLIPBOARD_WRITE => decode_clipboard_write(bytes),
         opcodes::OP_GUI_LINE_SPACING => decode_line_spacing(bytes),
@@ -735,6 +747,69 @@ fn decode_window_content(bytes: &[u8]) -> Result<Command, DecodeError> {
                 row: origin_row.saturating_add(line.row),
                 bg: line.bg,
             }),
+        },
+        size,
+    ))
+}
+
+fn decode_window_rows_delta(bytes: &[u8]) -> Result<Command, DecodeError> {
+    let size = semantic_size(bytes)?;
+    let opcode = bytes[0];
+    let sections = sections(&bytes[..size])?;
+    let mut window_id = 0;
+    let mut content_epoch = 0;
+    let mut flags = 0;
+    let mut cursor_row = 0;
+    let mut cursor_col = 0;
+    let mut cursor_shape = 0;
+    let mut rows = Vec::new();
+    let mut cursorline = None;
+
+    for (section_id, payload) in sections {
+        match section_id {
+            0x01 => {
+                if opcode == opcodes::OP_GUI_WINDOW_ROWS_DELTA {
+                    let (header, _) =
+                        semantic_decode::decode_gui_window_rows_delta_header(payload, 0)?;
+                    window_id = header.window_id;
+                    content_epoch = header.content_epoch;
+                    flags = header.flags;
+                    cursor_row = header.cursor_row;
+                    cursor_col = header.cursor_col;
+                    cursor_shape = header.cursor_shape;
+                } else {
+                    let (header, _) =
+                        semantic_decode::decode_gui_window_viewport_delta_header(payload, 0)?;
+                    window_id = header.window_id;
+                    content_epoch = header.content_epoch;
+                    flags = header.flags;
+                    cursor_row = header.cursor_row;
+                    cursor_col = header.cursor_col;
+                    cursor_shape = header.cursor_shape;
+                }
+            }
+            0x02 => rows = decode_delta_rows(payload)?,
+            0x09 => {
+                let (cl, _) = semantic_decode::decode_gui_window_content_cursorline(payload, 0)?;
+                cursorline = Some(Cursorline {
+                    row: cl.row,
+                    bg: cl.bg,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(Command::WindowRowsDelta(
+        WindowRowsDelta {
+            window_id,
+            content_epoch,
+            cursor_visible: flags & 0x01 != 0,
+            cursor_row,
+            cursor_col,
+            cursor_shape,
+            rows,
+            cursorline,
         },
         size,
     ))
@@ -1723,29 +1798,6 @@ fn decode_indent_guides(bytes: &[u8]) -> Result<Command, DecodeError> {
     ))
 }
 
-fn decode_window_delta(bytes: &[u8]) -> Result<Command, DecodeError> {
-    let size = semantic_size(bytes)?;
-    let sections = sections(&bytes[..size])?;
-    let mut window_id = 0;
-    let mut content_epoch = 0;
-
-    for (section_id, payload) in sections {
-        if section_id == 0x01 {
-            require_len(payload, 6, "window delta header")?;
-            window_id = read_u16(payload, 0);
-            content_epoch = read_u32(payload, 2);
-        }
-    }
-
-    Ok(Command::WindowDelta(
-        WindowDelta {
-            window_id,
-            content_epoch,
-        },
-        size,
-    ))
-}
-
 fn decode_window_overlay_delta(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = semantic_size(bytes)?;
     require_len(bytes, 13, "window overlay delta")?;
@@ -2041,6 +2093,38 @@ fn decode_rows(bytes: &[u8]) -> Result<Vec<Row>, DecodeError> {
     Ok(rows)
 }
 
+fn decode_delta_rows(bytes: &[u8]) -> Result<Vec<WindowDeltaRow>, DecodeError> {
+    require_len(bytes, 2, "delta rows count")?;
+    let count = read_u16(bytes, 0) as usize;
+    let mut offset = 2;
+    let mut rows = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        require_len(bytes, offset + 1, "delta row entry type")?;
+        let entry_type = bytes[offset];
+        offset += 1;
+
+        match entry_type {
+            0 => {
+                require_len(bytes, offset + 12, "delta row ref")?;
+                rows.push(WindowDeltaRow::Ref {
+                    row_id: read_u64(bytes, offset),
+                    content_hash: read_u32(bytes, offset + 8),
+                });
+                offset += 12;
+            }
+            1 => {
+                let (row, consumed) = semantic_decode::decode_row(bytes, offset)?;
+                rows.push(WindowDeltaRow::Full(row));
+                offset += consumed;
+            }
+            _ => return Err(DecodeError::Malformed("unknown delta row entry type")),
+        }
+    }
+
+    Ok(rows)
+}
+
 fn sections(bytes: &[u8]) -> Result<Vec<(u8, &[u8])>, DecodeError> {
     require_len(bytes, 2, "sectioned command header")?;
     let count = bytes[1] as usize;
@@ -2084,6 +2168,9 @@ fn custom_semantic_size(bytes: &[u8]) -> Result<usize, DecodeError> {
         opcodes::OP_GUI_CHANGE_SUMMARY => change_summary_size(bytes),
         opcodes::OP_GUI_TOOL_MANAGER => tool_manager_size(bytes),
         opcodes::OP_GUI_WINDOW_OVERLAY_DELTA => overlay_delta_size(bytes),
+        opcodes::OP_GUI_WINDOW_VIEWPORT_DELTA | opcodes::OP_GUI_WINDOW_ROWS_DELTA => {
+            sectioned_size(bytes, "window rows delta")
+        }
         _ => Err(DecodeError::UnknownOpcode(opcode)),
     }
 }
@@ -2463,6 +2550,19 @@ fn read_u32(bytes: &[u8], offset: usize) -> u32 {
     ])
 }
 
+fn read_u64(bytes: &[u8], offset: usize) -> u64 {
+    u64::from_be_bytes([
+        bytes[offset],
+        bytes[offset + 1],
+        bytes[offset + 2],
+        bytes[offset + 3],
+        bytes[offset + 4],
+        bytes[offset + 5],
+        bytes[offset + 6],
+        bytes[offset + 7],
+    ])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2497,6 +2597,52 @@ mod tests {
                 rows,
                 ..
             }, _) if rows[0].text == "hi" && rows[0].spans[0].fg == 0xAABBCC
+        ));
+    }
+
+    #[test]
+    fn decodes_window_rows_delta_ref_and_full_entries() {
+        let header = section(0x01, &[0, 1, 0, 0, 0, 7, 1, 0, 3, 0, 4, 2, 0, 0]);
+        let full_row = [
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 22, 0, 0, 0, 9, 0, 0, 0, 0xBB, 0, 0, 0, 2,
+            ],
+            b"ok".to_vec(),
+            vec![0, 0],
+        ]
+        .concat();
+        let rows = section(
+            0x02,
+            &[
+                vec![0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0xAA, 1],
+                full_row,
+            ]
+            .concat(),
+        );
+        let payload = [vec![opcodes::OP_GUI_WINDOW_ROWS_DELTA, 2], header, rows].concat();
+
+        let command = decode(&payload).unwrap();
+
+        assert_eq!(semantic_size(&payload).unwrap(), payload.len());
+        let Command::WindowRowsDelta(delta, _) = command else {
+            panic!("expected rows delta");
+        };
+        assert_eq!(delta.window_id, 1);
+        assert_eq!(delta.content_epoch, 7);
+        assert!(delta.cursor_visible);
+        assert_eq!(delta.cursor_row, 3);
+        assert_eq!(delta.cursor_col, 4);
+        assert_eq!(delta.cursor_shape, 2);
+        assert_eq!(
+            delta.rows[0],
+            WindowDeltaRow::Ref {
+                row_id: 11,
+                content_hash: 0xAA
+            }
+        );
+        assert!(matches!(
+            &delta.rows[1],
+            WindowDeltaRow::Full(Row { row_id: 22, content_hash: 0xBB, text, .. }) if text == "ok"
         ));
     }
 

--- a/rust/tui/src/terminal.rs
+++ b/rust/tui/src/terminal.rs
@@ -1,9 +1,19 @@
-use crate::protocol;
 use std::env;
 use std::fs::{File, OpenOptions};
-use std::io::{self, Read, Write};
-use std::os::fd::{AsRawFd, RawFd};
+use std::io::{self, Write};
 use std::path::PathBuf;
+
+use crossterm::cursor::{Hide, SetCursorStyle, Show};
+use crossterm::event::{DisableBracketedPaste, EnableBracketedPaste};
+use crossterm::execute;
+use crossterm::terminal::{
+    BeginSynchronizedUpdate, EndSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen,
+    SetTitle, disable_raw_mode, enable_raw_mode, size,
+};
+use ratatui::Terminal as RatatuiTerminal;
+use ratatui::backend::CrosstermBackend;
+#[cfg(test)]
+use ratatui::backend::TestBackend;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CellStyle {
@@ -26,11 +36,14 @@ impl Default for CellStyle {
     }
 }
 
+enum Backend {
+    Real(RatatuiTerminal<CrosstermBackend<File>>),
+    #[cfg(test)]
+    Test(RatatuiTerminal<TestBackend>),
+}
+
 pub struct Terminal {
-    writer: Box<dyn Write>,
-    reader: Option<File>,
-    fd: Option<RawFd>,
-    original_termios: Option<libc::termios>,
+    backend: Backend,
     width: u16,
     height: u16,
     real_tty: bool,
@@ -39,35 +52,28 @@ pub struct Terminal {
 
 impl Terminal {
     pub fn open() -> io::Result<Self> {
-        let tty = tty_file()?;
-        let reader = tty.try_clone()?;
-        let fd = tty.as_raw_fd();
-        let original_termios = make_raw(fd)?;
-        let (width, height) = query_terminal_size(fd).unwrap_or_else(|_| env_size());
-        let mut terminal = Self {
-            writer: Box::new(tty),
-            reader: Some(reader),
-            fd: Some(fd),
-            original_termios: Some(original_termios),
+        enable_raw_mode()?;
+        let mut tty = tty_file()?;
+        execute!(tty, EnterAlternateScreen, EnableBracketedPaste, Hide)?;
+        let backend = CrosstermBackend::new(tty);
+        let terminal = RatatuiTerminal::new(backend)?;
+        let (width, height) = size().unwrap_or_else(|_| env_size());
+
+        Ok(Self {
+            backend: Backend::Real(terminal),
             width,
             height,
             real_tty: true,
             active: true,
-        };
-        terminal
-            .writer
-            .write_all(b"\x1b[?1049h\x1b[?2004h\x1b[?25h")?;
-        terminal.flush()?;
-        Ok(terminal)
+        })
     }
 
     #[cfg(test)]
     pub fn memory(width: u16, height: u16) -> Self {
+        let backend = TestBackend::new(width, height);
+        let terminal = RatatuiTerminal::new(backend).expect("test terminal should initialize");
         Self {
-            writer: Box::new(Vec::<u8>::new()),
-            reader: None,
-            fd: None,
-            original_termios: None,
+            backend: Backend::Test(terminal),
             width,
             height,
             real_tty: false,
@@ -79,22 +85,12 @@ impl Terminal {
         (self.width, self.height)
     }
 
-    pub fn fd(&self) -> Option<RawFd> {
-        self.fd
-    }
-
-    pub fn read_input(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match &mut self.reader {
-            Some(reader) => reader.read(buf),
-            None => Ok(0),
-        }
-    }
-
     pub fn poll_size(&mut self) -> io::Result<Option<(u16, u16)>> {
-        let Some(fd) = self.fd else {
-            return Ok(None);
+        let (width, height) = match &mut self.backend {
+            Backend::Real(terminal) => terminal.size().map(|rect| (rect.width, rect.height))?,
+            #[cfg(test)]
+            Backend::Test(_) => (self.width, self.height),
         };
-        let (width, height) = query_terminal_size(fd)?;
 
         if width == self.width && height == self.height {
             Ok(None)
@@ -105,118 +101,74 @@ impl Terminal {
         }
     }
 
+    pub fn draw<F>(&mut self, render_callback: F) -> io::Result<()>
+    where
+        F: FnOnce(&mut ratatui::Frame<'_>),
+    {
+        match &mut self.backend {
+            Backend::Real(terminal) => {
+                execute!(terminal.backend_mut(), BeginSynchronizedUpdate)?;
+                let draw_result = terminal.draw(render_callback).map(|_| ());
+                let end_result = execute!(terminal.backend_mut(), EndSynchronizedUpdate);
+                draw_result?;
+                end_result?;
+            }
+            #[cfg(test)]
+            Backend::Test(terminal) => {
+                let _ = terminal.draw(render_callback);
+            }
+        }
+        Ok(())
+    }
+
     pub fn finish(&mut self) -> io::Result<()> {
         if self.real_tty && self.active {
-            self.writer
-                .write_all(b"\x1b[0m\x1b[?2004l\x1b[?25h\x1b[?1049l")?;
-            if let (Some(fd), Some(termios)) = (self.fd, self.original_termios.take()) {
-                restore_termios(fd, termios)?;
+            match &mut self.backend {
+                Backend::Real(terminal) => {
+                    let backend = terminal.backend_mut();
+                    execute!(backend, Show, DisableBracketedPaste, LeaveAlternateScreen)?;
+                }
+                #[cfg(test)]
+                Backend::Test(_) => {}
             }
+            disable_raw_mode()?;
             self.active = false;
         }
 
-        self.flush()
+        Ok(())
     }
 
     pub fn set_title(&mut self, title: &str) -> io::Result<()> {
-        write!(self.writer, "\x1b]0;{title}\x07")
+        match &mut self.backend {
+            Backend::Real(terminal) => execute!(terminal.backend_mut(), SetTitle(title))?,
+            #[cfg(test)]
+            Backend::Test(_) => {}
+        }
+        Ok(())
     }
 
     pub fn set_cursor_shape(&mut self, shape: u8) -> io::Result<()> {
-        let code = match shape {
-            1 => 5,
-            2 => 3,
-            _ => 1,
-        };
-        write!(self.writer, "\x1b[{code} q")
-    }
-
-    pub fn show_cursor(&mut self, col: u16, row: u16) -> io::Result<()> {
-        write!(self.writer, "\x1b[{};{}H", row as u32 + 1, col as u32 + 1)
-    }
-
-    pub fn scroll_region(&mut self, top: u16, bottom: u16, delta: i16) -> io::Result<()> {
-        if delta == 0 || top >= bottom {
-            return Ok(());
+        match &mut self.backend {
+            Backend::Real(terminal) => {
+                let style = match shape {
+                    1 => SetCursorStyle::BlinkingBar,
+                    2 => SetCursorStyle::BlinkingUnderScore,
+                    _ => SetCursorStyle::BlinkingBlock,
+                };
+                execute!(terminal.backend_mut(), style)?;
+            }
+            #[cfg(test)]
+            Backend::Test(_) => {}
         }
-
-        write!(
-            self.writer,
-            "\x1b[{};{}r",
-            top as u32 + 1,
-            bottom as u32 + 1
-        )?;
-
-        if delta > 0 {
-            write!(self.writer, "\x1b[{}S", delta)?;
-        } else {
-            write!(self.writer, "\x1b[{}T", -delta)?;
-        }
-
-        self.writer.write_all(b"\x1b[r")
-    }
-
-    pub fn write_cell(
-        &mut self,
-        col: u16,
-        row: u16,
-        text: &str,
-        style: CellStyle,
-    ) -> io::Result<()> {
-        self.show_cursor(col, row)?;
-        self.write_style(style)?;
-        write!(self.writer, "{text}")?;
-        self.writer.write_all(b"\x1b[0m")
+        Ok(())
     }
 
     pub fn flush(&mut self) -> io::Result<()> {
-        self.writer.flush()
-    }
-
-    fn write_style(&mut self, style: CellStyle) -> io::Result<()> {
-        self.writer.write_all(b"\x1b[0m")?;
-
-        if style.attrs & protocol::ATTR_BOLD != 0 {
-            self.writer.write_all(b"\x1b[1m")?;
+        match &mut self.backend {
+            Backend::Real(terminal) => terminal.backend_mut().flush(),
+            #[cfg(test)]
+            Backend::Test(_) => Ok(()),
         }
-        if style.attrs & protocol::ATTR_ITALIC != 0 {
-            self.writer.write_all(b"\x1b[3m")?;
-        }
-        if style.attrs & protocol::ATTR_UNDERLINE != 0 {
-            self.writer.write_all(b"\x1b[4m")?;
-        }
-        if style.attrs & protocol::ATTR_REVERSE != 0 {
-            self.writer.write_all(b"\x1b[7m")?;
-        }
-        if style.attrs & protocol::ATTR_STRIKETHROUGH != 0 {
-            self.writer.write_all(b"\x1b[9m")?;
-        }
-        if style.blend < 50 {
-            self.writer.write_all(b"\x1b[2m")?;
-        }
-        if style.fg != 0 {
-            write_rgb(self.writer.as_mut(), 38, style.fg)?;
-        }
-        if style.bg != 0 {
-            write_rgb(self.writer.as_mut(), 48, style.bg)?;
-        }
-        if style.ul_color != 0 {
-            write_rgb(self.writer.as_mut(), 58, style.ul_color)?;
-        }
-
-        let underline_style = (style.attrs >> protocol::UL_STYLE_SHIFT) & 0x07;
-        if underline_style != 0 {
-            let code = match underline_style {
-                1 => 3,
-                2 => 4,
-                3 => 5,
-                4 => 6,
-                _ => 1,
-            };
-            write!(self.writer, "\x1b[4:{code}m")?;
-        }
-
-        Ok(())
     }
 }
 
@@ -233,51 +185,6 @@ fn tty_file() -> io::Result<File> {
     OpenOptions::new().read(true).write(true).open(path)
 }
 
-fn make_raw(fd: RawFd) -> io::Result<libc::termios> {
-    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
-    let rc = unsafe { libc::tcgetattr(fd, termios.as_mut_ptr()) };
-    if rc != 0 {
-        return Err(io::Error::last_os_error());
-    }
-
-    let original = unsafe { termios.assume_init() };
-    let mut raw = original;
-    unsafe {
-        libc::cfmakeraw(&mut raw);
-    }
-
-    let rc = unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) };
-    if rc != 0 {
-        return Err(io::Error::last_os_error());
-    }
-
-    Ok(original)
-}
-
-fn restore_termios(fd: RawFd, termios: libc::termios) -> io::Result<()> {
-    let rc = unsafe { libc::tcsetattr(fd, libc::TCSANOW, &termios) };
-    if rc == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-fn query_terminal_size(fd: RawFd) -> io::Result<(u16, u16)> {
-    let mut winsize = std::mem::MaybeUninit::<libc::winsize>::zeroed();
-    let rc = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, winsize.as_mut_ptr()) };
-    if rc != 0 {
-        return Err(io::Error::last_os_error());
-    }
-
-    let winsize = unsafe { winsize.assume_init() };
-    if winsize.ws_col == 0 || winsize.ws_row == 0 {
-        Ok(env_size())
-    } else {
-        Ok((winsize.ws_col, winsize.ws_row))
-    }
-}
-
 fn env_size() -> (u16, u16) {
     (
         env_u16("COLUMNS").unwrap_or(80),
@@ -287,11 +194,4 @@ fn env_size() -> (u16, u16) {
 
 fn env_u16(name: &str) -> Option<u16> {
     env::var(name).ok()?.parse().ok()
-}
-
-fn write_rgb(writer: &mut dyn Write, prefix: u8, rgb: u32) -> io::Result<()> {
-    let r = (rgb >> 16) & 0xFF;
-    let g = (rgb >> 8) & 0xFF;
-    let b = rgb & 0xFF;
-    write!(writer, "\x1b[{prefix};2;{r};{g};{b}m")
 }


### PR DESCRIPTION
# TL;DR
The Rust TUI now uses crossterm and ratatui for terminal lifecycle, input, synchronized drawing, and screen diffing. This moves the Rust bake-off renderer onto the same retained-state, framework-driven footing as the Go TUI.

Closes #2149

## Context
The Rust TUI was previously doing most terminal work by hand: raw mode, ANSI output, a custom cell diff, scroll regions, a mio input loop, and termwiz input parsing. That made the bake-off compare spike architecture more than Rust versus Go. This PR puts Rust behind crossterm and ratatui so the comparison is about the framework fit and retained-state model.

## Changes
- Replaced the custom raw-mode/ANSI terminal wrapper with crossterm-managed raw mode, alternate screen, bracketed paste, cursor visibility, cursor shape, synchronized output, and ratatui’s managed terminal draw.
- Replaced the termwiz parser and custom mio dual-fd polling loop with crossterm events feeding the renderer loop through channels, so BEAM packets and input wake rendering independently.
- Moved final screen emission into one retained-state `terminal.draw` path instead of per-cell terminal writes.
- Added crossterm key mapping coverage for arrows, Home, End, Tab, Enter, Delete, modified keys, paste, and resize events.
- Added retained rows/viewport delta decoding for the actual ref-or-full row wire format, including `content_epoch` guards, missing-reference recovery, and empty visible-row snapshots.
- Preserved retained chrome and overlay drawing through the existing state store for status bar, tab bar, gutter, cursorline, picker, completion, and related semantic surfaces.

## Verification
- `cargo fmt --manifest-path rust/tui/Cargo.toml`
- `cargo test --manifest-path rust/tui/Cargo.toml` (100 passed)
- `make native.support`
- `make lint`
- `mix test.llm` (9492 tests, 0 failures)
- Focused bug-hunting review: `prtk-code-reviewer`, initial blockers fixed, targeted re-check passed
- Final acceptance review: initial blockers fixed, targeted re-check passed

Manual visual comparison against `bin/minga-go` is still recommended during the bake-off, because flicker and feel are partly terminal-dependent and cannot be fully proven by unit tests.

## Acceptance Criteria Addressed
- AC1: Crossterm owns terminal lifecycle and ratatui owns final diff/flush; termwiz, direct raw-mode handling, direct cell writes, and the custom mio loop are removed. ✅
- AC2: Input is read through crossterm events, with regression coverage for arrows, Home, End, Tab, Enter, modified keys, paste, and backend packet wakeups. ✅
- AC3: Full `WindowContent` and retained rows/viewport/overlay deltas update retained window state with `content_epoch` guards and row-reference resolution. ✅
- AC4: Status bar, tab bar, gutter, cursorline, picker, completion, and other retained semantic surfaces render through the retained draw path. ✅
- AC5: Screen output is rendered from retained state inside a single `terminal.draw` call for each batch. ✅
- AC6: Rust is now a fair retained-state crossterm/ratatui contender for the Go bake-off; manual feel testing remains the final comparison step. ✅
