### PR TITLE
perf(picker): revision-tagged async filtering keeps typing responsive

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -882,8 +882,11 @@ defmodule MingaEditor do
         ) :: state()
   defp handle_picker_candidates(state, payload, {:ok, items}) do
     picker_state = payload.picker_ui
+    # replace_items refilters synchronously against the current query, so the
+    # shown results are fresh; clear any :filtering status left by typing during
+    # the async load (its queued refilter is now redundant).
     picker = MingaEditor.UI.Picker.replace_items(picker_state.picker, items)
-    new_picker_state = %{picker_state | picker: picker, load_status: :ready}
+    new_picker_state = %{picker_state | picker: picker, load_status: :ready, filter_status: :idle}
 
     ModalOverlay.transition(
       state,

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -845,6 +845,18 @@ defmodule MingaEditor do
     end
   end
 
+  # Async picker refilter: PickerUI.handle_key updates the query and schedules
+  # this message tagged with a revision. Apply only if the revision is still
+  # current; a burst of keystrokes leaves several of these queued and all but
+  # the latest are dropped by the revision check in apply_refilter/2.
+  def handle_info({:picker_refilter, revision}, state) do
+    if MingaEditor.PickerUI.pending_refilter?(state, revision) do
+      {:noreply, Renderer.render_or_async(MingaEditor.PickerUI.apply_refilter(state, revision))}
+    else
+      {:noreply, state}
+    end
+  end
+
   def handle_info(_msg, state) do
     {:noreply, state}
   end

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -3,9 +3,11 @@ defmodule MingaEditor.PickerUI do
   Picker orchestration and modal state: open, key handling, close, and refresh.
 
   This is the live picker state layer used by the command palette, file finder,
-  buffer list, LSP actions, and agent pickers. All functions are pure
-  `state → state` or `state → {state, action}` transformations; the GenServer
-  dispatches any returned action tuple.
+  buffer list, LSP actions, and agent pickers. Functions are `state → state` or
+  `state → {state, action}` transformations; the GenServer dispatches any
+  returned action tuple. The one controlled side effect is that `handle_key/3`,
+  on a query-changing keystroke, enqueues a deferred `{:picker_refilter, rev}`
+  message to `self()` so input never blocks on scoring (see `apply_refilter/2`).
 
   The modal `picker_ui` state these functions produce is read directly by the
   semantic render-model builder (`RenderModel.UI.PickerBuilder`), which emits the
@@ -401,14 +403,13 @@ defmodule MingaEditor.PickerUI do
         _mods
       )
       when cp in [8, 127] do
-    new_picker = Picker.backspace(picker)
+    new_query = backspace_query(picker.query)
 
     # If query is now empty and we had mode-switched, switch back to original source
-    if new_picker.query == "" and prefix != "" and orig != nil do
+    if new_query == "" and prefix != "" and orig != nil do
       switch_back_to_original(state)
     else
-      state = update_picker(state, &%{&1 | picker: new_picker})
-      maybe_preview_selection(state)
+      schedule_refilter(state, new_query)
     end
   end
 
@@ -452,11 +453,77 @@ defmodule MingaEditor.PickerUI do
         new_state
 
       :no_switch ->
-        new_picker = Picker.type_char(picker, char)
-        state = update_picker(state, &%{&1 | picker: new_picker})
-        maybe_preview_selection(state)
+        schedule_refilter(state, picker.query <> char)
     end
   end
