### PR TITLE
fix(agent): harden activity spine follow-ups

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -49,7 +49,7 @@ opcode(1) + payload_length(2, big-endian) + payload(payload_length)
 
 This allows old frontends to skip unknown opcodes without crashing. When a frontend encounters an unrecognized opcode >= 0x90, it reads the 2-byte length, advances past the payload, and continues decoding the rest of the batch.
 
-Opcodes below 0x90 do NOT include a length prefix and retain their existing positional wire format. If a frontend encounters an unknown opcode below 0x90, it cannot determine the message size and must abort decoding. Known 0x90+ opcodes may document a wider envelope when the payload can exceed 64KB, as `gui_file_tree` does.
+Opcodes below 0x90 generally do NOT include a length prefix and retain their existing positional wire format. The explicit exception is `0x88 gui_agent_context`, which occupies a legacy opcode slot but now carries a 16-bit length-prefixed payload for compatibility with its expanded activity fields. If a frontend encounters an unknown opcode below 0x90, it cannot determine the message size and must abort decoding. Known 0x90+ opcodes may document a wider envelope when the payload can exceed 64KB, as `gui_file_tree` does.
 
 The BEAM-side encoder must use a documented length-prefixed envelope for all new opcodes (0x90+). Currently defined 0x90+ opcodes:
 
@@ -63,6 +63,7 @@ The BEAM-side encoder must use a documented length-prefixed envelope for all new
 | 0x95 | gui_cursor_animation | Cursor movement animation preference for GUI renderers. |
 | 0x96 | gui_hover_action | Optional action metadata for the hover popup |
 | 0x9A | gui_observatory | BEAM Observatory process tree and metrics for native sidebars. Uses a 32-bit payload length because large supervision trees can exceed 64KB. |
+| 0x9B | gui_edit_timeline | Agent edit timeline overlay with per-file summaries appended after the per-entry list. Uses a 16-bit payload length. |
 | 0x9F | gui_sidebars | Semantic sidebar host metadata. Uses a 32-bit payload length so future sidebar lists can grow without changing the envelope. |
 | 0xA3 | gui_extension_runtime | Generic frontend-extension runtime envelope. Uses a 32-bit payload length so extension-owned payloads can grow without changing the shared envelope. |
 
@@ -962,6 +963,29 @@ Toast when toast_present == 1:
 
 When the git status panel is closed, the BEAM sends `repo_state = not_a_repo`, no entries, and an empty `entry_base_path` as the hide signal. A non-git project opened in the Source Control tab also uses `repo_state = not_a_repo`, but includes the project root so the frontend can show the native "Not a git repository" empty state instead of hiding the panel. The frontend should still copy `syncing` and `toast` so remote operation feedback remains accurate while the panel is hidden.
 
+### 0x88 — gui_agent_context
+
+Agent activity chrome for the native agent context bar. The BEAM owns the visible task, elapsed timestamp, approval state, progress summary, and the current todo plan snapshot.
+
+```
+opcode(1) + payload_len(2) + payload(payload_len)
+
+Payload:
+  visible(1) + task_len(2) + task(task_len) + dispatch_timestamp(8) + status(1) + can_approve(1)
+  + active_action_len(2) + active_action(active_action_len)
+  + tool_count(2) + file_count(2)
+  + review_hint_len(2) + review_hint(review_hint_len)
+  + todo_count(1) + todos...
+
+Per todo:
+  status(1) + description_len(2) + description(description_len)
+```
+
+`status`: 0 = idle, 1 = working, 2 = iterating, 3 = needs_you, 4 = done, 5 = errored.
+`can_approve` means the agent is waiting on the user to approve or reject the current work. Frontends should treat it as the source of truth for the review affordance, and render the needs-you state when it is set.
+`dispatch_timestamp` is Unix seconds. `review_hint` is the short review copy shown next to the progress summary.
+`todo_count` is the number of visible todo items in the snapshot. The todo list is the editor's live projection of the provider plan, not a separate provider-only state. A hidden context may omit the progress and todo tail after `can_approve`; frontends must treat missing tail fields as empty progress and no todos for legacy compatibility.
+
 ### 0x98 — gui_workspaces
 
 Canonical workspace state for native frontends. This is the source of truth for workspace headers, active-workspace file tabs, badges, and workspace view mode. The old agent-group payload is gone; frontends should not infer workspace state from tab order or legacy agent-only lists.
@@ -1010,6 +1034,26 @@ Per action:
 `version` is currently 1. `level`: 0 = info, 1 = warning, 2 = error, 3 = success, 4 = progress. Flags: bit 0 = dismissable. `created_at` and `updated_at` are Unix seconds. `auto_dismiss_ms` uses `0xFFFFFFFF` for no auto-dismiss. Errors and progress notifications should normally use no auto-dismiss. Informational and success notifications may auto-dismiss after a short delay.
 
 TUI frontends do not render this opcode. The BEAM should also log important notifications to `*Messages*` so terminal users get the same information.
