### PR TITLE
feat: let Rust TUI launch BEAM child

### DIFF
--- a/bin/minga-rust
+++ b/bin/minga-rust
@@ -4,8 +4,8 @@
 # Usage:
 #   bin/minga-rust [filename]
 #
-# Equivalent to:
-#   MINGA_TUI_IMPL=rust bin/minga [filename]
+# Starts the Rust frontend first. Rust owns terminal stdin/stdout and launches
+# the BEAM editor core as a connected child over private protocol pipes.
 
 set -euo pipefail
 
@@ -15,6 +15,8 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 (cd "$PROJECT_DIR" && mix native.build.support && mix native.build.rust_tui)
 
 export MINGA_TUI_IMPL=rust
+export MINGA_RUST_TUI_HOST=local_child
+export MINGA_PROJECT_DIR="$PROJECT_DIR"
 export MINGA_SKIP_NATIVE_LAUNCH_BUILD=1
 
-exec "$SCRIPT_DIR/minga" "$@"
+exec "$PROJECT_DIR/priv/minga-renderer-rs" "$@"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -45,5 +45,11 @@ end
 # and the parser. Without this, the BEAM process sits idle and the
 # Swift frontend sees only its default (empty) SwiftUI state.
 if port_mode == :connected do
-  config :minga, start_editor: true, backend: :gui
+  connected_backend =
+    case System.get_env("MINGA_CONNECTED_BACKEND") do
+      "tui" -> :tui
+      _ -> :gui
+    end
+
+  config :minga, start_editor: true, backend: connected_backend
 end

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -289,7 +289,7 @@ Minga's frontends use the best native toolkit for their rendering surface, but t
 
 - **macOS: Swift + Metal.** SwiftUI renders chrome (tab bar, file tree, status bar, popups) as native views. Metal renders the editor text surface with GPU-accelerated glyph rasterization via CoreText. This gives macOS users native scrolling, system fonts, trackpad gestures, and full accessibility support.
 - **Linux: GTK4 (planned).** GTK4 widgets for chrome, Cairo or OpenGL for the text surface. Native Wayland/X11 integration, IME support, system theming.
-- **Terminal: Rust TUI target.** The desired terminal frontend is a semantic Ratatui/Terminal client that renders the same Semantic UI models as native GUI clients.
+- **Terminal: Rust TUI target.** The desired terminal frontend is a semantic Ratatui/Terminal client that renders the same Semantic UI models as native GUI clients. The preferred launch path starts Rust first so Rust owns terminal stdin/stdout and launches the BEAM editor core as a connected child over private protocol pipes. The older BEAM-parent TUI path remains available until the Rust-parent path fully replaces it.
 - **Terminal bakeoff: Go semantic reference.** The Go/Bubble Tea frontend is a working semantic reference while Rust is rebuilt.
 - **Parser: Zig + tree-sitter.** Zig remains parser infrastructure until that code is replaced.
 

--- a/docs/RUST_TUI.md
+++ b/docs/RUST_TUI.md
@@ -1,18 +1,26 @@
 # Rust TUI
 
-The Rust terminal frontend is the semantic TUI target. It runs as a BEAM-spawned port by default and uses the same packet-4 framing as the Go reference and native GUI connected mode.
+The Rust terminal frontend is the semantic TUI target. It supports two launch modes over the same packet-4 frontend protocol.
+
+- Rust-parent mode: `bin/minga-rust` starts Rust first, Rust owns terminal stdin/stdout, and Rust launches the BEAM editor core as a connected child over private pipes.
+- BEAM-parent mode: `MINGA_TUI_IMPL=rust bin/minga` keeps the existing BEAM-spawned renderer path for compatibility while this migration is in flight.
 
 Build it with:
 
 ```bash
-cd rust/tui
-cargo build --release
+mix native.build.rust_tui
 ```
 
-Run Minga against it from the repo root with:
+Run the Rust-parent path from the repo root with:
 
 ```bash
-MINGA_TUI_IMPL=rust mix run --no-halt
+bin/minga-rust
 ```
 
