### PR TITLE
feat(layout): footer overlays are registry-placed with click containment

### DIFF
--- a/go/tui/internal/ui/frame.go
+++ b/go/tui/internal/ui/frame.go
@@ -11,6 +11,12 @@ func (m Model) composeFrame(content string) string {
 		lipgloss.NewLayer(m.windowBackground()).X(0).Y(0).Z(0),
 		lipgloss.NewLayer(content).X(0).Y(0).Z(1),
 	}
+	// The single active secondary overlay is composited at its BEAM placement
+	// rect (#2281), below the picker/which-key floating layers but above the base
+	// content, instead of being footer-appended into the vertical layout.
+	if overlay := m.overlayLayer(); overlay != nil {
+		layers = append(layers, overlay)
+	}
 	if which := m.floatingWhichKeyLayer(); which != nil {
 		layers = append(layers, which)
 	}

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -928,13 +928,21 @@ func TestAgentChatVisibleRendersAsMainBody(t *testing.T) {
 }
 
 func TestOverlayLinesRenderRemainingSemanticSurfaces(t *testing.T) {
+	// Every overlay surface is registry-placed now (#2281): a surface renders only
+	// when the BEAM emits its placement, so each case provides one.
 	model := New(60, 12, nil)
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentContext: {AgentContext: protocol.AgentContext{Visible: true, Task: "Review diff", Status: 1, CanApprove: true}}}
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDAgentContext, Z: 260, HitKind: 8},
+	}
 	if got := strings.Join(model.overlayLines(), "\n"); !strings.Contains(got, "Review diff") {
 		t.Fatalf("agent context overlay missing content: %q", got)
 	}
 
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiToolManager: {ToolManager: protocol.ToolManager{Visible: true, Tools: []protocol.ToolSummary{{Name: "elixir-ls", Label: "Elixir LS", Status: 1}}}}}
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDToolManager, Z: 240, HitKind: 8},
+	}
 	if got := strings.Join(model.overlayLines(), "\n"); !strings.Contains(got, "Elixir LS") || !strings.Contains(got, "installed") {
 		t.Fatalf("tool manager overlay missing content: %q", got)
 	}
@@ -1351,6 +1359,12 @@ func TestSemanticMouseRoutesCompletionItemZones(t *testing.T) {
 			{Label: "beta", Detail: "fn"},
 		}}},
 	}
+	// The completion overlay is registry-placed now (#2281): it renders at its
+	// BEAM placement rect, and its zones are scanned from there. Place it at the
+	// bottom band where it historically rendered.
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDCompletionMenu, Rect: generated.Rect{Row: 12, Col: 0, Width: 60, Height: 4}, Z: 301, HitKind: 8},
+	}
 	model.viewport.SetContent(model.content())
 	_ = model.View()
 
@@ -1396,6 +1410,11 @@ func TestSemanticMouseRoutesHoverActionZone(t *testing.T) {
 	model.chrome = map[byte]protocol.ChromePayload{
 		generated.OPGuiHoverPopup:  {Hover: protocol.HoverPopup{Visible: true, Lines: []protocol.RichLine{{Segments: []protocol.RichSegment{{Text: "doc"}}}}}},
 		generated.OPGuiHoverAction: {HoverAction: protocol.HoverAction{Visible: true, Name: "Open documentation"}},
+	}
+	// The hover popup is registry-placed now (#2281): it renders at its BEAM
+	// placement rect and its hover-action zone is scanned from there.
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDHoverPopup, Rect: generated.Rect{Row: 12, Col: 0, Width: 60, Height: 4}, Z: 290, HitKind: 8},
 	}
 	model.viewport.SetContent(model.content())
 	_ = model.View()
