### PR TITLE
D4c: macOS rendering of feedback model

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		30AF3AD9C1C7F46956940CEC /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
 		30E31170A79F30413D15D858 /* GUIChromeDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */; };
 		312DC4940992B35ED9EE7648 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048C53BF025A1476EE8BC1A7 /* IMEComposition.swift */; };
+		32A5DD57F7DBCD039D98C2D7 /* FeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF185FF7AFC2D9E5430B6B65 /* FeedbackState.swift */; };
 		32A5F098C10CC21F9A294060 /* WhichKeyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEC828C1445B3314C8989E1 /* WhichKeyState.swift */; };
 		32E539855F602A532C3ED7B8 /* PreviewRegistry+Overlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0D41B1D748FBFE7916342C /* PreviewRegistry+Overlays.swift */; };
 		33D6C1F5975839C2A182B1D5 /* FileTreeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E88C12915EC4EBE96165AF /* FileTreeHeaderView.swift */; };
@@ -103,6 +104,7 @@
 		3EBD4C24E21423CCDB7E72E3 /* CompletionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA8938E70ED0123ACECD921 /* CompletionOverlay.swift */; };
 		41DCC27275D0E8E903EAA061 /* SidebarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */; };
 		422A1F1325C83168D9607566 /* PreviewSnapshotPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1D0E05FBEEC550591460C7 /* PreviewSnapshotPolicy.swift */; };
+		42ED480B514788ED4BF15A40 /* FeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF185FF7AFC2D9E5430B6B65 /* FeedbackState.swift */; };
 		43116CD030B0374BE3F4B3FE /* BEAMProcessManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2A06C5BA9E3F53A59E202F /* BEAMProcessManagerTests.swift */; };
 		431AE5CBC58EAC0932CFA35B /* BlinkingCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD70D674B039905BFB212246 /* BlinkingCursor.swift */; };
 		440B04A4C07375702A61EA24 /* AgentChatHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A4DA796E10E4A7D98A18E1 /* AgentChatHeaderView.swift */; };
@@ -389,11 +391,13 @@
 		E689D007EE7A0D6EEB9B31CB /* StatusBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575815EBAD4E1DFE0BE3DE57 /* StatusBarState.swift */; };
 		E6B945D114487F6BD18ADD31 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
 		E6D7005C89816EDB97B40ED7 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60980E90FDD864409144BA5B /* PickerState.swift */; };
+		E7A77B344139B5748EC8E4CC /* FeedbackStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E557E349097FF119EFE0F827 /* FeedbackStateTests.swift */; };
 		E8514E6E1DE509FA80D4D460 /* ProtocolErrorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A915C3108F2370C753A1931B /* ProtocolErrorState.swift */; };
 		E8AFF0E854D640C9D0904E64 /* AgentToolCallCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EBF8F752B40004FCD33C6F /* AgentToolCallCard.swift */; };
 		E91569370EFCE0FCD208C994 /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D118F59FBCA463A52B84FA /* AgentContextBar.swift */; };
 		EA49ADC46692D8613D80EA2D /* NativeSidebarRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2269E199608D475AB34F10 /* NativeSidebarRegistryTests.swift */; };
 		EAC789C161E01BAFF6B13871 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2036E3609EB1C3E575CFC /* BottomPanelView.swift */; };
+		EC0BB15B8545F2D5A1729581 /* FeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF185FF7AFC2D9E5430B6B65 /* FeedbackState.swift */; };
 		ECADBD9F2CD3F84CB52D8C4F /* HoverPopupState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D068C9707F3A44D03F7C3222 /* HoverPopupState.swift */; };
 		ECE870F634AC4B097DA300AC /* PortLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E23DC6E0ACB156F21293E87 /* PortLogger.swift */; };
 		ED749937278E2192F17A8F54 /* BlinkingCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD70D674B039905BFB212246 /* BlinkingCursor.swift */; };
