### PR TITLE
Preserve syntax highlights in folded rows

### DIFF
--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -103,6 +103,11 @@ defmodule MingaEditor.RenderModel.Window.Builder do
            compose_fp: non_neg_integer()
          }
 
+  @typep folded_source_ctx :: %{
+           line_byte_offsets: %{non_neg_integer() => non_neg_integer()},
+           highlight_segments_by_line: %{non_neg_integer() => [Highlight.styled_segment()]}
+         }
+
   @doc """
   Builds a `RenderWindow` for one editor window.
 
@@ -830,6 +835,20 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     line_byte_offsets =
       build_line_byte_offsets(lines, first_line, snapshot.first_line_byte_offset)
 
+    highlight_segments_by_line =
+      build_highlight_segments_by_line(
+        lines,
+        first_line,
+        visible_line_map,
+        line_byte_offsets,
+        ctx.highlight
+      )
+
+    source_ctx = %{
+      line_byte_offsets: line_byte_offsets,
+      highlight_segments_by_line: highlight_segments_by_line
+    }
+
     {entries, _counters} =
       Enum.map_reduce(visible_line_map, %{}, fn {buf_line, entry_type}, counters ->
         {visual_identity_index, counters} = next_visual_identity(buf_line, entry_type, counters)
@@ -841,7 +860,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
             lines,
             first_line,
             ctx,
-            line_byte_offsets,
+            source_ctx,
             visual_identity_index,
             retain_ctx
           )
@@ -857,6 +876,46 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     entries
   end
 
+  @spec build_highlight_segments_by_line(
+          [String.t()],
+          non_neg_integer(),
+          [DisplayMap.entry()],
+          %{non_neg_integer() => non_neg_integer()},
+          Highlight.t() | nil
+        ) :: %{non_neg_integer() => [Highlight.styled_segment()]}
+  defp build_highlight_segments_by_line(_lines, _first_line, _visible_line_map, _offsets, nil),
+    do: %{}
+
+  defp build_highlight_segments_by_line(
+         lines,
+         first_line,
+         visible_line_map,
+         line_byte_offsets,
+         %Highlight{} = hl
+       ) do
+    source_lines =
+      visible_line_map
+      |> Enum.map(&source_highlight_line/1)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+      |> Enum.map(fn buf_line ->
+        {buf_line,
+         {line_at(lines, buf_line, first_line), Map.get(line_byte_offsets, buf_line, 0)}}
+      end)
+      |> Enum.sort_by(fn {_buf_line, {_line_text, line_byte_offset}} -> line_byte_offset end)
+
+    source_lines
+    |> Enum.map(fn {_buf_line, line_with_offset} -> line_with_offset end)
+    |> then(&Highlight.styles_for_visible_lines(hl, &1))
+    |> then(fn highlight_segments -> Enum.zip(source_lines, highlight_segments) end)
+    |> Map.new(fn {{buf_line, _line_with_offset}, segments} -> {buf_line, segments} end)
+  end
+
+  @spec source_highlight_line(DisplayMap.entry()) :: non_neg_integer() | nil
+  defp source_highlight_line({buf_line, :normal}), do: buf_line
+  defp source_highlight_line({buf_line, {:fold_start, _hidden_count}}), do: buf_line
+  defp source_highlight_line(_entry), do: nil
+
   # Reuse only plain folded `:normal` rows; decoration-driven rows (folds,
   # virtual lines, blocks) recompose every frame to stay conservative (#2287).
   @spec build_visual_row_entry_retained(
@@ -865,7 +924,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
           [String.t()],
           non_neg_integer(),
           Context.t(),
-          %{non_neg_integer() => non_neg_integer()},
+          folded_source_ctx(),
           non_neg_integer(),
           retain_ctx()
         ) :: {Row.t(), non_neg_integer(), boolean()}
@@ -875,15 +934,16 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          lines,
          first_line,
          ctx,
-         line_byte_offsets,
+         source_ctx,
          index,
          retain_ctx
        ) do
     line_text = line_at(lines, buf_line, first_line)
+    hl_segments = Map.get(source_ctx.highlight_segments_by_line, buf_line)
     row_id = Row.stable_id(:normal, buf_line)
 
-    compose_or_reuse(retain_ctx, row_id, {:fold_normal, line_text}, fn ->
-      build_visual_row_entry(buf_line, :normal, lines, first_line, ctx, line_byte_offsets, index)
+    compose_or_reuse(retain_ctx, row_id, {:fold_normal, line_text, hl_segments}, fn ->
+      build_visual_row_entry(buf_line, :normal, lines, first_line, ctx, source_ctx, index)
     end)
   end
 
@@ -893,20 +953,11 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          lines,
          first_line,
          ctx,
-         line_byte_offsets,
+         source_ctx,
          index,
          retain_ctx
        ) do
-    row =
-      build_visual_row_entry(
-        buf_line,
-        entry_type,
-        lines,
-        first_line,
-        ctx,
-        line_byte_offsets,
-        index
-      )
+    row = build_visual_row_entry(buf_line, entry_type, lines, first_line, ctx, source_ctx, index)
 
     {row, row_input_hash(retain_ctx, {:fold_other, row.row_id, row.content_hash}), false}
   end
@@ -934,7 +985,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
           [String.t()],
           non_neg_integer(),
           Context.t(),
-          %{non_neg_integer() => non_neg_integer()},
+          folded_source_ctx(),
           non_neg_integer()
         ) :: Row.t()
   defp build_visual_row_entry(
@@ -943,12 +994,13 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          lines,
          first_line,
          ctx,
-         line_byte_offsets,
+         source_ctx,
          _index
        ) do
     line_text = line_at(lines, buf_line, first_line)
-    line_byte_offset = Map.get(line_byte_offsets, buf_line, 0)
-    {composed, spans} = compose_line(line_text, nil, ctx, buf_line, line_byte_offset)
+    line_byte_offset = Map.get(source_ctx.line_byte_offsets, buf_line, 0)
+    hl_segments = Map.get(source_ctx.highlight_segments_by_line, buf_line)
+    {composed, spans} = compose_line(line_text, hl_segments, ctx, buf_line, line_byte_offset)
 
     %Row{
       row_id: Row.stable_id(:normal, buf_line),
@@ -966,12 +1018,13 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          lines,
          first_line,
          ctx,
-         line_byte_offsets,
+         source_ctx,
          _index
        ) do
     line_text = line_at(lines, buf_line, first_line)
-    line_byte_offset = Map.get(line_byte_offsets, buf_line, 0)
-    {composed, spans} = compose_line(line_text, nil, ctx, buf_line, line_byte_offset)
+    line_byte_offset = Map.get(source_ctx.line_byte_offsets, buf_line, 0)
+    hl_segments = Map.get(source_ctx.highlight_segments_by_line, buf_line)
+    {composed, spans} = compose_line(line_text, hl_segments, ctx, buf_line, line_byte_offset)
     {composed, spans} = append_fold_summary(composed, spans, hidden_count, ctx)
 
     %Row{
@@ -990,7 +1043,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          _lines,
          _first_line,
          _ctx,
-         _line_byte_offsets,
+         _source_ctx,
          visual_identity_index
        ) do
     text = virtual_text_to_string(vt)
@@ -1014,7 +1067,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          _lines,
          _first_line,
          ctx,
-         _line_byte_offsets,
+         _source_ctx,
          visual_identity_index
        ) do
     # Block decorations render via callback; capture the rendered text using the same text width as the draw path.
@@ -1041,7 +1094,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
          _lines,
          _first_line,
          _ctx,
-         _line_byte_offsets,
+         _source_ctx,
          _index
        ) do
     hidden = FoldRegion.hidden_count(fold)

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -6,16 +6,19 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
   alias Minga.Core.Face
   alias Minga.Editing.Fold.Range, as: FoldRange
   alias Minga.Editing.Search.Match
+  alias Minga.Language.Highlight.Span, as: HighlightSpan
   alias MingaEditor.Layout
   alias MingaEditor.RenderModel.Window.Builder
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Scroll
   alias MingaEditor.Renderer.Context
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Highlighting
   alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
   alias MingaEditor.Window, as: EditorWindow
   alias MingaEditor.WindowTree
+  alias MingaEditor.UI.Highlight
   alias Minga.RenderModel.Window
   alias Minga.RenderModel.Window.Row
 
@@ -44,6 +47,17 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
   defp add_conceal(decs, start_pos, end_pos) do
     {_id, decs} = Decorations.add_conceal(decs, start_pos, end_pos, group: :test)
     decs
+  end
+
+  defp highlight_span(lines, line, start_col, width, capture_id) do
+    start_byte = Highlight.byte_offset_for_line(lines, line) + start_col
+    HighlightSpan.new(start_byte, start_byte + width, capture_id)
+  end
+
+  defp has_span?(%Row{spans: spans}, start_col, end_col) do
+    Enum.any?(spans, fn span ->
+      span.start_col == start_col and span.end_col == end_col and span.fg != 0
+    end)
   end
 
   defp build_window_model(state, ctx_overrides) do
@@ -311,6 +325,47 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       [fold_gutter] = Enum.filter(wf.window_model.gutter.entries, &(&1.buf_line == 0))
       assert fold_row.row_id == Row.stable_id(:fold_start, 0, 0, 2)
       assert fold_gutter.display_type == :fold_start
+    end
+
+    test "folded window rows preserve syntax highlight spans" do
+      content = "def folded\n  :ok\nend\nclass Visible\nend"
+      lines = String.split(content, "\n")
+      state = gui_state(content: content)
+      buffer = state.workspace.buffers.active
+
+      highlight =
+        state.theme
+        |> Highlight.from_theme()
+        |> Highlight.put_names(["keyword"])
+        |> Highlight.put_spans(1, [
+          highlight_span(lines, 0, 0, 3, 0),
+          highlight_span(lines, 3, 0, 5, 0)
+        ])
+
+      state =
+        EditorState.set_highlight(state, %Highlighting{highlights: %{buffer => highlight}})
+
+      window = Map.fetch!(state.workspace.windows.map, state.workspace.windows.active)
+      window = EditorWindow.set_fold_ranges(window, [FoldRange.new!(0, 2)])
+      window = EditorWindow.fold_at(window, 0)
+
+      windows =
+        Windows.set_map(
+          state.workspace.windows,
+          Map.put(state.workspace.windows.map, state.workspace.windows.active, window)
+        )
+
+      state = %{state | workspace: %{state.workspace | windows: windows}}
+
+      {[wf], _cursor, _state} = build_content(state)
+
+      [fold_row, visible_row | _rest] = wf.window_model.rows
+      assert fold_row.row_type == :fold_start
+      assert fold_row.text == "def folded ··· 2 lines"
+      assert has_span?(fold_row, 0, 3)
+
+      assert visible_row.text == "class Visible"
+      assert has_span?(visible_row, 0, 5)
     end
 
     test "decoration fold rows use stable decoration ids" do


### PR DESCRIPTION
# TL;DR
Folded editor rows now preserve tree-sitter syntax colors in the semantic window model. This fixes GUI buffers rendering as plain text when the fold-aware display map path is active.

## Context
The macOS GUI receives pre-resolved semantic window rows from `MingaEditor.RenderModel.Window.Builder`. The sequential and wrapped render paths already computed highlight segments before composing rows, but the folded path passed `nil` into line composition, which dropped syntax colors for visible rows whenever folds were active.

## Changes
- Compute syntax highlight segments for source-backed entries in the folded display-map path.
- Pass those segments into normal folded rows and fold-start rows before appending the fold summary suffix.
- Include folded-row highlight segments in the row-retention fingerprint so rows recompose when async tree-sitter highlights arrive or change.
- Add regression coverage for both a closed fold-start row and a normal row after the fold.

## Verification
- `mix test.debug test/minga_editor/render_model/window/builder_test.exs` ✅
- `mix compile --warnings-as-errors` ✅
- `make lint` ✅, exits 0 with existing large-struct Credo warnings
- `mix test.llm` ran; initial unrelated file-tree/gui action failures passed when rerun directly:
  - `mix test.llm test/minga_editor/handlers/gui_action_handler_test.exs:103 test/minga/project/file_tree_test.exs:403 test/minga/project/file_tree_test.exs:374`
  - `mix test.llm test/minga/project/file_tree_test.exs:403`

## Acceptance Criteria Addressed
- Folded semantic window rows retain syntax highlight spans ✅
- Fold-start rows keep syntax styling for the visible source text before the fold summary ✅
- Existing folded row identity and decoration row behavior remain intact ✅
