### PR TITLE
feat(protocol): BEAM-authoritative surface placements over the wire

### DIFF
--- a/go/tui/internal/protocol/chrome_decode.go
+++ b/go/tui/internal/protocol/chrome_decode.go
@@ -81,6 +81,8 @@ func decodeChrome(payload []byte) ChromePayload {
 		chrome.ConfigState, chrome.Summary, chrome.Bytes = decodeConfigState(payload)
 	case generated.OPGuiSplitSeparators:
 		chrome.Splits, chrome.Summary, chrome.Bytes = decodeSplitSeparators(payload)
+	case generated.OPGuiSurfaceLayout:
+		chrome.Placements, chrome.Summary, chrome.Bytes = decodeSurfaceLayout(payload)
 	default:
 		// Size unhandled chrome through the schema authority; fall back to the
 		// sectioned envelope only if the opcode is not generically sized.

--- a/go/tui/internal/protocol/chrome_layout.go
+++ b/go/tui/internal/protocol/chrome_layout.go
@@ -1,0 +1,53 @@
+package protocol
+
+import (
+	"fmt"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+)
+
+// decodeSurfaceLayout decodes gui_surface_layout (0xA4, #2268): the BEAM's
+// authoritative per-frame surface placement list. It is sectioned framing
+// (opcode, section_count, section{id, len16, body}) with a single section,
+// placements (id 0x01), holding a counted array of surface_placement. Each
+// placement carries a surface_id, a terminal-cell rect, a z band, and a
+// hit_kind. The list IS the compositing order (sort by z) and the same list
+// BEAM mouse hit-testing routes against, so a placement's rect is the surface's
+// hit rect by construction.
+//
+// The section body is decoded with the schema-generated
+// DecodeGuiSurfaceLayoutPlacements (the exact inverse of the Elixir
+// SurfaceLayoutEncoder), bounded by [sectionStart, sectionEnd) so a short or
+// malformed section degrades to an empty list rather than overrunning the
+// batch.
+func decodeSurfaceLayout(payload []byte) ([]generated.SurfacePlacement, string, int) {
+	size := sectionedSize(payload)
+	if size == 0 || len(payload) < 2 {
+		return nil, "", min(len(payload), 2)
+	}
+
+	var placements []generated.SurfacePlacement
+	offset := 2
+	for i := 0; i < int(payload[1]); i++ {
+		if len(payload) < offset+3 {
+			break
+		}
+		sectionID := payload[offset]
+		sectionLen := int(u16(payload, offset+1))
+		sectionStart := offset + 3
+		sectionEnd := sectionStart + sectionLen
+		offset = sectionEnd
+		if sectionEnd > len(payload) {
+			break
+		}
+
+		if sectionID == 0x01 {
+			if p, _, err := generated.DecodeGuiSurfaceLayoutPlacements(payload, sectionStart, sectionEnd); err == nil {
+				placements = p
+			}
+		}
+	}
+
+	summary := fmt.Sprintf("%d surfaces", len(placements))
+	return placements, summary, size
+}

--- a/go/tui/internal/protocol/chrome_layout_test.go
+++ b/go/tui/internal/protocol/chrome_layout_test.go
@@ -1,0 +1,80 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+)
+
+// surfacePlacement builds a 13-byte surface_placement body:
+// surface_id(u16) rect(row,col,width,height : u16) z(u16) hit_kind(u8).
+func surfacePlacement(surfaceID, row, col, width, height, z uint16, hitKind byte) []byte {
+	be16 := func(v uint16) []byte { return []byte{byte(v >> 8), byte(v)} }
+	out := be16(surfaceID)
+	out = append(out, be16(row)...)
+	out = append(out, be16(col)...)
+	out = append(out, be16(width)...)
+	out = append(out, be16(height)...)
+	out = append(out, be16(z)...)
+	return append(out, hitKind)
+}
+
+func TestDecodeSurfaceLayoutDecodesPlacements(t *testing.T) {
+	body := []byte{0, 2} // count = 2
+	body = append(body, surfacePlacement(1, 0, 0, 80, 24, 0, 1)...)
+	body = append(body, surfacePlacement(16, 5, 10, 40, 12, 301, 8)...)
+
+	packet := []byte{generated.OPGuiSurfaceLayout, 1}
+	packet = append(packet, section(0x01, body)...)
+	// A following command must not be swallowed: the layout command must report
+	// its own bounded size.
+	packet = append(packet, generated.OPCommitFrame, 0, 0, 0, 0, 0, 0, 0, 0)
+
+	first, err := DecodeCommand(packet)
+	if err != nil {
+		t.Fatalf("DecodeCommand returned error: %v", err)
+	}
+	if first.Kind != CommandChrome {
+		t.Fatalf("kind = %v, want chrome", first.Kind)
+	}
+	if first.Size != len(packet)-9 {
+		t.Fatalf("surface layout size = %d, want %d (must not swallow commit_frame)", first.Size, len(packet)-9)
+	}
+
+	placements := first.Chrome.Placements
+	if len(placements) != 2 {
+		t.Fatalf("placements = %d, want 2", len(placements))
+	}
+	want0 := generated.SurfacePlacement{SurfaceID: 1, Rect: generated.Rect{Row: 0, Col: 0, Width: 80, Height: 24}, Z: 0, HitKind: 1}
+	want1 := generated.SurfacePlacement{SurfaceID: 16, Rect: generated.Rect{Row: 5, Col: 10, Width: 40, Height: 12}, Z: 301, HitKind: 8}
+	if placements[0] != want0 {
+		t.Fatalf("placement[0] = %+v, want %+v", placements[0], want0)
+	}
+	if placements[1] != want1 {
+		t.Fatalf("placement[1] = %+v, want %+v", placements[1], want1)
+	}
+
+	second, err := DecodeCommand(packet[first.Size:])
+	if err != nil {
+		t.Fatalf("following commit_frame decode error: %v", err)
+	}
+	if second.Kind != CommandCommitFrame {
+		t.Fatalf("second kind = %v, want commit frame", second.Kind)
+	}
+}
+
+func TestDecodeSurfaceLayoutEmptyList(t *testing.T) {
+	packet := []byte{generated.OPGuiSurfaceLayout, 1}
+	packet = append(packet, section(0x01, []byte{0, 0})...) // count = 0
+
+	cmd, err := DecodeCommand(packet)
+	if err != nil {
+		t.Fatalf("DecodeCommand returned error: %v", err)
+	}
+	if len(cmd.Chrome.Placements) != 0 {
+		t.Fatalf("empty layout decoded %d placements, want 0", len(cmd.Chrome.Placements))
+	}
+	if cmd.Size != len(packet) {
+		t.Fatalf("empty layout size = %d, want %d", cmd.Size, len(packet))
+	}
+}

