### PR TITLE
feat(agent): ship bundled semantic UI status note

### DIFF
--- a/lib/minga_editor/agent/semantic_ui/bundled_status_note.ex
+++ b/lib/minga_editor/agent/semantic_ui/bundled_status_note.ex
@@ -1,0 +1,93 @@
+defmodule MingaEditor.Agent.SemanticUI.BundledStatusNote do
+  @moduledoc """
+  Bundled low-risk agent status note published through the semantic UI registry.
+  """
+
+  use GenServer
+
+  alias MingaEditor.Agent.SemanticUI.Registry
+
+  @entry_id "agent-status-note"
+  @source {:bundle, :agent_status_note}
+
+  @typedoc "Bundled source for the agent status note contribution."
+  @type source :: {:bundle, :agent_status_note}
+
+  @doc "Returns the source used for the bundled agent status note."
+  @spec source() :: source()
+  def source, do: @source
+
+  @doc "Returns the stable entry id for the bundled agent status note."
+  @spec entry_id() :: String.t()
+  def entry_id, do: @entry_id
+
+  @doc "Starts the bundled status note registrar."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc false
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: Keyword.get(opts, :name, __MODULE__),
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker
+    }
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, Registry.table()} | {:stop, term()}
+  def init(opts) do
+    registry = Keyword.get(opts, :registry, Registry)
+
+    case register(registry) do
+      :ok -> {:ok, registry}
+      {:error, reason} -> {:stop, {:agent_status_note_registration_failed, registry, reason}}
+    end
+  end
+
+  @doc "Returns the semantic transcript contribution entries for this bundled source."
+  @spec entries() :: [Registry.register_attrs()]
+  def entries do
+    [
+      %{
+        id: @entry_id,
+        surface: :transcript_enrichment,
+        target: :agent_chat,
+        priority: 10,
+        payload: {:system, "Agent UI registry online", :info},
+        actions: [
+          %{
+            id: "open_agent",
+            label: "Open agent panel",
+            kind: :primary,
+            editor_action: :toggle_agentic_view,
+            payload: %{source: @entry_id}
+          }
+        ]
+      }
+    ]
+  end
+
+  @doc "Registers the bundled status note into the semantic UI registry."
+  @spec register(Registry.table()) :: :ok | {:error, term()}
+  def register(registry \\ Registry) when is_atom(registry) do
+    Registry.register_many(registry, source(), entries())
+  end
+
+  @doc "Removes this bundled status note from the semantic UI registry."
+  @spec unregister(Registry.table()) :: :ok
+  def unregister(registry \\ Registry) when is_atom(registry) do
+    Registry.unregister_source(registry, source())
+  end
+
+  @doc "Reloads this bundled status note without touching other agent state."
+  @spec reload(Registry.table()) :: :ok | {:error, term()}
+  def reload(registry \\ Registry) when is_atom(registry) do
+    unregister(registry)
+    register(registry)
+  end
+end

--- a/lib/minga_editor/agent/semantic_ui/registry.ex
+++ b/lib/minga_editor/agent/semantic_ui/registry.ex
@@ -200,6 +200,25 @@ defmodule MingaEditor.Agent.SemanticUI.Registry do
     end
   end
 
+  @doc "Dispatches a semantic extension-panel action by frontend source label."
+  @spec dispatch_panel_action(EditorState.t(), String.t(), atom() | String.t(), map()) ::
+          {:ok, EditorState.t()} | :error
+  @spec dispatch_panel_action(table(), EditorState.t(), String.t(), atom() | String.t(), map()) ::
+          {:ok, EditorState.t()} | :error
+  def dispatch_panel_action(state, ext_name, action_name, context \\ %{}) do
+    dispatch_panel_action(table_for(state), state, ext_name, action_name, context)
+  end
+
+  def dispatch_panel_action(table, state, ext_name, action_name, context)
+      when is_binary(ext_name) do
+    action_id = semantic_action_id(action_name)
+
+    case panel_action_entry(table, ext_name, action_id) do
+      %Entry{id: entry_id} -> {:ok, dispatch_action(table, state, entry_id, action_id, context)}
+      nil -> :error
+    end
+  end
+
   @impl true
   @spec init(keyword()) :: {:ok, state()}
   def init(opts) do
