### PR TITLE
fix(observatory): move data collection off the Editor GenServer (#2631)

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -596,7 +596,7 @@ defmodule MingaEditor do
   end
 
   # A tick only *spawns* the collection Task and returns immediately, so the
-  # blocking SystemObserver calls in build_observatory_data/0 never run on the
+  # blocking SystemObserver calls in Observatory.Collector.collect/1 never run on the
   # Editor mailbox. The next tick is scheduled when the result lands (see the
   # :observatory_data_result clause), not here, so a collection that takes
   # longer than the 1s interval is effectively skipped, never queued.
@@ -1040,31 +1040,18 @@ defmodule MingaEditor do
 
   # Run the blocking SystemObserver collection in a supervised Task so the
   # Editor GenServer mailbox stays free. The token is echoed back with the
-  # result so the receiving clause can drop stale collections.
+  # result so the receiving clause can drop stale collections. Observatory
+  # .Collector.collect/1 is total, so the Task always sends a result and the
+  # refresh tick always re-arms even when collection fails.
   @spec spawn_observatory_collection(reference()) :: :ok
   defp spawn_observatory_collection(token) do
     editor = self()
 
     Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
-      send(editor, {:observatory_data_result, token, build_observatory_data()})
+      send(editor, {:observatory_data_result, token, Observatory.Collector.collect()})
     end)
 
     :ok
-  end
-
-  @spec build_observatory_data() :: Observatory.Data.t()
-  defp build_observatory_data do
-    case Minga.SystemObserver.snapshot() do
-      %{processes: processes} ->
-        processes
-        |> Minga.SystemObserver.TreeNode.build_tree()
-        |> Observatory.Data.visible(Minga.SystemObserver.samples())
-
-      nil ->
-        Observatory.Data.visible(nil, [])
-    end
-  catch
-    :exit, _ -> Observatory.Data.visible(nil, [])
   end
 
   # ── :DOWN classifier ────────────────────────────────────────────────────────

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -595,9 +595,27 @@ defmodule MingaEditor do
     {:noreply, new_state}
   end
 
+  # A tick only *spawns* the collection Task and returns immediately, so the
+  # blocking SystemObserver calls in build_observatory_data/0 never run on the
+  # Editor mailbox. The next tick is scheduled when the result lands (see the
+  # :observatory_data_result clause), not here, so a collection that takes
+  # longer than the 1s interval is effectively skipped, never queued.
   def handle_info({:observatory_tick, token}, state) do
+    if current_observatory_token?(state, token), do: spawn_observatory_collection(token)
+    {:noreply, state}
+  end
+
+  def handle_info(:observatory_tick, state) do
+    {:noreply, state}
+  end
+
+  # Async observatory data computed by the Task spawned on the matching tick.
+  # Apply it cheaply (no blocking work here) and only now schedule the next
+  # tick, which guarantees ticks are skipped-not-queued under slow collection.
+  # A result carrying a stale token (panel closed, or a newer tick already
+  # superseded this one) is dropped without scheduling anything.
+  def handle_info({:observatory_data_result, token, data}, state) do
     if current_observatory_token?(state, token) do
-      data = build_observatory_data()
       next_token = make_ref()
       timer = Process.send_after(self(), {:observatory_tick, next_token}, 1_000)
 
@@ -610,10 +628,6 @@ defmodule MingaEditor do
     else
       {:noreply, state}
     end
-  end
-
-  def handle_info(:observatory_tick, state) do
-    {:noreply, state}
   end
 
   # ── Handler-delegated bare atom events ─────────────────────────────────────
@@ -1023,6 +1037,20 @@ defmodule MingaEditor do
        do: true
 
   defp current_observatory_token?(_state, _token), do: false
+
+  # Run the blocking SystemObserver collection in a supervised Task so the
+  # Editor GenServer mailbox stays free. The token is echoed back with the
+  # result so the receiving clause can drop stale collections.
+  @spec spawn_observatory_collection(reference()) :: :ok
+  defp spawn_observatory_collection(token) do
+    editor = self()
+
+    Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
+      send(editor, {:observatory_data_result, token, build_observatory_data()})
+    end)
+
+    :ok
+  end
 
   @spec build_observatory_data() :: Observatory.Data.t()
   defp build_observatory_data do