--- a/go/tui/internal/protocol/commands.go
+++ b/go/tui/internal/protocol/commands.go
@@ -113,6 +113,11 @@ type ChromePayload struct {
 	ConfigState       ConfigState
 	ToolManager       ToolManager
 	Splits            SplitSeparators
+	// Placements carries the authoritative per-frame surface layout from
+	// gui_surface_layout (0xA4, #2268): the BEAM's one rect+z list that drives
+	// compositing order (sort by Z) and is the same list BEAM mouse hit-testing
+	// uses. Empty when the opcode is absent.
+	Placements []generated.SurfacePlacement
 }
 
 type WindowContent struct {

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -97,6 +97,13 @@ type Model struct {
 	// BEAM for a keyframe (#2219). It drives a subtle footer indicator while the
 	// frontend waits, and clears when a valid commit applies.
 	resyncPending bool
+	// surfacePlacements is the BEAM's authoritative per-frame surface layout from
+	// gui_surface_layout (0xA4, #2268): one rect+z list. Compositing reads the z
+	// of a placed surface to order it instead of the old hand-coded
+	// overlayLines() precedence chain; the rects equal what BEAM mouse
+	// hit-testing uses. Surfaces not yet promoted into the BEAM surface registry
+	// keep a reduced hand-ordered chain (transitional split, see overlayLines).
+	surfacePlacements []generated.SurfacePlacement
 }
 
 // frameStaging is the open frame transaction buffer (#2219). It lives only
@@ -468,6 +475,11 @@ func (m *Model) applyMutation(command protocol.Command) {
 			m.applyFileTreeSelection(command.Chrome.FileTreeSelection)
 		case generated.OPGuiBottomPanel:
 			m.clampBottomPanelScrollback(command.Chrome.Bottom)
+		case generated.OPGuiSurfaceLayout:
+			// The authoritative per-frame surface layout (#2268). Replace wholesale
+			// each frame: it is a full snapshot, not a delta, and an absent opcode
+			// (older BEAM) leaves the prior list which compositing tolerates.
+			m.surfacePlacements = command.Chrome.Placements
 		}
 	}
 }

--- a/go/tui/internal/ui/render_surfaces.go
+++ b/go/tui/internal/ui/render_surfaces.go
@@ -10,48 +10,172 @@ import (
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
 )
 
