### PR TITLE
feat: add active file highlight in file tree

### DIFF
--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -773,6 +773,8 @@ func (m Model) renderFileTreeRow(row protocol.FileTreeRow, width int) string {
 	selectionMarker := " "
 	if row.Selected {
 		selectionMarker = "▌"
+	} else if row.Active {
+		selectionMarker = "▎"
 	}
 	prefix := strings.Repeat("  ", int(row.Depth))
 	expander := " "
@@ -785,6 +787,8 @@ func (m Model) renderFileTreeRow(row protocol.FileTreeRow, width int) string {
 	markerStyle := lipgloss.NewStyle().Foreground(markerColor).Background(rowBackground)
 	if row.Selected {
 		markerStyle = markerStyle.Foreground(theme.Accent()).Bold(true)
+	} else if row.Active {
+		markerStyle = markerStyle.Foreground(theme.Accent())
 	}
 	icon := fileTreeIcon(row, row.Selected)
 	iconStyle := rowStyle


### PR DESCRIPTION
## Summary

- When a file is open in the current tab (`row.Active`), the file tree now shows a thin left accent bar (`▎`) in the theme accent color
- The active indicator is visually distinct from but less prominent than the selection highlight (`▌`)
- When a row is both active and selected, selection styling takes precedence (no change needed; the existing `if/else if` structure handles this)

Closes #2545
Part of epic #2531

## Test plan

- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [x] `go build ./cmd/...` succeeds
- [ ] Visual verification: open the TUI with a file tree visible, confirm the active file shows a thin accent bar on the left
- [ ] Visual verification: select a different file in the tree, confirm the selected file shows the bold half-block marker while the active file retains the thin accent bar
- [ ] Visual verification: select the active file, confirm only the selection highlight appears (no double marker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)