### PR TITLE
fix(lsp): drop malformed JSON-RPC headers

### DIFF
--- a/lib/minga/lsp/json_rpc.ex
+++ b/lib/minga/lsp/json_rpc.ex
@@ -138,22 +138,50 @@ defmodule Minga.LSP.JsonRpc do
       {:ok, msg, rest} ->
         decode_loop(rest, [msg | acc])
 
+      {:drop, rest} ->
+        decode_loop(rest, acc)
+
       :incomplete ->
         {Enum.reverse(acc), buffer}
     end
   end
 
-  @spec extract_one(binary()) :: {:ok, message(), binary()} | :incomplete
+  @spec extract_one(binary()) :: {:ok, message(), binary()} | {:drop, binary()} | :incomplete
   defp extract_one(buffer) do
-    with [headers_section, body_and_rest] <- :binary.split(buffer, "\r\n\r\n"),
-         {:ok, content_length} <- parse_content_length(headers_section),
-         true <- byte_size(body_and_rest) >= content_length do
-      <<json::binary-size(^content_length), rest::binary>> = body_and_rest
-      {:ok, JSON.decode!(json), rest}
-    else
-      _ -> :incomplete
+    case :binary.split(buffer, "\r\n\r\n") do
+      [headers_section, body_and_rest] ->
+        extract_with_headers(headers_section, body_and_rest)
+
+      [_partial] ->
+        :incomplete
     end
   end
+
+  @spec extract_with_headers(binary(), binary()) ::
+          {:ok, message(), binary()} | {:drop, binary()} | :incomplete
+  defp extract_with_headers(headers_section, body_and_rest) do
+    case parse_content_length(headers_section) do
+      {:ok, content_length} ->
+        extract_body(content_length, body_and_rest)
+
+      :error ->
+        Minga.Log.warning(
+          :lsp,
+          "LSP JSON-RPC decoder dropped a complete header block without a valid Content-Length"
+        )
+
+        {:drop, body_and_rest}
+    end
+  end
+
+  @spec extract_body(non_neg_integer(), binary()) :: {:ok, message(), binary()} | :incomplete
+  defp extract_body(content_length, body_and_rest)
+       when byte_size(body_and_rest) >= content_length do
+    <<json::binary-size(^content_length), rest::binary>> = body_and_rest
+    {:ok, JSON.decode!(json), rest}
+  end
+
+  defp extract_body(_content_length, _body_and_rest), do: :incomplete
 
   @spec parse_content_length(binary()) :: {:ok, non_neg_integer()} | :error
   defp parse_content_length(headers) do

--- a/test/minga/lsp/json_rpc_test.exs
+++ b/test/minga/lsp/json_rpc_test.exs
@@ -1,6 +1,8 @@
 defmodule Minga.LSP.JsonRpcTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Minga.LSP.JsonRpc
 
   describe "encode_request/3" do
@@ -165,6 +167,46 @@ defmodule Minga.LSP.JsonRpcTest do
 
       assert messages == []
       assert rest == buffer
+    end
+
+    test "drops complete header block without Content-Length and decodes following message" do
+      valid = IO.iodata_to_binary(JsonRpc.encode_notification("valid", %{}))
+      buffer = "X-Other: 1\r\n\r\n" <> valid
+
+      log =
+        capture_log(fn ->
+          {[decoded], rest} = JsonRpc.decode(buffer)
+
+          assert decoded["method"] == "valid"
+          assert rest == ""
+        end)
+
+      assert log =~ "dropped a complete header block"
+      assert log =~ "Content-Length"
+    end
+
+    test "drops complete header block with invalid Content-Length and decodes following message" do
+      valid = IO.iodata_to_binary(JsonRpc.encode_notification("valid", %{}))
+      buffer = "Content-Length: nope\r\n\r\n" <> valid
+
+      log =
+        capture_log(fn ->
+          {[decoded], rest} = JsonRpc.decode(buffer)
+
+          assert decoded["method"] == "valid"
+          assert rest == ""
+        end)
+
+      assert log =~ "dropped a complete header block"
+      assert log =~ "Content-Length"
+    end
+
+    test "raises on malformed JSON bodies" do
+      buffer = "Content-Length: 1\r\n\r\n{"
+
+      assert_raise JSON.DecodeError, fn ->
+        JsonRpc.decode(buffer)
+      end
     end
 
     test "handles message followed by partial message" do


### PR DESCRIPTION
## Summary
- Drop complete LSP JSON-RPC header blocks that lack a valid `Content-Length` instead of buffering them forever.
- Log a warning when the decoder drops an invalid header block.
- Add regression coverage for missing and invalid `Content-Length` headers followed by valid messages, plus malformed JSON still raising.

## Tests
- `mix test.debug test/minga/lsp/json_rpc_test.exs`
- `make lint`
- `make native.support`
- `mix test.llm --max-cases 16`
- `git diff --check`

Fixes #2284

## Notes
- The final reviewer subagent timed out twice without returning a verdict, so I completed the acceptance self-check manually and included the validation evidence here.
