### PR TITLE
perf(file-tree): one stat per entry in the walk + walk telemetry

### DIFF
--- a/lib/minga/project/file_tree.ex
+++ b/lib/minga/project/file_tree.ex
@@ -236,7 +236,20 @@ defmodule Minga.Project.FileTree do
   def ensure_entries(%__MODULE__{entries: entries} = tree) when is_list(entries), do: tree
 
   def ensure_entries(%__MODULE__{} = tree) do
-    %{tree | entries: tree.root |> walk(0, tree, []) |> filter_entries(tree)}
+    # Span only the actual filesystem walk (the memoized path above returns
+    # early), so `[:minga, :file_tree, :walk]` records real walk cost — its
+    # entry count and duration — for spotting large-repo overages (#2367).
+    entries =
+      Minga.Telemetry.span_with_stop_metadata(
+        [:minga, :file_tree, :walk],
+        %{root: tree.root},
+        fn ->
+          entries = tree.root |> walk(0, tree, []) |> filter_entries(tree)
+          {entries, %{entry_count: length(entries)}}
+        end
+      )
+
+    %{tree | entries: entries}
   end
 
   @doc "Refreshes the tree by rescanning the filesystem (clamps cursor)."
@@ -304,6 +317,12 @@ defmodule Minga.Project.FileTree do
   @spec invalidate_entries(t()) :: t()
   defp invalidate_entries(%__MODULE__{} = tree), do: %{tree | entries: nil}
 
+  # A child after a single stat pass: its name, absolute path, whether it is a
+  # directory (following symlinks, so a symlink-to-dir counts), and whether it
+  # is itself a symlink (so the walk shows it but never descends into it).
+  @typep stat_child ::
+           {name :: String.t(), full :: String.t(), dir? :: boolean(), symlink? :: boolean()}
+
   @spec walk(String.t(), non_neg_integer(), t(), [boolean()]) :: [entry()]
   defp walk(dir_path, depth, tree, parent_guides) do
     case File.ls(dir_path) do
@@ -312,17 +331,17 @@ defmodule Minga.Project.FileTree do
           names
           |> Enum.reject(&ignored?/1)
           |> maybe_filter_hidden(tree.show_hidden)
