### PR TITLE
fix(tui): handle Linux no-tty sentinel so Go renderer boots

### DIFF
--- a/lib/minga_editor/frontend/manager.ex
+++ b/lib/minga_editor/frontend/manager.ex
@@ -305,11 +305,8 @@ defmodule MingaEditor.Frontend.Manager do
 
   @spec detect_tty() :: String.t() | nil
   defp detect_tty do
-    with {output, 0} <- System.cmd("ps", ["-o", "tty=", "-p", to_string(:os.getpid())]),
-         tty_name = String.trim(output),
-         true <- tty_name != "" and tty_name != "??" do
-      tty_path_for(tty_name)
-    else
+    case System.cmd("ps", ["-o", "tty=", "-p", to_string(:os.getpid())]) do
+      {output, 0} -> tty_path_for(String.trim(output))
       _ -> nil
     end
   end
@@ -324,16 +321,32 @@ defmodule MingaEditor.Frontend.Manager do
 
   Checks if `/dev/{name}` exists first (handles long form and Linux).
   Falls back to `/dev/tty{name}` for short forms.
-  """
-  @spec tty_path_for(String.t()) :: String.t()
-  def tty_path_for(tty_name) do
-    path = "/dev/#{tty_name}"
 
-    if File.exists?(path) do
-      path
+  Returns `nil` when the process has no controlling terminal. `ps -o tty=`
+  reports this as all question marks: `"??"` on macOS, `"?"` on Linux. Without
+  this guard we would build a bogus path like `/dev/tty?`, which the Go renderer
+  cannot open and crashes on. Returning `nil` lets the renderer fall back to
+  `/dev/tty`.
+  """
+  @spec tty_path_for(String.t()) :: String.t() | nil
+  def tty_path_for(tty_name) do
+    if no_controlling_tty?(tty_name) do
+      nil
     else
-      "/dev/tty#{tty_name}"
+      path = "/dev/#{tty_name}"
+
+      if File.exists?(path) do
+        path
+      else
+        "/dev/tty#{tty_name}"
+      end
     end
+  end
+
+  @spec no_controlling_tty?(String.t()) :: boolean()
+  defp no_controlling_tty?(tty_name) do
+    trimmed = String.trim(tty_name)
+    trimmed == "" or trimmed == String.duplicate("?", String.length(trimmed))
   end
 
   @spec log_renderer_message(String.t(), String.t()) :: :ok

--- a/test/minga_editor/frontend/tty_detection_test.exs
+++ b/test/minga_editor/frontend/tty_detection_test.exs
@@ -48,5 +48,22 @@ defmodule MingaEditor.Frontend.TtyDetectionTest do
       # A name that definitely won't have a matching /dev/ entry
       assert Manager.tty_path_for("z999") == "/dev/ttyz999"
     end
+
+    test "returns nil for the Linux no-controlling-tty sentinel" do
+      # `ps -o tty=` reports a bare "?" on Linux when there is no controlling
+      # terminal. Building "/dev/tty?" crashes the Go renderer, so we must
+      # return nil and let it fall back to /dev/tty.
+      assert Manager.tty_path_for("?") == nil
+    end
+
+    test "returns nil for the macOS no-controlling-tty sentinel" do
+      # macOS reports "??" in the same situation.
+      assert Manager.tty_path_for("??") == nil
+    end
+
+    test "returns nil for an empty name" do
+      assert Manager.tty_path_for("") == nil
+      assert Manager.tty_path_for("   ") == nil
+    end
   end
 end


### PR DESCRIPTION
## Problem

`bin/minga-go` crashes at boot whenever `MINGA_TTY` is not already set. The Go/Charm renderer dies immediately:

```
[GO_TUI/error] open /dev/tty?: no such file or directory
Renderer: crashed (exit 1)
```

## Root cause

The BEAM passes the controlling-terminal device to the renderer via `MINGA_TTY`. When that var isn't pre-set (e.g. `bin/minga`'s `tty` probe reports "not a tty"), `MingaEditor.Frontend.Manager.detect_tty/0` shells out to `ps -o tty=` and builds a `/dev/` path.

The guard only rejected the macOS no-controlling-terminal sentinel `"??"`. On **Linux**, `ps -o tty=` emits a bare `"?"`, which slipped through to `tty_path_for("?")` and produced the bogus path `/dev/tty?`. The Zig renderer tolerated the bad path; the Go renderer hard-crashes on the failed open.

## Fix

- `tty_path_for/1` returns `nil` for any all-question-mark or empty name (`"?"`, `"??"`, `""`). `tty_env/0` already drops `MINGA_TTY` on `nil`, so the renderer falls back to `/dev/tty`, the real controlling-terminal device, instead of a path that can never open.
- `detect_tty/0` delegates the sentinel decision to `tty_path_for/1`, so there's a single source of truth instead of a partial `"??"`-only check.

## Verification

- `mix test test/minga_editor/frontend/tty_detection_test.exs` — 8 passed (added regression cases for `"?"`, `"??"`, empty/whitespace).
- Boot under a real PTY with `MINGA_TTY` unset: `detect_tty` resolves `pts/N` → `/dev/pts/N`, Go renderer boots and runs cleanly.
- Original crash path no longer produces `/dev/tty?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)