@@ -593,8 +597,10 @@
 		E34C34EC8FF8D20C141F2290 /* SidebarContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarContainer.swift; sourceTree = "<group>"; };
 		E3947E679EE2D80E4D8FED9E /* PickerOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerOverlay.swift; sourceTree = "<group>"; };
 		E4DCF10EBEB51624A4A1F428 /* InlineEditField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineEditField.swift; sourceTree = "<group>"; };
+		E557E349097FF119EFE0F827 /* FeedbackStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackStateTests.swift; sourceTree = "<group>"; };
 		E8D8E70B7413F570FBAC58C1 /* MessagesContentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentState.swift; sourceTree = "<group>"; };
 		EE173FAAAC37ACFF47EE03B8 /* EditTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTimelineView.swift; sourceTree = "<group>"; };
+		EF185FF7AFC2D9E5430B6B65 /* FeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackState.swift; sourceTree = "<group>"; };
 		F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorsTests.swift; sourceTree = "<group>"; };
 		F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BEAMProcessManager.swift; sourceTree = "<group>"; };
 		F220A60775A252A728477659 /* ProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolTests.swift; sourceTree = "<group>"; };
@@ -917,6 +923,7 @@
 				A583EB0DCE480D1A5FC7E440 /* BottomPanelState.swift */,
 				54D2036E3609EB1C3E575CFC /* BottomPanelView.swift */,
 				FD9F43E781BA11616C52373E /* BreadcrumbBar.swift */,
+				EF185FF7AFC2D9E5430B6B65 /* FeedbackState.swift */,
 				F6104336F33C41EBE21B10F6 /* SearchState.swift */,
 				7740BB367B27DD4B53FFB853 /* SearchToolbar.swift */,
 				575815EBAD4E1DFE0BE3DE57 /* StatusBarState.swift */,
@@ -962,6 +969,7 @@
 				57B35E8311966948B1BA7AEF /* DecoderRobustnessTests.swift */,
 				CE2E468DA824CDB99FCEF94A /* EditorScrollTrackTests.swift */,
 				9AA6F5FC902DD40A54F100FF /* ExtensionViewsTests.swift */,
+				E557E349097FF119EFE0F827 /* FeedbackStateTests.swift */,
 				BD2DE335B00721CBB29329F9 /* FontTests.swift */,
 				E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */,
 				754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */,
@@ -1256,6 +1264,7 @@
 				656FBA2E713E5E0C34EBEA57 /* ExtensionOverlayView.swift in Sources */,
 				7418E0530CBF38B03913971E /* ExtensionPanelState.swift in Sources */,
 				9CE776458D91F0A2A7B57836 /* ExtensionPanelView.swift in Sources */,
+				32A5DD57F7DBCD039D98C2D7 /* FeedbackState.swift in Sources */,
 				B63FE5EAD33D990E4493CB83 /* FileTreeHeaderView.swift in Sources */,
 				5319EAB17BE576DBFFA596A8 /* FileTreeRowView.swift in Sources */,
 				5769A0CDC98F728E5FAA3888 /* FileTreeState.swift in Sources */,
@@ -1391,6 +1400,7 @@
 				97DEF8B3975BAD9D33123588 /* ExtensionOverlayView.swift in Sources */,
 				28C1510C52A6EF2274FCC07E /* ExtensionPanelState.swift in Sources */,
 				03FF39E058C8040A25393AB6 /* ExtensionPanelView.swift in Sources */,
+				42ED480B514788ED4BF15A40 /* FeedbackState.swift in Sources */,
 				33D6C1F5975839C2A182B1D5 /* FileTreeHeaderView.swift in Sources */,
 				C783BC0C005A3B998297225F /* FileTreeRowView.swift in Sources */,
 				A42FCE83FF8C5493944C4FE7 /* FileTreeState.swift in Sources */,
@@ -1534,6 +1544,8 @@
 				BB0BC94AAD3AE83DD523A3EB /* ExtensionPanelState.swift in Sources */,
 				0B1004C174A2397C887879D0 /* ExtensionPanelView.swift in Sources */,
 				3A23159F3A6631F0AD99A702 /* ExtensionViewsTests.swift in Sources */,
