### PR TITLE
feat: enum primitive in the protocol schema

### DIFF
--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -1014,6 +1014,49 @@ value = 0x57
 name = "extension_action"
 value = 0x58
 
+# ── Enum vocabularies ─────────────────────────────────────────────────────
+#
+# An [[enums]] entry names a closed set of wire byte values with a stable
+# repr primitive. A field references one with `type = "enum", enum = "<name>"`,
+# which is sized and read as the underlying repr (so existing wire bytes are
+# unchanged) and surfaces in generated decoders as a typed constant rather than
+# a bare integer. The optional `default` is the byte value an encoder emits for
+# an unmapped atom (it must appear in `values`). Validation requires unique
+# value bytes, every byte in range for the repr, and a resolvable `default`.
+
+[[enums]]
+name = "completion_kind"
+repr = "u8"
+default = "unknown"
+values = [
+  { name = "unknown", value = 0 },
+  { name = "function", value = 1 },
+  { name = "method", value = 2 },
+  { name = "variable", value = 3 },
+  { name = "field", value = 4 },
+  { name = "module", value = 5 },
+  { name = "keyword", value = 7 },
+  { name = "snippet", value = 8 },
+  { name = "constant", value = 9 },
+  { name = "struct", value = 11 },
+  { name = "enum", value = 12 },
+]
+
+[[enums]]
+name = "git_file_status"
+repr = "u8"
+default = "unknown"
+values = [
+  { name = "unknown", value = 0 },
+  { name = "modified", value = 1 },
+  { name = "added", value = 2 },
+  { name = "deleted", value = 3 },
+  { name = "renamed", value = 4 },
+  { name = "copied", value = 5 },
+  { name = "untracked", value = 6 },
+  { name = "conflict", value = 7 },
+]
+
 # ── Shared wire structures ────────────────────────────────────────────────
 #
 # Reusable fixed-size and variable-length sub-structures referenced by name
@@ -1027,6 +1070,7 @@ value = 0x58
 #   rgb                            — 3-byte color (r:u8, g:u8, b:u8)
 #   counted_array                  — count prefix + repeated elements
 #   struct                         — reference to another [[structures]] entry
+#   enum                           — closed byte vocabulary ([[enums]] entry)
 
 [[structures]]
 name = "rect"
@@ -1149,7 +1193,7 @@ fields = [{ name = "slot", type = "u8" }, { name = "color", type = "rgb" }]
 [[structures]]
 name = "completion_item"
 fields = [
-  { name = "kind", type = "u8" },
+  { name = "kind", type = "enum", enum = "completion_kind" },
   { name = "label", type = "string16" },
   { name = "detail", type = "string16" },
 ]
@@ -1189,7 +1233,7 @@ name = "git_status_entry"
 fields = [
   { name = "path_hash", type = "u32" },
   { name = "section", type = "u8" },
-  { name = "status", type = "u8" },
+  { name = "status", type = "enum", enum = "git_file_status" },
   { name = "path", type = "string16" },
 ]
 

--- a/go/tui/internal/generated/semantic_decode.go
+++ b/go/tui/internal/generated/semantic_decode.go
@@ -508,7 +508,7 @@ func DecodeCompletionItem(data []byte, offset int) (CompletionItem, int, error) 
 	if err := decodeRequireLen(data, pos+1, "kind"); err != nil {
 		return CompletionItem{}, offset, err
 	}