+
+  # ── Async revision-tagged filtering ─────────────────────────────────────────
+  # Keypresses update the query immediately and schedule a refilter tagged with a
+  # bumped revision, so input never blocks on scoring a large candidate set. The
+  # editor process applies a refilter only if its revision is still current
+  # (`apply_refilter/2`), so a burst of keystrokes coalesces to a single scoring
+  # pass and stale results are dropped.
+
+  @spec backspace_query(String.t()) :: String.t()
+  defp backspace_query(""), do: ""
+  defp backspace_query(query), do: String.slice(query, 0, String.length(query) - 1)
+
+  @spec schedule_refilter(state(), String.t()) :: state()
+  defp schedule_refilter(state, new_query) do
+    {:picker, payload} = state.shell_state.modal
+    new_revision = payload.picker_ui.filter_revision + 1
+
+    new_state =
+      update_picker(state, fn ps ->
+        %{
+          ps
+          | picker: Picker.put_query(ps.picker, new_query),
+            filter_revision: new_revision,
+            filter_status: :filtering
+        }
+      end)
+
+    send(self(), {:picker_refilter, new_revision})
+    new_state
+  end
+
+  @doc """
+  Returns whether a scheduled refilter for `revision` is still the latest, so the
+  caller can skip applying and re-rendering superseded revisions entirely.
+  """
+  @spec pending_refilter?(state(), non_neg_integer()) :: boolean()
+  def pending_refilter?(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{filter_revision: revision}}}}},
+        revision
+      ),
+      do: true
+
+  def pending_refilter?(_state, _revision), do: false
+
+  @doc """
+  Applies the result of a scheduled refilter, but only when `revision` still
+  matches the picker's current `filter_revision`. A stale revision (superseded
+  by newer typing) is ignored, so out-of-date results never overwrite newer
+  ones. Runs the live preview for the freshly applied selection.
+  """
+  @spec apply_refilter(state(), non_neg_integer()) :: state()
+  def apply_refilter(
+        %{
+          shell_state: %{
+            modal:
+              {:picker, %{picker_ui: %{filter_revision: revision, picker: %Picker{} = picker}}}
+          }
+        } = state,
+        revision
+      ) do
+    refiltered = Picker.filter(picker, picker.query)
+
+    state
+    |> update_picker(fn ps -> %{ps | picker: refiltered, filter_status: :idle} end)
+    |> maybe_preview_selection()
+  end
+
+  def apply_refilter(state, _revision), do: state
 
   @spec select_item(EditorState.t(), Picker.t(), Picker.item(), module()) ::
           EditorState.t() | {EditorState.t(), {:execute_command, atom()}}

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -751,7 +751,11 @@ defmodule MingaEditor.PickerUI do
           source: new_source,
           layout: layout,
           original_source: original,
-          mode_prefix: prefix
+          mode_prefix: prefix,
+          # Fresh picker is already filtered synchronously; bump the revision so
+          # any refilter still queued for the previous source is dropped as stale.
+          filter_revision: &1.filter_revision + 1,
+          filter_status: :idle
       }
     )
   end
@@ -775,7 +779,10 @@ defmodule MingaEditor.PickerUI do
           source: orig,
           layout: layout,
           original_source: nil,
-          mode_prefix: ""
+          mode_prefix: "",
+          # See switch_to_source: drop any refilter queued for the prior source.
+          filter_revision: &1.filter_revision + 1,
+          filter_status: :idle
       }
     )
   end

--- a/lib/minga_editor/state/picker.ex
+++ b/lib/minga_editor/state/picker.ex
@@ -13,6 +13,12 @@ defmodule MingaEditor.State.Picker do
   @typedoc "Async loading status for sources that fetch candidates in the background."
   @type load_status :: :ready | :loading | {:error, String.t()}
 
+  @typedoc """
+  Async filtering status. `:idle` when the shown results match the current
+  query; `:filtering` while a refilter for the latest query revision is pending.
+  """
+  @type filter_status :: :idle | :filtering
+
   @type t :: %__MODULE__{
           picker: MingaEditor.UI.Picker.t() | nil,
           source: module() | nil,
@@ -23,7 +29,9 @@ defmodule MingaEditor.State.Picker do
           layout: MingaEditor.UI.Picker.Source.layout(),
           original_source: module() | nil,
           mode_prefix: String.t(),
-          load_status: load_status()
+          load_status: load_status(),
+          filter_revision: non_neg_integer(),
+          filter_status: filter_status()
         }
 
   defstruct picker: nil,
@@ -35,7 +43,9 @@ defmodule MingaEditor.State.Picker do
             layout: :bottom,
             original_source: nil,
             mode_prefix: "",
-            load_status: :ready
+            load_status: :ready,
+            filter_revision: 0,
+            filter_status: :idle
 
   @doc "Returns true if a picker is currently open."
   @spec open?(t()) :: boolean()

