### PR TITLE
feat(editor): coalesce agent stream deltas off the Editor mailbox

### DIFF
--- a/bench/keystroke_latency_baseline.exs
+++ b/bench/keystroke_latency_baseline.exs
@@ -12,10 +12,20 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
 
     * `small_frame`   — 100x40, a plain editor frame.
     * `large_frame`   — 220x60 with the file tree sidebar and status bar visible.
-    * `agent_stream`  — typing while a deterministic synthetic agent-streaming
-                        replay fixture drives competing render work between
-                        keystrokes. The jitter this adds is expected; we record
-                        it honestly so later work can show it shrinking.
+    * `agent_stream`  — typing while a deterministic synthetic agent producer
+                        drives token deltas at a fixed rate CONCURRENTLY with
+                        the keystrokes (a background process floods the
+                        production subscriber's mailbox, not the gaps between
+                        keys). This is the head-of-line-blocking pressure #2289
+                        targets. We sample the Editor `message_queue_len` during
+                        the run so the mailbox depth is recorded honestly and
+                        later work can show it shrinking (AC 1, AC 4).
+
+  When `MingaEditor.Agent.Ingest` is present (#2289), the producer feeds the
+  Ingest coalescer (the real subscriber) and the Editor receives batched
+  `{:agent_stream_batch, ...}` messages; otherwise it feeds the Editor directly,
+  reproducing the pre-#2289 per-delta path. The same bench therefore measures
+  before and after honestly across branches.
 
   Writes p50/p99 (and p99.9/max) JSON to `bench/baselines/keystroke_latency.json`
   and prints `METRIC` lines so a CI job can track the numbers over time without
@@ -28,7 +38,6 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
   alias Minga.Test.HeadlessPort
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Frontend.Capabilities
-  alias MingaEditor.UI.Panel.MessageStore
 
   Code.require_file("fixtures/agent_stream_replay.exs", __DIR__)
 
@@ -80,27 +89,122 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
     end)
   end
 
+  # Inter-token interval for the synthetic producer. ~6ms ≈ 160 tokens/sec, a
+  # realistic fast-model streaming rate that, delivered per-delta, floods the
+  # Editor mailbox ahead of queued keystrokes. The producer emits a small burst
+  # each cycle so deltas can pile up faster than the per-delta path drains them.
+  @agent_token_interval_ms 4
+  @agent_burst 3
+
   @spec scenario_agent_stream() :: map()
   defp scenario_agent_stream do
-    chunks = Minga.Bench.AgentStreamReplay.chunks()
-
     with_editor([width: 220, height: 60, capabilities: @gui_caps], fn ctx ->
       reveal_file_tree(ctx)
       warmup(ctx)
 
-      # Each keystroke is preceded by replaying the next deterministic agent
-      # chunk into the message store, so render work competes with typing in a
-      # repeatable way (no wall-clock randomness).
-      stream = Stream.cycle(chunks) |> Enum.take(@measured_keys)
+      {producer, session} = start_agent_producer(ctx)
 
-      stream
-      |> Enum.with_index(1)
-      |> Enum.map(fn {chunk, seq} ->
-        append_agent_chunk(ctx, chunk)
-        send_key(ctx, ?a, seq)
-      end)
-      |> summarize()
+      try do
+        samples =
+          1..@measured_keys
+          |> Enum.map(fn seq ->
+            # Sample the Editor mailbox depth at the instant the keystroke is
+            # enqueued: this is the head-of-line depth a key sees behind queued
+            # agent traffic (#2289 AC 4). send_key then measures the time for
+            # that key to produce its frame, which absorbs any blocking.
+            queue_len = editor_queue_len(ctx)
+            sample = send_key(ctx, ?a, seq)
+            Map.put(sample, :queue_len, queue_len)
+          end)
+
+        summarize(samples)
+      after
+        stop_agent_producer(producer, ctx, session)
+      end
     end)
+  end
+
+  # ── Concurrent agent producer (#2289) ───────────────────────────────────────
+
+  # Spawns a background process that streams agent token deltas at a fixed rate
+  # into the production subscriber, concurrent with typing. When the Editor runs
+  # an Ingest coalescer the deltas feed Ingest (the real subscriber) so the
+  # Editor sees batched messages; otherwise they feed the Editor directly,
+  # reproducing the pre-#2289 per-delta mailbox pressure.
+  @spec start_agent_producer(map()) :: {pid(), pid()}
+  defp start_agent_producer(ctx) do
+    chunks = Minga.Bench.AgentStreamReplay.chunks()
+    session = spawn(fn -> receive(do: (:stop -> :ok)) end)
+    target = agent_stream_target(ctx)
+
+    producer =
+      spawn_link(fn ->
+        stream_agent_deltas(target, session, chunks)
+      end)
+
+    {producer, session}
+  end
+
+  # The subscriber the real session would deliver to: the Ingest coalescer if
+  # this build has it (#2289), else the Editor itself.
+  @spec agent_stream_target(map()) :: pid()
+  defp agent_stream_target(%{editor: editor}) do
+    state = :sys.get_state(editor)
+
+    case ingest_pid(state) do
+      pid when is_pid(pid) -> pid
+      _ -> editor
+    end
+  end
+
+  @spec ingest_pid(term()) :: pid() | nil
+  defp ingest_pid(state) do
+    if Code.ensure_loaded?(MingaEditor.State) and
+         function_exported?(MingaEditor.State, :agent_ingest, 1) do
+      MingaEditor.State.agent_ingest(state)
+    end
+  rescue
+    _ -> nil
+  catch
+    _, _ -> nil
+  end
+
+  @spec stream_agent_deltas(pid(), pid(), [String.t()]) :: no_return()
+  defp stream_agent_deltas(target, session, chunks) do
+    chunks
+    |> Stream.cycle()
+    |> Stream.chunk_every(@agent_burst)
+    |> Enum.each(fn burst ->
+      Enum.each(burst, fn chunk ->
+        send(target, {:agent_event, session, {:text_delta, chunk}})
+      end)
+
+      receive do
+        :stop -> exit(:normal)
+      after
+        @agent_token_interval_ms -> :ok
+      end
+    end)
+  end
+
+  @spec stop_agent_producer(pid(), map(), pid()) :: :ok
+  defp stop_agent_producer(producer, _ctx, session) do
+    if Process.alive?(producer) do
+      send(producer, :stop)
+    end
+
+    if Process.alive?(session), do: Process.exit(session, :kill)
+    :ok
+  catch
+    _, _ -> :ok
+  end
+
+  @spec editor_queue_len(map()) :: non_neg_integer()
+  defp editor_queue_len(%{editor: editor}) do
+    case Process.info(editor, :message_queue_len) do
+      {:message_queue_len, len} -> len
+      _ -> 0
+    end
   end
 
   # ── Measurement core ─────────────────────────────────────────────────────────
@@ -121,7 +225,10 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
           correlated: boolean()
         }
   defp send_key(%{editor: editor, port: port}, codepoint, seq) do
-    _ = :sys.get_state(editor)
+    # Generous timeout: under the concurrent agent producer the per-delta path
+    # (pre-#2289) can deeply back up the Editor mailbox; we want the run to
+    # complete and surface that as large latency, not crash the sync barrier.
+    _ = :sys.get_state(editor, 30_000)
     ref = HeadlessPort.prepare_await(port)
     started_at = System.monotonic_time(:microsecond)
     send(editor, {:minga_input, {:key_press, codepoint, 0, seq}})
@@ -144,12 +251,12 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
     :ok
   end
 
-  @spec summarize([%{wall_us: non_neg_integer(), correlated: boolean()}]) :: map()
+  @spec summarize([map()]) :: map()
   defp summarize(samples) do
     wall = Enum.map(samples, & &1.wall_us)
     correlated = Enum.count(samples, & &1.correlated)
 
