### PR TITLE
feat(board): zoomed card identity and ESC affordance render semantically

### DIFF
--- a/extensions/board/frontend/go/tui/board.go
+++ b/extensions/board/frontend/go/tui/board.go
@@ -12,6 +12,23 @@ type Board struct {
 	FilterMode    bool
 	FilterText    string
 	Cards         []BoardCard
+	// ZoomedCardID is the card the user is zoomed into, or 0 in grid view. When
+	// non-zero, Visible is false and the frontend renders a zoom header (status
+	// icon, task, model, ESC affordance) over the editor instead of the grid.
+	ZoomedCardID uint32
+}
+
+// ZoomedCard returns the card matching ZoomedCardID, or nil when not zoomed.
+func (b Board) ZoomedCard() *BoardCard {
+	if b.ZoomedCardID == 0 {
+		return nil
+	}
+	for i := range b.Cards {
+		if b.Cards[i].ID == b.ZoomedCardID {
+			return &b.Cards[i]
+		}
+	}
+	return nil
 }
 
 // BoardCard is one Board card in the extension-owned legacy GUI payload.
@@ -79,6 +96,12 @@ func DecodeBoard(payload []byte) (Board, string, int) {
 		}
 		offset += sparklineCount * 2
 		board.Cards = append(board.Cards, card)
+	}
+	// Trailing zoomed_card_id u32 (0 = grid view). Tolerate older BEAMs that omit
+	// the trailer by leaving ZoomedCardID at zero rather than failing the decode.
+	if len(payload) >= offset+4 {
+		board.ZoomedCardID = binary.BigEndian.Uint32(payload[offset : offset+4])
+		offset += 4
 	}
 	return board, fmt.Sprintf("%d cards", len(board.Cards)), offset
 }

--- a/extensions/board/frontend/go/tui/board_test.go
+++ b/extensions/board/frontend/go/tui/board_test.go
@@ -11,6 +11,38 @@ func boardPacket() []byte {
 	packet = append(packet, []byte{0, 0, 0, 42, 1, 0, 8}...)
 	packet = append(packet, []byte("lib/a.ex")...)
 	packet = append(packet, []byte{2, 0, 0, 0xFF, 0xFF}...)
+	// Trailing zoomed_card_id u32 (0 = grid view, not zoomed).
+	packet = append(packet, []byte{0, 0, 0, 0}...)
+	return packet
+}
+
+// zoomedBoardPacket mirrors boardPacket but with visible=0, status=working, and
+// the trailing zoomed_card_id pointing at the single card: the BEAM's zoomed
+// state (visible? false while a card is zoomed).
+func zoomedBoardPacket() []byte {
+	packet := []byte{0x87, 0, 0, 0, 0, 7, 0, 1, 0, 0, 0}
+	packet = append(packet, []byte{0, 0, 0, 7, 1, 2, 0, 8}...)
+	packet = append(packet, []byte("fix auth")...)
+	packet = append(packet, byte(8))
+	packet = append(packet, []byte("claude-4")...)
+	packet = append(packet, []byte{0, 0, 0, 42, 1, 0, 8}...)
+	packet = append(packet, []byte("lib/a.ex")...)
+	packet = append(packet, []byte{2, 0, 0, 0xFF, 0xFF}...)
+	packet = append(packet, []byte{0, 0, 0, 7}...)
+	return packet
+}
+
+// legacyBoardPacket is boardPacket without the zoomed_card_id trailer: an older
+// BEAM. The decoder must tolerate it and leave ZoomedCardID at zero.
+func legacyBoardPacket() []byte {
+	packet := []byte{0x87, 1, 0, 0, 0, 7, 0, 1, 0, 0, 0}
+	packet = append(packet, []byte{0, 0, 0, 7, 3, 2, 0, 8}...)
+	packet = append(packet, []byte("fix auth")...)
+	packet = append(packet, byte(8))
+	packet = append(packet, []byte("claude-4")...)
+	packet = append(packet, []byte{0, 0, 0, 42, 1, 0, 8}...)
+	packet = append(packet, []byte("lib/a.ex")...)
+	packet = append(packet, []byte{2, 0, 0, 0xFF, 0xFF}...)
 	return packet
 }
 
