### PR TITLE
feat: FeedbackState model and BEAM-side gap fixes (D4a)

### DIFF
--- a/lib/minga/render_model/ui/feedback_state.ex
+++ b/lib/minga/render_model/ui/feedback_state.ex
@@ -1,0 +1,125 @@
+defmodule Minga.RenderModel.UI.FeedbackState do
+  @moduledoc """
+  Semantic feedback state for a single action lane.
+
+  The BEAM owns the status vocabulary and transition logic; frontends render
+  it according to the threshold contract below. The two-clock model separates
+  *acknowledgment* (one-frame optimistic echo, handled by the input path) from
+  *duration status* (this struct), so a snappy echo never waits for the spinner
+  delay.
+
+  ## Threshold contract (frontends implement, BEAM documents)
+
+  - Acknowledgment: within one frame, unconditional (input path, not this struct).
+  - Spinner: show only if still `pending`/`loading` at `@spinner_delay_ms` (100ms).
+  - Spinner hold: once shown, spinner stays for at least `@spinner_hold_ms` (500ms).
+  - Success dwell: `success` auto-clears to `idle` after `@success_dwell_ms` (1500ms).
+  - `error`/`timeout`: sticky until explicitly cleared or a new action starts.
+  - Queue suppression: while `queued` is true, terminal status is suppressed until
+    the lane drains (one final status when the last op completes).
+  """
+
+  @type status :: :idle | :pending | :loading | :success | :error | :timeout | :canceled
+
+  @type t :: %__MODULE__{
+          status: status(),
+          message: String.t() | nil,
+          queued: boolean(),
+          count: {non_neg_integer(), non_neg_integer()} | nil
+        }
+
+  defstruct status: :idle,
+            message: nil,
+            queued: false,
+            count: nil
+
+  @spinner_delay_ms 100
+  @spinner_hold_ms 500
+  @success_dwell_ms 1_500
+
+  @doc "Returns the spinner delay threshold in milliseconds."
+  @spec spinner_delay_ms() :: pos_integer()
+  def spinner_delay_ms, do: @spinner_delay_ms
+
+  @doc "Returns the minimum spinner hold time in milliseconds."
+  @spec spinner_hold_ms() :: pos_integer()
+  def spinner_hold_ms, do: @spinner_hold_ms
+
+  @doc "Returns the success dwell time before auto-clear in milliseconds."
+  @spec success_dwell_ms() :: pos_integer()
+  def success_dwell_ms, do: @success_dwell_ms
+
+  @doc "Creates an idle feedback state."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Transitions to pending with an optional message. Clears any prior count."
+  @spec start(t(), String.t() | nil) :: t()
+  def start(%__MODULE__{} = _fs, message \\ nil) do
+    %__MODULE__{status: :pending, message: message, queued: false, count: nil}
+  end
+
+  @doc "Transitions to loading (spinner threshold crossed)."
+  @spec mark_loading(t()) :: t()
+  def mark_loading(%__MODULE__{status: :pending} = fs) do
+    %{fs | status: :loading}
+  end
+
+  def mark_loading(%__MODULE__{} = fs), do: fs
+
+  @doc "Transitions to success with an optional message."
+  @spec succeed(t(), String.t() | nil) :: t()
+  def succeed(%__MODULE__{} = fs, message \\ nil) do
+    %{fs | status: :success, message: message}
+  end
+
+  @doc "Transitions to error with a message."
+  @spec fail(t(), String.t() | nil) :: t()
+  def fail(%__MODULE__{} = fs, message \\ nil) do
+    %{fs | status: :error, message: message}
+  end
+
+  @doc "Transitions to timeout with an optional message."
+  @spec mark_timeout(t(), String.t() | nil) :: t()
+  def mark_timeout(%__MODULE__{} = fs, message \\ nil) do
+    %{fs | status: :timeout, message: message}
+  end
+
+  @doc "Transitions to canceled."
+  @spec cancel(t()) :: t()
+  def cancel(%__MODULE__{} = fs) do
+    %{fs | status: :canceled, message: nil}
+  end
+
+  @doc "Clears to idle (e.g. after success dwell timer fires)."
+  @spec clear(t()) :: t()
+  def clear(%__MODULE__{} = _fs) do
+    %__MODULE__{}
+  end
+
+  @doc "Sets the queued flag (second op on a busy lane)."
+  @spec set_queued(t(), boolean()) :: t()
+  def set_queued(%__MODULE__{} = fs, queued) when is_boolean(queued) do
+    %{fs | queued: queued}
+  end
+
+  @doc "Updates the progress count for partial results."
+  @spec update_count(t(), non_neg_integer(), non_neg_integer()) :: t()
+  def update_count(%__MODULE__{} = fs, completed, total)
+      when is_integer(completed) and completed >= 0 and is_integer(total) and total >= 0 do
+    %{fs | count: {completed, total}}
+  end
+
+  @doc "Returns true when the state represents an active (non-terminal) operation."
+  @spec active?(t()) :: boolean()
+  def active?(%__MODULE__{status: status}) when status in [:pending, :loading], do: true
+  def active?(%__MODULE__{}), do: false
+
+  @doc "Returns true when the state is a terminal status (success, error, timeout, canceled)."
+  @spec terminal?(t()) :: boolean()
+  def terminal?(%__MODULE__{status: status})
+      when status in [:success, :error, :timeout, :canceled],
+      do: true
+
+  def terminal?(%__MODULE__{}), do: false
+end

