### PR TITLE
Make Git status cache-only and async

### DIFF
--- a/extensions/git_porcelain/lib/minga_git_porcelain/commands.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/commands.ex
@@ -641,7 +641,7 @@ defmodule MingaGitPorcelain.Commands do
 
   @spec staged_deleted?(String.t(), String.t()) :: boolean()
   defp staged_deleted?(git_root, rel_path) do
-    case Git.status(git_root) do
+    case Git.status(git_root, untracked_mode: :no) do
       {:ok, entries} -> Enum.any?(entries, &staged_deleted_entry?(&1, rel_path))
       {:error, _reason} -> false
     end

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -357,10 +357,7 @@ func (m Model) cursorStyleSequence() string {
 // applyCommands routes a decoded batch through the frame-transaction state
 // machine (#2219). begin_frame opens a staging buffer; semantic/chrome commands
 // accumulate in it without touching the live model; commit_frame validates and
-// replays the buffer atomically. Out-of-band commands (set_title/set_window_bg
-// side channels, protocol_error, transport survivors) apply directly with no
-// open transaction; the same command inside a transaction stages and applies at
-// commit. A semantic/chrome command with NO open transaction, or any stream
+// replays the buffer atomically. Out-of-band commands (set_title/set_window_bg, clipboard writes, no-op compatibility commands, protocol_error, transport survivors) apply directly with no open transaction; the same command inside a transaction stages and applies at commit. A semantic/chrome command with NO open transaction, or any stream
 // error / invalidation, is a protocol violation under the staged model and
 // triggers request_keyframe instead of a partial paint.
 func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
@@ -396,11 +393,11 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 			// land in Minga's *Messages* buffer instead.
 			m.protocolError = command.ProtocolError
 			m.logToMessages(protocol.LogLevelErr, "Go TUI protocol error: %s", command.ProtocolError)
-		case protocol.CommandSetTitle, protocol.CommandSetWindowBg:
-			// Sanctioned out-of-band side channels (emit.ex send_title/
-			// send_window_bg write these outside the begin/commit bracket). If one
-			// arrives inside an open transaction it still stages so the swap stays
-			// atomic; outside one it applies directly.
+		case protocol.CommandNoop:
+			// Sized-but-ignored compatibility commands, such as font setup, can arrive out of band during startup. They do not mutate the Go TUI and should not be treated as frame-transaction violations.
+			continue
+		case protocol.CommandSetTitle, protocol.CommandSetWindowBg, protocol.CommandClipboardWrite:
+			// Sanctioned out-of-band side channels (emit.ex send_title/send_window_bg and command helpers can write these outside the begin/commit bracket). If one arrives inside an open transaction it still stages so the swap stays atomic; outside one it applies directly.
 			if m.staging != nil {
 				m.staging.commands = append(m.staging.commands, command)
 			} else {

--- a/go/tui/internal/ui/staging_test.go
+++ b/go/tui/internal/ui/staging_test.go
@@ -341,9 +341,22 @@ func TestResyncIndicatorShowsThenClearsOnKeyframe(t *testing.T) {
 	}
 }
 
-// Out-of-band allowance: set_title / set_window_bg arriving with no open
-// transaction apply directly (sanctioned side channels) and do NOT request a
-// keyframe.
+// Out-of-band no-op compatibility commands, such as font setup decoded by the TUI only for sizing, must not invalidate the frame stream.
+func TestOutOfBandNoopDoesNotRequestKeyframe(t *testing.T) {
+	out := make(chan []byte, 16)
+	model := New(40, 8, out)
+
+	model = applyTo(t, model, protocol.Command{Kind: protocol.CommandNoop})
+
+	if model.resyncPending {
+		t.Fatal("out-of-band no-op must not mark resync pending")
+	}
+	if reqs := drainKeyframeRequests(t, out); len(reqs) != 0 {
+		t.Fatalf("out-of-band no-op must not request a keyframe: %v", reqs)
+	}
+}
+
+// Out-of-band allowance: set_title, set_window_bg, and clipboard_write arriving with no open transaction apply directly as sanctioned side channels and do NOT request a keyframe.
 func TestOutOfBandSideChannelsApplyWithoutTransaction(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out)
@@ -351,6 +364,7 @@ func TestOutOfBandSideChannelsApplyWithoutTransaction(t *testing.T) {
 	model = applyTo(t, model,
 		protocol.Command{Kind: protocol.CommandSetTitle, Title: "minga - file.ex"},
 		protocol.Command{Kind: protocol.CommandSetWindowBg, WindowBg: 0x112233},
+		protocol.Command{Kind: protocol.CommandClipboardWrite, ClipboardText: "copied text"},
 	)
 
 	if model.title != "minga - file.ex" {
@@ -358,6 +372,9 @@ func TestOutOfBandSideChannelsApplyWithoutTransaction(t *testing.T) {
 	}
 	if model.bg != 0x112233 {
 		t.Fatalf("out-of-band set_window_bg should apply directly, got 0x%06X", model.bg)
+	}
+	if model.pendingClipboard != "copied text" {
+		t.Fatalf("out-of-band clipboard_write should apply directly, got %q", model.pendingClipboard)
 	}
 	if reqs := drainKeyframeRequests(t, out); len(reqs) != 0 {
 		t.Fatalf("sanctioned out-of-band commands must not request a keyframe: %v", reqs)

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -157,6 +157,7 @@ defmodule Minga.Events do
       :branch,
       :ahead,
       :behind,
+      entry_base_path: nil,
       last_commit_message: "",
       stash_count: 0
     ]
@@ -167,6 +168,7 @@ defmodule Minga.Events do
             branch: String.t() | nil,
             ahead: non_neg_integer(),
             behind: non_neg_integer(),
+            entry_base_path: String.t() | nil,
             last_commit_message: String.t(),
             stash_count: non_neg_integer()
           }

--- a/lib/minga/git.ex
+++ b/lib/minga/git.ex
@@ -73,6 +73,14 @@ defmodule Minga.Git do
 
   @type diff_opts :: [diff_opt()]
 
+  @typedoc "How much untracked-file detail `git status` should enumerate."
+  @type untracked_mode :: :no | :normal | :all
+
+  @typedoc "Accepted `status/2` options."
+  @type status_opt :: {:untracked_mode, untracked_mode()} | {:timeout_ms, pos_integer()}
+
+  @type status_opts :: [status_opt()]
+
   # ── Delegated operations (go through the backend) ──────────────────────
 
   @doc """
@@ -122,8 +130,8 @@ defmodule Minga.Git do
   @doc """
   Returns a structured list of changed files with their status.
   """
-  @spec status(String.t()) :: {:ok, [status_entry()]} | {:error, String.t()}
-  def status(git_root), do: impl().status(git_root)
+  @spec status(String.t(), status_opts()) :: {:ok, [status_entry()]} | {:error, String.t()}
+  def status(git_root, opts \\ []), do: impl().status(git_root, opts)
 
   @doc """
   Returns the diff for a specific file or all changes.

--- a/lib/minga/git/backend.ex
+++ b/lib/minga/git/backend.ex
@@ -27,7 +27,7 @@ defmodule Minga.Git.Backend do
             ) ::
               {:ok, String.t()} | :error
 
-  @callback status(git_root :: String.t()) ::
+  @callback status(git_root :: String.t(), opts :: keyword()) ::
               {:ok, [Minga.Git.status_entry()]} | {:error, String.t()}
 
   @callback diff(git_root :: String.t(), opts :: Minga.Git.diff_opts()) ::

--- a/lib/minga/git/repo.ex
+++ b/lib/minga/git/repo.ex
@@ -23,6 +23,8 @@ defmodule Minga.Git.Repo do
   use GenServer
 
   alias Minga.Git
+  alias Minga.Git.Repo.Profile
+  alias Minga.Git.Repo.StatusSnapshot
   alias Minga.Git.StatusEntry
 
   @registry Minga.Git.Repo.Registry
@@ -42,6 +44,10 @@ defmodule Minga.Git.Repo do
     stash_count: 0,
     watcher_pid: nil,
     debounce_ref: nil,
+    refresh_task: nil,
+    refresh_pending?: false,
+    awaiting_refresh: [],
+    profile: nil,
     events_registry: Minga.Events.default_registry()
   ]
 
@@ -57,6 +63,10 @@ defmodule Minga.Git.Repo do
           stash_count: non_neg_integer(),
           watcher_pid: pid() | nil,
           debounce_ref: reference() | nil,
+          refresh_task: refresh_task() | nil,
+          refresh_pending?: boolean(),
+          awaiting_refresh: [GenServer.from()],
+          profile: Profile.t() | nil,
           events_registry: Minga.Events.registry()
         }
 
@@ -78,6 +88,9 @@ defmodule Minga.Git.Repo do
           last_commit_message: String.t(),
           stash_count: non_neg_integer()
         }
+
+  @typedoc "Cached status entries plus the path they are relative to."
+  @type status_snapshot :: StatusSnapshot.t()
 
   # ── Client API ─────────────────────────────────────────────────────────
 
@@ -147,6 +160,25 @@ defmodule Minga.Git.Repo do
     GenServer.call(server, :status)
   end
 
+  @doc "Returns cached status for the tracked repo containing `path`, without shelling out to git."
+  @spec cached_status_for_path(String.t()) :: {:ok, status_snapshot()} | :not_tracked
+  def cached_status_for_path(path) when is_binary(path) do
+    path = Path.expand(path)
+
+    case tracked_repo_for_path(path) do
+      nil -> :not_tracked
+      {_git_root, pid} -> {:ok, status_snapshot(pid)}
+    end
+  catch
+    :exit, _ -> :not_tracked
+  end
+
+  @doc "Returns the cached status entries with the path they are relative to."
+  @spec status_snapshot(GenServer.server()) :: status_snapshot()
+  def status_snapshot(server) do
+    GenServer.call(server, :status_snapshot)
+  end
+
   @doc "Returns the current branch name."
   @spec branch(GenServer.server()) :: String.t() | nil
   def branch(server) do
@@ -163,6 +195,12 @@ defmodule Minga.Git.Repo do
   @spec refresh(GenServer.server()) :: :ok
   def refresh(server) do
     GenServer.cast(server, :refresh)
+  end
+
+  @doc "Blocks until the repo has no in-flight or pending refresh work."
+  @spec await_refresh(GenServer.server()) :: :ok
+  def await_refresh(server) do
+    GenServer.call(server, :await_refresh, 5_000)
   end
 
   # ── GenServer Callbacks ────────────────────────────────────────────────
@@ -182,13 +220,10 @@ defmodule Minga.Git.Repo do
       events_registry: events_registry
     }
 
