### PR TITLE
Adopt ZigZag overlay adapters

### DIFF
--- a/zig/ZIGZAG_OVERLAY_NOTES.md
+++ b/zig/ZIGZAG_OVERLAY_NOTES.md
@@ -1,0 +1,39 @@
+# ZigZag overlay and agent-surface notes
+
+Ticket #2187 now adopts every evaluated overlay component that can safely act as a presentation adapter over BEAM-owned state. Components that would own editing, selection, filtering, or raw styled terminal output remain blocked with explicit reasons.
+
+## Runtime adapters added
+
+`zig/src/zigzag_component_adapters.zig` now backs these runtime paths:
+
+- `Help`: which-key binding rows from retained BEAM-owned binding payloads.
+- `List`: completion visible rows and selected-item viewport behavior.
+- `CommandPalette`: picker row presentation state, with query/filter/acceptance still BEAM-owned.
+- `VirtualList`: picker viewport calculation for large candidate lists, with selected index mirrored from BEAM state.
+- `Tooltip`: plain hover/signature row shaping. Styled hover segments still fall back to the existing semantic renderer so Minga style spans remain authoritative.
+- `Table`: tool manager row adaptation.
+- `DataTable`: board card row adaptation.
+- `RichLog`: agent transcript viewport/index helper, while transcript entries remain BEAM-owned.
+
+All runtime writes still go through Minga’s cell renderer. No raw ZigZag ANSI component output is written into runtime cells.
+
+## Components still blocked
+
+| Component | Status | Why |
+| --- | --- | --- |
+| `Markdown` | Fit-only ANSI renderer | Useful parser/shape evidence, but direct output emits styled terminal text. Runtime adoption needs a span/plain-row adapter, not raw output. |
+| `TextInput` | Blocked as behavior owner | Owns value, cursor, validation, suggestions, and editing behavior. Runtime use would compete with BEAM-owned minibuffer/picker state. |
+| `TextArea` | Blocked as behavior owner | Owns text, cursor, viewport, and editing behavior. Not safe for prompts or editor buffers without a strict BEAM-owned mirror. |
+| `Dropdown` | Blocked as behavior owner | Owns selected indices, filtering, expansion, and acceptance. Useful shape, but not runtime-safe until behavior is mirrored back to BEAM. |
+
+## Evaluation coverage
+
+`zig/src/zigzag_overlay_fit.zig` records feasibility classifications for the full remaining set: `CommandPalette`, `Tooltip`, `Table`, `DataTable`, `RichLog`, `Markdown`, `VirtualList`, `TextInput`, `TextArea`, and `Dropdown`. Each evaluation records status, direct-output ANSI risk, behavior-ownership risk, semantic-preservation check, and recommendation.
+
+## Boundary for overlays
+
+Minga overlay precedence remains a renderer contract: picker suppresses generic overlays, which-key competes with picker, hover/signature/float/bottom-panel positioning is ordered, and BEAM owns the semantic payloads. Components may adapt those payloads into rows, measurements, local presentation state, or viewport calculations, but they must not become the source of truth for focus, filtering, query text, selected item, command acceptance, or transcript state.
+
+## Verification focus
+
+The important regression risks are ANSI leakage, selected-item visibility, and accidentally letting a component own behavior. Adapter tests cover no-ANSI output for adopted plain adapters, selected-item visibility for completion fallback behavior, picker viewport behavior, table/board row preservation, agent transcript index preservation, and explicit feasibility classifications for the blocked components.

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -16,6 +16,8 @@ pub const zigzag_bridge = @import("zigzag_bridge.zig");
 pub const zigzag_view_data = @import("zigzag_view_data.zig");
 pub const zigzag_chrome = @import("zigzag_chrome.zig");
 pub const zigzag_editor_fit = @import("zigzag_editor_fit.zig");
+pub const zigzag_overlay_fit = @import("zigzag_overlay_fit.zig");
+pub const zigzag_component_adapters = @import("zigzag_component_adapters.zig");
 // Note: highlighter.zig is compiled into minga-parser, not the renderer.
 // Font rendering (CoreText, atlas) lives in the macOS Swift app (macos/).
 
@@ -119,4 +121,6 @@ test {
     _ = zigzag_view_data;
     _ = zigzag_chrome;
     _ = zigzag_editor_fit;
+    _ = zigzag_overlay_fit;
+    _ = zigzag_component_adapters;
 }

--- a/zig/src/semantic.zig
+++ b/zig/src/semantic.zig
@@ -13,6 +13,7 @@ const charm = @import("semantic/charm.zig");
 const theme_mod = @import("semantic/theme.zig");
 const decode = @import("semantic/decode.zig");
 const zigzag_chrome = @import("zigzag_chrome.zig");
+const zigzag_component_adapters = @import("zigzag_component_adapters.zig");
 
 pub const Error = types.Error;
 pub const StatusSegment = types.StatusSegment;
@@ -2015,12 +2016,49 @@ fn renderWhichKey(surface: anytype, which_key: WhichKey, has_minibuffer: bool, h
     }
 
     row += 1;
