### PR TITLE
Fix project switch file picker root

### DIFF
--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -270,10 +270,10 @@ defmodule MingaEditor.UI.Picker.FileSource do
   defp git_status_annotation(_), do: nil
 
   @spec project_root(Context.t() | EditorState.t() | nil) :: String.t()
-  defp project_root(%Context{file_tree: %{project_root: root}}) when is_binary(root), do: root
-
   defp project_root(%Context{picker_ui: %{context: %{project_root: root}}}) when is_binary(root),
     do: root
+
+  defp project_root(%Context{file_tree: %{project_root: root}}) when is_binary(root), do: root
 
   defp project_root(%EditorState{} = state) do
     case EditorState.file_tree_state(state).project_root do

--- a/lib/minga_editor/ui/picker/project_source.ex
+++ b/lib/minga_editor/ui/picker/project_source.ex
@@ -8,7 +8,10 @@ defmodule MingaEditor.UI.Picker.ProjectSource do
 
   @behaviour MingaEditor.UI.Picker.Source
 
+  alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
+  alias MingaEditor.PickerUI
   alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.FileSource
   alias MingaEditor.UI.Picker.Item
 
   alias Minga.Project
@@ -37,12 +40,12 @@ defmodule MingaEditor.UI.Picker.ProjectSource do
   @impl true
   @spec on_select(Item.t(), term()) :: term()
   def on_select(%Item{id: root_path}, state) do
-    Project.switch(root_path)
+    expanded_root = Path.expand(root_path)
+    Project.switch(expanded_root)
 
-    # After switching project, open the file finder scoped to the new root.
-    # We use a pending_command pattern so the Editor dispatches it after
-    # the picker closes.
-    Map.put(state, :pending_command, :project_find_file)
+    state
+    |> FileTreeFreshness.update_project_root(expanded_root)
+    |> PickerUI.open(FileSource, %{project_root: expanded_root})
   catch
     :exit, _ -> state
   end

--- a/test/minga_editor/ui/picker/file_source_test.exs
+++ b/test/minga_editor/ui/picker/file_source_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.Picker, as: PickerState
   alias MingaEditor.UI.Picker
+  alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.FileSource
   alias MingaEditor.UI.Picker.Item
 
@@ -239,6 +240,32 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
     assert is_integer(hot_index)
     assert is_integer(cold_index)
     assert hot_index < cold_index
+  end
+
+  test "explicit picker project root overrides stale file tree root", %{tmp_dir: tmp_dir} do
+    stale_root = Path.join(tmp_dir, "stale_file_source_root")
+    selected_root = Path.join(tmp_dir, "selected_file_source_root")
+
+    File.mkdir_p!(stale_root)
+    File.mkdir_p!(selected_root)
+    File.write!(Path.join(stale_root, "stale.txt"), "stale")
+    File.write!(Path.join(selected_root, "target.txt"), "target")
+
+    ctx =
+      start_editor("stale",
+        file_path: Path.join(stale_root, "stale.txt"),
+        project_root: stale_root
+      )
+
+    picker_context =
+      ctx
+      |> editor_state()
+      |> Context.from_editor_state(%{project_root: selected_root})
+
+    ids = FileSource.candidates(picker_context) |> Enum.map(& &1.id)
+
+    assert "target.txt" in ids
+    refute "stale.txt" in ids
   end
 
   describe "lean candidates and enrich/1" do