--- a/lib/minga_editor/frontend/emit/context.ex
+++ b/lib/minga_editor/frontend/emit/context.ex
@@ -128,7 +128,7 @@ defmodule MingaEditor.Frontend.Emit.Context do
       sidebar_registry: State.sidebar_registry(state),
       title: title,
       status_bar_data: MingaEditor.StatusBar.Data.from_state(state),
-      git_syncing: Map.get(state, :git_remote_op) != nil,
+      git_syncing: Map.get(state, :git_remote_op) != nil or git_lane_active?(state),
       git_toast: Map.get(state.shell_state, :git_toast),
       search: state.workspace.search,
       last_input_seq: Map.get(state, :last_input_seq, 0),
@@ -152,6 +152,16 @@ defmodule MingaEditor.Frontend.Emit.Context do
       config_state: gui_only(gui?, Map.get(state, :gui_config_state))
     }
   end
+
+  @spec git_lane_active?(map()) :: boolean()
+  defp git_lane_active?(%{async_actions: actions}) do
+    case Map.get(actions, :git_worktree) do
+      %{running: ref} when is_reference(ref) -> true
+      _ -> false
+    end
+  end
+
+  defp git_lane_active?(_state), do: false
 
   @spec gui_only(boolean(), value) :: value | nil when value: var
   defp gui_only(true, value), do: value

--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -137,7 +137,9 @@ defmodule MingaEditor.LspActions do
 
             ref = Client.request(client, "textDocument/references", params)
 
-            put_lsp_pending(state, ref, :references)
+            state
+            |> EditorState.set_status("Finding references…")
+            |> put_lsp_pending(ref, :references)
         end
     end
   end
@@ -312,7 +314,9 @@ defmodule MingaEditor.LspActions do
 
             ref = Client.request(client, "textDocument/rename", params)
 
-            put_lsp_pending(state, ref, :rename)
+            state
+            |> EditorState.set_status("Renaming…")
+            |> put_lsp_pending(ref, :rename)
         end
     end
   end

