### PR TITLE
fix(agent): polish model picker and errors

### DIFF
--- a/lib/minga_agent/event.ex
+++ b/lib/minga_agent/event.ex
@@ -95,8 +95,12 @@ defmodule MingaAgent.Event do
           limit: pos_integer()
         }
 
-  @typedoc "An error occurred in the agent."
-  @type error :: %__MODULE__.Error{message: String.t()}
+  @typedoc "An error occurred in the agent, with structured kind/provider metadata."
+  @type error :: %__MODULE__.Error{
+          message: String.t(),
+          kind: Error.kind(),
+          provider: String.t() | nil
+        }
 
   defmodule AgentStart do
     @moduledoc false

--- a/lib/minga_agent/event.ex
+++ b/lib/minga_agent/event.ex
@@ -217,8 +217,24 @@ defmodule MingaAgent.Event do
 
   defmodule Error do
     @moduledoc false
+
+    @type kind ::
+            :auth_failed
+            | :rate_limited
+            | :unreachable
+            | :invalid_model
+            | :provider_error
+            | :tool_error
+            | :internal_error
+            | :unknown
+
     @enforce_keys [:message]
-    defstruct [:message]
-    @type t :: %__MODULE__{message: String.t()}
+    defstruct [:message, kind: :unknown, provider: nil]
+
+    @type t :: %__MODULE__{
+            message: String.t(),
+            kind: kind(),
+            provider: String.t() | nil
+          }
   end
 end

--- a/lib/minga_agent/event.ex
+++ b/lib/minga_agent/event.ex
@@ -98,7 +98,7 @@ defmodule MingaAgent.Event do
   @typedoc "An error occurred in the agent, with structured kind/provider metadata."
   @type error :: %__MODULE__.Error{
           message: String.t(),
-          kind: Error.kind(),
+          kind: __MODULE__.Error.kind(),
           provider: String.t() | nil
         }
 

--- a/lib/minga_agent/model_catalog.ex
+++ b/lib/minga_agent/model_catalog.ex
@@ -35,8 +35,9 @@ defmodule MingaAgent.ModelCatalog do
 
     LLMDB.models()
     |> Enum.filter(&include_model?(&1, configured_providers, oauth))
-    |> Enum.sort_by(&{&1.provider, &1.name})
     |> Enum.map(&format_model(&1, current_model, oauth))
+    |> dedupe_models()
+    |> Enum.sort_by(&model_sort_key/1)
   end
 
   # ── Private ─────────────────────────────────────────────────────────────────
@@ -65,7 +66,7 @@ defmodule MingaAgent.ModelCatalog do
     end
   end
 
-  @excluded_patterns ~w(embedding tts whisper moderation realtime dall-e sora imagen veo aqa gemma)
+  @excluded_patterns ~w(embedding tts whisper moderation realtime dall-e sora imagen veo aqa gemma duo-chat)
 
   @spec include_model?(map(), MapSet.t(atom()), boolean()) :: boolean()
   defp include_model?(model, configured_providers, oauth) do
@@ -79,7 +80,7 @@ defmodule MingaAgent.ModelCatalog do
 
   defp provider_available?(model, configured_providers, oauth) do
     if codex_model?(model) do
-      oauth or model.provider in configured_providers
+      oauth and model.provider == :openai
     else
       model.provider in configured_providers
     end
@@ -109,23 +110,197 @@ defmodule MingaAgent.ModelCatalog do
 
   @spec format_model(map(), String.t(), boolean()) :: model_entry()
   defp format_model(model, current_model, oauth) do
+    canonical_id = canonical_model_id(model)
+
     {provider_str, full_id} =
       if codex_model?(model) and oauth do
-        {"openai_codex", "openai_codex:#{model.id}"}
+        {"openai_codex", "openai_codex:#{canonical_id}"}
       else
         provider = Atom.to_string(model.provider)
-        {provider, "#{provider}:#{model.id}"}
+        {provider, "#{provider}:#{canonical_id}"}
       end
 
     %{
       "id" => full_id,
-      "name" => model.name || model.id,
+      "name" => display_name(model, canonical_id),
       "provider" => provider_str,
       "context_window" => model.limits[:context],
       "cost" => format_cost(model.cost),
       "current" => full_id == current_model
     }
   end
+
+  @spec canonical_model_id(map()) :: String.t()
+  defp canonical_model_id(%{id: id, provider: provider} = model) do
+    provider_prefix = provider |> Atom.to_string() |> Kernel.<>("/")
+
+    id
+    |> String.trim()
+    |> String.replace_prefix(provider_prefix, "")
+    |> canonicalize_codex_id(model)
+  end
+
+  @spec canonicalize_codex_id(String.t(), map()) :: String.t()
+  defp canonicalize_codex_id(id, model) do
+    if codex_model?(model) do
+      id
+      |> String.replace_prefix("openai/", "")
+      |> String.replace_prefix("openai-", "")
+      |> normalize_codex_version_alias()
+    else
+      id
+    end
+  end
+
+  @spec normalize_codex_version_alias(String.t()) :: String.t()
+  defp normalize_codex_version_alias(id) do
+    id = Regex.replace(~r/^gpt-(\d)-(\d)(-.+)$/, id, "gpt-\\1.\\2\\3")
+    Regex.replace(~r/^gpt-(\d)(\d)(-.+)$/, id, "gpt-\\1.\\2\\3")
+  end
+
+  @spec display_name(map(), String.t()) :: String.t()
+  defp display_name(model, canonical_id) do
+    if codex_model?(model) do
+      codex_display_name(canonical_id)
+    else
+      model.name || canonical_id
+    end
+  end
+
+  @spec codex_display_name(String.t()) :: String.t()
+  defp codex_display_name("codex-mini"), do: "Codex Mini"
+
+  defp codex_display_name("gpt-" <> rest) do
+    case String.split(rest, "-", trim: true) do
+      [version, "codex" | variants] -> gpt_codex_display_name(version, variants)
+      _other -> titleize_model_id("gpt-" <> rest)
+    end
+  end
+
+  defp codex_display_name(id), do: titleize_model_id(id)
+
+  @spec gpt_codex_display_name(String.t(), [String.t()]) :: String.t()
+  defp gpt_codex_display_name(version, variants) do
+    suffix = variants |> Enum.map_join(" ", &String.capitalize/1)
+    String.trim("GPT-#{version} Codex #{suffix}")
+  end
+
+  @spec titleize_model_id(String.t()) :: String.t()
+  defp titleize_model_id(id) do
+    id
+    |> String.split("-", trim: true)
+    |> Enum.map_join(" ", &titleize_model_part/1)
+  end
+
+  @spec titleize_model_part(String.t()) :: String.t()
+  defp titleize_model_part("gpt"), do: "GPT"
+  defp titleize_model_part(part), do: String.capitalize(part)
+
+  @spec dedupe_models([model_entry()]) :: [model_entry()]
+  defp dedupe_models(models) do
+    models
+    |> Enum.group_by(& &1["id"])
+    |> Enum.map(fn {_id, entries} -> best_model_entry(entries) end)
+  end
+
+  @spec best_model_entry([model_entry()]) :: model_entry()
+  defp best_model_entry([entry | rest]) do
+    Enum.reduce(rest, entry, &prefer_model_entry/2)
+  end
+
+  @spec prefer_model_entry(model_entry(), model_entry()) :: model_entry()
+  defp prefer_model_entry(candidate, incumbent) do
+    if model_quality_key(candidate) < model_quality_key(incumbent), do: candidate, else: incumbent
+  end
+
+  @spec model_quality_key(model_entry()) :: {integer(), integer(), integer()}
+  defp model_quality_key(model) do
+    name = model["name"] || ""
+
+    {
+      prefixed_name_rank(name),
+      lowercase_name_rank(name),
+      String.length(name)
+    }
+  end
+
+  @spec prefixed_name_rank(String.t()) :: integer()
+  defp prefixed_name_rank("OpenAI: " <> _rest), do: 1
+  defp prefixed_name_rank(_name), do: 0
+
+  @spec lowercase_name_rank(String.t()) :: integer()
+  defp lowercase_name_rank(name), do: if(name == String.downcase(name), do: 1, else: 0)
+
+  @provider_sort_order %{
+    "openai_codex" => 0,
+    "anthropic" => 1,
+    "openai" => 2,
+    "google" => 3
+  }
+
+  @spec model_sort_key(model_entry()) :: tuple()
+  defp model_sort_key(model) do
+    id = model["id"] || ""
+    provider = model["provider"] || ""
+
+    {
+      current_rank(model),
+      Map.get(@provider_sort_order, provider, 99),
+      model_family_rank(id),
+      model_version_key(id),
+      model_variant_rank(id),
+      String.downcase(model["name"] || id)
+    }
+  end
+
+  @spec current_rank(model_entry()) :: integer()
+  defp current_rank(%{"current" => true}), do: 0
+  defp current_rank(_model), do: 1
+
+  @spec model_family_rank(String.t()) :: integer()
+  defp model_family_rank(id) do
+    if String.contains?(id, "gpt-"), do: 0, else: 1
+  end
+
+  @spec model_version_key(String.t()) :: [integer()]
+  defp model_version_key(id) do
+    case Regex.run(~r/gpt-(\d+(?:\.\d+)?)/, id) do
+      [_match, version] ->
+        version |> String.split(".") |> padded_version_parts() |> Enum.map(&negative_integer/1)
+
+      nil ->
+        []
+    end
+  end
+
+  @spec padded_version_parts([String.t()]) :: [String.t()]
+  defp padded_version_parts([major]), do: [major, "0"]
+  defp padded_version_parts(parts), do: parts
+
+  @spec negative_integer(String.t()) :: integer()
+  defp negative_integer(value), do: value |> String.to_integer() |> Kernel.*(-1)
+
+  @spec model_variant_rank(String.t()) :: integer()
+  defp model_variant_rank(id) do
+    id
+    |> String.downcase()
+    |> do_model_variant_rank()
+  end
+
+  @spec do_model_variant_rank(String.t()) :: integer()
+  defp do_model_variant_rank(id) do
+    model_variant_rank(
+      String.contains?(id, "max"),
+      String.contains?(id, "mini"),
+      String.contains?(id, "spark")
+    )
+  end
+
+  @spec model_variant_rank(boolean(), boolean(), boolean()) :: integer()
+  defp model_variant_rank(true, _mini?, _spark?), do: 0
+  defp model_variant_rank(false, false, false), do: 1
+  defp model_variant_rank(false, true, _spark?), do: 2
+  defp model_variant_rank(false, false, true), do: 3
 
   @spec format_cost(map()) :: map()
   defp format_cost(%{input: input, output: output}) do

