### PR TITLE
docs(frontend): clarify local semantic interaction state

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,6 +391,10 @@ A frame is atomic on the wire. The Emit stage brackets every frame's semantic an
 
 **The ephemeral-layer carve-out.** The transaction model says the BEAM owns structure, not pixels. A documented client-local ephemeral layer states what a frontend may render *between* commits without a round-trip: cursor blink, spinners, smooth scroll, local scrollback. The line is hit-testing: anything the BEAM hit-tests against (any placed surface) must come through a frame transaction, because input correctness depends on the BEAM and the frontend agreeing on geometry. Purely visual, non-interactive motion may live in the frontend. This is an accepted, bounded impurity, not a general escape hatch.
 
+**Frontend-local interaction state.** Semantic frontends are not dumb terminals. The BEAM owns the authoritative semantic model, durable editor state, placement, stacking, containment, and validation of committed actions. Frontends own zero-latency local interaction state when it can be resolved from the last committed semantic model and has no durable effect until activation. This is not about event frequency. It is about whether the interaction should feel instant without waiting for a BEAM render transaction.
+
+File tree is the canonical example. The BEAM sends stable row IDs, paths, labels, icons, expansion state, git state, diagnostics, focus context, and inline editing state. The frontend may own transient row selection while the user navigates the already committed row model. On activation, toggle, rename, delete, drag/drop, or another committed intent, the frontend sends a semantic action with stable row identity. The BEAM validates the action against its current model and may resync if the row is stale.
+
 ---
 
 ## Surface Placement Authority
