### PR TITLE
fix(macos): make CommandDispatcher the single writer to FrameState

### DIFF
--- a/macos/AGENTS.md
+++ b/macos/AGENTS.md
@@ -170,6 +170,8 @@ Each SwiftUI chrome element follows the **State + View** pattern:
 
 This is the "dumb renderer" principle in practice: the view never decides what to show. It renders what the State says. The State never decides what data to hold. It stores what the BEAM sent.
 
+`FrameState` (the renderer's per-frame grid metadata) follows the same rule: **`CommandDispatcher` is the single writer; views only read.** Most `FrameState` fields come straight from protocol opcodes. The one carve-out is the cell-grid dimensions (`cols`/`rows`): they are genuinely view-derived because they depend on the NSView's pixel size and font metrics, which the BEAM cannot know. Even so, the view does not write them directly. View-originated updates funnel through `CommandDispatcher.applyViewportResize(newCols:newRows:)`, and the dirty flag is cleared by `CommandDispatcher.markRendered()` after the view consumes a frame. With one writer, every `FrameState` mutation has one place to add logging, ordering checks, or BEAM coordination, regardless of whether the trigger is a protocol opcode or an AppKit event. The view still sends the `sendReady`/`sendResize` event itself, since that is a view-to-BEAM event, not a state write.
+
 ### GUIState is the container, not a god object
 
 `GUIState` holds all sub-states as `let` properties (not a flat bag of fields). Each sub-state is independently observable. Adding a new chrome element means adding one State class, one View, and one `let` property on `GUIState`. No existing code changes.

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -335,6 +335,27 @@ final class CommandDispatcher {
         apply(command)
     }
 
+    // MARK: - View-driven FrameState mutations
+
+    /// Applies a view-derived viewport resize. The cell-grid dimensions depend on
+    /// the NSView's pixel size and font metrics, which the BEAM cannot know, so
+    /// the trigger is an AppKit event (font change, window resize, line-spacing
+    /// change) rather than a protocol opcode. Routing it here keeps
+    /// `CommandDispatcher` the single writer to `FrameState`: every mutation has
+    /// one place to add logging, ordering checks, or BEAM coordination. The view
+    /// still sends the `sendResize`/`sendReady` event itself, since that is a
+    /// view-to-BEAM event, not state.
+    func applyViewportResize(newCols: UInt16, newRows: UInt16) {
+        frameState.resize(newCols: newCols, newRows: newRows)
+    }
+
+    /// Clears the dirty flag after the view has consumed the current
+    /// `FrameState` for a render. The view drives the render but does not own the
+    /// state, so it calls this instead of writing `frameState.dirty` directly.
+    func markRendered() {
+        frameState.dirty = false
+    }
+
     /// Apply a single render command to the presented FrameState/GUIState. This
     /// is the single mutation path: called directly for out-of-band commands and
     /// replayed for every staged command at commit. It must NOT handle the frame

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -406,7 +406,7 @@ final class EditorNSView: MTKView {
         if coreTextRenderer.cursorAnimating {
             needsDisplay = true
         }
-        dispatcher.frameState.dirty = false
+        dispatcher.markRendered()
     }
 
     private func currentGridDimensions() -> GridDimensions {
@@ -448,7 +448,7 @@ final class EditorNSView: MTKView {
         let grid = gridDimensions(width: frame.width, height: frame.height, cellWidth: newCellW, cellHeight: newCellH)
 
         if grid.cols != dispatcher.frameState.cols || grid.effectiveRows != dispatcher.frameState.rows {
-            dispatcher.frameState.resize(newCols: grid.cols, newRows: grid.effectiveRows)
+            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.effectiveRows)
             encoder.sendResize(cols: grid.cols, rows: grid.rawRows)
         }
 
@@ -532,7 +532,7 @@ final class EditorNSView: MTKView {
         guard frame.width > 0, frame.height > 0 else { return }
 
         let grid = currentGridDimensions()
-        dispatcher.frameState.resize(newCols: grid.cols, newRows: grid.effectiveRows)
+        dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.effectiveRows)
 
         if readySent {
             encoder.sendResize(cols: grid.cols, rows: grid.rawRows)
@@ -669,12 +669,12 @@ final class EditorNSView: MTKView {
             // First real frame size: send the ready event with actual
             // window dimensions so the BEAM never sees wrong defaults.
             readySent = true
-            dispatcher.frameState.resize(newCols: grid.cols, newRows: grid.effectiveRows)
+            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.effectiveRows)
             encoder.sendReady(cols: grid.cols, rows: grid.rawRows)
             os_signpost(.event, log: startupLog, name: "ReadySent", "%{public}dx%{public}d", grid.cols, grid.rawRows)
             PortLogger.info("Window ready: \(grid.cols)x\(grid.rawRows) raw cells, \(grid.effectiveRows) effective rows (\(Int(newSize.width))x\(Int(newSize.height))pt)")
         } else if grid.cols != dispatcher.frameState.cols || grid.effectiveRows != dispatcher.frameState.rows {
-            dispatcher.frameState.resize(newCols: grid.cols, newRows: grid.effectiveRows)
+            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.effectiveRows)
             encoder.sendResize(cols: grid.cols, rows: grid.rawRows)
             PortLogger.info("Window resized: \(grid.cols)x\(grid.rawRows) raw cells, \(grid.effectiveRows) effective rows")
         }
@@ -748,7 +748,7 @@ final class EditorNSView: MTKView {
         let grid = currentGridDimensions()
 
         if grid.cols != dispatcher.frameState.cols || grid.effectiveRows != dispatcher.frameState.rows {
-            dispatcher.frameState.resize(newCols: grid.cols, newRows: grid.effectiveRows)
+            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.effectiveRows)
             encoder.sendResize(cols: grid.cols, rows: grid.rawRows)
         }
     }

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -71,6 +71,48 @@ struct CommandDispatcherRoutingTests {
         #expect(dispatcher.frameState.defaultBg == expected)
     }
 