@@ -33,5 +65,61 @@ func TestRenderLines(t *testing.T) {
 	lines := RenderLines(board, 2)
 	if len(lines) != 2 || lines[0] != "Board  1 cards" || lines[1] != "> needs you  fix auth" {
 		t.Fatalf("rendered lines = %#v", lines)
+	}
+}
+
+func TestDecodeBoardZoomedCardID(t *testing.T) {
+	board, _, size := DecodeBoard(zoomedBoardPacket())
+	if size != len(zoomedBoardPacket()) {
+		t.Fatalf("size = %d, want %d", size, len(zoomedBoardPacket()))
+	}
+	if board.Visible {
+		t.Fatalf("zoomed board should report Visible=false, got %#v", board)
+	}
+	if board.ZoomedCardID != 7 {
+		t.Fatalf("ZoomedCardID = %d, want 7", board.ZoomedCardID)
+	}
+	card := board.ZoomedCard()
+	if card == nil || card.ID != 7 || card.Task != "fix auth" {
+		t.Fatalf("ZoomedCard = %#v", card)
+	}
+}
+
+func TestDecodeBoardLegacyPacketWithoutTrailer(t *testing.T) {
+	board, _, size := DecodeBoard(legacyBoardPacket())
+	if size != len(legacyBoardPacket()) {
+		t.Fatalf("size = %d, want %d", size, len(legacyBoardPacket()))
+	}
+	if board.ZoomedCardID != 0 {
+		t.Fatalf("legacy packet should leave ZoomedCardID=0, got %d", board.ZoomedCardID)
+	}
+	if board.ZoomedCard() != nil {
+		t.Fatalf("legacy packet should have no zoomed card")
+	}
+}
+
+func TestZoomHeaderLine(t *testing.T) {
+	board, _, _ := DecodeBoard(zoomedBoardPacket())
+	const width = 60
+	line := ZoomHeaderLine(board, width)
+	if line == "" {
+		t.Fatalf("expected a zoom header line for a zoomed board")
+	}
+	if got := []rune(line); len(got) != width {
+		t.Fatalf("zoom header width = %d, want %d: %q", len(got), width, line)
+	}
+	wantLeft := " ● fix auth · claude-4"
+	if got := string([]rune(line)[:len([]rune(wantLeft))]); got != wantLeft {
+		t.Fatalf("zoom header left = %q, want %q", got, wantLeft)
+	}
+	if want := "ESC back to Board "; line[len(line)-len(want):] != want {
+		t.Fatalf("zoom header should end with %q, got %q", want, line)
+	}
+}
+
+func TestZoomHeaderLineEmptyWhenNotZoomed(t *testing.T) {
+	board, _, _ := DecodeBoard(boardPacket())
+	if line := ZoomHeaderLine(board, 40); line != "" {
+		t.Fatalf("non-zoomed board should produce no header, got %q", line)
 	}
 }

--- a/extensions/board/frontend/go/tui/render.go
+++ b/extensions/board/frontend/go/tui/render.go
@@ -1,6 +1,9 @@
 package board
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // RenderLines renders a compact extension-owned Board summary for terminal frontends. The Charm TUI no longer carries this renderer in core parity code.
 func RenderLines(board Board, maxHeight int) []string {
@@ -19,6 +22,56 @@ func RenderLines(board Board, maxHeight int) []string {
 		}
 	}
 	return lines
+}
+
+// ZoomHeaderLine renders the single-line zoom header shown at the top of the
+// zoomed card view: status icon, task, optional model, and the "ESC back to
+// Board" affordance right-aligned to width. It returns "" when the board is not
+// zoomed or the zoomed card is missing. This restores the capability the old
+// cell-grid build_zoom_context_bar provided before it was disposed (#2328); it
+// is a contextual header over the editor, not a cell-grid draw path.
+func ZoomHeaderLine(board Board, width int) string {
+	card := board.ZoomedCard()
+	if card == nil || width <= 0 {
+		return ""
+	}
+
+	left := fmt.Sprintf(" %s %s", zoomStatusIcon(card.Status), card.Task)
+	if card.Model != "" {
+		left += " · " + card.Model
+	}
+	hint := " ESC back to Board "
+
+	leftRunes := []rune(left)
+	hintRunes := []rune(hint)
+	if len(leftRunes)+len(hintRunes) >= width {
+		// No room for the hint: clamp the identity to the available width.
+		if len(leftRunes) > width {
+			return string(leftRunes[:width])
+		}
+		return left
+	}
+	gap := width - len(leftRunes) - len(hintRunes)
+	return left + strings.Repeat(" ", gap) + hint
+}
+
+func zoomStatusIcon(status byte) string {
+	switch status {
+	case 0:
+		return "○"
+	case 1:
+		return "●"
+	case 2:
+		return "◉"
+	case 3:
+		return "◆"
+	case 4:
+		return "✓"
+	case 5:
+		return "✗"
+	default:
+		return "○"
+	}
 }
 
 func statusName(status byte) string {

--- a/extensions/board/frontend/macos/Sources/BoardFrontendRuntime.swift
+++ b/extensions/board/frontend/macos/Sources/BoardFrontendRuntime.swift
@@ -24,7 +24,8 @@ final class BoardFrontendRuntime {
                     focusedCardId: decoded.focusedCardID,
                     cards: decoded.cards,
                     filterMode: decoded.filterMode,
-                    filterText: decoded.filterText
+                    filterText: decoded.filterText,
+                    zoomedCardId: decoded.zoomedCardID
                 )
             },
             view: { context in
@@ -38,6 +39,15 @@ final class BoardFrontendRuntime {
                                 encoder: context.encoder,
                                 namespace: context.namespace
                             )
+                        } else if let card = state.zoomedCard {
+                            // Grid hidden but a card is zoomed: render the zoom
+                            // header at the top over the editor. The editor body
+                            // itself renders through the window pipeline; this is
+                            // a contextual header only, no cell-grid path (#2328).
+                            VStack(spacing: 0) {
+                                BoardZoomHeader(card: card, theme: context.theme)
+                                Spacer(minLength: 0)
+                            }
                         }
                     }
                 )
@@ -51,6 +61,10 @@ final class BoardFrontendRuntime {
         let filterMode: Bool
         let filterText: String
         let cards: [BoardCard]
+        // Card the user is zoomed into, or 0 in grid view. Non-zero means the
+        // grid is hidden (visible false) but the zoom header should render the
+        // card identity + ESC affordance over the editor (ticket #2328).
+        let zoomedCardID: UInt32
     }
 
     static var stateForTesting: BoardState {
@@ -127,7 +141,15 @@ final class BoardFrontendRuntime {
             ))
         }
 