-func (m Model) overlayLines() []string {
-	if completion, ok := m.completion(); ok && completion.Visible && len(completion.Items) > 0 {
-		return m.renderCompletion(completion)
-	}
-	if hover, ok := m.hoverPopup(); ok && hover.Visible && len(hover.Lines) > 0 {
-		return m.renderHover(hover)
-	}
-	if sig, ok := m.signatureHelp(); ok && sig.Visible && len(sig.Signatures) > 0 {
-		return m.renderSignature(sig)
-	}
-	if float, ok := m.floatPopup(); ok && float.Visible {
-		return m.renderFloat(float)
-	}
-	if context, ok := m.agentContext(); ok && context.Visible {
-		return m.renderAgentContext(context)
-	}
-	if chat, ok := m.agentChat(); ok && chat.Visible {
-		return m.renderAgentChat(chat)
-	}
-	if tools, ok := m.toolManager(); ok && tools.Visible {
-		return m.renderToolManager(tools)
-	}
-	if bottom, ok := m.bottomPanel(); ok && bottom.Visible {
-		return m.renderBottomPanel(bottom)
-	}
-	if ext, ok := m.extensionPanel(); ok && len(ext.Panels) > 0 {
-		return m.renderExtensionPanels(ext)
-	}
-	if obs, ok := m.observatory(); ok && obs.Visible {
-		return m.renderObservatory(obs)
-	}
-	if timeline, ok := m.editTimeline(); ok && timeline.Visible {
-		return m.renderEditTimeline(timeline)
-	}
-	if notes, ok := m.notifications(); ok && notes.Visible && len(notes.Items) > 0 {
-		return m.renderNotifications(notes)
-	}
-	if overlay, ok := m.extensionOverlay(); ok && len(overlay.Entries) > 0 {
-		return m.renderExtensionOverlay(overlay)
-	}
-	return nil
+// Registry surface ids (mirror MingaEditor.Layout.SurfaceRegistry.surface_id_u16/1).
+// Only the overlay surfaces the BEAM registry actually places are listed here;
+// the rest of the overlay candidates are not yet promoted into the registry
+// (transitional split, #2268; follow-up #2281 promotes them).
+const (
+	surfaceIDBottomPanel    uint16 = 12
+	surfaceIDCompletionMenu uint16 = 16
+)
+
+// overlayCandidate is one floating surface that may occupy the single active
+// overlay slot. order is its stacking key on one comparable z-band scale: lower
+// paints further back, so the HIGHEST-order visible candidate wins. For surfaces
+// the BEAM registry places, order is the BEAM-authoritative placement z (data,
+// looked up by surfaceID). For not-yet-promoted surfaces it is a transitional
+// order derived from the same registry z bands at its old relative position, so
+// the two are directly comparable. Either way the precedence is no longer a
+// hardcoded if-ladder: it is sorted data.
+type overlayCandidate struct {
+	visible bool
+	order   int
+	render  func() []string
 }
+
+// overlayLines returns the single active overlay's lines (the BEAM emits a
+// single-active-overlay decision; multiple simultaneous overlays remain out of
+// scope, #2268 AC-4). The precedence chain is deleted: candidates are collected
+// and the front-most visible one (highest order) wins, where a placed surface's
+// order is its gui_surface_layout z and an unplaced surface's order is a
+// documented transitional rank.
+func (m Model) overlayLines() []string {
+	candidates := m.overlayCandidates()
+
+	best := -1
+	var winner func() []string
+	for _, c := range candidates {
+		if c.visible && c.order > best {
+			best = c.order
+			winner = c.render
+		}
+	}
+	if winner == nil {
+		return nil
+	}
+	return winner()
+}
+
+// overlayCandidates lists every floating overlay surface with its stacking
+// order on ONE comparable scale. Placed surfaces (completion, bottom panel) use
+// their BEAM placement z directly; the not-yet-promoted surfaces use
+// transitional orders derived from the same registry z bands, slotted at their
+// old relative positions, until each is promoted into the BEAM surface registry
+// (#2281). Because everything shares the band scale, the old top-to-bottom
+// precedence is preserved exactly: completion (overlay band, top) > the six
+// floating overlays that historically sat above the bottom panel > bottom panel
+// (floating band, z=200) > the lower transitional set.
+func (m Model) overlayCandidates() []overlayCandidate {
+	completion, completionOK := m.completion()
+	hover, hoverOK := m.hoverPopup()
+	sig, sigOK := m.signatureHelp()
+	float, floatOK := m.floatPopup()
+	context, contextOK := m.agentContext()
+	chat, chatOK := m.agentChat()
+	tools, toolsOK := m.toolManager()
+	bottom, bottomOK := m.bottomPanel()
+	ext, extOK := m.extensionPanel()
+	obs, obsOK := m.observatory()
+	timeline, timelineOK := m.editTimeline()
+	notes, notesOK := m.notifications()
+	overlay, overlayOK := m.extensionOverlay()
+
+	return []overlayCandidate{
+		// Completion is registry-placed in the overlay band (z=301): it sits at the
+		// top, beating every transitional overlay below the overlay band, exactly
+		// as the old chain listed it first. Fallback orderOverlayTop is used only
+		// when the BEAM emits no placement for it (older BEAM / absent this frame).
+		{
+			visible: completionOK && completion.Visible && len(completion.Items) > 0,
+			order:   m.surfaceOrder(surfaceIDCompletionMenu, orderOverlayTop),
+			render:  func() []string { return m.renderCompletion(completion) },
+		},
+		// ── transitional overlays that historically sat ABOVE the bottom panel ──
+		// These live between the floating band (200) and the overlay band (300),
+		// preserving their old relative order: hover > signature > float >
+		// agentContext > agentChat > toolManager.
+		{visible: hoverOK && hover.Visible && len(hover.Lines) > 0, order: orderHover, render: func() []string { return m.renderHover(hover) }},
+		{visible: sigOK && sig.Visible && len(sig.Signatures) > 0, order: orderSignatureHelp, render: func() []string { return m.renderSignature(sig) }},
+		{visible: floatOK && float.Visible, order: orderFloatPopup, render: func() []string { return m.renderFloat(float) }},
+		{visible: contextOK && context.Visible, order: orderAgentContext, render: func() []string { return m.renderAgentContext(context) }},
+		{visible: chatOK && chat.Visible, order: orderAgentChat, render: func() []string { return m.renderAgentChat(chat) }},
+		{visible: toolsOK && tools.Visible, order: orderToolManager, render: func() []string { return m.renderToolManager(tools) }},
+		// Bottom panel is registry-placed in the floating band (z=200): it sits
+		// BELOW the six overlays above and ABOVE the lower transitional set, exactly
+		// as the old chain ordered it. Fallback orderBottomPanelFallback keeps that
+		// relative position when no placement is emitted.
+		{
+			visible: bottomOK && bottom.Visible,
+			order:   m.surfaceOrder(surfaceIDBottomPanel, orderBottomPanelFallback),
+			render:  func() []string { return m.renderBottomPanel(bottom) },
+		},
+		// ── transitional overlays that historically sat BELOW the bottom panel ──
+		// Below the floating band (200), preserving their old relative order.
+		{visible: extOK && len(ext.Panels) > 0, order: orderExtensionPanel, render: func() []string { return m.renderExtensionPanels(ext) }},
+		{visible: obsOK && obs.Visible, order: orderObservatory, render: func() []string { return m.renderObservatory(obs) }},
+		{visible: timelineOK && timeline.Visible, order: orderEditTimeline, render: func() []string { return m.renderEditTimeline(timeline) }},
+		{visible: notesOK && notes.Visible && len(notes.Items) > 0, order: orderNotifications, render: func() []string { return m.renderNotifications(notes) }},
+		{visible: overlayOK && len(overlay.Entries) > 0, order: orderExtensionOverlay, render: func() []string { return m.renderExtensionOverlay(overlay) }},
+	}
+}
+
+// surfaceOrder returns the BEAM placement z for a registry-placed surface, used
+// directly on the shared band scale, or the transitional fallback when the BEAM
+// has not (yet) emitted a placement for it (older BEAM, or the surface absent
+// from this frame's layout). The placement z and the transitional orders below
+// are derived from the SAME registry z bands, so a placed surface's data z and
+// an unplaced surface's transitional order are comparable on one scale.
+func (m Model) surfaceOrder(surfaceID uint16, fallback int) int {
+	for _, p := range m.surfacePlacements {
+		if p.SurfaceID == surfaceID {
+			return int(p.Z)
+		}
+	}
+	return fallback
+}
+
+// Transitional stacking orders for the not-yet-promoted overlay surfaces (#2281
+// deletes this whole table once they are promoted/placed). They are derived from
+// the registry z bands in MingaEditor.Layout.SurfaceRegistry (base 0 / editor
+// 100 / floating 200 / overlay 300; bottom_panel emits z=200, completion_menu
+// emits z=300+1). Go cannot import the Elixir bands, so this coupling is
+// documented explicitly: keep these values in step with surface_registry.ex.
+//
+// Scale, highest paints front-most:
+//   - completion (placed, overlay band, z=301) sits on top.
+//   - the six overlays that historically sat above the bottom panel occupy
+//     210..290, between the floating band (200) and the overlay band (300),
+//     preserving their old relative order.
+//   - bottom_panel (placed, floating band, z=200) sits below those six.
+//   - the lower transitional set occupies 150..199, below the floating band,
+//     preserving its old relative order.
+const (
+	// Above the bottom panel (200) and below the overlay band (300).
+	orderHover         = 290
+	orderSignatureHelp = 280
+	orderFloatPopup    = 270
+	orderAgentContext  = 260
+	orderAgentChat     = 250
+	orderToolManager   = 240
+
+	// Below the bottom panel (200).
+	orderExtensionPanel   = 190
+	orderObservatory      = 180
+	orderEditTimeline     = 170
+	orderNotifications    = 160
+	orderExtensionOverlay = 150
+
+	// orderOverlayTop is the fallback for completion when the BEAM emits no
+	// placement: it must outrank every transitional order, matching the live
+	// completion_menu z (overlay band + 1 = 301).
+	orderOverlayTop = 301
+
+	// orderBottomPanelFallback is the fallback for the bottom panel when the BEAM
+	// emits no placement: it sits at the floating band (200), keeping the bottom
+	// panel below the six overlays above and above the lower transitional set,
+	// exactly as the old chain ordered it.
+	orderBottomPanelFallback = 200
+)
 
 func (m Model) renderHover(hover protocol.HoverPopup) []string {
 	style := m.panelStyle()

--- a/go/tui/internal/ui/surface_layout_order_test.go
+++ b/go/tui/internal/ui/surface_layout_order_test.go
@@ -1,0 +1,140 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+// overlayLines stacking order is data (#2268 AC-2): the precedence chain is
+// deleted, so a placement z that inverts the old hand order must change which
+// surface occupies the single active overlay slot.
+
+func completionAndBottomPanelModel() Model {
+	model := New(80, 16, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiCompletion: {
+			Opcode:   generated.OPGuiCompletion,
+			Complete: protocol.Completion{Visible: true, Items: []protocol.CompletionItem{{Label: "Enum.map"}}},
+		},
+		generated.OPGuiBottomPanel: {
+			Opcode: generated.OPGuiBottomPanel,
+			Bottom: protocol.BottomPanel{Visible: true, Tabs: []protocol.PanelTab{{Type: 0x01, Name: "Messages"}}, Messages: []protocol.PanelMessage{{ID: 1, Level: 1, Text: "panel-msg"}}},
+		},
+	}
+	return model
+}
+
+func TestOverlayPrecedenceDefaultsToCompletionWhenNoPlacements(t *testing.T) {
+	// With no gui_surface_layout emitted (older BEAM), the band-derived fallbacks
+	// reproduce the old chain: completion (orderOverlayTop) outranks the bottom
+	// panel (orderBottomPanelFallback).
+	model := completionAndBottomPanelModel()
+	got := strings.Join(model.overlayLines(), "\n")
+	if !strings.Contains(got, "Enum.map") {
+		t.Fatalf("expected completion to win the overlay slot, got %q", got)
+	}
+	if strings.Contains(got, "panel-msg") {
+		t.Fatalf("bottom panel should not win over completion by default, got %q", got)
+	}
+}
+
+func TestOverlayPrecedenceFollowsPlacementZ(t *testing.T) {
+	// The BEAM places the bottom panel ABOVE completion (higher z). Stacking
+	// order is data, so the bottom panel now wins the single active overlay slot,
+	// inverting the old hand-coded chain. This is the AC-2 proof that the
+	// precedence is sorted placement data, not an if-ladder.
+	model := completionAndBottomPanelModel()
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDCompletionMenu, Z: 10, HitKind: 8},
+		{SurfaceID: surfaceIDBottomPanel, Z: 20, HitKind: 7},
+	}
+
+	got := strings.Join(model.overlayLines(), "\n")
+	if !strings.Contains(got, "panel-msg") {
+		t.Fatalf("expected bottom panel to win when placed above completion, got %q", got)
+	}
+	if strings.Contains(got, "Enum.map") {
+		t.Fatalf("completion should not win when the bottom panel is placed above it, got %q", got)
+	}
+}
+
+func TestOverlayPlacedSurfaceBeatsUnplacedSurface(t *testing.T) {
+	// A registry-placed surface (completion, overlay band z=301) outranks an
+	// unplaced transitional surface (agent context, order 260), preserving the old
+	// chain where completion sat on top. Orders share one band scale now, so the
+	// placement z must be in the overlay band to win, as the live registry emits.
+	model := New(80, 16, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiCompletion:   {Opcode: generated.OPGuiCompletion, Complete: protocol.Completion{Visible: true, Items: []protocol.CompletionItem{{Label: "Enum.map"}}}},
+		generated.OPGuiAgentContext: {Opcode: generated.OPGuiAgentContext, AgentContext: protocol.AgentContext{Visible: true, Task: "Review diff", Status: 1}},
+	}
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDCompletionMenu, Z: 301, HitKind: 8},
+	}
+
+	got := strings.Join(model.overlayLines(), "\n")
+	if !strings.Contains(got, "Enum.map") || strings.Contains(got, "Review diff") {
+		t.Fatalf("placed completion should beat unplaced agent context, got %q", got)
+	}
+}
+
+func TestOverlayBottomPanelOpenHoverWins(t *testing.T) {
+	// Regression for the stacking inversion (#2268 AC-2): the diagnostics/messages
+	// bottom panel and an LSP hover popup are independently visible. The old chain
+	// put hover ABOVE the bottom panel, and the band-aligned scale preserves that
+	// (orderHover 290 > bottom panel floating band 200). Hover must win the single
+	// active overlay slot, even with the bottom panel placed at its registry z.
+	model := New(80, 16, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiBottomPanel: {
+			Opcode: generated.OPGuiBottomPanel,
+			Bottom: protocol.BottomPanel{Visible: true, Tabs: []protocol.PanelTab{{Type: 0x01, Name: "Messages"}}, Messages: []protocol.PanelMessage{{ID: 1, Level: 1, Text: "panel-msg"}}},
+		},
+		generated.OPGuiHoverPopup: {
+			Opcode: generated.OPGuiHoverPopup,
+			Hover:  protocol.HoverPopup{Visible: true, Lines: []protocol.RichLine{{Segments: []protocol.RichSegment{{Text: "hover-doc"}}}}},
+		},
+	}
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDBottomPanel, Z: 200, HitKind: 7},
+	}
+
+	got := strings.Join(model.overlayLines(), "\n")
+	if !strings.Contains(got, "hover-doc") {
+		t.Fatalf("hover should win over the open bottom panel, got %q", got)
+	}
+	if strings.Contains(got, "panel-msg") {
+		t.Fatalf("bottom panel must not win over hover, got %q", got)
+	}
+}
+
+func TestOverlayBottomPanelOpenSignatureHelpWins(t *testing.T) {
+	// Same inversion guard for signature help: it historically sat above the
+	// bottom panel (orderSignatureHelp 280 > floating band 200), so with the panel
+	// open, triggering signature help must still show the signature popup.
+	model := New(80, 16, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiBottomPanel: {
+			Opcode: generated.OPGuiBottomPanel,
+			Bottom: protocol.BottomPanel{Visible: true, Tabs: []protocol.PanelTab{{Type: 0x01, Name: "Messages"}}, Messages: []protocol.PanelMessage{{ID: 1, Level: 1, Text: "panel-msg"}}},
+		},
+		generated.OPGuiSignatureHelp: {
+			Opcode:    generated.OPGuiSignatureHelp,
+			Signature: protocol.SignatureHelp{Visible: true, Signatures: []protocol.Signature{{Label: "map(enumerable, fun)"}}},
+		},
+	}
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDBottomPanel, Z: 200, HitKind: 7},
+	}
+
+	got := strings.Join(model.overlayLines(), "\n")
+	if !strings.Contains(got, "map(enumerable, fun)") {
+		t.Fatalf("signature help should win over the open bottom panel, got %q", got)
+	}
+	if strings.Contains(got, "panel-msg") {
+		t.Fatalf("bottom panel must not win over signature help, got %q", got)
+	}
+}

