### PR TITLE
fix(go): route chrome mouse interactions

### DIFF
--- a/bin/minga
+++ b/bin/minga
@@ -33,4 +33,48 @@ MINGA_ERL_FLAGS="+A 4 +sbwt none +sbwtdcpu none +sbwtdio none +swt very_low +swt
 
 export ERL_FLAGS="${MINGA_ERL_FLAGS} ${ERL_FLAGS:-}"
 
-exec mix minga "$@"
+should_redirect_stdio() {
+  if [ "${MINGA_DISABLE_LAUNCH_STDIO_REDIRECT:-}" = "1" ]; then
+    return 1
+  fi
+
+  local args=("$@")
+  local first=""
+  local i=0
+  while [ "$i" -lt "${#args[@]}" ]; do
+    local arg="${args[$i]}"
+    case "$arg" in
+      +gui|--headless|--minimal|--safe|-Q|--editor|--help|-h|--version|-v)
+        return 1
+        ;;
+      --config|--debug-log|-D|--name|--sname|--cookie-file|--host|--port)
+        i=$((i + 2))
+        continue
+        ;;
+      --no-context)
+        i=$((i + 1))
+        continue
+        ;;
+      *)
+        first="$arg"
+        break
+        ;;
+    esac
+  done
+
+  case "$first" in
+    sessions|detach|kill-session|login)
+      return 1
+      ;;
+  esac
+
+  return 0
+}
+
+if should_redirect_stdio "$@"; then
+  LOG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/minga"
+  mkdir -p "$LOG_DIR"
+  exec mix minga "$@" >> "$LOG_DIR/minga.log" 2>&1
+else
+  exec mix minga "$@"
+fi

