### PR TITLE
fix: SwiftUI convention cleanup (phase 1)

### DIFF
--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -31,6 +31,7 @@ struct AgentChatView: View {
     @State private var isModelHovered: Bool = false
     @State private var isThinkingHovered: Bool = false
     @State private var isHelpHovered: Bool = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Whether auto-scroll should follow streaming output.
     private var shouldAutoScroll: Bool { !userHasScrolledUp }
 
@@ -102,8 +103,7 @@ struct AgentChatView: View {
                         }
                         .transition(.opacity)
                         .animation(
-                            NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
-                                ? nil : .easeOut(duration: 0.2),
+                            reduceMotion ? nil : .easeOut(duration: 0.2),
                             value: userHasScrolledUp
                         )
                     }
@@ -1232,8 +1232,7 @@ struct AgentChatView: View {
     /// Scrolls to the last message with smooth animation.
     private func scrollToBottom(proxy: ScrollViewProxy) {
         guard let lastId = state.messages.last?.id else { return }
-        let animation: Animation? = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
-            ? nil : .easeOut(duration: 0.15)
+        let animation: Animation? = reduceMotion ? nil : .easeOut(duration: 0.15)
         withAnimation(animation) {
             proxy.scrollTo(lastId, anchor: .bottom)
         }

--- a/macos/Sources/Views/AgentContextBar.swift
+++ b/macos/Sources/Views/AgentContextBar.swift
@@ -97,7 +97,7 @@ struct AgentContextBar: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
         .background(statusColor.opacity(0.15))
-        .cornerRadius(4)
+        .clipShape(.rect(cornerRadius: 4))
     }
 
     private var statusColor: Color {
@@ -156,7 +156,7 @@ struct AgentContextBar: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(color.opacity(0.15))
-            .cornerRadius(4)
+            .clipShape(.rect(cornerRadius: 4))
         }
         .buttonStyle(.plain)
         .help(label)

--- a/macos/Sources/Views/EditTimelineView.swift
+++ b/macos/Sources/Views/EditTimelineView.swift
@@ -30,7 +30,7 @@ struct EditTimelineView: View {
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(themeColors.editorFg.opacity(0.08))
-                    .cornerRadius(4)
+                    .clipShape(.rect(cornerRadius: 4))
                     .help(file.path)
                 }
 

--- a/macos/Sources/Views/FileTreeHeaderContent.swift
+++ b/macos/Sources/Views/FileTreeHeaderContent.swift
@@ -15,9 +15,7 @@ struct FileTreeHeaderContent: View {
 
     @State private var isHovered = false
 
-    private var reduceMotion: Bool {
-        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
-    }
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var headerAnimationDuration: Double {
         reduceMotion ? 0 : 0.15

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -31,9 +31,10 @@ struct FileTreeView: View {
     private let indentWidth: CGFloat = 14
     private let chevronWidth: CGFloat = 12
 
-    /// Chevron/hover animation duration. Respects reduced motion.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private var animDuration: Double {
-        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.15
+        reduceMotion ? 0 : 0.15
     }
 
     @State private var scrollOffset: CGFloat = 0

--- a/macos/Sources/Views/FloatPopupOverlay.swift
+++ b/macos/Sources/Views/FloatPopupOverlay.swift
@@ -12,8 +12,10 @@ struct FloatPopupOverlay: View {
     let cellWidth: CGFloat
     let cellHeight: CGFloat
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private var animDuration: Double {
-        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.15
+        reduceMotion ? 0 : 0.15
     }
 
     /// Panel width in points, derived from cell dimensions.

--- a/macos/Sources/Views/GitStatusView.swift
+++ b/macos/Sources/Views/GitStatusView.swift
@@ -30,8 +30,10 @@ struct GitStatusView: View {
     private let directoryMaxWidth: CGFloat = 110
     @Namespace private var fileMoveNamespace
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private var animDuration: Double {
-        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.15
+        reduceMotion ? 0 : 0.15
     }
 
     @State private var hoveredEntryId: UInt32? = nil

--- a/macos/Sources/Views/HoverPopupOverlay.swift
+++ b/macos/Sources/Views/HoverPopupOverlay.swift
@@ -41,8 +41,10 @@ struct HoverPopupOverlay: View {
     private let maxHeight: CGFloat = 300
     private let gap: CGFloat = 4
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private var animDuration: Double {
-        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.15
+        reduceMotion ? 0 : 0.15
     }
 
     /// Whether to show the popup above the anchor (preferred) or below.

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -16,9 +16,10 @@ struct PickerOverlay: View {
     private let itemHeight: CGFloat = 24
     private let twoLineItemHeight: CGFloat = 40
 
-    /// Transition animation duration. Respects reduced motion.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private var animDuration: Double {
-        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.1
+        reduceMotion ? 0 : 0.1
     }
 
     var body: some View {

--- a/macos/Sources/Views/SidebarHeaderButton.swift
+++ b/macos/Sources/Views/SidebarHeaderButton.swift
@@ -14,9 +14,7 @@ struct SidebarHeaderButton: View {
 
     @State private var isHovered = false
 
-    private var reduceMotion: Bool {
-        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
-    }
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         Button(action: action) {

--- a/macos/Sources/Views/SignatureHelpOverlay.swift
+++ b/macos/Sources/Views/SignatureHelpOverlay.swift
@@ -38,8 +38,10 @@ struct SignatureHelpOverlay: View {
     private let maxWidth: CGFloat = 600
     private let gap: CGFloat = 4
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private var animDuration: Double {
-        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.1
+        reduceMotion ? 0 : 0.1
     }
 
     /// Whether to show above (preferred) or below the anchor.

--- a/macos/Sources/Views/StatusBarView.swift
+++ b/macos/Sources/Views/StatusBarView.swift
@@ -1178,6 +1178,7 @@ private struct StatusBarIconButton: View {
     let action: () -> Void
 
     @State private var isHovered = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var iconColor: Color {
         if isActive {
@@ -1187,7 +1188,6 @@ private struct StatusBarIconButton: View {
     }
 
     var body: some View {
-        let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
 
         Button(action: action) {
             Image(systemName: icon)

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -429,16 +429,14 @@ struct TabBarView: View {
                     .onTapGesture(count: 2) {
                         renameText = workspace.label
                         isRenaming = true
-                        DispatchQueue.main.async { renameFieldFocused = true }
+                        Task { @MainActor in renameFieldFocused = true }
                     }
                     .onTapGesture(count: 1) {
                         encoder?.sendExecuteCommand(name: "workspace_list")
                     }
             }
 
-            if true {
-                agentStatusDot(workspace.agentStatus, color: workspace.color)
-            }
+            agentStatusDot(workspace.agentStatus, color: workspace.color)
 
             Image(systemName: "chevron.down")
                 .font(.system(size: 7, weight: .bold))
@@ -453,16 +451,14 @@ struct TabBarView: View {
             Button("Rename Workspace...") {
                 renameText = workspace.label
                 isRenaming = true
-                DispatchQueue.main.async { renameFieldFocused = true }
+                Task { @MainActor in renameFieldFocused = true }
             }
             Button("Change Icon...") {
                 showIconPicker = true
             }
             Divider()
-            if !false {
-                Button("Close Workspace") {
-                    encoder?.sendWorkspaceClose(id: workspace.id)
-                }
+            Button("Close Workspace") {
+                encoder?.sendWorkspaceClose(id: workspace.id)
             }
         }
     }

--- a/macos/Sources/Views/ToolManagerView.swift
+++ b/macos/Sources/Views/ToolManagerView.swift
@@ -18,9 +18,10 @@ struct ToolManagerView: View {
     private let itemHeight: CGFloat = 64
     private let failedItemHeight: CGFloat = 96
 
-    /// Transition animation duration. Respects reduced motion.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private var animDuration: Double {
-        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.15
+        reduceMotion ? 0 : 0.15
     }
 
     var body: some View {

--- a/macos/Sources/Views/WhichKeyOverlay.swift
+++ b/macos/Sources/Views/WhichKeyOverlay.swift
@@ -14,9 +14,10 @@ struct WhichKeyOverlay: View {
     private let rowHeight: CGFloat = 22
     private let maxColumns = 4
 
-    /// Transition animation duration. Respects reduced motion.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private var animDuration: Double {
-        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.15
+        reduceMotion ? 0 : 0.15
     }
 
     var body: some View {

--- a/macos/Sources/Views/WorkspaceHeaderView.swift
+++ b/macos/Sources/Views/WorkspaceHeaderView.swift
@@ -228,7 +228,7 @@ struct WorkspaceHeaderView: View {
     private func beginRename(_ workspace: WorkspaceSummaryEntry) {
         renameText = workspace.label
         isRenaming = true
-        DispatchQueue.main.async { renameFieldFocused = true }
+        Task { @MainActor in renameFieldFocused = true }
     }
 
     private func commitRename(_ workspace: WorkspaceSummaryEntry) {


### PR DESCRIPTION
## Summary

Phase 1 of the SwiftUI conventions remediation plan: low-risk mechanical fixes across 16 view files.

- **Replace `NSWorkspace.shared.accessibilityDisplayShouldReduceMotion` with `@Environment(\.accessibilityReduceMotion)`** across 13 SwiftUI views. The NSWorkspace call is a synchronous system call that bypasses SwiftUI's environment update mechanism; views using it won't re-render if the user toggles reduce-motion at runtime. `SparklineView` already used `@Environment` correctly; now all views match.
- **Replace deprecated `cornerRadius(_:)` with `.clipShape(.rect(cornerRadius:))`** in `EditTimelineView` and `AgentContextBar` (3 call sites).
- **Remove dead `if true {}` and `if !false {}` scaffolding** in `TabBarView` (lines 439, 462). These wrapped `agentStatusDot` and "Close Workspace" button with always-true conditions left from removed feature flags.
- **Replace `DispatchQueue.main.async { focused = true }` with `Task { @MainActor in ... }`** for `@FocusState` timing in `TabBarView` (2x) and `WorkspaceHeaderView` (1x). Correct Swift 6 concurrency pattern. Left `DispatchQueue` calls in `SettingsView` and `InlineEditField` alone since those correctly use it for AppKit `makeFirstResponder` timing in `NSViewRepresentable`.

## Test plan

- [x] `xcodegen generate` succeeds
- [x] `xcodebuild build` succeeds (Debug)
- [x] All 866 tests pass
- [x] `grep -rn 'NSWorkspace.shared.accessibilityDisplayShouldReduceMotion' Views/` returns only `BlinkingCursor` (static, non-view) and `EditorNSView` (AppKit)
- [x] `grep -rn '\.cornerRadius(' Views/` returns zero results
- [x] No `if true` or `if !false` scaffolding remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)