### PR TITLE
fix(agent): smooth composer command friction

### DIFF
--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -180,8 +180,8 @@ defmodule Minga.Keymap.Scope.Agent do
       groups: @input_normal_groups,
       then: fn trie ->
         trie
-        # No Escape binding: in normal mode, Escape is a no-op (vim semantics).
-        # Use `q` or Ctrl+Q to leave the input field.
+        # A second Escape leaves input-normal and returns focus to chat navigation.
+        |> Bindings.bind(~k(ESC), :agent_unfocus_input, "Back to chat nav")
         |> Bindings.bind(~k(q), :agent_unfocus_input, "Back to chat nav")
       end
     )

--- a/lib/minga_agent/file_mention.ex
+++ b/lib/minga_agent/file_mention.ex
@@ -45,7 +45,7 @@ defmodule MingaAgent.FileMention do
   alias MingaAgent.ModelLimits
   alias ReqLLM.Message.ContentPart
 
-  @max_candidates 10
+  @max_candidates 50
   @max_file_size 256 * 1024
   @max_image_size 5 * 1024 * 1024
 
@@ -382,18 +382,64 @@ defmodule MingaAgent.FileMention do
     lower = String.downcase(prefix)
 
     files
-    |> Enum.filter(fn path ->
-      String.contains?(String.downcase(path), lower)
-    end)
-    |> Enum.sort_by(fn path ->
-      # Prefer prefix matches over substring matches
-      lower_path = String.downcase(path)
-
-      cond do
-        String.starts_with?(lower_path, lower) -> {0, path}
-        String.starts_with?(Path.basename(String.downcase(path)), lower) -> {1, path}
-        true -> {2, path}
-      end
-    end)
+    |> Enum.flat_map(&candidate_rank(&1, lower))
+    |> Enum.sort_by(fn {rank, path} -> {rank, path} end)
+    |> Enum.map(fn {_rank, path} -> path end)
   end
+
+  @spec candidate_rank(String.t(), String.t()) :: [{non_neg_integer(), String.t()}]
+  defp candidate_rank(path, lower_prefix) do
+    lower_path = String.downcase(path)
+    basename = Path.basename(lower_path)
+
+    case path_rank(lower_path, basename, lower_prefix) do
+      nil -> []
+      rank -> [{rank, path}]
+    end
+  end
+
+  @spec path_rank(String.t(), String.t(), String.t()) :: non_neg_integer() | nil
+  defp path_rank(lower_path, _basename, lower_prefix)
+       when lower_path == lower_prefix,
+       do: 0
+
+  defp path_rank(_lower_path, basename, lower_prefix)
+       when basename == lower_prefix,
+       do: 1
+
+  defp path_rank(lower_path, _basename, lower_prefix) do
+    path_rank_by_match(lower_path, lower_prefix)
+  end
+
+  @spec path_rank_by_match(String.t(), String.t()) :: non_neg_integer() | nil
+  defp path_rank_by_match(lower_path, lower_prefix) do
+    basename = Path.basename(lower_path)
+
+    case {String.starts_with?(lower_path, lower_prefix),
+          String.starts_with?(basename, lower_prefix), String.contains?(lower_path, lower_prefix),
+          subsequence?(lower_prefix, lower_path)} do
+      {true, _, _, _} -> 2
+      {_, true, _, _} -> 3
+      {_, _, true, _} -> 4
+      {_, _, _, true} -> 5
+      _ -> nil
+    end
+  end
+
+  @spec subsequence?(String.t(), String.t()) :: boolean()
+  defp subsequence?("", _text), do: true
+  defp subsequence?(_needle, ""), do: false
+
+  defp subsequence?(needle, text) do
+    needle
+    |> String.graphemes()
+    |> do_subsequence?(String.graphemes(text))
+  end
+
+  @spec do_subsequence?([String.t()], [String.t()]) :: boolean()
+  defp do_subsequence?([], _text), do: true
+  defp do_subsequence?(_needle, []), do: false
+
+  defp do_subsequence?([char | needle], [char | text]), do: do_subsequence?(needle, text)
+  defp do_subsequence?(needle, [_char | text]), do: do_subsequence?(needle, text)
 end

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -113,6 +113,24 @@ defmodule MingaEditor.Agent.SlashCommand do
     Enum.filter(commands(), fn cmd -> String.starts_with?(cmd.name, clean) end)
   end
 