--- a/go/tui/internal/protocol/commands.go
+++ b/go/tui/internal/protocol/commands.go
@@ -97,6 +97,7 @@ type WindowContent struct {
 	CursorRow      uint16
 	CursorCol      uint16
 	CursorShape    byte
+	CursorVisible  bool
 	ScrollLeft     uint16
 	ScrollLeftSet  bool
 	ContentEpoch   uint32
@@ -313,11 +314,12 @@ func decodeOverlayDelta(payload []byte) (Command, error) {
 	}
 
 	window := WindowContent{
-		ID:           u16(payload, 1),
-		ContentEpoch: u32(payload, 3),
-		CursorRow:    u16(payload, 8),
-		CursorCol:    u16(payload, 10),
-		CursorShape:  payload[12],
+		ID:            u16(payload, 1),
+		ContentEpoch:  u32(payload, 3),
+		CursorRow:     u16(payload, 8),
+		CursorCol:     u16(payload, 10),
+		CursorShape:   payload[12],
+		CursorVisible: payload[7]&0x01 != 0,
 	}
 
 	size := base
@@ -342,6 +344,7 @@ func decodeWindowHeader(opcode byte, section []byte, window *WindowContent) {
 		window.CursorRow = hdr.CursorRow
 		window.CursorCol = hdr.CursorCol
 		window.CursorShape = hdr.CursorShape
+		window.CursorVisible = hdr.Flags&0x02 != 0
 		window.ScrollLeft = hdr.ScrollLeft
 		window.ScrollLeftSet = true
 		window.ContentEpoch = hdr.ContentEpoch
@@ -354,6 +357,7 @@ func decodeWindowHeader(opcode byte, section []byte, window *WindowContent) {
 	}
 	window.ID = u16(section, 0)
 	window.ContentEpoch = u32(section, 2)
+	window.CursorVisible = section[6]&0x01 != 0
 	window.CursorRow = u16(section, 7)
 	window.CursorCol = u16(section, 9)
 	window.CursorShape = section[11]

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -55,6 +55,9 @@ func TestDecodeWindowContentRows(t *testing.T) {
 	if command.Window.ID != 7 || command.Window.CursorRow != 3 || command.Window.CursorCol != 4 {
 		t.Fatalf("header decoded incorrectly: %+v", command.Window)
 	}
+	if !command.Window.CursorVisible {
+		t.Fatalf("full window header should decode cursor_visible from flags: %+v", command.Window)
+	}
 	if len(command.Window.Rows) != 1 || command.Window.Rows[0].Text != "hi" {
 		t.Fatalf("rows decoded incorrectly: %+v", command.Window.Rows)
 	}
@@ -71,18 +74,19 @@ func TestDecodeWindowRowsAndViewportDeltasIncludeRowRefs(t *testing.T) {
 	}
 	rowsPayload := append([]byte{0, 1}, ref...)
 	tests := []struct {
-		name       string
-		opcode     byte
-		header     []byte
-		wantID     uint16
-		wantEpoch  uint32
-		wantRow    uint16
-		wantCol    uint16
-		wantShape  byte
-		wantScroll uint16
+		name              string
+		opcode            byte
+		header            []byte
+		wantID            uint16
+		wantEpoch         uint32
+		wantRow           uint16
+		wantCol           uint16
+		wantShape         byte
+		wantScroll        uint16
+		wantCursorVisible bool
 	}{
-		{name: "rows", opcode: generated.OPGuiWindowRowsDelta, header: []byte{0, 7, 0x12, 0x34, 0x56, 0x78, 0xAA, 0, 9, 0, 11, 2, 0, 13}, wantID: 7, wantEpoch: 0x12345678, wantRow: 9, wantCol: 11, wantShape: 2, wantScroll: 13},
-		{name: "viewport", opcode: generated.OPGuiWindowViewportDelta, header: []byte{0, 8, 0x22, 0x33, 0x44, 0x55, 0xBB, 0, 10, 0, 12, 3, 0, 14}, wantID: 8, wantEpoch: 0x22334455, wantRow: 10, wantCol: 12, wantShape: 3, wantScroll: 14},
+		{name: "rows", opcode: generated.OPGuiWindowRowsDelta, header: []byte{0, 7, 0x12, 0x34, 0x56, 0x78, 0xAA, 0, 9, 0, 11, 2, 0, 13}, wantID: 7, wantEpoch: 0x12345678, wantRow: 9, wantCol: 11, wantShape: 2, wantScroll: 13, wantCursorVisible: false},
+		{name: "viewport", opcode: generated.OPGuiWindowViewportDelta, header: []byte{0, 8, 0x22, 0x33, 0x44, 0x55, 0xBB, 0, 10, 0, 12, 3, 0, 14}, wantID: 8, wantEpoch: 0x22334455, wantRow: 10, wantCol: 12, wantShape: 3, wantScroll: 14, wantCursorVisible: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,6 +108,9 @@ func TestDecodeWindowRowsAndViewportDeltasIncludeRowRefs(t *testing.T) {
 			}
 			if window.ID != tt.wantID || window.ContentEpoch != tt.wantEpoch || window.CursorRow != tt.wantRow || window.CursorCol != tt.wantCol || window.CursorShape != tt.wantShape || window.ScrollLeft != tt.wantScroll {
 				t.Fatalf("header decoded incorrectly: %+v", window)
+			}
+			if window.CursorVisible != tt.wantCursorVisible {
+				t.Fatalf("cursor_visible decoded incorrectly: got %v want %v in %+v", window.CursorVisible, tt.wantCursorVisible, window)
 			}
 			if len(window.Rows) != 1 || !window.Rows[0].Ref {
 				t.Fatalf("row ref decoded incorrectly: %+v", window.Rows)

--- a/go/tui/internal/protocol/events.go
+++ b/go/tui/internal/protocol/events.go
@@ -72,6 +72,10 @@ func EncodeGUIFileTreeClick(index uint16) []byte {
 	return []byte{generated.OPGuiAction, generated.GUIActionFileTreeClick, byte(index >> 8), byte(index)}
 }
 
+func EncodeGUISelectTab(id uint32) []byte {
+	return []byte{generated.OPGuiAction, generated.GUIActionSelectTab, byte(id >> 24), byte(id >> 16), byte(id >> 8), byte(id)}
+}
+
 func EncodeGUIExecuteCommand(command string) []byte {
 	payload := []byte(command)
 	if len(payload) > 65535 {

--- a/go/tui/internal/ui/components.go
+++ b/go/tui/internal/ui/components.go
@@ -35,11 +35,11 @@ func (m Model) charmList(title string, items []componentItem, selected int, heig
 	delegate.ShowDescription = descriptions
 	delegate.SetSpacing(0)
 	delegate.Styles.NormalTitle = lipgloss.NewStyle().Foreground(theme.PopupText()).Background(theme.PopupSurface())
-	delegate.Styles.NormalDesc = lipgloss.NewStyle().Foreground(theme.Muted()).Background(theme.PopupSurface())
-	delegate.Styles.SelectedTitle = lipgloss.NewStyle().Bold(true).Foreground(theme.SelectionText()).Background(theme.Selection()).Padding(0, 1)
-	delegate.Styles.SelectedDesc = lipgloss.NewStyle().Foreground(theme.SelectionText()).Background(theme.Selection()).Padding(0, 1)
-	delegate.Styles.DimmedTitle = lipgloss.NewStyle().Foreground(theme.Muted())
-	delegate.Styles.DimmedDesc = lipgloss.NewStyle().Foreground(theme.Muted())
+	delegate.Styles.NormalDesc = lipgloss.NewStyle().Foreground(theme.PopupMutedText()).Background(theme.PopupSurface())
+	delegate.Styles.SelectedTitle = lipgloss.NewStyle().Bold(true).Foreground(theme.PopupSelectionText()).Background(theme.PopupSelection()).Padding(0, 1)
+	delegate.Styles.SelectedDesc = lipgloss.NewStyle().Foreground(theme.PopupSelectionText()).Background(theme.PopupSelection()).Padding(0, 1)
+	delegate.Styles.DimmedTitle = lipgloss.NewStyle().Foreground(theme.PopupMutedText())
+	delegate.Styles.DimmedDesc = lipgloss.NewStyle().Foreground(theme.PopupMutedText())
 	delegate.Styles.FilterMatch = lipgloss.NewStyle().Foreground(theme.Accent()).Underline(true)
 
 	listItems := make([]list.Item, 0, len(items))
@@ -50,8 +50,8 @@ func (m Model) charmList(title string, items []componentItem, selected int, heig
 	component.Title = title
 	component.Styles.Title = lipgloss.NewStyle().Bold(true).Foreground(theme.Accent()).Background(theme.PopupSurface())
 	component.Styles.TitleBar = lipgloss.NewStyle().Background(theme.PopupSurface()).Width(m.width)
-	component.Styles.StatusBar = lipgloss.NewStyle().Foreground(theme.Muted()).Background(theme.PopupSurface())
-	component.Styles.NoItems = lipgloss.NewStyle().Foreground(theme.Muted()).Background(theme.PopupSurface())
+	component.Styles.StatusBar = lipgloss.NewStyle().Foreground(theme.PopupMutedText()).Background(theme.PopupSurface())
+	component.Styles.NoItems = lipgloss.NewStyle().Foreground(theme.PopupMutedText()).Background(theme.PopupSurface())
 	component.SetShowStatusBar(false)
 	component.SetShowPagination(len(items) > height)
 	component.SetShowHelp(false)
@@ -68,7 +68,7 @@ func (m Model) charmTable(columns []table.Column, rows []table.Row, selected int
 	styles := table.DefaultStyles()
 	styles.Header = lipgloss.NewStyle().Bold(true).Foreground(theme.Accent()).Background(theme.PopupSurface()).Padding(0, 1)
 	styles.Cell = lipgloss.NewStyle().Foreground(theme.PopupText()).Background(theme.PopupSurface()).Padding(0, 1)
-	styles.Selected = lipgloss.NewStyle().Bold(true).Foreground(theme.SelectionText()).Background(theme.Selection())
+	styles.Selected = lipgloss.NewStyle().Bold(true).Foreground(theme.PopupSelectionText()).Background(theme.PopupSelection())
 	component := table.New(
 		table.WithColumns(columns),
 		table.WithRows(rows),

--- a/go/tui/internal/ui/input.go
+++ b/go/tui/internal/ui/input.go
@@ -44,7 +44,7 @@ func keyPacket(msg tea.KeyPressMsg) ([]byte, bool) {
 	if key.Text != "" {
 		runes := []rune(key.Text)
 		if len(runes) == 1 {
-			return protocol.EncodeKeyPress(runes[0], keyModifiers(key)), true
+			return protocol.EncodeKeyPress(runes[0], printableTextModifiers(key)), true
 		}
 		return protocol.EncodePaste(key.Text), true
 	}
@@ -111,6 +111,14 @@ func sgrMouseParts(code int, release bool) (byte, byte, byte) {
 		eventType = 2
 	}
 	return button, mods, eventType
+}
+
+func printableTextModifiers(key tea.Key) byte {
+	mods := keyModifiers(key)
+	if key.Mod.Contains(tea.ModShift) && !key.Mod.Contains(tea.ModCtrl) && !key.Mod.Contains(tea.ModAlt) {
+		mods &^= protocol.ModShift
+	}
+	return mods
 }
 
 func keyModifiers(key tea.Key) byte {

--- a/go/tui/internal/ui/input_test.go
+++ b/go/tui/internal/ui/input_test.go
@@ -29,12 +29,17 @@ func TestKeyPacketEncodesSpace(t *testing.T) {
 }
 
 func TestKeyPacketEncodesPrintableUppercaseWithoutShiftModifier(t *testing.T) {
-	packet, ok := keyPacket(tea.KeyPressMsg(tea.Key{Code: 'T', Text: "T"}))
-	if !ok {
-		t.Fatal("uppercase printable should encode a key packet")
-	}
-	if packet[0] != generated.OPKeyPress || codepoint(packet) != 'T' || packet[5] != 0 {
-		t.Fatalf("uppercase printable packet = %#v", packet)
+	for _, key := range []tea.Key{
+		{Code: 'T', Text: "T"},
+		{Code: 'T', Text: "T", Mod: tea.ModShift},
+	} {
+		packet, ok := keyPacket(tea.KeyPressMsg(key))
+		if !ok {
+			t.Fatal("uppercase printable should encode a key packet")
+		}
+		if packet[0] != generated.OPKeyPress || codepoint(packet) != 'T' || packet[5] != 0 {
+			t.Fatalf("uppercase printable packet = %#v", packet)
+		}
 	}
 }
 

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -43,6 +43,7 @@ type Model struct {
 	cursorlineChrome      protocol.CursorlineChrome
 	pendingClipboard      string
 	lastError             string
+	bottomPanelScrollback int
 	agentAnimationFrame   uint64
 	agentAnimationRunning bool
 }
@@ -108,7 +109,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.PasteMsg:
 		m.send(pastePacket(msg))
 	case tea.MouseMsg:
-		if packet, ok := m.semanticMousePacket(msg); ok {
+		if updated, ok := m.localMouse(msg); ok {
+			m = updated
+		} else if packet, ok := m.semanticMousePacket(msg); ok {
 			m.send(packet)
 		} else {
 			m.send(mousePacket(msg))
@@ -216,6 +219,8 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 				m.indentGuides[command.Chrome.IndentGuides.WindowID] = command.Chrome.IndentGuides
 			case generated.OPGuiFileTreeSelection:
 				m.applyFileTreeSelection(command.Chrome.FileTreeSelection)
+			case generated.OPGuiBottomPanel:
+				m.clampBottomPanelScrollback(command.Chrome.Bottom)
 			}
 		}
 	}
@@ -233,9 +238,7 @@ func (m *Model) putWindow(window protocol.WindowContent) {
 		sort.Slice(m.windowOrder, func(i, j int) bool { return m.windowOrder[i] < m.windowOrder[j] })
 	}
 	m.windows[window.ID] = window
-	m.cursorRow = window.CursorRow
-	m.cursorCol = window.CursorCol
-	m.cursorShape = window.CursorShape
+	m.refreshCursorFromWindows()
 }
 
 func (m *Model) applyWindowDelta(delta protocol.WindowContent) {
@@ -246,6 +249,7 @@ func (m *Model) applyWindowDelta(delta protocol.WindowContent) {
 	window.CursorRow = delta.CursorRow
 	window.CursorCol = delta.CursorCol
 	window.CursorShape = delta.CursorShape
+	window.CursorVisible = delta.CursorVisible
 	window.ContentEpoch = delta.ContentEpoch
 	if delta.ScrollLeftSet {
 		window.ScrollLeft = delta.ScrollLeft
@@ -284,9 +288,19 @@ func (m *Model) applyWindowDelta(delta protocol.WindowContent) {
 		window.Rows = rows
 	}
 	m.windows[delta.ID] = window
-	m.cursorRow = delta.CursorRow
-	m.cursorCol = delta.CursorCol
-	m.cursorShape = delta.CursorShape
+	m.refreshCursorFromWindows()
+}
+
+func (m *Model) refreshCursorFromWindows() {
+	for _, id := range m.windowOrder {
+		window := m.windows[id]
+		if !window.CursorVisible {
+			continue
+		}
+		m.cursorRow = window.CursorRow
+		m.cursorCol = window.CursorCol
+		m.cursorShape = window.CursorShape
+	}
 }
 
 func resolveWindowRows(previous []protocol.WindowRow, delta []protocol.WindowRow) ([]protocol.WindowRow, error) {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -105,8 +106,40 @@ func TestWhichKeyRendersCompactFloatingPopup(t *testing.T) {
 	}
 
 	view := ansi.Strip(model.View().Content)
-	if !strings.Contains(view, "Keys SPC  1/2") || !strings.Contains(view, "/   Search project") || !strings.Contains(view, "1  󰓩 Tab 1") {
-		t.Fatalf("which-key popup should render compact icon/key/description rows: %q", view)
+	if !strings.Contains(view, "Keys SPC") || !strings.Contains(view, "1/2") || !strings.Contains(view, "/    Search project") || !strings.Contains(view, "1   󰓩 Tab 1") {
+		t.Fatalf("which-key popup should render structured key/description rows: %q", view)
+	}
+	if !strings.Contains(view, "3 bindings") || !strings.Contains(view, "Esc") {
+		t.Fatalf("which-key popup should include a compact footer: %q", view)
+	}
+}
+
+func TestWhichKeyStylesGroupsAndLimitsColumnCount(t *testing.T) {
+	model := New(160, 24, nil)
+	bindings := []protocol.WhichKeyBinding{
+		{Key: "f", Description: "+file"},
+		{Key: "g", Description: "+git"},
+		{Key: "b", Description: "+buffer"},
+		{Key: "s", Description: "Search project"},
+		{Key: "1", Description: "Tab 1"},
+		{Key: "2", Description: "Tab 2"},
+		{Key: "3", Description: "Tab 3"},
+		{Key: "4", Description: "Tab 4"},
+		{Key: "5", Description: "Tab 5"},
+	}
+	popup := ansi.Strip(model.renderFloatingWhichKey(protocol.WhichKey{Visible: true, Prefix: "SPC", Bindings: bindings}))
+	if !strings.Contains(popup, "› +file ›") || !strings.Contains(popup, "› +git ›") {
+		t.Fatalf("group entries should read as navigable groups: %q", popup)
+	}
+	firstBindingRow := ""
+	for _, line := range strings.Split(popup, "\n") {
+		if strings.Contains(line, "+file") {
+			firstBindingRow = line
+			break
+		}
+	}
+	if count := strings.Count(firstBindingRow, "│"); count > 4 {
+		t.Fatalf("which-key should use at most three columns, got row %q", firstBindingRow)
 	}
 }
 
@@ -132,7 +165,7 @@ func TestHeaderRendersBreadcrumbWithTabs(t *testing.T) {
 	model := New(120, 24, nil)
 	model.chrome = map[byte]protocol.ChromePayload{
 		generated.OPGuiTabBar: {
-			Tabs: protocol.TabBar{Tabs: []protocol.Tab{{Icon: "󰈙", Label: "main.ex", Active: true}}},
+			Tabs: protocol.TabBar{Tabs: []protocol.Tab{{ID: 1, Icon: "󰈙", Label: "main.ex", Active: true}}},
 		},
 		generated.OPGuiBreadcrumb: {
 			Breadcrumb: protocol.Breadcrumb{Segments: []string{"lib", "minga", "main.ex"}},
@@ -142,6 +175,20 @@ func TestHeaderRendersBreadcrumbWithTabs(t *testing.T) {
 	header := ansi.Strip(strings.Join(model.headerLines(), "\n"))
 	if !strings.Contains(header, "▌ 󰈙 main.ex") || !strings.Contains(header, "lib › minga › main.ex") {
 		t.Fatalf("wide header should render active tab accent and breadcrumbs together: %q", header)
+	}
+}
+
+func TestHeaderTruncatesLongTabLabels(t *testing.T) {
+	model := New(120, 24, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiTabBar: {
+			Tabs: protocol.TabBar{Tabs: []protocol.Tab{{ID: 1, Icon: "󰈙", Label: "signature_help_builder_test.exs", Active: true}}},
+		},
+	}
+
+	header := ansi.Strip(strings.Join(model.headerLines(), "\n"))
+	if !strings.Contains(header, "signature_help_builder_…") || strings.Contains(header, "signature_help_builder_test.exs") {
+		t.Fatalf("header should truncate long tab labels, got %q", header)
 	}
 }
 
@@ -203,6 +250,34 @@ func TestPickerSelectedRowHasVisibleMarker(t *testing.T) {
 	}
 }
 
+func TestPickerSelectedRowUsesSelectionColors(t *testing.T) {
+	model := New(80, 24, nil)
+	rows := model.renderPickerList("Buffers", protocol.Picker{
+		Visible:  true,
+		Selected: 0,
+		Items:    []protocol.PickerItem{{Label: "[new 1]", Description: "dirty"}},
+	}, 2, 40)
+	joined := strings.Join(rows, "\n")
+	if !strings.Contains(joined, "48;2;58;66;92") {
+		t.Fatalf("selected picker row should use popup selection background: %q", joined)
+	}
+	if !strings.Contains(joined, "38;2;247;250;255") {
+		t.Fatalf("selected picker row should use popup selection foreground: %q", joined)
+	}
+}
+
+func TestPickerPreviewDefaultsToPopupTextAndSurface(t *testing.T) {
+	model := New(80, 24, nil)
+	rendered := model.renderPickerPreview(protocol.PickerPreview{Visible: true, Lines: []protocol.PreviewLine{{Segments: []protocol.PreviewSegment{{Text: "plain preview"}}}}}, 3, 40)
+	joined := strings.Join(rendered, "\n")
+	if !strings.Contains(joined, "38;2;217;224;245") {
+		t.Fatalf("plain preview text should use popup foreground instead of terminal default: %q", joined)
+	}
+	if !strings.Contains(joined, "48;2;41;45;62") {
+		t.Fatalf("preview rows should use popup surface background: %q", joined)
+	}
+}
+
 func TestPickerOverlayIsBounded(t *testing.T) {
 	model := New(100, 24, nil)
 	items := make([]protocol.PickerItem, 20)
@@ -237,6 +312,52 @@ func TestWidePickerPreviewRendersBesideList(t *testing.T) {
 	}
 	if len(rendered) > model.maxOverlayHeight() {
 		t.Fatalf("wide picker overlay height = %d, want <= %d", len(rendered), model.maxOverlayHeight())
+	}
+}
+
+func TestHiddenWindowCursorDoesNotOverrideVisibleWindowCursor(t *testing.T) {
+	model := New(80, 24, nil)
+	model.putWindow(protocol.WindowContent{ID: 1, CursorRow: 4, CursorCol: 18, CursorShape: 1, CursorVisible: true, Rows: []protocol.WindowRow{{Text: "typed text"}}})
+	model.putWindow(protocol.WindowContent{ID: 2, CursorRow: 1, CursorCol: 0, CursorShape: 0, CursorVisible: false, Rows: []protocol.WindowRow{{Text: "[new 1] *"}}})
+
+	if model.cursorRow != 4 || model.cursorCol != 18 || model.cursorShape != 1 {
+		t.Fatalf("hidden secondary window cursor should not override active cursor: row=%d col=%d shape=%d", model.cursorRow, model.cursorCol, model.cursorShape)
+	}
+}
+
+func TestHiddenWindowDeltaDoesNotOverrideVisibleWindowCursor(t *testing.T) {
+	model := New(80, 24, nil)
+	model.putWindow(protocol.WindowContent{ID: 1, ContentEpoch: 2, CursorRow: 4, CursorCol: 18, CursorShape: 1, CursorVisible: true, Rows: []protocol.WindowRow{{Text: "typed text"}}})
+	model.putWindow(protocol.WindowContent{ID: 2, ContentEpoch: 2, CursorRow: 1, CursorCol: 0, CursorShape: 0, CursorVisible: false, Rows: []protocol.WindowRow{{Text: "[new 1] *"}}})
+
+	model.applyWindowDelta(protocol.WindowContent{ID: 2, ContentEpoch: 2, CursorRow: 1, CursorCol: 0, CursorShape: 0, CursorVisible: false, Rows: []protocol.WindowRow{{Text: "[new 1] *"}}})
+
+	if model.cursorRow != 4 || model.cursorCol != 18 || model.cursorShape != 1 {
+		t.Fatalf("hidden secondary window delta should not override active cursor: row=%d col=%d shape=%d", model.cursorRow, model.cursorCol, model.cursorShape)
+	}
+}
+
+func TestVisibleToHiddenWindowDeltaRestoresRemainingVisibleCursor(t *testing.T) {
+	model := New(80, 24, nil)
+	model.putWindow(protocol.WindowContent{ID: 1, ContentEpoch: 2, CursorRow: 4, CursorCol: 18, CursorShape: 1, CursorVisible: true, Rows: []protocol.WindowRow{{Text: "typed text"}}})
+	model.putWindow(protocol.WindowContent{ID: 2, ContentEpoch: 2, CursorRow: 1, CursorCol: 0, CursorShape: 0, CursorVisible: true, Rows: []protocol.WindowRow{{Text: "[new 1] *"}}})
+
+	model.applyWindowDelta(protocol.WindowContent{ID: 2, ContentEpoch: 2, CursorRow: 1, CursorCol: 0, CursorShape: 0, CursorVisible: false, Rows: []protocol.WindowRow{{Text: "[new 1] *"}}})
+
+	if model.cursorRow != 4 || model.cursorCol != 18 || model.cursorShape != 1 {
+		t.Fatalf("visible-to-hidden delta should restore remaining visible cursor: row=%d col=%d shape=%d", model.cursorRow, model.cursorCol, model.cursorShape)
+	}
+}
+
+func TestHiddenToVisibleWindowDeltaUpdatesCursor(t *testing.T) {
+	model := New(80, 24, nil)
+	model.putWindow(protocol.WindowContent{ID: 1, ContentEpoch: 2, CursorRow: 4, CursorCol: 18, CursorShape: 1, CursorVisible: true, Rows: []protocol.WindowRow{{Text: "typed text"}}})
+	model.putWindow(protocol.WindowContent{ID: 2, ContentEpoch: 2, CursorRow: 1, CursorCol: 0, CursorShape: 0, CursorVisible: false, Rows: []protocol.WindowRow{{Text: "[new 1] *"}}})
+
+	model.applyWindowDelta(protocol.WindowContent{ID: 2, ContentEpoch: 2, CursorRow: 2, CursorCol: 5, CursorShape: 2, CursorVisible: true, Rows: []protocol.WindowRow{{Text: "[new 1] *"}}})
+
+	if model.cursorRow != 2 || model.cursorCol != 5 || model.cursorShape != 2 {
+		t.Fatalf("hidden-to-visible delta should update cursor: row=%d col=%d shape=%d", model.cursorRow, model.cursorCol, model.cursorShape)
 	}
 }
 
@@ -523,6 +644,17 @@ func TestSplitSeparatorsNormalizeAgainstHeaderAndFileTree(t *testing.T) {
 	}
 }
 
+func TestFileTreeSelectedRowPaintsBackgroundAcrossSegments(t *testing.T) {
+	model := New(40, 8, nil)
+	rendered := model.renderFileTreeRow(protocol.FileTreeRow{Name: "installer", Icon: "󰉋", Directory: true, Selected: true}, 24)
+	if count := strings.Count(rendered, "48;2;52;58;82"); count < 4 {
+		t.Fatalf("selected file-tree row should carry selection background across marker, icon, label, and fill, count=%d row=%q", count, rendered)
+	}
+	if got := displayWidth(ansi.Strip(rendered)); got != 24 {
+		t.Fatalf("selected file-tree row should fill requested width, got %d row=%q", got, rendered)
+	}
+}
+
 func TestFileTreeWidthRespectsProtocolGeometryAndSafetyClamp(t *testing.T) {
 	if got := fileTreeWidth(80, protocol.FileTree{Width: 18}); got != 18 {
 		t.Fatalf("file tree width = %d, want narrow protocol width 18", got)
@@ -539,7 +671,7 @@ func TestFileTreeReservesVisibleEmptyState(t *testing.T) {
 	model := New(80, 6, nil)
 	model.title = "Header"
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Status: 2, Width: 18, Root: "/repo"}}}
-	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 18, Width: 8, Height: 1}}})
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 8, Height: 1}}})
 	model.viewport.SetContent(model.content())
 
 	lines := strings.Split(ansi.Strip(model.View().Content), "\n")
@@ -558,7 +690,7 @@ func TestSemanticWindowsRespectProtocolFileTreeWidth(t *testing.T) {
 	model := New(80, 6, nil)
 	model.title = "Header"
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Width: 36, Rows: []protocol.FileTreeRow{{ID: "row-0", Name: "row-0"}}}}}
-	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 36, Width: 8, Height: 1}}})
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 8, Height: 1}}})
 	model.viewport.SetContent(model.content())
 
 	lines := strings.Split(ansi.Strip(model.View().Content), "\n")