-The Rust binary owns terminal lifecycle through `Terminal` and Ratatui. The BEAM remains the source of truth for editor state and sends Semantic UI commands; the Rust frontend decodes framed packets, retains semantic view state, renders that state, and sends input, resize, ready, and log events back over the same port.
+Run the compatibility BEAM-parent path with:
+
+```bash
+MINGA_TUI_IMPL=rust bin/minga
+```
+
+In both modes, the BEAM remains the source of truth for editor state and sends Semantic UI commands. Rust owns frontend concerns only: terminal lifecycle, input capture, resize handling, retained frontend view state, Ratatui rendering, and frontend capability reporting.

--- a/rust/tui/src/app.rs
+++ b/rust/tui/src/app.rs
@@ -7,6 +7,7 @@ use crate::semantic_state::SemanticState;
 use crate::signals;
 use crate::terminal::Terminal;
 use crossterm::event;
+use std::env;
 use std::io::{self, Write};
 use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::thread;
@@ -22,11 +23,12 @@ enum LoopEvent {
 pub fn run() -> io::Result<()> {
     let mut terminal = Terminal::open()?;
     let (cols, rows) = terminal.size();
-    let mut stdout = io::stdout().lock();
+    let cli_args = env::args().skip(1).collect::<Vec<_>>();
+    let mut host = beam_host::open(cli_args)?;
     let image_support = images::ImageSupport::default();
 
     beam_host::send_ready(
-        &mut stdout,
+        host.output(),
         FrontendCapabilities {
             width: cols,
             height: rows,
@@ -34,7 +36,7 @@ pub fn run() -> io::Result<()> {
         },
     )?;
     beam_host::log_info(
-        &mut stdout,
+        host.output(),
         &format!("started semantic rust tui size={cols}x{rows}"),
     );
 
@@ -42,15 +44,16 @@ pub fn run() -> io::Result<()> {
     let mut renderer = SemanticRenderer::new();
     let resize_signal = signals::ResizeSignal::install().ok();
     let (events_tx, events_rx) = mpsc::channel();
-    spawn_packet_reader(events_tx.clone());
+    spawn_packet_reader(host.take_reader()?, events_tx.clone());
     spawn_input_reader(events_tx);
+    let mut backend_closed = false;
 
     loop {
         if resize_signal
             .as_ref()
             .is_some_and(signals::ResizeSignal::take)
         {
-            publish_resize(&mut terminal, &mut state, &mut stdout)?;
+            publish_resize(&mut terminal, &mut state, host.output())?;
         }
 
         match events_rx.recv_timeout(Duration::from_millis(100)) {
@@ -60,31 +63,43 @@ pub fn run() -> io::Result<()> {
                     &mut state,
                     &mut renderer,
                     &mut terminal,
-                    &mut stdout,
+                    host.output(),
                 )?;
             }
             Ok(LoopEvent::Input(event)) => {
-                handle_input_event(event, &mut terminal, &mut state, &mut stdout)?;
+                handle_input_event(event, &mut terminal, &mut state, host.output())?;
             }
-            Ok(LoopEvent::BackendClosed) => break,
+            Ok(LoopEvent::BackendClosed) => {
+                backend_closed = true;
+                break;
+            }
             Err(RecvTimeoutError::Timeout) => {
                 if let Some((width, height)) = terminal.poll_size()? {
                     state.resize(width, height);
-                    beam_host::send_resize(&mut stdout, width, height)?;
+                    beam_host::send_resize(host.output(), width, height)?;
                 }
             }
             Err(RecvTimeoutError::Disconnected) => break,
         }
     }
 
-    terminal.finish()
+    terminal.finish()?;
+
+    if backend_closed
+        && let Some(status) = host.finish()
+        && !status.success()
+    {
+        return Err(io::Error::other(format!("BEAM child exited with {status}")));
+    }
+
+    host.shutdown();
+    Ok(())
 }
 
-fn spawn_packet_reader(events_tx: Sender<LoopEvent>) {
+fn spawn_packet_reader(mut reader: Box<dyn beam_host::PacketReader>, events_tx: Sender<LoopEvent>) {
     thread::spawn(move || {
-        let mut stdin = io::stdin().lock();
         loop {
-            match beam_host::read_framed_packet(&mut stdin) {
+            match beam_host::read_framed_packet(&mut reader) {
                 Ok(Some(packet)) => {
                     if events_tx.send(LoopEvent::Packet(packet)).is_err() {
                         break;
@@ -118,7 +133,7 @@ fn spawn_input_reader(events_tx: Sender<LoopEvent>) {
 fn publish_resize(
     terminal: &mut Terminal,
     state: &mut SemanticState,
-    output: &mut impl Write,
+    output: &mut (impl Write + ?Sized),
 ) -> io::Result<()> {
     if let Some((width, height)) = terminal.poll_size()? {
         let _timer = animation::RESIZE_SETTLE.timer();
@@ -132,7 +147,7 @@ fn handle_input_event(
     event: input::Event,
     terminal: &mut Terminal,
     state: &mut SemanticState,
-    output: &mut impl Write,
+    output: &mut (impl Write + ?Sized),
 ) -> io::Result<()> {
     match event {
         input::Event::Resize { cols, rows } => {
@@ -154,7 +169,7 @@ fn handle_packet(
     state: &mut SemanticState,
     renderer: &mut SemanticRenderer,
     terminal: &mut Terminal,
-    output: &mut impl Write,
+    output: &mut (impl Write + ?Sized),
 ) -> io::Result<()> {
     let mut should_render = false;
 

--- a/rust/tui/src/beam_host.rs
+++ b/rust/tui/src/beam_host.rs
@@ -1,6 +1,128 @@
 use crate::input;
 use crate::protocol::{self, Command, DecodeError};
+use std::env;
 use std::io::{self, Read, Write};
+use std::path::PathBuf;
+use std::process::{Child, Command as ProcessCommand, ExitStatus, Stdio};
+
+pub trait PacketReader: Read + Send {}
+
+impl<T> PacketReader for T where T: Read + Send {}
+
+pub trait PacketWriter: Write {}
+
+impl<T> PacketWriter for T where T: Write {}
+
+pub enum BeamHost {
+    Stdio {
+        reader: Option<Box<dyn PacketReader>>,
+        writer: Box<dyn PacketWriter>,
+    },
+    LocalChild {
+        child: Child,
+        reader: Option<Box<dyn PacketReader>>,
+        writer: Box<dyn PacketWriter>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostMode {
+    Stdio,
+    LocalChild,
+}
+
+pub fn open(cli_args: Vec<String>) -> io::Result<BeamHost> {
+    match host_mode(env::var("MINGA_RUST_TUI_HOST").ok().as_deref()) {
+        HostMode::LocalChild => spawn_local_child(cli_args),
+        HostMode::Stdio => Ok(BeamHost::Stdio {
+            reader: Some(Box::new(io::stdin())),
+            writer: Box::new(io::stdout()),
+        }),
+    }
+}
+
+fn host_mode(value: Option<&str>) -> HostMode {
+    match value {
+        Some("local_child") => HostMode::LocalChild,
+        _ => HostMode::Stdio,
+    }
+}
+
+fn spawn_local_child(cli_args: Vec<String>) -> io::Result<BeamHost> {
+    let mut command =
+        ProcessCommand::new(env::var("MINGA_BEAM_EXECUTABLE").unwrap_or_else(|_| "mix".to_owned()));
+    command.arg("minga").args(cli_args);
+
+    if let Some(project_dir) = env::var_os("MINGA_PROJECT_DIR") {
+        command.current_dir(PathBuf::from(project_dir));
+    }
+
+    command
+        .env("MINGA_PORT_MODE", "connected")
+        .env("MINGA_CONNECTED_BACKEND", "tui")
+        .env("MINGA_TUI_IMPL", "rust")
+        .env("MINGA_SKIP_NATIVE_LAUNCH_BUILD", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+
+    let mut child = command.spawn()?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::other("BEAM child stdin was not piped"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("BEAM child stdout was not piped"))?;
+
+    Ok(BeamHost::LocalChild {
+        child,
+        reader: Some(Box::new(stdout)),
+        writer: Box::new(stdin),
+    })
+}
+
+impl BeamHost {
+    pub fn take_reader(&mut self) -> io::Result<Box<dyn PacketReader>> {
+        let reader = match self {
+            Self::Stdio { reader, .. } | Self::LocalChild { reader, .. } => reader,
+        };
+
+        reader
+            .take()
+            .ok_or_else(|| io::Error::other("BEAM packet reader was already taken"))
+    }
+
+    pub fn output(&mut self) -> &mut dyn PacketWriter {
+        match self {
+            Self::Stdio { writer, .. } | Self::LocalChild { writer, .. } => writer.as_mut(),
+        }
+    }
+
+    pub fn shutdown(&mut self) {
+        if let Self::LocalChild { child, .. } = self {
+            if let Ok(Some(_status)) = child.try_wait() {
+                return;
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+
+    pub fn finish(&mut self) -> Option<ExitStatus> {
+        match self {
+            Self::Stdio { .. } => None,
+            Self::LocalChild { child, .. } => child.try_wait().ok().flatten(),
+        }
+    }
+}
+
+impl Drop for BeamHost {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrontendCapabilities {
@@ -9,18 +131,21 @@ pub struct FrontendCapabilities {
     pub image_support: u8,
 }
 
-pub fn send_ready(output: &mut impl Write, caps: FrontendCapabilities) -> io::Result<()> {
+pub fn send_ready(
+    output: &mut (impl Write + ?Sized),
+    caps: FrontendCapabilities,
+) -> io::Result<()> {
     protocol::write_packet(
         output,
         &protocol::encode_ready_with_caps(caps.width, caps.height, caps.image_support),
     )
 }
 
-pub fn send_resize(output: &mut impl Write, width: u16, height: u16) -> io::Result<()> {
+pub fn send_resize(output: &mut (impl Write + ?Sized), width: u16, height: u16) -> io::Result<()> {
     protocol::write_packet(output, &protocol::encode_resize(width, height))
 }
 
-pub fn send_input_event(event: input::Event, output: &mut impl Write) -> io::Result<()> {
+pub fn send_input_event(event: input::Event, output: &mut (impl Write + ?Sized)) -> io::Result<()> {
     match event {
         input::Event::Key {
             codepoint,
@@ -37,14 +162,14 @@ pub fn send_input_event(event: input::Event, output: &mut impl Write) -> io::Res
     }
 }
 
-pub fn log_info(output: &mut impl Write, msg: &str) {
+pub fn log_info(output: &mut (impl Write + ?Sized), msg: &str) {
     let _ = protocol::write_packet(
         output,
         &protocol::encode_log_message(protocol::LOG_LEVEL_INFO, msg),
     );
 }
 
-pub fn log_warn(output: &mut impl Write, msg: &str) {
+pub fn log_warn(output: &mut (impl Write + ?Sized), msg: &str) {
     let _ = protocol::write_packet(
         output,
         &protocol::encode_log_message(protocol::LOG_LEVEL_WARN, msg),
@@ -146,5 +271,12 @@ mod tests {
         let mut input = &[0, 0, 0, 3, 1, 2, 3][..];
         assert_eq!(read_framed_packet(&mut input).unwrap(), Some(vec![1, 2, 3]));
         assert_eq!(read_framed_packet(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn host_mode_defaults_to_stdio_unless_local_child_is_requested() {
+        assert_eq!(host_mode(None), HostMode::Stdio);
+        assert_eq!(host_mode(Some("stdio")), HostMode::Stdio);
+        assert_eq!(host_mode(Some("local_child")), HostMode::LocalChild);
     }
 }

--- a/rust/tui/src/protocol.rs
+++ b/rust/tui/src/protocol.rs
@@ -270,7 +270,7 @@ pub fn decode_command(bytes: &[u8]) -> Result<Command, DecodeError> {
     }
 }
 
-pub fn write_packet(writer: &mut impl Write, payload: &[u8]) -> io::Result<()> {
+pub fn write_packet(writer: &mut (impl Write + ?Sized), payload: &[u8]) -> io::Result<()> {
     writer.write_all(&(payload.len() as u32).to_be_bytes())?;
     writer.write_all(payload)?;
     writer.flush()


### PR DESCRIPTION
## Summary
- make bin/minga-rust start the Rust frontend first so Rust owns terminal stdin/stdout
- add a Rust local-child BEAM host that launches mix minga over private packet-4 pipes
- let connected BEAM mode select tui backend with MINGA_CONNECTED_BACKEND=tui while preserving GUI as the default
- document Rust-parent and BEAM-parent launch modes

Refs #2154

## Validation
- cargo fmt --manifest-path rust/tui/Cargo.toml --check
- cargo test --manifest-path rust/tui/Cargo.toml
- mix native.build.rust_tui
- mix compile --warnings-as-errors
- mix protocol.gen --check
- git diff --check HEAD~1..HEAD

## Notes
- Existing BEAM-parent Rust TUI launch remains available with MINGA_TUI_IMPL=rust bin/minga.