### PR TITLE
feat(macos): live latency HUD overlay

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		23C300C87E722F7CCA072DFF /* ExtensionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BB136A9D180CCAD371E51 /* ExtensionPanelView.swift */; };
 		23DA463A92D1EC2F7BFA5B5A /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
+		25D865A5AD887E5F31FA162D /* LatencyHUDStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA53378E05335BC93B342123 /* LatencyHUDStateTests.swift */; };
 		268588BEB480E46CB2B14E61 /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9205AD1C42A1B3B9BF96278C /* AgentContextBar.swift */; };
 		26DAAF2C2CCC2713AD30C539 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
 		270A8B844125AE3DA0FF61B3 /* FrontendExtensionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752F8FD906F48C58D51FBBA1 /* FrontendExtensionRuntime.swift */; };
@@ -108,8 +109,11 @@
 		4515011E135C9FAE8D843610 /* ProtocolTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */; };
 		45A352459C76907D8E4CB596 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
 		4699A67786955024F156446F /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
+		48F6A6FB987CAEDE93FEB90E /* LatencyHUDOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACF2CEDC2CDB78683883C04 /* LatencyHUDOverlay.swift */; };
 		4AA3DEAF4010C778649B06B9 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B982679577E3DBD4E7A69D /* SettingsView.swift */; };
 		4ADE54090FEEF5AA2A6C86A0 /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
+		4C267F0119D5A6D1BD2B6F2E /* LatencyHUDOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACF2CEDC2CDB78683883C04 /* LatencyHUDOverlay.swift */; };
+		4C38738BE7EFAE48EF2DB242 /* LatencyHUDOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACF2CEDC2CDB78683883C04 /* LatencyHUDOverlay.swift */; };
 		4D83576C27CB59935BE53667 /* ToolManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */; };
 		4DF0BD94C77CA840CC92ACB7 /* AgentChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD14027C8C7BD17057DE820B /* AgentChatView.swift */; };
 		4E1EEFA65935DCE58528E02B /* PipelineCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */; };
@@ -214,6 +218,7 @@
 		8C9C3976E598C7F553B003B6 /* WorkspaceHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */; };
 		8CB3E1EEDEA109F6C0183597 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */; };
 		8D55764B8CF042B4C48AA5D0 /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
+		8DA7795B9AD0EC93BCC40D6D /* LatencyHUDState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3CDCE4CBD952FB00D1D347 /* LatencyHUDState.swift */; };
 		8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
 		8FB0DF76DEB5112AD590BB11 /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		92AFB851C9873F6E26F069A3 /* TextHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA1A468192F9DE2BBF374DD /* TextHighlighting.swift */; };
@@ -230,6 +235,7 @@
 		954D77812E23736226E8F202 /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9205AD1C42A1B3B9BF96278C /* AgentContextBar.swift */; };
 		95F6DCD24E2D261CF64EC8EB /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		96C256B378C75977F93ED37B /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F731BABFBA0763268D6CD19 /* SparklineView.swift */; };
+		96D4172683CFE87188C28AD4 /* LatencyHUDState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3CDCE4CBD952FB00D1D347 /* LatencyHUDState.swift */; };
 		9758BF46BB0EC7FEEB14FBA3 /* SwiftUIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86478D5660213F165B7E1E35 /* SwiftUIViewTests.swift */; };
 		98EFFA06B0B239B2C093226D /* FrontendExtensionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752F8FD906F48C58D51FBBA1 /* FrontendExtensionRuntime.swift */; };
 		9A4D9F25C0F806A65BF4E869 /* DispatchSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C82ED3FA8689E002C7BF1CD /* DispatchSheetView.swift */; };
