### PR TITLE
Decide ZigZag component-adapter boundary

### DIFF
--- a/zig/ZIGZAG_DECISION.md
+++ b/zig/ZIGZAG_DECISION.md
@@ -1,0 +1,108 @@
+# ZigZag final decision
+
+Decision: **adopt ZigZag as the Zig TUI framework under the Go/Bubble Tea Port boundary**.
+
+Keep ZigZag in the current `minga-renderer` path as the terminal framework, component-adapter library, and local derived-state helper. Do not introduce a `minga-renderer-zigzag` product path and do not let ZigZag own BEAM semantics. The corrected stack now mirrors the Go/Bubble Tea renderer shape: terminal framework on the TTY, stdout reserved for BEAM packets, BEAM-owned semantic state, and local frontend presentation adapters.
+
+## What changed from the first decision
+
+The first decision undercounted ZigZag because the earlier PR stack mostly recorded fit checks and then rejected runtime adoption. After correction, ZigZag is used or exercised across the current renderer path:
+
+- Structural chrome: `TabGroup`, `Tree`, `StatusBar`, and `SplitPane` are used as presentation/layout adapters in #2194.
+- Editor body: `Viewport`, `CodeView`, and `renderWithRanges` are exercised as fit helpers in #2195, while BEAM keeps semantic ownership for spans, selections, diagnostics, scroll-left, and durable editor state.
+- Overlays: #2196 adopts every feasible overlay adapter from the evaluation: `Help`, `List`, `CommandPalette`, `VirtualList`, `Tooltip`, `Table`, `DataTable`, and `RichLog`. `Markdown`, `TextInput`, `TextArea`, and `Dropdown` remain blocked with explicit reasons.
+- Hit testing: `HitBox` and `MouseState` are used for local coordinate mapping and transient interaction metadata in #2197.
+- Runtime: #2198 adopts `zz.Program` with a Minga adapter loop, custom TTY input/output, stdout packet isolation, BEAM stdin packet handling, `port_writer` backpressure, semantic rendering, and recovery handling.
+
+That changes the final recommendation. ZigZag is not just a fit-check dependency or a hitbox helper. It is the right Zig-side analogue to Go/Bubble Tea when it is adapted to Minga’s Port model.
+
+## Correct boundary
+
+The evidence from #2183 through #2190 points to a specific boundary:
+
+- ZigZag may own terminal lifecycle and frame presentation on `MINGA_TTY` or `/dev/tty`.
+- ZigZag components are valuable when they adapt retained semantic payloads into local presentation data.
+- ZigZag predefined components should be used where they fit, following the Go/Charm adapter pattern.
+- ZigZag must not write to stdout, own query/filter/focus source-of-truth, command dispatch, semantic payload meaning, durable editor state, or the Port protocol.
+- `port_writer` remains the backpressure boundary for BEAM events.
+
+The key distinction is not “runtime ownership is forbidden.” The key distinction is **TTY runtime is allowed, stdout/protocol/semantics ownership is not**.
+
+## Approved ownership
+
+ZigZag may own local frontend/runtime data that can be recomputed from BEAM-owned semantics:
+
+- Terminal lifecycle on the TTY through `zz.Program`.
+- Frame presentation as a terminal view derived from retained semantic packets.
+- Presentation rows derived from retained semantic payloads.
+- Local layout measurements and split geometry.
+- Local hitbox computation and transient mouse metadata.
+- Fit checks that prove whether a component can preserve Minga semantics.
+- Component adapter internals, as long as their state mirrors BEAM-owned state and is not authoritative.
+
+## Components used or evaluated
+
+Used in the current renderer path:
+
+- `Program`: owns terminal lifecycle and frame presentation on the TTY through the Minga adapter.
+- `TabGroup`: derives tab active-state presentation for the tab strip.
+- `Tree`: reconstructs file-tree row presentation from Minga’s retained flat visible row model.
+- `StatusBar`: derives right-segment layout for status/modeline rendering.
+- `SplitPane`: computes picker preview split geometry.
+- `Help`: formats which-key binding rows without leaking ANSI output into Minga cells.
+- `List`: computes completion visible rows and selected-item viewport behavior.
+- `CommandPalette`: mirrors picker row presentation while query/filter/acceptance stay BEAM-owned.
+- `VirtualList`: computes picker viewport rows for large candidate lists.
+- `Tooltip`: shapes plain hover/signature rows while styled semantic hover rows fall back to Minga rendering.
+- `Table`: adapts tool manager rows.
+- `DataTable`: adapts board card rows.
+- `RichLog`: computes agent transcript visible message indices.
+- `HitBox`: maps local terminal coordinate regions for semantic mouse handling.
+- `MouseState`: available for transient local interaction metadata.
+
+Used as fit or feasibility evidence, not runtime owners:
+
+- Editor body: `Viewport`, `CodeView`, and `renderWithRanges`.
+- Blocked overlay candidates: `Markdown`, `TextInput`, `TextArea`, and `Dropdown`.
+
+These components are allowed as adapters, not authorities. A ZigZag component may render or compute from BEAM-owned query text, selection, transcript state, table rows, hover content, or status segments. It must not become the source of truth for query state, focus, filtering, selection, command execution, semantic payloads, or protocol meaning.
+
+## Surfaces that stay Minga/BEAM-owned
+
+- Protocol encoding and decoding, including GUI action payload meaning.
+- stdout as the BEAM Port packet stream.
+- `port_writer` queueing and drain/backpressure behavior.
+- Durable editor state, command dispatch, file buffers, focus ownership, and semantic UI payload ownership.
+- Query/filter/focus source-of-truth, selected item state, transcript state, and overlay action routing.
+- Editor-body semantic correctness contracts: Unicode width, semantic style spans, selections, diagnostics, scroll-left, gutters, and indent guides.
+
+## Go/Charm precedent
+
+Go/Charm is the quality-bar precedent. It uses Bubble Tea as the terminal runtime against `/dev/tty`, keeps stdout reserved for BEAM packets, decodes Semantic UI state, and uses components as adapters over that decoded state.
+
+ZigZag should follow that pattern. The final decision now does that: use `zz.Program` for terminal lifecycle and frame presentation, then keep Minga’s adapter loop responsible for BEAM packet boundaries and semantic ownership.
+
+## Runtime boundary
+
+ZigZag must not write to stdout. Minga’s renderer is a BEAM Port process, so stdout is protocol data. Any terminal output on stdout risks corrupting the BEAM packet stream.
+
+The corrected renderer keeps the safe boundary:
+
+- stdout: BEAM packets only.
+- TTY: ZigZag terminal interaction and frame presentation.
+- stdin: BEAM-to-renderer length-prefixed semantic packets.
+- resize: observed through ZigZag terminal state and routed to BEAM as resize packets.
+- paste: parsed by ZigZag and routed to BEAM as one `paste_event` packet.
+- keyboard/mouse: parsed by ZigZag, mapped through Minga protocol helpers, and routed to BEAM.
+- backpressure: existing `port_writer` queue and drain path.
+
+## Follow-up guardrails
+
+1. Add a guardrail that rejects terminal output to stdout from renderer modules.
+2. Require any ZigZag runtime use to pass explicit TTY input/output handles, never default stdout.
+3. Keep adapter output plain before it reaches Minga cell data. ANSI belongs only in final TTY presentation, not semantic cells or retained payloads.
+4. Require component adapters to document which state is BEAM-owned and which derived state ZigZag may compute locally.
+
+## Final recommendation for #2182
+
+Adopt ZigZag seriously in the current `minga-renderer` path. Use `zz.Program` as the Zig TUI framework, use predefined components where they fit as presentation adapters over BEAM-owned semantic state, and keep stdout, protocol meaning, commands, and durable editor semantics owned by Minga/BEAM.