--- a/lib/minga_agent/model_catalog.ex
+++ b/lib/minga_agent/model_catalog.ex
@@ -33,7 +33,15 @@ defmodule MingaAgent.ModelCatalog do
     configured_providers = configured_provider_atoms()
     oauth = Credentials.oauth_configured?()
 
-    LLMDB.models()
+    available_models_from(LLMDB.models(), current_model, configured_providers, oauth)
+  end
+
+  @doc false
+  @spec available_models_from([map()], String.t(), MapSet.t(atom()), boolean()) :: [model_entry()]
+  def available_models_from(models, current_model, configured_providers, oauth) do
+    current_model = canonical_current_model_id(current_model, oauth)
+
+    models
     |> Enum.filter(&include_model?(&1, configured_providers, oauth))
     |> Enum.map(&format_model(&1, current_model, oauth))
     |> dedupe_models()
@@ -75,7 +83,8 @@ defmodule MingaAgent.ModelCatalog do
       not model.retired and
       has_text_output?(model) and
       has_reasonable_context?(model) and
-      not excluded_by_name?(model.id)
+      not excluded_by_name?(model.id) and
+      not excluded_codex_reasoning_alias?(model)
   end
 
   defp provider_available?(model, configured_providers, oauth) do
@@ -106,6 +115,28 @@ defmodule MingaAgent.ModelCatalog do
   defp excluded_by_name?(id) do
     id_lower = String.downcase(id)
     Enum.any?(@excluded_patterns, &String.contains?(id_lower, &1))
+  end
+
+  @spec excluded_codex_reasoning_alias?(map()) :: boolean()
+  defp excluded_codex_reasoning_alias?(%{id: id} = model) do
+    codex_model?(model) and String.contains?(String.downcase(id), "xhigh")
+  end
+
+  @spec canonical_current_model_id(String.t(), boolean()) :: String.t()
+  defp canonical_current_model_id(current_model, oauth) do
+    case String.split(current_model, ":", parts: 2) do
+      ["openai_codex", id] when oauth -> "openai_codex:#{canonicalize_codex_alias_id(id)}"
+      [provider, id] -> "#{provider}:#{canonicalize_codex_alias_id(id)}"
+      _ -> current_model
+    end
+  end
+
+  @spec canonicalize_codex_alias_id(String.t()) :: String.t()
+  defp canonicalize_codex_alias_id(id) do
+    id
+    |> String.replace_prefix("openai/", "")
+    |> String.replace_prefix("openai-", "")
+    |> normalize_codex_version_alias()
   end
 
   @spec format_model(map(), String.t(), boolean()) :: model_entry()

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -3173,15 +3173,11 @@ defmodule MingaAgent.Providers.Native do
 
   defdelegate strip_provider_prefix(model), to: MingaAgent.Config
 
-  @spec emit_error_and_end(pid(), String.t() | Event.Error.t()) :: :ok
+  @spec emit_error_and_end(pid(), Event.Error.t()) :: :ok
   defp emit_error_and_end(provider_pid, %Event.Error{} = event) do
     send(provider_pid, {:agent_event, event})
     send(provider_pid, {:agent_event, %Event.AgentEnd{usage: nil}})
     :ok
-  end
-
-  defp emit_error_and_end(provider_pid, message) do
-    emit_error_and_end(provider_pid, %Event.Error{message: message})
   end
 
   # Reports an error that occurred inside the agent loop: logs a redacted
@@ -3231,13 +3227,6 @@ defmodule MingaAgent.Providers.Native do
   end
 
   defp error_event_message(:invalid_model, message, _provider), do: message
-  defp error_event_message(:tool_error, message, _provider), do: message
-
-  defp error_event_message(:internal_error, _message, _provider) do
-    "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."
-  end
-
-  defp error_event_message(:unknown, message, _provider), do: message
 
   @spec classify_error_reason(term()) :: Event.Error.kind()
   defp classify_error_reason(:invalid_format), do: :invalid_model
@@ -3301,8 +3290,6 @@ defmodule MingaAgent.Providers.Native do
       _other -> nil
     end
   end
-
-  defp provider_slug_from_model(_model), do: nil
 
   @spec normalize_usage(map() | nil, String.t()) :: Event.token_usage() | nil
   defp normalize_usage(nil, _model), do: nil

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1563,7 +1563,7 @@ defmodule MingaAgent.Providers.Native do
   defp do_agent_loop(lctx, context) do
     case ReqLLMAdapter.validate_model(lctx.model) do
       :ok -> do_agent_loop_validated(lctx, context)
-      {:error, message, reason} -> reported_error(lctx.provider_pid, message, reason)
+      {:error, message, reason} -> reported_error(lctx.provider_pid, message, reason, lctx.model)
     end
   end
 
@@ -1611,16 +1611,16 @@ defmodule MingaAgent.Providers.Native do
         process_and_continue(lctx, context, stream_response)
 
       {:error, reason} ->
-        reported_error(lctx.provider_pid, format_error(reason), reason)
+        reported_error(lctx.provider_pid, format_error(reason), reason, lctx.model)
     end
   rescue
     e ->
-      reported_error(lctx.provider_pid, Exception.message(e), e)
+      reported_error(lctx.provider_pid, Exception.message(e), e, lctx.model)
   catch
     # HTTP client or session process may die mid-stream. Targeted catch
     # per AGENTS.md rule 4.
     :exit, reason ->
-      reported_error(lctx.provider_pid, inspect(reason), reason)
+      reported_error(lctx.provider_pid, inspect(reason), reason, lctx.model)
   end
 
   # Processes a stream response and decides whether to continue (tool calls) or finish.
@@ -1685,7 +1685,7 @@ defmodule MingaAgent.Providers.Native do
 
       {:error, :stream_interrupted}
     else
-      reported_error(lctx.provider_pid, format_error(reason), reason)
+      reported_error(lctx.provider_pid, format_error(reason), reason, lctx.model)
     end
   end
 
@@ -3173,11 +3173,15 @@ defmodule MingaAgent.Providers.Native do
 
   defdelegate strip_provider_prefix(model), to: MingaAgent.Config
 
-  @spec emit_error_and_end(pid(), String.t()) :: :ok
-  defp emit_error_and_end(provider_pid, message) do
-    send(provider_pid, {:agent_event, %Event.Error{message: message}})
+  @spec emit_error_and_end(pid(), String.t() | Event.Error.t()) :: :ok
+  defp emit_error_and_end(provider_pid, %Event.Error{} = event) do
+    send(provider_pid, {:agent_event, event})
     send(provider_pid, {:agent_event, %Event.AgentEnd{usage: nil}})
     :ok
