### PR TITLE
feat(agent): add configurable status command

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -110,6 +110,17 @@ set :modeline_left_segments, [:mode, :filename, :position, :git]
 set :modeline_right_segments, [:diagnostics, :lsp, :filetype]
 ```
 
+### Agent status command
+
+Set `:agent_status_command` to replace the built-in `:agent` segment text with stdout from a shell command. Minga reruns it every `:agent_status_interval_ms` milliseconds, default `5000`; values below `1000` are treated as `1000`. Failed commands or empty output fall back to the built-in agent status and log one `*Messages*` entry.
+
+```elixir
+set :agent_status_command, ~s(echo "$MINGA_MODEL | $MINGA_STATUS")
+set :agent_status_interval_ms, 5_000
+```
+
+Available environment variables: `MINGA_SESSION_ID`, `MINGA_MODEL`, `MINGA_STATUS`, and `MINGA_WORKDIR`.
+
 ### Separator style
 
 `:modeline_separator` controls the glyph inserted between adjacent color zones.

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -87,6 +87,8 @@ defmodule Minga.Config.Options do
           | :agent_system_prompt
           | :agent_append_system_prompt
           | :agent_diff_size_threshold
+          | :agent_status_command
+          | :agent_status_interval_ms
           | :agent_max_turns
           | :agent_max_cost
           | :agent_api_base_url
@@ -316,6 +318,10 @@ defmodule Minga.Config.Options do
      "Additional text appended to the default agent system prompt."},
     {:agent_diff_size_threshold, :pos_integer, 1_048_576,
      "Maximum diff size shown inline before truncation or summarization."},
+    {:agent_status_command, :string_or_nil, nil,
+     "Shell command whose stdout replaces the built-in agent modeline status."},
+    {:agent_status_interval_ms, :pos_integer, 5_000,
+     "Milliseconds between agent status command runs. Values below 1000 are treated as 1000."},
     {:agent_max_turns, :pos_integer, 100, "Maximum number of turns allowed in an agent session."},
     {:agent_max_cost, :float_or_nil, nil, "Optional cost ceiling for an agent session."},
     {:agent_api_base_url, :string, "", "Base URL override for agent API requests."},

--- a/lib/minga/services/independent.ex
+++ b/lib/minga/services/independent.ex
@@ -15,6 +15,7 @@ defmodule Minga.Services.Independent do
       ├── Minga.CommandOutput.Registry    Registry(:unique)
       ├── Minga.Eval.TaskSupervisor      Task.Supervisor for eval/async work
       ├── Minga.Command.Registry         Named command lookup
+      ├── MingaAgent.StatusCommand       Cached agent status command output
       ├── Minga.Diagnostics              ETS-backed diagnostics store
       ├── Minga.Session.EventRecorder            Persistent editor event log (SQLite via exqlite)
       ├── MingaAgent.EventLog                    Persistent agent session event log
@@ -39,6 +40,7 @@ defmodule Minga.Services.Independent do
       {Registry, keys: :unique, name: Minga.CommandOutput.Registry},
       {Task.Supervisor, name: Minga.Eval.TaskSupervisor},
       Minga.Command.Registry,
+      MingaAgent.StatusCommand,
       Minga.Distribution.ConnectionManager,
       Minga.Diagnostics,
       Minga.Session.EventRecorder,

--- a/lib/minga_agent/status_command.ex
+++ b/lib/minga_agent/status_command.ex
@@ -1,0 +1,292 @@
+defmodule MingaAgent.StatusCommand do
+  @moduledoc """
+  Caches user-provided agent status modeline text.
+
+  The command runs outside the render path. Render code only updates the latest
+  context and reads the last successful stdout value.
+  """
+
+  use GenServer
+
+  alias Minga.Config.Options
+
+  @min_interval_ms 1_000
+  @default_timeout_ms 1_000
+  @tick :tick
+
+  @type context :: %{
+          optional(:session_id) => String.t() | nil,
+          optional(:model) => String.t() | nil,
+          optional(:status) => atom() | String.t() | nil,
+          optional(:workdir) => String.t() | nil
+        }
+
+  @type state :: %{
+          command: String.t() | nil,
+          interval_ms: pos_integer(),
+          context: context(),
+          value: String.t() | nil,
+          task: Task.t() | nil,
+          timer: reference() | nil,
+          next_run_at_ms: integer() | nil,
+          failure_reported?: boolean(),
+          task_supervisor: module(),
+          config_server: Options.server()
+        }
+
+  @doc false
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: Keyword.get(opts, :id, __MODULE__),
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :permanent,
+      shutdown: 5_000,
+      type: :worker
+    }
+  end
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc "Returns the last successful command output, or nil for built-in status."
+  @spec content(context(), GenServer.server()) :: String.t() | nil
+  def content(context, server \\ __MODULE__) when is_map(context) do
+    if server_alive?(server) do
+      GenServer.call(server, {:content, context}, 100)
+    else
+      nil
+    end
+  catch
+    :exit, _ -> nil
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, state()}
+  def init(opts) do
+    state = %{
+      command: nil,
+      interval_ms: @min_interval_ms,
+      context: %{},
+      value: nil,
+      task: nil,
+      timer: nil,
+      next_run_at_ms: nil,
+      failure_reported?: false,
+      task_supervisor: Keyword.get(opts, :task_supervisor, Minga.Eval.TaskSupervisor),
+      config_server: Keyword.get(opts, :config_server, Options.default_server())
+    }
+
+    {:ok, schedule(refresh_config(state), 0)}
+  end
+
+  @impl true
+  def handle_call({:content, context}, _from, state) do
+    state =
+      state
+      |> Map.put(:context, normalize_context(context))
+      |> refresh_config()
+      |> maybe_start_task()
+      |> schedule_current_interval()
+
+    {:reply, state.value, state}
+  end
+
+  @impl true
+  def handle_info(@tick, state) do
+    state =
+      state
+      |> Map.put(:timer, nil)
+      |> refresh_config()
+      |> maybe_start_task()
+      |> schedule_current_interval()
+
+    {:noreply, state}
+  end
+
+  def handle_info({ref, {:ok, output}}, %{task: %Task{ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+    {:noreply, %{state | task: nil, value: output, failure_reported?: false}}
+  end
+
+  def handle_info({ref, {:error, reason}}, %{task: %Task{ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+    {:noreply, command_failed(%{state | task: nil}, reason)}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{task: %Task{ref: ref}} = state) do
+    {:noreply, command_failed(%{state | task: nil}, reason)}
+  end
+
+  def handle_info({:command_timeout, ref}, %{task: %Task{ref: ref} = task} = state) do
+    Task.shutdown(task, :brutal_kill)
+    {:noreply, command_failed(%{state | task: nil}, :timeout)}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @spec refresh_config(state()) :: state()
+  defp refresh_config(state) do
+    command = configured_command(state)
+    interval_ms = configured_interval_ms(state)
+
+    if command == state.command and interval_ms == state.interval_ms do
+      state
+    else
+      state
+      |> cancel_timer()
+      |> cancel_task()
+      |> Map.merge(%{
+        command: command,
+        interval_ms: interval_ms,
+        value: nil,
+        next_run_at_ms: nil,
+        failure_reported?: false
+      })
+      |> schedule(0)
+    end
+  end
+
+  @spec configured_command(state()) :: String.t() | nil
+  defp configured_command(%{config_server: config_server}) do
+    case Options.get(config_server, :agent_status_command) do
+      command when is_binary(command) -> String.trim(command) |> blank_to_nil()
+      _other -> nil
+    end
+  end
+
+  @spec configured_interval_ms(state()) :: pos_integer()
+  defp configured_interval_ms(%{config_server: config_server}) do
+    case Options.get(config_server, :agent_status_interval_ms) do
+      value when is_integer(value) -> max(value, @min_interval_ms)
+      _other -> 5_000
+    end
+  end
+
+  @spec blank_to_nil(String.t()) :: String.t() | nil
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
+
+  @spec maybe_start_task(state()) :: state()
+  defp maybe_start_task(%{command: nil} = state), do: %{state | value: nil}
+  defp maybe_start_task(%{context: context} = state) when map_size(context) == 0, do: state
+  defp maybe_start_task(%{task: %Task{}} = state), do: state
+  defp maybe_start_task(%{next_run_at_ms: nil} = state), do: start_task(state, now_ms())
+
+  defp maybe_start_task(%{next_run_at_ms: next_run_at_ms} = state) do
+    now = now_ms()
+
+    if now >= next_run_at_ms do
+      start_task(state, now)
+    else
+      state
+    end
+  end
+
+  @spec start_task(state(), integer()) :: state()
+  defp start_task(%{command: command, context: context, task_supervisor: supervisor} = state, now) do
+    task = Task.Supervisor.async_nolink(supervisor, fn -> run_command(command, context) end)
+    Process.send_after(self(), {:command_timeout, task.ref}, @default_timeout_ms)
+    %{state | task: task, next_run_at_ms: now + state.interval_ms}
+  catch
+    :exit, reason -> command_failed(state, reason)
+  end
+
+  @spec run_command(String.t(), context()) :: {:ok, String.t()} | {:error, term()}
+  defp run_command(command, context) do
+    workdir = Map.get(context, :workdir) || File.cwd!()
+
+    case System.cmd("sh", ["-c", command],
+           cd: workdir,
+           env: env(context),
+           stderr_to_stdout: false
+         ) do
+      {output, 0} -> command_output(output)
+      {_output, status} -> {:error, {:exit_status, status}}
+    end
+  rescue
+    error -> {:error, error}
+  end
+
+  @spec command_output(String.t()) :: {:ok, String.t()} | {:error, :empty_output}
+  defp command_output(output) do
+    case String.trim(output) do
+      "" -> {:error, :empty_output}
+      text -> {:ok, text}
+    end
+  end
+
+  @spec env(context()) :: [{String.t(), String.t()}]
+  defp env(context) do
+    [
+      {"MINGA_SESSION_ID", env_value(Map.get(context, :session_id))},
+      {"MINGA_MODEL", env_value(Map.get(context, :model))},
+      {"MINGA_STATUS", env_value(Map.get(context, :status))},
+      {"MINGA_WORKDIR", env_value(Map.get(context, :workdir) || File.cwd!())}
+    ]
+  end
+
+  @spec env_value(term()) :: String.t()
+  defp env_value(nil), do: ""
+  defp env_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp env_value(value), do: to_string(value)
+
+  @spec now_ms() :: integer()
+  defp now_ms, do: System.monotonic_time(:millisecond)
+
+  @spec command_failed(state(), term()) :: state()
+  defp command_failed(state, reason) do
+    unless state.failure_reported? do
+      Minga.Events.broadcast(:log_message, %Minga.Events.LogMessageEvent{
+        text: "Agent status command failed, using built-in modeline: #{inspect(reason)}",
+        level: :info
+      })
+    end
+
+    %{state | value: nil, failure_reported?: true}
+  end
+
+  @spec schedule_current_interval(state()) :: state()
+  defp schedule_current_interval(state), do: schedule(state, state.interval_ms)
+
+  @spec schedule(state(), non_neg_integer()) :: state()
+  defp schedule(%{timer: nil} = state, delay_ms) do
+    %{state | timer: Process.send_after(self(), @tick, delay_ms)}
+  end
+
+  defp schedule(state, _delay_ms), do: state
+
+  @spec cancel_timer(state()) :: state()
+  defp cancel_timer(%{timer: nil} = state), do: state
+
+  defp cancel_timer(%{timer: timer} = state) do
+    Process.cancel_timer(timer)
+    %{state | timer: nil}
+  end
+
+  @spec cancel_task(state()) :: state()
+  defp cancel_task(%{task: nil} = state), do: state
+
+  defp cancel_task(%{task: %Task{} = task} = state) do
+    Task.shutdown(task, :brutal_kill)
+    %{state | task: nil}
+  end
+
+  @spec normalize_context(map()) :: context()
+  defp normalize_context(context) do
+    %{
+      session_id: Map.get(context, :session_id),
+      model: Map.get(context, :model),
+      status: Map.get(context, :status),
+      workdir: Map.get(context, :workdir)
+    }
+  end
+
+  @spec server_alive?(GenServer.server()) :: boolean()
+  defp server_alive?(server) when is_pid(server), do: Process.alive?(server)
+  defp server_alive?(server) when is_atom(server), do: Process.whereis(server) != nil
+  defp server_alive?(_server), do: false
+end

--- a/lib/minga_editor/shell/traditional/modeline.ex
+++ b/lib/minga_editor/shell/traditional/modeline.ex
@@ -46,6 +46,7 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
           :macro_recording => {true, String.t()} | false,
           optional(:agent_status) => MingaEditor.State.Agent.status(),
           optional(:active_tool_name) => String.t() | nil,
+          optional(:agent_status_command) => String.t() | nil,
           optional(:agent_theme_colors) => MingaEditor.UI.Theme.Agent.t() | nil,
           optional(:mode_override) => String.t() | nil,
           optional(:lsp_status) => lsp_status(),
@@ -602,33 +603,41 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
 
   @spec build_agent_segments(modeline_data(), non_neg_integer()) :: [render_segment()]
   defp build_agent_segments(data, bar_bg) do
+    status_command = Map.get(data, :agent_status_command)
     status = Map.get(data, :agent_status)
     colors = Map.get(data, :agent_theme_colors)
     active_tool_name = Map.get(data, :active_tool_name)
 
-    case {status, colors} do
-      {nil, _colors} ->
+    case {status_command, status, colors} do
+      {custom, _status, c} when is_binary(custom) and custom != "" ->
+        [{" #{custom} ", agent_status_fg(c), bar_bg, [], nil}]
+
+      {_custom, nil, _colors} ->
         []
 
-      {:idle, c} ->
+      {_custom, :idle, c} ->
         [{" ◯ Idle ", c.status_idle, bar_bg, [], nil}]
 
-      {:plan, c} ->
+      {_custom, :plan, c} ->
         [{" PLAN ", c.status_thinking, bar_bg, [bold: true], nil}]
 
-      {:thinking, c} ->
+      {_custom, :thinking, c} ->
         [{" ⟳ Thinking ", c.status_thinking, bar_bg, [bold: true], nil}]
 
-      {:tool_executing, c} ->
+      {_custom, :tool_executing, c} ->
         [{agent_tool_label(active_tool_name), c.status_tool, bar_bg, [bold: true], nil}]
 
-      {:error, c} ->
+      {_custom, :error, c} ->
         [{" ✗ Error ", c.status_error, bar_bg, [bold: true], nil}]
 
       _other ->
         []
     end
   end
+
+  @spec agent_status_fg(Theme.Agent.t() | nil) :: non_neg_integer()
+  defp agent_status_fg(%{status_idle: color}), do: color
+  defp agent_status_fg(_colors), do: 0xFFFFFF
 
   @spec agent_tool_label(String.t() | nil) :: String.t()
   defp agent_tool_label(name) when is_binary(name) and name != "", do: " ⚡ Running #{name} "

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -25,6 +25,7 @@ defmodule MingaEditor.StatusBar.Data do
   alias Minga.Git.MergeConflict
   alias Minga.LSP.SyncServer
   alias MingaEditor.Shell.Traditional.Modeline
+  alias MingaAgent.StatusCommand
   alias MingaEditor.UI.Theme
   alias MingaEditor.Session.ChromeState
 
@@ -72,6 +73,7 @@ defmodule MingaEditor.StatusBar.Data do
           macro_recording: {true, String.t()} | false,
           agent_status: AgentState.status(),
           active_tool_name: String.t() | nil,
+          agent_status_command: String.t() | nil,
           agent_theme_colors: Theme.Agent.t() | nil,
           background_subagent_count: non_neg_integer(),
           active_background_subagent_label: String.t() | nil,
@@ -94,6 +96,7 @@ defmodule MingaEditor.StatusBar.Data do
           macro_recording: {true, String.t()} | false,
           agent_status: AgentState.status(),
           active_tool_name: String.t() | nil,
+          agent_status_command: String.t() | nil,
           agent_theme_colors: Theme.Agent.t() | nil,
           # Background buffer context (same fields as buffer_data)
           cursor_line: non_neg_integer(),
@@ -208,6 +211,7 @@ defmodule MingaEditor.StatusBar.Data do
       macro_recording: Minga.Editing.macro_recording_status(state),
       agent_status: agent.runtime.status,
       active_tool_name: agent.runtime.active_tool_name,
+      agent_status_command: agent_status_command_content(state, agent),
       agent_theme_colors: if(agent.runtime.status, do: Theme.agent_theme(state.theme), else: nil),
       background_subagent_count: background.count,
       active_background_subagent_label: background.label,
@@ -351,6 +355,7 @@ defmodule MingaEditor.StatusBar.Data do
       macro_recording: Minga.Editing.macro_recording_status(state),
       agent_status: agent.runtime.status,
       active_tool_name: agent.runtime.active_tool_name,
+      agent_status_command: agent_status_command_content(state, agent),
       agent_theme_colors: Theme.agent_theme(state.theme),
       # Background buffer context
       cursor_line: line,
@@ -379,6 +384,56 @@ defmodule MingaEditor.StatusBar.Data do
       merge_conflict_count: merge_conflict_count(buf)
     }
   end
+
+  @spec agent_status_command_content(EditorState.t() | map(), AgentState.t()) :: String.t() | nil
+  defp agent_status_command_content(state, agent) do
+    StatusCommand.content(agent_status_command_context(state, agent))
+  end
+
+  @spec agent_status_command_context(EditorState.t() | map(), AgentState.t()) ::
+          StatusCommand.context()
+  defp agent_status_command_context(state, agent) do
+    session = AgentAccess.session(state)
+    {session_id, session_model, workdir} = session_context(session)
+    panel = AgentAccess.panel(state)
+
+    %{
+      session_id: session_id,
+      model: model_name(panel.model_name, session_model),
+      status: agent.runtime.status,
+      workdir: workdir || File.cwd!()
+    }
+  end
+
+  @spec session_context(pid() | nil) :: {String.t() | nil, String.t() | nil, String.t() | nil}
+  defp session_context(session) when is_pid(session) do
+    case safe_session_metadata(session) do
+      %MingaAgent.SessionMetadata{} = metadata ->
+        {metadata.id, metadata.model_name, metadata.workdir}
+
+      _other ->
+        {nil, nil, nil}
+    end
+  end
+
+  defp session_context(_session), do: {nil, nil, nil}
+
+  @spec safe_session_metadata(pid()) :: term()
+  defp safe_session_metadata(session) do
+    GenServer.call(session, :metadata)
+  catch
+    :exit, _ -> nil
+  end
+
+  @spec model_name(String.t(), String.t() | nil) :: String.t()
+  defp model_name(panel_model, _session_model) when is_binary(panel_model) and panel_model != "",
+    do: panel_model
+
+  defp model_name(_panel_model, session_model)
+       when is_binary(session_model) and session_model != "",
+       do: session_model
+
+  defp model_name(_panel_model, _session_model), do: Minga.Config.get(:agent_model)
 
   @spec attach_modeline_segments(map(), Theme.t(), ModelineSegments.table()) ::
           buffer_data() | agent_data()
@@ -524,6 +579,7 @@ defmodule MingaEditor.StatusBar.Data do
       macro_recording: d.macro_recording,
       agent_status: d.agent_status,
       active_tool_name: Map.get(d, :active_tool_name),
+      agent_status_command: Map.get(d, :agent_status_command),
       agent_theme_colors: d.agent_theme_colors,
       lsp_status: d.lsp_status,
       parser_status: d.parser_status,

--- a/test/minga_agent/status_command_test.exs
+++ b/test/minga_agent/status_command_test.exs
@@ -1,0 +1,108 @@
+defmodule MingaAgent.StatusCommandTest do
+  # Uses System.cmd through the status command runner; OS process tests stay serialized.
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 5_000
+
+  alias Minga.Config.Options
+  alias Minga.Events
+  alias MingaAgent.StatusCommand
+
+  setup do
+    options = start_supervised!({Options, name: nil})
+
+    task_supervisor =
+      Module.concat(__MODULE__, "TaskSupervisor#{System.unique_integer([:positive])}")
+
+    start_supervised!({Task.Supervisor, name: task_supervisor})
+
+    pid =
+      start_supervised!(
+        {StatusCommand, name: nil, config_server: options, task_supervisor: task_supervisor}
+      )
+
+    %{options: options, command: pid}
+  end
+
+  test "runs configured command with agent env and caches stdout", ctx do
+    dir = File.cwd!()
+
+    Options.set(
+      ctx.options,
+      :agent_status_command,
+      ~s[printf '%s|%s|%s|%s' "$MINGA_SESSION_ID" "$MINGA_MODEL" "$MINGA_STATUS" "$MINGA_WORKDIR"]
+    )
+
+    context = %{session_id: "s1", model: "sonnet", status: :thinking, workdir: dir}
+
+    assert StatusCommand.content(context, ctx.command) == nil
+
+    assert wait_until(fn -> StatusCommand.content(context, ctx.command) end) ==
+             "s1|sonnet|thinking|#{dir}"
+  end
+
+  test "render reads do not rerun before the interval", ctx do
+    path =
+      Path.join(System.tmp_dir!(), "minga-status-command-#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm(path) end)
+
+    Options.set(
+      ctx.options,
+      :agent_status_command,
+      "n=$(cat #{path} 2>/dev/null || echo 0); n=$((n + 1)); echo $n > #{path}; printf $n"
+    )
+
+    context = %{session_id: "s1", model: "sonnet", status: :idle, workdir: File.cwd!()}
+
+    assert wait_until(fn -> StatusCommand.content(context, ctx.command) end) == "1"
+
+    for _ <- 1..5 do
+      assert StatusCommand.content(context, ctx.command) == "1"
+    end
+
+    assert File.read!(path) == "1\n"
+  end
+
+  test "config changes replace the cached value without restart", ctx do
+    Options.set(ctx.options, :agent_status_command, "printf first")
+    context = %{session_id: "s1", model: "sonnet", status: :idle, workdir: File.cwd!()}
+
+    assert wait_until(fn -> StatusCommand.content(context, ctx.command) end) == "first"
+
+    Options.set(ctx.options, :agent_status_command, "printf second")
+
+    assert wait_until(fn -> StatusCommand.content(context, ctx.command) end) == "second"
+  end
+
+  test "failures fall back to nil and log once per command", ctx do
+    Events.subscribe(:log_message)
+    Options.set(ctx.options, :agent_status_command, "exit 7")
+    context = %{session_id: "s1", model: "sonnet", status: :idle, workdir: File.cwd!()}
+
+    assert StatusCommand.content(context, ctx.command) == nil
+    assert_receive {:minga_event, :log_message, %{text: text}}, 500
+    assert String.contains?(text, "Agent status command failed")
+
+    assert StatusCommand.content(context, ctx.command) == nil
+    refute_receive {:minga_event, :log_message, %{text: ^text}}, 100
+  end
+
+  @spec wait_until((-> term()), non_neg_integer()) :: term()
+  defp wait_until(fun, attempts \\ 50)
+
+  defp wait_until(fun, attempts) when attempts > 0 do
+    case fun.() do
+      nil ->
+        receive do
+        after
+          10 -> wait_until(fun, attempts - 1)
+        end
+
+      value ->
+        value
+    end
+  end
+
+  defp wait_until(fun, 0), do: flunk("condition was not met, last result: #{inspect(fun.())}")
+end

--- a/test/minga_editor/shell/traditional/modeline_test.exs
+++ b/test/minga_editor/shell/traditional/modeline_test.exs
@@ -126,6 +126,23 @@ defmodule MingaEditor.Shell.Traditional.ModelineTest do
       assert :filetype_menu in segment_targets(@base_data)
     end
 
+    test "agent status command replaces built-in agent label" do
+      theme = MingaEditor.UI.Theme.get!(:doom_one)
+      agent_colors = MingaEditor.UI.Theme.agent_theme(theme)
+
+      data =
+        Map.merge(@base_data, %{
+          agent_status: :thinking,
+          agent_status_command: "sonnet | thinking",
+          agent_theme_colors: agent_colors
+        })
+
+      text = segments_text(data, theme)
+
+      assert String.contains?(text, "sonnet | thinking")
+      refute String.contains?(text, "Thinking")
+    end
+
     test "agent status indicators show text labels" do
       theme = MingaEditor.UI.Theme.get!(:doom_one)
       agent_colors = MingaEditor.UI.Theme.agent_theme(theme)

--- a/test/minga_editor/status_bar/data_test.exs
+++ b/test/minga_editor/status_bar/data_test.exs
@@ -29,6 +29,19 @@ defmodule MingaEditor.StatusBar.DataTest do
     refute Map.has_key?(buffer_data, :modeline_segments)
   end
 
+  test "with_modeline_segments preserves agent status command output" do
+    state = state_with_tab_bar(TabBar.new(Tab.new_file(1, "main.ex")))
+    state = AgentAccess.update_agent(state, &AgentState.set_status(&1, :thinking))
+    {:buffer, data} = Data.from_state(state)
+    data = Map.put(data, :agent_status_command, "sonnet | thinking")
+
+    assert {:buffer, buffer_data} = Data.with_modeline_segments({:buffer, data}, state.theme)
+    text = modeline_text(buffer_data.modeline_segments)
+
+    assert String.contains?(text, "sonnet | thinking")
+    refute String.contains?(text, "Thinking")
+  end
+
   test "with_modeline_segments attaches GUI modeline segments from supplied registry" do
     table = :"status_bar_data_modeline_segments_#{System.unique_integer([:positive])}"
     start_supervised!({ModelineSegments, name: table})
@@ -259,6 +272,10 @@ defmodule MingaEditor.StatusBar.DataTest do
 
     :ets.insert(table, {buffer, git_pid})
     on_exit(fn -> :ets.delete(table, buffer) end)
+  end
+
+  defp modeline_text(%{left: left, right: right}) do
+    Enum.map_join(left ++ right, fn {_name, text, _fg, _bg, _opts, _target} -> text end)
   end
 
   defp handle(session_id, task) do


### PR DESCRIPTION
## Summary

- Add `:agent_status_command` and `:agent_status_interval_ms` config options.
- Run the configured command through a supervised cached agent service, with stdout replacing the built-in agent modeline segment.
- Pass `MINGA_SESSION_ID`, `MINGA_MODEL`, `MINGA_STATUS`, and `MINGA_WORKDIR` to the command.
- Fall back to built-in modeline content on failure, timeout, or empty output, with one `*Messages*` log per failure streak.
- Document the config example and env vars.

Closes #1413

## Validation

- `mix test.debug test/minga_agent/status_command_test.exs test/minga_editor/status_bar/data_test.exs test/minga_editor/shell/traditional/modeline_test.exs test/minga/config/options_test.exs`
- `mix native.build.support`
- `mix test.llm` passed: 56 doctests, 87 properties, 9171 tests, 0 failures, 334 excluded
- `mix compile --warnings-as-errors`
- `make lint` passed with existing struct-size warnings only
- `git diff --check`

## Review notes

- `prtk-code-reviewer` found interval, projection, and test-timeout issues. Fixed all three, and targeted re-review passed.
- Final reviewer subagent timed out and its run status was unavailable, so I completed a manual acceptance self-check against all five ticket criteria before commit.
