### PR TITLE
feat(git): classify huge repos and degrade git status visibly

### DIFF
--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -159,7 +159,9 @@ defmodule Minga.Events do
       :behind,
       entry_base_path: nil,
       last_commit_message: "",
-      stash_count: 0
+      stash_count: 0,
+      degraded?: false,
+      degraded_reason: nil
     ]
 
     @type t :: %__MODULE__{
@@ -170,7 +172,9 @@ defmodule Minga.Events do
             behind: non_neg_integer(),
             entry_base_path: String.t() | nil,
             last_commit_message: String.t(),
-            stash_count: non_neg_integer()
+            stash_count: non_neg_integer(),
+            degraded?: boolean(),
+            degraded_reason: Minga.Git.Repo.degraded_reason() | nil
           }
   end
 

--- a/lib/minga/git/repo.ex
+++ b/lib/minga/git/repo.ex
@@ -48,6 +48,8 @@ defmodule Minga.Git.Repo do
     refresh_pending?: false,
     awaiting_refresh: [],
     profile: nil,
+    degraded?: false,
+    degraded_reason: nil,
     events_registry: Minga.Events.default_registry()
   ]
 
@@ -67,8 +69,19 @@ defmodule Minga.Git.Repo do
           refresh_pending?: boolean(),
           awaiting_refresh: [GenServer.from()],
           profile: Profile.t() | nil,
+          degraded?: boolean(),
+          degraded_reason: degraded_reason() | nil,
           events_registry: Minga.Events.registry()
         }
+
+  @typedoc """
+  Why the cached status is degraded.
+
+  `:status_timeout` means `git status` exceeded the profile's bounded timeout on
+  a full checkout, so the entry list may be missing untracked (and other)
+  changes. The UI surfaces this so the omission is visible, never silent.
+  """
+  @type degraded_reason :: :status_timeout
 
   @typedoc "Options for starting a Git.Repo process."
   @type start_opt ::
@@ -86,7 +99,9 @@ defmodule Minga.Git.Repo do
           untracked_count: non_neg_integer(),
           conflict_count: non_neg_integer(),
           last_commit_message: String.t(),
-          stash_count: non_neg_integer()
+          stash_count: non_neg_integer(),
+          degraded?: boolean(),
+          degraded_reason: degraded_reason() | nil
         }
 
   @typedoc "Cached status entries plus the path they are relative to."
@@ -191,6 +206,18 @@ defmodule Minga.Git.Repo do
     GenServer.call(server, :summary)
   end
 
+  @doc """
+  Returns whether the cached status is degraded and why.
+
+  `{true, reason}` means the last `git status` was trimmed (e.g. timed out on a
+  full checkout) so untracked or other changes may be missing. `{false, nil}`
+  means the cache is complete.
+  """
+  @spec degraded(GenServer.server()) :: {boolean(), degraded_reason() | nil}
+  def degraded(server) do
+    GenServer.call(server, :degraded)
+  end
+
   @doc "Forces a status refresh. Used after staging/committing operations."
   @spec refresh(GenServer.server()) :: :ok
   def refresh(server) do
@@ -235,7 +262,16 @@ defmodule Minga.Git.Repo do
   end
 
   def handle_call(:status_snapshot, _from, state) do
-    {:reply, StatusSnapshot.new(state.git_root, entry_base_path(state), state.entries), state}
+    snapshot =
+      StatusSnapshot.new(
+        state.git_root,
+        entry_base_path(state),
+        state.entries,
+        state.degraded?,
+        state.degraded_reason
+      )
+
+    {:reply, snapshot, state}
   end
 
   def handle_call(:branch, _from, state) do
@@ -245,6 +281,10 @@ defmodule Minga.Git.Repo do
   def handle_call(:summary, _from, state) do
     summary = build_summary(state)
     {:reply, summary, state}
