### PR TITLE
fix(lsp): convert diagnostic UTF-16 columns

### DIFF
--- a/lib/minga/core/position_encoding.ex
+++ b/lib/minga/core/position_encoding.ex
@@ -1,0 +1,113 @@
+defmodule Minga.Core.PositionEncoding do
+  @moduledoc """
+  Converts between byte-indexed positions and external text position encodings.
+
+  Minga stores positions as `{line, byte_col}` where `byte_col` is a byte offset within the line. Some external protocols, including LSP, use UTF-16 or UTF-32 character offsets instead. This module keeps that conversion pure so Layer 0 data structures can translate ranges without depending on stateful LSP services.
+  """
+
+  @typedoc "An external offset encoding for character positions."
+  @type encoding :: :utf8 | :utf16 | :utf32
+
+  @typedoc "A zero-indexed line and byte-column position."
+  @type position :: {line :: non_neg_integer(), col :: non_neg_integer()}
+
+  @doc """
+  Negotiates the best offset encoding from a supported list.
+
+  Prefers UTF-8, then UTF-16, then UTF-32. Falls back to UTF-16 when the server or external source does not advertise support.
+  """
+  @spec negotiate([String.t()]) :: encoding()
+  def negotiate(server_encodings) when is_list(server_encodings) do
+    preference = [:utf8, :utf16, :utf32]
+
+    normalized =
+      server_encodings
+      |> Enum.map(&normalize_encoding/1)
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+
+    Enum.find(preference, :utf16, fn enc -> MapSet.member?(normalized, enc) end)
+  end
+
+  @doc "Returns the supported encoding strings in client preference order."
+  @spec client_supported_encodings() :: [String.t()]
+  def client_supported_encodings do
+    ["utf-8", "utf-32", "utf-16"]
+  end
+
+  @doc "Converts a byte-column position to an external position map."
+  @spec to_lsp(position(), String.t(), encoding()) :: map()
+  def to_lsp({line, byte_col}, line_text, encoding)
+      when is_integer(line) and is_integer(byte_col) and is_binary(line_text) do
+    character = byte_col_to_lsp(byte_col, line_text, encoding)
+    %{"line" => line, "character" => character}
+  end
+
+  @doc "Converts an external position map back to a byte-column position."
+  @spec from_lsp(map(), String.t(), encoding()) :: position()
+  def from_lsp(%{"line" => line, "character" => character}, line_text, encoding)
+      when is_integer(line) and is_integer(character) and is_binary(line_text) do
+    byte_col = lsp_to_byte_col(character, line_text, encoding)
+    {line, byte_col}
+  end
+
+  @spec normalize_encoding(String.t()) :: encoding() | nil
+  defp normalize_encoding("utf-8"), do: :utf8
+  defp normalize_encoding("utf-16"), do: :utf16
+  defp normalize_encoding("utf-32"), do: :utf32
+  defp normalize_encoding(_), do: nil
+
+  @spec byte_col_to_lsp(non_neg_integer(), String.t(), encoding()) :: non_neg_integer()
+  defp byte_col_to_lsp(byte_col, _line_text, :utf8), do: byte_col
+
+  defp byte_col_to_lsp(byte_col, line_text, :utf32) do
+    safe_byte_col = min(byte_col, byte_size(line_text))
+    prefix = binary_part(line_text, 0, safe_byte_col)
+    String.length(prefix)
+  end
+
+  defp byte_col_to_lsp(byte_col, line_text, :utf16) do
+    safe_byte_col = min(byte_col, byte_size(line_text))
+    prefix = binary_part(line_text, 0, safe_byte_col)
+    count_utf16_code_units(prefix)
+  end
+
+  @spec lsp_to_byte_col(non_neg_integer(), String.t(), encoding()) :: non_neg_integer()
+  defp lsp_to_byte_col(character, _line_text, :utf8), do: character
+  defp lsp_to_byte_col(character, line_text, :utf32), do: walk_codepoints(line_text, character)
+
+  defp lsp_to_byte_col(character, line_text, :utf16),
+    do: walk_utf16_units(line_text, character, 0)
+
+  @spec count_utf16_code_units(binary()) :: non_neg_integer()
+  defp count_utf16_code_units(binary) do
+    binary
+    |> String.to_charlist()
+    |> Enum.reduce(0, fn codepoint, acc ->
+      acc + utf16_units_for_codepoint(codepoint)
+    end)
+  end
+
+  @spec utf16_units_for_codepoint(non_neg_integer()) :: 1 | 2
+  defp utf16_units_for_codepoint(cp) when cp <= 0xFFFF, do: 1
+  defp utf16_units_for_codepoint(_cp), do: 2
+
+  @spec walk_codepoints(binary(), non_neg_integer()) :: non_neg_integer()
+  defp walk_codepoints(_binary, 0), do: 0
+  defp walk_codepoints(<<>>, _remaining), do: 0
+
+  defp walk_codepoints(<<c::utf8, rest::binary>>, remaining) do
+    byte_size_of_char = byte_size(<<c::utf8>>)
+    byte_size_of_char + walk_codepoints(rest, remaining - 1)
+  end
+
+  @spec walk_utf16_units(binary(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp walk_utf16_units(_binary, 0, byte_offset), do: byte_offset
+  defp walk_utf16_units(<<>>, _remaining, byte_offset), do: byte_offset
+
+  defp walk_utf16_units(<<c::utf8, rest::binary>>, remaining, byte_offset) do
+    char_bytes = byte_size(<<c::utf8>>)
+    units = utf16_units_for_codepoint(c)
+    walk_utf16_units(rest, remaining - units, byte_offset + char_bytes)
+  end
+end

--- a/lib/minga/diagnostics/decorations.ex
+++ b/lib/minga/diagnostics/decorations.ex
@@ -42,11 +42,12 @@ defmodule Minga.Diagnostics.Decorations do
   def apply(buf_pid, uri, gutter_colors, diag_server \\ Diagnostics)
       when is_pid(buf_pid) and is_binary(uri) do
     diagnostics = Diagnostics.for_uri(diag_server, uri)
+    line_cache = line_cache(buf_pid, diagnostics)
 
     Buffer.batch_decorations(buf_pid, fn decs ->
       decs
       |> Decorations.remove_group(@diagnostic_group)
-      |> add_diagnostic_ranges(diagnostics, gutter_colors)
+      |> add_diagnostic_ranges(diagnostics, gutter_colors, line_cache)
     end)
   end
 
@@ -62,19 +63,29 @@ defmodule Minga.Diagnostics.Decorations do
 
   # ── Private ──────────────────────────────────────────────────────────
 
-  @spec add_diagnostic_ranges(Decorations.t(), [Diagnostic.t()], MingaEditor.UI.Theme.Gutter.t()) ::
-          Decorations.t()
-  defp add_diagnostic_ranges(decs, diagnostics, gutter_colors) do
+  @spec add_diagnostic_ranges(
+          Decorations.t(),
+          [Diagnostic.t()],
+          MingaEditor.UI.Theme.Gutter.t(),
+          %{non_neg_integer() => String.t()}
+        ) :: Decorations.t()
+  defp add_diagnostic_ranges(decs, diagnostics, gutter_colors, line_cache) do
     Enum.reduce(diagnostics, decs, fn diag, acc ->
-      add_one(acc, diag, gutter_colors)
+      add_one(acc, diag, gutter_colors, line_cache)
     end)
   end
 
-  @spec add_one(Decorations.t(), Diagnostic.t(), MingaEditor.UI.Theme.Gutter.t()) ::
-          Decorations.t()
-  defp add_one(decs, %Diagnostic{range: range} = diag, gutter_colors) do
-    start_pos = {range.start_line, range.start_col}
-    end_pos = {range.end_line, range.end_col}
+  @spec add_one(
+          Decorations.t(),
+          Diagnostic.t(),
+          MingaEditor.UI.Theme.Gutter.t(),
+          %{non_neg_integer() => String.t()}
+        ) :: Decorations.t()
+  defp add_one(decs, %Diagnostic{} = diag, gutter_colors, line_cache) do
+    start_text = Map.get(line_cache, diag.range.start_line, "")
+    end_text = Map.get(line_cache, diag.range.end_line, "")
+    start_pos = Diagnostic.start_position(diag, start_text)
+    end_pos = Diagnostic.end_position(diag, end_text)
 
     # Skip zero-width ranges (some LSP servers report point diagnostics)
     if start_pos == end_pos do
@@ -98,6 +109,22 @@ defmodule Minga.Diagnostics.Decorations do
         )
 
       decs
+    end
+  end
+
+  @spec line_cache(pid(), [Diagnostic.t()]) :: %{non_neg_integer() => String.t()}
+  defp line_cache(buf_pid, diagnostics) do
+    diagnostics
+    |> Enum.flat_map(fn diag -> [diag.range.start_line, diag.range.end_line] end)
+    |> Enum.uniq()
+    |> Map.new(fn line -> {line, line_text(buf_pid, line)} end)
+  end
+
+  @spec line_text(pid(), non_neg_integer()) :: String.t()
+  defp line_text(buf_pid, line) do
+    case Buffer.lines(buf_pid, line, 1) do
+      [text] -> text
+      _ -> ""
     end
   end
 

--- a/lib/minga/diagnostics/diagnostic.ex
+++ b/lib/minga/diagnostics/diagnostic.ex
@@ -7,13 +7,18 @@ defmodule Minga.Diagnostics.Diagnostic do
   (e.g., `"expert"`, `"mix_compile"`).
   """
 
+  alias Minga.Core.PositionEncoding
+
   @enforce_keys [:range, :severity, :message]
-  defstruct [:range, :severity, :message, :source, :code]
+  defstruct [:range, :severity, :message, :source, :code, encoding: :utf8]
 
   @typedoc "Severity level, ordered from most to least severe."
   @type severity :: :error | :warning | :info | :hint
 
-  @typedoc "A source location range (zero-indexed lines and byte columns)."
+  @typedoc "The LSP position encoding used by range columns."
+  @type encoding :: :utf8 | :utf16 | :utf32
+
+  @typedoc "A zero-indexed source location range. Columns are raw offsets in the diagnostic's encoding."
   @type range :: %{
           start_line: non_neg_integer(),
           start_col: non_neg_integer(),
@@ -21,13 +26,16 @@ defmodule Minga.Diagnostics.Diagnostic do
           end_col: non_neg_integer()
         }
 
+  @type position :: {line :: non_neg_integer(), col :: non_neg_integer()}
+
   @typedoc "A diagnostic entry."
   @type t :: %__MODULE__{
           range: range(),
           severity: severity(),
           message: String.t(),
           source: String.t() | nil,
-          code: String.t() | integer() | nil
+          code: String.t() | integer() | nil,
+          encoding: encoding()
         }
 
   @severity_rank %{error: 0, warning: 1, info: 2, hint: 3}
@@ -50,11 +58,29 @@ defmodule Minga.Diagnostics.Diagnostic do
     rank_a = Map.fetch!(@severity_rank, a)
     rank_b = Map.fetch!(@severity_rank, b)
 
-    cond do
-      rank_a < rank_b -> :lt
-      rank_a > rank_b -> :gt
-      true -> :eq
-    end
+    compare_rank(rank_a, rank_b)
+  end
+
+  @doc "Returns the diagnostic start position as a byte-column position for the given line text."
+  @spec start_position(t(), String.t()) :: position()
+  def start_position(%__MODULE__{} = diagnostic, line_text) when is_binary(line_text) do
+    position_to_byte(
+      diagnostic.range.start_line,
+      diagnostic.range.start_col,
+      line_text,
+      diagnostic.encoding
+    )
+  end
+
+  @doc "Returns the diagnostic end position as a byte-column position for the given line text."
+  @spec end_position(t(), String.t()) :: position()
+  def end_position(%__MODULE__{} = diagnostic, line_text) when is_binary(line_text) do
+    position_to_byte(
+      diagnostic.range.end_line,
+      diagnostic.range.end_col,
+      line_text,
+      diagnostic.encoding
+    )
   end
 
   @doc """
@@ -93,5 +119,18 @@ defmodule Minga.Diagnostics.Diagnostic do
         (a_line == b_line and a_col == b_col and
            compare_severity(a.severity, b.severity) == :lt)
     end)