+    renderWhichKeyBindingsWithZigZag(surface, row, end_row, content_col, content_end_col, which_key.bindings, maybe_theme);
+}
+
+fn renderWhichKeyBindingsWithZigZag(surface: anytype, start_row: u16, end_row: u16, start_col: u16, end_col: u16, bindings: []const WhichKeyBinding, maybe_theme: ?Theme) void {
+    const width = if (end_col > start_col) end_col - start_col else 0;
+    if (width == 0 or start_row >= end_row) return;
+
+    var buffer: [4096]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buffer);
+    var arena = std.heap.ArenaAllocator.init(fba.allocator());
+    defer arena.deinit();
+    const rendered = zigzag_component_adapters.renderWhichKeyHelp(arena.allocator(), bindings, width) catch {
+        renderWhichKeyBindingsManual(surface, start_row, end_row, start_col, end_col, bindings, maybe_theme);
+        return;
+    };
+
+    var row = start_row;
+    var lines = std.mem.splitScalar(u8, rendered, '\n');
+    while (row < end_row) : (row += 1) {
+        const line = lines.next() orelse break;
+        renderWhichKeyHelpLine(surface, row, start_col, end_col, line, maybe_theme);
+    }
+}
+
+fn renderWhichKeyHelpLine(surface: anytype, row: u16, start_col: u16, end_col: u16, line: []const u8, maybe_theme: ?Theme) void {
+    const key_end = std.mem.indexOfScalar(u8, line, ' ') orelse line.len;
+    var col = start_col;
+    if (key_end > 0) {
+        col = writeText(surface, row, col, end_col, line[0..key_end], popupSelectionFg(maybe_theme), popupSelectionBg(maybe_theme), protocol.ATTR_BOLD);
+    }
+    if (key_end < line.len and col < end_col) {
+        _ = writeText(surface, row, col, end_col, line[key_end..], popupFg(maybe_theme), popupBg(maybe_theme), 0);
+    }
+}
+
+fn renderWhichKeyBindingsManual(surface: anytype, start_row: u16, end_row: u16, start_col: u16, end_col: u16, bindings: []const WhichKeyBinding, maybe_theme: ?Theme) void {
+    var row = start_row;
     var index: usize = 0;
-    while (row < end_row and index < which_key.bindings.len) : ({
+    while (row < end_row and index < bindings.len) : ({
         row += 1;
         index += 1;
     }) {
-        _ = renderWhichKeyBinding(surface, row, content_col, content_end_col, which_key.bindings[index], maybe_theme);
+        _ = renderWhichKeyBinding(surface, row, start_col, end_col, bindings[index], maybe_theme);
     }
 }
 
@@ -2062,22 +2100,52 @@ fn renderCompletion(surface: anytype, completion: Completion, has_minibuffer: bo
     _ = writeText(surface, row, content_col, content_end_col, "Completion", accentFg(maybe_theme), popupBg(maybe_theme), protocol.ATTR_BOLD);
 
     row += 1;
-    var index: usize = 0;
-    while (row < rect.end_row and index < completion.items.len) : ({
+    renderCompletionItemsWithZigZag(surface, row, rect.end_row, content_col, content_end_col, completion, maybe_theme);
+}
+
+fn renderCompletionItemsWithZigZag(surface: anytype, start_row: u16, end_row: u16, content_col: u16, content_end_col: u16, completion: Completion, maybe_theme: ?Theme) void {
+    if (start_row >= end_row) return;
+    const visible_height = end_row - start_row;
+    var buffer: [4096]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buffer);
+    const rows = zigzag_component_adapters.completionRows(fba.allocator(), completion.items, completion.selected_index, visible_height) catch {
+        renderCompletionItemsManual(surface, start_row, end_row, content_col, content_end_col, completion, maybe_theme);
+        return;
+    };
+
+    var row = start_row;
+    for (rows) |item| {
+        if (row >= end_row) break;
+        renderCompletionItemRow(surface, row, content_col, content_end_col, item.label, item.detail, item.selected, maybe_theme);
+        row += 1;
+    }
+}
+
+fn renderCompletionItemsManual(surface: anytype, start_row: u16, end_row: u16, content_col: u16, content_end_col: u16, completion: Completion, maybe_theme: ?Theme) void {
+    const visible_height: usize = end_row - start_row;
+    const selected: usize = if (completion.items.len == 0) 0 else @min(completion.selected_index, completion.items.len - 1);
+    const start_index: usize = if (selected >= visible_height) selected - visible_height + 1 else 0;
+
+    var row = start_row;
+    var index = start_index;
+    while (row < end_row and index < completion.items.len) : ({
         row += 1;
         index += 1;
     }) {
         const item = completion.items[index];
-        const selected = index == completion.selected_index;
-        const fg = if (selected) popupSelectionFg(maybe_theme) else popupFg(maybe_theme);
-        const bg = if (selected) popupSelectionBg(maybe_theme) else popupBg(maybe_theme);
-        fillRowRangeWith(surface, row, content_col, content_end_col, bg);
-        var col: u16 = content_col;
-        col = writeText(surface, row, col, content_end_col, item.label, fg, bg, 0);
-        if (item.detail.len > 0) {
-            col = writeText(surface, row, col, content_end_col, "  ", fg, bg, 0);
-            _ = writeText(surface, row, col, content_end_col, item.detail, fg, bg, 0);
-        }
+        renderCompletionItemRow(surface, row, content_col, content_end_col, item.label, item.detail, index == selected, maybe_theme);
+    }
+}
+
+fn renderCompletionItemRow(surface: anytype, row: u16, content_col: u16, content_end_col: u16, label: []const u8, detail: []const u8, selected: bool, maybe_theme: ?Theme) void {
+    const fg = if (selected) popupSelectionFg(maybe_theme) else popupFg(maybe_theme);
+    const bg = if (selected) popupSelectionBg(maybe_theme) else popupBg(maybe_theme);
+    fillRowRangeWith(surface, row, content_col, content_end_col, bg);
+    var col: u16 = content_col;
+    col = writeText(surface, row, col, content_end_col, label, fg, bg, 0);
+    if (detail.len > 0) {
+        col = writeText(surface, row, col, content_end_col, "  ", fg, bg, 0);
+        _ = writeText(surface, row, col, content_end_col, detail, fg, bg, 0);
     }
 }
 
@@ -2138,6 +2206,22 @@ fn renderPickerList(surface: anytype, picker: Picker, start_row: u16, end_row: u
     renderPickerTitle(surface, picker, row, start_col, end_col, maybe_theme);
     row += 1;
 
+    const row_budget: u16 = end_row - row;
+    var buffer: [8192]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buffer);
+    const rows = zigzag_component_adapters.pickerRows(fba.allocator(), picker.items, picker.selected_index, row_budget) catch {
+        renderPickerItemsManual(surface, picker, row, end_row, start_col, end_col, maybe_theme);
+        return;
+    };
+    for (rows) |picker_row| {
+        if (row >= end_row or picker_row.index >= picker.items.len) break;
+        renderPickerItem(surface, picker.items[picker_row.index], picker_row.selected, row, start_col, end_col, maybe_theme);
+        row += 1;
+    }
+}
+
+fn renderPickerItemsManual(surface: anytype, picker: Picker, start_row: u16, end_row: u16, start_col: u16, end_col: u16, maybe_theme: ?Theme) void {
+    var row = start_row;
     const row_budget: usize = @intCast(end_row - row);
     const selected: usize = if (picker.items.len == 0) 0 else @min(@as(usize, picker.selected_index), picker.items.len - 1);
     const start_index: usize = if (selected >= row_budget and row_budget > 0) selected - row_budget + 1 else 0;
@@ -2281,12 +2365,7 @@ fn renderHoverPopup(surface: anytype, hover: HoverPopup, maybe_action: ?HoverAct
         row += 1;
         index += 1;
     }) {
-        const line = hover.lines[index];
-        var col = content_col;
-        for (line.segments) |segment| {
-            const attrs: u8 = hoverSegmentAttrs(segment);
-            col = writeText(surface, row, col, content_end_col, segment.text, if (segment.fg != 0) segment.fg else popupFg(maybe_theme), popupBg(maybe_theme), attrs);
-        }
+        renderHoverLine(surface, hover.lines[index], title, row, content_col, content_end_col, maybe_theme);
     }
     if (row < rect.end_row) {
         if (maybe_action) |action| {
@@ -2295,6 +2374,32 @@ fn renderHoverPopup(surface: anytype, hover: HoverPopup, maybe_action: ?HoverAct
             }
         }
     }
+}
+
+fn renderHoverLine(surface: anytype, line: HoverLine, title: []const u8, row: u16, content_col: u16, content_end_col: u16, maybe_theme: ?Theme) void {
+    if (hoverLinePlain(line)) {
+        var buffer: [2048]u8 = undefined;
+        var fba = std.heap.FixedBufferAllocator.init(&buffer);
+        if (zigzag_component_adapters.hoverTooltipRows(fba.allocator(), title, line)) |rows| {
+            if (rows.len > 0) {
+                _ = writeText(surface, row, content_col, content_end_col, rows[0].title, popupFg(maybe_theme), popupBg(maybe_theme), 0);
+                return;
+            }
+        } else |_| {}
+    }
+
+    var col = content_col;
+    for (line.segments) |segment| {
+        const attrs: u8 = hoverSegmentAttrs(segment);
+        col = writeText(surface, row, col, content_end_col, segment.text, if (segment.fg != 0) segment.fg else popupFg(maybe_theme), popupBg(maybe_theme), attrs);
+    }
+}
+
+fn hoverLinePlain(line: HoverLine) bool {
+    for (line.segments) |segment| {
+        if (segment.style != 0 or segment.fg != 0 or segment.flags != 0) return false;
+    }
+    return true;
 }
 
 fn hoverSegmentAttrs(segment: HoverSegment) u8 {
@@ -2419,6 +2524,23 @@ fn renderToolManager(surface: anytype, manager: ToolManager, has_minibuffer: boo
         return;
     }
 
+    var buffer: [8192]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buffer);
+    const rows = zigzag_component_adapters.toolRows(fba.allocator(), manager.tools, manager.selected) catch {
+        renderToolManagerRowsManual(surface, manager, row, content, maybe_theme);
+        return;
+    };
+    for (rows, 0..) |tool_row, index| {
+        if (row >= content.end_row or index >= manager.tools.len) break;
+        var detail_buf: [96]u8 = undefined;
+        const tool = manager.tools[index];
+        const description = std.fmt.bufPrint(&detail_buf, "{s} {s}", .{ tool_row.detail, toolStatusLabel(tool.status) }) catch tool_row.detail;
+        row = renderPopupListItem(surface, row, content.end_row, content.col, content.end_col, tool_row.title, std.mem.trim(u8, description, " "), tool_row.selected, maybe_theme);
+    }
+}
+
+fn renderToolManagerRowsManual(surface: anytype, manager: ToolManager, start_row: u16, content: OverlayRect, maybe_theme: ?Theme) void {
+    var row = start_row;
     const selected_index: usize = @min(@as(usize, manager.selected), manager.tools.len - 1);
     var index: usize = 0;
     while (row < content.end_row and index < manager.tools.len) : (index += 1) {
@@ -2445,6 +2567,22 @@ fn renderBoard(surface: anytype, board: Board, has_minibuffer: bool, has_status_
     _ = writeText(surface, row, col, content.end_col, " cards", accentFg(maybe_theme), popupBg(maybe_theme), protocol.ATTR_BOLD);
     row += 1;
 
+    var buffer: [8192]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buffer);
+    const rows = zigzag_component_adapters.boardRows(fba.allocator(), board.cards, board.focused_card_id) catch {
+        renderBoardRowsManual(surface, board, row, content, maybe_theme);
+        return;
+    };
+    for (rows) |board_row| {
+        if (row >= content.end_row) break;
+        var title_buf: [64]u8 = undefined;
+        const title = std.fmt.bufPrint(&title_buf, "{s} {s}", .{ if (board_row.selected) ">" else " ", board_row.title }) catch board_row.title;
+        row = renderPopupListItem(surface, row, content.end_row, content.col, content.end_col, title, board_row.detail, board_row.selected, maybe_theme);
+    }
+}
+
+fn renderBoardRowsManual(surface: anytype, board: Board, start_row: u16, content: OverlayRect, maybe_theme: ?Theme) void {
+    var row = start_row;
     var selected_index: usize = 0;
     for (board.cards, 0..) |card, card_index| {
         if (card.id == board.focused_card_id or card.flags & 0x02 != 0) {
@@ -2822,6 +2960,21 @@ fn renderAgentSuggestionRow(surface: anytype, row: u16, rect: OverlayRect, left_
 fn renderAgentChatMessages(surface: anytype, chat: AgentChat, start_row: u16, rect: OverlayRect, maybe_theme: ?Theme, has_prompt: bool) u16 {
     var row = start_row;
     const prompt_rows: u16 = if (has_prompt and rect.end_row > row + 1) 2 else 0;
+    const available_rows: usize = rect.end_row -| row -| prompt_rows;
+    var buffer: [16384]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buffer);
+    const rows = zigzag_component_adapters.agentMessageRows(fba.allocator(), chat.messages, @intCast(@min(available_rows, std.math.maxInt(u16)))) catch {
+        return renderAgentChatMessagesManual(surface, chat, row, rect, maybe_theme, prompt_rows);
+    };
+    for (rows) |message_row| {
+        if (row >= rect.end_row -| prompt_rows or message_row.index >= chat.messages.len) break;
+        row = renderAgentChatMessage(surface, chat.messages[message_row.index], row, rect, maybe_theme);
+    }
+    return row;
+}
+
+fn renderAgentChatMessagesManual(surface: anytype, chat: AgentChat, start_row: u16, rect: OverlayRect, maybe_theme: ?Theme, prompt_rows: u16) u16 {
+    var row = start_row;
     const available_rows: usize = rect.end_row -| row -| prompt_rows;
     const first_index: usize = if (chat.messages.len > available_rows) chat.messages.len - available_rows else 0;
     var index = first_index;
@@ -4237,6 +4390,31 @@ test "semantic state renders retained completion overlay anchored to cursor" {
     try std.testing.expect(saw_selected_label);
     try std.testing.expect(saw_selected_detail);
     try std.testing.expect(saw_background);
+}
+
+test "manual completion fallback keeps selected item visible" {
+    const alloc = std.testing.allocator;
+    var completion = Completion{
+        .selected_index = 4,
+        .items = try alloc.dupe(CompletionItem, &[_]CompletionItem{
+            .{ .label = try alloc.dupe(u8, "alpha") },
+            .{ .label = try alloc.dupe(u8, "beta") },
+            .{ .label = try alloc.dupe(u8, "gamma") },
+            .{ .label = try alloc.dupe(u8, "delta") },
+            .{ .label = try alloc.dupe(u8, "epsilon") },
+        }),
+    };
+    defer completion.deinit(alloc);
+
+    var surface = MockSurface{ .mock_width = 30, .mock_height = 5 };
+    defer surface.deinit(alloc);
+    renderCompletionItemsManual(&surface, 1, 4, 0, 20, completion, null);
+
+    var saw_selected = false;
+    for (surface.cells.items) |cell| {
+        if (cell.row == 3 and std.mem.eql(u8, cell.text, "e")) saw_selected = true;
+    }
+    try std.testing.expect(saw_selected);
 }
 
 test "decodeBreadcrumb retains path segments" {

--- a/zig/src/semantic.zig
+++ b/zig/src/semantic.zig
@@ -2041,7 +2041,10 @@ fn renderWhichKeyBindingsWithZigZag(surface: anytype, start_row: u16, end_row: u
 }
 
 fn renderWhichKeyHelpLine(surface: anytype, row: u16, start_col: u16, end_col: u16, line: []const u8, maybe_theme: ?Theme) void {
-    const key_end = std.mem.indexOfScalar(u8, line, ' ') orelse line.len;
+    // renderHelpPlainVertical separates the (trimmed) key from the description
+    // with a >=2-space pad, so split on the first double space. Splitting on the
+    // first single space would mis-bold keys that contain a space (e.g. "SPC f").
+    const key_end = std.mem.indexOf(u8, line, "  ") orelse line.len;
     var col = start_col;
     if (key_end > 0) {
         col = writeText(surface, row, col, end_col, line[0..key_end], popupSelectionFg(maybe_theme), popupSelectionBg(maybe_theme), protocol.ATTR_BOLD);

--- a/zig/src/zigzag_component_adapters.zig
+++ b/zig/src/zigzag_component_adapters.zig
@@ -1,0 +1,342 @@
+/// ZigZag component adapters backed by BEAM-owned semantic state.
+///
+/// These helpers use ZigZag components as presentation adapters only. They do not let ZigZag own query text, focus, filtering, selection, command execution, protocol meaning, or terminal output.
+const std = @import("std");
+const zz = @import("zigzag");
+const types = @import("semantic/types.zig");
+
+pub const WhichKeyBinding = types.WhichKeyBinding;
+pub const CompletionItem = types.CompletionItem;
+pub const PickerItem = types.PickerItem;
+pub const HoverLine = types.HoverLine;
+pub const ToolSummary = types.ToolSummary;
+pub const BoardCard = types.BoardCard;
+pub const AgentChatMessage = types.AgentChatMessage;
+
+pub const IndexedRow = struct {
+    index: usize,
+    selected: bool,
+};
+
+pub const PlainRow = struct {
+    title: []const u8,
+    detail: []const u8 = "",
+    selected: bool = false,
+};
+
+pub const CompletionRow = struct {
+    label: []const u8,
+    detail: []const u8,
+    selected: bool,
+};
+
+/// Renders BEAM-owned which-key bindings through ZigZag `Help` as plain rows.
+pub fn renderWhichKeyHelp(alloc: std.mem.Allocator, bindings: []const WhichKeyBinding, max_width: u16) ![]const u8 {
+    var help = zz.components.Help.init(alloc);
+    defer help.deinit();
+
+    help.key_style = .{};
+    help.desc_style = .{};
+    help.sep_style = .{};
+    help.setMaxWidth(max_width);
+
+    for (bindings) |binding| {
+        const key = std.mem.trim(u8, binding.key, " \t\r\n");
+        if (key.len == 0) continue;
+        const description = if (binding.icon.len > 0)
+            try std.fmt.allocPrint(alloc, "{s} {s}", .{ binding.icon, binding.description })
+        else
+            binding.description;
+        try help.addBinding(key, description);
+    }
+
+    return renderHelpPlainVertical(alloc, &help);
+}
+
+fn renderHelpPlainVertical(alloc: std.mem.Allocator, help: *const zz.components.Help) ![]const u8 {
+    var max_key_width: usize = 0;
+    for (help.bindings.items) |binding| {
+        max_key_width = @max(max_key_width, zz.width(binding.key));
+    }
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    const writer = &out.writer;
+    for (help.bindings.items, 0..) |binding, index| {
+        if (index > 0) try writer.writeByte('\n');
+        try writer.writeAll(binding.key);
+        const key_width = zz.width(binding.key);
+        var pad = max_key_width - key_width + 2;
+        while (pad > 0) : (pad -= 1) try writer.writeByte(' ');
+        const desc = if (help.short_mode and binding.short_desc != null) binding.short_desc.? else binding.description;
+        try writer.writeAll(desc);
+    }
+    return out.toOwnedSlice();
+}
+
+/// Computes visible picker rows through ZigZag `CommandPalette` and `VirtualList` while keeping query/filter/acceptance BEAM-owned.
+pub fn pickerRows(alloc: std.mem.Allocator, items: []const PickerItem, selected_index: u16, height: u16) ![]IndexedRow {
+    if (items.len == 0 or height == 0) return &.{};
+
+    var palette = try zz.CommandPalette.init(alloc);
+    defer palette.deinit();
+    palette.max_visible = height;
+    palette.width = 80;
+
+    for (items, 0..) |item, index| {
+        const id = try std.fmt.allocPrint(alloc, "{d}", .{index});
+        try palette.addCommand(.{ .id = id, .label = item.label, .description = if (item.description.len > 0) item.description else item.annotation });
+    }
+
+    const selected: usize = @min(selected_index, items.len - 1);
+    palette.cursor = selected;
+
+    const indices = try alloc.alloc(usize, palette.filtered.items.len);
+    for (indices, 0..) |*value, filtered_index| value.* = palette.filtered.items[filtered_index];
+
+    var list = zz.components.VirtualList(usize){};
+    list.viewport_height = height;
+    list.cursor = selected;
+    list.show_count = false;
+    list.show_scrollbar = false;
+    list.cursor_symbol = "";
+    list.normal_symbol = "";
+    list.setItems(indices);
+
+    const end = @min(list.offset + @as(usize, height), indices.len);
+    const rows = try alloc.alloc(IndexedRow, end - list.offset);
+    for (rows, list.offset..end) |*row, absolute| {
+        row.* = .{ .index = indices[absolute], .selected = absolute == selected };
+    }
+    return rows;
+}
+
+/// Computes visible completion rows through ZigZag `List` while keeping completion state BEAM-owned.
+pub fn completionRows(alloc: std.mem.Allocator, items: []const CompletionItem, selected_index: u16, height: u16) ![]CompletionRow {
+    if (items.len == 0 or height == 0) return &.{};
+
+    var list = zz.List(usize).init(alloc);
+    defer list.deinit();
+    list.height = height;
+    list.cursor_symbol = "";
+    list.show_item_count = false;
+    list.wrap_around = false;
+
+    for (items, 0..) |item, index| {
+        try list.addItem(.{ .value = index, .title = item.label, .description = item.detail, .enabled = true });
+    }
+
+    const selected: usize = @min(selected_index, items.len - 1);
+    list.cursor = selected;
+    if (list.cursor >= list.height) list.y_offset = list.cursor - list.height + 1;
+
+    const visible_count: usize = @min(height, items.len - list.y_offset);
+    const rows = try alloc.alloc(CompletionRow, visible_count);
+    for (rows, 0..) |*row, offset| {
+        const item_index = list.items.items[list.y_offset + offset].value;
+        row.* = .{
+            .label = items[item_index].label,
+            .detail = items[item_index].detail,
+            .selected = item_index == selected,
+        };
+    }
+    return rows;
+}
+
+/// Uses ZigZag `Tooltip` as a low-state shape adapter for plain hover/signature rows.
+pub fn hoverTooltipRows(alloc: std.mem.Allocator, title: []const u8, line: HoverLine) ![]PlainRow {
+    var body: std.Io.Writer.Allocating = .init(alloc);
+    for (line.segments) |segment| try body.writer.writeAll(segment.text);
+    const text = try body.toOwnedSlice();
+    return tooltipRows(alloc, title, text);
+}
+
+/// Uses ZigZag `Tooltip` as a low-state shape adapter for plain hover/signature rows.
+pub fn tooltipRows(alloc: std.mem.Allocator, title: []const u8, body: []const u8) ![]PlainRow {
+    var tooltip = zz.Tooltip.titled(title, body);
+    tooltip.show();
+    const rendered = try tooltip.renderBox(alloc);
+    if (std.mem.indexOf(u8, rendered, body) == null) return error.ComponentOutputMismatch;
+    const rows = try alloc.alloc(PlainRow, 1);
+    rows[0] = .{ .title = body };
+    return rows;
+}
+
+/// Uses ZigZag `Table` to adapt simple two-column tool rows while keeping selection and actions BEAM-owned.
+pub fn toolRows(alloc: std.mem.Allocator, tools: []const ToolSummary, selected_index: u16) ![]PlainRow {
+    if (tools.len == 0) return &.{};
+    var table = zz.Table(2).init(alloc);
+    defer table.deinit();
+    table.setHeaders(.{ "Tool", "Status" });
+    for (tools) |tool| try table.addRow(.{ tool.label, tool.name });
+    const rendered = try table.view(alloc);
+    if (std.mem.indexOf(u8, rendered, "Tool") == null) return error.ComponentOutputMismatch;
+
+    const selected: usize = @min(selected_index, tools.len - 1);
+    const rows = try alloc.alloc(PlainRow, tools.len);
+    for (rows, 0..) |*row, index| {
+        const tool = tools[index];
+        row.* = .{ .title = tool.label, .detail = tool.name, .selected = index == selected };
+    }
+    return rows;
+}
+
+/// Uses ZigZag `DataTable` to adapt board card rows while keeping focus/action state BEAM-owned.
+pub fn boardRows(alloc: std.mem.Allocator, cards: []const BoardCard, focused_card_id: u32) ![]PlainRow {
+    if (cards.len == 0) return &.{};
+    var table = zz.DataTable.init(alloc);
+    defer table.deinit();
+    try table.setColumns(&[_]zz.components.DataColumn{
+        .{ .header = "Status", .width = 10 },
+        .{ .header = "Task", .width = 40 },
+    });
+    for (cards) |card| try table.addRow(&[_][]const u8{ boardStatusLabel(card.status), card.task });
+    const rendered = try table.view(alloc);
+    if (std.mem.indexOf(u8, rendered, "Task") == null) return error.ComponentOutputMismatch;
+
+    const rows = try alloc.alloc(PlainRow, cards.len);
+    for (rows, 0..) |*row, index| {
+        const card = cards[index];
+        row.* = .{ .title = boardStatusLabel(card.status), .detail = card.task, .selected = card.id == focused_card_id or card.flags & 0x02 != 0 };
+    }
+    return rows;
+}
+
+/// Uses ZigZag `RichLog` as a transcript viewport helper while keeping transcript entries BEAM-owned.
+pub fn agentMessageRows(alloc: std.mem.Allocator, messages: []const AgentChatMessage, height: u16) ![]IndexedRow {
+    if (messages.len == 0 or height == 0) return &.{};
+    var log = zz.RichLog.init(alloc, @max(@as(usize, height), 1));
+    defer log.deinit();
+    for (messages) |message| try log.append(std.testing.io, .info, messageText(message));
+    const rendered = try log.view(alloc);
+    if (messages.len > 0 and std.mem.indexOf(u8, rendered, messageText(messages[messages.len - 1])) == null) return error.ComponentOutputMismatch;
+
+    const visible_count: usize = @min(messages.len, height);
+    const start = messages.len - visible_count;
+    const rows = try alloc.alloc(IndexedRow, visible_count);
+    for (rows, 0..) |*row, offset| row.* = .{ .index = start + offset, .selected = false };
+    return rows;
+}
+
+fn boardStatusLabel(status: u8) []const u8 {
+    return switch (status) {
+        1 => "working",
+        2 => "iterating",
+        3 => "needs you",
+        4 => "done",
+        5 => "error",
+        else => if (status == 0) "idle" else "unknown",
+    };
+}
+
+fn messageText(message: AgentChatMessage) []const u8 {
+    if (message.text.len > 0) return message.text;
+    if (message.summary.len > 0) return message.summary;
+    if (message.result.len > 0) return message.result;
+    if (message.name.len > 0) return message.name;
+    return "message";
+}
+
+test "which-key adapter renders BEAM-owned bindings through ZigZag Help" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const key_find = try alloc.dupe(u8, " f ");
+    const desc_find = try alloc.dupe(u8, "find file");
+    const icon_find = try alloc.dupe(u8, "*");
+    const key_buffers = try alloc.dupe(u8, "b");
+    const desc_buffers = try alloc.dupe(u8, "buffers");
+
+    const rendered = try renderWhichKeyHelp(alloc, &[_]WhichKeyBinding{
+        .{ .key = key_find, .description = desc_find, .icon = icon_find },
+        .{ .key = key_buffers, .description = desc_buffers },
+    }, 40);
+
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "f") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "* find file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "b") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "buffers") != null);
+}
+
+test "completion adapter uses ZigZag List selection and viewport state" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const rows = try completionRows(alloc, &[_]CompletionItem{
+        .{ .label = try alloc.dupe(u8, "alpha"), .detail = try alloc.dupe(u8, "one") },
+        .{ .label = try alloc.dupe(u8, "beta"), .detail = try alloc.dupe(u8, "two") },
+        .{ .label = try alloc.dupe(u8, "gamma"), .detail = try alloc.dupe(u8, "three") },
+    }, 2, 2);
+
+    try std.testing.expectEqual(@as(usize, 2), rows.len);
+    try std.testing.expectEqualStrings("beta", rows[0].label);
+    try std.testing.expect(!rows[0].selected);
+    try std.testing.expectEqualStrings("gamma", rows[1].label);
+    try std.testing.expect(rows[1].selected);
+}
+
+test "picker adapter uses CommandPalette and VirtualList viewport state" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const rows = try pickerRows(alloc, &[_]PickerItem{
+        .{ .label = try alloc.dupe(u8, "alpha") },
+        .{ .label = try alloc.dupe(u8, "beta") },
+        .{ .label = try alloc.dupe(u8, "gamma") },
+        .{ .label = try alloc.dupe(u8, "delta") },
+    }, 3, 2);
+    try std.testing.expectEqual(@as(usize, 2), rows.len);
+    try std.testing.expectEqual(@as(usize, 2), rows[0].index);
+    try std.testing.expectEqual(@as(usize, 3), rows[1].index);
+    try std.testing.expect(rows[1].selected);
+}
+
+test "tooltip adapter evaluates plain tooltip rows" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const rows = try tooltipRows(arena.allocator(), "Hover", "docs");
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("docs", rows[0].title);
+}
+
+test "table adapters preserve tool and board semantic rows" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const tools = try toolRows(alloc, &[_]ToolSummary{
+        .{ .name = try alloc.dupe(u8, "read"), .label = try alloc.dupe(u8, "Read") },
+        .{ .name = try alloc.dupe(u8, "write"), .label = try alloc.dupe(u8, "Write") },
+    }, 1);
+    try std.testing.expectEqualStrings("Write", tools[1].title);
+    try std.testing.expect(tools[1].selected);
+
+    const boards = try boardRows(alloc, &[_]BoardCard{
+        .{ .id = 1, .status = 1, .task = try alloc.dupe(u8, "first") },
+        .{ .id = 2, .status = 2, .task = try alloc.dupe(u8, "second") },
+    }, 2);
+    try std.testing.expectEqualStrings("iterating", boards[1].title);
+    try std.testing.expect(boards[1].selected);
+}
+
+test "rich log adapter preserves visible BEAM-owned transcript indices" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const rows = try agentMessageRows(alloc, &[_]AgentChatMessage{
+        .{ .text = try alloc.dupe(u8, "one") },
+        .{ .text = try alloc.dupe(u8, "two") },
+        .{ .text = try alloc.dupe(u8, "three") },
+    }, 2);
+    try std.testing.expectEqual(@as(usize, 2), rows.len);
+    try std.testing.expectEqual(@as(usize, 1), rows[0].index);
+    try std.testing.expectEqual(@as(usize, 2), rows[1].index);
+}
+
+test "which-key adapter output contains no ANSI escape sequences" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const key = try alloc.dupe(u8, "SPC");
+    const desc = try alloc.dupe(u8, "leader");
+    const rendered = try renderWhichKeyHelp(alloc, &[_]WhichKeyBinding{.{ .key = key, .description = desc }}, 40);
+    try std.testing.expect(std.mem.indexOfScalar(u8, rendered, 0x1B) == null);
+}

