### PR TITLE
feat(agent): style composer command tokens

### DIFF
--- a/lib/minga_agent/file_mention.ex
+++ b/lib/minga_agent/file_mention.ex
@@ -86,11 +86,26 @@ defmodule MingaAgent.FileMention do
   def extract_mentions(text) do
     # Match @ at start of string or after whitespace, followed by non-whitespace
     Regex.scan(~r/(?:^|(?<=\s))@(\S+)/, text, return: :index)
-    |> Enum.map(fn [{start, len}, {_path_start, path_len}] ->
-      # The full match includes the @, but path is the capture group
-      path = String.slice(text, start + 1, path_len)
-      %{path: path, start: start, stop: start + len}
+    |> Enum.map(fn [{_match_start, _match_len}, {path_start, path_len}] ->
+      mention_start = path_start - 1
+      mention_stop = path_start + path_len
+      path = binary_part(text, path_start, path_len)
+
+      %{
+        path: path,
+        start: byte_offset_to_col(text, mention_start),
+        stop: byte_offset_to_col(text, mention_stop)
+      }
     end)
+  end
+
+  @spec byte_offset_to_col(String.t(), non_neg_integer()) :: non_neg_integer()
+  defp byte_offset_to_col(_text, 0), do: 0
+
+  defp byte_offset_to_col(text, byte_offset) do
+    text
+    |> binary_part(0, byte_offset)
+    |> String.length()
   end
 
   @doc """

--- a/lib/minga_editor/agent/view/prompt_render_window.ex
+++ b/lib/minga_editor/agent/view/prompt_render_window.ex
@@ -16,8 +16,11 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
 
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
+  alias MingaAgent.FileMention
   alias MingaEditor.Agent.ViewContext
+  alias MingaEditor.Agent.SlashCommand
   alias Minga.RenderModel.Window, as: RenderWindow
+  alias Minga.RenderModel.Window.DiagnosticRange
   alias Minga.RenderModel.Window.Gutter
   alias Minga.RenderModel.Window.GutterMetrics
   alias Minga.RenderModel.Window.HitRegion
@@ -32,6 +35,16 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
 
   @typedoc "Agent view context."
   @type ctx :: ViewContext.t()
+  @type token_status :: :valid | :invalid
+  @type token_range :: %{
+          start_col: non_neg_integer(),
+          end_col: non_neg_integer(),
+          status: token_status()
+        }
+  @type token_context :: %{
+          project_files: MapSet.t(String.t()),
+          project_root: String.t()
+        }
 
   @doc "Reserved window_id for the agent prompt RenderWindow."
   @spec prompt_window_id() :: pos_integer()
@@ -100,15 +113,35 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
 
     # Build wrapped visual lines
     wrapped = InputWrap.wrap_lines(lines, inner_width)
+    token_context = token_context(opts)
 
-    visual_rows =
+    {visual_rows, diagnostic_ranges} =
       wrapped
       |> Enum.drop(scroll)
       |> Enum.take(visible_count)
-      |> Enum.map(fn {logical_idx, vl} ->
+      |> Enum.with_index()
+      |> Enum.map_reduce([], fn {{logical_idx, vl}, display_row}, acc ->
         line_text = Enum.at(lines, logical_idx)
-        build_visual_row(vl, line_text, logical_idx, panel, at, inner_width)
+
+        {row, ranges} =
+          build_visual_row(
+            vl,
+            line_text,
+            logical_idx,
+            display_row,
+            panel,
+            at,
+            inner_width,
+            token_context
+          )
+
+        {row, [ranges | acc]}
       end)
+
+    diagnostic_ranges =
+      diagnostic_ranges
+      |> Enum.reverse()
+      |> List.flatten()
 
     # Cursor position relative to the visible window
     display_cursor_row = cursor_visual - scroll
@@ -133,7 +166,7 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
       cursor_visible: panel.input_focused,
       selection: selection,
       search_matches: [],
-      diagnostic_ranges: [],
+      diagnostic_ranges: diagnostic_ranges,
       document_highlights: [],
       annotations: [],
       gutter: prompt_gutter(prompt_id, rect, panel.input_focused),
@@ -227,16 +260,18 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
           InputWrap.visual_line(),
           String.t(),
           non_neg_integer(),
+          non_neg_integer(),
           Panel.t(),
           Theme.Agent.t(),
-          pos_integer()
-        ) :: Row.t()
-  defp build_visual_row(vl, line_text, logical_idx, panel, at, inner_width) do
-    {display_text, fg_color, bg_color} =
+          pos_integer(),
+          token_context()
+        ) :: {Row.t(), [DiagnosticRange.t()]}
+  defp build_visual_row(vl, line_text, logical_idx, display_row, panel, at, inner_width, ctx) do
+    {display_text, fg_color, bg_color, style_tokens?} =
       if UIState.paste_placeholder?(line_text) and vl.col_offset == 0 do
         case UIState.paste_block_index(line_text) do
           nil ->
-            {vl.text, rgb_to_int(at.text_fg), rgb_to_int(at.input_bg)}
+            {vl.text, rgb_to_int(at.text_fg), rgb_to_int(at.input_bg), true}
 
           block_index ->
             line_count = paste_block_line_count(panel.pasted_blocks, block_index)
@@ -245,33 +280,31 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
             # Paste pills use a distinct background for visual separation.
             # Blend the input_bg with a subtle highlight to create a pill effect.
             pill_bg = paste_pill_bg(at.input_bg)
-            {text, rgb_to_int(at.hint_fg), pill_bg}
+            {text, rgb_to_int(at.hint_fg), pill_bg, false}
         end
       else
-        {vl.text, rgb_to_int(at.text_fg), rgb_to_int(at.input_bg)}
+        {vl.text, rgb_to_int(at.text_fg), rgb_to_int(at.input_bg), true}
       end
 
-    # Build a single span covering the entire text with the appropriate color
     text_width = String.length(display_text)
+    row_start = vl.col_offset
+    row_end = row_start + text_width
+    accent_color = rgb_to_int(at.input_border)
 
-    spans =
-      if text_width > 0 do
-        [
-          %Span{
-            start_col: 0,
-            end_col: text_width,
-            fg: fg_color,
-            bg: bg_color,
-            attrs: 0,
-            font_weight: 0,
-            font_id: 0
-          }
-        ]
+    token_ranges =
+      if style_tokens? do
+        token_ranges(line_text, logical_idx, ctx)
       else
         []
       end
 
-    %Row{
+    valid_ranges = clipped_token_ranges(token_ranges, :valid, row_start, row_end)
+    invalid_ranges = clipped_token_ranges(token_ranges, :invalid, row_start, row_end)
+
+    spans = styled_spans(text_width, fg_color, bg_color, accent_color, valid_ranges)
+    diagnostic_ranges = diagnostic_ranges(display_row, invalid_ranges)
+
+    row = %Row{
       row_id: Row.stable_id(:normal, logical_idx, vl.col_offset),
       row_type: :normal,
       buf_line: logical_idx,
@@ -280,7 +313,213 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
       spans: spans,
       content_hash: Row.compute_hash(display_text, spans)
     }
+
+    {row, diagnostic_ranges}
   end
+
+  @spec token_context(keyword()) :: token_context()
+  defp token_context(opts) do
+    project_root = Keyword.get_lazy(opts, :project_root, &safe_project_root/0)
+
+    project_files =
+      opts
+      |> Keyword.get_lazy(:project_files, &safe_project_files/0)
+      |> Enum.map(&normalize_project_file/1)
+      |> MapSet.new()
+
+    %{project_root: project_root, project_files: project_files}
+  end
+
+  @spec token_ranges(String.t(), non_neg_integer(), token_context()) :: [token_range()]
+  defp token_ranges(line_text, logical_idx, ctx) do
+    slash_token_ranges(line_text, logical_idx) ++ mention_token_ranges(line_text, ctx)
+  end
+
+  @spec slash_token_ranges(String.t(), non_neg_integer()) :: [token_range()]
+  defp slash_token_ranges("/" <> _ = line_text, 0) do
+    token_length = leading_token_length(line_text)
+    token = String.slice(line_text, 0, token_length)
+    [%{start_col: 0, end_col: token_length, status: slash_token_status(token)}]
+  end
+
+  defp slash_token_ranges(_line_text, _logical_idx), do: []
+
+  @spec slash_token_status(String.t()) :: token_status()
+  defp slash_token_status(token) do
+    if SlashCommand.known_command?(token) or SlashCommand.completions(token) != [] do
+      :valid
+    else
+      :invalid
+    end
+  end
+
+  @spec leading_token_length(String.t()) :: non_neg_integer()
+  defp leading_token_length(text) do
+    text
+    |> String.graphemes()
+    |> Enum.take_while(&(&1 not in [" ", "\t", "\n"]))
+    |> length()
+  end
+
+  @spec mention_token_ranges(String.t(), token_context()) :: [token_range()]
+  defp mention_token_ranges(line_text, ctx) do
+    line_text
+    |> FileMention.extract_mentions()
+    |> Enum.map(fn %{path: path, start: start_col, stop: end_col} ->
+      %{
+        start_col: start_col,
+        end_col: end_col,
+        status: mention_token_status(path, ctx)
+      }
+    end)
+  end
+
+  @spec mention_token_status(String.t(), token_context()) :: token_status()
+  defp mention_token_status(path, ctx) do
+    if known_project_file?(path, ctx) or existing_project_file?(path, ctx.project_root) do
+      :valid
+    else
+      :invalid
+    end
+  end
+
+  @spec known_project_file?(String.t(), token_context()) :: boolean()
+  defp known_project_file?(path, %{project_files: project_files}) do
+    MapSet.member?(project_files, normalize_project_file(path))
+  end
+
+  @spec existing_project_file?(String.t(), String.t()) :: boolean()
+  defp existing_project_file?(path, project_root) do
+    path
+    |> Path.expand(project_root)
+    |> File.regular?()
+  rescue
+    _ -> false
+  end
+
+  @spec clipped_token_ranges(
+          [token_range()],
+          token_status(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          [token_range()]
+  defp clipped_token_ranges(token_ranges, status, row_start, row_end) do
+    token_ranges
+    |> Enum.filter(&(&1.status == status))
+    |> Enum.flat_map(&clip_token_range(&1, row_start, row_end))
+  end
+
+  @spec clip_token_range(token_range(), non_neg_integer(), non_neg_integer()) :: [token_range()]
+  defp clip_token_range(range, row_start, row_end) do
+    start_col = max(range.start_col, row_start)
+    end_col = min(range.end_col, row_end)
+
+    if end_col > start_col do
+      [%{range | start_col: start_col - row_start, end_col: end_col - row_start}]
+    else
+      []
+    end
+  end
+
+  @spec styled_spans(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          [token_range()]
+        ) :: [Span.t()]
+  defp styled_spans(0, _fg_color, _bg_color, _accent_color, _valid_ranges), do: []
+
+  defp styled_spans(text_width, fg_color, bg_color, accent_color, valid_ranges) do
+    valid_ranges
+    |> Enum.sort_by(& &1.start_col)
+    |> build_styled_spans(0, text_width, fg_color, bg_color, accent_color, [])
+  end
+
+  @spec build_styled_spans(
+          [token_range()],
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          [Span.t()]
+        ) :: [Span.t()]
+  defp build_styled_spans([], cursor, text_width, fg_color, bg_color, _accent_color, acc) do
+    acc = maybe_add_span(acc, cursor, text_width, fg_color, bg_color)
+    Enum.reverse(acc)
+  end
+
+  defp build_styled_spans(
+         [%{start_col: start_col, end_col: end_col} | rest],
+         cursor,
+         text_width,
+         fg_color,
+         bg_color,
+         accent_color,
+         acc
+       ) do
+    acc = maybe_add_span(acc, cursor, start_col, fg_color, bg_color)
+    acc = maybe_add_span(acc, start_col, end_col, accent_color, bg_color)
+    build_styled_spans(rest, end_col, text_width, fg_color, bg_color, accent_color, acc)
+  end
+
+  @spec maybe_add_span(
+          [Span.t()],
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          [Span.t()]
+  defp maybe_add_span(acc, start_col, end_col, fg_color, bg_color) when end_col > start_col do
+    [
+      %Span{
+        start_col: start_col,
+        end_col: end_col,
+        fg: fg_color,
+        bg: bg_color,
+        attrs: 0,
+        font_weight: 0,
+        font_id: 0
+      }
+      | acc
+    ]
+  end
+
+  defp maybe_add_span(acc, _start_col, _end_col, _fg_color, _bg_color), do: acc
+
+  @spec diagnostic_ranges(non_neg_integer(), [token_range()]) :: [DiagnosticRange.t()]
+  defp diagnostic_ranges(display_row, invalid_ranges) do
+    Enum.map(invalid_ranges, fn %{start_col: start_col, end_col: end_col} ->
+      %DiagnosticRange{
+        start_row: display_row,
+        start_col: start_col,
+        end_row: display_row,
+        end_col: end_col,
+        severity: :error
+      }
+    end)
+  end
+
+  @spec safe_project_files() :: [String.t()]
+  defp safe_project_files do
+    Minga.Project.files()
+  catch
+    :exit, _ -> []
+  end
+
+  @spec safe_project_root() :: String.t()
+  defp safe_project_root do
+    Minga.Project.resolve_root()
+  catch
+    :exit, _ -> File.cwd!()
+  end
+
+  @spec normalize_project_file(String.t()) :: String.t()
+  defp normalize_project_file("./" <> path), do: normalize_project_file(path)
+  defp normalize_project_file(path), do: path
 
   @spec build_selection(
           atom(),

--- a/test/minga_agent/file_mention_test.exs
+++ b/test/minga_agent/file_mention_test.exs
@@ -41,6 +41,11 @@ defmodule MingaAgent.FileMentionTest do
       mentions = FileMention.extract_mentions("@lib/foo.ex rest")
       assert [%{start: 0, stop: 11}] = mentions
     end
+
+    test "records character positions after non-ascii text" do
+      mentions = FileMention.extract_mentions("é @lib/foo.ex rest")
+      assert [%{path: "lib/foo.ex", start: 2, stop: 13}] = mentions
+    end
   end
 
   # ── Resolution ──────────────────────────────────────────────────────────────

--- a/test/minga_editor/agent/view/prompt_render_window_test.exs
+++ b/test/minga_editor/agent/view/prompt_render_window_test.exs
@@ -136,6 +136,67 @@ defmodule MingaEditor.Agent.View.PromptRenderWindowTest do
       assert Enum.map(model.rows, & &1.text) == ["before", "󰆏 [pasted 3 lines]", "after"]
       assert hd(Enum.at(model.rows, 1).spans).bg != hd(hd(model.rows).spans).bg
     end
+
+    test "tints valid slash commands and file mentions" do
+      ctx = prompt_ctx("/help @lib/minga.ex", input_focused: true)
+      model = PromptRenderWindow.build(ctx, 40, {0, 0, 40, 1}, project_files: ["lib/minga.ex"])
+
+      [row] = model.rows
+      accent = Theme.agent_theme(ctx.theme).input_border
+
+      assert row.text == "/help @lib/minga.ex"
+      assert model.diagnostic_ranges == []
+      assert Enum.any?(row.spans, &match?(%{start_col: 0, end_col: 5, fg: ^accent}, &1))
+      assert Enum.any?(row.spans, &match?(%{start_col: 6, end_col: 19, fg: ^accent}, &1))
+    end
+
+    test "aligns mention styling after non-ascii text" do
+      ctx = prompt_ctx("é @lib/minga.ex", input_focused: true)
+      model = PromptRenderWindow.build(ctx, 40, {0, 0, 40, 1}, project_files: ["lib/minga.ex"])
+
+      [row] = model.rows
+      accent = Theme.agent_theme(ctx.theme).input_border
+
+      assert Enum.any?(row.spans, &match?(%{start_col: 2, end_col: 15, fg: ^accent}, &1))
+    end
+
+    test "marks unknown slash commands and unresolved mentions with diagnostic ranges" do
+      ctx = prompt_ctx("/helpx @missing.ex", input_focused: true)
+
+      model =
+        PromptRenderWindow.build(ctx, 40, {0, 0, 40, 1},
+          project_files: ["lib/minga.ex"],
+          project_root: System.tmp_dir!()
+        )
+
+      assert Enum.map(model.diagnostic_ranges, fn range ->
+               {range.start_row, range.start_col, range.end_row, range.end_col, range.severity}
+             end) == [
+               {0, 0, 0, 6, :error},
+               {0, 7, 0, 18, :error}
+             ]
+    end
+
+    test "keeps cursor and selection coordinates with multi-span rows" do
+      ctx =
+        prompt_ctx("ask @lib/minga.ex now",
+          input_focused: true,
+          cursor: {0, 17},
+          mode: :visual,
+          mode_state: %{visual_start: {0, 4}}
+        )
+
+      model = PromptRenderWindow.build(ctx, 40, {0, 0, 40, 1}, project_files: ["lib/minga.ex"])
+      [row] = model.rows
+
+      assert length(row.spans) > 1
+      assert model.cursor_row == 0
+      assert model.cursor_col == 17
+      assert model.selection.start_row == 0
+      assert model.selection.start_col == 4
+      assert model.selection.end_row == 0
+      assert model.selection.end_col == 17
+    end
   end
 
   defp prompt_ctx(text, opts) do


### PR DESCRIPTION
# TL;DR
Composer input now gives live validity feedback for slash commands and @file mentions. Valid tokens get the agent accent tint; unknown commands and unresolved mentions get diagnostic underlines from the shared render model.

Closes #2472

## Context
This finishes the #2472 composer styling split from the agent UX audit in #2468. The change stays in the shared semantic prompt window model so both native GUI and terminal clients consume the same spans and diagnostic ranges.

## Changes
- Split agent prompt rows into multiple semantic spans when valid slash-command or @mention tokens are present.
- Emit prompt diagnostic ranges for unknown slash commands and unresolved file mentions, using the existing diagnostic underline path instead of inventing a parallel underline style.
- Preserve cursor, selection, paste placeholder, wrapping, and row-hash behavior while adding multi-span rows.
- Fix FileMention.extract_mentions/1 to return character ranges after non-ASCII text, which keeps mention cleanup and render styling aligned.

## Verification
- mix test test/minga_agent/file_mention_test.exs test/minga_editor/agent/view/prompt_render_window_test.exs: 52 passed
- mix test test/minga_editor/render_pipeline/content_test.exs test/minga_agent/file_mention_test.exs test/minga_editor/agent/view/prompt_render_window_test.exs: 58 passed
- mix compile --warnings-as-errors: passed
- make lint: passed
- mix native.build.support: built minga-parser and minga-hook-runner for the fresh worktree
- mix test test/minga_editor/integration/match_item_test.exs: 9 passed after building parser support
- mix test test/minga_editor/integration/agent_cursor_test.exs --seed 402208: 2 passed after an isolated full-suite failure in that file
- mix test.llm: 56 doctests, 87 properties, 9406 tests, 0 failures, 1 skipped, 339 excluded

## Acceptance Criteria Addressed
- Valid @mentions and a leading /command are visually tinted in the composer on both frontends via shared RenderWindow spans. ✅
- Unresolved mentions and unknown commands are marked live before submit via prompt diagnostic ranges. ✅
- Cursor and selection rendering remain correct with multi-span rows. ✅