### PR TITLE
fix(file-tree): move refresh off the Editor GenServer hot path (#2632)

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -703,9 +703,17 @@ defmodule MingaEditor do
     {:noreply, RenderHandler.handle_debounced_render(state)}
   end
 
-  # Debounced file-tree refresh timer fired — rescan the cached tree once for a burst of filesystem events.
+  # Debounced file-tree refresh timer fired — spawn an off-process rescan (#2632)
+  # so the recursive filesystem walk never blocks the Editor mailbox.
   def handle_info(:file_tree_refresh_timer, state) do
     {state, effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
+    {:noreply, EffectHandler.apply_effects(state, effects)}
+  end
+
+  # Async file-tree rescan finished — apply the refreshed tree with a cheap,
+  # atomic whole-tree swap, discarding it if the tree was re-rooted or closed.
+  def handle_info({:file_tree_refresh_result, _refreshed_tree, _token} = msg, state) do
+    {state, effects} = FileEventHandler.handle(state, msg)
     {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -717,6 +717,13 @@ defmodule MingaEditor do
     {:noreply, EffectHandler.apply_effects(state, effects)}
   end
 
+  # Async file-tree rescan crashed — clear in-flight tracking and honour a
+  # coalesced refresh so the refresh loop never wedges (#2632).
+  def handle_info({:file_tree_refresh_failed, _token} = msg, state) do
+    {state, effects} = FileEventHandler.handle(state, msg)
+    {:noreply, EffectHandler.apply_effects(state, effects)}
+  end
+
   # Renderer.Server writeback after each async frame completes.
   # EditorState narrows the merge to renderer-owned fields only.
   def handle_info({:render_done, %{caches: _caches, layout: _layout} = wb}, state) do

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -17,6 +17,11 @@ defmodule MingaEditor.FileTree.Freshness do
 
   @type state :: EditorState.t()
 
+  @typedoc "Effects emitted by the async refresh orchestration (interpreted by EffectHandler)."
+  @type effect ::
+          {:render, pos_integer()}
+          | {:start_file_tree_refresh, FileTree.t(), reference()}
+
   @doc "Returns true when the file tree is open."
   @spec open?(state()) :: boolean()
   def open?(state), do: match?(%FileTreeState{tree: %FileTree{}}, file_tree_state(state))
@@ -70,29 +75,124 @@ defmodule MingaEditor.FileTree.Freshness do
     |> FileTreeState.refresh_scheduled?()
   end
 
-  @doc "Refreshes cached filesystem entries after the debounce timer fires."
-  @spec flush_refresh(state()) :: state()
-  def flush_refresh(state) do
+  @doc """
+  Starts an async filesystem rescan after the debounce timer fires (#2632).
+
+  The heavy recursive `File.ls`/`File.lstat` walk must not run on the Editor
+  GenServer. This clears the debounce timer and, unless a rescan is already in
+  flight, mints a token and emits a `{:start_file_tree_refresh, tree, token}`
+  effect so `EffectHandler` can spawn the work off-process. The Task replies with
+  `{:file_tree_refresh_result, refreshed_tree, token}`, handled by
+  `apply_refresh_result/3`.
+
+  If a rescan is already in flight, the request is coalesced into a single
+  follow-up (`refresh_pending?`) instead of piling up Tasks (AC3): the in-flight
+  walk finishes, then exactly one fresh rescan starts.
+  """
+  @spec begin_refresh(state()) :: {state(), [effect()]}
+  def begin_refresh(state) do
+    state |> file_tree_state() |> begin_refresh(state)
+  end
+
+  # No open tree: just drop the debounce timer.
+  @spec begin_refresh(FileTreeState.t(), state()) :: {state(), [effect()]}
+  defp begin_refresh(%FileTreeState{tree: nil} = file_tree, state) do
+    {set_file_tree(state, FileTreeState.clear_refresh(file_tree)), []}
+  end
+
+  # A rescan is already running: coalesce instead of spawning another Task.
+  defp begin_refresh(%FileTreeState{tree: %FileTree{}, refresh_inflight: ref} = file_tree, state)
+       when is_reference(ref) do
+    file_tree =
+      file_tree
+      |> FileTreeState.clear_refresh()
+      |> FileTreeState.mark_refresh_pending()
+
+    {set_file_tree(state, file_tree), []}
+  end
+
+  # Idle: mint a token, mark in-flight, and emit the spawn effect.
+  defp begin_refresh(%FileTreeState{tree: %FileTree{} = tree} = file_tree, state) do
+    token = make_ref()
+    file_tree = FileTreeState.begin_inflight_refresh(file_tree, token)
+    {set_file_tree(state, file_tree), [{:start_file_tree_refresh, tree, token}]}
+  end
+
+  @doc """
+  Applies a finished async rescan, swapping the whole tree atomically (#2632 AC4).
+
+  The result is discarded when stale: the token no longer matches the in-flight
+  refresh, or the user re-rooted/closed the tree while the walk ran, so the
+  refreshed tree's root no longer matches the live tree (AC3/AC4 staleness
+  guard). After applying or dropping, a coalesced `refresh_pending?` request, if
+  any, starts exactly one fresh rescan.
+  """
+  @spec apply_refresh_result(state(), FileTree.t(), reference()) :: {state(), [effect()]}
+  def apply_refresh_result(state, %FileTree{} = refreshed_tree, token) when is_reference(token) do
+    state |> file_tree_state() |> apply_refresh_result(state, refreshed_tree, token)
+  end
+
+  # Fresh: the in-flight token matches and the tree is still rooted where the
+  # walk ran. Swap the whole tree in one cheap assignment (no FS walk here).
+  @spec apply_refresh_result(FileTreeState.t(), state(), FileTree.t(), reference()) ::
+          {state(), [effect()]}
+  defp apply_refresh_result(
+         %FileTreeState{refresh_inflight: token, tree: %FileTree{root: root}} = file_tree,
+         state,
+         %FileTree{root: root} = refreshed_tree,
+         token
+       ) do
+    watch_expanded_dirs(refreshed_tree)
+
+    file_tree = FileTreeState.replace_tree(file_tree, refreshed_tree)
+
+    state =
+      state
+      |> set_file_tree(file_tree)
+      |> sync_buffer(refreshed_tree)
+
+    finish_refresh(state, refreshed_tree, [{:render, 16}])
+  end
+
+  # Stale: re-rooted, closed, or superseded while the walk ran. Drop the result.
+  defp apply_refresh_result(%FileTreeState{}, state, _refreshed_tree, _token) do
+    finish_refresh(state, current_tree(state), [])
+  end
+
+  # Clears in-flight tracking and, when a refresh was coalesced while the Task
+  # ran, starts exactly one fresh rescan of the current tree (#2632 AC3).
+  @spec finish_refresh(state(), FileTree.t() | nil, [effect()]) :: {state(), [effect()]}
+  defp finish_refresh(state, tree, effects) do
+    state |> file_tree_state() |> finish_refresh(state, tree, effects)
+  end
+
+  @spec finish_refresh(FileTreeState.t(), state(), FileTree.t() | nil, [effect()]) ::
+          {state(), [effect()]}
+  defp finish_refresh(%FileTreeState{refresh_pending?: true}, state, %FileTree{} = tree, effects) do
+    token = make_ref()
+
+    file_tree =
+      state
+      |> file_tree_state()
+      |> FileTreeState.begin_inflight_refresh(token)
+
+    {set_file_tree(state, file_tree), [{:start_file_tree_refresh, tree, token} | effects]}
+  end
+
+  defp finish_refresh(%FileTreeState{}, state, _tree, effects) do
+    file_tree =
+      state
+      |> file_tree_state()
+      |> FileTreeState.clear_inflight_refresh()
+
+    {set_file_tree(state, file_tree), effects}
+  end
+
+  @spec current_tree(state()) :: FileTree.t() | nil
+  defp current_tree(state) do
     case file_tree_state(state) do
-      %FileTreeState{tree: nil} = file_tree ->
-        set_file_tree(state, FileTreeState.clear_refresh(file_tree))
-
-      %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
-        refreshed_tree =
-          tree
-          |> FileTree.refresh()
-          |> refresh_tree_git_status_from_cache(EditorState.events_registry(state))
-
-        watch_expanded_dirs(refreshed_tree)
-
-        file_tree =
-          file_tree
-          |> FileTreeState.clear_refresh()
-          |> FileTreeState.replace_tree(refreshed_tree)
-
-        state
-        |> set_file_tree(file_tree)
-        |> sync_buffer(refreshed_tree)
+      %FileTreeState{tree: %FileTree{} = tree} -> tree
+      %FileTreeState{} -> nil
     end
   end
 

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -154,10 +154,60 @@ defmodule MingaEditor.FileTree.Freshness do
     finish_refresh(state, refreshed_tree, [{:render, 16}])
   end
 
-  # Stale: re-rooted, closed, or superseded while the walk ran. Drop the result.
-  defp apply_refresh_result(%FileTreeState{}, state, _refreshed_tree, _token) do
+  # Current in-flight refresh completed, but the tree was re-rooted/closed while
+  # the walk ran so its root no longer matches. Drop the tree, but still finish
+  # the in-flight bookkeeping (clear in-flight, honour a coalesced refresh).
+  defp apply_refresh_result(
+         %FileTreeState{refresh_inflight: token},
+         state,
+         _refreshed_tree,
+         token
+       ) do
     finish_refresh(state, current_tree(state), [])
   end
+
+  # Superseded result: the token is no longer the current in-flight refresh
+  # (a newer refresh replaced it). Ignore it without touching in-flight tracking.
+  defp apply_refresh_result(%FileTreeState{}, state, _refreshed_tree, _token) do
+    {state, []}
+  end
+
+  @doc """
+  Handles a failed async rescan (#2632): the Task raised/threw or could not
+  finish, so no tree is applied. Clears in-flight tracking and honours a
+  coalesced refresh so the refresh loop never wedges. Ignored when the token is
+  no longer the current in-flight refresh.
+  """
+  @spec apply_refresh_failure(state(), reference()) :: {state(), [effect()]}
+  def apply_refresh_failure(state, token) when is_reference(token) do
+    state |> file_tree_state() |> apply_refresh_failure(state, token)
+  end
+
+  @spec apply_refresh_failure(FileTreeState.t(), state(), reference()) :: {state(), [effect()]}
+  defp apply_refresh_failure(%FileTreeState{refresh_inflight: token}, state, token) do
+    finish_refresh(state, current_tree(state), [])
+  end
+
+  defp apply_refresh_failure(%FileTreeState{}, state, _token) do
+    {state, []}
+  end
+
+  @doc """
+  Clears in-flight tracking when a refresh Task could not be spawned (#2632), so
+  a later timer can retry instead of wedging. No-op when the token is not the
+  current in-flight refresh.
+  """
+  @spec cancel_inflight_refresh(state(), reference()) :: state()
+  def cancel_inflight_refresh(state, token) when is_reference(token) do
+    state |> file_tree_state() |> cancel_inflight_refresh(state, token)
+  end
+
+  @spec cancel_inflight_refresh(FileTreeState.t(), state(), reference()) :: state()
+  defp cancel_inflight_refresh(%FileTreeState{refresh_inflight: token} = file_tree, state, token) do
+    set_file_tree(state, FileTreeState.clear_inflight_refresh(file_tree))
+  end
+
+  defp cancel_inflight_refresh(%FileTreeState{}, state, _token), do: state
 
   # Clears in-flight tracking and, when a refresh was coalesced while the Task
   # ran, starts exactly one fresh rescan of the current tree (#2632 AC3).

--- a/lib/minga_editor/file_tree/refresh.ex
+++ b/lib/minga_editor/file_tree/refresh.ex
@@ -59,27 +59,53 @@ defmodule MingaEditor.FileTree.Refresh do
 
   # Runs the rescan and ALWAYS sends a reply, converting any raise/throw/exit
   # into a failure sentinel so the Editor's in-flight flag is always cleared.
+  #
+  # The reply is computed with NO risky work (just building a tuple) and sent
+  # BEFORE any logging. Logging a failure can itself raise (a custom exception's
+  # `message/1` callback, or the logger), so it is deferred to an isolated,
+  # self-guarding helper after the send — the terminal message is guaranteed to
+  # go out no matter what the logging does, preserving the no-wedge invariant.
   @spec run(FileTree.t(), token(), Minga.Events.registry(), pid()) :: :ok
   defp run(tree, token, events_registry, reply_to) do
-    message =
+    {message, failure} =
       try do
         refreshed_tree =
           tree
           |> FileTree.refresh()
           |> Freshness.refresh_tree_git_status_from_cache(events_registry)
 
-        {:file_tree_refresh_result, refreshed_tree, token}
+        {{:file_tree_refresh_result, refreshed_tree, token}, nil}
       rescue
-        e ->
-          Minga.Log.warning(:editor, "File tree refresh failed: #{Exception.message(e)}")
-          {:file_tree_refresh_failed, token}
+        e -> {{:file_tree_refresh_failed, token}, {:rescue, e}}
       catch
-        kind, reason ->
-          Minga.Log.warning(:editor, "File tree refresh #{kind}: #{inspect(reason)}")
-          {:file_tree_refresh_failed, token}
+        kind, reason -> {{:file_tree_refresh_failed, token}, {:catch, kind, reason}}
       end
 
     send(reply_to, message)
+    log_failure(failure)
     :ok
+  end
+
+  # Logs a failure after the reply is already sent. Self-guarded so a raising
+  # `Exception.message/1` or logger can never propagate out of `run/4`.
+  @spec log_failure(nil | {:rescue, Exception.t()} | {:catch, atom(), term()}) :: :ok
+  defp log_failure(nil), do: :ok
+
+  defp log_failure({:rescue, exception}) do
+    Minga.Log.warning(:editor, "File tree refresh failed: #{Exception.message(exception)}")
+    :ok
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  defp log_failure({:catch, kind, reason}) do
+    Minga.Log.warning(:editor, "File tree refresh #{kind}: #{inspect(reason)}")
+    :ok
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
   end
 end

--- a/lib/minga_editor/file_tree/refresh.ex
+++ b/lib/minga_editor/file_tree/refresh.ex
@@ -1,0 +1,50 @@
+defmodule MingaEditor.FileTree.Refresh do
+  @moduledoc """
+  Async filesystem rescan for the open file tree (#2632).
+
+  A burst of filesystem events debounces into one `:file_tree_refresh_timer`.
+  When that timer fires the Editor must *not* run `FileTree.refresh/1` inline:
+  the rescan does recursive `File.ls`/`File.lstat` per expanded directory and
+  would block the Editor mailbox for all that I/O on projects with many
+  expanded dirs.
+
+  Instead the Editor spawns this Task. It captures the current tree, runs the
+  filesystem rescan and the cached git-status refresh off the Editor process,
+  then sends `{:file_tree_refresh_result, refreshed_tree, token}` back. The
+  Editor applies the result with a cheap, atomic whole-tree swap and discards
+  it if the user re-rooted or closed the tree while the walk was running (the
+  `token` plus root comparison in `MingaEditor.FileTree.Freshness`).
+  """
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.Freshness
+
+  @typedoc "Opaque token identifying one in-flight refresh; minted per spawn."
+  @type token :: reference()
+
+  @typedoc "The result message the Editor receives when a refresh Task finishes."
+  @type result :: {:file_tree_refresh_result, FileTree.t(), token()}
+
+  @doc """
+  Spawns a supervised Task that rescans `tree` off the calling process.
+
+  The Task runs `FileTree.refresh/1` (filesystem I/O) followed by the cached
+  git-status refresh, then sends `{:file_tree_refresh_result, refreshed_tree,
+  token}` to `reply_to`. Returns `:ok`. A crash in the Task is isolated by the
+  supervisor; the Editor simply keeps its prior tree.
+  """
+  @spec start(FileTree.t(), token(), Minga.Events.registry(), pid()) :: :ok
+  def start(%FileTree{} = tree, token, events_registry, reply_to)
+      when is_reference(token) and is_pid(reply_to) do
+    Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
+      refreshed_tree =
+        tree
+        |> FileTree.refresh()
+        |> Freshness.refresh_tree_git_status_from_cache(events_registry)
+
+      send(reply_to, {:file_tree_refresh_result, refreshed_tree, token})
+    end)
+
+    :ok
+  end
+end

--- a/lib/minga_editor/file_tree/refresh.ex
+++ b/lib/minga_editor/file_tree/refresh.ex
@@ -23,28 +23,63 @@ defmodule MingaEditor.FileTree.Refresh do
   @type token :: reference()
 
   @typedoc "The result message the Editor receives when a refresh Task finishes."
-  @type result :: {:file_tree_refresh_result, FileTree.t(), token()}
+  @type result ::
+          {:file_tree_refresh_result, FileTree.t(), token()}
+          | {:file_tree_refresh_failed, token()}
 
   @doc """
   Spawns a supervised Task that rescans `tree` off the calling process.
 
   The Task runs `FileTree.refresh/1` (filesystem I/O) followed by the cached
   git-status refresh, then sends `{:file_tree_refresh_result, refreshed_tree,
-  token}` to `reply_to`. Returns `:ok`. A crash in the Task is isolated by the
-  supervisor; the Editor simply keeps its prior tree.
+  token}` to `reply_to`.
+
+  The Task body is wrapped in `try/rescue/catch` so it *always* replies, even
+  when the filesystem walk or git-status decode raises or throws. On failure it
+  sends `{:file_tree_refresh_failed, token}` so the Editor can clear its
+  in-flight tracking and honour a coalesced refresh; the in-flight flag is never
+  left stuck (which would otherwise wedge all future refreshes, since the
+  coalescing path never spawns while one is "in flight").
+
+  Returns `:ok` when the Task was spawned, or `{:error, reason}` when the
+  supervisor refused (e.g. max children); the caller clears in-flight so a later
+  timer can retry rather than wedging.
   """
-  @spec start(FileTree.t(), token(), Minga.Events.registry(), pid()) :: :ok
+  @spec start(FileTree.t(), token(), Minga.Events.registry(), pid()) :: :ok | {:error, term()}
   def start(%FileTree{} = tree, token, events_registry, reply_to)
       when is_reference(token) and is_pid(reply_to) do
-    Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
-      refreshed_tree =
-        tree
-        |> FileTree.refresh()
-        |> Freshness.refresh_tree_git_status_from_cache(events_registry)
+    case Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
+           run(tree, token, events_registry, reply_to)
+         end) do
+      {:ok, _pid} -> :ok
+      {:ok, _pid, _info} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
-      send(reply_to, {:file_tree_refresh_result, refreshed_tree, token})
-    end)
+  # Runs the rescan and ALWAYS sends a reply, converting any raise/throw/exit
+  # into a failure sentinel so the Editor's in-flight flag is always cleared.
+  @spec run(FileTree.t(), token(), Minga.Events.registry(), pid()) :: :ok
+  defp run(tree, token, events_registry, reply_to) do
+    message =
+      try do
+        refreshed_tree =
+          tree
+          |> FileTree.refresh()
+          |> Freshness.refresh_tree_git_status_from_cache(events_registry)
 