-        return DecodedBoard(visible: visible, focusedCardID: focusedCardID, filterMode: filterMode, filterText: filterText, cards: cards)
+        // Trailing zoomed_card_id u32 (0 = grid view). Tolerate older BEAMs that
+        // omit the trailer by defaulting to 0 rather than failing the decode.
+        var zoomedCardID: UInt32 = 0
+        if pos + 4 <= data.endIndex {
+            zoomedCardID = readU32(data, pos)
+            pos += 4
+        }
+
+        return DecodedBoard(visible: visible, focusedCardID: focusedCardID, filterMode: filterMode, filterText: filterText, cards: cards, zoomedCardID: zoomedCardID)
     }
 
     private static func readString16(_ data: Data, _ pos: inout Int, _ end: Int) -> String? {

--- a/extensions/board/frontend/macos/Sources/Views/Board/BoardState.swift
+++ b/extensions/board/frontend/macos/Sources/Views/Board/BoardState.swift
@@ -26,16 +26,26 @@ final class BoardState {
 
     /// ID of the card being zoomed. Set when transitioning from Board
     /// to editor (visible true→false) or editor to Board (visible false→true).
-    /// Used by matchedGeometryEffect for spatial zoom animation.
+    /// Used by matchedGeometryEffect for spatial zoom animation and by the zoom
+    /// header. This is now authoritative from the wire (`zoomed_card_id`, #2328)
+    /// rather than inferred from the visible transition.
     var zoomedCardId: UInt32? = nil
 
+    /// The card the user is zoomed into, looked up from the current cards. The
+    /// BEAM sends all cards every frame, so this resolves even while the grid is
+    /// hidden. Drives the zoom header (status icon, task, model, ESC affordance).
+    var zoomedCard: BoardCard? {
+        guard let id = zoomedCardId, id != 0 else { return nil }
+        return cards.first { $0.id == id }
+    }
+
     /// Updates the board state from a decoded protocol command.
+    ///
+    /// `zoomedCardId` is authoritative from the wire: non-zero while a card is
+    /// zoomed (grid hidden), zero in grid view.
     func update(visible: Bool, focusedCardId: UInt32, cards: [BoardCard],
-                filterMode: Bool, filterText: String) {
-        // Detect zoom transitions and track the card being zoomed
-        if self.visible != visible && focusedCardId != 0 {
-            self.zoomedCardId = focusedCardId
-        }
+                filterMode: Bool, filterText: String, zoomedCardId: UInt32 = 0) {
+        self.zoomedCardId = zoomedCardId == 0 ? nil : zoomedCardId
 
         self.visible = visible
         self.focusedCardId = focusedCardId

--- a/extensions/board/frontend/macos/Sources/Views/Board/BoardZoomHeader.swift
+++ b/extensions/board/frontend/macos/Sources/Views/Board/BoardZoomHeader.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// The zoom header shown at the top of the zoomed card view.
+///
+/// When the user zooms into a Board card the grid is hidden and the card's
+/// workspace renders through the normal editor pipeline. Without this header the
+/// zoomed state has no card identity and no visible way back to the grid. The
+/// header restores the capability the old cell-grid `build_zoom_context_bar`
+/// provided before it was disposed (ticket #2328): a status icon, the task, the
+/// model, and an "ESC back to Board" affordance. It is a native SwiftUI bar over
+/// the editor, not a cell-grid draw path.
+struct BoardZoomHeader: View {
+    let card: BoardCard
+    let theme: ThemeColors
+
+    var body: some View {
+        HStack(spacing: 8) {
+            statusIcon
+            Text(card.isYouCard ? "Manual editing" : card.task)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(theme.editorFg)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if !card.model.isEmpty {
+                Text("· \(card.model)")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 12)
+            Text("ESC back to Board")
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(Color.blend(theme.editorBg, with: .white, amount: 0.05))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.treeSeparatorFg.opacity(0.4))
+                .frame(height: 1)
+        }
+        // VoiceOver: announce the zoomed card identity and the exit affordance.
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Zoomed into \(card.isYouCard ? "Manual editing" : card.task), \(card.isYouCard ? "You" : card.status.label)")
+        .accessibilityHint("Press Escape to go back to the Board")
+    }
+
+    /// Status icon mirroring the old cell-grid zoom bar glyphs.
+    private var statusIcon: some View {
+        Text(iconGlyph)
+            .font(.system(size: 12, weight: .bold))
+            .foregroundStyle(iconColor)
+    }
+
+    private var iconGlyph: String {
+        if card.isYouCard { return "◐" }
+        switch card.status {
+        case .idle: return "○"
+        case .working: return "●"
+        case .iterating: return "◉"
+        case .needsYou: return "◆"
+        case .done: return "✓"
+        case .errored: return "✗"
+        }
+    }
+
+    private var iconColor: Color {
+        if card.isYouCard { return .secondary }
+        switch card.status {
+        case .idle: return theme.agentStatusIdle
+        case .working: return theme.agentStatusWorking
+        case .iterating: return theme.agentStatusIterating
+        case .needsYou: return theme.agentStatusNeedsYou
+        case .done: return theme.agentStatusDone
+        case .errored: return theme.agentStatusErrored
+        }
+    }
+}
+
+// MARK: - Color Blending
+
+private extension Color {
+    /// Blends two colors by the given amount (0 = all base, 1 = all target).
+    static func blend(_ base: Color, with target: Color, amount: Double) -> Color {
+        let nsBase = NSColor(base).usingColorSpace(.sRGB) ?? NSColor(base)
+        let nsTarget = NSColor(target).usingColorSpace(.sRGB) ?? NSColor(target)
+        let t = max(0, min(1, amount))
+
+        let r = nsBase.redComponent * (1 - t) + nsTarget.redComponent * t
+        let g = nsBase.greenComponent * (1 - t) + nsTarget.greenComponent * t
+        let b = nsBase.blueComponent * (1 - t) + nsTarget.blueComponent * t
+        let a = nsBase.alphaComponent * (1 - t) + nsTarget.alphaComponent * t
+
+        return Color(nsColor: NSColor(srgbRed: r, green: g, blue: b, alpha: a))
+    }
+}

--- a/extensions/board/frontend/rust/tui/src/board.rs
+++ b/extensions/board/frontend/rust/tui/src/board.rs
@@ -7,6 +7,9 @@ pub struct Board {
     pub filter_mode: u8,
     pub filter_text: String,
     pub cards: Vec<BoardCard>,
+    /// Card the user is zoomed into, or 0 in grid view. Non-zero means the grid
+    /// is hidden (`visible == 0`) but the frontend renders a zoom header (#2328).
+    pub zoomed_card_id: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -94,6 +97,19 @@ pub fn decode_board(bytes: &[u8]) -> Result<(Board, usize), &'static str> {
         });
     }
 
