### PR TITLE
ci(zig): guard tree-sitter queries against their grammars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,9 @@ jobs:
       - name: Run Zig tests
         run: cd zig && zig build test
 
+      - name: Check tree-sitter queries compile against grammars
+        run: cd zig && zig build query-check
+
   test-go-tui:
     name: Test (Go TUI)
     runs-on: ubuntu-latest

--- a/priv/queries/gleam/highlights.scm
+++ b/priv/queries/gleam/highlights.scm
@@ -106,7 +106,8 @@
 (string) @string
 
 ; Bit Strings
-(bit_array_segment) @string.special
+; This vendored grammar names the node `bit_string_segment`, not `bit_array_segment`
+(bit_string_segment) @string.special
 
 ; Numbers
 (integer) @number

--- a/priv/queries/kotlin/highlights.scm
+++ b/priv/queries/kotlin/highlights.scm
@@ -177,7 +177,8 @@
 ] @number
 
 [
-  (null_literal)
+  ; `null` is an anonymous keyword in this grammar, not a `null_literal` node
+  "null"
   ; should be highlighted the same as booleans
   (boolean_literal)
 ] @boolean
@@ -347,7 +348,7 @@
   "as"
   "as?"
   ".."
-  "..<"
+  ; `..<` (rangeUntil) is not a token in this vendored grammar
   "->"
 ] @operator
 

--- a/priv/queries/make/highlights.scm
+++ b/priv/queries/make/highlights.scm
@@ -165,7 +165,7 @@
     "eval"
     "file"
     "value"
-    "let"
+    ; `let` is not a recognized keyword token in this vendored make grammar
   ] @function.builtin)
 
 "\\" @punctuation.special

--- a/priv/queries/protobuf/indents.scm
+++ b/priv/queries/protobuf/indents.scm
@@ -1,9 +1,8 @@
 [
   (message_body)
   (enum_body)
-  (oneof_body)
-  (service_body)
-  (rpc_body)
+  ; This vendored grammar has no `oneof_body`/`service_body`/`rpc_body` wrapper
+  ; nodes; those constructs hold their members as inline children instead.
   (block_lit)
 ] @indent
 

--- a/priv/queries/protobuf/indents.scm
+++ b/priv/queries/protobuf/indents.scm
@@ -2,7 +2,11 @@
   (message_body)
   (enum_body)
   ; This vendored grammar has no `oneof_body`/`service_body`/`rpc_body` wrapper
-  ; nodes; those constructs hold their members as inline children instead.
+  ; nodes; `service`, `oneof`, and `rpc` inline their `{ ... }` block directly,
+  ; so capture those parent nodes to indent their contents.
+  (service)
+  (oneof)
+  (rpc)
   (block_lit)
 ] @indent
 

--- a/priv/queries/protobuf/textobjects.scm
+++ b/priv/queries/protobuf/textobjects.scm
@@ -1,6 +1,8 @@
 (message (message_body) @class.inside) @class.around
 (enum (enum_body) @class.inside) @class.around
-(service (service_body) @class.inside) @class.around
+; This vendored grammar has no `service_body` node; `service` holds its members
+; inline, so only the outer `service` node is available for the textobject.
+(service) @class.around
 
 (rpc (message_or_enum_type) @parameter.inside) @function.inside
 (rpc (message_or_enum_type) @parameter.around) @function.around

