### PR TITLE
Re-color syntax highlights when the editor theme changes

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -987,7 +987,8 @@ defmodule MingaEditor do
           ])
         end
 
-        %{state | theme: theme}
+        state
+        |> EditorState.apply_theme(theme)
         |> EditorState.invalidate_all_windows()
         |> Layout.invalidate()
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -453,6 +453,20 @@ defmodule MingaEditor.State do
     update_workspace(state, fn workspace -> SessionState.update_highlight(workspace, fun) end)
   end
 
+  @doc """
+  Switches the active editor theme and re-colors existing syntax highlights.
+
+  Sets `state.theme` and rebuilds each buffer's highlight `face_registry`
+  from the new theme so tree-sitter colors update immediately. Buffers with
+  a syntax override keep their custom palette.
+  """
+  @spec apply_theme(t(), Theme.t()) :: t()
+  def apply_theme(%__MODULE__{} = state, %Theme{} = theme) do
+    state
+    |> Map.put(:theme, theme)
+    |> update_highlight(&Highlighting.retheme_all(&1, theme))
+  end
+
   @doc "Replaces the active workspace editing state."
   @spec set_editing(t(), VimState.t()) :: t()
   def set_editing(%__MODULE__{} = state, %VimState{} = editing) do

--- a/lib/minga_editor/state/highlighting.ex
+++ b/lib/minga_editor/state/highlighting.ex
@@ -56,6 +56,27 @@ defmodule MingaEditor.State.Highlighting do
     %{state | highlights: highlights}
   end
 
+  @doc """
+  Rebuilds every buffer's highlight face registry from a new theme.
+
+  Buffers with a stored `syntax_overrides` entry (e.g. the agent buffer's
+  dimmed delimiters) keep their custom, theme-independent palette and are
+  left untouched.
+  """
+  @spec retheme_all(t(), MingaEditor.UI.Theme.t()) :: t()
+  def retheme_all(%__MODULE__{highlights: highlights, syntax_overrides: overrides} = state, theme) do
+    rethemed =
+      Map.new(highlights, fn {pid, hl} ->
+        if Map.has_key?(overrides, pid) do
+          {pid, hl}
+        else
+          {pid, Highlight.retheme(hl, theme)}
+        end
+      end)
+
+    %{state | highlights: rethemed}
+  end
+
   @doc "Removes all highlight-related state for a buffer."
   @spec remove_buffer(t(), pid(), non_neg_integer(), %{pid() => non_neg_integer()}) :: t()
   def remove_buffer(%__MODULE__{} = state, buffer_pid, buffer_id, remaining_ids) do

--- a/lib/minga_editor/ui/highlight.ex
+++ b/lib/minga_editor/ui/highlight.ex
@@ -72,6 +72,19 @@ defmodule MingaEditor.UI.Highlight do
     }
   end
 
+  @doc """
+  Rebuilds the theme and face registry from a new `MingaEditor.UI.Theme.t()`.
+
+  Preserves the parsed `spans`, `version`, and `capture_names` (which are
+  theme-independent) while swapping the color mapping. Used when the editor
+  theme changes so existing tree-sitter highlights re-render with the new
+  palette instead of the stale one baked into the old `face_registry`.
+  """
+  @spec retheme(t(), MingaEditor.UI.Theme.t()) :: t()
+  def retheme(%__MODULE__{} = hl, %MingaEditor.UI.Theme{} = theme) do
+    %{hl | theme: theme.syntax, face_registry: FaceRegistry.from_theme(theme)}
+  end
+
   @doc "Stores capture names from a `highlight_names` event."
   @spec put_names(t(), [String.t()]) :: t()
   def put_names(%__MODULE__{} = hl, names) when is_list(names) do

--- a/lib/minga_editor/ui/picker/theme_source.ex
+++ b/lib/minga_editor/ui/picker/theme_source.ex
@@ -54,17 +54,13 @@ defmodule MingaEditor.UI.Picker.ThemeSource do
   # ── Private ─────────────────────────────────────────────────────────────────
 
   @spec put_theme(term(), Theme.t()) :: term()
-  defp put_theme(state, %Theme{} = theme) do
+  defp put_theme(%EditorState{} = state, %Theme{} = theme) do
     state
-    |> Map.put(:theme, theme)
-    |> reset_frontend_render_state()
+    |> EditorState.apply_theme(theme)
+    |> EditorState.reset_frontend_render_state()
   end
 
-  @spec reset_frontend_render_state(term()) :: term()
-  defp reset_frontend_render_state(%EditorState{} = state),
-    do: EditorState.reset_frontend_render_state(state)
-
-  defp reset_frontend_render_state(state), do: state
+  defp put_theme(state, %Theme{} = theme), do: Map.put(state, :theme, theme)
 
   @spec display_name(atom()) :: String.t()
   defp display_name(name) do

