### PR TITLE
fix(picker): stop Editor freeze on large directories (#2628)

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -866,7 +866,18 @@ defmodule MingaEditor do
     Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
       result =
         try do
-          MingaEditor.UI.Picker.Source.fetch(source_module, ctx)
+          case MingaEditor.UI.Picker.Source.fetch(source_module, ctx) do
+            {:ok, items, meta} ->
+              # Build the candidate cache here, off the editor process. The O(n)
+              # normalization (downcase, grapheme split, search-text join) is the
+              # work that froze the editor when a source returned 100K+ paths
+              # (#2628); doing it in the Task means the editor handler only swaps
+              # in the finished list instead of normalizing every path inline.
+              {:ok, items, MingaEditor.UI.Picker.Candidate.from_items(items), meta}
+
+            {:error, _reason} = error ->
+              error
+          end
         rescue
           e -> {:error, Exception.message(e)}
         catch
@@ -985,11 +996,15 @@ defmodule MingaEditor do
   @spec handle_picker_candidates(
           state(),
           PickerPayload.t(),
-          {:ok, [term()], MingaEditor.UI.Picker.Source.fetch_meta()} | {:error, String.t()}
+          {:ok, [term()], [MingaEditor.UI.Picker.Candidate.t()],
+           MingaEditor.UI.Picker.Source.fetch_meta()}
+          | {:error, String.t()}
         ) :: state()
-  defp handle_picker_candidates(state, payload, {:ok, items, meta}) do
+  defp handle_picker_candidates(state, payload, {:ok, items, candidates, meta}) do
     picker_state = payload.picker_ui
-    picker = MingaEditor.UI.Picker.replace_items(picker_state.picker, items)
+    # Candidates are pre-built by the fetch Task (#2628); the editor only swaps
+    # them in here, so the input loop stays responsive on large directories.
+    picker = MingaEditor.UI.Picker.put_candidates(picker_state.picker, items, candidates)
     new_picker_state = %{picker_state | picker: picker, load_status: :ready}
 
     state

--- a/lib/minga_editor/ui/picker.ex
+++ b/lib/minga_editor/ui/picker.ex
@@ -98,7 +98,24 @@ defmodule MingaEditor.UI.Picker do
   @doc "Replaces the item list and refilters against the current query."
   @spec replace_items(t(), [item()]) :: t()
   def replace_items(%__MODULE__{} = picker, items) when is_list(items) do
-    refilter(%{picker | items: items, candidates: Candidate.from_items(items)})
+    put_candidates(picker, items, Candidate.from_items(items))
+  end
+
+  @doc """
+  Installs an already-built candidate cache (and its source items) and refilters
+  against the current query.
+
+  This is the cheap half of `replace_items/2`: it skips the O(n)
+  `Candidate.from_items/1` normalization (downcase, grapheme split, search-text
+  join) because the caller has already done it. The async picker fetch builds the
+  candidates in its background Task and hands them here, so the editor's input
+  loop never pays that cost on large directories (#2628). Behavior is identical to
+  `replace_items/2` given `candidates == Candidate.from_items(items)`.
+  """
+  @spec put_candidates(t(), [item()], [Candidate.t()]) :: t()
+  def put_candidates(%__MODULE__{} = picker, items, candidates)
+      when is_list(items) and is_list(candidates) do
+    refilter(%{picker | items: items, candidates: candidates})
   end
 
   # ── Query manipulation ──────────────────────────────────────────────────────

--- a/test/minga_editor/picker_async_stale_test.exs
+++ b/test/minga_editor/picker_async_stale_test.exs
@@ -14,6 +14,7 @@ defmodule MingaEditor.PickerAsyncStaleTest do
 
   use Minga.Test.EditorCase, async: true
 
+  alias MingaEditor.UI.Picker.Candidate
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Picker.TodoSearchSource
 
@@ -61,11 +62,12 @@ defmodule MingaEditor.PickerAsyncStaleTest do
     # and must be ignored. This is latest-wins: a superseded fetch loses even if
     # it arrives after the picker opened.
     stale_revision = make_ref()
+    stale_items = [item("stale-sentinel")]
 
     send(
       ctx.editor,
       {:picker_candidates_result, TodoSearchSource, stale_revision,
-       {:ok, [item("stale-sentinel")], %{}}}
+       {:ok, stale_items, Candidate.from_items(stale_items), %{}}}
     )
 
     _ = :sys.get_state(ctx.editor, @sync_timeout)
@@ -77,5 +79,37 @@ defmodule MingaEditor.PickerAsyncStaleTest do
       end
 
     refute "stale-sentinel" in labels
+  end
+
+  test "applies a live-revision result carrying candidates pre-built off the editor",
+       %{project_root: root} do
+    ctx = start_editor("scratch", project_root: root)
+    :ok = GenServer.call(ctx.editor, {:api_execute_command, :search_todos}, @sync_timeout)
+
+    # Grab the picker's live fetch revision so the result passes the stale guard.
+    live_revision = picker_payload(ctx).picker_ui.fetch_revision
+    assert is_reference(live_revision)
+
+    # The result message carries already-built %Candidate{} structs, exactly like
+    # the fetch Task now produces (#2628). The editor handler must install them
+    # without re-running Candidate.from_items, so the input loop never normalizes
+    # the full set inline. Sending built candidates here exercises that path.
+    items = [item("prebuilt-sentinel")]
+    candidates = Candidate.from_items(items)
+    assert [%Candidate{}] = candidates
+
+    send(
+      ctx.editor,
+      {:picker_candidates_result, TodoSearchSource, live_revision, {:ok, items, candidates, %{}}}
+    )
+
+    _ = :sys.get_state(ctx.editor, @sync_timeout)
+    payload = picker_payload(ctx)
+
+    labels = Enum.map(payload.picker_ui.picker.items, & &1.label)
+    assert "prebuilt-sentinel" in labels
+    # The same candidates flow straight through; the picker keeps the pre-built set.
+    assert payload.picker_ui.picker.candidates == candidates
+    assert payload.picker_ui.load_status == :ready
   end
 end

