### PR TITLE
refactor: inline_ask and inline_edit share one overlay framework

### DIFF
--- a/lib/minga_editor/inline_ask/events.ex
+++ b/lib/minga_editor/inline_ask/events.ex
@@ -1,9 +1,15 @@
 defmodule MingaEditor.InlineAsk.Events do
   @moduledoc """
   Routes ephemeral agent session events into inline ask state.
+
+  This is the ask variant adapter over the shared
+  `MingaEditor.InlineOverlay.Events` framework: it supplies the store
+  accessor/setter and the ask-specific event transitions, and delegates
+  the session lookup and write-back plumbing to the framework.
   """
 
   alias MingaAgent.EphemeralSession
+  alias MingaEditor.InlineOverlay.Events, as: Overlay
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.InlineAsk
 
@@ -11,30 +17,36 @@ defmodule MingaEditor.InlineAsk.Events do
 
   @doc "Returns true when a session belongs to an inline ask."
   @spec session?(state(), pid()) :: boolean()
-  def session?(%{shell_state: %{inline_asks: asks}}, session_pid)
-      when is_map(asks) and is_pid(session_pid) do
-    InlineAsk.session?(asks, session_pid)
-  end
-
-  def session?(_state, _session_pid), do: false
+  def session?(state, session_pid), do: Overlay.session?(state, session_pid, spec())
 
   @doc "Handles an agent event emitted by an inline ask session."
   @spec handle_event(state(), pid(), term()) :: state()
   def handle_event(state, session_pid, event) when is_pid(session_pid) do
-    update_for_session(state, session_pid, fn ask -> apply_event(ask, session_pid, event) end)
+    Overlay.handle_event(state, session_pid, event, spec(), &apply_event/3)
   end
 
   @doc "Handles the async result of sending the inline ask prompt."
   @spec handle_prompt_result(state(), pid(), term()) :: state()
-  def handle_prompt_result(state, _session_pid, :ok), do: state
-
-  def handle_prompt_result(state, session_pid, {:error, reason}) do
-    EphemeralSession.stop(session_pid)
-
-    update_for_session(state, session_pid, fn ask ->
-      InlineAsk.fail(ask, "Failed to ask: #{inspect(reason)}")
-    end)
+  def handle_prompt_result(state, session_pid, result) do
+    Overlay.handle_prompt_result(state, session_pid, result, spec(), &fail/2)
   end
+
+  @spec spec() :: Overlay.spec()
+  defp spec do
+    %{
+      store: &store/1,
+      set_store: &EditorState.set_inline_asks/2,
+      session?: &InlineAsk.session?/2
+    }
+  end
+
+  @spec store(state()) :: InlineAsk.store() | nil
+  defp store(%{shell_state: %{inline_asks: asks}}) when is_map(asks), do: asks
+  defp store(_state), do: nil
+
+  @spec fail(InlineAsk.t(), term()) :: InlineAsk.t()
+  defp fail(%InlineAsk{} = ask, reason),
+    do: InlineAsk.fail(ask, "Failed to ask: #{inspect(reason)}")
 
   @spec apply_event(InlineAsk.t(), pid(), term()) :: InlineAsk.t()
   defp apply_event(%InlineAsk{} = ask, _session_pid, {:text_delta, text}),
@@ -64,26 +76,4 @@ defmodule MingaEditor.InlineAsk.Events do
   end
 
   defp apply_event(%InlineAsk{} = ask, _session_pid, _event), do: ask
-
-  @spec update_for_session(state(), pid(), (InlineAsk.t() -> InlineAsk.t())) :: state()
-  defp update_for_session(%{shell_state: %{inline_asks: asks}} = state, session_pid, fun) do
-    {buffer_pid, ask} = find_by_session(asks, session_pid)
-
-    case ask do
-      %InlineAsk{} -> put_inline_asks(state, Map.put(asks, buffer_pid, fun.(ask)))
-      nil -> state
-    end
-  end
-
-  defp update_for_session(state, _session_pid, _fun), do: state
-
-  @spec find_by_session(InlineAsk.store(), pid()) :: {pid() | nil, InlineAsk.t() | nil}
-  defp find_by_session(asks, session_pid) do
-    Enum.find(asks, {nil, nil}, fn {_buffer_pid, ask} -> ask.session_pid == session_pid end)
-  end
-
-  @spec put_inline_asks(state(), InlineAsk.store()) :: state()
-  defp put_inline_asks(state, asks) do
-    EditorState.set_inline_asks(state, asks)
-  end
 end

