### PR TITLE
D5: Bound agent-ingest batch size

### DIFF
--- a/lib/minga_editor/agent/ingest.ex
+++ b/lib/minga_editor/agent/ingest.ex
@@ -70,12 +70,23 @@ defmodule MingaEditor.Agent.Ingest do
   @type state :: %{
           editor: pid(),
           window_ms: non_neg_integer(),
+          max_batch_items: pos_integer(),
+          max_batch_bytes: pos_integer(),
           sessions: %{optional(pid()) => session_state()}
         }
 
   # One 60Hz frame. Adds at most one window to steady-state stream visibility,
   # below perception and partly absorbed by the Editor's render coalescing.
   @default_window_ms 16
+
+  # Batch size caps. A single coalesced flush is split into multiple bounded
+  # batches so the Editor's inline apply (`route_agent_stream_batch`) never
+  # receives a pathologically large batch from a big tool-output dump or
+  # paste-like burst. Item count is the primary guard; byte ceiling catches
+  # fewer-but-larger deltas. Both are conservative: normal streaming rarely
+  # exceeds a handful of small token deltas per 16ms window.
+  @max_batch_items 64
+  @max_batch_bytes 32_768
 
   @telemetry_flush [:minga, :agent, :ingest_flush]
 
@@ -87,6 +98,9 @@ defmodule MingaEditor.Agent.Ingest do
   `:editor` is the pid that batches and control events are forwarded to and
   defaults to the calling process. `:window_ms` overrides the coalescing tick
   (tests pass `0` so the tick fires on the next message turn deterministically).
+  `:max_batch_items` and `:max_batch_bytes` override the batch size caps (tests
+  use small values to exercise the splitting logic without generating hundreds
+  of deltas).
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
@@ -113,7 +127,17 @@ defmodule MingaEditor.Agent.Ingest do
   def init(opts) do
     editor = Keyword.get(opts, :editor, self())
     window_ms = Keyword.get(opts, :window_ms, @default_window_ms)
-    {:ok, %{editor: editor, window_ms: window_ms, sessions: %{}}}
+    max_items = Keyword.get(opts, :max_batch_items, @max_batch_items)
+    max_bytes = Keyword.get(opts, :max_batch_bytes, @max_batch_bytes)
+
+    {:ok,
+     %{
+       editor: editor,
+       window_ms: window_ms,
+       max_batch_items: max_items,
+       max_batch_bytes: max_bytes,
+       sessions: %{}
+     }}
   end
 
   @impl true
@@ -204,7 +228,7 @@ defmodule MingaEditor.Agent.Ingest do
 
     case pending do
       [] -> :ok
-      _ -> forward_batch(state, session_pid, Enum.reverse(pending), reason)
+      _ -> forward_bounded(state, session_pid, Enum.reverse(pending), reason)
     end
 
     # After a flush the session is idle again: the next delta re-arms the leading
@@ -215,6 +239,54 @@ defmodule MingaEditor.Agent.Ingest do
   end
 
   # ── Forwarding ───────────────────────────────────────────────────────────────
+
+  @spec forward_bounded(state(), pid(), batch(), :leading | :tick | :control) :: :ok
+  defp forward_bounded(state, session_pid, batch, reason) do
+    batch
+    |> chunk_batch(state.max_batch_items, state.max_batch_bytes)
+    |> Enum.each(&forward_batch(state, session_pid, &1, reason))
+  end
+
+  @spec chunk_batch(batch(), pos_integer(), pos_integer()) :: [batch()]
+  defp chunk_batch(batch, max_items, max_bytes) do
+    chunk_batch(batch, max_items, max_bytes, [], 0, 0, [])
+  end
+
+  defp chunk_batch([], _max_items, _max_bytes, current, _count, _bytes, chunks) do
+    case current do
+      [] -> Enum.reverse(chunks)
+      _ -> Enum.reverse([Enum.reverse(current) | chunks])
+    end
+  end
+
+  defp chunk_batch([delta | rest], max_items, max_bytes, current, count, bytes, chunks) do
+    delta_bytes = delta_byte_size(delta)
+    new_count = count + 1
+    new_bytes = bytes + delta_bytes
+
+    if count > 0 and (new_count > max_items or new_bytes > max_bytes) do
+      chunk_batch(
+        [delta | rest],
+        max_items,
+        max_bytes,
+        [],
+        0,
+        0,
+        [Enum.reverse(current) | chunks]
+      )
+    else
+      chunk_batch(rest, max_items, max_bytes, [delta | current], new_count, new_bytes, chunks)
+    end
+  end
+
+  @spec delta_byte_size(delta()) :: non_neg_integer()
+  defp delta_byte_size({:text_delta, text}) when is_binary(text), do: byte_size(text)
+  defp delta_byte_size({:thinking_delta, text}) when is_binary(text), do: byte_size(text)
+
+  defp delta_byte_size({:tool_update, _, _, value}) when is_binary(value),
+    do: byte_size(value)
+
+  defp delta_byte_size(_), do: 0
 
   @spec forward_batch(state(), pid(), batch(), :leading | :tick | :control) :: :ok
   defp forward_batch(%{editor: editor}, session_pid, batch, edge) do