+
+### 0x9B — gui_edit_timeline
+
+Edit timeline overlay data for native frontends. The BEAM sends the active entry list and the aggregate changed-file summaries in one payload so the frontend can switch between per-entry scrubbing and per-file review without guessing from local state.
+
+```
+opcode(1) + payload_len(2) + payload(payload_len)
+
+Payload:
+  visible(1) + viewing_index(2) + entry_count(1) + entries... + file_count(1) + files...
+
+Per entry:
+  index(1) + tool_name_len(1) + tool_name(tool_name_len) + timestamp_delta(4)
+
+Per file:
+  path_len(2) + path(path_len) + entry_count(1) + lines_added(4) + lines_removed(4) + review_status(1)
+```
+
+`viewing_index` is `0xFFFF` when the timeline is live at the latest state. When `file_count` is greater than zero, frontends should show the aggregate changed-file view and use the per-file rows for navigation and review status.
+`review_status`: 0 = pending, 1 = reviewing.
 
 ## GUI Action Input Opcode (Frontend → BEAM)
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -27,7 +27,7 @@ The frontend runs as a child process of the BEAM. Communication uses stdin (BEAM
 
 **Text encoding:** All text fields (titles, language names, query source, semantic content) are UTF-8 encoded.
 
-**Protocol version:** The schema carries a `protocol_version` integer (currently 5). The BEAM and every frontend compile against it and exchange it in the `ready` handshake. The BEAM rejects a frontend whose version does not match and sends an explicit `protocol_error` instead of streaming frames the frontend cannot decode. See "Protocol Version Negotiation" below.
+**Protocol version:** The schema carries a `protocol_version` integer (currently 6). The BEAM and every frontend compile against it and exchange it in the `ready` handshake. The BEAM rejects a frontend whose version does not match and sends an explicit `protocol_error` instead of streaming frames the frontend cannot decode. Version 6 bumps the semantic agent chrome contract so `gui_agent_context` is length-framed and `gui_edit_timeline` appends file summaries after the entry list. See "Protocol Version Negotiation" below.
 
 ---
 
@@ -756,7 +756,7 @@ Total size: 4 + msg_len bytes.
 
 ## Protocol Version Negotiation
 
-The schema (`docs/protocol_schema.toml`) carries a `protocol_version` integer (currently 5). `mix protocol.gen` emits it as a constant on every side: `Minga.Protocol.Opcodes.protocol_version()` (Elixir), `generated.ProtocolVersion` (Go), `PROTOCOL_VERSION` (Swift), `PROTOCOL_VERSION` (Zig parser). Bump it whenever the wire contract changes incompatibly; protocol_version 2 retired the 9 cell-paradigm render opcodes, protocol_version 3 (#2219) added the frame-transaction vocabulary (`begin_frame`, `commit_frame`, `request_keyframe`) and authoritative layout (`surface_placement`, `gui_surface_layout`), protocol_version 4 added the `gui_file_tree` row `heat_level` byte, and protocol_version 5 added producer-assigned `stream_instance` identity to the Messages stream. A frontend built against an older protocol handshakes with its old version and receives the `protocol_error` blocking surface instead of a desynced stream.
+The schema (`docs/protocol_schema.toml`) carries a `protocol_version` integer (currently 6). `mix protocol.gen` emits it as a constant on every side: `Minga.Protocol.Opcodes.protocol_version()` (Elixir), `generated.ProtocolVersion` (Go), `PROTOCOL_VERSION` (Swift), `PROTOCOL_VERSION` (Zig parser). Bump it whenever the wire contract changes incompatibly; protocol_version 2 retired the 9 cell-paradigm render opcodes, protocol_version 3 (#2219) added the frame-transaction vocabulary (`begin_frame`, `commit_frame`, `request_keyframe`) and authoritative layout (`surface_placement`, `gui_surface_layout`), protocol_version 4 added the `gui_file_tree` row `heat_level` byte, protocol_version 5 added producer-assigned `stream_instance` identity to the Messages stream, and protocol_version 6 frames `gui_agent_context` and appends `gui_edit_timeline` file summaries. A frontend built against an older protocol handshakes with its old version and receives the `protocol_error` blocking surface instead of a desynced stream.
 
 **Handshake.** A frontend appends its compiled-in `protocol_version` as a u16 tail on the extended `ready` event (after `caps_data`). A frontend that omits the tail (short ready, or extended ready without the tail) is treated as protocol_version 0.
 

--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -15,7 +15,8 @@ version = "2.0.0"
 # protocol_version 4 adds the gui_file_tree row heat_level byte for extension-owned
 # familiarity tinting. This changes the hand-decoded file-tree row payload.
 # protocol_version 5 adds producer-assigned stream_instance to the Messages stream.
-protocol_version = 5
+# protocol_version 6 frames gui_agent_context and appends gui_edit_timeline file summaries.
+protocol_version = 6
 description = "Minga port protocol opcode registry"
 
 # Directions:

--- a/go/tui/internal/generated/opcodes.go
+++ b/go/tui/internal/generated/opcodes.go
@@ -4,7 +4,7 @@ package generated
 
 // ProtocolVersion is the wire-contract version the frontend exchanges with
 // the BEAM in the ready handshake. A mismatch yields an explicit protocol_error.
-const ProtocolVersion uint16 = 5
+const ProtocolVersion uint16 = 6
 
 const (
 	// Input

--- a/go/tui/internal/protocol/generated_decode_test.go
+++ b/go/tui/internal/protocol/generated_decode_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"encoding/binary"
 	"reflect"
 	"testing"
 
@@ -17,6 +18,41 @@ import (
 // mix protocol.gen, which rewrites the generated/ directory, can never clobber
 // it. Keep the fixtures in sync with the encoder assertions in
 // protocol_schema_validation_test.exs.
+
+func appendWireU16(data []byte, value uint16) []byte {
+	var buf [2]byte
+	binary.BigEndian.PutUint16(buf[:], value)
+	return append(data, buf[:]...)
+}
+
+func appendWireU32(data []byte, value uint32) []byte {
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], value)
+	return append(data, buf[:]...)
+}
+
+func appendWireU64(data []byte, value uint64) []byte {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], value)
+	return append(data, buf[:]...)
+}
+
+func appendWireString8(data []byte, text string) []byte {
+	bytes := []byte(text)
+	if len(bytes) > 0xFF {
+		bytes = bytes[:0xFF]
+	}
+	return append(append(data, byte(len(bytes))), bytes...)
+}
+
+func appendWireString16(data []byte, text string) []byte {
+	bytes := []byte(text)
+	if len(bytes) > 0xFFFF {
+		bytes = bytes[:0xFFFF]
+	}
+	data = appendWireU16(data, uint16(len(bytes)))
+	return append(data, bytes...)
+}
 
 func TestDecodeGuiCompletionFieldsWithItems(t *testing.T) {
 	// header(7) + items(1: kind 'foo' 'bar') + documentation string16 "doc".
@@ -69,6 +105,72 @@ func TestDecodeHiddenCompletionSkipsTail(t *testing.T) {
 	f, consumed, err := generated.DecodeGuiCompletionFields([]byte{0}, 0, 1)
 	if err != nil || consumed != 1 || f.Visible != 0 || len(f.Items) != 0 {
 		t.Fatalf("hidden completion: f=%+v consumed=%d err=%v", f, consumed, err)
+	}
+}
+
+func TestDecodeGuiAgentContextFieldsWithTodos(t *testing.T) {
+	body := append([]byte{}, 1)
+	body = appendWireString16(body, "Review diff")
+	body = appendWireU64(body, 1_705_314_000)
+	body = append(body, 3, 1)
+	body = appendWireString16(body, "Running shell")
+	body = appendWireU16(body, 2)
+	body = appendWireU16(body, 1)
+	body = appendWireString16(body, "Review: approve or reject changes")
+	body = append(body, 1)
+	body = append(body, 1)
+	body = appendWireString16(body, "Inspect files")
+
+	payload := appendWireU16(nil, uint16(len(body)))
+	payload = append(payload, body...)
+
+	fields, consumed, err := generated.DecodeGuiAgentContextFields(payload, 0, len(payload))
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if consumed != len(payload) {
+		t.Fatalf("consumed %d, want %d", consumed, len(payload))
+	}
+	if fields.PayloadLen != uint16(len(body)) || fields.Visible != 1 || fields.Task != "Review diff" || fields.DispatchTimestamp != 1_705_314_000 || fields.Status != 3 || fields.CanApprove != 1 {
+		t.Fatalf("agent context header mismatch: %+v", fields)
+	}
+	if fields.ActiveAction != "Running shell" || fields.ToolCount != 2 || fields.FileCount != 1 || fields.ReviewHint != "Review: approve or reject changes" {
+		t.Fatalf("agent context progress mismatch: %+v", fields)
+	}
+	if len(fields.Todos) != 1 || fields.Todos[0].Status != 1 || fields.Todos[0].Description != "Inspect files" {
+		t.Fatalf("agent context todos mismatch: %+v", fields.Todos)
+	}
+}
+
+func TestDecodeGuiEditTimelineFieldsWithFiles(t *testing.T) {
+	payload := []byte{1}
+	payload = appendWireU16(payload, 0xFFFF)
+	payload = append(payload, 1)
+	payload = append(payload, 0)
+	payload = appendWireString8(payload, "write_file")
+	payload = appendWireU32(payload, 12)
+	payload = append(payload, 1)
+	payload = appendWireString16(payload, "lib/a.ex")
+	payload = append(payload, 2)
+	payload = appendWireU32(payload, 10)
+	payload = appendWireU32(payload, 3)
+	payload = append(payload, 1)
+
+	fields, consumed, err := generated.DecodeGuiEditTimelineFields(payload, 0, len(payload))
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if consumed != len(payload) {
+		t.Fatalf("consumed %d, want %d", consumed, len(payload))
+	}
+	if fields.Visible != 1 || fields.ViewingIndex != 0xFFFF || len(fields.Entries) != 1 || len(fields.Files) != 1 {
+		t.Fatalf("edit timeline shape mismatch: %+v", fields)
+	}
+	if fields.Entries[0].Index != 0 || fields.Entries[0].ToolName != "write_file" || fields.Entries[0].TimestampDelta != 12 {
+		t.Fatalf("edit timeline entry mismatch: %+v", fields.Entries[0])
+	}
+	if fields.Files[0].Path != "lib/a.ex" || fields.Files[0].EntryCount != 2 || fields.Files[0].LinesAdded != 10 || fields.Files[0].LinesRemoved != 3 || fields.Files[0].ReviewStatus != 1 {
+		t.Fatalf("edit timeline files mismatch: %+v", fields.Files[0])
 	}
 }
 

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1287,11 +1287,11 @@ func TestOverlayLinesRenderRemainingSemanticSurfaces(t *testing.T) {
 	// Every overlay surface is registry-placed now (#2281): a surface renders only
 	// when the BEAM emits its placement, so each case provides one.
 	model := New(60, 12, nil)
-	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentContext: {AgentContext: protocol.AgentContext{Visible: true, Task: "Review diff", Status: 1, CanApprove: true}}}
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentContext: {AgentContext: protocol.AgentContext{Visible: true, Task: "Review diff", Status: 3, CanApprove: true, Progress: protocol.AgentProgress{ActiveAction: "Running shell", ToolCount: 2, FileCount: 1, ReviewHint: "Review: approve or reject changes"}, Todos: []protocol.AgentTodo{{Status: 1, Description: "Inspect files"}}}}}
 	model.surfacePlacements = []generated.SurfacePlacement{
 		{SurfaceID: surfaceIDAgentContext, Z: 260, HitKind: 8},
 	}
-	if got := strings.Join(model.overlayLines(), "\n"); !strings.Contains(got, "Review diff") {
+	if got := strings.Join(model.overlayLines(), "\n"); !strings.Contains(got, "needs you") || !strings.Contains(got, "Review diff") {
 		t.Fatalf("agent context overlay missing content: %q", got)
 	}
 
@@ -2181,6 +2181,20 @@ func TestSemanticMouseRoutesEditTimelineEntryZones(t *testing.T) {
 	// OverlaySink containment swallows it (AC 2 containment fallback).
 	if _, ok := model.semanticMousePacket(tea.MouseClickMsg(tea.Mouse{Button: tea.MouseLeft, X: entry.EndX + 40, Y: entry.EndY + 30})); ok {
 		t.Fatalf("out-of-bounds timeline clicks should fall back to BEAM containment")
+	}
+}
+
+func TestOverlayLinesRenderEditTimelineFiles(t *testing.T) {
+	model := New(60, 12, nil)
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiEditTimeline: {Timeline: protocol.EditTimeline{
+		Visible:      true,
+		ViewingIndex: 0xFFFF,
+		Files:        []protocol.TimelineFile{{Path: "lib/a.ex", EntryCount: 2, LinesAdded: 10, LinesRemoved: 3, ReviewStatus: 1}},
+	}}}
+	model.surfacePlacements = []generated.SurfacePlacement{{SurfaceID: surfaceIDEditTimeline, Z: 170, HitKind: 8}}
+
+	if got := strings.Join(model.overlayLines(), "\n"); !strings.Contains(got, "lib/a.ex") || !strings.Contains(got, "+10/-3") {
+		t.Fatalf("edit timeline file summary overlay missing content: %q", got)
 	}
 }
 

--- a/lib/minga_agent/event_log/event_record.ex
+++ b/lib/minga_agent/event_log/event_record.ex
@@ -16,6 +16,7 @@ defmodule MingaAgent.EventLog.EventRecord do
           | :tool_call_finished
           | :tool_call_interrupted
           | :file_edit_proposed
+          | :todo_plan_updated
           | :approval_requested
           | :approval_resolved
           | :approval_interrupted

--- a/lib/minga_agent/event_log/taxonomy.ex
+++ b/lib/minga_agent/event_log/taxonomy.ex
@@ -15,6 +15,7 @@ defmodule MingaAgent.EventLog.Taxonomy do
     :tool_call_finished,
     :tool_call_interrupted,
     :file_edit_proposed,
+    :todo_plan_updated,
     :approval_requested,
     :approval_resolved,
     :approval_interrupted,

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -2517,6 +2517,9 @@ defmodule MingaAgent.Session do
   defp event_log_entry({:approval_pending, approval}),
     do: {:approval_requested, Map.put(approval, :approval_id, approval.tool_call_id)}
 
+  defp event_log_entry({:todo_plan_updated, todos}),
+    do: {:todo_plan_updated, %{todos: todo_items_payload(todos)}}
+
   defp event_log_entry({:approval_resolved, _decision}), do: nil
 
   defp event_log_entry({:system_message, _message, _level}), do: nil
@@ -2551,6 +2554,32 @@ defmodule MingaAgent.Session do
        }}
 
   defp event_log_entry(_event), do: nil