@@ -215,6 +234,7 @@ defmodule MingaEditor.Agent.SemanticUI.Registry do
         unregister_source(table, source)
       end)
 
+      seed_bundled_sources(table)
       seed_from_running_extensions(table)
     end
 
@@ -255,6 +275,20 @@ defmodule MingaEditor.Agent.SemanticUI.Registry do
   end
 
   def handle_info(_msg, table), do: {:noreply, table}
+
+  @spec seed_bundled_sources(table()) :: :ok
+  defp seed_bundled_sources(table) do
+    source = MingaEditor.Agent.SemanticUI.BundledStatusNote.source()
+
+    case do_register_many(
+           table,
+           source,
+           MingaEditor.Agent.SemanticUI.BundledStatusNote.entries()
+         ) do
+      :ok -> :ok
+      {:error, reason} -> log_manifest_entry_error(source, reason)
+    end
+  end
 
   @spec seed_from_running_extensions(table()) :: :ok
   defp seed_from_running_extensions(table) do
@@ -438,6 +472,40 @@ defmodule MingaEditor.Agent.SemanticUI.Registry do
       nil -> :error
     end
   end
+
+  @spec panel_action_entry(table(), String.t(), String.t()) :: Entry.t() | nil
+  defp panel_action_entry(table, ext_name, action_id) do
+    table
+    |> all()
+    |> Enum.find(&semantic_panel_action_entry?(&1, ext_name, action_id))
+  end
+
+  @spec semantic_panel_action_entry?(Entry.t(), String.t(), String.t()) :: boolean()
+  defp semantic_panel_action_entry?(
+         %Entry{surface: surface, actions: actions} = entry,
+         ext_name,
+         action_id
+       )
+       when surface in [:dashboard_section, :panel] do
+    semantic_panel_source?(entry, ext_name) and Enum.any?(actions, &(&1.id == action_id))
+  end
+
+  defp semantic_panel_action_entry?(%Entry{}, _ext_name, _action_id), do: false
+
+  @spec semantic_panel_source?(Entry.t(), String.t()) :: boolean()
+  defp semantic_panel_source?(
+         %Entry{source: source, payload: %ExtensionPanel.Panel{extension: extension}},
+         ext_name
+       ) do
+    extension == ext_name or source_label(source) == ext_name
+  end
+
+  defp semantic_panel_source?(%Entry{source: source}, ext_name),
+    do: source_label(source) == ext_name
+
+  @spec semantic_action_id(atom() | String.t()) :: String.t()
+  defp semantic_action_id(action_name) when is_atom(action_name), do: Atom.to_string(action_name)
+  defp semantic_action_id(action_name) when is_binary(action_name), do: action_name
 
   @spec dispatch_editor_action(EditorState.t(), map(), Action.editor_action()) :: EditorState.t()
   defp dispatch_editor_action(state, _context, nil), do: state

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -401,6 +401,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
           | {:search_replace_all, replacement :: String.t()}
           | :search_dismiss
           | {:sidebar_action, sidebar_id :: String.t(), kind :: String.t(), action :: String.t()}
+          | {:extension_panel_action, ext_name :: String.t(), action_name :: String.t(),
+             context :: map()}
           | {:extension_action, extension_id :: String.t(), action :: String.t(),
              payload :: binary()}
           | :float_popup_dismiss
@@ -2550,9 +2552,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
           action_name::binary-size(action_len), context_rest::binary>>
       ) do
     context = decode_panel_action_context(context_rest)
