### PR TITLE
refactor: extract agent chat into agentPanel struct

### DIFF
--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -5,9 +5,69 @@ import (
 	"image/color"
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
 )
+
+type agentPanel struct {
+	animationFrame   uint64
+	animationRunning bool
+}
+
+func (a *agentPanel) animating(chat protocol.AgentChat) bool {
+	if !chat.Visible {
+		return false
+	}
+	if chat.Status == 1 || chat.Status == 2 || chat.Pending != "" {
+		return true
+	}
+	for _, msg := range chat.Messages {
+		if msg.Kind == agentKindThinking || ((msg.Kind == agentKindTool || msg.Kind == agentKindStyledTool) && msg.Status == 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *agentPanel) tick() {
+	a.animationFrame++
+}
+
+func (a *agentPanel) spinner() string {
+	frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	return frames[int(a.animationFrame)%len(frames)]
+}
+
+func (a *agentPanel) handleKey(chat protocol.AgentChat, msg tea.KeyPressMsg) ([]byte, bool) {
+	if !chat.Visible {
+		return nil, false
+	}
+	key := msg.Key()
+	if !key.Mod.Contains(tea.ModCtrl) || !key.Mod.Contains(tea.ModAlt) {
+		return nil, false
+	}
+	switch key.Code {
+	case 'x', 'X':
+		index, ok := latestToolMessageIndex(chat.Messages)
+		if !ok {
+			return nil, false
+		}
+		return protocol.EncodeGUIAgentToolToggle(index), true
+	case 'z', 'Z':
+		index, ok := latestThinkingMessageIndex(chat.Messages)
+		if !ok {
+			return nil, false
+		}
+		return protocol.EncodeGUIAgentToolToggle(index), true
+	default:
+		return nil, false
+	}
+}
+
+func (a *agentPanel) panelHeight(height int) int {
+	return min(max(height/2, 8), 18)
+}
 
 const (
 	agentKindUser              byte = 0x01
@@ -30,7 +90,7 @@ const (
 )
 
 func (m Model) renderAgentChatPanel(chat protocol.AgentChat) []string {
-	return m.renderAgentChatPanelWithLimit(chat, max(m.width, 1), m.agentPanelHeight())
+	return m.renderAgentChatPanelWithLimit(chat, max(m.width, 1), m.agent.panelHeight(m.height))
 }
 
 func (m Model) renderAgentChatBody(chat protocol.AgentChat) []string {
@@ -76,7 +136,7 @@ func (m Model) renderAgentChatPanelWithLimit(chat protocol.AgentChat, width int,
 }
 
 func (m Model) agentPanelHeight() int {
-	return min(max(m.height/2, 8), 18)
+	return m.agent.panelHeight(m.height)
 }
 
 func agentDetailsVisible(width int) bool {
@@ -398,8 +458,7 @@ func (m Model) renderAgentStatusBadge(status byte) string {
 }
 
 func (m Model) agentSpinner() string {
-	frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
-	return frames[int(m.agentAnimationFrame)%len(frames)]
+	return m.agent.spinner()
 }
 
 func agentChatStatusLabel(status byte) string {

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -59,8 +59,7 @@ type Model struct {
 	// Once an extension ships a terminal runtime decoder, it reads from here.
 	extensionRuntimes     map[string]protocol.ExtensionRuntimePayload
 	bottomPanelScrollback int
-	agentAnimationFrame   uint64
-	agentAnimationRunning bool
+	agent                 agentPanel
 	// latency records end-to-end keystroke-to-write samples (ticket #2215).
 	// It is a pointer so the recorder persists across value-copied Model
 	// updates. hudVisible toggles the on-screen p50/p99 overlay at runtime.
@@ -206,8 +205,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.toggleHUD(msg) {
 			break
 		}
-		if m.handleAgentChatShortcut(msg) {
-			break
+		if chat, ok := m.agentChat(); ok {
+			if packet, handled := m.agent.handleKey(chat, msg); handled {
+				m.send(packet)
+				break
+			}
 		}
 		// Stamp the latency correlation sequence (ticket #2215) before
 		// encoding so the resulting frame's commit_frame resolves the sample.
@@ -241,11 +243,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case agentAnimationTickMsg:
-		m.agentAnimationFrame++
-		if m.agentAnimating() {
+		m.agent.tick()
+		if chat, ok := m.agentChat(); ok && m.agent.animating(chat) {
 			cmd = agentAnimationTick()
 		} else {
-			m.agentAnimationRunning = false
+			m.agent.animationRunning = false
 		}
 	case port.PacketMsg:
 		cmd = m.applyCommands(msg.Commands)
@@ -257,8 +259,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.send(protocol.EncodeLogMessage(protocol.LogLevelErr, msg.Err.Error()))
 	}
 
-	if m.agentAnimating() && !m.agentAnimationRunning {
-		m.agentAnimationRunning = true
+	if chat, ok := m.agentChat(); ok && m.agent.animating(chat) && !m.agent.animationRunning {
+		m.agent.animationRunning = true
 		cmd = tea.Batch(cmd, agentAnimationTick())
 	}
 
@@ -778,35 +780,6 @@ func (m *Model) toggleHUD(msg tea.KeyPressMsg) bool {
 		return true
 	}
 	return false
-}
-
-func (m Model) handleAgentChatShortcut(msg tea.KeyPressMsg) bool {
-	chat, ok := m.agentChat()
-	if !ok || !chat.Visible {
-		return false
-	}
-	key := msg.Key()
-	if !key.Mod.Contains(tea.ModCtrl) || !key.Mod.Contains(tea.ModAlt) {
-		return false
-	}
-	switch key.Code {
-	case 'x', 'X':
-		index, ok := latestToolMessageIndex(chat.Messages)
-		if !ok {
-			return false
-		}
-		m.send(protocol.EncodeGUIAgentToolToggle(index))
-		return true
-	case 'z', 'Z':
-		index, ok := latestThinkingMessageIndex(chat.Messages)
-		if !ok {
-			return false
-		}
-		m.send(protocol.EncodeGUIAgentToolToggle(index))
-		return true
-	default:
-		return false
-	}
 }
 
 func latestToolMessageIndex(messages []protocol.AgentChatMessage) (uint16, bool) {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1234,15 +1234,16 @@ func TestAgentChatShortcutTogglesLatestToolBlock(t *testing.T) {
 
 func TestAgentAnimationCueChangesAcrossFrames(t *testing.T) {
 	model := New(80, 24, nil)
-	model.agentAnimationFrame = 0
+	model.agent.animationFrame = 0
 	first := ansi.Strip(model.renderAgentStatusBadge(1))
-	model.agentAnimationFrame = 1
+	model.agent.animationFrame = 1
 	second := ansi.Strip(model.renderAgentStatusBadge(1))
 	if first == second {
 		t.Fatalf("thinking status badge should animate across frames: %q", first)
 	}
-	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentChat: {AgentChat: protocol.AgentChat{Visible: true, Status: 1}}}
-	if !model.agentAnimating() {
+	chat := protocol.AgentChat{Visible: true, Status: 1}
+	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentChat: {AgentChat: chat}}
+	if !model.agent.animating(chat) {
 		t.Fatalf("visible thinking agent should animate")
 	}
 }

--- a/go/tui/internal/ui/selectors.go
+++ b/go/tui/internal/ui/selectors.go
@@ -240,22 +240,6 @@ func (m Model) agentChatVisible() bool {
 	return ok && chat.Visible
 }
 
-func (m Model) agentAnimating() bool {
-	chat, ok := m.agentChat()
-	if !ok || !chat.Visible {
-		return false
-	}
-	if chat.Status == 1 || chat.Status == 2 || chat.Pending != "" {
-		return true
-	}
-	for _, msg := range chat.Messages {
-		if msg.Kind == agentKindThinking || ((msg.Kind == agentKindTool || msg.Kind == agentKindStyledTool) && msg.Status == 0) {
-			return true
-		}
-	}
-	return false
-}
-
 func (m Model) editTimeline() (protocol.EditTimeline, bool) {
 	for _, payload := range m.chrome {
 		if payload.Timeline.Visible {


### PR DESCRIPTION
## Summary

- Introduces `agentPanel` struct that owns animation state (`animationFrame`, `animationRunning`) and behavioral methods (`animating`, `spinner`, `handleKey`, `panelHeight`), replacing five scattered Model fields and methods
- Model delegates to `m.agent` for animation ticks, Ctrl+Alt+X/Z shortcut handling, and panel height calculation
- Rendering methods stay on Model for now (they call `m.agent.spinner()` for the animation cue); full rendering extraction is a follow-up
- Includes Phase 1 layout struct changes (separate PR #2524 for independent review)
- Phase 3 of the Go TUI architecture improvements plan, establishing the component extraction pattern for Phase 5 (overlay stack)

## Test plan

- [x] All 199 tests pass with `-race`
- [x] `go build ./cmd/...` clean
- [ ] Manual: agent chat animation, Ctrl+Alt+X/Z shortcuts, panel sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)