### PR TITLE
refactor: pure surface registry with focus-tree-derived placements

### DIFF
--- a/lib/minga_editor/layout/surface_registry.ex
+++ b/lib/minga_editor/layout/surface_registry.ex
@@ -1,0 +1,350 @@
+defmodule MingaEditor.Layout.SurfaceRegistry do
+  @moduledoc """
+  Pure surface registry: the single source for "what is where on screen".
+
+  Given the frame's editor state, `placements/1` returns an ordered list of
+  `MingaEditor.Layout.SurfaceRegistry.Placement` entries, each carrying a
+  `surface_id`, a `rect` (terminal cells, the existing `Layout.rect/0`
+  convention), a `z` band, and a `hit_kind`. The list is ordered back-to-front
+  by `z` (lowest first), so a stable sort by `z` reproduces paint order and a
+  reverse walk reproduces hit-test precedence.
+
+  This module is a calculation, not a process: state in, placements out. There
+  is no ETS, no GenServer, no cache of its own. It is consumed where
+  `MingaEditor.FocusTree`/`MingaEditor.Layout` are consumed today.
+
+  ## One source, derived from the focus tree
+
+  The registry is built by flattening the existing `MingaEditor.FocusTree`. The
+  focus tree is already the BEAM's authority for mouse routing: it carries the
+  per-frame `Layout` rects plus the single active overlay, with children stored
+  in rendered z-order (back to front). By projecting that same tree into
+  placement entries, the registry rect for every surface is, by construction,
+  the exact rect the focus tree (and therefore every hit-test that routes
+  through it) uses. That is the behaviour-neutrality guarantee the epic asks
+  for: registry rect == the rect each handler previously computed, because both
+  read the same tree.
+
+  ## Scope honesty: single active overlay
+
+  `FocusTree.add_modal_overlays/3` encodes the same exclusive precedence that
+  Go's `overlayLines()` chain encodes today: at most one modal overlay (picker
+  OR completion) is live per frame. The registry preserves that decision as
+  data; it emits the single active overlay and nothing else. Multiple
+  simultaneous overlays are newly *expressible* as a list but are deliberately
+  NOT produced here. Enabling them is out of scope (see #2268, AC-4).
+
+  Known enumeration gap for #2268 proper: the Go compositor's `overlayLines()`
+  chain also stacks surfaces that are not focus-tree nodes today (hover,
+  signature help, float popups, agent context, tool manager, extension
+  panels/overlays, observatory, timeline, notifications). Before "composite by
+  placement" is complete, those must be promoted to focus-tree/registry
+  surfaces; the gap lives in the FocusTree's coverage, not in this module's
+  derivation.
+
+  ## surface_id namespace and the #2264 coordination point
+
+  `surface_id/1` maps each focus-tree `content_type` to a stable atom in the
+  registry's namespace, and `surface_id_u16/1` maps that atom to a `u16` for
+  wire emission. This module is the single source of that mapping today.
+
+  Schema child #2264 (`feat/frame-transaction-schema-2264`) will define the
+  authoritative wire enum for `gui_surface_layout`'s `surface_id:u16`. That
+  branch is NOT merged at the time of this change, so the mapping lives here on
+  the BEAM side. **Unification point:** when #2264 lands, the generated enum
+  should become the single source and `surface_id_u16/1` should read from it
+  (or be replaced by the generated encoder reading these atoms). Until then,
+  keep `surface_id_u16/1` and the schema enum numerically in sync. No wire
+  packet is emitted from this slice; emission lands with #2268 proper after the
+  schema/emission children merge.
+
+  ## hit_kind
+
+  `hit_kind` reuses the window-scoped convention already encoded by
+  `Minga.RenderModel.Window.HitRegion` and `Minga.Frontend.Adapter.GUI.WindowEncoder`
+  (`:text`, `:gutter`, `:fold_control`, `:modeline`, `:status_bar`, `:divider`).
+  Surface-level entries extend it with `:chrome` (structural chrome that routes
+  to a handler but is not buffer text) and `:overlay` (a modal overlay surface).
+  It is a coarse classification of what a click on the surface means, not a
+  precise intra-surface region; intra-window hit regions stay with the window
+  encoder.
+
+  ## What is NOT unified here (documented per the epic)
+
+  Several handlers compute a region's *interpretation* from math that is too
+  entangled to swap behind a rect lookup without rewriting interaction
+  semantics. For those, the registry is the source of the surface RECT, but the
+  handler keeps its own interpretation:
+
+  * `MingaEditor.Input.AgentMouse` splits the agent window content rect into a
+    chat sub-column vs a preview sub-column using `chat_width_pct` math, and
+    splits the prompt area off the bottom using `PromptRenderer` height math.
+    The registry emits the agent window/panel rect; the chat/preview/prompt
+    sub-division stays in `AgentMouse` (it is interaction semantics, not a
+    placed surface). Forcing it into the registry would mean inventing
+    sub-surfaces that nothing else places.
+  * Tab-bar and modeline *segment* click regions
+    (`tab_bar_click_regions`, `modeline_click_regions`) are authored at render
+    time as text-property spans, not rects. The registry places the tab_bar and
+    status_bar/modeline surfaces; the per-segment command lookup stays where it
+    is.
+  * Intra-window buffer geometry (gutter width, fold column, scroll position to
+    buffer line) stays in `MingaEditor.Mouse.HitTest`. The registry places the
+    window content rect; translating a cell to a buffer position is window
+    interpretation, not surface placement.
+
+  These are left intentionally. The registry's job in this slice is to be the
+  one authority for surface *rects and z-order*, not to absorb every handler's
+  interpretation of a click inside its surface.
+  """
+
+  alias MingaEditor.FocusTree
+  alias MingaEditor.FocusTree.Node, as: TreeNode
+  alias MingaEditor.Layout.SurfaceRegistry.Placement
+
+  @typedoc "A surface identity in the registry's namespace."
+  @type surface_id ::
+          :tab_bar
+          | :editor_area
+          | :window
+          | :buffer_content
+          | :agent_chat_window
+          | :agent_chat_content
+          | :modeline
+          | :file_tree
+          | :sidebar
+          | :custom_sidebar
+          | :agent_panel
+          | :status_bar
+          | :minibuffer
+          | :bottom_panel
+          | :picker_backdrop
+          | :picker
+          | :completion_backdrop
+          | :completion_menu
+
+  @typedoc "Coarse classification of what a click on a surface means."
+  @type hit_kind ::
+          :text
+          | :gutter
+          | :fold_control
+          | :modeline
+          | :status_bar
+          | :divider
+          | :chrome
+          | :overlay
+
+  # ── z bands ─────────────────────────────────────────────────────────────────
+  # Lower paints first (further back). Reverse order is hit-test precedence.
+  # Bands leave gaps so future surfaces can slot between without renumbering the
+  # whole stack. These mirror the back-to-front order FocusTree already builds:
+  # base chrome and the editor area, then floating chrome (bottom panel), then
+  # the single active modal overlay on top.
+
+  @z_base_chrome 0
+  @z_editor_area 100
+  @z_floating_chrome 200
+  @z_overlay 300
+
+  @doc """
+  Returns the frame's surface placements ordered back-to-front by `z`.
+
+  Pure: takes editor or render-pipeline state and returns a list of
+  `Placement` structs. The list is the single source of surface rects and
+  z-order for both compositing (sort by `z`) and hit-testing (reverse the
+  sorted list).
+  """
+  @spec placements(map()) :: [Placement.t()]
+  def placements(state) do
+    state
+    |> FocusTree.get()
+    |> from_tree()
+  end
+
+  @doc """
+  Returns the rect of the first placed surface with `surface_id`, or `nil`.
+
+  This is the read site hit-testers use to ask the registry "where is surface
+  X?" instead of re-deriving the rect from `Layout` fields. Because placements
+  are projected from the focus tree, this rect is the same one mouse routing
+  hit-tests against. When several surfaces share an id (e.g. `:modeline` per
+  window), the frontmost (highest `z`, last in paint order) is returned.
+  """
+  @spec rect_for(map(), surface_id()) :: MingaEditor.Layout.rect() | nil
+  def rect_for(state, surface_id) do
+    state
+    |> placements()
+    |> rect_for_in(surface_id)
+  end
+
+  @doc """
+  Like `rect_for/2` but reads an already-computed placement list.
+  """
+  @spec rect_for_in([Placement.t()], surface_id()) :: MingaEditor.Layout.rect() | nil
+  def rect_for_in(placements, surface_id) do
+    placements
+    |> Enum.filter(&(&1.surface_id == surface_id))
+    |> Enum.max_by(& &1.z, fn -> nil end)
+    |> case do
+      nil -> nil
+      %Placement{rect: rect} -> rect
+    end
+  end
+
+  @doc """
+  Returns true when `(row, col)` falls inside the placed surface `surface_id`.
+
+  Half-open rect containment matching `FocusTree.Node.contains?/3`, so a
+  registry-backed bounds check agrees with focus-tree hit-testing.
+  """
+  @spec within?(map(), surface_id(), integer(), integer()) :: boolean()
+  def within?(state, surface_id, row, col) do
+    case rect_for(state, surface_id) do
+      nil -> false
+      rect -> contains?(rect, row, col)
+    end
+  end
+
+  @doc "Half-open rect containment: `row in [r, r+h)` and `col in [c, c+w)`."
+  @spec contains?(MingaEditor.Layout.rect(), integer(), integer()) :: boolean()
+  def contains?({r, c, w, h}, row, col) do
+    row >= r and row < r + h and col >= c and col < c + w
+  end
+
+  @doc """
+  Builds placements from an already-constructed focus tree.
+
+  Exposed so callers that already hold the cached tree (mouse routing, render
+  input) do not rebuild it. The tree's child order is rendered z-order; this
+  walk assigns each node a `z` band and preserves back-to-front ordering.
+  """
+  @spec from_tree(FocusTree.t()) :: [Placement.t()]
+  def from_tree(%TreeNode{} = root) do
+    root
+    |> collect()
+    |> Enum.reverse()
+    |> Enum.sort_by(& &1.z)
+  end
+
+  # Depth-first, back-to-front. Each placed node contributes one entry; the
+  # viewport root itself is not a placed surface. Surface ids repeat
+  # deliberately in split layouts: each window's buffer_content (and modeline)
+  # is a real, independently placed surface with its own rect, and the future
+  # emitter ships one placement per window. Consumers that want a single rect
+  # for an id (rect_for_in/2) take the topmost by z.
+  @spec collect(TreeNode.t()) :: [Placement.t()]
+  defp collect(%TreeNode{content_type: :viewport, children: children}) do
+    Enum.reduce(children, [], fn child, acc ->
+      collect(child) ++ acc
+    end)
+  end
+
+  defp collect(%TreeNode{} = node) do
+    case placement_for(node) do
+      nil ->
+        collect_children(node)
+
+      %Placement{} = placement ->
+        [placement | collect_children(node)]
+    end
+  end
+
+  @spec collect_children(TreeNode.t()) :: [Placement.t()]
+  defp collect_children(%TreeNode{children: children}) do
+    Enum.reduce(children, [], fn child, acc ->
+      collect(child) ++ acc
+    end)
+  end
+
+  @spec placement_for(TreeNode.t()) :: Placement.t() | nil
+  defp placement_for(%TreeNode{content_type: content_type, rect: rect}) do
+    case surface_id(content_type) do
+      nil ->
+        nil
+
+      id ->
+        Placement.new(id, rect, z_for(id), hit_kind_for(id))
+    end
+  end
+
+  # ── surface_id namespace ────────────────────────────────────────────────────
+
+  @doc """
+  Maps a focus-tree `content_type` to a registry `surface_id`, or `nil` for
+  content types that are not independently placed surfaces (the viewport root
+  and the per-window `:window` container, whose content child is the placed
+  surface).
+  """
+  @spec surface_id(TreeNode.content_type()) :: surface_id() | nil
+  def surface_id(:viewport), do: nil
+  def surface_id(:window), do: nil
+  def surface_id(:agent_chat_window), do: nil
+  def surface_id(:editor_area), do: :editor_area
+  def surface_id(:tab_bar), do: :tab_bar
+  def surface_id(:buffer_content), do: :buffer_content
+  def surface_id(:agent_chat_content), do: :agent_chat_content
+  def surface_id(:modeline), do: :modeline
+  def surface_id(:file_tree), do: :file_tree
+  def surface_id(:sidebar), do: :sidebar
+  def surface_id(:agent_panel), do: :agent_panel
+  def surface_id(:status_bar), do: :status_bar
+  def surface_id(:minibuffer), do: :minibuffer
+  def surface_id(:bottom_panel), do: :bottom_panel
+  def surface_id(:picker_backdrop), do: :picker_backdrop
+  def surface_id(:picker), do: :picker
+  def surface_id(:completion_backdrop), do: :completion_backdrop
+  def surface_id(:completion_menu), do: :completion_menu
+  def surface_id({:custom, :sidebar}), do: :custom_sidebar
+  def surface_id({:custom, _other}), do: :custom_sidebar
+  def surface_id(_other), do: nil
+
+  @doc """
+  Maps a registry `surface_id` atom to its `u16` wire value.
+
+  This is the single BEAM-side source of the surface enum until schema child
+  #2264 lands its generated enum. **Coordination point (#2264):** keep these
+  numbers in sync with `docs/protocol_schema.toml`'s `surface_id` enum when
+  that branch merges, then replace this with a read of the generated enum. See
+  the moduledoc.
+  """
+  @spec surface_id_u16(surface_id()) :: 0..65_535
+  def surface_id_u16(:editor_area), do: 1
+  def surface_id_u16(:tab_bar), do: 2
+  def surface_id_u16(:buffer_content), do: 3
+  def surface_id_u16(:agent_chat_content), do: 4
+  def surface_id_u16(:modeline), do: 5
+  def surface_id_u16(:file_tree), do: 6
+  def surface_id_u16(:sidebar), do: 7
+  def surface_id_u16(:custom_sidebar), do: 8
+  def surface_id_u16(:agent_panel), do: 9
+  def surface_id_u16(:status_bar), do: 10
+  def surface_id_u16(:minibuffer), do: 11
+  def surface_id_u16(:bottom_panel), do: 12
+  def surface_id_u16(:picker_backdrop), do: 13
+  def surface_id_u16(:picker), do: 14
+  def surface_id_u16(:completion_backdrop), do: 15
+  def surface_id_u16(:completion_menu), do: 16
+
+  # ── z assignment ────────────────────────────────────────────────────────────
+
+  @spec z_for(surface_id()) :: non_neg_integer()
+  defp z_for(:editor_area), do: @z_editor_area
+  defp z_for(:buffer_content), do: @z_editor_area + 1
+  defp z_for(:agent_chat_content), do: @z_editor_area + 1
+  defp z_for(:modeline), do: @z_editor_area + 2
+  defp z_for(:bottom_panel), do: @z_floating_chrome
+  defp z_for(id) when id in [:picker_backdrop, :completion_backdrop], do: @z_overlay
+  defp z_for(id) when id in [:picker, :completion_menu], do: @z_overlay + 1
+  defp z_for(_base_chrome), do: @z_base_chrome
+
+  # ── hit_kind classification ─────────────────────────────────────────────────
+
+  @spec hit_kind_for(surface_id()) :: hit_kind()
+  defp hit_kind_for(:buffer_content), do: :text
+  defp hit_kind_for(:agent_chat_content), do: :text
+  defp hit_kind_for(:modeline), do: :modeline
+  defp hit_kind_for(:status_bar), do: :status_bar
+  defp hit_kind_for(id) when id in [:picker, :completion_menu], do: :overlay
+  defp hit_kind_for(id) when id in [:picker_backdrop, :completion_backdrop], do: :overlay
+  defp hit_kind_for(_chrome), do: :chrome
+end