+    // MARK: - View-driven FrameState mutations
+
+    @Test("applyViewportResize writes grid dimensions and marks dirty")
+    @MainActor func applyViewportResizeUpdatesGrid() {
+        let (dispatcher, _) = makeDispatcher()
+        // Clear the dirty flag set at init so we can assert the resize sets it.
+        dispatcher.markRendered()
+        #expect(dispatcher.frameState.dirty == false)
+
+        // A view-driven resize (e.g. font change) funnels through the dispatcher.
+        dispatcher.applyViewportResize(newCols: 120, newRows: 40)
+
+        #expect(dispatcher.frameState.cols == 120)
+        #expect(dispatcher.frameState.rows == 40)
+        #expect(dispatcher.frameState.dirty == true)
+    }
+
+    @Test("applyViewportResize is a no-op when dimensions are unchanged")
+    @MainActor func applyViewportResizeNoOp() {
+        let (dispatcher, _) = makeDispatcher()
+        // Dispatcher starts at 80x24 (see makeDispatcher).
+        dispatcher.markRendered()
+        #expect(dispatcher.frameState.dirty == false)
+
+        dispatcher.applyViewportResize(newCols: 80, newRows: 24)
+
+        #expect(dispatcher.frameState.cols == 80)
+        #expect(dispatcher.frameState.rows == 24)
+        #expect(dispatcher.frameState.dirty == false)
+    }
+
+    @Test("markRendered clears the dirty flag the view consumed")
+    @MainActor func markRenderedClearsDirty() {
+        let (dispatcher, _) = makeDispatcher()
+        dispatcher.applyViewportResize(newCols: 100, newRows: 30)
+        #expect(dispatcher.frameState.dirty == true)
+
+        dispatcher.markRendered()
+
+        #expect(dispatcher.frameState.dirty == false)
+    }
+
     // MARK: - GUI chrome routing
 
     @Test("guiTabBar updates tabBarState")