+				EC0BB15B8545F2D5A1729581 /* FeedbackState.swift in Sources */,
+				E7A77B344139B5748EC8E4CC /* FeedbackStateTests.swift in Sources */,
 				2E484D45E7A416AC55352DE4 /* FileTreeHeaderView.swift in Sources */,
 				78DCE2F6E9A23B694737D77E /* FileTreeRowView.swift in Sources */,
 				CEA1DB4D4172F20E777A1979 /* FileTreeState.swift in Sources */,

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -760,6 +760,7 @@ struct ContentView: View {
     private var statusBar: some View {
         StatusBarView(
             state: appState.gui.statusBarState,
+            feedbackState: appState.gui.feedbackState,
             encoder: appState.encoder,
             isFileTreeVisible: appState.gui.fileTreeState.visible,
             isGitStatusVisible: appState.gui.gitStatusState.visible,

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -578,6 +578,7 @@ final class CommandDispatcher {
 
         case .guiStatusBar(let update):
             guiState.statusBarState.update(from: update)
+            guiState.feedbackState.update(message: update.message)
             frameState.totalLineCount = update.lineCount
             if update.mode != lastMode {
                 lastMode = update.mode

--- a/macos/Sources/Views/EditorChrome/FeedbackState.swift
+++ b/macos/Sources/Views/EditorChrome/FeedbackState.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+@MainActor
+@Observable
+final class FeedbackState {
+    private(set) var isPending = false
+    private(set) var showingSpinner = false
+
+    private var showTask: Task<Void, Never>?
+    private var holdTask: Task<Void, Never>?
+    private var spinnerOnTime: ContinuousClock.Instant?
+    private var lastMessage = ""
+
+    nonisolated static let spinnerDelay: Duration = .milliseconds(100)
+    nonisolated static let spinnerHold: Duration = .milliseconds(500)
+    nonisolated static let successDwell: Duration = .milliseconds(1_500)
+
+    func update(message: String) {
+        guard message != lastMessage else { return }
+        lastMessage = message
+        let pending = Self.isInflight(message)
+
+        if pending {
+            guard !isPending else { return }
+            isPending = true
+            holdTask?.cancel()
+            holdTask = nil
+            showTask?.cancel()
+            showTask = Task {
+                try? await Task.sleep(for: Self.spinnerDelay)
+                guard !Task.isCancelled, isPending else { return }
+                showingSpinner = true
+                spinnerOnTime = .now
+            }
+        } else {
+            let wasSpinning = showingSpinner
+            isPending = false
+            showTask?.cancel()
+            showTask = nil
+
+            if wasSpinning {
+                let elapsed = spinnerOnTime.map { ContinuousClock.now - $0 } ?? .zero
+                let remaining = Self.spinnerHold - elapsed
+                if remaining > .zero {
+                    holdTask?.cancel()
+                    holdTask = Task {
+                        try? await Task.sleep(for: remaining)
+                        guard !Task.isCancelled else { return }
+                        showingSpinner = false
+                        spinnerOnTime = nil
+                    }
+                } else {
+                    showingSpinner = false
+                    spinnerOnTime = nil
+                }
+            }
+        }
+    }
+
+    func cancel() {
+        isPending = false
+        showingSpinner = false
+        showTask?.cancel()
+        holdTask?.cancel()
+        showTask = nil
+        holdTask = nil
+        spinnerOnTime = nil
+        lastMessage = ""
+    }
+
+    nonisolated static func isInflight(_ message: String) -> Bool {
+        message.hasSuffix("…") || message.contains("… [")
+    }
+}

--- a/macos/Sources/Views/EditorChrome/StatusBarView.swift
+++ b/macos/Sources/Views/EditorChrome/StatusBarView.swift
@@ -33,6 +33,7 @@ private struct StatusBarSegmentGroup: Identifiable {
 
 struct StatusBarView: View {
     let state: StatusBarState
+    var feedbackState: FeedbackState?
     @Environment(\.themeColors) private var theme
     let encoder: InputEncoder?
     var isFileTreeVisible: Bool = false
@@ -179,11 +180,20 @@ struct StatusBarView: View {
                     .foregroundStyle(theme.modelineBarFg.opacity(0.8))
             }
         } else if !state.message.isEmpty {
-            Text(state.message)
-                .font(.system(size: 11))
-                .foregroundStyle(theme.modelineBarFg.opacity(0.7))
-                .lineLimit(1)
-                .truncationMode(.tail)
+            HStack(spacing: 4) {
+                if feedbackState?.showingSpinner == true, FeedbackState.isInflight(state.message) {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .scaleEffect(0.7)
+                        .frame(width: 14, height: 14)
+                        .transition(.opacity)
+                }
+                Text(state.message)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.modelineBarFg.opacity(0.7))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
         } else if !state.diagnosticHint.isEmpty {
             Text(state.diagnosticHint)
                 .font(.system(size: 11))

--- a/macos/Sources/Views/Shared/GUIState.swift
+++ b/macos/Sources/Views/Shared/GUIState.swift
@@ -44,6 +44,9 @@ final class GUIState {
     /// Status bar state.
     let statusBarState = StatusBarState()
 
+    /// Action feedback state (delay-then-show spinner, hold floor).
+    let feedbackState = FeedbackState()
+
     /// Picker (command palette) state.
     let pickerState = PickerState()
 

--- a/macos/Sources/Views/Sidebar/ActivityBar.swift
+++ b/macos/Sources/Views/Sidebar/ActivityBar.swift
@@ -119,9 +119,11 @@ struct ActivityBar: View {
 }
 
 struct PressableButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
-            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.1), value: configuration.isPressed)
     }
 }

--- a/macos/Sources/Views/Sidebar/ActivityBar.swift
+++ b/macos/Sources/Views/Sidebar/ActivityBar.swift
@@ -94,7 +94,7 @@ struct ActivityBar: View {
             }
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableButtonStyle())
         .help(item.displayName)
         .accessibilityLabel(item.displayName)
     }
@@ -115,5 +115,13 @@ struct ActivityBar: View {
         guard item.semanticKind == "git_status", let count = item.badgeCount, count > 0 else { return nil }
         let countText = count > 99 ? "99+" : String(count)
         return count == 1 ? "1 changed file" : "\(countText) changed files"
+    }
+}
+
+struct PressableButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
     }
 }

