### PR TITLE
fix: Messages auto-open + stutter-free scroll overscan

### DIFF
--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -629,7 +629,7 @@ defmodule MingaEditor.Agent.Events do
     end
   catch
     :exit, reason ->
-      {state, [{:log_warning, "Failed to reload remote file #{path}: #{inspect(reason)}"}]}
+      {state, [{:log, :agent, :error, "Failed to reload remote file #{path}: #{inspect(reason)}"}]}
   end
 
   @spec reload_remote_buffer_content(EditorState.t(), pid(), String.t(), String.t()) ::

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -629,7 +629,8 @@ defmodule MingaEditor.Agent.Events do
     end
   catch
     :exit, reason ->
-      {state, [{:log, :agent, :error, "Failed to reload remote file #{path}: #{inspect(reason)}"}]}
+      {state,
+       [{:log, :agent, :error, "Failed to reload remote file #{path}: #{inspect(reason)}"}]}
   end
 
   @spec reload_remote_buffer_content(EditorState.t(), pid(), String.t(), String.t()) ::

--- a/lib/minga_editor/handlers/effect_handler.ex
+++ b/lib/minga_editor/handlers/effect_handler.ex
@@ -36,7 +36,7 @@ defmodule MingaEditor.Handlers.EffectHandler do
   * `{:push_overlay, module}` — push an overlay handler onto the focus stack
   * `{:pop_overlay, module}` — pop an overlay handler from the focus stack
   * `{:log_message, msg}` — log to *Messages* buffer
-  * `{:log_warning, msg}` — log to both *Messages* and *Warnings* (warning level)
+  * `{:log_warning, msg}` — log at warning level to *Messages* buffer
   * `{:log, subsystem, level, msg}` — log via Minga.Log
   * `:sync_agent_transcript` — sync semantic agent transcript with session output
   * `{:update_tab_label, label}` — update active tab label

--- a/lib/minga_editor/handlers/effect_handler.ex
+++ b/lib/minga_editor/handlers/effect_handler.ex
@@ -157,7 +157,7 @@ defmodule MingaEditor.Handlers.EffectHandler do
 
   defp apply_effect(state, {:log_warning, msg}) when is_binary(msg) do
     Minga.Log.warning(:editor, msg)
-    MingaEditor.maybe_schedule_warning_popup(state)
+    state
   end
 
   defp apply_effect(state, :sync_agent_transcript), do: AgentLifecycle.sync_transcript(state)

--- a/lib/minga_editor/handlers/event_dispatcher.ex
+++ b/lib/minga_editor/handlers/event_dispatcher.ex
@@ -102,7 +102,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
     state = MessageLog.append_to_store(state, text, level)
     state = MingaEditor.schedule_render(state, 16)
 
-    if level in [:warning, :error] do
+    if level == :error do
       MingaEditor.maybe_schedule_warning_popup(state)
     else
       state

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -30,6 +30,8 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   alias MingaEditor.Viewport
   alias MingaEditor.Window
 
+  @overscan_rows 50
+
   @typedoc "Render pipeline input."
   @type state :: Input.t()
 
@@ -329,20 +331,24 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
           {non_neg_integer(), non_neg_integer()}
   defp scroll_overscan_before(first_line, true), do: {0, first_line}
   defp scroll_overscan_before(0, false), do: {0, 0}
-  defp scroll_overscan_before(first_line, false), do: {1, first_line - 1}
+
+  defp scroll_overscan_before(first_line, false) do
+    count = min(@overscan_rows, first_line)
+    {count, first_line - count}
+  end
 
   @spec scroll_overscan_after(non_neg_integer(), pos_integer(), non_neg_integer(), boolean()) ::
           non_neg_integer()
   defp scroll_overscan_after(_first_line, _visible_rows, _line_count, true), do: 0
 
   defp scroll_overscan_after(first_line, visible_rows, line_count, false) do
-    if first_line + visible_rows < line_count, do: 1, else: 0
+    min(@overscan_rows, max(0, line_count - first_line - visible_rows))
   end
 
   @spec scroll_fetch_rows(pos_integer(), non_neg_integer(), non_neg_integer(), boolean()) ::
           pos_integer()
   defp scroll_fetch_rows(visible_rows, _before, _after, true),