--- a/lib/minga_editor/inline_ask/render.ex
+++ b/lib/minga_editor/inline_ask/render.ex
@@ -1,10 +1,16 @@
 defmodule MingaEditor.InlineAsk.Render do
   @moduledoc """
   Renders inline asks as transient block decorations.
+
+  This is the ask variant adapter over the shared
+  `MingaEditor.InlineOverlay.Render` framework: it supplies the ask-specific
+  spec (group, glyph, body, footer, faces) and the store accessor, and
+  delegates layout to the framework.
   """
 
   alias Minga.Core.Decorations
   alias Minga.Core.Face
+  alias MingaEditor.InlineOverlay.Render, as: Overlay
   alias MingaEditor.State.InlineAsk
 
   @group :inline_ask
@@ -14,11 +20,7 @@ defmodule MingaEditor.InlineAsk.Render do
   def merge_decorations(%Decorations{} = decorations, state, buffer_pid)
       when is_pid(buffer_pid) do
     ask = state |> inline_asks() |> InlineAsk.active(buffer_pid)
-
-    case ask do
-      %InlineAsk{} -> add_ask_block(decorations, ask)
-      nil -> decorations
-    end
+    Overlay.merge_decorations(decorations, ask, spec())
   end
 
   def merge_decorations(%Decorations{} = decorations, _state, _buffer_pid), do: decorations
@@ -31,48 +33,36 @@ defmodule MingaEditor.InlineAsk.Render do
 
   def active?(_state), do: false
 
-  @spec add_ask_block(Decorations.t(), InlineAsk.t()) :: Decorations.t()
-  defp add_ask_block(%Decorations{} = decorations, %InlineAsk{} = ask) do
-    {_id, decorations} =
-      Decorations.add_block_decoration(decorations, ask.anchor_line,
-        placement: :below,
-        height: :dynamic,
-        priority: 1000,
-        group: @group,
-        render: fn width -> render_ask(ask, width) end
-      )
-
-    %{decorations | version: decorations.version + :erlang.phash2(ask)}
+  @spec spec() :: Overlay.spec()
+  defp spec do
+    %{
+      group: @group,
+      priority: 1000,
+      anchor_line: & &1.anchor_line,
+      prompt_glyph: "? ",
+      prompt: & &1.prompt,
+      header: &InlineAsk.header/1,
+      input?: &(&1.status == :input),
+      body_lines: &response_lines/2,
+      footer: fn _ask -> "╰─ Esc dismiss · Tab promote to workspace" end,
+      face: &face/1
+    }
   end
 
-  @spec render_ask(InlineAsk.t(), pos_integer()) :: [[{String.t(), Face.t()}]]
-  defp render_ask(%InlineAsk{} = ask, width) do
-    content_width = max(width - 4, 10)
-    base = [line("╭─ " <> InlineAsk.header(ask), :header, width)]
-    prompt = [line("│ ? " <> ask.prompt <> prompt_cursor(ask), :input, width)]
-    body = response_lines(ask, content_width, width)
-    footer = [line("╰─ Esc dismiss · Tab promote to workspace", :help, width)]
-    base ++ prompt ++ body ++ footer
-  end
+  @spec response_lines(InlineAsk.t(), pos_integer()) :: [{String.t(), atom()}]
+  defp response_lines(%InlineAsk{status: :input}, _content_width), do: []
 
-  @spec response_lines(InlineAsk.t(), pos_integer(), pos_integer()) :: [[{String.t(), Face.t()}]]
-  defp response_lines(%InlineAsk{status: :input}, _content_width, _width), do: []
+  defp response_lines(%InlineAsk{status: :thinking}, _content_width),
+    do: [{"… thinking", :body}]
 