+  @doc "Returns true when raw slash input names a registered or skill command."
+  @spec known_command?(String.t()) :: boolean()
+  def known_command?("/" <> rest) do
+    {cmd, _args} = parse_command(rest)
+    known_command_name?(cmd)
+  end
+
+  def known_command?(_text), do: false
+
+  @doc "Builds the user-facing message for an unknown slash command."
+  @spec unknown_command_message(String.t()) :: String.t()
+  def unknown_command_message("/" <> rest) do
+    {cmd, _args} = parse_command(rest)
+    unknown_command_message_for_name(cmd, suggestion_for_command(cmd))
+  end
+
+  def unknown_command_message(_text), do: "Not a slash command"
+
   @doc "Returns completion candidates for the current slash input, without the leading slash."
   @spec completion_candidates(state(), String.t()) :: [completion_candidate()]
   def completion_candidates(state, input) when is_binary(input) do
@@ -164,6 +182,60 @@ defmodule MingaEditor.Agent.SlashCommand do
     |> available_model_entries()
     |> filter_model_entries(prefix)
     |> Enum.map(&model_completion_candidate/1)
+  end
+
+  @spec known_command_name?(String.t()) :: boolean()
+  defp known_command_name?(cmd) do
+    command_name?(cmd) or skill_command?(cmd)
+  end
+
+  @spec command_name?(String.t()) :: boolean()
+  defp command_name?(cmd) do
+    Enum.any?(commands(), &(&1.name == cmd))
+  end
+
+  @spec skill_command?(String.t()) :: boolean()
+  defp skill_command?(cmd) do
+    parse_skill_command(cmd) != :not_skill
+  end
+
+  @spec unknown_command_message_for_name(String.t(), String.t() | nil) :: String.t()
+  defp unknown_command_message_for_name(cmd, nil), do: "Unknown command: /#{cmd}"
+
+  defp unknown_command_message_for_name(cmd, suggestion) do
+    "Unknown command: /#{cmd}. Did you mean /#{suggestion}?"
+  end
+
+  @spec suggestion_for_command(String.t()) :: String.t() | nil
+  defp suggestion_for_command(cmd) do
+    case completions(cmd) do
+      [%Command{name: name} | _] -> name
+      [] -> fuzzy_suggestion_for_command(cmd)
+    end
+  end
+
+  @spec fuzzy_suggestion_for_command(String.t()) :: String.t() | nil
+  defp fuzzy_suggestion_for_command(cmd) do
+    matches =
+      commands()
+      |> Enum.map(& &1.name)
+      |> Enum.map(&{command_distance(cmd, &1), &1})
+      |> Enum.filter(fn {distance, _name} -> distance <= 2 end)
+      |> Enum.sort_by(fn {distance, name} -> {distance, String.length(name), name} end)
+
+    case matches do
+      [{_distance, name} | _] -> name
+      [] -> nil
+    end
+  end
+
+  @spec command_distance(String.t(), String.t()) :: non_neg_integer()
+  defp command_distance(left, right) do
+    String.myers_difference(left, right)
+    |> Enum.reduce(0, fn
+      {:eq, _text}, acc -> acc
+      {_op, text}, acc -> acc + String.length(text)
+    end)
   end
 
   @spec available_model_entries(state()) :: [map()]
@@ -1248,7 +1320,8 @@ defmodule MingaEditor.Agent.SlashCommand do
     emit_system_message(state, summary)
   end
 
-  defdelegate detect_project_root, to: Minga.Project, as: :resolve_root
+  @spec detect_project_root() :: String.t()
+  defp detect_project_root, do: Minga.Project.resolve_root()
 
   @spec emit_system_message(state(), String.t()) :: state()
   defp emit_system_message(state, message) do
@@ -1290,7 +1363,9 @@ defmodule MingaEditor.Agent.SlashCommand do
     trimmed_args = String.trim(args)
     cmd_args = if trimmed_args == "", do: [], else: [trimmed_args]
 
-    case System.cmd(command_path, cmd_args, stderr_to_stdout: true) do
+    task = Task.async(fn -> System.cmd(command_path, cmd_args, stderr_to_stdout: true) end)
+
+    case Task.await(task, :infinity) do
       {output, 0} ->
         {:ok, emit_system_message(state, String.trim(output))}
 
