### PR TITLE
Record ZigZag editor-body helper boundary

### DIFF
--- a/zig/ZIGZAG_EDITOR_BODY_NOTES.md
+++ b/zig/ZIGZAG_EDITOR_BODY_NOTES.md
@@ -1,0 +1,24 @@
+# ZigZag editor-body notes
+
+Ticket #2186 evaluated the correctness-critical editor body against ZigZag helpers. The outcome is evidence-backed narrowing: keep runtime editor-body rendering on Minga's existing semantic cell path, and use ZigZag helper coverage as evidence for the final #2191 decision.
+
+Why runtime editor-body rendering stays manual in this slice:
+
+- Minga text rows, style spans, cursor placement, selections, search matches, diagnostics, indent guides, gutters, and scroll-left behavior are BEAM-owned semantic payloads.
+- ZigZag `CodeView` owns lightweight syntax highlighting and line-number rendering, which would replace Minga parser/style spans instead of preserving them.
+- ZigZag `TextArea` owns editable text state and cursor movement, which conflicts with BEAM-owned buffers, commands, and durable editor state.
+- ZigZag `Viewport` can consume derived text for local viewport helpers, but it must not own Minga scroll-left, cursor, or style-span semantics.
+- `renderWithRanges` is useful for ASCII byte-range style checks, but Minga spans are terminal-column semantics. Wide Unicode and combining graphemes make direct byte-range mapping unsafe without a dedicated semantic column mapper, so the fit test does not claim styled-range coverage for non-ASCII rows.
+
+What was verified:
+
+- `zig/src/zigzag_editor_fit.zig` adapts the existing full-editor semantic fixture into ZigZag `Viewport`, `CodeView`, and `renderWithRanges` helper views.
+- A Unicode test covers wide and combining text and records that semantic spans cannot be blindly mapped to ZigZag byte ranges.
+- Runtime editor-body rendering is unchanged, so the current renderer remains the visual correctness oracle.
+
+Rejected direct component swaps:
+
+- `CodeView`: useful for lightweight previews, but not for real editor buffers because it owns highlighting and line-number presentation.
+- `TextArea`: not suitable for runtime editor buffers because it owns editing state and cursor behavior.
+- `Viewport`: useful as a helper candidate, but not as the owner of Minga scroll/cursor/render semantics.
+- Direct `renderWithRanges`: useful only after Minga column spans are mapped to byte ranges safely for Unicode.

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -15,6 +15,7 @@ pub const apprt = @import("apprt.zig");
 pub const zigzag_bridge = @import("zigzag_bridge.zig");
 pub const zigzag_view_data = @import("zigzag_view_data.zig");
 pub const zigzag_chrome = @import("zigzag_chrome.zig");
+pub const zigzag_editor_fit = @import("zigzag_editor_fit.zig");
 // Note: highlighter.zig is compiled into minga-parser, not the renderer.
 // Font rendering (CoreText, atlas) lives in the macOS Swift app (macos/).
 
@@ -117,4 +118,5 @@ test {
     _ = zigzag_bridge;
     _ = zigzag_view_data;
     _ = zigzag_chrome;
+    _ = zigzag_editor_fit;
 }