-  defp response_lines(%InlineAsk{status: :thinking}, _content_width, width),
-    do: [line("│ … thinking", :body, width)]
-
-  defp response_lines(%InlineAsk{response: response, scroll: scroll}, content_width, width) do
+  defp response_lines(%InlineAsk{response: response, scroll: scroll}, content_width) do
     response
     |> String.split("\n")
     |> Enum.flat_map(&wrap_line(&1, content_width))
     |> Enum.drop(scroll)
     |> Enum.take(8)
-    |> Enum.map(&line("│ " <> &1, :body, width))
+    |> Enum.map(&{&1, :body})
   end
-
-  @spec prompt_cursor(InlineAsk.t()) :: String.t()
-  defp prompt_cursor(%InlineAsk{status: :input}), do: "█"
-  defp prompt_cursor(%InlineAsk{}), do: ""
 
   @spec wrap_line(String.t(), pos_integer()) :: [String.t()]
   defp wrap_line("", _width), do: [""]
@@ -82,11 +72,6 @@ defmodule MingaEditor.InlineAsk.Render do
     |> String.graphemes()
     |> Enum.chunk_every(width)
     |> Enum.map(&Enum.join/1)
-  end
-
-  @spec line(String.t(), atom(), pos_integer()) :: [{String.t(), Face.t()}]
-  defp line(text, kind, width) do
-    [{String.slice(text, 0, width), face(kind)}]
   end
 
   @spec face(atom()) :: Face.t()

--- a/lib/minga_editor/inline_edit/events.ex
+++ b/lib/minga_editor/inline_edit/events.ex
@@ -1,9 +1,15 @@
 defmodule MingaEditor.InlineEdit.Events do
   @moduledoc """
   Routes ephemeral agent session events into inline edit state.
+
+  This is the edit variant adapter over the shared
+  `MingaEditor.InlineOverlay.Events` framework: it supplies the store
+  accessor/setter and the edit-specific event transitions, and delegates
+  the session lookup and write-back plumbing to the framework.
   """
 
   alias MingaAgent.EphemeralSession
+  alias MingaEditor.InlineOverlay.Events, as: Overlay
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.InlineEdit
 
@@ -11,30 +17,36 @@ defmodule MingaEditor.InlineEdit.Events do
 
   @doc "Returns true when a session belongs to an inline edit."
   @spec session?(state(), pid()) :: boolean()
-  def session?(%{shell_state: %{inline_edits: edits}}, session_pid)
-      when is_map(edits) and is_pid(session_pid) do
-    InlineEdit.session?(edits, session_pid)
-  end
-
-  def session?(_state, _session_pid), do: false
+  def session?(state, session_pid), do: Overlay.session?(state, session_pid, spec())
 
   @doc "Handles an agent event emitted by an inline edit session."
   @spec handle_event(state(), pid(), term()) :: state()
   def handle_event(state, session_pid, event) when is_pid(session_pid) do
-    update_for_session(state, session_pid, fn edit -> apply_event(edit, session_pid, event) end)
+    Overlay.handle_event(state, session_pid, event, spec(), &apply_event/3)
   end
 
   @doc "Handles the async result of sending the inline edit prompt."
   @spec handle_prompt_result(state(), pid(), term()) :: state()
-  def handle_prompt_result(state, _session_pid, :ok), do: state
-
-  def handle_prompt_result(state, session_pid, {:error, reason}) do
-    EphemeralSession.stop(session_pid)
-
-    update_for_session(state, session_pid, fn edit ->
-      InlineEdit.fail(edit, "Failed to rewrite: #{inspect(reason)}")
-    end)
+  def handle_prompt_result(state, session_pid, result) do
+    Overlay.handle_prompt_result(state, session_pid, result, spec(), &fail/2)
   end
