### PR TITLE
feat(tui): patch cached composed lines instead of full recompose

### DIFF
--- a/go/tui/internal/latency/latency.go
+++ b/go/tui/internal/latency/latency.go
@@ -51,6 +51,20 @@ type Recorder struct {
 
 	resolved uint64
 	dropped  uint64
+
+	// compose is a ring buffer of frame compose-time durations (most recent
+	// wins), tracking how long View() spent building the frame (#2288). It is
+	// separate from the keystroke-to-write samples above so the HUD can show
+	// both the end-to-end latency and the frontend's own compose cost, the
+	// metric the line-cache is meant to drive down on large terminals.
+	compose      []time.Duration
+	composeHead  int
+	composeCount int
+	// composeCacheHits/Misses count cached vs recomposed body lines across all
+	// composes since boot. They feed the HUD and let tests assert the cache is
+	// actually serving hits on ref-row frames.
+	composeCacheHits   uint64
+	composeCacheMisses uint64
 }
 
 // New returns a Recorder using the wall clock.
@@ -63,6 +77,7 @@ func newWithClock(now func() time.Time) *Recorder {
 		now:     now,
 		pending: make(map[uint32]time.Time, ringSize),
 		samples: make([]time.Duration, ringSize),
+		compose: make([]time.Duration, ringSize),
 	}
 }
 
@@ -137,6 +152,23 @@ func (r *Recorder) dropForgetOrder(seq uint32) {
 	}
 }
 
