### PR TITLE
fix(completion): move LSP completion processing off the Editor GenServer (#2633)

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -901,6 +901,17 @@ defmodule MingaEditor do
     end
   end
 
+  # ── Async completion processing result ──────────────────────────────────
+  # LSP completion responses are parsed/sorted/filtered in a Task off the
+  # Editor hot path (CompletionHandling.handle_response/3). The Task sends this
+  # message back with the processed menu. apply_processed/5 applies it cheaply
+  # and uses the generation token to discard a stale, superseded result
+  # (latest-wins), so large completion sets never block input.
+  def handle_info({:completion_processed, gen, mode, payload, trigger_pos}, state) do
+    new_state = CompletionHandling.apply_processed(state, gen, mode, payload, trigger_pos)
+    {:noreply, Renderer.render_or_async(new_state)}
+  end
+
   # Async editor-action result: slow work offloaded via MingaEditor.AsyncAction
   # sends this when it finishes. Apply the in-flight result, then advance the lane
   # so the next queued op (if any) starts — lanes run one op at a time, in order.

--- a/lib/minga_editor/completion_handling.ex
+++ b/lib/minga_editor/completion_handling.ex
@@ -559,6 +559,12 @@ defmodule MingaEditor.CompletionHandling do
 
   # Spawns the parse/sort/filter work in a supervised Task so it never blocks
   # the Editor GenServer. The Task sends the processed result back to `editor`.
+  #
+  # The Task ALWAYS sends a terminal {:completion_processed, ...} message: on
+  # success with the built menu, on any crash (e.g. a malformed LSP item that
+  # FunctionClauseErrors in parse_item/1) with the `:failed` sentinel. If the
+  # Task cannot even be started, we send `:failed` directly. Either way the
+  # pending modal is never left stuck waiting on a message that never arrives.
   @spec start_completion_task(
           pid(),
           :primary | :merge,
@@ -568,11 +574,53 @@ defmodule MingaEditor.CompletionHandling do
           non_neg_integer()
         ) :: :ok
   defp start_completion_task(editor, mode, result, trigger_pos, prefix, gen) do
-    Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
-      payload = build_processed(mode, result, trigger_pos, prefix)
-      send(editor, {:completion_processed, gen, mode, payload, trigger_pos})
-    end)
+    case Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
+           run_completion_task(editor, mode, result, trigger_pos, prefix, gen)
+         end) do
+      {:ok, _pid} ->
+        :ok
 
+      {:error, reason} ->
+        # No Task means no {:completion_processed, ...} will arrive on its own;
+        # signal failure so the Editor clears the stuck pending modal.
+        Minga.Log.warning(:lsp, fn ->
+          "Completion Task failed to start (gen=#{gen}, mode=#{mode}): #{inspect(reason)}"
+        end)
+
+        send(editor, {:completion_processed, gen, mode, :failed, trigger_pos})
+        :ok
+    end
+  end
+
+  @spec run_completion_task(
+          pid(),
+          :primary | :merge,
+          term(),
+          {non_neg_integer(), non_neg_integer()},
+          String.t(),
+          non_neg_integer()
+        ) :: :ok
+  defp run_completion_task(editor, mode, result, trigger_pos, prefix, gen) do
+    payload =
+      try do
+        build_processed(mode, result, trigger_pos, prefix)
+      rescue
+        e ->
+          Minga.Log.warning(:lsp, fn ->
+            "Completion processing crashed (gen=#{gen}, mode=#{mode}): #{Exception.message(e)}"
+          end)
+
+          :failed
+      catch
+        kind, reason ->
+          Minga.Log.warning(:lsp, fn ->
+            "Completion processing failed (gen=#{gen}, mode=#{mode}): #{inspect({kind, reason})}"
+          end)
+
+          :failed
+      end
+
+    send(editor, {:completion_processed, gen, mode, payload, trigger_pos})
     :ok
   end
 
@@ -610,12 +658,15 @@ defmodule MingaEditor.CompletionHandling do
   `Completion`, so the common single-server path is a cheap assignment. If a
   secondary server's `:merge` result happened to land first, the primary result
   is unioned into it (rather than replacing it) so no server's items are lost.
