### PR TITLE
feat: add status bar segment separators

### DIFF
--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -241,6 +241,7 @@ func (m Model) renderStatusMessage(message string) string {
 }
 
 func (m Model) renderSegmentList(segments []protocol.StatusSegment) string {
+	sep := lipgloss.NewStyle().Foreground(m.palette().Muted()).Background(m.palette().ChromeSurface()).Render("│")
 	parts := make([]string, 0, len(segments))
 	for _, segment := range segments {
 		text := segment.Text
@@ -269,7 +270,7 @@ func (m Model) renderSegmentList(segments []protocol.StatusSegment) string {
 		}
 		parts = append(parts, rendered)
 	}
-	return strings.Join(parts, "")
+	return strings.Join(parts, sep)
 }
 
 func (m Model) gitSummary(git protocol.GitStatus) string {


### PR DESCRIPTION
## Summary

- Add thin `│` dividers between status bar segments using `Muted()` foreground on `ChromeSurface()` background
- Separators appear between left segments and between right segments independently; no separator between the left and right groups
- Single-character separator keeps the bar compact at narrow widths

Closes #2536
Part of epic #2531

## Test plan

- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [x] `go build ./cmd/...` succeeds
- [ ] Visual check: status bar shows muted `│` between segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)