+  end
+
+  @spec compare_rank(non_neg_integer(), non_neg_integer()) :: :lt | :eq | :gt
+  defp compare_rank(a, b) when a < b, do: :lt
+  defp compare_rank(a, b) when a > b, do: :gt
+  defp compare_rank(_a, _b), do: :eq
+
+  @spec position_to_byte(non_neg_integer(), non_neg_integer(), String.t(), encoding()) ::
+          position()
+  defp position_to_byte(line, col, _line_text, :utf8), do: {line, col}
+
+  defp position_to_byte(line, col, line_text, encoding) do
+    PositionEncoding.from_lsp(%{"line" => line, "character" => col}, line_text, encoding)
   end
 end

--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -908,10 +908,6 @@ defmodule Minga.LSP.Client do
     start_pos = Map.get(range, "start", %{"line" => 0, "character" => 0})
     end_pos = Map.get(range, "end", %{"line" => 0, "character" => 0})
 
-    # For position conversion we'd need the line text. For now, when using
-    # UTF-8 encoding the character offset equals byte offset. For UTF-16,
-    # we store the raw character offset — accurate conversion requires
-    # line text which will come from the buffer in the DocumentSync integration.
     start_line = Map.get(start_pos, "line", 0)
     start_col = Map.get(start_pos, "character", 0)
     end_line = Map.get(end_pos, "line", 0)
