### PR TITLE
feat(tui): add agent thinking controls

### DIFF
--- a/go/tui/internal/protocol/events.go
+++ b/go/tui/internal/protocol/events.go
@@ -168,6 +168,10 @@ func EncodeGUIExecuteCommand(command string) []byte {
 	return append(out, payload...)
 }
 
+func EncodeGUIAgentToolToggle(index uint16) []byte {
+	return []byte{generated.OPGuiAction, generated.GUIActionAgentToolToggle, byte(index >> 8), byte(index)}
+}
+
 // EncodeGUIBreadcrumbClick encodes a breadcrumb_click action. Wire format:
 // <gui_action, 0x06, segment_index:u8>. The GUI sends the clicked segment's
 // zero-based index (BreadcrumbBar.swift:51).

--- a/go/tui/internal/protocol/events_test.go
+++ b/go/tui/internal/protocol/events_test.go
@@ -57,6 +57,14 @@ func TestEncodeGUIExecuteCommand(t *testing.T) {
 	}
 }
 
+func TestEncodeGUIAgentToolToggle(t *testing.T) {
+	got := EncodeGUIAgentToolToggle(0x0102)
+	want := []byte{generated.OPGuiAction, generated.GUIActionAgentToolToggle, 0x01, 0x02}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("agent tool toggle packet = %v, want %v", got, want)
+	}
+}
+
 func TestEncodeGUIBreadcrumbClick(t *testing.T) {
 	got := EncodeGUIBreadcrumbClick(3)
 	want := []byte{generated.OPGuiAction, generated.GUIActionBreadcrumbClick, 3}

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -21,6 +21,11 @@ const (
 	agentKindApprovalTool byte = 0x09
 )
 
+const (
+	agentThinkingCollapsedLines = 1
+	agentThinkingExpandedLines  = 5
+)
+
 func (m Model) renderAgentChatPanel(chat protocol.AgentChat) []string {
 	return m.renderAgentChatPanelWithLimit(chat, max(m.width, 1), m.agentPanelHeight())
 }
@@ -540,11 +545,19 @@ func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width i
 	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
 	header := "  " + markerStyle.Render(marker) + labelStyle.Render(" Thinking "+state)
 	lines := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
-	for _, bodyLine := range compactTextLines(text, max(width-8, 8), 1) {
+	bodyLines := agentThinkingBodyLines(msg.Collapsed)
+	for _, bodyLine := range compactTextLines(text, max(width-8, 8), bodyLines) {
 		line := bodyStyle.Render("    " + firstCompactLine(bodyLine, max(width-6, 8)))
 		lines = append(lines, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
 	}
 	return lines
+}
+
+func agentThinkingBodyLines(collapsed bool) int {
+	if collapsed {
+		return agentThinkingCollapsedLines
+	}
+	return agentThinkingExpandedLines
 }
 
 func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) []string {

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -210,6 +210,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.toggleHUD(msg) {
 			break
 		}
+		if m.handleAgentChatShortcut(msg) {
+			break
+		}
 		// Stamp the latency correlation sequence (ticket #2215) before
 		// encoding so the resulting frame's commit_frame resolves the sample.
 		seq := m.latency.Stamp()
@@ -788,4 +791,35 @@ func (m *Model) toggleHUD(msg tea.KeyPressMsg) bool {
 		return true
 	}
 	return false
+}
+
+func (m Model) handleAgentChatShortcut(msg tea.KeyPressMsg) bool {
+	chat, ok := m.agentChat()
+	if !ok || !chat.Visible {
+		return false
+	}
+	key := msg.Key()
+	if !key.Mod.Contains(tea.ModCtrl) || !key.Mod.Contains(tea.ModAlt) {
+		return false
+	}
+	switch key.Code {
+	case 'z', 'Z':
+		index, ok := latestThinkingMessageIndex(chat.Messages)
+		if !ok {
+			return false
+		}
+		m.send(protocol.EncodeGUIAgentToolToggle(index))
+		return true
+	default:
+		return false
+	}
+}
+
+func latestThinkingMessageIndex(messages []protocol.AgentChatMessage) (uint16, bool) {
+	for index := len(messages) - 1; index >= 0; index-- {
+		if messages[index].Kind == agentKindThinking && index <= 0xFFFF {
+			return uint16(index), true
+		}
+	}
+	return 0, false
 }

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -988,6 +988,61 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 	}
 }
 
