### PR TITLE
fix(autobiography): don't let DB errors masquerade as "no history"

### DIFF
--- a/lib/minga_agent/autobiography.ex
+++ b/lib/minga_agent/autobiography.ex
@@ -80,21 +80,9 @@ defmodule MingaAgent.Autobiography do
   def for_line(path, needle, opts \\ []) when is_binary(path) and is_binary(needle) do
     trimmed = String.trim(needle)
 
-    with_db(opts, fn db ->
-      case candidates(db, path, opts) do
-        [] ->
-          {:ok, nil}
-
-        candidates when trimmed == "" ->
-          # Blank line carries no signal: attribute it to the most recent turn.
-          {:ok, candidates |> hd() |> build_entry(db)}
-
-        candidates ->
-          match =
-            Enum.find(candidates, &introduced?(&1, trimmed)) ||
-              Enum.find(candidates, &contains_after?(&1, trimmed))
-
-          {:ok, match && build_entry(match, db)}
+    with_db(opts, nil, fn db ->
+      with {:ok, cands} <- candidates(db, path, opts) do
+        {:ok, match_line(cands, trimmed) |> maybe_build_entry(db)}
       end
     end)
   end
@@ -104,20 +92,21 @@ defmodule MingaAgent.Autobiography do
   """
   @spec for_file(String.t(), [opt()]) :: {:ok, [Entry.t()]} | {:error, term()}
   def for_file(path, opts \\ []) when is_binary(path) do
-    with_db(opts, fn db ->
-      entries =
-        db
-        |> candidates(path, opts)
-        |> Enum.uniq_by(&{&1.session_id, payload(&1, "tool_call_id")})
-        |> Enum.map(&build_entry(&1, db))
+    with_db(opts, [], fn db ->
+      with {:ok, cands} <- candidates(db, path, opts) do
+        entries =
+          cands
+          |> Enum.uniq_by(&{&1.session_id, payload(&1, "tool_call_id")})
+          |> Enum.map(&build_entry(&1, db))
 
-      {:ok, entries}
+        {:ok, entries}
+      end
     end)
   end
 
   # ── Internals ──────────────────────────────────────────────────────────────
 
-  @spec candidates(Store.db(), String.t(), [opt()]) :: [EventRecord.t()]
+  @spec candidates(Store.db(), String.t(), [opt()]) :: {:ok, [EventRecord.t()]} | {:error, term()}
   defp candidates(db, path, opts) do
     limit = Keyword.get(opts, :limit, @candidate_limit)
 
@@ -125,10 +114,38 @@ defmodule MingaAgent.Autobiography do
     # same-named file in another directory and surface the WRONG file's history,
     # which is worse than none. If abs/rel path forms ever diverge in practice,
     # normalize both against the project root here, not by guessing on basename.
-    case Store.file_edits_for_path(db, path, limit) do
-      {:ok, edits} -> edits
-      {:error, _} -> []
-    end
+    Store.file_edits_for_path(db, path, limit)
+  end
+
+  @spec maybe_build_entry(EventRecord.t() | nil, Store.db()) :: Entry.t() | nil
+  defp maybe_build_entry(nil, _db), do: nil
+  defp maybe_build_entry(%EventRecord{} = edit, db), do: build_entry(edit, db)
+
+  # Find the edit that best explains `needle`, the cursor's (trimmed) line.
+  # Whole-line matches first (precise for short/common lines like `end`/`}`),
+  # falling back to substring only when no edit contains the line verbatim.
+  @spec match_line([EventRecord.t()], String.t()) :: EventRecord.t() | nil
+  defp match_line([], _needle), do: nil
+  # Blank line carries no signal: attribute it to the most recent turn.
+  defp match_line([latest | _], ""), do: latest
+
+  defp match_line(cands, needle) do
+    Enum.find(cands, &introduced_line?(&1, needle)) ||
+      Enum.find(cands, &has_line?(&1, "after_content", needle)) ||
+      Enum.find(cands, &introduced?(&1, needle)) ||
+      Enum.find(cands, &contains_after?(&1, needle))
+  end
+
+  @spec introduced_line?(EventRecord.t(), String.t()) :: boolean()
+  defp introduced_line?(edit, needle) do
+    has_line?(edit, "after_content", needle) and not has_line?(edit, "before_content", needle)
+  end
+
+  @spec has_line?(EventRecord.t(), String.t(), String.t()) :: boolean()
+  defp has_line?(edit, key, needle) do
+    (payload(edit, key) || "")
+    |> String.split("\n")
+    |> Enum.any?(&(String.trim(&1) == needle))
   end
 
   @spec introduced?(EventRecord.t(), String.t()) :: boolean()
@@ -170,8 +187,18 @@ defmodule MingaAgent.Autobiography do
 
     events =
       case Store.events_after(db, session_id, cursor, @context_window + 1) do
-        {:ok, evs} -> Enum.filter(evs, &(&1.id <= edit_id))
-        {:error, _} -> []
+        {:ok, evs} ->
+          Enum.filter(evs, &(&1.id <= edit_id))
+
+        {:error, reason} ->
+          # The edit was found but its turn context could not be read; surface a
+          # breadcrumb so blank reasoning isn't mistaken for "the agent said nothing".
+          Minga.Log.warning(
+            :agent,
+            "[autobiography] turn context read failed: #{inspect(reason)}"
+          )
+
+          []
       end
 
     turn = turn_slice(events)
@@ -220,9 +247,13 @@ defmodule MingaAgent.Autobiography do
   defp blank_to_nil(nil), do: nil
   defp blank_to_nil(text), do: if(String.trim(text) == "", do: nil, else: text)
 
-  @spec with_db([opt()], (Store.db() -> result)) :: result | {:error, term()}
+  # `empty` is the "no history" result for this query shape (nil for a line,
+  # [] for a file). A missing database is genuine absence (no agent has run),
+  # so it returns `{:ok, empty}`; any other open/read error propagates so the
+  # caller can distinguish "no history" from "could not read history".
+  @spec with_db([opt()], term(), (Store.db() -> result)) :: result | {:error, term()}
         when result: {:ok, term()}
-  defp with_db(opts, fun) do
+  defp with_db(opts, empty, fun) do
     case Keyword.fetch(opts, :db) do
       {:ok, db} ->
         fun.(db)
@@ -230,6 +261,7 @@ defmodule MingaAgent.Autobiography do
       :error ->
         case EventLog.open_read_connection(opts) do
           {:ok, db} -> try_close(db, fun)
+          {:error, :database_not_found} -> {:ok, empty}
           {:error, reason} -> {:error, reason}
         end
     end

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -156,7 +156,10 @@ defmodule MingaEditor.Commands.Agent do
       jump = ProvenanceJump.request(target_id, origin)
       AgentAccess.update_panel(state, &Panel.set_provenance_jump(&1, jump))
     else
-      _ -> state
+      # Dead session (nil pairs) or tool call not in the transcript (nil anchor):
+      # skip the jump and open at the bottom. A non-nil unexpected shape should
+      # surface as a WithClauseError rather than silently degrade.
+      nil -> state
     end
   end
 

--- a/test/minga_agent/autobiography_test.exs
+++ b/test/minga_agent/autobiography_test.exs
@@ -94,4 +94,47 @@ defmodule MingaAgent.AutobiographyTest do
     assert {:ok, nil} = Autobiography.for_line("/proj/lib/router.ex", "def handle", db: db)
     assert {:ok, []} = Autobiography.for_file("/proj/lib/router.ex", db: db)
   end
+
+  test "attributes a common line (`end`) to the turn that introduced it, not the latest", %{
+    db: db
+  } do
+    # First turn introduces the `end` (closing a def it added).
+    edit(db, "s1", "/p/a.ex",
+      before: "x = 1",
+      after: "def f do\n  :ok\nend",
+      tool_call_id: "introduces"
+    )
+
+    # A later turn touches the file but the `end` line is unchanged (present before and after).
+    edit(db, "s1", "/p/a.ex",
+      before: "def f do\n  :ok\nend",
+      after: "def f do\n  :ok2\nend",
+      tool_call_id: "later"
+    )
+
+    # Substring matching would pick "later" (most recent containing "end");
+    # whole-line introduced-matching correctly picks the turn that added the line.
+    assert {:ok, %Entry{tool_call_id: "introduces"}} =
+             Autobiography.for_line("/p/a.ex", "end", db: db)
+  end
+
+  test "a missing database reads as no history, not an error" do
+    # No :db injected and a dir with no event DB → genuine absence.
+    assert {:ok, nil} =
+             Autobiography.for_line("/p/a.ex", "x", db_dir: "/tmp/minga-no-such-dir-xyz")
+
+    assert {:ok, []} = Autobiography.for_file("/p/a.ex", db_dir: "/tmp/minga-no-such-dir-xyz")
+  end
+
+  test "a real read error propagates instead of looking like no history" do
+    # A closed connection forces reads to fail: this must surface as {:error, _},
+    # never as {:ok, nil}/{:ok, []} (which would falsely claim the agent never
+    # touched the line). Uses its own connection so the shared db's on_exit
+    # close doesn't double-close.
+    {:ok, closed} = Store.open_memory()
+    Store.close(closed)
+
+    assert {:error, _} = Autobiography.for_line("/p/a.ex", "x", db: closed)
+    assert {:error, _} = Autobiography.for_file("/p/a.ex", db: closed)
+  end
 end


### PR DESCRIPTION
# TL;DR
Self-review follow-ups to the merged Code Autobiography feature (#2421): stop the provenance lookup from reporting a real DB read failure as "no history", and make line attribution accurate for common lines.

Part of #1101

## Context
#2421 shipped Code Autobiography (`SPC g w` / `SPC g a`). A post-merge self-review (bug-hunter + silent-failure-hunter passes over the branch diff) found no blockers but three real issues worth fixing. This PR addresses them. All are in the read-only projection layer; no behavior change to the popup/jump/return UX.

## Changes
- **DB errors no longer masquerade as "no history" (the important one).** `MingaAgent.Autobiography.candidates/3` swallowed `{:error, _} -> []`, so a genuine event-log read failure surfaced as "No agent history for this line" — the feature confidently asserting the opposite of the truth, with no breadcrumb. It now propagates the error so the command layer's existing "Could not read agent history" status fires. A *missing* database (no agent has run yet) is genuine absence and still reads as no history, via a new `:database_not_found` → empty-result path in `with_db`.
- **Accurate attribution for common lines.** Substring matching attributed a line like `end` or `}` to the most recent edit that merely *contained* it. Matching now tries whole-line "introduced" and whole-line "present" before falling back to substring, so the turn that actually added the line wins. (Existing partial-needle behavior is preserved via the substring fallback.)
- **No silent blank reasoning.** `turn_context` now logs a warning when the turn-context read fails, so blank reasoning on a found edit isn't mistaken for "the agent said nothing".
- **Tighter jump guard.** `arm_provenance_jump`'s `with/else` went from `_ -> state` to `nil -> state`, so an unexpected return shape raises instead of silently degrading to a bottom-of-chat landing.

## Verification
- `mix test test/minga_agent/autobiography_test.exs` — 8 passed, including new cases:
  - common line (`end`) attributes to the introducing turn, not the latest
  - a missing DB reads as `{:ok, nil}` / `{:ok, []}` (no history)
  - a closed connection propagates `{:error, _}`, never `{:ok, nil}`
- Wider regression across the autobiography/agent/hover/input suites: 407 passed.
- `mix format`, `mix credo --strict` (changed files), and `mix compile --warnings-as-errors`: all clean.

## Acceptance Criteria Addressed
Hardening only; no new AC from #1101. Improves the trustworthiness of the already-shipped provenance read path.
