### PR TITLE
fix(tui): handle missing status bar in chrome cache

### DIFF
--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -143,7 +143,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
     end
   end
 
-  @spec stable_chrome_fingerprint(state(), Layout.t(), StatusBarData.t()) :: integer()
+  @spec stable_chrome_fingerprint(state(), Layout.t(), StatusBarData.t() | nil) :: integer()
   defp stable_chrome_fingerprint(state, layout, status_bar_data) do
     :erlang.phash2({
       layout.editor_area,
@@ -166,7 +166,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
   end
 
   @spec build_status_bar(state(), Layout.t(), map() | nil) ::
-          {[DisplayList.draw()], StatusBarData.t(),
+          {[DisplayList.draw()], StatusBarData.t() | nil,
            [MingaEditor.Shell.Traditional.Modeline.click_region()]}
   defp build_status_bar(_state, %{status_bar: nil}, _active_scroll) do
     {[], nil, []}
@@ -194,7 +194,8 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
     :exit, _ -> StatusBarData.from_state(state)
   end
 
-  @spec status_bar_dirty?(StatusBarData.t()) :: boolean()
+  @spec status_bar_dirty?(StatusBarData.t() | nil) :: boolean()
+  defp status_bar_dirty?(nil), do: false
   defp status_bar_dirty?({:buffer, %{dirty: dirty}}), do: dirty
   defp status_bar_dirty?({:agent, %{dirty: dirty}}), do: dirty
 

--- a/test/minga_editor/shell/traditional/chrome/tui_test.exs
+++ b/test/minga_editor/shell/traditional/chrome/tui_test.exs
@@ -54,6 +54,17 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUITest do
       assert %Chrome{} = chrome
     end
 
+    test "handles layouts too short for a status bar" do
+      state = base_state(rows: 3)
+      {scrolls, cursor_info, state, layout} = run_through_content(state)
+
+      chrome = ChromeTUI.build(state, layout, scrolls, cursor_info)
+
+      assert %Chrome{} = chrome
+      assert chrome.status_bar_draws == []
+      assert chrome.status_bar_data == nil
+    end
+
     test "tab bar field is a list (TUI renders tab bar)" do
       state = base_state()
       {scrolls, cursor_info, state, layout} = run_through_content(state)


### PR DESCRIPTION
# TL;DR
`bin/minga-go` now renders correctly when the TUI layout omits the status bar, such as tiny or invalid terminal-height startup states. The chrome cache no longer crashes on `nil` status bar data, and the regression is covered by a focused TUI chrome test.

## Context
After the latest `main` pull, `bin/minga-go` could appear not to boot. The Go renderer started, but the BEAM render pipeline dropped frames because `Chrome.TUI` computed no status bar for a very short layout and then called the status-bar dirty helper with `nil` while building the stable chrome fingerprint.

## Changes
- Allow the TUI chrome stable fingerprint to handle `nil` status bar data.
- Update specs for the no-status-bar layout path.
- Add a regression test for a 3-row TUI layout where the status bar is intentionally omitted.

## Verification
- `mix test.llm test/minga_editor/shell/traditional/chrome/tui_test.exs test/minga_editor/frontend/tty_detection_test.exs`
- `mix compile --warnings-as-errors`
- `make lint`
- Manual: launched `bin/minga-go` in the worktree and confirmed with the reporter that the editor boots and renders again.

## Notes
- Full `mix test.llm` still has a pre-existing failure on `main`: `test/minga_editor/integration/gui_protocol_test.exs:909` decodes `"error"` instead of `"gui_file_tree"`. I reproduced the same single-test failure on clean `main`, so it is not caused by this PR.
