### PR TITLE
refactor: centralize TUI layout into uiLayout struct

### DIFF
--- a/go/tui/internal/ui/input.go
+++ b/go/tui/internal/ui/input.go
@@ -180,7 +180,7 @@ func keyModifiers(key tea.Key) byte {
 // motion) honor the suppression.
 func (m Model) mousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	mouse := msg.Mouse()
-	offset := m.renderedHeaderHeight
+	offset := m.layout.header.Height
 	row := mouse.Y - offset
 	if !isWheelButton(mouse.Button) && mouse.Y < offset {
 		// Header-region policy: a PRESS on an unrouted header pixel must not

--- a/go/tui/internal/ui/input_test.go
+++ b/go/tui/internal/ui/input_test.go
@@ -244,8 +244,8 @@ func tabBarModel(headerRows int) Model {
 		}
 	}
 	model.chrome = chrome
-	model.refreshRenderedHeaderHeight()
-	if model.renderedHeaderHeight != headerRows {
+	model.layout = model.computeLayout()
+	if model.layout.header.Height != headerRows {
 		panic("tabBarModel: cached header height does not match requested rows")
 	}
 	return model
@@ -272,7 +272,7 @@ func TestMousePacketSubtractsHeaderOffset(t *testing.T) {
 			// the rule is independent of whether headerLines can ever collapse to
 			// zero rows (it cannot today: there is always a title fallback).
 			model := New(120, 24, nil)
-			model.renderedHeaderHeight = tc.offset
+			model.layout.header.Height = tc.offset
 			msg := tea.MouseClickMsg(tea.Mouse{X: 7, Y: tc.terminalY, Button: tea.MouseLeft})
 			packet, ok := model.mousePacket(msg)
 			if !ok {
@@ -296,7 +296,7 @@ func TestMousePacketSubtractsHeaderOffset(t *testing.T) {
 // (ticket #2256).
 func TestMousePacketOffsetMirrorsRenderedHeader(t *testing.T) {
 	model := tabBarModel(2)
-	if got, want := model.renderedHeaderHeight, len(model.headerLines()); got != want {
+	if got, want := model.layout.header.Height, len(model.headerLines()); got != want {
 		t.Fatalf("cached offset = %d, rendered header height = %d; must match", got, want)
 	}
 	msg := tea.MouseClickMsg(tea.Mouse{X: 0, Y: 6, Button: tea.MouseLeft})
@@ -393,7 +393,7 @@ func TestMousePacketNormalizesPresentationScrollOffset(t *testing.T) {
 	})
 	model.presentationScroll[7] = presentationScroll{anchorTop: 10, anchorLeft: 2, contentEpoch: 9, layoutGeneration: 5, rowOffset: 1, colOffset: 2}
 
-	packet, ok := model.mousePacket(tea.MouseClickMsg(tea.Mouse{X: 3, Y: model.renderedHeaderHeight, Button: tea.MouseLeft}))
+	packet, ok := model.mousePacket(tea.MouseClickMsg(tea.Mouse{X: 3, Y: model.layout.header.Height, Button: tea.MouseLeft}))
 	if !ok {
 		t.Fatal("click should encode a mouse packet")
 	}
@@ -419,7 +419,7 @@ func TestMousePacketClampsPresentationScrollOffsetInsideWindow(t *testing.T) {
 	})
 	model.presentationScroll[7] = presentationScroll{anchorTop: 10, anchorLeft: 2, contentEpoch: 9, layoutGeneration: 5, rowOffset: 1, colOffset: 2}
 
-	packet, ok := model.mousePacket(tea.MouseClickMsg(tea.Mouse{X: 9, Y: model.renderedHeaderHeight + 2, Button: tea.MouseLeft}))
+	packet, ok := model.mousePacket(tea.MouseClickMsg(tea.Mouse{X: 9, Y: model.layout.header.Height + 2, Button: tea.MouseLeft}))
 	if !ok {
 		t.Fatal("click should encode a mouse packet")
 	}

--- a/go/tui/internal/ui/layout.go
+++ b/go/tui/internal/ui/layout.go
@@ -1,0 +1,49 @@
+package ui
+
+// uiRect describes a rectangular region of the terminal in absolute screen
+// coordinates. A zero-value rect (Width == 0 || Height == 0) means the region
+// is absent this frame (e.g. no file tree visible).
+type uiRect struct {
+	X, Y, Width, Height int
+}
+
+func (r uiRect) Contains(x, y int) bool {
+	return r.Width > 0 && r.Height > 0 &&
+		x >= r.X && x < r.X+r.Width &&
+		y >= r.Y && y < r.Y+r.Height
+}
+
+func (r uiRect) Translate(x, y int) (int, int) {
+	return x - r.X, y - r.Y
+}
+
+// uiLayout describes the spatial arrangement of every top-level region for
+// one frame. It is computed once per Update() from the current chrome state
+// and terminal dimensions, then read by the renderer, the mouse router, and
+// the viewport sizing code. This is the single source of truth for "where is
+// each region on screen?", replacing the scattered bodyHeight() /
+// renderedHeaderHeight / leftChromeWidth() / semanticContentOffsets() calls.
+type uiLayout struct {
+	header   uiRect
+	body     uiRect
+	footer   uiRect
+	leftPane uiRect // file tree or sidebar; zero when neither is visible
+}
+
+func (m Model) computeLayout() uiLayout {
+	width := max(m.width, 1)
+	height := max(m.height, 1)
+
+	headerHeight := len(m.headerLines())
+	footerHeight := len(m.footerLines())
+	bodyHeight := max(height-headerHeight-footerHeight, 1)
+
+	leftPaneWidth := m.leftChromeWidth()
+
+	return uiLayout{
+		header: uiRect{X: 0, Y: 0, Width: width, Height: headerHeight},
+		body:   uiRect{X: leftPaneWidth, Y: headerHeight, Width: max(width-leftPaneWidth, 1), Height: bodyHeight},
+		footer: uiRect{X: 0, Y: headerHeight + bodyHeight, Width: width, Height: footerHeight},
+		leftPane: uiRect{X: 0, Y: headerHeight, Width: leftPaneWidth, Height: bodyHeight},
+	}
+}

--- a/go/tui/internal/ui/layout.go
+++ b/go/tui/internal/ui/layout.go
@@ -41,9 +41,9 @@ func (m Model) computeLayout() uiLayout {
 	leftPaneWidth := m.leftChromeWidth()
 
 	return uiLayout{
-		header: uiRect{X: 0, Y: 0, Width: width, Height: headerHeight},
-		body:   uiRect{X: leftPaneWidth, Y: headerHeight, Width: max(width-leftPaneWidth, 1), Height: bodyHeight},
-		footer: uiRect{X: 0, Y: headerHeight + bodyHeight, Width: width, Height: footerHeight},
+		header:   uiRect{X: 0, Y: 0, Width: width, Height: headerHeight},
+		body:     uiRect{X: leftPaneWidth, Y: headerHeight, Width: max(width-leftPaneWidth, 1), Height: bodyHeight},
+		footer:   uiRect{X: 0, Y: headerHeight + bodyHeight, Width: width, Height: footerHeight},
 		leftPane: uiRect{X: 0, Y: headerHeight, Width: leftPaneWidth, Height: bodyHeight},
 	}
 }

--- a/go/tui/internal/ui/layout.go
+++ b/go/tui/internal/ui/layout.go
@@ -20,9 +20,9 @@ func (r uiRect) Translate(x, y int) (int, int) {
 // uiLayout describes the spatial arrangement of every top-level region for
 // one frame. It is computed once per Update() from the current chrome state
 // and terminal dimensions, then read by the renderer, the mouse router, and
-// the viewport sizing code. This is the single source of truth for "where is
-// each region on screen?", replacing the scattered bodyHeight() /
-// renderedHeaderHeight / leftChromeWidth() / semanticContentOffsets() calls.
+// the viewport sizing code. This centralizes the scattered bodyHeight() /
+// renderedHeaderHeight / leftChromeWidth() / semanticContentOffsets() calls
+// into a single source of truth for region positions.
 type uiLayout struct {
 	header   uiRect
 	body     uiRect

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -59,8 +59,7 @@ type Model struct {
 	// Once an extension ships a terminal runtime decoder, it reads from here.
 	extensionRuntimes     map[string]protocol.ExtensionRuntimePayload
 	bottomPanelScrollback int
-	agentAnimationFrame   uint64
-	agentAnimationRunning bool
+	agent                 agentPanel
 	// latency records end-to-end keystroke-to-write samples (ticket #2215).
 	// It is a pointer so the recorder persists across value-copied Model
 	// updates. hudVisible toggles the on-screen p50/p99 overlay at runtime.
@@ -156,8 +155,8 @@ func New(width, height uint16, out chan<- []byte) Model {
 		lineCache:          newLineCache(),
 		presentationScroll: map[uint16]presentationScroll{},
 	}
-	// Seed the layout so the first mouse event before any frame/resize
-	// translates against the rendered fallback header.
+	// Seed the layout so the first mouse event lands in the correct
+	// region before the first BEAM frame arrives.
 	m.layout = m.computeLayout()
 	return m
 }
@@ -206,8 +205,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.toggleHUD(msg) {
 			break
 		}
-		if m.handleAgentChatShortcut(msg) {
-			break
+		if chat, ok := m.agentChat(); ok {
+			if packet, handled := m.agent.handleKey(chat, msg); handled {
+				m.send(packet)
+				break
+			}
 		}
 		// Stamp the latency correlation sequence (ticket #2215) before
 		// encoding so the resulting frame's commit_frame resolves the sample.
@@ -241,11 +243,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case agentAnimationTickMsg:
-		m.agentAnimationFrame++
-		if m.agentAnimating() {
+		m.agent.tick()
+		if chat, ok := m.agentChat(); ok && m.agent.animating(chat) {
 			cmd = agentAnimationTick()
 		} else {
-			m.agentAnimationRunning = false
+			m.agent.animationRunning = false
 		}
 	case port.PacketMsg:
 		cmd = m.applyCommands(msg.Commands)
@@ -257,8 +259,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.send(protocol.EncodeLogMessage(protocol.LogLevelErr, msg.Err.Error()))
 	}
 
-	if m.agentAnimating() && !m.agentAnimationRunning {
-		m.agentAnimationRunning = true
+	if chat, ok := m.agentChat(); ok && m.agent.animating(chat) && !m.agent.animationRunning {
+		m.agent.animationRunning = true
 		cmd = tea.Batch(cmd, agentAnimationTick())
 	}
 
@@ -778,35 +780,6 @@ func (m *Model) toggleHUD(msg tea.KeyPressMsg) bool {
 		return true
 	}
 	return false
-}
-
-func (m Model) handleAgentChatShortcut(msg tea.KeyPressMsg) bool {
-	chat, ok := m.agentChat()
-	if !ok || !chat.Visible {
-		return false
-	}
-	key := msg.Key()
-	if !key.Mod.Contains(tea.ModCtrl) || !key.Mod.Contains(tea.ModAlt) {
-		return false
-	}
-	switch key.Code {
-	case 'x', 'X':
-		index, ok := latestToolMessageIndex(chat.Messages)
-		if !ok {
-			return false
-		}
-		m.send(protocol.EncodeGUIAgentToolToggle(index))
-		return true
-	case 'z', 'Z':
-		index, ok := latestThinkingMessageIndex(chat.Messages)
-		if !ok {
-			return false
-		}
-		m.send(protocol.EncodeGUIAgentToolToggle(index))
-		return true
-	default:
-		return false
-	}
 }
 
 func latestToolMessageIndex(messages []protocol.AgentChatMessage) (uint16, bool) {

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -78,16 +78,12 @@ type Model struct {
 	// a tab_reorder or file_tree_drop gui_action (ticket #2229, AC3). It is nil
 	// when no draggable press is active.
 	mouseDrag *chromeDrag
-	// renderedHeaderHeight caches the number of header rows the last rendered
-	// frame placed above the editor body. Since #2244 collapsed layout to
-	// Layout.GUI (editor at BEAM row 0), outbound editor-body mouse rows must
-	// subtract this offset to mirror the inbound translation
-	// (render_content.go semanticContentOffsets). It is the single source of
-	// truth shared with the renderer (headerLines), recomputed whenever the
-	// inputs to headerLines change: applied commands (chrome) and resize
-	// (width/height). Caching avoids recomputing headerLines inconsistently per
-	// mouse event (ticket #2256).
-	renderedHeaderHeight int
+	// layout caches the spatial arrangement of every top-level region (header,
+	// body, footer, left pane) for the current frame. It is the single source
+	// of truth for region positions, replacing the old renderedHeaderHeight
+	// cache. Recomputed whenever inputs change: applied commands (chrome) and
+	// resize (width/height).
+	layout uiLayout
 	// staging holds the open frame transaction (#2219). It is non-nil only
 	// between a begin_frame and its commit_frame: semantic/chrome commands
 	// accumulate here instead of mutating the live model, so View() never paints
@@ -160,9 +156,9 @@ func New(width, height uint16, out chan<- []byte) Model {
 		lineCache:          newLineCache(),
 		presentationScroll: map[uint16]presentationScroll{},
 	}
-	// Seed the header-offset cache so the first mouse event before any
-	// frame/resize still translates against the rendered fallback header.
-	m.refreshRenderedHeaderHeight()
+	// Seed the layout so the first mouse event before any frame/resize
+	// translates against the rendered fallback header.
+	m.layout = m.computeLayout()
 	return m
 }
 
@@ -202,9 +198,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// its own, but resetting here keeps the cache from holding stale lines
 		// for the old geometry.
 		m.lineCache.reset()
-		m.refreshRenderedHeaderHeight()
+		m.layout = m.computeLayout()
 		m.viewport.SetWidth(msg.Width)
-		m.viewport.SetHeight(m.bodyHeight())
+		m.viewport.SetHeight(m.layout.body.Height)
 		m.send(protocol.EncodeResize(uint16(max(msg.Width, 1)), uint16(max(msg.Height, 1))))
 	case tea.KeyPressMsg:
 		if m.toggleHUD(msg) {
@@ -253,7 +249,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case port.PacketMsg:
 		cmd = m.applyCommands(msg.Commands)
-		m.refreshRenderedHeaderHeight()
+		m.layout = m.computeLayout()
 	case port.LogMsg:
 		m.send(protocol.EncodeLogMessage(msg.Level, msg.Text))
 	case port.ErrorMsg:
@@ -267,7 +263,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	m.viewport.SetWidth(max(m.width, 1))
-	m.viewport.SetHeight(m.bodyHeight())
+	m.viewport.SetHeight(m.layout.body.Height)
 	m.viewport.SetContent(m.composeBody())
 	return m, cmd
 }
@@ -755,16 +751,7 @@ func (m *Model) removeWindow(id uint16) {
 }
 
 func (m Model) bodyHeight() int {
-	return max(m.height-len(m.headerLines())-len(m.footerLines()), 1)
-}
-
-// refreshRenderedHeaderHeight recomputes the cached header offset from the same
-// headerLines the renderer uses, so outbound mouse translation (mousePacket)
-// stays consistent with the frame on screen (ticket #2256). Call it whenever an
-// input to headerLines changes: applied commands (chrome content) and resize
-// (width drives the breadcrumb threshold).
-func (m *Model) refreshRenderedHeaderHeight() {
-	m.renderedHeaderHeight = len(m.headerLines())
+	return m.layout.body.Height
 }
 
 func (m Model) maxOverlayHeight() int {

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -59,7 +59,8 @@ type Model struct {
 	// Once an extension ships a terminal runtime decoder, it reads from here.
 	extensionRuntimes     map[string]protocol.ExtensionRuntimePayload
 	bottomPanelScrollback int
-	agent                 agentPanel
+	agentAnimationFrame   uint64
+	agentAnimationRunning bool
 	// latency records end-to-end keystroke-to-write samples (ticket #2215).
 	// It is a pointer so the recorder persists across value-copied Model
 	// updates. hudVisible toggles the on-screen p50/p99 overlay at runtime.
@@ -205,11 +206,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.toggleHUD(msg) {
 			break
 		}
-		if chat, ok := m.agentChat(); ok {
-			if packet, handled := m.agent.handleKey(chat, msg); handled {
-				m.send(packet)
-				break
-			}
+		if m.handleAgentChatShortcut(msg) {
+			break
 		}
 		// Stamp the latency correlation sequence (ticket #2215) before
 		// encoding so the resulting frame's commit_frame resolves the sample.
@@ -243,11 +241,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case agentAnimationTickMsg:
-		m.agent.tick()
-		if chat, ok := m.agentChat(); ok && m.agent.animating(chat) {
+		m.agentAnimationFrame++
+		if m.agentAnimating() {
 			cmd = agentAnimationTick()
 		} else {
-			m.agent.animationRunning = false
+			m.agentAnimationRunning = false
 		}
 	case port.PacketMsg:
 		cmd = m.applyCommands(msg.Commands)
@@ -259,8 +257,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.send(protocol.EncodeLogMessage(protocol.LogLevelErr, msg.Err.Error()))
 	}
 
-	if chat, ok := m.agentChat(); ok && m.agent.animating(chat) && !m.agent.animationRunning {
-		m.agent.animationRunning = true
+	if m.agentAnimating() && !m.agentAnimationRunning {
+		m.agentAnimationRunning = true
 		cmd = tea.Batch(cmd, agentAnimationTick())
 	}
 
@@ -780,6 +778,35 @@ func (m *Model) toggleHUD(msg tea.KeyPressMsg) bool {
 		return true
 	}
 	return false
+}
+
+func (m Model) handleAgentChatShortcut(msg tea.KeyPressMsg) bool {
+	chat, ok := m.agentChat()
+	if !ok || !chat.Visible {
+		return false
+	}
+	key := msg.Key()
+	if !key.Mod.Contains(tea.ModCtrl) || !key.Mod.Contains(tea.ModAlt) {
+		return false
+	}
+	switch key.Code {
+	case 'x', 'X':
+		index, ok := latestToolMessageIndex(chat.Messages)
+		if !ok {
+			return false
+		}
+		m.send(protocol.EncodeGUIAgentToolToggle(index))
+		return true
+	case 'z', 'Z':
+		index, ok := latestThinkingMessageIndex(chat.Messages)
+		if !ok {
+			return false
+		}
+		m.send(protocol.EncodeGUIAgentToolToggle(index))
+		return true
+	default:
+		return false
+	}
 }
 
 func latestToolMessageIndex(messages []protocol.AgentChatMessage) (uint16, bool) {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1336,6 +1336,7 @@ func TestSplitSeparatorsNormalizeAgainstHeaderAndFileTree(t *testing.T) {
 		}},
 	}
 	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "body-0"}, {Text: "body-1"}, {Text: "body-2"}}})
+	model.layout = model.computeLayout()
 	model.viewport.SetContent(model.content())
 
 	lines := strings.Split(ansi.Strip(model.View().Content), "\n")
@@ -1412,6 +1413,7 @@ func TestSemanticWindowsNormalizeAbsoluteTUILayoutGeometry(t *testing.T) {
 	model := New(90, 8, nil)
 	model.title = "Header"
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiFileTree: {Tree: protocol.FileTree{Visible: true, Width: 36, Rows: []protocol.FileTreeRow{{ID: "row-0", Name: "row-0"}}}}}
+	model.layout = model.computeLayout()
 	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 1, Col: 37, Width: 8, Height: 1}}})
 	model.viewport.SetContent(model.content())
 
@@ -1475,7 +1477,7 @@ func TestPresentationScrollUsesOverscanRowsImmediately(t *testing.T) {
 		t.Fatalf("initial render should use committed visible rows, got %q", initial)
 	}
 
-	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.renderedHeaderHeight}))
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.layout.header.Height}))
 	scrolled := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
 	if !strings.Contains(scrolled, "bottom") || !strings.Contains(scrolled, "below") || strings.Contains(scrolled, "top") {
 		t.Fatalf("local presentation scroll should shift into overscan rows immediately, got %q", scrolled)
@@ -1522,7 +1524,7 @@ func TestPresentationScrollUsesMatchingOverscanGutterRows(t *testing.T) {
 		t.Fatalf("visible content should use the matching presentation gutter row, got %q", initial)
 	}
 
-	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.renderedHeaderHeight}))
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.layout.header.Height}))
 	scrolled := strings.Join(stripRenderedLines(model.renderWindowRows(model.windows[7])), "|")
 	if !strings.Contains(scrolled, "C  bottom") || !strings.Contains(scrolled, "D  below") {
 		t.Fatalf("locally shifted content should keep matching gutter rows, got %q", scrolled)
@@ -1559,9 +1561,9 @@ func TestPresentationScrollUsesPayloadLocalRowsForWrappedContent(t *testing.T) {
 		t.Fatalf("wrapped payload should not skip its first row just because document visual offset is non-zero, got %q", initial)
 	}
 
-	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.renderedHeaderHeight}))
-	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.renderedHeaderHeight}))
-	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.renderedHeaderHeight}))
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.layout.header.Height}))
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.layout.header.Height}))
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, X: 1, Y: model.layout.header.Height}))
 
 	scroll := model.presentationScroll[7]
 	if scroll.rowOffset != 3 {
@@ -1586,13 +1588,13 @@ func TestPresentationScrollShiftWheelMovesHorizontally(t *testing.T) {
 		Scroll:       protocol.ScrollPresentation{WindowID: 7, ContentEpoch: 9, AnchorTop: 10, AnchorLeft: 0, LayoutGeneration: 5},
 	})
 