### PR DESCRIPTION
## What

`EditorNSView` wrote `dispatcher.frameState` directly in six places: clearing the dirty flag after each render, and resizing the grid on font change, display-configuration change, first-ready, window resize, and line-spacing change. This made the view a second writer to `FrameState`, which `macos/AGENTS.md` documents as `CommandDispatcher`-owned, read-only to views.

This PR funnels every view-originated mutation through `CommandDispatcher` so it is the single writer.

## Changes

- **`CommandDispatcher.applyViewportResize(newCols:newRows:)`** is now the only path that writes `frameState.cols`/`rows`. All five view-driven resize call sites route through it. The view keeps its own `encoder.sendResize`/`sendReady` call, since that is a view-to-BEAM event, not a state write.
- **`CommandDispatcher.markRendered()`** clears the dirty flag the view consumed. A reader of `EditorNSView.renderFrame()` can no longer tell `frameState.dirty` exists.
- **`macos/AGENTS.md`** now states the single-writer rule for `FrameState` explicitly, with a documented carve-out: cell-grid dimensions are genuinely view-derived (they depend on NSView pixel size and font metrics the BEAM cannot know), but the view still does not write them directly.
- **`CommandDispatcherTests.swift`** adds coverage for the resize path (dimensions written, dirty set, no-op when unchanged) and `markRendered` clearing dirty.

## Why

With two writers, a protocol-driven resize and a view-driven resize can both write `cols`/`rows` in the same instant and silently drop the loser. Closing the breach now is cheap (a handful of call sites); closing it once split-pane resize, multi-monitor DPI changes, or live font reload land is much more expensive, and the symptoms then read as flicker or off-by-one cursor placement rather than the architectural cause.

The fix is **not** "BEAM owns cols/rows" — grid dimensions stay view-derived. Only the writer changes: regardless of whether the trigger is a protocol opcode or an AppKit event, `CommandDispatcher` performs the mutation.

## Static analysis (authored on Linux, not compiled)

This is macOS Swift/AppKit code authored on a Linux host, so it was not built. Compensating static checks performed:

- `rg 'dispatcher\.frameState\.\w+\s*=[^=]'` and `rg 'dispatcher\.frameState\.resize'` over `EditorNSView.swift` both return zero matches — no assignments and no mutating-method calls remain in the view. Remaining `dispatcher.frameState.*` references are reads (comparisons, member access, indexing).
- The only `frameState.resize` / `frameState.dirty = false` writes in `macos/Sources` now live in `CommandDispatcher.swift`.
- New method signatures match the replaced calls exactly: `applyViewportResize(newCols: UInt16, newRows: UInt16)` is called with `grid.cols`/`grid.effectiveRows` (both `UInt16`), the same arguments the old `frameState.resize(newCols:newRows:)` received. `markRendered()` takes no args, replacing `frameState.dirty = false`.
- Access/isolation verified: `CommandDispatcher` is `@MainActor final class` with internal `var frameState`; the new methods are internal and mutate `frameState` exactly as the existing `apply(_:)` opcode handlers already do. The view's call sites were already `@MainActor`-isolated and already accessed `dispatcher.frameState` synchronously, so no new isolation boundary is crossed.
- Behavior preserved: each call site keeps its surrounding `if grid.cols != ... ` guard and its `sendResize`/`sendReady` event; `applyViewportResize` calls `frameState.resize(...)` with identical args and `resize` keeps its own no-op guard.

**Validation: needs macOS build (authored on Linux, not compiled).** Before merge, run `mix swift.build` and the Swift test suite on macOS, plus the manual smoke from the ticket (resize window, change font size, change line spacing; cursor and gutter stay aligned, no flicker).

## Scope note

`PreviewRegistry.swift` seeds `frameState` fields directly for SwiftUI previews; that is fixture code outside the runtime dual-writer path and the ticket's `EditorNSView.swift`-scoped AC, so it was intentionally left unchanged.

Closes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)