### PR TITLE
fix(themes): make config-document keys visible via the standard @property capture

### DIFF
--- a/lib/minga_editor/ui/theme/astrodark.ex
+++ b/lib/minga_editor/ui/theme/astrodark.ex
@@ -134,7 +134,12 @@ defmodule MingaEditor.UI.Theme.AstroDark do
       "parameter" => [fg: @syn_text],
       "variable.member" => [fg: @syn_text],
       "field" => [fg: @syn_text],
-      "property" => [fg: @syn_text],
+      # Config/document keys (YAML, JSON, TOML, ...) capture as @property. Give
+      # it a visible accent so key-heavy files stay readable, matching how modern
+      # editors highlight keys. Code member access stays muted via @variable.member
+      # / @field above. Without this, @property would equal the editor foreground
+      # and keys would render as plain text.
+      "property" => [fg: @syn_purple],
       "tag.attribute" => [fg: @syn_orange],
       "attribute" => [fg: @syn_orange],
       "string.special.regex" => [fg: @syn_red],

--- a/lib/minga_editor/ui/theme/one_dark.ex
+++ b/lib/minga_editor/ui/theme/one_dark.ex
@@ -124,7 +124,11 @@ defmodule MingaEditor.UI.Theme.OneDark do
       "parameter" => [fg: @mono_1],
       "variable.member" => [fg: @mono_1],
       "field" => [fg: @mono_1],
-      "property" => [fg: @mono_1],
+      # Config/document keys (YAML, JSON, TOML, ...) capture as @property. Give
+      # it a visible accent so key-heavy files stay readable. Code member access
+      # stays muted via @variable.member / @field above. Without this, @property
+      # would equal the editor foreground and keys would render as plain text.
+      "property" => [fg: @hue_3],
       "attribute" => [fg: @hue_6],
       "tag.attribute" => [fg: @hue_6],
       "punctuation.bracket" => [fg: @mono_1],

--- a/lib/minga_editor/ui/theme/one_light.ex
+++ b/lib/minga_editor/ui/theme/one_light.ex
@@ -126,7 +126,11 @@ defmodule MingaEditor.UI.Theme.OneLight do
       "parameter" => [fg: @mono_1],
       "variable.member" => [fg: @mono_1],
       "field" => [fg: @mono_1],
-      "property" => [fg: @mono_1],
+      # Config/document keys (YAML, JSON, TOML, ...) capture as @property. Give
+      # it a visible accent so key-heavy files stay readable. Code member access
+      # stays muted via @variable.member / @field above. Without this, @property
+      # would equal the editor foreground and keys would render as plain text.
+      "property" => [fg: @hue_3],
       "attribute" => [fg: @hue_6],
       "tag.attribute" => [fg: @hue_6],
       "escape" => [fg: @hue_1],

--- a/priv/queries/erlang/highlights.scm
+++ b/priv/queries/erlang/highlights.scm
@@ -56,7 +56,7 @@
 (macro_call_expr name: (var) @constant)
 (macro_call_expr name: (var) @keyword.directive args: (_) )
 (macro_call_expr name: (atom) @keyword.directive)
-(record_field_name name: (atom) @property)
+(record_field_name name: (atom) @variable.member)
 (record_name name: (atom) @type)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -93,7 +93,7 @@
 ;; record
 (record_decl name: (atom) @type)
 (record_decl name: (macro_call_expr name: (var) @constant))
-(record_field name: (atom) @property)
+(record_field name: (atom) @variable.member)
 
 ;; type alias
 

--- a/priv/queries/ocaml/highlights.scm
+++ b/priv/queries/ocaml/highlights.scm
@@ -83,7 +83,11 @@
 ; Properties
 ;-----------
 
-[(label_name) (field_name) (instance_variable_name)] @property
+; Record fields and instance variables are code member access, so they use
+; @variable.member (matching nvim-treesitter). Labels are argument labels and
+; stay on @label.
+[(field_name) (instance_variable_name)] @variable.member
+(label_name) @label
 
 ; Functions
 ;----------

--- a/priv/queries/rust/highlights.scm
+++ b/priv/queries/rust/highlights.scm
@@ -2,7 +2,7 @@
 
 (type_identifier) @type
 (primitive_type) @type.builtin
