### PR TITLE
fix(agent): repair unconfigured workspace UX

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -966,9 +966,9 @@ Per visible tab:
   + path_len(2) + path(path_len) + tint_color_rgb(4)
 ```
 
-`version` is currently 2. Version 2 adds `tint_color_rgb` to each visible tab entry and bit 5 for pinned tabs. `mode`: 0 = editor, 1 = agent, 2 = file_tree, 3 = other. Workspace `kind`: 0 = manual, 1 = agent. Visible tab `kind`: 0 = file. `status`: 0 = idle, 1 = thinking, 2 = tool_executing, 3 = error, 4 = plan. Workspace flags: bit 0 = attention, bit 1 = closeable. Visible tab flags: bit 0 = dirty, bit 1 = attention, bit 2 = draft, bit 3 = draft_elsewhere, bit 4 = conflict, bit 5 = pinned. `tint_color_rgb` is `0` for no tint, otherwise `0xRRGGBB`.
+`version` is currently 2. Version 2 adds `tint_color_rgb` to each visible tab entry and bit 5 for pinned tabs. `mode`: 0 = editor, 1 = agent, 2 = file_tree, 3 = other. Workspace `kind`: 0 = manual, 1 = agent. Visible tab `kind`: 0 = file, 1 = agent. `status`: 0 = idle, 1 = thinking, 2 = tool_executing, 3 = error, 4 = plan. Workspace flags: bit 0 = attention, bit 1 = closeable. Visible tab flags: bit 0 = dirty, bit 1 = attention, bit 2 = draft, bit 3 = draft_elsewhere, bit 4 = conflict, bit 5 = pinned. `tint_color_rgb` is `0` for no tint, otherwise `0xRRGGBB`.
 
-The workspace list includes the manual project workspace and all agent workspaces. The visible tab list includes only file tabs for the active workspace. Agent view remains a workspace zoom surface, so it is not encoded as a normal file tab.
+The workspace list includes the manual project workspace and all agent workspaces. The visible tab list includes the active workspace's agent tab first when present, followed by its file tabs. Agent view remains a workspace zoom surface, so it is not encoded as a normal file tab.
 
 ### 0x99 — gui_notifications
 

--- a/lib/minga/frontend/adapter/gui/workspaces_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/workspaces_encoder.ex
@@ -121,6 +121,7 @@ defmodule Minga.Frontend.Adapter.GUI.WorkspacesEncoder do
 
   @spec encode_tab_kind(VisibleTab.kind()) :: non_neg_integer()
   defp encode_tab_kind(:file), do: 0
+  defp encode_tab_kind(:agent), do: 1
 
   @spec encode_visible_tab_flags(VisibleTab.t()) :: non_neg_integer()
   defp encode_visible_tab_flags(%VisibleTab{} = tab) do

--- a/lib/minga/render_model/ui/workspaces/visible_tab.ex
+++ b/lib/minga/render_model/ui/workspaces/visible_tab.ex
@@ -1,7 +1,7 @@
 defmodule Minga.RenderModel.UI.Workspaces.VisibleTab do
   @moduledoc false
 
-  @type kind :: :file
+  @type kind :: :file | :agent
   @type draft_state :: :none | :draft | :draft_elsewhere | :conflict
 
   @type t :: %__MODULE__{

--- a/lib/minga_agent/config.ex
+++ b/lib/minga_agent/config.ex
@@ -21,12 +21,12 @@ defmodule MingaAgent.Config do
   alias MingaAgent.Hooks.Hook
   alias MingaAgent.Hooks.Registry, as: HookRegistry
 
-  @default_model "anthropic:claude-sonnet-4"
+  @unconfigured_model "unknown"
 
   defstruct [
     # Provider & model
     provider: :auto,
-    model: @default_model,
+    model: @unconfigured_model,
     models: [],
 
     # Generation
@@ -138,7 +138,7 @@ defmodule MingaAgent.Config do
   def resolve do
     %__MODULE__{
       provider: get(:agent_provider, :auto),
-      model: get(:agent_model, nil) || @default_model,
+      model: resolve_model(),
       models: get(:agent_models, []),
       max_tokens: get(:agent_max_tokens, 16_384),
       prompt_cache: get(:agent_prompt_cache, true),
@@ -174,9 +174,13 @@ defmodule MingaAgent.Config do
     }
   end
 
-  @doc "Returns the default model string (with provider prefix)."
+  @doc "Returns the model used for new sessions when the user has not explicitly configured one."
   @spec default_model() :: String.t()
-  def default_model, do: @default_model
+  def default_model, do: resolve_model()
+
+  @doc "Returns the internal sentinel used when no configured provider has an available model."
+  @spec unconfigured_model() :: String.t()
+  def unconfigured_model, do: @unconfigured_model
 
   @doc "Returns a config with agent hooks disabled."
   @spec without_hooks(t()) :: t()
@@ -212,15 +216,22 @@ defmodule MingaAgent.Config do
   def normalize_hooks(_raw_hooks), do: raise(ArgumentError, ":agent_hooks must be a list")
 
   @doc """
-  Returns the configured model, falling back to the default.
+  Returns the configured model, then the first available credential-backed model.
 
-  Safe to call before Config is running (catches exits).
+  Safe to call before Config is running (catches exits). If no provider has credentials, returns the internal `"unknown"` sentinel rather than pretending a specific vendor model is ready.
   """
   @spec resolve_model() :: String.t()
   def resolve_model do
+    configured_model() || first_available_model() || @unconfigured_model
+  end
+
+  @doc "Returns the explicitly configured model, or nil when the user has not chosen one."
+  @spec configured_model() :: String.t() | nil
+  def configured_model do
     case get(:agent_model, nil) do
-      nil -> @default_model
-      model -> to_string(model)
+      model when is_binary(model) and model != "" -> model
+      model when model != nil -> to_string(model)
+      _other -> nil
     end
   end
 
@@ -235,45 +246,70 @@ defmodule MingaAgent.Config do
   end
 
   @doc """
-  Strips the "provider:" prefix from a model spec string.
+  Splits a model spec into `{model, provider}` regardless of whether the user wrote `provider:model` or `model@provider`.
 
-  Returns the bare model name. If there's no prefix, returns the string unchanged.
+  Returns `{bare_model, nil}` when no provider is encoded in the string.
 
   ## Examples
 
-      iex> MingaAgent.Config.strip_provider_prefix("anthropic:claude-sonnet-4")
-      "claude-sonnet-4"
+      iex> MingaAgent.Config.split_model_spec("anthropic:claude-sonnet-4")
+      {"claude-sonnet-4", "anthropic"}
 
-      iex> MingaAgent.Config.strip_provider_prefix("claude-sonnet-4")
-      "claude-sonnet-4"
+      iex> MingaAgent.Config.split_model_spec("claude-sonnet-4@anthropic")
+      {"claude-sonnet-4", "anthropic"}
+
+      iex> MingaAgent.Config.split_model_spec("claude-sonnet-4")
+      {"claude-sonnet-4", nil}
+  """
+  @spec split_model_spec(String.t()) :: {String.t(), String.t() | nil}
+  def split_model_spec(model) when is_binary(model) do
+    case String.split(model, "@", parts: 2) do
+      [name, provider] when name != "" and provider != "" ->
+        {name, String.downcase(provider)}
+
+      _ ->
+        case String.split(model, ":", parts: 2) do
+          [provider, name] when provider != "" and name != "" -> {name, String.downcase(provider)}
+          [name] -> {name, nil}
+          _ -> {model, nil}
+        end
+    end
+  end
+
+  @doc """
+  Strips the provider encoding from a model spec string.
+
+  Returns the bare model name. If there's no provider encoding, returns the string unchanged.
   """
   @spec strip_provider_prefix(String.t()) :: String.t()
   def strip_provider_prefix(model) when is_binary(model) do
-    case String.split(model, ":", parts: 2) do
-      [_provider, name] -> name
-      [name] -> name
-    end
+    {name, _provider} = split_model_spec(model)
+    name
   end
 
   @doc """
   Extracts the provider prefix from a model spec string.
 
   Returns the provider name, or `""` if no prefix is present.
-
-  ## Examples
-
-      iex> MingaAgent.Config.extract_provider_prefix("openai_codex:gpt-5.3-codex-spark")
-      "openai_codex"
-
-      iex> MingaAgent.Config.extract_provider_prefix("claude-sonnet-4")
-      ""
   """
   @spec extract_provider_prefix(String.t()) :: String.t()
   def extract_provider_prefix(model) when is_binary(model) do
-    case String.split(model, ":", parts: 2) do
-      [provider, _name] -> provider
-      [_name] -> ""
+    case split_model_spec(model) do
+      {_name, provider} when is_binary(provider) -> provider
+      _ -> ""
     end
+  end
+
+  @spec first_available_model() :: String.t() | nil
+  defp first_available_model do
+    case MingaAgent.ModelCatalog.available_models("") do
+      [%{"id" => model} | _rest] when is_binary(model) and model != "" -> model
+      _other -> nil
+    end
+  rescue
+    _ -> nil
+  catch
+    :exit, _ -> nil
   end
 
   @spec non_empty_env(String.t()) :: String.t() | nil

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -66,6 +66,9 @@ defmodule MingaAgent.Session do
   @typedoc "Context inherited by child subagent sessions."
   @type subagent_context :: SubagentContext.t()
 
+  @typedoc "Callback that reports whether credentials are currently configured."
+  @type credentials_configured_fn :: (-> boolean())
+
   @typedoc "Active tool call tracked while the provider is executing tools."
   @type active_tool_call :: {tool_call_id :: String.t(), name :: String.t()}
 
@@ -84,6 +87,7 @@ defmodule MingaAgent.Session do
           provider_source: Minga.Extension.ContributionCleanup.contribution_source(),
           provider_lease: CodeLease.t() | nil,
           provider_opts: keyword(),
+          credentials_configured_fn: credentials_configured_fn(),
           status: status(),
           messages: [Message.t()],
           message_ids: [pos_integer()],
@@ -236,7 +240,8 @@ defmodule MingaAgent.Session do
           status: status(),
           pending_approval: map() | nil,
           error: String.t() | nil,
-          active_tool_name: String.t() | nil
+          active_tool_name: String.t() | nil,
+          credentials_configured: boolean()
         }
 
   @doc "Returns a snapshot of session state for the editor to rebuild AgentState."
@@ -635,28 +640,47 @@ defmodule MingaAgent.Session do
 
   @spec do_init(keyword()) :: {:ok, state()}
   defp do_init(opts) do
-    provider_resolution = resolve_provider(opts)
-    provider_module = provider_resolution.module
-
-    provider_lease =
-      acquire_provider_lease!(provider_resolution.source, provider_module, provider_resolution.id)
-
     provider_opts =
       Keyword.merge(
         [subscriber: self()],
         Keyword.get(opts, :provider_opts, [])
       )
 
+    credentials_configured_fn =
+      Keyword.get(opts, :credentials_configured_fn, &Credentials.any_configured?/0)
+
     initial_thinking_level = Keyword.get(opts, :thinking_level)
     timestamp = Calendar.strftime(DateTime.utc_now(), "%H:%M:%S UTC")
 
     session_id = Keyword.get(opts, :session_id, generate_session_id())
-    model_name = Keyword.get(opts, :model_name, "unknown")
+    model_name = session_model_name(opts, provider_opts)
+    resolved_provider_resolution = resolve_provider(opts)
 
-    provider_name =
-      provider_opts
-      |> Keyword.get(:provider, "unknown")
-      |> to_string()
+    credentials_configured? =
+      session_credentials_configured?(
+        resolved_provider_resolution.module,
+        provider_opts,
+        credentials_configured_fn
+      )
+
+    provider_resolution =
+      if credentials_configured?,
+        do: resolved_provider_resolution,
+        else: unconfigured_provider_resolution()
+
+    provider_module = provider_resolution.module
+
+    {provider_name, provider_opts} =
+      session_provider_configuration(provider_module, model_name, provider_opts)
+
+    provider_lease =
+      if credentials_configured? do
+        acquire_provider_lease!(
+          provider_resolution.source,
+          provider_module,
+          provider_resolution.id
+        )
+      end
 
     now = DateTime.utc_now()
 
@@ -671,6 +695,7 @@ defmodule MingaAgent.Session do
       provider_source: provider_resolution.source,
       provider_lease: provider_lease,
       provider_opts: provider_opts,
+      credentials_configured_fn: credentials_configured_fn,
       status: :idle,
       messages: [
         Message.system(initial_system_message(timestamp, Keyword.get(opts, :startup_notice)))
@@ -711,7 +736,7 @@ defmodule MingaAgent.Session do
       touched_files: %{},
       boundaries: %{},
       pinned_ids: MapSet.new(),
-      credentials_configured: true
+      credentials_configured: credentials_configured?
     }
 
     maybe_mark_interrupted_work(state, Keyword.get(opts, :recover_interrupted_work?, true))
@@ -727,8 +752,11 @@ defmodule MingaAgent.Session do
       state.event_log_server
     )
 
-    # Start provider asynchronously so init doesn't block
-    send(self(), :start_provider)
+    # Start provider asynchronously so init doesn't block. An unconfigured local
+    # session is still useful for draft preservation, but must not boot a provider.
+    if credentials_configured? do
+      send(self(), :start_provider)
+    end
 
     {:ok, schedule_idle_gc(state, state.idle_gc_timeout_ms > 0, nil, state.idle_gc_timeout_ms)}
   end
@@ -1027,7 +1055,8 @@ defmodule MingaAgent.Session do
       status: state.status,
       pending_approval: public_pending_approval(state.pending_approval),
       error: state.error_message,
-      active_tool_name: state.active_tool_name
+      active_tool_name: state.active_tool_name,
+      credentials_configured: state.credentials_configured
     }
 
     {:reply, snapshot, state}
@@ -1089,6 +1118,7 @@ defmodule MingaAgent.Session do
       true ->
         Process.monitor(pid)
         state = state |> cancel_idle_gc_timer() |> put_subscriber(pid, role)
+        send(pid, {:agent_event, self(), {:credentials_status, state.credentials_configured}})
         {:reply, :ok, state}
 
       false ->
@@ -1211,13 +1241,24 @@ defmodule MingaAgent.Session do
     {:reply, result, state}
   end
 
-  def handle_call({:set_model, _model}, _from, %{provider: nil} = state) do
-    {:reply, {:error, :provider_not_ready}, state}
-  end
-
   def handle_call({:set_model, model}, _from, state) do
-    result = dispatch_optional(state.provider_module, :set_model, [state.provider, model])
-    state = %{state | model_name: model}
+    {state, refresh_result} =
+      state
+      |> update_model_configuration(model)
+      |> refresh_credentials_state_result()
+
+    result =
+      case {state.provider, refresh_result} do
+        {nil, {:error, reason}} ->
+          {:error, reason}
+
+        {nil, :ok} ->
+          :ok
+
+        {provider, _refresh_result} ->
+          dispatch_optional(state.provider_module, :set_model, [provider, model])
+      end
+
     {:reply, result, state}
   end
 
@@ -1305,25 +1346,7 @@ defmodule MingaAgent.Session do
 
   @impl GenServer
   def handle_info(:start_provider, state) do
-    case start_provider(state) do
-      {:ok, pid, lease} ->
-        Process.monitor(pid)
-        state = %{state | provider: pid, provider_lease: lease}
-        state = seed_provider_messages(state, state.messages)
-        state = apply_pending_thinking_level(state)
-        state = refresh_credentials_state(state)
-        state = maybe_show_auth_onboarding(state)
-        dispatch_session_start(state)
-        {:noreply, state}
-
-      {:error, reason} ->
-        Minga.Log.error(:agent, "[Agent.Session] failed to start provider: #{inspect(reason)}")
-        release_provider_lease(state.provider_lease)
-        state = %{state | provider_lease: nil, error_message: format_error(reason)}
-        state = set_error_status(state)
-        broadcast(state, {:error, state.error_message})
-        {:noreply, state}
-    end
+    {:noreply, refresh_credentials_state(state)}
   end
 
   def handle_info({:agent_provider_event, event}, state) do
@@ -1452,8 +1475,18 @@ defmodule MingaAgent.Session do
 
   @spec handle_send_prompt(String.t() | [ReqLLM.Message.ContentPart.t()], state()) ::
           {:reply, :ok | {:queued, :steering} | {:error, term()}, state()}
-  defp handle_send_prompt(_text, %{provider: nil} = state) do
-    {:reply, {:error, :provider_not_ready}, state}
+  defp handle_send_prompt(_content, %{credentials_configured: false} = state) do
+    # No usable provider yet. Refuse locally so callers can preserve the draft instead of clearing it.
+    {:reply, {:error, :credentials_not_configured}, state}
+  end
+
+  defp handle_send_prompt(content, %{provider: nil} = state) do
+    state = refresh_credentials_state(state)
+
+    case state.provider do
+      nil -> {:reply, {:error, :provider_not_ready}, state}
+      _ -> handle_send_prompt(content, state)
+    end
   end
 
   defp handle_send_prompt(content, %{status: status} = state)
@@ -1463,23 +1496,6 @@ defmodule MingaAgent.Session do
     state = %{state | steering_queue: state.steering_queue ++ [content]}
     broadcast(state, {:prompt_queued, content, :steering})
     {:reply, {:queued, :steering}, state}
-  end
-
-  defp handle_send_prompt(content, %{credentials_configured: false} = state) do
-    # No usable provider yet. Show the user's message followed by a gentle
-    # setup nudge instead of attempting a call that would fail with a raw
-    # provider error. Reply :ok so the input clears like a normal submit.
-    {user_msg, _send_content} = build_user_message(content)
-
-    state = append_msg(state, user_msg)
-    record_user_message(state, user_msg)
-
-    state =
-      state
-      |> append_system_message(auth_required_message(), :info)
-      |> notify_messages_changed()
-
-    {:reply, :ok, state}
   end
 
   defp handle_send_prompt(content, state) do
@@ -2687,6 +2703,13 @@ defmodule MingaAgent.Session do
   end
 
   @spec provider_name(map(), state()) :: String.t()
+  defp provider_name(_provider_state, %{
+         provider_module: MingaAgent.Providers.Native,
+         provider_name: provider_name
+       })
+       when provider_name not in ["", "unknown"],
+       do: provider_name
+
   defp provider_name(%{model: %{provider: provider}}, _state) when is_binary(provider),
     do: provider
 
@@ -2733,17 +2756,148 @@ defmodule MingaAgent.Session do
   # runs in the session process, off the render path.
   @spec refresh_credentials_state(state()) :: state()
   defp refresh_credentials_state(state) do
+    {state, _result} = refresh_credentials_state_result(state)
+    state
+  end
+
+  @spec refresh_credentials_state_result(state()) :: {state(), :ok | {:error, term()}}
+  defp refresh_credentials_state_result(state) do
     # Only the native provider resolves its own credentials from the
     # environment. Custom providers, and any caller that injects its own
     # `:llm_client` (tests, embedded transports), manage their own auth, so
     # treat them as always ready.
     configured? =
-      state.provider_module != MingaAgent.Providers.Native or
-        Keyword.has_key?(state.provider_opts, :llm_client) or
-        Credentials.any_configured?()
+      session_credentials_configured?(
+        state.provider_module,
+        state.provider_opts,
+        state.credentials_configured_fn
+      )
 
     state = %{state | credentials_configured: configured?}
+    {state, result} = maybe_start_provider_result(state)
     broadcast(state, {:credentials_status, configured?})
+    {state, result}
+  end
+
+  @spec update_model_configuration(state(), String.t()) :: state()
+  defp update_model_configuration(state, model) do
+    {provider_name, provider_opts} =
+      session_provider_configuration(state.provider_module, model, state.provider_opts)
+
+    %{
+      state
+      | model_name: model,
+        provider_name: provider_name,
+        provider_opts: provider_opts,
+        error_message: nil
+    }
+  end
+
+  @spec session_provider_configuration(module(), String.t(), keyword()) :: {String.t(), keyword()}
+  defp session_provider_configuration(provider_module, model, provider_opts) do
+    provider = session_model_provider(provider_module, model)
+
+    provider_opts =
+      provider_opts
+      |> Keyword.put(:model, model)
+      |> maybe_put_provider(provider)
+
+    {session_provider_name(provider, provider_opts), provider_opts}
+  end
+
+  @spec session_model_provider(module(), String.t()) :: String.t() | nil
+  defp session_model_provider(MingaAgent.Providers.Native, model) do
+    case AgentConfig.extract_provider_prefix(model) do
+      "" -> nil
+      provider -> String.downcase(provider)
+    end
+  end
+
+  defp session_model_provider(_provider_module, _model), do: nil
+
+  @spec session_provider_name(String.t() | nil, keyword()) :: String.t()
+  defp session_provider_name(provider, _provider_opts) when is_binary(provider), do: provider
+
+  defp session_provider_name(_provider, provider_opts) do
+    provider_opts
+    |> Keyword.get(:provider, "unknown")
+    |> to_string()
+  end
+
+  @spec maybe_put_provider(keyword(), String.t() | nil) :: keyword()
+  defp maybe_put_provider(provider_opts, nil), do: provider_opts
+  defp maybe_put_provider(provider_opts, ""), do: provider_opts
+
+  defp maybe_put_provider(provider_opts, provider) when is_binary(provider) do
+    Keyword.put(provider_opts, :provider, provider)
+  end
+
+  @spec session_model_name(keyword(), keyword()) :: String.t()
+  defp session_model_name(opts, provider_opts) do
+    unconfigured_model = AgentConfig.unconfigured_model()
+
+    case Keyword.get(opts, :model_name) do
+      model when is_binary(model) and model != "" and model != unconfigured_model ->
+        model
+
+      _ ->
+        provider_model_name(provider_opts, unconfigured_model) || unconfigured_model
+    end
+  end
+
+  @spec provider_model_name(keyword(), String.t()) :: String.t() | nil
+  defp provider_model_name(provider_opts, unconfigured_model) do
+    case Keyword.get(provider_opts, :model) do
+      model when is_binary(model) and model != "" and model != unconfigured_model ->
+        model
+
+      _ ->
+        nil
+    end
+  end
+
+  @spec maybe_start_provider_result(state()) :: {state(), :ok | {:error, term()}}
+  defp maybe_start_provider_result(%{provider: nil, credentials_configured: true} = state) do
+    if provider_startable?(state.provider_module, state.provider_opts, state.model_name) do
+      case start_provider(state) do
+        {:ok, pid, lease} ->
+          {attach_provider(state, pid, lease), :ok}
+
+        {:error, reason} ->
+          state = report_provider_start_error(state, reason)
+          {state, {:error, state.error_message}}
+      end
+    else
+      {state, :ok}
+    end
+  end
+
+  defp maybe_start_provider_result(state), do: {state, :ok}
+
+  @spec attach_provider(state(), pid(), CodeLease.t() | nil) :: state()
+  defp attach_provider(state, pid, lease) do
+    Process.monitor(pid)
+    state = clear_provider_start_error(%{state | provider: pid, provider_lease: lease})
+    state = seed_provider_messages(state, state.messages)
+    state = apply_pending_thinking_level(state)
+    state = maybe_show_auth_onboarding(state)
+    dispatch_session_start(state)
+    state
+  end
+
+  @spec clear_provider_start_error(state()) :: state()
+  defp clear_provider_start_error(%{status: :error} = state),
+    do: %{state | status: :idle, error_message: nil}
+
+  defp clear_provider_start_error(state), do: %{state | error_message: nil}
+
+  @spec report_provider_start_error(state(), term()) :: state()
+  defp report_provider_start_error(state, reason) do
+    Minga.Log.error(:agent, "[Agent.Session] failed to start provider: #{inspect(reason)}")
+    release_provider_lease(state.provider_lease)
+    state = %{state | provider_lease: nil, error_message: format_error(reason)}
+    state = set_error_status(state)
+    broadcast(state, {:error, state.error_message})
     state
   end
 
@@ -2783,22 +2937,6 @@ defmodule MingaAgent.Session do
 
     Ollama is detected automatically if it's running locally.
     Run /auth to see status for all providers.\
-    """
-  end
-
-  # Shown when the user submits a prompt before any provider is configured.
-  @spec auth_required_message() :: String.t()
-  defp auth_required_message do
-    """
-    No provider is configured yet, so there's nothing to send your message to.
-
-    Set one up to get started:
-
-      /auth anthropic <key>     add an API key (most common)
-      /login                    ChatGPT subscription (OpenAI only)
-      /login --manual           ChatGPT subscription on a headless server
-
-    Run /auth to see all providers and options.\
     """
   end
 
@@ -2901,6 +3039,33 @@ defmodule MingaAgent.Session do
   # Determines which provider module to use. If an explicit `:provider` option is
   # passed (common in tests and from existing code), use that as a config-owned provider. Otherwise, delegate
   # to the ProviderResolver which checks config and the provider registry.
+  @spec session_credentials_configured?(module(), keyword(), credentials_configured_fn()) ::
+          boolean()
+  defp session_credentials_configured?(provider_module, provider_opts, credentials_configured_fn) do
+    provider_module != MingaAgent.Providers.Native or
+      Keyword.has_key?(provider_opts, :llm_client) or
+      credentials_configured_fn.()
+  end
+
+  @spec provider_startable?(module(), keyword(), String.t()) :: boolean()
+  defp provider_startable?(provider_module, provider_opts, model_name) do
+    provider_module != MingaAgent.Providers.Native or
+      Keyword.has_key?(provider_opts, :llm_client) or
+      model_name != AgentConfig.unconfigured_model()
+  end
+
+  @spec unconfigured_provider_resolution() :: ProviderResolver.resolved()
+  defp unconfigured_provider_resolution do
+    %ProviderResolver.Resolved{
+      id: "unconfigured",
+      source: :config,
+      module: MingaAgent.Providers.Native,
+      name: "unconfigured",
+      display_name: "Unconfigured",
+      spec: nil
+    }
+  end
+
   @spec resolve_provider(keyword()) :: ProviderResolver.resolved()
   defp resolve_provider(opts) do
     case Keyword.fetch(opts, :provider) do

--- a/lib/minga_editor/agent/ui_state.ex
+++ b/lib/minga_editor/agent/ui_state.ex
@@ -42,9 +42,9 @@ defmodule MingaEditor.Agent.UIState do
   # Minimum number of lines for a paste to be collapsed.
   @paste_collapse_threshold 3
 
-  @doc "Creates a new UIState with default sub-structs."
+  @doc "Creates a new UIState with credential-aware panel defaults."
   @spec new() :: t()
-  def new, do: %__MODULE__{}
+  def new, do: %__MODULE__{panel: Panel.new()}
 
   # ── Prompt buffer lifecycle ─────────────────────────────────────────────
 
@@ -471,13 +471,13 @@ defmodule MingaEditor.Agent.UIState do
   @doc "Sets the model name."
   @spec set_model_name(t(), String.t()) :: t()
   def set_model_name(%__MODULE__{panel: panel} = state, model) do
-    %{state | panel: %{panel | model_name: model}}
+    %{state | panel: Panel.set_model_name(panel, model)}
   end
 
   @doc "Sets the provider name."
   @spec set_provider_name(t(), String.t()) :: t()
   def set_provider_name(%__MODULE__{panel: panel} = state, provider) do
-    %{state | panel: %{panel | provider_name: provider}}
+    %{state | panel: Panel.set_provider_name(panel, provider)}
   end
 
   @doc "Sets the scroll offset to an absolute value. Unpins from bottom."

--- a/lib/minga_editor/agent/ui_state/panel.ex
+++ b/lib/minga_editor/agent/ui_state/panel.ex
@@ -49,8 +49,8 @@ defmodule MingaEditor.Agent.UIState.Panel do
             prompt_history: [],
             history_index: -1,
             spinner_frame: 0,
-            provider_name: AgentConfig.extract_provider_prefix(AgentConfig.default_model()),
-            model_name: AgentConfig.default_model(),
+            provider_name: "",
+            model_name: "unknown",
             thinking_level: "medium",
             input_focused: false,
             display_start_index: 0,
@@ -61,19 +61,37 @@ defmodule MingaEditor.Agent.UIState.Panel do
             cached_display_message_pairs: [],
             cached_styled_messages: nil,
             message_version: 0,
-            # Assume configured until the session reports otherwise, so the
-            # common (authed) case never flashes a "not configured" indicator.
-            credentials_configured: true,
+            credentials_configured: false,
             provenance_jump: nil
 
-  @doc "Creates a new panel state with defaults."
+  @doc "Creates a new panel state with truthful model defaults."
   @spec new() :: t()
-  def new, do: %__MODULE__{}
+  def new do
+    model = AgentConfig.default_model()
+
+    %__MODULE__{
+      provider_name: AgentConfig.extract_provider_prefix(model),
+      model_name: model,
+      credentials_configured: false
+    }
+  end
 
   @doc "Sets whether any provider credential is configured (drives the model indicator)."
   @spec set_credentials_configured(t(), boolean()) :: t()
   def set_credentials_configured(%__MODULE__{} = panel, configured?) do
     %{panel | credentials_configured: configured?}
+  end
+
+  @doc "Sets the displayed provider name."
+  @spec set_provider_name(t(), String.t()) :: t()
+  def set_provider_name(%__MODULE__{} = panel, provider) when is_binary(provider) do
+    %{panel | provider_name: provider}
+  end
+
+  @doc "Sets the active model name."
+  @spec set_model_name(t(), String.t()) :: t()
+  def set_model_name(%__MODULE__{} = panel, model) when is_binary(model) do
+    %{panel | model_name: model}
   end
 
   @doc "Clears the active file mention completion."

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -46,6 +46,10 @@ defmodule MingaEditor.Commands.Agent do
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
 
+  @type prompt_readiness ::
+          :no_model | :credentials_missing | :starting | {:startup_failed, String.t()} | :ready
+  @type prompt_submit_status :: :ready | {:blocked, String.t()}
+
   @doc "Legacy alias for `toggle_agent_split/1`."
   @spec toggle_agentic_view(state()) :: state()
   def toggle_agentic_view(state), do: toggle_agent_split(state)
@@ -459,14 +463,17 @@ defmodule MingaEditor.Commands.Agent do
   @spec submit_prompt(state(), Panel.t(), boolean(), pid() | nil) :: state()
   defp submit_prompt(state, _panel, true, _session), do: state
 
-  defp submit_prompt(state, _panel, false, nil) do
-    EditorState.set_status(state, "No agent session, try closing and reopening the panel")
+  defp submit_prompt(state, panel, false, nil) do
+    case prompt_readiness(state, panel, nil) do
+      :no_model ->
+        EditorState.set_status(state, no_model_status())
+
+      _readiness ->
+        EditorState.set_status(state, "No agent session, try closing and reopening the panel")
+    end
   end
 
   defp submit_prompt(state, panel, false, _session) do
-    # Sending a new prompt ends any provenance jump: the user is driving the
-    # conversation again, so streaming should resume its bottom-pinned scroll.
-    state = AgentAccess.update_panel(state, &Panel.clear_provenance_jump/1)
     text = UIState.prompt_text(panel)
     submit_prompt_text(state, text, SlashCommand.slash_command?(text))
   end
@@ -508,21 +515,32 @@ defmodule MingaEditor.Commands.Agent do
     if remote_session_disconnected?(state) do
       EditorState.set_status(state, "Session disconnected. Your prompt will be preserved.")
     else
-      model = AgentAccess.panel(state).model_name
+      panel = AgentAccess.panel(state)
 
-      case resolve_prompt_for_session(state, text, model) do
-        {:ok, resolved} ->
+      case prompt_submit_status(state, panel) do
+        :ready ->
           state
-          |> clear_input_after_submit()
-          |> deliver_prompt(resolved)
+          |> AgentAccess.update_panel(&Panel.clear_provenance_jump/1)
+          |> resolve_and_deliver_prompt(text, panel.model_name)
 
-        {:error, msg} ->
+        {:blocked, msg} ->
           EditorState.set_status(state, msg)
       end
     end
   catch
     :exit, _ ->
       EditorState.set_status(state, "Agent session unavailable. Your prompt was preserved.")
+  end
+
+  @spec resolve_and_deliver_prompt(state(), String.t(), String.t()) :: state()
+  defp resolve_and_deliver_prompt(state, text, model) do
+    case resolve_prompt_for_session(state, text, model) do
+      {:ok, resolved} ->
+        deliver_prompt(state, resolved)
+
+      {:error, msg} ->
+        EditorState.set_status(state, msg)
+    end
   end
 
   # Clears the input and resets diff baselines after a prompt is submitted.
@@ -540,16 +558,18 @@ defmodule MingaEditor.Commands.Agent do
   defp deliver_prompt(state, resolved) do
     case AgentSession.send_prompt_pid(AgentAccess.session(state), resolved) do
       :ok ->
-        state
+        clear_input_after_submit(state)
 
       {:queued, :steering} ->
-        update_agent_ui(
-          state,
-          &UIState.push_toast(&1, "⏳ Queued (steer). Ctrl-C to cancel.", :info)
-        )
+        state
+        |> clear_input_after_submit()
+        |> update_agent_ui(&UIState.push_toast(&1, "⏳ Queued (steer). Ctrl-C to cancel.", :info))
 
       {:error, :provider_not_ready} ->
-        EditorState.set_status(state, "Agent provider still starting, try again in a moment")
+        EditorState.set_status(state, provider_starting_status())
+
+      {:error, :credentials_not_configured} ->
+        EditorState.set_status(state, credentials_missing_status())
 
       {:error, msg} when is_binary(msg) ->
         EditorState.set_status(state, msg)
@@ -564,22 +584,123 @@ defmodule MingaEditor.Commands.Agent do
     if remote_session_disconnected?(state) do
       EditorState.set_status(state, "Session disconnected. Your prompt will be preserved.")
     else
-      model = AgentAccess.panel(state).model_name
+      panel = AgentAccess.panel(state)
 
-      case resolve_prompt_for_session(state, text, model) do
-        {:ok, resolved} ->
-          state
-          |> update_agent_ui(&UIState.clear_input_and_scroll/1)
-          |> deliver_follow_up(resolved)
-
-        {:error, msg} ->
-          EditorState.set_status(state, msg)
+      case prompt_submit_status(state, panel) do
+        :ready -> resolve_and_deliver_follow_up(state, text, panel.model_name)
+        {:blocked, msg} -> EditorState.set_status(state, msg)
       end
     end
   catch
     :exit, _ ->
       EditorState.set_status(state, "Agent session unavailable. Your prompt was preserved.")
   end
+
+  @spec resolve_and_deliver_follow_up(state(), String.t(), String.t()) :: state()
+  defp resolve_and_deliver_follow_up(state, text, model) do
+    case resolve_prompt_for_session(state, text, model) do
+      {:ok, resolved} ->
+        deliver_follow_up(state, resolved)
+
+      {:error, msg} ->
+        EditorState.set_status(state, msg)
+    end
+  end
+
+  @spec prompt_submit_status(state(), Panel.t()) :: prompt_submit_status()
+  defp prompt_submit_status(state, panel) do
+    if remote_session?(state) do
+      :ready
+    else
+      state
+      |> prompt_readiness(panel, AgentAccess.session(state))
+      |> prompt_readiness_submit_status()
+    end
+  end
+
+  @spec prompt_readiness(state(), Panel.t(), pid() | nil) :: prompt_readiness()
+  defp prompt_readiness(state, %Panel{} = panel, session) do
+    case model_configured?(panel.model_name) do
+      true -> prompt_readiness_with_model(state, panel, session)
+      false -> :no_model
+    end
+  end
+
+  @spec prompt_readiness_with_model(state(), Panel.t(), pid() | nil) :: prompt_readiness()
+  defp prompt_readiness_with_model(state, %Panel{}, session) when is_pid(session) do
+    prompt_readiness_with_credentials(state, session)
+  end
+
+  defp prompt_readiness_with_model(_state, %Panel{credentials_configured: false}, nil),
+    do: :credentials_missing
+
+  defp prompt_readiness_with_model(state, %Panel{credentials_configured: true}, nil) do
+    prompt_readiness_with_credentials(state, nil)
+  end
+
+  @spec prompt_readiness_with_credentials(state(), pid() | nil) :: prompt_readiness()
+  defp prompt_readiness_with_credentials(_state, nil), do: :ready
+
+  defp prompt_readiness_with_credentials(_state, session) when is_pid(session) do
+    case Session.get_provider(session) do
+      provider when is_pid(provider) -> :ready
+      _provider -> providerless_prompt_readiness(session)
+    end
+  end
+
+  @spec providerless_prompt_readiness(pid()) :: prompt_readiness()
+  defp providerless_prompt_readiness(session) do
+    case Session.editor_snapshot(session) do
+      %{credentials_configured: false} -> :credentials_missing
+      %{error: error} when is_binary(error) and error != "" -> {:startup_failed, error}
+      _snapshot -> :starting
+    end
+  end
+
+  @spec model_configured?(String.t()) :: boolean()
+  defp model_configured?(model) when model in ["", "unknown"], do: false
+  defp model_configured?(model), do: model != AgentConfig.unconfigured_model()
+
+  @spec prompt_readiness_submit_status(prompt_readiness()) :: prompt_submit_status()
+  defp prompt_readiness_submit_status(:ready), do: :ready
+  defp prompt_readiness_submit_status(:no_model), do: {:blocked, no_model_status()}
+
+  defp prompt_readiness_submit_status(:credentials_missing),
+    do: {:blocked, credentials_missing_status()}
+
+  defp prompt_readiness_submit_status(:starting), do: {:blocked, provider_starting_status()}
+
+  defp prompt_readiness_submit_status({:startup_failed, error}) do
+    {:blocked, provider_startup_failed_status(error)}
+  end
+
+  @spec no_model_status() :: String.t()
+  defp no_model_status do
+    "No model configured. Your prompt was preserved. Run /auth, /login, or pick a configured model."
+  end
+
+  @spec credentials_missing_status() :: String.t()
+  defp credentials_missing_status do
+    "No provider credentials are configured for this model. Your prompt was preserved. Run /auth or /login to set one up."
+  end
+
+  @spec provider_starting_status() :: String.t()
+  defp provider_starting_status do
+    "Agent provider still starting. Your prompt was preserved."
+  end
+
+  @spec provider_startup_failed_status(String.t()) :: String.t()
+  defp provider_startup_failed_status(error) do
+    message = provider_startup_failed_message(error)
+    "#{message}. Your prompt was preserved."
+  end
+
+  @spec provider_startup_failed_message(String.t()) :: String.t()
+  defp provider_startup_failed_message("Failed to start agent: " <> _rest = message),
+    do: String.trim_trailing(message, ".")
+
+  defp provider_startup_failed_message(error),
+    do: "Failed to start agent: #{String.trim_trailing(error, ".")}"
 
   @spec resolve_prompt_for_session(state(), String.t(), String.t()) ::
           {:ok, String.t() | [ReqLLM.Message.ContentPart.t()]} | {:error, String.t()}
@@ -619,16 +740,20 @@ defmodule MingaEditor.Commands.Agent do
   defp deliver_follow_up(state, resolved) do
     case Session.queue_follow_up(AgentAccess.session(state), resolved) do
       :ok ->
-        state
+        update_agent_ui(state, &UIState.clear_input_and_scroll/1)
 
       {:queued, :follow_up} ->
-        update_agent_ui(
-          state,
+        state
+        |> update_agent_ui(&UIState.clear_input_and_scroll/1)
+        |> update_agent_ui(
           &UIState.push_toast(&1, "⏳ Queued (follow-up). Ctrl-C to cancel.", :info)
         )
 
       {:error, :provider_not_ready} ->
-        EditorState.set_status(state, "Agent provider still starting, try again in a moment")
+        EditorState.set_status(state, provider_starting_status())
+
+      {:error, :credentials_not_configured} ->
+        EditorState.set_status(state, credentials_missing_status())
 
       {:error, msg} when is_binary(msg) ->
         EditorState.set_status(state, msg)
@@ -792,11 +917,7 @@ defmodule MingaEditor.Commands.Agent do
     state
     |> AgentAccess.update_agent(fn _a -> %AgentState{buffer: agent_buf} end)
     |> AgentAccess.update_agent_ui(fn _a ->
-      ui = UIState.new()
-
-      ui
-      |> UIState.set_model_name(old_panel.model_name)
-      |> UIState.set_provider_name(old_panel.provider_name)
+      UIState.new()
       |> UIState.set_thinking_level(old_panel.thinking_level)
     end)
   end
@@ -1026,12 +1147,23 @@ defmodule MingaEditor.Commands.Agent do
   def set_model(state, model) do
     state = apply_model_and_provider(state, model)
 
-    if AgentAccess.session(state) do
-      Session.set_model(AgentAccess.session(state), model)
-      Session.add_system_message(AgentAccess.session(state), "Model: #{model}")
-    end
+    case AgentAccess.session(state) do
+      nil ->
+        EditorState.set_status(state, "Model: #{model}")
 
-    EditorState.set_status(state, "Model: #{model}")
+      session ->
+        case Session.set_model(session, model) do
+          :ok ->
+            Session.add_system_message(session, "Model: #{model}")
+            EditorState.set_status(state, "Model: #{model}")
+
+          {:error, reason} when is_binary(reason) ->
+            EditorState.set_status(state, reason)
+
+          {:error, reason} ->
+            EditorState.set_status(state, "Error: #{inspect(reason)}")
+        end
+    end
   end
 
   # ── Scope commands (keymap scope dispatch) ──────────────────────────────────

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -108,6 +108,8 @@ defmodule MingaEditor.Commands.AgentSession do
 
     session_opts = [
       thinking_level: panel.thinking_level,
+      model_name: panel.model_name,
+      provider_name: panel.provider_name,
       session_start_hook_enabled?: Keyword.get(opts, :session_start_hook_enabled?, true),
       recover_interrupted_work?: Keyword.get(opts, :recover_interrupted_work?, true),
       provider_opts: [

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -485,7 +485,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   end
 
   def encode_gui_tab_bar(%TabBar{} = tb, active_win_buffer) do
-    visible_tabs = TabBar.visible_file_tabs(tb)
+    visible_tabs = TabBar.visible_workspace_tabs(tb)
 
     active_index =
       case Enum.find_index(visible_tabs, &(&1.id == tb.active_id)) do
@@ -735,6 +735,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
   @spec encode_tab_kind(TabSummary.kind()) :: non_neg_integer()
   defp encode_tab_kind(:file), do: 0
+  defp encode_tab_kind(:agent), do: 1
 
   @spec encode_visible_tab_flags(TabSummary.t()) :: non_neg_integer()
   defp encode_visible_tab_flags(%TabSummary{} = tab) do

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -505,6 +505,23 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     end
   end
 
+  defp dispatch_action(state, {:execute_command, "workspace_goto_id:" <> workspace_id}) do
+    case Integer.parse(workspace_id) do
+      {id, ""} when id >= 0 ->
+        state
+        |> Commands.execute({:workspace_goto, id})
+        |> normalize_command_result()
+
+      _other ->
+        Minga.Log.warning(
+          :editor,
+          "[execute_command] invalid workspace id command: workspace_goto_id:#{workspace_id}"
+        )
+
+        state
+    end
+  end
+
   defp dispatch_action(state, {:execute_command, name_str}) do
     command = String.to_existing_atom(name_str)
 

--- a/lib/minga_editor/input/agent_panel.ex
+++ b/lib/minga_editor/input/agent_panel.ex
@@ -1,9 +1,8 @@
 defmodule MingaEditor.Input.AgentPanel do
   @moduledoc """
-  Input handler for the agent side panel (editor scope, panel visible).
+  Input handler for the agent prompt and side-panel navigation.
 
-  When the agent panel is visible in editor scope, this handler
-  intercepts keys for the panel's input field and navigation mode.
+  When the agent prompt is focused, this handler owns prompt editing in both editor scope and full agent workspaces. When the side panel is visible in editor scope but the prompt is not focused, it owns panel navigation.
 
   In insert mode, it handles prompt editing (Enter, Backspace, Ctrl
   combos, arrow keys, @-mention triggers). In normal/visual/
@@ -34,25 +33,25 @@ defmodule MingaEditor.Input.AgentPanel do
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
 
-  # Editor scope with agent side panel visible + input focused
-  def handle_key(%{workspace: %{keymap_scope: :editor}} = state, cp, mods) do
-    panel = AgentAccess.panel(state)
+  def handle_key(state, cp, mods) do
+    state |> AgentAccess.panel() |> route_panel_key(state, cp, mods)
+  end
 
-    if panel.visible and panel.input_focused do
-      {:handled, handle_panel_input(state, cp, mods)}
+  @spec route_panel_key(UIState.Panel.t(), EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          MingaEditor.Input.Handler.result()
+  defp route_panel_key(%{visible: true, input_focused: true}, state, cp, mods) do
+    {:handled, handle_panel_input(state, cp, mods)}
+  end
+
+  defp route_panel_key(%{visible: true}, %{workspace: %{keymap_scope: :editor}} = state, cp, mods) do
+    if is_pid(AgentAccess.agent(state).buffer) do
+      handle_panel_nav(state, cp, mods)
     else
-      agent = AgentAccess.agent(state)
-
-      if panel.visible and is_pid(agent.buffer) do
-        handle_panel_nav(state, cp, mods)
-      else
-        {:passthrough, state}
-      end
+      {:passthrough, state}
     end
   end
 
-  # Not our concern
-  def handle_key(state, _cp, _mods), do: {:passthrough, state}
+  defp route_panel_key(_panel, state, _cp, _mods), do: {:passthrough, state}
 
   # ── Panel input mode ────────────────────────────────────────────────────
 

--- a/lib/minga_editor/render_model/ui/agent_chat_builder.ex
+++ b/lib/minga_editor/render_model/ui/agent_chat_builder.ex
@@ -72,7 +72,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
     %AgentChat{
       visible?: true,
       status: ctx.shell_state.agent.runtime.status || :idle,
-      model_name: panel.model_name,
+      model_name: display_model_name(panel.model_name),
       thinking_level: panel.thinking_level,
       prompt: prompt_text,
       prompt_line_count: UIState.input_line_count(panel),
@@ -87,6 +87,10 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
       messages: gui_messages
     }
   end
+
+  @spec display_model_name(String.t()) :: String.t()
+  defp display_model_name(model) when model in ["", "unknown"], do: "No model configured"
+  defp display_model_name(model), do: model
 
   @spec log_agent_chat_message_stats([{pos_integer(), term()}]) :: :ok
   defp log_agent_chat_message_stats(messages) do

--- a/lib/minga_editor/session/chrome_state.ex
+++ b/lib/minga_editor/session/chrome_state.ex
@@ -243,7 +243,7 @@ defmodule MingaEditor.Session.ChromeState do
     workspace = TabBar.get_workspace(tb, active_workspace_id)
 
     tb
-    |> TabBar.visible_file_tabs(active_workspace_id)
+    |> TabBar.visible_workspace_tabs(active_workspace_id)
     |> Enum.map(&tab_summary(state, &1, active_workspace_id, workspace))
   end
 
@@ -320,7 +320,7 @@ defmodule MingaEditor.Session.ChromeState do
   defp buffer_dirty?(_pid), do: false
 
   @spec tab_tint_color(Tab.t(), Workspace.t() | nil) :: non_neg_integer()
-  defp tab_tint_color(%Tab{kind: :file}, %Workspace{kind: :agent, color: color})
+  defp tab_tint_color(%Tab{}, %Workspace{kind: :agent, color: color})
        when is_integer(color) and color > 0,
        do: color
 

--- a/lib/minga_editor/session/chrome_state/tab_summary.ex
+++ b/lib/minga_editor/session/chrome_state/tab_summary.ex
@@ -1,6 +1,6 @@
 defmodule MingaEditor.Session.ChromeState.TabSummary do
   @moduledoc """
-  User-facing summary for one file tab in workspace chrome.
+  User-facing summary for one visible content tab in workspace chrome.
 
   Tab summaries preserve workspace identity separately from path labels so the same logical path can appear in multiple workspaces without becoming ambiguous in chrome.
   """
@@ -9,7 +9,7 @@ defmodule MingaEditor.Session.ChromeState.TabSummary do
 
   @type draft_state :: :none | :draft | :draft_elsewhere | :conflict
 
-  @type kind :: :file
+  @type kind :: Tab.kind()
 
   @type t :: %__MODULE__{
           id: Tab.id(),
@@ -45,14 +45,10 @@ defmodule MingaEditor.Session.ChromeState.TabSummary do
   def new(attrs) when is_list(attrs) do
     kind = Keyword.fetch!(attrs, :kind)
 
-    if kind != :file do
-      raise ArgumentError, "TabSummary only supports file tabs, got #{inspect(kind)}"
-    end
-
     %__MODULE__{
       id: Keyword.fetch!(attrs, :id),
       workspace_id: Keyword.fetch!(attrs, :workspace_id),
-      kind: :file,
+      kind: kind,
       label: Keyword.fetch!(attrs, :label),
       path: Keyword.get(attrs, :path),
       icon: Keyword.fetch!(attrs, :icon),

--- a/lib/minga_editor/state/agent_access.ex
+++ b/lib/minga_editor/state/agent_access.ex
@@ -170,10 +170,7 @@ defmodule MingaEditor.State.AgentAccess do
 
     tab_bar =
       case TabBar.active_workspace(tab_bar) do
-        %Workspace{kind: :agent, id: workspace_id} ->
-          TabBar.update_workspace(tab_bar, workspace_id, &Workspace.set_agent_ui(&1, next_ui))
-
-        %Workspace{session: session, id: workspace_id} when is_pid(session) ->
+        %Workspace{id: workspace_id} ->
           TabBar.update_workspace(tab_bar, workspace_id, &Workspace.set_agent_ui(&1, next_ui))
 
         _workspace ->

--- a/lib/minga_editor/state/tab_bar.ex
+++ b/lib/minga_editor/state/tab_bar.ex
@@ -550,6 +550,25 @@ defmodule MingaEditor.State.TabBar do
     end
   end
 
+  @doc "Returns visible content tabs for the active workspace."
+  @spec visible_workspace_tabs(t()) :: [Tab.t()]
+  def visible_workspace_tabs(%__MODULE__{} = tb) do
+    visible_workspace_tabs(tb, active_workspace_id(tb))
+  end
+
+  @doc "Returns visible content tabs for the given workspace id. Agent workspaces show their agent tab first, followed by file tabs."
+  @spec visible_workspace_tabs(t(), non_neg_integer()) :: [Tab.t()]
+  def visible_workspace_tabs(%__MODULE__{} = tb, workspace_id)
+      when is_integer(workspace_id) and workspace_id >= 0 do
+    case get_workspace(tb, workspace_id) do
+      %Workspace{kind: :agent} ->
+        visible_agent_tabs(tb, workspace_id) ++ visible_file_tabs(tb, workspace_id)
+
+      _workspace ->
+        visible_file_tabs(tb, workspace_id)
+    end
+  end
+
   @doc "Returns visible file tabs for the active workspace."
   @spec visible_file_tabs(t()) :: [Tab.t()]
   def visible_file_tabs(%__MODULE__{} = tb) do
@@ -564,6 +583,15 @@ defmodule MingaEditor.State.TabBar do
     |> Enum.filter(&visible_file_tab?(&1, workspace_id))
     |> pinned_first()
   end
+
+  @spec visible_agent_tabs(t(), non_neg_integer()) :: [Tab.t()]
+  defp visible_agent_tabs(%__MODULE__{tabs: tabs}, workspace_id) do
+    Enum.filter(tabs, &visible_agent_tab?(&1, workspace_id))
+  end
+
+  @spec visible_agent_tab?(Tab.t(), non_neg_integer()) :: boolean()
+  defp visible_agent_tab?(%Tab{kind: :agent, group_id: workspace_id}, workspace_id), do: true
+  defp visible_agent_tab?(%Tab{}, _workspace_id), do: false
 
   @doc "Finds the file tab in a workspace that represents the given file reference."
   @spec find_file_tab_in_workspace(t(), non_neg_integer(), FileRef.t()) :: Tab.t() | nil
@@ -793,14 +821,14 @@ defmodule MingaEditor.State.TabBar do
   end
 
   @doc """
-  Switches to the given workspace by activating its first tab.
+  Switches to the given workspace by activating its first visible tab.
 
-  Returns unchanged if the workspace doesn't exist or has no tabs.
+  Returns unchanged if the workspace doesn't exist or has no visible tabs.
   """
   @spec switch_to_workspace(t(), non_neg_integer()) :: t()
   def switch_to_workspace(%__MODULE__{} = tb, workspace_id) do
     if Enum.any?(tb.workspaces, &(&1.id == workspace_id)) do
-      switch_to_first_tab_in(tb, workspace_id)
+      switch_to_first_visible_tab_in(tb, workspace_id)
     else
       tb
     end
@@ -837,7 +865,7 @@ defmodule MingaEditor.State.TabBar do
         idx -> Enum.at(workspaces, rem(idx + 1, length(workspaces)))
       end
 
-    switch_to_first_tab_in(tb, next.id)
+    switch_to_first_visible_tab_in(tb, next.id)
   end
 
   defp switch_to_cycled_agent_workspace(tb, workspaces, :prev) do
@@ -846,14 +874,14 @@ defmodule MingaEditor.State.TabBar do
     len = length(workspaces)
     prev_idx = if idx == 0, do: len - 1, else: idx - 1
     prev = Enum.at(workspaces, prev_idx)
-    switch_to_first_tab_in(tb, prev.id)
+    switch_to_first_visible_tab_in(tb, prev.id)
   end
 
-  # Switches active_id to the first tab in the given workspace.
-  # Returns unchanged if the workspace has no tabs.
-  @spec switch_to_first_tab_in(t(), non_neg_integer()) :: t()
-  defp switch_to_first_tab_in(tb, workspace_id) do
-    case tabs_in_workspace(tb, workspace_id) do
+  # Switches active_id to the first visible tab in the given workspace.
+  # Returns unchanged if the workspace has no visible tabs.
+  @spec switch_to_first_visible_tab_in(t(), non_neg_integer()) :: t()
+  defp switch_to_first_visible_tab_in(tb, workspace_id) do
+    case visible_workspace_tabs(tb, workspace_id) do
       [first | _] -> %{tb | active_id: first.id}
       [] -> tb
     end

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -433,14 +433,15 @@ defmodule MingaEditor.StatusBar.Data do
   end
 
   @spec model_name(String.t(), String.t() | nil) :: String.t()
-  defp model_name(panel_model, _session_model) when is_binary(panel_model) and panel_model != "",
-    do: panel_model
+  defp model_name(panel_model, _session_model)
+       when is_binary(panel_model) and panel_model not in ["", "unknown"],
+       do: panel_model
 
   defp model_name(_panel_model, session_model)
-       when is_binary(session_model) and session_model != "",
+       when is_binary(session_model) and session_model not in ["", "unknown"],
        do: session_model
 
-  defp model_name(_panel_model, _session_model), do: Minga.Config.get(:agent_model)
+  defp model_name(_panel_model, _session_model), do: "No model configured"
 
   @spec attach_modeline_segments(map(), Theme.t(), ModelineSegments.table()) ::
           buffer_data() | agent_data()

--- a/macos/Sources/Views/TabBarState.swift
+++ b/macos/Sources/Views/TabBarState.swift
@@ -47,6 +47,7 @@ struct WorkspaceTabEntry: Identifiable {
     let label: String
     let path: String
 
+    var isAgent: Bool { kind == 1 }
     var isDirty: Bool { flags & 0x0001 != 0 }
     var hasAttention: Bool { flags & 0x0002 != 0 }
     var isPinned: Bool { flags & 0x0020 != 0 }

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -163,7 +163,7 @@ struct TabBarView: View {
                     groupId: tab.workspaceId,
                     isActive: index == Int(tabBarState.activeIndex),
                     isDirty: tab.isDirty,
-                    isAgent: false,
+                    isAgent: tab.isAgent,
                     hasAttention: tab.hasAttention,
                     agentStatus: 0,
                     isPinned: tab.isPinned,
@@ -191,13 +191,13 @@ struct TabBarView: View {
     }
 
     func canMoveTabLeft(_ tab: TabEntry) -> Bool {
-        guard let index = movableTabIndex(tab) else { return false }
+        guard let index = movableFileTabIndex(for: tab) else { return false }
         return index > 0
     }
 
     func canMoveTabRight(_ tab: TabEntry) -> Bool {
-        guard let index = movableTabIndex(tab) else { return false }
-        return index < movableTabs(for: tab).count - 1
+        guard let index = movableFileTabIndex(for: tab) else { return false }
+        return index < movableFileTabs(for: tab).count - 1
     }
 
     func tabContextMenuMoveItems(for tab: TabEntry) -> [TabContextMenuMoveItem] {
@@ -215,7 +215,7 @@ struct TabBarView: View {
         return true
     }
 
-    func tabDropReorder(droppedTabs: [TabDragPayload], target tab: TabEntry, visibleIndex: Int) -> (id: UInt32, newIndex: UInt16)? {
+    func tabDropReorder(droppedTabs: [TabDragPayload], target tab: TabEntry, visibleIndex _: Int) -> (id: UInt32, newIndex: UInt16)? {
         guard let draggedId = droppedTabs.first?.id,
               draggedId != tab.id else {
             return nil
@@ -225,16 +225,33 @@ struct TabBarView: View {
               draggedTab.isPinned == tab.isPinned else {
             return nil
         }
-        return (draggedId, UInt16(visibleIndex))
+        guard let newIndex = visibleFileTabIndex(for: tab) else {
+            return nil
+        }
+        return (draggedId, UInt16(newIndex))
     }
 
-    private func movableTabIndex(_ tab: TabEntry) -> Int? {
-        movableTabs(for: tab).firstIndex { $0.id == tab.id }
+    func movableFileTabIndex(for tab: TabEntry) -> Int? {
+        movableFileTabs(for: tab).firstIndex { $0.id == tab.id }
+    }
+
+    func visibleFileTabIndex(for tab: TabEntry) -> Int? {
+        visibleFileTabs(for: tab).firstIndex { $0.id == tab.id }
     }
 
     private func movableTabs(for tab: TabEntry) -> [TabEntry] {
         displayTabs.filter { candidate in
             candidate.groupId == tab.groupId && candidate.isPinned == tab.isPinned
+        }
+    }
+
+    private func movableFileTabs(for tab: TabEntry) -> [TabEntry] {
+        movableTabs(for: tab).filter { !$0.isAgent }
+    }
+
+    private func visibleFileTabs(for tab: TabEntry) -> [TabEntry] {
+        displayTabs.filter { candidate in
+            candidate.groupId == tab.groupId && !candidate.isAgent
         }
     }
 
@@ -344,16 +361,7 @@ struct TabBarView: View {
 
     @MainActor
     private func workspaceGotoCommand(for workspace: WorkspaceEntry) -> String {
-        if workspace.kind == 0 {
-            return "manual_workspace"
-        }
-
-        let agentWorkspaces = tabBarState.workspaces.filter { $0.kind == 1 }
-        guard let idx = agentWorkspaces.firstIndex(where: { $0.id == workspace.id }), idx < 9 else {
-            return "workspace_next_agent"
-        }
-
-        return "workspace_goto_\(idx + 1)"
+        "workspace_goto_id:\(workspace.id)"
     }
 
     // MARK: - Workspace indicator

--- a/macos/Sources/Views/WorkspaceState.swift
+++ b/macos/Sources/Views/WorkspaceState.swift
@@ -139,13 +139,7 @@ final class WorkspaceState {
     }
 
     func switchCommand(for workspace: WorkspaceSummaryEntry) -> String {
-        if workspace.isManual { return "manual_workspace" }
-
-        let agentWorkspaces = workspaces.filter { $0.isAgent }
-        guard let idx = agentWorkspaces.firstIndex(where: { $0.id == workspace.id }), idx < 9 else {
-            return "workspace_next_agent"
-        }
-        return "workspace_goto_\(idx + 1)"
+        "workspace_goto_id:\(workspace.id)"
     }
 
     func hide() {

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -321,6 +321,22 @@ struct TabBarStateLifecycleTests {
         #expect(state.tabs[1].hasAttention == true)
     }
 
+    @Test("updateWorkspaces() marks canonical agent tabs")
+    @MainActor func updateWorkspacesMarksCanonicalAgentTabs() {
+        let state = TabBarState()
+        state.updateWorkspaces(activeWorkspaceId: 1, mode: 1, flags: 0, entries: [
+            Wire.WorkspaceEntry(id: 1, kind: 1, status: 0, flags: 0, colorR: 0x11, colorG: 0x22, colorB: 0x33,
+                                tabCount: 2, draftCount: 0, conflictCount: 0, runningBackgroundCount: 0, label: "Agent", icon: "cpu")
+        ], visibleTabs: [
+            Wire.WorkspaceTabEntry(id: 7, workspaceId: 1, kind: 1, flags: 0, pathHash: 0, tintColorRGB: 0, icon: "cpu", label: "Agent", path: ""),
+            Wire.WorkspaceTabEntry(id: 8, workspaceId: 1, kind: 0, flags: 0, pathHash: 0, tintColorRGB: 0, icon: "󰈙", label: "agent.ex", path: "/tmp/agent.ex")
+        ])
+
+        #expect(state.workspaceTabs.count == 2)
+        #expect(state.workspaceTabs[0].isAgent == true)
+        #expect(state.workspaceTabs[1].isAgent == false)
+    }
+
     @Test("hide() clears all tab state")
     @MainActor func hideClearsAll() {
         let state = TabBarState()

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -828,13 +828,14 @@ struct TabBarViewViewTests {
         let spy = SpyEncoder()
         let state = TabBarState()
         state.update(activeIndex: 0, entries: [
-            wireTab(id: 1),
-            wireTab(id: 2),
-            wireTab(id: 3, groupId: 1),
-            wireTab(id: 4, isPinned: true),
+            wireTab(id: 1, isPinned: true, label: "pinned-1.ex"),
+            wireTab(id: 2, isPinned: true, label: "pinned-2.ex"),
+            wireTab(id: 3, label: "plain-1.ex"),
+            wireTab(id: 4, label: "plain-2.ex"),
+            wireTab(id: 5, groupId: 1, label: "other-group.ex"),
         ])
         let sut = TabBarView(tabBarState: state, theme: ThemeColors(), encoder: spy)
-        let target = tab(id: 2)
+        let target = tab(id: 3, label: "plain-1.ex")
 
         #expect(TabDragPayload.contentType.identifier == "com.minga.tab-id")
         #expect(TabDragPayload.contentType != UTType.plainText)
@@ -842,17 +843,38 @@ struct TabBarViewViewTests {
         if let reorder = sut.tabDropReorder(droppedTabs: [], target: target, visibleIndex: 1) {
             Issue.record("Expected empty payload to be rejected, got \(reorder)")
         }
-        if let reorder = sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 3)], target: target, visibleIndex: 1) {
+        if let reorder = sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 5)], target: target, visibleIndex: 1) {
             Issue.record("Expected cross-workspace payload to be rejected, got \(reorder)")
         }
-        if let reorder = sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 4)], target: target, visibleIndex: 1) {
+        if let reorder = sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 1)], target: target, visibleIndex: 1) {
             Issue.record("Expected pinned-bucket mismatch to be rejected, got \(reorder)")
         }
 
-        let accepted = sut.handleTabDrop(droppedTabs: [TabDragPayload(id: 1)], target: target, visibleIndex: 1)
+        let dropTarget = tab(id: 4, label: "plain-2.ex")
+        #expect(sut.visibleFileTabIndex(for: dropTarget) == 3)
+        #expect(sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 3)], target: dropTarget, visibleIndex: 3)?.newIndex == 3)
+
+        let accepted = sut.handleTabDrop(droppedTabs: [TabDragPayload(id: 3)], target: dropTarget, visibleIndex: 3)
 
         #expect(accepted)
-        #expect(spy.guiActions == [.tabReorder(id: 1, newIndex: 1)])
+        #expect(spy.guiActions == [.tabReorder(id: 3, newIndex: 3)])
+    }
+
+    @Test("Canonical drag reorder ignores the leading agent tab")
+    @MainActor func canonicalDragReorderIgnoresLeadingAgentTab() throws {
+        let state = TabBarState()
+        state.update(activeIndex: 0, entries: [
+            Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: true, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "cpu", label: "Agent"),
+            wireTab(id: 2, label: "file-a.ex"),
+            wireTab(id: 3, label: "file-b.ex")
+        ])
+
+        let sut = TabBarView(tabBarState: state, theme: ThemeColors(), encoder: nil)
+
+        #expect(sut.movableFileTabIndex(for: tab(id: 2, label: "file-a.ex")) == 0)
+        #expect(sut.movableFileTabIndex(for: tab(id: 3, label: "file-b.ex")) == 1)
+        #expect(sut.movableFileTabIndex(for: TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: true, hasAttention: false, agentStatus: 0, isPinned: false, tintColor: nil, icon: "cpu", label: "Agent")) == nil)
+        #expect(sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 2)], target: tab(id: 3, label: "file-b.ex"), visibleIndex: 2)?.newIndex == 1)
     }
 
     @Test("Tab bar uses canonical active-workspace visible tabs")
@@ -880,6 +902,38 @@ struct TabBarViewViewTests {
         #expect(!strings.contains("legacy-agent-chat"))
         #expect(!strings.contains("background.ex"))
         #expect(!strings.contains("Research"))
+    }
+
+    @Test("Canonical workspace tabs render agent entries with the agent icon")
+    @MainActor func canonicalWorkspaceTabsRenderAgentEntriesWithAgentIcon() throws {
+        let fileState = TabBarState()
+        fileState.updateWorkspaces(activeWorkspaceId: 1, mode: 1, flags: 0, entries: [
+            Wire.WorkspaceEntry(id: 1, kind: 1, status: 0, flags: 0, colorR: 0x11, colorG: 0x22, colorB: 0x33,
+                                tabCount: 1, draftCount: 0, conflictCount: 0, runningBackgroundCount: 0, label: "Active", icon: "cpu")
+        ], visibleTabs: [
+            Wire.WorkspaceTabEntry(id: 42, workspaceId: 1, kind: 0, flags: 0, pathHash: 0, tintColorRGB: 0, icon: "󰈙", label: "active.ex", path: "/tmp/active.ex")
+        ])
+
+        let agentState = TabBarState()
+        agentState.updateWorkspaces(activeWorkspaceId: 1, mode: 1, flags: 0, entries: [
+            Wire.WorkspaceEntry(id: 1, kind: 1, status: 0, flags: 0, colorR: 0x11, colorG: 0x22, colorB: 0x33,
+                                tabCount: 1, draftCount: 0, conflictCount: 0, runningBackgroundCount: 0, label: "Active", icon: "cpu")
+        ], visibleTabs: [
+            Wire.WorkspaceTabEntry(id: 42, workspaceId: 1, kind: 1, flags: 0, pathHash: 0, tintColorRGB: 0, icon: "cpu", label: "Agent", path: "")
+        ])
+
+        let fileImages = try TabBarView(tabBarState: fileState, theme: ThemeColors(), encoder: nil)
+            .inspect()
+            .find(ViewType.ScrollView.self)
+            .findAll(ViewType.Image.self)
+            .count
+        let agentImages = try TabBarView(tabBarState: agentState, theme: ThemeColors(), encoder: nil)
+            .inspect()
+            .find(ViewType.ScrollView.self)
+            .findAll(ViewType.Image.self)
+            .count
+
+        #expect(agentImages == fileImages + 1)
     }
 }
 
@@ -943,8 +997,8 @@ struct WorkspaceHeaderViewTests {
         let manualWorkspace = try #require(state.workspaces.first { $0.isManual })
         let reviewWorkspace = try #require(state.workspaces.first { $0.label == "Review" })
 
-        #expect(state.switchCommand(for: manualWorkspace) == "manual_workspace")
-        #expect(state.switchCommand(for: reviewWorkspace) == "workspace_goto_2")
+        #expect(state.switchCommand(for: manualWorkspace) == "workspace_goto_id:0")
+        #expect(state.switchCommand(for: reviewWorkspace) == "workspace_goto_id:2")
     }
 }
 

--- a/test/minga/frontend/adapter/gui/workspaces_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/workspaces_encoder_test.exs
@@ -63,6 +63,74 @@ defmodule Minga.Frontend.Adapter.GUI.WorkspacesEncoderTest do
       assert cmd == ProtocolGUI.encode_gui_workspaces(chrome_state)
     end
 
+    test "matches legacy ChromeState wire format for agent visible tabs" do
+      chrome_state =
+        %{
+          chrome_state()
+          | active_workspace_id: 2,
+            active_tab_id: 7,
+            background_count: 0,
+            attention_count: 0,
+            draft_count: 0,
+            conflict_count: 0,
+            mode: :agent,
+            workspaces: [
+              WorkspaceSummary.new(
+                id: 2,
+                kind: :agent,
+                label: "Agent",
+                icon: "robot",
+                color: 0x123456,
+                status: :thinking,
+                attention?: true,
+                tab_count: 1,
+                draft_count: 0,
+                conflict_count: 0,
+                running_background_count: 0,
+                closeable?: true
+              )
+            ],
+            visible_tabs: [
+              TabSummary.new(
+                id: 7,
+                workspace_id: 2,
+                kind: :agent,
+                label: "Agent",
+                icon: "cpu"
+              )
+            ]
+        }
+
+      model = %Workspaces{
+        visible?: true,
+        active_workspace_id: 2,
+        mode: :agent,
+        workspaces: [
+          %Workspace{
+            id: 2,
+            kind: :agent,
+            label: "Agent",
+            icon: "robot",
+            color: 0x123456,
+            status: :thinking,
+            attention?: true,
+            tab_count: 1,
+            draft_count: 0,
+            conflict_count: 0,
+            running_background_count: 0,
+            closeable?: true
+          }
+        ],
+        visible_tabs: [
+          %VisibleTab{id: 7, workspace_id: 2, kind: :agent, label: "Agent", icon: "cpu"}
+        ]
+      }
+
+      {cmd, _caches} = WorkspacesEncoder.encode(model, Caches.new())
+
+      assert cmd == ProtocolGUI.encode_gui_workspaces(chrome_state)
+    end
+
     test "encodes workspace and visible tab summaries" do
       model = %Workspaces{
         visible?: true,
@@ -80,6 +148,22 @@ defmodule Minga.Frontend.Adapter.GUI.WorkspacesEncoderTest do
 
       assert <<@op_gui_workspaces, len::16, payload::binary-size(len)>> = cmd
       assert <<2::8, 0::16, 0::8, 0::8, 1::8, _rest::binary>> = payload
+    end
+
+    test "encodes agent visible tab kind" do
+      model = %Workspaces{
+        visible?: true,
+        active_workspace_id: 2,
+        mode: :agent,
+        visible_tabs: [
+          %VisibleTab{id: 9, workspace_id: 2, kind: :agent, label: "Agent", icon: "cpu", path: ""}
+        ]
+      }
+
+      {cmd, _caches} = WorkspacesEncoder.encode(model, Caches.new())
+
+      assert <<@op_gui_workspaces, len::16, payload::binary-size(len)>> = cmd
+      assert <<2::8, 2::16, 1::8, 0::8, 0::8, 1::16, 9::32, 2::16, 1::8, _rest::binary>> = payload
     end
 
     test "returns nil on second call with same semantic data" do

--- a/test/minga_agent/config_test.exs
+++ b/test/minga_agent/config_test.exs
@@ -9,7 +9,10 @@ defmodule MingaAgent.ConfigTest do
     test "returns a Config struct with all fields populated" do
       config = Config.resolve()
       assert %Config{} = config
-      assert is_binary(config.model)
+
+      assert provider_qualified_model?(config.model) or
+               config.model == Config.unconfigured_model()
+
       assert is_integer(config.max_tokens)
       assert is_integer(config.max_turns)
       assert is_integer(config.max_retries)
@@ -20,9 +23,11 @@ defmodule MingaAgent.ConfigTest do
       assert is_list(config.notify_on)
     end
 
-    test "model defaults to Sonnet when Options has nil" do
+    test "model defaults to a credential-backed model or the unconfigured sentinel" do
       config = Config.resolve()
-      assert config.model =~ "claude"
+
+      assert provider_qualified_model?(config.model) or
+               config.model == Config.unconfigured_model()
     end
 
     test "struct defaults match Options defaults" do
@@ -73,8 +78,25 @@ defmodule MingaAgent.ConfigTest do
   end
 
   describe "default_model/0" do
-    test "returns the Sonnet model string" do
-      assert Config.default_model() =~ "anthropic:claude"
+    test "returns a usable model or the unconfigured sentinel" do
+      model = Config.default_model()
+      assert is_binary(model)
+      refute model == ""
+    end
+  end
+
+  describe "model spec parsing" do
+    test "supports provider:model and model@provider forms" do
+      assert Config.split_model_spec("anthropic:claude-sonnet-4") ==
+               {"claude-sonnet-4", "anthropic"}
+
+      assert Config.split_model_spec("claude-sonnet-4@anthropic") ==
+               {"claude-sonnet-4", "anthropic"}
+
+      assert Config.strip_provider_prefix("claude-sonnet-4@anthropic") ==
+               "claude-sonnet-4"
+
+      assert Config.extract_provider_prefix("claude-sonnet-4@anthropic") == "anthropic"
     end
   end
 
@@ -90,5 +112,9 @@ defmodule MingaAgent.ConfigTest do
       assert hook.command == "echo policy >&2"
       assert hook.timeout_ms == 30_000
     end
+  end
+
+  defp provider_qualified_model?(model) when is_binary(model) do
+    String.contains?(model, ":") or String.contains?(model, "@")
   end
 end

--- a/test/minga_agent/session_provider_registry_test.exs
+++ b/test/minga_agent/session_provider_registry_test.exs
@@ -53,7 +53,11 @@ defmodule MingaAgent.SessionProviderRegistryTest do
     ProviderRegistry.unregister_source(NativeProviderPack.source())
 
     assert {:error, {%ArgumentError{message: message}, _stack}} =
-             Session.start_link(provider_opts: [], persist?: false)
+             Session.start_link(
+               model_name: "anthropic:test",
+               provider_opts: [provider: "anthropic", model: "anthropic:test"],
+               persist?: false
+             )
 
     assert message =~ ~s(agent provider "native" is not available: :not_found)
   end

--- a/test/minga_agent/session_recovery_test.exs
+++ b/test/minga_agent/session_recovery_test.exs
@@ -1,0 +1,194 @@
+defmodule MingaAgent.SessionRecoveryTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Test.StubProvider
+  alias MingaAgent.Config, as: AgentConfig
+  alias MingaAgent.Providers.Native
+  alias MingaAgent.Session
+
+  defp start_credential_checker(initial_state) do
+    checker =
+      {Agent, fn -> initial_state end}
+      |> Supervisor.child_spec(id: {:credential_checker, make_ref()})
+      |> start_supervised!()
+
+    {checker, fn -> Agent.get(checker, & &1) end}
+  end
+
+  defp start_session(opts, initial_credentials_state) do
+    {checker, credentials_configured_fn} = start_credential_checker(initial_credentials_state)
+
+    provider_opts =
+      Keyword.get(opts, :provider_opts, [])
+      |> Keyword.merge(skip_api_key_env: true)
+
+    {:ok, session} =
+      Session.start_link(
+        opts
+        |> Keyword.put(:provider_opts, provider_opts)
+        |> Keyword.put(:credentials_configured_fn, credentials_configured_fn)
+      )
+
+    {session, checker}
+  end
+
+  defmodule FailingProvider do
+    @behaviour MingaAgent.Provider
+
+    @impl MingaAgent.Provider
+    def start_link(_opts), do: {:error, {:spawn_failed, "boom"}}
+
+    @impl MingaAgent.Provider
+    def send_prompt(_pid, _text), do: :ok
+
+    @impl MingaAgent.Provider
+    def abort(_pid), do: :ok
+
+    @impl MingaAgent.Provider
+    def new_session(_pid), do: :ok
+
+    @impl MingaAgent.Provider
+    def seed_messages(_pid, _messages), do: :ok
+
+    @impl MingaAgent.Provider
+    def get_state(_pid), do: {:ok, %{model: nil}}
+  end
+
+  test "refresh_credentials/1 starts a provider only after credentials flip true and model is concrete" do
+    {session, checker} =
+      start_session(
+        [provider: Native, provider_opts: [model: AgentConfig.unconfigured_model()]],
+        false
+      )
+
+    assert Session.get_provider(session) == nil
+    assert Session.editor_snapshot(session).credentials_configured == false
+    assert {:error, :credentials_not_configured} = Session.send_prompt(session, "draft prompt")
+
+    assert :ok = Session.set_model(session, "anthropic:claude-sonnet-4-20250514")
+    assert Session.get_provider(session) == nil
+
+    Agent.update(checker, fn _ -> true end)
+    assert :ok = Session.refresh_credentials(session)
+    assert Session.editor_snapshot(session).credentials_configured == true
+    assert is_pid(Session.get_provider(session))
+  end
+
+  test "set_model/2 can recover a provider-less session when credentials already exist" do
+    {session, _checker} =
+      start_session(
+        [provider: Native, provider_opts: [model: AgentConfig.unconfigured_model()]],
+        true
+      )
+
+    assert Session.get_provider(session) == nil
+    assert :ok = Session.set_model(session, "claude-opus-4-20250514@anthropic")
+    assert is_pid(Session.get_provider(session))
+
+    metadata = Session.metadata(session)
+    assert metadata.model_name == "claude-opus-4-20250514@anthropic"
+    assert metadata.provider_name == "anthropic"
+    assert Session.subagent_context(session).provider_name == "anthropic"
+  end
+
+  test "subagent_context uses session provider metadata for native providers" do
+    {session, _checker} =
+      start_session(
+        [provider: Native, provider_opts: [model: "claude-opus-4-20250514@anthropic"]],
+        true
+      )
+
+    assert is_pid(Session.get_provider(session))
+    assert Session.subagent_context(session).provider_name == "anthropic"
+  end
+
+  test "set_model/2 returns startup errors when refresh triggers a failing provider" do
+    {checker, credentials_configured_fn} = start_credential_checker(false)
+
+    {:ok, session} =
+      Session.start_link(
+        provider: FailingProvider,
+        provider_opts: [model: AgentConfig.unconfigured_model(), skip_api_key_env: true],
+        credentials_configured_fn: credentials_configured_fn
+      )
+
+    Agent.update(checker, fn _ -> true end)
+
+    assert {:error, "Failed to start agent: boom"} =
+             Session.set_model(session, "anthropic:claude-sonnet-4-20250514")
+
+    assert Session.get_provider(session) == nil
+  end
+
+  test "custom providers still start when the top-level model name is unknown" do
+    {session, _checker} =
+      start_session(
+        [provider: StubProvider, provider_opts: [model: AgentConfig.unconfigured_model()]],
+        false
+      )
+
+    assert is_pid(Session.get_provider(session))
+  end
+
+  test "subscribe/2 sends the current credentials status to new subscribers" do
+    {unconfigured_session, _checker} =
+      start_session(
+        [provider: Native, provider_opts: [model: AgentConfig.unconfigured_model()]],
+        false
+      )
+
+    assert :ok = Session.subscribe(unconfigured_session, self())
+    assert_receive {:agent_event, ^unconfigured_session, {:credentials_status, false}}
+
+    {configured_session, _checker} =
+      start_session(
+        [provider: Native, provider_opts: [model: "anthropic:claude-sonnet-4-20250514"]],
+        true
+      )
+
+    assert :ok = Session.subscribe(configured_session, self())
+    assert_receive {:agent_event, ^configured_session, {:credentials_status, true}}
+  end
+
+  test "set_model/2 updates provider metadata for provider-qualified models" do
+    {session, _checker} =
+      start_session(
+        [provider: Native, provider_opts: [model: AgentConfig.unconfigured_model()]],
+        false
+      )
+
+    assert :ok = Session.set_model(session, "anthropic:claude-sonnet-4-20250514")
+    metadata = Session.metadata(session)
+
+    assert metadata.model_name == "anthropic:claude-sonnet-4-20250514"
+    assert metadata.provider_name == "anthropic"
+    assert Session.subagent_context(session).provider_name == "anthropic"
+  end
+
+  test "provider opts seed the stored model name when top-level model_name is absent" do
+    {session, _checker} =
+      start_session(
+        [provider: Native, provider_opts: [model: "anthropic:claude-sonnet-4-20250514"]],
+        true
+      )
+
+    assert is_pid(Session.get_provider(session))
+    assert Session.metadata(session).model_name == "anthropic:claude-sonnet-4-20250514"
+    assert Session.metadata(session).provider_name == "anthropic"
+  end
+
+  test "provider opts still start when top-level model_name is unknown" do
+    {session, _checker} =
+      start_session(
+        [
+          provider: Native,
+          model_name: AgentConfig.unconfigured_model(),
+          provider_opts: [model: "anthropic:claude-sonnet-4-20250514"]
+        ],
+        true
+      )
+
+    assert is_pid(Session.get_provider(session))
+    assert Session.metadata(session).model_name == "anthropic:claude-sonnet-4-20250514"
+  end
+end

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -357,10 +357,19 @@ defmodule MingaAgent.SessionTest do
   end
 
   defp start_subscribed_session(provider \\ MockProvider, provider_opts \\ []) do
+    provider_opts = native_provider_opts(provider, provider_opts)
     {:ok, session} = Session.start_link(provider: provider, provider_opts: provider_opts)
     Session.subscribe(session)
     session
   end
+
+  defp native_provider_opts(Native, provider_opts) do
+    provider_opts
+    |> Keyword.put_new(:provider, "anthropic")
+    |> Keyword.put_new(:model, "anthropic:test")
+  end
+
+  defp native_provider_opts(_provider, provider_opts), do: provider_opts
 
   defp agent_config(fields) do
     struct!(MingaAgent.Config, fields)
@@ -1043,6 +1052,8 @@ defmodule MingaAgent.SessionTest do
 
   describe "subscribe/unsubscribe" do
     test "stops receiving events after unsubscribe", %{session: session} do
+      assert_receive {:agent_event, ^session, {:credentials_status, true}}
+
       :ok = Session.unsubscribe(session)
 
       :ok = Session.send_prompt(session, "Test")

--- a/test/minga_editor/agent/ui_state_test.exs
+++ b/test/minga_editor/agent/ui_state_test.exs
@@ -20,7 +20,7 @@ defmodule MingaEditor.Agent.UIStateTest do
   end
 
   describe "new/0 and basic state" do
-    test "starts hidden, unfocused, empty, and configured with the default model" do
+    test "starts hidden, unfocused, empty, and uses the credential-aware default model" do
       ui = UIState.new()
 
       refute ui.panel.visible
@@ -33,7 +33,7 @@ defmodule MingaEditor.Agent.UIStateTest do
       assert UIState.input_line_count(ui) == 1
       assert UIState.input_empty?(ui)
       assert ui.panel.model_name == AgentConfig.default_model()
-      assert String.contains?(ui.panel.model_name, ":")
+      assert ui.panel.credentials_configured == false
     end
 
     test "toggle flips panel visibility" do

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -12,10 +12,12 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
   use ExUnit.Case, async: true
 
+  alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.Session
   alias Minga.Editing.Scroll
   alias MingaEditor.Agent.BufferSync
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.Panel
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Project.FileRef
   alias MingaEditor.Commands.Agent, as: AgentCommands
@@ -154,6 +156,84 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
     }
   end
 
+  defmodule PromptRejectingProvider do
+    @behaviour MingaAgent.Provider
+
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl MingaAgent.Provider
+    def send_prompt(pid, _text), do: GenServer.call(pid, :send_prompt)
+
+    @impl MingaAgent.Provider
+    def abort(pid), do: GenServer.cast(pid, :abort)
+
+    @impl MingaAgent.Provider
+    def new_session(pid), do: GenServer.cast(pid, :new_session)
+
+    @impl MingaAgent.Provider
+    def seed_messages(_pid, _messages), do: :ok
+
+    @impl MingaAgent.Provider
+    def get_state(_pid) do
+      {:ok,
+       %{
+         model: %{id: "test-model", name: "Test Model", provider: "test"},
+         is_streaming: false,
+         token_usage: nil
+       }}
+    end
+
+    @impl GenServer
+    def init(opts) do
+      {:ok, %{send_prompt_result: Keyword.fetch!(opts, :send_prompt_result)}}
+    end
+
+    @impl GenServer
+    def handle_call(:send_prompt, _from, state), do: {:reply, state.send_prompt_result, state}
+
+    @impl GenServer
+    def handle_cast(:abort, state), do: {:noreply, state}
+
+    @impl GenServer
+    def handle_cast(:new_session, state), do: {:noreply, state}
+  end
+
+  defmodule ReadinessSession do
+    use GenServer
+
+    @spec start_link(keyword()) :: GenServer.on_start()
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl GenServer
+    def init(opts), do: {:ok, Map.new(opts)}
+
+    @impl GenServer
+    def handle_call(:get_provider, _from, state), do: {:reply, Map.get(state, :provider), state}
+
+    def handle_call(:editor_snapshot, _from, state) do
+      snapshot = %{
+        status: Map.get(state, :status, :idle),
+        pending_approval: nil,
+        error: Map.get(state, :error),
+        active_tool_name: nil,
+        credentials_configured: Map.get(state, :credentials_configured, true)
+      }
+
+      {:reply, snapshot, state}
+    end
+
+    def handle_call({:send_prompt, content}, _from, state) do
+      if notify = Map.get(state, :notify) do
+        send(notify, {:readiness_session_prompt, content})
+      end
+
+      {:reply, Map.get(state, :send_prompt_result, :ok), state}
+    end
+  end
+
   # ── submit_prompt ────────────────────────────────────────────────────────
 
   describe "submit_prompt/1" do
@@ -173,19 +253,209 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == ""
     end
 
-    test "sets error status when no session exists" do
-      state = base_state(session: nil)
-
+    test "blocks submit and preserves draft when no model is configured" do
       state =
-        AgentAccess.update_agent_ui(state, fn ui ->
+        base_state(session: nil)
+        |> AgentAccess.update_agent_ui(fn ui ->
           ui = UIState.ensure_prompt_buffer(ui)
           BufferProcess.replace_content(ui.panel.prompt_buffer, "hello agent")
           ui
+        end)
+        |> AgentAccess.update_panel(fn panel ->
+          panel
+          |> Panel.set_credentials_configured(false)
+          |> Panel.set_model_name(AgentConfig.unconfigured_model())
+          |> Panel.set_provider_name("")
+        end)
+
+      new_state = AgentCommands.submit_prompt(state)
+
+      assert new_state.shell_state.status_msg =~ "No model configured"
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == "hello agent"
+    end
+
+    test "sets error status when model is configured but no session exists" do
+      state = base_state(session: nil)
+
+      state =
+        state
+        |> AgentAccess.update_agent_ui(fn ui ->
+          ui = UIState.ensure_prompt_buffer(ui)
+          BufferProcess.replace_content(ui.panel.prompt_buffer, "hello agent")
+          ui
+        end)
+        |> AgentAccess.update_panel(fn panel ->
+          panel
+          |> Panel.set_credentials_configured(true)
+          |> Panel.set_model_name("openai:gpt-5")
+          |> Panel.set_provider_name("openai")
         end)
 
       new_state = AgentCommands.submit_prompt(state)
 
       assert new_state.shell_state.status_msg =~ "No agent session"
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == "hello agent"
+    end
+
+    test "blocks submit as credentials missing when the local session reports credentials are not configured" do
+      {:ok, session} = ReadinessSession.start_link(provider: nil, credentials_configured: false)
+
+      state =
+        base_state(session: session)
+        |> AgentAccess.update_agent_ui(fn ui ->
+          ui = UIState.ensure_prompt_buffer(ui)
+          BufferProcess.replace_content(ui.panel.prompt_buffer, "draft prompt")
+          ui
+        end)
+        |> AgentAccess.update_panel(fn panel ->
+          panel
+          |> Panel.set_credentials_configured(true)
+          |> Panel.set_model_name("anthropic:claude-sonnet-4-20250514")
+          |> Panel.set_provider_name("anthropic")
+        end)
+
+      new_state = AgentCommands.submit_prompt(state)
+
+      assert new_state.shell_state.status_msg =~
+               "No provider credentials are configured for this model"
+
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == "draft prompt"
+    end
+
+    test "blocks submit as starting when credentials exist but no provider is attached yet" do
+      {:ok, session} = ReadinessSession.start_link(provider: nil)
+
+      state =
+        base_state(session: session)
+        |> AgentAccess.update_agent_ui(fn ui ->
+          ui = UIState.ensure_prompt_buffer(ui)
+          BufferProcess.replace_content(ui.panel.prompt_buffer, "draft prompt")
+          ui
+        end)
+        |> AgentAccess.update_panel(fn panel ->
+          panel
+          |> Panel.set_credentials_configured(true)
+          |> Panel.set_model_name("anthropic:claude-sonnet-4-20250514")
+          |> Panel.set_provider_name("anthropic")
+        end)
+
+      new_state = AgentCommands.submit_prompt(state)
+
+      assert new_state.shell_state.status_msg =~ "Agent provider still starting"
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == "draft prompt"
+    end
+
+    test "blocks submit with concrete startup failure when provider startup failed" do
+      {:ok, session} = ReadinessSession.start_link(provider: nil, error: "boom")
+
+      state =
+        base_state(session: session)
+        |> AgentAccess.update_agent_ui(fn ui ->
+          ui = UIState.ensure_prompt_buffer(ui)
+          BufferProcess.replace_content(ui.panel.prompt_buffer, "draft prompt")
+          ui
+        end)
+        |> AgentAccess.update_panel(fn panel ->
+          panel
+          |> Panel.set_credentials_configured(true)
+          |> Panel.set_model_name("anthropic:claude-sonnet-4-20250514")
+          |> Panel.set_provider_name("anthropic")
+        end)
+
+      new_state = AgentCommands.submit_prompt(state)
+
+      assert new_state.shell_state.status_msg ==
+               "Failed to start agent: boom. Your prompt was preserved."
+
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == "draft prompt"
+    end
+
+    test "ready provider still sends and clears a normal prompt" do
+      {:ok, session} = ReadinessSession.start_link(provider: self(), notify: self())
+
+      state =
+        base_state(session: session)
+        |> AgentAccess.update_agent_ui(fn ui ->
+          ui = UIState.ensure_prompt_buffer(ui)
+          BufferProcess.replace_content(ui.panel.prompt_buffer, "ready prompt")
+          ui
+        end)
+        |> AgentAccess.update_panel(fn panel ->
+          panel
+          |> Panel.set_credentials_configured(true)
+          |> Panel.set_model_name("anthropic:claude-sonnet-4-20250514")
+          |> Panel.set_provider_name("anthropic")
+        end)
+
+      new_state = AgentCommands.submit_prompt(state)
+
+      assert_receive {:readiness_session_prompt, "ready prompt"}
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == ""
+    end
+
+    test "ready local provider sends even when panel credentials cache is stale" do
+      {:ok, session} =
+        ReadinessSession.start_link(
+          provider: self(),
+          notify: self(),
+          credentials_configured: true
+        )
+
+      state =
+        base_state(session: session)
+        |> AgentAccess.update_agent_ui(fn ui ->
+          ui = UIState.ensure_prompt_buffer(ui)
+          BufferProcess.replace_content(ui.panel.prompt_buffer, "stale panel prompt")
+          ui
+        end)
+        |> AgentAccess.update_panel(fn panel ->
+          panel
+          |> Panel.set_credentials_configured(false)
+          |> Panel.set_model_name("anthropic:claude-sonnet-4-20250514")
+          |> Panel.set_provider_name("anthropic")
+        end)
+
+      new_state = AgentCommands.submit_prompt(state)
+
+      assert_receive {:readiness_session_prompt, "stale panel prompt"}
+      assert is_nil(new_state.shell_state.status_msg)
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == ""
+    end
+
+    test "preserves the prompt when an attached session rejects locally" do
+      for {error, expected_message} <- [
+            {:provider_not_ready, "Agent provider still starting"},
+            {:credentials_not_configured, "No provider credentials are configured"}
+          ] do
+        {:ok, session} =
+          Session.start_link(
+            provider: PromptRejectingProvider,
+            provider_opts: [send_prompt_result: {:error, error}, model: "anthropic:test"],
+            persist?: false
+          )
+
+        on_exit(fn -> Process.exit(session, :kill) end)
+        :sys.get_state(session)
+
+        state =
+          base_state(session: session)
+          |> AgentAccess.update_panel(fn panel ->
+            panel
+            |> Panel.set_credentials_configured(true)
+            |> Panel.set_model_name("anthropic:test")
+            |> Panel.set_provider_name("test")
+          end)
+          |> AgentAccess.update_agent_ui(fn ui ->
+            ui = UIState.ensure_prompt_buffer(ui)
+            BufferProcess.replace_content(ui.panel.prompt_buffer, "draft prompt")
+            ui
+          end)
+
+        new_state = AgentCommands.submit_prompt(state)
+
+        assert new_state.shell_state.status_msg =~ expected_message
+        assert UIState.prompt_text(AgentAccess.panel(new_state)) == "draft prompt"
+      end
     end
   end
 
@@ -515,8 +785,50 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       assert is_pid(active_workspace.session)
       assert EditorState.active_tab_kind(new_state) == :agent
       assert new_state.workspace.buffers.active == AgentAccess.agent(new_state).buffer
-      assert TabBar.get_workspace(tab_bar, 0) == source_workspace
+      manual_workspace = TabBar.get_workspace(tab_bar, 0)
+      assert manual_workspace.files == source_workspace.files
+      assert manual_workspace.active_file == source_workspace.active_file
+      assert manual_workspace.session == source_workspace.session
       assert TabBar.active(tab_bar).session == active_workspace.session
+    end
+
+    test "switching back to the source file tab restores file content" do
+      state = source_workspace_state()
+      file_tab_id = state.shell_state.tab_bar.active_id
+
+      new_state = AgentCommands.new_agent_session(state)
+      switched = EditorState.switch_tab(new_state, file_tab_id)
+      active_window = switched.workspace.windows.map[switched.workspace.windows.active]
+
+      assert EditorState.active_tab_kind(switched) == :file
+      assert active_window.content == {:buffer, switched.workspace.buffers.active}
+      refute MingaEditor.Window.Content.agent_chat?(active_window.content)
+    end
+
+    test "switching to a file tab inside an agent workspace restores file content" do
+      state = source_workspace_state()
+      file_tab_id = state.shell_state.tab_bar.active_id
+      file_tab = TabBar.get(state.shell_state.tab_bar, file_tab_id)
+
+      new_state = AgentCommands.new_agent_session(state)
+      agent_workspace_id = TabBar.active_workspace_id(new_state.shell_state.tab_bar)
+
+      tab_bar =
+        new_state.shell_state.tab_bar
+        |> TabBar.move_tab_to_workspace(file_tab_id, agent_workspace_id)
+        |> TabBar.update_context(file_tab_id, file_tab.context)
+
+      switched =
+        new_state
+        |> EditorState.set_tab_bar(tab_bar)
+        |> EditorState.switch_tab(file_tab_id)
+
+      active_window = switched.workspace.windows.map[switched.workspace.windows.active]
+
+      assert TabBar.active_workspace_id(switched.shell_state.tab_bar) == agent_workspace_id
+      assert EditorState.active_tab_kind(switched) == :file
+      assert active_window.content == {:buffer, switched.workspace.buffers.active}
+      refute MingaEditor.Window.Content.agent_chat?(active_window.content)
     end
 
     test "creating from an existing agent workspace preserves the source tab context" do
@@ -549,7 +861,10 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       assert tab_bar.active_id == source_active_id
       assert TabBar.active_workspace_id(tab_bar) == 0
-      assert TabBar.get_workspace(tab_bar, 0) == source_workspace
+      manual_workspace = TabBar.get_workspace(tab_bar, 0)
+      assert manual_workspace.files == source_workspace.files
+      assert manual_workspace.active_file == source_workspace.active_file
+      assert manual_workspace.session == source_workspace.session
       assert [%{files: [], active_file: nil, session: session}] = agent_workspaces
       assert is_pid(session)
     end

--- a/test/minga_editor/commands/inline_ask_promotion_hooks_test.exs
+++ b/test/minga_editor/commands/inline_ask_promotion_hooks_test.exs
@@ -6,6 +6,7 @@ defmodule MingaEditor.Commands.InlineAskPromotionHooksTest do
   alias MingaAgent.Hooks.RecordingHook
   alias MingaAgent.Session
   alias MingaAgent.SessionManager
+  alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Commands.InlineAsk, as: InlineAskCommand
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
@@ -43,7 +44,14 @@ defmodule MingaEditor.Commands.InlineAskPromotionHooksTest do
     File.write!(path, "hello")
     ctx = start_editor("hello", file_path: path, project_root: dir)
 
-    state = InlineAskCommand.open(editor_state(ctx))
+    state =
+      editor_state(ctx)
+      |> AgentAccess.update_panel(fn panel ->
+        panel
+        |> Panel.set_provider_name("anthropic")
+        |> Panel.set_model_name("anthropic:test")
+      end)
+      |> InlineAskCommand.open()
 
     ask =
       state

--- a/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
+++ b/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
@@ -12,6 +12,7 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
   alias Minga.SystemObserver.TreeNode
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
   alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
   alias MingaEditor.Session.ChromeState
   alias MingaEditor.Session.ChromeState.TabSummary
@@ -129,17 +130,26 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
       assert Bitwise.band(flags, 0x01) == 0
     end
 
-    test "agent tabs and file tabs from other workspaces are omitted" do
+    test "agent workspace shows its agent tab and file tabs while omitting other workspaces" do
       tab1 = %Tab{id: 1, kind: :file, label: "a.ex", group_id: 0}
       tab2 = %Tab{id: 2, kind: :agent, label: "Agent", group_id: 7}
       tab3 = %Tab{id: 3, kind: :file, label: "b.ex", group_id: 7}
-      tb = %TabBar{tabs: [tab1, tab2, tab3], active_id: 2, next_id: 4}
 
-      <<0x71, active_index::8, 1::8, rest::binary>> = ProtocolGUI.encode_gui_tab_bar(tb)
-      <<_flags::8, id::32, _rest::binary>> = rest
+      tb = %TabBar{
+        tabs: [tab1, tab2, tab3],
+        active_id: 2,
+        next_id: 4,
+        workspaces: [Workspace.new_manual(nil), Workspace.new_agent(7, "Agent")]
+      }
 
-      assert active_index == 255
-      assert id == 3
+      <<0x71, active_index::8, 2::8, rest::binary>> = ProtocolGUI.encode_gui_tab_bar(tb)
+      {agent_flags, agent_id, rest} = decode_tab_header(rest)
+      {_file_flags, file_id, _rest} = decode_tab_header(rest)
+
+      assert active_index == 0
+      assert Bitwise.band(agent_flags, 0x04) == 0x04
+      assert agent_id == 2
+      assert file_id == 3
     end
   end
 
@@ -242,6 +252,38 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
       assert label == "agent.ex"
       assert path == "/tmp/agent.ex"
       assert tint == 0
+    end
+
+    test "encodes visible agent tabs with agent kind byte" do
+      tab =
+        TabSummary.new(
+          id: 43,
+          workspace_id: 1,
+          kind: :agent,
+          label: "Agent",
+          icon: "cpu"
+        )
+
+      chrome_state =
+        chrome_state(
+          active_workspace_id: 1,
+          mode: :agent,
+          visible_tabs: [tab]
+        )
+
+      <<0x98, payload_len::16, payload::binary-size(payload_len)>> =
+        ProtocolGUI.encode_gui_workspaces(chrome_state)
+
+      <<2::8, 1::16, 1::8, _flags::8, 0::8, 1::16, 43::32, 1::16, 1::8, _tab_flags::16,
+        _path_hash::32, icon_len::8, icon::binary-size(icon_len), label_len::16,
+        label::binary-size(label_len), path_len::16, path::binary-size(path_len), tint::32>> =
+        payload
+
+      assert icon == "cpu"
+      assert label == "Agent"
+      assert path == ""
+      assert tint == 0
+      assert payload_len > 0
     end
 
     test "encodes pinned visible tabs with tint color metadata" do
@@ -1156,6 +1198,13 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
          acc
        ) do
     parse_observatory_sections(rest, [{id, section} | acc])
+  end
+
+  defp decode_tab_header(
+         <<flags::8, id::32, _workspace::16, icon_len::8, _icon::binary-size(icon_len),
+           label_len::16, _label::binary-size(label_len), _tint::32, rest::binary>>
+       ) do
+    {flags, id, rest}
   end
 
   defp sections_by_id(sections, id) do

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -20,6 +20,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
   alias MingaEditor.State.ResourcePressure
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
   alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
   alias MingaEditor.UI.Popup.Active, as: PopupActive
   alias Minga.Popup.Rule
@@ -57,6 +58,25 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
     assert unpinned_tab_bar.active_id == 1
     refute TabBar.get(unpinned_tab_bar, 3).pinned?
+  end
+
+  test "execute_command switches workspaces by exact workspace id", %{sidebar_registry: table} do
+    manual_tab = Tab.new_file(1, "main.ex")
+    agent_tab = Tab.new_agent(2, "Agent") |> Tab.set_group(7)
+
+    tab_bar = %TabBar{
+      tabs: [manual_tab, agent_tab],
+      active_id: 1,
+      next_id: 3,
+      workspaces: [Workspace.new_manual(nil), Workspace.new_agent(7, "Agent")]
+    }
+
+    state = base_state(table) |> EditorState.set_tab_bar(tab_bar)
+
+    switched = GuiActionHandler.dispatch(state, {:execute_command, "workspace_goto_id:7"})
+
+    assert EditorState.tab_bar(switched).active_id == 2
+    assert TabBar.active_workspace_id(EditorState.tab_bar(switched)) == 7
   end
 
   test "activating visible sidebars updates focus and keyboard scope", %{sidebar_registry: table} do

--- a/test/minga_editor/input/cua_tui_integration_test.exs
+++ b/test/minga_editor/input/cua_tui_integration_test.exs
@@ -136,7 +136,7 @@ defmodule MingaEditor.Input.CUATUIIntegrationTest do
 
       assert AgentAccess.input_focused?(state)
       assert UIState.input_text(AgentAccess.panel(state)) == "hello agent"
-      assert EditorState.status_msg(state) =~ "No agent session"
+      assert EditorState.status_msg(state) =~ "No model configured"
     end
   end
 

--- a/test/minga_editor/session/chrome_state_test.exs
+++ b/test/minga_editor/session/chrome_state_test.exs
@@ -70,7 +70,7 @@ defmodule MingaEditor.Session.ChromeStateTest do
   end
 
   describe "visible_tabs" do
-    test "includes only active workspace file tabs", %{tmp_dir: tmp_dir} do
+    test "includes active workspace content tabs", %{tmp_dir: tmp_dir} do
       {tb, group} = tab_bar_with_agent_workspace(tmp_dir)
       manual_chrome = ChromeState.from_editor_state(state(tab_bar: tb, project_root: tmp_dir))
 
@@ -83,8 +83,9 @@ defmodule MingaEditor.Session.ChromeStateTest do
         )
 
       assert agent_chrome.active_workspace_id == group.id
-      assert Enum.map(agent_chrome.visible_tabs, & &1.workspace_id) == [group.id]
-      assert Enum.map(agent_chrome.visible_tabs, & &1.label) == ["agent.ex"]
+      assert Enum.map(agent_chrome.visible_tabs, & &1.workspace_id) == [group.id, group.id]
+      assert Enum.map(agent_chrome.visible_tabs, & &1.kind) == [:agent, :file]
+      assert Enum.map(agent_chrome.visible_tabs, & &1.label) == ["Agent", "agent.ex"]
     end
 
     test "duplicate paths in different workspaces remain distinct", %{tmp_dir: tmp_dir} do
@@ -99,11 +100,11 @@ defmodule MingaEditor.Session.ChromeStateTest do
         )
 
       assert [%{id: 1, workspace_id: 0, path: ^duplicate_path}] = manual.visible_tabs
-      assert [%{id: 3, workspace_id: group_id, path: ^duplicate_path}] = agent.visible_tabs
+      assert [_, %{id: 3, workspace_id: group_id, path: ^duplicate_path}] = agent.visible_tabs
       assert group_id == group.id
     end
 
-    test "does not include agent-chat tabs in visible file tabs", %{tmp_dir: tmp_dir} do
+    test "includes agent tab before agent workspace file tabs", %{tmp_dir: tmp_dir} do
       {tb, _group} = tab_bar_with_agent_workspace(tmp_dir)
 
       chrome =
@@ -111,8 +112,8 @@ defmodule MingaEditor.Session.ChromeStateTest do
           state(tab_bar: TabBar.switch_to(tb, 2), project_root: tmp_dir)
         )
 
-      assert Enum.map(chrome.visible_tabs, & &1.kind) == [:file]
-      assert Enum.map(chrome.visible_tabs, & &1.label) == ["agent.ex"]
+      assert Enum.map(chrome.visible_tabs, & &1.kind) == [:agent, :file]
+      assert Enum.map(chrome.visible_tabs, & &1.label) == ["Agent", "agent.ex"]
     end
 
     test "keeps pinned agent workspace tabs first and tints them", %{tmp_dir: tmp_dir} do
@@ -124,8 +125,8 @@ defmodule MingaEditor.Session.ChromeStateTest do
 
       chrome = ChromeState.from_editor_state(state(tab_bar: tb, project_root: tmp_dir))
 
-      assert Enum.map(chrome.visible_tabs, & &1.label) == ["pinned.ex", "agent.ex"]
-      assert Enum.map(chrome.visible_tabs, & &1.pinned?) == [true, false]
+      assert Enum.map(chrome.visible_tabs, & &1.label) == ["Agent", "pinned.ex", "agent.ex"]
+      assert Enum.map(chrome.visible_tabs, & &1.pinned?) == [false, true, false]
       assert Enum.all?(chrome.visible_tabs, &(&1.tint_color > 0))
 
       manual_chrome =

--- a/test/minga_editor/state/event_routing_test.exs
+++ b/test/minga_editor/state/event_routing_test.exs
@@ -161,15 +161,15 @@ defmodule MingaEditor.State.EventRoutingTest do
   describe "Agent.Events.handle/2 — credentials status" do
     test "credentials_status updates the panel flag and re-renders" do
       %{state: state} = make_state()
-      assert AgentAccess.panel(state).credentials_configured == true
+      assert AgentAccess.panel(state).credentials_configured == false
 
-      {new_state, effects} = AgentEvents.handle(state, {:credentials_status, false})
+      {new_state, effects} = AgentEvents.handle(state, {:credentials_status, true})
 
-      assert AgentAccess.panel(new_state).credentials_configured == false
+      assert AgentAccess.panel(new_state).credentials_configured == true
       assert :render in effects
 
-      {restored, _effects} = AgentEvents.handle(new_state, {:credentials_status, true})
-      assert AgentAccess.panel(restored).credentials_configured == true
+      {restored, _effects} = AgentEvents.handle(new_state, {:credentials_status, false})
+      assert AgentAccess.panel(restored).credentials_configured == false
     end
   end
 

--- a/test/minga_editor/state/tab_bar_test.exs
+++ b/test/minga_editor/state/tab_bar_test.exs
@@ -473,19 +473,22 @@ defmodule MingaEditor.State.TabBarTest do
   end
 
   describe "workspace membership and switching" do
-    test "moves tabs to workspaces, lists members, and switches to the workspace's first tab" do
+    test "moves tabs to workspaces, lists members, and switches to the workspace's first visible tab" do
       tb = TabBar.new(file_tab(1, "a.ex"))
+      {tb, file_tab_two} = TabBar.add(tb, :file, "workspace.ex")
       {tb, _} = TabBar.add(tb, :agent, "Agent")
       {tb, group} = TabBar.add_workspace(tb, "Agent")
-      tb = TabBar.move_tab_to_workspace(tb, 2, group.id)
+      tb = TabBar.move_tab_to_workspace(tb, file_tab_two.id, group.id)
+      tb = TabBar.move_tab_to_workspace(tb, 3, group.id)
       tb = TabBar.switch_to(tb, 1)
 
-      assert TabBar.tabs_in_workspace(tb, group.id) |> Enum.map(& &1.id) == [2]
+      assert TabBar.tabs_in_workspace(tb, group.id) |> Enum.map(& &1.id) == [2, 3]
+      assert TabBar.visible_workspace_tabs(tb, group.id) |> Enum.map(& &1.id) == [3, 2]
       assert TabBar.tabs_in_workspace(tb, 0) |> Enum.map(& &1.id) == [1]
 
       tb = TabBar.switch_to_workspace(tb, group.id)
       assert TabBar.active_workspace_id(tb) == group.id
-      assert tb.active_id == 2
+      assert tb.active_id == 3
       assert TabBar.switch_to_workspace(tb, 999) == tb
     end
   end


### PR DESCRIPTION
# TL;DR
Fixes the broken new agent workspace UX when no usable model or credentials are configured. Agent workspaces now show a real Agent tab, preserve draft prompts on local configuration failures, recover provider startup after credentials/model selection, and block submit from a truthful provider-readiness state instead of a stale credential flag.

## Context
`SPC a n` could create an agent workspace that looked ready even when no provider credentials were available. The UI also exposed workspace and tab affordances that did not consistently switch the visible surface, which made the Agent view feel stuck after selecting files or workspace rows.

## Changes
- Replaced the hard-coded Claude/Sonnet fallback with a credential-aware model resolver and an internal `unknown` sentinel when no usable model is available.
- Display `No model configured` instead of pretending a vendor model is active.
- Split credential presence from provider readiness for prompt submit: no model, credentials missing, provider starting, startup failed, and ready are handled separately.
- Keep typing enabled and preserve drafts for every local blocked state, with actionable status copy.
- Recover provider startup when credentials become available or a concrete model is selected, without using process-global env mutation in tests.
- Keep provider metadata in sync for both `provider:model` and `model@provider` model specs.
- Route focused agent prompt input through the agent panel in both editor and agent scopes.
- Make Agent a first-class visible tab in agent workspaces and include `:agent` visible-tab support in semantic and legacy workspace encoders.
- Fix workspace/tab switching so selecting file tabs restores file content instead of leaving the Agent chat visible.
- Make macOS workspace dropdown rows switch by exact workspace id through the existing execute-command envelope.
- Fix macOS canonical Agent tab rendering and file-tab drag reorder indexing when an Agent tab leads the workspace tab strip.

## Verification
- `make lint`
- `mix test.llm --max-cases 4` (56 doctests, 87 properties, 9361 tests, 0 failures, 1 skipped, 333 excluded)
- `mix compile --warnings-as-errors`
- `mix test.llm test/minga_editor/commands/agent_commands_test.exs test/minga_editor/agent/ui_state_test.exs test/minga_agent/session_recovery_test.exs test/minga_agent/session_test.exs test/minga_agent/config_test.exs test/minga_agent/session_provider_registry_test.exs test/minga_editor/state/event_routing_test.exs`
- `mix swift.build`
- `xcodebuild test -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS'`
- Focused Swift test slice: `xcodebuild test -project Minga.xcodeproj -scheme Minga -destination 'platform=macOS' -only-testing:MingaTests/TabBarStateLifecycleTests -only-testing:MingaTests/TabBarViewViewTests -only-testing:MingaTests/WorkspaceHeaderViewTests`
