### PR TITLE
Add immediate presentation scroll

### DIFF
--- a/go/tui/internal/ui/input.go
+++ b/go/tui/internal/ui/input.go
@@ -196,6 +196,7 @@ func (m Model) mousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	if row < 0 {
 		row = 0
 	}
+	row, col := m.normalizePresentationMouse(row, mouse.X)
 	button := byte(3)
 	eventType := byte(0)
 	switch mouse.Button {
@@ -238,7 +239,35 @@ func (m Model) mousePacket(msg tea.MouseMsg) ([]byte, bool) {
 			eventType = protocol.MouseDrag
 		}
 	}
-	return protocol.EncodeMouseEvent(int16(row), int16(mouse.X), button, keyModToProtocol(mouse.Mod), eventType, 1), true
+	return protocol.EncodeMouseEvent(int16(row), int16(col), button, keyModToProtocol(mouse.Mod), eventType, 1), true
+}
+
+func (m Model) normalizePresentationMouse(row int, col int) (int, int) {
+	leftChrome := m.leftChromeWidth()
+	bodyCol := col - leftChrome
+	windowID, ok := m.presentationScrollWindowAtBody(bodyCol, row)
+	if !ok {
+		return row, col
+	}
+	window := m.windows[windowID]
+	placement, ok := m.semanticWindowPlacement(window)
+	if !ok {
+		return row, col
+	}
+	scroll, ok := m.presentationScroll[windowID]
+	if !ok || scroll.contentEpoch != window.Scroll.ContentEpoch || scroll.layoutGeneration != window.Scroll.LayoutGeneration || scroll.anchorTop != window.Scroll.AnchorTop || scroll.anchorLeft != window.Scroll.AnchorLeft {
+		return row, col
+	}
+	normalizedRow := clampInt(row+scroll.rowOffset, placement.row, placement.row+placement.height-1)
+	normalizedBodyCol := clampInt(bodyCol+scroll.colOffset, placement.col, placement.col+placement.width-1)
+	return normalizedRow, normalizedBodyCol + leftChrome
+}
+
+func clampInt(value int, low int, high int) int {
+	if high < low {
+		return low
+	}
+	return min(max(value, low), high)
 }
 
 // isWheelButton reports whether a Bubble Tea mouse button is a scroll-wheel

--- a/go/tui/internal/ui/input_test.go
+++ b/go/tui/internal/ui/input_test.go
@@ -218,6 +218,10 @@ func mouseRow(packet []byte) int16 {
 	return int16(uint16(packet[1])<<8 | uint16(packet[2]))
 }
 
+func mouseCol(packet []byte) int16 {
+	return int16(uint16(packet[3])<<8 | uint16(packet[4]))
+}
+
 // tabBarModel builds a model whose header renders headerRows rows above the
 // editor body and refreshes the cached offset exactly as Update does after
 // applyCommands (ticket #2256). The header is always at least one row (a tab bar
@@ -375,6 +379,58 @@ func TestMousePacketTranslatesDragSequence(t *testing.T) {
 // wheel over the header is still forwarded (clamped at row 0) rather than
 // suppressed, since the BEAM treats a wheel as a viewport scroll with no buffer
 // hit-test (ticket #2256).
+func TestMousePacketNormalizesPresentationScrollOffset(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{
+		ID:           7,
+		ContentEpoch: 9,
+		GeometrySet:  true,
+		Geometry:     protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 10, Height: 3}},
+		ScrollSet:    true,
+		Scroll: protocol.ScrollPresentation{
+			WindowID: 7, ContentEpoch: 9, AnchorTop: 10, AnchorLeft: 2, LayoutGeneration: 5,
+		},
+	})
+	model.presentationScroll[7] = presentationScroll{anchorTop: 10, anchorLeft: 2, contentEpoch: 9, layoutGeneration: 5, rowOffset: 1, colOffset: 2}
+
+	packet, ok := model.mousePacket(tea.MouseClickMsg(tea.Mouse{X: 3, Y: model.renderedHeaderHeight, Button: tea.MouseLeft}))
+	if !ok {
+		t.Fatal("click should encode a mouse packet")
+	}
+	if got := mouseRow(packet); got != 1 {
+		t.Fatalf("presentation-normalized row = %d, want 1", got)
+	}
+	if got := mouseCol(packet); got != 5 {
+		t.Fatalf("presentation-normalized col = %d, want 5", got)
+	}
+}
+
+func TestMousePacketClampsPresentationScrollOffsetInsideWindow(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{
+		ID:           7,
+		ContentEpoch: 9,
+		GeometrySet:  true,
+		Geometry:     protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 10, Height: 3}},
+		ScrollSet:    true,
+		Scroll: protocol.ScrollPresentation{
+			WindowID: 7, ContentEpoch: 9, AnchorTop: 10, AnchorLeft: 2, LayoutGeneration: 5,
+		},
+	})
+	model.presentationScroll[7] = presentationScroll{anchorTop: 10, anchorLeft: 2, contentEpoch: 9, layoutGeneration: 5, rowOffset: 1, colOffset: 2}
+
+	packet, ok := model.mousePacket(tea.MouseClickMsg(tea.Mouse{X: 9, Y: model.renderedHeaderHeight + 2, Button: tea.MouseLeft}))
+	if !ok {
+		t.Fatal("click should encode a mouse packet")
+	}
+	if got := mouseRow(packet); got != 2 {
+		t.Fatalf("presentation-normalized row should stay inside window, got %d", got)
+	}
+	if got := mouseCol(packet); got != 9 {
+		t.Fatalf("presentation-normalized col should stay inside window, got %d", got)
+	}
+}
+
 func TestMousePacketTranslatesWheelOverBody(t *testing.T) {
 	model := tabBarModel(1)
 

--- a/go/tui/internal/ui/line_cache.go
+++ b/go/tui/internal/ui/line_cache.go
@@ -215,6 +215,7 @@ func (m Model) windowContextFingerprint(window protocol.WindowContent, width int
 
 	// Per-window scroll and cursorline.
 	writeUint(uint64(window.ScrollLeft))
+	writeUint(uint64(m.presentationScrollEffectiveLeft(window)))
 	writeBool(window.Cursorline.Visible)
 	writeUint(uint64(window.Cursorline.Row))
 	writeUint(uint64(window.Cursorline.BG))

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -111,7 +111,17 @@ type Model struct {
 	// overlayLines() precedence chain; the rects equal what BEAM mouse
 	// hit-testing uses. Surfaces not yet promoted into the BEAM surface registry
 	// keep a reduced hand-ordered chain (transitional split, see overlayLines).
-	surfacePlacements []generated.SurfacePlacement
+	surfacePlacements  []generated.SurfacePlacement
+	presentationScroll map[uint16]presentationScroll
+}
+
+type presentationScroll struct {
+	anchorTop        uint32
+	anchorLeft       uint16
+	contentEpoch     uint32
+	layoutGeneration uint32
+	rowOffset        int
+	colOffset        int
 }
 
 // frameStaging is the open frame transaction buffer (#2219). It lives only
@@ -146,8 +156,9 @@ func New(width, height uint16, out chan<- []byte) Model {
 		latency:           latency.New(),
 		// MINGA_LATENCY_HUD=1 shows the latency overlay at boot; it is also
 		// toggled at runtime with ctrl+alt+l (ticket #2215).
-		hudVisible: latencyHUDEnvEnabled(),
-		lineCache:  newLineCache(),
+		hudVisible:         latencyHUDEnvEnabled(),
+		lineCache:          newLineCache(),
+		presentationScroll: map[uint16]presentationScroll{},
 	}
 	// Seed the header-offset cache so the first mouse event before any
 	// frame/resize still translates against the rendered fallback header.
@@ -211,6 +222,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if updated, ok := m.localMouse(msg); ok {
 			m = updated
 		} else {
+			m = m.applyPresentationScroll(msg)
 			updated, dragPacket, handled := m.handleChromeDrag(msg)
 			m = updated
 			switch {
@@ -609,6 +621,7 @@ func (m *Model) putWindow(window protocol.WindowContent) {
 		m.windowOrder = append(m.windowOrder, window.ID)
 		sort.Slice(m.windowOrder, func(i, j int) bool { return m.windowOrder[i] < m.windowOrder[j] })
 	}
+	m.reconcilePresentationScroll(window)
 	m.windows[window.ID] = window
 	m.refreshCursorFromWindows()
 }
@@ -671,8 +684,23 @@ func (m *Model) applyWindowDelta(delta protocol.WindowContent) {
 		}
 		window.Rows = rows
 	}
+	m.reconcilePresentationScroll(window)
 	m.windows[delta.ID] = window
 	m.refreshCursorFromWindows()
+}
+
+func (m *Model) reconcilePresentationScroll(window protocol.WindowContent) {
+	if !window.ScrollSet || window.Scroll.ResetRequired {
+		delete(m.presentationScroll, window.ID)
+		return
+	}
+	scroll, ok := m.presentationScroll[window.ID]
+	if !ok {
+		return
+	}
+	if scroll.contentEpoch != window.Scroll.ContentEpoch || scroll.layoutGeneration != window.Scroll.LayoutGeneration || scroll.anchorTop != window.Scroll.AnchorTop || scroll.anchorLeft != window.Scroll.AnchorLeft {
+		delete(m.presentationScroll, window.ID)
+	}
 }
 
 func (m *Model) refreshCursorFromWindows() {
@@ -712,6 +740,7 @@ func resolveWindowRows(previous []protocol.WindowRow, delta []protocol.WindowRow
 
 func (m *Model) removeWindow(id uint16) {
 	delete(m.windows, id)
+	delete(m.presentationScroll, id)
 	m.lineCache.dropWindow(id)
 	for index, windowID := range m.windowOrder {
 		if windowID == id {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1193,9 +1193,235 @@ func TestApplyWindowDeltaAppliesScrollLeftSetAndCropsRendering(t *testing.T) {
 	if window.ScrollLeft != 2 {
 		t.Fatalf("scroll left should update from matching-epoch delta, got %d", window.ScrollLeft)
 	}
-	rendered := ansi.Strip(model.renderSemanticContentRow(window, 0, 4))
+	rendered := ansi.Strip(model.renderSemanticContentRow(window, 0, 0, 4))
 	if !strings.HasPrefix(rendered, "cdef") {
 		t.Fatalf("cropped rendering should start at the updated scroll offset, got %q", rendered)
+	}
+}
+
+func stripRenderedLines(lines []string) []string {
+	stripped := make([]string, len(lines))
+	for i, line := range lines {
+		stripped[i] = ansi.Strip(line)
+	}
+	return stripped
+}
+
+func TestPresentationScrollUsesOverscanRowsImmediately(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{
+		ID:           7,
+		ContentEpoch: 9,
+		Rows: []protocol.WindowRow{
+			{ID: 1, ContentHash: 1, Text: "above"},
+			{ID: 2, ContentHash: 2, Text: "top"},
+			{ID: 3, ContentHash: 3, Text: "bottom"},
+			{ID: 4, ContentHash: 4, Text: "below"},
+		},
+		GeometrySet: true,
+		Geometry:    protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 10, Height: 2}},
+		ScrollSet:   true,
+		Scroll: protocol.ScrollPresentation{
+			WindowID: 7, ContentEpoch: 9, AnchorTop: 10, VisibleStartLine: 10, VisibleEndLine: 12, OverscanStartLine: 9, OverscanEndLine: 13,
+		},
+	})
+
+	initial := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
+	if !strings.Contains(initial, "top") || !strings.Contains(initial, "bottom") || strings.Contains(initial, "below") {
+		t.Fatalf("initial render should use committed visible rows, got %q", initial)
+	}
+
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.renderedHeaderHeight}))
+	scrolled := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
+	if !strings.Contains(scrolled, "bottom") || !strings.Contains(scrolled, "below") || strings.Contains(scrolled, "top") {
+		t.Fatalf("local presentation scroll should shift into overscan rows immediately, got %q", scrolled)
+	}
+}
+
+func TestPresentationScrollUsesMatchingOverscanGutterRows(t *testing.T) {
+	model := New(20, 6, nil)
+	model.gutters = map[uint16]protocol.Gutter{
+		7: {
+			WindowID:        7,
+			ContentHeight:   2,
+			CursorLine:      10,
+			LineNumberStyle: 3,
+			LineNumberWidth: 0,
+			SignColWidth:    2,
+			Entries: []protocol.GutterEntry{
+				{BufferLine: 9, SignType: 8, SignText: "A"},
+				{BufferLine: 10, SignType: 8, SignText: "B"},
+				{BufferLine: 11, SignType: 8, SignText: "C"},
+				{BufferLine: 12, SignType: 8, SignText: "D"},
+			},
+		},
+	}
+	model.putWindow(protocol.WindowContent{
+		ID:           7,
+		ContentEpoch: 9,
+		Rows: []protocol.WindowRow{
+			{ID: 1, ContentHash: 1, BufferLine: 9, Text: "above"},
+			{ID: 2, ContentHash: 2, BufferLine: 10, Text: "top"},
+			{ID: 3, ContentHash: 3, BufferLine: 11, Text: "bottom"},
+			{ID: 4, ContentHash: 4, BufferLine: 12, Text: "below"},
+		},
+		GeometrySet: true,
+		Geometry:    protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 10, Height: 2}},
+		ScrollSet:   true,
+		Scroll: protocol.ScrollPresentation{
+			WindowID: 7, ContentEpoch: 9, AnchorTop: 10, VisibleStartLine: 10, VisibleEndLine: 12, OverscanStartLine: 9, OverscanEndLine: 13,
+		},
+	})
+
+	initial := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
+	if !strings.Contains(initial, "B  top") || strings.Contains(initial, "A  top") {
+		t.Fatalf("visible content should use the matching presentation gutter row, got %q", initial)
+	}
+
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.renderedHeaderHeight}))
+	scrolled := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
+	if !strings.Contains(scrolled, "C  bottom") || !strings.Contains(scrolled, "D  below") {
+		t.Fatalf("locally shifted content should keep matching gutter rows, got %q", scrolled)
+	}
+}
+
+func TestPresentationScrollUsesPayloadLocalRowsForWrappedContent(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{
+		ID:           7,
+		ContentEpoch: 9,
+		Rows: []protocol.WindowRow{
+			{ID: 1, ContentHash: 1, Text: "above"},
+			{ID: 2, ContentHash: 2, Text: "top"},
+			{ID: 3, ContentHash: 3, Text: "middle"},
+			{ID: 4, ContentHash: 4, Text: "bottom"},
+			{ID: 5, ContentHash: 5, Text: "below"},
+		},
+		GeometrySet: true,
+		Geometry: protocol.PaneGeometry{
+			ContentRect:     protocol.Rect{Row: 0, Col: 0, Width: 10, Height: 2},
+			ViewportRows:    2,
+			VisualRowOffset: 1,
+			TotalVisualRows: 5,
+		},
+		ScrollSet: true,
+		Scroll: protocol.ScrollPresentation{
+			WindowID: 7, ContentEpoch: 9, AnchorTop: 10, VisibleStartLine: 10, VisibleEndLine: 12, OverscanStartLine: 10, OverscanEndLine: 12,
+		},
+	})
+
+	initial := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
+	if !strings.Contains(initial, "above") || !strings.Contains(initial, "top") || strings.Contains(initial, "middle") {
+		t.Fatalf("wrapped payload should not skip its first row just because document visual offset is non-zero, got %q", initial)
+	}
+
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.renderedHeaderHeight}))
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.renderedHeaderHeight}))
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.renderedHeaderHeight}))
+
+	scroll := model.presentationScroll[7]
+	if scroll.rowOffset != 3 {
+		t.Fatalf("wrapped presentation scroll should allow payload-local appended rows before clamping, got %d", scroll.rowOffset)
+	}
+
+	rendered := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
+	if !strings.Contains(rendered, "bottom") || !strings.Contains(rendered, "below") || strings.Contains(rendered, "top") {
+		t.Fatalf("wrapped presentation scroll should render the actual payload rows, got %q", rendered)
+	}
+}
+
+func TestPresentationScrollShiftWheelMovesHorizontally(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{
+		ID:           7,
+		ContentEpoch: 9,
+		Rows:         []protocol.WindowRow{{ID: 1, ContentHash: 1, Text: "abcdef"}},
+		GeometrySet:  true,
+		Geometry:     protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 4, Height: 1}},
+		ScrollSet:    true,
+		Scroll:       protocol.ScrollPresentation{WindowID: 7, ContentEpoch: 9, AnchorTop: 10, AnchorLeft: 0, LayoutGeneration: 5},
+	})
+
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, Mod: tea.ModShift, X: 1, Y: model.renderedHeaderHeight}))
+	scroll := model.presentationScroll[7]
+	if scroll.rowOffset != 0 || scroll.colOffset != 1 {
+		t.Fatalf("shift wheel-down should move presentation horizontally, got row=%d col=%d", scroll.rowOffset, scroll.colOffset)
+	}
+
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelUp, Mod: tea.ModShift, X: 1, Y: model.renderedHeaderHeight}))
+	if _, ok := model.presentationScroll[7]; ok {
+		t.Fatalf("shift wheel-up should cancel the horizontal offset and clear presentation scroll")
+	}
+}
+
+func TestPresentationScrollHorizontalOffsetInvalidatesCachedRows(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{
+		ID:           7,
+		ContentEpoch: 9,
+		Rows:         []protocol.WindowRow{{ID: 1, ContentHash: 1, Text: "abcdef"}},
+		GeometrySet:  true,
+		Geometry:     protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 10, Height: 1}},
+		ScrollSet:    true,
+		Scroll:       protocol.ScrollPresentation{WindowID: 7, ContentEpoch: 9, AnchorTop: 10, AnchorLeft: 2, LayoutGeneration: 5},
+	})
+
+	initial := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
+	if !strings.Contains(initial, "abcdef") {
+		t.Fatalf("initial render should show the unshifted cached row, got %q", initial)
+	}
+
+	model.presentationScroll[7] = presentationScroll{anchorTop: 10, anchorLeft: 2, contentEpoch: 9, layoutGeneration: 5, colOffset: 2}
+	scrolled := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
+	if !strings.Contains(scrolled, "cdef") || strings.Contains(scrolled, "abcdef") {
+		t.Fatalf("horizontal presentation scroll should invalidate cached rows and shift content, got %q", scrolled)
+	}
+}
+
+func TestPresentationScrollHorizontalWheelRightClampsAtContentEdge(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{
+		ID:           7,
+		ContentEpoch: 9,
+		Rows:         []protocol.WindowRow{{ID: 1, ContentHash: 1, Text: "abcdef"}},
+		GeometrySet:  true,
+		Geometry:     protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 4, Height: 1}},
+		ScrollSet:    true,
+		Scroll:       protocol.ScrollPresentation{WindowID: 7, ContentEpoch: 9, AnchorTop: 10, AnchorLeft: 0, LayoutGeneration: 5},
+	})
+
+	for range 10 {
+		model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelRight, X: 1, Y: model.renderedHeaderHeight}))
+	}
+
+	scroll := model.presentationScroll[7]
+	if scroll.colOffset != 2 {
+		t.Fatalf("horizontal presentation scroll should clamp at right edge, got col offset %d", scroll.colOffset)
+	}
+	rendered := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
+	if !strings.Contains(rendered, "cdef") || strings.TrimSpace(rendered) == "" {
+		t.Fatalf("repeated wheel-right should not blank content past the edge, got %q", rendered)
+	}
+}
+
+func TestPresentationScrollHorizontalWheelRightUsesTextRectWidth(t *testing.T) {
+	model := New(20, 6, nil)
+	model.putWindow(protocol.WindowContent{
+		ID:           7,
+		ContentEpoch: 9,
+		Rows:         []protocol.WindowRow{{ID: 1, ContentHash: 1, Text: "abcdef"}},
+		GeometrySet:  true,
+		Geometry:     protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 7, Height: 1}, TextRect: protocol.Rect{Row: 0, Col: 3, Width: 4, Height: 1}},
+		ScrollSet:    true,
+		Scroll:       protocol.ScrollPresentation{WindowID: 7, ContentEpoch: 9, AnchorTop: 10, AnchorLeft: 0, LayoutGeneration: 5},
+	})
+
+	for range 10 {
+		model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelRight, X: 3, Y: model.renderedHeaderHeight}))
+	}
+
+	if got := model.presentationScroll[7].colOffset; got != 2 {
+		t.Fatalf("horizontal presentation scroll should clamp against text rect width, got col offset %d", got)
 	}
 }
 
