### PR TITLE
Adopt ZigZag structural chrome adapters

### DIFF
--- a/zig/ZIGZAG_CHROME_NOTES.md
+++ b/zig/ZIGZAG_CHROME_NOTES.md
@@ -1,0 +1,32 @@
+# ZigZag static chrome notes
+
+Ticket #2185 now adopts ZigZag structural chrome components as presentation and layout adapters inside the current `minga-renderer` path. The important boundary is not “no ZigZag components”; it is “no ZigZag ownership of semantic state, terminal output, or command behavior.”
+
+## What changed
+
+`zig/src/zigzag_chrome.zig` now uses ZigZag structural components to derive local presentation data from BEAM-owned semantic payloads:
+
+- `TabGroup` derives tab active-state presentation for the tab strip. Tab IDs, labels, dirty/attention flags, and click actions remain semantic payloads owned by BEAM/Minga.
+- `Tree` reconstructs file-tree hierarchy/presentation from Minga’s retained flat visible row model. Expansion, selection, focus, git status, diagnostics, editing text, and row actions remain BEAM-owned.
+- `StatusBar` derives right-segment layout for modeline/status rendering. Segment text, styles, commands, and render priority remain Minga-owned.
+- `SplitPane` computes picker preview split geometry. Picker query, selection, preview content, and command acceptance remain BEAM-owned.
+
+The runtime still writes through Minga’s surface/cell renderer. ZigZag components produce derived presentation data or layout measurements; they do not write ANSI strings to the terminal and do not bypass the existing Port protocol.
+
+## Why this is the right boundary
+
+Direct component output is still unsafe because high-level ZigZag views render styled strings, while Minga’s TUI surface paints explicit cells with foreground, background, attrs, cursor placement, and hit-test parity. Writing those strings directly would bypass Minga’s semantic cell contract and risk ANSI escape leakage into the cell renderer.
+
+The corrected approach follows the Go/Charm pattern: use components as presentation adapters over decoded semantic state, but keep protocol meaning, terminal writes, and behavior ownership separate.
+
+## Verified coverage
+
+- `TabGroup`, `Tree`, `StatusBar`, and `SplitPane` have focused adapter tests in `zig/src/zigzag_chrome.zig`.
+- The existing `full_editor.bin` fixture still proves structural chrome can be represented from retained semantic packets at 80 columns and a wide terminal size.
+- Runtime tab strip, file tree, modeline/status layout, and picker split geometry now call the adapter helpers while preserving the existing surface renderer.
+
+## Still not adopted directly
+
+- Direct `TabGroup.view`, `Tree.view`, or `StatusBar.view` output is not written into runtime cells because that would import ANSI/string styling into a cell renderer.
+- `Breadcrumb` remains evidence-only for now because it was not needed to correct the structural chrome slice.
+- `SplitPane` is used for local geometry, not as a pane owner. Minga layout and semantic payloads remain authoritative.

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -14,6 +14,7 @@ pub const surface = @import("surface.zig");
 pub const apprt = @import("apprt.zig");
 pub const zigzag_bridge = @import("zigzag_bridge.zig");
 pub const zigzag_view_data = @import("zigzag_view_data.zig");
+pub const zigzag_chrome = @import("zigzag_chrome.zig");
 // Note: highlighter.zig is compiled into minga-parser, not the renderer.
 // Font rendering (CoreText, atlas) lives in the macOS Swift app (macos/).
 
@@ -115,4 +116,5 @@ test {
     _ = apprt;
     _ = zigzag_bridge;
     _ = zigzag_view_data;
+    _ = zigzag_chrome;
 }

--- a/zig/src/semantic.zig
+++ b/zig/src/semantic.zig
@@ -12,6 +12,7 @@ const types = @import("semantic/types.zig");
 const charm = @import("semantic/charm.zig");
 const theme_mod = @import("semantic/theme.zig");
 const decode = @import("semantic/decode.zig");
+const zigzag_chrome = @import("zigzag_chrome.zig");
 
 pub const Error = types.Error;
 pub const StatusSegment = types.StatusSegment;
@@ -1216,16 +1217,42 @@ fn renderFileTree(surface: anytype, file_tree: FileTree, header_rows: u16, has_s
         return;
     }
 