@@ -697,8 +829,8 @@ func TestCellbufStyleMapsProtocolAttrs(t *testing.T) {
 
 func TestSemanticWindowsUsePaneGeometryRects(t *testing.T) {
 	model := New(24, 6, nil)
-	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "left"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 0, Width: 10, Height: 1}}})
-	model.putWindow(protocol.WindowContent{ID: 2, Rows: []protocol.WindowRow{{Text: "right"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 12, Width: 10, Height: 1}}})
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "left"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 10, Height: 1}}})
+	model.putWindow(protocol.WindowContent{ID: 2, Rows: []protocol.WindowRow{{Text: "right"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 12, Width: 10, Height: 1}}})
 
 	lines := ansi.Strip(strings.Join(model.semanticLines(), "\n"))
 	first := strings.Split(lines, "\n")[0]
@@ -713,7 +845,7 @@ func TestSemanticWindowsUsePaneGeometryRects(t *testing.T) {
 func TestSemanticWindowsRespectHeaderRowOffset(t *testing.T) {
 	model := New(24, 6, nil)
 	model.title = "Header"
-	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 0, Width: 8, Height: 1}}})
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 8, Height: 1}}})
 	model.viewport.SetContent(model.content())
 
 	lines := strings.Split(ansi.Strip(model.View().Content), "\n")
@@ -722,11 +854,26 @@ func TestSemanticWindowsRespectHeaderRowOffset(t *testing.T) {
 	}
 }
 
+func TestSemanticWindowsDoNotClipFirstRowWithWorkspaceAndTabHeaders(t *testing.T) {
+	model := New(80, 8, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiWorkspaces: {Spaces: protocol.WorkspaceBar{Spaces: []protocol.Workspace{{ID: 1, Label: "Files", Icon: "folder", Active: true, TabCount: 1}}}},
+		generated.OPGuiTabBar:     {Tabs: protocol.TabBar{ActiveIndex: 0, Tabs: []protocol.Tab{{ID: 1, Label: "[new 1]", Active: true, Dirty: true}}}},
+	}
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "Hey this is a thing"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 24, Height: 1}}})
+	model.viewport.SetContent(model.content())
+
+	lines := strings.Split(ansi.Strip(model.View().Content), "\n")
+	if len(lines) < 3 || !strings.Contains(lines[2], "Hey this is a thing") {
+		t.Fatalf("semantic editor row 0 should render below workspace and tab headers: %+v", lines)
+	}
+}
+
 func TestSemanticWindowsRespectFileTreeOffset(t *testing.T) {
 	model := New(80, 6, nil)
 	model.title = "Header"
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Width: 24, Rows: []protocol.FileTreeRow{{ID: "row-0", Name: "row-0"}}}}}
-	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 24, Width: 8, Height: 1}}})
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 8, Height: 1}}})
 	model.viewport.SetContent(model.content())
 
 	lines := strings.Split(ansi.Strip(model.View().Content), "\n")
@@ -742,7 +889,7 @@ func TestSemanticWindowsRespectSidebarOffset(t *testing.T) {
 	model := New(80, 6, nil)
 	model.title = "Header"
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiSidebars: {Sidebars: protocol.Sidebars{Visible: true, Items: []protocol.Sidebar{{ID: "files", DisplayName: "Files", SemanticKind: "file_tree", PreferredWidth: 18, Visible: true}}}}}
-	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 18, Width: 8, Height: 1}}})
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 8, Height: 1}}})
 	model.viewport.SetContent(model.content())
 
 	lines := strings.Split(ansi.Strip(model.View().Content), "\n")
@@ -835,6 +982,7 @@ func TestSemanticMouseRoutesModelineAndFileTreeZones(t *testing.T) {
 	model := New(60, 12, nil)
 	model.chrome = map[byte]protocol.ChromePayload{
 		generated.OPGuiStatusBar: {Status: protocol.StatusBar{Left: []protocol.StatusSegment{{Text: " save ", Command: "save"}}, Right: []protocol.StatusSegment{{Text: " quit", Command: "quit"}}}},
+		generated.OPGuiTabBar:    {Tabs: protocol.TabBar{Tabs: []protocol.Tab{{ID: 41, Icon: "󰈙", Label: "one.ex"}, {ID: 42, Icon: "󰈙", Label: "two.ex", Active: true}}}},
 		generated.OPGuiFileTree:  {Tree: protocol.FileTree{Visible: true, Width: 24, Rows: []protocol.FileTreeRow{{ID: "row-0", Name: "row-0"}, {ID: "row-1", Name: "row-1"}}}},
 	}
 	model.viewport.SetContent(model.content())
@@ -849,6 +997,12 @@ func TestSemanticMouseRoutesModelineAndFileTreeZones(t *testing.T) {
 		t.Fatalf("non-left clicks should fall back")
 	}
 
+	tabZone := waitForZone(t, model, zoneIDTab(42))
+	cmd, ok = model.semanticMousePacket(tea.MouseClickMsg(tea.Mouse{Button: tea.MouseLeft, X: tabZone.StartX + 1, Y: tabZone.StartY}))
+	if !ok || !bytes.Equal(cmd, protocol.EncodeGUISelectTab(42)) {
+		t.Fatalf("tab click should route select-tab packet, ok=%v packet=%v", ok, cmd)
+	}
+
 	rowZone := waitForZone(t, model, zoneIDFileTreeRow(0))
 	cmd, ok = model.semanticMousePacket(tea.MouseClickMsg(tea.Mouse{Button: tea.MouseLeft, X: rowZone.StartX + 1, Y: rowZone.StartY}))
 	if !ok || !bytes.Equal(cmd, protocol.EncodeGUIFileTreeClick(0)) {
@@ -857,6 +1011,92 @@ func TestSemanticMouseRoutesModelineAndFileTreeZones(t *testing.T) {
 	if _, ok := model.semanticMousePacket(tea.MouseClickMsg(tea.Mouse{Button: tea.MouseLeft, X: rowZone.EndX + 10, Y: rowZone.EndY + 10})); ok {
 		t.Fatalf("out-of-bounds clicks should fall back")
 	}
+}
+
+func TestBottomPanelShowsLatestMessagesByDefault(t *testing.T) {
+	model, panel := bottomPanelTestModel(10, nil)
+	visible := model.visibleBottomPanelMessages(panel)
+	if len(visible) != model.bottomPanelVisibleRows() {
+		t.Fatalf("visible message count mismatch: got %d want %d", len(visible), model.bottomPanelVisibleRows())
+	}
+	if visible[0].Text != "msg-7" || visible[len(visible)-1].Text != "msg-9" {
+		t.Fatalf("bottom panel should start at latest messages, got %+v", visible)
+	}
+}
+
+func TestBottomPanelWheelScrollIsHandledLocally(t *testing.T) {
+	out := make(chan []byte, 1)
+	model, _ := bottomPanelTestModel(10, out)
+	next, _ := model.Update(tea.MouseClickMsg(tea.Mouse{Button: tea.MouseWheelUp, X: 10, Y: 9}))
+	updated := next.(Model)
+	if updated.bottomPanelScrollback != bottomPanelWheelLines {
+		t.Fatalf("wheel over bottom panel should update local scrollback, got %d", updated.bottomPanelScrollback)
+	}
+	select {
+	case packet := <-out:
+		t.Fatalf("wheel over bottom panel should not send editor mouse packet: %v", packet)
+	default:
+	}
+	body := ansi.Strip(strings.Join(updated.overlayLines(), "\n"))
+	if !strings.Contains(body, "msg-4") || strings.Contains(body, "msg-9") {
+		t.Fatalf("bottom panel should scroll older messages, got %q", body)
+	}
+}
+
+func TestBottomPanelWheelOutsidePanelFallsThrough(t *testing.T) {
+	out := make(chan []byte, 1)
+	model, _ := bottomPanelTestModel(10, out)
+	next, _ := model.Update(tea.MouseClickMsg(tea.Mouse{Button: tea.MouseWheelUp, X: 10, Y: 2}))
+	updated := next.(Model)
+	if updated.bottomPanelScrollback != 0 {
+		t.Fatalf("wheel outside bottom panel should not update local scrollback, got %d", updated.bottomPanelScrollback)
+	}
+	select {
+	case <-out:
+	default:
+		t.Fatalf("wheel outside bottom panel should fall through to editor mouse packet")
+	}
+}
+
+func TestBottomPanelChromeUpdateClampsAndResetsScrollback(t *testing.T) {
+	t.Run("shrinking list clamps stale scrollback", func(t *testing.T) {
+		model, panel := bottomPanelTestModel(10, nil)
+		model.bottomPanelScrollback = 6
+
+		shrunk := panel
+		shrunk.Messages = shrunk.Messages[:4]
+		updated, _ := model.Update(port.PacketMsg{Commands: []protocol.Command{{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiBottomPanel, Bottom: shrunk}}}})
+		got := updated.(Model)
+
+		if got.bottomPanelScrollback != 1 {
+			t.Fatalf("shrinking bottom panel should clamp stale scrollback to 1, got %d", got.bottomPanelScrollback)
+		}
+	})
+
+	t.Run("hidden panel resets stale scrollback", func(t *testing.T) {
+		model, panel := bottomPanelTestModel(10, nil)
+		model.bottomPanelScrollback = 5
+
+		hidden := panel
+		hidden.Visible = false
+		updated, _ := model.Update(port.PacketMsg{Commands: []protocol.Command{{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiBottomPanel, Bottom: hidden}}}})
+		got := updated.(Model)
+
+		if got.bottomPanelScrollback != 0 {
+			t.Fatalf("hidden bottom panel should reset stale scrollback to 0, got %d", got.bottomPanelScrollback)
+		}
+	})
+}
+
+func bottomPanelTestModel(messageCount int, out chan<- []byte) (Model, protocol.BottomPanel) {
+	model := New(80, 12, out)
+	messages := make([]protocol.PanelMessage, 0, messageCount)
+	for i := 0; i < messageCount; i++ {
+		messages = append(messages, protocol.PanelMessage{ID: uint32(i + 1), Level: 1, Text: fmt.Sprintf("msg-%d", i)})
+	}
+	panel := protocol.BottomPanel{Visible: true, ActiveTab: 0, Tabs: []protocol.PanelTab{{Type: 0x01, Name: "Messages"}}, Messages: messages}
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiBottomPanel: {Opcode: generated.OPGuiBottomPanel, Bottom: panel}}
+	return model, panel
 }
 
 func visibleIndex(value string, needle string) int {

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -5,8 +5,11 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
 )
