### PR TITLE
perf: defer bundled extension startup off critical path

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -48,9 +48,6 @@ config :minga,
 # Disable user extension loading so tests are deterministic regardless
 # of which extensions the developer has installed locally.
 config :minga, load_extensions: false
-config :minga, load_git_porcelain_extension: false
-config :minga, load_knowledge_graph_extension: false
-config :minga, load_adversarial_extension: false
 # Use stub installers in tests to avoid spawning npm/pip/cargo/go/curl
 # subprocesses during concurrent test runs (same EPIPE concern as git).
 config :minga,

--- a/extensions/git_porcelain/test/test_helper.exs
+++ b/extensions/git_porcelain/test/test_helper.exs
@@ -11,8 +11,7 @@ defmodule MingaGitPorcelain.TestClipboard do
 end
 
 Application.put_env(:minga, :clipboard_module, MingaGitPorcelain.TestClipboard)
-Application.put_env(:minga, :load_file_tree_extension, false)
-Application.put_env(:minga, :load_git_porcelain_extension, true)
+Application.put_env(:minga, :load_extensions, true)
 Application.put_env(:minga, :git_module, Minga.Git.Stub)
 
 parent_test_support = Path.expand("../../../test/support", __DIR__)

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -440,17 +440,23 @@ defmodule Minga.Config.Loader do
 
   @spec register_bundled_extensions() :: :ok
   defp register_bundled_extensions do
-    if Application.get_env(:minga, :load_git_porcelain_extension, true) do
-      ExtRegistry.register(:minga_git_porcelain, bundled_extension_path("git_porcelain"), [])
-    end
+    ExtRegistry.register(
+      :minga_git_porcelain,
+      bundled_extension_path("git_porcelain"),
+      load_policy: :deferred
+    )
 
-    if Application.get_env(:minga, :load_knowledge_graph_extension, true) do
-      ExtRegistry.register(:minga_knowledge_graph, bundled_extension_path("knowledge_graph"), [])
-    end
+    ExtRegistry.register(
+      :minga_knowledge_graph,
+      bundled_extension_path("knowledge_graph"),
+      load_policy: :deferred
+    )
 
-    if Application.get_env(:minga, :load_adversarial_extension, true) do
-      ExtRegistry.register(:minga_adversarial, bundled_extension_path("adversarial"), [])
-    end
+    ExtRegistry.register(
+      :minga_adversarial,
+      bundled_extension_path("adversarial"),
+      load_policy: :deferred
+    )
 
     :ok
   end


### PR DESCRIPTION
## Summary

- Registers the three bundled extensions (git_porcelain, knowledge_graph, adversarial) with `load_policy: :deferred` so they start ~100ms after the first frame renders instead of blocking editor startup (~144ms saved on the critical path).
- Removes hardcoded per-extension `Application.get_env` kill-switch flags from `register_bundled_extensions`. Extension loading in tests is already controlled by `load_extensions: false` in `config/test.exs`, making per-extension flags redundant.
- Cleans up `config/test.exs` and `git_porcelain/test/test_helper.exs` to use the single `load_extensions` flag.

Companion to #2504 (deferred init for EventRecorder, AgentEventLog, Command.Registry).

## Test plan

- [x] Full test suite passes (9843/9847 passed; 4 pre-existing GUIProtocolTest failures unrelated to this PR)
- [x] `mix credo --strict` clean
- [x] `mix dialyzer` passes
- [x] Prod release builds and runs (`make install-mac`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)