--- a/lib/minga/frontend/adapter/gui/surface_layout_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/surface_layout_encoder.ex
@@ -1,0 +1,92 @@
+defmodule Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder do
+  @moduledoc """
+  Encodes `gui_surface_layout` (0xA4): the authoritative per-frame surface
+  placement carrier (#2219 child E / #2268).
+
+  This is the single emitter of `gui_surface_layout`. It takes wire-shaped
+  placement maps (already numbered by `MingaEditor.Layout.SurfaceRegistry`, the
+  one source of surface rects and z-order that also feeds BEAM mouse
+  hit-testing) and lays them out as a sectioned command using the
+  schema-generated pure encoder
+  `Minga.Protocol.Encode.encode_gui_surface_layout_placements/1`. Because both
+  the placement bytes and the BEAM hit-test read the same registry placements,
+  the emitted rect for every surface equals its hit-test rect by construction
+  (#2268 AC-1).
+
+  ## Identity unification (#2268)
+
+  The schema carries `surface_id` as a raw `u16` and `hit_kind` as a raw `u8`
+  with no enum (a new schema vocabulary was explicitly avoided). The numeric
+  identity is authoritative in `SurfaceRegistry`, which projects each placement
+  to its wire shape (`SurfaceRegistry.wire_placements/1`). This encoder consumes
+  those plain maps and never depends on `MingaEditor.*`: one writer (the
+  registry owns the numbering), one reader (this encoder lays out bytes).
+
+  ## Framing
+
+  Sectioned framing (`opcode + section_count + section{id, len16, body}`) reuses
+  the gui_window_content/picker counted-array carrier so the generator emits a
+  placement decoder both frontends already know how to size (the reviewer-
+  adjudicated carrier choice from child A). There is a single section,
+  `placements` (id 0x01), holding a counted array of `surface_placement`.
+  """
+
+  alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Protocol.Encode
+  alias Minga.Protocol.Opcodes
+
+  @op_gui_surface_layout Opcodes.gui_surface_layout()
+  @section_placements 0x01
+
+  @typedoc "A placement already projected to its wire shape (see SurfaceRegistry.wire_placement/0)."
+  @type wire_placement :: %{
+          surface_id: non_neg_integer(),
+          rect: %{
+            row: non_neg_integer(),
+            col: non_neg_integer(),
+            width: non_neg_integer(),
+            height: non_neg_integer()
+          },
+          z: non_neg_integer(),
+          hit_kind: non_neg_integer()
+        }
+
+  @doc """
+  Encodes the frame's wire-shaped surface placements into a `gui_surface_layout`
+  command.
+
+  Always emits (one section, possibly with an empty placement array). The
+  command is part of the frame transaction, so it ships every frame between
+  begin_frame and commit_frame; there is no skip-if-unchanged cache because the
+  placement list IS the per-frame layout authority. Cell fields are clamped to
+  u16/u8 so a degenerate rect can never produce a malformed packet (mirrors the
+  window encoder's clamp policy).
+  """
+  @spec encode_command([wire_placement()]) :: binary()
+  def encode_command(placements) when is_list(placements) do
+    bounded = Enum.map(placements, &clamp/1)
+
+    section =
+      Wire.encode_section(
+        @section_placements,
+        Encode.encode_gui_surface_layout_placements(bounded)
+      )
+
+    IO.iodata_to_binary([<<@op_gui_surface_layout, 1::8>>, section])
+  end
+
+  @spec clamp(wire_placement()) :: map()
+  defp clamp(%{surface_id: surface_id, rect: rect, z: z, hit_kind: hit_kind}) do
+    %{
+      surface_id: Wire.clamp_u16(surface_id),
+      rect: %{
+        row: Wire.clamp_u16(rect.row),
+        col: Wire.clamp_u16(rect.col),
+        width: Wire.clamp_u16(rect.width),
+        height: Wire.clamp_u16(rect.height)
+      },
+      z: Wire.clamp_u16(z),
+      hit_kind: Wire.clamp_u8(hit_kind)
+    }
+  end
+end

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -77,11 +77,21 @@ defmodule MingaEditor.Frontend.Emit do
     # the frontend can resolve a keystroke-to-write latency sample.
     input_seq = Map.get(ctx, :last_input_seq, 0)
 
