### PR TITLE
feat: two-tier rendering bypasses ratatui diff for keystroke frames

### DIFF
--- a/rust/tui/src/app.rs
+++ b/rust/tui/src/app.rs
@@ -6,8 +6,8 @@ use crate::parity::{FrontendParityPolicy, GO_ZIG_PARITY};
 use crate::protocol;
 use crate::render_scheduler::{RenderBatch, RenderScheduler};
 use crate::runtime::{DrainDecision, FrameRuntime};
-use crate::semantic_renderer::SemanticRenderer;
-use crate::semantic_state::SemanticState;
+use crate::semantic_renderer::{SemanticRenderer, RECONCILIATION_INTERVAL};
+use crate::semantic_state::{DirtyKind, SemanticState};
 use crate::signals;
 use crate::terminal::Terminal;
 use crossterm::event;
@@ -234,7 +234,7 @@ fn process_loop_event(
                     runtime.startup_started.elapsed().as_millis()
                 ));
             }
-            if handle_packet(
+            match handle_packet(
                 &packet,
                 received_at,
                 runtime.policy,
@@ -242,7 +242,9 @@ fn process_loop_event(
                 terminal,
                 output,
             )? {
-                runtime.render_scheduler.request();
+                Some(DirtyKind::Partial) => runtime.render_scheduler.request_partial(),
+                Some(DirtyKind::Full) => runtime.render_scheduler.request(),
+                None => {}
             }
             Ok(false)
         }
@@ -283,11 +285,56 @@ fn render_now(
     state: &SemanticState,
     terminal: &mut Terminal,
 ) -> io::Result<()> {
+    let use_incremental = batch.dirty == DirtyKind::Partial
+        && terminal.is_real_tty()
+        && renderer.incremental_frame_count < RECONCILIATION_INTERVAL;
+
+    if use_incremental {
+        match renderer.render_incremental(state, terminal) {
+            Ok(metrics) if policy.tracing.render_latency => {
+                let surfaces = metrics.surfaces;
+                beam_host::trace(format!(
+                    "latency render render_mode=incremental requests={} pending_us={} cursor_style_us={} draw_us={} flush_us={} total_us={} windows_us={} chrome_us={} state={}",
+                    batch.request_count,
+                    batch.pending_us,
+                    metrics.cursor_style_us,
+                    metrics.draw_us,
+                    metrics.flush_us,
+                    metrics.total_us,
+                    surfaces.windows_us,
+                    surfaces.chrome_us,
+                    state.debug_summary()
+                ));
+                Ok(())
+            }
+            Ok(_) => Ok(()),
+            Err(error) => {
+                beam_host::trace(format!("render incremental failed error={error}, falling back to full"));
+                // Fall back to full render on incremental failure
+                renderer.incremental_frame_count = 0;
+                render_full(batch, policy, renderer, state, terminal)
+            }
+        }
+    } else {
+        if renderer.incremental_frame_count > 0 {
+            let _ = terminal.clear_for_reconciliation();
+        }
+        render_full(batch, policy, renderer, state, terminal)
+    }
+}
+
+fn render_full(
+    batch: RenderBatch,
+    policy: FrontendParityPolicy,
+    renderer: &mut SemanticRenderer,
+    state: &SemanticState,
+    terminal: &mut Terminal,
+) -> io::Result<()> {
     match renderer.render_with_metrics(state, terminal) {
         Ok(metrics) if policy.tracing.render_latency => {
             let surfaces = metrics.surfaces;
             beam_host::trace(format!(
-                "latency render requests={} pending_us={} cursor_style_us={} draw_us={} flush_us={} total_us={} clear_us={} tree_us={} windows_us={} separators_us={} overlays_us={} bottom_panel_us={} chrome_us={} state={}",
+                "latency render render_mode=full requests={} pending_us={} cursor_style_us={} draw_us={} flush_us={} total_us={} clear_us={} tree_us={} windows_us={} separators_us={} overlays_us={} bottom_panel_us={} chrome_us={} state={}",
                 batch.request_count,
                 batch.pending_us,
                 metrics.cursor_style_us,
@@ -467,9 +514,10 @@ fn handle_packet(
     state: &mut SemanticState,
     terminal: &mut Terminal,
     _output: &mut (impl Write + ?Sized),
-) -> io::Result<bool> {
+) -> io::Result<Option<DirtyKind>> {
     let decode_started = Instant::now();
     let mut should_render = false;
+    let mut packet_dirty = DirtyKind::Partial;
     let mut command_names = Vec::new();
 
     for decoded in beam_host::decode_packet(packet) {
@@ -496,23 +544,31 @@ fn handle_packet(
         {
             terminal.write_clipboard(&clipboard.text)?;
         }
-        should_render |= effect.render;
+        if effect.render {
+            should_render = true;
+            packet_dirty = packet_dirty.merge(effect.dirty);
+        }
     }
 
     let decode_apply_us = decode_started.elapsed().as_micros();
     if policy.tracing.packet_latency {
         beam_host::trace(format!(
-            "latency packet len={} queue_us={} decode_apply_us={} render={} commands=[{}] state={}",
+            "latency packet len={} queue_us={} decode_apply_us={} render={} dirty={:?} commands=[{}] state={}",
             packet.len(),
             received_at.elapsed().as_micros(),
             decode_apply_us,
             should_render,
+            packet_dirty,
             command_names.join(","),
             state.debug_summary()
         ));
     }
 
-    Ok(should_render)
+    Ok(if should_render {
+        Some(packet_dirty)
+    } else {
+        None
+    })
 }
 
 fn packet_head(packet: &[u8]) -> String {

--- a/rust/tui/src/render_scheduler.rs
+++ b/rust/tui/src/render_scheduler.rs
@@ -1,23 +1,50 @@
+use crate::semantic_state::DirtyKind;
 use std::time::Instant;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct RenderScheduler {
     pending: bool,
+    dirty: DirtyKind,
     request_count: u64,
     first_requested_at: Option<Instant>,
+}
+
+impl Default for RenderScheduler {
+    fn default() -> Self {
+        Self {
+            pending: false,
+            dirty: DirtyKind::Full,
+            request_count: 0,
+            first_requested_at: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RenderBatch {
     pub request_count: u64,
     pub pending_us: u128,
+    pub dirty: DirtyKind,
 }
 
 impl RenderScheduler {
     pub fn request(&mut self) {
         if !self.pending {
             self.first_requested_at = Some(Instant::now());
+            self.dirty = DirtyKind::Full;
+        } else {
+            self.dirty = DirtyKind::Full;
         }
+        self.pending = true;
+        self.request_count = self.request_count.saturating_add(1);
+    }
+
+    pub fn request_partial(&mut self) {
+        if !self.pending {
+            self.first_requested_at = Some(Instant::now());
+            self.dirty = DirtyKind::Partial;
+        }
+        // If already pending and Full, keep Full
         self.pending = true;
         self.request_count = self.request_count.saturating_add(1);
     }
@@ -37,10 +64,12 @@ impl RenderScheduler {
                 .first_requested_at
                 .map(|requested_at| requested_at.elapsed().as_micros())
                 .unwrap_or(0),
+            dirty: self.dirty,
         };
         self.pending = false;
         self.request_count = 0;
         self.first_requested_at = None;
+        self.dirty = DirtyKind::Full;
         Some(batch)
     }
 }
@@ -60,6 +89,40 @@ mod tests {
 
         let batch = scheduler.take_ready().unwrap();
         assert_eq!(batch.request_count, 2);
+        assert_eq!(batch.dirty, DirtyKind::Full);
         assert!(scheduler.take_ready().is_none());
+    }
+
+    #[test]
+    fn partial_requests_stay_partial_when_all_partial() {
+        let mut scheduler = RenderScheduler::default();
+
+        scheduler.request_partial();
+        scheduler.request_partial();
+
+        let batch = scheduler.take_ready().unwrap();
+        assert_eq!(batch.dirty, DirtyKind::Partial);
+    }
+
+    #[test]
+    fn full_request_escalates_partial_to_full() {
+        let mut scheduler = RenderScheduler::default();
+
+        scheduler.request_partial();
+        scheduler.request();
+
+        let batch = scheduler.take_ready().unwrap();
+        assert_eq!(batch.dirty, DirtyKind::Full);
+    }
+
+    #[test]
+    fn partial_after_full_stays_full() {
+        let mut scheduler = RenderScheduler::default();
+
+        scheduler.request();
+        scheduler.request_partial();
+
+        let batch = scheduler.take_ready().unwrap();
+        assert_eq!(batch.dirty, DirtyKind::Full);
     }
 }

--- a/rust/tui/src/renderer/chrome.rs
+++ b/rust/tui/src/renderer/chrome.rs
@@ -114,6 +114,108 @@ fn render_status_bar(
     }
 }
 
+pub(crate) fn status_bar_line(
+    state: &SemanticState,
+    frame: &layout::FrameLayout,
+    status_bar: &semantic::StatusBar,
+) -> Line<'static> {
+    let palette = Palette::new(state.theme());
+    let width = frame.status_bar.width as usize;
+    if !status_bar.left_segments.is_empty() || !status_bar.right_segments.is_empty() {
+        segmented_status_bar_line(status_bar, &palette, width)
+    } else {
+        fallback_status_bar_line(state, status_bar, &palette, width)
+    }
+}
+
+fn segmented_status_bar_line(
+    status_bar: &semantic::StatusBar,
+    palette: &Palette<'_>,
+    width: usize,
+) -> Line<'static> {
+    let base = palette.status_bar();
+    let left_spans: Vec<Span<'static>> = status_bar
+        .left_segments
+        .iter()
+        .map(|s| status_segment_span_owned(s, palette))
+        .collect();
+    let right_spans: Vec<Span<'static>> = status_bar
+        .right_segments
+        .iter()
+        .map(|s| status_segment_span_owned(s, palette))
+        .collect();
+    let left_width: usize = left_spans.iter().map(|s| s.content.len()).sum();
+    let right_width: usize = right_spans.iter().map(|s| s.content.len()).sum();
+    let available = width.saturating_sub(left_width + right_width);
+
+    let mut spans = left_spans;
+
+    if !status_bar.message.is_empty() {
+        let msg = &status_bar.message;
+        let msg_width = msg.len().min(available);
+        let left_pad = available.saturating_sub(msg_width) / 2;
+        let right_pad = available.saturating_sub(msg_width).saturating_sub(left_pad);
+        spans.push(Span::styled(" ".repeat(left_pad), base));
+        spans.push(Span::styled(
+            msg[..msg_width].to_owned(),
+            base.fg(palette.warning()).add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::styled(" ".repeat(right_pad), base));
+    } else {
+        spans.push(Span::styled(" ".repeat(available), base));
+    }
+
+    spans.extend(right_spans);
+    Line::from(spans)
+}
+
+fn status_segment_span_owned(segment: &semantic::StatusSegment, palette: &Palette<'_>) -> Span<'static> {
+    let mut style = palette.status_bar();
+    if segment.fg != 0 {
+        style = style.fg(theme::rgb(segment.fg));
+    }
+    if segment.bg != 0 {
+        style = style.bg(theme::rgb(segment.bg));
+    }
+    if segment.attrs & 0x01 != 0 {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    if segment.attrs & 0x02 != 0 {
+        style = style.add_modifier(Modifier::UNDERLINED);
+    }
+    if segment.attrs & 0x04 != 0 {
+        style = style.add_modifier(Modifier::ITALIC);
+    }
+    Span::styled(segment.text.clone(), style)
+}
+
+fn fallback_status_bar_line(
+    state: &SemanticState,
+    status_bar: &semantic::StatusBar,
+    palette: &Palette<'_>,
+    width: usize,
+) -> Line<'static> {
+    let mut left = if status_bar.filename.is_empty() {
+        status_bar.message.clone()
+    } else {
+        status_bar.filename.clone()
+    };
+    if !status_bar.branch.is_empty() {
+        left.push_str("  ");
+        left.push_str(&status_bar.branch);
+    }
+    let right = status_right_text(state, status_bar);
+    let left_width = left.len();
+    let right_width = right.len();
+    let padding = width.saturating_sub(left_width + right_width);
+    let style = palette.status_bar();
+    Line::from(vec![
+        Span::styled(left, style),
+        Span::styled(" ".repeat(padding), style),
+        Span::styled(right, style),
+    ])
+}
+
 fn render_segmented_status_bar(
     status_bar: &semantic::StatusBar,
     palette: &Palette<'_>,

--- a/rust/tui/src/renderer/editor.rs
+++ b/rust/tui/src/renderer/editor.rs
@@ -12,11 +12,11 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 #[derive(Clone, Copy)]
-struct RowRenderContext<'a> {
-    gutter: Option<&'a semantic::Gutter>,
-    indent_guides: Option<&'a semantic::IndentGuides>,
-    palette: Palette<'a>,
-    theme: Option<&'a semantic::Theme>,
+pub(crate) struct RowRenderContext<'a> {
+    pub(crate) gutter: Option<&'a semantic::Gutter>,
+    pub(crate) indent_guides: Option<&'a semantic::IndentGuides>,
+    pub(crate) palette: Palette<'a>,
+    pub(crate) theme: Option<&'a semantic::Theme>,
 }
 
 pub fn render_file_tree(
@@ -234,7 +234,7 @@ pub fn render_bottom_panel(state: &SemanticState, area: Rect, buffer: &mut Buffe
         .render(area, buffer);
 }
 
-fn window_line(
+pub(crate) fn window_line(
     window: &semantic::WindowContent,
     row_index: usize,
     width: u16,

--- a/rust/tui/src/semantic_renderer.rs
+++ b/rust/tui/src/semantic_renderer.rs
@@ -26,8 +26,12 @@ use std::io;
 use std::time::Instant;
 use unicode_width::UnicodeWidthStr;
 
+pub const RECONCILIATION_INTERVAL: u32 = 60;
+
 #[derive(Debug, Default)]
-pub struct SemanticRenderer;
+pub struct SemanticRenderer {
+    pub incremental_frame_count: u32,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RenderMetrics {
@@ -40,7 +44,9 @@ pub struct RenderMetrics {
 
 impl SemanticRenderer {
     pub fn new() -> Self {
-        Self
+        Self {
+            incremental_frame_count: 0,
+        }
     }
 
     pub fn render_startup(terminal: &mut Terminal, message: &str) -> io::Result<()> {
@@ -90,6 +96,7 @@ impl SemanticRenderer {
         state: &SemanticState,
         terminal: &mut Terminal,
     ) -> io::Result<RenderMetrics> {
+        self.incremental_frame_count = 0;
         let total_started = Instant::now();
         let cursor_style_started = Instant::now();
         terminal.set_cursor_style(state.cursor().shape, state.cursor_animation_enabled())?;
@@ -112,6 +119,99 @@ impl SemanticRenderer {
             cursor_style_us,
             draw_us,
             flush_us: flush_started.elapsed().as_micros(),
+            total_us: total_started.elapsed().as_micros(),
+            surfaces: surface_metrics,
+        })
+    }
+
+    pub fn render_incremental(
+        &mut self,
+        state: &SemanticState,
+        terminal: &mut Terminal,
+    ) -> io::Result<RenderMetrics> {
+        let total_started = Instant::now();
+
+        let cursor_style_started = Instant::now();
+        terminal.set_cursor_style(state.cursor().shape, state.cursor_animation_enabled())?;
+        let cursor_style_us = cursor_style_started.elapsed().as_micros();
+
+        let draw_started = Instant::now();
+
+        let content_area = content_area(
+            Rect {
+                x: 0,
+                y: 0,
+                width: state.width(),
+                height: state.height(),
+            },
+            state,
+        );
+        let frame_layout = layout::FrameLayout::compute(state, content_area);
+
+        let mut output = Vec::with_capacity(4096);
+        let palette = theme::Palette::new(state.theme());
+
+        crossterm::queue!(
+            output,
+            crossterm::cursor::Hide,
+            crossterm::terminal::BeginSynchronizedUpdate
+        )?;
+
+        let mut surface_metrics = surfaces::SurfaceRenderMetrics::default();
+        let windows_started = Instant::now();
+        for window in state.windows() {
+            let rect = geometry::window_rect(window, frame_layout.area);
+            let gutter = state.gutter(window.window_id);
+            let indent_guides = state.indent_guides(window.window_id);
+            let row_context = editor::RowRenderContext {
+                gutter,
+                indent_guides,
+                palette,
+                theme: state.theme(),
+            };
+            for row_idx in 0..rect.height as usize {
+                let line = editor::window_line(window, row_idx, rect.width, row_context);
+                let y = rect.y + row_idx as u16;
+                write_line_to_output(&mut output, rect.x, y, &line, rect.width)?;
+            }
+        }
+        surface_metrics.windows_us = windows_started.elapsed().as_micros();
+
+        let chrome_started = Instant::now();
+        if let Some(status_bar) = state.status_bar() {
+            let line = chrome::status_bar_line(state, &frame_layout, status_bar);
+            write_line_to_output(
+                &mut output,
+                frame_layout.status_bar.x,
+                frame_layout.status_bar.y,
+                &line,
+                frame_layout.status_bar.width,
+            )?;
+        }
+        surface_metrics.chrome_us = chrome_started.elapsed().as_micros();
+
+        if let Some((col, row)) = rendered_cursor_position(state, &frame_layout) {
+            crossterm::queue!(output, crossterm::cursor::MoveTo(col, row))?;
+        }
+
+        crossterm::queue!(
+            output,
+            crossterm::terminal::EndSynchronizedUpdate,
+            crossterm::cursor::Show
+        )?;
+
+        let draw_us = draw_started.elapsed().as_micros();
+
+        let flush_started = Instant::now();
+        terminal.write_raw(&output)?;
+        let flush_us = flush_started.elapsed().as_micros();
+
+        self.incremental_frame_count += 1;
+
+        Ok(RenderMetrics {
+            cursor_style_us,
+            draw_us,
+            flush_us,
             total_us: total_started.elapsed().as_micros(),
             surfaces: surface_metrics,
         })
@@ -264,6 +364,101 @@ fn rendered_cursor_position(
     }
 
     Some((col, rect.y.saturating_add(window.cursor_row)))
+}
+
+fn write_line_to_output(
+    output: &mut Vec<u8>,
+    x: u16,
+    y: u16,
+    line: &Line<'_>,
+    width: u16,
+) -> io::Result<()> {
+    use crossterm::cursor::MoveTo;
+    use crossterm::style::{
+        Attribute, Print, ResetColor, SetAttribute, SetBackgroundColor,
+        SetForegroundColor,
+    };
+
+    crossterm::queue!(output, MoveTo(x, y))?;
+
+    let mut col = 0u16;
+    for span in &line.spans {
+        if col >= width {
+            break;
+        }
+        let style = span.style;
+        if let Some(fg) = style.fg {
+            crossterm::queue!(output, SetForegroundColor(ratatui_color_to_crossterm(fg)))?;
+        }
+        if let Some(bg) = style.bg {
+            crossterm::queue!(output, SetBackgroundColor(ratatui_color_to_crossterm(bg)))?;
+        }
+        if style.add_modifier.contains(Modifier::BOLD) {
+            crossterm::queue!(output, SetAttribute(Attribute::Bold))?;
+        }
+        if style.add_modifier.contains(Modifier::ITALIC) {
+            crossterm::queue!(output, SetAttribute(Attribute::Italic))?;
+        }
+        if style.add_modifier.contains(Modifier::UNDERLINED) {
+            crossterm::queue!(output, SetAttribute(Attribute::Underlined))?;
+        }
+
+        let text = &span.content;
+        let text_width = UnicodeWidthStr::width(text.as_ref()) as u16;
+        if col + text_width <= width {
+            crossterm::queue!(output, Print(text))?;
+            col += text_width;
+        } else {
+            let remaining = (width - col) as usize;
+            let mut taken_width = 0;
+            let truncated: String = text
+                .chars()
+                .take_while(|c| {
+                    let w = unicode_width::UnicodeWidthChar::width(*c).unwrap_or(0);
+                    if taken_width + w > remaining {
+                        return false;
+                    }
+                    taken_width += w;
+                    true
+                })
+                .collect();
+            crossterm::queue!(output, Print(&truncated))?;
+            col += taken_width as u16;
+        }
+
+        crossterm::queue!(output, ResetColor, SetAttribute(Attribute::Reset))?;
+    }
+
+    if col < width {
+        let padding = " ".repeat((width - col) as usize);
+        crossterm::queue!(output, crossterm::style::Print(&padding))?;
+    }
+
+    Ok(())
+}
+
+fn ratatui_color_to_crossterm(color: ratatui::style::Color) -> crossterm::style::Color {
+    match color {
+        Color::Rgb(r, g, b) => crossterm::style::Color::Rgb { r, g, b },
+        Color::Black => crossterm::style::Color::Black,
+        Color::Red => crossterm::style::Color::DarkRed,
+        Color::Green => crossterm::style::Color::DarkGreen,
+        Color::Yellow => crossterm::style::Color::DarkYellow,
+        Color::Blue => crossterm::style::Color::DarkBlue,
+        Color::Magenta => crossterm::style::Color::DarkMagenta,
+        Color::Cyan => crossterm::style::Color::DarkCyan,
+        Color::Gray => crossterm::style::Color::Grey,
+        Color::DarkGray => crossterm::style::Color::DarkGrey,
+        Color::LightRed => crossterm::style::Color::Red,
+        Color::LightGreen => crossterm::style::Color::Green,
+        Color::LightYellow => crossterm::style::Color::Yellow,
+        Color::LightBlue => crossterm::style::Color::Blue,
+        Color::LightMagenta => crossterm::style::Color::Magenta,
+        Color::LightCyan => crossterm::style::Color::Cyan,
+        Color::White => crossterm::style::Color::White,
+        Color::Indexed(i) => crossterm::style::Color::AnsiValue(i),
+        _ => crossterm::style::Color::Reset,
+    }
 }
 
 fn pad_to_width(text: &str, width: usize) -> String {

--- a/rust/tui/src/semantic_state.rs
+++ b/rust/tui/src/semantic_state.rs
@@ -2,6 +2,21 @@ use crate::protocol::Command as ProtocolCommand;
 use crate::semantic;
 use std::collections::HashMap;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirtyKind {
+    Full,
+    Partial,
+}
+
+impl DirtyKind {
+    pub fn merge(self, other: DirtyKind) -> DirtyKind {
+        match (self, other) {
+            (DirtyKind::Partial, DirtyKind::Partial) => DirtyKind::Partial,
+            _ => DirtyKind::Full,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SemanticState {
     width: u16,
@@ -59,6 +74,7 @@ pub struct CursorState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StateEffect {
     pub render: bool,
+    pub dirty: DirtyKind,
     pub title: Option<String>,
     pub clipboard: Option<semantic::ClipboardWrite>,
 }
@@ -127,7 +143,7 @@ impl SemanticState {
                 self.clear();
                 StateEffect::render()
             }
-            ProtocolCommand::BatchEnd => StateEffect::render(),
+            ProtocolCommand::BatchEnd => StateEffect::render_partial(),
             ProtocolCommand::SetCursor { row, col } => {
                 self.cursor.row = row;
                 self.cursor.col = col;
@@ -140,6 +156,7 @@ impl SemanticState {
             }
             ProtocolCommand::SetTitle(title) => StateEffect {
                 render: false,
+                dirty: DirtyKind::Full,
                 title: Some(title),
                 clipboard: None,
             },
@@ -160,6 +177,7 @@ impl SemanticState {
             | ProtocolCommand::MeasureText { .. }
             | ProtocolCommand::Noop(_) => StateEffect {
                 render: false,
+                dirty: DirtyKind::Full,
                 title: None,
                 clipboard: None,
             },
@@ -402,11 +420,11 @@ impl SemanticState {
             }
             semantic::Command::WindowRowsDelta(delta, _) => {
                 self.apply_window_rows_delta(delta);
-                StateEffect::render()
+                StateEffect::render_partial()
             }
             semantic::Command::StatusBar(status_bar, _) => {
                 self.status_bar = Some(status_bar);
-                StateEffect::render()
+                StateEffect::render_partial()
             }
             semantic::Command::TabBar(tab_bar, _) => {
                 self.tab_bar = Some(tab_bar);
@@ -470,7 +488,7 @@ impl SemanticState {
             }
             semantic::Command::Gutter(gutter, _) => {
                 self.gutters.insert(gutter.window_id, gutter);
-                StateEffect::render()
+                StateEffect::render_partial()
             }
             semantic::Command::GutterSeparator(separator, _) => {
                 self.gutter_separator = Some(separator);
@@ -483,15 +501,15 @@ impl SemanticState {
             semantic::Command::IndentGuides(indent_guides, _) => {
                 self.indent_guides
                     .insert(indent_guides.window_id, indent_guides);
-                StateEffect::render()
+                StateEffect::render_partial()
             }
             semantic::Command::WindowOverlayDelta(delta, _) => {
                 self.apply_window_overlay_delta(delta);
-                StateEffect::render()
+                StateEffect::render_partial()
             }
             semantic::Command::Cursorline(cursorline, _) => {
                 self.apply_cursorline(cursorline);
-                StateEffect::render()
+                StateEffect::render_partial()
             }
             semantic::Command::LineSpacing(line_spacing, _) => {
                 self.line_spacing = Some(line_spacing);
@@ -523,6 +541,7 @@ impl SemanticState {
             }
             semantic::Command::ClipboardWrite(clipboard, _) => StateEffect {
                 render: false,
+                dirty: DirtyKind::Full,
                 title: None,
                 clipboard: Some(clipboard),
             },
@@ -681,6 +700,16 @@ impl StateEffect {
     fn render() -> Self {
         Self {
             render: true,
+            dirty: DirtyKind::Full,
+            title: None,
+            clipboard: None,
+        }
+    }
+
+    fn render_partial() -> Self {
+        Self {
+            render: true,
+            dirty: DirtyKind::Partial,
             title: None,
             clipboard: None,
         }

--- a/rust/tui/src/terminal.rs
+++ b/rust/tui/src/terminal.rs
@@ -183,6 +183,29 @@ impl Terminal {
         }
     }
 
+    pub fn clear_for_reconciliation(&mut self) -> io::Result<()> {
+        match &mut self.backend {
+            Backend::Real(terminal) => terminal.clear().map(|_| ()),
+            #[cfg(test)]
+            Backend::Test(_) => Ok(()),
+        }
+    }
+
+    pub fn write_raw(&mut self, bytes: &[u8]) -> io::Result<()> {
+        match &mut self.backend {
+            Backend::Real(terminal) => {
+                terminal.backend_mut().write_all(bytes)?;
+                terminal.backend_mut().flush()
+            }
+            #[cfg(test)]
+            Backend::Test(_) => Ok(()),
+        }
+    }
+
+    pub fn is_real_tty(&self) -> bool {
+        self.real_tty
+    }
+
     #[cfg(test)]
     pub fn buffer_text(&self) -> String {
         match &self.backend {


### PR DESCRIPTION
## Summary

- Add `DirtyKind` (Full/Partial) tracking to `SemanticState` and `StateEffect`, classifying each protocol command by whether it changes layout structure or just window content
- Route Partial frames (WindowRowsDelta, StatusBar, Gutter, IndentGuides, Cursorline, WindowOverlayDelta) to a new incremental rendering path that writes crossterm escape sequences directly to the TTY
- Route Full frames (theme, resize, file tree, overlays, window layout changes) through the existing ratatui `terminal.draw()` path
- Reconcile every 60 incremental frames with a full ratatui redraw to prevent TTY/buffer drift

## Motivation

Empirical measurement showed ratatui's cell-by-cell buffer diff costs ~2,400us per frame (78% of total draw time) for a 160x46 terminal. Our surface rendering code accounts for only 22% (~667us). The incremental path bypasses the diff entirely for the common keystroke case, targeting draw_us under 500us.

## Test plan

- [x] `cargo test --release` — 107 passed (3 new tests for DirtyKind merge logic)
- [x] `cargo clippy --all-targets --all-features` — 0 new warnings
- [x] Bug-hunting review: found and fixed BatchEnd returning Full (made incremental path unreachable) and wide-char truncation bug
- [ ] Manual: type in insert mode with `MINGA_RUST_TUI_TRACE=1`, verify `render_mode=incremental` in trace and `draw_us` < 500us
- [ ] Manual: resize terminal, toggle file tree, switch theme — verify clean full redraws
- [ ] Manual: sustained typing — verify no flicker at reconciliation boundaries

Closes #2175

🤖 Generated with [Claude Code](https://claude.com/claude-code)