+    // Trailing zoomed_card_id u32 (0 = grid view). Tolerate older BEAMs that omit
+    // the trailer by leaving zoomed_card_id at zero.
+    let mut zoomed_card_id = 0u32;
+    if bytes.len() >= offset + 4 {
+        zoomed_card_id = u32::from_be_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ]);
+        offset += 4;
+    }
+
     Ok((
         Board {
             visible,
@@ -101,6 +117,7 @@ pub fn decode_board(bytes: &[u8]) -> Result<(Board, usize), &'static str> {
             filter_mode,
             filter_text,
             cards,
+            zoomed_card_id,
         },
         offset,
     ))

--- a/extensions/board/frontend/rust/tui/src/lib.rs
+++ b/extensions/board/frontend/rust/tui/src/lib.rs
@@ -13,6 +13,21 @@ mod tests {
         packet.extend_from_slice(&[0, 0, 0, 42, 1, 0, 8]);
         packet.extend_from_slice(b"lib/a.ex");
         packet.extend_from_slice(&[2, 0, 0, 0xFF, 0xFF]);
+        // Trailing zoomed_card_id u32 (0 = grid view, not zoomed).
+        packet.extend_from_slice(&[0, 0, 0, 0]);
+        packet
+    }
+
+    fn zoomed_packet() -> Vec<u8> {
+        let mut packet = vec![0x87, 0, 0, 0, 0, 7, 0, 1, 0, 0, 0];
+        packet.extend_from_slice(&[0, 0, 0, 7, 1, 2, 0, 8]);
+        packet.extend_from_slice(b"fix auth");
+        packet.push(8);
+        packet.extend_from_slice(b"claude-4");
+        packet.extend_from_slice(&[0, 0, 0, 42, 1, 0, 8]);
+        packet.extend_from_slice(b"lib/a.ex");
+        packet.extend_from_slice(&[2, 0, 0, 0xFF, 0xFF]);
+        packet.extend_from_slice(&[0, 0, 0, 7]);
         packet
     }
 
