### PR TITLE
feat: increase details rail section divider weight

### DIFF
--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -355,10 +355,16 @@ func (m Model) renderAgentDetailFrame(kind string, title string, width int) stri
 
 func (m Model) renderAgentDetailsSection(label string, width int) string {
 	p := m.palette()
-	line := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground()).Render("─")
-	text := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(m.editorBackground()).Render(" " + label + " ")
-	remaining := max(width-lipgloss.Width(label)-4, 0)
-	return m.renderAgentDetailContentLine(text+strings.Repeat(line, remaining), width)
+	ruleStyle := lipgloss.NewStyle().Foreground(p.PopupBorder()).Background(m.editorBackground())
+	text := lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(m.editorBackground()).Render(" " + label + " ")
+	// renderAgentDetailContentLine uses bodyWidth = width-2 and prepends a space,
+	// so available content width is width-3.
+	labelVisual := lipgloss.Width(text)
+	totalRule := max(width-3-labelVisual, 0)
+	leftRule := min(3, totalRule)
+	rightRule := max(totalRule-leftRule, 0)
+	content := ruleStyle.Render(strings.Repeat("─", leftRule)) + text + ruleStyle.Render(strings.Repeat("─", rightRule))
+	return m.renderAgentDetailContentLine(content, width)
 }
 
 func (m Model) renderAgentDetailRow(label string, value string, width int) string {


### PR DESCRIPTION
## Summary
- Extends `─` rule characters to both sides of section labels in the details rail, filling available width for heavier visual dividers
- Brightens section header labels from `p.Muted()` to `p.Text()` so they stand out from row content below

Closes #2566
Part of epic #2531

## Test plan
- [x] `go build ./cmd/...` passes
- [x] `go test ./internal/ui/... -count=1 -race` passes (205 tests)
- [ ] Visual verification: section dividers ("Needs attention", "Hints") render with `─── Label ────────` spanning near-full rail width

🤖 Generated with [Claude Code](https://claude.com/claude-code)