### PR TITLE
perf(extension): skip type inference when compiling extensions at runtime

### DIFF
--- a/lib/minga/extension/compile_cache.ex
+++ b/lib/minga/extension/compile_cache.ex
@@ -354,16 +354,29 @@ defmodule Minga.Extension.CompileCache do
     end
   end
 
+  # Runs `fun` (a `ParallelCompiler` call) with the compiler options runtime
+  # extension compilation needs, restoring them afterward under a global lock.
+  #
+  # - `ignore_module_conflict`: extensions may redefine modules across reloads.
+  # - `infer_signatures: false`: skip the set-theoretic type inference pass.
+  #   Extensions are already type-checked when the release/test suite is built;
+  #   re-running inference on the full extension module graph at boot (issue
+  #   #2355) wastes large amounts of memory and surfaces type diagnostics (e.g.
+  #   around `MingaBoard.Shell.State.new/0`) for code that is not changing here.
+  #   Runtime compilation is a bounded "make the beams" step, not a re-validation.
   @spec compile_ignoring_module_conflicts((-> term())) :: term()
   defp compile_ignoring_module_conflicts(fun) do
     :global.trans({__MODULE__, :compiler_options}, fn ->
-      previous = Code.get_compiler_option(:ignore_module_conflict)
+      previous_conflict = Code.get_compiler_option(:ignore_module_conflict)
+      previous_infer = Code.get_compiler_option(:infer_signatures)
       Code.put_compiler_option(:ignore_module_conflict, true)
+      Code.put_compiler_option(:infer_signatures, false)
 
       try do
         fun.()
       after
-        Code.put_compiler_option(:ignore_module_conflict, previous)
+        Code.put_compiler_option(:ignore_module_conflict, previous_conflict)
+        Code.put_compiler_option(:infer_signatures, previous_infer)
       end
     end)
   end

--- a/lib/minga/extension/dev_reload.ex
+++ b/lib/minga/extension/dev_reload.ex
@@ -246,6 +246,10 @@ defmodule Minga.Extension.DevReload do
     if ex_files == [] do
       {:error, :no_source_files}
     else
+      # Unlike CompileCache (which disables type inference for the boot-time
+      # whole-graph compile, issue #2355), dev hot-reload deliberately keeps
+      # inference on: it recompiles a single changed extension, so there is no
+      # large-graph memory spike, and the developer wants the type diagnostics.
       case Kernel.ParallelCompiler.compile(ex_files, return_diagnostics: true) do
         {:ok, _modules, _diag_map} -> :ok
         {:error, errors, _diag_map} -> {:error, errors}

--- a/test/minga/extension/compile_cache_test.exs
+++ b/test/minga/extension/compile_cache_test.exs
@@ -33,6 +33,13 @@ defmodule Minga.Extension.CompileCacheTest do
   defp opts(cache_dir), do: [cache_dir: cache_dir, enabled: true]
 
   describe "type inference during runtime compilation (issue #2355)" do
+    # NOTE: `:infer_signatures` is global VM compiler state, not process-local.
+    # These tests are safe under `async: true` because CompileCache mutates and
+    # restores it under a `:global.trans` lock (so concurrent compiles here are
+    # serialized) and no other test suite touches `:infer_signatures`. If a
+    # future async test starts reading/writing that option, move this block to a
+    # separate `async: false` module.
+
     # A fixture that records, at compile time, whether type inference was on
     # while it was being compiled.
     defp write_infer_probe(src_dir) do

--- a/test/minga/extension/compile_cache_test.exs
+++ b/test/minga/extension/compile_cache_test.exs
@@ -32,6 +32,54 @@ defmodule Minga.Extension.CompileCacheTest do
 
   defp opts(cache_dir), do: [cache_dir: cache_dir, enabled: true]
 
