### PR TITLE
fix(agent): rehydrate provider tool history

### DIFF
--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -66,12 +66,14 @@ defmodule MingaAgent.Providers.Native do
   alias MingaAgent.Tool.PlanMode
   alias MingaAgent.Tool.Registry, as: ToolRegistry
   alias MingaAgent.Tool.Spec, as: ToolSpec
+  alias MingaAgent.ToolCall
   alias MingaAgent.Tools
   alias MingaAgent.Tools.Notebook
   alias MingaAgent.Tools.Shell
   alias MingaAgent.Tools.Todo
   alias Minga.Config
   alias ReqLLM.Context
+  alias ReqLLM.Message.ContentPart
 
   # Thinking levels and cycle order (not config-driven; mode-specific constants).
 
@@ -2923,7 +2925,45 @@ defmodule MingaAgent.Providers.Native do
   defp append_seed_message({:assistant, text}, context) when is_binary(text),
     do: Context.append(context, Context.assistant(text))
 
+  defp append_seed_message({:thinking, text, _collapsed}, context) when is_binary(text) do
+    if String.trim(text) == "" do
+      context
+    else
+      Context.append(context, Context.assistant([ContentPart.thinking(text)]))
+    end
+  end
+
+  defp append_seed_message({:tool_call, %ToolCall{} = tool_call}, context) do
+    reqllm_tool_call =
+      ReqLLMAdapter.assistant_tool_call(tool_call.id, tool_call.name, tool_call.args)
+
+    context
+    |> Context.append(Context.assistant("", tool_calls: [reqllm_tool_call]))
+    |> Context.append(seed_tool_result_message(tool_call))
+  end
+
   defp append_seed_message(_message, context), do: context
