### PR TITLE
fix(macos): preview file tree navigation locally

### DIFF
--- a/docs/CHARM_TUI.md
+++ b/docs/CHARM_TUI.md
@@ -36,7 +36,7 @@ The Charm renderer targets the Semantic UI path, not the legacy cell-grid path. 
 - semantic editor rows and spans
 - tab bar and workspace chrome
 - status bar and minibuffer
-- file tree
+- file tree, including BEAM-gated zero-latency local selection preview for unmodified j/k and Up/Down
 - picker, picker preview, completion, and which-key overlays
 
 It renders roughly 9 of the shared-chrome components today. Decoding and rendering the remaining components is tracked in #2100, and overall cross-frontend coverage is tracked in the Semantic UI inventory (#2113).

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -149,6 +149,7 @@ Tree flag bits:
   bit 0: visible
   bit 1: focused
   bit 4: empty
+  bit 5: frontend-local navigation eligible
 
 Tree state values:
   0 = hidden
@@ -179,6 +180,8 @@ When `tree_state == 0`, the frontend should hide the file tree. Hidden payloads 
 `row_count == 0` only means the payload contains no entry rows. It does not imply hidden. Use `tree_state` to distinguish hidden (`0`), loading (`1`), visible-empty (`2`), and error (`4`) states. The `empty` flag bit is retained for compatibility and is set only for `tree_state == 2`.
 
 When `tree_state == 4`, `error_reason` contains a short user-displayable reason. For all other states, `error_reason` is an empty string.
+
+When tree flag bit 5 is set, a semantic frontend may apply zero-latency local row navigation over the last committed row model while still forwarding the key to the BEAM. The next `gui_file_tree` or `gui_file_tree_selection` payload remains authoritative and reconciles any local prediction. The BEAM clears this bit for modes where row navigation is not safe to predict, such as inline editing, filtering, or help.
 
 ### 0x94 — gui_file_tree_selection
 

