### PR TITLE
perf(picker): read the project file cache for picker and tree filtering

### DIFF
--- a/lib/minga/project/file_tree.ex
+++ b/lib/minga/project/file_tree.ex
@@ -38,7 +38,8 @@ defmodule Minga.Project.FileTree do
           width: pos_integer(),
           git_status: GitStatus.status_map(),
           entries: [entry()] | nil,
-          filter: String.t() | nil
+          filter: String.t() | nil,
+          cached_files: [String.t()] | nil
         }
 
   @enforce_keys [:root]
@@ -49,7 +50,8 @@ defmodule Minga.Project.FileTree do
             width: 30,
             git_status: %{},
             entries: nil,
-            filter: nil
+            filter: nil,
+            cached_files: nil
 
   # ── Construction ──────────────────────────────────────────────────────────
 
@@ -234,6 +236,14 @@ defmodule Minga.Project.FileTree do
   def ensure_entries(%__MODULE__{entries: entries} = tree) when is_list(entries), do: tree
 
   def ensure_entries(%__MODULE__{} = tree) do
+    case cache_filter_entries(tree) do
+      entries when is_list(entries) -> %{tree | entries: entries}
+      :no_cache -> walk_entries(tree)
+    end
+  end
+
+  @spec walk_entries(t()) :: t()
+  defp walk_entries(%__MODULE__{} = tree) do
     # Span only the actual filesystem walk (the memoized path above returns
     # early), so `[:minga, :file_tree, :walk]` records real walk cost — its
     # entry count and duration — for spotting large-repo overages (#2367).
@@ -248,6 +258,93 @@ defmodule Minga.Project.FileTree do
       )
 
     %{tree | entries: entries}
+  end
+
+  @doc """
+  Attaches a cached flat list of project-relative file paths to the tree.
+
+  When set and a filter is active, `ensure_entries/1` builds the flat list of
+  matching entries from this cache in memory instead of walking the filesystem.
+  Pass `nil` to drop the cache and fall back to the filesystem walk.
+  """
+  @spec put_cached_files(t(), [String.t()] | nil) :: t()
+  def put_cached_files(%__MODULE__{} = tree, cached_files)
+      when is_list(cached_files) or is_nil(cached_files) do
+    invalidate_entries(%{tree | cached_files: cached_files})
+  end
+
+  # Builds flat filtered entries from the cached relative-path list. Returns
+  # `:no_cache` when there is no cache or no active filter, so the caller falls
+  # back to the filesystem walk (lazy, non-filtered browsing keeps walking).
+  @spec cache_filter_entries(t()) :: [entry()] | :no_cache
+  defp cache_filter_entries(%__MODULE__{cached_files: nil}), do: :no_cache
+
+  defp cache_filter_entries(%__MODULE__{cached_files: files} = tree) when is_list(files) do
+    if active_filter?(tree), do: build_cache_entries(files, tree), else: :no_cache
+  end
+
+  @spec build_cache_entries([String.t()], t()) :: [entry()]
+  defp build_cache_entries(files, %__MODULE__{filter: filter, root: root} = tree) do
+    needle = String.downcase(filter)
+
+    matches =
+      files
+      |> Enum.filter(&cache_path_matches?(&1, needle))
+      |> maybe_filter_hidden_paths(tree.show_hidden)
+      |> Enum.sort()
+
+    last_idx = length(matches) - 1
+
+    matches
+    |> Enum.with_index()
+    |> Enum.map(fn {rel_path, idx} -> cache_entry(rel_path, root, idx == last_idx) end)
+  end
+
+  @spec cache_path_matches?(String.t(), String.t()) :: boolean()
+  defp cache_path_matches?(rel_path, needle) do
+    rel_path |> String.downcase() |> String.contains?(needle)
+  end
+
+  @spec maybe_filter_hidden_paths([String.t()], boolean()) :: [String.t()]
+  defp maybe_filter_hidden_paths(paths, true), do: paths
+
+  defp maybe_filter_hidden_paths(paths, false) do
+    Enum.reject(paths, fn rel_path ->
+      rel_path |> Path.split() |> Enum.any?(&String.starts_with?(&1, "."))
+    end)
+  end
+
+  # Filtered cache matches are presented flat (depth 0, no tree guides): the
+  # filtered tree is a flat match list, not a nested expanded view (#2377).
+  @spec cache_entry(String.t(), String.t(), boolean()) :: entry()
+  defp cache_entry(rel_path, root, is_last) do
+    %{
+      path: Path.join(root, rel_path),
+      name: Path.basename(rel_path),
+      dir?: false,
+      depth: 0,
+      last_child?: is_last,
+      guides: []
+    }
+  end
+
+  @doc """
+  Computes the filtered visible entries by walking the filesystem.
+
+  Used by the async no-cache filter fallback (#2377 AC4): it runs the same walk
+  `ensure_entries/1` would, but returns just the entry list so the walk can run
+  off-process and the result be applied (or dropped if stale) later.
+  """
+  @spec filtered_walk_entries(t()) :: [entry()]
+  def filtered_walk_entries(%__MODULE__{} = tree) do
+    tree.root |> walk(0, tree, []) |> filter_entries(tree)
+  end
+
+  @doc "Replaces the cached visible entries with a precomputed list (clamps the cursor)."
+  @spec put_entries(t(), [entry()]) :: t()
+  def put_entries(%__MODULE__{} = tree, entries) when is_list(entries) do
+    max_idx = max(length(entries) - 1, 0)
+    %{tree | entries: entries, cursor: min(tree.cursor, max_idx)}
   end
 
   @doc "Refreshes the tree by rescanning the filesystem (clamps cursor)."

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -496,6 +496,11 @@ defmodule MingaEditor do
     {:noreply, EffectHandler.apply_effects(new_state, effects)}
   end
 
