### PR TITLE
feat(agent): show first-run empty states

### DIFF
--- a/lib/minga_editor/agent/transcript.ex
+++ b/lib/minga_editor/agent/transcript.ex
@@ -11,6 +11,8 @@ defmodule MingaEditor.Agent.Transcript do
   @typedoc "Line type for transcript-line-to-message mapping."
   @type line_type :: :text | :code | :tool | :thinking | :usage | :system | :empty
 
+  @type empty_state :: :credentials_missing | :no_model | nil
+
   @type display_result :: %{
           line_index: [{non_neg_integer(), line_type()}],
           display_messages: [term()],
@@ -21,6 +23,7 @@ defmodule MingaEditor.Agent.Transcript do
 
   @pinned_separator_id 4_000_000_001
   @hidden_separator_id 4_000_000_002
+  @empty_state_index 4_000_000_010
 
   @doc "Builds displayed semantic transcript metadata from raw session messages."
   @spec display([term()], keyword()) :: display_result()
@@ -28,6 +31,8 @@ defmodule MingaEditor.Agent.Transcript do
     display_start = Keyword.get(opts, :display_start_index, 0)
     pinned_ids = Keyword.get(opts, :pinned_ids, MapSet.new())
     message_id_pairs = Keyword.get(opts, :message_ids, [])
+    empty_state = Keyword.get(opts, :empty_state)
+
     hidden_count = min(display_start, length(messages))
 
     visible_entries =
@@ -37,6 +42,16 @@ defmodule MingaEditor.Agent.Transcript do
       |> Enum.map(fn {msg, idx} -> {idx, msg} end)
 
     pinned_entries = extract_pinned_message_entries(message_id_pairs, pinned_ids, hidden_count)
+
+    {visible_entries, pinned_entries, hidden_count, message_id_pairs} =
+      maybe_use_empty_state(
+        messages,
+        empty_state,
+        visible_entries,
+        pinned_entries,
+        hidden_count,
+        message_id_pairs
+      )
 
     {markdown, line_offsets, display_messages, display_message_pairs} =
       build_display_text(visible_entries, pinned_entries, hidden_count, message_id_pairs)
@@ -221,6 +236,80 @@ defmodule MingaEditor.Agent.Transcript do
     |> Enum.map(fn {{_id, msg}, idx} -> {idx, msg} end)
   end
 
+  @spec maybe_use_empty_state(
+          [term()],
+          empty_state(),
+          [{non_neg_integer(), term()}],
+          [{non_neg_integer(), term()}],
+          non_neg_integer(),
+          [{pos_integer(), term()}]
+        ) ::
+          {[{non_neg_integer(), term()}], [{non_neg_integer(), term()}], non_neg_integer(),
+           [{pos_integer(), term()}]}
+  defp maybe_use_empty_state(
+         messages,
+         empty_state,
+         visible_entries,
+         pinned_entries,
+         hidden_count,
+         message_id_pairs
+       )
+       when empty_state in [:credentials_missing, :no_model] do
+    if first_run_transcript?(messages) do
+      {[{@empty_state_index, empty_state_message(empty_state)}], [], 0, []}
+    else
+      {visible_entries, pinned_entries, hidden_count, message_id_pairs}
+    end
+  end
+
+  defp maybe_use_empty_state(
+         _messages,
+         _empty_state,
+         visible_entries,
+         pinned_entries,
+         hidden_count,
+         message_id_pairs
+       ) do
+    {visible_entries, pinned_entries, hidden_count, message_id_pairs}
+  end
+
+  @doc false
+  @spec first_run_transcript?([term()]) :: boolean()
+  def first_run_transcript?(messages) do
+    not Enum.any?(messages, &user_facing_turn_message?/1)
+  end
+
+  @spec user_facing_turn_message?(term()) :: boolean()
+  defp user_facing_turn_message?({kind, _}) when kind in [:user, :assistant, :tool_call, :usage],
+    do: true
+
+  defp user_facing_turn_message?({kind, _, _}) when kind in [:user, :thinking], do: true
+  defp user_facing_turn_message?(_message), do: false
+
+  @spec empty_state_message(:credentials_missing | :no_model) :: {:system, String.t(), :info}
+  defp empty_state_message(:credentials_missing) do
+    {:system,
+     """
+     Connect a provider
+
+     Add an API key with /auth <provider> <key>, or run /login to sign in with a ChatGPT subscription.
+
+     Examples:
+       /auth anthropic <key>
+       /auth openai <key>
+       /auth google <key>
+     """, :info}
+  end
+
+  defp empty_state_message(:no_model) do
+    {:system,
+     """
+     Pick a model
+
+     Use the model picker button, /model, or SPC a m to choose a configured model before starting a chat.
+     """, :info}
+  end
+
   @spec build_display_text(
           [{non_neg_integer(), term()}],
           [{non_neg_integer(), term()}],
@@ -273,6 +362,8 @@ defmodule MingaEditor.Agent.Transcript do
 
   defp display_message_id(_idx, {:system, "── " <> _rest, :info}, _id_by_index),
     do: @hidden_separator_id
+
+  defp display_message_id(@empty_state_index, _msg, _id_by_index), do: @empty_state_index
 
   defp display_message_id(idx, _msg, id_by_index), do: Map.get(id_by_index, idx, idx + 1)
 

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.AgentLifecycle do
   alias MingaEditor.Agent.MarkdownHighlight
   alias MingaEditor.Agent.ProvenanceJump
   alias MingaEditor.Agent.Transcript
+  alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.Session, as: AgentSession
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.View.Preview
@@ -99,6 +100,8 @@ defmodule MingaEditor.AgentLifecycle do
 
   @doc "Caches semantic transcript metadata for an explicit message list."
   @spec cache_messages(state(), [term()]) :: state()
+  def cache_messages(state, []), do: clear_transcript_cache(state)
+
   def cache_messages(state, messages) when is_list(messages) do
     cache_transcript(state, messages)
   end
@@ -112,24 +115,20 @@ defmodule MingaEditor.AgentLifecycle do
 
   @spec cache_transcript(state(), [term()]) :: state()
   defp cache_transcript(state, []) do
-    AgentAccess.update_panel(state, fn panel ->
-      %{
-        panel
-        | cached_line_index: [],
-          cached_display_messages: [],
-          cached_display_message_pairs: [],
-          cached_styled_messages: nil,
-          display_start_index: 0,
-          provenance_jump: nil
-      }
-    end)
+    cache_empty_transcript(state, first_run_empty_state(state, []))
   end
 
   defp cache_transcript(state, messages) do
+    cache_display_transcript(state, messages, first_run_empty_state(state, messages))
+  end
+
+  @spec cache_display_transcript(state(), [term()], Transcript.empty_state()) :: state()
+  defp cache_display_transcript(state, messages, empty_state) do
     panel = AgentAccess.panel(state)
     jump = panel.provenance_jump
 
     sync_opts = add_session_display_opts([], AgentAccess.session(state))
+    sync_opts = maybe_put_empty_state(sync_opts, empty_state)
 
     # A pending provenance jump may need an older, paged-out turn revealed so it
     # can be landed on. Otherwise keep the panel's current display window.
@@ -172,6 +171,69 @@ defmodule MingaEditor.AgentLifecycle do
       }
     end)
   end
