### PR TITLE
feat(go): add agent details and tool cards

### DIFF
--- a/go/tui/internal/protocol/chrome_agent.go
+++ b/go/tui/internal/protocol/chrome_agent.go
@@ -50,9 +50,7 @@ func decodeAgentChat(payload []byte) (AgentChat, string, int) {
 				chat.ModelName = value
 			}
 		case 0x03:
-			if value, _, ok := readString16(section, 0); ok {
-				chat.Prompt = value
-			}
+			chat = decodeAgentPrompt(chat, section)
 		case 0x04:
 			chat.Pending = decodeAgentPending(section)
 		case 0x07:
@@ -66,6 +64,22 @@ func decodeAgentChat(payload []byte) (AgentChat, string, int) {
 		}
 	}
 	return chat, fmt.Sprintf("%s %d messages", chat.ModelName, len(chat.Messages)), size
+}
+
+func decodeAgentPrompt(chat AgentChat, section []byte) AgentChat {
+	value, offset, ok := readString16(section, 0)
+	if !ok {
+		return chat
+	}
+	chat.Prompt = value
+	if len(section) >= offset+7 {
+		chat.PromptLineCount = section[offset]
+		chat.PromptCursorLine = u16(section, offset+1)
+		chat.PromptCursorCol = u16(section, offset+3)
+		chat.PromptVimMode = section[offset+5]
+		chat.PromptVisibleRows = section[offset+6]
+	}
+	return chat
 }
 
 func decodeAgentPending(section []byte) string {

--- a/go/tui/internal/protocol/chrome_types.go
+++ b/go/tui/internal/protocol/chrome_types.go
@@ -411,14 +411,19 @@ type AgentContext struct {
 }
 
 type AgentChat struct {
-	Visible       bool
-	Status        byte
-	ModelName     string
-	Prompt        string
-	ThinkingLevel string
-	Messages      []AgentChatMessage
-	Pending       string
-	Completion    []string
+	Visible           bool
+	Status            byte
+	ModelName         string
+	Prompt            string
+	PromptLineCount   byte
+	PromptCursorLine  uint16
+	PromptCursorCol   uint16
+	PromptVimMode     byte
+	PromptVisibleRows byte
+	ThinkingLevel     string
+	Messages          []AgentChatMessage
+	Pending           string
+	Completion        []string
 }
 
 type AgentChatMessage struct {

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -956,12 +956,19 @@ func TestDecodeAgentChatPreservesStructuredMessageDetails(t *testing.T) {
 	usage = append(usage, u32Bytes(20)...)
 	usage = append(usage, u32Bytes(12500)...)
 
-	chat := []byte{generated.OPGuiAgentChat, 2}
+	prompt := string16("fix it")
+	prompt = append(prompt, 2, 0, 1, 0, 4, 1, 2)
+
+	chat := []byte{generated.OPGuiAgentChat, 3}
 	chat = append(chat, section(0x01, []byte{1, 2})...)
+	chat = append(chat, section(0x03, prompt)...)
 	chat = append(chat, section(0x06, agentMessages(tool, approval, usage))...)
 	command, err := DecodeCommand(chat)
 	if err != nil {
 		t.Fatalf("DecodeCommand chat returned error: %v", err)
+	}
+	if command.Chrome.AgentChat.Prompt != "fix it" || command.Chrome.AgentChat.PromptLineCount != 2 || command.Chrome.AgentChat.PromptCursorLine != 1 || command.Chrome.AgentChat.PromptCursorCol != 4 || command.Chrome.AgentChat.PromptVimMode != 1 || command.Chrome.AgentChat.PromptVisibleRows != 2 {
+		t.Fatalf("prompt metadata decoded incorrectly: %+v", command.Chrome.AgentChat)
 	}
 	messages := command.Chrome.AgentChat.Messages
 	if len(messages) != 3 {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -30,7 +30,7 @@ func (m Model) renderAgentChatBody(chat protocol.AgentChat) []string {
 	limit := m.bodyHeight()
 	contentWidth := max(width-2, 1)
 	lines := m.renderAgentChatPanelWithLimit(chat, contentWidth, limit)
-	blank := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(strings.Repeat(" ", width))
+	blank := lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(strings.Repeat(" ", width))
 	for index, line := range lines {
 		lines[index] = m.insetAgentLine(line, width)
 	}
@@ -44,8 +44,8 @@ func (m Model) insetAgentLine(line string, width int) string {
 	if width <= 1 {
 		return line
 	}
-	inset := lipgloss.NewStyle().Background(m.editorBackground()).Render(" ")
-	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(inset+line, width))
+	inset := lipgloss.NewStyle().Background(m.agentSurface()).Render(" ")
+	return lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(inset+line, width))
 }
 
 func (m Model) renderAgentChatPanelWithLimit(chat protocol.AgentChat, width int, limit int) []string {
@@ -65,6 +65,10 @@ func (m Model) renderAgentChatPanelWithLimit(chat protocol.AgentChat, width int,
 
 	lines = append(lines, m.renderAgentMainColumn(chat, width, limit-1, empty)...)
 	return takeLines(lines, limit)
+}
+
+func (m Model) agentSurface() color.Color {
+	return m.palette().PopupSurface()
 }
 
 func (m Model) agentPanelHeight() int {
@@ -122,14 +126,14 @@ func (m Model) renderAgentMainColumn(chat protocol.AgentChat, width int, budget 
 }
 
 func (m Model) renderAgentBlankLine(width int) string {
-	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(strings.Repeat(" ", max(width, 1)))
+	return lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(strings.Repeat(" ", max(width, 1)))
 }
 
 func (m Model) renderAgentTranscriptHeader(width int) string {
 	p := m.palette()
-	label := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" Transcript ")
-	rule := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(strings.Repeat("─", max(width-lipgloss.Width(label), 0)))
-	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(label+rule, width))
+	label := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.agentSurface()).Render(" Transcript ")
+	rule := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Render(strings.Repeat("─", max(width-lipgloss.Width(label), 0)))
+	return lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(label+rule, width))
 }
 
 func (m Model) renderAgentTranscriptStatus(chat protocol.AgentChat, width int) string {
@@ -143,12 +147,12 @@ func (m Model) renderAgentTranscriptStatus(chat protocol.AgentChat, width int) s
 	if chat.ThinkingLevel != "" {
 		status += " · thinking " + chat.ThinkingLevel
 	}
-	return lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Width(width).Render(fit(status, width))
+	return lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Width(width).Render(fit(status, width))
 }
 
 func (m Model) renderAgentLandingState(width int) []string {
 	p := m.palette()
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface())
 	pillRow := strings.Join([]string{
 		m.renderAgentSuggestionPill("Explain this file"),
 		m.renderAgentSuggestionPill("Find failing tests"),
@@ -160,35 +164,35 @@ func (m Model) renderAgentLandingState(width int) []string {
 		m.renderAgentSuggestionPill("Draft a plan"),
 	}, "  ")
 	return []string{
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(titleStyle.Render("Try asking Minga"), width)),
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(pillRow, width)),
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(pillRowTwo, width)),
+		lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(titleStyle.Render("Try asking Minga"), width)),
+		lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(pillRow, width)),
+		lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(pillRowTwo, width)),
 	}
 }
 
 func (m Model) renderAgentSuggestionPill(label string) string {
 	p := m.palette()
-	marker := lipgloss.NewStyle().Foreground(p.Accent()).Background(m.editorBackground()).Bold(true).Render("›")
-	text := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Render(label)
+	marker := lipgloss.NewStyle().Foreground(p.Accent()).Background(m.agentSurface()).Bold(true).Render("›")
+	text := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface()).Render(label)
 	return marker + " " + text
 }
 
 func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {
 	p := m.palette()
-	base := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Width(width)
+	base := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface()).Width(width)
 	provider, modelName := splitAgentModelName(chat.ModelName)
-	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render("◇ Agent")
+	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface()).Render("◇ Agent")
 	model := m.agentHeaderBadge(nonEmpty(modelName, "no model"), p.SurfaceAlt(), p.Text())
 	status := m.renderAgentStatusBadge(chat.Status)
 	parts := []string{title}
 	if provider != "" {
-		parts = append(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(provider))
+		parts = append(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Render(provider))
 	}
 	parts = append(parts, model, status)
 	if chat.ThinkingLevel != "" {
-		parts = append(parts, m.agentHeaderBadge("thinking "+chat.ThinkingLevel, m.editorBackground(), p.Muted()))
+		parts = append(parts, m.agentHeaderBadge("thinking "+chat.ThinkingLevel, m.agentSurface(), p.Muted()))
 	}
-	content := strings.Join(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("  "))
+	content := strings.Join(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Render("  "))
 	return base.Render(fitStyled(content, width))
 }
 
@@ -197,10 +201,9 @@ func (m Model) agentHeaderBadge(text string, bg color.Color, fg color.Color) str
 }
 
 func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, rightWidth int, height int) []string {
-	p := m.palette()
-	separator := lipgloss.NewStyle().Background(m.editorBackground()).Render(strings.Repeat(" ", agentColumnGap()))
-	blankLeft := lipgloss.NewStyle().Background(p.EditorSurface()).Width(leftWidth).Render(strings.Repeat(" ", leftWidth))
-	blankRight := lipgloss.NewStyle().Background(m.editorBackground()).Width(rightWidth).Render(strings.Repeat(" ", rightWidth))
+	separator := lipgloss.NewStyle().Background(m.agentSurface()).Render(strings.Repeat(" ", agentColumnGap()))
+	blankLeft := lipgloss.NewStyle().Background(m.agentSurface()).Width(leftWidth).Render(strings.Repeat(" ", leftWidth))
+	blankRight := lipgloss.NewStyle().Background(m.agentSurface()).Width(rightWidth).Render(strings.Repeat(" ", rightWidth))
 	out := make([]string, 0, height)
 	for row := 0; row < height; row++ {
 		leftLine := lineAt(left, row)
@@ -258,21 +261,21 @@ func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget
 
 func (m Model) renderAgentDetailFrame(kind string, title string, width int) string {
 	p := m.palette()
-	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground())
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
+	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.agentSurface())
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface())
 	inner := max(width-2, 0)
 	if kind == "bottom" {
 		return border.Render("╰" + strings.Repeat("─", inner) + "╯")
 	}
 	titleText := " " + title + " "
 	line := "╭" + titleStyle.Render(titleText) + border.Render(strings.Repeat("─", max(inner-lipgloss.Width(titleText), 0))+"╮")
-	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))
+	return lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width))
 }
 
 func (m Model) renderAgentDetailsSection(label string, width int) string {
 	p := m.palette()
-	line := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground()).Render("─")
-	text := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" " + label + " ")
+	line := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.agentSurface()).Render("─")
+	text := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.agentSurface()).Render(" " + label + " ")
 	remaining := max(width-lipgloss.Width(label)-4, 0)
 	return m.renderAgentDetailContentLine(text+strings.Repeat(line, remaining), width)
 }
@@ -280,8 +283,8 @@ func (m Model) renderAgentDetailsSection(label string, width int) string {
 func (m Model) renderAgentDetailRow(label string, value string, width int) string {
 	p := m.palette()
 	labelWidth := min(max(width/3, 8), 10)
-	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Width(labelWidth)
-	valueStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
+	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Width(labelWidth)
+	valueStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface())
 	prefix := labelStyle.Render(label)
 	body := valueStyle.Render(firstCompactLine(value, max(width-labelWidth-4, 8)))
 	return m.renderAgentDetailContentLine(prefix+" "+body, width)
@@ -289,17 +292,17 @@ func (m Model) renderAgentDetailRow(label string, value string, width int) strin
 
 func (m Model) renderAgentDetailHint(key string, action string, width int) string {
 	p := m.palette()
-	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
-	actionStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface())
+	actionStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface())
 	line := keyStyle.Render(key) + actionStyle.Render("  "+action)
 	return m.renderAgentDetailContentLine(line, width)
 }
 
 func (m Model) renderAgentDetailContentLine(content string, width int) string {
 	p := m.palette()
-	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground())
+	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.agentSurface())
 	bodyWidth := max(width-2, 1)
-	body := lipgloss.NewStyle().Background(m.editorBackground()).Width(bodyWidth).Render(fitStyled(" "+content, bodyWidth))
+	body := lipgloss.NewStyle().Background(m.agentSurface()).Width(bodyWidth).Render(fitStyled(" "+content, bodyWidth))
 	return border.Render("│") + body + border.Render("│")
 }
 
@@ -465,11 +468,11 @@ func (m Model) renderAgentSystemMessage(msg protocol.AgentChatMessage, width int
 		markerColor = p.Diagnostic(0)
 		textColor = p.Text()
 	}
-	markerText := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render(marker)
-	labelText := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render(" " + label)
-	body := lipgloss.NewStyle().Foreground(textColor).Background(m.editorBackground()).Render("  " + firstCompactLine(msg.Text, max(width-lipgloss.Width(label)-8, 8)))
+	markerText := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.agentSurface()).Render(marker)
+	labelText := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.agentSurface()).Render(" " + label)
+	body := lipgloss.NewStyle().Foreground(textColor).Background(m.agentSurface()).Render("  " + firstCompactLine(msg.Text, max(width-lipgloss.Width(label)-8, 8)))
 	line := "  " + markerText + labelText + body
-	return []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))}
+	return []string{lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width))}
 }
 
 func (m Model) renderAgentUserMessage(msg protocol.AgentChatMessage, width int) []string {
@@ -478,12 +481,12 @@ func (m Model) renderAgentUserMessage(msg protocol.AgentChatMessage, width int) 
 	if len(lines) == 0 {
 		lines = []string{""}
 	}
-	header := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render("  ❯ You")
-	out := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface()).Render("  ❯ You")
+	out := []string{lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(header, width))}
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface())
 	for _, bodyLine := range lines {
 		line := bodyStyle.Render("    " + firstCompactLine(bodyLine, max(width-6, 8)))
-		out = append(out, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
+		out = append(out, lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width)))
 	}
 	return out
 }
@@ -494,13 +497,13 @@ func (m Model) renderAgentAssistantMessage(msg protocol.AgentChatMessage, width 
 	if len(lines) == 0 {
 		lines = []string{""}
 	}
-	header := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(m.editorBackground()).Render("  ◇ Minga")
-	out := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
-	rail := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("  │ ")
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(m.agentSurface()).Render("  ◇ Minga")
+	out := []string{lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(header, width))}
+	rail := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Render("  │ ")
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface())
 	for _, bodyLine := range lines {
 		line := rail + bodyStyle.Render(firstCompactLine(bodyLine, max(width-5, 8)))
-		out = append(out, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
+		out = append(out, lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width)))
 	}
 	return out
 }
@@ -519,14 +522,14 @@ func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width i
 	if !msg.Collapsed {
 		marker = m.agentSpinner()
 	}
-	markerStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Bold(true)
-	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Italic(true)
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
+	markerStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Bold(true)
+	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Italic(true)
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface())
 	header := "  " + markerStyle.Render(marker) + labelStyle.Render(" Thinking "+state)
-	lines := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
+	lines := []string{lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(header, width))}
 	for _, bodyLine := range compactTextLines(text, max(width-8, 8), 1) {
 		line := bodyStyle.Render("    " + firstCompactLine(bodyLine, max(width-6, 8)))
-		lines = append(lines, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
+		lines = append(lines, lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width)))
 	}
 	return lines
 }
@@ -537,7 +540,7 @@ func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) 
 	name := nonEmpty(msg.Name, "tool")
 	presentation := agentToolPresentationFor(name)
 	summary := nonEmpty(msg.Summary, msg.Text)
-	surface := m.editorBackground()
+	surface := m.agentSurface()
 	status := lipgloss.NewStyle().Bold(true).Foreground(statusColor).Background(surface).Render(statusIcon)
 	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(surface).Render(presentation.Icon + " " + presentation.Title)
 	rawName := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(name)
@@ -621,16 +624,16 @@ func agentToolMeta(msg protocol.AgentChatMessage) string {
 
 func (m Model) renderAgentToolBody(label string, text string, width int) string {
 	p := m.palette()
-	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(m.editorBackground())
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(m.agentSurface())
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface())
 	body := firstCompactLine(text, max(width-lipgloss.Width(label)-9, 8))
 	line := "  │  " + labelStyle.Render(label+":") + bodyStyle.Render(" "+body)
-	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))
+	return lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width))
 }
 
 func (m Model) renderAgentApprovalMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
-	surface := m.editorBackground()
+	surface := m.agentSurface()
 	header := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(surface).Render("  ◆ Approval")
 	name := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(surface).Render(" " + nonEmpty(msg.Name, "tool"))
 	kind := lipgloss.NewStyle().Foreground(p.Accent()).Background(surface).Render(" · " + approvalPreviewKindName(msg.PreviewKind))
@@ -663,7 +666,7 @@ func (m Model) renderAgentUsageMessage(msg protocol.AgentChatMessage, width int)
 	if usage.CostMicros > 0 {
 		text += fmt.Sprintf(" · $%.2f", float64(usage.CostMicros)/1_000_000)
 	}
-	return lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Width(width).Render(fitStyled(text, width))
+	return lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Width(width).Render(fitStyled(text, width))
 }
 
 func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string {
@@ -679,17 +682,17 @@ func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string 
 	if chat.Status == 1 || chat.Status == 2 {
 		markerColor = p.Warning()
 	}
-	marker := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render("❯")
-	modeText := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render(mode)
-	promptStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
+	marker := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.agentSurface()).Render("❯")
+	modeText := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface()).Render(mode)
+	promptStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface())
 	if placeholder {
 		promptStyle = promptStyle.Foreground(p.Muted()).Italic(true)
 	}
 	prefix := "  " + marker + " " + modeText + "  "
 	promptText := promptStyle.Render(firstCompactLine(prompt, max(width-lipgloss.Width(prefix)-4, 8)))
-	line := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(prefix+promptText, width))
-	hints := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("    Enter send  ·  Esc normal  ·  / commands  ·  " + cursor)
-	help := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(hints, width))
+	line := lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(prefix+promptText, width))
+	hints := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Render("    Enter send  ·  Esc normal  ·  / commands  ·  " + cursor)
+	help := lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(hints, width))
 	return []string{line, help}
 }
 

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -271,8 +271,8 @@ func (m Model) renderAgentDetailFrame(kind string, title string, width int) stri
 
 func (m Model) renderAgentDetailsSection(label string, width int) string {
 	p := m.palette()
-	line := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(p.PopupSurface()).Render("─")
-	text := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(p.PopupSurface()).Render(" " + label + " ")
+	line := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground()).Render("─")
+	text := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" " + label + " ")
 	remaining := max(width-lipgloss.Width(label)-4, 0)
 	return m.renderAgentDetailContentLine(text+strings.Repeat(line, remaining), width)
 }
@@ -280,8 +280,8 @@ func (m Model) renderAgentDetailsSection(label string, width int) string {
 func (m Model) renderAgentDetailRow(label string, value string, width int) string {
 	p := m.palette()
 	labelWidth := min(max(width/3, 8), 10)
-	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupSurface()).Width(labelWidth)
-	valueStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.PopupSurface())
+	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Width(labelWidth)
+	valueStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
 	prefix := labelStyle.Render(label)
 	body := valueStyle.Render(firstCompactLine(value, max(width-labelWidth-4, 8)))
 	return m.renderAgentDetailContentLine(prefix+" "+body, width)
@@ -289,17 +289,17 @@ func (m Model) renderAgentDetailRow(label string, value string, width int) strin
 
 func (m Model) renderAgentDetailHint(key string, action string, width int) string {
 	p := m.palette()
-	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.SelectionText()).Background(p.Selection()).Padding(0, 1)
-	actionStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupSurface())
-	line := keyStyle.Render(key) + actionStyle.Render(" "+action)
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
+	actionStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
+	line := keyStyle.Render(key) + actionStyle.Render("  "+action)
 	return m.renderAgentDetailContentLine(line, width)
 }
 
 func (m Model) renderAgentDetailContentLine(content string, width int) string {
 	p := m.palette()
-	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(p.PopupSurface())
+	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground())
 	bodyWidth := max(width-2, 1)
-	body := lipgloss.NewStyle().Background(p.PopupSurface()).Width(bodyWidth).Render(fitStyled(" "+content, bodyWidth))
+	body := lipgloss.NewStyle().Background(m.editorBackground()).Width(bodyWidth).Render(fitStyled(" "+content, bodyWidth))
 	return border.Render("│") + body + border.Render("│")
 }
 
