### PR TITLE
fix(tui): keep frame recovery off stderr

### DIFF
--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -391,8 +391,11 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 			// Out-of-band by design (#2219): the BEAM rejected this frontend's
 			// handshake protocol_version, so it never enters a transaction. Latch
 			// the reason so View renders a blocking error surface (ticket #2237).
+			// Do not write diagnostics to stderr: the TUI owns the terminal, so raw
+			// stderr can corrupt the rendered frame. Send them back to BEAM so they
+			// land in Minga's *Messages* buffer instead.
 			m.protocolError = command.ProtocolError
-			fmt.Fprintf(os.Stderr, "minga: protocol error: %s\n", command.ProtocolError)
+			m.logToMessages(protocol.LogLevelErr, "Go TUI protocol error: %s", command.ProtocolError)
 		case protocol.CommandSetTitle, protocol.CommandSetWindowBg:
 			// Sanctioned out-of-band side channels (emit.ex send_title/
 			// send_window_bg write these outside the begin/commit bracket). If one
@@ -493,14 +496,16 @@ func (m *Model) commitStaging(cmds []tea.Cmd, command protocol.Command) []tea.Cm
 // live model keeps the last committed frame, so View() never paints a partial.
 func (m *Model) invalidateStaging(cmds []tea.Cmd, reason string) []tea.Cmd {
 	m.staging = nil
-	fmt.Fprintf(os.Stderr, "minga: frame invalidated (%s), requesting keyframe from %d\n", reason, m.lastCommittedSeq)
 	// Debounce the keyframe request: after an invalidation, every stale
 	// in-flight frame also fails its base check (the BEAM advances
 	// base_frame_seq for frames we discarded), and re-requesting per frame
 	// would force a duplicate BEAM render each. One request per resync
-	// window; the pending flag clears when a valid commit applies.
+	// window; the pending flag clears when a valid commit applies. The diagnostic
+	// follows the same debounce and is sent to BEAM's *Messages* log instead of
+	// raw stderr, because stderr writes can corrupt the terminal renderer.
 	if !m.resyncPending {
 		m.resyncPending = true
+		m.logToMessages(protocol.LogLevelWarn, "Go TUI frame invalidated (%s), requesting keyframe from %d", reason, m.lastCommittedSeq)
 		m.send(protocol.EncodeRequestKeyframe(m.lastCommittedSeq))
 	}
 	return cmds
@@ -694,6 +699,10 @@ func (m Model) send(payload []byte) {
 	if m.out != nil {
 		m.out <- payload
 	}
+}
+
+func (m Model) logToMessages(level byte, format string, args ...any) {
+	m.send(protocol.EncodeLogMessage(level, fmt.Sprintf(format, args...)))
 }
 
 // toggleHUD flips the latency overlay when the toggle chord (ctrl+alt+l) is

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -237,7 +237,8 @@ func TestExtensionRuntimeIgnoresEmptyExtensionID(t *testing.T) {
 }
 
 func TestProtocolErrorRendersBlockingSurfaceAndTakesPrecedence(t *testing.T) {
-	model := New(80, 24, nil)
+	out := make(chan []byte, 4)
+	model := New(80, 24, out)
 	// Seed normal content so the test proves the error surface takes precedence
 	// over it rather than only rendering on a blank model.
 	updated, _ := model.Update(port.PacketMsg{Commands: frame(
@@ -270,6 +271,21 @@ func TestProtocolErrorRendersBlockingSurfaceAndTakesPrecedence(t *testing.T) {
 	}
 	if strings.Contains(rendered, "normal editor content") {
 		t.Fatalf("blocking surface should take precedence over normal content, got: %q", rendered)
+	}
+
+	packets := drainOutboundPackets(out)
+	if len(packets) != 1 {
+		t.Fatalf("protocol error should send one log_message packet, got %d", len(packets))
+	}
+	level, text, ok := decodeLogMessage(packets[0])
+	if !ok {
+		t.Fatalf("protocol error packet should be log_message, got %v", packets[0])
+	}
+	if level != protocol.LogLevelErr {
+		t.Fatalf("protocol error log level = %d, want err", level)
+	}
+	if !strings.Contains(text, "Go TUI protocol error: "+message) {
+		t.Fatalf("protocol error log should include reason, got %q", text)
 	}
 }
 

--- a/go/tui/internal/ui/staging_test.go
+++ b/go/tui/internal/ui/staging_test.go
@@ -39,16 +39,42 @@ func renderedBody(model Model) string {
 func drainKeyframeRequests(t *testing.T, out chan []byte) []uint32 {
 	t.Helper()
 	var seqs []uint32
+	for _, packet := range drainOutboundPackets(out) {
+		if seq, ok := decodeKeyframeRequest(packet); ok {
+			seqs = append(seqs, seq)
+		}
+	}
+	return seqs
+}
+
+func drainOutboundPackets(out chan []byte) [][]byte {
+	var packets [][]byte
 	for {
 		select {
 		case packet := <-out:
-			if len(packet) == 5 && packet[0] == generated.OPRequestKeyframe {
-				seqs = append(seqs, uint32(packet[1])<<24|uint32(packet[2])<<16|uint32(packet[3])<<8|uint32(packet[4]))
-			}
+			packets = append(packets, packet)
 		default:
-			return seqs
+			return packets
 		}
 	}
+}
+
+func decodeKeyframeRequest(packet []byte) (uint32, bool) {
+	if len(packet) != 5 || packet[0] != generated.OPRequestKeyframe {
+		return 0, false
+	}
+	return uint32(packet[1])<<24 | uint32(packet[2])<<16 | uint32(packet[3])<<8 | uint32(packet[4]), true
+}
+
+func decodeLogMessage(packet []byte) (byte, string, bool) {
+	if len(packet) < 4 || packet[0] != generated.OPLogMessage {
+		return 0, "", false
+	}
+	msgLen := int(packet[2])<<8 | int(packet[3])
+	if len(packet) != 4+msgLen {
+		return 0, "", false
+	}
+	return packet[1], string(packet[4:]), true
 }
 
 func applyTo(t *testing.T, model Model, commands ...protocol.Command) Model {
@@ -83,6 +109,43 @@ func TestInvalidationDebouncesKeyframeRequests(t *testing.T) {
 	}
 	if !strings.Contains(renderedBody(m), "fresh") {
 		t.Fatal("keyframe content should render after commit")
+	}
+}
+
+func TestInvalidationLogsToMessagesAndDebouncesDiagnostics(t *testing.T) {
+	out := make(chan []byte, 8)
+	m := New(80, 24, out)
+
+	m = applyTo(t, m, commitFrame(7))
+	packets := drainOutboundPackets(out)
+
+	var logs []string
+	var keyframes []uint32
+	for _, packet := range packets {
+		if seq, ok := decodeKeyframeRequest(packet); ok {
+			keyframes = append(keyframes, seq)
+		}
+		if level, text, ok := decodeLogMessage(packet); ok {
+			if level != protocol.LogLevelWarn {
+				t.Fatalf("invalidation log level = %d, want warn", level)
+			}
+			logs = append(logs, text)
+		}
+	}
+
+	if len(keyframes) != 1 || keyframes[0] != 0 {
+		t.Fatalf("first invalidation should request keyframe from last good seq 0, got %v", keyframes)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("first invalidation should send one log_message, got %d", len(logs))
+	}
+	if !strings.Contains(logs[0], "Go TUI frame invalidated (commit_frame with no open transaction)") {
+		t.Fatalf("invalidation log should explain the reason, got %q", logs[0])
+	}
+
+	m = applyTo(t, m, beginFrame(8, 7), windowRowsCommand(1, "stale"), commitFrame(8))
+	if packets := drainOutboundPackets(out); len(packets) != 0 {
+		t.Fatalf("pending resync should debounce duplicate keyframe requests and logs, got %d packets", len(packets))
 	}
 }
 

--- a/lib/minga_editor/renderer/server.ex
+++ b/lib/minga_editor/renderer/server.ex
@@ -12,12 +12,18 @@ defmodule MingaEditor.Renderer.Server do
   ## Snapshot mechanics
 
   The Editor pushes `RenderPipeline.Input` snapshots via
-  `cast_snapshot/3`. The Renderer holds an in-flight snapshot and a
-  pending one. When a snapshot arrives while a render is in progress,
-  the previous pending snapshot is dropped (most-recent-wins
-  coalescing) and a `[:minga, :render, :coalesced]` telemetry event
-  fires. After each render emit completes, the Renderer pulls any
-  pending snapshot and starts the next frame; otherwise it goes idle.
+  `cast_snapshot/3`. The Renderer holds an in-flight snapshot, a
+  pending one, and the latest frontend cache state it emitted. When a
+  snapshot arrives while a render is in progress, the previous pending
+  snapshot is dropped (most-recent-wins coalescing) and a
+  `[:minga, :render, :coalesced]` telemetry event fires. Each snapshot
+  is normalized against the renderer-owned cache state before it renders.
+  After each render emit completes, the Renderer stores the emitted
+  cache state and threads it into any pending snapshot before starting
+  the next frame; otherwise it goes idle. If the Editor emits a direct
+  bare frame boundary, that newer snapshot cache wins instead. That keeps
+  delta frame bases aligned with what the frontend just received, even
+  when the Editor has not yet processed the prior render writeback.
 
   ## Click-region writeback
 
@@ -49,6 +55,7 @@ defmodule MingaEditor.Renderer.Server do
   alias Minga.Telemetry
   alias MingaEditor.RenderPipeline
   alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.Renderer.Caches
   alias MingaEditor.UI.FontRegistry
 
   @typedoc "Render pipeline output after a frame has run."
@@ -81,6 +88,7 @@ defmodule MingaEditor.Renderer.Server do
           pending: {Input.t(), non_neg_integer(), integer()} | nil,
           in_flight: {Input.t(), non_neg_integer(), integer()} | nil,
           font_registry: FontRegistry.t(),
+          caches: Caches.t(),
           pipeline: pipeline()
         }
 
@@ -89,6 +97,7 @@ defmodule MingaEditor.Renderer.Server do
             pending: nil,
             in_flight: nil,
             font_registry: FontRegistry.new(),
+            caches: Caches.new(),
             pipeline: &RenderPipeline.run/1
 
   # ── API ────────────────────────────────────────────────────────────────────
@@ -149,12 +158,14 @@ defmodule MingaEditor.Renderer.Server do
       })
     end
 
+    snap = use_latest_caches(snap, state.caches)
     {:noreply, %{state | pending: {snap, seq, pushed_at}}}
   end
 
   def handle_cast({:render, snap, seq, pushed_at}, %__MODULE__{rendering?: false} = state) do
     Telemetry.hop_latency(:cast_snapshot, pushed_at)
     send(self(), :do_render)
+    snap = use_latest_caches(snap, state.caches)
     {:noreply, %{state | rendering?: true, in_flight: {snap, seq, pushed_at}}}
   end
 
@@ -181,9 +192,9 @@ defmodule MingaEditor.Renderer.Server do
       %{frame_seq: seq}
     )
 
-    state = %{state | font_registry: output.font_registry}
+    state = %{state | font_registry: output.font_registry, caches: output.caches}
     send_writeback(state.editor_pid, output, seq)
-    advance_pending(state)
+    advance_pending(state, output.caches)
   rescue
     e ->
       trace = Exception.format_stacktrace(__STACKTRACE__) |> String.slice(0, 500)
@@ -193,7 +204,7 @@ defmodule MingaEditor.Renderer.Server do
         "Renderer frame #{seq} dropped: #{Exception.message(e)}\n#{trace}"
       )
 
