### PR TITLE
fix(buffer): record clear-line edit deltas

### DIFF
--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -1525,7 +1525,8 @@ defmodule Minga.Buffer.Process do
         {:reply, {:ok, ""}, state}
 
       {:edited, yanked, new_doc, delta} ->
-        {:reply, {:ok, yanked}, push_undo(state, new_doc, :user, delta) |> mark_dirty()}
+        {:reply, {:ok, yanked},
+         push_undo(state, new_doc, :user, delta) |> mark_dirty() |> record_edit(delta)}
     end
   end
 

--- a/test/minga/buffer/buffer_changed_event_test.exs
+++ b/test/minga/buffer/buffer_changed_event_test.exs
@@ -4,6 +4,8 @@ defmodule Minga.Buffer.BufferChangedEventTest do
   alias Minga.Buffer.EditDelta
   alias Minga.Buffer.EditSource
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Core.Decorations
+  alias Minga.Core.Face
   alias Minga.Events
   alias Minga.Events.BufferChangedEvent
 
@@ -94,6 +96,42 @@ defmodule Minga.Buffer.BufferChangedEventTest do
                         source: :user,
                         delta: %EditDelta{inserted_text: ""}
                       }}
+    end
+  end
+
+  describe "clear_line broadcasts delta" do
+    test "clear_line sends a deletion delta, records it for consumers, and adjusts decorations" do
+      buf = start_supervised!({BufferProcess, content: "one\ntwo\nthree"})
+
+      _id =
+        BufferProcess.add_virtual_text(buf, {1, 3},
+          segments: [{" note", Face.new(fg: 0xFF0000)}],
+          placement: :inline
+        )
+
+      assert {:ok, "two"} = BufferProcess.clear_line(buf, 1)
+
+      assert_receive {:minga_event, :buffer_changed,
+                      %BufferChangedEvent{
+                        buffer: ^buf,
+                        source: :user,
+                        delta: %EditDelta{inserted_text: ""} = delta
+                      }}
+
+      assert delta.start_byte == 4
+      assert delta.old_end_byte == 7
+      assert delta.new_end_byte == 4
+      assert delta.start_position == {1, 0}
+      assert delta.old_end_position == {1, 3}
+      assert delta.new_end_position == {1, 0}
+      assert {:ok, [^delta]} = BufferProcess.consume_edit_deltas(buf, :lsp)
+
+      assert [virtual_text] =
+               buf
+               |> BufferProcess.decorations()
+               |> Decorations.virtual_texts_for_line(1)
+
+      assert virtual_text.anchor == {1, 0}
     end
   end
 


### PR DESCRIPTION
# TL;DR
`Buffer.clear_line/2` now records its edit delta through the same pipeline as other user edits. This keeps LSP incremental sync, `:buffer_changed` subscribers, and decoration anchors in sync after line-clearing operators.

Closes #2291

## Context
Issue #2291 found that `clear_line` computed a valid delta but skipped `record_edit/2`, unlike neighboring buffer mutation handlers. That meant consumers relying on buffer edit events or the change log could silently miss the clear-line operation.

## Changes
- Pipe the `clear_line` edited branch through `record_edit(delta)` after undo and dirty-state updates.
- Add a regression test that verifies the `:buffer_changed` event carries the clear-line delta.
- Verify the same test path records the delta for `consume_edit_deltas/2` and adjusts a virtual text decoration anchor after the cleared text.

## Verification
- `mix test.debug test/minga/buffer/buffer_changed_event_test.exs:103`
- `mix test.debug test/minga/buffer/buffer_changed_event_test.exs`
- `mix test.llm test/minga/buffer`
- `make lint`
- `mix compile.minga_zig`
- `mix test.llm --max-cases 1`
- `git diff --check`
- Final reviewer: PASS

## Acceptance Criteria Addressed
- Clearing a line produces a `:buffer_changed` event carrying the edit delta ✅
- After clearing a line, the LSP change log contains the edit and decoration anchors after the cleared text are adjusted ✅
- A regression test asserts the broadcast and change-log entry for the clear-line operation ✅
- A sweep confirmed no other delta-producing `handle_call` in `buffer/process.ex` skips `record_edit` ✅
