### PR TITLE
fix: lazily resolve the default renderer path in Manager.init

### DIFF
--- a/lib/minga_editor/frontend/manager.ex
+++ b/lib/minga_editor/frontend/manager.ex
@@ -119,7 +119,12 @@ defmodule MingaEditor.Frontend.Manager do
 
     backend = Keyword.get(opts, :backend, :tui)
     port_mode = Keyword.get(opts, :port_mode, Application.get_env(:minga, :port_mode, :spawn))
-    renderer_path = Keyword.get(opts, :renderer_path, default_renderer_path(backend))
+    # get_lazy: resolving the default path reads the global MINGA_FRONTEND
+    # selection, which must not happen when an explicit path is supplied
+    # (tests pass explicit paths and run concurrently with SelectionTest's
+    # env mutations).
+    renderer_path =
+      Keyword.get_lazy(opts, :renderer_path, fn -> default_renderer_path(backend) end)
 
     port_opener = Keyword.get(opts, :port_opener, &Port.open/2)
     state = %PortState{renderer_path: renderer_path, port_mode: port_mode}


### PR DESCRIPTION
## Summary

Fixes the test flake that failed PR #2249's CI (run 27256840864). `Keyword.get/3` evaluates its default eagerly, so `Manager.init` resolved `default_renderer_path/1` — which reads the global `MINGA_FRONTEND` selection — even when the caller supplied an explicit `renderer_path`. `ManagerTest` runs `async: true` and races `SelectionTest`'s sanctioned (`async: false`, on_exit-restored) env mutations; an unlucky interleaving inside the unknown-value test window crashed Manager init with Selection's fail-fast ArgumentError.

`Keyword.get_lazy/3` defers resolution, so an explicit path never touches the global selection — a correctness improvement beyond the flake (explicit configuration shouldn't consult ambient env).

## Tests

Proof under the hostile condition: `MINGA_FRONTEND=wgpu mix test test/minga_editor/frontend/manager_test.exs` → 22/22 pass (previously crashed in init).

🤖 Generated with [Claude Code](https://claude.com/claude-code)