### PR TITLE
feat(layout): registry-place hover and signature help popups

### DIFF
--- a/go/tui/internal/ui/render_surfaces.go
+++ b/go/tui/internal/ui/render_surfaces.go
@@ -11,12 +11,15 @@ import (
 )
 
 // Registry surface ids (mirror MingaEditor.Layout.SurfaceRegistry.surface_id_u16/1).
-// Only the overlay surfaces the BEAM registry actually places are listed here;
-// the rest of the overlay candidates are not yet promoted into the registry
-// (transitional split, #2268; follow-up #2281 promotes them).
+// Only the overlay surfaces the BEAM registry actually places are listed here.
+// #2281 promoted the two cursor-anchored popups (hover, signature help) whose
+// rect the BEAM authoritatively computes; the remaining overlay candidates have
+// no BEAM rect source and stay transitional (see overlayCandidates).
 const (
 	surfaceIDBottomPanel    uint16 = 12
 	surfaceIDCompletionMenu uint16 = 16
+	surfaceIDHoverPopup     uint16 = 17
+	surfaceIDSignatureHelp  uint16 = 18
 )
 
 // overlayCandidate is one floating surface that may occupy the single active
@@ -57,14 +60,15 @@ func (m Model) overlayLines() []string {
 }
 
 // overlayCandidates lists every floating overlay surface with its stacking
