### PR TITLE
refactor(editor): inline ask and edit share one overlay foundation

### DIFF
--- a/lib/minga_editor/inline_overlay/prompt.ex
+++ b/lib/minga_editor/inline_overlay/prompt.ex
@@ -1,0 +1,42 @@
+defmodule MingaEditor.InlineOverlay.Prompt do
+  @moduledoc """
+  Shared prompt-input and scroll mechanics for inline overlays.
+
+  Inline ask and inline edit edit a `:prompt` string while `:status` is
+  `:input`, and scroll their body with a `:scroll` offset clamped at zero.
+  Those transitions only touch fields common to both variant structs, so
+  they live here once instead of being copied per variant.
+
+  Each function takes and returns the variant's own struct, so the variant
+  modules keep their `@enforce_keys`, kind-specific fields, and terminal
+  transitions while delegating these shared edits.
+  """
+
+  @typedoc "An overlay struct carrying `:prompt`, `:status`, and `:scroll`."
+  @type overlay :: %{
+          :__struct__ => module(),
+          :prompt => String.t(),
+          :status => atom(),
+          :scroll => non_neg_integer(),
+          optional(atom()) => term()
+        }
+
+  @doc "Appends text to the prompt while the overlay is accepting input."
+  @spec append_input(overlay(), String.t()) :: overlay()
+  def append_input(%{status: :input, prompt: prompt} = overlay, text) when is_binary(text),
+    do: %{overlay | prompt: prompt <> text}
+
+  def append_input(overlay, _text) when is_map(overlay), do: overlay
+
+  @doc "Deletes one prompt grapheme while the overlay is accepting input."
+  @spec backspace(overlay()) :: overlay()
+  def backspace(%{status: :input, prompt: prompt} = overlay),
+    do: %{overlay | prompt: prompt |> String.graphemes() |> Enum.drop(-1) |> Enum.join()}
+
+  def backspace(overlay) when is_map(overlay), do: overlay
+
+  @doc "Scrolls the overlay body, clamped at zero."
+  @spec scroll(overlay(), integer()) :: overlay()
+  def scroll(%{scroll: current} = overlay, delta) when is_integer(delta),
+    do: %{overlay | scroll: max(current + delta, 0)}
+end

--- a/lib/minga_editor/inline_overlay/store.ex
+++ b/lib/minga_editor/inline_overlay/store.ex
@@ -1,0 +1,60 @@
+defmodule MingaEditor.InlineOverlay.Store do
+  @moduledoc """
+  Shared per-buffer store for inline overlays (ask and edit).
+
+  Both variants key their ephemeral overlays by `buffer_pid` and track an
+  optional `session_pid`. The lookup/insert/dismiss/session plumbing only
+  touches those two fields, so it lives here once and is reused by both
+  `MingaEditor.State.InlineAsk` and `MingaEditor.State.InlineEdit` rather
+  than being copied per variant.
+
+  An overlay is any struct carrying `:buffer_pid` and `:session_pid`. The
+  variant struct modules own their own fields and transitions; this module
+  owns only the store mechanics.
+  """
+
+  @typedoc "An overlay struct carrying `:buffer_pid` and `:session_pid`."
+  @type overlay :: %{
+          :__struct__ => module(),
+          :buffer_pid => pid(),
+          :session_pid => pid() | nil,
+          optional(atom()) => term()
+        }
+
+  @typedoc "A per-buffer overlay store."
+  @type store :: %{pid() => overlay()}
+
+  @doc "Returns the active overlay for a buffer, or `nil`."
+  @spec active(store(), pid() | nil) :: overlay() | nil
+  def active(store, buffer_pid) when is_map(store) and is_pid(buffer_pid),
+    do: Map.get(store, buffer_pid)
+
+  def active(_store, _buffer_pid), do: nil
+
+  @doc "Returns true when the given session pid belongs to an overlay in this store."
+  @spec session?(store(), pid()) :: boolean()
+  def session?(store, session_pid) when is_map(store) and is_pid(session_pid) do
+    Enum.any?(store, fn {_buffer, overlay} -> overlay.session_pid == session_pid end)
+  end
+
+  @doc "Opens or replaces an overlay for its buffer."
+  @spec put(store(), overlay()) :: store()
+  def put(store, %{buffer_pid: buffer_pid} = overlay) when is_map(store) do
+    Map.put(store, buffer_pid, overlay)
+  end
+
+  @doc """
+  Dismisses the overlay for a buffer.
+
+  Returns `{store, session_pid}` where `session_pid` is the dismissed
+  overlay's session pid (or `nil` when there was no overlay), so callers
+  can stop the session.
+  """
+  @spec dismiss(store(), pid() | nil) :: {store(), pid() | nil}
+  def dismiss(store, buffer_pid) when is_map(store) and is_pid(buffer_pid) do
+    {overlay, store} = Map.pop(store, buffer_pid)
+    {store, if(overlay, do: overlay.session_pid, else: nil)}
+  end
+
+  def dismiss(store, _buffer_pid), do: {store, nil}
+end

