### PR TITLE
fix(agent): make tool approvals escapable

### DIFF
--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1449,7 +1449,7 @@ defmodule MingaAgent.Session do
 
   defp handle_approval_response(_approval_id, decision, state) do
     %{tool_call_id: tool_call_id, reply_to: reply_to} = approval = state.pending_approval
-    state = maybe_set_trust_for_decision(state, approval.name, decision)
+    state = maybe_set_trust_for_decision(state, approval, decision)
 
     # Send the execution decision directly to the blocked Task process.
     send(reply_to, {:tool_approval_response, tool_call_id, execution_decision(decision)})
@@ -1661,7 +1661,7 @@ defmodule MingaAgent.Session do
   end
 
   defp handle_provider_event(%Event.ToolApproval{} = event, state) do
-    case Map.get(state.trust_levels, event.name) do
+    case trusted_scope_for_approval(state.trust_levels, event) do
       nil ->
         request_tool_approval(event, state)
 
@@ -1870,18 +1870,61 @@ defmodule MingaAgent.Session do
     append_msg(state, msg)
   end
 
-  @spec maybe_set_trust_for_decision(state(), String.t(), approval_decision()) :: state()
-  defp maybe_set_trust_for_decision(state, name, :approve_session),
-    do: put_tool_trust(state, name, :session)
+  @spec maybe_set_trust_for_decision(state(), MingaAgent.ToolApproval.t(), approval_decision()) ::
+          state()
+  defp maybe_set_trust_for_decision(state, approval, :approve_session),
+    do: put_tool_trust(state, approval_trust_key(approval), :session)
 
-  defp maybe_set_trust_for_decision(state, name, :approve_turn),
-    do: put_tool_trust(state, name, :turn)
+  defp maybe_set_trust_for_decision(state, approval, :approve_turn),
+    do: put_tool_trust(state, approval_trust_key(approval), :turn)
 
-  defp maybe_set_trust_for_decision(state, _name, _decision), do: state
+  defp maybe_set_trust_for_decision(state, _approval, _decision), do: state
 
   @spec put_tool_trust(state(), String.t(), trust_scope()) :: state()
   defp put_tool_trust(state, name, scope) when is_binary(name) and scope in [:session, :turn] do
     %{state | trust_levels: Map.put(state.trust_levels, name, scope)}
+  end
+
+  @spec trusted_scope_for_approval(%{String.t() => trust_scope()}, Event.ToolApproval.t()) ::
+          trust_scope() | nil
+  defp trusted_scope_for_approval(trust_levels, %Event.ToolApproval{} = event) do
+    Map.get(trust_levels, trust_key(event.name, event.args)) || Map.get(trust_levels, event.name)
+  end
+
+  @spec approval_trust_key(MingaAgent.ToolApproval.t()) :: String.t()
+  defp approval_trust_key(%MingaAgent.ToolApproval{name: name, args: args}) do
+    trust_key(name, args)
+  end
+
+  @spec trust_key(String.t(), map()) :: String.t()
+  defp trust_key("shell", args) when is_map(args), do: shell_trust_key(args)
+
+  defp trust_key("call_mcp_tool", args) when is_map(args),
+    do: hashed_trust_key("call_mcp_tool", args)
+
+  defp trust_key("list_mcp_tools", args) when is_map(args),
+    do: hashed_trust_key("list_mcp_tools", args)
+
+  defp trust_key("mcp_" <> _rest = name, args) when is_map(args), do: hashed_trust_key(name, args)
+  defp trust_key(name, _args), do: name
+
+  @spec shell_trust_key(map()) :: String.t()
+  defp shell_trust_key(args) do
+    case Map.get(args, "command") || Map.get(args, :command) do
+      command when is_binary(command) -> "shell:#{command}"
+      _other -> hashed_trust_key("shell", args)
+    end
+  end
+
+  @spec hashed_trust_key(String.t(), map()) :: String.t()
+  defp hashed_trust_key(name, args) do
+    hash =
+      :sha256
+      |> :crypto.hash(:erlang.term_to_binary(args))
+      |> Base.encode16(case: :lower)
+      |> String.slice(0, 12)
+
+    "#{name}:#{hash}"
   end
 
   @spec execution_decision(approval_decision()) :: :approve | :reject

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1922,7 +1922,6 @@ defmodule MingaAgent.Session do
       :sha256
       |> :crypto.hash(:erlang.term_to_binary(args))
       |> Base.encode16(case: :lower)