@@ -23,6 +38,7 @@ mod tests {
         assert_eq!(size, bytes.len());
         assert_eq!(board.visible, 1);
         assert_eq!(board.focused_card_id, 7);
+        assert_eq!(board.zoomed_card_id, 0);
         assert_eq!(board.cards.len(), 1);
         let card = &board.cards[0];
         assert_eq!(card.id, 7);
@@ -31,6 +47,24 @@ mod tests {
         assert_eq!(card.task, "fix auth");
         assert_eq!(card.model, "claude-4");
         assert_eq!(card.recent_files, ["lib/a.ex"]);
+    }
+
+    #[test]
+    fn decodes_zoomed_card_id() {
+        let bytes = zoomed_packet();
+        let (board, size) = decode_board(&bytes).unwrap();
+        assert_eq!(size, bytes.len());
+        assert_eq!(board.visible, 0);
+        assert_eq!(board.zoomed_card_id, 7);
+    }
+
+    #[test]
+    fn tolerates_legacy_packet_without_trailer() {
+        let mut bytes = packet();
+        bytes.truncate(bytes.len() - 4); // drop the zoomed_card_id trailer
+        let (board, size) = decode_board(&bytes).unwrap();
+        assert_eq!(size, bytes.len());
+        assert_eq!(board.zoomed_card_id, 0);
     }
 
     #[test]

--- a/extensions/board/frontend/zig/src/board.zig
+++ b/extensions/board/frontend/zig/src/board.zig
@@ -7,6 +7,9 @@ pub const Board = struct {
     filter_mode: bool,
     filter_text: []u8,
     cards: []BoardCard,
+    // Card the user is zoomed into, or 0 in grid view. Non-zero means the grid
+    // is hidden (visible false) but the frontend renders a zoom header (#2328).
+    zoomed_card_id: u32,
 
     pub fn deinit(self: *Board, alloc: std.mem.Allocator) void {
         alloc.free(self.filter_text);
@@ -81,7 +84,15 @@ pub fn decodeBoard(alloc: std.mem.Allocator, packet: []const u8) !Board {
         cards[decoded] = .{ .id = id, .status = status, .flags = flags, .task = task, .model = model, .timestamp = timestamp, .recent_files = files };
     }
 
-    return .{ .visible = packet[1] != 0, .focused_card_id = readU32(packet, 2), .filter_mode = packet[8] != 0, .filter_text = filter, .cards = cards };
+    // Trailing zoomed_card_id u32 (0 = grid view). Tolerate older BEAMs that omit
+    // the trailer by leaving zoomed_card_id at zero.
+    var zoomed_card_id: u32 = 0;
+    if (packet.len >= offset + 4) {
+        zoomed_card_id = readU32(packet, offset);
+        offset += 4;
+    }
+
+    return .{ .visible = packet[1] != 0, .focused_card_id = readU32(packet, 2), .filter_mode = packet[8] != 0, .filter_text = filter, .cards = cards, .zoomed_card_id = zoomed_card_id };
 }
 
 pub fn statusLabel(status: u8) []const u8 {
@@ -117,18 +128,38 @@ fn readString16(alloc: std.mem.Allocator, packet: []const u8, offset: *usize) ![
 }
 
 test "decodes extension-owned board payload" {
-    const packet = [_]u8{ 0x87, 1, 0, 0, 0, 7, 0, 1, 0, 0, 0, 0, 0, 0, 7, 3, 2, 0, 8 } ++ "fix auth".* ++ [_]u8{8} ++ "claude-4".* ++ [_]u8{ 0, 0, 0, 42, 1, 0, 8 } ++ "lib/a.ex".* ++ [_]u8{ 2, 0, 0, 0xFF, 0xFF };
+    // Trailing 0,0,0,0 is the zoomed_card_id u32 (0 = grid view).
+    const packet = [_]u8{ 0x87, 1, 0, 0, 0, 7, 0, 1, 0, 0, 0, 0, 0, 0, 7, 3, 2, 0, 8 } ++ "fix auth".* ++ [_]u8{8} ++ "claude-4".* ++ [_]u8{ 0, 0, 0, 42, 1, 0, 8 } ++ "lib/a.ex".* ++ [_]u8{ 2, 0, 0, 0xFF, 0xFF } ++ [_]u8{ 0, 0, 0, 0 };
     var board = try decodeBoard(std.testing.allocator, &packet);
     defer board.deinit(std.testing.allocator);
 
     try std.testing.expect(board.visible);
     try std.testing.expectEqual(@as(u32, 7), board.focused_card_id);
+    try std.testing.expectEqual(@as(u32, 0), board.zoomed_card_id);
     try std.testing.expectEqual(@as(usize, 1), board.cards.len);
     try std.testing.expectEqual(@as(u32, 7), board.cards[0].id);
     try std.testing.expectEqual(@as(u8, 3), board.cards[0].status);
     try std.testing.expectEqualStrings("fix auth", board.cards[0].task);
     try std.testing.expectEqualStrings("claude-4", board.cards[0].model);
     try std.testing.expectEqualStrings("lib/a.ex", board.cards[0].recent_files[0]);
+}
+
+test "decodes zoomed_card_id trailer" {
+    // visible=0, status working, trailing zoomed_card_id = 7.
+    const packet = [_]u8{ 0x87, 0, 0, 0, 0, 7, 0, 1, 0, 0, 0, 0, 0, 0, 7, 1, 2, 0, 8 } ++ "fix auth".* ++ [_]u8{8} ++ "claude-4".* ++ [_]u8{ 0, 0, 0, 42, 1, 0, 8 } ++ "lib/a.ex".* ++ [_]u8{ 2, 0, 0, 0xFF, 0xFF } ++ [_]u8{ 0, 0, 0, 7 };
+    var board = try decodeBoard(std.testing.allocator, &packet);
+    defer board.deinit(std.testing.allocator);
+
+    try std.testing.expect(!board.visible);
+    try std.testing.expectEqual(@as(u32, 7), board.zoomed_card_id);
+}
+
+test "tolerates legacy packet without zoom trailer" {
+    const packet = [_]u8{ 0x87, 1, 0, 0, 0, 7, 0, 1, 0, 0, 0, 0, 0, 0, 7, 3, 2, 0, 8 } ++ "fix auth".* ++ [_]u8{8} ++ "claude-4".* ++ [_]u8{ 0, 0, 0, 42, 1, 0, 8 } ++ "lib/a.ex".* ++ [_]u8{ 2, 0, 0, 0xFF, 0xFF };
+    var board = try decodeBoard(std.testing.allocator, &packet);
+    defer board.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(u32, 0), board.zoomed_card_id);
 }
 
 test "status labels are stable" {

--- a/extensions/board/lib/minga_board/frontend/adapter/gui/board_encoder.ex
+++ b/extensions/board/lib/minga_board/frontend/adapter/gui/board_encoder.ex
@@ -26,6 +26,13 @@ defmodule MingaBoard.Frontend.Adapter.GUI.BoardEncoder do
     cards = board.cards
     visible = if board.visible?, do: 1, else: 0
     focused_id = board.focused_card_id || 0
+    # zoomed_card_id (0 = grid view, not zoomed). When zoomed, visible? is false
+    # but this carries which card the user is inside so frontends can render the
+    # zoom header (status icon, task, model, ESC affordance) over the editor
+    # without reintroducing any cell-grid draw path (ticket #2328). It is a fixed
+    # u32 trailer after the cards array; older frontends that stop reading after
+    # the last card simply ignore it.
+    zoomed_id = board.zoomed_card_id || 0
 
     card_entries = Enum.map(cards, &encode_card(&1, board.focused_card_id))
 
@@ -35,8 +42,9 @@ defmodule MingaBoard.Frontend.Adapter.GUI.BoardEncoder do
     IO.iodata_to_binary([
       @op_gui_board,
       <<visible::8, focused_id::32, length(cards)::16, filter_mode::8,
-        byte_size(filter_bytes)::16, filter_bytes::binary>>
-      | card_entries
+        byte_size(filter_bytes)::16, filter_bytes::binary>>,
+      card_entries,
+      <<zoomed_id::32>>
     ])
   end
 

--- a/extensions/board/test/minga_board/frontend/adapter/gui/board_encoder_test.exs
+++ b/extensions/board/test/minga_board/frontend/adapter/gui/board_encoder_test.exs
@@ -128,6 +128,43 @@ defmodule MingaBoard.Frontend.Adapter.GUI.BoardEncoderTest do
       assert (flags &&& 0x01) == 1
     end
 
+    test "encodes zoomed_card_id as a u32 trailer after the cards array" do
+      # Zoomed state: visible? is false (grid hidden) but the zoom header data
+      # rides along so frontends can render the card identity + ESC affordance.
+      binary =
+        encode(
+          board(
+            visible?: false,
+            zoomed_card_id: 7,
+            cards: [card(id: 7, status: :working, display_task: "fix auth", model: "claude-4")]
+          )
+        )
+
+      <<@op_gui_board, visible::8, _focused::32, card_count::16, _filter_mode::8, filter_len::16,
+        _filter::binary-size(filter_len), rest::binary>> = unwrap_runtime(binary)
+
+      assert visible == 0
+      assert card_count == 1
+
+      # Consume the single card, then the trailing zoomed_card_id u32.
+      <<_id::32, _status::8, _flags::8, task_len::16, _task::binary-size(task_len), model_len::8,
+        _model::binary-size(model_len), _elapsed::32, file_count::8, after_files::binary>> = rest
+
+      assert file_count == 0
+      <<sparkline_count::8, _sparkline::binary-size(sparkline_count * 2), zoomed_id::32>> = after_files
+      assert zoomed_id == 7
+    end
+
+    test "encodes zoomed_card_id of 0 when not zoomed" do
+      <<@op_gui_board, _visible::8, _focused::32, card_count::16, _filter_mode::8, filter_len::16,
+        _filter::binary-size(filter_len), trailer::binary>> =
+        board() |> encode() |> unwrap_runtime()
+
+      assert card_count == 0
+      assert <<zoomed_id::32>> = trailer
+      assert zoomed_id == 0
+    end
+
     test "rejects malformed cards" do
       invalid_cards = [
         card(id: 0),

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		1A5BEC77FAE9F5332258C932 /* DispatchSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C82ED3FA8689E002C7BF1CD /* DispatchSheetView.swift */; };
 		1A7BC027E152504B67F6F418 /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
 		1BED638F0EE72345B63FA3E2 /* BottomPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */; };
+		1BF0117CF5B2C485E0C717E8 /* BoardZoomHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F6549E7DC147CB555B065EF /* BoardZoomHeader.swift */; };
 		1D2AE6CCA8AEE36DA0731D7B /* GitStatusState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B5F67DE84B139C6F8F3C9F /* GitStatusState.swift */; };
 		1E77051711F9373850137201 /* ObservatoryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1421FF1F017E45A031AF18 /* ObservatoryState.swift */; };
 		1F3D130725BB056ADCFAC2EB /* AgentSurfaceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483AA21EF140F07296D1E16A /* AgentSurfaceTypes.swift */; };