--- a/lib/minga_editor/observatory/collector.ex
+++ b/lib/minga_editor/observatory/collector.ex
@@ -1,0 +1,41 @@
+defmodule MingaEditor.Observatory.Collector do
+  @moduledoc """
+  Collects a BEAM Observatory snapshot off the Editor GenServer.
+
+  `collect/1` runs the blocking `Minga.SystemObserver` queries plus the process
+  tree build, then wraps the result in `MingaEditor.Observatory.Data`.
+
+  It is **total**: any failure while talking to the observer or building the
+  tree (observer process down, malformed snapshot data tripping `build_tree/1`
+  or `visible/2`, a throw, or an exit) falls back to an empty view instead of
+  raising. Totality is load-bearing because the Editor runs `collect/1` inside
+  an unmonitored Task whose result message is the only thing that re-arms the
+  refresh tick. A silent crash would freeze the refresh loop while the panel
+  stays open, so the collection must never raise.
+  """
+
+  alias Minga.SystemObserver
+  alias Minga.SystemObserver.TreeNode
+  alias MingaEditor.Observatory.Data
+
+  @doc """
+  Builds the current Observatory data, querying `server` for the process
+  snapshot and sample history. Always returns a `Data` struct, even on failure.
+  """
+  @spec collect(GenServer.server()) :: Data.t()
+  def collect(server \\ SystemObserver) do
+    case SystemObserver.snapshot(server) do
+      %{processes: processes} ->
+        processes
+        |> TreeNode.build_tree()
+        |> Data.visible(SystemObserver.samples(server))
+
+      nil ->
+        Data.visible(nil, [])
+    end
+  rescue
+    _ -> Data.visible(nil, [])
+  catch
+    _kind, _ -> Data.visible(nil, [])
+  end
+end

--- a/test/minga_editor/commands/ui_frontend_test.exs
+++ b/test/minga_editor/commands/ui_frontend_test.exs
@@ -4,7 +4,9 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
   alias MingaEditor.BottomPanel
   alias MingaEditor.Commands
   alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.Observatory
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
 
@@ -121,5 +123,70 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
 
       Process.cancel_timer(timer)
     end
+  end
+
+  describe "observatory refresh runs off the Editor GenServer" do
+    test "a tick spawns async collection without blocking or scheduling the next tick" do
+      token = make_ref()
+      state = observatory_state(@gui, token)
+
+      # The tick handler returns the *unchanged* state: build_observatory_data/0
+      # does not run inline (no data set) and no next tick is scheduled here.
+      assert {:noreply, ^state} = MingaEditor.handle_info({:observatory_tick, token}, state)
+      assert state.shell_state.observatory_data == nil
+
+      # The collection ran in a supervised Task and reported back as a message,
+      # exactly like a picker/async-action result.
+      assert_receive {:observatory_data_result, ^token, %Observatory.Data{}}, 2_000
+    end
+
+    test "a stale tick does not spawn collection" do
+      token = make_ref()
+      state = observatory_state(@gui, token)
+
+      assert {:noreply, ^state} = MingaEditor.handle_info({:observatory_tick, make_ref()}, state)
+
+      refute_receive {:observatory_data_result, _token, _data}, 200
+    end
+
+    test "the result handler applies data and schedules the next tick only now" do
+      token = make_ref()
+      state = observatory_state(@gui, token)
+      data = Observatory.Data.visible(nil, [])
+
+      assert {:noreply, new_state} =
+               MingaEditor.handle_info({:observatory_data_result, token, data}, state)
+
+      assert new_state.shell_state.observatory_data == data
+
+      assert {next_timer, next_token} = new_state.shell_state.observatory_timer
+      assert is_reference(next_timer)
+      # A fresh token gates the next cycle; the prior token is now stale.
+      assert next_token != token
+
+      # The scheduled timer is live: its tick is actually delivered (~1s later),
+      # proving the next cycle is armed only after a result lands.
+      assert_receive {:observatory_tick, ^next_token}, 3_000
+    end
+
+    test "a stale data result is ignored and schedules nothing" do
+      token = make_ref()
+      state = observatory_state(@gui, token)
+
+      data = Observatory.Data.visible(nil, [])
+
+      assert {:noreply, ^state} =
+               MingaEditor.handle_info({:observatory_data_result, make_ref(), data}, state)
+
+      assert state.shell_state.observatory_data == nil
+    end
+  end
+
+  # Builds editor state with the observatory open and a known refresh token, so
+  # current_observatory_token?/2 matches without scheduling a real timer.
+  defp observatory_state(caps, token) do
+    base = base_state(caps)
+    shell = ShellState.open_observatory(base.shell_state, {make_ref(), token})
+    %{base | shell_state: shell}
   end
 end