+        {:file_tree_refresh_result, refreshed_tree, token}
+      rescue
+        e ->
+          Minga.Log.warning(:editor, "File tree refresh failed: #{Exception.message(e)}")
+          {:file_tree_refresh_failed, token}
+      catch
+        kind, reason ->
+          Minga.Log.warning(:editor, "File tree refresh #{kind}: #{inspect(reason)}")
+          {:file_tree_refresh_failed, token}
+      end
+
+    send(reply_to, message)
     :ok
   end
 end

--- a/lib/minga_editor/handlers/effect_handler.ex
+++ b/lib/minga_editor/handlers/effect_handler.ex
@@ -221,14 +221,21 @@ defmodule MingaEditor.Handlers.EffectHandler do
   end
 
   defp apply_effect(state, {:start_file_tree_refresh, tree, token}) when is_reference(token) do
-    MingaEditor.FileTree.Refresh.start(
-      tree,
-      token,
-      EditorState.events_registry(state),
-      self()
-    )
+    case MingaEditor.FileTree.Refresh.start(
+           tree,
+           token,
+           EditorState.events_registry(state),
+           self()
+         ) do
+      :ok ->
+        state
 
-    state
+      {:error, reason} ->
+        # The supervisor refused the Task (e.g. max children). Clear in-flight so
+        # a later timer can retry instead of wedging the refresh loop (#2632).
+        Minga.Log.warning(:editor, "File tree refresh spawn failed: #{inspect(reason)}")
+        MingaEditor.FileTree.Freshness.cancel_inflight_refresh(state, token)
+    end
   end
 
   defp apply_effect(state, {:conceal_spans, pid, spans}) when is_pid(pid) do