+
+  @spec spec() :: Overlay.spec()
+  defp spec do
+    %{
+      store: &store/1,
+      set_store: &EditorState.set_inline_edits/2,
+      session?: &InlineEdit.session?/2
+    }
+  end
+
+  @spec store(state()) :: InlineEdit.store() | nil
+  defp store(%{shell_state: %{inline_edits: edits}}) when is_map(edits), do: edits
+  defp store(_state), do: nil
+
+  @spec fail(InlineEdit.t(), term()) :: InlineEdit.t()
+  defp fail(%InlineEdit{} = edit, reason),
+    do: InlineEdit.fail(edit, "Failed to rewrite: #{inspect(reason)}")
 
   @spec apply_event(InlineEdit.t(), pid(), term()) :: InlineEdit.t()
   defp apply_event(
@@ -82,21 +94,4 @@ defmodule MingaEditor.InlineEdit.Events do
 
   defp maybe_append_assistant_response(%InlineEdit{} = edit, response),
     do: InlineEdit.append_proposal(edit, response)
-
-  @spec update_for_session(state(), pid(), (InlineEdit.t() -> InlineEdit.t())) :: state()
-  defp update_for_session(%{shell_state: %{inline_edits: edits}} = state, session_pid, fun) do
-    {buffer_pid, edit} = find_by_session(edits, session_pid)
-
-    case edit do
-      %InlineEdit{} -> EditorState.set_inline_edits(state, Map.put(edits, buffer_pid, fun.(edit)))
-      nil -> state
-    end
-  end
-
-  defp update_for_session(state, _session_pid, _fun), do: state
-
-  @spec find_by_session(InlineEdit.store(), pid()) :: {pid() | nil, InlineEdit.t() | nil}
-  defp find_by_session(edits, session_pid) do
-    Enum.find(edits, {nil, nil}, fn {_buffer_pid, edit} -> edit.session_pid == session_pid end)
-  end
 end

--- a/lib/minga_editor/inline_edit/render.ex
+++ b/lib/minga_editor/inline_edit/render.ex
@@ -1,10 +1,16 @@
 defmodule MingaEditor.InlineEdit.Render do
   @moduledoc """
   Renders inline edits as transient block decorations.
+
+  This is the edit variant adapter over the shared
+  `MingaEditor.InlineOverlay.Render` framework: it supplies the
+  edit-specific spec (group, glyph, diff body, footer, faces) and the
+  store accessor, and delegates layout to the framework.
   """
 
   alias Minga.Core.Decorations
   alias Minga.Core.Face
+  alias MingaEditor.InlineOverlay.Render, as: Overlay
   alias MingaEditor.State.InlineEdit
 
   @group :inline_edit
@@ -14,46 +20,34 @@ defmodule MingaEditor.InlineEdit.Render do
   def merge_decorations(%Decorations{} = decorations, state, buffer_pid)
       when is_pid(buffer_pid) do
     edit = state |> inline_edits() |> InlineEdit.active(buffer_pid)
-
-    case edit do
-      %InlineEdit{} -> add_edit_block(decorations, edit)
-      nil -> decorations
-    end
+    Overlay.merge_decorations(decorations, edit, spec())
   end
 
   def merge_decorations(%Decorations{} = decorations, _state, _buffer_pid), do: decorations
 
-  @spec add_edit_block(Decorations.t(), InlineEdit.t()) :: Decorations.t()
-  defp add_edit_block(%Decorations{} = decorations, %InlineEdit{} = edit) do
-    {_id, decorations} =
-      Decorations.add_block_decoration(decorations, elem(edit.selection_range, 1),
-        placement: :below,
-        height: :dynamic,
-        priority: 1001,
-        group: @group,
-        render: fn width -> render_edit(edit, width) end
-      )
-
-    %{decorations | version: decorations.version + :erlang.phash2(edit)}
+  @spec spec() :: Overlay.spec()
+  defp spec do
+    %{
+      group: @group,
+      priority: 1001,
+      anchor_line: &elem(&1.selection_range, 1),
+      prompt_glyph: "✎ ",
+      prompt: & &1.prompt,
+      header: &InlineEdit.header/1,
+      input?: &(&1.status == :input),
+      body_lines: &body_lines/2,
+      footer: &footer_text/1,
+      face: &face/1
+    }
   end
 
-  @spec render_edit(InlineEdit.t(), pos_integer()) :: [[{String.t(), Face.t()}]]
-  defp render_edit(%InlineEdit{} = edit, width) do
-    content_width = max(width - 4, 10)
-    header = [line("╭─ " <> InlineEdit.header(edit), :header, width)]
-    prompt = [line("│ ✎ " <> edit.prompt <> prompt_cursor(edit), :input, width)]
-    body = body_lines(edit, content_width, width)
-    footer = [line(footer_text(edit), :help, width)]
-    header ++ prompt ++ body ++ footer
-  end
+  @spec body_lines(InlineEdit.t(), pos_integer()) :: [{String.t(), atom()}]
+  defp body_lines(%InlineEdit{status: :input}, _content_width), do: []
 
-  @spec body_lines(InlineEdit.t(), pos_integer(), pos_integer()) :: [[{String.t(), Face.t()}]]
-  defp body_lines(%InlineEdit{status: :input}, _content_width, _width), do: []
+  defp body_lines(%InlineEdit{status: :thinking}, _content_width),
+    do: [{"… thinking", :body}]
 
-  defp body_lines(%InlineEdit{status: :thinking}, _content_width, width),
-    do: [line("│ … thinking", :body, width)]
-
-  defp body_lines(%InlineEdit{} = edit, content_width, width) do
+  defp body_lines(%InlineEdit{} = edit, content_width) do
     removed = edit.original_text |> String.split("\n") |> Enum.map(&{"- " <> &1, :remove})
 
     added =
@@ -64,14 +58,8 @@ defmodule MingaEditor.InlineEdit.Render do
     (removed ++ added)
     |> Enum.drop(edit.scroll)
     |> Enum.take(10)
-    |> Enum.map(fn {text, face} ->
-      line("│ " <> String.slice(text, 0, content_width), face, width)
-    end)
+    |> Enum.map(fn {text, face} -> {String.slice(text, 0, content_width), face} end)
   end
-
-  @spec prompt_cursor(InlineEdit.t()) :: String.t()
-  defp prompt_cursor(%InlineEdit{status: :input}), do: "█"
-  defp prompt_cursor(%InlineEdit{}), do: ""
 
   @spec footer_text(InlineEdit.t()) :: String.t()
   defp footer_text(%InlineEdit{status: :input}), do: "╰─ Enter submit · Esc cancel"
@@ -82,9 +70,6 @@ defmodule MingaEditor.InlineEdit.Render do
   @spec status_face(InlineEdit.status()) :: atom()
   defp status_face(:error), do: :error
   defp status_face(_status), do: :add
-
-  @spec line(String.t(), atom(), pos_integer()) :: [{String.t(), Face.t()}]
-  defp line(text, kind, width), do: [{String.slice(text, 0, width), face(kind)}]
 
   @spec face(atom()) :: Face.t()
   defp face(:header), do: Face.new(fg: 0xC792EA, bold: true)

--- a/lib/minga_editor/inline_overlay/events.ex
+++ b/lib/minga_editor/inline_overlay/events.ex
@@ -1,0 +1,100 @@
+defmodule MingaEditor.InlineOverlay.Events do
+  @moduledoc """
+  Shared event-routing framework for inline overlays (ask and edit).
+
+  Both variants route ephemeral agent session events into per-buffer
+  overlay state in the same way: look up the overlay that owns a session
+  pid, apply a variant-specific transition, and write it back. This
+  module owns that shared plumbing (`session?/3`, `handle_event/4`,
+  `handle_prompt_result/4`, and the session lookup/update). The
+  variant-specific transitions (`apply_event`, the failure message) stay
+  in the adapters and are passed in as callbacks.
+
+  The `spec` map carries the store accessor, store setter, and the
+  `session?` predicate over the variant's state store.
+  """
+
+  alias MingaAgent.EphemeralSession
+  alias MingaEditor.State, as: EditorState
+
+  @typedoc """
+  Variant behaviour for an inline overlay event router.
+
+  * `:store` reads the variant's per-buffer overlay store off editor state.
+  * `:set_store` writes an updated store back onto editor state.
+  * `:session?` is true when a session pid belongs to this variant's store.
+  """
+  @type spec :: %{
+          store: (EditorState.t() -> %{pid() => struct()} | nil),
+          set_store: (EditorState.t(), %{pid() => struct()} -> EditorState.t()),
+          session?: (%{pid() => struct()}, pid() -> boolean())
+        }
+
+  @doc "Returns true when a session belongs to an overlay of this variant."
+  @spec session?(EditorState.t(), pid(), spec()) :: boolean()
+  def session?(state, session_pid, spec) when is_pid(session_pid) do
+    case spec.store.(state) do
+      store when is_map(store) -> spec.session?.(store, session_pid)
+      _ -> false
+    end
+  end
+
+  @doc """
+  Handles an agent event for the overlay that owns `session_pid`.
+
+  `apply_event` is the variant transition `(overlay, session_pid, event -> overlay)`.
+  """
+  @spec handle_event(EditorState.t(), pid(), term(), spec(), (struct(), pid(), term() -> struct())) ::
+          EditorState.t()
+  def handle_event(state, session_pid, event, spec, apply_event) when is_pid(session_pid) do
+    update_for_session(state, session_pid, spec, fn overlay ->
+      apply_event.(overlay, session_pid, event)
+    end)
+  end
+
+  @doc """
+  Handles the async result of sending the overlay's prompt.
+
+  On `{:error, reason}` the session is stopped and the overlay is failed
+  via `fail` (`(overlay, reason -> overlay)`).
+  """
+  @spec handle_prompt_result(EditorState.t(), pid(), term(), spec(), (struct(), term() ->
+                                                                        struct())) ::
+          EditorState.t()
+  def handle_prompt_result(state, _session_pid, :ok, _spec, _fail), do: state
+
+  def handle_prompt_result(state, session_pid, {:error, reason}, spec, fail) do
+    EphemeralSession.stop(session_pid)
+    update_for_session(state, session_pid, spec, fn overlay -> fail.(overlay, reason) end)
+  end
+
+  @doc """
+  Looks up the overlay that owns `session_pid`, applies `fun`, writes it back.
+
+  Returns the state unchanged when no overlay owns the session.
+  """
+  @spec update_for_session(EditorState.t(), pid(), spec(), (struct() -> struct())) ::
+          EditorState.t()
+  def update_for_session(state, session_pid, spec, fun) do
+    case spec.store.(state) do
+      store when is_map(store) ->
+        {buffer_pid, overlay} = find_by_session(store, session_pid)
+
+        if overlay do
+          spec.set_store.(state, Map.put(store, buffer_pid, fun.(overlay)))
+        else
+          state
+        end
+
+      _ ->
+        state
+    end
+  end
+
+  @spec find_by_session(%{pid() => struct()}, pid()) :: {pid() | nil, struct() | nil}
+  defp find_by_session(store, session_pid) do
+    Enum.find(store, {nil, nil}, fn {_buffer_pid, overlay} ->
+      overlay.session_pid == session_pid
+    end)
+  end
+end

--- a/lib/minga_editor/inline_overlay/render.ex
+++ b/lib/minga_editor/inline_overlay/render.ex
@@ -1,0 +1,105 @@
+defmodule MingaEditor.InlineOverlay.Render do
+  @moduledoc """
+  Shared rendering framework for inline overlays (ask and edit).
+
+  Inline asks and inline edits are near-twins: each renders a transient
+  block decoration anchored to a buffer line, with a header, a prompt
+  line, a status-dependent body, and a footer. This module owns that
+  common skeleton. The variant-specific pieces (group, priority, anchor,
+  prompt glyph, body lines, footer text, and the face palette) are
+  supplied as a `spec` map, so neither variant branches inside the call
+  site.
+
+  Variant adapters (`MingaEditor.InlineAsk.Render`,
+  `MingaEditor.InlineEdit.Render`) provide the spec and the store
+  accessor; this module does the layout.
+  """
+
+  alias Minga.Core.Decorations
+  alias Minga.Core.Face
+
+  @typedoc """
+  Variant behaviour for an inline overlay renderer.
+
+  * `:group` / `:priority` / `:anchor_line` configure the block decoration.
+  * `:prompt_glyph` is the marker shown before the prompt text (`"? "`, `"✎ "`).
+  * `:prompt` reads the in-progress prompt string off the overlay struct.
+  * `:header` returns the header text (without the `╭─ ` border).
+  * `:input?` is true while the overlay is still accepting prompt input
+    (the prompt cursor blinks only then).
+  * `:body_lines` returns the status-dependent body as `{text, face_kind}`
+    tuples, already trimmed to `content_width`.
+  * `:footer` returns the footer text (including the `╰─ ` border).
+  * `:face` maps a face kind atom to a `Face.t()`.
+  """
+  @type spec :: %{
+          group: atom(),
+          priority: non_neg_integer(),
+          anchor_line: (struct() -> non_neg_integer()),
+          prompt_glyph: String.t(),
+          prompt: (struct() -> String.t()),
+          header: (struct() -> String.t()),
+          input?: (struct() -> boolean()),
+          body_lines: (struct(), pos_integer() -> [{String.t(), atom()}]),
+          footer: (struct() -> String.t()),
+          face: (atom() -> Face.t())
+        }
+
+  @doc """
+  Merges an overlay block decoration for `overlay` into `decorations`.
+
+  When `overlay` is `nil` the decorations are returned unchanged, which
+  lets adapters pipe the active-overlay lookup straight in.
+  """
+  @spec merge_decorations(Decorations.t(), struct() | nil, spec()) :: Decorations.t()
+  def merge_decorations(%Decorations{} = decorations, nil, _spec), do: decorations
+
+  def merge_decorations(%Decorations{} = decorations, overlay, spec) when is_map(spec) do
+    {_id, decorations} =
+      Decorations.add_block_decoration(decorations, spec.anchor_line.(overlay),
+        placement: :below,
+        height: :dynamic,
+        priority: spec.priority,
+        group: spec.group,
+        render: fn width -> render(overlay, width, spec) end
+      )
+
+    %{decorations | version: decorations.version + :erlang.phash2(overlay)}
+  end
+
+  @spec render(struct(), pos_integer(), spec()) :: [[{String.t(), Face.t()}]]
+  defp render(overlay, width, spec) do
+    content_width = max(width - 4, 10)
+    header = [line("╭─ " <> spec.header.(overlay), :header, width, spec)]
+
+    prompt = [
+      line(
+        "│ " <> spec.prompt_glyph <> spec.prompt.(overlay) <> cursor(overlay, spec),
+        :input,
+        width,
+        spec
+      )
+    ]
+
+    body = body(overlay, content_width, width, spec)
+    footer = [line(spec.footer.(overlay), :help, width, spec)]
+    header ++ prompt ++ body ++ footer
+  end
+
+  @spec body(struct(), pos_integer(), pos_integer(), spec()) :: [[{String.t(), Face.t()}]]
+  defp body(overlay, content_width, width, spec) do
+    overlay
+    |> spec.body_lines.(content_width)
+    |> Enum.map(fn {text, kind} -> line("│ " <> text, kind, width, spec) end)
+  end
+
+  @spec cursor(struct(), spec()) :: String.t()
+  defp cursor(overlay, spec) do
+    if spec.input?.(overlay), do: "█", else: ""
+  end
+
+  @spec line(String.t(), atom(), pos_integer(), spec()) :: [{String.t(), Face.t()}]
+  defp line(text, kind, width, spec) do
+    [{String.slice(text, 0, width), spec.face.(kind)}]
+  end
+end


### PR DESCRIPTION
## Summary

Item 2 of #2221, in two honestly-different halves:

**Part A — dashboard: no change needed.** The audit (reviewer-confirmed) found the non-agent dashboard already collapsed to exactly one renderer post-deletion-wave; the other dashboard-named files are a cursor state machine, an input handler, and a modal payload — state, not render paths. The duplication the root-cause analysis flagged was eliminated by the upstream deletions.

**Part B — the inline twins consolidated.** `InlineOverlay.Render` owns the shared block-decoration layout once; `InlineOverlay.Events` owns the session plumbing once; the four public modules become thin variant adapters (faces, `? ` vs `✎ ` glyphs, footers, priorities 1000/1001, and the genuinely variant event clauses like edit's `produce_rewrite`). Extract-don't-branch via spec maps that raise on missing keys. The reviewer verified UX strings/faces/cursor/slicing byte-for-byte against HEAD, spec-map totality, and that coexisting ask+edit overlays keep their relative priority (the framework is invoked per-variant and cannot reorder them).

**Zero test modifications** — all 32 inline tests pass unchanged, the strongest preservation signal a pure refactor can offer.

## Tests

- Inline suites 32 (unchanged), dashboard suites 28; compile -W ok; make lint exit 0; full suite green modulo the 5 environmental parser failures (stash-verified pre-existing)
- Acceptance reviewer: PASS (all five verification points, including arg-order spot-checks on the spec callbacks)

Part of #2221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)