### PR TITLE
feat(ci): enforce keystroke latency budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,14 @@ jobs:
       - run: mix test --warnings-as-errors --exclude system_clipboard --exclude conformance
 
   keystroke-latency-baseline:
-    name: Keystroke Latency Baseline (record-only)
+    name: Keystroke Latency Baseline
     runs-on: ubuntu-latest
-    # Record-only: this job tracks p50/p99 over time and uploads the JSON as an
-    # artifact. It must never gate merges (ticket #2215), so it does not fail the
-    # workflow if the numbers drift.
-    continue-on-error: true
+    # Enforces keystroke latency budgets: the bench is recorded on every CI run,
+    # then checked against configured ceilings (bench/latency_budgets.json). The
+    # job fails if any scenario exceeds its p50 or p99 budget. Flake protection is
+    # rerun-once-on-breach: a first breach re-runs the full bench and re-checks, and
+    # only a second consecutive breach fails the job. The bench's 120-sample
+    # percentiles are the primary jitter defense; the rerun covers runner-level noise.
     steps:
       - uses: actions/checkout@v4
 
@@ -122,7 +124,20 @@ jobs:
       - name: Record keystroke latency baseline
         run: MIX_ENV=test mix run bench/keystroke_latency_baseline.exs | tee keystroke_latency_metrics.txt
 
+      - name: Check keystroke latency budgets
+        id: budget_check
+        continue-on-error: true
+        run: MIX_ENV=test mix run bench/check_latency_budgets.exs
+
+      - name: Re-run bench and re-check on breach (flake protection)
+        if: steps.budget_check.outcome == 'failure'
+        run: |
+          echo "First run breached budgets; re-running bench once before failing."
+          MIX_ENV=test mix run bench/keystroke_latency_baseline.exs | tee keystroke_latency_metrics.txt
+          MIX_ENV=test mix run bench/check_latency_budgets.exs
+
       - name: Upload latency baseline JSON
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: keystroke-latency-baseline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,14 +89,27 @@ jobs:
   keystroke-latency-baseline:
     name: Keystroke Latency Baseline
     runs-on: ubuntu-latest
-    # Enforces keystroke latency budgets: the bench is recorded on every CI run,
-    # then checked against configured ceilings (bench/latency_budgets.json). The
-    # job fails if any scenario exceeds its p50 or p99 budget. Flake protection is
-    # rerun-once-on-breach: a first breach re-runs the full bench and re-checks, and
-    # only a second consecutive breach fails the job. The bench's 120-sample
-    # percentiles are the primary jitter defense; the rerun covers runner-level noise.
+    # Same-runner A/B latency gate. GitHub hosted runners vary run-to-run, so an
+    # absolute ceiling calibrated on one machine can never be both tight and
+    # stable (PR #2298 saw runner p50 FASTER than the M1 baseline but tails ~30%
+    # noisier). So on pull_request runs we bench the PR's merge-base AND the PR
+    # HEAD on the SAME runner in the same job, then gate RELATIVELY: head must be
+    # within base * (1 + tolerance) per scenario/metric (tolerances in
+    # bench/latency_budgets.json: p50 +10%, p99 +20%). Runner speed cancels out.
+    #
+    # Absolute ceilings remain only as loose catastrophic sanity bounds. If the
+    # base bench cannot run (script missing at merge-base, base build fails) we
+    # fall back to absolute-sanity-only with a loud warning and do NOT fail the
+    # job for infrastructure reasons. On push-to-main there is no PR base, so we
+    # record + sanity-check + upload only (trend mode).
+    #
+    # Flake protection: rerun-once-on-breach re-runs only the HEAD bench and
+    # re-compares against the SAME base numbers; the base is never re-benched.
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need the merge-base revision available to bench the base side.
+          fetch-depth: 0
 
       - uses: erlef/setup-beam@v1
         with:
