### PR TITLE
feat(sdk): Minga.Extension.Diagnostics + advisory gutter tier

### DIFF
--- a/lib/minga/diagnostics.ex
+++ b/lib/minga/diagnostics.ex
@@ -136,6 +136,40 @@ defmodule Minga.Diagnostics do
   end
 
   @doc """
+  Returns the gutter sign per line for a URI: a severity for normal
+  producers, or `:diag_advisory` for lines whose only diagnostics come from
+  an extension (source prefixed `"ext:"`).
+
+  Lines that carry any non-extension diagnostic use that producer's most
+  severe sign, so compiler/LSP signs always win over extension advice on
+  the same line. Used by the gutter renderer to pick the sign icon.
+  """
+  @spec gutter_signs_by_line(GenServer.server(), uri()) :: %{
+          non_neg_integer() => Diagnostic.severity() | :diag_advisory
+        }
+  def gutter_signs_by_line(server \\ __MODULE__, uri) when is_binary(uri) do
+    server
+    |> table_name()
+    |> merged_for_uri(uri)
+    |> Enum.group_by(& &1.range.start_line)
+    |> Map.new(fn {line, diags} -> {line, line_gutter_sign(diags)} end)
+  end
+
+  @spec line_gutter_sign([Diagnostic.t()]) :: Diagnostic.severity() | :diag_advisory
+  defp line_gutter_sign(diags) do
+    case Enum.reject(diags, &advisory?/1) do
+      [] -> :diag_advisory
+      real -> real |> Enum.map(& &1.severity) |> Enum.reduce(&Diagnostic.more_severe/2)
+    end
+  end
+
+  @spec advisory?(Diagnostic.t()) :: boolean()
+  defp advisory?(%Diagnostic{source: source}) when is_binary(source),
+    do: String.starts_with?(source, "ext:")
+
+  defp advisory?(_diag), do: false
+
+  @doc """
   Returns the next diagnostic after `current_line` for a URI, or `nil`.
 
   Wraps around to the first diagnostic if past the last one.

--- a/lib/minga/extension/diagnostics.ex
+++ b/lib/minga/extension/diagnostics.ex
@@ -3,8 +3,8 @@ defmodule Minga.Extension.Diagnostics do
   Sanctioned diagnostics surface for extensions.
 
   Lets an extension publish line-level findings (linters, analyzers,
-  advisory agents) through the core diagnostics pipeline — gutter signs,
-  hover, navigation, and the picker — without importing core internals.
+  advisory agents) through the core diagnostics pipeline (gutter signs,
+  hover, navigation, and the picker) without importing core internals.
 
   Findings are namespaced under the extension's own source (`:"ext:<name>"`),
   so an extension can never publish under or clear another producer's

--- a/lib/minga/extension/diagnostics.ex
+++ b/lib/minga/extension/diagnostics.ex
@@ -1,0 +1,70 @@
+defmodule Minga.Extension.Diagnostics do
+  @moduledoc """
+  Sanctioned diagnostics surface for extensions.
+
+  Lets an extension publish line-level findings (linters, analyzers,
+  advisory agents) through the core diagnostics pipeline — gutter signs,
+  hover, navigation, and the picker — without importing core internals.
+
+  Findings are namespaced under the extension's own source (`:"ext:<name>"`),
+  so an extension can never publish under or clear another producer's
+  diagnostics (LSP, compiler). Severity is clamped to `:hint`: advice must
+  never outrank a compiler error in the gutter. Because the source carries
+  the `ext:` prefix, these render as a distinct, themeable advisory sign
+  (`:diag_advisory`) rather than a normal hint.
+
+  `uri` accepts either a `file://` URI or an absolute path.
+  """
+
+  alias Minga.Diagnostics
+  alias Minga.Diagnostics.Diagnostic
+  alias Minga.LSP.SyncServer
+
+  @typedoc "A line-level finding: a zero-indexed `line` and the `concern` text to show."
+  @type finding :: %{line: non_neg_integer(), concern: String.t()}
+
+  @doc """
+  Publishes `findings` for `uri`, replacing this extension's previous
+  findings for that URI.
+  """
+  @spec publish(atom(), String.t(), [finding()]) :: :ok
+  def publish(extension_name, uri, findings)
+      when is_atom(extension_name) and is_binary(uri) and is_list(findings) do
+    Diagnostics.publish(
+      source(extension_name),
+      normalize_uri(uri),
+      Enum.map(findings, &to_diagnostic(&1, extension_name))
+    )
+  end
+
+  @doc "Clears this extension's findings for a single URI."
+  @spec clear(atom(), String.t()) :: :ok
+  def clear(extension_name, uri) when is_atom(extension_name) and is_binary(uri) do
+    Diagnostics.clear(source(extension_name), normalize_uri(uri))
+  end
+
+  @doc "Clears all of this extension's findings across every URI."
+  @spec clear_all(atom()) :: :ok
+  def clear_all(extension_name) when is_atom(extension_name) do
+    Diagnostics.clear_source(source(extension_name))
+  end
+
+  @spec source(atom()) :: atom()
+  defp source(extension_name), do: :"ext:#{extension_name}"
+
+  @spec to_diagnostic(finding(), atom()) :: Diagnostic.t()
+  defp to_diagnostic(%{line: line, concern: concern}, extension_name)
+       when is_integer(line) and line >= 0 and is_binary(concern) do
+    %Diagnostic{
+      range: %{start_line: line, start_col: 0, end_line: line, end_col: 0},
+      severity: :hint,
+      message: concern,
+      source: "ext:#{extension_name}",
+      encoding: :utf8
+    }
+  end
+
+  @spec normalize_uri(String.t()) :: String.t()
+  defp normalize_uri("file://" <> _ = uri), do: uri
+  defp normalize_uri(path), do: SyncServer.path_to_uri(path)
+end

--- a/lib/minga/frontend/adapter/gui/window_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/window_encoder.ex
@@ -597,6 +597,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   defp encode_sign_type(:diag_hint), do: 7
   defp encode_sign_type(:annotation), do: 8
   defp encode_sign_type(:git_removed), do: 9
+  defp encode_sign_type(:diag_advisory), do: 10
 
   # ── Cursorline ─────────────────────────────────────────────────────────
 

--- a/lib/minga/render_model/window/gutter_entry.ex
+++ b/lib/minga/render_model/window/gutter_entry.ex
@@ -15,6 +15,7 @@ defmodule Minga.RenderModel.Window.GutterEntry do
           | :diag_warning
           | :diag_info
           | :diag_hint
+          | :diag_advisory
           | :annotation
 
   @enforce_keys [:buf_line, :display_type, :sign_type]

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -1774,6 +1774,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       :warning -> :diag_warning
       :info -> :diag_info
       :hint -> :diag_hint
+      :diag_advisory -> :diag_advisory
       nil -> resolve_git_sign(buf_line, git_signs)
     end
   end

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -428,7 +428,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
   def diagnostic_signs_for_path(nil), do: %{}
 
   def diagnostic_signs_for_path(path) when is_binary(path) do
-    Diagnostics.severity_by_line(SyncServer.path_to_uri(path))
+    Diagnostics.gutter_signs_by_line(SyncServer.path_to_uri(path))
   end
 
   # ── Visual selection ───────────────────────────────────────────────────────

--- a/lib/minga_editor/renderer/context.ex
+++ b/lib/minga_editor/renderer/context.ex
@@ -92,7 +92,7 @@ defmodule MingaEditor.Renderer.Context do
           nav_flash_bg: MingaEditor.UI.Theme.color() | nil,
           editor_bg: MingaEditor.UI.Theme.color(),
           has_sign_column: boolean(),
-          diagnostic_signs: %{non_neg_integer() => Diagnostic.severity()},
+          diagnostic_signs: %{non_neg_integer() => Diagnostic.severity() | :diag_advisory},
           git_signs: %{non_neg_integer() => Minga.Core.Diff.hunk_type()},
           decorations: Decorations.t(),
           git_colors: MingaEditor.UI.Theme.Git.t(),

--- a/lib/minga_editor/renderer/gutter.ex
+++ b/lib/minga_editor/renderer/gutter.ex
@@ -87,7 +87,7 @@ defmodule MingaEditor.Renderer.Gutter do
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
-          Diagnostic.severity() | nil,
+          Diagnostic.severity() | :diag_advisory | nil,
           atom() | nil,
           colors(),
           git_colors(),
@@ -217,11 +217,28 @@ defmodule MingaEditor.Renderer.Gutter do
     end
   end
 
-  @spec sign_for_severity(Diagnostic.severity(), colors()) :: {String.t(), non_neg_integer()}
+  @spec sign_for_severity(Diagnostic.severity() | :diag_advisory, colors()) ::
+          {String.t(), non_neg_integer()}
   defp sign_for_severity(:error, colors), do: {"E ", colors.error_fg}
   defp sign_for_severity(:warning, colors), do: {"W ", colors.warning_fg}
   defp sign_for_severity(:info, colors), do: {"I ", colors.info_fg}
   defp sign_for_severity(:hint, colors), do: {"H ", colors.hint_fg}
+  defp sign_for_severity(:diag_advisory, colors), do: {"? ", advisory_fg(colors)}
+
+  # Advisory amber. Uses the theme's explicit override when set, otherwise
+  # derives it as the midpoint of warning (yellow) and error (red), which
+  # lands on an amber that suits whatever palette the theme uses.
+  @spec advisory_fg(colors()) :: non_neg_integer()
+  defp advisory_fg(%{advisory_fg: fg}) when is_integer(fg), do: fg
+  defp advisory_fg(%{warning_fg: w, error_fg: e}), do: blend_rgb(w, e)
+
+  @spec blend_rgb(non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp blend_rgb(a, b) do
+    <<ar, ag, ab>> = <<a::24>>
+    <<br, bg, bb>> = <<b::24>>
+    <<blended::24>> = <<div(ar + br, 2), div(ag + bg, 2), div(ab + bb, 2)>>
+    blended
+  end
 
   @spec number_and_color(non_neg_integer(), non_neg_integer(), line_number_style(), colors()) ::
           {non_neg_integer(), non_neg_integer()}

--- a/lib/minga_editor/renderer/gutter/sign_context.ex
+++ b/lib/minga_editor/renderer/gutter/sign_context.ex
@@ -18,7 +18,7 @@ defmodule MingaEditor.Renderer.Gutter.SignContext do
 
   @typedoc "Per-window gutter sign rendering context."
   @type t :: %__MODULE__{
-          diagnostic_signs: %{non_neg_integer() => Diagnostic.severity()},
+          diagnostic_signs: %{non_neg_integer() => Diagnostic.severity() | :diag_advisory},
           git_signs: %{non_neg_integer() => atom()},
           colors: MingaEditor.UI.Theme.Gutter.t(),
           git_colors: MingaEditor.UI.Theme.Git.t(),

--- a/lib/minga_editor/ui/theme.ex
+++ b/lib/minga_editor/ui/theme.ex
@@ -141,7 +141,11 @@ defmodule MingaEditor.UI.Theme do
       :info_fg,
       :hint_fg,
       :fold_fg,
-      :separator_fg
+      :separator_fg,
+      # Advisory (extension-sourced) diagnostic sign color. Optional override:
+      # when nil, the renderer derives it from this theme's own warning/error
+      # colors so the amber suits each theme instead of a baked constant.
+      :advisory_fg
     ]
 
     @type t :: %__MODULE__{
@@ -152,7 +156,8 @@ defmodule MingaEditor.UI.Theme do
             info_fg: MingaEditor.UI.Theme.color(),
             hint_fg: MingaEditor.UI.Theme.color(),
             fold_fg: MingaEditor.UI.Theme.color(),
-            separator_fg: MingaEditor.UI.Theme.color() | nil
+            separator_fg: MingaEditor.UI.Theme.color() | nil,
+            advisory_fg: MingaEditor.UI.Theme.color() | nil
           }
   end
 

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -484,6 +484,7 @@ enum Wire {
         case diagHint = 7
         case annotation = 8
         case gitRemoved = 9
+        case diagAdvisory = 10
     }
 
     /// A single gutter entry for one visible line.

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -1226,7 +1226,7 @@ final class CoreTextMetalRenderer {
             quad.alpha = 1.0
             bgQuads.append(quad)
 
-        case .gitRemoved, .diagError, .diagWarning, .diagInfo, .diagHint:
+        case .gitRemoved, .diagError, .diagWarning, .diagInfo, .diagHint, .diagAdvisory:
             let (text, fg) = gutterTextSignAndColor(entry.signType, frameState: frameState)
             let cacheKey = AtlasKey.diagnosticSign(windowId: windowId, row: screenRow)
             let contentHash = gutterContentHash(text: text, fg: fg)
@@ -1482,9 +1482,22 @@ final class CoreTextMetalRenderer {
         case .diagWarning: return colorFromU24(frameState.gutterColors.warningFg, default: .zero)
         case .diagInfo: return colorFromU24(frameState.gutterColors.infoFg, default: .zero)
         case .diagHint: return colorFromU24(frameState.gutterColors.hintFg, default: .zero)
+        // Advisory amber, derived from this theme's warning + error colors
+        // (mirrors the TUI renderer) so it suits every palette without a
+        // dedicated wire color slot.
+        case .diagAdvisory:
+            return colorFromU24(blendU24(frameState.gutterColors.warningFg, frameState.gutterColors.errorFg), default: .zero)
         case .annotation: return .zero  // Annotation color is per-entry, not from theme
         case .none: return .zero
         }
+    }
+
+    /// Midpoint blend of two 24-bit RGB colors. Matches the BEAM TUI renderer's
+    /// `blend_rgb/2` so advisory amber looks identical across clients.
+    private func blendU24(_ a: UInt32, _ b: UInt32) -> UInt32 {
+        let ar = (a >> 16) & 0xFF, ag = (a >> 8) & 0xFF, ab = a & 0xFF
+        let br = (b >> 16) & 0xFF, bg = (b >> 8) & 0xFF, bb = b & 0xFF
+        return (((ar + br) / 2) << 16) | (((ag + bg) / 2) << 8) | ((ab + bb) / 2)
     }
 
     /// Returns the sign character and fg color (as U24) for a text-rendered gutter sign.
@@ -1495,6 +1508,8 @@ final class CoreTextMetalRenderer {
         case .diagWarning: return ("W", frameState.gutterColors.warningFg)
         case .diagInfo: return ("I", frameState.gutterColors.infoFg)
         case .diagHint: return ("H", frameState.gutterColors.hintFg)
+        case .diagAdvisory:
+            return ("?", blendU24(frameState.gutterColors.warningFg, frameState.gutterColors.errorFg))
         default: return ("", 0)
         }
     }
@@ -1553,7 +1568,7 @@ final class CoreTextMetalRenderer {
 
     private nonisolated static func signTextureDemand(_ signType: Wire.GutterSignType) -> Int {
         switch signType {
-        case .gitRemoved, .diagError, .diagWarning, .diagInfo, .diagHint, .annotation:
+        case .gitRemoved, .diagError, .diagWarning, .diagInfo, .diagHint, .diagAdvisory, .annotation:
             return 1
         case .gitAdded, .gitModified, .gitDeleted, .none:
             return 0

--- a/sdk/lib/minga/extension/diagnostics.ex
+++ b/sdk/lib/minga/extension/diagnostics.ex
@@ -3,7 +3,7 @@ defmodule Minga.Extension.Diagnostics do
   Sanctioned diagnostics surface for extensions.
 
   Publish line-level findings (linters, analyzers, advisory agents) through
-  Minga's diagnostics pipeline — gutter signs, hover, navigation, picker —
+  Minga's diagnostics pipeline (gutter signs, hover, navigation, picker)
   without importing core internals. Findings are namespaced under the
   extension's own source and clamped to `:hint` severity; they render as a
   distinct amber `?` sign so users don't confuse advice with compiler output.

--- a/sdk/lib/minga/extension/diagnostics.ex
+++ b/sdk/lib/minga/extension/diagnostics.ex
@@ -1,0 +1,28 @@
+defmodule Minga.Extension.Diagnostics do
+  @moduledoc """
+  Sanctioned diagnostics surface for extensions.
+
+  Publish line-level findings (linters, analyzers, advisory agents) through
+  Minga's diagnostics pipeline — gutter signs, hover, navigation, picker —
+  without importing core internals. Findings are namespaced under the
+  extension's own source and clamped to `:hint` severity; they render as a
+  distinct amber `?` sign so users don't confuse advice with compiler output.
+
+  `uri` accepts either a `file://` URI or an absolute path.
+
+  This is a compile-time stub. At runtime, the real module in Minga's BEAM
+  VM provides the implementation.
+  """
+
+  @typedoc "A line-level finding: a zero-indexed `line` and the `concern` text to show."
+  @type finding :: %{line: non_neg_integer(), concern: String.t()}
+
+  @spec publish(atom(), String.t(), [finding()]) :: :ok
+  def publish(_extension_name, _uri, _findings), do: raise("minga_sdk is compile-time only")
+
+  @spec clear(atom(), String.t()) :: :ok
+  def clear(_extension_name, _uri), do: raise("minga_sdk is compile-time only")
+
+  @spec clear_all(atom()) :: :ok
+  def clear_all(_extension_name), do: raise("minga_sdk is compile-time only")
+end

--- a/sdk/test/minga_sdk_test.exs
+++ b/sdk/test/minga_sdk_test.exs
@@ -44,13 +44,23 @@ defmodule MingaSdkTest do
       assert is_atom(Minga.Extension.AgentAPI)
     end
 
+    test "Diagnostics types are accessible" do
+      assert is_atom(Minga.Extension.Diagnostics)
+    end
+
     test "EditorAPI types are accessible" do
       assert is_atom(MingaEditor.Extension.EditorAPI)
     end
 
     test "Events types are accessible" do
       assert is_atom(Minga.Events)
-      assert %Minga.Events.BufferChangedEvent{buffer: self(), source: :user, delta: nil, version: nil}
+
+      assert %Minga.Events.BufferChangedEvent{
+        buffer: self(),
+        source: :user,
+        delta: nil,
+        version: nil
+      }
     end
 
     test "Buffer types are accessible" do

--- a/test/minga/diagnostics_test.exs
+++ b/test/minga/diagnostics_test.exs
@@ -168,6 +168,30 @@ defmodule Minga.DiagnosticsTest do
     end
   end
 
+  describe "gutter_signs_by_line/2" do
+    test "marks extension-only lines as :diag_advisory", %{server: s} do
+      ext = make_diag(line: 3, severity: :hint, source: "ext:adversarial")
+      Diagnostics.publish(s, :"ext:adversarial", @uri, [ext])
+
+      assert Diagnostics.gutter_signs_by_line(s, @uri)[3] == :diag_advisory
+    end
+
+    test "uses real severity for non-extension lines", %{server: s} do
+      Diagnostics.publish(s, :server_a, @uri, [make_diag(line: 1, severity: :warning)])
+
+      assert Diagnostics.gutter_signs_by_line(s, @uri)[1] == :warning
+    end
+
+    test "real diagnostics win over advisory on the same line", %{server: s} do
+      real = make_diag(line: 2, severity: :error, source: "expert")
+      ext = make_diag(line: 2, severity: :hint, source: "ext:adversarial")
+      Diagnostics.publish(s, :expert, @uri, [real])
+      Diagnostics.publish(s, :"ext:adversarial", @uri, [ext])
+
+      assert Diagnostics.gutter_signs_by_line(s, @uri)[2] == :error
+    end
+  end
+
   describe "count_tuples_by_uri_prefix/2" do
     test "returns counts for diagnostics under a URI prefix", %{server: s} do
       project_file = "file:///tmp/project/lib/a.ex"

--- a/test/minga/extension/diagnostics_test.exs
+++ b/test/minga/extension/diagnostics_test.exs
@@ -1,0 +1,59 @@
+defmodule Minga.Extension.DiagnosticsTest do
+  # Touches the globally-supervised Minga.Diagnostics singleton, so not async.
+  use ExUnit.Case, async: false
+
+  alias Minga.Diagnostics
+  alias Minga.Extension.Diagnostics, as: ExtDiagnostics
+
+  setup do
+    ext = :"ext_test_#{System.unique_integer([:positive])}"
+    uri = "file:///tmp/ext_diag_#{System.unique_integer([:positive])}.ex"
+    on_exit(fn -> ExtDiagnostics.clear_all(ext) end)
+    %{ext: ext, uri: uri}
+  end
+
+  test "publishes findings clamped to :hint and namespaced by extension", %{ext: ext, uri: uri} do
+    :ok = ExtDiagnostics.publish(ext, uri, [%{line: 4, concern: "assumes list non-empty"}])
+
+    assert [diag] = Diagnostics.for_uri(uri)
+    assert diag.severity == :hint
+    assert diag.message == "assumes list non-empty"
+    assert diag.source == "ext:#{ext}"
+    assert diag.range.start_line == 4
+  end
+
+  test "findings render as :diag_advisory in the gutter", %{ext: ext, uri: uri} do
+    :ok = ExtDiagnostics.publish(ext, uri, [%{line: 1, concern: "P99 is 340ms"}])
+
+    assert Diagnostics.gutter_signs_by_line(uri)[1] == :diag_advisory
+  end
+
+  test "does not clobber another producer's diagnostics on the same URI", %{ext: ext, uri: uri} do
+    real = %Diagnostics.Diagnostic{
+      range: %{start_line: 0, start_col: 0, end_line: 0, end_col: 1},
+      severity: :error,
+      message: "real compiler error",
+      source: "mix_compile"
+    }
+
+    Diagnostics.publish(:mix_compile, uri, [real])
+    :ok = ExtDiagnostics.publish(ext, uri, [%{line: 9, concern: "advice"}])
+
+    messages = uri |> Diagnostics.for_uri() |> Enum.map(& &1.message) |> Enum.sort()
+    assert messages == ["advice", "real compiler error"]
+
+    # Clearing the extension leaves the compiler diagnostic intact.
+    :ok = ExtDiagnostics.clear(ext, uri)
+    assert [%{message: "real compiler error"}] = Diagnostics.for_uri(uri)
+
+    Diagnostics.clear(:mix_compile, uri)
+  end
+
+  test "accepts an absolute path as well as a file URI", %{ext: ext} do
+    path = "/tmp/ext_diag_path_#{System.unique_integer([:positive])}.ex"
+    :ok = ExtDiagnostics.publish(ext, path, [%{line: 0, concern: "via path"}])
+
+    uri = Minga.LSP.SyncServer.path_to_uri(path)
+    assert [%{message: "via path"}] = Diagnostics.for_uri(uri)
+  end
+end


### PR DESCRIPTION
## What

Adds a sanctioned SDK capability, `Minga.Extension.Diagnostics`, so an extension can publish line-level findings through the core diagnostics pipeline (gutter signs, hover, navigation, picker) without reaching into core internals. Adds a distinct semantic gutter tier, `:diag_advisory`, for extension/advisory findings.

Foundation for the adversarial pair-programming agent (#1104); useful to any analyzer/linter extension.

## Why

The diagnostics framework is already source-agnostic and lists "external linters" as first-class producers, but publishing was core-only (LSP/compiler/test-runners). Exposing it via the SDK is the right reuse: extension findings get the entire gutter/hover/nav/picker UX, in both the TUI and macOS GUI, instead of each extension reinventing it on overlays.

## How

- **`Minga.Extension.Diagnostics.publish/clear/clear_all`** (SDK stub + real impl). Findings are a narrow `{line, concern}` shape. The runtime namespaces the source as `:"ext:<name>"`, so an extension can never publish under or clear another producer's diagnostics (LSP, compiler). Severity is **clamped to `:hint`** so advice never outranks a real error in the merge-by-severity gutter.
- **`:diag_advisory` semantic tier.** `Diagnostics.gutter_signs_by_line/2` marks lines whose only diagnostics are `ext:`-sourced as advisory; lines with any real diagnostic keep the real sign. The render model carries `:diag_advisory`; the TUI and macOS GUI each map it to an amber `?`. The amber is **derived from each theme's own warning+error colors at render time** (clients own presentation) rather than a baked constant; themes may override via a new optional `advisory_fg` gutter slot.

## Testing

- `mix test` — diagnostics (incl. new `gutter_signs_by_line` advisory cases), the SDK wrapper (namespacing + `:hint` clamp + "doesn't clobber LSP"), render/frontend/theme suites, SDK stub suite. All green.
- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` — clean (no new findings).

## ⚠️ Reviewer note

The Swift renderer changes (`ProtocolTypes.swift`, `CoreTextMetalRenderer.swift`) were written but **not compiled** — they were authored on Linux with no Swift toolchain. They mirror the existing `:diag_hint` path exactly and all three exhaustive `GutterSignType` switches handle the new `.diagAdvisory` case (compiler-enforced once built). Please `swift build` + eyeball the amber `?` on macOS before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)