### PR TITLE
feat: render Rust semantic TUI surfaces

### DIFF
--- a/rust/tui/src/semantic_renderer.rs
+++ b/rust/tui/src/semantic_renderer.rs
@@ -4,7 +4,7 @@ use crate::terminal::Terminal;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap};
 use std::io;
 
 #[derive(Debug, Default)]
@@ -37,6 +37,11 @@ impl SemanticRenderer {
             .constraints([
                 Constraint::Length(if state.tab_bar().is_some() { 1 } else { 0 }),
                 Constraint::Min(1),
+                Constraint::Length(if visible_minibuffer(state).is_some() {
+                    1
+                } else {
+                    0
+                }),
                 Constraint::Length(if state.status_bar().is_some() { 1 } else { 0 }),
             ])
             .split(area);
@@ -46,7 +51,11 @@ impl SemanticRenderer {
         }
 
         if let Some(status_bar) = state.status_bar() {
-            Self::render_status_bar(state, status_bar, vertical[2], buffer);
+            Self::render_status_bar(state, status_bar, vertical[3], buffer);
+        }
+
+        if let Some(minibuffer) = visible_minibuffer(state) {
+            Self::render_minibuffer(minibuffer, vertical[2], buffer);
         }
 
         if let Some(diagnostic) = state.diagnostic() {
@@ -69,7 +78,16 @@ impl SemanticRenderer {
             Self::render_file_tree(file_tree, horizontal[0], buffer);
         }
 
-        Self::render_windows(state, horizontal[1], buffer);
+        let editor_area = Self::render_bottom_panel(state, horizontal[1], buffer);
+        Self::render_windows(state, editor_area, buffer);
+        Self::render_breadcrumb(state, editor_area, buffer);
+        Self::render_completion(state, editor_area, buffer);
+        Self::render_signature_help(state, editor_area, buffer);
+        Self::render_hover_popup(state, editor_area, buffer);
+        Self::render_float_popup(state, editor_area, buffer);
+        Self::render_change_summary(state, editor_area, buffer);
+        Self::render_which_key(state, editor_area, buffer);
+        Self::render_picker(state, editor_area, buffer);
     }
 
     fn render_tab_bar(
@@ -191,13 +209,6 @@ impl SemanticRenderer {
             parts.push("observatory".to_owned());
         }
 
-        if let Some(board) = state
-            .board()
-            .filter(|board| board.visible != 0 && board.card_count > 0)
-        {
-            parts.push(format!("board {}", board.card_count));
-        }
-
         if let Some(agent_chat) = state
             .agent_chat()
             .filter(|agent_chat| agent_chat.visible != 0 && agent_chat.message_count > 0)
@@ -219,8 +230,42 @@ impl SemanticRenderer {
             parts.push(format!("agent {}", agent_context.task));
         }
 
+        if let Some(git_status) = state.git_status() {
+            if git_status.ahead > 0 || git_status.behind > 0 {
+                parts.push(format!("git +{}/-{}", git_status.ahead, git_status.behind));
+            }
+            if git_status.syncing {
+                parts.push("syncing".to_owned());
+            }
+            if git_status.stash_count > 0 {
+                parts.push(format!("stash {}", git_status.stash_count));
+            }
+        }
+
         parts.push(format!("{}:{}", status_bar.line, status_bar.col));
         parts.join("  ")
+    }
+
+    fn render_minibuffer(
+        minibuffer: &semantic::Minibuffer,
+        area: Rect,
+        buffer: &mut ratatui::buffer::Buffer,
+    ) {
+        let mut text = format!("{}{}", minibuffer.prompt, minibuffer.input);
+        if !minibuffer.context.is_empty() {
+            text.push_str("  ");
+            text.push_str(&minibuffer.context);
+        }
+        if minibuffer.total_candidates > 0 {
+            text.push_str(&format!(
+                "  {}/{}",
+                minibuffer.selected_index.saturating_add(1),
+                minibuffer.total_candidates
+            ));
+        }
+        Paragraph::new(text)
+            .style(Style::default().fg(Color::White).bg(Color::Black))
+            .render(area, buffer);
     }
 
     fn render_file_tree(
@@ -251,6 +296,376 @@ impl SemanticRenderer {
                 .wrap(Wrap { trim: false })
                 .render(rect, buffer);
         }
+    }
+
+    fn render_breadcrumb(state: &SemanticState, area: Rect, buffer: &mut ratatui::buffer::Buffer) {
+        let Some(breadcrumb) = state
+            .breadcrumb()
+            .filter(|breadcrumb| !breadcrumb.segments.is_empty())
+        else {
+            return;
+        };
+        let text = breadcrumb.segments.join(" / ");
+        Paragraph::new(text)
+            .style(Style::default().fg(Color::Gray))
+            .render(Rect { height: 1, ..area }, buffer);
+    }
+
+    fn render_bottom_panel(
+        state: &SemanticState,
+        area: Rect,
+        buffer: &mut ratatui::buffer::Buffer,
+    ) -> Rect {
+        let Some(panel) = state
+            .bottom_panel()
+            .filter(|panel| panel.visible && !panel.entries.is_empty())
+        else {
+            return area;
+        };
+        let percent = panel.height_percent.clamp(10, 60) as u16;
+        let requested_height = area.height.saturating_mul(percent) / 100;
+        let panel_height = bounded_dimension(requested_height, 3, area.height);
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(panel_height)])
+            .split(area);
+        let active_tab = panel
+            .tabs
+            .get(panel.active_tab_index as usize)
+            .map(|tab| tab.name.as_str())
+            .unwrap_or("Panel");
+        let lines: Vec<Line<'_>> = panel
+            .entries
+            .iter()
+            .take(chunks[1].height.saturating_sub(2) as usize)
+            .map(|entry| Line::from(format!("{}  {}", entry.file_path, entry.text)))
+            .collect();
+        Paragraph::new(lines)
+            .block(Block::default().borders(Borders::ALL).title(active_tab))
+            .style(Style::default().fg(Color::White).bg(Color::Black))
+            .wrap(Wrap { trim: false })
+            .render(chunks[1], buffer);
+        chunks[0]
+    }
+
+    fn render_completion(state: &SemanticState, area: Rect, buffer: &mut ratatui::buffer::Buffer) {
+        let Some(completion) = state
+            .completion()
+            .filter(|completion| completion.visible && !completion.items.is_empty())
+        else {
+            return;
+        };
+        let width = completion
+            .items
+            .iter()
+            .map(|item| {
+                item.label
+                    .len()
+                    .saturating_add(item.detail.len())
+                    .saturating_add(3)
+            })
+            .max()
+            .unwrap_or(20)
+            .min(area.width as usize)
+            .max(20.min(area.width as usize)) as u16;
+        let height = (completion.items.len() as u16).saturating_add(2).min(10);
+        let rect = anchored_rect(
+            area,
+            completion.anchor_col,
+            completion.anchor_row.saturating_add(1),
+            width,
+            height,
+        );
+        Clear.render(rect, buffer);
+        let lines = completion.items.iter().enumerate().map(|(index, item)| {
+            let style = if index == completion.selected_index as usize {
+                Style::default().fg(Color::Black).bg(Color::Cyan)
+            } else {
+                Style::default().fg(Color::White).bg(Color::Black)
+            };
+            Line::styled(format!("{}  {}", item.label, item.detail), style)
+        });
+        Paragraph::new(lines.collect::<Vec<_>>())
+            .block(Block::default().borders(Borders::ALL).title("Complete"))
+            .render(rect, buffer);
+    }
+
+    fn render_signature_help(
+        state: &SemanticState,
+        area: Rect,
+        buffer: &mut ratatui::buffer::Buffer,
+    ) {
+        let Some(help) = state
+            .signature_help()
+            .filter(|help| help.visible && !help.signatures.is_empty())
+        else {
+            return;
+        };
+        let signature = help
+            .signatures
+            .get(help.active_signature as usize)
+            .unwrap_or(&help.signatures[0]);
+        let rect = anchored_rect(
+            area,
+            help.anchor_col,
+            help.anchor_row.saturating_add(2),
+            area.width.min(48),
+            4,
+        );
+        Clear.render(rect, buffer);
+        Paragraph::new(vec![
+            Line::styled(signature.label.clone(), Style::default().fg(Color::Yellow)),
+            Line::from(signature.documentation.clone()),
+        ])
+        .block(Block::default().borders(Borders::ALL).title("Signature"))
+        .style(Style::default().fg(Color::White).bg(Color::Black))
+        .wrap(Wrap { trim: true })
+        .render(rect, buffer);
+    }
+
+    fn render_hover_popup(state: &SemanticState, area: Rect, buffer: &mut ratatui::buffer::Buffer) {
+        let Some(hover) = state
+            .hover_popup()
+            .filter(|hover| hover.visible && !hover.lines.is_empty())
+        else {
+            return;
+        };
+        let height = (hover.lines.len() as u16).saturating_add(2).min(8);
+        let rect = anchored_rect(
+            area,
+            hover.anchor_col,
+            hover.anchor_row.saturating_add(1),
+            area.width.min(52),
+            height,
+        );
+        Clear.render(rect, buffer);
+        let lines = hover.lines.iter().map(|line| {
+            let spans = line
+                .segments
+                .iter()
+                .map(|segment| {
+                    Span::styled(
+                        segment.text.clone(),
+                        style_from_semantic(segment.fg, 0, segment.flags as u16),
+                    )
+                })
+                .collect::<Vec<_>>();
+            Line::from(spans)
+        });
+        Paragraph::new(lines.collect::<Vec<_>>())
+            .block(Block::default().borders(Borders::ALL).title("Hover"))
+            .style(Style::default().fg(Color::White).bg(Color::Black))
+            .wrap(Wrap { trim: true })
+            .render(rect, buffer);
+    }
+
+    fn render_float_popup(state: &SemanticState, area: Rect, buffer: &mut ratatui::buffer::Buffer) {
+        let Some(popup) = state
+            .float_popup()
+            .filter(|popup| popup.visible && !popup.lines.is_empty())
+        else {
+            return;
+        };
+        let width = bounded_dimension(popup.width, 20, area.width);
+        let height = bounded_dimension(popup.height, 3, area.height);
+        let rect = centered_rect(area, width, height);
+        Clear.render(rect, buffer);
+        Paragraph::new(popup.lines.join("\n"))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(popup.title.as_str()),
+            )
+            .style(Style::default().fg(Color::White).bg(Color::Black))
+            .wrap(Wrap { trim: false })
+            .render(rect, buffer);
+    }
+
+    fn render_change_summary(
+        state: &SemanticState,
+        area: Rect,
+        buffer: &mut ratatui::buffer::Buffer,
+    ) {
+        let Some(summary) = state
+            .change_summary()
+            .filter(|summary| summary.visible && !summary.entries.is_empty())
+        else {
+            return;
+        };
+        let rect = Rect {
+            x: area
+                .x
+                .saturating_add(area.width.saturating_sub(area.width.min(44))),
+            y: area.y,
+            width: area.width.min(44),
+            height: area.height.min(12),
+        };
+        Clear.render(rect, buffer);
+        let lines = summary.entries.iter().enumerate().map(|(index, entry)| {
+            let style = if index == summary.selected_index as usize {
+                Style::default().fg(Color::Black).bg(Color::Green)
+            } else {
+                Style::default().fg(Color::White).bg(Color::Black)
+            };
+            Line::styled(
+                format!(
+                    "{} +{} -{}",
+                    entry.path, entry.lines_added, entry.lines_removed
+                ),
+                style,
+            )
+        });
+        Paragraph::new(lines.collect::<Vec<_>>())
+            .block(Block::default().borders(Borders::ALL).title("Changes"))
+            .render(rect, buffer);
+    }
+
+    fn render_which_key(state: &SemanticState, area: Rect, buffer: &mut ratatui::buffer::Buffer) {
+        let Some(which_key) = state
+            .which_key()
+            .filter(|which_key| which_key.visible && !which_key.bindings.is_empty())
+        else {
+            return;
+        };
+        let height = (which_key.bindings.len() as u16)
+            .saturating_add(2)
+            .min(area.height.min(10));
+        let rect = Rect {
+            x: area.x,
+            y: area.y.saturating_add(area.height.saturating_sub(height)),
+            width: area.width,
+            height,
+        };
+        Clear.render(rect, buffer);
+        let lines = which_key
+            .bindings
+            .iter()
+            .take(height.saturating_sub(2) as usize)
+            .map(|binding| {
+                Line::from(vec![
+                    Span::styled(
+                        format!("{} ", binding.key),
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(binding.description.clone()),
+                ])
+            });
+        Paragraph::new(lines.collect::<Vec<_>>())
+            .block(Block::default().borders(Borders::ALL).title(format!(
+                "{} {}/{}",
+                which_key.prefix,
+                which_key.page.saturating_add(1),
+                which_key.page_count.max(1)
+            )))
+            .style(Style::default().fg(Color::White).bg(Color::Black))
+            .render(rect, buffer);
+    }
+
+    fn render_picker(state: &SemanticState, area: Rect, buffer: &mut ratatui::buffer::Buffer) {
+        let Some(picker) = state.picker().filter(|picker| picker.visible) else {
+            return;
+        };
+        let width = area.width.saturating_mul(3) / 4;
+        let height = area.height.saturating_mul(3) / 4;
+        let rect = centered_rect(
+            area,
+            width.max(30).min(area.width),
+            height.max(8).min(area.height),
+        );
+        Clear.render(rect, buffer);
+        let chunks =
+            if picker.has_preview && visible_picker_preview(state).is_some() && rect.width >= 60 {
+                Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                    .split(rect)
+            } else {
+                Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Percentage(100)])
+                    .split(rect)
+            };
+        Self::render_picker_list(picker, chunks[0], buffer);
+        if chunks.len() > 1
+            && let Some(preview) = visible_picker_preview(state)
+        {
+            Self::render_picker_preview(preview, chunks[1], buffer);
+        }
+    }
+
+    fn render_picker_list(
+        picker: &semantic::Picker,
+        area: Rect,
+        buffer: &mut ratatui::buffer::Buffer,
+    ) {
+        let title = if picker.query.is_empty() {
+            format!(
+                "{} {}/{}",
+                picker.title, picker.filtered_count, picker.total_count
+            )
+        } else {
+            format!(
+                "{}: {} {}/{}",
+                picker.title, picker.query, picker.filtered_count, picker.total_count
+            )
+        };
+        let lines = picker
+            .items
+            .iter()
+            .enumerate()
+            .take(area.height.saturating_sub(2) as usize)
+            .map(|(index, item)| {
+                let style = if index == picker.selected_index as usize {
+                    Style::default().fg(Color::Black).bg(Color::Cyan)
+                } else {
+                    Style::default().fg(Color::White).bg(Color::Black)
+                };
+                let marker = if item.marked { "*" } else { " " };
+                Line::styled(
+                    format!(
+                        "{marker} {}  {} {}",
+                        item.label, item.description, item.annotation
+                    ),
+                    style,
+                )
+            });
+        Paragraph::new(lines.collect::<Vec<_>>())
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .render(area, buffer);
+    }
+
+    fn render_picker_preview(
+        preview: &semantic::PickerPreview,
+        area: Rect,
+        buffer: &mut ratatui::buffer::Buffer,
+    ) {
+        let lines = preview
+            .lines
+            .iter()
+            .take(area.height.saturating_sub(2) as usize)
+            .map(|line| {
+                let spans = line
+                    .iter()
+                    .map(|segment| {
+                        let mut style = Style::default();
+                        if segment.fg != 0 {
+                            style = style.fg(rgb(segment.fg));
+                        }
+                        if segment.bold {
+                            style = style.add_modifier(Modifier::BOLD);
+                        }
+                        Span::styled(segment.text.clone(), style)
+                    })
+                    .collect::<Vec<_>>();
+                Line::from(spans)
+            });
+        Paragraph::new(lines.collect::<Vec<_>>())
+            .block(Block::default().borders(Borders::ALL).title("Preview"))
+            .style(Style::default().fg(Color::White).bg(Color::Black))
+            .wrap(Wrap { trim: false })
+            .render(area, buffer);
     }
 
     fn row_line(row: &semantic::Row) -> Line<'_> {