+  end
+
+  defp emit_error_and_end(provider_pid, message) do
+    emit_error_and_end(provider_pid, %Event.Error{message: message})
   end
 
   # Reports an error that occurred inside the agent loop: logs the raw detail
@@ -3185,12 +3189,108 @@ defmodule MingaAgent.Providers.Native do
   # `{:reported, reason}` sentinel. The Task-completion handler matches that
   # sentinel and skips re-emitting, so a single failure surfaces exactly once
   # in the transcript instead of twice.
-  @spec reported_error(pid(), String.t(), term()) :: {:error, {:reported, term()}}
-  defp reported_error(provider_pid, message, reason) do
-    Minga.Log.error(:agent, "[Agent.Native] agent loop error: #{message}")
-    emit_error_and_end(provider_pid, message)
+  @spec reported_error(pid(), String.t(), term(), String.t()) :: {:error, {:reported, term()}}
+  defp reported_error(provider_pid, message, reason, model) do
+    event = error_event(message, reason, model)
+    Minga.Log.error(:agent, "[Agent.Native] agent loop error: #{event.message}")
+    emit_error_and_end(provider_pid, event)
     {:error, {:reported, reason}}
   end
+
+  @spec error_event(String.t(), term(), String.t()) :: Event.Error.t()
+  defp error_event(message, reason, model) do
+    kind = classify_error_reason(reason)
+    provider = provider_slug_from_model(model)
+
+    %Event.Error{
+      message: error_event_message(kind, message, provider),
+      kind: kind,
+      provider: provider
+    }
+  end
+
+  @spec error_event_message(Event.Error.kind(), String.t(), String.t() | nil) :: String.t()
+  defp error_event_message(:auth_failed, _message, provider) do
+    provider = provider || "provider"
+    "Couldn't authenticate with #{provider_label(provider)}. #{auth_hint_for_provider(provider)}"
+  end
+
+  defp error_event_message(:rate_limited, _message, _provider) do
+    "The model provider is rate limiting requests. Wait a moment, then try again."
+  end
+
+  defp error_event_message(:unreachable, _message, _provider) do
+    "Couldn't reach the model provider. Check your network connection, then try again."
+  end
+
+  defp error_event_message(:provider_error, message, _provider), do: message
+  defp error_event_message(:invalid_model, message, _provider), do: message
+  defp error_event_message(:tool_error, message, _provider), do: message
+  defp error_event_message(:internal_error, message, _provider), do: message
+  defp error_event_message(:unknown, message, _provider), do: message
+
+  @spec classify_error_reason(term()) :: Event.Error.kind()
+  defp classify_error_reason(:invalid_format), do: :invalid_model
+  defp classify_error_reason({:http_streaming_failed, reason}), do: classify_error_reason(reason)
+  defp classify_error_reason({:provider_build_failed, _reason}), do: :auth_failed
+  defp classify_error_reason({:exit, reason}), do: classify_error_reason(reason)
+  defp classify_error_reason({:throw, reason}), do: classify_error_reason(reason)
+  defp classify_error_reason(%{status: status}) when status in [401, 403], do: :auth_failed
+  defp classify_error_reason(%{status: 429}), do: :rate_limited
+  defp classify_error_reason(%{"status" => status}) when status in [401, 403], do: :auth_failed
+  defp classify_error_reason(%{"status" => 429}), do: :rate_limited
+  defp classify_error_reason(%{reason: reason}), do: classify_error_reason(reason)
+  defp classify_error_reason(%{"reason" => reason}), do: classify_error_reason(reason)
+
+  defp classify_error_reason(reason) when reason in [:timeout, :nxdomain, :econnrefused],
+    do: :unreachable
+
+  defp classify_error_reason(reason) when is_binary(reason),
+    do: classify_legacy_error_message(reason)
+
+  defp classify_error_reason(_reason), do: :provider_error
+
+  # Last-resort compatibility for third-party clients that only return a string.
+  # Internal provider/session contracts use `Event.Error.kind` instead.
+  @spec classify_legacy_error_message(String.t()) :: Event.Error.kind()
+  defp classify_legacy_error_message(message) do
+    classify_legacy_error_checks([
+      {:auth_failed, String.match?(message, ~r/\b(401|403)\b/)},
+      {:rate_limited, String.match?(message, ~r/\b429\b/)},
+      {:auth_failed,
+       String.contains?(message, [
+         "provider_build_failed",
+         "api_key",
+         "API_KEY",
+         "Couldn't authenticate"
+       ])},
+      {:unreachable,
+       String.contains?(message, [
+         "http_streaming_failed",
+         "econnrefused",
+         "nxdomain",
+         "timed out"
+       ])}
+    ])
+  end
+
+  @spec classify_legacy_error_checks([{Event.Error.kind(), boolean()}]) :: Event.Error.kind()
+  defp classify_legacy_error_checks([{kind, true} | _rest]), do: kind
+
+  defp classify_legacy_error_checks([{_kind, false} | rest]),
+    do: classify_legacy_error_checks(rest)
+
+  defp classify_legacy_error_checks([]), do: :provider_error
+
+  @spec provider_slug_from_model(String.t()) :: String.t() | nil
+  defp provider_slug_from_model(model) when is_binary(model) do
+    case String.split(model, ":", parts: 2) do
+      [provider, _model_id] when provider != "" -> provider
+      _other -> nil
+    end
+  end
+
+  defp provider_slug_from_model(_model), do: nil
 
   @spec normalize_usage(map() | nil, String.t()) :: Event.token_usage() | nil
   defp normalize_usage(nil, _model), do: nil
@@ -3228,16 +3328,103 @@ defmodule MingaAgent.Providers.Native do
   defp format_tool_result(result), do: inspect(result)
 
   @spec format_error(term()) :: String.t()
-  defp format_error(reason) when is_binary(reason), do: Redaction.format_error(reason)
-  defp format_error(%{message: msg}) when is_binary(msg), do: Redaction.format_error(msg)
-  defp format_error(%{"message" => msg}) when is_binary(msg), do: Redaction.format_error(msg)
+  defp format_error({:http_streaming_failed, reason}), do: format_error(reason)
+  defp format_error({:provider_build_failed, reason}), do: format_error(reason)
+  defp format_error({:exit, reason}), do: format_error(reason)
+  defp format_error({:throw, reason}), do: format_error(reason)
+  defp format_error(reason) when is_binary(reason), do: humanize_provider_error(reason)
+  defp format_error(%{reason: reason}) when is_binary(reason), do: humanize_provider_error(reason)
+
+  defp format_error(%{"reason" => reason}) when is_binary(reason),
+    do: humanize_provider_error(reason)
+
+  defp format_error(%{message: msg}) when is_binary(msg), do: humanize_provider_error(msg)
+  defp format_error(%{"message" => msg}) when is_binary(msg), do: humanize_provider_error(msg)
 
   defp format_error(:invalid_format) do
     ~s|Invalid model format. Expected "provider:model" (e.g., "anthropic:claude-sonnet-4"), | <>
       "got a bare model name without a provider prefix."
   end
 