+  def handle_info({:file_tree_filter_walk, _root, _filter, _entries} = msg, state) do
+    {new_state, effects} = FileEventHandler.handle(state, msg)
+    {:noreply, EffectHandler.apply_effects(new_state, effects)}
+  end
+
   def handle_info(
         {:minga_input, {:mouse_event, row, col, button, mods, event_type, click_count}},
         state

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -238,8 +238,23 @@ defmodule MingaEditor.Commands.FileTree do
   @doc "Starts inline file tree filtering."
   @spec filter(state()) :: state()
   def filter(state) do
-    update_file_tree(state, &FileTreeState.start_filtering/1)
+    file_tree = FileTreeState.start_filtering(file_tree_state(state))
+    maybe_spawn_filter_walk(file_tree)
+    update_file_tree(state, fn _ -> file_tree end)
   end
+
+  # Spawns the async no-cache filesystem walk when re-entering filtering carries
+  # a pre-existing filter on a root the project cache does not cover (#2377 AC4).
+  @spec maybe_spawn_filter_walk(FileTreeState.t()) :: :ok
+  defp maybe_spawn_filter_walk(%FileTreeState{tree: %FileTree{} = tree} = file_tree) do
+    if FileTreeState.needs_filter_walk?(file_tree) do
+      MingaEditor.FileTree.FilterWalk.start(tree, self())
+    end
+
+    :ok
+  end
+
+  defp maybe_spawn_filter_walk(%FileTreeState{}), do: :ok
 
   @doc "Toggles the file tree help overlay."
   @spec toggle_help(state()) :: state()

--- a/lib/minga_editor/file_tree/filter_walk.ex
+++ b/lib/minga_editor/file_tree/filter_walk.ex
@@ -1,0 +1,48 @@
+defmodule MingaEditor.FileTree.FilterWalk do
+  @moduledoc """
+  Async filesystem walk for filtering a file tree whose root is NOT covered by
+  the active project cache (#2377 AC4).
+
+  The active project root filters in memory from `Minga.Project.files/0`, so this
+  fallback only runs for other roots (e.g. a tree pointed at a subdirectory or a
+  directory opened before project detection). The walk runs off the Editor
+  process and its result is keyed by `(root, filter)`; the Editor drops the
+  result if the user has since changed the filter or re-rooted the tree
+  (stale-result dropping), so a slow walk can never clobber newer state.
+  """
+
+  alias Minga.Project.FileTree
+
+  @typedoc "An async walk result tagged with the (root, filter) it was computed for."
+  @type result ::
+          {:file_tree_filter_walk, root :: String.t(), filter :: String.t(), [FileTree.entry()]}
+
+  @doc """
+  Spawns an unlinked walk that computes the filtered entries for `tree` and
+  sends `{:file_tree_filter_walk, root, filter, entries}` back to `reply_to`.
+
+  Returns `:ok`. The process is unlinked so a walk crash never takes down the
+  Editor; a dropped result simply means the tree keeps its prior entries.
+  """
+  @spec start(FileTree.t(), pid()) :: :ok
+  def start(%FileTree{root: root, filter: filter} = tree, reply_to)
+      when is_binary(filter) and is_pid(reply_to) do
+    {:ok, _pid} =
+      Task.start(fn ->
+        entries = FileTree.filtered_walk_entries(tree)
+        send(reply_to, {:file_tree_filter_walk, root, filter, entries})
+      end)
+
+    :ok
+  end
+
+  @doc """
+  Returns true when an async walk result still matches the tree's current
+  `(root, filter)`. Stale results (the user changed the filter or re-rooted)
+  return false and must be dropped.
+  """
+  @spec fresh?(FileTree.t(), String.t(), String.t()) :: boolean()
+  def fresh?(%FileTree{root: root, filter: filter}, result_root, result_filter) do
+    root == result_root and filter == result_filter
+  end
+end

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -164,7 +164,10 @@ defmodule MingaEditor.FileTree.Freshness do
 
     case file_tree.tree do
       %FileTree{root: ^expanded_root} ->
-        set_file_tree(state, FileTreeState.set_project_root(file_tree, expanded_root))
+        file_tree
+        |> FileTreeState.set_project_root(expanded_root)
+        |> refilter_active_tree()
+        |> then(&set_file_tree(state, &1))
 
       %FileTree{} = old_tree ->
         unwatch_expanded_dirs(old_tree)
@@ -189,6 +192,17 @@ defmodule MingaEditor.FileTree.Freshness do
         set_file_tree(state, FileTreeState.set_project_root(file_tree, expanded_root))
     end
   end
+
+  # Re-applies the active filter so an open filtered tree picks up the freshly
+  # rebuilt project cache (#2377 AC3). No-op when no filter is active, so normal
+  # expanded browsing keeps its lazy-walked entries untouched.
+  @spec refilter_active_tree(FileTreeState.t()) :: FileTreeState.t()
+  defp refilter_active_tree(%FileTreeState{tree: %FileTree{filter: filter}} = file_tree)
+       when is_binary(filter) and filter != "" do
+    FileTreeState.update_filter(file_tree, filter)
+  end
+
+  defp refilter_active_tree(%FileTreeState{} = file_tree), do: file_tree
 
   @doc "Registers expanded tree directories with the external file watcher when it is running."
   @spec watch_expanded_dirs(FileTree.t()) :: :ok

--- a/lib/minga_editor/file_tree/project_cache.ex
+++ b/lib/minga_editor/file_tree/project_cache.ex
@@ -1,0 +1,46 @@
+defmodule MingaEditor.FileTree.ProjectCache do
+  @moduledoc """
+  Bridges the editor file tree to the project's background-rebuilt file cache
+  (#2377).
+
+  `Minga.Project` keeps a flat list of project-relative paths that it rebuilds in
+  the background. When a tree (or picker) root is the active project root, the
+  picker and the filtered tree read this cache instead of doing filesystem I/O on
+  the editor path. This module centralizes the "is this the active project root?"
+  decision and the cache reads, with `:exit` guards so callers work even when the
+  Project GenServer is unavailable (early startup, tests).
+  """
+
+  @doc "Returns true when `root` expands to the active project root."
+  @spec active_root?(String.t()) :: boolean()
+  def active_root?(root) when is_binary(root) do
+    case active_root() do
+      active when is_binary(active) -> Path.expand(active) == Path.expand(root)
+      _ -> false
+    end
+  end
+
+  @doc "Returns the active project root, or nil when none is set or the process is down."
+  @spec active_root() :: String.t() | nil
+  def active_root do
+    Minga.Project.root()
+  catch
+    :exit, _ -> nil
+  end
+
+  @doc "Returns the project's cached relative-path list (empty while rebuilding or unavailable)."
+  @spec files() :: [String.t()]
+  def files do
+    Minga.Project.files()
+  catch
+    :exit, _ -> []
+  end
+
+  @doc "Returns true while the project's file cache is rebuilding."
+  @spec rebuilding?() :: boolean()
+  def rebuilding? do
+    Minga.Project.rebuilding?()
+  catch
+    :exit, _ -> false
+  end
+end

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -68,6 +68,11 @@ defmodule MingaEditor.Handlers.FileEventHandler do
     handle_file_changed(state, path)
   end
 
+  def handle(state, {:file_tree_filter_walk, root, filter, entries})
+      when is_binary(root) and is_binary(filter) and is_list(entries) do
+    handle_filter_walk_result(state, root, filter, entries)
+  end
+
   def handle(state, :file_tree_refresh_timer) do
     state = FileTreeFreshness.flush_refresh(state)
     {state, [{:render, 16}]}
@@ -217,5 +222,16 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   defp handle_project_rebuilt(state, root) do
     state = FileTreeFreshness.update_project_root(state, root)
     {state, [{:render, 16}]}
+  end
+
+  @spec handle_filter_walk_result(EditorState.t(), String.t(), String.t(), [
+          Minga.Project.FileTree.entry()
+        ]) :: {EditorState.t(), [file_effect()]}
+  defp handle_filter_walk_result(state, root, filter, entries) do
+    file_tree =
+      EditorState.file_tree_state(state)
+      |> MingaEditor.State.FileTree.apply_filter_walk(root, filter, entries)
+
+    {EditorState.set_file_tree(state, file_tree), [{:render, 16}]}
   end
 end

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -14,6 +14,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
 
   alias Minga.Buffer
   alias MingaEditor.Commands
+  alias MingaEditor.FileTree.FilterWalk
   alias MingaEditor.FocusTree
   alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.State, as: EditorState
@@ -387,13 +388,13 @@ defmodule MingaEditor.Input.FileTreeHandler do
       set_file_tree(state, FileTreeState.clear_filter(file_tree_state(state)))
     else
       new_text = String.slice(text, 0, max(String.length(text) - 1, 0))
-      set_file_tree(state, FileTreeState.update_filter(file_tree_state(state), new_text))
+      apply_filter_update(state, new_text)
     end
   end
 
   defp handle_filter_key(state, cp, mods) when printable_text_key?(cp, mods) do
     new_text = current_filter_text(state) <> <<cp::utf8>>
-    set_file_tree(state, FileTreeState.update_filter(file_tree_state(state), new_text))
+    apply_filter_update(state, new_text)
   end
 
   defp handle_filter_key(state, _cp, _mods), do: state
@@ -405,6 +406,29 @@ defmodule MingaEditor.Input.FileTreeHandler do
       _ -> ""
     end
   end
+
+  # Updates the active filter, then kicks off the async no-cache filesystem walk
+  # when the tree root is not covered by the project cache (#2377 AC4). The
+  # active project root filters in memory inside update_filter/2, so the walk is
+  # only spawned for other roots. The walk result arrives as a
+  # {:file_tree_filter_walk, ...} message handled by the editor.
+  @spec apply_filter_update(EditorState.t(), String.t()) :: EditorState.t()
+  defp apply_filter_update(state, filter_text) do
+    file_tree = FileTreeState.update_filter(file_tree_state(state), filter_text)
+    maybe_spawn_filter_walk(file_tree)
+    set_file_tree(state, file_tree)
+  end
+
+  @spec maybe_spawn_filter_walk(FileTreeState.t()) :: :ok
+  defp maybe_spawn_filter_walk(%FileTreeState{tree: %FileTree{} = tree} = file_tree) do
+    if FileTreeState.needs_filter_walk?(file_tree) do
+      FilterWalk.start(tree, self())
+    end
+
+    :ok
+  end
+
+  defp maybe_spawn_filter_walk(%FileTreeState{}), do: :ok
 
   # ── Shared helpers ──────────────────────────────────────────────────────
 

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -8,6 +8,8 @@ defmodule MingaEditor.State.FileTree do
   """
 
   alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.FilterWalk
+  alias MingaEditor.FileTree.ProjectCache
   alias MingaEditor.State.FileTree.ClipboardMark
 
   @typedoc """
@@ -243,10 +245,12 @@ defmodule MingaEditor.State.FileTree do
   @spec start_filtering(t()) :: t()
   def start_filtering(%__MODULE__{tree: %FileTree{} = tree} = ft) do
     filter = tree.filter || ""
+    {tree, status} = filtered_tree(tree, filter)
 
     %{
       ft
-      | tree: FileTree.set_filter(tree, filter),
+      | tree: tree,
+        tree_status: status,
         filtering: true,
         editing: nil,
         help_visible: false
@@ -255,14 +259,99 @@ defmodule MingaEditor.State.FileTree do
 
   def start_filtering(%__MODULE__{} = ft), do: ft
 
-  @doc "Updates the active file tree filter."
+  @doc """
+  Updates the active file tree filter.
+
+  When the tree root matches the active project root, the matching entries are
+  filtered in memory from the project's cached file list (`Minga.Project.files/0`)
+  rather than walking the filesystem. Roots not covered by the active cache fall
+  back to the filesystem walk.
+
+  While the active project's cache is still rebuilding (empty list), the tree
+  reports a `:loading` pending state instead of silently re-shelling out.
+  """
   @spec update_filter(t(), String.t()) :: t()
   def update_filter(%__MODULE__{tree: %FileTree{} = tree} = ft, filter) when is_binary(filter) do
-    tree = FileTree.set_filter(tree, filter)
-    %{ft | tree: tree, tree_status: classify_tree(tree)}
+    {tree, status} = filtered_tree(tree, filter)
+    %{ft | tree: tree, tree_status: status}
   end
 
   def update_filter(%__MODULE__{} = ft, _filter), do: ft
+
+  @doc """
+  Returns true when filtering the tree requires the async no-cache filesystem
+  walk (#2377 AC4): a filter is active and the tree root is not the active
+  project root, so in-memory cache filtering does not cover it.
+  """
+  @spec needs_filter_walk?(t()) :: boolean()
+  def needs_filter_walk?(%__MODULE__{tree: %FileTree{filter: filter, root: root}})
+      when is_binary(filter) and filter != "" do
+    not ProjectCache.active_root?(root)
+  end
+
+  def needs_filter_walk?(%__MODULE__{}), do: false
+
+  @doc """
+  Applies an async no-cache filter walk result, dropping it if stale.
+
+  The result is keyed by the `(root, filter)` it was computed for; if the user
+  has since changed the filter or re-rooted the tree it is discarded so a slow
+  walk never clobbers newer state (#2377 AC4 stale-result dropping).
+  """
+  @spec apply_filter_walk(t(), String.t(), String.t(), [FileTree.entry()]) :: t()
+  def apply_filter_walk(%__MODULE__{tree: %FileTree{} = tree} = ft, root, filter, entries) do
+    if FilterWalk.fresh?(tree, root, filter) do
+      tree = FileTree.put_entries(tree, entries)
+      %{ft | tree: tree, tree_status: classify_entries(entries)}
+    else
+      ft
+    end
+  end
+
+  def apply_filter_walk(%__MODULE__{} = ft, _root, _filter, _entries), do: ft
+
+  # Resolves the filtered tree plus its presentation status. An empty filter is
+  # the full unfiltered tree (always classified from the walk). With an active
+  # filter, the active project root filters in memory from the cache; a
+  # rebuilding (empty) cache reports `:loading`; other roots defer to an async
+  # filesystem walk (`:loading` until the walk result arrives).
+  @spec filtered_tree(FileTree.t(), String.t()) :: {FileTree.t(), tree_status()}
+  defp filtered_tree(%FileTree{} = tree, "") do
+    tree = tree |> FileTree.put_cached_files(nil) |> FileTree.set_filter("")
+    {tree, classify_tree(tree)}
+  end
+
+  defp filtered_tree(%FileTree{root: root} = tree, filter) do
+    if ProjectCache.active_root?(root) do
+      filtered_from_cache(tree, filter, ProjectCache.files())
+    else
+      # No-cache root: clear the cache and mark loading; the editor spawns an
+      # async walk (see needs_filter_walk?/1) and applies the result later.
+      tree = tree |> FileTree.put_cached_files(nil) |> FileTree.set_filter(filter)
+      {tree, :loading}
+    end
+  end
+
+  @spec filtered_from_cache(FileTree.t(), String.t(), [String.t()]) ::
+          {FileTree.t(), tree_status()}
+  defp filtered_from_cache(tree, filter, []) do
+    # Active root but the cache is empty: a rebuild is in progress (or the
+    # project has no files). Show a pending state rather than re-shelling out.
+    tree = tree |> FileTree.put_cached_files([]) |> FileTree.set_filter(filter)
+    {tree, cache_pending_status(tree)}
+  end
+
+  defp filtered_from_cache(tree, filter, files) do
+    tree = tree |> FileTree.put_cached_files(files) |> FileTree.set_filter(filter)
+    {tree, classify_entries(FileTree.visible_entries(tree))}
+  end
+
+  @spec cache_pending_status(FileTree.t()) :: tree_status()
+  defp cache_pending_status(tree) do
+    if ProjectCache.rebuilding?(),
+      do: :loading,
+      else: classify_entries(FileTree.visible_entries(tree))
+  end
 
   @doc "Accepts the current filter and leaves the narrowed tree visible."
   @spec accept_filter(t()) :: t()
@@ -271,7 +360,8 @@ defmodule MingaEditor.State.FileTree do
   @doc "Clears the active filter and exits filtering mode."
   @spec clear_filter(t()) :: t()
   def clear_filter(%__MODULE__{tree: %FileTree{} = tree} = ft) do
-    tree = FileTree.clear_filter(tree)
+    # Drop the cache so non-filtered browsing resumes lazy filesystem walking.
+    tree = tree |> FileTree.put_cached_files(nil) |> FileTree.clear_filter()
     %{ft | tree: tree, filtering: false, tree_status: classify_tree(tree)}
   end
 

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
 
   @behaviour MingaEditor.UI.Picker.Source
 
+  alias MingaEditor.FileTree.ProjectCache
   alias MingaEditor.State, as: EditorState
   alias Minga.Git
   alias Minga.Language
@@ -34,7 +35,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   def candidates(ctx) do
     root = project_root(ctx)
 
-    case Minga.Project.list_files(root) do
+    case resolve_paths(root) do
       {:ok, paths} ->
         frecency_map = build_frecency_map()
         git_status_map = build_git_status_map(root)
@@ -48,6 +49,27 @@ defmodule MingaEditor.UI.Picker.FileSource do
         log_error(msg)
     end
   end
+
+  # Reads the project's background-rebuilt file cache when `root` is the active
+  # project root, so opening the picker never shells out for a known project
+  # (#2377 AC1). A populated mid-rebuild cache returns the stale list instantly,
+  # which is fine for a picker. When the active cache is still empty (e.g. the
+  # project was just switched and the first rebuild has not finished), the picker
+  # falls back to a one-shot `list_files/1` so it never opens empty. Roots that
+  # are not the active project always use the direct discovery.
+  @spec resolve_paths(String.t()) :: {:ok, [String.t()]} | {:error, String.t()}
+  defp resolve_paths(root) do
+    if ProjectCache.active_root?(root) do
+      resolve_active_paths(root, ProjectCache.files())
+    else
+      Minga.Project.list_files(root)
+    end
+  end
+
+  @spec resolve_active_paths(String.t(), [String.t()]) ::
+          {:ok, [String.t()]} | {:error, String.t()}
+  defp resolve_active_paths(root, []), do: Minga.Project.list_files(root)
+  defp resolve_active_paths(_root, paths), do: {:ok, paths}
 
   # Lean candidate: just enough to match (filename label, full-path search text)
   # and to enrich later (git status stashed in `meta`). Icon, color, two-line

--- a/test/minga/project/file_tree_test.exs
+++ b/test/minga/project/file_tree_test.exs
@@ -321,6 +321,53 @@ defmodule Minga.Project.FileTreeTest do
       assert names(tree) == ["alpha.txt", "beta.txt"]
     end
 
+    test "filters the cached path list in memory without walking the filesystem" do
+      # No tmp_dir / no files on disk: a walk would return []. The matches come
+      # entirely from the injected cache, proving in-memory filtering (#2377 AC2).
+      tree =
+        "/nonexistent_project_root"
+        |> FileTree.new()
+        |> FileTree.put_cached_files(["lib/target.ex", "lib/other.ex", "README.md"])
+        |> FileTree.set_filter("target")
+
+      assert names(tree) == ["target.ex"]
+      assert paths(tree) == ["/nonexistent_project_root/lib/target.ex"]
+    end
+
+    test "cache filtering presents matches flat at depth 0" do
+      tree =
+        "/root"
+        |> FileTree.new()
+        |> FileTree.put_cached_files(["a/b/c/deep.ex"])
+        |> FileTree.set_filter("deep")
+
+      assert [%{depth: 0, dir?: false, guides: []}] = FileTree.visible_entries(tree)
+    end
+
+    test "an empty cache yields no matches and does not walk the filesystem" do
+      tree =
+        "/nonexistent_project_root"
+        |> FileTree.new()
+        |> FileTree.put_cached_files([])
+        |> FileTree.set_filter("anything")
+
+      assert FileTree.visible_entries(tree) == []
+    end
+
+    @tag :tmp_dir
+    test "clearing the cache restores the filesystem walk for filtering", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, "walked.ex"))
+
+      tree =
+        tmp_dir
+        |> FileTree.new()
+        |> FileTree.put_cached_files(["cached_only.ex"])
+        |> FileTree.put_cached_files(nil)
+        |> FileTree.set_filter("walked")
+
+      assert names(tree) == ["walked.ex"]
+    end
+
     @tag :tmp_dir
     test "reroot preserves display settings and opens the new root", %{tmp_dir: tmp_dir} do
       next_root = Path.join(tmp_dir, "child")