--- a/test/minga_editor/agent/ingest_test.exs
+++ b/test/minga_editor/agent/ingest_test.exs
@@ -58,6 +58,10 @@ defmodule MingaEditor.Agent.IngestTest do
     start_supervised!({Ingest, editor: self(), window_ms: window_ms})
   end
 
+  defp start_ingest(window_ms, opts) do
+    start_supervised!({Ingest, [editor: self(), window_ms: window_ms] ++ opts})
+  end
+
   defp sync(pid), do: :sys.get_state(pid)
 
   # Takes the next message Ingest forwarded to us (the Editor), in mailbox order,
@@ -215,6 +219,109 @@ defmodule MingaEditor.Agent.IngestTest do
 
       send(ingest, {:ingest_tick, session_b})
       assert_receive {:agent_stream_batch, ^session_b, [{:text_delta, "b1"}]}
+    end
+  end
+
+  describe "batch size bounding (D5)" do
+    test "an oversized accumulation by item count splits into multiple bounded batches" do
+      ingest = start_ingest(10_000, max_batch_items: 3, max_batch_bytes: 100_000)
+      session = fake_session()
+
+      # Leading edge: forwarded immediately.
+      send(ingest, {:agent_event, session, {:text_delta, "lead"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "lead"}]}
+
+      # Accumulate 7 deltas (exceeds cap of 3 per batch).
+      for i <- 1..7 do
+        send(ingest, {:agent_event, session, {:text_delta, "d#{i}"}})
+      end
+
+      sync(ingest)
+      send(ingest, {:ingest_tick, session})
+
+      # Should split into batches of 3, 3, 1 (preserving order).
+      batch1 = next_forwarded()
+      batch2 = next_forwarded()
+      batch3 = next_forwarded()
+
+      assert {:agent_stream_batch, ^session,
+              [{:text_delta, "d1"}, {:text_delta, "d2"}, {:text_delta, "d3"}]} = batch1
+
+      assert {:agent_stream_batch, ^session,
+              [{:text_delta, "d4"}, {:text_delta, "d5"}, {:text_delta, "d6"}]} = batch2
+
+      assert {:agent_stream_batch, ^session, [{:text_delta, "d7"}]} = batch3
+
+      refute_received {:agent_stream_batch, _, _}
+    end
+
+    test "an oversized accumulation by byte size splits into multiple bounded batches" do
+      ingest = start_ingest(10_000, max_batch_items: 100, max_batch_bytes: 10)
+      session = fake_session()
+
+      send(ingest, {:agent_event, session, {:text_delta, "lead"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "lead"}]}
+
+      # Each delta is 6 bytes ("chunk1", "chunk2", "chunk3"). Cap is 10 bytes,
+      # so first batch fits "chunk1" (6 bytes), adding "chunk2" would be 12 > 10,
+      # so it splits: [chunk1], [chunk2], [chunk3].
+      send(ingest, {:agent_event, session, {:text_delta, "chunk1"}})
+      send(ingest, {:agent_event, session, {:text_delta, "chunk2"}})
+      send(ingest, {:agent_event, session, {:text_delta, "chunk3"}})
+      sync(ingest)
+      send(ingest, {:ingest_tick, session})
+
+      batch1 = next_forwarded()
+      batch2 = next_forwarded()
+      batch3 = next_forwarded()
+
+      assert {:agent_stream_batch, ^session, [{:text_delta, "chunk1"}]} = batch1
+      assert {:agent_stream_batch, ^session, [{:text_delta, "chunk2"}]} = batch2
+      assert {:agent_stream_batch, ^session, [{:text_delta, "chunk3"}]} = batch3
+
+      refute_received {:agent_stream_batch, _, _}
+    end
+
+    test "a batch within the cap is forwarded as a single batch (no spurious splitting)" do
+      ingest = start_ingest(10_000, max_batch_items: 10, max_batch_bytes: 100_000)
+      session = fake_session()
+
+      send(ingest, {:agent_event, session, {:text_delta, "lead"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "lead"}]}
+
+      send(ingest, {:agent_event, session, {:text_delta, "a"}})
+      send(ingest, {:agent_event, session, {:text_delta, "b"}})
+      send(ingest, {:agent_event, session, {:text_delta, "c"}})
+      sync(ingest)
+      send(ingest, {:ingest_tick, session})
+
+      assert next_forwarded() ==
+               {:agent_stream_batch, session,
+                [{:text_delta, "a"}, {:text_delta, "b"}, {:text_delta, "c"}]}
+
+      refute_received {:agent_stream_batch, _, _}
+    end
+
+    test "control-event flush of an oversized batch still flushes ahead of the control event" do
+      ingest = start_ingest(10_000, max_batch_items: 2, max_batch_bytes: 100_000)
+      session = fake_session()
+
+      send(ingest, {:agent_event, session, {:text_delta, "lead"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "lead"}]}
+
+      # Accumulate 3 deltas, then a control event triggers the flush.
+      send(ingest, {:agent_event, session, {:text_delta, "x1"}})
+      send(ingest, {:agent_event, session, {:text_delta, "x2"}})
+      send(ingest, {:agent_event, session, {:text_delta, "x3"}})
+      send(ingest, {:agent_event, session, {:status_changed, :idle}})
+      sync(ingest)
+
+      # Split batches arrive before the control event, in order.
+      assert {:agent_stream_batch, ^session, [{:text_delta, "x1"}, {:text_delta, "x2"}]} =
+               next_forwarded()
+
+      assert {:agent_stream_batch, ^session, [{:text_delta, "x3"}]} = next_forwarded()
+      assert {:agent_event, ^session, {:status_changed, :idle}} = next_forwarded()
     end
   end
 

