### PR TITLE
Align agent tool output caps with Pi and OpenCode (51KB)

### DIFF
--- a/lib/minga_agent/tools/directory_listing.ex
+++ b/lib/minga_agent/tools/directory_listing.ex
@@ -5,7 +5,7 @@ defmodule MingaAgent.Tools.DirectoryListing do
 
   alias MingaAgent.Tools.PathIgnore
 
-  @max_entries 200
+  @max_entries 500
 
   @type entry :: %{name: String.t(), type: :directory | :file}
 

--- a/lib/minga_agent/tools/fetch_url.ex
+++ b/lib/minga_agent/tools/fetch_url.ex
@@ -8,7 +8,7 @@ defmodule MingaAgent.Tools.FetchUrl do
   import Bitwise
 
   @default_timeout_ms 10_000
-  @default_max_bytes 100_000
+  @default_max_bytes 51_200
   @hard_timeout_ms 30_000
   @hard_max_bytes @default_max_bytes
   @allowed_schemes ~w(http https)

--- a/lib/minga_agent/tools/find.ex
+++ b/lib/minga_agent/tools/find.ex
@@ -11,7 +11,7 @@ defmodule MingaAgent.Tools.Find do
   alias MingaAgent.Tools.OutputLimit
   alias MingaAgent.Tools.PathIgnore
 
-  @max_results 200
+  @max_results 1_000
   @max_output_bytes OutputLimit.default_max_bytes()
 
   @doc """

--- a/lib/minga_agent/tools/output_limit.ex
+++ b/lib/minga_agent/tools/output_limit.ex
@@ -3,7 +3,7 @@ defmodule MingaAgent.Tools.OutputLimit do
   UTF-8-safe output truncation for model-facing agent tool results.
   """
 
-  @default_max_bytes 64_000
+  @default_max_bytes 51_200
   @default_timeout_ms 10_000
 
   @type command_status :: non_neg_integer() | :timeout

--- a/lib/minga_agent/tools/read_file.ex
+++ b/lib/minga_agent/tools/read_file.ex
@@ -16,7 +16,7 @@ defmodule MingaAgent.Tools.ReadFile do
 
   alias Minga.Buffer
 
-  @max_bytes 256_000
+  @max_bytes 51_200
 
   @typedoc "Options for partial file reads."
   @type read_opts :: [offset: pos_integer() | nil, limit: pos_integer() | nil]

--- a/test/minga_agent/tools/fetch_url_test.exs
+++ b/test/minga_agent/tools/fetch_url_test.exs
@@ -42,7 +42,7 @@ defmodule MingaAgent.Tools.FetchUrlTest do
     assert opts[:max_retries] == 0
     assert opts[:decode_body] == false
     assert opts[:redirect] == false
-    assert opts[:max_fetch_bytes] == 100_001
+    assert opts[:max_fetch_bytes] == 51_201
     assert opts[:connect_options][:hostname] == "docs.example"
     assert opts[:connect_options][:timeout] == 10_000
     assert {"host", "docs.example:8443"} in opts[:headers]
@@ -137,10 +137,10 @@ defmodule MingaAgent.Tools.FetchUrlTest do
            ) == {:error, "timeout_ms must be at most 30000"}
 
     assert FetchUrl.execute(
-             %{"url" => "https://example.test", "max_bytes" => 100_001},
+             %{"url" => "https://example.test", "max_bytes" => 51_201},
              fetcher,
              resolver
-           ) == {:error, "max_bytes must be at most 100000"}
+           ) == {:error, "max_bytes must be at most 51200"}
   end
 
   test "rejects DNS-resolved private hosts before fetching" do

--- a/test/minga_agent/tools/find_test.exs
+++ b/test/minga_agent/tools/find_test.exs
@@ -148,13 +148,13 @@ defmodule MingaAgent.Tools.FindTest do
     end
 
     test "marks truncated results when more matches exist than the model result cap", %{dir: dir} do
-      for index <- 1..205 do
+      for index <- 1..1_005 do
         File.write!(Path.join(dir, "many_#{index}.txt"), "many")
       end
 
       assert {:ok, output} = Find.execute("many_*.txt", dir)
       lines = String.split(output, "\n", trim: true)