-  defp format_error(reason), do: Redaction.format_error(reason)
+  defp format_error(reason), do: reason |> Redaction.format_error() |> humanize_provider_error()
+
+  @spec humanize_provider_error(String.t()) :: String.t()
+  defp humanize_provider_error(message) when is_binary(message) do
+    message
+    |> Redaction.format_error()
+    |> humanize_redacted_provider_error()
+  end
+
+  @spec humanize_redacted_provider_error(String.t()) :: String.t()
+  defp humanize_redacted_provider_error(message) do
+    humanize_redacted_provider_error(
+      message,
+      missing_api_key?(message),
+      raw_provider_dump?(message)
+    )
+  end
+
+  @spec humanize_redacted_provider_error(String.t(), boolean(), boolean()) :: String.t()
+  defp humanize_redacted_provider_error(message, true, _raw_dump?) do
+    provider = provider_name_from_error(message)
+    provider_label = provider_label(provider)
+    auth_hint = auth_hint_for_provider(provider)
+    "Couldn't authenticate with #{provider_label}. #{auth_hint}"
+  end
+
+  defp humanize_redacted_provider_error(_message, false, true) do
+    "Something went wrong talking to the model provider. Check the Messages panel for details."
+  end
+
+  defp humanize_redacted_provider_error(message, false, false), do: message
+
+  @spec missing_api_key?(String.t()) :: boolean()
+  defp missing_api_key?(message) do
+    String.contains?(message, ["api_key", "API_KEY", "API key", "provider_build_failed"])
+  end
+
+  @spec raw_provider_dump?(String.t()) :: boolean()
+  defp raw_provider_dump?(message) do
+    String.contains?(message, ["%ReqLLM.", "Splode", "bread_crumbs", "stacktrace:"])
+  end
+
+  @spec provider_name_from_error(String.t()) :: String.t()
+  defp provider_name_from_error(message) do
+    provider_name_from_error(
+      String.contains?(message, ["Anthropic", "ANTHROPIC", "anthropic"]),
+      String.contains?(message, ["OpenAI", "OPENAI", "openai"]),
+      String.contains?(message, ["Google", "GOOGLE", "google"])
+    )
+  end
+
+  @spec provider_name_from_error(boolean(), boolean(), boolean()) :: String.t()
+  defp provider_name_from_error(true, _openai?, _google?), do: "anthropic"
+  defp provider_name_from_error(false, true, _google?), do: "openai"
+  defp provider_name_from_error(false, false, true), do: "google"
+  defp provider_name_from_error(false, false, false), do: "provider"
+
+  @spec provider_label(String.t()) :: String.t()
+  defp provider_label("anthropic"), do: "Anthropic"
+  defp provider_label("openai"), do: "OpenAI"
+  defp provider_label("google"), do: "Google"
+  defp provider_label(_provider), do: "the model provider"
+
+  @spec auth_hint_for_provider(String.t()) :: String.t()
+  defp auth_hint_for_provider("openai") do
+    "Run /auth openai <key>, sign in with /login for Codex models, or pick another configured model with /model."
+  end
+
+  defp auth_hint_for_provider("anthropic") do
+    "Run /auth anthropic <key> or pick another configured model with /model."
+  end
+
+  defp auth_hint_for_provider("google") do
+    "Run /auth google <key> or pick another configured model with /model."
+  end
+
+  defp auth_hint_for_provider(_provider) do
+    "Run /auth to add an API key, sign in with /login, or pick another configured model with /model."
+  end
 
   @spec notify(pid(), Event.t()) :: Event.t()
   defp notify(subscriber, event) do

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -3184,14 +3184,17 @@ defmodule MingaAgent.Providers.Native do
     emit_error_and_end(provider_pid, %Event.Error{message: message})
   end
 
-  # Reports an error that occurred inside the agent loop: logs the raw detail
-  # for the Messages panel, emits Error + AgentEnd to the UI, and returns a
-  # `{:reported, reason}` sentinel. The Task-completion handler matches that
-  # sentinel and skips re-emitting, so a single failure surfaces exactly once
-  # in the transcript instead of twice.
+  # Reports an error that occurred inside the agent loop: logs a redacted
+  # diagnostic detail for Messages/logs, emits a friendly Error + AgentEnd to
+  # the UI, and returns a `{:reported, reason}` sentinel. The Task-completion
+  # handler matches that sentinel and skips re-emitting, so a single failure
+  # surfaces exactly once in the transcript instead of twice.
   @spec reported_error(pid(), String.t(), term(), String.t()) :: {:error, {:reported, term()}}
   defp reported_error(provider_pid, message, reason, model) do
     event = error_event(message, reason, model)
+    detail = Redaction.format_error(reason)
+
+    Minga.Log.error(:agent, "[Agent.Native] agent loop detail: #{detail}")
     Minga.Log.error(:agent, "[Agent.Native] agent loop error: #{event.message}")
     emit_error_and_end(provider_pid, event)
     {:error, {:reported, reason}}
@@ -3223,10 +3226,17 @@ defmodule MingaAgent.Providers.Native do
     "Couldn't reach the model provider. Check your network connection, then try again."
   end
 
-  defp error_event_message(:provider_error, message, _provider), do: message
+  defp error_event_message(:provider_error, _message, _provider) do
+    "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."
+  end
+
   defp error_event_message(:invalid_model, message, _provider), do: message
   defp error_event_message(:tool_error, message, _provider), do: message
-  defp error_event_message(:internal_error, message, _provider), do: message
+
+  defp error_event_message(:internal_error, _message, _provider) do
+    "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."
+  end
+
   defp error_event_message(:unknown, message, _provider), do: message
 
   @spec classify_error_reason(term()) :: Event.Error.kind()
@@ -3254,23 +3264,25 @@ defmodule MingaAgent.Providers.Native do
   # Internal provider/session contracts use `Event.Error.kind` instead.
   @spec classify_legacy_error_message(String.t()) :: Event.Error.kind()
   defp classify_legacy_error_message(message) do
+    normalized = String.downcase(message)
+
     classify_legacy_error_checks([
-      {:auth_failed, String.match?(message, ~r/\b(401|403)\b/)},
-      {:rate_limited, String.match?(message, ~r/\b429\b/)},
       {:auth_failed,
-       String.contains?(message, [
-         "provider_build_failed",
-         "api_key",
-         "API_KEY",
-         "Couldn't authenticate"
-       ])},
+       String.match?(normalized, ~r/\b(401|403)\b/) or
+         String.contains?(normalized, [
+           "unauthorized",
+           "invalid_api_key",
+           "api key",
+           "api_key",
+           "provider_build_failed",
+           "failed to build",
+           "couldn't authenticate"
+         ])},
+      {:rate_limited,
+       String.match?(normalized, ~r/\b429\b/) or
+         String.contains?(normalized, ["api rate limited", "rate limited", "rate limit"])},
       {:unreachable,
-       String.contains?(message, [
-         "http_streaming_failed",
-         "econnrefused",
-         "nxdomain",
-         "timed out"
-       ])}
+       String.contains?(normalized, ["timeout", "timed out", "nxdomain", "econnrefused"])}
     ])
   end
 
@@ -3406,10 +3418,15 @@ defmodule MingaAgent.Providers.Native do
   @spec provider_label(String.t()) :: String.t()
   defp provider_label("anthropic"), do: "Anthropic"
   defp provider_label("openai"), do: "OpenAI"
+  defp provider_label("openai_codex"), do: "OpenAI Codex"
   defp provider_label("google"), do: "Google"
   defp provider_label(_provider), do: "the model provider"
 
   @spec auth_hint_for_provider(String.t()) :: String.t()
+  defp auth_hint_for_provider("openai_codex") do
+    "Sign in with /login for Codex models, or pick another configured model with /model."
+  end
+
   defp auth_hint_for_provider("openai") do
     "Run /auth openai <key>, sign in with /login for Codex models, or pick another configured model with /model."
   end

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -2974,16 +2974,15 @@ defmodule MingaAgent.Session do
 
   defp humanize_error_kind(:invalid_model, message, _provider), do: message
 
-  defp humanize_error_kind(:provider_error, message, _provider) do
-    if raw_struct_dump?(message) do
-      "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."
-    else
-      message
-    end
+  defp humanize_error_kind(:provider_error, _message, _provider) do
+    "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."
   end
 
   defp humanize_error_kind(:tool_error, message, _provider), do: message
-  defp humanize_error_kind(:internal_error, message, _provider), do: message
+
+  defp humanize_error_kind(:internal_error, _message, _provider) do
+    "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."
+  end
 
   @type legacy_error_kind ::
           :auth_failed | :rate_limited | :unreachable | :raw_dump | :passthrough
@@ -3065,6 +3064,7 @@ defmodule MingaAgent.Session do
 
   @spec provider_label(String.t()) :: String.t()
   defp provider_label("provider"), do: "the model provider"
+  defp provider_label("openai_codex"), do: "OpenAI Codex"
 
   defp provider_label(provider) do
     provider
@@ -3074,6 +3074,10 @@ defmodule MingaAgent.Session do
   end
 
   @spec auth_hint(String.t()) :: String.t()
+  defp auth_hint("openai_codex") do
+    "Sign in with /login for Codex models, or pick another configured model with /model."
+  end
+
   defp auth_hint("provider"),
     do: "Run /auth to check credentials, or pick another configured model with /model."
 

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1721,16 +1721,24 @@ defmodule MingaAgent.Session do
     state
   end
 
-  defp handle_provider_event(%Event.Error{message: message}, state) do
+  defp handle_provider_event(%Event.Error{} = event, state) do
     # Show one human-readable line in the transcript. The raw error is already
     # logged to the Messages panel by the provider, so we don't repeat it here.
-    friendly = humanize_error(message)
+    friendly = humanize_error(event, state)
     notify(state, :error, friendly)
     state = set_error_status(state)
     state = %{state | error_message: friendly}
-    state = append_system_message(state, friendly, :error)
+    state = append_error_message_once(state, friendly)
     broadcast(state, {:error, friendly})
     state
+  end
+
+  @spec append_error_message_once(state(), String.t()) :: state()
+  defp append_error_message_once(%{messages: messages} = state, message) do
+    case List.last(messages) do
+      {:system, ^message, :error} -> state
+      _other -> append_system_message(state, message, :error)
+    end
   end
 
   @spec request_tool_approval(Event.ToolApproval.t(), state()) :: state()
