### PR TITLE
fix(macos): skip sized unhandled protocol commands

### DIFF
--- a/go/tui/internal/port/framing_contract_test.go
+++ b/go/tui/internal/port/framing_contract_test.go
@@ -1,0 +1,243 @@
+package port
+
+// Per-frontend framing contract for the Go TUI (generalized from PR #2347).
+//
+// Why this exists: three times in this project's history a hand-written framing
+// authority drifted from the generated schema and desynced a frontend's command
+// stream. PR #2347 was the third: the macOS decoder assumed unknown 0x90+ opcodes
+// were len16-prefixed, mis-sized the sectioned gui_surface_layout (0xA4), and
+// looped the loader. The generated CommandSize table is now the single framing
+// authority. PR #2347 added one opcode's regression; this test generalizes it so
+// a fourth instance is impossible on the Go side.
+//
+// What it asserts: for EVERY beam_to_frontend opcode the live port reader can
+// frame, a minimal payload followed by a commit_frame sentinel must be consumed
+// EXACTLY up to the sentinel by decodePacket (the real reader loop), and the
+// sentinel must decode as the next command. If the reader mis-sizes any opcode it
+// either swallows the commit_frame (no sentinel) or warns; either fails the test.
+//
+// How opcodes are enumerated (self-updating on schema regen): the test parses the
+// generated opcode constants file (generated/opcodes.go: `OP* byte = 0x..`) for
+// the full real opcode set, then classifies each through the live
+// generated.CommandSize. Opcodes it sizes (sized or custom) are framed by the
+// reader and enter the contract; opcodes it reports unknown are input/parser
+// opcodes the reader never frames and are skipped. Because the generated switch
+// regenerates from docs/protocol_schema.toml, a newly added beam_to_frontend
+// opcode automatically enters this loop the next time `mix protocol.gen` runs.
+//
+// How minimal payloads are synthesized: a single zero-fill synthesizer, kind- and
+// shape-agnostic. For each framed opcode it searches the smallest zero-filled body
+// (opcode byte + N zero bytes) such that `decodePacket(body ++ commit_frame)`
+// decodes as exactly [opcode, commit_frame] with no warning. Zero bytes mean zero
+// section/array counts and zero-length strings, so the search converges on each
+// opcode's true minimal bounded frame for both generated-sized framings (fixed /
+// len16 / len32 / sectioned) and the hand-written custom decoders (the chrome
+// decoders the reader still owns). A decoder that returns len(payload) on a
+// truncation fallback swallows the sentinel and is rejected, so a fallback can
+// never fake a pass (the #2322 sentinel guarantee).
+//
+// FAILURE BY DEFAULT IS THE POINT: if a new opcode cannot be framed by any
+// zero-filled body within the probe bound (e.g. a new custom decoder that needs
+// nonzero structure, or one that mis-frames), the test FAILS loudly naming the
+// opcode. Fix the framing or extend minimalBodyOverrides below; do not silence it.
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+// commitFrameSentinel is a complete fixed:9 commit_frame. It is appended after
+// each opcode's minimal body; the reader must leave it untouched and decode it as
+// the second command, proving the first command was framed to its exact length.
+var commitFrameSentinel = []byte{generated.OPCommitFrame, 0, 0, 0, 7, 0, 0, 0, 0}
+
+// maxMinimalBodyProbe bounds the zero-fill search. The largest known minimal
+// bounded frame (gui_git_status) is ~18 bytes; 48 leaves generous headroom while
+// keeping a failed search fast and unambiguous.
+const maxMinimalBodyProbe = 48
+
+// minimalBodyOverrides supplies a hand-built minimal body for any opcode whose
+// minimal bounded frame a zero-fill cannot express: opcodes whose decoder rejects
+// an all-zero length-prefix and requires a nonzero inner length field. Keyed by
+// opcode. A new opcode that needs nonzero structure goes here; until it does, the
+// contract test fails and names it, which is the intended loud signal.
+//
+// Each override is validated against the live reader exactly like an auto-probed
+// body (framesExactly), so a wrong override cannot silently pass.
+var minimalBodyOverrides = map[byte][]byte{
+	// clipboard_write (len16): decodeClipboardWrite requires payload_len >= 3 and a
+	// consistent inner text_len, so an all-zero len16 body is rejected. Minimal:
+	// opcode + payload_len(2)=3 + (text_len(2)=0, one filler byte) = 6 bytes.
+	generated.OPClipboardWrite: {generated.OPClipboardWrite, 0x00, 0x03, 0x00, 0x00, 0x00},
+	// gui_extension_runtime (len32): decodeExtensionRuntime reads two string16
+	// fields (extension_id, channel) inside payload_len, so payload_len must be >= 4
+	// for two zero-length strings. Minimal: opcode + payload_len(4)=4 + four zero
+	// bytes (two empty string16) = 9 bytes.
+	generated.OPGuiExtensionRuntime: {generated.OPGuiExtensionRuntime, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00},
+}
+
+func TestFramingContractEveryFramedOpcode(t *testing.T) {
+	opcodes := loadGeneratedOpcodes(t)
+
+	framed := 0
+	for _, op := range opcodes {
+		op := op
+		// Classify via the live framing authority the reader uses. Probe with a
+		// generously sized zero body so sized framings report .OK rather than
+		// .Incomplete; the classification only needs sized-vs-custom-vs-unknown.
+		probe := append([]byte{op.value}, make([]byte, maxMinimalBodyProbe)...)
+		_, status := generated.CommandSize(probe)
+		if status == generated.CommandSizeUnknown {
+			// Input/parser opcodes the BEAM->frontend reader never frames.
+			continue
+		}
+
+		framed++
+		t.Run(op.name, func(t *testing.T) {
+			body, ok := minimalBodyFor(op.value)
+			if !ok {
+				t.Fatalf("opcode %s (0x%02X) is framed by the reader but no minimal "+
+					"zero-filled body within %d bytes yields an exact frame; its decoder "+
+					"likely mis-frames or needs nonzero structure. Fix the framing or add "+
+					"an entry to minimalBodyOverrides.", op.name, op.value, maxMinimalBodyProbe)
+			}
+			assertExactFrame(t, op, body)
+		})
+	}
+
+	if framed == 0 {
+		t.Fatal("no framed opcodes discovered; opcode enumeration is broken")
+	}
+}
+
+// minimalBodyFor returns the smallest body (opcode + zero padding) that frames
+// exactly, or an explicit override. ok is false when nothing within the probe
+// bound produces an exact frame.
+func minimalBodyFor(opcode byte) (body []byte, ok bool) {
+	if override, found := minimalBodyOverrides[opcode]; found {
+		if framesExactly(override) {
+			return override, true
+		}
+		return nil, false
+	}
+	for n := 0; n <= maxMinimalBodyProbe; n++ {
+		candidate := make([]byte, 1+n)
+		candidate[0] = opcode
+		if framesExactly(candidate) {
+			return candidate, true
+		}
+	}
+	return nil, false
+}
+
+// framesExactly reports whether body ++ commit_frame decodes as exactly
+// [body's command, commit_frame] with no warning. A panic inside a hand decoder
+// on a malformed probe length counts as "this length does not frame": recover and
+// report false so the search continues to a valid length. A length that genuinely
+// frames never panics, so a real opcode still converges.
+func framesExactly(body []byte) (ok bool) {
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+
+	batch := make([]byte, 0, len(body)+len(commitFrameSentinel))
+	batch = append(batch, body...)
+	batch = append(batch, commitFrameSentinel...)
+
+	warned := false
+	cmds := decodePacket(batch, func(byte, string) { warned = true })
+	if warned || len(cmds) != 2 {
+		return false
+	}
+	return cmds[1].Kind == protocol.CommandCommitFrame
+}
+
+// assertExactFrame re-runs the frame for diagnostics, asserting the reader
+// consumes the body to exactly the sentinel boundary.
+func assertExactFrame(t *testing.T, op generatedOpcode, body []byte) {
+	t.Helper()
+	batch := make([]byte, 0, len(body)+len(commitFrameSentinel))
+	batch = append(batch, body...)
+	batch = append(batch, commitFrameSentinel...)
+
+	var warnings []string
+	cmds := decodePacket(batch, func(_ byte, text string) { warnings = append(warnings, text) })
+	if len(warnings) != 0 {
+		t.Fatalf("%s (0x%02X): reader warned while framing a minimal payload: %v",
+			op.name, op.value, warnings)
+	}
+	if len(cmds) != 2 {
+		t.Fatalf("%s (0x%02X): minimal frame of %d bytes + sentinel decoded into %d "+
+			"commands, want 2 ([opcode, commit_frame]); the opcode was mis-sized and "+
+			"swallowed or split the sentinel", op.name, op.value, len(body), len(cmds))
+	}
+	if cmds[len(cmds)-1].Kind != protocol.CommandCommitFrame {
+		t.Fatalf("%s (0x%02X): trailing command is %v, want CommitFrame; the opcode "+
+			"frame did not stop at the sentinel boundary", op.name, op.value, cmds[len(cmds)-1].Kind)
+	}
+}
+
+type generatedOpcode struct {
+	name  string
+	value byte
+}
+
+var opcodeConstLine = regexp.MustCompile(`^\s*(OP[A-Za-z0-9]+)\s+byte\s*=\s*(0x[0-9A-Fa-f]+)`)
+
+// loadGeneratedOpcodes parses generated/opcodes.go for the real opcode set. It
+// reads the file from disk (located relative to this test source via
+// runtime.Caller) so the list tracks whatever `mix protocol.gen` last wrote;
+// there is no hand-maintained opcode list to rot.
+func loadGeneratedOpcodes(t *testing.T) []generatedOpcode {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate test source to resolve the generated opcodes file")
+	}
+	// .../go/tui/internal/port/framing_contract_test.go -> .../go/tui/internal/generated/opcodes.go
+	path := filepath.Join(filepath.Dir(thisFile), "..", "generated", "opcodes.go")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open generated opcodes %s: %v", path, err)
+	}
+	defer f.Close()
+
+	var opcodes []generatedOpcode
+	seen := map[byte]bool{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		m := opcodeConstLine.FindStringSubmatch(scanner.Text())
+		if m == nil {
+			continue
+		}
+		// GUIAction* sub-opcodes share the byte space of real opcodes and are not
+		// wire commands; the OP prefix excludes them (they are GUIAction*, not OP*).
+		v, err := strconv.ParseUint(m[2], 0, 8)
+		if err != nil {
+			t.Fatalf("parse opcode value %q: %v", m[2], err)
+		}
+		if seen[byte(v)] {
+			continue
+		}
+		seen[byte(v)] = true
+		opcodes = append(opcodes, generatedOpcode{name: m[1], value: byte(v)})
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan generated opcodes: %v", err)
+	}
+	if len(opcodes) == 0 {
+		t.Fatalf("no OP* constants parsed from %s; the generated format changed", path)
+	}
+	return opcodes
+}

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -2588,19 +2588,6 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         return (.protocolError(message: message), 1 + 2 + messageLen)
 
     default:
