### PR TITLE
feat: honor Rust TUI cursor animation

### DIFF
--- a/rust/tui/src/semantic_renderer.rs
+++ b/rust/tui/src/semantic_renderer.rs
@@ -16,7 +16,7 @@ impl SemanticRenderer {
     }
 
     pub fn render(&mut self, state: &SemanticState, terminal: &mut Terminal) -> io::Result<()> {
-        terminal.set_cursor_shape(state.cursor().shape)?;
+        terminal.set_cursor_style(state.cursor().shape, state.cursor_animation_enabled())?;
         terminal.draw(|frame| {
             let area = frame.area();
             let content_area = Rect {

--- a/rust/tui/src/semantic_state.rs
+++ b/rust/tui/src/semantic_state.rs
@@ -157,6 +157,11 @@ impl SemanticState {
         self.cursor
     }
 
+    pub fn cursor_animation_enabled(&self) -> bool {
+        self.cursor_animation
+            .is_none_or(|cursor_animation| cursor_animation.enabled != 0)
+    }
+
     fn clear(&mut self) {
         self.windows.clear();
         self.window_order.clear();
@@ -523,6 +528,7 @@ mod tests {
 
         assert_eq!(state.line_spacing.unwrap().value, 2);
         assert_eq!(state.cursor_animation.unwrap().enabled, 1);
+        assert!(state.cursor_animation_enabled());
         assert_eq!(state.config_state.as_ref().unwrap().payload, vec![1, 2, 3]);
         assert_eq!(state.agent_context().unwrap().task, "review");
         assert_eq!(state.hover_action.as_ref().unwrap().payload, vec![4, 5]);
@@ -533,10 +539,22 @@ mod tests {
 
         assert!(state.line_spacing.is_none());
         assert!(state.cursor_animation.is_none());
+        assert!(state.cursor_animation_enabled());
         assert!(state.config_state.is_none());
         assert!(state.agent_context().is_none());
         assert!(state.hover_action.is_none());
         assert!(state.search_state().is_none());
         assert!(state.notifications().is_none());
+    }
+
+    #[test]
+    fn cursor_animation_zero_disables_terminal_blinking() {
+        let mut state = SemanticState::new(80, 24);
+
+        state.apply_protocol_command(ProtocolCommand::Semantic(
+            semantic::Command::CursorAnimation(semantic::CursorAnimation { enabled: 0 }, 0),
+        ));
+
+        assert!(!state.cursor_animation_enabled());
     }
 }

--- a/rust/tui/src/terminal.rs
+++ b/rust/tui/src/terminal.rs
@@ -149,14 +149,13 @@ impl Terminal {
     }
 
     pub fn set_cursor_shape(&mut self, shape: u8) -> io::Result<()> {
+        self.set_cursor_style(shape, true)
+    }
+
+    pub fn set_cursor_style(&mut self, shape: u8, animated: bool) -> io::Result<()> {
         match &mut self.backend {
             Backend::Real(terminal) => {
-                let style = match shape {
-                    1 => SetCursorStyle::BlinkingBar,
-                    2 => SetCursorStyle::BlinkingUnderScore,
-                    _ => SetCursorStyle::BlinkingBlock,
-                };
-                execute!(terminal.backend_mut(), style)?;
+                execute!(terminal.backend_mut(), cursor_style(shape, animated))?;
             }
             #[cfg(test)]
             Backend::Test(_) => {}
@@ -218,6 +217,17 @@ fn env_u16(name: &str) -> Option<u16> {
     env::var(name).ok()?.parse().ok()
 }
 
+fn cursor_style(shape: u8, animated: bool) -> SetCursorStyle {
+    match (shape, animated) {
+        (1, true) => SetCursorStyle::BlinkingBar,
+        (1, false) => SetCursorStyle::SteadyBar,
+        (2, true) => SetCursorStyle::BlinkingUnderScore,
+        (2, false) => SetCursorStyle::SteadyUnderScore,
+        (_, true) => SetCursorStyle::BlinkingBlock,
+        (_, false) => SetCursorStyle::SteadyBlock,
+    }
+}
+
 fn osc52_clipboard_sequence(text: &str) -> String {
     format!("\x1b]52;c;{}\x07", base64_encode(text.as_bytes()))
 }
@@ -258,5 +268,15 @@ mod tests {
     fn encodes_osc52_clipboard_sequence() {
         assert_eq!(osc52_clipboard_sequence("hello"), "\x1b]52;c;aGVsbG8=\x07");
         assert_eq!(osc52_clipboard_sequence("λ\n"), "\x1b]52;c;zrsK\x07");
+    }
+
+    #[test]
+    fn cursor_style_uses_animation_flag() {
+        assert_eq!(cursor_style(0, true).to_string(), "\x1b[1 q");
+        assert_eq!(cursor_style(0, false).to_string(), "\x1b[2 q");
+        assert_eq!(cursor_style(2, true).to_string(), "\x1b[3 q");
+        assert_eq!(cursor_style(2, false).to_string(), "\x1b[4 q");
+        assert_eq!(cursor_style(1, true).to_string(), "\x1b[5 q");
+        assert_eq!(cursor_style(1, false).to_string(), "\x1b[6 q");
     }
 }


### PR DESCRIPTION
## Summary
- Apply retained CursorAnimation semantic state in the new Rust TUI renderer.
- Map cursor animation enabled/disabled to Crossterm blinking vs steady cursor styles for block, bar, and underscore shapes.
- Keep the old set_cursor_shape API defaulting to blinking so the legacy renderer path remains source-compatible while the new semantic renderer uses the richer style call.

Refs #2147.

## Validation
- cargo fmt --manifest-path rust/tui/Cargo.toml --check
- cargo test --manifest-path rust/tui/Cargo.toml
- cargo clippy --manifest-path rust/tui/Cargo.toml -- -D warnings
- mix protocol.gen --check
- mix compile --warnings-as-errors
- mix native.build.rust_tui
- git diff --check