### PR TITLE
perf(picker): bounded top-K scoring over lean candidates

### DIFF
--- a/lib/minga_editor/render_model/ui/picker_builder.ex
+++ b/lib/minga_editor/render_model/ui/picker_builder.ex
@@ -44,7 +44,13 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
           PickerModel.t()
   defp build_open(ctx, picker, source, action_menu, mode_prefix, load_status) do
     has_preview = source != nil and Picker.Source.gui_preview?(source)
-    items = picker.filtered |> Enum.take(@max_items) |> Enum.map(&item_model(picker, &1))
+
+    items =
+      picker.filtered
+      |> Enum.take(@max_items)
+      |> enrich_for_display(source, picker.query)
+      |> Enum.map(&item_model(picker, &1))
+
     preview_lines = if has_preview, do: build_picker_preview(ctx)
 
     %PickerModel{
@@ -62,6 +68,22 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
       load_status: load_status,
       preview_lines: preview_lines
     }
+  end
+
+  # Builds the deferred display fields (icon, color, two-line description, status
+  # annotation) for just the visible window, then recomputes match positions
+  # against the enriched label. Sources that already return fully-built items
+  # (no `enrich/1`) pass through unchanged. This keeps display derivation in the
+  # render model (ruling 4) while filtering stays bounded and lean.
+  @spec enrich_for_display([Picker.Item.t()], module() | nil, String.t()) :: [Picker.Item.t()]
+  defp enrich_for_display(items, source, query) do
+    if source != nil and Picker.Source.enriches?(source) do
+      source
+      |> Picker.Source.enrich(items)
+      |> Enum.map(&%{&1 | match_positions: Picker.match_positions(&1.label, query)})
+    else
+      items
+    end
   end
 
   # Normalize one picker source item into the wire-shaped map the generated

--- a/lib/minga_editor/ui/picker.ex
+++ b/lib/minga_editor/ui/picker.ex
@@ -318,7 +318,12 @@ defmodule MingaEditor.UI.Picker do
     case split_query(query) do
       [] ->
         filtered = bounded_unscored(picker.items, result_limit(picker))
-        %{picker | filtered: filtered, selected: clamp_selection(picker.selected, length(filtered))}
+
+        %{
+          picker
+          | filtered: filtered,
+            selected: clamp_selection(picker.selected, length(filtered))
+        }
 
       segments ->
         filtered =
@@ -326,7 +331,11 @@ defmodule MingaEditor.UI.Picker do
           |> Scorer.top_k(segments, result_limit(picker))
           |> Enum.map(&highlight_winner(&1, query))
 
-        %{picker | filtered: filtered, selected: clamp_selection(picker.selected, length(filtered))}
+        %{
+          picker
+          | filtered: filtered,
+            selected: clamp_selection(picker.selected, length(filtered))
+        }
     end
   end
 

--- a/lib/minga_editor/ui/picker.ex
+++ b/lib/minga_editor/ui/picker.ex
@@ -36,6 +36,7 @@ defmodule MingaEditor.UI.Picker do
 
   @enforce_keys [:items, :title]
   defstruct items: [],
+            candidates: [],
             query: "",
             selected: 0,
             filtered: [],
@@ -43,7 +44,16 @@ defmodule MingaEditor.UI.Picker do
             title: "",
             marked: %{}
 
+  alias MingaEditor.UI.Picker.Candidate
   alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.Scorer
+
+  # Upper bound on how many results filtering retains. Sources with fewer items
+  # are unaffected (the full set fits); large sources (e.g. the file picker with
+  # tens of thousands of paths) are bounded to the best matches so each keystroke
+  # never scores-and-sorts the entire candidate list. Generous so paging past the
+  # visible window still has somewhere to land.
+  @result_limit 200
 
   @typedoc "A picker item struct."
   @type item :: Item.t()