-// order on ONE comparable scale. Placed surfaces (completion, bottom panel) use
-// their BEAM placement z directly; the not-yet-promoted surfaces use
-// transitional orders derived from the same registry z bands, slotted at their
-// old relative positions, until each is promoted into the BEAM surface registry
-// (#2281). Because everything shares the band scale, the old top-to-bottom
-// precedence is preserved exactly: completion (overlay band, top) > the six
-// floating overlays that historically sat above the bottom panel > bottom panel
-// (floating band, z=200) > the lower transitional set.
+// order on ONE comparable scale. Registry-placed surfaces (completion, bottom
+// panel, and the #2281-promoted hover/signature-help popups) use their BEAM
+// placement z directly; the remaining surfaces have no BEAM rect source yet and
+// keep transitional orders derived from the same registry z bands, slotted at
+// their old relative positions. Because everything shares the band scale, the
+// old top-to-bottom precedence is preserved exactly: completion (overlay band,
+// top) > hover > signature help > the four transitional overlays that
+// historically sat above the bottom panel > bottom panel (floating band, z=200)
+// > the lower transitional set.
 func (m Model) overlayCandidates() []overlayCandidate {
 	completion, completionOK := m.completion()
 	hover, hoverOK := m.hoverPopup()
@@ -90,20 +94,24 @@ func (m Model) overlayCandidates() []overlayCandidate {
 			order:   m.surfaceOrder(surfaceIDCompletionMenu, orderOverlayTop),
 			render:  func() []string { return m.renderCompletion(completion) },
 		},
-		// ── transitional overlays that historically sat ABOVE the bottom panel ──
-		// These live between the floating band (200) and the overlay band (300),
-		// preserving their old relative order: hover > signature > float >
-		// agentContext > agentChat > toolManager.
-		{visible: hoverOK && hover.Visible && len(hover.Lines) > 0, order: orderHover, render: func() []string { return m.renderHover(hover) }},
-		{visible: sigOK && sig.Visible && len(sig.Signatures) > 0, order: orderSignatureHelp, render: func() []string { return m.renderSignature(sig) }},
+		// ── floating popups that historically sat ABOVE the bottom panel ──
+		// hover and signature help are registry-placed (#2281): the BEAM emits a
+		// placement z for each, so they order by that data; the orderHover/
+		// orderSignatureHelp constants survive only as fallbacks for an older BEAM
+		// that emits no placement. The remaining surfaces below keep their
+		// transitional rank (no BEAM rect source yet), preserving the old relative
+		// order: hover > signature > float > agentContext > agentChat > toolManager.
+		{visible: hoverOK && hover.Visible && len(hover.Lines) > 0, order: m.surfaceOrder(surfaceIDHoverPopup, orderHover), render: func() []string { return m.renderHover(hover) }},
+		{visible: sigOK && sig.Visible && len(sig.Signatures) > 0, order: m.surfaceOrder(surfaceIDSignatureHelp, orderSignatureHelp), render: func() []string { return m.renderSignature(sig) }},
 		{visible: floatOK && float.Visible, order: orderFloatPopup, render: func() []string { return m.renderFloat(float) }},
 		{visible: contextOK && context.Visible, order: orderAgentContext, render: func() []string { return m.renderAgentContext(context) }},
 		{visible: chatOK && chat.Visible, order: orderAgentChat, render: func() []string { return m.renderAgentChat(chat) }},
 		{visible: toolsOK && tools.Visible, order: orderToolManager, render: func() []string { return m.renderToolManager(tools) }},
 		// Bottom panel is registry-placed in the floating band (z=200): it sits
-		// BELOW the six overlays above and ABOVE the lower transitional set, exactly
-		// as the old chain ordered it. Fallback orderBottomPanelFallback keeps that
-		// relative position when no placement is emitted.
+		// BELOW the popups and the four transitional overlays above, and ABOVE the
+		// lower transitional set, exactly as the old chain ordered it. Fallback
+		// orderBottomPanelFallback keeps that relative position when no placement is
+		// emitted.
 		{
 			visible: bottomOK && bottom.Visible,
 			order:   m.surfaceOrder(surfaceIDBottomPanel, orderBottomPanelFallback),
@@ -134,29 +142,38 @@ func (m Model) surfaceOrder(surfaceID uint16, fallback int) int {
 	return fallback
 }
 
-// Transitional stacking orders for the not-yet-promoted overlay surfaces (#2281
-// deletes this whole table once they are promoted/placed). They are derived from
-// the registry z bands in MingaEditor.Layout.SurfaceRegistry (base 0 / editor
-// 100 / floating 200 / overlay 300; bottom_panel emits z=200, completion_menu
-// emits z=300+1). Go cannot import the Elixir bands, so this coupling is
-// documented explicitly: keep these values in step with surface_registry.ex.
+// Transitional stacking orders for the overlay surfaces that are not yet
+// registry-placed (#2281 shrank this table by promoting hover/signature help;
+// it is fully deleted only once every surface grows a BEAM rect source). They
+// are derived from the registry z bands in MingaEditor.Layout.SurfaceRegistry
+// (base 0 / editor 100 / floating 200 / floating-overlay 280 / overlay 300;
+// bottom_panel emits z=200, completion_menu z=301, hover z=290, signature
+// help z=280). Go cannot import the Elixir bands, so this coupling is documented
+// explicitly: keep these values in step with surface_registry.ex.
 //
 // Scale, highest paints front-most:
 //   - completion (placed, overlay band, z=301) sits on top.
-//   - the six overlays that historically sat above the bottom panel occupy
-//     210..290, between the floating band (200) and the overlay band (300),
+//   - hover (placed, z=290) and signature help (placed, z=280) follow; their
+//     orderHover/orderSignatureHelp constants are kept only as fallbacks for an
+//     older BEAM that emits no placement.
+//   - the four transitional overlays that historically sat above the bottom
+//     panel occupy 240..270, between the floating band (200) and the popups,
 //     preserving their old relative order.
-//   - bottom_panel (placed, floating band, z=200) sits below those six.
+//   - bottom_panel (placed, floating band, z=200) sits below those.
 //   - the lower transitional set occupies 150..199, below the floating band,
 //     preserving its old relative order.
 const (
-	// Above the bottom panel (200) and below the overlay band (300).
+	// Fallbacks for the registry-placed popups (used only when the BEAM emits no
+	// placement for them): hover above signature help, both above the floating band.
 	orderHover         = 290
 	orderSignatureHelp = 280
-	orderFloatPopup    = 270
-	orderAgentContext  = 260
-	orderAgentChat     = 250
-	orderToolManager   = 240
+
+	// Transitional ranks for the surfaces with no BEAM rect source yet, above the
+	// bottom panel (200) and below the popups.
+	orderFloatPopup   = 270
+	orderAgentContext = 260
+	orderAgentChat    = 250
+	orderToolManager  = 240
 
 	// Below the bottom panel (200).
 	orderExtensionPanel   = 190

--- a/go/tui/internal/ui/surface_layout_order_test.go
+++ b/go/tui/internal/ui/surface_layout_order_test.go
@@ -111,6 +111,67 @@ func TestOverlayBottomPanelOpenHoverWins(t *testing.T) {
 	}
 }
 
+func TestOverlayHoverOrdersByEmittedPlacementZ(t *testing.T) {
+	// Hover is registry-placed (#2281): its stacking order is the emitted
+	// placement z, not the hardcoded fallback. Place the bottom panel ABOVE hover
+	// (higher z than hover's emitted z), and the bottom panel must win the slot,
+	// inverting the historical hover>panel order. This is the AC-2 proof that the
+	// promoted hover popup orders by placement data.
+	model := New(80, 16, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiBottomPanel: {
+			Opcode: generated.OPGuiBottomPanel,
+			Bottom: protocol.BottomPanel{Visible: true, Tabs: []protocol.PanelTab{{Type: 0x01, Name: "Messages"}}, Messages: []protocol.PanelMessage{{ID: 1, Level: 1, Text: "panel-msg"}}},
+		},
+		generated.OPGuiHoverPopup: {
+			Opcode: generated.OPGuiHoverPopup,
+			Hover:  protocol.HoverPopup{Visible: true, Lines: []protocol.RichLine{{Segments: []protocol.RichSegment{{Text: "hover-doc"}}}}},
+		},
+	}
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDHoverPopup, Z: 290, HitKind: 8},
+		{SurfaceID: surfaceIDBottomPanel, Z: 295, HitKind: 7},
+	}
+
+	got := strings.Join(model.overlayLines(), "\n")
+	if !strings.Contains(got, "panel-msg") {
+		t.Fatalf("bottom panel placed above hover should win the slot, got %q", got)
+	}
+	if strings.Contains(got, "hover-doc") {
+		t.Fatalf("hover should lose when placed below the bottom panel, got %q", got)
+	}
+}
+
+func TestOverlaySignatureHelpOrdersByEmittedPlacementZ(t *testing.T) {
+	// Signature help is registry-placed (#2281). With its emitted z below the
+	// bottom panel's, the panel wins the single active overlay slot, proving the
+	// promoted signature-help surface orders by placement data rather than the
+	// orderSignatureHelp fallback constant.
+	model := New(80, 16, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiBottomPanel: {
+			Opcode: generated.OPGuiBottomPanel,
+			Bottom: protocol.BottomPanel{Visible: true, Tabs: []protocol.PanelTab{{Type: 0x01, Name: "Messages"}}, Messages: []protocol.PanelMessage{{ID: 1, Level: 1, Text: "panel-msg"}}},
+		},
+		generated.OPGuiSignatureHelp: {
+			Opcode:    generated.OPGuiSignatureHelp,
+			Signature: protocol.SignatureHelp{Visible: true, Signatures: []protocol.Signature{{Label: "map(enumerable, fun)"}}},
+		},
+	}
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDSignatureHelp, Z: 180, HitKind: 8},
+		{SurfaceID: surfaceIDBottomPanel, Z: 200, HitKind: 7},
+	}
+
+	got := strings.Join(model.overlayLines(), "\n")
+	if !strings.Contains(got, "panel-msg") {
+		t.Fatalf("bottom panel placed above signature help should win the slot, got %q", got)
+	}
+	if strings.Contains(got, "map(enumerable, fun)") {
+		t.Fatalf("signature help should lose when placed below the bottom panel, got %q", got)
+	}
+}
+
 func TestOverlayBottomPanelOpenSignatureHelpWins(t *testing.T) {
 	// Same inversion guard for signature help: it historically sat above the
 	// bottom panel (orderSignatureHelp 280 > floating band 200), so with the panel

--- a/lib/minga_editor/floating_window.ex
+++ b/lib/minga_editor/floating_window.ex
@@ -139,6 +139,21 @@ defmodule MingaEditor.FloatingWindow do
     {interior_h, interior_w}
   end
 
+  @doc """
+  Returns the window's outer rect in `Layout.rect()` shape: `{row, col, width, height}`.
+
+  This is the exact box `render/1` paints into, including border, position
+  resolution, and viewport clamping. It is the authoritative placement rect for a
+  floating popup, so a caller (the `SurfaceRegistry`/`FocusTree`) can register the
+  surface's rect without re-rendering its content.
+  """
+  @spec box(Spec.t()) :: {non_neg_integer(), non_neg_integer(), pos_integer(), pos_integer()}
+  def box(%Spec{} = spec) do
+    {vp_rows, vp_cols} = spec.viewport
+    %{row: row, col: col, w: w, h: h} = compute_box(spec, vp_rows, vp_cols)
+    {row, col, w, h}
+  end
+
   # ── Box computation ──────────────────────────────────────────────────────
 
   @typep box :: %{

--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -12,9 +12,11 @@ defmodule MingaEditor.FocusTree do
   alias MingaEditor.BottomPanel
   alias MingaEditor.CompletionUI
   alias MingaEditor.FocusTree.Node, as: TreeNode
+  alias MingaEditor.HoverPopup
   alias MingaEditor.Input
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Layout
+  alias MingaEditor.SignatureHelp
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.UI.Picker, as: PickerData
@@ -39,6 +41,7 @@ defmodule MingaEditor.FocusTree do
 
     layout
     |> build_base(window_map(state), Input.editing_dispatch_handler(state), state)
+    |> add_floating_overlays(state)
     |> add_modal_overlays(state, layout)
     |> link_tree()
   end
@@ -316,6 +319,66 @@ defmodule MingaEditor.FocusTree do
           [TreeNode.t()]
   defp maybe_add(children, nil, _build), do: children
   defp maybe_add(children, rect, build), do: children ++ [build.(rect)]
+
+  # ── Floating overlay builders ─────────────────────────────────────────────
+  #
+  # Cursor-anchored LSP popups (hover, signature help). Their rect is the exact
+  # box the BEAM already computes for layout (`HoverPopup.box/3`/`SignatureHelp.box/3`,
+  # both driven by `FloatingWindow`), so the SurfaceRegistry can place them with a
+  # real rect/z/hit_kind instead of leaving them to a Go-side transitional rank
+  # (#2281). They sit ABOVE floating chrome (bottom panel) and BELOW the single
+  # active modal overlay, preserving the historical stacking order.
+
+  @spec add_floating_overlays(t(), map()) :: t()
+  defp add_floating_overlays(%TreeNode{} = root, state) do
+    root
+    |> maybe_add_hover_overlay(state)
+    |> maybe_add_signature_overlay(state)
+  end
+
+  @spec maybe_add_hover_overlay(t(), map()) :: t()
+  defp maybe_add_hover_overlay(%TreeNode{} = root, %{
+         shell_state: %{hover_popup: %HoverPopup{} = popup},
+         terminal_viewport: vp,
+         theme: theme
+       }) do
+    case HoverPopup.box(popup, {vp.rows, vp.cols}, theme) do
+      nil ->
+        root
+
+      rect ->
+        append_root_child(
+          root,
+          TreeNode.new(:hover_popup, rect,
+            handler: Input.Hover,
+            scrollable?: true,
+            focusable?: true
+          )
+        )
+    end
+  end
+
+  defp maybe_add_hover_overlay(%TreeNode{} = root, _state), do: root
+
+  @spec maybe_add_signature_overlay(t(), map()) :: t()
+  defp maybe_add_signature_overlay(%TreeNode{} = root, %{
+         shell_state: %{signature_help: %SignatureHelp{} = sh},
+         terminal_viewport: vp,
+         theme: theme
+       }) do
+    case SignatureHelp.box(sh, {vp.rows, vp.cols}, theme) do
+      nil ->
+        root
+
+      rect ->
+        append_root_child(
+          root,
+          TreeNode.new(:signature_help, rect, handler: Input.SignatureHelp)
+        )
+    end
+  end
+
+  defp maybe_add_signature_overlay(%TreeNode{} = root, _state), do: root
 
   # ── Overlay builders ──────────────────────────────────────────────────────
 

--- a/lib/minga_editor/hover_popup.ex
+++ b/lib/minga_editor/hover_popup.ex
@@ -118,6 +118,32 @@ defmodule MingaEditor.HoverPopup do
   def render(%__MODULE__{content_lines: []}, _viewport, _theme), do: []
 
   def render(%__MODULE__{} = popup, viewport, theme) do
+    popup
+    |> spec(viewport, theme)
+    |> FloatingWindow.render()
+  end
+
+  @doc """
+  Returns the popup's outer rect `{row, col, width, height}` in screen cells.
+
+  This is the same box `render/3` paints into (border, anchor placement, and
+  viewport clamping included), so the `SurfaceRegistry` can register the hover
+  surface's rect from the BEAM's own geometry instead of inventing one. Returns
+  `nil` when there is no content to place.
+  """
+  @spec box(t(), {pos_integer(), pos_integer()}, map()) :: MingaEditor.Layout.rect() | nil
+  def box(%__MODULE__{content_lines: []}, _viewport, _theme), do: nil
+
+  def box(%__MODULE__{} = popup, viewport, theme) do
+    popup
+    |> spec(viewport, theme)
+    |> FloatingWindow.box()
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────────
+
+  @spec spec(t(), {pos_integer(), pos_integer()}, map()) :: FloatingWindow.Spec.t()
+  defp spec(%__MODULE__{} = popup, viewport, theme) do
     {vp_rows, vp_cols} = viewport
     popup_theme = Map.get(theme, :popup, default_popup_theme())
 
@@ -146,7 +172,7 @@ defmodule MingaEditor.HoverPopup do
     # Focus indicator in border
     border_style = if popup.focused, do: :single, else: :rounded
 
-    spec = %FloatingWindow.Spec{
+    %FloatingWindow.Spec{
       content: content_draws,
       width: {:cols, total_width},
       height: {:rows, total_height},
@@ -156,11 +182,7 @@ defmodule MingaEditor.HoverPopup do
       theme: popup_theme,
       viewport: viewport
     }
-
-    FloatingWindow.render(spec)
   end
-
-  # ── Private ──────────────────────────────────────────────────────────────
 
   @spec build_content_draws(
           [Markdown.parsed_line()],

--- a/lib/minga_editor/layout/surface_registry.ex
+++ b/lib/minga_editor/layout/surface_registry.ex
@@ -34,20 +34,30 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   simultaneous overlays are newly *expressible* as a list but are deliberately
   NOT produced here. Enabling them is out of scope (see #2268, AC-4).
 
-  Known enumeration gap (transitional split, #2268). The Go compositor's
-  `overlayLines()` chain also stacks surfaces that are not focus-tree nodes
-  today (hover, signature help, float popups, agent context, tool manager,
-  extension panels/overlays, observatory, timeline, notifications). #2268 ships
-  a *transitional split*: the surfaces the focus tree already places (the editor
-  area + chrome, and the single active modal overlay: picker or completion)
-  composite by placement/z and hit-test from these placement rects; the
-  not-yet-promoted overlay set keeps a reduced, hand-ordered chain on the Go
-  side until each is promoted into the focus tree. Promoting them is mechanical
-  per surface (each already has BEAM-tracked state) but balloons across ~10
-  surfaces, so it is deferred to a follow-up (#2281): "promote ephemeral/agent
-  overlays into FocusTree so the registry enumerates every composited surface
-  and the Go reduced chain can be deleted." The gap lives in the FocusTree's
-  coverage, not in this module's derivation.
+  Enumeration gap (transitional split, #2268; partially closed by #2281). The Go
+  compositor's `overlayLines()` chain also stacks surfaces that are not focus-tree
+  nodes. #2268 shipped a *transitional split*; #2281 promotes the surfaces whose
+  rect the BEAM authoritatively computes:
+
+  * **Promoted (#2281): hover popup, signature help.** Both are cursor-anchored
+    floating popups whose exact on-screen box the BEAM already computes for layout
+    (`HoverPopup.box/3`/`SignatureHelp.box/3`, driven by `FloatingWindow`).
+    `FocusTree.add_floating_overlays/2` now adds them as overlay nodes from
+    `shell_state`, so the registry places them with a real rect/z/hit_kind and the
+    AC-1 one-source property covers them. They occupy the `@z_floating_overlay`
+    region (hover 290 > signature help 280), preserving the historical order.
+
+  * **Still transitional (documented remainder):** float popup, agent context,
+    agent chat, tool manager, extension panels/overlays, observatory, timeline,
+    notifications. These are NOT focus-tree nodes and the BEAM does not compute a
+    layout rect for them: the Go compositor positions each entirely frontend-side
+    (footer-appended, sized by `maxOverlayHeight`/terminal width), so there is no
+    BEAM-authoritative rect to register. Inventing one would not be behaviour-
+    neutral, so they keep a reduced hand-ordered fallback on the Go side until
+    each grows a BEAM rect source. The gap lives in the FocusTree's coverage (and,
+    upstream, in whether each surface's rect is BEAM-known), not in this module's
+    derivation. Because the remainder is non-empty, Go's transitional rank table is
+    *shrunk*, not deleted.
 
   ## surface_id namespace and the identity-unification call (#2268)
 
@@ -135,6 +145,8 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
           | :picker
           | :completion_backdrop
           | :completion_menu
+          | :hover_popup
+          | :signature_help
 
   @typedoc "Coarse classification of what a click on a surface means."
   @type hit_kind ::
@@ -152,11 +164,22 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   # Bands leave gaps so future surfaces can slot between without renumbering the
   # whole stack. These mirror the back-to-front order FocusTree already builds:
   # base chrome and the editor area, then floating chrome (bottom panel), then
-  # the single active modal overlay on top.
+  # cursor-anchored floating popups (hover, signature help), then the single
+  # active modal overlay on top.
+  #
+  # Band policy for the promoted floating popups (#2281): the historical Go
+  # transitional chain placed hover (290) above signature help (280), and both
+  # above the bottom panel (200) and below the modal overlay band (300). The
+  # registry reproduces that exact order by slotting both popups in a
+  # `@z_floating_overlay` region between the floating-chrome band (200) and the
+  # overlay band (300), with hover one step above signature help. The numeric
+  # gap to the overlay band stays explicit so a future surface can land between
+  # the popups and the modal overlay without renumbering.
 
   @z_base_chrome 0
   @z_editor_area 100
   @z_floating_chrome 200
+  @z_floating_overlay 280
   @z_overlay 300
 
   @doc """
@@ -355,6 +378,8 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   def surface_id(:picker), do: :picker
   def surface_id(:completion_backdrop), do: :completion_backdrop
   def surface_id(:completion_menu), do: :completion_menu
+  def surface_id(:hover_popup), do: :hover_popup
+  def surface_id(:signature_help), do: :signature_help
   def surface_id({:custom, :sidebar}), do: :custom_sidebar
   def surface_id({:custom, _other}), do: :custom_sidebar
   def surface_id(_other), do: nil
@@ -384,6 +409,8 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   def surface_id_u16(:picker), do: 14
   def surface_id_u16(:completion_backdrop), do: 15
   def surface_id_u16(:completion_menu), do: 16
+  def surface_id_u16(:hover_popup), do: 17
+  def surface_id_u16(:signature_help), do: 18
 
   @doc """
   Maps a registry `hit_kind` atom to its `u8` wire value.
@@ -412,6 +439,11 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   defp z_for(:agent_chat_content), do: @z_editor_area + 1
   defp z_for(:modeline), do: @z_editor_area + 2
   defp z_for(:bottom_panel), do: @z_floating_chrome
+  # Cursor-anchored floating popups, above floating chrome and below the modal
+  # overlay band. hover (z=290) paints in front of signature help (z=280),
+  # reproducing the historical Go transitional order exactly (#2281).
+  defp z_for(:hover_popup), do: @z_floating_overlay + 10
+  defp z_for(:signature_help), do: @z_floating_overlay
   defp z_for(id) when id in [:picker_backdrop, :completion_backdrop], do: @z_overlay
   defp z_for(id) when id in [:picker, :completion_menu], do: @z_overlay + 1
   defp z_for(_base_chrome), do: @z_base_chrome
@@ -425,5 +457,6 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   defp hit_kind_for(:status_bar), do: :status_bar
   defp hit_kind_for(id) when id in [:picker, :completion_menu], do: :overlay
   defp hit_kind_for(id) when id in [:picker_backdrop, :completion_backdrop], do: :overlay
+  defp hit_kind_for(id) when id in [:hover_popup, :signature_help], do: :overlay
   defp hit_kind_for(_chrome), do: :chrome
 end

--- a/lib/minga_editor/signature_help.ex
+++ b/lib/minga_editor/signature_help.ex
@@ -103,8 +103,25 @@ defmodule MingaEditor.SignatureHelp do
   def render(%__MODULE__{signatures: []}, _viewport, _theme), do: []
 
   def render(%__MODULE__{} = sh, viewport, theme) do
-    sig = Enum.at(sh.signatures, sh.active_signature)
-    if sig == nil, do: [], else: do_render(sh, sig, viewport, theme)
+    case spec(sh, viewport, theme) do
+      nil -> []
+      spec -> FloatingWindow.render(spec)
+    end
+  end
+
+  @doc """
+  Returns the tooltip's outer rect `{row, col, width, height}` in screen cells.
+
+  Same box `render/3` paints into (border, anchor placement, viewport clamping
+  included), so the `SurfaceRegistry` registers the signature-help surface's rect
+  from the BEAM's own geometry. Returns `nil` when there is no signature to place.
+  """
+  @spec box(t(), {pos_integer(), pos_integer()}, map()) :: MingaEditor.Layout.rect() | nil
+  def box(%__MODULE__{} = sh, viewport, theme) do
+    case spec(sh, viewport, theme) do
+      nil -> nil
+      spec -> FloatingWindow.box(spec)
+    end
   end
 
   # ── Private: parsing ────────────────────────────────────────────────────
@@ -151,9 +168,17 @@ defmodule MingaEditor.SignatureHelp do
 
   # ── Private: rendering ─────────────────────────────────────────────────
 
-  @spec do_render(t(), signature(), {pos_integer(), pos_integer()}, map()) ::
-          [DisplayList.draw()]
-  defp do_render(sh, sig, viewport, theme) do
+  @spec spec(t(), {pos_integer(), pos_integer()}, map()) :: FloatingWindow.Spec.t() | nil
+  defp spec(%__MODULE__{signatures: []}, _viewport, _theme), do: nil
+
+  defp spec(%__MODULE__{} = sh, viewport, theme) do
+    sig = Enum.at(sh.signatures, sh.active_signature)
+    if sig == nil, do: nil, else: build_spec(sh, sig, viewport, theme)
+  end
+
+  @spec build_spec(t(), signature(), {pos_integer(), pos_integer()}, map()) ::
+          FloatingWindow.Spec.t()
+  defp build_spec(sh, sig, viewport, theme) do
     popup_theme = Map.get(theme, :popup, %{bg: 0x21242B, border_fg: 0x5B6268, title_fg: 0xBBC2CF})
     syntax = Map.get(theme, :syntax, %{})
     editor_theme = Map.get(theme, :editor, %{})
@@ -198,7 +223,7 @@ defmodule MingaEditor.SignatureHelp do
     sig_width = String.length(sig.label) + 4
     width = max(sig_width, 30) |> min(elem(viewport, 1) - 4)
 
-    spec = %FloatingWindow.Spec{
+    %FloatingWindow.Spec{
       content: all_draws,
       width: {:cols, width + 2},
       height: {:rows, min(content_height, 8) + 2},
@@ -208,8 +233,6 @@ defmodule MingaEditor.SignatureHelp do
       theme: popup_theme,
       viewport: viewport
     }
-
-    FloatingWindow.render(spec)
   end
 
   @spec render_param_doc(String.t(), map(), non_neg_integer()) :: [DisplayList.draw()]

--- a/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
+++ b/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
@@ -16,8 +16,11 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
   alias Minga.Protocol.Opcodes
   alias MingaEditor.Frontend.Emit
   alias MingaEditor.Frontend.Emit.Context
+  alias MingaEditor.HoverPopup
   alias MingaEditor.Layout.SurfaceRegistry
   alias MingaEditor.Layout.SurfaceRegistry.Placement
+  alias MingaEditor.SignatureHelp
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -25,6 +28,28 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
   alias MingaEditor.DisplayList.{Cursor, Frame}
 
   @op_surface_layout Opcodes.gui_surface_layout()
+
+  # A base state with both promoted floating popups live in shell_state, so the
+  # focus tree adds hover/signature-help overlay nodes and the registry places them.
+  defp state_with_floating_popups do
+    state = base_state()
+    hover = HoverPopup.new("Returns the **value**.", 2, 6)
+
+    signature = %SignatureHelp{
+      signatures: [%{label: "map(enumerable, fun)", documentation: "", parameters: []}],
+      active_signature: 0,
+      active_parameter: 0,
+      anchor_row: 4,
+      anchor_col: 3
+    }
+
+    shell_state =
+      state.shell_state
+      |> ShellState.set_hover_popup(hover)
+      |> Map.put(:signature_help, signature)
+
+    %{state | shell_state: shell_state}
+  end
 
   defp emit_commands(state) do
     frame = %Frame{cursor: Cursor.new(0, 0, :block), splash: [DisplayList.draw(0, 0, "x")]}
@@ -128,6 +153,43 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
       assert surface_id, "decoded surface_id #{u16} has no registry surface"
       assert SurfaceRegistry.rect_for_in(placements, surface_id) != nil
     end
+  end
+
+  test "promoted floating popups (hover, signature help) emit registry placements (#2281)" do
+    state = state_with_floating_popups()
+    commands = emit_commands(state)
+    decoded = commands |> surface_layout_command() |> decode_placements()
+
+    placements = SurfaceRegistry.placements(state)
+    expected = Enum.map(placements, &expected_entry/1)
+
+    # The promoted surfaces are present in the registry derivation...
+    surface_ids = Enum.map(placements, & &1.surface_id)
+    assert :hover_popup in surface_ids, "hover popup should be a registry-placed surface"
+    assert :signature_help in surface_ids, "signature help should be a registry-placed surface"
+
+    # ...and their emitted bytes match the registry rect/z/hit_kind field-for-field.
+    hover_u16 = SurfaceRegistry.surface_id_u16(:hover_popup)
+    sig_u16 = SurfaceRegistry.surface_id_u16(:signature_help)
+    decoded_hover = Enum.find(decoded, &(&1.surface_id == hover_u16))
+    decoded_sig = Enum.find(decoded, &(&1.surface_id == sig_u16))
+
+    assert decoded_hover, "emitted layout missing the promoted hover surface"
+    assert decoded_sig, "emitted layout missing the promoted signature-help surface"
+
+    # Behaviour-neutral stacking: hover (z=290) paints in front of signature
+    # help (z=280), exactly the historical Go transitional order.
+    assert decoded_hover.z == 290
+    assert decoded_sig.z == 280
+    assert decoded_hover.z > decoded_sig.z
+
+    # The emitted rect equals the registry rect_for that surface (AC-1, AC-3:
+    # the same rect BEAM hit-testing routes against).
+    assert decoded_hover.rect == SurfaceRegistry.rect_for_in(placements, :hover_popup)
+    assert decoded_sig.rect == SurfaceRegistry.rect_for_in(placements, :signature_help)
+
+    # And the full emitted list still matches the registry, order included.
+    assert decoded == expected
   end
 
   test "empty placement list still emits a well-formed (zero-count) command" do


### PR DESCRIPTION
## Summary

A documented **partial** of #2281: promotes exactly the overlay surfaces whose rects the BEAM authoritatively owns — hover popup and signature help (via the existing `FloatingWindow` box math) — and leaves the rest honestly transitional.

- `HoverPopup.box/3` / `SignatureHelp.box/3` expose the floating-window outer rect; the FocusTree adds overlay nodes when visible; the SurfaceRegistry emits placements (z=290/280, hit_kind overlay, ids 17/18) over `gui_surface_layout`. The Go compositor orders both by emitted placement z; the hand constants demote to fallbacks that agree exactly (stacking unchanged, tested via both paths).
- **The audit finding that reshapes the ticket**: the remaining 9 transitional surfaces have BEAM *state* but no BEAM *rect* — the Go compositor footer-appends them, sized frontend-side, never positioned by any rect. Promoting them requires rect-based rendering work first (the same structural gap as the G6 parity remainder), not registration. Per the ticket's own instruction, no rects were invented; the remainder is documented in the registry moduledoc and the Go table.
- **Input routing verified safe** (acceptance review's make-or-break): the router bubbles through handler-less and passthrough nodes, so signature help passes all events to the node underneath; hover dismisses on click then passes through (cursor still places), and wheel over an unfocused popup still scrolls the buffer. One non-blocking note: the click-dismiss path has no direct dispatch_mouse test (covered transitively by 63 passing routing tests); worth adding when this area is next touched.
- **GUI unaffected**: macOS renders these popups from their own opcodes and ignores `gui_surface_layout` placements as structural hints — no double-render, no hit-test conflict.

No schema changes (`mix protocol.gen --check` clean — placements are data).

## Tests

- Elixir: full suite 9,435 green (one unrelated extension-lifecycle flake passes in isolation); emit test pins promoted rect/z/hit_kind on the wire == registry; registry/focus-tree/router/hover/signature suites 82 pass
- Go: 307 pass incl. 2 new placement-z ordering tests and both pre-existing bottom-panel regression tests passing via fallback AND placement paths; gofmt/vet clean
- Reviews: acceptance reviewer PASS (input-routing question investigated and answered; partial scope ruled correctly drawn and honestly documented)

Part of #2281 (does not close it — see the ticket comment for the remainder's real precondition). Follow-up chain from #2268/#2219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)