### PR TITLE
feat: add focused row cursor indicator in file tree

### DIFF
--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -769,10 +769,14 @@ func (m Model) renderFileTreeRow(row protocol.FileTreeRow, width int) string {
 	if row.Selected {
 		rowBackground = theme.TreeSelection()
 		textColor = theme.TreeSelectionText()
+	} else if row.Focused {
+		rowBackground = theme.TreeFocus()
 	}
 	selectionMarker := " "
 	if row.Selected {
 		selectionMarker = "▌"
+	} else if row.Focused {
+		selectionMarker = "▏"
 	}
 	prefix := strings.Repeat("  ", int(row.Depth))
 	expander := " "
@@ -785,6 +789,8 @@ func (m Model) renderFileTreeRow(row protocol.FileTreeRow, width int) string {
 	markerStyle := lipgloss.NewStyle().Foreground(markerColor).Background(rowBackground)
 	if row.Selected {
 		markerStyle = markerStyle.Foreground(theme.Accent()).Bold(true)
+	} else if row.Focused {
+		markerStyle = markerStyle.Foreground(theme.Accent())
 	}
 	icon := fileTreeIcon(row, row.Selected)
 	iconStyle := rowStyle

--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -254,6 +254,11 @@ func (p palette) TreeSelection() color.Color {
 	return p.slot(themeTreeSelectBG)
 }
 
+// TreeFocus returns a faint background tint for focused-but-not-selected file tree rows. It blends 40% of the way from TreeSurface toward TreeSelection so the focus cursor is visible without competing with selection styling.
+func (p palette) TreeFocus() color.Color {
+	return p.blendSlots(themeTreeBG, themeTreeSelectBG, 0.4)
+}
+
 func (p palette) TreeSelectionText() color.Color {
 	return p.slot(themeTreeSelectionFG)
 }
@@ -332,6 +337,21 @@ func (p palette) Info() color.Color {
 
 func (p palette) Hint() color.Color {
 	return p.slot(themeDiagnosticHint)
+}
+
+// blendSlots linearly interpolates between two theme slot colors by factor t (0.0 = slotA, 1.0 = slotB).
+func (p palette) blendSlots(slotA byte, slotB byte, t float64) color.Color {
+	a, okA := p.colors[slotA]
+	b, okB := p.colors[slotB]
+	if !okA || !okB {
+		return lipgloss.NoColor{}
+	}
+	rA, gA, bA := int(a>>16&0xFF), int(a>>8&0xFF), int(a&0xFF)
+	rB, gB, bB := int(b>>16&0xFF), int(b>>8&0xFF), int(b&0xFF)
+	r := uint32(float64(rA) + float64(rB-rA)*t)
+	g := uint32(float64(gA) + float64(gB-gA)*t)
+	bl := uint32(float64(bA) + float64(bB-bA)*t)
+	return lipgloss.Color(fmt.Sprintf("#%06X", (r<<16)|(g<<8)|bl))
 }
 
 func (p palette) slot(slot byte) color.Color {


### PR DESCRIPTION
## Summary

- Renders a visible focus cursor in the file tree for keyboard navigation: focused-but-not-selected rows get a faint background tint (40% blend from TreeSurface toward TreeSelection) and a thin left-edge marker (▏) in accent color
- Focus + Selected uses the existing selection styling (focus is implied by selection)
- Adds `TreeFocus()` and `blendSlots()` palette helpers to `theme.go` for theme-aware color interpolation

Closes #2546
Part of epic #2531

## Test plan

- [x] `go build ./cmd/...` succeeds
- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [ ] Visual verification: navigate file tree with keyboard, confirm focused row has subtle tint and thin marker distinct from bold selection marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)