@@ -224,6 +225,7 @@
 		8C29B80ABC5A804F27DF5C8F /* ProtocolErrorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6629A966DB0AA4903F49E756 /* ProtocolErrorState.swift */; };
 		8C9C3976E598C7F553B003B6 /* WorkspaceHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */; };
 		8CB3E1EEDEA109F6C0183597 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */; };
+		8D40258AC6336BA114C3E1D1 /* BoardZoomHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F6549E7DC147CB555B065EF /* BoardZoomHeader.swift */; };
 		8D55764B8CF042B4C48AA5D0 /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
 		8DA7795B9AD0EC93BCC40D6D /* LatencyHUDState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3CDCE4CBD952FB00D1D347 /* LatencyHUDState.swift */; };
 		8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
@@ -322,6 +324,7 @@
 		C963537E4C814650ECD2097B /* DispatchSheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D3C16BE95F0D44FFC187D7 /* DispatchSheetState.swift */; };
 		C97709E4D4BED5B2807481F5 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C26E064D810299C0302F439 /* EditorView.swift */; };
 		CA45D5770C1B334A821D3338 /* GitStatusHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */; };
+		CAACD2F4F8686A05F78F9679 /* BoardZoomHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F6549E7DC147CB555B065EF /* BoardZoomHeader.swift */; };
 		CC72FE91F267AA744D4A6F1D /* GitStatusHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */; };
 		CC8B2D0174D3E5839980702C /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
 		CD2952CCEB2FD594B269A75D /* GUIActionEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */; };