@@ -458,13 +458,12 @@ func (m Model) renderAgentSystemMessage(msg protocol.AgentChatMessage, width int
 	label := "System"
 	rail := "i"
 	railColor := p.Accent()
-	surface := p.SurfaceAlt()
 	if msg.Status == 1 || strings.Contains(strings.ToLower(msg.Text), "error") || strings.Contains(strings.ToLower(msg.Text), "couldn't authenticate") {
 		label = "Needs attention"
 		rail = "!"
 		railColor = p.Diagnostic(0)
 	}
-	return m.renderAgentCard(agentCardSpec{Label: label, Rail: rail, RailColor: railColor, Lines: compactTextLines(msg.Text, max(width-16, 8), 2), Width: width, Surface: surface})
+	return m.renderAgentCard(agentCardSpec{Label: label, Rail: rail, RailColor: railColor, Lines: compactTextLines(msg.Text, max(width-16, 8), 2), Width: width})
 }
 
 func (m Model) renderAgentTextMessage(label string, text string, fg color.Color, width int, maxLines int) []string {
@@ -472,13 +471,13 @@ func (m Model) renderAgentTextMessage(label string, text string, fg color.Color,
 	if len(parts) == 0 {
 		parts = []string{""}
 	}
-	return m.renderAgentCard(agentCardSpec{Label: label, Rail: "▌", RailColor: fg, Lines: parts, Width: width, Surface: m.palette().EditorSurface()})
+	return m.renderAgentCard(agentCardSpec{Label: label, Rail: "▌", RailColor: fg, Lines: parts, Width: width})
 }
 
 func (m Model) renderAgentCard(spec agentCardSpec) []string {
 	p := m.palette()
 	width := max(spec.Width, 1)
-	surface := spec.Surface
+	surface := m.editorBackground()
 	railColor := spec.RailColor
 	if railColor == nil {
 		railColor = p.Accent()
@@ -506,7 +505,6 @@ type agentCardSpec struct {
 	RailColor color.Color
 	Lines     []string
 	Width     int
-	Surface   color.Color
 }
 
 func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width int) []string {
@@ -524,7 +522,7 @@ func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width i
 	if !msg.Collapsed {
 		rail = m.agentSpinner()
 	}
-	return m.renderAgentCard(agentCardSpec{Label: label, Meta: meta, Rail: rail, RailColor: p.Muted(), Lines: compactTextLines(text, max(width-16, 8), 2), Width: width, Surface: p.SurfaceAlt()})
+	return m.renderAgentCard(agentCardSpec{Label: label, Meta: meta, Rail: rail, RailColor: p.Muted(), Lines: compactTextLines(text, max(width-16, 8), 2), Width: width})
 }
 
 func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) []string {
@@ -533,7 +531,7 @@ func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) 
 	name := nonEmpty(msg.Name, "tool")
 	presentation := agentToolPresentationFor(name)
 	summary := nonEmpty(msg.Summary, msg.Text)
-	surface := p.SurfaceAlt()
+	surface := m.editorBackground()
 	status := lipgloss.NewStyle().Bold(true).Foreground(statusColor).Background(surface).Render(statusIcon)
 	title := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(surface).Render(" " + presentation.Icon + " " + presentation.Title)
 	rawName := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(" " + name)
@@ -614,23 +612,24 @@ func agentToolMeta(msg protocol.AgentChatMessage) string {
 
 func (m Model) renderAgentToolBody(label string, text string, width int) string {
 	p := m.palette()
-	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(p.SurfaceAlt())
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt())
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(m.editorBackground())
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
 	body := firstCompactLine(text, max(width-lipgloss.Width(label)-4, 8))
 	line := labelStyle.Render("  "+label) + bodyStyle.Render("  "+body)
-	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(line, width))
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))
 }
 
 func (m Model) renderAgentApprovalMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
-	header := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(p.SurfaceAlt()).Render("◆ Approval")
-	name := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(p.SurfaceAlt()).Render(" " + nonEmpty(msg.Name, "tool"))
-	kind := lipgloss.NewStyle().Foreground(p.Accent()).Background(p.SurfaceAlt()).Render(" " + approvalPreviewKindName(msg.PreviewKind))
-	summary := lipgloss.NewStyle().Foreground(p.Text()).Background(p.SurfaceAlt()).Render("  " + firstCompactLine(msg.Summary, max(width-lipgloss.Width(header)-lipgloss.Width(name)-lipgloss.Width(kind)-3, 8)))
-	lines := []string{lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(header+name+kind+summary, width))}
+	surface := m.editorBackground()
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(surface).Render("◆ Approval")
+	name := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(surface).Render(" " + nonEmpty(msg.Name, "tool"))
+	kind := lipgloss.NewStyle().Foreground(p.Accent()).Background(surface).Render(" " + approvalPreviewKindName(msg.PreviewKind))
+	summary := lipgloss.NewStyle().Foreground(p.Text()).Background(surface).Render("  " + firstCompactLine(msg.Summary, max(width-lipgloss.Width(header)-lipgloss.Width(name)-lipgloss.Width(kind)-3, 8)))
+	lines := []string{lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(header+name+kind+summary, width))}
 	for _, previewLine := range msg.PreviewLines[:min(len(msg.PreviewLines), 2)] {
-		preview := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt()).Render("  " + firstCompactLine(previewLine, max(width-2, 8)))
-		lines = append(lines, lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(preview, width)))
+		preview := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render("  " + firstCompactLine(previewLine, max(width-2, 8)))
+		lines = append(lines, lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(preview, width)))
 	}
 	return lines
 }

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -28,12 +28,24 @@ func (m Model) renderAgentChatPanel(chat protocol.AgentChat) []string {
 func (m Model) renderAgentChatBody(chat protocol.AgentChat) []string {
 	width := max(m.width, 1)
 	limit := m.bodyHeight()
-	lines := m.renderAgentChatPanelWithLimit(chat, width, limit)
+	contentWidth := max(width-2, 1)
+	lines := m.renderAgentChatPanelWithLimit(chat, contentWidth, limit)
 	blank := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(strings.Repeat(" ", width))
+	for index, line := range lines {
+		lines[index] = m.insetAgentLine(line, width)
+	}
 	for len(lines) < limit {
 		lines = append(lines, blank)
 	}
 	return takeLines(lines, limit)
+}
+
+func (m Model) insetAgentLine(line string, width int) string {
+	if width <= 1 {
+		return line
+	}
+	inset := lipgloss.NewStyle().Background(m.editorBackground()).Render(" ")
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(inset+line, width))
 }
 
 func (m Model) renderAgentChatPanelWithLimit(chat protocol.AgentChat, width int, limit int) []string {
@@ -44,7 +56,7 @@ func (m Model) renderAgentChatPanelWithLimit(chat protocol.AgentChat, width int,
 	if agentDetailsVisible(width) && limit > 5 {
 		bodyBudget := limit - 1
 		detailWidth := agentDetailsWidth(width)
-		leftWidth := max(width-detailWidth-1, 40)
+		leftWidth := max(width-detailWidth-agentColumnGap(), 40)
 		left := m.renderAgentMainColumn(chat, leftWidth, bodyBudget, empty)
 		right := m.renderAgentDetailsRail(chat, detailWidth, bodyBudget)
 		lines = append(lines, m.joinAgentColumns(left, right, leftWidth, detailWidth, bodyBudget)...)
@@ -64,7 +76,11 @@ func agentDetailsVisible(width int) bool {
 }
 
 func agentDetailsWidth(width int) int {
-	return min(max(width/4, 28), 36)
+	return min(max(width/5, 24), 30)
+}
+
+func agentColumnGap() int {
+	return 3
 }
 
 func (m Model) renderAgentMainColumn(chat protocol.AgentChat, width int, budget int, empty bool) []string {
@@ -72,23 +88,34 @@ func (m Model) renderAgentMainColumn(chat protocol.AgentChat, width int, budget 
 	composer := m.renderAgentComposer(chat, width)
 	composerHeight := min(len(composer), max(budget, 0))
 	transcriptBudget := max(budget-composerHeight, 0)
-	if chat.Pending != "" && len(lines) < transcriptBudget {
+	statusHeight := 0
+	if transcriptBudget >= 4 {
+		statusHeight = 1
+	}
+	contentBudget := max(transcriptBudget-statusHeight, 0)
+	sparse := len(chat.Messages) <= 1 && chat.Pending == "" && strings.TrimSpace(chat.Prompt) == ""
+	if chat.Pending != "" && len(lines) < contentBudget {
 		lines = append(lines, m.renderAgentNotice("◆ approval", chat.Pending, width))
 	}
 
-	if len(lines) < transcriptBudget {
+	if len(lines) < contentBudget {
 		lines = append(lines, m.renderAgentTranscriptHeader(width))
 	}
 
-	messageLines := m.renderAgentTranscriptTail(chat, max(transcriptBudget-len(lines), 0), width)
+	messageLines := m.renderAgentTranscriptTail(chat, max(contentBudget-len(lines), 0), width)
 	lines = append(lines, messageLines...)
 
-	if empty && len(lines) < transcriptBudget {
-		lines = append(lines, takeLines(m.renderAgentEmptyState(width), max(transcriptBudget-len(lines), 0))...)
+	if empty && len(lines) < contentBudget {
+		lines = append(lines, takeLines(m.renderAgentEmptyState(width), max(contentBudget-len(lines), 0))...)
+	} else if sparse && len(lines) < contentBudget {
+		lines = append(lines, takeLines(m.renderAgentLandingState(width), max(contentBudget-len(lines), 0))...)
 	}
 
-	for len(lines) < transcriptBudget {
+	for len(lines) < contentBudget {
 		lines = append(lines, m.renderAgentBlankLine(width))
+	}
+	if statusHeight > 0 {
+		lines = append(lines, m.renderAgentTranscriptStatus(chat, width))
 	}
 	lines = append(lines, composer[:composerHeight]...)
 	return takeLines(lines, budget)
@@ -105,27 +132,57 @@ func (m Model) renderAgentTranscriptHeader(width int) string {
 	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(label+rule, width))
 }
 
+func (m Model) renderAgentTranscriptStatus(chat protocol.AgentChat, width int) string {
+	p := m.palette()
+	messageCount := len(chat.Messages)
+	label := "messages"
+	if messageCount == 1 {
+		label = "message"
+	}
+	status := fmt.Sprintf(" %d %s · %s", messageCount, label, agentChatStatusLabel(chat.Status))
+	if chat.ThinkingLevel != "" {
+		status += " · thinking " + chat.ThinkingLevel
+	}
+	return lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Width(width).Render(fit(status, width))
+}
+
+func (m Model) renderAgentLandingState(width int) []string {
+	p := m.palette()
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
+	return []string{
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(titleStyle.Render(" Try asking Minga"), width)),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(bodyStyle.Render("   • explain this file   • find failing tests   • draft an implementation plan"), width)),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(bodyStyle.Render("   • edit the current buffer   • run a command   • review recent changes"), width)),
+	}
+}
+
 func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {
 	p := m.palette()
-	base := lipgloss.NewStyle().Foreground(p.Text()).Background(p.Base()).Width(width)
-	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(p.Base()).Render("◇ Agent")
-	model := chat.ModelName
-	if model == "" {
-		model = "no model selected"
-	}
-	model = lipgloss.NewStyle().Foreground(p.Text()).Background(p.Base()).Render(model)
+	base := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Width(width)
+	provider, modelName := splitAgentModelName(chat.ModelName)
+	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render("◇ Agent")
+	model := m.agentHeaderBadge(nonEmpty(modelName, "no model"), p.SurfaceAlt(), p.Text())
 	status := m.renderAgentStatusBadge(chat.Status)
-	parts := []string{title, model, status}
-	if chat.ThinkingLevel != "" {
-		parts = append(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(p.Base()).Render("thinking "+chat.ThinkingLevel))
+	parts := []string{title}
+	if provider != "" {
+		parts = append(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(provider))
 	}
-	content := strings.Join(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(p.Base()).Render("  •  "))
+	parts = append(parts, model, status)
+	if chat.ThinkingLevel != "" {
+		parts = append(parts, m.agentHeaderBadge("thinking "+chat.ThinkingLevel, m.editorBackground(), p.Muted()))
+	}
+	content := strings.Join(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("  "))
 	return base.Render(fitStyled(content, width))
+}
+
+func (m Model) agentHeaderBadge(text string, bg color.Color, fg color.Color) string {
+	return lipgloss.NewStyle().Foreground(fg).Background(bg).Padding(0, 1).Render(text)
 }
 
 func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, rightWidth int, height int) []string {
 	p := m.palette()
-	separator := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Render("│")
+	separator := lipgloss.NewStyle().Background(m.editorBackground()).Render(strings.Repeat(" ", agentColumnGap()))
 	blankLeft := lipgloss.NewStyle().Background(p.EditorSurface()).Width(leftWidth).Render(strings.Repeat(" ", leftWidth))
 	blankRight := lipgloss.NewStyle().Background(m.editorBackground()).Width(rightWidth).Render(strings.Repeat(" ", rightWidth))
 	out := make([]string, 0, height)
@@ -145,7 +202,7 @@ func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, ri
 
 func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget int) []string {
 	p := m.palette()
-	head := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(p.SurfaceAlt()).Width(width).Render(fit(" ◇ Session", width))
+	head := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Width(width).Render(fit("◇ Session", width))
 	provider, model := splitAgentModelName(chat.ModelName)
 	lines := []string{head}
 	lines = append(lines, m.renderAgentDetailRow("Provider", nonEmpty(provider, "unknown"), width))
@@ -194,16 +251,17 @@ func (m Model) renderAgentDetailsSection(label string, width int) string {
 
 func (m Model) renderAgentDetailRow(label string, value string, width int) string {
 	p := m.palette()
-	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt())
+	labelWidth := min(max(width/3, 8), 10)
+	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt()).Width(labelWidth)
 	valueStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.SurfaceAlt())
-	prefix := labelStyle.Render(" " + label + " ")
-	body := valueStyle.Render(firstCompactLine(value, max(width-lipgloss.Width(label)-3, 8)))
-	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(prefix+body, width))
+	prefix := labelStyle.Render(label)
+	body := valueStyle.Render(firstCompactLine(value, max(width-labelWidth-1, 8)))
+	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(" "+prefix+" "+body, width))
 }
 
 func (m Model) renderAgentDetailHint(key string, action string, width int) string {
 	p := m.palette()
-	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.SelectionText()).Background(p.Selection()).Padding(0, 1)
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(p.SurfaceAlt()).Padding(0, 1)
 	actionStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt())
 	line := " " + keyStyle.Render(key) + actionStyle.Render(" "+action)
 	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(line, width))

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -659,52 +659,29 @@ func (m Model) renderAgentUsageMessage(msg protocol.AgentChatMessage, width int)
 
 func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string {
 	p := m.palette()
-	margin := 0
-	composerWidth := width
-	if width >= 72 {
-		margin = 2
-		composerWidth = max(width-(margin*2), 1)
-	}
-	innerWidth := max(composerWidth-2, 1)
-	borderColor := p.Accent()
-	if chat.Status == 1 || chat.Status == 2 {
-		if m.agentAnimationFrame%2 == 1 {
-			borderColor = p.Warning()
-		}
-	}
-	border := lipgloss.NewStyle().Foreground(borderColor).Background(m.editorBackground())
-	lineStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.PopupSurface())
-	topTitle := border.Render("╭─ Composer ")
-	topRule := border.Render(strings.Repeat("─", max(composerWidth-lipgloss.Width(topTitle)-1, 0)) + "╮")
 	prompt := strings.TrimRight(chat.Prompt, "\n")
 	placeholder := prompt == ""
 	if placeholder {
 		prompt = "Ask Minga to edit, explain, search, or run tools"
 	}
-	promptStyle := lineStyle
+	mode := agentPromptModeName(chat.PromptVimMode)
+	cursor := fmt.Sprintf("%d:%d", int(chat.PromptCursorLine)+1, int(chat.PromptCursorCol)+1)
+	markerColor := p.Accent()
+	if chat.Status == 1 || chat.Status == 2 {
+		markerColor = p.Warning()
+	}
+	marker := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render("❯")
+	modeText := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render(mode)
+	promptStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
 	if placeholder {
 		promptStyle = promptStyle.Foreground(p.Muted()).Italic(true)
 	}
-	mode := agentPromptModeName(chat.PromptVimMode)
-	modeBadge := lipgloss.NewStyle().Bold(true).Foreground(p.SelectionText()).Background(p.Selection()).Padding(0, 1).Render(mode)
-	cursor := fmt.Sprintf("%d:%d", int(chat.PromptCursorLine)+1, int(chat.PromptCursorCol)+1)
-	inputText := promptStyle.Render(firstCompactLine(prompt, max(innerWidth-lipgloss.Width(modeBadge)-4, 8)))
-	input := border.Render("│") + lineStyle.Render(" ") + modeBadge + lineStyle.Render("  ") + inputText
-	input += lineStyle.Render(strings.Repeat(" ", max(composerWidth-lipgloss.Width(input)-1, 0))) + border.Render("│")
-	hints := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(" Enter send  •  Esc normal  •  / commands  •  " + cursor)
-	bottom := border.Render("╰─") + hints + border.Render(strings.Repeat("─", max(composerWidth-2-lipgloss.Width(hints), 0))+"╯")
-	return []string{
-		m.renderAgentInsetBlockLine(topTitle+topRule, width, margin, m.editorBackground()),
-		m.renderAgentInsetBlockLine(input, width, margin, p.PopupSurface()),
-		m.renderAgentInsetBlockLine(bottom, width, margin, m.editorBackground()),
-	}
-}
-
-func (m Model) renderAgentInsetBlockLine(line string, width int, margin int, bg color.Color) string {
-	left := lipgloss.NewStyle().Background(m.editorBackground()).Render(strings.Repeat(" ", max(margin, 0)))
-	contentWidth := max(width-margin, 1)
-	content := lipgloss.NewStyle().Background(bg).Width(contentWidth).Render(fitStyled(line, contentWidth))
-	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(left+content, width))
+	prefix := "  " + marker + " " + modeText + "  "
+	promptText := promptStyle.Render(firstCompactLine(prompt, max(width-lipgloss.Width(prefix)-4, 8)))
+	line := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(prefix+promptText, width))
+	hints := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("    Enter send  ·  Esc normal  ·  / commands  ·  " + cursor)
+	help := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(hints, width))
+	return []string{line, help}
 }
 
 func agentPromptModeName(mode byte) string {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -181,7 +181,7 @@ func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {
 	base := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Width(width)
 	provider, modelName := splitAgentModelName(chat.ModelName)
 	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render("◇ Agent")
-	model := m.agentHeaderBadge(nonEmpty(modelName, "no model"), p.SurfaceAlt(), p.Text())
+	model := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Render("[" + nonEmpty(modelName, "no model") + "]")
 	status := m.renderAgentStatusBadge(chat.Status)
 	parts := []string{title}
 	if provider != "" {
@@ -189,19 +189,15 @@ func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {
 	}
 	parts = append(parts, model, status)
 	if chat.ThinkingLevel != "" {
-		parts = append(parts, m.agentHeaderBadge("thinking "+chat.ThinkingLevel, m.editorBackground(), p.Muted()))
+		parts = append(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("thinking: "+chat.ThinkingLevel))
 	}
 	content := strings.Join(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("  "))
 	return base.Render(fitStyled(content, width))
 }
 
-func (m Model) agentHeaderBadge(text string, bg color.Color, fg color.Color) string {
-	return lipgloss.NewStyle().Foreground(fg).Background(bg).Padding(0, 1).Render(text)
-}
-
 func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, rightWidth int, height int) []string {
 	p := m.palette()
-	separator := lipgloss.NewStyle().Background(m.editorBackground()).Render(strings.Repeat(" ", agentColumnGap()))
+	separator := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground()).Render(" │ ")
 	blankLeft := lipgloss.NewStyle().Background(p.EditorSurface()).Width(leftWidth).Render(strings.Repeat(" ", leftWidth))
 	blankRight := lipgloss.NewStyle().Background(m.editorBackground()).Width(rightWidth).Render(strings.Repeat(" ", rightWidth))
 	out := make([]string, 0, height)
@@ -671,6 +667,9 @@ func (m Model) renderAgentUsageMessage(msg protocol.AgentChatMessage, width int)
 
 func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string {
 	p := m.palette()
+	if width < 4 {
+		return nil
+	}
 	prompt := strings.TrimRight(chat.Prompt, "\n")
 	placeholder := prompt == ""
 	if placeholder {
@@ -682,18 +681,33 @@ func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string 
 	if chat.Status == 1 || chat.Status == 2 {
 		markerColor = p.Warning()
 	}
+	borderColor := p.PopupBorder()
+	if chat.Status == 1 || chat.Status == 2 {
+		borderColor = markerColor
+	}
+	border := lipgloss.NewStyle().Foreground(borderColor).Background(m.editorBackground())
+	title := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" Prompt ")
+	top := border.Render("╭") + title + border.Render(strings.Repeat("─", max(width-2-lipgloss.Width(title), 0))+"╮")
+	innerWidth := max(width-2, 1)
 	marker := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render("❯")
 	modeText := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render(mode)
 	promptStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
 	if placeholder {
 		promptStyle = promptStyle.Foreground(p.Muted()).Italic(true)
 	}
-	prefix := "  " + marker + " " + modeText + "  "
-	promptText := promptStyle.Render(firstCompactLine(prompt, max(width-lipgloss.Width(prefix)-4, 8)))
-	line := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(prefix+promptText, width))
-	hints := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("    Enter send  ·  Esc normal  ·  / commands  ·  " + cursor)
-	help := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(hints, width))
-	return []string{line, help}
+	prefix := " " + marker + " " + modeText + "  "
+	promptText := promptStyle.Render(firstCompactLine(prompt, max(innerWidth-lipgloss.Width(prefix)-1, 8)))
+	input := border.Render("│") + lipgloss.NewStyle().Background(m.editorBackground()).Width(innerWidth).Render(fitStyled(prefix+promptText, innerWidth)) + border.Render("│")
+	hints := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(" Enter send · Esc normal · / commands · " + cursor)
+	help := border.Render("│") + lipgloss.NewStyle().Background(m.editorBackground()).Width(innerWidth).Render(fitStyled(" "+hints, innerWidth)) + border.Render("│")
+	bottom := border.Render("╰" + strings.Repeat("─", max(width-2, 0)) + "╯")
+	style := lipgloss.NewStyle().Background(m.editorBackground()).Width(width)
+	return []string{
+		style.Render(fitStyled(top, width)),
+		style.Render(fitStyled(input, width)),
+		style.Render(fitStyled(help, width)),
+		style.Render(fitStyled(bottom, width)),
+	}
 }
 
 func agentPromptModeName(mode byte) string {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -435,9 +435,9 @@ func (m Model) renderAgentTranscriptTail(chat protocol.AgentChat, budget int, wi
 func (m Model) renderAgentMessage(msg protocol.AgentChatMessage, width int) []string {
 	switch msg.Kind {
 	case agentKindUser:
-		return m.renderAgentTextMessage("You", msg.Text, m.palette().Accent(), width, 2)
+		return m.renderAgentUserMessage(msg, width)
 	case agentKindAssistant, agentKindStyled:
-		return m.renderAgentTextMessage("Assistant", msg.Text, m.palette().Text(), width, 3)
+		return m.renderAgentAssistantMessage(msg, width)
 	case agentKindThinking:
 		return m.renderAgentThinkingMessage(msg, width)
 	case agentKindTool, agentKindStyledTool:
@@ -449,80 +449,86 @@ func (m Model) renderAgentMessage(msg protocol.AgentChatMessage, width int) []st
 	case agentKindUsage:
 		return []string{m.renderAgentUsageMessage(msg, width)}
 	default:
-		return m.renderAgentTextMessage("• Message", msg.Text, m.palette().Muted(), width, 1)
+		return m.renderAgentAssistantMessage(protocol.AgentChatMessage{Text: msg.Text}, width)
 	}
 }
 
 func (m Model) renderAgentSystemMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
 	label := "System"
-	rail := "i"
-	railColor := p.Accent()
+	marker := "i"
+	markerColor := p.Accent()
+	textColor := p.Muted()
 	if msg.Status == 1 || strings.Contains(strings.ToLower(msg.Text), "error") || strings.Contains(strings.ToLower(msg.Text), "couldn't authenticate") {
 		label = "Needs attention"
-		rail = "!"
-		railColor = p.Diagnostic(0)
+		marker = "!"
+		markerColor = p.Diagnostic(0)
+		textColor = p.Text()
 	}
-	return m.renderAgentCard(agentCardSpec{Label: label, Rail: rail, RailColor: railColor, Lines: compactTextLines(msg.Text, max(width-16, 8), 2), Width: width})
+	markerText := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render(marker)
+	labelText := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render(" " + label)
+	body := lipgloss.NewStyle().Foreground(textColor).Background(m.editorBackground()).Render("  " + firstCompactLine(msg.Text, max(width-lipgloss.Width(label)-8, 8)))
+	line := "  " + markerText + labelText + body
+	return []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))}
 }
 
