### PR TITLE
feat(autobiography): code provenance via agent event log

### DIFF
--- a/lib/minga/command/registry.ex
+++ b/lib/minga/command/registry.ex
@@ -38,6 +38,7 @@ defmodule Minga.Command.Registry do
     MingaEditor.Commands.Folding,
     MingaEditor.Commands.Diagnostics,
     MingaEditor.Commands.EditTimeline,
+    MingaEditor.Commands.Autobiography,
     MingaEditor.Commands.Lsp,
     MingaEditor.Commands.Project,
     MingaEditor.Commands.Agent,

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -185,7 +185,11 @@ defmodule Minga.Keymap.Defaults do
     {~k(t l), :cycle_line_numbers, "Toggle line numbers"},
     {~k(t p), :toggle_bottom_panel, "Toggle bottom panel"},
     {~k(t i), :toggle_invisible, "Toggle invisible chars"},
-    {~k(t w), :toggle_wrap, "Toggle word wrap"}
+    {~k(t w), :toggle_wrap, "Toggle word wrap"},
+
+    # ── Code provenance ─────────────────────────────────────────────────────────
+    {~k(g w), :code_why, "Why is this line like this?"},
+    {~k(g a), :code_autobiography, "Code autobiography"}
   ]
 
   # Group prefix descriptions shown in which-key at the SPC level.

--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -94,6 +94,7 @@ defmodule Minga.Keymap.Scope.Agent do
     |> Bindings.bind(~k(g a), :agent_apply_code_block, "Apply code block to file")
     |> Bindings.bind(~k(g p), :agent_pin_message, "Pin/unpin message")
     |> Bindings.bind(~k(g d), :goto_definition, "Go to definition")
+    |> Bindings.bind(~k(g b), :agent_provenance_return, "Back to source line")
     # z-prefix: domain fold/collapse commands
     |> Bindings.bind(~k(z a), :agent_toggle_collapse, "Toggle collapse at cursor")
     |> Bindings.bind(~k(z A), :agent_toggle_all_collapse, "Toggle all collapses")