--- a/lib/minga_editor/input/inline_ask.ex
+++ b/lib/minga_editor/input/inline_ask.ex
@@ -1,14 +1,19 @@
 defmodule MingaEditor.Input.InlineAsk do
   @moduledoc """
   Input handler for the active inline ask overlay.
+
+  This is the ask variant adapter over the shared
+  `MingaEditor.Input.InlineOverlay` plumbing: it supplies the store
+  accessor/setter and the ask-specific key table (Esc dismiss, Tab promote,
+  j/k scroll), and delegates the active lookup, submit, and dismissal to the
+  framework.
   """
 
   @behaviour MingaEditor.Input.Handler
 
-  import Bitwise, only: [band: 2]
-
   alias MingaAgent.EphemeralSession
   alias MingaEditor.Commands.InlineAsk, as: InlineAskCommand
+  alias MingaEditor.Input.InlineOverlay, as: Overlay
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.InlineAsk
 
@@ -24,22 +29,12 @@ defmodule MingaEditor.Input.InlineAsk do
   @doc false
   @spec handle_key(state(), non_neg_integer(), non_neg_integer(), keyword()) ::
           MingaEditor.Input.Handler.result()
-  def handle_key(
-        %{workspace: %{buffers: %{active: buffer_pid}}} = state,
-        codepoint,
-        modifiers,
-        opts
-      )
-      when is_pid(buffer_pid) and is_list(opts) do
-    ask = state |> EditorState.inline_asks() |> InlineAsk.active(buffer_pid)
-
-    case ask do
-      %InlineAsk{} -> {:handled, handle_inline_key(state, ask, codepoint, modifiers, opts)}
+  def handle_key(state, codepoint, modifiers, opts) when is_list(opts) do
+    case Overlay.active(state, spec(opts)) do
+      %InlineAsk{} = ask -> {:handled, handle_inline_key(state, ask, codepoint, modifiers, opts)}
       nil -> {:passthrough, state}
     end
   end