--- a/go/tui/internal/protocol/chrome_editor.go
+++ b/go/tui/internal/protocol/chrome_editor.go
@@ -200,7 +200,7 @@ func decodeFileTree(payload []byte) (FileTree, string, int) {
 
 	flags := body[1]
 	status := body[2]
-	tree := FileTree{Visible: flags&0x01 != 0, Focused: flags&0x02 != 0, Status: status}
+	tree := FileTree{Visible: flags&0x01 != 0, Focused: flags&0x02 != 0, Flags: flags, Status: status}
 	offset := 3
 	selected, next, ok := readString16(body, offset)
 	if !ok {

--- a/go/tui/internal/protocol/chrome_types.go
+++ b/go/tui/internal/protocol/chrome_types.go
@@ -146,6 +146,7 @@ type PreviewSegment struct {
 type FileTree struct {
 	Visible  bool
 	Focused  bool
+	Flags    byte
 	Status   byte
 	Selected string
 	Root     string

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -650,6 +650,13 @@ func TestDecodePickerPreviewChromeDoesNotSwallowFollowingCommands(t *testing.T) 
 	}
 }
 
+const (
+	fileTreeVisibleFlag         byte = 0x01
+	fileTreeFocusedFlag         byte = 0x02
+	fileTreeLocalNavigationFlag byte = 0x20
+	fileTreeReadyStatus         byte = 3
+)
+
 func TestDecodeFileTreeChromeRows(t *testing.T) {
 	row := []byte{
 		0, 0, 0, 1,
@@ -671,7 +678,7 @@ func TestDecodeFileTreeChromeRows(t *testing.T) {
 	row = append(row, 0, 0)
 	row = append(row, 0x6D, 0x80, 0x86) // icon color (R,G,B) follows editing payload
 	row = append(row, 0xFF)             // heat level (0xFF = none) trails the row
-	body := []byte{2, 1, 3}
+	body := []byte{2, fileTreeVisibleFlag | fileTreeFocusedFlag | fileTreeLocalNavigationFlag, fileTreeReadyStatus}
 	body = append(body, string16("/repo/lib")...)
 	body = append(body, string16("/repo")...)
 	body = append(body, 0, 30, 0, 1)
@@ -684,7 +691,7 @@ func TestDecodeFileTreeChromeRows(t *testing.T) {
 		t.Fatalf("DecodeCommand returned error: %v", err)
 	}
 	tree := command.Chrome.Tree
-	if !tree.Visible || tree.Status != 3 || tree.Root != "/repo" || len(tree.Rows) != 1 {
+	if !tree.Visible || !tree.Focused || tree.Flags&fileTreeLocalNavigationFlag == 0 || tree.Status != fileTreeReadyStatus || tree.Root != "/repo" || len(tree.Rows) != 1 {
 		t.Fatalf("file tree decoded incorrectly: %+v", tree)
 	}
 	if got := tree.Rows[0]; !got.Directory || !got.Selected || got.Name != "lib" || got.Depth != 1 || got.IconColor != 0x6D8086 {

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -205,6 +205,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if packet, ok := keyPacket(msg, seq); ok {
 			m.send(packet)
 		}
+		m.previewFileTreeNavigation(msg)
 	case tea.PasteMsg:
 		m.send(pastePacket(msg))
 	case tea.MouseMsg:

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1229,6 +1229,62 @@ func TestFileTreeSelectionUpdatesExistingTree(t *testing.T) {
 	}
 }
 
+func TestFileTreeLocalNavigationPreviewMovesSelectionWhenEligible(t *testing.T) {
+	t.Run("j advances locally while still forwarding to BEAM", func(t *testing.T) {
+		out := make(chan []byte, 1)
+		model := New(30, 6, out)
+		model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Focused: true, Flags: fileTreeVisibleFlag | fileTreeFocusedFlag | fileTreeLocalNavigationFlag, Status: fileTreeReadyStatus, Selected: "a", Rows: []protocol.FileTreeRow{{ID: "a", Name: "a", Selected: true, Focused: true}, {ID: "b", Name: "b"}}}}}
+
+		updated, _ := model.Update(tea.KeyPressMsg(tea.Key{Code: fileTreeLocalNavigationDownKey, Text: string(fileTreeLocalNavigationDownKey)}))
+		model = updated.(Model)
+
+		tree := model.chrome[generated.OPGuiFileTree].Tree
+		if tree.Selected != "b" || !tree.Rows[1].Selected || tree.Rows[0].Selected {
+			t.Fatalf("eligible j press should preview the next file-tree row: %+v", tree)
+		}
+		packets := drainOutboundPackets(out)
+		if len(packets) != 1 || packets[0][0] != generated.OPKeyPress || codepoint(packets[0]) != fileTreeLocalNavigationDownKey || packets[0][5] != 0 {
+			t.Fatalf("eligible j press should still forward the key packet: %#v", packets)
+		}
+	})
+
+	t.Run("up arrow retreats locally while still forwarding to BEAM", func(t *testing.T) {
+		out := make(chan []byte, 1)
+		model := New(30, 6, out)
+		model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Focused: true, Flags: fileTreeVisibleFlag | fileTreeFocusedFlag | fileTreeLocalNavigationFlag, Status: fileTreeReadyStatus, Selected: "b", Rows: []protocol.FileTreeRow{{ID: "a", Name: "a"}, {ID: "b", Name: "b", Selected: true, Focused: true}}}}}
+
+		updated, _ := model.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
+		model = updated.(Model)
+
+		tree := model.chrome[generated.OPGuiFileTree].Tree
+		if tree.Selected != "a" || !tree.Rows[0].Selected || tree.Rows[1].Selected {
+			t.Fatalf("eligible up-arrow press should preview the previous file-tree row: %+v", tree)
+		}
+		packets := drainOutboundPackets(out)
+		if len(packets) != 1 || packets[0][0] != generated.OPKeyPress || codepoint(packets[0]) != arrowUp || packets[0][5] != 0 {
+			t.Fatalf("eligible up-arrow press should still forward the key packet: %#v", packets)
+		}
+	})
+}
+
+func TestFileTreeLocalNavigationPreviewRequiresEligibilityFlag(t *testing.T) {
+	out := make(chan []byte, 1)
+	model := New(30, 6, out)
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Focused: true, Flags: fileTreeVisibleFlag | fileTreeFocusedFlag, Status: fileTreeReadyStatus, Selected: "a", Rows: []protocol.FileTreeRow{{ID: "a", Name: "a", Selected: true, Focused: true}, {ID: "b", Name: "b"}}}}}
+
+	updated, _ := model.Update(tea.KeyPressMsg(tea.Key{Code: fileTreeLocalNavigationDownKey, Text: string(fileTreeLocalNavigationDownKey)}))
+	model = updated.(Model)
+
+	tree := model.chrome[generated.OPGuiFileTree].Tree
+	if tree.Selected != "a" || !tree.Rows[0].Selected || tree.Rows[1].Selected {
+		t.Fatalf("file tree should not preview locally when the local-navigation flag is clear: %+v", tree)
+	}
+	packets := drainOutboundPackets(out)
+	if len(packets) != 1 || packets[0][0] != generated.OPKeyPress || codepoint(packets[0]) != fileTreeLocalNavigationDownKey || packets[0][5] != 0 {
+		t.Fatalf("non-eligible j press should still forward the key packet: %#v", packets)
+	}
+}
+
 func TestApplyCommandsStoresSemanticGuttersByWindow(t *testing.T) {
 	model := New(30, 6, nil)
 	_ = model.applyCommands(frame(

--- a/go/tui/internal/ui/semantic_state.go
+++ b/go/tui/internal/ui/semantic_state.go
@@ -3,9 +3,19 @@ package ui
 import (
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/jsmestad/minga/go/tui/internal/generated"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+const (
+	fileTreeVisibleFlag            byte = 0x01
+	fileTreeFocusedFlag            byte = 0x02
+	fileTreeLocalNavigationFlag    byte = 0x20
+	fileTreeReadyStatus            byte = 3
+	fileTreeLocalNavigationDownKey rune = 'j'
+	fileTreeLocalNavigationUpKey   rune = 'k'
 )
 
 func (m *Model) applyFileTreeSelection(selection protocol.FileTreeSelection) {
@@ -21,6 +31,76 @@ func (m *Model) applyFileTreeSelection(selection protocol.FileTreeSelection) {
 		payload.Tree.Rows[i].Focused = selected && selection.Focused
 	}
 	m.chrome[generated.OPGuiFileTree] = payload
+}
+
+func (m *Model) previewFileTreeNavigation(msg tea.KeyPressMsg) bool {
+	key := msg.Key()
+	if key.Mod.Contains(tea.ModShift) || key.Mod.Contains(tea.ModAlt) || key.Mod.Contains(tea.ModCtrl) || key.Mod.Contains(tea.ModSuper) {
+		return false
+	}
+
+	delta, ok := fileTreeNavigationDelta(key)
+	if !ok {
+		return false
+	}
+
+	payload, ok := m.fileTree()
+	if !ok || !payload.Visible || !payload.Focused || payload.Flags&fileTreeLocalNavigationFlag == 0 || payload.Status != fileTreeReadyStatus || len(payload.Rows) == 0 {
+		return false
+	}
+
+	selectedIndex := fileTreeSelectedIndex(payload)
+	if selectedIndex < 0 {
+		return false
+	}
+
+	nextIndex := selectedIndex + delta
+	if nextIndex < 0 {
+		nextIndex = 0
+	} else if nextIndex >= len(payload.Rows) {
+		nextIndex = len(payload.Rows) - 1
+	}
+	if nextIndex == selectedIndex {
+		return false
+	}
+
+	payload.Selected = payload.Rows[nextIndex].ID
+	payload.Focused = true
+	for i := range payload.Rows {
+		payload.Rows[i].Selected = i == nextIndex
+		payload.Rows[i].Focused = i == nextIndex
+	}
+	chrome := m.chrome[generated.OPGuiFileTree]
+	chrome.Tree = payload
+	m.chrome[generated.OPGuiFileTree] = chrome
+	return true
+}
+
+func fileTreeNavigationDelta(key tea.Key) (int, bool) {
+	switch key.Code {
+	case fileTreeLocalNavigationDownKey, tea.KeyDown:
+		return 1, true
+	case fileTreeLocalNavigationUpKey, tea.KeyUp:
+		return -1, true
+	default:
+		return 0, false
+	}
+}
+
+func fileTreeSelectedIndex(tree protocol.FileTree) int {
+	if tree.Selected != "" {
+		for i, row := range tree.Rows {
+			if row.ID == tree.Selected {
+				return i
+			}
+		}
+	}
+	for i, row := range tree.Rows {
+		if row.Selected {
+			return i
+		}
+	}
+	return -1
 }
 
 func (m Model) applyIndentGuide(window protocol.WindowContent, style lipgloss.Style, rowIndex int, col int, text string) (lipgloss.Style, string) {

--- a/lib/minga/frontend/adapter/gui/file_tree_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/file_tree_encoder.ex
@@ -51,7 +51,7 @@ defmodule Minga.Frontend.Adapter.GUI.FileTreeEncoder do
 
     payload =
       IO.iodata_to_binary([
-        <<2::8, file_tree_flags(model.status, model.focused?)::8,
+        <<2::8, file_tree_flags(model.status, model.focused?, model.local_navigation?)::8,
           encode_file_tree_status(model.status)::8>>,
         Wire.encode_string16(model.selected_id),
         Wire.encode_string16(root),
@@ -86,7 +86,10 @@ defmodule Minga.Frontend.Adapter.GUI.FileTreeEncoder do
   @spec ready_structural_fingerprint(FileTree.t()) :: non_neg_integer()
   defp ready_structural_fingerprint(%FileTree{} = model) do
     rows = Enum.map(model.rows, &structural_row/1)
-    :erlang.phash2({model.root_path, model.tree_width, model.status, rows})
+
+    :erlang.phash2(
+      {model.root_path, model.tree_width, model.status, model.local_navigation?, rows}
+    )
   end
 
   @spec selection_fingerprint(FileTree.t()) :: non_neg_integer()
@@ -138,12 +141,13 @@ defmodule Minga.Frontend.Adapter.GUI.FileTreeEncoder do
   @spec file_tree_selection_flags(boolean()) :: non_neg_integer()
   defp file_tree_selection_flags(focused?), do: Wire.maybe_flag(0, focused?, 0)
 
-  @spec file_tree_flags(FileTree.status(), boolean()) :: non_neg_integer()
-  defp file_tree_flags(status, focused?) do
+  @spec file_tree_flags(FileTree.status(), boolean(), boolean()) :: non_neg_integer()
+  defp file_tree_flags(status, focused?, local_navigation?) do
     0
     |> Wire.maybe_flag(visible_status?(status), 0)
     |> Wire.maybe_flag(focused?, 1)
     |> Wire.maybe_flag(status == :empty, 4)
+    |> Wire.maybe_flag(local_navigation?, 5)
   end
 
   @spec visible_status?(FileTree.status()) :: boolean()

--- a/lib/minga/render_model/ui/file_tree.ex
+++ b/lib/minga/render_model/ui/file_tree.ex
@@ -14,6 +14,7 @@ defmodule Minga.RenderModel.UI.FileTree do
           tree_width: non_neg_integer(),
           status: status(),
           focused?: boolean(),
+          local_navigation?: boolean(),
           selected_id: String.t(),
           rows: [Row.t()]
         }
@@ -22,6 +23,7 @@ defmodule Minga.RenderModel.UI.FileTree do
             tree_width: 0,
             status: :hidden,
             focused?: false,
+            local_navigation?: false,
             selected_id: "",
             rows: []
 end

--- a/lib/minga_editor/render_model/ui/file_tree_builder.ex
+++ b/lib/minga_editor/render_model/ui/file_tree_builder.ex
@@ -71,6 +71,7 @@ defmodule MingaEditor.RenderModel.UI.FileTreeBuilder do
       tree_width: tree.width,
       status: :ready,
       focused?: file_tree_focused?(file_tree),
+      local_navigation?: local_navigation?(file_tree),
       selected_id: selected_row_id(tree),
       rows: rows
     }
@@ -176,6 +177,12 @@ defmodule MingaEditor.RenderModel.UI.FileTreeBuilder do
 
   @spec file_tree_focused?(map()) :: boolean()
   defp file_tree_focused?(file_tree), do: Map.get(file_tree, :focused, false)
+
+  @spec local_navigation?(FileTreeState.t()) :: boolean()
+  defp local_navigation?(%FileTreeState{} = file_tree) do
+    file_tree_focused?(file_tree) and file_tree.editing == nil and not file_tree.filtering and
+      not file_tree.help_visible
+  end
 
   @spec dirty_paths(MingaEditor.State.Buffers.t()) :: MapSet.t(String.t())
   defp dirty_paths(%{list: buffer_list}) do

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -28,6 +28,13 @@ import Foundation
 import AppKit
 import os
 
+private enum FileTreeNavigationCodepoints {
+    static let downKey: UInt32 = 106
+    static let upKey: UInt32 = 107
+    static let downArrow: UInt32 = 57353
+    static let upArrow: UInt32 = 57352
+}
+
 /// Dispatches render commands to FrameState (metadata) and GUIState (chrome).
 @MainActor
 final class CommandDispatcher {
@@ -365,9 +372,9 @@ final class CommandDispatcher {
         guard modifiers == 0 else { return false }
 
         switch codepoint {
-        case 106, 57353: // j, Down arrow
+        case FileTreeNavigationCodepoints.downKey, FileTreeNavigationCodepoints.downArrow:
             return guiState.fileTreeState.previewNavigation(delta: 1)
-        case 107, 57352: // k, Up arrow
+        case FileTreeNavigationCodepoints.upKey, FileTreeNavigationCodepoints.upArrow:
             return guiState.fileTreeState.previewNavigation(delta: -1)
         default:
             return false

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -358,6 +358,22 @@ final class CommandDispatcher {
         frameState.dirty = false
     }
 
+    /// Applies a zero-latency local file-tree navigation preview when the BEAM marks the current tree model as eligible.
+    /// The key still goes to the BEAM; this only moves the transient selection highlight until the next authoritative file-tree payload reconciles it.
+    @discardableResult
+    func previewFileTreeNavigation(codepoint: UInt32, modifiers: UInt8) -> Bool {
+        guard modifiers == 0 else { return false }
+
+        switch codepoint {
+        case 106, 57353: // j, Down arrow
+            return guiState.fileTreeState.previewNavigation(delta: 1)
+        case 107, 57352: // k, Up arrow
+            return guiState.fileTreeState.previewNavigation(delta: -1)
+        default:
+            return false
+        }
+    }
+
     /// Apply a single render command to the presented FrameState/GUIState. This
     /// is the single mutation path: called directly for out-of-band commands and
     /// replayed for every staged command at commit. It must NOT handle the frame
@@ -475,7 +491,7 @@ final class CommandDispatcher {
             let visible = treeState != FileTreeVisibilityState.hidden.rawValue
             let focused = treeFlags & 0x02 != 0
             if visible {
-                guiState.fileTreeState.update(version: version, selectedId: selectedId, focused: focused, treeWidth: treeWidth, rootPath: rootPath, rawEntries: entries, treeState: treeState, errorReason: errorReason)
+                guiState.fileTreeState.update(version: version, treeFlags: treeFlags, selectedId: selectedId, focused: focused, treeWidth: treeWidth, rootPath: rootPath, rawEntries: entries, treeState: treeState, errorReason: errorReason)
             } else {
                 guiState.fileTreeState.hide(rootPath: rootPath)
             }

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -1581,6 +1581,7 @@ final class EditorNSView: MTKView {
     /// dispatcher recorder.
     private func sendKeyPress(codepoint: UInt32, modifiers: UInt8) {
         updateOptimisticTextInputMode(codepoint: codepoint, modifiers: modifiers)
+        dispatcher.previewFileTreeNavigation(codepoint: codepoint, modifiers: modifiers)
         recoveryManager?.onKeySent()
         let seq = dispatcher.latency.stamp()
         encoder.sendKeyPress(codepoint: codepoint, modifiers: modifiers, seq: seq)

--- a/macos/Sources/Views/FileTreeState.swift
+++ b/macos/Sources/Views/FileTreeState.swift
@@ -2,6 +2,10 @@
 
 import SwiftUI
 
+private enum FileTreeProtocolConstants {
+    static let localNavigationFlag: UInt8 = 0x20
+}
+
 /// A single file tree entry for SwiftUI rendering.
 struct FileTreeEntry: Identifiable {
     /// Visual states are layered in the same priority order as the BEAM TUI renderer: inline editing, drop target, selected row, active file, dirty buffer, git status, then directory emphasis.
@@ -42,7 +46,34 @@ struct FileTreeEntry: Identifiable {
     /// Extension-contributed familiarity/heat bucket 0...4, or 255 for none.
     let heatLevel: UInt8
 
-    init(id: String, pathHash: UInt32, index: Int, isDir: Bool, isExpanded: Bool, isSelected: Bool, isFocused: Bool, isActive: Bool, isDirty: Bool, isEditing: Bool, isLastChild: Bool, depth: Int, gitStatus: UInt8, diagnosticErrorCount: UInt16, diagnosticWarningCount: UInt16, diagnosticInfoCount: UInt16, diagnosticHintCount: UInt16, guides: [Bool], icon: String, iconColor: Color, name: String, relPath: String, path: String, editingType: UInt8, editingText: String, heatLevel: UInt8 = 255) {
+    init(
+        id: String,
+        pathHash: UInt32,
+        index: Int,
+        isDir: Bool,
+        isExpanded: Bool,
+        isSelected: Bool,
+        isFocused: Bool,
+        isActive: Bool,
+        isDirty: Bool,
+        isEditing: Bool,
+        isLastChild: Bool,
+        depth: Int,
+        gitStatus: UInt8,
+        diagnosticErrorCount: UInt16,
+        diagnosticWarningCount: UInt16,
+        diagnosticInfoCount: UInt16,
+        diagnosticHintCount: UInt16,
+        guides: [Bool],
+        icon: String,
+        iconColor: Color,
+        name: String,
+        relPath: String,
+        path: String,
+        editingType: UInt8,
+        editingText: String,
+        heatLevel: UInt8 = 255
+    ) {
         self.id = id
         self.pathHash = pathHash
         self.index = index
@@ -212,7 +243,17 @@ final class FileTreeState {
     /// function is called, the tree data has genuinely changed and the
     /// array rebuild is necessary (git status, file renames, expand/collapse
     /// can change entry content without changing count or selection).
-    func update(version: UInt8, treeFlags: UInt8 = 0, selectedId: String, focused: Bool, treeWidth: UInt16, rootPath: String, rawEntries: [Wire.FileTreeEntry], treeState: UInt8 = FileTreeVisibilityState.ready.rawValue, errorReason: String = "") {
+    func update(
+        version: UInt8,
+        treeFlags: UInt8 = 0,
+        selectedId: String,
+        focused: Bool,
+        treeWidth: UInt16,
+        rootPath: String,
+        rawEntries: [Wire.FileTreeEntry],
+        treeState: UInt8 = FileTreeVisibilityState.ready.rawValue,
+        errorReason: String = ""
+    ) {
         let decodedState = FileTreeVisibilityState(rawValue: treeState) ?? .ready
         self.version = version
         self.selectedId = selectedId
@@ -221,7 +262,7 @@ final class FileTreeState {
         self.projectRoot = rootPath
         self.visible = decodedState != .hidden
         self.focused = focused
-        self.localNavigationEnabled = treeFlags & 0x20 != 0
+        self.localNavigationEnabled = treeFlags & FileTreeProtocolConstants.localNavigationFlag != 0
         self.treeState = decodedState
         self.errorReason = errorReason
         self.entries = rawEntries.enumerated().map { index, entry in

--- a/macos/Sources/Views/FileTreeState.swift
+++ b/macos/Sources/Views/FileTreeState.swift
@@ -197,6 +197,7 @@ final class FileTreeState {
     var treeWidth: Int = 30
     var visible: Bool = false
     var focused: Bool = false
+    var localNavigationEnabled: Bool = false
     var treeState: FileTreeVisibilityState = .hidden
     var errorReason: String = ""
     /// Project root path sent by the BEAM (e.g., "/Users/foo/myproject").
@@ -211,7 +212,7 @@ final class FileTreeState {
     /// function is called, the tree data has genuinely changed and the
     /// array rebuild is necessary (git status, file renames, expand/collapse
     /// can change entry content without changing count or selection).
-    func update(version: UInt8, selectedId: String, focused: Bool, treeWidth: UInt16, rootPath: String, rawEntries: [Wire.FileTreeEntry], treeState: UInt8 = FileTreeVisibilityState.ready.rawValue, errorReason: String = "") {
+    func update(version: UInt8, treeFlags: UInt8 = 0, selectedId: String, focused: Bool, treeWidth: UInt16, rootPath: String, rawEntries: [Wire.FileTreeEntry], treeState: UInt8 = FileTreeVisibilityState.ready.rawValue, errorReason: String = "") {
         let decodedState = FileTreeVisibilityState(rawValue: treeState) ?? .ready
         self.version = version
         self.selectedId = selectedId
@@ -220,6 +221,7 @@ final class FileTreeState {
         self.projectRoot = rootPath
         self.visible = decodedState != .hidden
         self.focused = focused
+        self.localNavigationEnabled = treeFlags & 0x20 != 0
         self.treeState = decodedState
         self.errorReason = errorReason
         self.entries = rawEntries.enumerated().map { index, entry in
@@ -270,12 +272,48 @@ final class FileTreeState {
             return
         }
 
+        applySelection(selectedIndex: selectedIndex, focused: focused)
+    }
+
+    /// Applies a frontend-local row navigation preview over the last committed tree model.
+    /// The BEAM remains authoritative: the next gui_file_tree or gui_file_tree_selection payload reconciles this optimistic selection.
+    @discardableResult
+    func previewNavigation(delta: Int) -> Bool {
+        guard visible, focused, localNavigationEnabled, treeState == .ready, editingIndex == nil, !entries.isEmpty else {
+            return false
+        }
+
+        let nextIndex = min(max(selectedIndex + delta, 0), entries.count - 1)
+        guard nextIndex != selectedIndex else { return false }
+
+        applySelection(selectedIndex: nextIndex, focused: focused)
+        return true
+    }
+
+    private func applySelection(selectedIndex: Int, focused: Bool) {
+        guard entries.indices.contains(selectedIndex) else { return }
+
+        let previousIndex = self.selectedIndex
+        let selectedId = entries[selectedIndex].id
+        let focusChanged = self.focused != focused
+        var nextEntries = entries
+
+        if focusChanged {
+            nextEntries = nextEntries.map { entry in
+                entry.withSelection(isSelected: entry.id == selectedId, isFocused: focused)
+            }
+        } else {
+            if nextEntries.indices.contains(previousIndex), previousIndex != selectedIndex {
+                nextEntries[previousIndex] = nextEntries[previousIndex].withSelection(isSelected: false, isFocused: focused)
+            }
+
+            nextEntries[selectedIndex] = nextEntries[selectedIndex].withSelection(isSelected: true, isFocused: focused)
+        }
+
         self.selectedId = selectedId
         self.selectedIndex = selectedIndex
         self.focused = focused
-        self.entries = entries.map { entry in
-            entry.withSelection(isSelected: entry.id == selectedId, isFocused: focused)
-        }
+        self.entries = nextEntries
     }
 
     /// Computes the full absolute path for an entry.
@@ -294,6 +332,7 @@ final class FileTreeState {
     func hide(rootPath: String = "") {
         visible = false
         focused = false
+        localNavigationEnabled = false
         treeState = .hidden
         errorReason = ""
         entries = []

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -210,6 +210,44 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.fileTreeState.entries[0].isFocused == false)
     }
 
+    @Test("file tree local navigation preview moves selection when eligible")
+    @MainActor func fileTreeLocalNavigationPreviewMovesSelectionWhenEligible() {
+        let (dispatcher, gui) = makeDispatcher()
+        let entries = [
+            wireFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a"),
+            wireFileTreeEntry(pathHash: 2, isFocused: true, id: "/project/b", path: "/project/b", name: "b", relPath: "b")
+        ]
+        dispatcher.applyForTesting(.guiFileTree(version: 2, treeFlags: 0x23, treeState: 3, selectedId: "/project/a", treeWidth: 30,
+                                          rootPath: "/project", errorReason: "", entries: entries))
+
+        let moved = dispatcher.previewFileTreeNavigation(codepoint: 106, modifiers: 0)
+
+        #expect(moved == true)
+        #expect(gui.fileTreeState.selectedId == "/project/b")
+        #expect(gui.fileTreeState.selectedIndex == 1)
+        #expect(gui.fileTreeState.entries[0].isSelected == false)
+        #expect(gui.fileTreeState.entries[1].isSelected == true)
+    }
+
+    @Test("file tree local navigation preview is disabled without BEAM eligibility flag")
+    @MainActor func fileTreeLocalNavigationPreviewRequiresEligibilityFlag() {
+        let (dispatcher, gui) = makeDispatcher()
+        let entries = [
+            wireFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a"),
+            wireFileTreeEntry(pathHash: 2, isFocused: true, id: "/project/b", path: "/project/b", name: "b", relPath: "b")
+        ]
+        dispatcher.applyForTesting(.guiFileTree(version: 2, treeFlags: 0x03, treeState: 3, selectedId: "/project/a", treeWidth: 30,
+                                          rootPath: "/project", errorReason: "", entries: entries))
+
+        let moved = dispatcher.previewFileTreeNavigation(codepoint: 106, modifiers: 0)
+
+        #expect(moved == false)
+        #expect(gui.fileTreeState.selectedId == "/project/a")
+        #expect(gui.fileTreeState.selectedIndex == 0)
+        #expect(gui.fileTreeState.entries[0].isSelected == true)
+        #expect(gui.fileTreeState.entries[1].isSelected == false)
+    }
+
     @Test("guiFileTree hides when explicit tree state is hidden")
     @MainActor func guiFileTreeHidesOnHiddenState() {
         let (dispatcher, gui) = makeDispatcher()

--- a/macos/Tests/MingaTests/KeyboardInputTests.swift
+++ b/macos/Tests/MingaTests/KeyboardInputTests.swift
@@ -121,6 +121,26 @@ struct KeyboardInputTests {
         }
     }
 
+    @Test("Down arrow previews eligible file tree selection and still sends key")
+    @MainActor func downArrowPreviewsFileTreeSelection() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy) else { return }
+        let entries = [
+            keyboardFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a"),
+            keyboardFileTreeEntry(pathHash: 2, isFocused: true, id: "/project/b", path: "/project/b", name: "b", relPath: "b")
+        ]
+        view.dispatcher.applyForTesting(.guiFileTree(version: 2, treeFlags: 0x23, treeState: 3, selectedId: "/project/a", treeWidth: 30,
+                                                rootPath: "/project", errorReason: "", entries: entries))
+
+        guard let event = keyEvent(keyCode: 125) else { return }
+        view.keyDown(with: event)
+
+        #expect(view.dispatcher.guiState.fileTreeState.selectedId == "/project/b")
+        #expect(view.dispatcher.guiState.fileTreeState.selectedIndex == 1)
+        #expect(spy.keyPressCalls.count == 1)
+        #expect(spy.keyPressCalls[0].codepoint == 57353)
+    }
+
     @Test("Home/End/PageUp/PageDown send correct codepoints")
     @MainActor func navigationKeys() throws {
         let spy = SpyEncoder()
@@ -284,4 +304,43 @@ struct KeyboardInputTests {
             #expect(spy.keyPressCalls[i].codepoint == expected)
         }
     }
+}
+
+private func keyboardFileTreeEntry(
+    pathHash: UInt32,
+    isSelected: Bool = false,
+    isFocused: Bool = false,
+    id: String,
+    path: String,
+    name: String,
+    relPath: String
+) -> Wire.FileTreeEntry {
+    Wire.FileTreeEntry(
+        pathHash: pathHash,
+        id: id,
+        path: path,
+        isDir: false,
+        isExpanded: false,
+        isSelected: isSelected,
+        isFocused: isFocused,
+        isActive: false,
+        isDirty: false,
+        isEditing: false,
+        isLastChild: false,
+        depth: 0,
+        gitStatus: 0,
+        diagnosticErrorCount: 0,
+        diagnosticWarningCount: 0,
+        diagnosticInfoCount: 0,
+        diagnosticHintCount: 0,
+        guides: [],
+        icon: "",
+        iconColorR: 0x6D,
+        iconColorG: 0x80,
+        iconColorB: 0x86,
+        name: name,
+        relPath: relPath,
+        editingType: 0xFF,
+        editingText: ""
+    )
 }

--- a/macos/Tests/MingaTests/KeyboardInputTests.swift
+++ b/macos/Tests/MingaTests/KeyboardInputTests.swift
@@ -13,6 +13,21 @@ import Testing
 import Foundation
 import AppKit
 
+private enum FileTreeNavigationTestConstants {
+    static let visibleFlag: UInt8 = 0x01
+    static let focusedFlag: UInt8 = 0x02
+    static let localNavigationFlag: UInt8 = 0x20
+    static let readyState: UInt8 = 3
+    static let keyCodeK: UInt16 = 40
+    static let keyCodeDownArrow: UInt16 = 125
+    static let keyCodeUpArrow: UInt16 = 126
+    static let kittyLeftCodepoint: UInt32 = 57350
+    static let kittyRightCodepoint: UInt32 = 57351
+    static let kittyUpCodepoint: UInt32 = 57352
+    static let kittyDownCodepoint: UInt32 = 57353
+    static let characterKCodepoint: UInt32 = 0x6B
+}
+
 @Suite("EditorNSView Keyboard Input")
 struct KeyboardInputTests {
 
@@ -103,10 +118,10 @@ struct KeyboardInputTests {
         guard let view = makeView(spy: spy) else { return }
 
         let arrows: [(keyCode: UInt16, expected: UInt32)] = [
-            (123, 57350), // Left
-            (124, 57351), // Right
-            (126, 57352), // Up
-            (125, 57353), // Down
+            (123, FileTreeNavigationTestConstants.kittyLeftCodepoint),
+            (124, FileTreeNavigationTestConstants.kittyRightCodepoint),
+            (FileTreeNavigationTestConstants.keyCodeUpArrow, FileTreeNavigationTestConstants.kittyUpCodepoint),
+            (FileTreeNavigationTestConstants.keyCodeDownArrow, FileTreeNavigationTestConstants.kittyDownCodepoint),
         ]
 
         for (keyCode, _) in arrows {
@@ -115,9 +130,9 @@ struct KeyboardInputTests {
         }
 
         #expect(spy.keyPressCalls.count == 4)
-        for (i, (_, expected)) in arrows.enumerated() {
-            #expect(spy.keyPressCalls[i].codepoint == expected,
-                    "Arrow key at index \(i) should be \(expected)")
+        for (index, (_, expected)) in arrows.enumerated() {
+            #expect(spy.keyPressCalls[index].codepoint == expected,
+                    "Arrow key at index \(index) should be \(expected)")
         }
     }
 
@@ -129,16 +144,92 @@ struct KeyboardInputTests {
             keyboardFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a"),
             keyboardFileTreeEntry(pathHash: 2, isFocused: true, id: "/project/b", path: "/project/b", name: "b", relPath: "b")
         ]
-        view.dispatcher.applyForTesting(.guiFileTree(version: 2, treeFlags: 0x23, treeState: 3, selectedId: "/project/a", treeWidth: 30,
-                                                rootPath: "/project", errorReason: "", entries: entries))
+        view.dispatcher.applyForTesting(
+            .guiFileTree(
+                version: 2,
+                treeFlags: FileTreeNavigationTestConstants.visibleFlag |
+                    FileTreeNavigationTestConstants.focusedFlag |
+                    FileTreeNavigationTestConstants.localNavigationFlag,
+                treeState: FileTreeNavigationTestConstants.readyState,
+                selectedId: "/project/a",
+                treeWidth: 30,
+                rootPath: "/project",
+                errorReason: "",
+                entries: entries
+            )
+        )
 
-        guard let event = keyEvent(keyCode: 125) else { return }
+        guard let event = keyEvent(keyCode: FileTreeNavigationTestConstants.keyCodeDownArrow) else { return }
         view.keyDown(with: event)
 
         #expect(view.dispatcher.guiState.fileTreeState.selectedId == "/project/b")
         #expect(view.dispatcher.guiState.fileTreeState.selectedIndex == 1)
         #expect(spy.keyPressCalls.count == 1)
-        #expect(spy.keyPressCalls[0].codepoint == 57353)
+        #expect(spy.keyPressCalls[0].codepoint == FileTreeNavigationTestConstants.kittyDownCodepoint)
+    }
+
+    @Test("k previews eligible file tree selection and still sends key")
+    @MainActor func kKeyPreviewsFileTreeSelection() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy) else { return }
+        let entries = [
+            keyboardFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a"),
+            keyboardFileTreeEntry(pathHash: 2, isFocused: true, id: "/project/b", path: "/project/b", name: "b", relPath: "b")
+        ]
+        view.dispatcher.applyForTesting(
+            .guiFileTree(
+                version: 2,
+                treeFlags: FileTreeNavigationTestConstants.visibleFlag |
+                    FileTreeNavigationTestConstants.focusedFlag |
+                    FileTreeNavigationTestConstants.localNavigationFlag,
+                treeState: FileTreeNavigationTestConstants.readyState,
+                selectedId: "/project/a",
+                treeWidth: 30,
+                rootPath: "/project",
+                errorReason: "",
+                entries: entries
+            )
+        )
+
+        guard let event = keyEvent(keyCode: FileTreeNavigationTestConstants.keyCodeK, characters: "k", charactersIgnoringModifiers: "k") else { return }
+        view.keyDown(with: event)
+
+        #expect(view.dispatcher.guiState.fileTreeState.selectedId == "/project/b")
+        #expect(view.dispatcher.guiState.fileTreeState.selectedIndex == 1)
+        #expect(spy.keyPressCalls.count == 1)
+        #expect(spy.keyPressCalls[0].codepoint == FileTreeNavigationTestConstants.characterKCodepoint)
+    }
+
+    @Test("Up arrow previews eligible file tree selection and still sends key")
+    @MainActor func upArrowPreviewsFileTreeSelection() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy) else { return }
+        let entries = [
+            keyboardFileTreeEntry(pathHash: 1, isSelected: false, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a"),
+            keyboardFileTreeEntry(pathHash: 2, isSelected: true, isFocused: true, id: "/project/b", path: "/project/b", name: "b", relPath: "b")
+        ]
+        view.dispatcher.applyForTesting(
+            .guiFileTree(
+                version: 2,
+                treeFlags: FileTreeNavigationTestConstants.visibleFlag |
+                    FileTreeNavigationTestConstants.focusedFlag |
+                    FileTreeNavigationTestConstants.localNavigationFlag,
+                treeState: FileTreeNavigationTestConstants.readyState,
+                selectedId: "/project/b",
+                treeWidth: 30,
+                rootPath: "/project",
+                errorReason: "",
+                entries: entries
+            )
+        )
+
+        guard let event = keyEvent(keyCode: FileTreeNavigationTestConstants.keyCodeUpArrow) else { return }
+        view.keyDown(with: event)
+
+        #expect(view.dispatcher.guiState.fileTreeState.selectedId == "/project/a")
+        #expect(view.dispatcher.guiState.fileTreeState.selectedIndex == 0)
+        #expect(spy.keyPressCalls.count == 1)
+        #expect(spy.keyPressCalls[0].codepoint == FileTreeNavigationTestConstants.kittyUpCodepoint)
     }
 
     @Test("Home/End/PageUp/PageDown send correct codepoints")
@@ -159,8 +250,8 @@ struct KeyboardInputTests {
         }
 
         #expect(spy.keyPressCalls.count == 4)
-        for (i, (_, expected)) in keys.enumerated() {
-            #expect(spy.keyPressCalls[i].codepoint == expected)
+        for (index, (_, expected)) in keys.enumerated() {
+            #expect(spy.keyPressCalls[index].codepoint == expected)
         }
     }
 
@@ -300,8 +391,8 @@ struct KeyboardInputTests {
         }
 
         #expect(spy.keyPressCalls.count == 4)
-        for (i, (_, expected)) in fkeys.enumerated() {
-            #expect(spy.keyPressCalls[i].codepoint == expected)
+        for (index, (_, expected)) in fkeys.enumerated() {
+            #expect(spy.keyPressCalls[index].codepoint == expected)
         }
     }
 }

--- a/test/minga/frontend/adapter/gui/file_tree_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/file_tree_encoder_test.exs
@@ -126,6 +126,26 @@ defmodule Minga.Frontend.Adapter.GUI.FileTreeEncoderTest do
       assert selected_id == "/project/b.ex"
     end
 
+    test "encodes local navigation eligibility in tree flags" do
+      model = %{ready_tree("/project/a.ex") | local_navigation?: true}
+
+      {cmd, _caches} = FileTreeEncoder.encode(model, Caches.new())
+
+      assert <<@op_gui_file_tree, len::32, payload::binary-size(len)>> = cmd
+      assert <<2::8, tree_flags::8, _tree_state::8, _rest::binary>> = payload
+      assert Bitwise.band(tree_flags, 0x20) != 0
+    end
+
+    test "sends full tree when local navigation eligibility changes" do
+      model1 = ready_tree("/project/a.ex")
+      model2 = %{model1 | local_navigation?: true}
+
+      {_, caches} = FileTreeEncoder.encode(model1, Caches.new())
+      {cmd2, _caches} = FileTreeEncoder.encode(model2, caches)
+
+      assert <<@op_gui_file_tree, _len::32, _payload::binary>> = cmd2
+    end
+
     test "sends full tree when row structure changes" do
       model1 = ready_tree("/project/a.ex")
       model2 = %{ready_tree("/project/a.ex") | rows: [row("/project/a.ex"), row("/project/c.ex")]}

--- a/test/minga_editor/render_model/ui/file_tree_builder_test.exs
+++ b/test/minga_editor/render_model/ui/file_tree_builder_test.exs
@@ -76,6 +76,90 @@ defmodule MingaEditor.RenderModel.UI.FileTreeBuilderTest do
       assert row.icon_color == 0x519ABA
     end
 
+    test "disables local navigation while filtering" do
+      tree = %ProjectFileTree{
+        root: "/project",
+        width: 32,
+        cursor: 0,
+        expanded: MapSet.new(["/project"]),
+        git_status: %{},
+        entries: [
+          %{
+            path: "/project/main.rs",
+            name: "main.rs",
+            dir?: false,
+            depth: 1,
+            last_child?: true,
+            guides: []
+          }
+        ]
+      }
+
+      file_tree = %FileTreeState{tree: tree, focused: true, filtering: true, tree_status: :ready}
+      model = FileTreeBuilder.build(build_minimal_context(file_tree: file_tree))
+
+      assert model.status == :ready
+      refute model.local_navigation?
+    end
+
+    test "disables local navigation while help is visible" do
+      tree = %ProjectFileTree{
+        root: "/project",
+        width: 32,
+        cursor: 0,
+        expanded: MapSet.new(["/project"]),
+        git_status: %{},
+        entries: [
+          %{
+            path: "/project/main.rs",
+            name: "main.rs",
+            dir?: false,
+            depth: 1,
+            last_child?: true,
+            guides: []
+          }
+        ]
+      }
+
+      file_tree = %FileTreeState{
+        tree: tree,
+        focused: true,
+        help_visible: true,
+        tree_status: :ready
+      }
+
+      model = FileTreeBuilder.build(build_minimal_context(file_tree: file_tree))
+
+      assert model.status == :ready
+      refute model.local_navigation?
+    end
+
+    test "disables local navigation when file tree is not focused" do
+      tree = %ProjectFileTree{
+        root: "/project",
+        width: 32,
+        cursor: 0,
+        expanded: MapSet.new(["/project"]),
+        git_status: %{},
+        entries: [
+          %{
+            path: "/project/main.rs",
+            name: "main.rs",
+            dir?: false,
+            depth: 1,
+            last_child?: true,
+            guides: []
+          }
+        ]
+      }
+
+      file_tree = %FileTreeState{tree: tree, focused: false, tree_status: :ready}
+      model = FileTreeBuilder.build(build_minimal_context(file_tree: file_tree))
+
+      assert model.status == :ready
+      refute model.local_navigation?
+    end
+
     test "resolves per-filetype icon colors from the active theme" do
       path = "/project/main.rs"
 

--- a/test/minga_editor/render_model/ui/file_tree_builder_test.exs
+++ b/test/minga_editor/render_model/ui/file_tree_builder_test.exs
@@ -57,6 +57,7 @@ defmodule MingaEditor.RenderModel.UI.FileTreeBuilderTest do
       model = FileTreeBuilder.build(ctx)
 
       assert %FileTreeModel{status: :ready, focused?: true, tree_width: 32} = model
+      refute model.local_navigation?
       assert model.selected_id == path
 
       assert [row] = model.rows
@@ -96,6 +97,8 @@ defmodule MingaEditor.RenderModel.UI.FileTreeBuilderTest do
 
       doom = FileTreeBuilder.build(build_minimal_context(file_tree: file_tree, theme: :doom_one))
 
+      assert astrodark.local_navigation?
+      assert doom.local_navigation?
       assert [%{icon_color: astrodark_color}] = astrodark.rows
       assert [%{icon_color: doom_color}] = doom.rows
 


### PR DESCRIPTION
# TL;DR
Adds a macOS zero-latency local selection preview for file-tree navigation while keeping the BEAM authoritative for semantic model changes and committed actions.

## Context
Holding `j`, `k`, or arrow keys in the file tree could feel inconsistently laggy because every transient row movement had to wait for a BEAM round trip and a render update. This change lets the semantic frontend preview eligible row navigation immediately from the last committed file-tree model, then reconcile with the next authoritative BEAM payload.

## Changes
- Added a `local_navigation?` field to the file-tree semantic model.
- Emits file-tree flag bit 5 when local navigation is safe: file tree focused, not editing, not filtering, and help hidden.
- Includes the local navigation flag in the GUI file-tree cache fingerprint so eligibility changes send a full tree payload.
- Decodes the flag on macOS and previews unmodified `j`, `k`, Down, and Up navigation locally.
- Keeps forwarding the key event to the BEAM so durable state and key semantics remain authoritative.
- Optimizes macOS selection updates to rewrite only the previous and next rows when focus is unchanged.
- Documents the new file-tree flag in `docs/GUI_PROTOCOL.md`.

## Verification
- `mix test.llm`
- `mix swift.build`
- `mix compile --warnings-as-errors`
- `git diff --check`
- `mix zig.lint`
- `mix test.debug test/minga_editor/commands/match_bracket_command_test.exs test/minga_editor/commands/structural_navigation_test.exs`
- Targeted Xcode tests for `CommandDispatcherRoutingTests` and `KeyboardInputTests`
- Focused Elixir tests for `file_tree_encoder` and `file_tree_builder`

## Notes
- The initial full test run exposed missing parser artifacts in the new worktree. Building the Zig parser and copying it into the test priv path resolved those unrelated structural navigation failures, and the full `mix test.llm` run then passed.
- The final `reviewer` subagent was attempted twice but timed out operationally. A focused `prtk-code-reviewer` pass found no issues, and a manual fallback review found no merge blockers.