+
+  @spec todo_items_payload(term()) :: [map()]
+  defp todo_items_payload(todos) when is_list(todos) do
+    Enum.map(todos, &todo_item_payload/1)
+  end
+
+  defp todo_items_payload(_todos), do: []
+
+  @spec todo_item_payload(map()) :: map()
+  defp todo_item_payload(todo) do
+    %{
+      "id" => todo_value(todo, :id),
+      "description" => todo_value(todo, :description),
+      "status" => todo_status_payload(todo_value(todo, :status))
+    }
+  end
+
+  @spec todo_value(map(), atom()) :: term()
+  defp todo_value(todo, key) do
+    Map.get(todo, key) || Map.get(todo, Atom.to_string(key))
+  end
+
+  @spec todo_status_payload(term()) :: String.t()
+  defp todo_status_payload(status) when is_binary(status), do: status
+  defp todo_status_payload(status) when is_atom(status), do: Atom.to_string(status)
+  defp todo_status_payload(status), do: to_string(status)
 
   # When content is a ContentPart list (images attached), extract the text
   # for the chat message and pass the full parts to the provider.

--- a/lib/minga_editor/agent/activity.ex
+++ b/lib/minga_editor/agent/activity.ex
@@ -53,6 +53,14 @@ defmodule MingaEditor.Agent.Activity do
     %{activity | active_action: "", started_at: nil}
   end
 
+  @doc "Seeds the first visible timestamp without resetting the turn state."
+  @spec ensure_started_at(t()) :: t()
+  def ensure_started_at(%__MODULE__{started_at: nil} = activity) do
+    %{activity | started_at: DateTime.utc_now()}
+  end
+
+  def ensure_started_at(%__MODULE__{} = activity), do: activity
+
   @doc "Replaces the visible todo plan."
   @spec set_todos(t(), [TodoItem.t()]) :: t()
   def set_todos(%__MODULE__{} = activity, todos) when is_list(todos) do

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -255,6 +255,10 @@ defmodule MingaEditor.Agent.Events do
     cached = Map.take(approval, [:tool_call_id, :name, :args, :preview])
     state = AgentAccess.update_agent(state, &AgentState.set_pending_approval(&1, cached))
 
+    # Seed the visible activity timestamp once so approval-only agent context
+    # remains stable across renders without falling back to "now" every frame.
+    state = update_activity(state, &Activity.ensure_started_at/1)
+
     # Unfocus the prompt input so the ToolApproval input handler can
     # intercept y/n keys. The user needs to see and respond to the
     # approval prompt, not keep typing in the input field.
@@ -1043,6 +1047,8 @@ defmodule MingaEditor.Agent.Events do
       else: elem(handle(state, event), 0)
   end
 