-
-  def handle_key(state, _codepoint, _modifiers, _opts), do: {:passthrough, state}
 
   @impl true
   @spec handle_mouse(
@@ -55,78 +50,43 @@ defmodule MingaEditor.Input.InlineAsk do
 
   @spec handle_inline_key(state(), InlineAsk.t(), non_neg_integer(), non_neg_integer(), keyword()) ::
           state()
-  defp handle_inline_key(state, ask, 27, _modifiers, _opts), do: dismiss(state, ask)
+  defp handle_inline_key(state, ask, 27, _modifiers, opts),
+    do: Overlay.dismiss(state, ask, spec(opts))
 
   defp handle_inline_key(state, %InlineAsk{status: :answered} = ask, 9, _modifiers, _opts),
     do: InlineAskCommand.promote(state, ask)
 
-  defp handle_inline_key(state, %InlineAsk{status: status} = ask, ?j, _modifiers, _opts)
+  defp handle_inline_key(state, %InlineAsk{status: status} = ask, ?j, _modifiers, opts)
        when status in [:answered, :error],
-       do: update_ask(state, InlineAsk.scroll(ask, 1))
+       do: Overlay.update(state, InlineAsk.scroll(ask, 1), spec(opts))
 
-  defp handle_inline_key(state, %InlineAsk{status: status} = ask, ?k, _modifiers, _opts)
+  defp handle_inline_key(state, %InlineAsk{status: status} = ask, ?k, _modifiers, opts)
        when status in [:answered, :error],
-       do: update_ask(state, InlineAsk.scroll(ask, -1))
+       do: Overlay.update(state, InlineAsk.scroll(ask, -1), spec(opts))
 
   defp handle_inline_key(state, %InlineAsk{status: :input} = ask, 13, _modifiers, opts),
-    do: submit(state, ask, opts)
+    do: Overlay.submit(state, ask, "Type a question first", spec(opts))
 
-  defp handle_inline_key(state, %InlineAsk{status: :input} = ask, 127, _modifiers, _opts),
-    do: update_ask(state, InlineAsk.backspace(ask))
+  defp handle_inline_key(state, %InlineAsk{status: :input} = ask, 127, _modifiers, opts),
+    do: Overlay.backspace(state, ask, spec(opts))
 
-  defp handle_inline_key(state, %InlineAsk{status: :input} = ask, 8, _modifiers, _opts),
-    do: update_ask(state, InlineAsk.backspace(ask))
+  defp handle_inline_key(state, %InlineAsk{status: :input} = ask, 8, _modifiers, opts),
+    do: Overlay.backspace(state, ask, spec(opts))
 
-  defp handle_inline_key(state, %InlineAsk{status: :input} = ask, codepoint, modifiers, _opts)
-       when codepoint >= 32 do
-    if printable_text_input?(modifiers) do
-      update_ask(state, InlineAsk.append_input(ask, <<codepoint::utf8>>))
-    else
-      state
-    end
-  end
+  defp handle_inline_key(state, %InlineAsk{status: :input} = ask, codepoint, modifiers, opts)
+       when codepoint >= 32,
+       do: Overlay.append_printable(state, ask, codepoint, modifiers, spec(opts))
 
   defp handle_inline_key(state, _ask, _codepoint, _modifiers, _opts), do: state
 
-  @spec printable_text_input?(non_neg_integer()) :: boolean()
-  defp printable_text_input?(modifiers) when is_integer(modifiers) do
-    band(modifiers, 0x0E) == 0
-  end
-
-  @spec submit(state(), InlineAsk.t(), keyword()) :: state()
-  defp submit(state, %InlineAsk{prompt: ""}, _opts),
-    do: EditorState.set_status(state, "Type a question first")
-
-  defp submit(state, %InlineAsk{} = ask, opts) do
-    asker = Keyword.get(opts, :session_asker, &EphemeralSession.ask/3)
-
-    case asker.(InlineAsk.agent_prompt(ask), project_root(state), subscriber: self()) do
-      {:ok, session_pid} ->
-        update_ask(state, InlineAsk.thinking(ask, session_pid))
-
-      {:error, reason} ->
-        update_ask(state, InlineAsk.fail(ask, "Failed to start inline ask: #{inspect(reason)}"))
-    end
-  end
-
-  @spec dismiss(state(), InlineAsk.t()) :: state()
-  defp dismiss(state, %InlineAsk{buffer_pid: buffer_pid, session_pid: session_pid}) do
-    EphemeralSession.stop(session_pid)
-    {asks, _pid} = state |> EditorState.inline_asks() |> InlineAsk.dismiss(buffer_pid)
-    EditorState.set_inline_asks(state, asks)
-  end
-
-  @spec update_ask(state(), InlineAsk.t()) :: state()
-  defp update_ask(state, %InlineAsk{} = ask) do
-    state
-    |> EditorState.inline_asks()
-    |> InlineAsk.put(ask)
-    |> then(&EditorState.set_inline_asks(state, &1))
-  end
-
-  @spec project_root(state()) :: String.t()
-  defp project_root(state) do
-    file_tree = EditorState.file_tree_state(state)
-    file_tree.project_root || file_tree.original_root || File.cwd!()
+  @spec spec(keyword()) :: Overlay.spec()
+  defp spec(opts) do
+    %{
+      store: &EditorState.inline_asks/1,
+      set_store: &EditorState.set_inline_asks/2,
+      state_module: InlineAsk,
+      session_starter: Keyword.get(opts, :session_asker, &EphemeralSession.ask/3),
+      fail_prefix: "Failed to start inline ask: "
+    }
   end
 end

--- a/lib/minga_editor/input/inline_edit.ex
+++ b/lib/minga_editor/input/inline_edit.ex
@@ -1,12 +1,20 @@
 defmodule MingaEditor.Input.InlineEdit do
   @moduledoc """
   Input handler for the active inline edit overlay.
+
+  This is the edit variant adapter over the shared
+  `MingaEditor.Input.InlineOverlay` plumbing: it supplies the store
+  accessor/setter and the edit-specific key table (Esc/n reject, y/Enter
+  accept, j/k scroll), and delegates the active lookup, submit, and prompt
+  editing to the framework. Accept and reject route through
+  `MingaEditor.Commands.InlineEdit`.
   """
 
   @behaviour MingaEditor.Input.Handler
 
   alias MingaAgent.EphemeralSession
   alias MingaEditor.Commands.InlineEdit, as: InlineEditCommand
+  alias MingaEditor.Input.InlineOverlay, as: Overlay
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.InlineEdit
 
@@ -15,17 +23,12 @@ defmodule MingaEditor.Input.InlineEdit do
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
-  def handle_key(%{workspace: %{buffers: %{active: buffer_pid}}} = state, codepoint, _modifiers)
-      when is_pid(buffer_pid) do
-    edit = state |> EditorState.inline_edits() |> InlineEdit.active(buffer_pid)
-
-    case edit do
-      %InlineEdit{} -> {:handled, handle_inline_key(state, edit, codepoint)}
+  def handle_key(state, codepoint, _modifiers) do
+    case Overlay.active(state, spec()) do
+      %InlineEdit{} = edit -> {:handled, handle_inline_key(state, edit, codepoint)}
       nil -> {:passthrough, state}
     end
   end
-
-  def handle_key(state, _codepoint, _modifiers), do: {:passthrough, state}
 
   @impl true
   @spec handle_mouse(
@@ -50,56 +53,36 @@ defmodule MingaEditor.Input.InlineEdit do
     do: InlineEditCommand.accept(state, edit)
 
   defp handle_inline_key(state, %InlineEdit{status: status} = edit, ?j)
-       when status in [:proposed, :error], do: update_edit(state, InlineEdit.scroll(edit, 1))
+       when status in [:proposed, :error],
+       do: Overlay.update(state, InlineEdit.scroll(edit, 1), spec())
 
   defp handle_inline_key(state, %InlineEdit{status: status} = edit, ?k)
-       when status in [:proposed, :error], do: update_edit(state, InlineEdit.scroll(edit, -1))
+       when status in [:proposed, :error],
+       do: Overlay.update(state, InlineEdit.scroll(edit, -1), spec())
 
-  defp handle_inline_key(state, %InlineEdit{status: :input} = edit, 13), do: submit(state, edit)
+  defp handle_inline_key(state, %InlineEdit{status: :input} = edit, 13),
+    do: Overlay.submit(state, edit, "Type a rewrite instruction first", spec())
 
   defp handle_inline_key(state, %InlineEdit{status: :input} = edit, 127),
-    do: update_edit(state, InlineEdit.backspace(edit))
+    do: Overlay.backspace(state, edit, spec())
 
   defp handle_inline_key(state, %InlineEdit{status: :input} = edit, 8),
-    do: update_edit(state, InlineEdit.backspace(edit))
+    do: Overlay.backspace(state, edit, spec())
 
   defp handle_inline_key(state, %InlineEdit{status: :input} = edit, codepoint)
-       when codepoint >= 32 do
-    update_edit(state, InlineEdit.append_input(edit, <<codepoint::utf8>>))
-  end
+       when codepoint >= 32,
+       do: Overlay.append_printable(state, edit, codepoint, 0, spec())
 
   defp handle_inline_key(state, _edit, _codepoint), do: state
 
-  @spec submit(state(), InlineEdit.t()) :: state()
-  defp submit(state, %InlineEdit{prompt: ""}),
-    do: EditorState.set_status(state, "Type a rewrite instruction first")
-
-  defp submit(state, %InlineEdit{} = edit) do
-    case EphemeralSession.rewrite(InlineEdit.agent_prompt(edit), project_root(state),
-           subscriber: self()
-         ) do
-      {:ok, session_pid} ->
-        update_edit(state, InlineEdit.thinking(edit, session_pid))
-
-      {:error, reason} ->
-        update_edit(
-          state,
-          InlineEdit.fail(edit, "Failed to start inline edit: #{inspect(reason)}")
-        )
-    end
-  end
-
-  @spec update_edit(state(), InlineEdit.t()) :: state()
-  defp update_edit(state, %InlineEdit{} = edit) do
-    state
-    |> EditorState.inline_edits()
-    |> InlineEdit.put(edit)
-    |> then(&EditorState.set_inline_edits(state, &1))
-  end
-
-  @spec project_root(state()) :: String.t()
-  defp project_root(state) do
-    file_tree = EditorState.file_tree_state(state)
-    file_tree.project_root || file_tree.original_root || File.cwd!()
+  @spec spec() :: Overlay.spec()
+  defp spec do
+    %{
+      store: &EditorState.inline_edits/1,
+      set_store: &EditorState.set_inline_edits/2,
+      state_module: InlineEdit,
+      session_starter: &EphemeralSession.rewrite/3,
+      fail_prefix: "Failed to start inline edit: "
+    }
   end
 end

--- a/lib/minga_editor/input/inline_overlay.ex
+++ b/lib/minga_editor/input/inline_overlay.ex
@@ -1,0 +1,136 @@
+defmodule MingaEditor.Input.InlineOverlay do
+  @moduledoc """
+  Shared input plumbing for inline overlays (ask and edit).
+
+  Both overlay input handlers do the same framing work: find the overlay
+  that owns the active buffer, route the key to a variant-specific key
+  table, and on submit start an ephemeral agent session subscribed to the
+  Editor. This module owns that shared plumbing (active lookup, store
+  write-back, dismissal, submit, prompt-input guard, project root). The
+  variant adapters supply a `spec` map and their own key clauses.
+
+  The `spec` carries the variant's store accessor/setter, its state
+  module, and the `session_starter` (`EphemeralSession.ask/3` or
+  `EphemeralSession.rewrite/2`-shaped) used on submit. Keeping submit here
+  preserves the deliberate `subscriber: self()` direct subscription for
+  both variants.
+  """
+
+  import Bitwise, only: [band: 2]
+
+  alias MingaEditor.State, as: EditorState
+
+  @typedoc """
+  Variant behaviour for an inline overlay input handler.
+
+  * `:store` reads the variant's per-buffer overlay store off editor state.
+  * `:set_store` writes an updated store back onto editor state.
+  * `:state_module` is the variant state module (for `active/2`, `put/2`,
+    `dismiss/2`, `thinking/2`, `fail/2`, `append_input/2`, `backspace/1`,
+    `agent_prompt/1`).
+  * `:session_starter` starts the ephemeral session
+    (`(prompt, project_root, opts) -> {:ok, pid} | {:error, term}`).
+  * `:fail_prefix` is the status prefix used when the session fails to start.
+  """
+  @type spec :: %{
+          store: (EditorState.t() -> %{pid() => struct()}),
+          set_store: (EditorState.t(), %{pid() => struct()} -> EditorState.t()),
+          state_module: module(),
+          session_starter: (String.t(), String.t(), keyword() -> {:ok, pid()} | {:error, term()}),
+          fail_prefix: String.t()
+        }
+
+  @typedoc "Editor input handler state."
+  @type state :: MingaEditor.Input.Handler.handler_state()
+
+  @doc """
+  Returns the active overlay for the active buffer, or `nil`.
+
+  `nil` when there is no active buffer or no overlay for it, which lets the
+  adapter return `{:passthrough, state}`.
+  """
+  @spec active(state(), spec()) :: struct() | nil
+  def active(%{workspace: %{buffers: %{active: buffer_pid}}} = state, spec)
+      when is_pid(buffer_pid) do
+    spec.store.(state) |> spec.state_module.active(buffer_pid)
+  end
+
+  def active(_state, _spec), do: nil
+
+  @doc "Writes an updated overlay back into its store on editor state."
+  @spec update(state(), struct(), spec()) :: state()
+  def update(state, overlay, spec) do
+    state
+    |> spec.store.()
+    |> spec.state_module.put(overlay)
+    |> then(&spec.set_store.(state, &1))
+  end
+
+  @doc "Stops the overlay's session and removes it from its store."
+  @spec dismiss(state(), struct(), spec()) :: state()
+  def dismiss(state, overlay, spec) do
+    MingaAgent.EphemeralSession.stop(overlay.session_pid)
+
+    {store, _session_pid} =
+      state |> spec.store.() |> spec.state_module.dismiss(overlay.buffer_pid)
+
+    spec.set_store.(state, store)
+  end
+
+  @doc "Appends a printable codepoint to the prompt, honouring modifier gating."
+  @spec append_printable(state(), struct(), non_neg_integer(), non_neg_integer(), spec()) ::
+          state()
+  def append_printable(state, overlay, codepoint, modifiers, spec) do
+    if printable_text_input?(modifiers) do
+      update(state, spec.state_module.append_input(overlay, <<codepoint::utf8>>), spec)
+    else
+      state
+    end
+  end
+
+  @doc "Deletes one prompt character."
+  @spec backspace(state(), struct(), spec()) :: state()
+  def backspace(state, overlay, spec) do
+    update(state, spec.state_module.backspace(overlay), spec)
+  end
+
+  @doc """
+  Submits the overlay prompt by starting its ephemeral session.
+
+  Empty prompts set `empty_status` and do nothing else. On success the
+  overlay moves to `:thinking` with the session pid; on failure it is
+  marked failed via the state module's `fail/2`.
+  """
+  @spec submit(state(), struct(), String.t(), spec()) :: state()
+  def submit(state, %{prompt: ""}, empty_status, _spec),
+    do: EditorState.set_status(state, empty_status)
+
+  def submit(state, overlay, _empty_status, spec) do
+    prompt = spec.state_module.agent_prompt(overlay)
+
+    case spec.session_starter.(prompt, project_root(state), subscriber: self()) do
+      {:ok, session_pid} ->
+        update(state, spec.state_module.thinking(overlay, session_pid), spec)
+
+      {:error, reason} ->
+        update(
+          state,
+          spec.state_module.fail(overlay, "#{spec.fail_prefix}#{inspect(reason)}"),
+          spec
+        )
+    end
+  end
+
+  @doc "Returns the project root for the active session."
+  @spec project_root(state()) :: String.t()
+  def project_root(state) do
+    file_tree = EditorState.file_tree_state(state)
+    file_tree.project_root || file_tree.original_root || File.cwd!()
+  end
+
+  @doc "True when the modifier bits carry no control/meta that should suppress text input."
+  @spec printable_text_input?(non_neg_integer()) :: boolean()
+  def printable_text_input?(modifiers) when is_integer(modifiers) do
+    band(modifiers, 0x0E) == 0
+  end
+end

--- a/lib/minga_editor/state/inline_ask.ex
+++ b/lib/minga_editor/state/inline_ask.ex
@@ -3,9 +3,18 @@ defmodule MingaEditor.State.InlineAsk do
   Ephemeral inline ask overlays keyed by buffer.
 
   Inline asks are presentation state only. They are not persisted and they do not create workspaces until explicitly promoted.
+
+  The shared per-buffer store mechanics (`active/2`, `put/2`, `dismiss/2`,
+  `session?/2`) and prompt-input mechanics (`append_input/2`, `backspace/1`,
+  `scroll/2`) live in `MingaEditor.InlineOverlay.Store` and
+  `MingaEditor.InlineOverlay.Prompt` and are reused here. This module owns
+  only the ask-specific shape and transitions: the read-only response
+  accumulation and the `:answered` terminal state.
   """
 
   alias Minga.Project.FileRef
+  alias MingaEditor.InlineOverlay.Prompt
+  alias MingaEditor.InlineOverlay.Store
 
   @type status :: :input | :thinking | :answered | :error
 
@@ -98,50 +107,30 @@ defmodule MingaEditor.State.InlineAsk do
   defp file_identity(%FileRef{kind: :path, relative_path: path}) when is_binary(path), do: path
   defp file_identity(%FileRef{display_name: name}), do: name
 
-  @doc "Returns the active ask for a buffer."
+  # Store mechanics (active/session?/put/dismiss) and prompt mechanics
+  # (append_input/backspace/scroll) are shared with inline edit; see
+  # MingaEditor.InlineOverlay.Store and MingaEditor.InlineOverlay.Prompt.
+
   @spec active(store(), pid() | nil) :: t() | nil
-  def active(store, buffer_pid) when is_map(store) and is_pid(buffer_pid),
-    do: Map.get(store, buffer_pid)
+  defdelegate active(store, buffer_pid), to: Store
 
-  def active(_store, _buffer_pid), do: nil
-
-  @doc "Returns true when the given session pid belongs to an inline ask."
   @spec session?(store(), pid()) :: boolean()
-  def session?(store, session_pid) when is_map(store) and is_pid(session_pid) do
-    Enum.any?(store, fn {_buffer, ask} -> ask.session_pid == session_pid end)
-  end
+  defdelegate session?(store, session_pid), to: Store
 
-  @doc "Opens or replaces an ask for its buffer."
   @spec put(store(), t()) :: store()
-  def put(store, %__MODULE__{buffer_pid: buffer_pid} = ask) when is_map(store) do
-    Map.put(store, buffer_pid, ask)
-  end
+  defdelegate put(store, ask), to: Store
 
-  @doc "Dismisses the ask for a buffer."
   @spec dismiss(store(), pid() | nil) :: {store(), pid() | nil}
-  def dismiss(store, buffer_pid) when is_map(store) and is_pid(buffer_pid) do
-    {ask, store} = Map.pop(store, buffer_pid)
-    {store, if(ask, do: ask.session_pid, else: nil)}
-  end
+  defdelegate dismiss(store, buffer_pid), to: Store
 
-  def dismiss(store, _buffer_pid), do: {store, nil}
-
-  @doc "Appends input to an ask."
   @spec append_input(t(), String.t()) :: t()
-  def append_input(%__MODULE__{status: :input, prompt: prompt} = ask, text)
-      when is_binary(text) do
-    %{ask | prompt: prompt <> text}
-  end
+  defdelegate append_input(ask, text), to: Prompt
 
-  def append_input(%__MODULE__{} = ask, _text), do: ask
-
-  @doc "Deletes one input character."
   @spec backspace(t()) :: t()
-  def backspace(%__MODULE__{status: :input, prompt: prompt} = ask) do
-    %{ask | prompt: prompt |> String.graphemes() |> Enum.drop(-1) |> Enum.join()}
-  end
+  defdelegate backspace(ask), to: Prompt
 
-  def backspace(%__MODULE__{} = ask), do: ask
+  @spec scroll(t(), integer()) :: t()
+  defdelegate scroll(ask, delta), to: Prompt
 
   @doc "Marks the ask as thinking."
   @spec thinking(t(), pid()) :: t()
@@ -162,12 +151,6 @@ defmodule MingaEditor.State.InlineAsk do
   @doc "Marks the ask as answered."
   @spec answered(t()) :: t()
   def answered(%__MODULE__{} = ask), do: %{ask | status: :answered, session_pid: nil}
-
-  @doc "Scrolls response text within the bounded overlay."
-  @spec scroll(t(), integer()) :: t()
-  def scroll(%__MODULE__{scroll: current} = ask, delta) when is_integer(delta) do
-    %{ask | scroll: max(current + delta, 0)}
-  end
 
   @doc "Marks the ask as failed."
   @spec fail(t(), String.t()) :: t()

--- a/lib/minga_editor/state/inline_edit.ex
+++ b/lib/minga_editor/state/inline_edit.ex
@@ -1,9 +1,19 @@
 defmodule MingaEditor.State.InlineEdit do
   @moduledoc """
   Ephemeral inline edit overlays keyed by buffer.
+
+  The shared per-buffer store mechanics (`active/2`, `put/2`, `dismiss/2`,
+  `session?/2`) and prompt-input mechanics (`append_input/2`, `backspace/1`,
+  `scroll/2`) live in `MingaEditor.InlineOverlay.Store` and
+  `MingaEditor.InlineOverlay.Prompt` and are reused here. This module owns
+  only the edit-specific shape and transitions: the selection/original text,
+  the proposed rewrite with its `:stream` vs `:tool` source tracking, and the
+  `:proposed` terminal state.
   """
 
   alias Minga.Project.FileRef
+  alias MingaEditor.InlineOverlay.Prompt
+  alias MingaEditor.InlineOverlay.Store
 
   @type status :: :input | :thinking | :proposed | :error
   @type proposal_source :: :stream | :tool | nil
@@ -75,47 +85,30 @@ defmodule MingaEditor.State.InlineEdit do
     """
   end
 
-  @doc "Returns the active edit for a buffer."
+  # Store mechanics (active/session?/put/dismiss) and prompt mechanics
+  # (append_input/backspace/scroll) are shared with inline ask; see
+  # MingaEditor.InlineOverlay.Store and MingaEditor.InlineOverlay.Prompt.
+
   @spec active(store(), pid() | nil) :: t() | nil
-  def active(store, buffer_pid) when is_map(store) and is_pid(buffer_pid),
-    do: Map.get(store, buffer_pid)
+  defdelegate active(store, buffer_pid), to: Store
 
-  def active(_store, _buffer_pid), do: nil
-
-  @doc "Returns true when the given session pid belongs to an inline edit."
   @spec session?(store(), pid()) :: boolean()
-  def session?(store, session_pid) when is_map(store) and is_pid(session_pid) do
-    Enum.any?(store, fn {_buffer, edit} -> edit.session_pid == session_pid end)
-  end
+  defdelegate session?(store, session_pid), to: Store
 
-  @doc "Opens or replaces an edit for its buffer."
   @spec put(store(), t()) :: store()
-  def put(store, %__MODULE__{buffer_pid: buffer_pid} = edit) when is_map(store),
-    do: Map.put(store, buffer_pid, edit)
+  defdelegate put(store, edit), to: Store
 
-  @doc "Dismisses the edit for a buffer."
   @spec dismiss(store(), pid() | nil) :: {store(), pid() | nil}
-  def dismiss(store, buffer_pid) when is_map(store) and is_pid(buffer_pid) do
-    {edit, store} = Map.pop(store, buffer_pid)
-    {store, if(edit, do: edit.session_pid, else: nil)}
-  end
+  defdelegate dismiss(store, buffer_pid), to: Store
 
-  def dismiss(store, _buffer_pid), do: {store, nil}
-
-  @doc "Appends prompt input."
   @spec append_input(t(), String.t()) :: t()
-  def append_input(%__MODULE__{status: :input, prompt: prompt} = edit, text) when is_binary(text),
-    do: %{edit | prompt: prompt <> text}
+  defdelegate append_input(edit, text), to: Prompt
 
-  def append_input(%__MODULE__{} = edit, _text), do: edit
-
-  @doc "Deletes one prompt character."
   @spec backspace(t()) :: t()
-  def backspace(%__MODULE__{status: :input, prompt: prompt} = edit) do
-    %{edit | prompt: prompt |> String.graphemes() |> Enum.drop(-1) |> Enum.join()}
-  end
+  defdelegate backspace(edit), to: Prompt
 
-  def backspace(%__MODULE__{} = edit), do: edit
+  @spec scroll(t(), integer()) :: t()
+  defdelegate scroll(edit, delta), to: Prompt
 
   @doc "Marks the edit as thinking."
   @spec thinking(t(), pid()) :: t()
@@ -150,11 +143,6 @@ defmodule MingaEditor.State.InlineEdit do
   @doc "Marks the edit as proposed."
   @spec proposed(t()) :: t()
   def proposed(%__MODULE__{} = edit), do: %{edit | status: :proposed, session_pid: nil}
-
-  @doc "Scrolls diff text within the bounded overlay."
-  @spec scroll(t(), integer()) :: t()
-  def scroll(%__MODULE__{scroll: current} = edit, delta) when is_integer(delta),
-    do: %{edit | scroll: max(current + delta, 0)}
 
   @doc "Marks the edit as failed."
   @spec fail(t(), String.t()) :: t()


### PR DESCRIPTION
## Summary

Epic #2221's inline-merge item, completing what a prior slice started: the render/events layers of inline ask and inline edit were already shared; this merges the remaining duplicated **store, prompt, and input** mechanics into the same `InlineOverlay` foundation, so a fix to submit/dismiss/store/backspace logic changes one place instead of two.

- `InlineOverlay.Store` — the per-buffer store quartet that was byte-identical in both state modules
- `InlineOverlay.Prompt` — prompt editing + scroll, including the grapheme-aware backspace (the textbook drift hazard: one twin gets the unicode fix, the other doesn't)
- `Input.InlineOverlay` — shared input plumbing, including the submit path with the **deliberate `subscriber: self()` direct EphemeralSession subscription** (not through Agent.Ingest), byte-equivalent for both kinds vs main
- Per-kind modules keep only real differences: ask = response + `:answered` + promotion; edit = selection/original/proposed + `proposal_source` + accept/reject. No `:kind` branching in shared code; `proposal_source` never enters a shared module (reviewer-verified by grep)

**Behavior preservation proof: zero test files touched.** All existing suites pass unchanged — promotion, session seeding, file-ref resolution, accept/reject, escape, and the `subscriber == self()` assertion all run through the new shared paths.

**Line accounting, honestly**: this slice is net +145 (per-kind −86, shared modules +231, dominated by mandated moduledoc/type/spec overhead on small files). The acceptance reviewer ruled each of the three shared modules carries real duplicated logic rather than ceremony, and that the ticket's "duplication is the hazard, not the line count" framing governs; the bulk reduction landed in the earlier render/events slice.

## Tests

- Focused inline suites 88 passed; full `mix test.llm` 9,398 tests 0 failures; `mix compile --warnings-as-errors` clean; credo --strict clean on all 7 files; `make lint` green (only pre-existing warnings in unrelated files)
- Acceptance reviewer: PASS (explicit per-module ceremony-vs-logic ruling; submit subscription opts verified byte-equivalent; edit's unconditional-append semantics preserved via explicit `modifiers = 0`)

Closes #2314. Part of #2221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)