@@ -421,10 +468,17 @@ defmodule Minga.Project.FileTreeTest do
       parent = self()
       handler_id = {__MODULE__, ref}
 
+      # Filter on this test's root so a concurrent (async) walk in another test
+      # never trips the refute_receive below; telemetry handlers are global.
+      expected_root = Path.expand(tmp_dir)
+
       :telemetry.attach(
         handler_id,
         [:minga, :file_tree, :walk, :stop],
-        fn _event, _m, _meta, _ -> send(parent, {ref, :walked}) end,
+        fn
+          _event, _m, %{root: ^expected_root}, _ -> send(parent, {ref, :walked})
+          _event, _m, _meta, _ -> :ok
+        end,
         nil
       )
 

--- a/test/minga_editor/file_tree/filter_walk_test.exs
+++ b/test/minga_editor/file_tree/filter_walk_test.exs
@@ -1,0 +1,45 @@
+defmodule MingaEditor.FileTree.FilterWalkTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.FilterWalk
+
+  describe "fresh?/3" do
+    test "a result for the current root and filter is fresh" do
+      tree = "/root" |> FileTree.new() |> FileTree.set_filter("needle")
+
+      assert FilterWalk.fresh?(tree, "/root", "needle")
+    end
+
+    test "a result for a superseded filter is stale" do
+      tree = "/root" |> FileTree.new() |> FileTree.set_filter("newer")
+
+      refute FilterWalk.fresh?(tree, "/root", "older")
+    end
+
+    test "a result for a different root is stale" do
+      tree = "/current" |> FileTree.new() |> FileTree.set_filter("needle")
+
+      refute FilterWalk.fresh?(tree, "/previous", "needle")
+    end
+  end
+
+  describe "start/2 async walk" do
+    @tag :tmp_dir
+    test "walks off-process and replies with entries keyed by root and filter",
+         %{tmp_dir: tmp_dir} do
+      mkdir = fn p -> File.mkdir_p!(p) end
+      mkdir.(Path.join(tmp_dir, "lib"))
+      File.write!(Path.join([tmp_dir, "lib", "target.ex"]), "")
+      File.write!(Path.join(tmp_dir, "other.txt"), "")
+
+      tree = tmp_dir |> FileTree.new() |> FileTree.set_filter("target")
+
+      assert :ok = FilterWalk.start(tree, self())
+
+      root = tree.root
+      assert_receive {:file_tree_filter_walk, ^root, "target", entries}, 5_000
+      assert Enum.map(entries, & &1.name) == ["target.ex"]
+    end
+  end
+end