+func TestAgentChatThinkingRendersMultipleLinesWhenExpanded(t *testing.T) {
+	model := New(80, 24, nil)
+	msg := protocol.AgentChatMessage{
+		Kind:      agentKindThinking,
+		Text:      "first line\nsecond line\nthird line\nfourth line\nfifth line\nsixth line",
+		Collapsed: false,
+	}
+
+	view := ansi.Strip(strings.Join(model.renderAgentThinkingMessage(msg, 80), "\n"))
+	for _, want := range []string{"Thinking expanded", "first line", "second line", "third line", "fourth line", "fifth line"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expanded thinking missing %q in %q", want, view)
+		}
+	}
+	if strings.Contains(view, "sixth line") {
+		t.Fatalf("expanded thinking should cap body at five lines: %q", view)
+	}
+}
+
+func TestAgentChatThinkingCollapsedRemainsSingleLine(t *testing.T) {
+	model := New(80, 24, nil)
+	msg := protocol.AgentChatMessage{
+		Kind:      agentKindThinking,
+		Text:      "first line\nsecond line",
+		Collapsed: true,
+	}
+
+	view := ansi.Strip(strings.Join(model.renderAgentThinkingMessage(msg, 80), "\n"))
+	if !strings.Contains(view, "Thinking collapsed") || !strings.Contains(view, "first line") {
+		t.Fatalf("collapsed thinking should show header and first body line: %q", view)
+	}
+	if strings.Contains(view, "second line") {
+		t.Fatalf("collapsed thinking should only show one body line: %q", view)
+	}
+}
+
+func TestAgentChatShortcutTogglesLatestThinkingBlock(t *testing.T) {
+	out := make(chan []byte, 1)
+	model := New(80, 24, out)
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentChat: {AgentChat: protocol.AgentChat{
+		Visible: true,
+		Messages: []protocol.AgentChatMessage{
+			{Kind: agentKindUser, Text: "fix this"},
+			{Kind: agentKindThinking, Text: "first", Collapsed: true},
+			{Kind: agentKindAssistant, Text: "ok"},
+			{Kind: agentKindThinking, Text: "second", Collapsed: false},
+		},
+	}}}
+
+	_, _ = model.Update(tea.KeyPressMsg(tea.Key{Code: 'z', Mod: tea.ModCtrl | tea.ModAlt}))
+	if got, want := <-out, protocol.EncodeGUIAgentToolToggle(3); !bytes.Equal(got, want) {
+		t.Fatalf("ctrl+alt+z packet = %v, want %v", got, want)
+	}
+}
+
 func TestAgentAnimationCueChangesAcrossFrames(t *testing.T) {
 	model := New(80, 24, nil)
 	model.agentAnimationFrame = 0

--- a/lib/minga_editor/input/cua/tui_space_leader.ex
+++ b/lib/minga_editor/input/cua/tui_space_leader.ex
@@ -69,30 +69,44 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
     end
   end
 
-  # Any other key while SPC is pending: check leader trie
+  # Any other key while SPC is pending checks the leader root. Once a prefix is active,
+  # continue resolving keys inside the which-key node before normal CUA dispatch sees them.
   def handle_key(state, cp, mods) do
-    if pending?(state) do
-      # Cancel the timer
-      state = cancel_timer(state)
-      state = put_space_leader_pending(state, false)
+    handle_non_space_key(state, cp, mods, pending?(state), active_leader_node(state))
+  end
 
-      trie = leader_trie(state)
-      key = {cp, mods}
+  @spec handle_non_space_key(
+          EditorState.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean(),
+          Bindings.node_t() | nil
+        ) ::
+          MingaEditor.Input.Handler.result()
+  defp handle_non_space_key(state, cp, mods, true, _node) do
+    state = cancel_timer(state)
+    state = put_space_leader_pending(state, false)
 
-      case Map.get(trie.children, key) do
-        nil ->
-          # Not a leader key. The space stays, pass this key through.
-          {:passthrough, state}
+    trie = leader_trie(state)
+    key = {cp, mods}
 
-        node ->
-          # Leader match! Retract the space and enter leader mode.
-          state = retract_space(state)
-          state = enter_leader(state, node)
-          {:handled, state}
-      end
-    else
-      {:passthrough, state}
+    case Map.get(trie.children, key) do
+      nil ->
+        {:passthrough, state}
+
+      node ->
+        state = retract_space(state)
+        state = enter_leader(state, node)
+        {:handled, state}
     end
+  end
+
+  defp handle_non_space_key(state, cp, mods, false, node) when is_map(node) do
+    continue_leader(state, node, {cp, mods})
+  end
+
+  defp handle_non_space_key(state, _cp, _mods, false, _node) do
+    {:passthrough, state}
   end
 
   @doc """
@@ -128,6 +142,11 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
   @spec pending?(map()) :: boolean()
   defp pending?(%{shell_state: %{space_leader_pending: true}}), do: true
   defp pending?(_state), do: false
+
+  @spec active_leader_node(EditorState.t()) :: Bindings.node_t() | nil
+  defp active_leader_node(state) do
+    if active?(state), do: EditorState.whichkey(state).node, else: nil
+  end
 
   @spec put_space_leader_pending(EditorState.t(), boolean()) :: EditorState.t()
   defp put_space_leader_pending(state, value) do
@@ -170,6 +189,34 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
       {s, {:whichkey_update, wk}} = Commands.execute(state, {:leader_start, node})
       EditorState.set_whichkey(s, wk)
     end
+  end
+
+  @spec continue_leader(EditorState.t(), Bindings.node_t(), Bindings.key()) ::
+          MingaEditor.Input.Handler.result()
+  defp continue_leader(state, node, key) do
+    case Bindings.lookup(node, key) do
+      {:command, command} ->
+        state = cancel_leader(state)
+        {:handled, execute_command(state, command)}
+
+      {:prefix, sub_node} ->
+        {:handled, advance_leader(state, sub_node)}
+
+      :not_found ->
+        {:passthrough, cancel_leader(state)}
+    end
+  end
+
+  @spec advance_leader(EditorState.t(), Bindings.node_t()) :: EditorState.t()
+  defp advance_leader(state, node) do
+    {s, {:whichkey_update, wk}} = Commands.execute(state, {:leader_progress, node})
+    EditorState.set_whichkey(s, wk)
+  end
+
+  @spec cancel_leader(EditorState.t()) :: EditorState.t()
+  defp cancel_leader(state) do
+    {s, {:whichkey_update, wk}} = Commands.execute(state, :leader_cancel)
+    EditorState.set_whichkey(s, wk)
   end
 
   @spec execute_command(EditorState.t(), atom() | tuple()) :: EditorState.t()

--- a/test/minga_editor/input/cua_tui_integration_test.exs
+++ b/test/minga_editor/input/cua_tui_integration_test.exs
@@ -15,7 +15,10 @@ defmodule MingaEditor.Input.CUATUIIntegrationTest do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Registers
+  alias MingaEditor.State.TabBar
   alias MingaEditor.State.WhichKey
+  alias MingaEditor.State.Workspace, as: WorkspaceModel
+  alias MingaEditor.UI.Picker.ThinkingLevelSource
 
   @ctrl 0x02
   @enter 13
@@ -154,6 +157,20 @@ defmodule MingaEditor.Input.CUATUIIntegrationTest do
       assert state.shell_state.space_leader_pending == false
       assert buffer_content(ctx) == ""
     end
+
+    test "SPC a T opens the thinking-level picker" do
+      ctx = start_editor("", editing_model: :cua, backend: :tui)
+      install_agent_session(ctx, "low")
+
+      send_key_sync(ctx, @space)
+      send_key_sync(ctx, ?a)
+      send_key_sync(ctx, ?T)
+
+      assert {:picker, %{picker_ui: picker_ui}} = editor_state(ctx).shell_state.modal
+      assert picker_ui.source == ThinkingLevelSource
+      assert picker_ui.context == %{current_level: "low"}
+      assert buffer_content(ctx) == ""
+    end
   end
 
   describe "CUA TUI startup defaults" do
@@ -178,6 +195,22 @@ defmodule MingaEditor.Input.CUATUIIntegrationTest do
         |> UIState.set_input_focused(true)
         |> UIState.set_prompt_text(text)
       end)
+    end)
+
+    :sys.get_state(ctx.editor)
+  end
+
+  defp install_agent_session(ctx, thinking_level) do
+    :sys.replace_state(ctx.editor, fn state ->
+      state
+      |> EditorState.set_tab_bar(
+        TabBar.update_workspace(
+          state.shell_state.tab_bar,
+          0,
+          &WorkspaceModel.set_session(&1, self())
+        )
+      )
+      |> AgentAccess.update_agent_ui(&UIState.set_thinking_level(&1, thinking_level))
     end)
 
     :sys.get_state(ctx.editor)


### PR DESCRIPTION
# TL;DR
The Go TUI now has parity for agent thinking blocks: expanded thinking renders multiple lines, collapsed thinking stays compact, `Ctrl+Alt+Z` toggles the latest thinking block from the visible agent chat, and terminal users use the existing `SPC a T` thinking picker to change thinking level without leaving the editor.

Closes #2465

## Context
Issue #2465 identified a TUI/macOS parity gap: the backend already sends full thinking text and supports thinking-level changes, but the Go TUI only showed one thinking line and exposed thinking level as display-only state.

## Changes
- Render expanded thinking blocks with up to five body lines while keeping collapsed thinking to one body line.
- Add a Go TUI encoder for the existing agent_tool_toggle GUI action so the terminal frontend can toggle thinking blocks through the same BEAM path used by native UI surfaces.
- Add the agent-chat-visible `Ctrl+Alt+Z` shortcut to toggle the latest thinking block.
- Keep thinking-level changes on the existing `SPC a T` thinking picker, and teach the CUA TUI space-leader path to continue active which-key prefixes so that shared leader binding is reachable.
- Cover the behavior with Go tests for expanded and collapsed thinking rendering, action packet encoding, and shortcut packet emission, plus CUA TUI integration coverage for `SPC a T`.

## Verification
- `go test ./internal/protocol ./internal/ui`
- `go test ./...` from `go/tui`
- `mix compile --warnings-as-errors`
- `mix protocol.gen --check`
- `make lint`
- `mix native.build.support`
- `mix test test/minga_editor/integration/match_item_test.exs`
- `mix test test/minga_agent/session_recovery_test.exs:57`
- `mix test test/minga_editor/input/cua_tui_integration_test.exs test/minga_editor/input/cua/tui_space_leader_test.exs test/minga_editor/input/cua/space_leader_test.exs`
- `mix test.llm` final rerun passed: 56 doctests, 87 properties, 9394 tests, 0 failures, 1 skipped, 336 excluded

## Acceptance Criteria Addressed
- In the TUI, the user can read more than one line of thinking and expand/collapse it. ✅
- In the TUI, the user can change the thinking level (off/low/medium/high) without leaving the editor. ✅

## Notes
Manual terminal chord verification was not performed. Packet-level tests prove the TUI emits the intended existing BEAM action for thinking toggles while the agent chat is visible, and CUA TUI integration tests prove `SPC a T` opens the existing thinking-level picker.
