### PR TITLE
perf(search): run project & TODO search off the editor path with stale-result protection

### DIFF
--- a/lib/minga/project/project_search.ex
+++ b/lib/minga/project/project_search.ex
@@ -2,9 +2,19 @@ defmodule Minga.Project.ProjectSearch do
   @moduledoc """
   Searches across project files using `ripgrep` or `grep`.
 
-  Shells out to the fastest available tool and parses structured output
-  into a flat list of match results. All functions are pure — no process
-  state is mutated.
+  Shells out to the fastest available tool and parses its output, line by line,
+  into a flat list of match results.
+
+  The subprocess is driven through an Erlang `Port` in `{:line, _}` mode so output
+  is collected and parsed incrementally. The result cap is enforced *while*
+  collecting: once #{10_000} matches have been gathered the port is closed, which
+  terminates the still-running scan instead of letting it walk the whole tree and
+  buffer megabytes of output we would only throw away. This keeps memory and time
+  bounded on large repositories, where `rg`/`grep` can otherwise emit far more than
+  the cap.
+
+  This is line collection, not a streaming JSON Port protocol; structured streaming
+  of `rg --json` results into the picker as they arrive is a separate follow-up.
 
   ## Tool preference
 
@@ -13,6 +23,11 @@ defmodule Minga.Project.ProjectSearch do
   """
 
   @max_results 10_000