@@ -407,7 +411,7 @@ This is the design of record (recorded on epic #2330) for all surface input:
 
 > **Clients resolve clicks on content they render and send semantic intents (`gui_actions`); the BEAM owns placement, stacking, and containment for registry-placed surfaces.**
 
-A frontend hit-tests its own rendered content and emits an intent ("completion item 3 selected", "notification N dismissed"), exactly the contract SwiftUI already uses (native hit-test → `gui_action`). One pipeline, one way of doing things, on every client. The BEAM does not re-derive what a click means on rendered content. It owns structure: which rect a surface occupies, which surface wins when rects overlap (stacking depends on editor state only the BEAM has), and containment, so a click that misses every interactive element of a placed surface is swallowed (`MingaEditor.Input.OverlaySink`) instead of falling through to the buffer underneath.
+A frontend hit-tests its own rendered content and emits an intent ("completion item 3 selected", "notification N dismissed"), exactly the contract SwiftUI already uses (native hit-test to `gui_action`). One pipeline, one way of doing things, on every client. The BEAM does not re-derive what a click means on rendered content. It owns structure: which rect a surface occupies, which surface wins when rects overlap (stacking depends on editor state only the BEAM has), and containment, so a click that misses every interactive element of a placed surface is swallowed (`MingaEditor.Input.OverlaySink`) instead of falling through to the buffer underneath.
 
 Worked examples. Completion menu, notifications (dismiss and action), observatory rows, edit-timeline entries, and the float popup are all client-resolved on both frontends: the Go TUI tracks click zones (`completion:item:`, `notification:action:`, `observatory:node:`, `timeline:entry:`) and emits the matching `gui_action`, mirroring SwiftUI's native hit-testing. **The picker is the one documented exception:** it predates this rule and stays BEAM-resolved as shipped, to be aligned only if it ever needs rework.
 

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -128,7 +128,7 @@ When `visible == 0`, the frontend should hide the Observatory and clear selected
 
 ### 0x93 — gui_file_tree
 
-The native file tree receives the same semantic row model that the TUI renderer uses. The BEAM remains the source of truth for row identity, depth, selected/focused state, expansion state, git status, diagnostics, guide columns, icons, labels, and inline editing state. Swift should render this state directly and send user actions back through the existing file-tree action opcodes.
+The native file tree receives the same semantic row model that the TUI renderer uses. The BEAM remains the source of truth for row identity, depth, expansion state, git status, diagnostics, guide columns, icons, labels, focus context, inline editing state, and committed file actions. Semantic frontends are not dumb terminals: they may own zero-latency local interaction state, such as transient row selection while the user navigates the already committed row model. On activation, toggle, rename, delete, drag/drop, or another committed intent, the frontend sends a semantic action with stable row identity and the BEAM validates it against the current model.
 
 Legacy note: early GUI prototypes used the low 0x70 chrome range and inferred hidden state from an empty entry list. New frontends must ignore that sentinel behavior. `0x93` v2 is the canonical file-tree protocol, and `tree_state` is the only source of truth for hidden, loading, empty, ready, and error states.
 
@@ -182,7 +182,7 @@ When `tree_state == 4`, `error_reason` contains a short user-displayable reason.
 
 ### 0x94 — gui_file_tree_selection
 
-Selection and focus changes are common while navigating large trees. The BEAM sends this small update when the row model itself has not changed, so the native sidebar can update selection without receiving or decoding the full tree payload again.
+Selection and focus changes can still originate from the BEAM, for example after focus restoration, reveal-active-file, stale-row resync, or compatibility paths that still route navigation through the editor. The BEAM sends this small update when the row model itself has not changed, so the native sidebar can update selection without receiving or decoding the full tree payload again. This opcode is not a requirement that every transient navigation step round-trip through the BEAM.
 
 ```
 opcode(1) + payload_len(2) + payload(payload_len)

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -167,7 +167,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
           MingaEditor.Input.Handler.result()
   defp handle_non_leader_file_tree_key(state, cp, mods) do
     if Input.key_sequence_pending?(state) do
-      {:handled, delegate_to_mode_fsm_with_tree_buffer(state, cp, mods)}
+      {:handled, legacy_delegate_navigation_to_fake_tree_buffer(state, cp, mods)}
     else
       key = {cp, mods}
 
@@ -187,7 +187,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
           {:handled, state}
 
         :not_found ->
-          {:handled, delegate_to_mode_fsm_with_tree_buffer(state, cp, mods)}
+          {:handled, legacy_delegate_navigation_to_fake_tree_buffer(state, cp, mods)}
       end
     end
   end
@@ -207,13 +207,15 @@ defmodule MingaEditor.Input.FileTreeHandler do
     end
   end
 
-  @spec delegate_to_mode_fsm_with_tree_buffer(
+  # Legacy BEAM-round-tripped navigation path.
+  # This exists for compatibility with Vim motions that have not moved to the semantic frontend-local interaction contract yet. Semantic frontends should own zero-latency local file-tree selection over the last committed row model and send BEAM actions only when the user commits an intent such as open, toggle, rename, delete, or drop. See docs/ARCHITECTURE.md and docs/GUI_PROTOCOL.md.
+  @spec legacy_delegate_navigation_to_fake_tree_buffer(
           EditorState.t(),
           non_neg_integer(),
           non_neg_integer()
         ) ::
           EditorState.t()
-  defp delegate_to_mode_fsm_with_tree_buffer(state, cp, mods) do
+  defp legacy_delegate_navigation_to_fake_tree_buffer(state, cp, mods) do
     case file_tree_state(state).buffer do
       buf when is_pid(buf) ->
         real_active = state.workspace.buffers.active


### PR DESCRIPTION
# TL;DR
Clarifies that semantic frontends own zero-latency local interaction state when it can be resolved from the last committed model and has no durable effect until activation. Marks the current file-tree fake-buffer navigation path as legacy compatibility debt.

## Context
This PR makes the intended semantic UI ownership model explicit so future work does not misread the current file-tree keyboard path as the target architecture. The important distinction is zero-latency local interaction, not event frequency.

## Changes
- Added a frontend-local interaction state rule to `docs/ARCHITECTURE.md`.
- Updated the file-tree protocol docs to clarify that `gui_file_tree_selection` can support BEAM-originated selection changes but does not require every transient navigation step to round-trip through BEAM.
- Renamed the file-tree fake-buffer delegation helper to `legacy_delegate_navigation_to_fake_tree_buffer/3` and documented why it is compatibility debt.

## Verification
- `mix format lib/minga_editor/input/file_tree_handler.ex`
- `mix compile --warnings-as-errors`
- `git diff --check`
