### PR TITLE
feat: Credo tripwire for inline blocking (D3)

### DIFF
--- a/credo/checks/no_blocking_editor_call_check.exs
+++ b/credo/checks/no_blocking_editor_call_check.exs
@@ -2,9 +2,17 @@ defmodule Minga.Credo.NoBlockingEditorCallCheck do
   @moduledoc """
   Flags synchronous blocking calls inside MingaEditor modules.
 
-  MingaEditor is a single GenServer. Synchronous calls to LSP (`Client.request_sync`), shell commands (`System.cmd`), and sleeps (`Process.sleep`) inside command and handler code head-of-line-block input echo and rendering. These should use `AsyncAction.run/3` or a `Task` instead.
+  MingaEditor is a single GenServer. Synchronous calls to LSP (`Client.request_sync`), shell commands (`System.cmd`), task awaits (`Task.await`), and sleeps (`Process.sleep`) inside command and handler code head-of-line-block input echo and rendering. These should use `AsyncAction.run/3` or a `Task` instead.
 
   Calls nested inside `AsyncAction.run(...)` blocks or `Task.start`/`Task.async` bodies are exempt because the work is already off the critical path.
+
+  ## Inline suppression
+
+  Add `# minga:allow-blocking — <justification>` on the same line as a sanctioned blocking call to suppress the warning. The justification after the dash is required; a bare `# minga:allow-blocking` without explanation will not suppress.
+
+  ## Limitations
+
+  This check matches syntactic call tokens in-module only. A blocking call reached through a helper or another module (e.g. `format_and_replace/3` calling `Minga.Editing.format/2` which calls `System.cmd`) is invisible to it. It catches the copy-paste regression, not transitive blocking. Per-site review (D2) is the real isolation guarantee; this check is a regression tripwire.
 
   See responsiveness epic #2445 (D2/D3) for the full rationale.
   """
@@ -15,9 +23,11 @@ defmodule Minga.Credo.NoBlockingEditorCallCheck do
     category: :warning,
     explanations: [
       check: """
-      `Client.request_sync`, `System.cmd`, and `Process.sleep` block the calling process. Inside MingaEditor modules these block the single editor GenServer, causing head-of-line blocking for input echo and rendering.
+      `Client.request_sync`, `System.cmd`, `Task.await`, and `Process.sleep` block the calling process. Inside MingaEditor modules these block the single editor GenServer, causing head-of-line blocking for input echo and rendering.
 
       Use `AsyncAction.run/3` or a `Task` to move slow work off the critical path.
+
+      To suppress a sanctioned exception, add `# minga:allow-blocking — <justification>` on the same line.
       """
     ]
 
@@ -25,6 +35,7 @@ defmodule Minga.Credo.NoBlockingEditorCallCheck do
     {[:Client], :request_sync},
     {[:Minga, :LSP, :Client], :request_sync},
     {[:System], :cmd},
+    {[:Task], :await},
     {[:Process], :sleep}
   ]
 
@@ -36,6 +47,8 @@ defmodule Minga.Credo.NoBlockingEditorCallCheck do
     {[:Task], :async}
   ]
 
+  @suppression_pattern ~r/# minga:allow-blocking\s+—\s+\S/
+
   # Known blocking-call sites awaiting D2 migration (#2450).
   # Remove entries as each site is migrated to AsyncAction/Task.
   @known_sites [
@@ -44,8 +57,9 @@ defmodule Minga.Credo.NoBlockingEditorCallCheck do
     {"lib/minga_editor/ui/picker/workspace_symbol_source.ex", 46},
     {"lib/minga_editor/ui/picker/code_action_source.ex", 118},
     {"lib/minga_editor/agent/slash_command.ex", 1293},
+    {"lib/minga_editor/agent/slash_command.ex", 1371},
     {"lib/minga_editor/ui/picker/todo_search_source.ex", 99},
-    {"lib/minga_editor/ui/picker/todo_search_source.ex", 119},
+    {"lib/minga_editor/ui/picker/todo_search_source.ex", 119}
   ]
 
   @impl Credo.Check
@@ -55,10 +69,12 @@ defmodule Minga.Credo.NoBlockingEditorCallCheck do
     else
       issue_meta = IssueMeta.for(source_file, params)
       ast = SourceFile.ast(source_file)
+      source_lines = source_file |> SourceFile.source() |> String.split("\n")
 
       ast
       |> find_blocking_calls(issue_meta, false)
       |> Enum.reject(&known_site?(source_file, &1))
+      |> Enum.reject(&suppressed_by_comment?(source_lines, &1))
     end
   end
 