+
+  A `:failed` payload (the Task crashed or could not start) clears a still-pending
+  menu so it is not left stuck, while leaving an already-populated menu intact.
   """
   @spec apply_processed(
           EditorState.t(),
           non_neg_integer(),
           :primary | :merge,
-          Completion.t() | [Completion.item()],
+          Completion.t() | [Completion.item()] | :failed,
           {non_neg_integer(), non_neg_integer()}
         ) :: EditorState.t()
   def apply_processed(state, gen, mode, payload, trigger_pos) do
@@ -632,9 +683,21 @@ defmodule MingaEditor.CompletionHandling do
   @spec apply_processed_current(
           EditorState.t(),
           :primary | :merge,
-          Completion.t() | [Completion.item()],
+          Completion.t() | [Completion.item()] | :failed,
           {non_neg_integer(), non_neg_integer()}
         ) :: EditorState.t()
+  defp apply_processed_current(state, _mode, :failed, _trigger_pos) do
+    # Processing failed (crash or Task could not start). Don't leave the modal
+    # stuck waiting on a menu that will never arrive: dismiss it if it is still
+    # pending, but keep an already-populated menu (e.g. primary succeeded and a
+    # secondary merge failed) intact. A dropped completion self-heals on the
+    # next keystroke.
+    case ModalOverlay.completion(state) do
+      nil -> dismiss(state)
+      %Completion{} -> state
+    end
+  end
+
   defp apply_processed_current(state, :primary, %Completion{items: []}, _trigger_pos) do
     # No items: matches the old behaviour of leaving the pending menu empty
     # rather than showing an empty popup.

--- a/lib/minga_editor/completion_handling.ex
+++ b/lib/minga_editor/completion_handling.ex
@@ -517,10 +517,18 @@ defmodule MingaEditor.CompletionHandling do
   end
 
   @doc """
-  Handles an LSP completion response.
+  Handles an LSP completion response off the Editor hot path.
 
-  Matches the response ref against the pending trigger, creates a
-  `Completion` struct if items were returned, and renders.
+  Only the cheap bookkeeping runs on the Editor: `CompletionTrigger.classify_response/4`
+  matches the response `ref` against the pending request and decides whether it
+  is the primary response, a secondary one to merge, or stale. The expensive
+  work (parsing every item, sorting, and prefix-filtering) is then handed to a
+  Task under `Minga.Eval.TaskSupervisor`, which sends the processed result back
+  as `{:completion_processed, gen, mode, payload, trigger_pos}`. The Editor
+  applies that via `apply_processed/5` with a cheap state assignment.
+
+  This keeps the Editor mailbox responsive even when a server returns 1000+
+  completion items.
   """
   @spec handle_response(EditorState.t(), reference(), term()) :: EditorState.t()
   def handle_response(%{workspace: %{buffers: %{active: nil}}} = state, _ref, _result), do: state
@@ -528,8 +536,8 @@ defmodule MingaEditor.CompletionHandling do
   def handle_response(state, ref, result) do
     buffer_pid = state.workspace.buffers.active
 
-    {new_bridge, completion} =
-      CompletionTrigger.handle_response(
+    {new_bridge, classification} =
+      CompletionTrigger.classify_response(
         ModalOverlay.completion_trigger(state),
         ref,
         result,
@@ -537,20 +545,118 @@ defmodule MingaEditor.CompletionHandling do
       )
 
     new_state = ModalOverlay.put_completion_trigger(state, new_bridge)
+    dispatch_processing(new_state, classification, result)
+  end
 
-    case completion do
+  @spec dispatch_processing(EditorState.t(), CompletionTrigger.classification(), term()) ::
+          EditorState.t()
+  defp dispatch_processing(state, :ignore, _result), do: state
+
+  defp dispatch_processing(state, {mode, trigger_pos, prefix, gen}, result) do
+    start_completion_task(self(), mode, result, trigger_pos, prefix, gen)
+    state
+  end
+
+  # Spawns the parse/sort/filter work in a supervised Task so it never blocks
+  # the Editor GenServer. The Task sends the processed result back to `editor`.
+  @spec start_completion_task(
+          pid(),
+          :primary | :merge,
+          term(),
+          {non_neg_integer(), non_neg_integer()},
+          String.t(),
+          non_neg_integer()
+        ) :: :ok
+  defp start_completion_task(editor, mode, result, trigger_pos, prefix, gen) do
+    Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
+      payload = build_processed(mode, result, trigger_pos, prefix)
+      send(editor, {:completion_processed, gen, mode, payload, trigger_pos})
+    end)
+
+    :ok
+  end
+
+  # Primary: build the full sorted+filtered menu in the Task so the Editor only
+  # has to assign it. Merge: parse to items only; the (rare) merge math runs on
+  # the Editor at apply time against the live menu so ordering stays correct.
+  @spec build_processed(
+          :primary,
+          term(),
+          {non_neg_integer(), non_neg_integer()},
+          String.t()
+        ) :: Completion.t()
+  defp build_processed(:primary, {:ok, result}, trigger_pos, prefix) do
+    result
+    |> Completion.parse_response()
+    |> Completion.new(trigger_pos)
+    |> Completion.filter(prefix)
+  end
+
+  @spec build_processed(:merge, term(), {non_neg_integer(), non_neg_integer()}, String.t()) ::
+          [Completion.item()]
+  defp build_processed(:merge, {:ok, result}, _trigger_pos, _prefix) do
+    Completion.parse_response(result)
+  end
+
+  @doc """
+  Applies a completion result that was processed off the Editor in a Task.
+
+  Discards the result unless a completion modal is still open *and* it carries
+  the current request generation (`gen`). This latest-wins guard drops a stale
+  Task result from a request batch that was superseded by newer typing, so an
+  out-of-order or slow Task can never overwrite a fresher menu.
+
+  For a `:primary` result the Task already produced a fully sorted+filtered
+  `Completion`, so the common single-server path is a cheap assignment. If a
+  secondary server's `:merge` result happened to land first, the primary result
+  is unioned into it (rather than replacing it) so no server's items are lost.
+  """
+  @spec apply_processed(
+          EditorState.t(),
+          non_neg_integer(),
+          :primary | :merge,
+          Completion.t() | [Completion.item()],
+          {non_neg_integer(), non_neg_integer()}
+        ) :: EditorState.t()
+  def apply_processed(state, gen, mode, payload, trigger_pos) do
+    trigger = ModalOverlay.completion_trigger(state)
+
+    if ModalOverlay.match(state.shell_state.modal, :completion) and trigger.gen == gen do
+      apply_processed_current(state, mode, payload, trigger_pos)
+    else
+      # Stale generation or the menu was dismissed/replaced; discard.
+      state
+    end
+  end
+
+  @spec apply_processed_current(
+          EditorState.t(),
+          :primary | :merge,
+          Completion.t() | [Completion.item()],
+          {non_neg_integer(), non_neg_integer()}
+        ) :: EditorState.t()
+  defp apply_processed_current(state, :primary, %Completion{items: []}, _trigger_pos) do
+    # No items: matches the old behaviour of leaving the pending menu empty
+    # rather than showing an empty popup.
+    state
+  end
+
+  defp apply_processed_current(state, :primary, %Completion{} = built, _trigger_pos) do
+    case ModalOverlay.completion(state) do
       nil ->
-        new_state
+        # Fast path (single server / primary lands first): just assign the
+        # already-sorted, already-filtered menu the Task produced.
+        ModalOverlay.update_completion(state, fn _ -> built end)
 
       %Completion{} ->
-        # The trigger update above guarantees a `:completion` modal is
-        # open (any LSP response implies the trigger had pending refs).
-        ModalOverlay.update_completion(new_state, fn _ -> completion end)
-
-      {:merge, items, trigger_pos} ->
-        # Merge items from a secondary server into the existing completion
-        merge_completion_items(new_state, items, trigger_pos)
+        # A secondary :merge result landed first; union the primary items in so
+        # neither server's items are dropped.
+        merge_completion_items(state, built.items, built.trigger_position)
     end
+  end
+
+  defp apply_processed_current(state, :merge, items, trigger_pos) when is_list(items) do
+    merge_completion_items(state, items, trigger_pos)
   end
 
   @spec merge_completion_items(

--- a/lib/minga_editor/completion_trigger.ex
+++ b/lib/minga_editor/completion_trigger.ex
@@ -32,14 +32,35 @@ defmodule MingaEditor.CompletionTrigger do
           pending_ref: reference() | nil,
           pending_refs: MapSet.t(reference()),
           debounce_timer: reference() | nil,
-          trigger_position: {non_neg_integer(), non_neg_integer()} | nil
+          trigger_position: {non_neg_integer(), non_neg_integer()} | nil,
+          gen: non_neg_integer()
         }
+
+  @typedoc """
+  Result of classifying an incoming LSP completion response without parsing.
+
+  The heavy parse/sort/filter is deferred to a Task (see
+  `MingaEditor.CompletionHandling`); classification only decides whether the
+  response is the primary one (replaces the menu), a secondary one to merge,
+  or stale/ignorable. `gen` lets a late processed result be discarded if a
+  newer request batch has superseded it (latest-wins).
+  """
+  @type classification ::
+          {:primary | :merge, {non_neg_integer(), non_neg_integer()}, String.t(),
+           non_neg_integer()}
+          | :ignore
 
   @doc "Returns initial completion bridge state."
   @dialyzer {:no_opaque, new: 0}
   @spec new() :: t()
   def new do
-    %{pending_ref: nil, pending_refs: MapSet.new(), debounce_timer: nil, trigger_position: nil}
+    %{
+      pending_ref: nil,
+      pending_refs: MapSet.new(),
+      debounce_timer: nil,
+      trigger_position: nil,
+      gen: 0
+    }
   end
 
   @doc """