--- a/test/minga_editor/state/highlighting_test.exs
+++ b/test/minga_editor/state/highlighting_test.exs
@@ -1,0 +1,36 @@
+defmodule MingaEditor.State.HighlightingTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.State.Highlighting
+  alias MingaEditor.UI.Face.Registry
+  alias MingaEditor.UI.Highlight
+  alias MingaEditor.UI.Theme
+
+  describe "retheme_all/2" do
+    test "rebuilds normal buffers from the new theme but leaves override buffers untouched" do
+      normal_pid = self()
+      override_pid = spawn(fn -> :ok end)
+
+      override_syntax = %{"keyword" => [fg: 0x123456]}
+
+      state =
+        %Highlighting{}
+        |> Highlighting.put_highlight(normal_pid, Highlight.from_theme(Theme.get!(:doom_one)))
+        |> Highlighting.put_highlight(override_pid, Highlight.new(override_syntax))
+        |> Highlighting.set_syntax_overrides(%{override_pid => override_syntax})
+
+      one_light = Theme.get!(:one_light)
+      rethemed = Highlighting.retheme_all(state, one_light)
+
+      # Normal buffer picks up the new theme's palette.
+      normal_hl = rethemed.highlights[normal_pid]
+      assert normal_hl.theme == one_light.syntax
+
+      # Override buffer keeps its custom, theme-independent palette.
+      override_hl = rethemed.highlights[override_pid]
+      assert override_hl.theme == override_syntax
+
+      assert Registry.style_for(override_hl.face_registry, "keyword").fg == 0x123456
+    end
+  end
+end

--- a/test/minga_editor/ui/highlight_test.exs
+++ b/test/minga_editor/ui/highlight_test.exs
@@ -409,5 +409,31 @@ defmodule Minga.HighlightTest do
     end
   end
 
+  describe "retheme/2" do
+    test "swaps colors to the new theme while preserving spans, version, and capture names" do
+      spans = [%{start_byte: 0, end_byte: 7, capture_id: 0}]
+
+      hl =
+        Highlight.from_theme(MingaEditor.UI.Theme.get!(:doom_one))
+        |> Highlight.put_names(["keyword"])
+        |> Highlight.put_spans(3, spans)
+
+      before_fg = MingaEditor.UI.Face.Registry.style_for(hl.face_registry, "keyword").fg
+
+      one_light = MingaEditor.UI.Theme.get!(:one_light)
+      rethemed = Highlight.retheme(hl, one_light)
+
+      # Parse results are theme-independent and survive the swap.
+      assert rethemed.version == 3
+      assert rethemed.spans == List.to_tuple(spans)
+      assert rethemed.capture_names == {"keyword"}
+
+      # Colors come from the new theme.
+      assert rethemed.theme == one_light.syntax
+      after_fg = MingaEditor.UI.Face.Registry.style_for(rethemed.face_registry, "keyword").fg
+      assert after_fg != before_fg
+    end
+  end
+
   defp joined_text(result), do: Enum.map_join(result, fn {text, _style} -> text end)
 end


### PR DESCRIPTION
## What

Switching the editor theme now re-colors **existing** syntax highlights immediately. Previously theme changes only updated `state.theme`; open buffers' tree-sitter highlights kept the colors baked into their old `face_registry`, so they stayed on the previous palette until the next reparse.

## How

- **`EditorState.apply_theme/2`** — sets the theme and rebuilds every buffer's highlight `face_registry` from it.
- **`Highlighting.retheme_all/2`** — rethemes each buffer's highlight, preserving buffers with a syntax override (e.g. the agent buffer's dimmed delimiters).
- **`Highlight.retheme/2`** — swaps the palette while keeping theme-independent `spans`, `version`, and `capture_names`.
- Wired `apply_theme` into the `set_theme` path (`minga_editor.ex`) and the theme picker (`theme_source.ex`), replacing ad-hoc `Map.put(:theme, ...)` calls.

## Tests

New coverage in `test/minga_editor/state/highlighting_test.exs` and `test/minga_editor/ui/highlight_test.exs`.

## Validation

- `mix compile --warnings-as-errors` — ok
- `mix format --check-formatted` — ok
- `mix credo --strict` on changed files — clean (only the pre-existing `State` struct-field-count warning)
- Feature tests (12) + picker suite (189) — pass

## Provenance

This work was uncommitted WIP that sat on top of the merged AstroDark theme branch and was recovered from a dropped stash, then rebased onto current `main`. It's a self-contained follow-on to the AstroDark/themed-icon work.