### PR TITLE
fix(tui): polish semantic Go UI interactions

### DIFF
--- a/go/tui/internal/ui/input.go
+++ b/go/tui/internal/ui/input.go
@@ -100,7 +100,7 @@ func sgrMouseParts(code int, release bool) (byte, byte, byte) {
 	}
 	button := byte(3)
 	if code&wheelBit != 0 {
-		button = 0x40 + byte(code&0x03)
+		button = wheelButtonByte(code&0x03, code&shiftBit != 0)
 	} else {
 		button = byte(code & 0x03)
 	}
@@ -111,6 +111,18 @@ func sgrMouseParts(code int, release bool) (byte, byte, byte) {
 		eventType = 2
 	}
 	return button, mods, eventType
+}
+
+func wheelButtonByte(bits int, shifted bool) byte {
+	if shifted {
+		switch bits {
+		case 0:
+			return 0x43
+		case 1:
+			return 0x42
+		}
+	}
+	return 0x40 + byte(bits)
 }
 
 func printableTextModifiers(key tea.Key) byte {
@@ -147,9 +159,21 @@ func mousePacket(msg tea.MouseMsg) []byte {
 	case tea.MouseRight:
 		button = 2
 	case tea.MouseWheelUp:
-		button = 0x40
+		if mouse.Mod.Contains(tea.ModShift) {
+			button = 0x43
+		} else {
+			button = 0x40
+		}
 	case tea.MouseWheelDown:
-		button = 0x41
+		if mouse.Mod.Contains(tea.ModShift) {
+			button = 0x42
+		} else {
+			button = 0x41
+		}
+	case tea.MouseWheelRight:
+		button = 0x42
+	case tea.MouseWheelLeft:
+		button = 0x43
 	}
 	switch msg.(type) {
 	case tea.MouseReleaseMsg:

--- a/go/tui/internal/ui/input_test.go
+++ b/go/tui/internal/ui/input_test.go
@@ -71,6 +71,36 @@ func TestKeyPacketParsesFragmentedSGRMouseTail(t *testing.T) {
 	}
 }
 
+func TestMousePacketEncodesHorizontalWheel(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  tea.MouseMsg
+		want byte
+	}{
+		{name: "wheel right", msg: tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelRight}), want: 0x42},
+		{name: "wheel left", msg: tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelLeft}), want: 0x43},
+		{name: "shift wheel down", msg: tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, Mod: tea.ModShift}), want: 0x42},
+		{name: "shift wheel up", msg: tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelUp, Mod: tea.ModShift}), want: 0x43},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			packet := mousePacket(tc.msg)
+			if packet[0] != generated.OPMouseEvent || packet[5] != tc.want {
+				t.Fatalf("mouse packet opcode/button = %#x/%#x, want mouse/%#x", packet[0], packet[5], tc.want)
+			}
+		})
+	}
+}
+
+func TestKeyPacketParsesShiftWheelSGRMouseTailAsHorizontal(t *testing.T) {
+	packet, ok := keyPacket(tea.KeyPressMsg(tea.Key{Code: tea.KeyExtended, Text: "<69;57;23M"}))
+	if !ok {
+		t.Fatal("SGR shift wheel tail should encode a mouse packet")
+	}
+	if packet[5] != 0x42 {
+		t.Fatalf("shift wheel-down should encode wheel-right button, got %#x", packet[5])
+	}
+}
+
 func TestPastePacketEncodesBracketedPasteAsPasteEvent(t *testing.T) {
 	packet := pastePacket(tea.PasteMsg{Content: "hello\nworld"})
 	if packet[0] != generated.OPPasteEvent {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -702,6 +702,25 @@ func TestSemanticWindowsRespectProtocolFileTreeWidth(t *testing.T) {
 	}
 }
 
+func TestSemanticWindowsNormalizeAbsoluteTUILayoutGeometry(t *testing.T) {
+	model := New(90, 8, nil)
+	model.title = "Header"
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Width: 36, Rows: []protocol.FileTreeRow{{ID: "row-0", Name: "row-0"}}}}}
+	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 37, Width: 8, Height: 1}}})
+	model.viewport.SetContent(model.content())
+
+	lines := strings.Split(ansi.Strip(model.View().Content), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("semantic window should render with normalized geometry: %+v", lines)
+	}
+	if got := strings.Index(lines[1], "pane"); got != 37 {
+		t.Fatalf("absolute TUI geometry should not double-count file-tree width, got pane at %d in %q", got, lines[1])
+	}
+	if len(lines) > 2 && strings.Contains(lines[2], "pane") {
+		t.Fatalf("absolute TUI geometry should not double-count header rows: %+v", lines[:3])
+	}
+}
+
 func TestApplyWindowDeltaAppliesScrollLeftSetAndCropsRendering(t *testing.T) {
 	model := New(20, 6, nil)
 	model.putWindow(protocol.WindowContent{ID: 7, ContentEpoch: 9, ScrollLeft: 0, Rows: []protocol.WindowRow{{Text: "abcdef"}}})
@@ -1016,11 +1035,20 @@ func TestSemanticMouseRoutesModelineAndFileTreeZones(t *testing.T) {
 func TestBottomPanelShowsLatestMessagesByDefault(t *testing.T) {
 	model, panel := bottomPanelTestModel(10, nil)
 	visible := model.visibleBottomPanelMessages(panel)
-	if len(visible) != model.bottomPanelVisibleRows() {
-		t.Fatalf("visible message count mismatch: got %d want %d", len(visible), model.bottomPanelVisibleRows())
+	if len(visible) != model.bottomPanelVisibleRows(panel) {
+		t.Fatalf("visible message count mismatch: got %d want %d", len(visible), model.bottomPanelVisibleRows(panel))
 	}
 	if visible[0].Text != "msg-7" || visible[len(visible)-1].Text != "msg-9" {
 		t.Fatalf("bottom panel should start at latest messages, got %+v", visible)
+	}
+}
+
+func TestBottomPanelHeightUsesSemanticPercent(t *testing.T) {
+	model := New(80, 20, nil)
+	panel := protocol.BottomPanel{Visible: true, HeightPercent: 50}
+
+	if got := model.bottomPanelHeight(panel); got != 10 {
+		t.Fatalf("bottom panel height = %d, want semantic 50%% of terminal height", got)
 	}
 }
 

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -134,9 +134,16 @@ func (m Model) semanticWindowPlacement(window protocol.WindowContent) (semanticW
 	}, true
 }
 
-// Protocol window geometry is relative to the semantic editor surface. Bubble Tea adds TUI chrome around that surface after semantic content is composed.
+// Protocol window geometry may arrive as absolute TUI geometry from the BEAM layout. Bubble Tea composes header rows and left chrome around the body after semantic content is rendered, so subtract any visible chrome offsets when the protocol coordinates include them. Body-relative geometry stays unchanged.
 func (m Model) normalizeSemanticGeometry(row int, col int) (int, int) {
-	return row, col
+	rowOffset, colOffset := m.semanticContentOffsets()
+	if rowOffset > 0 {
+		row -= min(row, rowOffset)
+	}
+	if colOffset > 0 && col >= colOffset {
+		col -= colOffset
+	}
+	return max(row, 0), max(col, 0)
 }
 
 // Protocol chrome geometry is absolute terminal geometry, so split separators are normalized into Bubble Tea's body canvas.

--- a/go/tui/internal/ui/render_surfaces.go
+++ b/go/tui/internal/ui/render_surfaces.go
@@ -142,7 +142,7 @@ func (m Model) renderBottomPanel(panel protocol.BottomPanel) []string {
 	}
 	messages := m.visibleBottomPanelMessages(panel)
 	width := max(m.width, 1)
-	height := m.maxOverlayHeight()
+	height := m.bottomPanelHeight(panel)
 	p := m.palette()
 	headerLeft := fmt.Sprintf(" %s", title)
 	headerRight := fmt.Sprintf("%d messages", len(panel.Messages))
@@ -212,7 +212,7 @@ func bottomPanelLevelColor(p palette, level byte) color.Color {
 }
 
 func (m Model) visibleBottomPanelMessages(panel protocol.BottomPanel) []protocol.PanelMessage {
-	visibleRows := m.bottomPanelVisibleRows()
+	visibleRows := m.bottomPanelVisibleRows(panel)
 	if len(panel.Messages) <= visibleRows {
 		return panel.Messages
 	}
@@ -221,8 +221,18 @@ func (m Model) visibleBottomPanelMessages(panel protocol.BottomPanel) []protocol
 	return panel.Messages[start:end]
 }
 
-func (m Model) bottomPanelVisibleRows() int {
-	return max(m.maxOverlayHeight()-1, 1)
+func (m Model) bottomPanelVisibleRows(panel protocol.BottomPanel) int {
+	return max(m.bottomPanelHeight(panel)-1, 1)
+}
+
+func (m Model) bottomPanelHeight(panel protocol.BottomPanel) int {
+	maxHeight := max(m.height-1, 1)
+	percent := int(panel.HeightPercent)
+	if percent <= 0 {
+		percent = 30
+	}
+	percent = min(max(percent, 1), 100)
+	return min(max(m.height*percent/100, 4), maxHeight)
 }
 
 func (m Model) renderExtensionPanels(ext protocol.ExtensionPanel) []string {

--- a/go/tui/internal/ui/semantic_mouse.go
+++ b/go/tui/internal/ui/semantic_mouse.go
@@ -64,7 +64,7 @@ func (m *Model) clampBottomPanelScrollback(panel protocol.BottomPanel) {
 }
 
 func (m Model) maxBottomPanelScrollback(panel protocol.BottomPanel) int {
-	return max(len(panel.Messages)-m.bottomPanelVisibleRows(), 0)
+	return max(len(panel.Messages)-m.bottomPanelVisibleRows(panel), 0)
 }
 
 func (m Model) semanticMousePacket(msg tea.MouseMsg) ([]byte, bool) {

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -225,7 +225,7 @@ defmodule Minga.Config.Options do
      "Whether Insert mode Enter automatically inserts language-aware block-closing keywords."},
     {:scroll_margin, :non_neg_integer, 5,
      "Minimum number of context lines kept around the cursor while scrolling."},
-    {:scroll_lines, :pos_integer, 1, "Number of lines moved for each wheel-scroll step."},
+    {:scroll_lines, :pos_integer, 3, "Number of lines moved for each wheel-scroll step."},
     {:theme, :theme_atom, :astrodark, "Active color theme."},
     {:indent_with, {:enum, [:spaces, :tabs]}, :spaces,
      "Whether indentation inserts spaces or tab characters."},

--- a/lib/minga_editor/bottom_panel.ex
+++ b/lib/minga_editor/bottom_panel.ex
@@ -29,6 +29,7 @@ defmodule MingaEditor.BottomPanel do
 
   @type t :: %__MODULE__{
           visible: boolean(),
+          focused: boolean(),
           active_tab: tab(),
           tabs: [tab()],
           dismissed: boolean(),
@@ -37,6 +38,7 @@ defmodule MingaEditor.BottomPanel do
         }
 
   defstruct visible: false,
+            focused: false,
             active_tab: :messages,
             tabs: [:messages],
             dismissed: false,
@@ -46,7 +48,7 @@ defmodule MingaEditor.BottomPanel do
   @doc "Toggle panel visibility. Clears dismissed state on explicit open."
   @spec toggle(t()) :: t()
   def toggle(%__MODULE__{visible: true} = panel) do
-    %{panel | visible: false}
+    %{panel | visible: false, focused: false}
   end
 
   def toggle(%__MODULE__{visible: false} = panel) do
@@ -62,14 +64,28 @@ defmodule MingaEditor.BottomPanel do
   @doc "Hide the panel."
   @spec hide(t()) :: t()
   def hide(%__MODULE__{} = panel) do
-    %{panel | visible: false}
+    %{panel | visible: false, focused: false}
   end
 
   @doc "Dismiss the panel (prevents auto-open until explicit open)."
   @spec dismiss(t()) :: t()
   def dismiss(%__MODULE__{} = panel) do
-    %{panel | visible: false, dismissed: true}
+    %{panel | visible: false, focused: false, dismissed: true}
   end
+
+  @doc "Focuses the visible panel. Hidden panels stay unfocused."
+  @spec focus(t()) :: t()
+  def focus(%__MODULE__{visible: true} = panel), do: %{panel | focused: true}
+  def focus(%__MODULE__{} = panel), do: %{panel | focused: false}
+
+  @doc "Clears panel focus without changing visibility."
+  @spec blur(t()) :: t()
+  def blur(%__MODULE__{} = panel), do: %{panel | focused: false}
+
+  @doc "Returns true when the panel is visible and focused."
+  @spec focused?(t()) :: boolean()
+  def focused?(%__MODULE__{visible: true, focused: true}), do: true
+  def focused?(%__MODULE__{}), do: false
 
   @doc "Switch to a tab by index."
   @spec switch_tab(t(), non_neg_integer()) :: t()

--- a/lib/minga_editor/commands/buffer_management/gui.ex
+++ b/lib/minga_editor/commands/buffer_management/gui.ex
@@ -9,14 +9,19 @@ defmodule MingaEditor.Commands.BufferManagement.GUI do
   @impl true
   @spec view_messages(EditorState.t()) :: EditorState.t()
   def view_messages(state) do
-    new_panel = BottomPanel.show(EditorState.bottom_panel(state), :messages)
+    new_panel = state |> EditorState.bottom_panel() |> BottomPanel.show(:messages)
+
     EditorState.set_bottom_panel(state, new_panel)
   end
 
   @impl true
   @spec view_warnings(EditorState.t()) :: EditorState.t()
   def view_warnings(state) do
-    new_panel = BottomPanel.show(EditorState.bottom_panel(state), :messages, :warnings)
+    new_panel =
+      state
+      |> EditorState.bottom_panel()
+      |> BottomPanel.show(:messages, :warnings)
+
     EditorState.set_bottom_panel(state, new_panel)
   end
 end

--- a/lib/minga_editor/commands/buffer_management/tui.ex
+++ b/lib/minga_editor/commands/buffer_management/tui.ex
@@ -9,14 +9,19 @@ defmodule MingaEditor.Commands.BufferManagement.TUI do
   @impl true
   @spec view_messages(EditorState.t()) :: EditorState.t()
   def view_messages(state) do
-    new_panel = BottomPanel.show(EditorState.bottom_panel(state), :messages)
+    new_panel = state |> EditorState.bottom_panel() |> BottomPanel.show(:messages)
+
     EditorState.set_bottom_panel(state, new_panel)
   end
 
   @impl true
   @spec view_warnings(EditorState.t()) :: EditorState.t()
   def view_warnings(state) do
-    new_panel = BottomPanel.show(EditorState.bottom_panel(state), :messages, :warnings)
+    new_panel =
+      state
+      |> EditorState.bottom_panel()
+      |> BottomPanel.show(:messages, :warnings)
+
     EditorState.set_bottom_panel(state, new_panel)
   end
 end

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.Commands.Movement do
   alias Minga.Parser.Manager, as: ParserManager
   alias Minga.Parser.StructuralNavResult
 
+  alias MingaEditor.BottomPanel
   alias MingaEditor.DisplayMap
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.Commands.Helpers
@@ -553,6 +554,18 @@ defmodule MingaEditor.Commands.Movement do
   @spec navigate_window(state(), WindowTree.nav_direction()) :: state()
   defp navigate_window(%{workspace: %{windows: %{tree: nil}}} = state, _direction), do: state
 
+  defp navigate_window(state, :up) do
+    if BottomPanel.focused?(EditorState.bottom_panel(state)) do
+      panel = state |> EditorState.bottom_panel() |> BottomPanel.blur()
+
+      state
+      |> EditorState.set_bottom_panel(panel)
+      |> EditorState.set_keymap_scope(EditorState.scope_for_active_window(state))
+    else
+      navigate_window_to_neighbor(state, :up)
+    end
+  end
+
   # When file tree is focused, navigating right unfocuses the tree
   # and restores the scope based on the active window's content type.
   defp navigate_window(state, :right) do
@@ -583,10 +596,26 @@ defmodule MingaEditor.Commands.Movement do
         EditorState.focus_window(state, neighbor_id)
 
       :error ->
-        # No neighbor in that direction; check if the file tree is there
-        maybe_focus_file_tree(state, direction)
+        # No neighbor in that direction; check if an edge panel is there.
+        maybe_focus_edge_panel(state, direction)
     end
   end
+
+  @spec maybe_focus_edge_panel(state(), :left | :right | :up | :down) :: state()
+  defp maybe_focus_edge_panel(state, :down) do
+    panel = EditorState.bottom_panel(state)
+
+    if panel.visible do
+      state
+      |> EditorState.set_bottom_panel(BottomPanel.focus(panel))
+      |> update_file_tree(&FileTreeState.unfocus/1)
+      |> EditorState.set_keymap_scope(EditorState.scope_for_active_window(state))
+    else
+      state
+    end
+  end
+
+  defp maybe_focus_edge_panel(state, direction), do: maybe_focus_file_tree(state, direction)
 
   @spec maybe_focus_file_tree(state(), :left | :right | :up | :down) :: state()
   defp maybe_focus_file_tree(state, :left) do

--- a/lib/minga_editor/commands/ui/tui.ex
+++ b/lib/minga_editor/commands/ui/tui.ex
@@ -1,19 +1,26 @@
 defmodule MingaEditor.Commands.UI.TUI do
-  @moduledoc "TUI variant of UI commands. Panel commands are no-ops."
+  @moduledoc "TUI variant of UI commands for the Semantic UI bottom panel."
 
   @behaviour MingaEditor.Commands.UI.Frontend
 
+  alias MingaEditor.BottomPanel
   alias MingaEditor.State, as: EditorState
 
   @impl true
   @spec toggle_bottom_panel(EditorState.t()) :: EditorState.t()
-  def toggle_bottom_panel(state), do: state
+  def toggle_bottom_panel(state) do
+    EditorState.set_bottom_panel(state, BottomPanel.toggle(EditorState.bottom_panel(state)))
+  end
 
   @impl true
   @spec bottom_panel_next_tab(EditorState.t()) :: EditorState.t()
-  def bottom_panel_next_tab(state), do: state
+  def bottom_panel_next_tab(state) do
+    EditorState.set_bottom_panel(state, BottomPanel.next_tab(EditorState.bottom_panel(state)))
+  end
 
   @impl true
   @spec bottom_panel_prev_tab(EditorState.t()) :: EditorState.t()
-  def bottom_panel_prev_tab(state), do: state
+  def bottom_panel_prev_tab(state) do
+    EditorState.set_bottom_panel(state, BottomPanel.prev_tab(EditorState.bottom_panel(state)))
+  end
 end

--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.FocusTree do
 
   alias Minga.Buffer
   alias Minga.Editing.Completion
+  alias MingaEditor.BottomPanel
   alias MingaEditor.CompletionUI
   alias MingaEditor.FocusTree.Node, as: TreeNode
   alias MingaEditor.Input
@@ -164,6 +165,7 @@ defmodule MingaEditor.FocusTree do
       |> maybe_add(layout.agent_panel, &agent_panel_node/1)
       |> maybe_add(layout.status_bar, &TreeNode.new(:status_bar, &1, handler: bottom_handler))
       |> Kernel.++([TreeNode.new(:minibuffer, layout.minibuffer, handler: bottom_handler)])
+      |> maybe_add(bottom_panel_rect(layout, state), &bottom_panel_node/1)
 
     %TreeNode{
       id: :viewport,
@@ -174,6 +176,44 @@ defmodule MingaEditor.FocusTree do
       focusable?: false,
       children: children
     }
+  end
+
+  @spec bottom_panel_rect(Layout.t(), map() | nil) :: Layout.rect() | nil
+  defp bottom_panel_rect(_layout, nil), do: nil
+
+  defp bottom_panel_rect(
+         %Layout{terminal: {row, col, width, rows}},
+         %{
+           shell_state: %{
+             bottom_panel: %BottomPanel{visible: true, height_percent: height_percent}
+           }
+         }
+       ) do
+    panel_height = bottom_panel_height(rows, height_percent)
+    {row + rows - panel_height, col, width, panel_height}
+  end
+
+  defp bottom_panel_rect(_layout, _state), do: nil
+
+  @spec bottom_panel_height(non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp bottom_panel_height(rows, height_percent) do
+    max_height = max(rows - 1, 1)
+    percent = height_percent |> max(1) |> min(100)
+
+    rows
+    |> Kernel.*(percent)
+    |> div(100)
+    |> max(4)
+    |> min(max_height)
+  end
+
+  @spec bottom_panel_node(Layout.rect()) :: TreeNode.t()
+  defp bottom_panel_node(rect) do
+    TreeNode.new(:bottom_panel, rect,
+      handler: Input.BottomPanel,
+      scrollable?: true,
+      focusable?: true
+    )
   end
 
   @spec file_tree_node(Layout.rect(), map() | nil) :: TreeNode.t()

--- a/lib/minga_editor/input.ex
+++ b/lib/minga_editor/input.ex
@@ -21,6 +21,7 @@ defmodule MingaEditor.Input do
   alias MingaEditor.Input.AgentMouse
   alias MingaEditor.Input.AgentNav
   alias MingaEditor.Input.AgentPanel
+  alias MingaEditor.Input.BottomPanel
   alias MingaEditor.Input.Completion
   alias MingaEditor.Input.ConflictPrompt
   alias MingaEditor.Input.Dashboard
@@ -63,6 +64,7 @@ defmodule MingaEditor.Input do
     {Scoped, 100},
     {AgentNav, 110},
     {GlobalBindings, 120},
+    {BottomPanel, 125},
     {AgentMouse, 130}
   ]
 
@@ -96,6 +98,7 @@ defmodule MingaEditor.Input do
       Completion,
       Scoped,
       GlobalBindings,
+      BottomPanel,
       ModeFSM
     ]
   end
@@ -233,9 +236,36 @@ defmodule MingaEditor.Input do
   @spec ensure_handler_registry!() :: :ok
   defp ensure_handler_registry! do
     case :persistent_term.get(@handler_registry_key, :missing) do
-      :missing -> seed_builtin_handlers!()
-      _entries -> :ok
+      :missing ->
+        seed_builtin_handlers!()
+
+      entries ->
+        refresh_builtin_handlers!(entries)
     end
+  end
+
+  @spec refresh_builtin_handlers!([handler_entry()]) :: :ok
+  defp refresh_builtin_handlers!(entries) do
+    builtin_modules =
+      MapSet.new(Enum.map(@builtin_surface_handlers, fn {module, _priority} -> module end))
+
+    preserved_entries =
+      Enum.reject(entries, fn {module, source, _meta} ->
+        source == :builtin and MapSet.member?(builtin_modules, module)
+      end)
+
+    builtin_entries =
+      Enum.map(@builtin_surface_handlers, fn {module, priority} ->
+        {module, :builtin, %{phase: :surface, priority: priority}}
+      end)
+
+    refreshed = builtin_entries ++ preserved_entries
+
+    if refreshed != entries do
+      :persistent_term.put(@handler_registry_key, refreshed)
+    end
+
+    :ok
   end
 
   @spec seed_builtin_handlers!() :: :ok

--- a/lib/minga_editor/input/bottom_panel.ex
+++ b/lib/minga_editor/input/bottom_panel.ex
@@ -1,0 +1,119 @@
+defmodule MingaEditor.Input.BottomPanel do
+  @moduledoc """
+  Mouse handler for the Semantic UI bottom panel.
+
+  The bottom panel is not a `WindowTree` leaf, but it is still an interactive surface. Clicking it focuses the panel so window navigation can move into and out of it without routing the click to the underlying editor buffer.
+  """
+
+  @behaviour MingaEditor.Input.Handler
+
+  alias MingaEditor.BottomPanel
+  alias MingaEditor.FocusTree.Node, as: FocusNode
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  @impl true
+  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          MingaEditor.Input.Handler.result()
+  def handle_key(state, codepoint, modifiers) do
+    panel = EditorState.bottom_panel(state)
+
+    if BottomPanel.focused?(panel) do
+      handle_focused_key(state, panel, codepoint, modifiers)
+    else
+      {:passthrough, state}
+    end
+  end
+
+  @spec handle_focused_key(EditorState.t(), BottomPanel.t(), non_neg_integer(), non_neg_integer()) ::
+          MingaEditor.Input.Handler.result()
+  defp handle_focused_key(state, panel, ?q, 0) do
+    if Minga.Editing.active_model(state) == Minga.Editing.Model.Vim and
+         Minga.Editing.mode(state) == :normal do
+      {:handled, close_panel(state, panel)}
+    else
+      {:handled, state}
+    end
+  end
+
+  defp handle_focused_key(state, panel, 27, 0) do
+    if Minga.Editing.active_model(state) == Minga.Editing.Model.CUA do
+      {:handled, close_panel(state, panel)}
+    else
+      {:passthrough, state}
+    end
+  end
+
+  defp handle_focused_key(state, _panel, codepoint, modifiers) do
+    if vim_leader_key?(state, codepoint, modifiers) or
+         MingaEditor.Input.key_sequence_pending?(state) do
+      {:passthrough, state}
+    else
+      {:handled, state}
+    end
+  end
+
+  @spec vim_leader_key?(EditorState.t(), non_neg_integer(), non_neg_integer()) :: boolean()
+  defp vim_leader_key?(state, ?\s, 0) do
+    Minga.Editing.active_model(state) == Minga.Editing.Model.Vim and
+      Minga.Editing.mode(state) == :normal
+  end
+
+  defp vim_leader_key?(_state, _codepoint, _modifiers), do: false
+
+  @spec close_panel(EditorState.t(), BottomPanel.t()) :: EditorState.t()
+  defp close_panel(state, panel) do
+    state
+    |> EditorState.set_bottom_panel(BottomPanel.hide(panel))
+    |> EditorState.set_keymap_scope(EditorState.scope_for_active_window(state))
+  end
+
+  @impl true
+  @spec handle_mouse_at_node(
+          EditorState.t(),
+          FocusNode.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: MingaEditor.Input.Handler.result()
+  def handle_mouse_at_node(
+        state,
+        %FocusNode{content_type: :bottom_panel},
+        _row,
+        _col,
+        :left,
+        _mods,
+        :press,
+        _click_count
+      ) do
+    panel = state |> EditorState.bottom_panel() |> BottomPanel.focus()
+
+    state =
+      state
+      |> EditorState.set_bottom_panel(panel)
+      |> EditorState.update_file_tree(&FileTreeState.unfocus/1)
+      |> EditorState.set_keymap_scope(EditorState.scope_for_active_window(state))
+
+    {:handled, state}
+  end
+
+  def handle_mouse_at_node(
+        state,
+        %FocusNode{content_type: :bottom_panel},
+        _row,
+        _col,
+        _button,
+        _mods,
+        _event_type,
+        _click_count
+      ) do
+    {:handled, state}
+  end
+
+  def handle_mouse_at_node(state, _node, _row, _col, _button, _mods, _event_type, _click_count) do
+    {:passthrough, state}
+  end
+end

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -432,7 +432,7 @@ defmodule MingaEditor.Startup do
   def apply_config_options(state) do
     state =
       try do
-        theme_name = Config.get(:theme)
+        theme_name = Minga.Config.Options.get(EditorState.options_server(state), :theme)
 
         theme =
           case MingaEditor.UI.Theme.get(theme_name) do
@@ -448,7 +448,7 @@ defmodule MingaEditor.Startup do
               MingaEditor.UI.Theme.get!(MingaEditor.UI.Theme.default())
           end
 
-        %{state | theme: theme}
+        EditorState.apply_theme(state, theme)
       catch
         :exit, _ -> state
       end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -2062,8 +2062,9 @@ defmodule MingaEditor.State do
   """
   @spec focus_window(t(), Window.id()) :: t()
   def focus_window(%__MODULE__{workspace: %{windows: %{active: active}}} = state, target_id)
-      when target_id == active,
-      do: state
+      when target_id == active do
+    set_bottom_panel(state, BottomPanel.blur(bottom_panel(state)))
+  end
 
   def focus_window(%__MODULE__{workspace: %{buffers: %{active: nil}}} = state, _target_id),
     do: state
@@ -2087,6 +2088,8 @@ defmodule MingaEditor.State do
         # Agent chat windows use :agent scope; buffer windows use the
         # current scope (preserving :file_tree if the tree is focused).
         scope = scope_for_content(target_win.content, wspace.keymap_scope)
+
+        state = set_bottom_panel(state, BottomPanel.blur(bottom_panel(state)))
 
         %{
           state

--- a/test/minga_editor/bottom_panel_test.exs
+++ b/test/minga_editor/bottom_panel_test.exs
@@ -10,6 +10,7 @@ defmodule MingaEditor.BottomPanelTest do
       assert panel.active_tab == :messages
       assert panel.tabs == [:messages]
       assert panel.dismissed == false
+      assert panel.focused == false
       assert panel.filter == nil
       assert panel.height_percent == 30
     end
@@ -28,6 +29,7 @@ defmodule MingaEditor.BottomPanelTest do
       panel = %BottomPanel{visible: true}
       result = BottomPanel.toggle(panel)
       assert result.visible == false
+      assert result.focused == false
     end
 
     test "clears dismissed state on open" do
@@ -63,6 +65,27 @@ defmodule MingaEditor.BottomPanelTest do
       result = BottomPanel.dismiss(panel)
       assert result.visible == false
       assert result.dismissed == true
+    end
+  end
+
+  describe "focus/1 and blur/1" do
+    test "focuses a visible panel" do
+      panel = %BottomPanel{visible: true}
+      result = BottomPanel.focus(panel)
+      assert BottomPanel.focused?(result)
+    end
+
+    test "does not focus a hidden panel" do
+      panel = %BottomPanel{visible: false}
+      result = BottomPanel.focus(panel)
+      refute BottomPanel.focused?(result)
+    end
+
+    test "blur clears focus without hiding" do
+      panel = %BottomPanel{visible: true, focused: true}
+      result = BottomPanel.blur(panel)
+      assert result.visible == true
+      refute BottomPanel.focused?(result)
     end
   end
 

--- a/test/minga_editor/commands/buffer_management_frontend_test.exs
+++ b/test/minga_editor/commands/buffer_management_frontend_test.exs
@@ -20,11 +20,12 @@ defmodule MingaEditor.Commands.BufferManagement.FrontendTest do
   end
 
   describe "GUI.view_messages/1" do
-    test "opens bottom panel on messages tab" do
+    test "opens bottom panel on messages tab without stealing focus" do
       state = BufGUI.view_messages(base_state())
       assert state.shell_state.bottom_panel.visible == true
       assert state.shell_state.bottom_panel.active_tab == :messages
       assert state.shell_state.bottom_panel.filter == nil
+      assert state.shell_state.bottom_panel.focused == false
     end
 
     test "clears dismissed state" do
@@ -35,29 +36,32 @@ defmodule MingaEditor.Commands.BufferManagement.FrontendTest do
   end
 
   describe "GUI.view_warnings/1" do
-    test "opens bottom panel with warnings filter" do
+    test "opens bottom panel with warnings filter without stealing focus" do
       state = BufGUI.view_warnings(base_state())
       assert state.shell_state.bottom_panel.visible == true
       assert state.shell_state.bottom_panel.active_tab == :messages
       assert state.shell_state.bottom_panel.filter == :warnings
+      assert state.shell_state.bottom_panel.focused == false
     end
   end
 
   describe "TUI.view_messages/1" do
-    test "opens bottom panel on messages tab" do
+    test "opens bottom panel on messages tab without stealing focus" do
       state = BufTUI.view_messages(base_state())
       assert state.shell_state.bottom_panel.visible == true
       assert state.shell_state.bottom_panel.active_tab == :messages
       assert state.shell_state.bottom_panel.filter == nil
+      assert state.shell_state.bottom_panel.focused == false
     end
   end
 
   describe "TUI.view_warnings/1" do
-    test "opens bottom panel with warnings filter" do
+    test "opens bottom panel with warnings filter without stealing focus" do
       state = BufTUI.view_warnings(base_state())
       assert state.shell_state.bottom_panel.visible == true
       assert state.shell_state.bottom_panel.active_tab == :messages
       assert state.shell_state.bottom_panel.filter == :warnings
+      assert state.shell_state.bottom_panel.focused == false
     end
   end
 end

--- a/test/minga_editor/commands/ui_frontend_test.exs
+++ b/test/minga_editor/commands/ui_frontend_test.exs
@@ -111,20 +111,32 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
     end
   end
 
-  describe "TUI variants are no-ops" do
-    test "toggle_bottom_panel returns state unchanged" do
-      state = base_state()
-      assert UITUI.toggle_bottom_panel(state) == state
+  describe "TUI bottom panel commands" do
+    test "toggle_bottom_panel opens panel when hidden" do
+      state = UITUI.toggle_bottom_panel(base_state())
+      assert state.shell_state.bottom_panel.visible == true
     end
 
-    test "bottom_panel_next_tab returns state unchanged" do
-      state = base_state()
-      assert UITUI.bottom_panel_next_tab(state) == state
+    test "bottom_panel_next_tab cycles to next tab" do
+      state =
+        MingaEditor.State.set_bottom_panel(
+          base_state(),
+          %BottomPanel{tabs: [:messages, :diagnostics], active_tab: :messages}
+        )
+
+      state = UITUI.bottom_panel_next_tab(state)
+      assert state.shell_state.bottom_panel.active_tab == :diagnostics
     end
 
-    test "bottom_panel_prev_tab returns state unchanged" do
-      state = base_state()
-      assert UITUI.bottom_panel_prev_tab(state) == state
+    test "bottom_panel_prev_tab cycles to previous tab" do
+      state =
+        MingaEditor.State.set_bottom_panel(
+          base_state(),
+          %BottomPanel{tabs: [:messages, :diagnostics], active_tab: :diagnostics}
+        )
+
+      state = UITUI.bottom_panel_prev_tab(state)
+      assert state.shell_state.bottom_panel.active_tab == :messages
     end
   end
 end

--- a/test/minga_editor/commands/window_test.exs
+++ b/test/minga_editor/commands/window_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Commands.WindowTest do
   use ExUnit.Case, async: false
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.BottomPanel
   alias Minga.Config.Options
   alias MingaEditor
   alias MingaEditor.Commands.Movement
@@ -146,6 +147,26 @@ defmodule MingaEditor.Commands.WindowTest do
 
       result = Movement.execute(state, :window_left)
 
+      assert result.workspace.windows.active == state.workspace.windows.active
+    end
+
+    test "window_down focuses visible bottom panel when no lower window exists" do
+      {state, _buffer} = start_command_state()
+      state = EditorState.set_bottom_panel(state, %BottomPanel{visible: true})
+
+      result = Movement.execute(state, :window_down)
+
+      assert BottomPanel.focused?(result.shell_state.bottom_panel)
+      assert result.workspace.windows.active == state.workspace.windows.active
+    end
+
+    test "window_up returns from focused bottom panel to active editor window" do
+      {state, _buffer} = start_command_state()
+      state = EditorState.set_bottom_panel(state, %BottomPanel{visible: true, focused: true})
+
+      result = Movement.execute(state, :window_up)
+
+      refute BottomPanel.focused?(result.shell_state.bottom_panel)
       assert result.workspace.windows.active == state.workspace.windows.active
     end
   end

--- a/test/minga_editor/focus_tree_test.exs
+++ b/test/minga_editor/focus_tree_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.FocusTreeTest do
 
   use ExUnit.Case, async: true
 
+  alias MingaEditor.BottomPanel
   alias MingaEditor.FocusTree
   alias MingaEditor.FocusTree.Node, as: TreeNode
   alias MingaEditor.Layout
@@ -229,6 +230,23 @@ defmodule MingaEditor.FocusTreeTest do
       rendered_height = Enum.max(rendered_rows) - Enum.min(rendered_rows) + 1
 
       assert elem(picker_node.rect, 3) == rendered_height
+    end
+  end
+
+  describe "bottom panel" do
+    test "visible bottom panel is a focusable frontmost hit target" do
+      state = %MingaEditor.State{
+        port_manager: self(),
+        workspace: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()},
+        layout: single_window_layout(),
+        shell_state: %ShellState{bottom_panel: %BottomPanel{visible: true, height_percent: 25}}
+      }
+
+      tree = FocusTree.from_state(state)
+      hit = FocusTree.hit_test(tree, 20, 10)
+
+      assert hit.content_type == :bottom_panel
+      assert hit.focusable?
     end
   end
 

--- a/test/minga_editor/input/router_test.exs
+++ b/test/minga_editor/input/router_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Input.RouterTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Test.InputRouterMouseProbe
+  alias MingaEditor.BottomPanel
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.FocusTree
   alias MingaEditor.FocusTree.Node, as: FocusNode
@@ -79,6 +80,25 @@ defmodule MingaEditor.Input.RouterTest do
           handler: InputRouterMouseProbe,
           ref: :tree,
           scrollable?: true
+        )
+      ]
+    })
+  end
+
+  defp bottom_panel_tree do
+    FocusTree.link_tree(%FocusNode{
+      id: :viewport,
+      content_type: :viewport,
+      rect: {0, 0, 20, 10},
+      children: [
+        FocusNode.new(:buffer_content, {0, 0, 20, 10},
+          handler: InputRouterMouseProbe,
+          ref: :editor
+        ),
+        FocusNode.new(:bottom_panel, {7, 0, 20, 3},
+          handler: MingaEditor.Input.BottomPanel,
+          scrollable?: true,
+          focusable?: true
         )
       ]
     })
@@ -178,6 +198,39 @@ defmodule MingaEditor.Input.RouterTest do
       cursor = BufferProcess.cursor(state.workspace.buffers.active)
       assert elem(cursor, 0) == 0
     end
+
+    test "focused bottom panel handles Vim normal q" do
+      state =
+        EditorState.set_bottom_panel(base_state(), %BottomPanel{visible: true, focused: true})
+
+      new_state = Router.dispatch(state, ?q, 0)
+
+      refute new_state.shell_state.bottom_panel.visible
+    end
+
+    test "focused bottom panel handles CUA Escape" do
+      state = %{
+        EditorState.set_bottom_panel(base_state(), %BottomPanel{visible: true, focused: true})
+        | editing_model: :cua
+      }
+
+      new_state = Router.dispatch(state, 27, 0)
+
+      refute new_state.shell_state.bottom_panel.visible
+    end
+
+    test "focused bottom panel consumes CUA q without closing or editing the buffer" do
+      state = %{
+        EditorState.set_bottom_panel(base_state(), %BottomPanel{visible: true, focused: true})
+        | editing_model: :cua
+      }
+
+      before_content = BufferProcess.content(state.workspace.buffers.active)
+      new_state = Router.dispatch(state, ?q, 0)
+
+      assert new_state.shell_state.bottom_panel.visible
+      assert BufferProcess.content(new_state.workspace.buffers.active) == before_content
+    end
   end
 
   describe "dispatch_mouse/7" do
@@ -205,6 +258,16 @@ defmodule MingaEditor.Input.RouterTest do
       _state = Router.dispatch_mouse(state, 3, 3, :wheel_down, 0, :press, 1)
 
       assert_receive {:mouse_probe, :file_tree, :tree}
+      refute_receive {:mouse_probe, :buffer_content, :editor}, 20
+    end
+
+    test "clicking the bottom panel focuses it instead of the underlying editor" do
+      state = %{base_state() | focus_tree: bottom_panel_tree()}
+      state = EditorState.set_bottom_panel(state, %BottomPanel{visible: true})
+
+      new_state = Router.dispatch_mouse(state, 8, 10, :left, 0, :press, 1)
+
+      assert BottomPanel.focused?(new_state.shell_state.bottom_panel)
       refute_receive {:mouse_probe, :buffer_content, :editor}, 20
     end
 

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -33,8 +33,8 @@ defmodule MingaEditor.MouseTest do
       {state, buffer} = start_mouse_state(lines(0..29))
 
       state = mouse(state, 0, 0, :wheel_down, :press)
-      assert BufferProcess.cursor(buffer) == {4, 0}
-      assert active_viewport(state).top == 1
+      assert BufferProcess.cursor(buffer) == {6, 0}
+      assert active_viewport(state).top == 3
 
       BufferProcess.move_to(buffer, {5, 0})
       state = mouse(state, 0, 0, :wheel_up, :press)

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -295,6 +295,28 @@ defmodule MingaEditor.StartupTest do
       ShellRegistry.seed_builtin()
     end
 
+    test "apply_config_options uses the editor options server for the initial theme" do
+      editor_options = start_supervised!({Options, name: nil}, id: :editor_theme_options)
+      other_options = start_supervised!({Options, name: nil}, id: :other_theme_options)
+      {:ok, :doom_one} = Options.set(editor_options, :theme, :doom_one)
+      {:ok, :one_light} = Options.set(other_options, :theme, :one_light)
+      Process.put(:minga_config_options, other_options)
+
+      state =
+        Startup.build_initial_state(
+          backend: :headless,
+          port_manager: nil,
+          parser_manager: nil,
+          options_server: editor_options,
+          width: 80,
+          height: 24
+        )
+
+      assert Startup.apply_config_options(state).theme.name == :doom_one
+    after
+      Process.delete(:minga_config_options)
+    end
+
     test "normalizes nil and supplied options servers" do
       default_state =
         Startup.build_initial_state(


### PR DESCRIPTION
# TL;DR
Polishes the Go TUI semantic UI path so startup theme, geometry, scrolling, and bottom-panel interaction behave consistently. The Messages bottom panel is now a focusable surface, Go TUI wheel behavior follows Charm/Bubbles viewport conventions, and the configured default theme applies on startup.

## Context
This fixes several `bin/minga-go` regressions in the Semantic UI path: source/file-tree spacing looked wrong, the open `*Messages*` bottom panel could not be focused or closed like a pane, trackpad/wheel behavior differed across surfaces, and the default `:astrodark` theme only appeared after toggling themes manually.

## Changes
- Normalize Go TUI semantic window geometry when BEAM sends absolute TUI layout coordinates, avoiding doubled header/file-tree offsets.
- Make the bottom panel a first-class focus target with mouse focus, window navigation integration, and mode-aware key handling.
- Route explicit Messages/bottom-panel commands through `BottomPanel`, including TUI tab commands that were no-ops.
- Use `BottomPanel.hide/1` for focused Vim `q`, preserving warning auto-open semantics that `dismiss/1` would suppress.
- Align terminal wheel behavior with Bubbles viewport defaults by using 3 lines per wheel step and supporting horizontal wheel plus Shift+wheel horizontal mapping.
- Apply the configured theme from the editor's own options server during startup, so `bin/minga-go` starts with `:astrodark` instead of fallback colors.
- Refresh static built-in input handlers without dropping dynamic built-ins such as FileTree.

## Verification
- `mix test.llm test/minga_editor/bottom_panel_test.exs test/minga_editor/commands/buffer_management_frontend_test.exs test/minga_editor/commands/ui_frontend_test.exs test/minga_editor/focus_tree_test.exs test/minga_editor/input/router_test.exs test/minga_editor/commands/window_test.exs test/minga_editor/mouse_test.exs test/minga/config/options_test.exs test/minga_editor/input/agent_mouse_test.exs test/minga_editor/integration/mouse_test.exs test/minga_editor/startup_test.exs test/minga_editor/state/options_server_threading_test.exs` (206 tests, 0 failures)
- `cd go/tui && go test ./...` (188 passed)
- `mix compile --warnings-as-errors`
- `mix native.build.go_tui`

## Manual checks for reviewers
1. Launch `bin/minga-go` and confirm the initial colors match the configured/default `:astrodark` theme without opening the theme picker.
2. Open `*Messages*`, click the bottom panel, and confirm it receives focus.
3. In Vim mode, press `q` while the bottom panel is focused and confirm the panel closes.
4. In CUA mode, press `Esc` while the bottom panel is focused and confirm the panel closes, while ordinary `q` does not insert into the editor buffer.
5. Scroll with a trackpad or wheel over editor content, file tree, and bottom panel and confirm the step size feels consistent.