-	kind := data[pos]
+	kind := CompletionKind(data[pos])
 	pos++
 	label, pos, err := decodeString16(data, pos)
 	if err != nil {
@@ -643,7 +643,7 @@ func DecodeGitStatusEntry(data []byte, offset int) (GitStatusEntry, int, error) 
 	if err := decodeRequireLen(data, pos+1, "status"); err != nil {
 		return GitStatusEntry{}, offset, err
 	}
-	status := data[pos]
+	status := GitFileStatus(data[pos])
 	pos++
 	path, pos, err := decodeString16(data, pos)
 	if err != nil {

--- a/go/tui/internal/generated/semantic_types.go
+++ b/go/tui/internal/generated/semantic_types.go
@@ -2,6 +2,37 @@
 
 package generated
 
+// CompletionKind is a generated enum (repr u8).
+type CompletionKind uint8
+
+const (
+	CompletionKindUnknown  CompletionKind = 0
+	CompletionKindFunction CompletionKind = 1
+	CompletionKindMethod   CompletionKind = 2
+	CompletionKindVariable CompletionKind = 3
+	CompletionKindField    CompletionKind = 4
+	CompletionKindModule   CompletionKind = 5
+	CompletionKindKeyword  CompletionKind = 7
+	CompletionKindSnippet  CompletionKind = 8
+	CompletionKindConstant CompletionKind = 9
+	CompletionKindStruct   CompletionKind = 11
+	CompletionKindEnum     CompletionKind = 12
+)
+
+// GitFileStatus is a generated enum (repr u8).
+type GitFileStatus uint8
+
+const (
+	GitFileStatusUnknown   GitFileStatus = 0
+	GitFileStatusModified  GitFileStatus = 1
+	GitFileStatusAdded     GitFileStatus = 2
+	GitFileStatusDeleted   GitFileStatus = 3
+	GitFileStatusRenamed   GitFileStatus = 4
+	GitFileStatusCopied    GitFileStatus = 5
+	GitFileStatusUntracked GitFileStatus = 6
+	GitFileStatusConflict  GitFileStatus = 7
+)
+
 type Rect struct {
 	Row    uint16
 	Col    uint16
@@ -98,7 +129,7 @@ type ThemeColor struct {
 }
 
 type CompletionItem struct {
-	Kind   uint8
+	Kind   CompletionKind
 	Label  string
 	Detail string
 }
@@ -129,7 +160,7 @@ type ChangeSummaryEntry struct {
 type GitStatusEntry struct {
 	PathHash uint32
 	Section  uint8
-	Status   uint8
+	Status   GitFileStatus
 	Path     string
 }
 

--- a/go/tui/internal/protocol/generated_decode_test.go
+++ b/go/tui/internal/protocol/generated_decode_test.go
@@ -35,6 +35,32 @@ func TestDecodeGuiCompletionFieldsWithItems(t *testing.T) {
 	}
 }
 
+// The completion_item.kind and git_status_entry.status fields are schema enums,
+// so the generated decoders surface them as typed constants rather than bare
+// bytes. This pins the byte<->constant mapping and the typed field shape.
+func TestDecodeCompletionItemKindIsTypedEnum(t *testing.T) {
+	bytes := []byte{12, 0, 1, 'x', 0, 0}
+	item, _, err := generated.DecodeCompletionItem(bytes, 0)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if item.Kind != generated.CompletionKindEnum {
+		t.Fatalf("kind = %d, want CompletionKindEnum (%d)", item.Kind, generated.CompletionKindEnum)
+	}
+}
+
+func TestDecodeGitStatusEntryStatusIsTypedEnum(t *testing.T) {
+	// path_hash(4) + section(1) + status(1)=conflict(7) + empty path.
+	bytes := []byte{0, 0, 0, 0, 1, 7, 0, 0}
+	entry, _, err := generated.DecodeGitStatusEntry(bytes, 0)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if entry.Status != generated.GitFileStatusConflict {
+		t.Fatalf("status = %d, want GitFileStatusConflict (%d)", entry.Status, generated.GitFileStatusConflict)
+	}
+}
+
 func TestDecodeHiddenCompletionSkipsTail(t *testing.T) {
 	f, consumed, err := generated.DecodeGuiCompletionFields([]byte{0}, 0)
 	if err != nil || consumed != 1 || f.Visible != 0 || len(f.Items) != 0 {

--- a/mix/protocol_generator.ex
+++ b/mix/protocol_generator.ex
@@ -74,10 +74,61 @@ defmodule Minga.Mix.ProtocolGenerator do
   @spec load_schema!() :: schema()
   defp load_schema! do
     case @schema_path |> File.read!() |> Toml.decode() do
-      {:ok, schema} -> validate_schema!(schema)
+      {:ok, schema} -> schema |> validate_schema!() |> attach_enum_reprs()
       {:error, reason} -> Mix.raise("Failed to parse #{@schema_path}: #{inspect(reason)}")
     end
   end
+
+  # Annotate every `type = "enum"` field with the repr primitive of its enum so
+  # the downstream sizing/decode helpers can read it as that primitive while the
+  # Go type mapping still names the typed constant. Runs after validation so the
+  # enum reference is known to resolve.
+  @spec attach_enum_reprs(schema()) :: schema()
+  defp attach_enum_reprs(schema) do
+    emap = enums_map(schema)
+
+    schema
+    |> Map.update("structures", [], fn structs ->
+      Enum.map(structs, &map_entry_fields(&1, emap))
+    end)
+    |> Map.update("sections", [], fn sections ->
+      Enum.map(sections, &map_entry_fields(&1, emap))
+    end)
+    |> Map.update("command_fields", [], fn cfs -> Enum.map(cfs, &map_entry_fields(&1, emap)) end)
+  end
+
+  @spec map_entry_fields(map(), %{String.t() => enum()}) :: map()
+  defp map_entry_fields(entry, emap) do
+    entry
+    |> maybe_map_fields("fields", emap)
+    |> maybe_map_conditional_tail(emap)
+  end
+
+  @spec maybe_map_fields(map(), String.t(), %{String.t() => enum()}) :: map()
+  defp maybe_map_fields(entry, key, emap) do
+    case Map.get(entry, key) do
+      fields when is_list(fields) ->
+        Map.put(entry, key, Enum.map(fields, &annotate_enum_field(&1, emap)))
+
+      _ ->
+        entry
+    end
+  end
+
+  @spec maybe_map_conditional_tail(map(), %{String.t() => enum()}) :: map()
+  defp maybe_map_conditional_tail(entry, emap) do
+    case Map.get(entry, "conditional_tail") do
+      %{} = tail -> Map.put(entry, "conditional_tail", maybe_map_fields(tail, "fields", emap))
+      _ -> entry
+    end
+  end
+
+  @spec annotate_enum_field(map(), %{String.t() => enum()}) :: map()
+  defp annotate_enum_field(%{"type" => "enum", "enum" => name} = field, emap) do
+    Map.put(field, "repr", Map.fetch!(emap, name)["repr"])
+  end
+
+  defp annotate_enum_field(field, _emap), do: field
 
   @spec validate_schema!(schema()) :: schema()
   defp validate_schema!(schema) do
@@ -87,9 +138,11 @@ defmodule Minga.Mix.ProtocolGenerator do
     validate_duplicate_values!(Map.fetch!(schema, "gui_actions"), "GUI action")
     validate_gui_action_canonicals!(Map.fetch!(schema, "gui_actions"))
     validate_framing!(schema)
+    validate_enums!(schema)
     validate_structures!(schema)
     validate_sections!(schema)
     validate_command_fields!(schema)
+    validate_enum_field_refs!(schema)
     validate_conditional_tail_guards!(schema)
     schema
   end
@@ -738,6 +791,146 @@ defmodule Minga.Mix.ProtocolGenerator do
   defp framing_kind(%{"framing" => "fixed:" <> rest}), do: {:fixed, String.to_integer(rest)}
   defp framing_kind(%{"framing" => framing}), do: String.to_atom(framing)
 
+  # ── Enums ─────────────────────────────────────────────────────────────────
+  #
+  # An [[enums]] entry declares a closed byte vocabulary. A field references it
+  # with `type = "enum", enum = "<name>"`; it is sized and decoded as the
+  # underlying `repr` primitive and surfaces in generated decoders as a typed
+  # constant. Validation guards the invariants the consult locked: unique value
+  # bytes, every byte in range for the repr, and a `default` that resolves to a
+  # declared value.
+
+  @type enum :: %{String.t() => term()}
+
+  @enum_repr_max %{"u8" => 0xFF, "u16" => 0xFFFF, "u32" => 0xFFFFFFFF}
+
+  @spec enums_list(schema()) :: [enum()]
+  defp enums_list(schema), do: Map.get(schema, "enums", [])
+
+  @spec enums_map(schema()) :: %{String.t() => enum()}
+  defp enums_map(schema), do: Map.new(enums_list(schema), fn e -> {e["name"], e} end)
+
+  @spec enum_field?(map()) :: boolean()
+  defp enum_field?(%{"type" => "enum"}), do: true
+  defp enum_field?(_field), do: false
+
+  @spec validate_enums!(schema()) :: :ok
+  defp validate_enums!(schema) do
+    enums = enums_list(schema)
+    validate_enum_names!(enums)
+
+    Enum.each(enums, fn enum ->
+      validate_enum_repr!(enum)
+      validate_enum_values!(enum)
+      validate_enum_default!(enum)
+    end)
+  end
+
+  @spec validate_enum_names!([enum()]) :: :ok
+  defp validate_enum_names!(enums) do
+    names = Enum.map(enums, & &1["name"])
+    dupes = names -- Enum.uniq(names)
+
+    case dupes do
+      [] ->
+        :ok
+
+      _ ->
+        Mix.raise("Duplicate enum names in #{@schema_path}: #{Enum.join(Enum.uniq(dupes), ", ")}")
+    end
+  end
+
+  @spec validate_enum_repr!(enum()) :: :ok
+  defp validate_enum_repr!(%{"repr" => repr})
+       when is_map_key(@enum_repr_max, repr),
+       do: :ok
+
+  defp validate_enum_repr!(%{"name" => name} = enum) do
+    Mix.raise(
+      "Enum #{name} has invalid repr #{inspect(enum["repr"])} in #{@schema_path} (allowed: u8, u16, u32)"
+    )
+  end
+
+  @spec validate_enum_values!(enum()) :: :ok
+  defp validate_enum_values!(%{"name" => name, "repr" => repr} = enum) do
+    values = Map.get(enum, "values", [])
+    max = @enum_repr_max[repr]
+
+    out_of_range =
+      values
+      |> Enum.reject(fn v -> is_integer(v["value"]) and v["value"] >= 0 and v["value"] <= max end)
+      |> Enum.map_join(", ", fn v -> "#{v["name"]}=#{inspect(v["value"])}" end)
+
+    case out_of_range do
+      "" ->
+        :ok
+
+      _ ->
+        Mix.raise(
+          "Enum #{name} values out of range for #{repr} in #{@schema_path}: #{out_of_range}"
+        )
+    end
+
+    byte_values = Enum.map(values, & &1["value"])
+    dupes = byte_values -- Enum.uniq(byte_values)
+
+    case dupes do
+      [] ->
+        :ok
+
+      _ ->
+        Mix.raise(
+          "Enum #{name} has duplicate value bytes in #{@schema_path}: #{Enum.join(Enum.uniq(dupes), ", ")}"
+        )
+    end
+  end
+
+  @spec validate_enum_default!(enum()) :: :ok
+  defp validate_enum_default!(%{"default" => nil}), do: :ok
+  defp validate_enum_default!(enum) when not is_map_key(enum, "default"), do: :ok
+
+  defp validate_enum_default!(%{"name" => name, "default" => default} = enum) do
+    value_names = enum |> Map.get("values", []) |> MapSet.new(& &1["name"])
+
+    case MapSet.member?(value_names, default) do
+      true ->
+        :ok
+
+      false ->
+        Mix.raise(
+          "Enum #{name} default #{inspect(default)} is not a declared value in #{@schema_path}"
+        )
+    end
+  end
+
+  @spec validate_enum_field_refs!(schema()) :: :ok
+  defp validate_enum_field_refs!(schema) do
+    emap = enums_map(schema)
+
+    entries =
+      Map.get(schema, "structures", []) ++
+        Enum.reject(sections_list(schema), &entry_custom_layout?/1) ++
+        command_fields_list(schema)
+
+    bad =
+      entries
+      |> Enum.flat_map(fn entry ->
+        label = entry["name"] || entry["opcode"]
+        Enum.map(entry_fields(entry), &{label, &1})
+      end)
+      |> Enum.filter(fn {_label, field} ->
+        enum_field?(field) and not Map.has_key?(emap, field["enum"])
+      end)
+      |> Enum.map_join(", ", fn {label, field} ->
+        "#{label}.#{field["name"]} -> #{inspect(field["enum"])}"
+      end)
+
+    case bad do
+      "" -> :ok
+      _ -> Mix.raise("Fields reference unknown enums in #{@schema_path}: #{bad}")
+    end
+  end
+
   @spec framing_opcodes(schema()) :: [opcode()]
   defp framing_opcodes(schema) do
     schema
@@ -1303,6 +1496,10 @@ defmodule Minga.Mix.ProtocolGenerator do
   end
 
   defp fixed_field_size(%{"type" => "counted_array"}, _smap), do: nil
+
+  defp fixed_field_size(%{"type" => "enum", "repr" => repr}, smap),
+    do: fixed_type_size(repr, smap)
+
   defp fixed_field_size(%{"type" => type_name}, smap), do: fixed_type_size(type_name, smap)
 
   @spec fixed_structure_size(String.t(), %{String.t() => structure()}) :: non_neg_integer() | nil
@@ -1395,6 +1592,23 @@ defmodule Minga.Mix.ProtocolGenerator do
 
   @spec go_decode_field_assignment_statement(map(), %{String.t() => structure()}, String.t()) ::
           iodata()
+  defp go_decode_field_assignment_statement(
+         %{"name" => name, "type" => "enum", "enum" => enum_name, "repr" => repr},
+         _smap,
+         zero
+       ) do
+    local = go_local_name(name)
+    size = @primitive_sizes[repr]
+
+    [
+      "\t\tif err := decodeRequireLen(data, pos+#{size}, \"#{name}\"); err != nil {\n",
+      "\t\t\treturn #{zero}, offset, err\n",
+      "\t\t}\n",
+      "\t\t#{local} = #{go_struct_name(enum_name)}(#{@go_primitive_reads[repr]})\n",
+      go_pos_advance(size, "\t\t")
+    ]
+  end
+
   defp go_decode_field_assignment_statement(%{"name" => name, "type" => type}, _smap, zero)
        when is_map_key(@go_primitive_reads, type) do
     local = go_local_name(name)
@@ -1546,6 +1760,7 @@ defmodule Minga.Mix.ProtocolGenerator do
   # ── Go type mapping helpers ───────────────────────────────────────────────
 
   @spec go_type(map(), %{String.t() => structure()}) :: String.t()
+  defp go_type(%{"type" => "enum", "enum" => name}, _smap), do: go_struct_name(name)
   defp go_type(%{"type" => "u8"}, _smap), do: "uint8"
   defp go_type(%{"type" => "u16"}, _smap), do: "uint16"
   defp go_type(%{"type" => "u24"}, _smap), do: "uint32"
@@ -1633,6 +1848,7 @@ defmodule Minga.Mix.ProtocolGenerator do
     [
       "// Code generated by mix protocol.gen. DO NOT EDIT.\n\n",
       "package generated\n\n",
+      go_enum_definitions(enums_list(schema)),
       go_structure_definitions(structures, smap),
       go_size_constants(structures, smap),
       go_section_struct_definitions(sections, smap),
@@ -1640,6 +1856,35 @@ defmodule Minga.Mix.ProtocolGenerator do
     ]
     |> IO.iodata_to_binary()
     |> format_generated_go_file()
+  end
+
+  # Emit one named uint type per enum plus a typed constant for each value, so a
+  # decoded enum field surfaces as a self-documenting constant instead of a bare
+  # byte while still marshaling to its integer value.
+  @spec go_enum_definitions([enum()]) :: iodata()
+  defp go_enum_definitions([]), do: []
+
+  defp go_enum_definitions(enums) do
+    Enum.map(enums, fn enum ->
+      type_name = go_struct_name(enum["name"])
+      values = Map.get(enum, "values", [])
+
+      width =
+        values
+        |> Enum.map(fn v -> String.length("#{type_name}#{go_struct_name(v["name"])}") end)
+        |> Enum.max(fn -> 0 end)
+
+      [
+        "// #{type_name} is a generated enum (repr #{enum["repr"]}).\n",
+        "type #{type_name} #{go_type(%{"type" => enum["repr"]}, %{})}\n\n",
+        "const (\n",
+        Enum.map(values, fn v ->
+          cname = "#{type_name}#{go_struct_name(v["name"])}"
+          "\t#{String.pad_trailing(cname, width)} #{type_name} = #{v["value"]}\n"
+        end),
+        ")\n\n"
+      ]
+    end)
   end
 
   @spec go_structure_definitions([structure()], %{String.t() => structure()}) :: iodata()
@@ -1831,6 +2076,23 @@ defmodule Minga.Mix.ProtocolGenerator do
   end
 
   @spec go_decode_field_statement(map(), %{String.t() => structure()}, String.t()) :: iodata()
+  defp go_decode_field_statement(
+         %{"name" => name, "type" => "enum", "enum" => enum_name, "repr" => repr},
+         _smap,
+         zero
+       ) do
+    local = go_local_name(name)
+    size = @primitive_sizes[repr]
+
+    [
+      "\tif err := decodeRequireLen(data, pos+#{size}, \"#{name}\"); err != nil {\n",
+      "\t\treturn #{zero}, offset, err\n",
+      "\t}\n",
+      "\t#{local} := #{go_struct_name(enum_name)}(#{@go_primitive_reads[repr]})\n",
+      go_pos_advance(size, "\t")
+    ]
+  end
+
   defp go_decode_field_statement(%{"name" => name, "type" => type}, _smap, zero)
        when is_map_key(@go_primitive_reads, type) do
     local = go_local_name(name)

--- a/test/minga_editor/frontend/protocol_schema_test.exs
+++ b/test/minga_editor/frontend/protocol_schema_test.exs
@@ -263,6 +263,54 @@ defmodule MingaEditor.Frontend.ProtocolSchemaTest do
     )
   end
 
+  test "every enum has a repr, a resolvable default, and unique in-range values", %{
+    schema: schema
+  } do
+    repr_max = %{"u8" => 0xFF, "u16" => 0xFFFF, "u32" => 0xFFFFFFFF}
+
+    for enum <- schema["enums"] || [] do
+      assert is_binary(enum["name"])
+
+      assert Map.has_key?(repr_max, enum["repr"]),
+             "enum #{enum["name"]} has bad repr #{enum["repr"]}"
+
+      values = enum["values"] || []
+      value_names = MapSet.new(values, & &1["name"])
+      byte_values = Enum.map(values, & &1["value"])
+
+      assert byte_values == Enum.uniq(byte_values),
+             "enum #{enum["name"]} has duplicate value bytes"
+
+      for v <- values do
+        assert v["value"] >= 0 and v["value"] <= repr_max[enum["repr"]],
+               "enum #{enum["name"]} value #{v["name"]} out of range for #{enum["repr"]}"
+      end
+
+      if default = enum["default"] do
+        assert MapSet.member?(value_names, default),
+               "enum #{enum["name"]} default #{default} is not a declared value"
+      end
+    end
+  end
+
+  test "retrofitted enum fields reference declared enums", %{schema: schema} do
+    enum_names = MapSet.new(schema["enums"] || [], & &1["name"])
+    structures = Map.new(schema["structures"], fn s -> {s["name"], s} end)
+
+    completion_kind = field(structures["completion_item"], "kind")
+    assert completion_kind["type"] == "enum"
+    assert MapSet.member?(enum_names, completion_kind["enum"])
+
+    git_status = field(structures["git_status_entry"], "status")
+    assert git_status["type"] == "enum"
+    assert MapSet.member?(enum_names, git_status["enum"])
+  end
+
+  @spec field(map(), String.t()) :: map()
+  defp field(structure, name) do
+    Enum.find(structure["fields"], fn f -> f["name"] == name end)
+  end
+
   @spec assert_opcodes(map(), String.t(), keyword(non_neg_integer())) :: :ok
   defp assert_opcodes(schema, category, expected) do
     actual = opcodes_by_name(schema, category)


### PR DESCRIPTION
## Summary

STEP 1 (the keystone) of the locked #2225 design: the schema gains its one new concept, an `[[enums]]` primitive.

- Vocabularies with `repr`, optional `default`, and unique in-range byte values; fields reference them via `type = "enum", enum = "<name>"`.
- Generator: validation (unique names/bytes, repr range, resolvable defaults, no dangling refs), sizing as the underlying primitive, Go decoders mapping bytes to typed constants (`CompletionKind`, `GitFileStatus`).
- Retrofitted `completion_item.kind` and `git_status_entry.status`. The reviewer independently verified the byte values match all four hand-written encoder clause sets exactly, including the deliberate gaps at 6 and 10.
- **Byte-identical wire output**: `mix protocol.gen --check` and `mix protocol.golden --check` both exit 0; the 24 cross-language golden subtests pass unchanged.

Next slices per the design recorded on #2225: the Elixir pure-encoder emitter, then Completion → Picker → Breadcrumb → GitStatus family migrations behind the goldens.

## Tests

- `go test ./...`: 223 passed (incl. golden subtests + 2 new typed-constant mapping tests, placed outside the generated package so regen can't clobber them); gofmt clean
- Schema tests 47 passed; encoder tests 16 passed untouched; format/credo clean; compile -W clean except one pre-existing baseline warning (verified via git stash)
- Acceptance reviewer: PASS (re-ran the checks independently)

Part of #2225 and #2219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)