-      advance_pending(state)
+      advance_pending(state, state.caches)
   end
 
   def handle_info(_other, state), do: {:noreply, state}
@@ -247,16 +258,38 @@ defmodule MingaEditor.Renderer.Server do
     }
   end
 
-  @spec advance_pending(t()) :: {:noreply, t()}
-  defp advance_pending(state) do
+  @spec advance_pending(t(), Caches.t()) :: {:noreply, t()}
+  defp advance_pending(state, latest_caches) do
     case state.pending do
       nil ->
         {:noreply, %{state | rendering?: false, in_flight: nil}}
 
       {next_snap, next_seq, next_pushed_at} ->
         send(self(), :do_render)
+        next_snap = use_latest_caches(next_snap, latest_caches)
         {:noreply, %{state | in_flight: {next_snap, next_seq, next_pushed_at}, pending: nil}}
     end
+  end
+
+  @spec use_latest_caches(Input.t(), Caches.t()) :: Input.t()
+  defp use_latest_caches(
+         %Input{caches: %Caches{last_emitted_frame_seq: 0}} = snap,
+         %Caches{last_emitted_frame_seq: latest_seq}
+       )
+       when latest_seq > 0 do
+    snap
+  end
+
+  defp use_latest_caches(
+         %Input{caches: %Caches{last_emitted_frame_seq: snap_seq}} = snap,
+         %Caches{last_emitted_frame_seq: latest_seq}
+       )
+       when snap_seq > latest_seq do
+    snap
+  end
+
+  defp use_latest_caches(%Input{} = snap, %Caches{} = latest_caches) do
+    %{snap | caches: latest_caches}
   end
 
   @spec monotonic_now() :: integer()

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.Renderer.ServerTest do
   use ExUnit.Case, async: false
 
   alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.Renderer.Caches
   alias MingaEditor.Renderer.Server, as: RendererServer
   alias MingaEditor.Viewport
 