@@ -2940,35 +2948,71 @@ defmodule MingaAgent.Session do
     """
   end
 
-  # Turns a raw provider error (the ugly ReqLLM struct dump) into one human
-  # line for the transcript. The full detail is still logged to the Messages
-  # panel by the provider. Already human-readable messages (MCP notices, hook
-  # vetoes, turn/cost limits) are passed through unchanged.
-  @spec humanize_error(String.t()) :: String.t()
-  defp humanize_error(message) when is_binary(message) do
-    humanize_error_kind(classify_error(message), message)
+  # Turns provider errors into one human line for the transcript. New provider
+  # paths pass structured `Event.Error.kind` and `provider` fields, so the
+  # session does not infer meaning from text. The string classifier below is
+  # only a compatibility fallback for external providers or old persisted events
+  # that still send `kind: :unknown`.
+  @spec humanize_error(Event.Error.t(), state()) :: String.t()
+  defp humanize_error(%Event.Error{kind: :unknown, message: message, provider: provider}, state) do
+    humanize_legacy_error(message, provider || provider_slug(state))
   end
 
-  defp humanize_error(message), do: humanize_error(inspect(message))
+  defp humanize_error(%Event.Error{kind: kind, message: message, provider: provider}, state) do
+    humanize_error_kind(kind, message, provider || provider_slug(state))
+  end
 
-  @type error_kind ::
-          :rejected_key | :rate_limited | :auth_failed | :unreachable | :raw_dump | :passthrough
+  @spec humanize_error_kind(Event.Error.kind(), String.t(), String.t()) :: String.t()
+  defp humanize_error_kind(:auth_failed, _message, provider),
+    do: "Couldn't authenticate with #{provider_label(provider)}. #{auth_hint(provider)}"
 
-  @spec classify_error(String.t()) :: error_kind()
-  defp classify_error(message) do
-    classify_error_checks([
-      {:rejected_key,
-       String.match?(message, ~r/\b401\b/) or
-         String.contains?(message, ["unauthorized", "Unauthorized", "invalid_api_key"])},
+  defp humanize_error_kind(:rate_limited, _message, _provider),
+    do: "The model provider is rate limiting requests. Wait a moment, then try again."
+
+  defp humanize_error_kind(:unreachable, _message, _provider),
+    do: "Couldn't reach the model provider. Check your network connection, then try again."
+
+  defp humanize_error_kind(:invalid_model, message, _provider), do: message
+
+  defp humanize_error_kind(:provider_error, message, _provider) do
+    if raw_struct_dump?(message) do
+      "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."
+    else
+      message
+    end
+  end
+
+  defp humanize_error_kind(:tool_error, message, _provider), do: message
+  defp humanize_error_kind(:internal_error, message, _provider), do: message
+
+  @type legacy_error_kind ::
+          :auth_failed | :rate_limited | :unreachable | :raw_dump | :passthrough
+
+  @spec humanize_legacy_error(String.t(), String.t()) :: String.t()
+  defp humanize_legacy_error(message, provider) when is_binary(message) do
+    humanize_legacy_error_kind(classify_legacy_error(message), message, provider)
+  end
+
+  defp humanize_legacy_error(message, provider),
+    do: humanize_legacy_error(inspect(message), provider)
+
+  @spec classify_legacy_error(String.t()) :: legacy_error_kind()
+  defp classify_legacy_error(message) do
+    classify_legacy_error_checks([
+      {:auth_failed,
+       String.match?(message, ~r/\b(401|403)\b/) or
+         String.contains?(message, [
+           "unauthorized",
+           "Unauthorized",
+           "invalid_api_key",
+           "api_key",
+           "API_KEY",
+           "provider_build_failed",
+           "Failed to build",
+           "Couldn't authenticate"
+         ])},
       {:rate_limited,
        String.match?(message, ~r/\b429\b/) or String.contains?(message, "rate limit")},
-      {:auth_failed,
-       String.contains?(message, [
-         "api_key",
-         "API_KEY",
-         "provider_build_failed",
-         "Failed to build"
-       ])},
       {:unreachable,
        String.contains?(message, [
          "http_streaming_failed",
@@ -2980,30 +3024,61 @@ defmodule MingaAgent.Session do
     ])
   end
 
-  @spec classify_error_checks([{error_kind(), boolean()}]) :: error_kind()
-  defp classify_error_checks([{kind, true} | _rest]), do: kind
-  defp classify_error_checks([{_kind, false} | rest]), do: classify_error_checks(rest)
-  defp classify_error_checks([]), do: :passthrough
+  @spec classify_legacy_error_checks([{legacy_error_kind(), boolean()}]) :: legacy_error_kind()
+  defp classify_legacy_error_checks([{kind, true} | _rest]), do: kind
 
-  @spec humanize_error_kind(error_kind(), String.t()) :: String.t()
-  defp humanize_error_kind(:rejected_key, _message),
+  defp classify_legacy_error_checks([{_kind, false} | rest]),
+    do: classify_legacy_error_checks(rest)
+
+  defp classify_legacy_error_checks([]), do: :passthrough
+
+  @spec humanize_legacy_error_kind(legacy_error_kind(), String.t(), String.t()) :: String.t()
+  defp humanize_legacy_error_kind(:auth_failed, _message, provider),
+    do: "Couldn't authenticate with #{provider_label(provider)}. #{auth_hint(provider)}"
+
+  defp humanize_legacy_error_kind(:rate_limited, _message, _provider),
+    do: "The model provider is rate limiting requests. Wait a moment, then try again."
+
+  defp humanize_legacy_error_kind(:unreachable, _message, _provider),
+    do: "Couldn't reach the model provider. Check your network connection, then try again."
+
+  defp humanize_legacy_error_kind(:raw_dump, _message, _provider),
     do:
-      "The provider rejected your API key. Update it with /auth <provider> <key>, then try again."
+      "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."
 
-  defp humanize_error_kind(:rate_limited, _message),
-    do: "Rate limited by the provider. Wait a moment and try again."
+  defp humanize_legacy_error_kind(:passthrough, message, _provider), do: message
 
-  defp humanize_error_kind(:auth_failed, _message),
-    do:
-      "Couldn't authenticate with the model provider. Check your API key with /auth, then try again."
+  @spec provider_slug(state()) :: String.t()
+  defp provider_slug(%{provider_name: provider_name})
+       when is_binary(provider_name) and provider_name != "" do
+    provider_name
+  end
 
-  defp humanize_error_kind(:unreachable, _message),
-    do: "Couldn't reach the model provider. Check your network connection and try again."
+  defp provider_slug(%{model_name: model_name}) when is_binary(model_name) do
+    case String.split(model_name, ":", parts: 2) do
+      [provider | _rest] when provider != "" -> provider
+      _other -> "provider"
+    end
+  end
 
-  defp humanize_error_kind(:raw_dump, _message),
-    do: "Something went wrong talking to the model provider. Open the Messages panel for details."
+  defp provider_slug(_state), do: "provider"
 
-  defp humanize_error_kind(:passthrough, message), do: message
+  @spec provider_label(String.t()) :: String.t()
+  defp provider_label("provider"), do: "the model provider"
+
+  defp provider_label(provider) do
+    provider
+    |> String.replace("_", " ")
+    |> String.split(" ", trim: true)
+    |> Enum.map_join(" ", &String.capitalize/1)
+  end
+
+  @spec auth_hint(String.t()) :: String.t()
+  defp auth_hint("provider"),
+    do: "Run /auth to check credentials, or pick another configured model with /model."
+
+  defp auth_hint(provider),
+    do: "Run /auth #{provider} <key> or pick another configured model with /model."
 
   # Detects an inspected Elixir struct/exception leaking into the message, so
   # we never show a raw `%ReqLLM.Error{...}`-style dump in the transcript.

--- a/lib/minga_editor/agent/ui_state/panel.ex
+++ b/lib/minga_editor/agent/ui_state/panel.ex
@@ -76,9 +76,26 @@ defmodule MingaEditor.Agent.UIState.Panel do
     }
   end
 
+  @doc "Refreshes stale unqualified model names to the current credential-aware default."
+  @spec ensure_configured_model(t()) :: t()
+  def ensure_configured_model(%__MODULE__{} = panel) do
+    default_model = AgentConfig.default_model()
+
+    if stale_unqualified_model?(panel.model_name, default_model) do
+      %{
+        panel
+        | provider_name: AgentConfig.extract_provider_prefix(default_model),
+          model_name: default_model
+      }
+    else
+      panel
+    end
+  end
+
   @doc "Sets whether any provider credential is configured (drives the model indicator)."
   @spec set_credentials_configured(t(), boolean()) :: t()
   def set_credentials_configured(%__MODULE__{} = panel, configured?) do
+    panel = ensure_configured_model(panel)
     %{panel | credentials_configured: configured?}
   end
 
@@ -92,6 +109,18 @@ defmodule MingaEditor.Agent.UIState.Panel do
   @spec set_model_name(t(), String.t()) :: t()
   def set_model_name(%__MODULE__{} = panel, model) when is_binary(model) do
     %{panel | model_name: model}
+  end
+
+  @spec stale_unqualified_model?(String.t(), String.t()) :: boolean()
+  defp stale_unqualified_model?(model, default_model)
+       when model in ["", "unknown"] and default_model not in ["", "unknown"] do
+    true
+  end
+
+  defp stale_unqualified_model?(model, default_model) do
+    AgentConfig.extract_provider_prefix(model) == "" and
+      AgentConfig.extract_provider_prefix(default_model) != "" and
+      model != default_model
   end
 
   @doc "Clears the active file mention completion."

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -10,6 +10,7 @@ defmodule MingaEditor.Commands.AgentSession do
   alias MingaAgent.ProjectView
   alias MingaAgent.Session
   alias Minga.Buffer
+  alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.AgentLifecycle
   alias MingaEditor.Remote.EventReplay
   alias MingaEditor.Remote.SessionClient
@@ -103,7 +104,8 @@ defmodule MingaEditor.Commands.AgentSession do
 
   @spec do_start_agent_session(state(), keyword()) :: state()
   defp do_start_agent_session(state, opts) do
-    panel = AgentAccess.panel(state)
+    panel = AgentAccess.panel(state) |> Panel.ensure_configured_model()
+    state = AgentAccess.update_panel(state, fn _panel -> panel end)
     {project_view, created_project_view?} = session_project_view(state)
 
     session_opts = [

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -11,7 +11,6 @@ defmodule MingaEditor.StatusBar.Data do
   - `{:agent, t:agent_data()}` — an agent chat window
   """
 