@@ -1499,6 +1518,13 @@ func bottomPanelTestModel(messageCount int, out chan<- []byte) (Model, protocol.
 	}
 	panel := protocol.BottomPanel{Visible: true, ActiveTab: 0, Tabs: []protocol.PanelTab{{Type: 0x01, Name: "Messages"}}, Messages: messages}
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiBottomPanel: {Opcode: generated.OPGuiBottomPanel, Bottom: panel}}
+	// The bottom panel is registry-placed now (#2281): it renders and hit-tests by
+	// its BEAM placement rect (bottom band, full width). Place it where
+	// bottomPanelHeight computes its band so local scroll routing matches.
+	height := model.bottomPanelHeight(panel)
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDBottomPanel, Rect: generated.Rect{Row: uint16(model.height - height), Col: 0, Width: uint16(model.width), Height: uint16(height)}, Z: 200, HitKind: 7},
+	}
 	return model, panel
 }
 

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -183,12 +183,15 @@ func (m Model) footerLines() []string {
 	lines := []string{
 		lipgloss.NewStyle().Foreground(m.palette().Muted()).Background(m.palette().Base()).Width(m.width).Render(fitStyled(status, m.width)),
 	}
+	// The single active secondary overlay is no longer footer-appended here: it is
+	// composited at its BEAM placement rect by overlayLayer (#2281). The footer
+	// still carries the minibuffer when no full overlay is active so the prompt
+	// line stays in the vertical layout.
 	if !m.pickerVisible() && !m.whichKeyVisible() && !m.agentChatVisible() {
-		overlay := m.overlayLines()
-		if len(overlay) > 0 {
-			lines = append(lines, overlay...)
-		} else if mini, ok := m.minibuffer(); ok && mini.Visible {
-			lines = append(lines, m.renderMinibuffer(mini))
+		if _, active := m.overlayWinner(); !active {
+			if mini, ok := m.minibuffer(); ok && mini.Visible {
+				lines = append(lines, m.renderMinibuffer(mini))
+			}
 		}
 	}
 	return lines

--- a/go/tui/internal/ui/render_surfaces.go
+++ b/go/tui/internal/ui/render_surfaces.go
@@ -7,75 +7,166 @@ import (
 
 	"charm.land/bubbles/v2/table"
 	"charm.land/lipgloss/v2"
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/jsmestad/minga/go/tui/internal/generated"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
 )
 
+// overlayLayer returns the single active overlay positioned at its BEAM
+// placement rect, or nil when no overlay is active this frame. This replaces the
+// old footer-append: instead of joining the overlay's lines into the bottom of
+// the vertical layout, the winning overlay is composited as its own lipgloss
+// layer at the X/Y the BEAM emitted (the same rect BEAM mouse hit-testing routes
+// against), via the NewLayer path the picker overlay already proves. The Z is
+// taken from the placement so the layer sits above the base content. When the
+// winning surface has no placement rect this frame the overlay does not render
+// (no silent fallback position).
+func (m Model) overlayLayer() *lipgloss.Layer {
+	winner, ok := m.overlayWinner()
+	if !ok {
+		return nil
+	}
+	rect, ok := m.surfacePlacementFor(winner.surfaceID)
+	if !ok {
+		return nil
+	}
+	lines := winner.render()
+	// Trim trailing blank lines so a short overlay (a 1-2 line notification, a
+	// 2-line float popup) carries only its real content. The charm list/table
+	// renderers pad their output to the requested height with blank rows at the
+	// BOTTOM; the string-built renderers emit no padding. Trimming here makes the
+	// compositing uniform: every footer overlay is exactly its content tall (#2281).
+	lines = trimTrailingBlankLines(lines)
+	// Cap the content to the band height so it can never paint outside the BEAM
+	// rect the hit-tester routes against. takeLines keeps the TOP rows (the title
+	// and the first items), the same rows the old footer-append showed.
+	lines = takeLines(lines, int(rect.Height))
+	if len(lines) == 0 {
+		return nil
+	}
+	// Bottom-align the content inside the band rect: the rect is bottom-anchored
+	// (its bottom edge sits directly above the minibuffer, where the old footer-
+	// append put the overlay), so a shorter content block is pinned to the rect's
+	// bottom rows rather than its top. For the count-derivable surfaces the BEAM
+	// already sizes the rect to the content, so this offset is ~0; for the wrap-
+	// dependent surfaces it pushes the content down to the bottom and leaves the
+	// residual phantom zone ABOVE the content (documented in FooterOverlays).
+	y := int(rect.Row) + int(rect.Height) - len(lines)
+	if y < int(rect.Row) {
+		y = int(rect.Row)
+	}
+	// Scan the overlay's content for zone markers and merge them into the frame's
+	// zone map at the placement offset, so chrome zone routing (completion items,
+	// hover action) keeps working even though the overlay is composited as its own
+	// layer instead of footer-appended (#2281). ScanInto returns the marker-
+	// stripped content for compositing; zones are offset by the bottom-aligned Y.
+	content := m.zones.ScanInto(strings.Join(lines, "\n"), int(rect.Col), y)
+	// Z is offset above the base content/window layers (Z 0 and 1 in composeFrame)
+	// while staying below the picker/which-key floating layers; the placement z is
+	// a large band value (150..301), so add the base offset to keep it on top of
+	// content without colliding with the Z=0/1 base layers.
+	return lipgloss.NewLayer(content).X(int(rect.Col)).Y(y).Z(int(winner.order) + 2)
+}
+
+// trimTrailingBlankLines drops trailing lines whose visible content (ANSI escapes
+// stripped) is empty or whitespace. The charm list/table overlay renderers pad to
+// a fixed height with blank rows at the bottom; trimming them lets overlayLayer
+// bottom-align only the real content so a short overlay hugs the screen bottom
+// (#2281). A fully blank slice trims to empty (the caller drops the layer).
+func trimTrailingBlankLines(lines []string) []string {
+	end := len(lines)
+	for end > 0 && strings.TrimSpace(xansi.Strip(lines[end-1])) == "" {
+		end--
+	}
+	return lines[:end]
+}
+
 // Registry surface ids (mirror MingaEditor.Layout.SurfaceRegistry.surface_id_u16/1).
-// Only the overlay surfaces the BEAM registry actually places are listed here.
-// #2281 promoted the two cursor-anchored popups (hover, signature help) whose
-// rect the BEAM authoritatively computes; the remaining overlay candidates have
-// no BEAM rect source and stay transitional (see overlayCandidates).
+// Every overlay surface is now BEAM registry-placed: #2281 promoted the eight
+// footer-band secondary overlays (float popup through extension overlay) so the
+// BEAM owns their geometry and z, alongside the earlier cursor-anchored popups
+// (hover, signature help) and the completion/bottom-panel surfaces. There is no
+// transitional fallback table any more; ordering and positioning are placement
+// data end to end (see overlayCandidates / overlayLayer).
 const (
-	surfaceIDBottomPanel    uint16 = 12
-	surfaceIDCompletionMenu uint16 = 16
-	surfaceIDHoverPopup     uint16 = 17
-	surfaceIDSignatureHelp  uint16 = 18
+	surfaceIDBottomPanel      uint16 = 12
+	surfaceIDCompletionMenu   uint16 = 16
+	surfaceIDHoverPopup       uint16 = 17
+	surfaceIDSignatureHelp    uint16 = 18
+	surfaceIDFloatPopup       uint16 = 19
+	surfaceIDAgentContext     uint16 = 20
+	surfaceIDToolManager      uint16 = 21
+	surfaceIDExtensionPanel   uint16 = 22
+	surfaceIDObservatory      uint16 = 23
+	surfaceIDEditTimeline     uint16 = 24
+	surfaceIDNotifications    uint16 = 25
+	surfaceIDExtensionOverlay uint16 = 26
 )
 
 // overlayCandidate is one floating surface that may occupy the single active
-// overlay slot. order is its stacking key on one comparable z-band scale: lower
-// paints further back, so the HIGHEST-order visible candidate wins. For surfaces
-// the BEAM registry places, order is the BEAM-authoritative placement z (data,
-// looked up by surfaceID). For not-yet-promoted surfaces it is a transitional
-// order derived from the same registry z bands at its old relative position, so
-// the two are directly comparable. Either way the precedence is no longer a
-// hardcoded if-ladder: it is sorted data.
+// overlay slot. surfaceID is the surface's BEAM registry id; order is its
+// gui_surface_layout placement z, looked up by surfaceID. Lower z paints further
+// back, so the HIGHEST-z visible candidate with a placement wins. A candidate
+// with no emitted placement this frame (placed == false) is not eligible: there
+// is no fallback table any more, so a surface the BEAM did not place simply does
+// not render (documented in overlayWinner). The precedence is sorted placement
+// data end to end, not a hardcoded if-ladder.
 type overlayCandidate struct {
-	visible bool
-	order   int
-	render  func() []string
+	surfaceID uint16
+	visible   bool
+	placed    bool
+	order     int
+	render    func() []string
 }
 
 // overlayLines returns the single active overlay's lines (the BEAM emits a
 // single-active-overlay decision; multiple simultaneous overlays remain out of
-// scope, #2268 AC-4). The precedence chain is deleted: candidates are collected
-// and the front-most visible one (highest order) wins, where a placed surface's
-// order is its gui_surface_layout z and an unplaced surface's order is a
-// documented transitional rank.
+// scope, #2268 AC-4). Retained for tests and for any caller that wants only the
+// rendered content; positioning is done by overlayLayer via the placement rect.
 func (m Model) overlayLines() []string {
+	winner, ok := m.overlayWinner()
+	if !ok {
+		return nil
+	}
+	return winner.render()
+}
+
+// overlayWinner returns the single visible, placed overlay candidate with the
+// highest placement z, or ok=false when none qualifies. Selection is unchanged
+// (single active winner); what changed is that an eligible candidate must carry
+// a BEAM placement (placed). With no fallback table, a visible surface the BEAM
+// did not place this frame is skipped rather than footer-appended at a guessed
+// rank: it simply does not render that frame.
+func (m Model) overlayWinner() (overlayCandidate, bool) {
 	candidates := m.overlayCandidates()
 
 	best := -1
-	var winner func() []string
+	var winner overlayCandidate
+	found := false
 	for _, c := range candidates {
-		if c.visible && c.order > best {
+		if c.visible && c.placed && c.order > best {
 			best = c.order
-			winner = c.render
+			winner = c
+			found = true
 		}
 	}
-	if winner == nil {
-		return nil
-	}
-	return winner()
+	return winner, found
 }
 
-// overlayCandidates lists every floating overlay surface with its stacking
-// order on ONE comparable scale. Registry-placed surfaces (completion, bottom
-// panel, and the #2281-promoted hover/signature-help popups) use their BEAM
-// placement z directly; the remaining surfaces have no BEAM rect source yet and
-// keep transitional orders derived from the same registry z bands, slotted at
-// their old relative positions. Because everything shares the band scale, the
-// old top-to-bottom precedence is preserved exactly: completion (overlay band,
-// top) > hover > signature help > the four transitional overlays that
-// historically sat above the bottom panel > bottom panel (floating band, z=200)
-// > the lower transitional set.
+// overlayCandidates lists every floating overlay surface paired with its BEAM
+// placement. Every surface is registry-placed now (#2281), so each candidate's
+// stacking order is purely its gui_surface_layout z (surfaceOrder), looked up by
+// surfaceID. The historical top-to-bottom precedence is preserved by the emitted
+// z values themselves (completion 301 > hover 290 > signature help 280 > float
+// 270 > agent context 260 > tool manager 240 > bottom panel 200 > extension
+// panel 190 > observatory 180 > edit timeline 170 > notifications 160 > extension
+// overlay 150), not by any Go-side ordering.
 func (m Model) overlayCandidates() []overlayCandidate {
 	completion, completionOK := m.completion()
 	hover, hoverOK := m.hoverPopup()
 	sig, sigOK := m.signatureHelp()
 	float, floatOK := m.floatPopup()
 	context, contextOK := m.agentContext()
-	chat, chatOK := m.agentChat()
 	tools, toolsOK := m.toolManager()
 	bottom, bottomOK := m.bottomPanel()
 	ext, extOK := m.extensionPanel()
@@ -85,114 +176,51 @@ func (m Model) overlayCandidates() []overlayCandidate {
 	overlay, overlayOK := m.extensionOverlay()
 
 	return []overlayCandidate{
-		// Completion is registry-placed in the overlay band (z=301): it sits at the
-		// top, beating every transitional overlay below the overlay band, exactly
-		// as the old chain listed it first. Fallback orderOverlayTop is used only
-		// when the BEAM emits no placement for it (older BEAM / absent this frame).
-		{
-			visible: completionOK && completion.Visible && len(completion.Items) > 0,
-			order:   m.surfaceOrder(surfaceIDCompletionMenu, orderOverlayTop),
-			render:  func() []string { return m.renderCompletion(completion) },
-		},
-		// ── floating popups that historically sat ABOVE the bottom panel ──
-		// hover and signature help are registry-placed (#2281): the BEAM emits a
-		// placement z for each, so they order by that data; the orderHover/
-		// orderSignatureHelp constants survive only as fallbacks for an older BEAM
-		// that emits no placement. The remaining surfaces below keep their
-		// transitional rank (no BEAM rect source yet), preserving the old relative
-		// order: hover > signature > float > agentContext > agentChat > toolManager.
-		{visible: hoverOK && hover.Visible && len(hover.Lines) > 0, order: m.surfaceOrder(surfaceIDHoverPopup, orderHover), render: func() []string { return m.renderHover(hover) }},
-		{visible: sigOK && sig.Visible && len(sig.Signatures) > 0, order: m.surfaceOrder(surfaceIDSignatureHelp, orderSignatureHelp), render: func() []string { return m.renderSignature(sig) }},
-		{visible: floatOK && float.Visible, order: orderFloatPopup, render: func() []string { return m.renderFloat(float) }},
-		{visible: contextOK && context.Visible, order: orderAgentContext, render: func() []string { return m.renderAgentContext(context) }},
-		{visible: chatOK && chat.Visible, order: orderAgentChat, render: func() []string { return m.renderAgentChat(chat) }},
-		{visible: toolsOK && tools.Visible, order: orderToolManager, render: func() []string { return m.renderToolManager(tools) }},
-		// Bottom panel is registry-placed in the floating band (z=200): it sits
-		// BELOW the popups and the four transitional overlays above, and ABOVE the
-		// lower transitional set, exactly as the old chain ordered it. Fallback
-		// orderBottomPanelFallback keeps that relative position when no placement is
-		// emitted.
-		{
-			visible: bottomOK && bottom.Visible,
-			order:   m.surfaceOrder(surfaceIDBottomPanel, orderBottomPanelFallback),
-			render:  func() []string { return m.renderBottomPanel(bottom) },
-		},
-		// ── transitional overlays that historically sat BELOW the bottom panel ──
-		// Below the floating band (200), preserving their old relative order.
-		{visible: extOK && len(ext.Panels) > 0, order: orderExtensionPanel, render: func() []string { return m.renderExtensionPanels(ext) }},
-		{visible: obsOK && obs.Visible, order: orderObservatory, render: func() []string { return m.renderObservatory(obs) }},
-		{visible: timelineOK && timeline.Visible, order: orderEditTimeline, render: func() []string { return m.renderEditTimeline(timeline) }},
-		{visible: notesOK && notes.Visible && len(notes.Items) > 0, order: orderNotifications, render: func() []string { return m.renderNotifications(notes) }},
-		{visible: overlayOK && len(overlay.Entries) > 0, order: orderExtensionOverlay, render: func() []string { return m.renderExtensionOverlay(overlay) }},
+		m.candidate(surfaceIDCompletionMenu, completionOK && completion.Visible && len(completion.Items) > 0, func() []string { return m.renderCompletion(completion) }),
+		m.candidate(surfaceIDHoverPopup, hoverOK && hover.Visible && len(hover.Lines) > 0, func() []string { return m.renderHover(hover) }),
+		m.candidate(surfaceIDSignatureHelp, sigOK && sig.Visible && len(sig.Signatures) > 0, func() []string { return m.renderSignature(sig) }),
+		m.candidate(surfaceIDFloatPopup, floatOK && float.Visible, func() []string { return m.renderFloat(float) }),
+		m.candidate(surfaceIDAgentContext, contextOK && context.Visible, func() []string { return m.renderAgentContext(context) }),
+		m.candidate(surfaceIDToolManager, toolsOK && tools.Visible, func() []string { return m.renderToolManager(tools) }),
+		m.candidate(surfaceIDBottomPanel, bottomOK && bottom.Visible, func() []string { return m.renderBottomPanel(bottom) }),
+		m.candidate(surfaceIDExtensionPanel, extOK && visiblePanelCount(ext) > 0, func() []string { return m.renderExtensionPanels(ext) }),
+		m.candidate(surfaceIDObservatory, obsOK && obs.Visible, func() []string { return m.renderObservatory(obs) }),
+		m.candidate(surfaceIDEditTimeline, timelineOK && timeline.Visible, func() []string { return m.renderEditTimeline(timeline) }),
+		m.candidate(surfaceIDNotifications, notesOK && notes.Visible && len(notes.Items) > 0, func() []string { return m.renderNotifications(notes) }),
+		m.candidate(surfaceIDExtensionOverlay, overlayOK && len(overlay.Entries) > 0, func() []string { return m.renderExtensionOverlay(overlay) }),
 	}
 }
 
-// surfaceOrder returns the BEAM placement z for a registry-placed surface, used
-// directly on the shared band scale, or the transitional fallback when the BEAM
-// has not (yet) emitted a placement for it (older BEAM, or the surface absent
-// from this frame's layout). The placement z and the transitional orders below
-// are derived from the SAME registry z bands, so a placed surface's data z and
-// an unplaced surface's transitional order are comparable on one scale.
-func (m Model) surfaceOrder(surfaceID uint16, fallback int) int {
+// candidate builds an overlayCandidate, resolving the surface's BEAM placement z
+// by surfaceID. placed is false when the BEAM emitted no placement for this
+// surface this frame; such a candidate is ineligible (no fallback rank).
+func (m Model) candidate(surfaceID uint16, visible bool, render func() []string) overlayCandidate {
+	order, placed := m.surfaceOrder(surfaceID)
+	return overlayCandidate{surfaceID: surfaceID, visible: visible, placed: placed, order: order, render: render}
+}
+
+// surfaceOrder returns the BEAM placement z for a registry-placed surface and
+// whether a placement was found. There is no fallback table: a surface with no
+// placement this frame returns placed=false and is not eligible to render.
+func (m Model) surfaceOrder(surfaceID uint16) (int, bool) {
 	for _, p := range m.surfacePlacements {
 		if p.SurfaceID == surfaceID {
-			return int(p.Z)
+			return int(p.Z), true
 		}
 	}
-	return fallback
+	return 0, false
 }
 
-// Transitional stacking orders for the overlay surfaces that are not yet
-// registry-placed (#2281 shrank this table by promoting hover/signature help;
-// it is fully deleted only once every surface grows a BEAM rect source). They
-// are derived from the registry z bands in MingaEditor.Layout.SurfaceRegistry
-// (base 0 / editor 100 / floating 200 / floating-overlay 280 / overlay 300;
-// bottom_panel emits z=200, completion_menu z=301, hover z=290, signature
-// help z=280). Go cannot import the Elixir bands, so this coupling is documented
-// explicitly: keep these values in step with surface_registry.ex.
-//
-// Scale, highest paints front-most:
-//   - completion (placed, overlay band, z=301) sits on top.
-//   - hover (placed, z=290) and signature help (placed, z=280) follow; their
-//     orderHover/orderSignatureHelp constants are kept only as fallbacks for an
-//     older BEAM that emits no placement.
-//   - the four transitional overlays that historically sat above the bottom
-//     panel occupy 240..270, between the floating band (200) and the popups,
-//     preserving their old relative order.
-//   - bottom_panel (placed, floating band, z=200) sits below those.
-//   - the lower transitional set occupies 150..199, below the floating band,
-//     preserving its old relative order.
-const (
-	// Fallbacks for the registry-placed popups (used only when the BEAM emits no
-	// placement for them): hover above signature help, both above the floating band.
-	orderHover         = 290
-	orderSignatureHelp = 280
-
-	// Transitional ranks for the surfaces with no BEAM rect source yet, above the
-	// bottom panel (200) and below the popups.
-	orderFloatPopup   = 270
-	orderAgentContext = 260
-	orderAgentChat    = 250
-	orderToolManager  = 240
-
-	// Below the bottom panel (200).
-	orderExtensionPanel   = 190
-	orderObservatory      = 180
-	orderEditTimeline     = 170
-	orderNotifications    = 160
-	orderExtensionOverlay = 150
-
-	// orderOverlayTop is the fallback for completion when the BEAM emits no
-	// placement: it must outrank every transitional order, matching the live
-	// completion_menu z (overlay band + 1 = 301).
-	orderOverlayTop = 301
-
-	// orderBottomPanelFallback is the fallback for the bottom panel when the BEAM
-	// emits no placement: it sits at the floating band (200), keeping the bottom
-	// panel below the six overlays above and above the lower transitional set,
-	// exactly as the old chain ordered it.
-	orderBottomPanelFallback = 200
-)
+// surfacePlacementFor returns the BEAM placement rect for a surface id, or
+// ok=false when the surface has no placement this frame.
+func (m Model) surfacePlacementFor(surfaceID uint16) (generated.Rect, bool) {
+	for _, p := range m.surfacePlacements {
+		if p.SurfaceID == surfaceID {
+			return p.Rect, true
+		}
+	}
+	return generated.Rect{}, false
+}
 
 func (m Model) renderHover(hover protocol.HoverPopup) []string {
 	style := m.panelStyle()
@@ -244,10 +272,6 @@ func (m Model) renderAgentContext(context protocol.AgentContext) []string {
 		items = append(items, componentItem{title: "approval", description: "approve or request changes"})
 	}
 	return takeLines(m.charmList("Agent context", items, 0, m.maxOverlayHeight(), true), m.maxOverlayHeight())
-}
-
-func (m Model) renderAgentChat(chat protocol.AgentChat) []string {
-	return m.renderAgentChatPanel(chat)
 }
 
 func (m Model) renderToolManager(tools protocol.ToolManager) []string {
@@ -375,6 +399,22 @@ func (m Model) bottomPanelHeight(panel protocol.BottomPanel) int {
 	}
 	percent = min(max(percent, 1), 100)
 	return min(max(m.height*percent/100, 4), maxHeight)
+}
+
+// visiblePanelCount counts only Visible extension panels, matching what
+// renderExtensionPanels actually draws (it skips !Visible panels) and the BEAM's
+// MingaEditor.Layout.FooterOverlays predicate (Minga.Extension.Panel.visible()).
+// Gating on len(ext.Panels) would let an all-hidden panel set claim the overlay
+// slot and render an empty band; counting Visible panels keeps the candidate
+// gate, the renderer, and the BEAM placement predicate in agreement (#2281).
+func visiblePanelCount(ext protocol.ExtensionPanel) int {
+	count := 0
+	for _, panel := range ext.Panels {
+		if panel.Visible {
+			count++
+		}
+	}
+	return count
 }
 
 func (m Model) renderExtensionPanels(ext protocol.ExtensionPanel) []string {

--- a/go/tui/internal/ui/semantic_mouse.go
+++ b/go/tui/internal/ui/semantic_mouse.go
@@ -62,12 +62,20 @@ func (m Model) localMouse(msg tea.MouseMsg) (Model, bool) {
 }
 
 func (m Model) mouseInBottomPanel(y int) bool {
-	footerCount := len(m.footerLines())
-	overlayCount := max(footerCount-1, 0)
-	if overlayCount == 0 {
+	// The bottom panel is composited at its BEAM placement rect now (#2281), not
+	// footer-appended, so its on-screen band comes from the placement, not from a
+	// footer line count. Use the placement rect's row span when present; fall back
+	// to the locally computed panel height when no placement was emitted (older
+	// BEAM) so frontend scroll still works.
+	if rect, ok := m.surfacePlacementFor(surfaceIDBottomPanel); ok {
+		return y >= int(rect.Row) && y < int(rect.Row)+int(rect.Height)
+	}
+	panel, ok := m.bottomPanel()
+	if !ok || !panel.Visible {
 		return false
 	}
-	start := m.height - overlayCount
+	height := m.bottomPanelHeight(panel)
+	start := m.height - height
 	return y >= start && y < m.height
 }
 

--- a/go/tui/internal/ui/surface_layout_order_test.go
+++ b/go/tui/internal/ui/surface_layout_order_test.go
@@ -27,17 +27,15 @@ func completionAndBottomPanelModel() Model {
 	return model
 }
 
-func TestOverlayPrecedenceDefaultsToCompletionWhenNoPlacements(t *testing.T) {
-	// With no gui_surface_layout emitted (older BEAM), the band-derived fallbacks
-	// reproduce the old chain: completion (orderOverlayTop) outranks the bottom
-	// panel (orderBottomPanelFallback).
+func TestOverlayRendersNothingWithoutPlacements(t *testing.T) {
+	// The transitional fallback table is deleted (#2281): with no gui_surface_layout
+	// emitted, NO overlay is eligible (placed == false for all), so the single
+	// active overlay slot is empty. A surface the BEAM did not place simply does
+	// not render that frame, rather than footer-appending at a guessed rank.
 	model := completionAndBottomPanelModel()
 	got := strings.Join(model.overlayLines(), "\n")
-	if !strings.Contains(got, "Enum.map") {
-		t.Fatalf("expected completion to win the overlay slot, got %q", got)
-	}
-	if strings.Contains(got, "panel-msg") {
-		t.Fatalf("bottom panel should not win over completion by default, got %q", got)
+	if got != "" {
+		t.Fatalf("no overlay should render without placements, got %q", got)
 	}
 }
 
@@ -100,6 +98,7 @@ func TestOverlayBottomPanelOpenHoverWins(t *testing.T) {
 	}
 	model.surfacePlacements = []generated.SurfacePlacement{
 		{SurfaceID: surfaceIDBottomPanel, Z: 200, HitKind: 7},
+		{SurfaceID: surfaceIDHoverPopup, Z: 290, HitKind: 8},
 	}
 
 	got := strings.Join(model.overlayLines(), "\n")
@@ -189,6 +188,7 @@ func TestOverlayBottomPanelOpenSignatureHelpWins(t *testing.T) {
 	}
 	model.surfacePlacements = []generated.SurfacePlacement{
 		{SurfaceID: surfaceIDBottomPanel, Z: 200, HitKind: 7},
+		{SurfaceID: surfaceIDSignatureHelp, Z: 280, HitKind: 8},
 	}
 
 	got := strings.Join(model.overlayLines(), "\n")
@@ -197,5 +197,187 @@ func TestOverlayBottomPanelOpenSignatureHelpWins(t *testing.T) {
 	}
 	if strings.Contains(got, "panel-msg") {
 		t.Fatalf("bottom panel must not win over signature help, got %q", got)
+	}
+}
+
+// Per-surface placement: each promoted footer-band overlay (#2281) renders only
+// when the BEAM emits its placement, and the overlayLayer positions it at the
+// placement rect (X=Col, Y=Row). One sub-test per surface proves the surface id
+// wiring and the position-by-rect path.
+
+func TestPromotedFooterOverlaysRenderAtPlacementRect(t *testing.T) {
+	cases := []struct {
+		name      string
+		surfaceID uint16
+		z         uint16
+		chrome    map[byte]protocol.ChromePayload
+		needle    string
+	}{
+		{
+			name:      "float popup",
+			surfaceID: surfaceIDFloatPopup,
+			z:         270,
+			chrome:    map[byte]protocol.ChromePayload{generated.OPGuiFloatPopup: {Float: protocol.FloatPopup{Visible: true, Title: "Inspect", Lines: []string{"pid <0.1.0>"}}}},
+			needle:    "Inspect",
+		},
+		{
+			name:      "agent context",
+			surfaceID: surfaceIDAgentContext,
+			z:         260,
+			chrome:    map[byte]protocol.ChromePayload{generated.OPGuiAgentContext: {AgentContext: protocol.AgentContext{Visible: true, Task: "Review diff", Status: 1}}},
+			needle:    "Review diff",
+		},
+		{
+			name:      "tool manager",
+			surfaceID: surfaceIDToolManager,
+			z:         240,
+			chrome:    map[byte]protocol.ChromePayload{generated.OPGuiToolManager: {ToolManager: protocol.ToolManager{Visible: true, Tools: []protocol.ToolSummary{{Name: "elixir-ls", Label: "Elixir LS", Status: 1}}}}},
+			needle:    "Elixir LS",
+		},
+		{
+			name:      "extension panel",
+			surfaceID: surfaceIDExtensionPanel,
+			z:         190,
+			chrome:    map[byte]protocol.ChromePayload{generated.OPGuiExtensionPanel: {Extensions: protocol.ExtensionPanel{Panels: []protocol.ExtensionPanelEntry{{Visible: true, Title: "Linter"}}}}},
+			needle:    "Linter",
+		},
+		{
+			name:      "observatory",
+			surfaceID: surfaceIDObservatory,
+			z:         180,
+			chrome:    map[byte]protocol.ChromePayload{generated.OPGuiObservatory: {Observatory: protocol.Observatory{Visible: true, Count: 1, Nodes: []protocol.ObservatoryNode{{PID: "<0.1.0>", Name: "Editor", MessageQueueLen: 0}}}}},
+			needle:    "Editor",
+		},
+		{
+			name:      "edit timeline",
+			surfaceID: surfaceIDEditTimeline,
+			z:         170,
+			chrome:    map[byte]protocol.ChromePayload{generated.OPGuiEditTimeline: {Timeline: protocol.EditTimeline{Visible: true, Entries: []protocol.TimelineEntry{{Index: 0, ToolName: "format", TimestampDelta: 0}}}}},
+			needle:    "format",
+		},
+		{
+			name:      "notifications",
+			surfaceID: surfaceIDNotifications,
+			z:         160,
+			chrome:    map[byte]protocol.ChromePayload{generated.OPGuiNotifications: {Notifications: protocol.Notifications{Visible: true, Items: []protocol.Notification{{Title: "Build done", Source: "build"}}}}},
+			needle:    "Build done",
+		},
+		{
+			name:      "extension overlay",
+			surfaceID: surfaceIDExtensionOverlay,
+			z:         150,
+			chrome:    map[byte]protocol.ChromePayload{generated.OPGuiExtensionOverlay: {Overlay: protocol.ExtensionOverlay{Entries: []protocol.ExtensionOverlayEntry{{Extension: "lens", Row: 0, Col: 0, Content: "ref count 3"}}}}},
+			needle:    "ref count",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			model := New(80, 24, nil)
+			model.chrome = tc.chrome
+
+			// Without a placement the surface does not render (no fallback table).
+			if got := strings.Join(model.overlayLines(), "\n"); got != "" {
+				t.Fatalf("%s should not render without a placement, got %q", tc.name, got)
+			}
+
+			// With its placement, the surface wins the slot and renders.
+			model.surfacePlacements = []generated.SurfacePlacement{
+				{SurfaceID: tc.surfaceID, Rect: generated.Rect{Row: 16, Col: 0, Width: 80, Height: 8}, Z: tc.z, HitKind: 8},
+			}
+			if got := strings.Join(model.overlayLines(), "\n"); !strings.Contains(got, tc.needle) {
+				t.Fatalf("%s should render with its placement, got %q", tc.name, got)
+			}
+
+			// The overlay layer is bottom-aligned inside the placement band (#2281):
+			// its bottom edge sits at the rect's bottom edge (Row+Height) so a short
+			// overlay hugs the screen bottom instead of rendering at the band top.
+			layer := model.overlayLayer()
+			if layer == nil {
+				t.Fatalf("%s should produce an overlay layer when placed", tc.name)
+			}
+			rectBottom := 16 + 8
+			layerBottom := layer.GetY() + layer.Height()
+			if layerBottom != rectBottom {
+				t.Fatalf("%s layer bottom edge %d != rect bottom %d (content must hug the band bottom)", tc.name, layerBottom, rectBottom)
+			}
+			if layer.GetY() < 16 {
+				t.Fatalf("%s layer top %d escaped above the band top 16", tc.name, layer.GetY())
+			}
+		})
+	}
+}
+
+// TestShortNotificationsHugBandBottom is the position-pinning regression for the
+// short-overlay bug (#2281): before the fix every surface used a :max ceiling
+// rect and Go composited content at the band TOP, so a 2-line notification
+// rendered ~10 rows above the screen bottom and the rows below it phantom-
+// swallowed clicks. With the fix the BEAM sizes the notifications rect to its
+// content and Go bottom-aligns, so the overlay's bottom edge is the rect's bottom
+// edge (directly above the minibuffer) and the layer is exactly its content tall.
+func TestShortNotificationsHugBandBottom(t *testing.T) {
+	model := New(80, 24, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiNotifications: {Notifications: protocol.Notifications{
+			Visible: true,
+			Items:   []protocol.Notification{{Title: "Build done", Source: "build", Body: "ok"}},
+		}},
+	}
+	// BEAM content-height for 1 notification item: title bar + 2 lines = 3, so the
+	// bottom-anchored band is the lowest 3 rows of the screen (rows 21..23).
+	const bandRow, bandHeight = 21, 3
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDNotifications, Rect: generated.Rect{Row: bandRow, Col: 0, Width: 80, Height: bandHeight}, Z: 160, HitKind: 8},
+	}
+
+	layer := model.overlayLayer()
+	if layer == nil {
+		t.Fatalf("notifications overlay should render with its placement")
+	}
+	// The layer must NOT span the old full band (8..12 rows): a 2-3 line overlay is
+	// at most bandHeight tall, and its bottom edge is the screen bottom.
+	if got := layer.Height(); got > bandHeight {
+		t.Fatalf("notifications layer height %d exceeds band height %d (overflowed the rect)", got, bandHeight)
+	}
+	bottom := layer.GetY() + layer.Height()
+	if bottom != bandRow+bandHeight {
+		t.Fatalf("notifications bottom edge %d != band bottom %d (must hug the screen bottom)", bottom, bandRow+bandHeight)
+	}
+	if layer.GetY() < bandRow {
+		t.Fatalf("notifications top %d escaped above the band top %d", layer.GetY(), bandRow)
+	}
+}
+
+// TestWrapDependentOverlayBottomAlignsInMaxBand pins the wrap-dependent bucket
+// (#2281): a float popup keeps the :max ceiling band, but Go bottom-aligns its
+// short content so the overlay still hugs the screen bottom and the residual
+// phantom zone sits ABOVE the content (between the buffer and the overlay).
+func TestWrapDependentOverlayBottomAlignsInMaxBand(t *testing.T) {
+	model := New(80, 24, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiFloatPopup: {Float: protocol.FloatPopup{Visible: true, Title: "Inspect", Lines: []string{"pid <0.1.0>"}}},
+	}
+	// :max band for a 24-row terminal clamps to 8 rows, bottom-anchored at 16..23.
+	const bandRow, bandHeight = 16, 8
+	model.surfacePlacements = []generated.SurfacePlacement{
+		{SurfaceID: surfaceIDFloatPopup, Rect: generated.Rect{Row: bandRow, Col: 0, Width: 80, Height: bandHeight}, Z: 270, HitKind: 8},
+	}
+
+	layer := model.overlayLayer()
+	if layer == nil {
+		t.Fatalf("float popup overlay should render with its placement")
+	}
+	// Content is 2 lines (title + 1 line); it must bottom-align, not top-align.
+	if got := layer.Height(); got >= bandHeight {
+		t.Fatalf("float popup should render its short content (got %d lines), not fill the band", got)
+	}
+	bottom := layer.GetY() + layer.Height()
+	if bottom != bandRow+bandHeight {
+		t.Fatalf("float popup bottom edge %d != band bottom %d (must hug the screen bottom)", bottom, bandRow+bandHeight)
+	}
+	// The phantom zone is above the content: the layer top is strictly below the
+	// band top.
+	if layer.GetY() <= bandRow {
+		t.Fatalf("float popup should bottom-align (top %d) leaving the phantom zone above, band top %d", layer.GetY(), bandRow)
 	}
 }

--- a/go/tui/internal/ui/zones.go
+++ b/go/tui/internal/ui/zones.go
@@ -107,6 +107,55 @@ func (m *zoneManager) Scan(value string) string {
 	return string(out)
 }
 
+// ScanInto scans a detached content block (a separately composited overlay
+// layer, #2281) for zone markers, strips the markers, and merges the discovered
+// zones into the existing zone map with their coordinates offset by (offsetX,
+// offsetY). Unlike Scan it does NOT clobber the existing zones: the main frame
+// content is scanned first via Scan, then each separately positioned layer adds
+// its zones here so chrome zone routing (completion items, hover action) keeps
+// working even though the overlay is no longer footer-appended into the main
+// vertical layout. Returns the marker-stripped content for compositing.
+func (m *zoneManager) ScanInto(value string, offsetX int, offsetY int) string {
+	out := make([]byte, 0, len(value))
+	line := make([]byte, 0, 128)
+	tracked := map[string]*zoneInfo{}
+	y := 0
+
+	for pos := 0; pos < len(value); {
+		if marker, next, ok := readZoneMarker(value, pos); ok {
+			id := m.rids[marker]
+			if id != "" {
+				if start, ok := tracked[marker]; ok {
+					start.EndX = ansi.StringWidth(string(line)) - 1 + offsetX
+					start.EndY = y + offsetY
+					m.zones[id] = start
+					delete(tracked, marker)
+				} else {
+					tracked[marker] = &zoneInfo{id: id, StartX: ansi.StringWidth(string(line)) + offsetX, StartY: y + offsetY}
+				}
+			}
+			pos = next
+			continue
+		}
+
+		r, width := utf8.DecodeRuneInString(value[pos:])
+		if r == utf8.RuneError && width == 0 {
+			break
+		}
+		chunk := value[pos : pos+width]
+		out = append(out, chunk...)
+		if r == '\n' {
+			y++
+			line = line[:0]
+		} else {
+			line = append(line, chunk...)
+		}
+		pos += width
+	}
+
+	return string(out)
+}
+
 func readZoneMarker(value string, pos int) (string, int, bool) {
 	if pos+4 > len(value) || value[pos] != zoneMarkerStart || value[pos+1] != zoneMarkerBracket {
 		return "", pos, false

--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -16,6 +16,8 @@ defmodule MingaEditor.FocusTree do
   alias MingaEditor.Input
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Layout
+  alias MingaEditor.Layout.FooterOverlays
+  alias MingaEditor.Layout.OverlayBand
   alias MingaEditor.SignatureHelp
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.State.ModalOverlay
@@ -41,6 +43,7 @@ defmodule MingaEditor.FocusTree do
 
     layout
     |> build_base(window_map(state), Input.editing_dispatch_handler(state), state)
+    |> add_footer_band_overlays(state, layout)
     |> add_floating_overlays(state)
     |> add_modal_overlays(state, layout)
     |> link_tree()
@@ -319,6 +322,49 @@ defmodule MingaEditor.FocusTree do
           [TreeNode.t()]
   defp maybe_add(children, nil, _build), do: children
   defp maybe_add(children, rect, build), do: children ++ [build.(rect)]
+
+  # ── Footer-band overlay builders ──────────────────────────────────────────
+  #
+  # The eight secondary overlays (float popup, agent context, tool manager,
+  # extension panel, observatory, edit timeline, notifications, extension
+  # overlay) the owner ruled mouse-driven (#2330). `FooterOverlays.visible/1`
+  # decides which are live this frame (single-active model still holds, but the
+  # tree expresses each visible one so the registry/emitter carry their rect/z;
+  # Go composites the single highest-z winner). Each gets a bottom-anchored band
+  # rect from `OverlayBand` and the `Input.OverlaySink` handler so a click or
+  # scroll over a visible overlay is swallowed instead of bubbling to the buffer
+  # (AC-2). Per-surface activation semantics replace the sink via epic #2330
+  # children.
+  #
+  # Ordering matters for the hit-test. `FooterOverlays.visible/1` returns entries
+  # in ASCENDING z (back-to-front); this reduce appends them as root children in
+  # that order, so the highest-z overlay is the LAST child. `do_hit_path` reverses
+  # children before searching, so the last child (highest z) wins among same-rect
+  # siblings, making the BEAM hit-winner the SAME surface Go composites on top (its
+  # highest-z render winner). Inverting the order here would let the lowest-z node
+  # win the hit-test against the render winner, which the #2330 per-surface handlers
+  # must not see.
+
+  @spec add_footer_band_overlays(t(), map(), Layout.t()) :: t()
+  defp add_footer_band_overlays(%TreeNode{} = root, state, %Layout{terminal: terminal}) do
+    state
+    |> FooterOverlays.visible()
+    |> Enum.reduce(root, fn {surface_id, content_height}, acc ->
+      case OverlayBand.rect(terminal, content_height) do
+        nil -> acc
+        rect -> append_root_child(acc, footer_overlay_node(surface_id, rect))
+      end
+    end)
+  end
+
+  @spec footer_overlay_node(atom(), Layout.rect()) :: TreeNode.t()
+  defp footer_overlay_node(surface_id, rect) do
+    TreeNode.new(surface_id, rect,
+      handler: Input.OverlaySink,
+      scrollable?: true,
+      focusable?: true
+    )
+  end
 
   # ── Floating overlay builders ─────────────────────────────────────────────
   #

--- a/lib/minga_editor/focus_tree/node.ex
+++ b/lib/minga_editor/focus_tree/node.ex
@@ -36,6 +36,14 @@ defmodule MingaEditor.FocusTree.Node do
           | :completion_menu
           | :hover_popup
           | :signature_help
+          | :float_popup
+          | :agent_context
+          | :tool_manager
+          | :extension_panel
+          | :observatory
+          | :edit_timeline
+          | :notifications
+          | :extension_overlay
           | :which_key
           | {:custom, atom()}
 

--- a/lib/minga_editor/input/overlay_sink.ex
+++ b/lib/minga_editor/input/overlay_sink.ex
@@ -1,0 +1,51 @@
+defmodule MingaEditor.Input.OverlaySink do
+  @moduledoc """
+  Swallow-by-default mouse handler for placed secondary overlays (#2281).
+
+  The eight footer-band overlays (float popup, agent context, tool manager,
+  extension panel, observatory, edit timeline, notifications, extension overlay)
+  are now FocusTree nodes with a real rect. A FocusTree node with no handler
+  bubbles its mouse events to ancestors (router passthrough semantics), which
+  would let a click or scroll over a visible overlay reach the buffer underneath
+  and move its cursor. That is the exact bug the epic's AC-2 forbids.
+
+  This handler is the minimal safety floor: it consumes (`:handled`) presses,
+  releases, drags, and scroll wheel events that land inside the overlay's rect,
+  so they never bubble to the buffer. It does not yet interpret them, per-surface
+  activation semantics (clicking a notification, an observatory row, a timeline
+  entry) land as the epic's follow-up children (#2330). Those children replace
+  this sink with a surface-specific handler; until then, the overlay is safe to
+  click without editing the buffer behind it.
+  """
+
+  @behaviour MingaEditor.Input.Handler
+
+  @type state :: MingaEditor.Input.Handler.handler_state()
+
+  @impl true
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
+          MingaEditor.Input.Handler.result()
+  def handle_key(state, _codepoint, _modifiers) do
+    # Keyboard handling stays with the surface's existing key bindings; the sink
+    # only governs mouse routing, so keys pass through untouched.
+    {:passthrough, state}
+  end
+
+  @impl true
+  @spec handle_mouse(
+          state(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: MingaEditor.Input.Handler.result()
+  def handle_mouse(state, _row, _col, _button, _mods, _event_type, _click_count) do
+    # The router only calls this handler when the event already hit the overlay's
+    # rect, so every event reaching here is over a visible overlay: swallow it so
+    # it cannot bubble to the buffer. One handled verdict covers press, release,
+    # drag, and wheel scroll.
+    {:handled, state}
+  end
+end

--- a/lib/minga_editor/layout/footer_overlays.ex
+++ b/lib/minga_editor/layout/footer_overlays.ex
@@ -1,0 +1,248 @@
+defmodule MingaEditor.Layout.FooterOverlays do
+  @moduledoc """
+  BEAM visibility source for the eight footer-band secondary overlays (#2281).
+
+  These surfaces (float popup, agent context, tool manager, extension panel,
+  observatory, edit timeline, notifications, extension overlay) historically had
+  no BEAM rect: the Go compositor footer-appended one of them, sizing it
+  frontend-side. The owner ruled them mouse-driven (#2330), so the BEAM now owns
+  their footer-band geometry. This module is the single place that decides which
+  of the eight is visible this frame and how tall its band is, reading the SAME
+  underlying state the render-model builders read (so visibility never drifts
+  from what the frontend actually renders).
+
+  `visible/1` returns the visible footer overlays as `{surface_id, content_height}`
+  pairs. `MingaEditor.FocusTree` turns each into an overlay node via
+  `MingaEditor.Layout.OverlayBand.rect/2`; `MingaEditor.Layout.SurfaceRegistry`
+  then places them with the historical stacking z. Only one overlay shows at a
+  time in the fixed bottom band (single-active model, #2268 AC-4), and the band
+  rect is bottom-anchored: its bottom edge sits directly above the minibuffer,
+  exactly where the Go compositor used to footer-append the overlay.
+
+  ## Content height and the residual phantom zone
+
+  The rect must CONTAIN the rendered overlay (so a click over it is hit-tested and
+  swallowed) but it should not span the whole band for a short overlay, or the
+  rows below the content phantom-swallow clicks and the overlay renders well above
+  the screen bottom. Two buckets:
+
+    * **Count-derivable surfaces** (notifications, observatory, edit_timeline,
+      extension_overlay): the BEAM knows the line count the Go renderer draws, so
+      `content_height` is that count (clamped by the band ceiling, see the
+      per-surface helpers below). The rect is sized to the content and the overlay
+      hugs the screen bottom with no residual phantom zone (at most ~1 row of
+      conservative slack: e.g. a notification item with no body draws 1 line where
+      the count budgets 2).
+
+    * **Wrap-dependent surfaces** (float_popup, extension_panel, and the dormant
+      agent_context / tool_manager): these wrap text frontend-side where the BEAM
+      only knows an item count, not a wrapped line count, so `content_height` stays
+      `:max` (the clamp ceiling). Go bottom-aligns the rendered content within the
+      band (`Y = rect.Row + bandHeight - contentLines`), so the overlay still hugs
+      the screen bottom; the residual phantom zone (clamp ceiling minus rendered
+      lines) sits ABOVE the content, between the buffer and the overlay, not below
+      it. Per surface, the phantom band is at most `band_height - rendered_lines`
+      rows tall: float_popup renders `1 + min(line_count, ceiling-1)` lines so its
+      phantom zone is the remaining ceiling rows above; extension_panel renders a
+      title plus up to two blocks per visible panel until it fills the band, so its
+      phantom zone shrinks as panels are added; agent_context and tool_manager are
+      dormant (never visible today) so their phantom zone is moot until a future
+      child gives them a render-model source.
+
+  ## Live vs dormant sources (honesty, #2281)
+
+  Six surfaces have a live BEAM content source in the render-model path and so can
+  actually become visible here: float popup, extension panel, observatory, edit
+  timeline, notifications, extension overlay. Two are dormant on that path: the
+  agent-context builder is a permanent `visible: false` stub
+  (`MingaEditor.RenderModel.UI.AgentContextBuilder`, fed by `gui_payload/1` which
+  the traditional shell always returns `nil` for), and the tool manager is not in
+  the render-model UI at all (it ships only via the legacy `protocol/gui.ex`
+  path). Their predicates here are wired to the same future sources, so they are
+  placement-ready and will light up automatically when an epic child gives them a
+  BEAM render-model source. Today their predicates never fire, which is correct:
+  an overlay the BEAM never renders must not claim a footer band.
+  """
+
+  alias Minga.RenderModel.UI.AgentContext
+  alias MingaEditor.RenderModel.UI.AgentContextBuilder
+
+  @typedoc "A visible footer overlay: its registry surface id and its band content height."
+  @type entry :: {surface_id :: atom(), content_height :: non_neg_integer() | :max}
+
+  @doc """
+  Returns the visible footer-band overlays for the frame, back-to-front by z.
+
+  Each entry is `{surface_id, content_height}` where `surface_id` is a
+  `MingaEditor.Layout.SurfaceRegistry` surface id and `content_height` is the
+  BEAM-known content line count for the count-derivable surfaces (clamped by the
+  band ceiling) or `:max` for the wrap-dependent ones (see the moduledoc).
+
+  Order is ascending z (back-to-front): extension overlay (lowest z, painted
+  first) up to float popup (highest z, painted last). This ordering matters for
+  hit-testing: `FocusTree.add_footer_band_overlays/3` appends each entry as a
+  child in list order, and `FocusTree`'s hit path reverses children so the
+  LAST-appended (highest z) node wins among same-rect siblings. Returning
+  ascending z here makes the BEAM hit-winner the highest-z node, the SAME surface
+  Go composites on top (its highest-z render winner). If this returned descending
+  z, the lowest-z node would win the reversed hit-test, inverting it against the
+  render winner and breaking the per-surface handlers #2330 builds on top.
+  """
+  @spec visible(map()) :: [entry()]
+  def visible(state) do
+    [
+      {:extension_overlay, extension_overlay_visible?(state),
+       content_height_extension_overlay(state)},
+      {:notifications, notifications_visible?(state), content_height_notifications(state)},
+      {:edit_timeline, edit_timeline_visible?(state), content_height_edit_timeline(state)},
+      {:observatory, observatory_visible?(state), content_height_observatory(state)},
+      {:extension_panel, extension_panel_visible?(), :max},
+      {:tool_manager, tool_manager_visible?(state), :max},
+      {:agent_context, agent_context_visible?(state), :max},
+      {:float_popup, float_popup_visible?(state), :max}
+    ]
+    |> Enum.filter(fn {_id, visible?, _height} -> visible? end)
+    |> Enum.map(fn {id, _visible?, height} -> {id, height} end)
+  end
+
+  # ── Per-surface content height (count-derivable surfaces) ────────────────────
+  #
+  # These return the BEAM-known content line count so OverlayBand sizes the rect
+  # to the content (clamped by the band ceiling) instead of the full band, so a
+  # short overlay hugs the screen bottom instead of rendering rows above it. Each
+  # count is verified against what the Go renderer actually draws (after its own
+  # trailing-blank trim in overlayLayer):
+  #
+  #   * notifications  Go renders charmList("Notifications", items, desc=true): a
+  #     1-line title bar plus up to 2 lines per item (title + description). The
+  #     count `1 + 2 * item_count` is an exact-or-conservative upper bound on the
+  #     trimmed Go output (an item with no body/source draws 1 line, so the rect
+  #     is at most 1 row taller than the content per such item; OverlayBand clamps
+  #     the whole thing by the band ceiling).
+  #   * observatory / edit_timeline  Go renders charmTable: a 1-line header plus
+  #     one line per row. The count `1 + row_count` matches the trimmed table.
+  #   * extension_overlay  Go renders a 1-line title plus one line per entry. The
+  #     count `1 + entry_count` matches the trimmed output.
+
+  @spec content_height_notifications(map()) :: non_neg_integer()
+  defp content_height_notifications(%{notifications: %{items: items}}) when is_list(items) do
+    1 + 2 * length(items)
+  end
+
+  defp content_height_notifications(_state), do: 1
+
+  @spec content_height_observatory(map()) :: non_neg_integer()
+  defp content_height_observatory(%{shell_state: %{observatory_data: %{tree: tree}}}) do
+    1 + length(Minga.SystemObserver.TreeNode.flatten(tree))
+  end
+
+  defp content_height_observatory(_state), do: 1
+
+  @spec content_height_edit_timeline(map()) :: non_neg_integer()
+  defp content_height_edit_timeline(state) do
+    with timeline when timeline != nil <- edit_timeline_state(state),
+         path when is_binary(path) <- active_buffer_path(state) do
+      1 + length(MingaEditor.Agent.EditTimeline.entries_for(timeline, path))
+    else
+      _ -> 1
+    end
+  end
+
+  @spec content_height_extension_overlay(map()) :: non_neg_integer()
+  defp content_height_extension_overlay(_state) do
+    1 + length(Minga.Extension.Overlay.all())
+  end
+
+  # ── Per-surface visibility, each reading the builder's underlying source ──────
+
+  # Float popup: an observatory inspection float, or a window carrying a :float
+  # popup rule. Mirrors MingaEditor.RenderModel.UI.FloatPopupBuilder.
+  @spec float_popup_visible?(map()) :: boolean()
+  defp float_popup_visible?(%{shell_state: %{observatory_inspection: %{visible: true}}}), do: true
+
+  defp float_popup_visible?(%{workspace: %{windows: %{map: map}}}) when is_map(map) do
+    Enum.any?(map, fn
+      {_id,
+       %{
+         popup_meta: %MingaEditor.UI.Popup.Active{
+           rule: %Minga.Popup.Rule{display: :float}
+         }
+       }} ->
+        true
+
+      _ ->
+        false
+    end)
+  end
+
+  defp float_popup_visible?(_state), do: false
+
+  # Agent context: dormant on the render-model path (builder is a permanent stub,
+  # see moduledoc). Driving it through the builder keeps the predicate honest and
+  # ready to light up if a future child supplies a real gui_payload-backed model.
+  @spec agent_context_visible?(map()) :: boolean()
+  defp agent_context_visible?(_state) do
+    case AgentContextBuilder.build(nil) do
+      %AgentContext{visible: visible?} -> visible?
+    end
+  end
+
+  # Tool manager: not in the render-model UI; no BEAM content source on this path.
+  # Dormant until an epic child adds a render-model builder for it.
+  @spec tool_manager_visible?(map()) :: boolean()
+  defp tool_manager_visible?(_state), do: false
+
+  # Extension panel: any visible extension or semantic panel.
+  # Mirrors MingaEditor.RenderModel.UI.ExtensionPanelBuilder.
+  @spec extension_panel_visible?() :: boolean()
+  defp extension_panel_visible? do
+    Minga.Extension.Panel.visible() != [] or
+      MingaEditor.Agent.SemanticUI.Registry.panels() != []
+  end
+
+  # Observatory: the BEAM observatory panel is toggled on in shell_state.
+  # Mirrors MingaEditor.RenderModel.UI.ObservatoryBuilder.
+  @spec observatory_visible?(map()) :: boolean()
+  defp observatory_visible?(%{shell_state: %{observatory_visible: true}}), do: true
+  defp observatory_visible?(_state), do: false
+
+  # Edit timeline: the active buffer has timeline entries.
+  # Mirrors MingaEditor.RenderModel.UI.EditTimelineBuilder.
+  @spec edit_timeline_visible?(map()) :: boolean()
+  defp edit_timeline_visible?(state) do
+    with timeline when timeline != nil <- edit_timeline_state(state),
+         path when is_binary(path) <- active_buffer_path(state) do
+      MingaEditor.Agent.EditTimeline.has_entries?(timeline, path)
+    else
+      _ -> false
+    end
+  end
+
+  @spec edit_timeline_state(map()) :: term() | nil
+  defp edit_timeline_state(%{workspace: %{agent_ui: %{view: %{edit_timeline: timeline}}}}),
+    do: timeline
+
+  defp edit_timeline_state(_state), do: nil
+
+  @spec active_buffer_path(map()) :: String.t() | nil
+  defp active_buffer_path(%{workspace: %{buffers: %{active: buf}}}) when is_pid(buf) do
+    Minga.Buffer.file_path(buf)
+  catch
+    :exit, _ -> nil
+  end
+
+  defp active_buffer_path(_state), do: nil
+
+  # Notifications: any active notification item.
+  # Mirrors MingaEditor.RenderModel.UI.NotificationsBuilder (visible when items present).
+  @spec notifications_visible?(map()) :: boolean()
+  defp notifications_visible?(%{notifications: %{items: [_ | _]}}), do: true
+  defp notifications_visible?(_state), do: false
+
+  # Extension overlay: any registered extension inline overlay.
+  # Mirrors MingaEditor.RenderModel.UI.ExtensionOverlayBuilder (entries present).
+  @spec extension_overlay_visible?(map()) :: boolean()
+  defp extension_overlay_visible?(_state) do
+    Minga.Extension.Overlay.all() != []
+  end
+end

--- a/lib/minga_editor/layout/overlay_band.ex
+++ b/lib/minga_editor/layout/overlay_band.ex
@@ -1,0 +1,84 @@
+defmodule MingaEditor.Layout.OverlayBand do
+  @moduledoc """
+  Shared footer-band geometry for the single-active secondary overlays (#2281).
+
+  The Go compositor historically footer-appended one secondary overlay at the
+  bottom of the screen, sizing its height with `maxOverlayHeight()`
+  (`go/tui/internal/ui/model.go`: `min(max(height/3, 4), 12)`) and spanning the
+  full terminal width. These eight surfaces (float popup, agent context, tool
+  manager, extension panel, observatory, edit timeline, notifications, extension
+  overlay) are identical footer-band shapes, so the BEAM owns one rect helper for
+  all of them instead of eight copies.
+
+  `rect/2` ports that exact clamp. `content_height` is the surface's content line
+  count (BEAM-derivable from the chrome/UI models) or `:max` for a surface whose
+  wrapped line count the BEAM cannot know. The rect is bottom-anchored: it occupies
+  the lowest `height` rows of the terminal and the full width, the same band the
+  frontend appended into, so the rect's bottom edge sits where the old footer-append
+  put the overlay (directly above the minibuffer).
+
+  Only one overlay shows at a time in that band (single-active model, #2268 AC-4).
+  For the count-derivable surfaces (notifications, observatory, edit_timeline,
+  extension_overlay) the caller passes a real `content_height` so the band shrinks
+  to the content and the overlay hugs the screen bottom. For the wrap-dependent
+  surfaces (float_popup, extension_panel, and the dormant agent_context/tool_manager)
+  the caller passes `:max` (the clamp ceiling); the frontend bottom-aligns the
+  rendered content inside that band, so a short overlay still hugs the bottom and
+  the residual phantom rows sit ABOVE it (see `MingaEditor.Layout.FooterOverlays`).
+  Either way the rect only needs to CONTAIN the overlay so clicks over it are
+  hit-tested, not pixel-match it.
+  """
+
+  alias MingaEditor.Layout
+
+  @clamp_floor 4
+  @clamp_ceiling 12
+
+  @doc """
+  Returns the clamped footer-band height for a content line count.
+
+  Ports the Go `maxOverlayHeight()` clamp: the band is `terminal_rows / 3`,
+  floored at #{@clamp_floor} and ceiled at #{@clamp_ceiling}, and never taller
+  than the content it must contain. Passing `:max` for `content_height` yields
+  the clamp ceiling directly, the conservative size for a text-wrap-dependent
+  surface whose exact wrapped line count the BEAM cannot know.
+  """
+  @spec band_height(non_neg_integer(), non_neg_integer() | :max) :: non_neg_integer()
+  def band_height(terminal_rows, :max) do
+    max_overlay_height(terminal_rows)
+  end
+
+  def band_height(terminal_rows, content_height)
+      when is_integer(content_height) and content_height >= 0 do
+    min(content_height, max_overlay_height(terminal_rows))
+  end
+
+  @doc """
+  Returns the bottom-anchored, full-width footer-band rect for an overlay.
+
+  `content_height` is the surface's content line count (or `:max` to take the
+  clamp ceiling for a text-wrap-dependent surface). The rect spans the full
+  terminal width and the lowest `band_height/2` rows, matching where the Go
+  compositor footer-appended the overlay. Returns `nil` when the band would be
+  empty (zero content and zero clamp floor never happens, but a degenerate
+  terminal can produce a zero-height band).
+  """
+  @spec rect(Layout.rect(), non_neg_integer() | :max) :: Layout.rect() | nil
+  def rect({row, col, width, rows}, content_height) do
+    height = band_height(rows, content_height)
+
+    if height <= 0 do
+      nil
+    else
+      {row + rows - height, col, width, height}
+    end
+  end
+
+  @spec max_overlay_height(non_neg_integer()) :: non_neg_integer()
+  defp max_overlay_height(terminal_rows) do
+    terminal_rows
+    |> div(3)
+    |> max(@clamp_floor)
+    |> min(@clamp_ceiling)
+  end
+end

--- a/lib/minga_editor/layout/surface_registry.ex
+++ b/lib/minga_editor/layout/surface_registry.ex
@@ -34,30 +34,32 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   simultaneous overlays are newly *expressible* as a list but are deliberately
   NOT produced here. Enabling them is out of scope (see #2268, AC-4).
 
-  Enumeration gap (transitional split, #2268; partially closed by #2281). The Go
-  compositor's `overlayLines()` chain also stacks surfaces that are not focus-tree
-  nodes. #2268 shipped a *transitional split*; #2281 promotes the surfaces whose
-  rect the BEAM authoritatively computes:
+  Enumeration history (#2268 -> #2281). The Go compositor's `overlayLines()` chain
+  once stacked surfaces that were not focus-tree nodes via a hand-ordered rank
+  table. That table is now gone: every overlay surface is a focus-tree node with a
+  BEAM-authoritative rect.
 
-  * **Promoted (#2281): hover popup, signature help.** Both are cursor-anchored
-    floating popups whose exact on-screen box the BEAM already computes for layout
+  * **Cursor-anchored popups: hover popup, signature help.** Both are floating
+    popups whose exact on-screen box the BEAM computes for layout
     (`HoverPopup.box/3`/`SignatureHelp.box/3`, driven by `FloatingWindow`).
-    `FocusTree.add_floating_overlays/2` now adds them as overlay nodes from
-    `shell_state`, so the registry places them with a real rect/z/hit_kind and the
-    AC-1 one-source property covers them. They occupy the `@z_floating_overlay`
-    region (hover 290 > signature help 280), preserving the historical order.
+    `FocusTree.add_floating_overlays/2` adds them as overlay nodes from
+    `shell_state`; they occupy the `@z_floating_overlay` region (hover 290 >
+    signature help 280).
 
-  * **Still transitional (documented remainder):** float popup, agent context,
-    agent chat, tool manager, extension panels/overlays, observatory, timeline,
-    notifications. These are NOT focus-tree nodes and the BEAM does not compute a
-    layout rect for them: the Go compositor positions each entirely frontend-side
-    (footer-appended, sized by `maxOverlayHeight`/terminal width), so there is no
-    BEAM-authoritative rect to register. Inventing one would not be behaviour-
-    neutral, so they keep a reduced hand-ordered fallback on the Go side until
-    each grows a BEAM rect source. The gap lives in the FocusTree's coverage (and,
-    upstream, in whether each surface's rect is BEAM-known), not in this module's
-    derivation. Because the remainder is non-empty, Go's transitional rank table is
-    *shrunk*, not deleted.
+  * **Footer-band secondary overlays (#2281): float popup, agent context, tool
+    manager, extension panel, observatory, edit timeline, notifications, extension
+    overlay.** The owner ruled these mouse-driven (#2330), so the BEAM owning their
+    footer-band geometry is now the *designed* layout. `FocusTree.add_footer_band_overlays/3`
+    adds each visible one (per `MingaEditor.Layout.FooterOverlays`) as an overlay
+    node with a bottom-anchored full-width rect from `MingaEditor.Layout.OverlayBand`
+    (porting the Go `maxOverlayHeight` clamp). They carry the exact historical
+    stacking z (270/260/240/190/180/170/160/150), so Go composites the single
+    highest-z winner by its placement rect instead of footer-appending. The
+    single-active model still holds (#2268 AC-4): the tree may express several
+    placements, but Go renders one. Their click events route to
+    `MingaEditor.Input.OverlaySink`, which swallows mouse events so a click over a
+    visible overlay never reaches the buffer underneath (AC-2). Per-surface
+    activation semantics land as epic #2330 children.
 
   ## surface_id namespace and the identity-unification call (#2268)
 
@@ -147,6 +149,14 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
           | :completion_menu
           | :hover_popup
           | :signature_help
+          | :float_popup
+          | :agent_context
+          | :tool_manager
+          | :extension_panel
+          | :observatory
+          | :edit_timeline
+          | :notifications
+          | :extension_overlay
 
   @typedoc "Coarse classification of what a click on a surface means."
   @type hit_kind ::
@@ -181,6 +191,23 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   @z_floating_chrome 200
   @z_floating_overlay 280
   @z_overlay 300
+
+  # Footer-band secondary overlays (#2281). These eight occupy the historical
+  # transitional stacking the Go compositor encoded by hand. The owner ruled them
+  # mouse-driven (#2330), so the BEAM now owns their geometry and z. The exact z
+  # values are preserved from the Go transitional table so promotion is behaviour-
+  # neutral: float popup highest, extension overlay lowest. Some sit above the
+  # floating-chrome band (bottom panel, z=200) and some below it, exactly as the
+  # old chain ordered them. The single-active model still holds; multiple visible
+  # placements are expressible but Go renders only the highest-z winner.
+  @z_float_popup 270
+  @z_agent_context 260
+  @z_tool_manager 240
+  @z_extension_panel 190
+  @z_observatory 180
+  @z_edit_timeline 170
+  @z_notifications 160
+  @z_extension_overlay 150
 
   @doc """
   Returns the frame's surface placements ordered back-to-front by `z`.
@@ -380,6 +407,14 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   def surface_id(:completion_menu), do: :completion_menu
   def surface_id(:hover_popup), do: :hover_popup
   def surface_id(:signature_help), do: :signature_help
+  def surface_id(:float_popup), do: :float_popup
+  def surface_id(:agent_context), do: :agent_context
+  def surface_id(:tool_manager), do: :tool_manager
+  def surface_id(:extension_panel), do: :extension_panel
+  def surface_id(:observatory), do: :observatory
+  def surface_id(:edit_timeline), do: :edit_timeline
+  def surface_id(:notifications), do: :notifications
+  def surface_id(:extension_overlay), do: :extension_overlay
   def surface_id({:custom, :sidebar}), do: :custom_sidebar
   def surface_id({:custom, _other}), do: :custom_sidebar
   def surface_id(_other), do: nil
@@ -411,6 +446,14 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   def surface_id_u16(:completion_menu), do: 16
   def surface_id_u16(:hover_popup), do: 17
   def surface_id_u16(:signature_help), do: 18
+  def surface_id_u16(:float_popup), do: 19
+  def surface_id_u16(:agent_context), do: 20
+  def surface_id_u16(:tool_manager), do: 21
+  def surface_id_u16(:extension_panel), do: 22
+  def surface_id_u16(:observatory), do: 23
+  def surface_id_u16(:edit_timeline), do: 24
+  def surface_id_u16(:notifications), do: 25
+  def surface_id_u16(:extension_overlay), do: 26
 
   @doc """
   Maps a registry `hit_kind` atom to its `u8` wire value.
@@ -444,6 +487,16 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   # reproducing the historical Go transitional order exactly (#2281).
   defp z_for(:hover_popup), do: @z_floating_overlay + 10
   defp z_for(:signature_help), do: @z_floating_overlay
+  # Footer-band secondary overlays (#2281): exact historical stacking z preserved
+  # from the Go transitional table so promotion is behaviour-neutral.
+  defp z_for(:float_popup), do: @z_float_popup
+  defp z_for(:agent_context), do: @z_agent_context
+  defp z_for(:tool_manager), do: @z_tool_manager
+  defp z_for(:extension_panel), do: @z_extension_panel
+  defp z_for(:observatory), do: @z_observatory
+  defp z_for(:edit_timeline), do: @z_edit_timeline
+  defp z_for(:notifications), do: @z_notifications
+  defp z_for(:extension_overlay), do: @z_extension_overlay
   defp z_for(id) when id in [:picker_backdrop, :completion_backdrop], do: @z_overlay
   defp z_for(id) when id in [:picker, :completion_menu], do: @z_overlay + 1
   defp z_for(_base_chrome), do: @z_base_chrome
@@ -458,5 +511,19 @@ defmodule MingaEditor.Layout.SurfaceRegistry do
   defp hit_kind_for(id) when id in [:picker, :completion_menu], do: :overlay
   defp hit_kind_for(id) when id in [:picker_backdrop, :completion_backdrop], do: :overlay
   defp hit_kind_for(id) when id in [:hover_popup, :signature_help], do: :overlay
+
+  defp hit_kind_for(id)
+       when id in [
+              :float_popup,
+              :agent_context,
+              :tool_manager,
+              :extension_panel,
+              :observatory,
+              :edit_timeline,
+              :notifications,
+              :extension_overlay
+            ],
+       do: :overlay
+
   defp hit_kind_for(_chrome), do: :chrome
 end

--- a/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
+++ b/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
@@ -192,6 +192,43 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
     assert decoded == expected
   end
 
+  test "a visible footer-band overlay (notifications) emits a registry placement (#2281)" do
+    note =
+      MingaEditor.UI.Notification.new(%{
+        id: "n1",
+        level: :info,
+        title: "Build finished",
+        created_at: System.system_time(:millisecond)
+      })
+
+    center =
+      MingaEditor.UI.NotificationCenter.upsert(MingaEditor.UI.NotificationCenter.new(), note)
+
+    state = %{base_state() | notifications: center}
+
+    commands = emit_commands(state)
+    decoded = commands |> surface_layout_command() |> decode_placements()
+
+    placements = SurfaceRegistry.placements(state)
+    expected = Enum.map(placements, &expected_entry/1)
+
+    # The promoted notifications surface is present in the registry derivation...
+    assert :notifications in Enum.map(placements, & &1.surface_id)
+
+    # ...and its emitted bytes carry the historical stacking z (160) and the
+    # overlay hit_kind, matching the registry rect_for field-for-field.
+    notes_u16 = SurfaceRegistry.surface_id_u16(:notifications)
+    decoded_notes = Enum.find(decoded, &(&1.surface_id == notes_u16))
+
+    assert decoded_notes, "emitted layout missing the promoted notifications surface"
+    assert decoded_notes.z == 160
+    assert decoded_notes.hit_kind == SurfaceRegistry.hit_kind_u8(:overlay)
+    assert decoded_notes.rect == SurfaceRegistry.rect_for_in(placements, :notifications)
+
+    # And the full emitted list still matches the registry, order included.
+    assert decoded == expected
+  end
+
   test "empty placement list still emits a well-formed (zero-count) command" do
     # A degenerate state with no focus tree surfaces still produces a valid,
     # decodable command: the transaction always carries the layout authority,

--- a/test/minga_editor/layout/footer_band_overlays_test.exs
+++ b/test/minga_editor/layout/footer_band_overlays_test.exs
@@ -1,0 +1,270 @@
+defmodule MingaEditor.Layout.FooterBandOverlaysTest do
+  @moduledoc """
+  Promotion of the eight footer-band secondary overlays to registry-placed
+  FocusTree nodes (#2281), plus the click-containment safety floor (AC-2).
+
+  Covers four things:
+
+    * `OverlayBand.rect/2` ports the Go `maxOverlayHeight` clamp and bottom-anchors.
+    * A visible footer surface (notifications) becomes a FocusTree overlay node
+      and a `SurfaceRegistry` placement with the historical stacking z.
+    * A click or scroll over a visible overlay is swallowed by `Input.OverlaySink`
+      and never reaches the buffer underneath.
+    * With the overlay hidden, the same click reaches the buffer and moves its cursor.
+  """
+
+  use ExUnit.Case, async: true
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.FocusTree
+  alias MingaEditor.Input.Router
+  alias MingaEditor.Layout
+  alias MingaEditor.Layout.OverlayBand
+  alias MingaEditor.Layout.SurfaceRegistry
+  alias MingaEditor.UI.Notification
+  alias MingaEditor.UI.NotificationCenter
+
+  defp with_notifications(state) do
+    note =
+      Notification.new(%{
+        id: "n1",
+        level: :info,
+        title: "Build finished",
+        created_at: System.system_time(:millisecond)
+      })
+
+    center = NotificationCenter.upsert(NotificationCenter.new(), note)
+    %{state | notifications: center}
+  end
+
+  defp with_observatory(state) do
+    put_in(state.shell_state.observatory_visible, true)
+  end
+
+  describe "OverlayBand.rect/2" do
+    test "clamps band height to the Go maxOverlayHeight floor/ceiling and bottom-anchors" do
+      # 24 rows: 24/3 = 8, within [4, 12]. Content asks for max (clamp ceiling).
+      terminal = {0, 0, 80, 24}
+      assert OverlayBand.rect(terminal, :max) == {16, 0, 80, 8}
+
+      # Tall terminal: clamp ceiling 12 caps the band.
+      assert OverlayBand.rect({0, 0, 80, 60}, :max) == {48, 0, 80, 12}
+
+      # Short terminal: clamp floor 4 keeps a minimum band.
+      assert OverlayBand.rect({0, 0, 80, 9}, :max) == {5, 0, 80, 4}
+    end
+
+    test "a content height smaller than the clamp shrinks the band to fit content" do
+      # 3 content lines < clamp (8 for 24 rows): band is 3 tall.
+      assert OverlayBand.rect({0, 0, 80, 24}, 3) == {21, 0, 80, 3}
+    end
+  end
+
+  describe "FooterOverlays visibility and registry placement" do
+    test "a visible notifications surface is a registry placement at z=160" do
+      state = with_notifications(base_state())
+      placements = SurfaceRegistry.placements(state)
+      ids = Enum.map(placements, & &1.surface_id)
+
+      assert :notifications in ids
+      rect = SurfaceRegistry.rect_for(state, :notifications)
+      assert rect != nil
+
+      placement = Enum.find(placements, &(&1.surface_id == :notifications))
+      assert placement.z == 160
+      assert placement.hit_kind == :overlay
+    end
+
+    test "the notifications placement is the full-width bottom band sized to its content" do
+      state = with_notifications(base_state(rows: 24, cols: 80))
+      {row, col, width, height} = SurfaceRegistry.rect_for(state, :notifications)
+
+      # Full width, bottom-anchored. With ONE notification item the BEAM content
+      # height is title bar (1) + 2 lines per item = 3, well under the band ceiling
+      # (24/3 = 8), so the band is content-sized (3) and hugs the screen bottom.
+      # This is the position fix: a short notification no longer spans the full band
+      # and renders rows above the bottom (#2281).
+      assert col == 0
+      assert width == 80
+      assert height == 3
+      assert row + height == 24
+    end
+
+    test "no footer overlay is placed when none is visible" do
+      state = base_state()
+      ids = state |> SurfaceRegistry.placements() |> Enum.map(& &1.surface_id)
+
+      refute :notifications in ids
+      refute :float_popup in ids
+      refute :observatory in ids
+    end
+
+    test "the notifications focus node routes to the swallow-by-default sink" do
+      state = with_notifications(base_state())
+      tree = FocusTree.from_state(state)
+      {r, c, _w, _h} = SurfaceRegistry.rect_for(state, :notifications)
+
+      node = FocusTree.hit_test(tree, r, c)
+      assert node.content_type == :notifications
+      assert node.handler == MingaEditor.Input.OverlaySink
+    end
+  end
+
+  describe "hit-test winner matches the render winner (#2281)" do
+    test "two visible overlays resolve to the higher-z surface over the shared band" do
+      # Notifications (z=160) and observatory (z=180) are both visible this frame.
+      # Go composites the HIGHEST-z surface on top (observatory, 180), so the BEAM
+      # hit-test over the shared bottom band MUST resolve to observatory too: the
+      # hit-winner must equal the render-winner, or #2330's per-surface handlers
+      # would route a click to the wrong surface.
+      state =
+        base_state(rows: 24, cols: 80)
+        |> with_notifications()
+        |> with_observatory()
+
+      placements = SurfaceRegistry.placements(state)
+      ids = Enum.map(placements, & &1.surface_id)
+      assert :notifications in ids
+      assert :observatory in ids
+
+      tree = FocusTree.from_state(state)
+
+      # A point inside both bands (both are full-width, bottom-anchored). Use the
+      # observatory band's bottom-left cell, which both rects contain.
+      {obs_row, obs_col, _w, obs_h} = SurfaceRegistry.rect_for(state, :observatory)
+      hit_row = obs_row + obs_h - 1
+
+      node = FocusTree.hit_test(tree, hit_row, obs_col)
+
+      assert node.content_type == :observatory,
+             "expected the higher-z observatory to win the hit-test, got #{inspect(node.content_type)}"
+    end
+
+    test "across the full shared overlap the higher-z surface always wins" do
+      # Wherever the two bands overlap (both are full-width, bottom-anchored, so the
+      # shorter band's rows are a subset of the taller band's), the hit-test must
+      # return the higher-z observatory, never the lower-z notifications. This is
+      # the exact inversion the bug produced: appending visible/1 in descending z
+      # made the lowest-z node the last child, so the reversed hit-test picked it.
+      state =
+        base_state(rows: 24, cols: 80)
+        |> with_notifications()
+        |> with_observatory()
+
+      tree = FocusTree.from_state(state)
+      {n_row, n_col, _nw, n_h} = SurfaceRegistry.rect_for(state, :notifications)
+      {o_row, _oc, _ow, o_h} = SurfaceRegistry.rect_for(state, :observatory)
+
+      overlap_top = max(n_row, o_row)
+      overlap_bottom = min(n_row + n_h, o_row + o_h) - 1
+
+      for row <- overlap_top..overlap_bottom do
+        node = FocusTree.hit_test(tree, row, n_col)
+
+        assert node.content_type == :observatory,
+               "row #{row} in the shared band resolved to #{inspect(node.content_type)}, expected the higher-z observatory"
+      end
+    end
+  end
+
+  describe "short-overlay position pinning (#2281)" do
+    test "the short notifications band hugs the screen bottom, not the full band" do
+      state = with_notifications(base_state(rows: 24, cols: 80))
+      {row, _col, _w, height} = SurfaceRegistry.rect_for(state, :notifications)
+
+      # One notification: band is content-sized (3), not the :max ceiling (8), and
+      # its bottom edge is the screen bottom (above the minibuffer), matching where
+      # the old footer-append put it.
+      assert height == 3
+      assert row + height == 24
+      assert row == 21
+    end
+
+    test "a click immediately above a short notification reaches the buffer" do
+      # The notification band is the lowest 3 rows; the row directly above it (row
+      # 20) is outside the tightened rect, so a click there is NOT swallowed and
+      # reaches the buffer underneath. Before the fix the rect spanned the full band
+      # and this row phantom-swallowed the click.
+      state =
+        [rows: 24, cols: 80, content: long_content(200)]
+        |> base_state()
+        |> seed_state(0)
+        |> with_notifications()
+
+      assert {0, 0} == BufferProcess.cursor(state.workspace.buffers.active)
+
+      {n_row, n_col, _w, _h} = SurfaceRegistry.rect_for(state, :notifications)
+      above_row = n_row - 1
+
+      # The row above the band is buffer content, not overlay: confirm no overlay
+      # rect contains it.
+      refute SurfaceRegistry.within?(state, :notifications, above_row, n_col)
+
+      new_state = Router.dispatch_mouse(state, above_row, n_col, :left, 0, :press, 1)
+      {cur_line, _cur_col} = BufferProcess.cursor(new_state.workspace.buffers.active)
+
+      assert cur_line > 0,
+             "a click above the tightened notifications band should reach the buffer"
+    end
+  end
+
+  describe "click containment (AC-2)" do
+    test "a click over a visible notifications overlay does not move the buffer cursor" do
+      state = with_notifications(base_state())
+      buf = state.workspace.buffers.active
+      before = BufferProcess.cursor(buf)
+
+      {r, c, _w, _h} = SurfaceRegistry.rect_for(state, :notifications)
+      # The overlay sits at the bottom band, over buffer text; a raw click there
+      # would normally move the cursor. The sink must swallow it.
+      _state = Router.dispatch_mouse(state, r, c, :left, 0, :press, 1)
+
+      assert BufferProcess.cursor(buf) == before
+    end
+
+    test "a scroll over a visible notifications overlay does not scroll the buffer" do
+      # Tall buffer so a wheel event on the buffer would scroll it.
+      state =
+        [rows: 24, cols: 80, content: long_content(200)]
+        |> base_state()
+        |> seed_state(0)
+        |> with_notifications()
+
+      win_id = state.workspace.windows.active
+      before_top = state.workspace.windows.map[win_id].viewport.top
+
+      {r, c, _w, _h} = SurfaceRegistry.rect_for(state, :notifications)
+      new_state = Router.dispatch_mouse(state, r, c, :wheel_down, 0, :press, 1)
+
+      after_top = new_state.workspace.windows.map[win_id].viewport.top
+      assert after_top == before_top
+    end
+
+    test "with notifications hidden, the same click reaches the buffer and moves its cursor" do
+      # Same geometry, but no overlay: the click lands on buffer text and the
+      # normal-mode mouse handler moves the cursor there. This proves the sink is
+      # gated on visibility, not unconditionally swallowing buffer clicks. A tall
+      # buffer guarantees the click row maps to a real, non-zero buffer line.
+      state =
+        [rows: 24, cols: 80, content: long_content(200)]
+        |> base_state()
+        |> seed_state(0)
+
+      assert {0, 0} == BufferProcess.cursor(state.workspace.buffers.active)
+
+      # The band's top row, in the content area, is where the overlay would have
+      # sat: the only difference from the visible case is the overlay's presence.
+      layout = Layout.get(state)
+      {row, col, _w, _h} = OverlayBand.rect(layout.terminal, :max)
+
+      new_state = Router.dispatch_mouse(state, row, col, :left, 0, :press, 1)
+      {cur_line, _cur_col} = BufferProcess.cursor(new_state.workspace.buffers.active)
+
+      # The click row maps to a buffer line below the top, so the cursor moved off
+      # line 0: the event reached the buffer because no sink swallowed it.
+      assert cur_line > 0
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The ready-now child of epic #2330 (mouse-driven secondary overlays), built on the owner's design ruling: the BEAM owns footer-band geometry, the single-active-overlay model stays. This closes #2281 in its re-scoped form.

- **Eight surfaces registry-placed**: a shared `OverlayBand` helper computes bottom-anchored rects (porting the frontend's height clamp); `FooterOverlays` derives per-surface visibility + content heights; the registry emits placements (ids 19–26, z preserving the exact prior stacking) over the existing wire — no schema change.
- **Honest geometry, two buckets**: count-derivable surfaces (notifications `1+2×items`, observatory, edit timeline, extension overlay — each verified against the actual Go renderer output) get content-sized rects with ~zero phantom hit area; wrap-dependent surfaces (float popup, extension panel) keep the clamp-ceiling band with Go bottom-aligning content inside it, so **short overlays hug the screen bottom exactly as before** and the bounded residual phantom zone sits above the content, documented per surface. agent_context/tool_manager are registered but structurally dormant (no BEAM content source yet — their epic children light them up).
- **Hit winner == render winner, guaranteed**: footer nodes insert in ascending z so the BEAM's hit-test resolves to the same surface Go displays — the bug-hunt caught the inversion (latent landmine for per-surface handlers) and the fix is pinned by two-visible and full-overlap tests **proven non-tautological** (reverting the fix fails exactly those tests).
- **The Go fallback ordering table is deleted entirely**: `surfaceOrder` reads placement z only; the winner composites at its placement rect via the proven layer path; overlay zones merge at the placement offset (completion/hover clicks keep resolving at absolute screen coords, test-verified); the dead agentChat entry is gone.
- **The immediate UX fix shipped**: clicks/scrolls over a visible overlay are swallowed by a shared `OverlaySink` (the cursor no longer moves under a visible notification), with the hidden-case test proving the sink is visibility-gated. Per-surface *activation* semantics (clicking a notification acts on it) are the epic's follow-up children, to be filed against this infrastructure.

**Merge sequencing**: #2331 (completion doc preview) also touches `render_chrome.go` — whichever lands second gets a rebase pass.

## Tests

- Elixir: 13 new footer-band tests (containment triad, inversion pair, position pinning, content-sized heights) + focus/router/emit suites 87; full suite 9,336 / 0 failures; `make lint` green; `mix protocol.gen --check` exit 0
- Go: 325 passed incl. bottom-align position tests, placement-only ordering, renders-nothing-without-placements, zone-offset absolute-coord tests; gofmt/vet clean
- Reviews: prtk-code-reviewer bug-hunt (zones/transaction/dormancy/clamp clean; its two Important findings — hit-winner inversion and short-overlay float-up — fixed with mutation-proven tests), acceptance reviewer PASS (height spot-check against the real Go renderer, bottom-align edge cases, ordering invariant documentation verified)

Closes #2281. Part of #2330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)