--- a/test/minga/render_model/ui/feedback_state_test.exs
+++ b/test/minga/render_model/ui/feedback_state_test.exs
@@ -1,0 +1,199 @@
+defmodule Minga.RenderModel.UI.FeedbackStateTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.RenderModel.UI.FeedbackState
+
+  describe "new/0" do
+    test "returns idle state" do
+      fs = FeedbackState.new()
+      assert fs.status == :idle
+      assert fs.message == nil
+      assert fs.queued == false
+      assert fs.count == nil
+    end
+  end
+
+  describe "start/2" do
+    test "transitions to pending with message" do
+      fs = FeedbackState.new() |> FeedbackState.start("Formatting…")
+      assert fs.status == :pending
+      assert fs.message == "Formatting…"
+      assert fs.queued == false
+    end
+
+    test "transitions to pending without message" do
+      fs = FeedbackState.new() |> FeedbackState.start()
+      assert fs.status == :pending
+      assert fs.message == nil
+    end
+
+    test "resets count from prior state" do
+      fs =
+        FeedbackState.new()
+        |> FeedbackState.start("first")
+        |> FeedbackState.update_count(3, 5)
+        |> FeedbackState.start("second")
+
+      assert fs.count == nil
+    end
+  end
+
+  describe "mark_loading/1" do
+    test "transitions pending to loading" do
+      fs = FeedbackState.new() |> FeedbackState.start("Working…") |> FeedbackState.mark_loading()
+      assert fs.status == :loading
+      assert fs.message == "Working…"
+    end
+
+    test "no-ops on non-pending state" do
+      fs = FeedbackState.new() |> FeedbackState.mark_loading()
+      assert fs.status == :idle
+    end
+  end
+
+  describe "succeed/2" do
+    test "transitions to success with message" do
+      fs = FeedbackState.new() |> FeedbackState.start("Working…") |> FeedbackState.succeed("Done")
+      assert fs.status == :success
+      assert fs.message == "Done"
+    end
+
+    test "preserves queued flag" do
+      fs =
+        FeedbackState.new()
+        |> FeedbackState.start("Working…")
+        |> FeedbackState.set_queued(true)
+        |> FeedbackState.succeed("Done")
+
+      assert fs.status == :success
+      assert fs.queued == true
+    end
+  end
+
+  describe "fail/2" do
+    test "transitions to error with message" do
+      fs = FeedbackState.new() |> FeedbackState.fail("Something went wrong")
+      assert fs.status == :error
+      assert fs.message == "Something went wrong"
+    end
+  end
+
+  describe "mark_timeout/2" do
+    test "transitions to timeout with message" do
+      fs = FeedbackState.new() |> FeedbackState.mark_timeout("LSP timed out")
+      assert fs.status == :timeout
+      assert fs.message == "LSP timed out"
+    end
+  end
+
+  describe "cancel/1" do
+    test "transitions to canceled" do
+      fs = FeedbackState.new() |> FeedbackState.start("Working…") |> FeedbackState.cancel()
+      assert fs.status == :canceled
+      assert fs.message == nil
+    end
+  end
+
+  describe "clear/1" do
+    test "resets to idle" do
+      fs = FeedbackState.new() |> FeedbackState.succeed("Done") |> FeedbackState.clear()
+      assert fs.status == :idle
+      assert fs.message == nil
+      assert fs.queued == false
+      assert fs.count == nil
+    end
+  end
+
+  describe "set_queued/2" do
+    test "sets queued flag" do
+      fs =
+        FeedbackState.new() |> FeedbackState.start("Working…") |> FeedbackState.set_queued(true)
+
+      assert fs.queued == true
+    end
+
+    test "clears queued flag" do
+      fs =
+        FeedbackState.new()
+        |> FeedbackState.start("Working…")
+        |> FeedbackState.set_queued(true)
+        |> FeedbackState.set_queued(false)
+
+      assert fs.queued == false
+    end
+  end
+
+  describe "update_count/3" do
+    test "sets count tuple" do
+      fs =
+        FeedbackState.new()
+        |> FeedbackState.start("Renaming…")
+        |> FeedbackState.update_count(3, 5)
+
+      assert fs.count == {3, 5}
+    end
+  end
+
+  describe "active?/1" do
+    test "true for pending" do
+      assert FeedbackState.active?(FeedbackState.start(FeedbackState.new(), "x"))
+    end
+
+    test "true for loading" do
+      fs = FeedbackState.new() |> FeedbackState.start("x") |> FeedbackState.mark_loading()
+      assert FeedbackState.active?(fs)
+    end
+
+    test "false for idle" do
+      refute FeedbackState.active?(FeedbackState.new())
+    end
+
+    test "false for success" do
+      refute FeedbackState.active?(FeedbackState.succeed(FeedbackState.new(), "Done"))
+    end
+
+    test "false for error" do
+      refute FeedbackState.active?(FeedbackState.fail(FeedbackState.new(), "Failed"))
+    end
+  end
+
+  describe "terminal?/1" do
+    test "true for success" do
+      assert FeedbackState.terminal?(FeedbackState.succeed(FeedbackState.new()))
+    end
+
+    test "true for error" do
+      assert FeedbackState.terminal?(FeedbackState.fail(FeedbackState.new()))
+    end
+
+    test "true for timeout" do
+      assert FeedbackState.terminal?(FeedbackState.mark_timeout(FeedbackState.new()))
+    end
+
+    test "true for canceled" do
+      assert FeedbackState.terminal?(FeedbackState.cancel(FeedbackState.new()))
+    end
+
+    test "false for idle" do
+      refute FeedbackState.terminal?(FeedbackState.new())
+    end
+
+    test "false for pending" do
+      refute FeedbackState.terminal?(FeedbackState.start(FeedbackState.new()))
+    end
+  end
+
+  describe "threshold constants" do
+    test "spinner delay is 100ms" do
+      assert FeedbackState.spinner_delay_ms() == 100
+    end
+
+    test "spinner hold is 500ms" do
+      assert FeedbackState.spinner_hold_ms() == 500
+    end
+
+    test "success dwell is 1500ms" do
+      assert FeedbackState.success_dwell_ms() == 1_500
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Introduces `Minga.RenderModel.UI.FeedbackState` struct with status vocabulary (`idle | pending | loading | success | error | timeout | canceled`), optional message, `queued` flag, progress count tuple, and pure transition functions
- Documents the two-clock model (acknowledgment vs duration status) and threshold contract (100ms spinner delay, 500ms spinner hold, 1500ms success dwell, sticky error/timeout)
- Closes BEAM-side silent-action gaps: LSP find-references and rename now set pending status before `put_lsp_pending`
- Broadens `git_syncing` derivation to include in-flight local `git_worktree` AsyncAction lane ops (stage/unstage show feedback)

## Changes
- `lib/minga/render_model/ui/feedback_state.ex` (new) — FeedbackState struct, transition functions, threshold constants
- `lib/minga_editor/lsp_actions.ex` — add `set_status("Finding references…")` and `set_status("Renaming…")` before async LSP requests
- `lib/minga_editor/frontend/emit/context.ex` — broaden `git_syncing` to also check `async_actions[:git_worktree]`
- `test/minga/render_model/ui/feedback_state_test.exs` (new) — 29 tests

## Test plan
- [x] `mix test test/minga/render_model/ui/feedback_state_test.exs` — 29 tests pass
- [x] `mix compile` — clean (no warnings)
- [x] `mix format --check-formatted` — clean

Closes #2452

🤖 Generated with [Claude Code](https://claude.com/claude-code)