--- a/test/minga_editor/agent/ingest_test.exs
+++ b/test/minga_editor/agent/ingest_test.exs
@@ -302,6 +302,24 @@ defmodule MingaEditor.Agent.IngestTest do
       refute_received {:agent_stream_batch, _, _}
     end
 
+    test "a single delta exceeding the byte cap is forwarded as a one-element batch (no infinite loop)" do
+      ingest = start_ingest(10_000, max_batch_items: 100, max_batch_bytes: 3)
+      session = fake_session()
+
+      send(ingest, {:agent_event, session, {:text_delta, "lead"}})
+      assert_receive {:agent_stream_batch, ^session, [{:text_delta, "lead"}]}
+
+      # "hello" is 5 bytes, exceeding the 3-byte cap. The count > 0 guard in
+      # chunk_batch ensures the first element always enters the current chunk,
+      # preventing infinite recursion on an oversized single delta.
+      send(ingest, {:agent_event, session, {:text_delta, "hello"}})
+      sync(ingest)
+      send(ingest, {:ingest_tick, session})
+
+      assert next_forwarded() == {:agent_stream_batch, session, [{:text_delta, "hello"}]}
+      refute_received {:agent_stream_batch, _, _}
+    end
+
     test "control-event flush of an oversized batch still flushes ahead of the control event" do
       ingest = start_ingest(10_000, max_batch_items: 2, max_batch_bytes: 100_000)
       session = fake_session()


### PR DESCRIPTION
## Summary

- Cap coalesced flush batches by item count (64) and byte size (32KB) so a big tool-output dump or paste-like burst never delivers a pathologically large batch to the Editor's inline apply
- Oversized accumulations split into multiple bounded batches with order preserved
- Both caps are configurable via init opts (`max_batch_items`, `max_batch_bytes`) for testing
- Leading-edge flush and control-event ordering are unchanged

## Test plan

- [x] 4 new tests in `ingest_test.exs`: item-count splitting, byte-size splitting, no spurious splitting within cap, control-event flush of oversized batch
- [x] All 13 ingest tests pass
- [x] Credo clean, format clean

Closes #2455
Parent epic: #2445

🤖 Generated with [Claude Code](https://claude.com/claude-code)