### PR TITLE
refactor(diagnostics): mark advisory findings with a struct field, not a source prefix

### DIFF
--- a/lib/minga/diagnostics.ex
+++ b/lib/minga/diagnostics.ex
@@ -137,12 +137,12 @@ defmodule Minga.Diagnostics do
 
   @doc """
   Returns the gutter sign per line for a URI: a severity for normal
-  producers, or `:diag_advisory` for lines whose only diagnostics come from
-  an extension (source prefixed `"ext:"`).
+  producers, or `:diag_advisory` for lines whose only diagnostics are
+  advisory (`Diagnostic.advisory: true`, e.g. extension/LLM hints).
 
-  Lines that carry any non-extension diagnostic use that producer's most
-  severe sign, so compiler/LSP signs always win over extension advice on
-  the same line. Used by the gutter renderer to pick the sign icon.
+  Lines that carry any non-advisory diagnostic use that producer's most
+  severe sign, so compiler/LSP signs always win over advice on the same
+  line. Used by the gutter renderer to pick the sign icon.
   """
   @spec gutter_signs_by_line(GenServer.server(), uri()) :: %{
           non_neg_integer() => Diagnostic.severity() | :diag_advisory
@@ -164,10 +164,7 @@ defmodule Minga.Diagnostics do
   end
 
   @spec advisory?(Diagnostic.t()) :: boolean()
-  defp advisory?(%Diagnostic{source: source}) when is_binary(source),
-    do: String.starts_with?(source, "ext:")
-
-  defp advisory?(_diag), do: false
+  defp advisory?(%Diagnostic{advisory: advisory}), do: advisory == true
 
   @doc """
   Returns the next diagnostic after `current_line` for a URI, or `nil`.

--- a/lib/minga/diagnostics/diagnostic.ex
+++ b/lib/minga/diagnostics/diagnostic.ex
@@ -5,12 +5,16 @@ defmodule Minga.Diagnostics.Diagnostic do
   Source-agnostic: LSP servers, external linters, compilers, and test runners
   all produce the same struct. The `source` field identifies the producer
   (e.g., `"expert"`, `"mix_compile"`).
+
+  `advisory: true` marks a low-trust finding (e.g. an LLM/extension hint).
+  Advisory diagnostics render with a distinct gutter sign and never outrank
+  a real diagnostic on the same line.
   """
 
   alias Minga.Core.PositionEncoding
 
   @enforce_keys [:range, :severity, :message]
-  defstruct [:range, :severity, :message, :source, :code, encoding: :utf8]
+  defstruct [:range, :severity, :message, :source, :code, encoding: :utf8, advisory: false]
 
   @typedoc "Severity level, ordered from most to least severe."
   @type severity :: :error | :warning | :info | :hint
@@ -35,7 +39,8 @@ defmodule Minga.Diagnostics.Diagnostic do
           message: String.t(),
           source: String.t() | nil,
           code: String.t() | integer() | nil,
-          encoding: encoding()
+          encoding: encoding(),
+          advisory: boolean()
         }
 
   @severity_rank %{error: 0, warning: 1, info: 2, hint: 3}

--- a/lib/minga/extension/diagnostics.ex
+++ b/lib/minga/extension/diagnostics.ex
@@ -9,8 +9,8 @@ defmodule Minga.Extension.Diagnostics do
   Findings are namespaced under the extension's own source (`:"ext:<name>"`),
   so an extension can never publish under or clear another producer's
   diagnostics (LSP, compiler). Severity is clamped to `:hint`: advice must
-  never outrank a compiler error in the gutter. Because the source carries
-  the `ext:` prefix, these render as a distinct, themeable advisory sign
+  never outrank a compiler error in the gutter. Findings are flagged
+  `advisory: true`, so they render as a distinct, themeable advisory sign
   (`:diag_advisory`) rather than a normal hint.
 
   `uri` accepts either a `file://` URI or an absolute path.