--- a/test/minga_editor/ui/picker/project_source_test.exs
+++ b/test/minga_editor/ui/picker/project_source_test.exs
@@ -1,0 +1,102 @@
+defmodule MingaEditor.UI.Picker.ProjectSourceTest do
+  @moduledoc "Tests project picker selection behavior."
+
+  # Uses the global Minga.Project singleton and FileSource shells out for file discovery.
+  use Minga.Test.EditorCase, async: false
+
+  alias MingaEditor.Input.Picker, as: PickerInput
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.State.Picker, as: PickerState
+  alias MingaEditor.UI.Picker
+  alias MingaEditor.UI.Picker.FileSource
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.ProjectSource
+
+  @moduletag :tmp_dir
+
+  setup do
+    reset_global_project!()
+
+    on_exit(fn ->
+      reset_global_project!()
+    end)
+
+    :ok
+  end
+
+  test "selecting a project opens find file with the selected root, not the stale file tree root",
+       %{tmp_dir: tmp_dir} do
+    stale_root = Path.join(tmp_dir, "stale_root")
+    selected_root = Path.join(tmp_dir, "selected_root")
+
+    File.mkdir_p!(stale_root)
+    File.mkdir_p!(selected_root)
+    File.write!(Path.join(stale_root, "stale.txt"), "stale")
+    File.write!(Path.join(selected_root, "target.txt"), "target")
+
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(stale_root)
+    await_project_rebuild(stale_root)
+
+    ctx =
+      start_editor("stale",
+        file_path: Path.join(stale_root, "stale.txt"),
+        project_root: stale_root
+      )
+
+    state =
+      ctx
+      |> editor_state()
+      |> open_project_picker(selected_root)
+
+    assert {:handled, new_state} = PickerInput.handle_key(state, 13, 0)
+
+    assert {:picker,
+            %{
+              picker_ui: %{
+                context: %{project_root: ^selected_root},
+                picker: file_picker,
+                source: FileSource
+              }
+            }} = new_state.shell_state.modal
+
+    ids = Enum.map(file_picker.items, & &1.id)
+    assert "target.txt" in ids
+    refute "stale.txt" in ids
+    assert EditorState.file_tree_state(new_state).project_root == selected_root
+  end
+
+  defp open_project_picker(state, selected_root) do
+    picker =
+      [%Item{id: selected_root, label: Path.basename(selected_root), description: selected_root}]
+      |> Picker.new(title: ProjectSource.title(), max_visible: 10)
+
+    picker_state = %PickerState{
+      picker: picker,
+      source: ProjectSource,
+      restore: state.workspace.buffers.active_index,
+      layout: :centered
+    }
+
+    ModalOverlay.open(state, :picker, PickerPayload.new(picker_state))
+  end
+
+  defp reset_global_project! do
+    root = File.cwd!()
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(root)
+    await_project_rebuild(root)
+  end
+
+  defp await_project_rebuild(root) do
+    if Minga.Project.rebuilding?() do
+      assert_receive {:minga_event, :project_rebuilt,
+                      %Minga.Events.ProjectRebuiltEvent{root: ^root}},
+                     5_000
+    end
+
+    _ = :sys.get_state(Minga.Project)
+  end
+end


### PR DESCRIPTION
# TL;DR
Fixes the project picker flow so selecting a project immediately opens the file picker scoped to that selected project instead of scanning a stale editor root such as `/`.

## Context
When launching `Minga.app`, the editor can start with the file tree rooted at `/`. Pressing `SPC p p` correctly opens the project picker, but selecting a project previously queued `:project_find_file` after an async `Minga.Project.switch/1`. The file picker then resolved its root from stale editor file-tree state and could synchronously scan `/`, making the UI appear hung on the project picker.

## Changes
- Update `ProjectSource.on_select/2` to expand the selected root, switch `Minga.Project`, synchronize the editor file-tree root through `FileTreeFreshness.update_project_root/2`, and directly open `FileSource` with the selected project root in picker context.
- Remove the `pending_command: :project_find_file` hop for this flow so the selected project root is passed explicitly instead of being rediscovered from ambient editor state.
- Make `FileSource.project_root/1` prefer explicit picker context over ambient file-tree state, so caller-provided root context wins when both are present.
- Add regression coverage for both the full project-selection path and the lower-level FileSource context override.

## Verification
- `mix test.llm test/minga_editor/ui/picker/project_source_test.exs test/minga_editor/ui/picker/file_source_test.exs test/minga_editor/picker_ui_test.exs` passed, 20 tests.
- `mix compile --warnings-as-errors` passed.
- `make lint` completed with existing large-struct Credo warnings and no blocking exit.
- `make test.llm` was attempted after building native support. It failed once in `test/minga_editor/handlers/gui_action_handler_test.exs:103` with a `Minga.Project.root` timeout while global Project/file-tree tests were running concurrently. The failed test passed when rerun directly with `mix test.llm test/minga_editor/handlers/gui_action_handler_test.exs:103`.

## Notes for reviewers
The important invariant is that project switching still synchronizes editor/file-tree state. The explicit picker context is a narrow FileSource override, not a replacement for updating editor state.
