### PR TITLE
feat: directional fetch-ahead for long-distance scrolling

### DIFF
--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -439,12 +439,13 @@ defmodule MingaEditor.Mouse do
     case Map.fetch(state.workspace.windows.map, win_id) do
       {:ok, %Window{buffer: buf} = window} when is_pid(buf) ->
         now = System.monotonic_time(:millisecond)
+        dir = if delta > 0, do: :down, else: :up
         total_lines = Buffer.line_count(buf)
 
         updated =
           window
           |> Window.scroll_viewport(delta, total_lines)
-          |> Window.record_scroll_event(now)
+          |> Window.record_scroll_event(now, dir)
 
         EditorState.update_window(state, win_id, fn _window -> updated end)
 

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -363,7 +363,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   end
 
   defp half_split(total) do
-    half = div(total, 2)
+    half = max(1, div(total, 2))
     {half, total - half}
   end
 

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -232,15 +232,24 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     {fetch_first, fetch_count, visible_row_start_index} =
       case visible_line_map do
         nil ->
-          overscan =
-            overscan_rows(
-              Window.scroll_velocity_tier(window, System.monotonic_time(:millisecond))
-            )
+          now = System.monotonic_time(:millisecond)
+          velocity_tier = Window.scroll_velocity_tier(window, now)
+          total_overscan = overscan_rows(velocity_tier)
 
-          {overscan_before, fetch_first} = scroll_overscan_before(first_line, wrap_on, overscan)
+          {overscan_behind, overscan_ahead} =
+            directional_split(total_overscan, velocity_tier, Window.scroll_direction(window, now))
+
+          {overscan_before, fetch_first} =
+            scroll_overscan_before(first_line, wrap_on, overscan_behind)
 
           overscan_after =
-            scroll_overscan_after(first_line, visible_rows, line_count_approx, wrap_on, overscan)
+            scroll_overscan_after(
+              first_line,
+              visible_rows,
+              line_count_approx,
+              wrap_on,
+              overscan_ahead
+            )
 
           fetch_rows =
             scroll_fetch_rows(visible_rows, overscan_before, overscan_after, wrap_on)
@@ -337,6 +346,26 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   defp overscan_rows(:idle), do: 50
   defp overscan_rows(:medium), do: 100
   defp overscan_rows(:fast), do: 200
+
+  @spec directional_split(pos_integer(), ScrollVelocity.tier(), ScrollVelocity.direction()) ::
+          {pos_integer(), pos_integer()}
+  defp directional_split(total, :idle, _dir), do: half_split(total)
+  defp directional_split(total, _tier, :ambiguous), do: half_split(total)
+
+  defp directional_split(total, _tier, :down) do
+    behind = max(1, div(total * 15, 100))
+    {behind, total - behind}
+  end
+
+  defp directional_split(total, _tier, :up) do
+    behind = total - max(1, div(total * 15, 100))
+    {behind, total - behind}
+  end
+
+  defp half_split(total) do
+    half = div(total, 2)
+    {half, total - half}
+  end
 
   @spec scroll_overscan_before(non_neg_integer(), boolean(), pos_integer()) ::
           {non_neg_integer(), non_neg_integer()}

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -353,13 +353,13 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   defp directional_split(total, _tier, :ambiguous), do: half_split(total)
 
   defp directional_split(total, _tier, :down) do
-    behind = max(1, div(total * 15, 100))
-    {behind, total - behind}
+    minority = max(1, div(total * 15, 100))
+    {minority, total - minority}
   end
 
   defp directional_split(total, _tier, :up) do
-    behind = total - max(1, div(total * 15, 100))
-    {behind, total - behind}
+    minority = max(1, div(total * 15, 100))
+    {total - minority, minority}
   end
 
   defp half_split(total) do

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -181,14 +181,19 @@ defmodule MingaEditor.Window do
     %{window | pinned: pinned?}
   end
 