@@ -90,58 +111,57 @@ defmodule MingaEditor.CompletionTrigger do
   end
 
   @doc """
-  Handles an LSP response for a completion request. Returns the new
-  completion state if the response matches the pending ref, or nil
-  if it's stale.
+  Classifies an incoming LSP completion response and updates the bridge's
+  pending-ref bookkeeping, *without* parsing the (potentially huge) item list.
+
+  This is the cheap, on-the-Editor half of completion handling: it matches the
+  response `ref` against the bridge's pending refs and decides what the caller
+  should do, then returns the trigger position, the prefix typed since the
+  trigger, and the current request generation. The expensive parse/sort/filter
+  is performed by the caller in a Task (see `MingaEditor.CompletionHandling`).
+
+  Returns `{updated_bridge, classification}` where classification is one of:
+
+    * `{:primary, trigger_pos, prefix, gen}` — the authoritative response for
+      the request batch; the processed result replaces the menu.
+    * `{:merge, trigger_pos, prefix, gen}` — a secondary server's response to
+      merge into the existing menu.
+    * `:ignore` — stale ref, error, or no live request.
   """
-  @spec handle_response(t(), reference(), {:ok, term()} | {:error, term()}, pid()) ::
-          {t(),
-           Completion.t()
-           | {:merge, [Completion.item()], {non_neg_integer(), non_neg_integer()}}
-           | nil}
-  def handle_response(bridge, ref, result, buffer_pid)
+  @spec classify_response(t(), reference(), {:ok, term()} | {:error, term()}, pid()) ::
+          {t(), classification()}
+  def classify_response(bridge, ref, result, buffer_pid)
 