@@ -490,6 +493,7 @@
 		7A67102D81C9E70546F1019B /* MessagesContentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentState.swift; sourceTree = "<group>"; };
 		7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEncoder.swift; sourceTree = "<group>"; };
 		7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInputTests.swift; sourceTree = "<group>"; };
+		7F6549E7DC147CB555B065EF /* BoardZoomHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardZoomHeader.swift; sourceTree = "<group>"; };
 		82B744449C852E13511FFE8D /* MinibufferStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinibufferStateTests.swift; sourceTree = "<group>"; };
 		82D3C16BE95F0D44FFC187D7 /* DispatchSheetState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchSheetState.swift; sourceTree = "<group>"; };
 		83165B89231936674C54B513 /* EditorNSView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorNSView.swift; sourceTree = "<group>"; };
@@ -845,6 +849,7 @@
 			children = (
 				E3C7CD67746339B8220B016D /* BoardState.swift */,
 				14491B0CD5CB7C9361D2211A /* BoardView.swift */,
+				7F6549E7DC147CB555B065EF /* BoardZoomHeader.swift */,
 				82D3C16BE95F0D44FFC187D7 /* DispatchSheetState.swift */,
 				8C82ED3FA8689E002C7BF1CD /* DispatchSheetView.swift */,
 				5F731BABFBA0763268D6CD19 /* SparklineView.swift */,
@@ -1154,6 +1159,7 @@
 				DC64A4E8CF70866DFA0BC0D2 /* BoardState.swift in Sources */,
 				714E12952A0A53C30BDC8574 /* BoardTypes.swift in Sources */,
 				5B0A6E233E7A2A70B60604DA /* BoardView.swift in Sources */,
+				1BF0117CF5B2C485E0C717E8 /* BoardZoomHeader.swift in Sources */,
 				941C53DDBC488FE908656CD3 /* BottomPanelState.swift in Sources */,
 				1965FE752C77D2EB386EC4D8 /* BottomPanelView.swift in Sources */,
 				6860E9D6217B72EAA8AD71A5 /* BreadcrumbBar.swift in Sources */,
@@ -1280,6 +1286,7 @@
 				BC252EEC3A93FA52DD175768 /* BoardState.swift in Sources */,
 				D7F5054FF020EE435B8109E8 /* BoardTypes.swift in Sources */,
 				F9D5CBB0A577EBDB976DB406 /* BoardView.swift in Sources */,
+				8D40258AC6336BA114C3E1D1 /* BoardZoomHeader.swift in Sources */,
 				1BED638F0EE72345B63FA3E2 /* BottomPanelState.swift in Sources */,
 				279CEBE1AD001C3AFD74E285 /* BottomPanelView.swift in Sources */,
 				3DB25E7E934FAAD7A7B51084 /* BreadcrumbBar.swift in Sources */,
@@ -1409,6 +1416,7 @@
 				9F459146947E0ED4B4D8CA44 /* BoardState.swift in Sources */,
 				F7BE488FD715F65ECA74233B /* BoardTypes.swift in Sources */,
 				6C0BCE6332F19B87575EDDDA /* BoardView.swift in Sources */,
+				CAACD2F4F8686A05F78F9679 /* BoardZoomHeader.swift in Sources */,
 				5BEEC2FD4D95EBA70FE036E7 /* BottomPanelState.swift in Sources */,
 				59546703C9DBB4BA6E15DE28 /* BottomPanelView.swift in Sources */,
 				8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */,

--- a/macos/Tests/MingaTests/BoardFrontendRuntimeTests.swift
+++ b/macos/Tests/MingaTests/BoardFrontendRuntimeTests.swift
@@ -40,6 +40,27 @@ private func sampleBoardRuntimePayload() -> Data {
     return payload
 }
 
