### PR TITLE
feat: velocity-adaptive overscan for stutter-free momentum scrolling

### DIFF
--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -438,8 +438,14 @@ defmodule MingaEditor.Mouse do
   defp scroll_window_vertical(state, win_id, delta) do
     case Map.fetch(state.workspace.windows.map, win_id) do
       {:ok, %Window{buffer: buf} = window} when is_pid(buf) ->
+        now = System.monotonic_time(:millisecond)
         total_lines = Buffer.line_count(buf)
-        updated = Window.scroll_viewport(window, delta, total_lines)
+
+        updated =
+          window
+          |> Window.scroll_viewport(delta, total_lines)
+          |> Window.record_scroll_event(now)
+
         EditorState.update_window(state, win_id, fn _window -> updated end)
 
       _ ->

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -229,13 +229,13 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         {first_line, nil}
       end
 
-    # Fetch one stable row above/below simple mappings so clients can presentation-scroll without inventing rows.
-    velocity_tier = Window.scroll_velocity_tier(window, System.monotonic_time(:millisecond))
-
     {fetch_first, fetch_count, visible_row_start_index} =
       case visible_line_map do
         nil ->
-          overscan = overscan_rows(velocity_tier)
+          overscan =
+            overscan_rows(
+              Window.scroll_velocity_tier(window, System.monotonic_time(:millisecond))
+            )
 
           {overscan_before, fetch_first} = scroll_overscan_before(first_line, wrap_on, overscan)
 

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -30,7 +30,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   alias MingaEditor.Viewport
   alias MingaEditor.Window
 
-  @overscan_rows 50
+  alias MingaEditor.Window.ScrollVelocity
 
   @typedoc "Render pipeline input."
   @type state :: Input.t()
@@ -230,15 +230,21 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
       end
 
     # Fetch one stable row above/below simple mappings so clients can presentation-scroll without inventing rows.
+    velocity_tier = Window.scroll_velocity_tier(window, System.monotonic_time(:millisecond))
+
     {fetch_first, fetch_count, visible_row_start_index} =
       case visible_line_map do
         nil ->
-          {overscan_before, fetch_first} = scroll_overscan_before(first_line, wrap_on)
+          overscan = overscan_rows(velocity_tier)
+
+          {overscan_before, fetch_first} = scroll_overscan_before(first_line, wrap_on, overscan)
 
           overscan_after =
-            scroll_overscan_after(first_line, visible_rows, line_count_approx, wrap_on)
+            scroll_overscan_after(first_line, visible_rows, line_count_approx, wrap_on, overscan)
 
-          fetch_rows = scroll_fetch_rows(visible_rows, overscan_before, overscan_after, wrap_on)
+          fetch_rows =
+            scroll_fetch_rows(visible_rows, overscan_before, overscan_after, wrap_on)
+
           {fetch_first, fetch_rows, overscan_before}
 
         entries ->
@@ -327,22 +333,32 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     }
   end
 
-  @spec scroll_overscan_before(non_neg_integer(), boolean()) ::
-          {non_neg_integer(), non_neg_integer()}
-  defp scroll_overscan_before(first_line, true), do: {0, first_line}
+  @spec overscan_rows(ScrollVelocity.tier()) :: pos_integer()
+  defp overscan_rows(:idle), do: 50
+  defp overscan_rows(:medium), do: 100
+  defp overscan_rows(:fast), do: 200
 