--- a/priv/queries/xml/injections.scm
+++ b/priv/queries/xml/injections.scm
@@ -1,2 +1,2 @@
-((comment) @injection.content
+((Comment) @injection.content
  (#set! injection.language "comment"))

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -172,6 +172,31 @@ pub fn build(b: *std.Build) void {
     const run_parser_tests = b.addRunArtifact(parser_tests);
     test_step.dependOn(&run_parser_tests.step);
 
+    // ── Query/grammar compile guard ──────────────────────────────────────
+    // Dedicated, explicitly-named step that compiles every shipped tree-sitter
+    // query against its vendored grammar and fails on the first that does not
+    // compile. This catches "silent drift": a grammar bump that renames or
+    // removes a node makes `ts_query_new` return null at runtime, which only
+    // logs a warning and yields no highlights. `zig build query-check` (and
+    // CI) turn that into a hard failure. The same test also runs under
+    // `zig build test`; this step lets CI surface it by name.
+    const query_check_step = b.step("query-check", "Compile every shipped query against its grammar");
+    const query_check_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/parser_main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+        .filters = &.{"query guard:"},
+    });
+    query_check_tests.root_module.addIncludePath(b.path("vendor/tree-sitter/include"));
+    query_check_tests.root_module.link_libc = true;
+    query_check_tests.root_module.addCSourceFile(.{ .file = b.path("src/regex_sizeof.c"), .flags = &.{"-std=c11"} });
+    query_check_tests.root_module.linkLibrary(ts_lib);
+    for (grammar_libs) |gl| query_check_tests.root_module.linkLibrary(gl);
+    const run_query_check = b.addRunArtifact(query_check_tests);
+    query_check_step.dependOn(&run_query_check.step);
+
     const hook_runner_tests = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/hook_runner_main.zig"),

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -3172,3 +3172,76 @@ test "highlighter: collectSymbols honors tags query predicates" {
     try std.testing.expectEqual(@as(usize, 1), symbols.len);
     try std.testing.expectEqualStrings("Real", symbols[0].name);
 }
+
+// ── Query/grammar compile guard ────────────────────────────────────────────
+//
+// CI guard: every shipped query must compile against its vendored grammar.
+//
+// tree-sitter's `ts_query_new` returns null (not an error code we surface) when
+// a query references a node type that does not exist in the grammar. In the
+// running editor this only logs a warning and yields no highlights for that
+// language. A grammar bump that renames or removes a node therefore ships
+// "silently broken" highlighting that no other test catches.
+//
+// This test compiles every `(grammar, query_type)` pair in `builtin_grammars`
+// against the actual linked grammar and fails if any pair does not compile,
+// printing the language, query type, byte offset, and tree-sitter error type.
+// It runs as part of `zig build test`.
+
+test "query guard: every shipped query compiles against its grammar" {
+    const QueryKind = struct {
+        label: []const u8,
+        source: ?[]const u8,
+    };
+
+    var failures: usize = 0;
+
+    inline for (builtin_grammars) |entry| {
+        if (entry.func()) |lang| {
+            const kinds = [_]QueryKind{
+                .{ .label = "highlights", .source = entry.query },
+                .{ .label = "injections", .source = entry.injection_query },
+                .{ .label = "folds", .source = entry.fold_query },
+                .{ .label = "indents", .source = entry.indent_query },
+                .{ .label = "textobjects", .source = entry.textobject_query },
+                .{ .label = "tags", .source = entry.tags_query },
+            };
+
+            for (kinds) |kind| {
+                if (kind.source) |source| {
+                    var err_off: u32 = 0;
+                    var err_type: c.TSQueryError = c.TSQueryErrorNone;
+                    const compiled = c.ts_query_new(
+                        lang,
+                        source.ptr,
+                        @intCast(source.len),
+                        &err_off,
+                        &err_type,
+                    );
+
+                    if (compiled) |q| {
+                        c.ts_query_delete(q);
+                    } else {
+                        failures += 1;
+                        std.debug.print(
+                            "QUERY GUARD FAIL: {s}/{s} did not compile (offset {d}, ts_query_error {d}). " ++
+                                "Likely a renamed/removed grammar node; fix the query or quarantine it explicitly.\n",
+                            .{ entry.name, kind.label, err_off, err_type },
+                        );
+                    }
+                }
+            }
+        } else {
+            failures += 1;
+            std.debug.print(
+                "QUERY GUARD: grammar '{s}' returned a null TSLanguage (link/ABI problem)\n",
+                .{entry.name},
+            );
+        }
+    }
+
+    if (failures != 0) {
+        std.debug.print("QUERY GUARD: {d} query/grammar compile failure(s)\n", .{failures});
+    }
+    try std.testing.expectEqual(@as(usize, 0), failures);
+}


### PR DESCRIPTION
## Why

tree-sitter's `ts_query_new` returns `null` (with no error code we surface) when a query references a node type that does not exist in the grammar. In the running editor this only logs a warning and yields **no highlights** for that language. So a grammar bump that renames or removes a node ships silently-broken highlighting that no existing test catches. We had six such queries already broken against the current vendored grammars.

## What this adds

A CI guard that compiles **every shipped query against its vendored grammar** and fails on the first that does not compile.

- New zig test in `zig/src/highlighter.zig` iterates the comptime `builtin_grammars` table (which already holds both the linked grammar function and every query source, with `; inherits:` resolved at comptime), gets each `TSLanguage`, and runs `ts_query_new` for every present query type: highlights, injections, folds, indents, textobjects, tags. On failure it prints the language, query type, byte offset, and tree-sitter error, and the test fails non-zero.
- New `zig build query-check` step (`zig/build.zig`) runs only this guard via a test filter, so CI can surface it by name. The same test also runs under `zig build test`.
- New CI step "Check tree-sitter queries compile against grammars" in the `test-zig` job, mirroring the existing `zig build test` step.

This reuses the existing parser test harness (already links the tree-sitter lib and all grammar libs), so it adds no new build infrastructure.

## Currently-failing queries fixed

All six were `TSQueryErrorNodeType` (a node name that no longer exists in the vendored grammar). All were small node-name drift, so all were **fixed** (none quarantined):

| Query | Drift | Fix |
| --- | --- | --- |
| `kotlin/highlights` | `(null_literal)` node absent; `null` is an anonymous keyword | `(null_literal)` -> `"null"` |
| `kotlin/highlights` | `..<` (rangeUntil) token absent | dropped `"..<"` |
| `gleam/highlights` | node is `bit_string_segment`, not `bit_array_segment` | renamed |
| `make/highlights` | `let` is not a token in this grammar | dropped `"let"` |
| `xml/injections` | node is `Comment`, not `comment` | `(comment)` -> `(Comment)` |
| `protobuf/indents` | no `oneof_body`/`service_body`/`rpc_body` wrapper nodes | dropped those three |
| `protobuf/textobjects` | no `service_body` node | `(service (service_body) ...)` -> `(service)` |

## Validation

- `zig build test` -> 207/207 tests pass (includes the new guard)
- `zig build query-check` -> 1/1 test passes, exit 0
- `zig build` (release) -> exit 0
- `mix compile --warnings-as-errors` -> ok
- CI workflow YAML parses; new step mirrors existing `test-zig` steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
