### PR TITLE
fix(macos): app launch cwd stuck at / due to inherited TERM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ ifeq ($(OS),Darwin)
 	if [ -z "$$APP_PATH" ] || [ ! -d "$$APP_PATH" ]; then \
 		echo "\033[31mError: Could not locate Minga.app after build.\033[0m"; exit 1; \
 	fi; \
+	rm -rf "$(APP_DIR)/Minga.app" && \
 	cp -R "$$APP_PATH" "$(APP_DIR)/Minga.app" || { \
 		echo "\033[33mPermission denied. Try: sudo make install-mac\033[0m"; exit 1; \
 	}; \

--- a/macos/Sources/BEAMProcessManager.swift
+++ b/macos/Sources/BEAMProcessManager.swift
@@ -127,10 +127,6 @@ final class BEAMProcessManager {
         environment: [String: String],
         bundleURL: URL?
     ) -> Bool {
-        guard environment["TERM"] == nil || environment["TERM"]?.isEmpty == true else {
-            return false
-        }
-
         let currentPath = URL(fileURLWithPath: currentDirectoryPath).standardizedFileURL.path
 
         if currentPath == "/" || currentPath == "/Applications" || currentPath == "/System/Applications" {

--- a/macos/Tests/MingaTests/BEAMProcessManagerTests.swift
+++ b/macos/Tests/MingaTests/BEAMProcessManagerTests.swift
@@ -89,15 +89,16 @@ struct BEAMProcessManagerLaunchArgumentsTests {
         #expect(workingDirectory.path == "/Users/alice/code/minga")
     }
 
-    @Test("keeps /Applications for terminal launches")
-    @MainActor func keepsApplicationsForTerminalLaunches() {
+    @Test("uses HOME for /Applications even with TERM set")
+    @MainActor func usesHomeForApplicationsEvenWithTerm() {
         let workingDirectory = BEAMProcessManager.defaultWorkingDirectoryURL(
             currentDirectoryPath: "/Applications",
             environment: ["HOME": "/Users/alice", "TERM": "xterm-256color"],
-            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app")
+            bundleURL: URL(fileURLWithPath: "/Applications/Minga.app"),
+            fileExists: { path in path == "/Users/alice" }
         )
 
-        #expect(workingDirectory.path == "/Applications")
+        #expect(workingDirectory.path == "/Users/alice")
     }
 
     @Test("keeps cwd when HOME is missing")


### PR DESCRIPTION
## Summary

- Minga.app launched from Finder/Spotlight/Dock started with cwd=/ instead of $HOME because `shouldUseHomeWorkingDirectory` treated any non-empty `TERM` env var as "launched from terminal" and skipped the HOME redirect. Ghostty exports `TERM=xterm-ghostty` globally via launchd, so GUI apps inherit it.
- Removed the `TERM` guard; the cwd-based checks (`/`, `/Applications`, bundle path) are the reliable signal for launch-services context.
- Fixed `make install-mac`: `cp -R` over an existing `.app` merges rather than replaces, so stale Swift binaries survived across rebuilds (the installed binary was from May 29 despite rebuilding today).

## Test plan

- [x] Verified with `lsof -p <BEAM_PID> | grep cwd` that the BEAM process starts in `$HOME` when launched via `open /Applications/Minga.app`
- [x] Verified terminal launches (`cd ~/code/project && open Minga.app`) still use the terminal's cwd
- [ ] Run `make install` and confirm the installed binary timestamp matches the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)