### PR TITLE
feat(changeset): non-destructive preflight_merge conflict preview (#2426)

### DIFF
--- a/lib/minga_agent/changeset.ex
+++ b/lib/minga_agent/changeset.ex
@@ -94,13 +94,19 @@ defmodule MingaAgent.Changeset do
   end
 
   @doc """
-  Validates the merge plan back to the real project without applying it.
+  Previews the merge back to the real project without applying it.
 
-  This performs the same path validation and conflict planning as `merge/1`
-  but does not write, delete, or clean up anything. It is useful when a caller
-  needs to know whether a merge would succeed before mutating other state.
+  This runs the same path resolution and three-way merge planning as `merge/1`
+  but writes, deletes, and cleans up nothing on disk, and never stops the
+  GenServer. Use it when a caller needs to know whether a merge would succeed
+  before mutating other state.
+
+  Returns `{:ok, results}` when every file would merge cleanly, or
+  `{:conflict, details}` (same shape as `merge/1`) listing what could not be
+  auto-merged. In both cases `results` is the list of per-file decision tuples
+  (`{:ok, path, kind}` / `{:conflict, path, reason}`) the merge would produce.
   """
-  @spec preflight_merge(changeset()) :: {:ok, [map()]} | {:error, term()}
+  @spec preflight_merge(changeset()) :: {:ok, [tuple()]} | {:conflict, map()} | {:error, term()}
   def preflight_merge(cs) do
     GenServer.call(cs, :preflight_merge)
   end

--- a/lib/minga_agent/changeset/server.ex
+++ b/lib/minga_agent/changeset/server.ex
@@ -222,15 +222,33 @@ defmodule MingaAgent.Changeset.Server do
   end
 
   def handle_call(:merge, _from, state) do
-    case do_merge(state) do
-      :ok ->
+    plans = plan_merge(state)
+
+    # Apply every clean per-file plan, even on a partial conflict. Files that
+    # merged cleanly are written and pruned so a later retry skips them.
+    :ok = apply_plans(plans)
+
+    case conflict_details(plans) do
+      nil ->
         Overlay.cleanup(state.overlay)
         broadcast_merged(state)
         {:stop, :normal, :ok, state}
 
-      {:conflict, details} ->
+      details ->
         state = prune_successful_merge_results(state, details.results)
         {:reply, {:conflict, details}, state}
+    end
+  rescue
+    e ->
+      {:reply, {:error, Exception.message(e)}, state}
+  end
+
+  def handle_call(:preflight_merge, _from, state) do
+    plans = plan_merge(state)
+
+    case conflict_details(plans) do
+      nil -> {:reply, {:ok, results_from_plans(plans)}, state}
+      details -> {:reply, {:conflict, details}, state}
     end
   rescue
     e ->
@@ -251,27 +269,63 @@ defmodule MingaAgent.Changeset.Server do
 
   # ── Merge logic ─────────────────────────────────────────────────────────────
 
-  @spec do_merge(state()) :: :ok | {:conflict, map()} | {:error, term()}
-  defp do_merge(state) do
-    modification_results =
+  # A per-file merge plan pairs the decision result tuple with the disk action
+  # that `:merge` performs to realize it. `:preflight_merge` keeps the results
+  # and discards the actions, so planning is fully write-free and reusable.
+  @typep merge_action :: {:write, String.t(), binary()} | {:rm, String.t()} | :noop
+  @typep merge_plan :: {result :: tuple(), merge_action()}
+
+  # Plans the full merge without touching disk. Returns one plan per file; the
+  # caller decides whether to apply the write actions (`:merge`) or discard them
+  # (`:preflight_merge`). Planning is fully write-free so both paths can share it.
+  @spec plan_merge(state()) :: [merge_plan()]
+  defp plan_merge(state) do
+    modification_plans =
       Enum.map(state.modifications, fn {path, changeset_content} ->
-        merge_one_file(state, path, changeset_content)
+        plan_one_file(state, path, changeset_content)
       end)
 
-    deletion_results =
+    deletion_plans =
       Enum.map(state.deletions, fn path ->
-        merge_one_deletion(state, path)
+        plan_one_deletion(state, path)
       end)
 
-    all_results = modification_results ++ deletion_results
+    modification_plans ++ deletion_plans
+  end
+
+  # Builds the conflict report (matching `merge/1`'s shape) from a plan list, or
+  # `nil` when every file would merge cleanly.
+  @spec conflict_details([merge_plan()]) :: map() | nil
+  defp conflict_details(plans) do
+    all_results = results_from_plans(plans)
     conflicts = Enum.filter(all_results, &match?({:conflict, _, _}, &1))
 
     if conflicts == [] do
-      :ok
+      nil
     else
-      {:conflict, %{conflicts: conflicts, results: all_results}}
+      %{conflicts: conflicts, results: all_results}
     end
   end
+
+  @spec results_from_plans([merge_plan()]) :: [tuple()]
+  defp results_from_plans(plans), do: Enum.map(plans, fn {result, _action} -> result end)
+
+  # Performs the disk writes for the clean plans. Only reached from `:merge`.
+  # Conflict plans carry a `:noop` action, so partial merges write only the
+  # files that merged cleanly and leave conflicting files on disk untouched.
+  @spec apply_plans([merge_plan()]) :: :ok
+  defp apply_plans(plans) do
+    Enum.each(plans, fn {_result, action} -> apply_merge_action(action) end)
+  end
+
+  @spec apply_merge_action(merge_action()) :: :ok
+  defp apply_merge_action({:write, real_path, content}) do
+    File.mkdir_p!(Path.dirname(real_path))
+    File.write!(real_path, content)
+  end
+
+  defp apply_merge_action({:rm, real_path}), do: File.rm!(real_path)
+  defp apply_merge_action(:noop), do: :ok
 
   @spec prune_successful_merge_results(state(), [tuple()]) :: state()
   defp prune_successful_merge_results(state, results) do
@@ -291,8 +345,8 @@ defmodule MingaAgent.Changeset.Server do
 
   defp prune_successful_merge_result(_result, state), do: state
 
-  @spec merge_one_file(state(), String.t(), binary()) :: tuple()
-  defp merge_one_file(state, path, changeset_content) do
+  @spec plan_one_file(state(), String.t(), binary()) :: merge_plan()
+  defp plan_one_file(state, path, changeset_content) do
     real_path = Path.join(state.project_root, path)
     original = Map.get(state.originals, path)
 
@@ -302,61 +356,56 @@ defmodule MingaAgent.Changeset.Server do
         {:error, :enoent} -> nil
       end
 
-    merge_strategy(real_path, path, original, current_real, changeset_content)
+    plan_strategy(real_path, path, original, current_real, changeset_content)
   end
 
   # New file: didn't exist when changeset was created
-  @spec merge_strategy(String.t(), String.t(), binary() | nil, binary() | nil, binary()) ::
-          tuple()
-  defp merge_strategy(real_path, path, nil = _original, nil = _current_real, changeset_content) do
-    File.mkdir_p!(Path.dirname(real_path))
-    File.write!(real_path, changeset_content)
-    {:ok, path, :created}
+  @spec plan_strategy(String.t(), String.t(), binary() | nil, binary() | nil, binary()) ::
+          merge_plan()
+  defp plan_strategy(real_path, path, nil = _original, nil = _current_real, changeset_content) do
+    {{:ok, path, :created}, {:write, real_path, changeset_content}}
   end
 
   # New file but someone else also created it
-  defp merge_strategy(_real_path, path, nil = _original, _current_real, _changeset_content) do
-    {:conflict, path, :both_created}
+  defp plan_strategy(_real_path, path, nil = _original, _current_real, _changeset_content) do
+    {{:conflict, path, :both_created}, :noop}
   end
 
   # Real file unchanged since changeset was created: apply directly
-  defp merge_strategy(real_path, path, original, current_real, changeset_content)
+  defp plan_strategy(real_path, path, original, current_real, changeset_content)
        when current_real == original do
-    File.write!(real_path, changeset_content)
-    {:ok, path, :applied}
+    {{:ok, path, :applied}, {:write, real_path, changeset_content}}
   end
 
   # Real file was also modified: three-way merge
-  defp merge_strategy(real_path, path, original, current_real, changeset_content) do
+  defp plan_strategy(real_path, path, original, current_real, changeset_content) do
     ancestor_lines = String.split(original, "\n", trim: false)
     ours_lines = String.split(changeset_content, "\n", trim: false)
     theirs_lines = String.split(current_real, "\n", trim: false)
 
     case Minga.Core.Diff.merge3(ancestor_lines, ours_lines, theirs_lines) do
       {:ok, merged_lines} ->
-        File.write!(real_path, Enum.join(merged_lines, "\n"))
-        {:ok, path, :merged_three_way}
+        {{:ok, path, :merged_three_way}, {:write, real_path, Enum.join(merged_lines, "\n")}}
 
       {:conflict, _hunks} ->
-        {:conflict, path, :concurrent_edit}
+        {{:conflict, path, :concurrent_edit}, :noop}
     end
   end
 
-  @spec merge_one_deletion(state(), String.t()) :: tuple()
-  defp merge_one_deletion(state, path) do
+  @spec plan_one_deletion(state(), String.t()) :: merge_plan()
+  defp plan_one_deletion(state, path) do
     real_path = Path.join(state.project_root, path)
     original = Map.get(state.originals, path)
 
     case File.read(real_path) do
       {:ok, content} when content == original ->
-        File.rm!(real_path)
-        {:ok, path, :deleted}
+        {{:ok, path, :deleted}, {:rm, real_path}}
 
       {:ok, _changed} ->
-        {:conflict, path, :modified_before_delete}
+        {{:conflict, path, :modified_before_delete}, :noop}
 
       {:error, :enoent} ->
-        {:ok, path, :already_deleted}
+        {{:ok, path, :already_deleted}, :noop}
     end
   end
 

--- a/test/minga_agent/changeset/server_test.exs
+++ b/test/minga_agent/changeset/server_test.exs
@@ -485,6 +485,51 @@ defmodule MingaAgent.Changeset.ServerTest do
     end
   end
 
+  describe "preflight_merge" do
+    test "returns a clean preview without touching the real project", %{project: project} do
+      server = start_server(project)
+      ref = Process.monitor(server)
+
+      assert :ok = GenServer.call(server, {:write_file, "hello.txt", "agent version"})
+
+      result = GenServer.call(server, :preflight_merge)
+
+      # Clean preview mirrors the per-file decisions a merge would make.
+      assert {:ok, results} = result
+      assert {:ok, "hello.txt", :applied} in results
+
+      # The real project file is untouched and the server keeps running.
+      assert File.read!(Path.join(project, "hello.txt")) == "original content"
+      assert Process.alive?(server)
+      refute_received {:DOWN, ^ref, :process, ^server, _reason}
+
+      # A subsequent merge still applies cleanly, proving nothing was consumed.
+      assert :ok = GenServer.call(server, :merge)
+      assert File.read!(Path.join(project, "hello.txt")) == "agent version"
+    end
+
+    test "previews a conflict without mutating the real file", %{project: project} do
+      server = start_server(project)
+
+      # Agent modifies the file through the changeset.
+      assert :ok = GenServer.call(server, {:write_file, "hello.txt", "agent version"})
+
+      # Simulate a concurrent external edit to the same real project file.
+      File.write!(Path.join(project, "hello.txt"), "human version")
+
+      result = GenServer.call(server, :preflight_merge)
+
+      assert {:conflict, %{conflicts: [{:conflict, "hello.txt", :concurrent_edit}]} = details} =
+               result
+
+      assert {:conflict, "hello.txt", :concurrent_edit} in details.results
+
+      # The concurrent edit is preserved: preflight wrote nothing.
+      assert File.read!(Path.join(project, "hello.txt")) == "human version"
+      assert Process.alive?(server)
+    end
+  end
+
   describe "discard" do
     test "cleans up overlay and stops the server", %{project: project} do
       server = start_server(project)


### PR DESCRIPTION
## Summary

Implements `MingaAgent.Changeset.preflight_merge/1` as a **non-destructive conflict preview** for agent changesets. Previously the facade called an unimplemented `:preflight_merge` server message, which would crash.

## What changed

- Extract a pure `plan_merge/1` that produces a per-file `{result, action}` plan using the same three-way merge logic as `:merge`, without touching disk.
- `:merge` applies the plan's write actions; `:preflight_merge` returns the results and discards the actions — zero disk writes, no overlay cleanup, no GenServer stop.
- `:merge`'s contract and partial-merge behavior (clean files written even when siblings conflict, then pruned) are unchanged.
- Fix the facade docstring and spec to match reality.

## Testing

- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`: clean.
- New `Changeset.Server` tests: a clean preview leaves the project file byte-for-byte unchanged; a concurrent-edit preview returns `{:conflict, …}` without mutating the file.
- Verified no regression in the broader merge/routing suites (native provider, project_view routing, filesystem routing, tool_router): 78 passing.

Closes #2426. Part of #2422 (tracking) / epic #1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
