### PR TITLE
fix(buffer): reset decorations on replace_content

### DIFF
--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -2052,6 +2052,10 @@ defmodule Minga.Buffer.Process do
     |> push_undo_force_full(new_buf, undo_source)
     |> mark_dirty()
     |> clear_edits(source)
+    # Reset decorations so search highlights, diagnostics, and agent
+    # decorations don't stay anchored to text that no longer exists, matching
+    # replace_generated_content and accept_saved_content.
+    |> Map.put(:decorations, Decorations.new())
   end
 
   defp apply_operation(state, {:full, new_buf}, source, {:full, undo_source, :clear}) do

--- a/test/minga/buffer/process_test.exs
+++ b/test/minga/buffer/process_test.exs
@@ -945,6 +945,21 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.replace_content(pid, "goodbye")
       assert :reset_required = BufferProcess.consume_edit_deltas(pid, :test)
     end
+
+    test "replace_content clears stale decorations" do
+      {:ok, pid} = BufferProcess.start_link(content: "hello")
+
+      BufferProcess.add_block_decoration(pid, 0,
+        placement: :below,
+        render: fn _width -> [{"note", []}] end
+      )
+
+      assert BufferProcess.render_snapshot(pid, 0, 10).decorations.block_decorations != []
+
+      BufferProcess.replace_content(pid, "goodbye")
+
+      assert BufferProcess.render_snapshot(pid, 0, 10).decorations.block_decorations == []
+    end
   end
 
   # ── Per-consumer consume_edit_deltas ──────────────────────────────────────────────


### PR DESCRIPTION
## What

`Buffer.replace_content/3` routes through `apply_operation({:full, new_buf}, _, {:force_full, source, :clear})` in `lib/minga/buffer/process.ex`. That clause pushed undo, marked the buffer dirty, and cleared the edit log, but never reset decorations. Its two sibling full-replacement handlers (`replace_generated_content` and `accept_saved_content`) both set `decorations: Decorations.new()`.

As a result, search highlights, diagnostic underlines, and agent decorations stayed anchored to positions in content that no longer existed. This path is common, not exotic: agent file writes go through `Buffer.replace_content(pid, content, :agent)`.

## Fix

Reset decorations to `Decorations.new()` in the `:force_full ... :clear` clause, which is used exclusively by `replace_content`. This mirrors the sibling handlers and leaves `replace_generated_content` / `accept_saved_content` untouched.

## Test

Added a regression test in `test/minga/buffer/process_test.exs`: add a block decoration, call `replace_content`, assert `render_snapshot(...).decorations.block_decorations == []`. Verified it fails without the fix (stale `BlockDecoration` survives) and passes with it.

## Validation

- `mix compile --warnings-as-errors`: pass
- `mix format`: clean
- `mix credo --strict`: no findings on changed files
- `mix test test/minga/buffer/process_test.exs`: 104 passed

Closes #2293

🤖 Generated with [Claude Code](https://claude.com/claude-code)