### PR TITLE
refactor: file organization and shared patterns (SwiftUI Phase 2)

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		03FEC8AC31DA3A2806822AA6 /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D6B3C68CFF37BC4303933A /* ThemeColors.swift */; };
 		04DCD757C3C296EDE15973C8 /* ExtensionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BB136A9D180CCAD371E51 /* ExtensionPanelView.swift */; };
 		058481A528AFB6C7225A067D /* MouseInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */; };
+		05D9ADC00817DEEF52058F02 /* PointingHandModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA51F390E49935563AB0AEB6 /* PointingHandModifier.swift */; };
 		05EC70C811170EE160C5E4D9 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
 		067369CB702835E93D254606 /* PipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */; };
 		06D57AD02306EA08C458CC11 /* WorkspaceIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */; };
@@ -57,6 +58,7 @@
 		22A66EB080AFFEDCE9AC329D /* ActivityBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80457F318D9322F416DA291 /* ActivityBar.swift */; };
 		22EFBD4416697A01FDC9C2AD /* ProtocolCommandSize.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762CD389E04B0DE6A86CDBF2 /* ProtocolCommandSize.generated.swift */; };
 		236A0542773564BED642D5AD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84218125A9F97DBE87F349 /* ContentView.swift */; };
+		23780BE4829F0BB8140E73B4 /* StatusBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7661E4DEFDA15A9A256016 /* StatusBarState.swift */; };
 		23C300C87E722F7CCA072DFF /* ExtensionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BB136A9D180CCAD371E51 /* ExtensionPanelView.swift */; };
 		23DA463A92D1EC2F7BFA5B5A /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
@@ -74,6 +76,7 @@
 		2C176B25F957ABFA236A1F31 /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
 		2CB47C7E5221C260DE6EE77F /* ToolManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */; };
 		2DF34C5298A3A265364EDC7C /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */; };
+		2E602669F43F1C9F4505DC0D /* StatusBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7661E4DEFDA15A9A256016 /* StatusBarState.swift */; };
 		2FD4D85B9612CA458246F06E /* SignatureHelpOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0070B497768FE68A63F5F114 /* SignatureHelpOverlay.swift */; };
 		2FF702C4573CDB88FD43AF15 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84218125A9F97DBE87F349 /* ContentView.swift */; };
 		30AF3AD9C1C7F46956940CEC /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
@@ -81,6 +84,7 @@
 		31E0D1C2347322703DA6CC71 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
 		32171233224FC90E1E956631 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C0836F0D4150126F181C05 /* PickerState.swift */; };
 		321C190BE2954993724C135B /* NativeSidebarRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E97CAAF19098EC60D6557B /* NativeSidebarRegistry.swift */; };
+		329B3ECA2CC81AC6AF2FB4B7 /* GitStatusHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E61D39D699B0ABD5AB6232 /* GitStatusHeaderView.swift */; };
 		32B67B25582AA941FE71B84C /* SidebarHostState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FEDA452F802EBD0D2496AD6 /* SidebarHostState.swift */; };
 		32E539855F602A532C3ED7B8 /* PreviewRegistry+Overlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0D41B1D748FBFE7916342C /* PreviewRegistry+Overlays.swift */; };
 		333C467F77C10315777C85D2 /* HoverPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE5B840DF73BAC1A97CB7E6 /* HoverPopupOverlay.swift */; };
@@ -95,7 +99,7 @@
 		3943C8DF3827347B61E6B725 /* MinibufferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DDF3EED1B486C4639A06FF /* MinibufferView.swift */; };
 		39D845C41F25DA3045A8F5EB /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93D9A1EA61B37CB3C8F031A /* SparklineView.swift */; };
 		3A23159F3A6631F0AD99A702 /* ExtensionViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA6F5FC902DD40A54F100FF /* ExtensionViewsTests.swift */; };
-		3B7E389A35ADF448C5588469 /* FileTreeHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */; };
+		3AF745616FA7529826C8893D /* PointingHandModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA51F390E49935563AB0AEB6 /* PointingHandModifier.swift */; };
 		3CD49A10C9BA962BBCB00CA8 /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
 		3CE45B5FDE5CB6612B7942F4 /* SettingsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BBC8154E1D48CE215F2F25 /* SettingsState.swift */; };
 		3DB25E7E934FAAD7A7B51084 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
@@ -118,6 +122,7 @@
 		4ADE54090FEEF5AA2A6C86A0 /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		4C267F0119D5A6D1BD2B6F2E /* LatencyHUDOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACF2CEDC2CDB78683883C04 /* LatencyHUDOverlay.swift */; };
 		4C38738BE7EFAE48EF2DB242 /* LatencyHUDOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACF2CEDC2CDB78683883C04 /* LatencyHUDOverlay.swift */; };
+		4CEC9C90D223C2417FA1AE70 /* GitStatusHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E61D39D699B0ABD5AB6232 /* GitStatusHeaderView.swift */; };
 		4D83576C27CB59935BE53667 /* ToolManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */; };
 		4DF0BD94C77CA840CC92ACB7 /* AgentChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD14027C8C7BD17057DE820B /* AgentChatView.swift */; };
 		4E1EEFA65935DCE58528E02B /* PipelineCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */; };
@@ -131,6 +136,7 @@
 		53736DA2E4420D55D3D4E0A4 /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
 		545597C675EA0D630D24A4C8 /* WorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */; };
 		55399D2B1E4C5EBE632D7EBC /* PickerOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F606681DE9AA9D502A42AA /* PickerOverlay.swift */; };
+		5694D2C40ED162897A45AA46 /* StatusBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7661E4DEFDA15A9A256016 /* StatusBarState.swift */; };
 		58D1135E113BF3A33EF7815F /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		59546703C9DBB4BA6E15DE28 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */; };
 		5A8EF773EB260EC1A70BDA6A /* SearchToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48E4A7CE35A41F8198B7AE4 /* SearchToolbar.swift */; };
@@ -164,9 +170,9 @@
 		6860E9D6217B72EAA8AD71A5 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
 		686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F220A60775A252A728477659 /* ProtocolTests.swift */; };
 		68886327B4EB9F0766EB7DCD /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
+		69C8C77E1AE29FE49B66D21F /* FileTreeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F128DFB7120325BE68DE2B89 /* FileTreeHeaderView.swift */; };
 		6A52456182D34DA5C6D0525C /* GitStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5F52D925D26A6D8919A0CB /* GitStatusView.swift */; };
 		6AFA24DC3EE21023636C136A /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
-		6BA7D7FBA7A05CDEA428811D /* FileTreeHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */; };
 		6BE2E29A66DAA9D5B0B478C5 /* EditorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9448826AA38AB5FC0CEB79 /* EditorSettingsView.swift */; };
 		6C48A19EB071FA951E15B3D9 /* PreviewRegistry+Chrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF40BCB1722FAD446E1E6E52 /* PreviewRegistry+Chrome.swift */; };
 		6CF0F1BB4E1BDC0182EDCCB1 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
@@ -213,6 +219,7 @@
 		854BCC1151B43E9A161C95B5 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */; };
 		8589A861D9E1106F5E09992D /* EditorScrollTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5BCCFBC55C09439BAE0563 /* EditorScrollTrack.swift */; };
 		85E4813953F2ECED58655484 /* LatencyRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749F7E4A3595F1289002943E /* LatencyRecorder.swift */; };
+		866F78D7969A9FEB262B1882 /* FileTreeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F128DFB7120325BE68DE2B89 /* FileTreeHeaderView.swift */; };
 		870591324FCC1AD0BBCECCDA /* ObservatoryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1421FF1F017E45A031AF18 /* ObservatoryState.swift */; };
 		87C92A93D274184D1608DAC5 /* BlinkingCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3927622EC3475A69EE524899 /* BlinkingCursor.swift */; };
 		885248B3360E39F678FCAA67 /* AgentSurfaceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483AA21EF140F07296D1E16A /* AgentSurfaceTypes.swift */; };
@@ -228,6 +235,7 @@
 		8CB3E1EEDEA109F6C0183597 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */; };
 		8D55764B8CF042B4C48AA5D0 /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
 		8DA7795B9AD0EC93BCC40D6D /* LatencyHUDState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3CDCE4CBD952FB00D1D347 /* LatencyHUDState.swift */; };
+		8F5C757B71ED735F2BB8E05D /* PointingHandModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA51F390E49935563AB0AEB6 /* PointingHandModifier.swift */; };
 		8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
 		8FB0DF76DEB5112AD590BB11 /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		92AFB851C9873F6E26F069A3 /* TextHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA1A468192F9DE2BBF374DD /* TextHighlighting.swift */; };
@@ -290,7 +298,6 @@
 		B33F3F024CB62AFB86A64504 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */; };
 		B3E09FFA229E669574BA2380 /* SearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB3FF00584DBCEDE5FF79AC /* SearchState.swift */; };
 		B4302095BF2EE9B208325EC8 /* EditorScrollTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5BCCFBC55C09439BAE0563 /* EditorScrollTrack.swift */; };
