### PR TITLE
fix(macos): restore editor focus with observatory open

### DIFF
--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -622,13 +622,14 @@ final class EditorNSView: MTKView {
     func claimFirstResponder() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.reclaimFirstResponderIfNeeded()
+            self.reclaimFirstResponderIfNeeded(respectingTextInput: true)
         }
     }
 
     /// Reclaims first responder immediately when pointer interaction returns to the editor.
-    private func reclaimFirstResponderIfNeeded() {
+    func reclaimFirstResponderIfNeeded(respectingTextInput: Bool = false) {
         guard let window else { return }
+        if respectingTextInput, window.firstResponder is NSText { return }
         if window.firstResponder !== self {
             window.makeFirstResponder(self)
         }

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -621,10 +621,16 @@ final class EditorNSView: MTKView {
     /// reassign first responder to its own focus system.
     func claimFirstResponder() {
         DispatchQueue.main.async { [weak self] in
-            guard let self, let window = self.window else { return }
-            if window.firstResponder !== self {
-                window.makeFirstResponder(self)
-            }
+            guard let self else { return }
+            self.reclaimFirstResponderIfNeeded()
+        }
+    }
+
+    /// Reclaims first responder immediately when pointer interaction returns to the editor.
+    private func reclaimFirstResponderIfNeeded() {
+        guard let window else { return }
+        if window.firstResponder !== self {
+            window.makeFirstResponder(self)
         }
     }
 
@@ -1096,6 +1102,8 @@ final class EditorNSView: MTKView {
     // MARK: - Mouse
 
     override func mouseDown(with event: NSEvent) {
+        reclaimFirstResponderIfNeeded()
+
         // Scroll indicator track: intercept clicks on the right edge.
         let point = convert(event.locationInWindow, from: nil)
         if shouldCaptureScrollTrackClick(point) {
@@ -1147,6 +1155,7 @@ final class EditorNSView: MTKView {
     }
 
     override func rightMouseDown(with event: NSEvent) {
+        reclaimFirstResponderIfNeeded()
         resetCursorBlink()
         let (row, col) = cellPosition(from: event)
         let cc = UInt8(clamping: event.clickCount)
@@ -1219,6 +1228,7 @@ final class EditorNSView: MTKView {
     }
 
     override func otherMouseDown(with event: NSEvent) {
+        reclaimFirstResponderIfNeeded()
         let (row, col) = cellPosition(from: event)
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_MIDDLE,
                                modifiers: modifierBits(from: event.modifierFlags),

--- a/macos/Sources/Views/EditorView.swift
+++ b/macos/Sources/Views/EditorView.swift
@@ -18,7 +18,8 @@ struct EditorView: NSViewRepresentable {
 
     func updateNSView(_ nsView: EditorNSView, context: Context) {
         // When SwiftUI updates the view hierarchy (e.g., title change triggers
-        // a body re-evaluation), it can steal first responder. Reclaim it.
+        // a body re-evaluation), it can steal first responder. Reclaim it unless
+        // the user is actively typing in a text field.
         nsView.claimFirstResponder()
     }
 }

--- a/macos/Sources/Views/ObservatoryView.swift
+++ b/macos/Sources/Views/ObservatoryView.swift
@@ -18,6 +18,8 @@ struct ObservatoryView: View {
             treeList
         }
         .background(theme.treeBg)
+        .focusable(false)
+        .focusEffectDisabled()
         .onAppear(perform: reconcileLocalState)
         .onChange(of: state.nodes) { _, _ in reconcileLocalState() }
     }
@@ -62,6 +64,8 @@ struct ObservatoryView: View {
                 rowMainContent(node)
             }
             .buttonStyle(.plain)
+            .focusable(false)
+            .focusEffectDisabled()
             .frame(maxWidth: .infinity, alignment: .leading)
 
             Button {
@@ -74,6 +78,8 @@ struct ObservatoryView: View {
                     .frame(width: 16)
             }
             .buttonStyle(.plain)
+            .focusable(false)
+            .focusEffectDisabled()
         }
         // 12pt per depth level (down from 14) keeps deep nodes from starving
         // the name column; the right-side memory/sparkline cluster is tightened

--- a/macos/Tests/MingaTests/MouseInputTests.swift
+++ b/macos/Tests/MingaTests/MouseInputTests.swift
@@ -39,6 +39,25 @@ struct MouseInputTests {
     }
 
     @MainActor
+    private func makeWindowedView(spy: SpyEncoder) -> (view: EditorNSView, window: NSWindow, textField: NSTextField)? {
+        guard let view = makeView(spy: spy) else { return nil }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: view.frame.width, height: view.frame.height),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: view.frame)
+        let textField = NSTextField(frame: NSRect(x: 16, y: 16, width: 160, height: 24))
+        container.addSubview(view)
+        container.addSubview(textField)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+        return (view, window, textField)
+    }
+
+    @MainActor
     private func installPaneGeometryDivider(view: EditorNSView, dividerCol: UInt16) {
         let geometry = GUIPaneGeometry(
             windowId: 1,
@@ -86,18 +105,36 @@ struct MouseInputTests {
 
     // MARK: - Left click
 
-    @Test("mouseDown sends left button press with cell coordinates")
+    @Test("claimFirstResponder respects active text input")
+    @MainActor func claimFirstResponderRespectsActiveTextInput() throws {
+        let spy = SpyEncoder()
+        guard let (view, window, textField) = makeWindowedView(spy: spy) else { return }
+
+        #expect(window.makeFirstResponder(textField))
+        #expect(window.firstResponder is NSText)
+
+        view.reclaimFirstResponderIfNeeded(respectingTextInput: true)
+
+        #expect(window.firstResponder is NSText)
+        #expect(spy.mouseEventCalls.isEmpty)
+    }
+
+    @Test("mouseDown sends left button press and reclaims first responder")
     @MainActor func leftMouseDown() throws {
         let spy = SpyEncoder()
-        guard let view = makeView(spy: spy) else { return }
+        guard let (view, window, textField) = makeWindowedView(spy: spy) else { return }
         let cw = view.cellWidth
         let ch = view.cellHeight
+
+        #expect(window.makeFirstResponder(textField))
+        #expect(window.firstResponder is NSText)
 
         // Click at pixel (cw * 10, ch * 5) = cell (row=5, col=10)
         guard let event = mouseEvent(type: .leftMouseDown,
                                      location: NSPoint(x: cw * 10, y: ch * 5)) else { return }
         view.mouseDown(with: event)
 
+        #expect(window.firstResponder === view)
         #expect(spy.mouseEventCalls.count == 1)
         let call = spy.mouseEventCalls[0]
         #expect(call.button == MOUSE_BUTTON_LEFT)


### PR DESCRIPTION
# TL;DR
Keeps the BEAM Observatory sidebar open without breaking editor keyboard control. The macOS frontend now opts the Observatory out of focus and immediately reclaims first responder when the editor is clicked.

## Context
Interacting with the Observatory sidebar could leave keyboard focus in SwiftUI chrome. After that, typing and Vim leader sequences in the main editor stopped working until focus was restored indirectly.

## Changes
- Opt the Observatory root view and row buttons out of SwiftUI focus.
- Add `reclaimFirstResponderIfNeeded()` in `EditorNSView`.
- Call that helper from left, right, and middle mouse-down handlers so clicking the editor restores keyboard ownership immediately.

## Verification
- `mix swift.build`
- `xcodebuild -project macos/Minga.xcodeproj -scheme Minga test -destination 'platform=macOS'`
- Manual check:
  1. Open BEAM Observatory.
  2. Click Observatory rows or buttons.
  3. Click back into the editor.
  4. Verify normal typing, Vim motions, and leader chords like `SPC p p` still work while Observatory remains open.