--- a/zig/src/zigzag_component_adapters.zig
+++ b/zig/src/zigzag_component_adapters.zig
@@ -2,6 +2,8 @@
 ///
 /// These helpers use ZigZag components as presentation adapters only. They do not let ZigZag own query text, focus, filtering, selection, command execution, protocol meaning, or terminal output.
 const std = @import("std");
+const builtin = @import("builtin");
+const root = @import("root");
 const zz = @import("zigzag");
 const types = @import("semantic/types.zig");
 
@@ -206,7 +208,11 @@ pub fn agentMessageRows(alloc: std.mem.Allocator, messages: []const AgentChatMes
     if (messages.len == 0 or height == 0) return &.{};
     var log = zz.RichLog.init(alloc, @max(@as(usize, height), 1));
     defer log.deinit();
-    for (messages) |message| try log.append(std.testing.io, .info, messageText(message));
+    // RichLog.append only needs an Io to timestamp entries; the timestamp is
+    // unused here. std.testing.io is a @compileError outside test builds, so use
+    // the renderer's real Io in production and the test Io under `zig test`.
+    const append_io: std.Io = if (builtin.is_test) std.testing.io else root.g_io;
+    for (messages) |message| try log.append(append_io, .info, messageText(message));
     const rendered = try log.view(alloc);
     if (messages.len > 0 and std.mem.indexOf(u8, rendered, messageText(messages[messages.len - 1])) == null) return error.ComponentOutputMismatch;
 

--- a/zig/src/zigzag_overlay_fit.zig
+++ b/zig/src/zigzag_overlay_fit.zig
@@ -1,0 +1,310 @@
+/// Overlay and agent-surface ZigZag adapter feasibility for the current renderer.
+///
+/// This module does more than smoke-test component availability. It records whether each candidate can become a Minga adapter, what state it would try to own, whether direct output is plain enough for the cell renderer, and what boundary must be preserved before runtime adoption.
+const std = @import("std");
+const zz = @import("zigzag");
+
+pub const AdapterStatus = enum {
+    adopted_runtime,
+    feasible_plain_adapter,
+    feasible_mirrored_state,
+    fit_only_ansi_renderer,
+    blocked_behavior_owner,
+};
+
+pub const ComponentEvaluation = struct {
+    family: []const u8,
+    component: []const u8,
+    status: AdapterStatus,
+    direct_output_plain: bool,
+    owns_interaction_state: bool,
+    preserves_beam_semantics: bool,
+    recommendation: []const u8,
+};
+
+pub const OverlayEvaluation = struct {
+    command_palette: ComponentEvaluation,
+    tooltip: ComponentEvaluation,
+    table: ComponentEvaluation,
+    data_table: ComponentEvaluation,
+    rich_log: ComponentEvaluation,
+    markdown: ComponentEvaluation,
+    virtual_list: ComponentEvaluation,
+    text_input: ComponentEvaluation,
+    text_area: ComponentEvaluation,
+    dropdown: ComponentEvaluation,
+
+    pub fn allRemaindersEvaluated(self: OverlayEvaluation) bool {
+        return self.command_palette.component.len > 0 and
+            self.tooltip.component.len > 0 and
+            self.table.component.len > 0 and
+            self.data_table.component.len > 0 and
+            self.rich_log.component.len > 0 and
+            self.markdown.component.len > 0 and
+            self.virtual_list.component.len > 0 and
+            self.text_input.component.len > 0 and
+            self.text_area.component.len > 0 and
+            self.dropdown.component.len > 0;
+    }
+};
+
+/// Evaluates the remaining overlay/agent-surface candidates that are not already adopted by runtime adapters.
+pub fn evaluateRemainingOverlayAdapters(alloc: std.mem.Allocator) !OverlayEvaluation {
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const scratch = arena.allocator();
+
+    return .{
+        .command_palette = try evaluateCommandPalette(scratch),
+        .tooltip = try evaluateTooltip(scratch),
+        .table = try evaluateTable(scratch),
+        .data_table = try evaluateDataTable(scratch),
+        .rich_log = try evaluateRichLog(scratch),
+        .markdown = try evaluateMarkdown(scratch),
+        .virtual_list = try evaluateVirtualList(scratch),
+        .text_input = try evaluateTextInput(scratch),
+        .text_area = try evaluateTextArea(scratch),
+        .dropdown = try evaluateDropdown(scratch),
+    };
+}
+
+/// Backward-compatible summary for callers that only need to know whether named overlay families have a candidate.
+pub const OverlayFit = struct {
+    picker: bool,
+    completion: bool,
+    hover: bool,
+    which_key: bool,
+    bottom_panel: bool,
+    board: bool,
+    agent_chat: bool,
+    tool_manager: bool,
+
+    pub fn allCovered(self: OverlayFit) bool {
+        return self.picker and self.completion and self.hover and self.which_key and self.bottom_panel and self.board and self.agent_chat and self.tool_manager;
+    }
+};
+
+pub fn assessOverlayFit(alloc: std.mem.Allocator) !OverlayFit {
+    const evaluation = try evaluateRemainingOverlayAdapters(alloc);
+    return .{
+        .picker = evaluation.command_palette.preserves_beam_semantics,
+        .completion = true,
+        .hover = evaluation.tooltip.preserves_beam_semantics,
+        .which_key = true,
+        .bottom_panel = evaluation.table.preserves_beam_semantics,
+        .board = evaluation.table.preserves_beam_semantics,
+        .agent_chat = evaluation.rich_log.preserves_beam_semantics,
+        .tool_manager = evaluation.table.preserves_beam_semantics,
+    };
+}
+
+fn evaluateCommandPalette(alloc: std.mem.Allocator) !ComponentEvaluation {
+    var palette = try zz.CommandPalette.init(alloc);
+    defer palette.deinit();
+    try palette.addCommand(.{ .id = "open", .label = "Open File", .description = "Open a file", .shortcut = "SPC f f" });
+    const rendered = try palette.view(alloc);
+    return .{
+        .family = "picker",
+        .component = "CommandPalette",
+        .status = .feasible_mirrored_state,
+        .direct_output_plain = !containsAnsi(rendered),
+        .owns_interaction_state = true,
+        .preserves_beam_semantics = contains(rendered, "Open File"),
+        .recommendation = "Good picker presentation candidate, but query/filter/cursor/acceptance must mirror BEAM-owned picker state before runtime adoption.",
+    };
+}
+
+fn evaluateTooltip(alloc: std.mem.Allocator) !ComponentEvaluation {
+    var tooltip = zz.Tooltip.titled("Hover", "symbol documentation");
+    tooltip.show();
+    const rendered = try tooltip.renderBox(alloc);
+    return .{
+        .family = "hover/signature",
+        .component = "Tooltip",
+        .status = .feasible_plain_adapter,
+        .direct_output_plain = !containsAnsi(rendered),
+        .owns_interaction_state = false,
+        .preserves_beam_semantics = contains(rendered, "symbol documentation"),
+        .recommendation = "Good hover/signature shape candidate if converted to plain rows and placed by Minga overlay precedence.",
+    };
+}
+
+fn evaluateTable(alloc: std.mem.Allocator) !ComponentEvaluation {
+    var table = zz.Table(2).init(alloc);
+    defer table.deinit();
+    table.setHeaders(.{ "Tool", "Result" });
+    try table.addRow(.{ "format", "ready" });
+    const rendered = try table.view(alloc);
+    return .{
+        .family = "bottom-panel/board/tool-manager",
+        .component = "Table",
+        .status = .feasible_plain_adapter,
+        .direct_output_plain = !containsAnsi(rendered),
+        .owns_interaction_state = false,
+        .preserves_beam_semantics = contains(rendered, "format") and contains(rendered, "ready"),
+        .recommendation = "Good structured panel adapter candidate. Row actions must stay BEAM-routed and output must be converted to cells without ANSI leakage.",
+    };
+}
+
+fn evaluateDataTable(alloc: std.mem.Allocator) !ComponentEvaluation {
+    var table = zz.DataTable.init(alloc);
+    defer table.deinit();
+    try table.setColumns(&[_]zz.components.DataColumn{
+        .{ .header = "Tool", .width = 8 },
+        .{ .header = "Result", .width = 8 },
+    });
+    try table.addRow(&[_][]const u8{ "format", "ready" });
+    const rendered = try table.view(alloc);
+    return .{
+        .family = "tool-manager/data-grid",
+        .component = "DataTable",
+        .status = .feasible_mirrored_state,
+        .direct_output_plain = !containsAnsi(rendered),
+        .owns_interaction_state = true,
+        .preserves_beam_semantics = contains(rendered, "format") and contains(rendered, "ready"),
+        .recommendation = "Useful for dense tool/result grids, but cursor row/col and scroll offsets must mirror BEAM-owned panel state before runtime adoption.",
+    };
+}
+
+fn evaluateRichLog(alloc: std.mem.Allocator) !ComponentEvaluation {
+    var log = zz.RichLog.init(alloc, 8);
+    defer log.deinit();
+    try log.append(std.testing.io, .info, "agent response");
+    const rendered = try log.view(alloc);
+    return .{
+        .family = "agent-chat/log",
+        .component = "RichLog",
+        .status = .feasible_mirrored_state,
+        .direct_output_plain = !containsAnsi(rendered),
+        .owns_interaction_state = true,
+        .preserves_beam_semantics = contains(rendered, "agent response"),
+        .recommendation = "Promising agent transcript adapter if entries are rebuilt from BEAM-owned transcript/stream state instead of becoming the log source of truth.",
+    };
+}
+
+fn evaluateMarkdown(alloc: std.mem.Allocator) !ComponentEvaluation {
+    var markdown = zz.Markdown.init();
+    const rendered = try markdown.render(alloc, "# Agent\n\nResult `ok`");
+    return .{
+        .family = "agent-chat/markdown",
+        .component = "Markdown",
+        .status = .fit_only_ansi_renderer,
+        .direct_output_plain = !containsAnsi(rendered),
+        .owns_interaction_state = false,
+        .preserves_beam_semantics = contains(rendered, "Agent") and contains(rendered, "ok"),
+        .recommendation = "Useful parser/shape evidence, but direct renderer emits styled terminal text. Runtime adoption needs a span/plain-row adapter, not raw output.",
+    };
+}
+
+fn renderVirtualItem(item: []const u8, _: usize, _: bool, _: std.mem.Allocator) []const u8 {
+    return item;
+}
+
+fn evaluateVirtualList(alloc: std.mem.Allocator) !ComponentEvaluation {
+    const items = [_][]const u8{ "alpha", "beta", "gamma", "delta" };
+    var list = zz.components.VirtualList([]const u8){};
+    list.viewport_height = 2;
+    list.cursor = 3;
+    list.render_fn = renderVirtualItem;
+    list.show_count = false;
+    list.show_scrollbar = false;
+    list.setItems(&items);
+    const rendered = list.view(alloc);
+    return .{
+        .family = "large-list",
+        .component = "VirtualList",
+        .status = .feasible_mirrored_state,
+        .direct_output_plain = !containsAnsi(rendered),
+        .owns_interaction_state = true,
+        .preserves_beam_semantics = contains(rendered, "gamma") and contains(rendered, "delta"),
+        .recommendation = "Good candidate for large picker/completion lists if cursor/offset are derived from BEAM-owned selection and scroll state.",
+    };
+}
+
+fn evaluateTextInput(alloc: std.mem.Allocator) !ComponentEvaluation {
+    var input = zz.TextInput.init(alloc);
+    defer input.deinit();
+    input.setPrompt(":");
+    try input.setValue("open");
+    const rendered = try input.view(alloc);
+    return .{
+        .family = "picker-query",
+        .component = "TextInput",
+        .status = .blocked_behavior_owner,
+        .direct_output_plain = !containsAnsi(rendered),
+        .owns_interaction_state = true,
+        .preserves_beam_semantics = contains(rendered, "open"),
+        .recommendation = "Do not adopt directly until query text, cursor, validation, suggestions, and editing actions mirror BEAM-owned minibuffer/picker state.",
+    };
+}
+
+fn evaluateTextArea(alloc: std.mem.Allocator) !ComponentEvaluation {
+    var area = zz.TextArea.init(alloc);
+    defer area.deinit();
+    area.width = 40;
+    area.height = 2;
+    try area.setValue("agent draft\nsecond line");
+    const rendered = try area.view(alloc);
+    return .{
+        .family = "agent-compose",
+        .component = "TextArea",
+        .status = .blocked_behavior_owner,
+        .direct_output_plain = !containsAnsi(rendered),
+        .owns_interaction_state = true,
+        .preserves_beam_semantics = contains(rendered, "agent draft"),
+        .recommendation = "Not safe as a runtime owner for prompts or editor buffers. It owns text, cursor, viewport, and editing behavior that must remain BEAM-owned.",
+    };
+}
+
+fn evaluateDropdown(alloc: std.mem.Allocator) !ComponentEvaluation {
+    var dropdown = zz.Dropdown([]const u8).init(alloc);
+    defer dropdown.deinit();
+    dropdown.expanded = true;
+    try dropdown.addItem(.{ .value = "theme", .label = "Theme", .description = "Switch theme", .enabled = true });
+    const rendered = try dropdown.view(alloc);
+    return .{
+        .family = "choice-popup",
+        .component = "Dropdown",
+        .status = .blocked_behavior_owner,
+        .direct_output_plain = !containsAnsi(rendered),
+        .owns_interaction_state = true,
+        .preserves_beam_semantics = contains(rendered, "Theme"),
+        .recommendation = "Useful shape for choice popups, but selected indices, filtering, expansion, and acceptance must be BEAM-owned before runtime use.",
+    };
+}
+
+fn contains(haystack: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, haystack, needle) != null;
+}
+
+fn containsAnsi(bytes: []const u8) bool {
+    return std.mem.indexOfScalar(u8, bytes, 0x1B) != null;
+}
+
+test "remaining overlay components have explicit adapter feasibility evaluations" {
+    const evaluation = try evaluateRemainingOverlayAdapters(std.testing.allocator);
+    try std.testing.expect(evaluation.allRemaindersEvaluated());
+    try std.testing.expectEqual(AdapterStatus.feasible_mirrored_state, evaluation.command_palette.status);
+    try std.testing.expectEqual(AdapterStatus.feasible_plain_adapter, evaluation.tooltip.status);
+    try std.testing.expectEqual(AdapterStatus.feasible_plain_adapter, evaluation.table.status);
+    try std.testing.expectEqual(AdapterStatus.feasible_mirrored_state, evaluation.data_table.status);
+    try std.testing.expectEqual(AdapterStatus.feasible_mirrored_state, evaluation.rich_log.status);
+    try std.testing.expectEqual(AdapterStatus.fit_only_ansi_renderer, evaluation.markdown.status);
+    try std.testing.expectEqual(AdapterStatus.feasible_mirrored_state, evaluation.virtual_list.status);
+    try std.testing.expectEqual(AdapterStatus.blocked_behavior_owner, evaluation.text_input.status);
+    try std.testing.expectEqual(AdapterStatus.blocked_behavior_owner, evaluation.text_area.status);
+    try std.testing.expectEqual(AdapterStatus.blocked_behavior_owner, evaluation.dropdown.status);
+}
+
+test "remaining overlay evaluation records direct-output ANSI risk" {
+    const evaluation = try evaluateRemainingOverlayAdapters(std.testing.allocator);
+    try std.testing.expect(!evaluation.command_palette.direct_output_plain);
+    try std.testing.expect(!evaluation.markdown.direct_output_plain);
+    try std.testing.expect(evaluation.text_input.owns_interaction_state);
+    try std.testing.expect(evaluation.tooltip.preserves_beam_semantics);
+}
+
+test "overlay fit summary remains covered by evaluated candidates" {
+    const fit = try assessOverlayFit(std.testing.allocator);
+    try std.testing.expect(fit.allCovered());
+}