--- a/zig/src/zigzag_editor_fit.zig
+++ b/zig/src/zigzag_editor_fit.zig
@@ -1,0 +1,209 @@
+/// Editor-body ZigZag fit checks for the current renderer.
+///
+/// This module does not render runtime cells. The editor body is the highest correctness-risk TUI surface, so #2186 records where ZigZag helpers fit and where direct component output would change Minga semantics. Runtime text, spans, cursor, gutters, diagnostics, selections, and scroll-left stay on the existing semantic renderer path.
+const std = @import("std");
+const zz = @import("zigzag");
+const semantic = @import("semantic.zig");
+const zigzag_view_data = @import("zigzag_view_data.zig");
+
+pub const PlainCodeRow = struct {
+    text: []const u8,
+};
+
+/// Returns the number of BEAM-owned visible rows that fit through ZigZag `Viewport`.
+pub fn visibleWindowRowCount(alloc: std.mem.Allocator, window: semantic.WindowContent) !usize {
+    if (window.rows.len == 0 or window.text_height == 0) return 0;
+    const source = try joinedRows(alloc, window.rows);
+    var viewport = zz.Viewport.init(alloc, @max(window.text_width, 1), @max(window.text_height, 1));
+    defer viewport.deinit();
+    viewport.setWrap(false);
+    try viewport.setContent(source);
+    const rendered = try viewport.view(alloc);
+    var count: usize = 1;
+    for (rendered) |byte| {
+        if (byte == '\n') count += 1;
+    }
+    return @min(count, window.rows.len);
+}
+
+/// Renders a plain unstyled editor row through ZigZag `CodeView` with line numbers and syntax highlighting disabled.
+pub fn plainCodeRow(alloc: std.mem.Allocator, row: semantic.WindowRow) !PlainCodeRow {
+    const code = zz.components.CodeView{
+        .source = row.text,
+        .language = .plain,
+        .show_line_numbers = false,
+    };
+    const rendered = code.view(alloc);
+    if (std.mem.indexOfScalar(u8, rendered, 0x1B) != null) return error.AnsiOutputUnsupported;
+    return .{ .text = rendered };
+}
+
+/// Evidence from adapting one semantic editor window into ZigZag helpers.
+pub const EditorBodyFit = struct {
+    window_id: u16,
+    row_count: usize,
+    first_row_width: usize,
+    viewport_width: usize,
+    code_view_width: usize,
+    styled_row_width: usize,
+    ascii_span_ranges: bool,
+    styled_ranges_safe: bool,
+
+    /// Returns true when ZigZag helpers can consume the basic text rows without owning editor semantics.
+    pub fn hasTextHelperCoverage(self: EditorBodyFit) bool {
+        return self.row_count > 0 and self.first_row_width > 0 and (self.viewport_width > 0 or self.code_view_width > 0 or self.styled_row_width > 0);
+    }
+};
+
+/// Builds ZigZag helper views from the active retained semantic editor window.
+pub fn assessEditorBodyFit(alloc: std.mem.Allocator, state: *const semantic.State) !?EditorBodyFit {
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const scratch = arena.allocator();
+
+    const view_data = zigzag_view_data.fromSemanticState(state, 120);
+    const window = view_data.editor_window orelse return null;
+    const source = try joinedRows(scratch, window.rows);
+    const first_row = firstNonEmptyRow(window.rows) orelse return null;
+    const ascii_span_ranges = rowHasAsciiSpanRanges(first_row);
+
+    const viewport_width = try viewportViewWidth(scratch, source, window.text_width, window.text_height);
+    const code_view_width = codeViewWidth(scratch, source);
+    const styled_row_width = if (ascii_span_ranges) try styledRowWidth(scratch, first_row) else 0;
+
+    return .{
+        .window_id = window.window_id,
+        .row_count = window.rows.len,
+        .first_row_width = zz.width(first_row.text),
+        .viewport_width = viewport_width,
+        .code_view_width = code_view_width,
+        .styled_row_width = styled_row_width,
+        .ascii_span_ranges = ascii_span_ranges,
+        .styled_ranges_safe = ascii_span_ranges,
+    };
+}
+
+fn firstNonEmptyRow(rows: []const semantic.WindowRow) ?semantic.WindowRow {
+    for (rows) |row| {
+        if (row.text.len > 0) return row;
+    }
+    if (rows.len == 0) return null;
+    return rows[0];
+}
+
+fn joinedRows(alloc: std.mem.Allocator, rows: []const semantic.WindowRow) ![]const u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    for (rows, 0..) |row, index| {
+        if (index > 0) try out.writer.writeByte('\n');
+        try out.writer.writeAll(row.text);
+    }
+    return out.toOwnedSlice();
+}
+
+fn viewportViewWidth(alloc: std.mem.Allocator, source: []const u8, width: u16, height: u16) !usize {
+    var viewport = zz.Viewport.init(alloc, @max(width, 1), @max(height, 1));
+    defer viewport.deinit();
+    viewport.setWrap(false);
+    try viewport.setContent(source);
+    const rendered = try viewport.view(alloc);
+    return zz.width(rendered);
+}
+
+fn codeViewWidth(alloc: std.mem.Allocator, source: []const u8) usize {
+    const code = zz.components.CodeView{
+        .source = source,
+        .language = .plain,
+        .show_line_numbers = false,
+    };
+    const rendered = code.view(alloc);
+    return zz.width(rendered);
+}
+
+fn styledRowWidth(alloc: std.mem.Allocator, row: semantic.WindowRow) !usize {
+    const ranges = try styleRangesForRow(alloc, row);
+    const styled = try zz.renderWithRanges(alloc, row.text, ranges);
+    return zz.width(styled);
+}
+
+fn styleRangesForRow(alloc: std.mem.Allocator, row: semantic.WindowRow) ![]zz.StyleRange {
+    var ranges = try alloc.alloc(zz.StyleRange, row.spans.len);
+    for (row.spans, 0..) |span, index| {
+        ranges[index] = .{
+            .start = @min(span.start_col, row.text.len),
+            .end = @min(span.end_col, row.text.len),
+            .s = zigzag_view_data.styleFromSemantic(span.fg, span.bg, span.attrs),
+        };
+    }
+    return ranges;
+}
+
+fn rowHasAsciiSpanRanges(row: semantic.WindowRow) bool {
+    const codepoint_count = std.unicode.utf8CountCodepoints(row.text) catch return false;
+    return codepoint_count == row.text.len;
+}
+
+test "Viewport adapter derives visible editor row count" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const rows = try alloc.alloc(semantic.WindowRow, 3);
+    rows[0] = .{ .text = try alloc.dupe(u8, "one") };
+    rows[1] = .{ .text = try alloc.dupe(u8, "two") };
+    rows[2] = .{ .text = try alloc.dupe(u8, "three") };
+    const count = try visibleWindowRowCount(alloc, .{ .text_width = 20, .text_height = 2, .rows = rows });
+    try std.testing.expectEqual(@as(usize, 2), count);
+}
+
+test "CodeView adapter renders plain editor row without ANSI" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const row = try plainCodeRow(alloc, .{ .text = try alloc.dupe(u8, "plain text") });
+    try std.testing.expectEqualStrings("plain text", row.text);
+    try std.testing.expect(std.mem.indexOfScalar(u8, row.text, 0x1B) == null);
+}
+
+test "ZigZag editor helpers consume full editor fixture text without runtime ownership" {
+    const alloc = std.testing.allocator;
+    const fixture = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, "tests/fixtures/full_editor.bin", alloc, .limited(1024 * 1024));
+    defer alloc.free(fixture);
+
+    var state = try zigzag_view_data.decodeFixtureState(alloc, fixture);
+    defer state.deinit();
+
+    const fit = (try assessEditorBodyFit(alloc, &state)).?;
+    try std.testing.expect(fit.hasTextHelperCoverage());
+    try std.testing.expectEqual(state.windows[0].window_id, fit.window_id);
+    try std.testing.expectEqual(state.windows[0].rows.len, fit.row_count);
+    try std.testing.expect(fit.ascii_span_ranges);
+    try std.testing.expect(fit.styled_ranges_safe);
+    try std.testing.expect(fit.styled_row_width >= fit.first_row_width);
+}
+
+test "ZigZag unicode measurement covers wide and combining editor text but spans remain semantic" {
+    const alloc = std.testing.allocator;
+    const text = "a界e\u{301}";
+    try std.testing.expectEqual(@as(usize, 4), zz.width(text));
+
+    var rows = try alloc.alloc(semantic.WindowRow, 1);
+    rows[0] = .{
+        .text = try alloc.dupe(u8, text),
+        .spans = try alloc.dupe(semantic.WindowSpan, &.{.{ .start_col = 1, .end_col = 3, .fg = 0xabcdef }}),
+    };
+
+    var state = semantic.State.init(alloc);
+    defer state.deinit();
+    state.windows = try alloc.dupe(semantic.WindowContent, &.{.{
+        .window_id = 42,
+        .text_width = 20,
+        .text_height = 1,
+        .rows = rows,
+    }});
+
+    const fit = (try assessEditorBodyFit(alloc, &state)).?;
+    try std.testing.expect(fit.hasTextHelperCoverage());
+    try std.testing.expectEqual(@as(u16, 42), fit.window_id);
+    try std.testing.expect(!fit.ascii_span_ranges);
+    try std.testing.expect(!fit.styled_ranges_safe);
+    try std.testing.expectEqual(@as(usize, 0), fit.styled_row_width);
+}