@@ -116,25 +129,73 @@ jobs:
           key: deps-${{ runner.os }}-${{ hashFiles('.tool-versions') }}-${{ hashFiles('mix.lock') }}
           restore-keys: deps-${{ runner.os }}-${{ hashFiles('.tool-versions') }}-
 
+      # Bench the PR's merge-base on this same runner so the relative gate can
+      # compare like-for-like. Tolerant by design: any infrastructure failure
+      # here (script missing at base, build break) leaves BASE_AVAILABLE=0 and we
+      # fall back to absolute-sanity-only. Skipped on push (no PR base).
+      - name: Bench merge-base (A/B base side)
+        if: github.event_name == 'pull_request'
+        id: base_bench
+        run: |
+          set -u
+          HEAD_REF=$(git rev-parse HEAD)
+          BASE_SHA=$(git merge-base origin/main HEAD)
+          echo "Merge-base: $BASE_SHA"
+          echo "BASE_AVAILABLE=0" >> "$GITHUB_ENV"
+
+          if ! git cat-file -e "$BASE_SHA:bench/keystroke_latency_baseline.exs" 2>/dev/null; then
+            echo "::warning::bench/keystroke_latency_baseline.exs missing at merge-base $BASE_SHA; relative gate will be skipped (absolute sanity only)."
+            exit 0
+          fi
+
+          # Force checkout: the working tree is CI-disposable and may carry stale
+          # generated artifacts; -f avoids "would be overwritten" aborts.
+          git checkout -f --quiet "$BASE_SHA"
+
+          if mix deps.get && mix deps.compile && mix protocol.gen && mix native.build.support \
+            && MIX_ENV=test mix run bench/keystroke_latency_baseline.exs; then
+            cp bench/baselines/keystroke_latency.json /tmp/latency_base.json
+            echo "BASE_AVAILABLE=1" >> "$GITHUB_ENV"
+            echo "Captured base bench to /tmp/latency_base.json"
+          else
+            echo "::warning::base bench build/run failed at $BASE_SHA; relative gate will be skipped (absolute sanity only)."
+          fi
+
+          # Always return to HEAD so the rest of the job runs against the PR. The
+          # base bench rewrites the tracked baseline JSON, so -f is required to
+          # switch back cleanly (we already copied what we need to /tmp).
+          git checkout -f --quiet "$HEAD_REF"
+
+      # HEAD must be benched LAST so the uploaded artifact reflects the PR HEAD.
       - run: mix deps.get
       - run: mix deps.compile
       - run: mix protocol.gen
       - run: mix native.build.support
 
-      - name: Record keystroke latency baseline
+      - name: Record keystroke latency baseline (HEAD)
         run: MIX_ENV=test mix run bench/keystroke_latency_baseline.exs | tee keystroke_latency_metrics.txt
 
       - name: Check keystroke latency budgets
         id: budget_check
         continue-on-error: true
-        run: MIX_ENV=test mix run bench/check_latency_budgets.exs
+        run: |
+          if [ "${BASE_AVAILABLE:-0}" = "1" ]; then
+            MIX_ENV=test mix run bench/check_latency_budgets.exs --base /tmp/latency_base.json
+          else
+            MIX_ENV=test mix run bench/check_latency_budgets.exs
+          fi
 
-      - name: Re-run bench and re-check on breach (flake protection)
+      # Re-run only the HEAD bench and re-compare against the SAME base numbers.
+      - name: Re-run HEAD bench and re-check on breach (flake protection)
         if: steps.budget_check.outcome == 'failure'
         run: |
-          echo "First run breached budgets; re-running bench once before failing."
+          echo "First run breached budgets; re-running HEAD bench once before failing."
           MIX_ENV=test mix run bench/keystroke_latency_baseline.exs | tee keystroke_latency_metrics.txt
-          MIX_ENV=test mix run bench/check_latency_budgets.exs
+          if [ "${BASE_AVAILABLE:-0}" = "1" ]; then
+            MIX_ENV=test mix run bench/check_latency_budgets.exs --base /tmp/latency_base.json
+          else
+            MIX_ENV=test mix run bench/check_latency_budgets.exs
+          fi
 
       - name: Upload latency baseline JSON
         if: always()

