### PR TITLE
fix(tui): translate outbound mouse rows by the rendered header height

### DIFF
--- a/go/tui/internal/ui/input.go
+++ b/go/tui/internal/ui/input.go
@@ -159,8 +159,43 @@ func keyModifiers(key tea.Key) byte {
 	return mods
 }
 
-func mousePacket(msg tea.MouseMsg) []byte {
+// mousePacket encodes a raw editor-body mouse event for the BEAM, translating
+// the terminal row into the editor-relative row the BEAM hit-tests.
+//
+// Since #2244 collapsed layout to Layout.GUI, the BEAM places the editor at row
+// 0, but the Go TUI renders headerLines (tab bar, breadcrumb, ...) above the
+// body. The renderer already translates inbound BEAM geometry down by the
+// header height (render_content.go semanticContentOffsets); this is the
+// symmetric outbound subtraction so a click on the visually-Nth buffer line
+// reaches the BEAM as editor row N (ticket #2256). The macOS GUI already sends
+// editor-relative coordinates because its chrome lives outside the Metal view.
+//
+// Header-click policy: chrome (tabs, breadcrumbs, file tree) is zone-routed
+// before reaching here, so a raw event whose row lands in the header region is
+// an unrouted header pixel, not a buffer click. Forwarding it would become a
+// phantom click on editor row 0, so it is suppressed (ok=false). Wheel events
+// are forwarded regardless of row: the BEAM treats a wheel as a viewport scroll
+// (no buffer hit-test), and dropping a wheel over the header would silently
+// swallow scroll input. Only carried-row buffer events (press/release/drag/
+// motion) honor the suppression.
+func (m Model) mousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	mouse := msg.Mouse()
+	offset := m.renderedHeaderHeight
+	row := mouse.Y - offset
+	if !isWheelButton(mouse.Button) && mouse.Y < offset {
+		// Header-region policy: a PRESS on an unrouted header pixel must not
+		// become a phantom row-0 buffer click, so it is suppressed. Drag,
+		// motion, and release events are forwarded clamped to row 0 instead:
+		// an upward drag keeps extending at the top visible line, and a
+		// release over the header still terminates the BEAM's drag state
+		// (suppressing it latched dragging until the next press).
+		if _, isPress := msg.(tea.MouseClickMsg); isPress {
+			return nil, false
+		}
+	}
+	if row < 0 {
+		row = 0
+	}
 	button := byte(3)
 	eventType := byte(0)
 	switch mouse.Button {
@@ -203,7 +238,19 @@ func mousePacket(msg tea.MouseMsg) []byte {
 			eventType = protocol.MouseDrag
 		}
 	}
-	return protocol.EncodeMouseEvent(int16(mouse.Y), int16(mouse.X), button, keyModToProtocol(mouse.Mod), eventType, 1)
+	return protocol.EncodeMouseEvent(int16(row), int16(mouse.X), button, keyModToProtocol(mouse.Mod), eventType, 1), true
+}
+
+// isWheelButton reports whether a Bubble Tea mouse button is a scroll-wheel
+// button. Wheel events are forwarded as viewport scrolls and bypass the
+// header-region suppression that protects buffer hit-test rows (ticket #2256).
+func isWheelButton(button tea.MouseButton) bool {
+	switch button {
+	case tea.MouseWheelUp, tea.MouseWheelDown, tea.MouseWheelLeft, tea.MouseWheelRight:
+		return true
+	default:
+		return false
+	}
 }
 
 func keyModToProtocol(mod tea.KeyMod) byte {

--- a/go/tui/internal/ui/input_test.go
+++ b/go/tui/internal/ui/input_test.go
@@ -100,7 +100,10 @@ func TestMousePacketEncodesHorizontalWheel(t *testing.T) {
 		{name: "shift wheel up", msg: tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelUp, Mod: tea.ModShift}), want: 0x43},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			packet := mousePacket(tc.msg)