+    # gui_surface_layout (#2219 child E / #2268): the authoritative per-frame
+    # surface placement list, emitted inside the transaction from the SAME
+    # SurfaceRegistry placements that feed BEAM mouse hit-testing. One source,
+    # one rect+z list; Go composites by z and derives mouse zones from these
+    # rects (no more overlayLines precedence chain for placed surfaces). It rides
+    # with the chrome commands so it sits after content and before commit.
+    surface_layout_command =
+      Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder.encode_command(ctx.surface_placements)
+
     commands =
       [Protocol.encode_begin_frame(frame_seq, base_frame_seq)] ++
         flush_font_registration_commands() ++
         encoded_frame.metal_commands ++
-        encoded_frame.chrome_commands ++ [Protocol.encode_commit_frame(frame_seq, input_seq)]
+        encoded_frame.chrome_commands ++
+        [surface_layout_command, Protocol.encode_commit_frame(frame_seq, input_seq)]
 
     caches = update_tracking(ctx, caches)
     # Record both the seq and whether this frame carried the keyframe so the Editor

--- a/lib/minga_editor/frontend/emit/context.ex
+++ b/lib/minga_editor/frontend/emit/context.ex
@@ -53,7 +53,8 @@ defmodule MingaEditor.Frontend.Emit.Context do
           search: Search.t(),
           last_input_seq: non_neg_integer(),
           frame_seq: non_neg_integer() | nil,