-  alias MingaAgent.Session
   alias Minga.Buffer
   alias Minga.Diagnostics
   alias Minga.Config.ModelineSegments
@@ -318,16 +317,7 @@ defmodule MingaEditor.StatusBar.Data do
     panel = AgentAccess.panel(state)
     session = AgentAccess.session(state)
 
-    message_count =
-      if session do
-        try do
-          length(Session.messages(session))
-        catch
-          :exit, _ -> 0
-        end
-      else
-        0
-      end
+    message_count = agent_message_count(session)
 
     model_name = if panel.model_name != "", do: panel.model_name, else: "Agent"
 
@@ -391,6 +381,19 @@ defmodule MingaEditor.StatusBar.Data do
       merge_conflict_count: merge_conflict_count(buf)
     }
   end
+
+  @spec agent_message_count(pid() | nil) :: non_neg_integer()
+  defp agent_message_count(session) when is_pid(session) do
+    case safe_session_metadata(session) do
+      %MingaAgent.SessionMetadata{turn_count: count} when is_integer(count) and count >= 0 ->
+        count
+
+      _other ->
+        0
+    end
+  end
+
+  defp agent_message_count(_session), do: 0
 
   @spec agent_status_command_content(EditorState.t() | map(), AgentState.t()) :: String.t() | nil
   defp agent_status_command_content(state, agent) do

--- a/macos/Sources/Views/WorkspaceHeaderView.swift
+++ b/macos/Sources/Views/WorkspaceHeaderView.swift
@@ -98,7 +98,17 @@ struct WorkspaceHeaderView: View {
     }
 
     private var workspaceSwitcher: some View {
-        Menu {
+        Button {
+            encoder?.sendExecuteCommand(name: "workspace_next")
+        } label: {
+            Image(systemName: "rectangle.grid.1x2")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(theme.tabInactiveFg)
+                .frame(width: 24, height: rowHeight)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
             ForEach(workspaceState.workspaces) { workspace in
                 Button {
                     encoder?.sendExecuteCommand(name: workspaceState.switchCommand(for: workspace))
@@ -107,17 +117,10 @@ struct WorkspaceHeaderView: View {
                 }
                 .accessibilityIdentifier("workspace-row-\(workspace.id)")
             }
-        } label: {
-            Image(systemName: "rectangle.grid.1x2")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(theme.tabInactiveFg)
-                .frame(width: 24, height: rowHeight)
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
         .accessibilityIdentifier("workspace-switcher")
-        .accessibilityLabel("Workspace switcher")
-        .help("Switch workspace")
+        .accessibilityLabel("Switch to next workspace")
+        .help("Switch to next workspace")
     }
 
     private func agentStatusButton(_ workspace: WorkspaceSummaryEntry) -> some View {

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -1000,6 +1000,20 @@ struct WorkspaceHeaderViewTests {
         #expect(state.switchCommand(for: manualWorkspace) == "workspace_goto_id:0")
         #expect(state.switchCommand(for: reviewWorkspace) == "workspace_goto_id:2")
     }
+
+    @Test("Switcher click advances to the next workspace")
+    @MainActor func switcherClickAdvancesWorkspace() throws {
+        let spy = SpyEncoder()
+        let sut = WorkspaceHeaderView(workspaceState: populatedState(), theme: ThemeColors(), encoder: spy)
+        let buttons = try sut.inspect().findAll(ViewType.Button.self)
+        let button = try #require(buttons.first(where: {
+            (try? $0.accessibilityLabel().string()) == "Switch to next workspace"
+        }))
+
+        try button.tap()
+
+        #expect(spy.guiActions.contains(.executeCommand(name: "workspace_next")))
+    }
 }
 
 // MARK: - AgentChatView

--- a/test/minga_agent/model_catalog_test.exs
+++ b/test/minga_agent/model_catalog_test.exs
@@ -29,6 +29,24 @@ defmodule MingaAgent.ModelCatalogTest do
       end
     end
 
+    test "model IDs are unique after catalog alias normalization" do
+      ids = ModelCatalog.available_models() |> Enum.map(& &1["id"])
+
+      assert ids == Enum.uniq(ids)
+    end
+
+    test "current model sorts first when present" do
+      models = ModelCatalog.available_models()
+
+      if models != [] do
+        current_id = List.last(models)["id"]
+        [current | _rest] = ModelCatalog.available_models(current_id)
+
+        assert current["id"] == current_id
+        assert current["current"]
+      end
+    end
+
     test "excludes deprecated and retired models" do
       models = ModelCatalog.available_models()
 

--- a/test/minga_agent/model_catalog_test.exs
+++ b/test/minga_agent/model_catalog_test.exs
@@ -35,6 +35,49 @@ defmodule MingaAgent.ModelCatalogTest do
       assert ids == Enum.uniq(ids)
     end
 
+    test "canonical codex aliases dedupe, filter, and sort deterministically" do
+      current_model = "openai_codex:openai/gpt-5.1-codex-max"
+      configured_providers = MapSet.new([:openai])
+
+      models = [
+        codex_model("gpt-5.3-codex", "GPT-5.3 Codex"),
+        codex_model("openai/gpt-5.3-codex", "OpenAI: GPT-5.3 Codex"),
+        codex_model("gpt-5.3-codex-xhigh", "GPT-5.3 Codex XHigh"),
+        codex_model("gpt-5.2-codex", "GPT-5.2 Codex"),
+        codex_model("gpt-5.1-codex-max", "GPT-5.1 Codex Max"),
+        codex_model("openai-gpt-5.1-codex-max", "OpenAI: GPT-5.1 Codex Max"),
+        codex_model("gpt-5.1-codex", "GPT-5.1 Codex"),
+        codex_model("codex-mini", "Codex Mini")
+      ]
+
+      normalized =
+        ModelCatalog.available_models_from(models, current_model, configured_providers, true)
+
+      assert Enum.map(normalized, & &1["id"]) == [
+               "openai_codex:gpt-5.1-codex-max",
+               "openai_codex:gpt-5.3-codex",
+               "openai_codex:gpt-5.2-codex",
+               "openai_codex:gpt-5.1-codex",
+               "openai_codex:codex-mini"
+             ]
+
+      assert Enum.all?(normalized, &(&1["provider"] == "openai_codex"))
+      refute Enum.any?(normalized, &String.contains?(&1["id"], "xhigh"))
+      assert hd(normalized)["current"]
+    end
+
+    test "codex models stay hidden without oauth even when openai is configured" do
+      models = [
+        codex_model("gpt-5.3-codex", "GPT-5.3 Codex"),
+        codex_model("gpt-5.1-codex-max", "GPT-5.1 Codex Max")
+      ]
+
+      normalized =
+        ModelCatalog.available_models_from(models, "", MapSet.new([:openai]), false)
+
+      assert normalized == []
+    end
+
     test "current model sorts first when present" do
       models = ModelCatalog.available_models()
 