@@ -1299,6 +1374,8 @@ defmodule MingaEditor.Agent.SlashCommand do
     end
   rescue
     e -> {:error, "Command /#{cmd.name} error: #{Exception.message(e)}"}
+  catch
+    :exit, reason -> {:error, "Command /#{cmd.name} exited: #{inspect(reason)}"}
   end
 
   # ── Helpers ─────────────────────────────────────────────────────────────────

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -432,8 +432,12 @@ defmodule MingaEditor.Commands.Agent do
 
   @spec submit_prompt_text(state(), String.t(), boolean()) :: state()
   defp submit_prompt_text(state, text, true) do
-    state = clear_submitted_slash_input(state, text)
-    execute_slash_command(state, text)
+    if SlashCommand.known_command?(text) do
+      state = clear_submitted_slash_input(state, text)
+      execute_slash_command(state, text)
+    else
+      report_unknown_slash_command(state, text)
+    end
   end
 
   defp submit_prompt_text(state, text, false) do
@@ -460,6 +464,17 @@ defmodule MingaEditor.Commands.Agent do
       {:ok, state} -> state
       {:error, msg} -> EditorState.set_status(state, msg)
     end
+  end
+
+  @spec report_unknown_slash_command(state(), String.t()) :: state()
+  defp report_unknown_slash_command(state, text) do
+    message = SlashCommand.unknown_command_message(text)
+
+    if AgentAccess.session(state) do
+      Session.add_system_message(AgentAccess.session(state), message, :error)
+    end
+
+    EditorState.set_status(state, message)
   end
 
   @spec send_prompt_to_llm(state(), String.t()) :: state()

--- a/lib/minga_editor/commands/agent_sub_states.ex
+++ b/lib/minga_editor/commands/agent_sub_states.ex
@@ -403,14 +403,20 @@ defmodule MingaEditor.Commands.AgentSubStates do
           {String.t(), non_neg_integer(), non_neg_integer()} | nil
   defp slash_command_token_at_cursor(state) do
     panel = AgentAccess.panel(state)
-    {line, col} = UIState.input_cursor(panel)
-    current_line = Enum.at(UIState.input_lines(panel), line, "")
-    before_cursor = String.slice(current_line, 0, col)
 
-    if leading_slash_token?(before_cursor) do
-      {String.trim_leading(before_cursor, "/"), line, 0}
-    else
-      nil
+    case UIState.input_cursor(panel) do
+      {0, col} ->
+        current_line = Enum.at(UIState.input_lines(panel), 0, "")
+        before_cursor = String.slice(current_line, 0, col)
+
+        if leading_slash_token?(before_cursor) do
+          {String.trim_leading(before_cursor, "/"), 0, 0}
+        else
+          nil
+        end
+
+      {_line, _col} ->
+        nil
     end
   end
 

--- a/lib/minga_editor/commands/agent_sub_states.ex
+++ b/lib/minga_editor/commands/agent_sub_states.ex
@@ -151,11 +151,21 @@ defmodule MingaEditor.Commands.AgentSubStates do
     end
   end
 
-  @doc "Triggers /slash command completion when / is typed at position (0, 0)."
+  @doc "Returns true when the prompt cursor is inside the leading slash command token."
+  @spec slash_command_token_at_cursor?(state()) :: boolean()
+  def slash_command_token_at_cursor?(state), do: slash_command_token_at_cursor(state) != nil
+
+  @doc "Triggers /slash command completion from the current slash command token."
   @spec trigger_slash_completion(state()) :: state()
   def trigger_slash_completion(state) do
-    slash_completion_state(state, "")
-    |> update_slash_completion(state)
+    case slash_command_token_at_cursor(state) do
+      {prefix, anchor_line, anchor_col} ->
+        slash_completion_state(state, prefix, anchor_line, anchor_col)
+        |> update_slash_completion(state)
+
+      nil ->
+        update_slash_completion(nil, state)
+    end
   end
 
   # ── Diff review commands ───────────────────────────────────────────────────
@@ -334,7 +344,7 @@ defmodule MingaEditor.Commands.AgentSubStates do
     state = AgentCommands.input_backspace(state)
     new_input = trim_last_grapheme(comp.prefix)
 
-    slash_completion_state(state, new_input)
+    slash_completion_state(state, new_input, comp.anchor_line, comp.anchor_col)
     |> update_slash_completion(state)
   end
 