-        // Forward-compatibility: opcodes 0x90+ use a 2-byte length prefix
-        // so we can skip unknown opcodes without crashing. Opcodes below
-        // 0x90 without a length prefix are truly unknown and we must abort
-        // (we can't determine their size).
-        if opcode >= 0x90 {
-            guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-            let payloadLen = Int(readU16(data, rest))
-            let totalSize = 1 + 2 + payloadLen  // opcode + length + payload
-            guard data.count >= offset + totalSize else { throw ProtocolDecodeError.malformed }
-            // Skip the unknown opcode silently. The BEAM may be newer than
-            // this frontend; crashing would be worse than ignoring.
-            return (nil, totalSize)
-        }
         throw ProtocolDecodeError.unknownOpcode(opcode)
     }
 }

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -97,6 +97,25 @@ struct ProtocolDecoderTests {
         #expect(baseFrameSeq == 3)
     }
 
+    @Test("Skip known sized command without renderer handler")
+    func skipKnownSizedCommandWithoutRendererHandler() throws {
+        let data = Data([OP_GUI_SURFACE_LAYOUT, 0x01, 0x01, 0x00, 0x00, OP_COMMIT_FRAME, 0, 0, 0, 7, 0, 0, 0, 0])
+
+        let (ignored, size) = try decodeCommand(data: data, offset: 0)
+        guard case nil = ignored else {
+            Issue.record("Expected gui_surface_layout to be skipped, got \(String(describing: ignored))")
+            return
+        }
+        #expect(size == 5)
+
+        let (next, _) = try decodeCommand(data: data, offset: size)
+        guard case .commitFrame(let frameSeq, _) = next else {
+            Issue.record("Expected trailing .commitFrame, got \(String(describing: next))")
+            return
+        }
+        #expect(frameSeq == 7)
+    }
+
     @Test("Decode protocol_error command")
     func decodeProtocolError() throws {
         let message = "protocol_version mismatch: frontend 1, beam 2"

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -116,6 +116,232 @@ struct ProtocolDecoderTests {
         #expect(frameSeq == 7)
     }
 
+    // Per-frontend framing contract (generalized from PR #2347).
+    //
+    // Why this exists: three times in this project's history a hand-written framing
+    // authority drifted from the generated schema and desynced a frontend's command
+    // stream. PR #2347 was the third: this decoder's deleted fallback assumed unknown
+    // 0x90+ opcodes were len16-prefixed, mis-sized the sectioned gui_surface_layout
+    // (0xA4), corrupted the stream, and looped the loader. The generated commandSize
+    // table is now the single framing authority. skipKnownSizedCommandWithoutRendererHandler
+    // above covers ONE opcode; this test generalizes it across EVERY beam_to_frontend
+    // opcode the live decodeCommand path frames so a fourth instance is impossible.
+    //
+    // What it asserts: for every framed opcode, a minimal payload followed by a
+    // commit_frame sentinel must be consumed EXACTLY to the sentinel boundary by the
+    // live decodeCommand, and the sentinel must decode as the next command. A sizer
+    // that fell back to data.count on truncation would swallow the commit_frame and
+    // fail (the #2322 sentinel guarantee).
+    //
+    // How opcodes are enumerated (self-updating on schema regen): the test parses the
+    // generated opcode constants file (ProtocolOpcodes.generated.swift: `let OP_* :
+    // UInt8 = 0x..`) for the full real opcode set, located relative to this source via
+    // #filePath. There is no hand-maintained opcode list to rot; a new opcode added to
+    // docs/protocol_schema.toml regenerates that file and enters this loop. Each opcode
+    // is then classified through the live commandSize: .sized/.custom opcodes are framed
+    // by the renderer path; .unknown opcodes are input/parser-response opcodes the
+    // renderer never frames and are skipped.
+    //
+    // How minimal payloads are synthesized: a single zero-fill synthesizer, framing-kind
+    // agnostic. For each framed opcode it searches the smallest zero-filled body
+    // (opcode + N zero bytes) such that decodeCommand frames it to exactly its own length
+    // and the appended commit_frame decodes intact. Zero bytes mean zero section/array
+    // counts and zero-length strings, so the search converges on each opcode's true
+    // minimal bounded frame for both generated-sized framings (fixed / len16 / len32 /
+    // sectioned) and the custom decoders this file still owns (set_font, gui_git_status,
+    // the parser commands, etc.). Opcodes whose decoder requires a nonzero length prefix
+    // go in minimalBodyOverrides.
+    //
+    // FAILURE BY DEFAULT IS THE POINT: a new opcode that no zero-filled body within the
+    // probe bound can frame (a new custom needing nonzero structure, or a real
+    // mis-framing) fails this test loudly by name. Fix the framing or add an override;
+    // do not silence it.
+    @Test("Framing contract: every beam_to_frontend opcode is exactly framed")
+    func framingContractEveryFramedOpcode() throws {
+        let opcodes = try Self.loadGeneratedOpcodes()
+        #expect(opcodes.count > 30, "opcode enumeration parsed too few constants; the generated format may have changed")
+
+        var framed = 0
+        for op in opcodes {
+            // Classify each opcode by its framing kind on a minimal zero body. The two
+            // framing layers have different authorities and so are asserted differently:
+            //
+            //   .sized  -> the generated commandSize table is the authority and frames
+            //              the opcode from its length fields alone, no decoder needed.
+            //              An all-zero body gives zero length fields, i.e. the minimal
+            //              frame, for every fixed / len16 / len32 / sectioned opcode,
+            //              including ones whose hand decoder rejects empty content (the
+            //              decoder's content validation is orthogonal to framing). This
+            //              is the exact #2347 class: a sized-but-unhandled opcode that
+            //              must be skipped by its commandSize size, not a guessed one.
+            //
+            //   .custom -> the opcode uses bespoke framing; its live decoder owns sizing.
+            //              Here the live decodeCommand IS the framing authority, so the
+            //              contract drives it directly (zero-fill search, or an override
+            //              for a content-strict custom).
+            //
+            //   .unknown -> input / parser-response opcode the renderer never frames.
+            //   .incomplete -> only on a truncated probe; the probe is generously sized
+            //                  so this means the opcode is not a real framed command.
+            let probe = [op.value] + [UInt8](repeating: 0, count: Self.maxMinimalBodyProbe)
+            switch commandSize(probe) {
+            case .sized:
+                framed += 1
+                Self.assertSizedFramesToSentinel(op: op)
+            case .custom:
+                framed += 1
+                guard let body = Self.minimalCustomBody(for: op.value) else {
+                    Issue.record("custom opcode \(op.name) (0x\(String(op.value, radix: 16))) is framed by the renderer but no minimal zero-filled body within \(Self.maxMinimalBodyProbe) bytes yields an exact live frame; its decoder likely mis-frames or needs nonzero structure. Fix the framing or add an entry to minimalBodyOverrides.")
+                    continue
+                }
+                Self.assertCustomFramesToSentinel(op: op, body: body)
+            case .unknown, .incomplete:
+                continue
+            }
+        }
+
+        #expect(framed > 30, "discovered too few framed opcodes; classification silently broke")
+    }
+
+    // commit_frame is a complete fixed:9 command appended as the sentinel.
+    static let commitFrameSentinel: [UInt8] = [OP_COMMIT_FRAME, 0, 0, 0, 7, 0, 0, 0, 0]
+
+    // Bounds the zero-fill search for custom opcodes. The largest known minimal bounded
+    // custom frame is well under this; a failed search stays fast and unambiguous.
+    static let maxMinimalBodyProbe = 64
+
+    // Hand-built minimal bodies for CUSTOM opcodes whose live decoder rejects an all-zero
+    // body and requires a nonzero inner length field. Keyed by opcode value. Empty today;
+    // a new custom opcode that needs nonzero structure goes here, and until it does the
+    // contract fails and names it.
+    static let minimalBodyOverrides: [UInt8: [UInt8]] = [:]
+
+    // assertSizedFramesToSentinel asserts the generated commandSize authority frames a
+    // sized opcode exactly. The body is a zero-filled command of the authority's own
+    // size (zero length fields = minimal). The trailing commit_frame must then size as
+    // its own 9-byte command: a sizer that fell back to data.count on this minimal body
+    // would consume the sentinel and fail (the #2322 sentinel guarantee).
+    static func assertSizedFramesToSentinel(op: GeneratedOpcode) {
+        let label = "\(op.name) (0x\(String(op.value, radix: 16)))"
+        // Resolve the authority's size for a minimal zero body of this opcode.
+        let probe = [op.value] + [UInt8](repeating: 0, count: maxMinimalBodyProbe)
+        guard case .sized(let size) = commandSize(probe), size >= 1, size <= 1 + maxMinimalBodyProbe else {
+            Issue.record("\(label): expected a sized framing on a minimal body")
+            return
+        }
+        var body = [UInt8](repeating: 0, count: size)
+        body[0] = op.value
+
+        let framed = body + commitFrameSentinel
+        guard case .sized(let framedFirst) = commandSize(framed), framedFirst == size else {
+            Issue.record("\(label): commandSize re-framed the minimal body to a different size with the sentinel appended; the framing is not stable")
+            return
+        }
+        // The sentinel must remain an intact, separately-sized commit_frame.
+        let trailing = Array(framed[size...])
+        guard case .sized(let sentinelSize) = commandSize(trailing), sentinelSize == commitFrameSentinel.count else {
+            Issue.record("\(label): the trailing commit_frame did not size as a standalone 9-byte command (got \(commandSize(trailing))); the opcode frame over-read into the sentinel")
+            return
+        }
+
+        // And the live decodeCommand must advance by exactly that size: a sized opcode
+        // is either decoded or skipped, but never consumes past its commandSize bound.
+        // A content-strict decoder may throw .malformed on this synthetic minimal body;
+        // that is a content concern, not a framing one, so only a size mismatch fails.
+        if let (_, liveSize) = try? decodeCommand(data: Data(framed), offset: 0) {
+            if liveSize != size {
+                Issue.record("\(label): live decodeCommand advanced \(liveSize) bytes, want \(size) (the commandSize authority); the live path disagrees with the framing table")
+            }
+        }
+    }
+
+    static func minimalCustomBody(for opcode: UInt8) -> [UInt8]? {
+        if let override = minimalBodyOverrides[opcode] {
+            return customFramesExactly(override) ? override : nil
+        }
+        for n in 0...maxMinimalBodyProbe {
+            var candidate = [UInt8](repeating: 0, count: 1 + n)
+            candidate[0] = opcode
+            if customFramesExactly(candidate) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    // customFramesExactly reports whether a custom body ++ commit_frame decodes through
+    // the live path as exactly [body's command, commit_frame]: the first command consumes
+    // exactly body.count and the trailing 9 bytes decode as commit_frame. A decoder that
+    // throws on a too-short probe, or mis-sizes and swallows the sentinel, returns false
+    // so the search continues; a length that genuinely frames converges.
+    static func customFramesExactly(_ body: [UInt8]) -> Bool {
+        let data = Data(body + commitFrameSentinel)
+        guard let (_, size) = try? decodeCommand(data: data, offset: 0) else { return false }
+        guard size == body.count else { return false }
+        guard let (next, _) = try? decodeCommand(data: data, offset: size) else { return false }
+        if case .commitFrame = next { return true }
+        return false
+    }
+
+    static func assertCustomFramesToSentinel(op: GeneratedOpcode, body: [UInt8]) {
+        let data = Data(body + commitFrameSentinel)
+        let label = "\(op.name) (0x\(String(op.value, radix: 16)))"
+        do {
+            let (_, size) = try decodeCommand(data: data, offset: 0)
+            guard size == body.count else {
+                Issue.record("\(label): live decoder framed to \(size) bytes, want \(body.count); the custom opcode was mis-sized and swallowed or split the commit_frame sentinel")
+                return
+            }
+            let (next, _) = try decodeCommand(data: data, offset: size)
+            guard case .commitFrame = next else {
+                Issue.record("\(label): trailing command is \(String(describing: next)), want .commitFrame; the custom frame did not stop at the sentinel boundary")
+                return
+            }
+        } catch {
+            Issue.record("\(label): live decode threw while framing a minimal custom payload: \(error)")
+        }
+    }
+
+    struct GeneratedOpcode {
+        let name: String
+        let value: UInt8
+    }
+
+    // loadGeneratedOpcodes parses the generated opcode constants for the real opcode
+    // set. The file is located relative to this test source (#filePath) so the list
+    // tracks whatever `mix protocol.gen` last wrote.
+    static func loadGeneratedOpcodes() throws -> [GeneratedOpcode] {
+        // .../macos/Tests/MingaTests/ProtocolTests.swift -> .../macos/.generated/protocol/ProtocolOpcodes.generated.swift
+        let testFile = URL(fileURLWithPath: #filePath)
+        let generated = testFile
+            .deletingLastPathComponent()  // MingaTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // macos
+            .appendingPathComponent(".generated/protocol/ProtocolOpcodes.generated.swift")
+
+        let source = try String(contentsOf: generated, encoding: .utf8)
+
+        // Matches: let OP_FOO: UInt8 = 0x1A   (only OP_-prefixed UInt8 wire opcodes;
+        // GUI_ACTION_* sub-opcodes and PROTOCOL_VERSION are excluded by the pattern).
+        let pattern = #"let\s+(OP_[A-Z0-9_]+)\s*:\s*UInt8\s*=\s*(0x[0-9A-Fa-f]+)"#
+        let regex = try NSRegularExpression(pattern: pattern)
+        let full = NSRange(source.startIndex..<source.endIndex, in: source)
+
+        var opcodes: [GeneratedOpcode] = []
+        var seen = Set<UInt8>()
+        regex.enumerateMatches(in: source, range: full) { match, _, _ in
+            guard let match,
+                  let nameRange = Range(match.range(at: 1), in: source),
+                  let valueRange = Range(match.range(at: 2), in: source),
+                  let value = UInt8(String(source[valueRange]).dropFirst(2), radix: 16)
+            else { return }
+            if seen.insert(value).inserted {
+                opcodes.append(GeneratedOpcode(name: String(source[nameRange]), value: value))
+            }
+        }
+        return opcodes
+    }
+
     @Test("Decode protocol_error command")
     func decodeProtocolError() throws {
         let message = "protocol_version mismatch: frontend 1, beam 2"

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -3541,3 +3541,133 @@ test "generated-sized unrendered opcode does not consume following command" {
         try std.testing.expect(second == .commit_frame);
     }
 }
+
+// ── Per-frontend framing contract (generalized from PR #2347) ─────────────────
+//
+// Why this exists: three times in this project's history a hand-written framing
+// authority drifted from the generated schema and desynced a frontend's command
+// stream. PR #2347 was the third (the macOS decoder mis-sized the sectioned
+// gui_surface_layout, 0xA4, and looped the loader). The #2322 instance was the
+// Zig sizer missing the gui_completion documentation tail. PR #2347 added one
+// opcode's regression; this test generalizes it across EVERY opcode the parser
+// stream can carry so a fourth instance is impossible on the Zig side.
+//
+// What it asserts: for every OP_* the live commandSize/decodeCommand path frames,
+// a minimal payload followed by a commit_frame sentinel must be sized EXACTLY to
+// the body boundary, and the trailing commit_frame must remain a decodable 9-byte
+// command. The sentinel is the #2322 guarantee: a sizer that falls back to
+// payload.len on truncation would swallow the commit_frame and fail.
+//
+// How opcodes are enumerated (self-updating on schema regen): comptime reflection
+// over the generated opcodes module (`std.meta.declarations`) yields every OP_*
+// constant. There is no hand-maintained opcode list to rot; a new opcode added to
+// docs/protocol_schema.toml regenerates protocol_opcodes.zig and enters this loop
+// the next time the test compiles.
+//
+// Which opcodes the parser stream routes: commandSize routes generated-sized,
+// hand-custom (customCommandSize), AND parser commands (parserCommandSize); every
+// other opcode (frontend->BEAM input, parser responses) makes decodeCommand return
+// error.UnknownOpcode and is correctly excluded here.
+//
+// How minimal payloads are synthesized: a single zero-fill search, framing-kind
+// agnostic. For each opcode it finds the smallest zero-filled body that both sizes
+// to its own length and decodes without error; appending the commit_frame must not
+// change that size. Zero bytes mean zero counts and zero-length strings, so the
+// search converges on the true minimal bounded frame for fixed / len16 / len32 /
+// sectioned / custom / parser framings alike. Opcodes whose decoder requires a
+// nonzero length prefix (none today) would go in minimalBodyOverrides.
+//
+// FAILURE BY DEFAULT IS THE POINT: a new opcode that no zero-filled body within
+// the probe bound can frame (a new custom needing nonzero structure, or a real
+// mis-framing) fails this test loudly by name. Fix the framing or add an override;
+// do not silence it.
+
+const FramingContract = struct {
+    const max_probe = 48;
+
+    // commit_frame is a complete fixed:9 command; the sizer must leave it intact.
+    const sentinel = [_]u8{ OP_COMMIT_FRAME, 0, 0, 0, 7, 0, 0, 0, 0 };
+
+    /// Returns true when `op` is framed by the parser stream: decodeCommand routes
+    /// it rather than returning error.UnknownOpcode. Probed with a generous zero
+    /// body so length guards do not falsely report Malformed for a framed opcode.
+    fn isFramed(op: u8) bool {
+        var buf: [1 + max_probe]u8 = [_]u8{0} ** (1 + max_probe);
+        buf[0] = op;
+        if (decodeCommand(&buf)) |_| {
+            return true;
+        } else |err| return err != error.UnknownOpcode;
+    }
+
+    /// Finds the smallest zero-filled body (opcode + N zeros) that frames exactly:
+    /// it sizes to its own length, decodes without error, and appending the
+    /// sentinel does not extend that size (so the commit_frame survives). Writes
+    /// the body into `out` and returns its length, or null when nothing within the
+    /// probe bound frames (the loud-failure signal).
+    fn minimalBody(op: u8, out: []u8) ?usize {
+        var n: usize = 0;
+        while (n <= max_probe) : (n += 1) {
+            const len = 1 + n;
+            @memset(out[0..len], 0);
+            out[0] = op;
+            const body = out[0..len];
+
+            // Must size to exactly its own length.
+            if (commandSize(body) != len) continue;
+            // Must decode within those bounds without error.
+            _ = decodeCommand(body) catch continue;
+
+            // Appending the sentinel must not change the framed size: the body is
+            // bounded and the commit_frame stays a separate command.
+            var full: [1 + max_probe + sentinel.len]u8 = undefined;
+            @memcpy(full[0..len], body);
+            @memcpy(full[len .. len + sentinel.len], &sentinel);
+            if (commandSize(full[0 .. len + sentinel.len]) != len) continue;
+
+            return len;
+        }
+        return null;
+    }
+};
+
+test "framing contract: every parser-stream opcode is exactly framed" {
+    var framed: usize = 0;
+    inline for (@typeInfo(opcodes).@"struct".decls) |decl| {
+        comptime if (decl.name.len < 3 or !std.mem.eql(u8, decl.name[0..3], "OP_")) continue;
+        const value = @field(opcodes, decl.name);
+        comptime if (@TypeOf(value) != u8) continue;
+
+        if (FramingContract.isFramed(value)) {
+            framed += 1;
+
+            var body_buf: [1 + FramingContract.max_probe]u8 = undefined;
+            const body_len = FramingContract.minimalBody(value, &body_buf) orelse {
+                std.debug.print(
+                    "opcode {s} (0x{X:0>2}) is framed by the parser stream but no minimal " ++
+                        "zero-filled body within {d} bytes frames exactly; its sizer/decoder " ++
+                        "likely mis-frames or needs nonzero structure. Fix the framing or add " ++
+                        "a FramingContract override.\n",
+                    .{ decl.name, value, FramingContract.max_probe },
+                );
+                return error.UnframedOpcode;
+            };
+
+            // Build body ++ sentinel and assert exact framing to the boundary.
+            var full: [1 + FramingContract.max_probe + FramingContract.sentinel.len]u8 = undefined;
+            @memcpy(full[0..body_len], body_buf[0..body_len]);
+            @memcpy(full[body_len .. body_len + FramingContract.sentinel.len], &FramingContract.sentinel);
+            const packet = full[0 .. body_len + FramingContract.sentinel.len];
+
+            // The first command is framed to exactly body_len.
+            try std.testing.expectEqual(body_len, commandSize(packet));
+            // The trailing bytes are the intact commit_frame sentinel (9 bytes),
+            // proving no truncation fallback swallowed it (#2322).
+            try std.testing.expectEqual(@as(usize, FramingContract.sentinel.len), commandSize(packet[body_len..]));
+            try std.testing.expect((try decodeCommand(packet[body_len..])) == .commit_frame);
+        }
+    }
+
+    // Sanity: enumeration must discover a non-trivial framed set, else reflection
+    // or classification silently broke and the contract would assert nothing.
+    try std.testing.expect(framed > 30);
+}


### PR DESCRIPTION
# TL;DR
Fixes the macOS startup loader hang by letting the Swift decoder skip schema-sized protocol commands it does not render locally. The BEAM now emits `gui_surface_layout` every frame, and the frontend can safely ignore it without corrupting the frame stream.

## Context
`bin/minga-mac` could start the app but remain at the spinner forever. The log showed repeated `Protocol decode error: malformed` messages followed by keyframe requests. The failing opcode was `gui_surface_layout` (`0xA4`), which is sectioned in the generated protocol sizing table but had no local Swift render handler.

## Changes
- Removed the hard-coded `opcode >= 0x90` len16 fallback from `ProtocolDecoder.swift`.
- Let `decodeCommand` use the generated `commandSize(_:)` table for known sized commands, including sectioned commands.
- Added a regression test that skips `OP_GUI_SURFACE_LAYOUT` and then decodes a following `commit_frame`, proving stream alignment is preserved.

## Verification
- `mix swift.build`
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -destination "platform=macOS,arch=$ARCH" test`
- Timed `bin/minga-mac README.md` launch reached `Editor started` and `Opened: README.md` with zero fresh `Protocol decode error` entries.

## Notes
A few startup frame-sequence keyframe recovery warnings still appear, but the malformed decode loop is gone.