@@ -95,5 +138,18 @@ defmodule MingaAgent.ModelCatalogTest do
         assert provider in ["anthropic", "openai", "google"]
       end
     end
+  end
+
+  defp codex_model(id, name) do
+    %{
+      id: id,
+      name: name,
+      provider: :openai,
+      deprecated: false,
+      retired: false,
+      modalities: %{output: [:text]},
+      limits: %{context: 400_000},
+      cost: %{input: 1.75, output: 14}
+    }
   end
 end

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -1,6 +1,8 @@
 defmodule MingaAgent.Providers.NativeTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.ProjectView
@@ -1293,7 +1295,10 @@ defmodule MingaAgent.Providers.NativeTest do
 
       error = Enum.find(events, &match?(%Event.Error{}, &1))
       assert error != nil
-      assert error.message =~ "API rate limited"
+      assert %Event.Error{kind: :rate_limited, provider: "anthropic"} = error
+
+      assert error.message ==
+               "The model provider is rate limiting requests. Wait a moment, then try again."
 
       agent_end = Enum.find(events, &match?(%Event.AgentEnd{}, &1))
       assert agent_end != nil
@@ -1309,8 +1314,12 @@ defmodule MingaAgent.Providers.NativeTest do
 
       assert :ok = Native.send_prompt(pid, "Hello")
 
-      assert_receive {:agent_provider_event, %Event.Error{message: msg}}, 1_000
-      assert msg =~ "boom once"
+      assert_receive {:agent_provider_event, %Event.Error{message: msg, kind: :provider_error}},
+                     1_000
+
+      assert msg ==
+               "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."
+
       assert_receive {:agent_provider_event, %Event.AgentEnd{}}, 1_000
 
       refute_receive {:agent_provider_event, %Event.Error{}}, 200
@@ -1942,15 +1951,13 @@ defmodule MingaAgent.Providers.NativeTest do
   # ── Model format validation ──────────────────────────────────────────────────
 
   describe "provider error formatting" do
-    test "missing API key provider build errors are human-readable", %{tmp_dir: tmp_dir} do
+    test "missing API key provider build errors are human-readable and log raw detail", %{
+      tmp_dir: tmp_dir
+    } do
       reason =
         {:http_streaming_failed,
          {:provider_build_failed,
-          %{
-            reason: """
-            Failed to build Anthropic stream request: %ReqLLM.Error.Invalid.Parameter{parameter: ":api_key option, config :req_llm, anthropic_api_key, or ANTHROPIC_API_KEY env var (.env via dotenv)", bread_crumbs: [], stacktrace: #Splode.Stacktrace<>, class: :invalid}
-            """
-          }}}
+          %{reason: "Failed to build Anthropic stream request: api_key=sk-testsecret123"}}}
 
       {:ok, pid} =
         start_provider(
@@ -1960,18 +1967,83 @@ defmodule MingaAgent.Providers.NativeTest do
           max_retries: 0
         )
 
+      log =
+        capture_log(fn ->
+          Native.send_prompt(pid, "hello")
+          events = collect_events(2_000)
+
+          error = Enum.find(events, &match?(%Event.Error{}, &1))
+
+          assert %Event.Error{message: message, kind: :auth_failed, provider: "anthropic"} =
+                   error
+
+          assert message ==
+                   "Couldn't authenticate with Anthropic. Run /auth anthropic <key> or pick another configured model with /model."
+
+          refute message =~ "ReqLLM"
+          refute message =~ "Splode"
+          refute message =~ "bread_crumbs"
+        end)
+
+      assert log =~ "agent loop detail:"
+      assert log =~ "[REDACTED]"
+      refute log =~ "sk-testsecret123"
+    end
+
+    test "openai codex auth failures suggest /login instead of /auth openai_codex", %{
+      tmp_dir: tmp_dir
+    } do
+      {:ok, pid} =
+        start_provider(
+          model: "openai_codex:gpt-5.5",
+          llm_client: fake_error_client("Unauthorized"),
+          tmp_dir: tmp_dir,
+          max_retries: 0
+        )
+
       Native.send_prompt(pid, "hello")
       events = collect_events(2_000)
 
       error = Enum.find(events, &match?(%Event.Error{}, &1))
-      assert %Event.Error{message: message, kind: :auth_failed, provider: "anthropic"} = error
 
-      assert message ==
-               "Couldn't authenticate with Anthropic. Run /auth anthropic <key> or pick another configured model with /model."
+      assert %Event.Error{message: message, kind: :auth_failed, provider: "openai_codex"} =
+               error
 
-      refute message =~ "ReqLLM"
-      refute message =~ "Splode"
-      refute message =~ "bread_crumbs"
+      assert message =~ "/login"
+      refute message =~ "/auth openai_codex"
+    end
+
+    test "string-only provider errors classify auth, rate limit, and network failures", %{
+      tmp_dir: tmp_dir
+    } do
+      cases = [
+        {"Unauthorized", :auth_failed},
+        {"invalid_api_key", :auth_failed},
+        {"401", :auth_failed},
+        {"403", :auth_failed},
+        {"API rate limited", :rate_limited},
+        {"rate limit", :rate_limited},
+        {"429", :rate_limited},
+        {"timeout", :unreachable},
+        {"nxdomain", :unreachable},
+        {"econnrefused", :unreachable}
+      ]
+
+      Enum.each(cases, fn {reason, kind} ->
+        {:ok, pid} =
+          start_provider(
+            model: "anthropic:claude-sonnet-4-20250514",
+            llm_client: fake_error_client(reason),
+            tmp_dir: tmp_dir,
+            max_retries: 0
+          )
+
+        Native.send_prompt(pid, "hello")
+        events = collect_events(2_000)
+
+        error = Enum.find(events, &match?(%Event.Error{}, &1))
+        assert %Event.Error{kind: ^kind} = error
+      end)
     end
   end
 

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -1941,6 +1941,40 @@ defmodule MingaAgent.Providers.NativeTest do
 
   # ── Model format validation ──────────────────────────────────────────────────
 
