### PR TITLE
fix(macos): default app launch cwd to home

### DIFF
--- a/macos/Sources/BEAMProcessManager.swift
+++ b/macos/Sources/BEAMProcessManager.swift
@@ -95,6 +95,54 @@ final class BEAMProcessManager {
         return beamArgs
     }
 
+    /// Returns the working directory the embedded BEAM should start in.
+    ///
+    /// Finder, Spotlight, and Dock launches commonly inherit `/` as their cwd.
+    /// That is a poor default project root, so bundle launches fall back to HOME
+    /// when the inherited cwd is a launch-services placeholder rather than a user directory.
+    static func defaultWorkingDirectoryURL(
+        currentDirectoryPath: String = FileManager.default.currentDirectoryPath,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundleURL: URL? = Bundle.main.bundleURL,
+        fileExists: @escaping (String) -> Bool = { path in
+            var isDirectory: ObjCBool = false
+            return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+        }
+    ) -> URL {
+        let currentURL = URL(fileURLWithPath: currentDirectoryPath).standardizedFileURL
+
+        guard shouldUseHomeWorkingDirectory(currentDirectoryPath: currentDirectoryPath, environment: environment, bundleURL: bundleURL),
+              let homePath = environment["HOME"],
+              !homePath.isEmpty,
+              fileExists(homePath)
+        else {
+            return currentURL
+        }
+
+        return URL(fileURLWithPath: homePath).standardizedFileURL
+    }
+
+    private static func shouldUseHomeWorkingDirectory(
+        currentDirectoryPath: String,
+        environment: [String: String],
+        bundleURL: URL?
+    ) -> Bool {
+        guard environment["TERM"] == nil || environment["TERM"]?.isEmpty == true else {
+            return false
+        }
+
+        let currentPath = URL(fileURLWithPath: currentDirectoryPath).standardizedFileURL.path
+
+        if currentPath == "/" || currentPath == "/Applications" || currentPath == "/System/Applications" {
+            return true
+        }
+
+        guard let bundleURL else { return false }
+
+        let bundlePath = bundleURL.standardizedFileURL.path
+        return currentPath == bundlePath || currentPath.hasPrefix(bundlePath + "/")
+    }
+
     /// Spawns the BEAM release as a child process with piped stdin/stdout.
     func start() {
         guard let execURL = Self.beamExecutableURL() else {
@@ -122,6 +170,10 @@ final class BEAMProcessManager {
         // Tell the BEAM to use connected mode (don't spawn a GUI).
         var env = ProcessInfo.processInfo.environment
         env["MINGA_PORT_MODE"] = "connected"
+
+        let workingDirectoryURL = Self.defaultWorkingDirectoryURL(environment: env)
+        proc.currentDirectoryURL = workingDirectoryURL
+        env["PWD"] = workingDirectoryURL.path
 
         if launchArguments.contains("--safe") || launchArguments.contains("-Q") {
             env["MINGA_SAFE_MODE"] = "1"

--- a/macos/Tests/MingaTests/BEAMProcessManagerTests.swift
+++ b/macos/Tests/MingaTests/BEAMProcessManagerTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @Suite("BEAMProcessManager Launch Arguments")
@@ -27,5 +28,109 @@ struct BEAMProcessManagerLaunchArgumentsTests {
             "--editor",
             "--no-context"
         ])
+    }
+
+    @Test("uses HOME when launch services provides root as cwd")
+    @MainActor func usesHomeForRootWorkingDirectory() {
+        let workingDirectory = BEAMProcessManager.defaultWorkingDirectoryURL(
+            currentDirectoryPath: "/",
+            environment: ["HOME": "/Users/alice"],
+            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app"),
+            fileExists: { path in path == "/Users/alice" }
+        )
+
+        #expect(workingDirectory.path == "/Users/alice")
+    }
+
+    @Test("uses HOME when cwd is the Applications folder")
+    @MainActor func usesHomeForApplicationsWorkingDirectory() {
+        let workingDirectory = BEAMProcessManager.defaultWorkingDirectoryURL(
+            currentDirectoryPath: "/Applications",
+            environment: ["HOME": "/Users/alice"],
+            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app"),
+            fileExists: { path in path == "/Users/alice" }
+        )
+
+        #expect(workingDirectory.path == "/Users/alice")
+    }
+
+    @Test("uses HOME when cwd is System Applications")
+    @MainActor func usesHomeForSystemApplicationsWorkingDirectory() {
+        let workingDirectory = BEAMProcessManager.defaultWorkingDirectoryURL(
+            currentDirectoryPath: "/System/Applications",
+            environment: ["HOME": "/Users/alice"],
+            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app"),
+            fileExists: { path in path == "/Users/alice" }
+        )
+
+        #expect(workingDirectory.path == "/Users/alice")
+    }
+
+    @Test("uses HOME when cwd is inside the app bundle")
+    @MainActor func usesHomeForBundleWorkingDirectory() {
+        let workingDirectory = BEAMProcessManager.defaultWorkingDirectoryURL(
+            currentDirectoryPath: "/Applications/Minga.app/Contents/MacOS",
+            environment: ["HOME": "/Users/alice"],
+            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app"),
+            fileExists: { path in path == "/Users/alice" }
+        )
+
+        #expect(workingDirectory.path == "/Users/alice")
+    }
+
+    @Test("keeps a real terminal cwd")
+    @MainActor func keepsRealTerminalWorkingDirectory() {
+        let workingDirectory = BEAMProcessManager.defaultWorkingDirectoryURL(
+            currentDirectoryPath: "/Users/alice/code/minga",
+            environment: ["HOME": "/Users/alice"],
+            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app")
+        )
+
+        #expect(workingDirectory.path == "/Users/alice/code/minga")
+    }
+
+    @Test("keeps /Applications for terminal launches")
+    @MainActor func keepsApplicationsForTerminalLaunches() {
+        let workingDirectory = BEAMProcessManager.defaultWorkingDirectoryURL(
+            currentDirectoryPath: "/Applications",
+            environment: ["HOME": "/Users/alice", "TERM": "xterm-256color"],
+            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app")
+        )
+
+        #expect(workingDirectory.path == "/Applications")
+    }
+
+    @Test("keeps cwd when HOME is missing")
+    @MainActor func keepsCurrentDirectoryWhenHomeIsMissing() {
+        let workingDirectory = BEAMProcessManager.defaultWorkingDirectoryURL(
+            currentDirectoryPath: "/Applications",
+            environment: [:],
+            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app")
+        )
+
+        #expect(workingDirectory.path == "/Applications")
+    }
+
+    @Test("keeps cwd when HOME is empty")
+    @MainActor func keepsCurrentDirectoryWhenHomeIsEmpty() {
+        let workingDirectory = BEAMProcessManager.defaultWorkingDirectoryURL(
+            currentDirectoryPath: "/Applications",
+            environment: ["HOME": ""],
+            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app")
+        )
+
+        #expect(workingDirectory.path == "/Applications")
+    }
+
+    @Test("keeps cwd when HOME is not an existing directory")
+    @MainActor func keepsCurrentDirectoryWhenHomeIsInvalid() {
+        let workingDirectory = BEAMProcessManager.defaultWorkingDirectoryURL(
+            currentDirectoryPath: "/Applications",
+            environment: ["HOME": "/Users/alice"],
+            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app"),
+            fileExists: { path in path == "/Applications" }
+        )
+
+        #expect(workingDirectory.path == "/Applications")
     }
 }


### PR DESCRIPTION
# TL;DR
Minga.app now starts the embedded BEAM process in `$HOME` for Finder, Spotlight, and Dock-style launches instead of inheriting `/` or `/Applications` as the project root. Direct terminal-style launches still preserve their inherited cwd.

## Context
Launching a macOS app through Launch Services can give the process a placeholder working directory such as `/`. Minga used that cwd to infer the startup project root, which made the app open at filesystem root instead of somewhere useful.

## Changes
- Added a small cwd selection helper in `BEAMProcessManager` for bundled app launches.
- Falls back to `$HOME` when the inherited cwd is `/`, `/Applications`, `/System/Applications`, or inside `Minga.app`.
- Preserves terminal-style launches when `TERM` is present, so direct launches from a real shell cwd keep working.
- Validates `$HOME` as an existing directory before assigning it to `Process.currentDirectoryURL`.
- Mirrors the selected cwd into `PWD` for the BEAM child environment.
- Added focused Swift coverage for placeholder cwd fallback, terminal cwd preservation, bundle cwd fallback, and missing/empty/invalid `$HOME`.

## Verification
- `mix swift.build` passed.
- `xcodebuild -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS' -only-testing:MingaTests/BEAMProcessManagerLaunchArgumentsTests test` passed, 10 tests.
- `git diff --check` passed.
- Parent-orchestrated review loop ran 2 rounds with `prtk-code-reviewer`, `prtk-test-analyzer`, and `swift-expert`, then final `reviewer` gate passed.

## Acceptance Criteria Addressed
- Minga.app launches no longer default the embedded BEAM cwd to `/` or `/Applications` for Launch Services-style app starts. ✅
- Real terminal cwd is preserved for terminal-style launches. ✅
- Invalid `$HOME` does not cause an invalid process cwd to be assigned. ✅
