### PR TITLE
Add producer stream identity for Messages

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -574,7 +574,7 @@ Filter preset values:
   0x00 = none (user controls filters), 0x01 = warnings (preset to warnings+errors)
 
 Messages content_payload (when active tab is messages):
-  entry_count(2) + entries...
+  stream_instance(4) + entry_count(2) + entries...
 
 Per entry:
   id(4) + level(1) + subsystem(1) + timestamp_secs(4) + path_len(2) + path(path_len) + text_len(2) + text(text_len)
@@ -582,7 +582,7 @@ Per entry:
 Level bytes: 0=debug, 1=info, 2=warning, 3=error
 Subsystem bytes: 0=editor, 1=lsp, 2=parser, 3=git, 4=render, 5=agent, 6=zig, 7=gui
 
-Entries are sent incrementally: the BEAM tracks the last sent ID and only sends new entries each frame. On first connection (or reconnect), all entries are sent.
+Entries are sent incrementally: the BEAM tracks the last sent ID and only sends new entries each frame. `stream_instance` is a producer-assigned u32 that changes when the Messages producer is recreated, and frontends compose row identity from `(stream_instance, id)`. On first connection (or reconnect), all entries are sent.
 
 When hidden:
   opcode(1) + 0(1)

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -6,6 +6,8 @@ The BEAM editor core and rendering frontends communicate over a binary protocol 
 
 Frontend identity is opaque to Minga product behavior. The BEAM may adapt to declared capabilities such as terminal grid versus desktop window, text measurement, color depth, image support, float support, and Semantic UI support, but it must not special-case Swift, Go, GTK, or another implementation name for product features.
 
+Stream identity is producer-assigned and carried on the wire, never inferred by the consumer.
+
 ## Transport
 
 The frontend runs as a child process of the BEAM. Communication uses stdin (BEAM → Frontend) and stdout (Frontend → BEAM).