-    {:ok, {:extension_panel_action, ext_name, String.to_existing_atom(action_name), context}}
-  rescue
-    ArgumentError -> :error
+    {:ok, {:extension_panel_action, ext_name, action_name, context}}
   end
 
   def decode_gui_action(

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -19,6 +19,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   alias Minga.LSP.Supervisor, as: LspSupervisor
   alias Minga.LSP.SyncServer, as: LspSyncServer
 
+  alias MingaEditor.Agent.SemanticUI.Registry, as: SemanticUIRegistry
   alias MingaEditor.AsyncAction
   alias MingaEditor.BottomPanel
   alias MingaEditor.Commands
@@ -1815,13 +1816,24 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   defp find_float_popup_window_id(_state), do: nil
 
-  @spec route_panel_action_to_extension(state(), String.t(), atom(), map()) :: state()
+  @spec route_panel_action_to_extension(state(), String.t(), atom() | String.t(), map()) ::
+          state()
   defp route_panel_action_to_extension(state, ext_name, action_name, context) do
+    case SemanticUIRegistry.dispatch_panel_action(state, ext_name, action_name, context) do
+      {:ok, state} -> state
+      :error -> route_legacy_panel_action_to_extension(state, ext_name, action_name, context)
+    end
+  end
+
+  @spec route_legacy_panel_action_to_extension(state(), String.t(), atom() | String.t(), map()) ::
+          state()
+  defp route_legacy_panel_action_to_extension(state, ext_name, action_name, context) do
     ext_atom = String.to_existing_atom(ext_name)
+    action_atom = legacy_panel_action_name(action_name)
 
     case Minga.Extension.Registry.get(Minga.Extension.Registry, ext_atom) do
       {:ok, %{pid: pid}} when is_pid(pid) ->
-        send(pid, {:panel_action, action_name, context})
+        send(pid, {:panel_action, action_atom, context})
         state
 
       _ ->
@@ -1831,7 +1843,13 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     ArgumentError -> extension_panel_action_unavailable(state, ext_name, action_name)
   end
 
-  @spec extension_panel_action_unavailable(state(), String.t(), atom()) :: state()
+  @spec legacy_panel_action_name(atom() | String.t()) :: atom()
+  defp legacy_panel_action_name(action_name) when is_atom(action_name), do: action_name
+
+  defp legacy_panel_action_name(action_name) when is_binary(action_name),
+    do: String.to_existing_atom(action_name)
+
+  @spec extension_panel_action_unavailable(state(), String.t(), atom() | String.t()) :: state()
   defp extension_panel_action_unavailable(state, ext_name, action_name) do
     Minga.Log.warning(
       :editor,

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -103,6 +103,7 @@ defmodule MingaEditor.State do
             options_server: @default_options_server,
             events_registry: @default_events_registry,
             sidebar_registry: MingaEditor.Extension.Sidebar.default_table(),
+            agent_semantic_ui_registry: MingaEditor.Agent.SemanticUI.Registry.default_table(),
             workspace: nil,
             terminal_viewport: Viewport.new(24, 80),
             editing_model: :vim,
@@ -176,6 +177,7 @@ defmodule MingaEditor.State do
           options_server: options_server(),
           events_registry: events_registry(),
           sidebar_registry: MingaEditor.Extension.Sidebar.table(),
+          agent_semantic_ui_registry: MingaEditor.Agent.SemanticUI.Registry.table(),
           workspace: SessionState.t(),
           terminal_viewport: Viewport.t(),
           editing_model: :vim | :cua,
@@ -227,6 +229,12 @@ defmodule MingaEditor.State do
   @doc "Returns the active sidebar registry table for this state."
   @spec sidebar_registry(t() | map()) :: MingaEditor.Extension.Sidebar.table()
   def sidebar_registry(state), do: MingaEditor.Extension.Sidebar.table_for(state)
+
+  @doc "Stores the semantic agent UI registry table for this editor state."
+  @spec put_agent_semantic_ui_registry(t(), MingaEditor.Agent.SemanticUI.Registry.table()) :: t()
+  def put_agent_semantic_ui_registry(%__MODULE__{} = state, table) when is_atom(table) do
+    %{state | agent_semantic_ui_registry: table}
+  end
 
   @spec set_renderer(t(), pid() | nil) :: t()
   def set_renderer(%__MODULE__{} = state, pid) when is_pid(pid) or is_nil(pid),

--- a/test/minga/extension/panel_interaction_test.exs
+++ b/test/minga/extension/panel_interaction_test.exs
@@ -13,7 +13,7 @@ defmodule Minga.Extension.PanelInteractionTest do
         <<byte_size(ext_name)::8, ext_name::binary, byte_size(action_name)::8,
           action_name::binary, 0x01, 2::16>>
 
-      assert {:ok, {:extension_panel_action, ^ext_name, :session_selected, %{index: 2}}} =
+      assert {:ok, {:extension_panel_action, ^ext_name, ^action_name, %{index: 2}}} =
                ProtocolGUI.decode_gui_action(action_opcode, payload)
     end
 
@@ -27,7 +27,7 @@ defmodule Minga.Extension.PanelInteractionTest do
         <<byte_size(ext_name)::8, ext_name::binary, byte_size(action_name)::8,
           action_name::binary, 0x02, byte_size(node_id)::8, node_id::binary>>
 
-      assert {:ok, {:extension_panel_action, ^ext_name, :node_selected, %{node_id: ^node_id}}} =
+      assert {:ok, {:extension_panel_action, ^ext_name, ^action_name, %{node_id: ^node_id}}} =
                ProtocolGUI.decode_gui_action(action_opcode, payload)
     end
 
@@ -40,20 +40,21 @@ defmodule Minga.Extension.PanelInteractionTest do
         <<byte_size(ext_name)::8, ext_name::binary, byte_size(action_name)::8,
           action_name::binary>>
 
-      assert {:ok, {:extension_panel_action, ^ext_name, :refresh, %{}}} =
+      assert {:ok, {:extension_panel_action, ^ext_name, ^action_name, %{}}} =
                ProtocolGUI.decode_gui_action(action_opcode, payload)
     end
 
-    test "returns error for non-existent atom in action name" do
+    test "decodes arbitrary string action names for semantic registry routing" do
       action_opcode = Minga.Protocol.Opcodes.gui_action_extension_panel_action()
-      ext_name = "my_ext"
-      action_name = "this_atom_definitely_does_not_exist_#{System.unique_integer()}"
+      ext_name = "bundle:agent_status_note"
+      action_name = "open_agent"
 
       payload =
         <<byte_size(ext_name)::8, ext_name::binary, byte_size(action_name)::8,
           action_name::binary>>
 
-      assert :error = ProtocolGUI.decode_gui_action(action_opcode, payload)
+      assert {:ok, {:extension_panel_action, ^ext_name, ^action_name, %{}}} =
+               ProtocolGUI.decode_gui_action(action_opcode, payload)
     end
   end
 end

--- a/test/minga_editor/agent/semantic_ui/bundled_status_note_test.exs
+++ b/test/minga_editor/agent/semantic_ui/bundled_status_note_test.exs
@@ -1,0 +1,125 @@
+defmodule MingaEditor.Agent.SemanticUI.BundledStatusNoteTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Extension.ContributionCleanup
+  alias Minga.RenderModel.UI.ExtensionPanel.Content.Text
+  alias MingaEditor.Agent.SemanticUI.BundledStatusNote
+  alias MingaEditor.Agent.SemanticUI.Registry
+  alias MingaEditor.Editing
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
+
+  setup do
+    table = Module.concat(__MODULE__, "Registry#{System.unique_integer([:positive])}")
+    start_supervised!({Registry, name: table, notify: self()})
+    %{table: table}
+  end
+
+  test "declares a bundled transcript enrichment with editor action metadata" do
+    assert BundledStatusNote.source() == {:bundle, :agent_status_note}
+    assert BundledStatusNote.entry_id() == "agent-status-note"
+
+    assert [entry] = BundledStatusNote.entries()
+    assert entry.id == "agent-status-note"
+    assert entry.surface == :transcript_enrichment
+    assert entry.payload == {:system, "Agent UI registry online", :info}
+    assert [%{id: "open_agent", editor_action: :toggle_agentic_view}] = entry.actions
+  end
+
+  test "starts as a bundled registrar and publishes transcript rendering data", %{table: table} do
+    start_supervised!(
+      {BundledStatusNote,
+       name: Module.concat(__MODULE__, "Note#{System.unique_integer([:positive])}"),
+       registry: table}
+    )
+
+    assert %MingaEditor.Agent.SemanticUI.Entry{source: {:bundle, :agent_status_note}} =
+             Registry.get(table, BundledStatusNote.entry_id())
+
+    assert_receive {:agent_semantic_ui_changed, ^table}
+
+    assert [{message_id, {:system, "Agent UI registry online", :info}}] =
+             Registry.transcript_enrichments(table)
+
+    assert is_integer(message_id) and message_id > 0
+  end
+
+  test "dispatches semantic actions through the editor command pipeline", %{table: table} do
+    :ok =
+      Registry.register(table, {:bundle, :test_status}, %{
+        id: "test-status",
+        surface: :transcript_enrichment,
+        payload: {:system, "test", :info},
+        actions: [
+          %{
+            id: "choose_register",
+            label: "Choose register",
+            editor_action: {:select_register, "a"}
+          }
+        ]
+      })
+
+    state =
+      Registry.dispatch_action(table, base_state(table), "test-status", "choose_register", %{
+        button: :mouse
+      })
+
+    assert Editing.active_register(state) == "a"
+  end
+
+  test "source cleanup removes snapshots and action handlers and reload restores them", %{
+    table: table
+  } do
+    :ok = BundledStatusNote.register(table)
+    assert [_note] = Registry.transcript_enrichments(table)
+
+    assert :ok = Registry.unregister_source(table, BundledStatusNote.source())
+    assert Registry.transcript_enrichments(table) == []
+
+    state = base_state(table)
+
+    assert Registry.dispatch_action(table, state, BundledStatusNote.entry_id(), "open_agent", %{}) ==
+             state
+
+    assert :ok = BundledStatusNote.reload(table)
+    assert [_note] = Registry.transcript_enrichments(table)
+  end
+
+  test "rejects callback handlers so semantic actions stay code-lease free", %{table: table} do
+    assert {:error, {:unsupported, :handler}} =
+             Registry.register(table, {:extension, :leased_action}, %{
+               id: "leased-action",
+               surface: :dashboard_section,
+               payload: [%Text{text: "bad"}],
+               actions: [%{id: "callback", label: "Callback", handler: fn -> :ok end}]
+             })
+  end
+
+  test "cleanup is scoped to the semantic registry and leaves core agent state alone", %{
+    table: table
+  } do
+    state = base_state(table)
+    cleanup_state = EditorState.set_status(state, "approval and transcript state stay core-owned")
+
+    :ok = BundledStatusNote.register(table)
+
+    assert :ok =
+             ContributionCleanup.unregister_source(BundledStatusNote.source(),
+               callbacks: %{agent_semantic_ui_registry: &Registry.unregister_source(table, &1)}
+             )
+
+    assert Registry.transcript_enrichments(table) == []
+
+    assert EditorState.status_msg(cleanup_state) ==
+             "approval and transcript state stay core-owned"
+  end
+
+  defp base_state(table) do
+    %EditorState{
+      port_manager: self(),
+      agent_semantic_ui_registry: table,
+      workspace: %SessionState{viewport: Viewport.new(24, 80)}
+    }
+  end
+end

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -8,7 +8,10 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
   import ExUnit.CaptureLog
 
   alias Minga.Events
+  alias Minga.RenderModel.UI.ExtensionPanel.Content.Text
+  alias MingaEditor.Agent.SemanticUI.Registry, as: SemanticUIRegistry
   alias MingaEditor.Commands
+  alias MingaEditor.Editing
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.Frontend.Capabilities
@@ -26,8 +29,10 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
   setup do
     table = Module.concat(__MODULE__, "Sidebar#{System.unique_integer([:positive])}")
+    semantic_table = Module.concat(__MODULE__, "SemanticUI#{System.unique_integer([:positive])}")
     start_supervised!({Sidebar, name: table, notify: false})
-    %{sidebar_registry: table}
+    start_supervised!({SemanticUIRegistry, name: semantic_table, notify: false})
+    %{sidebar_registry: table, semantic_registry: semantic_table}
   end
 
   test "tab context actions target the requested tab without selecting it", %{
@@ -151,6 +156,35 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
     assert activated.workspace.keymap_scope == state.workspace.keymap_scope
     assert EditorState.sidebar_active_id(activated) == nil
+  end
+
+  test "extension panel actions route semantic registry entries before legacy extensions", %{
+    sidebar_registry: table,
+    semantic_registry: semantic_table
+  } do
+    :ok =
+      SemanticUIRegistry.register(semantic_table, {:bundle, :gui_action_test}, %{
+        id: "gui-action-test",
+        surface: :dashboard_section,
+        payload: [%Text{text: "GUI action test"}],
+        actions: [
+          %{
+            id: "choose_register",
+            label: "Choose register",
+            editor_action: {:select_register, "g"}
+          }
+        ]
+      })
+
+    state = base_state(table, agent_semantic_ui_registry: semantic_table)
+
+    new_state =
+      GuiActionHandler.dispatch(
+        state,
+        {:extension_panel_action, "bundle:gui_action_test", "choose_register", %{source: :mouse}}
+      )
+
+    assert Editing.active_register(new_state) == "g"
   end
 
   test "extension panel actions report unavailable extensions", %{sidebar_registry: table} do
@@ -357,7 +391,12 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
   defp base_state(sidebar_registry, opts \\ []) do
     opts = Keyword.put(opts, :sidebar_registry, sidebar_registry)
-    TestHelpers.base_state(opts)
+    state = TestHelpers.base_state(opts)
+
+    case Keyword.fetch(opts, :agent_semantic_ui_registry) do
+      {:ok, registry} -> EditorState.put_agent_semantic_ui_registry(state, registry)
+      :error -> state
+    end
   end
 
   defp clear_window_reset_pending(state) do

--- a/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
@@ -49,7 +49,8 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
              {101, :assistant, "old pinned"},
              {_, :system, "── pinned ──"},
              {_, :system, "── 2 earlier messages hidden ──"},
-             {103, :assistant, "visible"}
+             {103, :assistant, "visible"},
+             {_, :system, "Agent UI registry online"}
            ] = summaries
 
     refute {:user, "hidden"} in Enum.map(summaries, fn {_id, type, text} -> {type, text} end)

--- a/test/minga_editor/render_model/ui/extension_panel_builder_test.exs
+++ b/test/minga_editor/render_model/ui/extension_panel_builder_test.exs
@@ -15,9 +15,12 @@ defmodule MingaEditor.RenderModel.UI.ExtensionPanelBuilderTest do
   alias Minga.RenderModel.UI.ExtensionPanel.Content.TreeNode
   alias Minga.RenderModel.UI.ExtensionPanel.Content.Unknown
   alias Minga.RenderModel.UI.ExtensionPanel.Panel
+  alias MingaEditor.Agent.SemanticUI.Registry, as: SemanticUIRegistry
   alias MingaEditor.RenderModel.UI.ExtensionPanelBuilder
 
   setup do
+    semantic_table = Module.concat(__MODULE__, "SemanticUI#{System.unique_integer([:positive])}")
+    start_supervised!({SemanticUIRegistry, name: semantic_table, notify: false})
     ExtensionPanelRegistry.remove_all(:builder_test)
     ExtensionPanelRegistry.remove_all(:builder_other)
 
@@ -26,18 +29,20 @@ defmodule MingaEditor.RenderModel.UI.ExtensionPanelBuilderTest do
       ExtensionPanelRegistry.remove_all(:builder_other)
     end)
 
-    :ok
+    %{semantic_table: semantic_table}
   end
 
-  describe "build/0" do
-    test "builds extension panel model with empty panels" do
-      model = ExtensionPanelBuilder.build()
+  describe "build/1" do
+    test "builds extension panel model with empty panels", %{semantic_table: semantic_table} do
+      model = ExtensionPanelBuilder.build(semantic_table)
 
       assert %ExtensionPanel{} = model
       assert model.panels == []
     end
 
-    test "maps visible extension panels into semantic content blocks" do
+    test "maps visible extension panels into semantic content blocks", %{
+      semantic_table: semantic_table
+    } do
       :ok =
         ExtensionPanelRegistry.set(:builder_test, :status, %{
           title: "Status",
@@ -58,7 +63,7 @@ defmodule MingaEditor.RenderModel.UI.ExtensionPanelBuilderTest do
 
       :ok = ExtensionPanelRegistry.set(:builder_other, :hidden, %{visible: false})
 
-      model = ExtensionPanelBuilder.build()
+      model = ExtensionPanelBuilder.build(semantic_table)
 
       assert %ExtensionPanel{panels: [%Panel{} = panel]} = model
       assert panel.extension == "builder_test"
@@ -92,7 +97,9 @@ defmodule MingaEditor.RenderModel.UI.ExtensionPanelBuilderTest do
              ] = panel.content
     end
 
-    test "normalizes malformed extension panel content into semantic defaults" do
+    test "normalizes malformed extension panel content into semantic defaults", %{
+      semantic_table: semantic_table
+    } do
       :ok =
         ExtensionPanelRegistry.set(:builder_test, :malformed, %{
           title: "Broken",
@@ -111,7 +118,7 @@ defmodule MingaEditor.RenderModel.UI.ExtensionPanelBuilderTest do
           ]
         })
 
-      model = ExtensionPanelBuilder.build()
+      model = ExtensionPanelBuilder.build(semantic_table)
 
       assert %ExtensionPanel{panels: [%Panel{} = panel]} = model
       assert panel.extension == "builder_test"
@@ -137,7 +144,9 @@ defmodule MingaEditor.RenderModel.UI.ExtensionPanelBuilderTest do
              ] = panel.content
     end
 
