### PR TITLE
feat(agent): react to new LSP errors on save

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -186,6 +186,16 @@ Extension segments are removed automatically when the owning extension stops or 
 
 Each segment has a priority. When the window is too narrow, Minga drops the lowest-priority visible segment first, then recalculates the line. Built-in priorities keep mode, filename, position, filetype, and diagnostics longer than parser, percent, and background-agent details. Custom segments default to priority `50`; pass `priority:` to make them more or less important.
 
+## Agent reactive diagnostics
+
+Minga can post a quiet agent-chat suggestion when saving a file introduces a new LSP error. This is off by default so the editor never talks over you unless you ask it to.
+
+```elixir
+set :agent_react_to_lsp_errors_on_save, true
+```
+
+When enabled, the agent chat gets the file, position, and diagnostic message. The suggestion stays in chat, so you can ask the agent to apply a fix, open chat to discuss it, or ignore the message to dismiss it.
+
 ## Agent tool approval
 
 When the AI agent wants to run a destructive tool (writing a file, editing a file, or running a shell command), Minga pauses and shows a confirmation prompt:

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -99,6 +99,7 @@ defmodule Minga.Config.Options do
           | :agent_mention_max_file_size
           | :agent_notify_debounce
           | :agent_diagnostic_feedback
+          | :agent_react_to_lsp_errors_on_save
           | :agent_flush_before_shell
           | :confirm_quit
           | :line_spacing
@@ -336,6 +337,8 @@ defmodule Minga.Config.Options do
      "Milliseconds used to debounce repeated agent notifications."},
     {:agent_diagnostic_feedback, :boolean, true,
      "Whether diagnostics are fed back into agent context."},
+    {:agent_react_to_lsp_errors_on_save, :boolean, false,
+     "Whether the agent posts a chat suggestion when saving introduces a new LSP error."},
     {:agent_flush_before_shell, :boolean, true,
      "Whether pending agent output flushes before shell tools run."},
     {:confirm_quit, :boolean, true,

--- a/lib/minga/services/supervisor.ex
+++ b/lib/minga/services/supervisor.ex
@@ -40,6 +40,7 @@ defmodule Minga.Services.Supervisor do
       ├── Minga.LSP.SyncServer               Subscribes to buffer events, manages LSP sync
       ├── Minga.Project                      Project root detection, file cache
       └── MingaAgent.SessionManager          Session ID → PID registry, lifecycle events
+      └── MingaAgent.ReactiveDiagnostics     Opt-in saved-file LSP error suggestions
 
   MingaAgent.Supervisor was promoted to a top-level peer of Minga.Supervisor
   (between Services and Runtime) to support headless operation.
@@ -84,9 +85,10 @@ defmodule Minga.Services.Supervisor do
       Minga.LSP.Supervisor,
       Minga.LSP.SyncServer,
 
-      # Project and session registry (end of chain, minimal cascade)
+      # Project, session registry, and session-backed reactive surfaces (end of chain, minimal cascade)
       Minga.Project,
-      MingaAgent.SessionManager
+      MingaAgent.SessionManager,
+      MingaAgent.ReactiveDiagnostics
     ]
 
     Supervisor.init(children, strategy: :rest_for_one)

