### PR TITLE
fix(macos): restart-safe SwiftUI identity for Messages rows

### DIFF
--- a/macos/Sources/Views/MessagesContentState.swift
+++ b/macos/Sources/Views/MessagesContentState.swift
@@ -6,13 +6,34 @@
 import SwiftUI
 
 /// A rendered message entry for display in the Messages tab.
+///
+/// SwiftUI identity is `id`, a `(streamGeneration, seq)` composite, NOT the raw
+/// backend sequence number (`seq`). The BEAM `MessageStore` restarts its
+/// sequence at 1 whenever the backend restarts (or resends), so using `seq`
+/// alone as `ForEach`/scroll identity produced duplicate IDs across restarts
+/// (issue #2353). `MessagesContentState` bumps the generation when it sees a
+/// sequence go backwards, keeping every row's identity unique.
 struct MessageEntry: Identifiable, Equatable {
-    let id: UInt32
+    /// Restart-safe composite identity: `(UInt64(generation) << 32) | seq`.
+    /// Static fixtures (previews/tests) may pass a small raw sequence directly;
+    /// that is just generation 0, where the composite equals the sequence.
+    let id: UInt64
     let level: UInt8
     let subsystem: UInt8
     let timestampSecs: UInt32
     let filePath: String
     let text: String
+
+    /// Raw backend sequence number for this entry (the low 32 bits of `id`).
+    /// Resets to 1 on a backend restart; the generation in the high bits keeps
+    /// `id` unique even when `seq` repeats.
+    var seq: UInt32 { UInt32(id & 0xFFFF_FFFF) }
+
+    /// Builds the restart-safe composite identity from a stream generation and
+    /// a backend sequence number.
+    static func makeID(generation: UInt32, seq: UInt32) -> UInt64 {
+        (UInt64(generation) << 32) | UInt64(seq)
+    }
 
     /// Compact timestamp as HH:MM:SS.
     var timestamp: String {
@@ -192,11 +213,34 @@ final class MessagesContentState {
     /// Maximum entries to keep (matches BEAM-side cap).
     private let maxEntries = 1000
 
+    /// Current stream generation. Bumped whenever an incoming backend sequence
+    /// number is not greater than the last one seen, which happens when the BEAM
+    /// backend restarts (sequence resets to 1) or resends earlier IDs.
+    private var streamGeneration: UInt32 = 0
+    /// The last backend sequence number appended, or nil before any entry.
+    private var lastSeq: UInt32?
+    /// Composite IDs currently present, for defensive dedupe (issue #2353).
+    private var presentIDs: Set<UInt64> = []
+
     /// Append new entries from the protocol decoder.
+    ///
+    /// Each entry is given a restart-safe composite identity. When a backend
+    /// sequence number does not advance (`raw.id <= lastSeq`), the stream
+    /// generation is bumped so the repeated/reset sequence lands in a fresh
+    /// namespace and never collides with an already-displayed row.
     func appendEntries(_ rawEntries: [Wire.MessageEntry]) {
         for raw in rawEntries {
+            if let last = lastSeq, raw.id <= last {
+                streamGeneration &+= 1
+            }
+            lastSeq = raw.id
+
+            let id = MessageEntry.makeID(generation: streamGeneration, seq: raw.id)
+            // Defensive dedupe: never emit a duplicate SwiftUI identity.
+            if presentIDs.contains(id) { continue }
+
             let entry = MessageEntry(
-                id: raw.id,
+                id: id,
                 level: raw.level,
                 subsystem: raw.subsystem,
                 timestampSecs: raw.timestampSecs,
@@ -204,10 +248,13 @@ final class MessagesContentState {
                 text: raw.text
             )
             entries.append(entry)
+            presentIDs.insert(id)
         }
-        // Trim to max
+        // Trim to max, keeping the dedupe set in sync with the retained window.
         if entries.count > maxEntries {
-            entries.removeFirst(entries.count - maxEntries)
+            let overflow = entries.count - maxEntries
+            for dropped in entries.prefix(overflow) { presentIDs.remove(dropped.id) }
+            entries.removeFirst(overflow)
         }
         // Signal new entries for auto-scroll or "jump to latest"
         if !isAutoScrolling {

--- a/macos/Tests/MingaTests/MessagesContentStateTests.swift
+++ b/macos/Tests/MingaTests/MessagesContentStateTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+
+@Suite("Messages restart-safe identity (issue #2353)")
+struct MessagesContentStateIdentityTests {
+    private func wire(_ id: UInt32, _ text: String = "msg") -> Wire.MessageEntry {
+        Wire.MessageEntry(
+            id: id, level: 1, subsystem: 0, timestampSecs: 0, filePath: "", text: text)
+    }
+
+    @Test("a backend restart (sequence resets to 1) yields unique row identities")
+    @MainActor func restartKeepsIdentitiesUnique() {
+        let state = MessagesContentState()
+        state.appendEntries([wire(1), wire(2)])
+        // Backend restarts: the BEAM MessageStore sequence resets to 1, 2 again.
+        state.appendEntries([wire(1), wire(2)])
+
+        let ids = state.entries.map(\.id)
+        #expect(ids.count == 4)
+        // All four rows have distinct SwiftUI identities despite repeated seqs,
+        // so ForEach emits no duplicate-ID warning.
+        #expect(Set(ids).count == 4)
+        // The raw backend sequence is preserved on each entry.
+        #expect(state.entries.map(\.seq) == [1, 2, 1, 2])
+    }
+
+    @Test("identity is the (generation, seq) composite, not the raw sequence")
+    @MainActor func identityIsComposite() {
+        let state = MessagesContentState()
+        state.appendEntries([wire(1)])
+        #expect(state.entries[0].id == MessageEntry.makeID(generation: 0, seq: 1))
+
+        // Restart: same seq 1, but a new generation namespaces it.
+        state.appendEntries([wire(1)])
+        #expect(state.entries[1].id == MessageEntry.makeID(generation: 1, seq: 1))
+    }
+
+    @Test("a normal increasing sequence stays in a single generation")
+    @MainActor func monotonicSequenceOneGeneration() {
+        let state = MessagesContentState()
+        state.appendEntries([wire(1), wire(2), wire(3)])
+        #expect(state.entries.map(\.id) == [
+            MessageEntry.makeID(generation: 0, seq: 1),
+            MessageEntry.makeID(generation: 0, seq: 2),
+            MessageEntry.makeID(generation: 0, seq: 3),
+        ])
+    }
+
+    @Test("a resend of already-seen IDs is namespaced into a new generation")
+    @MainActor func resendNamespaced() {
+        let state = MessagesContentState()
+        state.appendEntries([wire(1), wire(2), wire(3)])
+        // Backend resends 2, 3 (e.g. after a reconnect) without a full restart.
+        state.appendEntries([wire(2), wire(3)])
+
+        let ids = state.entries.map(\.id)
+        #expect(ids.count == 5)
+        #expect(Set(ids).count == 5)
+    }
+
+    @Test("identities stay unique across many restarts (no ForEach collisions)")
+    @MainActor func manyRestartsStayUnique() {
+        let state = MessagesContentState()
+        for _ in 0..<5 {
+            state.appendEntries([wire(1), wire(2), wire(3)])
+        }
+        let ids = state.entries.map(\.id)
+        #expect(ids.count == 15)
+        #expect(Set(ids).count == ids.count)
+    }
+}

--- a/macos/Tests/MingaTests/MessagesContentStateTests.swift
+++ b/macos/Tests/MingaTests/MessagesContentStateTests.swift
@@ -68,4 +68,25 @@ struct MessagesContentStateIdentityTests {
         #expect(ids.count == 15)
         #expect(Set(ids).count == ids.count)
     }
+
+    @Test("entries are capped and identities stay unique across the trim boundary")
+    @MainActor func trimKeepsIdentitiesUniqueAndDedupeInSync() {
+        let state = MessagesContentState()
+        // 6 restarts × 300 = 1800 appended, well past the 1000-entry cap.
+        for _ in 0..<6 {
+            state.appendEntries((1...300).map { wire(UInt32($0)) })
+        }
+        // Trimmed to the cap, and every retained row still has a unique identity,
+        // so ForEach never sees a duplicate ID even after the dedupe set has been
+        // pruned alongside the trimmed window.
+        #expect(state.entries.count == 1000)
+        #expect(Set(state.entries.map(\.id)).count == 1000)
+
+        // A resend of an early sequence (whose original generation was trimmed
+        // out) still appends in a fresh generation rather than being wrongly
+        // deduped against a dropped id, and the cap holds.
+        state.appendEntries([wire(1)])
+        #expect(state.entries.count == 1000)
+        #expect(Set(state.entries.map(\.id)).count == state.entries.count)
+    }
 }


### PR DESCRIPTION
## Summary

Part of epic #2350. Fixes the macOS Messages panel SwiftUI duplicate-ID warnings (#2353).

`MessageEntry` used the raw BEAM sequence number (`UInt32`) as its `Identifiable` id. The BEAM `MessageStore` restarts its sequence at 1 whenever the backend restarts (or resends), so SwiftUI's `ForEach` saw duplicate IDs across restarts — logging `the ID N occurs multiple times within the collection` and reconciling rows undefined.

`MessagesContentState` now tracks a **stream generation**, bumping it whenever an incoming backend sequence does not advance (`raw.id <= lastSeq`, i.e. a restart or resend). `MessageEntry.id` becomes a restart-safe `(generation, seq)` composite (`UInt64`); the raw `seq` is kept as protocol data. A defensive dedupe by composite identity guarantees row identities are always unique. Scroll targets use `entry.id`, so they follow the composite identity automatically.

## Acceptance criteria
1. ✅ SwiftUI row identity unique across backend restarts/resends (generation namespacing).
2. ✅ BEAM sequence IDs still carried as protocol data (`seq`), but not the sole SwiftUI identity.
3. ✅ Frontend namespaces entries when the stream generation changes.
4. ✅ Duplicate backend sequence IDs from different generations don't create duplicate SwiftUI IDs.
5. ✅ Tests cover duplicate IDs and generation changes.

## Approach

Per the ticket's Developer Notes, this is the **frontend-local generation fallback** (no protocol/wire change, no TUI impact). The durable protocol-level session nonce (BEAM emits a generation, frontend keys on it) is the recommended follow-up.

## Tests
- New `MessagesContentStateTests.swift` (Swift Testing): restart, resend, monotonic single-generation, composite-identity, and many-restart uniqueness.

## ⚠️ Verification note
This is a **Swift-only** change. There is no Swift/Metal toolchain in the environment it was written in, so it is **compiled-untested locally** — the macOS CI Swift job validates compilation, and the change is contained (only `MessageEntry`'s id type + `appendEntries`; the view uses `entry.id` generically). Please confirm the Console no longer logs duplicate `ForEach` IDs after a BEAM restart with the Messages panel open (the ticket's manual check).

Closes #2353

🤖 Generated with [Claude Code](https://claude.com/claude-code)