-      assert length(Enum.reject(lines, &String.starts_with?(&1, "... (truncated"))) == 200
+      assert length(Enum.reject(lines, &String.starts_with?(&1, "... (truncated"))) == 1_000
       assert List.last(lines) == "... (truncated, refine the pattern or path for fewer results)"
     end
 
@@ -168,9 +168,9 @@ defmodule MingaAgent.Tools.FindTest do
       end
 
       assert {:ok, output} = Find.execute("long_*.txt", dir, %{"max_depth" => 5})
-      assert byte_size(output) < 65_000
+      assert byte_size(output) < 52_200
       assert String.valid?(output)
-      assert output =~ "truncated at 64KB"
+      assert output =~ "truncated at 51KB"
     end
 
     test "drops a truncated final line before ignore filtering", %{dir: dir} do

--- a/test/minga_agent/tools/grep_test.exs
+++ b/test/minga_agent/tools/grep_test.exs
@@ -175,9 +175,9 @@ defmodule MingaAgent.Tools.GrepTest do
       File.write!(Path.join(dir, "huge.txt"), Enum.join(lines, "\n") <> "\n")
 
       assert {:ok, output} = Grep.execute("needle", dir)
-      assert byte_size(output) < 65_000
+      assert byte_size(output) < 52_200
       assert String.valid?(output)
-      assert output =~ "truncated at 64KB"
+      assert output =~ "truncated at 51KB"
     end
 
     test "does not walk a directly requested ignored search root", %{dir: dir} do

--- a/test/minga_agent/tools/list_directory_test.exs
+++ b/test/minga_agent/tools/list_directory_test.exs
@@ -91,14 +91,14 @@ defmodule MingaAgent.Tools.ListDirectoryTest do
     end
 
     test "caps large directory listings", %{tmp_dir: dir} do
-      for index <- 1..205 do
+      for index <- 1..505 do
         File.write!(Path.join(dir, "file_#{index}.txt"), "")
       end
 
       assert {:ok, listing} = ListDirectory.execute(dir)
       lines = String.split(listing, "\n")
 
-      assert length(lines) == 201
+      assert length(lines) == 501
       assert List.last(lines) == "... (truncated, 5 more entries)"
     end
 

--- a/test/minga_agent/tools/read_file_test.exs
+++ b/test/minga_agent/tools/read_file_test.exs
@@ -48,7 +48,7 @@ defmodule MingaAgent.Tools.ReadFileTest do
       File.write!(path, content)
 
       assert {:ok, result} = ReadFile.execute(path)
-      assert result =~ "[truncated at 256KB]"
+      assert result =~ "[truncated at 51KB]"
       assert byte_size(result) < 300_000
     end
 
@@ -169,7 +169,7 @@ defmodule MingaAgent.Tools.ReadFileTest do
       :ok = Buffer.Process.replace_content(pid, large_content)
 
       assert {:ok, result} = ReadFile.execute(path)
-      assert result =~ "[truncated at 256KB]"
+      assert result =~ "[truncated at 51KB]"
     end
 
     test "works with expanded paths", %{tmp_dir: dir} do

--- a/test/minga_agent/tools/shell_test.exs
+++ b/test/minga_agent/tools/shell_test.exs
@@ -121,10 +121,10 @@ defmodule MingaAgent.Tools.ShellTest do
                )
 
       combined = collect_shell_chunks() |> IO.iodata_to_binary()
-      marker = "\n\n[stream truncated at 64KB]\n"
+      marker = "\n\n[stream truncated at 51KB]\n"
 
       assert String.ends_with?(combined, marker)
-      assert byte_size(String.replace_suffix(combined, marker, "")) == 64_000
+      assert byte_size(String.replace_suffix(combined, marker, "")) == 51_200
       assert length(:binary.matches(combined, marker)) == 1
     end
 
@@ -145,7 +145,7 @@ defmodule MingaAgent.Tools.ShellTest do
 
       assert String.valid?(combined)
       assert combined =~ "€"
-      assert combined =~ "[stream truncated at 64KB]"
+      assert combined =~ "[stream truncated at 51KB]"
       assert is_binary(JSON.encode!(%{output: combined}))
     end
 
@@ -160,14 +160,14 @@ defmodule MingaAgent.Tools.ShellTest do
       end
 
       command =