--- a/lib/minga_agent/reactive_diagnostics.ex
+++ b/lib/minga_agent/reactive_diagnostics.ex
@@ -1,0 +1,229 @@
+defmodule MingaAgent.ReactiveDiagnostics do
+  @moduledoc """
+  Posts an agent chat suggestion when a save introduces a new LSP error.
+
+  This is intentionally one concrete reactive surface, not a generic rule engine.
+  """
+
+  use GenServer
+
+  alias Minga.Config.Options
+  alias Minga.Diagnostics
+  alias Minga.Diagnostics.Diagnostic
+  alias Minga.Events
+  alias Minga.LSP.SyncServer
+  alias MingaAgent.Session
+  alias MingaAgent.SessionManager
+
+  @save_window_ms 5_000
+  @rate_limit_ms 10_000
+
+  @type fingerprint ::
+          {non_neg_integer(), non_neg_integer(), String.t(), String.t() | nil, term()}
+
+  @type pending_save :: %{
+          path: String.t(),
+          baseline: MapSet.t(fingerprint()),
+          saved_at_ms: integer()
+        }
+
+  @type notification :: %{fingerprint: fingerprint(), at_ms: integer()}
+
+  @type state :: %{
+          events_registry: Events.registry(),
+          diagnostics_server: GenServer.server(),
+          config_server: Options.server(),
+          session_manager: GenServer.server(),
+          post_fun: (String.t(), GenServer.server() -> :ok),
+          pending: %{String.t() => pending_save()},
+          last_notified: %{String.t() => notification()}
+        }
+
+  @doc false
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: Keyword.get(opts, :id, __MODULE__),
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :permanent,
+      shutdown: 5_000,
+      type: :worker
+    }
+  end
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, state()}
+  def init(opts) do
+    events_registry = Keyword.get(opts, :events_registry, Events.default_registry())
+    Events.subscribe(:buffer_saved, registry: events_registry)
+    Events.subscribe(:diagnostics_updated, registry: events_registry)
+
+    {:ok,
+     %{
+       events_registry: events_registry,
+       diagnostics_server: Keyword.get(opts, :diagnostics_server, Diagnostics),
+       config_server: Keyword.get(opts, :config_server, Options.default_server()),
+       session_manager: Keyword.get(opts, :session_manager, SessionManager),
+       post_fun: Keyword.get(opts, :post_fun, &post_to_latest_session/2),
+       pending: %{},
+       last_notified: %{}
+     }}
+  end
+
+  @impl true
+  def handle_info(
+        {:minga_event, :buffer_saved, %Events.BufferEvent{path: path}},
+        state
+      ) do
+    state = prune_pending(state)
+
+    if enabled?(state) do
+      uri = SyncServer.path_to_uri(path)
+      baseline = current_error_fingerprints(state, uri)
+
+      pending =
+        Map.put(state.pending, uri, %{path: path, baseline: baseline, saved_at_ms: now_ms()})
+
+      {:noreply, %{state | pending: pending}}
+    else
+      {:noreply, %{state | pending: %{}}}
+    end
+  end
+
+  def handle_info(
+        {:minga_event, :diagnostics_updated, %Events.DiagnosticsUpdatedEvent{uri: uri}},
+        state
+      ) do
+    state = prune_pending(state)
+
+    if enabled?(state) do
+      {:noreply, maybe_notify_new_error(state, uri)}
+    else
+      {:noreply, %{state | pending: %{}}}
+    end
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @spec maybe_notify_new_error(state(), String.t()) :: state()
+  defp maybe_notify_new_error(%{pending: pending} = state, uri) do
+    case Map.fetch(pending, uri) do
+      {:ok, pending_save} ->
+        notify_new_error(state, uri, pending_save)
+
+      :error ->
+        state
+    end
+  end
+
+  @spec notify_new_error(state(), String.t(), pending_save()) :: state()
+  defp notify_new_error(state, uri, pending_save) do
+    current = current_error_fingerprints(state, uri)
+
+    case Enum.find(current, &(not MapSet.member?(pending_save.baseline, &1))) do
+      nil ->
+        state
+
+      fingerprint ->
+        maybe_post_suggestion(state, uri, pending_save.path, fingerprint)
+    end
+  end
+
+  @spec maybe_post_suggestion(state(), String.t(), String.t(), fingerprint()) :: state()
+  defp maybe_post_suggestion(state, uri, path, fingerprint) do
+    now = now_ms()
+
+    case Map.get(state.last_notified, uri) do
+      %{fingerprint: ^fingerprint} ->
+        state
+
+      %{at_ms: at_ms} when now - at_ms < @rate_limit_ms ->
+        state
+
+      _notification ->
+        post_suggestion(state, path, fingerprint)
+        last_notified = Map.put(state.last_notified, uri, %{fingerprint: fingerprint, at_ms: now})
+        %{state | last_notified: last_notified}
+    end
+  end
+
+  @spec post_suggestion(state(), String.t(), fingerprint()) :: :ok
+  defp post_suggestion(state, path, fingerprint) do
+    state.post_fun.(suggestion_text(path, fingerprint), state.session_manager)
+  end
+
+  @spec suggestion_text(String.t(), fingerprint()) :: String.t()
+  defp suggestion_text(path, {line, col, message, _source, _code}) do
+    rel = Path.relative_to_cwd(path)
+
+    "New LSP error after save in #{rel}:#{line + 1}:#{col + 1}: #{message}\n\nAsk me to apply a fix, open chat to discuss it, or ignore this suggestion to dismiss it."
+  end
+
+  @spec current_error_fingerprints(state(), String.t()) :: MapSet.t(fingerprint())
+  defp current_error_fingerprints(state, uri) do
+    state.diagnostics_server
+    |> Diagnostics.for_uri(uri)
+    |> Enum.filter(&(&1.severity == :error))
+    |> Enum.map(&fingerprint/1)
+    |> MapSet.new()
+  end
+
+  @spec fingerprint(Diagnostic.t()) :: fingerprint()
+  defp fingerprint(%Diagnostic{} = diagnostic) do
+    {
+      diagnostic.range.start_line,
+      diagnostic.range.start_col,
+      diagnostic.message,
+      diagnostic.source,
+      diagnostic.code
+    }
+  end
+
+  @spec enabled?(state()) :: boolean()
+  defp enabled?(state), do: Options.get(state.config_server, :agent_react_to_lsp_errors_on_save)
+
+  @spec prune_pending(state()) :: state()
+  defp prune_pending(state) do
+    now = now_ms()
+
+    pending =
+      Map.reject(state.pending, fn {_uri, %{saved_at_ms: saved_at_ms}} ->
+        now - saved_at_ms > @save_window_ms
+      end)
+
+    %{state | pending: pending}
+  end
+
+  @spec post_to_latest_session(String.t(), GenServer.server()) :: :ok
+  defp post_to_latest_session(text, session_manager) do
+    case SessionManager.list_sessions(session_manager) do
+      [] ->
+        :ok
+
+      sessions ->
+        sessions
+        |> Enum.max_by(fn {_id, _pid, metadata} ->
+          DateTime.to_unix(metadata.last_message_at, :microsecond)
+        end)
+        |> post_to_session(text)
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
+  @spec post_to_session({String.t(), pid(), MingaAgent.SessionMetadata.t()} | nil, String.t()) ::
+          :ok
+  defp post_to_session(nil, _text), do: :ok
+
+  defp post_to_session({_id, pid, _metadata}, text),
+    do: Session.add_system_message(pid, text, :info)
+
+  @spec now_ms() :: integer()
+  defp now_ms, do: System.monotonic_time(:millisecond)
+end

