### PR TITLE
ci: cache Swift test harness build by source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,7 +477,20 @@ jobs:
 
       - run: mix deps.get
 
+      # Cache the compiled harness binary so it only rebuilds when its Swift
+      # sources (or the protocol generator that feeds the generated Swift) change.
+      # The binary lands in _build/test/lib/minga/priv, which the deps cache above
+      # also covers, but that key is not source-aware; this source-keyed cache lets
+      # the build step skip swiftc on a hit.
+      - name: Cache Swift test harness
+        id: harness-cache
+        uses: actions/cache@v4
+        with:
+          path: _build/test/lib/minga/priv/minga-test-harness
+          key: swift-harness-${{ runner.os }}-${{ hashFiles('macos/Sources/Protocol/**/*.swift', 'macos/Sources/Renderer/WindowContent.swift', 'macos/TestHarness/main.swift', 'mix/protocol_generator.ex') }}
+
       - name: Build Swift test harness
+        if: steps.harness-cache.outputs.cache-hit != 'true'
         run: mix swift.harness
 
       - name: Run BEAM-to-Swift protocol integration tests


### PR DESCRIPTION
## Summary

CI-gates the Swift test harness per #1040. The `swift-integration` job already builds the headless harness with `mix swift.harness` and runs the `:swift_harness`-tagged protocol round-trip tests (`gui_protocol_test.exs --include swift_harness`) on every PR, so the harness build and the tagged tests already block merges. The one acceptance criterion not yet met was caching the harness build so it only rebuilds when its Swift sources change; today it rebuilds unconditionally every run.

This adds a source-keyed `actions/cache` for the compiled harness binary and gates the build step on a cache miss.

## Changes

- New `Cache Swift test harness` step (id `harness-cache`) in the `swift-integration` job. Caches `_build/test/lib/minga/priv/minga-test-harness` keyed on the harness's Swift inputs (`macos/Sources/Protocol/**/*.swift`, `macos/Sources/Renderer/WindowContent.swift`, `macos/TestHarness/main.swift`) plus `mix/protocol_generator.ex` (the generator that produces the generated Swift the harness compiles in).
- The `Build Swift test harness` step now runs only when `steps.harness-cache.outputs.cache-hit != 'true'`, so `swiftc` is skipped on a cache hit.

On a cache hit the test step still compiles the Elixir suite (which runs the `:protocol_gen` compiler automatically via the `compilers:` list in `mix.exs`), so the Elixir-side generated protocol modules are always present; the restored binary already has the Swift protocol code compiled in.

## Acceptance criteria mapping

- Builds the harness in CI: existing `mix swift.harness` step (now cache-gated).
- Runs harness-dependent Swift tests: existing `mix test ... --include swift_harness` step.
- `:swift_harness` tag included in CI: `--include swift_harness` flips the default-excluded tag on.
- CI failure blocks the PR: both steps are in a required job.
- Harness build cached, rebuilds only when Swift sources change: this PR.

## Validation

- Parsed `.github/workflows/ci.yml` with a YAML loader (clean) and inspected the parsed `swift-integration` job to confirm step order, the `harness-cache` id, the cache-hit conditional, and the hashed key inputs.
- Confirmed the tag/test command against the source: `gui_protocol_test.exs` carries `@moduletag :swift_harness`, and it's the only test using that tag.
- `actionlint`/`yamllint` were not installable on this Linux host (no network for external binaries, no pyyaml), so linting beyond a YAML parse was not possible.

## What only CI can verify

This host is Linux, so the `macos-15` job cannot run here. CI must confirm: the cache key resolves and restores correctly, the build step is skipped on a hit and runs on a miss, and the harness binary path is captured/restored as expected on the macOS runner.

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)