### PR TITLE
refactor: route semantic mouse clicks by layout region

### DIFF
--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -135,7 +135,7 @@ type frameStaging struct {
 }
 
 func New(width, height uint16, out chan<- []byte) Model {
-	vp := viewport.New(viewport.WithWidth(int(width)), viewport.WithHeight(max(int(height)-3, 1)))
+	vp := viewport.New(viewport.WithWidth(int(width)), viewport.WithHeight(1))
 	m := Model{
 		width:             int(width),
 		height:            int(height),
@@ -158,6 +158,7 @@ func New(width, height uint16, out chan<- []byte) Model {
 	// Seed the layout so the first mouse event lands in the correct
 	// region before the first BEAM frame arrives.
 	m.layout = m.computeLayout()
+	m.viewport.SetHeight(m.layout.body.Height)
 	return m
 }
 

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1946,6 +1946,8 @@ func TestSemanticMouseRoutesModelineAndFileTreeZones(t *testing.T) {
 		generated.OPGuiTabBar:    {Tabs: protocol.TabBar{Tabs: []protocol.Tab{{ID: 41, Icon: "󰈙", Label: "one.ex"}, {ID: 42, Icon: "󰈙", Label: "two.ex", Active: true}}}},
 		generated.OPGuiFileTree:  {Tree: protocol.FileTree{Visible: true, Width: 24, Rows: []protocol.FileTreeRow{{ID: "row-0", Name: "row-0"}, {ID: "row-1", Name: "row-1"}}}},
 	}
+	model.layout = model.computeLayout()
+	model.viewport.SetHeight(model.layout.body.Height)
 	model.viewport.SetContent(model.content())
 	_ = model.View()
 
@@ -1979,6 +1981,8 @@ func TestSemanticMouseRoutesBreadcrumbSegmentZones(t *testing.T) {
 	model.chrome = map[byte]protocol.ChromePayload{
 		generated.OPGuiBreadcrumb: {Breadcrumb: protocol.Breadcrumb{Segments: []string{"lib", "minga", "main.ex"}}},
 	}
+	model.layout = model.computeLayout()
+	model.viewport.SetHeight(model.layout.body.Height)
 	model.viewport.SetContent(model.content())
 	_ = model.View()
 
@@ -2329,6 +2333,8 @@ func TestSemanticMouseRoutesSidebarItemZones(t *testing.T) {
 		}}},
 	}
 	model.putWindow(protocol.WindowContent{ID: 1, Rows: []protocol.WindowRow{{Text: "pane"}}, GeometrySet: true, Geometry: protocol.PaneGeometry{ContentRect: protocol.Rect{Row: 0, Col: 0, Width: 8, Height: 1}}})
+	model.layout = model.computeLayout()
+	model.viewport.SetHeight(model.layout.body.Height)
 	model.viewport.SetContent(model.content())
 	_ = model.View()
 

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1976,6 +1976,17 @@ func TestSemanticMouseRoutesModelineAndFileTreeZones(t *testing.T) {
 	}
 }
 