### PR DESCRIPTION
# TL;DR
Editor-body ZigZag usage remains evidence-only because the body is the highest correctness-risk surface. This PR exercises `Viewport`, `CodeView`, and `renderWithRanges` as helper fit checks, while runtime editor cells stay on Minga’s semantic renderer.

Closes #2186

## Context
This is the editor-body slice for #2182, stacked on #2194. The corrected stack uses more ZigZag components, but the editor body is where Minga’s semantic contracts are hardest to preserve: Unicode widths, style spans, selections, diagnostics, cursor placement, scroll-left, gutters, and indent guides all remain BEAM-owned.

## Changes
- Adds `zig/src/zigzag_editor_fit.zig` as the editor-body fit module.
- Exercises ZigZag `Viewport`, `CodeView`, and `renderWithRanges` against semantic editor-window data.
- Keeps `renderWithRanges` limited to ASCII-safe rows because Minga spans are terminal-column semantics and ZigZag ranges are byte ranges.
- Adds Unicode coverage for wide and combining graphemes.
- Updates `zig/ZIGZAG_EDITOR_BODY_NOTES.md` with the runtime boundary.
- Leaves runtime editor-body cell rendering unchanged.

## Verification
- `mix protocol.gen`
- `cd zig && rtk zig build test`
- `rtk mix zig.lint`
- `mix compile --warnings-as-errors`
- `git diff --check`

## Acceptance Criteria Addressed
- ZigZag helper fit is evaluated for text rows and style spans ✅
- `Viewport`, `CodeView`, and `renderWithRanges` are covered ✅
- Wide Unicode and combining grapheme behavior are covered ✅
- Runtime editor-body rendering remains on the existing semantic renderer path ✅
- No second renderer path is added ✅
- Evidence is available for #2191’s keep/narrow/remove decision ✅