+// ObserveCompose records a single frame's compose duration into the compose
+// ring (#2288). It also folds in how many body lines that compose served from
+// the line cache (hits) versus recomposed (misses), so the HUD can show the
+// cache's effect alongside the compose time it drives down.
+func (r *Recorder) ObserveCompose(d time.Duration, cacheHits, cacheMisses uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.compose[r.composeHead] = d
+	r.composeHead = (r.composeHead + 1) % ringSize
+	if r.composeCount < ringSize {
+		r.composeCount++
+	}
+	r.composeCacheHits += cacheHits
+	r.composeCacheMisses += cacheMisses
+}
+
 // Stats summarizes the resolved samples currently in the ring buffer.
 type Stats struct {
 	Count    int
@@ -145,6 +177,16 @@ type Stats struct {
 	P50      time.Duration
 	P99      time.Duration
 	Max      time.Duration
+
+	// ComposeCount/ComposeP50/ComposeP99/ComposeMax summarize frame compose
+	// time over the compose ring (#2288). ComposeCacheHits/Misses are the
+	// cumulative cached-vs-recomposed body-line counts since boot.
+	ComposeCount       int
+	ComposeP50         time.Duration
+	ComposeP99         time.Duration
+	ComposeMax         time.Duration
+	ComposeCacheHits   uint64
+	ComposeCacheMisses uint64
 }
 
 // Snapshot returns percentile statistics over the buffered samples. It copies
@@ -157,8 +199,27 @@ func (r *Recorder) Snapshot() Stats {
 		idx := (r.head - r.count + i + ringSize) % ringSize
 		window[i] = r.samples[idx]
 	}
-	stats := Stats{Count: r.count, Resolved: r.resolved, Dropped: r.dropped}
+	composeWindow := make([]time.Duration, r.composeCount)
+	for i := 0; i < r.composeCount; i++ {
+		idx := (r.composeHead - r.composeCount + i + ringSize) % ringSize
+		composeWindow[i] = r.compose[idx]
+	}
+	stats := Stats{
+		Count:              r.count,
+		Resolved:           r.resolved,
+		Dropped:            r.dropped,
+		ComposeCount:       r.composeCount,
+		ComposeCacheHits:   r.composeCacheHits,
+		ComposeCacheMisses: r.composeCacheMisses,
+	}
 	r.mu.Unlock()
+
+	if len(composeWindow) > 0 {
+		sort.Slice(composeWindow, func(i, j int) bool { return composeWindow[i] < composeWindow[j] })
+		stats.ComposeP50 = percentile(composeWindow, 0.50)
+		stats.ComposeP99 = percentile(composeWindow, 0.99)
+		stats.ComposeMax = composeWindow[len(composeWindow)-1]
+	}
 
 	if len(window) == 0 {
 		return stats
@@ -187,14 +248,34 @@ func percentile(sorted []time.Duration, ratio float64) time.Duration {
 	return sorted[index]
 }
 
-// HUD renders a one-line latency overlay suitable for an on-screen badge.
+// HUD renders a one-line latency overlay suitable for an on-screen badge. It
+// shows the keystroke-to-write latency and, when available, the frame compose
+// time and line-cache hit rate the #2288 line cache drives (compose time down,
+// hit rate up).
 func (s Stats) HUD() string {
-	if s.Count == 0 {
-		return "lat: (no samples)"
+	latPart := "lat: (no samples)"
+	if s.Count > 0 {
+		latPart = fmt.Sprintf(
+			"lat p50 %s  p99 %s  max %s  n=%d",
+			fmtDur(s.P50), fmtDur(s.P99), fmtDur(s.Max), s.Count,
+		)
+	}
+	if s.ComposeCount == 0 {
+		return latPart
+	}
+	return fmt.Sprintf("%s  %s", latPart, s.composeHUD())
+}
+
+// composeHUD renders the compose-time and cache portion of the HUD.
+func (s Stats) composeHUD() string {
+	total := s.ComposeCacheHits + s.ComposeCacheMisses
+	hitRate := 0.0
+	if total > 0 {
+		hitRate = float64(s.ComposeCacheHits) / float64(total) * 100
 	}
 	return fmt.Sprintf(
-		"lat p50 %s  p99 %s  max %s  n=%d",
-		fmtDur(s.P50), fmtDur(s.P99), fmtDur(s.Max), s.Count,
+		"compose p50 %s  p99 %s  cache %.0f%% (%d/%d)",
+		fmtDur(s.ComposeP50), fmtDur(s.ComposeP99), hitRate, s.ComposeCacheHits, total,
 	)
 }
 

--- a/go/tui/internal/ui/line_cache.go
+++ b/go/tui/internal/ui/line_cache.go
@@ -1,0 +1,314 @@
+package ui
+
+import (
+	"hash/fnv"
+	"sort"
+
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+// lineCache memoizes the rendered string of each window body row so that a
+// window-content delta whose rows are mostly refs (#2288, the ref-or-full wire
+// format) reuses the previously composed lines instead of re-running the
+// lipgloss tree for every row on every frame. The protocol's granularity is
+// rows, so the cache is line-level.
+//
+// Correctness over cleverness: a cached line is only ever returned when EVERY
+// input that produced it is identical. A row's rendered string depends on more
+// than its own text/spans (content_hash); it also depends on per-window state
+// (scroll, cursorline, selection, search, diagnostics, highlights, annotations,
+// gutter, indent guides, geometry width) and global state (theme/palette,
+// editor background, terminal width). All of that is folded into a per-window
+// "context" fingerprint. When the context changes, the window's whole row map
+// is dropped, so the cache can never serve a stale line. Within a stable
+// context, a row hits the cache only when its row_id, content_hash, and row
+// index all match, because the rendered output is also a function of the row's
+// position (cursorline row, gutter entry index, indent levels indexed by row,
+// per-row overlays). This makes patched output byte-identical to a from-scratch
+// compose by construction (AC 4): the cache stores exactly what the full path
+// produced, under an identical-inputs guarantee.
+//
+// The cache is a pointer field on Model so it survives the value-copied Model
+// the Bubbletea Update loop produces, the same lifetime trick latency.Recorder
+// uses.
+type lineCache struct {
+	windows map[uint16]*windowLineCache
+
+	// hits/misses count cached-vs-recomposed body lines for the in-progress
+	// compose. They are reset at the start of each compose (resetCounters) and
+	// read back after it (takeCounters) so the model can fold them into the
+	// latency HUD and tests can assert hit/miss behavior per frame.
+	//
+	// These counters are intentionally plain (non-atomic) fields: compose is
+	// single-threaded. It runs inside the Bubbletea Update loop (composeBody),
+	// and View() only reads the already-composed viewport content. No second
+	// goroutine ever touches the cache during a compose, so this invariant is
+	// load-bearing but implicit; do not read or mutate the cache off the Update
+	// goroutine.
+	hits   uint64
+	misses uint64
+}
+
+// windowLineCache holds one window's cached rows under a single context
+// fingerprint. A context change drops the whole map. The map is rebuilt fresh
+// on every window render (see beginWindowRender + builder.commit) and holds
+// exactly the rows rendered this frame, so it stays bounded at viewport size
+// even across vertical scroll, where the BEAM re-emits a row at a new index and
+// its old key would otherwise linger forever.
+type windowLineCache struct {
+	context uint64
+	rows    map[lineCacheKey]string
+}
+
+// lineCacheKey identifies a cached rendered row within a window context. The
+// row index is part of the key because a row's rendered output depends on its
+// position (cursorline, gutter, indent guides, overlays), so a row that moves
+// must recompose rather than reuse a line composed for a different position.
+type lineCacheKey struct {
+	rowID    uint64
+	hash     uint32
+	rowIndex int
+}
+
+func newLineCache() *lineCache {
+	return &lineCache{windows: map[uint16]*windowLineCache{}}
+}
+
+// reset clears every cached line. It is the full-invalidation sink used by
+// resize, structural commands, and keyframe resync (#2288 AC 2, AC 5).
+func (c *lineCache) reset() {
+	if c == nil {
+		return
+	}
+	c.windows = map[uint16]*windowLineCache{}
+}
+
+// dropWindow removes one window's cached lines when the window goes away, so a
+// closed split does not leak its row map for the life of the session.
+func (c *lineCache) dropWindow(windowID uint16) {
+	if c == nil {
+		return
+	}
+	delete(c.windows, windowID)
+}
+
+// resetCounters zeroes the per-compose hit/miss counters at the start of a
+// compose so each frame reports only its own cache activity.
+func (c *lineCache) resetCounters() {
+	if c == nil {
+		return
+	}
+	c.hits = 0
+	c.misses = 0
+}
+
+// takeCounters returns the per-compose hit/miss counts gathered since the last
+// resetCounters.
+func (c *lineCache) takeCounters() (hits, misses uint64) {
+	if c == nil {
+		return 0, 0
+	}
+	return c.hits, c.misses
+}
+
+// windowRenderBuilder accumulates the lines rendered for a single window during
+// one compose. It reads hits from the window's previous-frame map (prev) and
+// writes every row it touches into a fresh map (next). commit swaps
+// next in, so the stored map holds exactly the rows rendered this frame and can
+// never grow past the viewport. Without this rebuild, vertical scroll (the BEAM
+// re-emits a stable row at a shifted index) would keep adding new {id,hash,idx}
+// keys while the old-index entries lingered for the life of the session.
+type windowRenderBuilder struct {
+	cache    *lineCache
+	windowID uint16
+	context  uint64
+	prev     map[lineCacheKey]string // previous frame's rows, read-only lookups
+	next     map[lineCacheKey]string // this frame's rows, populated as we render
+}
+
+// beginWindowRender starts a fresh per-frame map for the window. It captures the
+// prior map for lookups only when the context still matches; a context change
+// means no prior line is reusable, so prev stays nil and every row misses.
+func (c *lineCache) beginWindowRender(windowID uint16, context uint64) *windowRenderBuilder {
+	if c == nil {
+		return nil
+	}
+	b := &windowRenderBuilder{
+		cache:    c,
+		windowID: windowID,
+		context:  context,
+		next:     map[lineCacheKey]string{},
+	}
+	if entry, ok := c.windows[windowID]; ok && entry.context == context {
+		b.prev = entry.rows
+	}
+	return b
+}
+
+// lookup returns a previously cached rendered row for the key, or ("", false) on
+// a miss. On a hit it also carries the line forward into this frame's map so the
+// row survives the per-frame rebuild without recomposing.
+func (b *windowRenderBuilder) lookup(key lineCacheKey) (string, bool) {
+	if b == nil || b.prev == nil {
+		return "", false
+	}
+	line, ok := b.prev[key]
+	if ok {
+		b.next[key] = line
+	}
+	return line, ok
+}
+
+// store records a freshly rendered row into this frame's map.
+func (b *windowRenderBuilder) store(key lineCacheKey, line string) {
+	if b == nil {
+		return
+	}
+	b.next[key] = line
+}
+
+// commit swaps this frame's map in as the window's cache, discarding
+// any prior-frame keys that were not rendered (and thus not carried forward).
+// This is what keeps the map bounded at the rendered row count.
+func (b *windowRenderBuilder) commit() {
+	if b == nil || b.cache == nil {
+		return
+	}
+	b.cache.windows[b.windowID] = &windowLineCache{context: b.context, rows: b.next}
+}
+
+// windowContextFingerprint folds every input that affects a window's row
+// rendering EXCEPT the per-row text/spans/id/hash (which are the cache key)
+// into one hash. Any change here invalidates the whole window's cached rows.
+// It is deliberately conservative: it mixes in the full per-window overlay and
+// chrome state, the global theme/background/width, and the placement geometry,
+// so a cached line is reused only under byte-for-byte identical render inputs.
+func (m Model) windowContextFingerprint(window protocol.WindowContent, width int, gutter protocol.Gutter, hasGutter bool) uint64 {
+	h := fnv.New64a()
+	writeUint := func(v uint64) {
+		var buf [8]byte
+		for i := 0; i < 8; i++ {
+			buf[i] = byte(v >> (8 * i))
+		}
+		h.Write(buf[:])
+	}
+	writeStr := func(s string) {
+		writeUint(uint64(len(s)))
+		h.Write([]byte(s))
+	}
+	writeBool := func(b bool) {
+		if b {
+			writeUint(1)
+		} else {
+			writeUint(0)
+		}
+	}
+
+	// Terminal/global render inputs.
+	writeUint(uint64(uint32(width)))
+	writeUint(uint64(m.bg))
+	// The active palette is the source of every color the row render reads
+	// (text, selection, search, diagnostic, gutter, indent guide). Fold its
+	// identity in so a theme swap invalidates cached lines. paletteFingerprint
+	// returns a stable digest of the palette's resolved colors.
+	writeUint(m.paletteFingerprint())
+
+	// Per-window scroll and cursorline.
+	writeUint(uint64(window.ScrollLeft))
+	writeBool(window.Cursorline.Visible)
+	writeUint(uint64(window.Cursorline.Row))
+	writeUint(uint64(window.Cursorline.BG))
+
+	// Per-window overlays. These shift a row's background/foreground per
+	// column, so any change recomposes the affected window's lines.
+	writeUint(uint64(window.Selection.Type))
+	writeUint(uint64(window.Selection.StartRow))
+	writeUint(uint64(window.Selection.StartCol))
+	writeUint(uint64(window.Selection.EndRow))
+	writeUint(uint64(window.Selection.EndCol))
+	for _, hl := range window.Highlights {
+		writeUint(uint64(hl.Kind))
+		writeUint(uint64(hl.StartRow))
+		writeUint(uint64(hl.StartCol))
+		writeUint(uint64(hl.EndRow))
+		writeUint(uint64(hl.EndCol))
+	}
+	for _, match := range window.SearchMatches {
+		writeUint(uint64(match.Row))
+		writeUint(uint64(match.StartCol))
+		writeUint(uint64(match.EndCol))
+		writeBool(match.Current)
+	}
+	for _, diag := range window.Diagnostics {
+		writeUint(uint64(diag.Severity))
+		writeUint(uint64(diag.StartRow))
+		writeUint(uint64(diag.StartCol))
+		writeUint(uint64(diag.EndRow))
+		writeUint(uint64(diag.EndCol))
+	}
+	for _, ann := range window.Annotations {
+		writeUint(uint64(ann.Row))
+		writeUint(uint64(ann.Kind))
+		writeUint(uint64(ann.FG))
+		writeUint(uint64(ann.BG))
+		writeStr(ann.Text)
+	}
+
+	// Gutter (line numbers, signs, cursor line) renders to the left of each row
+	// and is indexed by row, so its full identity is part of the context.
+	writeBool(hasGutter)
+	if hasGutter {
+		writeUint(uint64(gutter.SignColWidth))
+		writeUint(uint64(gutter.LineNumberWidth))
+		writeUint(uint64(gutter.LineNumberStyle))
+		writeUint(uint64(gutter.CursorLine))
+		writeUint(uint64(gutter.ContentHeight))
+		for _, entry := range gutter.Entries {
+			writeUint(uint64(entry.BufferLine))
+			writeUint(uint64(entry.SignType))
+			writeUint(uint64(entry.DisplayType))
+			writeStr(entry.SignText)
+		}
+	}
+
+	// Indent guides are indexed by row and column and change the rendered glyph
+	// of whitespace cells, so fold their full identity in too.
+	if guides, ok := m.indentGuides[window.ID]; ok {
+		writeUint(uint64(guides.TabWidth))
+		writeUint(uint64(guides.ActiveGuideCol))
+		for _, col := range guides.GuideCols {
+			writeUint(uint64(col))
+		}
+		for _, level := range guides.IndentLevels {
+			writeUint(uint64(level))
+		}
+	}
+
+	return h.Sum64()
+}
+
+// paletteFingerprint returns a stable digest of the active palette so any theme
+// change invalidates cached lines. It hashes the raw color slots directly (the
+// single source of every color the row render path resolves), sorted by slot so
+// the digest is deterministic regardless of Go's map iteration order.
+func (m Model) paletteFingerprint() uint64 {
+	colors := m.activePalette.colors
+	slots := make([]int, 0, len(colors))
+	for slot := range colors {
+		slots = append(slots, int(slot))
+	}
+	sort.Ints(slots)
+
+	h := fnv.New64a()
+	var buf [12]byte
+	for _, slot := range slots {
+		v := colors[byte(slot)]
+		buf[0] = byte(slot)
+		buf[1] = byte(v)
+		buf[2] = byte(v >> 8)
+		buf[3] = byte(v >> 16)
+		buf[4] = byte(v >> 24)
+		h.Write(buf[:5])
+	}
+	return h.Sum64()
+}

--- a/go/tui/internal/ui/line_cache_bench_test.go
+++ b/go/tui/internal/ui/line_cache_bench_test.go
@@ -1,0 +1,73 @@
+package ui
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/port"
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+// largeFrameModel builds a model with one window filling a 220x60 terminal,
+// committed through the real frame transaction path, so a compose exercises the
+// full body render. rowCount rows each have a stable id+hash so they are
+// cacheable.
+func largeFrameModel(b *testing.B, width, height, rowCount int) Model {
+	b.Helper()
+	m := New(uint16(width), uint16(height), nil)
+	rows := make([]protocol.WindowRow, rowCount)
+	for i := range rows {
+		rows[i] = protocol.WindowRow{
+			ID:          uint64(i + 1),
+			ContentHash: uint32(1000 + i),
+			Text:        fmt.Sprintf("line %4d  func example(arg int) (string, error) { return \"x\", nil }", i),
+		}
+	}
+	window := protocol.WindowContent{ID: 1, CursorVisible: true, ContentEpoch: 1, Rows: rows}
+	updated, _ := m.Update(port.PacketMsg{Commands: fullWindowFrame(1, window)})
+	return updated.(Model)
+}
+
+// BenchmarkComposeFullRecompose measures the full-recompose cost: the cache is
+// cleared before every compose, so every body line runs the lipgloss tree. This
+// is the pre-#2288 baseline cost on a 220x60 frame.
+func BenchmarkComposeFullRecompose(b *testing.B) {
+	m := largeFrameModel(b, 220, 60, 60)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.lineCache.reset()
+		_ = m.content()
+	}
+}
+
+// BenchmarkComposeWarmCacheAllRefs measures the patched-compose cost when every
+// row is an unchanged ref: the cache is warm and every body line is a hit. This
+// is the steady-state cost the #2288 line cache delivers.
+func BenchmarkComposeWarmCacheAllRefs(b *testing.B) {
+	m := largeFrameModel(b, 220, 60, 60)
+	_ = m.content() // warm the cache once
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.content()
+	}
+}
+
+// BenchmarkComposeWarmCacheOneDirtyRow measures the realistic keystroke case:
+// one row changed, the rest are cache hits. This is what a single edit costs on
+// a 220x60 frame with the line cache.
+func BenchmarkComposeWarmCacheOneDirtyRow(b *testing.B) {
+	m := largeFrameModel(b, 220, 60, 60)
+	_ = m.content() // warm
+
+	dirtyHash := uint32(0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Mutate one row's hash so exactly one line misses the cache, like a
+		// single-line edit delivered as a delta-with-refs frame.
+		dirtyHash++
+		win := m.windows[1]
+		win.Rows[30].ContentHash = 9_000_000 + dirtyHash
+		m.windows[1] = win
+		_ = m.content()
+	}
+}

--- a/go/tui/internal/ui/line_cache_test.go
+++ b/go/tui/internal/ui/line_cache_test.go
@@ -1,0 +1,412 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+// fullWindowFrame stages a full window-content command inside a fresh frame
+// transaction (begin/commit) so it commits through the real apply path the way
+// the BEAM delivers it. base 0 makes it a keyframe (always valid).
+func fullWindowFrame(seq uint32, window protocol.WindowContent) []protocol.Command {
+	return []protocol.Command{
+		beginFrame(seq, 0),
+		{Kind: protocol.CommandWindowContent, Window: window},
+		commitFrame(seq),
+	}
+}
+
+// deltaWindowFrame stages a window-delta command inside a delta transaction
+// (base = prior seq) so ref rows resolve against the committed window.
+func deltaWindowFrame(seq, base uint32, window protocol.WindowContent) []protocol.Command {
+	return []protocol.Command{
+		beginFrame(seq, base),
+		{Kind: protocol.CommandWindowDelta, Window: window},
+		commitFrame(seq),
+	}
+}
+
+// frameCounters returns the cache hit/miss counts of the compose that ran
+// during the model's last Update (composeBody records them and leaves them set
+// until the next compose). This is the real per-frame measurement: the refs of
+// a just-applied delta hit the cache state that existed before the delta.
+func frameCounters(m Model) (hits, misses uint64) {
+	return m.lineCache.takeCounters()
+}
+
+// recomposeCounters drives one fresh compose over the current model state and
+// returns its hit/miss counts. The first call after a state change warms the
+// cache; a second call is fully warm. Useful for asserting cold vs warm.
+func recomposeCounters(m Model) (hits, misses uint64) {
+	m.lineCache.resetCounters()
+	_ = m.content()
+	return m.lineCache.takeCounters()
+}
+
+// AC 1: a full-row frame recomposes every row (all misses), then a delta frame
+// whose rows are refs reuses the cached lines (hits) and only recomposes the
+// rows that arrived with full content (misses).
+func TestLineCacheCountsHitsForRefRowsAndMissesForFullRows(t *testing.T) {
+	m := New(80, 24, nil)
+
+	window := protocol.WindowContent{
+		ID:            1,
+		CursorVisible: true,
+		ContentEpoch:  1,
+		Rows: []protocol.WindowRow{
+			{ID: 1, ContentHash: 11, Text: "line one"},
+			{ID: 2, ContentHash: 22, Text: "line two"},
+			{ID: 3, ContentHash: 33, Text: "line three"},
+		},
+	}
+	m = applyTo(t, m, fullWindowFrame(1, window)...)
+
+	// The committed frame's own compose ran against a cold cache: every row is
+	// a miss.
+	if hits, misses := frameCounters(m); hits != 0 || misses != 3 {
+		t.Fatalf("cold full frame: hits=%d misses=%d, want 0/3", hits, misses)
+	}
+
+	// A fresh recompose with no state change is all hits: the rows are
+	// unchanged so every line is served from the cache.
+	if hits, misses := recomposeCounters(m); hits != 3 || misses != 0 {
+		t.Fatalf("warm recompose: hits=%d misses=%d, want 3/0", hits, misses)
+	}
+
+	// Delta frame: rows 1 and 3 are refs (unchanged), row 2 arrives full.
+	delta := protocol.WindowContent{
+		ID:           1,
+		ContentEpoch: 1,
+		Rows: []protocol.WindowRow{
+			{Ref: true, ID: 1, ContentHash: 11},
+			{ID: 2, ContentHash: 44, Text: "line two edited"},
+			{Ref: true, ID: 3, ContentHash: 33},
+		},
+	}
+	m = applyTo(t, m, deltaWindowFrame(2, 1, delta)...)
+
+	// The delta frame's own compose: two ref rows hit the cache warmed by the
+	// prior frame, the one full row is a miss.
+	if hits, misses := frameCounters(m); hits != 2 || misses != 1 {
+		t.Fatalf("delta-with-refs frame: hits=%d misses=%d, want 2/1", hits, misses)
+	}
+}
+
+// The per-window row map must stay bounded at the rendered row count even
+// across a long scroll, where the BEAM re-emits a stable row (same row_id and
+// content_hash) at a shifted viewport index. Because the cache key includes the
+// row index, a scrolled row lands under a new key while its old-index key would
+// otherwise linger forever. The per-frame rebuild discards keys not rendered
+// this frame, so the map equals the viewport size, not the accumulated total of
+// every (id, hash, index) ever seen.
+func TestLineCacheMapStaysBoundedAcrossScroll(t *testing.T) {
+	const viewport = 20 // rows visible at once
+	const buffer = 200  // total rows in the file
+	m := New(80, uint16(viewport+4), nil)
+
+	// A buffer line's stable wire identity: scrolling never changes a line's
+	// id/hash, only its viewport index, so the same row keeps the same key parts
+	// except rowIndex.
+	bufRow := func(bufLine int) protocol.WindowRow {
+		return protocol.WindowRow{
+			ID:          uint64(bufLine + 1),
+			ContentHash: uint32(1000 + bufLine),
+			Text:        "buffer line " + strings.Repeat("x", bufLine%7),
+		}
+	}
+	geom := protocol.PaneGeometry{ViewportRows: uint16(viewport)}
+
+	// Initial keyframe: the top viewport [0, viewport).
+	firstRows := make([]protocol.WindowRow, viewport)
+	for i := range firstRows {
+		firstRows[i] = bufRow(i)
+	}
+	m = applyTo(t, m, fullWindowFrame(1, protocol.WindowContent{
+		ID: 1, CursorVisible: true, ContentEpoch: 1, Geometry: geom, GeometrySet: true, Rows: firstRows,
+	})...)
+
+	// Scroll down one buffer line at a time via delta-with-refs frames (base !=
+	// 0, so the cache is kept, exactly how the BEAM expresses a vertical scroll).
+	// Each delta re-emits the visible rows: the carried-over rows are refs (same
+	// id/hash, now one index higher in the previous window's resolved set), and
+	// the newly revealed bottom row arrives full. Every carried row's viewport
+	// index shifts, so under the pre-fix unbounded cache the window map would
+	// accumulate one entry per (id, hash, index) pair seen across the whole
+	// scroll (~buffer * viewport entries) instead of staying at viewport size.
+	seq := uint32(1)
+	for top := 1; top <= buffer-viewport; top++ {
+		seq++
+		rows := make([]protocol.WindowRow, viewport)
+		for i := 0; i < viewport; i++ {
+			bl := top + i
+			if i < viewport-1 {
+				// Carried over from the prior viewport: emit as a ref.
+				rows[i] = protocol.WindowRow{Ref: true, ID: uint64(bl + 1), ContentHash: uint32(1000 + bl)}
+			} else {
+				// Newly revealed bottom line: full row.
+				rows[i] = bufRow(bl)
+			}
+		}
+		m = applyTo(t, m, deltaWindowFrame(seq, seq-1, protocol.WindowContent{
+			ID: 1, ContentEpoch: 1, Geometry: geom, GeometrySet: true, Rows: rows,
+		})...)
+	}
+
+	entry, ok := m.lineCache.windows[1]
+	if !ok {
+		t.Fatal("expected a cached entry for window 1")
+	}
+	got := len(entry.rows)
+	if got != viewport {
+		t.Fatalf("window map size = %d after scrolling a %d-row buffer; want exactly %d (the rendered row count), not the accumulated total", got, buffer, viewport)
+	}
+}
+
+// AC 4 (make-or-break): the patched output must be byte-identical to a
+// from-scratch full composition for the same model state. After a delta frame
+// patches cached lines, resetting the cache and recomposing from scratch must
+// produce exactly the same body string.
+func TestLineCachePatchedOutputEqualsFullRecompose(t *testing.T) {
+	build := func() Model {
+		m := New(120, 40, nil)
+		window := protocol.WindowContent{
+			ID:            1,
+			CursorVisible: true,
+			ContentEpoch:  1,
+			Cursorline:    protocol.Cursorline{Visible: true, Row: 1, BG: 0x223344},
+			Rows: []protocol.WindowRow{
+				{ID: 1, ContentHash: 11, Text: "alpha beta gamma"},
+				{ID: 2, ContentHash: 22, Text: "delta epsilon zeta"},
+				{ID: 3, ContentHash: 33, Text: "eta theta iota"},
+				{ID: 4, ContentHash: 44, Text: "kappa lambda mu"},
+			},
+		}
+		m = applyTo(t, m, fullWindowFrame(1, window)...)
+		delta := protocol.WindowContent{
+			ID:           1,
+			ContentEpoch: 1,
+			Cursorline:   protocol.Cursorline{Visible: true, Row: 1, BG: 0x223344},
+			Rows: []protocol.WindowRow{
+				{Ref: true, ID: 1, ContentHash: 11},
+				{ID: 2, ContentHash: 55, Text: "delta EDITED zeta"},
+				{Ref: true, ID: 3, ContentHash: 33},
+				{Ref: true, ID: 4, ContentHash: 44},
+			},
+		}
+		return applyTo(t, m, deltaWindowFrame(2, 1, delta)...)
+	}
+
+	patched := build()
+	patchedBody := patched.content()
+	// Confirm the patch path actually served hits, otherwise the equivalence
+	// claim is vacuous (it would just be two full recomposes).
+	if hits, _ := frameCounters(patched); hits == 0 {
+		t.Fatal("expected the patch path to serve cache hits; test would be vacuous")
+	}
+
+	// From-scratch composition of the identical final state: drop the cache so
+	// every line is recomposed by the full lipgloss path.
+	fresh := build()
+	fresh.lineCache.reset()
+	fullBody := fresh.content()
+
+	if patchedBody != fullBody {
+		t.Fatalf("patched output diverged from full recompose:\npatched=%q\nfull   =%q", patchedBody, fullBody)
+	}
+}
+
+// AC 4, broader: across a sequence of edits (each a delta touching one row),
+// the patched body must always equal a from-scratch recompose of the same
+// committed state.
+func TestLineCacheEquivalenceAcrossEditSequence(t *testing.T) {
+	m := New(100, 30, nil)
+	rows := []protocol.WindowRow{
+		{ID: 1, ContentHash: 100, Text: "func main() {"},
+		{ID: 2, ContentHash: 200, Text: "  fmt.Println(\"hi\")"},
+		{ID: 3, ContentHash: 300, Text: "}"},
+	}
+	m = applyTo(t, m, fullWindowFrame(1, protocol.WindowContent{ID: 1, CursorVisible: true, ContentEpoch: 1, Rows: rows})...)
+
+	edits := []struct {
+		hash uint32
+		text string
+	}{
+		{210, "  fmt.Println(\"hi there\")"},
+		{220, "  fmt.Println(\"hello\")"},
+		{230, "  fmt.Println(\"hello world\")"},
+	}
+	seq := uint32(1)
+	for _, edit := range edits {
+		seq++
+		delta := protocol.WindowContent{
+			ID:           1,
+			ContentEpoch: 1,
+			Rows: []protocol.WindowRow{
+				{Ref: true, ID: 1, ContentHash: 100},
+				{ID: 2, ContentHash: edit.hash, Text: edit.text},
+				{Ref: true, ID: 3, ContentHash: 300},
+			},
+		}
+		m = applyTo(t, m, deltaWindowFrame(seq, seq-1, delta)...)
+
+		patchedBody := m.content()
+		fresh := m
+		fresh.lineCache = newLineCache()
+		if patchedBody != fresh.content() {
+			t.Fatalf("edit %q: patched body diverged from full recompose", edit.text)
+		}
+	}
+}
+
+// AC 2: a resize invalidates the cache and takes the full composition path. The
+// first compose after resize is all misses (cold cache) at the new width.
+func TestLineCacheResizeInvalidatesCache(t *testing.T) {
+	m := New(80, 24, nil)
+	window := protocol.WindowContent{
+		ID:            1,
+		CursorVisible: true,
+		ContentEpoch:  1,
+		Rows: []protocol.WindowRow{
+			{ID: 1, ContentHash: 11, Text: "one"},
+			{ID: 2, ContentHash: 22, Text: "two"},
+		},
+	}
+	m = applyTo(t, m, fullWindowFrame(1, window)...)
+	// Warm the cache: a fresh recompose with no change is all hits.
+	if hits, misses := recomposeCounters(m); hits != 2 || misses != 0 {
+		t.Fatalf("cache failed to warm: hits=%d misses=%d, want 2/0", hits, misses)
+	}
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+
+	// The resize Update's own compose ran against a cleared cache: all misses.
+	if hits, misses := frameCounters(m); hits != 0 || misses != 2 {
+		t.Fatalf("post-resize compose: hits=%d misses=%d, want 0/2 (cache cleared)", hits, misses)
+	}
+}
+
+// AC 5: a keyframe (base_frame_seq=0) fully resets the cache along with the rest
+// of the staged state. A delta that edits a row, then a keyframe carrying fresh
+// content for the same row IDs, must recompose every row (cold cache) and the
+// rendered body must reflect the keyframe content with no stale lines.
+func TestLineCacheKeyframeResetsCache(t *testing.T) {
+	m := New(80, 24, nil)
+	window := protocol.WindowContent{
+		ID:            1,
+		CursorVisible: true,
+		ContentEpoch:  1,
+		Rows: []protocol.WindowRow{
+			{ID: 1, ContentHash: 11, Text: "stale one"},
+			{ID: 2, ContentHash: 22, Text: "stale two"},
+		},
+	}
+	m = applyTo(t, m, fullWindowFrame(1, window)...)
+	// Warm the cache so it holds the stale lines.
+	if hits, _ := recomposeCounters(m); hits == 0 {
+		t.Fatal("cache failed to warm before keyframe")
+	}
+
+	// Keyframe (base 0) resync with fresh content reusing the same row IDs.
+	keyframe := protocol.WindowContent{
+		ID:            1,
+		CursorVisible: true,
+		ContentEpoch:  2,
+		Rows: []protocol.WindowRow{
+			{ID: 1, ContentHash: 11, Text: "fresh one"},
+			{ID: 2, ContentHash: 22, Text: "fresh two"},
+		},
+	}
+	m = applyTo(t, m, fullWindowFrame(7, keyframe)...)
+
+	// The keyframe reset means its own compose is all misses (cold cache),
+	// even though the row IDs and hashes repeat from the pre-resync frame.
+	if hits, misses := frameCounters(m); hits != 0 || misses != 2 {
+		t.Fatalf("post-keyframe compose: hits=%d misses=%d, want 0/2 (cache reset)", hits, misses)
+	}
+
+	// And no stale line survives: the rendered body shows the fresh content.
+	body := renderedBody(m)
+	if !strings.Contains(body, "fresh one") || !strings.Contains(body, "fresh two") {
+		t.Fatalf("keyframe content missing from body: %q", body)
+	}
+	if strings.Contains(body, "stale one") || strings.Contains(body, "stale two") {
+		t.Fatalf("stale cached line survived keyframe reset: %q", body)
+	}
+}
+
+// A theme change must invalidate cached lines even though the rows are
+// unchanged refs, because the rendered colors depend on the palette (AC 2,
+// chrome-state-changed path). The context fingerprint folds the palette in, so
+// the post-theme compose recomposes rather than serving stale-colored lines.
+func TestLineCacheThemeChangeInvalidatesViaFingerprint(t *testing.T) {
+	m := New(80, 24, nil)
+	window := protocol.WindowContent{
+		ID:            1,
+		CursorVisible: true,
+		ContentEpoch:  1,
+		Rows: []protocol.WindowRow{
+			{ID: 1, ContentHash: 11, Text: "colored"},
+		},
+	}
+	m = applyTo(t, m, fullWindowFrame(1, window)...)
+	recomposeCounters(m) // warm
+
+	// Capture the raw (ANSI-bearing) body so a color-only change is visible;
+	// renderedBody strips ANSI and would hide it.
+	bodyBefore := m.content()
+
+	// Swap the editor foreground via a direct palette mutation, mirroring a
+	// gui_theme chrome change, then confirm the next compose recomposes.
+	m.activePalette.colors[themeEditorFG] = 0xFF0000
+	if hits, misses := recomposeCounters(m); hits != 0 || misses != 1 {
+		t.Fatalf("post-theme compose: hits=%d misses=%d, want 0/1 (palette fingerprint changed)", hits, misses)
+	}
+
+	// The recomposed line must differ from the pre-theme line (new fg color in
+	// the ANSI sequence), proving a stale-colored cached line was not reused.
+	if got := m.content(); got == bodyBefore {
+		t.Fatal("theme change produced an identical body; cached line was not recomposed")
+	}
+}
+
+// AC 3: the compose-time metric and cache stats are recorded through the
+// latency recorder and visible in the HUD string.
+func TestComposeMetricRecordedAndVisibleInHUD(t *testing.T) {
+	m := New(80, 24, nil)
+	window := protocol.WindowContent{
+		ID:            1,
+		CursorVisible: true,
+		ContentEpoch:  1,
+		Rows: []protocol.WindowRow{
+			{ID: 1, ContentHash: 11, Text: "metric line"},
+		},
+	}
+	m = applyTo(t, m, fullWindowFrame(1, window)...)
+	// A second frame so the cache serves at least one hit, exercising the
+	// cache portion of the HUD.
+	m = applyTo(t, m, deltaWindowFrame(2, 1, protocol.WindowContent{
+		ID:           1,
+		ContentEpoch: 1,
+		Rows:         []protocol.WindowRow{{Ref: true, ID: 1, ContentHash: 11}},
+	})...)
+
+	stats := m.latency.Snapshot()
+	if stats.ComposeCount == 0 {
+		t.Fatal("expected compose samples to be recorded")
+	}
+	if stats.ComposeCacheHits == 0 {
+		t.Fatal("expected at least one cache hit to be recorded")
+	}
+
+	hud := stats.HUD()
+	if !strings.Contains(hud, "compose") {
+		t.Fatalf("HUD missing compose section: %q", hud)
+	}
+	if !strings.Contains(hud, "cache") {
+		t.Fatalf("HUD missing cache section: %q", hud)
+	}
+}

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -65,6 +65,13 @@ type Model struct {
 	// updates. hudVisible toggles the on-screen p50/p99 overlay at runtime.
 	latency    *latency.Recorder
 	hudVisible bool
+	// lineCache memoizes composed window body lines so a window-content delta
+	// whose rows are mostly refs reuses cached lines instead of recomposing the
+	// whole body every frame (#2288). It is a pointer so it persists across the
+	// value-copied Model the Update loop produces (same lifetime trick as
+	// latency). Structural commands, resize, and keyframe resync clear it; see
+	// invalidateLineCache and the keyframe reset in commitStaging.
+	lineCache *lineCache
 	// mouseDrag tracks an in-progress press-drag over a draggable chrome zone
 	// (a tab or a file-tree row), so a release over a different target can emit
 	// a tab_reorder or file_tree_drop gui_action (ticket #2229, AC3). It is nil
@@ -139,6 +146,7 @@ func New(width, height uint16, out chan<- []byte) Model {
 		// MINGA_LATENCY_HUD=1 shows the latency overlay at boot; it is also
 		// toggled at runtime with ctrl+alt+l (ticket #2215).
 		hudVisible: latencyHUDEnvEnabled(),
+		lineCache:  newLineCache(),
 	}
 	// Seed the header-offset cache so the first mouse event before any
 	// frame/resize still translates against the rendered fallback header.
@@ -176,6 +184,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		// Resize is a structural change: every cached line was composed at the
+		// old width, so drop the cache and take the full composition path
+		// (#2288 AC 2). The context fingerprint would catch the width change on
+		// its own, but resetting here keeps the cache from holding stale lines
+		// for the old geometry.
+		m.lineCache.reset()
 		m.refreshRenderedHeaderHeight()
 		m.viewport.SetWidth(msg.Width)
 		m.viewport.SetHeight(m.bodyHeight())
@@ -237,8 +251,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	m.viewport.SetWidth(max(m.width, 1))
 	m.viewport.SetHeight(m.bodyHeight())
-	m.viewport.SetContent(m.content())
+	m.viewport.SetContent(m.composeBody())
 	return m, cmd
+}
+
+// composeBody renders the editor body (the expensive lipgloss path) and records
+// how long it took plus how many body lines came from the line cache vs were
+// recomposed (#2288). The line cache mutates its per-compose hit/miss counters
+// through its pointer while content() runs, so reset them first and fold the
+// elapsed time and counts into the latency HUD afterward. This is the single
+// compose-time observation per frame; it is where the line-cache win shows up.
+func (m *Model) composeBody() string {
+	start := time.Now()
+	m.lineCache.resetCounters()
+	content := m.content()
+	if m.latency != nil {
+		hits, misses := m.lineCache.takeCounters()
+		m.latency.ObserveCompose(time.Since(start), hits, misses)
+	}
+	return content
 }
 
 func (m Model) View() tea.View {
@@ -401,6 +432,15 @@ func (m *Model) commitStaging(cmds []tea.Cmd, command protocol.Command) []tea.Cm
 	// committed frame_seq, otherwise this delta assumes a frame we never applied.
 	if m.staging.base != 0 && m.staging.base != m.lastCommittedSeq {
 		return m.invalidateStaging(cmds, "frame base mismatch")
+	}
+
+	// Resync safety (#2288 AC 5): a keyframe (base 0) is a full reset of the
+	// staged state, so the composed-line cache must reset with it. The keyframe
+	// carries fresh full rows for the whole frame; clearing first guarantees no
+	// line composed against the pre-resync state survives. Delta frames (base
+	// != 0) keep the cache so their ref rows hit it.
+	if m.staging.base == 0 {
+		m.lineCache.reset()
 	}
 
 	// Valid: replay the buffer atomically through the live mutation path.
@@ -597,6 +637,7 @@ func resolveWindowRows(previous []protocol.WindowRow, delta []protocol.WindowRow
 
 func (m *Model) removeWindow(id uint16) {
 	delete(m.windows, id)
+	m.lineCache.dropWindow(id)
 	for index, windowID := range m.windowOrder {
 		if windowID == id {
 			m.windowOrder = append(m.windowOrder[:index], m.windowOrder[index+1:]...)

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -26,17 +26,12 @@ func (m Model) content() string {
 }
 
 func (m Model) semanticLines() []string {
-	if lines, ok := m.composedSemanticLines(); ok {
-		if len(lines) == 0 {
-			return nil
-		}
-		return lines
-	}
-	lines := make([]string, 0, m.bodyHeight())
-	for _, id := range m.windowOrder {
-		window := m.windows[id]
-		lines = append(lines, m.renderWindowRows(window)...)
-	}
+	// composedSemanticLines renders every window's rows exactly once. When no
+	// window carries geometry it returns those same rendered lines as the
+	// no-geometry fallback, so reuse them directly instead of re-rendering the
+	// windows a second time (which would also double-count the line cache
+	// hit/miss counters, #2288).
+	lines, _ := m.composedSemanticLines()
 	if len(lines) == 0 {
 		return nil
 	}
@@ -204,8 +199,31 @@ func (m Model) renderWindowRows(window protocol.WindowContent) []string {
 	} else if len(m.windowOrder) <= 1 {
 		height = max(height, m.bodyHeight())
 	}
+	// Composed-line cache (#2288): a row that arrived as a ref (unchanged
+	// content_hash) under an unchanged window render context reuses its
+	// previously composed line instead of re-running the lipgloss tree. The
+	// context fingerprint folds in every non-row input (scroll, overlays,
+	// gutter, indent guides, theme, width), so a cached line is only ever
+	// returned when it is byte-identical to a fresh compose (AC 4). The cache is
+	// a pointer field, so this value-receiver method still mutates its counters.
+	context := m.windowContextFingerprint(window, width, gutter, hasGutter)
+	// The cache map is rebuilt fresh each frame: the builder reads hits from the
+	// prior map and writes every row it touches (hit or miss) into a new map,
+	// committed at the end. This keeps the window's map at the rendered row count
+	// instead of accumulating an entry per (row_id, hash, index) ever seen, which
+	// would grow without bound under vertical scroll.
+	builder := m.lineCache.beginWindowRender(window.ID, context)
 	lines := make([]string, 0, height)
 	for rowIndex := 0; rowIndex < height; rowIndex++ {
+		key, cacheable := lineCacheKeyFor(window, rowIndex)
+		if cacheable {
+			if cached, ok := builder.lookup(key); ok {
+				m.lineCache.hits++
+				lines = append(lines, cached)
+				continue
+			}
+		}
+
 		contentWidth := width
 		gutterText := ""
 		if hasGutter {
@@ -214,9 +232,31 @@ func (m Model) renderWindowRows(window protocol.WindowContent) []string {
 		}
 
 		content := m.renderSemanticContentRow(window, rowIndex, contentWidth)
-		lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, gutterText, content))
+		line := lipgloss.JoinHorizontal(lipgloss.Top, gutterText, content)
+		if cacheable {
+			m.lineCache.misses++
+			builder.store(key, line)
+		}
+		lines = append(lines, line)
 	}
+	builder.commit()
 	return lines
+}
+
+// lineCacheKeyFor returns the cache key for a window row and whether the row is
+// cacheable. Only body rows with a stable wire identity (row_id and
+// content_hash both set) are cached; tilde fill rows past the content and rows
+// without an identity (e.g. synthesized in tests) always recompose so the cache
+// never keys on a degenerate identity.
+func lineCacheKeyFor(window protocol.WindowContent, rowIndex int) (lineCacheKey, bool) {
+	if rowIndex >= len(window.Rows) {
+		return lineCacheKey{}, false
+	}
+	row := window.Rows[rowIndex]
+	if row.ID == 0 || row.ContentHash == 0 {
+		return lineCacheKey{}, false
+	}
+	return lineCacheKey{rowID: row.ID, hash: row.ContentHash, rowIndex: rowIndex}, true
 }
 
 func (m Model) renderSemanticContentRow(window protocol.WindowContent, rowIndex int, width int) string {


### PR DESCRIPTION
## Summary

The frontend half of epic #2220's two-tier rendering: the Go TUI stops paying full lipgloss recompose on every frame. Composed body lines are cached by row identity (`row_id` + `content_hash` + row index) plus a per-window context fingerprint folding in every non-row render input (scroll, cursorline, selection, search, diagnostics, highlights, annotations, gutter, indent guides, width, background, full palette hash). Ref-row delta entries are cache hits; full rows recompose; any context change drops the window's cache.

**Measured win (220x60, M1):** full recompose 38.3ms/op → warm cache 11.8ms/op → one-dirty-row keystroke ~10ms/op, a **3.5x** improvement. The residual is compositor/join work outside the body cache. Compose time + cache hit rate now show in the latency HUD (`MINGA_LATENCY_HUD` / Ctrl+Alt+L).

- **Equivalence is the load-bearing guarantee**: tests run the same model state through the patch path and a from-scratch full composition and assert byte-identical output (single state + multi-edit sweep), with non-vacuous guards proving the patch path actually served hits. A bug-hunting pass traced every render input one-by-one against the key/fingerprint and found no stale-line gap.
- **Bounded by construction**: the cache rebuilds per frame (only rows rendered this frame survive the commit swap), so vertical scroll and long edit sessions keep each window's map at viewport size. The bug-hunt's one Important finding (unbounded growth via orphaned `{row_id, hash, old_index}` keys under scroll) is fixed this way and pinned by a regression test proven against the old behavior (3,620 accumulated entries vs exactly 20).
- **Invalidation**: resize, keyframe (`base_frame_seq=0`, tied into the #2219 resync path), theme/palette via fingerprint, window removal.
- **Drive-by fix**: the no-geometry fallback path rendered every window twice (once discarded); `semanticLines` now reuses `composedSemanticLines` output. Output identical, cache counters no longer double-count.

Pairs with #2287 (BEAM line-patch frames), which multiplies the win by making typical keystrokes ref-heavy delta frames; neither depends on the other.

## Tests

- `go test ./...` 305 passed; gofmt clean; vet clean
- 8 new cache tests: hit/miss counters (cold 0/3, warm 3/0, delta 2/1), resize/theme/keyframe invalidation, byte-identical equivalence x2, scroll boundedness, HUD metric
- 3 benchmarks for the before/after numbers
- Reviews: prtk-code-reviewer bug-hunt (key/fingerprint completeness verified input-by-input; one Important finding fixed as above), acceptance reviewer PASS
- Nothing outside go/tui touched

Closes #2288. Part of #2220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)