### PR TITLE
feat: wire 42 unused BEAM theme slots in palette

### DIFF
--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -21,12 +21,18 @@ const (
 	themeTreeHeaderBG     byte = 0x08
 	themeTreeHeaderFG     byte = 0x09
 	themeTreeSeparatorFG  byte = 0x0A
+	themeTreeGitModified  byte = 0x0B
+	themeTreeGitStaged    byte = 0x0C
+	themeTreeGitUntracked byte = 0x0D
 	themeTreeSelectionFG  byte = 0x0E
+	themeTreeGuideFG      byte = 0x0F
 	themeTabBG            byte = 0x10
 	themeTabActiveBG      byte = 0x11
 	themeTabActiveFG      byte = 0x12
 	themeTabInactiveFG    byte = 0x13
 	themeTabModifiedFG    byte = 0x14
+	themeTabSeparatorFG   byte = 0x15
+	themeTabCloseHoverFG  byte = 0x16
 	themeTabAttentionFG   byte = 0x17
 	themePopupBG          byte = 0x20
 	themePopupFG          byte = 0x21
@@ -36,9 +42,20 @@ const (
 	themePopupGroupFG     byte = 0x25
 	themePopupDescFG      byte = 0x26
 	themeBreadcrumbBG     byte = 0x27
+	themeBreadcrumbFG     byte = 0x28
+	themeBreadcrumbSepFG  byte = 0x29
 	themePopupSelFG       byte = 0x2A
 	themeModelineBG       byte = 0x30
 	themeModelineFG       byte = 0x31
+	themeModelineInfoBG   byte = 0x32
+	themeModelineInfoFG   byte = 0x33
+	themeModeNormalBG     byte = 0x34
+	themeModeNormalFG     byte = 0x35
+	themeModeInsertBG     byte = 0x36
+	themeModeInsertFG     byte = 0x37
+	themeModeVisualBG     byte = 0x38
+	themeModeVisualFG     byte = 0x39
+	themeStatusbarAccent  byte = 0x3A
 	themeAccent           byte = 0x40
 	themeGutterFG         byte = 0x50
 	themeGutterCurrentFG  byte = 0x51
@@ -46,9 +63,34 @@ const (
 	themeWarningFG        byte = 0x53
 	themeDiagnosticInfo   byte = 0x54
 	themeDiagnosticHint   byte = 0x55
+	themeGitAddedFG       byte = 0x56
+	themeGitModifiedFG    byte = 0x57
+	themeGitDeletedFG     byte = 0x58
 	themeHighlightReadBG  byte = 0x59
 	themeHighlightWriteBG byte = 0x5A
-	themeSelectionBG      byte = 0x5B
+	themeSelectionBG          byte = 0x5B
+	themeAgentStatusIdle      byte = 0x5C
+	themeAgentStatusWorking   byte = 0x5D
+	themeAgentStatusIterating byte = 0x5E
+	themeAgentStatusNeedsYou  byte = 0x5F
+	themeAgentStatusDone      byte = 0x60
+	themeAgentStatusErrored   byte = 0x61
+	themeGutterFoldFG         byte = 0x62
+	themeAgentPanelBG         byte = 0xA0
+	themeAgentHeaderBG        byte = 0xA1
+	themeAgentHeaderFG        byte = 0xA2
+	themeAgentUserBorder      byte = 0xA3
+	themeAgentUserLabel       byte = 0xA4
+	themeAgentAssistantBorder byte = 0xA5
+	themeAgentAssistantLabel  byte = 0xA6
+	themeAgentInputBorder     byte = 0xA7
+	themeAgentInputBG         byte = 0xA8
+	themeAgentInputPlaceholder byte = 0xA9
+	themeAgentTextFG          byte = 0xAA
+	themeAgentToolBorder      byte = 0xAB
+	themeAgentToolHeader      byte = 0xAC
+	themeAgentCodeBG          byte = 0xAD
+	themeAgentCodeBorder      byte = 0xAE
 )
 
 var requiredThemeSlots = []byte{
@@ -80,12 +122,18 @@ func bootstrapPalette() palette {
 		themeTreeHeaderBG:     0x000000,
 		themeTreeHeaderFG:     0xFFFFFF,
 		themeTreeSeparatorFG:  0x666666,
+		themeTreeGitModified:  0xE5C07B,
+		themeTreeGitStaged:    0x98C379,
+		themeTreeGitUntracked: 0x808080,
 		themeTreeSelectionFG:  0xFFFFFF,
+		themeTreeGuideFG:      0x444444,
 		themeTabBG:            0x000000,
 		themeTabActiveBG:      0x333333,
 		themeTabActiveFG:      0xFFFFFF,
 		themeTabInactiveFG:    0x999999,
 		themeTabModifiedFG:    0xFFAA00,
+		themeTabSeparatorFG:   0x444444,
+		themeTabCloseHoverFG:  0xFF5555,
 		themeTabAttentionFG:   0xFFAA00,
 		themePopupBG:          0x000000,
 		themePopupFG:          0xFFFFFF,
@@ -95,9 +143,20 @@ func bootstrapPalette() palette {
 		themePopupGroupFG:     0xFFFFFF,
 		themePopupDescFG:      0xFFFFFF,
 		themeBreadcrumbBG:     0x000000,
+		themeBreadcrumbFG:     0xCCCCCC,
+		themeBreadcrumbSepFG:  0x666666,
 		themePopupSelFG:       0xFFFFFF,
 		themeModelineBG:       0x000000,
 		themeModelineFG:       0xFFFFFF,
+		themeModelineInfoBG:   0x222222,
+		themeModelineInfoFG:   0xCCCCCC,
+		themeModeNormalBG:     0x61AFEF,
+		themeModeNormalFG:     0x1E1E1E,
+		themeModeInsertBG:     0x98C379,
+		themeModeInsertFG:     0x1E1E1E,
+		themeModeVisualBG:     0xC678DD,
+		themeModeVisualFG:     0x1E1E1E,
+		themeStatusbarAccent:  0x61AFEF,
 		themeAccent:           0xFFFFFF,
 		themeGutterFG:         0x999999,
 		themeGutterCurrentFG:  0xFFFFFF,
@@ -105,9 +164,34 @@ func bootstrapPalette() palette {
 		themeWarningFG:        0xFFAA00,
 		themeDiagnosticInfo:   0x00AAFF,
 		themeDiagnosticHint:   0x999999,
+		themeGitAddedFG:       0x98C379,
+		themeGitModifiedFG:    0xE5C07B,
+		themeGitDeletedFG:     0xE06C75,
 		themeHighlightReadBG:  0x333333,
 		themeHighlightWriteBG: 0x333333,
-		themeSelectionBG:      0x333333,
+		themeSelectionBG:          0x333333,
+		themeAgentStatusIdle:      0x808080,
+		themeAgentStatusWorking:   0x61AFEF,
+		themeAgentStatusIterating: 0xE5C07B,
+		themeAgentStatusNeedsYou:  0xE06C75,
+		themeAgentStatusDone:      0x98C379,
+		themeAgentStatusErrored:   0xE06C75,
+		themeGutterFoldFG:         0x666666,
+		themeAgentPanelBG:         0x1E1E1E,
+		themeAgentHeaderBG:        0x2D2D2D,
+		themeAgentHeaderFG:        0xCCCCCC,
+		themeAgentUserBorder:      0x61AFEF,
+		themeAgentUserLabel:       0x61AFEF,
+		themeAgentAssistantBorder: 0x555555,
+		themeAgentAssistantLabel:  0x808080,
+		themeAgentInputBorder:     0x61AFEF,
+		themeAgentInputBG:         0x1E1E1E,
+		themeAgentInputPlaceholder: 0x666666,
+		themeAgentTextFG:          0xCCCCCC,
+		themeAgentToolBorder:      0x555555,
+		themeAgentToolHeader:      0x999999,
+		themeAgentCodeBG:          0x2D2D2D,
+		themeAgentCodeBorder:      0x444444,
 	}}
 }
 
@@ -339,6 +423,197 @@ func (p palette) slot(slot byte) color.Color {
 		return lipgloss.Color(fmt.Sprintf("#%06X", rgb))
 	}
 	return lipgloss.NoColor{}
+}
+
+func (p palette) slotOr(slot byte, fallback byte) color.Color {
+	if _, ok := p.colors[slot]; ok {
+		return p.slot(slot)
+	}
+	return p.slot(fallback)
+}
+
+// --- Tree git status ---
+
+func (p palette) TreeGitModified() color.Color {
+	return p.slotOr(themeTreeGitModified, themeWarningFG)
+}
+
+func (p palette) TreeGitStaged() color.Color {
+	return p.slotOr(themeTreeGitStaged, themeAccent)
+}
+
+func (p palette) TreeGitUntracked() color.Color {
+	return p.slotOr(themeTreeGitUntracked, themeTabInactiveFG)
+}
+
+func (p palette) TreeGuide() color.Color {
+	return p.slotOr(themeTreeGuideFG, themeTreeSeparatorFG)
+}
+
+// --- Tab bar ---
+
+func (p palette) TabSeparator() color.Color {
+	return p.slotOr(themeTabSeparatorFG, themeTreeSeparatorFG)
+}
+
+func (p palette) TabCloseHover() color.Color {
+	return p.slotOr(themeTabCloseHoverFG, themeDiagnosticError)
+}
+
+// --- Breadcrumb ---
+
+func (p palette) BreadcrumbText() color.Color {
+	return p.slotOr(themeBreadcrumbFG, themeModelineFG)
+}
+
+func (p palette) BreadcrumbSeparator() color.Color {
+	return p.slotOr(themeBreadcrumbSepFG, themeTabInactiveFG)
+}
+
+// --- Modeline / Status ---
+
+func (p palette) ModelineInfo() color.Color {
+	return p.slotOr(themeModelineInfoBG, themeModelineBG)
+}
+
+func (p palette) ModelineInfoText() color.Color {
+	return p.slotOr(themeModelineInfoFG, themeModelineFG)
+}
+
+func (p palette) ModeNormal() color.Color {
+	return p.slotOr(themeModeNormalBG, themeAccent)
+}
+
+func (p palette) ModeNormalText() color.Color {
+	return p.slotOr(themeModeNormalFG, themeEditorBG)
+}
+
+func (p palette) ModeInsert() color.Color {
+	return p.slotOr(themeModeInsertBG, themeAccent)
+}
+
+func (p palette) ModeInsertText() color.Color {
+	return p.slotOr(themeModeInsertFG, themeEditorBG)
+}
+
+func (p palette) ModeVisual() color.Color {
+	return p.slotOr(themeModeVisualBG, themeAccent)
+}
+
+func (p palette) ModeVisualText() color.Color {
+	return p.slotOr(themeModeVisualFG, themeEditorBG)
+}
+
+func (p palette) StatusbarAccent() color.Color {
+	return p.slotOr(themeStatusbarAccent, themeAccent)
+}
+
+// --- Git gutter signs ---
+
+func (p palette) GitAdded() color.Color {
+	return p.slotOr(themeGitAddedFG, themeAccent)
+}
+
+func (p palette) GitModified() color.Color {
+	return p.slotOr(themeGitModifiedFG, themeWarningFG)
+}
+
+func (p palette) GitDeleted() color.Color {
+	return p.slotOr(themeGitDeletedFG, themeDiagnosticError)
+}
+
+// --- Agent status badges ---
+
+func (p palette) AgentStatusIdle() color.Color {
+	return p.slotOr(themeAgentStatusIdle, themeTabInactiveFG)
+}
+
+func (p palette) AgentStatusWorking() color.Color {
+	return p.slotOr(themeAgentStatusWorking, themeAccent)
+}
+
+func (p palette) AgentStatusIterating() color.Color {
+	return p.slotOr(themeAgentStatusIterating, themeWarningFG)
+}
+
+func (p palette) AgentStatusNeedsYou() color.Color {
+	return p.slotOr(themeAgentStatusNeedsYou, themeDiagnosticError)
+}
+
+func (p palette) AgentStatusDone() color.Color {
+	return p.slotOr(themeAgentStatusDone, themeAccent)
+}
+
+func (p palette) AgentStatusErrored() color.Color {
+	return p.slotOr(themeAgentStatusErrored, themeDiagnosticError)
+}
+
+// --- Gutter fold ---
+
+func (p palette) GutterFold() color.Color {
+	return p.slotOr(themeGutterFoldFG, themeGutterFG)
+}
+
+// --- Agent chat palette ---
+
+func (p palette) AgentPanel() color.Color {
+	return p.slotOr(themeAgentPanelBG, themeEditorBG)
+}
+
+func (p palette) AgentHeader() color.Color {
+	return p.slotOr(themeAgentHeaderBG, themeModelineBG)
+}
+
+func (p palette) AgentHeaderText() color.Color {
+	return p.slotOr(themeAgentHeaderFG, themeModelineFG)
+}
+
+func (p palette) AgentUserBorder() color.Color {
+	return p.slotOr(themeAgentUserBorder, themeAccent)
+}
+
+func (p palette) AgentUserLabel() color.Color {
+	return p.slotOr(themeAgentUserLabel, themeAccent)
+}
+
+func (p palette) AgentAssistantBorder() color.Color {
+	return p.slotOr(themeAgentAssistantBorder, themeTreeSeparatorFG)
+}
+
+func (p palette) AgentAssistantLabel() color.Color {
+	return p.slotOr(themeAgentAssistantLabel, themeTabInactiveFG)
+}
+
+func (p palette) AgentInputBorder() color.Color {
+	return p.slotOr(themeAgentInputBorder, themeAccent)
+}
+
+func (p palette) AgentInputSurface() color.Color {
+	return p.slotOr(themeAgentInputBG, themeEditorBG)
+}
+
+func (p palette) AgentInputPlaceholder() color.Color {
+	return p.slotOr(themeAgentInputPlaceholder, themeTabInactiveFG)
+}
+
+func (p palette) AgentText() color.Color {
+	return p.slotOr(themeAgentTextFG, themeEditorFG)
+}
+
+func (p palette) AgentToolBorder() color.Color {
+	return p.slotOr(themeAgentToolBorder, themeTreeSeparatorFG)
+}
+
+func (p palette) AgentToolHeader() color.Color {
+	return p.slotOr(themeAgentToolHeader, themeModelineFG)
+}
+
+func (p palette) AgentCodeSurface() color.Color {
+	return p.slotOr(themeAgentCodeBG, themePopupBG)
+}
+
+func (p palette) AgentCodeBorder() color.Color {
+	return p.slotOr(themeAgentCodeBorder, themePopupBorder)
 }
 
 func (m Model) palette() palette {


### PR DESCRIPTION
## Summary

- Add 42 named slot constants for all previously unused BEAM theme color slots (tree git status, tree guides, tab bar, breadcrumb, modeline/status mode colors, git gutter signs, agent status badges, gutter fold, 15-slot agent chat sub-palette)
- Add `slotOr()` fallback helper for graceful degradation when the BEAM hasn't sent a slot yet
- Add palette accessors for every new slot group with sensible fallback mappings
- Add bootstrap defaults for all new slots with dark-theme-appropriate colors

## Test plan

- [x] `go build ./cmd/...` succeeds
- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [x] No rendering code changes (downstream tickets consume accessors)
- [x] `git diff --check` clean

Closes #2551
Part of epic #2531

🤖 Generated with [Claude Code](https://claude.com/claude-code)