-    %{
+    base = %{
       samples: length(samples),
       correlated: correlated,
       p50_us: percentile(wall, 0.50),
@@ -157,6 +264,25 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
       p999_us: percentile(wall, 0.999),
       max_us: Enum.max(wall, fn -> 0 end)
     }
+
+    merge_queue_stats(base, Enum.flat_map(samples, &queue_len_of/1))
+  end
+
+  @spec queue_len_of(map()) :: [non_neg_integer()]
+  defp queue_len_of(%{queue_len: len}) when is_integer(len), do: [len]
+  defp queue_len_of(_sample), do: []
+
+  # When the scenario sampled the Editor mailbox depth, fold its distribution in
+  # so before/after runs can show the queue staying low (#2289 AC 4).
+  @spec merge_queue_stats(map(), [non_neg_integer()]) :: map()
+  defp merge_queue_stats(base, []), do: base
+
+  defp merge_queue_stats(base, queue_lens) do
+    Map.merge(base, %{
+      queue_p50: percentile(queue_lens, 0.50),
+      queue_p99: percentile(queue_lens, 0.99),
+      queue_max: Enum.max(queue_lens, fn -> 0 end)
+    })
   end
 
   # ── Editor lifecycle ─────────────────────────────────────────────────────────
@@ -232,20 +358,6 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
     _, _ -> :ok
   end
 
-  # Appends one deterministic agent chunk to the message store so the next
-  # render does more work, replicating agent-streaming pressure deterministically.
-  @spec append_agent_chunk(map(), String.t()) :: :ok
-  defp append_agent_chunk(%{editor: editor}, chunk) do
-    :sys.replace_state(editor, fn state ->
-      store = MessageStore.append(state.message_store, "[agent] " <> chunk)
-      %{state | message_store: store}
-    end)
-
-    :ok
-  catch
-    _, _ -> :ok
-  end
-
   @spec document() :: String.t()
   defp document do
     1..2_000
@@ -278,6 +390,15 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
     Enum.each(results, fn {scenario, stats} ->
       Enum.each([:p50_us, :p99_us, :p999_us, :max_us], fn field ->
         IO.puts("METRIC keystroke_#{scenario}_#{field}=#{Map.fetch!(stats, field)}")
+      end)
+
+      # Editor mailbox depth sampled during the scenario (#2289 AC 4). Only the
+      # agent_stream scenario records these.
+      Enum.each([:queue_p50, :queue_p99, :queue_max], fn field ->
+        case Map.fetch(stats, field) do
+          {:ok, value} -> IO.puts("METRIC keystroke_#{scenario}_#{field}=#{value}")
+          :error -> :ok
+        end
       end)
     end)
 

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -190,6 +190,13 @@ defmodule MingaEditor do
 
     state = EditorState.set_renderer(state, renderer_pid)
 
+    # Agent stream coalescer (#2289). Linked to the Editor so it shares the
+    # Editor's lifecycle: it subscribes to agent sessions on the Editor's behalf
+    # and forwards coalesced {:agent_stream_batch, ...} messages back here,
+    # keeping per-delta traffic out of the Editor mailbox.
+    {:ok, ingest} = MingaEditor.Agent.Ingest.start_link(editor: self())
+    state = EditorState.set_agent_ingest(state, ingest)
+
     # Logger redirect and startup messages
     if state.backend != :headless do
       log_path = Minga.LoggerHandler.install()
@@ -689,6 +696,14 @@ defmodule MingaEditor do
     route_agent_event(state, session_pid, event)
   end
 
+  # Coalesced agent stream batch from MingaEditor.Agent.Ingest (#2289). One
+  # batch replaces N per-delta messages: applied once (one bump_message_version,
+  # one :sync_agent_buffer, one render) instead of once per delta, so streaming
+  # load no longer floods the Editor mailbox ahead of queued keystrokes.
+  def handle_info({:agent_stream_batch, session_pid, batch}, state) do
+    route_agent_stream_batch(state, session_pid, batch)
+  end
+
   def handle_info({:inline_ask_prompt_sent, session_pid, result}, state) do
     state = InlineAskEvents.handle_prompt_result(state, session_pid, result)
     {:noreply, schedule_render(state, 16)}
@@ -1056,6 +1071,27 @@ defmodule MingaEditor do
   @spec route_agent_event(EditorState.t(), pid(), term()) :: {:noreply, EditorState.t()}
   defp route_agent_event(state, session_pid, event) do
     route_agent_event(state, session_pid, event, agent_event_owner(state, session_pid))
+  end
+
+  # Applies a coalesced stream batch (#2289). Mirrors route_agent_event owner
+  # routing: the active foreground agent's batch mutates the agent surface once;
+  # a background subagent's deltas carry no shell state (the shell only reacts to
+  # control events, which Ingest forwards individually), so its batch just
+  # schedules a render. Ephemeral inline sessions never route through Ingest.
+  @spec route_agent_stream_batch(EditorState.t(), pid(), [term()]) :: {:noreply, EditorState.t()}
+  defp route_agent_stream_batch(state, session_pid, batch) do
+    route_agent_stream_batch(state, session_pid, batch, agent_event_owner(state, session_pid))
+  end
+
+  @spec route_agent_stream_batch(EditorState.t(), pid(), [term()], atom()) ::
+          {:noreply, EditorState.t()}
+  defp route_agent_stream_batch(state, _session_pid, batch, :active_agent) do
+    {state, effects} = Events.handle_batch(state, batch)
+    {:noreply, EffectHandler.apply_effects(state, effects)}
+  end
+
+  defp route_agent_stream_batch(state, _session_pid, _batch, _owner) do
+    {:noreply, schedule_render(state, 16)}
   end
 
   @spec route_agent_event(EditorState.t(), pid(), term(), atom()) :: {:noreply, EditorState.t()}

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -82,20 +82,15 @@ defmodule MingaEditor.Agent.Events do
     {state, [:render | effects]}
   end
 
-  # Text deltas use a 1ms render delay so streaming text appears with
-  # minimal latency. The throttle guard in schedule_render coalesces
-  # multiple deltas arriving in the same millisecond into one render.
-  def handle(state, {:text_delta, _delta}) do
-    state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
-    state = AgentAccess.update_panel(state, &Panel.bump_message_version/1)
-    {state, [{:render, 1}, :sync_agent_buffer]}
-  end
+  # Single-delta entry points. The live streaming path coalesces deltas through
+  # `MingaEditor.Agent.Ingest` and applies them via `handle_batch/2`; these
+  # clauses remain for the durable remote event-replay path
+  # (`MingaEditor.Remote.EventReplay`), which feeds individual records and is a
+  # bounded one-shot, not a hot streaming loop. They delegate to the batch path
+  # so the state transitions stay in one place.
+  def handle(state, {:text_delta, _delta} = delta), do: handle_batch(state, [delta])
 
-  def handle(state, {:thinking_delta, _delta}) do
-    state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
-    state = AgentAccess.update_panel(state, &Panel.bump_message_version/1)
-    {state, [{:render, 50}, :sync_agent_buffer]}
-  end
+  def handle(state, {:thinking_delta, _delta} = delta), do: handle_batch(state, [delta])
 
   def handle(state, :messages_changed) do
     state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
@@ -336,7 +331,56 @@ defmodule MingaEditor.Agent.Events do
     {state, []}
   end
 
+  @doc """
+  Applies one coalesced batch of stream deltas (#2289).
+
+  `MingaEditor.Agent.Ingest` accumulates `{:text_delta, _}`, `{:thinking_delta, _}`
+  and `{:tool_update, _, _, _}` events arriving within a coalescing window and
+  forwards them here as a single batch. Applying the batch once means one
+  `bump_message_version`, one `:sync_agent_buffer`, and one render request per
+  window instead of per delta, which keeps the Editor mailbox shallow under
+  streaming load. The per-delta state transitions (auto-scroll, shell preview
+  updates) are folded in arrival order so the visible result matches the
+  unbatched path.
+  """
+  @spec handle_batch(EditorState.t(), [term()]) :: {EditorState.t(), [effect()]}
+  def handle_batch(state, []), do: {state, []}
+
+  def handle_batch(state, batch) do
+    state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
+    state = Enum.reduce(batch, state, &apply_batched_delta/2)
+
+    if buffer_affecting_batch?(batch) do
+      state = AgentAccess.update_panel(state, &Panel.bump_message_version/1)
+      {state, [{:render, 16}, :sync_agent_buffer]}
+    else
+      {state, [{:render, 16}]}
+    end
+  end
+
   # ── Private ────────────────────────────────────────────────────────────────
+
+  # Folds a single delta's preview-side mutation into state. Text and thinking
+  # deltas carry no per-delta state beyond the once-applied bump/sync; only
+  # shell tool updates mutate the preview, and they replace (not append) the
+  # partial output, so applying them in order matches the unbatched path.
+  @spec apply_batched_delta(term(), EditorState.t()) :: EditorState.t()
+  defp apply_batched_delta({:tool_update, _id, "shell", partial}, state) do
+    update_preview(state, &Preview.update_shell_output(&1, partial))
+  end
+
+  defp apply_batched_delta(_delta, state), do: state
+
+  # The agent transcript buffer only needs re-syncing when the batch carries
+  # assistant text or thinking; tool updates render into the preview only.
+  @spec buffer_affecting_batch?([term()]) :: boolean()
+  defp buffer_affecting_batch?(batch) do
+    Enum.any?(batch, fn
+      {:text_delta, _} -> true
+      {:thinking_delta, _} -> true
+      _ -> false
+    end)
+  end
 
   @spec sync_active_tool_name(EditorState.t(), String.t() | nil) :: EditorState.t()
   defp sync_active_tool_name(state, fallback_name) do

--- a/lib/minga_editor/agent/ingest.ex
+++ b/lib/minga_editor/agent/ingest.ex
@@ -1,0 +1,293 @@
+defmodule MingaEditor.Agent.Ingest do
+  @moduledoc """
+  Coalesces high-frequency agent stream deltas before they reach the Editor.
+
+  Agent token deltas (`:text_delta`, `:thinking_delta`, `:tool_update`) arrive
+  from `MingaAgent.Session` at potentially hundreds of messages per second.
+  Delivered straight into the Editor mailbox, each one runs a real buffer write
+  and sits FIFO ahead of any key press queued behind it: head-of-line blocking
+  that jitters keystroke latency under streaming load (epic #2220 AC 3, #2289).
+
+  Ingest sits between the session and the Editor. It subscribes to the session
+  on the Editor's behalf via `MingaAgent.Session.subscribe/2`, so deltas land in
+  *its* mailbox, not the Editor's. It then forwards one
+  `{:agent_stream_batch, session_pid, batch}` per coalescing window instead of
+  one message per delta. Keystrokes never pass through Ingest; they gain only a
+  shorter mailbox ahead of them.
+
+  ## Debounce strategy (leading + trailing edge)
+
+    * **Leading edge (#2289 AC 5):** the first delta after an idle period is
+      forwarded *immediately* as a one-element batch, so time-to-first-token is
+      unchanged. Forwarding then starts a `Process.send_after/3` tick.
+    * **Trailing edge (#2289 AC 2):** deltas that arrive while the tick is
+      pending accumulate in state. When the tick fires, the whole accumulation
+      forwards as a single batch and the session returns to idle. N steady-state
+      deltas within one window therefore produce exactly one Editor message and
+      one buffer sync.
+
+  ## Control-event ordering (#2289 AC 3)
+
+  Control events (status change, tool start/end, error, turn end, approvals,
+  anything that is not a stream delta) flush the pending batch *ahead of
+  themselves, in order*, then forward the control event unchanged as a normal
+  `{:agent_event, session_pid, event}`. The Editor therefore never observes a
+  turn ending before that turn's trailing text.
+
+  This is a Layer 2 process. `MingaAgent.Session` is unchanged.
+
+  ## Link policy
+
+  Ingest is `start_link`'d from `MingaEditor.init/1` and is intentionally linked
+  to the Editor without `trap_exit` or its own supervision. It is an
+  editor-integral process: it exists only to feed the Editor, holds no state the
+  Editor cannot rebuild on the next subscribe, and its callbacks are total over
+  arbitrary input (`route/3` classifies any non-delta term as a control event,
+  `handle_info/2` ignores unknown messages, and timer/flush handling tolerates
+  stale ticks). A crash here therefore means the Editor's own assumptions are
+  already broken, so propagating the crash to restart both together is the
+  correct outcome rather than silently losing the coalescer. This differs from
+  `Renderer.Server`, which is a supervised sibling the Editor resolves by pid;
+  Ingest is cheap to recreate and owned directly by the Editor on each boot.
+  """
+
+  use GenServer
+
+  alias MingaAgent.Session
+
+  @typedoc "Stream delta events that Ingest coalesces."
+  @type delta ::
+          {:text_delta, term()}
+          | {:thinking_delta, term()}
+          | {:tool_update, term(), term(), term()}
+
+  @typedoc "A coalesced run of deltas for one session, in arrival order."
+  @type batch :: [delta()]
+
+  @typedoc "Per-session accumulation: pending deltas (reversed) and the tick ref."
+  @type session_state :: %{pending: [delta()], timer: reference() | nil}
+
+  @type state :: %{
+          editor: pid(),
+          window_ms: non_neg_integer(),
+          sessions: %{optional(pid()) => session_state()}
+        }
+
+  # One 60Hz frame. Adds at most one window to steady-state stream visibility,
+  # below perception and partly absorbed by the Editor's render coalescing.
+  @default_window_ms 16
+
+  @telemetry_flush [:minga, :agent, :ingest_flush]
+
+  # ── Client API ──────────────────────────────────────────────────────────────
+
+  @doc """
+  Starts the ingest process.
+
+  `:editor` is the pid that batches and control events are forwarded to and
+  defaults to the calling process. `:window_ms` overrides the coalescing tick
+  (tests pass `0` so the tick fires on the next message turn deterministically).
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
+  end
+
+  @doc """
+  Subscribes Ingest to `session_pid` so the session's events flow through here.
+
+  Runs the `MingaAgent.Session.subscribe/2` call inside the Ingest process so
+  Ingest (not the caller) becomes the session subscriber. Returns the result of
+  the subscribe call.
+  """
+  @spec subscribe_session(GenServer.server(), pid(), keyword()) ::
+          :ok | {:error, term()}
+  def subscribe_session(server, session_pid, opts \\ []) when is_pid(session_pid) do
+    GenServer.call(server, {:subscribe_session, session_pid, opts})
+  end
+
+  # ── Server callbacks ─────────────────────────────────────────────────────────
+
+  @impl true
+  @spec init(keyword()) :: {:ok, state()}
+  def init(opts) do
+    editor = Keyword.get(opts, :editor, self())
+    window_ms = Keyword.get(opts, :window_ms, @default_window_ms)
+    {:ok, %{editor: editor, window_ms: window_ms, sessions: %{}}}
+  end
+
+  @impl true
+  @spec handle_call({:subscribe_session, pid(), keyword()}, GenServer.from(), state()) ::
+          {:reply, :ok | {:error, term()}, state()}
+  def handle_call({:subscribe_session, session_pid, opts}, _from, state) do
+    {:reply, do_subscribe(session_pid, opts), state}
+  end
+
+  @impl true
+  @spec handle_info({:agent_event, pid(), term()}, state()) :: {:noreply, state()}
+  def handle_info({:agent_event, session_pid, event}, state) do
+    {:noreply, route(state, session_pid, event)}
+  end
+
+  def handle_info({:ingest_tick, session_pid}, state) do
+    {:noreply, flush(state, session_pid, :tick)}
+  end
+
+  # Ingest monitors each session it subscribes to (see do_subscribe/2). When a
+  # session dies we drop its per-session accumulation so a crashed session never
+  # leaves a stale entry (and a stale armed timer) behind. The Editor learns of
+  # the death via its own SessionManager subscription, so no forwarding is
+  # needed here.
+  def handle_info({:DOWN, _ref, :process, session_pid, _reason}, state) do
+    {:noreply, drop_session(state, session_pid)}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # ── Routing ──────────────────────────────────────────────────────────────────
+
+  @spec route(state(), pid(), term()) :: state()
+  defp route(state, session_pid, event) do
+    route(state, session_pid, event, delta?(event))
+  end
+
+  @spec route(state(), pid(), term(), boolean()) :: state()
+  defp route(state, session_pid, event, true), do: accumulate(state, session_pid, event)
+
+  defp route(state, session_pid, event, false) do
+    # Control event: flush any pending deltas ahead of it (in order), then
+    # forward the control event unchanged. AC 3.
+    state = flush(state, session_pid, :control)
+    forward_control(state, session_pid, event)
+    state
+  end
+
+  @spec delta?(term()) :: boolean()
+  defp delta?({:text_delta, _}), do: true
+  defp delta?({:thinking_delta, _}), do: true
+  defp delta?({:tool_update, _, _, _}), do: true
+  defp delta?(_), do: false
+
+  # ── Accumulation + leading edge ──────────────────────────────────────────────
+
+  @spec accumulate(state(), pid(), delta()) :: state()
+  defp accumulate(state, session_pid, delta) do
+    accumulate(state, session_pid, delta, session(state, session_pid))
+  end
+
+  @spec accumulate(state(), pid(), delta(), session_state()) :: state()
+  # Leading edge: idle (no tick pending) means forward this delta immediately as
+  # a one-element batch, then arm the window for the steady-state stream. AC 5.
+  defp accumulate(state, session_pid, delta, %{timer: nil}) do
+    forward_batch(state, session_pid, [delta], :leading)
+    put_session(state, session_pid, %{pending: [], timer: arm(state, session_pid)})
+  end
+
+  # Steady state: a tick is already pending, so accumulate (reversed) and let the
+  # tick flush the batch.
+  defp accumulate(state, session_pid, delta, %{pending: pending} = sess) do
+    put_session(state, session_pid, %{sess | pending: [delta | pending]})
+  end
+
+  # ── Flush ────────────────────────────────────────────────────────────────────
+
+  @spec flush(state(), pid(), :tick | :control) :: state()
+  defp flush(state, session_pid, reason) do
+    flush(state, session_pid, reason, session(state, session_pid))
+  end
+
+  @spec flush(state(), pid(), :tick | :control, session_state()) :: state()
+  defp flush(state, _session_pid, _reason, %{timer: nil, pending: []}), do: state
+
+  defp flush(state, session_pid, reason, %{pending: pending, timer: timer}) do
+    cancel(timer)
+
+    case pending do
+      [] -> :ok
+      _ -> forward_batch(state, session_pid, Enum.reverse(pending), reason)
+    end
+
+    # After a flush the session is idle again: the next delta re-arms the leading
+    # edge. A flush triggered by the tick clears the timer; a flush triggered by
+    # a control event also returns to idle so trailing text after the control
+    # event coalesces fresh.
+    put_session(state, session_pid, %{pending: [], timer: nil})
+  end
+
+  # ── Forwarding ───────────────────────────────────────────────────────────────
+
+  @spec forward_batch(state(), pid(), batch(), :leading | :tick | :control) :: :ok
+  defp forward_batch(%{editor: editor}, session_pid, batch, edge) do
+    # A flush is a point event, not a spanned operation, so execute/3 rather
+    # than span/3 is the right telemetry shape here.
+    Minga.Telemetry.execute(@telemetry_flush, %{delta_count: length(batch)}, %{edge: edge})
+    send(editor, {:agent_stream_batch, session_pid, batch})
+    :ok
+  end
+
+  @spec forward_control(state(), pid(), term()) :: :ok
+  defp forward_control(%{editor: editor}, session_pid, event) do
+    send(editor, {:agent_event, session_pid, event})
+    :ok
+  end
+
+  # ── Session bookkeeping ──────────────────────────────────────────────────────
+
+  @spec do_subscribe(pid(), keyword()) :: :ok | {:error, term()}
+  defp do_subscribe(session_pid, opts) do
+    case Session.subscribe(session_pid, self(), opts) do
+      :ok ->
+        # Monitor the session so its abrupt death (no control event) still drops
+        # the per-session accumulation via the {:DOWN, ...} clause above. Only
+        # monitor on a successful subscribe so a rejected subscribe leaves no
+        # dangling monitor. Callers always pass a freshly started session pid
+        # (start, background start, restart), so this cannot double-register;
+        # even a duplicate :DOWN would be harmless since drop_session is
+        # idempotent.
+        Process.monitor(session_pid)
+        :ok
+
+      {:error, _reason} = error ->
+        error
+    end
+  catch
+    :exit, reason -> {:error, {:exit, reason}}
+  end
+
+  @spec session(state(), pid()) :: session_state()
+  defp session(state, session_pid) do
+    Map.get(state.sessions, session_pid, %{pending: [], timer: nil})
+  end
+
+  @spec put_session(state(), pid(), session_state()) :: state()
+  defp put_session(state, session_pid, %{pending: [], timer: nil}) do
+    %{state | sessions: Map.delete(state.sessions, session_pid)}
+  end
+
+  defp put_session(state, session_pid, sess) do
+    %{state | sessions: Map.put(state.sessions, session_pid, sess)}
+  end
+
+  @spec drop_session(state(), pid()) :: state()
+  defp drop_session(state, session_pid) do
+    case Map.get(state.sessions, session_pid) do
+      %{timer: timer} -> cancel(timer)
+      _ -> :ok
+    end
+
+    %{state | sessions: Map.delete(state.sessions, session_pid)}
+  end
+
+  @spec arm(state(), pid()) :: reference()
+  defp arm(%{window_ms: window_ms}, session_pid) do
+    Process.send_after(self(), {:ingest_tick, session_pid}, window_ms)
+  end
+
+  @spec cancel(reference() | nil) :: :ok
+  defp cancel(nil), do: :ok
+
+  defp cancel(timer) do
+    Process.cancel_timer(timer)
+    :ok
+  end
+end

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -109,7 +109,7 @@ defmodule MingaEditor.Commands.AgentSession do
       ]
     ]
 
-    case start_and_subscribe(session_opts) do
+    case start_and_subscribe(state, session_opts) do
       {:ok, pid} ->
         state =
           if AgentAccess.agent(state).buffer == nil do
@@ -216,9 +216,17 @@ defmodule MingaEditor.Commands.AgentSession do
   @doc "Responds to a stable tool approval id on a local or remote session."
   @spec respond_to_approval_pid(pid(), String.t() | nil, Session.approval_decision()) ::
           :ok | {:error, term()}
-  def respond_to_approval_pid(session, approval_id, decision)
+  def respond_to_approval_pid(session, _approval_id, decision)
       when is_pid(session) and node(session) == node() do
-    Session.respond_to_approval_as(session, self(), approval_id, decision)
+    # Local session: the Editor is not the session's driver. With the #2289
+    # ingest coalescer, the foreground session is subscribed by the Ingest
+    # process (which becomes the driver), and even without it the Editor's own
+    # subscription does not make it the *caller* of this function. The gated
+    # `respond_to_approval_as` would return {:error, :not_driver} here, so we use
+    # the ungated single-process variant, mirroring how `send_prompt_pid` uses
+    # ungated `Session.send_prompt` for the local-node case. Remote sessions keep
+    # the driver-attach semantics below.
+    Session.respond_to_approval(session, decision)
   end
 
   def respond_to_approval_pid(session, approval_id, decision) when is_pid(session) do
@@ -340,12 +348,12 @@ defmodule MingaEditor.Commands.AgentSession do
   defp sessionless_agent?(%Tab{kind: :agent, session: nil}), do: true
   defp sessionless_agent?(%Tab{}), do: false
 
-  @spec start_and_subscribe(keyword()) :: {:ok, pid()} | {:error, term()}
-  defp start_and_subscribe(opts) do
+  @spec start_and_subscribe(state(), keyword()) :: {:ok, pid()} | {:error, term()}
+  defp start_and_subscribe(state, opts) do
     case MingaAgent.SessionManager.start_session(opts) do
       {:ok, _session_id, pid} ->
         try do
-          Session.subscribe(pid)
+          subscribe_active_session(state, pid)
           {:ok, pid}
         catch
           :exit, reason ->
@@ -355,6 +363,17 @@ defmodule MingaEditor.Commands.AgentSession do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  # Routes the foreground session's events through the agent stream coalescer
+  # (#2289) so token deltas are batched before reaching the Editor mailbox.
+  # Falls back to a direct Editor subscription when the coalescer is absent.
+  @spec subscribe_active_session(state(), pid()) :: :ok | {:error, term()}
+  defp subscribe_active_session(state, pid) do
+    case EditorState.agent_ingest(state) do
+      ingest when is_pid(ingest) -> MingaEditor.Agent.Ingest.subscribe_session(ingest, pid)
+      _ -> Session.subscribe(pid)
     end
   end
 

--- a/lib/minga_editor/commands/agent_sub_states.ex
+++ b/lib/minga_editor/commands/agent_sub_states.ex
@@ -261,11 +261,34 @@ defmodule MingaEditor.Commands.AgentSubStates do
     approval = agent.pending_approval
 
     if is_pid(session) and is_map(approval) do
-      AgentSession.respond_to_approval_pid(session, approval.tool_call_id, decision)
-      update_agent(state, &AgentState.clear_pending_approval/1)
+      apply_approval_response(
+        state,
+        AgentSession.respond_to_approval_pid(session, approval.tool_call_id, decision)
+      )
     else
       state
     end
+  end
+
+  # Only clear the approval UI once the session has *accepted* the decision,
+  # so an undelivered response never silently drops the prompt while the agent
+  # stays blocked. `:no_pending_approval` is the one error that means the
+  # session already resolved this approval, so the prompt is stale: clear it
+  # rather than leave a dead prompt that every retry would re-fail.
+  @spec apply_approval_response(state(), :ok | {:error, term()}) :: state()
+  defp apply_approval_response(state, :ok) do
+    update_agent(state, &AgentState.clear_pending_approval/1)
+  end
+
+  defp apply_approval_response(state, {:error, :no_pending_approval}) do
+    state
+    |> update_agent(&AgentState.clear_pending_approval/1)
+    |> EditorState.set_status("Tool approval already resolved")
+  end
+
+  defp apply_approval_response(state, {:error, reason}) do
+    Minga.Log.error(:agent, "[Agent] tool approval response failed: #{inspect(reason)}")
+    EditorState.set_status(state, "Tool approval failed: #{inspect(reason)}")
   end
 
   # ── Private helpers ────────────────────────────────────────────────────────

--- a/lib/minga_editor/handlers/event_dispatcher.ex
+++ b/lib/minga_editor/handlers/event_dispatcher.ex
@@ -208,7 +208,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
         %Subagent.Handle{} = handle,
         _msg
       ) do
-    case subscribe_to_session(handle.pid) do
+    case subscribe_to_session(state, handle.pid) do
       :ok ->
         state = EditorState.ensure_shell_available(state)
 
@@ -301,7 +301,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
 
     with {:ok, ^new_pid} <- safe_session_lookup(event.session_id),
          true <- Commands.BufferManagement.agent_session_restart_owned?(state, event.old_pid),
-         :ok <- subscribe_to_restarted_session(event) do
+         :ok <- subscribe_to_restarted_session(state, event) do
       {:ok,
        Commands.BufferManagement.handle_agent_session_restarted(
          state,
@@ -335,9 +335,10 @@ defmodule MingaEditor.Handlers.EventDispatcher do
     :exit, reason -> {:error, {:exit, reason}}
   end
 
-  @spec subscribe_to_restarted_session(SessionManager.SessionRestartedEvent.t()) :: :ok | :stale
-  defp subscribe_to_restarted_session(%SessionManager.SessionRestartedEvent{} = event) do
-    case subscribe_to_session(event.new_pid) do
+  @spec subscribe_to_restarted_session(EditorState.t(), SessionManager.SessionRestartedEvent.t()) ::
+          :ok | :stale
+  defp subscribe_to_restarted_session(state, %SessionManager.SessionRestartedEvent{} = event) do
+    case subscribe_to_session(state, event.new_pid) do
       :ok ->
         :ok
 
@@ -347,11 +348,24 @@ defmodule MingaEditor.Handlers.EventDispatcher do
     end
   end
 
-  @spec subscribe_to_session(pid()) :: :ok | {:error, term()}
-  defp subscribe_to_session(pid) do
-    AgentSession.subscribe(pid, self())
+  # Subscribes to a local session through the agent stream coalescer (#2289) so
+  # token deltas are batched before reaching the Editor mailbox. Falls back to a
+  # direct Editor subscription if the coalescer is not running (e.g. headless
+  # boot races); correctness is unaffected, only mailbox pressure.
+  @spec subscribe_to_session(EditorState.t(), pid()) :: :ok | {:error, term()}
+  defp subscribe_to_session(state, pid) do
+    subscribe_through_ingest(EditorState.agent_ingest(state), pid)
   catch
     :exit, reason -> {:error, reason}
+  end
+
+  @spec subscribe_through_ingest(pid() | nil, pid()) :: :ok | {:error, term()}
+  defp subscribe_through_ingest(ingest, pid) when is_pid(ingest) do
+    MingaEditor.Agent.Ingest.subscribe_session(ingest, pid)
+  end
+
+  defp subscribe_through_ingest(_ingest, pid) do
+    AgentSession.subscribe(pid, self())
   end
 
   @spec log_stale_agent_session_restart(SessionManager.SessionRestartedEvent.t(), term()) :: :ok

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -98,6 +98,7 @@ defmodule MingaEditor.State do
   defstruct backend: :headless,
             port_manager: nil,
             renderer: nil,
+            agent_ingest: nil,
             keymap_server: @default_keymap_server,
             options_server: @default_options_server,
             events_registry: @default_events_registry,
@@ -155,6 +156,7 @@ defmodule MingaEditor.State do
           backend: backend(),
           port_manager: GenServer.server() | nil,
           renderer: pid() | nil,
+          agent_ingest: pid() | nil,
           keymap_server: keymap_server(),
           options_server: options_server(),
           events_registry: events_registry(),
@@ -203,6 +205,15 @@ defmodule MingaEditor.State do
   @spec set_renderer(t(), pid() | nil) :: t()
   def set_renderer(%__MODULE__{} = state, pid) when is_pid(pid) or is_nil(pid),
     do: %{state | renderer: pid}
+
+  @doc "Stores the agent stream-ingest coalescer pid (see `MingaEditor.Agent.Ingest`)."
+  @spec set_agent_ingest(t(), pid() | nil) :: t()
+  def set_agent_ingest(%__MODULE__{} = state, pid) when is_pid(pid) or is_nil(pid),
+    do: %{state | agent_ingest: pid}
+
+  @doc "Returns the agent stream-ingest coalescer pid, or nil if not started."
+  @spec agent_ingest(t()) :: pid() | nil
+  def agent_ingest(%__MODULE__{agent_ingest: pid}), do: pid
 
   @doc "Updates the current frontend-reported resource pressure."
   @spec set_resource_pressure(

--- a/test/minga_editor/agent/ingest_approval_regression_test.exs
+++ b/test/minga_editor/agent/ingest_approval_regression_test.exs
@@ -1,0 +1,178 @@
+defmodule MingaEditor.Agent.IngestApprovalRegressionTest do
+  @moduledoc """
+  Regression for the #2289 local tool-approval path.
+
+  When the foreground session is subscribed by the `MingaEditor.Agent.Ingest`
+  coalescer, the Ingest process becomes the session's *driver* (first subscriber
+  with the default :driver role). Local approvals are issued by the Editor, which
+  is therefore *not* the driver. Routing them through the driver-gated
+  `Session.respond_to_approval_as/4` returned `{:error, :not_driver}`: the user
+  pressed `y`, the prompt cleared, and the agent hung forever because the blocked
+  tool task never received its decision.
+
+  These tests pin the two halves of the fix:
+
+    * The editor's local approval path (`AgentSession.respond_to_approval_pid/3`)
+      uses the ungated `Session.respond_to_approval/2`, so the decision reaches
+      the blocked tool task even when Ingest holds the driver role.
+    * `Commands.AgentSubStates` only clears the approval UI when the session
+      accepts the decision; on an error it keeps the approval and surfaces the
+      failure instead of silently dropping it.
+
+  Uses a real `MingaAgent.Session` + real `Ingest` so the driver assignment and
+  the blocked-task reply are the genuine production paths, not stubs.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Event
+  alias MingaAgent.Session
+  alias MingaEditor.Agent.Ingest
+  alias MingaEditor.Commands.AgentSession
+  alias MingaEditor.Commands.AgentSubStates
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
+  alias MingaEditor.Viewport
+  alias MingaAgent.RuntimeState
+
+  @event_timeout 5_000
+
+  # Minimal provider: the session needs a provider pid to boot, but these tests
+  # drive approval events in directly rather than through a real turn.
+  defmodule QuietProvider do
+    @moduledoc false
+    @behaviour MingaAgent.Provider
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+    @impl MingaAgent.Provider
+    def send_prompt(_pid, _text), do: :ok
+    @impl MingaAgent.Provider
+    def abort(_pid), do: :ok
+    @impl MingaAgent.Provider
+    def new_session(_pid), do: :ok
+    @impl MingaAgent.Provider
+    def seed_messages(_pid, _messages), do: :ok
+    @impl MingaAgent.Provider
+    def get_state(_pid), do: {:ok, %{model: nil, is_streaming: false, token_usage: nil}}
+
+    @impl GenServer
+    def init(_opts), do: {:ok, %{}}
+  end
+
+  # Subscribe the session through a real Ingest process so Ingest, not the test
+  # process, holds the driver role. This is the exact topology that broke local
+  # approvals: the approver (here the test process, standing in for the Editor)
+  # is not the driver.
+  defp session_with_ingest_driver do
+    {:ok, session} = Session.start_link(provider: QuietProvider)
+    ingest = start_supervised!({Ingest, editor: self()})
+    assert :ok = Ingest.subscribe_session(ingest, session)
+    # Confirm the topology the bug depends on: Ingest is the driver, the test
+    # process (the would-be Editor) is not.
+    assert Session.subscriber_role(session, ingest) == :driver
+    refute Session.subscriber_role(session, self()) == :driver
+    %{session: session, ingest: ingest}
+  end
+
+  # Inject a pending tool approval whose blocked task is `reply_to`. The session
+  # broadcasts {:approval_pending, ...} to subscribers (Ingest forwards it on),
+  # and the decision later flows back to `reply_to`.
+  defp inject_pending_approval(session, reply_to) do
+    send(
+      session,
+      {:agent_provider_event,
+       %Event.ToolApproval{
+         tool_call_id: "tc1",
+         name: "shell",
+         args: %{"command" => "echo hi"},
+         reply_to: reply_to
+       }}
+    )
+
+    # Force a synchronous round-trip so the approval is registered before we act.
+    Session.status(session)
+    :ok
+  end
+
+  describe "local approval reaches the blocked tool task (CRITICAL regression)" do
+    test "respond_to_approval_pid/3 delivers the decision even though Ingest is the driver" do
+      %{session: session} = session_with_ingest_driver()
+      inject_pending_approval(session, self())
+
+      # The Editor (this process) is not the driver. The pre-fix gated path would
+      # return {:error, :not_driver} and never reply to the blocked task.
+      assert :ok = AgentSession.respond_to_approval_pid(session, "tc1", :approve)
+
+      # The blocked tool task receives its decision: the tool proceeds.
+      assert_receive {:tool_approval_response, "tc1", :approve}, @event_timeout
+    end
+
+    test "the editor command path approves and clears the pending approval" do
+      %{session: session} = session_with_ingest_driver()
+      inject_pending_approval(session, self())
+
+      approval = %{tool_call_id: "tc1", name: "shell", args: %{"command" => "echo hi"}}
+      state = editor_state_with(session, approval)
+
+      new_state = AgentSubStates.approve_tool(state)
+
+      # The session advanced (blocked task unblocked) and the UI cleared because
+      # the session accepted the decision.
+      assert_receive {:tool_approval_response, "tc1", :approve}, @event_timeout
+      assert AgentAccess.agent(new_state).pending_approval == nil
+    end
+  end
+
+  describe "silent-failure guard (CRITICAL regression, second half)" do
+    test "an already-resolved approval clears the stale prompt and tells the user" do
+      %{session: session} = session_with_ingest_driver()
+      # No pending approval is injected, so the session replies
+      # {:error, :no_pending_approval}: the approval already resolved and the
+      # prompt is stale. The UI clears (retrying would re-fail forever) and the
+      # user is told why, rather than the decision being silently swallowed.
+      approval = %{tool_call_id: "tc1", name: "shell", args: %{"command" => "echo hi"}}
+      state = editor_state_with(session, approval)
+
+      new_state = AgentSubStates.approve_tool(state)
+
+      assert AgentAccess.agent(new_state).pending_approval == nil
+      assert EditorState.status_msg(new_state) =~ "already resolved"
+      refute_receive {:tool_approval_response, _, _}, 200
+    end
+  end
+
+  # Builds a minimal traditional-shell Editor state whose active agent session is
+  # `session` and whose agent has the given pending approval.
+  defp editor_state_with(session, approval) do
+    agent_tab = Tab.new_agent(1, "Agent") |> Tab.set_session(session)
+    tb = TabBar.new(agent_tab)
+    {tb, ws} = TabBar.add_workspace(tb, "Agent", session)
+    tb = TabBar.move_tab_to_workspace(tb, 1, ws.id) |> Map.put(:active_id, 1)
+
+    tb =
+      TabBar.update_workspace(tb, ws.id, &Workspace.set_session(&1, session))
+
+    agent = %AgentState{
+      runtime: %RuntimeState{status: :idle},
+      pending_approval: approval
+    }
+
+    %EditorState{
+      port_manager: self(),
+      shell: MingaEditor.Shell.Traditional,
+      workspace: %MingaEditor.Session.State{
+        viewport: Viewport.new(24, 80)
+      },
+      shell_state: %MingaEditor.Shell.Traditional.State{
+        tab_bar: tb,
+        agent: agent
+      }
+    }
+  end
+end