@@ -330,6 +745,50 @@ fn style_from_semantic(fg: u32, bg: u32, attrs: u16) -> Style {
         style = style.add_modifier(Modifier::ITALIC);
     }
     style
+}
+
+fn visible_minibuffer(state: &SemanticState) -> Option<&semantic::Minibuffer> {
+    state.minibuffer().filter(|minibuffer| minibuffer.visible)
+}
+
+fn visible_picker_preview(state: &SemanticState) -> Option<&semantic::PickerPreview> {
+    state
+        .picker_preview()
+        .filter(|preview| preview.visible && !preview.lines.is_empty())
+}
+
+fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
+    Rect {
+        x: area.x.saturating_add(area.width.saturating_sub(width) / 2),
+        y: area
+            .y
+            .saturating_add(area.height.saturating_sub(height) / 2),
+        width,
+        height,
+    }
+}
+
+fn anchored_rect(area: Rect, col: u16, row: u16, width: u16, height: u16) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
+    let max_x = area.x.saturating_add(area.width.saturating_sub(width));
+    let max_y = area.y.saturating_add(area.height.saturating_sub(height));
+    Rect {
+        x: area.x.saturating_add(col).min(max_x),
+        y: area.y.saturating_add(row).min(max_y),
+        width,
+        height,
+    }
+}
+
+fn bounded_dimension(requested: u16, min: u16, max: u16) -> u16 {
+    if max == 0 {
+        0
+    } else {
+        requested.max(min.min(max)).min(max)
+    }
 }
 
 fn rgb(value: u32) -> Color {
@@ -514,10 +973,149 @@ mod tests {
         assert!(snapshot.contains("ext overlay 1"));
         assert!(snapshot.contains("ext panels 2"));
         assert!(snapshot.contains("observatory"));
-        assert!(snapshot.contains("board 3"));
         assert!(snapshot.contains("chat 4"));
         assert!(snapshot.contains("tools"));
         assert!(snapshot.contains("agent review"));
         assert!(snapshot.contains("12:3"));
+    }
+
+    #[test]
+    fn renders_common_semantic_surfaces() {
+        let mut state = SemanticState::new(100, 28);
+        state.apply_protocol_command(crate::protocol::Command::Semantic(
+            semantic::Command::WindowContent(
+                semantic::WindowContent {
+                    window_id: 1,
+                    origin_row: 0,
+                    origin_col: 0,
+                    text_width: 80,
+                    text_height: 20,
+                    cursor_row: 0,
+                    cursor_col: 4,
+                    cursor_shape: 1,
+                    content_epoch: 1,
+                    rows: vec![row("workspace content")],
+                    cursorline: None,
+                },
+                0,
+            ),
+        ));
+        state.apply_protocol_command(crate::protocol::Command::Semantic(
+            semantic::Command::Minibuffer(
+                semantic::Minibuffer {
+                    visible: true,
+                    prompt: ":".to_owned(),
+                    input: "write".to_owned(),
+                    context: "command".to_owned(),
+                    selected_index: 0,
+                    total_candidates: 2,
+                    ..semantic::Minibuffer::default()
+                },
+                0,
+            ),
+        ));
+        state.apply_protocol_command(crate::protocol::Command::Semantic(
+            semantic::Command::BottomPanel(
+                semantic::BottomPanel {
+                    visible: true,
+                    active_tab_index: 0,
+                    height_percent: 25,
+                    tabs: vec![semantic::BottomPanelTab {
+                        tab_type: 0,
+                        name: "Problems".to_owned(),
+                    }],
+                    entries: vec![semantic::BottomPanelEntry {
+                        id: 1,
+                        level: 1,
+                        subsystem: 0,
+                        timestamp_secs: 0,
+                        file_path: "lib/minga.ex".to_owned(),
+                        text: "warning text".to_owned(),
+                    }],
+                    ..semantic::BottomPanel::default()
+                },
+                0,
+            ),
+        ));
+        state.apply_protocol_command(crate::protocol::Command::Semantic(
+            semantic::Command::Completion(
+                semantic::Completion {
+                    visible: true,
+                    anchor_row: 1,
+                    anchor_col: 2,
+                    selected_index: 0,
+                    items: vec![semantic::CompletionItem {
+                        kind: 0,
+                        label: "Enum.map".to_owned(),
+                        detail: "fn".to_owned(),
+                    }],
+                },
+                0,
+            ),
+        ));
+        state.apply_protocol_command(crate::protocol::Command::Semantic(
+            semantic::Command::WhichKey(
+                semantic::WhichKey {
+                    visible: true,
+                    prefix: "SPC".to_owned(),
+                    page: 0,
+                    page_count: 1,
+                    bindings: vec![semantic::WhichKeyBinding {
+                        kind: 0,
+                        key: "f".to_owned(),
+                        description: "find file".to_owned(),
+                        icon: String::new(),
+                    }],
+                },
+                0,
+            ),
+        ));
+        state.apply_protocol_command(crate::protocol::Command::Semantic(
+            semantic::Command::FloatPopup(
+                semantic::FloatPopup {
+                    visible: true,
+                    width: 24,
+                    height: 5,
+                    title: "Info".to_owned(),
+                    lines: vec!["float detail".to_owned()],
+                },
+                0,
+            ),
+        ));
+        state.apply_protocol_command(crate::protocol::Command::Semantic(
+            semantic::Command::Picker(
+                semantic::Picker {
+                    visible: true,
+                    selected_index: 0,
+                    filtered_count: 1,
+                    total_count: 3,
+                    title: "Files".to_owned(),
+                    query: "minga".to_owned(),
+                    items: vec![semantic::PickerItem {
+                        label: "mix.exs".to_owned(),
+                        description: "root".to_owned(),
+                        annotation: "modified".to_owned(),
+                        icon_color: 0,
+                        marked: true,
+                    }],
+                    ..semantic::Picker::default()
+                },
+                0,
+            ),
+        ));
+
+        let mut terminal = Terminal::memory(100, 28);
+        SemanticRenderer::new()
+            .render(&state, &mut terminal)
+            .unwrap();
+
+        let snapshot = terminal.buffer_text();
+        assert!(snapshot.contains(":write  command  1/2"));
+        assert!(snapshot.contains("Problems"));
+        assert!(snapshot.contains("warning text"));
+        assert!(snapshot.contains("Enum.map"));
+        assert!(snapshot.contains("find file"));
+        assert!(snapshot.contains("Files: minga 1/3"));
+        assert!(snapshot.contains("mix.exs"));
     }
 }

