### PR TITLE
feat(agent): support indented markdown code blocks

### DIFF
--- a/docs/workstreams/agent-markdown-structure.md
+++ b/docs/workstreams/agent-markdown-structure.md
@@ -1,0 +1,23 @@
+# Agent Markdown Structure Decision
+
+## Decision
+
+Keep `MingaAgent.Markdown` as the structural parser for agent chat markdown, and keep tree-sitter markdown as the fenced-code syntax highlighting layer.
+
+## Rationale
+
+Agent chat rendering has to work on partial streaming text. The structural parser runs line-by-line on incomplete assistant output, can preserve open fenced-code behavior, and does not require a full tree reparse or node walk on each stream delta. That makes it the right source for the bounded chat-rendering subset.
+
+Tree-sitter stays valuable after structure is known. It should continue to provide language injection and syntax faces inside fenced code blocks, where correctness is worth the extra parser machinery and the structure has already identified code content.
+
+## Supported Subset
+
+The structural parser intentionally supports common agent-output markdown only: inline emphasis, inline code, safe links, fenced code blocks, indented code blocks outside list continuations, H1-H3 headings, unordered and numbered lists, blockquotes, horizontal rules, and plain paragraphs.
+
+## Non-Goals
+
+This is not a full CommonMark implementation. Do not add H4-H6, tables, task lists, footnotes, or nested block semantics unless the visual model defines how they render differently and tests cover that behavior.
+
+## Revisit Criteria
+
+Revisit tree-sitter as the structural source only if the renderer has an incremental node-walk cache that is cheap during streaming, preserves open-fence behavior on partial text, and produces the same styled-line shape without adding render-time flicker.

--- a/lib/minga_agent/markdown.ex
+++ b/lib/minga_agent/markdown.ex
@@ -13,6 +13,7 @@ defmodule MingaAgent.Markdown do
   - `` `inline code` ``
   - `[link text](https://example.com)`
   - Fenced code blocks (``` with optional language tag)
+  - Indented code blocks (4 spaces, outside list continuations)
   - `# Headers` (levels 1-3)
   - `- list items` and `* list items`
   - `> blockquotes`
@@ -214,16 +215,42 @@ defmodule MingaAgent.Markdown do
     parse_lines(rest, [{[{"", :plain}], :empty} | acc], nil)
   end
 
-  # Horizontal rule
-  defp parse_lines([line | rest], acc, nil) when line in ["---", "***", "___"] do
-    parse_lines(rest, [{[{"─────────────────────", :rule}], :rule} | acc], nil)
-  end
-
-  # Also match longer horizontal rules
   defp parse_lines([line | rest], acc, nil) do
-    parsed = parse_non_code_line(line, String.trim(line))
+    parsed = parse_indented_or_non_code_line(indented_code_line?(line, acc), line)
     parse_lines(rest, [parsed | acc], nil)
   end
+
+  @spec parse_indented_or_non_code_line(boolean(), String.t()) :: parsed_line()
+  defp parse_indented_or_non_code_line(true, line) do
+    {[{String.slice(line, 4..-1//1), {:code_content, ""}}], :code}
+  end
+
+  defp parse_indented_or_non_code_line(false, line) do
+    parse_non_code_line(line, String.trim(line))
+  end
+
+  @spec indented_code_line?(String.t(), [parsed_line()]) :: boolean()
+  defp indented_code_line?(line, acc) do
+    trimmed = String.trim(line)
+
+    trimmed != "" and indent_width(line) >= 4 and not markdown_list_line?(trimmed) and
+      not in_list_continuation?(acc)
+  end
+
+  @spec markdown_list_line?(String.t()) :: boolean()
+  defp markdown_list_line?("- " <> _), do: true
+  defp markdown_list_line?("* " <> _), do: true
+  defp markdown_list_line?(trimmed), do: Regex.match?(~r/^\d+\.\s/, trimmed)
+
+  @spec in_list_continuation?([parsed_line()]) :: boolean()
+  defp in_list_continuation?([{_segments, :list_item} | _rest]), do: true
+  defp in_list_continuation?([{_segments, :empty} | _rest]), do: false
+
+  defp in_list_continuation?([{[{text, _style} | _rest_segments], :text} | rest]) do
+    indent_width(text) >= 2 and in_list_continuation?(rest)
+  end
+
+  defp in_list_continuation?(_acc), do: false
 
   @spec parse_non_code_line(String.t(), String.t()) :: parsed_line()
   defp parse_non_code_line(_line, "###" <> _ = trimmed), do: parse_header_line(trimmed, :header3)

--- a/test/minga_agent/markdown_test.exs
+++ b/test/minga_agent/markdown_test.exs
@@ -192,6 +192,38 @@ defmodule MingaAgent.MarkdownTest do
       assert length(result) == 2
     end
 
+    test "parses indented code blocks outside lists" do
+      text = "    def hello\n    :world"
+      result = Markdown.parse(text)
+
+      assert [
+               {[{"def hello", {:code_content, ""}}], :code},
+               {[{":world", {:code_content, ""}}], :code}
+             ] = result
+    end
+
+    test "keeps four-space bullet continuations as prose" do
+      text = "- item\n    wrapped continuation\n    second continuation"
+      result = Markdown.parse(text)
+
+      assert [
+               {[{"  • item", :plain}], :list_item},
+               {[{"    wrapped continuation", :plain}], :text},
+               {[{"    second continuation", :plain}], :text}
+             ] = result
+    end
+
+    test "blank line ends list continuation before indented code" do
+      text = "- item\n\n    code"
+      result = Markdown.parse(text)
+
+      assert [
+               {[{"  • item", :plain}], :list_item},
+               {[{"", :plain}], :empty},
+               {[{"code", {:code_content, ""}}], :code}
+             ] = result
+    end
+
     test "parses multiple paragraphs" do
       text = "First line\n\nSecond line"
       result = Markdown.parse(text)


### PR DESCRIPTION
## Summary

- document the regex-vs-tree-sitter decision for agent markdown structure in docs/workstreams/agent-markdown-structure.md
- keep MingaAgent.Markdown as the streaming-friendly structural parser and tree-sitter as the fenced-code highlighting layer
- parse 4-space indented code blocks outside list continuations while preserving nested list items and wrapped bullet prose

Closes #2471

## Validation

- mix test test/minga_agent/markdown_test.exs
- mix test test/minga_agent/markdown_test.exs test/minga_editor/agent/markdown_highlight_test.exs
- mix compile --warnings-as-errors
- mix format --check-formatted
- git diff --check
- make lint
- mix native.build.support
- mix test failing locations from first full run after native support: session_recovery_test:57, session_recovery_test:168, lifecycle_contract_test:978, match_bracket_command_test:28, match_item_test:39
- mix test.llm