-		B4AA8AEC6D3ED269B8860786 /* GitStatusHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */; };
 		B4CEAC6B97A7EDBF0AE063DA /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93D9A1EA61B37CB3C8F031A /* SparklineView.swift */; };
 		B52AA9E18CD97F7F5F6A5701 /* ResyncState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2121F82B813972A7A40BEEA /* ResyncState.swift */; };
 		B52CC06DF924153EAA3BADBE /* SidebarHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */; };
@@ -325,10 +332,9 @@
 		C715D937E8591D8BA46A29CD /* FontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2DE335B00721CBB29329F9 /* FontTests.swift */; };
 		C8FAD7BE37506758A1DBF8F6 /* FileTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */; };
 		C97709E4D4BED5B2807481F5 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C26E064D810299C0302F439 /* EditorView.swift */; };
-		CA45D5770C1B334A821D3338 /* GitStatusHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */; };
-		CC72FE91F267AA744D4A6F1D /* GitStatusHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */; };
 		CC8B2D0174D3E5839980702C /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
 		CD2952CCEB2FD594B269A75D /* GUIActionEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */; };
+		CE2CB611955795DC12E79348 /* GitStatusHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E61D39D699B0ABD5AB6232 /* GitStatusHeaderView.swift */; };
 		CE2F1915565DB90F4A7FC04C /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		CE8489B606217C3889536EBD /* PreviewRegistry+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6904499C06BDDEDCECC5D364 /* PreviewRegistry+AgentChat.swift */; };
 		CED32F817C08FC30D21E09AC /* ProtocolSemanticDecode.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B639BCE7660087F70778E839 /* ProtocolSemanticDecode.generated.swift */; };
@@ -351,7 +357,6 @@
 		DF3B2A645C089F616B9DBD1B /* ProtocolEncoderDisconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */; };
 		DF3C7F2962B4563C54D82C8C /* PreviewSnapshotPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100F1DE1D6A8C5A2065AC582 /* PreviewSnapshotPolicyTests.swift */; };
 		DF9EDB44B49C0D61E40D149B /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
-		E04EB44BCBE0CEB501618F1A /* FileTreeHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */; };
 		E073657EE87B3F145830B7C7 /* FileTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */; };
 		E20D436BEA6628E24B9FFA2C /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		E2BC69E1121328310B830E45 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
@@ -385,6 +390,7 @@
 		F16FDEC1BFC1776B1109622E /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7C3564C27A7E14D894539 /* TabBarView.swift */; };
 		F2D5D585C99B45C63240426D /* ChangeSummaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22A4DA9EAA5CD1CFD71D3A8 /* ChangeSummaryState.swift */; };
 		F318B2BFA81A36DFBED83F72 /* WorkspaceHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */; };
+		F35194B27F291D1238082B2A /* FileTreeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F128DFB7120325BE68DE2B89 /* FileTreeHeaderView.swift */; };
 		F3BB64E36F257BD7FACEA5D6 /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
 		F4096578F8824E4D42C5B80B /* ProtocolErrorOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271269086D4FB1EC9FB5444D /* ProtocolErrorOverlay.swift */; };
 		F560D385A1FB0A46824F7B1F /* PickerOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F606681DE9AA9D502A42AA /* PickerOverlay.swift */; };
