### PR TITLE
feat(agent): render assistant code blocks across frontends

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -474,13 +474,26 @@ Typed payloads:
   0x07 (styled_assistant): type(1) + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url. Link URLs are limited to http, https, and mailto.
   0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url, auto_approved(1) + optional tool_preview_payload. The summary uses a UTF-8-safe preview budget so the styled payload and appended auto-approval/preview bytes still fit. Link URLs are limited to http, https, and mailto.
   0x09 (approval_tool_call): type(1) + status(1) + name_len(2) + name + summary_len(2) + summary + tool_call_id_len(2) + tool_call_id + preview_kind(1) + preview_line_count(2), per line: line_len(2) + line
+  0x0A (assistant_markdown): type(1) + block_count(2) + blocks...
 ```
+
+Markdown block payloads are BEAM-authored semantic structure. Frontends must render these blocks directly and must not infer code cards from styled-run flags, decorative rails, or all-code lines. Each block starts with `block_id(4) + kind(1) + flags(1)` and then a kind-specific payload:
+
+- `0x01 paragraph`: `line_count(2) + styled_lines`
+- `0x02 heading`: `level(1) + line_count(2) + styled_lines`
+- `0x03 list_item`: `indent(1) + ordered(1) + ordinal(4) + line_count(2) + styled_lines`
+- `0x04 blockquote`: `line_count(2) + styled_lines`
+- `0x05 rule`: no payload
+- `0x06 spacer`: `height(1)`
+- `0x07 code_block`: `language_len(2) + language + label_len(2) + label + target_path_len(2) + target_path + capability_flags(1) + line_count(2) + styled_lines`
+
+For code blocks, block flag `0x01` means complete; absence means streaming or incomplete. Capability flags are `0x01=copy`, `0x02=open`, and `0x04=apply`; frontends should only expose actions they actually implement. `block_id` is stable for a message and block index so streaming updates preserve identity.
 
 `auto_approved`: 0=not auto-approved, 1=session trust, 2=turn trust. The frame length makes appended fields deterministic and lets decoders distinguish current payloads from legacy unframed messages.
 
 `tool_preview_payload` is appended to current `tool_call` and `styled_tool_call` messages after `auto_approved`: `preview_kind(1) + preview_line_count(2) + lines...`, with each line encoded as `line_len(2) + line`. Legacy framed tool messages may omit this payload. Preview kinds match approval previews: 0=args, 1=diff, 2=command, 3=target. Tool-call previews are inline context only; `approval_tool_call` keeps the same preview payload fields as part of its required approval card shape.
 
-Styled run flags: 0x01=bold, 0x02=italic, 0x04=underline, 0x08=link URL present.
+Styled run flags: 0x01=bold, 0x02=italic, 0x04=underline, 0x08=link URL present, 0x10=code run (monospaced, preserve whitespace). The 0x10 bit is a run-level hint only and must not be used to infer fenced block boundaries, code-card containers, or language labels.
 
 ### 0x79 — gui_gutter_separator
 

--- a/go/tui/internal/protocol/chrome_agent.go
+++ b/go/tui/internal/protocol/chrome_agent.go
@@ -188,6 +188,12 @@ func decodeAgentMessage(body []byte) (AgentChatMessage, bool) {
 		msg = decodeToolCallMessage(msg, body, offset, true)
 	case 0x09:
 		msg = decodeApprovalMessage(msg, body, offset)
+	case 0x0A:
+		blocks, next, ok := decodeMarkdownBlocks(body, offset)
+		msg.MarkdownBlocks = blocks
+		msg.Text = plainMarkdownBlocks(blocks)
+		_ = next
+		return msg, ok
 	}
 	return msg, true
 }
@@ -352,6 +358,106 @@ func decodeStyledLines(body []byte, offset int) ([]AgentStyledLine, int, bool) {
 		lines = append(lines, line)
 	}
 	return lines, offset, true
+}
+
+func decodeMarkdownBlocks(body []byte, offset int) ([]AgentMarkdownBlock, int, bool) {
+	if len(body) < offset+2 {
+		return nil, offset, false
+	}
+	count := int(u16(body, offset))
+	offset += 2
+	blocks := make([]AgentMarkdownBlock, 0, count)
+	for i := 0; i < count; i++ {
+		if len(body) < offset+6 {
+			return blocks, offset, false
+		}
+		block := AgentMarkdownBlock{ID: u32(body, offset), Kind: body[offset+4], Flags: body[offset+5], Height: 1}
+		offset += 6
+		switch block.Kind {
+		case 0x01, 0x04:
+			lines, next, ok := decodeStyledLines(body, offset)
+			if !ok {
+				return blocks, offset, false
+			}
+			block.Lines = lines
+			offset = next
+		case 0x02:
+			if len(body) < offset+1 {
+				return blocks, offset, false
+			}
+			block.Level = body[offset]
+			lines, next, ok := decodeStyledLines(body, offset+1)
+			if !ok {
+				return blocks, offset, false
+			}
+			block.Lines = lines
+			offset = next
+		case 0x03:
+			if len(body) < offset+6 {
+				return blocks, offset, false
+			}
+			block.Indent = body[offset]
+			block.Ordered = body[offset+1] != 0
+			block.Ordinal = u32(body, offset+2)
+			lines, next, ok := decodeStyledLines(body, offset+6)
+			if !ok {
+				return blocks, offset, false
+			}
+			block.Lines = lines
+			offset = next
+		case 0x05:
+		case 0x06:
+			if len(body) < offset+1 {
+				return blocks, offset, false
+			}
+			block.Height = body[offset]
+			offset++
+		case 0x07:
+			var ok bool
+			block.Language, offset, ok = readString16(body, offset)
+			if !ok {
+				return blocks, offset, false
+			}
+			block.Label, offset, ok = readString16(body, offset)
+			if !ok {
+				return blocks, offset, false
+			}
+			block.TargetPath, offset, ok = readString16(body, offset)
+			if !ok || len(body) < offset+1 {
+				return blocks, offset, false
+			}
+			block.CapabilityFlags = body[offset]
+			offset++
+			lines, next, ok := decodeStyledLines(body, offset)
+			if !ok {
+				return blocks, offset, false
+			}
+			block.Lines = lines
+			offset = next
+		default:
+			return blocks, offset, false
+		}
+		blocks = append(blocks, block)
+	}
+	return blocks, offset, true
+}
+
+func plainMarkdownBlocks(blocks []AgentMarkdownBlock) string {
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		switch block.Kind {
+		case 0x05:
+			parts = append(parts, "---")
+		case 0x06:
+			parts = append(parts, "")
+		default:
+			text := plainStyledLines(block.Lines)
+			if text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
 }
 
 func plainStyledLines(lines []AgentStyledLine) string {

--- a/go/tui/internal/protocol/chrome_types.go
+++ b/go/tui/internal/protocol/chrome_types.go
@@ -459,6 +459,22 @@ type AgentStyledRun struct {
 	URL   string
 }
 
+func (run AgentStyledRun) Bold() bool {
+	return run.Flags&0x01 != 0
+}
+
+func (run AgentStyledRun) Italic() bool {
+	return run.Flags&0x02 != 0
+}
+
+func (run AgentStyledRun) Underline() bool {
+	return run.Flags&0x04 != 0
+}
+
+func (run AgentStyledRun) Code() bool {
+	return run.Flags&0x10 != 0
+}
+
 type AgentUsage struct {
 	Input      uint32
 	Output     uint32

--- a/go/tui/internal/protocol/chrome_types.go
+++ b/go/tui/internal/protocol/chrome_types.go
@@ -444,9 +444,31 @@ type AgentChatMessage struct {
 	DurationMS        uint32
 	AutoApprovedScope byte
 	StyledLines       []AgentStyledLine
+	MarkdownBlocks    []AgentMarkdownBlock
 	Usage             AgentUsage
 	PreviewKind       byte
 	PreviewLines      []string
+}
+
+// AgentMarkdownBlock is a BEAM-authored semantic markdown block. Renderers must not infer block/card structure from styled-run flags.
+type AgentMarkdownBlock struct {
+	ID              uint32
+	Kind            byte
+	Flags           byte
+	Lines           []AgentStyledLine
+	Level           byte
+	Indent          byte
+	Ordered         bool
+	Ordinal         uint32
+	Height          byte
+	Language        string
+	Label           string
+	TargetPath      string
+	CapabilityFlags byte
+}
+
+func (block AgentMarkdownBlock) Complete() bool {
+	return block.Flags&0x01 != 0
 }
 
 type AgentStyledLine []AgentStyledRun

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -1217,6 +1217,47 @@ func TestDecodeAgentChatStyledRunPreservesCodeFlag(t *testing.T) {
 	}
 }
 
+func TestDecodeAgentChatAssistantMarkdownCodeBlock(t *testing.T) {
+	messageBody := append(u32Bytes(77), 0x0A)
+	messageBody = append(messageBody, 0, 1) // one block
+	messageBody = append(messageBody, u32Bytes(123)...)
+	messageBody = append(messageBody, 0x07, 0x01) // code block, complete
+	messageBody = append(messageBody, string16("elixir")...)
+	messageBody = append(messageBody, string16("Elixir")...)
+	messageBody = append(messageBody, string16("lib/demo.ex")...)
+	messageBody = append(messageBody, 0x01) // copy capability
+	messageBody = append(messageBody, 0, 2) // two lines
+	messageBody = append(messageBody, 0, 1) // line one, one run
+	messageBody = append(messageBody, string16("")...)
+	messageBody = append(messageBody, 0x98, 0xBE, 0x65, 0x21, 0x24, 0x2B, 0x10)
+	messageBody = append(messageBody, 0, 1) // line two, one run
+	messageBody = append(messageBody, string16("IO.puts(:hi)")...)
+	messageBody = append(messageBody, 0x98, 0xBE, 0x65, 0x21, 0x24, 0x2B, 0x10)
+
+	chat := []byte{generated.OPGuiAgentChat, 2}
+	chat = append(chat, section(0x01, []byte{1, 0})...)
+	chat = append(chat, section(0x06, agentMessages(messageBody))...)
+
+	command, err := DecodeCommand(chat)
+	if err != nil {
+		t.Fatalf("DecodeCommand chat returned error: %v", err)
+	}
+	if len(command.Chrome.AgentChat.Messages) != 1 {
+		t.Fatalf("decoded %d messages, want 1", len(command.Chrome.AgentChat.Messages))
+	}
+	msg := command.Chrome.AgentChat.Messages[0]
+	if msg.Kind != 0x0A || len(msg.MarkdownBlocks) != 1 {
+		t.Fatalf("markdown message decoded incorrectly: %+v", msg)
+	}
+	block := msg.MarkdownBlocks[0]
+	if block.Kind != 0x07 || !block.Complete() || block.Language != "elixir" || block.Label != "Elixir" || block.TargetPath != "lib/demo.ex" {
+		t.Fatalf("code block decoded incorrectly: %+v", block)
+	}
+	if len(block.Lines) != 2 || block.Lines[0][0].Text != "" || !block.Lines[1][0].Code() {
+		t.Fatalf("code block lines decoded incorrectly: %+v", block.Lines)
+	}
+}
+
 func TestDecodeAgentChatPreservesStructuredMessageDetails(t *testing.T) {
 	tool := append(u32Bytes(7), 0x04, 1, 0, 0)
 	tool = append(tool, u32Bytes(42)...)

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -1192,6 +1192,31 @@ func TestDecodeAgentTimelineChrome(t *testing.T) {
 	}
 }
 
+func TestDecodeAgentChatStyledRunPreservesCodeFlag(t *testing.T) {
+	messageBody := append(u32Bytes(42), 0x07)
+	messageBody = append(messageBody, 0, 1) // one line
+	messageBody = append(messageBody, 0, 1) // one run
+	messageBody = append(messageBody, string16("  def hello")...)
+	messageBody = append(messageBody, 0x98, 0xBE, 0x65, 0x21, 0x24, 0x2B, 0x10)
+	messages := []byte{0xFF, 1, 0, 1, byte(len(messageBody) >> 24), byte(len(messageBody) >> 16), byte(len(messageBody) >> 8), byte(len(messageBody))}
+	messages = append(messages, messageBody...)
+	chat := []byte{generated.OPGuiAgentChat, 2}
+	chat = append(chat, section(0x01, []byte{1, 0})...)
+	chat = append(chat, section(0x06, messages)...)
+
+	command, err := DecodeCommand(chat)
+	if err != nil {
+		t.Fatalf("DecodeCommand chat returned error: %v", err)
+	}
+	if len(command.Chrome.AgentChat.Messages) != 1 {
+		t.Fatalf("decoded %d messages, want 1", len(command.Chrome.AgentChat.Messages))
+	}
+	run := command.Chrome.AgentChat.Messages[0].StyledLines[0][0]
+	if !run.Code() || run.Flags != 0x10 {
+		t.Fatalf("styled run flags = 0x%02X, want code flag", run.Flags)
+	}
+}
+
 func TestDecodeAgentChatPreservesStructuredMessageDetails(t *testing.T) {
 	tool := append(u32Bytes(7), 0x04, 1, 0, 0)
 	tool = append(tool, u32Bytes(42)...)

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -25,6 +25,7 @@ const (
 	agentThinkingCollapsedLines = 1
 	agentThinkingExpandedLines  = 5
 	agentToolExpandedLines      = 10
+	agentAssistantStyledLines   = 12
 )
 
 func (m Model) renderAgentChatPanel(chat protocol.AgentChat) []string {
@@ -512,12 +513,18 @@ func (m Model) renderAgentUserMessage(msg protocol.AgentChatMessage, width int) 
 
 func (m Model) renderAgentAssistantMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(m.editorBackground()).Render("  ◇ Minga")
+	out := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
+
+	if len(msg.StyledLines) > 0 {
+		out = append(out, m.renderAgentAssistantStyledLines(msg.StyledLines, width)...)
+		return out
+	}
+
 	lines := compactTextLines(msg.Text, max(width-12, 8), 3)
 	if len(lines) == 0 {
 		lines = []string{""}
 	}
-	header := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(m.editorBackground()).Render("  ◇ Minga")
-	out := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
 	rail := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render("  │ ")
 	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
 	for _, bodyLine := range lines {
@@ -525,6 +532,91 @@ func (m Model) renderAgentAssistantMessage(msg protocol.AgentChatMessage, width 
 		out = append(out, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
 	}
 	return out
+}
+
+func (m Model) renderAgentAssistantStyledLines(lines []protocol.AgentStyledLine, width int) []string {
+	if len(lines) == 0 {
+		return nil
+	}
+	p := m.palette()
+	surface := m.editorBackground()
+	rail := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render("  │ ")
+	bodyWidth := max(width-lipgloss.Width(rail), 8)
+	visible := min(len(lines), agentAssistantStyledLines)
+	out := make([]string, 0, visible+1)
+	for _, line := range lines[:visible] {
+		rendered := rail + m.renderAgentStyledLine(line, bodyWidth)
+		out = append(out, lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(rendered, width)))
+	}
+	if hidden := len(lines) - visible; hidden > 0 {
+		more := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render(fmt.Sprintf("… +%d lines · ⏎ expand", hidden))
+		out = append(out, lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(rail+more, width)))
+	}
+	return out
+}
+
+func (m Model) renderAgentStyledLine(line protocol.AgentStyledLine, width int) string {
+	if len(line) == 0 {
+		return strings.Repeat(" ", width)
+	}
+	isCode := agentStyledLineIsCode(line)
+	remaining := width
+	var rendered strings.Builder
+	for index, run := range line {
+		text := run.Text
+		if isCode && index == len(line)-1 && displayWidth(text) > remaining {
+			text = truncateCodeText(text, remaining)
+		}
+		part := agentStyledRunStyle(run, m.editorBackground()).Render(text)
+		rendered.WriteString(part)
+		remaining -= lipgloss.Width(part)
+		if remaining <= 0 {
+			break
+		}
+	}
+	return fitStyled(rendered.String(), width)
+}
+
+func agentStyledRunStyle(run protocol.AgentStyledRun, background color.Color) lipgloss.Style {
+	style := lipgloss.NewStyle().Background(background).ColorWhitespace(true)
+	if run.FG != 0 {
+		style = style.Foreground(lipgloss.Color(fmt.Sprintf("#%06X", run.FG&0xFFFFFF)))
+	}
+	if run.BG != 0 {
+		style = style.Background(lipgloss.Color(fmt.Sprintf("#%06X", run.BG&0xFFFFFF)))
+	}
+	if run.Bold() {
+		style = style.Bold(true)
+	}
+	if run.Italic() {
+		style = style.Italic(true)
+	}
+	if run.Underline() || run.URL != "" {
+		style = style.Underline(true)
+	}
+	return style
+}
+
+func agentStyledLineIsCode(line protocol.AgentStyledLine) bool {
+	for _, run := range line {
+		if run.Code() {
+			return true
+		}
+	}
+	return false
+}
+
+func truncateCodeText(text string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if displayWidth(text) <= width {
+		return text
+	}
+	if width == 1 {
+		return "›"
+	}
+	return fit(text, width-1) + "›"
 }
 
 func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width int) []string {

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -10,15 +10,16 @@ import (
 )
 
 const (
-	agentKindUser         byte = 0x01
-	agentKindAssistant    byte = 0x02
-	agentKindThinking     byte = 0x03
-	agentKindTool         byte = 0x04
-	agentKindSystem       byte = 0x05
-	agentKindUsage        byte = 0x06
-	agentKindStyled       byte = 0x07
-	agentKindStyledTool   byte = 0x08
-	agentKindApprovalTool byte = 0x09
+	agentKindUser              byte = 0x01
+	agentKindAssistant         byte = 0x02
+	agentKindThinking          byte = 0x03
+	agentKindTool              byte = 0x04
+	agentKindSystem            byte = 0x05
+	agentKindUsage             byte = 0x06
+	agentKindStyled            byte = 0x07
+	agentKindStyledTool        byte = 0x08
+	agentKindApprovalTool      byte = 0x09
+	agentKindAssistantMarkdown byte = 0x0A
 )
 
 const (
@@ -459,7 +460,7 @@ func (m Model) renderAgentMessage(msg protocol.AgentChatMessage, width int) []st
 	switch msg.Kind {
 	case agentKindUser:
 		return m.renderAgentUserMessage(msg, width)
-	case agentKindAssistant, agentKindStyled:
+	case agentKindAssistant, agentKindStyled, agentKindAssistantMarkdown:
 		return m.renderAgentAssistantMessage(msg, width)
 	case agentKindThinking:
 		return m.renderAgentThinkingMessage(msg, width)
@@ -516,6 +517,11 @@ func (m Model) renderAgentAssistantMessage(msg protocol.AgentChatMessage, width 
 	header := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(m.editorBackground()).Render("  ◇ Minga")
 	out := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
 
+	if len(msg.MarkdownBlocks) > 0 {
+		out = append(out, m.renderAgentAssistantMarkdownBlocks(msg.MarkdownBlocks, width)...)
+		return out
+	}
+
 	if len(msg.StyledLines) > 0 {
 		out = append(out, m.renderAgentAssistantStyledLines(msg.StyledLines, width)...)
 		return out
@@ -532,6 +538,66 @@ func (m Model) renderAgentAssistantMessage(msg protocol.AgentChatMessage, width 
 		out = append(out, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
 	}
 	return out
+}
+
+func (m Model) renderAgentAssistantMarkdownBlocks(blocks []protocol.AgentMarkdownBlock, width int) []string {
+	if len(blocks) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(blocks)*2)
+	for _, block := range blocks {
+		out = append(out, m.renderAgentMarkdownBlock(block, width)...)
+	}
+	return out
+}
+
+func (m Model) renderAgentMarkdownBlock(block protocol.AgentMarkdownBlock, width int) []string {
+	switch block.Kind {
+	case 0x01, 0x02, 0x03, 0x04:
+		return m.renderAgentAssistantStyledLines(block.Lines, width)
+	case 0x05:
+		p := m.palette()
+		surface := m.editorBackground()
+		rule := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render("  ─" + strings.Repeat("─", max(width-4, 1)))
+		return []string{lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(rule, width))}
+	case 0x06:
+		return []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render("")}
+	case 0x07:
+		return m.renderAgentCodeCard(block, width)
+	default:
+		return nil
+	}
+}
+
+func (m Model) renderAgentCodeCard(block protocol.AgentMarkdownBlock, width int) []string {
+	p := m.palette()
+	surface := m.editorBackground()
+	rail := lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render("  │ ")
+	bodyWidth := max(width-lipgloss.Width(rail)-2, 8)
+	label := nonEmpty(block.Label, "Code")
+	if block.TargetPath != "" {
+		label += " · " + block.TargetPath
+	}
+	if !block.Complete() {
+		label += " · streaming"
+	}
+	header := rail + lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Bold(true).Render("╭─ "+label)
+	out := []string{lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(header, width))}
+	for _, line := range block.Lines {
+		body := m.renderAgentCodeCardLine(line, bodyWidth)
+		out = append(out, lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(rail+"│ "+body, width)))
+	}
+	footer := rail + lipgloss.NewStyle().Foreground(p.Muted()).Background(surface).Render("╰"+strings.Repeat("─", max(min(bodyWidth, width-6), 1)))
+	out = append(out, lipgloss.NewStyle().Background(surface).Width(width).Render(fitStyled(footer, width)))
+	return out
+}
+
+func (m Model) renderAgentCodeCardLine(line protocol.AgentStyledLine, width int) string {
+	if len(line) == 0 {
+		return strings.Repeat(" ", width)
+	}
+	rendered := m.renderAgentStyledLine(line, width)
+	return fitStyled(rendered, width)
 }
 
 func (m Model) renderAgentAssistantStyledLines(lines []protocol.AgentStyledLine, width int) []string {
@@ -559,20 +625,34 @@ func (m Model) renderAgentStyledLine(line protocol.AgentStyledLine, width int) s
 	if len(line) == 0 {
 		return strings.Repeat(" ", width)
 	}
-	isCode := agentStyledLineIsCode(line)
+	isCode := agentStyledLineIsAllCode(line)
 	remaining := width
+	truncated := false
 	var rendered strings.Builder
 	for index, run := range line {
+		if remaining <= 0 {
+			truncated = true
+			break
+		}
 		text := run.Text
-		if isCode && index == len(line)-1 && displayWidth(text) > remaining {
-			text = truncateCodeText(text, remaining)
+		if displayWidth(text) > remaining {
+			truncated = true
+			text = fit(text, remaining)
 		}
 		part := agentStyledRunStyle(run, m.editorBackground()).Render(text)
 		rendered.WriteString(part)
 		remaining -= lipgloss.Width(part)
-		if remaining <= 0 {
+		if remaining <= 0 && index < len(line)-1 {
+			truncated = true
 			break
 		}
+	}
+	if isCode && truncated {
+		marker := lipgloss.NewStyle().Foreground(m.palette().Muted()).Background(m.editorBackground()).Render("›")
+		if width <= 1 {
+			return marker
+		}
+		return fitStyled(rendered.String(), width-1) + marker
 	}
 	return fitStyled(rendered.String(), width)
 }
@@ -597,26 +677,18 @@ func agentStyledRunStyle(run protocol.AgentStyledRun, background color.Color) li
 	return style
 }
 
-func agentStyledLineIsCode(line protocol.AgentStyledLine) bool {
+func agentStyledLineIsAllCode(line protocol.AgentStyledLine) bool {
+	hasCodeRun := false
 	for _, run := range line {
-		if run.Code() {
-			return true
+		if run.Text == "" {
+			continue
+		}
+		hasCodeRun = true
+		if !run.Code() {
+			return false
 		}
 	}
-	return false
-}
-
-func truncateCodeText(text string, width int) string {
-	if width <= 0 {
-		return ""
-	}
-	if displayWidth(text) <= width {
-		return text
-	}
-	if width == 1 {
-		return "›"
-	}
-	return fit(text, width-1) + "›"
+	return hasCodeRun
 }
 
 func (m Model) renderAgentThinkingMessage(msg protocol.AgentChatMessage, width int) []string {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -988,6 +988,51 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 	}
 }
 
+func TestAgentChatAssistantMarkdownCodeCardPreservesBlankLinesAndTruncates(t *testing.T) {
+	model := New(40, 16, nil)
+	msg := markdownCodeCardMessage()
+
+	view := ansi.Strip(strings.Join(model.renderAgentAssistantMessage(msg, 40), "\n"))
+	if !strings.Contains(view, "Elixir") {
+		t.Fatalf("markdown code card should render label: %q", view)
+	}
+	if !strings.Contains(view, "›") {
+		t.Fatalf("markdown code card should mark truncated code lines: %q", view)
+	}
+	if !strings.Contains(view, "│ │ ") {
+		t.Fatalf("markdown code card should preserve blank code rows: %q", view)
+	}
+}
+
+func TestAgentChatRenderMessageRoutesAssistantMarkdownCodeCards(t *testing.T) {
+	model := New(40, 16, nil)
+	msg := markdownCodeCardMessage()
+
+	view := ansi.Strip(strings.Join(model.renderAgentMessage(msg, 40), "\n"))
+	if !strings.Contains(view, "Elixir") || !strings.Contains(view, "╭─") {
+		t.Fatalf("renderAgentMessage should route assistant_markdown to code-card renderer: %q", view)
+	}
+}
+
+func markdownCodeCardMessage() protocol.AgentChatMessage {
+	return protocol.AgentChatMessage{
+		Kind: agentKindAssistantMarkdown,
+		MarkdownBlocks: []protocol.AgentMarkdownBlock{
+			{
+				ID:       1,
+				Kind:     0x07,
+				Flags:    0x01,
+				Language: "elixir",
+				Label:    "Elixir",
+				Lines: []protocol.AgentStyledLine{
+					{{Text: "", FG: 0x98BE65, BG: 0x21242B, Flags: 0x10}},
+					{{Text: "  " + strings.Repeat("x", 80), FG: 0x98BE65, BG: 0x21242B, Flags: 0x10}},
+				},
+			},
+		},
+	}
+}
+
 func TestAgentChatAssistantStyledLinesPreserveCodeIndentationAndOverflow(t *testing.T) {
 	model := New(80, 24, nil)
 	styledLines := []protocol.AgentStyledLine{
@@ -1021,6 +1066,36 @@ func TestAgentChatAssistantStyledCodeLineShowsLongLineIndicator(t *testing.T) {
 	view := ansi.Strip(strings.Join(model.renderAgentAssistantMessage(msg, 36), "\n"))
 	if !strings.Contains(view, "›") {
 		t.Fatalf("long styled code line should show truncation indicator: %q", view)
+	}
+}
+
+func TestAgentChatAssistantStyledCodeLineShowsIndicatorAcrossSplitRuns(t *testing.T) {
+	model := New(36, 16, nil)
+	msg := protocol.AgentChatMessage{
+		Kind: agentKindStyled,
+		StyledLines: []protocol.AgentStyledLine{
+			{{Text: "  " + strings.Repeat("x", 30), FG: 0x98BE65, BG: 0x21242B, Flags: 0x10}, {Text: "yy", FG: 0x98BE65, BG: 0x21242B, Flags: 0x10}},
+		},
+	}
+
+	view := ansi.Strip(strings.Join(model.renderAgentAssistantMessage(msg, 36), "\n"))
+	if !strings.Contains(view, "›") {
+		t.Fatalf("split-run styled code line should show truncation indicator: %q", view)
+	}
+}
+
+func TestAgentChatAssistantMixedProseAndInlineCodeOmitsCodeIndicator(t *testing.T) {
+	model := New(36, 16, nil)
+	msg := protocol.AgentChatMessage{
+		Kind: agentKindStyled,
+		StyledLines: []protocol.AgentStyledLine{
+			{{Text: "This line mentions ", FG: 0xBBC2CF}, {Text: "code()", FG: 0x98BE65, BG: 0x21242B, Flags: 0x10}, {Text: " and then keeps going with prose that should truncate", FG: 0xBBC2CF}},
+		},
+	}
+
+	view := ansi.Strip(strings.Join(model.renderAgentAssistantMessage(msg, 36), "\n"))
+	if strings.Contains(view, "›") {
+		t.Fatalf("mixed prose and inline code should not show code truncation indicator: %q", view)
 	}
 }
 

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -988,6 +988,42 @@ func TestAgentChatPanelRendersStructuredTranscript(t *testing.T) {
 	}
 }
 
+func TestAgentChatAssistantStyledLinesPreserveCodeIndentationAndOverflow(t *testing.T) {
+	model := New(80, 24, nil)
+	styledLines := []protocol.AgentStyledLine{
+		{{Text: "Here is code", FG: 0xBBC2CF}},
+		{{Text: "  def hello do", FG: 0x98BE65, BG: 0x21242B, Flags: 0x10}},
+		{{Text: "    :world", FG: 0x98BE65, BG: 0x21242B, Flags: 0x10}},
+	}
+	for i := 0; i < 12; i++ {
+		styledLines = append(styledLines, protocol.AgentStyledLine{{Text: fmt.Sprintf("line %02d", i), FG: 0xBBC2CF}})
+	}
+	msg := protocol.AgentChatMessage{Kind: agentKindStyled, StyledLines: styledLines}
+
+	view := ansi.Strip(strings.Join(model.renderAgentAssistantMessage(msg, 80), "\n"))
+	if !strings.Contains(view, "│   def hello do") || !strings.Contains(view, "│     :world") {
+		t.Fatalf("styled assistant should preserve code indentation: %q", view)
+	}
+	if !strings.Contains(view, "… +3 lines · ⏎ expand") {
+		t.Fatalf("styled assistant should show overflow affordance: %q", view)
+	}
+}
+
+func TestAgentChatAssistantStyledCodeLineShowsLongLineIndicator(t *testing.T) {
+	model := New(36, 16, nil)
+	msg := protocol.AgentChatMessage{
+		Kind: agentKindStyled,
+		StyledLines: []protocol.AgentStyledLine{
+			{{Text: "  " + strings.Repeat("x", 80), FG: 0x98BE65, BG: 0x21242B, Flags: 0x10}},
+		},
+	}
+
+	view := ansi.Strip(strings.Join(model.renderAgentAssistantMessage(msg, 36), "\n"))
+	if !strings.Contains(view, "›") {
+		t.Fatalf("long styled code line should show truncation indicator: %q", view)
+	}
+}
+
 func TestAgentChatThinkingRendersMultipleLinesWhenExpanded(t *testing.T) {
 	model := New(80, 24, nil)
 	msg := protocol.AgentChatMessage{

--- a/lib/minga/frontend/adapter/gui/agent_chat_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/agent_chat_encoder.ex
@@ -17,6 +17,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.AgentChat
   alias Minga.RenderModel.UI.AgentChat.ApprovalView
+  alias Minga.RenderModel.UI.AgentChat.MarkdownBlock
   alias Minga.RenderModel.UI.AgentChat.PromptCompletion
   alias Minga.RenderModel.UI.AgentChat.ToolCallView
   alias Minga.RenderModel.UI.AgentChat.Usage
@@ -317,16 +318,30 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
     {:styled_tool_call, tc, strip_styled_lines_links(styled_lines)}
   end
 
+  defp strip_chat_message_links({:assistant_markdown, blocks}) do
+    {:assistant_markdown, strip_markdown_block_links(blocks)}
+  end
+
   defp strip_chat_message_links(msg), do: msg
 
   @spec strip_styled_lines_links([AgentChat.styled_line()]) :: [AgentChat.styled_line()]
   defp strip_styled_lines_links(styled_lines) do
-    Enum.map(styled_lines, fn runs -> Enum.map(runs, &strip_styled_run_link/1) end)
+    Enum.map(styled_lines, &strip_styled_line_links/1)
   end
+
+  @spec strip_styled_line_links(AgentChat.styled_line()) :: AgentChat.styled_line()
+  defp strip_styled_line_links(runs), do: Enum.map(runs, &strip_styled_run_link/1)
 
   @spec strip_styled_run_link(AgentChat.styled_run()) :: AgentChat.styled_run()
   defp strip_styled_run_link({text, fg, bg, flags, _url}), do: {text, fg, bg, flags &&& 0xF3}
   defp strip_styled_run_link(run), do: run
+
+  @spec strip_markdown_block_links([MarkdownBlock.t()]) :: [MarkdownBlock.t()]
+  defp strip_markdown_block_links(blocks) do
+    Enum.map(blocks, fn %MarkdownBlock{} = block ->
+      MarkdownBlock.map_lines(block, &strip_styled_line_links/1)
+    end)
+  end
 
   # Unwrap {id, message} tuple: prefix with the stable uint32 ID, then encode the message.
   @spec encode_chat_message(AgentChat.message()) :: binary()
@@ -366,6 +381,16 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
       end)
 
     IO.iodata_to_binary([<<0x07::8, length(styled_lines)::16>> | line_binaries])
+  end
+
+  # Assistant markdown message: opcode 0x0A, block_count::16, then semantic blocks.
+  defp encode_chat_message_body({:assistant_markdown, blocks}) do
+    bounded_blocks = bound_markdown_blocks(blocks)
+
+    IO.iodata_to_binary([
+      <<0x0A::8, length(bounded_blocks)::16>>,
+      Enum.map(bounded_blocks, &encode_markdown_block/1)
+    ])
   end
 
   defp encode_chat_message_body({:thinking, text, collapsed}) do
@@ -483,6 +508,77 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
   defp auto_approved_scope_byte(:session), do: 1
   defp auto_approved_scope_byte(:turn), do: 2
   defp auto_approved_scope_byte(nil), do: 0
+
+  @spec bound_markdown_blocks([MarkdownBlock.t()]) :: [MarkdownBlock.t()]
+  defp bound_markdown_blocks(blocks) do
+    Enum.map(blocks, fn %MarkdownBlock{} = block ->
+      MarkdownBlock.map_lines(block, &bound_styled_line/1, 500)
+    end)
+  end
+
+  @spec bound_styled_line(AgentChat.styled_line()) :: AgentChat.styled_line()
+  defp bound_styled_line(runs), do: Enum.map(runs, &bound_styled_run/1)
+
+  @spec bound_styled_run(AgentChat.styled_run()) :: AgentChat.styled_run()
+  defp bound_styled_run({text, fg, bg, flags, url}),
+    do: {utf8_prefix_bytes(text, 2_000), fg, bg, flags, url}
+
+  defp bound_styled_run({text, fg, bg, flags}),
+    do: {utf8_prefix_bytes(text, 2_000), fg, bg, flags}
+
+  @spec encode_markdown_block(MarkdownBlock.t()) :: binary()
+  defp encode_markdown_block(%MarkdownBlock{kind: :paragraph} = block),
+    do: encode_block_header(block, 0x01) <> encode_styled_lines(block.lines)
+
+  defp encode_markdown_block(%MarkdownBlock{kind: :heading} = block),
+    do:
+      encode_block_header(block, 0x02) <>
+        <<min(block.level, 255)::8>> <> encode_styled_lines(block.lines)
+
+  defp encode_markdown_block(%MarkdownBlock{kind: :list_item} = block) do
+    ordered = if block.ordered, do: 1, else: 0
+
+    encode_block_header(block, 0x03) <>
+      <<min(block.indent, 255)::8, ordered::8, block.ordinal::32>> <>
+      encode_styled_lines(block.lines)
+  end
+
+  defp encode_markdown_block(%MarkdownBlock{kind: :blockquote} = block),
+    do: encode_block_header(block, 0x04) <> encode_styled_lines(block.lines)
+
+  defp encode_markdown_block(%MarkdownBlock{kind: :rule} = block),
+    do: encode_block_header(block, 0x05)
+
+  defp encode_markdown_block(%MarkdownBlock{kind: :spacer} = block),
+    do: encode_block_header(block, 0x06) <> <<min(block.height, 255)::8>>
+
+  defp encode_markdown_block(%MarkdownBlock{kind: :code_block} = block) do
+    language = utf8_prefix_bytes(block.language || "", @max_u16)
+    label = utf8_prefix_bytes(block.label || "", @max_u16)
+    target_path = utf8_prefix_bytes(block.target_path || "", @max_u16)
+
+    IO.iodata_to_binary([
+      encode_block_header(block, 0x07),
+      <<byte_size(language)::16, language::binary, byte_size(label)::16, label::binary,
+        byte_size(target_path)::16, target_path::binary, block.capability_flags::8>>,
+      encode_styled_lines(block.lines)
+    ])
+  end
+
+  @spec encode_block_header(MarkdownBlock.t(), non_neg_integer()) :: binary()
+  defp encode_block_header(%MarkdownBlock{} = block, kind),
+    do: <<block.id::32, kind::8, block.flags::8>>
+
+  @spec encode_styled_lines([AgentChat.styled_line()]) :: binary()
+  defp encode_styled_lines(styled_lines) do
+    line_binaries =
+      Enum.map(styled_lines, fn runs ->
+        run_binaries = Enum.map(runs, &encode_styled_run/1)
+        [<<length(runs)::16>> | run_binaries]
+      end)
+
+    IO.iodata_to_binary([<<length(styled_lines)::16>> | line_binaries])
+  end
 
   @spec encode_styled_run(AgentChat.styled_run()) :: binary()
   defp encode_styled_run({text, fg, bg, flags, url}) do

--- a/lib/minga/render_model/ui/agent_chat.ex
+++ b/lib/minga/render_model/ui/agent_chat.ex
@@ -25,6 +25,7 @@ defmodule Minga.RenderModel.UI.AgentChat do
     * `{:user, text}` / `{:user, text, attachments}`
     * `{:assistant, text}`
     * `{:styled_assistant, styled_lines}`
+    * `{:assistant_markdown, markdown_blocks}`
     * `{:thinking, text, collapsed?}`
     * `{:tool_call, %AgentChat.ToolCallView{}}`
     * `{:styled_tool_call, %AgentChat.ToolCallView{}, styled_lines}`
@@ -37,6 +38,7 @@ defmodule Minga.RenderModel.UI.AgentChat do
   """
 
   alias __MODULE__.ApprovalView
+  alias __MODULE__.MarkdownBlock
   alias __MODULE__.PromptCompletion
   alias __MODULE__.ToolCallView
   alias __MODULE__.Usage
@@ -55,6 +57,7 @@ defmodule Minga.RenderModel.UI.AgentChat do
           | {:user, String.t(), term()}
           | {:assistant, String.t()}
           | {:styled_assistant, [styled_line()]}
+          | {:assistant_markdown, [MarkdownBlock.t()]}
           | {:thinking, String.t(), boolean()}
           | {:tool_call, ToolCallView.t()}
           | {:styled_tool_call, ToolCallView.t(), [styled_line()]}

--- a/lib/minga/render_model/ui/agent_chat/markdown_block.ex
+++ b/lib/minga/render_model/ui/agent_chat/markdown_block.ex
@@ -1,0 +1,114 @@
+defmodule Minga.RenderModel.UI.AgentChat.MarkdownBlock do
+  @moduledoc """
+  Semantic markdown block for agent chat messages.
+
+  The BEAM owns markdown structure. Frontends render these blocks directly and must not infer code cards from styled-run flags or decorative text.
+  """
+
+  import Bitwise
+
+  @typedoc "Markdown block kind encoded on the gui_agent_chat wire."
+  @type kind :: :paragraph | :heading | :list_item | :blockquote | :rule | :spacer | :code_block
+
+  @typedoc "A styled text run: {text, fg_rgb, bg_rgb, flags} or with a trailing url."
+  @type styled_run ::
+          {String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
+          | {String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer(), String.t()}
+
+  @typedoc "A line of styled runs."
+  @type styled_line :: [styled_run()]
+
+  @type t :: %__MODULE__{
+          id: non_neg_integer(),
+          kind: kind(),
+          flags: non_neg_integer(),
+          lines: [styled_line()],
+          level: non_neg_integer(),
+          indent: non_neg_integer(),
+          ordered: boolean(),
+          ordinal: non_neg_integer(),
+          height: non_neg_integer(),
+          language: String.t(),
+          label: String.t(),
+          target_path: String.t(),
+          capability_flags: non_neg_integer()
+        }
+
+  @enforce_keys [:id, :kind]
+  defstruct id: 0,
+            kind: :paragraph,
+            flags: 0,
+            lines: [],
+            level: 0,
+            indent: 0,
+            ordered: false,
+            ordinal: 0,
+            height: 1,
+            language: "",
+            label: "",
+            target_path: "",
+            capability_flags: 0
+
+  @complete_flag 0x01
+  @copy_capability 0x01
+
+  @spec paragraph(non_neg_integer(), [styled_line()]) :: t()
+  def paragraph(id, lines), do: %__MODULE__{id: id, kind: :paragraph, lines: lines}
+
+  @spec heading(non_neg_integer(), non_neg_integer(), [styled_line()]) :: t()
+  def heading(id, level, lines),
+    do: %__MODULE__{id: id, kind: :heading, level: level, lines: lines}
+
+  @spec list_item(non_neg_integer(), non_neg_integer(), boolean(), non_neg_integer(), [
+          styled_line()
+        ]) :: t()
+  def list_item(id, indent, ordered?, ordinal, lines) do
+    %__MODULE__{
+      id: id,
+      kind: :list_item,
+      indent: indent,
+      ordered: ordered?,
+      ordinal: ordinal,
+      lines: lines
+    }
+  end
+
+  @spec blockquote(non_neg_integer(), [styled_line()]) :: t()
+  def blockquote(id, lines), do: %__MODULE__{id: id, kind: :blockquote, lines: lines}
+
+  @spec rule(non_neg_integer()) :: t()
+  def rule(id), do: %__MODULE__{id: id, kind: :rule}
+
+  @spec spacer(non_neg_integer(), non_neg_integer()) :: t()
+  def spacer(id, height), do: %__MODULE__{id: id, kind: :spacer, height: height}
+
+  @spec code_block(non_neg_integer(), String.t(), String.t(), String.t() | nil, boolean(), [
+          styled_line()
+        ]) :: t()
+  def code_block(id, language, label, target_path, complete?, lines) do
+    %__MODULE__{
+      id: id,
+      kind: :code_block,
+      flags: if(complete?, do: @complete_flag, else: 0),
+      lines: lines,
+      language: language || "",
+      label: label || "Code",
+      target_path: target_path || "",
+      capability_flags: @copy_capability
+    }
+  end
+
+  @spec map_lines(t(), (styled_line() -> styled_line())) :: t()
+  def map_lines(%__MODULE__{lines: lines} = block, mapper) when is_function(mapper, 1) do
+    %{block | lines: Enum.map(lines, mapper)}
+  end
+
+  @spec map_lines(t(), (styled_line() -> styled_line()), pos_integer()) :: t()
+  def map_lines(%__MODULE__{lines: lines} = block, mapper, max_lines)
+      when is_function(mapper, 1) and is_integer(max_lines) and max_lines > 0 do
+    %{block | lines: lines |> Enum.take(max_lines) |> Enum.map(mapper)}
+  end
+
+  @spec complete?(t()) :: boolean()
+  def complete?(%__MODULE__{flags: flags}), do: (flags &&& @complete_flag) != 0
+end

--- a/lib/minga_agent/markdown.ex
+++ b/lib/minga_agent/markdown.ex
@@ -63,6 +63,265 @@ defmodule MingaAgent.Markdown do
   @typedoc "Extracted code block with language and content."
   @type code_block :: %{language: String.t(), content: String.t()}
 
+  @typedoc "Semantic markdown block used by agent chat renderers before styling."
+  @type block ::
+          %{
+            kind: :paragraph,
+            lines: [String.t()]
+          }
+          | %{
+              kind: :heading,
+              level: 1..3,
+              text: String.t()
+            }
+          | %{
+              kind: :list_item,
+              indent: non_neg_integer(),
+              ordered: boolean(),
+              ordinal: non_neg_integer(),
+              text: String.t()
+            }
+          | %{
+              kind: :blockquote,
+              lines: [String.t()]
+            }
+          | %{kind: :rule}
+          | %{kind: :spacer, height: pos_integer()}
+          | %{
+              kind: :code_block,
+              language: String.t(),
+              lines: [String.t()],
+              complete?: boolean(),
+              target_path: String.t() | nil
+            }
+
+  @doc """
+  Parses markdown into semantic blocks without decorative rendering glyphs.
+
+  This parser intentionally keeps the same small markdown surface as `parse/1`,
+  but returns structure that frontends can render directly. Fenced code blocks
+  preserve blank lines and indentation, and an unclosed fence is returned as an
+  incomplete code block for streaming output.
+  """
+  @spec parse_blocks(String.t()) :: [block()]
+  def parse_blocks(text) when is_binary(text) do
+    text
+    |> String.split("\n")
+    |> parse_block_lines([], [], nil, 0)
+    |> finish_paragraph()
+    |> Enum.reverse()
+  end
+
+  @spec parse_block_lines([String.t()], [block()], [String.t()], map() | nil, non_neg_integer()) ::
+          [block()]
+  defp parse_block_lines([], acc, paragraph, nil, _code_index) do
+    finish_paragraph(acc, paragraph)
+  end
+
+  defp parse_block_lines(
+         [],
+         acc,
+         paragraph,
+         %{language: language, lines: lines, target_path: target_path},
+         _code_index
+       ) do
+    acc
+    |> finish_paragraph(paragraph)
+    |> prepend_code_block(language, lines, false, target_path)
+  end
+
+  defp parse_block_lines(
+         [line | rest],
+         acc,
+         paragraph,
+         %{language: language, lines: lines, target_path: target_path} = code,
+         code_index
+       ) do
+    if fence_line?(line) do
+      acc
+      |> finish_paragraph(paragraph)
+      |> prepend_code_block(language, lines, true, target_path)
+      |> then(&parse_block_lines(rest, &1, [], nil, code_index + 1))
+    else
+      parse_block_lines(rest, acc, paragraph, %{code | lines: [line | lines]}, code_index)
+    end
+  end
+
+  defp parse_block_lines([line | rest], acc, paragraph, nil, code_index) do
+    trimmed = String.trim(line)
+
+    case block_line_kind(line, trimmed) do
+      {:code_fence, language} ->
+        acc
+        |> finish_paragraph(paragraph)
+        |> then(
+          &parse_block_lines(
+            rest,
+            &1,
+            [],
+            %{language: language, lines: [], target_path: nil},
+            code_index
+          )
+        )
+
+      :spacer ->
+        acc
+        |> finish_paragraph(paragraph)
+        |> prepend_spacer()
+        |> then(&parse_block_lines(rest, &1, [], nil, code_index))
+
+      :rule ->
+        acc
+        |> finish_paragraph(paragraph)
+        |> then(&parse_block_lines(rest, [%{kind: :rule} | &1], [], nil, code_index))
+
+      {:heading, level, text} ->
+        acc
+        |> finish_paragraph(paragraph)
+        |> then(
+          &parse_block_lines(
+            rest,
+            [%{kind: :heading, level: level, text: text} | &1],
+            [],
+            nil,
+            code_index
+          )
+        )
+
+      {:blockquote, text} ->
+        acc
+        |> finish_paragraph(paragraph)
+        |> then(
+          &parse_block_lines(
+            rest,
+            [%{kind: :blockquote, lines: [text]} | &1],
+            [],
+            nil,
+            code_index
+          )
+        )
+
+      {:list_item, indent, ordered?, ordinal, text} ->
+        acc
+        |> finish_paragraph(paragraph)
+        |> then(
+          &parse_block_lines(
+            rest,
+            [
+              %{kind: :list_item, indent: indent, ordered: ordered?, ordinal: ordinal, text: text}
+              | &1
+            ],
+            [],
+            nil,
+            code_index
+          )
+        )
+
+      :paragraph ->
+        parse_block_lines(rest, acc, [line | paragraph], nil, code_index)
+    end
+  end
+
+  @spec finish_paragraph([block()], [String.t()]) :: [block()]
+  defp finish_paragraph(acc, []), do: acc
+
+  defp finish_paragraph(acc, paragraph),
+    do: [%{kind: :paragraph, lines: Enum.reverse(paragraph)} | acc]
+
+  @spec finish_paragraph([block()]) :: [block()]
+  defp finish_paragraph(acc), do: acc
+
+  @spec prepend_code_block([block()], String.t(), [String.t()], boolean(), String.t() | nil) :: [
+          block()
+        ]
+  defp prepend_code_block(acc, language, lines, complete?, target_path) do
+    [
+      %{
+        kind: :code_block,
+        language: language,
+        lines: Enum.reverse(lines),
+        complete?: complete?,
+        target_path: target_path
+      }
+      | acc
+    ]
+  end
+
+  @spec prepend_spacer([block()]) :: [block()]
+  defp prepend_spacer([%{kind: :spacer, height: height} = spacer | rest]),
+    do: [%{spacer | height: min(height + 1, 255)} | rest]
+
+  defp prepend_spacer(acc), do: [%{kind: :spacer, height: 1} | acc]
+
+  @spec block_line_kind(String.t(), String.t()) ::
+          :paragraph
+          | :rule
+          | :spacer
+          | {:code_fence, String.t()}
+          | {:heading, 1..3, String.t()}
+          | {:blockquote, String.t()}
+          | {:list_item, non_neg_integer(), boolean(), non_neg_integer(), String.t()}
+  defp block_line_kind(_line, ""), do: :spacer
+
+  defp block_line_kind(line, _trimmed) when is_binary(line) do
+    classify_block_line(fence_line?(line), line, String.trim(line))
+  end
+
+  @spec classify_block_line(boolean(), String.t(), String.t()) ::
+          :paragraph
+          | :rule
+          | {:code_fence, String.t()}
+          | {:heading, 1..3, String.t()}
+          | {:blockquote, String.t()}
+          | {:list_item, non_neg_integer(), boolean(), non_neg_integer(), String.t()}
+  defp classify_block_line(true, line, _trimmed), do: {:code_fence, fence_language(line)}
+  defp classify_block_line(false, _line, trimmed) when trimmed in ["---", "***", "___"], do: :rule
+
+  defp classify_block_line(false, line, trimmed) do
+    classify_non_fence_line(String.match?(trimmed, ~r/^[-*_]{3,}$/), line, trimmed)
+  end
+
+  @spec classify_non_fence_line(boolean(), String.t(), String.t()) ::
+          :paragraph
+          | :rule
+          | {:heading, 1..3, String.t()}
+          | {:blockquote, String.t()}
+          | {:list_item, non_neg_integer(), boolean(), non_neg_integer(), String.t()}
+  defp classify_non_fence_line(true, _line, _trimmed), do: :rule
+  defp classify_non_fence_line(false, _line, "###" <> text), do: {:heading, 3, String.trim(text)}
+  defp classify_non_fence_line(false, _line, "##" <> text), do: {:heading, 2, String.trim(text)}
+  defp classify_non_fence_line(false, _line, "#" <> text), do: {:heading, 1, String.trim(text)}
+
+  defp classify_non_fence_line(false, _line, ">" <> text),
+    do: {:blockquote, String.trim_leading(text)}
+
+  defp classify_non_fence_line(false, line, "- " <> text),
+    do: {:list_item, div(indent_width(line), 2), false, 0, text}
+
+  defp classify_non_fence_line(false, line, "* " <> text),
+    do: {:list_item, div(indent_width(line), 2), false, 0, text}
+
+  defp classify_non_fence_line(false, line, trimmed) do
+    case Regex.run(~r/^(\d+)\.\s+(.*)$/, trimmed) do
+      [_, ordinal, text] ->
+        {:list_item, div(indent_width(line), 2), true, String.to_integer(ordinal), text}
+
+      _ ->
+        :paragraph
+    end
+  end
+
+  @spec fence_line?(String.t()) :: boolean()
+  defp fence_line?(line), do: String.starts_with?(String.trim_leading(line), "```")
+
+  @spec fence_language(String.t()) :: String.t()
+  defp fence_language(line) do
+    line
+    |> String.trim_leading()
+    |> String.replace_prefix("```", "")
+    |> String.trim()
+  end
+
   @doc """
   Extracts fenced code blocks from markdown text.
 

--- a/lib/minga_editor/agent/markdown_highlight.ex
+++ b/lib/minga_editor/agent/markdown_highlight.ex
@@ -33,6 +33,7 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
   @flag_italic 0x02
   @flag_underline 0x04
   @flag_link 0x08
+  @flag_code 0x10
 
   @doc """
   Converts assistant message text to styled runs for the GUI.