+			packet, ok := New(80, 24, nil).mousePacket(tc.msg)
+			if !ok {
+				t.Fatal("wheel should encode a mouse packet")
+			}
 			if packet[0] != generated.OPMouseEvent || packet[5] != tc.want {
 				t.Fatalf("mouse packet opcode/button = %#x/%#x, want mouse/%#x", packet[0], packet[5], tc.want)
 			}
@@ -132,7 +135,10 @@ func TestMousePacketDistinguishesDragFromMotion(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			packet := mousePacket(tc.msg)
+			packet, ok := New(80, 24, nil).mousePacket(tc.msg)
+			if !ok {
+				t.Fatal("motion should encode a mouse packet")
+			}
 			if packet[7] != tc.wantEventType {
 				t.Fatalf("event type = %#x, want %#x", packet[7], tc.wantEventType)
 			}
@@ -206,4 +212,190 @@ func TestFitUsesTerminalCellWidth(t *testing.T) {
 
 func codepoint(packet []byte) rune {
 	return rune(uint32(packet[1])<<24 | uint32(packet[2])<<16 | uint32(packet[3])<<8 | uint32(packet[4]))
+}
+
+func mouseRow(packet []byte) int16 {
+	return int16(uint16(packet[1])<<8 | uint16(packet[2]))
+}
+
+// tabBarModel builds a model whose header renders headerRows rows above the
+// editor body and refreshes the cached offset exactly as Update does after
+// applyCommands (ticket #2256). The header is always at least one row (a tab bar
+// or the title fallback), so headerRows must be >= 1; a wide breadcrumb adds the
+// second row. The chrome path is the realistic source-of-truth check that the
+// cached offset matches the rendered headerLines.
+func tabBarModel(headerRows int) Model {
+	if headerRows < 1 {
+		panic("tabBarModel: header is always at least one row")
+	}
+	model := New(120, 24, nil)
+	chrome := map[byte]protocol.ChromePayload{
+		generated.OPGuiTabBar: {
+			Tabs: protocol.TabBar{Tabs: []protocol.Tab{{ID: 1, Icon: "󰈙", Label: "main.ex", Active: true}}},
+		},
+	}
+	if headerRows >= 2 {
+		chrome[generated.OPGuiBreadcrumb] = protocol.ChromePayload{
+			Breadcrumb: protocol.Breadcrumb{Segments: []string{"lib", "minga", "main.ex"}},
+		}
+	}
+	model.chrome = chrome
+	model.refreshRenderedHeaderHeight()
+	if model.renderedHeaderHeight != headerRows {
+		panic("tabBarModel: cached header height does not match requested rows")
+	}
+	return model
+}
+
+// TestMousePacketSubtractsHeaderOffset pins the outbound translation: a click on
+// the visually-Nth buffer line (terminal row N+headerHeight) must reach the BEAM
+// as editor row N, mirroring the inbound translation. Verified with the header
+// hidden (offset 0) and visible (one and two rows) (ticket #2256).
+func TestMousePacketSubtractsHeaderOffset(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		offset    int
+		terminalY int
+		wantRow   int16
+	}{
+		{name: "no header forwards row unchanged", offset: 0, terminalY: 5, wantRow: 5},
+		{name: "one header row subtracts one", offset: 1, terminalY: 5, wantRow: 4},
+		{name: "two header rows subtract two", offset: 2, terminalY: 5, wantRow: 3},
+		{name: "first body row maps to editor row zero", offset: 1, terminalY: 1, wantRow: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Pin the translation arithmetic directly against the cached offset so
+			// the rule is independent of whether headerLines can ever collapse to
+			// zero rows (it cannot today: there is always a title fallback).
+			model := New(120, 24, nil)
+			model.renderedHeaderHeight = tc.offset
+			msg := tea.MouseClickMsg(tea.Mouse{X: 7, Y: tc.terminalY, Button: tea.MouseLeft})
+			packet, ok := model.mousePacket(msg)
+			if !ok {
+				t.Fatal("body click should encode a mouse packet")
+			}
+			if got := mouseRow(packet); got != tc.wantRow {
+				t.Fatalf("encoded row = %d, want %d", got, tc.wantRow)
+			}
+			if gotCol := int16(uint16(packet[3])<<8 | uint16(packet[4])); gotCol != 7 {
+				t.Fatalf("encoded col = %d, want 7 (col is never offset)", gotCol)
+			}
+		})
+	}
+}
+
+// TestMousePacketOffsetMirrorsRenderedHeader pins AC2: the offset subtracted
+// from outbound rows is the same headerLines height the renderer uses for the
+// frame on screen, sourced through the cache that Update refreshes after
+// applyCommands. With a tab bar plus a wide breadcrumb the header is two rows,
+// so a click on visual line 4 (terminal row 6) reaches the BEAM as editor row 4
+// (ticket #2256).
+func TestMousePacketOffsetMirrorsRenderedHeader(t *testing.T) {
+	model := tabBarModel(2)
+	if got, want := model.renderedHeaderHeight, len(model.headerLines()); got != want {
+		t.Fatalf("cached offset = %d, rendered header height = %d; must match", got, want)
+	}
+	msg := tea.MouseClickMsg(tea.Mouse{X: 0, Y: 6, Button: tea.MouseLeft})
+	packet, ok := model.mousePacket(msg)
+	if !ok {
+		t.Fatal("body click should encode a mouse packet")
+	}
+	if got := mouseRow(packet); got != 4 {
+		t.Fatalf("encoded row = %d, want 4 (terminal row 6 minus two header rows)", got)
+	}
+}
+
+// TestMousePacketSuppressesHeaderRegionClick pins the header-click policy: a raw
+// buffer event whose row lands in the header region (chrome that was not
+// zone-routed) is suppressed instead of becoming a phantom editor row-0 click
+// (ticket #2256).
+func TestMousePacketSuppressesHeaderRegionClick(t *testing.T) {
+	model := tabBarModel(2)
+	for _, y := range []int{0, 1} {
+		msg := tea.MouseClickMsg(tea.Mouse{X: 3, Y: y, Button: tea.MouseLeft})
+		if packet, ok := model.mousePacket(msg); ok {
+			t.Fatalf("click at header row %d should be suppressed, got row %d", y, mouseRow(packet))
+		}
+	}
+}
+
+// TestMousePacketClampsHeaderRegionDragAndRelease pins the in-flight-gesture
+// half of the header policy: drag motion and release events that cross into
+// the header region are forwarded clamped to row 0 (an upward drag keeps
+// extending at the top visible line, and the release still terminates the
+// BEAM's drag state) rather than suppressed (ticket #2256 review note).
+func TestMousePacketClampsHeaderRegionDragAndRelease(t *testing.T) {
+	model := tabBarModel(1)
+	steps := []struct {
+		msg     tea.MouseMsg
+		wantRow int16
+	}{
+		{msg: tea.MouseClickMsg(tea.Mouse{X: 2, Y: 3, Button: tea.MouseLeft}), wantRow: 2},
+		{msg: tea.MouseMotionMsg(tea.Mouse{X: 2, Y: 0, Button: tea.MouseLeft}), wantRow: 0},
+		{msg: tea.MouseReleaseMsg(tea.Mouse{X: 2, Y: 0, Button: tea.MouseLeft}), wantRow: 0},
+	}
+	for _, step := range steps {
+		packet, ok := model.mousePacket(step.msg)
+		if !ok {
+			t.Fatalf("gesture step should encode a packet: %#v", step.msg)
+		}
+		if got := mouseRow(packet); got != step.wantRow {
+			t.Fatalf("expected row %d, got %d for %#v", step.wantRow, got, step.msg)
+		}
+	}
+}
+
+// TestMousePacketTranslatesDragSequence pins the #2229 buffer drag-selection
+// path: the press anchor and each drag-motion row are translated by the same
+// header offset so a selection anchored on the visually-Nth line stays aligned
+// (ticket #2256).
+func TestMousePacketTranslatesDragSequence(t *testing.T) {
+	model := tabBarModel(1)
+	steps := []struct {
+		msg     tea.MouseMsg
+		wantRow int16
+	}{
+		{msg: tea.MouseClickMsg(tea.Mouse{X: 2, Y: 4, Button: tea.MouseLeft}), wantRow: 3},
+		{msg: tea.MouseMotionMsg(tea.Mouse{X: 6, Y: 7, Button: tea.MouseLeft}), wantRow: 6},
+		{msg: tea.MouseReleaseMsg(tea.Mouse{X: 6, Y: 7, Button: tea.MouseLeft}), wantRow: 6},
+	}
+	for _, step := range steps {
+		packet, ok := model.mousePacket(step.msg)
+		if !ok {
+			t.Fatalf("drag step should encode a packet: %#v", step.msg)
+		}
+		if got := mouseRow(packet); got != step.wantRow {
+			t.Fatalf("drag step row = %d, want %d", got, step.wantRow)
+		}
+	}
+}
+
+// TestMousePacketTranslatesWheelOverBody pins wheel handling: a scroll wheel over
+// the body is forwarded with its row translated by the header offset, and a
+// wheel over the header is still forwarded (clamped at row 0) rather than
+// suppressed, since the BEAM treats a wheel as a viewport scroll with no buffer
+// hit-test (ticket #2256).
+func TestMousePacketTranslatesWheelOverBody(t *testing.T) {
+	model := tabBarModel(1)
+
+	bodyWheel := tea.MouseWheelMsg(tea.Mouse{X: 4, Y: 5, Button: tea.MouseWheelDown})
+	packet, ok := model.mousePacket(bodyWheel)
+	if !ok {
+		t.Fatal("body wheel should encode a packet")
+	}
+	if got := mouseRow(packet); got != 4 {
+		t.Fatalf("body wheel row = %d, want 4 (5 - one header row)", got)
+	}
+	if packet[5] != 0x41 {
+		t.Fatalf("wheel button = %#x, want wheel-down 0x41", packet[5])
+	}
+
+	headerWheel := tea.MouseWheelMsg(tea.Mouse{X: 4, Y: 0, Button: tea.MouseWheelUp})
+	packet, ok = model.mousePacket(headerWheel)
+	if !ok {
+		t.Fatal("header wheel should still be forwarded, not suppressed")
+	}
+	if got := mouseRow(packet); got != 0 {
+		t.Fatalf("header wheel row = %d, want 0 (clamped)", got)
+	}
 }

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -70,11 +70,21 @@ type Model struct {
 	// a tab_reorder or file_tree_drop gui_action (ticket #2229, AC3). It is nil
 	// when no draggable press is active.
 	mouseDrag *chromeDrag
+	// renderedHeaderHeight caches the number of header rows the last rendered
+	// frame placed above the editor body. Since #2244 collapsed layout to
+	// Layout.GUI (editor at BEAM row 0), outbound editor-body mouse rows must
+	// subtract this offset to mirror the inbound translation
+	// (render_content.go semanticContentOffsets). It is the single source of
+	// truth shared with the renderer (headerLines), recomputed whenever the
+	// inputs to headerLines change: applied commands (chrome) and resize
+	// (width/height). Caching avoids recomputing headerLines inconsistently per
+	// mouse event (ticket #2256).
+	renderedHeaderHeight int
 }
 
 func New(width, height uint16, out chan<- []byte) Model {
 	vp := viewport.New(viewport.WithWidth(int(width)), viewport.WithHeight(max(int(height)-3, 1)))
-	return Model{
+	m := Model{
 		width:             int(width),
 		height:            int(height),
 		out:               out,
@@ -91,6 +101,10 @@ func New(width, height uint16, out chan<- []byte) Model {
 		// toggled at runtime with ctrl+alt+l (ticket #2215).
 		hudVisible: latencyHUDEnvEnabled(),
 	}
+	// Seed the header-offset cache so the first mouse event before any
+	// frame/resize still translates against the rendered fallback header.
+	m.refreshRenderedHeaderHeight()
+	return m
 }
 
 // latencyHUDEnvEnabled reports whether MINGA_LATENCY_HUD requests the overlay on
@@ -123,6 +137,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.refreshRenderedHeaderHeight()
 		m.viewport.SetWidth(msg.Width)
 		m.viewport.SetHeight(m.bodyHeight())
 		m.send(protocol.EncodeResize(uint16(max(msg.Width, 1)), uint16(max(msg.Height, 1))))
@@ -154,8 +169,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			default:
 				if packet, ok := m.semanticMousePacket(msg); ok {
 					m.send(packet)
-				} else {
-					m.send(mousePacket(msg))
+				} else if packet, ok := m.mousePacket(msg); ok {
+					m.send(packet)
 				}
 			}
 		}