-          force_keyframe?: boolean()
+          force_keyframe?: boolean(),
+          surface_placements: [MingaEditor.Layout.SurfaceRegistry.wire_placement()]
         }
 
   @enforce_keys [:port_manager, :capabilities, :theme, :font_registry, :windows, :layout, :shell]
@@ -85,7 +86,8 @@ defmodule MingaEditor.Frontend.Emit.Context do
             search: %Search{},
             last_input_seq: 0,
             frame_seq: nil,
-            force_keyframe?: false
+            force_keyframe?: false,
+            surface_placements: []
 
   @doc "Builds an emit context from render pipeline input."
   @spec from_editor_state(map()) :: t()
@@ -121,7 +123,13 @@ defmodule MingaEditor.Frontend.Emit.Context do
       search: state.workspace.search,
       last_input_seq: Map.get(state, :last_input_seq, 0),
       frame_seq: Map.get(state, :frame_seq),
-      force_keyframe?: Map.get(state, :force_keyframe?, false)
+      force_keyframe?: Map.get(state, :force_keyframe?, false),
+      # The single per-frame surface layout authority (#2268), already projected
+      # to wire shape by the registry. Derived from the same focus tree mouse
+      # routing hit-tests against, so the emitted placement rect for every surface
+      # equals its BEAM hit-test rect by construction. The encoder consumes these
+      # plain maps and stays free of any MingaEditor dependency.
+      surface_placements: MingaEditor.Layout.SurfaceRegistry.wire_placements(state)
     }
   end
 