@@ -57,8 +58,10 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
         end)
       end)
 
-    # Overlay tree-sitter highlights on code block content lines
-    if has_spans?(highlight) do
+    # Overlay tree-sitter highlights on code block content lines. While a
+    # streamed fence is still open, keep the block plain monospaced so syntax
+    # colors do not churn token-by-token.
+    if has_spans?(highlight) and not open_fence?(text) do
       overlay_code_blocks(base_lines, parsed, text, highlight, theme_syntax, buffer_byte_offset)
     else
       base_lines
@@ -183,7 +186,8 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
     flags =
       if(face.bold, do: @flag_bold, else: 0) +
         if(face.italic, do: @flag_italic, else: 0) +
-        if face.underline, do: @flag_underline, else: 0
+        if(face.underline, do: @flag_underline, else: 0) +
+        @flag_code
 
     {text, fg, bg, flags}
   end
@@ -209,13 +213,16 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
   defp md_style_to_colors(:bold_italic, theme),
     do: {default_fg(theme), 0, @flag_bold + @flag_italic}
 
-  defp md_style_to_colors(:code, theme), do: {code_fg(theme), code_bg(theme), 0}
+  defp md_style_to_colors(:code, theme), do: {code_fg(theme), code_bg(theme), @flag_code}
 
   defp md_style_to_colors({:link, _url}, theme),
     do: {link_fg(theme), 0, @flag_underline + @flag_link}
 
   defp md_style_to_colors(:code_block, theme), do: {code_fg(theme), 0, 0}