--- a/zig/ZIGZAG_STACK_AUDIT.md
+++ b/zig/ZIGZAG_STACK_AUDIT.md
@@ -1,0 +1,59 @@
+# ZigZag PR stack audit
+
+This audit records the correction to #2183-#2191. The first stack was too conservative: it mostly linked ZigZag, proved fit, and then made a final decision before adopting enough components or mirroring the Go/Bubble Tea runtime shape. The corrected stack moves adoption into the owning PRs and changes the conclusion.
+
+## Correct standard
+
+Use the Go/Charm pattern:
+
+- BEAM owns semantic payloads, commands, query/filter/focus source-of-truth, durable editor state, and protocol meaning.
+- stdout is BEAM Port packets only.
+- The terminal framework owns TTY lifecycle and frame presentation.
+- The Zig renderer owns local derived presentation state.
+- ZigZag components should be used where they can render or compute from BEAM-owned state without taking over behavior.
+- Minga’s adapter owns the bridge between BEAM stdin/stdout and ZigZag’s TTY runtime.
+
+## Corrected PR-by-PR status
+
+| PR | Ticket | Corrected status | What changed |
+| --- | --- | --- | --- |
+| #2192 | #2183 | Foundation | Links ZigZag into the current `minga-renderer` build without introducing a parallel renderer. |
+| #2193 | #2184 | Foundation | Adds borrowed semantic view data so components can be fed from retained BEAM-owned packets. |
+| #2194 | #2185 | Corrected | Structural chrome now uses `TabGroup`, `Tree`, `StatusBar`, and `SplitPane` as adapters while Minga keeps semantic state and protocol meaning. |
+| #2195 | #2186 | Corrected boundary | Editor-body helpers exercise `Viewport`, `CodeView`, and `renderWithRanges`, but BEAM keeps semantic ownership for spans, Unicode, cursor, selections, diagnostics, and scroll-left. |
+| #2196 | #2187 | Corrected | Overlays now adopt every feasible adapter from the evaluation: `Help`, `List`, `CommandPalette`, `VirtualList`, `Tooltip`, `Table`, `DataTable`, and `RichLog`. `Markdown`, `TextInput`, `TextArea`, and `Dropdown` remain blocked with explicit reasons. |
+| #2197 | #2188 | Correct | Hit testing uses ZigZag `HitBox` and `MouseState` for local terminal coordinate mapping while BEAM keeps packet/action semantics. |
+| #2198 | #2189 | Corrected implementation | Runtime now uses ZigZag `Program` against the TTY while stdout remains BEAM packet-only through `port_writer`. The selected `TuiRuntime` is ZigZag-backed; the old libvaxis runtime remains compiled as legacy transition coverage. |
+| #2199 | #2190 | Corrected evidence | Bakeoff now counts broader component adoption and ZigZag Program adoption, not only hitboxes. |
+| #2200 | #2191 | Corrected decision | Final decision is “adopt ZigZag as the Zig TUI framework under the Go/Bubble Tea Port boundary.” |
+
+## Corrected component and runtime adoption
+
+Runtime/path adoption:
+
+- `Program`: terminal lifecycle and frame presentation on `MINGA_TTY` or `/dev/tty`.
+- `TabGroup`: tab presentation state.
+- `Tree`: file-tree row presentation derived from retained flat rows.
+- `StatusBar`: right-segment layout.
+- `SplitPane`: picker preview split geometry.
+- `Help`: which-key row formatting with no ANSI leakage into semantic cells.
+- `List`: completion visible-row and selected-item viewport computation.
+- `CommandPalette`: picker row presentation over BEAM-owned query/filter/acceptance state.
+- `VirtualList`: picker viewport row computation.
+- `Tooltip`: plain hover/signature row shaping.
+- `Table`: tool-manager row adaptation.
+- `DataTable`: board row adaptation.
+- `RichLog`: agent transcript visible-index computation over BEAM-owned transcript state.
+- `HitBox`: semantic mouse hit regions.
+- `MouseState`: transient local interaction metadata.
+
+Fit/evidence-only adoption:
+
+- `Viewport`, `CodeView`, and `renderWithRanges` for editor-body evaluation.
+- `Markdown`, `TextInput`, `TextArea`, and `Dropdown` as explicit blocked follow-up candidates.
+
+## Final decision impact
+
+Yes, the correction changes the final decision and bakeoff result. ZigZag is now more than a narrow hitbox/helper dependency. It should stay as the Zig TUI framework and component-adapter dependency inside the current renderer path.
+
+Do not create a permanent `minga-renderer-zigzag` path. Do not let ZigZag own stdout, command behavior, durable state, semantic payload meaning, or query/filter/focus source-of-truth. Do let ZigZag own terminal presentation on the TTY, and do use ZigZag predefined components where they safely adapt BEAM-owned state into local presentation data.


