### PR TITLE
docs: record the semantic-surface freeze policy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -856,6 +856,22 @@ Do **not** add new shared chrome through `ProtocolGUI.encode_gui_*`, `Minga.Rend
 
 When adding chrome data (diagnostic counts, indent info, selection size, etc.), design the semantic model fields first, extend the wire format in `docs/PROTOCOL.md` / `docs/GUI_PROTOCOL.md`, update the adapter encoder and `gui_protocol_test.exs`, then ensure each frontend that should display it decodes and renders the new fields. The cell-painted zig TUI modeline (`Chrome.TUI`) consumes the same model through the TUI adapter. Cross-frontend coverage (macOS SwiftUI, Charm/Go TUI) is tracked in the Semantic UI inventory (#2113); forgetting to update a frontend is a common mistake.
 
+### Semantic-surface freeze (in effect)
+
+The semantic UI protocol surface is frozen while the frontend remediation epics are in flight. Until [#2216](https://github.com/jsmestad/minga/issues/2216) (Go-only TUI), [#2218](https://github.com/jsmestad/minga/issues/2218) (semantic-only paradigm), and [#2219](https://github.com/jsmestad/minga/issues/2219) (transactional, layout-authoritative, fully generated protocol) are complete, do not add:
+
+- new semantic UI opcodes to `docs/protocol_schema.toml`,
+- new semantic surface payload types or `Minga.RenderModel.UI.*` chrome models,
+- new chrome message types for agent or extension features.
+
+Every new surface multiplies across every frontend decoder and renderer and expands the exact contract those epics are stabilizing.
+
+**Exemptions:** bug fixes to existing surfaces, and protocol changes required by #2218 or #2219 themselves (opcode retirement, frame transactions, rect/z fields, codegen).
+
+**Enforcement:** reviewers and ticket runners treat a PR that adds a new opcode or semantic surface during the freeze as a blocker unless the PR cites one of the exemptions. If a feature genuinely needs a new surface before the freeze lifts, it needs an explicit user decision on the ticket, not a reviewer waiver.
+
+The freeze lifts when all three linked epics are closed. Remove this section at that point.
+
 ### New command
 1. Add the command to the appropriate `Commands.*` sub-module's `__commands__/0` (implements `Minga.Command.Provider` behaviour). Include name, description, `requires_buffer` flag, and execute function. If no existing sub-module fits, create a new one and add it to the `@command_modules` list in `Minga.Command.Registry`.
 2. Add keybinding in `Minga.Keymap.Defaults`


### PR DESCRIPTION
## Summary

Adds the semantic-surface freeze policy to AGENTS.md, directly after the "Semantic UI first for shared visible chrome" section. While the frontend remediation epics are in flight, no new semantic UI opcodes, surface payload types, or chrome message types may be added. Exemptions: bug fixes to existing surfaces, and protocol changes required by #2218/#2219 themselves. The freeze lifts when #2216, #2218, and #2219 close, and the section says to remove itself at that point.

This makes the operating intent durable: agents and reviewers working from repo conventions enforce it without needing the remediation session context.

## Why now

Every new semantic surface multiplies across every frontend decoder and renderer, expanding the exact contract #2218/#2219 are stabilizing. Root-cause analysis of the TUI/GUI bug churn identified uncontrolled surface growth during migration as a primary driver.

## Tests

Docs-only change; no code touched. Acceptance reviewer passed (criteria coverage, placement, prose style).

Closes #2226. Part of #2221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)