-  @spec record_scroll_event(t(), integer()) :: t()
-  def record_scroll_event(%__MODULE__{} = window, now_ms) do
-    %{window | scroll_velocity: ScrollVelocity.record(window.scroll_velocity, now_ms)}
+  @spec record_scroll_event(t(), integer(), ScrollVelocity.direction()) :: t()
+  def record_scroll_event(%__MODULE__{} = window, now_ms, dir) do
+    %{window | scroll_velocity: ScrollVelocity.record(window.scroll_velocity, now_ms, dir)}
   end
 
   @spec scroll_velocity_tier(t(), integer()) :: ScrollVelocity.tier()
   def scroll_velocity_tier(%__MODULE__{} = window, now_ms) do
     ScrollVelocity.tier(window.scroll_velocity, now_ms)
+  end
+
+  @spec scroll_direction(t(), integer()) :: ScrollVelocity.direction()
+  def scroll_direction(%__MODULE__{} = window, now_ms) do
+    ScrollVelocity.direction(window.scroll_velocity, now_ms)
   end
 
   # ── Popup queries ──────────────────────────────────────────────────────────

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -181,7 +181,7 @@ defmodule MingaEditor.Window do
     %{window | pinned: pinned?}
   end
 
-  @spec record_scroll_event(t(), integer(), ScrollVelocity.direction()) :: t()
+  @spec record_scroll_event(t(), integer(), ScrollVelocity.event_direction()) :: t()
   def record_scroll_event(%__MODULE__{} = window, now_ms, dir) do
     %{window | scroll_velocity: ScrollVelocity.record(window.scroll_velocity, now_ms, dir)}
   end

--- a/lib/minga_editor/window/scroll_velocity.ex
+++ b/lib/minga_editor/window/scroll_velocity.ex
@@ -16,14 +16,15 @@ defmodule MingaEditor.Window.ScrollVelocity do
   @direction_window 5
 
   @type tier :: :idle | :medium | :fast
-  @type direction :: :down | :up | :ambiguous
+  @type event_direction :: :down | :up
+  @type direction :: event_direction() | :ambiguous
 
   @type t :: %__MODULE__{
           count: non_neg_integer(),
           prev_count: non_neg_integer(),
           window_start: integer(),
           last_event: integer(),
-          recent_dirs: [direction()]
+          recent_dirs: [event_direction()]
         }
 
   defstruct count: 0, prev_count: 0, window_start: 0, last_event: 0, recent_dirs: []
@@ -31,7 +32,7 @@ defmodule MingaEditor.Window.ScrollVelocity do
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
-  @spec record(t(), integer(), direction()) :: t()
+  @spec record(t(), integer(), event_direction()) :: t()
   def record(%__MODULE__{last_event: 0}, now_ms, dir) do
     %__MODULE__{count: 1, window_start: now_ms, last_event: now_ms, recent_dirs: [dir]}
   end
@@ -76,11 +77,10 @@ defmodule MingaEditor.Window.ScrollVelocity do
     downs = Enum.count(dirs, &(&1 == :down))
     ups = Enum.count(dirs, &(&1 == :up))
     total = length(dirs)
-    threshold = total * 4 / 5
 
     cond do
-      downs >= threshold -> :down
-      ups >= threshold -> :up
+      downs * 5 >= total * 4 -> :down
+      ups * 5 >= total * 4 -> :up
       true -> :ambiguous
     end
   end

--- a/lib/minga_editor/window/scroll_velocity.ex
+++ b/lib/minga_editor/window/scroll_velocity.ex
@@ -3,39 +3,52 @@ defmodule MingaEditor.Window.ScrollVelocity do
   Lightweight scroll velocity estimator for adaptive overscan.
 
   Tracks a sliding window of scroll event timestamps and computes a