@@ -343,7 +353,7 @@ defmodule MingaEditor.Commands.AgentSubStates do
     state = AgentCommands.input_char(state, char)
     new_input = comp.prefix <> char
 
-    slash_completion_state(state, new_input)
+    slash_completion_state(state, new_input, comp.anchor_line, comp.anchor_col)
     |> update_slash_completion(state)
   end
 
@@ -357,8 +367,9 @@ defmodule MingaEditor.Commands.AgentSubStates do
     |> Enum.join()
   end
 
-  @spec slash_completion_state(state(), String.t()) :: map() | nil
-  defp slash_completion_state(state, input) do
+  @spec slash_completion_state(state(), String.t(), non_neg_integer(), non_neg_integer()) ::
+          map() | nil
+  defp slash_completion_state(state, input, anchor_line, anchor_col) do
     candidates = SlashCommand.completion_candidates(state, input)
 
     if candidates == [] do
@@ -371,8 +382,8 @@ defmodule MingaEditor.Commands.AgentSubStates do
         all_files: [],
         candidates: labels,
         selected: 0,
-        anchor_line: 0,
-        anchor_col: 0,
+        anchor_line: anchor_line,
+        anchor_col: anchor_col,
         slash_candidates: Enum.map(candidates, &{&1.label, &1.description}),
         slash_insertions: Map.new(candidates, &{&1.label, &1.insert})
       }
@@ -387,6 +398,30 @@ defmodule MingaEditor.Commands.AgentSubStates do
   defp update_slash_completion(comp, state) do
     update_panel(state, fn p -> %{p | mention_completion: comp} end)
   end
+
+  @spec slash_command_token_at_cursor(state()) ::
+          {String.t(), non_neg_integer(), non_neg_integer()} | nil
+  defp slash_command_token_at_cursor(state) do
+    panel = AgentAccess.panel(state)
+    {line, col} = UIState.input_cursor(panel)
+    current_line = Enum.at(UIState.input_lines(panel), line, "")
+    before_cursor = String.slice(current_line, 0, col)
+
+    if leading_slash_token?(before_cursor) do
+      {String.trim_leading(before_cursor, "/"), line, 0}
+    else
+      nil
+    end
+  end
+
+  @spec leading_slash_token?(String.t()) :: boolean()
+  defp leading_slash_token?("/"), do: true
+
+  defp leading_slash_token?("/" <> rest) do
+    not String.contains?(rest, [" ", "\t", "\n"])
+  end
+
+  defp leading_slash_token?(_text), do: false
 
   @spec accept_slash_completion(state(), map()) :: state()
   defp accept_slash_completion(state, comp) do
@@ -494,6 +529,21 @@ defmodule MingaEditor.Commands.AgentSubStates do
 
   @spec list_project_files() :: [String.t()]
   defp list_project_files do
+    case cached_project_files() do
+      [] -> list_project_files_from_disk()
+      files -> files
+    end
+  end
+
+  @spec cached_project_files() :: [String.t()]
+  defp cached_project_files do
+    Minga.Project.files()
+  catch
+    :exit, _ -> []
+  end
+
+  @spec list_project_files_from_disk() :: [String.t()]
+  defp list_project_files_from_disk do
     root =
       try do
         case Minga.Project.root() do

--- a/lib/minga_editor/input/agent_panel.ex
+++ b/lib/minga_editor/input/agent_panel.ex
@@ -20,6 +20,7 @@ defmodule MingaEditor.Input.AgentPanel do
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Commands
   alias MingaEditor.Commands.Agent, as: AgentCommands
+  alias MingaEditor.Commands.AgentSubStates
   alias MingaEditor.LayoutPreset
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -101,15 +102,11 @@ defmodule MingaEditor.Input.AgentPanel do
   end
 
   defp handle_panel_self_insert(state, ?/, _mods) do
-    # Trigger slash command completion when / is typed at position (0, 0)
-    panel = MingaEditor.State.AgentAccess.panel(state)
-    {line, col} = MingaEditor.Agent.UIState.input_cursor(panel)
-
-    if line == 0 and col == 0 do
-      state = AgentCommands.input_char(state, "/")
+    if AgentSubStates.slash_command_token_at_cursor?(state) do
       AgentCommands.scope_trigger_slash_completion(state)
     else
-      AgentCommands.input_char(state, "/")
+      state = AgentCommands.input_char(state, "/")
+      AgentCommands.scope_trigger_slash_completion(state)
     end
   end
 