--- a/test/minga_editor/commands/ui_frontend_test.exs
+++ b/test/minga_editor/commands/ui_frontend_test.exs
@@ -130,8 +130,8 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
       token = make_ref()
       state = observatory_state(@gui, token)
 
-      # The tick handler returns the *unchanged* state: build_observatory_data/0
-      # does not run inline (no data set) and no next tick is scheduled here.
+      # The tick handler returns the *unchanged* state: collection does not run
+      # inline (no data set) and no next tick is scheduled here.
       assert {:noreply, ^state} = MingaEditor.handle_info({:observatory_tick, token}, state)
       assert state.shell_state.observatory_data == nil
 

--- a/test/minga_editor/observatory/collector_test.exs
+++ b/test/minga_editor/observatory/collector_test.exs
@@ -1,0 +1,69 @@
+defmodule MingaEditor.Observatory.CollectorTest.FakeObserver do
+  @moduledoc false
+  # Stand-in for Minga.SystemObserver that replies to :snapshot and :samples
+  # with caller-supplied values, so tests can feed Collector.collect/1 either
+  # well-formed or deliberately malformed observer output.
+  use GenServer
+
+  @spec start_link(%{snapshot: term(), samples: term()}) :: GenServer.on_start()
+  def start_link(replies), do: GenServer.start_link(__MODULE__, replies)
+
+  @impl true
+  def init(replies), do: {:ok, replies}
+
+  @impl true
+  def handle_call(:snapshot, _from, %{snapshot: snapshot} = replies),
+    do: {:reply, snapshot, replies}
+
+  def handle_call(:samples, _from, %{samples: samples} = replies),
+    do: {:reply, samples, replies}
+end
+
+defmodule MingaEditor.Observatory.CollectorTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Observatory.Collector
+  alias MingaEditor.Observatory.CollectorTest.FakeObserver
+  alias MingaEditor.Observatory.Data
+
+  describe "collect/1" do
+    test "returns the empty fallback when the observer reports no snapshot" do
+      {:ok, observer} = start_supervised({FakeObserver, %{snapshot: nil, samples: []}})
+
+      assert %Data{visible: true, tree: nil, samples: []} = Collector.collect(observer)
+    end
+
+    # Liveness guard: Collector.collect/1 runs inside an unmonitored Task in the
+    # Editor whose result message is the *only* thing that re-arms the refresh
+    # tick. A non-:exit failure (a raise/throw on malformed observer output)
+    # would kill the Task silently and freeze the refresh loop while the panel
+    # stays open. So collect/1 must be total: it returns the empty fallback
+    # rather than propagating the failure.
+    test "is total: malformed snapshot data yields the empty fallback instead of raising" do
+      # A non-empty snapshot map whose values are not ProcessSnapshot structs:
+      # build_tree/1 reads `.parent_pid` on each value and raises KeyError.
+      malformed = %{self() => %{not: :a_process_snapshot}}
+
+      # Sanity: this shape genuinely crashes the tree builder, so this test would
+      # fail without collect/1's rescue/catch (the regression it guards against).
+      assert_raise KeyError, fn ->
+        Minga.SystemObserver.TreeNode.build_tree(malformed)
+      end
+
+      {:ok, observer} =
+        start_supervised({FakeObserver, %{snapshot: %{processes: malformed}, samples: []}})
+
+      assert %Data{visible: true} = Collector.collect(observer)
+    end
+
+    test "is total: an observer that exits mid-call yields the empty fallback" do
+      {:ok, observer} =
+        start_supervised({FakeObserver, %{snapshot: %{processes: %{}}, samples: []}})
+
+      GenServer.stop(observer)
+
+      # snapshot/1 against a dead server exits; collect/1 catches it.
+      assert %Data{visible: true, tree: nil, samples: []} = Collector.collect(observer)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
`handle_info({:observatory_tick, token})` ran `build_observatory_data/0` synchronously on the Editor GenServer every second. That helper makes two blocking `GenServer.call`s to `Minga.SystemObserver` (`snapshot()` and `samples()`) and builds a process tree, so while the observatory panel was open it stalled the Editor mailbox once per second.

