### PR TITLE
fix(agent): prefer compatible Codex OAuth defaults

### DIFF
--- a/lib/minga_agent/model_catalog.ex
+++ b/lib/minga_agent/model_catalog.ex
@@ -277,6 +277,7 @@ defmodule MingaAgent.ModelCatalog do
     {
       current_rank(model),
       Map.get(@provider_sort_order, provider, 99),
+      oauth_account_compatibility_rank(provider, id),
       model_family_rank(id),
       model_version_key(id),
       model_variant_rank(id),
@@ -287,6 +288,35 @@ defmodule MingaAgent.ModelCatalog do
   @spec current_rank(model_entry()) :: integer()
   defp current_rank(%{"current" => true}), do: 0
   defp current_rank(_model), do: 1
+
+  @spec oauth_account_compatibility_rank(String.t(), String.t()) :: integer()
+  defp oauth_account_compatibility_rank("openai_codex", id) do
+    codex_oauth_default_rank(bare_model_id(id))
+  end
+
+  defp oauth_account_compatibility_rank(_provider, _id), do: 0
+
+  @spec codex_oauth_default_rank(String.t()) :: integer()
+  defp codex_oauth_default_rank(id) do
+    normalized = String.downcase(id)
+
+    codex_oauth_default_rank(
+      normalized,
+      String.contains?(normalized, "-spark")
+    )
+  end
+
+  @spec codex_oauth_default_rank(String.t(), boolean()) :: integer()
+  defp codex_oauth_default_rank(_id, true), do: 0
+  defp codex_oauth_default_rank(_id, false), do: 1
+
+  @spec bare_model_id(String.t()) :: String.t()
+  defp bare_model_id(id) do
+    case String.split(id, ":", parts: 2) do
+      [_provider, model_id] -> model_id
+      _other -> id
+    end
+  end
 
   @spec model_family_rank(String.t()) :: integer()
   defp model_family_rank(id) do

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -3202,31 +3202,40 @@ defmodule MingaAgent.Providers.Native do
     provider = provider_slug_from_model(model)
 
     %Event.Error{
-      message: error_event_message(kind, message, provider),
+      message: error_event_message(kind, message, provider, reason, model),
       kind: kind,
       provider: provider
     }
   end
 
-  @spec error_event_message(Event.Error.kind(), String.t(), String.t() | nil) :: String.t()
-  defp error_event_message(:auth_failed, _message, provider) do
+  @spec error_event_message(Event.Error.kind(), String.t(), String.t() | nil, term(), String.t()) ::
+          String.t()
+  defp error_event_message(:auth_failed, _message, provider, _reason, _model) do
     provider = provider || "provider"
     "Couldn't authenticate with #{provider_label(provider)}. #{auth_hint_for_provider(provider)}"
   end
 
-  defp error_event_message(:rate_limited, _message, _provider) do
+  defp error_event_message(:rate_limited, _message, _provider, _reason, _model) do
     "The model provider is rate limiting requests. Wait a moment, then try again."
   end
 
-  defp error_event_message(:unreachable, _message, _provider) do
+  defp error_event_message(:unreachable, _message, _provider, _reason, _model) do
     "Couldn't reach the model provider. Check your network connection, then try again."
   end
 
-  defp error_event_message(:provider_error, _message, _provider) do
+  defp error_event_message(:provider_error, _message, _provider, _reason, _model) do
     "The model provider returned an unexpected error. Open Messages for details, or pick another configured model with /model."
   end
 
-  defp error_event_message(:invalid_model, message, _provider), do: message
+  defp error_event_message(:invalid_model, message, "openai_codex", reason, model) do
+    if codex_chatgpt_model_incompatible?(reason) do
+      "This model isn't available for your ChatGPT account. Pick #{codex_chatgpt_fallback_model(model)} with /model, then retry."
+    else
+      message
+    end
+  end
+
+  defp error_event_message(:invalid_model, message, _provider, _reason, _model), do: message
 
   @spec classify_error_reason(term()) :: Event.Error.kind()
   defp classify_error_reason(:invalid_format), do: :invalid_model
@@ -3234,12 +3243,8 @@ defmodule MingaAgent.Providers.Native do
   defp classify_error_reason({:provider_build_failed, _reason}), do: :auth_failed
   defp classify_error_reason({:exit, reason}), do: classify_error_reason(reason)
   defp classify_error_reason({:throw, reason}), do: classify_error_reason(reason)
-  defp classify_error_reason(%{status: status}) when status in [401, 403], do: :auth_failed
-  defp classify_error_reason(%{status: 429}), do: :rate_limited
-  defp classify_error_reason(%{"status" => status}) when status in [401, 403], do: :auth_failed
-  defp classify_error_reason(%{"status" => 429}), do: :rate_limited
-  defp classify_error_reason(%{reason: reason}), do: classify_error_reason(reason)
-  defp classify_error_reason(%{"reason" => reason}), do: classify_error_reason(reason)
+
+  defp classify_error_reason(reason) when is_map(reason), do: classify_map_error_reason(reason)
 
   defp classify_error_reason(reason) when reason in [:timeout, :nxdomain, :econnrefused],
     do: :unreachable
@@ -3248,6 +3253,73 @@ defmodule MingaAgent.Providers.Native do
     do: classify_legacy_error_message(reason)
 
   defp classify_error_reason(_reason), do: :provider_error
+
+  @spec classify_map_error_reason(map()) :: Event.Error.kind()
+  defp classify_map_error_reason(reason) do
+    classify_map_error_reason(reason, codex_chatgpt_model_incompatible?(reason))
+  end
+
+  @spec classify_map_error_reason(map(), boolean()) :: Event.Error.kind()
+  defp classify_map_error_reason(_reason, true), do: :invalid_model
+
+  defp classify_map_error_reason(%{status: status}, false) when status in [401, 403],
+    do: :auth_failed
+
+  defp classify_map_error_reason(%{status: 429}, false), do: :rate_limited
+
+  defp classify_map_error_reason(%{"status" => status}, false) when status in [401, 403],
+    do: :auth_failed
+
+  defp classify_map_error_reason(%{"status" => 429}, false), do: :rate_limited
+  defp classify_map_error_reason(%{reason: reason}, false), do: classify_error_reason(reason)
+  defp classify_map_error_reason(%{"reason" => reason}, false), do: classify_error_reason(reason)
+  defp classify_map_error_reason(_reason, false), do: :provider_error
+
+  @spec codex_chatgpt_model_incompatible?(term()) :: boolean()
+  defp codex_chatgpt_model_incompatible?(%{response_body: response_body}) do
+    codex_chatgpt_model_incompatible?(response_body)
+  end
+
+  defp codex_chatgpt_model_incompatible?(%{"response_body" => response_body}) do
+    codex_chatgpt_model_incompatible?(response_body)
+  end
+
+  defp codex_chatgpt_model_incompatible?(%{detail: detail}) when is_binary(detail) do
+    codex_chatgpt_model_incompatible?(detail)
+  end
+
+  defp codex_chatgpt_model_incompatible?(%{"detail" => detail}) when is_binary(detail) do
+    codex_chatgpt_model_incompatible?(detail)
+  end
+
+  defp codex_chatgpt_model_incompatible?(message) when is_binary(message) do
+    normalized = String.downcase(message)
+
+    String.contains?(normalized, "model is not supported") and
+      String.contains?(normalized, "chatgpt account")
+  end
+
+  defp codex_chatgpt_model_incompatible?(_reason), do: false
+
+  @spec codex_chatgpt_fallback_model(String.t()) :: String.t()
+  defp codex_chatgpt_fallback_model(model) do
+    case String.split(model, ":", parts: 2) do
+      [provider, model_id] when provider != "" and model_id != "" ->
+        "#{provider}:#{codex_chatgpt_fallback_model_id(model_id)}"
+
+      _other ->
+        "openai_codex:#{codex_chatgpt_fallback_model_id(model)}"
+    end
+  end
+
+  @spec codex_chatgpt_fallback_model_id(String.t()) :: String.t()
+  defp codex_chatgpt_fallback_model_id(model_id) do
+    if String.ends_with?(model_id, "-spark") do
+      model_id
+    else
+      model_id <> "-spark"
+    end
+  end
 
   # Last-resort compatibility for third-party clients that only return a string.
   # Internal provider/session contracts use `Event.Error.kind` instead.

--- a/test/minga_agent/model_catalog_test.exs
+++ b/test/minga_agent/model_catalog_test.exs
@@ -78,6 +78,21 @@ defmodule MingaAgent.ModelCatalogTest do
       assert normalized == []
     end
 
+    test "chatgpt oauth codex spark sorts before known incompatible base codex" do
+      models = [
+        codex_model("gpt-5.3-codex", "GPT-5.3 Codex"),
+        codex_model("gpt-5.3-codex-spark", "GPT-5.3 Codex Spark")
+      ]
+
+      normalized =
+        ModelCatalog.available_models_from(models, "", MapSet.new(), true)
+
+      assert Enum.map(normalized, & &1["id"]) == [
+               "openai_codex:gpt-5.3-codex-spark",
+               "openai_codex:gpt-5.3-codex"
+             ]
+    end
+
     test "current model sorts first when present" do
       models = ModelCatalog.available_models()
 

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -2013,6 +2013,39 @@ defmodule MingaAgent.Providers.NativeTest do
       refute message =~ "/auth openai_codex"
     end
 
+    test "openai codex chatgpt account model incompatibility is actionable invalid_model", %{
+      tmp_dir: tmp_dir
+    } do
+      reason = %{
+        reason: "HTTP 400",
+        status: 400,
+        response_body: %{
+          "detail" =>
+            "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."
+        }
+      }
+
+      {:ok, pid} =
+        start_provider(
+          model: "openai_codex:gpt-5.3-codex",
+          llm_client: fake_error_client(reason),
+          tmp_dir: tmp_dir,
+          max_retries: 0
+        )
+
+      Native.send_prompt(pid, "hello")
+      events = collect_events(2_000)
+
+      error = Enum.find(events, &match?(%Event.Error{}, &1))
+
+      assert %Event.Error{message: message, kind: :invalid_model, provider: "openai_codex"} =
+               error
+
+      assert message =~ "gpt-5.3-codex-spark"
+      assert message =~ "/model"
+      refute message =~ "unexpected error"
+    end
+
     test "string-only provider errors classify auth, rate limit, and network failures", %{
       tmp_dir: tmp_dir
     } do


### PR DESCRIPTION
# TL;DR
Fixes the first-run Codex OAuth model selection failure by preferring Spark Codex variants for OpenAI Codex OAuth defaults and turning the known ChatGPT-account incompatibility 400 into an actionable invalid-model error.

Closes #2456

## Context
Fresh Codex OAuth users can see `openai_codex:gpt-5.3-codex` auto-selected even though the API rejects that model for ChatGPT-account OAuth. The working model from the live repro is the matching Spark variant.

## Changes
- Add a Codex OAuth catalog rank so `*-codex-spark` sorts before the bare Codex variant for first-run/default model selection.
- Preserve the existing catalog ordering for non-Spark Codex models when no Spark variant is present.
- Classify the ChatGPT-account model-incompatibility HTTP 400 as `Event.Error{kind: :invalid_model}` instead of a generic provider error.
- Render an actionable message that names the matching Spark fallback and points users to `/model`.

## Verification
- `mix test test/minga_agent/model_catalog_test.exs test/minga_agent/providers/native_test.exs:2016 test/minga_agent/session_test.exs:2165`
- `mix compile --warnings-as-errors`

## Notes
I could not run the project reviewer subagent gate because this session exposed only wait/send/close agent tools, not a spawn tool. Local focused validation passes.