--- a/lib/minga_editor/input/scoped.ex
+++ b/lib/minga_editor/input/scoped.ex
@@ -33,6 +33,7 @@ defmodule MingaEditor.Input.Scoped do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Input.AgentPanel
+  alias MingaEditor.Commands.AgentSubStates
   alias Minga.Keymap
 
   alias Minga.Keymap.Scope
@@ -268,6 +269,15 @@ defmodule MingaEditor.Input.Scoped do
           {:handled, EditorState.t()}
   defp handle_agent_self_insert(state, ?@, _mods) do
     {:handled, AgentCommands.scope_trigger_mention(state)}
+  end
+
+  defp handle_agent_self_insert(state, ?/, _mods) do
+    if AgentSubStates.slash_command_token_at_cursor?(state) do
+      {:handled, AgentCommands.scope_trigger_slash_completion(state)}
+    else
+      state = Commands.execute(state, {:agent_self_insert, "/"})
+      {:handled, AgentCommands.scope_trigger_slash_completion(state)}
+    end
   end
 
   defp handle_agent_self_insert(state, cp, _mods) do

--- a/test/minga/keymap/scope/agent_scope_shared_groups_test.exs
+++ b/test/minga/keymap/scope/agent_scope_shared_groups_test.exs
@@ -68,8 +68,9 @@ defmodule Minga.Keymap.Scope.AgentScopeSharedGroupsTest do
       assert {:command, :agent_unfocus_and_quit} = Bindings.lookup(trie, {?q, @ctrl})
     end
 
-    test "scope-specific q binding", %{trie: trie} do
+    test "scope-specific q and Escape bindings", %{trie: trie} do
       assert {:command, :agent_unfocus_input} = Bindings.lookup(trie, {?q, 0})
+      assert {:command, :agent_unfocus_input} = Bindings.lookup(trie, {27, 0})
     end
   end
 

--- a/test/minga_agent/file_mention_test.exs
+++ b/test/minga_agent/file_mention_test.exs
@@ -209,10 +209,10 @@ defmodule MingaAgent.FileMentionTest do
       assert comp.anchor_col == 5
     end
 
-    test "limits initial candidates to 10" do
-      files = Enum.map(1..20, &"file_#{&1}.ex")
+    test "limits initial candidates to 50" do
+      files = Enum.map(1..60, &"file_#{&1}.ex")
       comp = FileMention.new_completion(files, 0, 0)
-      assert length(comp.candidates) == 10
+      assert length(comp.candidates) == 50
     end
   end
 
@@ -233,6 +233,36 @@ defmodule MingaAgent.FileMentionTest do
 
       comp = FileMention.update_prefix(comp, "mymod")
       assert "lib/MyModule.ex" in comp.candidates
+    end
+
+    test "subsequence filtering finds abbreviated deep paths" do
+      files = [
+        "lib/minga_editor/commands/agent.ex",
+        "lib/minga_editor/input/scoped.ex",
+        "test/support/stub_server.ex"
+      ]
+
+      comp = FileMention.new_completion(files, 0, 0)
+
+      comp = FileMention.update_prefix(comp, "mecag")
+      assert comp.candidates == ["lib/minga_editor/commands/agent.ex"]
+    end
+
+    test "ranking prefers path and basename prefixes before fuzzy matches" do
+      files = [
+        "test/minga_editor/agent_test.exs",
+        "lib/minga_editor/agent.ex",
+        "lib/some/mega_file.ex"
+      ]
+
+      comp = FileMention.new_completion(files, 0, 0)
+
+      comp = FileMention.update_prefix(comp, "agent")
+
+      assert Enum.take(comp.candidates, 2) == [
+               "lib/minga_editor/agent.ex",
+               "test/minga_editor/agent_test.exs"
+             ]
     end
 
     test "clamps selected index when candidates shrink" do

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -172,6 +172,10 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       assert SlashCommand.unknown_command_message("/modle") ==
                "Unknown command: /modle. Did you mean /model?"
     end
+
+    test "returns a plain unknown command message when there is no close match" do
+      assert SlashCommand.unknown_command_message("/zzzz") == "Unknown command: /zzzz"
+    end
   end
 
   describe "completion_candidates/2" do

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -160,6 +160,20 @@ defmodule MingaEditor.Agent.SlashCommandTest do
     end
   end
 
