### PR TITLE
docs: add semantic Rust TUI workstreams

### DIFF
--- a/docs/workstreams/DAILY_DRIVER.md
+++ b/docs/workstreams/DAILY_DRIVER.md
@@ -1,0 +1,57 @@
+# Minga Daily Driver Workstream
+
+This workstream defines the minimum product slice that must become stable enough for Minga to be used as the author’s everyday editor and agent workspace.
+
+## Decision
+
+The daily-driver slice is not "all of Emacs plus all of Claude Code." It is the smallest end-to-end path where one person can open a real project, edit code safely, navigate quickly, run agent tasks, inspect changes, and recover from frontend crashes without losing editor state.
+
+## Non-Goals
+
+- Do not expand this workstream into general editor parity.
+- Do not add a new frontend architecture.
+- Do not preserve non-semantic frontend rendering paths for compatibility.
+- Do not require every experimental shell to reach parity before the traditional editor shell is stable.
+- Do not couple agent runtime behavior to one rendering surface.
+
+## Target Experience
+
+- Open Minga from a terminal or native app and attach to a BEAM-owned editor session.
+- Open, edit, save, and switch files without corrupting buffers, tabs, cursor state, or undo history.
+- Navigate projects with a file tree, picker, search, splits, tabs, and visible status feedback.
+- Use language features that matter for daily coding: syntax highlighting, diagnostics display, basic LSP interactions, comments, indentation, and structural navigation where available.
+- Run agent tasks against the same editor state without pretending the agent UI is a separate product.
+- Recover from frontend crashes or restarts while preserving BEAM-owned buffers and session state.
+
+## Required Lanes
+
+- **Editor Kernel:** buffer correctness, undo/redo, save/load, cursor/motion, search, project navigation, LSP, diagnostics, git state.
+- **Agent Runtime:** sessions, tool execution, approvals, filesystem edits, shell execution, change inspection, safety boundaries.
+- **Shell Composition:** traditional editor shell first, agentic shell experiments second, shared state underneath both.
+- **Semantic UI Contract:** one frontend contract for GUI and terminal clients, with capability flags rather than Swift/Rust/GTK identity.
+- **Frontend Clients:** Swift/macOS as the polish reference, Go terminal as the temporary semantic reference, Rust terminal as the desired long-term terminal frontend, Zig parser/tree-sitter until replaced.
+
+## Daily Driver Checklist
+
+- `bin/minga path/to/file` opens a real project reliably.
+- File open, edit, save, close, and reopen preserve content and cursor expectations.
+- Normal, insert, visual, command, and operator-pending flows are usable for normal editing.
+- File tree, picker, status bar, minibuffer, completion, which-key, diagnostics, and git signs render from Semantic UI.
+- Agent chat/task execution can read files, propose edits, apply edits, run shell commands, and show tool progress.
+- Frontend restart does not lose BEAM-owned editor state.
+- Resize, scroll, split, tab, popup, and input handling are stable in the chosen daily-driver frontend.
+- Focused validation exists for each daily-driver regression fixed during this workstream.
+
+## Ticket Rules
+
+Every ticket in this workstream must include:
+
+- Lane.
+- Non-goals.
+- Files to inspect first.
+- Files likely modified.
+- Acceptance criteria.
+- Validation commands.
+- Forbidden changes.
+
+Tickets that mix protocol cleanup, Rust renderer rebuilding, Zig deletion, and agent shell redesign in one scope should be split before implementation.

