### PR TITLE
feat: upgrade breadcrumb separator to styled chevron

### DIFF
--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -319,7 +319,7 @@ func TestHeaderRendersBreadcrumbWithTabs(t *testing.T) {
 	}
 
 	header := ansi.Strip(strings.Join(model.headerLines(), "\n"))
-	if !strings.Contains(header, "▌ 󰈙 main.ex") || !strings.Contains(header, "lib › minga › main.ex") {
+	if !strings.Contains(header, "▌ 󰈙 main.ex") || !strings.Contains(header, "lib ❯ minga ❯ main.ex") {
 		t.Fatalf("wide header should render active tab accent and breadcrumbs together: %q", header)
 	}
 }
@@ -350,7 +350,7 @@ func TestHeaderHidesBreadcrumbsAtNarrowWidth(t *testing.T) {
 	}
 
 	header := ansi.Strip(strings.Join(model.headerLines(), "\n"))
-	if strings.Contains(header, "lib › minga") {
+	if strings.Contains(header, "lib ❯ minga") {
 		t.Fatalf("narrow header should not spend a row on breadcrumbs: %q", header)
 	}
 }

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -136,7 +136,7 @@ func (m Model) renderBreadcrumb(crumb protocol.Breadcrumb) string {
 		}
 		segments = append(segments, m.zones.Mark(zoneIDBreadcrumbSegment(index), style.Render(segment)))
 	}
-	separator := lipgloss.NewStyle().Foreground(m.palette().GutterText()).Background(m.palette().EditorSurface()).Render(" › ")
+	separator := lipgloss.NewStyle().Foreground(m.palette().GutterText()).Background(m.palette().EditorSurface()).Render(" ❯ ")
 	text := "  " + strings.Join(segments, separator)
 	if git, ok := m.gitStatus(); ok && git.Branch != "" {
 		gitText := lipgloss.NewStyle().Foreground(m.palette().Muted()).Background(m.palette().EditorSurface()).Render("  ·  " + m.gitSummary(git))


### PR DESCRIPTION
## Summary

- Replace breadcrumb path separator `›` with styled chevron `❯` in `renderBreadcrumb()` for a more polished look matching the crush style
- Separator retains its `GutterText` color so it remains visually distinct from segment text
- Git branch `·` separator is unchanged
- Updated two breadcrumb test assertions in `model_test.go` to match the new separator

## Test plan

- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [x] `go build ./cmd/...` succeeds

Closes #2541
Part of epic #2531

🤖 Generated with [Claude Code](https://claude.com/claude-code)