+    var buffer: [8192]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buffer);
+    const rows = zigzag_chrome.fileTreeRows(fba.allocator(), file_tree) catch {
+        renderFileTreeRowsManual(surface, file_tree, row, end_row, tree_width, maybe_theme);
+        return;
+    };
+
+    var index: usize = 0;
+    while (row < end_row and index < rows.len) : ({
+        row += 1;
+        index += 1;
+    }) {
+        const presentation = rows[index];
+        if (presentation.source_index >= file_tree.rows.len) continue;
+        renderFileTreeRow(surface, file_tree, file_tree.rows[presentation.source_index], presentation, row, tree_width, maybe_theme);
+    }
+}
+
+fn renderFileTreeRowsManual(surface: anytype, file_tree: FileTree, start_row: u16, end_row: u16, tree_width: u16, maybe_theme: ?Theme) void {
+    var row = start_row;
     var index: usize = 0;
     while (row < end_row and index < file_tree.rows.len) : ({
         row += 1;
         index += 1;
     }) {
-        renderFileTreeRow(surface, file_tree, file_tree.rows[index], row, tree_width, maybe_theme);
+        const tree_row = file_tree.rows[index];
+        renderFileTreeRow(surface, file_tree, tree_row, .{
+            .source_index = index,
+            .depth = tree_row.depth,
+            .marker = if (tree_row.directory()) (if (tree_row.expanded()) "v" else ">") else " ",
+            .label = if (tree_row.editing_text.len > 0) tree_row.editing_text else tree_row.name,
+        }, row, tree_width, maybe_theme);
     }
 }
 