+  describe "known_command?/1 and unknown_command_message/1" do
+    test "recognizes built-in and skill commands" do
+      assert SlashCommand.known_command?("/model")
+      assert SlashCommand.known_command?("/skill:plan")
+      assert SlashCommand.known_command?("/skill:off:plan")
+      refute SlashCommand.known_command?("/modle")
+    end
+
+    test "suggests close slash command names" do
+      assert SlashCommand.unknown_command_message("/modle") ==
+               "Unknown command: /modle. Did you mean /model?"
+    end
+  end
+
   describe "completion_candidates/2" do
     test "returns slash command candidates before an argument" do
       labels = SlashCommand.completion_candidates(mock_state(), "mo") |> Enum.map(& &1.label)

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -250,6 +250,22 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == ""
     end
 
+    test "unknown slash command preserves draft and reports the error in chat" do
+      {:ok, session} = StubServer.start_link(notify: self())
+
+      state =
+        base_state(session: session)
+        |> AgentCommands.input_paste("/modle")
+
+      new_state = AgentCommands.submit_prompt(state)
+
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == "/modle"
+      assert new_state.shell_state.status_msg == "Unknown command: /modle. Did you mean /model?"
+
+      assert_receive {:stub_system_message, "Unknown command: /modle. Did you mean /model?",
+                      :error}
+    end
+
     test "blocks submit and preserves draft when no model is configured" do
       state =
         base_state(session: nil)
@@ -388,6 +404,26 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       assert_receive {:readiness_session_prompt, "ready prompt"}
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == ""
+    end
+
+    test "unresolved file mention preserves the prompt and does not send" do
+      {:ok, session} = ReadinessSession.start_link(provider: self(), notify: self())
+
+      state =
+        base_state(session: session)
+        |> AgentCommands.input_paste("@missing.ex explain")
+        |> AgentAccess.update_panel(fn panel ->
+          panel
+          |> Panel.set_credentials_configured(true)
+          |> Panel.set_model_name("anthropic:claude-sonnet-4-20250514")
+          |> Panel.set_provider_name("anthropic")
+        end)
+
+      new_state = AgentCommands.submit_prompt(state)
+
+      assert new_state.shell_state.status_msg =~ "Cannot resolve file mentions"
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == "@missing.ex explain"
+      refute_receive {:readiness_session_prompt, _prompt}
     end
 
     test "ready local provider sends even when panel credentials cache is stale" do

