### PR TITLE
feat(hover): sticky hover popup + 300ms delay (#2629)

### DIFF
--- a/go/tui/internal/ui/input.go
+++ b/go/tui/internal/ui/input.go
@@ -180,6 +180,14 @@ func keyModifiers(key tea.Key) byte {
 // motion) honor the suppression.
 func (m Model) mousePacket(msg tea.MouseMsg) ([]byte, bool) {
 	mouse := msg.Mouse()
+	// Sticky hover (#2629): free pointer motion inside the hover popup's rect is
+	// not forwarded, so the BEAM never sees motion over the popup and cannot
+	// dismiss it. Wheel, press, and drag still forward (wheel scrolls the popup
+	// content via the BEAM; a press focuses it), so only free motion is dropped.
+	if _, isMotion := msg.(tea.MouseMotionMsg); isMotion && mouse.Button == tea.MouseNone &&
+		m.mouseInHoverPopup(mouse.X, mouse.Y) {
+		return nil, false
+	}
 	offset := m.layout.header.Height
 	row := mouse.Y - offset
 	if !isWheelButton(mouse.Button) && mouse.Y < offset {

--- a/go/tui/internal/ui/semantic_mouse.go
+++ b/go/tui/internal/ui/semantic_mouse.go
@@ -177,6 +177,20 @@ func (m Model) presentationScrollWindowAtBody(x int, y int) (uint16, bool) {
 	return 0, false
 }
 
+// mouseInHoverPopup reports whether screen coordinates (x, y) fall inside the
+// hover popup's BEAM placement rect. The placement rect is composited at its
+// row/col as screen coordinates (overlayLayer), so a raw mouse coordinate is
+// compared directly, matching mouseInBottomPanel. Used to suppress free-motion
+// forwarding so motion over the popup does not dismiss it (#2629).
+func (m Model) mouseInHoverPopup(x int, y int) bool {
+	rect, ok := m.surfacePlacementFor(surfaceIDHoverPopup)
+	if !ok {
+		return false
+	}
+	return y >= int(rect.Row) && y < int(rect.Row)+int(rect.Height) &&
+		x >= int(rect.Col) && x < int(rect.Col)+int(rect.Width)
+}
+
 func (m Model) mouseInBottomPanel(y int) bool {
 	// The bottom panel is composited at its BEAM placement rect now (#2281), not
 	// footer-appended, so its on-screen band comes from the placement, not from a

--- a/lib/minga_editor/input/hover.ex
+++ b/lib/minga_editor/input/hover.ex
@@ -141,9 +141,11 @@ defmodule MingaEditor.Input.Hover do
     {:passthrough, state}
   end
 
-  # Scroll wheel when focused: scroll the hover content
+  # Scroll wheel over the popup scrolls its content. The popup node only receives
+  # wheel events when the pointer is inside its rect (scroll routing), so scrolling
+  # works whether or not the popup is keyboard-focused (#2629, AC-3).
   def handle_mouse(
-        %{shell_state: %{hover_popup: %HoverPopup{focused: true}}} = state,
+        %{shell_state: %{hover_popup: %HoverPopup{}}} = state,
         _r,
         _c,
         :wheel_down,
@@ -156,7 +158,7 @@ defmodule MingaEditor.Input.Hover do
   end
 
   def handle_mouse(
-        %{shell_state: %{hover_popup: %HoverPopup{focused: true}}} = state,
+        %{shell_state: %{hover_popup: %HoverPopup{}}} = state,
         _r,
         _c,
         :wheel_up,
@@ -168,7 +170,9 @@ defmodule MingaEditor.Input.Hover do
      EditorState.set_hover_popup(state, HoverPopup.scroll_up(state.shell_state.hover_popup))}
   end
 
-  # Any click dismisses hover
+  # A click inside the popup focuses it for scrolling rather than dismissing it
+  # (#2629, AC-4). This clause only runs when the pointer hit the popup rect, so a
+  # click outside still falls through to the buffer (which dismisses on motion).
   def handle_mouse(
         %{shell_state: %{hover_popup: %HoverPopup{}}} = state,
         _r,
@@ -178,7 +182,22 @@ defmodule MingaEditor.Input.Hover do
         :press,
         _cc
       ) do
-    {:passthrough, EditorState.dismiss_hover_popup(state)}
+    {:handled,
+     EditorState.set_hover_popup(state, HoverPopup.focus(state.shell_state.hover_popup))}
+  end
+
+  # Pointer motion inside the popup keeps it alive (#2629, AC-1). Swallowing the
+  # event here stops it bubbling to the buffer handler that would dismiss it.
+  def handle_mouse(
+        %{shell_state: %{hover_popup: %HoverPopup{}}} = state,
+        _r,
+        _c,
+        _btn,
+        _m,
+        :motion,
+        _cc
+      ) do
+    {:handled, state}
   end
 
   def handle_mouse(state, _row, _col, _btn, _mods, _type, _cc) do

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -322,20 +322,35 @@ defmodule MingaEditor.Mouse do
   # ── Mouse motion (hover tracking) ──
 
   def handle(state, row, col, :none, _mods, :motion, _cc) do
-    # Clear any existing hover popup when the mouse moves
-    state =
-      if state.shell_state.hover_popup != nil do
-        EditorState.dismiss_hover_popup(state)
-      else
-        state
-      end
-
-    update_mouse(state, &MouseState.set_hover(&1, row, col, backend: state.backend))
+    handle_hover_motion(state, row, col)
   end
 
   # ── Ignore all other mouse events ──
 
   def handle(state, _row, _col, _button, _mods, _type, _cc), do: state
+
+  # Free pointer motion drives hover tracking. When a hover popup is open and the
+  # pointer is inside its on-screen rect, the popup is kept alive untouched so the
+  # user can read, scroll, or click it (#2629); restarting the debounce here would
+  # thrash and dismissing it would defeat the point. Anywhere else, motion
+  # (re)starts the hover debounce, dismissing a stale popup first.
+  @spec handle_hover_motion(state(), integer(), integer()) :: state()
+  defp handle_hover_motion(%{shell_state: %{hover_popup: nil}} = state, row, col) do
+    update_mouse(state, &MouseState.set_hover(&1, row, col, backend: state.backend))
+  end
+
+  defp handle_hover_motion(state, row, col) do
+    keep_or_dismiss_hover(state, row, col, SurfaceRegistry.within?(state, :hover_popup, row, col))
+  end
+
+  @spec keep_or_dismiss_hover(state(), integer(), integer(), boolean()) :: state()
+  defp keep_or_dismiss_hover(state, _row, _col, true), do: state
+
+  defp keep_or_dismiss_hover(state, row, col, false) do
+    state
+    |> EditorState.dismiss_hover_popup()
+    |> update_mouse(&MouseState.set_hover(&1, row, col, backend: state.backend))
+  end
 
   @spec update_mouse(state(), (MouseState.t() -> MouseState.t())) :: state()
   defp update_mouse(state, fun) when is_function(fun, 1) do

--- a/lib/minga_editor/state/mouse.ex
+++ b/lib/minga_editor/state/mouse.ex
@@ -21,6 +21,10 @@ defmodule MingaEditor.State.Mouse do
   @double_click_ms 400
   # Maximum cell distance between clicks to count as multi-click
   @click_distance 2
+  # Hover debounce before requesting an LSP hover. Matches the VSCode default
+  # (`editor.hover.delay`) so a hovered symbol resolves quickly but transient
+  # pointer motion does not thrash the LSP.
+  @hover_delay_ms 300
 
   defstruct dragging: false,
             anchor: nil,
@@ -152,6 +156,10 @@ defmodule MingaEditor.State.Mouse do
   @spec double_click_ms() :: pos_integer()
   def double_click_ms, do: @double_click_ms
 
+  @doc "Returns the hover debounce delay in milliseconds (for testing)."
+  @spec hover_delay_ms() :: pos_integer()
+  def hover_delay_ms, do: @hover_delay_ms
+
   # ── Hover tracking ─────────────────────────────────────────────────────────
 
   @doc "Sets the hover position and starts a debounce timer."
@@ -161,7 +169,7 @@ defmodule MingaEditor.State.Mouse do
 
     timer =
       if Keyword.get(opts, :backend) != :headless do
-        Process.send_after(self(), :mouse_hover_timeout, 500)
+        Process.send_after(self(), :mouse_hover_timeout, @hover_delay_ms)
       end
 
     %{mouse | hover_pos: {row, col}, hover_timer: timer}

--- a/macos/Sources/Views/Overlays/HoverPopupOverlay.swift
+++ b/macos/Sources/Views/Overlays/HoverPopupOverlay.swift
@@ -103,7 +103,13 @@ struct HoverPopupOverlay: View {
                         )
                 )
                 .offset(x: offsetX, y: offsetY)
-                .allowsHitTesting(state.focused)
+                // Always intercept mouse events inside the popup (#2629). SwiftUI
+                // then handles motion (keeping the popup alive instead of the
+                // motion reaching EditorNSView and dismissing it via the BEAM),
+                // scrolling, clicks, and the Open button without requiring the
+                // user to keyboard-focus the popup first. Moving the pointer back
+                // out resumes editor motion events, which dismiss on leaving.
+                .allowsHitTesting(true)
                 .transition(.opacity.animation(.easeIn(duration: animDuration)))
         }
     }

--- a/test/minga_editor/input/hover_test.exs
+++ b/test/minga_editor/input/hover_test.exs
@@ -89,8 +89,11 @@ defmodule MingaEditor.Input.HoverTest do
   end
 
   describe "handle_mouse/7 sticky behavior (#2629)" do
-    test "pointer motion inside the popup keeps it open" do
+    test "motion event reaching the hover handler keeps the popup open" do
       state = state_with_hover()
+      # The hover node only receives motion when the pointer is inside the popup
+      # rect, so this handler keeps the popup for any motion that reaches it; the
+      # coordinate-gated routing is tested in MingaEditor.MouseTest.
       assert {:handled, new_state} = Hover.handle_mouse(state, 0, 0, :none, @none, :motion, 1)
       assert %HoverPopup{} = new_state.shell_state.hover_popup
     end

--- a/test/minga_editor/input/hover_test.exs
+++ b/test/minga_editor/input/hover_test.exs
@@ -88,6 +88,29 @@ defmodule MingaEditor.Input.HoverTest do
     end
   end
 
+  describe "handle_mouse/7 sticky behavior (#2629)" do
+    test "pointer motion inside the popup keeps it open" do
+      state = state_with_hover()
+      assert {:handled, new_state} = Hover.handle_mouse(state, 0, 0, :none, @none, :motion, 1)
+      assert %HoverPopup{} = new_state.shell_state.hover_popup
+    end
+
+    test "wheel scrolls the popup even when not focused" do
+      state = state_with_hover()
+
+      assert {:handled, new_state} =
+               Hover.handle_mouse(state, 0, 0, :wheel_down, @none, :press, 1)
+
+      assert new_state.shell_state.hover_popup.scroll_offset > 0
+    end
+
+    test "clicking inside the popup focuses it instead of dismissing" do
+      state = state_with_hover()
+      assert {:handled, new_state} = Hover.handle_mouse(state, 0, 0, :left, @none, :press, 1)
+      assert %HoverPopup{focused: true} = new_state.shell_state.hover_popup
+    end
+  end
+
   describe "handle_key/3 o (expand) on focused hover" do
     @key_o ?o
 

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -645,6 +645,44 @@ defmodule MingaEditor.MouseTest do
     end
   end
 
+  describe "sticky hover popup motion (#2629)" do
+    test "motion inside the popup rect keeps the popup open" do
+      {state, rect} = state_with_hover_popup()
+      {row, col, _w, _h} = rect
+
+      # A free-motion event landing inside the popup's rect must not dismiss it.
+      state = Mouse.handle(state, row, col, :none, 0, :motion, 1)
+
+      assert state.shell_state.hover_popup != nil
+    end
+
+    test "motion outside the popup rect dismisses the popup" do
+      {state, rect} = state_with_hover_popup()
+      {row, col, _w, height} = rect
+
+      # The row directly below the popup's bottom edge is outside it (and below
+      # the popup, which is anchored above the symbol), so motion there dismisses.
+      state = Mouse.handle(state, row + height, col, :none, 0, :motion, 1)
+
+      assert state.shell_state.hover_popup == nil
+    end
+  end
+
+  # Builds a state with an open hover popup and returns its placed screen rect.
+  defp state_with_hover_popup do
+    {state, _buffer} = start_mouse_state("hello\nworld\nfoo bar", width: 80, height: 24)
+    # Headless backend so set_hover does not start a real debounce timer.
+    state = %{state | backend: :headless}
+
+    popup = MingaEditor.HoverPopup.new("Documentation for symbol", 12, 10)
+    state = EditorState.set_hover_popup(state, popup)
+
+    rect = MingaEditor.Layout.SurfaceRegistry.rect_for(state, :hover_popup)
+    assert rect != nil, "expected the hover popup to be placed in the focus tree"
+
+    {state, rect}
+  end
+
   defp start_mouse_state(content, opts \\ []) do
     id = :erlang.unique_integer([:positive])
     events_registry = :"#{__MODULE__}.Events.#{id}"

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -656,15 +656,21 @@ defmodule MingaEditor.MouseTest do
       assert state.shell_state.hover_popup != nil
     end
 
-    test "motion outside the popup rect dismisses the popup" do
+    test "motion outside the popup rect dismisses and restarts the hover debounce" do
       {state, rect} = state_with_hover_popup()
       {row, col, _w, height} = rect
 
       # The row directly below the popup's bottom edge is outside it (and below
       # the popup, which is anchored above the symbol), so motion there dismisses.
-      state = Mouse.handle(state, row + height, col, :none, 0, :motion, 1)
+      out_row = row + height
+      state = Mouse.handle(state, out_row, col, :none, 0, :motion, 1)
 
       assert state.shell_state.hover_popup == nil
+
+      # Dismissing must also restart hover tracking at the new position, otherwise
+      # hovering a symbol after closing a popup would never re-open one. Guards
+      # against simplifying the dismiss branch down to just dismiss_hover_popup/1.
+      assert state.workspace.mouse.hover_pos == {out_row, col}
     end
   end
 

--- a/test/minga_editor/state/mouse_test.exs
+++ b/test/minga_editor/state/mouse_test.exs
@@ -3,6 +3,12 @@ defmodule MingaEditor.State.MouseTest do
 
   alias MingaEditor.State.Mouse
 
+  describe "hover_delay_ms/0" do
+    test "is the 300ms VSCode default" do
+      assert Mouse.hover_delay_ms() == 300
+    end
+  end
+
   describe "start_drag/2" do
     test "sets dragging to true and stores the anchor" do
       mouse = %Mouse{} |> Mouse.start_drag({5, 10})


### PR DESCRIPTION
## Summary

Keep the LSP hover popup alive when the mouse moves into it so the user can read, scroll, or interact with it, instead of dismissing on every pointer motion. Also lowers the hover debounce from 500ms to the 300ms VSCode default.

Before, the `:none` motion handler unconditionally dismissed any open popup and restarted the debounce, so the popup vanished the instant the user tried to reach it.

Closes #2629.

## Per-frontend changes

**BEAM (authoritative for both frontends)**
- `MingaEditor.Mouse` `:none` motion now hit-tests the popup's placement rect via `SurfaceRegistry.within?/4`. Inside the popup: keep it untouched (no dismiss, no debounce restart). Outside: dismiss and restart hover tracking. Implemented with pattern-matched helper clauses (no `cond`).
- `MingaEditor.Input.Hover.handle_mouse` swallows motion over the popup (sticky), scrolls on the wheel regardless of keyboard focus (AC-3), and focuses instead of dismissing on a click inside (AC-4).
- `MingaEditor.State.Mouse` hover debounce is now `@hover_delay_ms` (300), exposed via `hover_delay_ms/0`.

**macOS**
- `HoverPopupOverlay` now always intercepts mouse events (`allowsHitTesting(true)`). SwiftUI then keeps the popup alive (motion never reaches `EditorNSView`), scrolls it, and keeps the Open button clickable without first keyboard-focusing it.

**Go TUI**
- `mousePacket` suppresses free-motion forwarding when the pointer is inside the hover popup's BEAM placement rect (`mouseInHoverPopup`), so motion over the popup never reaches the BEAM motion handler. Wheel, press, and drag still forward.

## What macOS already handled vs. what changed

The dev notes suspected macOS might already keep the popup naturally. It did not: `HoverPopupOverlay` gated hit testing on `state.focused`, so an unfocused popup let motion fall through to `EditorNSView`, which forwarded it to the BEAM and dismissed the popup. The Open button and scrolling were likewise unreachable until the popup was keyboard-focused. Changing to `allowsHitTesting(true)` makes the SwiftUI overlay sticky and interactive natively, and the BEAM hit-test is the cross-frontend backstop.

## Go TUI zone handling

Mouse motion in the TUI is forwarded raw via `mousePacket` (clicks are zone-routed separately, but free motion was not). The new check compares the raw screen coordinate against the hover popup's surface placement rect (the same screen-space convention `overlayLayer`/`mouseInBottomPanel` use) and drops only `MouseMotionMsg` with `MouseNone`. The BEAM `within?` guard remains the authority, so even if a terminal reports motion the suppression also catches, behavior is correct.

## Validation

- `mix test.llm` on `state/mouse_test.exs`, `input/hover_test.exs`, `mouse_test.exs` — 60 tests, 0 failures. New tests: motion inside keeps the popup, motion outside dismisses, wheel/click behavior, and the 300ms delay constant.
- `cd go/tui && go build ./...` and `go test ./internal/ui/` — 272 passed.
- `mix swift.build` — built successfully.
- `make lint` — all checks passed.

## Risks

- macOS: `allowsHitTesting(true)` means the popup now captures clicks/scroll within its frame; outside its frame events still reach the editor. This is the intended sticky behavior and matches VSCode.
- v1 dismisses instantly on leaving both the popup and the symbol region (no dismiss grace timer). Not a regression: the old code dismissed on every motion.
- Cmd/Ctrl+hover underline is intentionally untouched (separate ticket #2630).

🤖 Generated with [Claude Code](https://claude.com/claude-code)