+
+  # Upper bound on subprocess wall-clock time. A pathological scan that never
+  # reaches the cap (e.g. a huge tree with few matches) still returns rather than
+  # blocking the background task forever.
+  @search_timeout_ms 30_000
 
   @typedoc "A single search match across the project."
   @type match :: %{
@@ -50,17 +65,22 @@ defmodule Minga.Project.ProjectSearch do
     end
   end
 
+  @doc "Returns the in-process result cap applied while collecting matches."
+  @spec max_results() :: pos_integer()
+  def max_results, do: @max_results
+
   @doc """
   Detects which search strategy to use.
   """
   @spec detect_strategy() :: strategy()
   def detect_strategy do
-    cond do
-      System.find_executable("rg") != nil -> :rg
-      System.find_executable("grep") != nil -> :grep
-      true -> :none
-    end
+    detect_strategy(System.find_executable("rg"), System.find_executable("grep"))
   end
+
+  @spec detect_strategy(String.t() | nil, String.t() | nil) :: strategy()
+  defp detect_strategy(rg, _grep) when is_binary(rg), do: :rg
+  defp detect_strategy(_rg, grep) when is_binary(grep), do: :grep
+  defp detect_strategy(_rg, _grep), do: :none
 
   @doc """
   Parses a single ripgrep JSON line into a match map.
@@ -136,21 +156,15 @@ defmodule Minga.Project.ProjectSearch do
     end
   end
 
+  @typedoc "Line-parser used to turn a single tool output line into a match or skip."
+  @type parser :: (String.t() -> {:ok, match()} | :skip)
+
   # ── Ripgrep ──────────────────────────────────────────────────────────────
 
   @spec search_with_rg(String.t(), String.t()) :: result()
   defp search_with_rg(query, root) do
     args = ["--json", "--line-number", "--column", "--", query, "."]
-
-    case System.cmd("rg", args, cd: root, stderr_to_stdout: true) do
-      {output, code} when code in [0, 1] ->
-        collect_matches(output, &parse_rg_json_line/1)
-
-      {_output, code} ->
-        {:error, "ripgrep exited with code #{code}"}
-    end
-  rescue
-    e -> {:error, "ripgrep failed: #{Exception.message(e)}"}
+    run_capped("rg", args, root, &parse_rg_json_line/1, "ripgrep")
   end
 
   # ── Grep fallback ────────────────────────────────────────────────────────
@@ -158,40 +172,92 @@ defmodule Minga.Project.ProjectSearch do
   @spec search_with_grep(String.t(), String.t()) :: result()
   defp search_with_grep(query, root) do
     args = ["-rn", "-I", "--", query, "."]
+    run_capped("grep", args, root, &parse_grep_line/1, "grep")
+  end
 
-    case System.cmd("grep", args, cd: root, stderr_to_stdout: true) do
-      {output, code} when code in [0, 1] ->
-        collect_matches(output, &parse_grep_line/1)
+  # ── Capped, incremental subprocess collection ──────────────────────────────
 
-      {_output, code} ->
-        {:error, "grep exited with code #{code}"}
+  # Spawns the tool through a Port in line mode and parses output as it arrives,
+  # accumulating matches until the cap is hit. Reaching the cap closes the port,
+  # which terminates the still-running scan — the cap is enforced *while*
+  # collecting, not after the full output has been buffered.
+  @spec run_capped(String.t(), [String.t()], String.t(), parser(), String.t()) :: result()
+  defp run_capped(tool, args, root, parser, label) do
+    case System.find_executable(tool) do
+      nil ->
+        {:error, "#{label} not found"}
+
+      executable ->
+        open_and_collect(executable, args, root, parser, label)
     end
   rescue
-    e -> {:error, "grep failed: #{Exception.message(e)}"}
+    e -> {:error, "#{label} failed: #{Exception.message(e)}"}
   end
 
-  # ── Helpers ──────────────────────────────────────────────────────────────
+  @spec open_and_collect(String.t(), [String.t()], String.t(), parser(), String.t()) :: result()
+  defp open_and_collect(executable, args, root, parser, label) do
+    port =
+      Port.open({:spawn_executable, executable}, [
+        :binary,
+        :exit_status,
+        :hide,
+        {:args, args},
+        {:cd, root},
+        {:line, 65_536}
+      ])
 
-  @spec collect_matches(String.t(), (String.t() -> {:ok, match()} | :skip)) :: result()
-  defp collect_matches(output, parser) do
-    lines = String.split(output, "\n", trim: true)
-    {matches, truncated?} = collect_lines(lines, parser, [], false)
-    {:ok, Enum.reverse(matches), truncated?}
+    collect(port, parser, [], 0, "", label)
   end
 
-  @spec collect_lines([String.t()], (String.t() -> {:ok, match()} | :skip), [match()], boolean()) ::
-          {[match()], boolean()}
-  defp collect_lines([], _parser, acc, truncated?), do: {acc, truncated?}
-
-  defp collect_lines(_lines, _parser, acc, _truncated?) when length(acc) >= @max_results do
-    {acc, true}
+  # Drains the port. `acc` holds matches newest-first, `count` tracks how many we
+  # have, and `partial` buffers the tail of an over-long line that the port split
+  # across `:line` fragments. On the cap, close the port and stop.
+  @spec collect(port(), parser(), [match()], non_neg_integer(), String.t(), String.t()) ::
+          result()
+  defp collect(port, _parser, acc, count, _partial, _label) when count >= @max_results do
+    close_port(port)
+    {:ok, Enum.reverse(acc), true}
   end
 
-  defp collect_lines([line | rest], parser, acc, _truncated?) do
-    case parser.(line) do
-      {:ok, match} -> collect_lines(rest, parser, [match | acc], false)
-      :skip -> collect_lines(rest, parser, acc, false)
+  defp collect(port, parser, acc, count, partial, label) do
+    receive do
+      {^port, {:data, {:eol, chunk}}} ->
+        {acc, count} = accumulate(parser, partial <> chunk, acc, count)
+        collect(port, parser, acc, count, "", label)
+
+      {^port, {:data, {:noeol, chunk}}} ->
+        collect(port, parser, acc, count, partial <> chunk, label)
+
+      {^port, {:exit_status, status}} when status in [0, 1] ->
+        {acc, _count} = accumulate(parser, partial, acc, count)
+        {:ok, Enum.reverse(acc), false}
+
+      {^port, {:exit_status, status}} ->
+        {:error, "#{label} exited with code #{status}"}
+    after
+      @search_timeout_ms ->
+        close_port(port)
+        {:error, "#{label} timed out"}
     end
+  end
+
+  @spec accumulate(parser(), String.t(), [match()], non_neg_integer()) ::
+          {[match()], non_neg_integer()}
+  defp accumulate(_parser, "", acc, count), do: {acc, count}
+
+  defp accumulate(parser, line, acc, count) do
+    case parser.(line) do
+      {:ok, match} -> {[match | acc], count + 1}
+      :skip -> {acc, count}
+    end
+  end
+
+  @spec close_port(port()) :: :ok
+  defp close_port(port) do
+    Port.close(port)
+    :ok
+  rescue
+    ArgumentError -> :ok
   end
 
   @spec normalize_path(String.t()) :: String.t()

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -822,13 +822,13 @@ defmodule MingaEditor do
   # When a picker source is async, PickerUI.open/3 opens the picker immediately
   # with a loading indicator, then sends this message to spawn the background fetch.
 
-  def handle_info({:picker_fetch_candidates, source_module, ctx}, state) do
+  def handle_info({:picker_fetch_candidates, source_module, revision, ctx}, state) do
     editor = self()
 
-    Task.start(fn ->
+    Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
       result =
         try do
-          {:ok, source_module.candidates(ctx)}
+          MingaEditor.UI.Picker.Source.fetch(source_module, ctx)
         rescue
           e -> {:error, Exception.message(e)}
         catch
@@ -836,17 +836,27 @@ defmodule MingaEditor do
           :throw, value -> {:error, "Source failed: #{inspect(value)}"}
         end
 
-      send(editor, {:picker_candidates_result, source_module, result})
+      send(editor, {:picker_candidates_result, source_module, revision, result})
     end)
 
     {:noreply, state}
   end
 
-  def handle_info({:picker_candidates_result, source_module, result}, state) do
+  # Latest-wins stale-result guard: a candidate fetch is applied only when the
+  # live picker is still the same source *and* the result carries the picker's
+  # current fetch revision. A newer search, project switch, reopen, or close
+  # mints a new revision (or drops the picker), so older in-flight fetches land
+  # here as stale and are discarded. This is intentionally NOT the AsyncAction
+  # lane token, which serializes FIFO; here the newest fetch wins.
+  def handle_info({:picker_candidates_result, source_module, revision, result}, state) do
     case state.shell_state.modal do
-      {:picker, %{picker_ui: %{source: ^source_module}} = payload} ->
-        new_state = handle_picker_candidates(state, payload, result)
-        {:noreply, Renderer.render_or_async(new_state)}
+      {:picker, %{picker_ui: %{source: ^source_module} = picker_ui} = payload} ->
+        if MingaEditor.State.Picker.current_fetch?(picker_ui, revision) do
+          new_state = handle_picker_candidates(state, payload, result)
+          {:noreply, Renderer.render_or_async(new_state)}
+        else
+          {:noreply, state}
+        end
 
       _ ->
         {:noreply, state}
@@ -915,18 +925,16 @@ defmodule MingaEditor do
   @spec handle_picker_candidates(
           state(),
           PickerPayload.t(),
-          {:ok, [term()]} | {:error, String.t()}
+          {:ok, [term()], MingaEditor.UI.Picker.Source.fetch_meta()} | {:error, String.t()}
         ) :: state()
-  defp handle_picker_candidates(state, payload, {:ok, items}) do
+  defp handle_picker_candidates(state, payload, {:ok, items, meta}) do
     picker_state = payload.picker_ui
     picker = MingaEditor.UI.Picker.replace_items(picker_state.picker, items)
     new_picker_state = %{picker_state | picker: picker, load_status: :ready}
 
-    ModalOverlay.transition(
-      state,
-      :picker,
-      PickerPayload.put_picker_ui(payload, new_picker_state)
-    )
+    state
+    |> ModalOverlay.transition(:picker, PickerPayload.put_picker_ui(payload, new_picker_state))
+    |> apply_fetch_status(meta)
   end
 
   defp handle_picker_candidates(state, payload, {:error, reason}) do
@@ -939,6 +947,13 @@ defmodule MingaEditor do
       PickerPayload.put_picker_ui(payload, new_picker_state)
     )
   end
+
+  @spec apply_fetch_status(state(), MingaEditor.UI.Picker.Source.fetch_meta()) :: state()
+  defp apply_fetch_status(state, %{status: status}) when is_binary(status) do
+    EditorState.set_status(state, status)
+  end
+
+  defp apply_fetch_status(state, _meta), do: state
 
   @spec current_observatory_token?(state(), reference()) :: boolean()
   defp current_observatory_token?(

--- a/lib/minga_editor/commands/search.ex
+++ b/lib/minga_editor/commands/search.ex
@@ -17,7 +17,6 @@ defmodule MingaEditor.Commands.Search do
   alias Minga.Mode
   alias Minga.Mode.CommandState
   alias Minga.Mode.SearchState
-  alias Minga.Project.ProjectSearch
 
   @type state :: EditorState.t()
 
@@ -209,24 +208,12 @@ defmodule MingaEditor.Commands.Search do
         :confirm_project_search
       )
       when is_binary(query) and query != "" do
-    root = project_root()
-
-    case ProjectSearch.search(query, root) do
-      {:ok, [], _truncated?} ->
-        EditorState.set_status(state, "No results for: #{query}")
-
-      {:ok, matches, truncated?} ->
-        msg = if truncated?, do: "Results truncated to 10,000", else: nil
-
-        state =
-          EditorState.update_search(state, &SearchData.set_project_results(&1, matches))
-
-        state = PickerUI.open(state, MingaEditor.UI.Picker.ProjectSearchSource)
-        if msg, do: EditorState.set_status(state, msg), else: state
-
-      {:error, msg} ->
-        EditorState.set_status(state, msg)
-    end
+    # Stash the query, then open the picker asynchronously. The actual `rg`/`grep`
+    # scan runs off the editor input path inside ProjectSearchSource.async_fetch/1,
+    # so confirming a search never blocks the editor on a large repository.
+    state
+    |> EditorState.update_search(&SearchData.set_project_query(&1, query))
+    |> PickerUI.open(MingaEditor.UI.Picker.ProjectSearchSource)
   end
 
   def execute(state, :confirm_project_search) do

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -113,11 +113,14 @@ defmodule MingaEditor.PickerUI do
       load_status: :loading
     }
 
+    {picker_state, revision} = PickerState.begin_fetch(picker_state)
+
     new_state = ModalOverlay.open(new_state, :picker, PickerPayload.new(picker_state))
 
     send(
       self(),
-      {:picker_fetch_candidates, source_module, Context.from_editor_state(state, context)}
+      {:picker_fetch_candidates, source_module, revision,
+       Context.from_editor_state(state, context)}
     )
 
     new_state

--- a/lib/minga_editor/state/picker.ex
+++ b/lib/minga_editor/state/picker.ex
@@ -13,6 +13,14 @@ defmodule MingaEditor.State.Picker do
   @typedoc "Async loading status for sources that fetch candidates in the background."
   @type load_status :: :ready | :loading | {:error, String.t()}
 
+  @typedoc """
+  Latest-wins guard for async candidate fetches. Each `open_async` mints a fresh
+  reference; a result whose revision doesn't match the live picker's is stale and
+  dropped. Unlike the AsyncAction lane token (FIFO serial), this drops *older*
+  in-flight fetches when a newer search, project switch, or reopen supersedes them.
+  """
+  @type fetch_revision :: reference() | nil
+
   @type t :: %__MODULE__{
           picker: MingaEditor.UI.Picker.t() | nil,
           source: module() | nil,
@@ -23,7 +31,8 @@ defmodule MingaEditor.State.Picker do
           layout: MingaEditor.UI.Picker.Source.layout(),
           original_source: module() | nil,
           mode_prefix: String.t(),
-          load_status: load_status()
+          load_status: load_status(),
+          fetch_revision: fetch_revision()
         }
 
   defstruct picker: nil,
@@ -35,7 +44,8 @@ defmodule MingaEditor.State.Picker do
             layout: :bottom,
             original_source: nil,
             mode_prefix: "",
-            load_status: :ready
+            load_status: :ready,
+            fetch_revision: nil
 
   @doc "Returns true if a picker is currently open."
   @spec open?(t()) :: boolean()
@@ -53,4 +63,22 @@ defmodule MingaEditor.State.Picker do
   def update_picker(%__MODULE__{} = ps, picker) do
     %{ps | picker: picker}
   end
+
+  @doc """
+  Mints a fresh fetch revision and marks the picker as loading.
+
+  Call this when starting an async candidate fetch. The returned `{ps, revision}`
+  tuple lets the caller tag the off-path fetch with `revision` so a stale result
+  (one whose revision no longer matches the live picker) can be dropped.
+  """
+  @spec begin_fetch(t()) :: {t(), reference()}
+  def begin_fetch(%__MODULE__{} = ps) do
+    revision = make_ref()
+    {%{ps | fetch_revision: revision, load_status: :loading}, revision}
+  end
+
+  @doc "Returns whether `revision` is the picker's current (live) fetch revision."
+  @spec current_fetch?(t(), fetch_revision()) :: boolean()
+  def current_fetch?(%__MODULE__{fetch_revision: revision}, revision), do: true
+  def current_fetch?(%__MODULE__{}, _revision), do: false
 end

--- a/lib/minga_editor/state/search.ex
+++ b/lib/minga_editor/state/search.ex
@@ -3,8 +3,9 @@ defmodule MingaEditor.State.Search do
   Groups search-related fields from EditorState.
 
   Tracks the last search pattern and direction (for `n`/`N` repeat),
-  cached project-wide search results for the picker, and the GUI search
-  toolbar state (active, flags, replace mode).
+  the pending project-wide search query (read off the editor path by the
+  project search picker source), and the GUI search toolbar state (active,
+  flags, replace mode).
   """
 
   @typedoc "GUI search toolbar state. Non-nil means the toolbar is active."
@@ -18,13 +19,13 @@ defmodule MingaEditor.State.Search do
   @type t :: %__MODULE__{
           last_pattern: String.t() | nil,
           last_direction: Minga.Editing.Search.direction(),
-          project_results: [Minga.Project.ProjectSearch.match()],
+          project_query: String.t() | nil,
           gui_search: gui_search() | nil
         }
 
   defstruct last_pattern: nil,
             last_direction: :forward,
-            project_results: [],
+            project_query: nil,
             gui_search: nil
 
   @doc "Records the last search pattern and direction."
@@ -45,10 +46,10 @@ defmodule MingaEditor.State.Search do
     %{s | last_direction: direction}
   end
 
-  @doc "Replaces the cached project search results."
-  @spec set_project_results(t(), [Minga.Project.ProjectSearch.match()]) :: t()
-  def set_project_results(%__MODULE__{} = s, results) when is_list(results) do
-    %{s | project_results: results}
+  @doc "Stores the pending project-wide search query for the async picker source."
+  @spec set_project_query(t(), String.t()) :: t()
+  def set_project_query(%__MODULE__{} = s, query) when is_binary(query) do
+    %{s | project_query: query}
   end
 
   @doc "Activates the GUI search toolbar with the given flags."

--- a/lib/minga_editor/ui/picker/project_search_source.ex
+++ b/lib/minga_editor/ui/picker/project_search_source.ex
@@ -2,20 +2,27 @@ defmodule MingaEditor.UI.Picker.ProjectSearchSource do
   @moduledoc """
   Picker source for project-wide search results.
 
-  Displays results from `Minga.Project.ProjectSearch` in a filterable picker.
-  Selecting a result opens the file at the matching line and column.
+  The scan runs off the editor input path: this source is async, so
+  `PickerUI.open/3` shows the picker immediately with a "Searching…" indicator
+  and `async_fetch/1` runs `Minga.Project.ProjectSearch.search/2` in a background
+  task. The query is read from the stashed `search.project_query`. Each match is
+  embedded directly in its `Item.id`, so selecting a result resolves the file and
+  position without a separate cached-results lookup. When the in-process result
+  cap is hit, the fetch reports a truncated status.
   """
 
   @behaviour MingaEditor.UI.Picker.Source
 
+  alias Minga.Buffer
   alias Minga.Language
+  alias Minga.Language.Devicon
+  alias Minga.Project.ProjectSearch
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
-
-  alias Minga.Buffer
-  alias MingaEditor.State, as: EditorState
-  alias Minga.Language.Devicon
   alias MingaEditor.UI.Picker.Source
+
+  @truncated_status "Results truncated to #{ProjectSearch.max_results()}"
 
   @impl true
   @spec title() :: String.t()
@@ -26,35 +33,64 @@ defmodule MingaEditor.UI.Picker.ProjectSearchSource do
   def preview?, do: true
 
   @impl true
+  @spec async?() :: boolean()
+  def async?, do: true
+
+  @impl true
   @spec candidates(Context.t()) :: [Item.t()]
-  def candidates(%Context{search: %{project_results: results}}) when is_list(results) do
-    results
-    |> Enum.with_index()
-    |> Enum.map(fn {match, idx} ->
+  def candidates(ctx) do
+    case async_fetch(ctx) do
+      {:ok, items, _meta} -> items
+      {:error, _reason} -> []
+    end
+  end
+
+  @impl true
+  @spec async_fetch(Context.t()) ::
+          {:ok, [Item.t()], Source.fetch_meta()} | {:error, String.t()}
+  def async_fetch(%Context{search: %{project_query: query}})
+      when is_binary(query) and query != "" do
+    case ProjectSearch.search(query, Minga.Project.resolve_root()) do
+      {:ok, matches, truncated?} ->
+        {:ok, build_items(matches), fetch_meta(truncated?)}
+
+      {:error, message} ->
+        {:error, message}
+    end
+  end
+
+  def async_fetch(_ctx), do: {:ok, [], %{}}
+
+  @impl true
+  @spec on_select(Item.t(), term()) :: term()
+  def on_select(%Item{id: %{file: _file} = match}, state) do
+    open_match(state, match)
+  end
+
+  def on_select(_item, state), do: state
+
+  @impl true
+  def on_cancel(state), do: Source.restore_or_keep(state)
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec build_items([ProjectSearch.match()]) :: [Item.t()]
+  defp build_items(matches) do
+    Enum.map(matches, fn match ->
       filename = Path.basename(match.file)
       ft = Language.detect_filetype(filename)
       {icon, color} = Devicon.icon_and_color(ft)
       label = "#{icon} #{match.file}:#{match.line}"
       desc = String.trim(match.text)
-      %Item{id: idx, label: label, description: desc, icon_color: color}
+      %Item{id: match, label: label, description: desc, icon_color: color}
     end)
   end
 
-  def candidates(_context), do: []
+  @spec fetch_meta(boolean()) :: Source.fetch_meta()
+  defp fetch_meta(true), do: %{status: @truncated_status}
+  defp fetch_meta(false), do: %{}
 
-  @impl true
-  @spec on_select(Item.t(), term()) :: term()
-  def on_select(%Item{id: idx}, %{workspace: %{search: %{project_results: results}}} = state)
-      when is_integer(idx) do
-    case Enum.at(results, idx) do
-      nil -> state
-      match -> open_match(state, match)
-    end
-  end
-
-  def on_select(_item, state), do: state
-
-  @spec open_match(map(), map()) :: map()
+  @spec open_match(map(), ProjectSearch.match()) :: map()
   defp open_match(state, match) do
     abs_path = Path.expand(match.file)
     line = max(match.line - 1, 0)
@@ -87,9 +123,4 @@ defmodule MingaEditor.UI.Picker.ProjectSearchSource do
     Buffer.move_to(pid, {line, col})
     new_state
   end
-
-  @impl true
-  def on_cancel(state), do: Source.restore_or_keep(state)
-
-  # ── Private ─────────────────────────────────────────────────────────────────
 end

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -139,6 +139,24 @@ defmodule MingaEditor.UI.Picker.Source do
   """
   @callback async?() :: boolean()
 
+  @typedoc """
+  Extra info an async source can report alongside its candidates, surfaced by the
+  editor once results land (e.g. a "results truncated" status line). Sources that
+  don't need it omit `async_fetch/1` and the editor uses an empty map.
+  """
+  @type fetch_meta :: %{optional(:status) => String.t()}
+
+  @doc """
+  Async candidate fetch with optional reporting metadata.
+
+  Runs off the editor input path inside the picker's background task. Sources that
+  need to report a status (e.g. project search reporting that results were capped)
+  implement this and return `{:ok, items, meta}`; everything else falls back to
+  `candidates/1` via `fetch/2`. Errors are returned as `{:error, message}`.
+  """
+  @callback async_fetch(Context.t()) ::
+              {:ok, [Picker.item()], fetch_meta()} | {:error, String.t()}
+
   @doc """
   Enriches a bounded list of items for display.
 
@@ -167,6 +185,7 @@ defmodule MingaEditor.UI.Picker.Source do
     layout: 0,
     keep_open_on_select?: 0,
     async?: 0,
+    async_fetch: 1,
     enrich: 1
   ]
 
@@ -324,6 +343,23 @@ defmodule MingaEditor.UI.Picker.Source do
       module.async?()
     else
       false
+    end
+  end
+
+  @doc """
+  Runs an async source's candidate fetch, returning `{:ok, items, meta}`.
+
+  Prefers the source's own `async_fetch/1` (so it can report status metadata such
+  as truncation); otherwise falls back to `candidates/1` with empty metadata. Used
+  by the editor's background fetch task, off the input path.
+  """
+  @spec fetch(module(), Context.t()) ::
+          {:ok, [Picker.item()], fetch_meta()} | {:error, String.t()}
+  def fetch(module, context) do
+    if exported?(module, :async_fetch, 1) do
+      module.async_fetch(context)
+    else
+      {:ok, module.candidates(context), %{}}
     end
   end
 

--- a/lib/minga_editor/ui/picker/todo_search_source.ex
+++ b/lib/minga_editor/ui/picker/todo_search_source.ex
@@ -3,6 +3,11 @@ defmodule MingaEditor.UI.Picker.TodoSearchSource do
   Picker source for project TODO-style comment markers.
 
   Uses `git grep` in repositories so ignored files stay ignored, and falls back to recursive `grep` outside git repositories.
+
+  The scan is async: the picker opens immediately with a "Searching…" indicator
+  and the project-wide `git grep`/`grep` shell-out runs in a background task off
+  the editor input path, with latest-wins stale-result protection (a reopen or
+  project switch drops an older in-flight result).
   """
 
   @behaviour MingaEditor.UI.Picker.Source
@@ -30,6 +35,10 @@ defmodule MingaEditor.UI.Picker.TodoSearchSource do
   @impl true
   @spec preview?() :: boolean()
   def preview?, do: true
+
+  @impl true
+  @spec async?() :: boolean()
+  def async?, do: true
 
   @impl true
   @spec candidates(Context.t()) :: [Item.t()]

--- a/test/minga/project/project_search_test.exs
+++ b/test/minga/project/project_search_test.exs
@@ -136,5 +136,26 @@ defmodule Minga.Project.ProjectSearchTest do
           :ok
       end
     end
+
+    test "caps results in-process and reports truncation when matches exceed the cap" do
+      dir = Path.join(System.tmp_dir!(), "minga-search-cap-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      over_cap = ProjectSearch.max_results() + 50
+      lines = Enum.map_join(1..over_cap, "\n", fn _ -> "NEEDLE here" end)
+      File.write!(Path.join(dir, "haystack.txt"), lines <> "\n")
+
+      case ProjectSearch.search("NEEDLE", dir) do
+        {:ok, matches, truncated?} ->
+          # The cap is enforced while collecting: we never accumulate more than
+          # the cap regardless of how many lines the subprocess could emit.
+          assert truncated?
+          assert length(matches) == ProjectSearch.max_results()
+
+        {:error, _} ->
+          :ok
+      end
+    end
   end
 end

--- a/test/minga_editor/commands/search_async_test.exs
+++ b/test/minga_editor/commands/search_async_test.exs
@@ -1,0 +1,76 @@
+defmodule MingaEditor.Commands.SearchAsyncTest do
+  @moduledoc """
+  Verifies project search confirmation hands off to the async picker path
+  instead of running the `rg`/`grep` scan synchronously on the editor input
+  path (ticket #2376, AC1/AC6).
+  """
+
+  use ExUnit.Case, async: true
+
+  import MingaEditor.RenderPipeline.TestHelpers, only: [base_state: 1]
+
+  alias Minga.Mode.SearchPromptState
+  alias MingaEditor.Commands.Search
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+
+  defp with_search_prompt(state, input) do
+    EditorState.transition_mode(state, :search_prompt, %SearchPromptState{input: input})
+  end
+
+  describe ":confirm_project_search" do
+    test "opens the picker immediately in a loading state without blocking on the scan" do
+      state =
+        base_state(content: "scratch")
+        |> with_search_prompt("some-query-that-need-not-match-anything")
+
+      # The command must return promptly. If it blocked on a real subprocess scan,
+      # it could not return a :loading picker synchronously — the picker would
+      # already hold results (or the call would hang on a large repo).
+      new_state = Search.execute(state, :confirm_project_search)
+
+      assert ModalOverlay.match(new_state.shell_state.modal, :picker)
+      {:picker, %{picker_ui: picker_ui}} = new_state.shell_state.modal
+      assert picker_ui.load_status == :loading
+      assert picker_ui.source == MingaEditor.UI.Picker.ProjectSearchSource
+
+      # A fresh fetch revision was minted: this is the latest-wins guard token,
+      # carried on the deferred fetch and checked when results land.
+      assert is_reference(picker_ui.fetch_revision)
+    end
+
+    test "stashes the query for the off-path source to read" do
+      state =
+        base_state(content: "scratch")
+        |> with_search_prompt("widget")
+
+      new_state = Search.execute(state, :confirm_project_search)
+      assert new_state.workspace.search.project_query == "widget"
+    end
+
+    test "defers the actual fetch via a self-sent message rather than running it inline" do
+      state =
+        base_state(content: "scratch")
+        |> with_search_prompt("widget")
+
+      _new_state = Search.execute(state, :confirm_project_search)
+
+      # PickerUI.open/3 for an async source enqueues the fetch to the editor's own
+      # mailbox (self() here is the test process), keeping the scan off the
+      # synchronous command path. Assert the deferred fetch was scheduled.
+      assert_received {:picker_fetch_candidates, MingaEditor.UI.Picker.ProjectSearchSource,
+                       revision, _ctx}
+
+      assert is_reference(revision)
+    end
+
+    test "empty query reports a status instead of opening the picker" do
+      state =
+        base_state(content: "scratch")
+        |> with_search_prompt("")
+
+      new_state = Search.execute(state, :confirm_project_search)
+      refute ModalOverlay.match(new_state.shell_state.modal, :picker)
+    end
+  end
+end

--- a/test/minga_editor/picker_async_stale_test.exs
+++ b/test/minga_editor/picker_async_stale_test.exs
@@ -1,0 +1,81 @@
+defmodule MingaEditor.PickerAsyncStaleTest do
+  @moduledoc """
+  Editor-level coverage for the async picker fetch path (ticket #2376):
+
+    * confirming an async picker returns control immediately with a loading state
+      and runs the candidate fetch off the editor input path (AC1/AC5);
+    * results are revision-tagged so a stale (older-revision) result is dropped
+      latest-wins and never overwrites the live picker (AC2/AC6).
+
+  Uses the TODO search source (async). The stale-drop assertion is robust against
+  the real background fetch: a sentinel item carried on a non-live revision can
+  never appear, regardless of whether the real fetch has landed.
+  """
+
+  use Minga.Test.EditorCase, async: true
+
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.TodoSearchSource
+
+  @sync_timeout 15_000
+
+  setup do
+    root =
+      Path.join(System.tmp_dir!(), "minga-async-picker-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf(root) end)
+    %{project_root: root}
+  end
+
+  defp picker_payload(ctx) do
+    case :sys.get_state(ctx.editor, @sync_timeout).shell_state.modal do
+      {:picker, payload} -> payload
+      _ -> nil
+    end
+  end
+
+  defp item(label), do: %Item{id: %{path: "/tmp/x.ex", line: 1}, label: label}
+
+  test "opens immediately in a loading state with a fetch revision (off the editor path)",
+       %{project_root: root} do
+    ctx = start_editor("scratch", project_root: root)
+
+    # The command returns :ok promptly with a loading picker, proving the scan did
+    # not run synchronously on the command path.
+    :ok = GenServer.call(ctx.editor, {:api_execute_command, :search_todos}, @sync_timeout)
+
+    payload = picker_payload(ctx)
+    assert payload != nil
+    assert payload.picker_ui.source == TodoSearchSource
+    assert payload.picker_ui.load_status == :loading
+    assert is_reference(payload.picker_ui.fetch_revision)
+  end
+
+  test "drops a stale (non-live-revision) result and never lets it overwrite the picker",
+       %{project_root: root} do
+    ctx = start_editor("scratch", project_root: root)
+    :ok = GenServer.call(ctx.editor, {:api_execute_command, :search_todos}, @sync_timeout)
+
+    # A result tagged with a revision that is not the picker's live one is stale
+    # and must be ignored. This is latest-wins: a superseded fetch loses even if
+    # it arrives after the picker opened.
+    stale_revision = make_ref()
+
+    send(
+      ctx.editor,
+      {:picker_candidates_result, TodoSearchSource, stale_revision,
+       {:ok, [item("stale-sentinel")], %{}}}
+    )
+
+    _ = :sys.get_state(ctx.editor, @sync_timeout)
+
+    labels =
+      case picker_payload(ctx) do
+        %{picker_ui: %{picker: %{items: items}}} -> Enum.map(items, & &1.label)
+        _ -> []
+      end
+
+    refute "stale-sentinel" in labels
+  end
+end

--- a/test/minga_editor/state/picker_test.exs
+++ b/test/minga_editor/state/picker_test.exs
@@ -1,0 +1,34 @@
+defmodule MingaEditor.State.PickerTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.State.Picker, as: PickerState
+
+  describe "begin_fetch/1 and current_fetch?/2" do
+    test "marks the picker loading and mints a fresh revision" do
+      {ps, revision} = PickerState.begin_fetch(%PickerState{})
+
+      assert ps.load_status == :loading
+      assert is_reference(revision)
+      assert ps.fetch_revision == revision
+    end
+
+    test "only the live revision is current (latest-wins, not FIFO)" do
+      {ps, first} = PickerState.begin_fetch(%PickerState{})
+      assert PickerState.current_fetch?(ps, first)
+
+      # A newer search / project switch / reopen mints a new revision on the same
+      # picker. The older in-flight fetch is now stale and must be dropped, even
+      # though it was requested first. This is the latest-wins behavior the ticket
+      # requires, distinct from the AsyncAction lane token's FIFO serialization.
+      {ps, second} = PickerState.begin_fetch(ps)
+
+      refute PickerState.current_fetch?(ps, first)
+      assert PickerState.current_fetch?(ps, second)
+    end
+
+    test "a nil revision never matches a picker that has a live fetch" do
+      {ps, _revision} = PickerState.begin_fetch(%PickerState{})
+      refute PickerState.current_fetch?(ps, nil)
+    end
+  end
+end

--- a/test/minga_editor/ui/picker/project_search_source_test.exs
+++ b/test/minga_editor/ui/picker/project_search_source_test.exs
@@ -1,0 +1,65 @@
+defmodule MingaEditor.UI.Picker.ProjectSearchSourceTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.State.Search
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.ProjectSearchSource
+
+  # Minimal Context carrying only the field the source reads (the stashed query).
+  defp ctx(query) do
+    struct!(Context,
+      buffers: %{active: nil},
+      editing: nil,
+      search: %Search{project_query: query},
+      viewport: nil,
+      tab_bar: nil,
+      picker_ui: %{},
+      capabilities: %{},
+      theme: nil
+    )
+  end
+
+  describe "async?/0" do
+    test "the project search source runs off the editor input path" do
+      assert ProjectSearchSource.async?()
+    end
+  end
+
+  describe "async_fetch/1" do
+    test "returns no items and no status when there is no pending query" do
+      assert {:ok, [], %{}} = ProjectSearchSource.async_fetch(ctx(nil))
+      assert {:ok, [], %{}} = ProjectSearchSource.async_fetch(ctx(""))
+    end
+
+    test "fetching the repo for a known term embeds each match in its item id" do
+      # Runs the real search against the repo root (resolve_root). Selection no
+      # longer depends on a separate cached-results list: the match travels in id.
+      case ProjectSearchSource.async_fetch(ctx("defmodule")) do
+        {:ok, [%Item{id: id} | _], _meta} ->
+          assert is_map(id)
+          assert is_binary(id.file)
+          assert is_integer(id.line) and id.line > 0
+
+        {:ok, [], _meta} ->
+          :ok
+
+        {:error, _} ->
+          :ok
+      end
+    end
+  end
+
+  describe "candidates/1" do
+    test "is a thin wrapper over async_fetch and returns [] on missing query" do
+      assert ProjectSearchSource.candidates(ctx(nil)) == []
+    end
+  end
+
+  describe "on_select/2" do
+    test "ignores items whose id is not a match map" do
+      state = %{ignored: true}
+      assert ProjectSearchSource.on_select(%Item{id: 0, label: "x"}, state) == state
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Project-wide text search (`rg`/`grep`/`git grep`) no longer blocks the editor GenServer while scanning a large repository. Confirming a project search returns control to the editor immediately with a searching state; the scan runs off the editor input path via a supervised `Task`, results are revision-tagged for latest-wins stale-result protection, and the 10,000 result cap is enforced in-process while collecting (the subprocess is terminated at the cap rather than running to completion).

This reuses the editor's existing async picker fetch mechanism (`async?/0` + `:picker_fetch_candidates` → Task → `:picker_candidates_result`) rather than inventing a second concurrency mechanism, and adds the per-source revision counter the ticket requires. No streaming `rg --json` Port protocol is introduced; that remains a follow-up.

## Acceptance Criteria

- [x] **1. Confirming project search returns control immediately with a pending/searching state; work runs off the editor input path via a supervised `Task`.** `:confirm_project_search` stashes the query and opens the picker in `:loading`; the scan runs in a Task under `Minga.Eval.TaskSupervisor`.
- [x] **2. Results are revision-tagged with a per-source counter so a newer search, project switch, or picker close drops stale results (latest-wins, not FIFO; not the AsyncAction lane token).** `PickerState.fetch_revision` is minted by `begin_fetch/1` on each open; the editor applies a result only when `current_fetch?/2` matches the live revision.
- [x] **3. The 10,000 result cap is enforced in-process while collecting, not only after full subprocess output.** `ProjectSearch` drives `rg`/`grep` through an Erlang Port in line mode and closes the port (terminating the scan) once the cap is reached.
- [x] **4. The project search picker opens when results are available and shows a truncated status when the cap is hit.** `async_fetch/1` returns `fetch_meta` with a truncated status that the editor surfaces on the status line.
- [x] **5. TODO search also avoids synchronous project-wide shell-out on picker open, using the same off-path + revision pattern.** `TodoSearchSource` is now `async?: true`, so its `git grep`/`grep` runs in the background Task with the same latest-wins guard.
- [x] **6. Tests cover stale-result dropping and a slow search path that does not synchronously block command handling.** See below.

## Tests

- `test/minga/project/project_search_test.exs` — in-process cap + truncation reporting.
- `test/minga_editor/state/picker_test.exs` — latest-wins revision guard (`begin_fetch/1`, `current_fetch?/2`), explicitly not-FIFO.
- `test/minga_editor/commands/search_async_test.exs` — `:confirm_project_search` opens a loading picker and defers the fetch via a self-sent message rather than scanning inline.
- `test/minga_editor/picker_async_stale_test.exs` — editor-level: opens off-path in a loading state and drops a non-live-revision result so it never overwrites the live picker.
- `test/minga_editor/ui/picker/project_search_source_test.exs` — source contract: async, empty-query handling, match embedded in `Item.id`.

Validation:
- `make lint` — All lint checks passed (format, credo --strict, compile --warnings-as-errors, dialyzer).
- `mix test.llm` — full suite passes; the only failures observed were pre-existing flaky integration/timing tests (agent integration, extension lifecycle idle-GC/crash-restart) and a missing tree-sitter parser binary in the worktree, all unrelated to this change and passing in isolation.

Closes #2376

🤖 Generated with [Claude Code](https://claude.com/claude-code)