### PR TITLE
feat(adversarial): analyze the live buffer, not the file on disk

### DIFF
--- a/extensions/adversarial/lib/minga_adversarial/commands.ex
+++ b/extensions/adversarial/lib/minga_adversarial/commands.ex
@@ -6,6 +6,7 @@ defmodule MingaAdversarial.Commands do
   Watcher, which owns the analysis lifecycle and the skepticism dial.
   """
 
+  alias Minga.Buffer
   alias MingaAdversarial.Watcher
   alias MingaEditor.Extension.EditorAPI
 
@@ -16,7 +17,7 @@ defmodule MingaAdversarial.Commands do
         EditorAPI.set_status(state, "Adversarial: no current file")
 
       path ->
-        case Watcher.analyze(path) do
+        case Watcher.analyze(path, live_content(state)) do
           :off ->
             EditorAPI.set_status(
               state,
@@ -44,5 +45,24 @@ defmodule MingaAdversarial.Commands do
   @spec cycle_skepticism(EditorAPI.state()) :: EditorAPI.state()
   def cycle_skepticism(state) do
     EditorAPI.set_status(state, "Adversarial skepticism: #{Watcher.cycle_skepticism()}")
+  end
+
+  # Live (possibly unsaved) text of the active buffer, or nil to fall back to
+  # disk. Analyzing the buffer means findings line up with what's on screen.
+  @spec live_content(EditorAPI.state()) :: String.t() | nil
+  defp live_content(state) do
+    case EditorAPI.active_buffer(state) do
+      pid when is_pid(pid) -> safe_content(pid)
+      _ -> nil
+    end
+  end
+
+  @spec safe_content(pid()) :: String.t() | nil
+  defp safe_content(pid) do
+    Buffer.content(pid)
+  rescue
+    _ -> nil
+  catch
+    :exit, _ -> nil
   end
 end

--- a/extensions/adversarial/lib/minga_adversarial/watcher.ex
+++ b/extensions/adversarial/lib/minga_adversarial/watcher.ex
@@ -55,10 +55,15 @@ defmodule MingaAdversarial.Watcher do
     GenServer.start_link(__MODULE__, opts, name: name)
   end
 
-  @doc "Analyzes `path` now. Returns `:off` when the dial is off, else `:ok`."
-  @spec analyze(GenServer.server(), String.t()) :: :ok | :off
-  def analyze(server \\ __MODULE__, path) do
-    GenServer.call(server, {:analyze, path})
+  @doc """
+  Analyzes `path` now. Returns `:off` when the dial is off, else `:ok`.
+
+  Pass `content` to analyze in-memory buffer text (including unsaved edits);
+  when `nil`, the file on disk is read instead.
+  """
+  @spec analyze(GenServer.server(), String.t(), String.t() | nil) :: :ok | :off
+  def analyze(server \\ __MODULE__, path, content \\ nil) do
+    GenServer.call(server, {:analyze, path, content})
   end
 
   @doc "Clears this extension's findings for `path`."
@@ -92,10 +97,10 @@ defmodule MingaAdversarial.Watcher do
   end
 
   @impl true
-  def handle_call({:analyze, path}, _from, state) do
+  def handle_call({:analyze, path, content}, _from, state) do
     case skepticism(state) do
       :off -> {:reply, :off, state}
-      skep -> {:reply, :ok, request(state, path, skep)}
+      skep -> {:reply, :ok, request(state, path, content, skep)}
     end
   end
 
@@ -113,7 +118,8 @@ defmodule MingaAdversarial.Watcher do
   def handle_info({:minga_event, :buffer_saved, %BufferEvent{path: path}}, state)
       when is_binary(path) do
     case skepticism(state) do
-      skep when skep in [:on_save, :paranoid] -> {:noreply, request(state, path, skep)}
+      # On save the buffer matches disk, so read from disk (content: nil).
+      skep when skep in [:on_save, :paranoid] -> {:noreply, request(state, path, nil, skep)}
       _ -> {:noreply, state}
     end
   end
@@ -154,9 +160,9 @@ defmodule MingaAdversarial.Watcher do
 
   # ── Analysis ─────────────────────────────────────────────────────────────
 
-  @spec request(state(), String.t(), skepticism()) :: state()
-  defp request(state, path, skep) do
-    with {:ok, content} <- File.read(path),
+  @spec request(state(), String.t(), String.t() | nil, skepticism()) :: state()
+  defp request(state, path, given_content, skep) do
+    with {:ok, content} <- read_source(given_content, path),
          true <- byte_size(content) <= @max_bytes do
       state = bump(state, path)
       gen = Map.fetch!(state.generation, path)
@@ -173,6 +179,11 @@ defmodule MingaAdversarial.Watcher do
       _ -> state
     end
   end
+
+  # Prefer caller-provided (live buffer) content; fall back to disk.
+  @spec read_source(String.t() | nil, String.t()) :: {:ok, String.t()} | {:error, term()}
+  defp read_source(content, _path) when is_binary(content), do: {:ok, content}
+  defp read_source(_nil, path), do: File.read(path)
 
   @spec deliver(state(), String.t(), {:ok, String.t()} | {:error, term()}) :: state()
   defp deliver(state, path, {:ok, text}) do

--- a/extensions/adversarial/test/minga_adversarial/watcher_test.exs
+++ b/extensions/adversarial/test/minga_adversarial/watcher_test.exs
@@ -55,6 +55,27 @@ defmodule MingaAdversarial.WatcherTest do
              Diagnostics.for_uri(uri)
   end
 
+  test "analyze uses provided live content instead of the file on disk", %{path: path} do
+    File.write!(path, "on_disk_only\n")
+    test_pid = self()
+
+    server =
+      start_watcher(:live_content,
+        skepticism: :manual,
+        ai_fun: fn messages, _max ->
+          send(test_pid, {:msgs, messages})
+          {:error, :stub}
+        end
+      )
+
+    assert :ok = Watcher.analyze(server, path, "live_buffer_text\n")
+
+    assert_receive {:msgs, messages}, 2_000
+    user = Enum.find(messages, &(&1.role == "user")).content
+    assert user =~ "live_buffer_text"
+    refute user =~ "on_disk_only"
+  end
+
   test "dial off makes analyze a no-op", %{path: path, uri: uri} do
     server =
       start_watcher(:off,

--- a/lib/minga_editor/extension/editor_api.ex
+++ b/lib/minga_editor/extension/editor_api.ex
@@ -101,6 +101,19 @@ defmodule MingaEditor.Extension.EditorAPI do
     end
   end
 
+  @doc """
+  Returns the pid of the active buffer, or `nil` when there is no live
+  active buffer. Use with `Minga.Buffer.content/1` to read the buffer's
+  in-memory text (including unsaved edits) rather than the file on disk.
+  """
+  @spec active_buffer(state()) :: pid() | nil
+  def active_buffer(state) do
+    case state.workspace.buffers.active do
+      pid when is_pid(pid) -> if Process.alive?(pid), do: pid, else: nil
+      _ -> nil
+    end
+  end
+
   @spec safe_file_path(pid()) :: String.t() | nil
   defp safe_file_path(pid) do
     Buffer.file_path(pid)


### PR DESCRIPTION
## What

Follow-up to the adversarial extension PR (#2430). Manual analyze (`SPC a A`) now reads the **active buffer's in-memory text** instead of the file on disk.

**Stacked on #2430** (base is `feat/adversarial-agent`). Review/merge #2430 first.

## Why

Review feedback on #2430: the Watcher read `File.read(path)`, so running analyze on a buffer with unsaved edits scored the on-disk version. Findings then landed on the wrong lines relative to what's on screen. On-save analysis was already correct (buffer == disk at save time); only manual-on-dirty-buffer was affected.

## How

- `EditorAPI.active_buffer/1` (new): returns the active buffer pid, the sanctioned way to reach `Minga.Buffer.content/1` for live text (no core-internals poking). Mirrors the existing `active_path/1`.
- `Watcher.analyze/3` takes optional `content`; `read_source/2` uses it when present, else falls back to `File.read`.
- The `adversarial-analyze` command passes the live buffer content; the `:buffer_saved` path keeps reading disk.

## Testing

Extension suite: 17 pass, including a new test asserting provided live content is used over the on-disk file. `mix format` + `mix compile --warnings-as-errors` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)