@@ -474,7 +480,6 @@
 		56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolDecoder.swift; sourceTree = "<group>"; };
 		56B00002D020FED57D265C74 /* SystemColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemColorTests.swift; sourceTree = "<group>"; };
 		57B35E8311966948B1BA7AEF /* DecoderRobustnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderRobustnessTests.swift; sourceTree = "<group>"; };
-		59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeHeaderContent.swift; sourceTree = "<group>"; };
 		5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTextMetalRenderer.swift; sourceTree = "<group>"; };
 		620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentRendererTests.swift; sourceTree = "<group>"; };
 		638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelState.swift; sourceTree = "<group>"; };
@@ -494,6 +499,7 @@
 		790F7E20F30FEEFC552B3685 /* WindowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContent.swift; sourceTree = "<group>"; };
 		79F5D551302873BE8F7240ED /* FontManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontManager.swift; sourceTree = "<group>"; };
 		7A67102D81C9E70546F1019B /* MessagesContentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentState.swift; sourceTree = "<group>"; };
+		7C7661E4DEFDA15A9A256016 /* StatusBarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarState.swift; sourceTree = "<group>"; };
 		7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEncoder.swift; sourceTree = "<group>"; };
 		7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInputTests.swift; sourceTree = "<group>"; };
 		82B744449C852E13511FFE8D /* MinibufferStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinibufferStateTests.swift; sourceTree = "<group>"; };
@@ -551,10 +557,10 @@
 		CE9448826AA38AB5FC0CEB79 /* EditorSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSettingsView.swift; sourceTree = "<group>"; };
 		CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyOverlay.swift; sourceTree = "<group>"; };
 		CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbBar.swift; sourceTree = "<group>"; };
-		D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusHeaderContent.swift; sourceTree = "<group>"; };
 		D17B2A4D2BADE64E249073E1 /* PreviewRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewRegistry.swift; sourceTree = "<group>"; };
 		D2D59D9EEB390C8DF351D595 /* FrameState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameState.swift; sourceTree = "<group>"; };
 		D48E4A7CE35A41F8198B7AE4 /* SearchToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchToolbar.swift; sourceTree = "<group>"; };
+		D4E61D39D699B0ABD5AB6232 /* GitStatusHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusHeaderView.swift; sourceTree = "<group>"; };
 		D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowView.swift; sourceTree = "<group>"; };
 		DA53378E05335BC93B342123 /* LatencyHUDStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatencyHUDStateTests.swift; sourceTree = "<group>"; };
 		DD14027C8C7BD17057DE820B /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
@@ -571,12 +577,14 @@
 		EF3D54D0AA54F1EC07318AEA /* ExtensionPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPanelState.swift; sourceTree = "<group>"; };
 		F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorsTests.swift; sourceTree = "<group>"; };
 		F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BEAMProcessManager.swift; sourceTree = "<group>"; };
+		F128DFB7120325BE68DE2B89 /* FileTreeHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeHeaderView.swift; sourceTree = "<group>"; };
 		F220A60775A252A728477659 /* ProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolTests.swift; sourceTree = "<group>"; };
 		F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceState.swift; sourceTree = "<group>"; };
 		F5647A59C841B3C408994CC7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMECompositionTests.swift; sourceTree = "<group>"; };
 		F6E97CAAF19098EC60D6557B /* NativeSidebarRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeSidebarRegistry.swift; sourceTree = "<group>"; };
 		FA1B4D69D3277F2372A8F6F1 /* FrameMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMetrics.swift; sourceTree = "<group>"; };
+		FA51F390E49935563AB0AEB6 /* PointingHandModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointingHandModifier.swift; sourceTree = "<group>"; };
 		FD66FBCBFC20D50D22A969C8 /* SymbolsNerdFontMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SymbolsNerdFontMono-Regular.ttf"; sourceTree = "<group>"; };
 		FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -644,6 +652,14 @@
 			path = bin;
 			sourceTree = "<group>";
 		};
+		4A459EB5F16F1758002B4FF9 /* Modifiers */ = {
+			isa = PBXGroup;
+			children = (
+				FA51F390E49935563AB0AEB6 /* PointingHandModifier.swift */,
+			);
+			path = Modifiers;
+			sourceTree = "<group>";
+		};
 		4AACF7C989E8FDB12B3EC840 /* Font */ = {
 			isa = PBXGroup;
 			children = (
@@ -704,13 +720,13 @@
 				836BA390DF0C2A711D270D2C /* ExtensionOverlayView.swift */,
 				EF3D54D0AA54F1EC07318AEA /* ExtensionPanelState.swift */,
 				4A9BB136A9D180CCAD371E51 /* ExtensionPanelView.swift */,
-				59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */,
+				F128DFB7120325BE68DE2B89 /* FileTreeHeaderView.swift */,
 				D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */,
 				CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */,
 				5458552EC58E44C7CD15A98A /* FileTreeView.swift */,
 				84C47F406747CA6DD924A1AB /* FloatPopupOverlay.swift */,
 				23EF5FFAD8310BD41CF784AC /* FloatPopupState.swift */,
-				D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */,
+				D4E61D39D699B0ABD5AB6232 /* GitStatusHeaderView.swift */,
 				16B5F67DE84B139C6F8F3C9F /* GitStatusState.swift */,
 				CA5F52D925D26A6D8919A0CB /* GitStatusView.swift */,
 				C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */,
@@ -745,6 +761,7 @@
 				0070B497768FE68A63F5F114 /* SignatureHelpOverlay.swift */,
 				3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */,
 				C93D9A1EA61B37CB3C8F031A /* SparklineView.swift */,
+				7C7661E4DEFDA15A9A256016 /* StatusBarState.swift */,
 				E892F827AFBE959F9DF25C05 /* StatusBarView.swift */,
 				0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */,
 				03D7C3564C27A7E14D894539 /* TabBarView.swift */,
@@ -757,6 +774,7 @@
 				556F4CD63B4A102AB3099B54 /* WorkspaceHeaderView.swift */,
 				73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */,
 				F3E27B6DBF72413F1D8CBBFD /* WorkspaceState.swift */,
+				4A459EB5F16F1758002B4FF9 /* Modifiers */,
 				CA9FBB32D6FA803D937F1B97 /* Settings */,
 			);
 			path = Views;
@@ -1147,7 +1165,7 @@
 				A25FEFF01578CFA880BDC424 /* ExtensionOverlayView.swift in Sources */,
 				A3450933A22B691CDAA7277A /* ExtensionPanelState.swift in Sources */,
 				B0DFAD8D1AF624C9EA6D1940 /* ExtensionPanelView.swift in Sources */,
-				E04EB44BCBE0CEB501618F1A /* FileTreeHeaderContent.swift in Sources */,
+				69C8C77E1AE29FE49B66D21F /* FileTreeHeaderView.swift in Sources */,
 				53736DA2E4420D55D3D4E0A4 /* FileTreeRowView.swift in Sources */,
 				E073657EE87B3F145830B7C7 /* FileTreeState.swift in Sources */,
 				5311F1060367B40B4077309F /* FileTreeView.swift in Sources */,
@@ -1159,7 +1177,7 @@
 				E4A2887CDB5EDB64080E5096 /* FrameState.swift in Sources */,
 				98EFFA06B0B239B2C093226D /* FrontendExtensionRuntime.swift in Sources */,
 				0704C24443A8A7455BE7853E /* GUIState.swift in Sources */,
-				CA45D5770C1B334A821D3338 /* GitStatusHeaderContent.swift in Sources */,
+				329B3ECA2CC81AC6AF2FB4B7 /* GitStatusHeaderView.swift in Sources */,
 				834AE58B6A66336706780324 /* GitStatusState.swift in Sources */,
 				5FC076D7FA45C7F1829213AA /* GitStatusView.swift in Sources */,
 				C61B2087D8184481CD9072B7 /* HoverPopupOverlay.swift in Sources */,
@@ -1186,6 +1204,7 @@
 				FA9C31900696A16D89169788 /* PickerOverlay.swift in Sources */,
 				785A55B784A3EE17DC3E0AC6 /* PickerState.swift in Sources */,
 				067369CB702835E93D254606 /* PipelineCache.swift in Sources */,
+				05D9ADC00817DEEF52058F02 /* PointingHandModifier.swift in Sources */,
 				ECE870F634AC4B097DA300AC /* PortLogger.swift in Sources */,
 				B7203DF9CF85663B0A266580 /* PowerThermalPolicy.swift in Sources */,
 				3E158E5FE11720525BA9FB3C /* PreviewFixtures.swift in Sources */,
@@ -1220,6 +1239,7 @@
 				8CB3E1EEDEA109F6C0183597 /* SignatureHelpState.swift in Sources */,
 				CE2F1915565DB90F4A7FC04C /* SlotAllocator.swift in Sources */,
 				B4CEAC6B97A7EDBF0AE063DA /* SparklineView.swift in Sources */,
+				5694D2C40ED162897A45AA46 /* StatusBarState.swift in Sources */,
 				084A4F7680D533CDACEC729A /* StatusBarView.swift in Sources */,
 				C134E5115725A3A85492FF51 /* TabBarState.swift in Sources */,
 				A574FC420DE17918612DFA48 /* TabBarView.swift in Sources */,
@@ -1274,7 +1294,7 @@
 				8320D5A4779EE1EF37A54477 /* ExtensionOverlayView.swift in Sources */,
 				EAB3B23E6209C12EE042F2DE /* ExtensionPanelState.swift in Sources */,
 				04DCD757C3C296EDE15973C8 /* ExtensionPanelView.swift in Sources */,
-				3B7E389A35ADF448C5588469 /* FileTreeHeaderContent.swift in Sources */,
+				866F78D7969A9FEB262B1882 /* FileTreeHeaderView.swift in Sources */,
 				CC8B2D0174D3E5839980702C /* FileTreeRowView.swift in Sources */,
 				A1F7FEEEDE79E743506763C7 /* FileTreeState.swift in Sources */,
 				630D7B1922CBCCF1335491C2 /* FileTreeView.swift in Sources */,
@@ -1286,7 +1306,7 @@
 				842F37A4A6D1D95F63E41E2A /* FrameState.swift in Sources */,
 				DCF995CAE4350E6FF0A42CE8 /* FrontendExtensionRuntime.swift in Sources */,
 				3897BF151EA81DDF38B85047 /* GUIState.swift in Sources */,
-				B4AA8AEC6D3ED269B8860786 /* GitStatusHeaderContent.swift in Sources */,
+				4CEC9C90D223C2417FA1AE70 /* GitStatusHeaderView.swift in Sources */,
 				1D2AE6CCA8AEE36DA0731D7B /* GitStatusState.swift in Sources */,
 				6A52456182D34DA5C6D0525C /* GitStatusView.swift in Sources */,
 				333C467F77C10315777C85D2 /* HoverPopupOverlay.swift in Sources */,
@@ -1312,6 +1332,7 @@
 				55399D2B1E4C5EBE632D7EBC /* PickerOverlay.swift in Sources */,
 				8B836B6CADA9E21721BAD96C /* PickerState.swift in Sources */,
 				E3B2DB94D802E1831C17474E /* PipelineCache.swift in Sources */,
+				3AF745616FA7529826C8893D /* PointingHandModifier.swift in Sources */,
 				70BAD234EF40359C5703FAAA /* PortLogger.swift in Sources */,
 				68886327B4EB9F0766EB7DCD /* PowerThermalPolicy.swift in Sources */,
 				9ADD91865E64B910DD187377 /* PreviewFixtures.swift in Sources */,
@@ -1348,6 +1369,7 @@
 				A74761E8F6B3FD1D0CFA1521 /* SignatureHelpState.swift in Sources */,
 				7FE374C007A79192530A6B26 /* SlotAllocator.swift in Sources */,
 				48B39FFBCC069B1955B990E9 /* SparklineView.swift in Sources */,
+				2E602669F43F1C9F4505DC0D /* StatusBarState.swift in Sources */,
 				DF9EDB44B49C0D61E40D149B /* StatusBarView.swift in Sources */,
 				9493C0265F69C3D588ACC37B /* TabBarState.swift in Sources */,
 				DE495CCFC92C702B2A3243A0 /* TabBarView.swift in Sources */,
@@ -1409,7 +1431,7 @@
 				7D395895306A81736A98E8B9 /* ExtensionPanelState.swift in Sources */,
 				23C300C87E722F7CCA072DFF /* ExtensionPanelView.swift in Sources */,
 				3A23159F3A6631F0AD99A702 /* ExtensionViewsTests.swift in Sources */,
-				6BA7D7FBA7A05CDEA428811D /* FileTreeHeaderContent.swift in Sources */,
+				F35194B27F291D1238082B2A /* FileTreeHeaderView.swift in Sources */,
 				20DE27562883B504C119A22F /* FileTreeRowView.swift in Sources */,
 				C8FAD7BE37506758A1DBF8F6 /* FileTreeState.swift in Sources */,
 				31E0D1C2347322703DA6CC71 /* FileTreeView.swift in Sources */,
@@ -1424,7 +1446,7 @@
 				CD2952CCEB2FD594B269A75D /* GUIActionEncoderTests.swift in Sources */,
 				30E31170A79F30413D15D858 /* GUIChromeDecoderTests.swift in Sources */,
 				36E0C059965477465E15CC02 /* GUIState.swift in Sources */,
-				CC72FE91F267AA744D4A6F1D /* GitStatusHeaderContent.swift in Sources */,
+				CE2CB611955795DC12E79348 /* GitStatusHeaderView.swift in Sources */,
 				7E2428F971A8835D3B42598B /* GitStatusState.swift in Sources */,
 				D946EB891A72053F283BF971 /* GitStatusView.swift in Sources */,
 				51BE3CA19AB1A7E18479EDD4 /* HoverPopupOverlay.swift in Sources */,
@@ -1460,6 +1482,7 @@
 				32171233224FC90E1E956631 /* PickerState.swift in Sources */,
 				BF4E98B0BE647893CB5DA85C /* PipelineCache.swift in Sources */,
 				4E1EEFA65935DCE58528E02B /* PipelineCacheTests.swift in Sources */,
+				8F5C757B71ED735F2BB8E05D /* PointingHandModifier.swift in Sources */,
 				5CADBD593C49EE44EBBD854E /* PortLogger.swift in Sources */,
 				05EC70C811170EE160C5E4D9 /* PowerThermalPolicy.swift in Sources */,
 				BA72343308BCD0E078452868 /* PowerThermalPolicyTests.swift in Sources */,
@@ -1507,6 +1530,7 @@
 				07C6F28E3CD1A55ABD5344AA /* SlotAllocatorTests.swift in Sources */,
 				39D845C41F25DA3045A8F5EB /* SparklineView.swift in Sources */,
 				0BCDFB56E8397D739F52ED34 /* StateLifecycleTests.swift in Sources */,
+				23780BE4829F0BB8140E73B4 /* StatusBarState.swift in Sources */,
 				531166B714D49278BA811033 /* StatusBarView.swift in Sources */,
 				9758BF46BB0EC7FEEB14FBA3 /* SwiftUIViewTests.swift in Sources */,
 				FEFCEFCDC21C5AA5456036D0 /* SystemColorTests.swift in Sources */,

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -175,8 +175,8 @@ struct AgentChatView: View {
             .accessibilityAddTraits(.isButton)
             .onHover { hovering in
                 isHelpHovered = hovering
-                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
             }
+            .pointingHandCursor()
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
@@ -212,7 +212,7 @@ struct AgentChatView: View {
         .accessibilityHint(state.isThinking ? "Disabled while the agent is streaming" : "Opens the model picker")
         .accessibilityAddTraits(.isButton)
         .onHover { isModelHovered = $0 }
-        .modifier(HeaderControlPointingHandModifier(isEnabled: !state.isThinking))
+        .pointingHandCursor(isEnabled: !state.isThinking)
     }
 
     @ViewBuilder
@@ -251,7 +251,7 @@ struct AgentChatView: View {
             .accessibilityHint("Opens a menu of thinking levels")
             .accessibilityAddTraits(.isButton)
             .onHover { isThinkingHovered = $0 }
-            .modifier(HeaderControlPointingHandModifier(isEnabled: true))
+            .pointingHandCursor()
         }
     }
 
@@ -277,44 +277,6 @@ struct AgentChatView: View {
         case "medium": return "Medium"
         case "high": return "High"
         default: return level.capitalized
-        }
-    }
-
-    private struct HeaderControlPointingHandModifier: ViewModifier {
-        let isEnabled: Bool
-        @State private var isHovered = false
-        @State private var didPushCursor = false
-
-        func body(content: Content) -> some View {
-            content
-                .onHover { hovering in
-                    isHovered = hovering
-                    syncCursor()
-                }
-                .onChange(of: isEnabled) { _, _ in
-                    syncCursor()
-                }
-                .onDisappear {
-                    popCursorIfNeeded()
-                }
-        }
-
-        private func syncCursor() {
-            let shouldPush = isHovered && isEnabled
-
-            if shouldPush && !didPushCursor {
-                NSCursor.pointingHand.push()
-                didPushCursor = true
-            } else if !shouldPush && didPushCursor {
-                popCursorIfNeeded()
-            }
-        }
-
-        private func popCursorIfNeeded() {
-            if didPushCursor {
-                NSCursor.pop()
-                didPushCursor = false
-            }
         }
     }
 