+  describe "type inference during runtime compilation (issue #2355)" do
+    # A fixture that records, at compile time, whether type inference was on
+    # while it was being compiled.
+    defp write_infer_probe(src_dir) do
+      module = :"Elixir.ExtInferProbe#{:erlang.unique_integer([:positive])}"
+      file = Path.join(src_dir, "infer_probe.ex")
+
+      File.write!(file, """
+      defmodule #{inspect(module)} do
+        @infer_during_compile Code.get_compiler_option(:infer_signatures)
+        def infer_during_compile, do: @infer_during_compile
+      end
+      """)
+
+      {src_dir, [file], module}
+    end
+
+    test "disables type inference while compiling and restores it after (cache path)", %{
+      cache_dir: cache_dir,
+      src_dir: src_dir
+    } do
+      {root, files, module} = write_infer_probe(src_dir)
+      before = Code.get_compiler_option(:infer_signatures)
+
+      assert {:ok, %{modules: modules}} =
+               CompileCache.load_or_compile(root, files, opts(cache_dir))
+
+      assert module in modules
+      # The extension's module graph was NOT type-inferred at compile time, so a
+      # release boot does not re-run the type checker over it (the #2355 spike).
+      assert module.infer_during_compile() == false
+      # The global compiler option is restored, not leaked, after the compile.
+      assert Code.get_compiler_option(:infer_signatures) == before
+    end
+
+    test "disables inference on the in-memory (cache-off) path too", %{src_dir: src_dir} do
+      {root, files, module} = write_infer_probe(src_dir)
+      before = Code.get_compiler_option(:infer_signatures)
+
+      assert {:ok, %{modules: modules}} =
+               CompileCache.load_or_compile(root, files, enabled: false)
+
+      assert module in modules
+      assert module.infer_during_compile() == false
+      assert Code.get_compiler_option(:infer_signatures) == before
+    end
+  end
+
   describe "load_or_compile/3" do
     test "compiles and writes beams on a miss", %{cache_dir: cache_dir, src_dir: src_dir} do
       {root, files, module} = write_extension(src_dir, ":v1")


### PR DESCRIPTION
## Summary

Part of epic #2350. Fixes the runtime extension type-check memory spike (#2355).

On a release first boot, `Minga.Extension.CompileCache` recompiles path/git extensions from source via `Kernel.ParallelCompiler`. The cache key includes minga's app version, so **every release invalidates the cache** and the first boot recompiles all path/git extensions. In Elixir 1.19+ that compile runs the set-theoretic **type inference pass** over the entire extension module graph (e.g. MingaBoard), which:
- spiked the BEAM footprint (~3.9 GB observed during the large-repo investigation), and
- logged a type-checking diagnostic around `MingaBoard.Shell.State.new/0`.

Type inference at **runtime** is wasted work: extensions are already type-checked when the release and the test suite are built. This makes the existing `compile_ignoring_module_conflicts/1` helper (which already save/restores `:ignore_module_conflict` under a `:global.trans` lock around both runtime compile sites) **also disable `:infer_signatures`** for the duration and restore it after. Runtime compilation becomes a bounded "produce the beams" step that no longer re-runs the type checker.

## Acceptance criteria

| AC | Status |
|----|--------|
| 1. No `MingaBoard.Shell.State.new/0` type-check error at startup | ✅ inference off → no type diagnostics during runtime compile |
| 2. Runtime loading doesn't type-check large module graphs unless requested | ✅ |
| 3. Validation happens at build/cache/bounded-runtime step | ✅ full inference at build/test; runtime is bounded |
| 4. Memory measured before/after | ⚠️ **needs a release build + large-repo repro** — not reproducible in CI/Linux dev; left for manual verification |
| 5. Tests cover the fixed path | ✅ |

## Tests
- Two new tests assert inference is `false` *during* the extension's own runtime compile (captured via a compile-time module attribute) and that the global option is **restored** afterward — for both the cache and in-memory paths.
- `mix test.llm`: **0 failures** (9315 tests); all 283 extension tests pass; `mix format`/`mix credo --strict` clean.
- Acceptance reviewer: PASS (confirmed save/restore is safe under the existing global lock; disabling inference changes no emitted beams).

## Note
AC4 (3.9 GB → reduced footprint measurement) requires building a release and reproducing in a large repo, which isn't possible in this environment. The change is principled: type inference is the memory-heavy phase of Elixir compilation, and this removes it from the boot path. Worth a manual before/after `mix release` footprint check.

Closes #2355

🤖 Generated with [Claude Code](https://claude.com/claude-code)