### PR TITLE
fix(theme): cover invisible tree-sitter and LSP highlight faces

### DIFF
--- a/lib/minga_editor/ui/theme/builder.ex
+++ b/lib/minga_editor/ui/theme/builder.ex
@@ -466,6 +466,8 @@ defmodule MingaEditor.UI.Theme.Builder do
       "string.special.regex" => [fg: p.syntax.constants],
       "string.escape" => [fg: p.syntax.operators],
       "string.regex" => [fg: p.syntax.constants],
+      # Modern tree-sitter capture name for "string.regex"; alias the same color.
+      "string.regexp" => [fg: p.syntax.constants],
       "character" => [fg: p.syntax.builtin],
       "comment" => [fg: p.syntax.comments, italic: true],
       "comment.doc" => [fg: p.syntax.comments, italic: true],
@@ -483,6 +485,11 @@ defmodule MingaEditor.UI.Theme.Builder do
       "method.call" => [fg: p.syntax.methods],
       "type" => [fg: p.syntax.type],
       "type.builtin" => [fg: p.syntax.type, bold: true],
+      # const/final and friends are storage modifiers, not types: color them
+      # like keywords so they stop inheriting the `type` color.
+      "type.qualifier" => [fg: p.syntax.keywords, bold: true],
+      # Scala/SQL storage modifiers (private, lazy, etc.); treat as keywords.
+      "storageclass" => [fg: p.syntax.keywords, bold: true],
       "variable" => [fg: p.syntax.variables],
       "variable.builtin" => [fg: p.semantic.error],
       "variable.parameter" => [fg: p.syntax.variables],
@@ -510,6 +517,10 @@ defmodule MingaEditor.UI.Theme.Builder do
       "tag.attribute" => [fg: p.syntax.type],
       "tag.error" => [fg: p.semantic.error, bold: true],
       "preproc" => [fg: p.syntax.operators, bold: true],
+      # Base markup face: parent for markup.* and the target for prose/POD
+      # blocks captured as bare `@markup`. Body prose renders at the editor
+      # foreground (intentionally plain, like normal text).
+      "markup" => [fg: p.base.fg],
       "markup.heading" => [fg: p.semantic.error, bold: true],
       "markup.heading.1" => [fg: p.semantic.error, bold: true],
       "markup.heading.2" => [fg: p.syntax.constants, bold: true],
@@ -521,6 +532,7 @@ defmodule MingaEditor.UI.Theme.Builder do
       "markup.strong" => [fg: p.syntax.constants, bold: true],
       "markup.italic" => [fg: p.syntax.variables, italic: true],
       "markup.strikethrough" => [fg: p.base.muted, strikethrough: true],
+      "markup.underline" => [fg: p.semantic.link, underline: true],
       "markup.raw" => [fg: p.syntax.strings],
       "markup.raw.block" => [fg: p.syntax.strings],
       "markup.raw.inline" => [fg: p.syntax.strings],
@@ -541,7 +553,48 @@ defmodule MingaEditor.UI.Theme.Builder do
       "embedded" => [fg: p.syntax.variables],
       "constructor" => [fg: p.semantic.info, bold: true],
       "error" => [fg: p.semantic.error, bold: true],