--- a/test/minga_agent/reactive_diagnostics_test.exs
+++ b/test/minga_agent/reactive_diagnostics_test.exs
@@ -1,0 +1,137 @@
+defmodule MingaAgent.ReactiveDiagnosticsTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Config.Options
+  alias Minga.Diagnostics
+  alias Minga.Diagnostics.Diagnostic
+  alias Minga.Events
+  alias Minga.LSP.SyncServer
+  alias MingaAgent.ReactiveDiagnostics
+
+  setup do
+    registry = :"reactive_diag_events_#{System.unique_integer([:positive])}"
+    diagnostics = :"reactive_diag_store_#{System.unique_integer([:positive])}"
+    options = :"reactive_diag_options_#{System.unique_integer([:positive])}"
+
+    start_supervised!({Registry, keys: :duplicate, name: registry})
+    start_supervised!({Diagnostics, name: diagnostics})
+    start_supervised!({Options, name: options})
+
+    parent = self()
+
+    watcher =
+      start_supervised!(
+        {ReactiveDiagnostics,
+         [
+           name: nil,
+           events_registry: registry,
+           diagnostics_server: diagnostics,
+           config_server: options,
+           session_manager: self(),
+           post_fun: fn text, _manager ->
+             send(parent, {:suggestion, text})
+             :ok
+           end
+         ]}
+      )
+
+    %{registry: registry, diagnostics: diagnostics, options: options, watcher: watcher}
+  end
+
+  test "posts a chat suggestion for a new error after save", ctx do
+    enable(ctx.options)
+    path = "/tmp/reactive_new.ex"
+    uri = SyncServer.path_to_uri(path)
+
+    save(ctx.registry, path)
+    publish(ctx.diagnostics, ctx.registry, uri, [diag("boom", 2, 4)])
+
+    assert_receive {:suggestion, text}, 200
+    assert String.contains?(text, "reactive_new.ex:3:5")
+    assert String.contains?(text, "boom")
+    assert String.contains?(text, "apply a fix")
+    assert String.contains?(text, "open chat")
+    assert String.contains?(text, "dismiss")
+  end
+
+  test "does not post when the error already existed before save", ctx do
+    enable(ctx.options)
+    path = "/tmp/reactive_existing.ex"
+    uri = SyncServer.path_to_uri(path)
+    existing = diag("already broken", 0, 0)
+
+    publish(ctx.diagnostics, ctx.registry, uri, [existing])
+    save(ctx.registry, path)
+    publish(ctx.diagnostics, ctx.registry, uri, [existing])
+
+    refute_receive {:suggestion, _text}, 100
+  end
+
+  test "dedupes the same diagnostic on rapid saves", ctx do
+    enable(ctx.options)
+    path = "/tmp/reactive_dedupe.ex"
+    uri = SyncServer.path_to_uri(path)
+    diagnostic = diag("same", 1, 0)
+
+    save(ctx.registry, path)
+    publish(ctx.diagnostics, ctx.registry, uri, [diagnostic])
+    assert_receive {:suggestion, _text}, 200
+
+    Diagnostics.clear(ctx.diagnostics, :elixir_ls, uri)
+    save(ctx.registry, path)
+    publish(ctx.diagnostics, ctx.registry, uri, [diagnostic])
+
+    refute_receive {:suggestion, _text}, 100
+  end
+
+  test "rate-limits different diagnostics from rapid saves", ctx do
+    enable(ctx.options)
+    path = "/tmp/reactive_rate_limit.ex"
+    uri = SyncServer.path_to_uri(path)
+
+    save(ctx.registry, path)
+    publish(ctx.diagnostics, ctx.registry, uri, [diag("first", 1, 0)])
+    assert_receive {:suggestion, _text}, 200
+
+    Diagnostics.clear(ctx.diagnostics, :elixir_ls, uri)
+    save(ctx.registry, path)
+    publish(ctx.diagnostics, ctx.registry, uri, [diag("second", 2, 0)])
+
+    refute_receive {:suggestion, _text}, 100
+  end
+
+  test "does nothing until explicitly enabled", ctx do
+    path = "/tmp/reactive_disabled.ex"
+    uri = SyncServer.path_to_uri(path)
+
+    save(ctx.registry, path)
+    publish(ctx.diagnostics, ctx.registry, uri, [diag("disabled", 0, 0)])
+
+    refute_receive {:suggestion, _text}, 100
+  end
+
+  defp enable(options), do: Options.set(options, :agent_react_to_lsp_errors_on_save, true)
+
+  defp save(registry, path) do
+    Events.broadcast(:buffer_saved, %Events.BufferEvent{buffer: self(), path: path}, registry)
+  end
+
+  defp publish(diagnostics, registry, uri, entries) do
+    Diagnostics.publish(diagnostics, :elixir_ls, uri, entries)
+
+    Events.broadcast(
+      :diagnostics_updated,
+      %Events.DiagnosticsUpdatedEvent{uri: uri, source: :elixir_ls},
+      registry
+    )
+  end
+
+  defp diag(message, line, col) do
+    %Diagnostic{
+      severity: :error,
+      message: message,
+      source: "elixir_ls",
+      range: %{start_line: line, start_col: col, end_line: line, end_col: col + 1}
+    }
+  end
+end


### PR DESCRIPTION
## Summary

- Add opt-in `:agent_react_to_lsp_errors_on_save` config for reactive diagnostics.
- Add `MingaAgent.ReactiveDiagnostics` to snapshot saved-file diagnostics, detect new LSP errors, and post a quiet agent-chat suggestion with file, position, and message.
- De-dupe repeated diagnostics and rate-limit rapid saves.

Closes #1415.

## Validation

- `mix test.debug test/minga_agent/reactive_diagnostics_test.exs test/minga/config/options_test.exs`
- `mix compile --warnings-as-errors`
- `make lint` (existing struct-size warnings only)
- `git diff --check`
- `mix native.build.support`
- `mix test.llm` (9170 tests, 0 failures)

Note: final reviewer subagent was attempted twice and timed out/not found, so I completed a manual acceptance self-check against #1415 before commit.
