### PR TITLE
feat: state-aware composer title in agent chat

### DIFF
--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -1058,7 +1058,7 @@ func (m Model) renderAgentComposer(chat protocol.AgentChat, width int) []string 
 		borderColor = markerColor
 	}
 	border := lipgloss.NewStyle().Foreground(borderColor).Background(m.editorBackground())
-	title := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" Prompt ")
+	title := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" " + agentComposerTitle(chat) + " ")
 	top := border.Render("╭") + title + border.Render(strings.Repeat("─", max(width-2-lipgloss.Width(title), 0))+"╮")
 	innerWidth := max(width-2, 1)
 	marker := lipgloss.NewStyle().Bold(true).Foreground(markerColor).Background(m.editorBackground()).Render("❯")
@@ -1098,6 +1098,20 @@ func agentPromptModeName(mode byte) string {
 		return "REPLACE"
 	default:
 		return "NORMAL"
+	}
+}
+
+func agentComposerTitle(chat protocol.AgentChat) string {
+	if chat.Pending != "" {
+		return "Approval needed"
+	}
+	switch chat.Status {
+	case 1, 2:
+		return "Running..."
+	case 3:
+		return "Error"
+	default:
+		return "Prompt"
 	}
 }
 


### PR DESCRIPTION
## Summary
- Derive the agent composer box title from `chat.Status` and `chat.Pending` instead of hardcoding "Prompt"
- Idle shows "Prompt", thinking/tool shows "Running...", error shows "Error", and pending approval shows "Approval needed"
- Title + border color together communicate current agent state at a glance

Closes #2565
Part of epic #2531

## Test plan
- [x] `go build ./cmd/...` succeeds
- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [ ] Visual: idle state shows "Prompt" title
- [ ] Visual: thinking/tool state shows "Running..." title
- [ ] Visual: error state shows "Error" title
- [ ] Visual: pending approval shows "Approval needed" title

🤖 Generated with [Claude Code](https://claude.com/claude-code)