### PR TITLE
feat: add search/filter match highlighting in file tree

### DIFF
--- a/go/tui/internal/protocol/chrome_types.go
+++ b/go/tui/internal/protocol/chrome_types.go
@@ -156,20 +156,21 @@ type FileTree struct {
 }
 
 type FileTreeRow struct {
-	ID        string
-	Path      string
-	PathHash  uint32
-	Name      string
-	Icon      string
-	IconColor uint32
-	Depth     byte
-	Flags     uint16
-	Directory bool
-	Expanded  bool
-	Selected  bool
-	Focused   bool
-	Active    bool
-	Dirty     bool
+	ID             string
+	Path           string
+	PathHash       uint32
+	Name           string
+	Icon           string
+	IconColor      uint32
+	Depth          byte
+	Flags          uint16
+	Directory      bool
+	Expanded       bool
+	Selected       bool
+	Focused        bool
+	Active         bool
+	Dirty          bool
+	MatchPositions []uint16
 }
 
 type StatusBar struct {

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1363,6 +1363,60 @@ func TestFileTreeSelectedRowPaintsBackgroundAcrossSegments(t *testing.T) {
 	}
 }
 
+func TestFileTreeMatchHighlightAccentsMatchedCharacters(t *testing.T) {
+	model := New(40, 8, nil)
+	_ = model.applyCommands(frame(testThemeCommand()))
+	rendered := model.renderFileTreeRow(protocol.FileTreeRow{
+		Name:           "main.go",
+		Icon:           "",
+		MatchPositions: []uint16{0, 1},
+	}, 30)
+	stripped := ansi.Strip(rendered)
+	if !strings.Contains(stripped, "main.go") {
+		t.Fatalf("rendered row should contain filename, got %q", stripped)
+	}
+	// The test theme accent 0x7DB7FF = (125, 183, 255) produces "125;183;255" in ANSI.
+	// Characters at positions 0 ("m") and 1 ("a") should carry this accent foreground.
+	if !strings.Contains(rendered, "125;183;255") {
+		t.Fatalf("matched characters should carry accent foreground color, got %q", rendered)
+	}
+}
+
+func TestFileTreeMatchHighlightSkippedWhenNoPositions(t *testing.T) {
+	model := New(40, 8, nil)
+	_ = model.applyCommands(frame(testThemeCommand()))
+	withMatch := model.renderFileTreeRow(protocol.FileTreeRow{
+		Name:           "main.go",
+		Icon:           "",
+		MatchPositions: []uint16{0},
+	}, 30)
+	withoutMatch := model.renderFileTreeRow(protocol.FileTreeRow{
+		Name: "main.go",
+		Icon: "",
+	}, 30)
+	// Without match positions, no accent highlighting should appear in the name portion.
+	// The accent color should only appear in the version with match positions.
+	if strings.Contains(withoutMatch, "125;183;255") {
+		t.Fatalf("row without match positions should not contain accent color, got %q", withoutMatch)
+	}
+	if !strings.Contains(withMatch, "125;183;255") {
+		t.Fatalf("row with match positions should contain accent color, got %q", withMatch)
+	}
+}
+
+func TestFileTreeMatchHighlightPreservesRowWidth(t *testing.T) {
+	model := New(40, 8, nil)
+	_ = model.applyCommands(frame(testThemeCommand()))
+	rendered := model.renderFileTreeRow(protocol.FileTreeRow{
+		Name:           "config.toml",
+		Icon:           "",
+		MatchPositions: []uint16{0, 3, 7},
+	}, 28)
+	if got := displayWidth(ansi.Strip(rendered)); got != 28 {
+		t.Fatalf("highlighted file-tree row should fill requested width, got %d row=%q", got, rendered)
+	}
+}
+
 func TestFileTreeWidthRespectsProtocolGeometryAndSafetyClamp(t *testing.T) {
 	if got := fileTreeWidth(80, protocol.FileTree{Width: 18}); got != 18 {
 		t.Fatalf("file tree width = %d, want narrow protocol width 18", got)

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"image/color"
 	"sort"
 	"strings"
 
@@ -795,7 +796,8 @@ func (m Model) renderFileTreeRow(row protocol.FileTreeRow, width int) string {
 	if row.Selected || row.Directory {
 		nameStyle = nameStyle.Bold(true)
 	}
-	content := markerStyle.Render(selectionMarker+prefix+expander) + rowStyle.Render(" ") + iconStyle.Render(icon.glyph) + rowStyle.Render(" ") + nameStyle.Render(row.Name)
+	nameRendered := renderFileTreeName(row.Name, row.MatchPositions, nameStyle, theme.Accent())
+	content := markerStyle.Render(selectionMarker+prefix+expander) + rowStyle.Render(" ") + iconStyle.Render(icon.glyph) + rowStyle.Render(" ") + nameRendered
 	if row.Dirty {
 		dirty := lipgloss.NewStyle().Foreground(theme.Warning()).Background(rowBackground).Render("●")
 		space := strings.Repeat(" ", max(width-lipgloss.Width(content)-lipgloss.Width(dirty), 1))
@@ -804,6 +806,31 @@ func (m Model) renderFileTreeRow(row protocol.FileTreeRow, width int) string {
 		content += rowStyle.Render(strings.Repeat(" ", remaining))
 	}
 	return rowStyle.Width(width).Render(fitStyled(content, width))
+}
+
+// renderFileTreeName renders a filename with optional accent highlighting on
+// matched character positions. When matchPositions is empty the name is rendered
+// with the base style only (no highlighting). Match positions are uint16 rune
+// indices into the name string, matching the fuzzy-match pattern used by the
+// picker overlay.
+func renderFileTreeName(name string, matchPositions []uint16, baseStyle lipgloss.Style, accent color.Color) string {
+	if len(matchPositions) == 0 {
+		return baseStyle.Render(name)
+	}
+	matchSet := make(map[uint16]bool, len(matchPositions))
+	for _, pos := range matchPositions {
+		matchSet[pos] = true
+	}
+	accentStyle := baseStyle.Foreground(accent)
+	var result strings.Builder
+	for i, r := range name {
+		if matchSet[uint16(i)] {
+			result.WriteString(accentStyle.Render(string(r)))
+		} else {
+			result.WriteString(baseStyle.Render(string(r)))
+		}
+	}
+	return result.String()
 }
 
 func fileTreeRowMuted(row protocol.FileTreeRow) bool {

--- a/go/tui/internal/ui/render_content.go
+++ b/go/tui/internal/ui/render_content.go
@@ -823,12 +823,14 @@ func renderFileTreeName(name string, matchPositions []uint16, baseStyle lipgloss
 	}
 	accentStyle := baseStyle.Foreground(accent)
 	var result strings.Builder
-	for i, r := range name {
-		if matchSet[uint16(i)] {
+	runeIdx := 0
+	for _, r := range name {
+		if matchSet[uint16(runeIdx)] {
 			result.WriteString(accentStyle.Render(string(r)))
 		} else {
 			result.WriteString(baseStyle.Render(string(r)))
 		}
+		runeIdx++
 	}
 	return result.String()
 }


### PR DESCRIPTION
## Summary

- Add `MatchPositions []uint16` field to `FileTreeRow` protocol struct, matching the fuzzy-match pattern already used by the picker
- Add `renderFileTreeName()` helper that accent-highlights matched characters when positions are provided, falls back to plain rendering when empty
- Add 3 tests covering: accent color on matched chars, no highlighting without positions, row width preservation

## Protocol gap (needs BEAM-side follow-up)

The BEAM-side `FileTree` model has a `filter` field and performs substring matching via `filter_walk.ex`, but the `gui_file_tree` wire format does not currently include match positions (or filter text) for file tree rows. The Go TUI rendering path is ready and will activate once the BEAM encoder (`file_tree_encoder.ex`) is extended to send `match_positions` per row.

Options for the BEAM-side extension:
1. **Preferred**: add a `match_positions` counted array (u8 count + u16 indices) to each row's wire tail, matching the picker item format
2. **Alternative**: add `filter_text` (string16) to the FileTree header and compute positions client-side

Closes #2568
Part of epic #2531

## Test plan

- [x] `go test ./internal/ui/... -count=1 -race` passes (208 tests, 3 new)
- [x] `go build ./cmd/...` succeeds
- [ ] Visual verification deferred until BEAM sends match positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)