--- a/docs/workstreams/RUST_TUI_REBUILD.md
+++ b/docs/workstreams/RUST_TUI_REBUILD.md
@@ -1,0 +1,88 @@
+# Rust TUI Rebuild Workstream
+
+This workstream proves whether Ratatui plus a modern terminal stack can deliver the same Semantic UI polish as the Swift frontend while remaining easier to maintain than the current Rust TUI and temporary Go TUI.
+
+## Decision
+
+The Rust TUI should be rebuilt as a semantic-only terminal frontend. It should not patch the current mixed legacy-cell and semantic renderer until it works by accident. The new shape is `BEAM protocol -> retained Semantic UI state -> Ratatui widgets -> Terminal`, with input and resize events flowing back to the BEAM over the existing port protocol.
+
+## Direction
+
+- Minga emits one Semantic UI stream for visible shared UI.
+- Frontends declare capabilities such as terminal grid, pixel surface, text measurement, color support, images, floats, and host mode.
+- Minga does not branch on Swift, Rust, Go, GTK, or terminal identity for product behavior.
+- The Rust TUI is a native terminal frontend, not a desktop GUI.
+- Go remains the temporary known-good semantic terminal reference during the bakeoff.
+- Zig remains responsible only where parser/tree-sitter work still depends on it.
+
+## Non-Goals
+
+- Do not keep non-semantic TUI rendering as a supported product path.
+- Do not make the Rust rebuild depend on Go runtime code.
+- Do not port Zig parser/tree-sitter code as part of the first Rust renderer proof.
+- Do not redesign the editor kernel, agent runtime, or shell model inside Rust frontend tickets.
+- Do not add frontend-specific BEAM policy branches beyond capability negotiation.
+
+## Architecture
+
+The Rust terminal frontend should keep the BEAM process boundary intact.
+
+- **Spawned mode:** BEAM starts the Rust frontend as a port process and supervises it.
+- **Connected mode:** a native host or terminal wrapper can start the BEAM and connect over stdin/stdout-compatible framing.
+- **Future client/server mode:** the protocol and process boundary remain compatible with remote or multi-client frontends because editor state stays in the BEAM.
+
+The Swift app is the startup quality reference: it owns host startup, launches or connects to BEAM with explicit environment, observes lifecycle, and treats the BEAM as the source of truth. Rust should mirror that discipline for terminal startup without copying SwiftUI structure.
+
+## Proof Checklist
+
+- Extended `ready` reports semantic UI support and terminal capabilities.
+- BEAM startup or connection mode works without terminal ownership races.
+- Semantic UI packets decode into retained Rust state without relying on legacy draw fallbacks.
+- Ratatui renders windows, chrome, gutters, cursor, selections, status, minibuffer, file tree, picker, completion, which-key, and agent surfaces from semantic state.
+- Input events, resize events, mouse events, and shutdown flow back to BEAM correctly.
+- Terminal resize and scroll do not corrupt retained state.
+- Unknown forward-compatible semantic opcodes are skipped safely when the envelope permits it.
+- Snapshot or trace fixtures compare Rust behavior against the Go semantic reference where useful.
+- Focused Rust tests cover protocol decode, semantic state transitions, and key rendering decisions.
+
+## First Ticket Stack
+
+### Ticket 1: Lock Semantic UI Direction
+
+Issue: https://github.com/jsmestad/minga/issues/2155
+
+Goal: make the frontend contract direction explicit in docs and runner guidance so agents stop introducing GUI-vs-TUI protocol splits.
+
+Acceptance criteria:
+
+- Documentation states that Minga emits one Semantic UI contract for GUI and terminal clients.
+- Documentation states that frontend identity is opaque to Minga product behavior and capabilities drive adaptations.
+- Stale references that describe GUI chrome as native-GUI-only are either updated or called out as historical naming to be renamed.
+- Non-semantic UI support is marked dead scope except for deletion or temporary buffer-window compatibility explicitly tracked by a ticket.
+
+### Ticket 2: Remove Non-Semantic Frontend Support
+
+Issue: https://github.com/jsmestad/minga/issues/2156
+
+Goal: remove or quarantine old non-semantic frontend rendering support so new agents cannot accidentally build against it.
+
+Acceptance criteria:
+
+- BEAM-side frontend emit code has a single semantic path for shared UI.
+- Legacy cell-grid TUI support is either deleted or isolated behind an explicit temporary compatibility boundary with fail-loud behavior.
+- Go and Rust frontend code no longer silently falls back to legacy cell rendering for shared chrome.
+- Tests or guardrails fail when a shared chrome feature is added only as cell draw commands.
+
+### Ticket 3: Build Fresh Rust Semantic TUI Skeleton
+
+Issue: https://github.com/jsmestad/minga/issues/2157
+
+Goal: create the clean Rust terminal frontend skeleton that starts from the semantic contract and Ratatui terminal lifecycle instead of the current mixed renderer.
+
+Acceptance criteria:
+
+- Rust TUI has clear modules for protocol decode, semantic state, terminal lifecycle, input encode, BEAM host/connection lifecycle, and Ratatui rendering.
+- Startup sends extended semantic capabilities and receives BEAM frames without blocking terminal input.
+- The first renderer can show a minimal semantic frame with status/minibuffer/window content from semantic packets.
+- Legacy draw commands are not the normal shared-chrome rendering path.
+- Focused Rust tests cover ready encoding, semantic decode, retained state update, and at least one rendered semantic surface.