@@ -927,7 +923,8 @@ defmodule Minga.LSP.Client do
       severity: convert_severity(Map.get(raw, "severity", 1)),
       message: Map.get(raw, "message", ""),
       source: Map.get(raw, "source", to_string(state.server_config.name)),
-      code: convert_code(Map.get(raw, "code"))
+      code: convert_code(Map.get(raw, "code")),
+      encoding: state.encoding
     }
   end
 

--- a/lib/minga/lsp/position_encoding.ex
+++ b/lib/minga/lsp/position_encoding.ex
@@ -2,175 +2,33 @@ defmodule Minga.LSP.PositionEncoding do
   @moduledoc """
   Converts between Minga's byte-indexed positions and LSP positions.
 
-  LSP historically uses UTF-16 code unit offsets for character positions
-  (a legacy of the Java/TypeScript origins). Modern servers support UTF-8
-  offset encoding via capability negotiation (LSP 3.17+).
+  LSP historically uses UTF-16 code unit offsets for character positions, a legacy of the JavaScript/TypeScript origins. Modern servers support UTF-8 offset encoding via capability negotiation in LSP 3.17+.
 
-  Minga stores positions as `{line, byte_col}` where `byte_col` is a byte
-  offset within the line. When the negotiated encoding is UTF-8, conversion
-  is zero-cost (byte offset = UTF-8 offset). When UTF-16, we must count
-  UTF-16 code units, which is O(n) in the line length.
-
-  ## Negotiation
-
-  During `initialize`, the client advertises supported position encodings.
-  The server responds with its chosen encoding. We prefer UTF-8 (zero-cost
-  for Minga), falling back to UTF-32, then UTF-16.
+  The conversion implementation lives in `Minga.Core.PositionEncoding` so pure diagnostics and other Layer 0 modules can use the same rules without depending on LSP services.
   """
 
+  alias Minga.Core.PositionEncoding, as: CorePositionEncoding
+
   @typedoc "The negotiated offset encoding for a server session."
-  @type encoding :: :utf8 | :utf16 | :utf32
+  @type encoding :: CorePositionEncoding.encoding()
 
   @doc """
   Negotiates the best offset encoding from the server's supported list.
 
-  Prefers UTF-8 (zero-cost), then UTF-32 (codepoint = straightforward),
-  then UTF-16 (requires surrogate pair counting). Falls back to UTF-16
-  if the server doesn't advertise support (LSP spec default).
-
-  ## Examples
-
-      iex> Minga.LSP.PositionEncoding.negotiate(["utf-8", "utf-16"])
-      :utf8
-
-      iex> Minga.LSP.PositionEncoding.negotiate(["utf-16"])
-      :utf16
-
-      iex> Minga.LSP.PositionEncoding.negotiate([])
-      :utf16
+  Prefers UTF-8, then UTF-16, then UTF-32. Falls back to UTF-16 if the server does not advertise support.
   """
   @spec negotiate([String.t()]) :: encoding()
-  def negotiate(server_encodings) when is_list(server_encodings) do
-    preference = [:utf8, :utf16, :utf32]
+  defdelegate negotiate(server_encodings), to: CorePositionEncoding
 
-    normalized =
-      server_encodings
-      |> Enum.map(&normalize_encoding/1)
-      |> Enum.reject(&is_nil/1)
-      |> MapSet.new()
-
-    Enum.find(preference, :utf16, fn enc -> MapSet.member?(normalized, enc) end)
-  end
-
-  @doc """
-  Returns the LSP encoding string for capability advertisement.
-
-  ## Examples
-
-      iex> Minga.LSP.PositionEncoding.client_supported_encodings()
-      ["utf-8", "utf-32", "utf-16"]
-  """
+  @doc "Returns the LSP encoding strings for capability advertisement."
   @spec client_supported_encodings() :: [String.t()]