-    do: visible_rows + div(visible_rows, 2)
+    do: visible_rows * 3
 
   defp scroll_fetch_rows(visible_rows, before_count, after_count, false),
     do: visible_rows + before_count + after_count

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -330,7 +330,6 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   @spec scroll_overscan_before(non_neg_integer(), boolean()) ::
           {non_neg_integer(), non_neg_integer()}
   defp scroll_overscan_before(first_line, true), do: {0, first_line}
-  defp scroll_overscan_before(0, false), do: {0, 0}
 
   defp scroll_overscan_before(first_line, false) do
     count = min(@overscan_rows, first_line)
@@ -342,7 +341,8 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   defp scroll_overscan_after(_first_line, _visible_rows, _line_count, true), do: 0
 
   defp scroll_overscan_after(first_line, visible_rows, line_count, false) do
-    min(@overscan_rows, max(0, line_count - first_line - visible_rows))
+    rows_after = line_count - first_line - visible_rows
+    min(@overscan_rows, max(0, rows_after))
   end
 
   @spec scroll_fetch_rows(pos_integer(), non_neg_integer(), non_neg_integer(), boolean()) ::

--- a/test/minga_editor/warnings_buffer_test.exs
+++ b/test/minga_editor/warnings_buffer_test.exs
@@ -14,16 +14,26 @@ defmodule MingaEditor.WarningsBufferTest do
       assert %{visible: true, active_tab: :messages, filter: :warnings} = bottom_panel(ctx)
     end
 
-    test "warning popup opens unless the panel was dismissed" do
+    test "warning-level events do not auto-open the panel" do
       ctx = start_editor("hello")
       set_gui_capabilities(ctx)
 
       broadcast_warning(ctx, "first warning")
+      state = editor_state(ctx)
+      refute state.shell_state.warning_popup_timer
+      refute bottom_panel(ctx).visible
+    end
+
+    test "error-level events auto-open the panel unless dismissed" do
+      ctx = start_editor("hello")
+      set_gui_capabilities(ctx)
+
+      broadcast_error(ctx, "something failed")
       flush_warning_popup(ctx)
-      assert %{visible: true, filter: :warnings} = bottom_panel(ctx)
+      assert %{visible: true} = bottom_panel(ctx)
 
       dismiss_bottom_panel(ctx)
-      broadcast_warning(ctx, "second warning")
+      broadcast_error(ctx, "another failure")
       flush_warning_popup(ctx)
       refute bottom_panel(ctx).visible
     end
@@ -52,6 +62,14 @@ defmodule MingaEditor.WarningsBufferTest do
     Minga.Events.broadcast(
       :log_message,
       %Minga.Events.LogMessageEvent{text: text, level: :warning},
+      ctx.events_registry
+    )
+  end
+
+  defp broadcast_error(ctx, text) do
+    Minga.Events.broadcast(
+      :log_message,
+      %Minga.Events.LogMessageEvent{text: text, level: :error},
       ctx.events_registry
     )
   end


### PR DESCRIPTION
## Summary

- **Messages panel auto-open restricted to errors only.** The `*Messages*` buffer was opening on every boot because warning-level log events (slow extension lifecycle, LSP info messages surfaced as warnings) triggered the warning popup. Emacs only auto-opens on errors, and now Minga matches that behavior. Warnings still log to `*Messages*` but no longer force the panel open.

- **Scroll overscan increased from 1 to 50 rows (Phase 1 of #2515).** Both frontends have presentation scroll systems that move the view client-side within overscan rows without a BEAM round-trip, but 1 row of runway was exhausted instantly during trackpad momentum scrolling. Increasing to 50 rows above/below gives enough runway to absorb typical momentum gestures. Wrapped files get 3x visible rows (up from 1.5x). No frontend changes needed; both GUI and TUI automatically adapt via ScrollPresentation metadata.

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` passes (9793/9821; 28 pre-existing parser-binary failures unrelated to changes)
- [ ] Boot TUI and GUI: verify `*Messages*` panel does not auto-open on startup (warnings still logged, panel stays closed)
- [ ] Open a 10K+ line file, perform medium and aggressive trackpad flicks on both TUI and GUI, verify no rhythmic stutter
- [ ] Click during active scroll momentum, verify cursor lands on the correct line
- [ ] Enable folds and soft wrap, scroll through folded/wrapped regions, verify correct display
- [ ] Run `bench/baselines/keystroke_latency.json` to verify p50 stays within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)