### PR TITLE
feat: add sidebar vertical border separator

### DIFF
--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1857,8 +1857,12 @@ func TestSemanticWindowsRespectSidebarOffset(t *testing.T) {
 	if len(lines) < 2 {
 		t.Fatalf("semantic window should render with sidebar offset: %+v", lines)
 	}
-	if got := strings.Index(lines[1], "pane"); got != 18 {
-		t.Fatalf("sidebar offset should leave pane at column 18, got %d in %q", got, lines[1])
+	if !strings.Contains(lines[1], "│") {
+		t.Fatalf("sidebar should have │ separator column: %q", lines[1])
+	}
+	// strings.Index returns byte offset: 18 ASCII sidebar chars + 3-byte │ = byte 21
+	if got := strings.Index(lines[1], "pane"); got != 21 {
+		t.Fatalf("sidebar + separator offset should place pane at byte 21 (18 sidebar + 3-byte separator), got %d in %q", got, lines[1])
 	}
 }
 

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -149,7 +149,7 @@ func (m Model) leftChromeWidth() int {
 		return fileTreeWidth(m.width, tree)
 	}
 	if sidebars, ok := m.sidebars(); ok && len(sidebars.Items) > 0 && m.width >= 60 {
-		return semanticSidebarWidth(m.width, sidebars)
+		return semanticSidebarWidth(m.width, sidebars) + 1 // +1 for │ separator column
 	}
 	return 0
 }
@@ -659,8 +659,10 @@ func (m Model) withSemanticSidebars(mainLines []string) []string {
 	theme := m.palette()
 	style := lipgloss.NewStyle().Foreground(theme.Muted()).Background(theme.Surface()).Width(width)
 	activeStyle := style.Bold(true).Foreground(theme.Text()).Background(theme.Selection())
+	sepStyle := lipgloss.NewStyle().Foreground(theme.TreeSeparator()).Background(m.editorBackground())
+	sep := sepStyle.Render("│")
 	lines := make([]string, max(len(mainLines), len(visible)+1))
-	lines[0] = lipgloss.JoinHorizontal(lipgloss.Top, style.Bold(true).Render(fit("Sidebars", width)), lineAt(mainLines, 0))
+	lines[0] = lipgloss.JoinHorizontal(lipgloss.Top, style.Bold(true).Render(fit("Sidebars", width)), sep, lineAt(mainLines, 0))
 	for i, item := range visible {
 		label := strings.TrimSpace(item.Icon + " " + item.DisplayName)
 		if item.BadgeCount != 0xFFFF && item.BadgeCount > 0 {
@@ -671,10 +673,10 @@ func (m Model) withSemanticSidebars(mainLines []string) []string {
 			leftStyle = activeStyle
 		}
 		marked := m.zones.Mark(zoneIDSidebarItem(item.ID), leftStyle.Render(fit(label, width)))
-		lines[i+1] = lipgloss.JoinHorizontal(lipgloss.Top, marked, lineAt(mainLines, i+1))
+		lines[i+1] = lipgloss.JoinHorizontal(lipgloss.Top, marked, sep, lineAt(mainLines, i+1))
 	}
 	for i := len(visible) + 1; i < len(lines); i++ {
-		lines[i] = lipgloss.JoinHorizontal(lipgloss.Top, style.Render(strings.Repeat(" ", width)), lineAt(mainLines, i))
+		lines[i] = lipgloss.JoinHorizontal(lipgloss.Top, style.Render(strings.Repeat(" ", width)), sep, lineAt(mainLines, i))
 	}
 	return lines
 }

--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -234,6 +234,10 @@ func (p palette) GutterCurrentText() color.Color {
 	return p.slot(themeGutterCurrentFG)
 }
 
+func (p palette) TreeSeparator() color.Color {
+	return p.slot(themeTreeSeparatorFG)
+}
+
 func (p palette) TreeSurface() color.Color {
 	return p.slot(themeTreeBG)
 }


### PR DESCRIPTION
## Summary

- Adds a `│` separator column between semantic sidebars and the main editor content in `withSemanticSidebars()`
- Uses `m.palette().TreeSeparator()` (new palette accessor for `themeTreeSeparatorFG` slot 0x0A) with the editor background, matching the file tree border style
- Accounts for the 1-column separator in `leftChromeWidth()` so layout calculations remain correct

Closes #2540
Part of epic #2531

## Test plan

- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [x] `go build ./cmd/...` succeeds
- [x] Updated `TestSemanticWindowsRespectSidebarOffset` to verify separator is present and offset is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)