@@ -168,6 +183,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case port.PacketMsg:
 		cmd = m.applyCommands(msg.Commands)
+		m.refreshRenderedHeaderHeight()
 	case port.LogMsg:
 		m.send(protocol.EncodeLogMessage(msg.Level, msg.Text))
 	case port.ErrorMsg:
@@ -440,6 +456,15 @@ func (m *Model) removeWindow(id uint16) {
 
 func (m Model) bodyHeight() int {
 	return max(m.height-len(m.headerLines())-len(m.footerLines()), 1)
+}
+
+// refreshRenderedHeaderHeight recomputes the cached header offset from the same
+// headerLines the renderer uses, so outbound mouse translation (mousePacket)
+// stays consistent with the frame on screen (ticket #2256). Call it whenever an
+// input to headerLines changes: applied commands (chrome content) and resize
+// (width drives the breadcrumb threshold).
+func (m *Model) refreshRenderedHeaderHeight() {
+	m.renderedHeaderHeight = len(m.headerLines())
 }
 
 func (m Model) maxOverlayHeight() int {


### PR DESCRIPTION
## Summary

Fixes #2256, the off-by-one in Go TUI buffer clicks surfaced by #2235's contract-forward test harness. The raw editor-body mouse path now subtracts a cached `renderedHeaderHeight` (same source as the renderer's `headerLines()`, refreshed on packet apply / resize / construction — the reviewer walked every `Update` input and confirmed no path changes the header without one of those).

**Header-region policy** (refined per review): presses on unrouted header pixels are suppressed — no phantom row-0 clicks; drag motion and release forward clamped to row 0, so upward drag-selection keeps extending at the top line and a release over the header still terminates the BEAM's drag state (pure suppression latched `dragging` until the next press); wheels always forward since the BEAM ignores wheel rows. Zone-routed chrome and the #2249 semantic drag path carry ids, not rows — untouched.

**Documented out of scope:** the SGR-tail fragmented-mouse fallback path also forwards raw rows, but offsetting it would break chrome clicks on those terminals (it bypasses zone routing entirely); it needs zone routing or #2219's BEAM-authoritative geometry.

## Tests

- `go test ./...`: 264 passed; gofmt + vet clean
- Regression tests: offset subtraction at header heights 0/1/2, cache-mirrors-renderer invariant, header press suppression, translated press-drag-release, **body→header upward drag + header release clamping** (the review-note case), wheel over body and header
- Acceptance reviewer: PASS (its warning — stuck-drag on header release — and both suggestions applied: clamp-not-suppress for in-flight gestures, `New()` cache seeding, the upward-drag test)

Closes #2256. Part of #2216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)