-    test "treats non-list panel content as an empty content list" do
+    test "treats non-list panel content as an empty content list", %{
+      semantic_table: semantic_table
+    } do
       :ok =
         ExtensionPanelRegistry.set(:builder_test, :non_list_content, %{
           title: "Empty",
@@ -145,7 +154,7 @@ defmodule MingaEditor.RenderModel.UI.ExtensionPanelBuilderTest do
           content: :bad
         })
 
-      model = ExtensionPanelBuilder.build()
+      model = ExtensionPanelBuilder.build(semantic_table)
 
       assert %ExtensionPanel{panels: [%Panel{} = panel]} = model
       assert panel.extension == "builder_test"


### PR DESCRIPTION
# TL;DR
A bundled agent status note now ships through the semantic agent UI registry, proving a low-risk built-in agent surface can be source-owned, cached, cleaned up, and reloaded without touching approval or transcript core state.

Closes #2088

## Context
Issue #2088 asks for one small built-in agent UI surface to use the semantic UI contribution registry after the semantic render model and registry work landed. This PR uses a transcript enrichment note instead of approval UI or core transcript rendering, which keeps the proof surface low-risk and avoids adding a new protocol surface during the semantic freeze.

## Changes
- Added `MingaEditor.Agent.SemanticUI.BundledStatusNote`, a bundled `:transcript_enrichment` contribution with source-owned metadata and declarative editor action metadata.
- Seeded the bundled note from `MingaEditor.Agent.SemanticUI.Registry` for the default registry table, while keeping test/editor tables injectable.
- Added semantic action dispatch support and an owning `EditorState.put_agent_semantic_ui_registry/2` helper for private test registries.
- Updated GUI `extension_panel_action` decoding to preserve action names as strings for semantic routing, while legacy extension fallback still converts to existing atoms before sending extension callbacks.
- Covered cleanup, reload, rendering data, action routing, decoder compatibility, semantic-before-legacy routing, and callback-handler rejection.

## Verification
- `mix test.llm test/minga_editor/agent/semantic_ui/bundled_status_note_test.exs test/minga_editor/handlers/gui_action_handler_test.exs test/minga_editor/render_model/ui/agent_chat_builder_test.exs test/minga_editor/render_model/ui/extension_panel_builder_test.exs test/minga/extension/panel_interaction_test.exs test/minga_editor/input/agent_mouse_test.exs` ✅, 46 tests
- `make lint` ✅, existing struct-size warnings only
- `mix test.llm` ✅, 56 doctests, 87 properties, 9345 tests, 0 failures, 1 skipped, 333 excluded
- `git diff --check` ✅
- Final reviewer gate ✅

## Acceptance Criteria Addressed
- One low-risk built-in agent UI surface publishes through the semantic UI registry instead of direct bespoke wiring ✅
- The surface renders correctly in the existing TUI path and has a safe native GUI semantic representation or fallback ✅
- Input and mouse actions for the surface route through the editor action pipeline ✅
- Disabling/reloading the bundled source removes snapshots and action handlers without affecting core approvals or transcript state ✅
- Tests cover rendering data, action routing, cleanup, reload, and code-lease behavior for action handlers ✅