+
+  @spec seed_tool_result_message(ToolCall.t()) :: ReqLLM.Message.t()
+  defp seed_tool_result_message(%ToolCall{} = tool_call) do
+    tool_result_message(%{
+      tool_call: tool_call,
+      result_text: seed_tool_result_text(tool_call),
+      is_error: seed_tool_result_error?(tool_call)
+    })
+  end
+
+  @spec seed_tool_result_text(ToolCall.t()) :: String.t()
+  defp seed_tool_result_text(%ToolCall{status: :running, result: ""}) do
+    "Tool call was still running when provider history was rebuilt."
+  end
+
+  defp seed_tool_result_text(%ToolCall{result: result}) when is_binary(result), do: result
+
+  @spec seed_tool_result_error?(ToolCall.t()) :: boolean()
+  defp seed_tool_result_error?(%ToolCall{is_error: true}), do: true
+  defp seed_tool_result_error?(%ToolCall{status: :complete}), do: false
+  defp seed_tool_result_error?(%ToolCall{}), do: true
 
   @spec system_prompt_from_context(Context.t()) :: String.t() | nil
   defp system_prompt_from_context(%Context{

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -9,7 +9,9 @@ defmodule MingaAgent.Providers.NativeTest do
   alias MingaAgent.Event
   alias MingaAgent.ProjectView.RecordingBackend
   alias MingaAgent.Providers.Native
+  alias MingaAgent.ToolCall
   alias MingaAgent.Tools
+  alias ReqLLM.Context
   alias ReqLLM.StreamResponse.MetadataHandle
 
   @moduletag :tmp_dir
@@ -134,6 +136,10 @@ defmodule MingaAgent.Providers.NativeTest do
     Enum.map_join(message.content, "", & &1.text)
   end
 
+  defp text_content(message) do
+    Enum.map_join(message.content, "", &(&1.text || ""))
+  end
+
   defp collect_spawned_processes(parent, count) do
     collect_spawned_processes(parent, count, [])
   end
@@ -189,6 +195,67 @@ defmodule MingaAgent.Providers.NativeTest do
       assert {:ok, %{"level" => "medium"}} = Native.cycle_thinking_level(pid)
       assert {:ok, %{"level" => "high"}} = Native.cycle_thinking_level(pid)
       assert {:ok, %{"level" => "off"}} = Native.cycle_thinking_level(pid)
+    end
+
+    test "seed_messages rehydrates tool calls, tool results, and thinking entries", %{
+      tmp_dir: dir
+    } do
+      {:ok, pid} = start_provider(tmp_dir: dir)
+
+      tool_call =
+        "tc_read"
+        |> ToolCall.new("read_file", %{"path" => "lib/a.ex"})
+        |> ToolCall.complete("file contents")
+
+      messages = [
+        {:user, "Inspect lib/a.ex"},
+        {:assistant, "I'll read it."},
+        {:thinking, "Need to inspect the file first.", true},
+        {:tool_call, tool_call},
+        {:assistant, "The file contains file contents."}
+      ]
+
+      assert :ok = Native.seed_messages(pid, messages)
+
+      %{context: context} = :sys.get_state(pid)
+      assert %Context{} = Context.validate!(context)
+
+      [
+        system_message,
+        user_message,
+        assistant_message,
+        thinking_message,
+        tool_call_message,
+        tool_result_message,
+        final_message
+      ] = context.messages
+
+      assert system_message.role == :system
+      assert user_message.role == :user
+      assert text_content(user_message) == "Inspect lib/a.ex"
+      assert assistant_message.role == :assistant
+      assert text_content(assistant_message) == "I'll read it."
+
+      assert thinking_message.role == :assistant
+
+      assert [%{type: :thinking, text: "Need to inspect the file first."}] =
+               thinking_message.content
+
+      assert tool_call_message.role == :assistant
+      assert text_content(tool_call_message) == ""
+      assert [reqllm_tool_call] = tool_call_message.tool_calls
+      assert reqllm_tool_call.id == "tc_read"
+      assert reqllm_tool_call.function.name == "read_file"
+      assert JSON.decode!(reqllm_tool_call.function.arguments) == %{"path" => "lib/a.ex"}
+
+      assert tool_result_message.role == :tool
+      assert tool_result_message.name == "read_file"
+      assert tool_result_message.tool_call_id == "tc_read"
+      assert text_content(tool_result_message) == "file contents"
+      assert tool_result_message.metadata == %{}
+
+      assert final_message.role == :assistant
+      assert text_content(final_message) == "The file contains file contents."
     end
 
     test "rebuilds built-in tool closures after fork store down so stale pids stop leaking", %{

--- a/test/minga_agent/session_store_test.exs
+++ b/test/minga_agent/session_store_test.exs
@@ -91,6 +91,10 @@ defmodule MingaAgent.SessionStoreTest do
       tool_calls = Enum.filter(loaded.messages, &match?({:tool_call, _}, &1))
       assert [{:tool_call, tc}] = tool_calls
       assert tc.name == "read_file"
+      assert tc.args == %{"path" => "lib/foo.ex"}
+      assert tc.result == "defmodule Foo do\nend"
+      assert tc.is_error == false
+      assert tc.collapsed == true
       assert tc.duration_ms == 42
       assert tc.status == :complete
       assert tc.auto_approved_scope == :session


### PR DESCRIPTION
## Summary

- Rehydrates persisted `{:tool_call, %ToolCall{}}` entries into ReqLLM assistant tool calls plus matching tool-result messages during native provider `seed_messages`.
- Rehydrates persisted thinking entries as ReqLLM `ContentPart.thinking/1` assistant content instead of dropping them.
- Strengthens SessionStore coverage to assert persisted tool calls carry args, result text, error status, collapsed state, duration, and trust scope needed by `/load`.

Fixes #2458.

## Validation

- `mix test test/minga_agent/providers/native_test.exs:200 test/minga_agent/session_store_test.exs`
- `mix test test/minga_agent/providers/native_test.exs test/minga_agent/providers/native/req_llm_adapter_test.exs`
- `mix compile --warnings-as-errors`
- `git diff --check origin/main...HEAD`

## Notes

- This restores the rich history that Minga already persists. ReqLLM provider-native reasoning details/signatures are still not persisted in Minga's transcript schema; that is a separate bug from the #2458 reducer drop and should be handled as a transcript/event schema follow-up.
- No delegated reviewer was run. The available subagent spawn tool requires explicit user authorization before spawning, so this PR relies on focused local validation.
