### PR TITLE
test(editor): update messages tray expectations

### DIFF
--- a/test/minga_editor/messages_buffer_test.exs
+++ b/test/minga_editor/messages_buffer_test.exs
@@ -7,31 +7,27 @@ defmodule MingaEditor.MessagesBufferTest do
 
   use Minga.Test.EditorCase, async: true
 
-  alias Minga.Buffer
-
   defp unique_tag(prefix) do
     "msgtest-#{prefix}-#{System.unique_integer([:positive])}"
   end
 
-  describe "*Messages* buffer popup" do
-    test "SPC b m opens a read-only messages popup and toggles it closed" do
+  describe "Messages tray" do
+    test "SPC b m opens the bottom messages tray without replacing the active buffer" do
       ctx = start_editor("hello")
+      active_before = active_window_buffer(ctx)
 
       send_keys_sync(ctx, "<SPC>bm")
-      assert Buffer.buffer_name(active_window_buffer(ctx)) == "*Messages*"
-      assert Buffer.read_only?(active_window_buffer(ctx))
 
-      send_keys_sync(ctx, "<SPC>bm")
-      refute Buffer.buffer_name(active_window_buffer(ctx)) == "*Messages*"
+      assert %{visible: true, active_tab: :messages, filter: nil} = bottom_panel(ctx)
+      assert active_window_buffer(ctx) == active_before
     end
 
-    test "insert mode is blocked in the read-only messages buffer" do
+    test "messages tray does not block normal editor input" do
       ctx = start_editor("hello")
       send_keys_sync(ctx, "<SPC>bm")
       send_keys_sync(ctx, "i")
 
-      assert editor_mode(ctx) == :normal
-      assert status_msg(ctx) =~ "read-only"
+      assert editor_mode(ctx) == :insert
     end
   end
 
@@ -47,7 +43,7 @@ defmodule MingaEditor.MessagesBufferTest do
 
       assert Minga.Log.messages_buffer() == pid_before
       assert Process.alive?(pid_before)
-      assert Buffer.buffer_name(pid_before) == "*Messages*"
+      assert Minga.Buffer.buffer_name(pid_before) == "*Messages*"
     end
   end
 
@@ -70,4 +66,6 @@ defmodule MingaEditor.MessagesBufferTest do
              end)
     end
   end
+
+  defp bottom_panel(ctx), do: editor_state(ctx).shell_state.bottom_panel
 end

--- a/test/minga_editor/warnings_buffer_test.exs
+++ b/test/minga_editor/warnings_buffer_test.exs
@@ -3,7 +3,6 @@ defmodule MingaEditor.WarningsBufferTest do
 
   alias MingaEditor.BottomPanel
   alias MingaEditor.Frontend.Capabilities
-  alias Minga.Buffer
 
   describe "warnings in native GUI" do
     test "SPC b W opens the warnings bottom panel" do
@@ -31,7 +30,7 @@ defmodule MingaEditor.WarningsBufferTest do
   end
 
   describe "warnings in TUI" do
-    test "warnings are stored and SPC b W opens the Messages buffer fallback" do
+    test "warnings are stored and SPC b W opens the warning-filtered messages tray" do
       ctx = start_editor("hello")
 
       broadcast_warning(ctx, "something broke")
@@ -45,7 +44,7 @@ defmodule MingaEditor.WarningsBufferTest do
 
       send_keys_sync(ctx, "<SPC>bW")
 
-      assert Buffer.buffer_name(active_window_buffer(ctx)) == "*Messages*"
+      assert %{visible: true, active_tab: :messages, filter: :warnings} = bottom_panel(ctx)
     end
   end
 


### PR DESCRIPTION
## Summary

- Updates stale messages-buffer smoke tests for the new TUI bottom-tray behavior from #2201.
- Verifies `SPC b m` opens the bottom messages tray without replacing the active buffer.
- Verifies `SPC b W` opens the warning-filtered messages tray in TUI.

## Validation

- `mix test.debug test/minga_editor/messages_buffer_test.exs test/minga_editor/warnings_buffer_test.exs` → 7 passed
- `mix compile --warnings-as-errors` → passed
- `git diff --check` → passed

Note: I also ran the CI Elixir command locally: `mix test --warnings-as-errors --exclude system_clipboard --exclude conformance`. It got past the original 3 failures from the CI log, then failed on unrelated parser/hook tests because this local worktree does not have generated Zig helper binaries (`minga-parser`, `minga-hook-runner`).