--- a/macos/Tests/MingaTests/FeedbackStateTests.swift
+++ b/macos/Tests/MingaTests/FeedbackStateTests.swift
@@ -83,4 +83,46 @@ struct FeedbackStateTests {
     func successDwell() {
         #expect(FeedbackState.successDwell == .milliseconds(1_500))
     }
+
+    // MARK: - Async spinner behavior
+
+    @Test("spinner appears after delay threshold")
+    @MainActor func spinnerAppearsAfterDelay() async throws {
+        let state = FeedbackState()
+        state.update(message: "Formatting…")
+        #expect(!state.showingSpinner)
+        try await Task.sleep(for: .milliseconds(150))
+        #expect(state.showingSpinner)
+    }
+
+    @Test("spinner holds after fast completion then clears")
+    @MainActor func spinnerHoldsAfterCompletion() async throws {
+        let state = FeedbackState()
+        state.update(message: "Formatting…")
+        try await Task.sleep(for: .milliseconds(150))
+        #expect(state.showingSpinner)
+        state.update(message: "Formatted")
+        #expect(state.showingSpinner)
+        try await Task.sleep(for: .milliseconds(600))
+        #expect(!state.showingSpinner)
+    }
+
+    @Test("fast completion prevents spinner from appearing")
+    @MainActor func fastCompletionPreventsSpinner() async throws {
+        let state = FeedbackState()
+        state.update(message: "Formatting…")
+        try await Task.sleep(for: .milliseconds(50))
+        state.update(message: "Formatted")
+        #expect(!state.showingSpinner)
+    }
+
+    @Test("cancel during spinner hold clears immediately")
+    @MainActor func cancelDuringSpinnerHold() async throws {
+        let state = FeedbackState()
+        state.update(message: "Formatting…")
+        try await Task.sleep(for: .milliseconds(150))
+        #expect(state.showingSpinner)
+        state.cancel()
+        #expect(!state.showingSpinner)
+    }
 }

