### PR TITLE
feat: generation-counter line cache for Rust TUI rendering

### DIFF
--- a/rust/tui/src/renderer/editor.rs
+++ b/rust/tui/src/renderer/editor.rs
@@ -1,12 +1,14 @@
 use super::geometry;
 use super::theme;
 use crate::semantic;
+use crate::semantic_renderer::CachedWindow;
 use crate::semantic_state::SemanticState;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
+use std::collections::HashMap;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -80,24 +82,56 @@ pub fn render_sidebars(
         .render(area, buffer);
 }
 
-pub fn render_windows(state: &SemanticState, area: Rect, buffer: &mut Buffer) {
+pub fn render_windows(
+    state: &SemanticState,
+    area: Rect,
+    buffer: &mut Buffer,
+    line_cache: &mut HashMap<u16, CachedWindow>,
+) {
     for window in state.windows() {
         let rect = geometry::window_rect(window, area);
-        let gutter = state.gutter(window.window_id);
-        let indent_guides = state.indent_guides(window.window_id);
-        let row_context = RowRenderContext {
-            gutter,
-            indent_guides,
-            theme: state.theme(),
+        let generation = state.window_render_generation(window.window_id);
+
+        let lines = match line_cache.get(&window.window_id) {
+            Some(cached) if cached.generation == generation => cached.lines.clone(),
+            _ => build_and_cache_lines(window, state, rect, generation, line_cache),
         };
-        let lines: Vec<Line<'_>> = (0..rect.height as usize)
-            .map(|row_index| window_line(window, row_index, rect.width, row_context))
-            .collect();
+
         Paragraph::new(lines)
             .style(theme::canvas(state.theme()))
             .wrap(Wrap { trim: false })
             .render(rect, buffer);
     }
+
+    let active_ids: Vec<u16> = state.windows().map(|w| w.window_id).collect();
+    line_cache.retain(|id, _| active_ids.contains(id));
+}
+
+fn build_and_cache_lines(
+    window: &semantic::WindowContent,
+    state: &SemanticState,
+    rect: Rect,
+    generation: u64,
+    line_cache: &mut HashMap<u16, CachedWindow>,
+) -> Vec<Line<'static>> {
+    let gutter = state.gutter(window.window_id);
+    let indent_guides = state.indent_guides(window.window_id);
+    let row_context = RowRenderContext {
+        gutter,
+        indent_guides,
+        theme: state.theme(),
+    };
+    let lines: Vec<Line<'static>> = (0..rect.height as usize)
+        .map(|row_index| window_line(window, row_index, rect.width, row_context))
+        .collect();
+    line_cache.insert(
+        window.window_id,
+        CachedWindow {
+            generation,
+            lines: lines.clone(),
+        },
+    );
+    lines
 }
 
 pub fn render_separators(state: &SemanticState, area: Rect, buffer: &mut Buffer) {

--- a/rust/tui/src/renderer/surfaces.rs
+++ b/rust/tui/src/renderer/surfaces.rs
@@ -1,9 +1,11 @@
 use super::{chrome, editor, overlays};
 use super::{layout::FrameLayout, theme};
+use crate::semantic_renderer::CachedWindow;
 use crate::semantic_state::SemanticState;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::widgets::{Paragraph, Widget};
+use std::collections::HashMap;
 use std::time::Instant;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -21,6 +23,7 @@ pub fn render_frame(
     state: &SemanticState,
     layout: &FrameLayout,
     buffer: &mut Buffer,
+    line_cache: &mut HashMap<u16, CachedWindow>,
 ) -> SurfaceRenderMetrics {
     let mut metrics = SurfaceRenderMetrics::default();
 
@@ -50,7 +53,7 @@ pub fn render_frame(
     metrics.tree_us = started.elapsed().as_micros();
 
     let started = Instant::now();
-    editor::render_windows(state, layout.area, buffer);
+    editor::render_windows(state, layout.area, buffer, line_cache);
     metrics.windows_us = started.elapsed().as_micros();
 
     let started = Instant::now();

--- a/rust/tui/src/semantic_renderer.rs
+++ b/rust/tui/src/semantic_renderer.rs
@@ -20,12 +20,21 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
+use std::collections::HashMap;
 use std::io;
 use std::time::Instant;
 use unicode_width::UnicodeWidthStr;
 
-#[derive(Debug, Default)]
-pub struct SemanticRenderer;
+#[derive(Debug, Clone)]
+pub(crate) struct CachedWindow {
+    pub generation: u64,
+    pub lines: Vec<Line<'static>>,
+}
+
+#[derive(Debug)]
+pub struct SemanticRenderer {
+    line_cache: HashMap<u16, CachedWindow>,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RenderMetrics {
@@ -36,9 +45,17 @@ pub struct RenderMetrics {
     pub surfaces: surfaces::SurfaceRenderMetrics,
 }
 
+impl Default for SemanticRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SemanticRenderer {
     pub fn new() -> Self {
-        Self
+        Self {
+            line_cache: HashMap::new(),
+        }
     }
 
     pub fn render_startup(terminal: &mut Terminal, message: &str) -> io::Result<()> {
@@ -95,10 +112,11 @@ impl SemanticRenderer {
 
         let draw_started = Instant::now();
         let mut surface_metrics = surfaces::SurfaceRenderMetrics::default();
+        let line_cache = &mut self.line_cache;
         terminal.draw(|frame| {
             let content_area = content_area(frame.area(), state);
             let layout = layout::FrameLayout::compute(state, content_area);
-            surface_metrics = surfaces::render_frame(state, &layout, frame.buffer_mut());
+            surface_metrics = surfaces::render_frame(state, &layout, frame.buffer_mut(), line_cache);
             if let Some((col, row)) = rendered_cursor_position(state, &layout) {
                 frame.set_cursor_position((col, row));
             }

--- a/rust/tui/src/semantic_state.rs
+++ b/rust/tui/src/semantic_state.rs
@@ -43,6 +43,8 @@ pub struct SemanticState {
     board: Option<semantic::Board>,
     agent_chat: Option<semantic::AgentChat>,
     tool_manager: Option<semantic::ToolManager>,
+    window_generations: HashMap<u16, u64>,
+    global_generation: u64,
     theme: Option<semantic::Theme>,
     diagnostic: Option<String>,
     cursor: CursorState,
@@ -105,6 +107,8 @@ impl SemanticState {
             board: None,
             agent_chat: None,
             tool_manager: None,
+            window_generations: HashMap::new(),
+            global_generation: 0,
             theme: None,
             diagnostic: None,
             cursor: CursorState {
@@ -119,6 +123,7 @@ impl SemanticState {
     pub fn resize(&mut self, width: u16, height: u16) {
         self.width = width;
         self.height = height;
+        self.bump_global_generation();
     }
 
     pub fn apply_protocol_command(&mut self, command: ProtocolCommand) -> StateEffect {
@@ -321,6 +326,11 @@ impl SemanticState {
             .is_none_or(|cursor_animation| cursor_animation.enabled != 0)
     }
 
+    pub fn window_render_generation(&self, window_id: u16) -> u64 {
+        self.window_generations.get(&window_id).copied().unwrap_or(0)
+            + self.global_generation
+    }
+
     pub fn debug_summary(&self) -> String {
         let row_count: usize = self.windows.values().map(|window| window.rows.len()).sum();
         format!(
@@ -337,11 +347,21 @@ impl SemanticState {
         )
     }
 
+    fn bump_window_generation(&mut self, window_id: u16) {
+        *self.window_generations.entry(window_id).or_insert(0) += 1;
+    }
+
+    fn bump_global_generation(&mut self) {
+        self.global_generation += 1;
+    }
+
     fn clear(&mut self) {
         self.windows.clear();
         self.window_order.clear();
         self.gutters.clear();
         self.indent_guides.clear();
+        self.window_generations.clear();
+        self.bump_global_generation();
         self.status_bar = None;
         self.tab_bar = None;
         self.file_tree = None;
@@ -461,7 +481,9 @@ impl SemanticState {
                 StateEffect::render()
             }
             semantic::Command::Gutter(gutter, _) => {
-                self.gutters.insert(gutter.window_id, gutter);
+                let wid = gutter.window_id;
+                self.gutters.insert(wid, gutter);
+                self.bump_window_generation(wid);
                 StateEffect::render()
             }
             semantic::Command::GutterSeparator(separator, _) => {
@@ -473,8 +495,9 @@ impl SemanticState {
                 StateEffect::render()
             }
             semantic::Command::IndentGuides(indent_guides, _) => {
-                self.indent_guides
-                    .insert(indent_guides.window_id, indent_guides);
+                let wid = indent_guides.window_id;
+                self.indent_guides.insert(wid, indent_guides);
+                self.bump_window_generation(wid);
                 StateEffect::render()
             }
             semantic::Command::WindowOverlayDelta(delta, _) => {
@@ -556,6 +579,7 @@ impl SemanticState {
             }
             semantic::Command::Theme(theme, _) => {
                 self.theme = Some(theme);
+                self.bump_global_generation();
                 StateEffect::render()
             }
         }
@@ -573,7 +597,9 @@ impl SemanticState {
             shape: window.cursor_shape,
         };
         self.cursor_window_id = Some(window.window_id);
-        self.windows.insert(window.window_id, window);
+        let wid = window.window_id;
+        self.windows.insert(wid, window);
+        self.bump_window_generation(wid);
     }
 
     fn apply_window_rows_delta(&mut self, delta: semantic::WindowRowsDelta) {
@@ -633,6 +659,7 @@ impl SemanticState {
             };
             self.cursor_window_id = Some(window.window_id);
         }
+        self.bump_window_generation(delta.window_id);
     }
 
     fn apply_window_overlay_delta(&mut self, delta: semantic::WindowOverlayDelta) {
@@ -652,6 +679,7 @@ impl SemanticState {
             };
             self.cursor_window_id = Some(window.window_id);
         }
+        self.bump_window_generation(delta.window_id);
     }
 
     fn apply_file_tree_selection(&mut self, selection: semantic::FileTreeSelection) {
@@ -665,6 +693,10 @@ impl SemanticState {
     fn apply_cursorline(&mut self, cursorline: semantic::Cursorline) {
         for window in self.windows.values_mut() {
             window.cursorline = Some(cursorline);
+        }
+        let ids: Vec<u16> = self.windows.keys().copied().collect();
+        for id in ids {
+            self.bump_window_generation(id);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add per-window and global render generation counters to `SemanticState`, bumped on every mutation that affects window rendering (content, cursor, scroll, gutter, indent guides, cursorline, theme, resize)
- Cache built `Vec<Line<'static>>` per window in `SemanticRenderer`; replay on cache hit instead of running expensive per-grapheme text processing in `window_line()`
- Stale cache entries pruned when windows are closed; `clear()` bumps global generation to prevent false cache hits after buffer switches

## Motivation

Empirical measurement showed Rust TUI rendering at ~2,500us per frame (p50), with `windows_us` at ~960us for unconditional row-by-row text processing. On cache hits (unchanged windows), this drops to the cost of `Vec::clone()`, which for 40 lines is on the order of microseconds. Expected `draw_us` improvement: 400-1,000us per keystroke.

## Test plan

- [x] `cargo test --release` — 104 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features` — 0 new warnings
- [x] Bug-hunting review: found and fixed stale-cache bug in `clear()` (missing `bump_global_generation`)
- [ ] Manual validation: type in insert mode with `MINGA_RUST_TUI_TRACE=1`, verify `windows_us` drops for successive keystrokes in the same window
- [ ] Visual regression check: cursor movement, scrolling, window splits, mode switches, theme changes, file tree toggling

Closes #2175

🤖 Generated with [Claude Code](https://claude.com/claude-code)