+
+  @spec cache_empty_transcript(state(), Transcript.empty_state()) :: state()
+  defp cache_empty_transcript(state, nil), do: clear_transcript_cache(state)
+
+  defp cache_empty_transcript(state, empty_state) do
+    cache_display_transcript(state, [], empty_state)
+  end
+
+  @spec clear_transcript_cache(state()) :: state()
+  defp clear_transcript_cache(state) do
+    AgentAccess.update_panel(state, fn panel ->
+      %{
+        panel
+        | cached_line_index: [],
+          cached_display_messages: [],
+          cached_display_message_pairs: [],
+          cached_styled_messages: nil,
+          display_start_index: 0,
+          provenance_jump: nil
+      }
+    end)
+  end
+
+  @spec first_run_empty_state(state(), [term()]) :: Transcript.empty_state()
+  defp first_run_empty_state(state, messages) do
+    if Transcript.first_run_transcript?(messages) do
+      panel = AgentAccess.panel(state)
+      empty_state_for_panel(panel, AgentAccess.session(state))
+    end
+  end
+
+  @spec empty_state_for_panel(MingaEditor.Agent.UIState.Panel.t(), pid() | nil) ::
+          Transcript.empty_state()
+  defp empty_state_for_panel(panel, session) do
+    empty_state_for_status(
+      configured_model?(panel.model_name),
+      credentials_configured?(panel, session)
+    )
+  end
+
+  @spec empty_state_for_status(boolean(), boolean()) :: Transcript.empty_state()
+  defp empty_state_for_status(false, _credentials_configured), do: :no_model
+  defp empty_state_for_status(true, false), do: :credentials_missing
+  defp empty_state_for_status(true, true), do: nil
+
+  @spec maybe_put_empty_state(keyword(), Transcript.empty_state()) :: keyword()
+  defp maybe_put_empty_state(opts, nil), do: opts
+  defp maybe_put_empty_state(opts, empty_state), do: Keyword.put(opts, :empty_state, empty_state)
+
+  @spec configured_model?(String.t()) :: boolean()
+  defp configured_model?(model) when model in ["", "unknown"], do: false
+  defp configured_model?(model), do: model != AgentConfig.unconfigured_model()
+
+  @spec credentials_configured?(MingaEditor.Agent.UIState.Panel.t(), pid() | nil) :: boolean()
+  defp credentials_configured?(_panel, session) when is_pid(session) do
+    session
+    |> AgentSession.editor_snapshot()
+    |> Map.get(:credentials_configured, false)
+  catch
+    :exit, _ -> false
+  end
+
+  defp credentials_configured?(panel, _session), do: panel.credentials_configured
 
   # The display window needed to render the jump target. Reveals a paged-out
   # target turn; otherwise keeps the panel's current window.