-    # Load initial status and branch synchronously so callers have data immediately
-    state = do_refresh(state)
-
-    # Start watching .git/ for changes
     state = start_git_watcher(state)
+    send(self(), :initial_refresh)
 
-    Minga.Log.debug(:editor, "[Git.Repo] started for #{git_root} (branch: #{state.branch})")
+    Minga.Log.debug(:editor, "[Git.Repo] started for #{git_root}")
 
     {:ok, state}
   end
@@ -197,6 +232,10 @@ defmodule Minga.Git.Repo do
   @spec handle_call(term(), GenServer.from(), t()) :: {:reply, term(), t()}
   def handle_call(:status, _from, state) do
     {:reply, state.entries, state}
+  end
+
+  def handle_call(:status_snapshot, _from, state) do
+    {:reply, StatusSnapshot.new(state.git_root, entry_base_path(state), state.entries), state}
   end
 
   def handle_call(:branch, _from, state) do
@@ -208,15 +247,58 @@ defmodule Minga.Git.Repo do
     {:reply, summary, state}
   end
 
+  def handle_call(
+        :await_refresh,
+        _from,
+        %{refresh_task: nil, refresh_pending?: false, debounce_ref: nil} = state
+      ) do
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:await_refresh, from, state) do
+    {:noreply, %{state | awaiting_refresh: [from | state.awaiting_refresh]}}
+  end
+
   @impl true
   @spec handle_cast(term(), t()) :: {:noreply, t()}
   def handle_cast(:refresh, state) do
-    state = do_refresh(state)
-    {:noreply, state}
+    {:noreply, request_refresh(state)}
   end
 
   @impl true
   @spec handle_info(term(), t()) :: {:noreply, t()}