-func (m Model) renderAgentTextMessage(label string, text string, fg color.Color, width int, maxLines int) []string {
-	parts := compactTextLines(text, max(width-16, 8), maxLines)
-	if len(parts) == 0 {
-		parts = []string{""}
-	}
-	return m.renderAgentCard(agentCardSpec{Label: label, Rail: "▌", RailColor: fg, Lines: parts, Width: width})
-}
-
-func (m Model) renderAgentCard(spec agentCardSpec) []string {
+func (m Model) renderAgentUserMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
-	width := max(spec.Width, 1)
-	surface := m.editorBackground()
-	railColor := spec.RailColor
-	if railColor == nil {
-		railColor = p.Accent()
+	lines := compactTextLines(msg.Text, max(width-12, 8), 2)
+	if len(lines) == 0 {
+		lines = []string{""}
 	}
-	railStyle := lipgloss.NewStyle().Bold(true).Foreground(railColor).Background(surface)
-	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(railColor).Background(surface)
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(surface)
-	lines := make([]string, 0, len(spec.Lines)+1)
-	header := railStyle.Render(spec.Rail) + labelStyle.Render(" "+spec.Label)
-	if spec.Meta != "" {
-		header += lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render("  " + spec.Meta)
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render("  ❯ You")
+	out := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
+	for _, bodyLine := range lines {
+		line := bodyStyle.Render("    " + firstCompactLine(bodyLine, max(width-6, 8)))
+		out = append(out, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
 	}
-	lines = append(lines, lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(header, width)))
-	for _, bodyLine := range spec.Lines {
-		line := railStyle.Render(spec.Rail) + bodyStyle.Render("  "+firstCompactLine(bodyLine, max(width-4, 8)))
-		lines = append(lines, lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(line, width)))
-	}
-	return lines
+	return out
 }
 
-type agentCardSpec struct {
-	Label     string
-	Meta      string
-	Rail      string
-	RailColor color.Color
-	Lines     []string
-	Width     int
+func (m Model) renderAgentAssistantMessage(msg protocol.AgentChatMessage, width int) []string {
+	p := m.palette()
+	lines := compactTextLines(msg.Text, max(width-12, 8), 3)
+	if len(lines) == 0 {
+		lines = []string{""}
+	}
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(m.editorBackground()).Render("  ◇ Minga")
+	out := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
+	rail := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("  │ ")
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
+	for _, bodyLine := range lines {
+		line := rail + bodyStyle.Render(firstCompactLine(bodyLine, max(width-5, 8)))
+		out = append(out, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
+	}
+	return out
 }
 
 func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
-	label := "Thinking"
-	meta := "expanded"
+	state := "expanded"
 	if msg.Collapsed {
-		meta = "collapsed"
+		state = "collapsed"
 	}
 	text := msg.Text
 	if text == "" {
 		text = "working through the request"
 	}
-	rail := "⋯"
+	marker := "⋯"
 	if !msg.Collapsed {
-		rail = m.agentSpinner()
+		marker = m.agentSpinner()
 	}
-	return m.renderAgentCard(agentCardSpec{Label: label, Meta: meta, Rail: rail, RailColor: p.Muted(), Lines: compactTextLines(text, max(width-16, 8), 2), Width: width})
+	markerStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Bold(true)
+	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Italic(true)
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
+	header := "  " + markerStyle.Render(marker) + labelStyle.Render(" Thinking "+state)
+	lines := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
+	for _, bodyLine := range compactTextLines(text, max(width-8, 8), 1) {
+		line := bodyStyle.Render("    " + firstCompactLine(bodyLine, max(width-6, 8)))
+		lines = append(lines, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
+	}
+	return lines
 }
 
 func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) []string {
@@ -533,21 +539,24 @@ func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) 
 	summary := nonEmpty(msg.Summary, msg.Text)
 	surface := m.editorBackground()
 	status := lipgloss.NewStyle().Bold(true).Foreground(statusColor).Background(surface).Render(statusIcon)
-	title := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(surface).Render(" " + presentation.Icon + " " + presentation.Title)
-	rawName := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(" " + name)
+	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(surface).Render(presentation.Icon + " " + presentation.Title)
+	rawName := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(name)
 	meta := agentToolMeta(msg)
 	metaText := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(meta)
-	label := lipgloss.NewStyle().Foreground(p.Accent()).Background(surface).Render(presentation.SummaryLabel + ": ")
-	available := max(width-lipgloss.Width(status)-lipgloss.Width(title)-lipgloss.Width(rawName)-lipgloss.Width(metaText)-lipgloss.Width(label)-6, 8)
-	summaryText := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(firstCompactLine(summary, available))
-	line := status + title + rawName + lipgloss.NewStyle().Background(surface).Render("  ") + label + summaryText
+	header := "  ├─ " + status + " " + title + lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(" · ") + rawName
 	if meta != "" {
-		line += lipgloss.NewStyle().Background(surface).Render("  ") + metaText
+		header += lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(" · ") + metaText
 	}
-	lines := []string{lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(line, width))}
+	label := lipgloss.NewStyle().Foreground(p.Accent()).Background(surface).Render(presentation.SummaryLabel + ":")
+	summaryText := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(" " + firstCompactLine(summary, max(width-lipgloss.Width(presentation.SummaryLabel)-9, 8)))
+	body := "  │  " + label + summaryText
+	lines := []string{
+		lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(header, width)),
+		lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(body, width)),
+	}
 	if msg.IsError && msg.Result != "" {
 		lines = append(lines, m.renderAgentToolBody("ERROR", msg.Result, width))
-	} else if !msg.Collapsed && msg.Result != "" && len(lines) < 3 {
+	} else if !msg.Collapsed && msg.Result != "" && len(lines) < 4 {
 		lines = append(lines, m.renderAgentToolBody(presentation.ResultLabel, msg.Result, width))
 	}
 	return lines
@@ -614,21 +623,21 @@ func (m Model) renderAgentToolBody(label string, text string, width int) string 
 	p := m.palette()
 	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(m.editorBackground())
 	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
-	body := firstCompactLine(text, max(width-lipgloss.Width(label)-4, 8))
-	line := labelStyle.Render("  "+label) + bodyStyle.Render("  "+body)
+	body := firstCompactLine(text, max(width-lipgloss.Width(label)-9, 8))
+	line := "  │  " + labelStyle.Render(label+":") + bodyStyle.Render(" "+body)
 	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))
 }
 
 func (m Model) renderAgentApprovalMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
 	surface := m.editorBackground()
-	header := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(surface).Render("◆ Approval")
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(surface).Render("  ◆ Approval")
 	name := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(surface).Render(" " + nonEmpty(msg.Name, "tool"))
-	kind := lipgloss.NewStyle().Foreground(p.Accent()).Background(surface).Render(" " + approvalPreviewKindName(msg.PreviewKind))
+	kind := lipgloss.NewStyle().Foreground(p.Accent()).Background(surface).Render(" · " + approvalPreviewKindName(msg.PreviewKind))
 	summary := lipgloss.NewStyle().Foreground(p.Text()).Background(surface).Render("  " + firstCompactLine(msg.Summary, max(width-lipgloss.Width(header)-lipgloss.Width(name)-lipgloss.Width(kind)-3, 8)))
 	lines := []string{lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(header+name+kind+summary, width))}
 	for _, previewLine := range msg.PreviewLines[:min(len(msg.PreviewLines), 2)] {
-		preview := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render("  " + firstCompactLine(previewLine, max(width-2, 8)))
+		preview := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render("  │  " + firstCompactLine(previewLine, max(width-5, 8)))
 		lines = append(lines, lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(preview, width)))
 	}
 	return lines
