### PR TITLE
Cap agent tool token spend

### DIFF
--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -2781,10 +2781,12 @@ defmodule MingaAgent.Providers.Native do
   defp do_maybe_compact(lctx, context) do
     compact_opts = [
       model: lctx.model,
-      llm_client: summary_client(lctx.llm_client, lctx.config)
+      llm_client: summary_client(lctx.llm_client, lctx.config),
+      threshold: lctx.config.compaction_threshold,
+      keep_recent: lctx.config.compaction_keep_recent
     ]
 
-    case Compaction.maybe_compact(context, compact_opts) do
+    case maybe_compact_with_opts(context, compact_opts) do
       {:compacted, new_context, summary_info} ->
         send(
           lctx.provider_pid,
@@ -2804,6 +2806,16 @@ defmodule MingaAgent.Providers.Native do
   @spec summary_client(llm_client(), AgentConfig.t()) :: Compaction.summary_fn()
   defp summary_client(llm_client, config) do
     ReqLLMAdapter.summary_client(llm_client, config)
+  end
+
+  @spec maybe_compact_with_opts(Context.t(), keyword()) ::
+          {:compacted, Context.t(), String.t()} | {:ok, Context.t()}
+  defp maybe_compact_with_opts(context, opts) do
+    if Keyword.get(opts, :threshold) == nil do
+      {:ok, context}
+    else
+      Compaction.maybe_compact(context, opts)
+    end
   end
 
   @spec refresh_tool_registry_contributions(state()) :: state()
@@ -3033,10 +3045,10 @@ defmodule MingaAgent.Providers.Native do
   write_file: Create/overwrite files. Auto-creates parent dirs.
   edit_file: Find-and-replace exact text. Read file first for exact match.
   apply_diff: Apply unified diffs to a file. Use for large or multi-hunk edits.
-  list_directory: List entries at a path.
-  find: Find files by name/glob. Prefer over shell+find.
-  grep: Search file contents by pattern. Prefer over shell+grep.
-  shell: Run shell commands in project root. Timeout: 30s.
+  list_directory: List entries at a known-small path. Bounded and ignores generated trees.
+  find: Find files by name/glob. Bounded and ignores generated trees. Prefer over shell+find.
+  grep: Search file contents by pattern. Bounded and ignores generated trees. Prefer over shell+grep.
+  shell: Run shell commands in project root. Timeout: 30s. Output capped for the model.
   </tools>
 
   multi_edit_file: Apply multiple edits to one file in a single call.
@@ -3045,7 +3057,8 @@ defmodule MingaAgent.Providers.Native do
   - Always read a file before editing it. old_text must match exactly.
   - Prefer apply_diff for large changes that are easiest to express as unified diff hunks.
   - Prefer multi_edit_file when making several exact replacements in the same file.
-  - Use find for file discovery, grep for content search.
+  - Use find for file discovery, grep for content search, and list_directory only for known-small directories.
+  - Do not use shell to recursively list or search files when find or grep can answer the question.
   - Verify changes by reading the result or running tests.
   - Be concise. Show file paths clearly.
   </rules>
@@ -3064,11 +3077,9 @@ defmodule MingaAgent.Providers.Native do
         @default_system_prompt_template
       end
 
-    # Always append environment info
     base <>
       "\n## Environment\n\n" <>
-      "- Project root: #{project_root}\n" <>
-      "- Current time: #{DateTime.utc_now() |> DateTime.to_iso8601()}"
+      "- Project root: #{project_root}"
   end
 
   # If the value looks like a file path, read it. Otherwise return as-is.

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -3434,16 +3434,36 @@ defmodule MingaAgent.Providers.Native do
 
   defp normalize_usage(usage, model) when is_map(usage) do
     normalized = %MingaAgent.TurnUsage{
-      input: Map.get(usage, :input_tokens, 0) || Map.get(usage, :input, 0),
-      output: Map.get(usage, :output_tokens, 0) || Map.get(usage, :output, 0),
-      cache_read: Map.get(usage, :cache_read_input_tokens, 0) || Map.get(usage, :cache_read, 0),
+      input: usage_value(usage, [:input_tokens, :input], 0),
+      output: usage_value(usage, [:output_tokens, :output], 0),
+      cache_read:
+        usage_value(
+          usage,
+          [:cache_read_input_tokens, :cached_input, :cached_tokens, :cache_read],
+          0
+        ),
       cache_write:
-        Map.get(usage, :cache_creation_input_tokens, 0) || Map.get(usage, :cache_write, 0),
-      cost: Map.get(usage, :total_cost, 0.0) || 0.0
+        usage_value(
+          usage,
+          [:cache_creation_input_tokens, :cache_creation, :cache_creation_tokens, :cache_write],
+          0
+        ),
+      cost: usage_value(usage, [:total_cost, :cost], 0.0)
     }
 
     {provider_atom, model_id} = parse_model_string(model)
     CostCalculator.ensure_cost(normalized, model_id, provider_atom)
+  end
+
+  @spec usage_value(map(), [atom()], term()) :: term()
+  defp usage_value(_usage, [], default), do: default
+
+  defp usage_value(usage, [key | rest], default) do
+    case Map.fetch(usage, key) do
+      {:ok, nil} -> usage_value(usage, rest, default)
+      {:ok, value} -> value
+      :error -> usage_value(usage, rest, default)
+    end
   end
 
   @spec parse_model_string(String.t()) :: {atom(), String.t()}

--- a/lib/minga_agent/providers/native/req_llm_adapter.ex
+++ b/lib/minga_agent/providers/native/req_llm_adapter.ex
@@ -29,9 +29,14 @@ defmodule MingaAgent.Providers.Native.ReqLLMAdapter do
           optional(:output) => non_neg_integer(),
           optional(:cache_read_input_tokens) => non_neg_integer(),
           optional(:cache_creation_input_tokens) => non_neg_integer(),
+          optional(:cached_input) => non_neg_integer(),
+          optional(:cached_tokens) => non_neg_integer(),
+          optional(:cache_creation) => non_neg_integer(),
+          optional(:cache_creation_tokens) => non_neg_integer(),
           optional(:cache_read) => non_neg_integer(),
           optional(:cache_write) => non_neg_integer(),
-          optional(:total_cost) => number()
+          optional(:total_cost) => number(),
+          optional(:cost) => number()
         }
 
   @typedoc "Callbacks used while streaming a provider response."

--- a/lib/minga_agent/tool_router.ex
+++ b/lib/minga_agent/tool_router.ex
@@ -27,6 +27,7 @@ defmodule MingaAgent.ToolRouter do
   alias MingaAgent.Changeset
   alias MingaAgent.ProjectView
   alias MingaAgent.ToolRouter.Context
+  alias MingaAgent.ToolRouter.SearchContext
 
   @typedoc "Fork store reference (nil when fork routing is disabled)."
   @type fork_store :: pid() | nil
@@ -36,6 +37,9 @@ defmodule MingaAgent.ToolRouter do
 
   @typedoc "Routing context passed by tool callbacks."
   @type context :: Context.t()
+
+  @typedoc "Trusted execution and filtering context for search tools."
+  @type search_context :: SearchContext.t()
 
   @doc """
   Builds a routing context from the fork store and changeset pids.
@@ -242,6 +246,39 @@ defmodule MingaAgent.ToolRouter do
   end
 
   def filesystem_path_result(%Context{}, path), do: {:ok, path}
+
+  @doc "Returns the trusted execution and logical filtering context for search tools."
+  @spec search_context(context(), String.t()) :: {:ok, search_context()} | {:error, term()}
+  def search_context(%Context{project_view: %ProjectView{} = view}, path) do
+    case project_view_result(fn -> ProjectView.prepare_working_dir(view) end) do
+      {:ok, cwd} ->
+        {:ok,
+         %SearchContext{
+           exec_path: Path.expand(project_view_relative_path(view, path), cwd),
+           filter_root: path
+         }}
+
+      {:error, {:project_view_unavailable, _}} = error ->
+        error
+
+      {:error, reason} ->
+        {:error, {:project_view_unavailable, {:working_dir_failed, reason}}}
+    end
+  end
+
+  def search_context(%Context{changeset: cs}, path) when cs != nil and is_pid(cs) do
+    try do
+      with {:ok, cwd} <- Changeset.prepare_working_dir(cs),
+           {:ok, relative_path} <- normalize_changeset_path(cs, path, true) do
+        {:ok, %SearchContext{exec_path: Path.expand(relative_path, cwd), filter_root: path}}
+      end
+    catch
+      :exit, reason -> {:error, {:changeset_unavailable, reason}}
+    end
+  end
+
+  def search_context(%Context{}, path),
+    do: {:ok, %SearchContext{exec_path: path, filter_root: path}}
 
   @doc "Returns the working directory for shell commands, or a tagged error if ProjectView is unavailable."
   @spec working_dir_result(context()) :: {:ok, String.t() | nil} | {:error, term()}

--- a/lib/minga_agent/tool_router.ex
+++ b/lib/minga_agent/tool_router.ex
@@ -497,16 +497,20 @@ defmodule MingaAgent.ToolRouter do
 
   defp materialize_forks_for_command(%Context{fork_store: fs, changeset: cs})
        when fs != nil and cs != nil do
-    with :ok <- fork_store_available(fs) do
-      fs
-      |> BufferForkStore.all()
-      |> Enum.reduce_while(:ok, fn {path, fork_pid}, :ok ->
-        case materialize_fork_for_command(cs, path, fork_pid) do
-          :ok -> {:cont, :ok}
-          {:error, _reason} = error -> {:halt, error}
-        end
-      end)
+    case fork_store_available(fs) do
+      :ok -> materialize_command_forks(BufferForkStore.all(fs), cs)
+      {:error, _reason} = error -> error
     end
+  end
+
+  @spec materialize_command_forks(%{String.t() => pid()}, pid()) :: :ok | {:error, term()}
+  defp materialize_command_forks(forks, changeset) do
+    Enum.reduce_while(forks, :ok, fn {path, fork_pid}, :ok ->
+      case materialize_fork_for_command(changeset, path, fork_pid) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
   end
 
   @spec materialize_fork_for_command(pid(), String.t(), pid()) :: :ok | {:error, term()}

--- a/lib/minga_agent/tool_router.ex
+++ b/lib/minga_agent/tool_router.ex
@@ -234,9 +234,10 @@ defmodule MingaAgent.ToolRouter do
     end
   end
 
-  def filesystem_path_result(%Context{changeset: cs}, path) when cs != nil and is_pid(cs) do
+  def filesystem_path_result(%Context{changeset: cs} = ctx, path) when cs != nil and is_pid(cs) do
     try do
-      with {:ok, cwd} <- Changeset.prepare_working_dir(cs),
+      with :ok <- materialize_forks_for_command(ctx),
+           {:ok, cwd} <- Changeset.prepare_working_dir(cs),
            {:ok, relative_path} <- normalize_changeset_path(cs, path, true) do
         {:ok, Path.expand(relative_path, cwd)}
       end
@@ -266,9 +267,10 @@ defmodule MingaAgent.ToolRouter do
     end
   end
 
-  def search_context(%Context{changeset: cs}, path) when cs != nil and is_pid(cs) do
+  def search_context(%Context{changeset: cs} = ctx, path) when cs != nil and is_pid(cs) do
     try do
-      with {:ok, cwd} <- Changeset.prepare_working_dir(cs),
+      with :ok <- materialize_forks_for_command(ctx),
+           {:ok, cwd} <- Changeset.prepare_working_dir(cs),
            {:ok, relative_path} <- normalize_changeset_path(cs, path, true) do
         {:ok, %SearchContext{exec_path: Path.expand(relative_path, cwd), filter_root: path}}
       end
@@ -290,9 +292,11 @@ defmodule MingaAgent.ToolRouter do
     end
   end
 
-  def working_dir_result(%Context{changeset: cs}) when cs != nil and is_pid(cs) do
+  def working_dir_result(%Context{changeset: cs} = ctx) when cs != nil and is_pid(cs) do
     try do
-      Changeset.prepare_working_dir(cs)
+      with :ok <- materialize_forks_for_command(ctx) do
+        Changeset.prepare_working_dir(cs)
+      end
     catch
       :exit, reason -> {:error, {:changeset_unavailable, reason}}
     end
@@ -485,6 +489,34 @@ defmodule MingaAgent.ToolRouter do
       :ok
     catch
       :exit, reason -> {:error, {:changeset_unavailable, reason}}
+    end
+  end
+
+  @spec materialize_forks_for_command(context()) :: :ok | {:error, term()}
+  defp materialize_forks_for_command(%Context{fork_store: nil}), do: :ok
+
+  defp materialize_forks_for_command(%Context{fork_store: fs, changeset: cs})
+       when fs != nil and cs != nil do
+    with :ok <- fork_store_available(fs) do
+      fs
+      |> BufferForkStore.all()
+      |> Enum.reduce_while(:ok, fn {path, fork_pid}, :ok ->
+        case materialize_fork_for_command(cs, path, fork_pid) do
+          :ok -> {:cont, :ok}
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+    end
+  end
+
+  @spec materialize_fork_for_command(pid(), String.t(), pid()) :: :ok | {:error, term()}
+  defp materialize_fork_for_command(changeset, path, fork_pid) do
+    with {:ok, relative_path} <- normalize_changeset_path(changeset, path, false) do
+      Changeset.materialize_command_file(
+        changeset,
+        relative_path,
+        Minga.Buffer.Fork.content(fork_pid)
+      )
     end
   end
 

--- a/lib/minga_agent/tool_router/search_context.ex
+++ b/lib/minga_agent/tool_router/search_context.ex
@@ -1,0 +1,15 @@
+defmodule MingaAgent.ToolRouter.SearchContext do
+  @moduledoc """
+  Trusted execution and filtering context for routed search tools.
+
+  `exec_path` is the physical directory searched by tools. It may be a ProjectView or changeset overlay. `filter_root` is the logical project path used for ignore filtering and result interpretation.
+  """
+
+  @enforce_keys [:exec_path, :filter_root]
+  defstruct [:exec_path, :filter_root]
+
+  @type t :: %__MODULE__{
+          exec_path: String.t(),
+          filter_root: String.t()
+        }
+end

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -47,6 +47,7 @@ defmodule MingaAgent.Tools do
   alias MingaAgent.Tool.Spec
   alias MingaAgent.ToolRouter
   alias MingaAgent.Tools.DeleteFile
+  alias MingaAgent.Tools.DirectoryListing
   alias MingaAgent.Tools.ApplyDiff
   alias MingaAgent.Tools.DiagnosticFeedback
   alias MingaAgent.Tools.EditFile
@@ -661,9 +662,7 @@ defmodule MingaAgent.Tools do
     Tool.new!(
       name: "list_directory",
       description: """
-      List files and directories at a path. Returns one entry per line.
-      Directories have a trailing slash. Hidden files (starting with .)
-      are included.
+      List files and directories at a known-small path. Returns at most 200 entries, one per line. Directories have a trailing slash. Generated, dependency, build, cache, and secret env files are omitted. Use find for broad file discovery instead of walking directories.
       """,
       parameter_schema: %{
         "type" => "object",
@@ -698,9 +697,10 @@ defmodule MingaAgent.Tools do
     Tool.new!(
       name: "find",
       description: """
-      Find files and directories by name pattern (glob). Returns a sorted list
-      of matching paths relative to the project root. Use this to discover files
-      by name or extension. The tool is read-only and does not require approval.
+      Find files and directories by name pattern (glob). Returns at most 200
+      sorted matching paths relative to the project root. Generated, dependency,
+      build, cache, and secret env paths are omitted. Use this for broad file
+      discovery instead of shell + find.
       """,
       parameter_schema: %{
         "type" => "object",
@@ -745,10 +745,10 @@ defmodule MingaAgent.Tools do
     Tool.new!(
       name: "grep",
       description: """
-      Search file contents for a pattern. Returns matching lines with file paths
-      and line numbers. Use this instead of shell + grep for structured, reliable
-      search results. The tool is read-only and does not require approval.
-      Prefer this over shell for searching code.
+      Search file contents for a pattern. Returns at most 100 matching lines with
+      file paths and line numbers. Generated, dependency, build, cache, and secret
+      env paths are omitted. Use this instead of shell + grep for structured,
+      bounded search results.
       """,
       parameter_schema: %{
         "type" => "object",
@@ -797,8 +797,9 @@ defmodule MingaAgent.Tools do
       name: "shell",
       description: """
       Run a shell command in the project root directory. Returns the combined
-      stdout and stderr output. Commands time out after 30 seconds.
-      Use this for running tests, linters, git commands, etc.
+      stdout and stderr output, capped at 64KB for the model. Commands time out
+      after 30 seconds. Use this for running tests, linters, git commands, etc.
+      Use find and grep for broad file discovery and content search.
       Do not use for interactive commands that require user input.
       """,
       parameter_schema: %{
@@ -1449,14 +1450,7 @@ defmodule MingaAgent.Tools do
 
   @spec format_project_view_entries([ProjectView.Backend.directory_entry()]) :: String.t()
   defp format_project_view_entries(entries) do
-    entries
-    |> Enum.sort_by(fn %{name: name, type: type} ->
-      {if(type == :directory, do: 0, else: 1), name}
-    end)
-    |> Enum.map_join("\n", fn
-      %{name: name, type: :directory} -> name <> "/"
-      %{name: name} -> name
-    end)
+    DirectoryListing.format_entries(entries)
   end
 
   # ── Path safety ─────────────────────────────────────────────────────────────

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -159,7 +159,7 @@ defmodule MingaAgent.Tools do
       shell(root, router_ctx, shell_output_callback),
       subagent(root, parent_session),
       git_status(root),
-      git_diff(root),
+      git_diff(root, router_ctx),
       git_log(root),
       git_stage(root),
       git_commit(root),
@@ -930,8 +930,8 @@ defmodule MingaAgent.Tools do
     )
   end
 
-  @spec git_diff(String.t()) :: Tool.t()
-  defp git_diff(root) do
+  @spec git_diff(String.t(), ToolRouter.context()) :: Tool.t()
+  defp git_diff(root, router_ctx) do
     Tool.new!(
       name: "git_diff",
       description: """
@@ -954,7 +954,7 @@ defmodule MingaAgent.Tools do
         opts = []
         opts = if args["path"], do: [{:path, args["path"]} | opts], else: opts
         opts = if args["staged"], do: [{:staged, args["staged"]} | opts], else: opts
-        GitTools.diff(root, opts)
+        GitTools.diff(root, opts, router_ctx)
       end
     )
   end

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -732,9 +732,11 @@ defmodule MingaAgent.Tools do
 
         case ToolRouter.filesystem_path_result(router_ctx, path) do
           {:ok, search_path} ->
+            public_args = Map.take(args, ["type", "max_depth"])
+
             routed_result(
               router_ctx,
-              Find.execute(args["pattern"], search_path, Map.put(args, "_filter_root", path))
+              Find.execute(args["pattern"], search_path, public_args, filter_root: path)
             )
 
           {:error, reason} ->
@@ -786,9 +788,11 @@ defmodule MingaAgent.Tools do
 
         case ToolRouter.filesystem_path_result(router_ctx, path) do
           {:ok, search_path} ->
+            public_args = Map.take(args, ["glob", "case_sensitive", "context_lines"])
+
             routed_result(
               router_ctx,
-              Grep.execute(args["pattern"], search_path, Map.put(args, "_filter_root", path))
+              Grep.execute(args["pattern"], search_path, public_args, filter_root: path)
             )
 
           {:error, reason} ->

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -683,7 +683,8 @@ defmodule MingaAgent.Tools do
             ListDirectory.execute(path)
 
           {:ok, entries} ->
-            {:ok, append_workspace_context(router_ctx, format_project_view_entries(entries))}
+            {:ok,
+             append_workspace_context(router_ctx, format_project_view_entries(path, entries))}
 
           {:error, reason} ->
             {:error, inspect(reason)}
@@ -731,7 +732,10 @@ defmodule MingaAgent.Tools do
 
         case ToolRouter.filesystem_path_result(router_ctx, path) do
           {:ok, search_path} ->
-            routed_result(router_ctx, Find.execute(args["pattern"], search_path, args))
+            routed_result(
+              router_ctx,
+              Find.execute(args["pattern"], search_path, Map.put(args, "_filter_root", path))
+            )
 
           {:error, reason} ->
             {:error, inspect(reason)}
@@ -782,7 +786,10 @@ defmodule MingaAgent.Tools do
 
         case ToolRouter.filesystem_path_result(router_ctx, path) do
           {:ok, search_path} ->
-            routed_result(router_ctx, Grep.execute(args["pattern"], search_path, args))
+            routed_result(
+              router_ctx,
+              Grep.execute(args["pattern"], search_path, Map.put(args, "_filter_root", path))
+            )
 
           {:error, reason} ->
             {:error, inspect(reason)}
@@ -1448,9 +1455,10 @@ defmodule MingaAgent.Tools do
   defp route_name(false, fork_store) when fork_store != nil, do: "fork"
   defp route_name(false, nil), do: "changeset"
 
-  @spec format_project_view_entries([ProjectView.Backend.directory_entry()]) :: String.t()
-  defp format_project_view_entries(entries) do
-    DirectoryListing.format_entries(entries)
+  @spec format_project_view_entries(String.t(), [ProjectView.Backend.directory_entry()]) ::
+          String.t()
+  defp format_project_view_entries(path, entries) do
+    DirectoryListing.format_entries(path, entries)
   end
 
   # ── Path safety ─────────────────────────────────────────────────────────────

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -730,13 +730,15 @@ defmodule MingaAgent.Tools do
       callback: fn args ->
         path = resolve_and_validate_path!(root, args["path"] || ".")
 
-        case ToolRouter.filesystem_path_result(router_ctx, path) do
-          {:ok, search_path} ->
+        case ToolRouter.search_context(router_ctx, path) do
+          {:ok, search} ->
             public_args = Map.take(args, ["type", "max_depth"])
 
             routed_result(
               router_ctx,
-              Find.execute(args["pattern"], search_path, public_args, filter_root: path)
+              Find.execute(args["pattern"], search.exec_path, public_args,
+                filter_root: search.filter_root
+              )
             )
 
           {:error, reason} ->
@@ -786,13 +788,15 @@ defmodule MingaAgent.Tools do
       callback: fn args ->
         path = resolve_and_validate_path!(root, args["path"] || ".")
 
-        case ToolRouter.filesystem_path_result(router_ctx, path) do
-          {:ok, search_path} ->
+        case ToolRouter.search_context(router_ctx, path) do
+          {:ok, search} ->
             public_args = Map.take(args, ["glob", "case_sensitive", "context_lines"])
 
             routed_result(
               router_ctx,
-              Grep.execute(args["pattern"], search_path, public_args, filter_root: path)
+              Grep.execute(args["pattern"], search.exec_path, public_args,
+                filter_root: search.filter_root
+              )
             )
 
           {:error, reason} ->

--- a/lib/minga_agent/tools/directory_listing.ex
+++ b/lib/minga_agent/tools/directory_listing.ex
@@ -12,18 +12,61 @@ defmodule MingaAgent.Tools.DirectoryListing do
   @doc "Formats filesystem entries under `path` using bounded agent-friendly defaults."
   @spec from_filesystem(String.t(), [String.t()]) :: String.t()
   def from_filesystem(path, entries) when is_binary(path) and is_list(entries) do
-    path
-    |> PathIgnore.filter_child_names(entries)
-    |> Enum.map(&filesystem_entry(path, &1))
-    |> format_entries()
+    if ignored_root?(path) do
+      ""
+    else
+      path
+      |> PathIgnore.filter_child_names(entries)
+      |> Enum.map(&filesystem_entry(path, &1))
+      |> format_entries()
+    end
   end
 
   @doc "Formats already-typed entries using bounded agent-friendly defaults."
   @spec format_entries([entry()]) :: String.t()
   def format_entries(entries) when is_list(entries) do
+    entries
+    |> Enum.reject(&PathIgnore.ignored_name?(&1.name))
+    |> format_visible_entries()
+  end
+
+  @doc "Formats already-typed entries under `path` using static and project ignore rules."
+  @spec format_entries(String.t(), [entry()]) :: String.t()
+  def format_entries(path, entries) when is_binary(path) and is_list(entries) do
+    if ignored_root?(path) do
+      ""
+    else
+      visible_names =
+        path |> PathIgnore.filter_child_names(Enum.map(entries, & &1.name)) |> MapSet.new()
+
+      entries |> Enum.filter(&MapSet.member?(visible_names, &1.name)) |> format_visible_entries()
+    end
+  end
+
+  @doc "Returns true when a path basename should be hidden from broad agent listings."
+  @spec ignored_name?(String.t()) :: boolean()
+  def ignored_name?(name) when is_binary(name), do: PathIgnore.ignored_name?(name)
+
+  @doc "Returns basenames that broad agent filesystem tools should omit by default."
+  @spec ignored_names() :: [String.t()]
+  def ignored_names, do: PathIgnore.ignored_names()
+
+  @spec ignored_root?(String.t()) :: boolean()
+  defp ignored_root?(path) do
+    PathIgnore.ignored_name?(Path.basename(Path.expand(path))) or
+      PathIgnore.ignored_directory?(path)
+  end
+
+  @spec filesystem_entry(String.t(), String.t()) :: entry()
+  defp filesystem_entry(path, name) do
+    type = if File.dir?(Path.join(path, name)), do: :directory, else: :file
+    %{name: name, type: type}
+  end
+
+  @spec format_visible_entries([entry()]) :: String.t()
+  defp format_visible_entries(entries) do
     {visible, hidden_count} =
       entries
-      |> Enum.reject(&PathIgnore.ignored_name?(&1.name))
       |> sort_entries()
       |> cap_entries()
 
@@ -35,20 +78,6 @@ defmodule MingaAgent.Tools.DirectoryListing do
         else: lines
 
     Enum.join(lines, "\n")
-  end
-
-  @doc "Returns true when a path basename should be hidden from broad agent listings."
-  @spec ignored_name?(String.t()) :: boolean()
-  def ignored_name?(name) when is_binary(name), do: PathIgnore.ignored_name?(name)
-
-  @doc "Returns basenames that broad agent filesystem tools should omit by default."
-  @spec ignored_names() :: [String.t()]
-  def ignored_names, do: PathIgnore.ignored_names()
-
-  @spec filesystem_entry(String.t(), String.t()) :: entry()
-  defp filesystem_entry(path, name) do
-    type = if File.dir?(Path.join(path, name)), do: :directory, else: :file
-    %{name: name, type: type}
   end
 
   @spec sort_entries([entry()]) :: [entry()]

--- a/lib/minga_agent/tools/directory_listing.ex
+++ b/lib/minga_agent/tools/directory_listing.ex
@@ -53,8 +53,7 @@ defmodule MingaAgent.Tools.DirectoryListing do
 
   @spec ignored_root?(String.t()) :: boolean()
   defp ignored_root?(path) do
-    PathIgnore.ignored_name?(Path.basename(Path.expand(path))) or
-      PathIgnore.ignored_directory?(path)
+    PathIgnore.ignored_path?(path)
   end
 
   @spec filesystem_entry(String.t(), String.t()) :: entry()

--- a/lib/minga_agent/tools/directory_listing.ex
+++ b/lib/minga_agent/tools/directory_listing.ex
@@ -1,0 +1,70 @@
+defmodule MingaAgent.Tools.DirectoryListing do
+  @moduledoc """
+  Formats bounded directory listings for agent tools.
+  """
+
+  alias MingaAgent.Tools.PathIgnore
+
+  @max_entries 200
+
+  @type entry :: %{name: String.t(), type: :directory | :file}
+
+  @doc "Formats filesystem entries under `path` using bounded agent-friendly defaults."
+  @spec from_filesystem(String.t(), [String.t()]) :: String.t()
+  def from_filesystem(path, entries) when is_binary(path) and is_list(entries) do
+    path
+    |> PathIgnore.filter_child_names(entries)
+    |> Enum.map(&filesystem_entry(path, &1))
+    |> format_entries()
+  end
+
+  @doc "Formats already-typed entries using bounded agent-friendly defaults."
+  @spec format_entries([entry()]) :: String.t()
+  def format_entries(entries) when is_list(entries) do
+    {visible, hidden_count} =
+      entries
+      |> Enum.reject(&PathIgnore.ignored_name?(&1.name))
+      |> sort_entries()
+      |> cap_entries()
+
+    lines = Enum.map(visible, &format_entry/1)
+
+    lines =
+      if hidden_count > 0,
+        do: lines ++ ["... (truncated, #{hidden_count} more entries)"],
+        else: lines
+
+    Enum.join(lines, "\n")
+  end
+
+  @doc "Returns true when a path basename should be hidden from broad agent listings."
+  @spec ignored_name?(String.t()) :: boolean()
+  def ignored_name?(name) when is_binary(name), do: PathIgnore.ignored_name?(name)
+
+  @doc "Returns basenames that broad agent filesystem tools should omit by default."
+  @spec ignored_names() :: [String.t()]
+  def ignored_names, do: PathIgnore.ignored_names()
+
+  @spec filesystem_entry(String.t(), String.t()) :: entry()
+  defp filesystem_entry(path, name) do
+    type = if File.dir?(Path.join(path, name)), do: :directory, else: :file
+    %{name: name, type: type}
+  end
+
+  @spec sort_entries([entry()]) :: [entry()]
+  defp sort_entries(entries) do
+    Enum.sort_by(entries, fn %{name: name, type: type} ->
+      {if(type == :directory, do: 0, else: 1), name}
+    end)
+  end
+
+  @spec cap_entries([entry()]) :: {[entry()], non_neg_integer()}
+  defp cap_entries(entries) do
+    visible = Enum.take(entries, @max_entries)
+    {visible, max(length(entries) - length(visible), 0)}
+  end
+
+  @spec format_entry(entry()) :: String.t()
+  defp format_entry(%{name: name, type: :directory}), do: name <> "/"
+  defp format_entry(%{name: name}), do: name
+end

