### PR TITLE
feat: add user message background band in agent chat

### DIFF
--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -557,16 +557,17 @@ func (m Model) renderAgentSystemMessage(msg protocol.AgentChatMessage, width int
 
 func (m Model) renderAgentUserMessage(msg protocol.AgentChatMessage, width int) []string {
 	p := m.palette()
+	bg := p.SurfaceAlt()
 	lines := compactTextLines(msg.Text, max(width-12, 8), 2)
 	if len(lines) == 0 {
 		lines = []string{""}
 	}
-	header := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(m.editorBackground()).Render("  ❯ You")
-	out := []string{lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(header, width))}
-	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(m.editorBackground())
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(bg).Render("  ❯ You")
+	out := []string{lipgloss.NewStyle().Background(bg).Width(width).Render(fitStyled(header, width))}
+	bodyStyle := lipgloss.NewStyle().Foreground(p.Text()).Background(bg)
 	for _, bodyLine := range lines {
 		line := bodyStyle.Render("    " + firstCompactLine(bodyLine, max(width-6, 8)))
-		out = append(out, lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(line, width)))
+		out = append(out, lipgloss.NewStyle().Background(bg).Width(width).Render(fitStyled(line, width)))
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

- Use `p.SurfaceAlt()` as the background color for user message rows in the agent chat transcript, replacing the default editor background
- Creates a subtle visual band that distinguishes user input from assistant output
- Keeps the `❯ You` header in accent color, only the background changes

Closes #2547
Part of epic #2531

## Test plan

- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [x] `go build ./cmd/...` succeeds
- [ ] Visual verification: user messages show a distinct background band from assistant messages in a themed session

🤖 Generated with [Claude Code](https://claude.com/claude-code)