--- a/test/minga_editor/agent/transcript_test.exs
+++ b/test/minga_editor/agent/transcript_test.exs
@@ -170,6 +170,25 @@ defmodule MingaEditor.Agent.TranscriptTest do
                {103, ^visible_message}
              ] = display_pairs
     end
+
+    test "empty state replaces startup-only transcript for display without mutating messages" do
+      startup = {:system, "Session started", :info}
+      result = Transcript.display([startup], empty_state: :credentials_missing)
+
+      assert [{_id, {:system, text, :info}}] = result.display_message_pairs
+      assert result.display_messages == [{:system, text, :info}]
+      assert text =~ "Connect a provider"
+      refute text =~ "Session started"
+    end
+
+    test "empty state does not replace transcripts with user turns" do
+      startup = {:system, "Session started", :info}
+      user = {:user, "hello"}
+      result = Transcript.display([startup, user], empty_state: :credentials_missing)
+
+      assert result.display_messages == [startup, user]
+      assert [{_id1, ^startup}, {_id2, ^user}] = result.display_message_pairs
+    end
   end
 
   describe "messages_to_markdown_with_offsets/1" do

--- a/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
@@ -86,10 +86,70 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
            ]
   end
 
+  test "build/1 sends connect-provider empty state for first-run no-credential sessions" do
+    session = fake_session_pid()
+
+    panel =
+      synced_panel([{:system, "Session started", :info}],
+        empty_state: :credentials_missing
+      )
+
+    model =
+      context(session, panel)
+      |> AgentChatBuilder.build()
+
+    assert [{_, :system, text}, {_, :system, "Agent UI registry online"}] =
+             Enum.map(model.messages, &message_summary/1)
+
+    assert text =~ "Connect a provider"
+    assert text =~ "/auth anthropic <key>"
+    assert text =~ "/login"
+    refute text =~ "Session started"
+  end
+
+  test "build/1 sends pick-model empty state for first-run sessions without a model" do
+    session = fake_session_pid()
+    panel = synced_panel([{:system, "Session started", :info}], empty_state: :no_model)
+
+    model =
+      context(session, panel)
+      |> AgentChatBuilder.build()
+
+    assert [{_, :system, text}, {_, :system, "Agent UI registry online"}] =
+             Enum.map(model.messages, &message_summary/1)
+
+    assert text =~ "Pick a model"
+    assert text =~ "/model"
+    assert text =~ "SPC a m"
+    refute text =~ "Session started"
+  end
+
+  test "build/1 keeps normal first-run display for ready sessions" do
+    session = fake_session_pid()
+    panel = synced_panel([{:system, "Session started", :info}])
+
+    model =
+      context(session, panel)
+      |> AgentChatBuilder.build()
+
+    assert [{_, :system, "Session started"}, {_, :system, "Agent UI registry online"}] =
+             Enum.map(model.messages, &message_summary/1)
+  end
+
   defp message_summary({id, {:assistant, text}}), do: {id, :assistant, text}
   defp message_summary({id, {:system, text, _level}}), do: {id, :system, text}
   defp message_summary({id, {:user, text}}), do: {id, :user, text}
   defp message_summary({id, {kind, _, _}}), do: {id, kind, nil}
+
+  defp synced_panel(messages, opts \\ []) do
+    %{display_messages: display_messages, display_message_pairs: display_pairs} =
+      Transcript.display(messages, opts)
+
+    %Panel{
+      cached_display_messages: display_messages,
+      cached_display_message_pairs: display_pairs
+    }
+  end
 
   defp context(session, panel) do
     tab = Tab.new_agent(1, "Agent") |> Tab.set_session(session)


### PR DESCRIPTION
## Summary
- Adds display-only first-run empty states for no-provider-credentials and no-model agent chats.
- Computes first-run readiness in `AgentLifecycle` and passes it into `Transcript.display/2` without mutating session messages or internal editor state.
- Keeps explicit empty `cache_messages/2` calls as cache clears, while live empty-session sync can show onboarding.
- Keeps ready first-run sessions on the existing normal transcript display.

Closes #2463

## Verification
- `mix test test/minga_editor/agent/transcript_test.exs test/minga_editor/render_model/ui/agent_chat_builder_test.exs test/minga_editor/commands/agent_commands_test.exs test/minga_editor/frontend/gui_agent_chat_protocol_test.exs`
- `mix test test/minga_editor/agent/concurrent_sessions_test.exs test/minga_editor/agent/transcript_test.exs test/minga_editor/render_model/ui/agent_chat_builder_test.exs test/minga_editor/commands/agent_commands_test.exs test/minga_editor/frontend/gui_agent_chat_protocol_test.exs`
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --strict lib/minga_editor/agent/transcript.ex lib/minga_editor/agent_lifecycle.ex test/minga_editor/agent/transcript_test.exs test/minga_editor/render_model/ui/agent_chat_builder_test.exs test/minga_editor/agent/concurrent_sessions_test.exs`
- `mix native.build.support`
- `mix dialyzer`
- `mix test`

Reviewer gate: skipped because no reviewer/subagent tool is available in this harness.