-      "warning" => [fg: p.semantic.warning, bold: true]
+      "warning" => [fg: p.semantic.warning, bold: true],
+      # Added/removed lines in diff and patch buffers. The base `diff` face
+      # exists so the dotted children chain back to the theme `default`.
+      "diff" => [fg: p.base.fg],
+      "diff.plus" => [fg: p.semantic.success],
+      "diff.minus" => [fg: p.semantic.error]
+    }
+    |> Map.merge(lsp_semantic(p))
+  end
+
+  # LSP semantic-token faces.
+  #
+  # `Minga.LSP.SemanticTokens` emits capture names like `@lsp.type.variable`
+  # and `@lsp.mod.deprecated`. Because of the leading `@`, dotted-name
+  # inheritance (`Face.infer_parent/1`) never reaches a styled tree-sitter
+  # ancestor, so these must carry concrete colors. Each type maps to the SAME
+  # palette color its tree-sitter equivalent uses, and modifiers carry only a
+  # decorative attribute (composed on top of the type's color at render time).
+  @spec lsp_semantic(Palette.t()) :: Theme.syntax()
+  defp lsp_semantic(%Palette{} = p) do
+    %{
+      # Base namespace faces so `@lsp.type.*` / `@lsp.mod.*` chain back to the
+      # theme `default` face. Without these, `Face.infer_parent/1` walks to the
+      # undefined `@lsp.type` / `@lsp` prefixes and falls through to the module
+      # default (wrong bg), instead of the theme-colored default.
+      "@lsp" => [],
+      "@lsp.type" => [],
+      "@lsp.mod" => [],
+      "@lsp.type.namespace" => [fg: p.syntax.type],
+      "@lsp.type.type" => [fg: p.syntax.type],
+      "@lsp.type.variable" => [fg: p.syntax.variables],
+      "@lsp.type.parameter" => [fg: p.syntax.variables],
+      "@lsp.type.property" => [fg: p.syntax.builtin],
+      "@lsp.type.function" => [fg: p.syntax.functions],
+      "@lsp.type.method" => [fg: p.syntax.methods],
+      "@lsp.type.keyword" => [fg: p.syntax.keywords, bold: true],
+      "@lsp.type.comment" => [fg: p.syntax.comments, italic: true],
+      "@lsp.type.string" => [fg: p.syntax.strings],
+      "@lsp.type.number" => [fg: p.syntax.numbers],
+      "@lsp.type.operator" => [fg: p.syntax.operators],
+      "@lsp.mod.deprecated" => [fg: p.base.fg, strikethrough: true],
+      "@lsp.mod.readonly" => [fg: p.syntax.constants]
     }
   end
 

--- a/priv/queries/c/highlights.scm
+++ b/priv/queries/c/highlights.scm
@@ -1,7 +1,7 @@
 (identifier) @variable
 
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z\\d_]*$"))
+ (#match? @constant "^[A-Z][A-Z0-9_]*$"))
 
 "break" @keyword
 "case" @keyword

--- a/priv/queries/perl/highlights.scm
+++ b/priv/queries/perl/highlights.scm
@@ -47,7 +47,7 @@
 (eof_marker) @preproc
 (data_section) @comment
 
-(pod) @text
+(pod) @markup
 
 [
   (number)

--- a/priv/queries/rust/highlights.scm
+++ b/priv/queries/rust/highlights.scm
@@ -8,7 +8,7 @@
 
 ; Assume all-caps names are constants
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z\\d_]+$'"))
+ (#match? @constant "^[A-Z][A-Z0-9_]+$"))
 
 ; Assume uppercase names are enum constructors
 ((identifier) @constructor

--- a/test/minga_editor/ui/theme/capture_coverage_test.exs
+++ b/test/minga_editor/ui/theme/capture_coverage_test.exs
@@ -77,6 +77,14 @@ defmodule MingaEditor.UI.Theme.CaptureCoverageTest do
   )
 
   describe "every query capture resolves to a visible face" do
+    test "the enumerator finds the full distinct capture set" do
+      # The captured set is computed from a per-line parse, so an unbalanced
+      # `"` inside a comment can't pair across newlines and swallow captures.
+      # Lock the count so a future parse regression that silently drops a
+      # capture (and lets it escape the coverage guard) fails loudly here.
+      assert length(all_query_captures()) == 113
+    end
+
     test "astrodark styles all captures except its documented plain set" do
       reg = Registry.from_theme(Theme.get!(:astrodark))
       default_fg = Theme.get!(:astrodark).editor.fg
@@ -233,25 +241,33 @@ defmodule MingaEditor.UI.Theme.CaptureCoverageTest do
   defp captures_in_file(path) do
     path
     |> File.read!()
-    # Strings before comments: literal string tokens like `";"` contain a `;`,
-    # so stripping comments first would truncate the line mid-string and
-    # desync quote pairing for the rest of the file.
-    |> strip_strings()
-    |> strip_comments()
+    |> String.split("\n")
+    |> Enum.map_join("\n", &strip_line/1)
     |> then(&Regex.scan(~r/@[A-Za-z][A-Za-z0-9_.]*/, &1))
     |> Enum.map(fn [match] -> String.trim_leading(match, "@") end)
   end
 
-  defp strip_comments(text) do
-    text
-    |> String.split("\n")
-    |> Enum.map_join("\n", &Regex.replace(~r/;.*$/, &1, ""))
+  # Parse a single line: strip strings, then comments. Both run per line so an
+  # unbalanced `"` inside a `;` comment can't pair across newlines and swallow
+  # the text between them, which would let a unique capture escape the guard.
+  #
+  # Strings before comments: a literal string token like `";"` contains a `;`,
+  # so stripping comments first would truncate the line mid-string and drop a
+  # real capture that follows on the same line.
+  defp strip_line(line) do
+    line
+    |> strip_strings()
+    |> strip_comments()
+  end
+
+  defp strip_comments(line) do
+    Regex.replace(~r/;.*$/, line, "")
   end
 
   # Remove double-quoted string literals, honoring backslash escapes so a
   # literal like `"\\"` (a single escaped backslash) is consumed as one string
-  # rather than desyncing the quote pairing for the rest of the file.
-  defp strip_strings(text) do
-    Regex.replace(~r/"(?:[^"\\]|\\.)*"/, text, "")
+  # rather than desyncing the quote pairing for the rest of the line.
+  defp strip_strings(line) do
+    Regex.replace(~r/"(?:[^"\\]|\\.)*"/, line, "")
   end
 end

