### PR TITLE
feat: add transcript message separators in agent chat

### DIFF
--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -193,6 +193,14 @@ func (m Model) renderAgentBlankLine(width int) string {
 	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(strings.Repeat(" ", max(width, 1)))
 }
 
+func (m Model) renderAgentTranscriptSeparator(width int) string {
+	p := m.palette()
+	indent := "    "
+	ruleWidth := max(width-len(indent), 0)
+	rule := lipgloss.NewStyle().Foreground(p.Muted()).Background(m.editorBackground()).Render(strings.Repeat("─", ruleWidth))
+	return lipgloss.NewStyle().Background(m.editorBackground()).Width(width).Render(fitStyled(indent+rule, width))
+}
+
 func (m Model) renderAgentTranscriptHeader(width int) string {
 	p := m.palette()
 	label := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" Transcript ")
@@ -506,7 +514,7 @@ func (m Model) renderAgentTranscriptTail(chat protocol.AgentChat, budget int, wi
 	for i := len(blocks) - 1; i >= 0; i-- {
 		lines = append(lines, blocks[i]...)
 		if i > 0 && len(lines) < budget {
-			lines = append(lines, m.renderAgentBlankLine(width))
+			lines = append(lines, m.renderAgentTranscriptSeparator(width))
 		}
 	}
 	if len(lines) > budget {


### PR DESCRIPTION
## Summary

- Replace blank-line separators between agent chat message groups with a subtle horizontal rule (`─`) in `Muted()` foreground color
- Separator is indented 4 characters to align with message content, skipping the rail area
- Makes long transcripts easier to scan without adding visual noise

Closes #2549
Part of epic #2531

## Test plan

- [x] `go build ./cmd/...` succeeds
- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [ ] Visual verification: open agent chat with multiple messages, confirm faint `─` rule appears between message groups
- [ ] Verify separator is visually lighter than message text
- [ ] Confirm separator aligns with message content (not flush-left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)