### PR TITLE
feat: Go TUI feedback spinner and animation tick (D4b)

### DIFF
--- a/go/tui/internal/ui/feedback.go
+++ b/go/tui/internal/ui/feedback.go
@@ -1,0 +1,89 @@
+package ui
+
+import (
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+const (
+	feedbackTickInterval = 80 * time.Millisecond
+	spinnerDelayMs       = 100 * time.Millisecond
+	spinnerHoldMs        = 500 * time.Millisecond
+)
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+type feedbackTickMsg struct{}
+
+func feedbackTick() tea.Cmd {
+	return tea.Tick(feedbackTickInterval, func(time.Time) tea.Msg {
+		return feedbackTickMsg{}
+	})
+}
+
+type feedbackState struct {
+	frame       uint64
+	ticking     bool
+	onset       time.Time
+	spinnerOn   bool
+	spinnerOnAt time.Time
+	lastMessage string
+}
+
+func (f *feedbackState) tick() {
+	f.frame++
+	now := time.Now()
+	if !f.onset.IsZero() && now.Sub(f.onset) >= spinnerDelayMs {
+		if !f.spinnerOn {
+			f.spinnerOn = true
+			f.spinnerOnAt = now
+		}
+	}
+	if f.onset.IsZero() && f.spinnerOn && !f.spinnerOnAt.IsZero() {
+		if now.Sub(f.spinnerOnAt) >= spinnerHoldMs {
+			f.spinnerOn = false
+		}
+	}
+}
+
+func (f feedbackState) spinner() string {
+	return spinnerFrames[int(f.frame)%len(spinnerFrames)]
+}
+
+// inflight returns true when the status message indicates a pending operation.
+// The BEAM convention is to suffix pending messages with "…".
+func inflight(message string) bool {
+	return strings.HasSuffix(message, "…") ||
+		strings.HasSuffix(message, "… [Esc to cancel]")
+}
+
+// updateStatus tracks in-flight status transitions.
+func (f *feedbackState) updateStatus(message string) {
+	if message == f.lastMessage {
+		return
+	}
+	f.lastMessage = message
+	if inflight(message) {
+		if f.onset.IsZero() {
+			f.onset = time.Now()
+		}
+	} else {
+		f.onset = time.Time{}
+	}
+}
+
+// active returns true when the feedback system needs the animation tick running.
+func (f feedbackState) active() bool {
+	return !f.onset.IsZero() || f.spinnerOn
+}
+
+// formatMessage prefixes the status message with a braille spinner when the
+// spinner is visible, or returns it unchanged. This is read-only (value receiver).
+func (f feedbackState) formatMessage(message string) string {
+	if f.spinnerOn && inflight(message) {
+		return f.spinner() + " " + message
+	}
+	return message
+}

--- a/go/tui/internal/ui/feedback_test.go
+++ b/go/tui/internal/ui/feedback_test.go
@@ -132,6 +132,42 @@ func TestFeedbackSpinnerRotates(t *testing.T) {
 	}
 }
 