@@ -650,11 +659,11 @@ func approvalPreviewKindName(kind byte) string {
 func (m Model) renderAgentUsageMessage(msg protocol.AgentChatMessage, width int) string {
 	p := m.palette()
 	usage := msg.Usage
-	text := fmt.Sprintf("◇ Usage  in %s  out %s", formatAgentTokens(usage.Input), formatAgentTokens(usage.Output))
+	text := fmt.Sprintf("  ◌ Usage · in %s · out %s", formatAgentTokens(usage.Input), formatAgentTokens(usage.Output))
 	if usage.CostMicros > 0 {
-		text += fmt.Sprintf("  $%.2f", float64(usage.CostMicros)/1_000_000)
+		text += fmt.Sprintf(" · $%.2f", float64(usage.CostMicros)/1_000_000)
 	}
-	return lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Width(width).Render(fit(text, width))
+	return lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Width(width).Render(fitStyled(text, width))
 }
 
 func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -69,21 +69,40 @@ func agentDetailsWidth(width int) int {
 
 func (m Model) renderAgentMainColumn(chat protocol.AgentChat, width int, budget int, empty bool) []string {
 	lines := make([]string, 0, budget)
-	if chat.Pending != "" && len(lines) < budget {
+	composer := m.renderAgentComposer(chat, width)
+	composerHeight := min(len(composer), max(budget, 0))
+	transcriptBudget := max(budget-composerHeight, 0)
+	if chat.Pending != "" && len(lines) < transcriptBudget {
 		lines = append(lines, m.renderAgentNotice("◆ approval", chat.Pending, width))
 	}
 
-	messageLines := m.renderAgentTranscriptTail(chat, max(budget-len(lines)-1, 0), width)
+	if len(lines) < transcriptBudget {
+		lines = append(lines, m.renderAgentTranscriptHeader(width))
+	}
+
+	messageLines := m.renderAgentTranscriptTail(chat, max(transcriptBudget-len(lines), 0), width)
 	lines = append(lines, messageLines...)
 
-	if empty && len(lines) < budget-1 {
-		lines = append(lines, takeLines(m.renderAgentEmptyState(width), max(budget-len(lines)-1, 0))...)
+	if empty && len(lines) < transcriptBudget {
+		lines = append(lines, takeLines(m.renderAgentEmptyState(width), max(transcriptBudget-len(lines), 0))...)
 	}
 
-	if len(lines) < budget {
-		lines = append(lines, m.renderAgentPrompt(chat, width))
+	for len(lines) < transcriptBudget {
+		lines = append(lines, m.renderAgentBlankLine(width))
 	}
+	lines = append(lines, composer[:composerHeight]...)
 	return takeLines(lines, budget)
+}
+
+func (m Model) renderAgentBlankLine(width int) string {
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(strings.Repeat(" ", max(width, 1)))
+}
+
+func (m Model) renderAgentTranscriptHeader(width int) string {
+	p := m.palette()
+	label := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" Transcript ")
+	rule := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(strings.Repeat("─", max(width-lipgloss.Width(label), 0)))
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(label+rule, width))
 }
 
 func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {
@@ -108,7 +127,7 @@ func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, ri
 	p := m.palette()
 	separator := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Render("│")
 	blankLeft := lipgloss.NewStyle().Background(p.EditorSurface()).Width(leftWidth).Render(strings.Repeat(" ", leftWidth))
-	blankRight := lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(rightWidth).Render(strings.Repeat(" ", rightWidth))
+	blankRight := lipgloss.NewStyle().Background(m.editorBackground()).Width(rightWidth).Render(strings.Repeat(" ", rightWidth))
 	out := make([]string, 0, height)
 	for row := 0; row < height; row++ {
 		leftLine := lineAt(left, row)
@@ -126,9 +145,11 @@ func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, ri
 
 func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget int) []string {
 	p := m.palette()
-	head := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(p.SurfaceAlt()).Width(width).Render(fit(" Details", width))
+	head := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(p.SurfaceAlt()).Width(width).Render(fit(" ◇ Session", width))
+	provider, model := splitAgentModelName(chat.ModelName)
 	lines := []string{head}
-	lines = append(lines, m.renderAgentDetailRow("Model", nonEmpty(chat.ModelName, "not selected"), width))
+	lines = append(lines, m.renderAgentDetailRow("Provider", nonEmpty(provider, "unknown"), width))
+	lines = append(lines, m.renderAgentDetailRow("Model", nonEmpty(model, "not selected"), width))
 	lines = append(lines, m.renderAgentDetailRow("State", agentChatStatusLabel(chat.Status), width))
 	if chat.ThinkingLevel != "" {
 		lines = append(lines, m.renderAgentDetailRow("Thinking", chat.ThinkingLevel, width))
@@ -145,6 +166,10 @@ func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget
 	}
 	if chat.Pending != "" {
 		lines = append(lines, m.renderAgentDetailRow("Approval", "waiting", width))
+	}
+	if lastAgentError(chat.Messages) != "" {
+		lines = append(lines, m.renderAgentDetailsSection("Needs attention", width))
+		lines = append(lines, m.renderAgentDetailRow("Auth", "run /auth or check API key", width))
 	}
 	if usage, ok := lastAgentUsage(chat.Messages); ok {
 		lines = append(lines, m.renderAgentDetailRow("Context", fmt.Sprintf("%s in · %s out", formatAgentTokens(usage.Input), formatAgentTokens(usage.Output)), width))
@@ -203,6 +228,27 @@ func agentToolCounts(messages []protocol.AgentChatMessage) (int, int, int) {
 	return toolCount, runningTools, erroredTools
 }
 
+func lastAgentError(messages []protocol.AgentChatMessage) string {
+	for index := len(messages) - 1; index >= 0; index-- {
+		msg := messages[index]
+		if msg.Kind == agentKindSystem && msg.Status == 1 && msg.Text != "" {
+			return msg.Text
+		}
+		if msg.IsError && msg.Text != "" {
+			return msg.Text
+		}
+	}
+	return ""
+}
+
+func splitAgentModelName(value string) (string, string) {
+	parts := strings.SplitN(strings.TrimSpace(value), ":", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", strings.TrimSpace(value)
+}
+
 func lastAgentUsage(messages []protocol.AgentChatMessage) (protocol.AgentUsage, bool) {
 	for index := len(messages) - 1; index >= 0; index-- {
 		if messages[index].Kind == agentKindUsage {
@@ -257,27 +303,28 @@ func (m Model) renderAgentTranscriptTail(chat protocol.AgentChat, budget int, wi
 	if budget <= 0 || len(chat.Messages) == 0 {
 		return nil
 	}
-	rendered := make([][]string, 0, len(chat.Messages))
+	blocks := make([][]string, 0, len(chat.Messages))
+	used := 0
 	for i := len(chat.Messages) - 1; i >= 0; i-- {
 		block := m.renderAgentMessage(chat.Messages[i], width)
 		if len(block) == 0 {
 			continue
 		}
-		rendered = append(rendered, block)
-		used := 0
-		for _, part := range rendered {
-			used += len(part)
+		if used > 0 && used+len(block) > budget {
+			break
 		}
+		blocks = append(blocks, block)
+		used += len(block)
 		if used >= budget {
 			break
 		}
 	}
 	lines := make([]string, 0, budget)
-	for i := len(rendered) - 1; i >= 0; i-- {
-		lines = append(lines, rendered[i]...)
+	for i := len(blocks) - 1; i >= 0; i-- {
+		lines = append(lines, blocks[i]...)
 	}
 	if len(lines) > budget {
-		lines = lines[len(lines)-budget:]
+		return lines[:budget]
 	}
 	return lines
 }
@@ -285,9 +332,9 @@ func (m Model) renderAgentTranscriptTail(chat protocol.AgentChat, budget int, wi
 func (m Model) renderAgentMessage(msg protocol.AgentChatMessage, width int) []string {
 	switch msg.Kind {
 	case agentKindUser:
-		return m.renderAgentTextMessage("┃ You", msg.Text, m.palette().Accent(), width, 2)
+		return m.renderAgentTextMessage("You", msg.Text, m.palette().Accent(), width, 2)
 	case agentKindAssistant, agentKindStyled:
-		return m.renderAgentTextMessage("▌ Assistant", msg.Text, m.palette().Text(), width, 3)
+		return m.renderAgentTextMessage("Assistant", msg.Text, m.palette().Text(), width, 3)
 	case agentKindThinking:
 		return m.renderAgentThinkingMessage(msg, width)
 	case agentKindTool, agentKindStyledTool:
@@ -295,7 +342,7 @@ func (m Model) renderAgentMessage(msg protocol.AgentChatMessage, width int) []st
 	case agentKindApprovalTool:
 		return m.renderAgentApprovalMessage(msg, width)
 	case agentKindSystem:
-		return m.renderAgentTextMessage("• System", msg.Text, m.palette().Muted(), width, 1)
+		return m.renderAgentTextMessage("System", msg.Text, m.palette().Muted(), width, 1)
 	case agentKindUsage:
 		return []string{m.renderAgentUsageMessage(msg, width)}
 	default:
@@ -304,39 +351,59 @@ func (m Model) renderAgentMessage(msg protocol.AgentChatMessage, width int) []st
 }
 
 func (m Model) renderAgentTextMessage(label string, text string, fg color.Color, width int, maxLines int) []string {
-	p := m.palette()
-	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(fg).Background(p.EditorSurface())
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.EditorSurface())
-	prefix := labelStyle.Render(label)
-	bodyWidth := max(width-lipgloss.Width(label)-2, 8)
-	parts := compactTextLines(text, bodyWidth, maxLines)
+	parts := compactTextLines(text, max(width-16, 8), maxLines)
 	if len(parts) == 0 {
 		parts = []string{""}
 	}
-	lines := make([]string, 0, len(parts))
-	for index, part := range parts {
-		left := prefix
-		if index > 0 {
-			left = labelStyle.Render(strings.Repeat(" ", lipgloss.Width(label)))
-		}
-		line := left + bodyStyle.Render("  "+part)
-		lines = append(lines, lipgloss.NewStyle().Background(p.EditorSurface()).Width(width).Render(fitStyled(line, width)))
+	return m.renderAgentCard(agentCardSpec{Label: label, Rail: "▌", RailColor: fg, Lines: parts, Width: width, Surface: m.palette().EditorSurface()})
+}
+
+func (m Model) renderAgentCard(spec agentCardSpec) []string {
+	p := m.palette()
+	width := max(spec.Width, 1)
+	surface := spec.Surface
+	railColor := spec.RailColor
+	if railColor == nil {
+		railColor = p.Accent()
+	}
+	railStyle := lipgloss.NewStyle().Bold(true).Foreground(railColor).Background(surface)
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(railColor).Background(surface)
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(surface)
+	lines := make([]string, 0, len(spec.Lines)+1)
+	header := railStyle.Render(spec.Rail) + labelStyle.Render(" "+spec.Label)
+	if spec.Meta != "" {
+		header += lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render("  " + spec.Meta)
+	}
+	lines = append(lines, lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(header, width)))
+	for _, bodyLine := range spec.Lines {
+		line := railStyle.Render(spec.Rail) + bodyStyle.Render("  "+firstCompactLine(bodyLine, max(width-4, 8)))
+		lines = append(lines, lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(line, width)))
 	}
 	return lines
 }
 
+type agentCardSpec struct {
+	Label     string
+	Meta      string
+	Rail      string
+	RailColor color.Color
+	Lines     []string
+	Width     int
+	Surface   color.Color
+}
+
 func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
-	label := "⋯ Thinking"
+	label := "Thinking"
+	meta := "expanded"
 	if msg.Collapsed {
-		label = "⋯ Thinking collapsed"
+		meta = "collapsed"
 	}
 	text := msg.Text
 	if text == "" {
 		text = "working through the request"
 	}
-	line := lipgloss.NewStyle().Italic(true).Foreground(p.Muted()).Background(p.SurfaceAlt()).Render(label) + lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt()).Render("  "+firstCompactLine(text, max(width-lipgloss.Width(label)-2, 8)))
-	return []string{lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(line, width))}
+	return m.renderAgentCard(agentCardSpec{Label: label, Meta: meta, Rail: "⋯", RailColor: p.Muted(), Lines: compactTextLines(text, max(width-16, 8), 2), Width: width, Surface: p.SurfaceAlt()})
 }
 
 func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) []string {
@@ -345,19 +412,20 @@ func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) 
 	name := nonEmpty(msg.Name, "tool")
 	presentation := agentToolPresentationFor(name)
 	summary := nonEmpty(msg.Summary, msg.Text)
-	status := lipgloss.NewStyle().Bold(true).Foreground(statusColor).Background(p.EditorSurface()).Render(statusIcon)
-	title := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(p.EditorSurface()).Render(" " + presentation.Icon + " " + presentation.Title)
-	rawName := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Render(" " + name)
+	surface := p.SurfaceAlt()
+	status := lipgloss.NewStyle().Bold(true).Foreground(statusColor).Background(surface).Render(statusIcon)
+	title := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(surface).Render(" " + presentation.Icon + " " + presentation.Title)
+	rawName := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(" " + name)
 	meta := agentToolMeta(msg)
-	metaText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Render(meta)
-	label := lipgloss.NewStyle().Foreground(p.Accent()).Background(p.EditorSurface()).Render(presentation.SummaryLabel + ": ")
+	metaText := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(meta)
+	label := lipgloss.NewStyle().Foreground(p.Accent()).Background(surface).Render(presentation.SummaryLabel + ": ")
 	available := max(width-lipgloss.Width(status)-lipgloss.Width(title)-lipgloss.Width(rawName)-lipgloss.Width(metaText)-lipgloss.Width(label)-6, 8)
-	summaryText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Render(firstCompactLine(summary, available))
-	line := status + title + rawName + lipgloss.NewStyle().Background(p.EditorSurface()).Render("  ") + label + summaryText
+	summaryText := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(firstCompactLine(summary, available))
+	line := status + title + rawName + lipgloss.NewStyle().Background(surface).Render("  ") + label + summaryText
 	if meta != "" {
-		line += lipgloss.NewStyle().Background(p.EditorSurface()).Render("  ") + metaText
+		line += lipgloss.NewStyle().Background(surface).Render("  ") + metaText
 	}
-	lines := []string{lipgloss.NewStyle().Background(p.EditorSurface()).Width(width).Render(fitStyled(line, width))}
+	lines := []string{lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(line, width))}
 	if msg.IsError && msg.Result != "" {
 		lines = append(lines, m.renderAgentToolBody("ERROR", msg.Result, width))
 	} else if !msg.Collapsed && msg.Result != "" && len(lines) < 3 {
@@ -469,15 +537,54 @@ func (m Model) renderAgentUsageMessage(msg protocol.AgentChatMessage, width int)
 	return lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Width(width).Render(fit(text, width))
 }
 
-func (m Model) renderAgentPrompt(chat protocol.AgentChat, width int) string {
+func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string {
 	p := m.palette()
-	prompt := strings.TrimSpace(chat.Prompt)
-	if prompt == "" {
+	innerWidth := max(width-2, 1)
+	border := lipgloss.NewStyle().Foreground(p.Accent()).Background(m.editorBackground())
+	lineStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.Base())
+	topTitle := border.Render("╭─ Composer ")
+	topRule := border.Render(strings.Repeat("─", max(width-lipgloss.Width(topTitle)-1, 0)) + "╮")
+	prompt := strings.TrimRight(chat.Prompt, "\n")
+	placeholder := prompt == ""
+	if placeholder {
 		prompt = "Ask Minga to edit, explain, search, or run tools"
 	}
-	prefix := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(p.Base()).Render("::: ")
-	text := lipgloss.NewStyle().Foreground(p.Text()).Background(p.Base()).Render(firstCompactLine(prompt, max(width-lipgloss.Width(prefix), 8)))
-	return lipgloss.NewStyle().Background(p.Base()).Width(width).Render(fitStyled(prefix+text, width))
+	promptStyle := lineStyle
+	if placeholder {
+		promptStyle = promptStyle.Foreground(p.Muted()).Italic(true)
+	}
+	mode := agentPromptModeName(chat.PromptVimMode)
+	modeBadge := lipgloss.NewStyle().Bold(true).Foreground(p.SelectionText()).Background(p.Selection()).Padding(0, 1).Render(mode)
+	cursor := fmt.Sprintf("%d:%d", int(chat.PromptCursorLine)+1, int(chat.PromptCursorCol)+1)
+	inputText := promptStyle.Render(firstCompactLine(prompt, max(innerWidth-lipgloss.Width(modeBadge)-3, 8)))
+	input := border.Render("│") + lineStyle.Render(" ") + modeBadge + lineStyle.Render(" ") + inputText
+	input += lineStyle.Render(strings.Repeat(" ", max(width-lipgloss.Width(input)-1, 0))) + border.Render("│")
+	hints := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(" Enter send  •  Esc normal  •  / commands  •  " + cursor)
+	bottom := border.Render("╰─") + hints + border.Render(strings.Repeat("─", max(width-2-lipgloss.Width(hints), 0))+"╯")
+	return []string{
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(topTitle+topRule, width)),
+		lipgloss.NewStyle().Background(p.Base()).Width(width).Render(fitStyled(input, width)),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(bottom, width)),
+	}
+}
+
+func agentPromptModeName(mode byte) string {
+	switch mode {
+	case 1:
+		return "INSERT"
+	case 2:
+		return "VISUAL"
+	case 3:
+		return "COMMAND"
+	case 4:
+		return "OP"
+	case 5:
+		return "SEARCH"
+	case 6:
+		return "REPLACE"
+	default:
+		return "NORMAL"
+	}
 }
 
 func (m Model) renderAgentEmptyState(width int) []string {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -22,8 +22,22 @@ const (
 )
 
 func (m Model) renderAgentChatPanel(chat protocol.AgentChat) []string {
+	return m.renderAgentChatPanelWithLimit(chat, max(m.width, 1), m.agentPanelHeight())
+}
+
+func (m Model) renderAgentChatBody(chat protocol.AgentChat) []string {
 	width := max(m.width, 1)
-	limit := m.agentPanelHeight()
+	limit := m.bodyHeight()
+	lines := m.renderAgentChatPanelWithLimit(chat, width, limit)
+	blank := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(strings.Repeat(" ", width))
+	for len(lines) < limit {
+		lines = append(lines, blank)
+	}
+	return takeLines(lines, limit)
+}
+
+func (m Model) renderAgentChatPanelWithLimit(chat protocol.AgentChat, width int, limit int) []string {
+	limit = max(limit, 1)
 	empty := chat.Pending == "" && strings.TrimSpace(chat.Prompt) == "" && len(chat.Messages) == 0
 	lines := []string{m.renderAgentHeader(chat, width)}
 

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -271,11 +271,17 @@ func (m Model) renderAgentStatusBadge(status byte) string {
 	style := lipgloss.NewStyle().Bold(true).Foreground(p.SelectionText()).Background(p.Selection()).Padding(0, 1)
 	switch status {
 	case 1, 2:
+		label = m.agentSpinner() + " " + label
 		style = style.Background(p.Accent())
 	case 3:
 		style = style.Background(p.Diagnostic(0))
 	}
 	return style.Render(label)
+}
+
+func (m Model) agentSpinner() string {
+	frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	return frames[int(m.agentAnimationFrame)%len(frames)]
 }
 
 func agentChatStatusLabel(status byte) string {
@@ -322,6 +328,9 @@ func (m Model) renderAgentTranscriptTail(chat protocol.AgentChat, budget int, wi
 	lines := make([]string, 0, budget)
 	for i := len(blocks) - 1; i >= 0; i-- {
 		lines = append(lines, blocks[i]...)
+		if i > 0 && len(lines) < budget {
+			lines = append(lines, m.renderAgentBlankLine(width))
+		}
 	}
 	if len(lines) > budget {
 		return lines[:budget]
@@ -403,7 +412,11 @@ func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width i
 	if text == "" {
 		text = "working through the request"
 	}
-	return m.renderAgentCard(agentCardSpec{Label: label, Meta: meta, Rail: "⋯", RailColor: p.Muted(), Lines: compactTextLines(text, max(width-16, 8), 2), Width: width, Surface: p.SurfaceAlt()})
+	rail := "⋯"
+	if !msg.Collapsed {
+		rail = m.agentSpinner()
+	}
+	return m.renderAgentCard(agentCardSpec{Label: label, Meta: meta, Rail: rail, RailColor: p.Muted(), Lines: compactTextLines(text, max(width-16, 8), 2), Width: width, Surface: p.SurfaceAlt()})
 }
 
 func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) []string {
@@ -474,7 +487,7 @@ func (m Model) agentToolStatus(msg protocol.AgentChatMessage) (string, color.Col
 	if msg.Status == 1 {
 		return "✓", p.Diagnostic(3)
 	}
-	return "●", p.Warning()
+	return m.agentSpinner(), p.Warning()
 }
 
 func agentToolMeta(msg protocol.AgentChatMessage) string {
@@ -540,7 +553,13 @@ func (m Model) renderAgentUsageMessage(msg protocol.AgentChatMessage, width int)
 func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string {
 	p := m.palette()
 	innerWidth := max(width-2, 1)
-	border := lipgloss.NewStyle().Foreground(p.Accent()).Background(m.editorBackground())
+	borderColor := p.Accent()
+	if chat.Status == 1 || chat.Status == 2 {
+		if m.agentAnimationFrame%2 == 1 {
+			borderColor = p.Warning()
+		}
+	}
+	border := lipgloss.NewStyle().Foreground(borderColor).Background(m.editorBackground())
 	lineStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.Base())
 	topTitle := border.Render("╭─ Composer ")
 	topRule := border.Render(strings.Repeat("─", max(width-lipgloss.Width(topTitle)-1, 0)) + "╮")

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -168,7 +168,9 @@ func (m Model) renderAgentLandingState(width int) []string {
 
 func (m Model) renderAgentSuggestionPill(label string) string {
 	p := m.palette()
-	return lipgloss.NewStyle().Foreground(p.Text()).Background(p.SurfaceAlt()).Padding(0, 1).Render(label)
+	marker := lipgloss.NewStyle().Foreground(p.Accent()).Background(m.editorBackground()).Bold(true).Render("›")
+	text := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Render(label)
+	return marker + " " + text
 }
 
 func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -148,29 +148,32 @@ func (m Model) renderAgentTranscriptStatus(chat protocol.AgentChat, width int) s
 
 func (m Model) renderAgentLandingState(width int) []string {
 	p := m.palette()
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
-	pillRow := strings.Join([]string{
-		m.renderAgentSuggestionPill("Explain this file"),
-		m.renderAgentSuggestionPill("Find failing tests"),
-		m.renderAgentSuggestionPill("Review changes"),
-	}, "  ")
-	pillRowTwo := strings.Join([]string{
-		m.renderAgentSuggestionPill("Edit current buffer"),
-		m.renderAgentSuggestionPill("Run a command"),
-		m.renderAgentSuggestionPill("Draft a plan"),
-	}, "  ")
+	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render("Minga is ready")
+	subtitle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("Ask in plain language, or start with a slash command.")
+	section := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render("Suggested next moves")
 	return []string{
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(titleStyle.Render("Try asking Minga"), width)),
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(pillRow, width)),
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(pillRowTwo, width)),
+		m.renderAgentBlankLine(width),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled("  "+title+"  "+subtitle, width)),
+		m.renderAgentBlankLine(width),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled("  "+section, width)),
+		m.renderAgentSuggestionRow(width, "/explain", "Explain this file", "/tests", "Find failing tests"),
+		m.renderAgentSuggestionRow(width, "/review", "Review changes", "/edit", "Edit current buffer"),
+		m.renderAgentSuggestionRow(width, "/run", "Run a command", "/plan", "Draft a plan"),
 	}
 }
 
-func (m Model) renderAgentSuggestionPill(label string) string {
+func (m Model) renderAgentSuggestionRow(width int, leftCommand string, leftLabel string, rightCommand string, rightLabel string) string {
+	columnWidth := max((width-6)/2, 12)
+	left := m.renderAgentSuggestionAction(leftCommand, leftLabel, columnWidth)
+	right := m.renderAgentSuggestionAction(rightCommand, rightLabel, columnWidth)
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled("  "+left+"  "+right, width))
+}
+
+func (m Model) renderAgentSuggestionAction(command string, label string, width int) string {
 	p := m.palette()
-	marker := lipgloss.NewStyle().Foreground(p.Accent()).Background(m.editorBackground()).Bold(true).Render("›")
-	text := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Render(label)
-	return marker + " " + text
+	cmd := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render(command)
+	text := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Render(" " + firstCompactLine(label, max(width-lipgloss.Width(command)-1, 4)))
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(cmd+text, width))
 }
 
 func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -23,26 +23,53 @@ const (
 
 func (m Model) renderAgentChatPanel(chat protocol.AgentChat) []string {
 	width := max(m.width, 1)
-	limit := m.maxOverlayHeight()
-	lines := []string{m.renderAgentHeader(chat, width)}
+	limit := m.agentPanelHeight()
 	empty := chat.Pending == "" && strings.TrimSpace(chat.Prompt) == "" && len(chat.Messages) == 0
+	lines := []string{m.renderAgentHeader(chat, width)}
 
-	if chat.Pending != "" && len(lines) < limit {
+	if agentDetailsVisible(width) && limit > 5 {
+		bodyBudget := limit - 1
+		detailWidth := agentDetailsWidth(width)
+		leftWidth := max(width-detailWidth-1, 40)
+		left := m.renderAgentMainColumn(chat, leftWidth, bodyBudget, empty)
+		right := m.renderAgentDetailsRail(chat, detailWidth, bodyBudget)
+		lines = append(lines, m.joinAgentColumns(left, right, leftWidth, detailWidth, bodyBudget)...)
+		return takeLines(lines, limit)
+	}
+
+	lines = append(lines, m.renderAgentMainColumn(chat, width, limit-1, empty)...)
+	return takeLines(lines, limit)
+}
+
+func (m Model) agentPanelHeight() int {
+	return min(max(m.height/2, 8), 18)
+}
+
+func agentDetailsVisible(width int) bool {
+	return width >= 104
+}
+
+func agentDetailsWidth(width int) int {
+	return min(max(width/4, 28), 36)
+}
+
+func (m Model) renderAgentMainColumn(chat protocol.AgentChat, width int, budget int, empty bool) []string {
+	lines := make([]string, 0, budget)
+	if chat.Pending != "" && len(lines) < budget {
 		lines = append(lines, m.renderAgentNotice("◆ approval", chat.Pending, width))
 	}
 
-	messageLines := m.renderAgentTranscriptTail(chat, max(limit-len(lines)-1, 0), width)
+	messageLines := m.renderAgentTranscriptTail(chat, max(budget-len(lines)-1, 0), width)
 	lines = append(lines, messageLines...)
 
-	if empty && len(lines) < limit-1 {
-		lines = append(lines, takeLines(m.renderAgentEmptyState(width), max(limit-len(lines)-1, 0))...)
+	if empty && len(lines) < budget-1 {
+		lines = append(lines, takeLines(m.renderAgentEmptyState(width), max(budget-len(lines)-1, 0))...)
 	}
 
-	if len(lines) < limit {
+	if len(lines) < budget {
 		lines = append(lines, m.renderAgentPrompt(chat, width))
 	}
-
-	return takeLines(lines, limit)
+	return takeLines(lines, budget)
 }
 
 func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {
@@ -61,6 +88,121 @@ func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {
 	}
 	content := strings.Join(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(p.Base()).Render("  •  "))
 	return base.Render(fitStyled(content, width))
+}
+
+func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, rightWidth int, height int) []string {
+	p := m.palette()
+	separator := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Render("│")
+	blankLeft := lipgloss.NewStyle().Background(p.EditorSurface()).Width(leftWidth).Render(strings.Repeat(" ", leftWidth))
+	blankRight := lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(rightWidth).Render(strings.Repeat(" ", rightWidth))
+	out := make([]string, 0, height)
+	for row := 0; row < height; row++ {
+		leftLine := lineAt(left, row)
+		if leftLine == "" {
+			leftLine = blankLeft
+		}
+		rightLine := lineAt(right, row)
+		if rightLine == "" {
+			rightLine = blankRight
+		}
+		out = append(out, leftLine+separator+rightLine)
+	}
+	return out
+}
+
+func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget int) []string {
+	p := m.palette()
+	head := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(p.SurfaceAlt()).Width(width).Render(fit(" Details", width))
+	lines := []string{head}
+	lines = append(lines, m.renderAgentDetailRow("Model", nonEmpty(chat.ModelName, "not selected"), width))
+	lines = append(lines, m.renderAgentDetailRow("State", agentChatStatusLabel(chat.Status), width))
+	if chat.ThinkingLevel != "" {
+		lines = append(lines, m.renderAgentDetailRow("Thinking", chat.ThinkingLevel, width))
+	}
+	lines = append(lines, m.renderAgentDetailRow("Messages", fmt.Sprintf("%d", len(chat.Messages)), width))
+
+	toolCount, runningTools, erroredTools := agentToolCounts(chat.Messages)
+	if toolCount > 0 {
+		value := fmt.Sprintf("%d", toolCount)
+		if runningTools > 0 || erroredTools > 0 {
+			value = fmt.Sprintf("%d · %d running · %d errors", toolCount, runningTools, erroredTools)
+		}
+		lines = append(lines, m.renderAgentDetailRow("Tools", value, width))
+	}
+	if chat.Pending != "" {
+		lines = append(lines, m.renderAgentDetailRow("Approval", "waiting", width))
+	}
+	if usage, ok := lastAgentUsage(chat.Messages); ok {
+		lines = append(lines, m.renderAgentDetailRow("Context", fmt.Sprintf("%s in · %s out", formatAgentTokens(usage.Input), formatAgentTokens(usage.Output)), width))
+		if usage.CostMicros > 0 {
+			lines = append(lines, m.renderAgentDetailRow("Cost", fmt.Sprintf("$%.2f", float64(usage.CostMicros)/1_000_000), width))
+		}
+	}
+	lines = append(lines, m.renderAgentDetailsSection("Hints", width))
+	lines = append(lines, m.renderAgentDetailHint("Enter", "send prompt", width))
+	lines = append(lines, m.renderAgentDetailHint("Tab", "complete", width))
+	lines = append(lines, m.renderAgentDetailHint("?", "agent help", width))
+	return takeLines(lines, budget)
+}
+
+func (m Model) renderAgentDetailsSection(label string, width int) string {
+	p := m.palette()
+	line := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt()).Render("─")
+	text := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(p.SurfaceAlt()).Render(" " + label + " ")
+	remaining := max(width-lipgloss.Width(label)-2, 0)
+	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(text+strings.Repeat(line, remaining), width))
+}
+
+func (m Model) renderAgentDetailRow(label string, value string, width int) string {
+	p := m.palette()
+	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt())
+	valueStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.SurfaceAlt())
+	prefix := labelStyle.Render(" " + label + " ")
+	body := valueStyle.Render(firstCompactLine(value, max(width-lipgloss.Width(label)-3, 8)))
+	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(prefix+body, width))
+}
+
+func (m Model) renderAgentDetailHint(key string, action string, width int) string {
+	p := m.palette()
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.SelectionText()).Background(p.Selection()).Padding(0, 1)
+	actionStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt())
+	line := " " + keyStyle.Render(key) + actionStyle.Render(" "+action)
+	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(line, width))
+}
+
+func agentToolCounts(messages []protocol.AgentChatMessage) (int, int, int) {
+	toolCount := 0
+	runningTools := 0
+	erroredTools := 0
+	for _, msg := range messages {
+		if msg.Kind != agentKindTool && msg.Kind != agentKindStyledTool && msg.Kind != agentKindApprovalTool {
+			continue
+		}
+		toolCount++
+		if msg.Status == 0 {
+			runningTools++
+		}
+		if msg.Status == 2 || msg.IsError {
+			erroredTools++
+		}
+	}
+	return toolCount, runningTools, erroredTools
+}
+
+func lastAgentUsage(messages []protocol.AgentChatMessage) (protocol.AgentUsage, bool) {
+	for index := len(messages) - 1; index >= 0; index-- {
+		if messages[index].Kind == agentKindUsage {
+			return messages[index].Usage, true
+		}
+	}
+	return protocol.AgentUsage{}, false
+}
+
+func nonEmpty(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }
 
 func (m Model) renderAgentStatusBadge(status byte) string {
@@ -186,21 +328,18 @@ func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width i
 func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
 	statusIcon, statusColor := m.agentToolStatus(msg)
-	name := msg.Name
-	if name == "" {
-		name = "tool"
-	}
-	summary := msg.Summary
-	if summary == "" {
-		summary = msg.Text
-	}
+	name := nonEmpty(msg.Name, "tool")
+	presentation := agentToolPresentationFor(name)
+	summary := nonEmpty(msg.Summary, msg.Text)
 	status := lipgloss.NewStyle().Bold(true).Foreground(statusColor).Background(p.EditorSurface()).Render(statusIcon)
-	nameText := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(p.EditorSurface()).Render(" Tool " + name)
+	title := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(p.EditorSurface()).Render(" " + presentation.Icon + " " + presentation.Title)
+	rawName := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Render(" " + name)
 	meta := agentToolMeta(msg)
 	metaText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Render(meta)
-	available := max(width-lipgloss.Width(status)-lipgloss.Width(nameText)-lipgloss.Width(metaText)-4, 8)
+	label := lipgloss.NewStyle().Foreground(p.Accent()).Background(p.EditorSurface()).Render(presentation.SummaryLabel + ": ")
+	available := max(width-lipgloss.Width(status)-lipgloss.Width(title)-lipgloss.Width(rawName)-lipgloss.Width(metaText)-lipgloss.Width(label)-6, 8)
 	summaryText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.EditorSurface()).Render(firstCompactLine(summary, available))