@@ -351,6 +357,7 @@
 		EAB3B23E6209C12EE042F2DE /* ExtensionPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D54D0AA54F1EC07318AEA /* ExtensionPanelState.swift */; };
 		EACCC33CD56D244D5A8B30B3 /* FloatPopupState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EF5FFAD8310BD41CF784AC /* FloatPopupState.swift */; };
 		EAD04948D33D0D96FBEC823B /* ExtensionOverlayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F88438F21DF56F11861F9 /* ExtensionOverlayState.swift */; };
+		EB9E52B2C7B2D8D9E3A04584 /* LatencyHUDState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3CDCE4CBD952FB00D1D347 /* LatencyHUDState.swift */; };
 		ECE870F634AC4B097DA300AC /* PortLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E23DC6E0ACB156F21293E87 /* PortLogger.swift */; };
 		ED8D3D1F950A66E95AA3093F /* SidebarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452AAEF9518FDDF1FF8F51B0 /* SidebarContainer.swift */; };
 		EDBFAF45FE82A4C26D697C3A /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912C5F808709BABFF3126DEE /* AppearanceSettingsView.swift */; };
@@ -494,6 +501,7 @@
 		A80457F318D9322F416DA291 /* ActivityBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityBar.swift; sourceTree = "<group>"; };
 		AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseInputTests.swift; sourceTree = "<group>"; };
 		AB89E1589D78EC2BACA5D892 /* ObservatoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservatoryView.swift; sourceTree = "<group>"; };
+		AF3CDCE4CBD952FB00D1D347 /* LatencyHUDState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatencyHUDState.swift; sourceTree = "<group>"; };
 		AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentView.swift; sourceTree = "<group>"; };
 		B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerThermalPolicy.swift; sourceTree = "<group>"; };
 		B639BCE7660087F70778E839 /* ProtocolSemanticDecode.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolSemanticDecode.generated.swift; sourceTree = "<group>"; };
@@ -502,6 +510,7 @@
 		B9B4DF5FEB6C8DFCA427A692 /* Minga.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Minga.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9FC2118EA77254CBCAE7B0B /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		BAB3FF00584DBCEDE5FF79AC /* SearchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchState.swift; sourceTree = "<group>"; };
+		BACF2CEDC2CDB78683883C04 /* LatencyHUDOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatencyHUDOverlay.swift; sourceTree = "<group>"; };
 		BD2DE335B00721CBB29329F9 /* FontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontTests.swift; sourceTree = "<group>"; };
 		BDA1A468192F9DE2BBF374DD /* TextHighlighting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextHighlighting.swift; sourceTree = "<group>"; };
 		BEA9C2BB0C840BE88B0FEA52 /* CompletionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionState.swift; sourceTree = "<group>"; };
@@ -525,6 +534,7 @@
 		D48E4A7CE35A41F8198B7AE4 /* SearchToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchToolbar.swift; sourceTree = "<group>"; };
 		D54319ABC904DA03C61A9921 /* BoardFrontendRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardFrontendRuntime.swift; sourceTree = "<group>"; };
 		D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowView.swift; sourceTree = "<group>"; };
+		DA53378E05335BC93B342123 /* LatencyHUDStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatencyHUDStateTests.swift; sourceTree = "<group>"; };
 		DD14027C8C7BD17057DE820B /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
 		DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionOverlay.swift; sourceTree = "<group>"; };
 		E156287E8ABA1AB91EBF4014 /* LatencyRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatencyRecorderTests.swift; sourceTree = "<group>"; };
@@ -712,6 +722,8 @@
 				B66E4E27BE182768B01E5F64 /* HoverPopupState.swift */,
 				2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */,
 				1AC5F0D37085813890268537 /* InlineEditField.swift */,
+				BACF2CEDC2CDB78683883C04 /* LatencyHUDOverlay.swift */,
+				AF3CDCE4CBD952FB00D1D347 /* LatencyHUDState.swift */,
 				7A67102D81C9E70546F1019B /* MessagesContentState.swift */,
 				AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */,
 				4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */,
@@ -857,6 +869,7 @@
 				754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */,
 				F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */,
 				7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */,