-  def client_supported_encodings do
-    ["utf-8", "utf-32", "utf-16"]
-  end
+  defdelegate client_supported_encodings, to: CorePositionEncoding
 
-  @doc """
-  Converts a Minga `{line, byte_col}` position to an LSP position map.
-
-  The `line_text` parameter is the content of the line (needed for UTF-16
-  conversion). For UTF-8 encoding, `byte_col` passes through directly.
-
-  ## Examples
-
-      iex> Minga.LSP.PositionEncoding.to_lsp({3, 10}, "hello world", :utf8)
-      %{"line" => 3, "character" => 10}
-  """
+  @doc "Converts a Minga `{line, byte_col}` position to an LSP position map."
   @spec to_lsp({non_neg_integer(), non_neg_integer()}, String.t(), encoding()) :: map()
-  def to_lsp({line, byte_col}, line_text, encoding)
-      when is_integer(line) and is_integer(byte_col) and is_binary(line_text) do
-    character = byte_col_to_lsp(byte_col, line_text, encoding)
-    %{"line" => line, "character" => character}
-  end
+  defdelegate to_lsp(position, line_text, encoding), to: CorePositionEncoding
 
-  @doc """
-  Converts an LSP position map back to a Minga `{line, byte_col}` tuple.
-
-  The `line_text` parameter is the content of the line (needed for UTF-16
-  conversion). For UTF-8 encoding, the character offset passes through.
-
-  ## Examples
-
-      iex> Minga.LSP.PositionEncoding.from_lsp(%{"line" => 3, "character" => 10}, "hello world", :utf8)
-      {3, 10}
-  """
+  @doc "Converts an LSP position map back to a Minga `{line, byte_col}` tuple."
   @spec from_lsp(map(), String.t(), encoding()) :: {non_neg_integer(), non_neg_integer()}
