### PR TITLE
Fix count prefixes multiplying leader commands

### DIFF
--- a/lib/minga/mode.ex
+++ b/lib/minga/mode.ex
@@ -23,7 +23,8 @@ defmodule Minga.Mode do
 
   * `{:continue, state}` — no-op; remain in the same mode.
   * `{:transition, mode, state}` — switch to `mode`, no commands.
-  * `{:execute, command | [command], state}` — run commands, stay in same mode.
+  * `{:execute, command | [command], state}` — run commands, stay in same mode, and repeat them by the accumulated count.
+  * `{:execute, command | [command], state, count_policy}` — run commands with explicit count handling.
   * `{:execute_then_transition, [command], mode, state}` — run commands, then switch mode.
   """
 
@@ -78,14 +79,19 @@ defmodule Minga.Mode do
 
   * `{:continue, state}` — no-op.
   * `{:transition, mode, state}` — switch mode.
-  * `{:execute, command | [command], state}` — execute and stay.
+  * `{:execute, command | [command], state}` — execute and stay, repeating by the accumulated count.
+  * `{:execute, command | [command], state, count_policy}` — execute and stay with explicit count handling.
   * `{:execute_then_transition, [command], mode, state}` — execute then switch.
   """
   @type result ::
           {:continue, state()}
           | {:transition, mode(), state()}
           | {:execute, command() | [command()], state()}
+          | {:execute, command() | [command()], state(), count_policy()}
           | {:execute_then_transition, [command()], mode(), state()}
+
+  @typedoc "How an execute result handles an accumulated count prefix."
+  @type count_policy :: :repeat_count | :discard_count
 
   @typedoc "A key event: `{codepoint, modifiers}`."
   @type key :: {non_neg_integer(), non_neg_integer()}
@@ -228,14 +234,22 @@ defmodule Minga.Mode do
     {new_mode, [], reset_count(state)}
   end
 
-  defp apply_result(mode, {:execute, commands, state}) when is_list(commands) do
+  defp apply_result(mode, {:execute, commands, state}) do
+    apply_result(mode, {:execute, commands, state, :repeat_count})
+  end
+
+  defp apply_result(mode, {:execute, commands, state, :repeat_count}) when is_list(commands) do
     count = state.count || 1
     expanded = List.duplicate(commands, count) |> List.flatten()
     {mode, expanded, reset_count(state)}
   end
 
-  defp apply_result(mode, {:execute, command, state}) do
-    apply_result(mode, {:execute, [command], state})
+  defp apply_result(mode, {:execute, commands, state, :discard_count}) when is_list(commands) do
+    {mode, commands, reset_count(state)}
+  end
+
+  defp apply_result(mode, {:execute, command, state, count_policy}) do
+    apply_result(mode, {:execute, [command], state, count_policy})
   end
 
   defp apply_result(_mode, {:execute_then_transition, commands, new_mode, state}) do

--- a/lib/minga/mode/normal.ex
+++ b/lib/minga/mode/normal.ex
@@ -159,7 +159,7 @@ defmodule Minga.Mode.Normal do
   # SPC pressed while not in leader mode → start leader sequence.
   def handle_key({@space, 0}, %ModeState{leader_node: nil} = state) do
     new_state = %{state | leader_node: state.leader_trie, leader_keys: ["SPC"]}
-    {:execute, {:leader_start, state.leader_trie}, new_state}
+    execute_discarding_count({:leader_start, state.leader_trie}, new_state)
   end
 
   # SPC pressed while already in leader mode: if the current node has a
@@ -168,28 +168,28 @@ defmodule Minga.Mode.Normal do
     case Bindings.lookup(node, {@space, 0}) do
       {:command, command} ->
         new_state = %{state | leader_node: nil, leader_keys: []}
-        {:execute, [command, :leader_cancel], new_state}
+        execute_discarding_count([command, :leader_cancel], new_state)
 
       {:prefix, sub_node} ->
         formatted = Bindings.format_key({@space, 0})
         new_keys = [formatted | state.leader_keys]
         new_state = %{state | leader_node: sub_node, leader_keys: new_keys}
-        {:execute, {:leader_progress, sub_node}, new_state}
+        execute_discarding_count({:leader_progress, sub_node}, new_state)
 
       :not_found ->
         new_state = %{state | leader_node: state.leader_trie, leader_keys: ["SPC"]}
-        {:execute, [:leader_cancel, {:leader_start, state.leader_trie}], new_state}
+        execute_discarding_count([:leader_cancel, {:leader_start, state.leader_trie}], new_state)
     end
   end
 
   # Ctrl+D / Ctrl+U while in leader mode → paginate which-key popup.
   # These are intercepted before the trie walk so they don't cancel the leader sequence.
   def handle_key({?d, 0x02}, %ModeState{leader_node: node} = state) when is_map(node) do