+  defp replay_one_catchup_event(event, state), do: elem(handle(state, event), 0)
+
   @spec catchup_already_applied?(EditorState.t(), String.t(), String.t()) :: boolean()
   defp catchup_already_applied?(state, path, tool_call_id) do
     state
@@ -1058,5 +1064,58 @@ defmodule MingaEditor.Agent.Events do
      payload["tool_call_id"], payload["tool_name"]}
   end
 
+  defp event_record_to_editor_event(%{event_type: :todo_plan_updated, payload: payload}) do
+    {:todo_plan_updated, todo_items_from_payload(Map.get(payload, "todos", []))}
+  end
+
   defp event_record_to_editor_event(_event), do: nil
+
+  @spec todo_items_from_payload(term()) :: [MingaAgent.TodoItem.t()]
+  defp todo_items_from_payload(items) when is_list(items) do
+    Enum.flat_map(items, fn
+      %{} = item ->
+        case todo_item_from_payload(item) do
+          nil -> []
+          todo -> [todo]
+        end
+
+      _ ->
+        []
+    end)
+  end
+
+  defp todo_items_from_payload(_items), do: []
+
+  @spec todo_item_from_payload(map()) :: MingaAgent.TodoItem.t() | nil
+  defp todo_item_from_payload(item) do
+    id = payload_string(item, "id")
+    description = payload_string(item, "description")
+
+    if id != "" and description != "" do
+      %MingaAgent.TodoItem{
+        id: id,
+        description: description,
+        status: todo_status_payload(item)
+      }
+    end
+  end
+
+  @spec todo_status_payload(map()) :: MingaAgent.TodoItem.status()
+  defp todo_status_payload(item) do
+    case payload_string(item, "status") do
+      "in_progress" -> :in_progress
+      "done" -> :done
+      _ -> :pending
+    end
+  end
+
+  @spec payload_string(map(), String.t()) :: String.t()
+  defp payload_string(payload, key) do
+    case Map.get(payload, key) || Map.get(payload, String.to_atom(key)) do
+      nil -> ""
+      value when is_binary(value) -> value
+      value when is_atom(value) -> Atom.to_string(value)
+      value -> to_string(value)
+    end
+  end
 end

--- a/lib/minga_editor/commands/edit_timeline.ex
+++ b/lib/minga_editor/commands/edit_timeline.ex
@@ -18,14 +18,16 @@ defmodule MingaEditor.Commands.EditTimeline do
   @command_specs [
     {:timeline_next_edit, "Next agent edit", true},
     {:timeline_prev_edit, "Previous agent edit", true},
-    {:timeline_next_file, "Next agent-changed file", true},
-    {:timeline_prev_file, "Previous agent-changed file", true},
+    {:timeline_next_file, "Next agent-changed file", false},
+    {:timeline_prev_file, "Previous agent-changed file", false},
     {:timeline_toggle, "Toggle edit timeline visibility", false},
     {:timeline_go_live, "Return to current file state", true}
   ]
 
   @spec execute(EditorState.t(), atom()) :: EditorState.t()
-  def execute(%{workspace: %{buffers: %{active: nil}}} = state, _cmd), do: state
+  def execute(%{workspace: %{buffers: %{active: nil}}} = state, cmd)
+      when cmd in [:timeline_next_edit, :timeline_prev_edit, :timeline_go_live],
+      do: state
 
   def execute(state, :timeline_next_edit) do
     with_timeline(state, fn path, timeline ->
@@ -119,9 +121,16 @@ defmodule MingaEditor.Commands.EditTimeline do
         current_path = active_path(state)
         target_path = next_path(paths, current_path, direction)
 
-        state
-        |> BufferRegistry.open_file_by_path(target_path)
-        |> EditorState.set_status("Agent change file: #{target_path}")
+        case BufferRegistry.open_file_by_path_result(state, target_path) do
+          {:ok, new_state} ->
+            EditorState.set_status(new_state, "Agent change file: #{target_path}")
+
+          {:error, reason} ->
+            EditorState.set_status(
+              state,
+              "Could not open agent change file #{target_path}: #{inspect(reason)}"
+            )
+        end
     end
   end
 

--- a/lib/minga_editor/layout/footer_overlays.ex
+++ b/lib/minga_editor/layout/footer_overlays.ex
@@ -34,37 +34,33 @@ defmodule MingaEditor.Layout.FooterOverlays do
       conservative slack: e.g. a notification item with no body draws 1 line where
       the count budgets 2).
 
-    * **Wrap-dependent surfaces** (float_popup, extension_panel, and the dormant
-      agent_context / tool_manager): these wrap text frontend-side where the BEAM
-      only knows an item count, not a wrapped line count, so `content_height` stays
-      `:max` (the clamp ceiling). Go bottom-aligns the rendered content within the
-      band (`Y = rect.Row + bandHeight - contentLines`), so the overlay still hugs
-      the screen bottom; the residual phantom zone (clamp ceiling minus rendered
-      lines) sits ABOVE the content, between the buffer and the overlay, not below
-      it. Per surface, the phantom band is at most `band_height - rendered_lines`
-      rows tall: float_popup renders `1 + min(line_count, ceiling-1)` lines so its
-      phantom zone is the remaining ceiling rows above; extension_panel renders a
-      title plus up to two blocks per visible panel until it fills the band, so its
-      phantom zone shrinks as panels are added; agent_context and tool_manager are
-      dormant (never visible today) so their phantom zone is moot until a future
-      child gives them a render-model source.
+    * **Wrap-dependent surfaces** (float_popup, agent_context, and extension_panel): these wrap
+      text frontend-side where the BEAM only knows an item count, not a wrapped
+      line count, so `content_height` stays `:max` (the clamp ceiling). Go
+      bottom-aligns the rendered content within the band (`Y = rect.Row +
+      bandHeight - contentLines`), so the overlay still hugs the screen bottom;
+      the residual phantom zone (clamp ceiling minus rendered lines) sits ABOVE
+      the content, between the buffer and the overlay, not below it. Per surface,
+      the phantom band is at most `band_height - rendered_lines` rows tall:
+      float_popup renders `1 + min(line_count, ceiling-1)` lines so its phantom
+      zone is the remaining ceiling rows above; agent_context renders the live
+      activity spine and may wrap the visible task or todo text; extension_panel
+      renders a title plus up to two blocks per visible panel until it fills the
+      band, so its phantom zone shrinks as panels are added.
 
   ## Live vs dormant sources (honesty, #2281)
 