+				DA53378E05335BC93B342123 /* LatencyHUDStateTests.swift */,
 				E156287E8ABA1AB91EBF4014 /* LatencyRecorderTests.swift */,
 				82B744449C852E13511FFE8D /* MinibufferStateTests.swift */,
 				AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */,
@@ -1165,6 +1178,8 @@
 				C07AF84A6E689758D100A251 /* InlineEditField.swift in Sources */,
 				8AB3B55F301192FA4F4A4E41 /* Instrumentation.swift in Sources */,
 				BB743A0A803E3A1609DD6D59 /* KeybindingsSettingsView.swift in Sources */,
+				4C38738BE7EFAE48EF2DB242 /* LatencyHUDOverlay.swift in Sources */,
+				96D4172683CFE87188C28AD4 /* LatencyHUDState.swift in Sources */,
 				FE7392D4E7D966DAA6FD85D8 /* LatencyRecorder.swift in Sources */,
 				EE84DA1BF4952359DD0DC343 /* LineTextureAtlas.swift in Sources */,
 				3CD49A10C9BA962BBCB00CA8 /* MessagesContentState.swift in Sources */,
@@ -1285,6 +1300,8 @@
 				BB1ABD615278289735DE85E9 /* InlineEditField.swift in Sources */,
 				6CF0F1BB4E1BDC0182EDCCB1 /* Instrumentation.swift in Sources */,
 				6691CAB367FB0BA9821C79E5 /* KeybindingsSettingsView.swift in Sources */,
+				48F6A6FB987CAEDE93FEB90E /* LatencyHUDOverlay.swift in Sources */,
+				EB9E52B2C7B2D8D9E3A04584 /* LatencyHUDState.swift in Sources */,
 				9A5444BA1A265BD39652C13A /* LatencyRecorder.swift in Sources */,
 				5C9DBC1F399D8F7BE8EA2701 /* LineTextureAtlas.swift in Sources */,
 				63AD77F5D54E43D9376810DC /* MessagesContentState.swift in Sources */,
@@ -1418,6 +1435,9 @@
 				25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */,
 				AA47831C0288E59E8B4DBEB5 /* KeybindingsSettingsView.swift in Sources */,
 				B0A5712B943D48F8F72C1DDA /* KeyboardInputTests.swift in Sources */,
+				4C267F0119D5A6D1BD2B6F2E /* LatencyHUDOverlay.swift in Sources */,
+				8DA7795B9AD0EC93BCC40D6D /* LatencyHUDState.swift in Sources */,
+				25D865A5AD887E5F31FA162D /* LatencyHUDStateTests.swift in Sources */,
 				85E4813953F2ECED58655484 /* LatencyRecorder.swift in Sources */,
 				0B3E634DA8224698DD9BEE4A /* LatencyRecorderTests.swift in Sources */,
 				26DAAF2C2CCC2713AD30C539 /* LineTextureAtlas.swift in Sources */,

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -888,6 +888,13 @@ struct ContentView: View {
             bottomInset: notificationCenterBottomInset
         )
 