+/// Zoomed-state payload: visible=0, the single card is status working, and the
+/// trailing zoomed_card_id points at it (matching the BEAM's zoomed encoding).
+private func sampleZoomedBoardRuntimePayload() -> Data {
+    var payload = Data([0x87, 0x00])
+    appendBoardRuntimeU32(&payload, 0x0000002A)  // focused id
+    appendBoardRuntimeU16(&payload, 0x0001)  // card count
+    payload.append(0x00)  // filter mode off
+    appendBoardRuntimeString16(&payload, "")  // empty filter text
+    appendBoardRuntimeU32(&payload, 0x0000002A)  // card id
+    payload.append(0x01)  // status working
+    payload.append(0x02)  // flags: focused
+    appendBoardRuntimeString16(&payload, "fix auth")
+    payload.append(0x08)
+    payload.append(contentsOf: Array("claude-4".utf8))
+    appendBoardRuntimeU32(&payload, 0x00000064)  // timestamp
+    payload.append(0x00)  // recent file count
+    payload.append(0x00)  // sparkline count
+    appendBoardRuntimeU32(&payload, 0x0000002A)  // zoomed_card_id trailer
+    return payload
+}
+
 private func extensionRuntimeEnvelope(extensionID: String, channel: String, payload: Data) -> Data {
     var body = Data()
     appendBoardRuntimeString16(&body, extensionID)
@@ -109,6 +130,54 @@ struct BoardFrontendRuntimeTests {
         #expect(card.dispatchTimestamp == 0x00000064)
         #expect(card.recentFiles == ["lib/auth.ex"])
         #expect(card.sparkline.count == 2)
+    }
+
+    @Test("decodes zoomed_card_id trailer and resolves the zoomed card")
+    @MainActor func decodeZoomedCardIdTrailer() throws {
+        let payload = sampleZoomedBoardRuntimePayload()
+        let envelope = extensionRuntimeEnvelope(extensionID: "minga_board", channel: "board", payload: payload)
+        let (cmd, _) = try decodeCommand(data: envelope, offset: 0)
+        guard case .guiExtensionRuntime(let message) = cmd else {
+            Issue.record("Expected guiExtensionRuntime, got \(String(describing: cmd))")
+            return
+        }
+
+        BoardFrontendRuntime.resetForTesting()
+        let registry = FrontendExtensionRuntimeRegistry()
+        BoardFrontendRuntime.register(into: registry, encoder: nil, theme: ThemeColors())
+        registry.dispatch(message)
+
+        let state = BoardFrontendRuntime.stateForTesting
+        // Grid is hidden while zoomed, but the zoomed card resolves for the header.
+        #expect(!state.visible)
+        #expect(state.zoomedCardId == 0x0000002A)
+        let zoomed = try #require(state.zoomedCard)
+        #expect(zoomed.id == 0x0000002A)
+        #expect(zoomed.task == "fix auth")
+        #expect(zoomed.model == "claude-4")
+        #expect(zoomed.status == .working)
+    }
+
+    @Test("payload without zoomed trailer leaves the board un-zoomed")
+    @MainActor func decodeWithoutZoomTrailer() throws {
+        // The grid-view sample payload has no zoomed_card_id trailer; the decoder
+        // must tolerate it and report no zoomed card.
+        let payload = sampleBoardRuntimePayload()
+        let envelope = extensionRuntimeEnvelope(extensionID: "minga_board", channel: "board", payload: payload)
+        let (cmd, _) = try decodeCommand(data: envelope, offset: 0)
+        guard case .guiExtensionRuntime(let message) = cmd else {
+            Issue.record("Expected guiExtensionRuntime, got \(String(describing: cmd))")
+            return
+        }
+
+        BoardFrontendRuntime.resetForTesting()
+        let registry = FrontendExtensionRuntimeRegistry()
+        BoardFrontendRuntime.register(into: registry, encoder: nil, theme: ThemeColors())
+        registry.dispatch(message)
+
+        let state = BoardFrontendRuntime.stateForTesting
+        #expect(state.zoomedCardId == nil)
+        #expect(state.zoomedCard == nil)
     }
 
     @Test("truncated generic extension runtime envelope throws")


### PR DESCRIPTION
## Summary

Restores the Board zoom context capability (#2328, from the #2311 disposal audit): zoomed into a card, you now see which card you're in (status icon, task, model) and how to get back ("ESC back to Board"), on both frontends — semantically, with no cell-grid paths.

- **Wire**: a `zoomed_card_id::u32` trailer on the Board extension runtime payload (inner 0x87 inside the length-prefixed envelope; 0 = grid). The envelope's length prefix makes the trailer invisible to every sizer — the #2322 framing concern was verified inapplicable, not assumed. Decode is backward-tolerant (absent reads as 0) and bounds-guarded in all four consumers (Go/Swift/Rust/Zig — the legacy decoders keep their `size == len` parity assertions honest).
- **Go TUI**: a width-clamped header line atop the zoomed view, status glyphs matching the old bar. **macOS**: a native SwiftUI `BoardZoomHeader` bar with VoiceOver labels, mounted when the grid is hidden and a card is zoomed; `zoomedCardId` is now wire-authoritative, assigned atomically per decoded frame (the zoom animation keying cannot observe a torn state — reviewer-verified).
- The Elixir side stays out of the chrome business: `build_chrome/4` still returns an empty `%Chrome{}`.

Acceptance review note: the initial verdict was BLOCKED on a suspected unrelated commit riding the branch; that turned out to be the reviewer comparing against a stale main ref — the "foreign commit" was the already-merged #2332 merge commit in main's own ancestry. The branch was simply behind main and has been fast-forwarded; the #2328 diff itself passed every acceptance gate (bounds-safety in all four decoders, backward tolerance, deterministic encoder, xcodegen convention, edge cases).

## Tests

- Elixir: encoder wire tests (id and id=0 cases), board suite 162 green, full suite 9,345 / 0 failures, lint green, `mix protocol.gen --check` exit 0 (schema untouched)
- Parity: `mix test.board_frontends` (Go + Rust + Zig) green with the new trailer exercised on all three
- Go: go/tui 327 + board frontend tests, vet/gofmt clean; macOS: full Swift suite 795 passed incl. 2 new decode tests
- Review: acceptance PASS on the diff (suggestions noted for future polish: runewidth-based clamp, a transition-keying test)

Closes #2328. Part of #2221 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)