@@ -110,7 +126,8 @@ defmodule Minga.Credo.NoBlockingEditorCallCheck do
 
       [
         format_issue(issue_meta,
-          message: "#{trigger} blocks the editor GenServer. Use AsyncAction.run/3 or a Task to move this off the critical path.",
+          message:
+            "#{trigger} blocks the editor GenServer. Use AsyncAction.run/3 or a Task to move this off the critical path.",
           trigger: trigger,
           line_no: meta[:line]
         )
@@ -136,6 +153,15 @@ defmodule Minga.Credo.NoBlockingEditorCallCheck do
     Enum.any?(@exempt_wrappers, fn {expected_parts, expected_func} ->
       func == expected_func && mod_parts == expected_parts
     end)
+  end
+
+  defp suppressed_by_comment?(source_lines, issue) do
+    line_index = (issue.line_no || 0) - 1
+
+    case Enum.at(source_lines, line_index) do
+      nil -> false
+      line -> Regex.match?(@suppression_pattern, line)
+    end
   end
 
   defp known_site?(%SourceFile{} = source_file, issue) do

--- a/test/minga/credo/no_blocking_editor_call_check_test.exs
+++ b/test/minga/credo/no_blocking_editor_call_check_test.exs
@@ -1,0 +1,203 @@
+Code.require_file("credo/checks/no_blocking_editor_call_check.exs")
+
+defmodule Minga.Credo.NoBlockingEditorCallCheckTest do
+  use Credo.Test.Case, async: true
+
+  alias Minga.Credo.NoBlockingEditorCallCheck
+
+  @moduletag :credo
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  defp check(source_code, filename \\ "lib/minga_editor/commands/example.ex") do
+    source_code
+    |> to_source_file(filename)
+    |> run_check(NoBlockingEditorCallCheck, [])
+  end
+
+  # ── Flagged calls ──────────────────────────────────────────────────────
+
+  test "flags inline System.cmd" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        System.cmd("formatter", ["--stdin"], input: content)
+      end
+    end
+    """
+    |> check()
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "System.cmd"
+      assert issue.message =~ "blocks the editor GenServer"
+    end)
+  end
+
+  test "flags inline Client.request_sync" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        Client.request_sync(client, "textDocument/formatting", params, 5_000)
+      end
+    end
+    """
+    |> check()
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "Client.request_sync"
+    end)
+  end
+
+  test "flags fully-qualified Minga.LSP.Client.request_sync" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        Minga.LSP.Client.request_sync(client, "textDocument/formatting", params, 5_000)
+      end
+    end
+    """
+    |> check()
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "Minga.LSP.Client.request_sync"
+    end)
+  end
+
+  test "flags inline Task.await" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        task = Task.async(fn -> :work end)
+        Task.await(task, 5_000)
+      end
+    end
+    """
+    |> check()
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "Task.await"
+    end)
+  end
+
+  test "flags inline Process.sleep" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        Process.sleep(100)
+      end
+    end
+    """
+    |> check()
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "Process.sleep"
+    end)
+  end
+
+  # ── Exempt wrappers ────────────────────────────────────────────────────
+
+  test "passes System.cmd inside AsyncAction.run (pipe)" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        state
+        |> AsyncAction.run(:format, fn ->
+          System.cmd("formatter", ["--stdin"], input: content)
+        end)
+      end
+    end
+    """
+    |> check()
+    |> refute_issues()
+  end
+
+  test "passes System.cmd inside AsyncAction.run (direct call)" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        MingaEditor.AsyncAction.run(state, :format, fn ->
+          System.cmd("formatter", ["--stdin"], input: content)
+        end)
+      end
+    end
+    """
+    |> check()
+    |> refute_issues()
+  end
+
+  test "passes blocking call inside Task.start body" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        Task.start(fn -> System.cmd("git", ["status"]) end)
+        state
+      end
+    end
+    """
+    |> check()
+    |> refute_issues()
+  end
+
+  test "passes blocking call inside Task.async body" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        Task.async(fn -> System.cmd("git", ["log"]) end)
+        state
+      end
+    end
+    """
+    |> check()
+    |> refute_issues()
+  end
+
+  # ── Inline comment suppression ─────────────────────────────────────────
+
+  test "suppresses with minga:allow-blocking comment and justification" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        System.cmd("formatter", ["--stdin"], input: content) # minga:allow-blocking — fast local binary, <10ms
+      end
+    end
+    """
+    |> check()
+    |> refute_issues()
+  end
+
+  test "does not suppress bare minga:allow-blocking without justification" do
+    """
+    defmodule MingaEditor.Commands.Example do
+      def run(state) do
+        System.cmd("formatter", ["--stdin"], input: content) # minga:allow-blocking
+      end
+    end
+    """
+    |> check()
+    |> assert_issue()
+  end
+
+  # ── Scope filtering ────────────────────────────────────────────────────
+
+  test "skips files outside minga_editor/" do
+    """
+    defmodule Minga.Git.System do
+      def run_command(args) do
+        System.cmd("git", args)
+      end
+    end
+    """
+    |> check("lib/minga/git/system.ex")
+    |> refute_issues()
+  end
+
+  test "skips test files" do
+    """
+    defmodule MingaEditor.Commands.ExampleTest do
+      def test_example do
+        System.cmd("echo", ["test"])
+      end
+    end
+    """
+    |> check("test/minga_editor/commands/example_test.exs")
+    |> refute_issues()
+  end
+end


### PR DESCRIPTION
## Summary
- Extends `NoBlockingEditorCallCheck` (EX9008) with `Task.await` in the flagged blocking calls list
- Adds inline comment suppression: `# minga:allow-blocking — <justification>` on the same line suppresses the warning; bare `# minga:allow-blocking` without explanation does not
- Adds 13 tests covering: flagged calls (System.cmd, Client.request_sync, Task.await, Process.sleep), exempt wrappers (AsyncAction.run pipe/direct, Task.start, Task.async), inline comment suppression (with/without justification), and scope filtering (non-editor files, test files)
- Expands limitation documentation: syntactic-only matching, not transitive; this is a regression tripwire, not a structural guarantee

## Test plan
- [x] `mix test test/minga/credo/no_blocking_editor_call_check_test.exs` — 13 tests pass
- [x] `mix credo --only Minga.Credo.NoBlockingEditorCallCheck` — 0 issues on the current tree
- [x] `mix format --check-formatted` — clean

Closes #2451

🤖 Generated with [Claude Code](https://claude.com/claude-code)