-  Six surfaces have a live BEAM content source in the render-model path and so can
-  actually become visible here: float popup, extension panel, observatory, edit
-  timeline, notifications, extension overlay. Two are dormant on that path: the
-  agent-context builder is a permanent `visible: false` stub
-  (`MingaEditor.RenderModel.UI.AgentContextBuilder`, fed by `gui_payload/1` which
-  the traditional shell always returns `nil` for), and the tool manager is not in
-  the render-model UI at all (it ships only via the legacy `protocol/gui.ex`
-  path). Their predicates here are wired to the same future sources, so they are
-  placement-ready and will light up automatically when an epic child gives them a
-  BEAM render-model source. Today their predicates never fire, which is correct:
-  an overlay the BEAM never renders must not claim a footer band.
+  Seven surfaces have a live BEAM content source in the render-model path and so
+  can actually become visible here: float popup, extension panel, observatory,
+  edit timeline, notifications, extension overlay, and agent context. One is
+  dormant on that path: the tool manager is not in the render-model UI at all (it
+  ships only via the legacy `protocol/gui.ex` path). Their predicates here are
+  wired to the same future sources, so they are placement-ready and will light up
+  automatically when an epic child gives them a BEAM render-model source. Today
+  the tool manager predicate never fires, which is correct: an overlay the BEAM
+  never renders must not claim a footer band.
   """
 
-  alias Minga.RenderModel.UI.AgentContext
   alias MingaEditor.RenderModel.UI.AgentContextBuilder
 
   @typedoc "A visible footer overlay: its registry surface id and its band content height."
@@ -189,14 +185,12 @@ defmodule MingaEditor.Layout.FooterOverlays do
 
   defp float_popup_visible?(_state), do: false
 
-  # Agent context: dormant on the render-model path (builder is a permanent stub,
-  # see moduledoc). Driving it through the builder keeps the predicate honest and
-  # ready to light up if a future child supplies a real gui_payload-backed model.
+  # Agent context: live BEAM-owned agent activity projection. The builder's
+  # visibility predicate reads the same live editor state as the render model but
+  # avoids building the full emit context, so this check stays cheap and non-recursive.
   @spec agent_context_visible?(map()) :: boolean()
-  defp agent_context_visible?(_state) do
-    case AgentContextBuilder.build(nil) do
-      %AgentContext{visible: visible?} -> visible?
-    end
+  defp agent_context_visible?(state) do
+    AgentContextBuilder.visible?(state)
   end
 
   # Tool manager: not in the render-model UI; no BEAM content source on this path.

--- a/lib/minga_editor/remote/event_replay.ex
+++ b/lib/minga_editor/remote/event_replay.ex
@@ -70,6 +70,10 @@ defmodule MingaEditor.Remote.EventReplay do
 
   def to_agent_event(%EventRecord{event_type: :message_changed}), do: :messages_changed
 
+  def to_agent_event(%EventRecord{event_type: :todo_plan_updated, payload: payload}) do
+    {:todo_plan_updated, todo_items_from_payload(payload_value(payload, "todos"))}
+  end
+
   def to_agent_event(%EventRecord{event_type: :error, payload: payload}),
     do: {:error, string_payload(payload, "message")}
 
@@ -150,6 +154,45 @@ defmodule MingaEditor.Remote.EventReplay do
     case payload_value(payload, key) do
       value when is_map(value) -> value
       _ -> %{}
+    end
+  end
+
+  @spec todo_items_from_payload(term()) :: [MingaAgent.TodoItem.t()]
+  defp todo_items_from_payload(items) when is_list(items) do
+    Enum.flat_map(items, fn
+      %{} = item ->
+        case todo_item_from_payload(item) do
+          nil -> []
+          todo -> [todo]
+        end
+
+      _ ->
+        []
+    end)
+  end
+
+  defp todo_items_from_payload(_items), do: []
+
+  @spec todo_item_from_payload(map()) :: MingaAgent.TodoItem.t() | nil
+  defp todo_item_from_payload(item) do
+    id = string_payload(item, "id")
+    description = string_payload(item, "description")
+
+    if id != "" and description != "" do
+      %MingaAgent.TodoItem{
+        id: id,
+        description: description,
+        status: todo_status_payload(item)
+      }
+    end
+  end
+
+  @spec todo_status_payload(map()) :: MingaAgent.TodoItem.status()
+  defp todo_status_payload(item) do
+    case string_payload(item, "status") do
+      "in_progress" -> :in_progress
+      "done" -> :done
+      _ -> :pending
     end
   end
 

--- a/lib/minga_editor/render_model/ui/agent_context_builder.ex
+++ b/lib/minga_editor/render_model/ui/agent_context_builder.ex
@@ -6,19 +6,21 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilder do
   alias Minga.RenderModel.UI.AgentContext.Todo
   alias MingaEditor.Agent.Activity
   alias MingaEditor.Frontend.Emit.Context
+  alias MingaEditor.State.AgentAccess
 
   @spec build(Context.t() | term()) :: AgentContext.t()
   def build(%Context{} = ctx) do
     activity = get_activity(ctx)
-    status = agent_status(ctx)
+    can_approve = can_approve?(ctx)
+    status = context_status(agent_status(ctx), can_approve)
 
-    if visible?(activity, status) do
+    if visible?(activity, status, can_approve) do
       %AgentContext{
         visible: true,
         task: task(activity, status),
         dispatch_timestamp: activity.started_at || DateTime.utc_now(),
-        status: context_status(status),
-        can_approve: can_approve?(ctx),
+        status: status,
+        can_approve: can_approve,
         todos: todos(activity),
         progress: progress(activity)
       }
@@ -29,6 +31,25 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilder do
 
   def build(_other), do: hidden()
 
+  @spec visible?(Context.t() | map()) :: boolean()
+  def visible?(%Context{} = ctx) do
+    visible?(
+      get_activity(ctx),
+      context_status(agent_status(ctx), can_approve?(ctx)),
+      can_approve?(ctx)
+    )
+  end
+
+  def visible?(state) when is_map(state) do
+    can_approve = can_approve_from_state(state)
+
+    visible?(
+      get_activity_from_state(state),
+      context_status(agent_status_from_state(state), can_approve),
+      can_approve
+    )
+  end
+
   @spec hidden() :: AgentContext.t()
   defp hidden do
     %AgentContext{visible: false}
@@ -38,31 +59,42 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilder do
   defp get_activity(%{agent_ui: %{view: %{activity: %Activity{} = activity}}}), do: activity
   defp get_activity(_ctx), do: Activity.new()
 
+  @spec get_activity_from_state(map()) :: Activity.t()
+  defp get_activity_from_state(state), do: AgentAccess.view(state).activity
+
   @spec agent_status(Context.t()) :: atom()
   defp agent_status(%{shell_state: %{agent: %{runtime: %{status: status}}}}), do: status
   defp agent_status(_ctx), do: :idle
 
-  @spec visible?(Activity.t(), atom()) :: boolean()
-  defp visible?(%Activity{}, status) when status in [:thinking, :tool_executing], do: true
+  @spec agent_status_from_state(map()) :: atom()
+  defp agent_status_from_state(state), do: AgentAccess.agent(state).runtime.status
 
-  defp visible?(%Activity{todos: todos} = activity, _status) do
+  @spec can_approve_from_state(map()) :: boolean()
+  defp can_approve_from_state(state), do: AgentAccess.agent(state).pending_approval != nil
+
+  @spec visible?(Activity.t(), atom(), boolean()) :: boolean()
+  defp visible?(%Activity{}, _status, true), do: true
+  defp visible?(%Activity{}, status, false) when status in [:working, :iterating], do: true
+
+  defp visible?(%Activity{todos: todos} = activity, _status, _can_approve) do
     todos != [] or activity.tool_count > 0 or Activity.file_count(activity) > 0
   end
 
   @spec task(Activity.t(), atom()) :: String.t()
   defp task(%Activity{active_action: action}, _status) when action not in ["", nil], do: action
   defp task(%Activity{todos: [%{description: description} | _]}, _status), do: description
-  defp task(_activity, :tool_executing), do: "Running tools"
-  defp task(_activity, :thinking), do: "Thinking"
+  defp task(_activity, :iterating), do: "Running tools"
+  defp task(_activity, :working), do: "Thinking"
   defp task(_activity, _status), do: "Agent activity"
 
-  @spec context_status(atom()) :: AgentContext.status()
-  defp context_status(:thinking), do: :working
-  defp context_status(:tool_executing), do: :iterating
-  defp context_status(:error), do: :errored
-  defp context_status(:idle), do: :done
-  defp context_status(:plan), do: :idle
-  defp context_status(_status), do: :idle
+  @spec context_status(atom(), boolean()) :: AgentContext.status()
+  defp context_status(_status, true), do: :needs_you
+  defp context_status(:thinking, false), do: :working
+  defp context_status(:tool_executing, false), do: :iterating
+  defp context_status(:error, false), do: :errored
+  defp context_status(:idle, false), do: :done
+  defp context_status(:plan, false), do: :idle
+  defp context_status(_status, false), do: :idle
 
   @spec can_approve?(Context.t()) :: boolean()
   defp can_approve?(%{shell_state: %{agent: %{pending_approval: approval}}}), do: approval != nil

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -41,6 +41,28 @@ private func appendConfigStateString16(_ data: inout Data, _ text: String) {
     data.append(contentsOf: bytes)
 }
 
+private func appendWireU16(_ data: inout Data, _ value: UInt16) {
+    appendConfigStateU16(&data, value)
+}
+
+private func appendWireU32(_ data: inout Data, _ value: UInt32) {
+    appendConfigStateU32(&data, value)
+}
+
+private func appendWireU64(_ data: inout Data, _ value: UInt64) {
+    appendConfigStateU64(&data, value)
+}
+
+private func appendWireString8(_ data: inout Data, _ text: String) {
+    let bytes = Array(text.utf8.prefix(Int(UInt8.max)))
+    data.append(UInt8(bytes.count))
+    data.append(contentsOf: bytes)
+}
+
+private func appendWireString16(_ data: inout Data, _ text: String) {
+    appendConfigStateString16(&data, text)
+}
+
 private func appendConfigStateValue(_ data: inout Data, _ value: SettingValue) {
     switch value {
     case .bool(let enabled):
@@ -95,6 +117,114 @@ struct ProtocolDecoderTests {
         }
         #expect(frameSeq == 7)
         #expect(baseFrameSeq == 3)
+    }
+
+    @Test("Decode framed gui_agent_context payload")
+    func decodeFramedGuiAgentContext() throws {
+        let dispatchTimestamp = Date(timeIntervalSince1970: 1_705_314_000)
+        var body = Data([1])
+        appendWireString16(&body, "Review diff")
+        appendWireU64(&body, UInt64(dispatchTimestamp.timeIntervalSince1970))
+        body.append(3)
+        body.append(1)
+        appendWireString16(&body, "Running shell")
+        appendWireU16(&body, 2)
+        appendWireU16(&body, 1)
+        appendWireString16(&body, "Review: approve or reject changes")
+        body.append(1)
+        body.append(1)
+        appendWireString16(&body, "Inspect files")
+
+        var payload = Data()
+        appendWireU16(&payload, UInt16(body.count))
+        payload.append(body)
+
+        var data = Data([OP_GUI_AGENT_CONTEXT])
+        data.append(payload)
+
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+        guard case .guiAgentContext(let visible, let task, let decodedTimestamp, let status, let canApprove, let progress, let todos) = cmd else {
+            Issue.record("Expected .guiAgentContext, got \(String(describing: cmd))")
+            return
+        }
+
+        #expect(visible)
+        #expect(task == "Review diff")
+        #expect(decodedTimestamp == dispatchTimestamp)
+        #expect(status == .needsYou)
+        #expect(canApprove)
+        #expect(progress.activeAction == "Running shell")
+        #expect(progress.toolCount == 2)
+        #expect(progress.fileCount == 1)
+        #expect(progress.reviewHint == "Review: approve or reject changes")
+        #expect(todos.count == 1)
+        #expect(todos[0].status == 1)
+        #expect(todos[0].description == "Inspect files")
+    }
+
+    @Test("Decode legacy gui_agent_context payload")
+    func decodeLegacyGuiAgentContext() throws {
+        let dispatchTimestamp = Date(timeIntervalSince1970: 1_705_314_100)
+        var data = Data([OP_GUI_AGENT_CONTEXT, 1])
+        appendWireString16(&data, "Legacy diff")
+        appendWireU64(&data, UInt64(dispatchTimestamp.timeIntervalSince1970))
+        data.append(4)
+        data.append(1)
+
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+        guard case .guiAgentContext(let visible, let task, let decodedTimestamp, let status, let canApprove, _, let todos) = cmd else {
+            Issue.record("Expected .guiAgentContext, got \(String(describing: cmd))")
+            return
+        }
+
+        #expect(visible)
+        #expect(task == "Legacy diff")
+        #expect(decodedTimestamp == dispatchTimestamp)
+        #expect(status == .done)
+        #expect(canApprove)
+        #expect(todos.isEmpty)
+    }
+
+    @Test("Decode gui_edit_timeline file summaries")
+    func decodeGuiEditTimelineFiles() throws {
+        var payload = Data([1])
+        appendWireU16(&payload, 0xFFFF)
+        payload.append(1)
+        payload.append(0)
+        appendWireString8(&payload, "write_file")
+        appendWireU32(&payload, 12)
+        payload.append(1)
+        appendWireString16(&payload, "lib/a.ex")
+        payload.append(2)
+        appendWireU32(&payload, 10)
+        appendWireU32(&payload, 3)
+        payload.append(1)
+
+        var data = Data([OP_GUI_EDIT_TIMELINE])
+        appendWireU16(&data, UInt16(payload.count))
+        data.append(payload)
+
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+        guard case .guiEditTimeline(let visible, let viewingIndex, let entries, let files) = cmd else {
+            Issue.record("Expected .guiEditTimeline, got \(String(describing: cmd))")
+            return
+        }
+
+        #expect(visible)
+        #expect(viewingIndex == 0xFFFF)
+        #expect(entries.count == 1)
+        #expect(entries[0].index == 0)
+        #expect(entries[0].toolName == "write_file")
+        #expect(entries[0].timestampDelta == 12)
+        #expect(files.count == 1)
+        #expect(files[0].path == "lib/a.ex")
+        #expect(files[0].entryCount == 2)
+        #expect(files[0].linesAdded == 10)
+        #expect(files[0].linesRemoved == 3)
+        #expect(files[0].reviewStatus == 1)
     }
 
     @Test("Skip known sized command without renderer handler")

--- a/test/minga/frontend/adapter/gui/agent_context_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/agent_context_encoder_test.exs
@@ -50,7 +50,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentContextEncoderTest do
         visible: true,
         task: "Done",
         dispatch_timestamp: ts,
-        status: :done,
+        status: :needs_you,
         can_approve: true
       }
 
@@ -62,7 +62,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentContextEncoderTest do
 
       assert <<@op_gui_agent_context, payload_len::16, payload::binary-size(payload_len)>> = cmd
 
-      assert <<1::8, ^task_len::16, "Done", ^timestamp_unix::64, 4::8, 1::8,
+      assert <<1::8, ^task_len::16, "Done", ^timestamp_unix::64, 3::8, 1::8,
                _progress_and_todos::binary>> = payload
     end
 
@@ -73,7 +73,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentContextEncoderTest do
         visible: true,
         task: "Done",
         dispatch_timestamp: ts,
-        status: :done,
+        status: :needs_you,
         can_approve: true,
         progress: %Progress{
           active_action: "shell",
@@ -93,7 +93,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentContextEncoderTest do
       task_len = byte_size("Done")
       timestamp_unix = DateTime.to_unix(ts)
 
-      assert <<1::8, ^task_len::16, "Done", ^timestamp_unix::64, 4::8, 1::8, 5::16, "shell",
+      assert <<1::8, ^task_len::16, "Done", ^timestamp_unix::64, 3::8, 1::8, 5::16, "shell",
                2::16, 1::16, 33::16, "Review: approve or reject changes", 2::8, 2::8, 13::16,
                "Inspect files", 1::8, 9::16, "Run tests">> = payload
     end

--- a/test/minga_agent/event_log/session_integration_test.exs
+++ b/test/minga_agent/event_log/session_integration_test.exs
@@ -5,6 +5,7 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
   alias MingaAgent.EventLog
   alias MingaAgent.EventLog.Store
   alias MingaAgent.Session
+  alias MingaAgent.TodoItem
 
   @moduletag :tmp_dir
 
@@ -113,6 +114,57 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
     def handle_cast(:new_session, state), do: {:noreply, state}
   end
 
+  defmodule TodoProvider do
+    @behaviour MingaAgent.Provider
+
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl MingaAgent.Provider
+    def send_prompt(pid, text), do: GenServer.cast(pid, {:prompt, text})
+
+    @impl MingaAgent.Provider
+    def abort(pid), do: GenServer.cast(pid, :abort)
+
+    @impl MingaAgent.Provider
+    def new_session(pid), do: GenServer.cast(pid, :new_session)
+
+    @impl MingaAgent.Provider
+    def seed_messages(_pid, _messages), do: :ok
+
+    @impl MingaAgent.Provider
+    def get_state(_pid), do: {:ok, %{model: "test", is_streaming: false, token_usage: nil}}
+
+    @impl true
+    def init(opts) do
+      {:ok, %{subscriber: Keyword.fetch!(opts, :subscriber)}}
+    end
+
+    @impl true
+    def handle_cast({:prompt, text}, state) do
+      send(state.subscriber, {:agent_provider_event, %Event.AgentStart{}})
+      send(state.subscriber, {:agent_provider_event, %Event.TextDelta{delta: text}})
+
+      send(
+        state.subscriber,
+        {:agent_provider_event,
+         %Event.TodoPlan{
+           todos: [
+             %TodoItem{id: "1", description: "Inspect files", status: :in_progress}
+           ]
+         }}
+      )
+
+      send(state.subscriber, {:agent_provider_event, %Event.AgentEnd{}})
+      {:noreply, state}
+    end
+
+    def handle_cast(:abort, state), do: {:noreply, state}
+    def handle_cast(:new_session, state), do: {:noreply, state}
+  end
+
   test "session broadcasts are durably recorded for replay", %{tmp_dir: tmp_dir} do
     log_name = unique_name("session-log")
 
@@ -156,6 +208,41 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
 
     tool_end = Enum.find(events, &(&1.event_type == :tool_call_finished))
     assert tool_end.payload["tool_call_id"] == "tool-1"
+    :ok = Store.close(db)
+  end
+
+  test "todo plans are recorded as JSON-safe payloads for replay", %{tmp_dir: tmp_dir} do
+    log_name = unique_name("todo-log")
+
+    log_pid =
+      start_supervised!(
+        {EventLog, name: log_name, db_dir: tmp_dir, retention_sweep?: false, health_check: :none}
+      )
+
+    session =
+      start_supervised!(
+        {Session,
+         session_id: "todo-session",
+         provider: TodoProvider,
+         event_log_server: log_name,
+         persist?: false,
+         hooks_enabled?: false}
+      )
+
+    :sys.get_state(session)
+    assert :ok = Session.send_prompt(session, "plan this")
+    :sys.get_state(session)
+    :sys.get_state(log_pid)
+
+    {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
+    events = wait_for_event(db, "todo-session", :todo_plan_updated, session, log_pid)
+    todo_event = Enum.find(events, &(&1.event_type == :todo_plan_updated))
+
+    assert todo_event.payload["todos"] == [
+             %{"id" => "1", "description" => "Inspect files", "status" => "in_progress"}
+           ]
+
+    assert JSON.decode!(JSON.encode!(todo_event.payload)) == todo_event.payload
     :ok = Store.close(db)
   end
 

--- a/test/minga_editor/commands/edit_timeline_test.exs
+++ b/test/minga_editor/commands/edit_timeline_test.exs
@@ -1,0 +1,49 @@
+defmodule MingaEditor.Commands.EditTimelineTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Agent.EditTimeline
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.Commands.EditTimeline, as: EditTimelineCommands
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
+  alias MingaEditor.Session.State, as: WorkspaceState
+  alias MingaEditor.Viewport
+
+  describe "execute/2" do
+    test "timeline_next_edit stays guarded when no buffer is active" do
+      state = state_with_timeline()
+
+      assert EditTimelineCommands.execute(state, :timeline_next_edit) == state
+    end
+
+    test "timeline_next_file works without an active buffer and reports open failures" do
+      state = state_with_timeline()
+
+      updated = EditTimelineCommands.execute(state, :timeline_next_file)
+
+      assert status = EditorState.status_msg(updated)
+      assert String.contains?(status, "Could not open agent change file /tmp/a-missing.ex")
+    end
+
+    test "timeline_prev_file wraps to the last path without an active buffer" do
+      state = state_with_timeline()
+
+      updated = EditTimelineCommands.execute(state, :timeline_prev_file)
+
+      assert status = EditorState.status_msg(updated)
+      assert String.contains?(status, "Could not open agent change file /tmp/b-missing.ex")
+    end
+  end
+
+  defp state_with_timeline do
+    timeline =
+      EditTimeline.new()
+      |> EditTimeline.record_edit("/tmp/a-missing.ex", "tc1", "write_file", "old", "new")
+      |> EditTimeline.record_edit("/tmp/b-missing.ex", "tc2", "write_file", "old", "new")
+
+    %EditorState{port_manager: self(), workspace: %WorkspaceState{viewport: Viewport.new(24, 80)}}
+    |> AgentAccess.update_agent_ui(fn ui ->
+      UIState.update_edit_timeline(ui, fn _ -> timeline end)
+    end)
+  end
+end

--- a/test/minga_editor/layout/footer_band_overlays_test.exs
+++ b/test/minga_editor/layout/footer_band_overlays_test.exs
@@ -20,12 +20,17 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.SystemObserver.ProcessSnapshot
   alias Minga.SystemObserver.TreeNode
+  alias MingaEditor.Agent.Activity
   alias MingaEditor.Agent.EditTimeline
+  alias MingaEditor.Agent.Events, as: AgentEvents
+  alias MingaEditor.Agent.UIState
   alias MingaEditor.FocusTree
   alias MingaEditor.Input.Router
   alias MingaEditor.Layout
   alias MingaEditor.Layout.OverlayBand
   alias MingaEditor.Layout.SurfaceRegistry
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.UI.Notification
   alias MingaEditor.UI.NotificationCenter
 
@@ -44,6 +49,25 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
 
   defp with_observatory(state) do
     put_in(state.shell_state.observatory_visible, true)
+  end
+
+  defp with_agent_context(state) do
+    approval = %{tool_call_id: "tc1", name: "shell", args: %{}}
+
+    state =
+      %{
+        state
+        | shell_state: %{
+            state.shell_state
+            | agent: AgentState.set_pending_approval(state.shell_state.agent, approval)
+          }
+      }
+      |> AgentAccess.update_agent_ui(fn ui ->
+        UIState.update_activity(ui, fn _ -> Activity.new() end)
+      end)
+
+    {state, _effects} = AgentEvents.handle(state, {:approval_pending, approval})
+    state
   end
 
   # Builds an observatory tree with `count` nodes (one root plus count-1 direct
@@ -180,6 +204,21 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
       {row, _col, _width, height} = SurfaceRegistry.rect_for(state, :edit_timeline)
 
       assert height == 3
+      assert row + height == 24
+    end
+
+    test "pending approval alone places the agent context band" do
+      state = with_agent_context(base_state(rows: 24, cols: 80))
+
+      assert AgentAccess.agent(state).pending_approval != nil
+      assert AgentAccess.view(state).activity.todos == []
+      assert AgentAccess.view(state).activity.tool_count == 0
+
+      {row, _col, _width, height} = SurfaceRegistry.rect_for(state, :agent_context)
+      ids = state |> SurfaceRegistry.placements() |> Enum.map(& &1.surface_id)
+
+      assert :agent_context in ids
+      assert height > 0
       assert row + height == 24
     end
 

--- a/test/minga_editor/remote/event_replay_test.exs
+++ b/test/minga_editor/remote/event_replay_test.exs
@@ -1,9 +1,15 @@
 defmodule MingaEditor.Remote.EventReplayTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.Agent.Events, as: AgentEvents
   alias MingaEditor.Remote.EventReplay
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
+  alias MingaEditor.Session.State, as: WorkspaceState
+  alias MingaEditor.Viewport
   alias MingaAgent.EventLog.EventRecord
   alias MingaAgent.ToolApproval.Preview
+  alias MingaAgent.TodoItem
 
   test "converts durable remote events into live agent events" do
     assert EventReplay.to_agent_event(record(:assistant_delta, %{"delta" => "hello"})) ==
@@ -81,6 +87,36 @@ defmodule MingaEditor.Remote.EventReplayTest do
            ) == {:prompt_queued, "next", :follow_up}
 
     assert EventReplay.to_agent_event(record(:message_changed, %{})) == :messages_changed
+
+    assert EventReplay.to_agent_event(
+             record(:todo_plan_updated, %{
+               "todos" => [
+                 %{"id" => "1", "description" => "Inspect files", "status" => "done"}
+               ]
+             })
+           ) ==
+             {:todo_plan_updated,
+              [%TodoItem{id: "1", description: "Inspect files", status: :done}]}
+  end
+
+  test "replays durable todo plans into editor activity on catch-up" do
+    state = %EditorState{
+      port_manager: self(),
+      workspace: %WorkspaceState{viewport: Viewport.new(24, 80)}
+    }
+
+    updated =
+      AgentEvents.replay_catchup(state, [
+        record(:todo_plan_updated, %{
+          "todos" => [
+            %{"id" => "1", "description" => "Inspect files", "status" => "in_progress"}
+          ]
+        })
+      ])
+
+    assert AgentAccess.view(updated).activity.todos == [
+             %TodoItem{id: "1", description: "Inspect files", status: :in_progress}
+           ]
   end
 
   test "ignores durable events that have no foreground UI equivalent" do

--- a/test/minga_editor/render_model/ui/agent_context_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_context_builder_test.exs
@@ -5,9 +5,12 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
   alias Minga.RenderModel.UI.AgentContext.Todo
   alias MingaAgent.TodoItem
   alias MingaEditor.Agent.Activity
+  alias MingaEditor.Agent.Events, as: AgentEvents
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.RenderModel.UI.AgentContextBuilder
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.AgentAccess
 
   describe "build/1" do
     test "projects activity, todos, and review vocabulary into agent context" do
@@ -37,7 +40,7 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
       assert %AgentContext{
                visible: true,
                task: "Running shell",
-               status: :iterating,
+               status: :needs_you,
                can_approve: true,
                todos: [%Todo{description: "Run tests", status: :in_progress}],
                progress: %{
@@ -47,6 +50,41 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
                  review_hint: "Review: approve or reject changes"
                }
              } = AgentContextBuilder.build(ctx)
+    end
+
+    test "approval-only visible context keeps the dispatch timestamp stable" do
+      approval = %{tool_call_id: "tc-approval", name: "shell", args: %{}}
+
+      state =
+        %{
+          shell_state: %{agent: AgentState.set_pending_approval(%AgentState{}, approval)},
+          workspace: %{agent_ui: UIState.new()}
+        }
+        |> then(fn state -> elem(AgentEvents.handle(state, {:approval_pending, approval}), 0) end)
+
+      started_at = AgentAccess.view(state).activity.started_at
+      assert started_at != nil
+
+      ctx = %Context{
+        port_manager: self(),
+        capabilities: nil,
+        theme: nil,
+        font_registry: nil,
+        windows: nil,
+        layout: nil,
+        shell: MingaEditor.Shell.Traditional,
+        shell_state: state.shell_state,
+        agent_ui: AgentAccess.agent_ui(state)
+      }
+
+      first = AgentContextBuilder.build(ctx)
+      second = AgentContextBuilder.build(ctx)
+
+      assert first.visible
+      assert first.status == :needs_you
+      assert first.dispatch_timestamp == started_at
+      assert second.dispatch_timestamp == started_at
+      assert first.dispatch_timestamp == second.dispatch_timestamp
     end
   end
 end


### PR DESCRIPTION
# TL;DR
This hardens the agent activity changeset spine that landed in #2495. It fixes follow-up issues in changed-file navigation, protocol framing/versioning docs, footer placement, todo-plan replay, and cross-frontend decoder coverage.

Refs #2495

## Context
#2495 added the live agent activity spine across the BEAM render model, protocol payloads, Go TUI, and macOS. A parent-orchestrated review loop found a few merge-safety issues after that PR merged, mostly around compatibility edges and replay behavior.

## Changes
- Lets `]f` and `[f` navigate agent-touched files even when no buffer is active, and preserves file-open failure status instead of reporting success.
- Bumps the protocol contract to version 6 and documents the framed `gui_agent_context` payload plus edit-timeline file summaries.
- Places the agent context footer overlay from live editor state, including approval-only states.
- Persists todo-plan updates as JSON-safe event-log payloads and replays them back into editor activity state.
- Seeds a stable activity timestamp for approval-only contexts so frontend elapsed timers do not jitter.
- Adds focused Elixir, Go, and Swift regression tests for protocol decoding, replay, footer placement, and navigation behavior.

## Compatibility
`gui_agent_context` now has an explicit protocol-version bump for its framed payload. Frontend decoders still cover the legacy agent-context shape, and hidden framed contexts may omit the progress/todo tail for compatibility.

## Verification
- `git diff --check`
- `mix protocol.gen --check`
- `mix test.llm test/minga_agent/event_log/session_integration_test.exs test/minga_editor/remote/event_replay_test.exs test/minga_editor/render_model/ui/agent_context_builder_test.exs test/minga_editor/layout/footer_band_overlays_test.exs test/minga_editor/commands/edit_timeline_test.exs test/minga/frontend/adapter/gui/agent_context_encoder_test.exs test/minga/frontend/adapter/gui/edit_timeline_encoder_test.exs`
- `make lint`
- `mix native.build.support`
- `mix test --failed` after building parser artifact
- `mix test.llm`
- `cd go/tui && go test ./internal/protocol ./internal/ui`
- `cd macos && xcodebuild test -project Minga.xcodeproj -scheme Minga -destination 'platform=macOS'`

## Review Loop Summary
- Round 1 found blockers in navigation, protocol versioning, footer placement, and todo replay.
- Round 2 found blockers in JSON-safe event-log payloads and stable approval-only timestamps.
- Round 3 found no blockers. Two doc/comment consistency notes were fixed before final validation.