+
+const maxTabLabelWidth = 24
 
 func (m Model) headerLines() []string {
 	lines := []string{}
@@ -101,7 +104,8 @@ func (m Model) renderTabs(tabBar protocol.TabBar) string {
 		if icon.color != "" {
 			iconText = lipgloss.NewStyle().Foreground(lipgloss.Color(icon.color)).Background(iconBackground).Render(icon.glyph)
 		}
-		label := strings.TrimSpace(iconText + " " + tab.Label)
+		tabLabel := ansi.TruncateWc(tab.Label, maxTabLabelWidth, "…")
+		label := strings.TrimSpace(iconText + " " + tabLabel)
 		if tab.Active {
 			label = lipgloss.NewStyle().Foreground(theme.Accent()).Background(theme.TabActive()).Render("▌") + " " + label
 		}
@@ -117,7 +121,7 @@ func (m Model) renderTabs(tabBar protocol.TabBar) string {
 		} else if tab.Tint != 0 {
 			style = style.Foreground(lipgloss.Color(fmt.Sprintf("#%06X", tab.Tint&0xFFFFFF)))
 		}
-		rendered = append(rendered, style.Render(label))
+		rendered = append(rendered, m.zones.Mark(zoneIDTab(tab.ID), style.Render(label)))
 	}
 	return rowStyle.Render(fitStyled(strings.Join(rendered, " "), m.width))
 }
@@ -191,7 +195,7 @@ func (m Model) renderStatusSegments(status protocol.StatusBar) string {
 	}
 	leftSpacer := strings.Repeat(" ", max((available-messageWidth)/2, 0))
 	rightSpacer := strings.Repeat(" ", max(available-messageWidth-lipgloss.Width(leftSpacer), 0))
-	spacerStyle := lipgloss.NewStyle().Background(m.palette().Base())
+	spacerStyle := lipgloss.NewStyle().Background(m.palette().ChromeSurface())
 	return left + spacerStyle.Render(leftSpacer) + message + spacerStyle.Render(rightSpacer) + right
 }
 
@@ -199,7 +203,7 @@ func (m Model) renderStatusMessage(message string) string {
 	if message == "" {
 		return ""
 	}
-	return lipgloss.NewStyle().Bold(true).Foreground(m.palette().Warning()).Background(m.palette().Base()).Render(message)
+	return lipgloss.NewStyle().Bold(true).Foreground(m.palette().Warning()).Background(m.palette().ChromeSurface()).Render(message)
 }
 
 func (m Model) renderSegmentList(segments []protocol.StatusSegment) string {
@@ -209,7 +213,7 @@ func (m Model) renderSegmentList(segments []protocol.StatusSegment) string {
 		if text == "" {
 			continue
 		}
-		style := lipgloss.NewStyle().Foreground(m.palette().Muted()).Background(m.palette().Base())
+		style := lipgloss.NewStyle().Foreground(m.palette().ChromeText()).Background(m.palette().ChromeSurface())
 		if segment.FG != 0 {
 			style = style.Foreground(lipgloss.Color(fmt.Sprintf("#%06X", segment.FG)))
 		}
@@ -363,9 +367,10 @@ func (m Model) renderPickerItemRow(title string, item protocol.PickerItem, selec
 	rowBackground := theme.PopupSurface()
 	rowForeground := theme.PopupText()
 	if selected {
+		rowBackground = theme.PopupSelection()
 		rowForeground = theme.PopupSelectionText()
 	}
-	markerText := lipgloss.NewStyle().Foreground(theme.Muted()).Background(rowBackground).Render(marker)
+	markerText := lipgloss.NewStyle().Foreground(theme.PopupMutedText()).Background(rowBackground).Render(marker)
 	if selected {
 		markerText = lipgloss.NewStyle().Bold(true).Foreground(theme.Accent()).Background(rowBackground).Render(marker)
 	} else if item.Marked {
@@ -381,14 +386,15 @@ func (m Model) renderPickerItemRow(title string, item protocol.PickerItem, selec
 	}
 	text := markerText + labelStyle.Render(" "+strings.TrimSpace(iconText+" "+item.Label))
 	if strings.TrimSpace(detail) != "" {
-		text += lipgloss.NewStyle().Foreground(theme.Muted()).Background(rowBackground).Render("  " + strings.TrimSpace(detail))
+		text += lipgloss.NewStyle().Foreground(theme.PopupMutedText()).Background(rowBackground).Render("  " + strings.TrimSpace(detail))
 	}
 	return lipgloss.NewStyle().Background(rowBackground).Width(width).Render(fitStyled(" "+text, width))
 }
 
 func (m Model) renderPickerWithSidePreview(title string, picker protocol.Picker, preview protocol.PickerPreview, height int) []string {
-	leftWidth := min(max(m.width*45/100, 36), max(m.width-20, 1))
-	rightWidth := max(m.width-leftWidth, 1)
+	dividerWidth := 1
+	leftWidth := min(max(m.width*42/100, 36), max(m.width-20-dividerWidth, 1))
+	rightWidth := max(m.width-leftWidth-dividerWidth, 1)
 	bodyHeight := max(height-1, 1)
 	left := m.renderPickerList(title, picker, bodyHeight, leftWidth)
 	right := m.renderPickerPreview(preview, bodyHeight, rightWidth)
@@ -396,8 +402,9 @@ func (m Model) renderPickerWithSidePreview(title string, picker protocol.Picker,
 	right = m.fillPopupLines(right, bodyHeight, rightWidth)
 	lines := make([]string, 0, height)
 	leftStyle := lipgloss.NewStyle().Width(leftWidth).Background(m.palette().PopupSurface())
+	divider := lipgloss.NewStyle().Foreground(m.palette().PopupBorder()).Background(m.palette().PopupSurface()).Render("│")
 	for i := 0; i < bodyHeight; i++ {
-		lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, leftStyle.Render(left[i]), right[i]))
+		lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, leftStyle.Render(left[i]), divider, right[i]))
 	}
 	lines = append(lines, m.renderPickerHelp(picker, m.width))
 	return lines
@@ -411,8 +418,8 @@ func (m Model) renderPickerHelp(picker protocol.Picker, width int) string {
 	}
 	left := fmt.Sprintf(" %d/%d", selected, len(picker.Items))
 	right := "↑↓ move  Enter choose  Esc close"
-	leftText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupChrome()).Render(left)
-	rightText := lipgloss.NewStyle().Foreground(p.Muted()).Background(p.PopupChrome()).Render(right)
+	leftText := lipgloss.NewStyle().Foreground(p.PopupMutedText()).Background(p.PopupChrome()).Render(left)
+	rightText := lipgloss.NewStyle().Foreground(p.PopupMutedText()).Background(p.PopupChrome()).Render(right)
 	spacer := strings.Repeat(" ", max(width-lipgloss.Width(leftText)-lipgloss.Width(rightText), 0))
 	return lipgloss.NewStyle().Background(p.PopupChrome()).Width(width).Render(fitStyled(leftText+spacer+rightText, width))
 }