-    {:execute, :whichkey_next_page, state}
+    execute_discarding_count(:whichkey_next_page, state)
   end
 
   def handle_key({?u, 0x02}, %ModeState{leader_node: node} = state) when is_map(node) do
-    {:execute, :whichkey_prev_page, state}
+    execute_discarding_count(:whichkey_prev_page, state)
   end
 
   # Any other key while in leader mode → walk the trie.
@@ -204,17 +204,17 @@ defmodule Minga.Mode.Normal do
             pending: nil
         }
 
-        {:execute, :leader_cancel, new_state}
+        execute_discarding_count(:leader_cancel, new_state)
 
       {:prefix, sub_node} ->
         formatted = Bindings.format_key(key)
         new_keys = [formatted | state.leader_keys]
         new_state = %{state | leader_node: sub_node, leader_keys: new_keys}
-        {:execute, {:leader_progress, sub_node}, new_state}
+        execute_discarding_count({:leader_progress, sub_node}, new_state)
 
       {:command, command} ->
         new_state = %{state | leader_node: nil, leader_keys: []}
-        {:execute, [command, :leader_cancel], new_state}
+        execute_discarding_count([command, :leader_cancel], new_state)
     end
   end
 
@@ -847,7 +847,18 @@ defmodule Minga.Mode.Normal do
      %Minga.Mode.OperatorPendingState{operator: :comment, op_count: count}}
   end
 
+  defp dispatch_prefix_command(:move_to_document_start, %ModeState{count: count} = state)
+       when is_integer(count) do
+    {:execute, {:goto_line, count}, %{state | count: nil}}
+  end
+
   defp dispatch_prefix_command(command, state) do
-    {:execute, command, state}
+    execute_discarding_count(command, state)
+  end
+
+  @spec execute_discarding_count(Mode.command() | [Mode.command()], ModeState.t()) ::
+          Mode.result()
+  defp execute_discarding_count(command_or_commands, state) do
+    {:execute, command_or_commands, state, :discard_count}
   end
 end

--- a/test/minga/mode/normal_bracket_nav_test.exs
+++ b/test/minga/mode/normal_bracket_nav_test.exs
@@ -22,14 +22,14 @@ defmodule Minga.Mode.NormalBracketNavTest do
     test "]f emits goto_next_textobject for :function" do
       state = press_bracket(:next)
 
-      assert {:execute, {:goto_next_textobject, :function}, _} =
+      assert {:execute, {:goto_next_textobject, :function}, _, :discard_count} =
                Normal.handle_key({?f, 0}, state)
     end
 
     test "[f emits goto_prev_textobject for :function" do
       state = press_bracket(:prev)
 
-      assert {:execute, {:goto_prev_textobject, :function}, _} =
+      assert {:execute, {:goto_prev_textobject, :function}, _, :discard_count} =
                Normal.handle_key({?f, 0}, state)
     end
   end
@@ -40,14 +40,14 @@ defmodule Minga.Mode.NormalBracketNavTest do
     test "]t emits goto_next_textobject for :class" do
       state = press_bracket(:next)
 
-      assert {:execute, {:goto_next_textobject, :class}, _} =
+      assert {:execute, {:goto_next_textobject, :class}, _, :discard_count} =
                Normal.handle_key({?t, 0}, state)
     end
 
     test "[t emits goto_prev_textobject for :class" do
       state = press_bracket(:prev)
 
-      assert {:execute, {:goto_prev_textobject, :class}, _} =
+      assert {:execute, {:goto_prev_textobject, :class}, _, :discard_count} =
                Normal.handle_key({?t, 0}, state)
     end
   end
@@ -58,14 +58,14 @@ defmodule Minga.Mode.NormalBracketNavTest do
     test "]a emits goto_next_textobject for :parameter" do
       state = press_bracket(:next)
 
-      assert {:execute, {:goto_next_textobject, :parameter}, _} =
+      assert {:execute, {:goto_next_textobject, :parameter}, _, :discard_count} =
                Normal.handle_key({?a, 0}, state)
     end
 
     test "[a emits goto_prev_textobject for :parameter" do
       state = press_bracket(:prev)
 
-      assert {:execute, {:goto_prev_textobject, :parameter}, _} =
+      assert {:execute, {:goto_prev_textobject, :parameter}, _, :discard_count} =
                Normal.handle_key({?a, 0}, state)
     end
   end
@@ -76,7 +76,7 @@ defmodule Minga.Mode.NormalBracketNavTest do
     test "prefix_node is cleared after successful dispatch" do
       state = press_bracket(:next)
 
