### PR TITLE
fix(editor): include EOL newline in inner-delimiter text objects

### DIFF
--- a/lib/minga/editing/text_object.ex
+++ b/lib/minga/editing/text_object.ex
@@ -278,6 +278,10 @@ defmodule Minga.Editing.TextObject do
         case {start_pos, end_pos} do
           {nil, _} -> nil
           {_, nil} -> nil
+          # An empty pair (e.g. `()`) advances the start past the retreated end,
+          # producing an inverted range. There is no inner content, so report no
+          # range; `ci(` still enters insert via the mode transition.
+          {s, e} when s > e -> nil
           {s, e} -> {s, e}
         end
     end
@@ -1512,15 +1516,23 @@ defmodule Minga.Editing.TextObject do
     text = Readable.line_at(buffer, line) || ""
     next_byte = Unicode.next_grapheme_byte_offset(text, col)
 
-    if next_byte > col and next_byte < byte_size(text) do
-      {line, next_byte}
-    else
-      next_line = line + 1
+    cond do
+      next_byte > col and next_byte < byte_size(text) ->
+        {line, next_byte}
 
-      case Readable.line_at(buffer, next_line) do
-        nil -> nil
-        _ -> {next_line, 0}
-      end
+      # Advanced past the last grapheme on the line. When a following line
+      # exists, the end-of-line column is the newline position, so return it
+      # rather than skipping to the next line. This keeps the trailing newline
+      # inside inner ranges when the open delimiter sits at end of line.
+      next_byte > col and next_byte == byte_size(text) and
+          Readable.line_at(buffer, line + 1) != nil ->
+        {line, byte_size(text)}
+
+      true ->
+        case Readable.line_at(buffer, line + 1) do
+          nil -> nil
+          _ -> {line + 1, 0}
+        end
     end
   end
 

--- a/lib/minga/editing/text_object.ex
+++ b/lib/minga/editing/text_object.ex
@@ -1515,24 +1515,15 @@ defmodule Minga.Editing.TextObject do
   defp advance_position(buffer, {line, col}) do
     text = Readable.line_at(buffer, line) || ""
     next_byte = Unicode.next_grapheme_byte_offset(text, col)
+    next_line = Readable.line_at(buffer, line + 1)
 
-    cond do
-      next_byte > col and next_byte < byte_size(text) ->
-        {line, next_byte}
-
-      # Advanced past the last grapheme on the line. When a following line
-      # exists, the end-of-line column is the newline position, so return it
-      # rather than skipping to the next line. This keeps the trailing newline
-      # inside inner ranges when the open delimiter sits at end of line.
-      next_byte > col and next_byte == byte_size(text) and
-          Readable.line_at(buffer, line + 1) != nil ->
-        {line, byte_size(text)}
-
-      true ->
-        case Readable.line_at(buffer, line + 1) do
-          nil -> nil
-          _ -> {line + 1, 0}
-        end
+    if next_byte > col and (next_byte < byte_size(text) or next_line != nil) do
+      {line, next_byte}
+    else
+      case next_line do
+        nil -> nil
+        _ -> {line + 1, 0}
+      end
     end
   end
 

--- a/test/minga/editing/text_object_test.exs
+++ b/test/minga/editing/text_object_test.exs
@@ -210,25 +210,16 @@ defmodule Minga.Editing.TextObjectTest do
     end
 
     test "handles empty parens" do
-      # Cursor between the delimiters: there is no inner content, so the range
-      # is nil rather than an inverted range. `ci(` still enters insert via the
-      # mode transition, matching vim's `ci(` on an empty pair.
       assert nil == TextObject.inner_parens(buf("()"), {0, 1}, "(", ")")
       assert nil == TextObject.inner_parens(buf("ab()"), {0, 3}, "(", ")")
     end
 
     test "includes the newline after an open delimiter at end of line" do
-      # `foo(` ends with the open paren, so the inner range starts at the
-      # newline ({0,4}) instead of skipping to the next line. Deleting this
-      # range removes the trailing newline after `(`, matching vim's `di(`,
-      # which leaves `foo(\n)`.
       b = buf("foo(\nbar\n)")
       assert {{0, 4}, {1, 2}} = TextObject.inner_parens(b, {1, 1}, "(", ")")
     end
 
     test "reports no inner range for an empty pair whose open delimiter is at EOL" do
-      # `x(` then a line with just `)`. There is no inner content between the
-      # delimiters, so the range is nil and `di(` leaves the buffer untouched.
       assert nil == TextObject.inner_parens(buf("x(\n)"), {0, 2}, "(", ")")
     end
 
@@ -239,11 +230,6 @@ defmodule Minga.Editing.TextObjectTest do
 
     test "works across multiple lines" do
       b = buf("foo(\n  bar\n)")