-      |> String.slice(0, 12)
 
     "#{name}:#{hash}"
   end

--- a/lib/minga_editor/input/tool_approval.ex
+++ b/lib/minga_editor/input/tool_approval.ex
@@ -4,7 +4,8 @@ defmodule MingaEditor.Input.ToolApproval do
 
   Active when `agent.pending_approval` is non-nil and the panel
   input is not focused. Handles y or Enter (approve), a (trust this tool for the session),
-  t (trust this tool for the current turn), n (deny), and swallows all other keys.
+  t (trust this tool for the current turn), n or Esc (deny), and lets unrelated keys continue
+  through normal editor routing.
   """
 
   @behaviour MingaEditor.Input.Handler
@@ -22,18 +23,24 @@ defmodule MingaEditor.Input.ToolApproval do
     agent = AgentAccess.agent(state)
 
     if is_map(agent.pending_approval) and not AgentAccess.input_focused?(state) do
-      {:handled, dispatch_approval(state, cp)}
+      dispatch_approval(state, cp)
     else
       {:passthrough, state}
     end
   end
 
-  @spec dispatch_approval(EditorState.t(), non_neg_integer()) :: EditorState.t()
-  defp dispatch_approval(state, ?y), do: Commands.execute(state, :agent_approve_tool)
-  defp dispatch_approval(state, 13), do: Commands.execute(state, :agent_approve_tool)
-  defp dispatch_approval(state, ?a), do: Commands.execute(state, :agent_trust_tool_session)
-  defp dispatch_approval(state, ?t), do: Commands.execute(state, :agent_trust_tool_turn)
-  defp dispatch_approval(state, ?n), do: Commands.execute(state, :agent_deny_tool)
-  defp dispatch_approval(state, 27), do: Commands.execute(state, :agent_dismiss_or_noop)
-  defp dispatch_approval(state, _cp), do: state
+  @spec dispatch_approval(EditorState.t(), non_neg_integer()) ::
+          MingaEditor.Input.Handler.result()
+  defp dispatch_approval(state, ?y), do: {:handled, Commands.execute(state, :agent_approve_tool)}
+  defp dispatch_approval(state, 13), do: {:handled, Commands.execute(state, :agent_approve_tool)}
+
+  defp dispatch_approval(state, ?a),
+    do: {:handled, Commands.execute(state, :agent_trust_tool_session)}
+
+  defp dispatch_approval(state, ?t),
+    do: {:handled, Commands.execute(state, :agent_trust_tool_turn)}
+
+  defp dispatch_approval(state, ?n), do: {:handled, Commands.execute(state, :agent_deny_tool)}
+  defp dispatch_approval(state, 27), do: {:handled, Commands.execute(state, :agent_deny_tool)}
+  defp dispatch_approval(state, _cp), do: {:passthrough, state}
 end

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -1451,13 +1451,70 @@ defmodule MingaAgent.SessionTest do
       send_approval(session)
       assert :ok = Session.respond_to_approval(session, :approve_session)
       assert_receive {:tool_approval_response, "tc1", :approve}, @event_timeout
-      assert Session.list_tool_trust(session) == %{"shell" => :session}
+      assert Session.list_tool_trust(session) == %{"shell:rm -rf /" => :session}
 
       session = start_subscribed_session()
       send_approval(session)
       assert :ok = Session.respond_to_approval(session, :approve_turn)
       assert_receive {:tool_approval_response, "tc1", :approve}, @event_timeout
-      assert Session.list_tool_trust(session) == %{"shell" => :turn}
+      assert Session.list_tool_trust(session) == %{"shell:rm -rf /" => :turn}
+    end
+
+    test "approval session trust for shell is scoped to the approved command" do
+      session = start_subscribed_session()
+      send_approval(session)
+      assert :ok = Session.respond_to_approval(session, :approve_session)
+      assert_receive {:tool_approval_response, "tc1", :approve}, @event_timeout
+
+      send_provider_event(session, %Event.ToolApproval{
+        tool_call_id: "tc_same",
+        name: "shell",
+        args: %{"command" => "rm -rf /"},
+        reply_to: self()
+      })
+
+      assert_receive {:tool_approval_response, "tc_same", :approve}, @event_timeout
+
+      assert_receive {:agent_event, _, {:tool_auto_approved, "tc_same", "shell", :session}},
+                     @event_timeout
+
+      send_provider_event(session, %Event.ToolApproval{
+        tool_call_id: "tc_other",
+        name: "shell",
+        args: %{"command" => "pwd"},
+        reply_to: self()
+      })
+
+      assert_receive {:agent_event, _, {:approval_pending, pending}}, @event_timeout
+      assert pending.tool_call_id == "tc_other"
+      refute_received {:tool_approval_response, "tc_other", :approve}
+    end
+
+    test "approval session trust for MCP tools is scoped to the approved arguments" do
+      session = start_subscribed_session()
+
+      send_provider_event(session, %Event.ToolApproval{
+        tool_call_id: "tc_mcp",
+        name: "mcp_files__delete",
+        args: %{"path" => "tmp/a.txt"},
+        reply_to: self()
+      })
+
+      assert_receive {:agent_event, _, {:approval_pending, _}}, @event_timeout
+      assert :ok = Session.respond_to_approval(session, :approve_session)
+      assert_receive {:tool_approval_response, "tc_mcp", :approve}, @event_timeout
+      refute Map.has_key?(Session.list_tool_trust(session), "mcp_files__delete")
+
+      send_provider_event(session, %Event.ToolApproval{
+        tool_call_id: "tc_mcp_other",
+        name: "mcp_files__delete",
+        args: %{"path" => "tmp/b.txt"},
+        reply_to: self()
+      })
+
+      assert_receive {:agent_event, _, {:approval_pending, pending}}, @event_timeout
+      assert pending.tool_call_id == "tc_mcp_other"
+      refute_received {:tool_approval_response, "tc_mcp_other", :approve}
     end
 
     test "bare approve sets no tool trust" do

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -1503,7 +1503,26 @@ defmodule MingaAgent.SessionTest do
       assert_receive {:agent_event, _, {:approval_pending, _}}, @event_timeout
       assert :ok = Session.respond_to_approval(session, :approve_session)
       assert_receive {:tool_approval_response, "tc_mcp", :approve}, @event_timeout
-      refute Map.has_key?(Session.list_tool_trust(session), "mcp_files__delete")
+
+      trust = Session.list_tool_trust(session)
+      assert [key] = Map.keys(trust)
+      assert key =~ ~r/^mcp_files__delete:[0-9a-f]{64}$/
+      assert trust[key] == :session
+
+      send_provider_event(session, %Event.ToolApproval{
+        tool_call_id: "tc_mcp_same",
+        name: "mcp_files__delete",
+        args: %{"path" => "tmp/a.txt"},
+        reply_to: self()
+      })
+
+      assert_receive {:tool_approval_response, "tc_mcp_same", :approve}, @event_timeout
+
+      assert_receive {:agent_event, _,
+                      {:tool_auto_approved, "tc_mcp_same", "mcp_files__delete", :session}},
+                     @event_timeout
+
+      refute_received {:agent_event, _, {:approval_pending, _}}
 
       send_provider_event(session, %Event.ToolApproval{
         tool_call_id: "tc_mcp_other",

--- a/test/minga_editor/input/scoped_test.exs
+++ b/test/minga_editor/input/scoped_test.exs
@@ -611,9 +611,9 @@ defmodule MingaEditor.Input.ScopedTest do
       end
     end
 
-    test "unrelated key is swallowed during approval", %{state: state} do
+    test "unrelated key passes through approval routing", %{state: state} do
       {:handled, new_state} = walk_surface_handlers(state, ?x, 0)
-      # The key is swallowed, pending_approval stays
+      # The approval handler passes it through, and downstream routing still handles the key.
       assert AgentAccess.agent(new_state).pending_approval != nil
     end
 

--- a/test/minga_editor/input/sub_state_handlers_test.exs
+++ b/test/minga_editor/input/sub_state_handlers_test.exs
@@ -151,6 +151,11 @@ defmodule MingaEditor.Input.SubStateHandlersTest do
       {:handled, _} = ToolApproval.handle_key(state, ?n, 0)
     end
 
+    test "handles Esc as denial when approval is pending", %{approval: approval} do
+      state = base_state(keymap_scope: :agent, agentic_active: true, pending_approval: approval)
+      {:handled, _} = ToolApproval.handle_key(state, 27, 0)
+    end
+
     test "handles a as session trust when approval is pending", %{approval: approval} do
       state = base_state(keymap_scope: :agent, agentic_active: true, pending_approval: approval)
       {:handled, _} = ToolApproval.handle_key(state, ?a, 0)
@@ -161,10 +166,9 @@ defmodule MingaEditor.Input.SubStateHandlersTest do
       {:handled, _} = ToolApproval.handle_key(state, ?t, 0)
     end
 
-    test "swallows unrelated keys when approval is pending", %{approval: approval} do
+    test "passes unrelated keys through when approval is pending", %{approval: approval} do
       state = base_state(keymap_scope: :agent, agentic_active: true, pending_approval: approval)
-      {:handled, new_state} = ToolApproval.handle_key(state, ?x, 0)
-      # Key is swallowed, approval still pending
+      {:passthrough, new_state} = ToolApproval.handle_key(state, ?x, 0)
       assert AgentAccess.agent(new_state).pending_approval != nil
     end
 

--- a/test/minga_editor/integration/agent_workflow_conformance_test.exs
+++ b/test/minga_editor/integration/agent_workflow_conformance_test.exs
@@ -194,13 +194,13 @@ defmodule MingaEditor.Integration.AgentWorkflowConformanceTest do
        %Event.ToolStart{
          tool_call_id: "tc_second",
          name: "shell",
-         args: %{"command" => "mix format --check-formatted"}
+         args: %{"command" => "mix test"}
        }},
       {:event,
        %Event.ToolApproval{
          tool_call_id: "tc_second",
          name: "shell",
-         args: %{"command" => "mix format --check-formatted"},
+         args: %{"command" => "mix test"},
          reply_to: self()
        }},
       {:event, %Event.AgentEnd{usage: nil}}

--- a/test/minga_editor/integration/agent_workflow_conformance_test.exs
+++ b/test/minga_editor/integration/agent_workflow_conformance_test.exs
@@ -125,7 +125,7 @@ defmodule MingaEditor.Integration.AgentWorkflowConformanceTest do
     assert %AgentChat{visible?: true, status: :error} = model
   end
 
-  test "tool approval can be denied through public agent input", %{
+  test "pressing Esc denies a visible tool approval through public agent input", %{
     tmp_dir: dir,
     options_server: options_server
   } do
@@ -159,7 +159,7 @@ defmodule MingaEditor.Integration.AgentWorkflowConformanceTest do
       "expected destructive tool approval to become visible"
     )
 
-    Workflow.deny_tool(ctx)
+    send_key_sync(ctx, 27)
 
     assert_receive {:tool_approval_response, "tc_deny", :reject}, @event_timeout
 


### PR DESCRIPTION
## Summary
- Makes Esc deny a pending tool approval so the agent unblocks instead of leaving a stuck approval.
- Lets unrelated keys pass through normal input routing while a tool approval is pending.
- Scopes approval-created session/turn trust to the approved shell command or MCP argument set, while preserving explicit name-level trust from existing trust APIs.

Closes #2461

## Verification
- mix test test/minga_editor/input/sub_state_handlers_test.exs test/minga_editor/agent/ingest_approval_regression_test.exs test/minga_editor/integration/agent_workflow_conformance_test.exs test/minga_agent/session_test.exs
- mix compile --warnings-as-errors
- mix format --check-formatted
- mix credo --strict lib/minga_editor/input/tool_approval.ex lib/minga_agent/session.ex test/minga_editor/input/sub_state_handlers_test.exs test/minga_agent/session_test.exs test/minga_editor/integration/agent_workflow_conformance_test.exs
- mix native.build.support
- mix test

Reviewer gate: skipped because no reviewer/subagent tool is available in this harness.