--- a/test/minga_editor/agent/ingest_test.exs
+++ b/test/minga_editor/agent/ingest_test.exs
@@ -1,0 +1,248 @@
+defmodule MingaEditor.Agent.IngestTest do
+  @moduledoc """
+  Coalescing contract for the agent stream ingest process (#2289).
+
+  Ingest sits between `MingaAgent.Session` and the Editor. These tests drive
+  `{:agent_event, session_pid, event}` messages straight into the Ingest process
+  (the same shape the session sends) with the test process standing in for the
+  Editor, and assert on the `{:agent_stream_batch, ...}` / `{:agent_event, ...}`
+  messages Ingest forwards. A large coalescing window plus a manually injected
+  `{:ingest_tick, ...}` makes the steady-state flush deterministic without
+  sleeping on the real timer.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Agent.Ingest
+
+  # Minimal stand-in for `MingaAgent.Session`: answers the `{:subscribe, pid,
+  # opts}` GenServer call with `:ok` so `Ingest.subscribe_session/3` (and the
+  # `Process.monitor/1` it performs on success) exercise the real code path
+  # without spinning up a full provider-backed session.
+  defmodule StubSession do
+    @moduledoc false
+    use GenServer
+
+    @spec start_link() :: GenServer.on_start()
+    def start_link, do: GenServer.start_link(__MODULE__, :ok)
+    @impl true
+    def init(:ok), do: {:ok, :ok}
+    @impl true
+    def handle_call({:subscribe, _pid, _opts}, _from, state), do: {:reply, :ok, state}
+  end
+
+  defp stub_session do
+    {:ok, pid} = StubSession.start_link()
+    # Unlink so a deliberate kill in the cleanup test does not take the test
+    # process (and the Ingest link runs through Ingest, not us) down with it.
+    Process.unlink(pid)
+    pid
+  end
+
+  # Stand-in session pid: a live, harmless process so monitors and pid tagging
+  # behave like the real thing.
+  defp fake_session do
+    pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> if Process.alive?(pid), do: send(pid, :stop) end)
+    pid
+  end
+
+  defp start_ingest(window_ms) do
+    # The test process is the Editor: batches and control events arrive here.
+    start_supervised!({Ingest, editor: self(), window_ms: window_ms})
+  end
+
+  defp sync(pid), do: :sys.get_state(pid)
+
+  # Takes the next message Ingest forwarded to us (the Editor), in mailbox order,
+  # so ordering assertions are positional rather than selective.
+  defp next_forwarded do
+    receive do
+      {:agent_stream_batch, _, _} = msg -> msg
+      {:agent_event, _, _} = msg -> msg
+    after
+      500 -> flunk("expected a forwarded message but none arrived")
+    end
+  end
+
+  describe "leading-edge flush (AC 5)" do
+    test "the first delta after idle is forwarded immediately as a one-element batch" do
+      ingest = start_ingest(10_000)
+      session = fake_session()
+
+      send(ingest, {:agent_event, session, {:text_delta, "hi"}})
+
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "hi"}]}
+    end
+
+    test "a control event arriving while idle is forwarded with no spurious batch" do
+      ingest = start_ingest(10_000)
+      session = fake_session()
+
+      send(ingest, {:agent_event, session, {:status_changed, :thinking}})
+
+      assert_receive {:agent_event, ^session, {:status_changed, :thinking}}
+      refute_received {:agent_stream_batch, _, _}
+    end
+  end
+
+  describe "steady-state coalescing (AC 2)" do
+    test "N deltas within one window produce exactly one batch with all deltas in order" do
+      ingest = start_ingest(10_000)
+      session = fake_session()
+
+      # First delta arms the window via the leading-edge flush.
+      send(ingest, {:agent_event, session, {:text_delta, "0"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "0"}]}
+
+      # These three accumulate while the window is open.
+      send(ingest, {:agent_event, session, {:text_delta, "1"}})
+      send(ingest, {:agent_event, session, {:thinking_delta, "2"}})
+      send(ingest, {:agent_event, session, {:text_delta, "3"}})
+      sync(ingest)
+
+      # Fire the window tick. Exactly one batch carrying all three, in order.
+      send(ingest, {:ingest_tick, session})
+
+      assert_receive {:agent_stream_batch, ^session,
+                      [{:text_delta, "1"}, {:thinking_delta, "2"}, {:text_delta, "3"}]}
+
+      refute_received {:agent_stream_batch, _, _}
+    end
+
+    test "an empty window (only the leading delta) does not emit a trailing batch" do
+      ingest = start_ingest(10_000)
+      session = fake_session()
+
+      send(ingest, {:agent_event, session, {:text_delta, "only"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "only"}]}
+
+      send(ingest, {:ingest_tick, session})
+      sync(ingest)
+
+      refute_received {:agent_stream_batch, _, _}
+    end
+  end
+
+  describe "control-event ordering (AC 3)" do
+    test "a control event flushes the pending batch ahead of itself, in order" do
+      ingest = start_ingest(10_000)
+      session = fake_session()
+
+      # Leading delta opens the window.
+      send(ingest, {:agent_event, session, {:text_delta, "lead"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "lead"}]}
+
+      # Trailing text accumulates, then turn-end arrives.
+      send(ingest, {:agent_event, session, {:text_delta, "trailing"}})
+      send(ingest, {:agent_event, session, {:status_changed, :idle}})
+      sync(ingest)
+
+      # Drain the mailbox in arrival order: the trailing-text batch must come
+      # out STRICTLY BEFORE the turn-end control event, so the Editor never sees
+      # a turn ending before that turn's text. Selective receive would hide a
+      # reorder, so we take the next two messages positionally.
+      assert next_forwarded() ==
+               {:agent_stream_batch, session, [{:text_delta, "trailing"}]}
+
+      assert next_forwarded() == {:agent_event, session, {:status_changed, :idle}}
+    end
+
+    test "after a control flush the next delta re-arms the leading edge immediately" do
+      ingest = start_ingest(10_000)
+      session = fake_session()
+
+      send(ingest, {:agent_event, session, {:text_delta, "a"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "a"}]}
+
+      send(ingest, {:agent_event, session, {:text_delta, "b"}})
+      send(ingest, {:agent_event, session, {:tool_started, "shell", %{}}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "b"}]}
+      assert_receive {:agent_event, ^session, {:tool_started, "shell", %{}}}
+
+      # Idle again: the next delta is a fresh leading edge, forwarded at once.
+      send(ingest, {:agent_event, session, {:text_delta, "c"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "c"}]}
+    end
+  end
+
+  describe "tick ordering relative to control flush" do
+    test "a stale tick after a control flush does not emit an empty batch" do
+      ingest = start_ingest(10_000)
+      session = fake_session()
+
+      send(ingest, {:agent_event, session, {:text_delta, "x"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "x"}]}
+
+      send(ingest, {:agent_event, session, {:text_delta, "y"}})
+      # Control event flushes "y" and cancels the armed tick.
+      send(ingest, {:agent_event, session, {:status_changed, :idle}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "y"}]}
+      assert_receive {:agent_event, ^session, {:status_changed, :idle}}
+
+      # A late tick (if the timer message had already been delivered) is a no-op.
+      send(ingest, {:ingest_tick, session})
+      sync(ingest)
+      refute_received {:agent_stream_batch, _, _}
+    end
+  end
+
+  describe "multiple sessions" do
+    test "deltas from different sessions coalesce independently" do
+      ingest = start_ingest(10_000)
+      session_a = fake_session()
+      session_b = fake_session()
+
+      send(ingest, {:agent_event, session_a, {:text_delta, "a0"}})
+      send(ingest, {:agent_event, session_b, {:text_delta, "b0"}})
+      assert_receive {:agent_stream_batch, ^session_a, [{:text_delta, "a0"}]}
+      assert_receive {:agent_stream_batch, ^session_b, [{:text_delta, "b0"}]}
+
+      send(ingest, {:agent_event, session_a, {:text_delta, "a1"}})
+      send(ingest, {:agent_event, session_b, {:text_delta, "b1"}})
+      sync(ingest)
+
+      send(ingest, {:ingest_tick, session_a})
+      assert_receive {:agent_stream_batch, ^session_a, [{:text_delta, "a1"}]}
+      # session_b's window is still open: no batch for it yet.
+      refute_received {:agent_stream_batch, ^session_b, _}
+
+      send(ingest, {:ingest_tick, session_b})
+      assert_receive {:agent_stream_batch, ^session_b, [{:text_delta, "b1"}]}
+    end
+  end
+
+  describe "session death cleanup" do
+    test "an abruptly killed session (no control event) drops its accumulation entry" do
+      ingest = start_ingest(10_000)
+      session = stub_session()
+
+      # Real subscribe path installs the Process.monitor on the session.
+      assert :ok = Ingest.subscribe_session(ingest, session)
+
+      # Open a window and accumulate so there is a live per-session entry (with an
+      # armed timer) to clean up.
+      send(ingest, {:agent_event, session, {:text_delta, "lead"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "lead"}]}
+      send(ingest, {:agent_event, session, {:text_delta, "trailing"}})
+      sync(ingest)
+      assert Map.has_key?(:sys.get_state(ingest).sessions, session)
+
+      # Kill the session abruptly: no control event flows through Ingest, so the
+      # only path that can drop the entry is the {:DOWN, ...} monitor message.
+      ref = Process.monitor(session)
+      Process.exit(session, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^session, _reason}
+
+      # Sync once so Ingest processes its own :DOWN before we inspect state.
+      sync(ingest)
+      refute Map.has_key?(:sys.get_state(ingest).sessions, session)
+    end
+  end
+end

--- a/test/minga_editor/agent/ingest_wiring_test.exs
+++ b/test/minga_editor/agent/ingest_wiring_test.exs
@@ -1,0 +1,63 @@
+defmodule MingaEditor.Agent.IngestWiringTest do
+  @moduledoc """
+  End-to-end wiring for the agent stream coalescer (#2289).
+
+  Proves the live Editor boots a `MingaEditor.Agent.Ingest` process and that a
+  `{:agent_stream_batch, session, batch}` message addressed to the active agent
+  session is applied once via `Agent.Events.handle_batch/2` (transcript version
+  bumped, no crash). The coalescing contract itself is covered by the cheaper
+  `MingaEditor.Agent.IngestTest`; this is a thin wiring smoke test.
+  """
+
+  use Minga.Test.EditorCase, async: true
+
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+
+  @moduletag :tmp_dir
+
+  defp fake_session do
+    pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> if Process.alive?(pid), do: send(pid, :stop) end)
+    pid
+  end
+
+  test "the editor boots an ingest process", %{tmp_dir: dir} do
+    ctx = start_editor("hello", project_root: dir)
+
+    assert is_pid(EditorState.agent_ingest(editor_state(ctx)))
+    assert Process.alive?(EditorState.agent_ingest(editor_state(ctx)))
+  end
+
+  test "a stream batch for the active session is applied once", %{tmp_dir: dir} do
+    ctx = start_editor("hello", project_root: dir)
+    session = fake_session()
+
+    # Make `session` the active agent so the batch routes to handle_batch/2.
+    :sys.replace_state(ctx.editor, fn state ->
+      agent_tab = Tab.new_agent(99, "Agent") |> Tab.set_session(session)
+      tb = TabBar.new(agent_tab)
+      {tb, ws} = TabBar.add_workspace(tb, "Agent", session)
+      tb = TabBar.move_tab_to_workspace(tb, 99, ws.id) |> Map.put(:active_id, 99)
+
+      EditorState.set_tab_bar(state, tb)
+    end)
+
+    state = editor_state(ctx)
+    assert AgentAccess.session(state) == session
+    version_before = AgentAccess.panel(state).message_version
+
+    send(ctx.editor, {:agent_stream_batch, session, [{:text_delta, "world"}]})
+    state = editor_state(ctx)
+
+    assert AgentAccess.panel(state).message_version == version_before + 1
+  end
+end

--- a/test/minga_editor/state/event_routing_test.exs
+++ b/test/minga_editor/state/event_routing_test.exs
@@ -69,20 +69,26 @@ defmodule MingaEditor.State.EventRoutingTest do
   end
 
   describe "Agent.Events.handle/2 — content deltas" do
-    test "text_delta triggers throttled render" do
+    # Live streaming coalesces deltas through MingaEditor.Agent.Ingest and applies
+    # them via handle_batch/2; the single-delta handle/2 clauses remain for the
+    # bounded remote event-replay path and delegate to the batch path, so they
+    # now request one coalesced render and one buffer sync.
+    test "text_delta requests a render and a buffer sync" do
       %{state: state} = make_state()
 
       {_new_state, effects} = AgentEvents.handle(state, {:text_delta, "hello"})
 
-      assert {:render, 1} in effects
+      assert {:render, 16} in effects
+      assert :sync_agent_buffer in effects
     end
 
-    test "thinking_delta triggers throttled render" do
+    test "thinking_delta requests a render and a buffer sync" do
       %{state: state} = make_state()
 
       {_new_state, effects} = AgentEvents.handle(state, {:thinking_delta, "hmm"})
 
-      assert {:render, 50} in effects
+      assert {:render, 16} in effects
+      assert :sync_agent_buffer in effects
     end
 
     test "messages_changed triggers buffer sync and tab label update" do
@@ -94,6 +100,46 @@ defmodule MingaEditor.State.EventRoutingTest do
       assert {:update_tab_label, ""} in effects
       # message_version is bumped so the GUI fingerprint cache is invalidated
       assert AgentAccess.panel(new_state).message_version == 1
+    end
+  end
+
+  describe "Agent.Events.handle_batch/2 — coalesced stream batch (#2289)" do
+    test "N text/thinking deltas produce exactly one buffer sync and one version bump" do
+      %{state: state} = make_state()
+
+      batch = [
+        {:text_delta, "a"},
+        {:thinking_delta, "b"},
+        {:text_delta, "c"},
+        {:text_delta, "d"}
+      ]
+
+      {new_state, effects} = AgentEvents.handle_batch(state, batch)
+
+      # One buffer sync, one render — not one per delta. AC 2.
+      assert Enum.count(effects, &(&1 == :sync_agent_buffer)) == 1
+      assert Enum.count(effects, &match?({:render, _}, &1)) == 1
+      # A single coalesced batch bumps the version exactly once.
+      assert AgentAccess.panel(new_state).message_version == 1
+    end
+
+    test "a tool-update-only batch renders without syncing the transcript buffer" do
+      %{state: state} = make_state()
+
+      batch = [{:tool_update, "id", "search", "partial"}]
+
+      {new_state, effects} = AgentEvents.handle_batch(state, batch)
+
+      refute :sync_agent_buffer in effects
+      assert {:render, 16} in effects
+      # No assistant text, so the transcript version is untouched.
+      assert AgentAccess.panel(new_state).message_version == 0
+    end
+
+    test "an empty batch is a no-op" do
+      %{state: state} = make_state()
+
+      assert {^state, []} = AgentEvents.handle_batch(state, [])
     end
   end
 


### PR DESCRIPTION
## Summary

Epic #2220 AC 3: keystroke latency stays bounded while an agent streams. The jitter source (per the architecture consult recorded on the ticket) was mailbox queue depth: every agent token delta was its own Editor message running a real buffer write, queued FIFO ahead of any key press behind it. Renders were never the problem (already coalesced to one in flight).

- **`MingaEditor.Agent.Ingest`** (Layer 2) subscribes to agent sessions on the Editor's behalf and coalesces deltas with **leading-edge + trailing-edge debounce**: the first delta after idle forwards immediately (time-to-first-token unchanged, AC 5 unit-tested), then a ~16ms tick batches the steady stream into one `{:agent_stream_batch, ...}` per window. The tick bounds Editor message rate, not paint timing; it's a bench-picked tunable, not a frame budget.
- **Ordering is structural**: control events (status/tool/error/turn-end) flush the pending batch ahead of themselves, and Ingest is the single sender for both message kinds, so FIFO guarantees no reorder. Tested positionally, plus a stale-tick guard.
- **EEP 76 priority messages rejected** by the consult: they can't preempt an in-flight callback (the actual blocking), would require tagging Layer 1 senders, and reintroduce the causal-reorder hazard. `MingaAgent.Session` is unchanged.
- **Driver semantics handled** (bug-hunt catch): Ingest becomes the session's first subscriber (driver), which silently broke local tool approvals — the approve call was rejected as not-driver and the error swallowed while the prompt cleared, leaving the agent hung. Fixed across all four local decision paths via the ungated `respond_to_approval/2` (mirroring the existing prompt precedent), with a real-topology regression test that was mutation-checked (reverting the fix fails it with `{:error, :not_driver}`). Approval responses are no longer fire-and-forget: a stale already-resolved prompt clears with a status message; other errors keep the prompt actionable and log loudly.
- **Lifecycle**: Ingest monitors sessions, so abrupt death (no control event) drops pending state; linked/unsupervised crash propagation documented as intentional.

**Measured**: Editor mailbox depth under synthetic streaming drops from `queue_max=3` deltas ahead of a keystroke to `1-2` batches; sync_agent_buffer calls drop by the coalescing ratio (per-flush `delta_count` telemetry). The bench's agent_stream scenario now drives deltas concurrently with typing (the old interleaved replay understated pressure) and samples `message_queue_len`.

## Tests

- Full suite: 9,451 tests 0 failures; `make lint` green (dialyzer pass)
- New: ingest coalescing/ordering/leading-edge/stale-tick/DOWN-cleanup tests, batch-application routing tests, end-to-end approval regression test (real Session + real Ingest)
- Reviews: prtk-code-reviewer bug-hunt (ordering/isolation/batch semantics verified sound; its critical driver finding fixed as above), acceptance reviewer PASS (verified all four approval entry points, no other `_as`-gated call sites affected, monitor leak-free, bench honesty incl. the widened pre-fix sync barrier)

Closes #2289. Part of #2220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)