-	line := status + nameText + lipgloss.NewStyle().Background(p.EditorSurface()).Render("  ") + summaryText
+	line := status + title + rawName + lipgloss.NewStyle().Background(p.EditorSurface()).Render("  ") + label + summaryText
 	if meta != "" {
 		line += lipgloss.NewStyle().Background(p.EditorSurface()).Render("  ") + metaText
 	}
@@ -208,9 +347,41 @@ func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) 
 	if msg.IsError && msg.Result != "" {
 		lines = append(lines, m.renderAgentToolBody("ERROR", msg.Result, width))
 	} else if !msg.Collapsed && msg.Result != "" && len(lines) < 3 {
-		lines = append(lines, m.renderAgentToolBody("result", msg.Result, width))
+		lines = append(lines, m.renderAgentToolBody(presentation.ResultLabel, msg.Result, width))
 	}
 	return lines
+}
+
+type agentToolPresentation struct {
+	Icon         string
+	Title        string
+	SummaryLabel string
+	ResultLabel  string
+}
+
+func agentToolPresentationFor(name string) agentToolPresentation {
+	switch strings.TrimSpace(name) {
+	case "shell", "bash":
+		return agentToolPresentation{Icon: "", Title: "Shell", SummaryLabel: "cmd", ResultLabel: "output"}
+	case "read_file":
+		return agentToolPresentation{Icon: "󰈙", Title: "Read", SummaryLabel: "path", ResultLabel: "content"}
+	case "write_file":
+		return agentToolPresentation{Icon: "󰈔", Title: "Write", SummaryLabel: "path", ResultLabel: "content"}
+	case "edit_file", "multi_edit_file":
+		return agentToolPresentation{Icon: "󰏫", Title: "Edit", SummaryLabel: "path", ResultLabel: "diff"}
+	case "apply_diff":
+		return agentToolPresentation{Icon: "", Title: "Diff", SummaryLabel: "patch", ResultLabel: "diff"}
+	case "todo":
+		return agentToolPresentation{Icon: "✓", Title: "Todo", SummaryLabel: "task", ResultLabel: "state"}
+	case "subagent":
+		return agentToolPresentation{Icon: "◇", Title: "Subagent", SummaryLabel: "task", ResultLabel: "report"}
+	case "lsp_diagnostics", "lsp_definition", "lsp_references", "lsp_hover", "lsp_rename", "lsp_code_actions", "lsp_workspace_symbols", "lsp_document_symbols":
+		return agentToolPresentation{Icon: "λ", Title: "LSP", SummaryLabel: "query", ResultLabel: "result"}
+	case "git", "git_stage", "git_commit":
+		return agentToolPresentation{Icon: "", Title: "Git", SummaryLabel: "op", ResultLabel: "result"}
+	default:
+		return agentToolPresentation{Icon: "●", Title: "Tool", SummaryLabel: "args", ResultLabel: "result"}
+	}
 }
 
 func (m Model) agentToolStatus(msg protocol.AgentChatMessage) (string, color.Color) {
@@ -250,14 +421,28 @@ func (m Model) renderAgentToolBody(label string, text string, width int) string 
 func (m Model) renderAgentApprovalMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
 	header := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(p.SurfaceAlt()).Render("◆ Approval")
-	name := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(p.SurfaceAlt()).Render(" " + msg.Name)
-	summary := lipgloss.NewStyle().Foreground(p.Text()).Background(p.SurfaceAlt()).Render("  " + firstCompactLine(msg.Summary, max(width-lipgloss.Width(header)-lipgloss.Width(name)-3, 8)))
-	lines := []string{lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(header+name+summary, width))}
-	if len(msg.PreviewLines) > 0 {
-		preview := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt()).Render("  " + firstCompactLine(msg.PreviewLines[0], max(width-2, 8)))
+	name := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(p.SurfaceAlt()).Render(" " + nonEmpty(msg.Name, "tool"))
+	kind := lipgloss.NewStyle().Foreground(p.Accent()).Background(p.SurfaceAlt()).Render(" " + approvalPreviewKindName(msg.PreviewKind))
+	summary := lipgloss.NewStyle().Foreground(p.Text()).Background(p.SurfaceAlt()).Render("  " + firstCompactLine(msg.Summary, max(width-lipgloss.Width(header)-lipgloss.Width(name)-lipgloss.Width(kind)-3, 8)))
+	lines := []string{lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(header+name+kind+summary, width))}
+	for _, previewLine := range msg.PreviewLines[:min(len(msg.PreviewLines), 2)] {
+		preview := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt()).Render("  " + firstCompactLine(previewLine, max(width-2, 8)))
 		lines = append(lines, lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(preview, width)))
 	}
 	return lines
+}
+
+func approvalPreviewKindName(kind byte) string {
+	switch kind {
+	case 1:
+		return "diff"
+	case 2:
+		return "command"
+	case 3:
+		return "target"
+	default:
+		return "args"
+	}
 }
 
 func (m Model) renderAgentUsageMessage(msg protocol.AgentChatMessage, width int) string {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -30,7 +30,7 @@ func (m Model) renderAgentChatBody(chat protocol.AgentChat) []string {
 	limit := m.bodyHeight()
 	contentWidth := max(width-2, 1)
 	lines := m.renderAgentChatPanelWithLimit(chat, contentWidth, limit)
-	blank := lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(strings.Repeat(" ", width))
+	blank := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(strings.Repeat(" ", width))
 	for index, line := range lines {
 		lines[index] = m.insetAgentLine(line, width)
 	}
@@ -44,8 +44,8 @@ func (m Model) insetAgentLine(line string, width int) string {
 	if width <= 1 {
 		return line
 	}
-	inset := lipgloss.NewStyle().Background(m.agentSurface()).Render(" ")
-	return lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(inset+line, width))
+	inset := lipgloss.NewStyle().Background(m.editorBackground()).Render(" ")
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(inset+line, width))
 }
 
 func (m Model) renderAgentChatPanelWithLimit(chat protocol.AgentChat, width int, limit int) []string {
@@ -65,10 +65,6 @@ func (m Model) renderAgentChatPanelWithLimit(chat protocol.AgentChat, width int,
 
 	lines = append(lines, m.renderAgentMainColumn(chat, width, limit-1, empty)...)
 	return takeLines(lines, limit)
-}
-
-func (m Model) agentSurface() color.Color {
-	return m.palette().PopupSurface()
 }
 
 func (m Model) agentPanelHeight() int {
@@ -126,14 +122,14 @@ func (m Model) renderAgentMainColumn(chat protocol.AgentChat, width int, budget 
 }
 
 func (m Model) renderAgentBlankLine(width int) string {
-	return lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(strings.Repeat(" ", max(width, 1)))
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(strings.Repeat(" ", max(width, 1)))
 }
 
 func (m Model) renderAgentTranscriptHeader(width int) string {
 	p := m.palette()
-	label := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.agentSurface()).Render(" Transcript ")
-	rule := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Render(strings.Repeat("─", max(width-lipgloss.Width(label), 0)))
-	return lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(label+rule, width))
+	label := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" Transcript ")
+	rule := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(strings.Repeat("─", max(width-lipgloss.Width(label), 0)))
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(label+rule, width))
 }
 
 func (m Model) renderAgentTranscriptStatus(chat protocol.AgentChat, width int) string {
@@ -147,12 +143,12 @@ func (m Model) renderAgentTranscriptStatus(chat protocol.AgentChat, width int) s
 	if chat.ThinkingLevel != "" {
 		status += " · thinking " + chat.ThinkingLevel
 	}
-	return lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Width(width).Render(fit(status, width))
+	return lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Width(width).Render(fit(status, width))
 }
 
 func (m Model) renderAgentLandingState(width int) []string {
 	p := m.palette()
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface())
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
 	pillRow := strings.Join([]string{
 		m.renderAgentSuggestionPill("Explain this file"),
 		m.renderAgentSuggestionPill("Find failing tests"),
@@ -164,35 +160,35 @@ func (m Model) renderAgentLandingState(width int) []string {
 		m.renderAgentSuggestionPill("Draft a plan"),
 	}, "  ")
 	return []string{
-		lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(titleStyle.Render("Try asking Minga"), width)),
-		lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(pillRow, width)),
-		lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(pillRowTwo, width)),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(titleStyle.Render("Try asking Minga"), width)),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(pillRow, width)),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(pillRowTwo, width)),
 	}
 }
 
 func (m Model) renderAgentSuggestionPill(label string) string {
 	p := m.palette()
-	marker := lipgloss.NewStyle().Foreground(p.Accent()).Background(m.agentSurface()).Bold(true).Render("›")
-	text := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface()).Render(label)
+	marker := lipgloss.NewStyle().Foreground(p.Accent()).Background(m.editorBackground()).Bold(true).Render("›")
+	text := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Render(label)
 	return marker + " " + text
 }
 
 func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {
 	p := m.palette()
-	base := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface()).Width(width)
+	base := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Width(width)
 	provider, modelName := splitAgentModelName(chat.ModelName)
-	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface()).Render("◇ Agent")
+	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render("◇ Agent")
 	model := m.agentHeaderBadge(nonEmpty(modelName, "no model"), p.SurfaceAlt(), p.Text())
 	status := m.renderAgentStatusBadge(chat.Status)
 	parts := []string{title}
 	if provider != "" {
-		parts = append(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Render(provider))
+		parts = append(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(provider))
 	}
 	parts = append(parts, model, status)
 	if chat.ThinkingLevel != "" {
-		parts = append(parts, m.agentHeaderBadge("thinking "+chat.ThinkingLevel, m.agentSurface(), p.Muted()))
+		parts = append(parts, m.agentHeaderBadge("thinking "+chat.ThinkingLevel, m.editorBackground(), p.Muted()))
 	}
-	content := strings.Join(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Render("  "))
+	content := strings.Join(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("  "))
 	return base.Render(fitStyled(content, width))
 }
 
@@ -201,9 +197,10 @@ func (m Model) agentHeaderBadge(text string, bg color.Color, fg color.Color) str
 }
 
 func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, rightWidth int, height int) []string {
-	separator := lipgloss.NewStyle().Background(m.agentSurface()).Render(strings.Repeat(" ", agentColumnGap()))
-	blankLeft := lipgloss.NewStyle().Background(m.agentSurface()).Width(leftWidth).Render(strings.Repeat(" ", leftWidth))
-	blankRight := lipgloss.NewStyle().Background(m.agentSurface()).Width(rightWidth).Render(strings.Repeat(" ", rightWidth))
+	p := m.palette()
+	separator := lipgloss.NewStyle().Background(m.editorBackground()).Render(strings.Repeat(" ", agentColumnGap()))
+	blankLeft := lipgloss.NewStyle().Background(p.EditorSurface()).Width(leftWidth).Render(strings.Repeat(" ", leftWidth))
+	blankRight := lipgloss.NewStyle().Background(m.editorBackground()).Width(rightWidth).Render(strings.Repeat(" ", rightWidth))
 	out := make([]string, 0, height)
 	for row := 0; row < height; row++ {
 		leftLine := lineAt(left, row)
@@ -261,21 +258,21 @@ func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget
 
 func (m Model) renderAgentDetailFrame(kind string, title string, width int) string {
 	p := m.palette()
-	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.agentSurface())
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface())
+	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground())
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
 	inner := max(width-2, 0)
 	if kind == "bottom" {
 		return border.Render("╰" + strings.Repeat("─", inner) + "╯")
 	}
 	titleText := " " + title + " "
 	line := "╭" + titleStyle.Render(titleText) + border.Render(strings.Repeat("─", max(inner-lipgloss.Width(titleText), 0))+"╮")
-	return lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width))
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))
 }
 
 func (m Model) renderAgentDetailsSection(label string, width int) string {
 	p := m.palette()
-	line := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.agentSurface()).Render("─")
-	text := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.agentSurface()).Render(" " + label + " ")
+	line := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground()).Render("─")
+	text := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" " + label + " ")
 	remaining := max(width-lipgloss.Width(label)-4, 0)
 	return m.renderAgentDetailContentLine(text+strings.Repeat(line, remaining), width)
 }
@@ -283,8 +280,8 @@ func (m Model) renderAgentDetailsSection(label string, width int) string {
 func (m Model) renderAgentDetailRow(label string, value string, width int) string {
 	p := m.palette()
 	labelWidth := min(max(width/3, 8), 10)
-	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Width(labelWidth)
-	valueStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface())
+	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Width(labelWidth)
+	valueStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
 	prefix := labelStyle.Render(label)
 	body := valueStyle.Render(firstCompactLine(value, max(width-labelWidth-4, 8)))
 	return m.renderAgentDetailContentLine(prefix+" "+body, width)
@@ -292,17 +289,17 @@ func (m Model) renderAgentDetailRow(label string, value string, width int) strin
 
 func (m Model) renderAgentDetailHint(key string, action string, width int) string {
 	p := m.palette()
-	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface())
-	actionStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface())
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
+	actionStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
 	line := keyStyle.Render(key) + actionStyle.Render("  "+action)
 	return m.renderAgentDetailContentLine(line, width)
 }
 
 func (m Model) renderAgentDetailContentLine(content string, width int) string {
 	p := m.palette()
-	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.agentSurface())
+	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground())
 	bodyWidth := max(width-2, 1)
-	body := lipgloss.NewStyle().Background(m.agentSurface()).Width(bodyWidth).Render(fitStyled(" "+content, bodyWidth))
+	body := lipgloss.NewStyle().Background(m.editorBackground()).Width(bodyWidth).Render(fitStyled(" "+content, bodyWidth))
 	return border.Render("│") + body + border.Render("│")
 }
 
@@ -468,11 +465,11 @@ func (m Model) renderAgentSystemMessage(msg protocol.AgentChatMessage, width int
 		markerColor = p.Diagnostic(0)
 		textColor = p.Text()
 	}
-	markerText := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.agentSurface()).Render(marker)
-	labelText := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.agentSurface()).Render(" " + label)
-	body := lipgloss.NewStyle().Foreground(textColor).Background(m.agentSurface()).Render("  " + firstCompactLine(msg.Text, max(width-lipgloss.Width(label)-8, 8)))
+	markerText := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render(marker)
+	labelText := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render(" " + label)
+	body := lipgloss.NewStyle().Foreground(textColor).Background(m.editorBackground()).Render("  " + firstCompactLine(msg.Text, max(width-lipgloss.Width(label)-8, 8)))
 	line := "  " + markerText + labelText + body
-	return []string{lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width))}
+	return []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))}
 }
 
 func (m Model) renderAgentUserMessage(msg protocol.AgentChatMessage, width int) []string {
@@ -481,12 +478,12 @@ func (m Model) renderAgentUserMessage(msg protocol.AgentChatMessage, width int) 
 	if len(lines) == 0 {
 		lines = []string{""}
 	}
-	header := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface()).Render("  ❯ You")
-	out := []string{lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(header, width))}
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface())
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render("  ❯ You")
+	out := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
 	for _, bodyLine := range lines {
 		line := bodyStyle.Render("    " + firstCompactLine(bodyLine, max(width-6, 8)))
-		out = append(out, lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width)))
+		out = append(out, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
 	}
 	return out
 }
@@ -497,13 +494,13 @@ func (m Model) renderAgentAssistantMessage(msg protocol.AgentChatMessage, width 
 	if len(lines) == 0 {
 		lines = []string{""}
 	}
-	header := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(m.agentSurface()).Render("  ◇ Minga")
-	out := []string{lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(header, width))}
-	rail := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Render("  │ ")
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface())
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(m.editorBackground()).Render("  ◇ Minga")
+	out := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
+	rail := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("  │ ")
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
 	for _, bodyLine := range lines {
 		line := rail + bodyStyle.Render(firstCompactLine(bodyLine, max(width-5, 8)))
-		out = append(out, lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width)))
+		out = append(out, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
 	}
 	return out
 }
@@ -522,14 +519,14 @@ func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width i
 	if !msg.Collapsed {
 		marker = m.agentSpinner()
 	}
-	markerStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Bold(true)
-	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Italic(true)
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface())
+	markerStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Bold(true)
+	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Italic(true)
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
 	header := "  " + markerStyle.Render(marker) + labelStyle.Render(" Thinking "+state)
-	lines := []string{lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(header, width))}
+	lines := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
 	for _, bodyLine := range compactTextLines(text, max(width-8, 8), 1) {
 		line := bodyStyle.Render("    " + firstCompactLine(bodyLine, max(width-6, 8)))
-		lines = append(lines, lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width)))
+		lines = append(lines, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
 	}
 	return lines
 }
@@ -540,7 +537,7 @@ func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) 
 	name := nonEmpty(msg.Name, "tool")
 	presentation := agentToolPresentationFor(name)
 	summary := nonEmpty(msg.Summary, msg.Text)
-	surface := m.agentSurface()
+	surface := m.editorBackground()
 	status := lipgloss.NewStyle().Bold(true).Foreground(statusColor).Background(surface).Render(statusIcon)
 	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(surface).Render(presentation.Icon + " " + presentation.Title)
 	rawName := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(name)
@@ -624,16 +621,16 @@ func agentToolMeta(msg protocol.AgentChatMessage) string {
 
 func (m Model) renderAgentToolBody(label string, text string, width int) string {
 	p := m.palette()
-	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(m.agentSurface())
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface())
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(m.editorBackground())
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
 	body := firstCompactLine(text, max(width-lipgloss.Width(label)-9, 8))
 	line := "  │  " + labelStyle.Render(label+":") + bodyStyle.Render(" "+body)
-	return lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(line, width))
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))
 }
 
 func (m Model) renderAgentApprovalMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
