### PR TITLE
Fix two flaky CI tests

### DIFF
--- a/test/minga/buffer/interval_tree_test.exs
+++ b/test/minga/buffer/interval_tree_test.exs
@@ -44,8 +44,14 @@ defmodule Minga.Core.IntervalTreeTest do
     end
   end
 
-  defp interval_list_gen(max_count, max_line, max_col) do
-    gen all(intervals <- list_of(interval_gen(max_line, max_col), max_length: max_count)) do
+  defp interval_list_gen(max_count, max_line, max_col, min_count \\ 0) do
+    gen all(
+          intervals <-
+            list_of(interval_gen(max_line, max_col),
+              min_length: min_count,
+              max_length: max_count
+            )
+        ) do
       intervals
     end
   end
@@ -487,7 +493,7 @@ defmodule Minga.Core.IntervalTreeTest do
     end
 
     property "delete removes exactly the targeted interval" do
-      check all(intervals <- interval_list_gen(20, 50, 20), intervals != []) do
+      check all(intervals <- interval_list_gen(20, 50, 20, 1)) do
         tree = IntervalTree.from_list(intervals)
         target = Enum.random(intervals)
 

--- a/test/minga_agent/hooks/command_runner_test.exs
+++ b/test/minga_agent/hooks/command_runner_test.exs
@@ -83,7 +83,11 @@ defmodule MingaAgent.Hooks.CommandRunnerTest do
     assert stderr =~ "tick-"
     assert stderr =~ "timed out after 100ms"
     assert stderr =~ "killed"
-    assert elapsed_ms < 500
+    # The 100ms hook timeout must be enforced promptly. Allow generous slack
+    # over that timeout for kill/cleanup and CI scheduling jitter; the
+    # @tag timeout: 2_000 above is the real guard against the timeout never
+    # firing. A tight bound here (was 500ms) flaked on contended runners.
+    assert elapsed_ms < 1_000
   end
 
   @tag timeout: 2_000


### PR DESCRIPTION
## What

main's CI has been intermittently red on **Test (Elixir)** from two unrelated flaky tests. This fixes both.

### 1. `IntervalTree` "delete removes exactly the targeted interval" (`StreamData.FilterTooNarrowError`)

The property filtered its generator with `intervals != []`. At small StreamData generation sizes `list_of` frequently yields `[]`, so too many consecutive values were filtered out and the run aborted (seed-dependent). Fixed per StreamData's own guidance: generate non-empty lists directly. `interval_list_gen` now takes an optional `min_count`, and the delete property requests `min_count: 1` and drops the filter.

Verified across seeds 0, 1, 42, 29021 (the seed that failed CI), 99999.

### 2. `CommandRunner` "times out by wall clock even when hook keeps writing stderr"

Asserted `elapsed_ms < 500` against a 100ms hook timeout. A contended runner took 544ms on the kill/cleanup path and failed. The `@tag timeout: 2_000` is the real guard against the timeout never firing, so the bound is loosened to `1_000ms` (still 10× the configured timeout) to absorb CI scheduling jitter.

Verified by running the test 5× across seeds.

## Why now

Both flakes surfaced on the `#2207` (Rust TUI removal) merge run and the PR run before it. Neither is related to that change; they're pre-existing timing/generator flakes. Landing them as a focused PR so main goes green and stays reliable.

## Validation

- `interval_tree_test.exs` across seeds 0/1/42/29021/99999 — all pass, no `FilterTooNarrowError`
- `command_runner_test.exs:67` run 5× — all pass
- Both files together — 54 passed