--- a/lib/minga_editor/handlers/effect_handler.ex
+++ b/lib/minga_editor/handlers/effect_handler.ex
@@ -61,6 +61,7 @@ defmodule MingaEditor.Handlers.EffectHandler do
   * `:render_now` — render immediately after a handler updates state
   * `{:save_session_deferred}` — send :save_session to self
   * `{:schedule_file_tree_refresh, delay}` — debounce one filesystem tree refresh
+  * `{:start_file_tree_refresh, tree, token}` — spawn the async tree rescan Task
   * `{:handle_git_remote_result, ref, result}` — process git remote result
   """
   @type effect ::
@@ -99,6 +100,7 @@ defmodule MingaEditor.Handlers.EffectHandler do
           | {:request_inlay_hints}
           | {:save_session_deferred}
           | {:schedule_file_tree_refresh, non_neg_integer()}
+          | {:start_file_tree_refresh, Minga.Project.FileTree.t(), reference()}
           | {:handle_git_remote_result, reference(), term()}
 
   @doc """
@@ -216,6 +218,17 @@ defmodule MingaEditor.Handlers.EffectHandler do
       ref = Process.send_after(self(), :file_tree_refresh_timer, delay)
       MingaEditor.FileTree.Freshness.schedule_refresh(state, ref)
     end