-  def handle_response(%{pending_ref: ref} = bridge, ref, {:ok, result}, buffer_pid) do
-    items = Completion.parse_response(result)
+  def classify_response(%{pending_ref: ref} = bridge, ref, {:ok, _result}, buffer_pid) do
     trigger_pos = bridge.trigger_position || get_cursor_position(buffer_pid)
+    prefix = get_typed_since_trigger(buffer_pid, trigger_pos)
     remaining = MapSet.delete(bridge.pending_refs, ref)
-
     bridge = %{bridge | pending_ref: nil, pending_refs: remaining}
-
-    case items do
-      [] ->
-        {bridge, nil}
-
-      _ ->
-        completion = Completion.new(items, trigger_pos)
-        prefix = get_typed_since_trigger(buffer_pid, trigger_pos)
-        completion = Completion.filter(completion, prefix)
-        {bridge, completion}
-    end
+    {bridge, {:primary, trigger_pos, prefix, bridge.gen}}
   end
 
-  # Response from a secondary server: merge into existing completion
-  def handle_response(%{pending_refs: refs} = bridge, ref, {:ok, result}, buffer_pid) do
+  # Response from a secondary server: merge into existing completion.
+  def classify_response(%{pending_refs: refs} = bridge, ref, {:ok, _result}, buffer_pid) do
     if MapSet.member?(refs, ref) do
-      items = Completion.parse_response(result)
+      trigger_pos = bridge.trigger_position || get_cursor_position(buffer_pid)
+      prefix = get_typed_since_trigger(buffer_pid, trigger_pos)
       remaining = MapSet.delete(refs, ref)
       bridge = %{bridge | pending_refs: remaining}
-      # Return items for the caller to merge into existing completion
-      {bridge, {:merge, items, bridge.trigger_position || get_cursor_position(buffer_pid)}}
+      {bridge, {:merge, trigger_pos, prefix, bridge.gen}}
     else
-      # Stale ref, ignore
-      {bridge, nil}
+      # Stale ref, ignore.
+      {bridge, :ignore}
     end
   end
 
-  def handle_response(bridge, _ref, {:error, error}, _buffer_pid) do
+  def classify_response(bridge, _ref, {:error, error}, _buffer_pid) do
     Minga.Log.debug(:lsp, "Completion request failed: #{inspect(error)}")
-    {%{bridge | pending_ref: nil}, nil}
+    {%{bridge | pending_ref: nil}, :ignore}
   end
 
-  # Stale response (ref doesn't match)
-  def handle_response(bridge, _ref, _result, _buffer_pid) do
-    {bridge, nil}
+  # Stale response (ref doesn't match any pending request).
+  def classify_response(bridge, _ref, _result, _buffer_pid) do
+    {bridge, :ignore}
   end
 
   @doc """
@@ -202,11 +222,15 @@ defmodule MingaEditor.CompletionTrigger do
         primary_ref = List.first(refs)
         all_refs = MapSet.new(refs)
 
+        # Mint a new generation for this request batch. A processed result that
+        # carries an older generation is discarded at apply time (latest-wins),
+        # so a slow Task from a superseded request can never clobber the menu.
         {%{
            bridge
            | pending_ref: primary_ref,
              pending_refs: all_refs,
-             trigger_position: {line, col}
+             trigger_position: {line, col},
+             gen: bridge.gen + 1
          }, nil}
     end
   end

--- a/test/minga_editor/completion_async_test.exs
+++ b/test/minga_editor/completion_async_test.exs
@@ -14,7 +14,11 @@ defmodule MingaEditor.CompletionAsyncTest do
     * (b) a stale processed result (older generation) is discarded latest-wins
       so a superseded Task can never overwrite a fresher menu;
     * (c) the merge path still unions a secondary server's items into the live
-      menu and re-applies the prefix filter correctly.
+      menu and re-applies the prefix filter correctly;
+    * (d) end-to-end through the live Editor: a completion response drives the
+      real `handle_info({:completion_processed, ...})` clause and the menu
+      becomes visible — and a malformed item that crashes the Task clears the
+      pending menu instead of leaving it stuck.
   """
 
   use Minga.Test.EditorCase, async: true
@@ -174,6 +178,87 @@ defmodule MingaEditor.CompletionAsyncTest do
 
       assert "from_secondary" in result_labels
       assert "from_primary" in result_labels