--- a/macos/Sources/Views/AgentContextBar.swift
+++ b/macos/Sources/Views/AgentContextBar.swift
@@ -160,9 +160,7 @@ struct AgentContextBar: View {
         }
         .buttonStyle(.plain)
         .help(label)
-        .onHover { isHovered in
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
+        .pointingHandCursor()
     }
 
     // MARK: - Helpers

--- a/macos/Sources/Views/BottomPanelView.swift
+++ b/macos/Sources/Views/BottomPanelView.swift
@@ -100,9 +100,7 @@ struct BottomPanelView: View {
             .buttonStyle(.plain)
             .help("Close panel")
             .padding(.horizontal, 8)
-            .onHover { isHovered in
-                if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
+            .pointingHandCursor()
         }
         .frame(height: 28)
         .background(theme.tabBg)

--- a/macos/Sources/Views/BreadcrumbBar.swift
+++ b/macos/Sources/Views/BreadcrumbBar.swift
@@ -52,9 +52,7 @@ struct BreadcrumbBar: View {
                             )
                     }
                     .buttonStyle(.plain)
-                    .onHover { isHovered in
-                        if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
+                    .pointingHandCursor()
                 }
 
                 Spacer()
@@ -103,8 +101,6 @@ struct BreadcrumbBar: View {
         .buttonStyle(.plain)
         .help(tooltip)
         .padding(.trailing, 4)
-        .onHover { isHovered in
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
+        .pointingHandCursor()
     }
 }

--- a/macos/Sources/Views/FileTreeHeaderView.swift
+++ b/macos/Sources/Views/FileTreeHeaderView.swift
@@ -1,4 +1,4 @@
-/// File tree header content for the unified toolbar.
+/// File tree header view for the unified toolbar.
 ///
 /// Shows the project name, git branch, and action buttons (new file,
 /// new folder, refresh, collapse all). Rendered inside the shared toolbar row
@@ -6,7 +6,7 @@
 
 import SwiftUI
 