--- a/lib/minga_agent/tools/find.ex
+++ b/lib/minga_agent/tools/find.ex
@@ -7,6 +7,8 @@ defmodule MingaAgent.Tools.Find do
   directory, truncated at a configurable limit.
   """
 
+  alias MingaAgent.Tools.DirectoryListing
+
   @max_results 200
 
   @doc """
@@ -75,6 +77,7 @@ defmodule MingaAgent.Tools.Find do
           {String.t(), [String.t()]}
   defp build_fd_command(fd, pattern, type, max_depth) do
     args = ["--color", "never", "--glob", "--max-depth", Integer.to_string(max_depth)]
+    args = args ++ fd_ignore_args()
 
     args =
       case type do
@@ -83,7 +86,7 @@ defmodule MingaAgent.Tools.Find do
         _ -> args
       end
 
-    args = args ++ ["--max-results", Integer.to_string(@max_results), pattern, "."]
+    args = args ++ ["--max-results", Integer.to_string(@max_results + 1), pattern, "."]
     {fd, args}
   end
 
@@ -93,6 +96,7 @@ defmodule MingaAgent.Tools.Find do
     find = System.find_executable("find") || "find"
 
     args = [".", "-maxdepth", Integer.to_string(max_depth)]
+    args = args ++ find_prune_args()
 
     args =
       case type do
@@ -101,9 +105,27 @@ defmodule MingaAgent.Tools.Find do
         _ -> args
       end
 
-    # Use -name for glob matching
-    args = args ++ ["-name", pattern]
+    args = args ++ ["-name", pattern, "-print"]
     {find, args}
+  end
+
+  @spec fd_ignore_args() :: [String.t()]
+  defp fd_ignore_args do
+    Enum.flat_map(DirectoryListing.ignored_names(), fn name -> ["--exclude", name] end)
+  end
+
+  @spec find_prune_args() :: [String.t()]
+  defp find_prune_args do
+    ignored_names = DirectoryListing.ignored_names()
+
+    ["("] ++ find_name_expression(ignored_names) ++ [")", "-prune", "-o"]
+  end
+
+  @spec find_name_expression([String.t()]) :: [String.t()]
+  defp find_name_expression([name]), do: ["-name", name]
+
+  defp find_name_expression([name | rest]) do
+    ["-name", name, "-o"] ++ find_name_expression(rest)
   end
 
   @spec format_output(String.t()) :: String.t()
@@ -115,7 +137,7 @@ defmodule MingaAgent.Tools.Find do
 
     if length(lines) > @max_results do
       truncated = Enum.take(lines, @max_results) |> Enum.join("\n")
-      truncated <> "\n\n... (truncated, #{length(lines) - @max_results} more results)"
+      truncated <> "\n\n... (truncated, refine the pattern or path for fewer results)"
     else
       Enum.join(lines, "\n")
     end

--- a/lib/minga_agent/tools/find.ex
+++ b/lib/minga_agent/tools/find.ex
@@ -23,12 +23,20 @@ defmodule MingaAgent.Tools.Find do
 
   Returns a sorted list of matching paths, one per line.
   """
-  @spec execute(String.t(), String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
-  def execute(pattern, path, opts \\ %{}) when is_binary(pattern) and is_binary(path) do
+  @type exec_opts :: [
+          filter_root: String.t(),
+          max_output_bytes: pos_integer(),
+          timeout_ms: pos_integer()
+        ]
+
+  @spec execute(String.t(), String.t(), map(), exec_opts()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def execute(pattern, path, opts \\ %{}, exec_opts \\ [])
+      when is_binary(pattern) and is_binary(path) do
     if File.dir?(path) do
       if ignored_search_root?(path),
         do: {:ok, "No matches found."},
-        else: do_execute(pattern, path, opts)
+        else: do_execute(pattern, path, public_opts(opts), exec_opts)
     else
       {:error, "Directory does not exist: #{path}"}
     end
@@ -40,18 +48,27 @@ defmodule MingaAgent.Tools.Find do
       PathIgnore.ignored_directory?(path)
   end
 
-  @spec do_execute(String.t(), String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
-  defp do_execute(pattern, path, opts) do
+  @spec public_opts(map()) :: map()
+  defp public_opts(opts) when is_map(opts) do
+    Map.take(opts, ["type", "max_depth"])
+  end
+
+  @spec do_execute(String.t(), String.t(), map(), exec_opts()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp do_execute(pattern, path, opts, exec_opts) do
     type = Map.get(opts, "type", "file")
     max_depth = Map.get(opts, "max_depth", 10)
-    filter_root = Map.get(opts, "_filter_root", path)
+    filter_root = Keyword.get(exec_opts, :filter_root, path)
+    max_output_bytes = Keyword.get(exec_opts, :max_output_bytes, @max_output_bytes)
+    timeout_ms = Keyword.get(exec_opts, :timeout_ms, OutputLimit.default_timeout_ms())
 
     {cmd, args} = build_command(pattern, path, type, max_depth)
 
     case OutputLimit.collect_command(cmd, args,
            cd: path,
            stderr_to_stdout: true,
-           max_bytes: @max_output_bytes
+           max_bytes: max_output_bytes,
+           timeout_ms: timeout_ms
          ) do
       {output, 0, truncated?} ->
         {:ok, format_output(filter_root, output, truncated?)}
@@ -59,6 +76,9 @@ defmodule MingaAgent.Tools.Find do
       {output, 1, truncated?} ->
         # Exit code 1 means no matches for fd/find
         {:ok, format_output(filter_root, output, truncated?)}
+
+      {_output, :timeout, _truncated?} ->
+        {:error, "Find timed out"}
 
       {output, _code, _truncated?} ->
         {:error, "Find failed: #{String.trim(output)}"}
@@ -138,7 +158,7 @@ defmodule MingaAgent.Tools.Find do
   defp format_output(root, output, command_truncated?) do
     lines =
       output
-      |> String.split("\n", trim: true)
+      |> OutputLimit.complete_lines(command_truncated?)
       |> then(&PathIgnore.filter_paths(root, &1))
       |> Enum.sort()
 

--- a/lib/minga_agent/tools/find.ex
+++ b/lib/minga_agent/tools/find.ex
@@ -8,8 +8,11 @@ defmodule MingaAgent.Tools.Find do
   """
 
   alias MingaAgent.Tools.DirectoryListing
+  alias MingaAgent.Tools.OutputLimit
+  alias MingaAgent.Tools.PathIgnore
 
   @max_results 200
+  @max_output_bytes OutputLimit.default_max_bytes()
 
   @doc """
   Searches for files matching `pattern` under `path`.
@@ -23,38 +26,41 @@ defmodule MingaAgent.Tools.Find do
   @spec execute(String.t(), String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
   def execute(pattern, path, opts \\ %{}) when is_binary(pattern) and is_binary(path) do
     if File.dir?(path) do
-      do_execute(pattern, path, opts)
+      if ignored_search_root?(path),
+        do: {:ok, "No matches found."},
+        else: do_execute(pattern, path, opts)
     else
       {:error, "Directory does not exist: #{path}"}
     end
+  end
+
+  @spec ignored_search_root?(String.t()) :: boolean()
+  defp ignored_search_root?(path) do
+    PathIgnore.ignored_name?(Path.basename(Path.expand(path))) or
+      PathIgnore.ignored_directory?(path)
   end
 
   @spec do_execute(String.t(), String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
   defp do_execute(pattern, path, opts) do
     type = Map.get(opts, "type", "file")
     max_depth = Map.get(opts, "max_depth", 10)
+    filter_root = Map.get(opts, "_filter_root", path)
 
     {cmd, args} = build_command(pattern, path, type, max_depth)
 
-    case System.cmd(cmd, args, stderr_to_stdout: true, cd: path) do
-      {output, 0} ->
-        if String.trim(output) == "" do
-          {:ok, "No matches found."}
-        else
-          {:ok, format_output(output)}
-        end
+    case OutputLimit.collect_command(cmd, args,
+           cd: path,
+           stderr_to_stdout: true,
+           max_bytes: @max_output_bytes
+         ) do
+      {output, 0, truncated?} ->
+        {:ok, format_output(filter_root, output, truncated?)}
 
-      {output, 1} ->
+      {output, 1, truncated?} ->
         # Exit code 1 means no matches for fd/find
-        trimmed = String.trim(output)
+        {:ok, format_output(filter_root, output, truncated?)}
 
-        if trimmed == "" do
-          {:ok, "No matches found."}
-        else
-          {:ok, format_output(output)}
-        end
-
-      {output, _code} ->
+      {output, _code, _truncated?} ->
         {:error, "Find failed: #{String.trim(output)}"}
     end
   rescue
@@ -128,18 +134,39 @@ defmodule MingaAgent.Tools.Find do
     ["-name", name, "-o"] ++ find_name_expression(rest)
   end
 
-  @spec format_output(String.t()) :: String.t()
-  defp format_output(output) do
+  @spec format_output(String.t(), String.t(), boolean()) :: String.t()
+  defp format_output(root, output, command_truncated?) do
     lines =
       output
       |> String.split("\n", trim: true)
+      |> then(&PathIgnore.filter_paths(root, &1))
       |> Enum.sort()
+
+    if lines == [] do
+      "No matches found."
+    else
+      lines
+      |> bounded_lines(command_truncated?)
+      |> OutputLimit.truncate_utf8(
+        @max_output_bytes,
+        "\n\n... (truncated at #{div(@max_output_bytes, 1000)}KB, refine the pattern or path for fewer results)"
+      )
+    end
+  end
+
+  @spec bounded_lines([String.t()], boolean()) :: String.t()
+  defp bounded_lines(lines, command_truncated?) do
+    marker =
+      if command_truncated?,
+        do:
+          "\n\n... (truncated at #{div(@max_output_bytes, 1000)}KB, refine the pattern or path for fewer results)",
+        else: ""
 
     if length(lines) > @max_results do
       truncated = Enum.take(lines, @max_results) |> Enum.join("\n")
-      truncated <> "\n\n... (truncated, refine the pattern or path for fewer results)"
+      truncated <> "\n\n... (truncated, refine the pattern or path for fewer results)" <> marker
     else
-      Enum.join(lines, "\n")
+      Enum.join(lines, "\n") <> marker
     end
   end
 end

--- a/lib/minga_agent/tools/find.ex
+++ b/lib/minga_agent/tools/find.ex
@@ -33,8 +33,10 @@ defmodule MingaAgent.Tools.Find do
           {:ok, String.t()} | {:error, String.t()}
   def execute(pattern, path, opts \\ %{}, exec_opts \\ [])
       when is_binary(pattern) and is_binary(path) do
+    filter_root = Keyword.get(exec_opts, :filter_root, path)
+
     if File.dir?(path) do
-      if ignored_search_root?(path),
+      if ignored_search_root?(filter_root),
         do: {:ok, "No matches found."},
         else: do_execute(pattern, path, public_opts(opts), exec_opts)
     else
@@ -44,8 +46,7 @@ defmodule MingaAgent.Tools.Find do
 
   @spec ignored_search_root?(String.t()) :: boolean()
   defp ignored_search_root?(path) do
-    PathIgnore.ignored_name?(Path.basename(Path.expand(path))) or
-      PathIgnore.ignored_directory?(path)
+    PathIgnore.ignored_path?(path)
   end
 
   @spec public_opts(map()) :: map()
@@ -112,7 +113,7 @@ defmodule MingaAgent.Tools.Find do
         _ -> args
       end
 
-    args = args ++ ["--max-results", Integer.to_string(@max_results + 1), pattern, "."]
+    args = args ++ ["--max-results", Integer.to_string(@max_results + 1), "--", pattern, "."]
     {fd, args}
   end
 

--- a/lib/minga_agent/tools/git.ex
+++ b/lib/minga_agent/tools/git.ex
@@ -156,18 +156,28 @@ defmodule MingaAgent.Tools.Git do
   @spec effective_diff(String.t(), diff_opts(), Context.t()) :: result()
   defp effective_diff(project_root, opts, %Context{} = context) do
     if Keyword.get(opts, :staged, false) do
-      {:error,
-       "git_diff staged=true is unavailable in routed overlay contexts; apply/export the overlay first"}
+      staged_overlay_error()
     else
-      max_input_bytes = Keyword.get(opts, :max_input_bytes, @max_input_bytes)
+      effective_unstaged_diff(project_root, opts, context)
+    end
+  end
 
-      with {:ok, path_filter} <- path_filter(project_root, Keyword.get(opts, :path)),
-           {:ok, entries, new_root} <-
-             routed_entries_and_root(project_root, context, max_input_bytes),
-           {:ok, entries} <- filter_entries(project_root, entries, path_filter),
-           {:ok, output} <- render_effective_diff(project_root, new_root, entries, opts) do
-        if output == "", do: {:ok, "No differences."}, else: {:ok, output}
-      end
+  @spec staged_overlay_error() :: {:error, String.t()}
+  defp staged_overlay_error do
+    {:error,
+     "git_diff staged=true is unavailable in routed overlay contexts; apply/export the overlay first"}
+  end
+
+  @spec effective_unstaged_diff(String.t(), diff_opts(), Context.t()) :: result()
+  defp effective_unstaged_diff(project_root, opts, %Context{} = context) do
+    max_input_bytes = Keyword.get(opts, :max_input_bytes, @max_input_bytes)
+
+    with {:ok, path_filter} <- path_filter(project_root, Keyword.get(opts, :path)),
+         {:ok, entries, new_root} <-
+           routed_entries_and_root(project_root, context, max_input_bytes),
+         {:ok, entries} <- filter_entries(project_root, entries, path_filter),
+         {:ok, output} <- render_effective_diff(project_root, new_root, entries, opts) do
+      if output == "", do: {:ok, "No differences."}, else: {:ok, output}
     end
   end
 
@@ -224,8 +234,6 @@ defmodule MingaAgent.Tools.Git do
     case ProjectView.diff(view) do
       {:ok, entries} -> normalize_entries(entries)
       {:error, reason} -> {:error, "project_view_unavailable: diff failed: #{inspect(reason)}"}
-      entries when is_list(entries) -> normalize_entries(entries)
-      other -> {:error, "project view diff returned invalid value: #{inspect(other)}"}
     end
   catch
     :exit, reason -> {:error, "project_view_unavailable: diff failed: #{inspect(reason)}"}
@@ -261,20 +269,35 @@ defmodule MingaAgent.Tools.Git do
   defp materialize_forks_for_changeset(%Context{fork_store: nil}, _max_input_bytes), do: :ok
 
   defp materialize_forks_for_changeset(%Context{fork_store: fs, changeset: cs}, max_input_bytes) do
-    with {:ok, forks} <- fork_map(fs) do
-      Enum.reduce_while(forks, :ok, fn {path, fork_pid}, :ok ->
-        relative_path = Path.relative_to(path, Changeset.project_root(cs))
-        content = Minga.Buffer.Fork.content(fork_pid)
+    case fork_map(fs) do
+      {:ok, forks} ->
+        materialize_fork_entries(forks, Changeset.project_root(cs), cs, max_input_bytes)
 
-        with {:ok, content} <- validate_input_size(relative_path, content, max_input_bytes) do
-          case Changeset.materialize_command_file(cs, relative_path, content) do
-            :ok -> {:cont, :ok}
-            {:error, reason} -> {:halt, {:error, reason}}
-          end
-        else
-          {:error, _reason} = error -> {:halt, error}
-        end
-      end)
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @spec materialize_fork_entries(%{String.t() => pid()}, String.t(), pid(), pos_integer()) ::
+          :ok | {:error, term()}
+  defp materialize_fork_entries(forks, project_root, changeset, max_input_bytes) do
+    Enum.reduce_while(forks, :ok, fn {path, fork_pid}, :ok ->
+      relative_path = Path.relative_to(path, project_root)
+      content = Minga.Buffer.Fork.content(fork_pid)
+
+      case validate_input_size(relative_path, content, max_input_bytes) do
+        {:ok, content} -> materialize_fork_entry(changeset, relative_path, content)
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  @spec materialize_fork_entry(pid(), String.t(), binary()) ::
+          {:cont, :ok} | {:halt, {:error, term()}}
+  defp materialize_fork_entry(changeset, relative_path, content) do
+    case Changeset.materialize_command_file(changeset, relative_path, content) do
+      :ok -> {:cont, :ok}
+      {:error, reason} -> {:halt, {:error, reason}}
     end
   end
 
@@ -322,19 +345,26 @@ defmodule MingaAgent.Tools.Git do
 
   @spec validate_fork_inputs(String.t(), pid(), pos_integer()) :: :ok | {:error, String.t()}
   defp validate_fork_inputs(project_root, fork_store, max_input_bytes) do
-    with {:ok, forks} <- fork_map(fork_store) do
-      Enum.reduce_while(forks, :ok, fn {path, fork_pid}, :ok ->
-        relative_path = Path.relative_to(path, project_root)
-        content = Minga.Buffer.Fork.content(fork_pid)
-
-        case validate_input_size(relative_path, content, max_input_bytes) do
-          {:ok, _content} -> {:cont, :ok}
-          {:error, _reason} = error -> {:halt, error}
-        end
-      end)
+    case fork_map(fork_store) do
+      {:ok, forks} -> validate_fork_entry_inputs(forks, project_root, max_input_bytes)
+      {:error, _reason} = error -> error
     end
   catch
     :exit, reason -> {:error, "fork diff unavailable: #{inspect(reason)}"}
+  end
+
+  @spec validate_fork_entry_inputs(%{String.t() => pid()}, String.t(), pos_integer()) ::
+          :ok | {:error, String.t()}
+  defp validate_fork_entry_inputs(forks, project_root, max_input_bytes) do
+    Enum.reduce_while(forks, :ok, fn {path, fork_pid}, :ok ->
+      relative_path = Path.relative_to(path, project_root)
+      content = Minga.Buffer.Fork.content(fork_pid)
+
+      case validate_input_size(relative_path, content, max_input_bytes) do
+        {:ok, _content} -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
   end
 
   @spec fork_content_by_relative_path(String.t(), pid()) ::
@@ -505,9 +535,9 @@ defmodule MingaAgent.Tools.Git do
     old_content = safe_read_diff_file(project_root, relative_path, max_input_bytes)
     new_content = routed_content(new_root, relative_path, kind, max_input_bytes)
 
-    with :ok <- maybe_write_diff_file(old_dir, relative_path, old_content),
-         :ok <- maybe_write_diff_file(new_dir, relative_path, new_content) do
-      :ok
+    case maybe_write_diff_file(old_dir, relative_path, old_content) do
+      :ok -> maybe_write_diff_file(new_dir, relative_path, new_content)
+      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/minga_agent/tools/git.ex
+++ b/lib/minga_agent/tools/git.ex
@@ -8,11 +8,24 @@ defmodule MingaAgent.Tools.Git do
   """
 
   alias Minga.Git
+  alias MingaAgent.BufferForkStore
+  alias MingaAgent.Changeset
+  alias MingaAgent.ProjectView
+  alias MingaAgent.ToolRouter.Context
+  alias MingaAgent.Tools.OutputLimit
+  alias MingaAgent.Tools.PathIgnore
+
+  @type diff_entry :: %{path: String.t(), kind: atom()}
+  @type diff_opts :: keyword()
+  @type result :: {:ok, String.t()} | {:error, String.t()}
+
+  @max_output_bytes OutputLimit.default_max_bytes()
+  @max_input_bytes OutputLimit.default_max_bytes()
 
   @doc """
   Returns a structured list of changed files with their status.
   """