--- a/bench/check_latency_budgets.exs
+++ b/bench/check_latency_budgets.exs
@@ -1,24 +1,184 @@
 defmodule Minga.Bench.CheckLatencyBudgets do
   @moduledoc """
-  Enforces keystroke latency budgets by comparing the latest bench output against
-  configured ceilings (bench/latency_budgets.json).
+  Enforces keystroke latency budgets with a same-runner A/B comparison.
 
-  Reads the JSON output from `mix run bench/keystroke_latency_baseline.exs`
-  (path: bench/baselines/keystroke_latency.json) and the budgets config, then exits
-  nonzero with a clear breach report if any scenario exceeds its p50 or p99 ceiling.
+  The gate is RELATIVE, not absolute. On `pull_request` CI runs the workflow
+  benches the PR's merge-base and the PR HEAD on the same runner, then runs this
+  script with `--base <base.json>`. For every scenario/metric we require:
 
-  Run with: MIX_ENV=test mix run bench/check_latency_budgets.exs
+      head <= base * (1 + tolerance)
+
+  with tolerances from `bench/latency_budgets.json` (`relative.p50_pct`,
+  `relative.p99_pct`). This cancels runner speed: GitHub hosted runners vary
+  run-to-run, so absolute ceilings calibrated on one machine can never be both
+  tight and stable.
+
+  Absolute ceilings survive only as loose catastrophic sanity bounds
+  (`absolute_sanity.scenarios`), recalibrated generously for runner reality.
+  They are NOT the gate; they catch a ~2x regression even when the base bench is
+  unavailable.
+
+  Modes:
+
+    * `--base <path>` given: relative gate (per scenario/metric) AND absolute
+      sanity. Either breach class exits 1 with a per-metric report.
+    * no `--base`: absolute sanity only, with a loud warning that the relative
+      gate was skipped. Used on push-to-main (record/trend) runs and as the
+      fallback when the base bench could not run for infrastructure reasons.
+
+  Run with:
+
+      MIX_ENV=test mix run bench/check_latency_budgets.exs [--base /path/to/base.json]
   """
 
   @baseline_path Path.join([__DIR__, "baselines", "keystroke_latency.json"])
   @budgets_path Path.join([__DIR__, "latency_budgets.json"])
 
-  @spec run() :: :ok | no_return()
-  def run do
-    baseline = load_json!(@baseline_path)
-    budgets = load_json!(@budgets_path)
+  @metrics [{"p50_us", "p50", "p50_pct"}, {"p99_us", "p99", "p99_pct"}]
 