-(field_identifier) @property
+(field_identifier) @variable.member
 
 ; Identifier conventions
 

--- a/priv/queries/scala/highlights.scm
+++ b/priv/queries/scala/highlights.scm
@@ -1,6 +1,6 @@
 ; CREDITS @stumash (stuart.mashaal@gmail.com)
 
-(field_expression field: (identifier) @property)
+(field_expression field: (identifier) @variable.member)
 (field_expression value: (identifier) @type
  (#match? @type "^[A-Z]"))
 

--- a/priv/queries/yaml/highlights.scm
+++ b/priv/queries/yaml/highlights.scm
@@ -31,6 +31,9 @@
   (reserved_directive)
 ] @keyword.directive
 
+; Mapping keys use the standard `@property` capture, the same convention
+; nvim-treesitter uses for config/document keys. Themes give `@property` a
+; visible accent so key-heavy YAML files stay readable.
 (block_mapping_pair
   key: (flow_node
     [

--- a/test/minga/parser/manager_test.exs
+++ b/test/minga/parser/manager_test.exs
@@ -117,6 +117,45 @@ defmodule Minga.Parser.ManagerTest do
     end
   end
 
+  describe "config-document key highlighting" do
+    test "captures YAML mapping keys as @property" do
+      server = start_parser_manager()
+      buffer_id = 42
+      # A mapping key, a quoted value, and a comment.
+      content = "name: \"minga\" # editor\n"
+
+      :ok = Manager.subscribe(server)
+      setup_buffer(server, buffer_id, "yaml", content)
+
+      captures = receive_captures(server, buffer_id, content)
+
+      # The mapping key resolves to the standard @property capture, matching
+      # nvim-treesitter's convention for config/document keys.
+      assert {"property", "name"} in captures
+      refute Enum.any?(captures, &match?({"property.yaml", _}, &1))
+
+      # And the quoted value still resolves through the string face.
+      assert {"string", "\"minga\""} in captures
+    end
+
+    test "captures Rust struct field access as @variable.member, not @property" do
+      server = start_parser_manager()
+      buffer_id = 43
+      # `cfg.name` is code field access; it should not collide with config keys.
+      content = "fn f(cfg: Config) { let _ = cfg.name; }\n"
+
+      :ok = Manager.subscribe(server)
+      setup_buffer(server, buffer_id, "rust", content)
+
+      captures = receive_captures(server, buffer_id, content)
+
+      # Code field access uses @variable.member (matches nvim-treesitter), so it
+      # stays distinct from config-document keys that now own @property.
+      assert {"variable.member", "name"} in captures
+      refute {"property", "name"} in captures
+    end
+  end
+
   @spec replacement_delta(String.t(), String.t(), String.t()) ::
           Minga.Parser.Protocol.edit_delta()
   defp replacement_delta(content, old_text, new_text) do
@@ -138,6 +177,21 @@ defmodule Minga.Parser.ManagerTest do
       new_end_position: new_end_position,
       inserted_text: new_text
     }
+  end
+
+  # Waits for the highlight broadcast for `buffer_id` and returns a list of
+  # `{capture_name, captured_text}` tuples for the parsed `content`.
+  defp receive_captures(_server, buffer_id, content) do
+    assert_receive {:minga_highlight, {:highlight_names, ^buffer_id, names}}, 2_000
+    assert_receive {:minga_highlight, {:highlight_spans, ^buffer_id, _version, spans}}, 2_000
+
+    names = List.to_tuple(names)
+
+    Enum.map(spans, fn span ->
+      name = elem(names, span.capture_id)
+      text = binary_part(content, span.start_byte, span.end_byte - span.start_byte)
+      {name, text}
+    end)
   end
 
   defp setup_buffer(server, buffer_id, content) do

--- a/test/minga_editor/ui/highlight_test.exs
+++ b/test/minga_editor/ui/highlight_test.exs
@@ -407,6 +407,39 @@ defmodule Minga.HighlightTest do
 
       assert dotted.fg != nil
     end
+
+    test "renders config-document keys (@property) distinctly from plain text and strings" do
+      theme = MingaEditor.UI.Theme.get!(:astrodark)
+
+      # Render `key: "value"` the way the YAML query captures it:
+      #   `key`     -> @property
+      #   `"value"` -> @string
+      line = ~s(key: "value")
+      key_span = %{start_byte: 0, end_byte: 3, capture_id: 0}
+      value_span = %{start_byte: 5, end_byte: 12, capture_id: 1}
+
+      hl =
+        Highlight.from_theme(theme)
+        |> Highlight.put_names(["property", "string"])
+        |> Highlight.put_spans(1, [key_span, value_span])
+
+      [{"key", key_face}, {": ", _gap}, {~s("value"), value_face}] =
+        Highlight.styles_for_line(hl, line, 0)
+
+      registry = hl.face_registry
+      default_fg = MingaEditor.UI.Face.Registry.style_for(registry, "default").fg
+      string_fg = MingaEditor.UI.Face.Registry.style_for(registry, "string").fg
+
+      # The key is visibly distinct from plain editor foreground (the bug):
+      # in astrodark, @property is a real accent, not the muted editor fg.
+      assert key_face.fg != nil
+      assert key_face.fg != default_fg
+
+      # Quoted values still resolve through the string face, and remain
+      # visibly distinct from keys.
+      assert value_face.fg == string_fg
+      assert value_face.fg != key_face.fg
+    end
   end
 
   describe "retheme/2" do

--- a/test/minga_editor/ui/theme/astrodark_test.exs
+++ b/test/minga_editor/ui/theme/astrodark_test.exs
@@ -63,9 +63,31 @@ defmodule MingaEditor.UI.Theme.AstroDarkTest do
     assert theme.syntax["comment"] == [fg: p.syn_comment, italic: true]
     assert theme.syntax["operator"] == [fg: p.syn_text]
     assert theme.syntax["variable.parameter"] == [fg: p.syn_text]
-    assert theme.syntax["property"] == [fg: p.syn_text]
+    assert theme.syntax["property"] == [fg: p.syn_purple]
     assert theme.syntax["field"] == [fg: p.syn_text]
     assert theme.syntax["string.regex"] == [fg: p.syn_red]
+  end
+
+  test "gives config-document keys (@property) a visible accent distinct from editor fg" do
+    theme = Theme.get!(:astrodark)
+    p = @palette
+
+    # Config/document keys (YAML, JSON, TOML, ...) capture as @property and get a
+    # visible accent so key-heavy files stay readable, matching nvim-treesitter.
+    assert theme.syntax["property"] == [fg: p.syn_purple]
+
+    # The accent must differ from the editor's default foreground (@syn_text);
+    # otherwise keys would render as plain text (the bug we fixed).
+    refute theme.syntax["property"] == [fg: p.syn_text]
+    assert p.syn_purple != p.syn_text
+
+    # Code member access stays muted on the editor foreground, so we did not
+    # broaden scope to recoloring struct/field access in code.
+    assert theme.syntax["variable.member"] == [fg: p.syn_text]
+    assert theme.syntax["field"] == [fg: p.syn_text]
+
+    # The legacy YAML-specific capture no longer exists.
+    refute Map.has_key?(theme.syntax, "property.yaml")
   end
 
   describe "icon_color/2" do

--- a/test/minga_editor/ui/theme/one_dark_test.exs
+++ b/test/minga_editor/ui/theme/one_dark_test.exs
@@ -52,7 +52,11 @@ defmodule MingaEditor.UI.Theme.OneDarkTest do
     assert theme.syntax["variable"] == [fg: p.hue_5]
     assert theme.syntax["variable.parameter"] == [fg: p.mono_1]
     assert theme.syntax["parameter"] == [fg: p.mono_1]
-    assert theme.syntax["property"] == [fg: p.mono_1]
+    # Config/document keys (@property) get a visible accent distinct from the
+    # editor foreground (mono_1); code member access (@field/@variable.member)
+    # stays muted.
+    assert theme.syntax["property"] == [fg: p.hue_3]
+    refute theme.syntax["property"] == [fg: p.mono_1]
     assert theme.syntax["field"] == [fg: p.mono_1]
     assert theme.syntax["string.regex"] == [fg: p.hue_1]
     assert theme.syntax["string.special.regex"] == [fg: p.hue_1]

--- a/test/minga_editor/ui/theme/one_light_test.exs
+++ b/test/minga_editor/ui/theme/one_light_test.exs
@@ -51,7 +51,11 @@ defmodule MingaEditor.UI.Theme.OneLightTest do
     assert theme.syntax["variable"] == [fg: p.hue_5]
     assert theme.syntax["variable.parameter"] == [fg: p.mono_1]
     assert theme.syntax["parameter"] == [fg: p.mono_1]
-    assert theme.syntax["property"] == [fg: p.mono_1]
+    # Config/document keys (@property) get a visible accent distinct from the
+    # editor foreground (mono_1); code member access (@field/@variable.member)
+    # stays muted.
+    assert theme.syntax["property"] == [fg: p.hue_3]
+    refute theme.syntax["property"] == [fg: p.mono_1]
     assert theme.syntax["field"] == [fg: p.mono_1]
     assert theme.syntax["string.regex"] == [fg: p.hue_1]
     assert theme.syntax["string.special.regex"] == [fg: p.hue_1]


### PR DESCRIPTION
## What

Make config/document keys (YAML, JSON, TOML, etc.) visibly highlighted the way modern editors do it, via the standard `@property` capture, and align code field/member-access captures to `@variable.member` to match nvim-treesitter.

Closes #2359

## Why

Config/document keys capture as `@property`, but several dark themes mapped `@property` to the editor's default foreground. Because those documents are mostly keys, files rendered almost unhighlighted:

- AstroDark mapped `property => @syn_text`, which is the editor foreground `@syn_text`. YAML keys rendered as plain text.
- OneDark and OneLight had the same `property => mono_1` collision (mono_1 is their editor fg).

The earlier version of this PR forked YAML onto a per-language `@property.yaml` capture. This reworks it to match nvim-treesitter's convention instead: keep keys on the standard `@property` and theme `@property` visibly. nvim reserves `@property` for config/document keys and uses `@variable.member` for code struct/field access, so we split our overloaded captures the same way before recoloring.

## Changes

**Queries**
- `priv/queries/yaml/highlights.scm`: revert the 4 `@property.yaml` key captures back to `@property`.
- Reclassify code field/member access `@property` -> `@variable.member` to match nvim-treesitter, verified against each language's upstream `highlights.scm`:
  - `rust` (`field_identifier`), `scala` (`field_expression field:`), `erlang` (`record_field_name`, `record_field`), `ocaml` (`field_name`/`instance_variable_name`; `label_name` now `@label`, matching nvim).
- Kept as `@property` where nvim-treesitter also keeps it (config/document keys or declarations, not member access): `c`, `cpp` (`field_initializer`), `go` (blanket `field_identifier`), `php_only` (`property_element` declaration), `dart` (`assignable_selector`), `lua` (table-key `field`).

**Themes**
- `astrodark.ex`: `property` -> `@syn_purple` (was the editor-fg `@syn_text`).
- `one_dark.ex` / `one_light.ex`: `property` -> `@hue_3` (was the editor-fg `mono_1`).
- `builder.ex`: drop the added `property.yaml` style.
- Catppuccin and Doom One already mapped `property` to a distinct color, so they're unchanged.
- `variable.member` / `field` left as each theme already had them, so code field access is not recolored.

**Tests**
- YAML mapping key resolves to `@property` (not `property.yaml`) and to a fg distinct from the editor default fg in AstroDark.
- A Rust struct field resolves to `@variable.member`.
- Quoted YAML values still resolve through `@string`.
- OneDark/OneLight theme tests updated for the new visible `property` accent.

## Validation

- `zig build` + `mix native.build.support` (parser binary)
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` (changed files clean)
- `mix test test/minga/parser/manager_test.exs test/minga_editor/ui/highlight_test.exs test/minga_editor/ui/theme/` -> all pass
- Empirical: parsing real YAML through the parser captures every key as `@property`; in AstroDark `@property` resolves to `0xDD97F1` (purple), distinct from the `0xADB0BB` editor foreground, while `@variable.member` stays muted at `0xADB0BB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)