--- a/macos/Tests/MingaTests/FeedbackStateTests.swift
+++ b/macos/Tests/MingaTests/FeedbackStateTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+
+@testable import Minga
+
+@Suite("FeedbackState")
+struct FeedbackStateTests {
+
+    // MARK: - isInflight detection
+
+    @Test("detects inflight from ellipsis suffix")
+    func inflightEllipsis() {
+        #expect(FeedbackState.isInflight("Formatting…"))
+        #expect(FeedbackState.isInflight("Finding references…"))
+        #expect(FeedbackState.isInflight("Renaming…"))
+    }
+
+    @Test("detects inflight with cancel hint")
+    func inflightCancelHint() {
+        #expect(FeedbackState.isInflight("Formatting… [Esc to cancel]"))
+    }
+
+    @Test("non-inflight messages")
+    func notInflight() {
+        #expect(!FeedbackState.isInflight("Formatted"))
+        #expect(!FeedbackState.isInflight("Format error: LSP request failed"))
+        #expect(!FeedbackState.isInflight(""))
+    }
+
+    // MARK: - Pending state
+
+    @Test("isPending set synchronously on inflight message")
+    @MainActor func pendingSetSync() {
+        let state = FeedbackState()
+        state.update(message: "Formatting…")
+        #expect(state.isPending)
+        #expect(!state.showingSpinner)
+    }
+
+    @Test("isPending cleared on non-inflight message")
+    @MainActor func pendingCleared() {
+        let state = FeedbackState()
+        state.update(message: "Formatting…")
+        #expect(state.isPending)
+        state.update(message: "Formatted")
+        #expect(!state.isPending)
+    }
+
+    @Test("duplicate message does not reset state")
+    @MainActor func duplicateIgnored() {
+        let state = FeedbackState()
+        state.update(message: "Formatting…")
+        let wasPending = state.isPending
+        state.update(message: "Formatting…")
+        #expect(state.isPending == wasPending)
+    }
+
+    // MARK: - Cancel
+
+    @Test("cancel clears all state immediately")
+    @MainActor func cancelClears() {
+        let state = FeedbackState()
+        state.update(message: "Formatting…")
+        #expect(state.isPending)
+        state.cancel()
+        #expect(!state.isPending)
+        #expect(!state.showingSpinner)
+    }
+
+    // MARK: - Threshold constants
+
+    @Test("spinner delay matches D4a contract")
+    func spinnerDelay() {
+        #expect(FeedbackState.spinnerDelay == .milliseconds(100))
+    }
+
+    @Test("spinner hold matches D4a contract")
+    func spinnerHold() {
+        #expect(FeedbackState.spinnerHold == .milliseconds(500))
+    }
+
+    @Test("success dwell matches D4a contract")
+    func successDwell() {
+        #expect(FeedbackState.successDwell == .milliseconds(1_500))
+    }
+}


### PR DESCRIPTION
## Summary

- Add `FeedbackState` (`@MainActor @Observable`) with delay-then-show spinner logic: `isPending` set synchronously, cancelable `Task` for 100ms spinner delay, 500ms spinner hold floor
- Wire `FeedbackState` through `GUIState` and `CommandDispatcher.guiStatusBar` handler
- Show `ProgressView().controlSize(.mini)` in status bar center segment when spinner is active and message is in-flight ("…" suffix)
- Add `PressableButtonStyle` with `.scaleEffect(0.92)` press feedback to Activity Bar buttons
- 10 Swift Testing tests covering inflight detection, pending lifecycle, cancel, and threshold constants

## Acceptance Criteria

1. **Acknowledgment within one display refresh** — `isPending` is set synchronously in `update(message:)`, status bar message renders immediately; spinner only appears after threshold
2. **Delay-then-show, race-free** — cancelable `Task` with 100ms delay; early completion cancels the show-task; spinner holds 500ms floor once shown
3. **Per-surface expression** — status bar = `ProgressView().controlSize(.mini)` with `.scaleEffect(0.7)`; git header already has its own `ProgressView` driven by `gitSyncing`
4. **Activity Bar press feedback** — custom `PressableButtonStyle` reading `configuration.isPressed` for `.scaleEffect(0.92 : 1.0)` (no `@GestureState`)
5. **Cancel hint** — BEAM appends "… [Esc to cancel]", detected by `isInflight` via `message.contains("… [")`; `cancel()` clears all state within one frame

## Test plan

- [x] 10 Swift Testing tests pass (`FeedbackStateTests`)
- [x] Full Xcode build succeeds (`BUILD SUCCEEDED`)
- [ ] Manual: trigger a long-running operation (e.g. external format), verify spinner appears after ~100ms in status bar
- [ ] Manual: verify Activity Bar buttons show press scale feedback on click

Closes #2454
Parent epic: #2445

🤖 Generated with [Claude Code](https://claude.com/claude-code)