--- a/lib/minga_editor/layout/surface_registry/placement.ex
+++ b/lib/minga_editor/layout/surface_registry/placement.ex
@@ -1,0 +1,39 @@
+defmodule MingaEditor.Layout.SurfaceRegistry.Placement do
+  @moduledoc """
+  One placed surface: its identity, rect, z band, and hit kind.
+
+  This struct mirrors the `surface_placement{surface_id, rect, z, hit_kind}`
+  shape the consult locked for the `gui_surface_layout` wire opcode (#2268),
+  expressed BEAM-side as data. It carries no wire encoding itself; the encoder
+  (a later #2268 child) reads `surface_id`/`rect`/`z`/`hit_kind` and maps
+  `surface_id` to `u16` via
+  `MingaEditor.Layout.SurfaceRegistry.surface_id_u16/1`.
+
+  `MingaEditor.Layout.SurfaceRegistry` is the only module that constructs these
+  (one writer per struct).
+  """
+
+  alias MingaEditor.Layout.SurfaceRegistry
+
+  @typedoc "A placed surface entry."
+  @type t :: %__MODULE__{
+          surface_id: SurfaceRegistry.surface_id(),
+          rect: MingaEditor.Layout.rect(),
+          z: non_neg_integer(),
+          hit_kind: SurfaceRegistry.hit_kind()
+        }
+
+  @enforce_keys [:surface_id, :rect, :z, :hit_kind]
+  defstruct [:surface_id, :rect, :z, :hit_kind]
+
+  @doc "Constructs a placement. Called only by `SurfaceRegistry`."
+  @spec new(
+          SurfaceRegistry.surface_id(),
+          MingaEditor.Layout.rect(),
+          non_neg_integer(),
+          SurfaceRegistry.hit_kind()
+        ) :: t()
+  def new(surface_id, rect, z, hit_kind) do
+    %__MODULE__{surface_id: surface_id, rect: rect, z: z, hit_kind: hit_kind}
+  end
+end

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -36,6 +36,7 @@ defmodule MingaEditor.Mouse do
   alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.FoldMap
   alias MingaEditor.Layout