@@ -51,6 +61,7 @@ defmodule MingaEditor.UI.Picker do
   @typedoc "Picker state. The `marked` map uses item ids as keys (values are `true`)."
   @type t :: %__MODULE__{
           items: [Item.t()],
+          candidates: [Candidate.t()],
           query: String.t(),
           selected: non_neg_integer(),
           filtered: [Item.t()],
@@ -69,20 +80,21 @@ defmodule MingaEditor.UI.Picker do
     title = Keyword.get(opts, :title, "")
     max_visible = Keyword.get(opts, :max_visible, 10)
 
-    %__MODULE__{
+    refilter(%__MODULE__{
       items: items,
+      candidates: Candidate.from_items(items),
       title: title,
       max_visible: max_visible,
       filtered: items,
       query: "",
       selected: 0
-    }
+    })
   end
 
   @doc "Replaces the item list and refilters against the current query."
   @spec replace_items(t(), [item()]) :: t()
   def replace_items(%__MODULE__{} = picker, items) when is_list(items) do
-    refilter(%{picker | items: items})
+    refilter(%{picker | items: items, candidates: Candidate.from_items(items)})
   end
 
   # ── Query manipulation ──────────────────────────────────────────────────────
@@ -294,42 +306,48 @@ defmodule MingaEditor.UI.Picker do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
+  # Empty query: no scoring, just present the leading slice of the (already
+  # source-ordered) items, bounded so huge sources don't materialize every item.
   @spec refilter(t()) :: t()
   defp refilter(%__MODULE__{items: items, query: ""} = picker) do
-    # Clear any stale match positions when query is empty
-    cleared = Enum.map(items, &%{&1 | match_positions: []})
-    %{picker | filtered: cleared, selected: clamp_selection(picker.selected, length(items))}
+    filtered = bounded_unscored(items, result_limit(picker))
+    %{picker | filtered: filtered, selected: clamp_selection(picker.selected, length(filtered))}
   end
 
-  defp refilter(%__MODULE__{items: items, query: query} = picker) do
-    segments = split_query(query)
-
-    case segments do
+  defp refilter(%__MODULE__{candidates: candidates, query: query} = picker) do
+    case split_query(query) do
       [] ->
-        cleared = Enum.map(items, &%{&1 | match_positions: []})
-        %{picker | filtered: cleared, selected: clamp_selection(picker.selected, length(items))}
+        filtered = bounded_unscored(picker.items, result_limit(picker))
+        %{picker | filtered: filtered, selected: clamp_selection(picker.selected, length(filtered))}
 
-      _ ->
-        scored = score_and_highlight(items, segments, query)
-        %{picker | filtered: scored, selected: clamp_selection(picker.selected, length(scored))}
+      segments ->
+        filtered =
+          candidates
+          |> Scorer.top_k(segments, result_limit(picker))
+          |> Enum.map(&highlight_winner(&1, query))
+
+        %{picker | filtered: filtered, selected: clamp_selection(picker.selected, length(filtered))}
     end
   end
 
-  @spec score_and_highlight([Item.t()], [String.t()], String.t()) :: [Item.t()]
-  defp score_and_highlight(items, segments, query) do
-    items
-    |> Enum.map(&score_item_with_positions(&1, segments, query))
-    |> Enum.filter(fn {_item, score} -> score > 0 end)
-    |> Enum.sort_by(fn {_item, score} -> -score end)
-    |> Enum.map(fn {item, _score} -> item end)
+  # Build a displayable item from a winning candidate, attaching match positions.
+  # Positions are computed only here, for the bounded winners, never for the
+  # whole candidate set.
+  @spec highlight_winner(Candidate.t(), String.t()) :: Item.t()
+  defp highlight_winner(%Candidate{item: %Item{label: label} = item}, query) do
+    %{item | match_positions: match_positions(label, query)}
   end
 
-  @spec score_item_with_positions(Item.t(), [String.t()], String.t()) ::
-          {Item.t(), non_neg_integer()}
-  defp score_item_with_positions(%Item{label: label} = item, segments, query) do
-    score = score_item(item, segments)
-    positions = if score > 0, do: match_positions(label, query), else: []
-    {%{item | match_positions: positions}, score}
+  @spec bounded_unscored([Item.t()], pos_integer()) :: [Item.t()]
+  defp bounded_unscored(items, limit) do
+    items
+    |> Enum.take(limit)
+    |> Enum.map(&%{&1 | match_positions: []})
+  end
+
+  @spec result_limit(t()) :: pos_integer()
+  defp result_limit(%__MODULE__{max_visible: max_visible}) do
+    max(@result_limit, max_visible)
   end
 
   # Split query into lowercase segments on whitespace, dropping empty segments.
@@ -338,92 +356,6 @@ defmodule MingaEditor.UI.Picker do
     query
     |> String.downcase()
     |> String.split(~r/\s+/, trim: true)
-  end
-
-  @spec score_item(Item.t(), [String.t()]) :: non_neg_integer()
-  defp score_item(%Item{label: label} = item, segments) do
-    scoring_label = label |> String.downcase() |> strip_icon_prefix()
-    searchable = searchable_text(item)
-
-    segment_scores =
-      Enum.map(segments, fn seg ->
-        label_score = score_segment(scoring_label, seg)
-        search_score = score_segment(searchable, seg)
-
-        if label_score > 0 do
-          label_score + 200
-        else
-          search_score
-        end
-      end)
-
-    if Enum.any?(segment_scores, &(&1 == 0)) do
-      0
-    else
-      base = Enum.sum(segment_scores)
-      length_bonus = max(0, 50 - String.length(scoring_label))
-      base + length_bonus
-    end
-  end
-
-  @spec searchable_text(Item.t()) :: String.t()
-  defp searchable_text(%Item{} = item) do
-    [item.description, item.annotation, item.search_text]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.join(" ")
-    |> String.downcase()
-  end
-
-  @spec strip_icon_prefix(String.t()) :: String.t()
-  defp strip_icon_prefix(label) do
-    case String.next_grapheme(label) do
-      {g, " " <> rest} when byte_size(g) > 1 -> rest
-      _ -> label
-    end
-  end
-
-  @spec score_segment(String.t(), String.t()) :: non_neg_integer()
-  defp score_segment(text, segment) do
-    case String.starts_with?(text, segment) do
-      true -> 300
-      false -> score_non_prefix_segment(text, segment)
-    end
-  end
-
-  @spec score_non_prefix_segment(String.t(), String.t()) :: non_neg_integer()
-  defp score_non_prefix_segment(text, segment) do
-    case String.contains?(text, segment) do
-      true -> 200
-      false -> score_fuzzy_segment(text, segment)
-    end
-  end
-
-  @spec score_fuzzy_segment(String.t(), String.t()) :: non_neg_integer()
-  defp score_fuzzy_segment(text, segment) do
-    case fuzzy_match?(text, segment) do
-      true -> 100
-      false -> 0
-    end
-  end
-
-  # Check if all characters in `needle` appear in order in `haystack`.
-  @spec fuzzy_match?(String.t(), String.t()) :: boolean()
-  defp fuzzy_match?(haystack, needle) do
-    haystack_graphemes = String.graphemes(haystack)
-    needle_graphemes = String.graphemes(needle)
-    do_fuzzy_match?(haystack_graphemes, needle_graphemes)
-  end
-
-  @spec do_fuzzy_match?([String.t()], [String.t()]) :: boolean()
-  defp do_fuzzy_match?(_haystack, []), do: true
-  defp do_fuzzy_match?([], _needle), do: false
-
-  defp do_fuzzy_match?([h | h_rest], [n | n_rest] = needle) do
-    if h == n do
-      do_fuzzy_match?(h_rest, n_rest)
-    else
-      do_fuzzy_match?(h_rest, needle)
-    end
   end
 
   # Find the 0-based indices of matched characters for a single segment.

--- a/lib/minga_editor/ui/picker.ex
+++ b/lib/minga_editor/ui/picker.ex
@@ -53,6 +53,10 @@ defmodule MingaEditor.UI.Picker do
   # tens of thousands of paths) are bounded to the best matches so each keystroke
   # never scores-and-sorts the entire candidate list. Generous so paging past the
   # visible window still has somewhere to land.
+  #
+  # Consequence: `count/1` (and the picker footer's filtered count) reports how
+  # many results are *shown*, capped here, not the true number of matches in a
+  # huge source. `total/1` still reflects the full candidate count.
   @result_limit 200
 
   @typedoc "A picker item struct."

--- a/lib/minga_editor/ui/picker/candidate.ex
+++ b/lib/minga_editor/ui/picker/candidate.ex
@@ -1,0 +1,74 @@
+defmodule MingaEditor.UI.Picker.Candidate do
+  @moduledoc """
+  Lean, pre-normalized scoring representation of a picker `%Item{}`.
+
+  The picker's filtering hot path used to re-downcase the label, strip the icon
+  prefix, and rebuild the searchable text for every candidate on every keystroke.
+  A `Candidate` precomputes those fields once when the item list is set, so
+  scoring a large set only does the match work, not the normalization work.
+
+  A candidate carries a reference to its source `item` (for late display
+  enrichment) and a stable `index` reflecting the source's original ordering,
+  which `Scorer` uses to break score ties exactly as the previous brute-force
+  sort did.
+
+  Match positions and per-render display state deliberately do not live here;
+  they are derived for the bounded winners only.
+  """
+
+  alias MingaEditor.UI.Picker.Item
+
+  @enforce_keys [:item, :norm_label, :norm_search, :label_length, :index]
+  defstruct [:item, :norm_label, :norm_search, :label_length, :index]
+
+  @type t :: %__MODULE__{
+          item: Item.t(),
+          norm_label: String.t(),
+          norm_search: String.t(),
+          label_length: non_neg_integer(),
+          index: non_neg_integer()
+        }
+
+  @doc """
+  Builds the candidate cache for a list of items, preserving order and tagging
+  each candidate with its original index.
+  """
+  @spec from_items([Item.t()]) :: [t()]
+  def from_items(items) when is_list(items) do
+    items
+    |> Enum.with_index()
+    |> Enum.map(fn {item, index} -> from_item(item, index) end)
+  end
+
+  @doc "Builds a single candidate from an item and its index."
+  @spec from_item(Item.t(), non_neg_integer()) :: t()
+  def from_item(%Item{} = item, index) do
+    norm_label = item.label |> String.downcase() |> strip_icon_prefix()
+
+    %__MODULE__{
+      item: item,
+      norm_label: norm_label,
+      norm_search: searchable_text(item),
+      label_length: String.length(norm_label),
+      index: index
+    }
+  end
+
+  # The label's first grapheme is a multi-byte icon glyph for file/buffer
+  # pickers; drop it (and its trailing space) so matching scores the real text.
+  @spec strip_icon_prefix(String.t()) :: String.t()
+  defp strip_icon_prefix(label) do
+    case String.next_grapheme(label) do
+      {g, " " <> rest} when byte_size(g) > 1 -> rest
+      _ -> label
+    end
+  end
+
+  @spec searchable_text(Item.t()) :: String.t()
+  defp searchable_text(%Item{} = item) do
+    [item.description, item.annotation, item.search_text]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" ")
+    |> String.downcase()
+  end
+end

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -41,7 +41,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
         score_map = build_score_map(frecency_map, git_status_map)
 
         paths
