### PR TITLE
fix(ui): require BEAM-provided startup theme

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,7 +27,7 @@ That's it. Save the file and restart Minga. Your options take effect immediately
 | `:autopair` | boolean | `true` | Auto-insert matching brackets and quotes |
 | `:autopair_block` | boolean | `true` | Auto-insert language-aware block-closing keywords on Enter |
 | `:scroll_margin` | non-negative integer | `5` | Lines to keep visible above/below cursor when scrolling |
-| `:theme` | theme name atom | `:doom_one` | Color theme (see [Themes](#themes) below) |
+| `:theme` | theme name atom | `:astrodark` | Color theme (see [Themes](#themes) below) |
 | `:indent_with` | `:spaces` or `:tabs` | `:spaces` | Whether to indent with spaces or tab characters |
 | `:trim_trailing_whitespace` | boolean | `false` | Strip trailing whitespace on save |
 | `:insert_final_newline` | boolean | `false` | Ensure file ends with a newline on save |
@@ -358,7 +358,8 @@ set :theme, :catppuccin_mocha
 
 | Theme | Style |
 |-------|-------|
-| `:doom_one` | Dark (default), Doom Emacs |
+| `:astrodark` | Dark (default), AstroNvim |
+| `:doom_one` | Dark, Doom Emacs |
 | `:catppuccin_frappe` | Dark, Catppuccin family |
 | `:catppuccin_latte` | Light, Catppuccin family |
 | `:catppuccin_macchiato` | Dark, Catppuccin family |

--- a/go/tui/internal/ui/line_cache_test.go
+++ b/go/tui/internal/ui/line_cache_test.go
@@ -14,6 +14,7 @@ import (
 func fullWindowFrame(seq uint32, window protocol.WindowContent) []protocol.Command {
 	return []protocol.Command{
 		beginFrame(seq, 0),
+		testThemeCommand(),
 		{Kind: protocol.CommandWindowContent, Window: window},
 		commitFrame(seq),
 	}

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -33,6 +33,7 @@ type Model struct {
 	windowOrder      []uint16
 	chrome           map[byte]protocol.ChromePayload
 	activePalette    palette
+	themeApplied     bool
 	gutters          map[uint16]protocol.Gutter
 	indentGuides     map[uint16]protocol.IndentGuides
 	cursorRow        uint16
@@ -138,7 +139,7 @@ func New(width, height uint16, out chan<- []byte) Model {
 		zones:             newZoneManager(),
 		windows:           map[uint16]protocol.WindowContent{},
 		chrome:            map[byte]protocol.ChromePayload{},
-		activePalette:     defaultPalette(),
+		activePalette:     bootstrapPalette(),
 		gutters:           map[uint16]protocol.Gutter{},
 		indentGuides:      map[uint16]protocol.IndentGuides{},
 		extensionRuntimes: map[string]protocol.ExtensionRuntimePayload{},
@@ -416,10 +417,23 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
+func stagingThemeValidation(commands []protocol.Command) (found bool, missing []byte) {
+	for _, command := range commands {
+		if command.Kind == protocol.CommandChrome && command.Chrome.Opcode == generated.OPGuiTheme {
+			found = true
+			missing = missingThemeSlots(command.Chrome.Theme)
+			if len(missing) > 0 {
+				return true, missing
+			}
+		}
+	}
+	return found, nil
+}
+
 // commitStaging validates the open transaction against the commit and, if valid,
 // replays its buffered commands through the live mutation switch in one shot,
 // then fires the commit-gated behaviors (latency resolve). An invalid or missing
-// transaction discards staging and requests a keyframe (#2219).
+// transaction discards staging and requests a keyframe (#2219), except a missing theme on a keyframe latches a protocol error because the BEAM must own theme selection.
 func (m *Model) commitStaging(cmds []tea.Cmd, command protocol.Command) []tea.Cmd {
 	if m.staging == nil {
 		// commit with no open begin: the begin was lost or truncated. Resync.
@@ -434,12 +448,24 @@ func (m *Model) commitStaging(cmds []tea.Cmd, command protocol.Command) []tea.Cm
 		return m.invalidateStaging(cmds, "frame base mismatch")
 	}
 
-	// Resync safety (#2288 AC 5): a keyframe (base 0) is a full reset of the
-	// staged state, so the composed-line cache must reset with it. The keyframe
-	// carries fresh full rows for the whole frame; clearing first guarantees no
-	// line composed against the pre-resync state survives. Delta frames (base
-	// != 0) keep the cache so their ref rows hit it.
+	// Resync safety (#2288 AC 5): gui_theme must be complete before any frame
+	// promotes. Keyframes must also carry gui_theme at all because the BEAM owns
+	// theme selection; otherwise the frontend would silently keep using
+	// bootstrap colors and hide a startup bug.
+	found, missing := stagingThemeValidation(m.staging.commands)
+	if found && len(missing) > 0 {
+		if m.staging.base == 0 {
+			m.protocolError = fmt.Sprintf("missing gui_theme slots in keyframe: %s", formatMissingThemeSlots(missing))
+			return m.invalidateStaging(cmds, "missing gui_theme slots in keyframe")
+		}
+		m.protocolError = fmt.Sprintf("missing gui_theme slots: %s", formatMissingThemeSlots(missing))
+		return m.invalidateStaging(cmds, "missing gui_theme slots")
+	}
 	if m.staging.base == 0 {
+		if !found {
+			m.protocolError = "missing gui_theme in keyframe"
+			return m.invalidateStaging(cmds, "missing gui_theme in keyframe")
+		}
 		m.lineCache.reset()
 	}
 
@@ -505,6 +531,7 @@ func (m *Model) applyMutation(command protocol.Command) {
 		switch command.Chrome.Opcode {
 		case generated.OPGuiTheme:
 			m.activePalette = paletteFromTheme(command.Chrome.Theme)
+			m.themeApplied = true
 		case generated.OPGuiCursorline:
 			m.cursorlineChrome = command.Chrome.CursorlineChrome
 		case generated.OPGuiGutter:

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -15,13 +15,57 @@ import (
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
 )
 
+func testThemeCommand() protocol.Command {
+	colors := map[byte]uint32{
+		themeEditorBG:         0x1E1F2A,
+		themeEditorFG:         0xC7D0E8,
+		themeTreeBG:           0x222433,
+		themeTreeFG:           0xB8C0D8,
+		themeTreeSelectBG:     0x343A52,
+		themeTreeDirFG:        0x7DB7FF,
+		themeTreeSelectionFG:  0xF7FAFF,
+		themeTabBG:            0x242634,
+		themeTabInactiveFG:    0x747B93,
+		themePopupBG:          0x292D3E,
+		themePopupFG:          0xD9E0F5,
+		themePopupSelBG:       0x3A425C,
+		themePopupSelFG:       0xF7FAFF,
+		themePopupDescFG:      0x747B93,
+		themePopupKeyFG:       0xF7FAFF,
+		themeBreadcrumbBG:     0x232634,
+		themeModelineBG:       0x222536,
+		themeModelineFG:       0xAEB7D0,
+		themeAccent:           0x7DB7FF,
+		themeGutterFG:         0x697088,
+		themeGutterCurrentFG:  0xC7D0E8,
+		themeDiagnosticError:  0xFF8AA6,
+		themeWarningFG:        0xF5C276,
+		themeDiagnosticInfo:   0x7DCFFF,
+		themeDiagnosticHint:   0xA6DA95,
+		themeHighlightReadBG:  0x33384C,
+		themeHighlightWriteBG: 0x4A3F2B,
+		themeSelectionBG:      0x2F4463,
+	}
+
+	for _, slot := range requiredThemeSlots {
+		if _, ok := colors[slot]; !ok {
+			colors[slot] = uint32(slot)<<16 | uint32(slot)<<8 | uint32(slot)
+		}
+	}
+
+	return protocol.Command{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiTheme, Theme: protocol.Theme{Colors: colors}}}
+}
+
 // frame wraps semantic/chrome commands in a keyframe transaction (#2219):
-// begin_frame(seq=1, base=0) ++ commands ++ commit_frame(seq=1). Under the
-// staged model nothing applies until commit, so tests that exercise the live
-// effect of a command must deliver it inside a transaction.
+// begin_frame(seq=1, base=0) ++ gui_theme ++ commands ++ commit_frame(seq=1).
+// Under the staged model nothing applies until commit, so tests that exercise
+// the live effect of a command must deliver it inside a transaction.
 func frame(commands ...protocol.Command) []protocol.Command {
-	out := make([]protocol.Command, 0, len(commands)+2)
+	out := make([]protocol.Command, 0, len(commands)+3)
 	out = append(out, protocol.Command{Kind: protocol.CommandBeginFrame, FrameSeq: 1, BaseFrameSeq: 0})
+	if found, _ := stagingThemeValidation(commands); !found {
+		out = append(out, testThemeCommand())
+	}
 	out = append(out, commands...)
 	out = append(out, protocol.Command{Kind: protocol.CommandCommitFrame, FrameSeq: 1})
 	return out
@@ -398,10 +442,10 @@ func TestPickerSelectedRowUsesSelectionColors(t *testing.T) {
 		Items:    []protocol.PickerItem{{Label: "[new 1]", Description: "dirty"}},
 	}, 2, 40)
 	joined := strings.Join(rows, "\n")
-	if !strings.Contains(joined, "48;2;58;66;92") {
+	if !strings.Contains(joined, "48;2;51;51;51") {
 		t.Fatalf("selected picker row should use popup selection background: %q", joined)
 	}
-	if !strings.Contains(joined, "38;2;247;250;255") {
+	if !strings.Contains(joined, "38;2;255;255;255") {
 		t.Fatalf("selected picker row should use popup selection foreground: %q", joined)
 	}
 }
@@ -410,10 +454,10 @@ func TestPickerPreviewDefaultsToPopupTextAndSurface(t *testing.T) {
 	model := New(80, 24, nil)
 	rendered := model.renderPickerPreview(protocol.PickerPreview{Visible: true, Lines: []protocol.PreviewLine{{Segments: []protocol.PreviewSegment{{Text: "plain preview"}}}}}, 3, 40)
 	joined := strings.Join(rendered, "\n")
-	if !strings.Contains(joined, "38;2;217;224;245") {
+	if !strings.Contains(joined, "38;2;255;255;255") {
 		t.Fatalf("plain preview text should use popup foreground instead of terminal default: %q", joined)
 	}
-	if !strings.Contains(joined, "48;2;41;45;62") {
+	if !strings.Contains(joined, "48;2;0;0;0") {
 		t.Fatalf("preview rows should use popup surface background: %q", joined)
 	}
 }
@@ -575,13 +619,171 @@ func TestCursorShapeSequenceTracksProtocolShape(t *testing.T) {
 
 func TestThemeCommandUpdatesModelPalette(t *testing.T) {
 	model := New(20, 4, nil)
-	_ = model.applyCommands(frame(protocol.Command{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiTheme, Theme: protocol.Theme{Colors: map[byte]uint32{themeEditorBG: 0x010203, themeSelectionBG: 0x112233}}}}))
+	_ = model.applyCommands(frame(testThemeCommand()))
 
-	if got := model.activePalette.colors[themeEditorBG]; got != 0x010203 {
-		t.Fatalf("editor background slot = 0x%06X, want 0x010203", got)
+	if got := model.activePalette.colors[themeEditorBG]; got != 0x1E1F2A {
+		t.Fatalf("editor background slot = 0x%06X, want 0x1E1F2A", got)
 	}
-	if got := model.activePalette.colors[themeSelectionBG]; got != 0x112233 {
-		t.Fatalf("selection slot = 0x%06X, want 0x112233", got)
+	if got := model.activePalette.colors[themeSelectionBG]; got != 0x2F4463 {
+		t.Fatalf("selection slot = 0x%06X, want 0x2F4463", got)
+	}
+}
+
+func TestBootstrapPaletteIsThemeAgnostic(t *testing.T) {
+	palette := bootstrapPalette()
+	want := map[byte]uint32{
+		themeEditorBG:        0x000000,
+		themeEditorFG:        0xFFFFFF,
+		themeTreeBG:          0x000000,
+		themeTreeSelectBG:    0x333333,
+		themeTreeSelectionFG: 0xFFFFFF,
+		themeTabBG:           0x000000,
+		themePopupBG:         0x000000,
+		themePopupSelFG:      0xFFFFFF,
+		themeModelineBG:      0x000000,
+		themeAccent:          0xFFFFFF,
+		themeDiagnosticError: 0xFF0000,
+		themeSelectionBG:     0x333333,
+	}
+
+	for slot, expected := range want {
+		if got := palette.colors[slot]; got != expected {
+			t.Fatalf("slot 0x%02X = 0x%06X, want 0x%06X", slot, got, expected)
+		}
+	}
+}
+
+func TestKeyframeWithoutThemeShowsProtocolError(t *testing.T) {
+	model := New(20, 4, nil)
+	_ = model.applyCommands([]protocol.Command{
+		{Kind: protocol.CommandBeginFrame, FrameSeq: 1, BaseFrameSeq: 0},
+		{Kind: protocol.CommandWindowContent, Window: protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "unthemed"}}}},
+		{Kind: protocol.CommandCommitFrame, FrameSeq: 1},
+	})
+
+	if model.protocolError != "missing gui_theme in keyframe" {
+		t.Fatalf("missing gui_theme should latch protocol error, got %q", model.protocolError)
+	}
+	if strings.Contains(ansi.Strip(model.View().Content), "unthemed") {
+		t.Fatalf("unthemed keyframe should not render content")
+	}
+}
+
+func TestKeyframeWithEmptyThemeShowsProtocolError(t *testing.T) {
+	model := New(20, 4, nil)
+	_ = model.applyCommands([]protocol.Command{
+		{Kind: protocol.CommandBeginFrame, FrameSeq: 1, BaseFrameSeq: 0},
+		{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiTheme, Theme: protocol.Theme{Colors: map[byte]uint32{}}}},
+		{Kind: protocol.CommandWindowContent, Window: protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "empty"}}}},
+		{Kind: protocol.CommandCommitFrame, FrameSeq: 1},
+	})
+
+	if !strings.Contains(model.protocolError, "missing gui_theme slots in keyframe") {
+		t.Fatalf("empty gui_theme should report missing slots, got %q", model.protocolError)
+	}
+	if !strings.Contains(model.protocolError, "0x01") || !strings.Contains(model.protocolError, "0xA0") {
+		t.Fatalf("empty gui_theme should list missing slot ids, got %q", model.protocolError)
+	}
+	if strings.Contains(ansi.Strip(model.View().Content), "empty") {
+		t.Fatalf("empty keyframe should not render content")
+	}
+}
+
+func TestKeyframeWithIncompleteThemeShowsProtocolError(t *testing.T) {
+	model := New(20, 4, nil)
+	_ = model.applyCommands([]protocol.Command{
+		{Kind: protocol.CommandBeginFrame, FrameSeq: 1, BaseFrameSeq: 0},
+		{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiTheme, Theme: protocol.Theme{Colors: map[byte]uint32{themeEditorBG: 0x1E1F2A, themeEditorFG: 0xC7D0E8}}}},
+		{Kind: protocol.CommandWindowContent, Window: protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "partial"}}}},
+		{Kind: protocol.CommandCommitFrame, FrameSeq: 1},
+	})
+
+	if !strings.Contains(model.protocolError, "missing gui_theme slots in keyframe") {
+		t.Fatalf("partial gui_theme should report missing slots, got %q", model.protocolError)
+	}
+	if !strings.Contains(model.protocolError, "0x03") || !strings.Contains(model.protocolError, "0xA0") {
+		t.Fatalf("partial gui_theme should list missing slot ids, got %q", model.protocolError)
+	}
+	if strings.Contains(ansi.Strip(model.View().Content), "partial") {
+		t.Fatalf("partial keyframe should not render content")
+	}
+}
+
+func TestDeltaFrameWithEmptyThemeShowsProtocolError(t *testing.T) {
+	model := New(20, 4, nil)
+	_ = model.applyCommands(frame(
+		protocol.Command{Kind: protocol.CommandWindowContent, Window: protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "baseline"}}}},
+	))
+	baselineEditorBG := model.activePalette.colors[themeEditorBG]
+
+	_ = model.applyCommands([]protocol.Command{
+		{Kind: protocol.CommandBeginFrame, FrameSeq: 2, BaseFrameSeq: 1},
+		{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiTheme, Theme: protocol.Theme{Colors: map[byte]uint32{}}}},
+		{Kind: protocol.CommandWindowContent, Window: protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "delta-empty"}}}},
+		{Kind: protocol.CommandCommitFrame, FrameSeq: 2},
+	})
+
+	if !strings.Contains(model.protocolError, "missing gui_theme slots") {
+		t.Fatalf("empty delta gui_theme should report missing slots, got %q", model.protocolError)
+	}
+	if !strings.Contains(model.protocolError, "0x01") || !strings.Contains(model.protocolError, "0xA0") {
+		t.Fatalf("empty delta gui_theme should list missing slot ids, got %q", model.protocolError)
+	}
+	if got := model.activePalette.colors[themeEditorBG]; got != baselineEditorBG {
+		t.Fatalf("delta theme failure should not change palette: 0x%06X != 0x%06X", got, baselineEditorBG)
+	}
+	if strings.Contains(ansi.Strip(model.View().Content), "delta-empty") {
+		t.Fatalf("empty delta frame should not render content")
+	}
+}
+
+func TestDeltaFrameWithPartialThemeShowsProtocolError(t *testing.T) {
+	model := New(20, 4, nil)
+	_ = model.applyCommands(frame(
+		protocol.Command{Kind: protocol.CommandWindowContent, Window: protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "baseline"}}}},
+	))
+	baselineEditorBG := model.activePalette.colors[themeEditorBG]
+
+	_ = model.applyCommands([]protocol.Command{
+		{Kind: protocol.CommandBeginFrame, FrameSeq: 3, BaseFrameSeq: 1},
+		{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiTheme, Theme: protocol.Theme{Colors: map[byte]uint32{themeEditorBG: 0x1E1F2A, themeEditorFG: 0xC7D0E8}}}},
+		{Kind: protocol.CommandWindowContent, Window: protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "delta-partial"}}}},
+		{Kind: protocol.CommandCommitFrame, FrameSeq: 3},
+	})
+
+	if !strings.Contains(model.protocolError, "missing gui_theme slots") {
+		t.Fatalf("partial delta gui_theme should report missing slots, got %q", model.protocolError)
+	}
+	if !strings.Contains(model.protocolError, "0x03") || !strings.Contains(model.protocolError, "0xA0") {
+		t.Fatalf("partial delta gui_theme should list missing slot ids, got %q", model.protocolError)
+	}
+	if got := model.activePalette.colors[themeEditorBG]; got != baselineEditorBG {
+		t.Fatalf("delta theme failure should not change palette: 0x%06X != 0x%06X", got, baselineEditorBG)
+	}
+	if strings.Contains(ansi.Strip(model.View().Content), "delta-partial") {
+		t.Fatalf("partial delta frame should not render content")
+	}
+}
+
+func TestPaletteUsesSemanticTreeAndPopupSlots(t *testing.T) {
+	palette := paletteFromTheme(protocol.Theme{Colors: map[byte]uint32{
+		themeTreeDirFG:       0x010203,
+		themeTreeSelectionFG: 0x020304,
+		themePopupDescFG:     0x030405,
+		themePopupKeyFG:      0x040506,
+	}})
+
+	if palette.TreeDirectoryText() != lipgloss.Color("#010203") {
+		t.Fatalf("tree directory text should use tree_dir_fg")
+	}
+	if palette.TreeSelectionText() != lipgloss.Color("#020304") {
+		t.Fatalf("tree selection text should use tree_selection_fg")
+	}
+	if palette.PopupMutedText() != lipgloss.Color("#030405") {
+		t.Fatalf("popup muted text should use popup_desc_fg")
+	}
+	if palette.KeycapText() != lipgloss.Color("#040506") {
+		t.Fatalf("keycap text should use popup_key_fg")
 	}
 }
 