-  @spec status(String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec status(String.t()) :: result()
   def status(project_root) do
     git_root = resolve_git_root(project_root)
 
@@ -45,7 +58,7 @@ defmodule MingaAgent.Tools.Git do
   @doc """
   Returns the diff for a specific file or all changes.
   """
-  @spec diff(String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec diff(String.t(), diff_opts()) :: result()
   def diff(project_root, opts \\ []) do
     git_root = resolve_git_root(project_root)
 
@@ -57,9 +70,23 @@ defmodule MingaAgent.Tools.Git do
   end
 
   @doc """
+  Returns the effective diff for the routed agent context.
+  """
+  @spec diff(String.t(), diff_opts(), Context.t() | nil) :: result()
+  def diff(project_root, opts, %Context{} = context) do
+    if routed_overlay_diff?(context) do
+      effective_diff(project_root, opts, context)
+    else
+      diff(project_root, opts)
+    end
+  end
+
+  def diff(project_root, opts, _context), do: diff(project_root, opts)
+
+  @doc """
   Returns recent commits as formatted entries.
   """
-  @spec log(String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec log(String.t(), keyword()) :: result()
   def log(project_root, opts \\ []) do
     git_root = resolve_git_root(project_root)
 
@@ -83,7 +110,7 @@ defmodule MingaAgent.Tools.Git do
   @doc """
   Stages specific files.
   """
-  @spec stage(String.t(), [String.t()]) :: {:ok, String.t()} | {:error, String.t()}
+  @spec stage(String.t(), [String.t()]) :: result()
   def stage(project_root, paths) when is_list(paths) do
     git_root = resolve_git_root(project_root)
 
@@ -100,7 +127,7 @@ defmodule MingaAgent.Tools.Git do
   uses whatever git identity is currently configured. The git-identity skill
   is a human workflow tool and cannot be automated here.
   """
-  @spec commit(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec commit(String.t(), String.t()) :: result()
   def commit(project_root, message) do
     git_root = resolve_git_root(project_root)
 
@@ -124,6 +151,590 @@ defmodule MingaAgent.Tools.Git do
       end
 
     "  #{label} #{path}"
+  end
+
+  @spec effective_diff(String.t(), diff_opts(), Context.t()) :: result()
+  defp effective_diff(project_root, opts, %Context{} = context) do
+    if Keyword.get(opts, :staged, false) do
+      {:error,
+       "git_diff staged=true is unavailable in routed overlay contexts; apply/export the overlay first"}
+    else
+      max_input_bytes = Keyword.get(opts, :max_input_bytes, @max_input_bytes)
+
+      with {:ok, path_filter} <- path_filter(project_root, Keyword.get(opts, :path)),
+           {:ok, entries, new_root} <-
+             routed_entries_and_root(project_root, context, max_input_bytes),
+           {:ok, entries} <- filter_entries(project_root, entries, path_filter),
+           {:ok, output} <- render_effective_diff(project_root, new_root, entries, opts) do
+        if output == "", do: {:ok, "No differences."}, else: {:ok, output}
+      end
+    end
+  end
+
+  @spec routed_overlay_diff?(Context.t()) :: boolean()
+  defp routed_overlay_diff?(%Context{project_view: %ProjectView{} = view}) do
+    caps = ProjectView.capabilities(view)
+    caps.isolation != :none or caps.mutates_project_root == false
+  catch
+    :exit, _ -> true
+  end
+
+  defp routed_overlay_diff?(%Context{fork_store: fs, changeset: cs}) do
+    fs != nil or cs != nil
+  end
+
+  @spec routed_entries_and_root(String.t(), Context.t(), pos_integer()) ::
+          {:ok, [diff_entry()], String.t() | {:forks, %{String.t() => binary()}}}
+          | {:error, String.t()}
+  defp routed_entries_and_root(
+         _project_root,
+         %Context{project_view: %ProjectView{} = view},
+         max_input_bytes
+       ) do
+    with {:ok, entries} <- project_view_diff_entries(view),
+         :ok <- validate_project_view_fork_inputs(view, max_input_bytes),
+         {:ok, working_dir} <- project_view_working_dir(view) do
+      {:ok, entries, working_dir}
+    end
+  end
+
+  defp routed_entries_and_root(project_root, %Context{changeset: cs} = context, max_input_bytes)
+       when cs != nil and is_pid(cs) do
+    with {:ok, working_dir} <- changeset_working_dir(context, max_input_bytes),
+         {:ok, entries} <- changeset_entries(cs),
+         {:ok, fork_entries} <- fork_entries(project_root, context.fork_store) do
+      {:ok, merge_entries(entries, fork_entries), working_dir}
+    end
+  end
+
+  defp routed_entries_and_root(project_root, %Context{fork_store: fs}, max_input_bytes)
+       when fs != nil do
+    with :ok <- validate_fork_inputs(project_root, fs, max_input_bytes),
+         {:ok, entries} <- fork_entries(project_root, fs),
+         {:ok, forks} <- fork_content_by_relative_path(project_root, fs) do
+      {:ok, entries, {:forks, forks}}
+    end
+  end
+
+  defp routed_entries_and_root(_project_root, %Context{}, _max_input_bytes),
+    do: {:error, "no routed overlay is active"}
+
+  @spec project_view_diff_entries(ProjectView.t()) :: {:ok, [diff_entry()]} | {:error, String.t()}
+  defp project_view_diff_entries(%ProjectView{} = view) do
+    case ProjectView.diff(view) do
+      {:ok, entries} -> normalize_entries(entries)
+      {:error, reason} -> {:error, "project_view_unavailable: diff failed: #{inspect(reason)}"}
+      entries when is_list(entries) -> normalize_entries(entries)
+      other -> {:error, "project view diff returned invalid value: #{inspect(other)}"}
+    end
+  catch
+    :exit, reason -> {:error, "project_view_unavailable: diff failed: #{inspect(reason)}"}
+  end
+
+  @spec project_view_working_dir(ProjectView.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp project_view_working_dir(%ProjectView{} = view) do
+    case ProjectView.prepare_working_dir(view) do
+      {:ok, working_dir} ->
+        {:ok, working_dir}
+
+      {:error, reason} ->
+        {:error, "project view working directory unavailable: #{inspect(reason)}"}
+    end
+  catch
+    :exit, reason -> {:error, "project view working directory unavailable: #{inspect(reason)}"}
+  end
+
+  @spec changeset_working_dir(Context.t(), pos_integer()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp changeset_working_dir(%Context{changeset: cs} = context, max_input_bytes) do
+    with :ok <- materialize_forks_for_changeset(context, max_input_bytes),
+         {:ok, working_dir} <- Changeset.prepare_working_dir(cs) do
+      {:ok, working_dir}
+    else
+      {:error, reason} -> {:error, "changeset working directory unavailable: #{inspect(reason)}"}
+    end
+  catch
+    :exit, reason -> {:error, "changeset working directory unavailable: #{inspect(reason)}"}
+  end
+
+  @spec materialize_forks_for_changeset(Context.t(), pos_integer()) :: :ok | {:error, term()}
+  defp materialize_forks_for_changeset(%Context{fork_store: nil}, _max_input_bytes), do: :ok
+
+  defp materialize_forks_for_changeset(%Context{fork_store: fs, changeset: cs}, max_input_bytes) do
+    with {:ok, forks} <- fork_map(fs) do
+      Enum.reduce_while(forks, :ok, fn {path, fork_pid}, :ok ->
+        relative_path = Path.relative_to(path, Changeset.project_root(cs))
+        content = Minga.Buffer.Fork.content(fork_pid)
+
+        with {:ok, content} <- validate_input_size(relative_path, content, max_input_bytes) do
+          case Changeset.materialize_command_file(cs, relative_path, content) do
+            :ok -> {:cont, :ok}
+            {:error, reason} -> {:halt, {:error, reason}}
+          end
+        else
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+    end
+  end
+
+  @spec changeset_entries(pid()) :: {:ok, [diff_entry()]} | {:error, String.t()}
+  defp changeset_entries(changeset) do
+    changeset
+    |> Changeset.summary()
+    |> normalize_entries()
+  catch
+    :exit, reason -> {:error, "changeset diff unavailable: #{inspect(reason)}"}
+  end
+
+  @spec fork_entries(String.t(), pid() | nil) :: {:ok, [diff_entry()]} | {:error, String.t()}
+  defp fork_entries(_project_root, nil), do: {:ok, []}
+
+  defp fork_entries(project_root, fork_store) do
+    with {:ok, forks} <- fork_map(fork_store) do
+      forks
+      |> Map.keys()
+      |> Enum.map(fn path ->
+        %{path: Path.relative_to(path, project_root), kind: fork_kind(path)}
+      end)
+      |> normalize_entries()
+    end
+  end
+
+  @spec fork_map(pid()) :: {:ok, %{String.t() => pid()}} | {:error, String.t()}
+  defp fork_map(fork_store) do
+    {:ok, BufferForkStore.all(fork_store)}
+  catch
+    :exit, reason -> {:error, "fork diff unavailable: #{inspect(reason)}"}
+  end
+
+  @spec validate_project_view_fork_inputs(ProjectView.t(), pos_integer()) ::
+          :ok | {:error, String.t()}
+  defp validate_project_view_fork_inputs(
+         %ProjectView{project_root: project_root, ref: %{fork_store: fork_store}},
+         max_input_bytes
+       )
+       when is_pid(fork_store) do
+    validate_fork_inputs(project_root, fork_store, max_input_bytes)
+  end
+
+  defp validate_project_view_fork_inputs(%ProjectView{}, _max_input_bytes), do: :ok
+
+  @spec validate_fork_inputs(String.t(), pid(), pos_integer()) :: :ok | {:error, String.t()}
+  defp validate_fork_inputs(project_root, fork_store, max_input_bytes) do
+    with {:ok, forks} <- fork_map(fork_store) do
+      Enum.reduce_while(forks, :ok, fn {path, fork_pid}, :ok ->
+        relative_path = Path.relative_to(path, project_root)
+        content = Minga.Buffer.Fork.content(fork_pid)
+
+        case validate_input_size(relative_path, content, max_input_bytes) do
+          {:ok, _content} -> {:cont, :ok}
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+    end
+  catch
+    :exit, reason -> {:error, "fork diff unavailable: #{inspect(reason)}"}
+  end
+
+  @spec fork_content_by_relative_path(String.t(), pid()) ::
+          {:ok, %{String.t() => binary()}} | {:error, String.t()}
+  defp fork_content_by_relative_path(project_root, fork_store) do
+    with {:ok, forks} <- fork_map(fork_store) do
+      {:ok,
+       Map.new(forks, fn {path, fork_pid} ->
+         {Path.relative_to(path, project_root), Minga.Buffer.Fork.content(fork_pid)}
+       end)}
+    end
+  catch
+    :exit, reason -> {:error, "fork diff unavailable: #{inspect(reason)}"}
+  end
+
+  @spec fork_kind(String.t()) :: :modified | :new
+  defp fork_kind(path) do
+    if File.exists?(path), do: :modified, else: :new
+  end
+
+  @spec merge_entries([diff_entry()], [diff_entry()]) :: [diff_entry()]
+  defp merge_entries(entries, fork_entries) do
+    entries
+    |> Enum.concat(fork_entries)
+    |> Enum.reduce(%{}, fn entry, acc -> Map.put(acc, entry.path, entry) end)
+    |> Map.values()
+    |> Enum.sort_by(& &1.path)
+  end
+
+  @spec normalize_entries([map()]) :: {:ok, [diff_entry()]} | {:error, String.t()}
+  defp normalize_entries(entries) do
+    Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, acc} ->
+      case normalize_entry(entry) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.sort_by(normalized, & &1.path)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec normalize_entry(map()) :: {:ok, diff_entry()} | {:error, String.t()}
+  defp normalize_entry(%{path: path} = entry) when is_binary(path) do
+    with {:ok, path} <- safe_relative_path(path) do
+      {:ok, %{path: path, kind: Map.get(entry, :kind, :modified)}}
+    end
+  end
+
+  defp normalize_entry(entry), do: {:error, "invalid diff entry: #{inspect(entry)}"}
+
+  @spec path_filter(String.t(), String.t() | nil) ::
+          {:ok, String.t() | nil} | {:error, String.t()}
+  defp path_filter(_project_root, nil), do: {:ok, nil}
+
+  defp path_filter(project_root, path) when is_binary(path) do
+    project_root = Path.expand(project_root)
+    target = Path.expand(path, project_root)
+
+    if target == project_root or String.starts_with?(target, project_root <> "/") do
+      {:ok, Path.relative_to(target, project_root) |> empty_to_nil()}
+    else
+      {:error, "path is outside the project root"}
+    end
+  end
+
+  defp path_filter(_project_root, _path), do: {:error, "path must be a string"}
+
+  @spec filter_entries(String.t(), [diff_entry()], String.t() | nil) ::
+          {:ok, [diff_entry()]} | {:error, String.t()}
+  defp filter_entries(project_root, entries, path_filter) do
+    allowed_paths =
+      project_root |> PathIgnore.filter_paths(Enum.map(entries, & &1.path)) |> MapSet.new()
+
+    {:ok,
+     Enum.filter(entries, fn entry ->
+       MapSet.member?(allowed_paths, entry.path) and path_matches_filter?(entry.path, path_filter)
+     end)}
+  end
+
+  @spec path_matches_filter?(String.t(), String.t() | nil) :: boolean()
+  defp path_matches_filter?(_path, nil), do: true
+
+  defp path_matches_filter?(path, path_filter) do
+    path == path_filter or String.starts_with?(path, path_filter <> "/")
+  end
+
+  @spec render_effective_diff(
+          String.t(),
+          String.t() | {:forks, %{String.t() => binary()}},
+          [diff_entry()],
+          diff_opts()
+        ) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp render_effective_diff(project_root, new_root, entries, opts) do
+    tmp = Path.join(System.tmp_dir!(), "minga-agent-diff-#{unique_id()}")
+
+    try do
+      old_dir = Path.join(tmp, "old")
+      new_dir = Path.join(tmp, "new")
+      File.mkdir_p!(old_dir)
+      File.mkdir_p!(new_dir)
+
+      max_input_bytes = Keyword.get(opts, :max_input_bytes, @max_input_bytes)
+
+      with :ok <-
+             materialize_diff_side(
+               project_root,
+               new_root,
+               old_dir,
+               new_dir,
+               entries,
+               max_input_bytes
+             ),
+           {:ok, output} <- run_no_index_diff(tmp, opts) do
+        {:ok, normalize_diff_paths(output)}
+      end
+    after
+      File.rm_rf(tmp)
+    end
+  rescue
+    error -> {:error, "effective git diff failed: #{Exception.message(error)}"}
+  end
+
+  @spec materialize_diff_side(
+          String.t(),
+          String.t() | {:forks, %{String.t() => binary()}},
+          String.t(),
+          String.t(),
+          [diff_entry()],
+          pos_integer()
+        ) ::
+          :ok | {:error, String.t()}
+  defp materialize_diff_side(project_root, new_root, old_dir, new_dir, entries, max_input_bytes) do
+    Enum.reduce_while(entries, :ok, fn entry, :ok ->
+      case materialize_diff_entry(
+             project_root,
+             new_root,
+             old_dir,
+             new_dir,
+             entry,
+             max_input_bytes
+           ) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  @spec materialize_diff_entry(
+          String.t(),
+          String.t() | {:forks, %{String.t() => binary()}},
+          String.t(),
+          String.t(),
+          diff_entry(),
+          pos_integer()
+        ) ::
+          :ok | {:error, String.t()}
+  defp materialize_diff_entry(
+         project_root,
+         new_root,
+         old_dir,
+         new_dir,
+         %{path: relative_path, kind: kind},
+         max_input_bytes
+       ) do
+    old_content = safe_read_diff_file(project_root, relative_path, max_input_bytes)
+    new_content = routed_content(new_root, relative_path, kind, max_input_bytes)
+
+    with :ok <- maybe_write_diff_file(old_dir, relative_path, old_content),
+         :ok <- maybe_write_diff_file(new_dir, relative_path, new_content) do
+      :ok
+    end
+  end
+
+  @spec routed_content(
+          String.t() | {:forks, %{String.t() => binary()}},
+          String.t(),
+          atom(),
+          pos_integer()
+        ) ::
+          {:ok, binary()} | {:error, term()}
+  defp routed_content(_new_root, _relative_path, :deleted, _max_input_bytes),
+    do: {:error, :enoent}
+
+  defp routed_content({:forks, forks}, relative_path, _kind, max_input_bytes) do
+    case Map.fetch(forks, relative_path) do
+      {:ok, content} -> validate_input_size(relative_path, content, max_input_bytes)
+      :error -> {:error, :enoent}
+    end
+  end
+
+  defp routed_content(new_root, relative_path, _kind, max_input_bytes),
+    do: safe_read_diff_file(new_root, relative_path, max_input_bytes)
+
+  @spec safe_read_diff_file(String.t(), String.t(), pos_integer()) ::
+          {:ok, binary()} | {:error, term()}
+  defp safe_read_diff_file(root, relative_path, max_input_bytes) do
+    path = Path.join(root, relative_path)
+
+    with :ok <- reject_symlink_path(root, relative_path),
+         {:ok, stat} <- File.stat(path),
+         :ok <- validate_input_size(relative_path, stat.size, max_input_bytes) do
+      File.read(path)
+    end
+  end
+
+  @spec reject_symlink_path(String.t(), String.t()) :: :ok | {:error, String.t() | atom()}
+  defp reject_symlink_path(root, relative_path) do
+    relative_path
+    |> Path.split()
+    |> Enum.reduce_while(:ok, fn component, current ->
+      current = if current == :ok, do: component, else: Path.join(current, component)
+
+      case File.lstat(Path.join(root, current)) do
+        {:ok, %File.Stat{type: :symlink}} ->
+          {:halt, {:error, "refusing to diff symlink path #{relative_path}"}}
+
+        {:ok, _stat} ->
+          {:cont, current}
+
+        {:error, :enoent} ->
+          {:halt, :ok}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      path when is_binary(path) -> :ok
+      result -> result
+    end
+  end
+
+  @spec validate_input_size(String.t(), binary() | non_neg_integer(), pos_integer()) ::
+          {:ok, binary()} | :ok | {:error, String.t()}
+  defp validate_input_size(relative_path, content, max_input_bytes) when is_binary(content) do
+    with :ok <- validate_input_size(relative_path, byte_size(content), max_input_bytes) do
+      {:ok, content}
+    end
+  end
+
+  defp validate_input_size(relative_path, size, max_input_bytes) when is_integer(size) do
+    if size <= max_input_bytes do
+      :ok
+    else
+      {:error, "git_diff input file too large: #{relative_path} exceeds #{max_input_bytes} bytes"}
+    end
+  end
+
+  @spec maybe_write_diff_file(String.t(), String.t(), {:ok, binary()} | {:error, term()}) ::
+          :ok | {:error, String.t()}
+  defp maybe_write_diff_file(_root, _relative_path, {:error, :enoent}), do: :ok
+
+  defp maybe_write_diff_file(root, relative_path, {:ok, content}) do
+    target = Path.join(root, relative_path)
+    File.mkdir_p!(Path.dirname(target))
+    File.write(target, content)
+  end
+
+  defp maybe_write_diff_file(_root, relative_path, {:error, reason}) do
+    {:error, "failed to read #{relative_path}: #{inspect(reason)}"}
+  end
+
+  @spec run_no_index_diff(String.t(), diff_opts()) :: {:ok, String.t()} | {:error, String.t()}
+  defp run_no_index_diff(tmp, opts) do
+    with {:ok, git} <- git_executable() do
+      max_bytes = Keyword.get(opts, :max_output_bytes, @max_output_bytes)
+
+      case OutputLimit.collect_command(git, ["diff", "--no-index", "--", "old", "new"],
+             cd: tmp,
+             stderr_to_stdout: true,
+             max_bytes: max_bytes,
+             timeout_ms: Keyword.get(opts, :timeout_ms, OutputLimit.default_timeout_ms())
+           ) do
+        {output, 0, truncated?} ->
+          {:ok, maybe_mark_truncated(output, truncated?, max_bytes)}
+
+        {output, 1, truncated?} ->
+          {:ok, maybe_mark_truncated(output, truncated?, max_bytes)}
+
+        {_output, :timeout, _truncated?} ->
+          {:error, "git diff --no-index timed out"}
+
+        {output, _code, _truncated?} ->
+          {:error, "git diff --no-index failed: #{String.trim(output)}"}
+      end
+    end
+  rescue
+    error -> {:error, "git diff --no-index failed: #{Exception.message(error)}"}
+  end
+
+  @spec git_executable() :: {:ok, String.t()} | {:error, String.t()}
+  defp git_executable do
+    case System.find_executable("git") do
+      nil -> {:error, "git executable not found"}
+      git -> {:ok, git}
+    end
+  end
+
+  @spec maybe_mark_truncated(String.t(), boolean(), pos_integer()) :: String.t()
+  defp maybe_mark_truncated(output, false, _max_bytes), do: output
+
+  defp maybe_mark_truncated(output, true, max_bytes) do
+    output <> "\n\n[truncated at #{div(max_bytes, 1000)}KB]"
+  end
+
+  @spec normalize_diff_paths(String.t()) :: String.t()
+  defp normalize_diff_paths(output) do
+    output
+    |> String.split("\n", trim: false)
+    |> Enum.map_reduce(:body, &normalize_diff_line/2)
+    |> elem(0)
+    |> Enum.join("\n")
+  end
+
+  @spec normalize_diff_line(String.t(), :body | :metadata | :expect_new_header) ::
+          {String.t(), :body | :metadata | :expect_new_header}
+  defp normalize_diff_line("diff --git " <> rest, _state) do
+    {"diff --git " <> normalize_diff_header_paths(rest), :metadata}
+  end
+
+  defp normalize_diff_line("--- " <> rest, :metadata) do
+    {"--- " <> normalize_diff_file_path(rest, "a"), :expect_new_header}
+  end
+
+  defp normalize_diff_line("+++ " <> rest, :expect_new_header) do
+    {"+++ " <> normalize_diff_file_path(rest, "b"), :body}
+  end
+
+  defp normalize_diff_line("@@" <> _rest = line, _state), do: {line, :body}
+  defp normalize_diff_line(line, state), do: {line, state}
+
+  @spec normalize_diff_header_paths(String.t()) :: String.t()
+  defp normalize_diff_header_paths("a/old/" <> paths) do
+    case normalize_diff_header_pair(paths, " b/new/") do
+      {:ok, line} -> line
+      :error -> normalize_old_only_diff_header(paths)
+    end
+  end
+
+  defp normalize_diff_header_paths("a/new/" <> paths) do
+    case normalize_diff_header_pair(paths, " b/new/") do
+      {:ok, line} -> line
+      :error -> "a/new/" <> paths
+    end
+  end
+
+  defp normalize_diff_header_paths(line), do: line
+
+  @spec normalize_old_only_diff_header(String.t()) :: String.t()
+  defp normalize_old_only_diff_header(paths) do
+    case normalize_diff_header_pair(paths, " b/old/") do
+      {:ok, line} -> line
+      :error -> "a/old/" <> paths
+    end
+  end
+
+  @spec normalize_diff_header_pair(String.t(), String.t()) :: {:ok, String.t()} | :error
+  defp normalize_diff_header_pair(paths, separator) do
+    case :binary.split(paths, separator) do
+      [old_path, new_path] -> {:ok, "a/" <> old_path <> " b/" <> new_path}
+      _ -> :error
+    end
+  end
+
+  @spec normalize_diff_file_path(String.t(), String.t()) :: String.t()
+  defp normalize_diff_file_path("/dev/null", _side), do: "/dev/null"
+  defp normalize_diff_file_path("a/old/" <> path, "a"), do: "a/" <> strip_diff_timestamp(path)
+  defp normalize_diff_file_path("b/new/" <> path, "b"), do: "b/" <> strip_diff_timestamp(path)
+  defp normalize_diff_file_path("old/" <> path, "a"), do: "a/" <> strip_diff_timestamp(path)
+  defp normalize_diff_file_path("new/" <> path, "b"), do: "b/" <> strip_diff_timestamp(path)
+  defp normalize_diff_file_path(path, _side), do: strip_diff_timestamp(path)
+
+  @spec strip_diff_timestamp(String.t()) :: String.t()
+  defp strip_diff_timestamp(path) do
+    path |> String.split("\t", parts: 2) |> hd()
+  end
+
+  @spec safe_relative_path(String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp safe_relative_path(path) do
+    components =
+      path |> String.trim_leading("./") |> Path.split() |> Enum.reject(&(&1 in [".", ""]))
+
+    if String.starts_with?(path, "/") or Enum.member?(components, "..") do
+      {:error, "unsafe diff path: #{inspect(path)}"}
+    else
+      {:ok, Path.join(components)}
+    end
+  end
+
+  @spec empty_to_nil(String.t()) :: String.t() | nil
+  defp empty_to_nil("."), do: nil
+  defp empty_to_nil(""), do: nil
+  defp empty_to_nil(path), do: path
+
+  @spec unique_id() :: String.t()
+  defp unique_id do
+    :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
   end
 
   @spec resolve_git_root(String.t()) :: String.t()

--- a/lib/minga_agent/tools/grep.ex
+++ b/lib/minga_agent/tools/grep.ex
@@ -34,8 +34,10 @@ defmodule MingaAgent.Tools.Grep do
           {:ok, String.t()} | {:error, String.t()}
   def execute(pattern, path, opts \\ %{}, exec_opts \\ [])
       when is_binary(pattern) and is_binary(path) do
+    filter_root = Keyword.get(exec_opts, :filter_root, path)
+
     if File.dir?(path) do
-      if ignored_search_root?(path),
+      if ignored_search_root?(filter_root),
         do: {:ok, "No matches found."},
         else: do_execute(pattern, path, public_opts(opts), exec_opts)
     else
@@ -45,8 +47,7 @@ defmodule MingaAgent.Tools.Grep do
 
   @spec ignored_search_root?(String.t()) :: boolean()
   defp ignored_search_root?(path) do
-    PathIgnore.ignored_name?(Path.basename(Path.expand(path))) or
-      PathIgnore.ignored_directory?(path)
+    PathIgnore.ignored_path?(path)
   end
 
   @spec public_opts(map()) :: map()
@@ -118,7 +119,7 @@ defmodule MingaAgent.Tools.Grep do
 
     args = if glob, do: args ++ ["--glob", glob], else: args
     args = args ++ rg_ignore_args()
-    args = args ++ ["--max-count", Integer.to_string(@max_matches), pattern, "."]
+    args = args ++ ["--max-count", Integer.to_string(@max_matches), "--", pattern, "."]
     {rg, args}
   end
 
@@ -131,7 +132,7 @@ defmodule MingaAgent.Tools.Grep do
     args = if context_lines > 0, do: args ++ ["-C", Integer.to_string(context_lines)], else: args
     args = if glob, do: args ++ ["--include", glob], else: args
     args = args ++ grep_ignore_args()
-    args = args ++ [pattern, "."]
+    args = args ++ ["--", pattern, "."]
     {grep, args}
   end
 

--- a/lib/minga_agent/tools/grep.ex
+++ b/lib/minga_agent/tools/grep.ex
@@ -8,8 +8,11 @@ defmodule MingaAgent.Tools.Grep do
   """
 
   alias MingaAgent.Tools.DirectoryListing
+  alias MingaAgent.Tools.OutputLimit
+  alias MingaAgent.Tools.PathIgnore
 
   @max_matches 100
+  @max_output_bytes OutputLimit.default_max_bytes()
 
   @doc """
   Searches for `pattern` in files under `path`.
@@ -24,10 +27,18 @@ defmodule MingaAgent.Tools.Grep do
   @spec execute(String.t(), String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
   def execute(pattern, path, opts \\ %{}) when is_binary(pattern) and is_binary(path) do
     if File.dir?(path) do
-      do_execute(pattern, path, opts)
+      if ignored_search_root?(path),
+        do: {:ok, "No matches found."},
+        else: do_execute(pattern, path, opts)
     else
       {:error, "Directory does not exist: #{path}"}
     end
+  end
+
+  @spec ignored_search_root?(String.t()) :: boolean()
+  defp ignored_search_root?(path) do
+    PathIgnore.ignored_name?(Path.basename(Path.expand(path))) or
+      PathIgnore.ignored_directory?(path)
   end
 
   @spec do_execute(String.t(), String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
@@ -35,22 +46,27 @@ defmodule MingaAgent.Tools.Grep do
     glob = Map.get(opts, "glob")
     case_sensitive = Map.get(opts, "case_sensitive", true)
     context_lines = Map.get(opts, "context_lines", 0)
+    filter_root = Map.get(opts, "_filter_root", path)
 
     {cmd, args} = build_command(pattern, path, glob, case_sensitive, context_lines)
 
-    case System.cmd(cmd, args, stderr_to_stdout: true, cd: path) do
-      {output, 0} ->
-        {:ok, truncate_output(output)}
+    case OutputLimit.collect_command(cmd, args,
+           cd: path,
+           stderr_to_stdout: true,
+           max_bytes: @max_output_bytes
+         ) do
+      {output, 0, truncated?} ->
+        {:ok, truncate_output(filter_root, output, truncated?)}
 
-      {output, 1} ->
+      {output, 1, truncated?} ->
         # Exit code 1 means no matches (for both grep and rg)
         if String.trim(output) == "" do
           {:ok, "No matches found."}
         else
-          {:ok, truncate_output(output)}
+          {:ok, truncate_output(filter_root, output, truncated?)}
         end
 
-      {output, _code} ->
+      {output, _code, _truncated?} ->
         {:error, "Search failed: #{String.trim(output)}"}
     end
   rescue
@@ -113,15 +129,46 @@ defmodule MingaAgent.Tools.Grep do
     end)
   end
 
-  @spec truncate_output(String.t()) :: String.t()
-  defp truncate_output(output) do
-    lines = String.split(output, "\n")
+  @spec truncate_output(String.t(), String.t(), boolean()) :: String.t()
+  defp truncate_output(root, output, command_truncated?) do
+    lines =
+      output
+      |> String.split("\n", trim: true)
+      |> then(&PathIgnore.filter_grep_lines(root, &1))
+
+    if Enum.any?(lines, &grep_result_line?/1) do
+      lines
+      |> bounded_lines(command_truncated?)
+      |> OutputLimit.truncate_utf8(
+        @max_output_bytes,
+        "\n\n... (truncated at #{div(@max_output_bytes, 1000)}KB, refine the pattern or path for fewer results)"
+      )
+    else
+      "No matches found."
+    end
+  end
+
+  @spec bounded_lines([String.t()], boolean()) :: String.t()
+  defp bounded_lines(lines, command_truncated?) do
+    marker =
+      if command_truncated?,
+        do:
+          "\n\n... (truncated at #{div(@max_output_bytes, 1000)}KB, refine the pattern or path for fewer results)",
+        else: ""
 
     if length(lines) > @max_matches do
       truncated = Enum.take(lines, @max_matches) |> Enum.join("\n")
-      truncated <> "\n\n... (truncated, #{length(lines) - @max_matches} more lines)"
+      truncated <> "\n\n... (truncated, #{length(lines) - @max_matches} more lines)" <> marker
     else
-      output
+      Enum.join(lines, "\n") <> marker
+    end
+  end
+
+  @spec grep_result_line?(String.t()) :: boolean()
+  defp grep_result_line?(line) do
+    case Regex.run(~r/^(.*?)([:\-])\d+\2/, line) do
+      [_whole, _path, _separator] -> true
+      _ -> false
     end
   end
 end

--- a/lib/minga_agent/tools/grep.ex
+++ b/lib/minga_agent/tools/grep.ex
@@ -7,6 +7,8 @@ defmodule MingaAgent.Tools.Grep do
   at a configurable match limit to avoid flooding the context window.
   """
 
+  alias MingaAgent.Tools.DirectoryListing
+
   @max_matches 100
 
   @doc """
@@ -79,6 +81,7 @@ defmodule MingaAgent.Tools.Grep do
         else: args
 
     args = if glob, do: args ++ ["--glob", glob], else: args
+    args = args ++ rg_ignore_args()
     args = args ++ ["--max-count", Integer.to_string(@max_matches), pattern, "."]
     {rg, args}
   end
@@ -91,8 +94,23 @@ defmodule MingaAgent.Tools.Grep do
     args = if case_sensitive, do: args, else: args ++ ["-i"]
     args = if context_lines > 0, do: args ++ ["-C", Integer.to_string(context_lines)], else: args
     args = if glob, do: args ++ ["--include", glob], else: args
+    args = args ++ grep_ignore_args()
     args = args ++ [pattern, "."]
     {grep, args}
+  end
+
+  @spec rg_ignore_args() :: [String.t()]
+  defp rg_ignore_args do
+    Enum.flat_map(DirectoryListing.ignored_names(), fn name ->
+      ["--glob", "!#{name}", "--glob", "!#{name}/**"]
+    end)
+  end
+
+  @spec grep_ignore_args() :: [String.t()]
+  defp grep_ignore_args do
+    Enum.flat_map(DirectoryListing.ignored_names(), fn name ->
+      ["--exclude", name, "--exclude-dir", name]
+    end)
   end
 
   @spec truncate_output(String.t()) :: String.t()

--- a/lib/minga_agent/tools/grep.ex
+++ b/lib/minga_agent/tools/grep.ex
@@ -24,12 +24,20 @@ defmodule MingaAgent.Tools.Grep do
 
   Returns structured output with file path, line number, and matching line.
   """
-  @spec execute(String.t(), String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
-  def execute(pattern, path, opts \\ %{}) when is_binary(pattern) and is_binary(path) do
+  @type exec_opts :: [
+          filter_root: String.t(),
+          max_output_bytes: pos_integer(),
+          timeout_ms: pos_integer()
+        ]
+
+  @spec execute(String.t(), String.t(), map(), exec_opts()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def execute(pattern, path, opts \\ %{}, exec_opts \\ [])
+      when is_binary(pattern) and is_binary(path) do
     if File.dir?(path) do
       if ignored_search_root?(path),
         do: {:ok, "No matches found."},
-        else: do_execute(pattern, path, opts)
+        else: do_execute(pattern, path, public_opts(opts), exec_opts)
     else
       {:error, "Directory does not exist: #{path}"}
     end
@@ -41,19 +49,28 @@ defmodule MingaAgent.Tools.Grep do
       PathIgnore.ignored_directory?(path)
   end
 
-  @spec do_execute(String.t(), String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
-  defp do_execute(pattern, path, opts) do
+  @spec public_opts(map()) :: map()
+  defp public_opts(opts) when is_map(opts) do
+    Map.take(opts, ["glob", "case_sensitive", "context_lines"])
+  end
+
+  @spec do_execute(String.t(), String.t(), map(), exec_opts()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp do_execute(pattern, path, opts, exec_opts) do
     glob = Map.get(opts, "glob")
     case_sensitive = Map.get(opts, "case_sensitive", true)
     context_lines = Map.get(opts, "context_lines", 0)
-    filter_root = Map.get(opts, "_filter_root", path)
+    filter_root = Keyword.get(exec_opts, :filter_root, path)
+    max_output_bytes = Keyword.get(exec_opts, :max_output_bytes, @max_output_bytes)
+    timeout_ms = Keyword.get(exec_opts, :timeout_ms, OutputLimit.default_timeout_ms())
 
     {cmd, args} = build_command(pattern, path, glob, case_sensitive, context_lines)
 
     case OutputLimit.collect_command(cmd, args,
            cd: path,
            stderr_to_stdout: true,
-           max_bytes: @max_output_bytes
+           max_bytes: max_output_bytes,
+           timeout_ms: timeout_ms
          ) do
       {output, 0, truncated?} ->
         {:ok, truncate_output(filter_root, output, truncated?)}
@@ -65,6 +82,9 @@ defmodule MingaAgent.Tools.Grep do
         else
           {:ok, truncate_output(filter_root, output, truncated?)}
         end
+
+      {_output, :timeout, _truncated?} ->
+        {:error, "Search timed out"}
 
       {output, _code, _truncated?} ->
         {:error, "Search failed: #{String.trim(output)}"}
@@ -133,7 +153,7 @@ defmodule MingaAgent.Tools.Grep do
   defp truncate_output(root, output, command_truncated?) do
     lines =
       output
-      |> String.split("\n", trim: true)
+      |> grep_lines(command_truncated?)
       |> then(&PathIgnore.filter_grep_lines(root, &1))
 
     if Enum.any?(lines, &grep_result_line?/1) do
@@ -146,6 +166,13 @@ defmodule MingaAgent.Tools.Grep do
     else
       "No matches found."
     end
+  end
+
+  @spec grep_lines(String.t(), boolean()) :: [String.t()]
+  defp grep_lines(output, false), do: String.split(output, "\n", trim: true)
+
+  defp grep_lines(output, true) do
+    OutputLimit.complete_lines(output, true)
   end
 
   @spec bounded_lines([String.t()], boolean()) :: String.t()

--- a/lib/minga_agent/tools/list_directory.ex
+++ b/lib/minga_agent/tools/list_directory.ex
@@ -6,6 +6,8 @@ defmodule MingaAgent.Tools.ListDirectory do
   Entries are sorted alphabetically with directories first.
   """
 
+  alias MingaAgent.Tools.DirectoryListing
+
   @doc """
   Lists the contents of the directory at `path`.
 
@@ -15,7 +17,7 @@ defmodule MingaAgent.Tools.ListDirectory do
   def execute(path) when is_binary(path) do
     case File.ls(path) do
       {:ok, entries} ->
-        {:ok, format_entries(path, entries)}
+        {:ok, DirectoryListing.from_filesystem(path, entries)}
 
       {:error, :enoent} ->
         {:error, "directory not found: #{path}"}
@@ -26,20 +28,5 @@ defmodule MingaAgent.Tools.ListDirectory do
       {:error, reason} ->
         {:error, "failed to list #{path}: #{reason}"}
     end
-  end
-
-  @spec format_entries(String.t(), [String.t()]) :: String.t()
-  defp format_entries(path, entries) do
-    entries
-    |> Enum.sort()
-    |> Enum.map(&label_entry(path, &1))
-    |> Enum.sort_by(fn entry -> if String.ends_with?(entry, "/"), do: 0, else: 1 end)
-    |> Enum.join("\n")
-  end
-
-  @spec label_entry(String.t(), String.t()) :: String.t()
-  defp label_entry(path, entry) do
-    full = Path.join(path, entry)
-    if File.dir?(full), do: entry <> "/", else: entry
   end
 end

--- a/lib/minga_agent/tools/output_limit.ex
+++ b/lib/minga_agent/tools/output_limit.ex
@@ -4,21 +4,34 @@ defmodule MingaAgent.Tools.OutputLimit do
   """
 
   @default_max_bytes 64_000
+  @default_timeout_ms 10_000
 
+  @type command_status :: non_neg_integer() | :timeout
   @type command_result ::
-          {output :: String.t(), exit_code :: non_neg_integer(), truncated? :: boolean()}
-  @type command_opts :: [cd: String.t(), stderr_to_stdout: boolean(), max_bytes: pos_integer()]
+          {output :: String.t(), status :: command_status(), truncated? :: boolean()}
+  @type command_opts :: [
+          cd: String.t(),
+          stderr_to_stdout: boolean(),
+          max_bytes: pos_integer(),
+          timeout_ms: pos_integer()
+        ]
+
   @typep output_state ::
-           {chunks :: [String.t()], retained_bytes :: non_neg_integer(), truncated? :: boolean()}
+           {chunks :: [binary()], retained_bytes :: non_neg_integer(), truncated? :: boolean()}
 
   @doc "Returns the default byte cap used for model-facing tool output."
   @spec default_max_bytes() :: pos_integer()
   def default_max_bytes, do: @default_max_bytes
 
+  @doc "Returns the default wall-clock timeout for bounded command collection."
+  @spec default_timeout_ms() :: pos_integer()
+  def default_timeout_ms, do: @default_timeout_ms
+
   @doc "Runs a command through a Port and retains at most `max_bytes` of output."
   @spec collect_command(String.t(), [String.t()], command_opts()) :: command_result()
   def collect_command(cmd, args, opts \\ []) when is_binary(cmd) and is_list(args) do
     max_bytes = Keyword.get(opts, :max_bytes, @default_max_bytes)
+    timeout_ms = Keyword.get(opts, :timeout_ms, @default_timeout_ms)
 
     port_opts = [
       :binary,
@@ -38,7 +51,7 @@ defmodule MingaAgent.Tools.OutputLimit do
       end
 
     port = Port.open({:spawn_executable, cmd}, port_opts)
-    collect_port(port, {[], 0, false}, max_bytes)
+    collect_port(port, {[], 0, false}, max_bytes, deadline(timeout_ms))
   end
 
   @doc "Truncates `output` to `max_bytes` without splitting UTF-8 codepoints."
@@ -50,10 +63,10 @@ defmodule MingaAgent.Tools.OutputLimit do
   end
 
   @doc "Returns at most `max_bytes` from the front of `output` without splitting UTF-8 codepoints."
-  @spec utf8_prefix(String.t(), non_neg_integer()) :: String.t()
+  @spec utf8_prefix(binary(), non_neg_integer()) :: String.t()
   def utf8_prefix(_output, limit) when limit <= 0, do: ""
 
-  def utf8_prefix(output, limit) do
+  def utf8_prefix(output, limit) when is_binary(output) do
     prefix = binary_part(output, 0, min(limit, byte_size(output)))
 
     if String.valid?(prefix) do
@@ -63,27 +76,42 @@ defmodule MingaAgent.Tools.OutputLimit do
     end
   end
 
-  @spec collect_port(port(), output_state(), pos_integer()) :: command_result()
-  defp collect_port(port, output_state, max_bytes) do
+  @doc "Splits command output into complete lines, dropping a truncated final line."
+  @spec complete_lines(String.t(), boolean()) :: [String.t()]
+  def complete_lines(output, true) do
+    output
+    |> String.split("\n", trim: true)
+    |> maybe_drop_truncated_tail(String.ends_with?(output, "\n"))
+  end
+
+  def complete_lines(output, false), do: String.split(output, "\n", trim: true)
+
+  @spec maybe_drop_truncated_tail([String.t()], boolean()) :: [String.t()]
+  defp maybe_drop_truncated_tail(lines, true), do: lines
+  defp maybe_drop_truncated_tail([] = lines, false), do: lines
+  defp maybe_drop_truncated_tail(lines, false), do: Enum.drop(lines, -1)
+
+  @spec collect_port(port(), output_state(), pos_integer(), integer()) :: command_result()
+  defp collect_port(port, output_state, max_bytes, deadline_ms) do
     receive do
       {^port, {:data, data}} ->
-        output_state = retain_output(output_state, data, max_bytes)
-
-        case output_state do
-          {_chunks, _retained, true} ->
-            close_port(port)
-            {output_state_to_binary(output_state), 0, true}
-
-          _ ->
-            collect_port(port, output_state, max_bytes)
+        if expired?(deadline_ms) do
+          close_port(port)
+          {output_state_to_binary(output_state), :timeout, elem(output_state, 2)}
+        else
+          collect_port(port, retain_output(output_state, data, max_bytes), max_bytes, deadline_ms)
         end
 
       {^port, {:exit_status, exit_code}} ->
         {output_state_to_binary(output_state), exit_code, elem(output_state, 2)}
+    after
+      remaining_ms(deadline_ms) ->
+        close_port(port)
+        {output_state_to_binary(output_state), :timeout, elem(output_state, 2)}
     end
   end
 
-  @spec retain_output(output_state(), String.t(), pos_integer()) :: output_state()
+  @spec retain_output(output_state(), binary(), pos_integer()) :: output_state()
   defp retain_output({_chunks, _retained_bytes, true} = output_state, _data, _max_bytes),
     do: output_state
 
@@ -93,18 +121,31 @@ defmodule MingaAgent.Tools.OutputLimit do
     if byte_size(data) <= remaining do
       {[data | chunks], retained_bytes + byte_size(data), false}
     else
-      prefix = utf8_prefix(data, remaining)
+      prefix = binary_part(data, 0, max(remaining, 0))
       chunks = if prefix == "", do: chunks, else: [prefix | chunks]
       {chunks, max_bytes, true}
     end
   end
 
   @spec output_state_to_binary(output_state()) :: String.t()
-  defp output_state_to_binary({chunks, _retained_bytes, _truncated?}) do
-    chunks
-    |> Enum.reverse()
-    |> IO.iodata_to_binary()
+  defp output_state_to_binary({chunks, _retained_bytes, truncated?}) do
+    output = chunks |> Enum.reverse() |> IO.iodata_to_binary()
+
+    if truncated? do
+      utf8_prefix(output, byte_size(output))
+    else
+      output
+    end
   end
+
+  @spec deadline(pos_integer()) :: integer()
+  defp deadline(timeout_ms), do: System.monotonic_time(:millisecond) + timeout_ms
+
+  @spec expired?(integer()) :: boolean()
+  defp expired?(deadline_ms), do: System.monotonic_time(:millisecond) >= deadline_ms
+
+  @spec remaining_ms(integer()) :: non_neg_integer()
+  defp remaining_ms(deadline_ms), do: max(deadline_ms - System.monotonic_time(:millisecond), 0)
 
   @spec close_port(port()) :: :ok
   defp close_port(port) do

--- a/lib/minga_agent/tools/output_limit.ex
+++ b/lib/minga_agent/tools/output_limit.ex
@@ -1,0 +1,116 @@
+defmodule MingaAgent.Tools.OutputLimit do
+  @moduledoc """
+  UTF-8-safe output truncation for model-facing agent tool results.
+  """
+
+  @default_max_bytes 64_000
+
+  @type command_result ::
+          {output :: String.t(), exit_code :: non_neg_integer(), truncated? :: boolean()}
+  @type command_opts :: [cd: String.t(), stderr_to_stdout: boolean(), max_bytes: pos_integer()]
+  @typep output_state ::
+           {chunks :: [String.t()], retained_bytes :: non_neg_integer(), truncated? :: boolean()}
+
+  @doc "Returns the default byte cap used for model-facing tool output."
+  @spec default_max_bytes() :: pos_integer()
+  def default_max_bytes, do: @default_max_bytes
+
+  @doc "Runs a command through a Port and retains at most `max_bytes` of output."
+  @spec collect_command(String.t(), [String.t()], command_opts()) :: command_result()
+  def collect_command(cmd, args, opts \\ []) when is_binary(cmd) and is_list(args) do
+    max_bytes = Keyword.get(opts, :max_bytes, @default_max_bytes)
+
+    port_opts = [
+      :binary,
+      :exit_status,
+      args: args
+    ]
+
+    port_opts =
+      if Keyword.get(opts, :stderr_to_stdout, false),
+        do: [:stderr_to_stdout | port_opts],
+        else: port_opts
+
+    port_opts =
+      case Keyword.get(opts, :cd) do
+        nil -> port_opts
+        cd -> [{:cd, cd} | port_opts]
+      end
+
+    port = Port.open({:spawn_executable, cmd}, port_opts)
+    collect_port(port, {[], 0, false}, max_bytes)
+  end
+
+  @doc "Truncates `output` to `max_bytes` without splitting UTF-8 codepoints."
+  @spec truncate_utf8(String.t(), non_neg_integer(), String.t()) :: String.t()
+  def truncate_utf8(output, max_bytes, _marker) when byte_size(output) <= max_bytes, do: output
+
+  def truncate_utf8(output, max_bytes, marker) do
+    utf8_prefix(output, max_bytes) <> marker
+  end
+
+  @doc "Returns at most `max_bytes` from the front of `output` without splitting UTF-8 codepoints."
+  @spec utf8_prefix(String.t(), non_neg_integer()) :: String.t()
+  def utf8_prefix(_output, limit) when limit <= 0, do: ""
+
+  def utf8_prefix(output, limit) do
+    prefix = binary_part(output, 0, min(limit, byte_size(output)))
+
+    if String.valid?(prefix) do
+      prefix
+    else
+      utf8_prefix(output, limit - 1)
+    end
+  end
+
+  @spec collect_port(port(), output_state(), pos_integer()) :: command_result()
+  defp collect_port(port, output_state, max_bytes) do
+    receive do
+      {^port, {:data, data}} ->
+        output_state = retain_output(output_state, data, max_bytes)
+
+        case output_state do
+          {_chunks, _retained, true} ->
+            close_port(port)
+            {output_state_to_binary(output_state), 0, true}
+
+          _ ->
+            collect_port(port, output_state, max_bytes)
+        end
+
+      {^port, {:exit_status, exit_code}} ->
+        {output_state_to_binary(output_state), exit_code, elem(output_state, 2)}
+    end
+  end
+
+  @spec retain_output(output_state(), String.t(), pos_integer()) :: output_state()
+  defp retain_output({_chunks, _retained_bytes, true} = output_state, _data, _max_bytes),
+    do: output_state
+
+  defp retain_output({chunks, retained_bytes, false}, data, max_bytes) do
+    remaining = max_bytes - retained_bytes
+
+    if byte_size(data) <= remaining do
+      {[data | chunks], retained_bytes + byte_size(data), false}
+    else
+      prefix = utf8_prefix(data, remaining)
+      chunks = if prefix == "", do: chunks, else: [prefix | chunks]
+      {chunks, max_bytes, true}
+    end
+  end
+
+  @spec output_state_to_binary(output_state()) :: String.t()
+  defp output_state_to_binary({chunks, _retained_bytes, _truncated?}) do
+    chunks
+    |> Enum.reverse()
+    |> IO.iodata_to_binary()
+  end
+
+  @spec close_port(port()) :: :ok
+  defp close_port(port) do
+    Port.close(port)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+end

--- a/lib/minga_agent/tools/path_ignore.ex
+++ b/lib/minga_agent/tools/path_ignore.ex
@@ -1,0 +1,111 @@
+defmodule MingaAgent.Tools.PathIgnore do
+  @moduledoc """
+  Shared ignore policy for broad agent filesystem tools.
+
+  Prefer project ignore rules when a path is inside a git worktree, and keep a
+  conservative generated-directory denylist for non-git directories or fallback
+  tools that cannot evaluate ignore files themselves.
+  """
+
+  @ignored_names MapSet.new([
+                   ".build",
+                   ".elixir_ls",
+                   ".env",
+                   ".envrc",
+                   ".expert",
+                   ".git",
+                   ".mypy_cache",
+                   ".next",
+                   ".pytest_cache",
+                   ".ruff_cache",
+                   ".terraform",
+                   ".venv",
+                   "DerivedData",
+                   "_build",
+                   "burrito_out",
+                   "cover",
+                   "deps",
+                   "dist",
+                   "node_modules",
+                   "tmp"
+                 ])
+
+  @doc "Returns true when a basename should be hidden from broad agent tools."
+  @spec ignored_name?(String.t()) :: boolean()
+  def ignored_name?(name) when is_binary(name), do: MapSet.member?(@ignored_names, name)
+
+  @doc "Returns conservative basenames broad agent filesystem tools omit by default."
+  @spec ignored_names() :: [String.t()]
+  def ignored_names, do: MapSet.to_list(@ignored_names)
+
+  @doc "Filters child entry names under `dir` using static and project ignore rules."
+  @spec filter_child_names(String.t(), [String.t()]) :: [String.t()]
+  def filter_child_names(dir, names) when is_binary(dir) and is_list(names) do
+    names
+    |> Enum.reject(&ignored_name?/1)
+    |> reject_gitignored_children(dir)
+  end
+
+  @spec reject_gitignored_children([String.t()], String.t()) :: [String.t()]
+  defp reject_gitignored_children([], _dir), do: []
+
+  defp reject_gitignored_children(names, dir) do
+    case git_root(dir) do
+      {:ok, root} ->
+        if git_ignored_path?(root, dir) do
+          names
+        else
+          ignored = git_ignored_child_names(root, dir, names)
+          Enum.reject(names, &MapSet.member?(ignored, &1))
+        end
+
+      :error ->
+        names
+    end
+  end
+
+  @spec git_root(String.t()) :: {:ok, String.t()} | :error
+  defp git_root(dir) do
+    case System.cmd("git", ["-C", dir, "rev-parse", "--show-toplevel"], stderr_to_stdout: true) do
+      {root, 0} -> {:ok, String.trim(root)}
+      {_output, _code} -> :error
+    end
+  rescue
+    ErlangError -> :error
+  end
+
+  @spec git_ignored_child_names(String.t(), String.t(), [String.t()]) :: MapSet.t(String.t())
+  defp git_ignored_child_names(root, dir, names) do
+    names
+    |> Enum.filter(&git_ignored_child?(root, dir, &1))
+    |> MapSet.new()
+  rescue
+    ErlangError -> MapSet.new()
+  end
+
+  @spec git_ignored_child?(String.t(), String.t(), String.t()) :: boolean()
+  defp git_ignored_child?(root, dir, name) do
+    rel_path =
+      dir
+      |> Path.join(name)
+      |> Path.relative_to(root)
+
+    git_ignored_relative_path?(root, rel_path)
+  end
+
+  @spec git_ignored_path?(String.t(), String.t()) :: boolean()
+  defp git_ignored_path?(root, dir) do
+    case Path.relative_to(dir, root) do
+      "." -> false
+      rel_path -> git_ignored_relative_path?(root, rel_path)
+    end
+  end
+
+  @spec git_ignored_relative_path?(String.t(), String.t()) :: boolean()
+  defp git_ignored_relative_path?(root, rel_path) do
+    case System.cmd("git", ["-C", root, "check-ignore", rel_path]) do
+      {_output, 0} -> true
+      {_output, _code} -> false
+    end
+  end
+end

--- a/lib/minga_agent/tools/path_ignore.ex
+++ b/lib/minga_agent/tools/path_ignore.ex
@@ -16,6 +16,7 @@ defmodule MingaAgent.Tools.PathIgnore do
                    ".git",
                    ".mypy_cache",
                    ".next",
+                   ".npmrc",
                    ".pytest_cache",
                    ".ruff_cache",
                    ".terraform",
@@ -30,20 +31,68 @@ defmodule MingaAgent.Tools.PathIgnore do
                    "tmp"
                  ])
 
+  @env_prefix ".env"
+
   @doc "Returns true when a basename should be hidden from broad agent tools."
   @spec ignored_name?(String.t()) :: boolean()
-  def ignored_name?(name) when is_binary(name), do: MapSet.member?(@ignored_names, name)
+  def ignored_name?(name) when is_binary(name) do
+    MapSet.member?(@ignored_names, name) or String.starts_with?(name, @env_prefix)
+  end
 
   @doc "Returns conservative basenames broad agent filesystem tools omit by default."
   @spec ignored_names() :: [String.t()]
-  def ignored_names, do: MapSet.to_list(@ignored_names)
+  def ignored_names do
+    @ignored_names
+    |> MapSet.to_list()
+    |> Kernel.++([".env*"])
+    |> Enum.uniq()
+  end
+
+  @doc "Returns true when a directory itself is ignored by project rules."
+  @spec ignored_directory?(String.t()) :: boolean()
+  def ignored_directory?(dir) when is_binary(dir) do
+    dir = Path.expand(dir)
+
+    case git_root(dir) do
+      {:ok, root} -> git_ignored_path?(root, dir)
+      :error -> false
+    end
+  end
 
   @doc "Filters child entry names under `dir` using static and project ignore rules."
   @spec filter_child_names(String.t(), [String.t()]) :: [String.t()]
   def filter_child_names(dir, names) when is_binary(dir) and is_list(names) do
-    names
-    |> Enum.reject(&ignored_name?/1)
-    |> reject_gitignored_children(dir)
+    dir = Path.expand(dir)
+
+    if ignored_directory?(dir) do
+      []
+    else
+      names
+      |> Enum.reject(&ignored_name?/1)
+      |> reject_gitignored_children(dir)
+    end
+  end
+
+  @doc "Filters relative result paths using static and project ignore rules."
+  @spec filter_paths(String.t(), [String.t()]) :: [String.t()]
+  def filter_paths(root, paths) when is_binary(root) and is_list(paths) do
+    root = Path.expand(root)
+
+    case git_root(root) do
+      {:ok, repo_root} -> Enum.reject(paths, &ignored_result_path?(repo_root, root, &1))
+      :error -> Enum.reject(paths, &ignored_path_name?/1)
+    end
+  end
+
+  @doc "Filters grep-style result lines using the path prefix before the line number."
+  @spec filter_grep_lines(String.t(), [String.t()]) :: [String.t()]
+  def filter_grep_lines(root, lines) when is_binary(root) and is_list(lines) do
+    root = Path.expand(root)
+
+    case git_root(root) do
+      {:ok, repo_root} -> Enum.reject(lines, &ignored_grep_line?(repo_root, root, &1))
+      :error -> Enum.reject(lines, &(grep_line_path(&1) |> ignored_path_name?()))
+    end
   end
 
   @spec reject_gitignored_children([String.t()], String.t()) :: [String.t()]
@@ -52,12 +101,8 @@ defmodule MingaAgent.Tools.PathIgnore do
   defp reject_gitignored_children(names, dir) do
     case git_root(dir) do
       {:ok, root} ->
-        if git_ignored_path?(root, dir) do
-          names
-        else
-          ignored = git_ignored_child_names(root, dir, names)
-          Enum.reject(names, &MapSet.member?(ignored, &1))
-        end
+        ignored = git_ignored_child_names(root, dir, names)
+        Enum.reject(names, &MapSet.member?(ignored, &1))
 
       :error ->
         names
@@ -67,7 +112,7 @@ defmodule MingaAgent.Tools.PathIgnore do
   @spec git_root(String.t()) :: {:ok, String.t()} | :error
   defp git_root(dir) do
     case System.cmd("git", ["-C", dir, "rev-parse", "--show-toplevel"], stderr_to_stdout: true) do
-      {root, 0} -> {:ok, String.trim(root)}
+      {root, 0} -> {:ok, Path.expand(String.trim(root))}
       {_output, _code} -> :error
     end
   rescue
@@ -103,9 +148,50 @@ defmodule MingaAgent.Tools.PathIgnore do
 
   @spec git_ignored_relative_path?(String.t(), String.t()) :: boolean()
   defp git_ignored_relative_path?(root, rel_path) do
-    case System.cmd("git", ["-C", root, "check-ignore", rel_path]) do
+    case System.cmd("git", ["-C", root, "check-ignore", "--", rel_path]) do
       {_output, 0} -> true
       {_output, _code} -> false
     end
+  end
+
+  @spec ignored_result_path?(String.t(), String.t(), String.t()) :: boolean()
+  defp ignored_result_path?(repo_root, root, path) do
+    normalized_path = normalize_result_path(repo_root, root, path)
+
+    ignored_path_name?(normalized_path) or git_ignored_relative_path?(repo_root, normalized_path)
+  end
+
+  @spec ignored_grep_line?(String.t(), String.t(), String.t()) :: boolean()
+  defp ignored_grep_line?(repo_root, root, line) do
+    case grep_line_path(line) do
+      nil -> false
+      path -> ignored_result_path?(repo_root, root, path)
+    end
+  end
+
+  @spec grep_line_path(String.t()) :: String.t() | nil
+  defp grep_line_path(line) do
+    case Regex.run(~r/^(.*?)([:\-])\d+\2/, line, capture: :all_but_first) do
+      [path, _separator] -> path
+      _ -> nil
+    end
+  end
+
+  @spec normalize_result_path(String.t(), String.t(), String.t()) :: String.t()
+  defp normalize_result_path(repo_root, root, path) do
+    repo_root = Path.expand(repo_root)
+
+    Path.join(root, path)
+    |> Path.expand()
+    |> Path.relative_to(repo_root)
+  end
+
+  @spec ignored_path_name?(String.t() | nil) :: boolean()
+  defp ignored_path_name?(nil), do: false
+
+  defp ignored_path_name?(path) do
+    path
+    |> Path.split()
+    |> Enum.any?(&ignored_name?/1)
   end
 end

--- a/lib/minga_agent/tools/path_ignore.ex
+++ b/lib/minga_agent/tools/path_ignore.ex
@@ -79,8 +79,21 @@ defmodule MingaAgent.Tools.PathIgnore do
     root = Path.expand(root)
 
     case git_root(root) do
-      {:ok, repo_root} -> Enum.reject(paths, &ignored_result_path?(repo_root, root, &1))
-      :error -> Enum.reject(paths, &ignored_path_name?/1)
+      {:ok, repo_root} ->
+        paths_with_normalized =
+          Enum.map(paths, fn path -> {path, normalize_result_path(repo_root, root, path)} end)
+
+        ignored =
+          git_ignored_relative_paths(repo_root, Enum.map(paths_with_normalized, &elem(&1, 1)))
+
+        paths_with_normalized
+        |> Enum.reject(fn {_path, normalized} ->
+          ignored_path_name?(normalized) or MapSet.member?(ignored, normalized)
+        end)
+        |> Enum.map(&elem(&1, 0))
+
+      :error ->
+        Enum.reject(paths, &ignored_path_name?/1)
     end
   end
 
@@ -90,8 +103,27 @@ defmodule MingaAgent.Tools.PathIgnore do
     root = Path.expand(root)
 
     case git_root(root) do
-      {:ok, repo_root} -> Enum.reject(lines, &ignored_grep_line?(repo_root, root, &1))
-      :error -> Enum.reject(lines, &(grep_line_path(&1) |> ignored_path_name?()))
+      {:ok, repo_root} ->
+        lines_with_paths =
+          Enum.map(lines, fn line -> {line, grep_line_path(line)} end)
+
+        normalized_paths =
+          Enum.flat_map(lines_with_paths, fn
+            {_line, nil} -> []
+            {_line, path} -> [normalize_result_path(repo_root, root, path)]
+          end)
+
+        ignored = git_ignored_relative_paths(repo_root, normalized_paths)
+
+        lines_with_paths
+        |> Enum.reject(fn
+          {_line, nil} -> false
+          {_line, path} -> ignored_normalized_path?(repo_root, root, path, ignored)
+        end)
+        |> Enum.map(&elem(&1, 0))
+
+      :error ->
+        Enum.reject(lines, &(grep_line_path(&1) |> ignored_path_name?()))
     end
   end
 
@@ -101,8 +133,17 @@ defmodule MingaAgent.Tools.PathIgnore do
   defp reject_gitignored_children(names, dir) do
     case git_root(dir) do
       {:ok, root} ->
-        ignored = git_ignored_child_names(root, dir, names)
-        Enum.reject(names, &MapSet.member?(ignored, &1))
+        names_with_rel_paths =
+          Enum.map(names, fn name ->
+            rel_path = dir |> Path.join(name) |> Path.relative_to(root)
+            {name, rel_path}
+          end)
+
+        ignored = git_ignored_relative_paths(root, Enum.map(names_with_rel_paths, &elem(&1, 1)))
+
+        names_with_rel_paths
+        |> Enum.reject(fn {_name, rel_path} -> MapSet.member?(ignored, rel_path) end)
+        |> Enum.map(&elem(&1, 0))
 
       :error ->
         names
@@ -119,25 +160,6 @@ defmodule MingaAgent.Tools.PathIgnore do
     ErlangError -> :error
   end
 
-  @spec git_ignored_child_names(String.t(), String.t(), [String.t()]) :: MapSet.t(String.t())
-  defp git_ignored_child_names(root, dir, names) do
-    names
-    |> Enum.filter(&git_ignored_child?(root, dir, &1))
-    |> MapSet.new()
-  rescue
-    ErlangError -> MapSet.new()
-  end
-
-  @spec git_ignored_child?(String.t(), String.t(), String.t()) :: boolean()
-  defp git_ignored_child?(root, dir, name) do
-    rel_path =
-      dir
-      |> Path.join(name)
-      |> Path.relative_to(root)
-
-    git_ignored_relative_path?(root, rel_path)
-  end
-
   @spec git_ignored_path?(String.t(), String.t()) :: boolean()
   defp git_ignored_path?(root, dir) do
     case Path.relative_to(dir, root) do
@@ -148,25 +170,44 @@ defmodule MingaAgent.Tools.PathIgnore do
 
   @spec git_ignored_relative_path?(String.t(), String.t()) :: boolean()
   defp git_ignored_relative_path?(root, rel_path) do
-    case System.cmd("git", ["-C", root, "check-ignore", "--", rel_path]) do
-      {_output, 0} -> true
-      {_output, _code} -> false
+    root
+    |> git_ignored_relative_paths([rel_path])
+    |> MapSet.member?(rel_path)
+  end
+
+  @spec git_ignored_relative_paths(String.t(), [String.t()]) :: MapSet.t(String.t())
+  defp git_ignored_relative_paths(_root, []), do: MapSet.new()
+
+  defp git_ignored_relative_paths(root, rel_paths) do
+    rel_paths = rel_paths |> Enum.reject(&(&1 in ["", "."])) |> Enum.uniq()
+
+    case rel_paths do
+      [] ->
+        MapSet.new()
+
+      [_ | _] ->
+        rel_paths
+        |> Enum.chunk_every(100)
+        |> Enum.reduce(MapSet.new(), &MapSet.union(&2, git_ignored_relative_path_batch(root, &1)))
+    end
+  rescue
+    ErlangError -> MapSet.new(rel_paths)
+  end
+
+  @spec git_ignored_relative_path_batch(String.t(), [String.t()]) :: MapSet.t(String.t())
+  defp git_ignored_relative_path_batch(root, rel_paths) do
+    case System.cmd("git", ["-C", root, "check-ignore", "--"] ++ rel_paths) do
+      {output, 0} -> output |> String.split("\n", trim: true) |> MapSet.new()
+      {_output, 1} -> MapSet.new()
+      {_output, _code} -> MapSet.new(rel_paths)
     end
   end
 
-  @spec ignored_result_path?(String.t(), String.t(), String.t()) :: boolean()
-  defp ignored_result_path?(repo_root, root, path) do
+  @spec ignored_normalized_path?(String.t(), String.t(), String.t(), MapSet.t(String.t())) ::
+          boolean()
+  defp ignored_normalized_path?(repo_root, root, path, ignored) do
     normalized_path = normalize_result_path(repo_root, root, path)
-
-    ignored_path_name?(normalized_path) or git_ignored_relative_path?(repo_root, normalized_path)
-  end
-
-  @spec ignored_grep_line?(String.t(), String.t(), String.t()) :: boolean()
-  defp ignored_grep_line?(repo_root, root, line) do
-    case grep_line_path(line) do
-      nil -> false
-      path -> ignored_result_path?(repo_root, root, path)
-    end
+    ignored_path_name?(normalized_path) or MapSet.member?(ignored, normalized_path)
   end
 
   @spec grep_line_path(String.t()) :: String.t() | nil

--- a/lib/minga_agent/tools/path_ignore.ex
+++ b/lib/minga_agent/tools/path_ignore.ex
@@ -48,6 +48,14 @@ defmodule MingaAgent.Tools.PathIgnore do
     |> Enum.uniq()
   end
 
+  @doc "Returns true when a path is hidden by static ignored segments or project rules."
+  @spec ignored_path?(String.t()) :: boolean()
+  def ignored_path?(path) when is_binary(path) do
+    path = Path.expand(path)
+
+    ignored_static_path?(path) or ignored_directory?(path)
+  end
+
   @doc "Returns true when a directory itself is ignored by project rules."
   @spec ignored_directory?(String.t()) :: boolean()
   def ignored_directory?(dir) when is_binary(dir) do
@@ -151,14 +159,37 @@ defmodule MingaAgent.Tools.PathIgnore do
   end
 
   @spec git_root(String.t()) :: {:ok, String.t()} | :error
-  defp git_root(dir) do
-    case System.cmd("git", ["-C", dir, "rev-parse", "--show-toplevel"], stderr_to_stdout: true) do
-      {root, 0} -> {:ok, Path.expand(String.trim(root))}
-      {_output, _code} -> :error
+  defp git_root(path) do
+    case nearest_existing_dir(path) do
+      nil ->
+        :error
+
+      dir ->
+        case System.cmd("git", ["-C", dir, "rev-parse", "--show-toplevel"],
+               stderr_to_stdout: true
+             ) do
+          {root, 0} -> {:ok, Path.expand(String.trim(root))}
+          {_output, _code} -> :error
+        end
     end
   rescue
     ErlangError -> :error
   end
+
+  @spec nearest_existing_dir(String.t()) :: String.t() | nil
+  defp nearest_existing_dir(path) do
+    path = Path.expand(path)
+
+    if File.dir?(path) do
+      path
+    else
+      nearest_existing_parent(path, Path.dirname(path))
+    end
+  end
+
+  @spec nearest_existing_parent(String.t(), String.t()) :: String.t() | nil
+  defp nearest_existing_parent(path, path), do: nil
+  defp nearest_existing_parent(_path, parent), do: nearest_existing_dir(parent)
 
   @spec git_ignored_path?(String.t(), String.t()) :: boolean()
   defp git_ignored_path?(root, dir) do
@@ -225,6 +256,14 @@ defmodule MingaAgent.Tools.PathIgnore do
     Path.join(root, path)
     |> Path.expand()
     |> Path.relative_to(repo_root)
+  end
+
+  @spec ignored_static_path?(String.t()) :: boolean()
+  defp ignored_static_path?(path) do
+    case git_root(path) do
+      {:ok, root} -> path |> Path.relative_to(root) |> ignored_path_name?()
+      :error -> path |> Path.relative_to(System.tmp_dir!()) |> ignored_path_name?()
+    end
   end
 
   @spec ignored_path_name?(String.t() | nil) :: boolean()

--- a/lib/minga_agent/tools/shell.ex
+++ b/lib/minga_agent/tools/shell.ex
@@ -60,32 +60,29 @@ defmodule MingaAgent.Tools.Shell do
         ]
       )
 
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
     now = System.monotonic_time(:millisecond)
+    deadline = now + timeout_ms
 
     collect_output(
       port,
       deadline,
       on_output,
       indicator_ms,
-      {[], 0, false},
-      [],
+      empty_output_state(),
+      empty_output_state(),
       now,
       now,
-      {0, false}
+      {0, false, ""}
     )
   rescue
     e ->
       {:error, "command failed: #{Exception.message(e)}"}
   end
 
-  # Collect output from the Port until it exits or times out.
-  # `pending` accumulates chunks between flushes. `last_flush` tracks
-  # when we last called on_output. `last_data` tracks when we last
-  # received any data (for the "running..." indicator).
   @typep output_state ::
-           {chunks :: [String.t()], retained_bytes :: non_neg_integer(), truncated? :: boolean()}
-  @typep stream_state :: {sent_bytes :: non_neg_integer(), truncated? :: boolean()}
+           {chunks :: [binary()], retained_bytes :: non_neg_integer(), truncated? :: boolean()}
+  @typep stream_state ::
+           {sent_bytes :: non_neg_integer(), truncated? :: boolean(), utf8_tail :: binary()}
 
   @spec collect_output(
           port(),
@@ -93,7 +90,7 @@ defmodule MingaAgent.Tools.Shell do
           (String.t() -> :ok) | nil,
           pos_integer(),
           output_state(),
-          [String.t()],
+          output_state(),
           integer(),
           integer(),
           stream_state()
@@ -110,51 +107,60 @@ defmodule MingaAgent.Tools.Shell do
          stream_state
        ) do
     remaining = max(deadline - System.monotonic_time(:millisecond), 0)
-    # Wake up at the sooner of: deadline, next debounce window, or running indicator
     wait_ms = min(remaining, @debounce_ms)
 
     receive do
       {^port, {:data, data}} ->
         now = System.monotonic_time(:millisecond)
-        acc = retain_output(acc, data)
-        new_pending = if on_output == nil, do: [], else: [data | pending]
 
-        if on_output != nil and now - last_flush >= @debounce_ms do
-          stream_state = flush_pending(on_output, new_pending, stream_state)
+        if now >= deadline do
+          if on_output != nil and not output_state_empty?(pending),
+            do: flush_pending(on_output, pending, stream_state)
 
-          collect_output(
-            port,
-            deadline,
-            on_output,
-            indicator_ms,
-            acc,
-            [],
-            now,
-            now,
-            stream_state
-          )
+          close_port(port)
+          {:error, "command timed out"}
         else
-          collect_output(
-            port,
-            deadline,
-            on_output,
-            indicator_ms,
-            acc,
-            new_pending,
-            last_flush,
-            now,
-            stream_state
-          )
+          acc = retain_output(acc, data)
+
+          new_pending =
+            if on_output == nil,
+              do: pending,
+              else: retain_output(pending, data, pending_limit(stream_state))
+
+          if on_output != nil and now - last_flush >= @debounce_ms do
+            stream_state = flush_pending(on_output, new_pending, stream_state)
+
+            collect_output(
+              port,
+              deadline,
+              on_output,
+              indicator_ms,
+              acc,
+              empty_output_state(),
+              now,
+              now,
+              stream_state
+            )
+          else
+            collect_output(
+              port,
+              deadline,
+              on_output,
+              indicator_ms,
+              acc,
+              new_pending,
+              last_flush,
+              now,
+              stream_state
+            )
+          end
         end
 
       {^port, {:exit_status, exit_code}} ->
-        # Flush any remaining pending output
-        if on_output != nil and pending != [], do: flush_pending(on_output, pending, stream_state)
+        if on_output != nil and not output_state_empty?(pending),
+          do: flush_pending(on_output, pending, stream_state)
 
-        output =
-          acc
-          |> output_state_to_binary()
-          |> String.trim_trailing()
+        output = acc |> output_state_to_binary() |> String.trim_trailing()
 
         result =
           if exit_code == 0 do
@@ -169,15 +175,12 @@ defmodule MingaAgent.Tools.Shell do
         now = System.monotonic_time(:millisecond)
 
         if now >= deadline do
-          # Flush before timing out
-          if on_output != nil and pending != [],
+          if on_output != nil and not output_state_empty?(pending),
             do: flush_pending(on_output, pending, stream_state)
 
-          Port.close(port)
-          elapsed_s = div(now - (deadline - remaining), 1_000)
-          {:error, "command timed out after #{elapsed_s}s"}
+          close_port(port)
+          {:error, "command timed out"}
         else
-          # Check if we should flush pending output or send a running indicator
           {new_pending, new_flush, new_data, stream_state} =
             maybe_flush_or_indicate(
               on_output,
@@ -206,13 +209,13 @@ defmodule MingaAgent.Tools.Shell do
 
   @spec maybe_flush_or_indicate(
           (String.t() -> :ok) | nil,
-          [String.t()],
+          output_state(),
           integer(),
           integer(),
           integer(),
           pos_integer(),
           stream_state()
-        ) :: {[String.t()], integer(), integer(), stream_state()}
+        ) :: {output_state(), integer(), integer(), stream_state()}
   defp maybe_flush_or_indicate(
          nil,
          pending,
@@ -234,68 +237,119 @@ defmodule MingaAgent.Tools.Shell do
          indicator_ms,
          stream_state
        ) do
-    if pending != [] and now - last_flush >= @debounce_ms do
-      # Flush accumulated output
+    if not output_state_empty?(pending) and now - last_flush >= @debounce_ms do
       stream_state = flush_pending(on_output, pending, stream_state)
-      {[], now, last_data, stream_state}
+      {empty_output_state(), now, last_data, stream_state}
     else
-      if pending == [] and now - last_data >= indicator_ms do
-        # No output for a while, send a running indicator
+      if output_state_empty?(pending) and now - last_data >= indicator_ms do
         stream_state = emit_stream_chunk(on_output, "[running...]\n", stream_state)
-        {[], now, now, stream_state}
+        {empty_output_state(), now, now, stream_state}
       else
         {pending, last_flush, last_data, stream_state}
       end
     end
   end
 
-  @spec flush_pending((String.t() -> :ok), [String.t()], stream_state()) :: stream_state()
+  @spec flush_pending((String.t() -> :ok), output_state(), stream_state()) :: stream_state()
   defp flush_pending(on_output, pending, stream_state) do
-    batch = pending |> Enum.reverse() |> IO.iodata_to_binary()
-    emit_stream_chunk(on_output, batch, stream_state)
+    stream_state = emit_stream_chunk(on_output, output_state_content(pending), stream_state)
+    maybe_emit_stream_truncation(on_output, stream_state, elem(pending, 2))
   end
 
-  @spec emit_stream_chunk((String.t() -> :ok), String.t(), stream_state()) :: stream_state()
-  defp emit_stream_chunk(_on_output, _batch, {_sent_bytes, true} = stream_state), do: stream_state
+  @spec maybe_emit_stream_truncation((String.t() -> :ok), stream_state(), boolean()) ::
+          stream_state()
+  defp maybe_emit_stream_truncation(_on_output, stream_state, false), do: stream_state
 
-  defp emit_stream_chunk(on_output, batch, {sent_bytes, false}) do
+  defp maybe_emit_stream_truncation(_on_output, {_sent_bytes, true, _tail} = stream_state, true),
+    do: stream_state
+
+  defp maybe_emit_stream_truncation(on_output, _stream_state, true) do
+    on_output.("\n\n[stream truncated at #{div(@max_output_bytes, 1000)}KB]\n")
+    {@max_output_bytes, true, ""}
+  end
+
+  @spec emit_stream_chunk((String.t() -> :ok), binary(), stream_state()) :: stream_state()
+  defp emit_stream_chunk(_on_output, _batch, {_sent_bytes, true, _tail} = stream_state),
+    do: stream_state
+
+  defp emit_stream_chunk(on_output, batch, {sent_bytes, false, tail}) do
+    batch = tail <> batch
     remaining = @max_output_bytes - sent_bytes
 
     if byte_size(batch) <= remaining do
-      on_output.(batch)
-      {sent_bytes + byte_size(batch), false}
+      {prefix, tail} = split_valid_prefix(batch)
+      if prefix != "", do: on_output.(prefix)
+      {sent_bytes + byte_size(prefix), false, tail}
     else
       chunk = OutputLimit.utf8_prefix(batch, remaining)
       if chunk != "", do: on_output.(chunk)
       on_output.("\n\n[stream truncated at #{div(@max_output_bytes, 1000)}KB]\n")
-      {@max_output_bytes, true}
+      {@max_output_bytes, true, ""}
     end
   end
 
-  @spec retain_output(output_state(), String.t()) :: output_state()
-  defp retain_output({_chunks, _retained_bytes, true} = output_state, _data), do: output_state
+  @spec split_valid_prefix(binary()) :: {String.t(), binary()}
+  defp split_valid_prefix(batch) do
+    prefix = OutputLimit.utf8_prefix(batch, byte_size(batch))
+    tail_size = byte_size(batch) - byte_size(prefix)
+    tail = binary_part(batch, byte_size(prefix), tail_size)
+    {prefix, tail}
+  end
 
-  defp retain_output({chunks, retained_bytes, false}, data) do
-    remaining = @max_output_bytes - retained_bytes
+  @spec empty_output_state() :: output_state()
+  defp empty_output_state, do: {[], 0, false}
+
+  @spec output_state_empty?(output_state()) :: boolean()
+  defp output_state_empty?({[], 0, false}), do: true
+  defp output_state_empty?(_output_state), do: false
+
+  @spec pending_limit(stream_state()) :: non_neg_integer()
+  defp pending_limit({sent_bytes, _truncated?, _tail}), do: max(@max_output_bytes - sent_bytes, 0)
+
+  @spec retain_output(output_state(), binary()) :: output_state()
+  defp retain_output(output_state, data), do: retain_output(output_state, data, @max_output_bytes)
+
+  @spec retain_output(output_state(), binary(), non_neg_integer()) :: output_state()
+  defp retain_output({_chunks, _retained_bytes, true} = output_state, _data, _max_bytes),
+    do: output_state
+
+  defp retain_output({chunks, retained_bytes, false}, data, max_bytes) do
+    remaining = max(max_bytes - retained_bytes, 0)
 
     if byte_size(data) <= remaining do
       {[data | chunks], retained_bytes + byte_size(data), false}
     else
-      prefix = OutputLimit.utf8_prefix(data, remaining)
-      marker = "\n\n[truncated at #{div(@max_output_bytes, 1000)}KB]"
-      chunks = if prefix == "", do: [marker | chunks], else: [marker, prefix | chunks]
-      {chunks, @max_output_bytes, true}
+      prefix = binary_part(data, 0, remaining)
+      chunks = if prefix == "", do: chunks, else: [prefix | chunks]
+      {chunks, max_bytes, true}
     end
   end
 
-  @spec output_state_to_binary(output_state()) :: String.t()
-  defp output_state_to_binary({chunks, _retained_bytes, _truncated?}) do
-    chunks
-    |> Enum.reverse()
-    |> IO.iodata_to_binary()
+  @spec output_state_content(output_state()) :: binary()
+  defp output_state_content({chunks, _retained_bytes, _truncated?}) do
+    chunks |> Enum.reverse() |> IO.iodata_to_binary()
   end
 
-  # Port env requires charlist tuples, not string tuples.
+  @spec output_state_to_binary(output_state()) :: String.t()
+  defp output_state_to_binary({_chunks, _retained_bytes, truncated?} = output_state) do
+    output = output_state_content(output_state)
+
+    if truncated? do
+      OutputLimit.utf8_prefix(output, byte_size(output)) <>
+        "\n\n[truncated at #{div(@max_output_bytes, 1000)}KB]"
+    else
+      output
+    end
+  end
+
+  @spec close_port(port()) :: :ok
+  defp close_port(port) do
+    Port.close(port)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
   @spec safe_env_charlist([{String.t(), String.t()}]) :: [{charlist(), charlist()}]
   defp safe_env_charlist(extra_env) do
     base = [

--- a/lib/minga_agent/tools/shell.ex
+++ b/lib/minga_agent/tools/shell.ex
@@ -19,6 +19,7 @@ defmodule MingaAgent.Tools.Shell do
 
   @debounce_ms 200
   @running_indicator_ms 3_000
+  @max_output_bytes 64_000
 
   @doc """
   Runs `command` in the given `cwd` with a `timeout_secs` limit.
@@ -119,7 +120,12 @@ defmodule MingaAgent.Tools.Shell do
         # Flush any remaining pending output
         if on_output != nil and pending != [], do: flush_pending(on_output, pending)
 
-        output = acc |> Enum.reverse() |> IO.iodata_to_binary() |> String.trim_trailing()
+        output =
+          acc
+          |> Enum.reverse()
+          |> IO.iodata_to_binary()
+          |> String.trim_trailing()
+          |> truncate_output()
 
         result =
           if exit_code == 0 do
@@ -191,6 +197,14 @@ defmodule MingaAgent.Tools.Shell do
     batch = pending |> Enum.reverse() |> IO.iodata_to_binary()
     on_output.(batch)
     :ok
+  end
+
+  @spec truncate_output(String.t()) :: String.t()
+  defp truncate_output(output) when byte_size(output) <= @max_output_bytes, do: output
+
+  defp truncate_output(output) do
+    truncated = binary_part(output, 0, @max_output_bytes)
+    truncated <> "\n\n[truncated at #{div(@max_output_bytes, 1000)}KB]"
   end
 
   # Port env requires charlist tuples, not string tuples.

--- a/lib/minga_agent/tools/shell.ex
+++ b/lib/minga_agent/tools/shell.ex
@@ -17,9 +17,11 @@ defmodule MingaAgent.Tools.Shell do
           env: [{String.t(), String.t()}]
         ]
 
+  alias MingaAgent.Tools.OutputLimit
+
   @debounce_ms 200
   @running_indicator_ms 3_000
-  @max_output_bytes 64_000
+  @max_output_bytes OutputLimit.default_max_bytes()
 
   @doc """
   Runs `command` in the given `cwd` with a `timeout_secs` limit.
@@ -61,7 +63,17 @@ defmodule MingaAgent.Tools.Shell do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
     now = System.monotonic_time(:millisecond)
 
-    collect_output(port, deadline, on_output, indicator_ms, [], [], now, now)
+    collect_output(
+      port,
+      deadline,
+      on_output,
+      indicator_ms,
+      {[], 0, false},
+      [],
+      now,
+      now,
+      {0, false}
+    )
   rescue
     e ->
       {:error, "command failed: #{Exception.message(e)}"}
@@ -71,15 +83,20 @@ defmodule MingaAgent.Tools.Shell do
   # `pending` accumulates chunks between flushes. `last_flush` tracks
   # when we last called on_output. `last_data` tracks when we last
   # received any data (for the "running..." indicator).
+  @typep output_state ::
+           {chunks :: [String.t()], retained_bytes :: non_neg_integer(), truncated? :: boolean()}
+  @typep stream_state :: {sent_bytes :: non_neg_integer(), truncated? :: boolean()}
+
   @spec collect_output(
           port(),
           integer(),
           (String.t() -> :ok) | nil,
           pos_integer(),
-          [String.t()],
+          output_state(),
           [String.t()],
           integer(),
-          integer()
+          integer(),
+          stream_state()
         ) :: {:ok, String.t()} | {:error, String.t()}
   defp collect_output(
          port,
@@ -89,7 +106,8 @@ defmodule MingaAgent.Tools.Shell do
          acc,
          pending,
          last_flush,
-         last_data
+         last_data,
+         stream_state
        ) do
     remaining = max(deadline - System.monotonic_time(:millisecond), 0)
     # Wake up at the sooner of: deadline, next debounce window, or running indicator
@@ -98,34 +116,45 @@ defmodule MingaAgent.Tools.Shell do
     receive do
       {^port, {:data, data}} ->
         now = System.monotonic_time(:millisecond)
-        new_pending = [data | pending]
+        acc = retain_output(acc, data)
+        new_pending = if on_output == nil, do: [], else: [data | pending]
 
         if on_output != nil and now - last_flush >= @debounce_ms do
-          flush_pending(on_output, new_pending)
-          collect_output(port, deadline, on_output, indicator_ms, [data | acc], [], now, now)
+          stream_state = flush_pending(on_output, new_pending, stream_state)
+
+          collect_output(
+            port,
+            deadline,
+            on_output,
+            indicator_ms,
+            acc,
+            [],
+            now,
+            now,
+            stream_state
+          )
         else
           collect_output(
             port,
             deadline,
             on_output,
             indicator_ms,
-            [data | acc],
+            acc,
             new_pending,
             last_flush,
-            now
+            now,
+            stream_state
           )
         end
 
       {^port, {:exit_status, exit_code}} ->
         # Flush any remaining pending output
-        if on_output != nil and pending != [], do: flush_pending(on_output, pending)
+        if on_output != nil and pending != [], do: flush_pending(on_output, pending, stream_state)
 
         output =
           acc
-          |> Enum.reverse()
-          |> IO.iodata_to_binary()
+          |> output_state_to_binary()
           |> String.trim_trailing()
-          |> truncate_output()
 
         result =
           if exit_code == 0 do
@@ -141,14 +170,24 @@ defmodule MingaAgent.Tools.Shell do
 
         if now >= deadline do
           # Flush before timing out
-          if on_output != nil and pending != [], do: flush_pending(on_output, pending)
+          if on_output != nil and pending != [],
+            do: flush_pending(on_output, pending, stream_state)
+
           Port.close(port)
           elapsed_s = div(now - (deadline - remaining), 1_000)
           {:error, "command timed out after #{elapsed_s}s"}
         else
           # Check if we should flush pending output or send a running indicator
-          {new_pending, new_flush, new_data} =
-            maybe_flush_or_indicate(on_output, pending, last_flush, last_data, now, indicator_ms)
+          {new_pending, new_flush, new_data, stream_state} =
+            maybe_flush_or_indicate(
+              on_output,
+              pending,
+              last_flush,
+              last_data,
+              now,
+              indicator_ms,
+              stream_state
+            )
 
           collect_output(
             port,
@@ -158,7 +197,8 @@ defmodule MingaAgent.Tools.Shell do
             acc,
             new_pending,
             new_flush,
-            new_data
+            new_data,
+            stream_state
           )
         end
     end
@@ -170,41 +210,89 @@ defmodule MingaAgent.Tools.Shell do
           integer(),
           integer(),
           integer(),
-          pos_integer()
-        ) :: {[String.t()], integer(), integer()}
-  defp maybe_flush_or_indicate(nil, pending, last_flush, last_data, _now, _indicator_ms) do
-    {pending, last_flush, last_data}
+          pos_integer(),
+          stream_state()
+        ) :: {[String.t()], integer(), integer(), stream_state()}
+  defp maybe_flush_or_indicate(
+         nil,
+         pending,
+         last_flush,
+         last_data,
+         _now,
+         _indicator_ms,
+         stream_state
+       ) do
+    {pending, last_flush, last_data, stream_state}
   end
 
-  defp maybe_flush_or_indicate(on_output, pending, last_flush, last_data, now, indicator_ms) do
+  defp maybe_flush_or_indicate(
+         on_output,
+         pending,
+         last_flush,
+         last_data,
+         now,
+         indicator_ms,
+         stream_state
+       ) do
     if pending != [] and now - last_flush >= @debounce_ms do
       # Flush accumulated output
-      flush_pending(on_output, pending)
-      {[], now, last_data}
+      stream_state = flush_pending(on_output, pending, stream_state)
+      {[], now, last_data, stream_state}
     else
       if pending == [] and now - last_data >= indicator_ms do
         # No output for a while, send a running indicator
-        on_output.("[running...]\n")
-        {[], now, now}
+        stream_state = emit_stream_chunk(on_output, "[running...]\n", stream_state)
+        {[], now, now, stream_state}
       else
-        {pending, last_flush, last_data}
+        {pending, last_flush, last_data, stream_state}
       end
     end
   end
 
-  @spec flush_pending((String.t() -> :ok), [String.t()]) :: :ok
-  defp flush_pending(on_output, pending) do
+  @spec flush_pending((String.t() -> :ok), [String.t()], stream_state()) :: stream_state()
+  defp flush_pending(on_output, pending, stream_state) do
     batch = pending |> Enum.reverse() |> IO.iodata_to_binary()
-    on_output.(batch)
-    :ok
+    emit_stream_chunk(on_output, batch, stream_state)
   end
 
-  @spec truncate_output(String.t()) :: String.t()
-  defp truncate_output(output) when byte_size(output) <= @max_output_bytes, do: output
+  @spec emit_stream_chunk((String.t() -> :ok), String.t(), stream_state()) :: stream_state()
+  defp emit_stream_chunk(_on_output, _batch, {_sent_bytes, true} = stream_state), do: stream_state
 
-  defp truncate_output(output) do
-    truncated = binary_part(output, 0, @max_output_bytes)
-    truncated <> "\n\n[truncated at #{div(@max_output_bytes, 1000)}KB]"
+  defp emit_stream_chunk(on_output, batch, {sent_bytes, false}) do
+    remaining = @max_output_bytes - sent_bytes
+
+    if byte_size(batch) <= remaining do
+      on_output.(batch)
+      {sent_bytes + byte_size(batch), false}
+    else
+      chunk = OutputLimit.utf8_prefix(batch, remaining)
+      if chunk != "", do: on_output.(chunk)
+      on_output.("\n\n[stream truncated at #{div(@max_output_bytes, 1000)}KB]\n")
+      {@max_output_bytes, true}
+    end
+  end
+
+  @spec retain_output(output_state(), String.t()) :: output_state()
+  defp retain_output({_chunks, _retained_bytes, true} = output_state, _data), do: output_state
+
+  defp retain_output({chunks, retained_bytes, false}, data) do
+    remaining = @max_output_bytes - retained_bytes
+
+    if byte_size(data) <= remaining do
+      {[data | chunks], retained_bytes + byte_size(data), false}
+    else
+      prefix = OutputLimit.utf8_prefix(data, remaining)
+      marker = "\n\n[truncated at #{div(@max_output_bytes, 1000)}KB]"
+      chunks = if prefix == "", do: [marker | chunks], else: [marker, prefix | chunks]
+      {chunks, @max_output_bytes, true}
+    end
+  end
+
+  @spec output_state_to_binary(output_state()) :: String.t()
+  defp output_state_to_binary({chunks, _retained_bytes, _truncated?}) do
+    chunks
+    |> Enum.reverse()
+    |> IO.iodata_to_binary()
   end
 
   # Port env requires charlist tuples, not string tuples.

--- a/lib/minga_agent/tools/shell.ex
+++ b/lib/minga_agent/tools/shell.ex
@@ -63,17 +63,16 @@ defmodule MingaAgent.Tools.Shell do
     now = System.monotonic_time(:millisecond)
     deadline = now + timeout_ms
 
-    collect_output(
-      port,
-      deadline,
-      on_output,
-      indicator_ms,
-      empty_output_state(),
-      empty_output_state(),
-      now,
-      now,
-      {0, false, ""}
-    )
+    collect_output(port, %{
+      deadline: deadline,
+      on_output: on_output,
+      indicator_ms: indicator_ms,
+      acc: empty_output_state(),
+      pending: empty_output_state(),
+      last_flush: now,
+      last_data: now,
+      stream_state: {0, false, ""}
+    })
   rescue
     e ->
       {:error, "command failed: #{Exception.message(e)}"}
@@ -83,127 +82,118 @@ defmodule MingaAgent.Tools.Shell do
            {chunks :: [binary()], retained_bytes :: non_neg_integer(), truncated? :: boolean()}
   @typep stream_state ::
            {sent_bytes :: non_neg_integer(), truncated? :: boolean(), utf8_tail :: binary()}
+  @typep collect_state :: %{
+           deadline: integer(),
+           on_output: (String.t() -> :ok) | nil,
+           indicator_ms: pos_integer(),
+           acc: output_state(),
+           pending: output_state(),
+           last_flush: integer(),
+           last_data: integer(),
+           stream_state: stream_state()
+         }
 
-  @spec collect_output(
-          port(),
-          integer(),
-          (String.t() -> :ok) | nil,
-          pos_integer(),
-          output_state(),
-          output_state(),
-          integer(),
-          integer(),
-          stream_state()
-        ) :: {:ok, String.t()} | {:error, String.t()}
-  defp collect_output(
-         port,
-         deadline,
-         on_output,
-         indicator_ms,
-         acc,
-         pending,
-         last_flush,
-         last_data,
-         stream_state
-       ) do
-    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+  @spec collect_output(port(), collect_state()) :: {:ok, String.t()} | {:error, String.t()}
+  defp collect_output(port, state) do
+    remaining = max(state.deadline - System.monotonic_time(:millisecond), 0)
     wait_ms = min(remaining, @debounce_ms)
 
     receive do
-      {^port, {:data, data}} ->
-        now = System.monotonic_time(:millisecond)
-
-        if now >= deadline do
-          if on_output != nil and not output_state_empty?(pending),
-            do: flush_pending(on_output, pending, stream_state)
-
-          close_port(port)
-          {:error, "command timed out"}
-        else
-          acc = retain_output(acc, data)
-
-          new_pending =
-            if on_output == nil,
-              do: pending,
-              else: retain_output(pending, data, pending_limit(stream_state))
-
-          if on_output != nil and now - last_flush >= @debounce_ms do
-            stream_state = flush_pending(on_output, new_pending, stream_state)
-
-            collect_output(
-              port,
-              deadline,
-              on_output,
-              indicator_ms,
-              acc,
-              empty_output_state(),
-              now,
-              now,
-              stream_state
-            )
-          else
-            collect_output(
-              port,
-              deadline,
-              on_output,
-              indicator_ms,
-              acc,
-              new_pending,
-              last_flush,
-              now,
-              stream_state
-            )
-          end
-        end
-
-      {^port, {:exit_status, exit_code}} ->
-        if on_output != nil and not output_state_empty?(pending),
-          do: flush_pending(on_output, pending, stream_state)
-
-        output = acc |> output_state_to_binary() |> String.trim_trailing()
-
-        result =
-          if exit_code == 0 do
-            output
-          else
-            "#{output}\n[exit code: #{exit_code}]"
-          end
-
-        {:ok, result}
+      {^port, {:data, data}} -> handle_port_data(port, data, state)
+      {^port, {:exit_status, exit_code}} -> handle_port_exit(exit_code, state)
     after
-      wait_ms ->
-        now = System.monotonic_time(:millisecond)
+      wait_ms -> handle_port_wait(port, state)
+    end
+  end
 
-        if now >= deadline do
-          if on_output != nil and not output_state_empty?(pending),
-            do: flush_pending(on_output, pending, stream_state)
+  @spec handle_port_data(port(), binary(), collect_state()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp handle_port_data(port, data, state) do
+    now = System.monotonic_time(:millisecond)
 
-          close_port(port)
-          {:error, "command timed out"}
-        else
-          {new_pending, new_flush, new_data, stream_state} =
-            maybe_flush_or_indicate(
-              on_output,
-              pending,
-              last_flush,
-              last_data,
-              now,
-              indicator_ms,
-              stream_state
-            )
+    if now >= state.deadline do
+      timeout_result(port, state)
+    else
+      state = %{state | acc: retain_output(state.acc, data), last_data: now}
+      state = retain_pending(data, state)
+      maybe_flush_pending_and_continue(port, now, state)
+    end
+  end
 
-          collect_output(
-            port,
-            deadline,
-            on_output,
-            indicator_ms,
-            acc,
-            new_pending,
-            new_flush,
-            new_data,
-            stream_state
-          )
-        end
+  @spec handle_port_exit(integer(), collect_state()) :: {:ok, String.t()}
+  defp handle_port_exit(exit_code, state) do
+    flush_if_needed(state)
+    output = state.acc |> output_state_to_binary() |> String.trim_trailing()
+
+    result = if exit_code == 0, do: output, else: "#{output}\n[exit code: #{exit_code}]"
+    {:ok, result}
+  end
+
+  @spec handle_port_wait(port(), collect_state()) :: {:ok, String.t()} | {:error, String.t()}
+  defp handle_port_wait(port, state) do
+    now = System.monotonic_time(:millisecond)
+
+    if now >= state.deadline do
+      timeout_result(port, state)
+    else
+      {pending, last_flush, last_data, stream_state} =
+        maybe_flush_or_indicate(
+          state.on_output,
+          state.pending,
+          state.last_flush,
+          state.last_data,
+          now,
+          state.indicator_ms,
+          state.stream_state
+        )
+
+      collect_output(port, %{
+        state
+        | pending: pending,
+          last_flush: last_flush,
+          last_data: last_data,
+          stream_state: stream_state
+      })
+    end
+  end
+
+  @spec timeout_result(port(), collect_state()) :: {:error, String.t()}
+  defp timeout_result(port, state) do
+    flush_if_needed(state)
+    close_port(port)
+    {:error, "command timed out"}
+  end
+
+  @spec flush_if_needed(collect_state()) :: :ok
+  defp flush_if_needed(%{on_output: nil}), do: :ok
+  defp flush_if_needed(%{pending: pending}) when pending == {[], 0, false}, do: :ok
+
+  defp flush_if_needed(state) do
+    _stream_state = flush_pending(state.on_output, state.pending, state.stream_state)
+    :ok
+  end
+
+  @spec retain_pending(binary(), collect_state()) :: collect_state()
+  defp retain_pending(_data, %{on_output: nil} = state), do: state
+
+  defp retain_pending(data, state) do
+    %{state | pending: retain_output(state.pending, data, pending_limit(state.stream_state))}
+  end
+
+  @spec maybe_flush_pending_and_continue(port(), integer(), collect_state()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp maybe_flush_pending_and_continue(port, now, state) do
+    if state.on_output != nil and now - state.last_flush >= @debounce_ms do
+      stream_state = flush_pending(state.on_output, state.pending, state.stream_state)
+
+      collect_output(port, %{
+        state
+        | pending: empty_output_state(),
+          last_flush: now,
+          stream_state: stream_state
+      })
+    else
+      collect_output(port, state)
     end
   end
 

--- a/lib/minga_agent/turn_usage.ex
+++ b/lib/minga_agent/turn_usage.ex
@@ -61,4 +61,21 @@ defmodule MingaAgent.TurnUsage do
   def format_short(%__MODULE__{} = u) do
     "↑#{u.input} ↓#{u.output} $#{u.cost}"
   end
+
+  @doc "Returns the share of input tokens served from prompt cache."
+  @spec cache_hit_rate(t()) :: float()
+  def cache_hit_rate(%__MODULE__{input: 0}), do: 0.0
+
+  def cache_hit_rate(%__MODULE__{} = u) do
+    u.cache_read / u.input
+  end
+
+  @doc "Formats a stable one-line report for token spend comparisons."
+  @spec format_cost_report(t()) :: String.t()
+  def format_cost_report(%__MODULE__{} = u) do
+    rate = Float.round(cache_hit_rate(u) * 100, 1)
+
+    "input=#{u.input} output=#{u.output} cache_read=#{u.cache_read} " <>
+      "cache_write=#{u.cache_write} cache_hit_rate=#{rate}% cost=$#{u.cost}"
+  end
 end

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -179,6 +179,48 @@ defmodule MingaAgent.Providers.NativeTest do
       assert session_state.system_prompt =~ "PROJECT RULE 1419"
     end
 
+    test "system prompt keeps cacheable environment prefix stable within a session", %{
+      tmp_dir: dir
+    } do
+      {:ok, pid} = start_provider(tmp_dir: dir)
+
+      assert {:ok, session_state} = Native.get_state(pid)
+      assert session_state.system_prompt =~ "Project root: #{dir}"
+      refute session_state.system_prompt =~ "Current time:"
+    end
+
+    test "auto compaction honors configured threshold", %{tmp_dir: dir} do
+      parent = self()
+
+      client = fn _model, messages, _opts ->
+        if Enum.any?(messages, &(text_content(&1) =~ "Summarize this conversation")) do
+          send(parent, :summary_called)
+          build_stream_response([ReqLLM.StreamChunk.text("summary")])
+        else
+          send(parent, :agent_called)
+          build_stream_response([ReqLLM.StreamChunk.text("answer")])
+        end
+      end
+
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: dir,
+          llm_client: client,
+          config: agent_config(compaction_threshold: 0.0, compaction_keep_recent: 1)
+        )
+
+      assert :ok =
+               Native.seed_messages(pid, [
+                 {:user, String.duplicate("user ", 200)},
+                 {:assistant, String.duplicate("assistant ", 200)}
+               ])
+
+      assert :ok = Native.send_prompt(pid, "continue")
+
+      assert_receive :summary_called, 1_000
+      assert_receive :agent_called, 1_000
+    end
+
     test "thinking level accepts known values, rejects unknown values, and cycles in order", %{
       tmp_dir: dir
     } do

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -7,6 +7,7 @@ defmodule MingaAgent.Providers.NativeTest do
   alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.ProjectView
   alias MingaAgent.Event
+  alias MingaAgent.TurnUsage
   alias MingaAgent.ProjectView.RecordingBackend
   alias MingaAgent.Providers.Native
   alias MingaAgent.ToolCall
@@ -186,6 +187,13 @@ defmodule MingaAgent.Providers.NativeTest do
 
       assert {:ok, session_state} = Native.get_state(pid)
       assert session_state.system_prompt =~ "Project root: #{dir}"
+
+      assert session_state.system_prompt =~
+               "list_directory: List entries at a known-small path. Bounded and ignores generated trees."
+
+      assert session_state.system_prompt =~
+               "Do not use shell to recursively list or search files when find or grep can answer the question."
+
       refute session_state.system_prompt =~ "Current time:"
     end
 
@@ -1898,6 +1906,119 @@ defmodule MingaAgent.Providers.NativeTest do
   # ── Cost budget tests (#404) ────────────────────────────────────────────────
 
   describe "cost budget" do
+    test "normalizes raw usage and reports prompt guidance", %{tmp_dir: dir} do
+      usage = %{
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_read_input_tokens: 750,
+        cache_creation_input_tokens: 100,
+        total_cost: 0.05
+      }
+
+      client =
+        fake_llm_client(
+          [ReqLLM.StreamChunk.text("Hello"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})],
+          usage
+        )
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, max_cost: 5.0)
+
+      assert {:ok, session_state} = Native.get_state(pid)
+
+      assert session_state.system_prompt =~
+               "list_directory: List entries at a known-small path. Bounded and ignores generated trees."
+
+      assert session_state.system_prompt =~
+               "Do not use shell to recursively list or search files when find or grep can answer the question."
+
+      :ok = Native.send_prompt(pid, "test")
+      events = collect_events(1_000)
+
+      assert %Event.AgentEnd{
+               usage: %TurnUsage{
+                 input: 1000,
+                 output: 500,
+                 cache_read: 750,
+                 cache_write: 100,
+                 cost: 0.05
+               }
+             } =
+               Enum.find(events, &match?(%Event.AgentEnd{}, &1))
+    end
+
+    test "normalizes ReqLLM canonical cache usage fields", %{tmp_dir: dir} do
+      usage = %{
+        input_tokens: 1100,
+        output_tokens: 550,
+        cached_input: 800,
+        cache_creation: 120,
+        total_cost: 0.06
+      }
+
+      client =
+        fake_llm_client(
+          [ReqLLM.StreamChunk.text("Hello"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})],
+          usage
+        )
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, max_cost: 5.0)
+      :ok = Native.send_prompt(pid, "test")
+      events = collect_events(1_000)
+
+      assert %Event.AgentEnd{
+               usage: %TurnUsage{
+                 input: 1100,
+                 output: 550,
+                 cache_read: 800,
+                 cache_write: 120,
+                 cost: 0.06
+               }
+             } = Enum.find(events, &match?(%Event.AgentEnd{}, &1))
+    end
+
+    test "normalizes fallback usage fields", %{tmp_dir: dir} do
+      usage = %{input: 1100, output: 550, cache_write: 120, cost: 0.06}
+
+      client =
+        fake_llm_client(
+          [ReqLLM.StreamChunk.text("Hello"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})],
+          usage
+        )
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, max_cost: 5.0)
+      :ok = Native.send_prompt(pid, "test")
+      events = collect_events(1_000)
+
+      assert %Event.AgentEnd{
+               usage: %TurnUsage{
+                 input: 1100,
+                 output: 550,
+                 cache_read: 0,
+                 cache_write: 120,
+                 cost: 0.06
+               }
+             } = Enum.find(events, &match?(%Event.AgentEnd{}, &1))
+    end
+
+    test "keeps explicit zero usage values", %{tmp_dir: dir} do
+      usage = %{input_tokens: 0, input: 1100, output_tokens: 0, output: 550, total_cost: 0.0}
+
+      client =
+        fake_llm_client(
+          [ReqLLM.StreamChunk.text("Hello"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})],
+          usage
+        )
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, max_cost: 5.0)
+      :ok = Native.send_prompt(pid, "test")
+      events = collect_events(1_000)
+
+      assert %Event.AgentEnd{usage: %TurnUsage{input: 0, output: 0, cost: cost}} =
+               Enum.find(events, &match?(%Event.AgentEnd{}, &1))
+
+      assert cost == 0.0
+    end
+
     test "budget can be read, changed, disabled, and reset by new_session", %{tmp_dir: dir} do
       usage = %{input_tokens: 1000, output_tokens: 500, total_cost: 0.05}
 

--- a/test/minga_agent/tool_router_test.exs
+++ b/test/minga_agent/tool_router_test.exs
@@ -260,6 +260,45 @@ defmodule MingaAgent.ToolRouterTest do
     end
   end
 
+  describe "search_context/2" do
+    test "uses the validated path for direct execution and filtering", %{path: path} do
+      ctx = ToolRouter.context(nil, nil)
+
+      assert {:ok, search} = ToolRouter.search_context(ctx, path)
+      assert search.exec_path == path
+      assert search.filter_root == path
+    end
+
+    test "uses ProjectView working dir for execution and validated path for filtering", %{
+      path: path
+    } do
+      project_root = Path.dirname(Path.dirname(path))
+      {:ok, view} = ProjectView.overlay(project_root)
+      ctx = ToolRouter.context(view, nil, nil)
+      overlay_dir = ProjectView.working_dir(view)
+
+      assert {:ok, search} = ToolRouter.search_context(ctx, Path.join(project_root, "lib"))
+      assert search.exec_path == Path.join(overlay_dir, "lib")
+      assert search.filter_root == Path.join(project_root, "lib")
+    end
+
+    test "uses changeset overlay dir for execution and validated path for filtering", %{
+      path: path
+    } do
+      project_root = Path.dirname(Path.dirname(path))
+
+      {:ok, changeset} =
+        start_supervised({MingaAgent.Changeset.Server, project_root: project_root})
+
+      ctx = ToolRouter.context(nil, nil, changeset)
+      overlay_dir = MingaAgent.Changeset.overlay_path(changeset)
+
+      assert {:ok, search} = ToolRouter.search_context(ctx, Path.join(project_root, "lib"))
+      assert search.exec_path == Path.join(overlay_dir, "lib")
+      assert search.filter_root == Path.join(project_root, "lib")
+    end
+  end
+
   describe "working_dir/1" do
     test "returns nil with no changeset" do
       ctx = ToolRouter.context(nil, nil)

--- a/test/minga_agent/tool_router_test.exs
+++ b/test/minga_agent/tool_router_test.exs
@@ -297,6 +297,30 @@ defmodule MingaAgent.ToolRouterTest do
       assert search.exec_path == Path.join(overlay_dir, "lib")
       assert search.filter_root == Path.join(project_root, "lib")
     end
+
+    test "materializes fork drafts into changeset search and command views", %{
+      store: store,
+      path: path
+    } do
+      project_root = Path.dirname(Path.dirname(path))
+
+      {:ok, changeset} =
+        start_supervised({MingaAgent.Changeset.Server, project_root: project_root})
+
+      ctx = ToolRouter.context(store, changeset)
+      original = File.read!(path)
+
+      assert :ok = ToolRouter.write_file(ctx, path, "fork draft needle\n")
+      assert File.read!(path) == original
+      assert {:ok, search} = ToolRouter.search_context(ctx, Path.join(project_root, "lib"))
+      assert File.read!(Path.join(search.exec_path, "foo.ex")) == "fork draft needle\n"
+
+      assert {:ok, resolved} = ToolRouter.filesystem_path_result(ctx, path)
+      assert File.read!(resolved) == "fork draft needle\n"
+
+      assert {:ok, cwd} = ToolRouter.working_dir_result(ctx)
+      assert File.read!(Path.join(cwd, "lib/foo.ex")) == "fork draft needle\n"
+    end
   end
 
   describe "working_dir/1" do

--- a/test/minga_agent/tools/find_test.exs
+++ b/test/minga_agent/tools/find_test.exs
@@ -4,6 +4,35 @@ defmodule MingaAgent.Tools.FindTest do
 
   alias MingaAgent.Tools.Find
 
+  defp with_fake_path(executables, fun) do
+    old_path = System.get_env("PATH") || ""
+
+    bin_dir =
+      Path.join(System.tmp_dir!(), "minga-find-bin-#{:erlang.unique_integer([:positive])}")
+
+    File.mkdir_p!(bin_dir)
+
+    for {name, contents} <- executables do
+      path = Path.join(bin_dir, name)
+      File.write!(path, contents)
+      File.chmod!(path, 0o755)
+    end
+
+    git = System.find_executable("git")
+    if git, do: File.ln_s!(git, Path.join(bin_dir, "git"))
+
+    sleep = System.find_executable("sleep")
+    if sleep, do: File.ln_s!(sleep, Path.join(bin_dir, "sleep"))
+
+    try do
+      System.put_env("PATH", bin_dir)
+      fun.()
+    after
+      System.put_env("PATH", old_path)
+      File.rm_rf!(bin_dir)
+    end
+  end
+
   setup do
     dir =
       Path.join(System.tmp_dir!(), "minga-find-") <>
@@ -119,6 +148,66 @@ defmodule MingaAgent.Tools.FindTest do
       assert byte_size(output) < 65_000
       assert String.valid?(output)
       assert output =~ "truncated at 64KB"
+    end
+
+    test "drops a truncated final line before ignore filtering", %{dir: dir} do
+      {_out, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
+      File.write!(Path.join(dir, ".gitignore"), "ignored_secret_file.txt\n")
+
+      fd = """
+      #!/bin/sh
+      printf 'visible.txt\nignored_secret_file.txt\n'
+      """
+
+      with_fake_path(%{"fd" => fd}, fn ->
+        assert {:ok, output} = Find.execute("*", dir, %{}, max_output_bytes: 20)
+        assert output =~ "visible.txt"
+        refute output =~ "ignored_"
+        refute output =~ "ignored_secret_file"
+      end)
+    end
+
+    test "returns timeout-specific errors for slow discovery commands", %{dir: dir} do
+      fd = """
+      #!/bin/sh
+      printf 'partial.txt\n'
+      sleep 2
+      """
+
+      with_fake_path(%{"fd" => fd}, fn ->
+        assert {:error, message} = Find.execute("*", dir, %{}, timeout_ms: 50)
+        assert message == "Find timed out"
+        refute message =~ "partial"
+      end)
+    end
+
+    test "model-supplied hidden args cannot raise trusted caps or timeouts", %{dir: dir} do
+      capped_fd = """
+      #!/bin/sh
+      printf 'visible.txt\nprivate_tail.txt\n'
+      """
+
+      with_fake_path(%{"fd" => capped_fd}, fn ->
+        assert {:ok, output} =
+                 Find.execute("*", dir, %{"_max_output_bytes" => 100_000}, max_output_bytes: 15)
+
+        assert output =~ "visible.txt"
+        refute output =~ "private"
+      end)
+
+      slow_fd = """
+      #!/bin/sh
+      printf 'visible.txt\nignored_secret_file.txt\n'
+      sleep 2
+      """
+
+      with_fake_path(%{"fd" => slow_fd}, fn ->
+        assert {:error, message} =
+                 Find.execute("*", dir, %{"_timeout_ms" => 100_000}, timeout_ms: 50)
+
+        assert message == "Find timed out"
+        refute message =~ "visible"
+      end)
     end
 
     test "results are sorted", %{dir: dir} do

--- a/test/minga_agent/tools/find_test.exs
+++ b/test/minga_agent/tools/find_test.exs
@@ -92,6 +92,29 @@ defmodule MingaAgent.Tools.FindTest do
       refute output =~ "_build"
     end
 
+    test "does not walk nested non-git ignored roots", %{dir: dir} do
+      ignored_root = Path.join([dir, "node_modules", "pkg"])
+      File.mkdir_p!(ignored_root)
+      File.write!(Path.join(ignored_root, "leaked.ex"), "defmodule Leaked")
+
+      assert {:ok, "No matches found."} = Find.execute("*.ex", ignored_root, %{"type" => "any"})
+    end
+
+    test "passes dash-prefixed fd patterns after an option terminator", %{dir: dir} do
+      fd = """
+      #!/bin/sh
+      case "$*" in
+        *" -- --literal.txt ."*) printf -- '--literal.txt\n' ;;
+        *) echo "bad args: $*" >&2; exit 2 ;;
+      esac
+      """
+
+      with_fake_path(%{"fd" => fd}, fn ->
+        assert {:ok, output} = Find.execute("--literal.txt", dir)
+        assert output =~ "--literal.txt"
+      end)
+    end
+
     test "suppresses secret env files while keeping visible matches", %{dir: dir} do
       File.write!(Path.join(dir, ".env.local"), "secret")
       File.write!(Path.join(dir, ".npmrc"), "secret")

--- a/test/minga_agent/tools/find_test.exs
+++ b/test/minga_agent/tools/find_test.exs
@@ -1,11 +1,18 @@
 defmodule MingaAgent.Tools.FindTest do
-  use ExUnit.Case, async: true
+  # Spawns OS processes through fd/find/git-backed ignore checks, which must not run async.
+  use ExUnit.Case, async: false
 
   alias MingaAgent.Tools.Find
 
-  @moduletag :tmp_dir
+  setup do
+    dir =
+      Path.join(System.tmp_dir!(), "minga-find-") <>
+        Integer.to_string(:erlang.unique_integer([:positive]))
 
-  setup %{tmp_dir: dir} do
+    File.rm_rf!(dir)
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
     File.write!(Path.join(dir, "hello.ex"), "defmodule Hello")
     File.write!(Path.join(dir, "world.ex"), "defmodule World")
     File.write!(Path.join(dir, "README.md"), "# Readme")
@@ -14,7 +21,7 @@ defmodule MingaAgent.Tools.FindTest do
     File.mkdir_p!(Path.join([dir, "lib", "sub"]))
     File.write!(Path.join([dir, "lib", "sub", "nested.ex"]), "defmodule Nested")
 
-    %{dir: dir}
+    {:ok, dir: dir}
   end
 
   describe "execute/3" do
@@ -56,6 +63,17 @@ defmodule MingaAgent.Tools.FindTest do
       refute output =~ "_build"
     end
 
+    test "suppresses secret env files while keeping visible matches", %{dir: dir} do
+      File.write!(Path.join(dir, ".env.local"), "secret")
+      File.write!(Path.join(dir, ".npmrc"), "secret")
+      File.write!(Path.join(dir, "visible_secret.txt"), "visible")
+
+      assert {:ok, output} = Find.execute("*", dir, %{"type" => "file"})
+      assert output =~ "visible_secret.txt"
+      refute output =~ ".env.local"
+      refute output =~ ".npmrc"
+    end
+
     test "respects project gitignore when discovering files", %{dir: dir} do
       {_out, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
       File.write!(Path.join(dir, ".gitignore"), "ignored_dir/\n")
@@ -67,6 +85,16 @@ defmodule MingaAgent.Tools.FindTest do
       refute output =~ "leaked.ex"
     end
 
+    test "does not walk a directly requested ignored search root", %{dir: dir} do
+      {_out, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
+      File.write!(Path.join(dir, ".gitignore"), "ignored_dir/\n")
+      ignored_dir = Path.join(dir, "ignored_dir")
+      File.mkdir_p!(ignored_dir)
+      File.write!(Path.join(ignored_dir, "leaked.ex"), "defmodule Leaked")
+
+      assert {:ok, "No matches found."} = Find.execute("*.ex", ignored_dir)
+    end
+
     test "marks truncated results when more matches exist than the model result cap", %{dir: dir} do
       for index <- 1..205 do
         File.write!(Path.join(dir, "many_#{index}.txt"), "many")
@@ -76,6 +104,21 @@ defmodule MingaAgent.Tools.FindTest do
       lines = String.split(output, "\n", trim: true)
       assert length(Enum.reject(lines, &String.starts_with?(&1, "... (truncated"))) == 200
       assert List.last(lines) == "... (truncated, refine the pattern or path for fewer results)"
+    end
+
+    test "byte-caps very long result paths without splitting UTF-8", %{dir: dir} do
+      segment = String.duplicate("é", 60)
+      long_dir = Path.join([dir, segment, segment, segment, segment])
+      File.mkdir_p!(long_dir)
+
+      for index <- 1..205 do
+        File.write!(Path.join(long_dir, "long_#{index}.txt"), "many")
+      end
+
+      assert {:ok, output} = Find.execute("long_*.txt", dir, %{"max_depth" => 5})
+      assert byte_size(output) < 65_000
+      assert String.valid?(output)
+      assert output =~ "truncated at 64KB"
     end
 
     test "results are sorted", %{dir: dir} do

--- a/test/minga_agent/tools/find_test.exs
+++ b/test/minga_agent/tools/find_test.exs
@@ -45,6 +45,39 @@ defmodule MingaAgent.Tools.FindTest do
       refute output =~ "nested.ex"
     end
 
+    test "ignores generated and dependency directories", %{dir: dir} do
+      File.mkdir_p!(Path.join([dir, "node_modules", "pkg"]))
+      File.mkdir_p!(Path.join([dir, "_build", "test"]))
+      File.write!(Path.join([dir, "node_modules", "pkg", "leaked.ex"]), "defmodule Leaked")
+      File.write!(Path.join([dir, "_build", "test", "compiled.ex"]), "defmodule Compiled")
+
+      assert {:ok, output} = Find.execute("*.ex", dir, %{"type" => "any"})
+      refute output =~ "node_modules"
+      refute output =~ "_build"
+    end
+
+    test "respects project gitignore when discovering files", %{dir: dir} do
+      {_out, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
+      File.write!(Path.join(dir, ".gitignore"), "ignored_dir/\n")
+      File.mkdir_p!(Path.join([dir, "ignored_dir"]))
+      File.write!(Path.join([dir, "ignored_dir", "leaked.ex"]), "defmodule Leaked")
+
+      assert {:ok, output} = Find.execute("*.ex", dir)
+      refute output =~ "ignored_dir"
+      refute output =~ "leaked.ex"
+    end
+
+    test "marks truncated results when more matches exist than the model result cap", %{dir: dir} do
+      for index <- 1..205 do
+        File.write!(Path.join(dir, "many_#{index}.txt"), "many")
+      end
+
+      assert {:ok, output} = Find.execute("many_*.txt", dir)
+      lines = String.split(output, "\n", trim: true)
+      assert length(Enum.reject(lines, &String.starts_with?(&1, "... (truncated"))) == 200
+      assert List.last(lines) == "... (truncated, refine the pattern or path for fewer results)"
+    end
+
     test "results are sorted", %{dir: dir} do
       assert {:ok, output} = Find.execute("*.ex", dir)
       lines = String.split(output, "\n", trim: true)

--- a/test/minga_agent/tools/grep_test.exs
+++ b/test/minga_agent/tools/grep_test.exs
@@ -1,11 +1,18 @@
 defmodule MingaAgent.Tools.GrepTest do
-  use ExUnit.Case, async: true
+  # Spawns OS processes through rg/grep/git-backed ignore checks, which must not run async.
+  use ExUnit.Case, async: false
 
   alias MingaAgent.Tools.Grep
 
-  @moduletag :tmp_dir
+  setup do
+    dir =
+      Path.join(System.tmp_dir!(), "minga-grep-") <>
+        Integer.to_string(:erlang.unique_integer([:positive]))
 
-  setup %{tmp_dir: dir} do
+    File.rm_rf!(dir)
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
     # Create test files
     File.write!(Path.join(dir, "hello.ex"), ~S"""
     defmodule Hello do
@@ -29,7 +36,7 @@ defmodule MingaAgent.Tools.GrepTest do
     And more text here.
     """)
 
-    %{dir: dir}
+    {:ok, dir: dir}
   end
 
   describe "execute/3" do
@@ -83,6 +90,36 @@ defmodule MingaAgent.Tools.GrepTest do
       assert output =~ "visible.txt"
       refute output =~ "node_modules"
       refute output =~ "_build"
+    end
+
+    test "suppresses secret env files while keeping visible matches", %{dir: dir} do
+      File.write!(Path.join(dir, "visible_secret.txt"), "shared_secret_token")
+      File.write!(Path.join(dir, ".env.local"), "shared_secret_token")
+      File.write!(Path.join(dir, ".npmrc"), "shared_secret_token")
+
+      assert {:ok, output} = Grep.execute("shared_secret_token", dir)
+      assert output =~ "visible_secret.txt"
+      refute output =~ ".env.local"
+      refute output =~ ".npmrc"
+    end
+
+    test "byte-caps very long matching lines without splitting UTF-8", %{dir: dir} do
+      File.write!(Path.join(dir, "huge.txt"), "needle " <> String.duplicate("é", 70_000))
+
+      assert {:ok, output} = Grep.execute("needle", dir)
+      assert byte_size(output) < 65_000
+      assert String.valid?(output)
+      assert output =~ "truncated at 64KB"
+    end
+
+    test "does not walk a directly requested ignored search root", %{dir: dir} do
+      {_out, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
+      File.write!(Path.join(dir, ".gitignore"), "ignored_dir/\n")
+      ignored_dir = Path.join(dir, "ignored_dir")
+      File.mkdir_p!(ignored_dir)
+      File.write!(Path.join(ignored_dir, "leaked.txt"), "expensive_token")
+
+      assert {:ok, "No matches found."} = Grep.execute("expensive_token", ignored_dir)
     end
 
     test "returns error for invalid path", %{dir: dir} do

--- a/test/minga_agent/tools/grep_test.exs
+++ b/test/minga_agent/tools/grep_test.exs
@@ -72,6 +72,19 @@ defmodule MingaAgent.Tools.GrepTest do
       assert output =~ "nested"
     end
 
+    test "ignores generated and dependency directories", %{dir: dir} do
+      File.write!(Path.join(dir, "visible.txt"), "expensive_token")
+      File.mkdir_p!(Path.join([dir, "node_modules", "pkg"]))
+      File.mkdir_p!(Path.join([dir, "_build", "test"]))
+      File.write!(Path.join([dir, "node_modules", "pkg", "leaked.txt"]), "expensive_token")
+      File.write!(Path.join([dir, "_build", "test", "compiled.txt"]), "expensive_token")
+
+      assert {:ok, output} = Grep.execute("expensive_token", dir)
+      assert output =~ "visible.txt"
+      refute output =~ "node_modules"
+      refute output =~ "_build"
+    end
+
     test "returns error for invalid path", %{dir: dir} do
       bad_path = Path.join(dir, "nonexistent_dir")
       result = Grep.execute("test", bad_path)

--- a/test/minga_agent/tools/grep_test.exs
+++ b/test/minga_agent/tools/grep_test.exs
@@ -121,6 +121,44 @@ defmodule MingaAgent.Tools.GrepTest do
       refute output =~ "_build"
     end
 
+    test "does not walk nested non-git ignored roots", %{dir: dir} do
+      ignored_root = Path.join([dir, "node_modules", "pkg"])
+      File.mkdir_p!(ignored_root)
+      File.write!(Path.join(ignored_root, "leaked.txt"), "expensive_token")
+
+      assert {:ok, "No matches found."} = Grep.execute("expensive_token", ignored_root)
+    end
+
+    test "passes dash-prefixed rg patterns after an option terminator", %{dir: dir} do
+      rg = """
+      #!/bin/sh
+      case "$*" in
+        *" -- --needle ."*) printf -- 'visible.txt:1:--needle\n' ;;
+        *) echo "bad args: $*" >&2; exit 2 ;;
+      esac
+      """
+
+      with_fake_path(%{"rg" => rg}, fn ->
+        assert {:ok, output} = Grep.execute("--needle", dir)
+        assert output =~ "visible.txt:1:--needle"
+      end)
+    end
+
+    test "passes dash-prefixed grep fallback patterns after an option terminator", %{dir: dir} do
+      grep = """
+      #!/bin/sh
+      case "$*" in
+        *" -- --needle ."*) printf -- './visible.txt:1:--needle\n' ;;
+        *) echo "bad args: $*" >&2; exit 2 ;;
+      esac
+      """
+
+      with_fake_path(%{"grep" => grep}, fn ->
+        assert {:ok, output} = Grep.execute("--needle", dir)
+        assert output =~ "visible.txt:1:--needle"
+      end)
+    end
+
     test "suppresses secret env files while keeping visible matches", %{dir: dir} do
       File.write!(Path.join(dir, "visible_secret.txt"), "shared_secret_token")
       File.write!(Path.join(dir, ".env.local"), "shared_secret_token")

--- a/test/minga_agent/tools/grep_test.exs
+++ b/test/minga_agent/tools/grep_test.exs
@@ -4,6 +4,35 @@ defmodule MingaAgent.Tools.GrepTest do
 
   alias MingaAgent.Tools.Grep
 
+  defp with_fake_path(executables, fun) do
+    old_path = System.get_env("PATH") || ""
+
+    bin_dir =
+      Path.join(System.tmp_dir!(), "minga-grep-bin-#{:erlang.unique_integer([:positive])}")
+
+    File.mkdir_p!(bin_dir)
+
+    for {name, contents} <- executables do
+      path = Path.join(bin_dir, name)
+      File.write!(path, contents)
+      File.chmod!(path, 0o755)
+    end
+
+    git = System.find_executable("git")
+    if git, do: File.ln_s!(git, Path.join(bin_dir, "git"))
+
+    sleep = System.find_executable("sleep")
+    if sleep, do: File.ln_s!(sleep, Path.join(bin_dir, "sleep"))
+
+    try do
+      System.put_env("PATH", bin_dir)
+      fun.()
+    after
+      System.put_env("PATH", old_path)
+      File.rm_rf!(bin_dir)
+    end
+  end
+
   setup do
     dir =
       Path.join(System.tmp_dir!(), "minga-grep-") <>
@@ -103,8 +132,9 @@ defmodule MingaAgent.Tools.GrepTest do
       refute output =~ ".npmrc"
     end
 
-    test "byte-caps very long matching lines without splitting UTF-8", %{dir: dir} do
-      File.write!(Path.join(dir, "huge.txt"), "needle " <> String.duplicate("é", 70_000))
+    test "byte-caps many matching lines without splitting UTF-8", %{dir: dir} do
+      lines = for index <- 1..100, do: "needle #{index} " <> String.duplicate("é", 400)
+      File.write!(Path.join(dir, "huge.txt"), Enum.join(lines, "\n") <> "\n")
 
       assert {:ok, output} = Grep.execute("needle", dir)
       assert byte_size(output) < 65_000
@@ -120,6 +150,83 @@ defmodule MingaAgent.Tools.GrepTest do
       File.write!(Path.join(ignored_dir, "leaked.txt"), "expensive_token")
 
       assert {:ok, "No matches found."} = Grep.execute("expensive_token", ignored_dir)
+    end
+
+    test "drops a truncated final line before ignore filtering", %{dir: dir} do
+      {_out, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
+      File.write!(Path.join(dir, ".gitignore"), "ignored_secret_file.txt\n")
+
+      rg = """
+      #!/bin/sh
+      printf 'visible.txt:1:public\nignored_secret_file.txt:1:private\n'
+      """
+
+      with_fake_path(%{"rg" => rg}, fn ->
+        assert {:ok, output} = Grep.execute("token", dir, %{}, max_output_bytes: 30)
+        assert output =~ "visible.txt:1:public"
+        refute output =~ "ignored_"
+        refute output =~ "private"
+      end)
+    end
+
+    test "drops a parseable truncated final result line", %{dir: dir} do
+      rg = """
+      #!/bin/sh
+      printf 'visible.txt:1:public\nvisible.txt:2:private_secret'
+      """
+
+      with_fake_path(%{"rg" => rg}, fn ->
+        assert {:ok, output} = Grep.execute("token", dir, %{}, max_output_bytes: 36)
+        assert output =~ "visible.txt:1:public"
+        refute output =~ "visible.txt:2:"
+        refute output =~ "private"
+      end)
+    end
+
+    test "returns timeout-specific errors for slow search commands", %{dir: dir} do
+      rg = """
+      #!/bin/sh
+      printf 'visible.txt:1:public\n'
+      sleep 2
+      """
+
+      with_fake_path(%{"rg" => rg}, fn ->
+        assert {:error, message} = Grep.execute("token", dir, %{}, timeout_ms: 50)
+        assert message == "Search timed out"
+        refute message =~ "visible"
+      end)
+    end
+
+    test "model-supplied hidden args cannot raise trusted caps or timeouts", %{dir: dir} do
+      capped_rg = """
+      #!/bin/sh
+      printf 'visible.txt:1:public\nvisible.txt:2:private_secret'
+      """
+
+      with_fake_path(%{"rg" => capped_rg}, fn ->
+        assert {:ok, output} =
+                 Grep.execute("token", dir, %{"_max_output_bytes" => 100_000},
+                   max_output_bytes: 36
+                 )
+
+        assert output =~ "visible.txt:1:public"
+        refute output =~ "visible.txt:2:"
+        refute output =~ "private"
+      end)
+
+      slow_rg = """
+      #!/bin/sh
+      printf 'visible.txt:1:public\nvisible.txt:2:private_secret'
+      sleep 2
+      """
+
+      with_fake_path(%{"rg" => slow_rg}, fn ->
+        assert {:error, message} =
+                 Grep.execute("token", dir, %{"_timeout_ms" => 100_000}, timeout_ms: 50)
+
+        assert message == "Search timed out"
+        refute message =~ "visible"
+      end)
     end
 
     test "returns error for invalid path", %{dir: dir} do

--- a/test/minga_agent/tools/list_directory_test.exs
+++ b/test/minga_agent/tools/list_directory_test.exs
@@ -1,9 +1,19 @@
 defmodule MingaAgent.Tools.ListDirectoryTest do
-  use ExUnit.Case, async: true
+  # Spawns OS processes through git-backed ignore checks, which must not run async.
+  use ExUnit.Case, async: false
 
   alias MingaAgent.Tools.ListDirectory
 
-  @moduletag :tmp_dir
+  setup do
+    dir =
+      Path.join(System.tmp_dir!(), "minga-list-directory-") <>
+        Integer.to_string(:erlang.unique_integer([:positive]))
+
+    File.rm_rf!(dir)
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    {:ok, tmp_dir: dir}
+  end
 
   describe "execute/1" do
     test "lists files and directories", %{tmp_dir: dir} do
@@ -53,7 +63,8 @@ defmodule MingaAgent.Tools.ListDirectoryTest do
       end
 
       File.mkdir_p!(Path.join(dir, "lib"))
-      File.write!(Path.join(dir, ".env"), "")
+      File.write!(Path.join(dir, ".env.local"), "")
+      File.write!(Path.join(dir, ".npmrc"), "")
       File.write!(Path.join(dir, ".hidden"), "")
 
       assert {:ok, listing} = ListDirectory.execute(dir)
@@ -61,7 +72,8 @@ defmodule MingaAgent.Tools.ListDirectoryTest do
 
       assert "lib/" in lines
       assert ".hidden" in lines
-      refute ".env" in lines
+      refute ".env.local" in lines
+      refute ".npmrc" in lines
 
       for ignored <- [
             "_build/",
@@ -90,21 +102,24 @@ defmodule MingaAgent.Tools.ListDirectoryTest do
       assert List.last(lines) == "... (truncated, 5 more entries)"
     end
 
-    test "omits entries ignored by project gitignore", %{tmp_dir: dir} do
+    test "returns an empty listing for statically ignored directory roots", %{tmp_dir: dir} do
+      for ignored <- ["node_modules", ".env.local"] do
+        ignored_dir = Path.join(dir, ignored)
+        File.mkdir_p!(ignored_dir)
+        File.write!(Path.join(ignored_dir, "leaked.txt"), "")
+
+        assert {:ok, ""} = ListDirectory.execute(ignored_dir)
+      end
+    end
+
+    test "returns an empty listing for a gitignored directory", %{tmp_dir: dir} do
       {_out, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
-      File.write!(Path.join(dir, ".gitignore"), "ignored_dir/\nignored_file.txt\n")
-      File.mkdir_p!(Path.join(dir, "ignored_dir"))
-      File.write!(Path.join(dir, "ignored_file.txt"), "")
-      File.mkdir_p!(Path.join(dir, "visible_dir"))
-      File.write!(Path.join(dir, "visible_file.txt"), "")
+      File.write!(Path.join(dir, ".gitignore"), "ignored_dir/\n")
+      ignored_dir = Path.join(dir, "ignored_dir")
+      File.mkdir_p!(ignored_dir)
+      File.write!(Path.join(ignored_dir, "leaked.txt"), "")
 
-      assert {:ok, listing} = ListDirectory.execute(dir)
-      lines = String.split(listing, "\n")
-
-      assert "visible_dir/" in lines
-      assert "visible_file.txt" in lines
-      refute "ignored_dir/" in lines
-      refute "ignored_file.txt" in lines
+      assert {:ok, ""} = ListDirectory.execute(ignored_dir)
     end
 
     test "returns error for nonexistent directory" do

--- a/test/minga_agent/tools/list_directory_test.exs
+++ b/test/minga_agent/tools/list_directory_test.exs
@@ -37,6 +37,76 @@ defmodule MingaAgent.Tools.ListDirectoryTest do
       assert listing =~ ".hidden"
     end
 
+    test "omits generated and dependency directories that bloat agent context", %{tmp_dir: dir} do
+      for ignored <- [
+            "_build",
+            ".build",
+            ".git",
+            ".elixir_ls",
+            ".expert",
+            "deps",
+            "node_modules",
+            "DerivedData",
+            "tmp"
+          ] do
+        File.mkdir_p!(Path.join(dir, ignored))
+      end
+
+      File.mkdir_p!(Path.join(dir, "lib"))
+      File.write!(Path.join(dir, ".env"), "")
+      File.write!(Path.join(dir, ".hidden"), "")
+
+      assert {:ok, listing} = ListDirectory.execute(dir)
+      lines = String.split(listing, "\n")
+
+      assert "lib/" in lines
+      assert ".hidden" in lines
+      refute ".env" in lines
+
+      for ignored <- [
+            "_build/",
+            ".build/",
+            ".git/",
+            ".elixir_ls/",
+            ".expert/",
+            "deps/",
+            "node_modules/",
+            "DerivedData/",
+            "tmp/"
+          ] do
+        refute ignored in lines
+      end
+    end
+
+    test "caps large directory listings", %{tmp_dir: dir} do
+      for index <- 1..205 do
+        File.write!(Path.join(dir, "file_#{index}.txt"), "")
+      end
+
+      assert {:ok, listing} = ListDirectory.execute(dir)
+      lines = String.split(listing, "\n")
+
+      assert length(lines) == 201
+      assert List.last(lines) == "... (truncated, 5 more entries)"
+    end
+
+    test "omits entries ignored by project gitignore", %{tmp_dir: dir} do
+      {_out, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
+      File.write!(Path.join(dir, ".gitignore"), "ignored_dir/\nignored_file.txt\n")
+      File.mkdir_p!(Path.join(dir, "ignored_dir"))
+      File.write!(Path.join(dir, "ignored_file.txt"), "")
+      File.mkdir_p!(Path.join(dir, "visible_dir"))
+      File.write!(Path.join(dir, "visible_file.txt"), "")
+
+      assert {:ok, listing} = ListDirectory.execute(dir)
+      lines = String.split(listing, "\n")
+
+      assert "visible_dir/" in lines
+      assert "visible_file.txt" in lines
+      refute "ignored_dir/" in lines
+      refute "ignored_file.txt" in lines
+    end
+
     test "returns error for nonexistent directory" do
       assert {:error, msg} = ListDirectory.execute("/nonexistent/dir")
       assert msg =~ "directory not found"

--- a/test/minga_agent/tools/output_limit_test.exs
+++ b/test/minga_agent/tools/output_limit_test.exs
@@ -1,0 +1,46 @@
+defmodule MingaAgent.Tools.OutputLimitTest do
+  # Spawns OS processes through Port command collection.
+  use ExUnit.Case, async: false
+
+  alias MingaAgent.Tools.OutputLimit
+
+  describe "collect_command/3" do
+    test "keeps truncated output valid when the cap splits a UTF-8 character across chunks" do
+      {output, status, truncated?} =
+        OutputLimit.collect_command(
+          "/bin/sh",
+          ["-c", "printf '\\342'; sleep 0.05; printf '\\202\\254'"],
+          max_bytes: 1,
+          timeout_ms: 1_000
+        )
+
+      assert status == 0
+      assert truncated?
+      assert String.valid?(output)
+    end
+
+    test "keeps the real exit status after output is capped" do
+      {output, status, truncated?} =
+        OutputLimit.collect_command("/bin/sh", ["-c", "printf 'abcdef'; exit 42"],
+          max_bytes: 3,
+          timeout_ms: 1_000
+        )
+
+      assert output == "abc"
+      assert status == 42
+      assert truncated?
+    end
+
+    test "returns timeout instead of success for capped commands that keep running" do
+      {output, status, truncated?} =
+        OutputLimit.collect_command("/bin/sh", ["-c", "yes x 2>/dev/null"],
+          max_bytes: 16,
+          timeout_ms: 100
+        )
+
+      assert status == :timeout
+      assert truncated?
+      assert String.valid?(output)
+    end
+  end
+end

--- a/test/minga_agent/tools/path_ignore_test.exs
+++ b/test/minga_agent/tools/path_ignore_test.exs
@@ -15,6 +15,20 @@ defmodule MingaAgent.Tools.PathIgnoreTest do
     end
   end
 
+  describe "ignored_path?/1" do
+    test "treats any ignored path segment as ignored" do
+      dir =
+        Path.join(System.tmp_dir!(), "minga-path-ignore-#{:erlang.unique_integer([:positive])}")
+
+      File.mkdir_p!(Path.join(dir, "lib"))
+      on_exit(fn -> File.rm_rf!(dir) end)
+
+      assert PathIgnore.ignored_path?(Path.join([dir, "node_modules", "pkg"]))
+      assert PathIgnore.ignored_path?(Path.join([dir, "lib", ".env.local"]))
+      refute PathIgnore.ignored_path?(Path.join([dir, "lib", "visible.ex"]))
+    end
+  end
+
   describe "filter_paths/2" do
     test "drops gitignored paths and secret env files while keeping visible results", %{
       tmp_dir: dir

--- a/test/minga_agent/tools/path_ignore_test.exs
+++ b/test/minga_agent/tools/path_ignore_test.exs
@@ -1,0 +1,49 @@
+defmodule MingaAgent.Tools.PathIgnoreTest do
+  # Spawns OS processes through git check-ignore, which must not run async.
+  use ExUnit.Case, async: false
+
+  alias MingaAgent.Tools.PathIgnore
+
+  @moduletag :tmp_dir
+
+  describe "ignored_name?/1" do
+    test "treats env variants and npmrc as ignored" do
+      assert PathIgnore.ignored_name?(".env")
+      assert PathIgnore.ignored_name?(".env.local")
+      assert PathIgnore.ignored_name?(".env.example")
+      assert PathIgnore.ignored_name?(".npmrc")
+    end
+  end
+
+  describe "filter_paths/2" do
+    test "drops gitignored paths and secret env files while keeping visible results", %{
+      tmp_dir: dir
+    } do
+      {_out, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
+      File.write!(Path.join(dir, ".gitignore"), "ignored_dir/\n")
+
+      assert PathIgnore.filter_paths(dir, [
+               "visible.ex",
+               "ignored_dir/leaked.ex",
+               ".env.local",
+               ".npmrc"
+             ]) == ["visible.ex"]
+    end
+  end
+
+  describe "filter_grep_lines/2" do
+    test "drops gitignored result lines and keeps visible results", %{tmp_dir: dir} do
+      {_out, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
+      File.write!(Path.join(dir, ".gitignore"), "ignored_dir/\n")
+
+      assert PathIgnore.filter_grep_lines(dir, [
+               "visible.ex:1:visible",
+               "visible.ex-1-visible",
+               "ignored_dir/leaked.ex:1:secret",
+               "ignored_dir/leaked.ex-1-secret",
+               ".env.local:2:secret",
+               ".npmrc:3:secret"
+             ]) == ["visible.ex:1:visible", "visible.ex-1-visible"]
+    end
+  end
+end

--- a/test/minga_agent/tools/project_view_routing_test.exs
+++ b/test/minga_agent/tools/project_view_routing_test.exs
@@ -3,11 +3,14 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
   use ExUnit.Case, async: false
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Git.Stub, as: GitStub
   alias MingaAgent.BufferForkStore
   alias MingaAgent.Changeset
   alias MingaAgent.ProjectView.RecordingBackend
   alias MingaAgent.ProjectView.UnavailableBackend
+  alias MingaAgent.ToolRouter
   alias MingaAgent.Tools
+  alias MingaAgent.Tools.Git, as: GitTools
 
   @moduletag :tmp_dir
 
@@ -288,7 +291,8 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     for {name, args} <- [
           {"find", %{"pattern" => "view_only.txt", "path" => "lib"}},
           {"grep", %{"pattern" => "view only", "path" => "lib"}},
-          {"shell", %{"command" => "test -f lib/view_only.txt && echo fallback"}}
+          {"shell", %{"command" => "test -f lib/view_only.txt && echo fallback"}},
+          {"git_diff", %{}}
         ] do
       assert {:error, message} = call_tool(tools, name, args)
       assert message =~ "project_view_unavailable"
@@ -343,6 +347,111 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     assert {:ok, changed} = Changeset.read_file(changeset, "lib/diff_target.txt")
     assert changed == "one\nTWO\n"
     assert File.read!(target_path) == "one\ntwo\n"
+  end
+
+  test "git_diff through changeset reports added modified and deleted overlay files",
+       %{tmp_dir: root} do
+    File.mkdir_p!(Path.join(root, "lib"))
+    {_out, 0} = System.cmd("git", ["init"], cd: root, stderr_to_stdout: true)
+    File.write!(Path.join(root, ".gitignore"), "ignored_dir/\n")
+    File.write!(Path.join(root, "lib/modified.txt"), "old line\n")
+    File.write!(Path.join(root, "lib/deleted.txt"), "delete me\n")
+
+    {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
+    tools = Tools.all(project_root: root, changeset: changeset)
+
+    assert {:ok, write_result} =
+             call_tool(tools, "write_file", %{
+               "path" => "lib/added.txt",
+               "content" => "new line\n"
+             })
+
+    assert write_result =~ "via changeset"
+
+    assert {:ok, edit_result} =
+             call_tool(tools, "edit_file", %{
+               "path" => "lib/modified.txt",
+               "old_text" => "old",
+               "new_text" => "new"
+             })
+
+    assert edit_result =~ "via changeset"
+    assert {:ok, delete_result} = call_tool(tools, "delete_file", %{"path" => "lib/deleted.txt"})
+    assert delete_result =~ "via changeset"
+
+    for path <- [".env.local", ".npmrc", "node_modules/pkg/secret.txt", "ignored_dir/secret.txt"] do
+      assert {:ok, _result} =
+               call_tool(tools, "write_file", %{
+                 "path" => path,
+                 "content" => "hidden overlay token\n"
+               })
+    end
+
+    assert {:ok, diff} = call_tool(tools, "git_diff", %{})
+    assert diff =~ "a/lib/added.txt"
+    assert diff =~ "+new line"
+    assert diff =~ "a/lib/modified.txt"
+    assert diff =~ "-old line"
+    assert diff =~ "+new line"
+    assert diff =~ "a/lib/deleted.txt"
+    assert diff =~ "-delete me"
+    refute diff =~ ".env.local"
+    refute diff =~ ".npmrc"
+    refute diff =~ "node_modules"
+    refute diff =~ "ignored_dir"
+    refute diff =~ "hidden overlay token"
+
+    assert File.read!(Path.join(root, "lib/modified.txt")) == "old line\n"
+    assert File.exists?(Path.join(root, "lib/deleted.txt"))
+    refute File.exists?(Path.join(root, "lib/added.txt"))
+  end
+
+  test "git_diff through ProjectView overlay reports view-local changes", %{tmp_dir: root} do
+    File.mkdir_p!(Path.join(root, "lib"))
+    {_out, 0} = System.cmd("git", ["init"], cd: root, stderr_to_stdout: true)
+    File.write!(Path.join(root, ".gitignore"), "ignored_dir/\n")
+    File.write!(Path.join(root, "lib/file.txt"), "root text\n")
+    File.write!(Path.join(root, "lib/delete.txt"), "root delete\n")
+
+    {:ok, view} = MingaAgent.ProjectView.overlay(root)
+    tools = Tools.all(project_root: root, project_view: view)
+
+    assert {:ok, _} =
+             call_tool(tools, "write_file", %{
+               "path" => "lib/file.txt",
+               "content" => "view text\n"
+             })
+
+    assert {:ok, _} =
+             call_tool(tools, "write_file", %{"path" => "lib/new.txt", "content" => "view new\n"})
+
+    assert {:ok, _} = call_tool(tools, "delete_file", %{"path" => "lib/delete.txt"})
+
+    for path <- [".env.local", ".npmrc", "node_modules/pkg/secret.txt", "ignored_dir/secret.txt"] do
+      assert {:ok, _result} =
+               call_tool(tools, "write_file", %{
+                 "path" => path,
+                 "content" => "hidden project view token\n"
+               })
+    end
+
+    assert {:ok, diff} = call_tool(tools, "git_diff", %{})
+    assert diff =~ "a/lib/file.txt"
+    assert diff =~ "-root text"
+    assert diff =~ "+view text"
+    assert diff =~ "a/lib/new.txt"
+    assert diff =~ "+view new"
+    assert diff =~ "a/lib/delete.txt"
+    assert diff =~ "-root delete"
+    refute diff =~ ".env.local"
+    refute diff =~ ".npmrc"
+    refute diff =~ "node_modules"
+    refute diff =~ "ignored_dir"
+    refute diff =~ "hidden project view token"
+
+    assert File.read!(Path.join(root, "lib/file.txt")) == "root text\n"
+    assert File.exists?(Path.join(root, "lib/delete.txt"))
+    refute File.exists?(Path.join(root, "lib/new.txt"))
   end
 
   test "list_directory through changeset suppresses secret entries and ignored roots",
@@ -419,6 +528,263 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     assert shell_result =~ "spoof=no"
   end
 
+  test "git_diff through fork store reports open-buffer fork drafts", %{root: root} do
+    File.mkdir_p!(Path.join(root, "lib"))
+    target_path = Path.join(root, "lib/fork_only.txt")
+    secret_path = Path.join(root, ".env.local")
+    ignored_path = Path.join(root, "node_modules/pkg/fork_secret.txt")
+    File.write!(target_path, "original fork only\n")
+    File.write!(secret_path, "original secret\n")
+
+    {:ok, _buffer} =
+      start_supervised({BufferProcess, content: "original fork only\n", file_path: target_path},
+        id: :fork_only_diff_buffer
+      )
+
+    {:ok, _secret_buffer} =
+      start_supervised({BufferProcess, content: "original secret\n", file_path: secret_path},
+        id: :fork_secret_diff_buffer
+      )
+
+    {:ok, _ignored_buffer} =
+      start_supervised({BufferProcess, content: "ignored original\n", file_path: ignored_path},
+        id: :fork_ignored_diff_buffer
+      )
+
+    {:ok, store} = start_supervised(BufferForkStore)
+    tools = Tools.all(project_root: root, fork_store: store)
+
+    assert {:ok, write_result} =
+             call_tool(tools, "write_file", %{
+               "path" => "lib/fork_only.txt",
+               "content" => "fork only draft\n"
+             })
+
+    assert write_result =~ "via fork"
+
+    assert {:ok, secret_result} =
+             call_tool(tools, "write_file", %{
+               "path" => ".env.local",
+               "content" => "hidden fork token\n"
+             })
+
+    assert secret_result =~ "via fork"
+
+    assert {:ok, ignored_result} =
+             call_tool(tools, "write_file", %{
+               "path" => "node_modules/pkg/fork_secret.txt",
+               "content" => "hidden nested fork token\n"
+             })
+
+    assert ignored_result =~ "via fork"
+
+    assert {:ok, diff_result} = call_tool(tools, "git_diff", %{})
+    assert diff_result =~ "a/lib/fork_only.txt"
+    assert diff_result =~ "-original fork only"
+    assert diff_result =~ "+fork only draft"
+    refute diff_result =~ ".env.local"
+    refute diff_result =~ "hidden fork token"
+    refute diff_result =~ "node_modules"
+    refute diff_result =~ "hidden nested fork token"
+    assert File.read!(target_path) == "original fork only\n"
+    assert File.read!(secret_path) == "original secret\n"
+  end
+
+  test "overlay git_diff rejects staged mode without falling back to real repo diff", %{
+    tmp_dir: root
+  } do
+    File.mkdir_p!(root)
+    GitStub.set_root(root, root)
+    GitStub.set_diff(root, "REAL REPO DIFF\n")
+    on_exit(fn -> GitStub.clear(root) end)
+
+    {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
+    tools = Tools.all(project_root: root, changeset: changeset)
+
+    assert {:error, message} = call_tool(tools, "git_diff", %{"staged" => true})
+    assert message =~ "staged=true is unavailable"
+    refute message =~ "REAL REPO DIFF"
+  end
+
+  test "overlay git_diff preserves hunk body marker lines while normalizing headers", %{
+    tmp_dir: root
+  } do
+    File.mkdir_p!(Path.join(root, "lib/a/old"))
+    File.mkdir_p!(Path.join(root, "old"))
+    {_out, 0} = System.cmd("git", ["init"], cd: root, stderr_to_stdout: true)
+    File.write!(Path.join(root, "lib/paths.txt"), "-- old/body marker\nplain\n")
+    File.write!(Path.join(root, "lib/a/old/file.txt"), "old path\n")
+    File.write!(Path.join(root, "old/file with space.txt"), "old spaced path\n")
+
+    {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
+    tools = Tools.all(project_root: root, changeset: changeset)
+
+    assert {:ok, _result} =
+             call_tool(tools, "write_file", %{
+               "path" => "lib/paths.txt",
+               "content" => "++ new/body kept\nplain\n"
+             })
+
+    assert {:ok, _result} =
+             call_tool(tools, "write_file", %{
+               "path" => "lib/a/old/file.txt",
+               "content" => "new path\n"
+             })
+
+    assert {:ok, _result} =
+             call_tool(tools, "write_file", %{
+               "path" => "old/file with space.txt",
+               "content" => "new spaced path\n"
+             })
+
+    assert {:ok, diff} = call_tool(tools, "git_diff", %{})
+    lines = String.split(diff, "\n")
+    assert "diff --git a/lib/paths.txt b/lib/paths.txt" in lines
+    assert "diff --git a/lib/a/old/file.txt b/lib/a/old/file.txt" in lines
+    assert "--- a/lib/a/old/file.txt" in lines
+    assert "+++ b/lib/a/old/file.txt" in lines
+    assert "diff --git a/old/file with space.txt b/old/file with space.txt" in lines
+    assert "--- a/old/file with space.txt" in lines
+    assert "+++ b/old/file with space.txt" in lines
+    assert diff =~ "--- old/body marker"
+    assert diff =~ "+++ new/body kept"
+    refute diff =~ "--- a/body marker"
+    refute diff =~ "+++ b/body kept"
+    refute diff =~ "diff --git a/lib/a/file.txt b/lib/a/file.txt"
+    refute diff =~ "b/new/old/file with space.txt"
+  end
+
+  test "overlay git_diff refuses symlink paths instead of reading outside contents", %{
+    root: root
+  } do
+    working_dir = Path.join(root, "../symlink-view")
+    File.mkdir_p!(Path.join(root, "lib"))
+    File.mkdir_p!(Path.join(working_dir, "lib"))
+    outside_path = Path.join(root, "../outside-secret.txt")
+    link_path = Path.join(root, "lib/link.txt")
+    File.write!(outside_path, "outside secret token\n")
+    File.ln_s!(outside_path, link_path)
+    File.write!(Path.join(working_dir, "lib/link.txt"), "draft\n")
+
+    {:ok, view} =
+      RecordingBackend.create(root,
+        parent: self(),
+        working_dir: working_dir,
+        diff: [%{path: "lib/link.txt", kind: :modified}]
+      )
+
+    assert {:ok, [%{path: "lib/link.txt"}]} = MingaAgent.ProjectView.diff(view)
+    tools = Tools.all(project_root: root, project_view: view)
+    assert {:error, message} = call_tool(tools, "git_diff", %{})
+    assert message =~ "refusing to diff symlink path lib/link.txt"
+    refute message =~ "outside secret token"
+  end
+
+  test "overlay git_diff caps large no-index diff output", %{tmp_dir: root} do
+    File.mkdir_p!(root)
+    {_out, 0} = System.cmd("git", ["init"], cd: root, stderr_to_stdout: true)
+    {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
+    big_content = String.duplicate("large diff line\n", 500)
+    tools = Tools.all(project_root: root, changeset: changeset)
+
+    assert {:ok, _result} =
+             call_tool(tools, "write_file", %{"path" => "big.txt", "content" => big_content})
+
+    context = ToolRouter.context(nil, nil, changeset)
+    assert {:ok, diff} = GitTools.diff(root, [max_output_bytes: 1_024], context)
+    assert byte_size(diff) < 2_000
+    assert diff =~ "[truncated at 1KB]"
+  end
+
+  test "overlay git_diff fails closed when one overlay file exceeds input cap", %{tmp_dir: root} do
+    File.mkdir_p!(root)
+    {_out, 0} = System.cmd("git", ["init"], cd: root, stderr_to_stdout: true)
+    GitStub.set_root(root, root)
+    GitStub.set_diff(root, "REAL REPO DIFF\n")
+    on_exit(fn -> GitStub.clear(root) end)
+
+    {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
+    oversized = String.duplicate("oversized secret token\n", 20)
+    tools = Tools.all(project_root: root, changeset: changeset)
+
+    assert {:ok, _result} =
+             call_tool(tools, "write_file", %{"path" => "big.txt", "content" => oversized})
+
+    context = ToolRouter.context(nil, nil, changeset)
+    assert {:error, message} = GitTools.diff(root, [max_input_bytes: 8], context)
+    assert message =~ "git_diff input file too large: big.txt exceeds 8 bytes"
+    refute message =~ "oversized secret token"
+    refute message =~ "REAL REPO DIFF"
+    refute File.exists?(Path.join(root, "big.txt"))
+  end
+
+  test "combined fork store and changeset git_diff rejects over-cap fork before materializing", %{
+    root: root
+  } do
+    File.mkdir_p!(Path.join(root, "lib"))
+    target_path = Path.join(root, "lib/large_fork.txt")
+    File.write!(target_path, "original\n")
+
+    {:ok, _buffer} =
+      start_supervised({BufferProcess, content: "original\n", file_path: target_path},
+        id: :large_combined_diff_buffer
+      )
+
+    {:ok, store} = start_supervised(BufferForkStore)
+    {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
+    tools = Tools.all(project_root: root, fork_store: store, changeset: changeset)
+    oversized = String.duplicate("combined fork secret\n", 20)
+
+    assert {:ok, write_result} =
+             call_tool(tools, "write_file", %{
+               "path" => "lib/large_fork.txt",
+               "content" => oversized
+             })
+
+    assert write_result =~ "via fork"
+    context = ToolRouter.context(nil, store, changeset)
+    overlay_file = Path.join(Changeset.overlay_path(changeset), "lib/large_fork.txt")
+
+    assert {:error, message} = GitTools.diff(root, [max_input_bytes: 8], context)
+    assert message =~ "git_diff input file too large: lib/large_fork.txt exceeds 8 bytes"
+    refute message =~ "combined fork secret"
+    refute File.exists?(overlay_file)
+    assert File.read!(target_path) == "original\n"
+  end
+
+  test "ProjectView git_diff rejects over-cap fork before preparing overlay", %{root: root} do
+    File.mkdir_p!(Path.join(root, "lib"))
+    target_path = Path.join(root, "lib/project_large_fork.txt")
+    File.write!(target_path, "original\n")
+
+    {:ok, _buffer} =
+      start_supervised({BufferProcess, content: "original\n", file_path: target_path},
+        id: :large_project_view_diff_buffer
+      )
+
+    {:ok, view} = MingaAgent.ProjectView.overlay(root)
+    tools = Tools.all(project_root: root, project_view: view)
+    oversized = String.duplicate("project view fork secret\n", 20)
+
+    assert {:ok, write_result} =
+             call_tool(tools, "write_file", %{
+               "path" => "lib/project_large_fork.txt",
+               "content" => oversized
+             })
+
+    assert write_result =~ "via ProjectView"
+    context = ToolRouter.context(view, nil, nil)
+
+    overlay_file =
+      Path.join(MingaAgent.ProjectView.working_dir(view), "lib/project_large_fork.txt")
+
+    assert {:error, message} = GitTools.diff(root, [max_input_bytes: 8], context)
+    assert message =~ "git_diff input file too large: lib/project_large_fork.txt exceeds 8 bytes"
+    refute message =~ "project view fork secret"
+    refute File.exists?(overlay_file)
+    assert File.read!(target_path) == "original\n"
+  end
+
   test "combined fork store and changeset search and shell see open-buffer fork drafts", %{
     root: root
   } do
@@ -453,7 +819,32 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
              call_tool(tools, "shell", %{"command" => "cat lib/forked.txt"})
 
     assert shell_result =~ "fork draft token"
+
+    assert {:ok, diff_result} = call_tool(tools, "git_diff", %{})
+    assert diff_result =~ "a/lib/forked.txt"
+    assert diff_result =~ "-original text"
+    assert diff_result =~ "+fork draft token"
     assert File.read!(target_path) == "original text\n"
+  end
+
+  test "dead changeset git_diff fails closed instead of returning real repo diff", %{
+    tmp_dir: root
+  } do
+    File.mkdir_p!(Path.join(root, "lib"))
+    File.write!(Path.join(root, "lib/file.txt"), "real repo\n")
+    GitStub.set_root(root, root)
+    GitStub.set_diff(root, "REAL REPO DIFF\n")
+    on_exit(fn -> GitStub.clear(root) end)
+
+    {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
+    tools = Tools.all(project_root: root, changeset: changeset)
+    ref = Process.monitor(changeset)
+    Process.exit(changeset, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^changeset, _reason}
+
+    assert {:error, message} = call_tool(tools, "git_diff", %{})
+    assert message =~ "changeset working directory unavailable"
+    refute message =~ "REAL REPO DIFF"
   end
 
   test "dead changeset multi_edit_file returns an unavailable error without mutating the project",

--- a/test/minga_agent/tools/project_view_routing_test.exs
+++ b/test/minga_agent/tools/project_view_routing_test.exs
@@ -15,11 +15,23 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     working_dir = Path.join(dir, "view")
     File.mkdir_p!(Path.join(root, "lib"))
     File.mkdir_p!(Path.join(working_dir, "lib"))
+    {_out, 0} = System.cmd("git", ["init"], cd: root, stderr_to_stdout: true)
+    {_out, 0} = System.cmd("git", ["init"], cd: working_dir, stderr_to_stdout: true)
+    File.write!(Path.join(root, ".gitignore"), "ignored_dir/\n")
     File.write!(Path.join(root, "lib/file.txt"), "root text\n")
     File.write!(Path.join(root, "lib/root_only.txt"), "root only\n")
     File.write!(Path.join(root, "lib/edit_target.txt"), "editable root text\n")
     File.write!(Path.join(working_dir, "lib/file.txt"), "view text\n")
     File.write!(Path.join(working_dir, "lib/overlay_only.txt"), "needle\n")
+    File.write!(Path.join(working_dir, "visible_secret.txt"), "shared_secret_token\n")
+    File.write!(Path.join(working_dir, ".env.local"), "shared_secret_token\n")
+    File.write!(Path.join(working_dir, ".npmrc"), "shared_secret_token\n")
+    File.mkdir_p!(Path.join(root, "ignored_dir"))
+    File.mkdir_p!(Path.join(working_dir, "ignored_dir"))
+    File.write!(Path.join(working_dir, "ignored_dir/leaked.txt"), "shared_secret_token\n")
+    File.mkdir_p!(Path.join(root, "node_modules"))
+    File.mkdir_p!(Path.join(working_dir, "node_modules"))
+    File.write!(Path.join(working_dir, "node_modules/leaked.txt"), "shared_secret_token\n")
 
     {:ok, view} =
       RecordingBackend.create(root,
@@ -141,6 +153,19 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     assert list_result =~ "ProjectView workspace 42"
     assert_receive {:project_view_call, {:list_directory, "lib"}}
 
+    assert {:ok, root_list_result} = call_tool(tools, "list_directory", %{"path" => "."})
+    refute root_list_result =~ ".env.local"
+    refute root_list_result =~ ".npmrc"
+    refute root_list_result =~ "ignored_dir"
+    assert_receive {:project_view_call, {:list_directory, ""}}
+
+    assert {:ok, ignored_root_result} =
+             call_tool(tools, "list_directory", %{"path" => "node_modules"})
+
+    assert ignored_root_result =~ "ProjectView workspace 42"
+    refute ignored_root_result =~ "leaked.txt"
+    assert_receive {:project_view_call, {:list_directory, "node_modules"}}
+
     assert {:ok, find_result} =
              call_tool(tools, "find", %{
                "pattern" => "overlay_only.txt",
@@ -151,11 +176,29 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     assert find_result =~ "overlay_only.txt"
     assert find_result =~ "ProjectView workspace 42"
 
+    assert {:ok, broad_find_result} =
+             call_tool(tools, "find", %{"pattern" => "*", "path" => ".", "type" => "file"})
+
+    assert broad_find_result =~ "visible_secret.txt"
+    refute broad_find_result =~ ".env.local"
+    refute broad_find_result =~ ".npmrc"
+    refute broad_find_result =~ "node_modules"
+    refute broad_find_result =~ "ignored_dir"
+
     assert {:ok, grep_result} =
              call_tool(tools, "grep", %{"pattern" => "needle", "path" => "lib"})
 
     assert grep_result =~ "overlay_only.txt"
     assert grep_result =~ "ProjectView workspace 42"
+
+    assert {:ok, broad_grep_result} =
+             call_tool(tools, "grep", %{"pattern" => "shared_secret_token", "path" => "."})
+
+    assert broad_grep_result =~ "visible_secret.txt"
+    refute broad_grep_result =~ ".env.local"
+    refute broad_grep_result =~ ".npmrc"
+    refute broad_grep_result =~ "node_modules"
+    refute broad_grep_result =~ "ignored_dir"
 
     assert {:ok, shell_result} =
              call_tool(tools, "shell", %{
@@ -268,6 +311,51 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     assert {:ok, changed} = Changeset.read_file(changeset, "lib/diff_target.txt")
     assert changed == "one\nTWO\n"
     assert File.read!(target_path) == "one\ntwo\n"
+  end
+
+  test "list_directory through changeset suppresses secret entries and ignored roots",
+       %{tmp_dir: root} do
+    File.mkdir_p!(root)
+    {_out, 0} = System.cmd("git", ["init"], cd: root, stderr_to_stdout: true)
+    File.write!(Path.join(root, ".gitignore"), "ignored_dir/\n")
+    File.write!(Path.join(root, "visible.txt"), "visible\n")
+    File.write!(Path.join(root, "visible_secret.txt"), "shared_secret_token\n")
+    File.write!(Path.join(root, ".env.local"), "shared_secret_token\n")
+    File.write!(Path.join(root, ".npmrc"), "shared_secret_token\n")
+    File.mkdir_p!(Path.join(root, "ignored_dir"))
+    File.write!(Path.join(root, "ignored_dir/leaked.txt"), "shared_secret_token\n")
+    File.mkdir_p!(Path.join(root, "node_modules"))
+    File.write!(Path.join(root, "node_modules/leaked.txt"), "shared_secret_token\n")
+
+    {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
+    tools = Tools.all(project_root: root, changeset: changeset)
+
+    assert {:ok, result} = call_tool(tools, "list_directory", %{"path" => "."})
+    assert result =~ "visible.txt"
+    refute result =~ ".env.local"
+    refute result =~ ".npmrc"
+    refute result =~ "ignored_dir"
+
+    assert {:ok, ignored_root_result} =
+             call_tool(tools, "list_directory", %{"path" => "node_modules"})
+
+    refute ignored_root_result =~ "leaked.txt"
+
+    assert {:ok, find_result} = call_tool(tools, "find", %{"pattern" => "*", "path" => "."})
+    assert find_result =~ "visible_secret.txt"
+    refute find_result =~ ".env.local"
+    refute find_result =~ ".npmrc"
+    refute find_result =~ "ignored_dir"
+    refute find_result =~ "node_modules"
+
+    assert {:ok, grep_result} =
+             call_tool(tools, "grep", %{"pattern" => "shared_secret_token", "path" => "."})
+
+    assert grep_result =~ "visible_secret.txt"
+    refute grep_result =~ ".env.local"
+    refute grep_result =~ ".npmrc"
+    refute grep_result =~ "ignored_dir"
+    refute grep_result =~ "node_modules"
   end
 
   test "dead changeset multi_edit_file returns an unavailable error without mutating the project",

--- a/test/minga_agent/tools/project_view_routing_test.exs
+++ b/test/minga_agent/tools/project_view_routing_test.exs
@@ -147,7 +147,10 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     assert File.read!(ambiguous_path) == "hello world hello world"
   end
 
-  test "discovery and shell tools use ProjectView working dir and env", %{tools: tools} do
+  test "discovery and shell tools use ProjectView working dir and env", %{
+    tools: tools,
+    working_dir: working_dir
+  } do
     assert {:ok, list_result} = call_tool(tools, "list_directory", %{"path" => "lib"})
     assert list_result =~ "overlay_only.txt"
     assert list_result =~ "ProjectView workspace 42"
@@ -177,13 +180,26 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     assert find_result =~ "ProjectView workspace 42"
 
     assert {:ok, broad_find_result} =
-             call_tool(tools, "find", %{"pattern" => "*", "path" => ".", "type" => "file"})
+             call_tool(tools, "find", %{
+               "pattern" => "*",
+               "path" => ".",
+               "type" => "file",
+               "_filter_root" => working_dir,
+               "_max_output_bytes" => 1_000_000,
+               "_timeout_ms" => 1_000_000
+             })
 
     assert broad_find_result =~ "visible_secret.txt"
     refute broad_find_result =~ ".env.local"
     refute broad_find_result =~ ".npmrc"
     refute broad_find_result =~ "node_modules"
     refute broad_find_result =~ "ignored_dir"
+
+    assert {:ok, ignored_find_result} =
+             call_tool(tools, "find", %{"pattern" => "*", "path" => "ignored_dir"})
+
+    assert ignored_find_result =~ "No matches found."
+    refute ignored_find_result =~ "leaked.txt"
 
     assert {:ok, grep_result} =
              call_tool(tools, "grep", %{"pattern" => "needle", "path" => "lib"})
@@ -192,13 +208,28 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     assert grep_result =~ "ProjectView workspace 42"
 
     assert {:ok, broad_grep_result} =
-             call_tool(tools, "grep", %{"pattern" => "shared_secret_token", "path" => "."})
+             call_tool(tools, "grep", %{
+               "pattern" => "shared_secret_token",
+               "path" => ".",
+               "_filter_root" => working_dir,
+               "_max_output_bytes" => 1_000_000,
+               "_timeout_ms" => 1_000_000
+             })
 
     assert broad_grep_result =~ "visible_secret.txt"
     refute broad_grep_result =~ ".env.local"
     refute broad_grep_result =~ ".npmrc"
     refute broad_grep_result =~ "node_modules"
     refute broad_grep_result =~ "ignored_dir"
+
+    assert {:ok, ignored_grep_result} =
+             call_tool(tools, "grep", %{
+               "pattern" => "shared_secret_token",
+               "path" => "ignored_dir"
+             })
+
+    assert ignored_grep_result =~ "No matches found."
+    refute ignored_grep_result =~ "leaked.txt"
 
     assert {:ok, shell_result} =
              call_tool(tools, "shell", %{
@@ -330,6 +361,15 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
     tools = Tools.all(project_root: root, changeset: changeset)
 
+    assert {:ok, write_result} =
+             call_tool(tools, "write_file", %{
+               "path" => "overlay_added.txt",
+               "content" => "shared_secret_token\n"
+             })
+
+    assert write_result =~ "via changeset"
+    refute File.exists?(Path.join(root, "overlay_added.txt"))
+
     assert {:ok, result} = call_tool(tools, "list_directory", %{"path" => "."})
     assert result =~ "visible.txt"
     refute result =~ ".env.local"
@@ -343,6 +383,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
 
     assert {:ok, find_result} = call_tool(tools, "find", %{"pattern" => "*", "path" => "."})
     assert find_result =~ "visible_secret.txt"
+    assert find_result =~ "overlay_added.txt"
     refute find_result =~ ".env.local"
     refute find_result =~ ".npmrc"
     refute find_result =~ "ignored_dir"
@@ -352,6 +393,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
              call_tool(tools, "grep", %{"pattern" => "shared_secret_token", "path" => "."})
 
     assert grep_result =~ "visible_secret.txt"
+    assert grep_result =~ "overlay_added.txt"
     refute grep_result =~ ".env.local"
     refute grep_result =~ ".npmrc"
     refute grep_result =~ "ignored_dir"

--- a/test/minga_agent/tools/project_view_routing_test.exs
+++ b/test/minga_agent/tools/project_view_routing_test.exs
@@ -3,6 +3,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
   use ExUnit.Case, async: false
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaAgent.BufferForkStore
   alias MingaAgent.Changeset
   alias MingaAgent.ProjectView.RecordingBackend
   alias MingaAgent.ProjectView.UnavailableBackend
@@ -398,6 +399,61 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     refute grep_result =~ ".npmrc"
     refute grep_result =~ "ignored_dir"
     refute grep_result =~ "node_modules"
+
+    fake_cwd = Path.join(root, "fake-cwd")
+    File.mkdir_p!(fake_cwd)
+    File.write!(Path.join(fake_cwd, "spoof.txt"), "spoofed\n")
+    overlay_dir = Changeset.overlay_path(changeset)
+
+    assert {:ok, shell_result} =
+             call_tool(tools, "shell", %{
+               "command" =>
+                 "printf 'file=%s\nbuild=%s\nevil=%s\nspoof=%s\n' \"$(cat overlay_added.txt 2>/dev/null)\" \"$MIX_BUILD_PATH\" \"${EVIL:-unset}\" \"$(test -f spoof.txt && echo yes || echo no)\"",
+               "_cwd" => fake_cwd,
+               "_env" => %{"EVIL" => "set"}
+             })
+
+    assert shell_result =~ "file=shared_secret_token"
+    assert shell_result =~ "build=#{Path.join(overlay_dir, "_build")}"
+    assert shell_result =~ "evil=unset"
+    assert shell_result =~ "spoof=no"
+  end
+
+  test "combined fork store and changeset search and shell see open-buffer fork drafts", %{
+    root: root
+  } do
+    File.mkdir_p!(Path.join(root, "lib"))
+    target_path = Path.join(root, "lib/forked.txt")
+    File.write!(target_path, "original text\n")
+
+    {:ok, _buffer} =
+      start_supervised({BufferProcess, content: "original text\n", file_path: target_path},
+        id: :combined_overlay_buffer
+      )
+
+    {:ok, store} = start_supervised(BufferForkStore)
+    {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
+    tools = Tools.all(project_root: root, fork_store: store, changeset: changeset)
+
+    assert {:ok, write_result} =
+             call_tool(tools, "write_file", %{
+               "path" => "lib/forked.txt",
+               "content" => "fork draft token\n"
+             })
+
+    assert write_result =~ "via fork"
+    assert File.read!(target_path) == "original text\n"
+
+    assert {:ok, grep_result} =
+             call_tool(tools, "grep", %{"pattern" => "fork draft token", "path" => "lib"})
+
+    assert grep_result =~ "forked.txt"
+
+    assert {:ok, shell_result} =
+             call_tool(tools, "shell", %{"command" => "cat lib/forked.txt"})
+
+    assert shell_result =~ "fork draft token"
+    assert File.read!(target_path) == "original text\n"
   end
 
   test "dead changeset multi_edit_file returns an unavailable error without mutating the project",

--- a/test/minga_agent/tools/shell_test.exs
+++ b/test/minga_agent/tools/shell_test.exs
@@ -79,6 +79,7 @@ defmodule MingaAgent.Tools.ShellTest do
       # At minimum 1 callback, but definitely not 20 separate ones
       count = :counters.get(callback_count, 1)
       assert count >= 1
+      assert count < 20
     end
 
     test "sends running indicator for silent commands", %{tmp_dir: dir} do
@@ -148,6 +149,28 @@ defmodule MingaAgent.Tools.ShellTest do
       assert is_binary(JSON.encode!(%{output: combined}))
     end
 
+    test "stream truncation stays valid when the cap splits a UTF-8 character across chunks", %{
+      tmp_dir: dir
+    } do
+      test_pid = self()
+
+      on_output = fn chunk ->
+        send(test_pid, {:shell_chunk, chunk})
+        :ok
+      end
+
+      command =
+        "elixir -e 'IO.write(String.duplicate(\"x\", 63999)); IO.binwrite(:stdio, <<226>>); Process.sleep(50); IO.binwrite(:stdio, <<130, 172>>)'"
+
+      assert {:ok, _output} = Shell.execute(command, dir, 5, on_output: on_output)
+
+      combined = collect_shell_chunks() |> IO.iodata_to_binary()
+
+      assert String.valid?(combined)
+      assert combined =~ "[stream truncated at 64KB]"
+      assert is_binary(JSON.encode!(%{output: combined}))
+    end
+
     test "works without on_output callback", %{tmp_dir: dir} do
       assert {:ok, output} = Shell.execute("echo hello", dir, 5, [])
       assert output == "hello"
@@ -189,6 +212,19 @@ defmodule MingaAgent.Tools.ShellTest do
       assert is_binary(JSON.encode!(%{output: output}))
     end
 
+    test "final truncation stays valid when the cap splits a UTF-8 character across chunks", %{
+      tmp_dir: dir
+    } do
+      command =
+        "elixir -e 'IO.write(String.duplicate(\"x\", 63999)); IO.binwrite(:stdio, <<226>>); Process.sleep(50); IO.binwrite(:stdio, <<130, 172>>)'"
+
+      assert {:ok, output} = Shell.execute(command, dir, 5)
+
+      assert String.valid?(output)
+      assert output =~ "[truncated at 64KB]"
+      assert is_binary(JSON.encode!(%{output: output}))
+    end
+
     test "runs in the specified directory", %{tmp_dir: dir} do
       assert {:ok, output} = Shell.execute("pwd", dir, 5)
       # Resolve symlinks (macOS /private/var vs /var)
@@ -197,6 +233,11 @@ defmodule MingaAgent.Tools.ShellTest do
 
     test "times out long-running commands", %{tmp_dir: dir} do
       assert {:error, msg} = Shell.execute("sleep 60", dir, 1)
+      assert msg =~ "timed out"
+    end
+
+    test "times out commands that continuously write output", %{tmp_dir: dir} do
+      assert {:error, msg} = Shell.execute("yes x", dir, 1)
       assert msg =~ "timed out"
     end
 

--- a/test/minga_agent/tools/shell_test.exs
+++ b/test/minga_agent/tools/shell_test.exs
@@ -127,6 +127,14 @@ defmodule MingaAgent.Tools.ShellTest do
       assert output =~ "error"
     end
 
+    test "truncates verbose command output before returning it to the model", %{tmp_dir: dir} do
+      assert {:ok, output} =
+               Shell.execute("awk 'BEGIN { for (i = 0; i < 70000; i++) printf \"x\" }'", dir, 5)
+
+      assert byte_size(output) < 70_000
+      assert output =~ "[truncated at"
+    end
+
     test "runs in the specified directory", %{tmp_dir: dir} do
       assert {:ok, output} = Shell.execute("pwd", dir, 5)
       # Resolve symlinks (macOS /private/var vs /var)

--- a/test/minga_agent/tools/shell_test.exs
+++ b/test/minga_agent/tools/shell_test.exs
@@ -1,5 +1,6 @@
 defmodule MingaAgent.Tools.ShellTest do
-  use ExUnit.Case, async: true
+  # Spawns shell OS processes, which must not run async.
+  use ExUnit.Case, async: false
 
   alias MingaAgent.Tools.Shell
 
@@ -105,6 +106,48 @@ defmodule MingaAgent.Tools.ShellTest do
       assert combined =~ "done"
     end
 
+    test "truncates streamed command output once", %{tmp_dir: dir} do
+      test_pid = self()
+
+      on_output = fn chunk ->
+        send(test_pid, {:shell_chunk, chunk})
+        :ok
+      end
+
+      assert {:ok, _output} =
+               Shell.execute("elixir -e 'IO.write(String.duplicate(\"x\", 70000))'", dir, 5,
+                 on_output: on_output
+               )
+
+      combined = collect_shell_chunks() |> IO.iodata_to_binary()
+      marker = "\n\n[stream truncated at 64KB]\n"
+
+      assert String.ends_with?(combined, marker)
+      assert byte_size(String.replace_suffix(combined, marker, "")) == 64_000
+      assert length(:binary.matches(combined, marker)) == 1
+    end
+
+    test "stream truncation preserves valid UTF-8 at the cap", %{tmp_dir: dir} do
+      test_pid = self()
+
+      on_output = fn chunk ->
+        send(test_pid, {:shell_chunk, chunk})
+        :ok
+      end
+
+      assert {:ok, _output} =
+               Shell.execute("elixir -e 'IO.write(String.duplicate(\"€\", 30000))'", dir, 5,
+                 on_output: on_output
+               )
+
+      combined = collect_shell_chunks() |> IO.iodata_to_binary()
+
+      assert String.valid?(combined)
+      assert combined =~ "€"
+      assert combined =~ "[stream truncated at 64KB]"
+      assert is_binary(JSON.encode!(%{output: combined}))
+    end
+
     test "works without on_output callback", %{tmp_dir: dir} do
       assert {:ok, output} = Shell.execute("echo hello", dir, 5, [])
       assert output == "hello"
@@ -129,10 +172,21 @@ defmodule MingaAgent.Tools.ShellTest do
 
     test "truncates verbose command output before returning it to the model", %{tmp_dir: dir} do
       assert {:ok, output} =
-               Shell.execute("awk 'BEGIN { for (i = 0; i < 70000; i++) printf \"x\" }'", dir, 5)
+               Shell.execute("elixir -e 'IO.write(String.duplicate(\"x\", 70000))'", dir, 5)
 
-      assert byte_size(output) < 70_000
-      assert output =~ "[truncated at"
+      marker = "\n\n[truncated at 64KB]"
+      assert String.ends_with?(output, marker)
+      assert byte_size(String.replace_suffix(output, marker, "")) == 64_000
+    end
+
+    test "preserves valid UTF-8 when truncating multibyte output", %{tmp_dir: dir} do
+      assert {:ok, output} =
+               Shell.execute("elixir -e 'IO.write(String.duplicate(\"€\", 30000))'", dir, 5)
+
+      assert String.valid?(output)
+      assert output =~ "€"
+      assert output =~ "[truncated at 64KB]"
+      assert is_binary(JSON.encode!(%{output: output}))
     end
 
     test "runs in the specified directory", %{tmp_dir: dir} do

--- a/test/minga_agent/turn_usage_test.exs
+++ b/test/minga_agent/turn_usage_test.exs
@@ -51,4 +51,24 @@ defmodule MingaAgent.TurnUsageTest do
       assert TurnUsage.format_short(u) == "↑100 ↓50 $0.01"
     end
   end
+
+  describe "cache_hit_rate/1" do
+    test "reports the cached share of input tokens" do
+      u = TurnUsage.new(1_000, 50, 750, 100, 0.01)
+      assert TurnUsage.cache_hit_rate(u) == 0.75
+    end
+
+    test "returns zero when no input tokens were reported" do
+      assert TurnUsage.cache_hit_rate(TurnUsage.new()) == 0.0
+    end
+  end
+
+  describe "format_cost_report/1" do
+    test "includes input output cache and cost fields for parity comparisons" do
+      u = TurnUsage.new(1_000, 50, 750, 100, 0.01)
+
+      assert TurnUsage.format_cost_report(u) ==
+               "input=1000 output=50 cache_read=750 cache_write=100 cache_hit_rate=75.0% cost=$0.01"
+    end
+  end
 end

--- a/test/support/minga_agent/project_view/recording_backend.ex
+++ b/test/support/minga_agent/project_view/recording_backend.ex
@@ -19,7 +19,8 @@ defmodule MingaAgent.ProjectView.RecordingBackend do
     ref = %{
       parent: Keyword.fetch!(opts, :parent),
       working_dir: working_dir,
-      env: Keyword.get(opts, :env, [])
+      env: Keyword.get(opts, :env, []),
+      diff: Keyword.get(opts, :diff, [])
     }
 
     {:ok, ProjectView.new(__MODULE__, project_root, ref, opts)}
@@ -97,7 +98,7 @@ defmodule MingaAgent.ProjectView.RecordingBackend do
   @spec diff(ProjectView.t()) :: {:ok, [map()]} | {:error, term()}
   def diff(%ProjectView{} = view) do
     record(view, :diff)
-    {:ok, []}
+    {:ok, view.ref.diff}
   end
 
   @impl true


### PR DESCRIPTION
## Summary

Fixes the token-spend gap in Minga's agentic UX by making routine filesystem and shell tools bounded, ignore-aware, and cache-friendly by default.

## What Changed

- Added shared broad-filesystem ignore handling for agent tools, including generated/dependency/env/cache directories and `git check-ignore` support for direct directory listings.
- Capped model-facing `list_directory`, `find`, `grep`, and `shell` results so basic exploration cannot flood the context window.
- Updated tool descriptions and the native provider prompt so models prefer bounded `find`/`grep` over raw shell recursion.
- Removed volatile current-time text from the system prompt so prompt prefixes stay cacheable.
- Wired configured compaction threshold and keep-recent settings into native provider compaction.
- Added cache hit rate and one-line cost report helpers for token-spend comparisons.

## Why

A coworker observed that basic Minga agentic-view workflows spent far more tokens than other modern harnesses. The root causes were unbounded or weakly bounded tool results, directory listings that exposed generated trees, shell output returned wholesale to the model, a timestamp in the system prompt that defeated cache-stable prefixes, and compaction settings that were not being applied by the native provider.

## Validation

- `mix test test/minga_agent/tools/list_directory_test.exs test/minga_agent/tools/find_test.exs test/minga_agent/tools/grep_test.exs test/minga_agent/tools/shell_test.exs test/minga_agent/providers/native_test.exs test/minga_agent/turn_usage_test.exs`
- `mix test test/minga_agent/tools_read_only_test.exs test/minga_agent/tools/project_view_routing_test.exs test/minga_agent/tool_packs/read_only_test.exs test/minga_agent/compaction_test.exs test/minga_agent/providers/native/req_llm_adapter_test.exs`
- `git diff --check`
- `mix compile --warnings-as-errors`
- `mix test test/minga_agent`
- `mix test.llm`