-fn renderFileTreeRow(surface: anytype, file_tree: FileTree, row: FileTreeRow, screen_row: u16, tree_width: u16, maybe_theme: ?Theme) void {
+fn renderFileTreeRow(surface: anytype, file_tree: FileTree, row: FileTreeRow, presentation: zigzag_chrome.TreeRowPresentation, screen_row: u16, tree_width: u16, maybe_theme: ?Theme) void {
     const selected = row.selected() or std.mem.eql(u8, row.id, file_tree.selected_id);
     const focused = row.focused() or (selected and file_tree.focused);
     const active = row.active();
@@ -1236,19 +1263,17 @@ fn renderFileTreeRow(surface: anytype, file_tree: FileTree, row: FileTreeRow, sc
 
     var col: u16 = 0;
     var depth: u8 = 0;
-    while (depth < row.depth and col < tree_width) : (depth += 1) {
+    while (depth < presentation.depth and col < tree_width) : (depth += 1) {
         col = writeText(surface, screen_row, col, tree_width, "  ", fg, bg, attrs);
     }
 
-    const marker = if (row.directory()) (if (row.expanded()) "v" else ">") else " ";
-    col = writeText(surface, screen_row, col, tree_width, marker, fg, bg, attrs);
+    col = writeText(surface, screen_row, col, tree_width, presentation.marker, fg, bg, attrs);
     col = writeText(surface, screen_row, col, tree_width, " ", fg, bg, attrs);
     if (row.icon.len > 0) {
         col = writeText(surface, screen_row, col, tree_width, row.icon, fg, bg, attrs);
         col = writeText(surface, screen_row, col, tree_width, " ", fg, bg, attrs);
     }
-    const label = if (row.editing_text.len > 0) row.editing_text else row.name;
-    col = writeText(surface, screen_row, col, tree_width, label, fg, bg, attrs);
+    col = writeText(surface, screen_row, col, tree_width, presentation.label, fg, bg, attrs);
     const git_marker = fileTreeGitMarker(row.git_status);
     if (git_marker.len > 0) {
         _ = writeText(surface, screen_row, col, tree_width, git_marker, fg, bg, attrs);
@@ -1756,35 +1781,55 @@ fn renderTabBar(surface: anytype, tab_bar: TabBar, has_workspaces: bool, maybe_t
     clearRow(surface, row, width);
     fillRowRemainder(surface, row, 0, width, tabBg(maybe_theme));
 
+    var buffer: [4096]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buffer);
+    const rows = zigzag_chrome.tabRows(fba.allocator(), tab_bar.tabs, tab_bar.active_index) catch {
+        renderTabBarManual(surface, tab_bar, row, width, maybe_theme);
+        return;
+    };
+
+    var col: u16 = 0;
+    for (rows, 0..) |tab_row, rendered_index| {
+        if (col >= width or tab_row.index >= tab_bar.tabs.len) break;
+        col = renderTabBarItem(surface, row, col, width, tab_bar.tabs[tab_row.index], tab_row.active, rendered_index, maybe_theme);
+    }
+}
+
+fn renderTabBarManual(surface: anytype, tab_bar: TabBar, row: u16, width: u16, maybe_theme: ?Theme) void {
     var col: u16 = 0;
     for (tab_bar.tabs, 0..) |tab, index| {
         if (col >= width) break;
-        const active = tab.active() or index == tab_bar.active_index;
-        const tab_fg = if (active) tabActiveFg(maybe_theme) else tabInactiveFg(maybe_theme);
-        const tab_bg = if (active) tabActiveBg(maybe_theme) else tabBg(maybe_theme);
-        const attrs: u8 = if (active) protocol.ATTR_BOLD else 0;
-        if (index > 0) col = writeText(surface, row, col, width, " ", tab_fg, tabBg(maybe_theme), 0);
-
-        if (active) {
-            col = writeText(surface, row, col, width, "▌ ", tabActiveFg(maybe_theme), tabActiveBg(maybe_theme), protocol.ATTR_BOLD);
-        }
-
-        if (tab.icon.len > 0) {
-            const icon_fg: u24 = if (tab.tint != 0) @intCast(tab.tint & 0x00FF_FFFF) else tab_fg;
-            col = writeText(surface, row, col, width, tab.icon, icon_fg, tab_bg, attrs);
-            col = writeText(surface, row, col, width, " ", tab_fg, tab_bg, attrs);
-        }
-
-        col = writeText(surface, row, col, width, tab.label, tab_fg, tab_bg, attrs);
-
-        if (tab.dirty()) {
-            col = writeText(surface, row, col, width, " *", tabDirtyFg(maybe_theme), tab_bg, 0);
-        }
-
-        if (tab.attention()) {
-            col = writeText(surface, row, col, width, " !", tabAttentionFg(maybe_theme), tabBg(maybe_theme), protocol.ATTR_BOLD);
-        }
+        col = renderTabBarItem(surface, row, col, width, tab, tab.active() or index == tab_bar.active_index, index, maybe_theme);
     }
+}
+
+fn renderTabBarItem(surface: anytype, row: u16, start_col: u16, width: u16, tab: Tab, active: bool, index: usize, maybe_theme: ?Theme) u16 {
+    var col = start_col;
+    const tab_fg = if (active) tabActiveFg(maybe_theme) else tabInactiveFg(maybe_theme);
+    const tab_bg = if (active) tabActiveBg(maybe_theme) else tabBg(maybe_theme);
+    const attrs: u8 = if (active) protocol.ATTR_BOLD else 0;
+    if (index > 0) col = writeText(surface, row, col, width, " ", tab_fg, tabBg(maybe_theme), 0);
+
+    if (active) {
+        col = writeText(surface, row, col, width, "▌ ", tabActiveFg(maybe_theme), tabActiveBg(maybe_theme), protocol.ATTR_BOLD);
+    }
+
+    if (tab.icon.len > 0) {
+        const icon_fg: u24 = if (tab.tint != 0) @intCast(tab.tint & 0x00FF_FFFF) else tab_fg;
+        col = writeText(surface, row, col, width, tab.icon, icon_fg, tab_bg, attrs);
+        col = writeText(surface, row, col, width, " ", tab_fg, tab_bg, attrs);
+    }
+
+    col = writeText(surface, row, col, width, tab.label, tab_fg, tab_bg, attrs);
+
+    if (tab.dirty()) {
+        col = writeText(surface, row, col, width, " *", tabDirtyFg(maybe_theme), tab_bg, 0);
+    }
+
+    if (tab.attention()) {
+        col = writeText(surface, row, col, width, " !", tabAttentionFg(maybe_theme), tabBg(maybe_theme), protocol.ATTR_BOLD);
+    }
+    return col;
 }
 
 fn hitTabBar(tab_bar: TabBar, row: u16, col: u16, width: u16, height: u16, has_workspaces: bool) ?HitAction {
@@ -2069,7 +2114,8 @@ fn renderPicker(surface: anytype, picker: Picker, maybe_preview: ?PickerPreview,
     const preview = if (maybe_preview) |preview| if (preview.visible and preview.lines.len > 0 and width >= 100) preview else null else null;
     if (preview) |visible_preview| {
         const content_width = content_end_col - content_col;
-        const left_width: u16 = @min(@max((content_width * 45) / 100, 36), @max(content_width -| 20, 1));
+        const split = zigzag_chrome.horizontalSplit(content_width, rect.end_row -| rect.row, 0.45);
+        const left_width: u16 = @min(@max(split.left_width, 36), @max(content_width -| 20, 1));
         const split_col = @min(content_end_col, content_col + left_width);
         renderPickerList(surface, picker, rect.row, rect.end_row -| 1, content_col, split_col, maybe_theme);
         renderPickerPreviewContent(surface, visible_preview, rect.row, rect.end_row -| 1, split_col, content_end_col, maybe_theme);
@@ -3484,12 +3530,15 @@ fn renderStatusSegments(surface: anytype, row: u16, width: u16, status: StatusBa
     }
     col = renderFooterIndicators(surface, row, width, col, search, changes, notifications, timeline, extension_overlay, extension_panel, observatory, agent_context, tool_manager, board, agent_chat, maybe_theme);
 
-    var right_width: u16 = 0;
-    for (status.right_segments) |segment| {
-        right_width +|= textWidth(segment.text);
-    }
-
-    col = if (right_width >= width) 0 else width - right_width;
+    var buffer: [4096]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buffer);
+    col = zigzag_chrome.statusRightStart(fba.allocator(), status, width) catch blk: {
+        var right_width: u16 = 0;
+        for (status.right_segments) |segment| {
+            right_width +|= textWidth(segment.text);
+        }
+        break :blk if (right_width >= width) 0 else width - right_width;
+    };
     for (status.right_segments) |segment| {
         col = writeText(surface, row, col, width, segment.text, themedSegmentFg(segment, maybe_theme), themedSegmentBg(segment, maybe_theme), segment.attrs);
     }

--- a/zig/src/zigzag_chrome.zig
+++ b/zig/src/zigzag_chrome.zig
@@ -1,0 +1,278 @@
+/// Static chrome ZigZag adapters for the current renderer.
+///
+/// These helpers use ZigZag structural components as presentation adapters over BEAM-owned semantic state. They do not let ZigZag own semantic payloads, commands, terminal output, expansion state, selected IDs, protocol meaning, or durable editor state.
+const std = @import("std");
+const zz = @import("zigzag");
+const semantic = @import("semantic.zig");
+const zigzag_view_data = @import("zigzag_view_data.zig");
+
+pub const TabPresentation = struct {
+    index: usize,
+    active: bool,
+};
+
+pub const SplitDims = struct {
+    left_width: u16,
+    right_width: u16,
+};
+
+pub const TreeRowPresentation = struct {
+    source_index: usize,
+    depth: u8,
+    marker: []const u8,
+    label: []const u8,
+};
+
+/// Derives tab presentation state through ZigZag `TabGroup` while keeping tab IDs and actions BEAM-owned.
+pub fn tabRows(alloc: std.mem.Allocator, tabs: []const semantic.Tab, active_index: u8) ![]TabPresentation {
+    if (tabs.len == 0) return &.{};
+
+    var group = zz.TabGroup.init(alloc);
+    defer group.deinit();
+    group.show_numbers = false;
+    group.activate_on_focus = false;
+
+    var selected: usize = @min(active_index, tabs.len - 1);
+    for (tabs, 0..) |tab, index| {
+        if (tab.active()) selected = index;
+        const id = try std.fmt.allocPrint(alloc, "{d}", .{tab.id});
+        _ = try group.addTab(.{ .id = id, .title = tab.label, .enabled = true, .visible = true });
+    }
+    _ = group.setActive(selected, .set_active);
+
+    const rows = try alloc.alloc(TabPresentation, group.tabs.items.len);
+    for (rows, 0..) |*row, index| {
+        row.* = .{ .index = index, .active = group.active_index != null and group.active_index.? == index };
+    }
+    return rows;
+}
+
+/// Computes split geometry through ZigZag `SplitPane`.
+pub fn horizontalSplit(width: u16, height: u16, ratio: f32) SplitDims {
+    var split = zz.SplitPane.init(.horizontal);
+    split.setSize(width, height);
+    split.setRatio(ratio);
+    const dims = split.dims();
+    return .{ .left_width = dims.a_width, .right_width = dims.b_width };
+}
+
+/// Uses ZigZag `StatusBar` segment groups to derive the right-aligned start column.
+pub fn statusRightStart(alloc: std.mem.Allocator, status: semantic.StatusBar, width: u16) !u16 {
+    var bar = zz.StatusBar.init(alloc);
+    defer bar.deinit();
+    bar.setWidth(width);
+    bar.setSeparator("");
+
+    for (status.left_segments) |segment| try bar.addLeft(.{ .text = segment.text, .style = null });
+    for (status.right_segments) |segment| try bar.addRight(.{ .text = segment.text, .style = null });
+
+    var right_width: u16 = 0;
+    for (bar.right.items) |segment| right_width +|= @intCast(@min(zz.width(segment.text), std.math.maxInt(u16)));
+    return if (right_width >= width) 0 else width - right_width;
+}
+
+/// Builds a ZigZag `Tree` from the BEAM-owned visible file tree and returns preserved row presentation data.
+pub fn fileTreeRows(alloc: std.mem.Allocator, tree: semantic.FileTree) ![]TreeRowPresentation {
+    if (tree.rows.len == 0) return &.{};
+
+    var component = zz.Tree(usize).init(alloc);
+    defer component.deinit();
+
+    var parent_by_depth: [256]usize = undefined;
+    var have_depth: [256]bool = [_]bool{false} ** 256;
+    const out = try alloc.alloc(TreeRowPresentation, tree.rows.len);
+
+    for (tree.rows, 0..) |row, index| {
+        const label = if (row.editing_text.len > 0) row.editing_text else row.name;
+        const node_index = if (row.depth == 0 or !have_depth[row.depth -| 1])
+            try component.addRoot(index, label)
+        else
+            try component.addChild(parent_by_depth[row.depth -| 1], index, label);
+        component.nodes.items[node_index].expanded = row.expanded();
+        parent_by_depth[row.depth] = node_index;
+        have_depth[row.depth] = true;
+
+        var clear_depth = @as(usize, row.depth) + 1;
+        while (clear_depth < have_depth.len) : (clear_depth += 1) have_depth[clear_depth] = false;
+
+        out[index] = .{
+            .source_index = index,
+            .depth = row.depth,
+            .marker = if (row.directory()) (if (component.nodes.items[node_index].expanded) "v" else ">") else " ",
+            .label = label,
+        };
+    }
+    return out;
+}
+
+/// Result of adapting retained static chrome into ZigZag component views.
+pub const StaticChromeFit = struct {
+    tab_group_width: usize,
+    status_bar_width: usize,
+    tree_width: usize,
+    tab_count: usize,
+    left_status_count: usize,
+    right_status_count: usize,
+    tree_row_count: usize,
+
+    /// Returns true when ZigZag can represent the main static chrome payloads as component views.
+    pub fn hasComponentCoverage(self: StaticChromeFit) bool {
+        return self.tab_count > 0 and self.tab_group_width > 0 and self.status_bar_width > 0 and self.tree_width > 0;
+    }
+};
+
+/// Builds ZigZag component views from retained semantic chrome without writing them to the terminal.
+pub fn assessStaticChromeFit(alloc: std.mem.Allocator, state: *const semantic.State, width: u16) !StaticChromeFit {
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const scratch = arena.allocator();
+    const view_data = zigzag_view_data.fromSemanticState(state, width);
+
+    const tab_group_width = if (view_data.tab_bar) |tabs| try tabGroupWidth(scratch, tabs, width) else 0;
+    const status_bar_width = if (view_data.status_bar) |status| try statusBarWidth(scratch, status, width) else 0;
+    const tree_width = if (state.file_tree) |tree| try treeWidth(scratch, tree) else 0;
+
+    return .{
+        .tab_group_width = tab_group_width,
+        .status_bar_width = status_bar_width,
+        .tree_width = tree_width,
+        .tab_count = if (view_data.tab_bar) |tabs| tabs.tabs.len else 0,
+        .left_status_count = if (view_data.status_bar) |status| status.left_segments.len else 0,
+        .right_status_count = if (view_data.status_bar) |status| status.right_segments.len else 0,
+        .tree_row_count = if (state.file_tree) |tree| tree.rows.len else 0,
+    };
+}
+
+fn tabGroupWidth(alloc: std.mem.Allocator, tabs: zigzag_view_data.TabBarInput, width: u16) !usize {
+    var group = zz.TabGroup.init(alloc);
+    defer group.deinit();
+    group.max_width = width;
+
+    for (tabs.tabs) |tab| {
+        const id = try std.fmt.allocPrint(alloc, "{d}", .{tab.id});
+        defer alloc.free(id);
+        _ = try group.addTab(.{ .id = id, .title = tab.label });
+    }
+    if (tabs.tabs.len > 0 and tabs.active_index < tabs.tabs.len) _ = group.setActive(tabs.active_index, .set_active);
+
+    const rendered = try group.view(alloc);
+    defer alloc.free(rendered);
+    return zz.width(rendered);
+}
+
+fn statusBarWidth(alloc: std.mem.Allocator, status: zigzag_view_data.StatusBarInput, width: u16) !usize {
+    var bar = zz.StatusBar.init(alloc);
+    defer bar.deinit();
+    bar.setWidth(width);
+
+    if (status.left_segments.len > 0 or status.right_segments.len > 0) {
+        for (status.left_segments) |segment| try bar.addLeft(.{ .text = segment.text, .style = zigzag_view_data.styleFromSemantic(segment.fg, segment.bg, segment.attrs) });
+        for (status.right_segments) |segment| try bar.addRight(.{ .text = segment.text, .style = zigzag_view_data.styleFromSemantic(segment.fg, segment.bg, segment.attrs) });
+    } else {
+        try bar.setLeft(status.filename, null);
+        try bar.setRight(status.filetype, null);
+    }
+
+    const rendered = try bar.view(alloc);
+    defer alloc.free(rendered);
+    return zz.width(rendered);
+}
+
+fn treeWidth(alloc: std.mem.Allocator, tree: semantic.FileTree) !usize {
+    var component = zz.Tree([]const u8).init(alloc);
+    defer component.deinit();
+
+    const root_label = if (tree.root_path.len > 0) tree.root_path else "Files";
+    const root = try component.addRoot(root_label, root_label);
+    for (tree.rows) |row| {
+        const label = if (row.editing_text.len > 0) row.editing_text else row.name;
+        _ = try component.addChild(root, label, label);
+    }
+
+    const rendered = try component.view(alloc);
+    defer alloc.free(rendered);
+    return zz.width(rendered);
+}
+
+test "TabGroup adapter derives active tab presentation" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const rows = try tabRows(alloc, &[_]semantic.Tab{
+        .{ .id = 1, .label = try alloc.dupe(u8, "one") },
+        .{ .id = 2, .flags = 0x01, .label = try alloc.dupe(u8, "two") },
+    }, 0);
+
+    try std.testing.expectEqual(@as(usize, 2), rows.len);
+    try std.testing.expect(!rows[0].active);
+    try std.testing.expect(rows[1].active);
+}
+
+test "SplitPane adapter derives horizontal split dimensions" {
+    const dims = horizontalSplit(100, 20, 0.45);
+    try std.testing.expectEqual(@as(u16, 44), dims.left_width);
+    try std.testing.expectEqual(@as(u16, 55), dims.right_width);
+}
+
+test "StatusBar adapter derives right segment start" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const right = try alloc.alloc(semantic.StatusSegment, 2);
+    right[0] = .{ .text = try alloc.dupe(u8, "Ln 1") };
+    right[1] = .{ .text = try alloc.dupe(u8, "Col 2") };
+
+    const start = try statusRightStart(alloc, .{ .right_segments = right }, 20);
+    try std.testing.expectEqual(@as(u16, 11), start);
+}
+
+test "Tree adapter preserves BEAM-owned file rows through ZigZag Tree" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const rows = try alloc.alloc(semantic.FileTreeRow, 3);
+    rows[0] = .{ .name = try alloc.dupe(u8, "src"), .depth = 0, .flags = 0x03 };
+    rows[1] = .{ .name = try alloc.dupe(u8, "main.zig"), .depth = 1 };
+    rows[2] = .{ .name = try alloc.dupe(u8, "test"), .depth = 0, .flags = 0x01 };
+
+    const presentation = try fileTreeRows(alloc, .{ .rows = rows });
+    try std.testing.expectEqual(@as(usize, 3), presentation.len);
+    try std.testing.expectEqualStrings("v", presentation[0].marker);
+    try std.testing.expectEqual(@as(u8, 1), presentation[1].depth);
+    try std.testing.expectEqualStrings("main.zig", presentation[1].label);
+    try std.testing.expectEqualStrings(">", presentation[2].marker);
+}
+
+test "ZigZag component views can represent full editor static chrome at 80x24" {
+    const alloc = std.testing.allocator;
+    const fixture = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, "tests/fixtures/full_editor.bin", alloc, .limited(1024 * 1024));
+    defer alloc.free(fixture);
+
+    var state = try zigzag_view_data.decodeFixtureState(alloc, fixture);
+    defer state.deinit();
+
+    const fit = try assessStaticChromeFit(alloc, &state, 80);
+    try std.testing.expect(fit.hasComponentCoverage());
+    try std.testing.expectEqual(state.tab_bar.?.tabs.len, fit.tab_count);
+    try std.testing.expectEqual(state.status_bar.?.left_segments.len, fit.left_status_count);
+    try std.testing.expectEqual(state.status_bar.?.right_segments.len, fit.right_status_count);
+    try std.testing.expectEqual(state.file_tree.?.rows.len, fit.tree_row_count);
+    try std.testing.expect(fit.tab_group_width <= 80);
+    try std.testing.expect(fit.status_bar_width <= 80);
+}
+
+test "ZigZag component views can represent full editor static chrome at wide size" {
+    const alloc = std.testing.allocator;
+    const fixture = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, "tests/fixtures/full_editor.bin", alloc, .limited(1024 * 1024));
+    defer alloc.free(fixture);
+
+    var state = try zigzag_view_data.decodeFixtureState(alloc, fixture);
+    defer state.deinit();
+
+    const narrow = try assessStaticChromeFit(alloc, &state, 80);
+    const wide = try assessStaticChromeFit(alloc, &state, 140);
+    try std.testing.expect(wide.hasComponentCoverage());
+    try std.testing.expect(wide.status_bar_width >= narrow.status_bar_width);
+    try std.testing.expect(wide.tab_group_width >= narrow.tab_group_width);
+    try std.testing.expect(wide.status_bar_width <= 140);
+}

--- a/zig/src/zigzag_view_data.zig
+++ b/zig/src/zigzag_view_data.zig
@@ -166,7 +166,8 @@ fn colorFromU24(rgb: u24) zz.Color {
     );
 }
 