-	surface := m.agentSurface()
+	surface := m.editorBackground()
 	header := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(surface).Render("  ◆ Approval")
 	name := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(surface).Render(" " + nonEmpty(msg.Name, "tool"))
 	kind := lipgloss.NewStyle().Foreground(p.Accent()).Background(surface).Render(" · " + approvalPreviewKindName(msg.PreviewKind))
@@ -666,7 +663,7 @@ func (m Model) renderAgentUsageMessage(msg protocol.AgentChatMessage, width int)
 	if usage.CostMicros > 0 {
 		text += fmt.Sprintf(" · $%.2f", float64(usage.CostMicros)/1_000_000)
 	}
-	return lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Width(width).Render(fitStyled(text, width))
+	return lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Width(width).Render(fitStyled(text, width))
 }
 
 func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string {
@@ -682,17 +679,17 @@ func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string 
 	if chat.Status == 1 || chat.Status == 2 {
 		markerColor = p.Warning()
 	}
-	marker := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.agentSurface()).Render("❯")
-	modeText := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.agentSurface()).Render(mode)
-	promptStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.agentSurface())
+	marker := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render("❯")
+	modeText := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render(mode)
+	promptStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
 	if placeholder {
 		promptStyle = promptStyle.Foreground(p.Muted()).Italic(true)
 	}
 	prefix := "  " + marker + " " + modeText + "  "
 	promptText := promptStyle.Render(firstCompactLine(prompt, max(width-lipgloss.Width(prefix)-4, 8)))
-	line := lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(prefix+promptText, width))
-	hints := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.agentSurface()).Render("    Enter send  ·  Esc normal  ·  / commands  ·  " + cursor)
-	help := lipgloss.NewStyle().Background(m.agentSurface()).Width(width).Render(fitStyled(hints, width))
+	line := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(prefix+promptText, width))
+	hints := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("    Enter send  ·  Esc normal  ·  / commands  ·  " + cursor)
+	help := lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(hints, width))
 	return []string{line, help}
 }
 

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -149,12 +149,26 @@ func (m Model) renderAgentTranscriptStatus(chat protocol.AgentChat, width int) s
 func (m Model) renderAgentLandingState(width int) []string {
 	p := m.palette()
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
+	pillRow := strings.Join([]string{
+		m.renderAgentSuggestionPill("Explain this file"),
+		m.renderAgentSuggestionPill("Find failing tests"),
+		m.renderAgentSuggestionPill("Review changes"),
+	}, "  ")
+	pillRowTwo := strings.Join([]string{
+		m.renderAgentSuggestionPill("Edit current buffer"),
+		m.renderAgentSuggestionPill("Run a command"),
+		m.renderAgentSuggestionPill("Draft a plan"),
+	}, "  ")
 	return []string{
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(titleStyle.Render(" Try asking Minga"), width)),
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(bodyStyle.Render("   • explain this file   • find failing tests   • draft an implementation plan"), width)),
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(bodyStyle.Render("   • edit the current buffer   • run a command   • review recent changes"), width)),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(titleStyle.Render("Try asking Minga"), width)),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(pillRow, width)),
+		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(pillRowTwo, width)),
 	}
+}
+
+func (m Model) renderAgentSuggestionPill(label string) string {
+	p := m.palette()
+	return lipgloss.NewStyle().Foreground(p.Text()).Background(p.SurfaceAlt()).Padding(0, 1).Render(label)
 }
 
 func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {
@@ -201,10 +215,8 @@ func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, ri
 }
 
 func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget int) []string {
-	p := m.palette()
-	head := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Width(width).Render(fit("◇ Session", width))
 	provider, model := splitAgentModelName(chat.ModelName)
-	lines := []string{head}
+	lines := []string{m.renderAgentDetailFrame("top", "◇ Session", width)}
 	lines = append(lines, m.renderAgentDetailRow("Provider", nonEmpty(provider, "unknown"), width))
 	lines = append(lines, m.renderAgentDetailRow("Model", nonEmpty(model, "not selected"), width))
 	lines = append(lines, m.renderAgentDetailRow("State", agentChatStatusLabel(chat.Status), width))
@@ -238,33 +250,55 @@ func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget
 	lines = append(lines, m.renderAgentDetailHint("Enter", "send prompt", width))
 	lines = append(lines, m.renderAgentDetailHint("Tab", "complete", width))
 	lines = append(lines, m.renderAgentDetailHint("?", "agent help", width))
+	lines = append(lines, m.renderAgentDetailFrame("bottom", "", width))
 	return takeLines(lines, budget)
+}
+
+func (m Model) renderAgentDetailFrame(kind string, title string, width int) string {
+	p := m.palette()
+	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground())
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground())
+	inner := max(width-2, 0)
+	if kind == "bottom" {
+		return border.Render("╰" + strings.Repeat("─", inner) + "╯")
+	}
+	titleText := " " + title + " "
+	line := "╭" + titleStyle.Render(titleText) + border.Render(strings.Repeat("─", max(inner-lipgloss.Width(titleText), 0))+"╮")
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))
 }
 
 func (m Model) renderAgentDetailsSection(label string, width int) string {
 	p := m.palette()
-	line := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt()).Render("─")
-	text := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(p.SurfaceAlt()).Render(" " + label + " ")
-	remaining := max(width-lipgloss.Width(label)-2, 0)
-	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(text+strings.Repeat(line, remaining), width))
+	line := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(p.PopupSurface()).Render("─")
+	text := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(p.PopupSurface()).Render(" " + label + " ")
+	remaining := max(width-lipgloss.Width(label)-4, 0)
+	return m.renderAgentDetailContentLine(text+strings.Repeat(line, remaining), width)
 }
 
 func (m Model) renderAgentDetailRow(label string, value string, width int) string {
 	p := m.palette()
 	labelWidth := min(max(width/3, 8), 10)
-	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt()).Width(labelWidth)
-	valueStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.SurfaceAlt())
+	labelStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupSurface()).Width(labelWidth)
+	valueStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.PopupSurface())
 	prefix := labelStyle.Render(label)
-	body := valueStyle.Render(firstCompactLine(value, max(width-labelWidth-1, 8)))
-	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(" "+prefix+" "+body, width))
+	body := valueStyle.Render(firstCompactLine(value, max(width-labelWidth-4, 8)))
+	return m.renderAgentDetailContentLine(prefix+" "+body, width)
 }
 
 func (m Model) renderAgentDetailHint(key string, action string, width int) string {
 	p := m.palette()
-	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(p.SurfaceAlt()).Padding(0, 1)
-	actionStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.SurfaceAlt())
-	line := " " + keyStyle.Render(key) + actionStyle.Render(" "+action)
-	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(line, width))
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.SelectionText()).Background(p.Selection()).Padding(0, 1)
+	actionStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupSurface())
+	line := keyStyle.Render(key) + actionStyle.Render(" "+action)
+	return m.renderAgentDetailContentLine(line, width)
+}
+
+func (m Model) renderAgentDetailContentLine(content string, width int) string {
+	p := m.palette()
+	border := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(p.PopupSurface())
+	bodyWidth := max(width-2, 1)
+	body := lipgloss.NewStyle().Background(p.PopupSurface()).Width(bodyWidth).Render(fitStyled(" "+content, bodyWidth))
+	return border.Render("│") + body + border.Render("│")
 }
 
 func agentToolCounts(messages []protocol.AgentChatMessage) (int, int, int) {
@@ -409,12 +443,26 @@ func (m Model) renderAgentMessage(msg protocol.AgentChatMessage, width int) []st
 	case agentKindApprovalTool:
 		return m.renderAgentApprovalMessage(msg, width)
 	case agentKindSystem:
-		return m.renderAgentTextMessage("System", msg.Text, m.palette().Muted(), width, 1)
+		return m.renderAgentSystemMessage(msg, width)
 	case agentKindUsage:
 		return []string{m.renderAgentUsageMessage(msg, width)}
 	default:
 		return m.renderAgentTextMessage("• Message", msg.Text, m.palette().Muted(), width, 1)
 	}
+}
+
+func (m Model) renderAgentSystemMessage(msg protocol.AgentChatMessage, width int) []string {
+	p := m.palette()
+	label := "System"
+	rail := "i"
+	railColor := p.Accent()
+	surface := p.SurfaceAlt()
+	if msg.Status == 1 || strings.Contains(strings.ToLower(msg.Text), "error") || strings.Contains(strings.ToLower(msg.Text), "couldn't authenticate") {
+		label = "Needs attention"
+		rail = "!"
+		railColor = p.Diagnostic(0)
+	}
+	return m.renderAgentCard(agentCardSpec{Label: label, Rail: rail, RailColor: railColor, Lines: compactTextLines(msg.Text, max(width-16, 8), 2), Width: width, Surface: surface})
 }
 
 func (m Model) renderAgentTextMessage(label string, text string, fg color.Color, width int, maxLines int) []string {
@@ -610,7 +658,13 @@ func (m Model) renderAgentUsageMessage(msg protocol.AgentChatMessage, width int)
 
 func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string {
 	p := m.palette()
-	innerWidth := max(width-2, 1)
+	margin := 0
+	composerWidth := width
+	if width >= 72 {
+		margin = 2
+		composerWidth = max(width-(margin*2), 1)
+	}
+	innerWidth := max(composerWidth-2, 1)
 	borderColor := p.Accent()
 	if chat.Status == 1 || chat.Status == 2 {
 		if m.agentAnimationFrame%2 == 1 {
@@ -618,9 +672,9 @@ func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string 
 		}
 	}
 	border := lipgloss.NewStyle().Foreground(borderColor).Background(m.editorBackground())
-	lineStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.Base())
+	lineStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(p.PopupSurface())
 	topTitle := border.Render("╭─ Composer ")
-	topRule := border.Render(strings.Repeat("─", max(width-lipgloss.Width(topTitle)-1, 0)) + "╮")
+	topRule := border.Render(strings.Repeat("─", max(composerWidth-lipgloss.Width(topTitle)-1, 0)) + "╮")
 	prompt := strings.TrimRight(chat.Prompt, "\n")
 	placeholder := prompt == ""
 	if placeholder {
@@ -633,16 +687,23 @@ func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string 
 	mode := agentPromptModeName(chat.PromptVimMode)
 	modeBadge := lipgloss.NewStyle().Bold(true).Foreground(p.SelectionText()).Background(p.Selection()).Padding(0, 1).Render(mode)
 	cursor := fmt.Sprintf("%d:%d", int(chat.PromptCursorLine)+1, int(chat.PromptCursorCol)+1)
-	inputText := promptStyle.Render(firstCompactLine(prompt, max(innerWidth-lipgloss.Width(modeBadge)-3, 8)))
-	input := border.Render("│") + lineStyle.Render(" ") + modeBadge + lineStyle.Render(" ") + inputText
-	input += lineStyle.Render(strings.Repeat(" ", max(width-lipgloss.Width(input)-1, 0))) + border.Render("│")
+	inputText := promptStyle.Render(firstCompactLine(prompt, max(innerWidth-lipgloss.Width(modeBadge)-4, 8)))
+	input := border.Render("│") + lineStyle.Render(" ") + modeBadge + lineStyle.Render("  ") + inputText
+	input += lineStyle.Render(strings.Repeat(" ", max(composerWidth-lipgloss.Width(input)-1, 0))) + border.Render("│")
 	hints := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(" Enter send  •  Esc normal  •  / commands  •  " + cursor)
-	bottom := border.Render("╰─") + hints + border.Render(strings.Repeat("─", max(width-2-lipgloss.Width(hints), 0))+"╯")
+	bottom := border.Render("╰─") + hints + border.Render(strings.Repeat("─", max(composerWidth-2-lipgloss.Width(hints), 0))+"╯")
 	return []string{
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(topTitle+topRule, width)),
-		lipgloss.NewStyle().Background(p.Base()).Width(width).Render(fitStyled(input, width)),
-		lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(bottom, width)),
+		m.renderAgentInsetBlockLine(topTitle+topRule, width, margin, m.editorBackground()),
+		m.renderAgentInsetBlockLine(input, width, margin, p.PopupSurface()),
+		m.renderAgentInsetBlockLine(bottom, width, margin, m.editorBackground()),
 	}
