### PR TITLE
perf: throttle mouse input at 60fps with input filter

### DIFF
--- a/go/tui/cmd/minga-renderer-go/main.go
+++ b/go/tui/cmd/minga-renderer-go/main.go
@@ -36,7 +36,8 @@ func run() error {
 	go writePackets(os.Stdout, out)
 
 	model := ui.New(width, height, out)
-	program := tea.NewProgram(model, tea.WithInput(tty), tea.WithOutput(tty))
+	filter := ui.NewInputFilter()
+	program := tea.NewProgram(model, tea.WithInput(tty), tea.WithOutput(tty), tea.WithFilter(filter.Filter))
 	port.StartReader(program, os.Stdin)
 
 	_, err = program.Run()

--- a/go/tui/internal/ui/filter.go
+++ b/go/tui/internal/ui/filter.go
@@ -1,0 +1,46 @@
+package ui
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+const inputFilterInterval = 16 * time.Millisecond // ~60fps
+
+type InputFilter struct {
+	now        func() time.Time
+	lastMotion time.Time
+	lastWheel  time.Time
+}
+
+func NewInputFilter() *InputFilter {
+	return &InputFilter{now: time.Now}
+}
+
+func (f *InputFilter) Filter(_ tea.Model, msg tea.Msg) tea.Msg {
+	switch msg.(type) {
+	case tea.MouseMotionMsg:
+		if !f.allow(&f.lastMotion) {
+			return nil
+		}
+	case tea.MouseWheelMsg:
+		if !f.allow(&f.lastWheel) {
+			return nil
+		}
+	}
+	return msg
+}
+
+func (f *InputFilter) allow(last *time.Time) bool {
+	now := f.now
+	if now == nil {
+		now = time.Now
+	}
+	at := now()
+	if !last.IsZero() && at.Sub(*last) < inputFilterInterval {
+		return false
+	}
+	*last = at
+	return true
+}

--- a/go/tui/internal/ui/filter.go
+++ b/go/tui/internal/ui/filter.go
@@ -33,11 +33,7 @@ func (f *InputFilter) Filter(_ tea.Model, msg tea.Msg) tea.Msg {
 }
 
 func (f *InputFilter) allow(last *time.Time) bool {
-	now := f.now
-	if now == nil {
-		now = time.Now
-	}
-	at := now()
+	at := f.now()
 	if !last.IsZero() && at.Sub(*last) < inputFilterInterval {
 		return false
 	}

--- a/go/tui/internal/ui/filter_test.go
+++ b/go/tui/internal/ui/filter_test.go
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestInputFilterThrottlesMotion(t *testing.T) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	f := &InputFilter{now: func() time.Time { return now }}
+
+	msg := tea.MouseMotionMsg(tea.Mouse{X: 5, Y: 5, Button: tea.MouseNone})
+
+	if got := f.Filter(nil, msg); got == nil {
+		t.Fatal("first motion should pass through")
+	}
+
+	now = now.Add(5 * time.Millisecond)
+	if got := f.Filter(nil, msg); got != nil {
+		t.Fatal("motion within 16ms should be dropped")
+	}
+
+	now = now.Add(20 * time.Millisecond)
+	if got := f.Filter(nil, msg); got == nil {
+		t.Fatal("motion after 16ms should pass through")
+	}
+}
+
+func TestInputFilterThrottlesWheel(t *testing.T) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	f := &InputFilter{now: func() time.Time { return now }}
+
+	msg := tea.MouseWheelMsg(tea.Mouse{X: 5, Y: 5, Button: tea.MouseWheelDown})
+
+	if got := f.Filter(nil, msg); got == nil {
+		t.Fatal("first wheel should pass through")
+	}
+
+	now = now.Add(5 * time.Millisecond)
+	if got := f.Filter(nil, msg); got != nil {
+		t.Fatal("wheel within 16ms should be dropped")
+	}
+
+	now = now.Add(20 * time.Millisecond)
+	if got := f.Filter(nil, msg); got == nil {
+		t.Fatal("wheel after 16ms should pass through")
+	}
+}
+
+func TestInputFilterPassesKeyPresses(t *testing.T) {
+	f := NewInputFilter()
+	msg := tea.KeyPressMsg(tea.Key{Code: 'a', Text: "a"})
+	if got := f.Filter(nil, msg); got == nil {
+		t.Fatal("key presses must never be dropped")
+	}
+}
+
+func TestInputFilterMotionAndWheelThrottleIndependently(t *testing.T) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	f := &InputFilter{now: func() time.Time { return now }}
+
+	motion := tea.MouseMotionMsg(tea.Mouse{X: 5, Y: 5, Button: tea.MouseNone})
+	wheel := tea.MouseWheelMsg(tea.Mouse{X: 5, Y: 5, Button: tea.MouseWheelDown})
+
+	if got := f.Filter(nil, motion); got == nil {
+		t.Fatal("first motion should pass")
+	}
+
+	now = now.Add(5 * time.Millisecond)
+	if got := f.Filter(nil, wheel); got == nil {
+		t.Fatal("first wheel should pass even when motion was just allowed")
+	}
+}

--- a/go/tui/internal/ui/filter_test.go
+++ b/go/tui/internal/ui/filter_test.go
@@ -57,6 +57,22 @@ func TestInputFilterPassesKeyPresses(t *testing.T) {
 	}
 }
 
+func TestInputFilterExactBoundaryPasses(t *testing.T) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	f := &InputFilter{now: func() time.Time { return now }}
+
+	msg := tea.MouseMotionMsg(tea.Mouse{X: 5, Y: 5, Button: tea.MouseNone})
+
+	if got := f.Filter(nil, msg); got == nil {
+		t.Fatal("first motion should pass through")
+	}
+
+	now = now.Add(inputFilterInterval)
+	if got := f.Filter(nil, msg); got == nil {
+		t.Fatal("motion at exactly 16ms should pass (condition is strictly less-than)")
+	}
+}
+
 func TestInputFilterMotionAndWheelThrottleIndependently(t *testing.T) {
 	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	f := &InputFilter{now: func() time.Time { return now }}


### PR DESCRIPTION
## Summary

- Adds an `InputFilter` that rate-limits `MouseMotionMsg` and `MouseWheelMsg` to one sample per 16ms (~60fps) using `tea.WithFilter`, preventing continuous mouse input from flooding the Bubble Tea update queue
- Motion and wheel streams throttle independently so a drag doesn't block scroll events and vice versa
- Key presses, clicks, and releases pass through unfiltered
- Phase 2 of the Go TUI architecture improvements plan (independent of Phase 1 layout struct)

## Test plan

- [x] 4 new filter tests: motion throttle, wheel throttle, key passthrough, independent throttle streams
- [x] All 203 tests pass with `-race`
- [x] `go build ./cmd/...` clean
- [ ] Manual: fast drag and scroll in TUI, verify responsiveness and no dropped key presses

🤖 Generated with [Claude Code](https://claude.com/claude-code)