+  def handle_info(:initial_refresh, state) do
+    {:noreply, request_refresh(state)}
+  end
+
+  def handle_info({:refresh_result, pid, result}, %{refresh_task: %{pid: pid, ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+
+    state =
+      state
+      |> clear_refresh_task()
+      |> apply_refresh_result(result)
+      |> maybe_run_pending_refresh()
+      |> reply_refresh_waiters_if_idle()
+
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{refresh_task: %{ref: ref}} = state) do
+    Minga.Log.warning(
+      :editor,
+      "[Git.Repo] refresh failed for #{state.git_root}: #{inspect(reason)}"
+    )
+
+    state =
+      state
+      |> clear_refresh_task()
+      |> maybe_run_pending_refresh()
+      |> reply_refresh_waiters_if_idle()
+
+    {:noreply, state}
+  end
+
   def handle_info({:file_event, _watcher_pid, {path, _events}}, state) do
     path_str = to_string(path)
 
@@ -234,9 +316,7 @@ defmodule Minga.Git.Repo do
   end
 
   def handle_info(:debounce_refresh, state) do
-    state = %{state | debounce_ref: nil}
-    state = do_refresh(state)
-    {:noreply, state}
+    {:noreply, state |> cancel_debounce() |> request_refresh()}
   end
 
   def handle_info(
@@ -256,14 +336,122 @@ defmodule Minga.Git.Repo do
   @impl true
   @spec terminate(term(), t()) :: :ok
   def terminate(_reason, state) do
+    stop_refresh_task(state)
     stop_git_watcher(state)
     :ok
   end
 
   # ── Private ────────────────────────────────────────────────────────────
 
-  @spec do_refresh(t()) :: t()
-  defp do_refresh(state) do
+  @spec tracked_repo_for_path(String.t()) :: {String.t(), pid()} | nil
+  defp tracked_repo_for_path(path) do
+    @registry
+    |> Registry.select([{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+    |> Enum.filter(fn {git_root, pid} ->
+      is_binary(git_root) and path_under_root?(path, git_root) and Process.alive?(pid)
+    end)
+    |> Enum.sort_by(fn {git_root, _pid} -> byte_size(git_root) end, :desc)
+    |> List.first()
+  end
+
+  @spec path_under_root?(String.t(), String.t()) :: boolean()
+  defp path_under_root?(path, root) do
+    expanded_root = Path.expand(root)
+    path == expanded_root or String.starts_with?(path, path_prefix(expanded_root))
+  end
+
+  @spec path_prefix(String.t()) :: String.t()
+  defp path_prefix("/"), do: "/"
+  defp path_prefix(root), do: root <> "/"
+
+  @spec entry_base_path(t()) :: String.t()
+  defp entry_base_path(%{project_root: root}) when is_binary(root), do: root
+  defp entry_base_path(%{git_root: root}), do: root
+
+  @typep refresh_task :: %{pid: pid(), ref: reference()}
+  @typep fetch_result(value) :: {:ok, value} | :error
+
+  @typep refresh_result :: %{
+           profile: Profile.t(),
+           entries: fetch_result([StatusEntry.t()]),
+           branch: fetch_result(String.t() | nil),
+           ahead_behind: fetch_result({non_neg_integer(), non_neg_integer()}),
+           last_commit_message: fetch_result(String.t()),
+           stash_count: fetch_result(non_neg_integer())
+         }
+
+  @spec request_refresh(t()) :: t()
+  defp request_refresh(%{refresh_task: nil} = state), do: start_refresh_task(state)
+  defp request_refresh(state), do: %{state | refresh_pending?: true}
+
+  @spec start_refresh_task(t()) :: t()
+  defp start_refresh_task(state) do
+    task = async_refresh(state.git_root, state.project_root, state.profile)
+    %{state | refresh_task: task, refresh_pending?: false}
+  end
+
+  @spec async_refresh(String.t(), String.t() | nil, Profile.t() | nil) :: refresh_task()
+  defp async_refresh(git_root, project_root, profile) do
+    fun = fn -> build_refresh_result(git_root, project_root, profile) end
+
+    case Process.whereis(Minga.Eval.TaskSupervisor) do
+      nil -> monitored_process(fun)
+      _pid -> supervised_monitored_process(Minga.Eval.TaskSupervisor, fun)
+    end
+  end
+
+  @spec supervised_monitored_process(atom(), (-> term())) :: refresh_task()
+  defp supervised_monitored_process(supervisor, fun) when is_atom(supervisor) do
+    owner = self()
+
+    case Task.Supervisor.start_child(supervisor, fn ->
+           send(owner, {:refresh_result, self(), fun.()})
+         end) do
+      {:ok, pid} -> %{pid: pid, ref: Process.monitor(pid)}
+      {:error, _reason} -> monitored_process(fun)
+    end
+  end
+
+  @spec monitored_process((-> term())) :: refresh_task()
+  defp monitored_process(fun) when is_function(fun, 0) do
+    owner = self()
+    {pid, ref} = spawn_monitor(fn -> send(owner, {:refresh_result, self(), fun.()}) end)
+    %{pid: pid, ref: ref}
+  end
+
+  @spec build_refresh_result(String.t(), String.t() | nil, Profile.t() | nil) :: refresh_result()
+  defp build_refresh_result(git_root, project_root, profile) do
+    profile = profile || Profile.detect(git_root)
+
+    %{
+      profile: profile,
+      entries: fetch_status(git_root, project_root, profile),
+      branch: fetch_branch(git_root),
+      ahead_behind: fetch_ahead_behind(git_root),
+      last_commit_message: fetch_last_commit_message(git_root),
+      stash_count: fetch_stash_count(git_root)
+    }
+  end
+
+  @spec clear_refresh_task(t()) :: t()
+  defp clear_refresh_task(state), do: %{state | refresh_task: nil}
+
+  @spec maybe_run_pending_refresh(t()) :: t()
+  defp maybe_run_pending_refresh(%{refresh_pending?: true} = state), do: request_refresh(state)
+  defp maybe_run_pending_refresh(state), do: state
+
+  @spec reply_refresh_waiters_if_idle(t()) :: t()
+  defp reply_refresh_waiters_if_idle(
+         %{refresh_task: nil, refresh_pending?: false, debounce_ref: nil} = state
+       ) do
+    Enum.each(state.awaiting_refresh, &GenServer.reply(&1, :ok))
+    %{state | awaiting_refresh: []}
+  end
+
+  defp reply_refresh_waiters_if_idle(state), do: state
+
+  @spec apply_refresh_result(t(), refresh_result()) :: t()
+  defp apply_refresh_result(state, result) do
     old_entries = state.entries
     old_branch = state.branch
     old_ahead = state.ahead
@@ -271,11 +459,11 @@ defmodule Minga.Git.Repo do
     old_last_commit_message = state.last_commit_message
     old_stash_count = state.stash_count
 
-    entries = fetch_status(state.git_root, state.project_root)
-    branch = fetch_branch(state.git_root)
-    {ahead, behind} = fetch_ahead_behind(state.git_root)
-    last_commit_message = fetch_last_commit_message(state.git_root)
-    stash_count = fetch_stash_count(state.git_root)
+    entries = fetched_or_current(result.entries, old_entries)
+    branch = fetched_or_current(result.branch, old_branch)
+    {ahead, behind} = fetched_or_current(result.ahead_behind, {old_ahead, old_behind})
+    last_commit_message = fetched_or_current(result.last_commit_message, old_last_commit_message)
+    stash_count = fetched_or_current(result.stash_count, old_stash_count)
 
     state = %{
       state
@@ -284,10 +472,10 @@ defmodule Minga.Git.Repo do
         ahead: ahead,
         behind: behind,
         last_commit_message: last_commit_message,
-        stash_count: stash_count
+        stash_count: stash_count,
+        profile: result.profile
     }
 
-    # Broadcast only if something changed
     changed =
       entries != old_entries or branch != old_branch or
         ahead != old_ahead or behind != old_behind or
@@ -298,12 +486,13 @@ defmodule Minga.Git.Repo do
         :git_status_changed,
         %Minga.Events.GitStatusEvent{
           git_root: state.git_root,
-          entries: entries,
-          branch: branch,
-          ahead: ahead,
-          behind: behind,
-          last_commit_message: last_commit_message,
-          stash_count: stash_count
+          entries: state.entries,
+          branch: state.branch,
+          ahead: state.ahead,
+          behind: state.behind,
+          entry_base_path: entry_base_path(state),
+          last_commit_message: state.last_commit_message,
+          stash_count: state.stash_count
         },
         state.events_registry
       )
@@ -328,54 +517,61 @@ defmodule Minga.Git.Repo do
     String.ends_with?(path_str, "/refs/stash") or String.ends_with?(path_str, "/logs/refs/stash")
   end
 
-  @spec fetch_status(String.t(), String.t() | nil) :: [StatusEntry.t()]
-  defp fetch_status(git_root, project_root) do
-    case Git.status(git_root) do
+  @spec fetched_or_current(fetch_result(value), value) :: value when value: term()
+  defp fetched_or_current({:ok, value}, _current), do: value
+  defp fetched_or_current(:error, current), do: current
+
+  @spec fetch_status(String.t(), String.t() | nil, Profile.t()) :: fetch_result([StatusEntry.t()])
+  defp fetch_status(git_root, project_root, %Profile{} = profile) do
+    case Git.status(git_root,
+           untracked_mode: profile.untracked_mode,
+           timeout_ms: profile.timeout_ms
+         ) do
       {:ok, entries} ->
-        maybe_relativize_paths(entries, git_root, project_root)
+        {:ok, maybe_relativize_paths(entries, git_root, project_root)}
 
       {:error, reason} ->
         Minga.Log.warning(:editor, "[Git.Repo] status failed: #{reason}")
-        []
+        :error
     end
   end
 
-  @spec fetch_branch(String.t()) :: String.t() | nil
+  @spec fetch_branch(String.t()) :: fetch_result(String.t() | nil)
   defp fetch_branch(git_root) do
     case Git.current_branch(git_root) do
-      {:ok, branch} -> branch
-      :error -> nil
+      {:ok, branch} -> {:ok, branch}
+      :error -> :error
     end
   end
 
-  @spec fetch_ahead_behind(String.t()) :: {non_neg_integer(), non_neg_integer()}
+  @spec fetch_ahead_behind(String.t()) :: fetch_result({non_neg_integer(), non_neg_integer()})
   defp fetch_ahead_behind(git_root) do
     case Git.ahead_behind(git_root) do
-      {:ok, ahead, behind} -> {ahead, behind}
-      :error -> {0, 0}
+      {:ok, ahead, behind} -> {:ok, {ahead, behind}}
+      :error -> :error
     end
   end
 
-  @spec fetch_last_commit_message(String.t()) :: String.t()
+  @spec fetch_last_commit_message(String.t()) :: fetch_result(String.t())
   defp fetch_last_commit_message(git_root) do
     case Git.last_commit_message(git_root) do
-      {:ok, message} -> message
-      :error -> ""
+      {:ok, message} -> {:ok, message}
+      :error -> :error
     end
   end
 
-  @spec fetch_stash_count(String.t()) :: non_neg_integer()
+  @spec fetch_stash_count(String.t()) :: fetch_result(non_neg_integer())
   defp fetch_stash_count(git_root) do
     case Git.stash_list(git_root) do
-      {:ok, entries} -> length(entries)
+      {:ok, entries} -> {:ok, length(entries)}
       {:error, reason} -> log_stash_count_failure(reason)
     end
   end
 
-  @spec log_stash_count_failure(String.t()) :: 0
+  @spec log_stash_count_failure(String.t()) :: :error
   defp log_stash_count_failure(reason) do
     Minga.Log.warning(:editor, "[Git.Repo] stash list failed: #{reason}")
-    0
+    :error
   end
 
   @spec maybe_relativize_paths([StatusEntry.t()], String.t(), String.t() | nil) :: [
@@ -449,6 +645,15 @@ defmodule Minga.Git.Repo do
     end
   end
 
+  @spec stop_refresh_task(t()) :: :ok
+  defp stop_refresh_task(%{refresh_task: nil}), do: :ok
+
+  defp stop_refresh_task(%{refresh_task: %{pid: pid, ref: ref}}) do
+    Process.demonitor(ref, [:flush])
+    Process.exit(pid, :kill)
+    :ok
+  end
+
   @spec stop_git_watcher(t()) :: :ok
   defp stop_git_watcher(%{watcher_pid: nil}), do: :ok
 
@@ -456,6 +661,14 @@ defmodule Minga.Git.Repo do
     GenServer.stop(pid)
   catch
     :exit, _ -> :ok
+  end
+
+  @spec cancel_debounce(t()) :: t()
+  defp cancel_debounce(%{debounce_ref: nil} = state), do: state
+
+  defp cancel_debounce(%{debounce_ref: ref} = state) do
+    Process.cancel_timer(ref)
+    %{state | debounce_ref: nil}
   end
 
   @spec schedule_debounce(t()) :: t()

--- a/lib/minga/git/repo/profile.ex
+++ b/lib/minga/git/repo/profile.ex
@@ -1,0 +1,89 @@
+defmodule Minga.Git.Repo.Profile do
+  @moduledoc """
+  Runtime policy for repo-wide git refreshes.
+
+  The profile is deliberately cheap to build. Ambient editor features use it to avoid expensive status modes in sparse or user-overridden huge repos.
+  """
+
+  @type size_class :: :unknown | :large | :huge
+
+  @type t :: %__MODULE__{
+          sparse?: boolean(),
+          size_class: size_class(),
+          untracked_mode: Minga.Git.untracked_mode(),
+          timeout_ms: pos_integer()
+        }
+
+  @enforce_keys [:sparse?, :size_class, :untracked_mode, :timeout_ms]
+  defstruct sparse?: false,
+            size_class: :unknown,
+            untracked_mode: :normal,
+            timeout_ms: 2_000
+
+  @doc "Builds the ambient git policy for `git_root`."
+  @spec detect(String.t()) :: t()
+  def detect(git_root) when is_binary(git_root) do
+    sparse? = sparse_checkout?(git_root)
+
+    %__MODULE__{
+      sparse?: sparse?,
+      size_class: if(sparse?, do: :large, else: :unknown),
+      untracked_mode: if(sparse?, do: :no, else: :normal),
+      timeout_ms: 2_000
+    }
+    |> apply_override(git_root)
+  end
+
+  @spec sparse_checkout?(String.t()) :: boolean()
+  defp sparse_checkout?(git_root) do
+    git_dir = git_dir(git_root)
+    sparse_file? = git_dir |> Path.join("info/sparse-checkout") |> File.exists?()
+    sparse_config? = git_dir |> Path.join("config") |> sparse_config_enabled?()
+    worktree_config? = git_root |> Path.join(".git/config") |> sparse_config_enabled?()
+    sparse_file? or sparse_config? or worktree_config?
+  end
+
+  @spec git_dir(String.t()) :: String.t()
+  defp git_dir(git_root) do
+    dot_git = Path.join(git_root, ".git")
+
+    case File.read(dot_git) do
+      {:ok, "gitdir: " <> rest} -> Path.expand(String.trim(rest), git_root)
+      _ -> dot_git
+    end
+  end
+
+  @spec sparse_config_enabled?(String.t()) :: boolean()
+  defp sparse_config_enabled?(path) do
+    case File.read(path) do
+      {:ok, config} -> Regex.match?(~r/^\s*sparsecheckout\s*=\s*true\s*$/im, config)
+      {:error, _} -> false
+    end
+  end
+
+  @spec apply_override(t(), String.t()) :: t()
+  defp apply_override(%__MODULE__{} = profile, git_root) do
+    overrides = Application.get_env(:minga, :git_repo_overrides, %{})
+    expanded_root = Path.expand(git_root)
+
+    override =
+      Enum.find_value(overrides, %{}, fn {root, value} ->
+        if Path.expand(to_string(root)) == expanded_root, do: Map.new(value), else: nil
+      end)
+
+    apply_profile_map(profile, override)
+  end
+
+  @spec apply_profile_map(t(), map()) :: t()
+  defp apply_profile_map(profile, override) when map_size(override) == 0, do: profile
+
+  defp apply_profile_map(profile, override) do
+    %{
+      profile
+      | sparse?: Map.get(override, :sparse?, profile.sparse?),
+        size_class: Map.get(override, :size_class, profile.size_class),
+        untracked_mode: Map.get(override, :untracked_mode, profile.untracked_mode),
+        timeout_ms: Map.get(override, :timeout_ms, profile.timeout_ms)
+    }
+  end
+end

--- a/lib/minga/git/repo/status_snapshot.ex
+++ b/lib/minga/git/repo/status_snapshot.ex
@@ -1,0 +1,25 @@
+defmodule Minga.Git.Repo.StatusSnapshot do
+  @moduledoc """
+  Cached git status entries for a tracked repository.
+
+  `entry_base_path` tells consumers which filesystem path the entry paths are relative to. This lets cache-only UI consumers render badges without shelling out to git.
+  """
+
+  alias Minga.Git.StatusEntry
+
+  @enforce_keys [:git_root, :entry_base_path, :entries]
+  defstruct [:git_root, :entry_base_path, :entries]
+
+  @type t :: %__MODULE__{
+          git_root: String.t(),
+          entry_base_path: String.t(),
+          entries: [StatusEntry.t()]
+        }
+
+  @doc "Builds a cached status snapshot."
+  @spec new(String.t(), String.t(), [StatusEntry.t()]) :: t()
+  def new(git_root, entry_base_path, entries)
+      when is_binary(git_root) and is_binary(entry_base_path) and is_list(entries) do
+    %__MODULE__{git_root: git_root, entry_base_path: entry_base_path, entries: entries}
+  end
+end

--- a/lib/minga/git/system.ex
+++ b/lib/minga/git/system.ex
@@ -3,19 +3,21 @@ defmodule Minga.Git.System do
   Git backend that shells out to the `git` CLI.
 
   This is the default (production) implementation of `Minga.Git.Backend`.
-  Every function spawns a short-lived OS process via `System.cmd/3`.
+  Every function spawns a short-lived OS process through a timeout-bounded helper.
   """
 
   @behaviour Minga.Git.Backend
 
   @cmd_timeout 5_000
+  @default_timeout_ms 2_000
+  @status_timeout_ms 2_000
 
   @impl true
   @spec root_for(String.t()) :: {:ok, String.t()} | :not_git
   def root_for(path) when is_binary(path) do
     dir = if File.dir?(path), do: path, else: Path.dirname(path)
 
-    case System.cmd("git", ["rev-parse", "--show-toplevel"],
+    case git_cmd(["rev-parse", "--show-toplevel"],
            cd: dir,
            stderr_to_stdout: true
          ) do
@@ -29,7 +31,7 @@ defmodule Minga.Git.System do
   @impl true
   @spec show_head(String.t(), String.t()) :: {:ok, String.t()} | :error
   def show_head(git_root, relative_path) when is_binary(git_root) and is_binary(relative_path) do
-    case System.cmd("git", ["show", "HEAD:#{relative_path}"],
+    case git_cmd(["show", "HEAD:#{relative_path}"],
            cd: git_root,
            stderr_to_stdout: true
          ) do
@@ -44,7 +46,7 @@ defmodule Minga.Git.System do
   @spec show_staged(String.t(), String.t()) :: {:ok, String.t()} | :error
   def show_staged(git_root, relative_path)
       when is_binary(git_root) and is_binary(relative_path) do
-    case System.cmd("git", ["show", ":#{relative_path}"],
+    case git_cmd(["show", ":#{relative_path}"],
            cd: git_root,
            stderr_to_stdout: true
          ) do
@@ -91,8 +93,7 @@ defmodule Minga.Git.System do
       when is_binary(git_root) and is_binary(relative_path) and is_integer(line_number) do
     line_1 = line_number + 1
 
-    case System.cmd(
-           "git",
+    case git_cmd(
            ["blame", "-L", "#{line_1},#{line_1}", "--porcelain", relative_path],
            cd: git_root,
            stderr_to_stdout: true
@@ -105,11 +106,16 @@ defmodule Minga.Git.System do
   end
 
   @impl true
-  @spec status(String.t()) :: {:ok, [Minga.Git.status_entry()]} | {:error, String.t()}
-  def status(git_root) when is_binary(git_root) do
-    case System.cmd("git", ["status", "--porcelain=v2", "-z", "-uall"],
+  @spec status(String.t(), Minga.Git.status_opts()) ::
+          {:ok, [Minga.Git.status_entry()]} | {:error, String.t()}
+  def status(git_root, opts \\ []) when is_binary(git_root) and is_list(opts) do
+    mode = Keyword.get(opts, :untracked_mode, :normal)
+    timeout_ms = Keyword.get(opts, :timeout_ms, @status_timeout_ms)
+
+    case git_cmd(["status", "--porcelain=v2", "-z", untracked_arg(mode)],
            cd: git_root,
-           stderr_to_stdout: true
+           stderr_to_stdout: true,
+           timeout_ms: timeout_ms
          ) do
       {output, 0} ->
         {:ok, parse_status_output(output)}
@@ -127,7 +133,7 @@ defmodule Minga.Git.System do
     with :ok <- Minga.Git.DiffOptions.validate(opts) do
       args = diff_args(opts)
 
-      case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
+      case git_cmd(args, cd: git_root, stderr_to_stdout: true) do
         {output, 0} -> {:ok, output}
         {output, _} -> {:error, "git diff failed: #{String.trim(output)}"}
       end
@@ -169,7 +175,7 @@ defmodule Minga.Git.System do
     args = ["log", "--format=#{format}", "-n", "#{count}"]
     args = if path, do: args ++ ["--", path], else: args
 
-    case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(args, cd: git_root, stderr_to_stdout: true) do
       {output, 0} ->
         entries =
           output
@@ -195,7 +201,7 @@ defmodule Minga.Git.System do
   def stage(git_root, paths) when is_binary(git_root) and is_list(paths) do
     args = ["add", "--"] ++ paths
 
-    case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(args, cd: git_root, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {output, _} -> {:error, "git add failed: #{String.trim(output)}"}
     end
@@ -210,7 +216,7 @@ defmodule Minga.Git.System do
     args = ["commit", "-m", message]
     args = if Keyword.get(opts, :amend, false), do: args ++ ["--amend"], else: args
 
-    case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(args, cd: git_root, stderr_to_stdout: true) do
       {output, 0} ->
         short_hash =
           case Regex.run(~r"\[[\w/.-]+ ([a-f0-9]+)\]", output) do
@@ -230,7 +236,7 @@ defmodule Minga.Git.System do
   @impl true
   @spec last_commit_message(String.t()) :: {:ok, String.t()} | :error
   def last_commit_message(git_root) when is_binary(git_root) do
-    case System.cmd("git", ["log", "-1", "--format=%B"], cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(["log", "-1", "--format=%B"], cd: git_root, stderr_to_stdout: true) do
       {msg, 0} -> {:ok, String.trim(msg)}
       _ -> :error
     end
@@ -241,7 +247,7 @@ defmodule Minga.Git.System do
   @impl true
   @spec ahead_behind(String.t()) :: {:ok, non_neg_integer(), non_neg_integer()} | :error
   def ahead_behind(git_root) when is_binary(git_root) do
-    case System.cmd("git", ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"],
+    case git_cmd(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"],
            cd: git_root,
            stderr_to_stdout: true
          ) do
@@ -272,7 +278,7 @@ defmodule Minga.Git.System do
   def unstage(git_root, paths) when is_binary(git_root) and is_list(paths) do
     args = ["reset", "HEAD", "--"] ++ paths
 
-    case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(args, cd: git_root, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {output, _} -> {:error, "git reset failed: #{String.trim(output)}"}
     end
@@ -283,7 +289,7 @@ defmodule Minga.Git.System do
   @impl true
   @spec unstage_all(String.t()) :: :ok | {:error, String.t()}
   def unstage_all(git_root) when is_binary(git_root) do
-    case System.cmd("git", ["reset", "HEAD"], cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(["reset", "HEAD"], cd: git_root, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {output, _} -> {:error, "git reset failed: #{String.trim(output)}"}
     end
@@ -297,13 +303,13 @@ defmodule Minga.Git.System do
     abs_path = Path.join(git_root, path)
 
     # Check if the file is tracked by git
-    case System.cmd("git", ["ls-files", "--error-unmatch", path],
+    case git_cmd(["ls-files", "--error-unmatch", path],
            cd: git_root,
            stderr_to_stdout: true
          ) do
       {_, 0} ->
         # Tracked file: restore from index/HEAD
-        case System.cmd("git", ["checkout", "--", path],
+        case git_cmd(["checkout", "--", path],
                cd: git_root,
                stderr_to_stdout: true
              ) do
@@ -327,7 +333,7 @@ defmodule Minga.Git.System do
   def branch_list(git_root) when is_binary(git_root) do
     format = "%(refname:short)%09%(upstream:short)%09%(upstream:track)%09%(HEAD)"
 
-    case System.cmd("git", ["branch", "-a", "--format=#{format}"],
+    case git_cmd(["branch", "-a", "--format=#{format}"],
            cd: git_root,
            stderr_to_stdout: true
          ) do
@@ -350,7 +356,7 @@ defmodule Minga.Git.System do
   @impl true
   @spec branch_create(String.t(), String.t()) :: :ok | {:error, String.t()}
   def branch_create(git_root, name) when is_binary(git_root) and is_binary(name) do
-    case System.cmd("git", ["checkout", "-b", name], cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(["checkout", "-b", name], cd: git_root, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {output, _} -> {:error, "git checkout -b failed: #{String.trim(output)}"}
     end
@@ -362,7 +368,7 @@ defmodule Minga.Git.System do
   @impl true
   @spec branch_switch(String.t(), String.t()) :: :ok | {:error, String.t()}
   def branch_switch(git_root, name) when is_binary(git_root) and is_binary(name) do
-    case System.cmd("git", ["checkout", name], cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(["checkout", name], cd: git_root, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {output, _} -> {:error, "git checkout failed: #{String.trim(output)}"}
     end
@@ -377,7 +383,7 @@ defmodule Minga.Git.System do
       when is_binary(git_root) and is_binary(name) do
     flag = if force, do: "-D", else: "-d"
 
-    case System.cmd("git", ["branch", flag, name], cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(["branch", flag, name], cd: git_root, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {output, _} -> {:error, "git branch delete failed: #{String.trim(output)}"}
     end
@@ -396,7 +402,7 @@ defmodule Minga.Git.System do
         do: args ++ ["--include-untracked"],
         else: args
 
-    case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(args, cd: git_root, stderr_to_stdout: true) do
       {output, 0} ->
         case String.trim(output) do
           "No local changes to save" -> {:error, "No changes to stash"}
@@ -413,7 +419,7 @@ defmodule Minga.Git.System do
   @impl true
   @spec stash_pop(String.t()) :: :ok | {:error, String.t()}
   def stash_pop(git_root) when is_binary(git_root) do
-    case System.cmd("git", ["stash", "pop"], cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(["stash", "pop"], cd: git_root, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {output, _} -> {:error, "git stash pop failed: #{String.trim(output)}"}
     end
@@ -426,7 +432,7 @@ defmodule Minga.Git.System do
   def stash_list(git_root) when is_binary(git_root) do
     format = "%gd%x1f%cr%x1f%gs"
 
-    case System.cmd("git", ["stash", "list", "--format=#{format}"],
+    case git_cmd(["stash", "list", "--format=#{format}"],
            cd: git_root,
            stderr_to_stdout: true
          ) do
@@ -449,7 +455,7 @@ defmodule Minga.Git.System do
   @impl true
   @spec stash_drop(String.t(), non_neg_integer()) :: :ok | {:error, String.t()}
   def stash_drop(git_root, index) when is_binary(git_root) and is_integer(index) and index >= 0 do
-    case System.cmd("git", ["stash", "drop", "stash@{#{index}}"],
+    case git_cmd(["stash", "drop", "stash@{#{index}}"],
            cd: git_root,
            stderr_to_stdout: true
          ) do
@@ -467,7 +473,7 @@ defmodule Minga.Git.System do
     args = if Keyword.get(opts, :set_upstream), do: args ++ ["--set-upstream"], else: args
     args = if Keyword.get(opts, :force), do: args ++ ["--force-with-lease"], else: args
 
-    case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(args, cd: git_root, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {output, _} -> {:error, "git push failed: #{String.trim(output)}"}
     end
@@ -481,7 +487,7 @@ defmodule Minga.Git.System do
     args = ["pull"]
     args = if Keyword.get(opts, :rebase), do: args ++ ["--rebase"], else: args
 
-    case System.cmd("git", args, cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(args, cd: git_root, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {output, _} -> {:error, "git pull failed: #{String.trim(output)}"}
     end
@@ -492,7 +498,7 @@ defmodule Minga.Git.System do
   @impl true
   @spec fetch_remotes(String.t(), keyword()) :: :ok | {:error, String.t()}
   def fetch_remotes(git_root, _opts \\ []) when is_binary(git_root) do
-    case System.cmd("git", ["fetch", "--all"], cd: git_root, stderr_to_stdout: true) do
+    case git_cmd(["fetch", "--all"], cd: git_root, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {output, _} -> {:error, "git fetch failed: #{String.trim(output)}"}
     end
@@ -513,7 +519,7 @@ defmodule Minga.Git.System do
 
       {:ok, _detached} ->
         # Detached HEAD: fall back to git CLI for the short SHA
-        case System.cmd("git", ["rev-parse", "--short", "HEAD"],
+        case git_cmd(["rev-parse", "--short", "HEAD"],
                cd: git_root,
                stderr_to_stdout: true
              ) do
@@ -531,6 +537,37 @@ defmodule Minga.Git.System do
   # ── Private ────────────────────────────────────────────────────────────────
 
   alias Minga.Git.StatusEntry
+
+  @spec untracked_arg(Minga.Git.untracked_mode()) :: String.t()
+  defp untracked_arg(:no), do: "-uno"
+  defp untracked_arg(:normal), do: "-unormal"
+  defp untracked_arg(:all), do: "-uall"
+  defp untracked_arg(_), do: "-unormal"
+
+  @spec git_cmd([String.t()], keyword()) :: {String.t(), non_neg_integer()}
+  defp git_cmd(args, opts) when is_list(args) and is_list(opts) do
+    timeout_ms = Keyword.get(opts, :timeout_ms, @default_timeout_ms)
+    cmd_opts = opts |> Keyword.delete(:timeout_ms) |> Keyword.put_new(:stderr_to_stdout, true)
+
+    case System.find_executable("git") do
+      nil -> {"git executable not found", 127}
+      executable -> run_cmd_with_timeout(executable, args, cmd_opts, timeout_ms)
+    end
+  rescue
+    e in [ErlangError, ArgumentError] -> {Exception.message(e), 1}
+  end
+
+  @spec run_cmd_with_timeout(String.t(), [String.t()], keyword(), pos_integer()) ::
+          {String.t(), non_neg_integer()}
+  defp run_cmd_with_timeout(executable, args, opts, timeout_ms) do
+    task = Task.async(fn -> System.cmd(executable, args, opts) end)
+
+    case Task.yield(task, timeout_ms) || Task.shutdown(task, :brutal_kill) do
+      {:ok, {output, code}} -> {output, code}
+      {:exit, reason} -> {inspect(reason), 1}
+      nil -> {"git command timed out after #{timeout_ms}ms", 124}
+    end
+  end
 
   @doc false
   @spec parse_status_output(String.t()) :: [Minga.Git.status_entry()]

--- a/lib/minga/project/file_tree.ex
+++ b/lib/minga/project/file_tree.ex
@@ -273,12 +273,6 @@ defmodule Minga.Project.FileTree do
     invalidate_entries(%{tree | filter: nil, cursor: 0})
   end
 
-  @doc "Refreshes git status for the tree root. Returns the updated tree."
-  @spec refresh_git_status(t()) :: t()
-  def refresh_git_status(%__MODULE__{} = tree) do
-    replace_git_status(tree, GitStatus.compute(tree.root))
-  end
-
   @doc "Replaces the cached git status map for the tree."
   @spec replace_git_status(t(), GitStatus.status_map()) :: t()
   def replace_git_status(%__MODULE__{} = tree, git_status) when is_map(git_status) do

--- a/lib/minga/project/file_tree/git_status.ex
+++ b/lib/minga/project/file_tree/git_status.ex
@@ -1,13 +1,8 @@
 defmodule Minga.Project.FileTree.GitStatus do
   @moduledoc """
-  Computes git status for all files under a directory tree.
+  Builds file-tree git badge maps from already-fetched repo status entries.
 
-  Runs `git status --porcelain=v1` and parses the output into a map
-  of `%{absolute_path => status_atom}`. Also propagates status up to
-  parent directories so collapsed dirs show the "worst" child status.
-
-  This module is pure (no GenServer). The caller is responsible for
-  caching the result and refreshing it on save/git operations.
+  This module never shells out to git. `Minga.Git.Repo` owns fetching and caching repo status; the file tree consumes those cached entries and converts them into `%{absolute_path => status_atom}` maps. Directory entries inherit the most severe descendant status so collapsed directories still show useful badges.
   """
 
   @typedoc "Git status for a single file."
@@ -15,29 +10,6 @@ defmodule Minga.Project.FileTree.GitStatus do
 
   @typedoc "Status map keyed by absolute file path."
   @type status_map :: %{String.t() => file_status()}
-
-  @doc """
-  Computes git status for all files under `root_path`.
-
-  Returns a status map with absolute paths as keys. If the path is not
-  inside a git repo, returns an empty map. Directory entries are included
-  with the "worst" status of any descendant.
-
-  Runs asynchronously-friendly: no side effects, no process state.
-  """
-  @spec compute(String.t()) :: status_map()
-  def compute(root_path) when is_binary(root_path) do
-    case Minga.Git.root_for(root_path) do
-      {:ok, git_root} ->
-        case Minga.Git.status(git_root) do
-          {:ok, entries} -> from_entries(entries, git_root, root_path)
-          {:error, _} -> %{}
-        end
-
-      :not_git ->
-        %{}
-    end
-  end
 
   @doc """
   Builds file-tree git status from an already-fetched git status event.

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -142,7 +142,11 @@ defmodule MingaEditor.Commands.FileTree do
 
   @spec refresh(state()) :: state()
   def refresh(state) do
-    with_tree(state, fn tree -> tree |> FileTree.refresh() |> FileTree.refresh_git_status() end)
+    with_tree(state, fn tree ->
+      tree
+      |> FileTree.refresh()
+      |> FileTreeFreshness.refresh_tree_git_status_from_cache(EditorState.events_registry(state))
+    end)
   end
 
   @spec with_tree(state(), (FileTree.t() -> FileTree.t())) :: state()
@@ -792,7 +796,9 @@ defmodule MingaEditor.Commands.FileTree do
         new_tree =
           tree
           |> FileTree.reroot(root)
-          |> FileTree.refresh_git_status()
+          |> FileTreeFreshness.refresh_tree_git_status_from_cache(
+            EditorState.events_registry(state)
+          )
 
         FileTreeFreshness.watch_expanded_dirs(new_tree)
         sync_and_update(state, new_tree)
@@ -867,7 +873,13 @@ defmodule MingaEditor.Commands.FileTree do
 
     root = file_tree_state(state).project_root || Minga.Project.root() || File.cwd!()
     tree = FileTree.new(root)
-    tree = FileTree.refresh_git_status(tree)
+
+    tree =
+      FileTreeFreshness.refresh_tree_git_status_from_cache(
+        tree,
+        EditorState.events_registry(state)
+      )
+
     tree = reveal_active(tree, state.workspace.buffers.active)
     FileTreeFreshness.watch_expanded_dirs(tree)
     buf = BufferSync.start_buffer(tree, EditorState.options_server(state))

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -7,6 +7,8 @@ defmodule MingaEditor.FileTree.Freshness do
 
   alias Minga.Buffer
   alias Minga.LSP.SyncServer
+  alias Minga.Git.Repo, as: GitRepo
+  alias Minga.Git.Repo.StatusSnapshot
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
   alias Minga.Project.FileTree.GitStatus
@@ -76,7 +78,11 @@ defmodule MingaEditor.FileTree.Freshness do
         set_file_tree(state, FileTreeState.clear_refresh(file_tree))
 
       %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
-        refreshed_tree = tree |> FileTree.refresh() |> FileTree.refresh_git_status()
+        refreshed_tree =
+          tree
+          |> FileTree.refresh()
+          |> refresh_tree_git_status_from_cache(EditorState.events_registry(state))
+
         watch_expanded_dirs(refreshed_tree)
 
         file_tree =
@@ -92,13 +98,17 @@ defmodule MingaEditor.FileTree.Freshness do
 
   @doc "Updates tree git badges from an already-fetched git status event."
   @spec refresh_git_status(state(), Minga.Events.GitStatusEvent.t()) :: state()
-  def refresh_git_status(state, %Minga.Events.GitStatusEvent{git_root: git_root, entries: entries}) do
+  def refresh_git_status(state, %Minga.Events.GitStatusEvent{
+        git_root: git_root,
+        entry_base_path: entry_base_path,
+        entries: entries
+      }) do
     case file_tree_state(state) do
       %FileTreeState{tree: nil} ->
         state
 
       %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
-        status = GitStatus.from_entries(entries, git_root, tree.root)
+        status = GitStatus.from_entries(entries, entry_base_path || git_root, tree.root)
         updated_tree = FileTree.replace_git_status(tree, status)
         file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
 
@@ -108,15 +118,36 @@ defmodule MingaEditor.FileTree.Freshness do
     end
   end
 
-  @doc "Refreshes tree git badges by querying the current git backend."
-  @spec refresh_git_status_from_disk(state()) :: state()
-  def refresh_git_status_from_disk(state) do
+  @doc "Refreshes tree git badges from the cached Git.Repo snapshot without shelling out to git."
+  @spec refresh_tree_git_status_from_cache(FileTree.t(), Minga.Events.registry()) :: FileTree.t()
+  def refresh_tree_git_status_from_cache(
+        %FileTree{} = tree,
+        events_registry \\ Minga.Events.default_registry()
+      ) do
+    case GitRepo.cached_status_for_path(tree.root) do
+      {:ok, %StatusSnapshot{entry_base_path: entry_base_path, entries: entries}} ->
+        status = GitStatus.from_entries(entries, entry_base_path, tree.root)
+        FileTree.replace_git_status(tree, status)
+
+      :not_tracked ->
+        ensure_repo_started(tree.root, events_registry)
+        tree
+    end
+  catch
+    :exit, _ -> tree
+  end
+
+  @doc "Refreshes tree git badges from the cached Git.Repo snapshot without shelling out to git."
+  @spec refresh_git_status_from_cache(state()) :: state()
+  def refresh_git_status_from_cache(state) do
     case file_tree_state(state) do
       %FileTreeState{tree: nil} ->
         state
 
       %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
-        updated_tree = FileTree.refresh_git_status(tree)
+        updated_tree =
+          refresh_tree_git_status_from_cache(tree, EditorState.events_registry(state))
+
         file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
 
         state
@@ -141,7 +172,7 @@ defmodule MingaEditor.FileTree.Freshness do
         new_tree =
           expanded_root
           |> FileTree.new(width: old_tree.width)
-          |> FileTree.refresh_git_status()
+          |> refresh_tree_git_status_from_cache(EditorState.events_registry(state))
 
         watch_expanded_dirs(new_tree)
 
@@ -169,6 +200,37 @@ defmodule MingaEditor.FileTree.Freshness do
   @spec unwatch_expanded_dirs(FileTree.t()) :: :ok
   def unwatch_expanded_dirs(%FileTree{root: root}) do
     safe_unwatch_directory_tree(root)
+  end
+
+  @spec ensure_repo_started(String.t(), Minga.Events.registry()) :: :ok
+  defp ensure_repo_started(root, events_registry) when is_binary(root) do
+    case Minga.Git.root_for(root) do
+      {:ok, git_root} ->
+        case GitRepo.ensure_started(git_root, root, events_registry) do
+          {:ok, _pid} ->
+            :ok
+
+          {:error, {:already_started, _pid}} ->
+            :ok
+
+          {:error, reason} ->
+            Minga.Log.warning(
+              :editor,
+              "File tree git repo start failed for #{root}: #{inspect(reason)}"
+            )
+        end
+
+      :not_git ->
+        :ok
+    end
+  catch
+    :exit, reason ->
+      Minga.Log.warning(
+        :editor,
+        "File tree git repo lookup failed for #{root}: #{inspect(reason)}"
+      )
+
+      :ok
   end
 
   @spec sync_buffer(state(), FileTree.t()) :: state()

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -135,7 +135,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   defp handle_buffer_saved(state, saved_buf) do
     new_state =
       state
-      |> FileTreeFreshness.refresh_git_status_from_disk()
+      |> FileTreeFreshness.refresh_git_status_from_cache()
       |> refresh_git_diff_views_for_buffer(saved_buf)
       |> EditorState.rebind_buffer_file_identity(saved_buf)
 

--- a/test/minga/git/repo/profile_test.exs
+++ b/test/minga/git/repo/profile_test.exs
@@ -1,0 +1,54 @@
+defmodule Minga.Git.Repo.ProfileTest do
+  @moduledoc "Tests for repo refresh policy detection."
+  # Mutates Application env for the override test, so this module must run serially.
+  use ExUnit.Case, async: false
+
+  alias Minga.Git.Repo.Profile
+
+  @moduletag :tmp_dir
+
+  test "defaults to normal untracked mode for ordinary repos", %{tmp_dir: dir} do
+    File.mkdir_p!(Path.join(dir, ".git"))
+
+    profile = Profile.detect(dir)
+
+    refute profile.sparse?
+    assert profile.size_class == :unknown
+    assert profile.untracked_mode == :normal
+  end
+
+  test "uses no untracked enumeration for sparse repos", %{tmp_dir: dir} do
+    sparse_file = Path.join([dir, ".git", "info", "sparse-checkout"])
+    File.mkdir_p!(Path.dirname(sparse_file))
+    File.write!(sparse_file, "lib/\n")
+
+    profile = Profile.detect(dir)
+
+    assert profile.sparse?
+    assert profile.size_class == :large
+    assert profile.untracked_mode == :no
+  end
+
+  test "applies per-repo config overrides", %{tmp_dir: dir} do
+    old = Application.get_env(:minga, :git_repo_overrides)
+
+    Application.put_env(:minga, :git_repo_overrides, %{
+      dir => %{sparse?: true, size_class: :huge, untracked_mode: :all, timeout_ms: 123}
+    })
+
+    on_exit(fn -> restore_overrides(old) end)
+
+    File.mkdir_p!(Path.join(dir, ".git"))
+
+    profile = Profile.detect(dir)
+
+    assert profile.sparse?
+    assert profile.size_class == :huge
+    assert profile.untracked_mode == :all
+    assert profile.timeout_ms == 123
+  end
+
+  @spec restore_overrides(term()) :: :ok
+  defp restore_overrides(nil), do: Application.delete_env(:minga, :git_repo_overrides)
+  defp restore_overrides(value), do: Application.put_env(:minga, :git_repo_overrides, value)
+end

--- a/test/minga/git/repo_test.exs
+++ b/test/minga/git/repo_test.exs
@@ -4,6 +4,7 @@ defmodule Minga.Git.RepoTest do
 
   alias Minga.Events
   alias Minga.Git.Repo
+  alias Minga.Git.Repo.StatusSnapshot
   alias Minga.Git.StashEntry
   alias Minga.Git.StatusEntry
   alias Minga.Git.Stub, as: GitStub
@@ -12,6 +13,7 @@ defmodule Minga.Git.RepoTest do
 
   describe "initial state" do
     setup %{tmp_dir: dir} do
+      events_registry = start_events_registry()
       GitStub.set_root(dir, dir)
       GitStub.set_branch(dir, "feat/xyz")
 
@@ -21,30 +23,34 @@ defmodule Minga.Git.RepoTest do
 
       on_exit(fn -> GitStub.clear(dir) end)
 
-      repo = start_supervised!({Repo, git_root: dir}, id: {Repo, dir})
-      %{root: dir, repo: repo}
+      repo = start_repo(dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
+      %{root: dir, repo: repo, events_registry: events_registry}
     end
 
-    test "loads status and branch from backend on start", %{repo: repo} do
+    test "loads status and branch from backend after start", %{repo: repo} do
       assert [%StatusEntry{path: "lib/foo.ex", status: :modified}] = Repo.status(repo)
       assert Repo.branch(repo) == "feat/xyz"
     end
 
-    test "loads ahead/behind counts on start", %{tmp_dir: dir} do
-      ab_dir = dir <> "/ab"
+    test "loads ahead/behind counts after start", %{tmp_dir: dir} do
+      events_registry = start_events_registry()
+      ab_dir = Path.join(dir, "ab")
       GitStub.set_root(ab_dir, ab_dir)
       GitStub.set_ahead_behind(ab_dir, 3, 1)
       on_exit(fn -> GitStub.clear(ab_dir) end)
 
-      repo = start_supervised!({Repo, git_root: ab_dir}, id: {Repo, ab_dir})
+      repo = start_repo(ab_dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
 
       summary = Repo.summary(repo)
       assert summary.ahead == 3
       assert summary.behind == 1
     end
 
-    test "loads stash count on start", %{tmp_dir: dir} do
-      stash_dir = dir <> "/stashes"
+    test "loads stash count after start", %{tmp_dir: dir} do
+      events_registry = start_events_registry()
+      stash_dir = Path.join(dir, "stashes")
       GitStub.set_root(stash_dir, stash_dir)
 
       GitStub.set_stashes(stash_dir, [
@@ -53,7 +59,8 @@ defmodule Minga.Git.RepoTest do
 
       on_exit(fn -> GitStub.clear(stash_dir) end)
 
-      repo = start_supervised!({Repo, git_root: stash_dir}, id: {Repo, stash_dir})
+      repo = start_repo(stash_dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
 
       assert Repo.summary(repo).stash_count == 1
     end
@@ -61,17 +68,21 @@ defmodule Minga.Git.RepoTest do
 
   describe "read APIs" do
     setup %{tmp_dir: dir} do
+      events_registry = start_events_registry()
       GitStub.set_root(dir, dir)
       on_exit(fn -> GitStub.clear(dir) end)
 
-      repo = start_supervised!({Repo, git_root: dir}, id: {Repo, dir})
-      %{root: dir, repo: repo}
+      repo = start_repo(dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
+      %{root: dir, repo: repo, events_registry: events_registry}
     end
 
-    test "status returns cached entries (not live)", %{root: dir, repo: repo} do
+    test "status returns cached entries and does not re-read live stub state", %{
+      root: dir,
+      repo: repo
+    } do
       assert Repo.status(repo) == []
 
-      # Change the stub after start; cached result should not change
       GitStub.set_status(dir, [
         %StatusEntry{path: "new.ex", status: :added, staged: true}
       ])
@@ -86,11 +97,13 @@ defmodule Minga.Git.RepoTest do
 
   describe "refresh" do
     setup %{tmp_dir: dir} do
+      events_registry = start_events_registry()
       GitStub.set_root(dir, dir)
       on_exit(fn -> GitStub.clear(dir) end)
 
-      repo = start_supervised!({Repo, git_root: dir}, id: {Repo, dir})
-      %{root: dir, repo: repo}
+      repo = start_repo(dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
+      %{root: dir, repo: repo, events_registry: events_registry}
     end
 
     test "re-reads status and branch from backend", %{root: dir, repo: repo} do
@@ -102,41 +115,66 @@ defmodule Minga.Git.RepoTest do
       GitStub.set_branch(dir, "develop")
 
       Repo.refresh(repo)
-      :sys.get_state(repo)
+      Repo.await_refresh(repo)
 
       assert Repo.status(repo) == [entry]
       assert Repo.branch(repo) == "develop"
     end
 
-    test "refresh publishes git_status_changed when status changes", %{root: dir, repo: repo} do
-      Events.subscribe(:git_status_changed)
+    test "keeps cached status when a later status refresh fails", %{root: dir, repo: repo} do
+      entry = %StatusEntry{path: "changed.ex", status: :modified, staged: false}
+      GitStub.set_status(dir, [entry])
+      Repo.refresh(repo)
+      Repo.await_refresh(repo)
+      assert Repo.status(repo) == [entry]
+
+      GitStub.set_status_error(dir, "status timed out")
+      GitStub.set_branch(dir, "still-updates")
+
+      Repo.refresh(repo)
+      Repo.await_refresh(repo)
+
+      assert Repo.status(repo) == [entry]
+      assert Repo.branch(repo) == "still-updates"
+    end
+
+    test "refresh publishes git_status_changed when status changes", %{
+      root: dir,
+      repo: repo,
+      events_registry: events_registry
+    } do
+      Events.subscribe(:git_status_changed, events_registry)
       entry = %StatusEntry{path: "new.ex", status: :added, staged: true}
       GitStub.set_status(dir, [entry])
 
       Repo.refresh(repo)
-      :sys.get_state(repo)
 
-      # Pin ^dir to only match events from this test's Repo (async-safe)
       assert_receive {:minga_event, :git_status_changed,
                       %Events.GitStatusEvent{git_root: ^dir, entries: [^entry]}}
     end
 
-    test "refresh does not publish event when status is unchanged", %{root: dir, repo: repo} do
-      Events.subscribe(:git_status_changed)
+    test "refresh does not publish event when status is unchanged", %{
+      root: dir,
+      repo: repo,
+      events_registry: events_registry
+    } do
+      Events.subscribe(:git_status_changed, events_registry)
 
       Repo.refresh(repo)
-      :sys.get_state(repo)
+      Repo.await_refresh(repo)
 
-      # Pin ^dir so we only refute events from this test's Repo
       refute_receive {:minga_event, :git_status_changed, %{git_root: ^dir}}, 50
     end
 
-    test "refresh publishes and caches last commit message changes", %{root: dir, repo: repo} do
-      Events.subscribe(:git_status_changed)
+    test "refresh publishes and caches last commit message changes", %{
+      root: dir,
+      repo: repo,
+      events_registry: events_registry
+    } do
+      Events.subscribe(:git_status_changed, events_registry)
       GitStub.set_last_commit_message(dir, "feat: updated subject")
 
       Repo.refresh(repo)
-      :sys.get_state(repo)
 
       assert_receive {:minga_event, :git_status_changed,
                       %Events.GitStatusEvent{
@@ -147,15 +185,18 @@ defmodule Minga.Git.RepoTest do
       assert Repo.summary(repo).last_commit_message == "feat: updated subject"
     end
 
-    test "refresh publishes and caches stash count changes", %{root: dir, repo: repo} do
-      Events.subscribe(:git_status_changed)
+    test "refresh publishes and caches stash count changes", %{
+      root: dir,
+      repo: repo,
+      events_registry: events_registry
+    } do
+      Events.subscribe(:git_status_changed, events_registry)
 
       GitStub.set_stashes(dir, [
         %StashEntry{index: 0, ref: "stash@{0}", date: "1 minute ago", message: "WIP"}
       ])
 
       Repo.refresh(repo)
-      :sys.get_state(repo)
 
       assert_receive {:minga_event, :git_status_changed,
                       %Events.GitStatusEvent{git_root: ^dir, stash_count: 1}}
@@ -163,8 +204,12 @@ defmodule Minga.Git.RepoTest do
       assert Repo.summary(repo).stash_count == 1
     end
 
-    test "stash ref file events refresh stash count", %{root: dir, repo: repo} do
-      Events.subscribe(:git_status_changed)
+    test "stash ref file events refresh stash count", %{
+      root: dir,
+      repo: repo,
+      events_registry: events_registry
+    } do
+      Events.subscribe(:git_status_changed, events_registry)
 
       GitStub.set_stashes(dir, [
         %StashEntry{index: 0, ref: "stash@{0}", date: "1 minute ago", message: "WIP"}
@@ -172,14 +217,17 @@ defmodule Minga.Git.RepoTest do
 
       send(repo, {:file_event, self(), {Path.join([dir, ".git", "refs", "stash"]), []}})
       send(repo, :debounce_refresh)
-      :sys.get_state(repo)
 
       assert_receive {:minga_event, :git_status_changed,
                       %Events.GitStatusEvent{git_root: ^dir, stash_count: 1}}
     end
 
-    test "stash log file events refresh stash count", %{root: dir, repo: repo} do
-      Events.subscribe(:git_status_changed)
+    test "stash log file events refresh stash count", %{
+      root: dir,
+      repo: repo,
+      events_registry: events_registry
+    } do
+      Events.subscribe(:git_status_changed, events_registry)
 
       GitStub.set_stashes(dir, [
         %StashEntry{index: 0, ref: "stash@{0}", date: "1 minute ago", message: "WIP"}
@@ -187,18 +235,20 @@ defmodule Minga.Git.RepoTest do
 
       send(repo, {:file_event, self(), {Path.join([dir, ".git", "logs", "refs", "stash"]), []}})
       send(repo, :debounce_refresh)
-      :sys.get_state(repo)
 
       assert_receive {:minga_event, :git_status_changed,
                       %Events.GitStatusEvent{git_root: ^dir, stash_count: 1}}
     end
 
-    test "refresh publishes git_status_changed when branch changes", %{root: dir, repo: repo} do
-      Events.subscribe(:git_status_changed)
+    test "refresh publishes git_status_changed when branch changes", %{
+      root: dir,
+      repo: repo,
+      events_registry: events_registry
+    } do
+      Events.subscribe(:git_status_changed, events_registry)
       GitStub.set_branch(dir, "feature/new")
 
       Repo.refresh(repo)
-      :sys.get_state(repo)
 
       assert_receive {:minga_event, :git_status_changed,
                       %Events.GitStatusEvent{git_root: ^dir, branch: "feature/new"}}
@@ -207,6 +257,7 @@ defmodule Minga.Git.RepoTest do
 
   describe "summary" do
     setup %{tmp_dir: dir} do
+      events_registry = start_events_registry()
       GitStub.set_root(dir, dir)
 
       GitStub.set_status(dir, [
@@ -219,8 +270,9 @@ defmodule Minga.Git.RepoTest do
 
       on_exit(fn -> GitStub.clear(dir) end)
 
-      repo = start_supervised!({Repo, git_root: dir}, id: {Repo, dir})
-      %{root: dir, repo: repo}
+      repo = start_repo(dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
+      %{root: dir, repo: repo, events_registry: events_registry}
     end
 
     test "aggregates counts by category", %{repo: repo} do
@@ -233,12 +285,13 @@ defmodule Minga.Git.RepoTest do
     end
 
     test "with zero entries returns all-zero counts", %{tmp_dir: dir} do
-      # Start a separate repo with empty status
-      empty_dir = dir <> "/empty"
+      events_registry = start_events_registry()
+      empty_dir = Path.join(dir, "empty")
       GitStub.set_root(empty_dir, empty_dir)
       on_exit(fn -> GitStub.clear(empty_dir) end)
 
-      repo = start_supervised!({Repo, git_root: empty_dir}, id: {Repo, empty_dir})
+      repo = start_repo(empty_dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
       summary = Repo.summary(repo)
 
       assert summary.staged_count == 0
@@ -251,7 +304,8 @@ defmodule Minga.Git.RepoTest do
     end
 
     test "conflict entries counted as conflicts regardless of staged flag", %{tmp_dir: dir} do
-      conflict_dir = dir <> "/conflict"
+      events_registry = start_events_registry()
+      conflict_dir = Path.join(dir, "conflict")
       GitStub.set_root(conflict_dir, conflict_dir)
 
       GitStub.set_status(conflict_dir, [
@@ -260,7 +314,8 @@ defmodule Minga.Git.RepoTest do
 
       on_exit(fn -> GitStub.clear(conflict_dir) end)
 
-      repo = start_supervised!({Repo, git_root: conflict_dir}, id: {Repo, conflict_dir})
+      repo = start_repo(conflict_dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
       summary = Repo.summary(repo)
 
       assert summary.conflict_count == 1
@@ -270,6 +325,7 @@ defmodule Minga.Git.RepoTest do
 
   describe "path relativization" do
     test "relativizes paths when project_root differs from git_root", %{tmp_dir: dir} do
+      events_registry = start_events_registry()
       git_root = dir
       project_root = Path.join(dir, "apps/myapp")
 
@@ -282,11 +338,8 @@ defmodule Minga.Git.RepoTest do
 
       on_exit(fn -> GitStub.clear(git_root) end)
 
-      repo =
-        start_supervised!(
-          {Repo, git_root: git_root, project_root: project_root},
-          id: {Repo, git_root}
-        )
+      repo = start_repo(git_root, project_root: project_root, events_registry: events_registry)
+      Repo.await_refresh(repo)
 
       entries = Repo.status(repo)
       assert length(entries) == 1
@@ -294,6 +347,7 @@ defmodule Minga.Git.RepoTest do
     end
 
     test "paths unchanged when project_root equals git_root", %{tmp_dir: dir} do
+      events_registry = start_events_registry()
       GitStub.set_root(dir, dir)
 
       GitStub.set_status(dir, [
@@ -302,16 +356,14 @@ defmodule Minga.Git.RepoTest do
 
       on_exit(fn -> GitStub.clear(dir) end)
 
-      repo =
-        start_supervised!(
-          {Repo, git_root: dir, project_root: dir},
-          id: {Repo, dir}
-        )
+      repo = start_repo(dir, project_root: dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
 
       assert [%StatusEntry{path: "lib/foo.ex"}] = Repo.status(repo)
     end
 
     test "paths unchanged when project_root is nil", %{tmp_dir: dir} do
+      events_registry = start_events_registry()
       GitStub.set_root(dir, dir)
 
       GitStub.set_status(dir, [
@@ -320,7 +372,8 @@ defmodule Minga.Git.RepoTest do
 
       on_exit(fn -> GitStub.clear(dir) end)
 
-      repo = start_supervised!({Repo, git_root: dir}, id: {Repo, dir})
+      repo = start_repo(dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
 
       assert [%StatusEntry{path: "lib/foo.ex"}] = Repo.status(repo)
     end
@@ -332,11 +385,66 @@ defmodule Minga.Git.RepoTest do
     end
 
     test "returns pid when repo exists", %{tmp_dir: dir} do
+      events_registry = start_events_registry()
       GitStub.set_root(dir, dir)
       on_exit(fn -> GitStub.clear(dir) end)
 
-      repo = start_supervised!({Repo, git_root: dir}, id: {Repo, dir})
+      repo = start_repo(dir, events_registry: events_registry)
       assert Repo.lookup(dir) == repo
     end
+
+    test "cached_status_for_path returns cached entries for containing tracked repo", %{
+      tmp_dir: dir
+    } do
+      events_registry = start_events_registry()
+      GitStub.set_root(dir, dir)
+      entry = %StatusEntry{path: "lib/foo.ex", status: :modified, staged: false}
+      GitStub.set_status(dir, [entry])
+      on_exit(fn -> GitStub.clear(dir) end)
+
+      _repo = start_repo(dir, events_registry: events_registry) |> tap(&Repo.await_refresh/1)
+
+      assert {:ok, %StatusSnapshot{git_root: ^dir, entry_base_path: ^dir, entries: [^entry]}} =
+               Repo.cached_status_for_path(Path.join(dir, "lib/foo.ex"))
+    end
+
+    test "cached_status_for_path returns the most specific tracked repo", %{tmp_dir: dir} do
+      events_registry = start_events_registry()
+      parent = Path.join(dir, "parent")
+      child = Path.join(parent, "apps/child")
+      File.mkdir_p!(child)
+
+      parent_entry = %StatusEntry{path: "root.ex", status: :modified, staged: false}
+      child_entry = %StatusEntry{path: "lib/child.ex", status: :added, staged: true}
+      GitStub.set_root(parent, parent)
+      GitStub.set_root(child, child)
+      GitStub.set_status(parent, [parent_entry])
+      GitStub.set_status(child, [child_entry])
+      on_exit(fn -> GitStub.clear(parent) end)
+      on_exit(fn -> GitStub.clear(child) end)
+
+      start_repo(parent, events_registry: events_registry) |> Repo.await_refresh()
+      start_repo(child, events_registry: events_registry) |> Repo.await_refresh()
+
+      assert {:ok, %StatusSnapshot{git_root: ^child, entries: [^child_entry]}} =
+               Repo.cached_status_for_path(Path.join(child, "lib/child.ex"))
+    end
+
+    test "cached_status_for_path does not start or query an untracked repo", %{tmp_dir: dir} do
+      assert Repo.cached_status_for_path(Path.join(dir, "missing.ex")) == :not_tracked
+    end
+  end
+
+  @spec start_events_registry() :: atom()
+  defp start_events_registry do
+    name = :"repo_events_#{System.unique_integer([:positive, :monotonic])}"
+    start_supervised!({Events, name: name}, id: {Events, name})
+    name
+  end
+
+  @spec start_repo(String.t(), keyword()) :: pid()
+  defp start_repo(git_root, opts) do
+    opts = Keyword.put(opts, :git_root, git_root)
+    start_supervised!({Repo, opts}, id: {Repo, git_root})
   end
 end

--- a/test/minga/project/file_tree/git_status_test.exs
+++ b/test/minga/project/file_tree/git_status_test.exs
@@ -2,80 +2,60 @@ defmodule Minga.Project.FileTree.GitStatusTest do
   use ExUnit.Case, async: true
 
   alias Minga.Git.StatusEntry
-  alias Minga.Git.Stub, as: GitStub
   alias Minga.Project.FileTree.GitStatus
 
   @moduletag :tmp_dir
 
-  setup %{tmp_dir: dir} do
-    GitStub.set_root(dir, dir)
-    on_exit(fn -> GitStub.clear(dir) end)
-    %{root: dir}
-  end
+  describe "from_entries/3" do
+    test "detects untracked files", %{tmp_dir: dir} do
+      entries = [%StatusEntry{path: "new_file.txt", status: :untracked, staged: false}]
 
-  describe "compute/1" do
-    test "returns empty map for non-git directory" do
-      assert GitStatus.compute("/tmp/not_a_repo_#{System.unique_integer()}") == %{}
-    end
-
-    test "detects untracked files", %{root: dir} do
-      GitStub.set_status(dir, [
-        %StatusEntry{path: "new_file.txt", status: :untracked, staged: false}
-      ])
-
-      status = GitStatus.compute(dir)
+      status = GitStatus.from_entries(entries, dir, dir)
       assert Map.get(status, Path.join(dir, "new_file.txt")) == :untracked
     end
 
-    test "detects staged files", %{root: dir} do
-      GitStub.set_status(dir, [
-        %StatusEntry{path: "staged.txt", status: :added, staged: true}
-      ])
+    test "detects staged files", %{tmp_dir: dir} do
+      entries = [%StatusEntry{path: "staged.txt", status: :added, staged: true}]
 
-      status = GitStatus.compute(dir)
+      status = GitStatus.from_entries(entries, dir, dir)
       assert Map.get(status, Path.join(dir, "staged.txt")) == :staged
     end
 
-    test "detects modified files", %{root: dir} do
-      GitStub.set_status(dir, [
-        %StatusEntry{path: "tracked.txt", status: :modified, staged: false}
-      ])
+    test "detects modified files", %{tmp_dir: dir} do
+      entries = [%StatusEntry{path: "tracked.txt", status: :modified, staged: false}]
 
-      status = GitStatus.compute(dir)
+      status = GitStatus.from_entries(entries, dir, dir)
       assert Map.get(status, Path.join(dir, "tracked.txt")) == :modified
     end
 
-    test "propagates status to parent directories", %{root: dir} do
-      GitStub.set_status(dir, [
-        %StatusEntry{path: "lib/app.ex", status: :untracked, staged: false}
-      ])
+    test "propagates status to parent directories", %{tmp_dir: dir} do
+      entries = [%StatusEntry{path: "lib/app.ex", status: :untracked, staged: false}]
 
-      status = GitStatus.compute(dir)
+      status = GitStatus.from_entries(entries, dir, dir)
       assert Map.get(status, Path.join(dir, "lib/app.ex")) == :untracked
       assert Map.get(status, Path.join(dir, "lib")) == :untracked
     end
 
-    test "directory shows worst child status", %{root: dir} do
-      GitStub.set_status(dir, [
+    test "directory shows worst child status", %{tmp_dir: dir} do
+      entries = [
         %StatusEntry{path: "src/tracked.ex", status: :modified, staged: false},
         %StatusEntry{path: "src/new.ex", status: :untracked, staged: false}
-      ])
+      ]
 
-      status = GitStatus.compute(dir)
+      status = GitStatus.from_entries(entries, dir, dir)
       assert Map.get(status, Path.join(dir, "src")) == :modified
     end
 
-    test "filters repo status to the requested root path", %{root: dir} do
+    test "filters repo status to the requested root path", %{tmp_dir: dir} do
       root_path = Path.join(dir, "app")
       File.mkdir_p!(root_path)
-      GitStub.set_root(root_path, dir)
 
-      GitStub.set_status(dir, [
+      entries = [
         %StatusEntry{path: "app/lib/inside.ex", status: :modified, staged: false},
         %StatusEntry{path: "application/lib/outside.ex", status: :conflict, staged: false}
-      ])
+      ]
 
-      status = GitStatus.compute(root_path)
+      status = GitStatus.from_entries(entries, dir, root_path)
 
       assert Map.get(status, Path.join([dir, "app", "lib"])) == :modified
       refute Map.has_key?(status, Path.join([dir, "application", "lib"]))

--- a/test/minga_editor/file_tree/freshness_test.exs
+++ b/test/minga_editor/file_tree/freshness_test.exs
@@ -1,0 +1,50 @@
+defmodule MingaEditor.FileTree.FreshnessTest do
+  @moduledoc "Tests for file tree freshness git-cache integration."
+  use ExUnit.Case, async: true
+
+  alias Minga.Events
+  alias Minga.Git.Repo
+  alias Minga.Git.StatusEntry
+  alias Minga.Git.Stub, as: GitStub
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.Freshness
+
+  @moduletag :tmp_dir
+
+  test "cache refresh starts a Git.Repo owner when no cache exists yet", %{tmp_dir: dir} do
+    events_registry = start_events_registry()
+    entry = %StatusEntry{path: "lib/foo.ex", status: :modified, staged: false}
+    GitStub.set_root(dir, dir)
+    GitStub.set_status(dir, [entry])
+
+    on_exit(fn ->
+      GitStub.clear(dir)
+      stop_repo(dir)
+    end)
+
+    tree = FileTree.new(dir)
+
+    assert %FileTree{} = Freshness.refresh_tree_git_status_from_cache(tree, events_registry)
+    assert repo = Repo.lookup(dir)
+
+    Repo.await_refresh(repo)
+    assert Repo.status(repo) == [entry]
+  end
+
+  @spec start_events_registry() :: atom()
+  defp start_events_registry do
+    name = :"file_tree_events_#{System.unique_integer([:positive, :monotonic])}"
+    start_supervised!({Events, name: name}, id: {Events, name})
+    name
+  end
+
+  @spec stop_repo(String.t()) :: :ok
+  defp stop_repo(git_root) do
+    case Repo.lookup(git_root) do
+      nil -> :ok
+      pid -> DynamicSupervisor.terminate_child(Minga.Git.Repo.Supervisor, pid)
+    end
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/test/support/git_stub.ex
+++ b/test/support/git_stub.ex
@@ -49,7 +49,16 @@ defmodule Minga.Git.Stub do
   @doc "Sets the status entries returned for `git_root`."
   @spec set_status(String.t(), [Minga.Git.status_entry()]) :: :ok
   def set_status(git_root, entries) when is_list(entries) do
-    :ets.insert(@table, {{:status, Path.expand(git_root)}, entries})
+    expanded = Path.expand(git_root)
+    :ets.delete(@table, {:status_error, expanded})
+    :ets.insert(@table, {{:status, expanded}, entries})
+    :ok
+  end
+
+  @doc "Forces `status/2` to return an error for `git_root`."
+  @spec set_status_error(String.t(), String.t()) :: :ok
+  def set_status_error(git_root, reason) when is_binary(reason) do
+    :ets.insert(@table, {{:status_error, Path.expand(git_root)}, reason})
     :ok
   end
 
@@ -141,6 +150,7 @@ defmodule Minga.Git.Stub do
     expanded = Path.expand(git_root)
     :ets.match_delete(@table, {{:root, expanded}, :_})
     :ets.match_delete(@table, {{:status, expanded}, :_})
+    :ets.match_delete(@table, {{:status_error, expanded}, :_})
     :ets.match_delete(@table, {{:head, expanded, :_}, :_})
     :ets.match_delete(@table, {{:staged, expanded, :_}, :_})
     :ets.match_delete(@table, {{:staged_paths, expanded}, :_})
@@ -189,11 +199,19 @@ defmodule Minga.Git.Stub do
   def blame_line(_git_root, _relative_path, _line_number), do: :error
 
   @impl true
-  @spec status(String.t()) :: {:ok, [Minga.Git.status_entry()]}
-  def status(git_root) do
-    case :ets.lookup(@table, {:status, Path.expand(git_root)}) do
-      [{_, entries}] -> {:ok, entries}
-      [] -> {:ok, []}
+  @spec status(String.t(), keyword()) :: {:ok, [Minga.Git.status_entry()]}
+  def status(git_root, _opts \\ []) do
+    expanded = Path.expand(git_root)
+
+    case :ets.lookup(@table, {:status_error, expanded}) do
+      [{_, reason}] ->
+        {:error, reason}
+
+      [] ->
+        case :ets.lookup(@table, {:status, expanded}) do
+          [{_, entries}] -> {:ok, entries}
+          [] -> {:ok, []}
+        end
     end
   end
 


### PR DESCRIPTION
# TL;DR
This makes Minga's Git status path safe for large and sparse repositories by moving repo refreshes off the UI path, making ambient UI consumers cache-only, and bounding Git shellouts. It also fixes a Go TUI transaction edge case where compatibility no-op commands could incorrectly invalidate frames.

## Context
Opening a file or refreshing visible chrome should not block on expensive repository-wide Git commands. This PR changes Git status ownership so the editor reads cached state during rendering and event handling, while `Minga.Git.Repo` refreshes in the background and publishes updates when fresh data arrives.

## Changes
- Make `Minga.Git.Repo` initialize without a synchronous refresh and run refreshes in monitored background workers.
- Add deterministic `Repo.await_refresh/1` synchronization for tests and callers that explicitly need to wait for pending Git work.
- Preserve cached Git data when a transient refresh field fails, so a timeout or command error does not wipe known-good UI state.
- Add `Minga.Git.Repo.Profile` to choose safer defaults for sparse repositories, including avoiding untracked enumeration by default there.
- Add `Git.status/2` options for untracked mode and timeout-aware shellouts.
- Make file-tree Git badges read from cached `Git.Repo` snapshots only, starting a repo owner on cache miss instead of shelling out.
- Replace the cross-module Git status snapshot map with `Minga.Git.Repo.StatusSnapshot`.
- Update git porcelain staged-delete checks to use the cheaper status mode.
- Ignore out-of-band Go TUI `noop` commands and keep sanctioned side-channel commands from forcing keyframes.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.debug test/minga/git/repo_test.exs test/minga/git/repo/profile_test.exs test/minga/project/file_tree/git_status_test.exs test/minga_editor/file_tree/freshness_test.exs` → 38 passed
- `make lint` → passed with existing struct-size Credo warnings only
- `mix test.llm` → PASS: 56 doctests, 94 properties, 9313 tests, 0 failures, 327 excluded
- `cd go/tui && go test ./...` → 394 passed in 7 packages
- `git diff --check` and `git diff --cached --check` → clean

## Review notes
- Ambient UI code should stay cache-only. Expensive Git status modes should remain behind explicit Git actions, not rendering, file-tree refresh, picker refresh, or modeline updates.
- The async Git tests use private event registries and `Repo.await_refresh/1`; they do not rely on sleeps or the global event bus.