+}
+
+func (m Model) renderAgentInsetBlockLine(line string, width int, margin int, bg color.Color) string {
+	left := lipgloss.NewStyle().Background(m.editorBackground()).Render(strings.Repeat(" ", max(margin, 0)))
+	contentWidth := max(width-margin, 1)
+	content := lipgloss.NewStyle().Background(bg).Width(contentWidth).Render(fitStyled(line, contentWidth))
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(left+content, width))
 }
 
 func agentPromptModeName(mode byte) string {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -180,19 +180,36 @@ func (m Model) renderAgentHeader(chat protocol.AgentChat, width int) string {
 	p := m.palette()
 	base := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Width(width)
 	provider, modelName := splitAgentModelName(chat.ModelName)
-	title := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render("◇ Agent")
-	model := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Render("[" + nonEmpty(modelName, "no model") + "]")
-	status := m.renderAgentStatusBadge(chat.Status)
-	parts := []string{title}
-	if provider != "" {
-		parts = append(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(provider))
+	modelName = nonEmpty(modelName, "no model")
+
+	icon := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render(agentHeaderIcon())
+	label := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render(" Agent")
+	model := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground()).Render(modelName)
+	muted := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
+
+	title := icon + label
+	identity := model
+	if provider != "" && width >= 52 {
+		identity = muted.Render(provider) + muted.Render(" / ") + model
 	}
-	parts = append(parts, model, status)
-	if chat.ThinkingLevel != "" {
-		parts = append(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("thinking: "+chat.ThinkingLevel))
+	if width < 34 {
+		title = icon
 	}
-	content := strings.Join(parts, lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("  "))
-	return base.Render(fitStyled(content, width))
+
+	left := title + muted.Render("  ") + identity
+	right := m.renderAgentStatusBadge(chat.Status)
+	if chat.ThinkingLevel != "" && width >= 56 {
+		right += muted.Render("  ◌ " + chat.ThinkingLevel)
+	}
+
+	leftBudget := max(width-lipgloss.Width(right)-1, 1)
+	left = fitStyled(left, leftBudget)
+	spacer := muted.Render(strings.Repeat(" ", max(width-lipgloss.Width(left)-lipgloss.Width(right), 1)))
+	return base.Render(fitStyled(left+spacer+right, width))
+}
+
+func agentHeaderIcon() string {
+	return "󰚩"
 }
 
 func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, rightWidth int, height int) []string {
@@ -361,13 +378,13 @@ func nonEmpty(value string, fallback string) string {
 func (m Model) renderAgentStatusBadge(status byte) string {
 	p := m.palette()
 	label := agentChatStatusLabel(status)
-	style := lipgloss.NewStyle().Bold(true).Foreground(p.SelectionText()).Background(p.Selection()).Padding(0, 1)
+	style := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(p.SurfaceAlt()).Padding(0, 1)
 	switch status {
 	case 1, 2:
 		label = m.agentSpinner() + " " + label
-		style = style.Background(p.Accent())
+		style = style.Foreground(p.SelectionText()).Background(p.Accent())
 	case 3:
-		style = style.Background(p.Diagnostic(0))
+		style = style.Foreground(p.SelectionText()).Background(p.Diagnostic(0))
 	}
 	return style.Render(label)
 }

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
@@ -21,27 +22,29 @@ const (
 )
 
 type Model struct {
-	width            int
-	height           int
-	out              chan<- []byte
-	viewport         viewport.Model
-	zones            *zoneManager
-	windows          map[uint16]protocol.WindowContent
-	windowOrder      []uint16
-	chrome           map[byte]protocol.ChromePayload
-	activePalette    palette
-	gutters          map[uint16]protocol.Gutter
-	indentGuides     map[uint16]protocol.IndentGuides
-	cells            map[position]cell
-	drawSeq          uint64
-	cursorRow        uint16
-	cursorCol        uint16
-	cursorShape      byte
-	title            string
-	bg               uint32
-	cursorlineChrome protocol.CursorlineChrome
-	pendingClipboard string
-	lastError        string
+	width                 int
+	height                int
+	out                   chan<- []byte
+	viewport              viewport.Model
+	zones                 *zoneManager
+	windows               map[uint16]protocol.WindowContent
+	windowOrder           []uint16
+	chrome                map[byte]protocol.ChromePayload
+	activePalette         palette
+	gutters               map[uint16]protocol.Gutter
+	indentGuides          map[uint16]protocol.IndentGuides
+	cells                 map[position]cell
+	drawSeq               uint64
+	cursorRow             uint16
+	cursorCol             uint16
+	cursorShape           byte
+	title                 string
+	bg                    uint32
+	cursorlineChrome      protocol.CursorlineChrome
+	pendingClipboard      string
+	lastError             string
+	agentAnimationFrame   uint64
+	agentAnimationRunning bool
 }
 
 type position struct {
@@ -76,8 +79,16 @@ func New(width, height uint16, out chan<- []byte) Model {
 	}
 }
 
+type agentAnimationTickMsg struct{}
+
 func (m Model) Init() tea.Cmd {
 	return nil
+}
+
+func agentAnimationTick() tea.Cmd {
+	return tea.Tick(180*time.Millisecond, func(time.Time) tea.Msg {
+		return agentAnimationTickMsg{}
+	})
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -102,6 +113,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.send(mousePacket(msg))
 		}
+	case agentAnimationTickMsg:
+		m.agentAnimationFrame++
+		if m.agentAnimating() {
+			cmd = agentAnimationTick()
+		} else {
+			m.agentAnimationRunning = false
+		}
 	case port.PacketMsg:
 		cmd = m.applyCommands(msg.Commands)
 	case port.LogMsg:
@@ -109,6 +127,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case port.ErrorMsg:
 		m.lastError = msg.Err.Error()
 		m.send(protocol.EncodeLogMessage(protocol.LogLevelErr, msg.Err.Error()))
+	}
+
+	if m.agentAnimating() && !m.agentAnimationRunning {
+		m.agentAnimationRunning = true
+		cmd = tea.Batch(cmd, agentAnimationTick())
 	}
 
 	m.viewport.SetWidth(max(m.width, 1))

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -372,7 +372,7 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 	}
 
 	view := ansi.Strip(strings.Join(model.renderAgentChatPanelWithLimit(chat, 120, 28), "\n"))
-	for _, want := range []string{"◇ Agent", "anthropic", "claude-sonnet-4", "thinking medium", "Read read_file", "path:", "Approval edit_file", "Usage", "Composer", "fix the renderer", "◇ Session", "Provider", "Model", "Context", "Hints", "╰"} {
+	for _, want := range []string{"◇ Agent", "anthropic", "claude-sonnet-4", "thinking medium", "Read read_file", "path:", "Approval edit_file", "Usage", "NORMAL", "fix the renderer", "◇ Session", "Provider", "Model", "Context", "Hints", "╰"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("agent chat panel missing %q in %q", want, view)
 		}
@@ -421,7 +421,7 @@ func TestAgentChatVisibleRendersAsMainBody(t *testing.T) {
 		t.Fatalf("agent details labels and values should not be smashed together: %q", body)
 	}
 	bottomComposer := strings.Join(bodyLines[max(len(bodyLines)-3, 0):], "\n")
-	if !strings.Contains(bottomComposer, "Composer") || !strings.Contains(bottomComposer, "Ask Minga") {
+	if !strings.Contains(bottomComposer, "NORMAL") || !strings.Contains(bottomComposer, "Ask Minga") {
 		t.Fatalf("agent composer should be pinned to bottom body rows: %+v", bodyLines)
 	}
 	footer := ansi.Strip(strings.Join(model.footerLines(), "\n"))

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -372,7 +372,7 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 	}
 
 	view := ansi.Strip(strings.Join(model.renderAgentChatPanelWithLimit(chat, 120, 28), "\n"))
-	for _, want := range []string{"◇ Agent", "anthropic", "claude-sonnet-4", "thinking medium", "Read", "read_file", "path:", "Approval edit_file", "Usage", "NORMAL", "fix the renderer", "◇ Session", "Provider", "Model", "Context", "Hints", "╰"} {
+	for _, want := range []string{"󰚩 Agent", "anthropic / claude-sonnet-4", "◌ medium", "Read", "read_file", "path:", "Approval edit_file", "Usage", "NORMAL", "fix the renderer", "◇ Session", "Provider", "Model", "Context", "Hints", "╰"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("agent chat panel missing %q in %q", want, view)
 		}
@@ -411,7 +411,7 @@ func TestAgentChatVisibleRendersAsMainBody(t *testing.T) {
 
 	bodyLines := strings.Split(ansi.Strip(model.content()), "\n")
 	body := strings.Join(bodyLines, "\n")
-	if !strings.Contains(body, "◇ Agent") || !strings.Contains(body, "Session") || !strings.Contains(body, "Ask Minga") || !strings.Contains(body, "Minga is ready") || !strings.Contains(body, "/explain") || !strings.Contains(body, "Explain this file") {
+	if !strings.Contains(body, "󰚩 Agent") || !strings.Contains(body, "Session") || !strings.Contains(body, "Ask Minga") || !strings.Contains(body, "Minga is ready") || !strings.Contains(body, "/explain") || !strings.Contains(body, "Explain this file") {
 		t.Fatalf("agent chat should render in main body: %q", body)
 	}
 	if strings.Contains(body, "~") {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -411,7 +411,7 @@ func TestAgentChatVisibleRendersAsMainBody(t *testing.T) {
 
 	bodyLines := strings.Split(ansi.Strip(model.content()), "\n")
 	body := strings.Join(bodyLines, "\n")
-	if !strings.Contains(body, "◇ Agent") || !strings.Contains(body, "Session") || !strings.Contains(body, "Ask Minga") || !strings.Contains(body, "Try asking Minga") || !strings.Contains(body, "Explain this file") {
+	if !strings.Contains(body, "◇ Agent") || !strings.Contains(body, "Session") || !strings.Contains(body, "Ask Minga") || !strings.Contains(body, "Minga is ready") || !strings.Contains(body, "/explain") || !strings.Contains(body, "Explain this file") {
 		t.Fatalf("agent chat should render in main body: %q", body)
 	}
 	if strings.Contains(body, "~") {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -41,6 +41,23 @@ func TestFloatingPickerRendersOverEditorAndSuppressesFooterOverlays(t *testing.T
 	}
 }
 
+func TestWorkspaceRowRendersAsQuietNavigation(t *testing.T) {
+	model := New(100, 20, nil)
+	row := ansi.Strip(model.renderWorkspaces(protocol.WorkspaceBar{Spaces: []protocol.Workspace{
+		{Label: "Files", Icon: "", TabCount: 1},
+		{Label: "Agent", Icon: "󰚩", TabCount: 1, Active: true},
+	}}))
+
+	for _, want := range []string{"Spaces", " Files (1 tab)", "▎󰚩 Agent (1 tab)"} {
+		if !strings.Contains(row, want) {
+			t.Fatalf("workspace row missing %q in %q", want, row)
+		}
+	}
+	if strings.Contains(row, "workspace") || strings.Contains(row, "Agent 1") || strings.Contains(row, "Files 1") {
+		t.Fatalf("workspace row should avoid implementation labels and bare counts: %q", row)
+	}
+}
+
 func TestViewCarriesFullWindowBackgroundColor(t *testing.T) {
 	model := New(20, 6, nil)
 	view := model.View()

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -355,7 +355,7 @@ func TestSemanticWindowRendersGutterCursorlineTildesAndModeline(t *testing.T) {
 }
 
 func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
-	model := New(120, 24, nil)
+	model := New(120, 34, nil)
 	chat := protocol.AgentChat{
 		Visible:       true,
 		Status:        2,
@@ -376,6 +376,21 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("agent chat panel missing %q in %q", want, view)
 		}
+	}
+}
+
+func TestAgentAnimationCueChangesAcrossFrames(t *testing.T) {
+	model := New(80, 24, nil)
+	model.agentAnimationFrame = 0
+	first := ansi.Strip(model.renderAgentStatusBadge(1))
+	model.agentAnimationFrame = 1
+	second := ansi.Strip(model.renderAgentStatusBadge(1))
+	if first == second {
+		t.Fatalf("thinking status badge should animate across frames: %q", first)
+	}
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentChat: {AgentChat: protocol.AgentChat{Visible: true, Status: 1}}}
+	if !model.agentAnimating() {
+		t.Fatalf("visible thinking agent should animate")
 	}
 }
 

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -336,7 +336,7 @@ func TestSemanticWindowRendersGutterCursorlineTildesAndModeline(t *testing.T) {
 }
 
 func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
-	model := New(80, 24, nil)
+	model := New(120, 24, nil)
 	chat := protocol.AgentChat{
 		Visible:       true,
 		Status:        2,
@@ -353,7 +353,7 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 	}
 
 	view := ansi.Strip(strings.Join(model.renderAgentChatPanel(chat), "\n"))
-	for _, want := range []string{"◇ Agent", "anthropic:claude-sonnet-4", "thinking medium", "Tool read_file", "Approval edit_file", "Usage", "::: fix the renderer"} {
+	for _, want := range []string{"◇ Agent", "anthropic:claude-sonnet-4", "thinking medium", "Read read_file", "path:", "Approval edit_file", "Usage", "::: fix the renderer", "Details", "Messages", "Context", "Hints"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("agent chat panel missing %q in %q", want, view)
 		}

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -150,6 +150,25 @@ func TestPickerPreviewRendersWithPicker(t *testing.T) {
 	}
 }
 
+func TestPickerSelectedRowHasVisibleMarker(t *testing.T) {
+	model := New(80, 24, nil)
+	rows := model.renderPickerList("Agent Model", protocol.Picker{
+		Visible:  true,
+		Selected: 1,
+		Items: []protocol.PickerItem{
+			{Label: "GPT-5 Codex", Description: "openai_codex"},
+			{Label: "Claude Sonnet", Description: "anthropic"},
+		},
+	}, 4, 80)
+	stripped := ansi.Strip(strings.Join(rows, "\n"))
+	if !strings.Contains(stripped, "▶") || !strings.Contains(stripped, "Claude Sonnet") {
+		t.Fatalf("selected picker row should include a visible marker: %q", stripped)
+	}
+	if strings.Contains(stripped, "▶ GPT-5 Codex") {
+		t.Fatalf("selection marker should only appear on selected row: %q", stripped)
+	}
+}
+
 func TestPickerOverlayIsBounded(t *testing.T) {
 	model := New(100, 24, nil)
 	items := make([]protocol.PickerItem, 20)
@@ -353,7 +372,7 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 	}
 
 	view := ansi.Strip(strings.Join(model.renderAgentChatPanel(chat), "\n"))
-	for _, want := range []string{"◇ Agent", "anthropic:claude-sonnet-4", "thinking medium", "Read read_file", "path:", "Approval edit_file", "Usage", "::: fix the renderer", "Details", "Messages", "Context", "Hints"} {
+	for _, want := range []string{"◇ Agent", "anthropic:claude-sonnet-4", "thinking medium", "Read read_file", "path:", "Approval edit_file", "Usage", "Composer", "fix the renderer", "Session", "Provider", "Model", "Context", "Hints"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("agent chat panel missing %q in %q", want, view)
 		}
@@ -375,12 +394,17 @@ func TestAgentChatVisibleRendersAsMainBody(t *testing.T) {
 	model.putWindow(protocol.WindowContent{ID: 7, Rows: []protocol.WindowRow{{Text: ""}}})
 	model.viewport.SetContent(model.content())
 
-	body := ansi.Strip(model.content())
-	if !strings.Contains(body, "◇ Agent") || !strings.Contains(body, "Details") || !strings.Contains(body, "Ask Minga") {
+	bodyLines := strings.Split(ansi.Strip(model.content()), "\n")
+	body := strings.Join(bodyLines, "\n")
+	if !strings.Contains(body, "◇ Agent") || !strings.Contains(body, "Session") || !strings.Contains(body, "Ask Minga") {
 		t.Fatalf("agent chat should render in main body: %q", body)
 	}
 	if strings.Contains(body, "~") {
 		t.Fatalf("agent chat body should not show editor tilde filler: %q", body)
+	}
+	bottomComposer := strings.Join(bodyLines[max(len(bodyLines)-3, 0):], "\n")
+	if !strings.Contains(bottomComposer, "Composer") || !strings.Contains(bottomComposer, "Ask Minga") {
+		t.Fatalf("agent composer should be pinned to bottom body rows: %+v", bodyLines)
 	}
 	footer := ansi.Strip(strings.Join(model.footerLines(), "\n"))
 	if strings.Contains(footer, "◇ Agent") || strings.Contains(footer, "Ask Minga") {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -372,7 +372,7 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 	}
 
 	view := ansi.Strip(strings.Join(model.renderAgentChatPanelWithLimit(chat, 120, 28), "\n"))
-	for _, want := range []string{"◇ Agent", "anthropic", "claude-sonnet-4", "thinking medium", "Read read_file", "path:", "Approval edit_file", "Usage", "NORMAL", "fix the renderer", "◇ Session", "Provider", "Model", "Context", "Hints", "╰"} {
+	for _, want := range []string{"◇ Agent", "anthropic", "claude-sonnet-4", "thinking medium", "Read", "read_file", "path:", "Approval edit_file", "Usage", "NORMAL", "fix the renderer", "◇ Session", "Provider", "Model", "Context", "Hints", "╰"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("agent chat panel missing %q in %q", want, view)
 		}

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -371,8 +371,8 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 		},
 	}
 
-	view := ansi.Strip(strings.Join(model.renderAgentChatPanel(chat), "\n"))
-	for _, want := range []string{"◇ Agent", "anthropic:claude-sonnet-4", "thinking medium", "Read read_file", "path:", "Approval edit_file", "Usage", "Composer", "fix the renderer", "Session", "Provider", "Model", "Context", "Hints"} {
+	view := ansi.Strip(strings.Join(model.renderAgentChatPanelWithLimit(chat, 120, 28), "\n"))
+	for _, want := range []string{"◇ Agent", "anthropic", "claude-sonnet-4", "thinking medium", "Read read_file", "path:", "Approval edit_file", "Usage", "Composer", "fix the renderer", "Session", "Provider", "Model", "Context", "Hints"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("agent chat panel missing %q in %q", want, view)
 		}
@@ -411,11 +411,14 @@ func TestAgentChatVisibleRendersAsMainBody(t *testing.T) {
 
 	bodyLines := strings.Split(ansi.Strip(model.content()), "\n")
 	body := strings.Join(bodyLines, "\n")
-	if !strings.Contains(body, "◇ Agent") || !strings.Contains(body, "Session") || !strings.Contains(body, "Ask Minga") {
+	if !strings.Contains(body, "◇ Agent") || !strings.Contains(body, "Session") || !strings.Contains(body, "Ask Minga") || !strings.Contains(body, "Try asking Minga") {
 		t.Fatalf("agent chat should render in main body: %q", body)
 	}
 	if strings.Contains(body, "~") {
 		t.Fatalf("agent chat body should not show editor tilde filler: %q", body)
+	}
+	if strings.Contains(body, "Messages1") || strings.Contains(body, "Provideranthropic") {
+		t.Fatalf("agent details labels and values should not be smashed together: %q", body)
 	}
 	bottomComposer := strings.Join(bodyLines[max(len(bodyLines)-3, 0):], "\n")
 	if !strings.Contains(bottomComposer, "Composer") || !strings.Contains(bottomComposer, "Ask Minga") {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -360,6 +360,34 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 	}
 }
 
+func TestAgentChatVisibleRendersAsMainBody(t *testing.T) {
+	model := New(120, 24, nil)
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentChat: {AgentChat: protocol.AgentChat{
+		Visible:       true,
+		Status:        0,
+		ModelName:     "anthropic:claude-sonnet-4",
+		ThinkingLevel: "medium",
+		Prompt:        "",
+		Messages: []protocol.AgentChatMessage{
+			{Kind: 0x05, Text: "Session started · 14:57:49 UTC"},
+		},
+	}}}
+	model.putWindow(protocol.WindowContent{ID: 7, Rows: []protocol.WindowRow{{Text: ""}}})
+	model.viewport.SetContent(model.content())
+
+	body := ansi.Strip(model.content())
+	if !strings.Contains(body, "◇ Agent") || !strings.Contains(body, "Details") || !strings.Contains(body, "Ask Minga") {
+		t.Fatalf("agent chat should render in main body: %q", body)
+	}
+	if strings.Contains(body, "~") {
+		t.Fatalf("agent chat body should not show editor tilde filler: %q", body)
+	}
+	footer := ansi.Strip(strings.Join(model.footerLines(), "\n"))
+	if strings.Contains(footer, "◇ Agent") || strings.Contains(footer, "Ask Minga") {
+		t.Fatalf("agent chat should not be duplicated in footer overlay: %q", footer)
+	}
+}
+
 func TestOverlayLinesRenderRemainingSemanticSurfaces(t *testing.T) {
 	model := New(60, 12, nil)
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentContext: {AgentContext: protocol.AgentContext{Visible: true, Task: "Review diff", Status: 1, CanApprove: true}}}

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -178,10 +178,10 @@ func TestPickerSelectedRowHasVisibleMarker(t *testing.T) {
 		},
 	}, 4, 80)
 	stripped := ansi.Strip(strings.Join(rows, "\n"))
-	if !strings.Contains(stripped, "▶") || !strings.Contains(stripped, "Claude Sonnet") {
+	if !strings.Contains(stripped, "▌") || !strings.Contains(stripped, "Claude Sonnet") {
 		t.Fatalf("selected picker row should include a visible marker: %q", stripped)
 	}
-	if strings.Contains(stripped, "▶ GPT-5 Codex") {
+	if strings.Contains(stripped, "▌ GPT-5 Codex") {
 		t.Fatalf("selection marker should only appear on selected row: %q", stripped)
 	}
 }
@@ -210,7 +210,7 @@ func TestWidePickerPreviewRendersBesideList(t *testing.T) {
 		protocol.PickerPreview{Visible: true, Lines: []protocol.PreviewLine{{Segments: []protocol.PreviewSegment{{Text: "def main"}}}}},
 	)
 	joined := strings.Join(rendered, "\n")
-	if !strings.Contains(joined, "test-advisor.md  .pi/agents") || !strings.Contains(joined, "def main") {
+	if !strings.Contains(joined, "test-advisor.md") || !strings.Contains(joined, ".pi/agents") || !strings.Contains(joined, "def main") {
 		t.Fatalf("wide picker should render one-row file results and preview together: %q", joined)
 	}
 	for index, line := range rendered {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -372,7 +372,7 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 	}
 
 	view := ansi.Strip(strings.Join(model.renderAgentChatPanelWithLimit(chat, 120, 28), "\n"))
-	for _, want := range []string{"◇ Agent", "anthropic", "claude-sonnet-4", "thinking medium", "Read read_file", "path:", "Approval edit_file", "Usage", "Composer", "fix the renderer", "Session", "Provider", "Model", "Context", "Hints"} {
+	for _, want := range []string{"◇ Agent", "anthropic", "claude-sonnet-4", "thinking medium", "Read read_file", "path:", "Approval edit_file", "Usage", "Composer", "fix the renderer", "◇ Session", "Provider", "Model", "Context", "Hints", "╰"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("agent chat panel missing %q in %q", want, view)
 		}
@@ -411,7 +411,7 @@ func TestAgentChatVisibleRendersAsMainBody(t *testing.T) {
 
 	bodyLines := strings.Split(ansi.Strip(model.content()), "\n")
 	body := strings.Join(bodyLines, "\n")
-	if !strings.Contains(body, "◇ Agent") || !strings.Contains(body, "Session") || !strings.Contains(body, "Ask Minga") || !strings.Contains(body, "Try asking Minga") {
+	if !strings.Contains(body, "◇ Agent") || !strings.Contains(body, "Session") || !strings.Contains(body, "Ask Minga") || !strings.Contains(body, "Try asking Minga") || !strings.Contains(body, "Explain this file") {
 		t.Fatalf("agent chat should render in main body: %q", body)
 	}
 	if strings.Contains(body, "~") {

--- a/go/tui/internal/ui/picker_overlay.go
+++ b/go/tui/internal/ui/picker_overlay.go
@@ -29,7 +29,7 @@ func (m Model) floatingPickerLayer() *lipgloss.Layer {
 
 func (m Model) renderFloatingPicker(picker protocol.Picker, preview protocol.PickerPreview) string {
 	popupWidth := m.floatingPickerWidth()
-	contentWidth := max(popupWidth-2, 1)
+	contentWidth := max(popupWidth-4, 1)
 	popupModel := m
 	popupModel.width = contentWidth
 	lines := popupModel.renderPicker(picker, preview)
@@ -37,7 +37,7 @@ func (m Model) renderFloatingPicker(picker protocol.Picker, preview protocol.Pic
 		return ""
 	}
 	content := strings.Join(lines, "\n")
-	return lipgloss.NewStyle().Width(contentWidth).Border(lipgloss.RoundedBorder()).BorderForeground(m.palette().PopupBorder()).Background(m.palette().PopupSurface()).Render(content)
+	return lipgloss.NewStyle().Width(contentWidth).Padding(0, 1).Border(lipgloss.RoundedBorder()).BorderForeground(m.palette().PopupBorder()).Background(m.palette().PopupSurface()).Render(content)
 }
 
 func (m Model) floatingPickerWidth() int {

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -31,36 +31,57 @@ func (m Model) headerLines() []string {
 
 func (m Model) renderWorkspaces(spaces protocol.WorkspaceBar) string {
 	theme := m.palette()
-	rowStyle := lipgloss.NewStyle().Background(theme.SurfaceAlt()).Width(m.width)
-	labelStyle := lipgloss.NewStyle().Foreground(theme.Muted()).Background(theme.SurfaceAlt()).Padding(0, 1)
-	activeStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.TabActiveText()).Background(theme.Surface()).Padding(0, 1)
-	inactiveStyle := lipgloss.NewStyle().Foreground(theme.TabInactiveText()).Background(theme.SurfaceAlt()).Padding(0, 1)
-	alertStyle := lipgloss.NewStyle().Foreground(theme.Warning()).Background(theme.SurfaceAlt())
-	rendered := []string{labelStyle.Render("workspace")}
+	rowStyle := lipgloss.NewStyle().Background(theme.EditorSurface()).Width(m.width)
+	labelStyle := lipgloss.NewStyle().Foreground(theme.Muted()).Background(theme.EditorSurface())
+	activeStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Accent()).Background(theme.EditorSurface())
+	inactiveStyle := lipgloss.NewStyle().Foreground(theme.TabInactiveText()).Background(theme.EditorSurface())
+	metaStyle := lipgloss.NewStyle().Foreground(theme.Muted()).Background(theme.EditorSurface())
+	alertStyle := lipgloss.NewStyle().Foreground(theme.Warning()).Background(theme.EditorSurface())
+	rendered := []string{labelStyle.Render("Spaces")}
+	separator := metaStyle.Render(" · ")
 	for _, space := range spaces.Spaces {
+		primaryStyle := inactiveStyle
+		marker := ""
+		if space.Active {
+			primaryStyle = activeStyle
+			marker = activeStyle.Render("▎")
+		}
 		label := strings.TrimSpace(space.Icon + " " + space.Label)
-		if space.TabCount > 0 {
-			label += fmt.Sprintf(" %d", space.TabCount)
-		}
-		if space.DraftCount > 0 {
-			label += alertStyle.Render(fmt.Sprintf(" D%d", space.DraftCount))
-		}
-		if space.ConflictCount > 0 {
-			label += alertStyle.Render(fmt.Sprintf(" C%d", space.ConflictCount))
-		}
-		if space.BackgroundCount > 0 {
-			label += alertStyle.Render(fmt.Sprintf(" B%d", space.BackgroundCount))
+		item := marker + primaryStyle.Render(label)
+		meta := workspaceSpaceMetadata(space)
+		if meta != "" {
+			item += metaStyle.Render(" (" + meta + ")")
 		}
 		if space.Attention {
-			label += alertStyle.Render(" !")
+			item += alertStyle.Render(" !")
 		}
-		style := inactiveStyle
-		if space.Active {
-			style = activeStyle
-		}
-		rendered = append(rendered, style.Render(label))
+		rendered = append(rendered, item)
 	}
-	return rowStyle.Render(fitStyled(strings.Join(rendered, " "), m.width))
+	return rowStyle.Render(fitStyled(strings.Join(rendered, separator), m.width))
+}
+
+func workspaceSpaceMetadata(space protocol.Workspace) string {
+	parts := make([]string, 0, 4)
+	if space.TabCount > 0 {
+		parts = append(parts, pluralCount(space.TabCount, "tab"))
+	}
+	if space.DraftCount > 0 {
+		parts = append(parts, pluralCount(space.DraftCount, "draft"))
+	}
+	if space.ConflictCount > 0 {
+		parts = append(parts, pluralCount(space.ConflictCount, "conflict"))
+	}
+	if space.BackgroundCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d running", space.BackgroundCount))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func pluralCount(count uint16, label string) string {
+	if count == 1 {
+		return fmt.Sprintf("%d %s", count, label)
+	}
+	return fmt.Sprintf("%d %ss", count, label)
 }
 
 func (m Model) renderTabs(tabBar protocol.TabBar) string {

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -318,9 +318,6 @@ func (m Model) renderPicker(picker protocol.Picker, preview protocol.PickerPrevi
 		itemBudget = max(itemBudget/2, 1)
 	}
 	lines := m.renderPickerList(title, picker, itemBudget+1, m.width)
-	if picker.ActionVisible && len(picker.Actions) > 0 {
-		lines = append(lines, m.popupLineStyle(m.width).Foreground(m.palette().Muted()).Render(fit(strings.Join(picker.Actions, "  "), m.width)))
-	}
 	if preview.Visible && len(preview.Lines) > 0 {
 		lines = append(lines, m.renderPickerPreview(preview, max(height-len(lines)-1, 1), m.width)...)
 	}
@@ -332,7 +329,7 @@ func (m Model) renderPickerList(title string, picker protocol.Picker, height int
 	theme := m.palette()
 	panelStyle := m.popupLineStyle(width)
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Accent()).Background(theme.PopupChrome()).Width(width)
-	lines := []string{titleStyle.Render(fit(title, width))}
+	lines := []string{titleStyle.Render(fitStyled(" "+title, width))}
 	rowBudget := max(height-1, 0)
 	selected := min(max(int(picker.Selected), 0), max(len(picker.Items)-1, 0))
 	start := 0
@@ -366,7 +363,6 @@ func (m Model) renderPickerItemRow(title string, item protocol.PickerItem, selec
 	rowBackground := theme.PopupSurface()
 	rowForeground := theme.PopupText()
 	if selected {
-		rowBackground = theme.PopupSelection()
 		rowForeground = theme.PopupSelectionText()
 	}
 	markerText := lipgloss.NewStyle().Foreground(theme.Muted()).Background(rowBackground).Render(marker)
@@ -387,7 +383,7 @@ func (m Model) renderPickerItemRow(title string, item protocol.PickerItem, selec
 	if strings.TrimSpace(detail) != "" {
 		text += lipgloss.NewStyle().Foreground(theme.Muted()).Background(rowBackground).Render("  " + strings.TrimSpace(detail))
 	}
-	return lipgloss.NewStyle().Background(rowBackground).Width(width).Render(fitStyled(text, width))
+	return lipgloss.NewStyle().Background(rowBackground).Width(width).Render(fitStyled(" "+text, width))
 }
 
 func (m Model) renderPickerWithSidePreview(title string, picker protocol.Picker, preview protocol.PickerPreview, height int) []string {

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -292,7 +292,7 @@ func (m Model) renderPicker(picker protocol.Picker, preview protocol.PickerPrevi
 		return m.renderPickerWithSidePreview(title, picker, preview, height)
 	}
 
-	itemBudget := max(height-1, 1)
+	itemBudget := max(height-2, 1)
 	if preview.Visible && len(preview.Lines) > 0 {
 		itemBudget = max(itemBudget/2, 1)
 	}
@@ -301,8 +301,9 @@ func (m Model) renderPicker(picker protocol.Picker, preview protocol.PickerPrevi
 		lines = append(lines, m.popupLineStyle(m.width).Foreground(m.palette().Muted()).Render(fit(strings.Join(picker.Actions, "  "), m.width)))
 	}
 	if preview.Visible && len(preview.Lines) > 0 {
-		lines = append(lines, m.renderPickerPreview(preview, max(height-len(lines), 1), m.width)...)
+		lines = append(lines, m.renderPickerPreview(preview, max(height-len(lines)-1, 1), m.width)...)
 	}
+	lines = append(lines, m.renderPickerHelp(picker, m.width))
 	return takeLines(m.fillPopupLines(lines, height, m.width), height)
 }
 
@@ -333,26 +334,31 @@ func (m Model) renderPickerItemRow(title string, item protocol.PickerItem, selec
 	if item.Marked {
 		marker = "*"
 	}
+	if selected {
+		marker = "▶"
+	}
 	detail := item.Description
 	if detail == "" {
 		detail = item.Annotation
 	}
 	icon := pickerItemIcon(title, item)
-	iconText := icon.glyph
-	iconBackground := m.palette().PopupSurface()
+	rowBackground := theme.PopupSurface()
+	rowForeground := theme.PopupText()
 	if selected {
-		iconBackground = theme.Selection()
+		rowBackground = theme.Accent()
+		rowForeground = theme.SelectionText()
 	}
-	if icon.color != "" {
-		iconText = lipgloss.NewStyle().Foreground(lipgloss.Color(icon.color)).Background(iconBackground).Render(icon.glyph)
+	iconText := icon.glyph
+	if icon.color != "" && !selected {
+		iconText = lipgloss.NewStyle().Foreground(lipgloss.Color(icon.color)).Background(rowBackground).Render(icon.glyph)
 	}
 	text := strings.TrimSpace(marker + " " + iconText + " " + item.Label)
 	if strings.TrimSpace(detail) != "" {
 		text += "  " + strings.TrimSpace(detail)
 	}
-	style := m.popupLineStyle(width)
+	style := m.popupLineStyle(width).Foreground(rowForeground).Background(rowBackground)
 	if selected {
-		style = style.Bold(true).Foreground(theme.SelectionText()).Background(theme.Selection())
+		style = style.Bold(true)
 	}
 	return style.Render(fit(text, width))
 }
@@ -360,16 +366,32 @@ func (m Model) renderPickerItemRow(title string, item protocol.PickerItem, selec
 func (m Model) renderPickerWithSidePreview(title string, picker protocol.Picker, preview protocol.PickerPreview, height int) []string {
 	leftWidth := min(max(m.width*45/100, 36), max(m.width-20, 1))
 	rightWidth := max(m.width-leftWidth, 1)
-	left := m.renderPickerList(title, picker, height, leftWidth)
-	right := m.renderPickerPreview(preview, height, rightWidth)
-	left = m.fillPopupLines(left, height, leftWidth)
-	right = m.fillPopupLines(right, height, rightWidth)
+	bodyHeight := max(height-1, 1)
+	left := m.renderPickerList(title, picker, bodyHeight, leftWidth)
+	right := m.renderPickerPreview(preview, bodyHeight, rightWidth)
+	left = m.fillPopupLines(left, bodyHeight, leftWidth)
+	right = m.fillPopupLines(right, bodyHeight, rightWidth)
 	lines := make([]string, 0, height)
 	leftStyle := lipgloss.NewStyle().Width(leftWidth).Background(m.palette().PopupSurface())
-	for i := 0; i < height; i++ {
+	for i := 0; i < bodyHeight; i++ {
 		lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, leftStyle.Render(left[i]), right[i]))
 	}
+	lines = append(lines, m.renderPickerHelp(picker, m.width))
 	return lines
+}
+
+func (m Model) renderPickerHelp(picker protocol.Picker, width int) string {
+	p := m.palette()
+	selected := 0
+	if len(picker.Items) > 0 {
+		selected = min(max(int(picker.Selected)+1, 1), len(picker.Items))
+	}
+	left := fmt.Sprintf(" %d/%d", selected, len(picker.Items))
+	right := "↑↓ move  Enter choose  Esc close"
+	leftText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupSurface()).Render(left)
+	rightText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupSurface()).Render(right)
+	spacer := strings.Repeat(" ", max(width-lipgloss.Width(leftText)-lipgloss.Width(rightText), 0))
+	return lipgloss.NewStyle().Background(p.PopupSurface()).Width(width).Render(fitStyled(leftText+spacer+rightText, width))
 }
 
 func (m Model) renderPickerPreview(preview protocol.PickerPreview, height int, width int) []string {

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -331,7 +331,7 @@ func (m Model) renderPicker(picker protocol.Picker, preview protocol.PickerPrevi
 func (m Model) renderPickerList(title string, picker protocol.Picker, height int, width int) []string {
 	theme := m.palette()
 	panelStyle := m.popupLineStyle(width)
-	titleStyle := panelStyle.Bold(true).Foreground(theme.Accent())
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Accent()).Background(theme.PopupChrome()).Width(width)
 	lines := []string{titleStyle.Render(fit(title, width))}
 	rowBudget := max(height-1, 0)
 	selected := min(max(int(picker.Selected), 0), max(len(picker.Items)-1, 0))
@@ -356,7 +356,7 @@ func (m Model) renderPickerItemRow(title string, item protocol.PickerItem, selec
 		marker = "*"
 	}
 	if selected {
-		marker = "▶"
+		marker = "▌"
 	}
 	detail := item.Description
 	if detail == "" {
@@ -366,22 +366,28 @@ func (m Model) renderPickerItemRow(title string, item protocol.PickerItem, selec
 	rowBackground := theme.PopupSurface()
 	rowForeground := theme.PopupText()
 	if selected {
-		rowBackground = theme.Accent()
-		rowForeground = theme.SelectionText()
+		rowBackground = theme.PopupSelection()
+		rowForeground = theme.PopupSelectionText()
+	}
+	markerText := lipgloss.NewStyle().Foreground(theme.Muted()).Background(rowBackground).Render(marker)
+	if selected {
+		markerText = lipgloss.NewStyle().Bold(true).Foreground(theme.Accent()).Background(rowBackground).Render(marker)
+	} else if item.Marked {
+		markerText = lipgloss.NewStyle().Foreground(theme.Warning()).Background(rowBackground).Render(marker)
 	}
 	iconText := icon.glyph
 	if icon.color != "" && !selected {
 		iconText = lipgloss.NewStyle().Foreground(lipgloss.Color(icon.color)).Background(rowBackground).Render(icon.glyph)
 	}
-	text := strings.TrimSpace(marker + " " + iconText + " " + item.Label)
-	if strings.TrimSpace(detail) != "" {
-		text += "  " + strings.TrimSpace(detail)
-	}
-	style := m.popupLineStyle(width).Foreground(rowForeground).Background(rowBackground)
+	labelStyle := lipgloss.NewStyle().Foreground(rowForeground).Background(rowBackground)
 	if selected {
-		style = style.Bold(true)
+		labelStyle = labelStyle.Bold(true)
 	}
-	return style.Render(fit(text, width))
+	text := markerText + labelStyle.Render(" "+strings.TrimSpace(iconText+" "+item.Label))
+	if strings.TrimSpace(detail) != "" {
+		text += lipgloss.NewStyle().Foreground(theme.Muted()).Background(rowBackground).Render("  " + strings.TrimSpace(detail))
+	}
+	return lipgloss.NewStyle().Background(rowBackground).Width(width).Render(fitStyled(text, width))
 }
 
 func (m Model) renderPickerWithSidePreview(title string, picker protocol.Picker, preview protocol.PickerPreview, height int) []string {
@@ -409,10 +415,10 @@ func (m Model) renderPickerHelp(picker protocol.Picker, width int) string {
 	}
 	left := fmt.Sprintf(" %d/%d", selected, len(picker.Items))
 	right := "↑↓ move  Enter choose  Esc close"
-	leftText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupSurface()).Render(left)
-	rightText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupSurface()).Render(right)
+	leftText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupChrome()).Render(left)
+	rightText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupChrome()).Render(right)
 	spacer := strings.Repeat(" ", max(width-lipgloss.Width(leftText)-lipgloss.Width(rightText), 0))
-	return lipgloss.NewStyle().Background(p.PopupSurface()).Width(width).Render(fitStyled(leftText+spacer+rightText, width))
+	return lipgloss.NewStyle().Background(p.PopupChrome()).Width(width).Render(fitStyled(leftText+spacer+rightText, width))
 }
 
 func (m Model) renderPickerPreview(preview protocol.PickerPreview, height int, width int) []string {

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -145,7 +145,7 @@ func (m Model) footerLines() []string {
 	lines := []string{
 		lipgloss.NewStyle().Foreground(m.palette().Muted()).Background(m.palette().Base()).Width(m.width).Render(fitStyled(status, m.width)),
 	}
-	if !m.pickerVisible() && !m.whichKeyVisible() {
+	if !m.pickerVisible() && !m.whichKeyVisible() && !m.agentChatVisible() {
 		overlay := m.overlayLines()
 		if len(overlay) > 0 {
 			lines = append(lines, overlay...)

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -13,6 +13,9 @@ import (
 )
 
 func (m Model) content() string {
+	if chat, ok := m.agentChat(); ok && chat.Visible {
+		return strings.Join(m.renderAgentChatBody(chat), "\n")
+	}
 	if len(m.windows) > 0 {
 		return strings.Join(m.fillBody(m.withFileTree(m.withSplitSeparators(m.semanticLines()))), "\n")
 	}

--- a/go/tui/internal/ui/selectors.go
+++ b/go/tui/internal/ui/selectors.go
@@ -240,6 +240,22 @@ func (m Model) agentChatVisible() bool {
 	return ok && chat.Visible
 }
 
+func (m Model) agentAnimating() bool {
+	chat, ok := m.agentChat()
+	if !ok || !chat.Visible {
+		return false
+	}
+	if chat.Status == 1 || chat.Status == 2 || chat.Pending != "" {
+		return true
+	}
+	for _, msg := range chat.Messages {
+		if msg.Kind == agentKindThinking || ((msg.Kind == agentKindTool || msg.Kind == agentKindStyledTool) && msg.Status == 0) {
+			return true
+		}
+	}
+	return false
+}
+
 func (m Model) board() (protocol.Board, bool) {
 	for _, payload := range m.chrome {
 		if payload.Board.Visible {

--- a/go/tui/internal/ui/selectors.go
+++ b/go/tui/internal/ui/selectors.go
@@ -235,6 +235,11 @@ func (m Model) agentChat() (protocol.AgentChat, bool) {
 	return protocol.AgentChat{}, false
 }
 
+func (m Model) agentChatVisible() bool {
+	chat, ok := m.agentChat()
+	return ok && chat.Visible
+}
+
 func (m Model) board() (protocol.Board, bool) {
 	for _, payload := range m.chrome {
 		if payload.Board.Visible {

--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -61,10 +61,10 @@ func defaultPalette() palette {
 		themeTabInactiveFG:    0x5B6268,
 		themeTabModifiedFG:    0xFF6C6B,
 		themeTabAttentionFG:   0xECBE7B,
-		themePopupBG:          0x31374A,
+		themePopupBG:          0x252A38,
 		themePopupFG:          0xD7DDF0,
-		themePopupBorder:      0x69738A,
-		themePopupSelBG:       0x3A4258,
+		themePopupBorder:      0x7A849B,
+		themePopupSelBG:       0x2F3650,
 		themePopupSelFG:       0xF2F5FF,
 		themeBreadcrumbBG:     0x21242B,
 		themeModelineBG:       0x22252D,
@@ -232,7 +232,7 @@ func (p palette) PopupSelectionText() color.Color {
 }
 
 func (p palette) PopupChrome() color.Color {
-	return lipgloss.Color("#2B3142")
+	return lipgloss.Color("#202532")
 }
 
 func (p palette) slot(slot byte) color.Color {

--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -61,11 +61,11 @@ func defaultPalette() palette {
 		themeTabInactiveFG:    0x5B6268,
 		themeTabModifiedFG:    0xFF6C6B,
 		themeTabAttentionFG:   0xECBE7B,
-		themePopupBG:          0x21242B,
-		themePopupFG:          0xBBC2CF,
-		themePopupBorder:      0x5B6268,
-		themePopupSelBG:       0x3E4451,
-		themePopupSelFG:       0xFFFFFF,
+		themePopupBG:          0x31374A,
+		themePopupFG:          0xD7DDF0,
+		themePopupBorder:      0x69738A,
+		themePopupSelBG:       0x3A4258,
+		themePopupSelFG:       0xF2F5FF,
 		themeBreadcrumbBG:     0x21242B,
 		themeModelineBG:       0x22252D,
 		themeModelineFG:       0xBBC2CF,
@@ -221,6 +221,18 @@ func (p palette) PopupText() color.Color {
 
 func (p palette) PopupBorder() color.Color {
 	return p.slot(themePopupBorder)
+}
+
+func (p palette) PopupSelection() color.Color {
+	return p.slot(themePopupSelBG)
+}
+
+func (p palette) PopupSelectionText() color.Color {
+	return p.slot(themePopupSelFG)
+}
+
+func (p palette) PopupChrome() color.Color {
+	return lipgloss.Color("#2B3142")
 }
 
 func (p palette) slot(slot byte) color.Color {

--- a/go/tui/internal/ui/which_key_overlay.go
+++ b/go/tui/internal/ui/which_key_overlay.go
@@ -39,7 +39,7 @@ func (m Model) renderFloatingWhichKey(which protocol.WhichKey) string {
 		title += fmt.Sprintf("  %d/%d", which.Page+1, which.PageCount)
 	}
 
-	lines := []string{lipgloss.NewStyle().Bold(true).Foreground(m.palette().Accent()).Background(m.palette().PopupSurface()).Width(inner).Render(fit(title, inner))}
+	lines := []string{lipgloss.NewStyle().Bold(true).Foreground(m.palette().Accent()).Background(m.palette().PopupChrome()).Width(inner).Render(fit(title, inner))}
 	columns := m.whichKeyColumns(inner)
 	rows := (len(which.Bindings) + columns - 1) / columns
 	cellWidth := max(inner/columns, 1)
@@ -61,7 +61,7 @@ func (m Model) renderFloatingWhichKey(which protocol.WhichKey) string {
 }
 
 func (m Model) renderWhichKeyCell(binding protocol.WhichKeyBinding, width int) string {
-	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(m.palette().SelectionText()).Background(m.palette().Selection()).Padding(0, 1)
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(m.palette().PopupSelectionText()).Background(m.palette().PopupSelection()).Padding(0, 1)
 	descStyle := lipgloss.NewStyle().Foreground(m.palette().PopupText()).Background(m.palette().PopupSurface())
 	key := strings.TrimSpace(binding.Key)
 	icon := whichKeyIcon(binding)


### PR DESCRIPTION
# TL;DR
Adds a focused agent UX polish pass to the semantic Go TUI. The agent surface now behaves more like a chat product, with a real transcript/composer/details layout, message cards, richer prompt metadata, tool-specific cards, and stronger picker selection.

Part of #2152

## Context
This PR builds on the semantic Go TUI renderer merged in #2152. The goal is to move the agent view away from styled editor rows and toward a structured TUI surface with clear regions, obvious focus, and better hierarchy.

## Design inspiration
The agent panel treatment is inspired by Charmbracelet’s Crush UI patterns, especially the structured transcript, composer, model/status details rail, and tool-specific cards. This PR reimplements those ideas for Minga’s semantic Go TUI and does not copy Crush source code.

## Changes
- Promotes visible agent chat into the main body instead of rendering it as a small footer overlay below an empty buffer.
- Splits the agent surface into header, transcript, composer, and details regions.
- Pins the composer to the bottom of the body with a bordered input surface, mode badge, cursor metadata, placeholder, and key hints.
- Renders user, assistant, system, thinking, usage, tool, and approval entries as card-like blocks with rails and stronger hierarchy.
- Preserves prompt metadata from the semantic protocol so the composer can display mode and cursor position.
- Adds a compact details rail with provider, model, state, thinking level, message/tool counts, context usage, cost, pending approval, and auth guidance when system errors are present.
- Adds tool-specific presentations for shell, file read/write, edit/diff, todo, subagent, LSP, git, and unknown tools.
- Makes picker selection visible with a full-row accent background and pointer marker.
- Adds a lightweight Bubble Tea animation tick while agent thinking/tool work is active.
- Animates active status badges, thinking rails, running tool indicators, and composer border color.
- Adds more transcript breathing room between cards without chopping card headers.
- Insets the agent body so content no longer hugs the terminal edge.
- Replaces the dominant full-height details divider with a softer column gap and smaller details rail.
- Adds sparse-transcript suggested actions and a transcript status row.
- Splits agent header model metadata into provider/model/status badges.
- Fixes details label/value spacing so fields do not read as smashed-together text.
- Turns sparse-session suggestions into higher-contrast pills.
- Renders system/error messages as alert-style cards instead of plain transcript text.
- Adds a real bordered details card with a darker surface and visible edge.
- Insets and darkens the composer input surface so it feels less mechanical and has stronger contrast.
- Adds a picker help/footer row with item count and navigation hints.

## Verification
- `cd go/tui && go test ./...` → 158 passed
- `mix compile --warnings-as-errors`
- `mix native.build.go_tui`
- `git diff --check`
- LSP diagnostics on touched Go files → no diagnostics

## Manual visual checks
- Open the Go TUI agent view and confirm the transcript/composer/details surface fills the main body instead of appearing as a small footer strip below an empty tilde-filled buffer.
- Confirm the composer is pinned to the bottom and looks like an input surface, not a statusline row.
- Confirm sparse sessions show pill-style suggested actions and the details rail reads as a compact card rather than a large empty pane.
- Confirm system/auth-error messages read as alert cards, not plain transcript text.
- While the agent is thinking or running tools, confirm the status badge/tool rail animates subtly and the composer border pulses.
- On a wide terminal, confirm the details rail appears on the right and feels secondary to the transcript.
- Trigger or inspect tool-call transcript entries and confirm common tools render as Shell, Read, Write, Edit, Diff, Todo, Subagent, LSP, or Git cards rather than generic tool rows.
- Open a model picker and confirm the selected row is obvious through the pointer marker and high-contrast full-row selection.