+  end
+
+  def handle_call(:degraded, _from, state) do
+    {:reply, {state.degraded?, state.degraded_reason}, state}
   end
 
   def handle_call(
@@ -371,9 +411,15 @@ defmodule Minga.Git.Repo do
   @typep refresh_task :: %{pid: pid(), ref: reference()}
   @typep fetch_result(value) :: {:ok, value} | :error
 
+  @typep status_result :: %{
+           entries: fetch_result([StatusEntry.t()]),
+           degraded?: boolean(),
+           degraded_reason: degraded_reason() | nil
+         }
+
   @typep refresh_result :: %{
            profile: Profile.t(),
-           entries: fetch_result([StatusEntry.t()]),
+           status: status_result(),
            branch: fetch_result(String.t() | nil),
            ahead_behind: fetch_result({non_neg_integer(), non_neg_integer()}),
            last_commit_message: fetch_result(String.t()),
@@ -425,7 +471,7 @@ defmodule Minga.Git.Repo do
 
     %{
       profile: profile,
-      entries: fetch_status(git_root, project_root, profile),
+      status: fetch_status(git_root, project_root, profile),
       branch: fetch_branch(git_root),
       ahead_behind: fetch_ahead_behind(git_root),
       last_commit_message: fetch_last_commit_message(git_root),
@@ -458,8 +504,12 @@ defmodule Minga.Git.Repo do
     old_behind = state.behind
     old_last_commit_message = state.last_commit_message
     old_stash_count = state.stash_count
+    old_degraded? = state.degraded?
 
-    entries = fetched_or_current(result.entries, old_entries)
+    # On a degraded (timed-out) status we keep the previously cached entries
+    # rather than dropping them, so the file list stays visible while the
+    # degraded flag tells the user it may be incomplete.
+    entries = fetched_or_current(result.status.entries, old_entries)
     branch = fetched_or_current(result.branch, old_branch)
     {ahead, behind} = fetched_or_current(result.ahead_behind, {old_ahead, old_behind})
     last_commit_message = fetched_or_current(result.last_commit_message, old_last_commit_message)
@@ -473,13 +523,16 @@ defmodule Minga.Git.Repo do
         behind: behind,
         last_commit_message: last_commit_message,
         stash_count: stash_count,
-        profile: result.profile
+        profile: result.profile,
+        degraded?: result.status.degraded?,
+        degraded_reason: result.status.degraded_reason
     }
 
     changed =
       entries != old_entries or branch != old_branch or
         ahead != old_ahead or behind != old_behind or
-        last_commit_message != old_last_commit_message or stash_count != old_stash_count
+        last_commit_message != old_last_commit_message or stash_count != old_stash_count or
+        state.degraded? != old_degraded?
 
     if changed do
       Minga.Events.broadcast(
@@ -492,7 +545,9 @@ defmodule Minga.Git.Repo do
           behind: state.behind,
           entry_base_path: entry_base_path(state),
           last_commit_message: state.last_commit_message,
-          stash_count: state.stash_count
+          stash_count: state.stash_count,
+          degraded?: state.degraded?,
+          degraded_reason: state.degraded_reason
         },
         state.events_registry
       )
@@ -521,20 +576,42 @@ defmodule Minga.Git.Repo do
   defp fetched_or_current({:ok, value}, _current), do: value
   defp fetched_or_current(:error, current), do: current
 
-  @spec fetch_status(String.t(), String.t() | nil, Profile.t()) :: fetch_result([StatusEntry.t()])
+  @spec fetch_status(String.t(), String.t() | nil, Profile.t()) :: status_result()
   defp fetch_status(git_root, project_root, %Profile{} = profile) do
     case Git.status(git_root,
            untracked_mode: profile.untracked_mode,
            timeout_ms: profile.timeout_ms
          ) do
       {:ok, entries} ->
-        {:ok, maybe_relativize_paths(entries, git_root, project_root)}
+        # A clean run clears any prior degraded flag.
+        %{
+          entries: {:ok, maybe_relativize_paths(entries, git_root, project_root)},
+          degraded?: false,
+          degraded_reason: nil
+        }
 
       {:error, reason} ->
-        Minga.Log.warning(:editor, "[Git.Repo] status failed: #{reason}")
-        :error
+        status_error_result(reason, profile)
     end
   end
+
+  # A status timeout on a full checkout (untracked_mode: :normal) means results
+  # were trimmed while untracked files were in scope. We keep the previously
+  # cached entries (handled in apply_refresh_result) and flag the cache degraded
+  # so the UI shows it, rather than silently dropping untracked visibility.
+  @spec status_error_result(String.t(), Profile.t()) :: status_result()
+  defp status_error_result(reason, profile) do
+    if status_timed_out?(reason) and Profile.degrades_visibly?(profile) do
+      Minga.Log.warning(:editor, "[Git.Repo] status degraded (timeout): #{reason}")
+      %{entries: :error, degraded?: true, degraded_reason: :status_timeout}
+    else
+      Minga.Log.warning(:editor, "[Git.Repo] status failed: #{reason}")
+      %{entries: :error, degraded?: false, degraded_reason: nil}
+    end
+  end
+
+  @spec status_timed_out?(String.t()) :: boolean()
+  defp status_timed_out?(reason), do: String.contains?(reason, "timed out")
 
   @spec fetch_branch(String.t()) :: fetch_result(String.t() | nil)
   defp fetch_branch(git_root) do
@@ -614,7 +691,9 @@ defmodule Minga.Git.Repo do
       untracked_count: counts.untracked,
       conflict_count: counts.conflict,
       last_commit_message: state.last_commit_message,
-      stash_count: state.stash_count
+      stash_count: state.stash_count,
+      degraded?: state.degraded?,
+      degraded_reason: state.degraded_reason
     }
   end
 