+func TestSemanticMouseBodyClickFallsThrough(t *testing.T) {
+	model := New(60, 12, nil)
+	model.layout = model.computeLayout()
+
+	bodyX := model.layout.body.X + 1
+	bodyY := model.layout.body.Y + 1
+	if _, ok := model.semanticMousePacket(tea.MouseClickMsg(tea.Mouse{Button: tea.MouseLeft, X: bodyX, Y: bodyY})); ok {
+		t.Fatal("body-region click should not be handled by semantic routing")
+	}
+}
+
 func TestSemanticMouseRoutesBreadcrumbSegmentZones(t *testing.T) {
 	model := New(120, 12, nil)
 	model.chrome = map[byte]protocol.ChromePayload{

--- a/go/tui/internal/ui/semantic_mouse.go
+++ b/go/tui/internal/ui/semantic_mouse.go
@@ -213,25 +213,29 @@ func (m Model) semanticMousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	if !ok || click.Button != tea.MouseLeft {
 		return nil, false
 	}
-	if packet, ok := m.modelineMousePacket(msg); ok {
+	if packet, ok := m.overlayMousePacket(msg); ok {
 		return packet, true
 	}
-	if packet, ok := m.tabMousePacket(msg); ok {
-		return packet, true
+	mouse := msg.Mouse()
+	switch {
+	case m.layout.header.Contains(mouse.X, mouse.Y):
+		return m.headerMousePacket(msg)
+	case m.layout.leftPane.Contains(mouse.X, mouse.Y):
+		return m.leftPaneMousePacket(msg)
+	case m.layout.footer.Contains(mouse.X, mouse.Y):
+		return m.footerMousePacket(msg)
 	}
-	if packet, ok := m.fileTreeMousePacket(msg); ok {
-		return packet, true
-	}
-	if packet, ok := m.breadcrumbMousePacket(msg); ok {
-		return packet, true
-	}
+	return nil, false
+}
+
+func (m Model) overlayMousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	if packet, ok := m.completionMousePacket(msg); ok {
 		return packet, true
 	}
-	if packet, ok := m.sidebarMousePacket(msg); ok {
+	if packet, ok := m.hoverActionMousePacket(msg); ok {
 		return packet, true
 	}
-	if packet, ok := m.hoverActionMousePacket(msg); ok {
+	if packet, ok := m.floatPopupMousePacket(msg); ok {
 		return packet, true
 	}
 	if packet, ok := m.notificationMousePacket(msg); ok {
@@ -243,10 +247,31 @@ func (m Model) semanticMousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	if packet, ok := m.editTimelineMousePacket(msg); ok {
 		return packet, true
 	}
-	if packet, ok := m.floatPopupMousePacket(msg); ok {
+	return nil, false
+}
+
+func (m Model) headerMousePacket(msg tea.MouseMsg) ([]byte, bool) {
+	if packet, ok := m.tabMousePacket(msg); ok {
+		return packet, true
+	}
+	if packet, ok := m.breadcrumbMousePacket(msg); ok {
 		return packet, true
 	}
 	return nil, false
+}
+
+func (m Model) leftPaneMousePacket(msg tea.MouseMsg) ([]byte, bool) {
+	if packet, ok := m.fileTreeMousePacket(msg); ok {
+		return packet, true
+	}
+	if packet, ok := m.sidebarMousePacket(msg); ok {
+		return packet, true
+	}
+	return nil, false
+}
+
+func (m Model) footerMousePacket(msg tea.MouseMsg) ([]byte, bool) {
+	return m.modelineMousePacket(msg)
 }
 
 // floatPopupMousePacket maps a click in the float popup's overlay band but

--- a/go/tui/internal/ui/semantic_mouse.go
+++ b/go/tui/internal/ui/semantic_mouse.go
@@ -228,6 +228,8 @@ func (m Model) semanticMousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	return nil, false
 }
 
+// overlayMousePacket is checked before spatial dispatch because overlays render
+// above all layout zones and must intercept clicks regardless of position.
 func (m Model) overlayMousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	if packet, ok := m.completionMousePacket(msg); ok {
 		return packet, true


### PR DESCRIPTION
## Summary

- Restructures `semanticMousePacket()` to use layout rects for spatial dispatch instead of linearly scanning all 11 zone handlers for every click
- Overlays (completion, hover, float popup, notifications, observatory, timeline) are checked first since they float above the layout grid
- Remaining clicks are dispatched by layout region: header (tabs, breadcrumb), left pane (file tree, sidebar), or footer (modeline)
- Fixes the viewport init in `New()` to derive its height from the computed layout instead of a hardcoded `-3`, keeping viewport and layout in sync from the start
- Phase 4 of the Go TUI architecture improvements plan

## Test plan

- [x] All 199 tests pass with `-race`
- [x] `go build ./cmd/...` clean
- [x] 3 semantic mouse tests updated to sync layout after setting chrome (modeline+fileTree, breadcrumb, sidebar)
- [ ] Manual: click tabs, file tree rows, breadcrumbs, modeline, sidebar items, completion popup, notifications, observatory, timeline, float popup dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)