-    breaches = check_scenarios(baseline, budgets)
+  @spec run([String.t()]) :: :ok | no_return()
+  def run(argv) do
+    head = load_json!(@baseline_path)
+    budgets = load_json!(@budgets_path)
+    base = load_base(parse_base_path(argv))
+
+    breaches = check(head, base, budgets)
+
+    report(breaches, base)
+  end
+
+  @spec parse_base_path([String.t()]) :: String.t() | nil
+  defp parse_base_path(["--base", path | _rest]), do: path
+  defp parse_base_path([_other | rest]), do: parse_base_path(rest)
+  defp parse_base_path([]), do: nil
+
+  @spec load_base(String.t() | nil) :: map() | nil
+  defp load_base(nil), do: nil
+  defp load_base(path), do: load_json!(path)
+
+  # ── Checking ─────────────────────────────────────────────────────────────────
+
+  @spec check(map(), map() | nil, map()) :: [map()]
+  defp check(head, base, budgets) do
+    head_scenarios = Map.get(head, "scenarios", %{})
+
+    Enum.flat_map(head_scenarios, fn {scenario, head_stats} ->
+      sanity = sanity_budget(budgets, scenario)
+      base_stats = base_scenario(base, scenario)
+
+      Enum.flat_map(@metrics, fn {key, label, pct_key} ->
+        head_us = Map.get(head_stats, key)
+
+        check_relative(scenario, label, head_us, base_stats, key, relative_pct(budgets, pct_key)) ++
+          check_sanity(scenario, label, head_us, Map.get(sanity, key))
+      end)
+    end)
+  end
+
+  @spec relative_pct(map(), String.t()) :: number() | nil
+  defp relative_pct(budgets, pct_key) do
+    budgets
+    |> Map.get("relative", %{})
+    |> Map.get(pct_key)
+  end
+
+  @spec sanity_budget(map(), String.t()) :: map()
+  defp sanity_budget(budgets, scenario) do
+    budgets
+    |> Map.get("absolute_sanity", %{})
+    |> Map.get("scenarios", %{})
+    |> Map.get(scenario, %{})
+  end
+
+  @spec base_scenario(map() | nil, String.t()) :: map() | nil
+  defp base_scenario(nil, _scenario), do: nil
+
+  defp base_scenario(base, scenario) do
+    base
+    |> Map.get("scenarios", %{})
+    |> Map.get(scenario)
+  end
+
+  # Relative gate only applies when we have a base bench to compare against.
+  @spec check_relative(
+          String.t(),
+          String.t(),
+          number() | nil,
+          map() | nil,
+          String.t(),
+          number() | nil
+        ) ::
+          [map()]
+  defp check_relative(_scenario, _label, _head_us, nil, _key, _pct), do: []
+
+  defp check_relative(scenario, label, nil, _base_stats, _key, _pct),
+    do: [%{kind: :relative, scenario: scenario, field: label, error: "no head measurement found"}]
+
+  defp check_relative(scenario, label, _head_us, _base_stats, _key, nil),
+    do: [
+      %{
+        kind: :relative,
+        scenario: scenario,
+        field: label,
+        error: "no relative tolerance configured"
+      }
+    ]
+
+  defp check_relative(scenario, label, head_us, base_stats, key, pct) do
+    eval_relative(scenario, label, head_us, Map.get(base_stats, key), pct)
+  end
+
+  @spec eval_relative(String.t(), String.t(), number(), number() | nil, number()) :: [map()]
+  defp eval_relative(scenario, label, _head_us, nil, _pct),
+    do: [%{kind: :relative, scenario: scenario, field: label, error: "no base measurement found"}]
+
+  defp eval_relative(scenario, label, head_us, base_us, pct) do
+    allowed = base_us * (1 + pct / 100)
+
+    if head_us > allowed do
+      [
+        %{
+          kind: :relative,
+          scenario: scenario,
+          field: label,
+          head: head_us,
+          base: base_us,
+          tolerance_pct: pct,
+          allowed: round_us(allowed),
+          over_pct: pct_over(head_us, allowed)
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  @spec check_sanity(String.t(), String.t(), number() | nil, number() | nil) :: [map()]
+  defp check_sanity(_scenario, _label, _head_us, nil), do: []
+
+  defp check_sanity(scenario, label, nil, _bound),
+    do: [%{kind: :sanity, scenario: scenario, field: label, error: "no head measurement found"}]
+
+  defp check_sanity(scenario, label, head_us, bound) when head_us > bound do
+    [
+      %{
+        kind: :sanity,
+        scenario: scenario,
+        field: label,
+        head: head_us,
+        bound: bound,
+        over_pct: pct_over(head_us, bound)
+      }
+    ]
+  end
+
+  defp check_sanity(_scenario, _label, _head_us, _bound), do: []
+
+  # ── Reporting ────────────────────────────────────────────────────────────────
+
+  @spec report([map()], map() | nil) :: :ok | no_return()
+  defp report(breaches, base) do
+    print_mode(base)
 
     if Enum.empty?(breaches) do
       IO.puts("✓ All latency budgets within limits")
@@ -30,59 +190,70 @@ defmodule Minga.Bench.CheckLatencyBudgets do
     end
   end
 
-  @spec check_scenarios(map(), map()) :: [map()]
-  defp check_scenarios(baseline, budgets) do
-    baseline_scenarios = Map.get(baseline, "scenarios", %{})
-    budget_scenarios = Map.get(budgets, "scenarios", %{})
+  @spec print_mode(map() | nil) :: :ok
+  defp print_mode(nil) do
+    IO.puts(:stderr, "WARNING: no --base provided; the relative same-runner gate is SKIPPED.")
 
-    Enum.flat_map(baseline_scenarios, fn {scenario_name, measured} ->
-      budget = Map.get(budget_scenarios, scenario_name, %{})
-
-      [
-        {"p50_us", "p50"},
-        {"p99_us", "p99"}
-      ]
-      |> Enum.flat_map(fn {key, label} ->
-        check_metric(scenario_name, label, Map.get(measured, key), Map.get(budget, key))
-      end)
-    end)
-  end
-
-  @spec check_metric(String.t(), String.t(), number() | nil, number() | nil) :: [map()]
-  defp check_metric(scenario, label, nil, _budget),
-    do: [%{scenario: scenario, field: label, error: "no measurement found"}]
-
-  defp check_metric(scenario, label, _measured, nil),
-    do: [%{scenario: scenario, field: label, error: "no budget configured"}]
-
-  defp check_metric(scenario, label, measured, budget) when measured > budget do
-    [
-      %{
-        scenario: scenario,
-        field: label,
-        measured: measured,
-        budget: budget,
-        excess_pct: round((measured - budget) / budget * 100)
-      }
-    ]
-  end
-
-  defp check_metric(_scenario, _label, _measured, _budget), do: []
-
-  @spec print_breaches([map()]) :: :ok
-  defp print_breaches(breaches) do
-    Enum.each(breaches, fn breach ->
-      case breach do
-        %{error: error, scenario: scenario, field: field} ->
-          IO.puts("  #{scenario}/#{field}: #{error}")
-
-        %{scenario: scenario, field: field, measured: measured, budget: budget, excess_pct: pct} ->
-          IO.puts("  #{scenario}/#{field}: #{measured}µs (budget: #{budget}µs, +#{pct}% over)")
-      end
-    end)
+    IO.puts(
+      :stderr,
+      "WARNING: enforcing ABSOLUTE SANITY bounds only (catastrophic-regression backstop, not the real gate)."
+    )
 
     :ok
   end
+
+  defp print_mode(_base) do
+    IO.puts("Relative same-runner gate active (head vs base) + absolute sanity backstop.")
+    :ok
+  end
+
+  @spec print_breaches([map()]) :: :ok
+  defp print_breaches(breaches) do
+    Enum.each(breaches, &print_breach/1)
+    :ok
+  end
+
+  @spec print_breach(map()) :: :ok
+  defp print_breach(%{error: error, kind: kind, scenario: scenario, field: field}) do
+    IO.puts("  [#{kind}] #{scenario}/#{field}: #{error}")
+  end
+
+  defp print_breach(%{
+         kind: :relative,
+         scenario: scenario,
+         field: field,
+         head: head,
+         base: base,
+         tolerance_pct: tol,
+         allowed: allowed,
+         over_pct: over
+       }) do
+    IO.puts(
+      "  [relative] #{scenario}/#{field}: head #{head}µs vs base #{base}µs " <>
+        "(allowed #{allowed}µs at +#{tol}%, +#{over}% over)"
+    )
+  end
+
+  defp print_breach(%{
+         kind: :sanity,
+         scenario: scenario,
+         field: field,
+         head: head,
+         bound: bound,
+         over_pct: over
+       }) do
+    IO.puts(
+      "  [sanity] #{scenario}/#{field}: head #{head}µs exceeds sanity bound #{bound}µs (+#{over}% over)"
+    )
+  end
+
+  # ── Math / IO helpers ────────────────────────────────────────────────────────
+
+  @spec pct_over(number(), number()) :: integer()
+  defp pct_over(measured, limit), do: round((measured - limit) / limit * 100)
+
+  @spec round_us(number()) :: integer()
+  defp round_us(value), do: round(value)
 
   @spec load_json!(String.t()) :: map()
   defp load_json!(path) do
@@ -121,4 +292,4 @@ defmodule Minga.Bench.CheckLatencyBudgets do
   end
 end
 
-Minga.Bench.CheckLatencyBudgets.run()
+Minga.Bench.CheckLatencyBudgets.run(System.argv())

--- a/bench/check_latency_budgets.exs
+++ b/bench/check_latency_budgets.exs
@@ -1,0 +1,124 @@
+defmodule Minga.Bench.CheckLatencyBudgets do
+  @moduledoc """
+  Enforces keystroke latency budgets by comparing the latest bench output against
+  configured ceilings (bench/latency_budgets.json).
+
+  Reads the JSON output from `mix run bench/keystroke_latency_baseline.exs`
+  (path: bench/baselines/keystroke_latency.json) and the budgets config, then exits
+  nonzero with a clear breach report if any scenario exceeds its p50 or p99 ceiling.
+
+  Run with: MIX_ENV=test mix run bench/check_latency_budgets.exs
+  """
+
+  @baseline_path Path.join([__DIR__, "baselines", "keystroke_latency.json"])
+  @budgets_path Path.join([__DIR__, "latency_budgets.json"])
+
+  @spec run() :: :ok | no_return()
+  def run do
+    baseline = load_json!(@baseline_path)
+    budgets = load_json!(@budgets_path)
+
+    breaches = check_scenarios(baseline, budgets)
+
+    if Enum.empty?(breaches) do
+      IO.puts("✓ All latency budgets within limits")
+      :ok
+    else
+      IO.puts("\n✗ Latency budget breaches detected:\n")
+      print_breaches(breaches)
+      System.halt(1)
+    end
+  end
+
+  @spec check_scenarios(map(), map()) :: [map()]
+  defp check_scenarios(baseline, budgets) do
+    baseline_scenarios = Map.get(baseline, "scenarios", %{})
+    budget_scenarios = Map.get(budgets, "scenarios", %{})
+
+    Enum.flat_map(baseline_scenarios, fn {scenario_name, measured} ->
+      budget = Map.get(budget_scenarios, scenario_name, %{})
+
+      [
+        {"p50_us", "p50"},
+        {"p99_us", "p99"}
+      ]
+      |> Enum.flat_map(fn {key, label} ->
+        check_metric(scenario_name, label, Map.get(measured, key), Map.get(budget, key))
+      end)
+    end)
+  end
+
+  @spec check_metric(String.t(), String.t(), number() | nil, number() | nil) :: [map()]
+  defp check_metric(scenario, label, nil, _budget),
+    do: [%{scenario: scenario, field: label, error: "no measurement found"}]
+
+  defp check_metric(scenario, label, _measured, nil),
+    do: [%{scenario: scenario, field: label, error: "no budget configured"}]
+
+  defp check_metric(scenario, label, measured, budget) when measured > budget do
+    [
+      %{
+        scenario: scenario,
+        field: label,
+        measured: measured,
+        budget: budget,
+        excess_pct: round((measured - budget) / budget * 100)
+      }
+    ]
+  end
+
+  defp check_metric(_scenario, _label, _measured, _budget), do: []
+
+  @spec print_breaches([map()]) :: :ok
+  defp print_breaches(breaches) do
+    Enum.each(breaches, fn breach ->
+      case breach do
+        %{error: error, scenario: scenario, field: field} ->
+          IO.puts("  #{scenario}/#{field}: #{error}")
+
+        %{scenario: scenario, field: field, measured: measured, budget: budget, excess_pct: pct} ->
+          IO.puts("  #{scenario}/#{field}: #{measured}µs (budget: #{budget}µs, +#{pct}% over)")
+      end
+    end)
+
+    :ok
+  end
+
+  @spec load_json!(String.t()) :: map()
+  defp load_json!(path) do
+    case File.read(path) do
+      {:ok, content} ->
+        decode_json!(path, content)
+
+      {:error, :enoent} ->
+        IO.puts(
+          :stderr,
+          "Error: #{path} not found. Run `MIX_ENV=test mix run bench/keystroke_latency_baseline.exs` first."
+        )
+
+        System.halt(1)
+
+      {:error, reason} ->
+        IO.puts(:stderr, "Error reading #{path}: #{inspect(reason)}")
+        System.halt(1)
+    end
+  end
+
+  @spec decode_json!(String.t(), String.t()) :: map()
+  defp decode_json!(path, content) do
+    case JSON.decode(content) do
+      {:ok, data} when is_map(data) ->
+        data
+
+      {:ok, other} ->
+        IO.puts(:stderr, "Error: #{path} did not decode to a JSON object: #{inspect(other)}")
+        System.halt(1)
+
+      {:error, reason} ->
+        IO.puts(:stderr, "Error parsing #{path}: #{inspect(reason)}")
+        System.halt(1)
+    end
+  end
+end
+
+Minga.Bench.CheckLatencyBudgets.run()

--- a/bench/latency_budgets.json
+++ b/bench/latency_budgets.json
@@ -1,0 +1,19 @@
+{
+  "description": "Keystroke latency budgets (ceilings) per scenario. Values are in microseconds. Budgets include ~15% headroom over the 2026-06-10 baseline (bench/baselines/keystroke_latency.json). Ratchet protocol: after each fast-path optimization PR merges (#2287, #2288, #2289), re-baseline with `mix run bench/keystroke_latency_baseline.exs`, then reduce all ceilings to new_measured + 15%.",
+  "baseline_date": "2026-06-10",
+  "baseline_source": "bench/baselines/keystroke_latency.json",
+  "scenarios": {
+    "small_frame": {
+      "p50_us": 2000,
+      "p99_us": 2400
+    },
+    "large_frame": {
+      "p50_us": 2100,
+      "p99_us": 2600
+    },
+    "agent_stream": {
+      "p50_us": 2200,
+      "p99_us": 2700
+    }
+  }
+}

--- a/bench/latency_budgets.json
+++ b/bench/latency_budgets.json
@@ -1,19 +1,28 @@
 {
-  "description": "Keystroke latency budgets (ceilings) per scenario. Values are in microseconds. Budgets include ~15% headroom over the 2026-06-10 baseline (bench/baselines/keystroke_latency.json). Ratchet protocol: after each fast-path optimization PR merges (#2287, #2288, #2289), re-baseline with `mix run bench/keystroke_latency_baseline.exs`, then reduce all ceilings to new_measured + 15%.",
+  "description": "Keystroke latency gate config. THE GATE IS RELATIVE, NOT ABSOLUTE. On pull_request CI runs we bench the PR's merge-base and the PR HEAD on the SAME runner in the same job, then require head <= base * (1 + tolerance) per scenario/metric. This cancels out runner speed: GitHub hosted runners vary run-to-run, so absolute ceilings calibrated on one machine (an M1) can never be both tight and stable. Evidence from PR #2298 run 27317381350: small_frame p50 was 1694us on the runner (FASTER than the 1813us M1 baseline) yet the tails inflated ~30% (large_frame p99 2836us vs 2174us M1; agent_stream p99 2897us vs 2245us M1). The noise lives in the tails, so the relative tolerances are looser for p99 than p50.",
+  "relative": {
+    "p50_pct": 10,
+    "p99_pct": 20,
+    "_note": "head <= base * (1 + pct/100), evaluated per scenario per metric on the same runner. p50 +10%, p99 +20% because tails are ~30% noisier even same-runner (see #2298 evidence above)."
+  },
+  "absolute_sanity": {
+    "_note": "Loose CATASTROPHIC sanity bounds only. These are NOT the gate; the relative comparison above is the gate. They are deliberately generous so a healthy runner never trips them (p50 4000us is ~2.2x the ~1800us M1 baseline and ~2.4x a fast 1694us runner read). They exist to catch a ~2x regression even when the base bench is broken/unavailable and the relative gate cannot run. Recalibrate only if normal runner reads start approaching these numbers.",
+    "scenarios": {
+      "small_frame": {
+        "p50_us": 4000,
+        "p99_us": 6000
+      },
+      "large_frame": {
+        "p50_us": 4000,
+        "p99_us": 6000
+      },
+      "agent_stream": {
+        "p50_us": 4000,
+        "p99_us": 6000
+      }
+    }
+  },
   "baseline_date": "2026-06-10",
   "baseline_source": "bench/baselines/keystroke_latency.json",
-  "scenarios": {
-    "small_frame": {
-      "p50_us": 2000,
-      "p99_us": 2400
-    },
-    "large_frame": {
-      "p50_us": 2100,
-      "p99_us": 2600
-    },
-    "agent_stream": {
-      "p50_us": 2200,
-      "p99_us": 2700
-    }
-  }
+  "ratchet": "Ratchet protocol: after each fast-path optimization PR merges (#2287, #2288, #2289), tighten the RELATIVE tolerances (p50_pct, p99_pct) toward 0 as the same-runner spread shrinks, and lower the absolute_sanity bounds toward (new typical runner read + generous margin). Do NOT ratchet absolute_sanity below ~2x a healthy runner read or it stops being a catastrophic bound and starts flaking on runner variance."
 }


### PR DESCRIPTION
## Summary

The keystroke latency bench job flips from record-only to enforcing (epic #2220 AC 4) — reworked after the first enforcing run failed on runner variance, exactly as predicted in review.

**The gate is a same-runner A/B comparison, not an absolute ceiling.** The failed run's evidence: the hosted runner was *faster* than the local M1 baseline at small-frame p50 (1694µs vs 1813µs) but ~30% worse in the tails (large-frame p99 2836µs vs 2174µs) — shared-runner jitter inflates percentiles, so no machine-calibrated ceiling can be both tight and stable. Instead, pull-request runs bench the PR's merge-base and the PR HEAD **on the same runner in the same job** and gate relatively: head ≤ base × (1 + tolerance), with p50 +10% and p99 +20% (tails are noisier even same-runner). Runner speed cancels out.

- **`bench/latency_budgets.json`**: relative tolerances + loose absolute sanity bounds (p50 4000µs / p99 6000µs, catastrophic backstop only) + ratchet protocol, citing the run-27317381350 evidence.
- **`bench/check_latency_budgets.exs`**: optional `--base <path>`; with it, the relative gate + sanity backstop, breach report shows head/base/allowed/% over; without it, sanity-only with loud warnings. Native JSON, pattern-matched clauses per AGENTS.md.
- **CI job**: benches merge-base first (force-checkout, build via warm cache, bench, stash JSON to /tmp), returns to HEAD (forced — the base bench dirties the tracked baseline JSON; a plain checkout would abort and silently bench base as HEAD), benches HEAD last so artifacts reflect the PR. Infra failures (bench missing at base, base build break) warn and fall back to sanity-only instead of failing. Push-to-main is record + sanity + artifact (trend mode). Rerun-once-on-breach re-benches HEAD only against the same base numbers.

Cost: one extra bench run plus an incremental merge-base rebuild on PRs (deps cache covers unchanged mix.lock; worst case a full base compile when the PR bumps deps).

This PR's own CI run is the live proof: it exercises the full A/B path (the merge-base contains the bench script).

## Tests

- Four local transcripts: pass (base == head, exit 0), relative breach (doctored faster base → exit 1 with `[relative]` per-metric report), no-base fallback (warnings + sanity-only, exit 0), sanity breach (exit 1 with `[sanity]` report)
- `mix format --check-formatted` + `credo --strict` clean on the script; workflow YAML parses
- Acceptance reviewer: PASS on the enforcing structure (pre-rework); the A/B rework was validated by the transcripts above and is proven live by this PR's CI

Closes #2290. Part of #2220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)