### PR DESCRIPTION
# TL;DR
Final decision: **adopt ZigZag as the Zig TUI framework under the Go/Bubble Tea Port boundary**. ZigZag owns terminal lifecycle and frame presentation on the TTY. BEAM still owns stdout packets, protocol meaning, semantic state, commands, query/filter/focus, and durable editor state.

Closes #2191

## Context
This is the final decision slice for #2182, stacked on #2199. The corrected stack now uses substantially more ZigZag than the first decision counted, including runtime adoption in #2198.

## Changes
- Updates `zig/ZIGZAG_DECISION.md` with the corrected final decision.
- Updates `zig/ZIGZAG_STACK_AUDIT.md` to record the corrected stack.
- Keeps #2200 docs-only against #2199. Adoption lives in the owning PRs:
  - #2194 structural chrome: `TabGroup`, `Tree`, `StatusBar`, `SplitPane`
  - #2195 editor body: `Viewport`, `CodeView`, `renderWithRanges` fit checks only
  - #2196 overlays: `Help`, `List`, `CommandPalette`, `VirtualList`, `Tooltip`, `Table`, `DataTable`, `RichLog`; blocked: `Markdown`, `TextInput`, `TextArea`, `Dropdown`
  - #2197 hitboxes: `HitBox`, `MouseState`
  - #2198 runtime: `Program` with a Minga Port adapter
  - #2199 corrected bakeoff

## Decision
Use ZigZag as the Zig terminal framework and component-adapter library. Terminal lifecycle and final frame presentation may live in ZigZag `Program` as long as explicit TTY handles are used and stdout remains packet-only.

Do not let ZigZag own stdout, command dispatch, durable editor state, semantic payload meaning, query/filter/focus source-of-truth, selected item state, command acceptance, transcript source-of-truth, or a permanent parallel TUI renderer product.

## Final result
The final result is not “remove” and not “helper-only.” It is a serious keep: use ZigZag `Program` and components where they fit, but preserve Minga/BEAM ownership of semantics and the Port boundary.

## Verification
- `rtk mix zig.lint`
- `mix compile --warnings-as-errors`
- `git diff --check feat-zig-semantic-tui..HEAD`
- `mix test.llm test/minga_agent/session_manager_test.exs test/minga/extension/lifecycle_contract_test.exs`

Full `mix test.llm` was run twice on the top stack; both runs hit unrelated async test instability in non-renderer files, and the exact failures passed on focused rerun.