-  defp md_style_to_colors({:code_content, _lang}, theme), do: {code_fg(theme), code_bg(theme), 0}
+
+  defp md_style_to_colors({:code_content, _lang}, theme),
+    do: {code_fg(theme), code_bg(theme), @flag_code}
+
   defp md_style_to_colors(:header1, theme), do: {header_fg(theme), 0, @flag_bold}
   defp md_style_to_colors(:header2, theme), do: {header_fg(theme), 0, @flag_bold}
   defp md_style_to_colors(:header3, theme), do: {header_fg(theme), 0, @flag_bold}
@@ -258,4 +265,13 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
   defp has_spans?(%Highlight{spans: spans}) when is_tuple(spans), do: tuple_size(spans) > 0
   defp has_spans?(%Highlight{spans: spans}) when is_list(spans), do: spans != []
   defp has_spans?(_), do: false
+
+  @spec open_fence?(String.t()) :: boolean()
+  defp open_fence?(text) do
+    text
+    |> String.split("\n")
+    |> Enum.count(&String.starts_with?(String.trim_leading(&1), "```"))
+    |> rem(2)
+    |> Kernel.==(1)
+  end
 end

--- a/lib/minga_editor/agent/markdown_highlight.ex
+++ b/lib/minga_editor/agent/markdown_highlight.ex
@@ -14,7 +14,9 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
   blocks only when highlight spans are available.
   """
 
+  alias Minga.Parser.Manager, as: ParserManager
   alias MingaAgent.Markdown
+  alias Minga.RenderModel.UI.AgentChat.MarkdownBlock
   alias MingaEditor.UI.Highlight
 
   @typedoc "A single styled text run: {text, fg_rgb, bg_rgb, flags} or {text, fg_rgb, bg_rgb, flags, url}."
@@ -34,6 +36,485 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
   @flag_underline 0x04
   @flag_link 0x08
   @flag_code 0x10
+  @snippet_highlight_timeout_ms 50
+
+  @type highlighter_result ::
+          {:ok, [String.t()], [Minga.Language.Highlight.Span.t()]}
+          | :unsupported
+          | :timeout
+          | :unavailable
+          | {:error, term()}
+          | nil
+
+  @type highlighter :: (String.t(), String.t(), keyword() -> highlighter_result())
+
+  @doc """
+  Converts assistant message text to semantic markdown blocks for GUI code-card rendering.
+
+  Inline code remains a styled-run flag inside paragraph/list/heading runs. Fenced code becomes an explicit `MarkdownBlock` code block; frontends should render cards from this block kind, not from `0x10`.
+  """
+  @spec render_blocks(
+          String.t(),
+          Highlight.t() | nil,
+          map(),
+          non_neg_integer(),
+          non_neg_integer(),
+          keyword()
+        ) :: [MarkdownBlock.t()]
+  def render_blocks(
+        text,
+        highlight,
+        theme_syntax,
+        message_id,
+        buffer_byte_offset \\ 0,
+        opts \\ []
+      )
+      when is_binary(text) and is_list(opts) do
+    highlighter = Keyword.get(opts, :highlighter, &ParserManager.highlight_source/3)
+
+    text
+    |> Markdown.parse_blocks()
+    |> Enum.with_index()
+    |> render_blocks(
+      text,
+      highlight,
+      theme_syntax,
+      message_id,
+      buffer_byte_offset,
+      highlighter,
+      0,
+      []
+    )
+  end
+
+  @spec render_blocks(
+          [{Markdown.block(), non_neg_integer()}],
+          String.t(),
+          Highlight.t() | nil,
+          map(),
+          non_neg_integer(),
+          non_neg_integer(),
+          highlighter(),
+          non_neg_integer(),
+          [MarkdownBlock.t()]
+        ) :: [MarkdownBlock.t()]
+  defp render_blocks(
+         [],
+         _text,
+         _highlight,
+         _theme_syntax,
+         _message_id,
+         _buffer_byte_offset,
+         _highlighter,
+         _code_index,
+         acc
+       ) do
+    Enum.reverse(acc)
+  end
+
+  defp render_blocks(
+         [{block, index} | rest],
+         text,
+         highlight,
+         theme_syntax,
+         message_id,
+         buffer_byte_offset,
+         highlighter,
+         code_index,
+         acc
+       ) do
+    id = block_id(message_id, index)
+
+    {rendered, next_code_index} =
+      render_block(
+        block,
+        id,
+        text,
+        highlight,
+        theme_syntax,
+        buffer_byte_offset,
+        highlighter,
+        code_index
+      )
+
+    render_blocks(
+      rest,
+      text,
+      highlight,
+      theme_syntax,
+      message_id,
+      buffer_byte_offset,
+      highlighter,
+      next_code_index,
+      [rendered | acc]
+    )
+  end
+
+  @spec render_block(
+          Markdown.block(),
+          non_neg_integer(),
+          String.t(),
+          Highlight.t() | nil,
+          map(),
+          non_neg_integer(),
+          highlighter(),
+          non_neg_integer()
+        ) :: {MarkdownBlock.t(), non_neg_integer()}
+  defp render_block(
+         %{kind: :paragraph, lines: lines},
+         id,
+         _text,
+         _highlight,
+         theme_syntax,
+         _offset,
+         _highlighter,
+         code_index
+       ) do
+    {MarkdownBlock.paragraph(id, Enum.map(lines, &inline_line_to_runs(&1, theme_syntax))),
+     code_index}
+  end
+
+  defp render_block(
+         %{kind: :heading, level: level, text: heading},
+         id,
+         _text,
+         _highlight,
+         theme_syntax,
+         _offset,
+         _highlighter,
+         code_index
+       ) do
+    line = [{heading, header_fg(theme_syntax), 0, @flag_bold}]
+    {MarkdownBlock.heading(id, level, [line]), code_index}
+  end
+
+  defp render_block(
+         %{kind: :list_item, indent: indent, ordered: ordered?, ordinal: ordinal, text: text},
+         id,
+         _text,
+         _highlight,
+         theme_syntax,
+         _offset,
+         _highlighter,
+         code_index
+       ) do
+    prefix = if ordered?, do: "#{ordinal}. ", else: "• "
+    lines = [inline_line_to_runs(String.duplicate("  ", indent) <> prefix <> text, theme_syntax)]
+    {MarkdownBlock.list_item(id, indent, ordered?, ordinal, lines), code_index}
+  end
+
+  defp render_block(
+         %{kind: :blockquote, lines: lines},
+         id,
+         _text,
+         _highlight,
+         theme_syntax,
+         _offset,
+         _highlighter,
+         code_index
+       ) do
+    rendered =
+      Enum.map(lines, fn line ->
+        [
+          {"│ ", comment_fg(theme_syntax), 0, @flag_italic}
+          | inline_line_to_runs(line, theme_syntax)
+        ]
+      end)
+
+    {MarkdownBlock.blockquote(id, rendered), code_index}
+  end
+
+  defp render_block(
+         %{kind: :rule},
+         id,
+         _text,
+         _highlight,
+         _theme_syntax,
+         _offset,
+         _highlighter,
+         code_index
+       ) do
+    {MarkdownBlock.rule(id), code_index}
+  end
+
+  defp render_block(
+         %{kind: :spacer, height: height},
+         id,
+         _text,
+         _highlight,
+         _theme_syntax,
+         _offset,
+         _highlighter,
+         code_index
+       ) do
+    {MarkdownBlock.spacer(id, height), code_index}
+  end
+
+  defp render_block(
+         %{kind: :code_block, language: language, lines: lines, complete?: complete?},
+         id,
+         text,
+         highlight,
+         theme_syntax,
+         buffer_byte_offset,
+         highlighter,
+         code_index
+       ) do
+    target_path = Markdown.infer_target_path(text, code_index)
+    label = code_label(language)
+
+    rendered_lines =
+      code_lines_to_runs(
+        lines,
+        complete?,
+        highlight,
+        theme_syntax,
+        text,
+        buffer_byte_offset,
+        code_index,
+        language,
+        highlighter
+      )
+
+    {MarkdownBlock.code_block(id, language, label, target_path, complete?, rendered_lines),
+     code_index + 1}
+  end
+
+  @spec inline_line_to_runs(String.t(), map()) :: styled_line()
+  defp inline_line_to_runs(line, theme_syntax) do
+    line
+    |> Markdown.parse_inline()
+    |> Enum.map(fn {segment, style} -> style_to_run(segment, style, theme_syntax) end)
+  end
+
+  @spec code_lines_to_runs(
+          [String.t()],
+          boolean(),
+          Highlight.t() | nil,
+          map(),
+          String.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          String.t(),
+          highlighter()
+        ) :: [styled_line()]
+  defp code_lines_to_runs(
+         lines,
+         false,
+         _highlight,
+         theme_syntax,
+         _text,
+         _buffer_byte_offset,
+         _code_index,
+         _language,
+         _highlighter
+       ) do
+    plain_code_lines_to_runs(lines, theme_syntax)
+  end
+
+  defp code_lines_to_runs(
+         lines,
+         true,
+         highlight,
+         theme_syntax,
+         text,
+         buffer_byte_offset,
+         code_index,
+         language,
+         highlighter
+       ) do
+    case code_highlight_source(highlight, lines, language, theme_syntax, highlighter) do
+      {:full_message, full_highlight} ->
+        highlighted_code_lines_to_runs(
+          lines,
+          full_highlight,
+          theme_syntax,
+          text,
+          buffer_byte_offset,
+          code_index
+        )
+
+      {:snippet, snippet_highlight} ->
+        highlighted_snippet_lines_to_runs(lines, snippet_highlight, theme_syntax)
+
+      :none ->
+        plain_code_lines_to_runs(lines, theme_syntax)
+    end
+  end
+
+  @spec plain_code_lines_to_runs([String.t()], map()) :: [styled_line()]
+  defp plain_code_lines_to_runs(lines, theme_syntax) do
+    Enum.map(lines, fn line ->
+      [{line, code_fg(theme_syntax), code_bg(theme_syntax), @flag_code}]
+    end)
+  end
+
+  @spec code_highlight_source(Highlight.t() | nil, [String.t()], String.t(), map(), highlighter()) ::
+          {:full_message, Highlight.t()} | {:snippet, Highlight.t()} | :none
+  defp code_highlight_source(
+         %Highlight{} = highlight,
+         _lines,
+         _language,
+         _theme_syntax,
+         _highlighter
+       ) do
+    if has_spans?(highlight), do: {:full_message, highlight}, else: :none
+  end
+
+  defp code_highlight_source(_highlight, lines, language, theme_syntax, highlighter) do
+    case snippet_highlight(lines, language, theme_syntax, highlighter) do
+      %Highlight{} = snippet -> {:snippet, snippet}
+      nil -> :none
+    end
+  end
+
+  @spec snippet_highlight([String.t()], String.t(), map(), highlighter()) :: Highlight.t() | nil
+  defp snippet_highlight(_lines, "", _theme_syntax, _highlighter), do: nil
+
+  defp snippet_highlight(lines, language, theme_syntax, highlighter) do
+    source = Enum.join(lines, "\n")
+
+    case highlighter.(language, source, timeout: @snippet_highlight_timeout_ms) do
+      {:ok, names, spans} when is_list(names) and is_list(spans) ->
+        theme_syntax
+        |> Highlight.new()
+        |> Highlight.put_names(names)
+        |> Highlight.put_spans(1, spans)
+
+      _result ->
+        nil
+    end
+  rescue
+    _error -> nil
+  catch
+    :exit, _reason -> nil
+    _kind, _reason -> nil
+  end
+
+  @spec highlighted_snippet_lines_to_runs([String.t()], Highlight.t(), map()) :: [styled_line()]
+  defp highlighted_snippet_lines_to_runs(lines, highlight, theme_syntax) do
+    lines
+    |> Enum.reduce({[], 0}, fn line, {acc, byte_offset} ->
+      segments = Highlight.styles_for_line(highlight, line, byte_offset)
+      next_byte_offset = byte_offset + byte_size(line) + 1
+      {[highlighted_segments_to_runs(segments, line, theme_syntax) | acc], next_byte_offset}
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+  end
+
+  @spec highlighted_segments_to_runs([Highlight.styled_segment()], String.t(), map()) ::
+          styled_line()
+  defp highlighted_segments_to_runs(segments, original_line, theme_syntax) do
+    case segments do
+      [{^original_line, %Minga.Core.Face{fg: nil}}] ->
+        [{original_line, code_fg(theme_syntax), code_bg(theme_syntax), @flag_code}]
+
+      _ ->
+        Enum.map(segments, &segment_to_run(&1, code_bg(theme_syntax)))
+    end
+  end
+
+  @spec highlighted_code_lines_to_runs(
+          [String.t()],
+          Highlight.t(),
+          map(),
+          String.t(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [styled_line()]
+  defp highlighted_code_lines_to_runs(
+         lines,
+         highlight,
+         theme_syntax,
+         text,
+         buffer_byte_offset,
+         code_index
+       ) do
+    original_lines = String.split(text, "\n")
+    line_byte_offsets = compute_line_byte_offsets(original_lines)
+    start_idx = code_content_start_line(original_lines, code_index)
+
+    lines
+    |> Enum.with_index()
+    |> Enum.map(fn {line, relative_idx} ->
+      line_idx = start_idx + relative_idx
+      original_line = Enum.at(original_lines, line_idx, line)
+      line_start_byte = buffer_byte_offset + Map.get(line_byte_offsets, line_idx, 0)
+      segments = Highlight.styles_for_line(highlight, original_line, line_start_byte)
+
+      highlighted_segments_to_runs(segments, original_line, theme_syntax)
+    end)
+  end
+
+  @spec code_content_start_line([String.t()], non_neg_integer()) :: non_neg_integer()
+  defp code_content_start_line(lines, target_code_index) do
+    lines
+    |> Enum.with_index()
+    |> Enum.reduce_while({false, 0}, fn {line, idx}, {inside_code?, code_index} ->
+      if fence_line?(line) do
+        code_content_start_line_step(inside_code?, code_index, target_code_index, idx)
+      else
+        {:cont, {inside_code?, code_index}}
+      end
+    end)
+    |> case do
+      {:found, line_idx} -> line_idx
+      {_inside_code?, _code_index} -> 0
+    end
+  end
+
+  @spec code_content_start_line_step(
+          boolean(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          {:halt, {:found, non_neg_integer()}} | {:cont, {boolean(), non_neg_integer()}}
+  defp code_content_start_line_step(false, code_index, target_code_index, idx)
+       when code_index == target_code_index do
+    {:halt, {:found, idx + 1}}
+  end
+
+  defp code_content_start_line_step(false, code_index, _target_code_index, _idx) do
+    {:cont, {true, code_index}}
+  end
+
+  defp code_content_start_line_step(true, code_index, _target_code_index, _idx) do
+    {:cont, {false, code_index + 1}}
+  end
+
+  @spec code_label(String.t()) :: String.t()
+  defp code_label(""), do: "Code"
+  defp code_label("elixir"), do: "Elixir"
+  defp code_label("ex"), do: "Elixir"
+  defp code_label("python"), do: "Python"
+  defp code_label("py"), do: "Python"
+  defp code_label("swift"), do: "Swift"
+  defp code_label("go"), do: "Go"
+  defp code_label("rust"), do: "Rust"
+  defp code_label("sh"), do: "Shell"
+  defp code_label("bash"), do: "Shell"
+  defp code_label("zsh"), do: "Shell"
+  defp code_label("javascript"), do: "JavaScript"
+  defp code_label("js"), do: "JavaScript"
+  defp code_label("typescript"), do: "TypeScript"
+  defp code_label("ts"), do: "TypeScript"
+
+  defp code_label(language) do
+    language
+    |> String.split(~r/[\s,]/, parts: 2)
+    |> hd()
+    |> String.trim()
+    |> case do
+      "" -> "Code"
+      value -> String.capitalize(value)
+    end
+  end
+
+  @spec block_id(non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp block_id(message_id, block_index),
+    do: :erlang.phash2({message_id, block_index}, 4_294_967_296)
 
   @doc """
   Converts assistant message text to styled runs for the GUI.