-  def from_lsp(%{"line" => line, "character" => character}, line_text, encoding)
-      when is_integer(line) and is_integer(character) and is_binary(line_text) do
-    byte_col = lsp_to_byte_col(character, line_text, encoding)
-    {line, byte_col}
-  end
-
-  # ── Private ────────────────────────────────────────────────────────────────
-
-  @spec normalize_encoding(String.t()) :: encoding() | nil
-  defp normalize_encoding("utf-8"), do: :utf8
-  defp normalize_encoding("utf-16"), do: :utf16
-  defp normalize_encoding("utf-32"), do: :utf32
-  defp normalize_encoding(_), do: nil
-
-  # UTF-8: byte_col IS the LSP character offset (zero cost)
-  @spec byte_col_to_lsp(non_neg_integer(), String.t(), encoding()) :: non_neg_integer()
-  defp byte_col_to_lsp(byte_col, _line_text, :utf8), do: byte_col
-
-  # UTF-32: count codepoints in the bytes before byte_col
-  defp byte_col_to_lsp(byte_col, line_text, :utf32) do
-    safe_byte_col = min(byte_col, byte_size(line_text))
-    prefix = binary_part(line_text, 0, safe_byte_col)
-    String.length(prefix)
-  end
-
-  # UTF-16: count UTF-16 code units in the bytes before byte_col
-  defp byte_col_to_lsp(byte_col, line_text, :utf16) do
-    safe_byte_col = min(byte_col, byte_size(line_text))
-    prefix = binary_part(line_text, 0, safe_byte_col)
-    count_utf16_code_units(prefix)
-  end
-
-  # UTF-8: LSP character offset IS byte_col
-  @spec lsp_to_byte_col(non_neg_integer(), String.t(), encoding()) :: non_neg_integer()
-  defp lsp_to_byte_col(character, _line_text, :utf8), do: character
-
-  # UTF-32: walk codepoints until we've consumed `character` of them
-  defp lsp_to_byte_col(character, line_text, :utf32) do
-    walk_codepoints(line_text, character)
-  end
-
-  # UTF-16: walk codepoints, counting UTF-16 code units, until consumed
-  defp lsp_to_byte_col(character, line_text, :utf16) do
-    walk_utf16_units(line_text, character, 0)
-  end
-
-  @spec count_utf16_code_units(binary()) :: non_neg_integer()
-  defp count_utf16_code_units(binary) do
-    binary
-    |> String.to_charlist()
-    |> Enum.reduce(0, fn codepoint, acc ->
-      acc + utf16_units_for_codepoint(codepoint)
-    end)
-  end
-
-  @spec utf16_units_for_codepoint(non_neg_integer()) :: 1 | 2
-  defp utf16_units_for_codepoint(cp) when cp <= 0xFFFF, do: 1
-  defp utf16_units_for_codepoint(_cp), do: 2
-
-  @spec walk_codepoints(binary(), non_neg_integer()) :: non_neg_integer()
-  defp walk_codepoints(_binary, 0), do: 0
-
-  defp walk_codepoints(<<>>, _remaining), do: 0
-
-  defp walk_codepoints(<<c::utf8, rest::binary>>, remaining) do
-    byte_size_of_char = byte_size(<<c::utf8>>)
-    byte_size_of_char + walk_codepoints(rest, remaining - 1)
-  end
-
-  @spec walk_utf16_units(binary(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
-  defp walk_utf16_units(_binary, 0, byte_offset), do: byte_offset
-  defp walk_utf16_units(<<>>, _remaining, byte_offset), do: byte_offset
-
-  defp walk_utf16_units(<<c::utf8, rest::binary>>, remaining, byte_offset) do
-    char_bytes = byte_size(<<c::utf8>>)
-    units = utf16_units_for_codepoint(c)
-    walk_utf16_units(rest, remaining - units, byte_offset + char_bytes)
-  end
+  defdelegate from_lsp(position, line_text, encoding), to: CorePositionEncoding
 end

--- a/lib/minga/render_model/window/diagnostic_range.ex
+++ b/lib/minga/render_model/window/diagnostic_range.ex
@@ -7,6 +7,8 @@ defmodule Minga.RenderModel.Window.DiagnosticRange do
   underline style and color.
   """
 
+  alias Minga.Diagnostics.Diagnostic
+
   @enforce_keys [:start_row, :start_col, :end_row, :end_col, :severity]
   defstruct start_row: 0,
             start_col: 0,
@@ -19,28 +21,49 @@ defmodule Minga.RenderModel.Window.DiagnosticRange do
           start_col: non_neg_integer(),
           end_row: non_neg_integer(),
           end_col: non_neg_integer(),
-          severity: Minga.Diagnostics.Diagnostic.severity()
+          severity: Diagnostic.severity()
         }
 
   @doc "Converts diagnostics to display-coordinate ranges for visible lines."
-  @spec from_diagnostics(
-          [Minga.Diagnostics.Diagnostic.t()],
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: [t()]
+  @spec from_diagnostics([Diagnostic.t()], non_neg_integer(), non_neg_integer()) :: [t()]
+  def from_diagnostics([], _viewport_top, _viewport_bottom), do: []
+
   def from_diagnostics(diagnostics, viewport_top, viewport_bottom) do
+    from_diagnostics(diagnostics, viewport_top, viewport_bottom, %{})
+  end
+
+  @doc "Converts diagnostics to display-coordinate ranges for visible lines using line text for encoded columns."
+  @spec from_diagnostics(
+          [Diagnostic.t()],
+          non_neg_integer(),
+          non_neg_integer(),
+          %{non_neg_integer() => String.t()}
+        ) :: [t()]
+  def from_diagnostics([], _viewport_top, _viewport_bottom, _line_texts), do: []
+
+  def from_diagnostics(diagnostics, viewport_top, viewport_bottom, line_texts) do
     diagnostics
     |> Enum.filter(fn %{range: r} ->
       r.start_line < viewport_bottom and r.end_line >= viewport_top
     end)
-    |> Enum.map(fn %{range: r, severity: severity} ->
-      %__MODULE__{
-        start_row: max(r.start_line - viewport_top, 0),
-        start_col: r.start_col,
-        end_row: max(r.end_line - viewport_top, 0),
-        end_col: r.end_col,
-        severity: severity
-      }
-    end)
+    |> Enum.map(&from_diagnostic(&1, viewport_top, line_texts))
+  end
+
+  @spec from_diagnostic(Diagnostic.t(), non_neg_integer(), %{non_neg_integer() => String.t()}) ::
+          t()
+  defp from_diagnostic(%Diagnostic{} = diag, viewport_top, line_texts) do
+    {start_line, start_col} =
+      Diagnostic.start_position(diag, Map.get(line_texts, diag.range.start_line, ""))
+
+    {end_line, end_col} =
+      Diagnostic.end_position(diag, Map.get(line_texts, diag.range.end_line, ""))
+
+    %__MODULE__{
+      start_row: max(start_line - viewport_top, 0),
+      start_col: start_col,
+      end_row: max(end_line - viewport_top, 0),
+      end_col: end_col,
+      severity: diag.severity
+    }
   end
 end

--- a/lib/minga_editor/commands/diagnostics.ex
+++ b/lib/minga_editor/commands/diagnostics.ex
@@ -10,6 +10,7 @@ defmodule MingaEditor.Commands.Diagnostics do
 
   alias Minga.Buffer
   alias Minga.Diagnostics
+  alias Minga.Diagnostics.Diagnostic
   alias MingaEditor.UI.Picker.Sources.Diagnostics, as: DiagPickerSource
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
@@ -89,9 +90,22 @@ defmodule MingaEditor.Commands.Diagnostics do
             EditorState.set_status(state, "No diagnostics")
 
           diag ->
-            Buffer.move_to(buf, {diag.range.start_line, diag.range.start_col})
+            Buffer.move_to(buf, start_position(diag, buf))
             EditorState.set_status(state, diag.message)
         end
+    end
+  end
+
+  @spec start_position(Diagnostic.t(), pid()) :: Diagnostic.position()
+  defp start_position(%Diagnostic{} = diag, buf) do
+    Diagnostic.start_position(diag, start_line_text(diag, buf))
+  end
+
+  @spec start_line_text(Diagnostic.t(), pid()) :: String.t()
+  defp start_line_text(%Diagnostic{} = diag, buf) do
+    case Buffer.lines(buf, diag.range.start_line, 1) do
+      [text] -> text
+      _ -> ""
     end
   end
 

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -25,6 +25,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
   alias Minga.Core.Unicode
   alias Minga.Core.WrapMap
   alias Minga.Diagnostics
+  alias Minga.Diagnostics.Diagnostic
   alias MingaEditor.DisplayMap
   alias MingaEditor.FoldMap
   alias MingaEditor.Layout
@@ -234,7 +235,9 @@ defmodule MingaEditor.RenderModel.Window.Builder do
         viewport,
         visible_row_count,
         visual_entries,
-        wrapped_coordinates?
+        wrapped_coordinates?,
+        lines,
+        first_line
       )
 
     # Document highlights in display coordinates
@@ -1882,32 +1885,77 @@ defmodule MingaEditor.RenderModel.Window.Builder do
           Viewport.t(),
           pos_integer(),
           [visual_row_entry()],
-          boolean()
+          boolean(),
+          [String.t()],
+          non_neg_integer()
         ) :: [DiagnosticRange.t()]
-  defp build_diagnostic_ranges(nil, _viewport, _visible_rows, _visual_entries, _wrapped?), do: []
+  defp build_diagnostic_ranges(
+         nil,
+         _viewport,
+         _visible_rows,
+         _visual_entries,
+         _wrapped?,
+         _lines,
+         _first_line
+       ),
+       do: []
 
-  defp build_diagnostic_ranges(path, viewport, visible_rows, visual_entries, wrapped?)
+  defp build_diagnostic_ranges(
+         path,
+         viewport,
+         visible_rows,
+         visual_entries,
+         wrapped?,
+         lines,
+         first_line
+       )
        when is_binary(path) do
     uri = SyncServer.path_to_uri(path)
-    diagnostics = Diagnostics.for_uri(uri)
-    viewport_bottom = viewport.top + visible_rows
 
-    if wrapped? do
-      Enum.flat_map(diagnostics, &diagnostic_to_wrapped_ranges(&1, visual_entries))
-    else
-      DiagnosticRange.from_diagnostics(diagnostics, viewport.top, viewport_bottom)
+    case Diagnostics.for_uri(uri) do
+      [] ->
+        []
+
+      diagnostics ->
+        viewport_bottom = viewport.top + visible_rows
+        line_cache = diagnostic_line_cache(diagnostics, lines, first_line)
+
+        if wrapped? do
+          Enum.flat_map(
+            diagnostics,
+            &diagnostic_to_wrapped_ranges(&1, visual_entries, line_cache)
+          )
+        else
+          DiagnosticRange.from_diagnostics(diagnostics, viewport.top, viewport_bottom, line_cache)
+        end
     end
   end
 
-  @spec diagnostic_to_wrapped_ranges(Diagnostics.Diagnostic.t(), [visual_row_entry()]) :: [
-          DiagnosticRange.t()
-        ]
-  defp diagnostic_to_wrapped_ranges(%{range: range, severity: severity}, visual_entries) do
+  @spec diagnostic_line_cache([Diagnostic.t()], [String.t()], non_neg_integer()) :: %{
+          non_neg_integer() => String.t()
+        }
+  defp diagnostic_line_cache(diagnostics, lines, first_line) do
+    diagnostics
+    |> Enum.flat_map(fn diag -> [diag.range.start_line, diag.range.end_line] end)
+    |> Enum.uniq()
+    |> Map.new(fn line -> {line, line_at(lines, line, first_line)} end)
+  end
+
+  @spec diagnostic_to_wrapped_ranges(Diagnostic.t(), [visual_row_entry()], %{
+          non_neg_integer() => String.t()
+        }) :: [DiagnosticRange.t()]
+  defp diagnostic_to_wrapped_ranges(%Diagnostic{} = diag, visual_entries, line_cache) do
+    {start_line, start_byte} =
+      Diagnostic.start_position(diag, Map.get(line_cache, diag.range.start_line, ""))
+
+    {end_line, end_byte} =
+      Diagnostic.end_position(diag, Map.get(line_cache, diag.range.end_line, ""))
+
     project_byte_range(
-      range.start_line,
-      range.start_col,
-      range.end_line,
-      range.end_col,
+      start_line,
+      start_byte,
+      end_line,
+      end_byte,
       visual_entries,
       fn start_row, start_col, end_row, end_col ->
         %DiagnosticRange{
@@ -1915,7 +1963,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
           start_col: start_col,
           end_row: end_row,
           end_col: end_col,
-          severity: severity
+          severity: diag.severity
         }
       end
     )

--- a/lib/minga_editor/ui/picker/sources/diagnostics.ex
+++ b/lib/minga_editor/ui/picker/sources/diagnostics.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.UI.Picker.Sources.Diagnostics do
 
   alias Minga.Buffer
   alias Minga.Diagnostics
+  alias Minga.Diagnostics.Diagnostic
   alias Minga.LSP.SyncServer
 
   @impl true
@@ -28,30 +29,46 @@ defmodule MingaEditor.UI.Picker.Sources.Diagnostics do
   def candidates(%{workspace: %{buffers: %{active: buf}}}) when is_pid(buf) do
     buf
     |> Buffer.file_path()
-    |> candidates_for_path()
+    |> candidates_for_path(buf)
   end
 
   def candidates(_state), do: []
 
-  @spec candidates_for_path(String.t() | nil) :: [Item.t()]
-  defp candidates_for_path(nil), do: []
+  @spec candidates_for_path(String.t() | nil, pid()) :: [Item.t()]
+  defp candidates_for_path(nil, _buf), do: []
 
-  defp candidates_for_path(path) do
+  defp candidates_for_path(path, buf) do
     path
     |> SyncServer.path_to_uri()
     |> Diagnostics.for_uri()
-    |> Enum.map(&format_candidate/1)
+    |> Enum.map(&format_candidate(&1, buf))
   end
 
-  @spec format_candidate(Diagnostics.Diagnostic.t()) :: Item.t()
-  defp format_candidate(diag) do
+  @spec format_candidate(Diagnostic.t(), pid()) :: Item.t()
+  defp format_candidate(diag, buf) do
+    {line, byte_col} = start_position(diag, buf)
     icon = severity_icon(diag.severity)
-    line = diag.range.start_line + 1
-    col = diag.range.start_col + 1
+    display_line = line + 1
+    display_col = byte_col + 1
     source_tag = if diag.source, do: " (#{diag.source})", else: ""
-    label = "#{icon} #{line}:#{col}  #{diag.message}#{source_tag}"
+    label = "#{icon} #{display_line}:#{display_col}  #{diag.message}#{source_tag}"
 
-    %Item{id: {diag.range.start_line, diag.range.start_col}, label: label}
+    %Item{id: {line, byte_col}, label: label}
+  end
+
+  @spec start_position(Diagnostic.t(), pid()) :: Diagnostic.position()
+  defp start_position(%Diagnostic{} = diag, buf) do
+    diag
+    |> start_line_text(buf)
+    |> then(&Diagnostic.start_position(diag, &1))
+  end
+
+  @spec start_line_text(Diagnostic.t(), pid()) :: String.t()
+  defp start_line_text(%Diagnostic{} = diag, buf) do
+    case Buffer.lines(buf, diag.range.start_line, 1) do
+      [text] -> text
+      _ -> ""
+    end
   end
 
   @impl true

--- a/test/minga/diagnostics/decorations_test.exs
+++ b/test/minga/diagnostics/decorations_test.exs
@@ -17,7 +17,7 @@ defmodule Minga.Diagnostics.DecorationsTest do
     fold_fg: 0x5B6268
   }
 
-  defp make_diagnostic(severity, start_line, start_col, end_line, end_col) do
+  defp make_diagnostic(severity, start_line, start_col, end_line, end_col, opts \\ []) do
     %Diagnostic{
       range: %{
         start_line: start_line,
@@ -26,7 +26,8 @@ defmodule Minga.Diagnostics.DecorationsTest do
         end_col: end_col
       },
       severity: severity,
-      message: "test #{severity}"
+      message: "test #{severity}",
+      encoding: Keyword.get(opts, :encoding, :utf8)
     }
   end
 
@@ -76,6 +77,44 @@ defmodule Minga.Diagnostics.DecorationsTest do
       decs = BufferProcess.decorations(pid)
       ranges = Decorations.highlights_for_line(decs, 0)
       assert length(ranges) == 2
+    end
+
+    test "UTF-16 diagnostics convert to byte-accurate decoration columns", ctx do
+      {:ok, pid} = BufferProcess.start_link(content: "\"héllo wörld\" <> undefined_var")
+      uri = "file:///test/utf16.ex"
+
+      Diagnostics.publish(ctx.diag_name, :test, uri, [
+        make_diagnostic(:error, 0, 17, 0, 30, encoding: :utf16)
+      ])
+
+      DiagDecorations.apply(pid, uri, @gutter_colors, ctx.diag_name)
+
+      [range] =
+        pid
+        |> BufferProcess.decorations()
+        |> Decorations.highlights_for_line(0)
+
+      assert range.start == {0, 19}
+      assert range.end_ == {0, 32}
+    end
+
+    test "UTF-8 diagnostics keep raw decoration columns", ctx do
+      {:ok, pid} = BufferProcess.start_link(content: "\"héllo wörld\" <> undefined_var")
+      uri = "file:///test/utf8.ex"
+
+      Diagnostics.publish(ctx.diag_name, :test, uri, [
+        make_diagnostic(:error, 0, 19, 0, 32, encoding: :utf8)
+      ])
+
+      DiagDecorations.apply(pid, uri, @gutter_colors, ctx.diag_name)
+
+      [range] =
+        pid
+        |> BufferProcess.decorations()
+        |> Decorations.highlights_for_line(0)
+
+      assert range.start == {0, 19}
+      assert range.end_ == {0, 32}
     end
 
     test "zero-width diagnostic is skipped", ctx do

--- a/test/minga/diagnostics/diagnostic_test.exs
+++ b/test/minga/diagnostics/diagnostic_test.exs
@@ -9,7 +9,8 @@ defmodule Minga.Diagnostics.DiagnosticTest do
       severity: Keyword.get(opts, :severity, :error),
       message: Keyword.get(opts, :message, "something went wrong"),
       source: Keyword.get(opts, :source, "test"),
-      code: Keyword.get(opts, :code, nil)
+      code: Keyword.get(opts, :code, nil),
+      encoding: Keyword.get(opts, :encoding, :utf8)
     }
   end
 
@@ -34,6 +35,27 @@ defmodule Minga.Diagnostics.DiagnosticTest do
     test "less severe returns :gt" do
       assert Diagnostic.compare_severity(:hint, :error) == :gt
       assert Diagnostic.compare_severity(:info, :warning) == :gt
+    end
+  end
+
+  describe "position conversion" do
+    test "defaults to UTF-8 byte columns" do
+      diag = make_diag(range: %{start_line: 0, start_col: 19, end_line: 0, end_col: 32})
+
+      assert diag.encoding == :utf8
+      assert Diagnostic.start_position(diag, "\"héllo wörld\" <> undefined_var") == {0, 19}
+      assert Diagnostic.end_position(diag, "\"héllo wörld\" <> undefined_var") == {0, 32}
+    end
+
+    test "converts UTF-16 offsets to byte columns" do
+      diag =
+        make_diag(
+          range: %{start_line: 0, start_col: 17, end_line: 0, end_col: 30},
+          encoding: :utf16
+        )
+
+      assert Diagnostic.start_position(diag, "\"héllo wörld\" <> undefined_var") == {0, 19}
+      assert Diagnostic.end_position(diag, "\"héllo wörld\" <> undefined_var") == {0, 32}
     end
   end
 

--- a/test/minga/lsp/client_test.exs
+++ b/test/minga/lsp/client_test.exs
@@ -20,6 +20,7 @@ defmodule Minga.LSP.ClientTest do
       MockLSPServer.server_config(
         request_configuration: Map.get(context, :request_configuration, false),
         request_unknown: Map.get(context, :request_unknown, false),
+        position_encoding: Map.get(context, :position_encoding, "utf-8"),
         settings: server_settings
       )
 
@@ -95,6 +96,26 @@ defmodule Minga.LSP.ClientTest do
       assert diag.code == "W001"
       assert diag.range.start_line == 0
       assert diag.range.start_col == 0
+    end
+
+    @tag position_encoding: "utf-16"
+    test "didOpen stores diagnostics with the negotiated UTF-16 encoding", %{
+      client: client,
+      diag_server: diag_server
+    } do
+      Minga.Events.subscribe(:diagnostics_updated)
+
+      Client.did_open(client, @uri, "elixir", "\"héllo wörld\" <> undefined_var\n")
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: @uri}},
+                     @event_timeout
+
+      assert Client.encoding(client) == :utf16
+      assert [diag] = Diagnostics.for_uri(diag_server, @uri)
+      assert diag.encoding == :utf16
+      assert diag.range.start_col == 0
+      assert diag.range.end_col == 5
     end
 
     test "didOpen during startup is sent once the client becomes ready", %{

--- a/test/minga/render_model/window/diagnostic_range_test.exs
+++ b/test/minga/render_model/window/diagnostic_range_test.exs
@@ -1,0 +1,39 @@
+defmodule Minga.RenderModel.Window.DiagnosticRangeTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Diagnostics.Diagnostic
+  alias Minga.RenderModel.Window.DiagnosticRange
+
+  describe "from_diagnostics/4" do
+    test "converts UTF-16 diagnostic columns to byte columns" do
+      diagnostic = diagnostic(:utf16, 17, 30)
+      line_texts = %{0 => "\"héllo wörld\" <> undefined_var"}
+
+      assert [range] = DiagnosticRange.from_diagnostics([diagnostic], 0, 1, line_texts)
+      assert range.start_row == 0
+      assert range.start_col == 19
+      assert range.end_row == 0
+      assert range.end_col == 32
+      assert range.severity == :error
+    end
+
+    test "keeps UTF-8 diagnostic columns unchanged" do
+      diagnostic = diagnostic(:utf8, 19, 32)
+      line_texts = %{0 => "\"héllo wörld\" <> undefined_var"}
+
+      assert [range] = DiagnosticRange.from_diagnostics([diagnostic], 0, 1, line_texts)
+      assert range.start_col == 19
+      assert range.end_col == 32
+    end
+  end
+
+  @spec diagnostic(Diagnostic.encoding(), non_neg_integer(), non_neg_integer()) :: Diagnostic.t()
+  defp diagnostic(encoding, start_col, end_col) do
+    %Diagnostic{
+      range: %{start_line: 0, start_col: start_col, end_line: 0, end_col: end_col},
+      severity: :error,
+      message: "undefined variable",
+      encoding: encoding
+    }
+  end
+end

--- a/test/support/mock_lsp_server.ex
+++ b/test/support/mock_lsp_server.ex
@@ -28,6 +28,7 @@ defmodule Minga.Test.MockLSPServer do
           {:request_configuration, boolean()}
           | {:request_unknown, boolean()}
           | {:stderr_banner, boolean()}
+          | {:position_encoding, String.t()}
           | {:settings, map()}
 
   @doc """
@@ -41,7 +42,8 @@ defmodule Minga.Test.MockLSPServer do
       [
         {Keyword.get(opts, :request_configuration, false), "--request-configuration"},
         {Keyword.get(opts, :request_unknown, false), "--request-unknown"},
-        {Keyword.get(opts, :stderr_banner, false), "--stderr-banner"}
+        {Keyword.get(opts, :stderr_banner, false), "--stderr-banner"},
+        {true, "--position-encoding=#{Keyword.get(opts, :position_encoding, "utf-8")}"}
       ]
       |> Enum.flat_map(fn
         {true, arg} -> [arg]

--- a/test/support/mock_lsp_server_script.exs
+++ b/test/support/mock_lsp_server_script.exs
@@ -73,7 +73,7 @@ defmodule MockServer do
   defp handle_message(%{"method" => "initialize", "id" => id}) do
     result = %{
       "capabilities" => %{
-        "positionEncoding" => "utf-8",
+        "positionEncoding" => position_encoding(),
         "textDocumentSync" => %{
           "openClose" => true,
           "change" => 1,
@@ -200,6 +200,13 @@ defmodule MockServer do
 
   defp stderr_banner? do
     "--stderr-banner" in System.argv()
+  end
+
+  defp position_encoding do
+    Enum.find_value(System.argv(), "utf-8", fn
+      "--position-encoding=" <> encoding -> encoding
+      _ -> nil
+    end)
   end
 
   defp send_test_diagnostic(uri, code, message) do


### PR DESCRIPTION
# TL;DR
Diagnostics from UTF-16 LSP servers now render at the correct byte columns on lines with non-ASCII text. This fixes misplaced underlines, diagnostic jumps, picker locations, and semantic GUI diagnostic ranges for files containing accented text, emoji, or CJK before the diagnostic span.

Closes #2283

## Context
LSP servers default to UTF-16 position encoding unless they negotiate another encoding. Minga stored diagnostic ranges with raw LSP character offsets but later treated those columns as byte columns, which shifted underlines left on lines like `"héllo wörld" <> undefined_var`.

## Changes
- Added pure `Minga.Core.PositionEncoding` conversion helpers so Layer 0 diagnostics can convert UTF-8, UTF-16, and UTF-32 offsets without depending on LSP services.
- Stored the negotiated encoding on `Minga.Diagnostics.Diagnostic` when LSP diagnostics are converted.
- Converted diagnostic ranges to byte columns before creating buffer decorations, diagnostic navigation targets, picker entries, and semantic GUI diagnostic ranges.
- Kept `Minga.LSP.PositionEncoding` as the LSP-facing delegate so existing LSP call sites keep the same API.
- Extended the mock LSP server so client tests can negotiate UTF-16.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.llm test/minga/diagnostics test/minga/render_model/window/diagnostic_range_test.exs test/minga_editor/render_model/window/builder_test.exs test/minga/lsp/semantic_tokens_test.exs`
- `mix test.debug test/minga/lsp/client_test.exs --include heavy`
- `mix test.debug test/minga_agent/session_manager_test.exs:331`
- `make lint`
- `mix test.llm` (PASS: 56 doctests, 94 properties, 9404 tests, 0 failures, 327 excluded)
- Final reviewer gate: PASS

## Acceptance Criteria Addressed
- A diagnostic on a line with multi-byte characters underlines exactly the span the server reported for UTF-16 position encoding ✅
- Servers that negotiate UTF-8 keep current behavior ✅
- Regression coverage publishes or converts a UTF-16 diagnostic on a line like `"héllo wörld"` and asserts byte-accurate decoration columns ✅