--- a/lib/minga/git/repo/profile.ex
+++ b/lib/minga/git/repo/profile.ex
@@ -20,19 +20,101 @@ defmodule Minga.Git.Repo.Profile do
             untracked_mode: :normal,
             timeout_ms: 2_000
 
+  # Size proxy: `.git/index` file size.
+  #
+  # The index file holds one entry per tracked path (roughly a few dozen bytes
+  # each: mode, sha, flags, and the path string). Its size therefore scales with
+  # the tracked-file count, which is the cost driver for `git status`. Reading a
+  # single `File.stat` is O(1) and adds no filesystem walk at startup, so it is a
+  # cheap stand-in for "how big is this working tree" without enumerating it.
+  #
+  # Thresholds are heuristic, picked from observed index sizes (~80-100 bytes per
+  # entry): ~10 MB ≈ 100k+ tracked files (huge), ~2 MB ≈ 20k+ (large). They are
+  # intentionally conservative and only affect the bounded `timeout_ms`, never
+  # whether untracked files are hidden.
+  @huge_index_bytes 10 * 1024 * 1024
+  @large_index_bytes 2 * 1024 * 1024
+
+  # Bounded timeouts per size class. Larger repos get a longer (still bounded)
+  # budget so a normal status has a chance to finish before degrading.
+  @huge_timeout_ms 4_000
+  @large_timeout_ms 3_000
+  @default_timeout_ms 2_000
+
   @doc "Builds the ambient git policy for `git_root`."
   @spec detect(String.t()) :: t()
   def detect(git_root) when is_binary(git_root) do
     sparse? = sparse_checkout?(git_root)
 
-    %__MODULE__{
-      sparse?: sparse?,
-      size_class: if(sparse?, do: :large, else: :unknown),
-      untracked_mode: if(sparse?, do: :no, else: :normal),
-      timeout_ms: 2_000
-    }
+    sparse?
+    |> base_profile(git_root)
     |> apply_override(git_root)
   end
