### PR TITLE
Use portable SIG.UNBLOCK in the libvaxis TUI signal setup

### DIFF
--- a/zig/src/apprt/tui.zig
+++ b/zig/src/apprt/tui.zig
@@ -1040,8 +1040,11 @@ fn installSignalHandlers() void {
         std.posix.sigaddset(&unblock_set, std.posix.SIG.WINCH);
         std.posix.sigaddset(&unblock_set, std.posix.SIG.TERM);
         std.posix.sigaddset(&unblock_set, std.posix.SIG.INT);
-        const SIG_UNBLOCK = 2;
-        std.posix.sigprocmask(SIG_UNBLOCK, &unblock_set, null);
+        // SIG.UNBLOCK is 1 on x86_64 Linux but 2 on macOS/BSD. Hardcoding 2
+        // means SIG_SETMASK on Linux, which would *set* the mask to block
+        // exactly these signals instead of unblocking them, so SIGWINCH would
+        // still never reach the handler. Use the portable constant.
+        std.posix.sigprocmask(std.posix.SIG.UNBLOCK, &unblock_set, null);
     }
 
     const mask = switch (builtin.os.tag) {


### PR DESCRIPTION
## What

`installSignalHandlers` in `src/apprt/tui.zig` hardcoded `const SIG_UNBLOCK = 2` to unblock SIGWINCH/SIGTERM/SIGINT. On x86_64 Linux `SIG_UNBLOCK` is `1` and `2` is `SIG_SETMASK`, so the call **set** the process mask to block exactly those three signals instead of unblocking them — the opposite of the documented intent ("Without this, SIGWINCH never reaches our handler and the editor never learns about terminal resizes"). The symptom was masked because resize is also detected through the polling path.

Fix: use `std.posix.SIG.UNBLOCK`, which resolves to the correct value on every target (1 on x86_64 Linux, 2 on macOS/BSD).

## Why now

Found while reviewing the ZigZag runtime PR (#2198), whose new `zigzag_tui.zig` had copied the same `SIG_UNBLOCK = 2` mistake (fixed there too). This fixes the original libvaxis runtime on `main`.

## Test

- `zig build` (release renderer) — compiles; `installSignalHandlers` is on the active render path.
- `zig build test` — passes.
- `zig fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)