### PR TITLE
feat: add bracket framing to horizontal separator labels

### DIFF
--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -599,7 +599,7 @@ func horizontalSeparatorText(width int, filename string) string {
 	if label == "" || width < 4 {
 		return line
 	}
-	label = " " + label + " "
+	label = "╴" + label + "╶"
 	if displayWidth(label) > width {
 		label = fit(label, width)
 	}


### PR DESCRIPTION
## Summary

- Wrap split-separator filename labels with box-drawing bracket characters (`╴` before and `╶` after) for a more polished look: `────╴filename.ex╶────`
- One-line change in `horizontalSeparatorText()` replacing space padding with bracket characters

## Test plan

- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [x] `go build ./cmd/...` succeeds
- [x] Bracket characters (`╴` U+2574, `╶` U+2576) are standard box-drawing glyphs rendered correctly across common terminal fonts

Closes #2542
Part of epic #2531

🤖 Generated with [Claude Code](https://claude.com/claude-code)