--- a/rust/tui/src/semantic_state.rs
+++ b/rust/tui/src/semantic_state.rs
@@ -11,6 +11,18 @@ pub struct SemanticState {
     status_bar: Option<semantic::StatusBar>,
     tab_bar: Option<semantic::TabBar>,
     file_tree: Option<semantic::FileTree>,
+    picker: Option<semantic::Picker>,
+    picker_preview: Option<semantic::PickerPreview>,
+    minibuffer: Option<semantic::Minibuffer>,
+    breadcrumb: Option<semantic::Breadcrumb>,
+    completion: Option<semantic::Completion>,
+    which_key: Option<semantic::WhichKey>,
+    signature_help: Option<semantic::SignatureHelp>,
+    float_popup: Option<semantic::FloatPopup>,
+    hover_popup: Option<semantic::HoverPopup>,
+    bottom_panel: Option<semantic::BottomPanel>,
+    change_summary: Option<semantic::ChangeSummary>,
+    git_status: Option<semantic::GitStatus>,
     line_spacing: Option<semantic::LineSpacing>,
     cursor_animation: Option<semantic::CursorAnimation>,
     config_state: Option<semantic::ConfigState>,
@@ -55,6 +67,18 @@ impl SemanticState {
             status_bar: None,
             tab_bar: None,
             file_tree: None,
+            picker: None,
+            picker_preview: None,
+            minibuffer: None,
+            breadcrumb: None,
+            completion: None,
+            which_key: None,
+            signature_help: None,
+            float_popup: None,
+            hover_popup: None,
+            bottom_panel: None,
+            change_summary: None,
+            git_status: None,
             line_spacing: None,
             cursor_animation: None,
             config_state: None,
@@ -155,6 +179,54 @@ impl SemanticState {
         self.file_tree.as_ref()
     }
 
+    pub fn picker(&self) -> Option<&semantic::Picker> {
+        self.picker.as_ref()
+    }
+
+    pub fn picker_preview(&self) -> Option<&semantic::PickerPreview> {
+        self.picker_preview.as_ref()
+    }
+
+    pub fn minibuffer(&self) -> Option<&semantic::Minibuffer> {
+        self.minibuffer.as_ref()
+    }
+
+    pub fn breadcrumb(&self) -> Option<&semantic::Breadcrumb> {
+        self.breadcrumb.as_ref()
+    }
+
+    pub fn completion(&self) -> Option<&semantic::Completion> {
+        self.completion.as_ref()
+    }
+
+    pub fn which_key(&self) -> Option<&semantic::WhichKey> {
+        self.which_key.as_ref()
+    }
+
+    pub fn signature_help(&self) -> Option<&semantic::SignatureHelp> {
+        self.signature_help.as_ref()
+    }
+
+    pub fn float_popup(&self) -> Option<&semantic::FloatPopup> {
+        self.float_popup.as_ref()
+    }
+
+    pub fn hover_popup(&self) -> Option<&semantic::HoverPopup> {
+        self.hover_popup.as_ref()
+    }
+
+    pub fn bottom_panel(&self) -> Option<&semantic::BottomPanel> {
+        self.bottom_panel.as_ref()
+    }
+
+    pub fn change_summary(&self) -> Option<&semantic::ChangeSummary> {
+        self.change_summary.as_ref()
+    }
+
+    pub fn git_status(&self) -> Option<&semantic::GitStatus> {
+        self.git_status.as_ref()
+    }
+
     pub fn agent_context(&self) -> Option<&semantic::AgentContext> {
         self.agent_context.as_ref()
     }
@@ -191,10 +263,6 @@ impl SemanticState {
         self.sidebars.as_ref()
     }
 
-    pub fn board(&self) -> Option<semantic::Board> {
-        self.board
-    }
-
     pub fn agent_chat(&self) -> Option<semantic::AgentChat> {
         self.agent_chat
     }
@@ -222,6 +290,18 @@ impl SemanticState {
         self.status_bar = None;
         self.tab_bar = None;
         self.file_tree = None;
+        self.picker = None;
+        self.picker_preview = None;
+        self.minibuffer = None;
+        self.breadcrumb = None;
+        self.completion = None;
+        self.which_key = None;
+        self.signature_help = None;
+        self.float_popup = None;
+        self.hover_popup = None;
+        self.bottom_panel = None;
+        self.change_summary = None;
+        self.git_status = None;
         self.line_spacing = None;
         self.cursor_animation = None;
         self.config_state = None;
@@ -272,6 +352,54 @@ impl SemanticState {
             }
             semantic::Command::FileTreeSelection(selection, _) => {
                 self.apply_file_tree_selection(selection);
+                StateEffect::render()
+            }
+            semantic::Command::Picker(picker, _) => {
+                self.picker = Some(picker);
+                StateEffect::render()
+            }
+            semantic::Command::PickerPreview(preview, _) => {
+                self.picker_preview = Some(preview);
+                StateEffect::render()
+            }
+            semantic::Command::Minibuffer(minibuffer, _) => {
+                self.minibuffer = Some(minibuffer);
+                StateEffect::render()
+            }
+            semantic::Command::Breadcrumb(breadcrumb, _) => {
+                self.breadcrumb = Some(breadcrumb);
+                StateEffect::render()
+            }
+            semantic::Command::Completion(completion, _) => {
+                self.completion = Some(completion);
+                StateEffect::render()
+            }
+            semantic::Command::WhichKey(which_key, _) => {
+                self.which_key = Some(which_key);
+                StateEffect::render()
+            }
+            semantic::Command::SignatureHelp(signature_help, _) => {
+                self.signature_help = Some(signature_help);
+                StateEffect::render()
+            }
+            semantic::Command::FloatPopup(float_popup, _) => {
+                self.float_popup = Some(float_popup);
+                StateEffect::render()
+            }
+            semantic::Command::HoverPopup(hover_popup, _) => {
+                self.hover_popup = Some(hover_popup);
+                StateEffect::render()
+            }
+            semantic::Command::BottomPanel(bottom_panel, _) => {
+                self.bottom_panel = Some(bottom_panel);
+                StateEffect::render()
+            }
+            semantic::Command::ChangeSummary(change_summary, _) => {
+                self.change_summary = Some(change_summary);
+                StateEffect::render()
+            }
+            semantic::Command::GitStatus(git_status, _) => {
+                self.git_status = Some(git_status);
                 StateEffect::render()
             }
             semantic::Command::Cursorline(cursorline, _) => {
@@ -347,19 +475,7 @@ impl SemanticState {
                 self.tool_manager = Some(tool_manager);
                 StateEffect::render()
             }
-            semantic::Command::Picker(..)
-            | semantic::Command::PickerPreview(..)
-            | semantic::Command::Minibuffer(..)
-            | semantic::Command::Breadcrumb(..)
-            | semantic::Command::Completion(..)
-            | semantic::Command::WhichKey(..)
-            | semantic::Command::SignatureHelp(..)
-            | semantic::Command::FloatPopup(..)
-            | semantic::Command::HoverPopup(..)
-            | semantic::Command::BottomPanel(..)
-            | semantic::Command::ChangeSummary(..)
-            | semantic::Command::GitStatus(..)
-            | semantic::Command::Theme(..)
+            semantic::Command::Theme(..)
             | semantic::Command::Gutter(..)
             | semantic::Command::GutterSeparator(..)
             | semantic::Command::SplitSeparators(..)
@@ -689,7 +805,7 @@ mod tests {
         assert_eq!(state.extension_panel().unwrap().panel_count, 6);
         assert_eq!(state.observatory().unwrap().payload, vec![6, 7]);
         assert_eq!(state.sidebars().unwrap().sidebar_count, 8);
-        assert_eq!(state.board().unwrap().card_count, 10);
+        assert_eq!(state.board.unwrap().card_count, 10);
         assert_eq!(state.agent_chat().unwrap().message_count, 11);
         assert_eq!(state.tool_manager().unwrap().visible, 1);
 
@@ -709,7 +825,7 @@ mod tests {
         assert!(state.extension_panel().is_none());
         assert!(state.observatory().is_none());
         assert!(state.sidebars().is_none());
-        assert!(state.board().is_none());
+        assert!(state.board.is_none());
         assert!(state.agent_chat().is_none());
         assert!(state.tool_manager().is_none());
     }

--- a/rust/tui/src/terminal.rs
+++ b/rust/tui/src/terminal.rs
@@ -126,6 +126,7 @@ impl Terminal {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn set_cursor_shape(&mut self, shape: u8) -> io::Result<()> {
         self.set_cursor_style(shape, true)
     }


### PR DESCRIPTION
## Summary
- retain common decoded Semantic UI surfaces in Rust state instead of discarding them after decode
- render compact Ratatui surfaces for minibuffer, picker, picker preview, completion, which-key, signature help, hover, float popup, bottom panel, change summary, breadcrumb, and git status indicators
- remove Board from visible Rust TUI status rendering while leaving protocol decode/state cleanup to the Board extension ticket

## Validation
- mix protocol.gen --check
- cargo fmt --manifest-path rust/tui/Cargo.toml --check
- cargo test --manifest-path rust/tui/Cargo.toml
- cargo clippy --manifest-path rust/tui/Cargo.toml -- -D warnings
- mix compile --warnings-as-errors
- mix native.build.rust_tui
- git diff --check