### PR TITLE
feat(agent): improve tool-call transcript display

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -468,15 +468,17 @@ Typed payloads:
   0x01 (user):      type(1) + text_len(4) + text
   0x02 (assistant): type(1) + text_len(4) + text
   0x03 (thinking):  type(1) + collapsed(1) + text_len(4) + text
-  0x04 (tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + result_len(4) + result + auto_approved(1)
+  0x04 (tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + result_len(4) + result + auto_approved(1) + optional tool_preview_payload
   0x05 (system):    type(1) + level(1) + text_len(4) + text
   0x06 (usage):     type(1) + input(4) + output(4) + cache_read(4) + cache_write(4) + cost_micros(4)
   0x07 (styled_assistant): type(1) + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url. Link URLs are limited to http, https, and mailto.
-  0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url, auto_approved(1). The summary uses a UTF-8-safe preview budget so the styled payload and trailing auto_approved byte still fit. Link URLs are limited to http, https, and mailto.
+  0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url, auto_approved(1) + optional tool_preview_payload. The summary uses a UTF-8-safe preview budget so the styled payload and appended auto-approval/preview bytes still fit. Link URLs are limited to http, https, and mailto.
   0x09 (approval_tool_call): type(1) + status(1) + name_len(2) + name + summary_len(2) + summary + tool_call_id_len(2) + tool_call_id + preview_kind(1) + preview_line_count(2), per line: line_len(2) + line
 ```
 
 `auto_approved`: 0=not auto-approved, 1=session trust, 2=turn trust. The frame length makes appended fields deterministic and lets decoders distinguish current payloads from legacy unframed messages.
+
+`tool_preview_payload` is appended to current `tool_call` and `styled_tool_call` messages after `auto_approved`: `preview_kind(1) + preview_line_count(2) + lines...`, with each line encoded as `line_len(2) + line`. Legacy framed tool messages may omit this payload. Preview kinds match approval previews: 0=args, 1=diff, 2=command, 3=target. Tool-call previews are inline context only; `approval_tool_call` keeps the same preview payload fields as part of its required approval card shape.
 
 Styled run flags: 0x01=bold, 0x02=italic, 0x04=underline, 0x08=link URL present.
 

--- a/go/tui/internal/protocol/chrome_agent.go
+++ b/go/tui/internal/protocol/chrome_agent.go
@@ -237,7 +237,9 @@ func decodeToolCallMessage(msg AgentChatMessage, body []byte, offset int, styled
 		}
 		if len(body) > next {
 			msg.AutoApprovedScope = body[next]
+			next++
 		}
+		msg = decodeToolPreview(msg, body, next)
 		return msg
 	}
 
@@ -252,6 +254,27 @@ func decodeToolCallMessage(msg AgentChatMessage, body []byte, offset int, styled
 	}
 	if len(body) > next {
 		msg.AutoApprovedScope = body[next]
+		next++
+	}
+	msg = decodeToolPreview(msg, body, next)
+	return msg
+}
+
+func decodeToolPreview(msg AgentChatMessage, body []byte, offset int) AgentChatMessage {
+	if len(body) < offset+3 {
+		return msg
+	}
+	msg.PreviewKind = body[offset]
+	lineCount := int(u16(body, offset+1))
+	offset += 3
+	msg.PreviewLines = make([]string, 0, lineCount)
+	for i := 0; i < lineCount; i++ {
+		line, next, ok := readString16(body, offset)
+		if !ok {
+			break
+		}
+		msg.PreviewLines = append(msg.PreviewLines, line)
+		offset = next
 	}
 	return msg
 }

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -1199,6 +1199,9 @@ func TestDecodeAgentChatPreservesStructuredMessageDetails(t *testing.T) {
 	tool = append(tool, string16("lib/app.ex")...)
 	tool = append(tool, u32Bytes(2)...)
 	tool = append(tool, 'o', 'k', 1)
+	tool = append(tool, 1, 0, 2)
+	tool = append(tool, string16("-old")...)
+	tool = append(tool, string16("+new")...)
 
 	approval := append(u32Bytes(8), 0x09, 0)
 	approval = append(approval, string16("edit_file")...)
@@ -1232,7 +1235,7 @@ func TestDecodeAgentChatPreservesStructuredMessageDetails(t *testing.T) {
 	if len(messages) != 3 {
 		t.Fatalf("message count = %d, want 3: %+v", len(messages), messages)
 	}
-	if got := messages[0]; got.Name != "read_file" || got.Summary != "lib/app.ex" || got.Result != "ok" || got.DurationMS != 42 || got.AutoApprovedScope != 1 {
+	if got := messages[0]; got.Name != "read_file" || got.Summary != "lib/app.ex" || got.Result != "ok" || got.DurationMS != 42 || got.AutoApprovedScope != 1 || got.PreviewKind != 1 || len(got.PreviewLines) != 2 || got.PreviewLines[0] != "-old" || got.PreviewLines[1] != "+new" {
 		t.Fatalf("tool message decoded incorrectly: %+v", got)
 	}
 	if got := messages[1]; got.Name != "edit_file" || got.PreviewKind != 1 || len(got.PreviewLines) != 1 || got.PreviewLines[0] != "+hello" {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -24,6 +24,7 @@ const (
 const (
 	agentThinkingCollapsedLines = 1
 	agentThinkingExpandedLines  = 5
+	agentToolExpandedLines      = 10
 )
 
 func (m Model) renderAgentChatPanel(chat protocol.AgentChat) []string {
@@ -583,10 +584,17 @@ func (m Model) renderAgentToolMessage(msg protocol.AgentChatMessage, width int) 
 		lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(header, width)),
 		lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(body, width)),
 	}
+
+	if len(msg.PreviewLines) > 0 {
+		lines = append(lines, m.renderAgentToolPreviewLines(msg.PreviewKind, msg.PreviewLines, width)...)
+	}
+
 	if msg.IsError && msg.Result != "" {
-		lines = append(lines, m.renderAgentToolBody("ERROR", msg.Result, width))
-	} else if !msg.Collapsed && msg.Result != "" && len(lines) < 4 {
-		lines = append(lines, m.renderAgentToolBody(presentation.ResultLabel, msg.Result, width))
+		lines = append(lines, m.renderAgentToolTextLines("ERROR", msg.Result, width, agentToolExpandedLines)...)
+	} else if hasAgentToolResult(msg) && msg.Collapsed {
+		lines = append(lines, m.renderAgentToolCollapsedHint(width))
+	} else if !msg.Collapsed {
+		lines = append(lines, m.renderAgentToolResultLines(presentation.ResultLabel, msg, width)...)
 	}
 	return lines
 }
@@ -648,13 +656,124 @@ func agentToolMeta(msg protocol.AgentChatMessage) string {
 	return strings.Join(parts, " · ")
 }
 
-func (m Model) renderAgentToolBody(label string, text string, width int) string {
+func hasAgentToolResult(msg protocol.AgentChatMessage) bool {
+	return strings.TrimSpace(msg.Result) != "" || len(msg.StyledLines) > 0
+}
+
+func (m Model) renderAgentToolCollapsedHint(width int) string {
 	p := m.palette()
-	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(m.editorBackground())
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground())
-	body := firstCompactLine(text, max(width-lipgloss.Width(label)-9, 8))
-	line := "  │  " + labelStyle.Render(label+":") + bodyStyle.Render(" "+body)
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Italic(true)
+	line := "  │  " + bodyStyle.Render("result collapsed, Ctrl+Alt+X expands latest tool")
 	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))
+}
+
+func (m Model) renderAgentToolPreviewLines(kind byte, lines []string, width int) []string {
+	label := approvalPreviewKindName(kind)
+	return m.renderAgentToolPlainLines(label, lines, width, min(len(lines), 8))
+}
+
+func (m Model) renderAgentToolResultLines(label string, msg protocol.AgentChatMessage, width int) []string {
+	if len(msg.StyledLines) > 0 {
+		return m.renderAgentToolStyledLines(label, msg.StyledLines, width, agentToolExpandedLines)
+	}
+	return m.renderAgentToolTextLines(label, msg.Result, width, agentToolExpandedLines)
+}
+
+func (m Model) renderAgentToolTextLines(label string, text string, width int, limit int) []string {
+	return m.renderAgentToolPlainLines(label, agentToolTextLines(text), width, limit)
+}
+
+func agentToolTextLines(text string) []string {
+	text = strings.TrimRight(text, "\n")
+	if text == "" {
+		return nil
+	}
+	return strings.Split(text, "\n")
+}
+
+func (m Model) renderAgentToolPlainLines(label string, rawLines []string, width int, limit int) []string {
+	if len(rawLines) == 0 || limit <= 0 {
+		return nil
+	}
+	p := m.palette()
+	out := make([]string, 0, min(len(rawLines), limit)+1)
+	for index, raw := range rawLines[:min(len(rawLines), limit)] {
+		out = append(out, m.renderAgentToolLine(label, raw, index == 0, width, agentToolLineColor(raw, p)))
+	}
+	if len(rawLines) > limit {
+		remaining := fmt.Sprintf("… +%d lines", len(rawLines)-limit)
+		out = append(out, m.renderAgentToolLine(label, remaining, false, width, p.Muted()))
+	}
+	return out
+}
+
+func (m Model) renderAgentToolStyledLines(label string, styledLines []protocol.AgentStyledLine, width int, limit int) []string {
+	if len(styledLines) == 0 || limit <= 0 {
+		return nil
+	}
+	p := m.palette()
+	out := make([]string, 0, min(len(styledLines), limit)+1)
+	for index, runs := range styledLines[:min(len(styledLines), limit)] {
+		out = append(out, m.renderAgentToolStyledLine(label, runs, index == 0, width))
+	}
+	if len(styledLines) > limit {
+		remaining := fmt.Sprintf("… +%d lines", len(styledLines)-limit)
+		out = append(out, m.renderAgentToolLine(label, remaining, false, width, p.Muted()))
+	}
+	return out
+}
+
+func (m Model) renderAgentToolStyledLine(label string, runs protocol.AgentStyledLine, showLabel bool, width int) string {
+	p := m.palette()
+	labelText := strings.Repeat(" ", len(label))
+	if showLabel {
+		labelText = label
+	}
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(m.editorBackground())
+	body := renderAgentStyledRuns(runs, p.Muted(), m.editorBackground())
+	line := "  │  " + labelStyle.Render(labelText+":") + " " + body
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))
+}
+
+func renderAgentStyledRuns(runs protocol.AgentStyledLine, fallback color.Color, background color.Color) string {
+	parts := make([]string, 0, len(runs))
+	for _, run := range runs {
+		style := lipgloss.NewStyle().Foreground(fallback).Background(background)
+		if run.FG != 0 {
+			style = style.Foreground(lipgloss.Color(fmt.Sprintf("#%06X", run.FG)))
+		}
+		if run.Flags&0x01 != 0 {
+			style = style.Bold(true)
+		}
+		if run.Flags&0x02 != 0 {
+			style = style.Italic(true)
+		}
+		parts = append(parts, style.Render(run.Text))
+	}
+	return strings.Join(parts, "")
+}
+
+func (m Model) renderAgentToolLine(label string, text string, showLabel bool, width int, textColor color.Color) string {
+	p := m.palette()
+	labelText := strings.Repeat(" ", len(label))
+	if showLabel {
+		labelText = label
+	}
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Warning()).Background(m.editorBackground())
+	bodyStyle := lipgloss.NewStyle().Foreground(textColor).Background(m.editorBackground())
+	body := fit(strings.TrimRight(text, "\r"), max(width-lipgloss.Width(label)-9, 8))
+	line := "  │  " + labelStyle.Render(labelText+":") + bodyStyle.Render(" "+body)
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width))
+}
+
+func agentToolLineColor(line string, p palette) color.Color {
+	if strings.HasPrefix(line, "+") {
+		return p.Diagnostic(3)
+	}
+	if strings.HasPrefix(line, "-") {
+		return p.Diagnostic(0)
+	}
+	return p.Muted()
 }
 
 func (m Model) renderAgentApprovalMessage(msg protocol.AgentChatMessage, width int) []string {

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -803,6 +803,13 @@ func (m Model) handleAgentChatShortcut(msg tea.KeyPressMsg) bool {
 		return false
 	}
 	switch key.Code {
+	case 'x', 'X':
+		index, ok := latestToolMessageIndex(chat.Messages)
+		if !ok {
+			return false
+		}
+		m.send(protocol.EncodeGUIAgentToolToggle(index))
+		return true
 	case 'z', 'Z':
 		index, ok := latestThinkingMessageIndex(chat.Messages)
 		if !ok {
@@ -813,6 +820,15 @@ func (m Model) handleAgentChatShortcut(msg tea.KeyPressMsg) bool {
 	default:
 		return false
 	}
+}
+
+func latestToolMessageIndex(messages []protocol.AgentChatMessage) (uint16, bool) {
+	for index := len(messages) - 1; index >= 0; index-- {
+		if (messages[index].Kind == agentKindTool || messages[index].Kind == agentKindStyledTool) && index <= 0xFFFF {
+			return uint16(index), true
+		}
+	}
+	return 0, false
 }
 
 func latestThinkingMessageIndex(messages []protocol.AgentChatMessage) (uint16, bool) {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1024,6 +1024,65 @@ func TestAgentChatThinkingCollapsedRemainsSingleLine(t *testing.T) {
 	}
 }
 
+func TestAgentChatToolExpandedRendersMultipleResultLines(t *testing.T) {
+	model := New(96, 24, nil)
+	msg := protocol.AgentChatMessage{
+		Kind:      agentKindTool,
+		Name:      "grep",
+		Summary:   "TODO in lib",
+		Status:    1,
+		Collapsed: false,
+		Result:    "first match\nsecond match\nthird match",
+	}
+
+	view := ansi.Strip(strings.Join(model.renderAgentToolMessage(msg, 96), "\n"))
+	for _, want := range []string{"Tool", "TODO in lib", "first match", "second match", "third match"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expanded tool result missing %q in %q", want, view)
+		}
+	}
+}
+
+func TestAgentChatToolCollapsedShowsExpansionHint(t *testing.T) {
+	model := New(96, 24, nil)
+	msg := protocol.AgentChatMessage{
+		Kind:      agentKindTool,
+		Name:      "read_file",
+		Summary:   "lib/app.ex",
+		Status:    1,
+		Collapsed: true,
+		Result:    "line one\nline two",
+	}
+
+	view := ansi.Strip(strings.Join(model.renderAgentToolMessage(msg, 96), "\n"))
+	if !strings.Contains(view, "result collapsed") || !strings.Contains(view, "Ctrl+Alt+X") {
+		t.Fatalf("collapsed tool should show expansion hint: %q", view)
+	}
+	if strings.Contains(view, "line two") {
+		t.Fatalf("collapsed tool should not dump result lines: %q", view)
+	}
+}
+
+func TestAgentChatToolRendersInlineDiffPreview(t *testing.T) {
+	model := New(96, 24, nil)
+	msg := protocol.AgentChatMessage{
+		Kind:         agentKindTool,
+		Name:         "edit_file",
+		Summary:      "lib/app.ex",
+		Status:       1,
+		Collapsed:    true,
+		PreviewKind:  1,
+		PreviewLines: []string{"file: lib/app.ex", "-old", "+new"},
+	}
+
+	view := ansi.Strip(strings.Join(model.renderAgentToolMessage(msg, 96), "\n"))
+	for _, want := range []string{"diff:", "file: lib/app.ex", "-old", "+new"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("tool preview missing %q in %q", want, view)
+		}
+	}
+}
+
 func TestAgentChatShortcutTogglesLatestThinkingBlock(t *testing.T) {
 	out := make(chan []byte, 1)
 	model := New(80, 24, out)
@@ -1040,6 +1099,25 @@ func TestAgentChatShortcutTogglesLatestThinkingBlock(t *testing.T) {
 	_, _ = model.Update(tea.KeyPressMsg(tea.Key{Code: 'z', Mod: tea.ModCtrl | tea.ModAlt}))
 	if got, want := <-out, protocol.EncodeGUIAgentToolToggle(3); !bytes.Equal(got, want) {
 		t.Fatalf("ctrl+alt+z packet = %v, want %v", got, want)
+	}
+}
+
+func TestAgentChatShortcutTogglesLatestToolBlock(t *testing.T) {
+	out := make(chan []byte, 1)
+	model := New(80, 24, out)
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentChat: {AgentChat: protocol.AgentChat{
+		Visible: true,
+		Messages: []protocol.AgentChatMessage{
+			{Kind: agentKindUser, Text: "fix this"},
+			{Kind: agentKindTool, Name: "read_file", Collapsed: true},
+			{Kind: agentKindAssistant, Text: "ok"},
+			{Kind: agentKindStyledTool, Name: "grep", Collapsed: false},
+		},
+	}}}
+
+	_, _ = model.Update(tea.KeyPressMsg(tea.Key{Code: 'x', Mod: tea.ModCtrl | tea.ModAlt}))
+	if got, want := <-out, protocol.EncodeGUIAgentToolToggle(3); !bytes.Equal(got, want) {
+		t.Fatalf("ctrl+alt+x packet = %v, want %v", got, want)
 	}
 }
 

--- a/lib/minga/frontend/adapter/gui/agent_chat_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/agent_chat_encoder.ex
@@ -187,6 +187,23 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
     |> :erlang.iolist_to_binary()
   end
 
+  @spec encode_preview_payload(ToolCallView.preview_kind(), [String.t()]) :: binary()
+  defp encode_preview_payload(kind, lines) when is_list(lines) do
+    line_binaries =
+      lines
+      |> Enum.take(20)
+      |> Enum.map(fn line ->
+        bytes = preview_text_bytes(line, 1_000)
+        <<byte_size(bytes)::16, bytes::binary>>
+      end)
+
+    IO.iodata_to_binary([
+      <<preview_kind_byte(kind)::8, length(line_binaries)::16>> | line_binaries
+    ])
+  end
+
+  defp encode_preview_payload(kind, _lines), do: <<preview_kind_byte(kind)::8, 0::16>>
+
   # ── Chat messages ──
 
   @typedoc "A chat message that may carry pre-computed styled runs."
@@ -368,10 +385,12 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
     collapsed_byte = if tc.collapsed, do: 1, else: 0
     auto_approved_byte = auto_approved_scope_byte(tc.auto_approved_scope)
 
+    preview_bytes = encode_preview_payload(tc.preview_kind, tc.preview_lines)
+
     <<0x04::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32,
       byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
       summary_bytes::binary, byte_size(result_bytes)::32, result_bytes::binary,
-      auto_approved_byte::8>>
+      auto_approved_byte::8, preview_bytes::binary>>
   end
 
   # Approval tool call: inline approval card attached to the tool message.
@@ -405,7 +424,8 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
   #   0x08, status::8, error::8, collapsed::8, duration::32, name_len::16, name,
   #   summary_len::16, summary, line_count::16, then per line: run_count::16,
   #   then per run: text_len::16, text, fg::24, bg::24, flags::8,
-  #   and when flags bit 0x08 is set: url_len::16, url. auto_approved::8 is appended after the styled line payload.
+  #   and when flags bit 0x08 is set: url_len::16, url.
+  #   auto_approved::8 and preview payload are appended after the styled line payload.
   defp encode_chat_message_body({:styled_tool_call, %ToolCallView{} = tc, styled_lines}) do
     name_bytes = :erlang.iolist_to_binary([tc.name])
     summary_bytes = utf8_prefix_bytes(tc.summary || "", @max_chat_text_bytes)
@@ -422,12 +442,15 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
         [<<length(runs)::16>> | run_binaries]
       end)
 
+    preview_bytes = encode_preview_payload(tc.preview_kind, tc.preview_lines)
+
     IO.iodata_to_binary([
       <<0x08::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32,
         byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
         summary_bytes::binary, length(styled_lines)::16>>,
       line_binaries,
-      <<auto_approved_byte::8>>
+      <<auto_approved_byte::8>>,
+      preview_bytes
     ])
   end
 

--- a/lib/minga/render_model/ui/agent_chat.ex
+++ b/lib/minga/render_model/ui/agent_chat.ex
@@ -138,6 +138,9 @@ defmodule Minga.RenderModel.UI.AgentChat do
     @typedoc "Resolved scope that auto-approved this tool call."
     @type auto_approved_scope :: :session | :turn | nil
 
+    @typedoc "Resolved preview kind for inline tool-call previews."
+    @type preview_kind :: :diff | :command | :target | :args
+
     @type t :: %__MODULE__{
             name: String.t(),
             summary: String.t(),
@@ -146,7 +149,9 @@ defmodule Minga.RenderModel.UI.AgentChat do
             is_error: boolean(),
             collapsed: boolean(),
             duration_ms: non_neg_integer() | nil,
-            auto_approved_scope: auto_approved_scope()
+            auto_approved_scope: auto_approved_scope(),
+            preview_kind: preview_kind(),
+            preview_lines: [String.t()]
           }
 
     defstruct name: "",
@@ -156,7 +161,9 @@ defmodule Minga.RenderModel.UI.AgentChat do
               is_error: false,
               collapsed: true,
               duration_ms: nil,
-              auto_approved_scope: nil
+              auto_approved_scope: nil,
+              preview_kind: :args,
+              preview_lines: []
   end
 
   defmodule ApprovalView do

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -44,6 +44,7 @@ defmodule MingaAgent.Session do
   alias MingaAgent.SessionStore
   alias MingaAgent.EditBoundary
   alias MingaAgent.SubagentContext
+  alias MingaAgent.ToolApproval
   alias MingaAgent.ToolCall
   alias MingaAgent.TurnUsage
 
@@ -1658,7 +1659,8 @@ defmodule MingaAgent.Session do
     )
 
     state = record_file_touch(state, event.path, event.before_content, event.after_content)
-    state
+    state = record_tool_file_preview(state, event)
+    notify_messages_changed(state)
   end
 
   defp handle_provider_event(%Event.SystemMessage{} = event, state) do
@@ -2004,6 +2006,19 @@ defmodule MingaAgent.Session do
       {:tool_call, %ToolCall{id: ^tool_call_id} = tc} -> {:tool_call, updater.(tc)}
       other -> other
     end)
+  end
+
+  @spec record_tool_file_preview(state(), Event.ToolFileChanged.t()) :: state()
+  defp record_tool_file_preview(state, %Event.ToolFileChanged{} = event) do
+    preview =
+      ToolApproval.build_file_diff_preview(event.path, event.before_content, event.after_content)
+
+    messages =
+      update_tool_call(state.messages, event.tool_call_id, fn tc ->
+        ToolCall.set_preview(tc, preview)
+      end)
+
+    %{state | messages: messages}
   end
 
   # ── Status management ──────────────────────────────────────────────────────

--- a/lib/minga_agent/session_store.ex
+++ b/lib/minga_agent/session_store.ex
@@ -11,6 +11,8 @@ defmodule MingaAgent.SessionStore do
   picker calls `list/0` to scan the directory for past sessions.
   """
 
+  alias MingaAgent.ToolApproval.Preview
+
   @typedoc "Session metadata for the picker (without full message content)."
   @type session_meta :: %{
           id: String.t(),
@@ -346,19 +348,29 @@ defmodule MingaAgent.SessionStore do
     }
   end
 
-  @spec deserialize_tool_preview(map() | nil) :: MingaAgent.ToolApproval.Preview.t() | nil
+  @spec deserialize_tool_preview(map() | nil) :: Preview.t() | nil
   defp deserialize_tool_preview(%{"kind" => kind, "summary" => summary, "lines" => lines})
        when is_binary(summary) and is_list(lines) do
-    MingaAgent.ToolApproval.Preview.new(deserialize_preview_kind(kind), summary, lines)
+    with preview_kind when not is_nil(preview_kind) <- deserialize_preview_kind(kind),
+         true <- Enum.all?(lines, &is_binary/1) do
+      Preview.new(preview_kind, summary, lines)
+    else
+      _ -> nil
+    end
   end
 
   defp deserialize_tool_preview(_preview), do: nil
 
-  @spec deserialize_preview_kind(String.t() | nil) :: MingaAgent.ToolApproval.Preview.kind()
+  @spec deserialize_preview_kind(term()) :: Preview.kind() | nil
   defp deserialize_preview_kind("diff"), do: :diff
+  defp deserialize_preview_kind(:diff), do: :diff
   defp deserialize_preview_kind("command"), do: :command
+  defp deserialize_preview_kind(:command), do: :command
   defp deserialize_preview_kind("target"), do: :target
-  defp deserialize_preview_kind(_kind), do: :args
+  defp deserialize_preview_kind(:target), do: :target
+  defp deserialize_preview_kind("args"), do: :args
+  defp deserialize_preview_kind(:args), do: :args
+  defp deserialize_preview_kind(_kind), do: nil
 
   @spec serialize_auto_approved_scope(MingaAgent.ToolCall.auto_approved_scope() | nil) ::
           String.t() | nil

--- a/lib/minga_agent/session_store.ex
+++ b/lib/minga_agent/session_store.ex
@@ -225,7 +225,8 @@ defmodule MingaAgent.SessionStore do
       "is_error" => tc.is_error,
       "collapsed" => tc.collapsed,
       "auto_approved_scope" => serialize_auto_approved_scope(tc.auto_approved_scope),
-      "duration_ms" => tc.duration_ms
+      "duration_ms" => tc.duration_ms,
+      "preview" => serialize_tool_preview(tc.preview)
     }
   end
 
@@ -307,6 +308,7 @@ defmodule MingaAgent.SessionStore do
        is_error: raw["is_error"] || false,
        collapsed: raw["collapsed"] || true,
        auto_approved_scope: deserialize_auto_approved_scope(raw["auto_approved_scope"]),
+       preview: deserialize_tool_preview(raw["preview"]),
        started_at: nil,
        duration_ms: raw["duration_ms"]
      }}
@@ -332,6 +334,31 @@ defmodule MingaAgent.SessionStore do
       size_kb: attachment["size_kb"] || attachment[:size_kb] || 0
     }
   end
+
+  @spec serialize_tool_preview(MingaAgent.ToolApproval.Preview.t() | nil) :: map() | nil
+  defp serialize_tool_preview(nil), do: nil
+
+  defp serialize_tool_preview(%MingaAgent.ToolApproval.Preview{} = preview) do
+    %{
+      "kind" => Atom.to_string(preview.kind),
+      "summary" => preview.summary,
+      "lines" => preview.lines
+    }
+  end
+
+  @spec deserialize_tool_preview(map() | nil) :: MingaAgent.ToolApproval.Preview.t() | nil
+  defp deserialize_tool_preview(%{"kind" => kind, "summary" => summary, "lines" => lines})
+       when is_binary(summary) and is_list(lines) do
+    MingaAgent.ToolApproval.Preview.new(deserialize_preview_kind(kind), summary, lines)
+  end
+
+  defp deserialize_tool_preview(_preview), do: nil
+
+  @spec deserialize_preview_kind(String.t() | nil) :: MingaAgent.ToolApproval.Preview.kind()
+  defp deserialize_preview_kind("diff"), do: :diff
+  defp deserialize_preview_kind("command"), do: :command
+  defp deserialize_preview_kind("target"), do: :target
+  defp deserialize_preview_kind(_kind), do: :args
 
   @spec serialize_auto_approved_scope(MingaAgent.ToolCall.auto_approved_scope() | nil) ::
           String.t() | nil

--- a/lib/minga_agent/session_store.ex
+++ b/lib/minga_agent/session_store.ex
@@ -351,7 +351,7 @@ defmodule MingaAgent.SessionStore do
   @spec deserialize_tool_preview(map() | nil) :: Preview.t() | nil
   defp deserialize_tool_preview(%{"kind" => kind, "summary" => summary, "lines" => lines})
        when is_binary(summary) and is_list(lines) do
-    with preview_kind when not is_nil(preview_kind) <- deserialize_preview_kind(kind),
+    with {:ok, preview_kind} <- deserialize_preview_kind(kind),
          true <- Enum.all?(lines, &is_binary/1) do
       Preview.new(preview_kind, summary, lines)
     else
@@ -361,16 +361,16 @@ defmodule MingaAgent.SessionStore do
 
   defp deserialize_tool_preview(_preview), do: nil
 
-  @spec deserialize_preview_kind(term()) :: Preview.kind() | nil
-  defp deserialize_preview_kind("diff"), do: :diff
-  defp deserialize_preview_kind(:diff), do: :diff
-  defp deserialize_preview_kind("command"), do: :command
-  defp deserialize_preview_kind(:command), do: :command
-  defp deserialize_preview_kind("target"), do: :target
-  defp deserialize_preview_kind(:target), do: :target
-  defp deserialize_preview_kind("args"), do: :args
-  defp deserialize_preview_kind(:args), do: :args
-  defp deserialize_preview_kind(_kind), do: nil
+  @spec deserialize_preview_kind(term()) :: {:ok, Preview.kind()} | :error
+  defp deserialize_preview_kind("diff"), do: {:ok, :diff}
+  defp deserialize_preview_kind(:diff), do: {:ok, :diff}
+  defp deserialize_preview_kind("command"), do: {:ok, :command}
+  defp deserialize_preview_kind(:command), do: {:ok, :command}
+  defp deserialize_preview_kind("target"), do: {:ok, :target}
+  defp deserialize_preview_kind(:target), do: {:ok, :target}
+  defp deserialize_preview_kind("args"), do: {:ok, :args}
+  defp deserialize_preview_kind(:args), do: {:ok, :args}
+  defp deserialize_preview_kind(_kind), do: :error
 
   @spec serialize_auto_approved_scope(MingaAgent.ToolCall.auto_approved_scope() | nil) ::
           String.t() | nil

--- a/lib/minga_agent/tool_approval.ex
+++ b/lib/minga_agent/tool_approval.ex
@@ -86,8 +86,9 @@ defmodule MingaAgent.ToolApproval do
   defp do_build_preview(name, %{"path" => path} = args)
        when name in ["edit_file", "multi_edit_file", "apply_diff"] do
     path = stringify_value(path)
+    lines = edit_diff_preview_lines(name, args)
 
-    Preview.new(:target, path, preview_lines(["file: #{path}", edit_summary(name, args)]))
+    Preview.new(:diff, path, preview_lines(["file: #{path}" | lines]))
   end
 
   defp do_build_preview(name, %{"paths" => paths})
@@ -139,6 +140,66 @@ defmodule MingaAgent.ToolApproval do
   defp diff_op_preview_lines({:eq, _lines}), do: []
   defp diff_op_preview_lines({:ins, lines}), do: Enum.map(lines, &("+" <> &1))
   defp diff_op_preview_lines({:del, lines}), do: Enum.map(lines, &("-" <> &1))
+
+  @spec edit_diff_preview_lines(String.t(), map()) :: [String.t()]
+  defp edit_diff_preview_lines("edit_file", args) do
+    old_text = stringify_value(Map.get(args, "old_text") || Map.get(args, "find") || "")
+    new_text = stringify_value(Map.get(args, "new_text") || Map.get(args, "replace") || "")
+    diff_preview_lines(old_text, new_text)
+  end
+
+  defp edit_diff_preview_lines("multi_edit_file", args) do
+    args
+    |> Map.get("edits", [])
+    |> multi_edit_diff_preview_lines()
+    |> case do
+      [] -> ["No textual changes detected"]
+      lines -> Enum.take(lines, 20)
+    end
+  end
+
+  defp edit_diff_preview_lines("apply_diff", args) do
+    args
+    |> Map.get("diff", "")
+    |> stringify_value()
+    |> String.split("\n")
+    |> Enum.reject(&diff_metadata_line?/1)
+    |> Enum.filter(&diff_change_line?/1)
+    |> Enum.take(20)
+    |> case do
+      [] -> [edit_summary("apply_diff", args)]
+      lines -> lines
+    end
+  end
+
+  @spec multi_edit_diff_preview_lines(term()) :: [String.t()]
+  defp multi_edit_diff_preview_lines(edits) when is_list(edits) do
+    edits
+    |> Enum.flat_map(&multi_edit_entry_diff_preview_lines/1)
+    |> Enum.reject(&(&1 == "No textual changes detected"))
+  end
+
+  defp multi_edit_diff_preview_lines(_edits), do: []
+
+  @spec multi_edit_entry_diff_preview_lines(term()) :: [String.t()]
+  defp multi_edit_entry_diff_preview_lines(edit) when is_map(edit) do
+    edit = stringify_keys(edit)
+    old_text = stringify_value(Map.get(edit, "old_text") || Map.get(edit, "find") || "")
+    new_text = stringify_value(Map.get(edit, "new_text") || Map.get(edit, "replace") || "")
+    diff_preview_lines(old_text, new_text)
+  end
+
+  defp multi_edit_entry_diff_preview_lines(_edit), do: []
+
+  @spec diff_metadata_line?(String.t()) :: boolean()
+  defp diff_metadata_line?("+++" <> _rest), do: true
+  defp diff_metadata_line?("---" <> _rest), do: true
+  defp diff_metadata_line?(_line), do: false
+
+  @spec diff_change_line?(String.t()) :: boolean()
+  defp diff_change_line?("+" <> _rest), do: true
+  defp diff_change_line?("-" <> _rest), do: true
+  defp diff_change_line?(_line), do: false
 
   @spec edit_summary(String.t(), map()) :: String.t()
   defp edit_summary("edit_file", args) do

--- a/lib/minga_agent/tool_approval.ex
+++ b/lib/minga_agent/tool_approval.ex
@@ -167,7 +167,7 @@ defmodule MingaAgent.ToolApproval do
     |> Enum.filter(&diff_change_line?/1)
     |> Enum.take(20)
     |> case do
-      [] -> [edit_summary("apply_diff", args)]
+      [] -> [apply_diff_summary(args)]
       lines -> lines
     end
   end
@@ -201,20 +201,8 @@ defmodule MingaAgent.ToolApproval do
   defp diff_change_line?("-" <> _rest), do: true
   defp diff_change_line?(_line), do: false
 
-  @spec edit_summary(String.t(), map()) :: String.t()
-  defp edit_summary("edit_file", args) do
-    old_text = stringify_value(Map.get(args, "old_text") || Map.get(args, "find") || "")
-    new_text = stringify_value(Map.get(args, "new_text") || Map.get(args, "replace") || "")
-    "replace #{inspect(truncate(old_text, 40))} with #{inspect(truncate(new_text, 40))}"
-  end
-
-  defp edit_summary("multi_edit_file", args) do
-    edits = Map.get(args, "edits", [])
-    count = if is_list(edits), do: length(edits), else: 0
-    "#{count} edit(s)"
-  end
-
-  defp edit_summary("apply_diff", args) do
+  @spec apply_diff_summary(map()) :: String.t()
+  defp apply_diff_summary(args) do
     diff = stringify_value(Map.get(args, "diff", ""))
     hunk_count = diff |> String.split("\n") |> Enum.count(&String.starts_with?(&1, "@@"))
     "#{hunk_count} diff hunk(s)"

--- a/lib/minga_agent/tool_approval.ex
+++ b/lib/minga_agent/tool_approval.ex
@@ -8,6 +8,7 @@ defmodule MingaAgent.ToolApproval do
   handling, chat decorations, and GUI protocol encoding.
   """
 
+  alias Minga.RenderModel.UI.AgentChat.ToolArgSummary
   alias MingaAgent.ToolApproval.Preview
   alias MingaAgent.ToolRouter
 
@@ -65,6 +66,23 @@ defmodule MingaAgent.ToolApproval do
     do_build_preview(name, stringify_keys(args))
   end
 
+  @doc "Builds an IO-free structured preview for completed transcript tool-call cards."
+  @spec build_transcript_preview(String.t(), map()) :: preview()
+  def build_transcript_preview(name, args) when is_binary(name) and is_map(args) do
+    do_build_transcript_preview(name, stringify_keys(args))
+  end
+
+  @doc "Builds an IO-free diff preview from explicit before/after file content."
+  @spec build_file_diff_preview(String.t(), String.t(), String.t()) :: preview()
+  def build_file_diff_preview(path, before_content, after_content)
+      when is_binary(path) and is_binary(before_content) and is_binary(after_content) do
+    Preview.new(
+      :diff,
+      path,
+      preview_lines(["file: #{path}" | diff_preview_lines(before_content, after_content)])
+    )
+  end
+
   @spec do_build_preview(String.t(), map()) :: preview()
   defp do_build_preview("shell", %{"command" => command} = args) do
     command = stringify_value(command)
@@ -81,6 +99,11 @@ defmodule MingaAgent.ToolApproval do
     lines = diff_preview_lines(before, content)
 
     Preview.new(:diff, path, preview_lines(["file: #{path}" | lines]))
+  end
+
+  defp do_build_preview(name, args)
+       when name in ["read_file", "grep", "find", "list_directory"] do
+    read_only_preview(name, args)
   end
 
   defp do_build_preview(name, %{"path" => path} = args)
@@ -112,6 +135,35 @@ defmodule MingaAgent.ToolApproval do
     summary = inspect(args, limit: 20, printable_limit: 120)
     Preview.new(:args, summary, [summary])
   end
+
+  @spec do_build_transcript_preview(String.t(), map()) :: preview()
+  defp do_build_transcript_preview("write_file", %{"path" => path}) do
+    path = stringify_value(path)
+    Preview.new(:target, path, [])
+  end
+
+  defp do_build_transcript_preview(name, args)
+       when name in ["read_file", "grep", "find", "list_directory"] do
+    read_only_preview(name, args)
+  end
+
+  defp do_build_transcript_preview(name, args) do
+    name
+    |> do_build_preview(args)
+    |> transcript_safe_preview()
+  end
+
+  @spec read_only_preview(String.t(), map()) :: preview()
+  defp read_only_preview(name, args) do
+    summary = name |> ToolArgSummary.summarize(args) |> stringify_value()
+    Preview.new(:args, summary, [])
+  end
+
+  @spec transcript_safe_preview(preview()) :: preview()
+  defp transcript_safe_preview(%Preview{kind: :args, summary: summary}),
+    do: Preview.new(:args, summary, [])
+
+  defp transcript_safe_preview(%Preview{} = preview), do: preview
 
   @spec read_existing(String.t()) :: String.t()
   defp read_existing(path) do

--- a/lib/minga_agent/tool_approval/preview.ex
+++ b/lib/minga_agent/tool_approval/preview.ex
@@ -13,6 +13,7 @@ defmodule MingaAgent.ToolApproval.Preview do
           lines: [String.t()]
         }
 
+  @derive JSON.Encoder
   @enforce_keys [:kind, :summary, :lines]
   defstruct [:kind, :summary, :lines]
 

--- a/lib/minga_agent/tool_call.ex
+++ b/lib/minga_agent/tool_call.ex
@@ -11,6 +11,8 @@ defmodule MingaAgent.ToolCall do
   marks a failure, `abort/1` handles user cancellation mid-execution.
   """
 
+  alias MingaAgent.ToolApproval.Preview
+
   @typedoc "Tool call execution status."
   @type status :: :running | :complete | :error
 
@@ -27,6 +29,7 @@ defmodule MingaAgent.ToolCall do
           is_error: boolean(),
           collapsed: boolean(),
           auto_approved_scope: auto_approved_scope() | nil,
+          preview: Preview.t() | nil,
           started_at: integer() | nil,
           duration_ms: non_neg_integer() | nil
         }
@@ -40,6 +43,7 @@ defmodule MingaAgent.ToolCall do
             is_error: false,
             collapsed: true,
             auto_approved_scope: nil,
+            preview: nil,
             started_at: nil,
             duration_ms: nil
 
@@ -103,6 +107,12 @@ defmodule MingaAgent.ToolCall do
   @spec set_auto_approved_scope(t(), auto_approved_scope() | nil) :: t()
   def set_auto_approved_scope(%__MODULE__{} = tc, scope) when scope in [:session, :turn, nil] do
     %{tc | auto_approved_scope: scope}
+  end
+
+  @doc "Records the transcript preview captured while the tool executed."
+  @spec set_preview(t(), Preview.t()) :: t()
+  def set_preview(%__MODULE__{} = tc, %Preview{} = preview) do
+    %{tc | preview: preview}
   end
 
   @doc "Returns true if the tool call has finished (complete or error)."

--- a/lib/minga_editor/agent/ui_state/panel.ex
+++ b/lib/minga_editor/agent/ui_state/panel.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.Agent.UIState.Panel do
   """
 
   alias MingaAgent.Config, as: AgentConfig
+  alias MingaEditor.Agent.Transcript
   alias Minga.Buffer
   alias Minga.Editing.Scroll
 
@@ -42,6 +43,8 @@ defmodule MingaEditor.Agent.UIState.Panel do
           credentials_configured: boolean(),
           provenance_jump: MingaEditor.Agent.ProvenanceJump.t() | nil
         }
+
+  @type styled_cache :: [MingaEditor.Agent.MarkdownHighlight.styled_lines()] | nil
 
   defstruct visible: false,
             scroll: %Scroll{},
@@ -125,6 +128,45 @@ defmodule MingaEditor.Agent.UIState.Panel do
   @spec set_model_name(t(), String.t()) :: t()
   def set_model_name(%__MODULE__{} = panel, model) when is_binary(model) do
     %{panel | model_name: model}
+  end
+
+  @doc "Replaces cached transcript projection data after a transcript sync."
+  @spec cache_transcript_display(t(), Transcript.display_result(), styled_cache(), keyword()) ::
+          t()
+  def cache_transcript_display(%__MODULE__{} = panel, display, styled_messages, opts \\ []) do
+    %{
+      panel
+      | cached_line_index: display.line_index,
+        cached_display_messages: display.display_messages,
+        cached_display_message_pairs: display.display_message_pairs,
+        cached_styled_messages: styled_messages,
+        display_start_index: Keyword.get(opts, :display_start_index, panel.display_start_index),
+        provenance_jump: Keyword.get(opts, :provenance_jump, panel.provenance_jump)
+    }
+  end
+
+  @doc "Clears cached transcript projection data when there is no displayable transcript."
+  @spec clear_transcript_cache(t()) :: t()
+  def clear_transcript_cache(%__MODULE__{} = panel) do
+    %{
+      panel
+      | cached_line_index: [],
+        cached_display_messages: [],
+        cached_display_message_pairs: [],
+        cached_styled_messages: nil,
+        display_start_index: 0,
+        provenance_jump: nil
+    }
+  end
+
+  @doc "Stores semantic scroll state for the agent transcript panel."
+  @spec set_scroll(t(), Scroll.t()) :: t()
+  def set_scroll(%__MODULE__{} = panel, %Scroll{} = scroll), do: %{panel | scroll: scroll}
+
+  @doc "Replaces cached styled transcript runs without changing the display window."
+  @spec cache_styled_messages(t(), styled_cache()) :: t()
+  def cache_styled_messages(%__MODULE__{} = panel, styled_messages) do
+    %{panel | cached_styled_messages: styled_messages}
   end
 
   @spec stale_unqualified_model?(String.t(), String.t()) :: boolean()

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.AgentLifecycle do
   alias MingaEditor.Agent.MarkdownHighlight
   alias MingaEditor.Agent.ProvenanceJump
   alias MingaEditor.Agent.Transcript
+  alias MingaEditor.Agent.UIState.Panel
   alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.Session, as: AgentSession
   alias MingaEditor.Agent.UIState
@@ -160,15 +161,10 @@ defmodule MingaEditor.AgentLifecycle do
     # display window and mark the jump landed so later re-syncs hold position
     # instead of re-pinning to the bottom.
     AgentAccess.update_panel(state, fn p ->
-      %{
-        p
-        | cached_line_index: result.line_index,
-          cached_display_messages: result.display_messages,
-          cached_display_message_pairs: result.display_message_pairs,
-          cached_styled_messages: styled,
-          display_start_index: display_start,
-          provenance_jump: advance_jump(jump)
-      }
+      Panel.cache_transcript_display(p, result, styled,
+        display_start_index: display_start,
+        provenance_jump: advance_jump(jump)
+      )
     end)
   end
 
@@ -181,17 +177,7 @@ defmodule MingaEditor.AgentLifecycle do
 
   @spec clear_transcript_cache(state()) :: state()
   defp clear_transcript_cache(state) do
-    AgentAccess.update_panel(state, fn panel ->
-      %{
-        panel
-        | cached_line_index: [],
-          cached_display_messages: [],
-          cached_display_message_pairs: [],
-          cached_styled_messages: nil,
-          display_start_index: 0,
-          provenance_jump: nil
-      }
-    end)
+    AgentAccess.update_panel(state, &Panel.clear_transcript_cache/1)
   end
 
   @spec first_run_empty_state(state(), [term()]) :: Transcript.empty_state()
@@ -373,7 +359,7 @@ defmodule MingaEditor.AgentLifecycle do
       styled = compute_styled_messages(state, messages)
 
       AgentAccess.update_panel(state, fn p ->
-        %{p | cached_styled_messages: styled}
+        Panel.cache_styled_messages(p, styled)
       end)
     else
       _ -> state

--- a/lib/minga_editor/remote/event_replay.ex
+++ b/lib/minga_editor/remote/event_replay.ex
@@ -5,6 +5,7 @@ defmodule MingaEditor.Remote.EventReplay do
   alias MingaEditor.Handlers.EffectHandler
   alias MingaEditor.State, as: EditorState
   alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.ToolApproval.Preview
 
   @type event :: term()
 
@@ -43,13 +44,16 @@ defmodule MingaEditor.Remote.EventReplay do
   end
 
   def to_agent_event(%EventRecord{event_type: :approval_requested, payload: payload}) do
-    {:approval_pending,
-     %{
-       tool_call_id: string_payload(payload, "tool_call_id"),
-       name: string_payload(payload, "name"),
-       args: map_payload(payload, "args"),
-       preview: payload_value(payload, "preview")
-     }}
+    approval = %{
+      tool_call_id: string_payload(payload, "tool_call_id"),
+      name: string_payload(payload, "name"),
+      args: map_payload(payload, "args")
+    }
+
+    case approval_preview(payload_value(payload, "preview")) do
+      nil -> {:approval_pending, approval}
+      preview -> {:approval_pending, Map.put(approval, :preview, preview)}
+    end
   end
 
   def to_agent_event(%EventRecord{event_type: :approval_resolved, payload: payload}),
@@ -79,6 +83,48 @@ defmodule MingaEditor.Remote.EventReplay do
   end
 
   def to_agent_event(%EventRecord{}), do: nil
+
+  @spec approval_preview(term()) :: Preview.t() | nil
+  defp approval_preview(%Preview{} = preview), do: preview
+
+  defp approval_preview(%{} = preview) do
+    case {payload_value(preview, "kind"), payload_value(preview, "summary"),
+          payload_value(preview, "lines")} do
+      {kind, summary, lines} when is_binary(summary) and is_list(lines) ->
+        case preview_kind(kind) do
+          nil ->
+            nil
+
+          preview_kind ->
+            if Enum.all?(lines, &is_binary/1) do
+              Preview.new(preview_kind, summary, lines)
+            else
+              nil
+            end
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp approval_preview(_preview), do: nil
+
+  @spec preview_kind(term()) :: Preview.kind() | nil
+  defp preview_kind(kind) when is_atom(kind) and kind in [:diff, :command, :target, :args],
+    do: kind
+
+  defp preview_kind(kind) when is_binary(kind) do
+    case kind do
+      "diff" -> :diff
+      "command" -> :command
+      "target" -> :target
+      "args" -> :args
+      _ -> nil
+    end
+  end
+
+  defp preview_kind(_kind), do: nil
 
   @spec payload_value(map(), String.t()) :: term()
   defp payload_value(payload, key) when is_map(payload) do

--- a/lib/minga_editor/remote/event_replay.ex
+++ b/lib/minga_editor/remote/event_replay.ex
@@ -91,17 +91,7 @@ defmodule MingaEditor.Remote.EventReplay do
     case {payload_value(preview, "kind"), payload_value(preview, "summary"),
           payload_value(preview, "lines")} do
       {kind, summary, lines} when is_binary(summary) and is_list(lines) ->
-        case preview_kind(kind) do
-          nil ->
-            nil
-
-          preview_kind ->
-            if Enum.all?(lines, &is_binary/1) do
-              Preview.new(preview_kind, summary, lines)
-            else
-              nil
-            end
-        end
+        build_approval_preview(preview_kind(kind), summary, lines)
 
       _ ->
         nil
@@ -109,6 +99,17 @@ defmodule MingaEditor.Remote.EventReplay do
   end
 
   defp approval_preview(_preview), do: nil
+
+  @spec build_approval_preview(Preview.kind() | nil, String.t(), [term()]) :: Preview.t() | nil
+  defp build_approval_preview(nil, _summary, _lines), do: nil
+
+  defp build_approval_preview(preview_kind, summary, lines) do
+    if Enum.all?(lines, &is_binary/1) do
+      Preview.new(preview_kind, summary, lines)
+    else
+      nil
+    end
+  end
 
   @spec preview_kind(term()) :: Preview.kind() | nil
   defp preview_kind(kind) when is_atom(kind) and kind in [:diff, :command, :target, :args],

--- a/lib/minga_editor/render_model/ui/agent_chat_builder.ex
+++ b/lib/minga_editor/render_model/ui/agent_chat_builder.ex
@@ -290,7 +290,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
 
   @spec tool_call_view(ToolCall.t()) :: ToolCallView.t()
   defp tool_call_view(%ToolCall{} = tc) do
-    preview = ToolApproval.build_preview(tc.name, tc.args)
+    preview = tc.preview || ToolApproval.build_transcript_preview(tc.name, tc.args)
 
     %ToolCallView{
       name: tc.name,

--- a/lib/minga_editor/render_model/ui/agent_chat_builder.ex
+++ b/lib/minga_editor/render_model/ui/agent_chat_builder.ex
@@ -290,6 +290,8 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
 
   @spec tool_call_view(ToolCall.t()) :: ToolCallView.t()
   defp tool_call_view(%ToolCall{} = tc) do
+    preview = ToolApproval.build_preview(tc.name, tc.args)
+
     %ToolCallView{
       name: tc.name,
       summary: tool_call_summary(tc),
@@ -298,7 +300,9 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
       is_error: tc.is_error,
       collapsed: tc.collapsed,
       duration_ms: tc.duration_ms,
-      auto_approved_scope: tc.auto_approved_scope
+      auto_approved_scope: tc.auto_approved_scope,
+      preview_kind: Map.get(preview, :kind, :args),
+      preview_lines: Map.get(preview, :lines, [])
     }
   end
 

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -1180,9 +1180,9 @@ enum PreviewRegistry {
         [
             Wire.ChatMessage(beamId: 1, content: .user(text: "The notification card should use our configured theme.")),
             Wire.ChatMessage(beamId: 2, content: .thinking(text: "Inspecting the SwiftUI chrome path and checking whether the notification background bypasses ThemeColors.", collapsed: false)),
-            Wire.ChatMessage(beamId: 3, content: .toolCall(name: "read", summary: "macos/Sources/Views/NotificationCenterView.swift", status: 1, isError: false, collapsed: false, autoApprovedScope: 0, durationMs: 148, result: "Found .ultraThinMaterial on the card background.")),
+            Wire.ChatMessage(beamId: 3, content: .toolCall(name: "read", summary: "macos/Sources/Views/NotificationCenterView.swift", status: 1, isError: false, collapsed: false, autoApprovedScope: 0, durationMs: 148, result: "Found .ultraThinMaterial on the card background.", previewKind: 0, previewLines: [])),
             Wire.ChatMessage(beamId: 4, content: .assistant(text: "I’ll switch the card to theme.popupBg and keep severity as a themed border, so light and dark themes stay under BEAM control.")),
-            Wire.ChatMessage(beamId: 5, content: .styledToolCall(name: "edit", summary: "Apply notification theme polish", status: 1, isError: false, collapsed: false, autoApprovedScope: 0, durationMs: 93, resultLines: [[styledRun(".background(theme.popupBg", 0x98, 0xBE, 0x65, bold: true), styledRun(", in: RoundedRectangle(cornerRadius: 10))", 0xBB, 0xC2, 0xCF)]])),
+            Wire.ChatMessage(beamId: 5, content: .styledToolCall(name: "edit", summary: "Apply notification theme polish", status: 1, isError: false, collapsed: false, autoApprovedScope: 0, durationMs: 93, resultLines: [[styledRun(".background(theme.popupBg", 0x98, 0xBE, 0x65, bold: true), styledRun(", in: RoundedRectangle(cornerRadius: 10))", 0xBB, 0xC2, 0xCF)]], previewKind: 0, previewLines: [])),
             Wire.ChatMessage(beamId: 6, content: .usage(input: 128_000, output: 3_840, cacheRead: 64_000, cacheWrite: 1_280, costMicros: 431_000)),
         ]
     }
@@ -1583,7 +1583,7 @@ enum PreviewRegistry {
             rawMessages: [
                 Wire.ChatMessage(beamId: 1, content: .user(text: "Refactor the buffer module to separate read and write concerns into distinct GenServer processes.")),
                 Wire.ChatMessage(beamId: 2, content: .thinking(text: "The buffer module currently mixes read-only queries (content, line count, syntax tree) with mutation operations (insert, delete, undo/redo). Splitting these would let readers proceed without blocking on writes, improving latency for completions and diagnostics that only need a snapshot.", collapsed: false)),
-                Wire.ChatMessage(beamId: 3, content: .toolCall(name: "read", summary: "lib/minga/buffer/process.ex", status: 0, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 0, result: "")),
+                Wire.ChatMessage(beamId: 3, content: .toolCall(name: "read", summary: "lib/minga/buffer/process.ex", status: 0, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 0, result: "", previewKind: 0, previewLines: [])),
             ]
         )
 
@@ -1614,7 +1614,7 @@ enum PreviewRegistry {
             rawMessages: [
                 Wire.ChatMessage(beamId: 1, content: .user(text: "Run the full test suite and fix any failures.")),
                 Wire.ChatMessage(beamId: 2, content: .thinking(text: "I'll run the tests first to identify failures before making changes.", collapsed: true)),
-                Wire.ChatMessage(beamId: 3, content: .toolCall(name: "read", summary: "mix.exs", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 62, result: "Read 48 lines")),
+                Wire.ChatMessage(beamId: 3, content: .toolCall(name: "read", summary: "mix.exs", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 62, result: "Read 48 lines", previewKind: 0, previewLines: [])),
                 Wire.ChatMessage(beamId: 4, content: .approvalToolCall(name: "shell", summary: "mix test --trace", toolCallId: "tc-approve-1", previewKind: 2, previewLines: ["mix test --trace", "", "Runs the full test suite with verbose output.", "This command may take several minutes."])),
             ]
         )
@@ -1646,8 +1646,8 @@ enum PreviewRegistry {
             rawMessages: [
                 Wire.ChatMessage(beamId: 1, content: .user(text: "Deploy the staging environment.")),
                 Wire.ChatMessage(beamId: 2, content: .thinking(text: "I'll check the deployment configuration and run the staging deploy script.", collapsed: true)),
-                Wire.ChatMessage(beamId: 3, content: .toolCall(name: "shell", summary: "mix release --env=staging", status: 1, isError: false, collapsed: true, autoApprovedScope: 2, durationMs: 4200, result: "Release built successfully")),
-                Wire.ChatMessage(beamId: 4, content: .toolCall(name: "shell", summary: "scripts/deploy.sh staging", status: 2, isError: true, collapsed: false, autoApprovedScope: 2, durationMs: 12400, result: "Error: SSH connection to staging-01.internal timed out after 30s\nexit code: 1")),
+                Wire.ChatMessage(beamId: 3, content: .toolCall(name: "shell", summary: "mix release --env=staging", status: 1, isError: false, collapsed: true, autoApprovedScope: 2, durationMs: 4200, result: "Release built successfully", previewKind: 0, previewLines: [])),
+                Wire.ChatMessage(beamId: 4, content: .toolCall(name: "shell", summary: "scripts/deploy.sh staging", status: 2, isError: true, collapsed: false, autoApprovedScope: 2, durationMs: 12400, result: "Error: SSH connection to staging-01.internal timed out after 30s\nexit code: 1", previewKind: 0, previewLines: [])),
                 Wire.ChatMessage(beamId: 5, content: .system(text: "Tool execution failed. The deploy script could not reach the staging host.", isError: true)),
                 Wire.ChatMessage(beamId: 6, content: .assistant(text: "The deploy failed because the staging host is unreachable. Check that the VPN is connected and that staging-01.internal is responding to SSH on port 22.")),
             ]
@@ -1722,10 +1722,10 @@ enum PreviewRegistry {
             rawMessages: [
                 Wire.ChatMessage(beamId: 1, content: .user(text: "Add input validation to the user registration form.")),
                 Wire.ChatMessage(beamId: 2, content: .thinking(text: "I need to add validation for email format, password strength, and required fields.", collapsed: true)),
-                Wire.ChatMessage(beamId: 3, content: .toolCall(name: "read", summary: "lib/minga/accounts/registration.ex", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 95, result: "Read 82 lines")),
-                Wire.ChatMessage(beamId: 4, content: .toolCall(name: "edit", summary: "Add changeset validations", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 210, result: "Applied 3 edits")),
-                Wire.ChatMessage(beamId: 5, content: .toolCall(name: "edit", summary: "Add error message helpers", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 145, result: "Applied 1 edit")),
-                Wire.ChatMessage(beamId: 6, content: .toolCall(name: "shell", summary: "mix test test/minga/accounts/registration_test.exs", status: 1, isError: false, collapsed: true, autoApprovedScope: 2, durationMs: 3400, result: "8 tests, 0 failures")),
+                Wire.ChatMessage(beamId: 3, content: .toolCall(name: "read", summary: "lib/minga/accounts/registration.ex", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 95, result: "Read 82 lines", previewKind: 0, previewLines: [])),
+                Wire.ChatMessage(beamId: 4, content: .toolCall(name: "edit", summary: "Add changeset validations", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 210, result: "Applied 3 edits", previewKind: 0, previewLines: [])),
+                Wire.ChatMessage(beamId: 5, content: .toolCall(name: "edit", summary: "Add error message helpers", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 145, result: "Applied 1 edit", previewKind: 0, previewLines: [])),
+                Wire.ChatMessage(beamId: 6, content: .toolCall(name: "shell", summary: "mix test test/minga/accounts/registration_test.exs", status: 1, isError: false, collapsed: true, autoApprovedScope: 2, durationMs: 3400, result: "8 tests, 0 failures", previewKind: 0, previewLines: [])),
                 Wire.ChatMessage(beamId: 7, content: .assistant(text: "I added input validation to the registration changeset: email format check via a regex, password minimum length of 8 characters with at least one digit, and validate_required on name, email, and password. All 8 tests pass.")),
                 Wire.ChatMessage(beamId: 8, content: .usage(input: 96_000, output: 2_150, cacheRead: 48_000, cacheWrite: 960, costMicros: 287_000)),
             ]

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -3089,6 +3089,30 @@ private struct DecodedChatMessageCandidate {
     let nextOffset: Int
 }
 
+private struct DecodedToolPreview {
+    let kind: UInt8
+    let lines: [String]
+    let nextOffset: Int
+}
+
+private func decodeToolPreview(data: Data, start: Int, end: Int) throws -> DecodedToolPreview {
+    guard end >= start + 3 else { throw ProtocolDecodeError.malformed }
+    let previewKind = data[start]
+    let lineCount = Int(readU16(data, start + 1))
+    var pos = start + 3
+    var previewLines: [String] = []
+    previewLines.reserveCapacity(lineCount)
+    for _ in 0..<lineCount {
+        guard end >= pos + 2 else { throw ProtocolDecodeError.malformed }
+        let lineLen = Int(readU16(data, pos))
+        guard end >= pos + 2 + lineLen else { throw ProtocolDecodeError.malformed }
+        let line = String(data: data[(pos + 2)..<(pos + 2 + lineLen)], encoding: .utf8) ?? ""
+        previewLines.append(line)
+        pos += 2 + lineLen
+    }
+    return DecodedToolPreview(kind: previewKind, lines: previewLines, nextOffset: pos)
+}
+
 private func decodeFramedChatMessages(data: Data, start: Int, end: Int, count: Int) throws -> [Wire.ChatMessage] {
     var messages: [Wire.ChatMessage] = []
     messages.reserveCapacity(count)
@@ -3186,11 +3210,15 @@ private func decodeChatMessageCandidates(data: Data, start: Int, end: Int) throw
         if end > baseOffset {
             let autoApprovedScope = data[baseOffset]
             if autoApprovedScope <= 2 {
-                let messageWithAuto = Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result))
+                let messageWithAuto = Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result, previewKind: 0, previewLines: []))
                 candidates.append(DecodedChatMessageCandidate(message: messageWithAuto, nextOffset: baseOffset + 1))
+                if end > baseOffset + 1, let preview = try? decodeToolPreview(data: data, start: baseOffset + 1, end: end) {
+                    let messageWithPreview = Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result, previewKind: preview.kind, previewLines: preview.lines))
+                    candidates.append(DecodedChatMessageCandidate(message: messageWithPreview, nextOffset: preview.nextOffset))
+                }
             }
         }
-        let messageWithoutAuto = Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: 0, durationMs: duration, result: result))
+        let messageWithoutAuto = Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: 0, durationMs: duration, result: result, previewKind: 0, previewLines: []))
         candidates.append(DecodedChatMessageCandidate(message: messageWithoutAuto, nextOffset: baseOffset))
         return candidates
 
@@ -3319,11 +3347,15 @@ private func decodeChatMessageCandidates(data: Data, start: Int, end: Int) throw
         if end > stcBaseOffset {
             let stcAutoApprovedScope = data[stcBaseOffset]
             if stcAutoApprovedScope <= 2 {
-                let stcMessageWithAuto = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: stcAutoApprovedScope, durationMs: stcDuration, resultLines: stcLines))
+                let stcMessageWithAuto = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: stcAutoApprovedScope, durationMs: stcDuration, resultLines: stcLines, previewKind: 0, previewLines: []))
                 stcCandidates.append(DecodedChatMessageCandidate(message: stcMessageWithAuto, nextOffset: stcBaseOffset + 1))
+                if end > stcBaseOffset + 1, let stcPreview = try? decodeToolPreview(data: data, start: stcBaseOffset + 1, end: end) {
+                    let stcMessageWithPreview = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: stcAutoApprovedScope, durationMs: stcDuration, resultLines: stcLines, previewKind: stcPreview.kind, previewLines: stcPreview.lines))
+                    stcCandidates.append(DecodedChatMessageCandidate(message: stcMessageWithPreview, nextOffset: stcPreview.nextOffset))
+                }
             }
         }
-        let stcMessageWithoutAuto = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: 0, durationMs: stcDuration, resultLines: stcLines))
+        let stcMessageWithoutAuto = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: 0, durationMs: stcDuration, resultLines: stcLines, previewKind: 0, previewLines: []))
         stcCandidates.append(DecodedChatMessageCandidate(message: stcMessageWithoutAuto, nextOffset: stcBaseOffset))
         return stcCandidates
 

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -615,9 +615,9 @@ enum Wire {
         /// Assistant message with pre-styled text runs from tree-sitter.
         case styledAssistant(lines: [[StyledTextRun]])
         case thinking(text: String, collapsed: Bool)
-        case toolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String)
+        case toolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String, previewKind: UInt8, previewLines: [String])
         /// Tool call with pre-styled result runs from tree-sitter.
-        case styledToolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, resultLines: [[StyledTextRun]])
+        case styledToolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, resultLines: [[StyledTextRun]], previewKind: UInt8, previewLines: [String])
         case approvalToolCall(name: String, summary: String, toolCallId: String, previewKind: UInt8, previewLines: [String])
         case system(text: String, isError: Bool)
         case usage(input: UInt32, output: UInt32, cacheRead: UInt32, cacheWrite: UInt32, costMicros: UInt32)

--- a/macos/Sources/Views/AgentChatState.swift
+++ b/macos/Sources/Views/AgentChatState.swift
@@ -9,8 +9,8 @@ enum ChatMessageEntry: Identifiable {
     /// Assistant message with pre-styled text runs from the BEAM (tree-sitter or markdown parser).
     case styledAssistant(id: Int, lines: [[Wire.StyledTextRun]])
     case thinking(id: Int, text: String, collapsed: Bool)
-    case toolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String)
-    case styledToolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, resultLines: [[Wire.StyledTextRun]])
+    case toolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String, previewKind: UInt8, previewLines: [String])
+    case styledToolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, resultLines: [[Wire.StyledTextRun]], previewKind: UInt8, previewLines: [String])
     case approvalToolCall(id: Int, name: String, summary: String, toolCallId: String, previewKind: UInt8, previewLines: [String])
     case system(id: Int, text: String, isError: Bool)
     case usage(id: Int, input: UInt32, output: UInt32, cacheRead: UInt32, cacheWrite: UInt32, costMicros: UInt32)
@@ -19,8 +19,8 @@ enum ChatMessageEntry: Identifiable {
         switch self {
         case .user(let id, _), .assistant(let id, _), .styledAssistant(let id, _),
              .thinking(let id, _, _),
-             .toolCall(let id, _, _, _, _, _, _, _, _),
-             .styledToolCall(let id, _, _, _, _, _, _, _, _),
+             .toolCall(let id, _, _, _, _, _, _, _, _, _, _),
+             .styledToolCall(let id, _, _, _, _, _, _, _, _, _, _),
              .approvalToolCall(let id, _, _, _, _, _),
              .system(let id, _, _),
              .usage(let id, _, _, _, _, _):
@@ -135,10 +135,10 @@ final class AgentChatState {
                 return .styledAssistant(id: id, lines: lines)
             case .thinking(let text, let collapsed):
                 return .thinking(id: id, text: text, collapsed: collapsed)
-            case .toolCall(let name, let summary, let st, let isError, let collapsed, let autoApprovedScope, let duration, let result):
-                return .toolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result)
-            case .styledToolCall(let name, let summary, let st, let isError, let collapsed, let autoApprovedScope, let duration, let resultLines):
-                return .styledToolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, resultLines: resultLines)
+            case .toolCall(let name, let summary, let st, let isError, let collapsed, let autoApprovedScope, let duration, let result, let previewKind, let previewLines):
+                return .toolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result, previewKind: previewKind, previewLines: previewLines)
+            case .styledToolCall(let name, let summary, let st, let isError, let collapsed, let autoApprovedScope, let duration, let resultLines, let previewKind, let previewLines):
+                return .styledToolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, resultLines: resultLines, previewKind: previewKind, previewLines: previewLines)
             case .approvalToolCall(let name, let summary, let toolCallId, let previewKind, let previewLines):
                 return .approvalToolCall(id: id, name: name, summary: summary, toolCallId: toolCallId, previewKind: previewKind, previewLines: previewLines)
             case .system(let text, let isError):

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -347,10 +347,10 @@ struct AgentChatView: View {
             styledAssistantBlock(lines)
         case .thinking(_, let text, let collapsed):
             thinkingBlock(text, collapsed: collapsed)
-        case .toolCall(_, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let result):
-            toolCallCard(messageIndex: index, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result, resultLines: nil)
-        case .styledToolCall(_, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let resultLines):
-            toolCallCard(messageIndex: index, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: nil, resultLines: resultLines)
+        case .toolCall(_, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let result, let previewKind, let previewLines):
+            toolCallCard(messageIndex: index, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result, resultLines: nil, previewKind: previewKind, previewLines: previewLines)
+        case .styledToolCall(_, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let resultLines, let previewKind, let previewLines):
+            toolCallCard(messageIndex: index, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: nil, resultLines: resultLines, previewKind: previewKind, previewLines: previewLines)
         case .approvalToolCall(_, let name, let summary, let toolCallId, let previewKind, let previewLines):
             approvalToolCallCard(name: name, summary: summary, toolCallId: toolCallId, previewKind: previewKind, previewLines: previewLines)
         case .system(_, let text, let isError):
@@ -522,8 +522,9 @@ struct AgentChatView: View {
     }
 
     @ViewBuilder
-    private func toolCallCard(messageIndex: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String?, resultLines: [[Wire.StyledTextRun]]?) -> some View {
+    private func toolCallCard(messageIndex: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String?, resultLines: [[Wire.StyledTextRun]]?, previewKind _: UInt8, previewLines: [String]) -> some View {
         let hasResult = result?.isEmpty == false || resultLines?.isEmpty == false
+        let visiblePreviewLines = Array(previewLines.prefix(8))
 
         VStack(alignment: .leading, spacing: 0) {
             // Header (clickable to toggle collapse)
@@ -577,6 +578,16 @@ struct AgentChatView: View {
                 if hasResult, messageIndex <= Int(UInt16.max) {
                     encoder?.sendAgentToolToggle(index: UInt16(messageIndex))
                 }
+            }
+
+            if !visiblePreviewLines.isEmpty {
+                Rectangle()
+                    .fill(theme.agentToolBorder.opacity(0.2))
+                    .frame(height: 1)
+
+                approvalPreviewLines(visiblePreviewLines)
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 8)
             }
 
             // Result (collapsed by default, supports styled or plain text)
@@ -735,9 +746,18 @@ struct AgentChatView: View {
     private func approvalPreviewLine(_ line: String) -> some View {
         Text(line)
             .font(.system(size: 10, design: .monospaced))
-            .foregroundStyle(theme.agentTextFg.opacity(0.65))
-            .lineLimit(1)
+            .foregroundStyle(approvalPreviewLineColor(line))
             .truncationMode(.tail)
+    }
+
+    private func approvalPreviewLineColor(_ line: String) -> Color {
+        if line.hasPrefix("+") {
+            return Color.green.opacity(0.75)
+        }
+        if line.hasPrefix("-") {
+            return Color.red.opacity(0.75)
+        }
+        return theme.agentTextFg.opacity(0.65)
     }
 
     private func approvalButtons(toolCallId _: String) -> some View {

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -385,12 +385,13 @@ func chatMessageToJSON(_ msg: Wire.ChatMessage) -> [String: Any] {
         result["kind"] = "styled_assistant"; result["lines"] = linesJSON
     case .thinking(let text, let collapsed):
         result["kind"] = "thinking"; result["text"] = text; result["collapsed"] = collapsed
-    case .toolCall(let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let durationMs, let resultStr):
+    case .toolCall(let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let durationMs, let resultStr, let previewKind, let previewLines):
         result["kind"] = "tool_call"; result["name"] = name; result["summary"] = summary
         result["status"] = Int(status); result["is_error"] = isError; result["collapsed"] = collapsed
         result["auto_approved_scope"] = Int(autoApprovedScope)
         result["duration_ms"] = Int(durationMs); result["result"] = resultStr
-    case .styledToolCall(let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let durationMs, let resultLines):
+        result["preview_kind"] = Int(previewKind); result["preview_lines"] = previewLines
+    case .styledToolCall(let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let durationMs, let resultLines, let previewKind, let previewLines):
         let linesJSON: [[Any]] = resultLines.map { runs in
             runs.map { run -> [String: Any] in
                 return [
@@ -407,6 +408,7 @@ func chatMessageToJSON(_ msg: Wire.ChatMessage) -> [String: Any] {
         result["status"] = Int(status); result["is_error"] = isError; result["collapsed"] = collapsed
         result["auto_approved_scope"] = Int(autoApprovedScope)
         result["duration_ms"] = Int(durationMs); result["result_lines"] = linesJSON
+        result["preview_kind"] = Int(previewKind); result["preview_lines"] = previewLines
     case .approvalToolCall(let name, let summary, let toolCallId, let previewKind, let previewLines):
         result["kind"] = "approval_tool_call"
         result["name"] = name

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -2083,12 +2083,16 @@ struct GUIAgentChatDecoderTests {
         appendU32(&msgs, UInt32(result.utf8.count))
         msgs.append(contentsOf: result.utf8)
         msgs.append(2) // autoApprovedScope at end
+        msgs.append(1) // previewKind diff
+        appendU16(&msgs, 2)
+        appendString16(&msgs, "-old")
+        appendString16(&msgs, "+new")
 
         let data = buildChatData(status: 2, model: "claude", messages: buildMessagesPayload(count: 1, msgs))
         let (cmd, _) = try decodeCommand(data: data, offset: 0)
         guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
         guard messages.count == 1 else { Issue.record("Expected 1 message"); return }
-        guard case .toolCall(let name, _, let tcStatus, let isError, let collapsed, let autoApprovedScope, let duration, let tcResult) = messages[0].content else { Issue.record("Expected .toolCall"); return }
+        guard case .toolCall(let name, _, let tcStatus, let isError, let collapsed, let autoApprovedScope, let duration, let tcResult, let previewKind, let previewLines) = messages[0].content else { Issue.record("Expected .toolCall"); return }
         #expect(name == "read_file")
         #expect(tcStatus == 1)
         #expect(isError == false)
@@ -2096,6 +2100,8 @@ struct GUIAgentChatDecoderTests {
         #expect(autoApprovedScope == 2)
         #expect(duration == 1234)
         #expect(tcResult == "file contents here")
+        #expect(previewKind == 1)
+        #expect(previewLines == ["-old", "+new"])
     }
 
     @Test("Decode gui_agent_chat framed tool_call with auto_approved followed by another message")
@@ -2124,7 +2130,7 @@ struct GUIAgentChatDecoderTests {
 
         guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
         guard messages.count == 2 else { Issue.record("Expected 2 messages"); return }
-        guard case .toolCall(let name, _, _, _, _, let autoApprovedScope, _, let tcResult) = messages[0].content else { Issue.record("Expected .toolCall"); return }
+        guard case .toolCall(let name, _, _, _, _, let autoApprovedScope, _, let tcResult, _, _) = messages[0].content else { Issue.record("Expected .toolCall"); return }
         guard case .user(let laterText) = messages[1].content else { Issue.record("Expected trailing user message"); return }
 
         #expect(name == "read_file")
@@ -2159,7 +2165,7 @@ struct GUIAgentChatDecoderTests {
 
         guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
         guard messages.count == 2 else { Issue.record("Expected 2 messages"); return }
-        guard case .toolCall(let name, _, _, _, _, let autoApprovedScope, _, let tcResult) = messages[0].content else { Issue.record("Expected .toolCall"); return }
+        guard case .toolCall(let name, _, _, _, _, let autoApprovedScope, _, let tcResult, _, _) = messages[0].content else { Issue.record("Expected .toolCall"); return }
         guard case .user(let laterText) = messages[1].content else { Issue.record("Expected trailing user message"); return }
 
         #expect(name == "read_file")
@@ -2312,7 +2318,7 @@ struct GUIAgentChatDecoderTests {
 
         guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
         guard messages.count == 2 else { Issue.record("Expected 2 messages"); return }
-        guard case .styledToolCall(let name, _, _, _, _, let autoApprovedScope, _, let resultLines) = messages[0].content else { Issue.record("Expected .styledToolCall"); return }
+        guard case .styledToolCall(let name, _, _, _, _, let autoApprovedScope, _, let resultLines, _, _) = messages[0].content else { Issue.record("Expected .styledToolCall"); return }
         guard case .assistant(let laterText) = messages[1].content else { Issue.record("Expected trailing assistant message"); return }
 
         #expect(name == "shell")
@@ -2351,7 +2357,7 @@ struct GUIAgentChatDecoderTests {
 
         guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
         guard messages.count == 2 else { Issue.record("Expected 2 messages"); return }
-        guard case .styledToolCall(let name, _, _, _, _, let autoApprovedScope, _, let resultLines) = messages[0].content else { Issue.record("Expected .styledToolCall"); return }
+        guard case .styledToolCall(let name, _, _, _, _, let autoApprovedScope, _, let resultLines, _, _) = messages[0].content else { Issue.record("Expected .styledToolCall"); return }
         guard case .assistant(let laterText) = messages[1].content else { Issue.record("Expected trailing assistant message"); return }
 
         #expect(name == "shell")

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -383,7 +383,7 @@ struct AgentChatStateLifecycleTests {
             Wire.ChatMessage(beamId: 2, content: .assistant(text: "hi")),
             Wire.ChatMessage(beamId: 3, content: .thinking(text: "analyzing...", collapsed: false)),
             Wire.ChatMessage(beamId: 4, content: .toolCall(name: "read_file", summary: "lib/minga.ex", status: 1, isError: false,
-                     collapsed: true, autoApprovedScope: 0, durationMs: 500, result: "contents")),
+                     collapsed: true, autoApprovedScope: 0, durationMs: 500, result: "contents", previewKind: 0, previewLines: [])),
             Wire.ChatMessage(beamId: 5, content: .system(text: "session started", isError: false)),
             Wire.ChatMessage(beamId: 6, content: .usage(input: 100, output: 50, cacheRead: 80, cacheWrite: 20, costMicros: 5000))
         ]

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -1127,8 +1127,8 @@ struct AgentChatViewTests {
     @Test("Auto-approved tool calls show the subtle scope pill")
     @MainActor func autoApprovedIndicatorRenders() throws {
         let state = chatState(messages: [
-            .toolCall(id: 1, name: "shell", summary: "git diff --cached", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 500, result: ""),
-            .toolCall(id: 2, name: "shell", summary: "git status --short", status: 1, isError: false, collapsed: true, autoApprovedScope: 2, durationMs: 250, result: "")
+            .toolCall(id: 1, name: "shell", summary: "git diff --cached", status: 1, isError: false, collapsed: true, autoApprovedScope: 1, durationMs: 500, result: "", previewKind: 0, previewLines: []),
+            .toolCall(id: 2, name: "shell", summary: "git status --short", status: 1, isError: false, collapsed: true, autoApprovedScope: 2, durationMs: 250, result: "", previewKind: 0, previewLines: [])
         ])
 
         let sut = AgentChatView(state: state, theme: ThemeColors(), isInsertMode: false, encoder: nil)

--- a/test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs
@@ -276,12 +276,42 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
 
       <<1::32, 0x04::8, 0::8, 0::8, 1::8, 0::32, name_len::16, name::binary-size(name_len),
         summary_len::16, summary::binary-size(summary_len), result_len::32,
-        result::binary-size(result_len), auto_approved::8>> = m1
+        result::binary-size(result_len), auto_approved::8, preview_kind::8, preview_count::16>> =
+        m1
 
       assert name == "write_file"
       assert summary == "lib/x.ex"
       assert result == "file contents"
       assert auto_approved == 1
+      assert preview_kind == 0
+      assert preview_count == 0
+    end
+
+    test "tool_call message carries preview lines after auto-approved scope" do
+      tc = %ToolCallView{
+        name: "edit_file",
+        summary: "lib/x.ex",
+        status: :complete,
+        collapsed: true,
+        preview_kind: :diff,
+        preview_lines: ["file: lib/x.ex", "-old", "+new"]
+      }
+
+      binary = encode(%AgentChat{visible?: true, messages: [{1, {:tool_call, tc}}]})
+      assert [m1] = messages!(binary)
+
+      <<1::32, 0x04::8, _status::8, _error::8, _collapsed::8, _duration::32, name_len::16,
+        _name::binary-size(name_len), summary_len::16, _summary::binary-size(summary_len),
+        result_len::32, _result::binary-size(result_len), auto_approved::8, kind::8,
+        line_count::16, l1_len::16, l1::binary-size(l1_len), l2_len::16, l2::binary-size(l2_len),
+        l3_len::16, l3::binary-size(l3_len)>> = m1
+
+      assert auto_approved == 0
+      assert kind == 1
+      assert line_count == 3
+      assert l1 == "file: lib/x.ex"
+      assert l2 == "-old"
+      assert l3 == "+new"
     end
 
     test "tool_call status byte mapping" do
@@ -330,7 +360,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
       <<1::32, 0x08::8, status::8, error::8, collapsed::8, duration::32, name_len::16,
         name::binary-size(name_len), summary_len::16, _summary::binary-size(summary_len),
         line_count::16, run_count::16, text_len::16, text::binary-size(text_len), fg::24, bg::24,
-        flags::8, auto_approved::8>> = m1
+        flags::8, auto_approved::8, preview_kind::8, preview_count::16>> = m1
 
       assert status == 1
       assert error == 0
@@ -344,6 +374,8 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
       assert bg == 0x000000
       assert flags == 0x01
       assert auto_approved == 0
+      assert preview_kind == 0
+      assert preview_count == 0
     end
 
     test "approval_tool_call message with explicit preview" do

--- a/test/minga_agent/session_store_test.exs
+++ b/test/minga_agent/session_store_test.exs
@@ -3,7 +3,6 @@ defmodule MingaAgent.SessionStoreTest do
 
   alias MingaAgent.Branch
   alias MingaAgent.SessionStore
-  alias MingaAgent.ToolApproval.Preview
   alias MingaAgent.ToolCall
   alias MingaAgent.TurnUsage
 
@@ -31,7 +30,6 @@ defmodule MingaAgent.SessionStoreTest do
            is_error: false,
            collapsed: true,
            auto_approved_scope: :session,
-           preview: Preview.new(:diff, "lib/foo.ex", ["file: lib/foo.ex", "-old", "+new"]),
            started_at: nil,
            duration_ms: 42
          }},
@@ -100,9 +98,7 @@ defmodule MingaAgent.SessionStoreTest do
       assert tc.duration_ms == 42
       assert tc.status == :complete
       assert tc.auto_approved_scope == :session
-      assert tc.preview.kind == :diff
-      assert tc.preview.summary == "lib/foo.ex"
-      assert tc.preview.lines == ["file: lib/foo.ex", "-old", "+new"]
+      assert tc.preview == nil
     end
 
     test "loads corrupted message atoms defensively", %{tmp_dir: dir} do
@@ -126,6 +122,55 @@ defmodule MingaAgent.SessionStoreTest do
       assert {:ok, loaded} = SessionStore.load("bad-atoms", dir)
       assert {:system, "bad level", :info} in loaded.messages
       assert {:tool_call, %{status: :complete}} = List.last(loaded.messages)
+    end
+
+    test "rejects malformed preview payloads defensively", %{tmp_dir: dir} do
+      sessions_dir = SessionStore.sessions_dir(dir)
+      File.mkdir_p!(sessions_dir)
+
+      base_payload = %{
+        "id" => "bad-preview",
+        "timestamp" => "2026-01-01T00:00:00Z",
+        "model_name" => "test-model",
+        "messages" => [
+          %{
+            "type" => "tool_call",
+            "id" => "tc",
+            "name" => "shell",
+            "args" => %{"command" => "mix test"},
+            "status" => "complete",
+            "result" => "ok",
+            "is_error" => false,
+            "collapsed" => true,
+            "auto_approved_scope" => "session",
+            "duration_ms" => 10,
+            "preview" => %{"kind" => "shell", "summary" => "mix test", "lines" => ["$ mix test"]}
+          }
+        ],
+        "usage" => %{}
+      }
+
+      File.write!(Path.join(sessions_dir, "bad-preview-kind.json"), JSON.encode!(base_payload))
+
+      {:ok, loaded_kind} = SessionStore.load("bad-preview-kind", dir)
+      [{:tool_call, tool_call_kind}] = loaded_kind.messages
+      assert tool_call_kind.preview == nil
+
+      bad_lines_payload =
+        put_in(base_payload, ["messages", Access.at(0), "preview"], %{
+          "kind" => "diff",
+          "summary" => "lib/foo.ex",
+          "lines" => ["-old", 123]
+        })
+
+      File.write!(
+        Path.join(sessions_dir, "bad-preview-lines.json"),
+        JSON.encode!(bad_lines_payload)
+      )
+
+      {:ok, loaded_lines} = SessionStore.load("bad-preview-lines", dir)
+      [{:tool_call, tool_call_lines}] = loaded_lines.messages
+      assert tool_call_lines.preview == nil
     end
 
     test "preserves thinking messages" do

--- a/test/minga_agent/session_store_test.exs
+++ b/test/minga_agent/session_store_test.exs
@@ -3,6 +3,7 @@ defmodule MingaAgent.SessionStoreTest do
 
   alias MingaAgent.Branch
   alias MingaAgent.SessionStore
+  alias MingaAgent.ToolApproval.Preview
   alias MingaAgent.ToolCall
   alias MingaAgent.TurnUsage
 
@@ -30,6 +31,7 @@ defmodule MingaAgent.SessionStoreTest do
            is_error: false,
            collapsed: true,
            auto_approved_scope: :session,
+           preview: Preview.new(:diff, "lib/foo.ex", ["file: lib/foo.ex", "-old", "+new"]),
            started_at: nil,
            duration_ms: 42
          }},
@@ -98,6 +100,9 @@ defmodule MingaAgent.SessionStoreTest do
       assert tc.duration_ms == 42
       assert tc.status == :complete
       assert tc.auto_approved_scope == :session
+      assert tc.preview.kind == :diff
+      assert tc.preview.summary == "lib/foo.ex"
+      assert tc.preview.lines == ["file: lib/foo.ex", "-old", "+new"]
     end
 
     test "loads corrupted message atoms defensively", %{tmp_dir: dir} do

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -1388,6 +1388,53 @@ defmodule MingaAgent.SessionTest do
                        _tool_name}},
                      200
     end
+
+    test "captures file diff preview on the matching tool call", %{session: session} do
+      send(
+        session,
+        {:agent_provider_event,
+         %Event.ToolStart{
+           tool_call_id: "tc1",
+           name: "write_file",
+           args: %{"path" => "lib/foo.ex", "content" => "new content"}
+         }}
+      )
+
+      send(
+        session,
+        {:agent_provider_event,
+         %Event.ToolEnd{tool_call_id: "tc1", name: "write_file", result: "wrote file"}}
+      )
+
+      send(
+        session,
+        {:agent_provider_event,
+         %Event.ToolFileChanged{
+           tool_call_id: "tc1",
+           path: "lib/foo.ex",
+           before_content: "old content",
+           after_content: "new content"
+         }}
+      )
+
+      assert_receive {:agent_event, _,
+                      {:file_changed, "lib/foo.ex", "old content", "new content", "tc1",
+                       _tool_name}},
+                     200
+
+      tool_call =
+        Session.messages(session)
+        |> Enum.find_value(fn
+          {:tool_call, tool_call} -> tool_call
+          _ -> nil
+        end)
+
+      assert tool_call.preview.kind == :diff
+      assert tool_call.preview.summary == "lib/foo.ex"
+      assert "file: lib/foo.ex" in tool_call.preview.lines
+      assert "-old content" in tool_call.preview.lines
+      assert "+new content" in tool_call.preview.lines
+    end
   end
 
   describe "tool approval" do

--- a/test/minga_agent/tool_approval_test.exs
+++ b/test/minga_agent/tool_approval_test.exs
@@ -12,6 +12,23 @@ defmodule MingaAgent.ToolApprovalTest do
       assert "$ rm -rf tmp/build" in preview.lines
     end
 
+    test "builds clean empty previews for read-only tools" do
+      previews = [
+        {"read_file", %{"path" => "lib/app.ex"}, "lib/app.ex"},
+        {"grep", %{"pattern" => "defmodule", "path" => "lib"}, "defmodule in lib"},
+        {"find", %{"name" => "*.ex", "path" => "lib"}, "*.ex in lib"},
+        {"list_directory", %{"path" => "lib"}, "lib"}
+      ]
+
+      for {name, args, summary} <- previews do
+        preview = ToolApproval.build_preview(name, args)
+
+        assert preview.kind == :args
+        assert preview.summary == summary
+        assert preview.lines == []
+      end
+    end
+
     test "builds diff preview for write_file tools" do
       path =
         Path.join(

--- a/test/minga_agent/tool_approval_test.exs
+++ b/test/minga_agent/tool_approval_test.exs
@@ -2,6 +2,7 @@ defmodule MingaAgent.ToolApprovalTest do
   use ExUnit.Case, async: true
 
   alias MingaAgent.ToolApproval
+  alias MingaAgent.ToolApproval.Preview
 
   describe "build_preview/2" do
     test "builds command preview for shell tools" do
@@ -10,6 +11,16 @@ defmodule MingaAgent.ToolApprovalTest do
       assert preview.kind == :command
       assert preview.summary == "rm -rf tmp/build"
       assert "$ rm -rf tmp/build" in preview.lines
+    end
+
+    test "encodes approval previews as JSON" do
+      preview = Preview.new(:diff, "lib/app.ex", ["file: lib/app.ex", "-old", "+new"])
+
+      assert JSON.decode!(JSON.encode!(preview)) == %{
+               "kind" => "diff",
+               "summary" => "lib/app.ex",
+               "lines" => ["file: lib/app.ex", "-old", "+new"]
+             }
     end
 
     test "builds clean empty previews for read-only tools" do

--- a/test/minga_agent/tool_approval_test.exs
+++ b/test/minga_agent/tool_approval_test.exs
@@ -52,7 +52,7 @@ defmodule MingaAgent.ToolApprovalTest do
       assert Enum.all?(preview.lines, &(String.length(&1) <= 300))
     end
 
-    test "builds target preview for edit_file tools" do
+    test "builds diff preview for edit_file tools" do
       preview =
         ToolApproval.build_preview("edit_file", %{
           "path" => "lib/a.ex",
@@ -60,34 +60,42 @@ defmodule MingaAgent.ToolApprovalTest do
           "new_text" => "new"
         })
 
-      assert preview.kind == :target
+      assert preview.kind == :diff
       assert preview.summary == "lib/a.ex"
       assert "file: lib/a.ex" in preview.lines
-      assert ~s(replace "old" with "new") in preview.lines
+      assert "-old" in preview.lines
+      assert "+new" in preview.lines
     end
 
-    test "builds edit-count preview for multi_edit_file tools" do
+    test "builds diff preview for multi_edit_file tools" do
       preview =
         ToolApproval.build_preview("multi_edit_file", %{
           "path" => "lib/a.ex",
-          "edits" => [%{}, %{}]
+          "edits" => [
+            %{"old_text" => "old", "new_text" => "new"},
+            %{"find" => "before", "replace" => "after"}
+          ]
         })
 
-      assert preview.kind == :target
+      assert preview.kind == :diff
       assert preview.summary == "lib/a.ex"
-      assert "2 edit(s)" in preview.lines
+      assert "-old" in preview.lines
+      assert "+new" in preview.lines
+      assert "-before" in preview.lines
+      assert "+after" in preview.lines
     end
 
-    test "builds hunk-count preview for apply_diff tools" do
+    test "builds diff preview for apply_diff tools" do
       preview =
         ToolApproval.build_preview("apply_diff", %{
           "path" => "lib/a.ex",
           "diff" => "@@ -1,1 +1,1 @@\n-old\n+new\n"
         })
 
-      assert preview.kind == :target
+      assert preview.kind == :diff
       assert preview.summary == "lib/a.ex"
-      assert "1 diff hunk(s)" in preview.lines
+      assert "-old" in preview.lines
+      assert "+new" in preview.lines
     end
 
     test "builds target preview for git_stage tools" do

--- a/test/minga_editor/remote/event_replay_test.exs
+++ b/test/minga_editor/remote/event_replay_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Remote.EventReplayTest do
 
   alias MingaEditor.Remote.EventReplay
   alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.ToolApproval.Preview
 
   test "converts durable remote events into live agent events" do
     assert EventReplay.to_agent_event(record(:assistant_delta, %{"delta" => "hello"})) ==
@@ -24,7 +25,11 @@ defmodule MingaEditor.Remote.EventReplayTest do
                "tool_call_id" => "tc1",
                "name" => "shell",
                "args" => %{"command" => "mix test"},
-               "preview" => %{"kind" => "shell"}
+               "preview" => %{
+                 "kind" => "command",
+                 "summary" => "mix test",
+                 "lines" => ["$ mix test", "cwd: /tmp"]
+               }
              })
            ) ==
              {:approval_pending,
@@ -32,8 +37,42 @@ defmodule MingaEditor.Remote.EventReplayTest do
                 tool_call_id: "tc1",
                 name: "shell",
                 args: %{"command" => "mix test"},
-                preview: %{"kind" => "shell"}
+                preview: %Preview{
+                  kind: :command,
+                  summary: "mix test",
+                  lines: ["$ mix test", "cwd: /tmp"]
+                }
               }}
+
+    assert {:approval_pending, approval} =
+             EventReplay.to_agent_event(
+               record(:approval_requested, %{
+                 "tool_call_id" => "tc2",
+                 "name" => "shell",
+                 "args" => %{"command" => "mix test"},
+                 "preview" => %{"kind" => "nope", "summary" => "bad", "lines" => ["x"]}
+               })
+             )
+
+    assert approval.tool_call_id == "tc2"
+    assert approval.name == "shell"
+    assert approval.args == %{"command" => "mix test"}
+    refute Map.has_key?(approval, :preview)
+
+    assert {:approval_pending, approval} =
+             EventReplay.to_agent_event(
+               record(:approval_requested, %{
+                 "tool_call_id" => "tc3",
+                 "name" => "shell",
+                 "args" => %{"command" => "mix test"},
+                 "preview" => %{"kind" => "shell"}
+               })
+             )
+
+    assert approval.tool_call_id == "tc3"
+    assert approval.name == "shell"
+    assert approval.args == %{"command" => "mix test"}
+    refute Map.has_key?(approval, :preview)
 
     assert EventReplay.to_agent_event(record(:waiting_for_input, %{})) == {:status_changed, :idle}
 

--- a/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
 
   alias MingaEditor.Agent.Transcript
   alias MingaEditor.Agent.UIState
+  alias MingaAgent.ToolApproval
   alias MingaAgent.ToolCall
   alias Minga.Editing.Scroll
   alias MingaEditor.Agent.UIState.Panel
@@ -163,6 +164,91 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
     assert "file: lib/app.ex" in view.preview_lines
     assert "-old" in view.preview_lines
     assert "+new" in view.preview_lines
+  end
+
+  test "build/1 omits raw inspected preview lines for completed read-only tool calls" do
+    session = fake_session_pid()
+
+    read_only_calls = [
+      {"read_file", %{"path" => "lib/app.ex"}, "lib/app.ex"},
+      {"grep", %{"pattern" => "defmodule", "path" => "lib"}, "defmodule in lib"},
+      {"find", %{"name" => "*.ex", "path" => "lib"}, "*.ex in lib"},
+      {"list_directory", %{"path" => "lib"}, "lib"}
+    ]
+
+    display_pairs =
+      read_only_calls
+      |> Enum.with_index(1)
+      |> Enum.map(fn {{name, args, _summary}, id} ->
+        {id, {:tool_call, ToolCall.new("tc-#{id}", name, args) |> ToolCall.complete("ok")}}
+      end)
+
+    panel = %Panel{
+      cached_display_message_pairs: display_pairs,
+      cached_styled_messages: List.duplicate(nil, length(display_pairs))
+    }
+
+    model =
+      context(session, panel)
+      |> AgentChatBuilder.build()
+
+    views = for {_id, {:tool_call, view}} <- model.messages, do: view
+
+    assert Enum.map(views, & &1.summary) ==
+             Enum.map(read_only_calls, fn {_name, _args, summary} -> summary end)
+
+    assert Enum.all?(views, &(&1.preview_lines == []))
+  end
+
+  test "build/1 uses captured write_file previews instead of recomputing current disk state" do
+    session = fake_session_pid()
+    path = "/tmp/minga-agent-chat-write-preview.txt"
+
+    tool_call =
+      ToolCall.new("tc-write", "write_file", %{"path" => path, "content" => "new\n"})
+      |> ToolCall.set_preview(ToolApproval.build_file_diff_preview(path, "old\n", "new\n"))
+      |> ToolCall.complete("wrote file")
+
+    panel = %Panel{
+      cached_display_message_pairs: [{1, {:tool_call, tool_call}}],
+      cached_styled_messages: [nil]
+    }
+
+    model =
+      context(session, panel)
+      |> AgentChatBuilder.build()
+
+    assert {1, {:tool_call, view}} = List.first(model.messages)
+    assert view.name == "write_file"
+    assert view.summary == path
+    assert view.preview_kind == :diff
+    assert "file: #{path}" in view.preview_lines
+    assert "-old" in view.preview_lines
+    assert "+new" in view.preview_lines
+  end
+
+  test "build/1 does not invent write_file transcript previews from current disk state" do
+    session = fake_session_pid()
+    path = "/tmp/minga-agent-chat-write-preview.txt"
+
+    tool_call =
+      ToolCall.new("tc-write", "write_file", %{"path" => path, "content" => "new\n"})
+      |> ToolCall.complete("wrote file")
+
+    panel = %Panel{
+      cached_display_message_pairs: [{1, {:tool_call, tool_call}}],
+      cached_styled_messages: [nil]
+    }
+
+    model =
+      context(session, panel)
+      |> AgentChatBuilder.build()
+
+    assert {1, {:tool_call, view}} = List.first(model.messages)
+    assert view.name == "write_file"
+    assert view.summary == path
+    assert view.preview_kind == :target
+    assert view.preview_lines == []
   end
 
   defp message_summary({id, {:assistant, text}}), do: {id, :assistant, text}

--- a/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
@@ -26,18 +26,13 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
     visible_message = {:assistant, "visible"}
     message_ids = [{101, old_message}, {102, hidden_message}, {103, visible_message}]
 
-    %{display_messages: display_messages, display_message_pairs: display_pairs} =
-      Transcript.display([old_message, hidden_message, visible_message],
+    panel =
+      synced_panel([old_message, hidden_message, visible_message],
         display_start_index: 2,
         message_ids: message_ids,
-        pinned_ids: MapSet.new([101])
+        pinned_ids: MapSet.new([101]),
+        styled_messages: [nil, nil, nil, nil]
       )
-
-    panel = %Panel{
-      cached_display_messages: display_messages,
-      cached_display_message_pairs: display_pairs,
-      cached_styled_messages: [nil, nil, nil, nil]
-    }
 
     model =
       context(session, panel)
@@ -61,22 +56,16 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
   test "build/1 emits only messages through the manual semantic scroll viewport" do
     session = fake_session_pid()
 
-    panel = %Panel{
-      scroll: Scroll.new(2) |> Scroll.update_metrics(5, 1),
-      cached_line_index: [
-        {0, :text},
-        {0, :empty},
-        {1, :text},
-        {1, :empty},
-        {2, :text}
-      ],
-      cached_display_message_pairs: [
-        {1, {:assistant, "first"}},
-        {2, {:assistant, "second"}},
-        {3, {:assistant, "third"}}
-      ],
-      cached_styled_messages: [nil, nil, nil]
-    }
+    panel =
+      synced_panel(
+        [
+          {:assistant, "first"},
+          {:assistant, "second"},
+          {:assistant, "third"}
+        ],
+        scroll: Scroll.new(2) |> Scroll.update_metrics(5, 1),
+        styled_messages: [nil, nil, nil]
+      )
 
     model =
       context(session, panel)
@@ -148,10 +137,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
         "new_text" => "new"
       })
 
-    panel = %Panel{
-      cached_display_message_pairs: [{1, {:tool_call, tool_call}}],
-      cached_styled_messages: [nil]
-    }
+    panel = synced_panel([{:tool_call, tool_call}], styled_messages: [nil])
 
     model =
       context(session, panel)
@@ -176,17 +162,12 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
       {"list_directory", %{"path" => "lib"}, "lib"}
     ]
 
-    display_pairs =
+    panel =
       read_only_calls
-      |> Enum.with_index(1)
-      |> Enum.map(fn {{name, args, _summary}, id} ->
-        {id, {:tool_call, ToolCall.new("tc-#{id}", name, args) |> ToolCall.complete("ok")}}
+      |> Enum.map(fn {name, args, _summary} ->
+        {:tool_call, ToolCall.new("tc-#{name}", name, args) |> ToolCall.complete("ok")}
       end)
-
-    panel = %Panel{
-      cached_display_message_pairs: display_pairs,
-      cached_styled_messages: List.duplicate(nil, length(display_pairs))
-    }
+      |> synced_panel(styled_messages: List.duplicate(nil, length(read_only_calls)))
 
     model =
       context(session, panel)
@@ -209,10 +190,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
       |> ToolCall.set_preview(ToolApproval.build_file_diff_preview(path, "old\n", "new\n"))
       |> ToolCall.complete("wrote file")
 
-    panel = %Panel{
-      cached_display_message_pairs: [{1, {:tool_call, tool_call}}],
-      cached_styled_messages: [nil]
-    }
+    panel = synced_panel([{:tool_call, tool_call}], styled_messages: [nil])
 
     model =
       context(session, panel)
@@ -235,10 +213,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
       ToolCall.new("tc-write", "write_file", %{"path" => path, "content" => "new\n"})
       |> ToolCall.complete("wrote file")
 
-    panel = %Panel{
-      cached_display_message_pairs: [{1, {:tool_call, tool_call}}],
-      cached_styled_messages: [nil]
-    }
+    panel = synced_panel([{:tool_call, tool_call}], styled_messages: [nil])
 
     model =
       context(session, panel)
@@ -257,14 +232,16 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
   defp message_summary({id, {kind, _, _}}), do: {id, kind, nil}
 
   defp synced_panel(messages, opts \\ []) do
-    %{display_messages: display_messages, display_message_pairs: display_pairs} =
-      Transcript.display(messages, opts)
+    {panel_opts, transcript_opts} = Keyword.split(opts, [:scroll, :styled_messages])
+    display = Transcript.display(messages, transcript_opts)
 
-    %Panel{
-      cached_display_messages: display_messages,
-      cached_display_message_pairs: display_pairs
-    }
+    Panel.new()
+    |> Panel.cache_transcript_display(display, Keyword.get(panel_opts, :styled_messages))
+    |> maybe_set_panel_scroll(Keyword.get(panel_opts, :scroll))
   end
+
+  defp maybe_set_panel_scroll(panel, nil), do: panel
+  defp maybe_set_panel_scroll(panel, scroll), do: Panel.set_scroll(panel, scroll)
 
   defp context(session, panel) do
     tab = Tab.new_agent(1, "Agent") |> Tab.set_session(session)

--- a/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
 
   alias MingaEditor.Agent.Transcript
   alias MingaEditor.Agent.UIState
+  alias MingaAgent.ToolCall
   alias Minga.Editing.Scroll
   alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Frontend.Emit.Context
@@ -134,6 +135,34 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
 
     assert [{_, :system, "Session started"}, {_, :system, "Agent UI registry online"}] =
              Enum.map(model.messages, &message_summary/1)
+  end
+
+  test "build/1 resolves tool calls with clean summaries and inline diff previews" do
+    session = fake_session_pid()
+
+    tool_call =
+      ToolCall.new("tc-1", "edit_file", %{
+        "path" => "lib/app.ex",
+        "old_text" => "old",
+        "new_text" => "new"
+      })
+
+    panel = %Panel{
+      cached_display_message_pairs: [{1, {:tool_call, tool_call}}],
+      cached_styled_messages: [nil]
+    }
+
+    model =
+      context(session, panel)
+      |> AgentChatBuilder.build()
+
+    assert {1, {:tool_call, view}} = List.first(model.messages)
+    assert view.name == "edit_file"
+    assert view.summary == "lib/app.ex"
+    assert view.preview_kind == :diff
+    assert "file: lib/app.ex" in view.preview_lines
+    assert "-old" in view.preview_lines
+    assert "+new" in view.preview_lines
   end
 
   defp message_summary({id, {:assistant, text}}), do: {id, :assistant, text}


### PR DESCRIPTION
## Summary
- add inline tool-call preview fields to the agent chat render model and populate them from the existing ToolApproval preview primitive
- encode/decode optional preview payloads for tool_call and styled_tool_call across BEAM, Go TUI, and macOS
- render bounded inline previews/results and use Ctrl+Alt+X for latest tool-card expansion while keeping Ctrl+Alt+Z thinking-only
- document the appended gui_agent_chat tool preview payload in docs/GUI_PROTOCOL.md

## Notes
- Tests exercise public preview, render-model, protocol, and frontend model boundaries. No new tests use :sys.replace_state or direct editor/session internal state mutation.

## Validation
- mix test test/minga_agent/tool_approval_test.exs test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs test/minga_editor/render_model/ui/agent_chat_builder_test.exs test/minga/render_model/ui/agent_chat/tool_arg_summary_test.exs
- cd go/tui && go test ./internal/protocol ./internal/ui
- cd go/tui && go test ./...
- xcodebuild build -project macos/Minga.xcodeproj -scheme Minga -configuration Debug -derivedDataPath /private/tmp/minga-xcode-derived-2464 -clonedSourcePackagesDirPath /private/tmp/minga-spm-2464 -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO
- mix native.build.support
- mix test
- mix format --check-formatted
- mix compile --warnings-as-errors
- mix credo --strict
- xcodebuild test -project macos/Minga.xcodeproj -scheme Minga -configuration Debug -destination 'platform=macOS' -derivedDataPath /private/tmp/minga-xcode-derived-2464 -clonedSourcePackagesDirPath /private/tmp/minga-spm-2464 -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO
- git diff --check

Fixes #2464