+
+  # Sparse checkouts keep the conservative `:no` untracked mode (AC 3): the
+  # checkout deliberately omits paths, so enumerating untracked files is both
+  # expensive and misleading.
+  @spec base_profile(boolean(), String.t()) :: t()
+  defp base_profile(true, _git_root) do
+    %__MODULE__{
+      sparse?: true,
+      size_class: :large,
+      untracked_mode: :no,
+      timeout_ms: @default_timeout_ms
+    }
+  end
+
+  # Non-sparse (full) checkouts classify by index size and ALWAYS keep
+  # `untracked_mode: :normal` (AC 2). A huge repo must never silently fall back
+  # to `:no`, which would hide untracked files; instead it degrades visibly when
+  # the bounded timeout trims results.
+  defp base_profile(false, git_root) do
+    size_class = classify_size(git_root)
+
+    %__MODULE__{
+      sparse?: false,
+      size_class: size_class,
+      untracked_mode: :normal,
+      timeout_ms: timeout_for_size(size_class)
+    }
+  end
+
+  @spec classify_size(String.t()) :: size_class()
+  defp classify_size(git_root) do
+    case index_size(git_root) do
+      bytes when bytes >= @huge_index_bytes -> :huge
+      bytes when bytes >= @large_index_bytes -> :large
+      _bytes -> :unknown
+    end
+  end
+
+  # Returns the `.git/index` size in bytes, or 0 when it cannot be read (no
+  # index yet, permissions, or a worktree without one). 0 classifies as
+  # `:unknown`, the safe default.
+  @spec index_size(String.t()) :: non_neg_integer()
+  defp index_size(git_root) do
+    case git_root |> git_dir() |> Path.join("index") |> File.stat() do
+      {:ok, %File.Stat{size: size}} -> size
+      {:error, _reason} -> 0
+    end
+  end
+
+  @spec timeout_for_size(size_class()) :: pos_integer()
+  defp timeout_for_size(:huge), do: @huge_timeout_ms
+  defp timeout_for_size(:large), do: @large_timeout_ms
+  defp timeout_for_size(_size_class), do: @default_timeout_ms
+
+  @doc """
+  Returns true when this profile still enumerates untracked files (`:normal`).
+
+  A status timeout on such a profile means results were trimmed while untracked
+  files were in scope, so the omission must be surfaced as degraded (AC 2/5).
+  Sparse / `:no` profiles deliberately omit untracked files, so a timeout there
+  is not a visibility regression worth flagging.
+  """
+  @spec degrades_visibly?(t()) :: boolean()
+  def degrades_visibly?(%__MODULE__{untracked_mode: :normal}), do: true
+  def degrades_visibly?(%__MODULE__{}), do: false
 
   @spec sparse_checkout?(String.t()) :: boolean()
   defp sparse_checkout?(git_root) do

--- a/lib/minga/git/repo/status_snapshot.ex
+++ b/lib/minga/git/repo/status_snapshot.ex
@@ -3,23 +3,37 @@ defmodule Minga.Git.Repo.StatusSnapshot do
   Cached git status entries for a tracked repository.
 
   `entry_base_path` tells consumers which filesystem path the entry paths are relative to. This lets cache-only UI consumers render badges without shelling out to git.