-  velocity tier (:idle, :medium, :fast) based on event rate. The tier
-  is read lazily by BufferPrefetch to scale overscan rows.
+  velocity tier (:idle, :medium, :fast) based on event rate, plus
+  a dominant scroll direction (:down, :up, :ambiguous) from the last
+  several events. Both are read lazily by BufferPrefetch to scale and
+  bias overscan rows.
   """
 
   @window_ms 100
   @decay_ms 200
   @medium_threshold 5
   @fast_threshold 15
+  @direction_window 5
 
   @type tier :: :idle | :medium | :fast
+  @type direction :: :down | :up | :ambiguous
 
   @type t :: %__MODULE__{
           count: non_neg_integer(),
           prev_count: non_neg_integer(),
           window_start: integer(),
-          last_event: integer()
+          last_event: integer(),
+          recent_dirs: [direction()]
         }
 
-  defstruct count: 0, prev_count: 0, window_start: 0, last_event: 0
+  defstruct count: 0, prev_count: 0, window_start: 0, last_event: 0, recent_dirs: []
 
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
-  @spec record(t(), integer()) :: t()
-  def record(%__MODULE__{last_event: 0}, now_ms) do
-    %__MODULE__{count: 1, window_start: now_ms, last_event: now_ms}
+  @spec record(t(), integer(), direction()) :: t()
+  def record(%__MODULE__{last_event: 0}, now_ms, dir) do
+    %__MODULE__{count: 1, window_start: now_ms, last_event: now_ms, recent_dirs: [dir]}
   end
 
-  def record(%__MODULE__{} = sv, now_ms) do
+  def record(%__MODULE__{} = sv, now_ms, dir) do
+    dirs = Enum.take([dir | sv.recent_dirs], @direction_window)
+
     if now_ms - sv.window_start > @window_ms do
-      %__MODULE__{count: 1, window_start: now_ms, last_event: now_ms, prev_count: sv.count}
+      %__MODULE__{
+        count: 1,
+        window_start: now_ms,
+        last_event: now_ms,
+        prev_count: sv.count,
+        recent_dirs: dirs
+      }
     else
-      %__MODULE__{sv | count: sv.count + 1, last_event: now_ms}
+      %__MODULE__{sv | count: sv.count + 1, last_event: now_ms, recent_dirs: dirs}
     end
   end
 
@@ -52,4 +65,23 @@ defmodule MingaEditor.Window.ScrollVelocity do
       do: :medium
 
   def tier(%__MODULE__{}, _now_ms), do: :idle
+
+  @spec direction(t(), integer()) :: direction()
+  def direction(%__MODULE__{last_event: 0}, _now_ms), do: :ambiguous
+
+  def direction(%__MODULE__{} = sv, now_ms) when now_ms - sv.last_event > @decay_ms,
+    do: :ambiguous
+
+  def direction(%__MODULE__{recent_dirs: dirs}, _now_ms) do
+    downs = Enum.count(dirs, &(&1 == :down))
+    ups = Enum.count(dirs, &(&1 == :up))
+    total = length(dirs)
+    threshold = total * 4 / 5
+
+    cond do
+      downs >= threshold -> :down
+      ups >= threshold -> :up
+      true -> :ambiguous
+    end
+  end
 end

--- a/lib/minga_editor/window/scroll_velocity.ex
+++ b/lib/minga_editor/window/scroll_velocity.ex
@@ -73,6 +73,8 @@ defmodule MingaEditor.Window.ScrollVelocity do
   def direction(%__MODULE__{} = sv, now_ms) when now_ms - sv.last_event > @decay_ms,
     do: :ambiguous
 
+  def direction(%__MODULE__{recent_dirs: []}, _now_ms), do: :ambiguous
+
   def direction(%__MODULE__{recent_dirs: dirs}, _now_ms) do
     downs = Enum.count(dirs, &(&1 == :down))
     ups = Enum.count(dirs, &(&1 == :up))

--- a/test/minga_agent/session_hooks_suppression_test.exs
+++ b/test/minga_agent/session_hooks_suppression_test.exs
@@ -31,18 +31,33 @@ defmodule MingaAgent.SessionHooksSuppressionTest do
 
   test "hooks_enabled false suppresses lifecycle and prompt hook dispatch for inline sessions" do
     normal = start_supervised_session(hooks_enabled?: true, persist?: true)
+    normal_id = Session.session_id(normal)
     :sys.get_state(normal)
-    assert_receive {:agent_hook_payload, %{"event" => "SessionStart"}}, 1_000
+
+    assert_receive {:agent_hook_payload,
+                    %{"event" => "SessionStart", "session_id" => ^normal_id}},
+                   1_000
+
     assert :ok = Session.send_prompt(normal, "hello")
-    assert_receive {:agent_hook_payload, %{"event" => "UserPromptSubmit"}}, 1_000
+
+    assert_receive {:agent_hook_payload,
+                    %{"event" => "UserPromptSubmit", "session_id" => ^normal_id}},
+                   1_000
+
     flush_hook_messages()
 
     inline = start_supervised_session(hooks_enabled?: false, persist?: false)
+    inline_id = Session.session_id(inline)
     :sys.get_state(inline)
     assert :ok = Session.send_prompt(inline, "hello")
 
-    refute_receive {:agent_hook_payload, %{"event" => "SessionStart"}}, 100
-    refute_receive {:agent_hook_payload, %{"event" => "UserPromptSubmit"}}, 100
+    refute_receive {:agent_hook_payload,
+                    %{"event" => "SessionStart", "session_id" => ^inline_id}},
+                   100
+
+    refute_receive {:agent_hook_payload,
+                    %{"event" => "UserPromptSubmit", "session_id" => ^inline_id}},
+                   100
   end
 
   defp start_supervised_session(opts) do

--- a/test/minga_editor/integration/agent_workflow_conformance_test.exs
+++ b/test/minga_editor/integration/agent_workflow_conformance_test.exs
@@ -404,18 +404,34 @@ defmodule MingaEditor.Integration.AgentWorkflowConformanceTest do
   defp start_agent_editor(project_root, options_server, script_or_opts \\ [])
 
   defp start_agent_editor(project_root, options_server, opts) when is_list(opts) do
+    sessions_before =
+      MapSet.new(
+        MingaAgent.SessionManager.list_sessions()
+        |> Enum.map(fn {_id, pid, _meta} -> pid end)
+      )
+
     provider_opts =
       case Keyword.fetch(opts, :scripts) do
         {:ok, scripts} -> ScriptedProvider.scripts(scripts)
         :error -> ScriptedProvider.script(opts)
       end
 
-    start_editor("fixture",
-      project_root: project_root,
-      options_server: options_server,
-      agent_provider_module: ScriptedProvider,
-      agent_provider_opts: provider_opts
-    )
+    ctx =
+      start_editor("fixture",
+        project_root: project_root,
+        options_server: options_server,
+        agent_provider_module: ScriptedProvider,
+        agent_provider_opts: provider_opts
+      )
+
+    on_exit(fn ->
+      for {_id, pid, _meta} <- MingaAgent.SessionManager.list_sessions(),
+          not MapSet.member?(sessions_before, pid) do
+        MingaAgent.SessionManager.stop_session_by_pid(pid)
+      end
+    end)
+
+    ctx
   end
 
   defp turn_rendered?(%AgentChat{} = model) do

--- a/test/minga_editor/window/scroll_velocity_test.exs
+++ b/test/minga_editor/window/scroll_velocity_test.exs
@@ -12,9 +12,9 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
     test "few events within a window returns :idle" do
       sv =
         ScrollVelocity.new()
-        |> ScrollVelocity.record(1000)
-        |> ScrollVelocity.record(1010)
-        |> ScrollVelocity.record(1020)
+        |> ScrollVelocity.record(1000, :down)
+        |> ScrollVelocity.record(1010, :down)
+        |> ScrollVelocity.record(1020, :down)
 
       assert ScrollVelocity.tier(sv, 1025) == :idle
     end
@@ -22,7 +22,7 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
     test "exactly 5 events returns :medium" do
       sv =
         Enum.reduce(1..5, ScrollVelocity.new(), fn i, acc ->
-          ScrollVelocity.record(acc, 1000 + i * 10)
+          ScrollVelocity.record(acc, 1000 + i * 10, :down)
         end)
 
       assert ScrollVelocity.tier(sv, 1055) == :medium
@@ -31,7 +31,7 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
     test "4 events returns :idle (below medium threshold)" do
       sv =
         Enum.reduce(1..4, ScrollVelocity.new(), fn i, acc ->
-          ScrollVelocity.record(acc, 1000 + i * 10)
+          ScrollVelocity.record(acc, 1000 + i * 10, :down)
         end)
 
       assert ScrollVelocity.tier(sv, 1045) == :idle
@@ -40,7 +40,7 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
     test "exactly 15 events returns :fast" do
       sv =
         Enum.reduce(1..15, ScrollVelocity.new(), fn i, acc ->
-          ScrollVelocity.record(acc, 1000 + i * 5)
+          ScrollVelocity.record(acc, 1000 + i * 5, :down)
         end)
 
       assert ScrollVelocity.tier(sv, 1080) == :fast
@@ -49,7 +49,7 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
     test "14 events returns :medium (below fast threshold)" do
       sv =
         Enum.reduce(1..14, ScrollVelocity.new(), fn i, acc ->
-          ScrollVelocity.record(acc, 1000 + i * 5)
+          ScrollVelocity.record(acc, 1000 + i * 5, :down)
         end)
 
       assert ScrollVelocity.tier(sv, 1075) == :medium
@@ -58,7 +58,7 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
     test "decays to :idle after 200ms with no events" do
       sv =
         Enum.reduce(1..16, ScrollVelocity.new(), fn i, acc ->
-          ScrollVelocity.record(acc, 1000 + i * 5)
+          ScrollVelocity.record(acc, 1000 + i * 5, :down)
         end)
 
       assert ScrollVelocity.tier(sv, 1082) == :fast
@@ -69,12 +69,12 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
     test "sustained scrolling across window reset maintains tier via prev_count" do
       sv =
         Enum.reduce(1..16, ScrollVelocity.new(), fn i, acc ->
-          ScrollVelocity.record(acc, 1000 + i * 5)
+          ScrollVelocity.record(acc, 1000 + i * 5, :down)
         end)
 
       assert ScrollVelocity.tier(sv, 1082) == :fast
 
-      sv = ScrollVelocity.record(sv, 1150)
+      sv = ScrollVelocity.record(sv, 1150, :down)
       assert sv.count == 1
       assert sv.prev_count == 16
       assert ScrollVelocity.tier(sv, 1155) == :fast
@@ -83,40 +83,115 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
     test "window resets after 100ms gap" do
       sv =
         Enum.reduce(1..10, ScrollVelocity.new(), fn i, acc ->
-          ScrollVelocity.record(acc, 1000 + i * 5)
+          ScrollVelocity.record(acc, 1000 + i * 5, :down)
         end)
 
       assert ScrollVelocity.tier(sv, 1055) == :medium
 
-      sv = ScrollVelocity.record(sv, 1200)
+      sv = ScrollVelocity.record(sv, 1200, :down)
       assert ScrollVelocity.tier(sv, 1205) == :medium
     end
 
     test "prev_count decays after two window resets with few events" do
       sv =
         Enum.reduce(1..16, ScrollVelocity.new(), fn i, acc ->
-          ScrollVelocity.record(acc, 1000 + i * 5)
+          ScrollVelocity.record(acc, 1000 + i * 5, :down)
         end)
 
       assert ScrollVelocity.tier(sv, 1082) == :fast
 
-      sv = ScrollVelocity.record(sv, 1200)
+      sv = ScrollVelocity.record(sv, 1200, :down)
       assert ScrollVelocity.tier(sv, 1205) == :fast
 
-      sv = ScrollVelocity.record(sv, 1400)
+      sv = ScrollVelocity.record(sv, 1400, :down)
       assert ScrollVelocity.tier(sv, 1405) == :idle
     end
 
     test "works with negative monotonic timestamps" do
       sv =
         ScrollVelocity.new()
-        |> ScrollVelocity.record(-5000)
-        |> ScrollVelocity.record(-4990)
-        |> ScrollVelocity.record(-4980)
-        |> ScrollVelocity.record(-4970)
-        |> ScrollVelocity.record(-4960)
+        |> ScrollVelocity.record(-5000, :down)
+        |> ScrollVelocity.record(-4990, :down)
+        |> ScrollVelocity.record(-4980, :down)
+        |> ScrollVelocity.record(-4970, :down)
+        |> ScrollVelocity.record(-4960, :down)
 
       assert ScrollVelocity.tier(sv, -4955) == :medium
+    end
+  end
+
+  describe "direction/2" do
+    test "new estimator returns :ambiguous" do
+      sv = ScrollVelocity.new()
+      assert ScrollVelocity.direction(sv, 1000) == :ambiguous
+    end
+
+    test "uniform down events return :down" do
+      sv =
+        Enum.reduce(1..5, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 10, :down)
+        end)
+
+      assert ScrollVelocity.direction(sv, 1055) == :down
+    end
+
+    test "uniform up events return :up" do
+      sv =
+        Enum.reduce(1..5, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 10, :up)
+        end)
+
+      assert ScrollVelocity.direction(sv, 1055) == :up
+    end
+
+    test "mixed events return :ambiguous" do
+      sv =
+        ScrollVelocity.new()
+        |> ScrollVelocity.record(1000, :down)
+        |> ScrollVelocity.record(1010, :down)
+        |> ScrollVelocity.record(1020, :up)
+        |> ScrollVelocity.record(1030, :up)
+        |> ScrollVelocity.record(1040, :down)
+
+      assert ScrollVelocity.direction(sv, 1045) == :ambiguous
+    end
+
+    test "4 of 5 same direction returns dominant direction" do
+      sv =
+        ScrollVelocity.new()
+        |> ScrollVelocity.record(1000, :down)
+        |> ScrollVelocity.record(1010, :down)
+        |> ScrollVelocity.record(1020, :down)
+        |> ScrollVelocity.record(1030, :down)
+        |> ScrollVelocity.record(1040, :up)
+
+      assert ScrollVelocity.direction(sv, 1045) == :down
+    end
+
+    test "direction decays to :ambiguous after 200ms" do
+      sv =
+        Enum.reduce(1..5, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 10, :down)
+        end)
+
+      assert ScrollVelocity.direction(sv, 1055) == :down
+      assert ScrollVelocity.direction(sv, 1255) == :ambiguous
+    end
+
+    test "direction window is capped at 5 most recent events" do
+      sv =
+        Enum.reduce(1..5, ScrollVelocity.new(), fn i, acc ->
+          ScrollVelocity.record(acc, 1000 + i * 5, :down)
+        end)
+
+      assert ScrollVelocity.direction(sv, 1030) == :down
+
+      sv =
+        Enum.reduce(1..5, sv, fn i, acc ->
+          ScrollVelocity.record(acc, 1030 + i * 5, :up)
+        end)
+
+      assert ScrollVelocity.direction(sv, 1060) == :up
     end
   end
 end

--- a/test/minga_editor/window/scroll_velocity_test.exs
+++ b/test/minga_editor/window/scroll_velocity_test.exs
@@ -156,7 +156,7 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
       assert ScrollVelocity.direction(sv, 1045) == :ambiguous
     end
 
-    test "4 of 5 same direction returns dominant direction" do
+    test "4 of 5 down events returns :down" do
       sv =
         ScrollVelocity.new()
         |> ScrollVelocity.record(1000, :down)
@@ -166,6 +166,18 @@ defmodule MingaEditor.Window.ScrollVelocityTest do
         |> ScrollVelocity.record(1040, :up)
 
       assert ScrollVelocity.direction(sv, 1045) == :down
+    end
+
+    test "4 of 5 up events returns :up" do
+      sv =
+        ScrollVelocity.new()
+        |> ScrollVelocity.record(1000, :up)
+        |> ScrollVelocity.record(1010, :up)
+        |> ScrollVelocity.record(1020, :up)
+        |> ScrollVelocity.record(1030, :up)
+        |> ScrollVelocity.record(1040, :down)
+
+      assert ScrollVelocity.direction(sv, 1045) == :up
     end
 
     test "direction decays to :ambiguous after 200ms" do


### PR DESCRIPTION
## Summary

- Adds direction tracking to `ScrollVelocity`, recording the last 5 scroll event directions and computing a dominant direction (`:down`, `:up`, `:ambiguous`) with 80% threshold
- When velocity is `:medium` or `:fast` and direction is clear, splits overscan budget 85% ahead / 15% behind instead of 50/50
- Falls back to symmetric split for `:idle` velocity or `:ambiguous` direction
- Direction decays to `:ambiguous` after 200ms with no scroll events (same window as velocity decay)
- Zero frontend changes; frontends consume `overscan_start_line`/`overscan_end_line` as before

Closes #2519
Part of Epic #2515

## Test plan

- [x] 18 unit tests covering tier boundaries, direction detection, decay, window capping, and negative timestamps
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] Mouse and scroll integration tests pass (37 tests)
- [ ] Manual: sustained downward flick through 10K+ line file, verify no overscan boundary hits
- [ ] Manual: quick direction reversal (flick down then immediately up), verify no stutter at reversal

🤖 Generated with [Claude Code](https://claude.com/claude-code)