+    end
+  end
+
+  describe "(d) end-to-end through the live Editor handle_info" do
+    # Inject a pending completion modal whose bridge expects `ref`, so a real
+    # {:lsp_response, ref, ...} sent to the live Editor drives the whole async
+    # pipeline: handle_info -> CompletionHandling.handle_response -> Task ->
+    # {:completion_processed, ...} -> the Editor's handle_info apply clause.
+    defp inject_pending_completion(ctx, ref) do
+      :sys.replace_state(ctx.editor, fn state ->
+        owner = state.shell_state.tab_bar.active_id
+
+        trigger = %{
+          CompletionTrigger.new()
+          | pending_ref: ref,
+            pending_refs: MapSet.new([ref]),
+            trigger_position: {0, 0},
+            gen: 1
+        }
+
+        payload = CompletionPayload.new(owner, trigger: trigger)
+        ModalOverlay.open(state, :completion, payload)
+      end)
+    end
+
+    test "a real LSP completion response routes through handle_info and becomes visible" do
+      ctx = start_editor("hello")
+      ref = make_ref()
+      inject_pending_completion(ctx, ref)
+
+      result =
+        {:ok,
+         %{
+           "items" => [
+             %{"label" => "zeta", "filterText" => "zeta", "sortText" => "2"},
+             %{"label" => "alpha", "filterText" => "alpha", "sortText" => "1"}
+           ]
+         }}
+
+      # Drive the real Editor mailbox: this exercises the actual
+      # handle_info({:completion_processed, ...}) dispatch clause, which the
+      # unit tests bypass by calling apply_processed/5 directly.
+      send(ctx.editor, {:lsp_response, ref, result})
+
+      final =
+        wait_until(ctx, fn state -> match?(%Completion{}, ModalOverlay.completion(state)) end,
+          max_attempts: 200,
+          interval_ms: 10,
+          message: "completion never became visible via the live Editor handle_info"
+        )
+
+      completion = ModalOverlay.completion(final)
+      assert %Completion{} = completion
+      # Sorted in the Task (sortText order), not response order.
+      assert Enum.map(completion.filtered, & &1.label) == ["alpha", "zeta"]
+    end
+
+    test "a malformed item crashes the Task but clears the stuck pending menu" do
+      ctx = start_editor("hello")
+      ref = make_ref()
+      inject_pending_completion(ctx, ref)
+
+      # A bare `null` in the items list FunctionClauseErrors in parse_item/1.
+      # The Task must still report (with :failed) so the pending modal is
+      # dismissed rather than left stuck on a never-arriving menu.
+      result = {:ok, %{"items" => [nil]}}
+
+      send(ctx.editor, {:lsp_response, ref, result})
+
+      _ =
+        wait_until(
+          ctx,
+          fn state -> not ModalOverlay.match(state.shell_state.modal, :completion) end,
+          max_attempts: 200,
+          interval_ms: 10,
+          message: "pending completion modal was left stuck after a Task crash"
+        )
+
+      final = editor_state(ctx)
+      refute ModalOverlay.match(final.shell_state.modal, :completion)
+      assert ModalOverlay.completion(final) == nil
     end
   end
 end