+  alias MingaEditor.Layout.SurfaceRegistry
   alias MingaEditor.Mouse.HitTest
   alias MingaEditor.Mouse.Target.Buffer, as: BufferTarget
   alias MingaEditor.Renderer.Gutter
@@ -1665,22 +1666,17 @@ defmodule MingaEditor.Mouse do
 
   # ── Tab bar click detection ──────────────────────────────────────────────
 
+  # The tab-bar *surface rect* comes from the surface registry (the single
+  # source for "what is where on screen"); the per-tab *segment* command lookup
+  # stays here because segments are render-time text-property spans, not placed
+  # surfaces. See `MingaEditor.Layout.SurfaceRegistry` moduledoc.
   @spec tab_bar_click(state(), non_neg_integer(), non_neg_integer()) ::
           {:command, tab_command()} | :not_tab_bar
   defp tab_bar_click(state, row, col) do
-    layout = Layout.get(state)
-
-    case layout.tab_bar do
-      nil ->
-        :not_tab_bar
-
-      {tb_row, tb_col, tb_width, tb_height} ->
-        if row >= tb_row and row < tb_row + tb_height and col >= tb_col and
-             col < tb_col + tb_width do
-          find_tab_bar_region(state.shell_state.tab_bar_click_regions, row, col)
-        else
-          :not_tab_bar
-        end
+    if SurfaceRegistry.within?(state, :tab_bar, row, col) do
+      find_tab_bar_region(state.shell_state.tab_bar_click_regions, row, col)
+    else
+      :not_tab_bar
     end
   end
 