-	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, Mod: tea.ModShift, X: 1, Y: model.renderedHeaderHeight}))
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown, Mod: tea.ModShift, X: 1, Y: model.layout.header.Height}))
 	scroll := model.presentationScroll[7]
 	if scroll.rowOffset != 0 || scroll.colOffset != 1 {
 		t.Fatalf("shift wheel-down should move presentation horizontally, got row=%d col=%d", scroll.rowOffset, scroll.colOffset)
 	}
 
-	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelUp, Mod: tea.ModShift, X: 1, Y: model.renderedHeaderHeight}))
+	model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelUp, Mod: tea.ModShift, X: 1, Y: model.layout.header.Height}))
 	if _, ok := model.presentationScroll[7]; ok {
 		t.Fatalf("shift wheel-up should cancel the horizontal offset and clear presentation scroll")
 	}
@@ -1635,7 +1637,7 @@ func TestPresentationScrollHorizontalWheelRightClampsAtContentEdge(t *testing.T)
 	})
 
 	for range 10 {
-		model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelRight, X: 1, Y: model.renderedHeaderHeight}))
+		model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelRight, X: 1, Y: model.layout.header.Height}))
 	}
 
 	scroll := model.presentationScroll[7]
@@ -1661,7 +1663,7 @@ func TestPresentationScrollHorizontalWheelRightUsesTextRectWidth(t *testing.T) {
 	})
 
 	for range 10 {
-		model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelRight, X: 3, Y: model.renderedHeaderHeight}))
+		model = model.applyPresentationScroll(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelRight, X: 3, Y: model.layout.header.Height}))
 	}
 
 	if got := model.presentationScroll[7].colOffset; got != 2 {

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -141,7 +141,7 @@ func (m Model) normalizeChromeGeometry(row int, col int) (int, int) {
 }
 
 func (m Model) semanticContentOffsets() (int, int) {
-	return len(m.headerLines()), m.leftChromeWidth()
+	return m.layout.header.Height, m.layout.leftPane.Width
 }
 
 func (m Model) leftChromeWidth() int {

--- a/go/tui/internal/ui/semantic_mouse.go
+++ b/go/tui/internal/ui/semantic_mouse.go
@@ -161,7 +161,8 @@ func maxPresentationLeft(window protocol.WindowContent) int {
 }
 
 func (m Model) presentationScrollWindowAt(x int, y int) (uint16, bool) {
-	return m.presentationScrollWindowAtBody(x-m.leftChromeWidth(), y-m.renderedHeaderHeight)
+	bodyX, bodyY := m.layout.body.Translate(x, y)
+	return m.presentationScrollWindowAtBody(bodyX, bodyY)
 }
 
 func (m Model) presentationScrollWindowAtBody(x int, y int) (uint16, bool) {


### PR DESCRIPTION
## Summary

- Introduces a `uiLayout` struct (`layout.go`) with `uiRect` type providing `Contains` and `Translate` methods, centralizing all spatial region calculations (header, body, footer, left pane) into a single source of truth
- Replaces the `renderedHeaderHeight` cache and scattered height/width computations across 6 files, eliminating a class of layout-drift bugs where mouse translation and rendering compute offsets independently (ticket #2256)
- Phase 1 of the Go TUI architecture improvements plan (layout struct > input filter > agent chat extraction > mouse rect routing > overlay stack)

## Test plan

- [x] All 199 existing tests pass with `-race` (no new tests needed; layout is computed from the same inputs, just centralized)
- [x] `go build ./cmd/...` clean
- [ ] Manual: launch TUI connected to BEAM, verify mouse clicks land correctly on tabs, file tree, editor body, and breadcrumbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)