--- a/lib/minga_editor/layout/surface_registry.ex
+++ b/lib/minga_editor/layout/surface_registry.ex
@@ -34,29 +34,42 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   simultaneous overlays are newly *expressible* as a list but are deliberately
   NOT produced here. Enabling them is out of scope (see #2268, AC-4).
 
-  Known enumeration gap for #2268 proper: the Go compositor's `overlayLines()`
-  chain also stacks surfaces that are not focus-tree nodes today (hover,
-  signature help, float popups, agent context, tool manager, extension
-  panels/overlays, observatory, timeline, notifications). Before "composite by
-  placement" is complete, those must be promoted to focus-tree/registry
-  surfaces; the gap lives in the FocusTree's coverage, not in this module's
-  derivation.
+  Known enumeration gap (transitional split, #2268). The Go compositor's
+  `overlayLines()` chain also stacks surfaces that are not focus-tree nodes
+  today (hover, signature help, float popups, agent context, tool manager,
+  extension panels/overlays, observatory, timeline, notifications). #2268 ships
+  a *transitional split*: the surfaces the focus tree already places (the editor
+  area + chrome, and the single active modal overlay: picker or completion)
+  composite by placement/z and hit-test from these placement rects; the
+  not-yet-promoted overlay set keeps a reduced, hand-ordered chain on the Go
+  side until each is promoted into the focus tree. Promoting them is mechanical
+  per surface (each already has BEAM-tracked state) but balloons across ~10
+  surfaces, so it is deferred to a follow-up (#2281): "promote ephemeral/agent
+  overlays into FocusTree so the registry enumerates every composited surface
+  and the Go reduced chain can be deleted." The gap lives in the FocusTree's
+  coverage, not in this module's derivation.
 
-  ## surface_id namespace and the #2264 coordination point
+  ## surface_id namespace and the identity-unification call (#2268)
 
   `surface_id/1` maps each focus-tree `content_type` to a stable atom in the
-  registry's namespace, and `surface_id_u16/1` maps that atom to a `u16` for
-  wire emission. This module is the single source of that mapping today.
+  registry's namespace; `surface_id_u16/1` maps that atom to its `u16` wire
+  value and `hit_kind_u8/1` maps a `hit_kind` atom to its `u8` wire value. This
+  module is the single source of both mappings.
 
-  Schema child #2264 (`feat/frame-transaction-schema-2264`) will define the
-  authoritative wire enum for `gui_surface_layout`'s `surface_id:u16`. That
-  branch is NOT merged at the time of this change, so the mapping lives here on
-  the BEAM side. **Unification point:** when #2264 lands, the generated enum
-  should become the single source and `surface_id_u16/1` should read from it
-  (or be replaced by the generated encoder reading these atoms). Until then,
-  keep `surface_id_u16/1` and the schema enum numerically in sync. No wire
-  packet is emitted from this slice; emission lands with #2268 proper after the
-  schema/emission children merge.
+  **Unification decision (#2268 proper):** the schema (`surface_placement` in
+  `docs/protocol_schema.toml`, generated decoders on every frontend) carries
+  `surface_id` as a raw `u16` and `hit_kind` as a raw `u8`. It deliberately does
+  NOT add a `surface_id`/`hit_kind` enum: that would be a new schema vocabulary,
+  and the consult's instruction was to keep the schema as the cross-language
+  source of truth *without* a new vocabulary. The cross-language source of truth
+  is therefore the wire shape plus the generated codec; the numeric identity of
+  each surface stays authoritative here, and the emitter
+  (`Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder`) *consumes* these functions
+  rather than re-deriving numbers. One writer (this module), one reader (the
+  encoder). `hit_kind_u8/1` reuses the window-encoder hit-kind numbering
+  (`Minga.Frontend.Adapter.GUI.WindowEncoder` 1..6) and extends it with
+  `:chrome` (7) and `:overlay` (8) so a placement's hit kind and a window hit
+  region speak the same u8.
 
   ## hit_kind
 
@@ -159,6 +172,54 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
     state
     |> FocusTree.get()
     |> from_tree()
+  end
+
+  @typedoc """
+  A placement projected to its wire shape: surface_id/hit_kind already mapped to
+  their numeric identity, rect as a `{row, col, width, height}` cell map, z verbatim.
+  """
+  @type wire_placement :: %{
+          surface_id: 0..65_535,
+          rect: %{
+            row: non_neg_integer(),
+            col: non_neg_integer(),
+            width: non_neg_integer(),
+            height: non_neg_integer()
+          },
+          z: non_neg_integer(),
+          hit_kind: 0..255
+        }
+
+  @doc """
+  Returns the frame's placements projected to their wire shape.
+
+  This is the boundary between the registry (which owns the surface/hit-kind
+  numbering) and the wire encoder (which only lays out bytes). The encoder
+  consumes these plain maps, so it never depends on `MingaEditor.*`: the registry
+  stays the single authority for the numeric identity (#2268 unification call),
+  and the emitter stays a pure byte layout over data. Order is preserved
+  (back-to-front by z), so the wire list IS the compositing order.
+  """
+  @spec wire_placements(map()) :: [wire_placement()]
+  def wire_placements(state) do
+    state
+    |> placements()
+    |> Enum.map(&to_wire/1)
+  end
+
+  @spec to_wire(Placement.t()) :: wire_placement()
+  defp to_wire(%Placement{
+         surface_id: surface_id,
+         rect: {row, col, width, height},
+         z: z,
+         hit_kind: hit_kind
+       }) do
+    %{
+      surface_id: surface_id_u16(surface_id),
+      rect: %{row: row, col: col, width: width, height: height},
+      z: z,
+      hit_kind: hit_kind_u8(hit_kind)
+    }
   end
 
   @doc """
@@ -301,11 +362,10 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   @doc """
   Maps a registry `surface_id` atom to its `u16` wire value.
 
-  This is the single BEAM-side source of the surface enum until schema child
-  #2264 lands its generated enum. **Coordination point (#2264):** keep these
-  numbers in sync with `docs/protocol_schema.toml`'s `surface_id` enum when
-  that branch merges, then replace this with a read of the generated enum. See
-  the moduledoc.
+  Single BEAM-side source of the surface numbering. The schema carries
+  `surface_id` as a raw `u16` (no enum, by decision: see the moduledoc), and
+  `Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder` consumes this function
+  rather than re-deriving numbers.
   """
   @spec surface_id_u16(surface_id()) :: 0..65_535
   def surface_id_u16(:editor_area), do: 1
@@ -324,6 +384,25 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   def surface_id_u16(:picker), do: 14
   def surface_id_u16(:completion_backdrop), do: 15
   def surface_id_u16(:completion_menu), do: 16
+
+  @doc """
+  Maps a registry `hit_kind` atom to its `u8` wire value.
+
+  Reuses the window-encoder hit-kind numbering
+  (`Minga.Frontend.Adapter.GUI.WindowEncoder`: text 1, gutter 2, fold_control 3,
+  modeline 4, divider 5, status_bar 6) so a placement's hit kind and a per-window
+  hit region speak the same u8, and extends it with `:chrome` (7) and `:overlay`
+  (8) for surface-level entries. Consumed by `SurfaceLayoutEncoder`.
+  """
+  @spec hit_kind_u8(hit_kind()) :: 0..255
+  def hit_kind_u8(:text), do: 1
+  def hit_kind_u8(:gutter), do: 2
+  def hit_kind_u8(:fold_control), do: 3
+  def hit_kind_u8(:modeline), do: 4
+  def hit_kind_u8(:divider), do: 5
+  def hit_kind_u8(:status_bar), do: 6
+  def hit_kind_u8(:chrome), do: 7
+  def hit_kind_u8(:overlay), do: 8
 
   # ── z assignment ────────────────────────────────────────────────────────────
 

--- a/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
+++ b/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
@@ -1,0 +1,147 @@
+defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
+  @moduledoc """
+  End-to-end AC-1 proof for #2268: the BEAM hit-test rect for every placed
+  surface equals the emitted placement rect, because both read the same
+  `SurfaceRegistry` placements.
+
+  The other half of the AC (registry rect == focus-tree hit-test rect) is pinned
+  in `MingaEditor.Layout.SurfaceRegistryTest`. This test pins the missing leg:
+  the bytes the emitter actually puts on the wire decode back to the exact rects
+  (and z, surface_id, hit_kind) the registry produced. Chaining the two gives
+  emitted-bytes == hit-test rects, one source, test-proven.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Protocol.Opcodes
+  alias MingaEditor.Frontend.Emit
+  alias MingaEditor.Frontend.Emit.Context
+  alias MingaEditor.Layout.SurfaceRegistry
+  alias MingaEditor.Layout.SurfaceRegistry.Placement
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  alias MingaEditor.DisplayList
+  alias MingaEditor.DisplayList.{Cursor, Frame}
+
+  @op_surface_layout Opcodes.gui_surface_layout()
+
+  defp emit_commands(state) do
+    frame = %Frame{cursor: Cursor.new(0, 0, :block), splash: [DisplayList.draw(0, 0, "x")]}
+    ctx = Context.from_editor_state(state)
+    Emit.emit(frame, ctx)
+    assert_receive {:"$gen_cast", {:send_commands, commands}}
+    commands
+  end
+
+  defp surface_layout_command(commands) do
+    Enum.find(commands, &match?(<<@op_surface_layout, _::binary>>, &1))
+  end
+
+  # Decode the sectioned gui_surface_layout command back into placement maps.
+  # Format: opcode(1) section_count(1) then section{id(1) len(u16) body}; the
+  # placements section body is count(u16) + count * surface_placement, where
+  # surface_placement is surface_id(u16) rect(row,col,width,height : u16 each)
+  # z(u16) hit_kind(u8) = 13 bytes.
+  defp decode_placements(<<@op_surface_layout, 1::8, 0x01::8, len::16, body::binary-size(len)>>) do
+    <<count::16, rest::binary>> = body
+    decode_entries(rest, count, [])
+  end
+
+  defp decode_entries(_rest, 0, acc), do: Enum.reverse(acc)
+
+  defp decode_entries(
+         <<surface_id::16, row::16, col::16, width::16, height::16, z::16, hit_kind::8,
+           rest::binary>>,
+         remaining,
+         acc
+       ) do
+    entry = %{
+      surface_id: surface_id,
+      rect: {row, col, width, height},
+      z: z,
+      hit_kind: hit_kind
+    }
+
+    decode_entries(rest, remaining - 1, [entry | acc])
+  end
+
+  # The expected wire entry for a registry placement: rect verbatim (cells),
+  # surface_id/hit_kind through the registry's authoritative numbering.
+  defp expected_entry(%Placement{} = p) do
+    %{
+      surface_id: SurfaceRegistry.surface_id_u16(p.surface_id),
+      rect: p.rect,
+      z: p.z,
+      hit_kind: SurfaceRegistry.hit_kind_u8(p.hit_kind)
+    }
+  end
+
+  test "every frame's transaction carries a gui_surface_layout command before commit" do
+    commands = emit_commands(base_state())
+
+    assert cmd = surface_layout_command(commands)
+
+    commit = <<Opcodes.commit_frame(), 0::32, 0::32>>
+    # The layout packet rides inside the transaction, immediately before commit.
+    assert List.last(commands) |> binary_part(0, 1) == <<Opcodes.commit_frame()>>
+    refute commit == cmd
+    surface_idx = Enum.find_index(commands, &(&1 == cmd))
+    commit_idx = length(commands) - 1
+    assert surface_idx < commit_idx
+  end
+
+  test "emitted placement bytes decode to the exact rects BEAM hit-testing uses (AC-1)" do
+    state = base_state()
+    commands = emit_commands(state)
+
+    decoded = commands |> surface_layout_command() |> decode_placements()
+
+    # The registry is the BEAM hit-test source. Project its placements through
+    # the same authoritative numbering the emitter uses; the decoded wire bytes
+    # must match field-for-field, in the same order.
+    expected =
+      state
+      |> SurfaceRegistry.placements()
+      |> Enum.map(&expected_entry/1)
+
+    assert decoded == expected
+    # Sanity: there is real content here, not an empty list masking the check.
+    refute decoded == []
+  end
+
+  test "rect for each decoded surface_id equals the registry rect_for that surface" do
+    state = base_state()
+    commands = emit_commands(state)
+    decoded = commands |> surface_layout_command() |> decode_placements()
+    placements = SurfaceRegistry.placements(state)
+
+    # For each emitted surface, the wire rect equals the rect the registry hands
+    # the hit-tester (rect_for_in takes the topmost by z, the same precedence the
+    # emitted z list encodes).
+    for %{surface_id: u16} <- decoded do
+      surface_id =
+        Enum.find_value(placements, fn p ->
+          if SurfaceRegistry.surface_id_u16(p.surface_id) == u16, do: p.surface_id
+        end)
+
+      assert surface_id, "decoded surface_id #{u16} has no registry surface"
+      assert SurfaceRegistry.rect_for_in(placements, surface_id) != nil
+    end
+  end
+
+  test "empty placement list still emits a well-formed (zero-count) command" do
+    # A degenerate state with no focus tree surfaces still produces a valid,
+    # decodable command: the transaction always carries the layout authority,
+    # even when the authority is empty.
+    state = base_state()
+    # Force an empty placement context directly through the encoder to prove the
+    # zero-count framing round-trips (the live state always has chrome, so this
+    # exercises the boundary the production encoder must handle).
+    cmd = Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder.encode_command([])
+    # opcode, section_count=1, section{id=0x01, len=2, body=<<count::16 = 0>>}.
+    assert <<@op_surface_layout, 1::8, 0x01::8, 2::16, 0::16>> == cmd
+    assert decode_placements(cmd) == []
+    _ = state
+  end
+end


### PR DESCRIPTION
## Summary

The last child of epic #2219: surface placement becomes BEAM-authoritative on the wire. The SurfaceRegistry's focus-tree-derived placements (rect in terminal cells, z, hit_kind) are emitted via `gui_surface_layout` (0xA4, sectioned counted-array) inside the frame transaction, before `commit_frame`.

- **Identity stays registry-authoritative.** A new Layer-1 `SurfaceLayoutEncoder` (zero MingaEditor deps) consumes plain wire maps from `SurfaceRegistry.wire_placements/1`; `surface_id_u16/1` and `hit_kind_u8/1` are the single numbering source. No new enum, per the archie consult.
- **Go: stacking is data.** The `overlayLines()` hardcoded precedence if-ladder is deleted. All overlay candidates order on one z-band scale tied to the registry's bands (base 0 / editor 100 / floating 200 / overlay 300): placed surfaces use their emitted placement z directly; the ~10 not-yet-promoted overlays carry transitional orders slotted at their old chain positions (hover 290 … toolManager 240 above the bottom panel at 200; extension/observatory/timeline/notifications below). Promotion of the transitional set, which deletes the table, is #2281.
- **AC-1 proven end-to-end**: a test decodes the emitted placement bytes and asserts they equal the exact rects the BEAM hit-tests against, so frontend compositing and BEAM hit-testing can no longer drift.
- **#2230 picker rows** are delivered by this chain: picker clicks are BEAM-hit-tested through the same focus-tree rect now emitted; no Go zone code needed.
- **Swift unchanged by design**: the GUI composites natively and treats placements as structural hints; the generated sizing table already carries the opcode (suite 766 green, harness 26 with the opcode flowing).

The acceptance reviewer initially BLOCKED on a real find: a flat placed-above-everything offset inverted six reachable stackings (hover, signature help, float popups, agent context, agent chat, tool manager all beat the bottom panel in the old chain). The z-band-aligned scale above is the fix, with the old chain order confirmed from git history and pinned by regression tests (`TestOverlayBottomPanelOpenHoverWins`, `TestOverlayBottomPanelOpenSignatureHelpWins`). Targeted re-review: PASS.

## Tests

- Elixir: 734 tests green (incl. new `surface_layout_emit_test.exs` end-to-end bytes==hit-test-rects, empty-list framing, split-layout registry test); `mix test.llm` green modulo the 5 environmental parser-binary failures
- Go: 297 passed; gofmt/vet clean; bounded sectioned decoder truncation tests; 7 TestOverlay precedence tests incl. the two new inversions regressions
- Swift: 766 passed + harness 26 (no code changes; opcode sized and ignored)
- `mix protocol.gen --check` + `mix protocol.golden --check` green; `make lint` green; bench 120/120 frame correlation holds (p99 ~1.3–1.6ms)
- Reviews: acceptance reviewer BLOCKED → fixed → targeted re-review PASS

Closes #2268. Part of #2219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)