@@ -421,11 +428,13 @@ func (m Model) renderPickerPreview(preview protocol.PickerPreview, height int, w
 	theme := m.palette()
 	style := m.popupLineStyle(width)
 	limit := min(len(preview.Lines), max(height-1, 0))
-	lines := []string{style.Bold(true).Foreground(theme.Accent()).Render(fit("Preview", width))}
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Accent()).Background(theme.PopupChrome()).Width(width)
+	lines := []string{titleStyle.Render(fit(" Preview", width))}
 	for _, line := range preview.Lines[:limit] {
 		var builder strings.Builder
+		builder.WriteString(lipgloss.NewStyle().Background(theme.PopupSurface()).Render(" "))
 		for _, segment := range line.Segments {
-			segmentStyle := lipgloss.NewStyle().Background(theme.PopupSurface())
+			segmentStyle := lipgloss.NewStyle().Foreground(theme.PopupText()).Background(theme.PopupSurface())
 			if segment.FG != 0 {
 				segmentStyle = segmentStyle.Foreground(lipgloss.Color(fmt.Sprintf("#%06X", segment.FG)))
 			}

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -134,8 +134,13 @@ func (m Model) semanticWindowPlacement(window protocol.WindowContent) (semanticW
 	}, true
 }
 
-// Protocol geometry is absolute screen geometry, while Bubble Tea renders the body after header and left chrome are already consumed.
+// Protocol window geometry is relative to the semantic editor surface. Bubble Tea adds TUI chrome around that surface after semantic content is composed.
 func (m Model) normalizeSemanticGeometry(row int, col int) (int, int) {
+	return row, col
+}
+
+// Protocol chrome geometry is absolute terminal geometry, so split separators are normalized into Bubble Tea's body canvas.
+func (m Model) normalizeChromeGeometry(row int, col int) (int, int) {
 	rowOffset, colOffset := m.semanticContentOffsets()
 	return row - rowOffset, col - colOffset
 }
@@ -441,8 +446,8 @@ func (m Model) withSplitSeparators(lines []string) []string {
 		style = style.Foreground(lipgloss.Color(fmt.Sprintf("#%06X", splits.Color)))
 	}
 	for _, vertical := range splits.Verticals {
-		startRow, col := m.normalizeSemanticGeometry(int(vertical.StartRow), int(vertical.Col))
-		endRow, _ := m.normalizeSemanticGeometry(int(vertical.EndRow), int(vertical.Col))
+		startRow, col := m.normalizeChromeGeometry(int(vertical.StartRow), int(vertical.Col))
+		endRow, _ := m.normalizeChromeGeometry(int(vertical.EndRow), int(vertical.Col))
 		if col < 0 || endRow < 0 {
 			continue
 		}
@@ -452,7 +457,7 @@ func (m Model) withSplitSeparators(lines []string) []string {
 		}
 	}
 	for _, horizontal := range splits.Horizontals {
-		row, col := m.normalizeSemanticGeometry(int(horizontal.Row), int(horizontal.Col))
+		row, col := m.normalizeChromeGeometry(int(horizontal.Row), int(horizontal.Col))
 		if row < 0 || row >= len(out) {
 			continue
 		}
@@ -690,40 +695,15 @@ func (m Model) gutterSign(entry protocol.GutterEntry) string {
 func (m Model) renderFileTree(tree protocol.FileTree, width int, height int) []string {
 	theme := m.palette()
 	style := lipgloss.NewStyle().Foreground(theme.TreeText()).Background(theme.TreeSurface()).Width(width)
-	selectedStyle := style.Foreground(theme.Text()).Background(theme.TreeSelection()).Bold(true)
-	header := style.Bold(true).Foreground(theme.TreeHeaderText()).Background(theme.TreeHeader()).Render(fit("Files  "+tree.Root, width))
+	header := style.Bold(true).Foreground(theme.TreeHeaderText()).Background(theme.TreeHeader()).Render(fit(" Files  "+tree.Root, width))
 	lines := []string{header}
 	if len(tree.Rows) == 0 {
 		if status := fileTreeStatusText(tree); status != "" && len(lines) < height {
-			lines = append(lines, style.Render(fit(status, width)))
+			lines = append(lines, style.Foreground(theme.TreeMutedText()).Render(fit(" "+status, width)))
 		}
 	}
 	for rowIndex, row := range tree.Rows {
-		prefix := strings.Repeat("  ", int(row.Depth))
-		marker := " "
-		if row.Directory && row.Expanded {
-			marker = "v"
-		} else if row.Directory {
-			marker = ">"
-		}
-		dirty := ""
-		if row.Dirty {
-			dirty = " *"
-		}
-		icon := fileTreeIcon(row)
-		iconText := icon.glyph
-		iconBackground := theme.TreeSurface()
-		if row.Selected {
-			iconBackground = theme.TreeSelection()
-		}
-		if icon.color != "" {
-			iconText = lipgloss.NewStyle().Foreground(lipgloss.Color(icon.color)).Background(iconBackground).Render(icon.glyph)
-		}
-		text := fit(fmt.Sprintf("%s%s %s %s%s", prefix, marker, iconText, row.Name, dirty), width)
-		rendered := style.Render(text)
-		if row.Selected {
-			rendered = selectedStyle.Render(text)
-		}
+		rendered := m.renderFileTreeRow(row, width)
 		lines = append(lines, m.zones.Mark(zoneIDFileTreeRow(rowIndex), rendered))
 		if len(lines) >= height {
 			return lines
@@ -733,6 +713,62 @@ func (m Model) renderFileTree(tree protocol.FileTree, width int, height int) []s
 		lines = append(lines, style.Render(strings.Repeat(" ", width)))
 	}
 	return lines
+}
+
+func (m Model) renderFileTreeRow(row protocol.FileTreeRow, width int) string {
+	theme := m.palette()
+	rowBackground := theme.TreeSurface()
+	textColor := theme.TreeText()
+	markerColor := theme.TreeMutedText()
+	if row.Directory {
+		textColor = theme.TreeDirectoryText()
+	}
+	if fileTreeRowMuted(row) {
+		textColor = theme.TreeMutedText()
+	}
+	if row.Selected {
+		rowBackground = theme.TreeSelection()
+		textColor = theme.TreeSelectionText()
+	}
+	selectionMarker := " "
+	if row.Selected {
+		selectionMarker = "▌"
+	}
+	prefix := strings.Repeat("  ", int(row.Depth))
+	expander := " "
+	if row.Directory && row.Expanded {
+		expander = "▾"
+	} else if row.Directory {
+		expander = "▸"
+	}
+	rowStyle := lipgloss.NewStyle().Foreground(textColor).Background(rowBackground)
+	markerStyle := lipgloss.NewStyle().Foreground(markerColor).Background(rowBackground)
+	if row.Selected {
+		markerStyle = markerStyle.Foreground(theme.Accent()).Bold(true)
+	}
+	icon := fileTreeIcon(row)
+	iconStyle := rowStyle
+	if icon.color != "" && !row.Selected && !fileTreeRowMuted(row) {
+		iconStyle = iconStyle.Foreground(lipgloss.Color(icon.color))
+	}
+	nameStyle := rowStyle
+	if row.Selected || row.Directory {
+		nameStyle = nameStyle.Bold(true)
+	}
+	content := markerStyle.Render(selectionMarker+prefix+expander) + rowStyle.Render(" ") + iconStyle.Render(icon.glyph) + rowStyle.Render(" ") + nameStyle.Render(row.Name)
+	if row.Dirty {
+		dirty := lipgloss.NewStyle().Foreground(theme.Warning()).Background(rowBackground).Render("●")
+		space := strings.Repeat(" ", max(width-lipgloss.Width(content)-lipgloss.Width(dirty), 1))
+		content += rowStyle.Render(space) + dirty
+	} else if remaining := width - lipgloss.Width(content); remaining > 0 {
+		content += rowStyle.Render(strings.Repeat(" ", remaining))
+	}
+	return rowStyle.Width(width).Render(fitStyled(content, width))
+}
+
+func fileTreeRowMuted(row protocol.FileTreeRow) bool {
+	name := strings.TrimSpace(row.Name)
+	return strings.HasPrefix(name, ".") || strings.Contains(row.Path, "/.")
 }
 
 func fileTreeStatusText(tree protocol.FileTree) string {

--- a/go/tui/internal/ui/render_surfaces.go
+++ b/go/tui/internal/ui/render_surfaces.go
@@ -2,9 +2,11 @@ package ui
 
 import (
 	"fmt"
+	"image/color"
 	"strings"
 
 	"charm.land/bubbles/v2/table"
+	"charm.land/lipgloss/v2"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
 )
 
@@ -155,16 +157,89 @@ func (m Model) renderBottomPanel(panel protocol.BottomPanel) []string {
 	if len(panel.Tabs) > int(panel.ActiveTab) {
 		title = panel.Tabs[panel.ActiveTab].Name
 	}
-	rows := make([]table.Row, 0, len(panel.Messages))
-	for _, msg := range panel.Messages {
-		rows = append(rows, table.Row{levelName(msg.Level), msg.Path, msg.Text})
+	messages := m.visibleBottomPanelMessages(panel)
+	width := max(m.width, 1)
+	height := m.maxOverlayHeight()
+	p := m.palette()
+	headerLeft := fmt.Sprintf(" %s", title)
+	headerRight := fmt.Sprintf("%d messages", len(panel.Messages))
+	if m.bottomPanelScrollback > 0 {
+		headerRight += fmt.Sprintf("  ↑%d", m.bottomPanelScrollback)
 	}
-	columns := []table.Column{
-		{Title: title, Width: 10},
-		{Title: "Path", Width: max(m.width/4, 12)},
-		{Title: "Message", Width: max(m.width-max(m.width/4, 12)-14, 20)},
+	leftText := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(p.PopupChrome()).Render(headerLeft)
+	rightText := lipgloss.NewStyle().Foreground(p.PopupMutedText()).Background(p.PopupChrome()).Render(headerRight)
+	spacer := strings.Repeat(" ", max(width-lipgloss.Width(leftText)-lipgloss.Width(rightText), 0))
+	lines := []string{lipgloss.NewStyle().Background(p.PopupChrome()).Width(width).Render(fitStyled(leftText+spacer+rightText, width))}
+	rowBudget := max(height-1, 0)
+	pathWidth := min(max(width/4, 12), max(width-18, 1))
+	messageWidth := max(width-pathWidth-8, 1)
+	for _, msg := range messages[:min(len(messages), rowBudget)] {
+		lines = append(lines, m.renderBottomPanelMessage(msg, pathWidth, messageWidth, width))
 	}
-	return takeLines(m.charmTable(columns, rows, 0, m.maxOverlayHeight()), m.maxOverlayHeight())
+	lineStyle := m.popupLineStyle(width)
+	for len(lines) < height {
+		lines = append(lines, lineStyle.Render(strings.Repeat(" ", width)))
+	}
+	return takeLines(lines, height)
+}
+
+func (m Model) renderBottomPanelMessage(msg protocol.PanelMessage, pathWidth int, messageWidth int, width int) string {
+	p := m.palette()
+	badge := bottomPanelLevelBadge(msg.Level)
+	badgeColor := bottomPanelLevelColor(p, msg.Level)
+	badgeText := lipgloss.NewStyle().Bold(true).Foreground(p.EditorSurface()).Background(badgeColor).Width(5).Align(lipgloss.Center).Render(badge)
+	path := msg.Path
+	if strings.TrimSpace(path) == "" {
+		path = "messages"
+	}
+	pathText := lipgloss.NewStyle().Foreground(p.PopupMutedText()).Background(p.PopupSurface()).Width(pathWidth).Render(fit(path, pathWidth))
+	messageText := lipgloss.NewStyle().Foreground(p.PopupText()).Background(p.PopupSurface()).Width(messageWidth).Render(fit(msg.Text, messageWidth))
+	row := " " + badgeText + " " + pathText + " " + messageText
+	return lipgloss.NewStyle().Background(p.PopupSurface()).Width(width).Render(fitStyled(row, width))
+}
+
+func bottomPanelLevelBadge(level byte) string {
+	switch level {
+	case 1:
+		return "WRN"
+	case 2:
+		return "ERR"
+	case 3:
+		return "OK"
+	case 4:
+		return "RUN"
+	default:
+		return "INF"
+	}
+}
+
+func bottomPanelLevelColor(p palette, level byte) color.Color {
+	switch level {
+	case 1:
+		return p.Warning()
+	case 2:
+		return p.Error()
+	case 3:
+		return p.Hint()
+	case 4:
+		return p.Info()
+	default:
+		return p.Info()
+	}
+}
+
+func (m Model) visibleBottomPanelMessages(panel protocol.BottomPanel) []protocol.PanelMessage {
+	visibleRows := m.bottomPanelVisibleRows()
+	if len(panel.Messages) <= visibleRows {
+		return panel.Messages
+	}
+	start := max(len(panel.Messages)-visibleRows-m.bottomPanelScrollback, 0)
+	end := min(start+visibleRows, len(panel.Messages))
+	return panel.Messages[start:end]
+}
+
+func (m Model) bottomPanelVisibleRows() int {
+	return max(m.maxOverlayHeight()-1, 1)
 }
 
 func (m Model) renderExtensionPanels(ext protocol.ExtensionPanel) []string {

--- a/go/tui/internal/ui/semantic_mouse.go
+++ b/go/tui/internal/ui/semantic_mouse.go
@@ -11,6 +11,8 @@ import (
 const (
 	zonePrefixFileTreeRow     = "file-tree:row:"
 	zonePrefixModelineCommand = "modeline:command:"
+	zonePrefixTab             = "tab:id:"
+	bottomPanelWheelLines     = 3
 )
 
 func zoneIDFileTreeRow(index int) string {
@@ -21,12 +23,59 @@ func zoneIDModelineCommand(command string) string {
 	return zonePrefixModelineCommand + url.QueryEscape(command)
 }
 
+func zoneIDTab(id uint32) string {
+	return fmt.Sprintf("%s%d", zonePrefixTab, id)
+}
+
+func (m Model) localMouse(msg tea.MouseMsg) (Model, bool) {
+	mouse := msg.Mouse()
+	if mouse.Button != tea.MouseWheelUp && mouse.Button != tea.MouseWheelDown {
+		return m, false
+	}
+	panel, ok := m.bottomPanel()
+	if !ok || !panel.Visible || !m.mouseInBottomPanel(mouse.Y) {
+		return m, false
+	}
+	if mouse.Button == tea.MouseWheelUp {
+		m.bottomPanelScrollback += bottomPanelWheelLines
+	} else {
+		m.bottomPanelScrollback -= bottomPanelWheelLines
+	}
+	m.clampBottomPanelScrollback(panel)
+	return m, true
+}
+
+func (m Model) mouseInBottomPanel(y int) bool {
+	footerCount := len(m.footerLines())
+	overlayCount := max(footerCount-1, 0)
+	if overlayCount == 0 {
+		return false
+	}
+	start := m.height - overlayCount
+	return y >= start && y < m.height
+}
+
+func (m *Model) clampBottomPanelScrollback(panel protocol.BottomPanel) {
+	if !panel.Visible {
+		m.bottomPanelScrollback = 0
+		return
+	}
+	m.bottomPanelScrollback = min(max(m.bottomPanelScrollback, 0), m.maxBottomPanelScrollback(panel))
+}
+
+func (m Model) maxBottomPanelScrollback(panel protocol.BottomPanel) int {
+	return max(len(panel.Messages)-m.bottomPanelVisibleRows(), 0)
+}
+
 func (m Model) semanticMousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	click, ok := msg.(tea.MouseClickMsg)
 	if !ok || click.Button != tea.MouseLeft {
 		return nil, false
 	}
 	if packet, ok := m.modelineMousePacket(msg); ok {
+		return packet, true
+	}
+	if packet, ok := m.tabMousePacket(msg); ok {
 		return packet, true
 	}
 	if packet, ok := m.fileTreeMousePacket(msg); ok {
@@ -50,6 +99,20 @@ func (m Model) modelineMousePacket(msg tea.MouseMsg) ([]byte, bool) {
 		zoneInfo := m.zones.Get(zoneIDModelineCommand(segment.Command))
 		if zoneInfo != nil && zoneInfo.InBounds(msg) {
 			return protocol.EncodeGUIExecuteCommand(segment.Command), true
+		}
+	}
+	return nil, false
+}
+
+func (m Model) tabMousePacket(msg tea.MouseMsg) ([]byte, bool) {
+	tabs, ok := m.tabBar()
+	if !ok {
+		return nil, false
+	}
+	for _, tab := range tabs.Tabs {
+		zoneInfo := m.zones.Get(zoneIDTab(tab.ID))
+		if zoneInfo != nil && zoneInfo.InBounds(msg) {
+			return protocol.EncodeGUISelectTab(tab.ID), true
 		}
 	}
 	return nil, false

--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -48,37 +48,37 @@ type palette struct {
 
 func defaultPalette() palette {
 	return palette{colors: map[byte]uint32{
-		themeEditorBG:         0x282C34,
-		themeEditorFG:         0xBBC2CF,
-		themeTreeBG:           0x21242B,
-		themeTreeFG:           0xBBC2CF,
-		themeTreeSelectBG:     0x3E4451,
-		themeTreeHeaderBG:     0x282C34,
-		themeTreeHeaderFG:     0xBBC2CF,
-		themeTabBG:            0x282C34,
-		themeTabActiveBG:      0x3E4451,
-		themeTabActiveFG:      0xFFFFFF,
-		themeTabInactiveFG:    0x5B6268,
-		themeTabModifiedFG:    0xFF6C6B,
-		themeTabAttentionFG:   0xECBE7B,
-		themePopupBG:          0x252A38,
-		themePopupFG:          0xD7DDF0,
-		themePopupBorder:      0x7A849B,
-		themePopupSelBG:       0x2F3650,
-		themePopupSelFG:       0xF2F5FF,
-		themeBreadcrumbBG:     0x21242B,
-		themeModelineBG:       0x22252D,
-		themeModelineFG:       0xBBC2CF,
-		themeAccent:           0x51AFEF,
-		themeGutterFG:         0x5B6268,
-		themeGutterCurrentFG:  0xBBC2CF,
-		themeDiagnosticError:  0xFF6C6B,
-		themeWarningFG:        0xECBE7B,
-		themeDiagnosticInfo:   0x51AFEF,
-		themeDiagnosticHint:   0x98BE65,
-		themeHighlightReadBG:  0x3A3F4B,
+		themeEditorBG:         0x1E1F2A,
+		themeEditorFG:         0xC7D0E8,
+		themeTreeBG:           0x222433,
+		themeTreeFG:           0xB8C0D8,
+		themeTreeSelectBG:     0x343A52,
+		themeTreeHeaderBG:     0x1A1D29,
+		themeTreeHeaderFG:     0x9EC5FF,
+		themeTabBG:            0x242634,
+		themeTabActiveBG:      0x30364D,
+		themeTabActiveFG:      0xF2F5FF,
+		themeTabInactiveFG:    0x747B93,
+		themeTabModifiedFG:    0xF5B66F,
+		themeTabAttentionFG:   0xE8C774,
+		themePopupBG:          0x292D3E,
+		themePopupFG:          0xD9E0F5,
+		themePopupBorder:      0x4C5267,
+		themePopupSelBG:       0x3A425C,
+		themePopupSelFG:       0xF7FAFF,
+		themeBreadcrumbBG:     0x232634,
+		themeModelineBG:       0x222536,
+		themeModelineFG:       0xAEB7D0,
+		themeAccent:           0x7DB7FF,
+		themeGutterFG:         0x697088,
+		themeGutterCurrentFG:  0xC7D0E8,
+		themeDiagnosticError:  0xFF8AA6,
+		themeWarningFG:        0xF5C276,
+		themeDiagnosticInfo:   0x7DCFFF,
+		themeDiagnosticHint:   0xA6DA95,
+		themeHighlightReadBG:  0x33384C,
 		themeHighlightWriteBG: 0x4A3F2B,
-		themeSelectionBG:      0x264F78,
+		themeSelectionBG:      0x2F4463,
 	}}
 }
 
@@ -111,7 +111,19 @@ func (p palette) Text() color.Color {
 }
 
 func (p palette) Muted() color.Color {
+	return p.slot(themeTabInactiveFG)
+}
+
+func (p palette) ChromeText() color.Color {
 	return p.slot(themeModelineFG)
+}
+
+func (p palette) ChromeMuted() color.Color {
+	return p.slot(themeTabInactiveFG)
+}
+
+func (p palette) ChromeSurface() color.Color {
+	return p.slot(themeModelineBG)
 }
 
 func (p palette) Accent() color.Color {
@@ -179,8 +191,20 @@ func (p palette) TreeText() color.Color {
 	return p.slot(themeTreeFG)
 }
 
+func (p palette) TreeMutedText() color.Color {
+	return p.slot(themeTabInactiveFG)
+}
+
+func (p palette) TreeDirectoryText() color.Color {
+	return p.slot(themeAccent)
+}
+
 func (p palette) TreeSelection() color.Color {
 	return p.slot(themeTreeSelectBG)
+}
+
+func (p palette) TreeSelectionText() color.Color {
+	return p.slot(themePopupSelFG)
 }
 
 func (p palette) TreeHeader() color.Color {
@@ -232,7 +256,31 @@ func (p palette) PopupSelectionText() color.Color {
 }
 
 func (p palette) PopupChrome() color.Color {
-	return lipgloss.Color("#202532")
+	return p.slot(themeBreadcrumbBG)
+}
+
+func (p palette) PopupMutedText() color.Color {
+	return p.slot(themeTabInactiveFG)
+}
+
+func (p palette) KeycapSurface() color.Color {
+	return p.slot(themePopupSelBG)
+}
+
+func (p palette) KeycapText() color.Color {
+	return p.slot(themePopupSelFG)
+}
+
+func (p palette) Error() color.Color {
+	return p.slot(themeDiagnosticError)
+}
+
+func (p palette) Info() color.Color {
+	return p.slot(themeDiagnosticInfo)
+}
+
+func (p palette) Hint() color.Color {
+	return p.slot(themeDiagnosticHint)
 }
 
 func (p palette) slot(slot byte) color.Color {

--- a/go/tui/internal/ui/which_key_overlay.go
+++ b/go/tui/internal/ui/which_key_overlay.go
@@ -31,61 +31,122 @@ func (m Model) renderFloatingWhichKey(which protocol.WhichKey) string {
 	popupWidth := m.whichKeyWidth()
 	contentWidth := max(popupWidth-2, 1)
 	inner := max(contentWidth-2, 1)
-	title := "Keys"
-	if which.Prefix != "" {
-		title += " " + which.Prefix
-	}
-	if which.PageCount > 1 {
-		title += fmt.Sprintf("  %d/%d", which.Page+1, which.PageCount)
-	}
+	columns := m.whichKeyColumns(inner, len(which.Bindings))
+	gutter := m.whichKeyColumnGutter()
+	gutterWidth := lipgloss.Width(gutter)
+	cellWidth := max((inner-gutterWidth*(columns-1))/columns, 1)
+	keyWidth := whichKeyKeyWidth(which.Bindings)
 
-	lines := []string{lipgloss.NewStyle().Bold(true).Foreground(m.palette().Accent()).Background(m.palette().PopupChrome()).Width(inner).Render(fit(title, inner))}
-	columns := m.whichKeyColumns(inner)
+	lines := []string{m.renderWhichKeyHeader(which, inner)}
 	rows := (len(which.Bindings) + columns - 1) / columns
-	cellWidth := max(inner/columns, 1)
 	for row := 0; row < rows; row++ {
 		cells := make([]string, 0, columns)
 		for col := 0; col < columns; col++ {
 			index := row*columns + col
 			if index >= len(which.Bindings) {
-				cells = append(cells, strings.Repeat(" ", cellWidth))
+				cells = append(cells, m.popupLineStyle(cellWidth).Render(strings.Repeat(" ", cellWidth)))
 				continue
 			}
-			cells = append(cells, m.renderWhichKeyCell(which.Bindings[index], cellWidth))
+			cells = append(cells, m.renderWhichKeyCell(which.Bindings[index], cellWidth, keyWidth))
 		}
-		lines = append(lines, strings.Join(cells, ""))
+		lines = append(lines, strings.Join(cells, gutter))
 	}
+	lines = append(lines, m.renderWhichKeyFooter(which, inner))
 
 	content := strings.Join(lines, "\n")
-	return lipgloss.NewStyle().Width(contentWidth).Padding(0, 1).Border(lipgloss.RoundedBorder()).BorderForeground(m.palette().PopupBorder()).Background(m.palette().PopupSurface()).Render(content)
+	return lipgloss.NewStyle().Width(contentWidth).Padding(0, 1).Border(lipgloss.NormalBorder()).BorderForeground(m.palette().PopupBorder()).Background(m.palette().PopupSurface()).Render(content)
 }
 
-func (m Model) renderWhichKeyCell(binding protocol.WhichKeyBinding, width int) string {
-	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(m.palette().PopupSelectionText()).Background(m.palette().PopupSelection()).Padding(0, 1)
-	descStyle := lipgloss.NewStyle().Foreground(m.palette().PopupText()).Background(m.palette().PopupSurface())
+func (m Model) renderWhichKeyHeader(which protocol.WhichKey, width int) string {
+	p := m.palette()
+	label := lipgloss.NewStyle().Foreground(p.PopupMutedText()).Background(p.PopupChrome()).Render(" Keys ")
+	prefix := which.Prefix
+	if prefix == "" {
+		prefix = "root"
+	}
+	prefixText := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(p.PopupChrome()).Render(prefix)
+	pager := ""
+	if which.PageCount > 1 {
+		pager = fmt.Sprintf("%d/%d ", which.Page+1, which.PageCount)
+	}
+	pagerText := lipgloss.NewStyle().Foreground(p.PopupMutedText()).Background(p.PopupChrome()).Render(pager)
+	spacer := strings.Repeat(" ", max(width-lipgloss.Width(label)-lipgloss.Width(prefixText)-lipgloss.Width(pagerText), 0))
+	return lipgloss.NewStyle().Background(p.PopupChrome()).Width(width).Render(fitStyled(label+prefixText+spacer+pagerText, width))
+}
+
+func (m Model) renderWhichKeyFooter(which protocol.WhichKey, width int) string {
+	p := m.palette()
+	left := fmt.Sprintf(" %d bindings", len(which.Bindings))
+	right := "Esc close"
+	if which.PageCount > 1 {
+		wideRight := "Tab next  •  Esc close"
+		if lipgloss.Width(left)+lipgloss.Width(wideRight)+4 <= width {
+			right = wideRight
+		} else {
+			right = "Tab next  Esc"
+		}
+	}
+	if lipgloss.Width(left)+lipgloss.Width(right)+2 > width {
+		right = "Esc"
+	}
+	leftText := lipgloss.NewStyle().Foreground(p.PopupMutedText()).Background(p.PopupChrome()).Render(left)
+	rightText := lipgloss.NewStyle().Foreground(p.PopupMutedText()).Background(p.PopupChrome()).Render(right)
+	spacer := strings.Repeat(" ", max(width-lipgloss.Width(leftText)-lipgloss.Width(rightText), 0))
+	return lipgloss.NewStyle().Background(p.PopupChrome()).Width(width).Render(fitStyled(leftText+spacer+rightText, width))
+}
+
+func (m Model) renderWhichKeyCell(binding protocol.WhichKeyBinding, width int, keyWidth int) string {
+	p := m.palette()
+	group := whichKeyGroup(binding)
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(p.KeycapText()).Background(p.KeycapSurface()).Width(keyWidth).Align(lipgloss.Center)
+	descStyle := lipgloss.NewStyle().Foreground(p.PopupText()).Background(p.PopupSurface())
+	iconBackground := p.PopupSurface()
+	if group {
+		keyStyle = lipgloss.NewStyle().Foreground(p.PopupMutedText()).Background(p.PopupSurface()).Width(keyWidth).Align(lipgloss.Center)
+		descStyle = lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(p.PopupSurface())
+	}
 	key := strings.TrimSpace(binding.Key)
 	icon := whichKeyIcon(binding)
 	iconText := icon.glyph
-	if icon.color != "" {
-		iconText = lipgloss.NewStyle().Foreground(lipgloss.Color(icon.color)).Background(m.palette().PopupSurface()).Render(icon.glyph)
+	if icon.color != "" && !group {
+		iconText = lipgloss.NewStyle().Foreground(lipgloss.Color(icon.color)).Background(iconBackground).Render(icon.glyph)
+	} else if group {
+		iconText = lipgloss.NewStyle().Foreground(p.PopupMutedText()).Background(iconBackground).Render("›")
 	}
 	label := strings.TrimSpace(iconText + " " + binding.Description)
-	keyPart := keyStyle.Render(key)
+	if group && !strings.HasSuffix(label, "›") {
+		label += " ›"
+	}
+	keyPart := keyStyle.Render(fit(key, keyWidth))
 	remaining := max(width-lipgloss.Width(keyPart)-1, 0)
 	cell := keyPart
 	if remaining > 0 {
 		cell += " " + descStyle.Render(fit(label, remaining))
 	}
-	return lipgloss.NewStyle().Background(m.palette().PopupSurface()).Width(width).Render(fitStyled(cell, width))
+	return lipgloss.NewStyle().Background(p.PopupSurface()).Width(width).Render(fitStyled(cell, width))
 }
 
-func (m Model) whichKeyColumns(width int) int {
+func whichKeyGroup(binding protocol.WhichKeyBinding) bool {
+	return strings.HasPrefix(strings.TrimSpace(binding.Description), "+")
+}
+
+func whichKeyKeyWidth(bindings []protocol.WhichKeyBinding) int {
+	width := 3
+	for _, binding := range bindings {
+		width = max(width, lipgloss.Width(strings.TrimSpace(binding.Key)))
+	}
+	return min(max(width, 3), 6)
+}
+
+func (m Model) whichKeyColumnGutter() string {
+	return lipgloss.NewStyle().Foreground(m.palette().PopupBorder()).Background(m.palette().PopupSurface()).Render("  │  ")
+}
+
+func (m Model) whichKeyColumns(width int, count int) int {
 	switch {
-	case width >= 96:
-		return 4
-	case width >= 64:
+	case width >= 72 && count >= 9:
 		return 3
-	case width >= 36:
+	case width >= 42 && count >= 4:
 		return 2
 	default:
 		return 1
@@ -96,5 +157,5 @@ func (m Model) whichKeyWidth() int {
 	if m.width <= 24 {
 		return max(m.width, 1)
 	}
-	return min(max(m.width*2/3, 42), max(m.width-4, 1))
+	return min(max(m.width/2, 48), min(96, max(m.width-4, 1)))
 }

--- a/lib/minga/logger_handler.ex
+++ b/lib/minga/logger_handler.ex
@@ -9,8 +9,7 @@ defmodule Minga.LoggerHandler do
      (writes to `~/.local/share/minga/minga.log`)
   2. Adds a custom handler that forwards messages to the `*Messages*` buffer
      via `Minga.Events` broadcasts
-  3. Redirects the `:standard_error` IO device to the same log file so that
-     raw BEAM warnings (e.g. `IO.warn/2`) don't corrupt the TUI either
+  3. Redirects the `:standard_io` and `:standard_error` IO devices to the same log file so that raw Mix output, `IO.puts/2`, and raw BEAM warnings don't corrupt the TUI either
 
   ## Crash recovery
 
@@ -22,7 +21,7 @@ defmodule Minga.LoggerHandler do
 
   ## Installation
 
-  Called from the Editor's `init/1` after the `*Messages*` buffer is ready:
+  Called before standalone TUI app start and again from the Editor's `init/1` after the `*Messages*` buffer is ready:
 
       Minga.LoggerHandler.install()
 
@@ -81,7 +80,7 @@ defmodule Minga.LoggerHandler do
   end
 
   @doc """
-  Install the file handler and stderr redirect for TUI mode.
+  Install the file handler and stdio redirects for TUI mode.
 
   Idempotent: skips any handler or redirect that is already in place.
   Safe to call on every Editor init, including restarts after a crash
@@ -96,6 +95,7 @@ defmodule Minga.LoggerHandler do
   def install do
     log_path = Path.join(@log_dir, @log_file)
     File.mkdir_p!(@log_dir)
+    ensure_buffer_table()
 
     # 1. Replace the default handler with a file-based one.
     #    Idempotent: skip if already installed (Editor restarting after a
@@ -112,10 +112,14 @@ defmodule Minga.LoggerHandler do
     # 2. Add our custom handler that sends to *Messages*.
     install_messages_handler()
 
-    # 3. Redirect :standard_error to the log file so IO.warn and raw BEAM
-    #    warnings don't paint over the TUI. We open a unicode-mode file device
-    #    and register it as :standard_error (the OTP IO protocol convention).
+    # 3. Redirect :standard_io and :standard_error to the log file so Mix output,
+    #    IO.puts, IO.warn, and raw BEAM warnings don't paint over the TUI. We open
+    #    unicode-mode file devices and register them using the OTP IO names.
     #    Idempotent: skip if already redirected.
+    unless stdout_redirected?() do
+      redirect_standard_io(log_path)
+    end
+
     unless stderr_redirected?() do
       redirect_standard_error(log_path)
     end
@@ -128,6 +132,7 @@ defmodule Minga.LoggerHandler do
   def uninstall do
     :logger.remove_handler(@handler_id)
     :logger.remove_handler(@file_handler_id)
+    restore_standard_io()
     restore_standard_error()
 
     # Re-add the stock console handler
@@ -250,41 +255,58 @@ defmodule Minga.LoggerHandler do
     end
   end
 
-  # ── stderr redirect ────────────────────────────────────────────────────────
+  # ── stdio redirects ───────────────────────────────────────────────────────
+
+  @spec redirect_standard_io(String.t()) :: :ok
+  defp redirect_standard_io(log_path) do
+    redirect_registered_io(:standard_io, :minga_original_stdout, :minga_stdout_file, log_path)
+  end
 
   @spec redirect_standard_error(String.t()) :: :ok
   defp redirect_standard_error(log_path) do
-    # Stash the original device so we can restore it later.
-    case Process.whereis(:standard_error) do
+    redirect_registered_io(:standard_error, :minga_original_stderr, :minga_stderr_file, log_path)
+  end
+
+  @spec redirect_registered_io(atom(), atom(), atom(), String.t()) :: :ok
+  defp redirect_registered_io(device_name, original_key, file_key, log_path) do
+    case Process.whereis(device_name) do
       nil ->
         :ok
 
       original ->
-        :persistent_term.put(:minga_original_stderr, original)
+        :persistent_term.put(original_key, original)
         {:ok, file} = File.open(log_path, [:append, :utf8])
-        :persistent_term.put(:minga_stderr_file, file)
+        :persistent_term.put(file_key, file)
 
-        # Swap the registered name. Any process writing to :standard_error
-        # (including IO.warn) will now hit our file device instead.
-        Process.unregister(:standard_error)
-        Process.register(file, :standard_error)
+        Process.unregister(device_name)
+        Process.register(file, device_name)
     end
 
     :ok
   end
 
+  @spec restore_standard_io() :: :ok
+  defp restore_standard_io do
+    restore_registered_io(:standard_io, :minga_original_stdout, :minga_stdout_file)
+  end
+
   @spec restore_standard_error() :: :ok
   defp restore_standard_error do
-    try do
-      original = :persistent_term.get(:minga_original_stderr)
-      file = :persistent_term.get(:minga_stderr_file)
+    restore_registered_io(:standard_error, :minga_original_stderr, :minga_stderr_file)
+  end
 
-      Process.unregister(:standard_error)
-      Process.register(original, :standard_error)
+  @spec restore_registered_io(atom(), atom(), atom()) :: :ok
+  defp restore_registered_io(device_name, original_key, file_key) do
+    try do
+      original = :persistent_term.get(original_key)
+      file = :persistent_term.get(file_key)
+
+      Process.unregister(device_name)
+      Process.register(original, device_name)
       File.close(file)
 
-      :persistent_term.erase(:minga_original_stderr)
-      :persistent_term.erase(:minga_stderr_file)
+      :persistent_term.erase(original_key)
+      :persistent_term.erase(file_key)
     rescue
       ArgumentError -> :ok
     end
@@ -312,6 +334,11 @@ defmodule Minga.LoggerHandler do
   @spec handler_installed?(atom()) :: boolean()
   defp handler_installed?(handler_id) do
     match?({:ok, _}, :logger.get_handler_config(handler_id))
+  end
+
+  @spec stdout_redirected?() :: boolean()
+  defp stdout_redirected? do
+    :persistent_term.get(:minga_original_stdout, nil) != nil
   end
 
   @spec stderr_redirected?() :: boolean()

--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -996,10 +996,22 @@ defmodule Minga.LSP.Client do
 
   @spec spawn_server(String.t(), [String.t()], String.t()) :: port()
   defp spawn_server(executable, args, root_path) do
+    stderr_path = child_stderr_log_path()
+
     Port.open(
-      {:spawn_executable, String.to_charlist(executable)},
+      {:spawn_executable, ~c"/bin/sh"},
       [
-        {:args, Enum.map(args, &String.to_charlist/1)},
+        {:args,
+         Enum.map(
+           [
+             "-c",
+             "log_path=$1; shift; exec \"$@\" 2>> \"$log_path\"",
+             "minga-lsp-wrapper",
+             stderr_path,
+             executable | args
+           ],
+           &String.to_charlist/1
+         )},
         {:cd, String.to_charlist(root_path)},
         {:env, []},
         :binary,
@@ -1008,6 +1020,13 @@ defmodule Minga.LSP.Client do
         :stream
       ]
     )
+  end
+
+  @spec child_stderr_log_path() :: String.t()
+  defp child_stderr_log_path do
+    log_dir = Path.expand("~/.local/share/minga")
+    File.mkdir_p!(log_dir)
+    Path.join(log_dir, "minga.log")
   end
 
   @spec find_executable(Minga.LSP.ServerConfig.t()) ::

--- a/lib/minga_editor/commands/buffer_management/frontend.ex
+++ b/lib/minga_editor/commands/buffer_management/frontend.ex
@@ -2,8 +2,7 @@ defmodule MingaEditor.Commands.BufferManagement.Frontend do
   @moduledoc """
   Behaviour for GUI/TUI variant dispatch of buffer management commands.
 
-  Commands that show messages or warnings use the bottom panel on GUI
-  and gap buffers in popup windows on TUI.
+  Commands that show messages or warnings use the bottom panel on GUI and TUI.
   """
 
   alias MingaEditor.State, as: EditorState

--- a/lib/minga_editor/commands/buffer_management/tui.ex
+++ b/lib/minga_editor/commands/buffer_management/tui.ex
@@ -1,26 +1,22 @@
 defmodule MingaEditor.Commands.BufferManagement.TUI do
-  @moduledoc "TUI variant of buffer management commands. Opens gap buffers in windows."
+  @moduledoc "TUI variant of buffer management commands. Uses the bottom message tray."
 
   @behaviour MingaEditor.Commands.BufferManagement.Frontend
 
-  alias MingaEditor.Commands.BufferManagement
+  alias MingaEditor.BottomPanel
   alias MingaEditor.State, as: EditorState
 
   @impl true
   @spec view_messages(EditorState.t()) :: EditorState.t()
   def view_messages(state) do
-    case Minga.Log.MessagesBuffer.pid() do
-      nil -> EditorState.set_status(state, "No messages buffer")
-      pid -> BufferManagement.open_special_buffer(state, "*Messages*", pid)
-    end
+    new_panel = BottomPanel.show(EditorState.bottom_panel(state), :messages)
+    EditorState.set_bottom_panel(state, new_panel)
   end
 
   @impl true
   @spec view_warnings(EditorState.t()) :: EditorState.t()
   def view_warnings(state) do
-    case Minga.Log.MessagesBuffer.pid() do
-      nil -> EditorState.set_status(state, "No messages buffer")
-      pid -> BufferManagement.open_special_buffer(state, "*Messages*", pid)
-    end
+    new_panel = BottomPanel.show(EditorState.bottom_panel(state), :messages, :warnings)
+    EditorState.set_bottom_panel(state, new_panel)
   end
 end

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -141,7 +141,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       if is_active do
         not Minga.Editing.minibuffer_mode?(state)
       else
-        true
+        false
       end
 
     # Selection in display coordinates

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -329,10 +329,13 @@ defmodule MingaEditor.RenderPipeline.Input do
         } = input
       ) do
     case Map.fetch(windows, id) do
-      {:ok, window} ->
+      {:ok, %{buffer: ^buf} = window} ->
         cursor = Minga.Buffer.cursor(buf)
         new_map = Map.put(windows, id, %{window | cursor: cursor})
         %{input | workspace: %{ws | windows: %{ws.windows | map: new_map}}}
+
+      {:ok, _window} ->
+        input
 
       :error ->
         input

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -2019,7 +2019,7 @@ defmodule MingaEditor.State do
         } = state
       ) do
     case Map.fetch(windows, id) do
-      {:ok, window} ->
+      {:ok, %{buffer: ^buf} = window} ->
         cursor = Buffer.cursor(buf)
 
         %{
@@ -2029,6 +2029,9 @@ defmodule MingaEditor.State do
               | windows: %{ws | map: Map.put(windows, id, %{window | cursor: cursor})}
             }
         }
+
+      {:ok, _window} ->
+        state
 
       :error ->
         state
@@ -2179,8 +2182,27 @@ defmodule MingaEditor.State do
 
     state
     |> set_workspace(SessionState.restore_tab_context(state.workspace, context))
+    |> sync_file_tab_active_window_buffer()
     |> sync_agent_ui_from_active_workspace()
   end
+
+  @spec sync_file_tab_active_window_buffer(t()) :: t()
+  defp sync_file_tab_active_window_buffer(%__MODULE__{} = state) do
+    case tab_bar(state) do
+      %TabBar{} = tb ->
+        sync_file_tab_active_window_buffer(state, TabBar.active(tb))
+
+      nil ->
+        state
+    end
+  end
+
+  @spec sync_file_tab_active_window_buffer(t(), Tab.t() | nil) :: t()
+  defp sync_file_tab_active_window_buffer(%__MODULE__{} = state, %Tab{kind: :file}) do
+    sync_active_window_buffer(state)
+  end
+
+  defp sync_file_tab_active_window_buffer(%__MODULE__{} = state, _tab), do: state
 
   # Builds a typed context for a brand-new tab, using agent-shaped defaults for agent tabs.
   @spec build_empty_tab_defaults(t()) :: Tab.context()

--- a/lib/mix/tasks/minga.ex
+++ b/lib/mix/tasks/minga.ex
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.Minga do
       Application.put_env(:minga, :backend, :gui)
     end
 
-    install_protocol_stdio_guard()
+    install_protocol_stdio_guard(gui?, headless?, terminal_command?, help_args?(args))
     Mix.Task.run("app.start")
     Minga.CLI.main(remaining_args)
 
@@ -70,10 +70,17 @@ defmodule Mix.Tasks.Minga do
     "--help" in args or "-h" in args
   end
 
-  @spec install_protocol_stdio_guard() :: :ok
-  defp install_protocol_stdio_guard do
-    if System.get_env("MINGA_PORT_MODE") == "connected" do
-      Minga.LoggerHandler.install()
+  @spec install_protocol_stdio_guard(boolean(), boolean(), boolean(), boolean()) :: :ok
+  defp install_protocol_stdio_guard(gui?, headless?, terminal_command?, help?) do
+    cond do
+      System.get_env("MINGA_PORT_MODE") == "connected" ->
+        Minga.LoggerHandler.install()
+
+      not gui? and not headless? and not terminal_command? and not help? ->
+        Minga.LoggerHandler.install()
+
+      true ->
+        :ok
     end
 
     :ok

--- a/test/minga/lsp/client_test.exs
+++ b/test/minga/lsp/client_test.exs
@@ -51,6 +51,28 @@ defmodule Minga.LSP.ClientTest do
       assert Client.encoding(client) == :utf8
       assert Client.server_name(client) == :mock_lsp
     end
+
+    test "server stderr output does not break stdio protocol", %{diag_server: diag_server} do
+      root_path = Path.join(System.tmp_dir!(), "stderr_lsp_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(root_path)
+      Minga.Events.subscribe(:lsp_status_changed)
+
+      client =
+        start_supervised!(
+          Supervisor.child_spec(
+            {Client,
+             server_config: MockLSPServer.server_config(stderr_banner: true),
+             root_path: root_path,
+             diagnostics: diag_server},
+            id: :stderr_lsp_client
+          )
+        )
+
+      wait_until_ready(client)
+
+      assert Client.status(client) == :ready
+      assert Client.server_name(client) == :mock_lsp
+    end
   end
 
   describe "document sync" do

--- a/test/minga_editor/commands/buffer_management_frontend_test.exs
+++ b/test/minga_editor/commands/buffer_management_frontend_test.exs
@@ -44,18 +44,20 @@ defmodule MingaEditor.Commands.BufferManagement.FrontendTest do
   end
 
   describe "TUI.view_messages/1" do
-    test "resolves live singleton" do
+    test "opens bottom panel on messages tab" do
       state = BufTUI.view_messages(base_state())
-      assert Minga.Log.MessagesBuffer.pid() != nil
-      refute state.shell_state.status_msg == "No messages buffer"
+      assert state.shell_state.bottom_panel.visible == true
+      assert state.shell_state.bottom_panel.active_tab == :messages
+      assert state.shell_state.bottom_panel.filter == nil
     end
   end
 
   describe "TUI.view_warnings/1" do
-    test "resolves live singleton" do
+    test "opens bottom panel with warnings filter" do
       state = BufTUI.view_warnings(base_state())
-      assert Minga.Log.MessagesBuffer.pid() != nil
-      refute state.shell_state.status_msg == "No messages buffer"
+      assert state.shell_state.bottom_panel.visible == true
+      assert state.shell_state.bottom_panel.active_tab == :messages
+      assert state.shell_state.bottom_panel.filter == :warnings
     end
   end
 end

--- a/test/minga_editor/messages_buffer_test.exs
+++ b/test/minga_editor/messages_buffer_test.exs
@@ -7,31 +7,27 @@ defmodule MingaEditor.MessagesBufferTest do
 
   use Minga.Test.EditorCase, async: true
 
-  alias Minga.Buffer
-
   defp unique_tag(prefix) do
     "msgtest-#{prefix}-#{System.unique_integer([:positive])}"
   end
 
-  describe "*Messages* buffer popup" do
-    test "SPC b m opens a read-only messages popup and toggles it closed" do
+  describe "Messages tray" do
+    test "SPC b m opens the bottom messages tray without replacing the active buffer" do
       ctx = start_editor("hello")
+      active_before = active_window_buffer(ctx)
 
       send_keys_sync(ctx, "<SPC>bm")
-      assert Buffer.buffer_name(active_window_buffer(ctx)) == "*Messages*"
-      assert Buffer.read_only?(active_window_buffer(ctx))
 
-      send_keys_sync(ctx, "<SPC>bm")
-      refute Buffer.buffer_name(active_window_buffer(ctx)) == "*Messages*"
+      assert %{visible: true, active_tab: :messages, filter: nil} = bottom_panel(ctx)
+      assert active_window_buffer(ctx) == active_before
     end
 
-    test "insert mode is blocked in the read-only messages buffer" do
+    test "messages tray does not block normal editor input" do
       ctx = start_editor("hello")
       send_keys_sync(ctx, "<SPC>bm")
       send_keys_sync(ctx, "i")
 
-      assert editor_mode(ctx) == :normal
-      assert status_msg(ctx) =~ "read-only"
+      assert editor_mode(ctx) == :insert
     end
   end
 
@@ -47,7 +43,7 @@ defmodule MingaEditor.MessagesBufferTest do
 
       assert Minga.Log.messages_buffer() == pid_before
       assert Process.alive?(pid_before)
-      assert Buffer.buffer_name(pid_before) == "*Messages*"
+      assert Minga.Buffer.buffer_name(pid_before) == "*Messages*"
     end
   end
 
@@ -70,4 +66,6 @@ defmodule MingaEditor.MessagesBufferTest do
              end)
     end
   end
+
+  defp bottom_panel(ctx), do: editor_state(ctx).shell_state.bottom_panel
 end

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -121,6 +121,27 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       assert Enum.any?(divider_regions, &(&1.rect == {0, 39, 1, 23}))
     end
 
+    test "inactive GUI windows hide their cursor" do
+      state = gui_state(content: "left\nright")
+      buffer = state.workspace.buffers.active
+      {:ok, tree} = WindowTree.split(state.workspace.windows.tree, 1, :vertical, 2)
+      second = EditorWindow.new(2, buffer, 24, 80)
+
+      windows = %Windows{
+        state.workspace.windows
+        | tree: tree,
+          map: Map.put(state.workspace.windows.map, 2, second),
+          next_id: 3
+      }
+
+      state = %{state | workspace: %{state.workspace | windows: windows}}
+
+      {[left, right], _cursor, _state} = build_content(state)
+
+      assert left.window_model.cursor_visible == true
+      assert right.window_model.cursor_visible == false
+    end
+
     test "ordinary buffer edits change row hashes without bumping content epoch or forcing refresh" do
       state = gui_state(content: "hello")
       {[wf], _cursor, state} = build_content(state)

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -3,7 +3,9 @@ defmodule MingaEditor.RenderPipeline.InputTest do
 
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.TestHelpers
+  alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
 
   setup do
     state = TestHelpers.base_state()
@@ -252,6 +254,23 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       win_id = synced.workspace.windows.active
       window = Map.get(synced.workspace.windows.map, win_id)
       assert window.cursor == {1, 0}
+    end
+
+    test "does not copy the active buffer cursor into a window showing another buffer", %{
+      state: state
+    } do
+      original_window = Map.fetch!(state.workspace.windows.map, state.workspace.windows.active)
+      original_cursor = original_window.cursor
+      {:ok, other_buf} = BufferProcess.start_link(content: "other buffer")
+      :ok = Minga.Buffer.move_to(other_buf, {0, 5})
+
+      state = put_in(state.workspace.buffers, Buffers.add(state.workspace.buffers, other_buf))
+      input = Input.from_editor_state(state)
+      synced = Input.sync_active_window_cursor(input)
+
+      window = Map.fetch!(synced.workspace.windows.map, synced.workspace.windows.active)
+      assert window.buffer == original_window.buffer
+      assert window.cursor == original_cursor
     end
 
     test "no-op when no active buffer", %{state: state} do

--- a/test/minga_editor/state_test.exs
+++ b/test/minga_editor/state_test.exs
@@ -106,6 +106,41 @@ defmodule MingaEditor.StateTest do
       assert EditorState.focus_window(new_state(), 2) == new_state()
       assert EditorState.sync_active_window_cursor(new_state()) == new_state()
     end
+
+    test "sync_active_window_cursor does not write active buffer cursor into another buffer window" do
+      {state, files_buf} = state_with_buffer("files")
+      file_buf = start_buffer("typed text")
+      BufferProcess.move_to(file_buf, {0, 5})
+
+      state = put_in(state.workspace.buffers, Buffers.add(state.workspace.buffers, file_buf))
+      synced = EditorState.sync_active_window_cursor(state)
+
+      assert active_window(synced).buffer == files_buf
+      assert active_window(synced).cursor == active_window(state).cursor
+    end
+  end
+
+  describe "tab context restore" do
+    test "file tab restore syncs the active window back to the restored active buffer" do
+      {state, files_buf} = state_with_buffer("files")
+      file_buf = start_buffer("typed text")
+      buffers = %Buffers{list: [files_buf, file_buf], active: file_buf, active_index: 1}
+      windows = state.workspace.windows
+      files_window = Window.new(1, files_buf, 24, 80)
+
+      context =
+        %{state.workspace | buffers: buffers, windows: %{windows | map: %{1 => files_window}}}
+        |> SessionState.to_tab_context()
+
+      tab = Tab.new_file(1, "[new 1]") |> Tab.set_context(context)
+      state = EditorState.set_tab_bar(state, TabBar.new(tab))
+
+      restored = EditorState.restore_tab_context(state, context)
+
+      assert restored.workspace.buffers.active == file_buf
+      assert active_window(restored).buffer == file_buf
+      assert Content.buffer_pid(active_window(restored).content) == file_buf
+    end
   end
 
   describe "window content synchronization" do

--- a/test/minga_editor/warnings_buffer_test.exs
+++ b/test/minga_editor/warnings_buffer_test.exs
@@ -3,7 +3,6 @@ defmodule MingaEditor.WarningsBufferTest do
 
   alias MingaEditor.BottomPanel
   alias MingaEditor.Frontend.Capabilities
-  alias Minga.Buffer
 
   describe "warnings in native GUI" do
     test "SPC b W opens the warnings bottom panel" do
@@ -31,7 +30,7 @@ defmodule MingaEditor.WarningsBufferTest do
   end
 
   describe "warnings in TUI" do
-    test "warnings are stored and SPC b W opens the Messages buffer fallback" do
+    test "warnings are stored and SPC b W opens the warning-filtered messages tray" do
       ctx = start_editor("hello")
 
       broadcast_warning(ctx, "something broke")
@@ -45,7 +44,7 @@ defmodule MingaEditor.WarningsBufferTest do
 
       send_keys_sync(ctx, "<SPC>bW")
 
-      assert Buffer.buffer_name(active_window_buffer(ctx)) == "*Messages*"
+      assert %{visible: true, active_tab: :messages, filter: :warnings} = bottom_panel(ctx)
     end
   end
 

--- a/test/support/mock_lsp_server.ex
+++ b/test/support/mock_lsp_server.ex
@@ -25,7 +25,10 @@ defmodule Minga.Test.MockLSPServer do
 
   @typedoc "Options for the mock server config."
   @type server_config_opt ::
-          {:request_configuration, boolean()} | {:request_unknown, boolean()} | {:settings, map()}
+          {:request_configuration, boolean()}
+          | {:request_unknown, boolean()}
+          | {:stderr_banner, boolean()}
+          | {:settings, map()}
 
   @doc """
   Returns a ServerConfig struct suitable for `LSP.Client.start_link/1`.
@@ -37,7 +40,8 @@ defmodule Minga.Test.MockLSPServer do
     request_args =
       [
         {Keyword.get(opts, :request_configuration, false), "--request-configuration"},
-        {Keyword.get(opts, :request_unknown, false), "--request-unknown"}
+        {Keyword.get(opts, :request_unknown, false), "--request-unknown"},
+        {Keyword.get(opts, :stderr_banner, false), "--stderr-banner"}
       ]
       |> Enum.flat_map(fn
         {true, arg} -> [arg]

--- a/test/support/mock_lsp_server_script.exs
+++ b/test/support/mock_lsp_server_script.exs
@@ -19,6 +19,7 @@ defmodule MockServer do
     # of the parent port doesn't produce noisy :epipe errors.
     :io.setopts(:standard_io, binary: true, encoding: :latin1)
     Logger.configure(level: :none)
+    if stderr_banner?(), do: IO.puts(:standard_error, "mock lsp stderr banner")
     loop("")
   end
 
@@ -195,6 +196,10 @@ defmodule MockServer do
 
   defp request_unknown? do
     "--request-unknown" in System.argv()
+  end
+
+  defp stderr_banner? do
+    "--stderr-banner" in System.argv()
   end
 
   defp send_test_diagnostic(uri, code, message) do


### PR DESCRIPTION
# TL;DR
Fixes Go TUI chrome and startup-output bugs: scrolling over the bottom Messages panel now scrolls message history instead of the editor, tabs now render predictably and can be clicked, and raw startup/LSP stderr no longer corrupts the terminal frame.

## Context
This came from startup sessions where the Messages panel auto-opened because an extension compilation warning was present. The panel was visible, but wheel input over it still scrolled the main editor content. Follow-up screenshots showed long tab labels making the Go TUI tab row look odd, inert tab clicks, and raw startup output such as `direnv`/LSP/compiler messages painting over the active TUI frame.

## Changes
- Add local bottom panel scrollback state in the Go TUI and consume wheel events when the pointer is over the bottom panel.
- Render the bottom Messages panel from the current scrollback window, defaulting to the latest entries.
- Clamp or reset bottom panel scrollback when new panel payloads arrive so stale offsets cannot point past available messages.
- Cap long Go TUI tab labels so one filename does not dominate the tab row.
- Add tab hit zones and encode `select_tab` GUI actions from left-clicks.
- Redirect standalone TUI launcher stdout/stderr to `~/.local/share/minga/minga.log` so Mix/compiler/extension output cannot corrupt the terminal frame.
- Install the TUI stdio guard before `mix minga` app startup and redirect both `:standard_io` and `:standard_error` to the Minga log in TUI mode.
- Redirect LSP child stderr to the Minga log while preserving stdout for JSON-RPC.
- Add regression tests for bottom panel wheel routing, scrollback clamp/reset behavior, tab click routing, long tab label truncation, and LSP stderr noise during startup.

## Verification
- `git diff --check` passed.
- `bash -n bin/minga` passed.
- `mix test.debug test/minga/lsp/client_test.exs test/minga/logger_handler_test.exs` passed, 18 tests.
- `cd go/tui && go test ./internal/ui` passed, 64 tests.
- `cd go/tui && go test ./...` passed, 169 tests across 6 packages.
- LSP diagnostics on touched Go files found no diagnostics. ElixirLS was unavailable in this worktree for LSP diagnostics, so focused compile/test validation covered the Elixir changes.
- Parent-orchestrated review loop round 1 found no blockers; one test coverage improvement was applied and revalidated.