--- a/test/minga_editor/ui/theme/capture_coverage_test.exs
+++ b/test/minga_editor/ui/theme/capture_coverage_test.exs
@@ -1,0 +1,257 @@
+defmodule MingaEditor.UI.Theme.CaptureCoverageTest do
+  @moduledoc """
+  Regression guard against "invisible" tree-sitter captures.
+
+  Faces resolve through `MingaEditor.UI.Face.Registry`, which walks the dotted
+  capture name (`Minga.Core.Face.infer_parent/1`) up to a styled ancestor or,
+  failing that, to the editor's default foreground. A capture that resolves to
+  the editor default fg with no distinguishing attribute is effectively
+  invisible: it renders identically to plain body text.
+
+  This test enumerates every distinct `@capture` used across
+  `priv/queries/**/highlights.scm` and asserts each resolves to a *styled*
+  face (a foreground different from the editor default, or a bold / italic /
+  underline / strikethrough attribute). A small, explicitly documented
+  allowlist covers captures that a theme deliberately renders as plain text.
+
+  Two themes are checked:
+
+    * `:astrodark` - a real built-in theme whose palette intentionally mutes
+      operators, variables, members, parameters, etc. to the editor foreground
+      (it mirrors AstroNvim's astrotheme, where those captures are plain).
+    * a synthetic builder-default theme built from a palette where every role
+      is a distinct color. Here nothing is muted, so the only plain captures
+      are the universal sentinels (`markup` body prose, `none`, `spell`). This
+      proves `MingaEditor.UI.Theme.Builder`'s face map covers every capture.
+
+  The test also asserts the LSP semantic-token captures emitted by
+  `Minga.LSP.SemanticTokens` (`@lsp.type.*` / `@lsp.mod.*`) resolve to styled
+  faces, since nothing styled them before this guard was added.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Core.Face
+  alias MingaEditor.UI.Face.Registry
+  alias MingaEditor.UI.Theme
+  alias MingaEditor.UI.Theme.Builder
+
+  # Captures a theme is allowed to render as plain editor-foreground text.
+  #
+  # `none` and `spell` are non-styling sentinel captures (tree-sitter uses them
+  # to clear or annotate, not to color). `markup` is base prose body text,
+  # which renders at the editor foreground by design.
+  @universal_plain MapSet.new(~w(none spell markup))
+
+  # AstroDark deliberately maps these to the editor foreground (`@syn_text`)
+  # via `operators`/`variables` palette roles and explicit syntax overrides,
+  # matching AstroNvim's astrotheme. They are intentionally plain, not bugs.
+  @astrodark_plain MapSet.union(
+                     @universal_plain,
+                     MapSet.new(~w(
+                       operator
+                       variable
+                       variable.array
+                       variable.hash
+                       variable.member
+                       variable.parameter
+                       variable.parameter.builtin
+                       variable.scalar
+                       parameter
+                       field
+                       property
+                       property.definition
+                       embedded
+                       escape
+                       string.escape
+                       punctuation.special
+                     ))
+                   )
+
+  # LSP semantic-token captures emitted by Minga.LSP.SemanticTokens.
+  @lsp_captures ~w(
+    @lsp.type.namespace @lsp.type.type @lsp.type.variable @lsp.type.parameter
+    @lsp.type.property @lsp.type.function @lsp.type.method @lsp.type.keyword
+    @lsp.type.comment @lsp.type.string @lsp.type.number @lsp.type.operator
+    @lsp.mod.deprecated @lsp.mod.readonly
+  )
+
+  describe "every query capture resolves to a visible face" do
+    test "astrodark styles all captures except its documented plain set" do
+      reg = Registry.from_theme(Theme.get!(:astrodark))
+      default_fg = Theme.get!(:astrodark).editor.fg
+
+      invisible =
+        Enum.reject(all_query_captures(), fn capture ->
+          MapSet.member?(@astrodark_plain, capture) or
+            styled?(Registry.style_for(reg, capture), default_fg)
+        end)
+
+      assert invisible == [],
+             "captures resolve to the editor default fg in :astrodark " <>
+               "(invisible). Either add a face in the theme/Builder or add " <>
+               "them to @astrodark_plain with a rationale: #{inspect(invisible)}"
+    end
+
+    test "a builder-default theme styles every capture except the sentinels" do
+      reg = Registry.from_theme(distinct_palette_theme())
+      default_fg = distinct_palette_theme().editor.fg
+
+      invisible =
+        Enum.reject(all_query_captures(), fn capture ->
+          MapSet.member?(@universal_plain, capture) or
+            styled?(Registry.style_for(reg, capture), default_fg)
+        end)
+
+      assert invisible == [],
+             "the Builder face map leaves these captures invisible in a " <>
+               "distinct-color theme: #{inspect(invisible)}"
+    end
+  end
+
+  # Expected astrodark foregrounds per the Builder's LSP mapping: each
+  # `@lsp.type.*` shares the SAME palette role color as the equivalent
+  # tree-sitter capture. `variable`/`parameter`/`operator` resolve to the
+  # editor foreground because astrodark deliberately mutes those roles.
+  @astrodark_lsp_fg %{
+    # variables/operators map to @syn_text (the editor fg) in astrodark.
+    "@lsp.type.variable" => 0xADB0BB,
+    "@lsp.type.parameter" => 0xADB0BB,
+    "@lsp.type.operator" => 0xADB0BB,
+    "@lsp.type.namespace" => 0xDFAB25,
+    "@lsp.type.type" => 0xDFAB25,
+    "@lsp.type.property" => 0x4AC2B8,
+    "@lsp.type.function" => 0x5EB7FF,
+    "@lsp.type.method" => 0x5EB7FF,
+    "@lsp.type.keyword" => 0xDD97F1,
+    "@lsp.type.comment" => 0x696C76,
+    "@lsp.type.string" => 0x87C05F,
+    "@lsp.type.number" => 0xF5983A
+  }
+
+  describe "LSP semantic-token captures resolve to styled faces" do
+    test "astrodark: every LSP face is defined with the mapped color" do
+      reg = Registry.from_theme(Theme.get!(:astrodark))
+
+      # All LSP captures must be defined faces, not undefined fallbacks. An
+      # undefined `@lsp.*` capture resolves to the module default (wrong bg),
+      # which is exactly the bug this guards against.
+      for capture <- @lsp_captures do
+        assert Registry.get(reg, capture) != nil,
+               "#{capture} is not a defined face; it would fall through to the " <>
+                 "module default with the wrong background"
+      end
+
+      for {lsp, expected_fg} <- @astrodark_lsp_fg do
+        assert Registry.style_for(reg, lsp).fg == expected_fg,
+               "#{lsp} should resolve to 0x#{Integer.to_string(expected_fg, 16)}"
+      end
+
+      # The deprecated modifier composes strikethrough regardless of color.
+      assert Registry.style_for(reg, "@lsp.mod.deprecated").strikethrough == true
+      # readonly maps to the constant color (a visible accent).
+      assert styled?(Registry.style_for(reg, "@lsp.mod.readonly"), 0xADB0BB)
+    end
+
+    test "builder-default theme: every LSP face is styled" do
+      theme = distinct_palette_theme()
+      reg = Registry.from_theme(theme)
+
+      for capture <- @lsp_captures do
+        face = Registry.style_for(reg, capture)
+
+        assert styled?(face, theme.editor.fg),
+               "#{capture} resolves to a plain default face in the builder " <>
+                 "default theme"
+      end
+    end
+  end
+
+  # A face is "styled" if it visibly differs from plain body text: a different
+  # foreground, or any distinguishing attribute (a modifier face like
+  # @lsp.mod.deprecated carries strikethrough without changing the fg).
+  defp styled?(%Face{} = face, default_fg) do
+    face.fg != default_fg or face.bold == true or face.italic == true or
+      face.underline == true or face.strikethrough == true
+  end
+
+  # Build a theme from a palette where every role is a distinct color, none
+  # equal to the editor foreground. Used to prove Builder coverage independent
+  # of any one theme's deliberate mutes.
+  defp distinct_palette_theme do
+    palette = %{
+      variant: :dark,
+      bg: 0x000000,
+      fg: 0xFFFFFF,
+      surface: 0x101010,
+      overlay: 0x202020,
+      muted: 0x303030,
+      subtle: 0x404040,
+      accent: 0x111111,
+      highlight: 0x112233,
+      selection_bg: 0x223344,
+      error: 0xFF0001,
+      warning: 0xFF8800,
+      info: 0x0088FF,
+      success: 0x00FF01,
+      match: 0xFFFF00,
+      link: 0x00FFFF,
+      border: 0x445566,
+      contrast_fg: 0x010101,
+      builtin: 0x11AA11,
+      functions: 0x2266FF,
+      keywords: 0xAA22FF,
+      methods: 0x33AAFF,
+      operators: 0xFF66AA,
+      constants: 0xFFAA22,
+      strings: 0x66CC33,
+      numbers: 0xCC8822,
+      type: 0xDDAA22,
+      variables: 0xCCCCEE,
+      comments: 0x778899
+    }
+
+    Builder.from_palette(:capture_coverage_probe, palette)
+  end
+
+  # Distinct `@capture` names used across every built-in highlights query,
+  # excluding comment lines (`; ...`) and quoted literals (e.g. objc's
+  # `"@optional"` token strings, which are not capture annotations).
+  defp all_query_captures do
+    query_files()
+    |> Enum.flat_map(&captures_in_file/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp query_files do
+    [Application.app_dir(:minga, "priv"), "queries", "*", "highlights.scm"]
+    |> Path.join()
+    |> Path.wildcard()
+  end
+
+  defp captures_in_file(path) do
+    path
+    |> File.read!()
+    # Strings before comments: literal string tokens like `";"` contain a `;`,
+    # so stripping comments first would truncate the line mid-string and
+    # desync quote pairing for the rest of the file.
+    |> strip_strings()
+    |> strip_comments()
+    |> then(&Regex.scan(~r/@[A-Za-z][A-Za-z0-9_.]*/, &1))
+    |> Enum.map(fn [match] -> String.trim_leading(match, "@") end)
+  end
+
+  defp strip_comments(text) do
+    text
+    |> String.split("\n")
+    |> Enum.map_join("\n", &Regex.replace(~r/;.*$/, &1, ""))
+  end
+
+  # Remove double-quoted string literals, honoring backslash escapes so a
+  # literal like `"\\"` (a single escaped backslash) is consumed as one string
+  # rather than desyncing the quote pairing for the rest of the file.
+  defp strip_strings(text) do
+    Regex.replace(~r/"(?:[^"\\]|\\.)*"/, text, "")
+  end
+end


### PR DESCRIPTION
## Problem

Faces resolve through `Face.Registry` by walking the dotted capture name (`Face.infer_parent/1`) up to a styled ancestor, or falling back to the editor default foreground. A capture that resolves to the editor default fg with no distinguishing attribute is effectively invisible: it renders identically to plain body text. In AstroDark the editor default fg is `@syn_text` (`0xADB0BB`).

Several tree-sitter captures, and **every** LSP semantic-token capture, had no styled face, so they rendered as plain text in built-in palette themes.

## Faces added (`lib/minga_editor/ui/theme/builder.ex`)

- `diff.plus` (semantic.success / green) and `diff.minus` (semantic.error / red): previously invisible in diff and patch buffers.
- base `markup` (prose body, editor fg) and `markup.underline` (link color + underline attribute).
- `storageclass` and `type.qualifier` mapped to the keyword color, so storage modifiers (`const`/`final`, scala/sql modifiers) stop inheriting the `type` color.
- `string.regexp` (modern name) aliased to whatever `string.regex` uses.
- LSP semantic-token faces `@lsp.type.{namespace,type,variable,parameter,property,function,method,keyword,comment,string,number,operator}`, each mapped to the **same palette color** its tree-sitter equivalent uses (variable→variables, function→functions, method→methods, type→type, keyword→keywords, comment→comments, string→strings, number→numbers, operator→operators, namespace→type, parameter→variables, property→builtin). Plus modifier faces `@lsp.mod.deprecated` (strikethrough) and `@lsp.mod.readonly` (constant color).
  - `Minga.LSP.SemanticTokens` emits these `@lsp.type.*` / `@lsp.mod.*` names. **Semantic tokens are enabled and wired into the live flow** (requested on buffer events via `SemanticTokenSync`, responses applied at highlight layer 2), but nothing styled them in built-in themes: `Registry.with_lsp_defaults/1` only runs for disk-loaded themes in `theme/loader.ex`, not for `Registry.from_theme/1` used by the live editor. Adding the faces to the Builder map fixes every built-in palette theme.
  - Base `@lsp` / `@lsp.type` / `@lsp.mod` faces are added so the `@`-prefixed names chain back to the **theme** default (correct background) instead of the module default. The same applies to a base `diff` face. Without these, `infer_parent/1` walks to undefined prefixes and falls through to `Face.default()`, painting a wrong background block.

## Query fixes

- `priv/queries/c/highlights.scm` and `priv/queries/rust/highlights.scm`: the `#match?` regex used `\d`, which is invalid in POSIX ERE (the engine uses `regcomp` with `REG_EXTENDED`), so the predicate silently failed and passed unconditionally, over-coloring non-constant identifiers as constants. Changed `\d` to `[0-9]` and removed a stray `'` in the rust pattern. Kept the `^[A-Z][A-Z0-9_]*$` style.
- `priv/queries/perl/highlights.scm`: the POD block was captured as the legacy unstyled `@text`. Changed to `@markup` now that a base `markup` face exists.

## Regression guard (the key deliverable)

`test/minga_editor/ui/theme/capture_coverage_test.exs`:

- Enumerates every distinct `@capture` used across `priv/queries/**/highlights.scm` (113 captures), excluding comment lines and quoted literals. The extractor strips strings before comments and honors backslash escapes, because literal tokens like `";"` and `"\\"` would otherwise desync quote pairing.
- Resolves each capture through the real `Face.Registry` for `:astrodark` and for a synthetic distinct-color builder-default theme.
- Asserts none resolve to the editor default fg, except a documented allowlist. For astrodark that allowlist is the roles it deliberately mutes to `@syn_text` (operators, variables and its members/parameters/array/hash/scalar, field, property, embedded, escape, string.escape, punctuation.special) plus the universal sentinels `markup` (prose body), `none`, and `spell`. The builder-default theme only allows those three sentinels.
- Asserts the `@lsp.type.*` / `@lsp.mod.*` faces are defined and resolve to the mapped colors.

The guard **fails before** the face additions (it flags `diff.plus`, `diff.minus`, `markup.underline`, `storageclass`, and all LSP captures) and **passes after**.

## Allowlist note

The astrodark plain allowlist is larger than a naive "every capture must be colored" expectation, but it is legitimate: astrodark mirrors AstroNvim's astrotheme, where `operators` and `variables` palette roles equal the editor foreground on purpose, and members/parameters/fields/properties are explicitly overridden to `@syn_text`. Those captures are intentionally plain, not bugs, so they are documented in the allowlist rather than forced to a color.

## Validation

- `zig build`: clean
- `mix compile --warnings-as-errors`: clean
- `mix format --check-formatted`: clean
- `mix credo --strict` (changed files): no issues
- New guard test: 4 passing (fails on pre-change builder, confirmed via stash)
- `mix test test/minga_editor/ui/ test/minga_editor/ui/face/ test/minga/lsp/semantic_tokens_test.exs test/minga/language/tree_sitter_test.exs test/minga_editor/handlers/highlight_handler_test.exs`: all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)