@@ -213,7 +214,8 @@ defmodule Minga.Keymap.Scope.Agent do
        [
          {"]m / [m", "Next / prev message"},
          {"]c / [c", "Next / prev code block"},
-         {"]t / [t", "Next / prev tool call"}
+         {"]t / [t", "Next / prev tool call"},
+         {"gb", "Back to source line (after SPC g w)"}
        ]},
       {"Copy",
        [

--- a/lib/minga_agent/autobiography.ex
+++ b/lib/minga_agent/autobiography.ex
@@ -18,6 +18,15 @@ defmodule MingaAgent.Autobiography do
     list of edit-turns.
 
   Both return `Entry` structs. Lines/files the agent never wrote return `nil` / `[]`.
+
+  ## Known limitations (v1)
+
+  Provenance is keyed on the file path recorded at edit time, matched exactly.
+  If a file is renamed or moved after the agent edited it, lookups miss and the
+  file reads as "no history" even though the edits exist under the old path.
+  Bridging renames would require consulting `git` (blame/log `--follow`); that
+  is deliberately out of scope for v1. Coverage is also bounded by the event
+  log's retention window.
   """
 
   alias MingaAgent.EventLog
@@ -112,16 +121,13 @@ defmodule MingaAgent.Autobiography do
   defp candidates(db, path, opts) do
     limit = Keyword.get(opts, :limit, @candidate_limit)
 
+    # ponytail: exact path match only. A basename/suffix fallback would match a
+    # same-named file in another directory and surface the WRONG file's history,
+    # which is worse than none. If abs/rel path forms ever diverge in practice,
+    # normalize both against the project root here, not by guessing on basename.
     case Store.file_edits_for_path(db, path, limit) do
-      {:ok, [_ | _] = edits} ->
-        edits
-
-      _ ->
-        # Fall back to basename suffix when absolute/relative path forms disagree.
-        case Store.file_edits_for_path_suffix(db, "/" <> Path.basename(path), limit) do
-          {:ok, edits} -> edits
-          {:error, _} -> []
-        end
+      {:ok, edits} -> edits
+      {:error, _} -> []
     end
   end
 

--- a/lib/minga_agent/autobiography.ex
+++ b/lib/minga_agent/autobiography.ex
@@ -1,0 +1,238 @@
+defmodule MingaAgent.Autobiography do
+  @moduledoc """
+  Code provenance over the durable agent event log: "git blame for the agent's mind".
+
+  Every agent file edit is already persisted as a `:file_edit_proposed` event
+  carrying the file path, the full before/after content, and the originating
+  `tool_call_id`/session. The agent's reasoning for that edit (the user request
+  that prompted it, plus the thinking and assistant text of that turn) is
+  persisted in the same per-session, append-only log.
+
+  So provenance is a read-only projection, not new captured state. We never
+  reconstruct or summarise "why" after the fact: we point at the reasoning that
+  was recorded live when the edit happened.
+
+  * `for_line/3` answers "why is this line like this?" by content-matching the
+    line against the `after_content` of past edits (most recent wins).
+  * `for_file/2` answers "what did the agent do to this file?" as a chronological
+    list of edit-turns.
+
+  Both return `Entry` structs. Lines/files the agent never wrote return `nil` / `[]`.
+  """
+
+  alias MingaAgent.EventLog
+  alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.EventLog.Store
+
+  # How many past edits of a file to consider. Newest first; retention-bounded anyway.
+  @candidate_limit 200
+  # How many events before an edit to scan for its turn's request/thinking.
+  # ponytail: fixed window covers a normal turn; a turn longer than this just
+  # loses its leading user_message, upgrade to per-turn indexing if it bites.
+  @context_window 5000
+
+  defmodule Entry do
+    @moduledoc "One agent edit-turn that produced or changed code, with its recorded reasoning."
+
+    @enforce_keys [:path, :session_id, :occurred_at]
+    defstruct [
+      :path,
+      :session_id,
+      :tool_call_id,
+      :tool_name,
+      :occurred_at,
+      :user_request,
+      :thinking,
+      :assistant_text
+    ]
+
+    @type t :: %__MODULE__{
+            path: String.t(),
+            session_id: String.t(),
+            tool_call_id: String.t() | nil,
+            tool_name: String.t() | nil,
+            occurred_at: DateTime.t(),
+            user_request: String.t() | nil,
+            thinking: String.t() | nil,
+            assistant_text: String.t() | nil
+          }
+  end
+
+  @typedoc "Read options. `:db` injects an open connection (caller owns it); otherwise one is opened."
+  @type opt :: {:db, Store.db()} | {:db_dir, String.t()} | {:limit, pos_integer()}
+
+  @doc """
+  Returns the most recent agent edit-turn whose `after_content` contains `needle`, or `nil`.
+
+  Prefers the edit that *introduced* the text (present after, absent before);
+  falls back to the most recent edit that merely contains it.
+  """
+  @spec for_line(String.t(), String.t(), [opt()]) :: {:ok, Entry.t() | nil} | {:error, term()}
+  def for_line(path, needle, opts \\ []) when is_binary(path) and is_binary(needle) do
+    trimmed = String.trim(needle)
+
+    with_db(opts, fn db ->
+      case candidates(db, path, opts) do
+        [] ->
+          {:ok, nil}
+
+        candidates when trimmed == "" ->
+          # Blank line carries no signal: attribute it to the most recent turn.
+          {:ok, candidates |> hd() |> build_entry(db)}
+
+        candidates ->
+          match =
+            Enum.find(candidates, &introduced?(&1, trimmed)) ||
+              Enum.find(candidates, &contains_after?(&1, trimmed))
+
+          {:ok, match && build_entry(match, db)}
+      end
+    end)
+  end
+
+  @doc """
+  Returns the file's agent edit-turns, most recent first, one per `{session, tool_call}`.
+  """
+  @spec for_file(String.t(), [opt()]) :: {:ok, [Entry.t()]} | {:error, term()}
+  def for_file(path, opts \\ []) when is_binary(path) do
+    with_db(opts, fn db ->
+      entries =
+        db
+        |> candidates(path, opts)
+        |> Enum.uniq_by(&{&1.session_id, payload(&1, "tool_call_id")})
+        |> Enum.map(&build_entry(&1, db))
+
+      {:ok, entries}
+    end)
+  end
+
+  # ── Internals ──────────────────────────────────────────────────────────────
+
+  @spec candidates(Store.db(), String.t(), [opt()]) :: [EventRecord.t()]
+  defp candidates(db, path, opts) do
+    limit = Keyword.get(opts, :limit, @candidate_limit)
+
+    case Store.file_edits_for_path(db, path, limit) do
+      {:ok, [_ | _] = edits} ->
+        edits
+
+      _ ->
+        # Fall back to basename suffix when absolute/relative path forms disagree.
+        case Store.file_edits_for_path_suffix(db, "/" <> Path.basename(path), limit) do
+          {:ok, edits} -> edits
+          {:error, _} -> []
+        end
+    end
+  end
+
+  @spec introduced?(EventRecord.t(), String.t()) :: boolean()
+  defp introduced?(edit, needle) do
+    contains_after?(edit, needle) and
+      not String.contains?(payload(edit, "before_content") || "", needle)
+  end
+
+  @spec contains_after?(EventRecord.t(), String.t()) :: boolean()
+  defp contains_after?(edit, needle),
+    do: String.contains?(payload(edit, "after_content") || "", needle)
+
+  @spec build_entry(EventRecord.t(), Store.db()) :: Entry.t()
+  defp build_entry(%EventRecord{} = edit, db) do
+    context = turn_context(db, edit.session_id, edit.id)
+
+    %Entry{
+      path: payload(edit, "path"),
+      session_id: edit.session_id,
+      tool_call_id: payload(edit, "tool_call_id"),
+      tool_name: payload(edit, "tool_name"),
+      occurred_at: edit.wall_clock,
+      user_request: context.user_request,
+      thinking: context.thinking,
+      assistant_text: context.assistant_text
+    }
+  end
+
+  @spec turn_context(Store.db(), String.t(), non_neg_integer() | nil) :: %{
+          user_request: String.t() | nil,
+          thinking: String.t() | nil,
+          assistant_text: String.t() | nil
+        }
+  defp turn_context(_db, _session_id, nil),
+    do: %{user_request: nil, thinking: nil, assistant_text: nil}
+
+  defp turn_context(db, session_id, edit_id) do
+    cursor = max(edit_id - @context_window, 0)
+
+    events =
+      case Store.events_after(db, session_id, cursor, @context_window + 1) do
+        {:ok, evs} -> Enum.filter(evs, &(&1.id <= edit_id))
+        {:error, _} -> []
+      end
+
+    turn = turn_slice(events)
+
+    %{
+      user_request: last_user_request(events),
+      thinking: concat_deltas(turn, :thinking_delta),
+      assistant_text: concat_deltas(turn, :assistant_delta)
+    }
+  end
+
+  # Events from the most recent user_message up to the edit (the turn that made it).
+  @spec turn_slice([EventRecord.t()]) :: [EventRecord.t()]
+  defp turn_slice(events) do
+    case last_event(events, :user_message) do
+      nil -> events
+      user_msg -> Enum.filter(events, &(&1.id > user_msg.id))
+    end
+  end
+
+  @spec last_user_request([EventRecord.t()]) :: String.t() | nil
+  defp last_user_request(events) do
+    case last_event(events, :user_message) do
+      nil -> nil
+      ev -> blank_to_nil(payload(ev, "text"))
+    end
+  end
+
+  @spec last_event([EventRecord.t()], EventRecord.event_type()) :: EventRecord.t() | nil
+  defp last_event(events, type) do
+    events |> Enum.filter(&(&1.event_type == type)) |> List.last()
+  end
+
+  @spec concat_deltas([EventRecord.t()], EventRecord.event_type()) :: String.t() | nil
+  defp concat_deltas(events, type) do
+    events
+    |> Enum.filter(&(&1.event_type == type))
+    |> Enum.map_join("", &(payload(&1, "delta") || ""))
+    |> blank_to_nil()
+  end
+
+  @spec payload(EventRecord.t(), String.t()) :: term()
+  defp payload(%EventRecord{payload: payload}, key), do: Map.get(payload, key)
+
+  @spec blank_to_nil(String.t() | nil) :: String.t() | nil
+  defp blank_to_nil(nil), do: nil
+  defp blank_to_nil(text), do: if(String.trim(text) == "", do: nil, else: text)
+
+  @spec with_db([opt()], (Store.db() -> result)) :: result | {:error, term()}
+        when result: {:ok, term()}
+  defp with_db(opts, fun) do
+    case Keyword.fetch(opts, :db) do
+      {:ok, db} ->
+        fun.(db)
+
+      :error ->
+        case EventLog.open_read_connection(opts) do
+          {:ok, db} -> try_close(db, fun)
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  @spec try_close(Store.db(), (Store.db() -> result)) :: result when result: term()
+  defp try_close(db, fun) do
+    fun.(db)
+  after
+    Store.close(db)
+  end
+end

--- a/lib/minga_agent/event_log/store.ex
+++ b/lib/minga_agent/event_log/store.ex
@@ -100,6 +100,51 @@ defmodule MingaAgent.EventLog.Store do
     end
   end
 
+  @doc """
+  Returns `:file_edit_proposed` events whose payload `path` exactly matches, most recent first.
+
+  Used by code-provenance reads to find every agent edit that touched a file,
+  across all sessions. Bounded by `limit` (newest events win).
+  """
+  @spec file_edits_for_path(db(), String.t(), pos_integer()) ::
+          {:ok, [EventRecord.t()]} | {:error, term()}
+  def file_edits_for_path(db, path, limit \\ 200)
+      when is_binary(path) and is_integer(limit) and limit > 0 do
+    sql = """
+    SELECT id, session_id, event_type, payload, wall_clock, monotonic_ts
+    FROM events
+    WHERE event_type = 'file_edit_proposed' AND json_extract(payload, '$.path') = ?1
+    ORDER BY id DESC
+    LIMIT ?2
+    """
+
+    query_events(db, sql, [path, limit])
+  end
+
+  @doc """
+  Like `file_edits_for_path/3` but matches any stored path ending in `suffix`.
+
+  Fallback for when the editor's absolute path and the agent's stored path
+  disagree (e.g. project-relative storage). `%` and `_` in `suffix` are escaped.
+  """
+  @spec file_edits_for_path_suffix(db(), String.t(), pos_integer()) ::
+          {:ok, [EventRecord.t()]} | {:error, term()}
+  def file_edits_for_path_suffix(db, suffix, limit \\ 200)
+      when is_binary(suffix) and is_integer(limit) and limit > 0 do
+    escaped = suffix |> String.replace("\\", "\\\\") |> String.replace(["%", "_"], &("\\" <> &1))
+
+    sql = """
+    SELECT id, session_id, event_type, payload, wall_clock, monotonic_ts
+    FROM events
+    WHERE event_type = 'file_edit_proposed'
+      AND json_extract(payload, '$.path') LIKE ?1 ESCAPE '\\'
+    ORDER BY id DESC
+    LIMIT ?2
+    """
+
+    query_events(db, sql, ["%" <> escaped, limit])
+  end
+
   @doc "Returns the total number of agent events."
   @spec count(db()) :: {:ok, non_neg_integer()} | {:error, term()}
   def count(db) do

--- a/lib/minga_agent/event_log/store.ex
+++ b/lib/minga_agent/event_log/store.ex
@@ -121,30 +121,6 @@ defmodule MingaAgent.EventLog.Store do
     query_events(db, sql, [path, limit])
   end
 
-  @doc """
-  Like `file_edits_for_path/3` but matches any stored path ending in `suffix`.
-
-  Fallback for when the editor's absolute path and the agent's stored path
-  disagree (e.g. project-relative storage). `%` and `_` in `suffix` are escaped.
-  """
-  @spec file_edits_for_path_suffix(db(), String.t(), pos_integer()) ::
-          {:ok, [EventRecord.t()]} | {:error, term()}
-  def file_edits_for_path_suffix(db, suffix, limit \\ 200)
-      when is_binary(suffix) and is_integer(limit) and limit > 0 do
-    escaped = suffix |> String.replace("\\", "\\\\") |> String.replace(["%", "_"], &("\\" <> &1))
-
-    sql = """
-    SELECT id, session_id, event_type, payload, wall_clock, monotonic_ts
-    FROM events
-    WHERE event_type = 'file_edit_proposed'
-      AND json_extract(payload, '$.path') LIKE ?1 ESCAPE '\\'
-    ORDER BY id DESC
-    LIMIT ?2
-    """
-
-    query_events(db, sql, ["%" <> escaped, limit])
-  end
-
   @doc "Returns the total number of agent events."
   @spec count(db()) :: {:ok, non_neg_integer()} | {:error, term()}
   def count(db) do

--- a/lib/minga_editor/agent/buffer_sync.ex
+++ b/lib/minga_editor/agent/buffer_sync.ex
@@ -84,6 +84,20 @@ defmodule MingaEditor.Agent.BufferSync do
     agent_theme = Keyword.get(opts, :agent_theme, default_agent_theme())
     last_line = max(length(text_lines) - 1, 0)
 
+    # Where to leave the cursor after the content swap. The live-streaming path
+    # passes nothing and keeps pinning to the bottom (auto-scroll). Provenance
+    # jumps pass `{:message_id, id}` to land on a specific turn. `:keep` holds
+    # the current cursor (used after a jump has landed so re-syncs don't yank
+    # the reader back to the bottom).
+    cursor =
+      resolve_cursor_target(
+        Keyword.get(opts, :cursor_target, {:bottom}),
+        pid,
+        display_message_pairs,
+        line_offsets,
+        last_line
+      )
+
     try do
       Buffer.replace_content_with_decorations(
         pid,
@@ -97,7 +111,7 @@ defmodule MingaEditor.Agent.BufferSync do
             opts
           )
         end,
-        cursor: {last_line, 0}
+        cursor: cursor
       )
     rescue
       e ->
@@ -133,6 +147,95 @@ defmodule MingaEditor.Agent.BufferSync do
 
     text = parts |> Enum.reverse() |> Enum.join("\n\n")
     {text, Enum.reverse(offsets)}
+  end
+
+  @doc """
+  Resolves the message a provenance jump should land on for a given tool call.
+
+  A reviewer asking "why is this line like this?" wants to read the turn
+  top-down, so we land on the message that *opened* the turn the edit belongs
+  to: the nearest preceding `:user` message. If the turn was agent-initiated
+  (no user prompt before the edit), we land on the nearest preceding
+  `:thinking` block instead. Failing both, we land on the tool call itself.
+
+  Takes `[{message_id, message}]` (from `Session.messages_with_ids/1`) and the
+  `tool_call_id` of the edit. Returns the stable id to target, or `nil` when
+  the tool call is not in the list.
+  """
+  @spec turn_anchor_id([{pos_integer(), term()}], String.t()) :: pos_integer() | nil
+  def turn_anchor_id(messages_with_ids, tool_call_id) do
+    case Enum.find_index(messages_with_ids, &tool_call_match?(&1, tool_call_id)) do
+      nil ->
+        nil
+
+      tc_index ->
+        before = Enum.take(messages_with_ids, tc_index)
+
+        anchor_id(before, :user) || anchor_id(before, :thinking) ||
+          elem(Enum.at(messages_with_ids, tc_index), 0)
+    end
+  end
+
+  @spec tool_call_match?({pos_integer(), term()}, String.t()) :: boolean()
+  defp tool_call_match?({_id, {:tool_call, %{id: tcid}}}, tool_call_id), do: tcid == tool_call_id
+  defp tool_call_match?(_pair, _tool_call_id), do: false
+
+  # Most recent message of `kind` in the given prefix, or nil.
+  @spec anchor_id([{pos_integer(), term()}], :user | :thinking) :: pos_integer() | nil
+  defp anchor_id(pairs, kind) do
+    pairs
+    |> Enum.reverse()
+    |> Enum.find_value(fn {id, msg} -> if message_kind(msg) == kind, do: id end)
+  end
+
+  @spec message_kind(term()) :: atom()
+  defp message_kind({kind, _}), do: kind
+  defp message_kind({kind, _, _}), do: kind
+  defp message_kind(_), do: :unknown
+
+  @typedoc "Where to leave the buffer cursor after a sync."
+  @type cursor_target :: {:bottom} | :keep | {:message_id, pos_integer()}
+
+  @doc false
+  @spec resolve_cursor_target(
+          cursor_target(),
+          pid(),
+          [{pos_integer(), term()}],
+          [ChatDecorations.line_offset()],
+          non_neg_integer()
+        ) :: {non_neg_integer(), non_neg_integer()}
+  def resolve_cursor_target(
+        {:message_id, id},
+        _pid,
+        display_message_pairs,
+        line_offsets,
+        last_line
+      ) do
+    with display_idx when is_integer(display_idx) <-
+           Enum.find_index(display_message_pairs, fn {mid, _msg} -> mid == id end),
+         {_idx, start_line, _count} <- List.keyfind(line_offsets, display_idx, 0) do
+      {start_line, 0}
+    else
+      # Target not in the rendered window (paged out, or not displayed). The
+      # caller is responsible for un-hiding it before sync; fall back to bottom.
+      _ -> {last_line, 0}
+    end
+  end
+
+  def resolve_cursor_target(:keep, pid, _pairs, _offsets, last_line) do
+    case safe_cursor(pid) do
+      {line, col} -> {line, col}
+      _ -> {last_line, 0}
+    end
+  end
+
+  def resolve_cursor_target(_bottom, _pid, _pairs, _offsets, last_line), do: {last_line, 0}
+
+  @spec safe_cursor(pid()) :: {non_neg_integer(), non_neg_integer()} | nil
+  defp safe_cursor(pid) do
+    Buffer.cursor(pid)
+  catch
+    :exit, _ -> nil
   end
 
   # Buffer text is content only. Visual headers (▎ You, ▎ Agent, ┌─ ✓ bash)

--- a/lib/minga_editor/agent/provenance_jump.ex
+++ b/lib/minga_editor/agent/provenance_jump.ex
@@ -1,0 +1,49 @@
+defmodule MingaEditor.Agent.ProvenanceJump do
+  @moduledoc """
+  A pending "jump to the turn that wrote this line" navigation.
+
+  Created when the user presses Enter on a code-provenance popup
+  (`MingaAgent.Autobiography`). It holds everything the async session-load and
+  the subsequent buffer re-syncs need to land the chat cursor on the right turn
+  and to get the reader back to where they started:
+
+  * `target_message_id` — the stable chat message id to land on (the turn's
+    opening user message, resolved once at request time so layout shifts during
+    the multi-sync load can't move it; see `BufferSync.turn_anchor_id/2`).
+  * `landed?` — false until the first sync after load performs the jump. While
+    false, syncs land on the target; once true, syncs leave the cursor where it
+    is so re-syncs don't yank the reader back to the bottom.
+  * `origin` — `{path, line}` of the source file the user jumped from, for the
+    return trip. Stored as a path (not a buffer pid) so it survives the source
+    buffer being closed.
+
+  The whole struct is cleared when the user sends a new prompt (live streaming
+  should resume its bottom-pinned auto-scroll).
+  """
+
+  @enforce_keys [:target_message_id]
+  defstruct [:target_message_id, :origin, landed?: false]
+
+  @type origin :: {path :: String.t(), line :: non_neg_integer()}
+
+  @type t :: %__MODULE__{
+          target_message_id: pos_integer(),
+          landed?: boolean(),
+          origin: origin() | nil
+        }
+
+  @doc "Creates a pending jump to `target_message_id`, remembering the origin for the return trip."
+  @spec request(pos_integer(), origin() | nil) :: t()
+  def request(target_message_id, origin \\ nil) when is_integer(target_message_id) do
+    %__MODULE__{target_message_id: target_message_id, origin: origin}
+  end
+
+  @doc "Marks the jump as landed (the cursor has been placed on the target turn)."
+  @spec mark_landed(t()) :: t()
+  def mark_landed(%__MODULE__{} = jump), do: %{jump | landed?: true}
+
+  @doc "Returns the cursor target a sync should use for this jump's current phase."
+  @spec cursor_target(t()) :: {:message_id, pos_integer()} | :keep
+  def cursor_target(%__MODULE__{landed?: false, target_message_id: id}), do: {:message_id, id}
+  def cursor_target(%__MODULE__{landed?: true}), do: :keep
+end

--- a/lib/minga_editor/agent/ui_state/panel.ex
+++ b/lib/minga_editor/agent/ui_state/panel.ex
@@ -39,7 +39,8 @@ defmodule MingaEditor.Agent.UIState.Panel do
           cached_display_message_pairs: [{pos_integer(), term()}],
           cached_styled_messages: [MingaEditor.Agent.MarkdownHighlight.styled_lines()] | nil,
           message_version: non_neg_integer(),
-          credentials_configured: boolean()
+          credentials_configured: boolean(),
+          provenance_jump: MingaEditor.Agent.ProvenanceJump.t() | nil
         }
 
   defstruct visible: false,
@@ -62,7 +63,8 @@ defmodule MingaEditor.Agent.UIState.Panel do
             message_version: 0,
             # Assume configured until the session reports otherwise, so the
             # common (authed) case never flashes a "not configured" indicator.
-            credentials_configured: true
+            credentials_configured: true,
+            provenance_jump: nil
 
   @doc "Creates a new panel state with defaults."
   @spec new() :: t()
@@ -127,4 +129,14 @@ defmodule MingaEditor.Agent.UIState.Panel do
   def bump_message_version(%__MODULE__{message_version: v} = panel) do
     %{panel | message_version: v + 1}
   end
+
+  @doc "Arms a pending provenance jump (Enter from a code-provenance popup)."
+  @spec set_provenance_jump(t(), MingaEditor.Agent.ProvenanceJump.t() | nil) :: t()
+  def set_provenance_jump(%__MODULE__{} = panel, jump) do
+    %{panel | provenance_jump: jump}
+  end
+
+  @doc "Clears any pending provenance jump (e.g. when the user sends a new prompt)."
+  @spec clear_provenance_jump(t()) :: t()
+  def clear_provenance_jump(%__MODULE__{} = panel), do: %{panel | provenance_jump: nil}
 end

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -12,6 +12,7 @@ defmodule MingaEditor.AgentLifecycle do
 
   alias MingaEditor.Agent.BufferSync, as: AgentBufferSync
   alias MingaEditor.Agent.MarkdownHighlight
+  alias MingaEditor.Agent.ProvenanceJump
   alias MingaAgent.Session, as: AgentSession
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.View.Preview
@@ -122,16 +123,24 @@ defmodule MingaEditor.AgentLifecycle do
   defp sync_buffer_content(state, buffer, messages) do
     agent = AgentAccess.agent(state)
     panel = AgentAccess.panel(state)
+    jump = panel.provenance_jump
 
     sync_opts =
       if agent.pending_approval, do: [pending_approval: agent.pending_approval], else: []
 
+    sync_opts = add_session_display_opts(sync_opts, AgentAccess.session(state))
+
+    # A pending provenance jump may need an older, paged-out turn revealed so it
+    # can be landed on. Otherwise keep the panel's current display window.
+    display_start = jump_display_start(jump, panel.display_start_index, sync_opts[:message_ids])
+
     sync_opts =
-      if panel.display_start_index > 0,
-        do: Keyword.put(sync_opts, :display_start_index, panel.display_start_index),
+      if display_start > 0,
+        do: Keyword.put(sync_opts, :display_start_index, display_start),
         else: sync_opts
 
-    sync_opts = add_session_display_opts(sync_opts, AgentAccess.session(state))
+    cursor_target = if jump, do: ProvenanceJump.cursor_target(jump), else: {:bottom}
+    sync_opts = Keyword.put(sync_opts, :cursor_target, cursor_target)
 
     {line_index, display_messages, display_message_pairs} =
       AgentBufferSync.sync(buffer, messages, sync_opts)
@@ -153,7 +162,9 @@ defmodule MingaEditor.AgentLifecycle do
     )
 
     # Cache the line index and styled messages in the UI state so
-    # callers can read them without recomputing.
+    # callers can read them without recomputing. Persist the (possibly lowered)
+    # display window and mark the jump landed so later re-syncs hold position
+    # instead of re-pinning to the bottom.
     state =
       AgentAccess.update_panel(state, fn p ->
         %{
@@ -161,7 +172,9 @@ defmodule MingaEditor.AgentLifecycle do
           | cached_line_index: line_index,
             cached_display_messages: display_messages,
             cached_display_message_pairs: display_message_pairs,
-            cached_styled_messages: styled
+            cached_styled_messages: styled,
+            display_start_index: display_start,
+            provenance_jump: advance_jump(jump)
         }
       end)
 
@@ -169,6 +182,30 @@ defmodule MingaEditor.AgentLifecycle do
     # replace_generated_content clears edit deltas, so we do a full reparse.
     HighlightSync.request_reparse_buffer(state, buffer)
   end
+
+  # The display window needed to render the jump target. Reveals a paged-out
+  # target turn; otherwise keeps the panel's current window.
+  @spec jump_display_start(
+          ProvenanceJump.t() | nil,
+          non_neg_integer(),
+          [{pos_integer(), term()}] | nil
+        ) ::
+          non_neg_integer()
+  defp jump_display_start(nil, current, _pairs), do: current
+  defp jump_display_start(%ProvenanceJump{landed?: true}, current, _pairs), do: current
+
+  defp jump_display_start(%ProvenanceJump{target_message_id: id}, current, pairs) do
+    case pairs && Enum.find_index(pairs, fn {mid, _msg} -> mid == id end) do
+      nil -> current
+      target_index -> min(current, target_index)
+    end
+  end
+
+  # After the first sync that lands the jump, mark it landed so subsequent
+  # syncs hold the cursor (`:keep`) rather than re-landing or re-pinning.
+  @spec advance_jump(ProvenanceJump.t() | nil) :: ProvenanceJump.t() | nil
+  defp advance_jump(nil), do: nil
+  defp advance_jump(%ProvenanceJump{} = jump), do: ProvenanceJump.mark_landed(jump)
 
   @doc """
   Updates the active agent tab's label to the first user prompt (truncated).

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -17,6 +17,7 @@ defmodule MingaEditor.Commands.Agent do
   alias MingaAgent.Message
   alias MingaAgent.Session
   alias MingaAgent.SessionStore
+  alias MingaEditor.Agent.ProvenanceJump
   alias MingaEditor.Agent.SlashCommand
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
@@ -90,11 +91,17 @@ defmodule MingaEditor.Commands.Agent do
   Opens the agent panel (creating it if needed) and resumes the persisted
   session `session_id` into it, then activates the agent view.
 
+  With a `tool_call_id`, arms a provenance jump so the chat lands on the turn
+  that produced that edit (the turn's opening user message) instead of the
+  bottom of the conversation, and remembers the source file+line for the
+  return trip. Without one, behaves like a plain resume (lands at the bottom).
+
   Unlike `toggle_agent_split/1` this never closes an open panel; it is the
   entry point for "jump from code into the agent session that wrote it".
   """
-  @spec open_session(state(), String.t()) :: state()
-  def open_session(state, session_id) when is_binary(session_id) do
+  @spec open_session(state(), String.t(), String.t() | nil) :: state()
+  def open_session(state, session_id, tool_call_id \\ nil) when is_binary(session_id) do
+    origin = capture_origin(state)
     state = ensure_agent_state(state)
     return_target = build_return_target(state)
 
@@ -108,6 +115,7 @@ defmodule MingaEditor.Commands.Agent do
 
           session_pid ->
             load_persisted_session(session_pid, session_id)
+            state = arm_provenance_jump(state, session_pid, tool_call_id, origin)
             activate_agent_view(state, return_target)
         end
 
@@ -122,6 +130,55 @@ defmodule MingaEditor.Commands.Agent do
     :ok
   catch
     :exit, _ -> :ok
+  end
+
+  # Source file + cursor line the user jumped from, for the return trip.
+  @spec capture_origin(state()) :: ProvenanceJump.origin() | nil
+  defp capture_origin(%{workspace: %{buffers: %{active: buf}}}) when is_pid(buf) do
+    with path when is_binary(path) <- safe_file_path(buf),
+         {line, _col} <- safe_cursor(buf) do
+      {path, line}
+    else
+      _ -> nil
+    end
+  end
+
+  defp capture_origin(_state), do: nil
+
+  @spec arm_provenance_jump(state(), pid(), String.t() | nil, ProvenanceJump.origin() | nil) ::
+          state()
+  defp arm_provenance_jump(state, _session_pid, nil, _origin), do: state
+
+  defp arm_provenance_jump(state, session_pid, tool_call_id, origin) do
+    with pairs when is_list(pairs) <- safe_messages_with_ids(session_pid),
+         target_id when is_integer(target_id) <-
+           AgentBufferSync.turn_anchor_id(pairs, tool_call_id) do
+      jump = ProvenanceJump.request(target_id, origin)
+      AgentAccess.update_panel(state, &Panel.set_provenance_jump(&1, jump))
+    else
+      _ -> state
+    end
+  end
+
+  @spec safe_file_path(pid()) :: String.t() | nil
+  defp safe_file_path(buf) do
+    Buffer.file_path(buf)
+  catch
+    :exit, _ -> nil
+  end
+
+  @spec safe_cursor(pid()) :: {non_neg_integer(), non_neg_integer()} | nil
+  defp safe_cursor(buf) do
+    Buffer.cursor(buf)
+  catch
+    :exit, _ -> nil
+  end
+
+  @spec safe_messages_with_ids(pid()) :: [{pos_integer(), term()}] | nil
+  defp safe_messages_with_ids(session_pid) do
+    Session.messages_with_ids(session_pid)
+  catch
+    :exit, _ -> nil
   end
 
   @spec ensure_agent_state(state()) :: state()
@@ -406,6 +463,9 @@ defmodule MingaEditor.Commands.Agent do
   end
 
   defp submit_prompt(state, panel, false, _session) do
+    # Sending a new prompt ends any provenance jump: the user is driving the
+    # conversation again, so streaming should resume its bottom-pinned scroll.
+    state = AgentAccess.update_panel(state, &Panel.clear_provenance_jump/1)
     text = UIState.prompt_text(panel)
     submit_prompt_text(state, text, SlashCommand.slash_command?(text))
   end

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -1390,6 +1390,70 @@ defmodule MingaEditor.Commands.Agent do
   @spec scope_close(state()) :: state()
   def scope_close(state), do: return_to_editor(state)
 
+  @doc """
+  Returns to the source line a provenance jump came from.
+
+  Closes the loop for "jump from code into the agent": leaves the agent view,
+  reopens the origin file, and places the cursor on the line the user pressed
+  `SPC g w` on. No-op with a status message when there is no active jump.
+  """
+  @spec scope_provenance_return(state()) :: state()
+  def scope_provenance_return(state) do
+    case AgentAccess.panel(state).provenance_jump do
+      %ProvenanceJump{origin: {path, line}} ->
+        state
+        |> AgentAccess.update_panel(&Panel.clear_provenance_jump/1)
+        |> return_to_editor()
+        |> return_to_origin(path, line)
+
+      _ ->
+        EditorState.set_status(state, "No source line to return to")
+    end
+  end
+
+  # After return_to_editor we are on the origin's file tab; place the cursor on
+  # the origin line, reopening the file if it was closed in the meantime.
+  @spec return_to_origin(state(), String.t(), non_neg_integer()) :: state()
+  defp return_to_origin(state, path, line) do
+    active = state.workspace.buffers.active
+
+    if is_pid(active) and safe_file_path(active) == path do
+      safe_move_to(active, {line, 0})
+      state
+    else
+      open_origin_buffer(state, path, line)
+    end
+  end
+
+  @spec open_origin_buffer(state(), String.t(), non_neg_integer()) :: state()
+  defp open_origin_buffer(state, path, line) do
+    case Enum.find_index(state.workspace.buffers.list, &(safe_file_path(&1) == path)) do
+      nil ->
+        case Commands.start_buffer(path, EditorState.options_server(state)) do
+          {:ok, pid} ->
+            state = Commands.add_buffer(state, pid)
+            safe_move_to(pid, {line, 0})
+            state
+
+          {:error, _reason} ->
+            EditorState.set_status(state, "Could not reopen #{Path.basename(path)}")
+        end
+
+      idx ->
+        state = EditorState.switch_buffer(state, idx)
+        safe_move_to(state.workspace.buffers.active, {line, 0})
+        state
+    end
+  end
+
+  @spec safe_move_to(pid(), {non_neg_integer(), non_neg_integer()}) :: :ok
+  defp safe_move_to(buf, pos) do
+    Buffer.move_to(buf, pos)
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+
   @doc "Dismisses active overlays or returns to the editor (ESC behavior)."
   @spec scope_dismiss_or_noop(state()) :: state()
   def scope_dismiss_or_noop(state), do: dismiss_agent_transient_or_return(state)
@@ -1883,6 +1947,7 @@ defmodule MingaEditor.Commands.Agent do
     {:agent_session_switcher, "Agent session switcher", :scope_session_switcher},
     {:agent_toggle_help, "Toggle agent help", :scope_toggle_help},
     {:agent_close, "Return to editor", :scope_close},
+    {:agent_provenance_return, "Return to provenance source line", :scope_provenance_return},
     {:agent_dismiss_or_noop, "Dismiss agent or no-op", :scope_dismiss_or_noop},
     {:agent_accept_hunk, "Accept agent hunk", :scope_accept_hunk},
     {:agent_reject_hunk, "Reject agent hunk", :scope_reject_hunk},

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -86,6 +86,44 @@ defmodule MingaEditor.Commands.Agent do
     end
   end
 
+  @doc """
+  Opens the agent panel (creating it if needed) and resumes the persisted
+  session `session_id` into it, then activates the agent view.
+
+  Unlike `toggle_agent_split/1` this never closes an open panel; it is the
+  entry point for "jump from code into the agent session that wrote it".
+  """
+  @spec open_session(state(), String.t()) :: state()
+  def open_session(state, session_id) when is_binary(session_id) do
+    state = ensure_agent_state(state)
+    return_target = build_return_target(state)
+
+    case find_agent_tab(state) do
+      %Tab{id: agent_id} ->
+        state = state |> EditorState.switch_tab(agent_id) |> maybe_start_session()
+
+        case AgentAccess.session(state) do
+          nil ->
+            EditorState.set_status(state, "No agent session available")
+
+          session_pid ->
+            load_persisted_session(session_pid, session_id)
+            activate_agent_view(state, return_target)
+        end
+
+      nil ->
+        EditorState.set_status(state, "Could not open agent")
+    end
+  end
+
+  @spec load_persisted_session(pid(), String.t()) :: :ok
+  defp load_persisted_session(session_pid, session_id) do
+    Session.load_session(session_pid, session_id)
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+
   @spec ensure_agent_state(state()) :: state()
   defp ensure_agent_state(state) do
     agent = AgentAccess.agent(state)

--- a/lib/minga_editor/commands/autobiography.ex
+++ b/lib/minga_editor/commands/autobiography.ex
@@ -95,8 +95,9 @@ defmodule MingaEditor.Commands.Autobiography do
   defp maybe_open_action(popup, nil), do: popup
   defp maybe_open_action(popup, action), do: HoverPopup.with_open_action(popup, action)
 
+  @doc false
   @spec why_markdown(Entry.t(), String.t()) :: String.t()
-  defp why_markdown(%Entry{} = entry, path) do
+  def why_markdown(%Entry{} = entry, path) do
     [
       "## Why is this line like this?",
       "`#{Path.basename(path)}` · #{format_time(entry.occurred_at)} · session #{short(entry.session_id)}",
@@ -108,8 +109,9 @@ defmodule MingaEditor.Commands.Autobiography do
     |> compact_join()
   end
 
+  @doc false
   @spec autobiography_markdown([Entry.t()], String.t()) :: String.t()
-  defp autobiography_markdown(entries, path) do
+  def autobiography_markdown(entries, path) do
     shown = Enum.take(entries, @max_timeline_entries)
 
     header = [

--- a/lib/minga_editor/commands/autobiography.ex
+++ b/lib/minga_editor/commands/autobiography.ex
@@ -45,8 +45,7 @@ defmodule MingaEditor.Commands.Autobiography do
           EditorState.set_status(state, "No agent history for this line")
 
         {:ok, %Entry{} = entry} ->
-          action = {:open_session, entry.session_id, entry.tool_call_id}
-          show_popup(state, why_markdown(entry, path), action)
+          show_why_popup(state, entry, path)
 
         {:error, _reason} ->
           EditorState.set_status(state, "Could not read agent history")
@@ -71,6 +70,16 @@ defmodule MingaEditor.Commands.Autobiography do
 
   # ── Helpers ──────────────────────────────────────────────────────────────
 
+  @spec show_why_popup(EditorState.t(), Entry.t(), String.t()) :: EditorState.t()
+  defp show_why_popup(state, %Entry{} = entry, path) do
+    action = {:open_session, entry.session_id, entry.tool_call_id}
+
+    popup_opts =
+      if expandable_entry?(entry), do: [expanded: why_expanded_markdown(entry, path)], else: []
+
+    show_popup(state, why_markdown(entry, path), action, popup_opts)
+  end
+
   @spec with_path(EditorState.t(), (Buffer.t(), String.t() -> EditorState.t())) :: EditorState.t()
   defp with_path(state, fun) do
     buf = state.workspace.buffers.active
@@ -81,12 +90,14 @@ defmodule MingaEditor.Commands.Autobiography do
     end
   end
 
-  @spec show_popup(EditorState.t(), String.t(), HoverPopup.open_action() | nil) :: EditorState.t()
-  defp show_popup(state, markdown, open_action \\ nil) do
+  @spec show_popup(EditorState.t(), String.t(), HoverPopup.open_action() | nil, keyword()) ::
+          EditorState.t()
+  defp show_popup(state, markdown, open_action \\ nil, popup_opts \\ []) do
     vp = state.terminal_viewport
+    opts = Keyword.put(popup_opts, :theme, state.theme)
 
     markdown
-    |> HoverPopup.new(div(vp.rows, 2), div(vp.cols, 4), theme: state.theme)
+    |> HoverPopup.new(div(vp.rows, 2), div(vp.cols, 4), opts)
     |> HoverPopup.focus()
     |> maybe_open_action(open_action)
     |> then(&EditorState.set_hover_popup(state, &1))
@@ -99,15 +110,48 @@ defmodule MingaEditor.Commands.Autobiography do
   @doc false
   @spec why_markdown(Entry.t(), String.t()) :: String.t()
   def why_markdown(%Entry{} = entry, path) do
+    why_markdown(entry, path, @why_excerpt, why_hint(entry, :collapsed))
+  end
+
+  @doc false
+  @spec why_expanded_markdown(Entry.t(), String.t()) :: String.t()
+  def why_expanded_markdown(%Entry{} = entry, path) do
+    why_markdown(entry, path, :full, why_hint(entry, :expanded))
+  end
+
+  @spec why_markdown(Entry.t(), String.t(), pos_integer() | :full, String.t()) :: String.t()
+  defp why_markdown(%Entry{} = entry, path, excerpt, hint) do
     [
       "## Why is this line like this?",
       "`#{Path.basename(path)}` · #{format_time(entry.occurred_at)} · session #{short(entry.session_id)}",
       request_block(entry.user_request),
-      thinking_block(entry.thinking, @why_excerpt),
-      said_block(entry.assistant_text, @why_excerpt),
-      "_Enter: open the agent at this turn_"
+      thinking_block(entry.thinking, excerpt),
+      said_block(entry.assistant_text, excerpt),
+      hint
     ]
     |> compact_join()
+  end
+
+  # The popup is expandable only when something is actually truncated, so `o`
+  # never opens a view identical to the collapsed one.
+  @spec expandable_entry?(Entry.t()) :: boolean()
+  defp expandable_entry?(%Entry{thinking: thinking, assistant_text: assistant}) do
+    over_excerpt?(thinking) or over_excerpt?(assistant)
+  end
+
+  @spec over_excerpt?(String.t() | nil) :: boolean()
+  defp over_excerpt?(nil), do: false
+  defp over_excerpt?(text), do: String.length(one_line(text)) > @why_excerpt
+
+  @spec why_hint(Entry.t(), :collapsed | :expanded) :: String.t()
+  defp why_hint(%Entry{} = entry, phase) do
+    base = "Enter: open the agent at this turn"
+
+    cond do
+      not expandable_entry?(entry) -> "_#{base}_"
+      phase == :collapsed -> "_#{base} · o: expand_"
+      phase == :expanded -> "_#{base} · o: collapse_"
+    end
   end
 
   @doc false
@@ -138,11 +182,11 @@ defmodule MingaEditor.Commands.Autobiography do
   defp request_block(nil), do: nil
   defp request_block(text), do: "**You asked:** #{one_line(text)}"
 
-  @spec thinking_block(String.t() | nil, pos_integer()) :: String.t() | nil
+  @spec thinking_block(String.t() | nil, pos_integer() | :full) :: String.t() | nil
   defp thinking_block(nil, _max), do: nil
   defp thinking_block(text, max), do: "**Thinking:** #{truncate(one_line(text), max)}"
 
-  @spec said_block(String.t() | nil, pos_integer()) :: String.t() | nil
+  @spec said_block(String.t() | nil, pos_integer() | :full) :: String.t() | nil
   defp said_block(nil, _max), do: nil
   defp said_block(text, max), do: "**Agent:** #{truncate(one_line(text), max)}"
 
@@ -164,8 +208,10 @@ defmodule MingaEditor.Commands.Autobiography do
   @spec one_line(String.t()) :: String.t()
   defp one_line(text), do: text |> String.replace(~r/\s+/, " ") |> String.trim()
 
-  @spec truncate(String.t(), pos_integer()) :: String.t()
-  defp truncate(text, max) do
+  @spec truncate(String.t(), pos_integer() | :full) :: String.t()
+  defp truncate(text, :full), do: text
+
+  defp truncate(text, max) when is_integer(max) do
     if String.length(text) > max, do: String.slice(text, 0, max) <> "…", else: text
   end
 

--- a/lib/minga_editor/commands/autobiography.ex
+++ b/lib/minga_editor/commands/autobiography.ex
@@ -1,0 +1,173 @@
+defmodule MingaEditor.Commands.Autobiography do
+  @moduledoc """
+  Code-provenance commands: "git blame for the agent's mind".
+
+  * `code_why` (`SPC g w`) answers "why is this line like this?" by showing the
+    agent edit-turn that wrote the line under the cursor, with the request that
+    prompted it and the agent's recorded thinking.
+  * `code_autobiography` (`SPC g a`) shows the full timeline of agent edit-turns
+    for the current file.
+
+  Both read `MingaAgent.Autobiography`, which projects the durable agent event
+  log. Only agent-written code has provenance; hand-edited lines show nothing.
+  """
+
+  use MingaEditor.Commands.Provider
+
+  alias Minga.Buffer
+  alias MingaAgent.Autobiography
+  alias MingaAgent.Autobiography.Entry
+  alias MingaEditor.HoverPopup
+  alias MingaEditor.State, as: EditorState
+
+  @command_specs [
+    {:code_why, "Why is this line like this?", true},
+    {:code_autobiography, "Code autobiography for this file", true}
+  ]
+
+  # Cap how much recorded text we pour into the popup; it stays scannable.
+  @why_excerpt 800
+  @timeline_excerpt 240
+  @max_timeline_entries 15
+
+  @spec execute(EditorState.t(), :code_why | :code_autobiography) :: EditorState.t()
+  def execute(%{workspace: %{buffers: %{active: nil}}} = state, _cmd) do
+    EditorState.set_status(state, "No active buffer")
+  end
+
+  def execute(state, :code_why) do
+    with_path(state, fn buf, path ->
+      {line, _col} = Buffer.cursor(buf)
+      needle = Buffer.content_on_lines(buf, line, line)
+
+      case Autobiography.for_line(path, needle, []) do
+        {:ok, nil} ->
+          EditorState.set_status(state, "No agent history for this line")
+
+        {:ok, %Entry{} = entry} ->
+          show_popup(state, why_markdown(entry, path), {:open_session, entry.session_id})
+
+        {:error, _reason} ->
+          EditorState.set_status(state, "Could not read agent history")
+      end
+    end)
+  end
+
+  def execute(state, :code_autobiography) do
+    with_path(state, fn _buf, path ->
+      case Autobiography.for_file(path, []) do
+        {:ok, []} ->
+          EditorState.set_status(state, "No agent history for this file")
+
+        {:ok, entries} ->
+          show_popup(state, autobiography_markdown(entries, path))
+
+        {:error, _reason} ->
+          EditorState.set_status(state, "Could not read agent history")
+      end
+    end)
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────────────
+
+  @spec with_path(EditorState.t(), (Buffer.t(), String.t() -> EditorState.t())) :: EditorState.t()
+  defp with_path(state, fun) do
+    buf = state.workspace.buffers.active
+
+    case Buffer.file_path(buf) do
+      nil -> EditorState.set_status(state, "No file path")
+      path -> fun.(buf, path)
+    end
+  end
+
+  @spec show_popup(EditorState.t(), String.t(), HoverPopup.open_action() | nil) :: EditorState.t()
+  defp show_popup(state, markdown, open_action \\ nil) do
+    vp = state.terminal_viewport
+
+    markdown
+    |> HoverPopup.new(div(vp.rows, 2), div(vp.cols, 4), theme: state.theme)
+    |> HoverPopup.focus()
+    |> maybe_open_action(open_action)
+    |> then(&EditorState.set_hover_popup(state, &1))
+  end
+
+  @spec maybe_open_action(HoverPopup.t(), HoverPopup.open_action() | nil) :: HoverPopup.t()
+  defp maybe_open_action(popup, nil), do: popup
+  defp maybe_open_action(popup, action), do: HoverPopup.with_open_action(popup, action)
+
+  @spec why_markdown(Entry.t(), String.t()) :: String.t()
+  defp why_markdown(%Entry{} = entry, path) do
+    [
+      "## Why is this line like this?",
+      "`#{Path.basename(path)}` · #{format_time(entry.occurred_at)} · session #{short(entry.session_id)}",
+      request_block(entry.user_request),
+      thinking_block(entry.thinking, @why_excerpt),
+      said_block(entry.assistant_text, @why_excerpt),
+      "_Enter: open this session_"
+    ]
+    |> compact_join()
+  end
+
+  @spec autobiography_markdown([Entry.t()], String.t()) :: String.t()
+  defp autobiography_markdown(entries, path) do
+    shown = Enum.take(entries, @max_timeline_entries)
+
+    header = [
+      "## Autobiography — `#{Path.basename(path)}`",
+      "#{length(entries)} agent edit-turn(s)#{overflow_note(entries)}"
+    ]
+
+    (header ++ Enum.map(shown, &timeline_entry/1)) |> compact_join()
+  end
+
+  @spec timeline_entry(Entry.t()) :: String.t()
+  defp timeline_entry(%Entry{} = entry) do
+    [
+      "### #{format_time(entry.occurred_at)} · session #{short(entry.session_id)}",
+      request_block(entry.user_request),
+      thinking_block(entry.thinking, @timeline_excerpt),
+      said_block(entry.assistant_text, @timeline_excerpt)
+    ]
+    |> compact_join()
+  end
+
+  @spec request_block(String.t() | nil) :: String.t() | nil
+  defp request_block(nil), do: nil
+  defp request_block(text), do: "**You asked:** #{one_line(text)}"
+
+  @spec thinking_block(String.t() | nil, pos_integer()) :: String.t() | nil
+  defp thinking_block(nil, _max), do: nil
+  defp thinking_block(text, max), do: "**Thinking:** #{truncate(one_line(text), max)}"
+
+  @spec said_block(String.t() | nil, pos_integer()) :: String.t() | nil
+  defp said_block(nil, _max), do: nil
+  defp said_block(text, max), do: "**Agent:** #{truncate(one_line(text), max)}"
+
+  @spec overflow_note([Entry.t()]) :: String.t()
+  defp overflow_note(entries) do
+    if length(entries) > @max_timeline_entries do
+      ", showing #{@max_timeline_entries} most recent"
+    else
+      ""
+    end
+  end
+
+  @spec format_time(DateTime.t()) :: String.t()
+  defp format_time(%DateTime{} = dt), do: Calendar.strftime(dt, "%b %-d, %Y %H:%M")
+
+  @spec short(String.t()) :: String.t()
+  defp short(session_id), do: String.slice(session_id, 0, 8)
+
+  @spec one_line(String.t()) :: String.t()
+  defp one_line(text), do: text |> String.replace(~r/\s+/, " ") |> String.trim()
+
+  @spec truncate(String.t(), pos_integer()) :: String.t()
+  defp truncate(text, max) do
+    if String.length(text) > max, do: String.slice(text, 0, max) <> "…", else: text
+  end
+
+  @spec compact_join([String.t() | nil]) :: String.t()
+  defp compact_join(parts), do: parts |> Enum.reject(&is_nil/1) |> Enum.join("\n\n")
+
+  commands(@command_specs)
+end

--- a/lib/minga_editor/commands/autobiography.ex
+++ b/lib/minga_editor/commands/autobiography.ex
@@ -45,7 +45,8 @@ defmodule MingaEditor.Commands.Autobiography do
           EditorState.set_status(state, "No agent history for this line")
 
         {:ok, %Entry{} = entry} ->
-          show_popup(state, why_markdown(entry, path), {:open_session, entry.session_id})
+          action = {:open_session, entry.session_id, entry.tool_call_id}
+          show_popup(state, why_markdown(entry, path), action)
 
         {:error, _reason} ->
           EditorState.set_status(state, "Could not read agent history")
@@ -104,7 +105,7 @@ defmodule MingaEditor.Commands.Autobiography do
       request_block(entry.user_request),
       thinking_block(entry.thinking, @why_excerpt),
       said_block(entry.assistant_text, @why_excerpt),
-      "_Enter: open this session_"
+      "_Enter: open the agent at this turn_"
     ]
     |> compact_join()
   end

--- a/lib/minga_editor/hover_popup.ex
+++ b/lib/minga_editor/hover_popup.ex
@@ -34,7 +34,7 @@ defmodule MingaEditor.HoverPopup do
   @type open_action ::
           atom()
           | {:goto_location, String.t(), non_neg_integer(), non_neg_integer()}
-          | {:open_session, String.t()}
+          | {:open_session, String.t(), String.t() | nil}
 
   @typedoc "A hover popup state."
   @type t :: %__MODULE__{
@@ -87,8 +87,8 @@ defmodule MingaEditor.HoverPopup do
     %{popup | open_action: action}
   end
 
-  def with_open_action(%__MODULE__{} = popup, {:open_session, session_id} = action)
-      when is_binary(session_id) do
+  def with_open_action(%__MODULE__{} = popup, {:open_session, session_id, tool_call_id} = action)
+      when is_binary(session_id) and (is_binary(tool_call_id) or is_nil(tool_call_id)) do
     %{popup | open_action: action}
   end
 
@@ -102,7 +102,7 @@ defmodule MingaEditor.HoverPopup do
   def open_action_name(nil), do: ""
   def open_action_name(action) when is_atom(action), do: Atom.to_string(action)
   def open_action_name({:goto_location, _uri, _line, _col}), do: "goto_location"
-  def open_action_name({:open_session, _session_id}), do: "open_session"
+  def open_action_name({:open_session, _session_id, _tool_call_id}), do: "open_session"
 
   @doc "Scroll content down (later lines visible)."
   @spec scroll_down(t()) :: t()

--- a/lib/minga_editor/hover_popup.ex
+++ b/lib/minga_editor/hover_popup.ex
@@ -28,7 +28,12 @@ defmodule MingaEditor.HoverPopup do
             anchor_col: 0,
             scroll_offset: 0,
             focused: false,
-            open_action: nil
+            open_action: nil,
+            # The not-currently-shown variant for an expandable popup (e.g. the
+            # full thinking behind a truncated provenance preview). `nil` when
+            # the popup is not expandable; swapped with `content_lines` on toggle.
+            alt_content_lines: nil,
+            expanded?: false
 
   @typedoc "Action available from a focused hover popup."
   @type open_action ::
@@ -43,7 +48,9 @@ defmodule MingaEditor.HoverPopup do
           anchor_col: non_neg_integer(),
           scroll_offset: non_neg_integer(),
           focused: boolean(),
-          open_action: open_action() | nil
+          open_action: open_action() | nil,
+          alt_content_lines: [Markdown.parsed_line()] | nil,
+          expanded?: boolean()
         }
 
   @max_width 60
@@ -55,20 +62,52 @@ defmodule MingaEditor.HoverPopup do
 
   Parses the markdown content and anchors the popup at the given
   cursor position.
+
+  Pass `:expanded` with an alternate (fuller) markdown to make the popup
+  expandable: it shows `markdown_text` initially and toggles to the expanded
+  version via `toggle_expand/1` (e.g. a truncated thinking preview that opens
+  to the full reasoning).
   """
   @spec new(String.t(), non_neg_integer(), non_neg_integer(), keyword()) :: t()
   def new(markdown_text, cursor_row, cursor_col, opts \\ []) do
     theme = Keyword.get(opts, :theme, Theme.get!(Theme.default()))
 
-    content_lines =
-      markdown_text
-      |> Markdown.parse()
-      |> SyntaxHighlight.enhance(theme, opts)
+    parse = fn md -> md |> Markdown.parse() |> SyntaxHighlight.enhance(theme, opts) end
+
+    alt_content_lines =
+      case Keyword.get(opts, :expanded) do
+        nil -> nil
+        expanded_md -> parse.(expanded_md)
+      end
 
     %__MODULE__{
-      content_lines: content_lines,
+      content_lines: parse.(markdown_text),
       anchor_row: cursor_row,
-      anchor_col: cursor_col
+      anchor_col: cursor_col,
+      alt_content_lines: alt_content_lines
+    }
+  end
+
+  @doc "Returns true when the popup can toggle to an expanded view."
+  @spec expandable?(t()) :: boolean()
+  def expandable?(%__MODULE__{alt_content_lines: nil}), do: false
+  def expandable?(%__MODULE__{alt_content_lines: _}), do: true
+
+  @doc """
+  Toggles between the collapsed and expanded content, resetting scroll.
+
+  No-op for a non-expandable popup.
+  """
+  @spec toggle_expand(t()) :: t()
+  def toggle_expand(%__MODULE__{alt_content_lines: nil} = popup), do: popup
+
+  def toggle_expand(%__MODULE__{content_lines: shown, alt_content_lines: alt} = popup) do
+    %{
+      popup
+      | content_lines: alt,
+        alt_content_lines: shown,
+        expanded?: not popup.expanded?,
+        scroll_offset: 0
     }
   end
 

--- a/lib/minga_editor/hover_popup.ex
+++ b/lib/minga_editor/hover_popup.ex
@@ -31,7 +31,10 @@ defmodule MingaEditor.HoverPopup do
             open_action: nil
 
   @typedoc "Action available from a focused hover popup."
-  @type open_action :: atom() | {:goto_location, String.t(), non_neg_integer(), non_neg_integer()}
+  @type open_action ::
+          atom()
+          | {:goto_location, String.t(), non_neg_integer(), non_neg_integer()}
+          | {:open_session, String.t()}
 
   @typedoc "A hover popup state."
   @type t :: %__MODULE__{
@@ -84,6 +87,11 @@ defmodule MingaEditor.HoverPopup do
     %{popup | open_action: action}
   end
 
+  def with_open_action(%__MODULE__{} = popup, {:open_session, session_id} = action)
+      when is_binary(session_id) do
+    %{popup | open_action: action}
+  end
+
   @doc "Returns true when the popup exposes an Open action."
   @spec open_action?(t()) :: boolean()
   def open_action?(%__MODULE__{open_action: nil}), do: false
@@ -94,6 +102,7 @@ defmodule MingaEditor.HoverPopup do
   def open_action_name(nil), do: ""
   def open_action_name(action) when is_atom(action), do: Atom.to_string(action)
   def open_action_name({:goto_location, _uri, _line, _col}), do: "goto_location"
+  def open_action_name({:open_session, _session_id}), do: "open_session"
 
   @doc "Scroll content down (later lines visible)."
   @spec scroll_down(t()) :: t()

--- a/lib/minga_editor/input/hover.ex
+++ b/lib/minga_editor/input/hover.ex
@@ -92,8 +92,8 @@ defmodule MingaEditor.Input.Hover do
     LspActions.open_location(state, uri, line, col)
   end
 
-  defp execute_open_action(state, {:open_session, session_id}) do
-    Commands.Agent.open_session(state, session_id)
+  defp execute_open_action(state, {:open_session, session_id, tool_call_id}) do
+    Commands.Agent.open_session(state, session_id, tool_call_id)
   end
 
   defp execute_open_action(state, action) when is_atom(action) do

--- a/lib/minga_editor/input/hover.ex
+++ b/lib/minga_editor/input/hover.ex
@@ -64,6 +64,19 @@ defmodule MingaEditor.Input.Hover do
     {:handled, execute_open_action(state, action)}
   end
 
+  # When focused, o toggles an expandable popup (e.g. full vs truncated thinking).
+  def handle_key(
+        %{shell_state: %{hover_popup: %HoverPopup{focused: true} = popup}} = state,
+        ?o,
+        0
+      ) do
+    if HoverPopup.expandable?(popup) do
+      {:handled, EditorState.set_hover_popup(state, HoverPopup.toggle_expand(popup))}
+    else
+      {:passthrough, EditorState.dismiss_hover_popup(state)}
+    end
+  end
+
   # When focused, q or Escape dismisses
   def handle_key(%{shell_state: %{hover_popup: %HoverPopup{focused: true}}} = state, ?q, 0) do
     {:handled, EditorState.dismiss_hover_popup(state)}

--- a/lib/minga_editor/input/hover.ex
+++ b/lib/minga_editor/input/hover.ex
@@ -92,6 +92,10 @@ defmodule MingaEditor.Input.Hover do
     LspActions.open_location(state, uri, line, col)
   end
 
+  defp execute_open_action(state, {:open_session, session_id}) do
+    Commands.Agent.open_session(state, session_id)
+  end
+
   defp execute_open_action(state, action) when is_atom(action) do
     case Commands.execute(state, action) do
       {new_state, _action} -> new_state

--- a/test/minga_agent/autobiography_test.exs
+++ b/test/minga_agent/autobiography_test.exs
@@ -86,11 +86,12 @@ defmodule MingaAgent.AutobiographyTest do
     assert Enum.map(entries, & &1.tool_call_id) == ["t3", "t2", "t1"]
   end
 
-  test "falls back to basename match when the exact path differs", %{db: db} do
-    # Agent stored a project-relative path; caller asks with an absolute one.
-    edit(db, "s1", "lib/router.ex", after: "def handle, do: :ok")
+  test "does not attribute a same-named file in another directory (no false positive)", %{db: db} do
+    # A different file shares the basename and even the exact line text.
+    edit(db, "s1", "/other/dir/router.ex", after: "def handle, do: :ok")
 
-    assert {:ok, %Entry{path: "lib/router.ex"}} =
-             Autobiography.for_line("/home/me/proj/lib/router.ex", "def handle", db: db)
+    # Exact-path lookup must not borrow the other file's history.
+    assert {:ok, nil} = Autobiography.for_line("/proj/lib/router.ex", "def handle", db: db)
+    assert {:ok, []} = Autobiography.for_file("/proj/lib/router.ex", db: db)
   end
 end

--- a/test/minga_agent/autobiography_test.exs
+++ b/test/minga_agent/autobiography_test.exs
@@ -1,0 +1,96 @@
+defmodule MingaAgent.AutobiographyTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Autobiography
+  alias MingaAgent.Autobiography.Entry
+  alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.EventLog.Store
+
+  setup do
+    {:ok, db} = Store.open_memory()
+    on_exit(fn -> Store.close(db) end)
+    {:ok, db: db}
+  end
+
+  defp insert(db, session_id, type, payload) do
+    {:ok, _id} = Store.insert(db, EventRecord.new(session_id, type, payload))
+    :ok
+  end
+
+  defp edit(db, session_id, path, opts) do
+    insert(db, session_id, :file_edit_proposed, %{
+      "path" => path,
+      "before_content" => Keyword.get(opts, :before, ""),
+      "after_content" => Keyword.fetch!(opts, :after),
+      "tool_call_id" => Keyword.get(opts, :tool_call_id, "tc"),
+      "tool_name" => Keyword.get(opts, :tool_name, "apply_diff")
+    })
+  end
+
+  test "for_line attributes a line to the turn that introduced it", %{db: db} do
+    insert(db, "s1", :user_message, %{"text" => "add auth handling"})
+    insert(db, "s1", :thinking_delta, %{"delta" => "I'll use "})
+    insert(db, "s1", :thinking_delta, %{"delta" => "middleware"})
+    insert(db, "s1", :assistant_delta, %{"delta" => "Adding an auth middleware."})
+
+    edit(db, "s1", "/proj/router.ex",
+      before: "",
+      after: "def handle, do: :auth",
+      tool_call_id: "tc1"
+    )
+
+    assert {:ok, %Entry{} = entry} =
+             Autobiography.for_line("/proj/router.ex", "def handle", db: db)
+
+    assert entry.session_id == "s1"
+    assert entry.tool_call_id == "tc1"
+    assert entry.user_request == "add auth handling"
+    assert entry.thinking == "I'll use middleware"
+    assert entry.assistant_text == "Adding an auth middleware."
+  end
+
+  test "for_line prefers the edit that introduced the text over one that only contains it", %{
+    db: db
+  } do
+    # Older edit already contains the line (so it didn't introduce it).
+    edit(db, "s1", "/p/a.ex", before: "x = 1", after: "x = 1\nkeep = true", tool_call_id: "old")
+    # Newer edit introduces a different line.
+    edit(db, "s1", "/p/a.ex",
+      before: "x = 1\nkeep = true",
+      after: "x = 1\nkeep = true\nnew = 2",
+      tool_call_id: "new"
+    )
+
+    assert {:ok, %Entry{tool_call_id: "new"}} =
+             Autobiography.for_line("/p/a.ex", "new = 2", db: db)
+
+    # "keep = true" was present-before in the newer edit, so attribution lands on the introducer.
+    assert {:ok, %Entry{tool_call_id: "old"}} =
+             Autobiography.for_line("/p/a.ex", "keep = true", db: db)
+  end
+
+  test "for_line returns nil when the agent never wrote the line", %{db: db} do
+    edit(db, "s1", "/p/a.ex", after: "alpha")
+    assert {:ok, nil} = Autobiography.for_line("/p/a.ex", "beta", db: db)
+    assert {:ok, nil} = Autobiography.for_line("/p/other.ex", "alpha", db: db)
+  end
+
+  test "for_file lists distinct edit-turns most recent first", %{db: db} do
+    edit(db, "s1", "/p/a.ex", after: "one", tool_call_id: "t1")
+    edit(db, "s1", "/p/a.ex", after: "one\ntwo", tool_call_id: "t2")
+    # Same tool_call_id collapses to one turn even if it emitted two edits.
+    edit(db, "s2", "/p/a.ex", after: "one\ntwo\nthree", tool_call_id: "t3")
+    edit(db, "s2", "/p/a.ex", after: "one\ntwo\nthree\nthree2", tool_call_id: "t3")
+
+    assert {:ok, entries} = Autobiography.for_file("/p/a.ex", db: db)
+    assert Enum.map(entries, & &1.tool_call_id) == ["t3", "t2", "t1"]
+  end
+
+  test "falls back to basename match when the exact path differs", %{db: db} do
+    # Agent stored a project-relative path; caller asks with an absolute one.
+    edit(db, "s1", "lib/router.ex", after: "def handle, do: :ok")
+
+    assert {:ok, %Entry{path: "lib/router.ex"}} =
+             Autobiography.for_line("/home/me/proj/lib/router.ex", "def handle", db: db)
+  end
+end

--- a/test/minga_editor/agent/provenance_jump_test.exs
+++ b/test/minga_editor/agent/provenance_jump_test.exs
@@ -1,0 +1,100 @@
+defmodule MingaEditor.Agent.ProvenanceJumpTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Agent.BufferSync
+  alias MingaEditor.Agent.ProvenanceJump
+
+  describe "ProvenanceJump lifecycle" do
+    test "request targets a message and starts un-landed" do
+      jump = ProvenanceJump.request(42, {"/p/a.ex", 7})
+      assert jump.target_message_id == 42
+      assert jump.origin == {"/p/a.ex", 7}
+      refute jump.landed?
+    end
+
+    test "un-landed jumps target the message; landed jumps keep the cursor" do
+      jump = ProvenanceJump.request(42)
+      assert ProvenanceJump.cursor_target(jump) == {:message_id, 42}
+
+      landed = ProvenanceJump.mark_landed(jump)
+      assert landed.landed?
+      assert ProvenanceJump.cursor_target(landed) == :keep
+    end
+  end
+
+  describe "turn_anchor_id/2" do
+    # ids are stable message ids; messages are {kind, ...} tuples.
+    defp pairs do
+      [
+        {1, {:user, "add auth"}},
+        {2, {:thinking, "use middleware", false}},
+        {3, {:assistant, "Adding it."}},
+        {4, {:tool_call, %{id: "tc_auth", name: "apply_diff", result: ""}}},
+        {5, {:thinking, "now rate limit", false}},
+        {6, {:tool_call, %{id: "tc_rate", name: "apply_diff", result: ""}}}
+      ]
+    end
+
+    test "lands on the user message that opened the turn" do
+      assert BufferSync.turn_anchor_id(pairs(), "tc_auth") == 1
+    end
+
+    test "falls back to the preceding thinking when the turn had no user prompt" do
+      # tc_rate's turn has thinking (id 5) but no user message after id 1's turn;
+      # nearest preceding :user is id 1, so it wins (top-down read of the turn).
+      assert BufferSync.turn_anchor_id(pairs(), "tc_rate") == 1
+    end
+
+    test "uses thinking when there is no preceding user message at all" do
+      agent_initiated = [
+        {10, {:thinking, "proactive cleanup", false}},
+        {11, {:tool_call, %{id: "tc_x", name: "apply_diff", result: ""}}}
+      ]
+
+      assert BufferSync.turn_anchor_id(agent_initiated, "tc_x") == 10
+    end
+
+    test "falls back to the tool call itself when nothing precedes it" do
+      only_tc = [{20, {:tool_call, %{id: "tc_y", name: "apply_diff", result: ""}}}]
+      assert BufferSync.turn_anchor_id(only_tc, "tc_y") == 20
+    end
+
+    test "returns nil when the tool call is absent" do
+      assert BufferSync.turn_anchor_id(pairs(), "tc_missing") == nil
+    end
+  end
+
+  describe "resolve_cursor_target/5" do
+    # display_message_pairs: [{id, msg}] in display order
+    # line_offsets: [{display_idx, start_line, line_count}]
+    defp display_pairs, do: [{1, {:user, "a"}}, {2, {:assistant, "b"}}, {3, {:user, "c"}}]
+    defp offsets, do: [{0, 0, 2}, {1, 3, 4}, {2, 8, 1}]
+
+    test "message_id resolves to the message's start line" do
+      assert BufferSync.resolve_cursor_target(
+               {:message_id, 3},
+               self(),
+               display_pairs(),
+               offsets(),
+               99
+             ) ==
+               {8, 0}
+    end
+
+    test "missing message_id falls back to the bottom (last line)" do
+      assert BufferSync.resolve_cursor_target(
+               {:message_id, 999},
+               self(),
+               display_pairs(),
+               offsets(),
+               99
+             ) ==
+               {99, 0}
+    end
+
+    test "bottom target resolves to the last line" do
+      assert BufferSync.resolve_cursor_target({:bottom}, self(), display_pairs(), offsets(), 99) ==
+               {99, 0}
+    end
+  end
+end

--- a/test/minga_editor/commands/agent_split_toggle_test.exs
+++ b/test/minga_editor/commands/agent_split_toggle_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
 
   alias MingaEditor.Agent.BufferSync
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Agent.View.Preview
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.Commands.Agent, as: AgentCommands
@@ -320,6 +321,47 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       new_state = AgentCommands.open_session(state, "sess-1")
 
       assert AgentAccess.panel(new_state).provenance_jump == nil
+    end
+  end
+
+  describe "scope_provenance_return/1" do
+    alias MingaEditor.Agent.ProvenanceJump
+
+    test "returns to the editor and clears the jump" do
+      session = fake_session()
+      state = base_state(active: true, session: session)
+
+      jump =
+        ProvenanceJump.request(1, {"/tmp/no_such_file.ex", 5}) |> ProvenanceJump.mark_landed()
+
+      state = AgentAccess.update_panel(state, &Panel.set_provenance_jump(&1, jump))
+      assert EditorState.active_tab_kind(state) == :agent
+
+      new_state = AgentCommands.scope_provenance_return(state)
+
+      assert EditorState.active_tab_kind(new_state) == :file
+      assert AgentAccess.panel(new_state).provenance_jump == nil
+    end
+
+    test "is a no-op with a status message when there is no active jump" do
+      state = base_state(active: true)
+      assert AgentAccess.panel(state).provenance_jump == nil
+
+      new_state = AgentCommands.scope_provenance_return(state)
+
+      assert %EditorState{} = new_state
+      assert EditorState.active_tab_kind(new_state) == :agent
+    end
+  end
+
+  describe "agent scope binding" do
+    alias Minga.Keymap.Bindings
+    alias Minga.Keymap.Scope.Agent, as: AgentScope
+
+    test "g b returns to the provenance source" do
+      trie = AgentScope.keymap(:normal, %{})
+      {:prefix, g_node} = Bindings.lookup(trie, {?g, 0})
+      assert {:command, :agent_provenance_return} = Bindings.lookup(g_node, {?b, 0})
     end
   end
 

--- a/test/minga_editor/commands/agent_split_toggle_test.exs
+++ b/test/minga_editor/commands/agent_split_toggle_test.exs
@@ -269,6 +269,31 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
     Process.demonitor(ref, [:flush])
   end
 
+  describe "open_session/2" do
+    test "opens the agent view and resumes the requested session" do
+      {:ok, session} = StubServer.start_link(notify: self())
+      state = base_state(session: session)
+      assert EditorState.active_tab_kind(state) == :file
+
+      new_state = AgentCommands.open_session(state, "sess-42")
+
+      assert EditorState.active_tab_kind(new_state) == :agent
+      assert_receive {:stub_loaded_session, "sess-42"}
+    end
+
+    test "does not crash when the session pid is dead" do
+      # Unlinked so killing it does not propagate to the test process.
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}
+
+      state = base_state(session: dead)
+      new_state = AgentCommands.open_session(state, "sess-1")
+
+      assert %EditorState{} = new_state
+    end
+  end
+
   describe "round-trip toggle" do
     test "toggle cycle returns to file tab" do
       state = base_state()

--- a/test/minga_editor/commands/agent_split_toggle_test.exs
+++ b/test/minga_editor/commands/agent_split_toggle_test.exs
@@ -292,6 +292,35 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
 
       assert %EditorState{} = new_state
     end
+
+    test "with a tool_call_id, arms a provenance jump to the turn's opening message" do
+      messages = [
+        {:user, "add auth"},
+        {:thinking, "use middleware", false},
+        {:tool_call, MingaAgent.ToolCall.new("tc_auth", "apply_diff")}
+      ]
+
+      {:ok, session} = StubServer.start_link(notify: self(), messages: messages)
+      state = base_state(session: session)
+
+      new_state = AgentCommands.open_session(state, "sess-42", "tc_auth")
+
+      jump = AgentAccess.panel(new_state).provenance_jump
+      assert jump != nil
+      # default ids zip with index+1, so the :user message is id 1.
+      assert jump.target_message_id == 1
+      refute jump.landed?
+      assert_receive {:stub_loaded_session, "sess-42"}
+    end
+
+    test "without a tool_call_id, arms no jump (plain resume)" do
+      {:ok, session} = StubServer.start_link(notify: self(), messages: [{:user, "hi"}])
+      state = base_state(session: session)
+
+      new_state = AgentCommands.open_session(state, "sess-1")
+
+      assert AgentAccess.panel(new_state).provenance_jump == nil
+    end
   end
 
   describe "round-trip toggle" do

--- a/test/minga_editor/commands/autobiography_command_test.exs
+++ b/test/minga_editor/commands/autobiography_command_test.exs
@@ -57,9 +57,27 @@ defmodule MingaEditor.Commands.AutobiographyCommandTest do
       refute md =~ "You asked"
     end
 
-    test "truncates very long thinking" do
+    test "truncates very long thinking and offers the expand hint" do
       md = Autobiography.why_markdown(entry(thinking: String.duplicate("x", 1000)), "/p/a.ex")
       assert md =~ "…"
+      assert md =~ "o: expand"
+    end
+
+    test "short content shows no expand hint" do
+      md = Autobiography.why_markdown(entry(thinking: "short"), "/p/a.ex")
+      refute md =~ "o: expand"
+      assert md =~ "_Enter: open the agent at this turn_"
+    end
+  end
+
+  describe "why_expanded_markdown/2" do
+    test "shows the full thinking untruncated and a collapse hint" do
+      long = String.duplicate("z", 1000)
+      md = Autobiography.why_expanded_markdown(entry(thinking: long), "/p/a.ex")
+
+      assert md =~ long
+      refute md =~ "…"
+      assert md =~ "o: collapse"
     end
   end
 

--- a/test/minga_editor/commands/autobiography_command_test.exs
+++ b/test/minga_editor/commands/autobiography_command_test.exs
@@ -49,7 +49,7 @@ defmodule MingaEditor.Commands.AutobiographyCommandTest do
       assert md =~ "add auth handling"
       assert md =~ "use middleware"
       assert md =~ "Added an auth middleware."
-      assert md =~ "_Enter: open this session_"
+      assert md =~ "_Enter: open the agent at this turn_"
     end
 
     test "omits the request line when there is no recorded request" do

--- a/test/minga_editor/commands/autobiography_command_test.exs
+++ b/test/minga_editor/commands/autobiography_command_test.exs
@@ -3,7 +3,21 @@ defmodule MingaEditor.Commands.AutobiographyCommandTest do
 
   alias Minga.Keymap.Bindings
   alias Minga.Keymap.Defaults
+  alias MingaAgent.Autobiography.Entry
   alias MingaEditor.Commands.Autobiography
+
+  defp entry(opts \\ []) do
+    %Entry{
+      path: Keyword.get(opts, :path, "/proj/lib/router.ex"),
+      session_id: Keyword.get(opts, :session_id, "a1b2c3d4e5f6"),
+      tool_call_id: "tc1",
+      tool_name: "apply_diff",
+      occurred_at: Keyword.get(opts, :occurred_at, ~U[2026-03-08 14:22:00Z]),
+      user_request: Keyword.get(opts, :user_request, "add auth handling"),
+      thinking: Keyword.get(opts, :thinking, "use middleware"),
+      assistant_text: Keyword.get(opts, :assistant_text, "Added an auth middleware.")
+    }
+  end
 
   test "provider exports the code-provenance commands" do
     names = Autobiography.__commands__() |> Enum.map(& &1.name)
@@ -22,5 +36,50 @@ defmodule MingaEditor.Commands.AutobiographyCommandTest do
     {:prefix, g_node} = Bindings.lookup(trie, {?g, 0})
     assert {:command, :code_why} = Bindings.lookup(g_node, {?w, 0})
     assert {:command, :code_autobiography} = Bindings.lookup(g_node, {?a, 0})
+  end
+
+  describe "why_markdown/2" do
+    test "renders request, thinking, agent text, and the open-session hint" do
+      md = Autobiography.why_markdown(entry(), "/proj/lib/router.ex")
+
+      assert md =~ "Why is this line like this?"
+      assert md =~ "router.ex"
+      assert md =~ "session a1b2c3d4"
+      assert md =~ "Mar 8, 2026"
+      assert md =~ "add auth handling"
+      assert md =~ "use middleware"
+      assert md =~ "Added an auth middleware."
+      assert md =~ "_Enter: open this session_"
+    end
+
+    test "omits the request line when there is no recorded request" do
+      md = Autobiography.why_markdown(entry(user_request: nil), "/p/a.ex")
+      refute md =~ "You asked"
+    end
+
+    test "truncates very long thinking" do
+      md = Autobiography.why_markdown(entry(thinking: String.duplicate("x", 1000)), "/p/a.ex")
+      assert md =~ "…"
+    end
+  end
+
+  describe "autobiography_markdown/2" do
+    test "renders a header with the turn count and each entry" do
+      entries = [entry(session_id: "newsessionid"), entry(session_id: "oldsessionid")]
+      md = Autobiography.autobiography_markdown(entries, "/proj/lib/router.ex")
+
+      assert md =~ "Autobiography — `router.ex`"
+      assert md =~ "2 agent edit-turn(s)"
+      assert md =~ "session newsessi"
+      assert md =~ "session oldsessi"
+    end
+
+    test "caps the list and notes the overflow" do
+      entries = for n <- 1..16, do: entry(session_id: "s#{n}")
+      md = Autobiography.autobiography_markdown(entries, "/p/a.ex")
+
+      assert md =~ "16 agent edit-turn(s)"
+      assert md =~ "showing 15 most recent"
+    end
   end
 end

--- a/test/minga_editor/commands/autobiography_command_test.exs
+++ b/test/minga_editor/commands/autobiography_command_test.exs
@@ -1,0 +1,26 @@
+defmodule MingaEditor.Commands.AutobiographyCommandTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Keymap.Bindings
+  alias Minga.Keymap.Defaults
+  alias MingaEditor.Commands.Autobiography
+
+  test "provider exports the code-provenance commands" do
+    names = Autobiography.__commands__() |> Enum.map(& &1.name)
+    assert :code_why in names
+    assert :code_autobiography in names
+  end
+
+  test "both commands require an active buffer" do
+    for cmd <- Autobiography.__commands__() do
+      assert cmd.requires_buffer
+    end
+  end
+
+  test "SPC g w resolves to :code_why and SPC g a to :code_autobiography" do
+    trie = Defaults.leader_trie()
+    {:prefix, g_node} = Bindings.lookup(trie, {?g, 0})
+    assert {:command, :code_why} = Bindings.lookup(g_node, {?w, 0})
+    assert {:command, :code_autobiography} = Bindings.lookup(g_node, {?a, 0})
+  end
+end

--- a/test/minga_editor/hover_popup_test.exs
+++ b/test/minga_editor/hover_popup_test.exs
@@ -245,4 +245,40 @@ defmodule MingaEditor.HoverPopupTest do
       assert atom.open_action == :some_command
     end
   end
+
+  describe "expandable popups" do
+    test "a popup without :expanded is not expandable and toggle is a no-op" do
+      popup = HoverPopup.new("collapsed", 1, 1)
+      refute HoverPopup.expandable?(popup)
+      assert HoverPopup.toggle_expand(popup) == popup
+    end
+
+    test "toggle_expand swaps content and flips the flag, resetting scroll" do
+      popup =
+        "collapsed body"
+        |> HoverPopup.new(1, 1, expanded: "the full expanded body")
+        |> Map.put(:scroll_offset, 5)
+
+      assert HoverPopup.expandable?(popup)
+      refute popup.expanded?
+
+      expanded = HoverPopup.toggle_expand(popup)
+      assert expanded.expanded?
+      assert expanded.scroll_offset == 0
+      # content_lines now holds the expanded text; collapsed is stashed in alt.
+      assert render_text(expanded.content_lines) =~ "full expanded body"
+      assert render_text(expanded.alt_content_lines) =~ "collapsed body"
+
+      back = HoverPopup.toggle_expand(expanded)
+      refute back.expanded?
+      assert render_text(back.content_lines) =~ "collapsed body"
+    end
+  end
+
+  # Flattens parsed markdown lines back to their text for assertions.
+  defp render_text(lines) do
+    Enum.map_join(lines, "\n", fn {segments, _type} ->
+      Enum.map_join(segments, "", fn {text, _style} -> text end)
+    end)
+  end
 end

--- a/test/minga_editor/hover_popup_test.exs
+++ b/test/minga_editor/hover_popup_test.exs
@@ -218,4 +218,27 @@ defmodule MingaEditor.HoverPopupTest do
       assert row >= 0
     end
   end
+
+  describe "with_open_action/2 and open_action_name/1" do
+    test "accepts an open_session action and exposes it" do
+      popup =
+        "x"
+        |> HoverPopup.new(1, 1)
+        |> HoverPopup.with_open_action({:open_session, "sess-123"})
+
+      assert popup.open_action == {:open_session, "sess-123"}
+      assert HoverPopup.open_action?(popup)
+      assert HoverPopup.open_action_name({:open_session, "sess-123"}) == "open_session"
+    end
+
+    test "still accepts goto_location and atom actions" do
+      goto =
+        HoverPopup.with_open_action(HoverPopup.new("x", 1, 1), {:goto_location, "f.ex", 0, 0})
+
+      assert goto.open_action == {:goto_location, "f.ex", 0, 0}
+
+      atom = HoverPopup.with_open_action(HoverPopup.new("x", 1, 1), :some_command)
+      assert atom.open_action == :some_command
+    end
+  end
 end

--- a/test/minga_editor/hover_popup_test.exs
+++ b/test/minga_editor/hover_popup_test.exs
@@ -220,15 +220,19 @@ defmodule MingaEditor.HoverPopupTest do
   end
 
   describe "with_open_action/2 and open_action_name/1" do
-    test "accepts an open_session action and exposes it" do
+    test "accepts an open_session action (with and without a tool_call_id) and exposes it" do
       popup =
         "x"
         |> HoverPopup.new(1, 1)
-        |> HoverPopup.with_open_action({:open_session, "sess-123"})
+        |> HoverPopup.with_open_action({:open_session, "sess-123", "tc1"})
 
-      assert popup.open_action == {:open_session, "sess-123"}
+      assert popup.open_action == {:open_session, "sess-123", "tc1"}
       assert HoverPopup.open_action?(popup)
-      assert HoverPopup.open_action_name({:open_session, "sess-123"}) == "open_session"
+      assert HoverPopup.open_action_name({:open_session, "sess-123", "tc1"}) == "open_session"
+
+      # tool_call_id is optional (plain resume).
+      no_tc = HoverPopup.with_open_action(HoverPopup.new("x", 1, 1), {:open_session, "s", nil})
+      assert no_tc.open_action == {:open_session, "s", nil}
     end
 
     test "still accepts goto_location and atom actions" do

--- a/test/minga_editor/input/hover_test.exs
+++ b/test/minga_editor/input/hover_test.exs
@@ -87,4 +87,31 @@ defmodule MingaEditor.Input.HoverTest do
       assert new_state.shell_state.hover_popup == nil
     end
   end
+
+  describe "handle_key/3 o (expand) on focused hover" do
+    @key_o ?o
+
+    defp state_with_expandable_hover do
+      popup =
+        "collapsed"
+        |> HoverPopup.new(10, 20, expanded: "the full expanded text")
+        |> HoverPopup.focus()
+
+      MingaEditor.State.set_hover_popup(base_state(), popup)
+    end
+
+    test "o toggles an expandable popup without dismissing it" do
+      state = state_with_expandable_hover()
+      assert {:handled, new_state} = Hover.handle_key(state, @key_o, @none)
+      popup = new_state.shell_state.hover_popup
+      assert popup != nil
+      assert popup.expanded?
+    end
+
+    test "o dismisses a non-expandable popup (no special behavior)" do
+      state = state_with_hover(focused: true)
+      assert {:passthrough, new_state} = Hover.handle_key(state, @key_o, @none)
+      assert new_state.shell_state.hover_popup == nil
+    end
+  end
 end

--- a/test/support/stub_server.ex
+++ b/test/support/stub_server.ex
@@ -59,6 +59,15 @@ defmodule Minga.Test.StubServer do
     {:reply, snapshot, state}
   end
 
+  def handle_call({:load_session, session_id}, _from, state) do
+    case Map.get(state, :notify) do
+      pid when is_pid(pid) -> send(pid, {:stub_loaded_session, session_id})
+      _ -> :ok
+    end
+
+    {:reply, :ok, Map.put(state, :loaded_session, session_id)}
+  end
+
   def handle_call(_msg, _from, state), do: {:reply, :ok, state}
 
   @spec toggle_pinned_id(MapSet.t(pos_integer()), pos_integer()) :: MapSet.t(pos_integer())


### PR DESCRIPTION
# TL;DR
`SPC g w` ("why is this line like this?") and `SPC g a` (file autobiography) now surface the agent's *actual recorded reasoning* for code it wrote, projected from the durable agent event log. From the popup, `Enter` reopens the originating session.

Part of #1101

## Context
#1101 ("Code Autobiography") asks to connect code to the agent's intent: when reviewing a large session of LLM changes across many commits, see what the agent was thinking when a given line was written.

The key design constraint (from the issue discussion): you can't reconstruct "why" after the fact without pontificating. So we don't generate or summarize. We were *there* when it happened, because the agent's reasoning is already recorded live: `:file_edit_proposed` events persist before/after content + `tool_call_id` per turn, alongside that turn's `user_message` / `thinking_delta` / `assistant_delta`. This PR is a **read-only projection** over that log. No new capture, no new persistent store, anchored on immutable keys (commit/session/tool_call ids), so it points at reasoning recorded live rather than guessing.

This is the buildable spine of the epic; see "Deferred" below for what's intentionally left.

## Changes
- **`MingaAgent.Autobiography`** (Layer 1): `for_line/3` content-matches the cursor's line against past edits' `after_content` (prefers the edit that *introduced* it) and recovers that turn's request + thinking + assistant text by slicing the session's events around the edit. `for_file/2` lists distinct edit-turns, newest first. Returns typed `Entry` structs. Derive-on-demand; no correlation store.
- **`Store.file_edits_for_path/3` + `_suffix/3`**: cross-session lookup of `:file_edit_proposed` by path (`json_extract`), with a basename fallback for path-form mismatches.
- **`MingaEditor.Commands.Autobiography`** (Layer 2): renders entries into the existing `HoverPopup`. `code_why` / `code_autobiography` commands, reachable via `M-x`.
- **Clickable open-session**: new `HoverPopup` `{:open_session, id}` action → `Commands.Agent.open_session/2` (a non-toggling "open agent + resume session" entry point). Press `Enter` on a focused `code_why` popup to jump into the session that wrote the line.
- **Keymap**: `SPC g w` → `code_why`, `SPC g a` → `code_autobiography` (note: `SPC g s` from the issue is already taken by git stage-file, so autobiography is `g a`).

### Design decisions / deviations
- **File-level, not function-level autobiography.** There's no symbol point-query in the editor (LSP `documentSymbol` returns all symbols). Rather than build a resolver, `SPC g a` shows the file's edit-turn timeline, which fits the "review a whole session over many commits" use case. `SPC g w` stays precise (line-level).
- **No structured `record_decision` capture.** The transcript already holds the reasoning; asking the model to also summarize its decisions would be a lossy, after-the-fact editorialization. We surface the raw recorded thinking instead.

### Deferred (still open under #1101)
- Per-*turn* jump within a session (needs `tool_call_id → message_id` resolve + scroll-to-message API). Today `Enter` opens the session, not the exact turn.
- True per-function scoping (needs a symbol resolver).
- The faded "rejected approaches" branching timeline panel.

## Verification
Automated (run in the worktree after `mix deps.get`):
- `mix test test/minga_agent/autobiography_test.exs` — projection logic (introducing-edit attribution, nil when agent never wrote the line, file timeline ordering, basename fallback). 5 passed.
- `mix test test/minga_editor/hover_popup_test.exs test/minga_editor/commands/autobiography_command_test.exs` — open-action plumbing + command/keymap wiring. 30 passed.
- `mix test test/minga_editor/input/` — hover dispatch unaffected. 335 passed.
- `mix compile --warnings-as-errors`, `mix format`, `mix credo --strict` on changed files — all clean.

Manual (needs an agent session that has edited a file):
1. Open a file the agent has edited; put the cursor on an agent-written line.
2. `SPC g w` → popup shows the request + the agent's thinking/assistant text for the edit that wrote that line.
3. Press `K` to focus the popup, then `Enter` → the agent panel opens with that session resumed.
4. `SPC g a` → popup lists the file's agent edit-turns, newest first.
5. On a hand-written line / a file the agent never touched → status "No agent history for this line".

Not yet verified end-to-end: the live popup→Enter→panel-loads sequence (needs a running session + seeded event DB). The underlying `load_session` / agent-open helpers are existing, in-use code.

## Acceptance Criteria Addressed
Mapping to the behaviors described in #1101:
- `SPC g w` "why is it like this?" for current code ✅
- `M-x code_why` / `M-x code_autobiography` ✅
- File-level autobiography view (`SPC g a`) ✅ (in place of the function-level `SPC g s`)
- Clickable session reference from the narrative ✅ (opens session; per-turn jump deferred)
- Function-level autobiography, structured rejected-approaches, branching timeline panel — ⬜ deferred (see above)
