### PR TITLE
fix(agent): bound provider restart recovery

### DIFF
--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -79,6 +79,23 @@ defmodule MingaAgent.Session do
   @type tool_approval_policy ::
           :interactive | {:auto_approve, trust_scope()} | {:reject, String.t()}
 
+  @typedoc "Provider restart backoff policy."
+  @type provider_restart_policy :: %{
+          base_delay_ms: pos_integer(),
+          max_attempts: pos_integer(),
+          max_delay_ms: pos_integer(),
+          window_ms: non_neg_integer()
+        }
+
+  @typedoc "Provider restart backoff runtime state."
+  @type provider_restart_state :: %{
+          attempts: non_neg_integer(),
+          window_started_at_ms: integer() | nil,
+          timer_ref: reference() | nil,
+          timer_token: reference() | nil,
+          last_reason: term()
+        }
+
   @typedoc "Internal session state."
   @type state :: %{
           session_id: String.t(),
@@ -91,6 +108,8 @@ defmodule MingaAgent.Session do
           provider_source: Minga.Extension.ContributionCleanup.contribution_source(),
           provider_lease: CodeLease.t() | nil,
           provider_opts: keyword(),
+          provider_restart_policy: provider_restart_policy(),
+          provider_restart: provider_restart_state(),
           credentials_configured_fn: credentials_configured_fn(),
           status: status(),
           messages: [Message.t()],
@@ -132,6 +151,11 @@ defmodule MingaAgent.Session do
           pinned_ids: MapSet.t(pos_integer()),
           credentials_configured: boolean()
         }
+
+  @provider_restart_default_base_delay_ms 2_000
+  @provider_restart_default_max_delay_ms 30_000
+  @provider_restart_default_max_attempts 5
+  @provider_restart_default_window_ms 60_000
 
   # ── Public API ──────────────────────────────────────────────────────────────
 
@@ -175,6 +199,12 @@ defmodule MingaAgent.Session do
   @spec new_session(GenServer.server()) :: :ok | {:error, term()}
   def new_session(session) do
     GenServer.call(session, :new_session)
+  end
+
+  @doc "Retries provider startup immediately, resetting any exhausted restart backoff."
+  @spec restart_provider(GenServer.server()) :: :ok | {:error, term()}
+  def restart_provider(session) do
+    GenServer.call(session, :restart_provider)
   end
 
   @doc "Seeds a session transcript without sending a prompt."
@@ -700,6 +730,8 @@ defmodule MingaAgent.Session do
       provider_source: provider_resolution.source,
       provider_lease: provider_lease,
       provider_opts: provider_opts,