-      {:execute, _, new_state} = Normal.handle_key({?f, 0}, state)
+      {:execute, _, new_state, :discard_count} = Normal.handle_key({?f, 0}, state)
       assert new_state.prefix_node == nil
     end
 
@@ -101,7 +101,7 @@ defmodule Minga.Mode.NormalBracketNavTest do
     test "]a emits goto_next_textobject :parameter" do
       state = press_bracket(:next)
 
-      assert {:execute, {:goto_next_textobject, :parameter}, _} =
+      assert {:execute, {:goto_next_textobject, :parameter}, _, :discard_count} =
                Normal.handle_key({?a, 0}, state)
     end
   end

--- a/test/minga/mode/normal_movement_dispatch_test.exs
+++ b/test/minga/mode/normal_movement_dispatch_test.exs
@@ -6,6 +6,7 @@ defmodule Minga.Mode.NormalMovementDispatchTest do
   """
   use ExUnit.Case, async: true
 
+  alias Minga.Keymap.Defaults
   alias Minga.Mode
 
   @ctrl 0x02
@@ -51,6 +52,35 @@ defmodule Minga.Mode.NormalMovementDispatchTest do
       assert Mode.process(:normal, {?j, 0}, state) ==
                {:normal, [:move_down, :move_down], Mode.initial_state()}
     end
+
+    test "count before a leader sequence is discarded instead of multiplying commands" do
+      {:normal, [], counted} = Mode.process(:normal, {?3, 0}, leader_state())
+      {:normal, leader_start_commands, leader} = Mode.process(:normal, {32, 0}, counted)
+      {:normal, progress_commands, leader} = Mode.process(:normal, {?w, 0}, leader)
+      {:normal, split_commands, finished} = Mode.process(:normal, {?v, 0}, leader)
+
+      assert match?([{:leader_start, _node}], leader_start_commands)
+      assert match?([{:leader_progress, _node}], progress_commands)
+      assert split_commands == [:split_vertical, :leader_cancel]
+      assert finished.count == nil
+      assert finished.leader_node == nil
+    end
+
+    test "count before a prefix-trie command is discarded instead of multiplying the command" do
+      {:normal, [], counted} = Mode.process(:normal, {?3, 0}, Mode.initial_state())
+      {:normal, [], prefix} = Mode.process(:normal, {?g, 0}, counted)
+
+      assert Mode.process(:normal, {?d, 0}, prefix) ==
+               {:normal, [:goto_definition], Mode.initial_state()}
+    end
+
+    test "gg consumes a count as a target line instead of repeating the prefix command" do
+      {:normal, [], counted} = Mode.process(:normal, {?5, 0}, Mode.initial_state())
+      {:normal, [], prefix} = Mode.process(:normal, {?g, 0}, counted)
+
+      assert Mode.process(:normal, {?g, 0}, prefix) ==
+               {:normal, [{:goto_line, 5}], Mode.initial_state()}
+    end
   end
 
   describe "Layer 0 pure key dispatch — page and viewport scroll commands" do
@@ -93,6 +123,10 @@ defmodule Minga.Mode.NormalMovementDispatchTest do
       assert_commands(?;, [:repeat_find_char])
       assert_commands(?,, [:repeat_find_char_reverse])
     end
+  end
+
+  defp leader_state do
+    %{Mode.initial_state() | leader_trie: Defaults.leader_trie()}
   end
 
   defp assert_commands(codepoint, expected_commands),

--- a/test/minga/mode/normal_test.exs
+++ b/test/minga/mode/normal_test.exs
@@ -153,16 +153,16 @@ defmodule Minga.Mode.NormalTest do
 
   describe "leader key sequences" do
     test "space starts leader mode, progress advances, and invalid keys cancel" do
-      {:execute, {:leader_start, node}, leader_state} = handle({32, 0})
+      {:execute, {:leader_start, node}, leader_state, :discard_count} = handle({32, 0})
       assert leader_state.leader_node == node
       assert leader_state.leader_keys == ["SPC"]
 
       case handle({?f, 0}, leader_state) do
-        {:execute, {:leader_progress, sub_node}, progressed} ->
+        {:execute, {:leader_progress, sub_node}, progressed, :discard_count} ->
           assert progressed.leader_node == sub_node
           assert "f" in progressed.leader_keys
 
-        {:execute, [_command, :leader_cancel], progressed} ->
+        {:execute, [_command, :leader_cancel], progressed, :discard_count} ->
           assert progressed.leader_node == nil
       end
 
@@ -173,7 +173,7 @@ defmodule Minga.Mode.NormalTest do
             {{27, 0}, nil, :replace}
           ] do
         state = leader_state |> Map.put(:count, count) |> Map.put(:pending, pending)
-        {:execute, :leader_cancel, cancelled} = handle(key, state)
+        {:execute, :leader_cancel, cancelled, :discard_count} = handle(key, state)
         assert cancelled.leader_node == nil
         assert cancelled.leader_keys == []
         assert cancelled.count == nil
@@ -181,8 +181,8 @@ defmodule Minga.Mode.NormalTest do
     end
 
     test "SPC SPC executes :project_find_file" do
-      {:execute, {:leader_start, _node}, leader_state} = handle({32, 0})
-      {:execute, commands, finished_state} = handle({32, 0}, leader_state)
+      {:execute, {:leader_start, _node}, leader_state, :discard_count} = handle({32, 0})
+      {:execute, commands, finished_state, :discard_count} = handle({32, 0}, leader_state)
       assert is_list(commands)
       assert :project_find_file in commands
       assert :leader_cancel in commands
@@ -191,11 +191,14 @@ defmodule Minga.Mode.NormalTest do
     end
 
     test "repeated space restarts leader when space is not bound at the current node" do
-      {:execute, {:leader_start, _node}, leader_state} = handle({32, 0})
-      {:execute, {:leader_progress, p_node}, p_state} = handle({?p, 0}, leader_state)
+      {:execute, {:leader_start, _node}, leader_state, :discard_count} = handle({32, 0})
+
+      {:execute, {:leader_progress, p_node}, p_state, :discard_count} =
+        handle({?p, 0}, leader_state)
+
       assert p_state.leader_node == p_node
 
-      {:execute, result, restarted} = handle({32, 0}, p_state)
+      {:execute, result, restarted, :discard_count} = handle({32, 0}, p_state)
       assert is_list(result)
       assert :leader_cancel in result
       assert restarted.leader_keys == ["SPC"]
@@ -209,7 +212,7 @@ defmodule Minga.Mode.NormalTest do
         fresh_state() |> Map.put(:leader_node, leader_trie) |> Map.put(:leader_keys, ["SPC"])
 
       for {key, command} <- [{{?d, 0x02}, :whichkey_next_page}, {{?u, 0x02}, :whichkey_prev_page}] do
-        {:execute, ^command, new_state} = handle(key, state)
+        {:execute, ^command, new_state, :discard_count} = handle(key, state)
         assert new_state.leader_node == leader_trie
         assert new_state.leader_keys == ["SPC"]
       end


### PR DESCRIPTION
# TL;DR
Counts no longer multiply leader or normal prefix-trie commands. A typo like `3 SPC w v` now runs one split, while count-aware motions and operators still behave normally.

Closes #2292

## Context
Issue #2292 identified that `Mode.apply_result/2` repeated every `{:execute, ...}` result by the accumulated normal-mode count. That is correct for motions like `3j`, but wrong for leader and most prefix-trie commands because it turns accidental counts into repeated side effects.

## Changes
- Added an explicit `count_policy` for mode execute results, preserving the existing repeat-by-count default for normal motion commands.
- Marked leader dispatch and non-count-consuming prefix-trie dispatch as `:discard_count`, so the command runs once and the count is cleared at the dispatch boundary.
- Kept count-consuming prefix behavior explicit: `gc` still carries the count into operator-pending mode, and counted `gg` now routes to `{:goto_line, count}` instead of repeating the prefix command.
- Updated direct normal-mode tests that inspect prefix-trie dispatch tuples to account for the explicit count policy.

## Verification
- `mix test.debug test/minga/mode/normal_bracket_nav_test.exs test/minga/mode/normal_movement_dispatch_test.exs test/minga/mode/normal_test.exs test/minga/mode/operator_pending_test.exs test/minga/editing/model/vim_test.exs` passed, 69 tests.
- `mix compile.minga_zig` passed, building parser binaries needed by parser-backed tests.
- `mix test.debug test/minga_editor/commands/match_bracket_command_test.exs test/minga_editor/commands/structural_navigation_test.exs` passed, 6 tests.
- `mix test.llm --max-cases 1` passed, 9401 tests, 94 properties, 56 doctests, 0 failures.
- `make lint` passed with exit 0. It reported only existing oversized-struct warnings in untouched files.
- `git diff --check` passed.

## Acceptance Criteria Addressed
- A count typed before a leader sequence is discarded: `3 SPC w v` splits exactly once. ✅
- A count typed before a prefix-trie command does not duplicate the command. ✅
- Counts still multiply motions and operators as before. ✅
- Regression tests cover a counted leader command and a counted prefix-trie command. ✅