--- a/test/minga_editor/completion_async_test.exs
+++ b/test/minga_editor/completion_async_test.exs
@@ -1,0 +1,179 @@
+defmodule MingaEditor.CompletionAsyncTest do
+  @moduledoc """
+  Coverage for processing LSP completion responses off the Editor hot path
+  (ticket #2633).
+
+  The Editor only does cheap ref bookkeeping when a completion response
+  arrives; the parse/sort/filter runs in a Task that sends the processed menu
+  back as `{:completion_processed, gen, mode, payload, trigger_pos}`. These
+  tests prove:
+
+    * (a) the parse/sort/filter does not run on the Editor path — the
+      synchronous handler leaves the menu pending and the built menu only
+      arrives later, as a message, already sorted and filtered;
+    * (b) a stale processed result (older generation) is discarded latest-wins
+      so a superseded Task can never overwrite a fresher menu;
+    * (c) the merge path still unions a secondary server's items into the live
+      menu and re-applies the prefix filter correctly.
+  """
+
+  use Minga.Test.EditorCase, async: true
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Editing.Completion
+  alias MingaEditor.CompletionHandling
+  alias MingaEditor.CompletionTrigger
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
+
+  @sync_timeout 15_000
+
+  defp items(raws), do: Completion.parse_response(%{"items" => raws})
+
+  defp completion_from(raws, trigger_pos, prefix) do
+    raws
+    |> items()
+    |> Completion.new(trigger_pos)
+    |> Completion.filter(prefix)
+  end
+
+  defp open_completion_modal(state, completion, gen) do
+    owner = state.shell_state.tab_bar.active_id
+    trigger = %{CompletionTrigger.new() | gen: gen}
+    payload = CompletionPayload.new(owner, completion: completion, trigger: trigger)
+    ModalOverlay.open(state, :completion, payload)
+  end
+
+  defp labels(%Completion{filtered: filtered}), do: Enum.map(filtered, & &1.label)
+
+  describe "(a) parse/sort/filter runs off the Editor process" do
+    test "the synchronous handler leaves the menu pending and the built menu arrives async" do
+      ctx = start_editor("hello")
+      state = editor_state(ctx)
+
+      # Open a pending completion modal with a primary request in flight. `self()`
+      # is the test process, so the Task will send the processed menu back to us.
+      ref = make_ref()
+
+      trigger = %{
+        CompletionTrigger.new()
+        | pending_ref: ref,
+          pending_refs: MapSet.new([ref]),
+          trigger_position: {0, 0},
+          gen: 1
+      }
+
+      state = ModalOverlay.put_completion_trigger(state, trigger)
+
+      # sortText is deliberately out of label order to prove sorting happened in
+      # the Task, not on the Editor.
+      result =
+        {:ok,
+         %{
+           "items" => [
+             %{"label" => "banana", "filterText" => "banana", "sortText" => "2"},
+             %{"label" => "apple", "filterText" => "apple", "sortText" => "1"}
+           ]
+         }}
+
+      returned = CompletionHandling.handle_response(state, ref, result)
+
+      # The Editor path itself never parsed/built the menu: it is still pending.
+      assert ModalOverlay.completion(returned) == nil
+
+      # The built menu arrives later, off-process, already sorted and filtered.
+      assert_receive {:completion_processed, 1, :primary, %Completion{} = built, {0, 0}},
+                     @sync_timeout
+
+      assert labels(built) == ["apple", "banana"]
+    end
+  end
+
+  describe "(b) stale processed result is discarded latest-wins" do
+    test "a result tagged with an older generation never overwrites the live menu" do
+      ctx = start_editor("hello")
+      state = editor_state(ctx)
+
+      existing = completion_from([%{"label" => "keep", "filterText" => "keep"}], {0, 0}, "")
+      state = open_completion_modal(state, existing, 5)
+
+      stale =
+        completion_from(
+          [%{"label" => "stale-sentinel", "filterText" => "stale-sentinel"}],
+          {0, 0},
+          ""
+        )
+
+      # Generation 4 is stale relative to the live generation 5: discard it.
+      discarded = CompletionHandling.apply_processed(state, 4, :primary, stale, {0, 0})
+      assert labels(ModalOverlay.completion(discarded)) == ["keep"]
+
+      # The same result on the live generation 5 is applied (sanity check that the
+      # guard is about the generation, not the payload).
+      applied = CompletionHandling.apply_processed(state, 5, :primary, stale, {0, 0})
+      assert "stale-sentinel" in labels(ModalOverlay.completion(applied))
+    end
+
+    test "a result is discarded when the completion menu has been dismissed" do
+      ctx = start_editor("hello")
+      state = editor_state(ctx)
+
+      # No completion modal is open (modal is :none), so any processed result is stale.
+      built = completion_from([%{"label" => "ghost", "filterText" => "ghost"}], {0, 0}, "")
+      result = CompletionHandling.apply_processed(state, 1, :primary, built, {0, 0})
+
+      assert ModalOverlay.completion(result) == nil
+    end
+  end
+
+  describe "(c) merge path still produces correct merged+filtered completions" do
+    test "secondary server items are unioned in, sorted, and prefix-filtered" do
+      ctx = start_editor("hello")
+      # Cursor at end of "hello" so the prefix typed since trigger {0, 0} is "hello".
+      BufferProcess.move_to(ctx.buffer, {0, 5})
+      state = editor_state(ctx)
+
+      existing =
+        completion_from(
+          [%{"label" => "helloThere", "filterText" => "helloThere", "sortText" => "1"}],
+          {0, 0},
+          "hello"
+        )
+
+      state = open_completion_modal(state, existing, 5)
+
+      merge_items =
+        items([
+          %{"label" => "helloWorld", "filterText" => "helloWorld", "sortText" => "2"},
+          %{"label" => "goodbye", "filterText" => "goodbye", "sortText" => "0"}
+        ])
+
+      merged = CompletionHandling.apply_processed(state, 5, :merge, merge_items, {0, 0})
+      completion = ModalOverlay.completion(merged)
+
+      # Union of both servers, sorted by sortText, with "goodbye" filtered out by
+      # the "hello" prefix.
+      assert labels(completion) == ["helloThere", "helloWorld"]
+      refute "goodbye" in labels(completion)
+    end
+
+    test "a primary result that lands after a secondary merge unions instead of replacing" do
+      ctx = start_editor("hello")
+      state = editor_state(ctx)
+
+      # A secondary :merge already populated the menu first.
+      secondary = completion_from([%{"label" => "from_secondary"}], {0, 0}, "")
+      state = open_completion_modal(state, secondary, 5)
+
+      # The slower primary result lands afterwards; its items must be unioned in.
+      primary =
+        completion_from([%{"label" => "from_primary"}], {0, 0}, "")
+
+      merged = CompletionHandling.apply_processed(state, 5, :primary, primary, {0, 0})
+      result_labels = labels(ModalOverlay.completion(merged))
+
+      assert "from_secondary" in result_labels
+      assert "from_primary" in result_labels
+    end
+  end
+end