--- a/lib/minga_editor/ui/picker.ex
+++ b/lib/minga_editor/ui/picker.ex
@@ -124,6 +124,18 @@ defmodule MingaEditor.UI.Picker do
     refilter(%{picker | query: query})
   end
 
+  @doc """
+  Sets the query without refiltering, keeping the current `filtered` results.
+
+  Used by the async/revision-tagged filtering path: the query updates
+  immediately for display while the (potentially expensive) refilter is
+  scheduled separately, so previous results stay visible until it completes.
+  """
+  @spec put_query(t(), String.t()) :: t()
+  def put_query(%__MODULE__{} = picker, query) when is_binary(query) do
+    %{picker | query: query}
+  end
+
   # ── Navigation ──────────────────────────────────────────────────────────────
 
   @doc "Moves the selection down by one (wraps around)."

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -379,6 +379,29 @@ defmodule MingaEditor.PickerUITest do
       labels = Enum.map(picker_ui(state).picker.filtered, & &1.label)
       assert "bravo" in labels and "boson" in labels
     end
+
+    test "switching source drops a refilter queued for the previous source" do
+      {state, _original_buf, _preview_buf} = preview_promotion_state()
+
+      # Type then backspace to an empty query so the next char can mode-switch;
+      # both keystrokes schedule a refilter for the FileSource picker.
+      state = PickerUI.handle_key(state, ?x, 0)
+      state = PickerUI.handle_key(state, 127, 0)
+      stale_rev = picker_ui(state).filter_revision
+      assert picker_ui(state).filter_status == :filtering
+
+      # ">" mode-switches to the command source (query is now empty).
+      state = PickerUI.handle_key(state, ?>, 0)
+      switched = picker_ui(state)
+      assert switched.source == MingaEditor.UI.Picker.CommandSource
+      assert switched.filter_status == :idle
+      assert switched.filter_revision > stale_rev
+
+      # The refilter queued for the old FileSource picker is now stale: it must
+      # not apply to the new source.
+      refute PickerUI.pending_refilter?(state, stale_rev)
+      assert PickerUI.apply_refilter(state, stale_rev) == state
+    end
   end
 
   defp async_filter_state(labels) do

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -301,4 +301,96 @@ defmodule MingaEditor.PickerUITest do
       assert pui.picker.query == "fix"
     end
   end
+
+  describe "async revision-tagged filtering" do
+    test "typing updates the query and schedules a refilter without applying it inline" do
+      state = async_filter_state(["bravo", "boson", "charlie", "alpha"])
+
+      state =
+        state
+        |> PickerUI.handle_key(?b, 0)
+        |> PickerUI.handle_key(?r, 0)
+
+      pui = picker_ui(state)
+      assert pui.picker.query == "br"
+      assert pui.filter_revision == 2
+      assert pui.filter_status == :filtering
+      # Deferred: the previous (empty-query) results are still shown.
+      assert Picker.count(pui.picker) == 4
+    end
+
+    test "handle_key schedules a revision-tagged refilter message" do
+      state = async_filter_state(["bravo", "alpha"])
+      _ = PickerUI.handle_key(state, ?b, 0)
+      assert_received {:picker_refilter, 1}
+    end
+
+    test "applying the current revision updates the filtered results" do
+      state = async_filter_state(["bravo", "boson", "charlie", "alpha"])
+
+      state =
+        state
+        |> PickerUI.handle_key(?b, 0)
+        |> PickerUI.handle_key(?r, 0)
+        |> PickerUI.apply_refilter(2)
+
+      pui = picker_ui(state)
+      assert pui.filter_status == :idle
+      assert Enum.map(pui.picker.filtered, & &1.label) == ["bravo"]
+    end
+
+    test "a stale revision is ignored and does not overwrite newer results" do
+      state = async_filter_state(["bravo", "boson", "charlie", "alpha"])
+
+      state =
+        state
+        |> PickerUI.handle_key(?b, 0)
+        |> PickerUI.handle_key(?r, 0)
+
+      # Revision 1 ("b") finishes late; it must not apply over the pending "br".
+      state = PickerUI.apply_refilter(state, 1)
+      stale_pui = picker_ui(state)
+      assert stale_pui.filter_status == :filtering
+      assert Picker.count(stale_pui.picker) == 4
+
+      # The current revision applies.
+      state = PickerUI.apply_refilter(state, 2)
+      assert Enum.map(picker_ui(state).picker.filtered, & &1.label) == ["bravo"]
+    end
+
+    test "backspace schedules a refilter that widens the query" do
+      state = async_filter_state(["bravo", "boson", "charlie", "alpha"])
+
+      state =
+        state
+        |> PickerUI.handle_key(?b, 0)
+        |> PickerUI.handle_key(?r, 0)
+        |> PickerUI.apply_refilter(2)
+
+      assert Enum.map(picker_ui(state).picker.filtered, & &1.label) == ["bravo"]
+
+      state = PickerUI.handle_key(state, 127, 0)
+      pui = picker_ui(state)
+      assert pui.picker.query == "b"
+      assert pui.filter_revision == 3
+      assert pui.filter_status == :filtering
+
+      state = PickerUI.apply_refilter(state, 3)
+      labels = Enum.map(picker_ui(state).picker.filtered, & &1.label)
+      assert "bravo" in labels and "boson" in labels
+    end
+  end
+
+  defp async_filter_state(labels) do
+    state = TestHelpers.base_state(content: "x")
+    items = Enum.map(labels, &%Item{id: &1, label: &1})
+    picker = Picker.new(items, title: "Test", max_visible: 10)
+    picker_state = %PickerState{picker: picker, source: NoBulkActionsSource, restore: 0}
+    ModalOverlay.open(state, :picker, PickerPayload.new(picker_state))
+  end
+
+  defp picker_ui(state) do
+    {:picker, %{picker_ui: pui}} = state.shell_state.modal
+    pui
+  end
 end