-struct FileTreeHeaderContent: View {
+struct FileTreeHeaderView: View {
     let fileTreeState: FileTreeState
     let theme: ThemeColors
     let encoder: InputEncoder?

--- a/macos/Sources/Views/GitStatusHeaderView.swift
+++ b/macos/Sources/Views/GitStatusHeaderView.swift
@@ -1,11 +1,11 @@
-/// Git status header content for the unified toolbar.
+/// Git status header view for the unified toolbar.
 ///
 /// Shows project name, branch name, and ahead/behind indicators. Rendered
 /// inside the shared toolbar row so it shares the same background as the tab bar.
 
 import SwiftUI
 
-struct GitStatusHeaderContent: View {
+struct GitStatusHeaderView: View {
     let state: GitStatusState
     let theme: ThemeColors
     let projectName: String

--- a/macos/Sources/Views/Modifiers/PointingHandModifier.swift
+++ b/macos/Sources/Views/Modifiers/PointingHandModifier.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct PointingHandModifier: ViewModifier {
+    var isEnabled: Bool = true
+    @State private var isHovered = false
+    @State private var didPushCursor = false
+
+    func body(content: Content) -> some View {
+        content
+            .onHover { hovering in
+                isHovered = hovering
+                syncCursor()
+            }
+            .onChange(of: isEnabled) { _, _ in
+                syncCursor()
+            }
+            .onDisappear {
+                if didPushCursor {
+                    NSCursor.pop()
+                    didPushCursor = false
+                }
+            }
+    }
+
+    private func syncCursor() {
+        let shouldPush = isHovered && isEnabled
+
+        if shouldPush && !didPushCursor {
+            NSCursor.pointingHand.push()
+            didPushCursor = true
+        } else if !shouldPush && didPushCursor {
+            NSCursor.pop()
+            didPushCursor = false
+        }
+    }
+}
+
+extension View {
+    func pointingHandCursor(isEnabled: Bool = true) -> some View {
+        modifier(PointingHandModifier(isEnabled: isEnabled))
+    }
+}

--- a/macos/Sources/Views/NativeSidebarRegistry.swift
+++ b/macos/Sources/Views/NativeSidebarRegistry.swift
@@ -45,7 +45,7 @@ enum NativeSidebarRegistry {
         kind: "file_tree",
         fallbackIcon: "folder",
         makeHeader: { context, _ in
-            AnyView(FileTreeHeaderContent(
+            AnyView(FileTreeHeaderView(
                 fileTreeState: context.guiState.fileTreeState,
                 theme: context.theme,
                 encoder: context.encoder,
@@ -70,7 +70,7 @@ enum NativeSidebarRegistry {
         kind: "git_status",
         fallbackIcon: "point.3.filled.connected.trianglepath.dotted",
         makeHeader: { context, _ in
-            AnyView(GitStatusHeaderContent(
+            AnyView(GitStatusHeaderView(
                 state: context.guiState.gitStatusState,
                 theme: context.theme,
                 projectName: context.projectName,

--- a/macos/Sources/Views/SidebarHeaderButton.swift
+++ b/macos/Sources/Views/SidebarHeaderButton.swift
@@ -43,7 +43,7 @@ struct SidebarHeaderButton: View {
                     isHovered = hovering
                 }
             }
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
         }
+        .pointingHandCursor()
     }
 }

--- a/macos/Sources/Views/StatusBarState.swift
+++ b/macos/Sources/Views/StatusBarState.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+@MainActor
+@Observable
+final class StatusBarState {
+    /// 0 = buffer window, 1 = agent chat window.
+    var contentKind: UInt8 = 0
+    var mode: UInt8 = 0
+    var cursorLine: UInt32 = 1
+    var cursorCol: UInt32 = 1
+    var lineCount: UInt32 = 1
+    var flags: UInt8 = 0
+    var safeMode: Bool = false
+    var lspStatus: UInt8 = 0
+    var gitBranch: String = ""
+    var message: String = ""
+    var filetype: String = ""
+    var errorCount: UInt16 = 0
+    var warningCount: UInt16 = 0
+    // Agent-only fields
+    var modelName: String = ""
+    var messageCount: UInt32 = 0
+    var sessionStatus: UInt8 = 0
+    // Extended fields (TUI modeline parity)
+    var infoCount: UInt16 = 0
+    var hintCount: UInt16 = 0
+    var macroRecording: UInt8 = 0
+    var parserStatus: UInt8 = 0
+    var agentStatus: UInt8 = 0
+    var activeToolName: String = ""
+    var gitAdded: UInt16 = 0
+    var gitModified: UInt16 = 0
+    var gitDeleted: UInt16 = 0
+    var icon: String = ""
+    var iconColorR: UInt8 = 0
+    var iconColorG: UInt8 = 0
+    var iconColorB: UInt8 = 0
+    var filename: String = ""
+    var diagnosticHint: String = ""
+    var backgroundSubagentCount: UInt16 = 0
+    var backgroundSubagentLabel: String = ""
+    var indent: StatusBarUpdate.IndentInfo = .init(kind: 0, size: 2)
+    var modelineSegmentsPresent: Bool = false
+    var modelineLeftSegments: [Wire.StatusBarSegment] = []
+    var modelineRightSegments: [Wire.StatusBarSegment] = []
+    var selection: StatusBarUpdate.SelectionInfo = .init(mode: 0, size: 0)
+
+    /// Updates status bar properties, guarding each assignment with an
+    /// equality check to prevent redundant `@Observable` notifications.
+    /// During j/k scroll, only cursorLine changes; the other ~25 fields
+    /// stay the same. Without guards, every write fires a notification
+    /// that invalidates the SwiftUI sub-view reading that property.
+    func update(from data: StatusBarUpdate) {
+        if self.contentKind != data.contentKind { self.contentKind = data.contentKind }
+        if self.mode != data.mode { self.mode = data.mode }
+        if self.cursorLine != data.cursorLine { self.cursorLine = data.cursorLine }
+        if self.cursorCol != data.cursorCol { self.cursorCol = data.cursorCol }
+        if self.lineCount != data.lineCount { self.lineCount = data.lineCount }
+        if self.flags != data.flags { self.flags = data.flags }
+        if self.safeMode != data.safeMode { self.safeMode = data.safeMode }
+        if self.lspStatus != data.lspStatus { self.lspStatus = data.lspStatus }
+        if self.gitBranch != data.gitBranch { self.gitBranch = data.gitBranch }
+        if self.message != data.message { self.message = data.message }
+        if self.filetype != data.filetype { self.filetype = data.filetype }
+        if self.errorCount != data.errorCount { self.errorCount = data.errorCount }
+        if self.warningCount != data.warningCount { self.warningCount = data.warningCount }
+        if self.modelName != data.modelName { self.modelName = data.modelName }
+        if self.messageCount != data.messageCount { self.messageCount = data.messageCount }
+        if self.sessionStatus != data.sessionStatus { self.sessionStatus = data.sessionStatus }
+        if self.infoCount != data.infoCount { self.infoCount = data.infoCount }
+        if self.hintCount != data.hintCount { self.hintCount = data.hintCount }
+        if self.macroRecording != data.macroRecording { self.macroRecording = data.macroRecording }
+        if self.parserStatus != data.parserStatus { self.parserStatus = data.parserStatus }
+        if self.agentStatus != data.agentStatus { self.agentStatus = data.agentStatus }
+        if self.activeToolName != data.activeToolName { self.activeToolName = data.activeToolName }
+        if self.gitAdded != data.gitAdded { self.gitAdded = data.gitAdded }
+        if self.gitModified != data.gitModified { self.gitModified = data.gitModified }
+        if self.gitDeleted != data.gitDeleted { self.gitDeleted = data.gitDeleted }
+        if self.icon != data.icon { self.icon = data.icon }
+        if self.iconColorR != data.iconColorR { self.iconColorR = data.iconColorR }
+        if self.iconColorG != data.iconColorG { self.iconColorG = data.iconColorG }
+        if self.iconColorB != data.iconColorB { self.iconColorB = data.iconColorB }
+        if self.filename != data.filename { self.filename = data.filename }
+        if self.diagnosticHint != data.diagnosticHint { self.diagnosticHint = data.diagnosticHint }
+        if self.backgroundSubagentCount != data.backgroundSubagentCount { self.backgroundSubagentCount = data.backgroundSubagentCount }
+        if self.backgroundSubagentLabel != data.backgroundSubagentLabel { self.backgroundSubagentLabel = data.backgroundSubagentLabel }
+        if self.indent != data.indent { self.indent = data.indent }
+        let hasModelineSegments = data.modelineSegmentsPresent || !data.modelineLeftSegments.isEmpty || !data.modelineRightSegments.isEmpty
+        if self.modelineSegmentsPresent != hasModelineSegments { self.modelineSegmentsPresent = hasModelineSegments }
+        if self.modelineLeftSegments != data.modelineLeftSegments { self.modelineLeftSegments = data.modelineLeftSegments }
+        if self.modelineRightSegments != data.modelineRightSegments { self.modelineRightSegments = data.modelineRightSegments }
+        if self.selection != data.selection { self.selection = data.selection }
+    }
+
+    var modeName: String {
+        switch mode {
+        case 0: return "NORMAL"
+        case 1: return "INSERT"
+        case 2: return "VISUAL"
+        case 3: return "COMMAND"
+        case 4: return "O-PENDING"
+        case 5: return "SEARCH"
+        case 6: return "REPLACE"
+        default: return "NORMAL"
+        }
+    }
+
+    var hasGit: Bool { flags & 0x02 != 0 }
+    var hasLsp: Bool { flags & 0x01 != 0 }
+    var isDirty: Bool { flags & 0x04 != 0 }
+    var isInsertMode: Bool { mode == 1 }
+    var isAgentWindow: Bool { contentKind == 1 }
+    var isRecordingMacro: Bool { macroRecording > 0 }
+    var hasGitDiffStats: Bool { gitAdded > 0 || gitModified > 0 || gitDeleted > 0 }
+    var hasRunningBackgroundSubagents: Bool { backgroundSubagentCount > 0 }
+    var isSafeMode: Bool { safeMode }
+
+    /// The macro register character (a-z), or nil if not recording.
+    var macroRegister: Character? {
+        guard macroRecording > 0, macroRecording <= 26 else { return nil }
+        return Character(UnicodeScalar(96 + macroRecording))
+    }
+
+    /// Titleized filetype for display (e.g., "elixir" -> "Elixir", "c_sharp" -> "C Sharp").
+    var filetypeDisplay: String {
+        filetype
+            .replacingOccurrences(of: "_", with: " ")
+            .split(separator: " ")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+
+    /// Icon color as a SwiftUI Color from the 24-bit RGB components.
+    var iconColor: Color {
+        Color(
+            red: Double(iconColorR) / 255.0,
+            green: Double(iconColorG) / 255.0,
+            blue: Double(iconColorB) / 255.0
+        )
+    }
+
+    var sessionStatusName: String {
+        switch sessionStatus {
+        case 0: return "idle"
+        case 1: return "thinking"
+        case 2: return "executing"
+        case 3: return "error"
+        case 4: return "plan"
+        default: return "idle"
+        }
+    }
+}

--- a/macos/Sources/Views/StatusBarView.swift
+++ b/macos/Sources/Views/StatusBarView.swift
@@ -25,158 +25,6 @@ private extension StatusBarUpdate.SelectionInfo {
     }
 }
 
-
-@MainActor
-@Observable
-final class StatusBarState {
-    /// 0 = buffer window, 1 = agent chat window.
-    var contentKind: UInt8 = 0
-    var mode: UInt8 = 0
-    var cursorLine: UInt32 = 1
-    var cursorCol: UInt32 = 1
-    var lineCount: UInt32 = 1
-    var flags: UInt8 = 0
-    var safeMode: Bool = false
-    var lspStatus: UInt8 = 0
-    var gitBranch: String = ""
-    var message: String = ""
-    var filetype: String = ""
-    var errorCount: UInt16 = 0
-    var warningCount: UInt16 = 0
-    // Agent-only fields
-    var modelName: String = ""
-    var messageCount: UInt32 = 0
-    var sessionStatus: UInt8 = 0
-    // Extended fields (TUI modeline parity)
-    var infoCount: UInt16 = 0
-    var hintCount: UInt16 = 0
-    var macroRecording: UInt8 = 0
-    var parserStatus: UInt8 = 0
-    var agentStatus: UInt8 = 0
-    var activeToolName: String = ""
-    var gitAdded: UInt16 = 0
-    var gitModified: UInt16 = 0
-    var gitDeleted: UInt16 = 0
-    var icon: String = ""
-    var iconColorR: UInt8 = 0
-    var iconColorG: UInt8 = 0
-    var iconColorB: UInt8 = 0
-    var filename: String = ""
-    var diagnosticHint: String = ""
-    var backgroundSubagentCount: UInt16 = 0
-    var backgroundSubagentLabel: String = ""
-    var indent: StatusBarUpdate.IndentInfo = .init(kind: 0, size: 2)
-    var modelineSegmentsPresent: Bool = false
-    var modelineLeftSegments: [Wire.StatusBarSegment] = []
-    var modelineRightSegments: [Wire.StatusBarSegment] = []
-    var selection: StatusBarUpdate.SelectionInfo = .init(mode: 0, size: 0)
-
-    /// Updates status bar properties, guarding each assignment with an
-    /// equality check to prevent redundant `@Observable` notifications.
-    /// During j/k scroll, only cursorLine changes; the other ~25 fields
-    /// stay the same. Without guards, every write fires a notification
-    /// that invalidates the SwiftUI sub-view reading that property.
-    func update(from data: StatusBarUpdate) {
-        if self.contentKind != data.contentKind { self.contentKind = data.contentKind }
-        if self.mode != data.mode { self.mode = data.mode }
-        if self.cursorLine != data.cursorLine { self.cursorLine = data.cursorLine }
-        if self.cursorCol != data.cursorCol { self.cursorCol = data.cursorCol }
-        if self.lineCount != data.lineCount { self.lineCount = data.lineCount }
-        if self.flags != data.flags { self.flags = data.flags }
-        if self.safeMode != data.safeMode { self.safeMode = data.safeMode }
-        if self.lspStatus != data.lspStatus { self.lspStatus = data.lspStatus }
-        if self.gitBranch != data.gitBranch { self.gitBranch = data.gitBranch }
-        if self.message != data.message { self.message = data.message }
-        if self.filetype != data.filetype { self.filetype = data.filetype }
-        if self.errorCount != data.errorCount { self.errorCount = data.errorCount }
-        if self.warningCount != data.warningCount { self.warningCount = data.warningCount }
-        if self.modelName != data.modelName { self.modelName = data.modelName }
-        if self.messageCount != data.messageCount { self.messageCount = data.messageCount }
-        if self.sessionStatus != data.sessionStatus { self.sessionStatus = data.sessionStatus }
-        if self.infoCount != data.infoCount { self.infoCount = data.infoCount }
-        if self.hintCount != data.hintCount { self.hintCount = data.hintCount }
-        if self.macroRecording != data.macroRecording { self.macroRecording = data.macroRecording }
-        if self.parserStatus != data.parserStatus { self.parserStatus = data.parserStatus }
-        if self.agentStatus != data.agentStatus { self.agentStatus = data.agentStatus }
-        if self.activeToolName != data.activeToolName { self.activeToolName = data.activeToolName }
-        if self.gitAdded != data.gitAdded { self.gitAdded = data.gitAdded }
-        if self.gitModified != data.gitModified { self.gitModified = data.gitModified }
-        if self.gitDeleted != data.gitDeleted { self.gitDeleted = data.gitDeleted }
-        if self.icon != data.icon { self.icon = data.icon }
-        if self.iconColorR != data.iconColorR { self.iconColorR = data.iconColorR }
-        if self.iconColorG != data.iconColorG { self.iconColorG = data.iconColorG }
-        if self.iconColorB != data.iconColorB { self.iconColorB = data.iconColorB }
-        if self.filename != data.filename { self.filename = data.filename }
-        if self.diagnosticHint != data.diagnosticHint { self.diagnosticHint = data.diagnosticHint }
-        if self.backgroundSubagentCount != data.backgroundSubagentCount { self.backgroundSubagentCount = data.backgroundSubagentCount }
-        if self.backgroundSubagentLabel != data.backgroundSubagentLabel { self.backgroundSubagentLabel = data.backgroundSubagentLabel }
-        if self.indent != data.indent { self.indent = data.indent }
-        let hasModelineSegments = data.modelineSegmentsPresent || !data.modelineLeftSegments.isEmpty || !data.modelineRightSegments.isEmpty
-        if self.modelineSegmentsPresent != hasModelineSegments { self.modelineSegmentsPresent = hasModelineSegments }
-        if self.modelineLeftSegments != data.modelineLeftSegments { self.modelineLeftSegments = data.modelineLeftSegments }
-        if self.modelineRightSegments != data.modelineRightSegments { self.modelineRightSegments = data.modelineRightSegments }
-        if self.selection != data.selection { self.selection = data.selection }
-    }
-
-    var modeName: String {
-        switch mode {
-        case 0: return "NORMAL"
-        case 1: return "INSERT"
-        case 2: return "VISUAL"
-        case 3: return "COMMAND"
-        case 4: return "O-PENDING"
-        case 5: return "SEARCH"
-        case 6: return "REPLACE"
-        default: return "NORMAL"
-        }
-    }
-
-    var hasGit: Bool { flags & 0x02 != 0 }
-    var hasLsp: Bool { flags & 0x01 != 0 }
-    var isDirty: Bool { flags & 0x04 != 0 }
-    var isInsertMode: Bool { mode == 1 }
-    var isAgentWindow: Bool { contentKind == 1 }
-    var isRecordingMacro: Bool { macroRecording > 0 }
-    var hasGitDiffStats: Bool { gitAdded > 0 || gitModified > 0 || gitDeleted > 0 }
-    var hasRunningBackgroundSubagents: Bool { backgroundSubagentCount > 0 }
-    var isSafeMode: Bool { safeMode }
-
-    /// The macro register character (a-z), or nil if not recording.
-    var macroRegister: Character? {
-        guard macroRecording > 0, macroRecording <= 26 else { return nil }
-        return Character(UnicodeScalar(96 + macroRecording))
-    }
-
-    /// Titleized filetype for display (e.g., "elixir" → "Elixir", "c_sharp" → "C Sharp").
-    var filetypeDisplay: String {
-        filetype
-            .replacingOccurrences(of: "_", with: " ")
-            .split(separator: " ")
-            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
-            .joined(separator: " ")
-    }
-
-    /// Icon color as a SwiftUI Color from the 24-bit RGB components.
-    var iconColor: Color {
-        Color(
-            red: Double(iconColorR) / 255.0,
-            green: Double(iconColorG) / 255.0,
-            blue: Double(iconColorB) / 255.0
-        )
-    }
-
-    var sessionStatusName: String {
-        switch sessionStatus {
-        case 0: return "idle"
-        case 1: return "thinking"
-        case 2: return "executing"
-        case 3: return "error"
-        case 4: return "plan"
-        default: return "idle"
-        }
-    }
-}
-
 private struct StatusBarSegmentGroup: Identifiable {
     let id: String
     let kind: String
@@ -282,7 +130,7 @@ struct StatusBarView: View {
             .help(tooltip)
             .accessibilityLabel(tooltip)
             .accessibilityHint("Runs the status bar action")
-            .statusBarPointingHand()
+            .pointingHandCursor()
         } else {
             content()
                 .help(tooltip)
@@ -472,7 +320,7 @@ struct StatusBarView: View {
         .accessibilityLabel(backgroundSubagentText)
         .accessibilityHint("Switches to a background sub-agent session")
         .padding(.horizontal, 6)
-        .statusBarPointingHand()
+        .pointingHandCursor()
     }
 
     private var backgroundSubagentText: String {
@@ -529,7 +377,7 @@ struct StatusBarView: View {
         .accessibilityLabel("Git branch \(state.gitBranch)")
         .accessibilityHint("Opens the branch picker")
         .padding(.horizontal, 6)
-        .statusBarPointingHand()
+        .pointingHandCursor()
     }
 
     @ViewBuilder
@@ -587,7 +435,7 @@ struct StatusBarView: View {
             .accessibilityLabel(diagnosticsAccessibilityLabel)
             .accessibilityHint("Shows diagnostics")
             .padding(.horizontal, 4)
-            .statusBarPointingHand()
+            .pointingHandCursor()
         }
     }
 
@@ -654,7 +502,7 @@ struct StatusBarView: View {
         .help("Indent settings")
         .accessibilityLabel("Indent settings: \(state.indent.label) \(state.indent.size)")
         .accessibilityHint("Changes indentation settings")
-        .statusBarPointingHand()
+        .pointingHandCursor()
     }
 
     @ViewBuilder
@@ -677,7 +525,7 @@ struct StatusBarView: View {
         .help("Change language mode (SPC b l)")
         .accessibilityLabel("Language mode \(state.filetypeDisplay)")
         .accessibilityHint("Changes language mode")
-        .statusBarPointingHand()
+        .pointingHandCursor()
     }
 
     @ViewBuilder
@@ -705,7 +553,7 @@ struct StatusBarView: View {
             .help("Buffer list")
             .accessibilityLabel("Buffer \(displayText)")
             .accessibilityHint("Opens the buffer list")
-            .statusBarPointingHand()
+            .pointingHandCursor()
         }
     }
 
@@ -1058,7 +906,7 @@ private struct StatusBarModelineSegmentView: View {
             .help(accessibilityHelp)
             .accessibilityLabel(trimmedDisplayText)
             .accessibilityHint(accessibilityHint)
-            .statusBarPointingHand()
+            .pointingHandCursor()
         }
     }
 
@@ -1133,35 +981,6 @@ private struct StatusBarModelineSegmentView: View {
     }
 }
 
-private struct StatusBarPointingHandModifier: ViewModifier {
-    @State private var didPushCursor = false
-
-    func body(content: Content) -> some View {
-        content
-            .onHover { hovering in
-                if hovering, !didPushCursor {
-                    NSCursor.pointingHand.push()
-                    didPushCursor = true
-                } else if !hovering, didPushCursor {
-                    NSCursor.pop()
-                    didPushCursor = false
-                }
-            }
-            .onDisappear {
-                if didPushCursor {
-                    NSCursor.pop()
-                    didPushCursor = false
-                }
-            }
-    }
-}
-
-private extension View {
-    func statusBarPointingHand() -> some View {
-        modifier(StatusBarPointingHandModifier())
-    }
-}
-
 // MARK: - Reusable toolbar-style icon button with hover highlight
 
 /// A compact icon button that shows a subtle rounded-rect fill on hover,
@@ -1218,7 +1037,7 @@ private struct StatusBarIconButton: View {
                 }
             }
         }
-        .statusBarPointingHand()
+        .pointingHandCursor()
     }
 }
 

--- a/macos/Sources/Views/TabBarState.swift
+++ b/macos/Sources/Views/TabBarState.swift
@@ -149,6 +149,82 @@ final class TabBarState {
         )
     }
 
+    // MARK: - Display tabs
+
+    var displayTabs: [TabEntry] {
+        if hasCanonicalWorkspaceTabs {
+            return workspaceTabs.enumerated().map { index, tab in
+                TabEntry(
+                    id: tab.id,
+                    groupId: tab.workspaceId,
+                    isActive: index == Int(activeIndex),
+                    isDirty: tab.isDirty,
+                    isAgent: tab.isAgent,
+                    hasAttention: tab.hasAttention,
+                    agentStatus: 0,
+                    isPinned: tab.isPinned,
+                    tintColor: tab.tintColor,
+                    icon: tab.icon,
+                    label: tab.label
+                )
+            }
+        }
+
+        return tabs
+    }
+
+    // MARK: - Tab ordering
+
+    func canMoveTabLeft(_ tab: TabEntry) -> Bool {
+        guard let index = movableFileTabIndex(for: tab) else { return false }
+        return index > 0
+    }
+
+    func canMoveTabRight(_ tab: TabEntry) -> Bool {
+        guard let index = movableFileTabIndex(for: tab) else { return false }
+        return index < movableFileTabs(for: tab).count - 1
+    }
+
+    func tabDropReorder(droppedTabs: [TabDragPayload], target tab: TabEntry, visibleIndex _: Int) -> (id: UInt32, newIndex: UInt16)? {
+        guard let draggedId = droppedTabs.first?.id,
+              draggedId != tab.id else {
+            return nil
+        }
+        guard let draggedTab = displayTabs.first(where: { $0.id == draggedId }),
+              draggedTab.groupId == tab.groupId,
+              draggedTab.isPinned == tab.isPinned else {
+            return nil
+        }
+        guard let newIndex = visibleFileTabIndex(for: tab) else {
+            return nil
+        }
+        return (draggedId, UInt16(newIndex))
+    }
+
+    func movableFileTabIndex(for tab: TabEntry) -> Int? {
+        movableFileTabs(for: tab).firstIndex { $0.id == tab.id }
+    }
+
+    func visibleFileTabIndex(for tab: TabEntry) -> Int? {
+        visibleFileTabs(for: tab).firstIndex { $0.id == tab.id }
+    }
+
+    private func movableTabs(for tab: TabEntry) -> [TabEntry] {
+        displayTabs.filter { candidate in
+            candidate.groupId == tab.groupId && candidate.isPinned == tab.isPinned
+        }
+    }
+
+    private func movableFileTabs(for tab: TabEntry) -> [TabEntry] {
+        movableTabs(for: tab).filter { !$0.isAgent }
+    }
+
+    private func visibleFileTabs(for tab: TabEntry) -> [TabEntry] {
+        displayTabs.filter { candidate in
+            candidate.groupId == tab.groupId && !candidate.isAgent
+        }
+    }
+
     /// Clear all tab state.
     func hide() {
         tabs = []

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -105,9 +105,7 @@ struct TabBarView: View {
             .menuIndicator(.hidden)
             .frame(width: 28)
             .help("New file or agent session")
-            .onHover { isHovered in
-                if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
+            .pointingHandCursor()
 
             // Window split buttons
             tabBarButton(
@@ -156,25 +154,7 @@ struct TabBarView: View {
     }
 
     private var displayTabs: [TabEntry] {
-        if tabBarState.hasCanonicalWorkspaceTabs {
-            return tabBarState.workspaceTabs.enumerated().map { index, tab in
-                TabEntry(
-                    id: tab.id,
-                    groupId: tab.workspaceId,
-                    isActive: index == Int(tabBarState.activeIndex),
-                    isDirty: tab.isDirty,
-                    isAgent: tab.isAgent,
-                    hasAttention: tab.hasAttention,
-                    agentStatus: 0,
-                    isPinned: tab.isPinned,
-                    tintColor: tab.tintColor,
-                    icon: tab.icon,
-                    label: tab.label
-                )
-            }
-        }
-
-        return tabBarState.tabs
+        tabBarState.displayTabs
     }
 
     func performTabContextMenuAction(_ action: TabContextMenuAction, for tab: TabEntry) {
@@ -190,69 +170,19 @@ struct TabBarView: View {
         }
     }
 
-    func canMoveTabLeft(_ tab: TabEntry) -> Bool {
-        guard let index = movableFileTabIndex(for: tab) else { return false }
-        return index > 0
-    }
-
-    func canMoveTabRight(_ tab: TabEntry) -> Bool {
-        guard let index = movableFileTabIndex(for: tab) else { return false }
-        return index < movableFileTabs(for: tab).count - 1
-    }
-
     func tabContextMenuMoveItems(for tab: TabEntry) -> [TabContextMenuMoveItem] {
         [
-            TabContextMenuMoveItem(id: .moveLeft, title: "Move Tab Left", isDisabled: !canMoveTabLeft(tab)),
-            TabContextMenuMoveItem(id: .moveRight, title: "Move Tab Right", isDisabled: !canMoveTabRight(tab))
+            TabContextMenuMoveItem(id: .moveLeft, title: "Move Tab Left", isDisabled: !tabBarState.canMoveTabLeft(tab)),
+            TabContextMenuMoveItem(id: .moveRight, title: "Move Tab Right", isDisabled: !tabBarState.canMoveTabRight(tab))
         ]
     }
 
     func handleTabDrop(droppedTabs: [TabDragPayload], target tab: TabEntry, visibleIndex: Int) -> Bool {
-        guard let reorder = tabDropReorder(droppedTabs: droppedTabs, target: tab, visibleIndex: visibleIndex) else {
+        guard let reorder = tabBarState.tabDropReorder(droppedTabs: droppedTabs, target: tab, visibleIndex: visibleIndex) else {
             return false
         }
         encoder?.sendTabReorder(id: reorder.id, newIndex: reorder.newIndex)
         return true
-    }
-
-    func tabDropReorder(droppedTabs: [TabDragPayload], target tab: TabEntry, visibleIndex _: Int) -> (id: UInt32, newIndex: UInt16)? {
-        guard let draggedId = droppedTabs.first?.id,
-              draggedId != tab.id else {
-            return nil
-        }
-        guard let draggedTab = displayTabs.first(where: { $0.id == draggedId }),
-              draggedTab.groupId == tab.groupId,
-              draggedTab.isPinned == tab.isPinned else {
-            return nil
-        }
-        guard let newIndex = visibleFileTabIndex(for: tab) else {
-            return nil
-        }
-        return (draggedId, UInt16(newIndex))
-    }
-
-    func movableFileTabIndex(for tab: TabEntry) -> Int? {
-        movableFileTabs(for: tab).firstIndex { $0.id == tab.id }
-    }
-
-    func visibleFileTabIndex(for tab: TabEntry) -> Int? {
-        visibleFileTabs(for: tab).firstIndex { $0.id == tab.id }
-    }
-
-    private func movableTabs(for tab: TabEntry) -> [TabEntry] {
-        displayTabs.filter { candidate in
-            candidate.groupId == tab.groupId && candidate.isPinned == tab.isPinned
-        }
-    }
-
-    private func movableFileTabs(for tab: TabEntry) -> [TabEntry] {
-        movableTabs(for: tab).filter { !$0.isAgent }
-    }
-
-    private func visibleFileTabs(for tab: TabEntry) -> [TabEntry] {
-        displayTabs.filter { candidate in
-            candidate.groupId == tab.groupId && !candidate.isAgent
-        }
     }
 
     // MARK: - Tab strip layouts
@@ -342,12 +272,7 @@ struct TabBarView: View {
         .buttonStyle(.plain)
         .accessibilityLabel("Switch to workspace \(workspace.label)")
         .help("Switch to workspace")
-        .onHover { isHovered in
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
-        .onDisappear {
-            NSCursor.pop()
-        }
+        .pointingHandCursor()
         .contextMenu {
             Button("Switch to Workspace") {
                 encoder?.sendExecuteCommand(name: workspaceGotoCommand(for: workspace))
@@ -734,9 +659,7 @@ struct TabBarView: View {
         }
         .buttonStyle(.plain)
         .help("Close tab")
-        .onHover { isHovered in
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
+        .pointingHandCursor()
     }
 
     @ViewBuilder
@@ -753,9 +676,7 @@ struct TabBarView: View {
         }
         .buttonStyle(.plain)
         .help(tooltip)
-        .onHover { isHovered in
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
+        .pointingHandCursor()
     }
 
     private var verticalSeparator: some View {

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -223,7 +223,7 @@ struct GitStatusViewEmptyStateTests {
 
 // MARK: - GitStatusView Branch Header
 
-@Suite("GitStatusHeaderContent Branch Header")
+@Suite("GitStatusHeaderView Branch Header")
 struct GitStatusViewBranchHeaderTests {
 
     @Test("Branch header shows project and branch name")
@@ -232,7 +232,7 @@ struct GitStatusViewBranchHeaderTests {
         state.repoState = .normal
         state.branchName = "feat/sidebar-polish"
 
-        let sut = GitStatusHeaderContent(state: state, theme: ThemeColors(), projectName: "minga", leadingPadding: 10)
+        let sut = GitStatusHeaderView(state: state, theme: ThemeColors(), projectName: "minga", leadingPadding: 10)
         let body = try sut.inspect()
         let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
 
@@ -246,7 +246,7 @@ struct GitStatusViewBranchHeaderTests {
         state.repoState = .normal
         state.branchName = ""
 
-        let sut = GitStatusHeaderContent(state: state, theme: ThemeColors(), projectName: "minga", leadingPadding: 10)
+        let sut = GitStatusHeaderView(state: state, theme: ThemeColors(), projectName: "minga", leadingPadding: 10)
         let body = try sut.inspect()
         let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
 
@@ -260,7 +260,7 @@ struct GitStatusViewBranchHeaderTests {
         state.branchName = "main"
         state.stashCount = 2
 
-        let sut = GitStatusHeaderContent(state: state, theme: ThemeColors(), projectName: "minga", leadingPadding: 10)
+        let sut = GitStatusHeaderView(state: state, theme: ThemeColors(), projectName: "minga", leadingPadding: 10)
         let body = try sut.inspect()
         let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
 
@@ -279,7 +279,7 @@ struct FileTreeViewTests {
         state.visible = true
         state.projectRoot = "/Users/test/code/minga"
 
-        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "main", leadingPadding: 10)
+        let sut = FileTreeHeaderView(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "main", leadingPadding: 10)
         let body = try sut.inspect()
         let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
 
@@ -293,7 +293,7 @@ struct FileTreeViewTests {
         state.visible = true
         state.projectRoot = ""
 
-        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "", leadingPadding: 10)
+        let sut = FileTreeHeaderView(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "", leadingPadding: 10)
         let body = try sut.inspect()
         let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
 
@@ -305,7 +305,7 @@ struct FileTreeViewTests {
         let state = FileTreeState()
         state.visible = true
 
-        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "", leadingPadding: 10)
+        let sut = FileTreeHeaderView(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "", leadingPadding: 10)
         let body = try sut.inspect()
         let buttons = body.findAll(ViewType.Button.self)
         #expect(buttons.count == 4)
@@ -318,7 +318,7 @@ struct FileTreeViewTests {
         state.selectedIndex = 7
         let spy = SpyEncoder()
 
-        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: spy, branchName: "main", leadingPadding: 10)
+        let sut = FileTreeHeaderView(fileTreeState: state, theme: ThemeColors(), encoder: spy, branchName: "main", leadingPadding: 10)
         let buttons = try sut.inspect().findAll(ViewType.Button.self)
 
         try buttons[0].tap()
@@ -340,7 +340,7 @@ struct FileTreeViewTests {
         state.visible = true
         state.projectRoot = "/Users/test/code/minga"
 
-        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "main", leadingPadding: 10)
+        let sut = FileTreeHeaderView(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "main", leadingPadding: 10)
 
         #expect(sut.accessibilityLabelText == "File tree for minga, branch main")
     }

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -787,18 +787,17 @@ struct TabBarViewViewTests {
             wireTab(id: 4),
             wireTab(id: 5, groupId: 1),
         ])
-        let sut = TabBarView(tabBarState: state, theme: ThemeColors(), encoder: nil)
 
-        #expect(!sut.canMoveTabLeft(tab(id: 1, isActive: true, isPinned: true)))
-        #expect(sut.canMoveTabRight(tab(id: 1, isActive: true, isPinned: true)))
-        #expect(sut.canMoveTabLeft(tab(id: 2, isPinned: true)))
-        #expect(!sut.canMoveTabRight(tab(id: 2, isPinned: true)))
-        #expect(!sut.canMoveTabLeft(tab(id: 3)))
-        #expect(sut.canMoveTabRight(tab(id: 3)))
-        #expect(sut.canMoveTabLeft(tab(id: 4)))
-        #expect(!sut.canMoveTabRight(tab(id: 4)))
-        #expect(!sut.canMoveTabLeft(tab(id: 5, groupId: 1)))
-        #expect(!sut.canMoveTabRight(tab(id: 5, groupId: 1)))
+        #expect(!state.canMoveTabLeft(tab(id: 1, isActive: true, isPinned: true)))
+        #expect(state.canMoveTabRight(tab(id: 1, isActive: true, isPinned: true)))
+        #expect(state.canMoveTabLeft(tab(id: 2, isPinned: true)))
+        #expect(!state.canMoveTabRight(tab(id: 2, isPinned: true)))
+        #expect(!state.canMoveTabLeft(tab(id: 3)))
+        #expect(state.canMoveTabRight(tab(id: 3)))
+        #expect(state.canMoveTabLeft(tab(id: 4)))
+        #expect(!state.canMoveTabRight(tab(id: 4)))
+        #expect(!state.canMoveTabLeft(tab(id: 5, groupId: 1)))
+        #expect(!state.canMoveTabRight(tab(id: 5, groupId: 1)))
     }
 
     @Test("Tab context menu move actions use bucket edge rules")
@@ -840,19 +839,19 @@ struct TabBarViewViewTests {
         #expect(TabDragPayload.contentType.identifier == "com.minga.tab-id")
         #expect(TabDragPayload.contentType != UTType.plainText)
 
-        if let reorder = sut.tabDropReorder(droppedTabs: [], target: target, visibleIndex: 1) {
+        if let reorder = state.tabDropReorder(droppedTabs: [], target: target, visibleIndex: 1) {
             Issue.record("Expected empty payload to be rejected, got \(reorder)")
         }
-        if let reorder = sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 5)], target: target, visibleIndex: 1) {
+        if let reorder = state.tabDropReorder(droppedTabs: [TabDragPayload(id: 5)], target: target, visibleIndex: 1) {
             Issue.record("Expected cross-workspace payload to be rejected, got \(reorder)")
         }
-        if let reorder = sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 1)], target: target, visibleIndex: 1) {
+        if let reorder = state.tabDropReorder(droppedTabs: [TabDragPayload(id: 1)], target: target, visibleIndex: 1) {
             Issue.record("Expected pinned-bucket mismatch to be rejected, got \(reorder)")
         }
 
         let dropTarget = tab(id: 4, label: "plain-2.ex")
-        #expect(sut.visibleFileTabIndex(for: dropTarget) == 3)
-        #expect(sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 3)], target: dropTarget, visibleIndex: 3)?.newIndex == 3)
+        #expect(state.visibleFileTabIndex(for: dropTarget) == 3)
+        #expect(state.tabDropReorder(droppedTabs: [TabDragPayload(id: 3)], target: dropTarget, visibleIndex: 3)?.newIndex == 3)
 
         let accepted = sut.handleTabDrop(droppedTabs: [TabDragPayload(id: 3)], target: dropTarget, visibleIndex: 3)
 
@@ -869,12 +868,10 @@ struct TabBarViewViewTests {
             wireTab(id: 3, label: "file-b.ex")
         ])
 
-        let sut = TabBarView(tabBarState: state, theme: ThemeColors(), encoder: nil)
-
-        #expect(sut.movableFileTabIndex(for: tab(id: 2, label: "file-a.ex")) == 0)
-        #expect(sut.movableFileTabIndex(for: tab(id: 3, label: "file-b.ex")) == 1)
-        #expect(sut.movableFileTabIndex(for: TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: true, hasAttention: false, agentStatus: 0, isPinned: false, tintColor: nil, icon: "cpu", label: "Agent")) == nil)
-        #expect(sut.tabDropReorder(droppedTabs: [TabDragPayload(id: 2)], target: tab(id: 3, label: "file-b.ex"), visibleIndex: 2)?.newIndex == 1)
+        #expect(state.movableFileTabIndex(for: tab(id: 2, label: "file-a.ex")) == 0)
+        #expect(state.movableFileTabIndex(for: tab(id: 3, label: "file-b.ex")) == 1)
+        #expect(state.movableFileTabIndex(for: TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: true, hasAttention: false, agentStatus: 0, isPinned: false, tintColor: nil, icon: "cpu", label: "Agent")) == nil)
+        #expect(state.tabDropReorder(droppedTabs: [TabDragPayload(id: 2)], target: tab(id: 3, label: "file-b.ex"), visibleIndex: 2)?.newIndex == 1)
     }
 
     @Test("Tab bar uses canonical active-workspace visible tabs")


### PR DESCRIPTION
## Summary

- Extract `StatusBarState` from `StatusBarView.swift` into its own file, restoring the `*State/*View` pairing every other feature follows
- Consolidate 16 inline `NSCursor.pointingHand.push()/pop()` call sites and 2 file-private `ViewModifier` implementations into a single shared `PointingHandModifier` at `Views/Modifiers/PointingHandModifier.swift`
- Rename `FileTreeHeaderContent` → `FileTreeHeaderView` and `GitStatusHeaderContent` → `GitStatusHeaderView` (files, types, callers)
- Move tab-ordering logic (`canMoveTabLeft`, `canMoveTabRight`, `tabDropReorder`, `movableFileTabIndex`, `visibleFileTabIndex`) from `TabBarView` to `TabBarState` for unit testability

## Test plan

- [x] `xcodegen generate` succeeds
- [x] `xcodebuild -scheme Minga -configuration Debug build` passes with zero errors
- [ ] Verify tab reordering (drag-drop, context menu Move Left/Right) still works
- [ ] Verify pointing hand cursor appears on hover for tab bar buttons, breadcrumb segments, status bar icons, agent chat header controls
- [ ] Verify collapsed workspace capsule cursor cleans up on disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)