-  defp scroll_overscan_before(first_line, false) do
-    count = min(@overscan_rows, first_line)
+  @spec scroll_overscan_before(non_neg_integer(), boolean(), pos_integer()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp scroll_overscan_before(first_line, true, _overscan), do: {0, first_line}
+
+  defp scroll_overscan_before(first_line, false, overscan) do
+    count = min(overscan, first_line)
     {count, first_line - count}
   end
 
-  @spec scroll_overscan_after(non_neg_integer(), pos_integer(), non_neg_integer(), boolean()) ::
-          non_neg_integer()
-  defp scroll_overscan_after(_first_line, _visible_rows, _line_count, true), do: 0
+  @spec scroll_overscan_after(
+          non_neg_integer(),
+          pos_integer(),
+          non_neg_integer(),
+          boolean(),
+          pos_integer()
+        ) :: non_neg_integer()
+  defp scroll_overscan_after(_first_line, _visible_rows, _line_count, true, _overscan), do: 0
 
-  defp scroll_overscan_after(first_line, visible_rows, line_count, false) do
+  defp scroll_overscan_after(first_line, visible_rows, line_count, false, overscan) do
     rows_after = line_count - first_line - visible_rows
-    min(@overscan_rows, max(0, rows_after))
+    min(overscan, max(0, rows_after))
   end
 
   @spec scroll_fetch_rows(pos_integer(), non_neg_integer(), non_neg_integer(), boolean()) ::

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -31,6 +31,7 @@ defmodule MingaEditor.Window do
   alias MingaEditor.Viewport
   alias MingaEditor.Window.Content
   alias MingaEditor.Window.RenderCache
+  alias MingaEditor.Window.ScrollVelocity
   alias MingaEditor.UI.Popup.Active, as: PopupActive
 
   @compile {:inline, dirty?: 2}
@@ -50,7 +51,8 @@ defmodule MingaEditor.Window do
           textobject_positions: %{atom() => [{non_neg_integer(), non_neg_integer()}]},
           document_symbols: [Symbol.t()],
           popup_meta: PopupActive.t() | nil,
-          render_cache: RenderCache.t()
+          render_cache: RenderCache.t(),
+          scroll_velocity: ScrollVelocity.t()
         }
 
   @enforce_keys [:id, :content, :buffer, :viewport]
@@ -66,7 +68,8 @@ defmodule MingaEditor.Window do
     textobject_positions: %{},
     document_symbols: [],
     popup_meta: nil,
