### PR TITLE
feat: add picker input field separator styling

### DIFF
--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -449,7 +449,13 @@ func (m Model) renderPickerList(title string, picker protocol.Picker, height int
 	panelStyle := m.popupLineStyle(width)
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Accent()).Background(theme.PopupChrome()).Width(width).ColorWhitespace(true)
 	lines := []string{renderPadded(titleStyle, " "+title, width)}
-	rowBudget := max(height-1, 0)
+	headerRows := 1
+	if height > 2 {
+		sepStyle := lipgloss.NewStyle().Foreground(theme.PopupBorder()).Background(theme.PopupSurface()).Width(width).ColorWhitespace(true)
+		lines = append(lines, renderPadded(sepStyle, strings.Repeat("─", max(width, 1)), width))
+		headerRows = 2
+	}
+	rowBudget := max(height-headerRows, 0)
 	selected := min(max(int(picker.Selected), 0), max(len(picker.Items)-1, 0))
 	start := 0
 	if selected >= rowBudget && rowBudget > 0 {


### PR DESCRIPTION
## Summary

- Adds a thin `─` separator line between the picker query/title header and the results list to visually distinguish the input area from results
- Separator uses `PopupBorder` foreground on `PopupSurface` background, matching the existing side-preview divider aesthetic
- Gracefully skipped when picker height is too small (<=2 rows) to preserve item visibility

Closes #2535
Part of epic #2531

## Test plan

- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [x] `go build ./cmd/...` succeeds
- [ ] Visual verification: picker renders separator between title and items at various widths
- [ ] Narrow picker (height <= 2) still shows items without separator

🤖 Generated with [Claude Code](https://claude.com/claude-code)