@@ -79,6 +80,80 @@ defmodule MingaEditor.Renderer.ServerTest do
     refute renderer_busy?(renderer)
   end
 
+  test "pending snapshots inherit the latest emitted caches before rendering" do
+    parent = self()
+    renderer = start_renderer(parent, pipeline: cache_probe_pipeline(parent))
+    initial_caches = %Caches{last_emitted_frame_seq: 10}
+    in_flight = %{stub_snapshot() | caches: initial_caches}
+    pending = %{stub_snapshot() | caches: initial_caches}
+
+    :sys.replace_state(renderer, fn state ->
+      %{state | rendering?: true, in_flight: {in_flight, 11, 0}, pending: {pending, 12, 0}}
+    end)
+
+    send(renderer, :do_render)
+
+    assert_receive {:pipeline_input, 11, 10}, @async_render_timeout
+    assert_receive {:pipeline_input, 12, 11}, @async_render_timeout
+
+    assert_receive {:render_done, %{frame_seq: 11, caches: %Caches{last_emitted_frame_seq: 11}}},
+                   @async_render_timeout
+
+    assert_receive {:render_done, %{frame_seq: 12, caches: %Caches{last_emitted_frame_seq: 12}}},
+                   @async_render_timeout
+  end
+
+  test "idle renderer uses its latest caches when the editor writeback is still stale" do
+    parent = self()
+    renderer = start_renderer(parent, pipeline: cache_probe_pipeline(parent))
+    stale_editor_snapshot = %{stub_snapshot() | caches: %Caches{last_emitted_frame_seq: 10}}
+
+    :sys.replace_state(renderer, fn state ->
+      %{state | caches: %Caches{last_emitted_frame_seq: 11}}
+    end)
+
+    RendererServer.cast_snapshot(renderer, stale_editor_snapshot, 12)
+
+    assert_receive {:pipeline_input, 12, 11}, @async_render_timeout
+
+    assert_receive {:render_done, %{frame_seq: 12, caches: %Caches{last_emitted_frame_seq: 12}}},
+                   @async_render_timeout
+  end
+
+  test "frontend reset snapshots keep their reset caches" do
+    parent = self()
+    renderer = start_renderer(parent, pipeline: cache_probe_pipeline(parent))
+    reset_snapshot = %{stub_snapshot() | caches: %Caches{last_emitted_frame_seq: 0}}
+
+    :sys.replace_state(renderer, fn state ->
+      %{state | caches: %Caches{last_emitted_frame_seq: 11}}
+    end)
+
+    RendererServer.cast_snapshot(renderer, reset_snapshot, 12)
+
+    assert_receive {:pipeline_input, 12, 0}, @async_render_timeout
+
+    assert_receive {:render_done, %{frame_seq: 12, caches: %Caches{last_emitted_frame_seq: 12}}},
+                   @async_render_timeout
+  end
+
+  test "direct editor-emitted frame boundaries can advance beyond renderer caches" do
+    parent = self()
+    renderer = start_renderer(parent, pipeline: cache_probe_pipeline(parent))
+    boundary_advanced_snapshot = %{stub_snapshot() | caches: %Caches{last_emitted_frame_seq: 12}}
+
+    :sys.replace_state(renderer, fn state ->
+      %{state | caches: %Caches{last_emitted_frame_seq: 11}}
+    end)
+
+    RendererServer.cast_snapshot(renderer, boundary_advanced_snapshot, 13)
+
+    assert_receive {:pipeline_input, 13, 12}, @async_render_timeout
+
+    assert_receive {:render_done, %{frame_seq: 13, caches: %Caches{last_emitted_frame_seq: 13}}},
+                   @async_render_timeout
+  end
+
   describe "render_or_async dispatch" do
     test "non-headless backend with renderer dispatches asynchronously" do
       renderer = start_renderer(self(), pipeline: & &1)