-          |> Enum.sort_by(fn name ->
-            full = Path.join(dir_path, name)
-            {if(File.dir?(full), do: 0, else: 1), String.downcase(name)}
+          |> Enum.map(&stat_child(dir_path, &1))
+          |> Enum.sort_by(fn {name, _full, dir?, _symlink?} ->
+            {if(dir?, do: 0, else: 1), String.downcase(name)}
           end)
 
         last_idx = length(sorted) - 1
 
         sorted
         |> Enum.with_index()
-        |> Enum.flat_map(fn {name, idx} ->
-          walk_entry(name, dir_path, depth, tree, parent_guides, idx == last_idx)
+        |> Enum.flat_map(fn {child, idx} ->
+          walk_entry(child, depth, tree, parent_guides, idx == last_idx)
         end)
 
       {:error, _} ->
@@ -330,22 +349,51 @@ defmodule Minga.Project.FileTree do
     end
   end
 
-  @spec walk_entry(String.t(), String.t(), non_neg_integer(), t(), [boolean()], boolean()) ::
-          [entry()]
-  defp walk_entry(name, dir_path, depth, tree, parent_guides, is_last) do
+  # Stats a child exactly once (plus a single follow-stat only for symlinks),
+  # replacing the previous `File.dir?` (sort) + `File.dir?` (walk_entry) +
+  # `File.lstat` (descend guard) per child.
+  @spec stat_child(String.t(), String.t()) :: stat_child()
+  defp stat_child(dir_path, name) do
     full = Path.join(dir_path, name)
-    is_dir = File.dir?(full)
+    {dir?, symlink?} = dir_and_symlink(full)
+    {name, full, dir?, symlink?}
+  end
 
+  # Resolves directory-ness (following symlinks) and symlink-ness with the
+  # fewest stats: one `File.lstat` settles real dirs and files; only an entry
+  # that is itself a symlink needs a second, following `File.stat` to learn
+  # whether its target is a directory.
+  @spec dir_and_symlink(String.t()) :: {dir? :: boolean(), symlink? :: boolean()}
+  defp dir_and_symlink(full) do
+    case File.lstat(full) do
+      {:ok, %File.Stat{type: :directory}} -> {true, false}
+      {:ok, %File.Stat{type: :symlink}} -> {symlink_target_dir?(full), true}
+      {:ok, %File.Stat{}} -> {false, false}
+      {:error, _} -> {false, false}
+    end
+  end
+
+  @spec symlink_target_dir?(String.t()) :: boolean()
+  defp symlink_target_dir?(full) do
+    case File.stat(full) do
+      {:ok, %File.Stat{type: :directory}} -> true
+      _ -> false
+    end
+  end
+
+  @spec walk_entry(stat_child(), non_neg_integer(), t(), [boolean()], boolean()) :: [entry()]
+  defp walk_entry({name, full, dir?, symlink?}, depth, tree, parent_guides, is_last) do
     entry = %{
       path: full,
       name: name,
-      dir?: is_dir,
+      dir?: dir?,
       depth: depth,
       last_child?: is_last,
       guides: parent_guides
     }
 
-    if is_dir and descend_into_directory?(tree, full) and not symlinked_directory?(full) do
+    # Show symlinked directories, but never descend into them (cycle safety).
+    if dir? and not symlink? and descend_into_directory?(tree, full) do
       # Children need to know: at this entry's depth, are there more siblings?
       # If this entry is NOT the last child, its depth column should draw │.
       child_guides = parent_guides ++ [not is_last]
@@ -375,14 +423,6 @@ defmodule Minga.Project.FileTree do
 
     entry.name |> String.downcase() |> String.contains?(needle) or
       relative_path |> String.downcase() |> String.contains?(needle)
-  end
-
-  @spec symlinked_directory?(String.t()) :: boolean()
-  defp symlinked_directory?(path) do
-    case File.lstat(path) do
-      {:ok, %File.Stat{type: :symlink}} -> true
-      _ -> false
-    end
   end
 
   @spec active_filter?(t()) :: boolean()

--- a/test/minga/project/file_tree_test.exs
+++ b/test/minga/project/file_tree_test.exs
@@ -327,4 +327,102 @@ defmodule Minga.Project.FileTreeTest do
       assert MapSet.member?(rerooted.expanded, Path.expand(next_root))
     end
   end
+
+  describe "symlinks" do
+    @tag :tmp_dir
+    test "a symlinked directory is shown as a directory but never descended", %{tmp_dir: tmp_dir} do
+      mkdir(Path.join(tmp_dir, "real"))
+      touch(Path.join(tmp_dir, "real/inside.txt"))
+      :ok = File.ln_s(Path.join(tmp_dir, "real"), Path.join(tmp_dir, "link"))
+
+      entries =
+        tmp_dir
+        |> FileTree.new()
+        |> expand_path(["link"])
+        |> FileTree.visible_entries()
+
+      link_entry = Enum.find(entries, &(&1.name == "link"))
+      # Shown as an expandable directory (target is a dir, following the link)...
+      assert link_entry.dir? == true
+      # ...but the target's children are never walked, even when expanded (cycle safety).
+      refute "inside.txt" in Enum.map(entries, & &1.name)
+
+      # The real directory still descends normally.
+      real_names =
+        tmp_dir |> FileTree.new() |> expand_path(["real"]) |> FileTree.visible_entries()
+
+      assert "inside.txt" in Enum.map(real_names, & &1.name)
+    end
+
+    @tag :tmp_dir
+    test "a symlink to a file is shown as a file", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, "target.txt"))
+      :ok = File.ln_s(Path.join(tmp_dir, "target.txt"), Path.join(tmp_dir, "alias.txt"))
+
+      alias_entry =
+        tmp_dir
+        |> FileTree.new()
+        |> FileTree.visible_entries()
+        |> Enum.find(&(&1.name == "alias.txt"))
+
+      assert alias_entry.dir? == false
+    end
+  end
+
+  describe "walk telemetry (#2367)" do
+    @tag :tmp_dir
+    test "emits a [:minga, :file_tree, :walk] span with the entry count", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, "a.txt"))
+      touch(Path.join(tmp_dir, "b.txt"))
+
+      ref = make_ref()
+      parent = self()
+      handler_id = {__MODULE__, ref}
+
+      :telemetry.attach(
+        handler_id,
+        [:minga, :file_tree, :walk, :stop],
+        fn _event, measurements, metadata, _ ->
+          send(parent, {ref, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      # Force a real walk (fresh tree has entries: nil).
+      tmp_dir |> FileTree.new() |> FileTree.visible_entries()
+
+      assert_receive {^ref, measurements, metadata}
+      assert is_integer(measurements.duration)
+      assert metadata.entry_count == 2
+      assert metadata.root == Path.expand(tmp_dir)
+    end
+
+    @tag :tmp_dir
+    test "does not span when entries are already memoized", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, "a.txt"))
+
+      ref = make_ref()
+      parent = self()
+      handler_id = {__MODULE__, ref}
+
+      :telemetry.attach(
+        handler_id,
+        [:minga, :file_tree, :walk, :stop],
+        fn _event, _m, _meta, _ -> send(parent, {ref, :walked}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      # First call walks (and memoizes entries); a second ensure_entries on the
+      # already-populated tree must not walk again.
+      walked = tmp_dir |> FileTree.new() |> FileTree.ensure_entries()
+      assert_receive {^ref, :walked}
+
+      FileTree.ensure_entries(walked)
+      refute_receive {^ref, :walked}
+    end
+  end
 end


### PR DESCRIPTION
Closes #2367 · part of epic #2350 (resolves the deferred file-tree slice of #2357 AC2).

## Summary

The file-tree walk stat'd each child **2–3 times**: `File.dir?` in the sort comparator (`file_tree.ex:317`), `File.dir?` again in `walk_entry` (`:337`), and `File.lstat` for the symlink/descend guard (`:382`). The walk runs synchronously on open, `reveal` (every file opened from the tree), refresh, and toggle, so the redundant syscalls show up as input latency in large repos — including the **cold first walk**, which no cache could help.

Now each child is stat'd **once** via `File.lstat` (capturing type + symlink-ness), with a single follow-`File.stat` only for the symlink minority (needed to tell whether a symlink points at a directory). Plus a `[:minga, :file_tree, :walk]` telemetry span so any residual large-repo cost is **measured** before building anything heavier.

## Why this (and not a cache/async)

This landed after four design rounds + adversarial review converged here:
- **Async `:file_tree` lane** — rejected: incompatible with synchronous click dispatch (`selected_entry.dir?`), didn't address the hot `reveal`/`refresh` paths.
- **Incremental expand/collapse splice** — rejected: only speeds the rare toggle, doesn't generalize to multi-ancestor `reveal` or watcher re-walks, and forces buffer-sync/authority coupling.
- **Per-directory listing cache** — rejected as premature: no measurement, the walk is thin by construction (`reveal`/open only walk the active file's ancestor path), and it carried a struct-vs-cache desync + Layer-0 purity hazard.

So: shave the walk (helps *every* path, including cold), measure, and let telemetry — not speculation — justify any caching later. Deferred (telemetry-gated): a struct-local watcher-invalidated `dir → listing` map is the first escalation if a real overage shows up.

## Acceptance criteria
1. ✅ One `File.lstat` per regular entry (reused by sort / `dir?` / descend guard); one follow-`stat` for symlinks; redundant `File.dir?` removed.
2. ✅ Behavior preserved — a symlink-to-dir is shown as an expandable directory but never descended (cycle-safe); sort/hidden/ignore unchanged.
3. ✅ `[:minga, :file_tree, :walk]` span records `entry_count` + duration, only on a real walk (not the memoized return).
4. ✅ No cache / splice / async built.

## Tests
- New: symlink-to-dir shown-but-not-descended, symlink-to-file shown as file, telemetry span fires with entry count, and memoized `ensure_entries` does **not** re-span.
- `mix test.llm`: green (one unrelated pre-existing `extension/lifecycle_contract` concurrency flake, passes on retry).
- `test/minga/project/` + file-tree command/builder suites: 183 pass. `mix format` / `mix credo --strict`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)