This moves the collection off the Editor process using the same `Task.Supervisor` + result-message pattern the async picker uses:

- The `{:observatory_tick, token}` clause now only spawns a supervised Task (under `Minga.Eval.TaskSupervisor`) that runs the collection and sends `{:observatory_data_result, token, data}` back to the editor. It does no blocking work and no longer schedules the next tick inline.
- A new `{:observatory_data_result, token, data}` clause applies the data cheaply via `EditorState.set_observatory_data/2`, mints the next token, and only now schedules the next tick.
- Stale results (panel closed, or a newer tick superseded this one) are dropped via the existing `current_observatory_token?/2` guard.

Open/close behaviour is unchanged: the first tick is still scheduled on open (`open_beam_observatory`), and close cancels the timer and flips `observatory_visible: false`, so any in-flight Task result lands as stale and is ignored.

## Liveness: collection is total (bug-hunt fix)
Because collection now runs in an **unmonitored** Task whose result message is the *only* thing that re-arms the next tick, the collection must never crash silently. The old `build_observatory_data/0` only had `catch :exit`, so an ordinary exception or throw (e.g. `TreeNode.build_tree/1` or `Observatory.Data.visible/2` hitting malformed snapshot data) would kill the Task with no result message, freezing the refresh loop permanently while the panel stayed open. That is a regression from the inline version, which would have crashed+restarted the Editor instead of stalling.

Fix: the collection now lives in `MingaEditor.Observatory.Collector` with a public, documented, **total** `collect/1`. A raise, throw, or exit (observer down, malformed data) falls back to an empty view, so the Task always reports a result and the loop always re-arms. Extracting to a real module (instead of a `@doc false` test seam, which the project's credo rules reject) also gives the totality guarantee a public contract to unit-test directly.

## How the skip-not-queue guarantee (AC#3) works
The next tick is scheduled **only** when a result arrives, never inside the tick handler. During collection no tick is pending, so a collection that takes longer than 1s cannot accumulate a backlog: ticks effectively fire every `collection_time + 1s`. If the panel closes mid-collection, the result is dropped by the token guard and nothing is rescheduled. Because `collect/1` is total, a failed collection still produces a result, so the loop re-arms instead of freezing.

## Acceptance criteria
1. Collection no longer blocks the Editor GenServer; it runs in a supervised Task. ✅
2. The 1s tick still fires and updates the panel; scheduled on each result. ✅
3. Collection longer than 1s skips the next tick (not queued); next tick is armed only on result. ✅
4. Data arrives asynchronously and is applied like a Task result; mirrors the picker `{:..._result}` pattern. ✅

## Validation
- `mix test test/minga_editor/observatory/collector_test.exs test/minga_editor/commands/ui_frontend_test.exs test/minga_editor/input/observatory_test.exs` — 25 passed.
  - Editor-side tests prove: a tick spawns async work and does not set data inline or schedule a tick; a stale tick spawns nothing; the result handler applies data and arms the next tick (verified by receiving the delivered `{:observatory_tick, next_token}`); a stale data result is ignored.
  - `CollectorTest` proves `collect/1` is total: it returns the empty fallback for a nil snapshot, for malformed snapshot data that genuinely raises `KeyError` in `build_tree/1` (asserted), and for an observer that exits mid-call.
- `make lint` — all checks passed (format, credo --strict, compile --warnings-as-errors, dialyzer).

## Risks
- Low. The collection result races with a close; handled by the existing token guard (close nils the timer, so the stale result is dropped). The same guard handles close-then-reopen with an old Task still in flight.
- One extra short-lived Task per second while the panel is open, supervised under the existing `Minga.Eval.TaskSupervisor`.

Closes #2631

🤖 Generated with [Claude Code](https://claude.com/claude-code)