@@ -126,6 +201,13 @@ defmodule MingaEditor.Renderer.ServerTest do
     ])
 
     input
+  end
+
+  defp cache_probe_pipeline(parent) do
+    fn input ->
+      send(parent, {:pipeline_input, input.frame_seq, input.caches.last_emitted_frame_seq})
+      %{input | caches: %{input.caches | last_emitted_frame_seq: input.frame_seq}}
+    end
   end
 
   defp attach_coalesce_handler do


### PR DESCRIPTION
# TL;DR
Fixes Go TUI frame desync recovery so invalidation diagnostics go to `*Messages*` instead of corrupting the terminal, and keeps async renderer delta bases aligned with the last frame the frontend received.

## Context
The Go TUI correctly drops a transaction when its `base_frame_seq` does not match the frontend's last committed frame. The broken behavior was twofold: the diagnostic was written to raw stderr, which painted over the TUI, and the async renderer could produce those mismatched bases by rendering from stale Editor-owned cache snapshots before writeback caught up.

## Changes
- Route Go TUI protocol/frame invalidation diagnostics through the existing `log_message` event path so they appear in `*Messages*` instead of raw stderr.
- Debounce repeated frame invalidation diagnostics with the existing keyframe request window.
- Make `MingaEditor.Renderer.Server` keep the latest frontend cache state it emitted and normalize incoming async snapshots against that renderer-owned cache before rendering.
- Preserve explicit reset snapshots (`last_emitted_frame_seq == 0`) so reconnect/keyframe reset still emits a full base-0 frame.
- Preserve snapshots whose frame sequence is newer than the renderer cache, covering direct Editor-emitted bare frame boundaries.

## Compatibility
No protocol changes. Existing `log_message`, `request_keyframe`, `begin_frame`, and `commit_frame` wire formats are unchanged.

## Verification
- `mix test.debug test/minga_editor/renderer/server_test.exs`, 10 passed
- `mix test.llm test/minga_editor/input/router_test.exs test/minga_editor/render_pipeline/input_test.exs`, 40 passed
- `cd go/tui && go test ./internal/ui ./internal/protocol ./internal/port`, 365 passed
- `git diff --check`