--- a/test/minga_editor/layout/surface_registry_test.exs
+++ b/test/minga_editor/layout/surface_registry_test.exs
@@ -1,0 +1,280 @@
+defmodule MingaEditor.Layout.SurfaceRegistryTest do
+  @moduledoc """
+  Tests for the pure surface registry.
+
+  The load-bearing guarantee (epic #2219 / #2268 AC-1) is behaviour
+  neutrality: the registry rect for every placed surface equals the rect the
+  focus tree (and therefore every hit-test routing through it) uses. We prove
+  that by deriving both from the same layout and asserting agreement, plus the
+  scope-honesty rule that only the single active overlay is placed.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.BottomPanel
+  alias MingaEditor.FocusTree
+  alias MingaEditor.Layout
+  alias MingaEditor.Layout.SurfaceRegistry
+  alias MingaEditor.Layout.SurfaceRegistry.Placement
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+
+  defp single_window_layout do
+    %Layout{
+      terminal: {0, 0, 80, 24},
+      tab_bar: {0, 0, 80, 1},
+      editor_area: {1, 0, 80, 21},
+      file_tree: nil,
+      window_layouts: %{
+        1 => %{
+          total: {1, 0, 80, 21},
+          content: {1, 0, 80, 21},
+          modeline: {22, 0, 80, 0}
+        }
+      },
+      horizontal_separators: [],
+      agent_panel: nil,
+      status_bar: {22, 0, 80, 1},
+      minibuffer: {23, 0, 80, 1}
+    }
+  end
+
+  defp tree_nodes(%{children: children} = node) do
+    [node | Enum.flat_map(children, &tree_nodes/1)]
+  end
+
+  defp split_layout do
+    %Layout{
+      terminal: {0, 0, 80, 24},
+      tab_bar: {0, 0, 80, 1},
+      editor_area: {1, 0, 80, 21},
+      file_tree: {1, 0, 30, 21},
+      window_layouts: %{
+        1 => %{total: {1, 30, 25, 21}, content: {1, 30, 25, 21}, modeline: {22, 30, 25, 0}},
+        2 => %{total: {1, 55, 25, 21}, content: {1, 55, 25, 21}, modeline: {22, 55, 25, 0}}
+      },
+      horizontal_separators: [],
+      agent_panel: nil,
+      status_bar: {22, 0, 80, 1},
+      minibuffer: {23, 0, 80, 1}
+    }
+  end
+
+  defp placements_from_layout(layout) do
+    layout
+    |> FocusTree.from_layout()
+    |> SurfaceRegistry.from_tree()
+  end
+
+  describe "placements/from_tree" do
+    test "enumerates the canonical chrome surfaces with rects from the layout" do
+      placements = placements_from_layout(single_window_layout())
+      by_id = Map.new(placements, &{&1.surface_id, &1})
+
+      assert by_id[:tab_bar].rect == {0, 0, 80, 1}
+      assert by_id[:editor_area].rect == {1, 0, 80, 21}
+      assert by_id[:buffer_content].rect == {1, 0, 80, 21}
+      assert by_id[:status_bar].rect == {22, 0, 80, 1}
+      assert by_id[:minibuffer].rect == {23, 0, 80, 1}
+    end
+
+    test "skips nil chrome regions" do
+      layout = %{single_window_layout() | tab_bar: nil, status_bar: nil}
+      ids = layout |> placements_from_layout() |> Enum.map(& &1.surface_id)
+
+      refute :tab_bar in ids
+      refute :status_bar in ids
+      assert :editor_area in ids
+      assert :minibuffer in ids
+    end
+
+    test "the viewport root and window containers are not placed surfaces" do
+      ids = single_window_layout() |> placements_from_layout() |> Enum.map(& &1.surface_id)
+
+      refute :viewport in ids
+      refute :window in ids
+    end
+
+    test "ordering is back-to-front by z (non-decreasing)" do
+      zs = single_window_layout() |> placements_from_layout() |> Enum.map(& &1.z)
+      assert zs == Enum.sort(zs)
+    end
+
+    test "every placement carries a hit_kind" do
+      placements = single_window_layout() |> placements_from_layout()
+
+      assert Enum.all?(placements, fn %Placement{hit_kind: k} ->
+               k in [
+                 :text,
+                 :gutter,
+                 :fold_control,
+                 :modeline,
+                 :status_bar,
+                 :divider,
+                 :chrome,
+                 :overlay
+               ]
+             end)
+
+      buffer = Enum.find(placements, &(&1.surface_id == :buffer_content))
+      assert buffer.hit_kind == :text
+    end
+  end
+
+  # ── Behaviour neutrality: registry rect == focus-tree hit-test rect ──────────
+
+  describe "registry rect equals focus-tree hit-test rect (AC-1)" do
+    test "single-window layout: each placed surface's rect contains a hit that resolves to it" do
+      layout = single_window_layout()
+      tree = FocusTree.from_layout(layout)
+      placements = SurfaceRegistry.from_tree(tree)
+
+      # tab_bar surface rect: the focus-tree node hit at the surface origin must
+      # have the same rect the registry placed.
+      assert_surface_rect_matches_tree(tree, placements, :tab_bar)
+      assert_surface_rect_matches_tree(tree, placements, :status_bar)
+      assert_surface_rect_matches_tree(tree, placements, :minibuffer)
+      assert_surface_rect_matches_tree(tree, placements, :buffer_content)
+    end
+
+    test "split layout: one buffer_content placement per window, distinct rects" do
+      # Surface ids repeat deliberately in splits: each window's content is a
+      # real, independently placed surface. The future emitter ships one
+      # placement per window; rect_for_in/2 takes the topmost by z for
+      # single-rect consumers.
+      layout = split_layout()
+      tree = FocusTree.from_layout(layout)
+      placements = SurfaceRegistry.from_tree(tree)
+
+      content_placements =
+        Enum.filter(placements, &(&1.surface_id == :buffer_content))
+
+      window_count =
+        tree
+        |> tree_nodes()
+        |> Enum.count(&(&1.content_type == :window))
+
+      assert window_count > 1
+      assert length(content_placements) == window_count
+
+      rects = Enum.map(content_placements, & &1.rect)
+      assert length(Enum.uniq(rects)) == length(rects)
+    end
+
+    test "split layout: sidebar rect resolves via hit-test and agrees with the tree" do
+      layout = split_layout()
+      tree = FocusTree.from_layout(layout)
+      placements = SurfaceRegistry.from_tree(tree)
+
+      assert_surface_rect_matches_tree(tree, placements, :sidebar)
+    end
+
+    test "split layout: editor area rect equals the tree node rect (even when occluded at its origin)" do
+      # The sidebar overlays the editor area's top-left, so a hit at the editor
+      # area origin resolves to the sidebar. The registry rect must still equal
+      # the focus tree's editor_area node rect: same authoritative source.
+      layout = split_layout()
+      tree = FocusTree.from_layout(layout)
+      placements = SurfaceRegistry.from_tree(tree)
+
+      registry_rect = SurfaceRegistry.rect_for_in(placements, :editor_area)
+      tree_node = Enum.find(tree.children, &(&1.content_type == :editor_area))
+
+      assert registry_rect == tree_node.rect
+    end
+
+    test "rect_for_in returns the placed rect a hit-tester would read" do
+      placements = placements_from_layout(single_window_layout())
+      assert SurfaceRegistry.rect_for_in(placements, :tab_bar) == {0, 0, 80, 1}
+      assert SurfaceRegistry.rect_for_in(placements, :status_bar) == {22, 0, 80, 1}
+      assert SurfaceRegistry.rect_for_in(placements, :file_tree) == nil
+    end
+
+    test "within?/contains? matches FocusTree.Node half-open containment" do
+      assert SurfaceRegistry.contains?({0, 0, 80, 1}, 0, 0)
+      assert SurfaceRegistry.contains?({0, 0, 80, 1}, 0, 79)
+      refute SurfaceRegistry.contains?({0, 0, 80, 1}, 0, 80)
+      refute SurfaceRegistry.contains?({0, 0, 80, 1}, 1, 0)
+    end
+
+    # For each placed surface, hit the focus tree at the surface's top-left
+    # cell. The deepest tree node whose content_type maps back to that surface
+    # must carry the exact rect the registry placed. This is the "one source,
+    # test-proven" guarantee.
+    defp assert_surface_rect_matches_tree(tree, placements, surface_id) do
+      rect = SurfaceRegistry.rect_for_in(placements, surface_id)
+      assert rect, "expected #{surface_id} to be placed"
+
+      {r, c, _w, _h} = rect
+      path = FocusTree.hit_path(tree, r, c)
+
+      tree_node =
+        Enum.find(path, fn node ->
+          SurfaceRegistry.surface_id(node.content_type) == surface_id
+        end)
+
+      assert tree_node,
+             "expected focus-tree hit at (#{r},#{c}) to include a #{surface_id} node"
+
+      assert tree_node.rect == rect,
+             "registry rect #{inspect(rect)} != focus-tree rect #{inspect(tree_node.rect)} for #{surface_id}"
+    end
+  end
+
+  # ── Scope honesty: single active overlay only ───────────────────────────────
+
+  describe "single active overlay (AC-4)" do
+    test "with a bottom panel visible, the panel is placed as floating chrome above the editor" do
+      state = %MingaEditor.State{
+        port_manager: self(),
+        workspace: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()},
+        layout: single_window_layout(),
+        shell_state: %ShellState{bottom_panel: %BottomPanel{visible: true, height_percent: 25}}
+      }
+
+      placements = SurfaceRegistry.placements(state)
+      by_id = Map.new(placements, &{&1.surface_id, &1})
+
+      assert panel = by_id[:bottom_panel]
+      assert panel.z > by_id[:editor_area].z
+    end
+
+    test "no modal active: no overlay surfaces are placed" do
+      placements = placements_from_layout(single_window_layout())
+      overlay_ids = [:picker, :picker_backdrop, :completion_menu, :completion_backdrop]
+      assert Enum.all?(placements, &(&1.surface_id not in overlay_ids))
+    end
+  end
+
+  # ── Wire mapping coordination point (#2264) ─────────────────────────────────
+
+  describe "surface_id_u16 mapping" do
+    test "maps each placed surface id to a stable, unique u16" do
+      ids = [
+        :editor_area,
+        :tab_bar,
+        :buffer_content,
+        :agent_chat_content,
+        :modeline,
+        :file_tree,
+        :sidebar,
+        :custom_sidebar,
+        :agent_panel,
+        :status_bar,
+        :minibuffer,
+        :bottom_panel,
+        :picker_backdrop,
+        :picker,
+        :completion_backdrop,
+        :completion_menu
+      ]
+
+      u16s = Enum.map(ids, &SurfaceRegistry.surface_id_u16/1)
+
+      assert Enum.all?(u16s, &(&1 in 0..65_535))
+      assert length(Enum.uniq(u16s)) == length(u16s), "surface_id_u16 must be injective"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The wire-independent prep slice of #2268 (epic #2219 child E): `MingaEditor.Layout.SurfaceRegistry`, a pure calculation deriving ordered `{surface_id, rect, z, hit_kind}` placements by flattening the existing FocusTree — so **registry rects equal hit-test rects by construction**, the one-source property the epic demands. No wire emission (that's #2268 proper, after the transaction chain); no process, no ETS.

- Z bands gapped for the future sort-by-z compositor: base chrome 0, editor 100–102, floating 200, overlay backdrop/body 300/301 (reviewer-verified coherent: paint order and reverse hit-test precedence both fall out).
- **Contract fixed by review:** the first cut carried a dead dedup parameter whose docs promised one-placement-per-id; the real (and correct) contract is one placement per window in splits — each window's content is an independently placed surface. Docs now tell the truth and a split-layout test pins it.
- **Known gap, documented where child E starts:** Go's `overlayLines()` stacks surfaces that aren't focus-tree nodes yet (hover, signature, notifications, observatory, …). The gap lives in FocusTree coverage, not this module; promoting those is child E's work before composite-by-placement is complete.
- One behavior-neutral production change: `Mouse.tab_bar_click/3` reads the registry (same rect source via the cached tree, same half-open containment). AgentMouse subdivision, segment lookups, and intra-window geometry deliberately stay as handler interpretation per the epic's don't-force-it guidance, with reasons in the moduledoc.
- surface_id atom→u16 mapping is the single BEAM-side source until #2264's schema enum lands (coordination point in both moduledocs).

## Tests

- 14 registry tests incl. the AC-1 rect-equivalence proof (focus-tree node at surface origin carries exactly the placed rect, occlusion case included) and the per-window split contract
- Scoped suites 458 + mouse/focus-tree 61 post-fix; compile -W ok; make lint green; full suite green modulo the 5 environmental parser failures
- Acceptance reviewer: BLOCKED → fixed (dead parameter removed, docs reconciled, split test added, gap sentence recorded) — blocker resolution per its prescribed option (b)

Part of #2268 and #2219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)