@@ -25,7 +27,7 @@ The frontend runs as a child process of the BEAM. Communication uses stdin (BEAM
 
 **Text encoding:** All text fields (titles, language names, query source, semantic content) are UTF-8 encoded.
 
-**Protocol version:** The schema carries a `protocol_version` integer (currently 4). The BEAM and every frontend compile against it and exchange it in the `ready` handshake. The BEAM rejects a frontend whose version does not match and sends an explicit `protocol_error` instead of streaming frames the frontend cannot decode. See "Protocol Version Negotiation" below.
+**Protocol version:** The schema carries a `protocol_version` integer (currently 5). The BEAM and every frontend compile against it and exchange it in the `ready` handshake. The BEAM rejects a frontend whose version does not match and sends an explicit `protocol_error` instead of streaming frames the frontend cannot decode. See "Protocol Version Negotiation" below.
 
 ---
 
@@ -754,7 +756,7 @@ Total size: 4 + msg_len bytes.
 
 ## Protocol Version Negotiation
 
-The schema (`docs/protocol_schema.toml`) carries a `protocol_version` integer (currently 4). `mix protocol.gen` emits it as a constant on every side: `Minga.Protocol.Opcodes.protocol_version()` (Elixir), `generated.ProtocolVersion` (Go), `PROTOCOL_VERSION` (Swift), `PROTOCOL_VERSION` (Zig parser). Bump it whenever the wire contract changes incompatibly; protocol_version 2 retired the 9 cell-paradigm render opcodes, protocol_version 3 (#2219) added the frame-transaction vocabulary (`begin_frame`, `commit_frame`, `request_keyframe`) and authoritative layout (`surface_placement`, `gui_surface_layout`), and protocol_version 4 added the `gui_file_tree` row `heat_level` byte. A frontend built against an older protocol handshakes with its old version and receives the `protocol_error` blocking surface instead of a desynced stream.
+The schema (`docs/protocol_schema.toml`) carries a `protocol_version` integer (currently 5). `mix protocol.gen` emits it as a constant on every side: `Minga.Protocol.Opcodes.protocol_version()` (Elixir), `generated.ProtocolVersion` (Go), `PROTOCOL_VERSION` (Swift), `PROTOCOL_VERSION` (Zig parser). Bump it whenever the wire contract changes incompatibly; protocol_version 2 retired the 9 cell-paradigm render opcodes, protocol_version 3 (#2219) added the frame-transaction vocabulary (`begin_frame`, `commit_frame`, `request_keyframe`) and authoritative layout (`surface_placement`, `gui_surface_layout`), protocol_version 4 added the `gui_file_tree` row `heat_level` byte, and protocol_version 5 added producer-assigned `stream_instance` identity to the Messages stream. A frontend built against an older protocol handshakes with its old version and receives the `protocol_error` blocking surface instead of a desynced stream.
 
 **Handshake.** A frontend appends its compiled-in `protocol_version` as a u16 tail on the extended `ready` event (after `caps_data`). A frontend that omits the tail (short ready, or extended ready without the tail) is treated as protocol_version 0.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -207,7 +207,7 @@ Between frames, the frontend must not mutate committed editor state or present n
 
 ## Frame Transactions
 
-> Status: protocol_version 3 defines the transaction vocabulary (#2219 child A) and the BEAM now brackets every emitted frame with `begin_frame`/`commit_frame` (#2219 child B). Both frontends decode the markers and gate frames and latency on `commit_frame` exactly as they did `batch_end`; they ignore `base_frame_seq` for now. Children C/D move the frontends onto real staging/commit (paint nothing until the matching `commit_frame`, resync on truncation). This section is the authoritative spec those children build against.
+> Status: protocol_version 4 keeps the transaction vocabulary introduced in protocol_version 3 (#2219 child A) and the BEAM now brackets every emitted frame with `begin_frame`/`commit_frame` (#2219 child B). Both frontends decode the markers and gate frames and latency on `commit_frame` exactly as they did `batch_end`; they ignore `base_frame_seq` for now. Children C/D move the frontends onto real staging/commit (paint nothing until the matching `commit_frame`, resync on truncation). This section is the authoritative spec those children build against.
 
 A frame transaction makes a frame atomic: the BEAM brackets a frame's semantic commands between `begin_frame` and `commit_frame`, and a frontend paints nothing until it sees the matching `commit_frame`. This replaces the single `batch_end` terminator with an explicit open/close pair so a truncated or out-of-order stream can never paint a partial frame.
 

--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -14,7 +14,8 @@ version = "2.0.0"
 # bracket every frame. See docs/PROTOCOL.md.
 # protocol_version 4 adds the gui_file_tree row heat_level byte for extension-owned
 # familiarity tinting. This changes the hand-decoded file-tree row payload.
-protocol_version = 4
+# protocol_version 5 adds producer-assigned stream_instance to the Messages stream.
+protocol_version = 5
 description = "Minga port protocol opcode registry"
 
 # Directions:
@@ -464,6 +465,7 @@ value = 0x7B
 direction = "beam_to_frontend"
 framing = "sectioned"
 
+# Custom payload includes the Messages stream header stream_instance:u32 before entry_count when visible.
 [[opcodes]]
 category = "gui_chrome"
 name = "gui_bottom_panel"

--- a/go/tui/internal/generated/opcodes.go
+++ b/go/tui/internal/generated/opcodes.go
@@ -4,7 +4,7 @@ package generated
 
 // ProtocolVersion is the wire-contract version the frontend exchanges with
 // the BEAM in the ready handshake. A mismatch yields an explicit protocol_error.
-const ProtocolVersion uint16 = 4
+const ProtocolVersion uint16 = 5
 
 const (
 	// Input

--- a/go/tui/internal/protocol/chrome_panels.go
+++ b/go/tui/internal/protocol/chrome_panels.go
@@ -133,11 +133,12 @@ func decodeBottomPanel(payload []byte) (BottomPanel, string, int) {
 		}
 		panel.Tabs = append(panel.Tabs, tab)
 	}
-	if len(payload) < offset+2 {
+	if len(payload) < offset+6 {
 		return panel, bottomPanelSummary(panel), offset
 	}
-	msgCount := int(u16(payload, offset))
-	offset += 2
+	panel.StreamInstance = u32(payload, offset)
+	msgCount := int(u16(payload, offset+4))
+	offset += 6
 	panel.Messages = make([]PanelMessage, 0, msgCount)
 	for i := 0; i < msgCount && len(payload) >= offset+14; i++ {
 		msg := PanelMessage{ID: u32(payload, offset), Level: payload[offset+4], Subsystem: payload[offset+5], Timestamp: u32(payload, offset+6)}

--- a/go/tui/internal/protocol/chrome_types.go
+++ b/go/tui/internal/protocol/chrome_types.go
@@ -332,12 +332,13 @@ type NotificationAction struct {
 }
 
 type BottomPanel struct {
-	Visible       bool
-	ActiveTab     byte
-	HeightPercent byte
-	Filter        byte
-	Tabs          []PanelTab
-	Messages      []PanelMessage
+	Visible        bool
+	ActiveTab      byte
+	HeightPercent  byte
+	Filter         byte
+	StreamInstance uint32
+	Tabs           []PanelTab
+	Messages       []PanelMessage
 }
 
 type PanelTab struct {

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -1039,15 +1039,29 @@ func TestDecodePanelAndSidebarChrome(t *testing.T) {
 
 	bottom := []byte{generated.OPGuiBottomPanel, 1, 0, 30, 0, 1, 2}
 	bottom = append(bottom, string8("Messages")...)
-	bottom = append(bottom, 0, 1, 0, 0, 0, 5, 1, 2, 0, 0, 0, 9)
+	bottom = append(bottom, 0, 0, 0, 7, 0, 1, 0, 0, 0, 5, 1, 2, 0, 0, 0, 9)
 	bottom = append(bottom, string16("lib/main.ex")...)
 	bottom = append(bottom, string16("warning")...)
 	command, err = DecodeCommand(bottom)
 	if err != nil {
 		t.Fatalf("DecodeCommand bottom panel returned error: %v", err)
 	}
-	if !command.Chrome.Bottom.Visible || len(command.Chrome.Bottom.Tabs) != 1 || len(command.Chrome.Bottom.Messages) != 1 {
+	if !command.Chrome.Bottom.Visible || command.Chrome.Bottom.StreamInstance != 7 || len(command.Chrome.Bottom.Tabs) != 1 || len(command.Chrome.Bottom.Messages) != 1 {
 		t.Fatalf("bottom panel decoded incorrectly: %+v", command.Chrome.Bottom)
+	}
+
+	firstBottom := bottomPanelPacket(7, 1, "first")
+	firstCommand, err := DecodeCommand(firstBottom)
+	if err != nil {
+		t.Fatalf("DecodeCommand first bottom panel returned error: %v", err)
+	}
+	secondBottom := bottomPanelPacket(8, 1, "second")
+	secondCommand, err := DecodeCommand(secondBottom)
+	if err != nil {
+		t.Fatalf("DecodeCommand second bottom panel returned error: %v", err)
+	}
+	if firstCommand.Chrome.Bottom.StreamInstance == secondCommand.Chrome.Bottom.StreamInstance || firstCommand.Chrome.Bottom.Messages[0].ID != secondCommand.Chrome.Bottom.Messages[0].ID {
+		t.Fatalf("bottom panel stream identity not preserved: first=%+v second=%+v", firstCommand.Chrome.Bottom, secondCommand.Chrome.Bottom)
 	}
 
 	sidebarEntry := string16("files")
@@ -1240,6 +1254,19 @@ func u32Bytes(value uint32) []byte {
 func section(id byte, payload []byte) []byte {
 	out := []byte{id, byte(len(payload) >> 8), byte(len(payload))}
 	return append(out, payload...)
+}
+
+func bottomPanelPacket(streamInstance uint32, id uint32, text string) []byte {
+	bottom := []byte{generated.OPGuiBottomPanel, 1, 0, 30, 0, 1, 2}
+	bottom = append(bottom, string8("Messages")...)
+	bottom = append(bottom, u32Bytes(streamInstance)...)
+	bottom = append(bottom, 0, 1)
+	bottom = append(bottom, u32Bytes(id)...)
+	bottom = append(bottom, 1, 0)
+	bottom = append(bottom, u32Bytes(9)...)
+	bottom = append(bottom, string16("lib/main.ex")...)
+	bottom = append(bottom, string16(text)...)
+	return bottom
 }
 
 func string16(value string) []byte {

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -529,6 +529,9 @@ func (m *Model) applyMutation(command protocol.Command) {
 	case protocol.CommandExtensionRuntime:
 		m.applyExtensionRuntime(command.ExtensionRuntime)
 	case protocol.CommandChrome:
+		if command.Chrome.Opcode == generated.OPGuiBottomPanel {
+			command.Chrome.Bottom = m.mergedBottomPanel(command.Chrome.Bottom)
+		}
 		m.chrome[command.Chrome.Opcode] = command.Chrome
 		switch command.Chrome.Opcode {
 		case generated.OPGuiTheme:
@@ -551,6 +554,37 @@ func (m *Model) applyMutation(command protocol.Command) {
 			m.surfacePlacements = command.Chrome.Placements
 		}
 	}
+}
+
+func (m *Model) mergedBottomPanel(next protocol.BottomPanel) protocol.BottomPanel {
+	currentPayload, ok := m.chrome[generated.OPGuiBottomPanel]
+	if !next.Visible {
+		if ok {
+			next.StreamInstance = currentPayload.Bottom.StreamInstance
+			next.Messages = currentPayload.Bottom.Messages
+		}
+		return next
+	}
+
+	if !ok || currentPayload.Bottom.StreamInstance != next.StreamInstance {
+		return next
+	}
+
+	seen := make(map[uint32]struct{}, len(currentPayload.Bottom.Messages)+len(next.Messages))
+	messages := make([]protocol.PanelMessage, 0, len(currentPayload.Bottom.Messages)+len(next.Messages))
+	for _, msg := range currentPayload.Bottom.Messages {
+		seen[msg.ID] = struct{}{}
+		messages = append(messages, msg)
+	}
+	for _, msg := range next.Messages {
+		if _, ok := seen[msg.ID]; ok {
+			continue
+		}
+		seen[msg.ID] = struct{}{}
+		messages = append(messages, msg)
+	}
+	next.Messages = messages
+	return next
 }
 
 // applyExtensionRuntime stores the latest gui_extension_runtime (0xA3) envelope

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1885,6 +1885,7 @@ func TestBottomPanelChromeUpdateClampsAndResetsScrollback(t *testing.T) {
 		model.bottomPanelScrollback = 6
 
 		shrunk := panel
+		shrunk.StreamInstance++
 		shrunk.Messages = shrunk.Messages[:4]
 		updated, _ := model.Update(port.PacketMsg{Commands: frame(protocol.Command{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiBottomPanel, Bottom: shrunk}})})
 		got := updated.(Model)
@@ -1909,13 +1910,59 @@ func TestBottomPanelChromeUpdateClampsAndResetsScrollback(t *testing.T) {
 	})
 }
 
+func TestBottomPanelMessageDeltasAppendWithinStream(t *testing.T) {
+	model, panel := bottomPanelTestModel(2, nil)
+
+	delta := panel
+	delta.Messages = []protocol.PanelMessage{{ID: 2, Level: 1, Text: "msg-1"}, {ID: 3, Level: 1, Text: "msg-2"}}
+	updated, _ := model.Update(port.PacketMsg{Commands: frame(protocol.Command{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiBottomPanel, Bottom: delta}})})
+	got := updated.(Model).chrome[generated.OPGuiBottomPanel].Bottom.Messages
+
+	if len(got) != 3 || got[0].ID != 1 || got[1].ID != 2 || got[2].ID != 3 {
+		t.Fatalf("bottom panel should append same-stream deltas without duplicates, got %+v", got)
+	}
+}
+
+func TestBottomPanelMessageStreamChangeReplacesMessages(t *testing.T) {
+	model, panel := bottomPanelTestModel(2, nil)
+
+	next := panel
+	next.StreamInstance++
+	next.Messages = []protocol.PanelMessage{{ID: 1, Level: 1, Text: "fresh"}}
+	updated, _ := model.Update(port.PacketMsg{Commands: frame(protocol.Command{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiBottomPanel, Bottom: next}})})
+	got := updated.(Model).chrome[generated.OPGuiBottomPanel].Bottom.Messages
+
+	if len(got) != 1 || got[0].Text != "fresh" {
+		t.Fatalf("bottom panel should replace messages on stream change, got %+v", got)
+	}
+}
+
+func TestBottomPanelHideReopenKeepsSameStreamMessages(t *testing.T) {
+	model, panel := bottomPanelTestModel(2, nil)
+
+	hidden := panel
+	hidden.Visible = false
+	hidden.Messages = nil
+	updated, _ := model.Update(port.PacketMsg{Commands: frame(protocol.Command{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiBottomPanel, Bottom: hidden}})})
+	hiddenModel := updated.(Model)
+
+	reopened := panel
+	reopened.Messages = nil
+	updated, _ = hiddenModel.Update(port.PacketMsg{Commands: frame(protocol.Command{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{Opcode: generated.OPGuiBottomPanel, Bottom: reopened}})})
+	got := updated.(Model).chrome[generated.OPGuiBottomPanel].Bottom.Messages
+
+	if len(got) != 2 || got[0].ID != 1 || got[1].ID != 2 {
+		t.Fatalf("bottom panel should keep cached same-stream messages across hide/reopen, got %+v", got)
+	}
+}
+
 func bottomPanelTestModel(messageCount int, out chan<- []byte) (Model, protocol.BottomPanel) {
 	model := New(80, 12, out)
 	messages := make([]protocol.PanelMessage, 0, messageCount)
 	for i := 0; i < messageCount; i++ {
 		messages = append(messages, protocol.PanelMessage{ID: uint32(i + 1), Level: 1, Text: fmt.Sprintf("msg-%d", i)})
 	}
-	panel := protocol.BottomPanel{Visible: true, ActiveTab: 0, Tabs: []protocol.PanelTab{{Type: 0x01, Name: "Messages"}}, Messages: messages}
+	panel := protocol.BottomPanel{Visible: true, ActiveTab: 0, Tabs: []protocol.PanelTab{{Type: 0x01, Name: "Messages"}}, StreamInstance: 42, Messages: messages}
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiBottomPanel: {Opcode: generated.OPGuiBottomPanel, Bottom: panel}}
 	// The bottom panel is registry-placed now (#2281): it renders and hit-tests by
 	// its BEAM placement rect (bottom band, full width). Place it where

--- a/lib/minga/frontend/adapter/gui/bottom_panel_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/bottom_panel_encoder.ex
@@ -22,7 +22,7 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoder do
   #   visible: opcode + visible=1(1) + active_tab_index(1) + height_percent(1)
   #            + filter(1) + tab_count(1) + tab_defs... + content
   #   tab_def: tab_type(1) + name_len(1) + name
-  #   content: entry_count(2) + entries...
+  #   content: stream_instance(4) + entry_count(2) + entries...
   #   entry: id(4) + level(1) + subsystem(1) + ts_secs(4)
   #          + path_len(2) + path + text_len(2) + text
   #   hidden: opcode + visible=0(1)
@@ -41,11 +41,11 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoder do
       <<@op_gui_bottom_panel, 1, model.active_tab_index::8, model.height_percent::8,
         model.filter_byte::8, length(model.tabs)::8, tab_defs::binary>>
 
-    header <> encode_messages(model.messages)
+    header <> encode_messages(model.stream_instance, model.messages)
   end
 
-  @spec encode_messages([BottomPanel.MessageEntry.t()]) :: binary()
-  defp encode_messages(entries) do
+  @spec encode_messages(non_neg_integer(), [BottomPanel.MessageEntry.t()]) :: binary()
+  defp encode_messages(stream_instance, entries) do
     entry_data =
       for entry <- entries, into: <<>> do
         path_bytes = entry.file_path || ""
@@ -55,6 +55,6 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoder do
           entry.text::binary>>
       end
 
-    <<length(entries)::16, entry_data::binary>>
+    <<stream_instance::32, length(entries)::16, entry_data::binary>>
   end
 end

--- a/lib/minga/frontend/adapter/gui/bottom_panel_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/bottom_panel_encoder.ex
@@ -44,8 +44,8 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoder do
     header <> encode_messages(model.stream_instance, model.messages)
   end
 
-  @spec encode_messages(non_neg_integer(), [BottomPanel.MessageEntry.t()]) :: binary()
-  defp encode_messages(stream_instance, entries) do
+  @spec encode_messages(BottomPanel.stream_instance(), [BottomPanel.MessageEntry.t()]) :: binary()
+  defp encode_messages(stream_instance, entries) when stream_instance in 1..0xFFFF_FFFF do
     entry_data =
       for entry <- entries, into: <<>> do
         path_bytes = entry.file_path || ""

--- a/lib/minga/render_model/ui/bottom_panel.ex
+++ b/lib/minga/render_model/ui/bottom_panel.ex
@@ -3,7 +3,7 @@ defmodule Minga.RenderModel.UI.BottomPanel do
   Semantic bottom panel model.
 
   Describes the bottom panel as domain data: visibility, the active tab index,
-  height, filter, the tab definitions (pre-resolved type byte + name), and the
+  height, filter, the message stream instance, the tab definitions (pre-resolved type byte + name), and the
   resolved message entries to send this frame. The GUI adapter
   (`Minga.Frontend.Adapter.GUI.BottomPanelEncoder`) owns the wire encoding.
 
@@ -22,6 +22,7 @@ defmodule Minga.RenderModel.UI.BottomPanel do
           active_tab_index: non_neg_integer(),
           height_percent: non_neg_integer(),
           filter_byte: non_neg_integer(),
+          stream_instance: non_neg_integer(),
           tabs: [tab()],
           messages: [MessageEntry.t()]
         }
@@ -30,6 +31,7 @@ defmodule Minga.RenderModel.UI.BottomPanel do
             active_tab_index: 0,
             height_percent: 0,
             filter_byte: 0,
+            stream_instance: 0,
             tabs: [],
             messages: []
 

--- a/lib/minga/render_model/ui/bottom_panel.ex
+++ b/lib/minga/render_model/ui/bottom_panel.ex
@@ -17,12 +17,15 @@ defmodule Minga.RenderModel.UI.BottomPanel do
   @typedoc "A tab definition: its wire type byte and display name."
   @type tab :: {type_byte :: non_neg_integer(), name :: String.t()}
 
+  @typedoc "Producer-assigned Messages stream identity. Hidden panels keep 0 because they do not encode content."
+  @type stream_instance :: 1..0xFFFF_FFFF
+
   @type t :: %__MODULE__{
           visible?: boolean(),
           active_tab_index: non_neg_integer(),
           height_percent: non_neg_integer(),
           filter_byte: non_neg_integer(),
-          stream_instance: non_neg_integer(),
+          stream_instance: 0 | stream_instance(),
           tabs: [tab()],
           messages: [MessageEntry.t()]
         }

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -21,19 +21,20 @@ defmodule MingaEditor.Frontend.Emit do
   Converts the frame to semantic protocol command binaries and sends them to the frontend port.
 
   Also sends title and window background color when they change
-  (side-channel writes). Returns updated caches and the renderer-owned font
-  registry for write-back to the Renderer process.
+  (side-channel writes). Returns updated caches, the renderer-owned font
+  registry, and the message store for write-back to the Editor process.
   """
   @spec emit(ComposedFrame.t(), ctx(), Chrome.t() | nil, Caches.t()) ::
-          {Caches.t(), FontRegistry.t()}
+          {Caches.t(), FontRegistry.t(), MingaEditor.UI.Panel.MessageStore.t()}
   def emit(frame, ctx, chrome \\ nil, caches \\ %Caches{}) do
     FontRegistry.with_process_registry(ctx.font_registry, fn ->
-      caches = emit_semantic(frame, ctx, chrome, caches)
-      {caches, FontRegistry.current_process_registry(ctx.font_registry)}
+      {caches, ctx} = emit_semantic(frame, ctx, chrome, caches)
+      {caches, FontRegistry.current_process_registry(ctx.font_registry), ctx.message_store}
     end)
   end
 
-  @spec emit_semantic(ComposedFrame.t(), ctx(), Chrome.t() | nil, Caches.t()) :: Caches.t()
+  @spec emit_semantic(ComposedFrame.t(), ctx(), Chrome.t() | nil, Caches.t()) ::
+          {Caches.t(), ctx()}
   defp emit_semantic(frame, ctx, chrome, caches) do
     {render_model, ctx} =
       Telemetry.span([:minga, :render, :ui_model_build], %{}, fn ->
@@ -108,7 +109,7 @@ defmodule MingaEditor.Frontend.Emit do
         MingaEditor.Frontend.send_render_commands(ctx.port_manager, commands)
         caches = send_title(render_model, caches)
         caches = send_window_bg(render_model, caches)
-        caches
+        {caches, ctx}
       end
     )
   end

--- a/lib/minga_editor/render_model/ui/bottom_panel_builder.ex
+++ b/lib/minga_editor/render_model/ui/bottom_panel_builder.ex
@@ -44,11 +44,18 @@ defmodule MingaEditor.RenderModel.UI.BottomPanelBuilder do
       active_tab_index: active_index,
       height_percent: panel.height_percent,
       filter_byte: EditorPanel.filter_byte(panel.filter),
+      stream_instance: message_stream_instance(store),
       tabs: tabs
     }
 
     resolve_content(panel.active_tab, base, store)
   end
+
+  @spec message_stream_instance(term()) :: non_neg_integer()
+  defp message_stream_instance(%MessageStore{stream_instance: stream_instance}),
+    do: stream_instance
+
+  defp message_stream_instance(_store), do: 0
 
   @spec resolve_content(atom(), BottomPanel.t(), term()) :: {BottomPanel.t(), term()}
   defp resolve_content(:messages, base, store) do

--- a/lib/minga_editor/render_model/ui/bottom_panel_builder.ex
+++ b/lib/minga_editor/render_model/ui/bottom_panel_builder.ex
@@ -31,7 +31,8 @@ defmodule MingaEditor.RenderModel.UI.BottomPanelBuilder do
     {%BottomPanel{visible?: false}, store}
   end
 
-  defp build_panel(%{visible: true} = panel, store) do
+  defp build_panel(%{visible: true} = panel, %MessageStore{} = store) do
+    store = MessageStore.ensure_stream_instance(store)
     active_index = Enum.find_index(panel.tabs, &(&1 == panel.active_tab)) || 0
 
     tabs =
@@ -51,11 +52,9 @@ defmodule MingaEditor.RenderModel.UI.BottomPanelBuilder do
     resolve_content(panel.active_tab, base, store)
   end
 
-  @spec message_stream_instance(term()) :: non_neg_integer()
+  @spec message_stream_instance(MessageStore.t()) :: MessageStore.stream_instance()
   defp message_stream_instance(%MessageStore{stream_instance: stream_instance}),
     do: stream_instance
-
-  defp message_stream_instance(_store), do: 0
 
   @spec resolve_content(atom(), BottomPanel.t(), term()) :: {BottomPanel.t(), term()}
   defp resolve_content(:messages, base, store) do

--- a/lib/minga_editor/render_pipeline.ex
+++ b/lib/minga_editor/render_pipeline.ex
@@ -188,8 +188,16 @@ defmodule MingaEditor.RenderPipeline do
     Telemetry.span([:minga, :render, :stage], %{stage: :emit}, fn ->
       input = %{input | font_registry: FontRegistry.current_process_registry(input.font_registry)}
       ctx = MingaEditor.Frontend.Emit.Context.from_editor_state(input)
-      {updated_caches, updated_font_registry} = Emit.emit(frame, ctx, chrome, input.caches)
-      %{input | caches: updated_caches, font_registry: updated_font_registry}
+
+      {updated_caches, updated_font_registry, updated_message_store} =
+        Emit.emit(frame, ctx, chrome, input.caches)
+
+      %{
+        input
+        | caches: updated_caches,
+          font_registry: updated_font_registry,
+          message_store: updated_message_store
+      }
     end)
   end
 

--- a/lib/minga_editor/renderer/server.ex
+++ b/lib/minga_editor/renderer/server.ex
@@ -57,6 +57,7 @@ defmodule MingaEditor.Renderer.Server do
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.UI.FontRegistry
+  alias MingaEditor.UI.Panel.MessageStore
 
   @typedoc "Render pipeline output after a frame has run."
   @type render_output :: Input.t()
@@ -73,6 +74,7 @@ defmodule MingaEditor.Renderer.Server do
           required(:shell_identity) => MingaEditor.Shell.Identity.t() | nil,
           required(:shell_state) => term(),
           required(:windows) => term(),
+          required(:message_store) => MingaEditor.UI.Panel.MessageStore.t(),
           required(:frame_seq) => non_neg_integer(),
           required(:keyframe?) => boolean(),
           required(:render_sent_at) => integer()
@@ -89,6 +91,7 @@ defmodule MingaEditor.Renderer.Server do
           in_flight: {Input.t(), non_neg_integer(), integer()} | nil,
           font_registry: FontRegistry.t(),
           caches: Caches.t(),
+          message_store: MessageStore.t() | nil,
           pipeline: pipeline()
         }
 
@@ -98,6 +101,7 @@ defmodule MingaEditor.Renderer.Server do
             in_flight: nil,
             font_registry: FontRegistry.new(),
             caches: Caches.new(),
+            message_store: nil,
             pipeline: &RenderPipeline.run/1
 
   # ── API ────────────────────────────────────────────────────────────────────
@@ -158,14 +162,14 @@ defmodule MingaEditor.Renderer.Server do
       })
     end
 
-    snap = use_latest_caches(snap, state.caches)
+    snap = use_latest_renderer_state(snap, state.caches, state.message_store)
     {:noreply, %{state | pending: {snap, seq, pushed_at}}}
   end
 
   def handle_cast({:render, snap, seq, pushed_at}, %__MODULE__{rendering?: false} = state) do
     Telemetry.hop_latency(:cast_snapshot, pushed_at)
     send(self(), :do_render)
-    snap = use_latest_caches(snap, state.caches)
+    snap = use_latest_renderer_state(snap, state.caches, state.message_store)
     {:noreply, %{state | rendering?: true, in_flight: {snap, seq, pushed_at}}}
   end
 
@@ -192,9 +196,15 @@ defmodule MingaEditor.Renderer.Server do
       %{frame_seq: seq}
     )
 
-    state = %{state | font_registry: output.font_registry, caches: output.caches}
+    state = %{
+      state
+      | font_registry: output.font_registry,
+        caches: output.caches,
+        message_store: output.message_store
+    }
+
     send_writeback(state.editor_pid, output, seq)
-    advance_pending(state, output.caches)
+    advance_pending(state, output.caches, output.message_store)
   rescue
     e ->
       trace = Exception.format_stacktrace(__STACKTRACE__) |> String.slice(0, 500)
@@ -204,7 +214,7 @@ defmodule MingaEditor.Renderer.Server do
         "Renderer frame #{seq} dropped: #{Exception.message(e)}\n#{trace}"
       )
 
-      advance_pending(state, state.caches)
+      advance_pending(state, state.caches, state.message_store)
   end
 
   def handle_info(_other, state), do: {:noreply, state}
@@ -247,6 +257,7 @@ defmodule MingaEditor.Renderer.Server do
       shell_identity: output.shell_identity,
       shell_state: output.shell_state,
       windows: output.workspace.windows,
+      message_store: output.message_store,
       frame_seq: seq,
       # Whether the frame this render emitted carried the keyframe. The Editor clears
       # keyframe_pending? only on a writeback that actually honored the request, so an
@@ -258,17 +269,24 @@ defmodule MingaEditor.Renderer.Server do
     }
   end
 
-  @spec advance_pending(t(), Caches.t()) :: {:noreply, t()}
-  defp advance_pending(state, latest_caches) do
+  @spec advance_pending(t(), Caches.t(), MessageStore.t() | nil) :: {:noreply, t()}
+  defp advance_pending(state, latest_caches, latest_message_store) do
     case state.pending do
       nil ->
         {:noreply, %{state | rendering?: false, in_flight: nil}}
 
       {next_snap, next_seq, next_pushed_at} ->
         send(self(), :do_render)
-        next_snap = use_latest_caches(next_snap, latest_caches)
+        next_snap = use_latest_renderer_state(next_snap, latest_caches, latest_message_store)
         {:noreply, %{state | in_flight: {next_snap, next_seq, next_pushed_at}, pending: nil}}
     end
+  end
+
+  @spec use_latest_renderer_state(Input.t(), Caches.t(), MessageStore.t() | nil) :: Input.t()
+  defp use_latest_renderer_state(%Input{} = snap, %Caches{} = latest_caches, latest_message_store) do
+    snap
+    |> use_latest_caches(latest_caches)
+    |> use_latest_message_store(latest_message_store)
   end
 
   @spec use_latest_caches(Input.t(), Caches.t()) :: Input.t()
@@ -290,6 +308,16 @@ defmodule MingaEditor.Renderer.Server do
 
   defp use_latest_caches(%Input{} = snap, %Caches{} = latest_caches) do
     %{snap | caches: latest_caches}
+  end
+
+  @spec use_latest_message_store(Input.t(), MessageStore.t() | nil) :: Input.t()
+  defp use_latest_message_store(%Input{} = snap, nil), do: snap
+
+  defp use_latest_message_store(
+         %Input{message_store: %MessageStore{} = store} = snap,
+         %MessageStore{} = latest
+       ) do
+    %{snap | message_store: MessageStore.merge_sent_cursor(store, latest)}
   end
 
   @spec monotonic_now() :: integer()

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -28,6 +28,7 @@ defmodule MingaEditor.Startup do
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace.Persistence, as: WorkspacePersistence
   alias MingaEditor.State.Windows
+  alias MingaEditor.UI.Panel.MessageStore
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.Window
@@ -163,6 +164,7 @@ defmodule MingaEditor.Startup do
       shell: shell_entry.module,
       shell_identity: ShellIdentity.new(shell_entry),
       shell_state: init_shell_state(shell_entry.module, opts),
+      message_store: MessageStore.new(),
       session: EditorSessionState.new(Keyword.take(opts, [:swap_dir, :session_dir]))
     }
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -656,6 +656,7 @@ defmodule MingaEditor.State do
         layout: render_output.layout,
         focus_tree: render_output.focus_tree,
         caches: render_output.caches,
+        message_store: render_output.message_store,
         # Clear keyframe_pending? only when the frame that just emitted actually
         # carried the keyframe. A render that started before the request (or one
         # that the request didn't force) must not swallow the still-pending flag (#2219).
@@ -683,6 +684,12 @@ defmodule MingaEditor.State do
   """
   @spec apply_renderer_writeback(t(), map()) :: t()
   def apply_renderer_writeback(%__MODULE__{} = state, %{caches: caches, layout: layout} = wb) do
+    state = %{
+      state
+      | message_store:
+          merge_renderer_message_store(state.message_store, Map.get(wb, :message_store))
+    }
+
     if renderer_writeback_shell_current?(state, wb) do
       # Clear keyframe_pending? only when this writeback's frame actually carried
       # the keyframe. An in-flight delta render that started before the request
@@ -708,6 +715,13 @@ defmodule MingaEditor.State do
   # Keeps keyframe_pending? set until an async frame that actually honored the
   # request writes back. The flag lives on the writeback's `keyframe?` field, stamped
   # from the emitted caches in Renderer.Server.writeback_from_output/2 (#2219).
+  @spec merge_renderer_message_store(MessageStore.t(), MessageStore.t() | nil) :: MessageStore.t()
+  defp merge_renderer_message_store(%MessageStore{} = current, %MessageStore{} = emitted) do
+    MessageStore.merge_sent_cursor(current, emitted)
+  end
+
+  defp merge_renderer_message_store(%MessageStore{} = current, _emitted), do: current
+
   @spec clear_keyframe_pending_from_writeback?(t(), map()) :: boolean()
   defp clear_keyframe_pending_from_writeback?(%__MODULE__{keyframe_pending?: false}, _wb),
     do: false
@@ -1746,7 +1760,11 @@ defmodule MingaEditor.State do
     state
     |> update_workspace(&SessionState.mark_frontend_reset_pending/1)
     |> then(fn state ->
-      %{state | caches: MingaEditor.Renderer.Caches.reset_frontend_state(state.caches)}
+      %{
+        state
+        | caches: MingaEditor.Renderer.Caches.reset_frontend_state(state.caches),
+          message_store: MessageStore.reset_sent_cursor(state.message_store)
+      }
     end)
   end
 

--- a/lib/minga_editor/ui/panel/message_store.ex
+++ b/lib/minga_editor/ui/panel/message_store.ex
@@ -22,12 +22,20 @@ defmodule MingaEditor.UI.Panel.MessageStore do
   @type t :: %__MODULE__{
           entries: [Entry.t()],
           next_id: pos_integer(),
-          last_sent_id: non_neg_integer()
+          last_sent_id: non_neg_integer(),
+          stream_instance: pos_integer()
         }
 
   defstruct entries: [],
             next_id: 1,
-            last_sent_id: 0
+            last_sent_id: 0,
+            stream_instance: 1
+
+  @doc "Creates a message stream with a producer-assigned restart instance."
+  @spec new() :: t()
+  def new do
+    %__MODULE__{stream_instance: System.unique_integer([:monotonic, :positive])}
+  end
 
   @doc "Append a structured log entry. Trims to #{@max_entries} entries."
   @spec append(t(), String.t(), level(), subsystem()) :: t()

--- a/lib/minga_editor/ui/panel/message_store.ex
+++ b/lib/minga_editor/ui/panel/message_store.ex
@@ -19,27 +19,41 @@ defmodule MingaEditor.UI.Panel.MessageStore do
   @type subsystem ::
           :editor | :lsp | :parser | :git | :render | :agent | :zig | :gui
 
+  @type stream_instance :: 1..0xFFFF_FFFF
+
   @type t :: %__MODULE__{
           entries: [Entry.t()],
           next_id: pos_integer(),
           last_sent_id: non_neg_integer(),
-          stream_instance: pos_integer()
+          stream_instance: 0 | stream_instance()
         }
 
   defstruct entries: [],
             next_id: 1,
             last_sent_id: 0,
-            stream_instance: 1
+            stream_instance: 0
 
   @doc "Creates a message stream with a producer-assigned restart instance."
   @spec new() :: t()
   def new do
-    %__MODULE__{stream_instance: System.unique_integer([:monotonic, :positive])}
+    %__MODULE__{stream_instance: next_stream_instance()}
+  end
+
+  @doc "Ensures a raw struct has a producer-assigned restart instance."
+  @spec ensure_stream_instance(t()) :: t()
+  def ensure_stream_instance(%__MODULE__{stream_instance: instance} = store)
+      when instance in 1..0xFFFF_FFFF do
+    store
+  end
+
+  def ensure_stream_instance(%__MODULE__{} = store) do
+    %{store | stream_instance: next_stream_instance()}
   end
 
   @doc "Append a structured log entry. Trims to #{@max_entries} entries."
   @spec append(t(), String.t(), level(), subsystem()) :: t()
   def append(%__MODULE__{} = store, text, level \\ :info, subsystem \\ :editor) do
+    store = ensure_stream_instance(store)
     file_path = extract_file_path(text)
 
     entry = %Entry{
@@ -72,6 +86,23 @@ defmodule MingaEditor.UI.Panel.MessageStore do
   def mark_sent(%__MODULE__{} = store, id) do
     %{store | last_sent_id: id}
   end
+
+  @doc "Resets the consumer send cursor after frontend state is lost."
+  @spec reset_sent_cursor(t()) :: t()
+  def reset_sent_cursor(%__MODULE__{} = store), do: %{store | last_sent_id: 0}
+
+  @doc "Merges the producer's sent cursor without replacing newer entries."
+  @spec merge_sent_cursor(t(), t()) :: t()
+  def merge_sent_cursor(
+        %__MODULE__{stream_instance: instance} = current,
+        %__MODULE__{
+          stream_instance: instance
+        } = emitted
+      ) do
+    %{current | last_sent_id: max(current.last_sent_id, emitted.last_sent_id)}
+  end
+
+  def merge_sent_cursor(%__MODULE__{} = current, %__MODULE__{}), do: current
 
   @doc "Parse level and subsystem from a log message text prefix."
   @spec parse_prefix(String.t()) :: {level(), subsystem(), String.t()}
@@ -144,4 +175,14 @@ defmodule MingaEditor.UI.Panel.MessageStore do
   def subsystem_byte(:agent), do: 5
   def subsystem_byte(:zig), do: 6
   def subsystem_byte(:gui), do: 7
+
+  @spec next_stream_instance() :: stream_instance()
+  defp next_stream_instance do
+    normalize_stream_instance(System.unique_integer([:monotonic, :positive]))
+  end
+
+  @spec normalize_stream_instance(pos_integer()) :: stream_instance()
+  defp normalize_stream_instance(instance) do
+    rem(instance - 1, 0xFFFF_FFFF) + 1
+  end
 end

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -1055,14 +1055,14 @@ enum PreviewRegistry {
     private static func populateMessages(_ state: MessagesContentState) {
         let baseTime: UInt32 = 43200  // 12:00:00
         state.appendEntries([
-            Wire.MessageEntry(id: 1, level: 1, subsystem: 0, timestampSecs: baseTime, filePath: "lib/minga/editor.ex", text: "Buffer opened: editor.ex (1250 lines)"),
-            Wire.MessageEntry(id: 2, level: 0, subsystem: 1, timestampSecs: baseTime + 1, filePath: "", text: "ElixirLS initialized in 340ms"),
-            Wire.MessageEntry(id: 3, level: 2, subsystem: 2, timestampSecs: baseTime + 3, filePath: "lib/minga/buffer/document.ex", text: "Tree-sitter parse timeout (>50ms) on large file"),
-            Wire.MessageEntry(id: 4, level: 1, subsystem: 3, timestampSecs: baseTime + 5, filePath: "", text: "Branch switched: feat/preview-host (2 ahead)"),
-            Wire.MessageEntry(id: 5, level: 3, subsystem: 4, timestampSecs: baseTime + 8, filePath: "", text: "Metal shader compilation failed: fragment_main"),
-            Wire.MessageEntry(id: 6, level: 1, subsystem: 5, timestampSecs: baseTime + 12, filePath: "", text: "Agent session started (claude-sonnet-4, medium thinking)"),
-            Wire.MessageEntry(id: 7, level: 0, subsystem: 6, timestampSecs: baseTime + 14, filePath: "", text: "TUI grid resized to 112x36"),
-            Wire.MessageEntry(id: 8, level: 2, subsystem: 7, timestampSecs: baseTime + 18, filePath: "", text: "SwiftUI layout cycle detected in NotificationCard"),
+            Wire.MessageEntry(streamInstance: 1, id: 1, level: 1, subsystem: 0, timestampSecs: baseTime, filePath: "lib/minga/editor.ex", text: "Buffer opened: editor.ex (1250 lines)"),
+            Wire.MessageEntry(streamInstance: 1, id: 2, level: 0, subsystem: 1, timestampSecs: baseTime + 1, filePath: "", text: "ElixirLS initialized in 340ms"),
+            Wire.MessageEntry(streamInstance: 1, id: 3, level: 2, subsystem: 2, timestampSecs: baseTime + 3, filePath: "lib/minga/buffer/document.ex", text: "Tree-sitter parse timeout (>50ms) on large file"),
+            Wire.MessageEntry(streamInstance: 1, id: 4, level: 1, subsystem: 3, timestampSecs: baseTime + 5, filePath: "", text: "Branch switched: feat/preview-host (2 ahead)"),
+            Wire.MessageEntry(streamInstance: 1, id: 5, level: 3, subsystem: 4, timestampSecs: baseTime + 8, filePath: "", text: "Metal shader compilation failed: fragment_main"),
+            Wire.MessageEntry(streamInstance: 1, id: 6, level: 1, subsystem: 5, timestampSecs: baseTime + 12, filePath: "", text: "Agent session started (claude-sonnet-4, medium thinking)"),
+            Wire.MessageEntry(streamInstance: 1, id: 7, level: 0, subsystem: 6, timestampSecs: baseTime + 14, filePath: "", text: "TUI grid resized to 112x36"),
+            Wire.MessageEntry(streamInstance: 1, id: 8, level: 2, subsystem: 7, timestampSecs: baseTime + 18, filePath: "", text: "SwiftUI layout cycle detected in NotificationCard"),
         ])
     }
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1495,15 +1495,16 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             pos += nameLen
             tabs.append(Wire.BottomPanelTab(tabType: tabType, name: name))
         }
-        // Content payload: entry_count(2) + entries...
+        // Messages content payload: stream_instance(4) + entry_count(2) + entries...
         var entries: [Wire.MessageEntry] = []
-        guard data.count >= pos + 2 else {
+        guard data.count >= pos + 6 else {
             return (.guiBottomPanel(visible: true, activeTabIndex: activeTabIndex,
                                      heightPercent: heightPercent, filterPreset: filterPreset,
                                      tabs: tabs, entries: []), pos - offset)
         }
-        let entryCount = Int(readU16(data, pos))
-        pos += 2
+        let streamInstance = readU32(data, pos)
+        let entryCount = Int(readU16(data, pos + 4))
+        pos += 6
         for _ in 0..<entryCount {
             // id(4) + level(1) + subsystem(1) + timestamp_secs(4) + path_len(2)
             guard data.count >= pos + 12 else { break }
@@ -1523,7 +1524,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= pos + textLen else { break }
             let text = String(data: data[pos..<(pos + textLen)], encoding: .utf8) ?? ""
             pos += textLen
-            entries.append(Wire.MessageEntry(id: entryId, level: level, subsystem: subsystem,
+            entries.append(Wire.MessageEntry(streamInstance: streamInstance, id: entryId, level: level, subsystem: subsystem,
                                             timestampSecs: tsSecs, filePath: filePath, text: text))
         }
         return (.guiBottomPanel(visible: true, activeTabIndex: activeTabIndex,

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -542,6 +542,7 @@ enum Wire {
 
     /// A structured log entry from the Messages tab content.
     struct MessageEntry: Sendable {
+        let streamInstance: UInt32
         let id: UInt32
         let level: UInt8
         let subsystem: UInt8

--- a/macos/Sources/Views/MessagesContentState.swift
+++ b/macos/Sources/Views/MessagesContentState.swift
@@ -7,16 +7,9 @@ import SwiftUI
 
 /// A rendered message entry for display in the Messages tab.
 ///
-/// SwiftUI identity is `id`, a `(streamGeneration, seq)` composite, NOT the raw
-/// backend sequence number (`seq`). The BEAM `MessageStore` restarts its
-/// sequence at 1 whenever the backend restarts (or resends), so using `seq`
-/// alone as `ForEach`/scroll identity produced duplicate IDs across restarts
-/// (issue #2353). `MessagesContentState` bumps the generation when it sees a
-/// sequence go backwards, keeping every row's identity unique.
+/// SwiftUI identity is `id`, a `(streamInstance, seq)` composite carried by the wire contract, NOT the raw backend sequence number (`seq`).
 struct MessageEntry: Identifiable, Equatable {
-    /// Restart-safe composite identity: `(UInt64(generation) << 32) | seq`.
-    /// Static fixtures (previews/tests) may pass a small raw sequence directly;
-    /// that is just generation 0, where the composite equals the sequence.
+    /// Restart-safe composite identity: `(UInt64(streamInstance) << 32) | seq`.
     let id: UInt64
     let level: UInt8
     let subsystem: UInt8
@@ -25,14 +18,11 @@ struct MessageEntry: Identifiable, Equatable {
     let text: String
 
     /// Raw backend sequence number for this entry (the low 32 bits of `id`).
-    /// Resets to 1 on a backend restart; the generation in the high bits keeps
-    /// `id` unique even when `seq` repeats.
     var seq: UInt32 { UInt32(id & 0xFFFF_FFFF) }
 
-    /// Builds the restart-safe composite identity from a stream generation and
-    /// a backend sequence number.
-    static func makeID(generation: UInt32, seq: UInt32) -> UInt64 {
-        (UInt64(generation) << 32) | UInt64(seq)
+    /// Builds the restart-safe composite identity from a producer stream instance and a backend sequence number.
+    static func makeID(streamInstance: UInt32, seq: UInt32) -> UInt64 {
+        (UInt64(streamInstance) << 32) | UInt64(seq)
     }
 
     /// Compact timestamp as HH:MM:SS.
@@ -213,34 +203,11 @@ final class MessagesContentState {
     /// Maximum entries to keep (matches BEAM-side cap).
     private let maxEntries = 1000
 
-    /// Current stream generation. Bumped whenever an incoming backend sequence
-    /// number is not greater than the last one seen, which happens when the BEAM
-    /// backend restarts (sequence resets to 1) or resends earlier IDs.
-    private var streamGeneration: UInt32 = 0
-    /// The last backend sequence number appended, or nil before any entry.
-    private var lastSeq: UInt32?
-    /// Composite IDs currently present, for defensive dedupe (issue #2353).
-    private var presentIDs: Set<UInt64> = []
-
     /// Append new entries from the protocol decoder.
-    ///
-    /// Each entry is given a restart-safe composite identity. When a backend
-    /// sequence number does not advance (`raw.id <= lastSeq`), the stream
-    /// generation is bumped so the repeated/reset sequence lands in a fresh
-    /// namespace and never collides with an already-displayed row.
     func appendEntries(_ rawEntries: [Wire.MessageEntry]) {
         for raw in rawEntries {
-            if let last = lastSeq, raw.id <= last {
-                streamGeneration &+= 1
-            }
-            lastSeq = raw.id
-
-            let id = MessageEntry.makeID(generation: streamGeneration, seq: raw.id)
-            // Defensive dedupe: never emit a duplicate SwiftUI identity.
-            if presentIDs.contains(id) { continue }
-
             let entry = MessageEntry(
-                id: id,
+                id: MessageEntry.makeID(streamInstance: raw.streamInstance, seq: raw.id),
                 level: raw.level,
                 subsystem: raw.subsystem,
                 timestampSecs: raw.timestampSecs,
@@ -248,13 +215,9 @@ final class MessagesContentState {
                 text: raw.text
             )
             entries.append(entry)
-            presentIDs.insert(id)
         }
-        // Trim to max, keeping the dedupe set in sync with the retained window.
         if entries.count > maxEntries {
-            let overflow = entries.count - maxEntries
-            for dropped in entries.prefix(overflow) { presentIDs.remove(dropped.id) }
-            entries.removeFirst(overflow)
+            entries.removeFirst(entries.count - maxEntries)
         }
         // Signal new entries for auto-scroll or "jump to latest"
         if !isAutoScrolling {

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -582,7 +582,7 @@ struct CommandDispatcherRoutingTests {
     @MainActor func guiBottomPanelVisible() {
         let (dispatcher, gui) = makeDispatcher()
         let tabs = [Wire.BottomPanelTab(tabType: 0, name: "Messages")]
-        let entries = [Wire.MessageEntry(id: 1, level: 1, subsystem: 0,
+        let entries = [Wire.MessageEntry(streamInstance: 1, id: 1, level: 1, subsystem: 0,
                                        timestampSecs: 3600, filePath: "", text: "test")]
         dispatcher.applyForTesting(.guiBottomPanel(visible: true, activeTabIndex: 0,
                                              heightPercent: 30, filterPreset: 0,

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -1672,6 +1672,7 @@ struct GUIBottomPanelDecoderTests {
         appendString8(&data, "Messages")
 
         // Entries
+        appendU32(&data, 7) // streamInstance
         appendU16(&data, 1) // entryCount
 
         // Entry 1
@@ -1696,6 +1697,7 @@ struct GUIBottomPanelDecoderTests {
         #expect(tabs.count == 1)
         #expect(tabs[0].name == "Messages")
         #expect(entries.count == 1)
+        #expect(entries[0].streamInstance == 7)
         #expect(entries[0].id == 42)
         #expect(entries[0].level == 1)
         #expect(entries[0].subsystem == 0)

--- a/macos/Tests/MingaTests/MessagesContentStateTests.swift
+++ b/macos/Tests/MingaTests/MessagesContentStateTests.swift
@@ -1,92 +1,44 @@
 import Testing
 import Foundation
 
-@Suite("Messages restart-safe identity (issue #2353)")
+@Suite("Messages wire-assigned identity")
 struct MessagesContentStateIdentityTests {
-    private func wire(_ id: UInt32, _ text: String = "msg") -> Wire.MessageEntry {
-        Wire.MessageEntry(
-            id: id, level: 1, subsystem: 0, timestampSecs: 0, filePath: "", text: text)
+    private func wire(_ id: UInt32, streamInstance: UInt32 = 1, _ text: String = "msg") -> Wire.MessageEntry {
+        Wire.MessageEntry(streamInstance: streamInstance, id: id, level: 1, subsystem: 0, timestampSecs: 0, filePath: "", text: text)
     }
 
-    @Test("a backend restart (sequence resets to 1) yields unique row identities")
-    @MainActor func restartKeepsIdentitiesUnique() {
+    @Test("reused sequence IDs from a new stream instance do not collide")
+    @MainActor func reusedSequenceIDsAcrossInstancesStayUnique() {
         let state = MessagesContentState()
-        state.appendEntries([wire(1), wire(2)])
-        // Backend restarts: the BEAM MessageStore sequence resets to 1, 2 again.
-        state.appendEntries([wire(1), wire(2)])
+        state.appendEntries([wire(1, streamInstance: 10), wire(2, streamInstance: 10)])
+        state.appendEntries([wire(1, streamInstance: 11), wire(2, streamInstance: 11)])
 
         let ids = state.entries.map(\.id)
-        #expect(ids.count == 4)
-        // All four rows have distinct SwiftUI identities despite repeated seqs,
-        // so ForEach emits no duplicate-ID warning.
-        #expect(Set(ids).count == 4)
-        // The raw backend sequence is preserved on each entry.
+        #expect(ids == [
+            MessageEntry.makeID(streamInstance: 10, seq: 1),
+            MessageEntry.makeID(streamInstance: 10, seq: 2),
+            MessageEntry.makeID(streamInstance: 11, seq: 1),
+            MessageEntry.makeID(streamInstance: 11, seq: 2),
+        ])
+        #expect(Set(ids).count == ids.count)
         #expect(state.entries.map(\.seq) == [1, 2, 1, 2])
     }
 
-    @Test("identity is the (generation, seq) composite, not the raw sequence")
-    @MainActor func identityIsComposite() {
+    @Test("identity is composed directly from wire stream instance and sequence")
+    @MainActor func identityComesFromWireFields() {
         let state = MessagesContentState()
-        state.appendEntries([wire(1)])
-        #expect(state.entries[0].id == MessageEntry.makeID(generation: 0, seq: 1))
+        state.appendEntries([wire(7, streamInstance: 42)])
 
-        // Restart: same seq 1, but a new generation namespaces it.
-        state.appendEntries([wire(1)])
-        #expect(state.entries[1].id == MessageEntry.makeID(generation: 1, seq: 1))
+        #expect(state.entries[0].id == MessageEntry.makeID(streamInstance: 42, seq: 7))
     }
 
-    @Test("a normal increasing sequence stays in a single generation")
-    @MainActor func monotonicSequenceOneGeneration() {
+    @Test("entries are capped without a defensive identity dedupe path")
+    @MainActor func trimKeepsLatestEntries() {
         let state = MessagesContentState()
-        state.appendEntries([wire(1), wire(2), wire(3)])
-        #expect(state.entries.map(\.id) == [
-            MessageEntry.makeID(generation: 0, seq: 1),
-            MessageEntry.makeID(generation: 0, seq: 2),
-            MessageEntry.makeID(generation: 0, seq: 3),
-        ])
-    }
+        state.appendEntries((1...1005).map { wire(UInt32($0), streamInstance: 3) })
 
-    @Test("a resend of already-seen IDs is namespaced into a new generation")
-    @MainActor func resendNamespaced() {
-        let state = MessagesContentState()
-        state.appendEntries([wire(1), wire(2), wire(3)])
-        // Backend resends 2, 3 (e.g. after a reconnect) without a full restart.
-        state.appendEntries([wire(2), wire(3)])
-
-        let ids = state.entries.map(\.id)
-        #expect(ids.count == 5)
-        #expect(Set(ids).count == 5)
-    }
-
-    @Test("identities stay unique across many restarts (no ForEach collisions)")
-    @MainActor func manyRestartsStayUnique() {
-        let state = MessagesContentState()
-        for _ in 0..<5 {
-            state.appendEntries([wire(1), wire(2), wire(3)])
-        }
-        let ids = state.entries.map(\.id)
-        #expect(ids.count == 15)
-        #expect(Set(ids).count == ids.count)
-    }
-
-    @Test("entries are capped and identities stay unique across the trim boundary")
-    @MainActor func trimKeepsIdentitiesUniqueAndDedupeInSync() {
-        let state = MessagesContentState()
-        // 6 restarts × 300 = 1800 appended, well past the 1000-entry cap.
-        for _ in 0..<6 {
-            state.appendEntries((1...300).map { wire(UInt32($0)) })
-        }
-        // Trimmed to the cap, and every retained row still has a unique identity,
-        // so ForEach never sees a duplicate ID even after the dedupe set has been
-        // pruned alongside the trimmed window.
         #expect(state.entries.count == 1000)
-        #expect(Set(state.entries.map(\.id)).count == 1000)
-
-        // A resend of an early sequence (whose original generation was trimmed
-        // out) still appends in a fresh generation rather than being wrongly
-        // deduped against a dropped id, and the cap holds.
-        state.appendEntries([wire(1)])
-        #expect(state.entries.count == 1000)
-        #expect(Set(state.entries.map(\.id)).count == state.entries.count)
+        #expect(state.entries.first?.seq == 6)
+        #expect(state.entries.last?.seq == 1005)
     }
 }

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -468,7 +468,7 @@ struct BottomPanelStateLifecycleTests {
     @MainActor func hideKeepsMessages() {
         let state = BottomPanelState()
         state.messagesState.appendEntries([
-            Wire.MessageEntry(id: 1, level: 1, subsystem: 0,
+            Wire.MessageEntry(streamInstance: 1, id: 1, level: 1, subsystem: 0,
                            timestampSecs: 0, filePath: "", text: "test")
         ])
         state.hide()
@@ -488,7 +488,7 @@ struct MessagesContentStateLifecycleTests {
 
         // Add 5 entries
         let entries = (0..<5).map {
-            Wire.MessageEntry(id: UInt32($0), level: 1, subsystem: 0,
+            Wire.MessageEntry(streamInstance: 1, id: UInt32($0), level: 1, subsystem: 0,
                            timestampSecs: UInt32($0), filePath: "", text: "msg \($0)")
         }
         state.appendEntries(entries)
@@ -499,11 +499,11 @@ struct MessagesContentStateLifecycleTests {
     @MainActor func filteringWorks() {
         let state = MessagesContentState()
         state.appendEntries([
-            Wire.MessageEntry(id: 0, level: 0, subsystem: 0, timestampSecs: 0,
+            Wire.MessageEntry(streamInstance: 1, id: 0, level: 0, subsystem: 0, timestampSecs: 0,
                            filePath: "", text: "debug msg"),
-            Wire.MessageEntry(id: 1, level: 1, subsystem: 0, timestampSecs: 0,
+            Wire.MessageEntry(streamInstance: 1, id: 1, level: 1, subsystem: 0, timestampSecs: 0,
                            filePath: "", text: "info msg"),
-            Wire.MessageEntry(id: 2, level: 3, subsystem: 1, timestampSecs: 0,
+            Wire.MessageEntry(streamInstance: 1, id: 2, level: 3, subsystem: 1, timestampSecs: 0,
                            filePath: "", text: "error in LSP"),
         ])
 
@@ -520,9 +520,9 @@ struct MessagesContentStateLifecycleTests {
     @MainActor func searchFilters() {
         let state = MessagesContentState()
         state.appendEntries([
-            Wire.MessageEntry(id: 0, level: 1, subsystem: 0, timestampSecs: 0,
+            Wire.MessageEntry(streamInstance: 1, id: 0, level: 1, subsystem: 0, timestampSecs: 0,
                            filePath: "", text: "File opened: editor.ex"),
-            Wire.MessageEntry(id: 1, level: 1, subsystem: 0, timestampSecs: 0,
+            Wire.MessageEntry(streamInstance: 1, id: 1, level: 1, subsystem: 0, timestampSecs: 0,
                            filePath: "", text: "File saved: buffer.ex"),
         ])
 
@@ -571,7 +571,7 @@ struct MessagesContentStateLifecycleTests {
 
         // New entries while scrolled up show "new entries" indicator
         state.appendEntries([
-            Wire.MessageEntry(id: 0, level: 1, subsystem: 0, timestampSecs: 0,
+            Wire.MessageEntry(streamInstance: 1, id: 0, level: 1, subsystem: 0, timestampSecs: 0,
                            filePath: "", text: "new")
         ])
         #expect(state.hasNewEntries == true)
@@ -602,7 +602,7 @@ struct MessagesContentStateLifecycleTests {
         #expect(state.isAutoScrolling == true)
 
         state.appendEntries([
-            Wire.MessageEntry(id: 0, level: 1, subsystem: 0, timestampSecs: 0,
+            Wire.MessageEntry(streamInstance: 1, id: 0, level: 1, subsystem: 0, timestampSecs: 0,
                            filePath: "", text: "tailing")
         ])
         // At the bottom, new entries follow the tail rather than raising the
@@ -615,7 +615,7 @@ struct MessagesContentStateLifecycleTests {
         let state = MessagesContentState()
         state.scrolledUp()
         state.appendEntries([
-            Wire.MessageEntry(id: 0, level: 1, subsystem: 0, timestampSecs: 0,
+            Wire.MessageEntry(streamInstance: 1, id: 0, level: 1, subsystem: 0, timestampSecs: 0,
                            filePath: "", text: "new")
         ])
         #expect(state.hasNewEntries == true)

--- a/test/minga/frontend/adapter/gui/bottom_panel_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/bottom_panel_encoder_test.exs
@@ -25,6 +25,7 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
         height_percent: 30,
         filter_byte: 0,
         tabs: [{0x01, "Messages"}],
+        stream_instance: 99,
         messages: []
       }
 
@@ -35,7 +36,7 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
       assert height == 30
       assert filter == 0
       assert tab_count == 1
-      assert <<0x01, 8::8, "Messages", 0::32, 0::16>> = rest
+      assert <<0x01, 8::8, "Messages", 99::32, 0::16>> = rest
     end
 
     test "encodes multiple tab defs and a non-zero filter" do
@@ -45,12 +46,13 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
         height_percent: 45,
         filter_byte: 1,
         tabs: [{0x01, "Messages"}, {0x02, "Diagnostics"}, {0x03, "Terminal"}],
+        stream_instance: 99,
         messages: []
       }
 
       assert <<@op_gui_bottom_panel, 1, 1::8, 45::8, 1::8, 3::8, 0x01, l1::8,
                _n1::binary-size(l1), 0x02, l2::8, _n2::binary-size(l2), 0x03, l3::8,
-               _n3::binary-size(l3), 0::32, 0::16>> = encode(model)
+               _n3::binary-size(l3), 99::32, 0::16>> = encode(model)
     end
 
     test "encodes message entries" do
@@ -94,6 +96,7 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
       model = %BottomPanel{
         visible?: true,
         tabs: [{0x01, "Messages"}],
+        stream_instance: 99,
         messages: [%MessageEntry{id: 1, level_byte: 0, subsystem_byte: 0, ts_secs: 0, text: "t"}]
       }
 
@@ -107,7 +110,12 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
 
   describe "encode/2 cache skipping" do
     test "returns nil on the second call with an unchanged model" do
-      model = %BottomPanel{visible?: true, tabs: [{0x01, "Messages"}], messages: []}
+      model = %BottomPanel{
+        visible?: true,
+        tabs: [{0x01, "Messages"}],
+        stream_instance: 99,
+        messages: []
+      }
 
       {cmd1, caches} = BottomPanelEncoder.encode(model, Caches.new())
       assert cmd1 != nil
@@ -119,7 +127,13 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
     test "re-encodes when the model changes" do
       {_cmd, caches} = BottomPanelEncoder.encode(%BottomPanel{}, Caches.new())
 
-      changed = %BottomPanel{visible?: true, tabs: [{0x01, "Messages"}], messages: []}
+      changed = %BottomPanel{
+        visible?: true,
+        tabs: [{0x01, "Messages"}],
+        stream_instance: 99,
+        messages: []
+      }
+
       {cmd2, _caches} = BottomPanelEncoder.encode(changed, caches)
       assert cmd2 != nil
     end

--- a/test/minga/frontend/adapter/gui/bottom_panel_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/bottom_panel_encoder_test.exs
@@ -35,7 +35,7 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
       assert height == 30
       assert filter == 0
       assert tab_count == 1
-      assert <<0x01, 8::8, "Messages", 0::16>> = rest
+      assert <<0x01, 8::8, "Messages", 0::32, 0::16>> = rest
     end
 
     test "encodes multiple tab defs and a non-zero filter" do
@@ -50,7 +50,7 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
 
       assert <<@op_gui_bottom_panel, 1, 1::8, 45::8, 1::8, 3::8, 0x01, l1::8,
                _n1::binary-size(l1), 0x02, l2::8, _n2::binary-size(l2), 0x03, l3::8,
-               _n3::binary-size(l3), 0::16>> = encode(model)
+               _n3::binary-size(l3), 0::32, 0::16>> = encode(model)
     end
 
     test "encodes message entries" do
@@ -60,6 +60,7 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
         height_percent: 30,
         filter_byte: 0,
         tabs: [{0x01, "Messages"}],
+        stream_instance: 99,
         messages: [
           %MessageEntry{
             id: 42,
@@ -73,8 +74,9 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
       }
 
       <<@op_gui_bottom_panel, 1, 0::8, 30::8, 0::8, 1::8, 0x01, nlen::8, _name::binary-size(nlen),
-        entry_count::16, entries::binary>> = encode(model)
+        stream_instance::32, entry_count::16, entries::binary>> = encode(model)
 
+      assert stream_instance == 99
       assert entry_count == 1
 
       <<id::32, level::8, sub::8, ts::32, plen::16, path::binary-size(plen), tlen::16,
@@ -96,7 +98,8 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
       }
 
       <<@op_gui_bottom_panel, 1, _::binary-size(4), 0x01, nlen::8, _name::binary-size(nlen),
-        1::16, _id::32, _lvl::8, _sub::8, _ts::32, 0::16, tlen::16, "t">> = encode(model)
+        _stream_instance::32, 1::16, _id::32, _lvl::8, _sub::8, _ts::32, 0::16, tlen::16, "t">> =
+        encode(model)
 
       assert tlen == 1
     end

--- a/test/minga/render_model/ui/bottom_panel_test.exs
+++ b/test/minga/render_model/ui/bottom_panel_test.exs
@@ -10,6 +10,7 @@ defmodule Minga.RenderModel.UI.BottomPanelTest do
 
       refute panel.visible?
       assert panel.tabs == []
+      assert panel.stream_instance == 0
       assert panel.messages == []
     end
 
@@ -19,6 +20,7 @@ defmodule Minga.RenderModel.UI.BottomPanelTest do
         active_tab_index: 0,
         height_percent: 30,
         filter_byte: 1,
+        stream_instance: 12,
         tabs: [{0x01, "Messages"}],
         messages: [
           %MessageEntry{id: 1, level_byte: 1, subsystem_byte: 0, ts_secs: 10, text: "hi"}
@@ -26,6 +28,7 @@ defmodule Minga.RenderModel.UI.BottomPanelTest do
       }
 
       assert [{0x01, "Messages"}] = panel.tabs
+      assert panel.stream_instance == 12
       assert [%MessageEntry{id: 1, text: "hi"}] = panel.messages
     end
   end

--- a/test/minga_editor/frontend/emit/keyframe_side_channel_test.exs
+++ b/test/minga_editor/frontend/emit/keyframe_side_channel_test.exs
@@ -99,7 +99,7 @@ defmodule MingaEditor.Frontend.Emit.KeyframeSideChannelTest do
         force_keyframe?: Keyword.get(opts, :force_keyframe?, false)
     }
 
-    {new_caches, _font_registry} = Emit.emit(frame, ctx, nil, caches)
+    {new_caches, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches)
     # The frame's render commands go to port_manager (self()); drain that cast so the
     # side-channel assertions only see set_title/set_window_bg.
     assert_receive {:"$gen_cast", {:send_commands, _commands}}

--- a/test/minga_editor/frontend/emit_test.exs
+++ b/test/minga_editor/frontend/emit_test.exs
@@ -236,7 +236,7 @@ defmodule MingaEditor.Frontend.EmitTest do
       {_id, registry, true} = FontRegistry.get_or_register(FontRegistry.new(), "Fira Code")
       ctx = %{Context.from_editor_state(base_state()) | font_registry: registry}
 
-      {_caches, font_registry} = Emit.emit(frame, ctx, nil, %Caches{})
+      {_caches, font_registry, _message_store} = Emit.emit(frame, ctx, nil, %Caches{})
       assert_receive {:"$gen_cast", {:send_commands, commands}}
 
       assert FontRegistry.pending_registrations(font_registry) == []
@@ -255,7 +255,7 @@ defmodule MingaEditor.Frontend.EmitTest do
       _layout = Layout.put(state)
       ctx = Context.from_editor_state(state)
 
-      {caches, _font_registry} = Emit.emit(frame, ctx, nil, %Caches{})
+      {caches, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, %Caches{})
       assert_receive {:"$gen_cast", {:send_commands, _}}
 
       assert is_map(caches.emit_prev_viewport_tops)
@@ -273,14 +273,14 @@ defmodule MingaEditor.Frontend.EmitTest do
       ctx = Context.from_editor_state(state)
       caches0 = %Caches{}
 
-      {caches1, _font_registry} = Emit.emit(frame, ctx, nil, caches0)
+      {caches1, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches0)
       # Flush first commands + title
       assert_receive {:"$gen_cast", {:send_commands, _commands}}
 
       assert is_binary(caches1.last_title)
 
       # Emit again with same ctx; title should not be re-sent (cache hit)
-      {caches2, _font_registry} = Emit.emit(frame, ctx, nil, caches1)
+      {caches2, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches1)
       assert_receive {:"$gen_cast", {:send_commands, _commands2}}
 
       assert caches2.last_title == caches1.last_title
@@ -295,13 +295,13 @@ defmodule MingaEditor.Frontend.EmitTest do
       ctx = Context.from_editor_state(state)
       caches0 = %Caches{}
 
-      {caches1, _font_registry} = Emit.emit(frame, ctx, nil, caches0)
+      {caches1, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches0)
       assert_receive {:"$gen_cast", {:send_commands, _}}
 
       assert caches1.last_window_bg == state.theme.editor.bg
 
       # Emit again, should not re-send
-      {caches2, _font_registry} = Emit.emit(frame, ctx, nil, caches1)
+      {caches2, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches1)
       assert_receive {:"$gen_cast", {:send_commands, _}}
       assert caches2.last_window_bg == caches1.last_window_bg
     end
@@ -346,7 +346,7 @@ defmodule MingaEditor.Frontend.EmitTest do
         force_keyframe?: Keyword.get(opts, :force_keyframe?, false)
     }
 
-    {new_caches, _font_registry} = Emit.emit(frame, ctx, nil, caches)
+    {new_caches, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches)
     assert_receive {:"$gen_cast", {:send_commands, commands}}
     {commands, new_caches}
   end

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -802,6 +802,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       # Tab: type=0 (messages), name="Messages"
       tab = <<0::8, 8::8, "Messages"::binary>>
 
+      # Content: stream_instance(4) + entry_count(2) + entries...
       # Entry: id(4) + level(1) + subsystem(1) + timestamp(4) + path_len(2) + path + text_len(2) + text
       path = "lib/editor.ex"
       text = "File opened"
@@ -811,7 +812,7 @@ defmodule Minga.Integration.GUIProtocolTest do
           text::binary>>
 
       cmd =
-        <<0x7C, 1::8, 0::8, 30::8, 0::8, 1::8, tab::binary, 1::16, entry::binary>>
+        <<0x7C, 1::8, 0::8, 30::8, 0::8, 1::8, tab::binary, 7::32, 1::16, entry::binary>>
 
       Port.command(port, cmd)
 

--- a/test/minga_editor/render_model/ui/bottom_panel_builder_test.exs
+++ b/test/minga_editor/render_model/ui/bottom_panel_builder_test.exs
@@ -64,6 +64,7 @@ defmodule MingaEditor.RenderModel.UI.BottomPanelBuilderTest do
       panel = %EditorPanel{visible: true, active_tab: :messages, tabs: [:messages]}
       {model, out_store} = BottomPanelBuilder.build(ctx(panel, store))
 
+      assert model.stream_instance == store.stream_instance
       assert length(model.messages) == 2
       assert out_store.last_sent_id == 2
 
@@ -88,6 +89,19 @@ defmodule MingaEditor.RenderModel.UI.BottomPanelBuilderTest do
       assert length(model2.messages) == 1
       assert hd(model2.messages).text == "Second"
       assert store4.last_sent_id == 2
+    end
+
+    test "fresh producers can reuse ids without reusing stream identity" do
+      first_store = MessageStore.new() |> MessageStore.append("First", :info, :editor)
+      second_store = MessageStore.new() |> MessageStore.append("Second", :info, :editor)
+      panel = %EditorPanel{visible: true, active_tab: :messages, tabs: [:messages]}
+
+      {first_model, _first_store} = BottomPanelBuilder.build(ctx(panel, first_store))
+      {second_model, _second_store} = BottomPanelBuilder.build(ctx(panel, second_store))
+
+      assert hd(first_model.messages).id == 1
+      assert hd(second_model.messages).id == 1
+      assert first_model.stream_instance != second_model.stream_instance
     end
   end
 end

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -6,6 +6,7 @@ defmodule MingaEditor.RenderPipeline.InputTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
+  alias MingaEditor.UI.Panel.MessageStore
 
   setup do
     state = TestHelpers.base_state()
@@ -92,6 +93,23 @@ defmodule MingaEditor.RenderPipeline.InputTest do
     end
   end
 
+  describe "EditorState.reset_frontend_render_state/1" do
+    test "resets frontend caches and message send cursor", %{state: state} do
+      message_store =
+        state.message_store
+        |> MessageStore.append("first", :info, :editor)
+        |> MessageStore.mark_sent(1)
+
+      state = %{state | message_store: message_store}
+
+      result = EditorState.reset_frontend_render_state(state)
+
+      assert result.message_store.last_sent_id == 0
+      assert result.message_store.stream_instance == message_store.stream_instance
+      assert Enum.map(result.message_store.entries, & &1.text) == ["first"]
+    end
+  end
+
   describe "EditorState.apply_render_output/2" do
     test "writes back mutated windows", %{state: state} do
       input = Input.from_editor_state(state)
@@ -131,6 +149,22 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       result = EditorState.apply_render_output(state, mutated_input)
 
       assert result.layout == layout
+    end
+
+    test "writes back message store cursor advances", %{state: state} do
+      input = Input.from_editor_state(state)
+
+      message_store =
+        state.message_store
+        |> MessageStore.append("first", :info, :editor)
+        |> MessageStore.append("second", :info, :editor)
+        |> MessageStore.mark_sent(2)
+
+      result = EditorState.apply_render_output(state, %{input | message_store: message_store})
+
+      assert result.message_store.last_sent_id == 2
+      assert result.message_store.stream_instance == message_store.stream_instance
+      assert Enum.map(result.message_store.entries, & &1.text) == ["first", "second"]
     end
   end
 
@@ -194,7 +228,38 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       assert result.shell_state.tab_bar_click_regions == [{:tab, 2}]
     end
 
-    test "drops renderer writeback without shell identity", %{state: state} do
+    test "merges renderer message-store writeback", %{state: state} do
+      current_store =
+        state.message_store
+        |> MessageStore.append("first", :info, :editor)
+        |> MessageStore.append("second", :info, :editor)
+
+      state = %{state | message_store: current_store}
+      input = Input.from_editor_state(state)
+      emitted_store = MessageStore.mark_sent(current_store, 1)
+
+      writeback = %{
+        caches: input.caches,
+        layout: :rendered_layout,
+        windows: state.workspace.windows,
+        shell_id: :traditional,
+        shell_identity: input.shell_identity,
+        shell_state: state.shell_state,
+        message_store: emitted_store
+      }
+
+      result = EditorState.apply_renderer_writeback(state, writeback)
+
+      assert result.message_store.last_sent_id == 1
+      assert result.message_store.stream_instance == current_store.stream_instance
+      assert Enum.map(result.message_store.entries, & &1.text) == ["first", "second"]
+    end
+
+    test "drops renderer writeback without shell identity but keeps message cursor", %{
+      state: state
+    } do
+      current_store = MessageStore.append(state.message_store, "first", :info, :editor)
+      state = %{state | message_store: current_store}
       input = Input.from_editor_state(state)
 
       writeback = %{
@@ -203,7 +268,8 @@ defmodule MingaEditor.RenderPipeline.InputTest do
         focus_tree: :rendered_focus_tree,
         windows: state.workspace.windows,
         shell_id: :traditional,
-        shell_state: %{state.shell_state | modeline_click_regions: [{:old, 1}]}
+        shell_state: %{state.shell_state | modeline_click_regions: [{:old, 1}]},
+        message_store: MessageStore.mark_sent(current_store, 1)
       }
 
       result = EditorState.apply_renderer_writeback(state, writeback)
@@ -211,6 +277,7 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       assert result.layout == nil
       assert result.focus_tree == nil
       assert result.shell_state.modeline_click_regions == []
+      assert result.message_store.last_sent_id == 1
     end
 
     test "drops stale renderer writeback after shell changes", %{state: state} do

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -11,6 +11,7 @@ defmodule MingaEditor.Renderer.ServerTest do
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Renderer.Server, as: RendererServer
+  alias MingaEditor.UI.Panel.MessageStore
   alias MingaEditor.Viewport
 
   # Async renderer writeback can lag a bit under CI load, keep this local to the renderer assertions.
@@ -78,6 +79,25 @@ defmodule MingaEditor.Renderer.ServerTest do
                    @async_render_timeout
 
     refute renderer_busy?(renderer)
+  end
+
+  test "pending snapshots inherit the latest emitted message cursor before rendering" do
+    parent = self()
+    renderer = start_renderer(parent, pipeline: message_cursor_probe_pipeline(parent))
+
+    first_store = MessageStore.new() |> MessageStore.append("first")
+    pending_store = first_store |> MessageStore.append("second")
+    in_flight = %{stub_snapshot() | message_store: first_store}
+    pending = %{stub_snapshot() | message_store: pending_store}
+
+    :sys.replace_state(renderer, fn state ->
+      %{state | rendering?: true, in_flight: {in_flight, 1, 0}, pending: {pending, 2, 0}}
+    end)
+
+    send(renderer, :do_render)
+
+    assert_receive {:pipeline_message_cursor, 1, 0}, @async_render_timeout
+    assert_receive {:pipeline_message_cursor, 2, 1}, @async_render_timeout
   end
 
   test "pending snapshots inherit the latest emitted caches before rendering" do
@@ -210,6 +230,18 @@ defmodule MingaEditor.Renderer.ServerTest do
     end
   end
 
+  defp message_cursor_probe_pipeline(parent) do
+    fn input ->
+      send(parent, {:pipeline_message_cursor, input.frame_seq, input.message_store.last_sent_id})
+
+      %{
+        input
+        | caches: %{input.caches | last_emitted_frame_seq: input.frame_seq},
+          message_store: MessageStore.mark_sent(input.message_store, input.frame_seq)
+      }
+    end
+  end
+
   defp attach_coalesce_handler do
     handler_id = {__MODULE__, :coalesced, make_ref()}
 
@@ -248,7 +280,8 @@ defmodule MingaEditor.Renderer.ServerTest do
       workspace: %{
         windows: %MingaEditor.State.Windows{},
         viewport: Viewport.new(24, 80)
-      }
+      },
+      message_store: MessageStore.new()
     }
   end
 

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -185,6 +185,7 @@ defmodule MingaEditor.StartupTest do
       assert active in state.workspace.buffers.list
       # No modal overlay is pushed on an empty launch.
       assert state.shell_state.modal == :none
+      assert state.message_store.stream_instance > 0
     end
 
     test "uses supplied options server for automatic startup view" do

--- a/test/minga_editor/ui/panel/message_store_test.exs
+++ b/test/minga_editor/ui/panel/message_store_test.exs
@@ -3,6 +3,16 @@ defmodule MingaEditor.UI.Panel.MessageStoreTest do
 
   alias MingaEditor.UI.Panel.MessageStore
 
+  describe "new/0" do
+    test "assigns a producer stream instance for restart-safe frontend identity" do
+      first = MessageStore.new()
+      second = MessageStore.new()
+
+      assert first.stream_instance > 0
+      assert second.stream_instance > first.stream_instance
+    end
+  end
+
   describe "append/4" do
     test "adds an entry with auto-incrementing id" do
       store =

--- a/test/minga_editor/ui/panel/message_store_test.exs
+++ b/test/minga_editor/ui/panel/message_store_test.exs
@@ -19,6 +19,7 @@ defmodule MingaEditor.UI.Panel.MessageStoreTest do
         %MessageStore{}
         |> MessageStore.append("Hello world")
 
+      assert store.stream_instance > 0
       assert length(store.entries) == 1
       [entry] = store.entries
       assert entry.id == 1
@@ -100,6 +101,30 @@ defmodule MingaEditor.UI.Panel.MessageStoreTest do
     test "updates last_sent_id" do
       store = MessageStore.mark_sent(%MessageStore{}, 42)
       assert store.last_sent_id == 42
+    end
+  end
+
+  describe "consumer cursor helpers" do
+    test "reset_sent_cursor keeps entries and rewinds the consumer cursor" do
+      store = %MessageStore{} |> MessageStore.append("A") |> MessageStore.mark_sent(1)
+
+      reset = MessageStore.reset_sent_cursor(store)
+
+      assert reset.last_sent_id == 0
+      assert reset.stream_instance == store.stream_instance
+      assert Enum.map(reset.entries, & &1.text) == ["A"]
+    end
+
+    test "merge_sent_cursor never rewinds or crosses streams" do
+      current = %MessageStore{} |> MessageStore.append("A") |> MessageStore.mark_sent(2)
+      stale = MessageStore.mark_sent(current, 1)
+      other_stream = %MessageStore{} |> MessageStore.append("B") |> MessageStore.mark_sent(10)
+
+      assert MessageStore.merge_sent_cursor(current, stale).last_sent_id == 2
+      assert MessageStore.merge_sent_cursor(current, other_stream).last_sent_id == 2
+
+      assert Enum.map(MessageStore.merge_sent_cursor(current, other_stream).entries, & &1.text) ==
+               ["A"]
     end
   end
 

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -1504,9 +1504,9 @@ fn guiBottomPanelSize(payload: []const u8) usize {
         if (!readString8Size(payload, &offset)) return payload.len;
     }
 
-    if (payload.len < offset + 2) return payload.len;
-    const entry_count = std.mem.readInt(u16, payload[offset..][0..2], .big);
-    offset += 2;
+    if (payload.len < offset + 6) return payload.len;
+    const entry_count = std.mem.readInt(u16, payload[offset + 4 ..][0..2], .big);
+    offset += 6;
 
     var entry_index: u16 = 0;
     while (entry_index < entry_count) : (entry_index += 1) {
@@ -2763,6 +2763,8 @@ test "commandSize: gui_bottom_panel packet" {
         'T',                 'e',
         's',                 't',
         's',                 0,
+        0,                   0,
+        7,                   0,
         1,                   0,
         0,                   0,
         7,                   3,


### PR DESCRIPTION
# TL;DR
Messages rows now get restart-safe identity from a producer-assigned `stream_instance` carried on the wire. This removes the Swift inference fallback and makes repeated sequence IDs safe across producer restarts.

Closes #2373

## Context
Issue #2373 identified that SwiftUI row identity for Messages was still inferred from local sequence behavior. That worked only when the consumer noticed sequence IDs move backward. This PR moves identity ownership to the producer and bumps the protocol contract so every frontend decodes the same header.

## Changes
- Bumped `protocol_version` to 4 and documented that stream identity is producer-assigned, not consumer-inferred.
- Added `stream_instance` to the Messages content payload in `gui_bottom_panel`, emitted before `entry_count`.
- Initialized `MessageStore` with a monotonic producer instance in editor startup.
- Updated Swift to compose row identity as `makeID(streamInstance, seq)` from decoded wire fields.
- Removed Swift `streamGeneration`, `lastSeq`, and `presentIDs` inference/dedupe state.
- Updated the Go TUI bottom-panel decoder and Zig protocol sizing helper for the custom payload.
- Added regressions for reused message IDs across different stream instances.

## Verification
- `mix protocol.gen --check`
- `mix test.llm test/minga/frontend/adapter/gui/bottom_panel_encoder_test.exs test/minga/render_model/ui/bottom_panel_test.exs test/minga_editor/render_model/ui/bottom_panel_builder_test.exs test/minga_editor/ui/panel/message_store_test.exs`
- `cd go/tui && go test ./internal/protocol`
- `cd zig && zig fmt --check src/protocol.zig && zig build test`
- `make lint` passed with existing struct-size warnings
- `mix test.llm --max-cases 1` passed: 9167 tests, 56 doctests, 87 properties, 0 failures
- `mix swift.build` skipped locally because `xcodebuild` is not installed

## Acceptance Criteria Addressed
- Add monotonic `stream_instance` to restart-sensitive Messages stream header ✅
- Bump `protocol_version` and emit `stream_instance` unconditionally ✅
- Compose Swift identity directly from `stream_instance` and `seq` ✅
- Delete Swift inference and defensive dedupe paths ✅
- Cover reused sequence IDs from a new stream instance with regression tests ✅