-        |> Enum.map(&format_file_candidate(&1, git_status_map))
+        |> Enum.map(&lean_candidate(&1, git_status_map))
         |> sort_by_score(score_map)
 
       {:error, msg} ->
@@ -49,23 +49,40 @@ defmodule MingaEditor.UI.Picker.FileSource do
     end
   end
 
-  @spec format_file_candidate(String.t(), %{String.t() => atom()}) :: Item.t()
-  defp format_file_candidate(path, git_status_map) do
+  # Lean candidate: just enough to match (filename label, full-path search text)
+  # and to enrich later (git status stashed in `meta`). Icon, color, two-line
+  # description, and the status annotation are built in `enrich/1` for the
+  # bounded winners only, so a 50k-file repo never materializes 50k rich items.
+  @spec lean_candidate(String.t(), %{String.t() => atom()}) :: Item.t()
+  defp lean_candidate(path, git_status_map) do
+    %Item{
+      id: path,
+      label: Path.basename(path),
+      search_text: path,
+      meta: %{git: Map.get(git_status_map, path)}
+    }
+  end
+
+  @impl true
+  @spec enrich([Item.t()]) :: [Item.t()]
+  def enrich(items), do: Enum.map(items, &enrich_item/1)
+
+  @spec enrich_item(Item.t()) :: Item.t()
+  defp enrich_item(%Item{id: path, meta: meta} = item) do
     filename = Path.basename(path)
     dir = Path.dirname(path)
     ft = Language.detect_filetype(filename)
     {icon, color} = Devicon.icon_and_color(ft)
     dir_display = if dir == ".", do: "", else: dir
+    annotation = git_status_annotation(Map.get(meta, :git))
 