@@ -60,7 +60,8 @@ defmodule Minga.Extension.Diagnostics do
       severity: :hint,
       message: concern,
       source: "ext:#{extension_name}",
-      encoding: :utf8
+      encoding: :utf8,
+      advisory: true
     }
   end
 

--- a/test/minga/diagnostics_test.exs
+++ b/test/minga/diagnostics_test.exs
@@ -24,7 +24,8 @@ defmodule Minga.DiagnosticsTest do
       severity: Keyword.get(opts, :severity, :error),
       message: Keyword.get(opts, :message, "test error"),
       source: Keyword.get(opts, :source, "test_server"),
-      code: Keyword.get(opts, :code, nil)
+      code: Keyword.get(opts, :code, nil),
+      advisory: Keyword.get(opts, :advisory, false)
     }
   end
 
@@ -169,14 +170,14 @@ defmodule Minga.DiagnosticsTest do
   end
 
   describe "gutter_signs_by_line/2" do
-    test "marks extension-only lines as :diag_advisory", %{server: s} do
-      ext = make_diag(line: 3, severity: :hint, source: "ext:adversarial")
+    test "marks advisory-only lines as :diag_advisory", %{server: s} do
+      ext = make_diag(line: 3, severity: :hint, advisory: true)
       Diagnostics.publish(s, :"ext:adversarial", @uri, [ext])
 
       assert Diagnostics.gutter_signs_by_line(s, @uri)[3] == :diag_advisory
     end
 
-    test "uses real severity for non-extension lines", %{server: s} do
+    test "uses real severity for non-advisory lines", %{server: s} do
       Diagnostics.publish(s, :server_a, @uri, [make_diag(line: 1, severity: :warning)])
 
       assert Diagnostics.gutter_signs_by_line(s, @uri)[1] == :warning
@@ -184,7 +185,7 @@ defmodule Minga.DiagnosticsTest do
 
     test "real diagnostics win over advisory on the same line", %{server: s} do
       real = make_diag(line: 2, severity: :error, source: "expert")
-      ext = make_diag(line: 2, severity: :hint, source: "ext:adversarial")
+      ext = make_diag(line: 2, severity: :hint, advisory: true)
       Diagnostics.publish(s, :expert, @uri, [real])
       Diagnostics.publish(s, :"ext:adversarial", @uri, [ext])
 

--- a/test/minga/extension/diagnostics_test.exs
+++ b/test/minga/extension/diagnostics_test.exs
@@ -17,6 +17,7 @@ defmodule Minga.Extension.DiagnosticsTest do
 
     assert [diag] = Diagnostics.for_uri(uri)
     assert diag.severity == :hint
+    assert diag.advisory == true
     assert diag.message == "assumes list non-empty"
     assert diag.source == "ext:#{ext}"
     assert diag.range.start_line == 4


### PR DESCRIPTION
## What

Follow-up to #2429 (now merged). Replaces the implicit "advisory = source string starts with `ext:`" heuristic with an explicit `Diagnostic.advisory` boolean.

## Why

Review feedback on #2429: keying advisory rendering off a `source` string prefix is a fragile, unenforced contract. Any producer that happened to use an `ext:`-prefixed source string would silently render as advisory, and an extension setting a custom source string would lose advisory rendering. It worked for every real input today (only the SDK wrapper mints `ext:` sources), so this is clarity, not a bug fix.

## How

- `Minga.Diagnostics.Diagnostic` gains `advisory: false` (defaulted, **not** enforced, so every existing struct literal is unchanged).
- `Minga.Extension.Diagnostics` (the SDK wrapper) sets `advisory: true`.
- `Minga.Diagnostics.gutter_signs_by_line/2` checks the field instead of the `ext:` source prefix.

Net: ~24 insertions / 19 deletions across 5 files.

## Testing

`mix test test/minga/diagnostics_test.exs test/minga/extension/diagnostics_test.exs` — 42 pass. `mix format --check-formatted` and `mix compile --warnings-as-errors` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)