### PR TITLE
feat: add nerd font icons to status bar mode and file type

### DIFF
--- a/go/tui/internal/ui/icons.go
+++ b/go/tui/internal/ui/icons.go
@@ -97,6 +97,29 @@ func whichKeyIcon(binding protocol.WhichKeyBinding) uiIcon {
 	}
 }
 
+// modeIcon returns a nerd font icon for the given vi mode name. The mode name
+// should be the trimmed text from a modeline segment (NORMAL, INSERT, etc.).
+func modeIcon(mode string) string {
+	switch mode {
+	case "NORMAL":
+		return ""
+	case "INSERT":
+		return ""
+	case "VISUAL":
+		return "󰈈"
+	case "COMMAND":
+		return ""
+	case "OP":
+		return ""
+	case "SEARCH":
+		return ""
+	case "REPLACE":
+		return "󰛔"
+	default:
+		return ""
+	}
+}
+
 func devIconForPath(path string, directory bool) uiIcon {
 	if directory && strings.TrimSpace(path) == "" {
 		return uiIcon{glyph: "", color: "#61AFEF"}

--- a/go/tui/internal/ui/icons_test.go
+++ b/go/tui/internal/ui/icons_test.go
@@ -23,6 +23,27 @@ func TestFileTreeIconUsesTransmittedColorOnlyWhenUnselected(t *testing.T) {
 	}
 }
 
+func TestModeIconReturnsGlyphForKnownModes(t *testing.T) {
+	cases := []struct {
+		mode string
+		want string
+	}{
+		{"NORMAL", ""},
+		{"INSERT", ""},
+		{"VISUAL", "󰈈"},
+		{"COMMAND", ""},
+		{"SEARCH", ""},
+		{"REPLACE", "󰛔"},
+		{"unknown", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := modeIcon(tc.mode); got != tc.want {
+			t.Errorf("modeIcon(%q) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
 func TestFileTreeIconKeepsDeviconFallbackWhenSelected(t *testing.T) {
 	// When the BEAM sends no glyph, the renderer derives one locally; the
 	// transmitted color is not consulted on that path, even if the row is selected.

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -307,6 +307,67 @@ func TestFooterRendersStatusMessageWithModelineSegments(t *testing.T) {
 	}
 }
 
+func TestFooterRendersModeIconBeforeModeText(t *testing.T) {
+	model := New(80, 24, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiStatusBar: {
+			Status: protocol.StatusBar{
+				Left:  []protocol.StatusSegment{{Text: " NORMAL "}},
+				Right: []protocol.StatusSegment{{Text: "1:1"}},
+			},
+		},
+	}
+	footer := ansi.Strip(strings.Join(model.footerLines(), "\n"))
+	if !strings.Contains(footer, " NORMAL") {
+		t.Fatalf("footer should prepend mode icon before mode text: %q", footer)
+	}
+}
+
+func TestFooterRendersFileIconBeforeFilename(t *testing.T) {
+	model := New(80, 24, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiStatusBar: {
+			Status: protocol.StatusBar{
+				Filename: "main.go",
+				Left:     []protocol.StatusSegment{{Text: " NORMAL "}},
+				Right:    []protocol.StatusSegment{{Text: "1:1"}},
+			},
+		},
+	}
+	footer := ansi.Strip(strings.Join(model.footerLines(), "\n"))
+	icon := devIconForPath("main.go", false)
+	if icon.glyph == "" {
+		t.Fatal("expected devicon for main.go")
+	}
+	if !strings.Contains(footer, icon.glyph) {
+		t.Fatalf("footer should render file type icon for filename: %q (want glyph %q)", footer, icon.glyph)
+	}
+}
+
+func TestFooterFallbackRendersFileIcon(t *testing.T) {
+	model := New(80, 24, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiStatusBar: {
+			Status: protocol.StatusBar{
+				Filename: "app.rs",
+				Line:     10,
+				Column:   5,
+			},
+		},
+	}
+	footer := ansi.Strip(strings.Join(model.footerLines(), "\n"))
+	icon := devIconForPath("app.rs", false)
+	if icon.glyph == "" {
+		t.Fatal("expected devicon for app.rs")
+	}
+	if !strings.Contains(footer, icon.glyph) {
+		t.Fatalf("fallback footer should render file type icon before filename: %q (want glyph %q)", footer, icon.glyph)
+	}
+	if !strings.Contains(footer, "app.rs") {
+		t.Fatalf("fallback footer should still contain filename: %q", footer)
+	}
+}
+
 func TestHeaderRendersBreadcrumbWithTabs(t *testing.T) {
 	model := New(120, 24, nil)
 	model.chrome = map[byte]protocol.ChromePayload{

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -153,7 +153,12 @@ func (m Model) footerLines() []string {
 		if len(chromeStatus.Left) > 0 || len(chromeStatus.Right) > 0 {
 			status = m.renderStatusSegments(chromeStatus)
 		} else if chromeStatus.Filename != "" {
-			status = fmt.Sprintf("%s  %d:%d", chromeStatus.Filename, chromeStatus.Line, chromeStatus.Column)
+			icon := devIconForPath(chromeStatus.Filename, false)
+			prefix := chromeStatus.Filename
+			if icon.glyph != "" {
+				prefix = icon.glyph + " " + chromeStatus.Filename
+			}
+			status = fmt.Sprintf("%s  %d:%d", prefix, chromeStatus.Line, chromeStatus.Column)
 			if chromeStatus.Message != "" {
 				status += "  " + chromeStatus.Message
 			}
@@ -201,6 +206,17 @@ func (m Model) renderStatusSegments(status protocol.StatusBar) string {
 	left := m.renderSegmentList(status.Left)
 	right := m.renderSegmentList(status.Right)
 	message := m.renderStatusMessage(status.Message)
+	// Prepend a devicon for the current file type before the right segments.
+	if status.Filename != "" {
+		icon := devIconForPath(status.Filename, false)
+		if icon.glyph != "" {
+			fileStyle := lipgloss.NewStyle().Foreground(m.palette().ChromeText()).Background(m.palette().ChromeSurface())
+			if icon.color != "" {
+				fileStyle = fileStyle.Foreground(lipgloss.Color(icon.color))
+			}
+			right = fileStyle.Render(icon.glyph+" ") + right
+		}
+	}
 	leftWidth := lipgloss.Width(left)
 	rightWidth := lipgloss.Width(right)
 	messageWidth := lipgloss.Width(message)
@@ -262,6 +278,10 @@ func (m Model) renderSegmentList(segments []protocol.StatusSegment) string {
 		}
 		if segment.Attrs&0x04 != 0 {
 			style = style.Italic(true)
+		}
+		// Prepend a nerd font icon when the segment carries a vi mode name.
+		if icon := modeIcon(strings.TrimSpace(text)); icon != "" {
+			text = strings.Replace(text, strings.TrimSpace(text), icon+" "+strings.TrimSpace(text), 1)
 		}
 		rendered := style.Render(text)
 		if segment.Command != "" {


### PR DESCRIPTION
## Summary

- Prepend nerd font icons before vi mode text (NORMAL, INSERT, VISUAL, COMMAND, OP, SEARCH, REPLACE) in modeline segments
- Render devicons for the current file type before the filename in the status bar (both segment-based and fallback rendering paths)
- Uses the existing `go-devicons` library that was already used for tab and file tree icons

Closes #2561
Part of epic #2531

## Test plan

- [x] `go build ./cmd/...` succeeds
- [x] `go test ./internal/ui/... -count=1 -race` passes (209 tests, including 4 new)
- [ ] Visually confirm mode icon renders alongside mode text in the status bar
- [ ] Visually confirm file type devicon renders before the filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)