### PR TITLE
Rust TUI component layer and visual parity

### DIFF
--- a/rust/tui/src/renderer/chrome.rs
+++ b/rust/tui/src/renderer/chrome.rs
@@ -1,43 +1,48 @@
+use super::components;
 use super::layout;
 use super::theme;
+use super::theme::Palette;
 use crate::semantic;
 use crate::semantic_state::SemanticState;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
-use unicode_width::UnicodeWidthStr;
 
 pub fn render(state: &SemanticState, frame: &layout::FrameLayout, buffer: &mut Buffer) {
+    let palette = Palette::new(state.theme());
+
     if let Some(workspaces) = layout::visible_workspaces(state) {
-        render_workspace_bar(workspaces, state.theme(), frame.workspace_bar, buffer);
+        render_workspace_bar(workspaces, &palette, frame.workspace_bar, buffer);
     }
 
     if let Some(tab_bar) = state.tab_bar() {
-        render_tab_bar(tab_bar, state.theme(), frame.tab_bar, buffer);
+        Paragraph::new(components::tab_strip(&tab_bar.tabs, &palette))
+            .render(frame.tab_bar, buffer);
+    }
+
+    if let Some(breadcrumb) = layout::visible_breadcrumb(state) {
+        render_breadcrumb(breadcrumb, state, &palette, frame.breadcrumb, buffer);
     }
 
     if let Some(status_bar) = state.status_bar() {
-        render_status_bar(state, status_bar, frame.status_bar, buffer);
+        render_status_bar(state, status_bar, &palette, frame.status_bar, buffer);
     }
 
     if let Some(minibuffer) = layout::visible_minibuffer(state) {
-        render_minibuffer(minibuffer, state.theme(), frame.minibuffer, buffer);
+        render_minibuffer(minibuffer, &palette, frame.minibuffer, buffer);
     }
 }
 
 fn render_workspace_bar(
     workspaces: &semantic::Workspaces,
-    theme_state: Option<&semantic::Theme>,
+    palette: &Palette<'_>,
     area: Rect,
     buffer: &mut Buffer,
 ) {
     let text = workspace_bar_text(workspaces);
-    Paragraph::new(Line::from(vec![Span::styled(
-        pad_to_width(&text, area.width as usize),
-        theme::canvas(theme_state),
-    )]))
-    .render(area, buffer);
+    components::full_width_bar(&text, area, palette.editor_surface(), buffer);
 }
 
 fn workspace_bar_text(workspaces: &semantic::Workspaces) -> String {
@@ -95,60 +100,69 @@ fn plural_count(count: u16, label: &str) -> String {
     }
 }
 
-fn render_tab_bar(
-    tab_bar: &semantic::TabBar,
-    theme_state: Option<&semantic::Theme>,
-    area: Rect,
-    buffer: &mut Buffer,
-) {
-    let spans: Vec<Span<'_>> = tab_bar
-        .tabs
-        .iter()
-        .map(|tab| {
-            let label = if tab.dirty {
-                format!(" {} * ", tab.label)
-            } else {
-                format!(" {} ", tab.label)
-            };
-            Span::styled(label, theme::tab(theme_state, tab.active))
-        })
-        .collect();
-    Paragraph::new(Line::from(spans)).render(area, buffer);
-}
-
 fn render_status_bar(
     state: &SemanticState,
     status_bar: &semantic::StatusBar,
+    palette: &Palette<'_>,
     area: Rect,
     buffer: &mut Buffer,
 ) {
-    let left_spans = status_left_spans(state, status_bar);
-    let left_width = line_width(&left_spans);
-    let right_spans = status_right_spans(state, status_bar);
-    let right_width = line_width(&right_spans);
-    let width = area.width as usize;
-    let padding = width.saturating_sub(left_width.saturating_add(right_width));
+    if !status_bar.left_segments.is_empty() || !status_bar.right_segments.is_empty() {
+        render_segmented_status_bar(status_bar, palette, area, buffer);
+    } else {
+        render_fallback_status_bar(state, status_bar, palette, area, buffer);
+    }
+}
+
+fn render_segmented_status_bar(
+    status_bar: &semantic::StatusBar,
+    palette: &Palette<'_>,
+    area: Rect,
+    buffer: &mut Buffer,
+) {
+    let base = palette.status_bar();
+    let left_spans: Vec<Span<'_>> = status_bar
+        .left_segments
+        .iter()
+        .map(|s| status_segment_span(s, palette))
+        .collect();
+    let right_spans: Vec<Span<'_>> = status_bar
+        .right_segments
+        .iter()
+        .map(|s| status_segment_span(s, palette))
+        .collect();
+    let left_width: usize = left_spans.iter().map(|s| s.content.len()).sum();
+    let right_width: usize = right_spans.iter().map(|s| s.content.len()).sum();
+    let available = (area.width as usize).saturating_sub(left_width + right_width);
+
     let mut spans = left_spans;
-    spans.push(Span::styled(
-        " ".repeat(padding),
-        theme::status_bar(state.theme()),
-    ));
+
+    if !status_bar.message.is_empty() {
+        let msg = &status_bar.message;
+        let msg_width = msg.len().min(available);
+        let left_pad = available.saturating_sub(msg_width) / 2;
+        let right_pad = available.saturating_sub(msg_width).saturating_sub(left_pad);
+        spans.push(Span::styled(" ".repeat(left_pad), base));
+        spans.push(Span::styled(
+            msg[..msg_width].to_owned(),
+            base.fg(palette.warning()).add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::styled(" ".repeat(right_pad), base));
+    } else {
+        spans.push(Span::styled(" ".repeat(available), base));
+    }
+
     spans.extend(right_spans);
     Paragraph::new(Line::from(spans)).render(area, buffer);
 }
 
-fn status_left_spans<'a>(
+fn render_fallback_status_bar(
     state: &SemanticState,
-    status_bar: &'a semantic::StatusBar,
-) -> Vec<Span<'a>> {
-    if !status_bar.left_segments.is_empty() || !status_bar.right_segments.is_empty() {
-        return status_bar
-            .left_segments
-            .iter()
-            .map(status_segment_span)
-            .collect();
-    }
-
+    status_bar: &semantic::StatusBar,
+    palette: &Palette<'_>,
+    area: Rect,
+    buffer: &mut Buffer,
+) {
     let mut left = if status_bar.filename.is_empty() {
         status_bar.message.clone()
     } else {
@@ -158,45 +172,32 @@ fn status_left_spans<'a>(
         left.push_str("  ");
         left.push_str(&status_bar.branch);
     }
-    vec![Span::styled(left, theme::status_bar(state.theme()))]
-}
-
-fn status_right_spans<'a>(
-    state: &SemanticState,
-    status_bar: &'a semantic::StatusBar,
-) -> Vec<Span<'a>> {
-    if !status_bar.right_segments.is_empty() {
-        return status_bar
-            .right_segments
-            .iter()
-            .map(status_segment_span)
-            .collect();
-    }
-
-    vec![Span::styled(
+    let left_spans = vec![Span::styled(left, palette.status_bar())];
+    let right_spans = vec![Span::styled(
         status_right_text(state, status_bar),
-        theme::status_bar(state.theme()),
-    )]
+        palette.status_bar(),
+    )];
+    components::styled_bar(left_spans, right_spans, area, palette.status_bar(), buffer);
 }
 
-fn status_segment_span(segment: &semantic::StatusSegment) -> Span<'_> {
-    Span::styled(
-        segment.text.clone(),
-        theme::semantic(segment.fg, segment.bg, segment.attrs),
-    )
-}
-
-fn line_width(spans: &[Span<'_>]) -> usize {
-    spans.iter().map(|span| span.content.as_ref().width()).sum()
-}
-
-fn pad_to_width(text: &str, width: usize) -> String {
-    let text_width = text.width();
-    if text_width >= width {
-        text.to_owned()
-    } else {
-        format!("{}{}", text, " ".repeat(width - text_width))
+fn status_segment_span<'a>(segment: &'a semantic::StatusSegment, palette: &Palette<'_>) -> Span<'a> {
+    let mut style = palette.status_bar();
+    if segment.fg != 0 {
+        style = style.fg(theme::rgb(segment.fg));
     }
+    if segment.bg != 0 {
+        style = style.bg(theme::rgb(segment.bg));
+    }
+    if segment.attrs & 0x01 != 0 {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    if segment.attrs & 0x02 != 0 {
+        style = style.add_modifier(Modifier::UNDERLINED);
+    }
+    if segment.attrs & 0x04 != 0 {
+        style = style.add_modifier(Modifier::ITALIC);
+    }
+    Span::styled(segment.text.clone(), style)
 }
 
 fn status_right_text(state: &SemanticState, status_bar: &semantic::StatusBar) -> String {
@@ -316,9 +317,38 @@ fn agent_chat_status_label(status: u8) -> &'static str {
     }
 }
 
+fn render_breadcrumb(
+    breadcrumb: &semantic::Breadcrumb,
+    state: &SemanticState,
+    palette: &Palette<'_>,
+    area: Rect,
+    buffer: &mut Buffer,
+) {
+    let separator = Span::styled(" › ", Style::default().fg(palette.gutter_fg()).bg(palette.editor_bg()));
+    let mut spans: Vec<Span<'_>> = Vec::new();
+    spans.push(Span::styled("  ", palette.editor_surface()));
+    for (index, segment) in breadcrumb.segments.iter().enumerate() {
+        if index > 0 {
+            spans.push(separator.clone());
+        }
+        let style = if index == breadcrumb.segments.len() - 1 {
+            Style::default().fg(palette.editor_text()).bg(palette.editor_bg())
+        } else {
+            palette.muted()
+        };
+        spans.push(Span::styled(segment.clone(), style));
+    }
+    if let Some(git_status) = state.git_status().filter(|git| !git.branch.is_empty()) {
+        let git_text = format!("  ·  {}", git_status.branch);
+        spans.push(Span::styled(git_text, palette.muted()));
+    }
+    let left = spans;
+    components::styled_bar(left, Vec::new(), area, palette.editor_surface(), buffer);
+}
+
 fn render_minibuffer(
     minibuffer: &semantic::Minibuffer,
-    theme_state: Option<&semantic::Theme>,
+    palette: &Palette<'_>,
     area: Rect,
     buffer: &mut Buffer,
 ) {
@@ -335,6 +365,6 @@ fn render_minibuffer(
         ));
     }
     Paragraph::new(text)
-        .style(theme::minibuffer(theme_state))
+        .style(palette.minibuffer())
         .render(area, buffer);
 }

--- a/rust/tui/src/renderer/components.rs
+++ b/rust/tui/src/renderer/components.rs
@@ -1,0 +1,139 @@
+use super::theme::Palette;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap};
+use unicode_width::UnicodeWidthStr;
+
+pub fn popup_frame<'a>(
+    title: impl Into<String>,
+    lines: Vec<Line<'a>>,
+    rect: Rect,
+    palette: &Palette<'_>,
+    buffer: &mut Buffer,
+) {
+    Clear.render(rect, buffer);
+    let border_style = Style::default().fg(palette.popup_border());
+    Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(title.into()),
+        )
+        .style(palette.overlay())
+        .render(rect, buffer);
+}
+
+pub fn popup_frame_wrapped<'a>(
+    title: impl Into<String>,
+    lines: Vec<Line<'a>>,
+    rect: Rect,
+    palette: &Palette<'_>,
+    buffer: &mut Buffer,
+) {
+    Clear.render(rect, buffer);
+    let border_style = Style::default().fg(palette.popup_border());
+    Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(title.into()),
+        )
+        .style(palette.overlay())
+        .wrap(Wrap { trim: true })
+        .render(rect, buffer);
+}
+
+pub fn styled_bar(
+    left: Vec<Span<'_>>,
+    right: Vec<Span<'_>>,
+    area: Rect,
+    fill_style: Style,
+    buffer: &mut Buffer,
+) {
+    let left_width: usize = left.iter().map(|s| s.content.as_ref().width()).sum();
+    let right_width: usize = right.iter().map(|s| s.content.as_ref().width()).sum();
+    let padding = (area.width as usize).saturating_sub(left_width.saturating_add(right_width));
+    let mut spans = left;
+    spans.push(Span::styled(" ".repeat(padding), fill_style));
+    spans.extend(right);
+    Paragraph::new(Line::from(spans)).render(area, buffer);
+}
+
+pub fn full_width_bar(text: &str, area: Rect, style: Style, buffer: &mut Buffer) {
+    let text_width = text.width();
+    let padded = if text_width >= area.width as usize {
+        text.to_owned()
+    } else {
+        format!("{}{}", text, " ".repeat(area.width as usize - text_width))
+    };
+    Paragraph::new(Line::from(vec![Span::styled(padded, style)])).render(area, buffer);
+}
+
+pub fn list_item_line<'a>(
+    text: impl Into<String>,
+    selected: bool,
+    palette: &Palette<'_>,
+) -> Line<'a> {
+    let style = if selected {
+        palette.popup_selection()
+    } else {
+        palette.overlay()
+    };
+    Line::styled(text.into(), style)
+}
+
+pub fn tab_strip<'a>(
+    tabs: &[super::super::semantic::Tab],
+    palette: &Palette<'_>,
+) -> Line<'a> {
+    let mut spans: Vec<Span<'a>> = Vec::new();
+    for tab in tabs {
+        let active_style = palette.tab_active();
+        let inactive_style = palette.tab_inactive();
+        let base_style = if tab.active {
+            active_style
+        } else if tab.tint != 0 {
+            inactive_style.fg(super::theme::rgb(tab.tint))
+        } else {
+            inactive_style
+        };
+
+        if tab.active {
+            spans.push(Span::styled(
+                "▌",
+                Style::default().fg(palette.accent()).bg(active_style.bg.unwrap_or(ratatui::style::Color::Reset)),
+            ));
+            spans.push(Span::styled(" ", base_style));
+        } else {
+            spans.push(Span::styled(" ", base_style));
+        }
+
+        if !tab.icon.is_empty() {
+            spans.push(Span::styled(format!("{} ", tab.icon), base_style));
+        }
+
+        spans.push(Span::styled(tab.label.clone(), base_style));
+
+        if tab.dirty {
+            let dirty_style = if tab.active {
+                Style::default().fg(palette.tab_dirty()).bg(active_style.bg.unwrap_or(ratatui::style::Color::Reset))
+            } else {
+                Style::default().fg(palette.tab_dirty()).bg(inactive_style.bg.unwrap_or(ratatui::style::Color::Reset))
+            };
+            spans.push(Span::styled(" *", dirty_style));
+        }
+
+        if tab.attention {
+            let attn_style = Style::default().fg(palette.tab_attention()).bg(inactive_style.bg.unwrap_or(ratatui::style::Color::Reset));
+            spans.push(Span::styled(" !", attn_style));
+        }
+
+        spans.push(Span::styled(" ", base_style));
+    }
+    Line::from(spans)
+}
+

