### PR TITLE
fix: add VoiceOver accessibility to interactive elements

### DIFF
--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -290,6 +290,7 @@ struct ContentView: View {
             ZStack {
                 theme.tabBg
                 TitleBarDragRegion()
+                    .accessibilityHidden(true)
             }
         }
     }
@@ -414,6 +415,18 @@ struct ContentView: View {
                         NSCursor.resizeLeftRight.push()
                     } else {
                         NSCursor.pop()
+                    }
+                }
+                .accessibilityLabel("Change summary resize handle")
+                .accessibilityAdjustableAction { direction in
+                    let step: CGFloat = 20
+                    switch direction {
+                    case .increment:
+                        changeSummaryWidth = min(changeSummaryWidth + step, changeSummaryMaxWidth)
+                    case .decrement:
+                        changeSummaryWidth = max(changeSummaryWidth - step, changeSummaryMinWidth)
+                    @unknown default:
+                        break
                     }
                 }
         }

--- a/macos/Sources/Views/BreadcrumbBar.swift
+++ b/macos/Sources/Views/BreadcrumbBar.swift
@@ -40,19 +40,21 @@ struct BreadcrumbBar: View {
                             .padding(.horizontal, 4)
                     }
 
-                    Text(segment)
-                        .font(.system(size: 11.5))
-                        .foregroundStyle(
-                            index == state.segments.count - 1
-                                ? theme.breadcrumbFg
-                                : theme.breadcrumbFg.opacity(0.6)
-                        )
-                        .onTapGesture {
-                            encoder?.sendBreadcrumbClick(index: UInt8(index))
-                        }
-                        .onHover { isHovered in
-                            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                        }
+                    Button {
+                        encoder?.sendBreadcrumbClick(index: UInt8(index))
+                    } label: {
+                        Text(segment)
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(
+                                index == state.segments.count - 1
+                                    ? theme.breadcrumbFg
+                                    : theme.breadcrumbFg.opacity(0.6)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { isHovered in
+                        if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    }
                 }
 
                 Spacer()

--- a/macos/Sources/Views/ChangeSummaryView.swift
+++ b/macos/Sources/Views/ChangeSummaryView.swift
@@ -175,6 +175,8 @@ struct ChangeSummaryView: View {
         .onHover { hovering in
             hoveredEntryId = hovering ? entry.id : nil
         }
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel("\(entry.action.indicator) file: \(fileName(from: entry.path))")
         .onTapGesture {
             encoder?.sendChangeSummaryClick(index: UInt32(entry.id))
         }

--- a/macos/Sources/Views/CompletionOverlay.swift
+++ b/macos/Sources/Views/CompletionOverlay.swift
@@ -115,6 +115,7 @@ struct CompletionOverlay: View {
         .onHover { isHovered in
             hoveredItemId = isHovered ? item.id : nil
         }
+        .accessibilityAddTraits(.isButton)
         .onTapGesture {
             encoder?.sendCompletionSelect(index: UInt16(item.id))
         }

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -287,6 +287,7 @@ struct FileTreeView: View {
             fileTreeRow(entry, onActivate: { activateEntry(id: entry.id) })
                 .id(entry.id)
                 .contentShape(Rectangle())
+                .accessibilityAddTraits(.isButton)
                 .onTapGesture {
                     activateEntry(id: entry.id)
                 }

--- a/macos/Sources/Views/GitStatusView.swift
+++ b/macos/Sources/Views/GitStatusView.swift
@@ -223,6 +223,8 @@ struct GitStatusView: View {
         .padding(.horizontal, 10)
         .frame(height: sectionHeaderHeight)
         .contentShape(Rectangle())
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint(state.collapsedSections.contains(section) ? "Double tap to expand" : "Double tap to collapse")
         .onTapGesture {
             withAnimation(.easeInOut(duration: animDuration)) {
                 if state.collapsedSections.contains(section) {
@@ -324,6 +326,7 @@ struct GitStatusView: View {
             encoder?.sendGitOpenFile(path: entry.path)
         }
         .contextMenu { fileContextMenu(entry) }
+        .accessibilityAddTraits(.isButton)
         .accessibilityLabel("\(statusAccessibilityLabel(entry.status)) file: \(entry.filename)")
     }
 

--- a/macos/Sources/Views/Settings/AppearanceSettingsView.swift
+++ b/macos/Sources/Views/Settings/AppearanceSettingsView.swift
@@ -16,10 +16,12 @@ struct AppearanceSettingsView: View {
                 } else {
                     LazyVGrid(columns: columns, spacing: 12) {
                         ForEach(state.themePreviews) { preview in
-                            ThemeSwatch(preview: preview, selected: preview.atom == state.currentThemeName)
-                                .onTapGesture {
-                                    state.update(key: "theme", value: .atom(preview.atom))
-                                }
+                            Button {
+                                state.update(key: "theme", value: .atom(preview.atom))
+                            } label: {
+                                ThemeSwatch(preview: preview, selected: preview.atom == state.currentThemeName)
+                            }
+                            .buttonStyle(.plain)
                         }
                     }
                     .padding(.vertical, 4)

--- a/macos/Sources/Views/SidebarContainer.swift
+++ b/macos/Sources/Views/SidebarContainer.swift
@@ -104,5 +104,17 @@ struct SidebarContainer: View {
                     NSCursor.pop()
                 }
             }
+            .accessibilityLabel("Sidebar resize handle")
+            .accessibilityAdjustableAction { direction in
+                let step: CGFloat = 20
+                switch direction {
+                case .increment:
+                    sidebarWidth = SidebarSizing.clamp(sidebarWidth + step, for: activeSidebar)
+                case .decrement:
+                    sidebarWidth = SidebarSizing.clamp(sidebarWidth - step, for: activeSidebar)
+                @unknown default:
+                    break
+                }
+            }
     }
 }

--- a/macos/Sources/Views/SparklineView.swift
+++ b/macos/Sources/Views/SparklineView.swift
@@ -7,6 +7,15 @@ struct SparklineView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    private var accessibilityDescription: String {
+        guard !data.isEmpty, !data.allSatisfy({ $0 == 0.0 }) else {
+            return "Sparkline chart, no activity"
+        }
+        let peak = data.max() ?? 0
+        let avg = data.reduce(0, +) / Float(data.count)
+        return "Sparkline chart, \(data.count) points, peak \(Int(peak * 100))%, average \(Int(avg * 100))%"
+    }
+
     var body: some View {
         GeometryReader { geometry in
             if data.isEmpty || data.allSatisfy({ $0 == 0.0 }) {
@@ -61,5 +70,7 @@ struct SparklineView: View {
                 .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: data)
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
     }
 }

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -479,6 +479,7 @@ struct TabBarView: View {
         Circle()
             .fill(agentStatusColor(status, accent: color))
             .frame(width: 6, height: 6)
+            .accessibilityHidden(true)
     }
 
     private func agentStatusColor(_ status: UInt8, accent: Color) -> Color {


### PR DESCRIPTION
## Summary
- Add `.accessibilityLabel` and `.accessibilityAdjustableAction` to resize handles in `SidebarContainer` and `ContentView` change summary sidebar
- Hide decorative elements from VoiceOver: `TitleBarDragRegion` and `agentStatusDot` (parent buttons carry the semantic label)
- Add accessibility label to `SparklineView` with data summary (point count, peak, average)
- Convert `BreadcrumbBar` segments and `AppearanceSettingsView` theme swatches from `onTapGesture` to `Button` for native keyboard/VoiceOver support
- Add `.accessibilityAddTraits(.isButton)` to tappable list rows: `CompletionOverlay`, `FileTreeView`, `ChangeSummaryView`, `GitStatusView` (section headers and file rows)

Phase 6 of the [SwiftUI conventions remediation plan](https://github.com/jsmestad/minga/pull/2508).

## Test plan
- [ ] Build succeeds (verified locally)
- [ ] Enable VoiceOver (Cmd+F5) and verify resize handles are announced and adjustable with VO+Up/Down
- [ ] Verify breadcrumb segments are focusable and activatable via keyboard
- [ ] Verify SparklineView announces data summary
- [ ] Verify decorative dots and drag regions are skipped by VoiceOver

🤖 Generated with [Claude Code](https://claude.com/claude-code)