### PR TITLE
fix(agent): recover from cost cap preflight

### DIFF
--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -623,29 +623,28 @@ defmodule MingaAgent.Providers.Native do
   end
 
   def handle_call({:send_prompt, content}, _from, state) do
-    # Append user message to context.
-    # content is either a string or a list of ContentPart (for multi-modal).
-    context = Context.append(state.context, Context.user(content))
-
-    state = %{
-      state
-      | context: context,
-        streaming: true,
-        interrupted: false,
-        last_user_prompt: content
-    }
-
-    # Notify subscriber that agent is starting
-    notify(state.subscriber, %Event.AgentStart{})
-
-    # Check cost budget before starting
     if over_budget?(state) do
       notify(state.subscriber, %Event.Error{
         message: cost_limit_message(state.session_cost, state.max_cost)
       })
 
-      {:reply, {:error, :cost_limit_reached}, %{state | context: context}}
+      {:reply, {:error, :cost_limit_reached}, clear_stuck_streaming(state)}
     else
+      # Append user message to context.
+      # content is either a string or a list of ContentPart (for multi-modal).
+      context = Context.append(state.context, Context.user(content))
+
+      state = %{
+        state
+        | context: context,
+          streaming: true,
+          interrupted: false,
+          last_user_prompt: content
+      }
+
+      # Notify subscriber that agent is starting
+      notify(state.subscriber, %Event.AgentStart{})
+
       # Spawn the agent turn loop in a linked task
       lctx = %LoopCtx{
         provider_pid: self(),
@@ -680,7 +679,7 @@ defmodule MingaAgent.Providers.Native do
 
   def handle_call(:abort, _from, %{task: nil} = state) do
     stop_registered_tool_workers(state.tool_workers)
-    {:reply, :ok, %{state | tool_workers: %{}}}
+    {:reply, :ok, %{state | streaming: false, tool_workers: %{}}}
   end
 
   def handle_call(:abort, _from, state) do
@@ -990,12 +989,14 @@ defmodule MingaAgent.Providers.Native do
 
   def handle_call({:set_max_cost, amount}, _from, state) when is_number(amount) and amount > 0 do
     Minga.Log.info(:agent, "[Agent.Native] cost budget set to $#{Float.round(amount + 0.0, 2)}")
-    {:reply, :ok, %{state | max_cost: amount + 0.0}}
+    state = %{state | max_cost: amount + 0.0}
+    {:reply, :ok, clear_stuck_streaming(state)}
   end
 
   def handle_call({:set_max_cost, nil}, _from, state) do
     Minga.Log.info(:agent, "[Agent.Native] cost budget disabled")
-    {:reply, :ok, %{state | max_cost: nil}}
+    state = %{state | max_cost: nil}
+    {:reply, :ok, clear_stuck_streaming(state)}
   end
 
   @impl GenServer
@@ -3112,6 +3113,17 @@ defmodule MingaAgent.Providers.Native do
        when is_number(max_cost) do
     session_cost >= max_cost
   end
+
+  @spec clear_stuck_streaming(state()) :: state()
+  defp clear_stuck_streaming(%{streaming: true, task: nil} = state) do
+    if over_budget?(state) do
+      state
+    else
+      %{state | streaming: false, tool_workers: %{}}
+    end
+  end
+
+  defp clear_stuck_streaming(state), do: state
 
   @spec cost_limit_message(float(), float() | nil) :: String.t()
   defp cost_limit_message(session_cost, max_cost) do

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -1886,6 +1886,55 @@ defmodule MingaAgent.Providers.NativeTest do
       assert budget.session_cost == 0.0
     end
 
+    test "preflight cost limit does not wedge streaming and recovers after budget increase", %{
+      tmp_dir: dir
+    } do
+      call_count = :counters.new(1, [:atomics])
+
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          build_stream_response(
+            [
+              ReqLLM.StreamChunk.text("Initial"),
+              ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+            ],
+            %{total_cost: 2.0}
+          )
+        else
+          build_stream_response([
+            ReqLLM.StreamChunk.text("Recovered"),
+            ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+          ])
+        end
+      end
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, max_cost: 1.0)
+
+      assert :ok = Native.send_prompt(pid, "initial prompt")
+      initial_events = collect_events(1_000)
+      assert Enum.any?(initial_events, &match?(%Event.TextDelta{delta: "Initial"}, &1))
+      assert Enum.any?(initial_events, &match?(%Event.AgentEnd{}, &1))
+      assert {:ok, %{session_cost: 2.0}} = GenServer.call(pid, :get_budget)
+
+      assert {:error, :cost_limit_reached} = Native.send_prompt(pid, "blocked by budget")
+
+      assert_receive {:agent_provider_event, %Event.Error{message: message}}, 1_000
+      assert message =~ "Session cost limit reached"
+      refute_received {:agent_provider_event, %Event.AgentStart{}}
+      assert {:ok, %{is_streaming: false}} = Native.get_state(pid)
+
+      assert :ok = GenServer.call(pid, {:set_max_cost, 3.0})
+      assert :ok = Native.send_prompt(pid, "after budget increase")
+
+      events = collect_events(1_000)
+      assert Enum.any?(events, &match?(%Event.TextDelta{delta: "Recovered"}, &1))
+      assert Enum.any?(events, &match?(%Event.AgentEnd{}, &1))
+      assert {:ok, %{is_streaming: false}} = Native.get_state(pid)
+    end
+
     test "agent stops when cost budget is exceeded during tool loop", %{tmp_dir: dir} do
       File.write!(Path.join(dir, "test.txt"), "hello")
 


### PR DESCRIPTION
# TL;DR
Cost-cap preflight checks no longer wedge the native provider in `streaming: true`. After a user raises the cap with `/budget`, the next prompt can send without requiring `/clear`.

Closes #2460

## Context
The native provider checked the cost cap after marking itself streaming and emitting `AgentStart`. If the session was already over budget, no task was started and no `AgentEnd` reset the provider. That left later prompts stuck behind `:already_streaming`, so the suggested `/budget <amount>` recovery did not work.

## Changes
- Move the preflight cost-cap check before the provider appends the prompt, flips `streaming`, or emits `AgentStart`.
- Keep `abort` defensive by clearing `streaming` when no task is running.
- Make `set_max_cost` clear stale no-task streaming state once the new budget allows progress.
- Add a public-behavior regression test: spend through a normal successful prompt, hit the preflight cap on the next prompt, raise the budget, and verify the next prompt succeeds.

## Verification
- `mix test test/minga_agent/providers/native_test.exs` -> 46 passed
- `mix compile --warnings-as-errors` -> passed
- `mix format --check-formatted` -> passed
- `mix credo --strict lib/minga_agent/providers/native.ex test/minga_agent/providers/native_test.exs` -> passed, with the existing oversized `LoopCtx` warning
- `mix native.build.support` -> built and copied `minga-parser` and `minga-hook-runner`
- `mix test` -> 9,686 passed, 1 skipped, 191 excluded

## Acceptance Criteria Addressed
- Raising the cap with `/budget <amount>` lets the next prompt send after the cost cap is hit.
- The provider is not left `streaming: true` with no task after the preflight cost-cap path.
- A native provider regression test covers the over-budget preflight path and recovery without `/clear`.