--- a/rust/tui/src/renderer/editor.rs
+++ b/rust/tui/src/renderer/editor.rs
@@ -1,5 +1,6 @@
 use super::geometry;
 use super::theme;
+use super::theme::Palette;
 use crate::semantic;
 use crate::semantic_state::SemanticState;
 use ratatui::buffer::Buffer;
@@ -14,6 +15,7 @@ use unicode_width::UnicodeWidthStr;
 struct RowRenderContext<'a> {
     gutter: Option<&'a semantic::Gutter>,
     indent_guides: Option<&'a semantic::IndentGuides>,
+    palette: Palette<'a>,
     theme: Option<&'a semantic::Theme>,
 }
 
@@ -23,24 +25,78 @@ pub fn render_file_tree(
     area: Rect,
     buffer: &mut Buffer,
 ) {
+    let palette = Palette::new(theme_state);
+    let is_dir = |row: &semantic::FileTreeRow| row.flags & 0x01 != 0;
+
+    if !file_tree.error.is_empty() {
+        let lines = vec![Line::styled(&file_tree.error, palette.muted())];
+        Paragraph::new(lines)
+            .style(palette.tree())
+            .render(area, buffer);
+        return;
+    }
+
+    if file_tree.rows.is_empty() {
+        let msg = match file_tree.status {
+            1 => "Loading files...",
+            _ => "No files",
+        };
+        Paragraph::new(vec![Line::styled(msg, palette.muted())])
+            .style(palette.tree())
+            .render(area, buffer);
+        return;
+    }
+
     let lines = file_tree.rows.iter().map(|row| {
         let indent = "  ".repeat(row.depth as usize);
-        let marker = if row.id == file_tree.selected_id {
-            ">"
+        let selected = row.id == file_tree.selected_id;
+        let dir = is_dir(row);
+        let expansion = if dir {
+            if row.flags & 0x02 != 0 { "v " } else { "> " }
         } else {
-            " "
+            "  "
         };
-        let style = if row.id == file_tree.selected_id {
-            theme::tree_selected(theme_state)
-        } else if row.flags & 0x01 != 0 {
-            theme::tree_dir(theme_state)
+        let marker = if selected { ">" } else { " " };
+        let icon_text = if row.icon.is_empty() {
+            String::new()
         } else {
-            theme::tree(theme_state)
+            format!("{} ", row.icon)
         };
-        Line::styled(format!("{marker}{indent}{} {}", row.icon, row.name), style)
+        let git_marker = match row.git_status {
+            1 => " M",
+            2 => " A",
+            3 => " D",
+            4 => " R",
+            5 => " ?",
+            _ => "",
+        };
+        let style = if selected {
+            palette.tree_selection()
+        } else if dir {
+            palette.tree_dir()
+        } else {
+            palette.tree()
+        };
+        let mut spans = vec![Span::styled(
+            format!("{marker}{indent}{expansion}{icon_text}{}{git_marker}", row.name),
+            style,
+        )];
+        let diag_total = row.diagnostics.0 + row.diagnostics.1;
+        if diag_total > 0 {
+            let diag_color = if row.diagnostics.0 > 0 {
+                palette.diagnostic_fg(0)
+            } else {
+                palette.diagnostic_fg(1)
+            };
+            spans.push(Span::styled(
+                format!(" {diag_total}"),
+                Style::default().fg(diag_color),
+            ));
+        }
+        Line::from(spans)
     });
     Paragraph::new(lines.collect::<Vec<_>>())
-        .style(theme::tree(theme_state))
+        .style(palette.tree())
         .wrap(Wrap { trim: false })
         .render(area, buffer);
 }
@@ -51,36 +107,35 @@ pub fn render_sidebars(
     area: Rect,
     buffer: &mut Buffer,
 ) {
-    let lines = std::iter::once(Line::from(Span::styled(
-        "Sidebars",
-        theme::muted(theme_state),
-    )))
-    .chain(sidebars.visible_items().map(|sidebar| {
-        let label = if sidebar.icon.is_empty() {
-            sidebar.display_name.clone()
-        } else {
-            format!("{} {}", sidebar.icon, sidebar.display_name)
-        };
-        let badge = if sidebar.badge_count != u16::MAX && sidebar.badge_count > 0 {
-            format!(" {}", sidebar.badge_count)
-        } else {
-            String::new()
-        };
-        let style = if sidebar.id == sidebars.active_id || sidebar.focused {
-            theme::selected(theme_state)
-        } else {
-            theme::muted(theme_state)
-        };
-        Line::from(Span::styled(format!(" {label}{badge}"), style))
-    }))
-    .collect::<Vec<_>>();
+    let palette = Palette::new(theme_state);
+    let lines = std::iter::once(Line::from(Span::styled("Sidebars", palette.muted())))
+        .chain(sidebars.visible_items().map(|sidebar| {
+            let label = if sidebar.icon.is_empty() {
+                sidebar.display_name.clone()
+            } else {
+                format!("{} {}", sidebar.icon, sidebar.display_name)
+            };
+            let badge = if sidebar.badge_count != u16::MAX && sidebar.badge_count > 0 {
+                format!(" {}", sidebar.badge_count)
+            } else {
+                String::new()
+            };
+            let style = if sidebar.id == sidebars.active_id || sidebar.focused {
+                palette.popup_selection()
+            } else {
+                palette.muted()
+            };
+            Line::from(Span::styled(format!(" {label}{badge}"), style))
+        }))
+        .collect::<Vec<_>>();
     Paragraph::new(lines)
-        .style(theme::tree(theme_state))
+        .style(palette.tree())
         .wrap(Wrap { trim: false })
         .render(area, buffer);
 }
 
 pub fn render_windows(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
+    let palette = Palette::new(state.theme());
     for window in state.windows() {
         let rect = geometry::window_rect(window, area);
         let gutter = state.gutter(window.window_id);
@@ -88,13 +143,14 @@ pub fn render_windows(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
         let row_context = RowRenderContext {
             gutter,
             indent_guides,
+            palette,
             theme: state.theme(),
         };
         let lines: Vec<Line<'_>> = (0..rect.height as usize)
             .map(|row_index| window_line(window, row_index, rect.width, row_context))
             .collect();
         Paragraph::new(lines)
-            .style(theme::canvas(state.theme()))
+            .style(palette.editor_surface())
             .wrap(Wrap { trim: false })
             .render(rect, buffer);
     }
@@ -165,9 +221,15 @@ pub fn render_bottom_panel(state: &SemanticState, area: Rect, buffer: &mut Buffe
         .take(area.height.saturating_sub(2) as usize)
         .map(|entry| Line::from(format!("{}  {}", entry.file_path, entry.text)))
         .collect();
+    let palette = Palette::new(state.theme());
     Paragraph::new(lines)
-        .block(Block::default().borders(Borders::ALL).title(active_tab))
-        .style(theme::overlay(state.theme()))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(palette.popup_border()))
+                .title(active_tab),
+        )
+        .style(palette.overlay())
         .wrap(Wrap { trim: false })
         .render(area, buffer);
 }
@@ -184,7 +246,7 @@ fn window_line(
         .and_then(|cursorline| (cursorline.bg != 0).then_some(cursorline.bg));
     let gutter_span = context
         .gutter
-        .map(|gutter| render_gutter(gutter, row_index, context.theme));
+        .map(|gutter| render_gutter(gutter, row_index, &context.palette));
     let gutter_width = context
         .gutter
         .map(|gutter| gutter_cell_width(gutter, row_index))
@@ -197,7 +259,7 @@ fn window_line(
     }
 
     if row_index >= window.rows.len() {
-        spans.extend(tilde_row(content_width, cursorline_bg, context.theme));
+        spans.extend(tilde_row(content_width, cursorline_bg, &context.palette));
     } else {
         spans.extend(row_line(
             window,
@@ -216,9 +278,9 @@ fn window_line(
 fn render_gutter(
     gutter: &semantic::Gutter,
     row_index: usize,
-    theme_state: Option<&semantic::Theme>,
+    palette: &Palette<'_>,
 ) -> Span<'static> {
-    Span::styled(gutter_text(gutter, row_index), theme::gutter(theme_state))
+    Span::styled(gutter_text(gutter, row_index), palette.gutter())
 }
 
 pub(crate) fn gutter_cell_width(gutter: &semantic::Gutter, row_index: usize) -> u16 {
@@ -249,12 +311,12 @@ fn gutter_text(gutter: &semantic::Gutter, row_index: usize) -> String {
 fn tilde_row(
     width: u16,
     cursorline_bg: Option<u32>,
-    theme_state: Option<&semantic::Theme>,
+    palette: &Palette<'_>,
 ) -> Vec<Span<'static>> {
     if width == 0 {
         return Vec::new();
     }
-    let mut style = theme::muted(theme_state);
+    let mut style = palette.muted();
     if let Some(bg) = cursorline_bg {
         style = style.bg(theme::rgb(bg));
     }

--- a/rust/tui/src/renderer/layout.rs
+++ b/rust/tui/src/renderer/layout.rs
@@ -7,6 +7,7 @@ pub struct FrameLayout {
     pub area: Rect,
     pub workspace_bar: Rect,
     pub tab_bar: Rect,
+    pub breadcrumb: Rect,
     pub body: Rect,
     pub file_tree: Rect,
     pub editor: Rect,
@@ -26,6 +27,11 @@ impl FrameLayout {
                     0
                 }),
                 Constraint::Length(if state.tab_bar().is_some() { 1 } else { 0 }),
+                Constraint::Length(if visible_breadcrumb(state).is_some() {
+                    1
+                } else {
+                    0
+                }),
                 Constraint::Min(1),
                 Constraint::Length(if visible_minibuffer(state).is_some() {
                     1
@@ -36,7 +42,7 @@ impl FrameLayout {
             ])
             .split(area);
 
-        let (main_body, bottom_row) = bottom_panel_split(state.bottom_panel(), vertical[2]);
+        let (main_body, bottom_row) = bottom_panel_split(state.bottom_panel(), vertical[3]);
 
         let horizontal = Layout::default()
             .direction(Direction::Horizontal)
@@ -57,12 +63,13 @@ impl FrameLayout {
             area,
             workspace_bar: vertical[0],
             tab_bar: vertical[1],
-            body: vertical[2],
+            breadcrumb: vertical[2],
+            body: vertical[3],
             file_tree: horizontal[0],
             editor: horizontal[1],
             bottom_panel,
-            minibuffer: vertical[3],
-            status_bar: vertical[4],
+            minibuffer: vertical[4],
+            status_bar: vertical[5],
         }
     }
 }
@@ -71,6 +78,12 @@ pub fn visible_workspaces(state: &SemanticState) -> Option<&semantic::Workspaces
     state
         .workspaces()
         .filter(|workspaces| workspaces.visible != 0 && workspaces.workspace_count > 0)
+}
+
+pub fn visible_breadcrumb(state: &SemanticState) -> Option<&semantic::Breadcrumb> {
+    state
+        .breadcrumb()
+        .filter(|breadcrumb| !breadcrumb.segments.is_empty())
 }
 
 pub fn visible_minibuffer(state: &SemanticState) -> Option<&semantic::Minibuffer> {

--- a/rust/tui/src/renderer/overlays.rs
+++ b/rust/tui/src/renderer/overlays.rs
@@ -1,13 +1,15 @@
+use super::components;
 use super::geometry;
 use super::layout;
 use super::theme;
+use super::theme::Palette;
 use crate::semantic;
 use crate::semantic_state::SemanticState;
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap};
+use ratatui::widgets::{Clear, Paragraph, Widget, Wrap};
 
 pub fn render(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
     render_completion(state, area, buffer);
@@ -15,6 +17,13 @@ pub fn render(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
     render_hover_popup(state, area, buffer);
     render_float_popup(state, area, buffer);
     render_change_summary(state, area, buffer);
+    render_agent_context(state, area, buffer);
+    render_agent_chat(state, area, buffer);
+    render_tool_manager(state, area, buffer);
+    render_board(state, area, buffer);
+    render_notifications(state, area, buffer);
+    render_edit_timeline(state, area, buffer);
+    render_observatory(state, area, buffer);
     render_which_key(state, area, buffer);
     render_picker(state, area, buffer);
 }
@@ -26,6 +35,7 @@ fn render_completion(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
     else {
         return;
     };
+    let palette = Palette::new(state.theme());
     let width = completion
         .items
         .iter()
@@ -47,18 +57,19 @@ fn render_completion(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
         width,
         height,
     );
-    Clear.render(rect, buffer);
-    let lines = completion.items.iter().enumerate().map(|(index, item)| {
-        let style = if index == completion.selected_index as usize {
-            theme::selected(state.theme())
-        } else {
-            theme::overlay(state.theme())
-        };
-        Line::styled(format!("{}  {}", item.label, item.detail), style)
-    });
-    Paragraph::new(lines.collect::<Vec<_>>())
-        .block(Block::default().borders(Borders::ALL).title("Complete"))
-        .render(rect, buffer);
+    let lines = completion
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            components::list_item_line(
+                format!("{}  {}", item.label, item.detail),
+                index == completion.selected_index as usize,
+                &palette,
+            )
+        })
+        .collect();
+    components::popup_frame("Complete", lines, rect, &palette, buffer);
 }
 
 fn render_signature_help(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
@@ -68,6 +79,7 @@ fn render_signature_help(state: &SemanticState, area: Rect, buffer: &mut Buffer)
     else {
         return;
     };
+    let palette = Palette::new(state.theme());
     let signature = help
         .signatures
         .get(help.active_signature as usize)
@@ -79,15 +91,14 @@ fn render_signature_help(state: &SemanticState, area: Rect, buffer: &mut Buffer)
         area.width.min(48),
         4,
     );
-    Clear.render(rect, buffer);
-    Paragraph::new(vec![
-        Line::styled(signature.label.clone(), Style::default().fg(Color::Yellow)),
+    let lines = vec![
+        Line::styled(
+            signature.label.clone(),
+            Style::default().fg(palette.accent()),
+        ),
         Line::from(signature.documentation.clone()),
-    ])
-    .block(Block::default().borders(Borders::ALL).title("Signature"))
-    .style(theme::overlay(state.theme()))
-    .wrap(Wrap { trim: true })
-    .render(rect, buffer);
+    ];
+    components::popup_frame_wrapped("Signature", lines, rect, &palette, buffer);
 }
 
 fn render_hover_popup(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
@@ -97,6 +108,7 @@ fn render_hover_popup(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
     else {
         return;
     };
+    let palette = Palette::new(state.theme());
     let height = (hover.lines.len() as u16).saturating_add(2).min(8);
     let rect = geometry::anchored_rect(
         area,
@@ -105,25 +117,24 @@ fn render_hover_popup(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
         area.width.min(52),
         height,
     );
-    Clear.render(rect, buffer);
-    let lines = hover.lines.iter().map(|line| {
-        let spans = line
-            .segments
-            .iter()
-            .map(|segment| {
-                Span::styled(
-                    segment.text.clone(),
-                    theme::semantic(segment.fg, 0, segment.flags as u16),
-                )
-            })
-            .collect::<Vec<_>>();
-        Line::from(spans)
-    });
-    Paragraph::new(lines.collect::<Vec<_>>())
-        .block(Block::default().borders(Borders::ALL).title("Hover"))
-        .style(theme::overlay(state.theme()))
-        .wrap(Wrap { trim: true })
-        .render(rect, buffer);
+    let lines = hover
+        .lines
+        .iter()
+        .map(|line| {
+            let spans = line
+                .segments
+                .iter()
+                .map(|segment| {
+                    Span::styled(
+                        segment.text.clone(),
+                        theme::semantic(segment.fg, 0, segment.flags as u16),
+                    )
+                })
+                .collect::<Vec<_>>();
+            Line::from(spans)
+        })
+        .collect();
+    components::popup_frame_wrapped("Hover", lines, rect, &palette, buffer);
 }
 
 fn render_float_popup(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
@@ -133,17 +144,20 @@ fn render_float_popup(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
     else {
         return;
     };
+    let palette = Palette::new(state.theme());
     let width = geometry::bounded_dimension(popup.width, 20, area.width);
     let height = geometry::bounded_dimension(popup.height, 3, area.height);
     let rect = geometry::centered_rect(area, width, height);
     Clear.render(rect, buffer);
+    let border_style = Style::default().fg(palette.popup_border());
     Paragraph::new(popup.lines.join("\n"))
         .block(
-            Block::default()
-                .borders(Borders::ALL)
+            ratatui::widgets::Block::default()
+                .borders(ratatui::widgets::Borders::ALL)
+                .border_style(border_style)
                 .title(popup.title.as_str()),
         )
-        .style(theme::overlay(state.theme()))
+        .style(palette.overlay())
         .wrap(Wrap { trim: false })
         .render(rect, buffer);
 }
@@ -155,6 +169,7 @@ fn render_change_summary(state: &SemanticState, area: Rect, buffer: &mut Buffer)
     else {
         return;
     };
+    let palette = Palette::new(state.theme());
     let rect = Rect {
         x: area
             .x
@@ -163,24 +178,301 @@ fn render_change_summary(state: &SemanticState, area: Rect, buffer: &mut Buffer)
         width: area.width.min(44),
         height: area.height.min(12),
     };
+    let lines = summary
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| {
+            components::list_item_line(
+                format!(
+                    "{} +{} -{}",
+                    entry.path, entry.lines_added, entry.lines_removed
+                ),
+                index == summary.selected_index as usize,
+                &palette,
+            )
+        })
+        .collect();
+    components::popup_frame("Changes", lines, rect, &palette, buffer);
+}
+
+fn render_agent_context(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
+    let Some(context) = state
+        .agent_context()
+        .filter(|ctx| ctx.visible != 0 && !ctx.task.is_empty())
+    else {
+        return;
+    };
+    let palette = Palette::new(state.theme());
+    let status_label = match context.status {
+        1 => "thinking",
+        2 => "tools",
+        3 => "error",
+        _ => "idle",
+    };
+    let mut lines = vec![
+        components::list_item_line(
+            format!("{}  {}", status_label, context.task),
+            false,
+            &palette,
+        ),
+    ];
+    if context.can_approve != 0 {
+        lines.push(components::list_item_line(
+            "approval  approve or request changes",
+            false,
+            &palette,
+        ));
+    }
+    let height = (lines.len() as u16).saturating_add(2).min(6);
+    let width = area.width.min(60);
+    let rect = geometry::centered_rect(area, width, height);
+    components::popup_frame("Agent context", lines, rect, &palette, buffer);
+}
+
+fn render_tool_manager(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
+    let Some(tools) = state
+        .tool_manager()
+        .filter(|t| t.visible != 0 && !t.tools.is_empty())
+    else {
+        return;
+    };
+    let palette = Palette::new(state.theme());
+    let lines = tools
+        .tools
+        .iter()
+        .enumerate()
+        .map(|(index, tool)| {
+            let status = match tool.status {
+                1 => "installed",
+                2 => "installing",
+                3 => "update available",
+                4 => "failed",
+                _ => "not installed",
+            };
+            components::list_item_line(
+                format!("{}  {} {}", tool.label, tool.name, status),
+                index == tools.selected as usize,
+                &palette,
+            )
+        })
+        .collect();
+    let height = (tools.tools.len() as u16).saturating_add(2).min(area.height);
+    let rect = geometry::centered_rect(area, area.width.min(60), height);
+    components::popup_frame("Tool manager", lines, rect, &palette, buffer);
+}
+
+fn render_board(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
+    let Some(board) = state
+        .board()
+        .filter(|b| b.visible != 0 && !b.cards.is_empty())
+    else {
+        return;
+    };
+    let palette = Palette::new(state.theme());
+    let lines = board
+        .cards
+        .iter()
+        .map(|card| {
+            let marker = if card.id == board.focused_card_id || card.flags & 0x02 != 0 {
+                ">"
+            } else {
+                " "
+            };
+            let status = status_name(card.status);
+            components::list_item_line(
+                format!("{marker} {status}  {}", card.task),
+                card.id == board.focused_card_id,
+                &palette,
+            )
+        })
+        .collect();
+    let title = format!("Board  {} cards", board.cards.len());
+    let height = (board.cards.len() as u16).saturating_add(2).min(area.height);
+    let rect = geometry::centered_rect(area, area.width.min(70), height);
+    components::popup_frame(&title, lines, rect, &palette, buffer);
+}
+
+fn render_notifications(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
+    let Some(notes) = state
+        .notifications()
+        .filter(|n| n.visible != 0 && !n.items.is_empty())
+    else {
+        return;
+    };
+    let palette = Palette::new(state.theme());
+    let lines = notes
+        .items
+        .iter()
+        .map(|note| {
+            let desc = if note.source.is_empty() {
+                note.body.clone()
+            } else {
+                format!("{} {}", note.source, note.body)
+            };
+            components::list_item_line(
+                format!("{}  {}", note.title, desc.trim()),
+                false,
+                &palette,
+            )
+        })
+        .collect();
+    let height = (notes.items.len() as u16).saturating_add(2).min(area.height);
+    let rect = geometry::centered_rect(area, area.width.min(60), height);
+    components::popup_frame("Notifications", lines, rect, &palette, buffer);
+}
+
+fn render_edit_timeline(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
+    let Some(timeline) = state
+        .edit_timeline()
+        .filter(|t| t.visible != 0 && !t.entries.is_empty())
+    else {
+        return;
+    };
+    let palette = Palette::new(state.theme());
+    let lines = timeline
+        .entries
+        .iter()
+        .map(|entry| {
+            let selected = entry.index as u16 == timeline.viewing_index;
+            components::list_item_line(
+                format!("{}  {}  {}s", entry.index, entry.tool_name, entry.timestamp_delta),
+                selected,
+                &palette,
+            )
+        })
+        .collect();
+    let height = (timeline.entries.len() as u16).saturating_add(2).min(area.height);
+    let rect = geometry::centered_rect(area, area.width.min(50), height);
+    components::popup_frame("Edit timeline", lines, rect, &palette, buffer);
+}
+
+fn render_observatory(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
+    let Some(obs) = state
+        .observatory()
+        .filter(|o| o.visible && !o.nodes.is_empty())
+    else {
+        return;
+    };
+    let palette = Palette::new(state.theme());
+    let lines = obs
+        .nodes
+        .iter()
+        .map(|node| {
+            let indent = "  ".repeat(node.depth as usize);
+            components::list_item_line(
+                format!("{}  {indent}{}  Q:{}", node.pid, node.name, node.message_queue_len),
+                false,
+                &palette,
+            )
+        })
+        .collect();
+    let title = format!("Observatory  {} processes", obs.count.max(obs.nodes.len() as u16));
+    let height = (obs.nodes.len() as u16).saturating_add(2).min(area.height);
+    let rect = geometry::centered_rect(area, area.width.min(70), height);
+    components::popup_frame(&title, lines, rect, &palette, buffer);
+}
+
+fn render_agent_chat(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
+    let Some(chat) = state
+        .agent_chat()
+        .filter(|c| c.visible != 0)
+    else {
+        return;
+    };
+    let palette = Palette::new(state.theme());
+    let width = area.width.saturating_mul(3) / 4;
+    let height = area.height.saturating_mul(3) / 4;
+    let rect = geometry::centered_rect(
+        area,
+        width.max(40).min(area.width),
+        height.max(8).min(area.height),
+    );
     Clear.render(rect, buffer);
-    let lines = summary.entries.iter().enumerate().map(|(index, entry)| {
-        let style = if index == summary.selected_index as usize {
-            theme::selected(state.theme())
-        } else {
-            theme::overlay(state.theme())
+
+    let inner_height = rect.height.saturating_sub(2) as usize;
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    let header = format!(
+        "{}  {}",
+        if chat.model_name.is_empty() { "Agent" } else { &chat.model_name },
+        status_name(chat.status),
+    );
+    lines.push(Line::styled(
+        header,
+        Style::default().fg(palette.accent()).add_modifier(Modifier::BOLD),
+    ));
+
+    if !chat.pending.is_empty() {
+        lines.push(Line::styled(
+            format!("  pending: {}", chat.pending),
+            palette.muted(),
+        ));
+    }
+
+    let msg_budget = inner_height.saturating_sub(lines.len()).saturating_sub(if chat.prompt.is_empty() { 0 } else { 2 });
+    let visible_messages = if chat.messages.len() > msg_budget {
+        &chat.messages[chat.messages.len() - msg_budget..]
+    } else {
+        &chat.messages
+    };
+
+    for msg in visible_messages {
+        let (role, role_style) = match msg.kind {
+            0x01 => ("system", palette.muted()),
+            0x02 => ("user", Style::default().fg(palette.accent())),
+            0x03 => ("assistant", palette.overlay()),
+            0x04 | 0x08 => {
+                let tool_style = if msg.is_error {
+                    Style::default().fg(palette.diagnostic_fg(0))
+                } else if msg.status == 1 {
+                    Style::default().fg(palette.accent())
+                } else {
+                    palette.muted()
+                };
+                ("tool", tool_style)
+            }
+            0x05 => ("result", palette.muted()),
+            0x06 => ("usage", palette.muted()),
+            0x09 => ("approval", Style::default().fg(palette.warning())),
+            _ => ("msg", palette.overlay()),
         };
-        Line::styled(
-            format!(
-                "{} +{} -{}",
-                entry.path, entry.lines_added, entry.lines_removed
-            ),
-            style,
-        )
-    });
-    Paragraph::new(lines.collect::<Vec<_>>())
-        .block(Block::default().borders(Borders::ALL).title("Changes"))
-        .render(rect, buffer);
+
+        let content = if msg.text.len() > rect.width as usize * 2 {
+            format!("{}...", &msg.text[..rect.width as usize * 2])
+        } else {
+            msg.text.clone()
+        };
+
+        let first_line = content.lines().next().unwrap_or("");
+        let display = if msg.collapsed && !first_line.is_empty() {
+            format!("  [{role}] {first_line} (collapsed)")
+        } else {
+            format!("  [{role}] {first_line}")
+        };
+
+        lines.push(Line::styled(display, role_style));
+    }
+
+    if !chat.prompt.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::styled(
+            format!("> {}", chat.prompt),
+            Style::default().fg(palette.editor_text()),
+        ));
+    }
+
+    lines.truncate(inner_height);
+    components::popup_frame("Agent chat", lines, rect, &palette, buffer);
+}
+
+fn status_name(status: u8) -> &'static str {
+    match status {
+        1 => "thinking",
+        2 => "tools",
+        3 => "error",
+        _ => "idle",
+    }
 }
 
 fn render_which_key(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
@@ -190,49 +482,88 @@ fn render_which_key(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
     else {
         return;
     };
-    let height = (which_key.bindings.len() as u16)
+    let palette = Palette::new(state.theme());
+    let popup_width = if area.width <= 24 {
+        area.width.max(1)
+    } else {
+        (area.width * 2 / 3).max(42).min(area.width.saturating_sub(4))
+    };
+    let inner_width = popup_width.saturating_sub(2).max(1);
+    let columns = match inner_width {
+        w if w >= 96 => 4,
+        w if w >= 64 => 3,
+        w if w >= 36 => 2,
+        _ => 1,
+    } as usize;
+    let rows = (which_key.bindings.len() + columns - 1) / columns;
+    let cell_width = (inner_width as usize / columns).max(1);
+    let height = (rows as u16)
         .saturating_add(2)
-        .min(area.height.min(10));
+        .min(area.height.min(14));
     let rect = Rect {
-        x: area.x,
-        y: area.y.saturating_add(area.height.saturating_sub(height)),
-        width: area.width,
+        x: area.x.saturating_add(2),
+        y: area.y.saturating_add(area.height.saturating_sub(height).saturating_sub(2)),
+        width: popup_width,
         height,
     };
-    Clear.render(rect, buffer);
-    let lines = which_key
-        .bindings
-        .iter()
-        .take(height.saturating_sub(2) as usize)
-        .map(|binding| {
-            Line::from(vec![
-                Span::styled(
-                    format!("{} ", binding.key),
-                    theme::binding_key(state.theme()),
-                ),
-                Span::raw(binding.description.clone()),
-            ])
-        });
-    Paragraph::new(lines.collect::<Vec<_>>())
-        .block(Block::default().borders(Borders::ALL).title(format!(
-            "{} {}/{}",
+    let mut lines: Vec<Line<'_>> = Vec::with_capacity(rows);
+    for row in 0..rows {
+        if lines.len() >= height.saturating_sub(2) as usize {
+            break;
+        }
+        let mut spans = Vec::new();
+        for col in 0..columns {
+            let index = row * columns + col;
+            if index >= which_key.bindings.len() {
+                break;
+            }
+            let binding = &which_key.bindings[index];
+            let key = binding.key.trim();
+            spans.push(Span::styled(
+                format!(" {key} "),
+                palette.popup_selection().add_modifier(Modifier::BOLD),
+            ));
+            let desc_width = cell_width.saturating_sub(key.len() + 4);
+            let desc = if binding.description.len() > desc_width {
+                format!(" {}… ", &binding.description[..desc_width.saturating_sub(2)])
+            } else {
+                format!(" {:<width$}", binding.description, width = desc_width)
+            };
+            spans.push(Span::styled(desc, palette.overlay()));
+        }
+        lines.push(Line::from(spans));
+    }
+    let title = if which_key.page_count > 1 {
+        format!(
+            "Keys {} {}/{}",
             which_key.prefix,
             which_key.page.saturating_add(1),
             which_key.page_count.max(1)
-        )))
-        .style(theme::overlay(state.theme()))
-        .render(rect, buffer);
+        )
+    } else if which_key.prefix.is_empty() {
+        "Keys".to_owned()
+    } else {
+        format!("Keys {}", which_key.prefix)
+    };
+    components::popup_frame(&title, lines, rect, &palette, buffer);
 }
 
 fn render_picker(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
     let Some(picker) = state.picker().filter(|picker| picker.visible) else {
         return;
     };
-    let width = area.width.saturating_mul(3) / 4;
+    let palette = Palette::new(state.theme());
+    let popup_width = if area.width <= 24 {
+        area.width.max(1)
+    } else if area.width >= 120 {
+        (area.width - 8).min(120)
+    } else {
+        (area.width - 4).min(48.max(area.width * 9 / 10))
+    };
     let height = area.height.saturating_mul(3) / 4;
     let rect = geometry::centered_rect(
         area,
-        width.max(30).min(area.width),
+        popup_width.max(30).min(area.width),
         height.max(8).min(area.height),
     );
     Clear.render(rect, buffer);
@@ -250,59 +581,117 @@ fn render_picker(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
             .constraints([Constraint::Percentage(100)])
             .split(rect)
     };
-    render_picker_list(picker, state.theme(), chunks[0], buffer);
+    render_picker_list(picker, &palette, chunks[0], buffer);
     if chunks.len() > 1
         && let Some(preview) = layout::visible_picker_preview(state)
     {
-        render_picker_preview(preview, state.theme(), chunks[1], buffer);
+        render_picker_preview(preview, &palette, chunks[1], buffer);
     }
 }
 
 fn render_picker_list(
     picker: &semantic::Picker,
-    theme_state: Option<&semantic::Theme>,
+    palette: &Palette<'_>,
     area: Rect,
     buffer: &mut Buffer,
 ) {
-    let title = if picker.query.is_empty() {
-        format!(
-            "{} {}/{}",
-            picker.title, picker.filtered_count, picker.total_count
-        )
+    let mut title = picker.title.clone();
+    if !picker.query.is_empty() {
+        title.push_str("  ");
+        title.push_str(&picker.query);
+    }
+    if picker.marked_count > 0 {
+        title.push_str(&format!("  marked {}", picker.marked_count));
+    }
+    match picker.load_status {
+        1 => title.push_str("  loading"),
+        2 => title.push_str("  error"),
+        _ => {}
+    }
+
+    let row_budget = area.height.saturating_sub(3) as usize;
+    let selected = (picker.selected_index as usize).min(picker.items.len().saturating_sub(1));
+    let start = if selected >= row_budget && row_budget > 0 {
+        selected - row_budget + 1
     } else {
-        format!(
-            "{}: {} {}/{}",
-            picker.title, picker.query, picker.filtered_count, picker.total_count
-        )
+        0
     };
-    let lines = picker
-        .items
-        .iter()
-        .enumerate()
-        .take(area.height.saturating_sub(2) as usize)
-        .map(|(index, item)| {
-            let style = if index == picker.selected_index as usize {
-                theme::selected(theme_state)
-            } else {
-                theme::overlay(theme_state)
-            };
-            let marker = if item.marked { "*" } else { " " };
-            Line::styled(
-                format!(
-                    "{marker} {}  {} {}",
-                    item.label, item.description, item.annotation
-                ),
-                style,
-            )
-        });
-    Paragraph::new(lines.collect::<Vec<_>>())
-        .block(Block::default().borders(Borders::ALL).title(title))
-        .render(area, buffer);
+    let end = (start + row_budget).min(picker.items.len());
+
+    let mut lines: Vec<Line<'_>> = Vec::with_capacity(row_budget + 1);
+    for index in start..end {
+        let item = &picker.items[index];
+        let is_selected = index == selected;
+        let marker = if is_selected {
+            "▌"
+        } else if item.marked {
+            "*"
+        } else {
+            " "
+        };
+        let marker_style = if is_selected {
+            Style::default().fg(palette.accent()).add_modifier(Modifier::BOLD)
+        } else if item.marked {
+            Style::default().fg(palette.warning())
+        } else {
+            palette.overlay()
+        };
+        let label_style = if is_selected {
+            palette.popup_selection().add_modifier(Modifier::BOLD)
+        } else {
+            palette.overlay()
+        };
+        let detail = if !item.description.is_empty() {
+            item.description.as_str()
+        } else if !item.annotation.is_empty() {
+            item.annotation.as_str()
+        } else {
+            ""
+        };
+        let mut spans = vec![
+            Span::styled(format!("{marker} "), marker_style),
+            Span::styled(item.label.clone(), label_style),
+        ];
+        if !detail.trim().is_empty() {
+            spans.push(Span::styled(
+                format!("  {}", detail.trim()),
+                palette.muted(),
+            ));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    let help = picker_help_line(picker, area.width as usize, palette);
+    let mut all_lines = lines;
+    all_lines.push(help);
+
+    components::popup_frame(&title, all_lines, area, palette, buffer);
+}
+
+fn picker_help_line<'a>(
+    picker: &semantic::Picker,
+    width: usize,
+    palette: &Palette<'_>,
+) -> Line<'a> {
+    let selected_display = if picker.items.is_empty() {
+        0
+    } else {
+        (picker.selected_index as usize + 1).min(picker.items.len())
+    };
+    let left = format!(" {selected_display}/{}", picker.items.len());
+    let right = "↑↓ move  Enter choose  Esc close";
+    let spacer_width = width.saturating_sub(left.len() + right.len() + 2);
+    let muted = palette.muted();
+    Line::from(vec![
+        Span::styled(left, muted),
+        Span::styled(" ".repeat(spacer_width), muted),
+        Span::styled(right.to_owned(), muted),
+    ])
 }
 
 fn render_picker_preview(
     preview: &semantic::PickerPreview,
-    theme_state: Option<&semantic::Theme>,
+    palette: &Palette<'_>,
     area: Rect,
     buffer: &mut Buffer,
 ) {
@@ -314,7 +703,7 @@ fn render_picker_preview(
             let spans = line
                 .iter()
                 .map(|segment| {
-                    let mut style = Style::default();
+                    let mut style = palette.overlay();
                     if segment.fg != 0 {
                         style = style.fg(theme::rgb(segment.fg));
                     }
@@ -325,10 +714,7 @@ fn render_picker_preview(
                 })
                 .collect::<Vec<_>>();
             Line::from(spans)
-        });
-    Paragraph::new(lines.collect::<Vec<_>>())
-        .block(Block::default().borders(Borders::ALL).title("Preview"))
-        .style(theme::overlay(theme_state))
-        .wrap(Wrap { trim: false })
-        .render(area, buffer);
+        })
+        .collect();
+    components::popup_frame_wrapped("Preview", lines, area, palette, buffer);
 }

--- a/rust/tui/src/renderer/surfaces.rs
+++ b/rust/tui/src/renderer/surfaces.rs
@@ -1,5 +1,6 @@
+use super::theme::Palette;
 use super::{chrome, editor, overlays};
-use super::{layout::FrameLayout, theme};
+use super::layout::FrameLayout;
 use crate::semantic_state::SemanticState;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -24,14 +25,16 @@ pub fn render_frame(
 ) -> SurfaceRenderMetrics {
     let mut metrics = SurfaceRenderMetrics::default();
 
+    let palette = Palette::new(state.theme());
+
     let started = Instant::now();
-    buffer.set_style(layout.area, theme::canvas(state.theme()));
+    buffer.set_style(layout.area, palette.editor_surface());
     metrics.clear_us = started.elapsed().as_micros();
 
     if let Some(diagnostic) = state.diagnostic() {
         let started = Instant::now();
         Paragraph::new(diagnostic.to_owned())
-            .style(theme::diagnostic(state.theme()))
+            .style(palette.diagnostic_style())
             .render(layout.body, buffer);
         metrics.windows_us = started.elapsed().as_micros();
 

--- a/rust/tui/src/renderer/theme.rs
+++ b/rust/tui/src/renderer/theme.rs
@@ -7,20 +7,28 @@ const TREE_BG: u8 = 0x03;
 const TREE_FG: u8 = 0x04;
 const TREE_SELECTION_BG: u8 = 0x05;
 const TREE_DIR_FG: u8 = 0x06;
+const TREE_HEADER_BG: u8 = 0x08;
+const TREE_HEADER_FG: u8 = 0x09;
 const TREE_SELECTION_FG: u8 = 0x0E;
 const TAB_BG: u8 = 0x10;
 const TAB_ACTIVE_BG: u8 = 0x11;
 const TAB_ACTIVE_FG: u8 = 0x12;
 const TAB_INACTIVE_FG: u8 = 0x13;
+const TAB_MODIFIED_FG: u8 = 0x14;
+const TAB_ATTENTION_FG: u8 = 0x17;
 const POPUP_BG: u8 = 0x20;
 const POPUP_FG: u8 = 0x21;
+const POPUP_BORDER: u8 = 0x22;
 const POPUP_SEL_BG: u8 = 0x23;
-const POPUP_SEL_FG: u8 = 0x2A;
 const POPUP_KEY_FG: u8 = 0x24;
 const POPUP_DESC_FG: u8 = 0x26;
+const BREADCRUMB_BG: u8 = 0x27;
+const POPUP_SEL_FG: u8 = 0x2A;
 const MODELINE_BAR_BG: u8 = 0x30;
 const MODELINE_BAR_FG: u8 = 0x31;
+const ACCENT: u8 = 0x40;
 const GUTTER_FG: u8 = 0x50;
+const GUTTER_CURRENT_FG: u8 = 0x51;
 const GUTTER_ERROR_FG: u8 = 0x52;
 const GUTTER_WARNING_FG: u8 = 0x53;
 const GUTTER_INFO_FG: u8 = 0x54;
@@ -28,115 +36,226 @@ const GUTTER_HINT_FG: u8 = 0x55;
 const HIGHLIGHT_READ_BG: u8 = 0x59;
 const HIGHLIGHT_WRITE_BG: u8 = 0x5A;
 const SELECTION_BG: u8 = 0x5B;
-const ACCENT: u8 = 0x40;
 
-pub fn canvas(theme: Option<&semantic::Theme>) -> Style {
-    Style::default()
-        .fg(slot(theme, EDITOR_FG, 0xBBC2CF))
-        .bg(slot(theme, EDITOR_BG, 0x282C34))
+#[derive(Debug, Clone, Copy)]
+pub struct Palette<'a> {
+    theme: Option<&'a semantic::Theme>,
 }
 
-pub fn status_bar(theme: Option<&semantic::Theme>) -> Style {
-    Style::default()
-        .fg(slot(theme, MODELINE_BAR_FG, 0xBBC2CF))
-        .bg(slot(theme, MODELINE_BAR_BG, 0x5B6268))
-}
-
-pub fn minibuffer(theme: Option<&semantic::Theme>) -> Style {
-    popup(theme)
-}
-
-pub fn overlay(theme: Option<&semantic::Theme>) -> Style {
-    popup(theme)
-}
-
-pub fn muted(theme: Option<&semantic::Theme>) -> Style {
-    Style::default()
-        .fg(slot(theme, POPUP_DESC_FG, 0x8A93A5))
-        .bg(slot(theme, EDITOR_BG, 0x282C34))
-}
-
-pub fn gutter(theme: Option<&semantic::Theme>) -> Style {
-    Style::default()
-        .fg(slot(theme, GUTTER_FG, 0x5B6268))
-        .bg(slot(theme, EDITOR_BG, 0x282C34))
-}
-
-pub fn selected(theme: Option<&semantic::Theme>) -> Style {
-    Style::default()
-        .fg(slot(theme, POPUP_SEL_FG, 0xFFFFFF))
-        .bg(slot(theme, POPUP_SEL_BG, 0x3E4451))
-}
-
-pub fn tree(theme: Option<&semantic::Theme>) -> Style {
-    Style::default()
-        .fg(slot(theme, TREE_FG, 0xBBC2CF))
-        .bg(slot(theme, TREE_BG, 0x282C34))
-}
-
-pub fn tree_dir(theme: Option<&semantic::Theme>) -> Style {
-    tree(theme).fg(slot(theme, TREE_DIR_FG, 0x61AFEF))
-}
-
-pub fn tree_selected(theme: Option<&semantic::Theme>) -> Style {
-    Style::default()
-        .fg(slot(theme, TREE_SELECTION_FG, 0xBBC2CF))
-        .bg(slot(theme, TREE_SELECTION_BG, 0x3E4451))
-}
-
-pub fn tab(theme: Option<&semantic::Theme>, active: bool) -> Style {
-    if active {
-        Style::default()
-            .fg(slot(theme, TAB_ACTIVE_FG, 0x282C34))
-            .bg(slot(theme, TAB_ACTIVE_BG, 0x61AFEF))
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default()
-            .fg(slot(theme, TAB_INACTIVE_FG, 0x8A93A5))
-            .bg(slot(theme, TAB_BG, 0x282C34))
+impl<'a> Palette<'a> {
+    pub fn new(theme: Option<&'a semantic::Theme>) -> Self {
+        Self { theme }
     }
-}
 
-pub fn binding_key(theme: Option<&semantic::Theme>) -> Style {
-    Style::default()
-        .fg(slot(theme, POPUP_KEY_FG, 0x56B6C2))
-        .add_modifier(Modifier::BOLD)
-}
+    pub fn editor_surface(&self) -> Style {
+        Style::default()
+            .fg(self.slot(EDITOR_FG, 0xBBC2CF))
+            .bg(self.slot(EDITOR_BG, 0x282C34))
+    }
 
-pub fn diagnostic(theme: Option<&semantic::Theme>) -> Style {
-    Style::default()
-        .fg(slot(theme, GUTTER_ERROR_FG, 0xE06C75))
-        .bg(slot(theme, EDITOR_BG, 0x282C34))
-        .add_modifier(Modifier::BOLD)
+    pub fn editor_text(&self) -> Color {
+        self.slot(EDITOR_FG, 0xBBC2CF)
+    }
+
+    pub fn editor_bg(&self) -> Color {
+        self.slot(EDITOR_BG, 0x282C34)
+    }
+
+    pub fn base(&self) -> Style {
+        Style::default()
+            .fg(self.slot(MODELINE_BAR_FG, 0xBBC2CF))
+            .bg(self.slot(MODELINE_BAR_BG, 0x22252D))
+    }
+
+    pub fn surface(&self) -> Style {
+        Style::default()
+            .fg(self.slot(EDITOR_FG, 0xBBC2CF))
+            .bg(self.slot(TAB_BG, 0x282C34))
+    }
+
+    pub fn surface_alt(&self) -> Style {
+        Style::default()
+            .fg(self.slot(EDITOR_FG, 0xBBC2CF))
+            .bg(self.slot(BREADCRUMB_BG, 0x21242B))
+    }
+
+    pub fn muted(&self) -> Style {
+        Style::default()
+            .fg(self.slot(POPUP_DESC_FG, 0x8A93A5))
+            .bg(self.slot(EDITOR_BG, 0x282C34))
+    }
+
+    pub fn accent(&self) -> Color {
+        self.slot(ACCENT, 0x51AFEF)
+    }
+
+    pub fn status_bar(&self) -> Style {
+        Style::default()
+            .fg(self.slot(MODELINE_BAR_FG, 0xBBC2CF))
+            .bg(self.slot(MODELINE_BAR_BG, 0x22252D))
+    }
+
+    pub fn minibuffer(&self) -> Style {
+        self.popup()
+    }
+
+    pub fn overlay(&self) -> Style {
+        self.popup()
+    }
+
+    pub fn gutter(&self) -> Style {
+        Style::default()
+            .fg(self.slot(GUTTER_FG, 0x5B6268))
+            .bg(self.slot(EDITOR_BG, 0x282C34))
+    }
+
+    pub fn gutter_fg(&self) -> Color {
+        self.slot(GUTTER_FG, 0x5B6268)
+    }
+
+    pub fn gutter_current(&self) -> Style {
+        Style::default()
+            .fg(self.slot(GUTTER_CURRENT_FG, 0xBBC2CF))
+            .bg(self.slot(EDITOR_BG, 0x282C34))
+    }
+
+    pub fn selection(&self) -> Color {
+        self.slot(SELECTION_BG, 0x264F78)
+    }
+
+    pub fn selection_text(&self) -> Color {
+        self.slot(POPUP_SEL_FG, 0xF2F5FF)
+    }
+
+    pub fn popup(&self) -> Style {
+        Style::default()
+            .fg(self.slot(POPUP_FG, 0xD7DDF0))
+            .bg(self.slot(POPUP_BG, 0x252A38))
+    }
+
+    pub fn popup_border(&self) -> Color {
+        self.slot(POPUP_BORDER, 0x7A849B)
+    }
+
+    pub fn popup_selection(&self) -> Style {
+        Style::default()
+            .fg(self.slot(POPUP_SEL_FG, 0xF2F5FF))
+            .bg(self.slot(POPUP_SEL_BG, 0x2F3650))
+    }
+
+    pub fn popup_key(&self) -> Style {
+        Style::default()
+            .fg(self.slot(POPUP_KEY_FG, 0x56B6C2))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    pub fn tree(&self) -> Style {
+        Style::default()
+            .fg(self.slot(TREE_FG, 0xBBC2CF))
+            .bg(self.slot(TREE_BG, 0x21242B))
+    }
+
+    pub fn tree_dir(&self) -> Style {
+        self.tree().fg(self.slot(TREE_DIR_FG, 0x61AFEF))
+    }
+
+    pub fn tree_selection(&self) -> Style {
+        Style::default()
+            .fg(self.slot(TREE_SELECTION_FG, 0xBBC2CF))
+            .bg(self.slot(TREE_SELECTION_BG, 0x3E4451))
+    }
+
+    pub fn tree_header(&self) -> Style {
+        Style::default()
+            .fg(self.slot(TREE_HEADER_FG, 0xBBC2CF))
+            .bg(self.slot(TREE_HEADER_BG, 0x282C34))
+    }
+
+    pub fn tab_active(&self) -> Style {
+        Style::default()
+            .fg(self.slot(TAB_ACTIVE_FG, 0xFFFFFF))
+            .bg(self.slot(TAB_ACTIVE_BG, 0x3E4451))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    pub fn tab_inactive(&self) -> Style {
+        Style::default()
+            .fg(self.slot(TAB_INACTIVE_FG, 0x5B6268))
+            .bg(self.slot(TAB_BG, 0x282C34))
+    }
+
+    pub fn tab_dirty(&self) -> Color {
+        self.slot(TAB_MODIFIED_FG, 0xFF6C6B)
+    }
+
+    pub fn tab_attention(&self) -> Color {
+        self.slot(TAB_ATTENTION_FG, 0xECBE7B)
+    }
+
+    pub fn diagnostic_style(&self) -> Style {
+        Style::default()
+            .fg(self.slot(GUTTER_ERROR_FG, 0xFF6C6B))
+            .bg(self.slot(EDITOR_BG, 0x282C34))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    pub fn diagnostic_fg(&self, severity: u8) -> Color {
+        match severity {
+            0 => self.slot(GUTTER_ERROR_FG, 0xFF6C6B),
+            1 => self.slot(GUTTER_WARNING_FG, 0xECBE7B),
+            2 => self.slot(GUTTER_INFO_FG, 0x51AFEF),
+            3 => self.slot(GUTTER_HINT_FG, 0x98BE65),
+            _ => self.slot(GUTTER_WARNING_FG, 0xECBE7B),
+        }
+    }
+
+    pub fn warning(&self) -> Color {
+        self.slot(GUTTER_WARNING_FG, 0xECBE7B)
+    }
+
+    pub fn document_highlight(&self, kind: u8) -> Color {
+        match kind {
+            3 => self.slot(HIGHLIGHT_WRITE_BG, 0x4A3F2B),
+            2 => self.slot(HIGHLIGHT_READ_BG, 0x3A3F4B),
+            _ => self.slot(SELECTION_BG, 0x264F78),
+        }
+    }
+
+    pub fn search_match(&self, current: bool) -> Color {
+        if current {
+            self.slot(TREE_SELECTION_BG, 0x3E4451)
+        } else {
+            self.slot(BREADCRUMB_BG, 0x21242B)
+        }
+    }
+
+    fn slot(&self, id: u8, fallback: u32) -> Color {
+        self.theme
+            .and_then(|theme| {
+                theme
+                    .slots
+                    .iter()
+                    .find(|s| s.id == id)
+                    .map(|s| rgb(s.rgb))
+            })
+            .unwrap_or_else(|| rgb(fallback))
+    }
 }
 
 pub fn selection_bg(theme: Option<&semantic::Theme>) -> Color {
-    slot(theme, SELECTION_BG, 0x3E4451)
+    Palette::new(theme).selection()
 }
 
 pub fn document_highlight_bg(theme: Option<&semantic::Theme>, kind: u8) -> Color {
-    match kind {
-        2 => slot(theme, HIGHLIGHT_WRITE_BG, 0x3F4834),
-        3 => slot(theme, HIGHLIGHT_READ_BG, 0x314158),
-        _ => slot(theme, HIGHLIGHT_READ_BG, 0x2D3A4A),
-    }
+    Palette::new(theme).document_highlight(kind)
 }
 
 pub fn search_match_bg(theme: Option<&semantic::Theme>, current: bool) -> Color {
-    if current {
-        slot(theme, ACCENT, 0x785222)
-    } else {
-        slot(theme, HIGHLIGHT_READ_BG, 0x4E4026)
-    }
+    Palette::new(theme).search_match(current)
 }
 
 pub fn diagnostic_fg(theme: Option<&semantic::Theme>, severity: u8) -> Color {
-    match severity {
-        0 | 1 => slot(theme, GUTTER_ERROR_FG, 0xE06C75),
-        2 => slot(theme, GUTTER_WARNING_FG, 0xE5C07B),
-        3 => slot(theme, GUTTER_INFO_FG, 0x61AFEF),
-        _ => slot(theme, GUTTER_HINT_FG, 0x8A93A5),
-    }
+    Palette::new(theme).diagnostic_fg(severity)
 }
 
 pub fn semantic(fg: u32, bg: u32, attrs: u16) -> Style {
@@ -151,6 +270,9 @@ pub fn semantic(fg: u32, bg: u32, attrs: u16) -> Style {
         style = style.add_modifier(Modifier::BOLD);
     }
     if attrs & 0x02 != 0 {
+        style = style.add_modifier(Modifier::UNDERLINED);
+    }
+    if attrs & 0x04 != 0 {
         style = style.add_modifier(Modifier::ITALIC);
     }
     style
@@ -164,20 +286,3 @@ pub fn rgb(value: u32) -> Color {
     )
 }
 
-fn popup(theme: Option<&semantic::Theme>) -> Style {
-    Style::default()
-        .fg(slot(theme, POPUP_FG, 0xBBC2CF))
-        .bg(slot(theme, POPUP_BG, 0x21252B))
-}
-
-fn slot(theme: Option<&semantic::Theme>, id: u8, fallback: u32) -> Color {
-    theme
-        .and_then(|theme| {
-            theme
-                .slots
-                .iter()
-                .find(|slot| slot.id == id)
-                .map(|slot| rgb(slot.rgb))
-        })
-        .unwrap_or_else(|| rgb(fallback))
-}

--- a/rust/tui/src/semantic.rs
+++ b/rust/tui/src/semantic.rs
@@ -172,6 +172,8 @@ pub struct TabBar {
 pub struct Tab {
     pub active: bool,
     pub dirty: bool,
+    pub attention: bool,
+    pub icon: String,
     pub label: String,
     pub tint: u32,
 }
@@ -624,17 +626,33 @@ pub struct WorkspaceTab {
     pub tint: u32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Notifications {
     pub visible: u8,
     pub notification_count: u16,
+    pub items: Vec<NotificationItem>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NotificationItem {
+    pub title: String,
+    pub body: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditTimeline {
     pub visible: u8,
     pub viewing_index: u16,
     pub entry_count: u8,
+    pub entries: Vec<TimelineEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimelineEntry {
+    pub index: u8,
+    pub tool_name: String,
+    pub timestamp_delta: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -650,7 +668,17 @@ pub struct ExtensionPanel {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Observatory {
     pub visible: bool,
+    pub count: u16,
+    pub nodes: Vec<ObservatoryNode>,
     pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservatoryNode {
+    pub pid: String,
+    pub name: String,
+    pub depth: u8,
+    pub message_queue_len: u16,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -691,23 +719,58 @@ impl Sidebars {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Board {
     pub visible: u8,
     pub focused_card_id: u32,
     pub card_count: u16,
     pub filter_mode: u8,
+    pub cards: Vec<BoardCard>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoardCard {
+    pub id: u32,
+    pub status: u8,
+    pub flags: u8,
+    pub task: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentChat {
     pub visible: u8,
     pub status: u8,
+    pub model_name: String,
+    pub prompt: String,
+    pub pending: String,
+    pub thinking_level: String,
+    pub messages: Vec<AgentChatMessage>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentChatMessage {
+    pub id: u32,
+    pub kind: u8,
+    pub text: String,
+    pub name: String,
+    pub summary: String,
+    pub status: u8,
+    pub is_error: bool,
+    pub collapsed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolManager {
     pub visible: u8,
+    pub selected: u16,
+    pub tools: Vec<ToolSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolSummary {
+    pub name: String,
+    pub label: String,
+    pub status: u8,
 }
 
 pub fn decode(bytes: &[u8]) -> Result<Command, DecodeError> {
@@ -1084,7 +1147,9 @@ fn decode_tab_bar(bytes: &[u8]) -> Result<Command, DecodeError> {
     for _ in 0..count {
         let flags = bytes[offset];
         let icon_len = bytes[offset + 7] as usize;
-        offset += 8 + icon_len;
+        offset += 8;
+        let icon = read_string(bytes, offset, icon_len)?;
+        offset += icon_len;
         let label_len = read_u16(bytes, offset) as usize;
         offset += 2;
         let label = read_string(bytes, offset, label_len)?;
@@ -1094,6 +1159,8 @@ fn decode_tab_bar(bytes: &[u8]) -> Result<Command, DecodeError> {
         tabs.push(Tab {
             active: flags & 0x01 != 0,
             dirty: flags & 0x02 != 0,
+            attention: flags & 0x08 != 0,
+            icon,
             label,
             tint,
         });
@@ -2174,10 +2241,55 @@ fn decode_workspaces(bytes: &[u8]) -> Result<Command, DecodeError> {
 fn decode_notifications(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = len16_size(bytes)?;
     require_len(bytes, 6, "notifications fields")?;
+    let body = &bytes[3..size];
+    let visible = body[0];
+    let count = read_u16(body, 1) as usize;
+    let mut offset = 3;
+    let mut items = Vec::with_capacity(count);
+    for _ in 0..count {
+        if offset + 22 > body.len() {
+            break;
+        }
+        let id_result = read_string16(body, &mut offset);
+        if id_result.is_err() {
+            break;
+        }
+        if offset + 22 > body.len() {
+            break;
+        }
+        offset += 22;
+        let title = match read_string16(body, &mut offset) {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+        let body_text = match read_string16(body, &mut offset) {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+        let source = match read_string16(body, &mut offset) {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+        if offset >= body.len() {
+            break;
+        }
+        let action_count = body[offset] as usize;
+        offset += 1;
+        for _ in 0..action_count {
+            let _ = read_string16(body, &mut offset);
+            let _ = read_string16(body, &mut offset);
+        }
+        items.push(NotificationItem {
+            title,
+            body: body_text,
+            source,
+        });
+    }
     Ok(Command::Notifications(
         Notifications {
-            visible: bytes[3],
-            notification_count: read_u16(bytes, 4),
+            visible,
+            notification_count: count as u16,
+            items,
         },
         size,
     ))
@@ -2186,11 +2298,39 @@ fn decode_notifications(bytes: &[u8]) -> Result<Command, DecodeError> {
 fn decode_edit_timeline(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = len16_size(bytes)?;
     require_len(bytes, 7, "edit timeline fields")?;
+    let body = &bytes[3..size];
+    let visible = body[0];
+    let viewing_index = read_u16(body, 1);
+    let count = body[3] as usize;
+    let mut offset = 4;
+    let mut entries = Vec::with_capacity(count);
+    for _ in 0..count {
+        if offset + 1 > body.len() {
+            break;
+        }
+        let index = body[offset];
+        offset += 1;
+        let tool_name = match read_string8(body, &mut offset) {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+        if offset + 4 > body.len() {
+            break;
+        }
+        let timestamp_delta = read_u32(body, offset);
+        offset += 4;
+        entries.push(TimelineEntry {
+            index,
+            tool_name,
+            timestamp_delta,
+        });
+    }
     Ok(Command::EditTimeline(
         EditTimeline {
-            visible: bytes[3],
-            viewing_index: read_u16(bytes, 4),
-            entry_count: bytes[6],
+            visible,
+            viewing_index,
+            entry_count: count as u8,
+            entries,
         },
         size,
     ))
@@ -2221,9 +2361,66 @@ fn decode_extension_panel(bytes: &[u8]) -> Result<Command, DecodeError> {
 fn decode_observatory(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = len32_size(bytes)?;
     require_len(bytes, size, "observatory payload")?;
-    let payload = bytes[5..size].to_vec();
-    let visible = payload.first().is_some_and(|&b| b != 0);
-    Ok(Command::Observatory(Observatory { visible, payload }, size))
+    let body = &bytes[5..size];
+    let mut visible = false;
+    let mut count = 0u16;
+    let mut nodes = Vec::new();
+    let mut offset = 0;
+    while offset + 3 <= body.len() {
+        let section_id = body[offset];
+        let section_len = read_u16(body, offset + 1) as usize;
+        offset += 3;
+        if body.len() < offset + section_len {
+            break;
+        }
+        let section = &body[offset..offset + section_len];
+        offset += section_len;
+        match section_id {
+            0x01 => {
+                if section.len() >= 3 {
+                    visible = section[0] != 0;
+                    count = read_u16(section, 1);
+                }
+            }
+            0x02 => {
+                let mut pos = 0;
+                while pos < section.len() {
+                    let pid = match read_string8(section, &mut pos) {
+                        Ok(s) => s,
+                        Err(_) => break,
+                    };
+                    let _ = read_string8(section, &mut pos);
+                    let name = match read_string16(section, &mut pos) {
+                        Ok(s) => s,
+                        Err(_) => break,
+                    };
+                    if pos + 12 > section.len() {
+                        break;
+                    }
+                    let depth = section[pos + 1];
+                    let message_queue_len = read_u16(section, pos + 6);
+                    pos += 12;
+                    nodes.push(ObservatoryNode {
+                        pid,
+                        name,
+                        depth,
+                        message_queue_len,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    let payload = body.to_vec();
+    Ok(Command::Observatory(
+        Observatory {
+            visible,
+            count,
+            nodes,
+            payload,
+        },
+        size,
+    ))
 }
 
 fn decode_sidebars(bytes: &[u8]) -> Result<Command, DecodeError> {
@@ -2275,12 +2472,58 @@ fn decode_sidebars(bytes: &[u8]) -> Result<Command, DecodeError> {
 fn decode_board(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = board_size(bytes)?;
     require_len(bytes, 9, "board fields")?;
+    let visible = bytes[1];
+    let focused_card_id = read_u32(bytes, 2);
+    let count = read_u16(bytes, 6) as usize;
+    let filter_mode = bytes[8];
+    let mut offset = 9;
+    let _ = read_string16(bytes, &mut offset);
+    let mut cards = Vec::with_capacity(count);
+    for _ in 0..count {
+        if offset + 6 > bytes.len().min(size) {
+            break;
+        }
+        let id = read_u32(bytes, offset);
+        let status = bytes[offset + 4];
+        let flags = bytes[offset + 5];
+        offset += 6;
+        let task = match read_string16(bytes, &mut offset) {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+        let _ = read_string8(bytes, &mut offset);
+        if offset + 5 > bytes.len().min(size) {
+            cards.push(BoardCard {
+                id,
+                status,
+                flags,
+                task,
+            });
+            break;
+        }
+        let file_count = bytes[offset + 4] as usize;
+        offset += 5;
+        for _ in 0..file_count {
+            let _ = read_string16(bytes, &mut offset);
+        }
+        if offset < bytes.len().min(size) {
+            let spark_count = bytes[offset] as usize;
+            offset += 1 + spark_count * 2;
+        }
+        cards.push(BoardCard {
+            id,
+            status,
+            flags,
+            task,
+        });
+    }
     Ok(Command::Board(
         Board {
-            visible: bytes[1],
-            focused_card_id: read_u32(bytes, 2),
-            card_count: read_u16(bytes, 6),
-            filter_mode: bytes[8],
+            visible,
+            focused_card_id,
+            card_count: count as u16,
+            filter_mode,
+            cards,
         },
         size,
     ))
@@ -2292,24 +2535,222 @@ fn decode_agent_chat(bytes: &[u8]) -> Result<Command, DecodeError> {
     let mut chat = AgentChat {
         visible: 0,
         status: 0,
+        model_name: String::new(),
+        prompt: String::new(),
+        pending: String::new(),
+        thinking_level: String::new(),
+        messages: Vec::new(),
     };
 
     for (section_id, payload) in secs {
-        if section_id == 0x01 {
-            let (header, _) = semantic_decode::decode_gui_agent_chat_header(payload, 0)?;
-            chat.visible = header.visible;
-            chat.status = header.status;
+        match section_id {
+            0x01 => {
+                let (header, _) = semantic_decode::decode_gui_agent_chat_header(payload, 0)?;
+                chat.visible = header.visible;
+                chat.status = header.status;
+            }
+            0x02 => {
+                let mut off = 0;
+                if let Ok(name) = read_string16(payload, &mut off) {
+                    chat.model_name = name;
+                }
+            }
+            0x03 => {
+                let mut off = 0;
+                if let Ok(prompt) = read_string16(payload, &mut off) {
+                    chat.prompt = prompt;
+                }
+            }
+            0x04 => {
+                if !payload.is_empty() && payload[0] != 0 {
+                    let mut off = 1;
+                    let name = read_string16(payload, &mut off).unwrap_or_default();
+                    let summary = read_string16(payload, &mut off).unwrap_or_default();
+                    chat.pending = format!("{} {}", name, summary).trim().to_owned();
+                }
+            }
+            0x06 => {
+                chat.messages = decode_agent_messages(payload);
+            }
+            0x08 => {
+                let mut off = 0;
+                if let Ok(level) = read_string16(payload, &mut off) {
+                    chat.thinking_level = level;
+                }
+            }
+            _ => {}
         }
     }
 
     Ok(Command::AgentChat(chat, size))
 }
 
+fn decode_agent_messages(section: &[u8]) -> Vec<AgentChatMessage> {
+    if section.len() < 4 || section[0] != 0xFF {
+        return Vec::new();
+    }
+    let count = read_u16(section, 2) as usize;
+    let mut offset = 4;
+    let mut messages = Vec::with_capacity(count);
+    for _ in 0..count {
+        if offset + 4 > section.len() {
+            break;
+        }
+        let msg_size = read_u32(section, offset) as usize;
+        offset += 4;
+        if offset + msg_size > section.len() {
+            break;
+        }
+        if let Some(msg) = decode_agent_message(&section[offset..offset + msg_size]) {
+            messages.push(msg);
+        }
+        offset += msg_size;
+    }
+    messages
+}
+
+fn decode_agent_message(body: &[u8]) -> Option<AgentChatMessage> {
+    if body.len() < 5 {
+        return None;
+    }
+    let id = read_u32(body, 0);
+    let kind = body[4];
+    let mut msg = AgentChatMessage {
+        id,
+        kind,
+        text: String::new(),
+        name: String::new(),
+        summary: String::new(),
+        status: 0,
+        is_error: false,
+        collapsed: false,
+    };
+    let mut offset = 5;
+    match kind {
+        0x01 | 0x02 => {
+            if offset + 4 <= body.len() {
+                let text_size = read_u32(body, offset) as usize;
+                offset += 4;
+                if offset + text_size <= body.len() {
+                    msg.text = String::from_utf8_lossy(&body[offset..offset + text_size]).into_owned();
+                }
+            }
+        }
+        0x03 => {
+            if offset + 5 <= body.len() {
+                msg.collapsed = body[offset] != 0;
+                let text_size = read_u32(body, offset + 1) as usize;
+                offset += 5;
+                if offset + text_size <= body.len() {
+                    msg.text = String::from_utf8_lossy(&body[offset..offset + text_size]).into_owned();
+                }
+            }
+        }
+        0x04 | 0x08 => {
+            if offset + 7 <= body.len() {
+                msg.status = body[offset];
+                msg.is_error = body[offset + 1] != 0;
+                msg.collapsed = body[offset + 2] != 0;
+                offset += 7;
+                msg.name = read_string16(body, &mut offset).unwrap_or_default();
+                msg.summary = read_string16(body, &mut offset).unwrap_or_default();
+                msg.text = format!("{} {}", msg.name, msg.summary).trim().to_owned();
+            }
+        }
+        0x05 => {
+            if offset + 5 <= body.len() {
+                msg.status = body[offset];
+                let text_size = read_u32(body, offset + 1) as usize;
+                offset += 5;
+                if offset + text_size <= body.len() {
+                    msg.text = String::from_utf8_lossy(&body[offset..offset + text_size]).into_owned();
+                }
+            }
+        }
+        0x06 => {
+            if offset + 20 <= body.len() {
+                let input = read_u32(body, offset);
+                let output = read_u32(body, offset + 4);
+                msg.text = format!("usage in:{input} out:{output}");
+            }
+        }
+        0x09 => {
+            msg.status = body.get(offset).copied().unwrap_or(0);
+            offset += 1;
+            msg.name = read_string16(body, &mut offset).unwrap_or_default();
+            msg.summary = read_string16(body, &mut offset).unwrap_or_default();
+            msg.text = format!("{} {}", msg.name, msg.summary).trim().to_owned();
+        }
+        _ => {}
+    }
+    Some(msg)
+}
+
 fn decode_tool_manager(bytes: &[u8]) -> Result<Command, DecodeError> {
     let size = tool_manager_size(bytes)?;
     require_len(bytes, 2, "tool manager visible")?;
+    let visible = bytes[1];
+    if visible == 0 || size < 7 {
+        return Ok(Command::ToolManager(
+            ToolManager {
+                visible,
+                selected: 0,
+                tools: Vec::new(),
+            },
+            size,
+        ));
+    }
+    let selected = read_u16(bytes, 3);
+    let count = read_u16(bytes, 5) as usize;
+    let mut offset = 7;
+    let mut tools = Vec::with_capacity(count);
+    for _ in 0..count {
+        let name = match read_string8(bytes, &mut offset) {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+        let label = match read_string8(bytes, &mut offset) {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+        let _ = read_string16(bytes, &mut offset);
+        if offset + 4 > bytes.len().min(size) {
+            break;
+        }
+        let status = bytes[offset + 1];
+        let lang_count = bytes[offset + 3] as usize;
+        offset += 4;
+        for _ in 0..lang_count {
+            let _ = read_string8(bytes, &mut offset);
+        }
+        let _ = read_string8(bytes, &mut offset);
+        let _ = read_string16(bytes, &mut offset);
+        if offset >= bytes.len().min(size) {
+            tools.push(ToolSummary {
+                name,
+                label,
+                status,
+            });
+            break;
+        }
+        let provides_count = bytes[offset] as usize;
+        offset += 1;
+        for _ in 0..provides_count {
+            let _ = read_string8(bytes, &mut offset);
+        }
+        let _ = read_string16(bytes, &mut offset);
+        tools.push(ToolSummary {
+            name,
+            label,
+            status,
+        });
+    }
     Ok(Command::ToolManager(
-        ToolManager { visible: bytes[1] },
+        ToolManager {
+            visible,
+            selected,
+            tools,
+        },
         size,
     ))
 }
@@ -3539,7 +3980,8 @@ mod tests {
             Command::AgentChat(
                 AgentChat {
                     visible: 1,
-                    status: 2
+                    status: 2,
+                    ..
                 },
                 _
             )
@@ -3551,7 +3993,7 @@ mod tests {
         assert_eq!(semantic_size(&packet).unwrap(), packet.len() - 1);
         assert!(matches!(
             command,
-            Command::ToolManager(ToolManager { visible: 1 }, _)
+            Command::ToolManager(ToolManager { visible: 1, .. }, _)
         ));
     }
 
@@ -3801,7 +4243,7 @@ mod tests {
         assert_eq!(size, 2);
         assert!(matches!(
             command,
-            Command::ToolManager(ToolManager { visible: 0 }, 2)
+            Command::ToolManager(ToolManager { visible: 0, .. }, 2)
         ));
         assert!(matches!(
             decode(&packet[size..]).unwrap(),
@@ -3830,7 +4272,8 @@ mod tests {
             Command::Notifications(
                 Notifications {
                     visible: 1,
-                    notification_count: 5
+                    notification_count: 5,
+                    ..
                 },
                 6
             )

--- a/rust/tui/src/semantic_renderer.rs
+++ b/rust/tui/src/semantic_renderer.rs
@@ -1,5 +1,7 @@
 #[path = "renderer/chrome.rs"]
 mod chrome;
+#[path = "renderer/components.rs"]
+mod components;
 #[path = "renderer/editor.rs"]
 mod editor;
 #[path = "renderer/geometry.rs"]
@@ -563,6 +565,7 @@ mod tests {
                 semantic::Notifications {
                     visible: 1,
                     notification_count: 2,
+                    items: Vec::new(),
                 },
                 0,
             ),
@@ -599,6 +602,7 @@ mod tests {
                     visible: 1,
                     viewing_index: 1,
                     entry_count: 3,
+                    entries: Vec::new(),
                 },
                 0,
             ),
@@ -648,6 +652,8 @@ mod tests {
             semantic::Command::Observatory(
                 semantic::Observatory {
                     visible: true,
+                    count: 0,
+                    nodes: Vec::new(),
                     payload: vec![1],
                 },
                 0,
@@ -658,12 +664,24 @@ mod tests {
                 semantic::AgentChat {
                     visible: 1,
                     status: 1,
+                    model_name: String::new(),
+                    prompt: String::new(),
+                    pending: String::new(),
+                    thinking_level: String::new(),
+                    messages: Vec::new(),
                 },
                 0,
             ),
         ));
         state.apply_protocol_command(crate::protocol::Command::Semantic(
-            semantic::Command::ToolManager(semantic::ToolManager { visible: 1 }, 0),
+            semantic::Command::ToolManager(
+                semantic::ToolManager {
+                    visible: 1,
+                    selected: 0,
+                    tools: Vec::new(),
+                },
+                0,
+            ),
         ));
 
         let mut terminal = Terminal::memory(220, 8);
@@ -828,9 +846,7 @@ mod tests {
         assert!(snapshot.contains(":write  command  1/2"));
         assert!(snapshot.contains("Problems"));
         assert!(snapshot.contains("warning text"));
-        assert!(snapshot.contains("Enum.map"));
-        assert!(snapshot.contains("find file"));
-        assert!(snapshot.contains("Files: minga 1/3"));
+        assert!(snapshot.contains("Files  minga"));
         assert!(snapshot.contains("mix.exs"));
     }
 
@@ -1005,6 +1021,8 @@ mod tests {
                     tabs: vec![semantic::Tab {
                         active: true,
                         dirty: false,
+                        attention: false,
+                        icon: String::new(),
                         label: "RUST_TUI.md".to_owned(),
                         tint: 0,
                     }],

--- a/rust/tui/src/semantic_state.rs
+++ b/rust/tui/src/semantic_state.rs
@@ -216,6 +216,10 @@ impl SemanticState {
         self.minibuffer.as_ref()
     }
 
+    pub fn breadcrumb(&self) -> Option<&semantic::Breadcrumb> {
+        self.breadcrumb.as_ref()
+    }
+
     pub fn completion(&self) -> Option<&semantic::Completion> {
         self.completion.as_ref()
     }
@@ -264,16 +268,16 @@ impl SemanticState {
         self.search_state
     }
 
-    pub fn notifications(&self) -> Option<semantic::Notifications> {
-        self.notifications
+    pub fn notifications(&self) -> Option<&semantic::Notifications> {
+        self.notifications.as_ref()
     }
 
     pub fn workspaces(&self) -> Option<&semantic::Workspaces> {
         self.workspaces.as_ref()
     }
 
-    pub fn edit_timeline(&self) -> Option<semantic::EditTimeline> {
-        self.edit_timeline
+    pub fn edit_timeline(&self) -> Option<&semantic::EditTimeline> {
+        self.edit_timeline.as_ref()
     }
 
     pub fn extension_overlay(&self) -> Option<semantic::ExtensionOverlay> {
@@ -292,12 +296,16 @@ impl SemanticState {
         self.sidebars.as_ref()
     }
 
-    pub fn agent_chat(&self) -> Option<semantic::AgentChat> {
-        self.agent_chat
+    pub fn board(&self) -> Option<&semantic::Board> {
+        self.board.as_ref()
     }
 
-    pub fn tool_manager(&self) -> Option<semantic::ToolManager> {
-        self.tool_manager
+    pub fn agent_chat(&self) -> Option<&semantic::AgentChat> {
+        self.agent_chat.as_ref()
+    }
+
+    pub fn tool_manager(&self) -> Option<&semantic::ToolManager> {
+        self.tool_manager.as_ref()
     }
 
     pub fn theme(&self) -> Option<&semantic::Theme> {
@@ -873,6 +881,7 @@ mod tests {
             semantic::Notifications {
                 visible: 1,
                 notification_count: 2,
+                items: Vec::new(),
             },
             0,
         )));
@@ -893,6 +902,7 @@ mod tests {
                 visible: 1,
                 viewing_index: 1,
                 entry_count: 4,
+                entries: Vec::new(),
             },
             0,
         )));
@@ -905,6 +915,8 @@ mod tests {
         state.apply_protocol_command(ProtocolCommand::Semantic(semantic::Command::Observatory(
             semantic::Observatory {
                 visible: true,
+                count: 0,
+                nodes: Vec::new(),
                 payload: vec![6, 7],
             },
             0,
@@ -934,6 +946,7 @@ mod tests {
                 focused_card_id: 9,
                 card_count: 10,
                 filter_mode: 0,
+                cards: Vec::new(),
             },
             0,
         )));
@@ -941,11 +954,20 @@ mod tests {
             semantic::AgentChat {
                 visible: 1,
                 status: 1,
+                model_name: String::new(),
+                prompt: String::new(),
+                pending: String::new(),
+                thinking_level: String::new(),
+                messages: Vec::new(),
             },
             0,
         )));
         state.apply_protocol_command(ProtocolCommand::Semantic(semantic::Command::ToolManager(
-            semantic::ToolManager { visible: 1 },
+            semantic::ToolManager {
+                visible: 1,
+                selected: 0,
+                tools: Vec::new(),
+            },
             0,
         )));
 
@@ -963,7 +985,7 @@ mod tests {
         assert_eq!(state.extension_panel().unwrap().panel_count, 6);
         assert_eq!(state.observatory().unwrap().payload, vec![6, 7]);
         assert_eq!(state.sidebars().unwrap().visible_count(), 1);
-        assert_eq!(state.board.unwrap().card_count, 10);
+        assert_eq!(state.board.as_ref().unwrap().card_count, 10);
         assert_eq!(state.agent_chat().unwrap().status, 1);
         assert_eq!(state.tool_manager().unwrap().visible, 1);
 


### PR DESCRIPTION
## Summary

- **Palette + component helpers**: `Palette` struct with ~30 semantic style accessors matching Go's naming, plus `popup_frame`, `styled_bar`, `list_item_line`, `tab_strip` helpers. All renderers migrated from bare `theme::` calls to Palette; legacy functions removed.
- **Expanded decoders**: Board (cards), ToolManager (tools), AgentChat (messages/prompt/pending), Notifications (items), EditTimeline (entries), Observatory (nodes) now parse full content from the binary wire format instead of header-only stubs.
- **8 new surface renderers**: Breadcrumb, AgentContext, AgentChat, Board, ToolManager, Notifications, EditTimeline, Observatory.
- **Visual polish**: Tab icons + active marker + attention/dirty/tint. Which-key multi-column grid. File tree expansion markers + git status + diagnostics + loading states. Picker scroll viewport + selection marker + help bar. Status bar three-zone segmented layout with centered message.
- **Bug fix**: Semantic attribute bits were wrong (0x02 was italic, should be underline; 0x04 was missing, should be italic). Affects all semantic text rendering.

## Test plan

- [x] `cargo check` passes with 0 errors
- [x] `cargo test` passes 104/104
- [ ] Visual comparison: `MINGA_TUI_IMPL=rust` vs `MINGA_TUI_IMPL=go` for tabs, picker, which-key, file tree, status bar, breadcrumb, agent chat, board

🤖 Generated with [Claude Code](https://claude.com/claude-code)