+  end
+
+  defp apply_effect(state, {:start_file_tree_refresh, tree, token}) when is_reference(token) do
+    MingaEditor.FileTree.Refresh.start(
+      tree,
+      token,
+      EditorState.events_registry(state),
+      self()
+    )
+
+    state
   end
 
   defp apply_effect(state, {:conceal_spans, pid, spans}) when is_pid(pid) do

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   functions.
   """
 
+  alias Minga.Project.FileTree
   alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.State, as: EditorState
@@ -18,6 +19,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
           | {:render, pos_integer()}
           | {:log_message, String.t()}
           | {:schedule_file_tree_refresh, non_neg_integer()}
+          | {:start_file_tree_refresh, FileTree.t(), reference()}
           | {:request_code_lens}
           | {:request_inlay_hints}
           | {:save_session_deferred}
@@ -74,8 +76,12 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   end
 
   def handle(state, :file_tree_refresh_timer) do
-    state = FileTreeFreshness.flush_refresh(state)
-    {state, [{:render, 16}]}
+    FileTreeFreshness.begin_refresh(state)
+  end
+
+  def handle(state, {:file_tree_refresh_result, %FileTree{} = refreshed_tree, token})
+      when is_reference(token) do
+    FileTreeFreshness.apply_refresh_result(state, refreshed_tree, token)
   end
 
   def handle(state, {:git_remote_result, ref, result}) when is_reference(ref) do

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -84,6 +84,10 @@ defmodule MingaEditor.Handlers.FileEventHandler do
     FileTreeFreshness.apply_refresh_result(state, refreshed_tree, token)
   end
 
+  def handle(state, {:file_tree_refresh_failed, token}) when is_reference(token) do
+    FileTreeFreshness.apply_refresh_failure(state, token)
+  end
+
   def handle(state, {:git_remote_result, ref, result}) when is_reference(ref) do
     {state, [{:handle_git_remote_result, ref, result}]}
   end

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -46,6 +46,8 @@ defmodule MingaEditor.State.FileTree do
           tree_status: tree_status(),
           tree_width: pos_integer(),
           refresh_timer: reference() | nil,
+          refresh_inflight: reference() | nil,
+          refresh_pending?: boolean(),
           clipboard_mark: clipboard_mark() | nil,
           filtering: boolean(),
           help_visible: boolean()
@@ -60,6 +62,8 @@ defmodule MingaEditor.State.FileTree do
             tree_status: :hidden,
             tree_width: 30,
             refresh_timer: nil,
+            refresh_inflight: nil,
+            refresh_pending?: false,
             clipboard_mark: nil,
             filtering: false,
             help_visible: false
@@ -179,6 +183,39 @@ defmodule MingaEditor.State.FileTree do
   @spec clear_refresh(t()) :: t()
   def clear_refresh(%__MODULE__{} = ft), do: %{ft | refresh_timer: nil}
 
+  @doc "Returns true when an async refresh Task is currently in flight."
+  @spec refresh_inflight?(t()) :: boolean()
+  def refresh_inflight?(%__MODULE__{refresh_inflight: ref}) when is_reference(ref), do: true
+  def refresh_inflight?(%__MODULE__{}), do: false
+
+  @doc "Returns the token of the in-flight refresh Task, or nil when none is running."
+  @spec refresh_inflight_token(t()) :: reference() | nil
+  def refresh_inflight_token(%__MODULE__{refresh_inflight: ref}), do: ref
+
+  @doc "Returns true when another refresh was requested while one was in flight."
+  @spec refresh_pending?(t()) :: boolean()
+  def refresh_pending?(%__MODULE__{refresh_pending?: pending?}), do: pending?
+
+  @doc """
+  Marks an async refresh as in flight under `token` and clears the debounce timer.
+
+  Also clears any `refresh_pending?` flag: the freshly spawned Task supersedes a
+  request that was coalesced while a previous Task was running.
+  """
+  @spec begin_inflight_refresh(t(), reference()) :: t()
+  def begin_inflight_refresh(%__MODULE__{} = ft, token) when is_reference(token) do
+    %{ft | refresh_inflight: token, refresh_pending?: false, refresh_timer: nil}
+  end
+
+  @doc "Records that a refresh was requested while one was already in flight."
+  @spec mark_refresh_pending(t()) :: t()
+  def mark_refresh_pending(%__MODULE__{} = ft), do: %{ft | refresh_pending?: true}
+
+  @doc "Clears in-flight and pending refresh tracking once a Task result is handled."
+  @spec clear_inflight_refresh(t()) :: t()
+  def clear_inflight_refresh(%__MODULE__{} = ft),
+    do: %{ft | refresh_inflight: nil, refresh_pending?: false}
+
   @doc "Marks the sidebar as failed with a displayable reason."
   @spec error(t(), term()) :: t()
   def error(%__MODULE__{} = ft, reason) do
@@ -197,7 +234,9 @@ defmodule MingaEditor.State.FileTree do
         tree_status: :hidden,
         clipboard_mark: nil,
         filtering: false,
-        help_visible: false
+        help_visible: false,
+        refresh_inflight: nil,
+        refresh_pending?: false
     }
   end
 

--- a/test/minga_editor/file_tree/refresh_test.exs
+++ b/test/minga_editor/file_tree/refresh_test.exs
@@ -24,4 +24,17 @@ defmodule MingaEditor.FileTree.RefreshTest do
     assert "alpha.ex" in names
     assert "beta.ex" in names
   end
+
+  test "start/4 always replies with a failure sentinel when the rescan raises" do
+    # A nil root makes the filesystem walk raise (`File.ls(nil)`); the Task must
+    # still reply so the Editor's in-flight flag is cleared and never wedges
+    # (#2632). The sentinel carries the same token for staleness matching.
+    bad_tree = %FileTree{root: nil}
+    token = make_ref()
+
+    assert :ok = Refresh.start(bad_tree, token, Minga.Events.default_registry(), self())
+
+    assert_receive {:file_tree_refresh_failed, ^token}, 2_000
+    refute_receive {:file_tree_refresh_result, _tree, ^token}, 100
+  end
 end

--- a/test/minga_editor/file_tree/refresh_test.exs
+++ b/test/minga_editor/file_tree/refresh_test.exs
@@ -1,0 +1,27 @@
+defmodule MingaEditor.FileTree.RefreshTest do
+  @moduledoc "Tests for the async file-tree rescan Task (#2632)."
+  use ExUnit.Case, async: true
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.Refresh
+
+  @moduletag :tmp_dir
+
+  test "start/4 rescans off-process and replies with the refreshed tree and token",
+       %{tmp_dir: tmp_dir} do
+    File.write!(Path.join(tmp_dir, "alpha.ex"), "")
+    tree = FileTree.new(tmp_dir) |> FileTree.ensure_entries()
+
+    # A file created after the tree snapshot must show up in the rescan result.
+    File.write!(Path.join(tmp_dir, "beta.ex"), "")
+
+    token = make_ref()
+    assert :ok = Refresh.start(tree, token, Minga.Events.default_registry(), self())
+
+    assert_receive {:file_tree_refresh_result, %FileTree{} = refreshed, ^token}, 2_000
+
+    names = refreshed |> FileTree.visible_entries() |> Enum.map(& &1.name)
+    assert "alpha.ex" in names
+    assert "beta.ex" in names
+  end
+end

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -299,6 +299,13 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
 
       assert ft(new_state).tree.root == Path.expand(new_root)
       assert effects == []
+
+      # The re-root discard path still completes the in-flight bookkeeping:
+      # clearing in-flight is what lets a later timer spawn a new rescan. If it
+      # stayed set, every later timer would coalesce-only and the tree would
+      # never refresh again after a re-root (#2632 AC3 — no permanent wedge).
+      refute FileTreeState.refresh_inflight?(ft(new_state))
+      refute FileTreeState.refresh_pending?(ft(new_state))
     end
 
     test "overlapping events coalesce into one follow-up rescan, not piled Tasks",

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -200,7 +200,8 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       Process.cancel_timer(first_ref)
     end
 
-    test "refresh timer rescans entries and clears pending timer", %{tmp_dir: tmp_dir} do
+    test "refresh timer spawns an async rescan without blocking I/O in the handler",
+         %{tmp_dir: tmp_dir} do
       File.write!(Path.join(tmp_dir, "alpha.ex"), "")
 
       state =
@@ -208,16 +209,135 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
         |> state_with_tree()
         |> FileTreeFreshness.schedule_refresh(make_ref())
 
+      # A new file appears after the tree was opened. The handler must NOT rescan
+      # inline, so the returned tree still does not see it (#2632 AC1).
       File.write!(Path.join(tmp_dir, "beta.ex"), "")
 
       {new_state, effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
 
-      names =
-        ft(new_state).tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
+      assert [{:start_file_tree_refresh, %FileTree{root: root}, token}] = effects
+      assert root == Path.expand(tmp_dir)
+      assert is_reference(token)
 
-      assert "beta.ex" in names
+      names = ft(new_state).tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
+      refute "beta.ex" in names
+
+      # Debounce timer cleared, refresh now tracked as in-flight.
       refute FileTreeFreshness.refresh_scheduled?(new_state)
+      assert FileTreeState.refresh_inflight?(ft(new_state))
+    end
+
+    test "refresh result swaps the whole tree atomically and clears in-flight",
+         %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
+      state = state_with_tree(tmp_dir)
+
+      {pending_state, [{:start_file_tree_refresh, captured_tree, token}]} =
+        FileEventHandler.handle(state, :file_tree_refresh_timer)
+
+      # Simulate the Task's off-process rescan picking up a newly created file.
+      File.write!(Path.join(tmp_dir, "beta.ex"), "")
+      refreshed_tree = FileTree.refresh(captured_tree)
+
+      {new_state, effects} =
+        FileEventHandler.handle(
+          pending_state,
+          {:file_tree_refresh_result, refreshed_tree, token}
+        )
+
+      names = ft(new_state).tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
+      assert "beta.ex" in names
       assert {:render, 16} in effects
+      refute FileTreeState.refresh_inflight?(ft(new_state))
+    end
+
+    test "a stale result for a superseded token is discarded", %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
+      state = state_with_tree(tmp_dir)
+
+      {pending_state, [{:start_file_tree_refresh, captured_tree, _token}]} =
+        FileEventHandler.handle(state, :file_tree_refresh_timer)
+
+      File.write!(Path.join(tmp_dir, "beta.ex"), "")
+      refreshed_tree = FileTree.refresh(captured_tree)
+
+      {new_state, effects} =
+        FileEventHandler.handle(
+          pending_state,
+          {:file_tree_refresh_result, refreshed_tree, make_ref()}
+        )
+
+      names = ft(new_state).tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
+      refute "beta.ex" in names
+      assert effects == []
+    end
+
+    test "a result for a re-rooted tree is discarded", %{tmp_dir: tmp_dir} do
+      old_root = Path.join(tmp_dir, "old")
+      new_root = Path.join(tmp_dir, "new")
+      File.mkdir_p!(old_root)
+      File.mkdir_p!(new_root)
+      File.write!(Path.join(old_root, "old.ex"), "")
+
+      state = state_with_tree(old_root)
+
+      {pending_state, [{:start_file_tree_refresh, captured_tree, token}]} =
+        FileEventHandler.handle(state, :file_tree_refresh_timer)
+
+      # User re-roots the tree while the walk runs. The in-flight token is still
+      # set, but the live tree root no longer matches the captured walk's root.
+      rerooted = FileTreeState.replace_tree(ft(pending_state), FileTree.new(new_root))
+      rerooted_state = EditorState.set_file_tree(pending_state, rerooted)
+
+      refreshed_tree = FileTree.refresh(captured_tree)
+
+      {new_state, effects} =
+        FileEventHandler.handle(
+          rerooted_state,
+          {:file_tree_refresh_result, refreshed_tree, token}
+        )
+
+      assert ft(new_state).tree.root == Path.expand(new_root)
+      assert effects == []
+    end
+
+    test "overlapping events coalesce into one follow-up rescan, not piled Tasks",
+         %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
+      state = state_with_tree(tmp_dir)
+
+      # First timer spawns one rescan.
+      {state, [{:start_file_tree_refresh, captured_tree, token}]} =
+        FileEventHandler.handle(state, :file_tree_refresh_timer)
+
+      # A second burst arrives while the first rescan is still in flight. No new
+      # Task is spawned; the request is coalesced (#2632 AC3).
+      {state, second_effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
+      assert second_effects == []
+      assert FileTreeState.refresh_pending?(ft(state))
+
+      # When the in-flight rescan completes, exactly one fresh rescan starts.
+      refreshed_tree = FileTree.refresh(captured_tree)
+
+      {state, effects} =
+        FileEventHandler.handle(state, {:file_tree_refresh_result, refreshed_tree, token})
+
+      assert [{:start_file_tree_refresh, _tree, follow_up_token}] =
+               Enum.filter(effects, &match?({:start_file_tree_refresh, _, _}, &1))
+
+      assert follow_up_token != token
+      assert FileTreeState.refresh_inflight?(ft(state))
+      refute FileTreeState.refresh_pending?(ft(state))
+
+      # The follow-up completing with no further pending request clears in-flight.
+      {state, follow_up_effects} =
+        FileEventHandler.handle(
+          state,
+          {:file_tree_refresh_result, FileTree.refresh(refreshed_tree), follow_up_token}
+        )
+
+      refute Enum.any?(follow_up_effects, &match?({:start_file_tree_refresh, _, _}, &1))
+      refute FileTreeState.refresh_inflight?(ft(state))
     end
 
     test "diagnostics under the tree root schedule render", %{tmp_dir: tmp_dir} do

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -340,6 +340,84 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       refute FileTreeState.refresh_inflight?(ft(state))
     end
 
+    test "a failed rescan clears in-flight so a later timer is not wedged",
+         %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
+      state = state_with_tree(tmp_dir)
+
+      {state, [{:start_file_tree_refresh, _tree, token}]} =
+        FileEventHandler.handle(state, :file_tree_refresh_timer)
+
+      # The Task crashed and sent the failure sentinel instead of a tree.
+      {state, fail_effects} =
+        FileEventHandler.handle(state, {:file_tree_refresh_failed, token})
+
+      assert fail_effects == []
+      refute FileTreeState.refresh_inflight?(ft(state))
+
+      # A later timer must spawn a brand new rescan — the loop is not wedged.
+      {_state, retry_effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
+
+      assert [{:start_file_tree_refresh, _retry_tree, retry_token}] = retry_effects
+      assert retry_token != token
+    end
+
+    test "a failed rescan still honours a coalesced refresh", %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
+      state = state_with_tree(tmp_dir)
+
+      {state, [{:start_file_tree_refresh, _tree, token}]} =
+        FileEventHandler.handle(state, :file_tree_refresh_timer)
+
+      # A burst arrived while the rescan ran; it coalesced into refresh_pending?.
+      {state, []} = FileEventHandler.handle(state, :file_tree_refresh_timer)
+      assert FileTreeState.refresh_pending?(ft(state))
+
+      # Even though the rescan failed, the coalesced request starts exactly one
+      # fresh rescan (#2632 AC3) — no tree was applied, but the loop continues.
+      {state, fail_effects} =
+        FileEventHandler.handle(state, {:file_tree_refresh_failed, token})
+
+      assert [{:start_file_tree_refresh, _retry_tree, follow_up_token}] = fail_effects
+      assert follow_up_token != token
+      assert FileTreeState.refresh_inflight?(ft(state))
+      refute FileTreeState.refresh_pending?(ft(state))
+    end
+
+    test "a stale failure sentinel for a superseded token is ignored",
+         %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
+      state = state_with_tree(tmp_dir)
+
+      {state, [{:start_file_tree_refresh, _tree, token}]} =
+        FileEventHandler.handle(state, :file_tree_refresh_timer)
+
+      # A failure for some other (already superseded) refresh must not clear the
+      # genuine in-flight refresh.
+      {new_state, effects} =
+        FileEventHandler.handle(state, {:file_tree_refresh_failed, make_ref()})
+
+      assert effects == []
+      assert FileTreeState.refresh_inflight_token(ft(new_state)) == token
+    end
+
+    test "cancel_inflight_refresh clears only the matching in-flight token",
+         %{tmp_dir: tmp_dir} do
+      state = state_with_tree(tmp_dir)
+
+      {state, [{:start_file_tree_refresh, _tree, token}]} =
+        FileEventHandler.handle(state, :file_tree_refresh_timer)
+
+      # A non-matching token (a newer refresh) must be left untouched.
+      untouched = FileTreeFreshness.cancel_inflight_refresh(state, make_ref())
+      assert FileTreeState.refresh_inflight_token(ft(untouched)) == token
+
+      # The matching token (e.g. a failed Task.Supervisor.start_child) is cleared
+      # so a later timer can retry instead of wedging (#2632).
+      cleared = FileTreeFreshness.cancel_inflight_refresh(state, token)
+      refute FileTreeState.refresh_inflight?(ft(cleared))
+    end
+
     test "diagnostics under the tree root schedule render", %{tmp_dir: tmp_dir} do
       file_path = Path.join(tmp_dir, "alpha.ex")
       state = state_with_tree(tmp_dir)


### PR DESCRIPTION
## Summary

The debounced file-tree refresh ran `FileTree.refresh/1` (recursive `File.ls`/`File.lstat` per expanded directory) inline on the Editor GenServer in `handle_info(:file_tree_refresh_timer)`. On projects with many expanded dirs this blocked the Editor mailbox behind queued keystrokes.

The rescan now follows the established async pattern used by the file-tree filter walk and the picker fetch:

1. On `:file_tree_refresh_timer`, `Freshness.begin_refresh/1` mints a token, marks the refresh in-flight, clears the debounce timer, and returns a `{:start_file_tree_refresh, tree, token}` effect (no filesystem I/O on the Editor).
2. `EffectHandler` interprets that effect by spawning a supervised Task (`MingaEditor.FileTree.Refresh`, on `Minga.Eval.TaskSupervisor`) that runs `FileTree.refresh/1` + `refresh_tree_git_status_from_cache/2` off-process, then sends `{:file_tree_refresh_result, refreshed_tree, token}` back to the Editor.
3. A new `handle_info({:file_tree_refresh_result, ...})` clause does the cheap, atomic work: `watch_expanded_dirs`, `FileTreeState.replace_tree` (whole-tree swap), and `sync_buffer`.

## In-flight + staleness guards

- **In-flight / coalescing (AC3):** `FileTreeState` gains `refresh_inflight` (the active token) and `refresh_pending?`. While a rescan is in flight, additional timers do **not** spawn more Tasks; they set a single `refresh_pending?` flag. When the in-flight Task's result is handled, exactly one fresh rescan is started if a request was coalesced. Never queued indefinitely.
- **Staleness (AC3/AC4):** a result is applied only when its `token` still matches `refresh_inflight` **and** the live tree root matches the refreshed tree's root. If the user re-rooted or closed the tree while the walk ran, the result is discarded and the current tree is kept. `close/1` also clears in-flight/pending tracking.
- **Atomicity (AC4):** the refreshed tree replaces the old one in a single assignment, so the renderer never sees a partial tree.

## Validation

- `mix test.llm test/minga_editor/handlers/file_event_handler_test.exs test/minga_editor/file_tree/refresh_test.exs test/minga_editor/file_tree/freshness_test.exs` — 28 tests, 0 failures.
- `mix test.llm test/minga_editor/file_tree_integration_test.exs test/minga_editor/integration/file_tree_test.exs test/minga_editor/state/file_tree_filter_test.exs test/minga_editor/state/file_tree_editing_test.exs test/minga_editor/file_tree/filter_walk_test.exs` — 30 tests, 0 failures.
- `make lint` — all checks passed (format, credo, compile --warnings-as-errors, dialyzer).

New tests prove: the timer handler emits the spawn effect without rescanning inline (no blocking I/O), the result swaps the tree atomically, a superseded-token result is dropped, a re-rooted result is dropped, overlapping events coalesce into one follow-up rescan, and the `Refresh` Task does the work off-process and replies with the token.

## Risks

- A refresh result now lands one message later than before, so the tree updates a few ms after the debounce instead of synchronously. This is the intended trade for not blocking the mailbox.
- `replace_tree` still does a single `File.ls` for status classification (unchanged from prior behavior and shared with the other cheap handlers); only the recursive walk moved off-process.

Closes #2632

🤖 Generated with [Claude Code](https://claude.com/claude-code)