--- a/test/minga_editor/completion_trigger_test.exs
+++ b/test/minga_editor/completion_trigger_test.exs
@@ -68,36 +68,66 @@ defmodule MingaEditor.CompletionTriggerTest do
     end
   end
 
-  # ── handle_response/4 ────────────────────────────────────────────────────
+  # ── classify_response/4 ──────────────────────────────────────────────────
+  #
+  # classify_response does the cheap, on-the-Editor half of completion handling:
+  # it matches the response ref against the pending request and reports what to
+  # do, without parsing the (potentially huge) item list. The parse/sort/filter
+  # is performed by CompletionHandling in a Task.
 
-  describe "handle_response/4" do
+  describe "classify_response/4" do
     test "stale response (ref doesn't match) is ignored" do
       ref = make_ref()
       bridge = %{CompletionTrigger.new() | pending_ref: make_ref()}
       {:ok, buf} = BufferProcess.start_link(content: "hello")
 
-      {result_bridge, result} = CompletionTrigger.handle_response(bridge, ref, {:ok, nil}, buf)
-      assert result == nil
+      {result_bridge, classification} =
+        CompletionTrigger.classify_response(bridge, ref, {:ok, nil}, buf)
+
+      assert classification == :ignore
       assert is_map(result_bridge)
 
       GenServer.stop(buf)
     end
 
-    test "error response clears pending ref" do
+    test "error response clears pending ref and is ignored" do
       ref = make_ref()
       bridge = %{CompletionTrigger.new() | pending_ref: ref}
       {:ok, buf} = BufferProcess.start_link(content: "hello")
 
-      {result_bridge, result} =
-        CompletionTrigger.handle_response(bridge, ref, {:error, "timeout"}, buf)
+      {result_bridge, classification} =
+        CompletionTrigger.classify_response(bridge, ref, {:error, "timeout"}, buf)
 
-      assert result == nil
+      assert classification == :ignore
       assert result_bridge.pending_ref == nil
 
       GenServer.stop(buf)
     end
 
-    test "secondary server response returns :merge tuple" do
+    test "primary response (ref matches pending_ref) classifies as :primary and carries gen" do
+      ref = make_ref()
+
+      bridge = %{
+        CompletionTrigger.new()
+        | pending_ref: ref,
+          pending_refs: MapSet.new([ref]),
+          trigger_position: {0, 0},
+          gen: 7
+      }
+
+      {:ok, buf} = BufferProcess.start_link(content: "hello")
+
+      {result_bridge, classification} =
+        CompletionTrigger.classify_response(bridge, ref, {:ok, %{"items" => []}}, buf)
+
+      assert {:primary, {0, 0}, _prefix, 7} = classification
+      assert result_bridge.pending_ref == nil
+      refute MapSet.member?(result_bridge.pending_refs, ref)
+
+      GenServer.stop(buf)
+    end
+
+    test "secondary server response classifies as :merge and carries gen" do
       primary_ref = make_ref()
       secondary_ref = make_ref()
       refs = MapSet.new([primary_ref, secondary_ref])
@@ -106,24 +136,37 @@ defmodule MingaEditor.CompletionTriggerTest do
         CompletionTrigger.new()
         | pending_ref: primary_ref,
           pending_refs: refs,
-          trigger_position: {0, 0}
+          trigger_position: {0, 0},
+          gen: 3
       }
 
       {:ok, buf} = BufferProcess.start_link(content: "hello")
 
-      # Simulate response from secondary (ref doesn't match primary but is in pending_refs)
-      lsp_result = %{
-        "items" => [
-          %{"label" => "world", "kind" => 6}
-        ]
-      }
+      lsp_result = %{"items" => [%{"label" => "world", "kind" => 6}]}
 
-      {result_bridge, result} =
-        CompletionTrigger.handle_response(bridge, secondary_ref, {:ok, lsp_result}, buf)
+      {result_bridge, classification} =
+        CompletionTrigger.classify_response(bridge, secondary_ref, {:ok, lsp_result}, buf)
 
-      assert {:merge, items, _pos} = result
-      assert items != []
-      assert not MapSet.member?(result_bridge.pending_refs, secondary_ref)
+      assert {:merge, {0, 0}, _prefix, 3} = classification
+      refute MapSet.member?(result_bridge.pending_refs, secondary_ref)
+
+      GenServer.stop(buf)
+    end
+  end
+
+  # ── send + gen bump ───────────────────────────────────────────────────────
+
+  describe "generation bumping" do
+    test "each request batch mints a strictly newer generation" do
+      {:ok, buf} = BufferProcess.start_link(file_path: "/tmp/test_gen.ex", content: "hello")
+      BufferProcess.move_to(buf, {0, 5})
+
+      bridge0 = CompletionTrigger.new()
+      bridge1 = CompletionTrigger.flush_debounce(bridge0, [self()], buf)
+      bridge2 = CompletionTrigger.flush_debounce(bridge1, [self()], buf)
+
+      assert bridge1.gen == bridge0.gen + 1
+      assert bridge2.gen == bridge1.gen + 1
 
       GenServer.stop(buf)
     end

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -8,6 +8,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Editing.Completion
+  alias MingaEditor.CompletionHandling
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.Handlers.LspEventHandler
   alias MingaEditor.State, as: EditorState