### PR DESCRIPTION
## Summary

Part of epic #2350 (large-repo responsiveness). **Stacked on #2361** (#2351 bounded top-K) — base branch is `feat/picker-bounded-topk`; retarget to `main` once #2361 merges.

Printable keypresses and backspace used to run a full refilter inline before the editor could handle the next input. Now a query-changing keystroke:
- updates the query immediately (`Picker.put_query`, no scoring),
- bumps a monotonic `filter_revision`, marks the picker `:filtering`,
- and schedules a deferred `{:picker_refilter, rev}` self-message.

The editor applies a scheduled refilter only when its revision is still current (`apply_refilter/2`); superseded revisions are dropped by a cheap `pending_refilter?/2` guard. A burst of keystrokes leaves several messages in the editor mailbox and the revision check **coalesces them to a single scoring pass**, so stale results never overwrite newer ones. Previous results stay visible until the latest revision applies.

### Design note
Filtering is deferred + coalesced via revision-tagged self-messages run in the editor process, **not** a separate Task/worker. Justified because #2351 already made scoring bounded/fast, and a Task per keystroke would copy the ~50k candidate list each time. Under the single editor-GenServer mailbox (FIFO), `filter_revision` is monotonic and never resets within a picker session, so a stale message can't match a newer revision and cross-picker collisions can't occur (a scheduled message is always drained before a freshly-opened picker could climb back to that revision).

## Acceptance criteria
1. ✅ Typing updates query without blocking on a refilter (`put_query` + deferred message).
2. ✅ Refilter tagged with a revision/generation ID (`filter_revision`).
3. ✅ Stale results ignored (revision equality-match in `apply_refilter/2`).
4. ✅ Superseded in-flight work finishes harmlessly (dropped by `pending_refilter?/2` before scoring).
5. ✅ Previous results stay visible with `filter_status: :filtering` until the latest applies.
6. ✅ Tests cover rapid typing, scheduling, current-revision apply, stale-revision ignore, backspace.

## Tests
- Full suite `mix test.llm`: **0 failures** (9335 tests).
- `mix format --check-formatted`, `mix credo --strict`: clean.
- Bug-hunt (prtk-code-reviewer) + acceptance reviewer: PASS, no correctness bugs.

## Notes
- `filter_status` is stored in picker state but not yet surfaced to a frontend; AC5 is met by keeping previous results visible. A visible "filtering…" indicator is a possible follow-up.

Closes #2352

🤖 Generated with [Claude Code](https://claude.com/claude-code)