+  describe "provider error formatting" do
+    test "missing API key provider build errors are human-readable", %{tmp_dir: tmp_dir} do
+      reason =
+        {:http_streaming_failed,
+         {:provider_build_failed,
+          %{
+            reason: """
+            Failed to build Anthropic stream request: %ReqLLM.Error.Invalid.Parameter{parameter: ":api_key option, config :req_llm, anthropic_api_key, or ANTHROPIC_API_KEY env var (.env via dotenv)", bread_crumbs: [], stacktrace: #Splode.Stacktrace<>, class: :invalid}
+            """
+          }}}
+
+      {:ok, pid} =
+        start_provider(
+          model: "anthropic:claude-sonnet-4-20250514",
+          llm_client: fake_error_client(reason),
+          tmp_dir: tmp_dir,
+          max_retries: 0
+        )
+
+      Native.send_prompt(pid, "hello")
+      events = collect_events(2_000)
+
+      error = Enum.find(events, &match?(%Event.Error{}, &1))
+      assert %Event.Error{message: message, kind: :auth_failed, provider: "anthropic"} = error
+
+      assert message ==
+               "Couldn't authenticate with Anthropic. Run /auth anthropic <key> or pick another configured model with /model."
+
+      refute message =~ "ReqLLM"
+      refute message =~ "Splode"
+      refute message =~ "bread_crumbs"
+    end
+  end
+
   describe "model format validation" do
     test "bare model name without provider prefix returns :invalid_format error", %{
       tmp_dir: tmp_dir

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -2162,34 +2162,61 @@ defmodule MingaAgent.SessionTest do
   end
 
   describe "provider error presentation" do
-    test "raw provider errors are humanized in the transcript", %{tmp_dir: dir} do
-      # A custom llm_client counts as "configured", so the prompt reaches the
-      # provider, fails, and the session must show one human line instead of
-      # the raw error string.
-      client = fn _model, _messages, _opts ->
-        {:error, "provider_build_failed: missing api_key option"}
-      end
+    test "openai codex auth failures suggest /login instead of /auth openai_codex" do
+      session = start_subscribed_session()
 
-      session =
-        start_subscribed_session(Native,
-          project_root: dir,
-          llm_client: client,
-          max_retries: 0,
-          config: agent_config(tool_approval: :none)
-        )
-
-      assert :ok = Session.send_prompt(session, "hey")
-
-      assert_receive {:agent_event, ^session, {:error, message}}, @event_timeout
-      refute message =~ "provider_build_failed"
-
-      assert message ==
-               "Couldn't authenticate with Anthropic. Run /auth anthropic <key> or pick another configured model with /model."
+      send_provider_event(
+        session,
+        %Event.Error{
+          kind: :auth_failed,
+          provider: "openai_codex",
+          message: "missing oauth"
+        }
+      )
 
       assert Enum.any?(Session.messages(session), fn
-               {:system, text, :error} -> text == message
-               _ -> false
+               {:system, text, :error} ->
+                 text =~ "/login" and not String.contains?(text, "/auth openai_codex")
+
+               _ ->
+                 false
              end)
+    end
+
+    test "structured provider errors render friendly transcript copy" do
+      cases = [
+        {%Event.Error{kind: :rate_limited, provider: "anthropic", message: "rate limited"},
+         "The model provider is rate limiting requests. Wait a moment, then try again."},
+        {%Event.Error{kind: :unreachable, provider: "anthropic", message: "nxdomain"},
+         "Couldn't reach the model provider. Check your network connection, then try again."},
+        {%Event.Error{kind: :provider_error, provider: "anthropic", message: "boom"},
+         "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."}
+      ]
+
+      for {event, expected} <- cases do
+        session = start_subscribed_session()
+        send_provider_event(session, event)
+
+        assert Enum.any?(Session.messages(session), fn
+                 {:system, text, :error} -> text == expected
+                 _ -> false
+               end)
+      end
+    end
+
+    test "repeated structured provider errors append one transcript row" do
+      session = start_subscribed_session()
+      event = %Event.Error{kind: :rate_limited, provider: "anthropic", message: "rate limited"}
+
+      send_provider_event(session, event)
+      send_provider_event(session, event)
+
+      expected = "The model provider is rate limiting requests. Wait a moment, then try again."
+
+      assert Enum.count(Session.messages(session), fn
+               {:system, text, :error} -> text == expected
+               _ -> false
+             end) == 1
     end
   end
 end

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -1614,6 +1614,19 @@ defmodule MingaAgent.SessionTest do
       assert Session.list_tool_trust(session) == %{}
     end
 
+    test "duplicate provider errors are not appended twice" do
+      session = start_subscribed_session()
+
+      send_provider_event(session, %Event.Error{message: "boom"})
+      send_provider_event(session, %Event.Error{message: "boom"})
+
+      errors =
+        Session.messages(session)
+        |> Enum.filter(&match?({:system, "boom", :error}, &1))
+
+      assert length(errors) == 1
+    end
+
     test "revoke_tool_trust removes one or all entries" do
       session = start_subscribed_session()
       assert :ok = Session.set_tool_trust(session, "shell", :session)
@@ -2169,7 +2182,9 @@ defmodule MingaAgent.SessionTest do
 
       assert_receive {:agent_event, ^session, {:error, message}}, @event_timeout
       refute message =~ "provider_build_failed"
-      assert message =~ "API key"
+
+      assert message ==
+               "Couldn't authenticate with Anthropic. Run /auth anthropic <key> or pick another configured model with /model."
 
       assert Enum.any?(Session.messages(session), fn
                {:system, text, :error} -> text == message

--- a/test/minga_editor/status_bar/data_test.exs
+++ b/test/minga_editor/status_bar/data_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.StatusBar.DataTest do
   alias Minga.Config.ModelineSegments
   alias Minga.Config.Options
   alias Minga.Mode.VisualState
+  alias MingaAgent.SessionMetadata
   alias MingaAgent.Subagent.Handle
   alias MingaEditor.StatusBar.Data
   alias MingaEditor.State, as: EditorState
@@ -16,10 +17,37 @@ defmodule MingaEditor.StatusBar.DataTest do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Windows
+  alias MingaEditor.State.Workspace, as: WorkspaceModel
   alias MingaEditor.Viewport
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
   alias MingaEditor.Session.State, as: SessionState
+
+  defmodule MetadataSession do
+    use GenServer
+
+    @spec start_link(keyword()) :: GenServer.on_start()
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl GenServer
+    def init(opts), do: {:ok, Map.new(opts)}
+
+    @impl GenServer
+    def handle_call(:metadata, _from, state) do
+      now = DateTime.utc_now()
+
+      metadata = %SessionMetadata{
+        id: "test-session",
+        model_name: "openai_codex:gpt-5-codex",
+        created_at: now,
+        last_message_at: now,
+        message_count: Map.fetch!(state, :message_count),
+        turn_count: Map.fetch!(state, :turn_count)
+      }
+
+      {:reply, metadata, state}
+    end
+  end
 
   test "from_state leaves GUI modeline segments detached by default" do
     state = state_with_tab_bar(TabBar.new(Tab.new_file(1, "main.ex")))
@@ -96,6 +124,27 @@ defmodule MingaEditor.StatusBar.DataTest do
 
     assert data.background_subagent_count == 1
     assert data.active_background_subagent_label == "session-2: tests"
+  end
+
+  test "agent status message count uses user turns instead of raw transcript entries" do
+    {:ok, session} = MetadataSession.start_link(message_count: 4, turn_count: 1)
+    agent_buffer = start_buffer("", :markdown)
+
+    tb = TabBar.new(Tab.new_file(1, "main.ex"))
+    {tb, agent_tab} = TabBar.add(tb, :agent, "Agent")
+
+    tb =
+      tb
+      |> TabBar.switch_to(agent_tab.id)
+      |> TabBar.update_tab(agent_tab.id, &Tab.set_session(&1, session))
+
+    workspace_id = TabBar.active_workspace_id(tb)
+    tb = TabBar.update_workspace(tb, workspace_id, &WorkspaceModel.set_session(&1, session))
+
+    state = state_with_agent_window(agent_buffer, tb)
+
+    assert {:agent, data} = Data.from_state(state)
+    assert data.message_count == 1
   end
 
   test "threads active_tool_name from state into modeline data and clears it on status changes" do
@@ -215,6 +264,23 @@ defmodule MingaEditor.StatusBar.DataTest do
     %EditorState{
       port_manager: self(),
       workspace: %SessionState{viewport: Viewport.new(24, 80)},
+      shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: tab_bar}
+    }
+  end
+
+  defp state_with_agent_window(agent_buffer, tab_bar) do
+    %EditorState{
+      port_manager: self(),
+      workspace: %SessionState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{list: [agent_buffer], active_index: 0, active: agent_buffer},
+        windows: %Windows{
+          tree: WindowTree.new(1),
+          map: %{1 => Window.new_agent_chat(1, agent_buffer, 24, 80)},
+          active: 1,
+          next_id: 2
+        }
+      },
       shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: tab_bar}
     }
   end


### PR DESCRIPTION
# TL;DR
Agent UX is cleaner when model/auth failures happen: the chat pane shows actionable errors, duplicate provider failures collapse to one transcript row, the status bar counts user turns, and the model picker no longer shows duplicate or reasoning-level alias rows. The macOS workspace switcher beside the header label now advances workspaces on click while keeping the full workspace list in the context menu.

## Context
This PR fixes several rough edges found while using the native agent UI: the Files/Agent workspace switcher was not behaving like a clickable return affordance, provider errors leaked raw ReqLLM/Splode dumps into chat, one failed prompt could produce repeated error rows and an inflated message count, stale bare model names could survive in panel state, and the model picker exposed duplicated LLMDB aliases.

## Changes
- Makes the macOS workspace header switcher a normal click target that sends `workspace_next`, with the full workspace list still available from the context menu.
- Adds structured `Event.Error` metadata (`kind` and `provider`) so provider/session error rendering does not rely on parsing internal strings.
- Formats provider auth, rate-limit, network, and raw-dump failures into chat-friendly messages with concrete recovery actions.
- Dedupes adjacent identical provider errors before appending transcript rows.
- Changes the agent status bar count to use user turns instead of raw transcript entries.
- Self-heals stale bare model names in agent panel state to the configured default model before session startup.
- Normalizes the model catalog for pickers: official OpenAI Codex OAuth rows only, canonical ids, duplicate removal, current-model-first sorting, and no reasoning-level aliases like `xhigh` as separate models.

## Verification
- `mix test.debug test/minga_agent/model_catalog_test.exs test/minga_agent/session_test.exs:2165 test/minga_agent/session_test.exs:1617 test/minga_agent/providers/native_test.exs:1945 test/minga_editor/status_bar/data_test.exs test/minga_editor/state/event_routing_test.exs:147`
- `mix compile --warnings-as-errors`
- `mix swift.build`
- `xcodebuild test -project Minga.xcodeproj -scheme Minga -destination 'platform=macOS' -only-testing:MingaTests/WorkspaceHeaderViewTests`
- `git diff --check`

## Notes
The final reviewer subagent was attempted twice, but both runs timed out without a recoverable status. Local validation above passed before commit.