-fn decodeFixtureState(alloc: std.mem.Allocator, bytes: []const u8) !semantic.State {
+/// Decodes a length-prefixed render fixture into retained semantic state for Zig-side adapter and chrome tests.
+pub fn decodeFixtureState(alloc: std.mem.Allocator, bytes: []const u8) !semantic.State {
     var state = semantic.State.init(alloc);
     errdefer state.deinit();
 


### PR DESCRIPTION
# TL;DR
Structural chrome now uses ZigZag components as presentation/layout adapters inside the current `minga-renderer` path. Minga still owns semantic state, cell rendering, terminal output, and all actions.

Closes #2185

## Context
This is the static chrome slice for #2182. The corrected goal is not to avoid ZigZag components. The goal is to use them where they fit without letting them own BEAM semantic state or terminal writes.

## Changes
- Adds `zig/src/zigzag_chrome.zig` as the structural chrome adapter module.
- Uses `TabGroup` to derive tab active-state presentation.
- Uses `Tree` to derive file-tree row presentation from Minga’s retained flat row model.
- Uses `StatusBar` to derive right-aligned status/modeline segment layout.
- Uses `SplitPane` to compute picker preview split geometry.
- Keeps runtime writes on Minga’s existing semantic surface/cell renderer.
- Updates `zig/ZIGZAG_CHROME_NOTES.md` with the corrected component-adapter boundary.

## Verification
- `cd zig && rtk zig build test`
- `rtk mix zig.lint`
- `mix compile --warnings-as-errors`
- `git diff --check`

## Acceptance Criteria Addressed
- ZigZag component fit is evaluated for tab bar, status/modeline, file tree, and split geometry ✅
- Structural components are used as adapters where they preserve BEAM-owned semantics ✅
- No second renderer path is added ✅
- No direct ANSI component output is written into Minga cells ✅
- Evidence is available for #2191’s keep/narrow/remove decision ✅