@@ -169,7 +170,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       assert [%{layer: 2}] = Tuple.to_list(highlight.spans)
     end
 
-    test "untracked completion response updates the visible completion and returns render_now" do
+    test "untracked completion response is processed off-thread, then becomes visible" do
       state = buffer_state("hello\n")
       ref = make_ref()
       trigger = %{CompletionTrigger.new() | pending_ref: ref, pending_refs: MapSet.new([ref])}
@@ -192,14 +193,25 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
       assert effects == [:render_now]
 
-      completion = ModalOverlay.completion(new_state)
-      assert %Completion{} = completion
-      assert [%{label: "hello_world"}] = completion.filtered
-      assert completion.selected == 0
+      # The handler only does cheap ref bookkeeping: pending refs are cleared
+      # synchronously, but the parse/sort/filter is deferred to a Task (#2633),
+      # so the menu is not yet visible right after handle/2 returns.
+      assert ModalOverlay.completion(new_state) == nil
 
       new_trigger = ModalOverlay.completion_trigger(new_state)
       assert new_trigger.pending_ref == nil
       assert MapSet.new() == new_trigger.pending_refs
+
+      # Drive the async result the Task sends back, exactly as the Editor's
+      # {:completion_processed, ...} handle_info clause does, and confirm the
+      # completion ultimately becomes visible.
+      assert_receive {:completion_processed, gen, mode, processed, trigger_pos}, 5_000
+      applied = CompletionHandling.apply_processed(new_state, gen, mode, processed, trigger_pos)
+
+      completion = ModalOverlay.completion(applied)
+      assert %Completion{} = completion
+      assert [%{label: "hello_world"}] = completion.filtered
+      assert completion.selected == 0
     end
   end
 


### PR DESCRIPTION
## Summary

LSP completion responses were parsed, sorted, and prefix-filtered synchronously inside the Editor GenServer's `handle_info`. A language server returning 1000+ items blocked the Editor mailbox during parse/sort/filter, so typing stuttered while the menu was being built.

This moves the heavy work off the Editor hot path, mirroring the async picker pattern (#2628):

- `CompletionTrigger.classify_response/4` replaces the parsing `handle_response/4`. It does only cheap ref bookkeeping on the Editor (match the response ref against the pending request, update `pending_refs`, report `:primary` / `:merge` / `:ignore` plus trigger position, prefix, and request generation). It never parses the item list.
- `CompletionHandling.handle_response/3` hands the raw result to a Task under `Minga.Eval.TaskSupervisor`. The Task parses + sorts + filters and sends `{:completion_processed, gen, mode, payload, trigger_pos}` back.
- A new `handle_info` clause in `MingaEditor` applies the processed menu via `CompletionHandling.apply_processed/5` with a cheap state assignment.
- The render path (`CompletionBuilder.visible_items`, bounded `Enum.slice` to 10) is unchanged.

## How merge + stale ordering is handled

Each completion request batch mints a new **generation** on the trigger (`gen`), bumped in `send_completion_requests`. `apply_processed/5` discards a processed result unless a completion modal is still open **and** it carries the current generation. This is latest-wins: a slow Task from a request batch that newer typing superseded can never clobber a fresher menu, and a result for a dismissed menu is dropped.

Within a single batch (multiple LSP servers):

- The **primary** path is a direct assignment, so the common single-server case does **zero** sort/filter on the Editor.
- If a **secondary** `:merge` result happens to land first, the primary result is **unioned** into the existing menu instead of replacing it, so no server's items are dropped regardless of which Task finishes first. The (rare) merge math runs on the Editor at apply time against the live menu, which keeps ordering correct.

## Validation

- `mix test.llm` on all 13 completion test files: **128 tests, 0 failures**.
- New `test/minga_editor/completion_async_test.exs` proves:
  - (a) parse/sort/filter runs off the Editor: the synchronous handler leaves the menu pending and the sorted, filtered menu arrives later as a message;
  - (b) a stale (older-generation) processed result is discarded; a dismissed-menu result is discarded;
  - (c) the merge path still unions a secondary server's items in, sorts, and re-applies the prefix filter; and a primary result that lands after a secondary merge unions instead of replacing.
- `make lint`: credo `--strict` and dialyzer pass (no new issues in changed files); `mix format` clean.

## Risks

- For the `:primary` fast path, the menu is filtered in the Task with the prefix captured when the response arrived. If the user types during processing, the popup briefly shows the slightly older filter; the next keystroke re-filters via the existing `update_filter` path, so this self-corrects and matches prior behavior.
- The generation guard relies on the completion modal staying open between request and apply (it is opened when the request is sent). A dismissed/replaced modal correctly drops the result.

Closes #2633

🤖 Generated with [Claude Code](https://claude.com/claude-code)