### PR TITLE
fix: allow font and config commands outside frame transactions

### DIFF
--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -158,7 +158,9 @@ final class CommandDispatcher {
     /// invalidation, because byte boundaries are no longer trustworthy.
     private static func isOutOfBandAllowed(_ command: RenderCommand) -> Bool {
         switch command {
-        case .setTitle, .setWindowBg, .protocolError:
+        case .setTitle, .setWindowBg, .protocolError,
+             .setFont, .setFontFallback, .registerFont,
+             .guiConfigState:
             return true
         default:
             return false


### PR DESCRIPTION
## Summary

- Font config commands (`setFont`, `setFontFallback`, `registerFont`) and `guiConfigState` are sent by the BEAM before the first render frame, outside any frame transaction
- The dispatcher's `isOutOfBandAllowed` only permitted `setTitle`, `setWindowBg`, and `protocolError`, causing font commands to hit the `invalidate("out-of-transaction command")` path
- This silently dropped the user's configured font and left Menlo as the permanent default
- The fix adds font and config state commands to the out-of-band allowlist

## Test plan

- [x] All 900 Swift tests pass
- [ ] Launch Minga with `set :font_family, "JetBrainsMono Nerd Font"` in config.exs and verify the editor renders in JetBrains Mono instead of Menlo
- [ ] Check `*Messages*` buffer for "Font changed: JetBrainsMonoNF-Regular" log entry on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)