--- a/docs/workstreams/RUST_TUI_TICKET_STACK.md
+++ b/docs/workstreams/RUST_TUI_TICKET_STACK.md
@@ -1,0 +1,193 @@
+# Rust TUI Ticket Stack
+
+These are the first three tickets for the semantic-only Rust TUI direction. They are intentionally sequential: do not start ticket 2 until ticket 1 has settled the contract language, and do not start ticket 3 until ticket 2 has made the old non-semantic path hard to use accidentally.
+
+## Ticket 1: Lock Semantic UI Direction
+
+Issue: https://github.com/jsmestad/minga/issues/2155
+
+### Summary
+
+Make Minga’s frontend contract direction explicit: the BEAM emits one Semantic UI contract, and GUI/TUI/native/web clients adapt through declared capabilities rather than separate product protocols.
+
+### Developer Notes
+
+Lane: Semantic UI Contract.
+
+Inspect first:
+
+- `docs/PROTOCOL.md`
+- `docs/GUI_PROTOCOL.md`
+- `docs/RETAINED_GUI_RENDERING_SPEC.md`
+- `lib/minga_editor/frontend/capabilities.ex`
+- `lib/minga_editor/frontend/emit.ex`
+- `docs/CHARM_TUI.md`
+
+Likely modified:
+
+- `docs/PROTOCOL.md`
+- `docs/GUI_PROTOCOL.md`
+- `docs/RETAINED_GUI_RENDERING_SPEC.md`
+- `docs/ARCHITECTURE.md`
+- `docs/CHARM_TUI.md`
+
+Required direction:
+
+- Minga emits Semantic UI for shared visible UI.
+- Frontend identity is opaque to product behavior.
+- Capabilities describe rendering surfaces: terminal grid, desktop window, web, text measurement, color support, images, float support, and host mode.
+- Existing `GUI_*` names may remain temporarily as historical wire names, but docs must describe the contract as Semantic UI rather than native-GUI-only chrome.
+
+Forbidden changes:
+
+- Do not change opcode values.
+- Do not rewrite transport framing.
+- Do not implement renderer behavior.
+- Do not delete Zig parser/tree-sitter code.
+- Do not add new Swift/Rust/Go product branches in BEAM code.
+
+### Acceptance Criteria
+
+- Docs state that GUI, terminal, and future frontends consume one Semantic UI contract.
+- Docs distinguish historical `GUI` naming from the semantic contract direction.
+- Docs say non-semantic shared UI work is stale scope unless the ticket is deleting old support.
+- Capability negotiation is described as the only frontend adaptation mechanism for product behavior.
+- `mix protocol.gen --check` still passes if protocol docs or schema are touched.
+
+### Validation
+
+Run the smallest relevant set:
+
+```bash
+mix protocol.gen --check
+mix compile --warnings-as-errors
+```
+
+## Ticket 2: Remove Non-Semantic Frontend Support
+
+Issue: https://github.com/jsmestad/minga/issues/2156
+
+### Summary
+
+Remove or quarantine non-semantic shared UI rendering support so future frontend work cannot silently route chrome through legacy cell-grid paths.
+
+### Developer Notes
+
+Lane: Semantic UI Contract plus Frontend Clients.
+
+Inspect first:
+
+- `lib/minga_editor/frontend/emit.ex`
+- `lib/minga_editor/frontend/emit/tui.ex`
+- `lib/minga_editor/frontend/emit/tui/cell_command_encoder.ex`
+- `lib/minga_editor/frontend/adapter.ex`
+- `lib/minga_editor/frontend/protocol/gui.ex`
+- `go/tui/internal/ui/model.go`
+- `go/tui/internal/ui/render_content.go`
+- `rust/tui/src/renderer/mod.rs`
+- `rust/tui/src/semantic.rs`
+
+Likely modified:
+
+- BEAM frontend emit modules.
+- Go TUI semantic guardrail tests.
+- Rust TUI renderer or semantic-state code if it currently falls back silently.
+- Protocol docs if behavior changes.
+
+Required direction:
+
+- Shared chrome must be modeled as Semantic UI.
+- Legacy cell drawing may remain only for explicitly tracked temporary buffer-window compatibility, not shared chrome.
+- If a frontend receives an unsupported legacy shared chrome path, it should fail loudly in tests or log an actionable warning in development.
+
+Forbidden changes:
+
+- Do not rewrite the Rust TUI from scratch in this ticket.
+- Do not delete the Go semantic reference.
+- Do not delete Zig parser/tree-sitter code.
+- Do not change editor kernel behavior.
+- Do not broaden this into protocol renaming.
+
+### Acceptance Criteria
+
+- BEAM-side shared UI emission has one semantic path.
+- Go and Rust do not silently fall back to legacy cells for shared chrome.
+- Tests or guardrails catch shared chrome added only via cell commands.
+- Existing semantic Go TUI behavior remains usable as a reference.
+- Validation covers BEAM protocol generation and affected frontend tests.
+
+### Validation
+
+Run the smallest relevant set:
+
+```bash
+mix protocol.gen --check
+mix test.llm test/path/to/affected_test.exs
+cd go/tui && go test ./...
+cd rust/tui && cargo test
+```
+
+## Ticket 3: Build Fresh Rust Semantic TUI Skeleton
+
+Issue: https://github.com/jsmestad/minga/issues/2157
+
+### Summary
+
+Create the fresh Rust terminal frontend skeleton around Ratatui plus Terminal, semantic state, and BEAM lifecycle discipline, without carrying forward the current mixed legacy renderer as the foundation.
+
+### Developer Notes
+
+Lane: Rust terminal frontend.
+
+Inspect first:
+
+- `rust/tui/Cargo.toml`
+- `rust/tui/src/main.rs`
+- `rust/tui/src/protocol.rs`
+- `rust/tui/src/semantic.rs`
+- `rust/tui/src/terminal.rs`
+- `rust/tui/src/input.rs`
+- `macos/Sources/BEAMProcessManager.swift`
+- `lib/minga_editor/frontend/manager.ex`
+- `go/tui/internal/protocol/events.go`
+- `go/tui/internal/ui/model.go`
+
+Likely modified:
+
+- Rust TUI module layout.
+- Rust protocol and semantic state tests.
+- BEAM frontend manager only if a new Rust binary name or launch path is required.
+- Docs for running the Rust TUI.
+
+Required direction:
+
+- Rust owns terminal lifecycle correctly through Ratatui and Terminal.
+- BEAM remains the source of truth.
+- The frontend can run as a BEAM-spawned port and preserve future connected/client-server options.
+- The first renderer proves semantic decode and rendering, not full feature parity.
+
+Forbidden changes:
+
+- Do not port Zig parser/tree-sitter code.
+- Do not remove Go reference code.
+- Do not redesign the Semantic UI contract.
+- Do not add a second frontend protocol.
+- Do not make Rust own editor state.
+
+### Acceptance Criteria
+
+- Rust TUI has clear modules for protocol decode, semantic state, terminal lifecycle, input encode, BEAM host or connection lifecycle, and Ratatui rendering.
+- Startup sends extended semantic capabilities.
+- The frontend reads framed BEAM packets and updates semantic state without blocking input.
+- A minimal semantic frame renders from retained state.
+- Focused Rust tests cover ready encoding, semantic decode, retained state update, and at least one rendered semantic surface.
+
+### Validation
+
+Run the smallest relevant set:
+
+```bash
+cd rust/tui && cargo fmt --check
+cd rust/tui && cargo test
+mix compile --warnings-as-errors
+```


### PR DESCRIPTION
## Summary
- add daily-driver workstream scope for Minga stabilization
- add semantic-only Rust TUI rebuild workstream and proof checklist
- add first three ticket bodies and links for issues #2155, #2156, and #2157

## Validation
- git diff --cached --check
- rg -n "—" docs/workstreams/DAILY_DRIVER.md docs/workstreams/RUST_TUI_REBUILD.md docs/workstreams/RUST_TUI_TICKET_STACK.md