### PR TITLE
fix(agent): unblock destructive subagents

### DIFF
--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -2345,6 +2345,9 @@ defmodule MingaAgent.Providers.Native do
 
       {:tool_approval_response, _tool_call_id, :reject} ->
         {"Tool rejected by user", true, mode, false}
+
+      {:tool_approval_response, _tool_call_id, {:reject, message}} ->
+        {message, true, mode, false}
     after
       config.approval_timeout_ms ->
         {"Tool approval timed out", true, mode, false}

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -75,6 +75,10 @@ defmodule MingaAgent.Session do
   @typedoc "Remote attachment role."
   @type attachment_role :: :driver | :viewer
 
+  @typedoc "How a session handles tool approvals when no interactive driver should answer them."
+  @type tool_approval_policy ::
+          :interactive | {:auto_approve, trust_scope()} | {:reject, String.t()}
+
   @typedoc "Internal session state."
   @type state :: %{
           session_id: String.t(),
@@ -95,6 +99,7 @@ defmodule MingaAgent.Session do
           subscribers: MapSet.t(pid()),
           subscriber_roles: %{pid() => attachment_role()},
           driver: pid() | nil,
+          tool_approval_policy: tool_approval_policy(),
           idle_gc_timeout_ms: non_neg_integer(),
           idle_gc_timer: {timer_ref :: reference(), token :: reference()} | nil,
           idle_gc_token_fn: (-> reference()),
@@ -705,6 +710,7 @@ defmodule MingaAgent.Session do
       subscribers: MapSet.new(),
       subscriber_roles: %{},
       driver: nil,
+      tool_approval_policy: Keyword.get(opts, :tool_approval_policy, :interactive),
       idle_gc_timeout_ms: Keyword.get_lazy(opts, :idle_gc_timeout_ms, &idle_gc_timeout_ms/0),
       idle_gc_timer: nil,
       idle_gc_token_fn: Keyword.get(opts, :idle_gc_token_fn, &make_ref/0),
@@ -1743,6 +1749,17 @@ defmodule MingaAgent.Session do
   end
 
   @spec request_tool_approval(Event.ToolApproval.t(), state()) :: state()
+  defp request_tool_approval(event, %{tool_approval_policy: {:auto_approve, scope}} = state) do
+    auto_approve_tool(event, state, scope)
+  end
+
+  defp request_tool_approval(event, %{tool_approval_policy: {:reject, message}} = state) do
+    send(event.reply_to, {:tool_approval_response, event.tool_call_id, {:reject, message}})
+
+    broadcast(state, {:approval_rejected, event.tool_call_id, event.name, message})
+    state
+  end
+
   defp request_tool_approval(event, state) do
     notify(state, :approval, "Approval needed: #{event.name}")
 

--- a/lib/minga_agent/tools/subagent.ex
+++ b/lib/minga_agent/tools/subagent.ex
@@ -42,6 +42,7 @@ defmodule MingaAgent.Tools.Subagent do
   @subagent_timeout_ms 300_000
   @provider_ready_retry_ms 10
   @provider_ready_max_attempts 100
+  @approval_unavailable_message "Subagent tool approval is unavailable because this child session has no interactive approval driver. Run the subagent with worktree isolation or route approvals through the parent session."
 
   @doc """
   Runs a sub-agent task.
@@ -60,9 +61,29 @@ defmodule MingaAgent.Tools.Subagent do
   @spec start_background(String.t(), opts()) :: {:ok, String.t()} | {:error, String.t()}
   defp start_background(task, opts) do
     if worktree_isolation?(opts) do
-      {:error, "Worktree isolation is only supported for foreground subagents"}
+      start_worktree_background(task, opts)
     else
       do_start_background(task, opts)
+    end
+  end
+
+  @spec start_worktree_background(String.t(), opts()) :: {:ok, String.t()} | {:error, String.t()}
+  defp start_worktree_background(task, opts) do
+    project_root =
+      Keyword.get(opts, :project_root) || parent_context(opts).project_root ||
+        detect_project_root()
+
+    case create_worktree(project_root) do
+      {:ok, worktree} ->
+        worktree_opts = Keyword.put(opts, :project_root, worktree.path)
+
+        case do_start_background(task, worktree_opts) do
+          {:ok, result} -> {:ok, result <> worktree_metadata(worktree)}
+          {:error, reason} -> finish_worktree_error(worktree, reason)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -278,7 +299,7 @@ defmodule MingaAgent.Tools.Subagent do
   @spec finish_worktree_result(worktree(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
   defp finish_worktree_result(worktree, result) do
     if worktree_changed?(worktree) do
-      {:ok, result <> "\n\nWorktree: #{worktree.path}\nBranch: #{worktree.branch}"}
+      {:ok, result <> worktree_metadata(worktree)}
     else
       cleanup_worktree_if_clean(worktree)
       {:ok, result}
@@ -288,11 +309,16 @@ defmodule MingaAgent.Tools.Subagent do
   @spec finish_worktree_error(worktree(), String.t()) :: {:error, String.t()}
   defp finish_worktree_error(worktree, reason) do
     if worktree_changed?(worktree) do
-      {:error, reason <> "\n\nWorktree: #{worktree.path}\nBranch: #{worktree.branch}"}
+      {:error, reason <> worktree_metadata(worktree)}
     else
       cleanup_worktree_if_clean(worktree)
       {:error, reason}
     end
+  end
+
+  @spec worktree_metadata(worktree()) :: String.t()
+  defp worktree_metadata(worktree) do
+    "\n\nWorktree: #{worktree.path}\nBranch: #{worktree.branch}"
   end
 
   @spec worktree_changed?(worktree()) :: boolean()
@@ -382,6 +408,7 @@ defmodule MingaAgent.Tools.Subagent do
           ]
           |> maybe_put_thinking_level(thinking_level)
           |> maybe_put_notifier(opts)
+          |> put_tool_approval_policy(opts)
 
         {:ok, session_opts}
 
@@ -395,6 +422,15 @@ defmodule MingaAgent.Tools.Subagent do
     case Keyword.fetch(opts, :notifier) do
       {:ok, notifier} -> Keyword.put(session_opts, :notifier, notifier)
       :error -> session_opts
+    end
+  end
+
+  @spec put_tool_approval_policy(keyword(), opts()) :: keyword()
+  defp put_tool_approval_policy(session_opts, opts) do
+    if worktree_isolation?(opts) do
+      Keyword.put(session_opts, :tool_approval_policy, {:auto_approve, :session})
+    else
+      Keyword.put(session_opts, :tool_approval_policy, {:reject, @approval_unavailable_message})
     end
   end
 

--- a/test/minga_agent/tools/subagent_test.exs
+++ b/test/minga_agent/tools/subagent_test.exs
@@ -10,6 +10,7 @@ defmodule MingaAgent.Tools.SubagentTest do
   alias MingaAgent.SessionManager
   alias MingaAgent.Subagent.Handle
   alias MingaAgent.Tools.Subagent
+  alias ReqLLM.StreamResponse.MetadataHandle
 
   @moduletag :tmp_dir
 
@@ -612,6 +613,49 @@ defmodule MingaAgent.Tools.SubagentTest do
     refute_receive {:notified, :complete, _}, 50
   end
 
+  test "background native subagent rejects destructive tools immediately without an approval driver",
+       %{
+         manager: manager,
+         tmp_dir: dir
+       } do
+    started_at = System.monotonic_time(:millisecond)
+
+    assert {:ok, _result} =
+             Subagent.execute("write through native tool",
+               background: true,
+               session_manager: manager,
+               project_root: dir,
+               provider: MingaAgent.Providers.Native,
+               model: "anthropic:claude-sonnet-4-20250514",
+               provider_opts: [
+                 llm_client: native_write_client("child.txt", "from native\n", "write rejected"),
+                 skip_api_key_env: true
+               ]
+             )
+
+    [handle] = SessionManager.list_background_subagents(manager, nil)
+    Session.subscribe(handle.pid)
+
+    assert_receive {:agent_event, _pid,
+                    {:approval_rejected, "tc_write_file", "write_file", message}},
+                   1_000
+
+    elapsed_ms = System.monotonic_time(:millisecond) - started_at
+    assert elapsed_ms < 2_000
+    assert message =~ "no interactive approval driver"
+    assert_eventually_idle(handle.pid)
+    refute File.exists?(Path.join(dir, "child.txt"))
+
+    assert {:tool_call, tool_call} =
+             Enum.find(
+               Session.messages(handle.pid),
+               &match?({:tool_call, %{id: "tc_write_file"}}, &1)
+             )
+
+    assert tool_call.status == :error
+    assert tool_call.result == message
+  end
+
   # ── Foreground subagent tests ──────────────────────────────────────────────
 
   test "foreground subagent still blocks and returns final text" do
@@ -648,6 +692,27 @@ defmodule MingaAgent.Tools.SubagentTest do
     assert File.read!(Path.join(worktree_path, "child.txt")) == "from child\n"
     refute File.exists?(Path.join(root, "child.txt"))
     assert File.exists?(worktree_path)
+  end
+
+  test "worktree-isolated native subagent auto-approves destructive tools", %{tmp_dir: dir} do
+    root = init_git_repo!(dir)
+
+    assert {:ok, result} =
+             Subagent.execute("write through native tool",
+               isolation: "worktree",
+               project_root: root,
+               provider: MingaAgent.Providers.Native,
+               model: "anthropic:claude-sonnet-4-20250514",
+               provider_opts: [
+                 llm_client: native_write_client("child.txt", "from native\n", "native wrote"),
+                 skip_api_key_env: true
+               ]
+             )
+
+    assert result =~ "native wrote"
+    assert [_, worktree_path] = Regex.run(~r/Worktree: (.+)/, result)
+    assert File.read!(Path.join(worktree_path, "child.txt")) == "from native\n"
+    refute File.exists?(Path.join(root, "child.txt"))
   end
 
   test "worktree-isolated subagent removes a clean no-op worktree", %{tmp_dir: dir} do
@@ -696,18 +761,46 @@ defmodule MingaAgent.Tools.SubagentTest do
     assert message =~ "requires a clean git tree"
   end
 
-  test "worktree isolation rejects background subagents", %{tmp_dir: dir} do
+  test "worktree-isolated background native subagent auto-approves destructive tools", %{
+    manager: manager,
+    tmp_dir: dir
+  } do
     root = init_git_repo!(dir)
 
-    assert {:error, message} =
-             Subagent.execute("noop",
+    assert {:ok, result} =
+             Subagent.execute("write through native tool",
                isolation: "worktree",
                background: true,
+               session_manager: manager,
                project_root: root,
-               provider: WorktreeProvider
+               provider: MingaAgent.Providers.Native,
+               model: "anthropic:claude-sonnet-4-20250514",
+               provider_opts: [
+                 llm_client:
+                   native_write_client(
+                     "background-child.txt",
+                     "from background native\n",
+                     "background native wrote"
+                   ),
+                 skip_api_key_env: true
+               ]
              )
 
-    assert message =~ "only supported for foreground"
+    assert result =~ "Background subagent started"
+    assert [_, worktree_path] = Regex.run(~r/Worktree: (.+)/, result)
+    [handle] = SessionManager.list_background_subagents(manager, nil)
+    Session.subscribe(handle.pid)
+
+    assert_receive {:agent_event, _pid,
+                    {:tool_auto_approved, "tc_write_file", "write_file", :session}},
+                   1_000
+
+    assert_eventually_idle(handle.pid)
+
+    assert File.read!(Path.join(worktree_path, "background-child.txt")) ==
+             "from background native\n"
+
+    refute File.exists?(Path.join(root, "background-child.txt"))
   end
 
   # ── Context inheritance tests ──────────────────────────────────────────────
@@ -887,6 +980,51 @@ defmodule MingaAgent.Tools.SubagentTest do
     assert_receive {^ref, {:provider_started, _provider_pid, opts}}, 1_000
     assertions.(opts)
     :ok
+  end
+
+  @spec native_write_client(String.t(), String.t(), String.t()) :: function()
+  defp native_write_client(path, content, final_text) do
+    call_count = :counters.new(1, [:atomics])
+
+    fn _model, _messages, _opts ->
+      count = :counters.get(call_count, 1)
+      :counters.add(call_count, 1, 1)
+
+      chunks =
+        if count == 0 do
+          [
+            ReqLLM.StreamChunk.tool_call(
+              "write_file",
+              %{"path" => path, "content" => content},
+              %{id: "tc_write_file", index: 0}
+            ),
+            ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+          ]
+        else
+          [ReqLLM.StreamChunk.text(final_text), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+        end
+
+      build_stream_response(chunks)
+    end
+  end
+
+  @spec build_stream_response([ReqLLM.StreamChunk.t()]) ::
+          {:ok, ReqLLM.StreamResponse.t()}
+  defp build_stream_response(chunks) do
+    {:ok, handle} =
+      MetadataHandle.start_link(fn ->
+        %{usage: %{}, finish_reason: :stop}
+      end)
+
+    stream_response = %ReqLLM.StreamResponse{
+      stream: chunks,
+      metadata_handle: handle,
+      cancel: fn -> :ok end,
+      model: elem(ReqLLM.model("anthropic:claude-sonnet-4-20250514"), 1),
+      context: ReqLLM.Context.new()
+    }
+
+    {:ok, stream_response}
   end
 
   @spec init_git_repo!(String.t()) :: String.t()


### PR DESCRIPTION
# TL;DR
Subagents now have an explicit approval policy: isolated worktree children auto-approve approval requests, while unmanaged children reject approval requests immediately with a clear subagent-specific message. Background worktree subagents are supported so destructive native tools can run in an isolated child worktree.

Closes #2459

## Context
Subagents previously inherited the default destructive-tool approval mode, but child sessions had no approval driver that could answer native provider approval prompts. A destructive tool call could therefore sit until the 5-minute approval timeout, which made write-capable subagents unusable.

## Changes
- Added a session-level `tool_approval_policy` so child sessions can auto-approve isolated worktree requests or reject unmanaged approval requests immediately.
- Updated native provider approval handling so session-level rejections can carry an actionable result message instead of collapsing to the generic user rejection text.
- Enabled background subagents to use worktree isolation and return the isolated worktree metadata with the background handle message.
- Added native end-to-end subagent coverage for foreground worktree writes, background worktree writes, and unmanaged background fail-fast rejection.

## Verification
- `mix test test/minga_agent/tools/subagent_test.exs` -> 25 passed
- `mix test test/minga_agent/session_test.exs:1400 test/minga_agent/session_test.exs:1480 test/minga_agent/session_test.exs:1518` -> 3 passed
- `mix test test/minga_agent/providers/native_test.exs:840 test/minga_agent/providers/native_test.exs:930` -> 2 passed
- `mix compile --warnings-as-errors` -> passed
- `mix format --check-formatted` -> passed
- `mix credo --strict lib/minga_agent/session.ex lib/minga_agent/providers/native.ex lib/minga_agent/tools/subagent.ex test/minga_agent/tools/subagent_test.exs` -> passed, with the existing oversized `LoopCtx` warning
- `mix native.build.support` -> built and copied `minga-parser` and `minga-hook-runner`
- `mix test` -> 9,686 passed, 1 skipped, 191 excluded

## Acceptance Criteria Addressed
- A subagent can complete a task that writes files under the chosen policy: foreground and background worktree-isolated native subagents write through `write_file`.
- If approval cannot be granted, the destructive call fails fast with an actionable message: unmanaged background native subagents reject approval requests immediately.
- New subagent tests cover destructive tool execution and the no-driver fail-fast path.
