### PR TITLE
feat: write Rust TUI clipboard via OSC 52

### DIFF
--- a/rust/tui/src/app.rs
+++ b/rust/tui/src/app.rs
@@ -189,6 +189,11 @@ fn handle_packet(
         if let Some(title) = effect.title {
             terminal.set_title(&title)?;
         }
+        if let Some(clipboard) = effect.clipboard
+            && clipboard.target == 0
+        {
+            terminal.write_clipboard(&clipboard.text)?;
+        }
         should_render |= effect.render;
     }
 

--- a/rust/tui/src/semantic_state.rs
+++ b/rust/tui/src/semantic_state.rs
@@ -33,6 +33,7 @@ pub struct CursorState {
 pub struct StateEffect {
     pub render: bool,
     pub title: Option<String>,
+    pub clipboard: Option<semantic::ClipboardWrite>,
 }
 
 impl SemanticState {
@@ -85,11 +86,9 @@ impl SemanticState {
             ProtocolCommand::SetTitle(title) => StateEffect {
                 render: false,
                 title: Some(title),
+                clipboard: None,
             },
-            ProtocolCommand::Semantic(command) => {
-                self.apply_semantic_command(command);
-                StateEffect::render()
-            }
+            ProtocolCommand::Semantic(command) => self.apply_semantic_command(command),
             ProtocolCommand::DrawText(_) | ProtocolCommand::DrawStyledText(_) => {
                 self.diagnostic = Some(
                     "Semantic UI required: received legacy cell-grid command in Rust semantic TUI."
@@ -107,6 +106,7 @@ impl SemanticState {
             | ProtocolCommand::Noop(_) => StateEffect {
                 render: false,
                 title: None,
+                clipboard: None,
             },
         }
     }
@@ -178,40 +178,71 @@ impl SemanticState {
         };
     }
 
-    fn apply_semantic_command(&mut self, command: semantic::Command) {
+    fn apply_semantic_command(&mut self, command: semantic::Command) -> StateEffect {
         self.diagnostic = None;
 
         match command {
-            semantic::Command::WindowContent(window, _) => self.put_window(window),
-            semantic::Command::WindowRowsDelta(delta, _) => self.apply_window_rows_delta(delta),
-            semantic::Command::StatusBar(status_bar, _) => self.status_bar = Some(status_bar),
-            semantic::Command::TabBar(tab_bar, _) => self.tab_bar = Some(tab_bar),
-            semantic::Command::FileTree(file_tree, _) => self.file_tree = Some(file_tree),
-            semantic::Command::FileTreeSelection(selection, _) => {
-                self.apply_file_tree_selection(selection)
+            semantic::Command::WindowContent(window, _) => {
+                self.put_window(window);
+                StateEffect::render()
             }
-            semantic::Command::Cursorline(cursorline, _) => self.apply_cursorline(cursorline),
+            semantic::Command::WindowRowsDelta(delta, _) => {
+                self.apply_window_rows_delta(delta);
+                StateEffect::render()
+            }
+            semantic::Command::StatusBar(status_bar, _) => {
+                self.status_bar = Some(status_bar);
+                StateEffect::render()
+            }
+            semantic::Command::TabBar(tab_bar, _) => {
+                self.tab_bar = Some(tab_bar);
+                StateEffect::render()
+            }
+            semantic::Command::FileTree(file_tree, _) => {
+                self.file_tree = Some(file_tree);
+                StateEffect::render()
+            }
+            semantic::Command::FileTreeSelection(selection, _) => {
+                self.apply_file_tree_selection(selection);
+                StateEffect::render()
+            }
+            semantic::Command::Cursorline(cursorline, _) => {
+                self.apply_cursorline(cursorline);
+                StateEffect::render()
+            }
             semantic::Command::LineSpacing(line_spacing, _) => {
-                self.line_spacing = Some(line_spacing)
+                self.line_spacing = Some(line_spacing);
+                StateEffect::render()
             }
             semantic::Command::CursorAnimation(cursor_animation, _) => {
-                self.cursor_animation = Some(cursor_animation)
+                self.cursor_animation = Some(cursor_animation);
+                StateEffect::render()
             }
             semantic::Command::ConfigState(config_state, _) => {
-                self.config_state = Some(config_state)
+                self.config_state = Some(config_state);
+                StateEffect::render()
             }
             semantic::Command::AgentContext(agent_context, _) => {
-                self.agent_context = Some(agent_context)
+                self.agent_context = Some(agent_context);
+                StateEffect::render()
             }
             semantic::Command::HoverAction(hover_action, _) => {
-                self.hover_action = Some(hover_action)
+                self.hover_action = Some(hover_action);
+                StateEffect::render()
             }
             semantic::Command::SearchState(search_state, _) => {
-                self.search_state = Some(search_state)
+                self.search_state = Some(search_state);
+                StateEffect::render()
             }
             semantic::Command::Notifications(notifications, _) => {
-                self.notifications = Some(notifications)
+                self.notifications = Some(notifications);
+                StateEffect::render()
             }
+            semantic::Command::ClipboardWrite(clipboard, _) => StateEffect {
+                render: false,
+                title: None,
+                clipboard: Some(clipboard),
+            },
             semantic::Command::Picker(..)
             | semantic::Command::PickerPreview(..)
             | semantic::Command::Minibuffer(..)
@@ -230,7 +261,6 @@ impl SemanticState {
             | semantic::Command::SplitSeparators(..)
             | semantic::Command::IndentGuides(..)
             | semantic::Command::WindowOverlayDelta(..)
-            | semantic::Command::ClipboardWrite(..)
             | semantic::Command::Workspaces(..)
             | semantic::Command::EditTimeline(..)
             | semantic::Command::ExtensionOverlay(..)
@@ -239,7 +269,7 @@ impl SemanticState {
             | semantic::Command::Sidebars(..)
             | semantic::Command::Board(..)
             | semantic::Command::AgentChat(..)
-            | semantic::Command::ToolManager(..) => {}
+            | semantic::Command::ToolManager(..) => StateEffect::render(),
         }
     }
 
@@ -319,6 +349,7 @@ impl StateEffect {
         Self {
             render: true,
             title: None,
+            clipboard: None,
         }
     }
 }
@@ -420,6 +451,24 @@ mod tests {
                 shape: 1
             }
         );
+    }
+
+    #[test]
+    fn emits_clipboard_side_effect_without_rendering() {
+        let mut state = SemanticState::new(80, 24);
+        let effect = state.apply_protocol_command(ProtocolCommand::Semantic(
+            semantic::Command::ClipboardWrite(
+                semantic::ClipboardWrite {
+                    target: 0,
+                    text: "copied".to_owned(),
+                },
+                0,
+            ),
+        ));
+
+        assert!(!effect.render);
+        assert!(effect.title.is_none());
+        assert_eq!(effect.clipboard.unwrap().text, "copied");
     }
 
     #[test]

--- a/rust/tui/src/terminal.rs
+++ b/rust/tui/src/terminal.rs
@@ -164,6 +164,19 @@ impl Terminal {
         Ok(())
     }
 
+    pub fn write_clipboard(&mut self, text: &str) -> io::Result<()> {
+        match &mut self.backend {
+            Backend::Real(terminal) => {
+                terminal
+                    .backend_mut()
+                    .write_all(osc52_clipboard_sequence(text).as_bytes())?;
+            }
+            #[cfg(test)]
+            Backend::Test(_) => {}
+        }
+        Ok(())
+    }
+
     pub fn flush(&mut self) -> io::Result<()> {
         match &mut self.backend {
             Backend::Real(terminal) => terminal.backend_mut().flush(),
@@ -203,4 +216,47 @@ fn env_size() -> (u16, u16) {
 
 fn env_u16(name: &str) -> Option<u16> {
     env::var(name).ok()?.parse().ok()
+}
+
+fn osc52_clipboard_sequence(text: &str) -> String {
+    format!("\x1b]52;c;{}\x07", base64_encode(text.as_bytes()))
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut encoded = String::with_capacity(bytes.len().div_ceil(3) * 4);
+
+    for chunk in bytes.chunks(3) {
+        let first = chunk[0];
+        let second = chunk.get(1).copied().unwrap_or(0);
+        let third = chunk.get(2).copied().unwrap_or(0);
+
+        encoded.push(TABLE[(first >> 2) as usize] as char);
+        encoded.push(TABLE[(((first & 0b0000_0011) << 4) | (second >> 4)) as usize] as char);
+
+        if chunk.len() > 1 {
+            encoded.push(TABLE[(((second & 0b0000_1111) << 2) | (third >> 6)) as usize] as char);
+        } else {
+            encoded.push('=');
+        }
+
+        if chunk.len() > 2 {
+            encoded.push(TABLE[(third & 0b0011_1111) as usize] as char);
+        } else {
+            encoded.push('=');
+        }
+    }
+
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_osc52_clipboard_sequence() {
+        assert_eq!(osc52_clipboard_sequence("hello"), "\x1b]52;c;aGVsbG8=\x07");
+        assert_eq!(osc52_clipboard_sequence("λ\n"), "\x1b]52;c;zrsK\x07");
+    }
 }


### PR DESCRIPTION
## Summary
- Turn Rust semantic ClipboardWrite into an explicit state side effect instead of dropping it in the new semantic TUI path.
- Write general clipboard requests to the terminal with OSC 52 from the Ratatui terminal backend.
- Add regression coverage for the clipboard side effect and OSC 52 payload encoding.

Refs #2147.

## Notes
- Target 0 maps to the terminal clipboard. Target 1 is the macOS find pasteboard in the GUI protocol, which has no terminal OSC 52 equivalent, so the Rust TUI ignores it rather than writing it to the wrong clipboard.

## Validation
- cargo fmt --manifest-path rust/tui/Cargo.toml --check
- cargo test --manifest-path rust/tui/Cargo.toml
- cargo clippy --manifest-path rust/tui/Cargo.toml -- -D warnings
- mix protocol.gen --check
- mix compile --warnings-as-errors
- mix native.build.rust_tui
- git diff --check