@@ -265,6 +746,9 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
   defp has_spans?(%Highlight{spans: spans}) when is_tuple(spans), do: tuple_size(spans) > 0
   defp has_spans?(%Highlight{spans: spans}) when is_list(spans), do: spans != []
   defp has_spans?(_), do: false
+
+  @spec fence_line?(String.t()) :: boolean()
+  defp fence_line?(line), do: String.starts_with?(String.trim_leading(line), "```")
 
   @spec open_fence?(String.t()) :: boolean()
   defp open_fence?(text) do

--- a/lib/minga_editor/agent/markdown_highlight.ex
+++ b/lib/minga_editor/agent/markdown_highlight.ex
@@ -48,6 +48,23 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
 
   @type highlighter :: (String.t(), String.t(), keyword() -> highlighter_result())
 
+  @typep render_context :: %{
+           text: String.t(),
+           highlight: Highlight.t() | nil,
+           theme_syntax: map(),
+           message_id: non_neg_integer(),
+           buffer_byte_offset: non_neg_integer(),
+           highlighter: highlighter()
+         }
+
+  @typep code_context :: %{
+           highlight: Highlight.t() | nil,
+           theme_syntax: map(),
+           text: String.t(),
+           buffer_byte_offset: non_neg_integer(),
+           highlighter: highlighter()
+         }
+
   @doc """
   Converts assistant message text to semantic markdown blocks for GUI code-card rendering.
 
@@ -72,118 +89,57 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
       when is_binary(text) and is_list(opts) do
     highlighter = Keyword.get(opts, :highlighter, &ParserManager.highlight_source/3)
 
-    text
-    |> Markdown.parse_blocks()
-    |> Enum.with_index()
-    |> render_blocks(
-      text,
-      highlight,
-      theme_syntax,
-      message_id,
-      buffer_byte_offset,
-      highlighter,
-      0,
-      []
-    )
+    context = %{
+      text: text,
+      highlight: highlight,
+      theme_syntax: theme_syntax,
+      message_id: message_id,
+      buffer_byte_offset: buffer_byte_offset,
+      highlighter: highlighter
+    }
+
+    text |> Markdown.parse_blocks() |> Enum.with_index() |> render_parsed_blocks(context, 0, [])
   end
 
-  @spec render_blocks(
+  @spec render_parsed_blocks(
           [{Markdown.block(), non_neg_integer()}],
-          String.t(),
-          Highlight.t() | nil,
-          map(),
-          non_neg_integer(),
-          non_neg_integer(),
-          highlighter(),
+          render_context(),
           non_neg_integer(),
           [MarkdownBlock.t()]
         ) :: [MarkdownBlock.t()]
-  defp render_blocks(
-         [],
-         _text,
-         _highlight,
-         _theme_syntax,
-         _message_id,
-         _buffer_byte_offset,
-         _highlighter,
-         _code_index,
-         acc
-       ) do
+  defp render_parsed_blocks([], _context, _code_index, acc) do
     Enum.reverse(acc)
   end
 
-  defp render_blocks(
-         [{block, index} | rest],
-         text,
-         highlight,
-         theme_syntax,
-         message_id,
-         buffer_byte_offset,
-         highlighter,
-         code_index,
-         acc
-       ) do
-    id = block_id(message_id, index)
+  defp render_parsed_blocks([{block, index} | rest], context, code_index, acc) do
+    id = block_id(context.message_id, index)
 
     {rendered, next_code_index} =
       render_block(
         block,
         id,
-        text,
-        highlight,
-        theme_syntax,
-        buffer_byte_offset,
-        highlighter,
+        context,
         code_index
       )
 
-    render_blocks(
-      rest,
-      text,
-      highlight,
-      theme_syntax,
-      message_id,
-      buffer_byte_offset,
-      highlighter,
-      next_code_index,
-      [rendered | acc]
-    )
+    render_parsed_blocks(rest, context, next_code_index, [rendered | acc])
   end
 
   @spec render_block(
           Markdown.block(),
           non_neg_integer(),
-          String.t(),
-          Highlight.t() | nil,
-          map(),
-          non_neg_integer(),
-          highlighter(),
+          render_context(),
           non_neg_integer()
         ) :: {MarkdownBlock.t(), non_neg_integer()}
-  defp render_block(
-         %{kind: :paragraph, lines: lines},
-         id,
-         _text,
-         _highlight,
-         theme_syntax,
-         _offset,
-         _highlighter,
-         code_index
-       ) do
+  defp render_block(%{kind: :paragraph, lines: lines}, id, context, code_index) do
+    theme_syntax = context.theme_syntax
+
     {MarkdownBlock.paragraph(id, Enum.map(lines, &inline_line_to_runs(&1, theme_syntax))),
      code_index}
   end
 
-  defp render_block(
-         %{kind: :heading, level: level, text: heading},
-         id,
-         _text,
-         _highlight,
-         theme_syntax,
-         _offset,
-         _highlighter,
-         code_index
-       ) do
+  defp render_block(%{kind: :heading, level: level, text: heading}, id, context, code_index) do
+    theme_syntax = context.theme_syntax
     line = [{heading, header_fg(theme_syntax), 0, @flag_bold}]
     {MarkdownBlock.heading(id, level, [line]), code_index}
   end
@@ -191,28 +147,18 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
   defp render_block(
          %{kind: :list_item, indent: indent, ordered: ordered?, ordinal: ordinal, text: text},
          id,
-         _text,
-         _highlight,
-         theme_syntax,
-         _offset,
-         _highlighter,
+         context,
          code_index
        ) do
+    theme_syntax = context.theme_syntax
     prefix = if ordered?, do: "#{ordinal}. ", else: "• "
     lines = [inline_line_to_runs(String.duplicate("  ", indent) <> prefix <> text, theme_syntax)]
     {MarkdownBlock.list_item(id, indent, ordered?, ordinal, lines), code_index}
   end
 
-  defp render_block(
-         %{kind: :blockquote, lines: lines},
-         id,
-         _text,
-         _highlight,
-         theme_syntax,
-         _offset,
-         _highlighter,
-         code_index
-       ) do
+  defp render_block(%{kind: :blockquote, lines: lines}, id, context, code_index) do
+    theme_syntax = context.theme_syntax
+
     rendered =
       Enum.map(lines, fn line ->
         [
@@ -224,42 +170,21 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
     {MarkdownBlock.blockquote(id, rendered), code_index}
   end
 
-  defp render_block(
-         %{kind: :rule},
-         id,
-         _text,
-         _highlight,
-         _theme_syntax,
-         _offset,
-         _highlighter,
-         code_index
-       ) do
+  defp render_block(%{kind: :rule}, id, _context, code_index) do
     {MarkdownBlock.rule(id), code_index}
   end
 
-  defp render_block(
-         %{kind: :spacer, height: height},
-         id,
-         _text,
-         _highlight,
-         _theme_syntax,
-         _offset,
-         _highlighter,
-         code_index
-       ) do
+  defp render_block(%{kind: :spacer, height: height}, id, _context, code_index) do
     {MarkdownBlock.spacer(id, height), code_index}
   end
 
   defp render_block(
          %{kind: :code_block, language: language, lines: lines, complete?: complete?},
          id,
-         text,
-         highlight,
-         theme_syntax,
-         buffer_byte_offset,
-         highlighter,
+         context,
          code_index
        ) do
+    text = context.text
     target_path = Markdown.infer_target_path(text, code_index)
     label = code_label(language)
 
@@ -267,13 +192,15 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
       code_lines_to_runs(
         lines,
         complete?,
-        highlight,
-        theme_syntax,
-        text,
-        buffer_byte_offset,
+        %{
+          highlight: context.highlight,
+          theme_syntax: context.theme_syntax,
+          text: text,
+          buffer_byte_offset: context.buffer_byte_offset,
+          highlighter: context.highlighter
+        },
         code_index,
-        language,
-        highlighter
+        language
       )
 
     {MarkdownBlock.code_block(id, language, label, target_path, complete?, rendered_lines),
@@ -290,47 +217,31 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
   @spec code_lines_to_runs(
           [String.t()],
           boolean(),
-          Highlight.t() | nil,
-          map(),
-          String.t(),
+          code_context(),
           non_neg_integer(),
-          non_neg_integer(),
-          String.t(),
-          highlighter()
+          String.t()
         ) :: [styled_line()]
-  defp code_lines_to_runs(
-         lines,
-         false,
-         _highlight,
-         theme_syntax,
-         _text,
-         _buffer_byte_offset,
-         _code_index,
-         _language,
-         _highlighter
-       ) do
-    plain_code_lines_to_runs(lines, theme_syntax)
+  defp code_lines_to_runs(lines, false, context, _code_index, _language) do
+    plain_code_lines_to_runs(lines, context.theme_syntax)
   end
 
-  defp code_lines_to_runs(
-         lines,
-         true,
-         highlight,
-         theme_syntax,
-         text,
-         buffer_byte_offset,
-         code_index,
-         language,
-         highlighter
-       ) do
-    case code_highlight_source(highlight, lines, language, theme_syntax, highlighter) do
+  defp code_lines_to_runs(lines, true, context, code_index, language) do
+    theme_syntax = context.theme_syntax
+
+    case code_highlight_source(
+           context.highlight,
+           lines,
+           language,
+           theme_syntax,
+           context.highlighter
+         ) do
       {:full_message, full_highlight} ->
         highlighted_code_lines_to_runs(
           lines,
           full_highlight,
           theme_syntax,
-          text,
-          buffer_byte_offset,
+          context.text,
+          context.buffer_byte_offset,
           code_index
         )
 

--- a/lib/minga_editor/agent/ui_state/panel.ex
+++ b/lib/minga_editor/agent/ui_state/panel.ex
@@ -38,13 +38,19 @@ defmodule MingaEditor.Agent.UIState.Panel do
           cached_line_index: [{non_neg_integer(), MingaEditor.Agent.Transcript.line_type()}],
           cached_display_messages: [term()],
           cached_display_message_pairs: [{pos_integer(), term()}],
-          cached_styled_messages: [MingaEditor.Agent.MarkdownHighlight.styled_lines()] | nil,
+          cached_styled_messages: styled_cache(),
+          cached_styled_fingerprint: non_neg_integer() | nil,
           message_version: non_neg_integer(),
           credentials_configured: boolean(),
           provenance_jump: MingaEditor.Agent.ProvenanceJump.t() | nil
         }
 
-  @type styled_cache :: [MingaEditor.Agent.MarkdownHighlight.styled_lines()] | nil
+  @type rendered_message :: %{
+          styled_lines: MingaEditor.Agent.MarkdownHighlight.styled_lines() | nil,
+          markdown_blocks: [Minga.RenderModel.UI.AgentChat.MarkdownBlock.t()] | nil
+        }
+
+  @type styled_cache :: [rendered_message() | nil] | nil
 
   defstruct visible: false,
             scroll: %Scroll{},
@@ -63,6 +69,7 @@ defmodule MingaEditor.Agent.UIState.Panel do
             cached_display_messages: [],
             cached_display_message_pairs: [],
             cached_styled_messages: nil,
+            cached_styled_fingerprint: nil,
             message_version: 0,
             credentials_configured: false,
             provenance_jump: nil
@@ -140,6 +147,8 @@ defmodule MingaEditor.Agent.UIState.Panel do
         cached_display_messages: display.display_messages,
         cached_display_message_pairs: display.display_message_pairs,
         cached_styled_messages: styled_messages,
+        cached_styled_fingerprint:
+          Keyword.get(opts, :styled_fingerprint, panel.cached_styled_fingerprint),
         display_start_index: Keyword.get(opts, :display_start_index, panel.display_start_index),
         provenance_jump: Keyword.get(opts, :provenance_jump, panel.provenance_jump)
     }
@@ -154,6 +163,7 @@ defmodule MingaEditor.Agent.UIState.Panel do
         cached_display_messages: [],
         cached_display_message_pairs: [],
         cached_styled_messages: nil,
+        cached_styled_fingerprint: nil,
         display_start_index: 0,
         provenance_jump: nil
     }
@@ -164,10 +174,20 @@ defmodule MingaEditor.Agent.UIState.Panel do
   def set_scroll(%__MODULE__{} = panel, %Scroll{} = scroll), do: %{panel | scroll: scroll}
 
   @doc "Replaces cached styled transcript runs without changing the display window."
-  @spec cache_styled_messages(t(), styled_cache()) :: t()
-  def cache_styled_messages(%__MODULE__{} = panel, styled_messages) do
-    %{panel | cached_styled_messages: styled_messages}
+  @spec cache_styled_messages(t(), styled_cache(), non_neg_integer() | nil) :: t()
+  def cache_styled_messages(%__MODULE__{} = panel, styled_messages, styled_fingerprint) do
+    %{
+      panel
+      | cached_styled_messages: styled_messages,
+        cached_styled_fingerprint: styled_fingerprint
+    }
   end
+
+  @spec styled_cache_fingerprint(map() | nil) :: non_neg_integer()
+  def styled_cache_fingerprint(nil), do: 0
+
+  def styled_cache_fingerprint(theme_syntax) when is_map(theme_syntax),
+    do: :erlang.phash2(theme_syntax)
 
   @spec stale_unqualified_model?(String.t(), String.t()) :: boolean()
   defp stale_unqualified_model?(model, default_model)

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -24,6 +24,7 @@ defmodule MingaEditor.AgentLifecycle do
   alias MingaEditor.LayoutPreset
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.UI.Highlight
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   @type state :: EditorState.t()
@@ -143,7 +144,15 @@ defmodule MingaEditor.AgentLifecycle do
     result = Transcript.display(messages, sync_opts)
 
     # Compute styled runs for GUI rendering against the displayed transcript.
-    styled = compute_styled_messages(state, result.display_messages)
+    # Reuse unchanged entries so streaming deltas restyle only the message that
+    # actually changed instead of reprocessing the whole visible transcript.
+    styled =
+      compute_styled_messages(
+        state,
+        result.display_messages,
+        panel.cached_display_messages,
+        panel.cached_styled_messages || []
+      )
 
     styled_assistant_count =
       Enum.count(styled, fn
@@ -356,7 +365,15 @@ defmodule MingaEditor.AgentLifecycle do
 
     with true <- is_pid(session),
          messages when messages != [] <- displayed_messages_for_styling(state, session) do
-      styled = compute_styled_messages(state, messages)
+      panel = AgentAccess.panel(state)
+
+      styled =
+        compute_styled_messages(
+          state,
+          messages,
+          panel.cached_display_messages,
+          panel.cached_styled_messages || []
+        )
 
       AgentAccess.update_panel(state, fn p ->
         Panel.cache_styled_messages(p, styled)
@@ -383,10 +400,12 @@ defmodule MingaEditor.AgentLifecycle do
 
   # Computes styled runs for each message. Assistant messages and tool call results
   # get markdown styling; other message types pass through as nil.
-  @spec compute_styled_messages(state(), [term()]) :: [
+  @spec compute_styled_messages(state(), [term()], [term()], [
+          MarkdownHighlight.styled_lines() | nil
+        ]) :: [
           MarkdownHighlight.styled_lines() | nil
         ]
-  defp compute_styled_messages(state, messages) do
+  defp compute_styled_messages(state, messages, previous_messages, previous_styled) do
     highlight = nil
     theme_syntax = state.theme.syntax
 
@@ -396,21 +415,55 @@ defmodule MingaEditor.AgentLifecycle do
 
     messages
     |> Enum.with_index()
-    |> Enum.map(fn
-      {{:assistant, text}, idx} ->
-        byte_offset = Map.get(byte_offset_map, idx, 0)
-        MarkdownHighlight.stylize(text, highlight, theme_syntax, byte_offset)
+    |> Enum.map(fn {message, idx} ->
+      case cached_styled_message(message, idx, previous_messages, previous_styled) do
+        {:ok, styled} ->
+          styled
 
-      {{:tool_call, %MingaAgent.ToolCall{result: result}}, idx}
-      when is_binary(result) and result != "" ->
-        byte_offset = Map.get(byte_offset_map, idx, 0)
-        # Tool call results use the same markdown/tree-sitter styling pipeline
-        text = String.slice(result, 0, @max_styled_result_chars)
-        MarkdownHighlight.stylize(text, highlight, theme_syntax, byte_offset)
-
-      _ ->
-        nil
+        :miss ->
+          style_message(message, idx, highlight, theme_syntax, byte_offset_map)
+      end
     end)
+  end
+
+  @spec cached_styled_message(term(), non_neg_integer(), [term()], [
+          MarkdownHighlight.styled_lines() | nil
+        ]) :: {:ok, MarkdownHighlight.styled_lines() | nil} | :miss
+  defp cached_styled_message(message, idx, previous_messages, previous_styled)
+       when idx < length(previous_styled) do
+    case {Enum.at(previous_messages, idx), Enum.at(previous_styled, idx)} do
+      {^message, styled} -> {:ok, styled}
+      _ -> :miss
+    end
+  end
+
+  defp cached_styled_message(_message, _idx, _previous_messages, _previous_styled) do
+    :miss
+  end
+
+  @spec style_message(term(), non_neg_integer(), Highlight.t() | nil, map(), %{
+          non_neg_integer() => non_neg_integer()
+        }) :: MarkdownHighlight.styled_lines() | nil
+  defp style_message({:assistant, text}, idx, highlight, theme_syntax, byte_offset_map) do
+    byte_offset = Map.get(byte_offset_map, idx, 0)
+    MarkdownHighlight.stylize(text, highlight, theme_syntax, byte_offset)
+  end
+
+  defp style_message(
+         {:tool_call, %MingaAgent.ToolCall{result: result}},
+         idx,
+         highlight,
+         theme_syntax,
+         byte_offset_map
+       )
+       when is_binary(result) and result != "" do
+    byte_offset = Map.get(byte_offset_map, idx, 0)
+    text = String.slice(result, 0, @max_styled_result_chars)
+    MarkdownHighlight.stylize(text, highlight, theme_syntax, byte_offset)
+  end
+
+  defp style_message(_message, _idx, _highlight, _theme_syntax, _byte_offset_map) do
+    nil
   end
 
   # Computes the byte offset of each message's start line within the full buffer text.

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -144,14 +144,26 @@ defmodule MingaEditor.AgentLifecycle do
     result = Transcript.display(messages, sync_opts)
 
     # Compute styled runs for GUI rendering against the displayed transcript.
-    # Reuse unchanged entries so streaming deltas restyle only the message that
-    # actually changed instead of reprocessing the whole visible transcript.
+    # Reuse unchanged entries only when the style context still matches the
+    # cached fingerprint; theme changes must force a restyle.
+    styled_fingerprint = Panel.styled_cache_fingerprint(state.theme.syntax)
+
+    {previous_messages, previous_styled} =
+      if panel.cached_styled_fingerprint == styled_fingerprint do
+        {panel.cached_display_messages, panel.cached_styled_messages || []}
+      else
+        {[], []}
+      end
+
+    message_ids = Enum.map(result.display_message_pairs, fn {id, _message} -> id end)
+
     styled =
       compute_styled_messages(
         state,
         result.display_messages,
-        panel.cached_display_messages,
-        panel.cached_styled_messages || []
+        message_ids,
+        previous_messages,
+        previous_styled
       )
 
     styled_assistant_count =
@@ -172,7 +184,8 @@ defmodule MingaEditor.AgentLifecycle do
     AgentAccess.update_panel(state, fn p ->
       Panel.cache_transcript_display(p, result, styled,
         display_start_index: display_start,
-        provenance_jump: advance_jump(jump)
+        provenance_jump: advance_jump(jump),
+        styled_fingerprint: styled_fingerprint
       )
     end)
   end
@@ -366,17 +379,28 @@ defmodule MingaEditor.AgentLifecycle do
     with true <- is_pid(session),
          messages when messages != [] <- displayed_messages_for_styling(state, session) do
       panel = AgentAccess.panel(state)
+      styled_fingerprint = Panel.styled_cache_fingerprint(state.theme.syntax)
+
+      {previous_messages, previous_styled} =
+        if panel.cached_styled_fingerprint == styled_fingerprint do
+          {panel.cached_display_messages, panel.cached_styled_messages || []}
+        else
+          {[], []}
+        end
+
+      message_ids = displayed_message_ids_for_styling(state, session)
 
       styled =
         compute_styled_messages(
           state,
           messages,
-          panel.cached_display_messages,
-          panel.cached_styled_messages || []
+          message_ids,
+          previous_messages,
+          previous_styled
         )
 
       AgentAccess.update_panel(state, fn p ->
-        Panel.cache_styled_messages(p, styled)
+        Panel.cache_styled_messages(p, styled, styled_fingerprint)
       end)
     else
       _ -> state
@@ -398,14 +422,29 @@ defmodule MingaEditor.AgentLifecycle do
     end
   end
 
+  @spec displayed_message_ids_for_styling(state(), pid()) :: [pos_integer()]
+  defp displayed_message_ids_for_styling(state, session) do
+    panel = AgentAccess.panel(state)
+
+    case panel.cached_display_message_pairs do
+      [] -> session |> AgentSession.messages_with_ids() |> Enum.map(fn {id, _message} -> id end)
+      pairs -> Enum.map(pairs, fn {id, _message} -> id end)
+    end
+  catch
+    :exit, _ -> []
+  end
+
   # Computes styled runs for each message. Assistant messages and tool call results
   # get markdown styling; other message types pass through as nil.
-  @spec compute_styled_messages(state(), [term()], [term()], [
-          MarkdownHighlight.styled_lines() | nil
-        ]) :: [
-          MarkdownHighlight.styled_lines() | nil
-        ]
-  defp compute_styled_messages(state, messages, previous_messages, previous_styled) do
+  @spec compute_styled_messages(
+          state(),
+          [term()],
+          [pos_integer()],
+          [term()],
+          Panel.styled_cache()
+        ) ::
+          Panel.styled_cache()
+  defp compute_styled_messages(state, messages, message_ids, previous_messages, previous_styled) do
     highlight = nil
     theme_syntax = state.theme.syntax
 
@@ -413,45 +452,137 @@ defmodule MingaEditor.AgentLifecycle do
     full_lines = String.split(full_text, "\n")
     byte_offset_map = message_byte_offsets(line_offsets, full_lines)
 
-    messages
-    |> Enum.with_index()
-    |> Enum.map(fn {message, idx} ->
-      case cached_styled_message(message, idx, previous_messages, previous_styled) do
-        {:ok, styled} ->
-          styled
+    compute_styled_messages(
+      messages,
+      message_ids,
+      previous_messages,
+      previous_styled || [],
+      0,
+      highlight,
+      theme_syntax,
+      byte_offset_map,
+      []
+    )
+  end
+
+  @spec compute_styled_messages(
+          [term()],
+          [pos_integer()],
+          [term()],
+          Panel.styled_cache(),
+          non_neg_integer(),
+          Highlight.t() | nil,
+          map(),
+          %{non_neg_integer() => non_neg_integer()},
+          [Panel.rendered_message() | nil]
+        ) :: [Panel.rendered_message() | nil]
+  defp compute_styled_messages(
+         [],
+         _message_ids,
+         _previous_messages,
+         _previous_styled,
+         _idx,
+         _highlight,
+         _theme_syntax,
+         _byte_offset_map,
+         acc
+       ) do
+    Enum.reverse(acc)
+  end
+
+  defp compute_styled_messages(
+         [message | messages],
+         message_ids,
+         previous_messages,
+         previous_styled,
+         idx,
+         highlight,
+         theme_syntax,
+         byte_offset_map,
+         acc
+       ) do
+    {next_previous_messages, next_previous_styled, cached} =
+      cached_styled_message(message, previous_messages, previous_styled)
+
+    {message_id, next_message_ids} = next_message_id(message_ids, idx)
+
+    styled =
+      case cached do
+        {:ok, cached_styled} ->
+          cached_styled
 
         :miss ->
-          style_message(message, idx, highlight, theme_syntax, byte_offset_map)
+          style_message(message, idx, message_id, highlight, theme_syntax, byte_offset_map)
       end
-    end)
+
+    compute_styled_messages(
+      messages,
+      next_message_ids,
+      next_previous_messages,
+      next_previous_styled,
+      idx + 1,
+      highlight,
+      theme_syntax,
+      byte_offset_map,
+      [styled | acc]
+    )
   end
 
-  @spec cached_styled_message(term(), non_neg_integer(), [term()], [
-          MarkdownHighlight.styled_lines() | nil
-        ]) :: {:ok, MarkdownHighlight.styled_lines() | nil} | :miss
-  defp cached_styled_message(message, idx, previous_messages, previous_styled)
-       when idx < length(previous_styled) do
-    case {Enum.at(previous_messages, idx), Enum.at(previous_styled, idx)} do
-      {^message, styled} -> {:ok, styled}
-      _ -> :miss
-    end
+  @spec cached_styled_message(term(), [term()], Panel.styled_cache()) ::
+          {[term()], Panel.styled_cache(), {:ok, Panel.rendered_message() | nil} | :miss}
+  defp cached_styled_message(message, [previous_message | previous_messages], [
+         styled | previous_styled
+       ])
+       when message == previous_message do
+    {previous_messages, previous_styled, {:ok, styled}}
   end
 
-  defp cached_styled_message(_message, _idx, _previous_messages, _previous_styled) do
-    :miss
+  defp cached_styled_message(_message, [_previous_message | previous_messages], [
+         _styled | previous_styled
+       ]) do
+    {previous_messages, previous_styled, :miss}
   end
 
-  @spec style_message(term(), non_neg_integer(), Highlight.t() | nil, map(), %{
+  defp cached_styled_message(_message, [_previous_message | previous_messages], []) do
+    {previous_messages, [], :miss}
+  end
+
+  defp cached_styled_message(_message, [], [_styled | previous_styled]) do
+    {[], previous_styled, :miss}
+  end
+
+  defp cached_styled_message(_message, [], []) do
+    {[], [], :miss}
+  end
+
+  @spec next_message_id([pos_integer()], non_neg_integer()) :: {pos_integer(), [pos_integer()]}
+  defp next_message_id([id | rest], _idx), do: {id, rest}
+  defp next_message_id([], idx), do: {idx + 1, []}
+
+  @spec style_message(term(), non_neg_integer(), pos_integer(), Highlight.t() | nil, map(), %{
           non_neg_integer() => non_neg_integer()
-        }) :: MarkdownHighlight.styled_lines() | nil
-  defp style_message({:assistant, text}, idx, highlight, theme_syntax, byte_offset_map) do
+        }) :: Panel.rendered_message() | nil
+  defp style_message(
+         {:assistant, text},
+         idx,
+         message_id,
+         highlight,
+         theme_syntax,
+         byte_offset_map
+       ) do
     byte_offset = Map.get(byte_offset_map, idx, 0)
-    MarkdownHighlight.stylize(text, highlight, theme_syntax, byte_offset)
+
+    %{
+      styled_lines: MarkdownHighlight.stylize(text, highlight, theme_syntax, byte_offset),
+      markdown_blocks:
+        MarkdownHighlight.render_blocks(text, highlight, theme_syntax, message_id, byte_offset)
+    }
   end
 
   defp style_message(
          {:tool_call, %MingaAgent.ToolCall{result: result}},
          idx,
+         _message_id,
          highlight,
          theme_syntax,
          byte_offset_map
@@ -459,10 +590,14 @@ defmodule MingaEditor.AgentLifecycle do
        when is_binary(result) and result != "" do
     byte_offset = Map.get(byte_offset_map, idx, 0)
     text = String.slice(result, 0, @max_styled_result_chars)
-    MarkdownHighlight.stylize(text, highlight, theme_syntax, byte_offset)
+
+    %{
+      styled_lines: MarkdownHighlight.stylize(text, highlight, theme_syntax, byte_offset),
+      markdown_blocks: nil
+    }
   end
 
-  defp style_message(_message, _idx, _highlight, _theme_syntax, _byte_offset_map) do
+  defp style_message(_message, _idx, _message_id, _highlight, _theme_syntax, _byte_offset_map) do
     nil
   end
 

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -28,6 +28,11 @@ defmodule MingaEditor.AgentLifecycle do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   @type state :: EditorState.t()
+  @typep style_context :: %{
+           highlight: Highlight.t() | nil,
+           theme_syntax: map(),
+           byte_offset_map: %{non_neg_integer() => non_neg_integer()}
+         }
 
   # Maximum characters of tool call result to send for styled rendering.
   # Matches the truncation in Transcript.message_to_markdown/1.
@@ -452,15 +457,19 @@ defmodule MingaEditor.AgentLifecycle do
     full_lines = String.split(full_text, "\n")
     byte_offset_map = message_byte_offsets(line_offsets, full_lines)
 
+    style_context = %{
+      highlight: highlight,
+      theme_syntax: theme_syntax,
+      byte_offset_map: byte_offset_map
+    }
+
     compute_styled_messages(
       messages,
       message_ids,
       previous_messages,
       previous_styled || [],
       0,
-      highlight,
-      theme_syntax,
-      byte_offset_map,
+      style_context,
       []
     )
   end
@@ -471,9 +480,7 @@ defmodule MingaEditor.AgentLifecycle do
           [term()],
           Panel.styled_cache(),
           non_neg_integer(),
-          Highlight.t() | nil,
-          map(),
-          %{non_neg_integer() => non_neg_integer()},
+          style_context(),
           [Panel.rendered_message() | nil]
         ) :: [Panel.rendered_message() | nil]
   defp compute_styled_messages(
@@ -482,9 +489,7 @@ defmodule MingaEditor.AgentLifecycle do
          _previous_messages,
          _previous_styled,
          _idx,
-         _highlight,
-         _theme_syntax,
-         _byte_offset_map,
+         _style_context,
          acc
        ) do
     Enum.reverse(acc)
@@ -496,9 +501,7 @@ defmodule MingaEditor.AgentLifecycle do
          previous_messages,
          previous_styled,
          idx,
-         highlight,
-         theme_syntax,
-         byte_offset_map,
+         style_context,
          acc
        ) do
     {next_previous_messages, next_previous_styled, cached} =
@@ -512,7 +515,7 @@ defmodule MingaEditor.AgentLifecycle do
           cached_styled
 
         :miss ->
-          style_message(message, idx, message_id, highlight, theme_syntax, byte_offset_map)
+          style_message(message, idx, message_id, style_context)
       end
 
     compute_styled_messages(
@@ -521,9 +524,7 @@ defmodule MingaEditor.AgentLifecycle do
       next_previous_messages,
       next_previous_styled,
       idx + 1,
-      highlight,
-      theme_syntax,
-      byte_offset_map,
+      style_context,
       [styled | acc]
     )
   end
@@ -559,23 +560,32 @@ defmodule MingaEditor.AgentLifecycle do
   defp next_message_id([id | rest], _idx), do: {id, rest}
   defp next_message_id([], idx), do: {idx + 1, []}
 
-  @spec style_message(term(), non_neg_integer(), pos_integer(), Highlight.t() | nil, map(), %{
-          non_neg_integer() => non_neg_integer()
-        }) :: Panel.rendered_message() | nil
+  @spec style_message(term(), non_neg_integer(), pos_integer(), style_context()) ::
+          Panel.rendered_message() | nil
   defp style_message(
          {:assistant, text},
          idx,
          message_id,
-         highlight,
-         theme_syntax,
-         byte_offset_map
+         style_context
        ) do
-    byte_offset = Map.get(byte_offset_map, idx, 0)
+    byte_offset = Map.get(style_context.byte_offset_map, idx, 0)
 
     %{
-      styled_lines: MarkdownHighlight.stylize(text, highlight, theme_syntax, byte_offset),
+      styled_lines:
+        MarkdownHighlight.stylize(
+          text,
+          style_context.highlight,
+          style_context.theme_syntax,
+          byte_offset
+        ),
       markdown_blocks:
-        MarkdownHighlight.render_blocks(text, highlight, theme_syntax, message_id, byte_offset)
+        MarkdownHighlight.render_blocks(
+          text,
+          style_context.highlight,
+          style_context.theme_syntax,
+          message_id,
+          byte_offset
+        )
     }
   end
 
@@ -583,21 +593,25 @@ defmodule MingaEditor.AgentLifecycle do
          {:tool_call, %MingaAgent.ToolCall{result: result}},
          idx,
          _message_id,
-         highlight,
-         theme_syntax,
-         byte_offset_map
+         style_context
        )
        when is_binary(result) and result != "" do
-    byte_offset = Map.get(byte_offset_map, idx, 0)
+    byte_offset = Map.get(style_context.byte_offset_map, idx, 0)
     text = String.slice(result, 0, @max_styled_result_chars)
 
     %{
-      styled_lines: MarkdownHighlight.stylize(text, highlight, theme_syntax, byte_offset),
+      styled_lines:
+        MarkdownHighlight.stylize(
+          text,
+          style_context.highlight,
+          style_context.theme_syntax,
+          byte_offset
+        ),
       markdown_blocks: nil
     }
   end
 
-  defp style_message(_message, _idx, _message_id, _highlight, _theme_syntax, _byte_offset_map) do
+  defp style_message(_message, _idx, _message_id, _style_context) do
     nil
   end
 

--- a/lib/minga_editor/frontend/emit/context.ex
+++ b/lib/minga_editor/frontend/emit/context.ex
@@ -27,7 +27,7 @@ defmodule MingaEditor.Frontend.Emit.Context do
   @type t :: %__MODULE__{
           port_manager: pid(),
           capabilities: Capabilities.t(),
-          theme: Theme.t(),
+          theme: Theme.t() | nil,
           font_registry: FontRegistry.t(),
           windows: Windows.t(),
           layout: Layout.t(),

--- a/lib/minga_editor/render_model/ui/agent_chat_builder.ex
+++ b/lib/minga_editor/render_model/ui/agent_chat_builder.ex
@@ -7,7 +7,9 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
   alias MingaAgent.TurnUsage
   alias MingaEditor.Agent.SemanticUI.Registry, as: SemanticUIRegistry
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Agent.View.PromptRenderWindow
+  alias MingaEditor.UI.Theme
   alias Minga.Buffer
   alias Minga.Editing.Scroll
   alias Minga.RenderModel.UI.AgentChat
@@ -51,7 +53,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
     inner_width = max(ctx.viewport.cols - 10, 20)
     visible_rows = PromptRenderWindow.visible_rows(panel, inner_width)
 
-    {messages_with_ids, styled_cache} = displayed_messages_for_model(panel, session)
+    {messages_with_ids, styled_cache} = displayed_messages_for_model(panel, session, ctx.theme)
     pending_approval = ctx.shell_state.agent.pending_approval
 
     gui_messages =
@@ -97,6 +99,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
     {styled, plain} =
       Enum.reduce(messages, {0, 0}, fn
         {_, {:styled_assistant, _}}, {s, p} -> {s + 1, p}
+        {_, {:assistant_markdown, _}}, {s, p} -> {s + 1, p}
         {_, {:styled_tool_call, _, _}}, {s, p} -> {s + 1, p}
         {_, {:assistant, _}}, {s, p} -> {s, p + 1}
         _, acc -> acc
@@ -140,12 +143,26 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
     :exit, _ -> ""
   end
 
-  @spec displayed_messages_for_model(MingaEditor.Agent.UIState.Panel.t(), pid()) ::
+  @spec displayed_messages_for_model(MingaEditor.Agent.UIState.Panel.t(), pid(), Theme.t() | nil) ::
           {[{pos_integer(), term()}], [term()] | nil}
-  defp displayed_messages_for_model(panel, session) do
+  defp displayed_messages_for_model(panel, session, theme) do
     pairs = displayed_message_pairs(panel, session)
-    visible_message_slice(panel, pairs, panel.cached_styled_messages)
+
+    styled_cache =
+      if panel.cached_styled_fingerprint == styled_cache_fingerprint(theme) do
+        panel.cached_styled_messages
+      else
+        nil
+      end
+
+    visible_message_slice(panel, pairs, styled_cache)
   end
+
+  @spec styled_cache_fingerprint(Theme.t() | nil) :: non_neg_integer()
+  defp styled_cache_fingerprint(nil), do: 0
+
+  defp styled_cache_fingerprint(%Theme{syntax: syntax}),
+    do: Panel.styled_cache_fingerprint(syntax)
 
   @spec displayed_message_pairs(MingaEditor.Agent.UIState.Panel.t(), pid()) :: [
           {pos_integer(), term()}
@@ -235,16 +252,34 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
   defp maybe_style_message({{id, {:assistant, _text} = msg}, nil}, _pending_approval),
     do: {id, msg}
 
-  defp maybe_style_message({{id, {:assistant, _text}}, styled_lines}, _pending_approval),
-    do: {id, {:styled_assistant, styled_lines}}
+  defp maybe_style_message(
+         {{id, {:assistant, _text}}, %{markdown_blocks: blocks}},
+         _pending_approval
+       )
+       when is_list(blocks) and blocks != [] do
+    {id, {:assistant_markdown, blocks}}
+  end
 
-  defp maybe_style_message({{id, {:tool_call, tc} = msg}, styled_lines}, pending_approval) do
+  defp maybe_style_message(
+         {{id, {:assistant, _text}}, %{styled_lines: styled_lines}},
+         _pending_approval
+       )
+       when is_list(styled_lines) do
+    {id, {:styled_assistant, styled_lines}}
+  end
+
+  defp maybe_style_message({{id, {:assistant, _text}}, styled_lines}, _pending_approval)
+       when is_list(styled_lines) do
+    {id, {:styled_assistant, styled_lines}}
+  end
+
+  defp maybe_style_message({{id, {:tool_call, tc} = msg}, cache_entry}, pending_approval) do
     case maybe_inline_approval({id, msg}, pending_approval) do
       {^id, {:approval_tool_call, _tc, _approval}} = approval_message ->
         approval_message
 
-      {^id, {:tool_call, _tc}} when is_list(styled_lines) ->
-        {id, {:styled_tool_call, tc, styled_lines}}
+      {^id, {:tool_call, _tc}} ->
+        maybe_styled_tool_call(id, tc, cache_entry, msg)
 
       unchanged ->
         unchanged
@@ -252,6 +287,19 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
   end
 
   defp maybe_style_message({{id, msg}, _cache_entry}, _pending_approval), do: {id, msg}
+
+  @spec maybe_styled_tool_call(pos_integer(), ToolCall.t(), term(), term()) ::
+          {pos_integer(), term()}
+  defp maybe_styled_tool_call(id, tc, %{styled_lines: styled_lines}, _fallback)
+       when is_list(styled_lines) do
+    {id, {:styled_tool_call, tc, styled_lines}}
+  end
+
+  defp maybe_styled_tool_call(id, tc, styled_lines, _fallback) when is_list(styled_lines) do
+    {id, {:styled_tool_call, tc, styled_lines}}
+  end
+
+  defp maybe_styled_tool_call(id, _tc, _cache_entry, fallback), do: {id, fallback}
 
   @spec maybe_inline_approval({pos_integer(), term()}, map() | nil) :: {pos_integer(), term()}
   defp maybe_inline_approval({id, {:tool_call, tc}}, %{tool_call_id: tool_call_id} = approval)
@@ -280,6 +328,8 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
 
   defp to_core_body({:styled_tool_call, %ToolCall{} = tc, styled_lines}),
     do: {:styled_tool_call, tool_call_view(tc), styled_lines}
+
+  defp to_core_body({:assistant_markdown, blocks}), do: {:assistant_markdown, blocks}
 
   defp to_core_body({:approval_tool_call, %ToolCall{} = tc, approval}),
     do: {:approval_tool_call, approval_view(tc, approval)}

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -3160,6 +3160,119 @@ private func decodeLegacyChatMessages(data: Data, start: Int, end: Int, remainin
     throw ProtocolDecodeError.malformed
 }
 
+private func decodeAgentStyledLines(data: Data, start: Int, end: Int) throws -> ([[Wire.StyledTextRun]], Int) {
+    guard end >= start + 2 else { throw ProtocolDecodeError.malformed }
+    let lineCount = Int(readU16(data, start))
+    var lines: [[Wire.StyledTextRun]] = []
+    lines.reserveCapacity(lineCount)
+    var pos = start + 2
+    for _ in 0..<lineCount {
+        guard end >= pos + 2 else { throw ProtocolDecodeError.malformed }
+        let runCount = Int(readU16(data, pos))
+        var runs: [Wire.StyledTextRun] = []
+        runs.reserveCapacity(runCount)
+        pos += 2
+        for _ in 0..<runCount {
+            guard end >= pos + 9 else { throw ProtocolDecodeError.malformed }
+            let textLen = Int(readU16(data, pos))
+            guard end >= pos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
+            let runText = String(data: data[(pos + 2)..<(pos + 2 + textLen)], encoding: .utf8) ?? ""
+            let fgOff = pos + 2 + textLen
+            let flags = data[fgOff + 6]
+            var nextRunPos = fgOff + 7
+            var linkURL: String? = nil
+            if (flags & 0x08) != 0 {
+                guard end >= nextRunPos + 2 else { throw ProtocolDecodeError.malformed }
+                let urlLen = Int(readU16(data, nextRunPos))
+                guard end >= nextRunPos + 2 + urlLen else { throw ProtocolDecodeError.malformed }
+                guard let decodedLinkURL = String(data: data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+                linkURL = decodedLinkURL
+                nextRunPos += 2 + urlLen
+            }
+            runs.append(Wire.StyledTextRun(
+                text: runText,
+                fgR: data[fgOff], fgG: data[fgOff + 1], fgB: data[fgOff + 2],
+                bgR: data[fgOff + 3], bgG: data[fgOff + 4], bgB: data[fgOff + 5],
+                bold: (flags & 0x01) != 0,
+                italic: (flags & 0x02) != 0,
+                underline: (flags & 0x04) != 0,
+                code: (flags & 0x10) != 0,
+                linkURL: linkURL
+            ))
+            pos = nextRunPos
+        }
+        lines.append(runs)
+    }
+    return (lines, pos)
+}
+
+private func decodeAgentMarkdownBlocks(data: Data, start: Int, end: Int) throws -> ([Wire.AgentMarkdownBlock], Int) {
+    guard end >= start + 2 else { throw ProtocolDecodeError.malformed }
+    let blockCount = Int(readU16(data, start))
+    var blocks: [Wire.AgentMarkdownBlock] = []
+    blocks.reserveCapacity(blockCount)
+    var pos = start + 2
+    for _ in 0..<blockCount {
+        guard end >= pos + 6 else { throw ProtocolDecodeError.malformed }
+        let blockID = readU32(data, pos)
+        let rawKind = data[pos + 4]
+        let flags = data[pos + 5]
+        guard let kind = Wire.AgentMarkdownBlockKind(rawValue: rawKind) else { throw ProtocolDecodeError.malformed }
+        pos += 6
+        var lines: [[Wire.StyledTextRun]] = []
+        var level: UInt8 = 0
+        var indent: UInt8 = 0
+        var ordered = false
+        var ordinal: UInt32 = 0
+        var height: UInt8 = 1
+        var language = ""
+        var label = ""
+        var targetPath = ""
+        var capabilityFlags: UInt8 = 0
+
+        switch kind {
+        case .paragraph, .blockquote:
+            (lines, pos) = try decodeAgentStyledLines(data: data, start: pos, end: end)
+        case .heading:
+            guard end >= pos + 1 else { throw ProtocolDecodeError.malformed }
+            level = data[pos]
+            (lines, pos) = try decodeAgentStyledLines(data: data, start: pos + 1, end: end)
+        case .listItem:
+            guard end >= pos + 6 else { throw ProtocolDecodeError.malformed }
+            indent = data[pos]
+            ordered = data[pos + 1] != 0
+            ordinal = readU32(data, pos + 2)
+            (lines, pos) = try decodeAgentStyledLines(data: data, start: pos + 6, end: end)
+        case .rule:
+            break
+        case .spacer:
+            guard end >= pos + 1 else { throw ProtocolDecodeError.malformed }
+            height = data[pos]
+            pos += 1
+        case .codeBlock:
+            language = try readRequiredString16(data: data, pos: &pos, end: end)
+            label = try readRequiredString16(data: data, pos: &pos, end: end)
+            targetPath = try readRequiredString16(data: data, pos: &pos, end: end)
+            guard end >= pos + 1 else { throw ProtocolDecodeError.malformed }
+            capabilityFlags = data[pos]
+            pos += 1
+            (lines, pos) = try decodeAgentStyledLines(data: data, start: pos, end: end)
+        }
+
+        blocks.append(Wire.AgentMarkdownBlock(id: blockID, kind: kind, flags: flags, lines: lines, level: level, indent: indent, ordered: ordered, ordinal: ordinal, height: height, language: language, label: label, targetPath: targetPath, capabilityFlags: capabilityFlags))
+    }
+    return (blocks, pos)
+}
+
+private func readRequiredString16(data: Data, pos: inout Int, end: Int) throws -> String {
+    guard end >= pos + 2 else { throw ProtocolDecodeError.malformed }
+    let length = Int(readU16(data, pos))
+    guard end >= pos + 2 + length else { throw ProtocolDecodeError.malformed }
+    let value = String(data: data[(pos + 2)..<(pos + 2 + length)], encoding: .utf8) ?? ""
+    pos += 2 + length
+    return value
+}
+
 private func decodeChatMessageCandidates(data: Data, start: Int, end: Int) throws -> [DecodedChatMessageCandidate] {
     guard start + 5 <= end else { throw ProtocolDecodeError.malformed }
 
@@ -3360,6 +3473,10 @@ private func decodeChatMessageCandidates(data: Data, start: Int, end: Int) throw
         let stcMessageWithoutAuto = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: 0, durationMs: stcDuration, resultLines: stcLines, previewKind: 0, previewLines: []))
         stcCandidates.append(DecodedChatMessageCandidate(message: stcMessageWithoutAuto, nextOffset: stcBaseOffset))
         return stcCandidates
+
+    case 0x0A: // assistant_markdown
+        let (blocks, next) = try decodeAgentMarkdownBlocks(data: data, start: pos + 1, end: end)
+        return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .assistantMarkdown(blocks: blocks)), nextOffset: next)]
 
     case 0x09: // approval_tool_call
         guard end >= pos + 8 else { throw ProtocolDecodeError.malformed }

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -3281,6 +3281,7 @@ private func decodeChatMessageCandidates(data: Data, start: Int, end: Int) throw
                     bold: (flags & 0x01) != 0,
                     italic: (flags & 0x02) != 0,
                     underline: (flags & 0x04) != 0,
+                    code: (flags & 0x10) != 0,
                     linkURL: linkURL
                 ))
                 rPos = nextRunPos
@@ -3335,6 +3336,7 @@ private func decodeChatMessageCandidates(data: Data, start: Int, end: Int) throw
                     bold: (flags & 0x01) != 0,
                     italic: (flags & 0x02) != 0,
                     underline: (flags & 0x04) != 0,
+                    code: (flags & 0x10) != 0,
                     linkURL: linkURL
                 ))
                 stcPos = nextRunPos

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -578,9 +578,10 @@ enum Wire {
         let bold: Bool
         let italic: Bool
         let underline: Bool
+        let code: Bool
         let linkURL: String?
 
-        init(text: String, fgR: UInt8, fgG: UInt8, fgB: UInt8, bgR: UInt8, bgG: UInt8, bgB: UInt8, bold: Bool, italic: Bool, underline: Bool, linkURL: String? = nil) {
+        init(text: String, fgR: UInt8, fgG: UInt8, fgB: UInt8, bgR: UInt8, bgG: UInt8, bgB: UInt8, bold: Bool, italic: Bool, underline: Bool, code: Bool = false, linkURL: String? = nil) {
             self.text = text
             self.fgR = fgR
             self.fgG = fgG
@@ -591,6 +592,7 @@ enum Wire {
             self.bold = bold
             self.italic = italic
             self.underline = underline
+            self.code = code
             self.linkURL = linkURL
         }
     }

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -603,6 +603,36 @@ enum Wire {
         let bindings: [(key: String, description: String)]
     }
 
+    /// Semantic markdown block kind from gui_agent_chat assistant_markdown messages.
+    enum AgentMarkdownBlockKind: UInt8, Sendable {
+        case paragraph = 0x01
+        case heading = 0x02
+        case listItem = 0x03
+        case blockquote = 0x04
+        case rule = 0x05
+        case spacer = 0x06
+        case codeBlock = 0x07
+    }
+
+    /// BEAM-authored semantic markdown block. Frontends render this structure directly and never infer block semantics from styled-run flags.
+    struct AgentMarkdownBlock: Sendable, Identifiable {
+        let id: UInt32
+        let kind: AgentMarkdownBlockKind
+        let flags: UInt8
+        let lines: [[StyledTextRun]]
+        let level: UInt8
+        let indent: UInt8
+        let ordered: Bool
+        let ordinal: UInt32
+        let height: UInt8
+        let language: String
+        let label: String
+        let targetPath: String
+        let capabilityFlags: UInt8
+
+        var isComplete: Bool { flags & 0x01 != 0 }
+    }
+
     /// A chat message from gui_agent_chat, with a stable BEAM-assigned ID.
     struct ChatMessage: Sendable {
         /// Stable uint32 ID assigned by the BEAM. Persists across streaming updates.
@@ -616,6 +646,8 @@ enum Wire {
         case assistant(text: String)
         /// Assistant message with pre-styled text runs from tree-sitter.
         case styledAssistant(lines: [[StyledTextRun]])
+        /// Assistant message with BEAM-authored semantic markdown blocks.
+        case assistantMarkdown(blocks: [AgentMarkdownBlock])
         case thinking(text: String, collapsed: Bool)
         case toolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String, previewKind: UInt8, previewLines: [String])
         /// Tool call with pre-styled result runs from tree-sitter.

--- a/macos/Sources/Views/AgentChatState.swift
+++ b/macos/Sources/Views/AgentChatState.swift
@@ -8,6 +8,8 @@ enum ChatMessageEntry: Identifiable {
     case assistant(id: Int, text: String)
     /// Assistant message with pre-styled text runs from the BEAM (tree-sitter or markdown parser).
     case styledAssistant(id: Int, lines: [[Wire.StyledTextRun]])
+    /// Assistant message with BEAM-authored semantic markdown blocks.
+    case assistantMarkdown(id: Int, blocks: [Wire.AgentMarkdownBlock])
     case thinking(id: Int, text: String, collapsed: Bool)
     case toolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String, previewKind: UInt8, previewLines: [String])
     case styledToolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, resultLines: [[Wire.StyledTextRun]], previewKind: UInt8, previewLines: [String])
@@ -18,6 +20,7 @@ enum ChatMessageEntry: Identifiable {
     var id: Int {
         switch self {
         case .user(let id, _), .assistant(let id, _), .styledAssistant(let id, _),
+             .assistantMarkdown(let id, _),
              .thinking(let id, _, _),
              .toolCall(let id, _, _, _, _, _, _, _, _, _, _),
              .styledToolCall(let id, _, _, _, _, _, _, _, _, _, _),
@@ -133,6 +136,8 @@ final class AgentChatState {
                 return .assistant(id: id, text: text)
             case .styledAssistant(let lines):
                 return .styledAssistant(id: id, lines: lines)
+            case .assistantMarkdown(let blocks):
+                return .assistantMarkdown(id: id, blocks: blocks)
             case .thinking(let text, let collapsed):
                 return .thinking(id: id, text: text, collapsed: collapsed)
             case .toolCall(let name, let summary, let st, let isError, let collapsed, let autoApprovedScope, let duration, let result, let previewKind, let previewLines):

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -16,6 +16,18 @@ private struct ScrollViewHeightKey: PreferenceKey {
     }
 }
 
+private enum AssistantLineGroup: Identifiable {
+    case prose(id: Int, lines: [[Wire.StyledTextRun]])
+    case code(id: Int, label: String?, lines: [[Wire.StyledTextRun]])
+
+    var id: Int {
+        switch self {
+        case .prose(let id, _), .code(let id, _, _):
+            return id
+        }
+    }
+}
+
 struct AgentChatView: View {
     let state: AgentChatState
     let theme: ThemeColors
@@ -404,9 +416,18 @@ struct AgentChatView: View {
     @ViewBuilder
     private func styledAssistantBlock(_ lines: [[Wire.StyledTextRun]]) -> some View {
         HStack {
-            VStack(alignment: .leading, spacing: 2) {
-                ForEach(Array(lines.enumerated()), id: \.offset) { _, runs in
-                    styledLineView(runs, baseFontSize: 13, monospaced: false)
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(groupAssistantLines(lines)) { group in
+                    switch group {
+                    case .prose(_, let proseLines):
+                        VStack(alignment: .leading, spacing: 2) {
+                            ForEach(Array(proseLines.enumerated()), id: \.offset) { _, runs in
+                                styledLineView(runs, baseFontSize: 13, monospaced: false)
+                            }
+                        }
+                    case .code(_, let label, let codeLines):
+                        codeBlockView(label: label, lines: codeLines)
+                    }
                 }
             }
             Spacer(minLength: 40)
@@ -436,14 +457,15 @@ struct AgentChatView: View {
                     blue: Double(run.bgB) / 255.0
                 )
             }
-            let design: Font.Design = monospaced ? .monospaced : .default
+            let runMonospaced = monospaced || run.code
+            let design: Font.Design = runMonospaced ? .monospaced : .default
             if run.bold && run.italic {
                 attr.font = .system(size: baseFontSize, weight: .bold, design: design).italic()
             } else if run.bold {
                 attr.font = .system(size: baseFontSize, weight: .bold, design: design)
             } else if run.italic {
                 attr.font = .system(size: baseFontSize, design: design).italic()
-            } else if monospaced {
+            } else if runMonospaced {
                 attr.font = .system(size: baseFontSize, design: .monospaced)
             }
             if run.underline {
@@ -479,9 +501,100 @@ struct AgentChatView: View {
 
     private func shouldScrollHorizontally(_ runs: [Wire.StyledTextRun]) -> Bool {
         let textRuns = runs.filter { !$0.text.isEmpty }
-        return !textRuns.isEmpty && textRuns.allSatisfy { run in
-            run.bgR != 0 || run.bgG != 0 || run.bgB != 0
+        return !textRuns.isEmpty && textRuns.allSatisfy(\.code)
+    }
+
+    @ViewBuilder
+    private func codeBlockView(label: String?, lines: [[Wire.StyledTextRun]]) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let label, !label.isEmpty {
+                HStack {
+                    Spacer()
+                    Text(label)
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(theme.agentTextFg.opacity(0.45))
+                        .padding(.bottom, 4)
+                }
+            }
+
+            ScrollView(.horizontal) {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(lines.enumerated()), id: \.offset) { _, runs in
+                        styledLineView(runs, baseFontSize: 12, monospaced: true)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
         }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.agentCodeBg)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(theme.agentToolBorder.opacity(0.25), lineWidth: 1)
+        )
+    }
+
+    private func groupAssistantLines(_ lines: [[Wire.StyledTextRun]]) -> [AssistantLineGroup] {
+        var groups: [AssistantLineGroup] = []
+        var prose: [[Wire.StyledTextRun]] = []
+        var index = 0
+        var groupId = 0
+
+        func flushProse() {
+            guard !prose.isEmpty else { return }
+            groups.append(.prose(id: groupId, lines: prose))
+            groupId += 1
+            prose.removeAll(keepingCapacity: true)
+        }
+
+        while index < lines.count {
+            let line = lines[index]
+            if lineIsCodeBlockContent(line) {
+                let label = codeBlockLabel(from: prose.last)
+                if label != nil {
+                    _ = prose.popLast()
+                }
+                flushProse()
+
+                var codeLines: [[Wire.StyledTextRun]] = []
+                while index < lines.count && lineIsCodeBlockContent(lines[index]) {
+                    codeLines.append(lines[index])
+                    index += 1
+                }
+                if index < lines.count && lineLooksLikeCodeFooter(lines[index]) {
+                    index += 1
+                }
+                groups.append(.code(id: groupId, label: label, lines: codeLines))
+                groupId += 1
+            } else {
+                prose.append(line)
+                index += 1
+            }
+        }
+
+        flushProse()
+        return groups
+    }
+
+    private func lineIsCodeBlockContent(_ runs: [Wire.StyledTextRun]) -> Bool {
+        let textRuns = runs.filter { !$0.text.isEmpty }
+        return !textRuns.isEmpty && textRuns.allSatisfy(\.code)
+    }
+
+    private func codeBlockLabel(from runs: [Wire.StyledTextRun]?) -> String? {
+        guard let runs else { return nil }
+        let text = runs.map(\.text).joined().trimmingCharacters(in: .whitespaces)
+        guard text.hasPrefix("┌─") else { return nil }
+        let withoutPrefix = text.dropFirst(2).trimmingCharacters(in: .whitespaces)
+        let label = withoutPrefix.trimmingCharacters(in: CharacterSet(charactersIn: "─ "))
+        return label.isEmpty ? nil : label
+    }
+
+    private func lineLooksLikeCodeFooter(_ runs: [Wire.StyledTextRun]) -> Bool {
+        runs.map(\.text).joined().trimmingCharacters(in: .whitespaces).hasPrefix("└")
     }
 
     private func safeLinkURL(_ value: String?) -> URL? {

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -16,18 +16,6 @@ private struct ScrollViewHeightKey: PreferenceKey {
     }
 }
 
-private enum AssistantLineGroup: Identifiable {
-    case prose(id: Int, lines: [[Wire.StyledTextRun]])
-    case code(id: Int, label: String?, lines: [[Wire.StyledTextRun]])
-
-    var id: Int {
-        switch self {
-        case .prose(let id, _), .code(let id, _, _):
-            return id
-        }
-    }
-}
-
 struct AgentChatView: View {
     let state: AgentChatState
     let theme: ThemeColors
@@ -357,6 +345,8 @@ struct AgentChatView: View {
             assistantBlock(text)
         case .styledAssistant(_, let lines):
             styledAssistantBlock(lines)
+        case .assistantMarkdown(_, let blocks):
+            assistantMarkdownBlock(blocks)
         case .thinking(_, let text, let collapsed):
             thinkingBlock(text, collapsed: collapsed)
         case .toolCall(_, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let result, let previewKind, let previewLines):
@@ -416,22 +406,103 @@ struct AgentChatView: View {
     @ViewBuilder
     private func styledAssistantBlock(_ lines: [[Wire.StyledTextRun]]) -> some View {
         HStack {
-            VStack(alignment: .leading, spacing: 6) {
-                ForEach(groupAssistantLines(lines)) { group in
-                    switch group {
-                    case .prose(_, let proseLines):
-                        VStack(alignment: .leading, spacing: 2) {
-                            ForEach(Array(proseLines.enumerated()), id: \.offset) { _, runs in
-                                styledLineView(runs, baseFontSize: 13, monospaced: false)
-                            }
-                        }
-                    case .code(_, let label, let codeLines):
-                        codeBlockView(label: label, lines: codeLines)
-                    }
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(Array(lines.enumerated()), id: \.offset) { _, runs in
+                    styledLineView(runs, baseFontSize: 13, monospaced: false)
                 }
             }
             Spacer(minLength: 40)
         }
+    }
+
+    @ViewBuilder
+    private func assistantMarkdownBlock(_ blocks: [Wire.AgentMarkdownBlock]) -> some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(blocks) { block in
+                    markdownBlockView(block)
+                }
+            }
+            Spacer(minLength: 40)
+        }
+    }
+
+    @ViewBuilder
+    private func markdownBlockView(_ block: Wire.AgentMarkdownBlock) -> some View {
+        switch block.kind {
+        case .paragraph:
+            markdownLines(block.lines, baseFontSize: 13, monospaced: false)
+        case .heading:
+            markdownLines(block.lines, baseFontSize: block.level == 1 ? 15 : 14, monospaced: false)
+        case .listItem:
+            markdownLines(block.lines, baseFontSize: 13, monospaced: false)
+                .padding(.leading, CGFloat(block.indent) * 12)
+        case .blockquote:
+            markdownLines(block.lines, baseFontSize: 13, monospaced: false)
+                .padding(.leading, 8)
+                .overlay(alignment: .leading) {
+                    Rectangle().fill(theme.agentToolBorder.opacity(0.35)).frame(width: 2)
+                }
+        case .rule:
+            Rectangle().fill(theme.agentToolBorder.opacity(0.25)).frame(height: 1)
+        case .spacer:
+            Spacer().frame(height: CGFloat(max(block.height, 1)) * 6)
+        case .codeBlock:
+            agentCodeCard(block)
+        }
+    }
+
+    @ViewBuilder
+    private func markdownLines(_ lines: [[Wire.StyledTextRun]], baseFontSize: CGFloat, monospaced: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, runs in
+                styledLineView(runs, baseFontSize: baseFontSize, monospaced: monospaced)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func agentCodeCard(_ block: Wire.AgentMarkdownBlock) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text(block.label.isEmpty ? "Code" : block.label)
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(theme.agentTextFg.opacity(0.55))
+                if !block.targetPath.isEmpty {
+                    Text(block.targetPath)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(theme.agentTextFg.opacity(0.38))
+                }
+                if !block.isComplete {
+                    Text("streaming")
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(theme.agentTextFg.opacity(0.38))
+                }
+                Spacer(minLength: 0)
+            }
+
+            ScrollView(.horizontal) {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(block.lines.enumerated()), id: \.offset) { _, runs in
+                        styledLineView(runs, baseFontSize: 12, monospaced: true, allowHorizontalScroll: false)
+                            .fixedSize(horizontal: true, vertical: false)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+        }
+        .padding(8)
+        .background(RoundedRectangle(cornerRadius: 8).fill(theme.agentCodeBg))
+        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(theme.agentCodeBorder.opacity(0.35), lineWidth: 1))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(codeBlockAccessibilityLabel(block))
+        .accessibilityHint("Horizontally scrolls code content.")
+    }
+
+    private func codeBlockAccessibilityLabel(_ block: Wire.AgentMarkdownBlock) -> String {
+        let language = block.label.isEmpty ? "Code" : block.label
+        let state = block.isComplete ? "complete" : "streaming"
+        return "Code block, \(language), \(block.lines.count) lines, \(state)"
     }
 
     private func buildAttributedString(_ runs: [Wire.StyledTextRun], baseFontSize: CGFloat = 13, monospaced: Bool = false) -> AttributedString {
@@ -480,12 +551,12 @@ struct AgentChatView: View {
     }
 
     @ViewBuilder
-    private func styledLineView(_ runs: [Wire.StyledTextRun], baseFontSize: CGFloat, monospaced: Bool) -> some View {
+    private func styledLineView(_ runs: [Wire.StyledTextRun], baseFontSize: CGFloat, monospaced: Bool, allowHorizontalScroll: Bool = true) -> some View {
         if runs.isEmpty || (runs.count == 1 && runs[0].text.isEmpty) {
             Text(" ")
                 .font(.system(size: baseFontSize, design: monospaced ? .monospaced : .default))
                 .foregroundStyle(.clear)
-        } else if shouldScrollHorizontally(runs) {
+        } else if allowHorizontalScroll && shouldScrollHorizontally(runs) {
             ScrollView(.horizontal) {
                 Text(buildAttributedString(runs, baseFontSize: baseFontSize, monospaced: monospaced))
                     .font(.system(size: baseFontSize, design: monospaced ? .monospaced : .default))
@@ -502,99 +573,6 @@ struct AgentChatView: View {
     private func shouldScrollHorizontally(_ runs: [Wire.StyledTextRun]) -> Bool {
         let textRuns = runs.filter { !$0.text.isEmpty }
         return !textRuns.isEmpty && textRuns.allSatisfy(\.code)
-    }
-
-    @ViewBuilder
-    private func codeBlockView(label: String?, lines: [[Wire.StyledTextRun]]) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            if let label, !label.isEmpty {
-                HStack {
-                    Spacer()
-                    Text(label)
-                        .font(.system(size: 10, weight: .medium, design: .monospaced))
-                        .foregroundStyle(theme.agentTextFg.opacity(0.45))
-                        .padding(.bottom, 4)
-                }
-            }
-
-            ScrollView(.horizontal) {
-                VStack(alignment: .leading, spacing: 2) {
-                    ForEach(Array(lines.enumerated()), id: \.offset) { _, runs in
-                        styledLineView(runs, baseFontSize: 12, monospaced: true)
-                    }
-                }
-                .padding(.vertical, 2)
-            }
-        }
-        .padding(8)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(theme.agentCodeBg)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .strokeBorder(theme.agentToolBorder.opacity(0.25), lineWidth: 1)
-        )
-    }
-
-    private func groupAssistantLines(_ lines: [[Wire.StyledTextRun]]) -> [AssistantLineGroup] {
-        var groups: [AssistantLineGroup] = []
-        var prose: [[Wire.StyledTextRun]] = []
-        var index = 0
-        var groupId = 0
-
-        func flushProse() {
-            guard !prose.isEmpty else { return }
-            groups.append(.prose(id: groupId, lines: prose))
-            groupId += 1
-            prose.removeAll(keepingCapacity: true)
-        }
-
-        while index < lines.count {
-            let line = lines[index]
-            if lineIsCodeBlockContent(line) {
-                let label = codeBlockLabel(from: prose.last)
-                if label != nil {
-                    _ = prose.popLast()
-                }
-                flushProse()
-
-                var codeLines: [[Wire.StyledTextRun]] = []
-                while index < lines.count && lineIsCodeBlockContent(lines[index]) {
-                    codeLines.append(lines[index])
-                    index += 1
-                }
-                if index < lines.count && lineLooksLikeCodeFooter(lines[index]) {
-                    index += 1
-                }
-                groups.append(.code(id: groupId, label: label, lines: codeLines))
-                groupId += 1
-            } else {
-                prose.append(line)
-                index += 1
-            }
-        }
-
-        flushProse()
-        return groups
-    }
-
-    private func lineIsCodeBlockContent(_ runs: [Wire.StyledTextRun]) -> Bool {
-        let textRuns = runs.filter { !$0.text.isEmpty }
-        return !textRuns.isEmpty && textRuns.allSatisfy(\.code)
-    }
-
-    private func codeBlockLabel(from runs: [Wire.StyledTextRun]?) -> String? {
-        guard let runs else { return nil }
-        let text = runs.map(\.text).joined().trimmingCharacters(in: .whitespaces)
-        guard text.hasPrefix("┌─") else { return nil }
-        let withoutPrefix = text.dropFirst(2).trimmingCharacters(in: .whitespaces)
-        let label = withoutPrefix.trimmingCharacters(in: CharacterSet(charactersIn: "─ "))
-        return label.isEmpty ? nil : label
-    }
-
-    private func lineLooksLikeCodeFooter(_ runs: [Wire.StyledTextRun]) -> Bool {
-        runs.map(\.text).joined().trimmingCharacters(in: .whitespaces).hasPrefix("└")
     }
 
     private func safeLinkURL(_ value: String?) -> URL? {

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -370,19 +370,27 @@ func chatMessageToJSON(_ msg: Wire.ChatMessage) -> [String: Any] {
     case .assistant(let text):
         result["kind"] = "assistant"; result["text"] = text
     case .styledAssistant(let lines):
-        let linesJSON: [[Any]] = lines.map { runs in
-            runs.map { run -> [String: Any] in
-                return [
-                    "text": run.text,
-                    "fg": [Int(run.fgR), Int(run.fgG), Int(run.fgB)],
-                    "bg": [Int(run.bgR), Int(run.bgG), Int(run.bgB)],
-                    "bold": run.bold,
-                    "italic": run.italic,
-                    "underline": run.underline
-                ]
-            }
+        result["kind"] = "styled_assistant"; result["lines"] = styledLinesToJSON(lines)
+    case .assistantMarkdown(let blocks):
+        result["kind"] = "assistant_markdown"
+        result["blocks"] = blocks.map { block -> [String: Any] in
+            return [
+                "id": Int(block.id),
+                "kind": Int(block.kind.rawValue),
+                "flags": Int(block.flags),
+                "lines": styledLinesToJSON(block.lines),
+                "level": Int(block.level),
+                "indent": Int(block.indent),
+                "ordered": block.ordered,
+                "ordinal": Int(block.ordinal),
+                "height": Int(block.height),
+                "language": block.language,
+                "label": block.label,
+                "target_path": block.targetPath,
+                "capability_flags": Int(block.capabilityFlags),
+                "is_complete": block.isComplete
+            ]
         }
-        result["kind"] = "styled_assistant"; result["lines"] = linesJSON
     case .thinking(let text, let collapsed):
         result["kind"] = "thinking"; result["text"] = text; result["collapsed"] = collapsed
     case .toolCall(let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let durationMs, let resultStr, let previewKind, let previewLines):
@@ -392,18 +400,7 @@ func chatMessageToJSON(_ msg: Wire.ChatMessage) -> [String: Any] {
         result["duration_ms"] = Int(durationMs); result["result"] = resultStr
         result["preview_kind"] = Int(previewKind); result["preview_lines"] = previewLines
     case .styledToolCall(let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let durationMs, let resultLines, let previewKind, let previewLines):
-        let linesJSON: [[Any]] = resultLines.map { runs in
-            runs.map { run -> [String: Any] in
-                return [
-                    "text": run.text,
-                    "fg": [Int(run.fgR), Int(run.fgG), Int(run.fgB)],
-                    "bg": [Int(run.bgR), Int(run.bgG), Int(run.bgB)],
-                    "bold": run.bold,
-                    "italic": run.italic,
-                    "underline": run.underline
-                ]
-            }
-        }
+        let linesJSON = styledLinesToJSON(resultLines)
         result["kind"] = "styled_tool_call"; result["name"] = name; result["summary"] = summary
         result["status"] = Int(status); result["is_error"] = isError; result["collapsed"] = collapsed
         result["auto_approved_scope"] = Int(autoApprovedScope)
@@ -424,6 +421,21 @@ func chatMessageToJSON(_ msg: Wire.ChatMessage) -> [String: Any] {
         result["cost_micros"] = Int(costMicros)
     }
     return result
+}
+
+func styledLinesToJSON(_ lines: [[Wire.StyledTextRun]]) -> [[Any]] {
+    return lines.map { runs in
+        runs.map { run -> [String: Any] in
+            return [
+                "text": run.text,
+                "fg": [Int(run.fgR), Int(run.fgG), Int(run.fgB)],
+                "bg": [Int(run.bgR), Int(run.bgG), Int(run.bgB)],
+                "bold": run.bold,
+                "italic": run.italic,
+                "underline": run.underline
+            ]
+        }
+    }
 }
 
 // MARK: - Main loop

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -2263,7 +2263,7 @@ struct GUIAgentChatDecoderTests {
         // Line 1: 2 runs
         appendU16(&msgs, 2)
         appendString16(&msgs, "def ")
-        appendRGB(&msgs, 0x51, 0xAF, 0xEF); appendRGB(&msgs, 0x28, 0x2C, 0x34); msgs.append(0x01) // bold
+        appendRGB(&msgs, 0x51, 0xAF, 0xEF); appendRGB(&msgs, 0x28, 0x2C, 0x34); msgs.append(0x11) // bold + code
         appendString16(&msgs, "hello")
         appendRGB(&msgs, 0x98, 0xBE, 0x65); appendRGB(&msgs, 0x28, 0x2C, 0x34); msgs.append(0x02) // italic
         // Line 2: 1 run
@@ -2281,8 +2281,10 @@ struct GUIAgentChatDecoderTests {
         #expect(lines.count == 2)
         #expect(lines[0][0].text == "def ")
         #expect(lines[0][0].bold == true)
+        #expect(lines[0][0].code == true)
         #expect(lines[0][1].text == "hello")
         #expect(lines[0][1].italic == true)
+        #expect(lines[0][1].code == false)
         #expect(lines[1][0].text == "  :ok")
         #expect(lines[1][0].underline == true)
     }

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -2289,6 +2289,45 @@ struct GUIAgentChatDecoderTests {
         #expect(lines[1][0].underline == true)
     }
 
+    @Test("Decode gui_agent_chat with assistant_markdown code block")
+    func decodeAssistantMarkdownCodeBlock() throws {
+        var msgs = Data()
+        appendU32(&msgs, 42)
+        msgs.append(0x0A)
+        appendU16(&msgs, 1)
+        appendU32(&msgs, 77)
+        msgs.append(0x07)
+        msgs.append(0x01)
+        appendString16(&msgs, "swift")
+        appendString16(&msgs, "Swift")
+        appendString16(&msgs, "macos/App.swift")
+        msgs.append(0x01)
+        appendU16(&msgs, 2)
+        appendU16(&msgs, 1)
+        appendString16(&msgs, "")
+        appendRGB(&msgs, 0x98, 0xBE, 0x65); appendRGB(&msgs, 0x21, 0x24, 0x2B); msgs.append(0x10)
+        appendU16(&msgs, 1)
+        appendString16(&msgs, "print(\"hi\")")
+        appendRGB(&msgs, 0x98, 0xBE, 0x65); appendRGB(&msgs, 0x21, 0x24, 0x2B); msgs.append(0x10)
+
+        let data = buildChatData(model: "claude", messages: buildMessagesPayload(count: 1, msgs))
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+
+        guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
+        guard messages.count == 1 else { Issue.record("Expected 1 message"); return }
+        guard case .assistantMarkdown(let blocks) = messages[0].content else { Issue.record("Expected .assistantMarkdown"); return }
+        #expect(blocks.count == 1)
+        #expect(blocks[0].kind == .codeBlock)
+        #expect(blocks[0].isComplete == true)
+        #expect(blocks[0].language == "swift")
+        #expect(blocks[0].label == "Swift")
+        #expect(blocks[0].targetPath == "macos/App.swift")
+        #expect(blocks[0].lines.count == 2)
+        #expect(blocks[0].lines[0][0].text == "")
+        #expect(blocks[0].lines[1][0].code == true)
+    }
+
     @Test("Decode gui_agent_chat framed styled_tool_call with auto_approved followed by another message")
     func decodeFramedStyledToolCallWithAutoApprovedAndTrailingMessage() throws {
         var toolMessage = Data()

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -1139,6 +1139,59 @@ struct AgentChatViewTests {
         #expect(strings.contains("auto-approved · turn"))
     }
 
+    @Test("Styled assistant keeps decorative rails literal")
+    @MainActor func styledAssistantKeepsRailsLiteral() throws {
+        func run(_ text: String, code: Bool = false) -> Wire.StyledTextRun {
+            Wire.StyledTextRun(text: text, fgR: 0xBB, fgG: 0xC2, fgB: 0xCF, bgR: 0, bgG: 0, bgB: 0, bold: false, italic: false, underline: false, code: code)
+        }
+
+        let state = chatState(messages: [
+            .styledAssistant(id: 1, lines: [[run("┌─ python")], [run("  print(\"hi\")", code: true)], [run("└")]])
+        ])
+
+        let sut = AgentChatView(state: state, theme: ThemeColors(), isInsertMode: false, encoder: nil)
+        let body = try sut.inspect()
+        let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("┌─ python"))
+        #expect(strings.contains("└"))
+        #expect(!strings.contains("python"))
+    }
+
+    @Test("Assistant markdown renders semantic code card")
+    @MainActor func assistantMarkdownRendersCodeCard() throws {
+        func run(_ text: String, code: Bool = false) -> Wire.StyledTextRun {
+            Wire.StyledTextRun(text: text, fgR: 0x98, fgG: 0xBE, fgB: 0x65, bgR: 0x21, bgG: 0x24, bgB: 0x2B, bold: false, italic: false, underline: false, code: code)
+        }
+
+        let block = Wire.AgentMarkdownBlock(
+            id: 7,
+            kind: .codeBlock,
+            flags: 0,
+            lines: [[run("", code: true)], [run("print(\"hi\")", code: true)]],
+            level: 0,
+            indent: 0,
+            ordered: false,
+            ordinal: 0,
+            height: 1,
+            language: "swift",
+            label: "Swift",
+            targetPath: "macos/App.swift",
+            capabilityFlags: 1
+        )
+
+        let state = chatState(messages: [.assistantMarkdown(id: 1, blocks: [block])])
+        let sut = AgentChatView(state: state, theme: ThemeColors(), isInsertMode: false, encoder: nil)
+        let body = try sut.inspect()
+        let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("Swift"))
+        #expect(strings.contains("macos/App.swift"))
+        #expect(strings.contains("streaming"))
+        #expect(strings.contains("print(\"hi\")"))
+        #expect(try body.findAll(ViewType.ScrollView.self).count == 2)
+    }
+
     @Test("User message renders as bubble")
     @MainActor func userMessage() throws {
         let state = AgentChatState()

--- a/test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs
@@ -7,6 +7,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
   alias Minga.Frontend.Adapter.GUI.Caches
   alias Minga.RenderModel.UI.AgentChat
   alias Minga.RenderModel.UI.AgentChat.ApprovalView
+  alias Minga.RenderModel.UI.AgentChat.MarkdownBlock
   alias Minga.RenderModel.UI.AgentChat.PromptCompletion
   alias Minga.RenderModel.UI.AgentChat.ToolCallView
   alias Minga.RenderModel.UI.AgentChat.Usage
@@ -337,6 +338,41 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
       assert t1 == "def "
       assert fg1 == 0xFF0000
       assert flags1 == 0x11
+    end
+
+    test "assistant_markdown message encodes semantic code block payload" do
+      blocks = [
+        MarkdownBlock.paragraph(10, [
+          [{"Use ", 0xBBC2CF, 0, 0}, {"code", 0x98BE65, 0x21242B, 0x10}]
+        ]),
+        MarkdownBlock.code_block(11, "elixir", "Elixir", "lib/demo.ex", true, [
+          [{"", 0x98BE65, 0x21242B, 0x10}],
+          [{"def hello", 0x98BE65, 0x21242B, 0x10}]
+        ])
+      ]
+
+      binary = encode(%AgentChat{visible?: true, messages: [{7, {:assistant_markdown, blocks}}]})
+      assert [m1] = messages!(binary)
+
+      <<7::32, 0x0A::8, 2::16, 10::32, 0x01::8, 0::8, 1::16, 2::16, use_len::16,
+        use::binary-size(use_len), _use_fg::24, _use_bg::24, 0::8, code_len::16,
+        code::binary-size(code_len), _code_fg::24, _code_bg::24, code_flags::8, 11::32, 0x07::8,
+        0x01::8, lang_len::16, lang::binary-size(lang_len), label_len::16,
+        label::binary-size(label_len), path_len::16, path::binary-size(path_len), 0x01::8, 2::16,
+        1::16, empty_len::16, empty::binary-size(empty_len), _empty_fg::24, _empty_bg::24,
+        empty_flags::8, 1::16, line_len::16, line::binary-size(line_len), _line_fg::24,
+        _line_bg::24, line_flags::8>> = m1
+
+      assert use == "Use "
+      assert code == "code"
+      assert code_flags == 0x10
+      assert lang == "elixir"
+      assert label == "Elixir"
+      assert path == "lib/demo.ex"
+      assert empty == ""
+      assert empty_flags == 0x10
+      assert line == "def hello"
+      assert line_flags == 0x10
     end
 
     test "styled_tool_call message with sub-opcode 0x08" do

--- a/test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs
@@ -324,7 +324,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
 
     test "styled_assistant message with styled runs" do
       styled = [
-        [{"def ", 0xFF0000, 0, 0x01}, {"hello", 0xBBC2CF, 0, 0}],
+        [{"def ", 0xFF0000, 0, 0x11}, {"hello", 0xBBC2CF, 0, 0}],
         [{"  :world", 0x98BE65, 0, 0}]
       ]
 
@@ -336,7 +336,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
 
       assert t1 == "def "
       assert fg1 == 0xFF0000
-      assert flags1 == 0x01
+      assert flags1 == 0x11
     end
 
     test "styled_tool_call message with sub-opcode 0x08" do

--- a/test/minga_agent/markdown_test.exs
+++ b/test/minga_agent/markdown_test.exs
@@ -341,4 +341,42 @@ defmodule MingaAgent.MarkdownTest do
       assert Markdown.extract_code_blocks(md) == []
     end
   end
+
+  describe "parse_blocks/1" do
+    test "parses paragraphs and headings without markdown markers" do
+      assert [
+               %{kind: :heading, level: 1, text: "Title"},
+               %{kind: :paragraph, lines: ["Hello `code`"]}
+             ] = Markdown.parse_blocks("# Title\nHello `code`")
+    end
+
+    test "parses complete fenced code blocks without decorative rails" do
+      blocks = Markdown.parse_blocks("Use this:\n```elixir\ndef hello do\n  :world\nend\n```")
+
+      assert [%{kind: :paragraph}, %{kind: :code_block} = code] = blocks
+      assert code.language == "elixir"
+      assert code.complete? == true
+      assert code.lines == ["def hello do", "  :world", "end"]
+      refute Enum.any?(code.lines, &String.contains?(&1, "┌"))
+      refute Enum.any?(code.lines, &String.contains?(&1, "└"))
+    end
+
+    test "keeps blank lines inside fenced code blocks" do
+      assert [%{kind: :code_block, lines: ["one", "", "two"]}] =
+               Markdown.parse_blocks("```\none\n\ntwo\n```")
+    end
+
+    test "preserves nested list indentation" do
+      assert [
+               %{kind: :list_item, indent: 0, text: "Top"},
+               %{kind: :list_item, indent: 1, text: "Middle"},
+               %{kind: :list_item, indent: 2, text: "Deep"}
+             ] = Markdown.parse_blocks("- Top\n  - Middle\n    - Deep")
+    end
+
+    test "marks unclosed fenced code blocks incomplete for streaming" do
+      assert [%{kind: :code_block, complete?: false, lines: ["IO.puts(:hi)"]}] =
+               Markdown.parse_blocks("```elixir\nIO.puts(:hi)")
+    end
+  end
 end

--- a/test/minga_editor/agent/concurrent_sessions_test.exs
+++ b/test/minga_editor/agent/concurrent_sessions_test.exs
@@ -10,6 +10,7 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.AgentLifecycle
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
@@ -291,17 +292,58 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
       state =
         [Tab.new_agent(1, "Agent") |> Tab.set_session(session)]
         |> base_state(1)
+
+      fingerprint = Panel.styled_cache_fingerprint(state.theme.syntax)
+
+      state =
+        state
         |> AgentAccess.update_panel(fn panel ->
           %{
             panel
             | cached_display_messages: [message],
-              cached_styled_messages: cached
+              cached_styled_messages: cached,
+              cached_styled_fingerprint: fingerprint
           }
         end)
 
       updated = AgentLifecycle.update_styled_cache(state)
 
       assert AgentAccess.panel(updated).cached_styled_messages == cached
+    end
+
+    test "update_styled_cache invalidates stale styles when the theme syntax changes" do
+      message = {:assistant, "plain answer"}
+      cached = [[{"plain answer", 0xBBC2CF, 0, 0}]]
+
+      {:ok, session} = StubServer.start_link(messages: [message])
+
+      state =
+        [Tab.new_agent(1, "Agent") |> Tab.set_session(session)]
+        |> base_state(1)
+
+      old_theme = state.theme
+      new_theme = %{old_theme | syntax: Map.put(old_theme.syntax, "variable", fg: 0x123456)}
+      fingerprint = Panel.styled_cache_fingerprint(old_theme.syntax)
+
+      state =
+        state
+        |> Map.put(:theme, new_theme)
+        |> AgentAccess.update_panel(fn panel ->
+          %{
+            panel
+            | cached_display_messages: [message],
+              cached_styled_messages: cached,
+              cached_styled_fingerprint: fingerprint
+          }
+        end)
+
+      updated = AgentLifecycle.update_styled_cache(state)
+
+      assert [%{styled_lines: [[{"plain answer", fg, 0, 0}]], markdown_blocks: [block]}] =
+               AgentAccess.panel(updated).cached_styled_messages
+
+      assert fg == 0x123456
+      assert [[{"plain answer", ^fg, 0, 0}]] = block.lines
     end
 
     test "update_styled_cache restyles unchanged displayed messages when style cache is missing" do
@@ -322,8 +364,10 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
 
       updated = AgentLifecycle.update_styled_cache(state)
 
-      assert [[[{"unchanged answer", _fg, 0, 0}]]] =
+      assert [%{styled_lines: [[{"unchanged answer", _fg, 0, 0}]], markdown_blocks: [block]}] =
                AgentAccess.panel(updated).cached_styled_messages
+
+      assert block.kind == :paragraph
     end
 
     test "switch_tab rebuilds a background agent tab's semantic transcript cache" do

--- a/test/minga_editor/agent/concurrent_sessions_test.exs
+++ b/test/minga_editor/agent/concurrent_sessions_test.exs
@@ -282,6 +282,50 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
       assert panel.provenance_jump == nil
     end
 
+    test "update_styled_cache reuses unchanged displayed message styles" do
+      message = {:assistant, "unchanged answer"}
+      cached = [[{"cached styled answer", 0x98BE65, 0x21242B, 0x10}]]
+
+      {:ok, session} = StubServer.start_link(messages: [message])
+
+      state =
+        [Tab.new_agent(1, "Agent") |> Tab.set_session(session)]
+        |> base_state(1)
+        |> AgentAccess.update_panel(fn panel ->
+          %{
+            panel
+            | cached_display_messages: [message],
+              cached_styled_messages: cached
+          }
+        end)
+
+      updated = AgentLifecycle.update_styled_cache(state)
+
+      assert AgentAccess.panel(updated).cached_styled_messages == cached
+    end
+
+    test "update_styled_cache restyles unchanged displayed messages when style cache is missing" do
+      message = {:assistant, "unchanged answer"}
+
+      {:ok, session} = StubServer.start_link(messages: [message])
+
+      state =
+        [Tab.new_agent(1, "Agent") |> Tab.set_session(session)]
+        |> base_state(1)
+        |> AgentAccess.update_panel(fn panel ->
+          %{
+            panel
+            | cached_display_messages: [message],
+              cached_styled_messages: nil
+          }
+        end)
+
+      updated = AgentLifecycle.update_styled_cache(state)
+
+      assert [[[{"unchanged answer", _fg, 0, 0}]]] =
+               AgentAccess.panel(updated).cached_styled_messages
+    end
+
     test "switch_tab rebuilds a background agent tab's semantic transcript cache" do
       {:ok, background_session} =
         StubServer.start_link(

--- a/test/minga_editor/agent/markdown_highlight_test.exs
+++ b/test/minga_editor/agent/markdown_highlight_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaEditor.Agent.MarkdownHighlightTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Language.Highlight.Span
   alias MingaEditor.Agent.MarkdownHighlight
 
   alias MingaEditor.UI.Highlight
@@ -219,6 +220,104 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
       line = hd(result)
       bold_run = Enum.find(line, fn {t, _fg, _bg, _flags} -> t == "bold" end)
       assert bold_run != nil
+    end
+  end
+
+  describe "render_blocks/5" do
+    test "inline code remains a run flag inside a paragraph block" do
+      [block] = MarkdownHighlight.render_blocks("Use `GenServer` here", nil, @theme_syntax, 42)
+
+      assert block.kind == :paragraph
+      assert [[{"Use ", _, 0, 0}, {"GenServer", _, _, flags}, {" here", _, 0, 0}]] = block.lines
+      assert Bitwise.band(flags, 0x10) != 0
+    end
+
+    test "fenced code becomes an explicit complete code block" do
+      [_paragraph, code] =
+        MarkdownHighlight.render_blocks(
+          "In `lib/demo.ex`:\n```elixir\ndef hello\n```",
+          nil,
+          @theme_syntax,
+          42
+        )
+
+      assert code.kind == :code_block
+      assert code.language == "elixir"
+      assert code.label == "Elixir"
+      assert code.target_path == "lib/demo.ex"
+      assert code.flags == 0x01
+      assert [[{"def hello", _, _, flags}]] = code.lines
+      assert Bitwise.band(flags, 0x10) != 0
+    end
+
+    test "unclosed fenced code block is semantic streaming code" do
+      [code] = MarkdownHighlight.render_blocks("```python\nprint('hi')", nil, @theme_syntax, 99)
+
+      assert code.kind == :code_block
+      assert code.language == "python"
+      assert code.label == "Python"
+      assert code.flags == 0
+      assert [[{"print('hi')", _, _, flags}]] = code.lines
+      assert Bitwise.band(flags, 0x10) != 0
+    end
+
+    test "complete fenced code block keeps tree-sitter styling in semantic code card" do
+      text = "```elixir\ndef hello\n```"
+
+      highlight =
+        make_highlight(
+          spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
+          capture_names: ["keyword"],
+          theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
+        )
+
+      [code] = MarkdownHighlight.render_blocks(text, highlight, @theme_syntax, 99)
+
+      keyword_run =
+        code.lines |> hd() |> Enum.find(fn {text, _fg, _bg, _flags} -> text == "def" end)
+
+      assert {"def", 0xFF0000, _, flags} = keyword_run
+      assert Bitwise.band(flags, 0x01) != 0
+      assert Bitwise.band(flags, 0x10) != 0
+    end
+
+    test "complete semantic code card requests snippet highlighting when no full-message highlight exists" do
+      test_pid = self()
+      text = "```elixir\ndef hello\n```"
+
+      highlighter = fn language, source, opts ->
+        send(test_pid, {:highlight_requested, language, source, opts})
+        {:ok, ["keyword"], [Span.new(0, 3, 0)]}
+      end
+
+      [code] =
+        MarkdownHighlight.render_blocks(text, nil, @theme_syntax, 99, 0, highlighter: highlighter)
+
+      assert_received {:highlight_requested, "elixir", "def hello", opts}
+      assert opts[:timeout]
+
+      keyword_run =
+        code.lines |> hd() |> Enum.find(fn {text, _fg, _bg, _flags} -> text == "def" end)
+
+      assert {"def", 0x51AFEF, _, flags} = keyword_run
+      assert Bitwise.band(flags, 0x10) != 0
+    end
+
+    test "incomplete semantic code card stays plain monospaced while streaming" do
+      text = "```elixir\ndef hello"
+
+      highlight =
+        make_highlight(
+          spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
+          capture_names: ["keyword"],
+          theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
+        )
+
+      [code] = MarkdownHighlight.render_blocks(text, highlight, @theme_syntax, 99)
+
+      assert [[{"def hello", 0x98BE65, _, flags}]] = code.lines
+      assert Bitwise.band(flags, 0x10) != 0
+      refute Bitwise.band(flags, 0x01) != 0
     end
   end
 end

--- a/test/minga_editor/agent/markdown_highlight_test.exs
+++ b/test/minga_editor/agent/markdown_highlight_test.exs
@@ -75,9 +75,10 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
       line = hd(result)
       code_run = Enum.find(line, fn {t, _fg, _bg, _flags} -> t == "GenServer" end)
       assert code_run != nil
-      {_, fg, bg, _} = code_run
+      {_, fg, bg, flags} = code_run
       assert fg == 0x98BE65
       assert bg == 0x21242B
+      assert Bitwise.band(flags, 0x10) != 0
     end
 
     test "link text strips markdown and carries url metadata" do
@@ -110,6 +111,8 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
 
       # Three lines: header, code content, footer
       assert length(result) == 3
+      [{_text, _fg, _bg, flags}] = Enum.at(result, 1)
+      assert Bitwise.band(flags, 0x10) != 0
     end
   end
 
@@ -143,6 +146,7 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
       assert fg == 0xFF0000
       assert bg != 0
       assert Bitwise.band(flags, 0x01) != 0
+      assert Bitwise.band(flags, 0x10) != 0
     end
 
     test "code block content at nonzero byte offset uses correct spans" do
@@ -183,6 +187,25 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
       assert header_text == "My Header"
       assert fg == 0x51AFEF
       assert Bitwise.band(flags, 0x01) != 0
+    end
+
+    test "open fenced block skips tree-sitter overlay while preserving code flag" do
+      text = "```elixir\ndef hello"
+
+      highlight =
+        make_highlight(
+          spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
+          capture_names: ["keyword"],
+          theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
+        )
+
+      result = MarkdownHighlight.stylize(text, highlight, @theme_syntax, 0)
+
+      [{code_text, fg, _bg, flags}] = Enum.at(result, 1)
+      assert code_text == "def hello"
+      assert fg == 0x98BE65
+      assert Bitwise.band(flags, 0x10) != 0
+      refute Bitwise.band(flags, 0x01) != 0
     end
 
     test "falls back when highlight has no spans" do

--- a/test/minga_editor/integration/agent_workflow_conformance_test.exs
+++ b/test/minga_editor/integration/agent_workflow_conformance_test.exs
@@ -482,7 +482,7 @@ defmodule MingaEditor.Integration.AgentWorkflowConformanceTest do
   defp follow_up_turn_rendered?(%AgentChat{} = model) do
     model.visible? and model.status == :idle and
       Enum.any?(model.messages, &match?({_, {:user, "do this next"}}, &1)) and
-      Enum.any?(model.messages, &match?({_, {:styled_assistant, _}}, &1))
+      assistant_rendered?(model.messages)
   end
 
   defp provider_crash_rendered?(%AgentChat{} = model) do
@@ -498,7 +498,14 @@ defmodule MingaEditor.Integration.AgentWorkflowConformanceTest do
   end
 
   defp assistant_rendered?(messages) do
-    Enum.any?(messages, &match?({_, {:styled_assistant, _}}, &1))
+    Enum.any?(
+      messages,
+      fn
+        {_, {:styled_assistant, _}} -> true
+        {_, {:assistant_markdown, _}} -> true
+        _message -> false
+      end
+    )
   end
 
   defp tool_rendered?(messages) do

--- a/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
@@ -8,6 +8,8 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
   alias Minga.Editing.Scroll
   alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Frontend.Emit.Context
+  alias Minga.RenderModel.UI.AgentChat.MarkdownBlock
+  alias MingaEditor.UI.Theme
   alias MingaEditor.RenderModel.UI.AgentChatBuilder
   alias MingaEditor.Shell.Traditional
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
@@ -51,6 +53,48 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
            ] = summaries
 
     refute {:user, "hidden"} in Enum.map(summaries, fn {_id, type, text} -> {type, text} end)
+  end
+
+  test "build/1 emits semantic assistant markdown blocks when cache has them" do
+    session = fake_session_pid()
+
+    blocks = [
+      MarkdownBlock.code_block(123, "elixir", "Elixir", nil, true, [
+        [{"IO.puts(:hi)", 0x98BE65, 0x21242B, 0x10}]
+      ])
+    ]
+
+    panel =
+      synced_panel([{:assistant, "```elixir\nIO.puts(:hi)\n```"}],
+        styled_messages: [
+          %{styled_lines: [[{"fallback", 0xBBC2CF, 0, 0}]], markdown_blocks: blocks}
+        ],
+        styled_fingerprint: Panel.styled_cache_fingerprint(Theme.Fallback.theme().syntax)
+      )
+
+    model =
+      context(session, panel, theme: Theme.Fallback.theme())
+      |> AgentChatBuilder.build()
+
+    assert [{1, {:assistant_markdown, ^blocks}} | _] = model.messages
+  end
+
+  test "build/1 ignores stale styled cache when theme syntax changes" do
+    session = fake_session_pid()
+    old_theme = Theme.Fallback.theme()
+    new_theme = %{old_theme | syntax: Map.put(old_theme.syntax, "variable", fg: 0x12_34_56)}
+
+    panel =
+      synced_panel([{:assistant, "cached answer"}],
+        styled_messages: [[{"cached answer", 0x98BE65, 0, 0}]],
+        styled_fingerprint: Panel.styled_cache_fingerprint(old_theme.syntax)
+      )
+
+    model =
+      context(session, panel, theme: new_theme)
+      |> AgentChatBuilder.build()
+
+    assert {1, {:assistant, "cached answer"}} = hd(model.messages)
   end
 
   test "build/1 emits only messages through the manual semantic scroll viewport" do
@@ -232,18 +276,22 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
   defp message_summary({id, {kind, _, _}}), do: {id, kind, nil}
 
   defp synced_panel(messages, opts \\ []) do
-    {panel_opts, transcript_opts} = Keyword.split(opts, [:scroll, :styled_messages])
+    {panel_opts, transcript_opts} =
+      Keyword.split(opts, [:scroll, :styled_messages, :styled_fingerprint])
+
     display = Transcript.display(messages, transcript_opts)
 
     Panel.new()
-    |> Panel.cache_transcript_display(display, Keyword.get(panel_opts, :styled_messages))
+    |> Panel.cache_transcript_display(display, Keyword.get(panel_opts, :styled_messages),
+      styled_fingerprint: Keyword.get(panel_opts, :styled_fingerprint)
+    )
     |> maybe_set_panel_scroll(Keyword.get(panel_opts, :scroll))
   end
 
   defp maybe_set_panel_scroll(panel, nil), do: panel
   defp maybe_set_panel_scroll(panel, scroll), do: Panel.set_scroll(panel, scroll)
 
-  defp context(session, panel) do
+  defp context(session, panel, opts \\ []) do
     tab = Tab.new_agent(1, "Agent") |> Tab.set_session(session)
     {tab_bar, workspace} = TabBar.add_workspace(TabBar.new(tab), "Agent", session)
     tab_bar = TabBar.move_tab_to_workspace(tab_bar, tab.id, workspace.id)
@@ -252,7 +300,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
     %Context{
       port_manager: self(),
       capabilities: nil,
-      theme: nil,
+      theme: Keyword.get(opts, :theme),
       font_registry: nil,
       windows: %Windows{map: %{1 => window}, active: 1},
       layout: nil,


### PR DESCRIPTION
# TL;DR
Assistant markdown/code rendering now has an explicit semantic code-card path. BEAM emits `assistant_markdown` blocks for fenced code, macOS and the Go TUI render those blocks as code cards, and `0x10` remains a run-level inline/code styling hint rather than a source of block inference.

Closes #2470

## Changes
- Add semantic assistant markdown blocks and a `0x0A assistant_markdown` GUI agent chat payload for BEAM-authored paragraphs, list items, spacers, and fenced code blocks.
- Keep `0x10` as a run-level code hint for monospace/preserved whitespace; frontends no longer infer cards from `0x10`, decorative rails, all-code lines, or markdown parsing.
- Render macOS assistant code cards from explicit block data with a label, single horizontal scroll container, blank-line/indentation preservation, streaming state, and accessibility metadata.
- Render Go TUI assistant code cards from the same semantic block data with preserved blank/indented code lines and `›` truncation markers for overflowing code.
- Preserve styled-assistant fallback behavior for older payloads and inline prose styling.
- Cache rendered assistant markdown/styled output with theme syntax fingerprint invalidation so unchanged streaming entries can be reused without serving stale styles.
- Keep incomplete streamed fences plain monospaced until the fence closes; complete code blocks can use snippet syntax highlighting when parser support is available.

## Verification
- `mix test.llm test/minga_agent/markdown_test.exs test/minga_editor/agent/markdown_highlight_test.exs test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs test/minga_editor/render_model/ui/agent_chat_builder_test.exs test/minga_editor/agent/concurrent_sessions_test.exs`: 129 passed
- `cd go/tui && go test ./internal/protocol ./internal/ui`: 349 passed
- `mix swift.build`: passed
- `xcodebuild -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS' -only-testing:MingaTests/AgentChatViewTests test`: passed, 10 tests
- `xcodebuild -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS' -only-testing:MingaTests/GUIAgentChatDecoderTests test`: passed, 19 tests
- `xcodebuild -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS' test`: passed, 863 tests
- `mix compile --warnings-as-errors`: passed
- `mix protocol.gen --check`: passed
- `git diff --check`: passed

## Acceptance Criteria Addressed
- [x] TUI assistant messages preserve code indentation, blank code lines, overflow affordance, and long-line markers.
- [x] macOS renders fenced code as semantic code cards with labels while inline code remains distinct prose styling.
- [x] Streamed open fences stay plain monospaced until the fence closes, avoiding mid-stream syntax-color churn.
- [x] Styled/semantic cache reuse prevents full visible transcript restyling on unchanged streaming entries without stale theme colors.

## Notes
- `styled_tool_call_markdown` was intentionally deferred. Tool-call results still use the existing styled fallback path.
- A manual live visual pass for streaming `elixir`/`python`/bare/misspelled fences in both frontends is still recommended before merge.