@@ -1338,7 +1564,7 @@ func TestSemanticRowsRespectScrollLeftAndIndentGuides(t *testing.T) {
 	model.indentGuides[7] = protocol.IndentGuides{WindowID: 7, TabWidth: 2, GuideCols: []uint16{2}}
 	window := protocol.WindowContent{ID: 7, ScrollLeft: 2, Rows: []protocol.WindowRow{{Text: "    x"}}}
 
-	rendered := ansi.Strip(model.renderSemanticContentRow(window, 0, 8))
+	rendered := ansi.Strip(model.renderSemanticContentRow(window, 0, 0, 8))
 	if !strings.HasPrefix(rendered, "│ ") || !strings.Contains(rendered, "x") {
 		t.Fatalf("scroll-left rendering should keep display-column guides aligned with AstroVim-style guide glyphs: %q", rendered)
 	}

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -213,9 +213,13 @@ func (m Model) renderWindowRows(window protocol.WindowContent) []string {
 	// instead of accumulating an entry per (row_id, hash, index) ever seen, which
 	// would grow without bound under vertical scroll.
 	builder := m.lineCache.beginWindowRender(window.ID, context)
+	sourceStart := m.presentationSourceStart(window, height)
+	overscanBefore := presentationPayloadOverscanBefore(window)
 	lines := make([]string, 0, height)
 	for rowIndex := 0; rowIndex < height; rowIndex++ {
-		key, cacheable := lineCacheKeyFor(window, rowIndex)
+		sourceRowIndex := rowIndex + sourceStart
+		contentRowIndex := sourceRowIndex - overscanBefore
+		key, cacheable := lineCacheKeyFor(window, sourceRowIndex)
 		if cacheable {
 			if cached, ok := builder.lookup(key); ok {
 				m.lineCache.hits++
@@ -227,11 +231,11 @@ func (m Model) renderWindowRows(window protocol.WindowContent) []string {
 		contentWidth := width
 		gutterText := ""
 		if hasGutter {
-			gutterText = m.renderGutterEntry(gutter, rowIndex)
+			gutterText = m.renderGutterEntry(gutter, sourceRowIndex)
 			contentWidth = max(width-lipgloss.Width(gutterText), 1)
 		}
 
-		content := m.renderSemanticContentRow(window, rowIndex, contentWidth)
+		content := m.renderSemanticContentRow(window, sourceRowIndex, contentRowIndex, contentWidth)
 		line := lipgloss.JoinHorizontal(lipgloss.Top, gutterText, content)
 		if cacheable {
 			m.lineCache.misses++
@@ -248,6 +252,72 @@ func (m Model) renderWindowRows(window protocol.WindowContent) []string {
 // content_hash both set) are cached; tilde fill rows past the content and rows
 // without an identity (e.g. synthesized in tests) always recompose so the cache
 // never keys on a degenerate identity.
+func (m Model) presentationSourceStart(window protocol.WindowContent, height int) int {
+	if !window.ScrollSet {
+		return 0
+	}
+	before, _ := presentationPayloadOverscanBounds(window, height)
+	maxStart := max(len(window.Rows)-height, 0)
+	start := min(before, maxStart)
+	if scroll, ok := m.presentationScroll[window.ID]; ok && scroll.contentEpoch == window.Scroll.ContentEpoch && scroll.layoutGeneration == window.Scroll.LayoutGeneration && scroll.anchorTop == window.Scroll.AnchorTop && scroll.anchorLeft == window.Scroll.AnchorLeft {
+		start += scroll.rowOffset
+	}
+	return min(max(start, 0), maxStart)
+}
+
+func scrollOverscanBefore(scroll protocol.ScrollPresentation) int {
+	if scroll.VisibleStartLine <= scroll.OverscanStartLine {
+		return 0
+	}
+	return int(scroll.VisibleStartLine - scroll.OverscanStartLine)
+}
+
+func scrollOverscanAfter(scroll protocol.ScrollPresentation) int {
+	if scroll.OverscanEndLine <= scroll.VisibleEndLine {
+		return 0
+	}
+	return int(scroll.OverscanEndLine - scroll.VisibleEndLine)
+}
+
+func presentationPayloadOverscanBounds(window protocol.WindowContent, visibleRows int) (before int, after int) {
+	before = presentationPayloadOverscanBefore(window)
+	if visibleRows > 0 {
+		return before, max(len(window.Rows)-visibleRows-before, 0)
+	}
+	return before, scrollOverscanAfter(window.Scroll)
+}
+
+func presentationPayloadOverscanBefore(window protocol.WindowContent) int {
+	if !window.ScrollSet {
+		return 0
+	}
+	return scrollOverscanBefore(window.Scroll)
+}
+
+func presentationVisibleRows(window protocol.WindowContent) int {
+	if window.GeometrySet {
+		if window.Geometry.ViewportRows > 0 {
+			return int(window.Geometry.ViewportRows)
+		}
+		if window.Geometry.TextRect.Height > 0 {
+			return int(window.Geometry.TextRect.Height)
+		}
+		if window.Geometry.ContentRect.Height > 0 {
+			return int(window.Geometry.ContentRect.Height)
+		}
+	}
+	return 0
+}
+
+func (m Model) presentationScrollEffectiveLeft(window protocol.WindowContent) int {
+	scrollLeft := int(window.ScrollLeft)
+	scroll, ok := m.presentationScroll[window.ID]
+	if !ok || scroll.contentEpoch != window.Scroll.ContentEpoch || scroll.layoutGeneration != window.Scroll.LayoutGeneration || scroll.anchorTop != window.Scroll.AnchorTop || scroll.anchorLeft != window.Scroll.AnchorLeft {
+		return scrollLeft
+	}
+	return max(scrollLeft+scroll.colOffset, 0)
+}
+
 func lineCacheKeyFor(window protocol.WindowContent, rowIndex int) (lineCacheKey, bool) {
 	if rowIndex >= len(window.Rows) {
 		return lineCacheKey{}, false
@@ -259,12 +329,12 @@ func lineCacheKeyFor(window protocol.WindowContent, rowIndex int) (lineCacheKey,
 	return lineCacheKey{rowID: row.ID, hash: row.ContentHash, rowIndex: rowIndex}, true
 }
 
-func (m Model) renderSemanticContentRow(window protocol.WindowContent, rowIndex int, width int) string {
-	cursorline := window.Cursorline.Visible && rowIndex == int(window.Cursorline.Row)
-	if rowIndex >= len(window.Rows) {
+func (m Model) renderSemanticContentRow(window protocol.WindowContent, sourceRowIndex int, contentRowIndex int, width int) string {
+	cursorline := window.Cursorline.Visible && contentRowIndex == int(window.Cursorline.Row)
+	if sourceRowIndex < 0 || sourceRowIndex >= len(window.Rows) {
 		return m.renderTildeRow(width, cursorline, window.Cursorline.BG)
 	}
-	return m.renderRow(window, window.Rows[rowIndex], rowIndex, width, cursorline, window.Cursorline.BG)
+	return m.renderRow(window, window.Rows[sourceRowIndex], contentRowIndex, width, cursorline, window.Cursorline.BG)
 }
 
 func (m Model) renderTildeRow(width int, cursorline bool, cursorlineBG uint32) string {
@@ -283,6 +353,7 @@ func (m Model) renderRow(window protocol.WindowContent, row protocol.WindowRow, 
 
 	var builder strings.Builder
 	scrollLeft := int(window.ScrollLeft)
+	scrollLeft = m.presentationScrollEffectiveLeft(window)
 	col := 0
 	for graphemes := uniseg.NewGraphemes(row.Text); graphemes.Next(); {
 		text := graphemes.Str()
@@ -614,7 +685,7 @@ func (m Model) renderGutterEntry(gutter protocol.Gutter, rowIndex int) string {
 		return ""
 	}
 	style := lipgloss.NewStyle().Foreground(m.palette().GutterText()).Background(m.editorBackground()).Width(width)
-	if rowIndex >= len(gutter.Entries) {
+	if rowIndex < 0 || rowIndex >= len(gutter.Entries) {
 		return style.Render(strings.Repeat(" ", width))
 	}
 	entry := gutter.Entries[rowIndex]

--- a/go/tui/internal/ui/semantic_mouse.go
+++ b/go/tui/internal/ui/semantic_mouse.go
@@ -95,6 +95,88 @@ func (m Model) localMouse(msg tea.MouseMsg) (Model, bool) {
 	return m, true
 }
 
+func (m Model) applyPresentationScroll(msg tea.MouseMsg) Model {
+	mouse := msg.Mouse()
+	if !isWheelButton(mouse.Button) {
+		return m
+	}
+	windowID, ok := m.presentationScrollWindowAt(mouse.X, mouse.Y)
+	if !ok {
+		return m
+	}
+	window := m.windows[windowID]
+	if !window.ScrollSet || window.Scroll.ResetRequired {
+		return m
+	}
+	scroll := m.presentationScroll[windowID]
+	if scroll.contentEpoch != window.Scroll.ContentEpoch || scroll.layoutGeneration != window.Scroll.LayoutGeneration || scroll.anchorTop != window.Scroll.AnchorTop || scroll.anchorLeft != window.Scroll.AnchorLeft {
+		scroll = presentationScroll{anchorTop: window.Scroll.AnchorTop, anchorLeft: window.Scroll.AnchorLeft, contentEpoch: window.Scroll.ContentEpoch, layoutGeneration: window.Scroll.LayoutGeneration}
+	}
+	before, after := presentationPayloadOverscanBounds(window, presentationVisibleRows(window))
+	switch mouse.Button {
+	case tea.MouseWheelDown:
+		if mouse.Mod.Contains(tea.ModShift) {
+			scroll.colOffset = min(scroll.colOffset+1, maxPresentationColOffset(window))
+		} else {
+			scroll.rowOffset = min(scroll.rowOffset+1, after)
+		}
+	case tea.MouseWheelUp:
+		if mouse.Mod.Contains(tea.ModShift) {
+			scroll.colOffset = max(scroll.colOffset-1, minPresentationColOffset(window))
+		} else {
+			scroll.rowOffset = max(scroll.rowOffset-1, -before)
+		}
+	case tea.MouseWheelRight:
+		scroll.colOffset = min(scroll.colOffset+1, maxPresentationColOffset(window))
+	case tea.MouseWheelLeft:
+		scroll.colOffset = max(scroll.colOffset-1, minPresentationColOffset(window))
+	}
+	if scroll.rowOffset == 0 && scroll.colOffset == 0 {
+		delete(m.presentationScroll, windowID)
+	} else {
+		m.presentationScroll[windowID] = scroll
+	}
+	return m
+}
+
+func maxPresentationColOffset(window protocol.WindowContent) int {
+	return maxPresentationLeft(window) - int(window.ScrollLeft)
+}
+
+func minPresentationColOffset(window protocol.WindowContent) int {
+	return -int(window.ScrollLeft)
+}
+
+func maxPresentationLeft(window protocol.WindowContent) int {
+	textWidth := int(window.Geometry.TextRect.Width)
+	if textWidth <= 0 {
+		textWidth = int(window.Geometry.ContentRect.Width)
+	}
+	textWidth = max(textWidth, 1)
+	maxRowWidth := 0
+	for _, row := range window.Rows {
+		maxRowWidth = max(maxRowWidth, displayWidth(row.Text))
+	}
+	return max(maxRowWidth-textWidth, 0)
+}
+
+func (m Model) presentationScrollWindowAt(x int, y int) (uint16, bool) {
+	return m.presentationScrollWindowAtBody(x-m.leftChromeWidth(), y-m.renderedHeaderHeight)
+}
+
+func (m Model) presentationScrollWindowAtBody(x int, y int) (uint16, bool) {
+	for _, id := range m.windowOrder {
+		placement, ok := m.semanticWindowPlacement(m.windows[id])
+		if !ok {
+			continue
+		}
+		if y >= placement.row && y < placement.row+placement.height && x >= placement.col && x < placement.col+placement.width {
+			return id, true
+		}
+	}
+	return 0, false
+}
+
 func (m Model) mouseInBottomPanel(y int) bool {
 	// The bottom panel is composited at its BEAM placement rect now (#2281), not
 	// footer-appended, so its on-screen band comes from the placement, not from a

--- a/go/tui/internal/ui/semantic_state.go
+++ b/go/tui/internal/ui/semantic_state.go
@@ -45,7 +45,7 @@ func guideColumnVisible(guides protocol.IndentGuides, col int) bool {
 }
 
 func guideEnabledOnRow(guides protocol.IndentGuides, rowIndex int, col int) bool {
-	if len(guides.IndentLevels) == 0 || rowIndex >= len(guides.IndentLevels) || guides.TabWidth == 0 {
+	if len(guides.IndentLevels) == 0 || rowIndex < 0 || rowIndex >= len(guides.IndentLevels) || guides.TabWidth == 0 {
 		return true
 	}
 	return col/int(guides.TabWidth) <= int(guides.IndentLevels[rowIndex])

--- a/lib/minga/render_model/window/scroll_presentation.ex
+++ b/lib/minga/render_model/window/scroll_presentation.ex
@@ -55,8 +55,11 @@ defmodule Minga.RenderModel.Window.ScrollPresentation do
   def from_window(%Window{geometry: nil}), do: nil
 
   def from_window(%Window{geometry: %PaneGeometry{} = geometry} = window) do
-    {visible_start_line, visible_end_line} =
-      visible_line_range(window.rows, geometry.viewport.top)
+    {overscan_start_line, overscan_end_line} =
+      line_range(window.rows, geometry.viewport.top)
+
+    visible_start_line = max(geometry.viewport.top, overscan_start_line)
+    visible_end_line = min(visible_start_line + geometry.viewport.rows, overscan_end_line)
 
     %__MODULE__{
       window_id: window.window_id,
@@ -66,17 +69,17 @@ defmodule Minga.RenderModel.Window.ScrollPresentation do
       anchor_visual_row_offset: geometry.viewport.visual_row_offset,
       visible_start_line: visible_start_line,
       visible_end_line: visible_end_line,
-      overscan_start_line: visible_start_line,
-      overscan_end_line: visible_end_line,
+      overscan_start_line: overscan_start_line,
+      overscan_end_line: overscan_end_line,
       content_epoch: window.content_epoch,
       layout_generation: layout_generation(geometry)
     }
   end
 
-  @spec visible_line_range([Row.t()], non_neg_integer()) :: {non_neg_integer(), non_neg_integer()}
-  defp visible_line_range([], fallback_line), do: {fallback_line, fallback_line}
+  @spec line_range([Row.t()], non_neg_integer()) :: {non_neg_integer(), non_neg_integer()}
+  defp line_range([], fallback_line), do: {fallback_line, fallback_line}
 
-  defp visible_line_range(rows, _fallback_line) do
+  defp line_range(rows, _fallback_line) do
     {first, last} =
       Enum.reduce(rows, {nil, nil}, fn %Row{buf_line: line}, {min_line, max_line} ->
         {min_line(min_line, line), max_line(max_line, line)}

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -162,15 +162,38 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     # Build visual rows from the same data the draw path uses. Unchanged rows
     # are reused from the retained-row cache (no recompose) when their cheap
     # input fingerprint matches; only composed rows count as rasterized (#2287).
+    all_visual_entries =
+      build_visual_entries(
+        lines,
+        first_line,
+        visible_line_map,
+        wrap_on,
+        ctx,
+        snapshot,
+        retain_ctx
+      )
+
+    visible_row_start_index = scroll.visible_row_start_index + viewport.visual_row_offset
+    payload_overscan_before = max(scroll.visible_row_start_index - viewport.visual_row_offset, 0)
+
     visual_entries =
-      lines
-      |> build_visual_entries(first_line, visible_line_map, wrap_on, ctx, snapshot, retain_ctx)
-      |> trim_visual_entries(viewport.visual_row_offset, visible_row_count)
+      trim_visual_entries(all_visual_entries, visible_row_start_index, visible_row_count)
 
-    {new_retained, rasterized} = retained_stats(visual_entries, retain_ctx)
-    new_retained_wrap = retained_wrap_lines(visual_entries, wrap_on and visible_line_map == nil)
+    presentation_entries =
+      presentation_visual_entries(
+        all_visual_entries,
+        visible_row_start_index,
+        visible_row_count,
+        payload_overscan_before
+      )
 
-    visual_rows = Enum.map(visual_entries, & &1.row)
+    {new_retained, rasterized} = retained_stats(presentation_entries, retain_ctx)
+
+    new_retained_wrap =
+      retained_wrap_lines(presentation_entries, wrap_on and visible_line_map == nil)
+
+    presentation_rows = Enum.map(presentation_entries, & &1.row)
+    committed_rows = Enum.map(visual_entries, & &1.row)
     wrapped_coordinates? = wrap_on and visible_line_map == nil
 
     # Cursor in display coordinates
@@ -197,7 +220,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
         display_cursor_row,
         display_cursor_col,
         cursor_shape,
-        visual_rows
+        committed_rows
       )
 
     # Hide the editor cursor when the minibuffer has focus (command, search,
@@ -271,7 +294,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       window_id: win_id,
       content_kind: content_kind,
       rect: rect,
-      rows: visual_rows,
+      rows: presentation_rows,
       cursor_row: display_cursor_row,
       cursor_col: display_cursor_col,
       cursor_shape: cursor_shape,
@@ -282,7 +305,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       diagnostic_ranges: diagnostic_ranges,
       document_highlights: doc_highlights,
       annotations: annotations,
-      gutter: build_gutter(scroll, ctx, content_kind, visual_entries),
+      gutter: build_gutter(scroll, ctx, content_kind, presentation_entries),
       cursorline: build_cursorline(content_row, display_cursor_row, is_active, ctx),
       indent_guides: build_indent_guides(scroll, ctx, content_kind),
       geometry: geometry,
@@ -349,6 +372,20 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       {^input_hash, %Row{} = cached} -> {cached, input_hash, true}
       _ -> {compose_fun.(), input_hash, false}
     end
+  end
+
+  @spec presentation_visual_entries(
+          [visual_row_entry()],
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [visual_row_entry()]
+  defp presentation_visual_entries(entries, visible_start, visible_count, overscan_before) do
+    before_count = min(visible_start, overscan_before)
+    start = visible_start - before_count
+    count = visible_count + before_count + 1
+
+    trim_visual_entries(entries, start, count)
   end
 
   @spec retained_stats([visual_row_entry()], retain_ctx()) ::
@@ -1813,7 +1850,11 @@ defmodule MingaEditor.RenderModel.Window.Builder do
 
   defp build_indent_guides(%WindowScroll{} = scroll, %Context{} = ctx, :buffer) do
     if indent_guides_enabled?() do
-      lines = Enum.take(scroll.lines, Viewport.content_rows(scroll.viewport))
+      lines =
+        scroll.lines
+        |> Enum.drop(scroll.visible_row_start_index)
+        |> Enum.take(Viewport.content_rows(scroll.viewport))
+
       {guides, levels} = IndentGuide.compute_with_levels(lines, ctx.tab_width, ctx.cursor_col)
       indent_guides_from_guides(scroll.win_id, ctx.tab_width, guides, levels)
     else

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -377,16 +377,21 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         {first_line, nil}
       end
 
-    # Fetch buffer data: need to cover all visible buffer lines
-    {fetch_first, fetch_count} =
+    # Fetch one stable row above/below simple mappings so clients can presentation-scroll without inventing rows.
+    {fetch_first, fetch_count, visible_row_start_index} =
       case visible_line_map do
         nil ->
-          fetch_rows = if wrap_on, do: visible_rows + div(visible_rows, 2), else: visible_rows
-          {first_line, fetch_rows}
+          {overscan_before, fetch_first} = scroll_overscan_before(first_line, wrap_on)
+
+          overscan_after =
+            scroll_overscan_after(first_line, visible_rows, line_count_approx, wrap_on)
+
+          fetch_rows = scroll_fetch_rows(visible_rows, overscan_before, overscan_after, wrap_on)
+          {fetch_first, fetch_rows, overscan_before}
 
         entries ->
           {buf_first, buf_last} = buffer_range_from_entries(entries)
-          {buf_first, buf_last - buf_first + 1}
+          {buf_first, buf_last - buf_first + 1, 0}
       end
 
     snapshot = Buffer.render_snapshot(window.buffer, fetch_first, fetch_count)
@@ -397,7 +402,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         wrap_on: wrap_on,
         is_active: is_active,
         viewport: viewport,
-        first_line: first_line,
+        first_line: fetch_first,
         lines: lines,
         snapshot: snapshot,
         buf: window.buffer,
@@ -465,9 +470,32 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
       width_oracle: width_oracle,
       git_signs: ContentHelpers.signs_for_window(state, window),
       visible_line_map: visible_line_map,
-      total_visual_rows: total_visual_rows
+      total_visual_rows: total_visual_rows,
+      visible_row_start_index: visible_row_start_index
     }
   end
+
+  @spec scroll_overscan_before(non_neg_integer(), boolean()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp scroll_overscan_before(first_line, true), do: {0, first_line}
+  defp scroll_overscan_before(0, false), do: {0, 0}
+  defp scroll_overscan_before(first_line, false), do: {1, first_line - 1}
+
+  @spec scroll_overscan_after(non_neg_integer(), pos_integer(), non_neg_integer(), boolean()) ::
+          non_neg_integer()
+  defp scroll_overscan_after(_first_line, _visible_rows, _line_count, true), do: 0
+
+  defp scroll_overscan_after(first_line, visible_rows, line_count, false) do
+    if first_line + visible_rows < line_count, do: 1, else: 0
+  end
+
+  @spec scroll_fetch_rows(pos_integer(), non_neg_integer(), non_neg_integer(), boolean()) ::
+          pos_integer()
+  defp scroll_fetch_rows(visible_rows, _before, _after, true),
+    do: visible_rows + div(visible_rows, 2)
+
+  defp scroll_fetch_rows(visible_rows, before_count, after_count, false),
+    do: visible_rows + before_count + after_count
 
   @spec total_visual_rows_for_frontend(
           state(),

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -69,6 +69,7 @@ defmodule MingaEditor.RenderPipeline.Scroll do
       git_signs: %{},
       visible_line_map: nil,
       total_visual_rows: nil,
+      visible_row_start_index: 0,
       content_epoch: 0,
       full_refresh: true
     ]
@@ -97,6 +98,7 @@ defmodule MingaEditor.RenderPipeline.Scroll do
             visible_line_map:
               [VisibleLines.line_entry()] | [MingaEditor.DisplayMap.entry()] | nil,
             total_visual_rows: non_neg_integer() | nil,
+            visible_row_start_index: non_neg_integer(),
             content_epoch: non_neg_integer(),
             full_refresh: boolean()
           }

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -298,6 +298,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Create the editor view.
         let nsView = EditorNSView(encoder: enc, fontFace: face, dispatcher: disp,
                                    coreTextRenderer: ctRenderer, fontManager: fm)
+        disp.onScrollPresentationReset = { [weak nsView] in
+            nsView?.resetSmoothScrollState()
+        }
         nsView.guiState = appState.gui
         nsView.statusBarState = appState.gui.statusBarState
         appState.gui.settingsState.encoder = enc

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -74,6 +74,10 @@ final class CommandDispatcher {
     /// Called when line_spacing changes, so EditorNSView can trigger a resize.
     var onLineSpacingChanged: ((Float) -> Void)?
 
+    /// Called when a reset-required scroll presentation is promoted into GUI state.
+    /// The editor view uses this to discard local smooth-scroll state once per frame.
+    var onScrollPresentationReset: (() -> Void)?
+
     /// Called when the BEAM changes the GUI cursor animation preference.
     var onCursorAnimationChanged: ((Bool) -> Void)?
 
@@ -250,6 +254,10 @@ final class CommandDispatcher {
             apply(staged)
         }
 
+        if openBaseFrameSeq == 0 {
+            pruneAuthoritativeFrameState(liveWindowIds: liveWindowIds(from: stagedCommands))
+        }
+
         // Record the clean commit and clear the transaction.
         lastCommittedFrameSeq = frameSeq
         hasCommitted = true
@@ -283,6 +291,51 @@ final class CommandDispatcher {
         }
 
         return (found, [])
+    }
+
+    private func pruneAuthoritativeFrameState(liveWindowIds: Set<UInt16>) {
+        guiState.windowContents = Dictionary(uniqueKeysWithValues: guiState.windowContents.filter { liveWindowIds.contains($0.key) })
+        frameState.windowGutters = Dictionary(uniqueKeysWithValues: frameState.windowGutters.filter { liveWindowIds.contains($0.key) })
+        frameState.windowIndentGuides = Dictionary(uniqueKeysWithValues: frameState.windowIndentGuides.filter { liveWindowIds.contains($0.key) })
+        currentFrameWindowIds = liveWindowIds
+        refreshDerivedGutterStateAfterPrune()
+    }
+
+    private func refreshDerivedGutterStateAfterPrune() {
+        guard let activeGutter = frameState.windowGutters.values.filter(\.isActive).sorted(by: { $0.windowId < $1.windowId }).first else {
+            frameState.gutterCol = 0
+            frameState.viewportTopLine = 0xFFFF_FFFF
+            return
+        }
+
+        frameState.gutterCol = UInt16(activeGutter.lineNumberWidth) + UInt16(activeGutter.signColWidth)
+        frameState.viewportTopLine = activeGutter.entries.first?.bufLine ?? 0xFFFF_FFFF
+    }
+
+    private func liveWindowIds(from commands: [RenderCommand]) -> Set<UInt16> {
+        var ids = Set<UInt16>()
+        ids.reserveCapacity(commands.count)
+
+        for command in commands {
+            switch command {
+            case .guiWindowContent(let data):
+                ids.insert(data.windowId)
+            case .guiWindowOverlayDelta(let data):
+                ids.insert(data.windowId)
+            case .guiWindowViewportDelta(let data):
+                ids.insert(data.windowId)
+            case .guiWindowRowsDelta(let data):
+                ids.insert(data.windowId)
+            case .guiGutter(let data):
+                ids.insert(data.windowId)
+            case .guiIndentGuides(let data):
+                ids.insert(data.windowId)
+            default:
+                continue
+            }
+        }
+
+        return ids
     }
 
     private static func missingThemeSlots(in slots: [(UInt8, UInt8, UInt8, UInt8)]) -> [UInt8] {
@@ -563,6 +616,9 @@ final class CommandDispatcher {
         case .guiWindowContent(let data):
             guiState.windowContents[data.windowId] = data
             currentFrameWindowIds.insert(data.windowId)
+            if data.scrollPresentation?.resetRequired == true {
+                onScrollPresentationReset?()
+            }
             // BEAM controls cursor visibility per window. When the minibuffer
             // or other overlay has focus, cursor_visible is false.
             frameState.cursorVisible = data.cursorVisible
@@ -584,6 +640,9 @@ final class CommandDispatcher {
             }
             guiState.windowContents[delta.windowId] = updated
             currentFrameWindowIds.insert(delta.windowId)
+            if updated.scrollPresentation?.resetRequired == true {
+                onScrollPresentationReset?()
+            }
             frameState.cursorVisible = delta.cursorVisible
             frameState.dirty = true
 

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -449,9 +449,10 @@ final class CoreTextMetalRenderer {
 
         // Gutter spacing: left margin for breathing room, right padding before separator.
         // The sign column is always reserved (2 cell widths) for consistent layout.
-        let gutterLeftMarginPt: Float = frameState.gutterCol > 0 ? round(Float(Self.gutterLeftMarginPt) * scale) / scale : 0
+        let hasGutterChrome = frameState.gutterCol > 0 || !frameState.windowGutters.isEmpty
+        let gutterLeftMarginPt: Float = hasGutterChrome ? round(Float(Self.gutterLeftMarginPt) * scale) / scale : 0
         let gutterLeftMarginPx = gutterLeftMarginPt * scale
-        let gutterPaddingPt: Float = frameState.gutterCol > 0 ? round(Float(Self.gutterRightGapPt) * scale) / scale : 0
+        let gutterPaddingPt: Float = hasGutterChrome ? round(Float(Self.gutterRightGapPt) * scale) / scale : 0
         let gutterPaddingPx = gutterPaddingPt * scale
 
         let resolvedCursor = CoreTextMetalRenderer.resolveCursor(
@@ -490,7 +491,12 @@ final class CoreTextMetalRenderer {
                     scrollOffsetPx: smoothScrollOffsetPx
                 )
                 let windowRowOffset = Float(paneGeometry?.textRect.row ?? gutter.contentRow) * displayCellH * scale
-                let scrollableWindowRowOffset = windowRowOffset - windowScrollOffsetPx.y
+                let presentationScrollOffsetPx = CoreTextMetalRenderer.presentationScrollOffset(
+                    scrollLeft: content.scrollLeft,
+                    scrollOffsetPx: windowScrollOffsetPx
+                )
+                let scrollableWindowRowOffset = windowRowOffset - presentationScrollOffsetPx.y
+                let scrollableWindowColOffset = presentationScrollOffsetPx.x
                 let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
                 let textCol = Float(paneGeometry?.textRect.col ?? fallbackTextCol)
                 let contentColOffset = textCol * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
@@ -503,15 +509,25 @@ final class CoreTextMetalRenderer {
                     viewportWidth: Float(viewportSize.width)
                 )
                 let contentRightPx = windowBounds.x + windowBounds.width
+                let contentTopPx = Float(paneGeometry?.textRect.row ?? gutter.contentRow) * displayCellH * scale
+                let overscanBeforeRows = CoreTextMetalRenderer.presentationOverscanBeforeRows(content)
+                let committedVisibleRows = CoreTextMetalRenderer.committedVisibleRows(
+                    paneGeometry: paneGeometry,
+                    gutter: gutter,
+                    fallback: max(content.rows.count - overscanBeforeRows, 0)
+                )
+                let contentBottomPx = min(contentTopPx + Float(committedVisibleRows) * displayCellH * scale, Float(viewportSize.height))
 
                 if let cursorline = content.cursorline, cursorline.bg != 0 {
                     let yPos = scrollableWindowRowOffset + Float(cursorline.row) * displayCellH * scale
-                    var clQuad = QuadGPU()
-                    clQuad.position = SIMD2<Float>(windowBounds.x, yPos)
-                    clQuad.size = SIMD2<Float>(windowBounds.width, displayCellH * scale)
-                    clQuad.color = colorFromU24(cursorline.bg, default: defaultBg)
-                    clQuad.alpha = 1.0
-                    bgQuads.append(clQuad)
+                    if let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: yPos, height: displayCellH * scale, top: contentTopPx, bottom: contentBottomPx) {
+                        var clQuad = QuadGPU()
+                        clQuad.position = SIMD2<Float>(windowBounds.x, clipped.y)
+                        clQuad.size = SIMD2<Float>(windowBounds.width, clipped.height)
+                        clQuad.color = colorFromU24(cursorline.bg, default: defaultBg)
+                        clQuad.alpha = 1.0
+                        bgQuads.append(clQuad)
+                    }
                 }
 
                 // Horizontal scroll: shift line textures and overlays left by scrollLeft columns.
@@ -533,12 +549,15 @@ final class CoreTextMetalRenderer {
                     appendSelectionQuads(
                         selection: sel,
                         rowOffset: scrollableWindowRowOffset,
-                        colOffset: contentColOffset,
+                        colOffset: contentColOffset - scrollableWindowColOffset,
                         scrollLeft: scrollLeftInt,
-                        visibleRows: content.rows.count,
+                        visibleRows: committedVisibleRows,
                         visibleCols: contentCols,
                         cellW: cellW, cellH: displayCellH, scale: scale,
                         viewportWidth: contentRightPx,
+                        clipLeft: contentColOffset,
+                        clipTop: contentTopPx,
+                        clipBottom: contentBottomPx,
                         quads: &semanticOverlayQuads
                     )
                 }
@@ -550,15 +569,16 @@ final class CoreTextMetalRenderer {
                     // Document highlights are typically single-line (one identifier).
                     // Draw on startRow only; multi-row highlights are rare for this feature.
                     let hlY = scrollableWindowRowOffset + Float(highlight.startRow) * displayCellH * scale
-                    let rawHlX = contentColOffset + Float(highlight.startCol) * cellW * scale - hScrollPx
+                    let rawHlX = contentColOffset + Float(highlight.startCol) * cellW * scale - hScrollPx - scrollableWindowColOffset
                     let rawHlRight = rawHlX + Float(highlight.endCol - highlight.startCol) * cellW * scale
                     let hlX = max(rawHlX, contentColOffset)
                     let hlRight = min(rawHlRight, contentRightPx)
-                    guard hlRight > hlX else { continue }
+                    guard hlRight > hlX,
+                          let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: hlY, height: displayCellH * scale, top: contentTopPx, bottom: contentBottomPx) else { continue }
 
                     var quad = QuadGPU()
-                    quad.position = SIMD2<Float>(hlX, hlY)
-                    quad.size = SIMD2<Float>(hlRight - hlX, displayCellH * scale)
+                    quad.position = SIMD2<Float>(hlX, clipped.y)
+                    quad.size = SIMD2<Float>(hlRight - hlX, clipped.height)
                     // Write references get a warmer amber tint; read/text get a subtle blue-gray.
                     // Colors are driven by the theme via ThemeColors slots 0x59/0x5A.
                     quad.color = highlight.kind == .write
@@ -572,15 +592,16 @@ final class CoreTextMetalRenderer {
                 for match in content.searchMatches {
                     guard match.endCol > match.startCol else { continue }
                     let matchY = scrollableWindowRowOffset + Float(match.row) * displayCellH * scale
-                    let rawMatchX = contentColOffset + Float(match.startCol) * cellW * scale - hScrollPx
+                    let rawMatchX = contentColOffset + Float(match.startCol) * cellW * scale - hScrollPx - scrollableWindowColOffset
                     let rawMatchRight = rawMatchX + Float(match.endCol - match.startCol) * cellW * scale
                     let matchX = max(rawMatchX, contentColOffset)
                     let matchRight = min(rawMatchRight, contentRightPx)
-                    guard matchRight > matchX else { continue }
+                    guard matchRight > matchX,
+                          let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: matchY, height: displayCellH * scale, top: contentTopPx, bottom: contentBottomPx) else { continue }
 
                     var quad = QuadGPU()
-                    quad.position = SIMD2<Float>(matchX, matchY)
-                    quad.size = SIMD2<Float>(matchRight - matchX, displayCellH * scale)
+                    quad.position = SIMD2<Float>(matchX, clipped.y)
+                    quad.size = SIMD2<Float>(matchRight - matchX, clipped.height)
                     quad.color = match.isCurrent
                         ? SIMD3<Float>(0.95, 0.75, 0.0)    // current match: gold
                         : SIMD3<Float>(0.35, 0.35, 0.15)   // other matches: dim gold
@@ -593,11 +614,14 @@ final class CoreTextMetalRenderer {
                 // so each texture is at most viewport-wide. Fixes gutter bleedthrough
                 // (no leftward position shift) and text truncation (texture always
                 // covers the visible portion).
+                let localScrollInsetCols = scrollLeftInt > 0 ? 1 : 0
+                let localClipScrollLeft = max(scrollLeftInt - localScrollInsetCols, 0)
+                let localClipXOffset = Float(localScrollInsetCols) * cellW * scale
                 var clippedRows: [GUIVisualRow] = []
                 clippedRows.reserveCapacity(content.rows.count)
                 for row in content.rows {
                     clippedRows.append(
-                        wcr.clipRowToViewport(row, scrollLeft: scrollLeftInt, viewportCols: contentCols)
+                        wcr.clipRowToViewport(row, scrollLeft: localClipScrollLeft, viewportCols: contentCols + 2)
                     )
                 }
 
@@ -606,16 +630,32 @@ final class CoreTextMetalRenderer {
                 for (rowIdx, clippedRow) in clippedRows.enumerated() {
                     let displayRow = UInt16(rowIdx)
                     if let atlas, let entry = wcr.renderRowToAtlas(displayRow: displayRow, row: clippedRow, windowId: content.windowId, contentEpoch: content.contentEpoch, atlas: atlas, metrics: &frameMetrics) {
-                        rowEntriesByRow[displayRow] = entry
-                        let yPos = scrollableWindowRowOffset + Float(rowIdx) * displayCellH * scale
+                        let presentationRow = rowIdx - overscanBeforeRows
+                        if presentationRow >= 0 && presentationRow < committedVisibleRows {
+                            rowEntriesByRow[UInt16(presentationRow)] = entry
+                        }
+                        let yPos = scrollableWindowRowOffset + Float(presentationRow) * displayCellH * scale
                         let textYOffset = (displayCellH - cellH) * scale * 0.5
 
                         let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
+                        let rawLineX = contentColOffset - localClipXOffset - scrollableWindowColOffset
+                        let clippedLeftPx = max(contentColOffset - rawLineX, 0)
+                        let lineX = max(rawLineX, contentColOffset)
+                        let visiblePixelWidth = min(Float(entry.pixelWidth) - clippedLeftPx, contentRightPx - lineX)
+                        let rawLineY = yPos + textYOffset
+                        let clippedTopPx = max(contentTopPx - rawLineY, 0)
+                        let lineY = max(rawLineY, contentTopPx)
+                        let visiblePixelHeight = min(Float(entry.pixelHeight) - clippedTopPx, contentBottomPx - lineY)
+                        guard visiblePixelWidth > 0, visiblePixelHeight > 0 else { continue }
+                        let visibleUVX = uvOrigin.x + uvSize.x * clippedLeftPx / Float(entry.pixelWidth)
+                        let visibleUVWidth = uvSize.x * visiblePixelWidth / Float(entry.pixelWidth)
+                        let visibleUVY = uvOrigin.y + uvSize.y * clippedTopPx / Float(entry.pixelHeight)
+                        let visibleUVHeight = uvSize.y * visiblePixelHeight / Float(entry.pixelHeight)
                         var lineGPU = LineGPU()
-                        lineGPU.position = SIMD2<Float>(contentColOffset, yPos + textYOffset)
-                        lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
-                        lineGPU.uvOrigin = uvOrigin
-                        lineGPU.uvSize = uvSize
+                        lineGPU.position = SIMD2<Float>(lineX, lineY)
+                        lineGPU.size = SIMD2<Float>(visiblePixelWidth, visiblePixelHeight)
+                        lineGPU.uvOrigin = SIMD2<Float>(visibleUVX, visibleUVY)
+                        lineGPU.uvSize = SIMD2<Float>(visibleUVWidth, visibleUVHeight)
                         lineInstances.append(lineGPU)
                     }
                 }
@@ -630,8 +670,9 @@ final class CoreTextMetalRenderer {
                     for (rowIndex, rowAnnotations) in annotationsByRow {
                         let linePixelWidth = Float(rowEntriesByRow[rowIndex]?.pixelWidth ?? 0)
                         let rowY = scrollableWindowRowOffset + Float(rowIndex) * displayCellH * scale
-                        var cursorX = contentColOffset + linePixelWidth
-                            + Float(wcr.annotationGap) * scale
+                        guard let clippedRow = CoreTextMetalRenderer.clipVerticalQuad(y: rowY, height: displayCellH * scale, top: contentTopPx, bottom: contentBottomPx) else { continue }
+                        var cursorX = max(contentColOffset, contentColOffset - scrollableWindowColOffset + linePixelWidth
+                            + Float(wcr.annotationGap) * scale)
 
                         for (annIdx, ann) in rowAnnotations.enumerated() {
                             let annKey = AtlasKey.lineAnnotation(windowId: content.windowId, row: rowIndex, subIndex: UInt16(min(annIdx, Int(UInt16.max))))
@@ -643,13 +684,20 @@ final class CoreTextMetalRenderer {
                             let (uvOrigin, uvSize) = atlas.uvForSlot(annEntry.slotIndex, pixelWidth: annEntry.pixelWidth)
                             let visiblePixelWidth = min(Float(annEntry.pixelWidth), contentRightPx - cursorX)
                             guard visiblePixelWidth > 0 else { continue }
+                            let rawLineY = rowY
+                        let clippedTopPx = max(contentTopPx - rawLineY, 0)
+                            let visiblePixelHeight = min(Float(annEntry.pixelHeight) - clippedTopPx, contentBottomPx - rawLineY)
+                            guard visiblePixelHeight > 0 else { continue }
+                            let visibleUVX = uvOrigin.x
                             let visibleUVWidth = uvSize.x * visiblePixelWidth / Float(annEntry.pixelWidth)
+                            let visibleUVY = uvOrigin.y + uvSize.y * clippedTopPx / Float(annEntry.pixelHeight)
+                            let visibleUVHeight = uvSize.y * visiblePixelHeight / Float(annEntry.pixelHeight)
 
                             var lineGPU = LineGPU()
-                            lineGPU.position = SIMD2<Float>(cursorX, rowY)
-                            lineGPU.size = SIMD2<Float>(visiblePixelWidth, Float(annEntry.pixelHeight))
-                            lineGPU.uvOrigin = uvOrigin
-                            lineGPU.uvSize = SIMD2<Float>(visibleUVWidth, uvSize.y)
+                            lineGPU.position = SIMD2<Float>(cursorX, clippedRow.y)
+                            lineGPU.size = SIMD2<Float>(visiblePixelWidth, visiblePixelHeight)
+                            lineGPU.uvOrigin = SIMD2<Float>(visibleUVX, visibleUVY)
+                            lineGPU.uvSize = SIMD2<Float>(visibleUVWidth, visibleUVHeight)
                             lineInstances.append(lineGPU)
 
                             cursorX += Float(annEntry.pixelWidth) + Float(wcr.annotationSpacing) * scale
@@ -668,15 +716,16 @@ final class CoreTextMetalRenderer {
                     }
 
                     let diagY = scrollableWindowRowOffset + Float(diag.startRow) * displayCellH * scale + displayCellH * scale - 2.0 * scale
-                    let rawDiagX = contentColOffset + Float(diag.startCol) * cellW * scale - hScrollPx
+                    let rawDiagX = contentColOffset + Float(diag.startCol) * cellW * scale - hScrollPx - scrollableWindowColOffset
                     let rawDiagRight = rawDiagX + Float(diag.endCol - diag.startCol) * cellW * scale
                     let diagX = max(rawDiagX, contentColOffset)
                     let diagRight = min(rawDiagRight, contentRightPx)
-                    guard diagRight > diagX else { continue }
+                    guard diagRight > diagX,
+                          let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: diagY, height: 2.0 * scale, top: contentTopPx, bottom: contentBottomPx) else { continue }
 
                     var quad = QuadGPU()
-                    quad.position = SIMD2<Float>(diagX, diagY)
-                    quad.size = SIMD2<Float>(diagRight - diagX, 2.0 * scale)
+                    quad.position = SIMD2<Float>(diagX, clipped.y)
+                    quad.size = SIMD2<Float>(diagRight - diagX, clipped.height)
                     quad.color = diagColor
                     quad.alpha = 1.0
                     diagnosticQuads.append(quad)
@@ -702,6 +751,7 @@ final class CoreTextMetalRenderer {
                     targetWindowId: scrollTargetWindowId,
                     scrollOffsetPx: smoothScrollOffsetPx
                 ).y,
+                overscanBeforeRows: windowContents[windowGutter.windowId].map(CoreTextMetalRenderer.presentationOverscanBeforeRows) ?? CoreTextMetalRenderer.scrollOverscanBefore(windowContents[windowGutter.windowId]?.scrollPresentation),
                 bgQuads: &bgQuads,
                 lineInstances: &lineInstances
             )
@@ -764,30 +814,38 @@ final class CoreTextMetalRenderer {
                 viewportWidth: Float(viewportSize.width)
             )
             let contentRightPx = windowBounds.x + windowBounds.width
-            let guideScrollOffsetY = CoreTextMetalRenderer.smoothScrollOffset(
-                for: guideData.windowId,
-                targetWindowId: scrollTargetWindowId,
-                scrollOffsetPx: smoothScrollOffsetPx
-            ).y
-            let contentTopY = Float(gutter.contentRow) * displayCellH * scale - guideScrollOffsetY
             let lineCellH = displayCellH * scale
-
             let inactiveFg = colorFromU24(frameState.gutterColors.fg, default: SIMD3<Float>(0.33, 0.33, 0.33))
             let tabW = max(UInt16(guideData.tabWidth), 1)
+            let guideScrollLeft = windowContents[guideData.windowId]?.scrollLeft ?? 0
+            let guideScrollOffset = CoreTextMetalRenderer.presentationScrollOffset(
+                scrollLeft: guideScrollLeft,
+                scrollOffsetPx: CoreTextMetalRenderer.smoothScrollOffset(
+                    for: guideData.windowId,
+                    targetWindowId: scrollTargetWindowId,
+                    scrollOffsetPx: smoothScrollOffsetPx
+                )
+            )
+            let guideScrollOffsetY = guideScrollOffset.y
+            let guideScrollOffsetX = guideScrollOffset.x
+            let guideTopY = Float(paneGeometry?.textRect.row ?? gutter.contentRow) * displayCellH * scale
+            let guideHeightPx = Float(max(Int(paneGeometry?.textRect.height ?? gutter.contentHeight), 0)) * lineCellH
+            let guideBottomY = min(guideTopY + guideHeightPx, Float(viewportSize.height))
+            let textRightPx = contentRightPx
 
             var guideQuads: [QuadGPU] = []
 
             if guideData.lineIndentLevels.isEmpty {
-                let contentHeightPx = Float(gutter.contentHeight) * displayCellH * scale
                 guideQuads.reserveCapacity(guideData.guideCols.count)
+                let baseY = guideTopY - guideScrollOffsetY
                 for col in guideData.guideCols {
-                    let guideX = windowContentColOffset + Float(col) * cellW * scale
-                    let guideWidth = min(1.0 * scale, contentRightPx - guideX)
-                    guard guideWidth > 0 else { continue }
+                    let guideX = windowContentColOffset - guideScrollOffsetX + Float(col) * cellW * scale
+                    guard let vertical = CoreTextMetalRenderer.clipVerticalQuad(y: baseY, height: guideHeightPx, top: guideTopY, bottom: guideBottomY),
+                          let horizontal = CoreTextMetalRenderer.clipHorizontalRect(x: guideX, width: 1.0 * scale, left: windowContentColOffset, right: textRightPx) else { continue }
                     let isActive = col == guideData.activeGuideCol
                     var quad = QuadGPU()
-                    quad.position = SIMD2<Float>(guideX, contentTopY)
-                    quad.size = SIMD2<Float>(guideWidth, contentHeightPx)
+                    quad.position = SIMD2<Float>(horizontal.x, vertical.y)
+                    quad.size = SIMD2<Float>(horizontal.width, vertical.height)
                     quad.color = inactiveFg
                     quad.alpha = isActive ? 0.4 : 0.15
                     guideQuads.append(quad)
@@ -795,18 +853,18 @@ final class CoreTextMetalRenderer {
             } else {
                 guideQuads.reserveCapacity(guideData.guideCols.count * guideData.lineIndentLevels.count)
                 for (lineIdx, level) in guideData.lineIndentLevels.enumerated() {
-                    let lineY = contentTopY + Float(lineIdx) * lineCellH
+                    let lineY = guideTopY + Float(lineIdx) * lineCellH - guideScrollOffsetY
                     for col in guideData.guideCols {
                         let guideLevel = col / tabW
                         // Strict < so guides appear only in whitespace, not at the text-start column.
                         guard guideLevel < level else { continue }
-                        let guideX = windowContentColOffset + Float(col) * cellW * scale
-                        let guideWidth = min(1.0 * scale, contentRightPx - guideX)
-                        guard guideWidth > 0 else { continue }
+                        let guideX = windowContentColOffset - guideScrollOffsetX + Float(col) * cellW * scale
+                        guard let vertical = CoreTextMetalRenderer.clipVerticalQuad(y: lineY, height: lineCellH, top: guideTopY, bottom: guideBottomY),
+                              let horizontal = CoreTextMetalRenderer.clipHorizontalRect(x: guideX, width: 1.0 * scale, left: windowContentColOffset, right: textRightPx) else { continue }
                         let isActive = col == guideData.activeGuideCol
                         var quad = QuadGPU()
-                        quad.position = SIMD2<Float>(guideX, lineY)
-                        quad.size = SIMD2<Float>(guideWidth, lineCellH)
+                        quad.position = SIMD2<Float>(horizontal.x, vertical.y)
+                        quad.size = SIMD2<Float>(horizontal.width, vertical.height)
                         quad.color = inactiveFg
                         quad.alpha = isActive ? 0.4 : 0.15
                         guideQuads.append(quad)
@@ -833,25 +891,64 @@ final class CoreTextMetalRenderer {
         // For block cursors, draw the cursor bg here so the text pass composites over it.
         // Beam and underline cursors are drawn AFTER text (pass 5).
         if let renderCursor, cursorBlinkVisible, renderCursor.shape == .block {
-            let cursorScrollOffsetPx = CoreTextMetalRenderer.smoothScrollOffset(
-                for: renderCursor.windowId,
-                targetWindowId: scrollTargetWindowId,
-                scrollOffsetPx: smoothScrollOffsetPx
+            let cursorScrollLeft = renderCursor.windowId.flatMap { windowContents[$0]?.scrollLeft } ?? 0
+            let cursorScrollOffsetPx = CoreTextMetalRenderer.presentationScrollOffset(
+                scrollLeft: cursorScrollLeft,
+                scrollOffsetPx: CoreTextMetalRenderer.smoothScrollOffset(
+                    for: renderCursor.windowId,
+                    targetWindowId: scrollTargetWindowId,
+                    scrollOffsetPx: smoothScrollOffsetPx
+                )
             )
             let cursorX = renderCursor.x - cursorScrollOffsetPx.x
             let cursorY = renderCursor.y - cursorScrollOffsetPx.y
             var cursorQuad = QuadGPU()
-            cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cursorX), CoreTextMetalRenderer.snapToPixel(cursorY))
-            cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cellW * scale), CoreTextMetalRenderer.snapToPixel(displayCellH * scale))
+            let cursorWidth = CoreTextMetalRenderer.snapToPixel(cellW * scale)
+            let cursorHeight = CoreTextMetalRenderer.snapToPixel(displayCellH * scale)
+            let cursorWindowBounds = renderCursor.windowId.flatMap { windowId -> (x: Float, width: Float)? in
+                guard let gutter = frameState.windowGutters[windowId] else { return nil }
+                return CoreTextMetalRenderer.cursorHorizontalBounds(
+                    geometry: windowContents[windowId]?.paneGeometry,
+                    gutter: gutter,
+                    frameCols: frameState.cols,
+                    cellW: cellW,
+                    scale: scale,
+                    gutterLeftMarginPx: gutterLeftMarginPx,
+                    gutterPaddingPx: gutterPaddingPx,
+                    viewportWidth: Float(viewportSize.width)
+                )
+            }
+            let cursorBounds = CoreTextMetalRenderer.paneVerticalBounds(
+                for: renderCursor.windowId,
+                windowContents: windowContents,
+                gutters: frameState.windowGutters,
+                displayCellH: displayCellH,
+                scale: scale,
+                viewportHeight: Float(viewportSize.height)
+            )
+            var shouldDrawCursor = true
+            if let cursorWindowBounds, let cursorBounds {
+                if let horizontal = CoreTextMetalRenderer.clipHorizontalRect(x: cursorX, width: cursorWidth, left: cursorWindowBounds.x, right: cursorWindowBounds.x + cursorWindowBounds.width), let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: cursorY, height: cursorHeight, top: cursorBounds.top, bottom: cursorBounds.bottom) {
+                    cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(horizontal.x), CoreTextMetalRenderer.snapToPixel(clipped.y))
+                    cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(horizontal.width), CoreTextMetalRenderer.snapToPixel(clipped.height))
+                } else {
+                    shouldDrawCursor = false
+                }
+            } else {
+                cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cursorX), CoreTextMetalRenderer.snapToPixel(cursorY))
+                cursorQuad.size = SIMD2<Float>(cursorWidth, cursorHeight)
+            }
             cursorQuad.color = cursorColor
             cursorQuad.alpha = 1.0
 
-            var cursorBgParams = BgParamsGPU(cornerRadius: 0.0)
-            encoder.setRenderPipelineState(bgPipeline)
-            encoder.setVertexBytes(&cursorQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
-            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
-            encoder.setFragmentBytes(&cursorBgParams, length: MemoryLayout<BgParamsGPU>.size, index: 0)
-            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+            if shouldDrawCursor {
+                var cursorBgParams = BgParamsGPU(cornerRadius: 0.0)
+                encoder.setRenderPipelineState(bgPipeline)
+                encoder.setVertexBytes(&cursorQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
+                encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+                encoder.setFragmentBytes(&cursorBgParams, length: MemoryLayout<BgParamsGPU>.size, index: 0)
+                encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+            }
 
             // Restore default (no rounding) for subsequent draws.
             encoder.setFragmentBytes(&defaultBgParams, length: MemoryLayout<BgParamsGPU>.size, index: 0)
@@ -880,47 +977,21 @@ final class CoreTextMetalRenderer {
             drawQuadBatches(diagnosticQuads, encoder: encoder, uniforms: &uniforms)
         }
 
-        // Pass 4: Gutter gap fills (left margin + right padding).
-        let totalGutterExtraPx = gutterLeftMarginPx + gutterPaddingPx
-        if frameState.gutterCol > 0 && totalGutterExtraPx > 0 {
-            // Left margin fill: from window edge to the start of gutter content.
-            if gutterLeftMarginPx > 0 {
-                var leftFill = QuadGPU()
-                leftFill.position = SIMD2<Float>(0, 0)
-                leftFill.size = SIMD2<Float>(gutterLeftMarginPx, Float(viewportSize.height))
-                leftFill.color = defaultBg
-                leftFill.alpha = 1.0
-                encoder.setRenderPipelineState(bgPipeline)
-                encoder.setVertexBytes(&leftFill, length: MemoryLayout<QuadGPU>.stride, index: 0)
-                encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
-                encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
-            }
-
-            // Right padding fill: between gutter columns and content separator.
-            var rightFill = QuadGPU()
-            rightFill.position = SIMD2<Float>(Float(frameState.gutterCol) * cellW * scale + gutterLeftMarginPx, 0)
-            rightFill.size = SIMD2<Float>(gutterPaddingPx, Float(viewportSize.height))
-            rightFill.color = defaultBg
-            rightFill.alpha = 1.0
+        // Pass 4/5: Gutter gap fills and separator lines.
+        let gutterChromeQuads = CoreTextMetalRenderer.gutterChromeQuads(
+            frameState: frameState,
+            cellW: cellW,
+            cellH: displayCellH,
+            scale: scale,
+            gutterLeftMarginPx: gutterLeftMarginPx,
+            gutterPaddingPx: gutterPaddingPx,
+            viewportHeight: Float(viewportSize.height),
+            defaultBg: defaultBg,
+            separatorColor: colorFromU24(frameState.gutterSeparatorColor, default: SIMD3<Float>(0.3, 0.3, 0.3))
+        )
+        if !gutterChromeQuads.isEmpty {
             encoder.setRenderPipelineState(bgPipeline)
-            encoder.setVertexBytes(&rightFill, length: MemoryLayout<QuadGPU>.stride, index: 0)
-            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
-            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
-        }
-
-        // Pass 5: Gutter separator line.
-        if frameState.gutterCol > 0 && frameState.gutterSeparatorColor != 0 {
-            var sepQuad = QuadGPU()
-            let sepX = (Float(frameState.gutterCol) * cellW + gutterLeftMarginPt + gutterPaddingPt) * scale - 1.0
-            sepQuad.position = SIMD2<Float>(sepX, 0)
-            sepQuad.size = SIMD2<Float>(1.0, Float(viewportSize.height))
-            sepQuad.color = colorFromU24(frameState.gutterSeparatorColor, default: SIMD3<Float>(0.3, 0.3, 0.3))
-            sepQuad.alpha = 1.0
-
-            encoder.setRenderPipelineState(bgPipeline)
-            encoder.setVertexBytes(&sepQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
-            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
-            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+            drawQuadBatches(gutterChromeQuads, encoder: encoder, uniforms: &uniforms)
         }
 
         // Pass 5.5: Split separators (vertical lines between split panes,
@@ -975,27 +1046,24 @@ final class CoreTextMetalRenderer {
                         let centerX = hX + (hW - labelW) * 0.5
                         let labelY = Float(horiz.row) * displayCellH * scale
 
-                        // Small bg fill behind label so it "breaks" the horizontal line
+                        // Small bg fill behind label so it "breaks" the horizontal line.
+                        // Clip it to the separator rect so labels in narrow horizontal splits never erase neighboring panes.
                         let padPx: Float = 4.0 * scale
-                        var labelBg = QuadGPU()
-                        labelBg.position = SIMD2<Float>(centerX - padPx, hY - 1)
-                        labelBg.size = SIMD2<Float>(labelW + padPx * 2, 3.0)
-                        labelBg.color = defaultBg
-                        labelBg.alpha = 1.0
-                        encoder.setRenderPipelineState(bgPipeline)
-                        encoder.setVertexBytes(&labelBg, length: MemoryLayout<QuadGPU>.stride, index: 0)
-                        encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
-                        encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+                        if let labelBgBounds = CoreTextMetalRenderer.clipHorizontalRect(x: centerX - padPx, width: labelW + padPx * 2, left: hX, right: hX + hW) {
+                            var labelBg = QuadGPU()
+                            labelBg.position = SIMD2<Float>(labelBgBounds.x, hY - 1)
+                            labelBg.size = SIMD2<Float>(labelBgBounds.width, 3.0)
+                            labelBg.color = defaultBg
+                            labelBg.alpha = 1.0
+                            encoder.setRenderPipelineState(bgPipeline)
+                            encoder.setVertexBytes(&labelBg, length: MemoryLayout<QuadGPU>.stride, index: 0)
+                            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+                            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+                        }
 
                         // Render the label texture immediately. The main line texture pass has already run by the time split separators are drawn, so queuing this into lineInstances would leave only the background gap visible.
                         let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
-                        var lineGPU = LineGPU()
-                        lineGPU.position = SIMD2<Float>(centerX, labelY)
-                        lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
-                        lineGPU.uvOrigin = uvOrigin
-                        lineGPU.uvSize = uvSize
-
-                        if let atlasTexture = atlas.texture {
+                        if var lineGPU = CoreTextMetalRenderer.clippedHorizontalLineGPU(x: centerX, y: labelY, width: Float(entry.pixelWidth), height: Float(entry.pixelHeight), uvOrigin: uvOrigin, uvSize: uvSize, clipLeft: hX, clipRight: hX + hW), let atlasTexture = atlas.texture {
                             encoder.setRenderPipelineState(linePipeline)
                             encoder.setVertexBytes(&lineGPU, length: MemoryLayout<LineGPU>.stride, index: 0)
                             encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
@@ -1011,16 +1079,43 @@ final class CoreTextMetalRenderer {
         // Block cursor is drawn in pass 2 (before text) so text shows on top.
         // Beam and underline are drawn AFTER text so they overlay it.
         if let renderCursor, cursorBlinkVisible, renderCursor.shape != .block {
-            let cursorScrollOffsetPx = CoreTextMetalRenderer.smoothScrollOffset(
-                for: renderCursor.windowId,
-                targetWindowId: scrollTargetWindowId,
-                scrollOffsetPx: smoothScrollOffsetPx
+            let cursorScrollLeft = renderCursor.windowId.flatMap { windowContents[$0]?.scrollLeft } ?? 0
+            let cursorScrollOffsetPx = CoreTextMetalRenderer.presentationScrollOffset(
+                scrollLeft: cursorScrollLeft,
+                scrollOffsetPx: CoreTextMetalRenderer.smoothScrollOffset(
+                    for: renderCursor.windowId,
+                    targetWindowId: scrollTargetWindowId,
+                    scrollOffsetPx: smoothScrollOffsetPx
+                )
             )
             let cursorX = renderCursor.x - cursorScrollOffsetPx.x
             let cursorY = renderCursor.y - cursorScrollOffsetPx.y
+            let cursorWindowBounds = renderCursor.windowId.flatMap { windowId -> (x: Float, width: Float)? in
+                guard let gutter = frameState.windowGutters[windowId] else { return nil }
+                return CoreTextMetalRenderer.cursorHorizontalBounds(
+                    geometry: windowContents[windowId]?.paneGeometry,
+                    gutter: gutter,
+                    frameCols: frameState.cols,
+                    cellW: cellW,
+                    scale: scale,
+                    gutterLeftMarginPx: gutterLeftMarginPx,
+                    gutterPaddingPx: gutterPaddingPx,
+                    viewportWidth: Float(viewportSize.width)
+                )
+            }
             var cursorQuad = QuadGPU()
             cursorQuad.color = cursorColor
             cursorQuad.alpha = 1.0
+            var shouldDrawCursor = true
+
+            let cursorBounds = CoreTextMetalRenderer.paneVerticalBounds(
+                for: renderCursor.windowId,
+                windowContents: windowContents,
+                gutters: frameState.windowGutters,
+                displayCellH: displayCellH,
+                scale: scale,
+                viewportHeight: Float(viewportSize.height)
+            )
 
             switch renderCursor.shape {
             case .block:
@@ -1028,20 +1123,41 @@ final class CoreTextMetalRenderer {
 
             case .beam:
                 let beamWidth: Float = 2.0 * scale
-                cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cursorX), CoreTextMetalRenderer.snapToPixel(cursorY))
-                cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(beamWidth), CoreTextMetalRenderer.snapToPixel(displayCellH * scale))
+                let beamHeight = CoreTextMetalRenderer.snapToPixel(displayCellH * scale)
+                if let cursorWindowBounds, let cursorBounds {
+                    if let horizontal = CoreTextMetalRenderer.clipHorizontalRect(x: cursorX, width: beamWidth, left: cursorWindowBounds.x, right: cursorWindowBounds.x + cursorWindowBounds.width), let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: cursorY, height: beamHeight, top: cursorBounds.top, bottom: cursorBounds.bottom) {
+                        cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(horizontal.x), CoreTextMetalRenderer.snapToPixel(clipped.y))
+                        cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(horizontal.width), CoreTextMetalRenderer.snapToPixel(clipped.height))
+                    } else {
+                        shouldDrawCursor = false
+                    }
+                } else {
+                    cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cursorX), CoreTextMetalRenderer.snapToPixel(cursorY))
+                    cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(beamWidth), beamHeight)
+                }
 
             case .underline:
                 let ulHeight: Float = 2.0 * scale
                 let cellBottom = cursorY + displayCellH * scale
-                cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cursorX), CoreTextMetalRenderer.snapToPixel(cellBottom - ulHeight))
-                cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cellW * scale), CoreTextMetalRenderer.snapToPixel(ulHeight))
+                if let cursorWindowBounds, let cursorBounds {
+                    if let horizontal = CoreTextMetalRenderer.clipHorizontalRect(x: cursorX, width: cellW * scale, left: cursorWindowBounds.x, right: cursorWindowBounds.x + cursorWindowBounds.width), let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: cellBottom - ulHeight, height: ulHeight, top: cursorBounds.top, bottom: cursorBounds.bottom) {
+                        cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(horizontal.x), CoreTextMetalRenderer.snapToPixel(clipped.y))
+                        cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(horizontal.width), CoreTextMetalRenderer.snapToPixel(clipped.height))
+                    } else {
+                        shouldDrawCursor = false
+                    }
+                } else {
+                    cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cursorX), CoreTextMetalRenderer.snapToPixel(cellBottom - ulHeight))
+                    cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cellW * scale), CoreTextMetalRenderer.snapToPixel(ulHeight))
+                }
             }
 
-            encoder.setRenderPipelineState(bgPipeline)
-            encoder.setVertexBytes(&cursorQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
-            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
-            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+            if shouldDrawCursor {
+                encoder.setRenderPipelineState(bgPipeline)
+                encoder.setVertexBytes(&cursorQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
+                encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+                encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+            }
         }
 
         // Pass 7: Scroll indicator (overlay scrollbar).
@@ -1123,6 +1239,7 @@ final class CoreTextMetalRenderer {
         gutterHoverWindowId: UInt16?,
         gutterHoverRow: UInt16?,
         scrollOffsetY: Float,
+        overscanBeforeRows: Int,
         bgQuads: inout [QuadGPU],
         lineInstances: inout [LineGPU]
     ) {
@@ -1130,17 +1247,26 @@ final class CoreTextMetalRenderer {
         let baseRow = gutter.contentRow
         let baseCol = gutter.contentCol
 
+        let clipTop = Float(gutter.contentRow) * cellH * scale
+        let clipBottom = Float(gutter.contentRow + gutter.contentHeight) * cellH * scale
+
         for (rowIndex, entry) in gutter.entries.enumerated() {
-            let screenRow = baseRow + UInt16(rowIndex)
-            let yPos = Float(screenRow) * cellH * scale - scrollOffsetY
+            let presentationRow = rowIndex - overscanBeforeRows
+            let screenRowInt = Int(baseRow) + presentationRow
+            let screenRow = UInt16(clamping: screenRowInt)
+            let atlasRow = UInt16(clamping: rowIndex)
+            let rowY = (Float(baseRow) + Float(presentationRow)) * cellH * scale - scrollOffsetY
+            guard CoreTextMetalRenderer.clipVerticalQuad(y: rowY, height: cellH * scale, top: clipTop, bottom: clipBottom) != nil else { continue }
+            let yPos = rowY
             let xOffset = Float(baseCol) * cellW * scale + gutterLeftMarginPx
 
             // Sign column (leftmost in gutter)
             if signColWidth > 0 {
                 renderGutterSign(
-                    entry: entry, windowId: gutter.windowId, screenRow: screenRow, yPos: yPos, xOffset: xOffset,
+                    entry: entry, windowId: gutter.windowId, atlasRow: atlasRow, yPos: yPos, xOffset: xOffset,
                     cellW: cellW, cellH: cellH, scale: scale,
                     frameState: frameState,
+                    clipTop: clipTop, clipBottom: clipBottom,
                     bgQuads: &bgQuads, lineInstances: &lineInstances,
                 )
             }
@@ -1148,7 +1274,7 @@ final class CoreTextMetalRenderer {
             // Fold indicator (dedicated cell after the diagnostic/git sign column)
             if signColWidth >= 3 {
                 appendFoldRangeHighlight(
-                    entry: entry, rowIndex: rowIndex, screenRow: screenRow, yPos: yPos,
+                    entry: entry, presentationRow: presentationRow, screenRow: screenRow, yPos: yPos,
                     gutter: gutter, xOffset: xOffset,
                     signColWidth: signColWidth,
                     cellW: cellW, cellH: cellH, scale: scale,
@@ -1157,6 +1283,7 @@ final class CoreTextMetalRenderer {
                     gutterHoverWindowId: gutterHoverWindowId,
                     gutterHoverRow: gutterHoverRow,
                     frameState: frameState,
+                    clipTop: clipTop, clipBottom: clipBottom,
                     bgQuads: &bgQuads,
                 )
 
@@ -1168,6 +1295,7 @@ final class CoreTextMetalRenderer {
                     gutterHoverWindowId: gutterHoverWindowId,
                     gutter: gutter,
                     frameState: frameState,
+                    clipTop: clipTop, clipBottom: clipBottom,
                     bgQuads: &bgQuads,
                 )
             }
@@ -1176,14 +1304,47 @@ final class CoreTextMetalRenderer {
             if gutter.lineNumberStyle != .none && gutter.lineNumberWidth > 0 && shouldRenderLineNumber(for: entry) {
                 renderGutterLineNumber(
                     entry: entry, gutter: gutter,
-                    screenRow: screenRow, yPos: yPos, xOffset: xOffset,
+                    atlasRow: atlasRow, yPos: yPos, xOffset: xOffset,
                     signColWidth: signColWidth,
                     cellW: cellW, cellH: cellH, scale: scale,
                     frameState: frameState,
+                    clipTop: clipTop, clipBottom: clipBottom,
                     lineInstances: &lineInstances,
                 )
             }
         }
+    }
+
+    private func appendClippedGutterQuad(
+        x: Float, y: Float, width: Float, height: Float,
+        color: SIMD3<Float>, alpha: Float,
+        clipTop: Float, clipBottom: Float,
+        quads: inout [QuadGPU]
+    ) {
+        guard let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: y, height: height, top: clipTop, bottom: clipBottom) else { return }
+        var quad = QuadGPU()
+        quad.position = SIMD2<Float>(x, clipped.y)
+        quad.size = SIMD2<Float>(width, clipped.height)
+        quad.color = color
+        quad.alpha = alpha
+        quads.append(quad)
+    }
+
+    private func appendClippedGutterLine(
+        x: Float, y: Float, width: Float, height: Float,
+        uvOrigin: SIMD2<Float>, uvSize: SIMD2<Float>,
+        clipTop: Float, clipBottom: Float,
+        lineInstances: inout [LineGPU]
+    ) {
+        guard let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: y, height: height, top: clipTop, bottom: clipBottom) else { return }
+        let topRatio = height > 0 ? (clipped.y - y) / height : 0
+        let visibleRatio = height > 0 ? clipped.height / height : 0
+        var lineGPU = LineGPU()
+        lineGPU.position = SIMD2<Float>(x, clipped.y)
+        lineGPU.size = SIMD2<Float>(width, clipped.height)
+        lineGPU.uvOrigin = SIMD2<Float>(uvOrigin.x, uvOrigin.y + uvSize.y * topRatio)
+        lineGPU.uvSize = SIMD2<Float>(uvSize.x, uvSize.y * visibleRatio)
+        lineInstances.append(lineGPU)
     }
 
     /// Renders a git or diagnostic sign for one gutter row.
@@ -1192,72 +1353,48 @@ final class CoreTextMetalRenderer {
     /// using Metal quads. Diagnostic signs (E/W/I/H) are rendered as
     /// CTLine textures in the diagnostic color.
     private func renderGutterSign(
-        entry: Wire.GutterEntry, windowId: UInt16, screenRow: UInt16, yPos: Float, xOffset: Float,
+        entry: Wire.GutterEntry, windowId: UInt16, atlasRow: UInt16, yPos: Float, xOffset: Float,
         cellW: Float, cellH: Float, scale: Float,
         frameState: FrameState,
+        clipTop: Float, clipBottom: Float,
         bgQuads: inout [QuadGPU],
         lineInstances: inout [LineGPU],
     ) {
         switch entry.signType {
         case .gitAdded:
-            var quad = QuadGPU()
             let gitBarWidth = round(3.0 * scale)
-            quad.position = SIMD2<Float>(xOffset, yPos)
-            quad.size = SIMD2<Float>(gitBarWidth, cellH * scale)
-            quad.color = gutterSignColor(entry.signType, frameState: frameState)
-            quad.alpha = 1.0
-            bgQuads.append(quad)
+            appendClippedGutterQuad(x: xOffset, y: yPos, width: gitBarWidth, height: cellH * scale, color: gutterSignColor(entry.signType, frameState: frameState), alpha: 1.0, clipTop: clipTop, clipBottom: clipBottom, quads: &bgQuads)
 
         case .gitModified:
-            var quad = QuadGPU()
             let gitBarWidth = round(3.0 * scale)
-            quad.position = SIMD2<Float>(xOffset, yPos)
-            quad.size = SIMD2<Float>(gitBarWidth, cellH * scale)
-            quad.color = gutterSignColor(entry.signType, frameState: frameState)
-            quad.alpha = 1.0
-            bgQuads.append(quad)
+            appendClippedGutterQuad(x: xOffset, y: yPos, width: gitBarWidth, height: cellH * scale, color: gutterSignColor(entry.signType, frameState: frameState), alpha: 1.0, clipTop: clipTop, clipBottom: clipBottom, quads: &bgQuads)
 
         case .gitDeleted:
-            var quad = QuadGPU()
             let barHeight = round(2.0 * scale)
-            quad.position = SIMD2<Float>(xOffset, yPos + cellH * scale - barHeight)
-            quad.size = SIMD2<Float>(cellW * 2 * scale, barHeight)
-            quad.color = gutterSignColor(entry.signType, frameState: frameState)
-            quad.alpha = 1.0
-            bgQuads.append(quad)
+            appendClippedGutterQuad(x: xOffset, y: yPos + cellH * scale - barHeight, width: cellW * 2 * scale, height: barHeight, color: gutterSignColor(entry.signType, frameState: frameState), alpha: 1.0, clipTop: clipTop, clipBottom: clipBottom, quads: &bgQuads)
 
         case .gitRemoved, .diagError, .diagWarning, .diagInfo, .diagHint, .diagAdvisory:
             let (text, fg) = gutterTextSignAndColor(entry.signType, frameState: frameState)
-            let cacheKey = AtlasKey.diagnosticSign(windowId: windowId, row: screenRow)
+            let cacheKey = AtlasKey.diagnosticSign(windowId: windowId, row: atlasRow)
             let contentHash = gutterContentHash(text: text, fg: fg)
             if let atlas, let wcr = windowContentRenderer,
                let entry = wcr.renderSimpleText(text, fg: fg, bold: true,
                                                  key: cacheKey, contentHash: contentHash, atlas: atlas, metrics: &frameMetrics) {
                 let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
-                var lineGPU = LineGPU()
-                lineGPU.position = SIMD2<Float>(xOffset, yPos)
-                lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
-                lineGPU.uvOrigin = uvOrigin
-                lineGPU.uvSize = uvSize
-                lineInstances.append(lineGPU)
+                appendClippedGutterLine(x: xOffset, y: yPos, width: Float(entry.pixelWidth), height: Float(entry.pixelHeight), uvOrigin: uvOrigin, uvSize: uvSize, clipTop: clipTop, clipBottom: clipBottom, lineInstances: &lineInstances)
             }
 
         case .annotation:
             // Render annotation icon text with the annotation's custom fg color.
             let text = entry.signText.isEmpty ? "●" : entry.signText
             let fg = entry.signFg
-            let cacheKey = AtlasKey.annotationIcon(windowId: windowId, row: screenRow)
+            let cacheKey = AtlasKey.annotationIcon(windowId: windowId, row: atlasRow)
             let contentHash = gutterContentHash(text: text, fg: fg)
             if let atlas, let wcr = windowContentRenderer,
                let atlasEntry = wcr.renderSimpleText(text, fg: fg, bold: false,
                                                       key: cacheKey, contentHash: contentHash, atlas: atlas, metrics: &frameMetrics) {
                 let (uvOrigin, uvSize) = atlas.uvForSlot(atlasEntry.slotIndex, pixelWidth: atlasEntry.pixelWidth)
-                var lineGPU = LineGPU()
-                lineGPU.position = SIMD2<Float>(xOffset, yPos)
-                lineGPU.size = SIMD2<Float>(Float(atlasEntry.pixelWidth), Float(atlasEntry.pixelHeight))
-                lineGPU.uvOrigin = uvOrigin
-                lineGPU.uvSize = uvSize
-                lineInstances.append(lineGPU)
+                appendClippedGutterLine(x: xOffset, y: yPos, width: Float(atlasEntry.pixelWidth), height: Float(atlasEntry.pixelHeight), uvOrigin: uvOrigin, uvSize: uvSize, clipTop: clipTop, clipBottom: clipBottom, lineInstances: &lineInstances)
             }
 
         case .none:
@@ -1267,7 +1404,7 @@ final class CoreTextMetalRenderer {
 
     /// Draws a subtle range highlight while hovering an unfolded fold chevron.
     private func appendFoldRangeHighlight(
-        entry: Wire.GutterEntry, rowIndex: Int, screenRow: UInt16, yPos: Float,
+        entry: Wire.GutterEntry, presentationRow: Int, screenRow: UInt16, yPos: Float,
         gutter: Wire.WindowGutter, xOffset: Float,
         signColWidth: Int,
         cellW: Float, cellH: Float, scale: Float,
@@ -1276,6 +1413,7 @@ final class CoreTextMetalRenderer {
         gutterHoverWindowId: UInt16?,
         gutterHoverRow: UInt16?,
         frameState: FrameState,
+        clipTop: Float, clipBottom: Float,
         bgQuads: inout [QuadGPU],
     ) {
         guard gutterHoverWindowId == gutter.windowId else { return }
@@ -1284,7 +1422,7 @@ final class CoreTextMetalRenderer {
         guard let foldEndLine = entry.foldEndLine, foldEndLine > entry.bufLine else { return }
 
         let rowsInRange = Int(foldEndLine - entry.bufLine + 1)
-        let visibleRows = max(0, min(rowsInRange, Int(gutter.contentHeight) - rowIndex))
+        let visibleRows = max(0, min(rowsInRange, Int(gutter.contentHeight) - presentationRow))
         guard visibleRows > 0 else { return }
 
         let gutterWidth = Float(gutter.lineNumberWidth) + Float(signColWidth)
@@ -1293,12 +1431,7 @@ final class CoreTextMetalRenderer {
         let width = max(0, min(windowRightX, viewportWidthPx) - contentX)
         guard width > 0 else { return }
 
-        var quad = QuadGPU()
-        quad.position = SIMD2<Float>(contentX, yPos)
-        quad.size = SIMD2<Float>(width, Float(visibleRows) * cellH * scale)
-        quad.color = colorFromU24(frameState.gutterColors.foldFg, default: SIMD3<Float>(0.33, 0.33, 0.33))
-        quad.alpha = 0.10
-        bgQuads.append(quad)
+        appendClippedGutterQuad(x: contentX, y: yPos, width: width, height: Float(visibleRows) * cellH * scale, color: colorFromU24(frameState.gutterColors.foldFg, default: SIMD3<Float>(0.33, 0.33, 0.33)), alpha: 0.10, clipTop: clipTop, clipBottom: clipBottom, quads: &bgQuads)
     }
 
     /// Renders the fold indicator for one gutter row as a path-style chevron.
@@ -1310,6 +1443,7 @@ final class CoreTextMetalRenderer {
         gutterHoverWindowId: UInt16?,
         gutter: Wire.WindowGutter,
         frameState: FrameState,
+        clipTop: Float, clipBottom: Float,
         bgQuads: inout [QuadGPU],
     ) {
         let collapsed: Bool
@@ -1333,18 +1467,18 @@ final class CoreTextMetalRenderer {
         let lineWidth = max(1.0, round(1.5 * scale))
 
         if collapsed {
-            appendChevronSegment(from: SIMD2<Float>(centerX - half * 0.35, centerY - half), to: SIMD2<Float>(centerX + half * 0.35, centerY), lineWidth: lineWidth, color: color, quads: &bgQuads)
-            appendChevronSegment(from: SIMD2<Float>(centerX + half * 0.35, centerY), to: SIMD2<Float>(centerX - half * 0.35, centerY + half), lineWidth: lineWidth, color: color, quads: &bgQuads)
+            appendChevronSegment(from: SIMD2<Float>(centerX - half * 0.35, centerY - half), to: SIMD2<Float>(centerX + half * 0.35, centerY), lineWidth: lineWidth, color: color, clipTop: clipTop, clipBottom: clipBottom, quads: &bgQuads)
+            appendChevronSegment(from: SIMD2<Float>(centerX + half * 0.35, centerY), to: SIMD2<Float>(centerX - half * 0.35, centerY + half), lineWidth: lineWidth, color: color, clipTop: clipTop, clipBottom: clipBottom, quads: &bgQuads)
         } else {
-            appendChevronSegment(from: SIMD2<Float>(centerX - half, centerY - half * 0.25), to: SIMD2<Float>(centerX, centerY + half * 0.45), lineWidth: lineWidth, color: color, quads: &bgQuads)
-            appendChevronSegment(from: SIMD2<Float>(centerX, centerY + half * 0.45), to: SIMD2<Float>(centerX + half, centerY - half * 0.25), lineWidth: lineWidth, color: color, quads: &bgQuads)
+            appendChevronSegment(from: SIMD2<Float>(centerX - half, centerY - half * 0.25), to: SIMD2<Float>(centerX, centerY + half * 0.45), lineWidth: lineWidth, color: color, clipTop: clipTop, clipBottom: clipBottom, quads: &bgQuads)
+            appendChevronSegment(from: SIMD2<Float>(centerX, centerY + half * 0.45), to: SIMD2<Float>(centerX + half, centerY - half * 0.25), lineWidth: lineWidth, color: color, clipTop: clipTop, clipBottom: clipBottom, quads: &bgQuads)
         }
     }
 
     /// Approximates a diagonal chevron stroke with overlapping square Metal quads.
     private func appendChevronSegment(
         from start: SIMD2<Float>, to end: SIMD2<Float>, lineWidth: Float,
-        color: SIMD3<Float>, quads: inout [QuadGPU]
+        color: SIMD3<Float>, clipTop: Float, clipBottom: Float, quads: inout [QuadGPU]
     ) {
         let delta = end - start
         let length = max(1.0, sqrt(delta.x * delta.x + delta.y * delta.y))
@@ -1353,12 +1487,7 @@ final class CoreTextMetalRenderer {
         for index in 0...steps {
             let t = Float(index) / Float(steps)
             let point = start + delta * t
-            var quad = QuadGPU()
-            quad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(point.x - lineWidth * 0.5), CoreTextMetalRenderer.snapToPixel(point.y - lineWidth * 0.5))
-            quad.size = SIMD2<Float>(lineWidth, lineWidth)
-            quad.color = color
-            quad.alpha = 1.0
-            quads.append(quad)
+            appendClippedGutterQuad(x: CoreTextMetalRenderer.snapToPixel(point.x - lineWidth * 0.5), y: CoreTextMetalRenderer.snapToPixel(point.y - lineWidth * 0.5), width: lineWidth, height: lineWidth, color: color, alpha: 1.0, clipTop: clipTop, clipBottom: clipBottom, quads: &quads)
         }
     }
 
@@ -1410,10 +1539,11 @@ final class CoreTextMetalRenderer {
     /// Renders a line number for one gutter row.
     private func renderGutterLineNumber(
         entry: Wire.GutterEntry, gutter: Wire.WindowGutter,
-        screenRow: UInt16, yPos: Float, xOffset: Float,
+        atlasRow: UInt16, yPos: Float, xOffset: Float,
         signColWidth: Int,
         cellW: Float, cellH: Float, scale: Float,
         frameState: FrameState,
+        clipTop: Float, clipBottom: Float,
         lineInstances: inout [LineGPU],
     ) {
         let (numberStr, isCurrent) = gutterNumberString(
@@ -1432,19 +1562,14 @@ final class CoreTextMetalRenderer {
         let padCols = max(lnWidth - numberStr.count - 1, 0)
         let startCol = UInt16(signColWidth + padCols)
 
-        let cacheKey = AtlasKey.gutterLineNumber(windowId: gutter.windowId, row: screenRow)
+        let cacheKey = AtlasKey.gutterLineNumber(windowId: gutter.windowId, row: atlasRow)
         let contentHash = gutterContentHash(text: numberStr, fg: fg)
         if let atlas, let wcr = windowContentRenderer,
            let entry = wcr.renderSimpleText(numberStr, fg: fg,
                                              key: cacheKey, contentHash: contentHash, atlas: atlas, metrics: &frameMetrics) {
             let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
             let xPos = xOffset + Float(startCol) * cellW * scale
-            var lineGPU = LineGPU()
-            lineGPU.position = SIMD2<Float>(xPos, yPos)
-            lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
-            lineGPU.uvOrigin = uvOrigin
-            lineGPU.uvSize = uvSize
-            lineInstances.append(lineGPU)
+            appendClippedGutterLine(x: xPos, y: yPos, width: Float(entry.pixelWidth), height: Float(entry.pixelHeight), uvOrigin: uvOrigin, uvSize: uvSize, clipTop: clipTop, clipBottom: clipBottom, lineInstances: &lineInstances)
         }
     }
 
@@ -1687,6 +1812,158 @@ final class CoreTextMetalRenderer {
         return scrollOffsetPx
     }
 
+    nonisolated static func presentationScrollOffset(scrollLeft: UInt16, scrollOffsetPx: SIMD2<Float>) -> SIMD2<Float> {
+        let x = scrollLeft == 0 && scrollOffsetPx.x < 0 ? 0 : scrollOffsetPx.x
+        return SIMD2<Float>(x, scrollOffsetPx.y)
+    }
+
+    nonisolated static func scrollOverscanBefore(_ presentation: GUIScrollPresentation?) -> Int {
+        guard let presentation, presentation.visibleStartLine > presentation.overscanStartLine else { return 0 }
+        return Int(presentation.visibleStartLine - presentation.overscanStartLine)
+    }
+
+    nonisolated static func presentationOverscanBeforeRows(_ content: GUIWindowContent) -> Int {
+        presentationPayloadOverscanBeforeRows(rows: content.rows, scrollPresentation: content.scrollPresentation)
+    }
+
+    nonisolated static func presentationPayloadOverscanBeforeRows(rows: [GUIVisualRow], scrollPresentation: GUIScrollPresentation?) -> Int {
+        guard let scrollPresentation else { return 0 }
+        if let index = rows.firstIndex(where: { $0.bufLine >= scrollPresentation.visibleStartLine }) {
+            return index
+        }
+        if scrollPresentation.anchorTop != scrollPresentation.visibleStartLine,
+           let index = rows.firstIndex(where: { $0.bufLine >= scrollPresentation.anchorTop }) {
+            return index
+        }
+        return scrollOverscanBefore(scrollPresentation)
+    }
+
+    nonisolated static func gutterChromeRects(
+        frameState: FrameState,
+        cellW: Float,
+        cellH: Float,
+        scale: Float,
+        gutterLeftMarginPx: Float,
+        gutterPaddingPx: Float,
+        viewportHeight: Float
+    ) -> (leftFills: [(x: Float, y: Float, width: Float, height: Float)], rightFills: [(x: Float, y: Float, width: Float, height: Float)], separators: [(x: Float, y: Float, width: Float, height: Float)]) {
+        guard gutterLeftMarginPx > 0 || gutterPaddingPx > 0 || frameState.gutterSeparatorColor != 0 else { return ([], [], []) }
+        var leftFills: [(x: Float, y: Float, width: Float, height: Float)] = []
+        var rightFills: [(x: Float, y: Float, width: Float, height: Float)] = []
+        var separators: [(x: Float, y: Float, width: Float, height: Float)] = []
+
+        if !frameState.windowGutters.isEmpty {
+            for gutter in frameState.windowGutters.values.sorted(by: { $0.windowId < $1.windowId }) {
+                let gutterWidthCols = Int(gutter.lineNumberWidth) + Int(gutter.signColWidth)
+                guard gutterWidthCols > 0 else { continue }
+                let top = Float(gutter.contentRow) * cellH * scale
+                let height = Float(gutter.contentHeight) * cellH * scale
+                guard let vertical = clipVerticalQuad(y: top, height: height, top: 0, bottom: viewportHeight) else { continue }
+                let gutterLeftX = Float(gutter.contentCol) * cellW * scale
+                if gutterLeftMarginPx > 0 {
+                    leftFills.append((x: gutterLeftX, y: vertical.y, width: gutterLeftMarginPx, height: vertical.height))
+                }
+                let gutterRightX = Float(Int(gutter.contentCol) + gutterWidthCols) * cellW * scale + gutterLeftMarginPx
+                if gutterPaddingPx > 0 {
+                    rightFills.append((x: gutterRightX, y: vertical.y, width: gutterPaddingPx, height: vertical.height))
+                }
+                if frameState.gutterSeparatorColor != 0 {
+                    separators.append((x: gutterRightX + gutterPaddingPx - 1.0, y: vertical.y, width: 1.0, height: vertical.height))
+                }
+            }
+            return (leftFills, rightFills, separators)
+        }
+
+        guard frameState.gutterCol > 0 else { return ([], [], []) }
+        if gutterLeftMarginPx > 0 {
+            leftFills.append((x: 0, y: 0, width: gutterLeftMarginPx, height: viewportHeight))
+        }
+        if gutterPaddingPx > 0 {
+            rightFills.append((x: Float(frameState.gutterCol) * cellW * scale + gutterLeftMarginPx, y: 0, width: gutterPaddingPx, height: viewportHeight))
+        }
+        if frameState.gutterSeparatorColor != 0 {
+            let gutterLeftMarginPt = gutterLeftMarginPx / scale
+            let gutterPaddingPt = gutterPaddingPx / scale
+            separators.append((x: (Float(frameState.gutterCol) * cellW + gutterLeftMarginPt + gutterPaddingPt) * scale - 1.0, y: 0, width: 1.0, height: viewportHeight))
+        }
+        return (leftFills, rightFills, separators)
+    }
+
+    nonisolated static func gutterChromeQuads(
+        frameState: FrameState,
+        cellW: Float,
+        cellH: Float,
+        scale: Float,
+        gutterLeftMarginPx: Float,
+        gutterPaddingPx: Float,
+        viewportHeight: Float,
+        defaultBg: SIMD3<Float>,
+        separatorColor: SIMD3<Float>
+    ) -> [QuadGPU] {
+        let rects = gutterChromeRects(
+            frameState: frameState,
+            cellW: cellW,
+            cellH: cellH,
+            scale: scale,
+            gutterLeftMarginPx: gutterLeftMarginPx,
+            gutterPaddingPx: gutterPaddingPx,
+            viewportHeight: viewportHeight
+        )
+        var quads: [QuadGPU] = []
+        for rect in rects.leftFills + rects.rightFills {
+            var quad = QuadGPU()
+            quad.position = SIMD2<Float>(rect.x, rect.y)
+            quad.size = SIMD2<Float>(rect.width, rect.height)
+            quad.color = defaultBg
+            quad.alpha = 1.0
+            quads.append(quad)
+        }
+        for rect in rects.separators {
+            var quad = QuadGPU()
+            quad.position = SIMD2<Float>(rect.x, rect.y)
+            quad.size = SIMD2<Float>(rect.width, rect.height)
+            quad.color = separatorColor
+            quad.alpha = 1.0
+            quads.append(quad)
+        }
+        return quads
+    }
+
+    nonisolated static func committedVisibleRows(paneGeometry: GUIPaneGeometry?, gutter: Wire.WindowGutter, fallback: Int) -> Int {
+        if let paneGeometry {
+            let rows = Int(paneGeometry.textRect.height)
+            if rows > 0 { return rows }
+        }
+        if gutter.contentHeight > 0 {
+            return Int(gutter.contentHeight)
+        }
+        return fallback
+    }
+
+    nonisolated static func paneVerticalBounds(
+        for windowId: UInt16?,
+        windowContents: [UInt16: GUIWindowContent],
+        gutters: [UInt16: Wire.WindowGutter],
+        displayCellH: Float,
+        scale: Float,
+        viewportHeight: Float
+    ) -> (top: Float, bottom: Float)? {
+        guard let windowId else { return nil }
+        if let geometry = windowContents[windowId]?.paneGeometry {
+            let top = Float(geometry.textRect.row) * displayCellH * scale
+            let rows = max(Int(geometry.textRect.height), 0)
+            let bottom = min(top + Float(rows) * displayCellH * scale, viewportHeight)
+            return bottom > top ? (top, bottom) : nil
+        }
+        if let gutter = gutters[windowId] {
+            let top = Float(gutter.contentRow) * displayCellH * scale
+            let rows = max(Int(gutter.contentHeight), 0)
+            let bottom = min(top + Float(rows) * displayCellH * scale, viewportHeight)
+            return bottom > top ? (top, bottom) : nil
+        }
+        return nil
+    }
+
     nonisolated static func windowWidthCols(gutter: Wire.WindowGutter, frameCols: UInt16) -> Int {
         if gutter.contentWidth > 0 {
             return Int(gutter.contentWidth)
@@ -1734,6 +2011,67 @@ final class CoreTextMetalRenderer {
         let left = Float(gutter.contentCol) * cellW * scale
         let right = min(left + Float(windowWidthCols(gutter: gutter, frameCols: frameCols)) * cellW * scale, viewportWidth)
         return (x: left, width: max(right - left, 0))
+    }
+
+    nonisolated static func cursorHorizontalBounds(
+        geometry: GUIPaneGeometry?,
+        gutter: Wire.WindowGutter,
+        frameCols: UInt16,
+        cellW: Float,
+        scale: Float,
+        gutterLeftMarginPx: Float,
+        gutterPaddingPx: Float,
+        viewportWidth: Float
+    ) -> (x: Float, width: Float) {
+        let windowBounds = windowHorizontalBounds(
+            geometry: geometry,
+            gutter: gutter,
+            frameCols: frameCols,
+            cellW: cellW,
+            scale: scale,
+            viewportWidth: viewportWidth
+        )
+        let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
+        let textCol = Float(geometry?.textRect.col ?? fallbackTextCol)
+        let left = max(windowBounds.x, textCol * cellW * scale + gutterLeftMarginPx + gutterPaddingPx)
+        let right = windowBounds.x + windowBounds.width
+        return (x: left, width: max(right - left, 0))
+    }
+
+    nonisolated static func clipVerticalQuad(y: Float, height: Float, top: Float, bottom: Float) -> (y: Float, height: Float)? {
+        let clippedTop = max(y, top)
+        let clippedBottom = min(y + height, bottom)
+        guard clippedBottom > clippedTop else { return nil }
+        return (clippedTop, clippedBottom - clippedTop)
+    }
+
+    nonisolated static func clipHorizontalRect(x: Float, width: Float, left: Float, right: Float) -> (x: Float, width: Float)? {
+        let clippedLeft = max(x, left)
+        let clippedRight = min(x + width, right)
+        guard clippedRight > clippedLeft else { return nil }
+        return (clippedLeft, clippedRight - clippedLeft)
+    }
+
+    nonisolated static func clippedHorizontalLineGPU(
+        x: Float,
+        y: Float,
+        width: Float,
+        height: Float,
+        uvOrigin: SIMD2<Float>,
+        uvSize: SIMD2<Float>,
+        clipLeft: Float,
+        clipRight: Float
+    ) -> LineGPU? {
+        guard width > 0, let clipped = clipHorizontalRect(x: x, width: width, left: clipLeft, right: clipRight) else { return nil }
+        let clippedLeftPx = clipped.x - x
+        let visibleRatio = clipped.width / width
+        let leftRatio = clippedLeftPx / width
+        var lineGPU = LineGPU()
+        lineGPU.position = SIMD2<Float>(clipped.x, y)
+        lineGPU.size = SIMD2<Float>(clipped.width, height)
+        lineGPU.uvOrigin = SIMD2<Float>(uvOrigin.x + uvSize.x * leftRatio, uvOrigin.y)
+        lineGPU.uvSize = SIMD2<Float>(uvSize.x * visibleRatio, uvSize.y)
+        return lineGPU
     }
 
     nonisolated static func cursorlineHorizontalBounds(
@@ -1852,9 +2190,10 @@ final class CoreTextMetalRenderer {
     /// Insert-mode beam cursors use the insertion point exactly. Normal-mode block cursors render over a character cell, so an end-of-line insertion point must draw over the final rendered character instead of the next empty cell.
     nonisolated static func resolvedSemanticCursorCol(_ content: GUIWindowContent) -> UInt16 {
         guard content.cursorShape == .block else { return content.cursorCol }
-        guard Int(content.cursorRow) < content.rows.count else { return content.cursorCol }
+        let rowIndex = Int(content.cursorRow) + presentationOverscanBeforeRows(content)
+        guard rowIndex >= 0, rowIndex < content.rows.count else { return content.cursorCol }
 
-        let row = content.rows[Int(content.cursorRow)]
+        let row = content.rows[rowIndex]
         let width = displayWidth(row.text)
         guard width > 0, Int(content.cursorCol) >= width else { return content.cursorCol }
         return UInt16(width - 1)
@@ -1887,6 +2226,9 @@ final class CoreTextMetalRenderer {
         visibleCols: Int,
         cellW: Float, cellH: Float, scale: Float,
         viewportWidth: Float,
+        clipLeft: Float,
+        clipTop: Float,
+        clipBottom: Float,
         quads: inout [QuadGPU]
     ) {
         guard visibleRows > 0, visibleCols > 0, cellW > 0, cellH > 0, scale > 0 else {
@@ -1908,16 +2250,17 @@ final class CoreTextMetalRenderer {
         let selColor = currentThemeColors?.selectionBgSIMD ?? Self.systemSelectionColor
         let lineHeightPx = cellH * scale
         let colWidthPx = cellW * scale
-        let rightEdgePx = min(colOffset + Float(visibleCols) * colWidthPx, viewportWidth)
-        let fullLineWidthPx = max(rightEdgePx - colOffset, 0)
-        guard fullLineWidthPx > 0 else { return }
 
         switch sel.type {
         case .line:
+            let fullLineWidthPx = max(viewportWidth - clipLeft, 0)
+            guard fullLineWidthPx > 0 else { return }
             for row in startRow...endRow {
+                let y = rowOffset + Float(row) * lineHeightPx
+                guard let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: y, height: lineHeightPx, top: clipTop, bottom: clipBottom) else { continue }
                 var quad = QuadGPU()
-                quad.position = SIMD2<Float>(colOffset, rowOffset + Float(row) * lineHeightPx)
-                quad.size = SIMD2<Float>(fullLineWidthPx, lineHeightPx)
+                quad.position = SIMD2<Float>(clipLeft, clipped.y)
+                quad.size = SIMD2<Float>(fullLineWidthPx, clipped.height)
                 quad.color = selColor
                 quad.alpha = 1.0
                 quads.append(quad)
@@ -1931,10 +2274,16 @@ final class CoreTextMetalRenderer {
 
                 let visibleStartCol = Float(clampedCols.start - scrollLeft)
                 let visibleEndCol = Float(clampedCols.end - scrollLeft)
+                let rawX = colOffset + visibleStartCol * colWidthPx
+                let rawRight = colOffset + visibleEndCol * colWidthPx
+                let x = max(rawX, clipLeft)
+                let right = min(rawRight, viewportWidth)
+                guard right > x,
+                      let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: y, height: lineHeightPx, top: clipTop, bottom: clipBottom) else { continue }
 
                 var quad = QuadGPU()
-                quad.position = SIMD2<Float>(colOffset + visibleStartCol * colWidthPx, y)
-                quad.size = SIMD2<Float>((visibleEndCol - visibleStartCol) * colWidthPx, lineHeightPx)
+                quad.position = SIMD2<Float>(x, clipped.y)
+                quad.size = SIMD2<Float>(right - x, clipped.height)
                 quad.color = selColor
                 quad.alpha = 1.0
                 quads.append(quad)
@@ -1948,10 +2297,16 @@ final class CoreTextMetalRenderer {
 
                 let visibleStartCol = Float(clampedCols.start - scrollLeft)
                 let visibleEndCol = Float(clampedCols.end - scrollLeft)
+                let rawX = colOffset + visibleStartCol * colWidthPx
+                let rawRight = colOffset + visibleEndCol * colWidthPx
+                let x = max(rawX, clipLeft)
+                let right = min(rawRight, viewportWidth)
+                guard right > x,
+                      let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: y, height: lineHeightPx, top: clipTop, bottom: clipBottom) else { continue }
 
                 var quad = QuadGPU()
-                quad.position = SIMD2<Float>(colOffset + visibleStartCol * colWidthPx, y)
-                quad.size = SIMD2<Float>((visibleEndCol - visibleStartCol) * colWidthPx, lineHeightPx)
+                quad.position = SIMD2<Float>(x, clipped.y)
+                quad.size = SIMD2<Float>(right - x, clipped.height)
                 quad.color = selColor
                 quad.alpha = 1.0
                 quads.append(quad)

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -221,6 +221,7 @@ final class EditorNSView: MTKView {
     /// Cleans up window-bound observers and monitors.
     private func cleanupWindowResources() {
         cleanupBlinkResources()
+        resetSmoothScrollState()
         scrollerStyleTask?.cancel()
         scrollerStyleTask = nil
         scrollFadeWorkItem?.cancel()
@@ -335,9 +336,13 @@ final class EditorNSView: MTKView {
 
     // MARK: - Rendering
 
-    /// Sub-cell-height vertical pixel offset for smooth trackpad scrolling.
-    /// Positive = content shifted up (scrolled down). Always in [0, cellHeight).
-    private var scrollPixelOffset: CGFloat = 0
+    /// Sub-cell vertical/horizontal pixel offset for smooth trackpad scrolling.
+    /// Positive = content shifted up/left. Each component stays within one cell.
+    private var scrollPixelOffset = CGPoint(x: 0, y: 0)
+
+    /// Client-only boundary elasticity applied when the target pane is already
+    /// at the top or bottom of the committed overscan range.
+    private var scrollElasticOffsetY: CGFloat = 0
 
     /// Window receiving the current fractional smooth-scroll offset.
     /// Nil means the event location did not resolve to a scrollable editor window, so fractional offset is disabled instead of shifting every pane.
@@ -383,6 +388,8 @@ final class EditorNSView: MTKView {
             flashScrollIndicator()
         }
 
+        clearSmoothScrollStateIfTargetWindowMissing()
+
         let validGutterHoverWindowId = gutterHoverWindowId.flatMap { windowId in
             dispatcher.currentFrameWindowIds.contains(windowId) ? windowId : nil
         }
@@ -398,7 +405,7 @@ final class EditorNSView: MTKView {
                                 gutterHoverRow: validGutterHoverRow,
                                 drawable: drawable, viewportSize: drawableSize,
                                 contentScale: scale,
-                                scrollOffset: SIMD2<Float>(0, Float(scrollPixelOffset)),
+                                scrollOffset: SIMD2<Float>(Float(scrollPixelOffset.x), Float(scrollPixelOffset.y + scrollElasticOffsetY)),
                                 scrollTargetWindowId: scrollTargetWindowId)
         if coreTextRenderer.cursorAnimationGeneration != cursorAnimationGeneration {
             resetCursorBlink()
@@ -1282,6 +1289,7 @@ final class EditorNSView: MTKView {
             setDividerCursorState(.none)
         }
         clearGutterHover()
+        resetSmoothScrollState()
         super.mouseExited(with: event)
     }
 
@@ -1368,6 +1376,10 @@ final class EditorNSView: MTKView {
     }
 
     override func scrollWheel(with event: NSEvent) {
+        if event.hasPreciseScrollingDeltas && event.phase == .began {
+            finishSmoothScrollGesture()
+        }
+
         let (row, col) = cellPosition(from: event)
         let mods = modifierBits(from: event.modifierFlags)
 
@@ -1386,6 +1398,7 @@ final class EditorNSView: MTKView {
     private func handleTrackpadScroll(event: NSEvent, row: Int16, col: Int16, mods: UInt8) {
         if event.phase == .began {
             scrollAccumulator.reset()
+            scrollElasticOffsetY = 0
             scrollTargetWindowId = nil
             scrollTargetCellPosition = nil
         }
@@ -1399,14 +1412,38 @@ final class EditorNSView: MTKView {
         for e in vEvents {
             sendScrollEvent(e, row: targetCell.row, col: targetCell.col, mods: mods)
         }
-        scrollPixelOffset = scrollTargetWindowId == nil ? 0 : scrollAccumulator.pixelOffsetY
-
         // Horizontal: discrete column events
         let hEvents = scrollAccumulator.accumulateHorizontal(
             deltaX: event.scrollingDeltaX, cellWidth: cellWidth)
         for e in hEvents {
             sendScrollEvent(e, row: targetCell.row, col: targetCell.col, mods: mods)
         }
+        let targetWindowContent = scrollTargetWindowId.flatMap { guiState?.windowContents[$0] }
+        let targetScrollPresentation = targetWindowContent?.scrollPresentation
+        let payloadOverscan = Self.presentationScrollPayloadOverscanBounds(
+            for: targetWindowContent,
+            scrollPresentation: targetScrollPresentation
+        )
+        let boundaryAvailability = Self.presentationScrollBoundaryAvailability(
+            for: targetWindowContent,
+            scrollPresentation: targetScrollPresentation
+        )
+        let translation = Self.presentationScrollTranslation(
+            scrollPresentation: targetScrollPresentation,
+            scrollOffset: CGPoint(x: scrollAccumulator.pixelOffsetX, y: scrollAccumulator.pixelOffsetY),
+            scrollDeltaY: event.scrollingDeltaY,
+            currentElasticOffsetY: scrollElasticOffsetY,
+            cellHeight: effectiveCellHeight,
+            payloadOverscanBefore: payloadOverscan.before,
+            payloadOverscanAfter: payloadOverscan.after,
+            boundaryBefore: boundaryAvailability.before,
+            boundaryAfter: boundaryAvailability.after
+        )
+        if translation.scrollOffset.y == 0, translation.elasticOffsetY != 0 {
+            scrollAccumulator.snapVertical()
+        }
+        scrollPixelOffset = scrollTargetWindowId == nil ? CGPoint(x: 0, y: 0) : translation.scrollOffset
+        scrollElasticOffsetY = scrollTargetWindowId == nil ? 0 : translation.elasticOffsetY
 
         // Snap to zero when gesture/momentum ends
         if (event.phase == .ended || event.phase == .cancelled) && event.momentumPhase == [] {
@@ -1423,7 +1460,8 @@ final class EditorNSView: MTKView {
 
     private func finishSmoothScrollGesture() {
         scrollAccumulator.reset()
-        scrollPixelOffset = 0
+        scrollPixelOffset = CGPoint(x: 0, y: 0)
+        scrollElasticOffsetY = 0
         scrollTargetWindowId = nil
         scrollTargetCellPosition = nil
     }
@@ -1435,6 +1473,23 @@ final class EditorNSView: MTKView {
 
         if scrollTargetWindowId != nil && scrollTargetCellPosition == nil {
             scrollTargetCellPosition = (row, col)
+        }
+    }
+
+    func resetSmoothScrollState() {
+        scrollAccumulator.reset()
+        scrollPixelOffset = .zero
+        scrollElasticOffsetY = 0
+        scrollTargetWindowId = nil
+        scrollTargetCellPosition = nil
+        needsDisplay = true
+    }
+
+    private func clearSmoothScrollStateIfTargetWindowMissing() {
+        guard let targetWindowId = scrollTargetWindowId else { return }
+        guard dispatcher.currentFrameWindowIds.contains(targetWindowId), guiState?.windowContents[targetWindowId] != nil else {
+            resetSmoothScrollState()
+            return
         }
     }
 
@@ -1461,7 +1516,7 @@ final class EditorNSView: MTKView {
         guard Self.shouldResetSmoothScrollTarget(
             currentTargetWindowId: scrollTargetWindowId,
             pointerWindowId: pointerWindowId,
-            pixelOffset: scrollPixelOffset
+            hasPixelOffset: Self.hasActivePresentationOffset(scrollPixelOffset: scrollPixelOffset, scrollElasticOffsetY: scrollElasticOffsetY)
         ) else { return }
 
         resetSmoothScrollOffsetPreservingTarget()
@@ -1470,13 +1525,132 @@ final class EditorNSView: MTKView {
 
     private func resetSmoothScrollOffsetPreservingTarget() {
         scrollAccumulator.reset()
-        scrollPixelOffset = 0
+        scrollPixelOffset = CGPoint(x: 0, y: 0)
+        scrollElasticOffsetY = 0
     }
 
-    nonisolated static func shouldResetSmoothScrollTarget(currentTargetWindowId: UInt16?, pointerWindowId: UInt16?, pixelOffset: CGFloat) -> Bool {
-        guard pixelOffset != 0 else { return false }
+    nonisolated static func shouldResetSmoothScrollTarget(currentTargetWindowId: UInt16?, pointerWindowId: UInt16?, hasPixelOffset: Bool) -> Bool {
+        guard hasPixelOffset else { return false }
         guard let currentTargetWindowId else { return false }
         return pointerWindowId != currentTargetWindowId
+    }
+
+    nonisolated static func presentationNormalizedGutterPoint(
+        _ point: NSPoint,
+        scrollTargetWindowId: UInt16?,
+        targetGutterRect: GUICellRect?,
+        scrollPixelOffset: CGPoint,
+        scrollElasticOffsetY: CGFloat,
+        cellWidth: CGFloat,
+        cellHeight: CGFloat
+    ) -> NSPoint {
+        guard scrollTargetWindowId != nil, let targetGutterRect else { return point }
+        guard cellWidth > 0, cellHeight > 0 else { return point }
+
+        let rawCol = Int(point.x / cellWidth)
+        let rawRow = Int(point.y / cellHeight)
+        let startRow = Int(targetGutterRect.row)
+        let endRow = startRow + Int(targetGutterRect.height)
+        let startCol = Int(targetGutterRect.col)
+        let endCol = startCol + Int(targetGutterRect.width)
+        guard rawRow >= startRow && rawRow < endRow && rawCol >= startCol && rawCol < endCol else { return point }
+
+        let offsetY = scrollPixelOffset.y + scrollElasticOffsetY
+        guard offsetY != 0 else { return point }
+
+        let minY = CGFloat(startRow) * cellHeight
+        let maxY = CGFloat(endRow) * cellHeight - 0.001
+        let normalizedY = min(max(point.y + offsetY, minY), maxY)
+        return NSPoint(x: point.x, y: normalizedY)
+    }
+
+    nonisolated static func presentationScrollTranslation(
+        scrollPresentation: GUIScrollPresentation?,
+        scrollOffset: CGPoint,
+        scrollDeltaY: CGFloat,
+        currentElasticOffsetY: CGFloat,
+        cellHeight: CGFloat,
+        payloadOverscanBefore: Int,
+        payloadOverscanAfter: Int,
+        boundaryBefore: Int,
+        boundaryAfter: Int
+    ) -> (scrollOffset: CGPoint, elasticOffsetY: CGFloat) {
+        guard scrollPresentation != nil else { return (scrollOffset, 0) }
+        guard cellHeight > 0 else { return (scrollOffset, 0) }
+        guard scrollDeltaY != 0 else { return (scrollOffset, currentElasticOffsetY) }
+
+        let pullingTowardBefore = scrollDeltaY > 0
+        let pullingTowardAfter = scrollDeltaY < 0
+        let hasRenderablePayload =
+            (pullingTowardBefore && payloadOverscanBefore > 0) ||
+            (pullingTowardAfter && payloadOverscanAfter > 0)
+        if hasRenderablePayload {
+            return (scrollOffset, 0)
+        }
+
+        let pullingPastTop = pullingTowardBefore && boundaryBefore == 0
+        let pullingPastBottom = pullingTowardAfter && boundaryAfter == 0
+        guard pullingPastTop || pullingPastBottom else {
+            return (CGPoint(x: scrollOffset.x, y: 0), 0)
+        }
+
+        let maxElastic = max(cellHeight * 0.75, 1)
+        let dampedPull = -scrollDeltaY * 0.35
+        let elasticOffsetY = min(max(currentElasticOffsetY + dampedPull, -maxElastic), maxElastic)
+        return (CGPoint(x: scrollOffset.x, y: 0), elasticOffsetY)
+    }
+
+    nonisolated static func presentationScrollBoundaryAvailability(
+        for windowContent: GUIWindowContent?,
+        scrollPresentation: GUIScrollPresentation?
+    ) -> (before: Int, after: Int) {
+        guard let scrollPresentation else { return (0, 0) }
+
+        let payload = presentationScrollPayloadOverscanBounds(for: windowContent, scrollPresentation: scrollPresentation)
+        let hasContentBefore = scrollPresentation.anchorTop > 0 || scrollPresentation.anchorVisualRowOffset > 0 || payload.before > 0
+        let hasContentAfter: Bool
+        if let totalLines = windowContent?.paneGeometry?.viewport.totalLines, totalLines > 0 {
+            hasContentAfter = scrollPresentation.visibleEndLine < totalLines || payload.after > 0
+        } else {
+            hasContentAfter = payload.after > 0
+        }
+
+        return (hasContentBefore ? 1 : 0, hasContentAfter ? 1 : 0)
+    }
+
+    nonisolated static func presentationScrollPayloadOverscanBounds(
+        for windowContent: GUIWindowContent?,
+        scrollPresentation: GUIScrollPresentation?
+    ) -> (before: Int, after: Int) {
+        guard let scrollPresentation else { return (0, 0) }
+        let before = windowContent.map { CoreTextMetalRenderer.presentationPayloadOverscanBeforeRows(rows: $0.rows, scrollPresentation: scrollPresentation) } ?? CoreTextMetalRenderer.scrollOverscanBefore(scrollPresentation)
+        if let windowContent {
+            let visibleRows = presentationPayloadVisibleRows(for: windowContent)
+            if visibleRows > 0 {
+                return (before, max(windowContent.rows.count - visibleRows - before, 0))
+            }
+        }
+        let after = max(0, Int(scrollPresentation.overscanEndLine) - Int(scrollPresentation.visibleEndLine))
+        return (before, after)
+    }
+
+    nonisolated static func presentationPayloadVisibleRows(for windowContent: GUIWindowContent) -> Int {
+        if let geometry = windowContent.paneGeometry {
+            let textRows = Int(geometry.textRect.height)
+            if textRows > 0 { return textRows }
+            let viewportRows = Int(geometry.viewport.rows)
+            if viewportRows > 0 { return viewportRows }
+            let contentRows = Int(geometry.contentRect.height)
+            if contentRows > 0 { return contentRows }
+        }
+        return 0
+    }
+
+    nonisolated static func presentationScrollOverscanBounds(
+        for windowContent: GUIWindowContent?,
+        scrollPresentation: GUIScrollPresentation?
+    ) -> (before: Int, after: Int) {
+        presentationScrollBoundaryAvailability(for: windowContent, scrollPresentation: scrollPresentation)
     }
 
     nonisolated static func smoothScrollTargetWindowId(row: Int16, col: Int16, windowGutters: [UInt16: Wire.WindowGutter]) -> UInt16? {
@@ -1734,16 +1908,32 @@ final class EditorNSView: MTKView {
     }
 
     private func foldChevronEntry(at point: NSPoint) -> (gutter: Wire.WindowGutter, entry: Wire.GutterEntry)? {
+        let point = Self.presentationNormalizedGutterPoint(
+            point,
+            scrollTargetWindowId: scrollTargetWindowId,
+            targetGutterRect: scrollTargetWindowId.flatMap { guiState?.windowContents[$0]?.paneGeometry?.gutterRect },
+            scrollPixelOffset: scrollPixelOffset,
+            scrollElasticOffsetY: scrollElasticOffsetY,
+            cellWidth: cellWidth,
+            cellHeight: effectiveCellHeight
+        )
         guard let (gutter, rowIndex) = gutterHit(at: point) else { return nil }
         guard Int(gutter.signColWidth) >= 3 else { return nil }
-        guard rowIndex >= 0 && rowIndex < gutter.entries.count else { return nil }
+
+        let content = guiState?.windowContents[gutter.windowId]
+        let presentationBeforeRows = Self.presentationScrollPayloadOverscanBounds(
+            for: content,
+            scrollPresentation: content?.scrollPresentation
+        ).before
+        let presentationRowIndex = rowIndex + presentationBeforeRows
+        guard presentationRowIndex >= 0 && presentationRowIndex < gutter.entries.count else { return nil }
 
         let gutterX = CGFloat(gutter.contentCol) * cellWidth + CoreTextMetalRenderer.gutterLeftMarginPt
         let foldColumnOffset = CGFloat(Int(gutter.signColWidth) - 1)
         let foldStartX = gutterX + foldColumnOffset * cellWidth
         guard point.x >= foldStartX && point.x < foldStartX + cellWidth else { return nil }
 
-        let entry = gutter.entries[rowIndex]
+        let entry = gutter.entries[presentationRowIndex]
         switch entry.displayType {
         case .foldOpen, .foldStart:
             return (gutter, entry)
@@ -1753,6 +1943,15 @@ final class EditorNSView: MTKView {
     }
 
     private func updateGutterHover(at point: NSPoint) {
+        let point = Self.presentationNormalizedGutterPoint(
+            point,
+            scrollTargetWindowId: scrollTargetWindowId,
+            targetGutterRect: scrollTargetWindowId.flatMap { guiState?.windowContents[$0]?.paneGeometry?.gutterRect },
+            scrollPixelOffset: scrollPixelOffset,
+            scrollElasticOffsetY: scrollElasticOffsetY,
+            cellWidth: cellWidth,
+            cellHeight: effectiveCellHeight
+        )
         let next: (Bool, UInt16?, UInt16?)
         if let (gutter, rowIndex) = gutterHit(at: point), rowIndex >= 0 && rowIndex < gutter.entries.count {
             next = (true, gutter.windowId, gutter.contentRow + UInt16(rowIndex))
@@ -1801,10 +2000,44 @@ final class EditorNSView: MTKView {
     }
 
     private func cellPosition(from event: NSEvent) -> (row: Int16, col: Int16) {
-        let point = convert(event.locationInWindow, from: nil)
+        clearSmoothScrollStateIfTargetWindowMissing()
+        let rawPoint = convert(event.locationInWindow, from: nil)
+        let point = presentationNormalizedPoint(rawPoint)
         let row = Int16(point.y / effectiveCellHeight)
         let col = cellColumn(at: point, row: row)
         return (row, col)
+    }
+
+    private func presentationNormalizedPoint(_ point: NSPoint) -> NSPoint {
+        guard Self.hasActivePresentationOffset(scrollPixelOffset: scrollPixelOffset, scrollElasticOffsetY: scrollElasticOffsetY) else { return point }
+        let rawRow = Int16(point.y / effectiveCellHeight)
+        let rawCol = max(0, Int16(point.x / cellWidth))
+        guard smoothScrollTargetWindowId(row: rawRow, col: rawCol) == scrollTargetWindowId else { return point }
+        let scrollLeft = scrollTargetWindowId.flatMap { guiState?.windowContents[$0]?.scrollLeft } ?? 0
+        let presentationOffset = CGPoint(x: scrollPixelOffset.x, y: scrollPixelOffset.y + scrollElasticOffsetY)
+        let offset = Self.presentationScrollOffset(scrollLeft: scrollLeft, scrollOffset: presentationOffset)
+        let normalized = NSPoint(x: point.x + offset.x, y: point.y + offset.y)
+        guard let targetWindowId = scrollTargetWindowId,
+              let rect = guiState?.windowContents[targetWindowId]?.paneGeometry?.contentRect else { return normalized }
+        return Self.clampPresentationPoint(normalized, to: rect, cellWidth: cellWidth, cellHeight: effectiveCellHeight)
+    }
+
+    nonisolated static func hasActivePresentationOffset(scrollPixelOffset: CGPoint, scrollElasticOffsetY: CGFloat) -> Bool {
+        scrollPixelOffset.x != 0 || scrollPixelOffset.y != 0 || scrollElasticOffsetY != 0
+    }
+
+    nonisolated static func presentationScrollOffset(scrollLeft: UInt16, scrollOffset: CGPoint) -> CGPoint {
+        let x = scrollLeft == 0 && scrollOffset.x < 0 ? 0 : scrollOffset.x
+        return CGPoint(x: x, y: scrollOffset.y)
+    }
+
+    nonisolated static func clampPresentationPoint(_ point: NSPoint, to rect: GUICellRect, cellWidth: CGFloat, cellHeight: CGFloat) -> NSPoint {
+        guard rect.width > 0, rect.height > 0, cellWidth > 0, cellHeight > 0 else { return point }
+        let minX = CGFloat(rect.col) * cellWidth
+        let maxX = CGFloat(Int(rect.col) + Int(rect.width)) * cellWidth - 0.001
+        let minY = CGFloat(rect.row) * cellHeight
+        let maxY = CGFloat(Int(rect.row) + Int(rect.height)) * cellHeight - 0.001
+        return NSPoint(x: min(max(point.x, minX), maxX), y: min(max(point.y, minY), maxY))
     }
 
     private func rawCellPosition(at point: NSPoint) -> (row: Int16, col: Int16) {

--- a/macos/Sources/Views/ScrollAccumulator.swift
+++ b/macos/Sources/Views/ScrollAccumulator.swift
@@ -14,9 +14,9 @@ struct ScrollAccumulator {
     /// shift content by a sub-line amount.
     var pixelOffsetY: CGFloat = 0
 
-    /// Accumulated horizontal pixel delta. Emits discrete column events
-    /// when it crosses cellWidth boundaries.
-    var accumulatorX: CGFloat = 0
+    /// Fractional horizontal pixel offset within the current left column.
+    /// Positive = content shifted left, negative = content shifted right.
+    var pixelOffsetX: CGFloat = 0
 
     /// Scroll direction emitted to the BEAM.
     enum Event: Equatable {
@@ -29,7 +29,7 @@ struct ScrollAccumulator {
     /// Reset both accumulators (call at the start of a new gesture).
     mutating func reset() {
         pixelOffsetY = 0
-        accumulatorX = 0
+        pixelOffsetX = 0
     }
 
     /// Accumulate a vertical pixel delta from a trackpad event.
@@ -64,17 +64,17 @@ struct ScrollAccumulator {
     mutating func accumulateHorizontal(deltaX: CGFloat, cellWidth: CGFloat) -> [Event] {
         guard cellWidth > 0 else { return [] }
 
-        accumulatorX += deltaX
+        pixelOffsetX += deltaX
 
         var events: [Event] = []
 
-        while accumulatorX >= cellWidth {
+        while pixelOffsetX >= cellWidth {
             events.append(.scrollLeft)
-            accumulatorX -= cellWidth
+            pixelOffsetX -= cellWidth
         }
-        while accumulatorX <= -cellWidth {
+        while pixelOffsetX <= -cellWidth {
             events.append(.scrollRight)
-            accumulatorX += cellWidth
+            pixelOffsetX += cellWidth
         }
 
         return events

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -26,8 +26,8 @@ struct CommandDispatcherRoutingTests {
 
     // MARK: - Basic commands
 
-    @Test("commitFrame preserves retained windows (no cell-grid clear/prune path)")
-    @MainActor func commitFramePreservesRetainedWindows() {
+    @Test("empty keyframe prunes retained windows and stale gutter globals")
+    @MainActor func emptyKeyframePrunesRetainedWindowState() {
         let (dispatcher, gui) = makeDispatcher()
         gui.windowContents[1] = GUIWindowContent(
             windowId: 1, fullRefresh: false,
@@ -36,13 +36,79 @@ struct CommandDispatcherRoutingTests {
             searchMatches: [], diagnosticUnderlines: [],
             documentHighlights: []
         )
+        dispatcher.applyForTesting(.guiGutter(data: Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 5, contentHeight: 24,
+            isActive: true, contentWidth: 80, cursorLine: 9, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 3,
+            entries: [Wire.GutterEntry(bufLine: 9, displayType: .normal, signType: .none, foldEndLine: 0xFFFF_FFFF, signFg: 0, signText: "")]
+        )))
+        dispatcher.applyForTesting(.guiIndentGuides(data: IndentGuideData(
+            windowId: 1, tabWidth: 4, activeGuideCol: 0xFFFF,
+            guideCols: [2], lineIndentLevels: [1]
+        )))
+        #expect(dispatcher.currentFrameWindowIds == [1])
+        #expect(dispatcher.frameState.gutterCol == 7)
+        #expect(dispatcher.frameState.viewportTopLine == 9)
 
-        // A keyframe transaction (base 0) opened then committed.
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
+        #expect(gui.windowContents.isEmpty)
+        #expect(dispatcher.frameState.windowGutters.isEmpty)
+        #expect(dispatcher.frameState.windowIndentGuides.isEmpty)
+        #expect(dispatcher.currentFrameWindowIds.isEmpty)
+        #expect(dispatcher.frameState.gutterCol == 0)
+        #expect(dispatcher.frameState.viewportTopLine == 0xFFFF_FFFF)
+    }
+
+    @Test("keyframe commit prunes stale window content, gutters, and indent guides")
+    @MainActor func keyframeCommitPrunesStaleWindowState() {
+        let (dispatcher, gui) = makeDispatcher()
+        gui.windowContents[2] = GUIWindowContent(
+            windowId: 2, fullRefresh: false,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+        dispatcher.applyForTesting(.guiGutter(data: Wire.WindowGutter(
+            windowId: 2, contentRow: 0, contentCol: 5, contentHeight: 24,
+            isActive: false, contentWidth: 80, cursorLine: 0, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 3, entries: []
+        )))
+        dispatcher.applyForTesting(.guiIndentGuides(data: IndentGuideData(
+            windowId: 2, tabWidth: 4, activeGuideCol: 0xFFFF,
+            guideCols: [], lineIndentLevels: []
+        )))
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: GUIWindowContent(
+            windowId: 1, fullRefresh: false,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )))
+        dispatcher.dispatch(.guiGutter(data: Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 5, contentHeight: 24,
+            isActive: true, contentWidth: 80, cursorLine: 0, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 3, entries: []
+        )))
+        dispatcher.dispatch(.guiIndentGuides(data: IndentGuideData(
+            windowId: 1, tabWidth: 4, activeGuideCol: 0xFFFF,
+            guideCols: [], lineIndentLevels: []
+        )))
+        dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
+
         #expect(gui.windowContents[1] != nil)
+        #expect(gui.windowContents[2] == nil)
+        #expect(dispatcher.frameState.windowGutters[1] != nil)
+        #expect(dispatcher.frameState.windowGutters[2] == nil)
+        #expect(dispatcher.frameState.windowIndentGuides[1] != nil)
+        #expect(dispatcher.frameState.windowIndentGuides[2] == nil)
+        #expect(dispatcher.currentFrameWindowIds == [1])
     }
 
     @Test("setCursorShape updates frameState cursor shape")
@@ -641,6 +707,72 @@ struct CommandDispatcherRoutingTests {
 
         #expect(gui.windowContents[7] != nil)
         #expect(gui.windowContents[7]?.cursorRow == 5)
+    }
+
+    @Test("reset-required scroll presentation clears local smooth-scroll state once per promoted frame")
+    @MainActor func resetRequiredScrollPresentationClearsLocalStateOnce() {
+        let (dispatcher, gui) = makeDispatcher()
+        var resetCount = 0
+        dispatcher.onScrollPresentationReset = { resetCount += 1 }
+
+        let resetPresentation = GUIScrollPresentation(
+            windowId: 7,
+            resetRequired: true,
+            anchorTop: 5,
+            anchorLeft: 2,
+            anchorVisualRowOffset: 0,
+            visibleStartLine: 5,
+            visibleEndLine: 8,
+            overscanStartLine: 4,
+            overscanEndLine: 9,
+            contentEpoch: 42,
+            layoutGeneration: 77
+        )
+
+        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+            windowId: 7, fullRefresh: true, contentEpoch: 42,
+            cursorRow: 5, cursorCol: 10, cursorShape: .beam,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [],
+            scrollPresentation: resetPresentation
+        )))
+        #expect(resetCount == 1)
+
+        dispatcher.applyForTesting(.guiWindowOverlayDelta(data: GUIWindowOverlayDelta(
+            windowId: 7, contentEpoch: 42,
+            cursorVisible: true, cursorRow: 5, cursorCol: 10,
+            cursorShape: .beam, cursorline: nil
+        )))
+        #expect(resetCount == 1)
+
+        gui.windowContents[7] = GUIWindowContent(
+            windowId: 7, fullRefresh: false, contentEpoch: 42,
+            cursorRow: 5, cursorCol: 10, cursorShape: .beam,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+
+        dispatcher.applyForTesting(.guiWindowRowsDelta(data: GUIWindowRowsDelta(
+            windowId: 7,
+            contentEpoch: 42,
+            cursorVisible: true,
+            cursorRow: 5,
+            cursorCol: 10,
+            cursorShape: .beam,
+            scrollLeft: 0,
+            rows: [],
+            selection: nil,
+            searchMatches: [],
+            diagnosticUnderlines: [],
+            documentHighlights: [],
+            lineAnnotations: [],
+            paneGeometry: nil,
+            cursorline: nil,
+            scrollPresentation: resetPresentation
+        )))
+        #expect(resetCount == 2)
     }
 
     @Test("guiWindowOverlayDelta updates matching retained content")

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -70,6 +70,176 @@ struct CoreTextMetalRendererCursorTests {
         #expect(CoreTextMetalRenderer.smoothScrollOffset(for: nil, targetWindowId: 1, scrollOffsetPx: offset) == .zero)
     }
 
+    @Test("boundary availability uses BEAM document position")
+    func boundaryAvailabilityUsesBeamDocumentPosition() {
+        let geometry = GUIPaneGeometry(
+            windowId: 7,
+            totalRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
+            contentRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
+            textRect: GUICellRect(row: 0, col: 0, width: 10, height: 2),
+            gutterRect: GUICellRect(row: 0, col: 0, width: 2, height: 5),
+            clipRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
+            viewport: GUIViewportSummary(top: 10, left: 0, rows: 2, cols: 10, totalLines: 100, visualRowOffset: 1, totalVisualRows: 5),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 1, signColWidth: 1),
+            hitRegions: []
+        )
+        let content = GUIWindowContent(
+            windowId: 7, fullRefresh: true, contentEpoch: 1, cursorVisible: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            scrollLeft: 0, rows: [], selection: nil, searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [], lineAnnotations: [], paneGeometry: geometry, cursorline: nil,
+            scrollPresentation: GUIScrollPresentation(
+                windowId: 7, resetRequired: false, anchorTop: 10, anchorLeft: 0, anchorVisualRowOffset: 1,
+                visibleStartLine: 10, visibleEndLine: 12, overscanStartLine: 10, overscanEndLine: 12,
+                contentEpoch: 1, layoutGeneration: 1
+            )
+        )
+
+        let bounds = EditorNSView.presentationScrollBoundaryAvailability(for: content, scrollPresentation: content.scrollPresentation)
+        #expect(bounds.before == 1)
+        #expect(bounds.after == 1)
+    }
+
+    @Test("split label texture is clipped horizontally to separator bounds")
+    func splitLabelTextureIsClippedHorizontallyToSeparatorBounds() {
+        let clipped = CoreTextMetalRenderer.clippedHorizontalLineGPU(
+            x: 80,
+            y: 12,
+            width: 60,
+            height: 16,
+            uvOrigin: SIMD2<Float>(0.20, 0.10),
+            uvSize: SIMD2<Float>(0.60, 0.30),
+            clipLeft: 100,
+            clipRight: 130
+        )
+
+        #expect(clipped?.position.x == 100)
+        #expect(clipped?.position.y == 12)
+        #expect(clipped?.size.x == 30)
+        #expect(clipped?.size.y == 16)
+        #expect(abs((clipped?.uvOrigin.x ?? 0) - 0.40) < 0.0001)
+        #expect(abs((clipped?.uvSize.x ?? 0) - 0.30) < 0.0001)
+        #expect(clipped?.uvOrigin.y == 0.10)
+        #expect(clipped?.uvSize.y == 0.30)
+    }
+
+    @Test("payload overscan ignores document visual row offset")
+    func payloadOverscanIgnoresDocumentVisualRowOffset() {
+        let geometry = GUIPaneGeometry(
+            windowId: 7,
+            totalRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
+            contentRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
+            textRect: GUICellRect(row: 0, col: 0, width: 10, height: 2),
+            gutterRect: GUICellRect(row: 0, col: 0, width: 2, height: 5),
+            clipRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
+            viewport: GUIViewportSummary(top: 0, left: 0, rows: 2, cols: 10, totalLines: 5, visualRowOffset: 1, totalVisualRows: 5),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 1, signColWidth: 1),
+            hitRegions: []
+        )
+        let content = GUIWindowContent(
+            windowId: 7, fullRefresh: true, contentEpoch: 1, cursorVisible: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            scrollLeft: 0,
+            rows: [
+                GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 10, contentHash: 1, text: "first", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 10, contentHash: 2, text: "second", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 3, bufLine: 11, contentHash: 3, text: "third", spans: [])
+            ],
+            selection: nil, searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [], lineAnnotations: [], paneGeometry: geometry, cursorline: nil,
+            scrollPresentation: GUIScrollPresentation(
+                windowId: 7, resetRequired: false, anchorTop: 10, anchorLeft: 0, anchorVisualRowOffset: 1,
+                visibleStartLine: 10, visibleEndLine: 12, overscanStartLine: 10, overscanEndLine: 12,
+                contentEpoch: 1, layoutGeneration: 1
+            )
+        )
+
+        let payload = EditorNSView.presentationScrollPayloadOverscanBounds(for: content, scrollPresentation: content.scrollPresentation)
+        #expect(payload.before == 0)
+        #expect(payload.after == 1)
+        #expect(CoreTextMetalRenderer.presentationOverscanBeforeRows(content) == 0)
+    }
+
+    @Test("payload overscan preserves line-delta rows before viewport")
+    func payloadOverscanPreservesLineDeltaRowsBeforeViewport() {
+        let content = GUIWindowContent(
+            windowId: 7, fullRefresh: true, contentEpoch: 1, cursorVisible: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            scrollLeft: 0,
+            rows: [
+                GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 9, contentHash: 1, text: "above", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 10, contentHash: 2, text: "top", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 3, bufLine: 11, contentHash: 3, text: "bottom", spans: [])
+            ],
+            selection: nil, searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [], lineAnnotations: [], paneGeometry: nil, cursorline: nil,
+            scrollPresentation: GUIScrollPresentation(
+                windowId: 7, resetRequired: false, anchorTop: 10, anchorLeft: 0, anchorVisualRowOffset: 0,
+                visibleStartLine: 10, visibleEndLine: 12, overscanStartLine: 9, overscanEndLine: 12,
+                contentEpoch: 1, layoutGeneration: 1
+            )
+        )
+
+        let payload = EditorNSView.presentationScrollPayloadOverscanBounds(for: content, scrollPresentation: content.scrollPresentation)
+        #expect(payload.before == 1)
+        #expect(CoreTextMetalRenderer.presentationOverscanBeforeRows(content) == 1)
+    }
+
+    @Test("payload overscan counts wrapped visual rows before viewport")
+    func payloadOverscanCountsWrappedVisualRowsBeforeViewport() {
+        let content = GUIWindowContent(
+            windowId: 7, fullRefresh: true, contentEpoch: 1, cursorVisible: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            scrollLeft: 0,
+            rows: [
+                GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 9, contentHash: 1, text: "above first wrap", spans: []),
+                GUIVisualRow(rowType: .wrapContinuation, rowId: 2, bufLine: 9, contentHash: 2, text: "above second wrap", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 3, bufLine: 10, contentHash: 3, text: "visible", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 4, bufLine: 11, contentHash: 4, text: "below", spans: [])
+            ],
+            selection: nil, searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [], lineAnnotations: [], paneGeometry: nil, cursorline: nil,
+            scrollPresentation: GUIScrollPresentation(
+                windowId: 7, resetRequired: false, anchorTop: 10, anchorLeft: 0, anchorVisualRowOffset: 0,
+                visibleStartLine: 10, visibleEndLine: 12, overscanStartLine: 9, overscanEndLine: 12,
+                contentEpoch: 1, layoutGeneration: 1
+            )
+        )
+
+        let payload = EditorNSView.presentationScrollPayloadOverscanBounds(for: content, scrollPresentation: content.scrollPresentation)
+        #expect(payload.before == 2)
+        #expect(CoreTextMetalRenderer.presentationOverscanBeforeRows(content) == 2)
+    }
+
+    @Test("right split gutter separator uses per-window screen coordinates")
+    func rightSplitGutterSeparatorUsesPerWindowScreenCoordinates() {
+        var frameState = FrameState(cols: 100, rows: 40)
+        frameState.gutterSeparatorColor = 0x334455
+        frameState.windowGutters[2] = Wire.WindowGutter(
+            windowId: 2, contentRow: 3, contentCol: 40, contentHeight: 10,
+            isActive: true, contentWidth: 40, cursorLine: 0, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 1, entries: []
+        )
+
+        let rects = CoreTextMetalRenderer.gutterChromeRects(
+            frameState: frameState,
+            cellW: 8,
+            cellH: 16,
+            scale: 2,
+            gutterLeftMarginPx: 12,
+            gutterPaddingPx: 16,
+            viewportHeight: 300
+        )
+
+        #expect(rects.leftFills.count == 1)
+        #expect(rects.leftFills[0].x == 640)
+        #expect(rects.leftFills[0].y == 96)
+        #expect(rects.leftFills[0].height == 204)
+        #expect(rects.rightFills.count == 1)
+        #expect(rects.rightFills[0].x == 732)
+        #expect(rects.rightFills[0].height == 204)
+        #expect(rects.separators.count == 1)
+        #expect(rects.separators[0].x == 747)
+        #expect(rects.separators[0].y == 96)
+        #expect(rects.separators[0].height == 204)
+    }
+
     @Test("split panes use per-window text width for semantic clipping")
     func splitPanesUsePerWindowTextWidthForSemanticClipping() {
         let gutter = Wire.WindowGutter(
@@ -115,6 +285,126 @@ struct CoreTextMetalRendererCursorTests {
 
         #expect(bounds.x == 0)
         #expect(bounds.width == 640)
+    }
+
+    @Test("committed visible rows prefer the pane geometry height")
+    func committedVisibleRowsPreferPaneGeometryHeight() {
+        let geometry = GUIPaneGeometry(
+            windowId: 1,
+            totalRect: GUICellRect(row: 2, col: 4, width: 10, height: 14),
+            contentRect: GUICellRect(row: 2, col: 4, width: 10, height: 14),
+            textRect: GUICellRect(row: 3, col: 6, width: 8, height: 9),
+            gutterRect: GUICellRect(row: 2, col: 4, width: 2, height: 14),
+            clipRect: GUICellRect(row: 2, col: 4, width: 10, height: 14),
+            viewport: GUIViewportSummary(top: 10, left: 0, rows: 9, cols: 80, totalLines: 100, visualRowOffset: 0, totalVisualRows: 100),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 4, signColWidth: 1),
+            hitRegions: []
+        )
+        let gutter = Wire.WindowGutter(
+            windowId: 1, contentRow: 2, contentCol: 4, contentHeight: 14,
+            isActive: true, contentWidth: 80, cursorLine: 3, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 1, entries: []
+        )
+
+        #expect(CoreTextMetalRenderer.committedVisibleRows(paneGeometry: geometry, gutter: gutter, fallback: 99) == 9)
+    }
+
+    @Test("pane vertical bounds use the pane text rect")
+    func paneVerticalBoundsUsePaneTextRect() {
+        let geometry = GUIPaneGeometry(
+            windowId: 1,
+            totalRect: GUICellRect(row: 2, col: 4, width: 10, height: 14),
+            contentRect: GUICellRect(row: 2, col: 4, width: 10, height: 14),
+            textRect: GUICellRect(row: 3, col: 6, width: 8, height: 9),
+            gutterRect: GUICellRect(row: 2, col: 4, width: 2, height: 14),
+            clipRect: GUICellRect(row: 2, col: 4, width: 10, height: 14),
+            viewport: GUIViewportSummary(top: 10, left: 0, rows: 9, cols: 80, totalLines: 100, visualRowOffset: 0, totalVisualRows: 100),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 4, signColWidth: 1),
+            hitRegions: []
+        )
+        let content = GUIWindowContent(
+            windowId: 1,
+            fullRefresh: true,
+            cursorRow: 0,
+            cursorCol: 0,
+            cursorShape: .block,
+            rows: [],
+            selection: nil,
+            searchMatches: [],
+            diagnosticUnderlines: [],
+            documentHighlights: [],
+            paneGeometry: geometry
+        )
+        let gutter = Wire.WindowGutter(
+            windowId: 1, contentRow: 2, contentCol: 4, contentHeight: 14,
+            isActive: true, contentWidth: 80, cursorLine: 3, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 1, entries: []
+        )
+
+        let bounds = CoreTextMetalRenderer.paneVerticalBounds(
+            for: 1,
+            windowContents: [1: content],
+            gutters: [1: gutter],
+            displayCellH: 16,
+            scale: 2,
+            viewportHeight: 1_000
+        )
+
+        #expect(bounds?.top == 96)
+        #expect(bounds?.bottom == 384)
+    }
+
+    @Test("presentation scroll offset keeps negative x clamped when horizontal scroll is at zero")
+    func presentationScrollOffsetKeepsNegativeXClampedAtLeftEdge() {
+        let suppressed = CoreTextMetalRenderer.presentationScrollOffset(scrollLeft: 0, scrollOffsetPx: SIMD2<Float>(-12, 5))
+        #expect(suppressed.x == 0)
+        #expect(suppressed.y == 5)
+
+        let preserved = CoreTextMetalRenderer.presentationScrollOffset(scrollLeft: 3, scrollOffsetPx: SIMD2<Float>(-12, 5))
+        #expect(preserved.x == -12)
+        #expect(preserved.y == 5)
+    }
+
+    @Test("horizontal rect clipping trims to pane text bounds")
+    func horizontalRectClippingTrimsToPaneTextBounds() {
+        let clipped = CoreTextMetalRenderer.clipHorizontalRect(x: 120, width: 40, left: 128, right: 160)
+        #expect(clipped?.x == 128)
+        #expect(clipped?.width == 32)
+        #expect(CoreTextMetalRenderer.clipHorizontalRect(x: 0, width: 10, left: 20, right: 30) == nil)
+    }
+
+    @Test("cursor horizontal bounds start at semantic text rect")
+    func cursorHorizontalBoundsStartAtSemanticTextRect() {
+        let geometry = GUIPaneGeometry(
+            windowId: 1,
+            totalRect: GUICellRect(row: 0, col: 4, width: 20, height: 10),
+            contentRect: GUICellRect(row: 0, col: 4, width: 20, height: 10),
+            textRect: GUICellRect(row: 0, col: 8, width: 16, height: 10),
+            gutterRect: GUICellRect(row: 0, col: 4, width: 4, height: 10),
+            clipRect: GUICellRect(row: 0, col: 4, width: 20, height: 10),
+            viewport: GUIViewportSummary(top: 0, left: 0, rows: 10, cols: 80, totalLines: 100, visualRowOffset: 0, totalVisualRows: 100),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 3, signColWidth: 1),
+            hitRegions: []
+        )
+        let gutter = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 4, contentHeight: 10,
+            isActive: true, contentWidth: 20, cursorLine: 0, lineNumberStyle: .hybrid,
+            lineNumberWidth: 3, signColWidth: 1, entries: []
+        )
+
+        let bounds = CoreTextMetalRenderer.cursorHorizontalBounds(
+            geometry: geometry,
+            gutter: gutter,
+            frameCols: 80,
+            cellW: 8,
+            scale: 2,
+            gutterLeftMarginPx: 3,
+            gutterPaddingPx: 5,
+            viewportWidth: 1_600
+        )
+
+        #expect(bounds.x == 136)
+        #expect(bounds.width == 248)
     }
 
     @Test("smooth scroll target requires content column even for one row match")
@@ -192,6 +482,33 @@ struct CoreTextMetalRendererCursorTests {
         )
 
         #expect(CoreTextMetalRenderer.resolvedSemanticCursorCol(content) == 1)
+    }
+
+    @Test("semantic block cursor accounts for overscan rows before the viewport")
+    func semanticBlockCursorAccountsForOverscanRowsBeforeTheViewport() {
+        let content = GUIWindowContent(
+            windowId: 1, fullRefresh: true,
+            cursorRow: 0, cursorCol: 4, cursorShape: .block,
+            rows: [
+                GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 9, contentHash: 1, text: "above", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 10, contentHash: 2, text: "this", spans: [])
+            ],
+            selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [],
+            scrollPresentation: GUIScrollPresentation(windowId: 1, resetRequired: false, anchorTop: 10, anchorLeft: 0, anchorVisualRowOffset: 0, visibleStartLine: 10, visibleEndLine: 11, overscanStartLine: 9, overscanEndLine: 11, contentEpoch: 1, layoutGeneration: 1)
+        )
+
+        #expect(CoreTextMetalRenderer.resolvedSemanticCursorCol(content) == 3)
+    }
+
+    @Test("vertical clipping helper preserves partial quads and drops fully hidden ones")
+    func verticalClippingHelperPreservesPartialQuadsAndDropsFullyHiddenOnes() {
+        let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: 8, height: 12, top: 10, bottom: 20)
+        #expect(clipped?.y == 10)
+        #expect(clipped?.height == 10)
+
+        #expect(CoreTextMetalRenderer.clipVerticalQuad(y: 0, height: 5, top: 10, bottom: 20) == nil)
     }
 
     @Test("legacy cursor is used when semantic content is unavailable")

--- a/macos/Tests/MingaTests/MouseInputTests.swift
+++ b/macos/Tests/MingaTests/MouseInputTests.swift
@@ -345,10 +345,25 @@ struct MouseInputTests {
             windowId: 7, contentRow: 0, contentCol: 20, contentHeight: 24,
             isActive: false, contentWidth: 80, cursorLine: 42, lineNumberStyle: .hybrid,
             lineNumberWidth: 4, signColWidth: 3,
-            entries: [Wire.GutterEntry(bufLine: 42, displayType: .foldStart, signType: .none, foldEndLine: 50)]
+            entries: [
+                Wire.GutterEntry(bufLine: 41, displayType: .normal, signType: .none),
+                Wire.GutterEntry(bufLine: 42, displayType: .foldStart, signType: .none, foldEndLine: 50)
+            ]
         )
         view.dispatcher.applyForTesting(.guiGutter(data: activeGutter))
         view.dispatcher.applyForTesting(.guiGutter(data: inactiveGutter))
+        view.guiState?.windowContents[7] = GUIWindowContent(
+            windowId: 7, fullRefresh: true,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [],
+            scrollPresentation: GUIScrollPresentation(
+                windowId: 7, resetRequired: false, anchorTop: 42, anchorLeft: 0, anchorVisualRowOffset: 0,
+                visibleStartLine: 42, visibleEndLine: 43, overscanStartLine: 41, overscanEndLine: 43,
+                contentEpoch: 1, layoutGeneration: 1
+            )
+        )
 
         guard let event = mouseEvent(type: .leftMouseDown,
                                      location: NSPoint(x: cw * 22.2, y: ch * 0.5)) else { return }
@@ -356,6 +371,77 @@ struct MouseInputTests {
 
         #expect(spy.guiActions == [.foldToggleAtLine(windowId: 7, bufferLine: 42)])
         #expect(spy.mouseEventCalls.isEmpty)
+    }
+
+    @Test("fold chevron hit testing uses payload-local overscan for wrapped rows")
+    @MainActor func foldChevronHitTestingUsesPayloadLocalOverscanForWrappedRows() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy) else { return }
+        let cw = view.cellWidth
+        let ch = view.cellHeight
+
+        let gutter = Wire.WindowGutter(
+            windowId: 7, contentRow: 0, contentCol: 0, contentHeight: 2,
+            isActive: true, contentWidth: 20, cursorLine: 10, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 3,
+            entries: [
+                Wire.GutterEntry(bufLine: 10, displayType: .foldStart, signType: .none, foldEndLine: 12),
+                Wire.GutterEntry(bufLine: 11, displayType: .foldStart, signType: .none, foldEndLine: 13)
+            ]
+        )
+        let geometry = GUIPaneGeometry(
+            windowId: 7,
+            totalRect: GUICellRect(row: 0, col: 0, width: 20, height: 2),
+            contentRect: GUICellRect(row: 0, col: 0, width: 20, height: 2),
+            textRect: GUICellRect(row: 0, col: 7, width: 13, height: 2),
+            gutterRect: GUICellRect(row: 0, col: 0, width: 7, height: 2),
+            clipRect: GUICellRect(row: 0, col: 0, width: 20, height: 2),
+            viewport: GUIViewportSummary(top: 10, left: 0, rows: 2, cols: 20, totalLines: 20, visualRowOffset: 1, totalVisualRows: 5),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 4, signColWidth: 3),
+            hitRegions: []
+        )
+
+        view.dispatcher.applyForTesting(.guiGutter(data: gutter))
+        view.guiState?.windowContents[7] = GUIWindowContent(
+            windowId: 7, fullRefresh: true,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [
+                GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 10, contentHash: 1, text: "first", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 10, contentHash: 2, text: "second", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 3, bufLine: 11, contentHash: 3, text: "third", spans: [])
+            ],
+            selection: nil, searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [], paneGeometry: geometry,
+            scrollPresentation: GUIScrollPresentation(
+                windowId: 7, resetRequired: false, anchorTop: 10, anchorLeft: 0, anchorVisualRowOffset: 1,
+                visibleStartLine: 10, visibleEndLine: 12, overscanStartLine: 10, overscanEndLine: 12,
+                contentEpoch: 1, layoutGeneration: 1
+            )
+        )
+
+        guard let event = mouseEvent(type: .leftMouseDown,
+                                     location: NSPoint(x: cw * 6.2, y: ch * 0.5)) else { return }
+        view.mouseDown(with: event)
+
+        #expect(spy.guiActions == [.foldToggleAtLine(windowId: 7, bufferLine: 10)])
+        #expect(spy.mouseEventCalls.isEmpty)
+    }
+
+    @Test("presentation scroll normalization shifts fold hit testing vertically only")
+    @MainActor func presentationScrollNormalizationShiftsFoldHitTestingVerticallyOnly() {
+        let normalized = EditorNSView.presentationNormalizedGutterPoint(
+            NSPoint(x: 18.0, y: 3.0),
+            scrollTargetWindowId: 7,
+            targetGutterRect: GUICellRect(row: 0, col: 2, width: 6, height: 4),
+            scrollPixelOffset: CGPoint(x: 0, y: 8.0),
+            scrollElasticOffsetY: 0,
+            cellWidth: 8.0,
+            cellHeight: 8.0
+        )
+
+        #expect(normalized.x == 18.0)
+        #expect(Int(normalized.y / 8.0) == 1)
+        #expect(normalized.y > 3.0)
     }
 
     @Test("mouseDown ignores stale gutter data from a previous frame")
@@ -384,11 +470,11 @@ struct MouseInputTests {
 
     @Test("smooth scroll target resets when pointer leaves target pane")
     func smoothScrollTargetResetsWhenPointerLeavesTargetPane() {
-        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 2, pixelOffset: 4) == true)
-        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: nil, pixelOffset: 4) == true)
-        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 1, pixelOffset: 4) == false)
-        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 2, pixelOffset: 0) == false)
-        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: nil, pointerWindowId: 2, pixelOffset: 4) == false)
+        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 2, hasPixelOffset: true) == true)
+        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: nil, hasPixelOffset: true) == true)
+        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 1, hasPixelOffset: true) == false)
+        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: 1, pointerWindowId: 2, hasPixelOffset: false) == false)
+        #expect(EditorNSView.shouldResetSmoothScrollTarget(currentTargetWindowId: nil, pointerWindowId: 2, hasPixelOffset: true) == false)
     }
 
     @Test("smooth scroll routing keeps the gesture target cell after the pointer moves")
@@ -400,6 +486,227 @@ struct MouseInputTests {
         let fallbackTarget = EditorNSView.smoothScrollEventCellPosition(targetCell: nil, row: 5, col: 40)
         #expect(fallbackTarget.row == 5)
         #expect(fallbackTarget.col == 40)
+    }
+
+    @Test("presentation scroll offset suppresses negative horizontal normalization when scrollLeft is zero")
+    func presentationScrollOffsetSuppressesNegativeHorizontalNormalization() {
+        let suppressed = EditorNSView.presentationScrollOffset(scrollLeft: 0, scrollOffset: CGPoint(x: -8, y: 3))
+        #expect(suppressed.x == 0)
+        #expect(suppressed.y == 3)
+
+        let preserved = EditorNSView.presentationScrollOffset(scrollLeft: 2, scrollOffset: CGPoint(x: -8, y: 3))
+        #expect(preserved.x == -8)
+        #expect(preserved.y == 3)
+    }
+
+    @Test("elastic-only presentation offsets still count as active for pointer normalization")
+    func elasticOnlyPresentationOffsetCountsAsActive() {
+        #expect(EditorNSView.hasActivePresentationOffset(scrollPixelOffset: .zero, scrollElasticOffsetY: 4) == true)
+        #expect(EditorNSView.hasActivePresentationOffset(scrollPixelOffset: CGPoint(x: 3, y: 0), scrollElasticOffsetY: 0) == true)
+        #expect(EditorNSView.hasActivePresentationOffset(scrollPixelOffset: .zero, scrollElasticOffsetY: 0) == false)
+    }
+
+    @Test("presentation-normalized points stay inside the target pane")
+    func presentationNormalizedPointClampsToTargetPane() {
+        let rect = GUICellRect(row: 2, col: 4, width: 10, height: 3)
+        let point = EditorNSView.clampPresentationPoint(NSPoint(x: 200, y: 200), to: rect, cellWidth: 10, cellHeight: 20)
+        #expect(point.x < 140)
+        #expect(point.x >= 40)
+        #expect(point.y < 100)
+        #expect(point.y >= 40)
+    }
+
+    @Test("top boundary smooth scroll becomes bounded elastic while content stays clamped")
+    func topBoundarySmoothScrollBecomesBoundedElastic() {
+        let presentation = GUIScrollPresentation(
+            windowId: 1,
+            resetRequired: false,
+            anchorTop: 10,
+            anchorLeft: 0,
+            anchorVisualRowOffset: 0,
+            visibleStartLine: 10,
+            visibleEndLine: 20,
+            overscanStartLine: 10,
+            overscanEndLine: 21,
+            contentEpoch: 1,
+            layoutGeneration: 1
+        )
+
+        let translation = EditorNSView.presentationScrollTranslation(
+            scrollPresentation: presentation,
+            scrollOffset: CGPoint(x: 4, y: 8),
+            scrollDeltaY: 120,
+            currentElasticOffsetY: 0,
+            cellHeight: 20,
+            payloadOverscanBefore: 0,
+            payloadOverscanAfter: 1,
+            boundaryBefore: 0,
+            boundaryAfter: 1
+        )
+
+        #expect(translation.scrollOffset.x == 4)
+        #expect(translation.scrollOffset.y == 0)
+        #expect(translation.elasticOffsetY < 0)
+        #expect(abs(translation.elasticOffsetY) <= 15)
+    }
+
+    @Test("bottom boundary smooth scroll becomes bounded elastic while content stays clamped")
+    func bottomBoundarySmoothScrollBecomesBoundedElastic() {
+        let presentation = GUIScrollPresentation(
+            windowId: 1,
+            resetRequired: false,
+            anchorTop: 10,
+            anchorLeft: 0,
+            anchorVisualRowOffset: 0,
+            visibleStartLine: 10,
+            visibleEndLine: 20,
+            overscanStartLine: 9,
+            overscanEndLine: 20,
+            contentEpoch: 1,
+            layoutGeneration: 1
+        )
+
+        let translation = EditorNSView.presentationScrollTranslation(
+            scrollPresentation: presentation,
+            scrollOffset: CGPoint(x: 4, y: 8),
+            scrollDeltaY: -120,
+            currentElasticOffsetY: 0,
+            cellHeight: 20,
+            payloadOverscanBefore: 1,
+            payloadOverscanAfter: 0,
+            boundaryBefore: 1,
+            boundaryAfter: 0
+        )
+
+        #expect(translation.scrollOffset.x == 4)
+        #expect(translation.scrollOffset.y == 0)
+        #expect(translation.elasticOffsetY > 0)
+        #expect(abs(translation.elasticOffsetY) <= 15)
+    }
+
+    @Test("middle smooth scroll keeps normal content offset")
+    func middleSmoothScrollKeepsNormalContentOffset() {
+        let presentation = GUIScrollPresentation(
+            windowId: 1,
+            resetRequired: false,
+            anchorTop: 10,
+            anchorLeft: 0,
+            anchorVisualRowOffset: 0,
+            visibleStartLine: 10,
+            visibleEndLine: 20,
+            overscanStartLine: 9,
+            overscanEndLine: 21,
+            contentEpoch: 1,
+            layoutGeneration: 1
+        )
+
+        let translation = EditorNSView.presentationScrollTranslation(
+            scrollPresentation: presentation,
+            scrollOffset: CGPoint(x: 4, y: 8),
+            scrollDeltaY: 12,
+            currentElasticOffsetY: 3,
+            cellHeight: 20,
+            payloadOverscanBefore: 1,
+            payloadOverscanAfter: 1,
+            boundaryBefore: 1,
+            boundaryAfter: 1
+        )
+
+        #expect(translation.scrollOffset.x == 4)
+        #expect(translation.scrollOffset.y == 8)
+        #expect(translation.elasticOffsetY == 0)
+    }
+
+    @Test("smooth scroll clamps when document has rows but payload cannot render them")
+    func smoothScrollClampsWhenPayloadCannotRenderDocumentRows() {
+        let presentation = GUIScrollPresentation(
+            windowId: 1,
+            resetRequired: false,
+            anchorTop: 10,
+            anchorLeft: 0,
+            anchorVisualRowOffset: 5,
+            visibleStartLine: 10,
+            visibleEndLine: 20,
+            overscanStartLine: 10,
+            overscanEndLine: 20,
+            contentEpoch: 1,
+            layoutGeneration: 1
+        )
+
+        let translation = EditorNSView.presentationScrollTranslation(
+            scrollPresentation: presentation,
+            scrollOffset: CGPoint(x: 4, y: 8),
+            scrollDeltaY: 12,
+            currentElasticOffsetY: 3,
+            cellHeight: 20,
+            payloadOverscanBefore: 0,
+            payloadOverscanAfter: 0,
+            boundaryBefore: 5,
+            boundaryAfter: 7
+        )
+
+        #expect(translation.scrollOffset.x == 4)
+        #expect(translation.scrollOffset.y == 0)
+        #expect(translation.elasticOffsetY == 0)
+    }
+
+    @Test("mid-document wrapped scroll with no payload rows before does not bounce at top")
+    func midDocumentWrappedScrollWithoutPayloadBeforeDoesNotBounceAtTop() {
+        let geometry = GUIPaneGeometry(
+            windowId: 1,
+            totalRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
+            contentRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
+            textRect: GUICellRect(row: 0, col: 0, width: 10, height: 2),
+            gutterRect: GUICellRect(row: 0, col: 0, width: 2, height: 5),
+            clipRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
+            viewport: GUIViewportSummary(top: 20, left: 0, rows: 2, cols: 10, totalLines: 100, visualRowOffset: 0, totalVisualRows: 300),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 1, signColWidth: 1),
+            hitRegions: []
+        )
+        let presentation = GUIScrollPresentation(
+            windowId: 1,
+            resetRequired: false,
+            anchorTop: 20,
+            anchorLeft: 0,
+            anchorVisualRowOffset: 0,
+            visibleStartLine: 20,
+            visibleEndLine: 22,
+            overscanStartLine: 20,
+            overscanEndLine: 22,
+            contentEpoch: 1,
+            layoutGeneration: 1
+        )
+        let content = GUIWindowContent(
+            windowId: 1, fullRefresh: true, contentEpoch: 1, cursorVisible: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            scrollLeft: 0,
+            rows: [
+                GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 20, contentHash: 1, text: "visible", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 21, contentHash: 2, text: "visible", spans: [])
+            ],
+            selection: nil, searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [], lineAnnotations: [], paneGeometry: geometry, cursorline: nil,
+            scrollPresentation: presentation
+        )
+
+        let payload = EditorNSView.presentationScrollPayloadOverscanBounds(for: content, scrollPresentation: presentation)
+        let boundary = EditorNSView.presentationScrollBoundaryAvailability(for: content, scrollPresentation: presentation)
+        let translation = EditorNSView.presentationScrollTranslation(
+            scrollPresentation: presentation,
+            scrollOffset: CGPoint(x: 4, y: 8),
+            scrollDeltaY: 120,
+            currentElasticOffsetY: 0,
+            cellHeight: 20,
+            payloadOverscanBefore: payload.before,
+            payloadOverscanAfter: payload.after,
+            boundaryBefore: boundary.before,
+            boundaryAfter: boundary.after
+        )
+
+        #expect(payload.before == 0)
+        #expect(boundary.before == 1)
+        #expect(translation.scrollOffset.x == 4)
+        #expect(translation.scrollOffset.y == 0)
+        #expect(translation.elasticOffsetY == 0)
     }
 
     @Test("mouseMoved sends motion event")

--- a/macos/Tests/MingaTests/ScrollAccumulatorTests.swift
+++ b/macos/Tests/MingaTests/ScrollAccumulatorTests.swift
@@ -107,7 +107,7 @@ struct ScrollAccumulatorVerticalTests {
 
         acc.reset()
         #expect(acc.pixelOffsetY == 0)
-        #expect(acc.accumulatorX == 0)
+        #expect(acc.pixelOffsetX == 0)
     }
 }
 
@@ -119,7 +119,7 @@ struct ScrollAccumulatorHorizontalTests {
         var acc = ScrollAccumulator()
         let events = acc.accumulateHorizontal(deltaX: 5, cellWidth: 10)
         #expect(events.isEmpty)
-        #expect(acc.accumulatorX == 5)
+        #expect(acc.pixelOffsetX == 5)
     }
 
     @Test("positive delta crossing cellWidth produces scrollLeft")
@@ -127,7 +127,7 @@ struct ScrollAccumulatorHorizontalTests {
         var acc = ScrollAccumulator()
         let events = acc.accumulateHorizontal(deltaX: 15, cellWidth: 10)
         #expect(events == [.scrollLeft])
-        #expect(acc.accumulatorX == 5)
+        #expect(acc.pixelOffsetX == 5)
     }
 
     @Test("negative delta crossing cellWidth produces scrollRight")
@@ -135,7 +135,7 @@ struct ScrollAccumulatorHorizontalTests {
         var acc = ScrollAccumulator()
         let events = acc.accumulateHorizontal(deltaX: -15, cellWidth: 10)
         #expect(events == [.scrollRight])
-        #expect(acc.accumulatorX == -5)
+        #expect(acc.pixelOffsetX == -5)
     }
 
     @Test("large delta produces multiple events")
@@ -143,7 +143,7 @@ struct ScrollAccumulatorHorizontalTests {
         var acc = ScrollAccumulator()
         let events = acc.accumulateHorizontal(deltaX: -35, cellWidth: 10)
         #expect(events == [.scrollRight, .scrollRight, .scrollRight])
-        #expect(acc.accumulatorX == -5)
+        #expect(acc.pixelOffsetX == -5)
     }
 
     @Test("zero cellWidth returns no events")

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -7,7 +7,18 @@
 
 import Testing
 import SwiftUI
+import AppKit
 import ViewInspector
+
+private func currentModifierBitsForTest() -> UInt8 {
+    var mods: UInt8 = 0
+    let flags = NSEvent.modifierFlags
+    if flags.contains(.shift) { mods |= 0x01 }
+    if flags.contains(.control) { mods |= 0x02 }
+    if flags.contains(.option) { mods |= 0x04 }
+    if flags.contains(.command) { mods |= 0x08 }
+    return mods
+}
 
 // MARK: - ActivityBar
 
@@ -380,11 +391,12 @@ struct FileTreeViewTests {
         let spy = SpyEncoder()
 
         let sut = FileTreeView(fileTreeState: state, theme: ThemeColors(), encoder: spy)
+        let expectedModifiers = currentModifierBitsForTest()
         let handled = sut.handleDrop(urls: [URL(fileURLWithPath: "/tmp/from.txt")], onto: entry)
 
         #expect(handled)
         #expect(spy.guiActions == [
-            .fileTreeDrop(sourcePaths: ["/tmp/from.txt"], targetIndex: 4, targetId: "lib/file.ex", targetPathHash: 0xABCD, targetPath: "/project/lib/file.ex", targetIsDir: false, modifiers: 0)
+            .fileTreeDrop(sourcePaths: ["/tmp/from.txt"], targetIndex: 4, targetId: "lib/file.ex", targetPathHash: 0xABCD, targetPath: "/project/lib/file.ex", targetIsDir: false, modifiers: expectedModifiers)
         ])
     }
 

--- a/macos/Tests/MingaTests/SlotAllocatorTests.swift
+++ b/macos/Tests/MingaTests/SlotAllocatorTests.swift
@@ -212,6 +212,21 @@ struct SlotAllocatorCapacityTests {
             Issue.record("Expected win1 to be evicted by window invalidation"); return
         }
     }
+
+    @Test("gutter atlas keys stay distinct across presentation rows")
+    func gutterAtlasKeysStayDistinctAcrossPresentationRows() {
+        let windowId: UInt16 = 7
+        let lineNumberKey0 = AtlasKey.gutterLineNumber(windowId: windowId, row: 0)
+        let lineNumberKey1 = AtlasKey.gutterLineNumber(windowId: windowId, row: 1)
+        let diagnosticKey0 = AtlasKey.diagnosticSign(windowId: windowId, row: 0)
+        let diagnosticKey1 = AtlasKey.diagnosticSign(windowId: windowId, row: 1)
+        let annotationKey0 = AtlasKey.annotationIcon(windowId: windowId, row: 0)
+        let annotationKey1 = AtlasKey.annotationIcon(windowId: windowId, row: 1)
+
+        #expect(lineNumberKey0 != lineNumberKey1)
+        #expect(diagnosticKey0 != diagnosticKey1)
+        #expect(annotationKey0 != annotationKey1)
+    }
 }
 
 @Suite("SlotAllocator — UV Computation")

--- a/test/minga/frontend/adapter/gui/window_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/window_encoder_test.exs
@@ -269,6 +269,37 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
            ]
   end
 
+  test "encodes distinct visible and overscan bounds for simple windows" do
+    rows = [
+      %Row{
+        row_id: Row.stable_id(:normal, 6),
+        row_type: :normal,
+        buf_line: 4,
+        text: "above",
+        spans: [],
+        content_hash: 111
+      },
+      %Row{
+        row_id: Row.stable_id(:normal, 7),
+        row_type: :normal,
+        buf_line: 5,
+        text: "visible",
+        spans: [],
+        content_hash: 222
+      }
+    ]
+
+    decoded =
+      window(content_epoch: 42, geometry: geometry_model(), rows: rows)
+      |> WindowEncoder.encode_window_content()
+      |> GUIWindowDecoder.decode()
+
+    assert decoded.scroll_presentation.visible_start_line == 5
+    assert decoded.scroll_presentation.visible_end_line == 6
+    assert decoded.scroll_presentation.overscan_start_line == 4
+    assert decoded.scroll_presentation.overscan_end_line == 6
+  end
+
   test "encodes every selection type" do
     for type <- [:char, :line, :block] do
       decoded =

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -21,6 +21,7 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
   alias MingaEditor.UI.Highlight
   alias Minga.RenderModel.Window
   alias Minga.RenderModel.Window.Row
+  alias Minga.RenderModel.Window.ScrollPresentation
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -400,6 +401,42 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       assert wf.window_model.geometry.viewport.total_visual_rows == 20
     end
 
+    test "wrapped presentation payload keeps document visual offset separate from payload overscan" do
+      state =
+        gui_state(rows: 3, cols: 20, content: "abcdefghijABCDEFGHIJklmnopqrstKLMNOPQRST\ntail")
+
+      buffer = state.workspace.buffers.active
+      assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
+      assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
+      :ok = BufferProcess.move_to(buffer, {0, 16})
+
+      win_id = state.workspace.windows.active
+      window = Map.fetch!(state.workspace.windows.map, win_id)
+      viewport = Viewport.put_top_visual(window.viewport, 0, 1, 3)
+      window = EditorWindow.set_viewport(window, viewport)
+
+      windows =
+        Windows.set_map(
+          state.workspace.windows,
+          Map.put(state.workspace.windows.map, win_id, window)
+        )
+
+      state = %{state | workspace: %{state.workspace | windows: windows}}
+
+      {[wf], _cursor, _state} = build_content(state)
+      model = wf.window_model
+      presentation = ScrollPresentation.from_window(model)
+
+      assert Enum.map(model.rows, & &1.text) == ["EFGHIJklmnopqr", "stKLMNOPQRST", "tail"]
+      assert Enum.map(model.rows, & &1.visual_index) == [1, 2, 0]
+      assert model.geometry.viewport.visual_row_offset == 1
+      assert presentation.anchor_visual_row_offset == 1
+      assert presentation.visible_start_line == 0
+      assert presentation.overscan_start_line == 0
+      assert presentation.visible_end_line == 2
+      assert presentation.overscan_end_line == 2
+    end
+
     test "cursor line reveals conceals while other model rows stay concealed" do
       state = gui_state(content: "**bold**\n**italic**")
       buffer = state.workspace.buffers.active
@@ -470,6 +507,50 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       assert model.selection.start_row == 2
       assert model.selection.end_row == 2
       assert model.selection.end_col == 7
+    end
+
+    test "scrolled simple window keeps overscan rows and matching scroll presentation metadata" do
+      state =
+        gui_state(rows: 5, cols: 20, content: "def foo do\n  if x do\n    :ok\n  end\nend\n:tail")
+
+      buffer = state.workspace.buffers.active
+      :ok = BufferProcess.move_to(buffer, {2, 4})
+
+      win_id = state.workspace.windows.active
+      window = Map.fetch!(state.workspace.windows.map, win_id)
+      window = EditorWindow.set_viewport(window, Viewport.put_top(window.viewport, 1))
+
+      windows =
+        Windows.set_map(
+          state.workspace.windows,
+          Map.put(state.workspace.windows.map, win_id, window)
+        )
+
+      state = %{state | workspace: %{state.workspace | windows: windows}}
+
+      {[wf], _cursor, _state} = build_content(state)
+      model = wf.window_model
+      presentation = ScrollPresentation.from_window(model)
+
+      assert Enum.map(model.rows, & &1.text) == [
+               "def foo do",
+               "  if x do",
+               "    :ok",
+               "  end",
+               "end",
+               ":tail"
+             ]
+
+      assert model.indent_guides.line_indent_levels == [1, 2, 1, 0]
+      assert presentation != nil
+      assert presentation.window_id == model.window_id
+      assert presentation.visible_start_line == 1
+      assert presentation.visible_end_line == 5
+      assert presentation.overscan_start_line == 0
+      assert presentation.overscan_end_line == 6
+      assert presentation.content_epoch == model.content_epoch
+      assert presentation.reset_required == model.full_refresh
+      assert is_integer(presentation.layout_generation)
     end
 
     test "includes gutter and indent guide models built from current-frame data" do


### PR DESCRIPTION
# TL;DR
Minga now supports immediate client-local presentation scrolling while keeping BEAM-owned viewport state authoritative. The PR extends the existing scroll presentation contract into real BEAM overscan rows, Go TUI local row/cell presentation scroll, macOS 2D pixel presentation offsets, pointer normalization, and reconciliation resets.

Closes #2409

## Context
#2409 defines the smooth-scroll architecture: clients may make scroll motion feel immediate, but only by transforming committed content inside BEAM-provided geometry and reconciliation metadata. This PR builds on the merged contract work from #2420 and wires the behavior through both live frontends.

## Changes
- Fetches one committed overscan row above and below simple BEAM window mappings, then exposes visible and overscan ranges through `ScrollPresentation` metadata.
- Keeps semantic row rendering authoritative while letting clients choose a presentation source row inside the committed overscan range.
- Adds Go TUI ephemeral presentation scroll state keyed by window, content epoch, layout generation, and committed anchors.
- Adds Go TUI immediate cached integer-row and cell-column presentation scroll, including pointer-coordinate normalization before mouse events are sent back to BEAM.
- Extends macOS precise scrolling from vertical-only fractional offsets to 2D pixel offsets, with per-pane targeting, pointer normalization, and reset when the pointer leaves the target pane.
- Clips macOS text, selection, highlights, search, diagnostics, and annotations to pane content bounds so local motion cannot bleed into gutters or adjacent panes.
- Adds focused Go and Swift tests for presentation scroll, pointer normalization, horizontal accumulator behavior, and target reset behavior.

## Verification
- `make lint` passed, with existing oversized-struct warnings only.
- `mix protocol.gen --check` passed.
- `cd go/tui && go test ./...` passed: 409 tests.
- `mix compile --warnings-as-errors` passed.
- `mix test.llm test/minga/frontend/adapter/gui/window_encoder_test.exs test/minga_editor/render_model/window/builder_test.exs` passed: 30 tests.
- `mix test.llm test/minga_editor/integration/match_item_test.exs` passed after building/copying `minga-parser` into the test priv path.
- `mix test.llm test/minga_editor/commands/structural_navigation_test.exs` passed after the same parser setup.
- `mix test.llm test/minga_editor/handlers/gui_action_git_async_test.exs` passed in isolation after one full-suite log-capture pollution failure.
- `mix test.llm test/minga_editor/integration/agent_cursor_test.exs` passed in isolation after one full-suite startup timeout under load.
- `git diff --check` passed.

Local caveat: `mix swift.build` skipped because this environment does not have `xcodebuild`. Swift changes were statically reviewed and covered by updated Swift tests, but macOS CI should run the real Swift build.

## Acceptance Criteria Addressed
- Scrolling starts visually on the client without waiting for a BEAM frame when committed overscan content exists ✅
- BEAM remains authoritative for logical viewport, layout, cursor, selection, hit-test geometry, wrapping, folds, and emitted rows ✅
- Client-local scroll state is frontend-only and discardable on invalidation ✅
- Frames carry anchor, content epoch, visible range, overscan range, and layout generation for reconciliation ✅
- Frontends transform only committed/cached rows inside pane bounds, with clipping to prevent blank/stale/bleed behavior ✅
- Pointer input is normalized through the active presentation transform before BEAM receives mouse events ✅
- Reconciliation clears local presentation state on reset flags, anchor drift, content epoch changes, and layout generation changes ✅
- macOS supports 2D pixel presentation offsets; Go TUI supports immediate integer row/cell cached scrolling ✅

## Review Notes
A focused bug-hunting pass found row-coordinate and macOS clipping issues during development. Those blockers were fixed, and targeted re-review passed. A final reviewer gate then found the Go pointer-normalization gap; that was fixed and targeted re-review passed.