--- a/test/minga_editor/ui/picker_test.exs
+++ b/test/minga_editor/ui/picker_test.exs
@@ -293,6 +293,39 @@ defmodule MingaEditor.UI.PickerTest do
     end
   end
 
+  describe "replace_items/2 and put_candidates/3" do
+    alias MingaEditor.UI.Picker.Candidate
+
+    @new_items [
+      %Item{id: :x, label: "router.ex", description: "/project/lib/router.ex"},
+      %Item{id: :y, label: "schema.ex", description: "/project/lib/schema.ex"}
+    ]
+
+    test "replace_items swaps in a fresh set and refilters" do
+      picker = Picker.new(@items) |> Picker.filter("router")
+      replaced = Picker.replace_items(picker, @new_items)
+
+      assert Picker.total(replaced) == 2
+      assert replaced.query == "router"
+      # "router" now matches router.ex from the new set, not the old README/config.
+      assert Enum.map(replaced.filtered, & &1.id) == [:x]
+    end
+
+    test "put_candidates produces the same picker as replace_items for built candidates" do
+      base = Picker.new(@items) |> Picker.filter("ex")
+
+      via_replace = Picker.replace_items(base, @new_items)
+      via_put = Picker.put_candidates(base, @new_items, Candidate.from_items(@new_items))
+
+      # The seam split (build off-process, install cheaply) must not change scoring,
+      # ordering, items, or candidates versus the all-in-one path.
+      assert via_put.filtered == via_replace.filtered
+      assert via_put.candidates == via_replace.candidates
+      assert via_put.items == via_replace.items
+      assert via_put.selected == via_replace.selected
+    end
+  end
+
   describe "move_down/1 and move_up/1" do
     test "move_down advances selection" do
       picker = Picker.new(@items)


### PR DESCRIPTION
## Summary

Opening the file picker (SPC f f) on a 100K+ file directory froze the whole macOS app: keyboard and mouse input were blocked until the picker finished loading.

The filesystem walk was already async (a `Task`), but the Editor GenServer processed the results synchronously. `handle_info({:picker_candidates_result, ...})` called `Picker.replace_items/2`, which ran `Candidate.from_items/1` over every path (`String.downcase`, grapheme split, search-text join) inline on the editor's input loop. For a huge source that O(n) normalization blocked all input.

### Fix (Developer Notes approach A)

Move the candidate-building into the existing fetch Task so the heavy work runs off the editor process:

- The fetch `Task` (`Minga.Eval.TaskSupervisor`) now builds the candidate cache and sends pre-built `%Candidate{}` structs in `:picker_candidates_result` (`{:ok, items, candidates, meta}`). Because Erlang message copying is done by the sender, the editor never pays the normalization or copy cost.
- Split `Picker.replace_items/2` into a build half and an assign half. New `Picker.put_candidates/3` is the cheap assign half (`refilter` only). `replace_items/2` is now `put_candidates(picker, items, Candidate.from_items(items))`, so existing callers and behavior are unchanged.
- The handler calls `put_candidates/3` with the pre-built candidates: a cheap, bounded `refilter`, no per-item string work.
- The loading indicator (`load_status`) is preserved: the picker opens `:loading` and flips to `:ready` when candidates land.

### Scoring / stale-guard semantics preserved

- Scoring and matching are untouched. `put_candidates(p, items, Candidate.from_items(items))` is behavior-identical to the old `replace_items(p, items)`; a unit test asserts equal `filtered`, `candidates`, `items`, and `selected`. The `#2635` scorer-per-keystroke bottleneck is explicitly out of scope.
- The latest-wins `MingaEditor.State.Picker.current_fetch?/2` revision guard still gates every result before it is applied. Pre-built candidates flow through the exact same guard; a stale revision is dropped, a live revision is applied.

## Validation

- `mix test.llm test/minga_editor/ui/picker_test.exs test/minga_editor/picker_async_stale_test.exs` — 56 tests, 0 failures
- `mix test.llm` on `state/picker_test.exs`, `integration/picker_lifecycle_test.exs`, `picker_ui_test.exs`, `render_model/ui/picker_builder_test.exs` — 27 tests, 0 failures
- `make lint` — format, credo, compile (warnings-as-errors), and dialyzer pass (the one credo `List.last/1` note is pre-existing in `scorer.ex`, untouched here)

New/updated tests:
- `picker_test.exs`: `put_candidates/3` is behavior-equivalent to `replace_items/2`; `replace_items/2` refilters against the current query.
- `picker_async_stale_test.exs`: the result message now carries pre-built `%Candidate{}` structs; a live-revision result installs them with no re-normalization, and the stale-revision result is still dropped.

## Risks

- The `:picker_candidates_result` message contract changed from `{:ok, items, meta}` to `{:ok, items, candidates, meta}`. The only producer is the fetch Task in `lib/minga_editor.ex`, updated in the same commit; tests that synthesize the message were updated.
- Candidate structs are larger than raw items, so the inter-process message copy is bigger. This copy is borne by the sending Task, not the editor, so editor responsiveness is unaffected.

Closes #2628

🤖 Generated with [Claude Code](https://claude.com/claude-code)