-    annotation = git_status_annotation(Map.get(git_status_map, path))
-
-    %Item{
-      id: path,
-      label: "#{icon} #{filename}",
-      description: dir_display,
-      icon_color: color,
-      annotation: annotation,
-      two_line: true
+    %{
+      item
+      | label: "#{icon} #{filename}",
+        description: dir_display,
+        icon_color: color,
+        annotation: annotation,
+        two_line: true
     }
   end
 

--- a/lib/minga_editor/ui/picker/item.ex
+++ b/lib/minga_editor/ui/picker/item.ex
@@ -26,6 +26,10 @@ defmodule MingaEditor.UI.Picker.Item do
   - `:active` — when true, marks this item as the currently active selection
     (e.g. the current thinking level). The centered picker renderer draws a
     `●` indicator for active items and blank padding for inactive siblings.
+  - `:meta` — opaque source-private map carried alongside the item. Used by
+    sources that defer display enrichment (e.g. `FileSource` stashes the git
+    status here so the bounded winners can be enriched without re-reading state).
+    Never rendered directly.
   """
 
   @enforce_keys [:id, :label]
@@ -38,7 +42,8 @@ defmodule MingaEditor.UI.Picker.Item do
     search_text: "",
     match_positions: [],
     two_line: false,
-    active: false
+    active: false,
+    meta: %{}
   ]
 
   @type t :: %__MODULE__{
@@ -50,6 +55,7 @@ defmodule MingaEditor.UI.Picker.Item do
           search_text: String.t(),
           match_positions: [non_neg_integer()],
           two_line: boolean(),
-          active: boolean()
+          active: boolean(),
+          meta: map()
         }
 end

--- a/lib/minga_editor/ui/picker/scorer.ex
+++ b/lib/minga_editor/ui/picker/scorer.ex
@@ -71,8 +71,12 @@ defmodule MingaEditor.UI.Picker.Scorer do
 
   # Maintain `kept` as a list sorted worst-first so the weakest entry is the head
   # and cheap to evict once the window exceeds `k`.
-  @spec bounded_insert([{non_neg_integer(), Candidate.t()}], non_neg_integer(),
-          {non_neg_integer(), Candidate.t()}, pos_integer()) ::
+  @spec bounded_insert(
+          [{non_neg_integer(), Candidate.t()}],
+          non_neg_integer(),
+          {non_neg_integer(), Candidate.t()},
+          pos_integer()
+        ) ::
           {non_neg_integer(), [{non_neg_integer(), Candidate.t()}]}
   defp bounded_insert(kept, count, entry, k) do
     kept = insert_sorted(kept, entry)

--- a/lib/minga_editor/ui/picker/scorer.ex
+++ b/lib/minga_editor/ui/picker/scorer.ex
@@ -1,0 +1,148 @@
+defmodule MingaEditor.UI.Picker.Scorer do
+  @moduledoc """
+  Bounded top-K scoring over precomputed picker candidates.
+
+  Scores each candidate against the query segments using its precomputed,
+  pre-lowered label/search fields and keeps only the best `k` results without
+  sorting the full match set. This is what keeps the picker responsive when a
+  source has tens of thousands of candidates: instead of scoring, fully sorting,
+  and computing match positions for every candidate on each keystroke, we score
+  once and retain a small bounded window.
+
+  Ordering reproduces the previous brute-force order exactly: higher score
+  first, ties broken by the candidate's original `index` (stable). So for
+  `k >= match_count` the result is identical to filtering and fully sorting.
+  """
+
+  alias MingaEditor.UI.Picker.Candidate
+
+  @label_match_bonus 200
+  @prefix_score 300
+  @substring_score 200
+  @fuzzy_score 100
+  @max_length_bonus 50
+
+  @doc """
+  Returns the best `k` candidates for the given lowercase query `segments`,
+  ordered best-first. Candidates that do not match every segment are dropped.
+
+  Selection is bounded: a running window of at most `k` entries is maintained
+  while scanning, so the full match list is never sorted.
+  """
+  @spec top_k([Candidate.t()], [String.t()], pos_integer()) :: [Candidate.t()]
+  def top_k(candidates, segments, k) when is_list(candidates) and is_list(segments) and k > 0 do
+    candidates
+    |> Enum.reduce({0, []}, fn candidate, {count, kept} ->
+      case score_candidate(candidate, segments) do
+        score when score > 0 -> bounded_insert(kept, count, {score, candidate}, k)
+        _zero -> {count, kept}
+      end
+    end)
+    |> elem(1)
+    |> Enum.reverse()
+    |> Enum.map(fn {_score, candidate} -> candidate end)
+  end
+
+  @doc """
+  Scores a single candidate against the query segments. Returns `0` when any
+  segment fails to match. Mirrors the picker's historical scoring: a label
+  match outranks a search-field-only match, prefix beats substring beats fuzzy,
+  and shorter labels get a small bonus.
+  """
+  @spec score_candidate(Candidate.t(), [String.t()]) :: non_neg_integer()
+  def score_candidate(%Candidate{} = candidate, segments) do
+    segment_scores =
+      Enum.map(segments, fn segment ->
+        label_score = score_segment(candidate.norm_label, segment)
+
+        if label_score > 0 do
+          label_score + @label_match_bonus
+        else
+          score_segment(candidate.norm_search, segment)
+        end
+      end)
+
+    if Enum.any?(segment_scores, &(&1 == 0)) do
+      0
+    else
+      Enum.sum(segment_scores) + max(0, @max_length_bonus - candidate.label_length)
+    end
+  end
+
+  # Maintain `kept` as a list sorted worst-first so the weakest entry is the head
+  # and cheap to evict once the window exceeds `k`.
+  @spec bounded_insert([{non_neg_integer(), Candidate.t()}], non_neg_integer(),
+          {non_neg_integer(), Candidate.t()}, pos_integer()) ::
+          {non_neg_integer(), [{non_neg_integer(), Candidate.t()}]}
+  defp bounded_insert(kept, count, entry, k) do
+    kept = insert_sorted(kept, entry)
+
+    if count + 1 > k do
+      [_evicted | rest] = kept
+      {k, rest}
+    else
+      {count + 1, kept}
+    end
+  end
+
+  @spec insert_sorted([{non_neg_integer(), Candidate.t()}], {non_neg_integer(), Candidate.t()}) ::
+          [{non_neg_integer(), Candidate.t()}]
+  defp insert_sorted([], entry), do: [entry]
+
+  defp insert_sorted([head | tail] = list, entry) do
+    if better?(entry, head) do
+      [head | insert_sorted(tail, entry)]
+    else
+      [entry | list]
+    end
+  end
+
+  # Higher score wins; ties broken by lower original index (stable order).
+  @spec better?({non_neg_integer(), Candidate.t()}, {non_neg_integer(), Candidate.t()}) ::
+          boolean()
+  defp better?({score_a, cand_a}, {score_b, cand_b}) do
+    score_a > score_b or (score_a == score_b and cand_a.index < cand_b.index)
+  end
+
+  @spec score_segment(String.t(), String.t()) :: non_neg_integer()
+  defp score_segment(text, segment) do
+    case String.starts_with?(text, segment) do
+      true -> @prefix_score
+      false -> score_non_prefix_segment(text, segment)
+    end
+  end
+
+  @spec score_non_prefix_segment(String.t(), String.t()) :: non_neg_integer()
+  defp score_non_prefix_segment(text, segment) do
+    case String.contains?(text, segment) do
+      true -> @substring_score
+      false -> score_fuzzy_segment(text, segment)
+    end
+  end
+
+  @spec score_fuzzy_segment(String.t(), String.t()) :: non_neg_integer()
+  defp score_fuzzy_segment(text, segment) do
+    case fuzzy_match?(text, segment) do
+      true -> @fuzzy_score
+      false -> 0
+    end
+  end
+
+  # Check if all characters in `needle` appear in order in `haystack`.
+  @spec fuzzy_match?(String.t(), String.t()) :: boolean()
+  defp fuzzy_match?(haystack, needle) do
+    do_fuzzy_match?(String.graphemes(haystack), String.graphemes(needle))
+  end
+
+  @spec do_fuzzy_match?([String.t()], [String.t()]) :: boolean()
+  defp do_fuzzy_match?(_haystack, []), do: true
+  defp do_fuzzy_match?([], _needle), do: false
+
+  defp do_fuzzy_match?([h | h_rest], [n | n_rest] = needle) do
+    if h == n do
+      do_fuzzy_match?(h_rest, n_rest)
+    else
+      do_fuzzy_match?(h_rest, needle)
+    end
+  end
+end

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -27,7 +27,8 @@ defmodule MingaEditor.UI.Picker.Source do
         def title, do: "My picker"
 
         @impl true
-        def candidates(_context), do: [{:a, "item a", "description"}]
+        def candidates(_context),
+          do: [%MingaEditor.UI.Picker.Item{id: :a, label: "item a", description: "description"}]
 
         @impl true
         def on_select(item, state), do: state
@@ -138,6 +139,21 @@ defmodule MingaEditor.UI.Picker.Source do
   """
   @callback async?() :: boolean()
 
+  @doc """
+  Enriches a bounded list of items for display.
+
+  Filtering keeps only the top results, so a source with expensive per-item
+  display work (icons, colors, two-line descriptions, status annotations) can
+  return lean items from `candidates/1` and defer that work to this callback,
+  which runs only on the small set actually shown. The default is identity, so
+  sources that already return fully-built items need not implement it.
+
+  Enrichment must be a pure function of the items themselves (any state a source
+  needs should be stashed in `Item.meta` at `candidates/1` time), because it runs
+  on every render of the visible window.
+  """
+  @callback enrich([Picker.item()]) :: [Picker.item()]
+
   @optional_callbacks [
     preview?: 0,
     live_preview?: 0,
@@ -150,7 +166,8 @@ defmodule MingaEditor.UI.Picker.Source do
     on_bulk_action: 3,
     layout: 0,
     keep_open_on_select?: 0,
-    async?: 0
+    async?: 0,
+    enrich: 1
   ]
 
   @doc """
@@ -307,6 +324,23 @@ defmodule MingaEditor.UI.Picker.Source do
       module.async?()
     else
       false
+    end
+  end
+
+  @doc "Returns whether a source defers display enrichment to `enrich/1`."
+  @spec enriches?(module()) :: boolean()
+  def enriches?(module), do: exported?(module, :enrich, 1)
+
+  @doc """
+  Enriches the bounded display items for a source, returning them unchanged
+  when the source does not implement `enrich/1`.
+  """
+  @spec enrich(module(), [Picker.item()]) :: [Picker.item()]
+  def enrich(module, items) do
+    if enriches?(module) do
+      module.enrich(items)
+    else
+      items
     end
   end
 

--- a/test/minga_editor/input/interrupt_test.exs
+++ b/test/minga_editor/input/interrupt_test.exs
@@ -46,7 +46,7 @@ defmodule MingaEditor.Input.InterruptTest do
 
   @spec open_modal_variant(EditorState.t(), ModalOverlay.variant()) :: EditorState.t()
   defp open_modal_variant(state, :picker) do
-    picker = MingaEditor.UI.Picker.new(["x"])
+    picker = MingaEditor.UI.Picker.new([%MingaEditor.UI.Picker.Item{id: "x", label: "x"}])
     ModalOverlay.open(state, :picker, PickerPayload.new(%Picker{picker: picker}))
   end
 
@@ -240,7 +240,12 @@ defmodule MingaEditor.Input.InterruptTest do
   describe "overlay dismissal" do
     test "closes open picker" do
       state = base_state()
-      picker = MingaEditor.UI.Picker.new(["a", "b", "c"])
+      picker =
+        MingaEditor.UI.Picker.new([
+          %MingaEditor.UI.Picker.Item{id: "a", label: "a"},
+          %MingaEditor.UI.Picker.Item{id: "b", label: "b"},
+          %MingaEditor.UI.Picker.Item{id: "c", label: "c"}
+        ])
 
       state =
         ModalOverlay.open(state, :picker, PickerPayload.new(%Picker{picker: picker, source: nil}))

--- a/test/minga_editor/input/interrupt_test.exs
+++ b/test/minga_editor/input/interrupt_test.exs
@@ -240,6 +240,7 @@ defmodule MingaEditor.Input.InterruptTest do
   describe "overlay dismissal" do
     test "closes open picker" do
       state = base_state()
+
       picker =
         MingaEditor.UI.Picker.new([
           %MingaEditor.UI.Picker.Item{id: "a", label: "a"},

--- a/test/minga_editor/input/picker_mouse_test.exs
+++ b/test/minga_editor/input/picker_mouse_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
   alias MingaEditor.VimState
   alias MingaEditor.Input.Picker, as: PickerInput
   alias MingaEditor.UI.Picker, as: PickerData
+  alias MingaEditor.UI.Picker.Item
 
   defmodule TestSource do
     @moduledoc false
@@ -47,14 +48,14 @@ defmodule MingaEditor.Input.PickerMouseTest do
 
   describe "scroll wheel" do
     test "wheel_down moves picker selection down" do
-      state = picker_state([%{id: 1, label: "one"}, %{id: 2, label: "two"}])
+      state = picker_state([%Item{id: 1, label: "one"}, %Item{id: 2, label: "two"}])
       {:handled, new_state} = PickerInput.handle_mouse(state, 10, 10, :wheel_down, 0, :press, 1)
       {:picker, %{picker_ui: %{picker: pui}}} = new_state.shell_state.modal
       assert pui.selected == 1
     end
 
     test "wheel_up moves picker selection up" do
-      state = picker_state([%{id: 1, label: "one"}, %{id: 2, label: "two"}])
+      state = picker_state([%Item{id: 1, label: "one"}, %Item{id: 2, label: "two"}])
       # Move down first, then up
       {:handled, state} = PickerInput.handle_mouse(state, 10, 10, :wheel_down, 0, :press, 1)
       {:handled, new_state} = PickerInput.handle_mouse(state, 10, 10, :wheel_up, 0, :press, 1)
@@ -65,7 +66,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
 
   describe "click to select" do
     test "clicking a candidate selects and confirms it" do
-      items = [%{id: 1, label: "alpha"}, %{id: 2, label: "beta"}, %{id: 3, label: "gamma"}]
+      items = [%Item{id: 1, label: "alpha"}, %Item{id: 2, label: "beta"}, %Item{id: 3, label: "gamma"}]
       state = picker_state(items)
 
       # Items render upward from prompt_row (29). With 3 items:
@@ -79,7 +80,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
     end
 
     test "clicking the only bottom candidate selects and confirms it" do
-      state = picker_state([%{id: 1, label: "only"}])
+      state = picker_state([%Item{id: 1, label: "only"}])
 
       {:handled, new_state} = PickerInput.handle_mouse(state, 28, 10, :left, 0, :press, 1)
 
@@ -88,7 +89,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
     end
 
     test "clicking the last rendered bottom candidate selects it when the list is viewport-capped" do
-      items = for n <- 1..40, do: %{id: n, label: "item-#{n}"}
+      items = for n <- 1..40, do: %Item{id: n, label: "item-#{n}"}
       state = picker_state(items, 40)
 
       # 30 rows leave 27 item rows, plus separator and prompt. The last rendered item is item 27.
@@ -99,7 +100,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
     end
 
     test "clicking the bottom picker separator does not select from the end of the list" do
-      items = for n <- 1..40, do: %{id: n, label: "item-#{n}"}
+      items = for n <- 1..40, do: %Item{id: n, label: "item-#{n}"}
       state = picker_state(items, 40)
 
       {:handled, new_state} = PickerInput.handle_mouse(state, 1, 10, :left, 0, :press, 1)
@@ -109,7 +110,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
     end
 
     test "clicking outside items area is handled but does nothing" do
-      items = [%{id: 1, label: "one"}]
+      items = [%Item{id: 1, label: "one"}]
       state = picker_state(items)
 
       # Click on row 0 (well above the picker)
@@ -143,7 +144,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
     end
 
     test "clicking an item inside the centered float selects it" do
-      items = [%{id: 1, label: "alpha"}, %{id: 2, label: "beta"}]
+      items = [%Item{id: 1, label: "alpha"}, %Item{id: 2, label: "beta"}]
       state = centered_picker_state(items)
 
       # Two visible items + prompt + border = 5 rows, centered: box starts at row 9.
@@ -156,7 +157,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
     end
 
     test "clicking the prompt row in a tall centered picker ignores hidden items" do
-      items = for n <- 1..20, do: %{id: n, label: "item-#{n}"}
+      items = for n <- 1..20, do: %Item{id: n, label: "item-#{n}"}
       state = centered_picker_state(items, 20)
 
       max_height = max(div(24 * 7, 10), 5)
@@ -172,7 +173,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
     end
 
     test "clicking the last rendered row in a tall centered picker selects the selected-visible slice" do
-      items = for n <- 1..20, do: %{id: n, label: "item-#{n}"}
+      items = for n <- 1..20, do: %Item{id: n, label: "item-#{n}"}
 
       state =
         items
@@ -197,7 +198,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
     end
 
     test "clicking outside the centered float dismisses the picker" do
-      items = [%{id: 1, label: "alpha"}]
+      items = [%Item{id: 1, label: "alpha"}]
       state = centered_picker_state(items)
 
       # One visible item + prompt + border = 4 rows, centered: box starts at row 10.
@@ -210,7 +211,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
     end
 
     test "scroll wheel works inside centered picker" do
-      items = [%{id: 1, label: "one"}, %{id: 2, label: "two"}]
+      items = [%Item{id: 1, label: "one"}, %Item{id: 2, label: "two"}]
       state = centered_picker_state(items)
 
       {:handled, new_state} =

--- a/test/minga_editor/input/picker_mouse_test.exs
+++ b/test/minga_editor/input/picker_mouse_test.exs
@@ -66,7 +66,12 @@ defmodule MingaEditor.Input.PickerMouseTest do
 
   describe "click to select" do
     test "clicking a candidate selects and confirms it" do
-      items = [%Item{id: 1, label: "alpha"}, %Item{id: 2, label: "beta"}, %Item{id: 3, label: "gamma"}]
+      items = [
+        %Item{id: 1, label: "alpha"},
+        %Item{id: 2, label: "beta"},
+        %Item{id: 3, label: "gamma"}
+      ]
+
       state = picker_state(items)
 
       # Items render upward from prompt_row (29). With 3 items:

--- a/test/minga_editor/ui/picker/candidate_test.exs
+++ b/test/minga_editor/ui/picker/candidate_test.exs
@@ -1,0 +1,44 @@
+defmodule MingaEditor.UI.Picker.CandidateTest do
+  @moduledoc "The lean candidate precomputes normalized scoring fields."
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.UI.Picker.Candidate
+  alias MingaEditor.UI.Picker.Item
+
+  test "from_items tags each candidate with its original index" do
+    items = for i <- 1..3, do: %Item{id: i, label: "item #{i}"}
+    candidates = Candidate.from_items(items)
+
+    assert Enum.map(candidates, & &1.index) == [0, 1, 2]
+    assert Enum.map(candidates, & &1.item) == items
+  end
+
+  test "norm_label is lowercased and icon-stripped" do
+    cand = Candidate.from_item(%Item{id: 1, label: "🔥 Config.EXS"}, 0)
+
+    assert cand.norm_label == "config.exs"
+    assert cand.label_length == String.length("config.exs")
+  end
+
+  test "plain labels keep their text" do
+    cand = Candidate.from_item(%Item{id: 1, label: "README.md"}, 0)
+    assert cand.norm_label == "readme.md"
+  end
+
+  test "norm_search folds description, annotation, and search_text" do
+    cand =
+      Candidate.from_item(
+        %Item{id: 1, label: "app.ex", description: "Lib/Deep", annotation: "M", search_text: "PATH"},
+        0
+      )
+
+    assert cand.norm_search == "lib/deep m path"
+  end
+
+  test "nil annotation is skipped during normalization" do
+    cand =
+      Candidate.from_item(%Item{id: 1, label: "x", description: "d", annotation: nil, search_text: "y"}, 0)
+
+    assert cand.norm_search == "d y"
+  end
+end

--- a/test/minga_editor/ui/picker/candidate_test.exs
+++ b/test/minga_editor/ui/picker/candidate_test.exs
@@ -28,7 +28,13 @@ defmodule MingaEditor.UI.Picker.CandidateTest do
   test "norm_search folds description, annotation, and search_text" do
     cand =
       Candidate.from_item(
-        %Item{id: 1, label: "app.ex", description: "Lib/Deep", annotation: "M", search_text: "PATH"},
+        %Item{
+          id: 1,
+          label: "app.ex",
+          description: "Lib/Deep",
+          annotation: "M",
+          search_text: "PATH"
+        },
         0
       )
 
@@ -37,7 +43,10 @@ defmodule MingaEditor.UI.Picker.CandidateTest do
 
   test "nil annotation is skipped during normalization" do
     cand =
-      Candidate.from_item(%Item{id: 1, label: "x", description: "d", annotation: nil, search_text: "y"}, 0)
+      Candidate.from_item(
+        %Item{id: 1, label: "x", description: "d", annotation: nil, search_text: "y"},
+        0
+      )
 
     assert cand.norm_search == "d y"
   end

--- a/test/minga_editor/ui/picker/file_source_test.exs
+++ b/test/minga_editor/ui/picker/file_source_test.exs
@@ -241,6 +241,36 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
     assert hot_index < cold_index
   end
 
+  describe "lean candidates and enrich/1" do
+    test "enrich builds icon, color, two-line description, and git annotation for winners" do
+      lean = %Item{
+        id: "lib/foo/bar.ex",
+        label: "bar.ex",
+        search_text: "lib/foo/bar.ex",
+        meta: %{git: :modified}
+      }
+
+      [enriched] = FileSource.enrich([lean])
+
+      assert enriched.id == "lib/foo/bar.ex"
+      assert String.ends_with?(enriched.label, " bar.ex")
+      assert String.first(enriched.label) != "b"
+      assert enriched.description == "lib/foo"
+      assert enriched.annotation == "M"
+      assert enriched.two_line == true
+      assert is_integer(enriched.icon_color)
+    end
+
+    test "enrich uses an empty description for root-level files and no git annotation" do
+      lean = %Item{id: "mix.exs", label: "mix.exs", search_text: "mix.exs", meta: %{git: nil}}
+
+      [enriched] = FileSource.enrich([lean])
+
+      assert enriched.description == ""
+      assert enriched.annotation == nil
+    end
+  end
+
   defp build_file_picker_state(state, items) do
     picker = items |> Picker.new(title: "Find file", max_visible: 10) |> mark_all_picker()
 

--- a/test/minga_editor/ui/picker/scorer_test.exs
+++ b/test/minga_editor/ui/picker/scorer_test.exs
@@ -1,0 +1,104 @@
+defmodule MingaEditor.UI.Picker.ScorerTest do
+  @moduledoc "Bounded top-K scoring matches the brute-force ordering it replaces."
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias MingaEditor.UI.Picker.Candidate
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.Scorer
+
+  # Reference implementation: the previous behavior, score every candidate then
+  # fully sort. Ties broken by original index, exactly as `top_k` claims to.
+  defp brute_force(candidates, segments) do
+    candidates
+    |> Enum.map(fn c -> {Scorer.score_candidate(c, segments), c} end)
+    |> Enum.filter(fn {score, _c} -> score > 0 end)
+    |> Enum.sort_by(fn {score, c} -> {-score, c.index} end)
+    |> Enum.map(fn {_score, c} -> c end)
+  end
+
+  defp candidates(labels) do
+    labels
+    |> Enum.map(&%Item{id: &1, label: &1})
+    |> Candidate.from_items()
+  end
+
+  describe "top_k/3 vs brute force" do
+    test "with k >= matches, returns the exact full sorted order" do
+      cands = candidates(["config.exs", "xconfig.exs", "lib/config/runtime.exs", "readme.md"])
+      segments = ["config"]
+
+      assert Scorer.top_k(cands, segments, length(cands)) == brute_force(cands, segments)
+    end
+
+    test "bounded result is the prefix of the brute-force order" do
+      cands = candidates(["config.exs", "xconfig.exs", "lib/config/runtime.exs", "config_helper.ex"])
+      segments = ["config"]
+
+      full = brute_force(cands, segments)
+
+      for k <- 1..length(cands) do
+        assert Scorer.top_k(cands, segments, k) == Enum.take(full, k)
+      end
+    end
+
+    test "prefix beats substring beats fuzzy, label beats search-only" do
+      cands =
+        candidates([
+          # fuzzy on label
+          "ceonfig.ex",
+          # substring on label
+          "xconfig.exs",
+          # prefix on label
+          "config.exs"
+        ])
+
+      [first, second, third] = Scorer.top_k(cands, ["config"], 3) |> Enum.map(& &1.item.label)
+
+      assert first == "config.exs"
+      assert second == "xconfig.exs"
+      assert third == "ceonfig.ex"
+    end
+
+    test "drops candidates that fail any segment (orderless)" do
+      cands = candidates(["buffer-switch", "buffer-kill", "file-open"])
+      result = Scorer.top_k(cands, ["b", "sw"], 10) |> Enum.map(& &1.item.label)
+
+      assert result == ["buffer-switch"]
+    end
+
+    test "matches against the search field when the label does not match" do
+      cands = [%Item{id: 1, label: "app.ex", search_text: "lib/deep/path/app.ex"}]
+      cands = Candidate.from_items(cands)
+
+      assert Scorer.top_k(cands, ["deep"], 5) |> length() == 1
+    end
+  end
+
+  describe "bounded large sets" do
+    test "never returns more than k and stays a prefix of brute force" do
+      labels = for i <- 1..10_000, do: "module_#{i}_config.ex"
+      cands = candidates(labels)
+      segments = ["config"]
+
+      result = Scorer.top_k(cands, segments, 200)
+
+      assert length(result) == 200
+      assert result == Enum.take(brute_force(cands, segments), 200)
+    end
+  end
+
+  property "top_k always equals the prefix of the brute-force order" do
+    check all(
+            labels <-
+              list_of(string(?a..?z, min_length: 1, max_length: 6), min_length: 1, max_length: 40),
+            query <- string(?a..?z, min_length: 1, max_length: 3),
+            k <- integer(1..50)
+          ) do
+      cands = candidates(labels)
+      segments = [query]
+
+      assert Scorer.top_k(cands, segments, k) == Enum.take(brute_force(cands, segments), k)
+    end
+  end
+end

--- a/test/minga_editor/ui/picker/scorer_test.exs
+++ b/test/minga_editor/ui/picker/scorer_test.exs
@@ -32,7 +32,9 @@ defmodule MingaEditor.UI.Picker.ScorerTest do
     end
 
     test "bounded result is the prefix of the brute-force order" do
-      cands = candidates(["config.exs", "xconfig.exs", "lib/config/runtime.exs", "config_helper.ex"])
+      cands =
+        candidates(["config.exs", "xconfig.exs", "lib/config/runtime.exs", "config_helper.ex"])
+
       segments = ["config"]
 
       full = brute_force(cands, segments)

--- a/test/minga_editor/ui/picker_test.exs
+++ b/test/minga_editor/ui/picker_test.exs
@@ -67,6 +67,42 @@ defmodule MingaEditor.UI.PickerTest do
     end
   end
 
+  describe "bounded result set" do
+    @result_limit 200
+
+    test "filtering a huge candidate set is bounded to the result limit" do
+      items = for i <- 1..5_000, do: %Item{id: i, label: "config_#{i}.ex"}
+      picker = Picker.new(items) |> Picker.filter("config")
+
+      assert Picker.count(picker) == @result_limit
+      assert Picker.total(picker) == 5_000
+      assert Picker.selected_item(picker) != nil
+    end
+
+    test "empty query on a huge set is also bounded" do
+      items = for i <- 1..5_000, do: %Item{id: i, label: "file_#{i}.ex"}
+      picker = Picker.new(items)
+
+      assert Picker.count(picker) == @result_limit
+      assert Picker.total(picker) == 5_000
+    end
+
+    test "small sets are unaffected (full list shown)" do
+      items = for i <- 1..10, do: %Item{id: i, label: "thing_#{i}"}
+      picker = Picker.new(items) |> Picker.filter("thing")
+
+      assert Picker.count(picker) == 10
+    end
+
+    test "match positions are attached to filtered winners only" do
+      items = for i <- 1..300, do: %Item{id: i, label: "config_#{i}.ex"}
+      picker = Picker.new(items) |> Picker.filter("config")
+
+      assert Enum.all?(picker.filtered, &(&1.match_positions != []))
+      assert length(picker.filtered) == @result_limit
+    end
+  end
+
   describe "fuzzy/orderless matching" do
     test "orderless matching — segments match independently" do
       items = [
@@ -320,7 +356,7 @@ defmodule MingaEditor.UI.PickerTest do
     end
 
     test "scrolls to keep selection visible" do
-      items = for i <- 1..20, do: {i, "item #{i}", "desc #{i}"}
+      items = for i <- 1..20, do: %Item{id: i, label: "item #{i}", description: "desc #{i}"}
       picker = Picker.new(items, max_visible: 5)
 
       # Move to item 10
@@ -343,7 +379,7 @@ defmodule MingaEditor.UI.PickerTest do
 
   describe "page_down/1" do
     test "jumps down by max_visible items" do
-      items = for i <- 1..20, do: {i, "item #{i}", "desc #{i}"}
+      items = for i <- 1..20, do: %Item{id: i, label: "item #{i}", description: "desc #{i}"}
       picker = Picker.new(items, max_visible: 5)
       assert picker.selected == 0
 
@@ -355,7 +391,7 @@ defmodule MingaEditor.UI.PickerTest do
     end
 
     test "clamps to last item" do
-      items = for i <- 1..20, do: {i, "item #{i}", "desc #{i}"}
+      items = for i <- 1..20, do: %Item{id: i, label: "item #{i}", description: "desc #{i}"}
       picker = Picker.new(items, max_visible: 5)
 
       # Jump 4 pages — should clamp to 19 (last item)
@@ -377,7 +413,7 @@ defmodule MingaEditor.UI.PickerTest do
 
   describe "page_up/1" do
     test "jumps up by max_visible items" do
-      items = for i <- 1..20, do: {i, "item #{i}", "desc #{i}"}
+      items = for i <- 1..20, do: %Item{id: i, label: "item #{i}", description: "desc #{i}"}
       picker = Picker.new(items, max_visible: 5)
 
       # Start at item 15
@@ -392,7 +428,7 @@ defmodule MingaEditor.UI.PickerTest do
     end
 
     test "clamps to first item" do
-      items = for i <- 1..20, do: {i, "item #{i}", "desc #{i}"}
+      items = for i <- 1..20, do: %Item{id: i, label: "item #{i}", description: "desc #{i}"}
       picker = Picker.new(items, max_visible: 5)
 
       # Start at item 3


### PR DESCRIPTION
## Summary

Part of epic #2350 (large-repo responsiveness). Makes picker filtering responsive when a source has tens of thousands of candidates (the file picker showed ~50,773 candidates in a large repo).

Previously every keystroke re-normalized, scored, **fully sorted**, and computed match positions for **every** candidate, and FileSource eagerly built a rich `%Item{}` (Devicon + git annotation) for all ~50k paths up front.

Now:
- **Lean candidate cache** (`Picker.Candidate`): precomputes `norm_label`/`norm_search`/`label_length` + a stable `index` once when items are set, so scoring does only the match work.
- **Bounded top-K** (`Picker.Scorer.top_k/3`): keeps the best `@result_limit` (200) results via bounded insertion ordered by `{-score, index}`, **never sorting the full match set**. The order reproduces the previous brute-force order exactly.
- **Late position highlighting**: `match_positions` computed only for the bounded winners.
- **Deferred FileSource enrichment**: `candidates/1` returns lean items (filename label, full-path search text, git status stashed in the new opaque `Item.meta`); an optional `enrich/1` Source callback (identity default) builds icon/color/two-line description/annotation. The render-model builder enriches + re-highlights **only the visible window**, so a 50k-file repo never materializes 50k rich items.

### Design note
Enrichment runs in `PickerBuilder` (single chokepoint, visible-only, matches the builder's documented "all display derivation lives here, ruling 4" charter) rather than scattered across `PickerUI` call sites. Selection/marks/bulk/preview use only `Item.id`, so lean items work off the render path. (Refines archie's picker_ui suggestion after reviewing the contract.)

## Acceptance criteria
1. ✅ Lean candidate representation with precomputed searchable fields (`Candidate`).
2. ✅ Bounded top result set instead of sorting every match (`Scorer.top_k`, capped at 200).
3. ✅ Match positions computed only for kept winners.
4. ✅ FileSource icon/color/two-line description/annotation enrichment happens after filtering, for the bounded set.
5. ✅ Selection, visible rows, marks, bulk actions intact (use `Item.id`).
6. ✅ Tests compare bounded scoring against brute-force ordering on small sets (property test + 10k synthetic + per-`k` prefix equality).

## Tests
- Full suite `mix test.llm`: **0 failures** (56 doctests, 95 properties, 9330 tests).
- New: `scorer_test.exs` (top_k vs brute-force reference, property, 10k synthetic), `candidate_test.exs`, picker bounded-result tests, FileSource `enrich/1` tests.
- `mix format --check-formatted`, `mix credo --strict`, `make lint` → clean.
- Focused bug-hunt (prtk-code-reviewer) + acceptance reviewer → PASS, no correctness bugs.

## Known/intended behavior changes
- Large-match / empty-query result sets are bounded to 200; `filtered_count` ("X of Y") now reflects results shown vs `total_count` files (deliberate bounding, not a follow-up blocker).
- A previously-undocumented test convenience of passing bare strings/maps/tuples as picker items no longer works (production sources always returned `%Item{}`; tests updated accordingly).

Closes #2351

🤖 Generated with [Claude Code](https://claude.com/claude-code)