@@ -787,7 +989,7 @@ func TestSplitSeparatorsNormalizeAgainstHeaderAndFileTree(t *testing.T) {
 func TestFileTreeSelectedRowPaintsBackgroundAcrossSegments(t *testing.T) {
 	model := New(40, 8, nil)
 	rendered := model.renderFileTreeRow(protocol.FileTreeRow{Name: "installer", Icon: "󰉋", Directory: true, Selected: true}, 24)
-	if count := strings.Count(rendered, "48;2;52;58;82"); count < 4 {
+	if count := strings.Count(rendered, "48;2;51;51;51"); count < 4 {
 		t.Fatalf("selected file-tree row should carry selection background across marker, icon, label, and fill, count=%d row=%q", count, rendered)
 	}
 	if got := displayWidth(ansi.Strip(rendered)); got != 24 {

--- a/go/tui/internal/ui/staging_test.go
+++ b/go/tui/internal/ui/staging_test.go
@@ -77,7 +77,7 @@ func TestInvalidationDebouncesKeyframeRequests(t *testing.T) {
 	}
 
 	// The keyframe arrives and commits: pending clears, content applies.
-	m = applyTo(t, m, beginFrame(9, 0), windowRowsCommand(1, "fresh"), commitFrame(9))
+	m = applyTo(t, m, beginFrame(9, 0), testThemeCommand(), windowRowsCommand(1, "fresh"), commitFrame(9))
 	if m.resyncPending {
 		t.Fatal("valid commit should clear resyncPending")
 	}
@@ -93,7 +93,7 @@ func TestStagingDoesNotPaintBeforeCommit(t *testing.T) {
 	model := New(40, 8, out)
 
 	// Commit a first keyframe so there is a known baseline frame on screen.
-	model = applyTo(t, model, beginFrame(1, 0), windowRowsCommand(1, "committed line"), commitFrame(1))
+	model = applyTo(t, model, beginFrame(1, 0), testThemeCommand(), windowRowsCommand(1, "committed line"), commitFrame(1))
 	before := renderedBody(model)
 	if !strings.Contains(before, "committed line") {
 		t.Fatalf("baseline frame should render committed content: %q", before)
@@ -118,7 +118,7 @@ func TestStagingDoesNotPaintBeforeCommit(t *testing.T) {
 func TestStagingAppliesAtomicallyOnCommit(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out)
-	model = applyTo(t, model, beginFrame(1, 0), windowRowsCommand(1, "first frame"), commitFrame(1))
+	model = applyTo(t, model, beginFrame(1, 0), testThemeCommand(), windowRowsCommand(1, "first frame"), commitFrame(1))
 
 	// Stage the next frame across two separate packets, committing only at the end.
 	model = applyTo(t, model, beginFrame(2, 1), windowRowsCommand(1, "second frame"))
@@ -144,7 +144,7 @@ func TestStagingAppliesAtomicallyOnCommit(t *testing.T) {
 func TestTruncatedTransactionRequestsKeyframeAndKeepsPriorFrame(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out)
-	model = applyTo(t, model, beginFrame(7, 0), windowRowsCommand(1, "good frame"), commitFrame(7))
+	model = applyTo(t, model, beginFrame(7, 0), testThemeCommand(), windowRowsCommand(1, "good frame"), commitFrame(7))
 	drainKeyframeRequests(t, out) // clear
 
 	// Open a transaction, feed content, then open ANOTHER begin before committing.
@@ -171,7 +171,7 @@ func TestTruncatedTransactionRequestsKeyframeAndKeepsPriorFrame(t *testing.T) {
 func TestStreamErrorInsideTransactionRequestsKeyframe(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out)
-	model = applyTo(t, model, beginFrame(3, 0), windowRowsCommand(1, "stable"), commitFrame(3))
+	model = applyTo(t, model, beginFrame(3, 0), testThemeCommand(), windowRowsCommand(1, "stable"), commitFrame(3))
 	drainKeyframeRequests(t, out)
 
 	// The reader appends CommandStreamError at the failure point and stops, so no
@@ -210,7 +210,7 @@ func TestStreamErrorOutsideTransactionIsHarmless(t *testing.T) {
 func TestCommitSeqMismatchRequestsKeyframe(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out)
-	model = applyTo(t, model, beginFrame(10, 0), windowRowsCommand(1, "base"), commitFrame(10))
+	model = applyTo(t, model, beginFrame(10, 0), testThemeCommand(), windowRowsCommand(1, "base"), commitFrame(10))
 	drainKeyframeRequests(t, out)
 
 	model = applyTo(t, model, beginFrame(11, 10), windowRowsCommand(1, "mismatch"), commitFrame(99))
@@ -232,7 +232,7 @@ func TestCommitSeqMismatchRequestsKeyframe(t *testing.T) {
 func TestBaseMismatchRequestsKeyframe(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out)
-	model = applyTo(t, model, beginFrame(20, 0), windowRowsCommand(1, "committed"), commitFrame(20))
+	model = applyTo(t, model, beginFrame(20, 0), testThemeCommand(), windowRowsCommand(1, "committed"), commitFrame(20))
 	drainKeyframeRequests(t, out)
 
 	// base 19 was never committed (last good is 20) -> base mismatch.
@@ -252,7 +252,7 @@ func TestBaseMismatchRequestsKeyframe(t *testing.T) {
 func TestResyncIndicatorShowsThenClearsOnKeyframe(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out)
-	model = applyTo(t, model, beginFrame(30, 0), windowRowsCommand(1, "ok"), commitFrame(30))
+	model = applyTo(t, model, beginFrame(30, 0), testThemeCommand(), windowRowsCommand(1, "ok"), commitFrame(30))
 
 	// Force an invalidation (double begin).
 	model = applyTo(t, model, beginFrame(31, 30), beginFrame(32, 30))
@@ -265,7 +265,7 @@ func TestResyncIndicatorShowsThenClearsOnKeyframe(t *testing.T) {
 	}
 
 	// A valid keyframe (base 0) arrives and commits -> indicator clears.
-	model = applyTo(t, model, beginFrame(40, 0), windowRowsCommand(1, "recovered"), commitFrame(40))
+	model = applyTo(t, model, beginFrame(40, 0), testThemeCommand(), windowRowsCommand(1, "recovered"), commitFrame(40))
 	if model.resyncPending {
 		t.Fatal("resyncPending should clear after a valid commit")
 	}
@@ -306,7 +306,7 @@ func TestOutOfBandSideChannelsApplyWithoutTransaction(t *testing.T) {
 func TestSemanticCommandOutsideTransactionRequestsKeyframe(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out)
-	model = applyTo(t, model, beginFrame(50, 0), windowRowsCommand(1, "committed"), commitFrame(50))
+	model = applyTo(t, model, beginFrame(50, 0), testThemeCommand(), windowRowsCommand(1, "committed"), commitFrame(50))
 	drainKeyframeRequests(t, out)
 
 	model = applyTo(t, model, windowRowsCommand(1, "stray semantic"))
@@ -327,7 +327,7 @@ func TestLatencyResolvesOnCommit(t *testing.T) {
 	model := New(40, 8, out)
 	seq := model.latency.Stamp()
 
-	model = applyTo(t, model, beginFrame(60, 0), windowRowsCommand(1, "frame"))
+	model = applyTo(t, model, beginFrame(60, 0), testThemeCommand(), windowRowsCommand(1, "frame"))
 	if model.latency.Snapshot().Resolved != 0 {
 		t.Fatal("latency must not resolve before commit")
 	}

--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -3,19 +3,25 @@ package ui
 import (
 	"fmt"
 	"image/color"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
 )
 
 const (
+	// Slot IDs mirror MingaEditor.UI.Theme.Slots. The bootstrap values below are only used before the first BEAM gui_theme command arrives.
 	themeEditorBG         byte = 0x01
 	themeEditorFG         byte = 0x02
 	themeTreeBG           byte = 0x03
 	themeTreeFG           byte = 0x04
 	themeTreeSelectBG     byte = 0x05
+	themeTreeDirFG        byte = 0x06
+	themeTreeActiveFG     byte = 0x07
 	themeTreeHeaderBG     byte = 0x08
 	themeTreeHeaderFG     byte = 0x09
+	themeTreeSeparatorFG  byte = 0x0A
+	themeTreeSelectionFG  byte = 0x0E
 	themeTabBG            byte = 0x10
 	themeTabActiveBG      byte = 0x11
 	themeTabActiveFG      byte = 0x12
@@ -26,11 +32,11 @@ const (
 	themePopupFG          byte = 0x21
 	themePopupBorder      byte = 0x22
 	themePopupSelBG       byte = 0x23
-	themePopupSelFG       byte = 0x2A
+	themePopupKeyFG       byte = 0x24
+	themePopupGroupFG     byte = 0x25
+	themePopupDescFG      byte = 0x26
 	themeBreadcrumbBG     byte = 0x27
-	themeHighlightReadBG  byte = 0x59
-	themeHighlightWriteBG byte = 0x5A
-	themeSelectionBG      byte = 0x5B
+	themePopupSelFG       byte = 0x2A
 	themeModelineBG       byte = 0x30
 	themeModelineFG       byte = 0x31
 	themeAccent           byte = 0x40
@@ -40,54 +46,99 @@ const (
 	themeWarningFG        byte = 0x53
 	themeDiagnosticInfo   byte = 0x54
 	themeDiagnosticHint   byte = 0x55
+	themeHighlightReadBG  byte = 0x59
+	themeHighlightWriteBG byte = 0x5A
+	themeSelectionBG      byte = 0x5B
 )
+
+var requiredThemeSlots = []byte{
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+	0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+	0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+	0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A,
+	0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A,
+	0x40,
+	0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B,
+	0x5C, 0x5D, 0x5E, 0x5F, 0x60, 0x61,
+	0x62,
+	0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE,
+}
 
 type palette struct {
 	colors map[byte]uint32
 }
 
-func defaultPalette() palette {
+func bootstrapPalette() palette {
 	return palette{colors: map[byte]uint32{
-		themeEditorBG:         0x1E1F2A,
-		themeEditorFG:         0xC7D0E8,
-		themeTreeBG:           0x222433,
-		themeTreeFG:           0xB8C0D8,
-		themeTreeSelectBG:     0x343A52,
-		themeTreeHeaderBG:     0x1A1D29,
-		themeTreeHeaderFG:     0x9EC5FF,
-		themeTabBG:            0x242634,
-		themeTabActiveBG:      0x30364D,
-		themeTabActiveFG:      0xF2F5FF,
-		themeTabInactiveFG:    0x747B93,
-		themeTabModifiedFG:    0xF5B66F,
-		themeTabAttentionFG:   0xE8C774,
-		themePopupBG:          0x292D3E,
-		themePopupFG:          0xD9E0F5,
-		themePopupBorder:      0x4C5267,
-		themePopupSelBG:       0x3A425C,
-		themePopupSelFG:       0xF7FAFF,
-		themeBreadcrumbBG:     0x232634,
-		themeModelineBG:       0x222536,
-		themeModelineFG:       0xAEB7D0,
-		themeAccent:           0x7DB7FF,
-		themeGutterFG:         0x697088,
-		themeGutterCurrentFG:  0xC7D0E8,
-		themeDiagnosticError:  0xFF8AA6,
-		themeWarningFG:        0xF5C276,
-		themeDiagnosticInfo:   0x7DCFFF,
-		themeDiagnosticHint:   0xA6DA95,
-		themeHighlightReadBG:  0x33384C,
-		themeHighlightWriteBG: 0x4A3F2B,
-		themeSelectionBG:      0x2F4463,
+		themeEditorBG:         0x000000,
+		themeEditorFG:         0xFFFFFF,
+		themeTreeBG:           0x000000,
+		themeTreeFG:           0xFFFFFF,
+		themeTreeSelectBG:     0x333333,
+		themeTreeDirFG:        0xFFFFFF,
+		themeTreeActiveFG:     0xFFFFFF,
+		themeTreeHeaderBG:     0x000000,
+		themeTreeHeaderFG:     0xFFFFFF,
+		themeTreeSeparatorFG:  0x666666,
+		themeTreeSelectionFG:  0xFFFFFF,
+		themeTabBG:            0x000000,
+		themeTabActiveBG:      0x333333,
+		themeTabActiveFG:      0xFFFFFF,
+		themeTabInactiveFG:    0x999999,
+		themeTabModifiedFG:    0xFFAA00,
+		themeTabAttentionFG:   0xFFAA00,
+		themePopupBG:          0x000000,
+		themePopupFG:          0xFFFFFF,
+		themePopupBorder:      0x666666,
+		themePopupSelBG:       0x333333,
+		themePopupKeyFG:       0xFFFFFF,
+		themePopupGroupFG:     0xFFFFFF,
+		themePopupDescFG:      0xFFFFFF,
+		themeBreadcrumbBG:     0x000000,
+		themePopupSelFG:       0xFFFFFF,
+		themeModelineBG:       0x000000,
+		themeModelineFG:       0xFFFFFF,
+		themeAccent:           0xFFFFFF,
+		themeGutterFG:         0x999999,
+		themeGutterCurrentFG:  0xFFFFFF,
+		themeDiagnosticError:  0xFF0000,
+		themeWarningFG:        0xFFAA00,
+		themeDiagnosticInfo:   0x00AAFF,
+		themeDiagnosticHint:   0x999999,
+		themeHighlightReadBG:  0x333333,
+		themeHighlightWriteBG: 0x333333,
+		themeSelectionBG:      0x333333,
 	}}
 }
 
 func paletteFromTheme(theme protocol.Theme) palette {
-	base := defaultPalette()
+	colors := make(map[byte]uint32, len(theme.Colors))
 	for slot, rgb := range theme.Colors {
-		base.colors[slot] = rgb
+		colors[slot] = rgb
 	}
-	return base
+	return palette{colors: colors}
+}
+
+func missingThemeSlots(theme protocol.Theme) []byte {
+	missing := make([]byte, 0, len(requiredThemeSlots))
+	for _, slot := range requiredThemeSlots {
+		if _, ok := theme.Colors[slot]; !ok {
+			missing = append(missing, slot)
+		}
+	}
+	return missing
+}
+
+func formatMissingThemeSlots(slots []byte) string {
+	if len(slots) == 0 {
+		return ""
+	}
+
+	parts := make([]string, len(slots))
+	for i, slot := range slots {
+		parts[i] = fmt.Sprintf("0x%02X", slot)
+	}
+	return strings.Join(parts, ", ")
 }
 
 func (p palette) Base() color.Color {
@@ -196,7 +247,7 @@ func (p palette) TreeMutedText() color.Color {
 }
 
 func (p palette) TreeDirectoryText() color.Color {
-	return p.slot(themeAccent)
+	return p.slot(themeTreeDirFG)
 }
 
 func (p palette) TreeSelection() color.Color {
@@ -204,7 +255,7 @@ func (p palette) TreeSelection() color.Color {
 }
 
 func (p palette) TreeSelectionText() color.Color {
-	return p.slot(themePopupSelFG)
+	return p.slot(themeTreeSelectionFG)
 }
 
 func (p palette) TreeHeader() color.Color {
@@ -260,7 +311,7 @@ func (p palette) PopupChrome() color.Color {
 }
 
 func (p palette) PopupMutedText() color.Color {
-	return p.slot(themeTabInactiveFG)
+	return p.slot(themePopupDescFG)
 }
 
 func (p palette) KeycapSurface() color.Color {
@@ -268,7 +319,7 @@ func (p palette) KeycapSurface() color.Color {
 }
 
 func (p palette) KeycapText() color.Color {
-	return p.slot(themePopupSelFG)
+	return p.slot(themePopupKeyFG)
 }
 
 func (p palette) Error() color.Color {

--- a/lib/minga/config/theme_registry.ex
+++ b/lib/minga/config/theme_registry.ex
@@ -2,7 +2,7 @@ defmodule Minga.Config.ThemeRegistry do
   @moduledoc """
   Layer 0 registry of available themes with source-owned registration.
 
-  Stores theme data (opaque to this module) with source ownership tracking so that disabling or reloading an extension pack cleanly removes only that pack's themes. The core fallback theme (`:minga_default`) is always present in the name list but not stored here; it lives in `MingaEditor.UI.Theme.Fallback`.
+  Stores theme data (opaque to this module) with source ownership tracking so that disabling or reloading an extension pack cleanly removes only that pack's themes. The core minimal theme (`:minga_default`) is always present in the name list but not stored here; it lives in `MingaEditor.UI.Theme.Fallback` and is only used when selected explicitly.
 
   Config.Options and Config.Completion query `available/0` for validation and tab-completion without importing from MingaEditor.*.
   """

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -996,24 +996,18 @@ defmodule MingaEditor do
   @doc false
   @spec apply_runtime_config_option(EditorState.t(), atom(), term()) :: EditorState.t()
   def apply_runtime_config_option(state, :theme, theme_name) when is_atom(theme_name) do
-    case MingaEditor.UI.Theme.get(theme_name) do
-      {:ok, theme} ->
-        if state.port_manager do
-          MingaEditor.Frontend.send_commands(state.port_manager, [
-            MingaEditor.Frontend.Protocol.GUI.encode_gui_theme(theme)
-          ])
-        end
+    theme = MingaEditor.UI.Theme.get!(theme_name)
 
-        state
-        |> EditorState.apply_theme(theme)
-        |> EditorState.invalidate_all_windows()
-        |> Layout.invalidate()
-
-      :error ->
-        state
+    if state.port_manager do
+      MingaEditor.Frontend.send_commands(state.port_manager, [
+        MingaEditor.Frontend.Protocol.GUI.encode_gui_theme(theme)
+      ])
     end
-  catch
-    :exit, _ -> state
+
+    state
+    |> EditorState.apply_theme(theme)
+    |> EditorState.invalidate_all_windows()
+    |> Layout.invalidate()
   end
 
   def apply_runtime_config_option(state, name, _value)

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -430,36 +430,13 @@ defmodule MingaEditor.Startup do
   """
   @spec apply_config_options(MingaEditor.State.t()) :: MingaEditor.State.t()
   def apply_config_options(state) do
-    state =
-      try do
-        theme_name = Minga.Config.Options.get(EditorState.options_server(state), :theme)
+    theme_name = Minga.Config.Options.get(EditorState.options_server(state), :theme)
+    theme = MingaEditor.UI.Theme.get!(theme_name)
+    state = EditorState.apply_theme(state, theme)
 
-        theme =
-          case MingaEditor.UI.Theme.get(theme_name) do
-            {:ok, t} ->
-              t
-
-            :error ->
-              Minga.Log.warning(
-                :config,
-                "Theme #{inspect(theme_name)} not available (pack disabled?), falling back to #{inspect(MingaEditor.UI.Theme.default())}"
-              )
-
-              MingaEditor.UI.Theme.get!(MingaEditor.UI.Theme.default())
-          end
-
-        EditorState.apply_theme(state, theme)
-      catch
-        :exit, _ -> state
-      end
-
-    try do
-      case Config.load_error() do
-        nil -> state
-        error -> EditorState.set_status(state, error)
-      end
-    catch
-      :exit, _ -> state
+    case Config.load_error() do
+      nil -> state
+      error -> EditorState.set_status(state, error)
     end
   end
 

--- a/lib/minga_editor/ui/theme.ex
+++ b/lib/minga_editor/ui/theme.ex
@@ -6,7 +6,7 @@ defmodule MingaEditor.UI.Theme do
   syntax highlighting, editor chrome, modeline, gutter, picker, minibuffer,
   search highlights, and popups.
 
-  Built-in themes are shipped as bundled theme pack extensions under `Minga.Extensions.ThemePacks`. The core retains a single minimal fallback theme (`:minga_default`) that always loads regardless of which extensions are enabled.
+  Built-in themes are shipped as bundled theme pack extensions under `Minga.Extensions.ThemePacks`. The core retains a single minimal theme (`:minga_default`) for tests and explicit use, but startup does not silently fall back to it when the configured theme is unavailable.
 
   ## Usage in config
 
@@ -563,14 +563,9 @@ defmodule MingaEditor.UI.Theme do
     Minga.Config.ThemeRegistry.available()
   end
 
-  @doc "Returns the default theme name atom. Falls back to `:minga_default` if `:astrodark` is not available."
+  @doc "Returns the configured default theme name atom. Startup fails if this theme is unavailable."
   @spec default() :: atom()
-  def default do
-    case Minga.Config.ThemeRegistry.get_theme(:astrodark) do
-      {:ok, _} -> :astrodark
-      :error -> :minga_default
-    end
-  end
+  def default, do: :astrodark
 
   # Folder icons have no language definition; this is their default tint when a
   # theme does not override the `:directory` key.

--- a/lib/minga_editor/ui/theme/doom_one.ex
+++ b/lib/minga_editor/ui/theme/doom_one.ex
@@ -2,8 +2,7 @@ defmodule MingaEditor.UI.Theme.DoomOne do
   @moduledoc """
   Doom One theme, sourced from doomemacs/themes doom-one-theme.el.
 
-  A dark theme with vibrant accent colors on a muted background. This is
-  Minga's default theme.
+  A dark theme with vibrant accent colors on a muted background.
   """
 
   # ── Doom One palette ──────────────────────────────────────────────────

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -62,10 +62,9 @@ private final class TitleBarDragNSView: NSView {
 /// random quip so the user sees a friendly loading state instead of a blank
 /// dark screen. Fades out when the first commit_frame arrives.
 ///
-/// Adapts to the macOS system appearance (light/dark) to minimize the flash
-/// when the editor's actual theme loads. The exact theme colors are not
-/// available yet (BEAM has not sent guiTheme), but matching the system
-/// appearance gets close enough for most users.
+/// Adapts to the macOS system appearance (light/dark) before the BEAM sends
+/// guiTheme. The overlay is a loading surface, not a theme fallback; the BEAM
+/// still owns the editor theme.
 struct StartupOverlay: View {
     @Environment(\.colorScheme) private var systemScheme
 

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -1992,9 +1992,27 @@ enum PreviewRegistry {
 
     // MARK: - Helpers
 
-    /// ThemeColors() already initializes with Doom One defaults, which look representative for preview screenshots without any BEAM theme push.
+    /// Preview-only theme fixture. Runtime theme selection comes from the BEAM via guiTheme; previews apply explicit slots because ThemeColors itself starts with neutral bootstrap colors.
     private static func populatedTheme() -> ThemeColors {
-        ThemeColors()
+        let theme = ThemeColors()
+        theme.applySlots([
+            (GUI_COLOR_EDITOR_BG, 0x28, 0x2C, 0x34),
+            (GUI_COLOR_EDITOR_FG, 0xBB, 0xC2, 0xCF),
+            (GUI_COLOR_TREE_BG, 0x21, 0x24, 0x2B),
+            (GUI_COLOR_TREE_FG, 0xBB, 0xC2, 0xCF),
+            (GUI_COLOR_TREE_SELECTION_BG, 0x22, 0x57, 0xA0),
+            (GUI_COLOR_TAB_BG, 0x21, 0x24, 0x2B),
+            (GUI_COLOR_TAB_ACTIVE_BG, 0x28, 0x2C, 0x34),
+            (GUI_COLOR_TAB_ACTIVE_FG, 0xBB, 0xC2, 0xCF),
+            (GUI_COLOR_TAB_INACTIVE_FG, 0x5B, 0x62, 0x68),
+            (GUI_COLOR_POPUP_BG, 0x21, 0x24, 0x2B),
+            (GUI_COLOR_POPUP_FG, 0xBB, 0xC2, 0xCF),
+            (GUI_COLOR_MODELINE_BAR_BG, 0x21, 0x24, 0x2B),
+            (GUI_COLOR_MODELINE_BAR_FG, 0xBB, 0xC2, 0xCF),
+            (GUI_COLOR_ACCENT, 0x51, 0xAF, 0xEF),
+            (GUI_COLOR_SELECTION_BG, 0x26, 0x4F, 0x78),
+        ])
+        return theme
     }
 
     private static func wireFileEntry(

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -138,6 +138,20 @@ final class CommandDispatcher {
         }
     }
 
+    /// gui_theme must carry the full slot set the frontends rely on. Missing slots are a protocol bug, not a theme fallback case.
+    static let requiredThemeSlots: [UInt8] = [
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+        0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+        0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A,
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A,
+        0x40,
+        0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B,
+        0x5C, 0x5D, 0x5E, 0x5F, 0x60, 0x61,
+        0x62,
+        0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE,
+    ]
+
     init(cols: UInt16, rows: UInt16, guiState: GUIState) {
         self.frameState = FrameState(cols: cols, rows: rows)
         self.guiState = guiState
@@ -209,6 +223,26 @@ final class CommandDispatcher {
             return
         }
 
+        let validation = stagedThemeValidation()
+        if validation.found {
+            if !validation.missingSlots.isEmpty {
+                let missingSlots = CommandDispatcher.formatMissingThemeSlots(validation.missingSlots)
+                if openBaseFrameSeq == 0 {
+                    PortLogger.warn("Keyframe committed with incomplete gui_theme, missing slots: \(missingSlots)")
+                    apply(.protocolError(message: "missing gui_theme slots in keyframe: \(missingSlots)"))
+                    return invalidate(reason: "missing gui_theme slots in keyframe: \(missingSlots)")
+                }
+
+                PortLogger.warn("Frame committed with incomplete gui_theme, missing slots: \(missingSlots)")
+                apply(.protocolError(message: "missing gui_theme slots: \(missingSlots)"))
+                return invalidate(reason: "missing gui_theme slots: \(missingSlots)")
+            }
+        } else if openBaseFrameSeq == 0 {
+            PortLogger.warn("Keyframe committed without gui_theme; refusing to present unthemed frame")
+            apply(.protocolError(message: "missing gui_theme in keyframe"))
+            return invalidate(reason: "missing gui_theme in keyframe")
+        }
+
         // Promote: replay the staged commands through the single mutation path.
         // This whole loop runs synchronously before onFrameReady, so SwiftUI's
         // render pass observes one consistent update rather than each step.
@@ -233,6 +267,31 @@ final class CommandDispatcher {
         }
         onFramePresented?()
         onFrameReady?()
+    }
+
+    private func stagedThemeValidation() -> (found: Bool, missingSlots: [UInt8]) {
+        var found = false
+
+        for command in stagedCommands {
+            if case .guiTheme(let slots) = command {
+                found = true
+                let missingSlots = CommandDispatcher.missingThemeSlots(in: slots)
+                if !missingSlots.isEmpty {
+                    return (true, missingSlots)
+                }
+            }
+        }
+
+        return (found, [])
+    }
+
+    private static func missingThemeSlots(in slots: [(UInt8, UInt8, UInt8, UInt8)]) -> [UInt8] {
+        let present = Set(slots.map { $0.0 })
+        return requiredThemeSlots.filter { !present.contains($0) }
+    }
+
+    private static func formatMissingThemeSlots(_ slots: [UInt8]) -> String {
+        slots.map { String(format: "0x%02X", $0) }.joined(separator: ", ")
     }
 
     /// Discards the open transaction's staged commands without promoting any of

--- a/macos/Sources/Views/ThemeColors.swift
+++ b/macos/Sources/Views/ThemeColors.swift
@@ -1,8 +1,6 @@
 /// Observable theme colors driven by the BEAM via the gui_theme protocol message.
 ///
-/// All SwiftUI chrome views reference this shared instance for their colors.
-/// Defaults to Doom One colors so the app looks correct before the BEAM sends
-/// a theme. Updated by CommandDispatcher when a gui_theme message arrives.
+/// All SwiftUI chrome views reference this shared instance for their colors. Initial values are neutral bootstrap colors used only before the first BEAM gui_theme command arrives. Theme selection belongs to the BEAM.
 
 import SwiftUI
 
@@ -11,137 +9,139 @@ import SwiftUI
 @Observable
 final class ThemeColors {
     // ── Editor ──
-    var editorBg: Color = color(0x282C34)
-    var editorFg: Color = color(0xBBC2CF)
+    var editorBg: Color = color(0x000000)
+    var editorFg: Color = color(0xFFFFFF)
 
     // ── File tree ──
-    var treeBg: Color = color(0x21242B)
-    var treeFg: Color = color(0xBBC2CF)
-    var treeSelectionBg: Color = color(0x2257A0)
-    var treeDirFg: Color = color(0x51AFEF)
-    var treeActiveFg: Color = color(0x51AFEF)
-    var treeHeaderBg: Color = color(0x21242B)
-    var treeHeaderFg: Color = color(0x51AFEF)
-    var treeSeparatorFg: Color = color(0x3F444A)
-    var treeGitModified: Color = color(0xECBE7B)
-    var treeGitStaged: Color = color(0x98BE65)
-    var treeGitUntracked: Color = color(0x98BE65)
-    var treeSelectionFg: Color = color(0xBBC2CF)
-    var treeGuideFg: Color = color(0x3F444A)
+    var treeBg: Color = color(0x000000)
+    var treeFg: Color = color(0xFFFFFF)
+    var treeSelectionBg: Color = color(0x333333)
+    var treeDirFg: Color = color(0xFFFFFF)
+    var treeActiveFg: Color = color(0xFFFFFF)
+    var treeHeaderBg: Color = color(0x000000)
+    var treeHeaderFg: Color = color(0xFFFFFF)
+    var treeSeparatorFg: Color = color(0x666666)
+    var treeGitModified: Color = color(0xFFAA00)
+    var treeGitStaged: Color = color(0x00AA00)
+    var treeGitUntracked: Color = color(0x00AA00)
+    var treeSelectionFg: Color = color(0xFFFFFF)
+    var treeGuideFg: Color = color(0x666666)
 
     // ── Tab bar ──
-    var tabBg: Color = color(0x21242B)
-    var tabActiveBg: Color = color(0x282C34)
-    var tabActiveFg: Color = color(0xBBC2CF)
-    var tabInactiveFg: Color = color(0x5B6268)
-    var tabModifiedFg: Color = color(0xECBE7B)
-    var tabSeparatorFg: Color = color(0x3F444A)
-    var tabCloseHoverFg: Color = color(0xFF6C6B)
-    var tabAttentionFg: Color = color(0xFF6C6B)
+    var tabBg: Color = color(0x000000)
+    var tabActiveBg: Color = color(0x333333)
+    var tabActiveFg: Color = color(0xFFFFFF)
+    var tabInactiveFg: Color = color(0x999999)
+    var tabModifiedFg: Color = color(0xFFAA00)
+    var tabSeparatorFg: Color = color(0x666666)
+    var tabCloseHoverFg: Color = color(0xFF0000)
+    var tabAttentionFg: Color = color(0xFFAA00)
 
     // ── Popup (which-key, completion) ──
-    var popupBg: Color = color(0x21242B)
-    var popupFg: Color = color(0xBBC2CF)
-    var popupBorder: Color = color(0x3F444A)
-    var popupSelBg: Color = color(0x2257A0)
-    var popupSelFg: Color = color(0xDFDFDF)
-    var popupKeyFg: Color = color(0x51AFEF)
-    var popupGroupFg: Color = color(0xC678DD)
-    var popupDescFg: Color = color(0xBBC2CF)
+    var popupBg: Color = color(0x000000)
+    var popupFg: Color = color(0xFFFFFF)
+    var popupBorder: Color = color(0x666666)
+    var popupSelBg: Color = color(0x333333)
+    var popupSelFg: Color = color(0xFFFFFF)
+    var popupKeyFg: Color = color(0xFFFFFF)
+    var popupGroupFg: Color = color(0xFFFFFF)
+    var popupDescFg: Color = color(0xFFFFFF)
 
     // ── Breadcrumb ──
-    var breadcrumbBg: Color = color(0x21242B)
-    var breadcrumbFg: Color = color(0xBBC2CF)
-    var breadcrumbSeparatorFg: Color = color(0x3F444A)
+    var breadcrumbBg: Color = color(0x000000)
+    var breadcrumbFg: Color = color(0xFFFFFF)
+    var breadcrumbSeparatorFg: Color = color(0x666666)
 
     // ── Modeline / status bar ──
-    var modelineBarBg: Color = color(0x21242B)
-    var modelineBarFg: Color = color(0xBBC2CF)
-    var modelineInfoBg: Color = color(0x3F444A)
-    var modelineInfoFg: Color = color(0xBBC2CF)
-    var modeNormalBg: Color = color(0x51AFEF)
-    var modeNormalFg: Color = color(0x21242B)
-    var modeInsertBg: Color = color(0x98BE65)
-    var modeInsertFg: Color = color(0x21242B)
-    var modeVisualBg: Color = color(0xC678DD)
-    var modeVisualFg: Color = color(0x21242B)
-    var statusbarAccentFg: Color = color(0x51AFEF)
+    var modelineBarBg: Color = color(0x000000)
+    var modelineBarFg: Color = color(0xFFFFFF)
+    var modelineInfoBg: Color = color(0x333333)
+    var modelineInfoFg: Color = color(0xFFFFFF)
+    var modeNormalBg: Color = color(0xFFFFFF)
+    var modeNormalFg: Color = color(0x000000)
+    var modeInsertBg: Color = color(0xFFFFFF)
+    var modeInsertFg: Color = color(0x000000)
+    var modeVisualBg: Color = color(0xFFFFFF)
+    var modeVisualFg: Color = color(0x000000)
+    var statusbarAccentFg: Color = color(0xFFFFFF)
 
     // ── Gutter ──
-    var gutterFg: Color = color(0x555555)
-    var gutterCurrentFg: Color = color(0xBBC2CF)
-    var gutterErrorFg: Color = color(0xFF6C6B)
-    var gutterWarningFg: Color = color(0xECBE7B)
-    var gutterInfoFg: Color = color(0x51AFEF)
-    var gutterHintFg: Color = color(0x555555)
-    var gutterFoldFg: Color = color(0x555555)
-    var gitAddedFg: Color = color(0x98BE65)
-    var gitModifiedFg: Color = color(0x51AFEF)
-    var gitDeletedFg: Color = color(0xFF6C6B)
+    var gutterFg: Color = color(0x999999)
+    var gutterCurrentFg: Color = color(0xFFFFFF)
+    var gutterErrorFg: Color = color(0xFF0000)
+    var gutterWarningFg: Color = color(0xFFAA00)
+    var gutterInfoFg: Color = color(0x00AAFF)
+    var gutterHintFg: Color = color(0x999999)
+    var gutterFoldFg: Color = color(0x999999)
+    var gitAddedFg: Color = color(0x00AA00)
+    var gitModifiedFg: Color = color(0x00AAFF)
+    var gitDeletedFg: Color = color(0xFF0000)
 
     // ── Document highlights + Selection ──
-    var highlightReadBg: Color = color(0x3A3F4B)
-    var highlightWriteBg: Color = color(0x4A3F2B)
-    var selectionBg: Color = color(0x264F78)
+    var highlightReadBg: Color = color(0x333333)
+    var highlightWriteBg: Color = color(0x333333)
+    var selectionBg: Color = color(0x333333)
 
     // Raw SIMD3 values for Metal renderer (highlight + selection).
     var highlightReadBgSIMD: SIMD3<Float> = SIMD3<Float>(
-        Float((0x3A3F4B >> 16) & 0xFF) / 255.0,
-        Float((0x3A3F4B >> 8) & 0xFF) / 255.0,
-        Float(0x3A3F4B & 0xFF) / 255.0
+        Float((0x333333 >> 16) & 0xFF) / 255.0,
+        Float((0x333333 >> 8) & 0xFF) / 255.0,
+        Float(0x333333 & 0xFF) / 255.0
     )
     var highlightWriteBgSIMD: SIMD3<Float> = SIMD3<Float>(
-        Float((0x4A3F2B >> 16) & 0xFF) / 255.0,
-        Float((0x4A3F2B >> 8) & 0xFF) / 255.0,
-        Float(0x4A3F2B & 0xFF) / 255.0
+        Float((0x333333 >> 16) & 0xFF) / 255.0,
+        Float((0x333333 >> 8) & 0xFF) / 255.0,
+        Float(0x333333 & 0xFF) / 255.0
     )
     var selectionBgSIMD: SIMD3<Float> = SIMD3<Float>(
-        Float((0x264F78 >> 16) & 0xFF) / 255.0,
-        Float((0x264F78 >> 8) & 0xFF) / 255.0,
-        Float(0x264F78 & 0xFF) / 255.0
+        Float((0x333333 >> 16) & 0xFF) / 255.0,
+        Float((0x333333 >> 8) & 0xFF) / 255.0,
+        Float(0x333333 & 0xFF) / 255.0
     )
 
     // Raw 24-bit RGB values for Metal renderer.
     // Updated alongside the Color properties when gui_theme slots arrive.
-    var editorFgRGB: UInt32 = 0xBBC2CF
-    var gutterFgRGB: UInt32 = 0x555555
-    var gutterCurrentFgRGB: UInt32 = 0xBBC2CF
-    var gutterErrorFgRGB: UInt32 = 0xFF6C6B
-    var gutterWarningFgRGB: UInt32 = 0xECBE7B
-    var gutterInfoFgRGB: UInt32 = 0x51AFEF
-    var gutterHintFgRGB: UInt32 = 0x555555
-    var gutterFoldFgRGB: UInt32 = 0x555555
-    var gitAddedFgRGB: UInt32 = 0x98BE65
-    var gitModifiedFgRGB: UInt32 = 0x51AFEF
-    var gitDeletedFgRGB: UInt32 = 0xFF6C6B
+    var editorFgRGB: UInt32 = 0xFFFFFF
+    var gutterFgRGB: UInt32 = 0x999999
+    var gutterCurrentFgRGB: UInt32 = 0xFFFFFF
+    var gutterErrorFgRGB: UInt32 = 0xFF0000
+    var gutterWarningFgRGB: UInt32 = 0xFFAA00
+    var gutterInfoFgRGB: UInt32 = 0x00AAFF
+    var gutterHintFgRGB: UInt32 = 0x999999
+    var gutterFoldFgRGB: UInt32 = 0x999999
+    var gitAddedFgRGB: UInt32 = 0x00AA00
+    var gitModifiedFgRGB: UInt32 = 0x00AAFF
+    var gitDeletedFgRGB: UInt32 = 0xFF0000
 
     // ── Agent status (shared across tab badges, chat header) ──
-    var agentStatusIdle: Color = color(0x555555)
-    var agentStatusWorking: Color = color(0x98BE65)
-    var agentStatusIterating: Color = color(0x98BE65)
-    var agentStatusNeedsYou: Color = color(0xECBE7B)
-    var agentStatusDone: Color = color(0x51AFEF)
-    var agentStatusErrored: Color = color(0xFF6C6B)
+    var agentStatusIdle: Color = color(0x999999)
+    var agentStatusWorking: Color = color(0x00AA00)
+    var agentStatusIterating: Color = color(0x00AA00)
+    var agentStatusNeedsYou: Color = color(0xFFAA00)
+    var agentStatusDone: Color = color(0xFFFFFF)
+    var agentStatusErrored: Color = color(0xFF0000)
 
     // ── Agent chat theme ──
-    var agentPanelBg: Color = color(0x282C34)
-    var agentHeaderBg: Color = color(0x1E2127)
-    var agentHeaderFg: Color = color(0x51AFEF)
-    var agentUserBorder: Color = color(0x51AFEF)
-    var agentUserLabel: Color = color(0x51AFEF)
-    var agentAssistantBorder: Color = color(0x98BE65)
-    var agentAssistantLabel: Color = color(0x98BE65)
-    var agentInputBorder: Color = color(0x51AFEF)
-    var agentInputBg: Color = color(0x282C34)
-    var agentInputPlaceholder: Color = color(0x5B6268)
-    var agentTextFg: Color = color(0xBBC2CF)
-    var agentToolBorder: Color = color(0xECBE7B)
-    var agentToolHeader: Color = color(0xECBE7B)
-    var agentCodeBg: Color = color(0x1E2127)
-    var agentCodeBorder: Color = color(0x5B6268)
+    var agentPanelBg: Color = color(0x000000)
+    var agentHeaderBg: Color = color(0x000000)
+    var agentHeaderFg: Color = color(0xFFFFFF)
+    var agentUserBorder: Color = color(0xFFFFFF)
+    var agentUserLabel: Color = color(0xFFFFFF)
+    var agentAssistantBorder: Color = color(0x00AA00)
+    var agentAssistantLabel: Color = color(0x00AA00)
+    var agentInputBorder: Color = color(0xFFFFFF)
+    var agentInputBg: Color = color(0x000000)
+    var agentInputPlaceholder: Color = color(0x999999)
+    var agentTextFg: Color = color(0xFFFFFF)
+    var agentToolBorder: Color = color(0xFFAA00)
+    var agentToolHeader: Color = color(0xFFAA00)
+    var agentCodeBg: Color = color(0x000000)
+    var agentCodeBorder: Color = color(0x666666)
 
     // ── Accent ──
-    var accent: Color = color(0x51AFEF)
+    var accent: Color = color(0xFFFFFF)
+
+    private(set) var hasAppliedTheme = false
 
     // ── Shared chrome contrast tokens ──
     var chromeSecondaryFg: Color { editorFg.opacity(0.78) }
@@ -167,6 +167,8 @@ final class ThemeColors {
 
     /// Apply a batch of color slot updates from the gui_theme protocol message.
     func applySlots(_ slots: [(UInt8, UInt8, UInt8, UInt8)]) {
+        hasAppliedTheme = true
+
         for (slotId, r, g, b) in slots {
             let c = Color(
                 red: Double(r) / 255.0,

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -7,6 +7,13 @@
 import Testing
 import Foundation
 
+@MainActor
+fileprivate func completeThemeSlots() -> [(UInt8, UInt8, UInt8, UInt8)] {
+    CommandDispatcher.requiredThemeSlots.map { slot in
+        (slot, slot, slot, slot)
+    }
+}
+
 @Suite("CommandDispatcher Routing")
 struct CommandDispatcherRoutingTests {
 
@@ -32,6 +39,7 @@ struct CommandDispatcherRoutingTests {
 
         // A keyframe transaction (base 0) opened then committed.
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
         #expect(gui.windowContents[1] != nil)
@@ -886,11 +894,13 @@ struct CommandDispatcherRoutingTests {
 
         // Two well-formed keyframe transactions; onFirstRender fires only once.
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
         #expect(callCount == 1)
         #expect(dispatcher.onFirstRender == nil)
 
         dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
         #expect(callCount == 1)
     }
@@ -909,6 +919,53 @@ struct CommandDispatcherRoutingTests {
         let expected: UInt32 = (0xAA << 16) | (0xBB << 8) | 0xCC
         #expect(dispatcher.frameState.gutterColors.fg == expected)
         #expect(gui.themeColors.gutterFgRGB == expected)
+        #expect(gui.themeColors.hasAppliedTheme)
+    }
+
+    @Test("keyframe with content but no guiTheme presents protocol error")
+    @MainActor func keyframeWithoutThemeErrors() {
+        let (dispatcher, gui) = makeDispatcher()
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "unthemed.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(gui.protocolErrorState.isPresented)
+        #expect(gui.protocolErrorState.message == "missing gui_theme in keyframe")
+        #expect(gui.tabBarState.tabs.isEmpty)
+    }
+
+    @Test("keyframe with empty guiTheme rejects promotion")
+    @MainActor func keyframeWithEmptyThemeErrors() {
+        let (dispatcher, gui) = makeDispatcher()
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: []))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "empty.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+
+        #expect(gui.protocolErrorState.isPresented)
+        #expect(gui.protocolErrorState.message?.contains("missing gui_theme slots in keyframe") == true)
+        #expect(gui.protocolErrorState.message?.contains("0x01") == true)
+        #expect(gui.themeColors.hasAppliedTheme == false)
+        #expect(gui.tabBarState.tabs.isEmpty)
+    }
+
+    @Test("keyframe with partial guiTheme rejects promotion")
+    @MainActor func keyframeWithPartialThemeErrors() {
+        let (dispatcher, gui) = makeDispatcher()
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: [(GUI_COLOR_EDITOR_BG, 0x00, 0x00, 0x00)]))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "partial.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
+
+        #expect(gui.protocolErrorState.isPresented)
+        #expect(gui.protocolErrorState.message?.contains("missing gui_theme slots in keyframe") == true)
+        #expect(gui.protocolErrorState.message?.contains("0x02") == true)
+        #expect(gui.protocolErrorState.message?.contains("0xA0") == true)
+        #expect(gui.themeColors.hasAppliedTheme == false)
+        #expect(gui.tabBarState.tabs.isEmpty)
     }
 }
 
@@ -942,6 +999,7 @@ struct CommandDispatcherStagingTests {
 
         // Establish a committed baseline so we have a "presented" tab bar.
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("old.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
         #expect(gui.tabBarState.tabs.first?.label == "old.ex")
@@ -959,6 +1017,7 @@ struct CommandDispatcherStagingTests {
         let (dispatcher, _) = makeDispatcher()
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.setCursorShape(.block))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
         #expect(dispatcher.frameState.cursorShape == .block)
@@ -976,6 +1035,7 @@ struct CommandDispatcherStagingTests {
         let (dispatcher, gui) = makeDispatcher()
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("a.ex")]))
         dispatcher.dispatch(.setCursorShape(.beam))
         // Nothing promoted yet.
@@ -997,6 +1057,7 @@ struct CommandDispatcherStagingTests {
         dispatcher.onFrameReady = { readyCount += 1 }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("a.ex")]))
         #expect(readyCount == 0)
 
@@ -1011,6 +1072,7 @@ struct CommandDispatcherStagingTests {
         let (dispatcher, gui) = makeDispatcher()
 
         dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("base.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 5, seq: 0))
 
@@ -1023,6 +1085,52 @@ struct CommandDispatcherStagingTests {
         #expect(dispatcher.lastCommittedFrameSeq == 6)
     }
 
+    @Test("delta frame with empty guiTheme rejects promotion")
+    @MainActor func deltaFrameWithEmptyThemeErrors() {
+        let (dispatcher, gui) = makeDispatcher()
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("base.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 5, seq: 0))
+        let baselineThemeBg = gui.themeColors.editorBg
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 6, baseFrameSeq: 5))
+        dispatcher.dispatch(.guiTheme(slots: []))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("empty-delta.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 6, seq: 0))
+
+        #expect(gui.protocolErrorState.isPresented)
+        #expect(gui.protocolErrorState.message?.contains("missing gui_theme slots: ") == true)
+        #expect(gui.protocolErrorState.message?.contains("0x01") == true)
+        #expect(gui.protocolErrorState.message?.contains("0xA0") == true)
+        #expect(gui.themeColors.editorBg == baselineThemeBg)
+        #expect(gui.tabBarState.tabs.first?.label == "base.ex")
+    }
+
+    @Test("delta frame with partial guiTheme rejects promotion")
+    @MainActor func deltaFrameWithPartialThemeErrors() {
+        let (dispatcher, gui) = makeDispatcher()
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("base.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 5, seq: 0))
+        let baselineThemeBg = gui.themeColors.editorBg
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 6, baseFrameSeq: 5))
+        dispatcher.dispatch(.guiTheme(slots: [(GUI_COLOR_EDITOR_BG, 0x00, 0x00, 0x00)]))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("partial-delta.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 6, seq: 0))
+
+        #expect(gui.protocolErrorState.isPresented)
+        #expect(gui.protocolErrorState.message?.contains("missing gui_theme slots: ") == true)
+        #expect(gui.protocolErrorState.message?.contains("0x02") == true)
+        #expect(gui.protocolErrorState.message?.contains("0xA0") == true)
+        #expect(gui.themeColors.editorBg == baselineThemeBg)
+        #expect(gui.tabBarState.tabs.first?.label == "base.ex")
+    }
+
     // MARK: - Invalidation requests a keyframe with no partial promotion
 
     @Test("commit seq mismatch invalidates with no promotion and requests keyframe")
@@ -1033,6 +1141,7 @@ struct CommandDispatcherStagingTests {
 
         // Commit a clean baseline so lastCommittedFrameSeq is known.
         dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("good.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
 
@@ -1071,6 +1180,7 @@ struct CommandDispatcherStagingTests {
 
         // The keyframe arrives: pending clears and content promotes.
         dispatcher.dispatch(.beginFrame(frameSeq: 9, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("fresh.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 9, seq: 0))
         #expect(gui.resyncState.pending == false)
@@ -1084,9 +1194,11 @@ struct CommandDispatcherStagingTests {
         dispatcher.onRequestKeyframe = { requested.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("staged.ex")]))
         // A new begin before commit: the first frame was truncated.
         dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
 
         // The truncated frame promoted nothing.
         #expect(gui.tabBarState.tabs.isEmpty)
@@ -1101,6 +1213,7 @@ struct CommandDispatcherStagingTests {
         dispatcher.onRequestKeyframe = { requested.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 10, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("base.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 10, seq: 0))
 
@@ -1131,6 +1244,7 @@ struct CommandDispatcherStagingTests {
         dispatcher.onRequestKeyframe = { requested.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("partial.ex")]))
         dispatcher.decodeFailed()
 
@@ -1154,6 +1268,7 @@ struct CommandDispatcherStagingTests {
 
         // The recovering keyframe arrives and commits cleanly.
         dispatcher.dispatch(.beginFrame(frameSeq: 7, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("recovered.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 7, seq: 0))
 

--- a/macos/Tests/MingaTests/ThemeColorsTests.swift
+++ b/macos/Tests/MingaTests/ThemeColorsTests.swift
@@ -23,6 +23,22 @@ struct ThemeColorsSlotMappingTests {
         Color(red: Double(r) / 255.0, green: Double(g) / 255.0, blue: Double(b) / 255.0)
     }
 
+    @Test("ThemeColors bootstrap is neutral until guiTheme arrives")
+    @MainActor func bootstrapIsNeutral() {
+        let theme = ThemeColors()
+        #expect(theme.hasAppliedTheme == false)
+        #expect(theme.editorBg == Color(red: 0, green: 0, blue: 0))
+        #expect(theme.editorFg == Color(red: 1, green: 1, blue: 1))
+        #expect(theme.popupBg == Color(red: 0, green: 0, blue: 0))
+        #expect(theme.selectionBg == Color(red: Double(0x33) / 255.0, green: Double(0x33) / 255.0, blue: Double(0x33) / 255.0))
+    }
+
+    @Test("applySlots marks BEAM theme as applied")
+    @MainActor func applySlotsMarksThemeApplied() {
+        let theme = applySlot(GUI_COLOR_EDITOR_BG)
+        #expect(theme.hasAppliedTheme)
+    }
+
     // MARK: - Editor slots
 
     @Test("Slot 0x01 maps to editorBg")

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -317,6 +317,71 @@ defmodule MingaEditor.StartupTest do
       Process.delete(:minga_config_options)
     end
 
+    test "apply_config_options raises when the configured theme is unavailable" do
+      options_server = start_supervised!({Options, name: nil}, id: :missing_theme_options)
+      {:ok, :astrodark} = Options.set(options_server, :theme, :astrodark)
+      Minga.Extensions.ThemePacks.unregister_pack(Minga.Extensions.ThemePacks.AstroNvim)
+
+      state =
+        Startup.build_initial_state(
+          backend: :headless,
+          port_manager: nil,
+          parser_manager: nil,
+          options_server: options_server,
+          width: 80,
+          height: 24
+        )
+
+      assert_raise ArgumentError, ~r/unknown theme: :astrodark/, fn ->
+        Startup.apply_config_options(state)
+      end
+    after
+      Minga.Extensions.ThemePacks.register_pack(Minga.Extensions.ThemePacks.AstroNvim)
+    end
+
+    test "apply_config_options exits instead of silently keeping a fallback theme when options go away" do
+      options_server = start_supervised!({Options, name: nil}, id: :gone_options)
+      {:ok, _} = Options.set(options_server, :theme, :doom_one)
+
+      state =
+        Startup.build_initial_state(
+          backend: :headless,
+          port_manager: nil,
+          parser_manager: nil,
+          options_server: options_server,
+          width: 80,
+          height: 24
+        )
+
+      ref = Process.monitor(options_server)
+      Process.exit(options_server, :shutdown)
+      assert_receive {:DOWN, ^ref, :process, ^options_server, _}
+
+      assert catch_exit(Startup.apply_config_options(state))
+    end
+
+    test "runtime theme application raises when the requested theme is unavailable" do
+      options_server = start_supervised!({Options, name: nil}, id: :runtime_missing_theme_options)
+      {:ok, :doom_one} = Options.set(options_server, :theme, :doom_one)
+      Minga.Extensions.ThemePacks.unregister_pack(Minga.Extensions.ThemePacks.AstroNvim)
+
+      state =
+        Startup.build_initial_state(
+          backend: :headless,
+          port_manager: nil,
+          parser_manager: nil,
+          options_server: options_server,
+          width: 80,
+          height: 24
+        )
+
+      assert_raise ArgumentError, ~r/unknown theme: :astrodark/, fn ->
+        MingaEditor.apply_runtime_config_option(state, :theme, :astrodark)
+      end
+    after
+      Minga.Extensions.ThemePacks.register_pack(Minga.Extensions.ThemePacks.AstroNvim)
+    end
+
     test "normalizes nil and supplied options servers" do
       default_state =
         Startup.build_initial_state(

--- a/test/minga_editor/ui/theme_test.exs
+++ b/test/minga_editor/ui/theme_test.exs
@@ -1,12 +1,15 @@
 defmodule Minga.ThemeTest do
-  use ExUnit.Case, async: true
+  # async: false because this suite mutates the global theme pack registry.
+  use ExUnit.Case, async: false
 
+  alias Minga.Extensions.ThemePacks
   alias MingaEditor.UI.Theme
 
   describe "available/0" do
     test "includes fallback and all bundled pack themes" do
       themes = Theme.available()
       assert :minga_default in themes
+      assert :astrodark in themes
       assert :doom_one in themes
       assert :catppuccin_frappe in themes
       assert :catppuccin_latte in themes
@@ -21,6 +24,15 @@ defmodule Minga.ThemeTest do
   describe "default/0" do
     test "returns :astrodark" do
       assert Theme.default() == :astrodark
+    end
+
+    test "stays :astrodark when AstroNvim is unavailable" do
+      ThemePacks.unregister_pack(ThemePacks.AstroNvim)
+
+      assert Theme.default() == :astrodark
+      refute :astrodark in Theme.available()
+    after
+      ThemePacks.register_pack(ThemePacks.AstroNvim)
     end
   end
 
@@ -107,6 +119,7 @@ defmodule Minga.ThemeTest do
   describe "all themes are valid" do
     for theme_name <- [
           :minga_default,
+          :astrodark,
           :doom_one,
           :catppuccin_frappe,
           :catppuccin_latte,


### PR DESCRIPTION
# TL;DR
BEAM is now the single source of truth for startup and runtime theme selection. The Go TUI and macOS frontend use only neutral bootstrap colors before a valid `gui_theme`, and invalid theme payloads surface protocol errors instead of silently painting frontend defaults.

## Context
Frontends should not encode AstroDark, Doom One, or any other product theme as a fallback. If BEAM cannot resolve or transmit the configured theme, startup/runtime should fail visibly instead of hiding the issue behind fallback colors.

## Changes
- Replaced BEAM theme fallback paths with `MingaEditor.UI.Theme.get!/1`, so missing configured themes raise instead of falling back to `:minga_default`.
- Removed silent runtime/startup recovery paths that could leave fallback theme colors in place after theme lookup/application exits.
- Clarified the built-in default theme as `:astrodark` in theme docs and theme module docs.
- Renamed the Go TUI default palette to a neutral bootstrap palette and stopped overlaying BEAM theme colors on a frontend product palette.
- Made Go reject keyframes missing `gui_theme` and reject empty/incomplete `gui_theme` payloads in any frame before promotion.
- Replaced Swift `ThemeColors` Doom One defaults with neutral bootstrap colors.
- Made Swift reject keyframes missing `guiTheme` and reject empty/incomplete `guiTheme` payloads in any frame before promotion.
- Updated Swift previews to apply explicit fixture slots instead of depending on runtime defaults.

## Verification
- `cd go/tui && go test ./internal/ui` → 143 passed in 1 package
- `mix test.llm test/minga_editor/startup_test.exs test/minga_editor/ui/theme_test.exs` → 117 tests, 0 failures
- `mix compile --warnings-as-errors` → ok
- `mix native.build.go_tui` → ok
- `mix swift.build` → skipped because `xcodebuild` is not available in this environment

## Review Loop
- Round 1 found startup/runtime fallback risks and missing empty/incomplete theme payload validation.
- Round 2 found Swift test helper visibility and delta-frame partial theme validation gaps.
- Round 3 found no correctness or silent-failure blockers. One reviewer suggested rejecting delta frames with no `gui_theme`, but that is intentionally deferred because deltas may omit `gui_theme` when the theme is unchanged.

## Acceptance Criteria Addressed
- BEAM owns theme selection and application ✅
- Missing configured BEAM themes fail instead of silently falling back ✅
- Go TUI has no product-theme default and only uses neutral bootstrap colors before a valid `gui_theme` ✅
- macOS has no product-theme default and only uses neutral bootstrap colors before a valid `guiTheme` ✅
- Frontends reject missing keyframe themes and incomplete theme payloads instead of hiding startup/runtime bugs ✅