-        "elixir -e 'IO.write(String.duplicate(\"x\", 63999)); IO.binwrite(:stdio, <<226>>); Process.sleep(50); IO.binwrite(:stdio, <<130, 172>>)'"
+        "elixir -e 'IO.write(String.duplicate(\"x\", 51199)); IO.binwrite(:stdio, <<226>>); Process.sleep(50); IO.binwrite(:stdio, <<130, 172>>)'"
 
       assert {:ok, _output} = Shell.execute(command, dir, 5, on_output: on_output)
 
       combined = collect_shell_chunks() |> IO.iodata_to_binary()
 
       assert String.valid?(combined)
-      assert combined =~ "[stream truncated at 64KB]"
+      assert combined =~ "[stream truncated at 51KB]"
       assert is_binary(JSON.encode!(%{output: combined}))
     end
 
@@ -197,9 +197,9 @@ defmodule MingaAgent.Tools.ShellTest do
       assert {:ok, output} =
                Shell.execute("elixir -e 'IO.write(String.duplicate(\"x\", 70000))'", dir, 5)
 
-      marker = "\n\n[truncated at 64KB]"
+      marker = "\n\n[truncated at 51KB]"
       assert String.ends_with?(output, marker)
-      assert byte_size(String.replace_suffix(output, marker, "")) == 64_000
+      assert byte_size(String.replace_suffix(output, marker, "")) == 51_200
     end
 
     test "preserves valid UTF-8 when truncating multibyte output", %{tmp_dir: dir} do
@@ -208,7 +208,7 @@ defmodule MingaAgent.Tools.ShellTest do
 
       assert String.valid?(output)
       assert output =~ "€"
-      assert output =~ "[truncated at 64KB]"
+      assert output =~ "[truncated at 51KB]"
       assert is_binary(JSON.encode!(%{output: output}))
     end
 
@@ -216,12 +216,12 @@ defmodule MingaAgent.Tools.ShellTest do
       tmp_dir: dir
     } do
       command =
-        "elixir -e 'IO.write(String.duplicate(\"x\", 63999)); IO.binwrite(:stdio, <<226>>); Process.sleep(50); IO.binwrite(:stdio, <<130, 172>>)'"
+        "elixir -e 'IO.write(String.duplicate(\"x\", 51199)); IO.binwrite(:stdio, <<226>>); Process.sleep(50); IO.binwrite(:stdio, <<130, 172>>)'"
 
       assert {:ok, output} = Shell.execute(command, dir, 5)
 
       assert String.valid?(output)
-      assert output =~ "[truncated at 64KB]"
+      assert output =~ "[truncated at 51KB]"
       assert is_binary(JSON.encode!(%{output: output}))
     end
 


### PR DESCRIPTION
## Summary

- Lowers the default agent tool output cap from 64KB to 51KB, matching Pi and OpenCode's shared standard
- Lowers `read_file` from 256KB to 51KB (was a 4x outlier vs. every other tool)
- Lowers `fetch_url` from 100KB to 51KB
- Raises `find` result cap from 200 to 1,000 (matching Pi)
- Raises directory listing entry cap from 200 to 500 (matching Pi)

The old caps were generous outliers. A single 256KB `read_file` consumed ~73K tokens (36% of Claude's 200K context), accelerating compaction unnecessarily. The new 51KB uniform cap aligns with what Pi and OpenCode independently converged on.

| Tool | Before | After | Pi / OpenCode |
|------|--------|-------|---------------|
| Shell | 64KB | 51KB | 51KB |
| Grep | 64KB + 100 matches | 51KB + 100 matches | 51KB + 100 matches |
| Git diff | 64KB | 51KB | 51KB |
| Find | 64KB + 200 results | 51KB + 1,000 results | 51KB + 1,000 results |
| Read file | 256KB | 51KB | 51KB |
| Fetch URL | 100KB | 51KB | 51KB |
| Dir listing | 200 entries | 500 entries | 500 entries |

## Test plan

- [x] All 97 affected tool tests pass (shell, read_file, grep, find, directory listing, fetch_url)
- [ ] Verify truncation markers display correctly in an agent session
- [ ] Confirm partial reads (offset/limit) still work for navigating large files

🤖 Generated with [Claude Code](https://claude.com/claude-code)