-    render_cache: %RenderCache{}
+    render_cache: %RenderCache{},
+    scroll_velocity: %ScrollVelocity{}
   ]
 
   @doc """
@@ -176,6 +179,16 @@ defmodule MingaEditor.Window do
   @spec set_pinned(t(), boolean()) :: t()
   def set_pinned(%__MODULE__{} = window, pinned?) when is_boolean(pinned?) do
     %{window | pinned: pinned?}
+  end
+
+  @spec record_scroll_event(t(), integer()) :: t()
+  def record_scroll_event(%__MODULE__{} = window, now_ms) do
+    %{window | scroll_velocity: ScrollVelocity.record(window.scroll_velocity, now_ms)}
+  end
+
+  @spec scroll_velocity_tier(t(), integer()) :: ScrollVelocity.tier()
+  def scroll_velocity_tier(%__MODULE__{} = window, now_ms) do
+    ScrollVelocity.tier(window.scroll_velocity, now_ms)
   end
 
   # ── Popup queries ──────────────────────────────────────────────────────────

--- a/lib/minga_editor/window/scroll_velocity.ex
+++ b/lib/minga_editor/window/scroll_velocity.ex
@@ -1,0 +1,51 @@
+defmodule MingaEditor.Window.ScrollVelocity do
+  @moduledoc """
+  Lightweight scroll velocity estimator for adaptive overscan.
+
+  Tracks a sliding window of scroll event timestamps and computes a
+  velocity tier (:idle, :medium, :fast) based on event rate. The tier
+  is read lazily by BufferPrefetch to scale overscan rows.
+  """
+
+  @window_ms 100
+  @decay_ms 200
+  @medium_threshold 5
+  @fast_threshold 15
+
+  @type tier :: :idle | :medium | :fast
+
+  @type t :: %__MODULE__{
+          count: non_neg_integer(),
+          window_start: integer(),
+          last_event: integer()
+        }
+
+  defstruct count: 0, window_start: 0, last_event: 0
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @spec record(t(), integer()) :: t()
+  def record(%__MODULE__{} = sv, now_ms) do
+    if now_ms - sv.window_start > @window_ms do
+      %__MODULE__{count: 1, window_start: now_ms, last_event: now_ms}
+    else
+      %__MODULE__{sv | count: sv.count + 1, last_event: now_ms}
+    end
+  end
+
+  @spec tier(t(), integer()) :: tier()
+  def tier(%__MODULE__{last_event: 0}, _now_ms), do: :idle
+
+  def tier(%__MODULE__{} = sv, now_ms) do
+    if now_ms - sv.last_event > @decay_ms do
+      :idle
+    else
+      cond do
+        sv.count >= @fast_threshold -> :fast
+        sv.count >= @medium_threshold -> :medium
+        true -> :idle
+      end
+    end
+  end
+end

--- a/lib/minga_editor/window/scroll_velocity.ex
+++ b/lib/minga_editor/window/scroll_velocity.ex
@@ -16,19 +16,24 @@ defmodule MingaEditor.Window.ScrollVelocity do
 
   @type t :: %__MODULE__{
           count: non_neg_integer(),
+          prev_count: non_neg_integer(),
           window_start: integer(),
           last_event: integer()
         }
 
-  defstruct count: 0, window_start: 0, last_event: 0
+  defstruct count: 0, prev_count: 0, window_start: 0, last_event: 0
 
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
   @spec record(t(), integer()) :: t()
+  def record(%__MODULE__{last_event: 0}, now_ms) do
+    %__MODULE__{count: 1, window_start: now_ms, last_event: now_ms}
+  end
+
   def record(%__MODULE__{} = sv, now_ms) do
     if now_ms - sv.window_start > @window_ms do
-      %__MODULE__{count: 1, window_start: now_ms, last_event: now_ms}
+      %__MODULE__{count: 1, window_start: now_ms, last_event: now_ms, prev_count: sv.count}
     else
       %__MODULE__{sv | count: sv.count + 1, last_event: now_ms}
     end
@@ -36,16 +41,15 @@ defmodule MingaEditor.Window.ScrollVelocity do
 
   @spec tier(t(), integer()) :: tier()
   def tier(%__MODULE__{last_event: 0}, _now_ms), do: :idle
+  def tier(%__MODULE__{} = sv, now_ms) when now_ms - sv.last_event > @decay_ms, do: :idle
 
-  def tier(%__MODULE__{} = sv, now_ms) do
-    if now_ms - sv.last_event > @decay_ms do
-      :idle
-    else
-      cond do
-        sv.count >= @fast_threshold -> :fast
-        sv.count >= @medium_threshold -> :medium
-        true -> :idle
-      end
-    end
-  end
+  def tier(%__MODULE__{count: c, prev_count: p}, _now_ms)
+      when c >= @fast_threshold or p >= @fast_threshold,
+      do: :fast
+
+  def tier(%__MODULE__{count: c, prev_count: p}, _now_ms)
+      when c >= @medium_threshold or p >= @medium_threshold,
+      do: :medium
+
+  def tier(%__MODULE__{}, _now_ms), do: :idle
 end

--- a/test/minga_editor/window/scroll_velocity_test.exs
+++ b/test/minga_editor/window/scroll_velocity_test.exs
@@ -19,22 +19,40 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
       assert ScrollVelocity.tier(sv, 1025) == :idle
     end
 
-    test "5+ events within 100ms returns :medium" do
+    test "exactly 5 events returns :medium" do
       sv =
-        Enum.reduce(1..6, ScrollVelocity.new(), fn i, acc ->
+        Enum.reduce(1..5, ScrollVelocity.new(), fn i, acc ->
           ScrollVelocity.record(acc, 1000 + i * 10)
         end)
 
-      assert ScrollVelocity.tier(sv, 1065) == :medium
+      assert ScrollVelocity.tier(sv, 1055) == :medium
     end
 
-    test "15+ events within 100ms returns :fast" do
+    test "4 events returns :idle (below medium threshold)" do
       sv =
-        Enum.reduce(1..16, ScrollVelocity.new(), fn i, acc ->
+        Enum.reduce(1..4, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 10)
+        end)
+
+      assert ScrollVelocity.tier(sv, 1045) == :idle
+    end
+
+    test "exactly 15 events returns :fast" do
+      sv =
+        Enum.reduce(1..15, ScrollVelocity.new(), fn i, acc ->
           ScrollVelocity.record(acc, 1000 + i * 5)
         end)
 
-      assert ScrollVelocity.tier(sv, 1082) == :fast
+      assert ScrollVelocity.tier(sv, 1080) == :fast
+    end
+
+    test "14 events returns :medium (below fast threshold)" do
+      sv =
+        Enum.reduce(1..14, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 5)
+        end)
+
+      assert ScrollVelocity.tier(sv, 1075) == :medium
     end
 
     test "decays to :idle after 200ms with no events" do
@@ -44,7 +62,22 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
         end)
 
       assert ScrollVelocity.tier(sv, 1082) == :fast
-      assert ScrollVelocity.tier(sv, 1300) == :idle
+      assert ScrollVelocity.tier(sv, 1280) == :fast
+      assert ScrollVelocity.tier(sv, 1283) == :idle
+    end
+
+    test "sustained scrolling across window reset maintains tier via prev_count" do
+      sv =
+        Enum.reduce(1..16, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 5)
+        end)
+
+      assert ScrollVelocity.tier(sv, 1082) == :fast
+
+      sv = ScrollVelocity.record(sv, 1150)
+      assert sv.count == 1
+      assert sv.prev_count == 16
+      assert ScrollVelocity.tier(sv, 1155) == :fast
     end
 
     test "window resets after 100ms gap" do
@@ -56,7 +89,34 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
       assert ScrollVelocity.tier(sv, 1055) == :medium
 
       sv = ScrollVelocity.record(sv, 1200)
-      assert ScrollVelocity.tier(sv, 1205) == :idle
+      assert ScrollVelocity.tier(sv, 1205) == :medium
+    end
+
+    test "prev_count decays after two window resets with few events" do
+      sv =
+        Enum.reduce(1..16, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 5)
+        end)
+
+      assert ScrollVelocity.tier(sv, 1082) == :fast
+
+      sv = ScrollVelocity.record(sv, 1200)
+      assert ScrollVelocity.tier(sv, 1205) == :fast
+
+      sv = ScrollVelocity.record(sv, 1400)
+      assert ScrollVelocity.tier(sv, 1405) == :idle
+    end
+
+    test "works with negative monotonic timestamps" do
+      sv =
+        ScrollVelocity.new()
+        |> ScrollVelocity.record(-5000)
+        |> ScrollVelocity.record(-4990)
+        |> ScrollVelocity.record(-4980)
+        |> ScrollVelocity.record(-4970)
+        |> ScrollVelocity.record(-4960)
+
+      assert ScrollVelocity.tier(sv, -4955) == :medium
     end
   end
 end

--- a/test/minga_editor/window/scroll_velocity_test.exs
+++ b/test/minga_editor/window/scroll_velocity_test.exs
@@ -1,0 +1,62 @@
+defmodule MingaEditor.Window.ScrollVelocityTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Window.ScrollVelocity
+
+  describe "tier/2" do
+    test "new estimator returns :idle" do
+      sv = ScrollVelocity.new()
+      assert ScrollVelocity.tier(sv, 1000) == :idle
+    end
+
+    test "few events within a window returns :idle" do
+      sv =
+        ScrollVelocity.new()
+        |> ScrollVelocity.record(1000)
+        |> ScrollVelocity.record(1010)
+        |> ScrollVelocity.record(1020)
+
+      assert ScrollVelocity.tier(sv, 1025) == :idle
+    end
+
+    test "5+ events within 100ms returns :medium" do
+      sv =
+        Enum.reduce(1..6, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 10)
+        end)
+
+      assert ScrollVelocity.tier(sv, 1065) == :medium
+    end
+
+    test "15+ events within 100ms returns :fast" do
+      sv =
+        Enum.reduce(1..16, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 5)
+        end)
+
+      assert ScrollVelocity.tier(sv, 1082) == :fast
+    end
+
+    test "decays to :idle after 200ms with no events" do
+      sv =
+        Enum.reduce(1..16, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 5)
+        end)
+
+      assert ScrollVelocity.tier(sv, 1082) == :fast
+      assert ScrollVelocity.tier(sv, 1300) == :idle
+    end
+
+    test "window resets after 100ms gap" do
+      sv =
+        Enum.reduce(1..10, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 5)
+        end)
+
+      assert ScrollVelocity.tier(sv, 1055) == :medium
+
+      sv = ScrollVelocity.record(sv, 1200)
+      assert ScrollVelocity.tier(sv, 1205) == :idle
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a `ScrollVelocity` struct that tracks scroll event rate per window using a sliding 100ms timestamp window
- `BufferPrefetch` reads the velocity tier from the window and scales overscan dynamically: 50 rows at idle, 100 at medium velocity (5+ events/100ms), 200 at fast (15+ events/100ms)
- Velocity decays to idle after 200ms with no scroll events, computed lazily (no timer)
- No frontend changes; both GUI and TUI read overscan bounds from `ScrollPresentation` metadata

Phase 3 of #2515. Builds on Phase 1 (#2516, merged in #2520).

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] 6 unit tests for `ScrollVelocity` (tier thresholds, decay, window reset)
- [x] Full editor test suite passes (4298/4310, 12 pre-existing parser-binary failures)
- [ ] Aggressive trackpad flick through 10K+ line file on macOS GUI produces no visible pause
- [ ] Aggressive trackpad flick through 10K+ line file on TUI (iTerm2, Kitty) produces no visible pause
- [ ] After flick momentum ends, wait 500ms, perform slow scroll: verify overscan has returned to baseline
- [ ] Run `bench/baselines/keystroke_latency.json` to verify p50 stays within budget at 200-row overscan

🤖 Generated with [Claude Code](https://claude.com/claude-code)