### PR TITLE
fix(lsp): log buffer open failures

### DIFF
--- a/lib/minga/lsp/sync_server.ex
+++ b/lib/minga/lsp/sync_server.ex
@@ -271,9 +271,17 @@ defmodule Minga.LSP.SyncServer do
         end
     end
   rescue
-    _ -> state
+    exception ->
+      Minga.Log.warning(
+        :lsp,
+        "LSP buffer open failed: " <> Exception.format(:error, exception, __STACKTRACE__)
+      )
+
+      state
   catch
-    :exit, _ -> state
+    :exit, reason ->
+      Minga.Log.warning(:lsp, "LSP buffer open exited: #{inspect(reason)}")
+      state
   end
 
   @spec lsp_auto_start?() :: boolean()

--- a/test/minga/lsp/sync_server_test.exs
+++ b/test/minga/lsp/sync_server_test.exs
@@ -3,9 +3,14 @@ defmodule Minga.LSP.SyncServerTest do
   use ExUnit.Case, async: false
 
   alias Minga.Buffer.EditDelta
+  import ExUnit.CaptureLog
+
   alias Minga.Buffer.EditSource
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Events
+  alias Minga.Language
+  alias Minga.Language.Registry, as: LanguageRegistry
+  alias Minga.LSP.ServerConfig
   alias Minga.LSP.SyncServer
 
   @moduletag :tmp_dir
@@ -44,6 +49,27 @@ defmodule Minga.LSP.SyncServerTest do
       Events.broadcast(:buffer_opened, %Events.BufferEvent{buffer: buf, path: "/tmp/no_lsp.txt"})
       sync_server()
 
+      assert SyncServer.clients_for_buffer(buf) == []
+    end
+
+    test "buffer_opened logs open path exceptions and keeps SyncServer alive", %{tmp_dir: dir} do
+      Minga.Config.Options.set(:lsp_auto_start, true)
+      on_exit(fn -> Minga.Config.Options.set(:lsp_auto_start, false) end)
+      register_broken_lsp_language()
+
+      path = Path.join(dir, "boom.lspboom")
+      File.write!(path, "hello")
+      buf = start_buffer(file_path: path, filetype: :lsp_boom)
+
+      log =
+        capture_log(fn ->
+          Events.broadcast(:buffer_opened, %Events.BufferEvent{buffer: buf, path: path})
+          sync_server()
+        end)
+
+      assert log =~ "LSP buffer open failed"
+      assert log =~ "FunctionClauseError"
+      assert is_map(:sys.get_state(SyncServer))
       assert SyncServer.clients_for_buffer(buf) == []
     end
 
@@ -171,6 +197,21 @@ defmodule Minga.LSP.SyncServerTest do
       ref = Process.monitor(client)
       %{state | client_monitors: Map.put(state.client_monitors, ref, {buf, client})}
     end)
+  end
+
+  defp register_broken_lsp_language do
+    language = %Language{
+      name: :lsp_boom,
+      label: "Broken LSP",
+      comment_token: "#",
+      extensions: ["lspboom"],
+      language_servers: [
+        %ServerConfig{name: :broken_lsp, command: "broken-lsp", root_markers: nil}
+      ]
+    }
+
+    :ok = LanguageRegistry.register(language, {:extension, :sync_server_test})
+    on_exit(fn -> LanguageRegistry.unregister_source({:extension, :sync_server_test}) end)
   end
 
   defp sync_server do


### PR DESCRIPTION
# TL;DR
LSP buffer-open failures now leave a warning breadcrumb instead of disappearing silently. SyncServer still keeps the existing crash-safe behavior for dead buffer calls.

Closes #2285

## Context
Issue #2285 called out that the entire LSP buffer-open path could fail under a broad rescue or caught exit with no log output. That made common reports like "LSP never started for this file" hard to debug from the minga log.

## Changes
- Log rescued exceptions in `Minga.LSP.SyncServer` with `Minga.Log.warning(:lsp, ...)` and `Exception.format/3`.
- Log caught exits from the same hot path with the inspected exit reason.
- Keep both failure paths returning the existing SyncServer state so dead-buffer races remain non-crashing.
- Add a regression test that registers a deliberately broken LSP config, captures the warning, and verifies SyncServer remains alive.

## Verification
- `mix test.debug test/minga/lsp/sync_server_test.exs` passed, 10 tests.
- `make lint` passed.
- `mix compile.minga_zig` passed to build the parser artifact needed by integration tests.
- `mix test.llm test/minga_editor/integration/match_item_test.exs` passed after the parser build.
- `mix test.debug test/minga_agent/tools/subagent_receive_loop_test.exs` passed after an unrelated full-suite async timeout.
- `mix test.debug test/minga_editor/agent/ingest_test.exs` passed after unrelated full-suite async receive timeouts.
- `mix test.llm --max-cases 1` passed, 56 doctests, 94 properties, 9399 tests, 0 failures, 326 excluded.

## Acceptance Criteria Addressed
- When opening a buffer fails inside the LSP sync path, a warning naming the failure appears in the minga log. ✅
- Behavior is otherwise unchanged: a buffer pid dying mid-call still does not crash the SyncServer. ✅
- A test simulates a raising dependency in the open path and asserts a warning is logged and the SyncServer stays alive. ✅
