### PR TITLE
feat: convert external formatter to AsyncAction (D2)

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -906,6 +906,10 @@ defmodule MingaEditor do
     GuiActionHandler.apply_git_result(state, result)
   end
 
+  defp apply_async_result(state, :format_external, result) do
+    MingaEditor.Commands.Formatting.apply_format_external_result(state, result)
+  end
+
   # Defensive fallthrough: a lane with no apply handler degrades to a logged
   # no-op rather than crashing the editor GenServer.
   defp apply_async_result(state, lane, _result) do

--- a/lib/minga_editor/commands/formatting.ex
+++ b/lib/minga_editor/commands/formatting.ex
@@ -170,25 +170,43 @@ defmodule MingaEditor.Commands.Formatting do
 
   # ── Private helpers ───────────────────────────────────────────────────────
 
+  @format_external_lane :format_external
+
   @spec format_and_replace(state(), pid(), Minga.Editing.Formatter.formatter_spec()) :: state()
   defp format_and_replace(state, buf, spec) do
     content = Buffer.content(buf)
-    buf_name = Buffer.file_path(buf) |> Path.basename()
+    version = Buffer.version(buf)
 
-    case Minga.Editing.format(content, spec) do
-      {:ok, formatted} ->
-        {cursor_line, cursor_col} = Buffer.cursor(buf)
-        Buffer.replace_content(buf, formatted)
-        line_count = Buffer.line_count(buf)
-        safe_line = min(cursor_line, max(line_count - 1, 0))
-        Buffer.move_to(buf, {safe_line, cursor_col})
-        Minga.Log.info(:editor, "Formatted: #{buf_name}")
-        EditorState.set_status(state, "Formatted")
+    state
+    |> EditorState.set_status("Formatting…")
+    |> MingaEditor.AsyncAction.run(@format_external_lane, fn ->
+      case Minga.Editing.format(content, spec) do
+        {:ok, formatted} -> {:ok, formatted, buf, version}
+        {:error, msg} -> {:error, msg}
+      end
+    end)
+  end
 
-      {:error, msg} ->
-        Minga.Log.warning(:editor, "Formatter failed: #{buf_name} (#{msg})")
-        EditorState.set_status(state, "Format error: #{msg}")
+  @doc false
+  @spec apply_format_external_result(state(), term()) :: state()
+  def apply_format_external_result(state, {:ok, formatted, buf, version}) do
+    if Process.alive?(buf) and Buffer.version(buf) == version do
+      {cursor_line, cursor_col} = Buffer.cursor(buf)
+      Buffer.replace_content(buf, formatted)
+      line_count = Buffer.line_count(buf)
+      safe_line = min(cursor_line, max(line_count - 1, 0))
+      Buffer.move_to(buf, {safe_line, cursor_col})
+      buf_name = (Buffer.file_path(buf) || "scratch") |> Path.basename()
+      Minga.Log.info(:editor, "Formatted: #{buf_name}")
+      EditorState.set_status(state, "Formatted")
+    else
+      EditorState.set_status(state, "Buffer changed, format skipped")
     end
+  end
+
+  def apply_format_external_result(state, {:error, msg}) do
+    Minga.Log.warning(:editor, "Formatter failed: #{msg}")
+    EditorState.set_status(state, "Format error: #{msg}")
   end
 
   # When the formatter binary is missing and a tool recipe exists for it,

--- a/test/minga_editor/commands/formatting_async_test.exs
+++ b/test/minga_editor/commands/formatting_async_test.exs
@@ -1,0 +1,89 @@
+defmodule MingaEditor.Commands.FormattingAsyncTest do
+  @moduledoc "Tests for async external formatter result application."
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Commands.Formatting
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Windows
+  alias MingaEditor.VimState
+  alias MingaEditor.Viewport
+  alias MingaEditor.Window
+  alias MingaEditor.WindowTree
+
+  describe "apply_format_external_result/2" do
+    test "applies formatted content when buffer version matches" do
+      state = base_state("hello world\n")
+      buf = state.workspace.buffers.active
+      version = Buffer.version(buf)
+
+      new_state =
+        Formatting.apply_format_external_result(state, {:ok, "HELLO WORLD\n", buf, version})
+
+      assert Buffer.content(buf) == "HELLO WORLD\n"
+      assert new_state.shell_state.status_msg == "Formatted"
+    end
+
+    test "skips formatting when buffer version changed" do
+      state = base_state("hello world\n")
+      buf = state.workspace.buffers.active
+      old_version = Buffer.version(buf)
+
+      Buffer.replace_content(buf, "modified\n")
+
+      new_state =
+        Formatting.apply_format_external_result(state, {:ok, "STALE\n", buf, old_version})
+
+      assert Buffer.content(buf) == "modified\n"
+      assert new_state.shell_state.status_msg =~ "Buffer changed"
+    end
+
+    test "handles formatter error" do
+      state = base_state("hello\n")
+
+      new_state =
+        Formatting.apply_format_external_result(state, {:error, "formatter exited with code 1"})
+
+      assert new_state.shell_state.status_msg =~ "Format error"
+    end
+
+    test "preserves cursor position after formatting" do
+      state = base_state("line one\nline two\nline three\n")
+      buf = state.workspace.buffers.active
+      Buffer.move_to(buf, {1, 3})
+      version = Buffer.version(buf)
+
+      new_state =
+        Formatting.apply_format_external_result(
+          state,
+          {:ok, "LINE ONE\nLINE TWO\nLINE THREE\n", buf, version}
+        )
+
+      assert Buffer.content(buf) == "LINE ONE\nLINE TWO\nLINE THREE\n"
+      {line, col} = Buffer.cursor(buf)
+      assert line == 1
+      assert col == 3
+      assert new_state.shell_state.status_msg == "Formatted"
+    end
+  end
+
+  defp base_state(content) do
+    buffer = start_supervised!({BufferProcess, content: content}, id: {:buffer, make_ref()})
+
+    workspace = %MingaEditor.Session.State{
+      viewport: Viewport.new(24, 80),
+      editing: VimState.new(),
+      buffers: %Buffers{active: buffer, list: [buffer], active_index: 0},
+      windows: %Windows{
+        tree: WindowTree.new(1),
+        map: %{1 => Window.new(1, buffer, 24, 80)},
+        active: 1,
+        next_id: 2
+      }
+    }
+
+    %EditorState{port_manager: self(), workspace: workspace}
+  end
+end


### PR DESCRIPTION
## Summary
- Converts the blocking `format_and_replace` external formatter subprocess call from synchronous inline execution to the `AsyncAction` lane-based queue (`:format_external` lane)
- Adds staleness guard: captures `Buffer.version` at request time and discards results if the buffer was edited while formatting ran
- Shows immediate "Formatting…" status feedback while the async work runs
- First migration for #2450; additional blocking I/O sites will land in follow-up PRs

## Changes
- `lib/minga_editor/commands/formatting.ex` — `format_and_replace` now calls `AsyncAction.run/3` instead of blocking inline; new public `apply_format_external_result/2` handles the async callback with version check
- `lib/minga_editor.ex` — new `apply_async_result` clause for `:format_external` lane
- `test/minga_editor/commands/formatting_async_test.exs` (new) — 4 tests covering: version-match apply, staleness skip, error handling, cursor preservation

## Test plan
- [x] `mix test test/minga_editor/commands/formatting_async_test.exs` — 4 tests pass
- [x] `mix test test/minga_editor/async_action_test.exs` — 7 tests pass (existing, no regressions)
- [x] `mix format --check-formatted` — clean

Closes #2450

🤖 Generated with [Claude Code](https://claude.com/claude-code)