+func TestFeedbackTickAdvancesFrame(t *testing.T) {
+	var f feedbackState
+	if f.frame != 0 {
+		t.Fatalf("initial frame should be 0, got %d", f.frame)
+	}
+	f.tick()
+	if f.frame != 1 {
+		t.Errorf("frame after one tick should be 1, got %d", f.frame)
+	}
+	f.tick()
+	f.tick()
+	if f.frame != 3 {
+		t.Errorf("frame after three ticks should be 3, got %d", f.frame)
+	}
+	// Verify the spinner output changes across consecutive ticks, covering the
+	// picker-loading case where tick() is the only driver of spinner animation.
+	frames := make([]string, len(spinnerFrames)+1)
+	f.frame = 0
+	for i := range frames {
+		frames[i] = f.spinner()
+		f.tick()
+	}
+	// The first len(spinnerFrames) entries should all be distinct (one full cycle).
+	seen := map[string]bool{}
+	for _, s := range frames[:len(spinnerFrames)] {
+		if seen[s] {
+			t.Errorf("duplicate spinner frame %q within one cycle", s)
+		}
+		seen[s] = true
+	}
+	// After a full cycle the spinner wraps: frame[0] == frame[len(spinnerFrames)].
+	if frames[0] != frames[len(spinnerFrames)] {
+		t.Errorf("spinner should wrap after full cycle: frame[0]=%q, frame[%d]=%q", frames[0], len(spinnerFrames), frames[len(spinnerFrames)])
+	}
+}
+
 func TestFeedbackDuplicateMessage(t *testing.T) {
 	var f feedbackState
 	f.updateStatus("Formatting…")

--- a/go/tui/internal/ui/feedback_test.go
+++ b/go/tui/internal/ui/feedback_test.go
@@ -1,0 +1,144 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInflight(t *testing.T) {
+	tests := []struct {
+		message string
+		want    bool
+	}{
+		{"Formatting…", true},
+		{"Finding references…", true},
+		{"Renaming…", true},
+		{"Formatting… [Esc to cancel]", true},
+		{"Formatted", false},
+		{"Format error: LSP request failed", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.message, func(t *testing.T) {
+			if got := inflight(tt.message); got != tt.want {
+				t.Errorf("inflight(%q) = %v, want %v", tt.message, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFeedbackUpdateStatus(t *testing.T) {
+	var f feedbackState
+	f.updateStatus("Formatting…")
+	if f.onset.IsZero() {
+		t.Error("onset should be set for in-flight message")
+	}
+	if f.lastMessage != "Formatting…" {
+		t.Errorf("lastMessage = %q, want %q", f.lastMessage, "Formatting…")
+	}
+
+	f.updateStatus("Formatted")
+	if !f.onset.IsZero() {
+		t.Error("onset should be cleared for non-in-flight message")
+	}
+}
+
+func TestFeedbackSpinnerDelay(t *testing.T) {
+	var f feedbackState
+	f.updateStatus("Formatting…")
+
+	f.tick()
+	if f.spinnerOn {
+		t.Error("spinner should not be on before delay threshold")
+	}
+
+	f.onset = time.Now().Add(-spinnerDelayMs - time.Millisecond)
+	f.tick()
+	if !f.spinnerOn {
+		t.Error("spinner should be on after delay threshold")
+	}
+}
+
+func TestFeedbackFormatMessage(t *testing.T) {
+	var f feedbackState
+
+	result := f.formatMessage("Formatting…")
+	if result != "Formatting…" {
+		t.Errorf("should not prefix spinner when not active, got %q", result)
+	}
+
+	f.spinnerOn = true
+	f.frame = 0
+	result = f.formatMessage("Formatting…")
+	want := spinnerFrames[0] + " " + "Formatting…"
+	if result != want {
+		t.Errorf("should prefix spinner, got %q want %q", result, want)
+	}
+
+	result = f.formatMessage("Formatted")
+	if result != "Formatted" {
+		t.Errorf("should not prefix non-inflight message, got %q", result)
+	}
+}
+
+func TestFeedbackActive(t *testing.T) {
+	var f feedbackState
+	if f.active() {
+		t.Error("idle state should not be active")
+	}
+
+	f.updateStatus("Formatting…")
+	if !f.active() {
+		t.Error("in-flight state should be active")
+	}
+
+	f.updateStatus("Formatted")
+	if f.active() {
+		t.Error("cleared state should not be active")
+	}
+}
+
+func TestFeedbackSpinnerHold(t *testing.T) {
+	var f feedbackState
+	f.updateStatus("Formatting…")
+	f.onset = time.Now().Add(-spinnerDelayMs - time.Millisecond)
+	f.tick()
+	if !f.spinnerOn {
+		t.Fatal("spinner should be on")
+	}
+
+	f.updateStatus("Formatted")
+	if !f.spinnerOn {
+		t.Error("spinner should hold after status clears (hold floor)")
+	}
+	if !f.active() {
+		t.Error("should be active during hold period")
+	}
+
+	f.spinnerOnAt = time.Now().Add(-spinnerHoldMs - time.Millisecond)
+	f.tick()
+	if f.spinnerOn {
+		t.Error("spinner should clear after hold floor elapsed")
+	}
+}
+
+func TestFeedbackSpinnerRotates(t *testing.T) {
+	var f feedbackState
+	first := f.spinner()
+	f.frame++
+	second := f.spinner()
+	if first == second {
+		t.Error("spinner should rotate on frame advance")
+	}
+}
+
+func TestFeedbackDuplicateMessage(t *testing.T) {
+	var f feedbackState
+	f.updateStatus("Formatting…")
+	onset := f.onset
+
+	f.updateStatus("Formatting…")
+	if !f.onset.Equal(onset) {
+		t.Error("duplicate message should not reset onset")
+	}
+}

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -256,7 +256,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if status, ok := m.statusBar(); ok {
 			m.feedback.updateStatus(status.Message)
 		}
-		if m.feedback.active() {
+		pickerLoading := false
+		if picker, ok := m.chrome[generated.OPGuiPicker]; ok && picker.Picker.LoadStatus == 1 {
+			pickerLoading = true
+		}
+		if m.feedback.active() || pickerLoading {
 			cmd = feedbackTick()
 		} else {
 			m.feedback.ticking = false
@@ -279,7 +283,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if status, ok := m.statusBar(); ok {
 		m.feedback.updateStatus(status.Message)
 	}
-	if m.feedback.active() && !m.feedback.ticking {
+	needsTick := m.feedback.active()
+	if !needsTick {
+		if picker, ok := m.chrome[generated.OPGuiPicker]; ok && picker.Picker.LoadStatus == 1 {
+			needsTick = true
+		}
+	}
+	if needsTick && !m.feedback.ticking {
 		m.feedback.ticking = true
 		cmd = tea.Batch(cmd, feedbackTick())
 	}

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -60,6 +60,7 @@ type Model struct {
 	extensionRuntimes     map[string]protocol.ExtensionRuntimePayload
 	bottomPanelScrollback int
 	agent                 agentPanel
+	feedback              feedbackState
 	// latency records end-to-end keystroke-to-write samples (ticket #2215).
 	// It is a pointer so the recorder persists across value-copied Model
 	// updates. hudVisible toggles the on-screen p50/p99 overlay at runtime.
@@ -250,6 +251,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.agent.animationRunning = false
 		}
+	case feedbackTickMsg:
+		m.feedback.tick()
+		if status, ok := m.statusBar(); ok {
+			m.feedback.updateStatus(status.Message)
+		}
+		if m.feedback.active() {
+			cmd = feedbackTick()
+		} else {
+			m.feedback.ticking = false
+		}
 	case port.PacketMsg:
 		cmd = m.applyCommands(msg.Commands)
 		m.layout = m.computeLayout()
@@ -263,6 +274,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if chat, ok := m.agentChat(); ok && m.agent.animating(chat) && !m.agent.animationRunning {
 		m.agent.animationRunning = true
 		cmd = tea.Batch(cmd, agentAnimationTick())
+	}
+
+	if status, ok := m.statusBar(); ok {
+		m.feedback.updateStatus(status.Message)
+	}
+	if m.feedback.active() && !m.feedback.ticking {
+		m.feedback.ticking = true
+		cmd = tea.Batch(cmd, feedbackTick())
 	}
 
 	m.viewport.SetWidth(max(m.width, 1))

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -237,7 +237,8 @@ func (m Model) renderStatusMessage(message string) string {
 	if message == "" {
 		return ""
 	}
-	return lipgloss.NewStyle().Bold(true).Foreground(m.palette().Warning()).Background(m.palette().ChromeSurface()).Render(message)
+	displayed := m.feedback.formatMessage(message)
+	return lipgloss.NewStyle().Bold(true).Foreground(m.palette().Warning()).Background(m.palette().ChromeSurface()).Render(displayed)
 }
 
 func (m Model) renderSegmentList(segments []protocol.StatusSegment) string {
@@ -422,7 +423,7 @@ func (m Model) renderPicker(picker protocol.Picker, preview protocol.PickerPrevi
 		title += fmt.Sprintf("  marked %d", picker.Marked)
 	}
 	if picker.LoadStatus == 1 {
-		title += "  loading"
+		title += "  " + m.feedback.spinner() + " loading"
 	} else if picker.LoadStatus == 2 && picker.LoadError != "" {
 		title += "  " + picker.LoadError
 	}


### PR DESCRIPTION
## Summary
- Adds a general-purpose 80ms animation tick (`feedbackTickMsg`) that arms independently of the 180ms agent animation tick whenever any status message indicates an in-flight operation
- Renders braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) prefix on status bar messages after 100ms delay, with 500ms hold floor
- Picker "loading" text now shows an animated spinner
- In-flight detection uses the BEAM convention: status messages ending with "…" indicate pending operations

## Changes
- `go/tui/internal/ui/feedback.go` (new) — feedbackState struct, tick logic, spinner delay/hold, message formatting
- `go/tui/internal/ui/feedback_test.go` (new) — 15 tests covering inflight detection, delay, hold, rotation, formatting
- `go/tui/internal/ui/model.go` — add `feedback feedbackState` field, wire `feedbackTickMsg` handler, arm tick on in-flight status
- `go/tui/internal/ui/render_chrome.go` — status message rendering uses `formatMessage()` for spinner prefix; picker loading uses animated spinner

## Test plan
- [x] `go test ./...` — 460 tests pass (15 new, 0 regressions)
- [x] `go build ./...` — clean

Closes #2453

🤖 Generated with [Claude Code](https://claude.com/claude-code)