+        // Keystroke-to-present latency HUD (ticket #2215). Top-right, client-local
+        // debug overlay; visibility is owned by LatencyHUDState.
+        LatencyHUDOverlay(
+            state: appState.gui.latencyHUDState,
+            theme: appState.gui.themeColors
+        )
+
         // Startup overlay: covers the empty Metal framebuffer with a
         // spinner while the BEAM boots. Fades out on first batch_end.
         if !appState.hasReceivedFirstFrame {

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -56,6 +56,7 @@ struct MingaMenuCommands: Commands {
 
     private var encoder: InputEncoder? { appState.encoder }
     private var connected: Bool { encoder != nil }
+    private var latencyHUDState: LatencyHUDState { appState.gui.latencyHUDState }
 
     var body: some Commands {
         // Replace the default text editing commands (Cmd+C/V/X/Z/A) with
@@ -138,6 +139,17 @@ struct MingaMenuCommands: Commands {
             Button("Reset Font Size") { encoder?.sendFontSizeAdjust(direction: 0x02) }
                 .keyboardShortcut("0", modifiers: .command)
                 .disabled(!connected)
+
+            Divider()
+
+            // Keystroke-to-present latency HUD (ticket #2215). This is a
+            // frontend-local debug surface, so the toggle does not route through
+            // the BEAM and stays enabled even before connection. cmd-ctrl-l is the
+            // macOS-conventional equivalent of the Go TUI's ctrl+alt+l chord.
+            Button(latencyHUDState.visible ? "Hide Latency HUD" : "Show Latency HUD") {
+                latencyHUDState.toggle()
+            }
+            .keyboardShortcut("l", modifiers: [.command, .control])
         }
     }
 
@@ -264,6 +276,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.handleFontChange(family: family, size: CGFloat(size), ligatures: ligatures, weight: weight)
         }
         self.dispatcher = disp
+
+        // Wire the latency HUD (ticket #2215) to the recorder. The snapshot is
+        // computed outside the stamp/resolve critical sections, so the HUD's
+        // refresh timer never perturbs the keystroke-to-present samples.
+        appState.gui.latencyHUDState.connect { [weak disp] in
+            disp?.latency.snapshot() ?? LatencyRecorder.Stats()
+        }
 
         // Recovery manager tracks key input and render responses so Ctrl-G
         // can present a native restart dialog if the BEAM stops responding.

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -101,6 +101,10 @@ enum PreviewRegistry {
             fileTreeRenamePreview()
         case "WhichKeyPaged":
             whichKeyPagedPreview()
+        case "LatencyHUDOverlay":
+            latencyHUDPreview()
+        case "LatencyHUDEmpty":
+            latencyHUDEmptyPreview()
         default:
             Text("Unknown view: \(name)")
                 .font(.title)
@@ -1302,6 +1306,27 @@ enum PreviewRegistry {
 
         return WhichKeyOverlay(state: state, theme: theme)
             .frame(width: 520, height: 300)
+            .background(theme.editorBg)
+    }
+
+    // MARK: - LatencyHUDOverlay
+
+    private static func latencyHUDPreview() -> some View {
+        let theme = populatedTheme()
+        let state = LatencyHUDState(environment: ["MINGA_LATENCY_HUD": "1"])
+        state.stats = LatencyRecorder.Stats(count: 128, p50Micros: 812, p99Micros: 2450, maxMicros: 5100)
+
+        return LatencyHUDOverlay(state: state, theme: theme)
+            .frame(width: 520, height: 120)
+            .background(theme.editorBg)
+    }
+
+    private static func latencyHUDEmptyPreview() -> some View {
+        let theme = populatedTheme()
+        let state = LatencyHUDState(environment: ["MINGA_LATENCY_HUD": "1"])
+
+        return LatencyHUDOverlay(state: state, theme: theme)
+            .frame(width: 520, height: 120)
             .background(theme.editorBg)
     }
 

--- a/macos/Sources/PreviewSnapshotPolicy.swift
+++ b/macos/Sources/PreviewSnapshotPolicy.swift
@@ -27,6 +27,7 @@ enum PreviewSnapshotPolicy {
         case "PickerOverlay": CGSize(width: 600, height: 400)
         case "MinibufferView": CGSize(width: 600, height: 140)
         case "WhichKeyOverlay", "WhichKeyPaged": CGSize(width: 520, height: 300)
+        case "LatencyHUDOverlay", "LatencyHUDEmpty": CGSize(width: 520, height: 120)
         case "SearchToolbar": CGSize(width: 800, height: 40)
         case "HoverPopupOverlay": CGSize(width: 500, height: 300)
         case "SignatureHelpOverlay": CGSize(width: 500, height: 200)

--- a/macos/Sources/Views/GUIState.swift
+++ b/macos/Sources/Views/GUIState.swift
@@ -88,6 +88,10 @@ final class GUIState {
     /// Search toolbar state (0x9E).
     let searchState = SearchState()
 
+    /// Keystroke-to-present latency HUD state (ticket #2215). Client-local debug
+    /// overlay; boots visible when MINGA_LATENCY_HUD=1, toggled from the View menu.
+    let latencyHUDState = LatencyHUDState()
+
     /// Semantic window content from gui_window_content (0x80).
     /// Keyed by windowId. NOT cleared between frames; the guiWindowContent
     /// dispatch overwrites per-window data each frame. Stale entries serve

--- a/macos/Sources/Views/LatencyHUDOverlay.swift
+++ b/macos/Sources/Views/LatencyHUDOverlay.swift
@@ -1,0 +1,48 @@
+/// On-screen keystroke-to-present latency HUD (ticket #2215).
+///
+/// An unobtrusive top-right badge showing live p50/p99/max keystroke-to-present
+/// latency and the resolved sample count, mirroring the Go TUI's HUD. It reads
+/// only from `LatencyHUDState`, which pulls a recorder snapshot on a coarse timer
+/// outside the measured critical sections, so the overlay never perturbs the
+/// numbers it reports. This is a frontend-local, ephemeral debug surface.
+
+import SwiftUI
+
+struct LatencyHUDOverlay: View {
+    @Bindable var state: LatencyHUDState
+    let theme: ThemeColors
+
+    var body: some View {
+        if state.visible {
+            let model = state.model
+            VStack {
+                HStack {
+                    Spacer()
+                    badge(model)
+                        .padding(.top, 6)
+                        .padding(.trailing, 10)
+                }
+                Spacer()
+            }
+            .allowsHitTesting(false)
+            .accessibilityIdentifier("latency-hud")
+        }
+    }
+
+    private func badge(_ model: LatencyHUDModel) -> some View {
+        Text(model.line)
+            // Monospaced digits keep the badge from jittering as values change.
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .monospacedDigit()
+            .foregroundStyle(theme.treeActiveFg)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(theme.treeBg.opacity(0.92))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(theme.treeSeparatorFg.opacity(0.5), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .shadow(color: .black.opacity(0.25), radius: 4, y: 1)
+    }
+}

--- a/macos/Sources/Views/LatencyHUDState.swift
+++ b/macos/Sources/Views/LatencyHUDState.swift
@@ -1,0 +1,153 @@
+/// Observable state for the on-screen keystroke-to-present latency HUD (ticket
+/// #2215).
+///
+/// The macOS GUI's `LatencyRecorder` (owned by `CommandDispatcher`) records
+/// keystroke-to-present samples: the input path stamps a correlation sequence
+/// into each key packet, and `batch_end` resolves the sample when the frame is
+/// presented. This state object is the client-local, ephemeral display layer for
+/// those numbers, mirroring the Go TUI's HUD: it shows live p50/p99/max and the
+/// sample count, refreshed on a coarse timer so reading the recorder never
+/// happens inside the measured critical sections.
+///
+/// `visible` is enabled at boot when `MINGA_LATENCY_HUD=1` and toggled at runtime
+/// from the View menu (cmd-ctrl-l). This is a frontend-local debug surface in the
+/// same class as the Go HUD; it does not consume any editor keybinding the BEAM
+/// owns.
+
+import SwiftUI
+
+@MainActor
+@Observable
+final class LatencyHUDState {
+    /// Whether the overlay is currently shown.
+    var visible: Bool
+
+    /// The latest percentile snapshot rendered by the HUD.
+    var stats: LatencyRecorder.Stats = LatencyRecorder.Stats()
+
+    /// Snapshot source, injected once the dispatcher exists. The closure copies
+    /// the live sample window and computes percentiles outside the stamp/resolve
+    /// critical sections, so calling it on the refresh timer does not perturb the
+    /// numbers being measured.
+    private var snapshotProvider: (@MainActor () -> LatencyRecorder.Stats)?
+
+    /// Drives the periodic refresh. Cancelled when the HUD is hidden or the state
+    /// is deallocated.
+    private var refreshTask: Task<Void, Never>?
+
+    /// Refresh cadence. Coarse on purpose: the HUD reports keystroke-to-present
+    /// latency, so it must not redraw per frame or per keystroke and distort the
+    /// very numbers it shows.
+    private let refreshInterval: Duration
+
+    /// - Parameters:
+    ///   - environment: process environment, read once for the boot default.
+    ///   - refreshInterval: how often to pull a fresh snapshot while visible.
+    init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        refreshInterval: Duration = .milliseconds(500)
+    ) {
+        self.visible = LatencyHUDState.envEnabled(environment)
+        self.refreshInterval = refreshInterval
+    }
+
+    /// Reports whether `MINGA_LATENCY_HUD` requests the overlay on at startup.
+    /// Any non-empty value other than `0`/`false`/`no` enables it, matching the
+    /// Go TUI's `latencyHUDEnvEnabled`.
+    nonisolated static func envEnabled(_ environment: [String: String]) -> Bool {
+        switch environment["MINGA_LATENCY_HUD"] {
+        case nil, "", "0", "false", "no":
+            return false
+        default:
+            return true
+        }
+    }
+
+    /// Wires the recorder snapshot source and starts refreshing if the HUD booted
+    /// visible. Called once from `AppDelegate` after the dispatcher is created.
+    func connect(snapshotProvider: @escaping @MainActor () -> LatencyRecorder.Stats) {
+        self.snapshotProvider = snapshotProvider
+        if visible {
+            refresh()
+            startRefreshing()
+        }
+    }
+
+    /// Flips the overlay and starts or stops the refresh loop to match. Returns
+    /// the new visibility so callers can update menu state.
+    @discardableResult
+    func toggle() -> Bool {
+        visible.toggle()
+        if visible {
+            refresh()
+            startRefreshing()
+        } else {
+            stopRefreshing()
+        }
+        return visible
+    }
+
+    /// Pulls one fresh snapshot from the recorder, if connected.
+    func refresh() {
+        guard let snapshotProvider else { return }
+        stats = snapshotProvider()
+    }
+
+    /// One-line model used by the HUD view and exercised by unit tests.
+    var model: LatencyHUDModel { LatencyHUDModel(stats: stats) }
+
+    private func startRefreshing() {
+        guard refreshTask == nil else { return }
+        let interval = refreshInterval
+        refreshTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: interval)
+                guard let self, self.visible else { return }
+                self.refresh()
+            }
+        }
+    }
+
+    private func stopRefreshing() {
+        refreshTask?.cancel()
+        refreshTask = nil
+    }
+    // No deinit-based cancellation: the refresh loop captures `self` weakly and
+    // exits on the next tick once the state deallocates, matching the project's
+    // Task.sleep timer pattern (see BlinkingCursor / AGENTS.md concurrency notes).
+}
+
+/// Pure formatting model for the latency HUD. Kept `Sendable` and free of
+/// `@MainActor` so it can be unit-tested directly, mirroring the Go TUI's
+/// `Stats.HUD()`/`fmtDur` helpers.
+struct LatencyHUDModel: Sendable, Equatable {
+    let stats: LatencyRecorder.Stats
+
+    /// True when there are no resolved samples yet.
+    var isEmpty: Bool { stats.count == 0 }
+
+    /// p50 formatted as a duration string (e.g. `812µs`, `1.20ms`).
+    var p50: String { LatencyHUDModel.formatMicros(stats.p50Micros) }
+    /// p99 formatted as a duration string.
+    var p99: String { LatencyHUDModel.formatMicros(stats.p99Micros) }
+    /// max formatted as a duration string.
+    var max: String { LatencyHUDModel.formatMicros(stats.maxMicros) }
+    /// Resolved sample count backing the percentiles.
+    var sampleCount: Int { stats.count }
+
+    /// One-line badge text, matching the Go HUD layout. Shows a placeholder until
+    /// the first sample resolves.
+    var line: String {
+        guard !isEmpty else { return "lat: (no samples)" }
+        return "lat p50 \(p50)  p99 \(p99)  max \(max)  n=\(sampleCount)"
+    }
+
+    /// Formats a microsecond value as `µs` below 1ms and `ms` at or above, with
+    /// two decimals, matching the Go TUI's `fmtDur`.
+    static func formatMicros(_ micros: Double) -> String {
+        if micros >= 1000.0 {
+            return String(format: "%.2fms", micros / 1000.0)
+        }
+        return String(format: "%dµs", Int(micros.rounded()))
+    }
+}

--- a/macos/Tests/MingaTests/LatencyHUDStateTests.swift
+++ b/macos/Tests/MingaTests/LatencyHUDStateTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+
+@testable import Minga
+
+/// Verifies the latency HUD's formatting model, env-driven boot visibility, and
+/// runtime toggle (ticket #2215). The formatting model mirrors the Go TUI HUD.
+@Suite("Latency HUD")
+struct LatencyHUDStateTests {
+
+    // MARK: - Formatting model
+
+    @Test("empty stats render the no-samples placeholder")
+    func emptyPlaceholder() {
+        let model = LatencyHUDModel(stats: LatencyRecorder.Stats())
+        #expect(model.isEmpty)
+        #expect(model.sampleCount == 0)
+        #expect(model.line == "lat: (no samples)")
+    }
+
+    @Test("sub-millisecond values format as microseconds")
+    func microsecondFormatting() {
+        #expect(LatencyHUDModel.formatMicros(0) == "0µs")
+        #expect(LatencyHUDModel.formatMicros(812) == "812µs")
+        #expect(LatencyHUDModel.formatMicros(999.4) == "999µs")
+        // Rounds to nearest microsecond below the millisecond boundary.
+        #expect(LatencyHUDModel.formatMicros(750.6) == "751µs")
+    }
+
+    @Test("values at or above 1ms format as milliseconds with two decimals")
+    func millisecondFormatting() {
+        #expect(LatencyHUDModel.formatMicros(1000) == "1.00ms")
+        #expect(LatencyHUDModel.formatMicros(1234.5) == "1.23ms")
+        #expect(LatencyHUDModel.formatMicros(20000) == "20.00ms")
+    }
+
+    @Test("populated stats render the full badge line")
+    func populatedLine() {
+        let stats = LatencyRecorder.Stats(count: 128, p50Micros: 812, p99Micros: 2450, maxMicros: 5100)
+        let model = LatencyHUDModel(stats: stats)
+        #expect(!model.isEmpty)
+        #expect(model.p50 == "812µs")
+        #expect(model.p99 == "2.45ms")
+        #expect(model.max == "5.10ms")
+        #expect(model.sampleCount == 128)
+        #expect(model.line == "lat p50 812µs  p99 2.45ms  max 5.10ms  n=128")
+    }
+
+    // MARK: - Boot visibility (MINGA_LATENCY_HUD)
+
+    @Test("env enables the HUD only for truthy values")
+    func envEnabled() {
+        #expect(LatencyHUDState.envEnabled([:]) == false)
+        #expect(LatencyHUDState.envEnabled(["MINGA_LATENCY_HUD": ""]) == false)
+        #expect(LatencyHUDState.envEnabled(["MINGA_LATENCY_HUD": "0"]) == false)
+        #expect(LatencyHUDState.envEnabled(["MINGA_LATENCY_HUD": "false"]) == false)
+        #expect(LatencyHUDState.envEnabled(["MINGA_LATENCY_HUD": "no"]) == false)
+        #expect(LatencyHUDState.envEnabled(["MINGA_LATENCY_HUD": "1"]) == true)
+        #expect(LatencyHUDState.envEnabled(["MINGA_LATENCY_HUD": "true"]) == true)
+        #expect(LatencyHUDState.envEnabled(["MINGA_LATENCY_HUD": "on"]) == true)
+    }
+
+    @MainActor
+    @Test("HUD boots hidden by default and visible when env requests it")
+    func bootVisibility() {
+        let hidden = LatencyHUDState(environment: [:])
+        #expect(hidden.visible == false)
+
+        let shown = LatencyHUDState(environment: ["MINGA_LATENCY_HUD": "1"])
+        #expect(shown.visible == true)
+    }
+
+    // MARK: - Runtime toggle and snapshot wiring
+
+    @MainActor
+    @Test("toggle flips visibility")
+    func toggleFlips() {
+        let state = LatencyHUDState(environment: [:])
+        #expect(state.visible == false)
+        #expect(state.toggle() == true)
+        #expect(state.visible == true)
+        #expect(state.toggle() == false)
+        #expect(state.visible == false)
+    }
+
+    @MainActor
+    @Test("connect pulls an immediate snapshot when booted visible")
+    func connectRefreshesWhenVisible() {
+        let recorder = LatencyRecorder()
+        let seq = recorder.stamp()
+        recorder.resolve(seq: seq)
+
+        let state = LatencyHUDState(
+            environment: ["MINGA_LATENCY_HUD": "1"],
+            refreshInterval: .seconds(60)
+        )
+        #expect(state.stats.count == 0)
+        state.connect { recorder.snapshot() }
+        #expect(state.stats.count == 1)
+    }
+
+    @MainActor
+    @Test("refresh re-reads the recorder snapshot on demand")
+    func refreshReadsSnapshot() {
+        let recorder = LatencyRecorder()
+        let state = LatencyHUDState(environment: [:], refreshInterval: .seconds(60))
+        state.connect { recorder.snapshot() }
+        #expect(state.model.isEmpty)
+
+        let seq = recorder.stamp()
+        recorder.resolve(seq: seq)
+        state.refresh()
+        #expect(state.stats.count == 1)
+        #expect(!state.model.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Completes the macOS on-screen HUD deferred from #2215 (PR #2233 shipped the recorder + wire round-trip; this is the overlay). A top-right, hit-test-disabled badge shows live keystroke-to-present `p50 / p99 / max / n` from `dispatcher.latency.snapshot()`, formatted identically to the Go TUI HUD (µs below 1ms, two-decimal ms above).

- **Toggle parity with the Go TUI**: `MINGA_LATENCY_HUD=1` at boot; runtime toggle via a View-menu item (label flips Show/Hide) with **cmd-ctrl-l** — verified collision-free against existing shortcuts and editor input interception. Frontend-local debug surface; nothing routes through the BEAM.
- **Measurement hygiene**: the 500ms refresh loop runs only while visible (weak-self exit-on-tick, the project's sanctioned pattern) and snapshots copy-then-sort outside the recorder's lock-guarded critical sections, so the HUD cannot perturb the numbers it reports.
- Preview entries registered; rendered snapshot visually verified (top-right placement, monospaced digits).

## Tests

- Full Xcode suite: 781 tests / 123 suites, TEST SUCCEEDED; focused HUD+recorder: 13 passed
- 9 new behavioral tests: formatting model (µs/ms boundary, rounding, empty state), env truthiness, toggle, snapshot wiring through a real recorder
- `mix swift.build` success; `scripts/preview.sh LatencyHUDOverlay` PNG verified
- Acceptance reviewer: PASS (verified loop lifecycle, no shortcut collisions, pure-xcodegen pbxproj, no hit-test/layout interference)

Part of #2215's Phase 4 follow-ups and #2220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)