-      # Line 0: "foo(" — `(` is at {0,3} and is the last char on its line
-      # Line 1: "  bar" — 5 chars (indices 0-4)
-      # Line 2: ")"     — `)` is at {2,0}
-      # inner start: advance from {0,3} → {0,4} (the newline after the open `(`)
-      # inner end: retreat from {2,0} → {1,4} (last char of "  bar")
       result = TextObject.inner_parens(b, {1, 2}, "(", ")")
       assert {{0, 4}, {1, 4}} = result
     end

--- a/test/minga/editing/text_object_test.exs
+++ b/test/minga/editing/text_object_test.exs
@@ -210,21 +210,42 @@ defmodule Minga.Editing.TextObjectTest do
     end
 
     test "handles empty parens" do
-      b = buf("()")
-      result = TextObject.inner_parens(b, {0, 0}, "(", ")")
-      # inner content is empty — start is after open, end is before close
-      assert nil == result
+      # Cursor between the delimiters: there is no inner content, so the range
+      # is nil rather than an inverted range. `ci(` still enters insert via the
+      # mode transition, matching vim's `ci(` on an empty pair.
+      assert nil == TextObject.inner_parens(buf("()"), {0, 1}, "(", ")")
+      assert nil == TextObject.inner_parens(buf("ab()"), {0, 3}, "(", ")")
+    end
+
+    test "includes the newline after an open delimiter at end of line" do
+      # `foo(` ends with the open paren, so the inner range starts at the
+      # newline ({0,4}) instead of skipping to the next line. Deleting this
+      # range removes the trailing newline after `(`, matching vim's `di(`,
+      # which leaves `foo(\n)`.
+      b = buf("foo(\nbar\n)")
+      assert {{0, 4}, {1, 2}} = TextObject.inner_parens(b, {1, 1}, "(", ")")
+    end
+
+    test "reports no inner range for an empty pair whose open delimiter is at EOL" do
+      # `x(` then a line with just `)`. There is no inner content between the
+      # delimiters, so the range is nil and `di(` leaves the buffer untouched.
+      assert nil == TextObject.inner_parens(buf("x(\n)"), {0, 2}, "(", ")")
+    end
+
+    test "leaves a plain single-line pair unchanged" do
+      assert {{0, 1}, {0, 1}} = TextObject.inner_parens(buf("(x)"), {0, 1}, "(", ")")
+      assert {{0, 3}, {0, 4}} = TextObject.inner_parens(buf("ab(cd)"), {0, 4}, "(", ")")
     end
 
     test "works across multiple lines" do
       b = buf("foo(\n  bar\n)")
-      # Line 0: "foo(" — `(` is at {0,3}
+      # Line 0: "foo(" — `(` is at {0,3} and is the last char on its line
       # Line 1: "  bar" — 5 chars (indices 0-4)
       # Line 2: ")"     — `)` is at {2,0}
-      # inner start: advance from {0,3} → {1,0} (start of next line)
+      # inner start: advance from {0,3} → {0,4} (the newline after the open `(`)
       # inner end: retreat from {2,0} → {1,4} (last char of "  bar")
       result = TextObject.inner_parens(b, {1, 2}, "(", ")")
-      assert {{1, 0}, {1, 4}} = result
+      assert {{0, 4}, {1, 4}} = result
     end
 
     test "ignores escaped delimiters" do


### PR DESCRIPTION
## What

`di(` / `ci(` / `yi(` on a multi-line delimiter pair whose opening delimiter is the last character of its line left a stray blank line. Before: `foo(\nbar\n)` + `di(` produced `foo(\n\n)`. After: it produces `foo(\n)`, matching nvim.

## Cause

`advance_position/2` computed the inner-range start with `next_byte < byte_size(text)`. When the open delimiter is the last grapheme on its line, `next_byte == byte_size(text)`, so the check failed and it fell through to `{line + 1, 0}`, skipping past the newline that immediately follows the delimiter.

## Fix

- `advance_position/2` now returns `{line, byte_size(text)}` (the end-of-line newline position) when the advance lands at end of line and a following line exists. Single-line cases never hit this branch, so they are unchanged.
- `inner_parens/4` reports `nil` for an empty pair (e.g. `()` with the cursor inside) instead of an inverted range. This stops `di()` / `yi()` from deleting/yanking the delimiters, and `ci()` still enters insert because the operator drives the mode transition.

## Verification

Confirmed every case against nvim (`di(`): multi-line open-at-EOL → `foo(\n)`, `(x)` → `()`, `ab(cd)` → `ab()`, empty `ab()` → unchanged, empty pair at EOL `x(\n)` → unchanged.

## Tests

Updated the existing multi-line assertion (it encoded the bug) and added regression tests covering: open delimiter at EOL (multi-line), empty pair, empty pair at EOL, and a plain single-line pair.

Validation: `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` (no new findings), and the text-object/operator/conformance test files all pass.

Closes #2296

🤖 Generated with [Claude Code](https://claude.com/claude-code)