+      provider_restart_policy: provider_restart_policy(opts),
+      provider_restart: initial_provider_restart_state(),
       credentials_configured_fn: credentials_configured_fn,
       status: :idle,
       messages: [
@@ -1105,6 +1137,29 @@ defmodule MingaAgent.Session do
     {:reply, :ok, put_tool_trust(state, name, scope)}
   end
 
+  def handle_call(:restart_provider, _from, state) do
+    state =
+      state
+      |> cancel_provider_restart_timer()
+      |> reset_provider_restart()
+
+    {state, result} = refresh_credentials_state_result(state)
+
+    case {state.provider, result} do
+      {provider, :ok} when is_pid(provider) ->
+        {:reply, :ok, state}
+
+      {_provider, :ok} when state.credentials_configured == false ->
+        {:reply, {:error, :credentials_not_configured}, state}
+
+      {_provider, :ok} ->
+        {:reply, {:error, :provider_not_ready}, state}
+
+      {_provider, {:error, reason}} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
   def handle_call({:revoke_tool_trust, :all}, _from, state) do
     {:reply, :ok, %{state | trust_levels: %{}}}
   end
@@ -1355,6 +1410,15 @@ defmodule MingaAgent.Session do
     {:noreply, refresh_credentials_state(state)}
   end
 
+  def handle_info({:start_provider, token}, %{provider_restart: %{timer_token: token}} = state) do
+    state = put_provider_restart_timer(state, nil, nil)
+    {:noreply, refresh_credentials_state(state)}
+  end
+
+  def handle_info({:start_provider, _token}, state) do
+    {:noreply, state}
+  end
+
   def handle_info({:agent_provider_event, event}, state) do
     state = handle_provider_event(event, state)
     {:noreply, state}
@@ -1364,19 +1428,18 @@ defmodule MingaAgent.Session do
     Minga.Log.warning(:agent, "[Agent.Session] provider process died: #{inspect(reason)}")
     release_provider_lease(state.provider_lease)
 
-    state = %{
+    state =
       state
-      | provider: nil,
+      |> Map.merge(%{
+        provider: nil,
         provider_lease: nil,
         error_message: "Agent provider crashed",
         turn_active?: false
-    }
+      })
+      |> set_error_status()
+      |> maybe_schedule_provider_restart(reason)
 
-    state = set_error_status(state)
     broadcast(state, {:error, state.error_message})
-
-    # Try to restart the provider after a brief delay
-    Process.send_after(self(), :start_provider, 2000)
     {:noreply, state}
   end
 
@@ -2891,6 +2954,8 @@ defmodule MingaAgent.Session do
 
         {:error, reason} ->
           state = report_provider_start_error(state, reason)
+          state = maybe_schedule_provider_restart(state, reason)
+          broadcast(state, {:error, state.error_message})
           {state, {:error, state.error_message}}
       end
     else
@@ -2904,7 +2969,13 @@ defmodule MingaAgent.Session do
   defp attach_provider(state, pid, lease) do
     Process.unlink(pid)
     Process.monitor(pid)
-    state = clear_provider_start_error(%{state | provider: pid, provider_lease: lease})
+
+    state =
+      state
+      |> cancel_provider_restart_timer()
+      |> Map.merge(%{provider: pid, provider_lease: lease})
+      |> clear_provider_start_error()
+
     state = seed_provider_messages(state, state.messages)
     state = apply_pending_thinking_level(state)
     state = maybe_show_auth_onboarding(state)
@@ -2924,9 +2995,156 @@ defmodule MingaAgent.Session do
     release_provider_lease(state.provider_lease)
     state = %{state | provider_lease: nil, error_message: format_error(reason)}
     state = set_error_status(state)
-    broadcast(state, {:error, state.error_message})
     state
   end
+
+  @spec provider_restart_policy(keyword()) :: provider_restart_policy()
+  defp provider_restart_policy(opts) do
+    %{
+      base_delay_ms:
+        Keyword.get(
+          opts,
+          :provider_restart_backoff_base_ms,
+          @provider_restart_default_base_delay_ms
+        ),
+      max_attempts:
+        Keyword.get(opts, :provider_restart_max_attempts, @provider_restart_default_max_attempts),
+      max_delay_ms:
+        Keyword.get(
+          opts,
+          :provider_restart_backoff_max_ms,
+          @provider_restart_default_max_delay_ms
+        ),
+      window_ms:
+        Keyword.get(opts, :provider_restart_window_ms, @provider_restart_default_window_ms)
+    }
+  end
+
+  @spec initial_provider_restart_state() :: provider_restart_state()
+  defp initial_provider_restart_state do
+    %{
+      attempts: 0,
+      window_started_at_ms: nil,
+      timer_ref: nil,
+      timer_token: nil,
+      last_reason: nil
+    }
+  end
+
+  @spec reset_provider_restart(state()) :: state()
+  defp reset_provider_restart(state) do
+    %{state | provider_restart: initial_provider_restart_state()}
+  end
+
+  @spec maybe_schedule_provider_restart(state(), term()) :: state()
+  defp maybe_schedule_provider_restart(state, reason) do
+    case next_provider_restart(state.provider_restart, state.provider_restart_policy, reason) do
+      {:ok, restart, delay_ms} ->
+        token = make_ref()
+        timer_ref = Process.send_after(self(), {:start_provider, token}, delay_ms)
+
+        state
+        |> cancel_provider_restart_timer()
+        |> put_provider_restart(%{restart | timer_ref: timer_ref, timer_token: token})
+        |> put_provider_retrying_error(delay_ms)
+
+      :exhausted ->
+        state
+        |> cancel_provider_restart_timer()
+        |> put_provider_restart(%{state.provider_restart | last_reason: reason})
+        |> put_provider_restart_exhausted_error()
+    end
+  end
+
+  @spec next_provider_restart(provider_restart_state(), provider_restart_policy(), term()) ::
+          {:ok, provider_restart_state(), pos_integer()} | :exhausted
+  defp next_provider_restart(restart, policy, reason) do
+    now_ms = System.monotonic_time(:millisecond)
+
+    {attempts, window_started_at_ms} =
+      case restart do
+        %{window_started_at_ms: window_started_at_ms, attempts: attempts}
+        when is_integer(window_started_at_ms) and
+               now_ms - window_started_at_ms <= policy.window_ms ->
+          {attempts + 1, window_started_at_ms}
+
+        _other ->
+          {1, now_ms}
+      end
+
+    if attempts > policy.max_attempts do
+      :exhausted
+    else
+      next_restart = %{
+        restart
+        | attempts: attempts,
+          window_started_at_ms: window_started_at_ms,
+          timer_ref: nil,
+          timer_token: nil,
+          last_reason: reason
+      }
+
+      {:ok, next_restart, provider_restart_delay_ms(policy, attempts)}
+    end
+  end
+
+  @spec provider_restart_delay_ms(provider_restart_policy(), pos_integer()) :: pos_integer()
+  defp provider_restart_delay_ms(
+         %{base_delay_ms: base_delay_ms, max_delay_ms: max_delay_ms},
+         attempts
+       ) do
+    exponential = base_delay_ms * round(:math.pow(2, attempts - 1))
+    min(exponential, max_delay_ms)
+  end
+
+  @spec cancel_provider_restart_timer(state()) :: state()
+  defp cancel_provider_restart_timer(%{provider_restart: %{timer_ref: timer_ref}} = state)
+       when is_reference(timer_ref) do
+    Process.cancel_timer(timer_ref)
+    put_provider_restart_timer(state, nil, nil)
+  end
+
+  defp cancel_provider_restart_timer(state), do: state
+
+  @spec put_provider_restart(state(), provider_restart_state()) :: state()
+  defp put_provider_restart(state, restart), do: %{state | provider_restart: restart}
+
+  @spec put_provider_restart_timer(state(), reference() | nil, reference() | nil) :: state()
+  defp put_provider_restart_timer(state, timer_ref, timer_token) do
+    restart = %{state.provider_restart | timer_ref: timer_ref, timer_token: timer_token}
+    put_provider_restart(state, restart)
+  end
+
+  @spec put_provider_retrying_error(state(), pos_integer()) :: state()
+  defp put_provider_retrying_error(state, delay_ms) do
+    seconds = Float.round(delay_ms / 1000, 1)
+    attempts = state.provider_restart.attempts
+    max_attempts = state.provider_restart_policy.max_attempts
+    cause = provider_restart_cause(state)
+
+    message =
+      "#{cause}. Retrying in #{seconds}s (attempt #{attempts}/#{max_attempts}). Press Ctrl-C to retry now, or run /clear to reset."
+
+    %{state | error_message: message}
+  end
+
+  @spec put_provider_restart_exhausted_error(state()) :: state()
+  defp put_provider_restart_exhausted_error(state) do
+    cause = provider_restart_cause(state)
+
+    message =
+      "#{cause}. Automatic restart stopped. Press Ctrl-C to retry now, or run /clear to reset."
+
+    %{state | error_message: message}
+  end
+
+  @spec provider_restart_cause(state()) :: String.t()
+  defp provider_restart_cause(%{error_message: message})
+       when is_binary(message) and message != "" do
+    String.trim_trailing(message, ".")
+  end
+
+  defp provider_restart_cause(_state), do: "Agent provider unavailable"
 
   # Shows an onboarding message when no credentials are configured and the
   # native provider is active. Only fires once per session. Relies on the

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -773,6 +773,26 @@ defmodule MingaEditor.Commands.Agent do
     end
   end
 
+  @doc "Retries the current agent provider after a startup or crash error."
+  @spec restart_agent_provider(state()) :: state()
+  def restart_agent_provider(state) do
+    case AgentAccess.session(state) do
+      nil ->
+        EditorState.set_status(state, "No agent session to restart")
+
+      session ->
+        case Session.restart_provider(session) do
+          :ok ->
+            EditorState.set_status(state, "Agent provider restarted")
+
+          {:error, reason} ->
+            EditorState.set_status(state, "Agent restart failed: #{inspect(reason)}")
+        end
+    end
+  catch
+    :exit, _ -> EditorState.set_status(state, "Agent restart failed")
+  end
+
   @doc """
   Pulls all queued messages back into the prompt input without aborting the agent.
 
@@ -831,10 +851,10 @@ defmodule MingaEditor.Commands.Agent do
   """
   @spec scope_ctrl_c(state()) :: state()
   def scope_ctrl_c(state) do
-    if AgentAccess.agent(state).runtime.status in [:thinking, :tool_executing] do
-      abort_agent(state)
-    else
-      input_to_normal(state)
+    case AgentAccess.agent(state).runtime.status do
+      status when status in [:thinking, :tool_executing] -> abort_agent(state)
+      :error -> restart_agent_provider(state)
+      _status -> input_to_normal(state)
     end
   end
 

--- a/test/minga_agent/session_recovery_test.exs
+++ b/test/minga_agent/session_recovery_test.exs
@@ -54,6 +54,96 @@ defmodule MingaAgent.SessionRecoveryTest do
     def get_state(_pid), do: {:ok, %{model: nil}}
   end
 
+  defmodule FlakyStartProvider do
+    @behaviour MingaAgent.Provider
+
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts) do
+      test_pid = Keyword.fetch!(opts, :test_pid)
+      tracker = Keyword.fetch!(opts, :tracker)
+
+      attempt =
+        Agent.get_and_update(tracker, fn state ->
+          attempt = Map.get(state, :attempts, 0) + 1
+          failures_remaining = Map.get(state, :failures_remaining, 0)
+
+          next_failures =
+            if failures_remaining == :always, do: :always, else: max(failures_remaining - 1, 0)
+
+          next_state = %{state | attempts: attempt, failures_remaining: next_failures}
+          {{attempt, failures_remaining}, next_state}
+        end)
+
+      send(test_pid, {:flaky_start_attempt, elem(attempt, 0)})
+
+      case attempt do
+        {_attempt, :always} ->
+          {:error, {:spawn_failed, "boom"}}
+
+        {_attempt, failures_remaining} when failures_remaining > 0 ->
+          {:error, {:spawn_failed, "boom"}}
+
+        _attempt ->
+          GenServer.start_link(__MODULE__, opts)
+      end
+    end
+
+    @impl MingaAgent.Provider
+    def send_prompt(_pid, _text), do: :ok
+
+    @impl MingaAgent.Provider
+    def abort(_pid), do: :ok
+
+    @impl MingaAgent.Provider
+    def new_session(_pid), do: :ok
+
+    @impl MingaAgent.Provider
+    def seed_messages(_pid, _messages), do: :ok
+
+    @impl MingaAgent.Provider
+    def get_state(_pid), do: {:ok, %{model: nil}}
+
+    @impl GenServer
+    def init(opts) do
+      test_pid = Keyword.fetch!(opts, :test_pid)
+      send(test_pid, {:flaky_provider_started, self()})
+      {:ok, %{test_pid: test_pid}}
+    end
+  end
+
+  defmodule CrashableProvider do
+    @behaviour MingaAgent.Provider
+
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl MingaAgent.Provider
+    def send_prompt(_pid, _text), do: :ok
+
+    @impl MingaAgent.Provider
+    def abort(_pid), do: :ok
+
+    @impl MingaAgent.Provider
+    def new_session(_pid), do: :ok
+
+    @impl MingaAgent.Provider
+    def seed_messages(_pid, _messages), do: :ok
+
+    @impl MingaAgent.Provider
+    def get_state(_pid), do: {:ok, %{model: nil}}
+
+    @impl GenServer
+    def init(opts) do
+      test_pid = Keyword.fetch!(opts, :test_pid)
+      send(test_pid, {:crashable_provider_started, self()})
+      {:ok, %{test_pid: test_pid}}
+    end
+  end
+
   test "refresh_credentials/1 starts a provider only after credentials flip true and model is concrete" do
     {session, checker} =
       start_session(
@@ -114,10 +204,93 @@ defmodule MingaAgent.SessionRecoveryTest do
 
     Agent.update(checker, fn _ -> true end)
 
-    assert {:error, "Failed to start agent: boom"} =
-             Session.set_model(session, "anthropic:claude-sonnet-4-20250514")
+    assert {:error, message} = Session.set_model(session, "anthropic:claude-sonnet-4-20250514")
+    assert message =~ "Failed to start agent: boom"
+    assert message =~ "Press Ctrl-C to retry now"
 
     assert Session.get_provider(session) == nil
+  end
+
+  test "provider start failures retry with backoff and recover" do
+    {:ok, tracker} = Agent.start_link(fn -> %{attempts: 0, failures_remaining: 1} end)
+
+    {:ok, session} =
+      Session.start_link(
+        provider: FlakyStartProvider,
+        provider_opts: [test_pid: self(), tracker: tracker],
+        provider_restart_backoff_base_ms: 1,
+        provider_restart_backoff_max_ms: 1,
+        provider_restart_max_attempts: 3
+      )
+
+    on_exit(fn ->
+      Process.exit(session, :kill)
+      Process.exit(tracker, :kill)
+    end)
+
+    assert_receive {:flaky_start_attempt, 1}, 1_000
+    assert_receive {:flaky_start_attempt, 2}, 1_000
+    assert_receive {:flaky_provider_started, provider}, 1_000
+    assert Session.get_provider(session) == provider
+    assert Session.status(session) == :idle
+  end
+
+  test "repeated provider crashes back off and stop after the configured cap" do
+    {:ok, session} =
+      Session.start_link(
+        provider: CrashableProvider,
+        provider_opts: [test_pid: self()],
+        provider_restart_backoff_base_ms: 1,
+        provider_restart_backoff_max_ms: 1,
+        provider_restart_max_attempts: 2
+      )
+
+    on_exit(fn -> Process.exit(session, :kill) end)
+
+    assert :ok = Session.subscribe(session)
+
+    assert_receive {:crashable_provider_started, provider1}, 1_000
+    Process.exit(provider1, :kill)
+    assert_receive {:crashable_provider_started, provider2}, 1_000
+    Process.exit(provider2, :kill)
+    assert_receive {:crashable_provider_started, provider3}, 1_000
+    Process.exit(provider3, :kill)
+
+    assert_snapshot_error(session, "Automatic restart stopped")
+
+    refute_receive {:crashable_provider_started, _provider4}, 50
+  end
+
+  test "restart_provider/1 recovers manually after automatic start retries are exhausted" do
+    {:ok, tracker} = Agent.start_link(fn -> %{attempts: 0, failures_remaining: :always} end)
+
+    {:ok, session} =
+      Session.start_link(
+        provider: FlakyStartProvider,
+        provider_opts: [test_pid: self(), tracker: tracker],
+        provider_restart_backoff_base_ms: 1,
+        provider_restart_backoff_max_ms: 1,
+        provider_restart_max_attempts: 1
+      )
+
+    on_exit(fn ->
+      Process.exit(session, :kill)
+      Process.exit(tracker, :kill)
+    end)
+
+    assert :ok = Session.subscribe(session)
+    assert_receive {:flaky_start_attempt, 1}, 1_000
+    assert_receive {:flaky_start_attempt, 2}, 1_000
+
+    assert_snapshot_error(session, "Automatic restart stopped")
+
+    Agent.update(tracker, &%{&1 | failures_remaining: 0})
+
+    assert :ok = Session.restart_provider(session)
+    assert_receive {:flaky_start_attempt, 3}, 1_000
+    assert_receive {:flaky_provider_started, provider}, 1_000
+    assert Session.get_provider(session) == provider
+    assert Session.status(session) == :idle
   end
 
   test "custom providers still start when the top-level model name is unknown" do
@@ -190,5 +363,23 @@ defmodule MingaAgent.SessionRecoveryTest do
 
     assert is_pid(Session.get_provider(session))
     assert Session.metadata(session).model_name == "anthropic:claude-sonnet-4-20250514"
+  end
+
+  defp assert_snapshot_error(session, expected_text, attempts \\ 20)
+
+  defp assert_snapshot_error(session, expected_text, attempts) when attempts > 0 do
+    snapshot = Session.editor_snapshot(session)
+
+    if is_binary(snapshot.error) and String.contains?(snapshot.error, expected_text) do
+      :ok
+    else
+      assert_receive {:agent_event, ^session, _event}, 1_000
+      assert_snapshot_error(session, expected_text, attempts - 1)
+    end
+  end
+
+  defp assert_snapshot_error(session, expected_text, 0) do
+    snapshot = Session.editor_snapshot(session)
+    assert is_binary(snapshot.error) and String.contains?(snapshot.error, expected_text)
   end
 end

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -40,6 +40,22 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
   alias MingaEditor.Input
   alias Minga.Test.StubServer
 
+  defmodule RestartStubSession do
+    use GenServer
+
+    @spec start_link(pid()) :: GenServer.on_start()
+    def start_link(test_pid), do: GenServer.start_link(__MODULE__, test_pid)
+
+    @impl GenServer
+    def init(test_pid), do: {:ok, test_pid}
+
+    @impl GenServer
+    def handle_call(:restart_provider, _from, test_pid) do
+      send(test_pid, :restart_provider_called)
+      {:reply, :ok, test_pid}
+    end
+  end
+
   # ── Helpers ──────────────────────────────────────────────────────────────
 
   defp command!(name) do
@@ -591,6 +607,21 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
     test "no-ops when no session exists" do
       state = base_state(session: nil)
       assert AgentCommands.abort_agent(state) == state
+    end
+  end
+
+  describe "scope_ctrl_c/1" do
+    test "retries the provider when the agent is in error state" do
+      {:ok, session} = RestartStubSession.start_link(self())
+
+      state =
+        base_state(session: session)
+        |> AgentAccess.update_agent(&AgentState.set_error(&1, "provider failed"))
+
+      new_state = AgentCommands.scope_ctrl_c(state)
+
+      assert_receive :restart_provider_called
+      assert new_state.shell_state.status_msg == "Agent provider restarted"
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds bounded, tokenized provider restart backoff inside `MingaAgent.Session` for crash and startup-failure paths.
- Preserves the underlying provider failure cause while appending retry/recovery guidance.
- Adds `Session.restart_provider/1` and routes agent Ctrl-C in `:error` state through it so users have a discoverable retry path.

Closes #2462

## Verification
- mix test test/minga_agent/session_recovery_test.exs test/minga_agent/session_provider_registry_test.exs
- mix test test/minga_agent/session_recovery_test.exs test/minga_agent/session_provider_registry_test.exs test/minga_editor/commands/agent_commands_test.exs test/minga_agent/session_test.exs
- mix compile --warnings-as-errors
- mix format --check-formatted
- mix credo --strict lib/minga_agent/session.ex test/minga_agent/session_recovery_test.exs test/minga_editor/commands/agent_commands_test.exs
- mix native.build.support
- mix test

Reviewer gate: skipped because no reviewer/subagent tool is available in this harness.