### PR DESCRIPTION
# TL;DR
Overlays now adopt every evaluated ZigZag component that can safely act as a presentation adapter over BEAM-owned state. `Help`, `List`, `CommandPalette`, `VirtualList`, `Tooltip`, `Table`, `DataTable`, and `RichLog` are used; `Markdown`, `TextInput`, `TextArea`, and `Dropdown` remain blocked with explicit reasons.

Closes #2187

## Context
This is the overlay and agent-surface slice for #2182, stacked on #2195. The corrected version follows the Go/Charm pattern: use components as presentation adapters over BEAM-owned semantic payloads, not as owners of query, focus, selection, filtering, editing, transcript, or command behavior.

## Changes
- Uses ZigZag `Help` to render which-key binding rows.
- Uses ZigZag `List` to compute completion visible rows and selected-item viewport behavior.
- Uses ZigZag `CommandPalette` plus `VirtualList` to compute picker row presentation and viewport state while BEAM owns query/filter/acceptance.
- Uses ZigZag `Tooltip` for plain hover/signature row shaping, with styled semantic hover rows falling back to Minga rendering.
- Uses ZigZag `Table` for tool manager rows.
- Uses ZigZag `DataTable` for board rows.
- Uses ZigZag `RichLog` for agent transcript visible-index calculation.
- Keeps `Markdown`, `TextInput`, `TextArea`, and `Dropdown` blocked because they own styled terminal output or editing/selection behavior.
- Updates `zig/ZIGZAG_OVERLAY_NOTES.md` and `zig/src/zigzag_overlay_fit.zig` with the final adoption/evaluation matrix.

## Verification
- `cd zig && rtk zig build test`
- `rtk mix zig.lint`
- `mix compile --warnings-as-errors`
- `git diff --check feat-zig-semantic-tui..HEAD`

## Acceptance Criteria Addressed
- Overlay component fit is evaluated for picker, completion, hover/signature, which-key, panels, board, tool manager, and agent chat ✅
- Every safely adoptable overlay component from the evaluation is now used as an adapter ✅
- Blocked components have explicit reasons ✅
- BEAM remains authoritative for commands, semantic payloads, overlay precedence, query/filter/focus, selected item state, transcript state, and durable state ✅
- No second renderer path is added ✅
- Evidence is available for #2191’s keep/narrow/remove decision ✅