+
+  `degraded?`/`degraded_reason` flag when the cached entries are incomplete (e.g. `git status` timed out on a full checkout), so consumers can show a visible "degraded" indicator instead of silently trusting a trimmed list.
   """
 
   alias Minga.Git.StatusEntry
 
+  @type degraded_reason :: Minga.Git.Repo.degraded_reason()
+
   @enforce_keys [:git_root, :entry_base_path, :entries]
-  defstruct [:git_root, :entry_base_path, :entries]
+  defstruct [:git_root, :entry_base_path, :entries, degraded?: false, degraded_reason: nil]
 
   @type t :: %__MODULE__{
           git_root: String.t(),
           entry_base_path: String.t(),
-          entries: [StatusEntry.t()]
+          entries: [StatusEntry.t()],
+          degraded?: boolean(),
+          degraded_reason: degraded_reason() | nil
         }
 
   @doc "Builds a cached status snapshot."
   @spec new(String.t(), String.t(), [StatusEntry.t()]) :: t()
-  def new(git_root, entry_base_path, entries)
-      when is_binary(git_root) and is_binary(entry_base_path) and is_list(entries) do
-    %__MODULE__{git_root: git_root, entry_base_path: entry_base_path, entries: entries}
+  @spec new(String.t(), String.t(), [StatusEntry.t()], boolean(), degraded_reason() | nil) :: t()
+  def new(git_root, entry_base_path, entries, degraded? \\ false, degraded_reason \\ nil)
+      when is_binary(git_root) and is_binary(entry_base_path) and is_list(entries) and
+             is_boolean(degraded?) do
+    %__MODULE__{
+      git_root: git_root,
+      entry_base_path: entry_base_path,
+      entries: entries,
+      degraded?: degraded?,
+      degraded_reason: degraded_reason
+    }
   end
 end

--- a/lib/minga_editor/shell/traditional/modeline.ex
+++ b/lib/minga_editor/shell/traditional/modeline.ex
@@ -52,6 +52,7 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
           optional(:parser_status) => parser_status(),
           optional(:git_branch) => String.t() | nil,
           optional(:git_diff_summary) => git_diff_summary(),
+          optional(:git_degraded) => boolean(),
           optional(:diagnostic_counts) =>
             {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil,
           optional(:indent_type) => :spaces | :tabs,
@@ -105,6 +106,10 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
 
   # Nerd Font branch icon (U+E0A0)
   @branch_icon "\uE0A0"
+
+  # Warning icon for a degraded git status (results trimmed, e.g. status timeout)
+  @git_degraded_icon "\u{F071}"
+  @git_degraded_fg 0xECBE7B
 
   # Nerd Font diagnostic icons
   @diag_error_icon "\u{F057}"
@@ -568,6 +573,7 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
   defp build_git_segments(data, bar_bg, theme) do
     branch = Map.get(data, :git_branch)
     summary = Map.get(data, :git_diff_summary)
+    degraded? = Map.get(data, :git_degraded, false)
 
     case branch do
       nil ->
@@ -577,12 +583,19 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
         []
 
       name ->
-        [
-          {" #{@branch_icon} #{name}", theme.modeline.info_fg, bar_bg, [], nil}
-          | build_diff_stat_segments(summary, bar_bg, theme.git)
-        ]
+        [{" #{@branch_icon} #{name}", theme.modeline.info_fg, bar_bg, [], nil}] ++
+          build_diff_stat_segments(summary, bar_bg, theme.git) ++
+          build_git_degraded_segments(degraded?, bar_bg)
     end
   end
+
+  # Visible indicator that the cached git status is degraded (e.g. it timed out
+  # on a huge full checkout, so untracked or other changes may be missing).
+  @spec build_git_degraded_segments(boolean(), non_neg_integer()) :: [render_segment()]
+  defp build_git_degraded_segments(true, bar_bg),
+    do: [{" #{@git_degraded_icon}", @git_degraded_fg, bar_bg, [bold: true], nil}]
+
+  defp build_git_degraded_segments(false, _bar_bg), do: []
 
   @spec build_diff_stat_segments(git_diff_summary(), non_neg_integer(), Theme.Git.t()) :: [
           render_segment()

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -23,6 +23,7 @@ defmodule MingaEditor.StatusBar.Data do
   alias Minga.Config.Options
   alias Minga.Git
   alias Minga.Git.MergeConflict
+  alias Minga.Git.Repo, as: GitRepo
   alias Minga.LSP.SyncServer
   alias MingaEditor.Shell.Traditional.Modeline
   alias MingaEditor.UI.Theme
@@ -59,6 +60,7 @@ defmodule MingaEditor.StatusBar.Data do
           dirty: boolean(),
           git_branch: String.t() | nil,
           git_diff_summary: git_diff_summary(),
+          git_degraded: boolean(),
           diagnostic_counts:
             {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil,
           diagnostic_hint: String.t() | nil,
@@ -104,6 +106,7 @@ defmodule MingaEditor.StatusBar.Data do
           dirty: boolean(),
           git_branch: String.t() | nil,
           git_diff_summary: git_diff_summary(),
+          git_degraded: boolean(),
           diagnostic_counts:
             {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil,
           diagnostic_hint: String.t() | nil,
@@ -169,6 +172,7 @@ defmodule MingaEditor.StatusBar.Data do
     file_path = if buf, do: buffer_file_path(buf), else: nil
 
     {git_branch, git_diff_summary} = git_modeline_data(buf)
+    git_degraded = git_degraded?(file_path)
     diagnostic_counts = diagnostic_modeline_data_from_path(file_path)
 
     # Fetch diagnostic hint for the current cursor line (shown in status bar
@@ -196,6 +200,7 @@ defmodule MingaEditor.StatusBar.Data do
       dirty: dirty,
       git_branch: git_branch,
       git_diff_summary: git_diff_summary,
+      git_degraded: git_degraded,
       diagnostic_counts: diagnostic_counts,
       diagnostic_hint: diagnostic_hint,
       indent_type: indent_type,
@@ -332,6 +337,7 @@ defmodule MingaEditor.StatusBar.Data do
     file_path = if buf, do: buffer_file_path(buf), else: nil
 
     {git_branch, git_diff_summary} = git_modeline_data(buf)
+    git_degraded = git_degraded?(file_path)
     diagnostic_counts = diagnostic_modeline_data_from_path(file_path)
     diagnostic_hint = cursor_line_diagnostic_hint_from_path(file_path, line)
     mode = Minga.Editing.mode(state)
@@ -361,6 +367,7 @@ defmodule MingaEditor.StatusBar.Data do
       dirty: dirty,
       git_branch: git_branch,
       git_diff_summary: git_diff_summary,
+      git_degraded: git_degraded,
       diagnostic_counts: diagnostic_counts,
       diagnostic_hint: diagnostic_hint,
       indent_type: indent_type,
@@ -407,6 +414,23 @@ defmodule MingaEditor.StatusBar.Data do
         catch
           :exit, _ -> {nil, nil}
         end
+    end
+  end
+
+  @doc """
+  Returns true when the tracked repo's cached status is degraded for `path`.
+
+  Reads the repo's cache-only snapshot (no git shell-out). Degraded means the
+  last `git status` was trimmed (e.g. timed out on a huge full checkout), so the
+  modeline shows a visible indicator rather than implying the status is complete.
+  """
+  @spec git_degraded?(String.t() | nil) :: boolean()
+  def git_degraded?(nil), do: false
+
+  def git_degraded?(path) when is_binary(path) do
+    case GitRepo.cached_status_for_path(path) do
+      {:ok, %{degraded?: degraded?}} -> degraded?
+      :not_tracked -> false
     end
   end
 
@@ -529,6 +553,7 @@ defmodule MingaEditor.StatusBar.Data do
       parser_status: d.parser_status,
       git_branch: d.git_branch,
       git_diff_summary: d.git_diff_summary,
+      git_degraded: Map.get(d, :git_degraded, false),
       diagnostic_counts: d.diagnostic_counts,
       indent_type: d.indent_type,
       indent_size: d.indent_size,

--- a/test/minga/git/repo/profile_test.exs
+++ b/test/minga/git/repo/profile_test.exs
@@ -7,6 +7,10 @@ defmodule Minga.Git.Repo.ProfileTest do
 
   @moduletag :tmp_dir
 
+  # Index sizes just past the heuristic thresholds (2 MB large, 10 MB huge).
+  @large_index_bytes 2 * 1024 * 1024
+  @huge_index_bytes 10 * 1024 * 1024
+
   test "defaults to normal untracked mode for ordinary repos", %{tmp_dir: dir} do
     File.mkdir_p!(Path.join(dir, ".git"))
 
@@ -15,6 +19,51 @@ defmodule Minga.Git.Repo.ProfileTest do
     refute profile.sparse?
     assert profile.size_class == :unknown
     assert profile.untracked_mode == :normal
+    assert profile.timeout_ms == 2_000
+  end
+
+  test "classifies a large full checkout from index size but keeps bounded normal mode",
+       %{tmp_dir: dir} do
+    write_index(dir, @large_index_bytes)
+
+    profile = Profile.detect(dir)
+
+    refute profile.sparse?
+    assert profile.size_class == :large
+    # AC 2: a large full checkout degrades to a bounded :normal, never :no.
+    assert profile.untracked_mode == :normal
+    assert profile.timeout_ms == 3_000
+  end
+
+  test "classifies a huge full checkout with a larger but bounded timeout", %{tmp_dir: dir} do
+    write_index(dir, @huge_index_bytes)
+
+    profile = Profile.detect(dir)
+
+    assert profile.size_class == :huge
+    assert profile.untracked_mode == :normal
+    assert profile.timeout_ms == 4_000
+  end
+
+  test "resolves a gitdir pointer file when sizing the index", %{tmp_dir: dir} do
+    # Worktree-style `.git` file pointing at the real git dir elsewhere.
+    real_git_dir = Path.join(dir, "real-git-dir")
+    File.mkdir_p!(real_git_dir)
+    File.write!(Path.join(real_git_dir, "index"), :binary.copy(<<0>>, @huge_index_bytes))
+
+    File.write!(Path.join(dir, ".git"), "gitdir: #{real_git_dir}\n")
+
+    profile = Profile.detect(dir)
+
+    assert profile.size_class == :huge
+  end
+
+  test "degrades_visibly? is true for normal full checkouts and false for sparse :no" do
+    full = %Profile{sparse?: false, size_class: :huge, untracked_mode: :normal, timeout_ms: 4_000}
+    sparse = %Profile{sparse?: true, size_class: :large, untracked_mode: :no, timeout_ms: 3_000}
+
+    assert Profile.degrades_visibly?(full)
+    refute Profile.degrades_visibly?(sparse)
   end
 
   test "uses no untracked enumeration for sparse repos", %{tmp_dir: dir} do
@@ -51,4 +100,12 @@ defmodule Minga.Git.Repo.ProfileTest do
   @spec restore_overrides(term()) :: :ok
   defp restore_overrides(nil), do: Application.delete_env(:minga, :git_repo_overrides)
   defp restore_overrides(value), do: Application.put_env(:minga, :git_repo_overrides, value)
+
+  # Writes a `.git/index` of the given byte size so size classification has a
+  # cheap proxy to read via File.stat.
+  @spec write_index(String.t(), non_neg_integer()) :: :ok
+  defp write_index(dir, bytes) do
+    File.mkdir_p!(Path.join(dir, ".git"))
+    File.write!(Path.join([dir, ".git", "index"]), :binary.copy(<<0>>, bytes))
+  end
 end

--- a/test/minga/git/repo_test.exs
+++ b/test/minga/git/repo_test.exs
@@ -435,6 +435,73 @@ defmodule Minga.Git.RepoTest do
     end
   end
 
+  describe "degraded status" do
+    test "flags degraded and keeps cached entries when status times out on a full checkout", %{
+      tmp_dir: dir
+    } do
+      events_registry = start_events_registry()
+      GitStub.set_root(dir, dir)
+      entry = %StatusEntry{path: "lib/foo.ex", status: :modified, staged: false}
+      GitStub.set_status(dir, [entry])
+      on_exit(fn -> GitStub.clear(dir) end)
+
+      repo = start_repo(dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
+
+      # Healthy to start.
+      assert {false, nil} = Repo.degraded(repo)
+      assert [^entry] = Repo.status(repo)
+
+      # A subsequent status times out; the repo (full checkout, untracked :normal)
+      # must surface this visibly instead of dropping the cached entries.
+      GitStub.set_status_error(dir, "git status failed: git command timed out after 4000ms")
+      Repo.refresh(repo)
+      Repo.await_refresh(repo)
+
+      assert {true, :status_timeout} = Repo.degraded(repo)
+      assert [^entry] = Repo.status(repo)
+      assert Repo.summary(repo).degraded?
+
+      assert {:ok, %StatusSnapshot{degraded?: true, degraded_reason: :status_timeout}} =
+               Repo.cached_status_for_path(Path.join(dir, "lib/foo.ex"))
+    end
+
+    test "clears the degraded flag once status succeeds again", %{tmp_dir: dir} do
+      events_registry = start_events_registry()
+      GitStub.set_root(dir, dir)
+      on_exit(fn -> GitStub.clear(dir) end)
+
+      repo = start_repo(dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
+
+      GitStub.set_status_error(dir, "git status failed: git command timed out after 4000ms")
+      Repo.refresh(repo)
+      Repo.await_refresh(repo)
+      assert {true, :status_timeout} = Repo.degraded(repo)
+
+      GitStub.set_status(dir, [%StatusEntry{path: "a.ex", status: :modified, staged: false}])
+      Repo.refresh(repo)
+      Repo.await_refresh(repo)
+
+      assert {false, nil} = Repo.degraded(repo)
+    end
+
+    test "a non-timeout status error does not flag degraded", %{tmp_dir: dir} do
+      events_registry = start_events_registry()
+      GitStub.set_root(dir, dir)
+      on_exit(fn -> GitStub.clear(dir) end)
+
+      repo = start_repo(dir, events_registry: events_registry)
+      Repo.await_refresh(repo)
+
+      GitStub.set_status_error(dir, "git status failed: fatal: not a git repository")
+      Repo.refresh(repo)
+      Repo.await_refresh(repo)
+
+      assert {false, nil} = Repo.degraded(repo)
+    end
+  end
+
   @spec start_events_registry() :: atom()
   defp start_events_registry do
     name = :"repo_events_#{System.unique_integer([:positive, :monotonic])}"

--- a/test/minga_editor/shell/traditional/modeline_test.exs
+++ b/test/minga_editor/shell/traditional/modeline_test.exs
@@ -192,6 +192,16 @@ defmodule MingaEditor.Shell.Traditional.ModelineTest do
         for unexpected <- excludes, do: refute(String.contains?(text, unexpected))
       end
     end
+
+    test "renders a degraded warning indicator when git status is degraded" do
+      degraded_icon = "\u{F071}"
+
+      degraded = segments_text(Map.merge(@base_data, %{git_branch: "main", git_degraded: true}))
+      assert String.contains?(degraded, degraded_icon)
+
+      healthy = segments_text(Map.merge(@base_data, %{git_branch: "main", git_degraded: false}))
+      refute String.contains?(healthy, degraded_icon)
+    end
   end
 
   describe "configurable segments" do


### PR DESCRIPTION
## Summary

`Minga.Git.Repo.Profile.detect/1` previously only auto-detected sparse checkouts; ordinary huge repos defaulted to normal untracked enumeration with a fixed timeout and, on a timeout, silently dropped all status. This adds cheap size classification plus a safe, visible degraded policy.

- **Size proxy:** classify full (non-sparse) checkouts from the `.git/index` file size via `File.stat`. The index holds ~80-100 bytes per tracked entry, so its size scales with tracked-file count, the cost driver for `git status`. This is O(1) and adds no startup filesystem walk. The existing `git_dir/1` helper resolves `gitdir:` pointer files first. Heuristic thresholds (documented in code): `>= 10 MB` → `:huge`, `>= 2 MB` → `:large`, else `:unknown`.
- **Bounded timeouts:** huge `4_000ms`, large `3_000ms`, else `2_000ms`. Full checkouts always keep `untracked_mode: :normal`, never `:no`.
- **Visible degraded indicator:** when `git status` times out on a full checkout, `Git.Repo` keeps the previously cached entries (no data drop) and records a degraded flag (`:status_timeout`). It is exposed via `Repo.degraded/1`, the summary, the cached `StatusSnapshot`, and the `:git_status_changed` event. The shared modeline renders a warning icon (`\u{F071}`) in the git segment, so both the Go TUI and macOS GUI surface it from the same BEAM render model (modeline segments are a generic styled-text list already on the wire, so no Swift/Go or protocol-struct changes were needed).

## Acceptance criteria

- [x] 1. Cheap, named size proxy (`.git/index` size), thresholds documented as heuristic, resolves `gitdir:` pointer, no startup walk.
- [x] 2. Huge and large repos default to `untracked_mode: :normal` with a bounded timeout and a visible "degraded" indicator on timeout; never silently `:no`.
- [x] 3. `untracked_mode: :no` reserved for sparse checkouts and explicit override (sparse behavior unchanged: `:no`, `:large`, 2s).
- [x] 4. Manual `:git_repo_overrides` still win (`apply_override` preserved).
- [x] 5. Modeline indicates degraded status (timed out / untracked omitted) from the repo profile.
- [x] 6. Tests cover sparse checkout, manual overrides, and size-heuristic paths, including that a large full checkout degrades to bounded `:normal` rather than `:no`.

## Tests

- `test/minga/git/repo/profile_test.exs`: large/huge classification from index size, bounded timeouts, gitdir-pointer resolution, `degrades_visibly?` predicate, sparse + override paths.
- `test/minga/git/repo_test.exs`: degraded flag set on status timeout with cached entries retained, flag cleared on recovery, non-timeout errors do not flag degraded.
- `test/minga_editor/shell/traditional/modeline_test.exs`: degraded warning icon rendered only when `git_degraded` is true.

`make lint` and `mix test.llm` both pass. The two intermittent failures seen during full-suite runs (`agent_cursor_test`, `file_tree_test` walk-telemetry span) pass in isolation and are pre-existing flakes unrelated to git; a separate set of `structural_navigation` failures was the parser binary missing from the test build path, not this change.

Closes #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)