--- a/test/minga_editor/integration/file_tree_test.exs
+++ b/test/minga_editor/integration/file_tree_test.exs
@@ -88,6 +88,71 @@ defmodule Minga.Integration.FileTreeTest do
     end
   end
 
+  describe "filtering reads the project cache (#2377)" do
+    test "filtering the active project root matches descendants from the cache", %{tmp_dir: dir} do
+      ctx = start_project_editor(dir)
+
+      Minga.Events.subscribe(:project_rebuilt)
+      Minga.Project.switch(dir)
+      await_project_rebuild(dir)
+
+      ctx = open_file_tree(ctx)
+
+      # `/` enters filtering, then type a needle that only matches a nested file.
+      send_keys_sync(ctx, "/gamma")
+
+      assert file_tree_contains?(ctx, "gamma.txt"),
+             "filtering should surface the nested match from the cache without expanding"
+
+      refute file_tree_contains?(ctx, "alpha.txt"),
+             "non-matching entries should be filtered out"
+    end
+
+    test "an open filtered tree refreshes when the project cache rebuilds", %{tmp_dir: dir} do
+      %{file: file, project_root: root} = setup_fixture(%{tmp_dir: dir})
+
+      # Share the default event registry with the global Minga.Project so the
+      # editor receives its :project_rebuilt broadcasts.
+      registry = Minga.Events.default_registry()
+
+      ctx =
+        start_editor("alpha content",
+          file_path: file,
+          project_root: root,
+          events_registry: registry
+        )
+
+      Minga.Events.subscribe(:project_rebuilt, registry)
+      Minga.Project.switch(dir)
+      await_project_rebuild(dir)
+
+      ctx = open_file_tree(ctx)
+      send_keys_sync(ctx, "/delta")
+
+      refute file_tree_contains?(ctx, "delta.txt")
+
+      # Add a matching file and rebuild the cache; the open filtered tree should
+      # pick it up on the :project_rebuilt event.
+      File.write!(Path.join(dir, "delta.txt"), "delta content")
+      Minga.Project.invalidate()
+      await_project_rebuild(dir)
+      _ = editor_state(ctx)
+
+      assert file_tree_contains?(ctx, "delta.txt"),
+             "the filtered tree should re-filter the rebuilt cache on :project_rebuilt"
+    end
+  end
+
+  defp await_project_rebuild(root) do
+    if Minga.Project.rebuilding?() do
+      assert_receive {:minga_event, :project_rebuilt,
+                      %Minga.Events.ProjectRebuiltEvent{root: ^root}},
+                     5_000
+    end
+
+    _ = :sys.get_state(Minga.Project)
+  end
+
   defp file_tree_contains?(ctx, name) do
     ctx
     |> editor_state()