--- a/test/minga_editor/commands/agent_sub_states_test.exs
+++ b/test/minga_editor/commands/agent_sub_states_test.exs
@@ -1,0 +1,146 @@
+defmodule MingaEditor.Commands.AgentSubStatesTest do
+  @moduledoc "Tests for agent prompt sub-state transitions."
+
+  # async: false because these tests temporarily mutate the global Minga.Project singleton registration/state, change the cwd via File.cd!/2, and exercise project file discovery that touches filesystem and global process state.
+  use ExUnit.Case, async: false
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.Commands.Agent, as: AgentCommands
+  alias MingaEditor.Commands.AgentSubStates
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
+  alias MingaEditor.Viewport
+
+  @moduletag :tmp_dir
+
+  describe "trigger_slash_completion/1" do
+    test "does not reopen slash completion from a later prompt line" do
+      state = prompt_state("/mo\nsecond line", {1, 0})
+      state = AgentCommands.input_char(state, "/")
+      state = AgentSubStates.trigger_slash_completion(state)
+
+      assert AgentAccess.panel(state).mention_completion == nil
+      assert BufferProcess.content(AgentAccess.panel(state).prompt_buffer) == "/mo\n/second line"
+    end
+  end
+
+  describe "trigger_mention/1" do
+    test "prefers cached project files over late disk files", %{tmp_dir: tmp_dir} do
+      root = Path.join(tmp_dir, "cached_project_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(root)
+      File.write!(Path.join(root, "mix.exs"), "")
+      File.write!(Path.join(root, "cached.ex"), "cached")
+      File.write!(Path.join(root, "late.ex"), "late")
+
+      with_project_state(root, ["cached.ex"], fn ->
+        state = prompt_state("draft", {0, 0})
+        state = AgentSubStates.trigger_mention(state)
+        candidates = AgentAccess.panel(state).mention_completion.candidates
+
+        assert "cached.ex" in candidates
+        refute "late.ex" in candidates
+      end)
+    end
+
+    test "falls back to disk files when the project cache is empty", %{tmp_dir: tmp_dir} do
+      root = Path.join(tmp_dir, "empty_cache_project_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(root)
+      File.write!(Path.join(root, "mix.exs"), "")
+      File.write!(Path.join(root, "disk.ex"), "disk")
+
+      with_project_state(root, [], fn ->
+        state = prompt_state("draft", {0, 0})
+        state = AgentSubStates.trigger_mention(state)
+        candidates = AgentAccess.panel(state).mention_completion.candidates
+
+        assert "disk.ex" in candidates
+      end)
+    end
+
+    test "falls back to cwd discovery when Project is unavailable", %{tmp_dir: tmp_dir} do
+      cwd = Path.join(tmp_dir, "project_unavailable_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(cwd)
+      File.write!(Path.join(cwd, "cwd.ex"), "cwd")
+
+      without_project(fn ->
+        File.cd!(cwd, fn ->
+          state = prompt_state("draft", {0, 0})
+          state = AgentSubStates.trigger_mention(state)
+          candidates = AgentAccess.panel(state).mention_completion.candidates
+
+          assert "cwd.ex" in candidates
+        end)
+      end)
+    end
+  end
+
+  defp prompt_state(text, cursor) do
+    prompt_buffer =
+      start_supervised!(
+        Supervisor.child_spec(
+          {BufferProcess, [content: text]},
+          id: {:prompt_buffer, System.unique_integer([:positive])}
+        )
+      )
+
+    BufferProcess.move_to(prompt_buffer, cursor)
+
+    panel = %{UIState.new().panel | prompt_buffer: prompt_buffer, input_focused: true}
+    agent_ui = %{UIState.new() | panel: panel}
+
+    %EditorState{
+      port_manager: self(),
+      workspace: %SessionState{
+        viewport: Viewport.new(24, 80),
+        agent_ui: agent_ui
+      }
+    }
+  end
+
+  defp with_project_state(root, cached_files, fun) when is_list(cached_files) do
+    pid = project_pid!()
+    original_state = :sys.get_state(pid)
+
+    :sys.replace_state(pid, fn state ->
+      %{state | current_root: root, cached_files: cached_files, rebuilding?: false}
+    end)
+
+    try do
+      fun.()
+    after
+      maybe_restore_project_registration(pid)
+      :sys.replace_state(pid, fn _ -> original_state end)
+    end
+  end
+
+  defp project_pid! do
+    case Process.whereis(Minga.Project) do
+      nil -> start_supervised!({Minga.Project, subscribe: false})
+      pid -> pid
+    end
+  end
+
+  defp maybe_restore_project_registration(pid) do
+    if Process.whereis(Minga.Project) == nil do
+      true = Process.register(pid, Minga.Project)
+    end
+  end
+
+  defp without_project(fun) do
+    case Process.whereis(Minga.Project) do
+      nil ->
+        fun.()
+
+      pid ->
+        true = :erlang.unregister(Minga.Project)
+
+        try do
+          fun.()
+        after
+          true = Process.register(pid, Minga.Project)
+        end
+    end
+  end
+end

--- a/test/minga_editor/input/scoped_test.exs
+++ b/test/minga_editor/input/scoped_test.exs
@@ -713,6 +713,42 @@ defmodule MingaEditor.Input.ScopedTest do
       assert Minga.Buffer.content(AgentAccess.panel(state).prompt_buffer) == "/model "
       assert AgentAccess.panel(state).mention_completion == nil
     end
+
+    test "re-summons slash completion after the first command character" do
+      state = base_state(keymap_scope: :editor, panel_visible: true, input_focused: true)
+
+      {:handled, state} = walk_surface_handlers(state, ?/, 0)
+      {:handled, state} = walk_surface_handlers(state, ?m, 0)
+      {:handled, state} = walk_surface_handlers(state, ?o, 0)
+      {:handled, state} = walk_surface_handlers(state, 27, 0)
+      assert AgentAccess.panel(state).mention_completion == nil
+
+      {:handled, state} = walk_surface_handlers(state, ?/, 0)
+      comp = AgentAccess.panel(state).mention_completion
+
+      assert Minga.Buffer.content(AgentAccess.panel(state).prompt_buffer) == "/mo"
+      assert comp.prefix == "mo"
+      assert comp.slash_candidates == [{"model", "Set the model: /model <name>"}]
+    end
+  end
+
+  describe "agent scope — slash command completion sub-state" do
+    test "re-summons slash completion inside a partially typed command token" do
+      state = base_state(keymap_scope: :agent, agentic_active: true, input_focused: true)
+
+      {:handled, state} = walk_surface_handlers(state, ?/, 0)
+      {:handled, state} = walk_surface_handlers(state, ?m, 0)
+      {:handled, state} = walk_surface_handlers(state, ?o, 0)
+      {:handled, state} = walk_surface_handlers(state, 27, 0)
+      assert AgentAccess.panel(state).mention_completion == nil
+
+      {:handled, state} = walk_surface_handlers(state, ?/, 0)
+      comp = AgentAccess.panel(state).mention_completion
+
+      assert Minga.Buffer.content(AgentAccess.panel(state).prompt_buffer) == "/mo"
+      assert comp.prefix == "mo"
+      assert comp.slash_candidates == [{"model", "Set the model: /model <name>"}]
+    end
   end
 
   describe "editor scope — panel mention completion" do

--- a/test/support/stub_server.ex
+++ b/test/support/stub_server.ex
@@ -87,6 +87,15 @@ defmodule Minga.Test.StubServer do
   end
 
   @impl GenServer
+  def handle_cast({:add_system_message, text, level}, state) do
+    case Map.get(state, :notify) do
+      pid when is_pid(pid) -> send(pid, {:stub_system_message, text, level})
+      _ -> :ok
+    end
+
+    {:noreply, state}
+  end
+
   def handle_cast(_msg, state), do: {:noreply, state}
 
   @impl GenServer


### PR DESCRIPTION
# TL;DR
Agent composer input is now recoverable when slash commands or file mentions fail, and slash completion can be reopened from a partially typed command token. Mention completion also uses the existing async project file cache first, raises the candidate cap, and supports fuzzy/subsequence matching for larger repositories.

Closes #2467

## Context
Issue #2467 covers composer friction in the agent chat: mistyped slash commands erased drafts, slash completion was hard to reopen after typing a prefix, input-normal Escape was not discoverable through the keymap, and @-mention completion was too shallow for larger project file sets.

## Changes
- Preserve unknown slash command drafts, show an actionable error in the status bar, and add an error-level system message to the chat transcript with a close command suggestion when available.
- Derive slash completion state from the current leading command token, then wire both the editor side-panel input path and full agent scope input path so pressing `/` inside `/mo` reopens completion without mutating the draft.
- Bind Escape in agent input-normal keymaps to the same unfocus command as `q`, matching the existing scoped input behavior and making the second Escape path discoverable.
- Prefer `Minga.Project.files/0` for @-mention completion so the existing async project cache is used before falling back to a direct file list.
- Raise @-mention candidates from 10 to 50 and rank exact, prefix, substring, and subsequence matches so abbreviated deep paths can still resolve.
- Extend tests through public input, command, and session surfaces, including unknown slash preservation, slash re-summon in both input routes, unresolved mention preservation, and mention fuzzy ranking.

## Verification
- `mix test test/minga_agent/file_mention_test.exs test/minga_editor/agent/slash_command_test.exs test/minga_editor/commands/agent_commands_test.exs test/minga_editor/input/scoped_test.exs test/minga/keymap/scope/agent_scope_shared_groups_test.exs`: 191 passed
- `mix format --check-formatted`: passed
- `mix compile --warnings-as-errors`: passed
- `git diff --check`: passed
- `mix credo --strict` on touched files: passed after removing the strict Credo findings in `lib/minga_editor/agent/slash_command.ex`
- `mix native.build.support`: passed, built `minga-parser` and `minga-hook-runner`
- `mix test.llm`: passed after native support was built, 9378 tests, 0 failures
- A later exact-state `mix test.llm` rerun hit one unrelated async failure in `test/minga_agent/session_manager_test.exs:315`; rerunning that location passed with `mix test test/minga_agent/session_manager_test.exs:315`

## Acceptance Criteria Addressed
- [x] Mistyped slash command shows an actionable persistent message with a suggestion and leaves typed text recoverable.
- [x] Slash completion can be re-summoned after typing the first command characters.
- [x] Esc has a sensible and discoverable exit path from composer input-normal.
- [x] @-mention completion is more responsive and fuzzy for larger repos, and bad mentions preserve the prompt instead of sending or clearing it.