--- a/test/minga_editor/state/file_tree_filter_test.exs
+++ b/test/minga_editor/state/file_tree_filter_test.exs
@@ -1,0 +1,77 @@
+defmodule MingaEditor.State.FileTreeFilterTest do
+  @moduledoc """
+  Covers the cache-vs-walk filtering decision and async no-cache stale-drop in
+  MingaEditor.State.FileTree (#2377).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  # These tests run without the Minga.Project GenServer, so ProjectCache treats
+  # every root as "not the active project" (the :exit guard returns false). That
+  # is exactly the no-cache fallback path we want to exercise here.
+
+  defp open_tree(root) do
+    %FileTreeState{}
+    |> FileTreeState.open(FileTree.new(root), nil)
+  end
+
+  test "filtering a no-cache root marks the tree loading pending the async walk" do
+    ft = open_tree("/nonexistent_root") |> FileTreeState.update_filter("needle")
+
+    assert ft.tree.filter == "needle"
+    assert ft.tree_status == :loading
+    assert FileTreeState.needs_filter_walk?(ft)
+  end
+
+  test "an empty filter never needs an async walk" do
+    ft = open_tree("/nonexistent_root") |> FileTreeState.update_filter("")
+
+    refute FileTreeState.needs_filter_walk?(ft)
+  end
+
+  test "apply_filter_walk installs entries for the current root and filter" do
+    ft = open_tree("/nonexistent_root") |> FileTreeState.update_filter("needle")
+    root = ft.tree.root
+
+    entries = [
+      %{
+        path: "/nonexistent_root/needle.ex",
+        name: "needle.ex",
+        dir?: false,
+        depth: 0,
+        last_child?: true,
+        guides: []
+      }
+    ]
+
+    updated = FileTreeState.apply_filter_walk(ft, root, "needle", entries)
+
+    assert FileTree.visible_entries(updated.tree) == entries
+    assert updated.tree_status == :ready
+  end
+
+  test "apply_filter_walk drops a stale result for a superseded filter" do
+    ft = open_tree("/nonexistent_root") |> FileTreeState.update_filter("newer")
+    root = ft.tree.root
+    before = ft.tree.entries
+
+    stale = [
+      %{
+        path: "/nonexistent_root/old.ex",
+        name: "old.ex",
+        dir?: false,
+        depth: 0,
+        last_child?: true,
+        guides: []
+      }
+    ]
+
+    updated = FileTreeState.apply_filter_walk(ft, root, "older", stale)
+
+    # The stale walk result is discarded; the tree keeps its prior entries.
+    assert updated.tree.entries == before
+  end
+end

--- a/test/minga_editor/ui/picker/file_source_test.exs
+++ b/test/minga_editor/ui/picker/file_source_test.exs
@@ -242,6 +242,56 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
     assert hot_index < cold_index
   end
 
+  test "reads the project file cache for the active root without re-discovering on disk",
+       %{tmp_dir: tmp_dir} do
+    project = Path.join(tmp_dir, "cache_active_root_#{:erlang.unique_integer([:positive])}")
+    File.mkdir_p!(project)
+    File.write!(Path.join(project, "mix.exs"), "")
+    File.write!(Path.join(project, "cached.ex"), "cached")
+
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(project)
+    await_project_rebuild(project)
+
+    # Create a new file AFTER the cache was built. A fresh discovery would list
+    # it; reading the cache must not, proving the picker uses Minga.Project.files/0.
+    File.write!(Path.join(project, "added_after_cache.ex"), "late")
+
+    ctx =
+      start_editor("cached", file_path: Path.join(project, "cached.ex"), project_root: project)
+
+    ids = ctx |> editor_state() |> FileSource.candidates() |> Enum.map(& &1.id)
+
+    assert "cached.ex" in ids
+    refute "added_after_cache.ex" in ids
+  end
+
+  test "falls back to direct discovery for a root that is not the active project",
+       %{tmp_dir: tmp_dir} do
+    active = Path.join(tmp_dir, "fallback_active_#{:erlang.unique_integer([:positive])}")
+    other = Path.join(tmp_dir, "fallback_other_#{:erlang.unique_integer([:positive])}")
+    File.mkdir_p!(active)
+    File.mkdir_p!(other)
+    File.write!(Path.join(active, "mix.exs"), "")
+    File.write!(Path.join(other, "outside.txt"), "outside")
+
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(active)
+    await_project_rebuild(active)
+
+    ctx = start_editor("active", file_path: Path.join(active, "mix.exs"), project_root: active)
+
+    picker_context =
+      ctx
+      |> editor_state()
+      |> Context.from_editor_state(%{project_root: other})
+
+    ids = FileSource.candidates(picker_context) |> Enum.map(& &1.id)
+
+    # The non-active root is discovered directly on disk, not from the cache.
+    assert "outside.txt" in ids
+  end
+
   test "explicit picker project root overrides stale file tree root", %{tmp_dir: tmp_dir} do
     stale_root = Path.join(tmp_dir, "stale_file_source_root")
     selected_root = Path.join(tmp_dir, "selected_file_source_root")


### PR DESCRIPTION
## Summary

The file picker and the file-tree filter both did filesystem I/O on the editor path even though `Minga.Project` keeps a background-rebuilt flat file cache (`Minga.Project.files/0`). Both surfaces now read that cache instead of shelling out (`git ls-files`/`fd`/`find`) or walking the tree on every filter keystroke.

The shared move:
- Picker `FileSource.candidates/1` reads `Minga.Project.files/0` when the requested root is the active project root, falling back to a one-shot `list_files/1` only when that cache is still empty (just-switched project) or the root is not the active project. The lean-candidate / late-enrichment path from #2351 is untouched.
- File-tree filtering builds the flat list of matches in memory from the cached relative-path list (`Minga.Project.FileTree.put_cached_files/2`), not a filesystem walk. Matches stay flat (the existing filtered-tree UX).
- A rebuilding (empty) active cache shows a pending `:loading` state and never silently re-shells-out for the active root; an open filtered tree re-filters the rebuilt cache on `:project_rebuilt`.
- Roots not covered by the active cache keep a bounded async filesystem walk (`MingaEditor.FileTree.FilterWalk`) with stale-result dropping keyed by `(root, filter)`, so a slow walk never clobbers newer state.

Backend-only; both frontends (macOS GUI, Go TUI) share this path. No Swift/Go changes.

## Stacked PR

This is **STACKED on #2380** (base branch `feat/filetree-reuse-excludes`, which deletes `@default_ignore` from `Minga.Project.FileTree` and reads `file_find_excludes` from config). Review/merge #2380 first.

## Acceptance criteria

- [x] **AC1** Picker reads `Minga.Project.files/0` when the requested root is the active project root; no synchronous discovery for a known project. A mid-rebuild (populated) cache returns the stale list instantly. (Empty cache right after a fresh switch falls back to one-shot `list_files/1` so the picker never opens empty.)
- [x] **AC2** File-tree filtering runs in memory over the cached path list. No filesystem walk while filtering the active root.
- [x] **AC3** Empty/rebuilding cache shows a pending `:loading` state and does not silently re-shell-out for the active root; an open picker/tree refreshes on `:project_rebuilt`.
- [x] **AC4** Roots not represented by the active cache keep the direct fallback (picker: `list_files/1`) or a bounded async walk (tree no-cache case) with stale-result dropping.
- [x] **AC5** Normal expanded-directory browsing stays lazy (only active filters use the cache; clearing the filter drops the cache and resumes lazy walking).
- [x] **AC6** Tests: picker uses the cache without re-discovering on disk for the active root; tree filters the cache in memory; stale-drop on the no-cache async fallback.

## Tests run

- `mix test.llm` (full Elixir suite): **0 failures** (56 doctests, 87 properties, 9182 tests, 334 excluded)
- `make lint` (format + credo --strict + compile + dialyzer): **All lint checks passed**

New/updated tests:
- `test/minga/project/file_tree_test.exs` — in-memory cache filtering, flat depth-0 matches, empty cache yields no matches without walking, clearing the cache restores the walk.
- `test/minga_editor/file_tree/filter_walk_test.exs` — async walk + `fresh?/3` stale-drop.
- `test/minga_editor/state/file_tree_filter_test.exs` — cache-vs-walk decision, `needs_filter_walk?/1`, `apply_filter_walk/4` stale-drop.
- `test/minga_editor/ui/picker/file_source_test.exs` — active root reads cache (does not see a file added after the cache built), non-active root falls back to direct discovery.
- `test/minga_editor/integration/file_tree_test.exs` — filtering the active root matches descendants from the cache; an open filtered tree refreshes on `:project_rebuilt`.

Closes #2377

🤖 Generated with [Claude Code](https://claude.com/claude-code)