### PR TITLE
feat(hover): Cmd/Ctrl+hover underline preview (#2630)

### DIFF
--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -16,7 +16,11 @@ version = "2.0.0"
 # familiarity tinting. This changes the hand-decoded file-tree row payload.
 # protocol_version 5 adds producer-assigned stream_instance to the Messages stream.
 # protocol_version 6 frames gui_agent_context and appends gui_edit_timeline file summaries.
-protocol_version = 7
+# protocol_version 7 baseline.
+# protocol_version 8 adds set_link_cursor (#2630): a 1-byte beam_to_frontend hint
+# that toggles the pointing-hand cursor while Cmd/Ctrl+hover previews a navigable
+# go-to-definition symbol. Emitted out-of-band (post-commit), like set_title.
+protocol_version = 8
 description = "Minga port protocol opcode registry"
 
 # Directions:
@@ -174,6 +178,19 @@ name = "set_window_bg"
 value = 0x17
 direction = "beam_to_frontend"
 framing = "fixed:4"
+
+# set_link_cursor (#2630) reuses the freed cell-paradigm value 0x19 (destroy_region,
+# retired in protocol_version 2). fixed:2 = opcode(1) + active(u8: 1 = navigable
+# symbol under the pointer, 0 = none). The GUI frontend toggles NSCursor.pointingHand
+# on this hint while Cmd+hover previews a go-to-definition link; the TUI sizes and
+# skips it (no terminal pointer-shape control). Emitted out-of-band post-commit, so
+# it joins the frontend out-of-band allowlist alongside set_title/set_window_bg.
+[[opcodes]]
+category = "render"
+name = "set_link_cursor"
+value = 0x19
+direction = "beam_to_frontend"
+framing = "fixed:2"
 
 # protocol_error reuses the freed cell-paradigm value 0x18. The BEAM emits it when
 # a frontend's handshake protocol_version does not match the BEAM's, carrying a

--- a/go/tui/internal/generated/command_size.go
+++ b/go/tui/internal/generated/command_size.go
@@ -24,7 +24,7 @@ func CommandSize(payload []byte) (int, CommandSizeStatus) {
 		return 0, CommandSizeIncomplete
 	}
 	switch payload[0] {
-	case OPSetCursorShape:
+	case OPSetCursorShape, OPSetLinkCursor:
 		return fixedCommandSize(payload, 2)
 	case OPSetWindowBg:
 		return fixedCommandSize(payload, 4)

--- a/go/tui/internal/generated/opcodes.go
+++ b/go/tui/internal/generated/opcodes.go
@@ -4,7 +4,7 @@ package generated
 
 // ProtocolVersion is the wire-contract version the frontend exchanges with
 // the BEAM in the ready handshake. A mismatch yields an explicit protocol_error.
-const ProtocolVersion uint16 = 7
+const ProtocolVersion uint16 = 8
 
 const (
 	// Input
@@ -26,6 +26,7 @@ const (
 	OPSetCursorShape byte = 0x15
 	OPSetTitle       byte = 0x16
 	OPSetWindowBg    byte = 0x17
+	OPSetLinkCursor  byte = 0x19
 	OPProtocolError  byte = 0x18
 
 	// Config

--- a/lib/minga_editor/frontend.ex
+++ b/lib/minga_editor/frontend.ex
@@ -112,6 +112,17 @@ defmodule MingaEditor.Frontend do
     send_commands(port, [Protocol.encode_set_window_bg(color)])
   end
 
+  @doc """
+  Toggles the GUI go-to-definition link cursor (#2630).
+
+  Emitted out-of-band (post-commit) like `set_title`, so it joins the frontend
+  out-of-band allowlist. The GUI shows `NSCursor.pointingHand` while `active`.
+  """
+  @spec set_link_cursor(GenServer.server(), boolean()) :: :ok
+  def set_link_cursor(port \\ MingaEditor.Frontend.Manager, active) do
+    send_commands(port, [Protocol.encode_set_link_cursor(active)])
+  end
+
   @doc "Configures the editor font."
   @spec configure_font(GenServer.server(), String.t(), pos_integer(), boolean(), atom(), [
           String.t()

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -61,7 +61,8 @@ defmodule MingaEditor.Frontend.Emit do
           caches
           | adapter_gui_caches: Minga.Frontend.Adapter.GUI.Caches.new(),
             last_title: nil,
-            last_window_bg: nil
+            last_window_bg: nil,
+            last_link_cursor: nil
         }
       else
         caches
@@ -109,6 +110,7 @@ defmodule MingaEditor.Frontend.Emit do
         MingaEditor.Frontend.send_render_commands(ctx.port_manager, commands)
         caches = send_title(render_model, caches)
         caches = send_window_bg(render_model, caches)
+        caches = send_link_cursor(ctx, caches)
         {caches, ctx}
       end
     )
@@ -253,4 +255,20 @@ defmodule MingaEditor.Frontend.Emit do
       caches
     end
   end
+
+  # Edge-triggered out-of-band cursor hint for the Cmd/Ctrl+hover link preview
+  # (#2630). Mirrors send_title/send_window_bg: only emits when the navigable
+  # state flips, so an unchanged preview never re-sends. GUI-only by construction
+  # (ctx.link_cursor is gated on gui? when the context is built).
+  @spec send_link_cursor(ctx(), Caches.t()) :: Caches.t()
+  defp send_link_cursor(%{gui?: true, link_cursor: active}, caches) do
+    if active != caches.last_link_cursor do
+      MingaEditor.Frontend.set_link_cursor(active)
+      %{caches | last_link_cursor: active}
+    else
+      caches
+    end
+  end
+
+  defp send_link_cursor(_ctx, caches), do: caches
 end

--- a/lib/minga_editor/frontend/emit/context.ex
+++ b/lib/minga_editor/frontend/emit/context.ex
@@ -59,7 +59,8 @@ defmodule MingaEditor.Frontend.Emit.Context do
           gui?: boolean(),
           line_spacing: number() | nil,
           cursor_animate: boolean() | nil,
-          config_state: Minga.RenderModel.UI.ConfigState.t() | nil
+          config_state: Minga.RenderModel.UI.ConfigState.t() | nil,
+          link_cursor: boolean()
         }
 
   @enforce_keys [:port_manager, :capabilities, :theme, :font_registry, :windows, :layout, :shell]
@@ -96,7 +97,8 @@ defmodule MingaEditor.Frontend.Emit.Context do
             gui?: false,
             line_spacing: nil,
             cursor_animate: nil,
-            config_state: nil
+            config_state: nil,
+            link_cursor: false
 
   @doc "Builds an emit context from render pipeline input."
   @spec from_editor_state(map()) :: t()
@@ -149,7 +151,10 @@ defmodule MingaEditor.Frontend.Emit.Context do
       gui?: gui?,
       line_spacing: gui_only(gui?, Map.get(state, :line_spacing)),
       cursor_animate: gui_only(gui?, Map.get(state, :cursor_animate)),
-      config_state: gui_only(gui?, Map.get(state, :gui_config_state))
+      config_state: gui_only(gui?, Map.get(state, :gui_config_state)),
+      # The pointing-hand cursor is GUI-only; a non-nil Cmd/Ctrl-hover link range
+      # means a navigable symbol is under the pointer (#2630).
+      link_cursor: gui? and state.workspace.cmd_hover_link != nil
     }
   end
 

--- a/lib/minga_editor/frontend/protocol.ex
+++ b/lib/minga_editor/frontend/protocol.ex
@@ -49,6 +49,7 @@ defmodule MingaEditor.Frontend.Protocol do
   @op_scroll_prefetch_hint Opcodes.scroll_prefetch_hint()
   @op_set_title Opcodes.set_title()
   @op_set_window_bg Opcodes.set_window_bg()
+  @op_set_link_cursor Opcodes.set_link_cursor()
   @op_set_font Opcodes.set_font()
   @op_set_font_fallback Opcodes.set_font_fallback()
   @op_register_font Opcodes.register_font()
@@ -274,6 +275,17 @@ defmodule MingaEditor.Frontend.Protocol do
     g = Bitwise.band(Bitwise.bsr(rgb, 8), 0xFF)
     b = Bitwise.band(rgb, 0xFF)
     <<@op_set_window_bg, r::8, g::8, b::8>>
+  end
+
+  @doc """
+  Encodes a set_link_cursor command (#2630).
+
+  `active` toggles the GUI pointing-hand cursor while a Cmd/Ctrl+hover
+  go-to-definition link preview is shown. The TUI sizes and skips it.
+  """
+  @spec encode_set_link_cursor(boolean()) :: binary()
+  def encode_set_link_cursor(active) when is_boolean(active) do
+    <<@op_set_link_cursor, if(active, do: 1, else: 0)::8>>
   end
 
   @doc """

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -46,6 +46,7 @@ defmodule MingaEditor.Mouse do
   alias MingaEditor.State.Mouse, as: MouseState
   alias MingaEditor.State.Windows
   alias MingaEditor.State.WhichKey, as: WhichKeyState
+  alias MingaEditor.UI.Highlight
   alias MingaEditor.Viewport
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
@@ -319,15 +320,146 @@ defmodule MingaEditor.Mouse do
     EditorState.update_mouse(state, &MouseState.stop_resize/1)
   end
 
-  # ── Mouse motion (hover tracking) ──
+  # ── Mouse motion (hover tracking + Cmd/Ctrl link preview) ──
 
-  def handle(state, row, col, :none, _mods, :motion, _cc) do
-    handle_hover_motion(state, row, col)
+  def handle(state, row, col, :none, mods, :motion, _cc) do
+    handle_motion(state, row, col, mods)
   end
 
   # ── Ignore all other mouse events ──
 
   def handle(state, _row, _col, _button, _mods, _type, _cc), do: state
+
+  # Free pointer motion. With the go-to-definition modifier held (Cmd/Super on
+  # every frontend, or Ctrl on the TUI) the pointer previews a navigable symbol as
+  # an underlined link (#2630); otherwise it drives normal hover tracking (#2629).
+  # The link preview is computed locally (word boundaries + tree-sitter scope), so
+  # it never sends a per-motion LSP request and cannot regress input latency.
+  @spec handle_motion(state(), integer(), integer(), non_neg_integer()) :: state()
+  defp handle_motion(state, row, col, mods) when band(mods, @mod_super) != 0 do
+    update_cmd_hover_link(state, row, col)
+  end
+
+  # Ctrl on native GUI frontends follows platform context-menu semantics, so it
+  # is not a link-preview modifier there; fall through to plain hover.
+  defp handle_motion(
+         %{capabilities: %Capabilities{frontend_type: :native_gui}} = state,
+         row,
+         col,
+         mods
+       )
+       when band(mods, @mod_ctrl) != 0 do
+    clear_cmd_hover_link_then_hover(state, row, col)
+  end
+
+  # Ctrl on the TUI mirrors Ctrl+click go-to-definition, so it previews the link.
+  defp handle_motion(state, row, col, mods) when band(mods, @mod_ctrl) != 0 do
+    update_cmd_hover_link(state, row, col)
+  end
+
+  defp handle_motion(state, row, col, _mods) do
+    clear_cmd_hover_link_then_hover(state, row, col)
+  end
+
+  # ── Cmd/Ctrl-hover link preview (#2630) ──────────────────────────────────────
+
+  # Resolves the navigable symbol under the pointer and sets a transient link
+  # decoration on its full word range, or clears it when there is nothing
+  # navigable there. Intentionally leaves the hover popup and hover debounce
+  # untouched: the link preview is an independent layer from the LSP hover popup.
+  @spec update_cmd_hover_link(state(), integer(), integer()) :: state()
+  defp update_cmd_hover_link(state, row, col) do
+    set_cmd_hover_link_if_changed(state, navigable_link_at(state, row, col))
+  end
+
+  @spec set_cmd_hover_link_if_changed(state(), EditorState.cmd_hover_link()) :: state()
+  defp set_cmd_hover_link_if_changed(%{workspace: %{cmd_hover_link: link}} = state, link),
+    do: state
+
+  defp set_cmd_hover_link_if_changed(state, link) do
+    EditorState.set_cmd_hover_link(state, link)
+  end
+
+  # Clears any standing link decoration (modifier released, or pointer moved off a
+  # navigable symbol) before running normal hover tracking. Skips the clear write
+  # when there is nothing to clear so plain motion stays allocation-free.
+  @spec clear_cmd_hover_link_then_hover(state(), integer(), integer()) :: state()
+  defp clear_cmd_hover_link_then_hover(%{workspace: %{cmd_hover_link: nil}} = state, row, col) do
+    handle_hover_motion(state, row, col)
+  end
+
+  defp clear_cmd_hover_link_then_hover(state, row, col) do
+    state
+    |> EditorState.set_cmd_hover_link(nil)
+    |> handle_hover_motion(row, col)
+  end
+
+  # Returns the full word range `{start, end_exclusive}` for a navigable symbol at
+  # the pointer, or nil. Navigable means: an identifier character sits under the
+  # pointer, the position is not inside a comment or string (tree-sitter scope),
+  # and an inner-word text object resolves. No LSP request is made.
+  @spec navigable_link_at(state(), integer(), integer()) :: EditorState.cmd_hover_link()
+  defp navigable_link_at(state, row, col) do
+    case mouse_to_buffer_pos(state, row, col) do
+      nil -> nil
+      {line, buf_col} -> navigable_link_at_pos(state, line, buf_col)
+    end
+  end
+
+  @spec navigable_link_at_pos(state(), non_neg_integer(), non_neg_integer()) ::
+          EditorState.cmd_hover_link()
+  defp navigable_link_at_pos(state, line, col) do
+    buf = state.workspace.buffers.active
+
+    with text when is_binary(text) <- cursor_line_text(buf, line),
+         true <- identifier_char_at?(text, col),
+         {{sl, sc}, {el, ec}} <- word_boundaries_at(buf, line, col),
+         true <- navigable_scope?(state, buf, line, col) do
+      {{sl, sc}, {el, Unicode.next_grapheme_byte_offset(text, ec)}}
+    else
+      _ -> nil
+    end
+  catch
+    :exit, _ -> nil
+  end
+
+  # True when the byte under `col` begins an identifier-class grapheme (ASCII word
+  # char or any non-ASCII byte, which we treat as a Unicode letter). Punctuation,
+  # whitespace, and line-end positions are not navigable.
+  @spec identifier_char_at?(String.t(), non_neg_integer()) :: boolean()
+  defp identifier_char_at?(text, col) when col >= byte_size(text), do: false
+
+  defp identifier_char_at?(text, col) do
+    case binary_part(text, col, 1) do
+      <<c>> -> identifier_byte?(c)
+      _ -> false
+    end
+  end
+
+  @spec identifier_byte?(byte()) :: boolean()
+  defp identifier_byte?(c) when c in ?a..?z, do: true
+  defp identifier_byte?(c) when c in ?A..?Z, do: true
+  defp identifier_byte?(c) when c in ?0..?9, do: true
+  defp identifier_byte?(?_), do: true
+  defp identifier_byte?(c) when c >= 128, do: true
+  defp identifier_byte?(_), do: false
+
+  # True when the tree-sitter scope at the position is code (not a comment or
+  # string). When no highlight data exists yet (parser still loading, or a plain
+  # buffer) the scope degrades to `:code`, matching `Highlight.scope_at/2`.
+  @spec navigable_scope?(state(), pid(), non_neg_integer(), non_neg_integer()) :: boolean()
+  defp navigable_scope?(state, buf, line, col) do
+    case Map.fetch(state.workspace.highlight.highlights, buf) do
+      {:ok, %Highlight{} = hl} ->
+        offset = Buffer.byte_offset_for_line(buf, line) + col
+        Highlight.scope_at(hl, offset) == :code
+
+      :error ->
+        true
+    end
+  catch
+    :exit, _ -> true
+  end
 
   # Free pointer motion drives hover tracking. When a hover popup is open and the
   # pointer is inside its on-screen rect, the popup is kept alive untouched so the

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -367,9 +367,20 @@ defmodule MingaEditor.Mouse do
   # decoration on its full word range, or clears it when there is nothing
   # navigable there. Intentionally leaves the hover popup and hover debounce
   # untouched: the link preview is an independent layer from the LSP hover popup.
+  #
+  # Hot-path guard (responsiveness epic): when the pointer cell is unchanged from
+  # the previous resolved motion, the whole word-boundary + tree-sitter + buffer
+  # snapshot resolution is skipped. Transitions that change the active buffer
+  # reset `cmd_hover_cell` to nil, so a same-cell motion re-resolves afterwards.
   @spec update_cmd_hover_link(state(), integer(), integer()) :: state()
+  defp update_cmd_hover_link(%{workspace: %{cmd_hover_cell: {row, col}}} = state, row, col) do
+    state
+  end
+
   defp update_cmd_hover_link(state, row, col) do
-    set_cmd_hover_link_if_changed(state, navigable_link_at(state, row, col))
+    state
+    |> set_cmd_hover_link_if_changed(navigable_link_at(state, row, col))
+    |> EditorState.set_cmd_hover_cell({row, col})
   end
 
   @spec set_cmd_hover_link_if_changed(state(), EditorState.cmd_hover_link()) :: state()
@@ -384,13 +395,17 @@ defmodule MingaEditor.Mouse do
   # navigable symbol) before running normal hover tracking. Skips the clear write
   # when there is nothing to clear so plain motion stays allocation-free.
   @spec clear_cmd_hover_link_then_hover(state(), integer(), integer()) :: state()
-  defp clear_cmd_hover_link_then_hover(%{workspace: %{cmd_hover_link: nil}} = state, row, col) do
+  defp clear_cmd_hover_link_then_hover(
+         %{workspace: %{cmd_hover_link: nil, cmd_hover_cell: nil}} = state,
+         row,
+         col
+       ) do
     handle_hover_motion(state, row, col)
   end
 
   defp clear_cmd_hover_link_then_hover(state, row, col) do
     state
-    |> EditorState.set_cmd_hover_link(nil)
+    |> EditorState.clear_cmd_hover_link()
     |> handle_hover_motion(row, col)
   end
 
@@ -822,6 +837,10 @@ defmodule MingaEditor.Mouse do
       {target_line, target_col} ->
         buf = state.workspace.buffers.active
         Buffer.move_to(buf, {target_line, target_col})
+        # Navigation may open or switch to a different buffer, so drop the link
+        # preview now; otherwise its underline would draw against the new buffer
+        # until the next mouse motion (#2630).
+        state = EditorState.clear_cmd_hover_link(state)
         state = cancel_mode_for_mouse(state)
         state = EditorState.transition_mode(state, :normal)
         MingaEditor.dispatch_command(state, :goto_definition)

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -97,12 +97,25 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
         {decorations, state.caches.doc_highlight_cache}
       end
 
+    {decorations, cmd_hover_link_cache} =
+      if is_active do
+        merge_cmd_hover_link_decoration(
+          decorations,
+          state.workspace.cmd_hover_link,
+          state.theme,
+          state.caches.cmd_hover_link_cache
+        )
+      else
+        {decorations, state.caches.cmd_hover_link_cache}
+      end
+
     state = %{
       state
       | caches: %{
           state.caches
           | search_decoration_cache: search_cache,
-            doc_highlight_cache: doc_highlight_cache
+            doc_highlight_cache: doc_highlight_cache,
+            cmd_hover_link_cache: cmd_hover_link_cache
         }
     }
 
@@ -323,6 +336,71 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       theme.editor.highlight_read_bg || 0x3A3F4B,
       theme.editor.highlight_write_bg || 0x4A3F2B
     }
+  end
+
+  # ── Cmd/Ctrl-hover link decoration (#2630) ──────────────────────────────────
+
+  @doc """
+  Merges the transient Cmd/Ctrl-hover go-to-definition link into decorations.
+
+  Styles the full word range with an underline in the theme link/accent color so
+  it reads as a clickable link rather than its original syntax color (#2630).
+  Returns `{merged_decorations, updated_cache}`. Cached on the link range + base
+  decoration version + color so an unchanged preview never rebuilds decorations
+  (and so never forces an idle re-render).
+  """
+  @spec merge_cmd_hover_link_decoration(
+          Decorations.t(),
+          {Buffer.position(), Buffer.position()} | nil,
+          MingaEditor.UI.Theme.t(),
+          term()
+        ) :: {Decorations.t(), term()}
+  def merge_cmd_hover_link_decoration(decs, nil, _theme, nil), do: {decs, nil}
+
+  def merge_cmd_hover_link_decoration(decs, nil, _theme, _cache) do
+    {Decorations.remove_group(decs, :cmd_hover_link), nil}
+  end
+
+  def merge_cmd_hover_link_decoration(decs, {start_pos, end_pos} = link, theme, cached) do
+    fingerprint = {link, decs.version, cmd_hover_link_color(theme)}
+
+    case cached do
+      {^fingerprint, cached_decs} ->
+        {cached_decs, cached}
+
+      _ ->
+        result = rebuild_cmd_hover_link_decoration(decs, start_pos, end_pos, theme)
+        {result, {fingerprint, result}}
+    end
+  end
+
+  @spec rebuild_cmd_hover_link_decoration(
+          Decorations.t(),
+          Buffer.position(),
+          Buffer.position(),
+          MingaEditor.UI.Theme.t()
+        ) :: Decorations.t()
+  defp rebuild_cmd_hover_link_decoration(decs, start_pos, end_pos, theme) do
+    Decorations.batch(decs, fn d ->
+      d = Decorations.remove_group(d, :cmd_hover_link)
+      style = Face.new(fg: cmd_hover_link_color(theme), underline: true)
+
+      {_id, d} =
+        Decorations.add_highlight(d, start_pos, end_pos,
+          style: style,
+          priority: -8,
+          group: :cmd_hover_link
+        )
+
+      d
+    end)
+  end
+
+  # The theme's link/accent color, falling back to a blue accent when a theme
+  # does not define one.
+  @spec cmd_hover_link_color(MingaEditor.UI.Theme.t()) :: non_neg_integer()
+  defp cmd_hover_link_color(theme) do
+    theme.editor.link_fg || 0x61AFEF
   end
 
   @doc "Returns the decorations for a window's buffer."

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -128,6 +128,7 @@ defmodule MingaEditor.RenderPipeline.Input do
           agent_ui: UIState.t(),
           editing: VimState.t(),
           document_highlights: [EditorState.document_highlight()] | nil,
+          cmd_hover_link: EditorState.cmd_hover_link(),
           mouse: Mouse.t(),
           search: Search.t(),
           keymap_scope: Minga.Keymap.Scope.scope_name()
@@ -210,6 +211,7 @@ defmodule MingaEditor.RenderPipeline.Input do
         agent_ui: ws.agent_ui,
         editing: ws.editing,
         document_highlights: ws.document_highlights,
+        cmd_hover_link: ws.cmd_hover_link,
         mouse: ws.mouse,
         search: ws.search,
         keymap_scope: ws.keymap_scope

--- a/lib/minga_editor/renderer/caches.ex
+++ b/lib/minga_editor/renderer/caches.ex
@@ -26,6 +26,7 @@ defmodule MingaEditor.Renderer.Caches do
     # ── Content stage: inter-frame caches ─────────────────────────────────────
     search_decoration_cache: nil,
     doc_highlight_cache: nil,
+    cmd_hover_link_cache: nil,
 
     # ── Content stage: within-frame cache (reset after each window render) ────
     block_render_cache: %{},
@@ -50,6 +51,7 @@ defmodule MingaEditor.Renderer.Caches do
     emit_prev_editing_mode: nil,
     last_title: nil,
     last_window_bg: nil,
+    last_link_cursor: nil,
 
     # ── Frame transaction (#2219) ────────────────────────────────────────────
     # The frame_seq of the last successfully-emitted frame. A delta frame names
@@ -72,6 +74,7 @@ defmodule MingaEditor.Renderer.Caches do
           chrome_prev_result: term(),
           search_decoration_cache: term(),
           doc_highlight_cache: term(),
+          cmd_hover_link_cache: term(),
           block_render_cache: %{term() => term()},
           frame_rows_rasterized: non_neg_integer(),
           frame_render_path: :patch | :full,
@@ -83,6 +86,7 @@ defmodule MingaEditor.Renderer.Caches do
           emit_prev_editing_mode: atom() | nil,
           last_title: String.t() | nil,
           last_window_bg: non_neg_integer() | nil,
+          last_link_cursor: boolean() | nil,
           last_emitted_frame_seq: non_neg_integer(),
           last_frame_keyframe?: boolean(),
           adapter_gui_caches: Minga.Frontend.Adapter.GUI.Caches.t()
@@ -100,6 +104,7 @@ defmodule MingaEditor.Renderer.Caches do
       | adapter_gui_caches: Minga.Frontend.Adapter.GUI.Caches.new(),
         last_title: nil,
         last_window_bg: nil,
+        last_link_cursor: nil,
         # A reconnecting frontend has no committed base, so force the next frame to
         # a keyframe (base_frame_seq 0) by clearing the last-emitted frame_seq.
         last_emitted_frame_seq: 0

--- a/lib/minga_editor/session/state.ex
+++ b/lib/minga_editor/session/state.ex
@@ -29,6 +29,18 @@ defmodule MingaEditor.Session.State do
   @typedoc "A document highlight range from the LSP server."
   @type document_highlight :: Minga.LSP.DocumentHighlight.t()
 
+  @typedoc "A buffer position as `{line, byte_col}`."
+  @type position :: {non_neg_integer(), non_neg_integer()}
+
+  @typedoc """
+  Transient Cmd/Ctrl-hover go-to-definition link range.
+
+  `{start_pos, end_pos}` in buffer coordinates (end exclusive), or `nil` when no
+  navigable symbol is under the pointer. Set on the mouse-motion path while the
+  super/ctrl modifier is held and cleared otherwise; never persisted across tabs.
+  """
+  @type cmd_hover_link :: {position(), position()} | nil
+
   @type t :: %__MODULE__{
           keymap_scope: Scope.scope_name(),
           buffers: Buffers.t(),
@@ -44,6 +56,7 @@ defmodule MingaEditor.Session.State do
           editing: VimState.t(),
           feature_state: FeatureState.t(),
           document_highlights: [document_highlight()] | nil,
+          cmd_hover_link: cmd_hover_link(),
           agent_ui: UIState.t()
         }
 
@@ -62,6 +75,7 @@ defmodule MingaEditor.Session.State do
             editing: VimState.new(),
             feature_state: FeatureState.new(),
             document_highlights: nil,
+            cmd_hover_link: nil,
             agent_ui: UIState.new()
 
   @doc "Returns the list of field names (for snapshot/restore compatibility)."
@@ -288,6 +302,12 @@ defmodule MingaEditor.Session.State do
   @spec set_document_highlights(t(), [document_highlight()] | nil) :: t()
   def set_document_highlights(%__MODULE__{} = wspace, highlights) do
     %{wspace | document_highlights: highlights}
+  end
+
+  @doc "Updates the transient Cmd/Ctrl-hover go-to-definition link range."
+  @spec set_cmd_hover_link(t(), cmd_hover_link()) :: t()
+  def set_cmd_hover_link(%__MODULE__{} = wspace, link) do
+    %{wspace | cmd_hover_link: link}
   end
 
   @doc "Updates the search sub-struct."

--- a/lib/minga_editor/session/state.ex
+++ b/lib/minga_editor/session/state.ex
@@ -41,6 +41,15 @@ defmodule MingaEditor.Session.State do
   """
   @type cmd_hover_link :: {position(), position()} | nil
 
+  @typedoc """
+  The pointer cell `{row, col}` the Cmd/Ctrl-hover link was last resolved at.
+
+  A motion-path dedup key: while the modifier is held, resolution (word
+  boundaries + tree-sitter scope) is skipped when the pointer cell has not moved
+  since the previous motion. Cleared together with `cmd_hover_link`.
+  """
+  @type cmd_hover_cell :: position() | nil
+
   @type t :: %__MODULE__{
           keymap_scope: Scope.scope_name(),
           buffers: Buffers.t(),
@@ -57,6 +66,7 @@ defmodule MingaEditor.Session.State do
           feature_state: FeatureState.t(),
           document_highlights: [document_highlight()] | nil,
           cmd_hover_link: cmd_hover_link(),
+          cmd_hover_cell: cmd_hover_cell(),
           agent_ui: UIState.t()
         }
 
@@ -76,6 +86,7 @@ defmodule MingaEditor.Session.State do
             feature_state: FeatureState.new(),
             document_highlights: nil,
             cmd_hover_link: nil,
+            cmd_hover_cell: nil,
             agent_ui: UIState.new()
 
   @doc "Returns the list of field names (for snapshot/restore compatibility)."
@@ -99,6 +110,10 @@ defmodule MingaEditor.Session.State do
       context
       |> TabContext.to_workspace_map()
       |> Enum.reduce(ws, fn {field, value}, acc -> Map.put(acc, field, value) end)
+      # The Cmd/Ctrl-hover link is transient pointer state, not snapshotted per
+      # tab. Force it off on every restore so a switch never carries a stale
+      # underline (or GUI hand cursor) from the previous tab's buffer (#2630).
+      |> clear_cmd_hover_link()
 
     update_in(ws.buffers, &Buffers.scrub_dead_active/1)
   end
@@ -308,6 +323,24 @@ defmodule MingaEditor.Session.State do
   @spec set_cmd_hover_link(t(), cmd_hover_link()) :: t()
   def set_cmd_hover_link(%__MODULE__{} = wspace, link) do
     %{wspace | cmd_hover_link: link}
+  end
+
+  @doc "Records the pointer cell the Cmd/Ctrl-hover link was last resolved at."
+  @spec set_cmd_hover_cell(t(), cmd_hover_cell()) :: t()
+  def set_cmd_hover_cell(%__MODULE__{} = wspace, cell) do
+    %{wspace | cmd_hover_cell: cell}
+  end
+
+  @doc """
+  Clears the Cmd/Ctrl-hover link preview and its dedup cell.
+
+  Called on transitions that change the active buffer without a mouse motion (tab
+  switch, window focus, go-to-definition navigation) so a stale underline never
+  lingers against the new buffer's coordinates.
+  """
+  @spec clear_cmd_hover_link(t()) :: t()
+  def clear_cmd_hover_link(%__MODULE__{} = wspace) do
+    %{wspace | cmd_hover_link: nil, cmd_hover_cell: nil}
   end
 
   @doc "Updates the search sub-struct."

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -614,6 +614,18 @@ defmodule MingaEditor.State do
     update_workspace(state, &SessionState.set_cmd_hover_link(&1, link))
   end
 
+  @doc "Records the pointer cell the Cmd/Ctrl-hover link was last resolved at."
+  @spec set_cmd_hover_cell(t(), SessionState.cmd_hover_cell()) :: t()
+  def set_cmd_hover_cell(%__MODULE__{} = state, cell) do
+    update_workspace(state, &SessionState.set_cmd_hover_cell(&1, cell))
+  end
+
+  @doc "Clears the Cmd/Ctrl-hover link preview and its dedup cell."
+  @spec clear_cmd_hover_link(t()) :: t()
+  def clear_cmd_hover_link(%__MODULE__{} = state) do
+    update_workspace(state, &SessionState.clear_cmd_hover_link/1)
+  end
+
   @doc "Replaces the active workspace LSP pending request map."
   @spec set_lsp_pending(t(), %{reference() => atom() | tuple()}) :: t()
   def set_lsp_pending(%__MODULE__{} = state, pending) when is_map(pending) do
@@ -2230,7 +2242,12 @@ defmodule MingaEditor.State do
               wspace
               | windows: %{ws | map: windows, active: target_id},
                 buffers: %{buffers | active: target_win.buffer},
-                keymap_scope: scope
+                keymap_scope: scope,
+                # Focusing another window can swap the active buffer; drop any
+                # standing Cmd/Ctrl-hover link so it never draws against the new
+                # buffer's coordinates before the next motion (#2630).
+                cmd_hover_link: nil,
+                cmd_hover_cell: nil
             }
         }
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -77,6 +77,9 @@ defmodule MingaEditor.State do
   @typedoc "A document highlight range from the LSP server."
   @type document_highlight :: Minga.LSP.DocumentHighlight.t()
 
+  @typedoc "Transient Cmd/Ctrl-hover go-to-definition link range, or nil."
+  @type cmd_hover_link :: SessionState.cmd_hover_link()
+
   @typedoc "Re-export of `Minga.Keymap.server/0` for editor-state callers."
   @type keymap_server :: Minga.Keymap.server()
 
@@ -603,6 +606,12 @@ defmodule MingaEditor.State do
   @spec set_document_highlights(t(), [document_highlight()] | nil) :: t()
   def set_document_highlights(%__MODULE__{} = state, highlights) do
     update_workspace(state, &SessionState.set_document_highlights(&1, highlights))
+  end
+
+  @doc "Replaces the transient Cmd/Ctrl-hover go-to-definition link range."
+  @spec set_cmd_hover_link(t(), cmd_hover_link()) :: t()
+  def set_cmd_hover_link(%__MODULE__{} = state, link) do
+    update_workspace(state, &SessionState.set_cmd_hover_link(&1, link))
   end
 
   @doc "Replaces the active workspace LSP pending request map."

--- a/lib/minga_editor/state/tab/context.ex
+++ b/lib/minga_editor/state/tab/context.ex
@@ -40,6 +40,16 @@ defmodule MingaEditor.State.Tab.Context do
 
   @workspace_fields @snapshot_fields ++ @shared_fields
 
+  # Transient pointer state that is deliberately NOT carried per tab. The
+  # Cmd/Ctrl-hover go-to-definition link preview (#2630) tracks the symbol under
+  # the mouse for the current frame only; snapshotting it would restore a stale
+  # underline (and GUI hand cursor) against the wrong buffer on tab switch, which
+  # is exactly what the clear-on-transition design avoids. Listed here so the
+  # "tab context carries every session workspace field" guard stays meaningful:
+  # a new NON-transient workspace field still fails that test until it is added
+  # to @snapshot_fields/@shared_fields above.
+  @transient_fields [:cmd_hover_link, :cmd_hover_cell]
+
   @typedoc "Workspace fields carried by a tab context."
   @type field_name ::
           :keymap_scope
@@ -105,6 +115,16 @@ defmodule MingaEditor.State.Tab.Context do
   @doc "Returns the workspace field names represented by this context."
   @spec field_names() :: [field_name()]
   def field_names, do: @workspace_fields
+
+  @doc """
+  Returns workspace fields intentionally excluded from per-tab snapshotting.
+
+  These are transient pointer/frame state (#2630), never persisted or restored.
+  Together with `field_names/0` they must account for every `Session.State`
+  field; the `feature_state_test` guard enforces that.
+  """
+  @spec transient_fields() :: [atom()]
+  def transient_fields, do: @transient_fields
 
   @doc "Returns an empty context for a brand-new tab with no saved workspace yet."
   @spec empty() :: t()

--- a/lib/minga_editor/ui/theme.ex
+++ b/lib/minga_editor/ui/theme.ex
@@ -110,7 +110,8 @@ defmodule MingaEditor.UI.Theme do
       :selection_bg,
       :whitespace_fg,
       :indent_guide_fg,
-      :indent_guide_active_fg
+      :indent_guide_active_fg,
+      :link_fg
     ]
 
     @type t :: %__MODULE__{
@@ -126,7 +127,8 @@ defmodule MingaEditor.UI.Theme do
             selection_bg: MingaEditor.UI.Theme.color() | nil,
             whitespace_fg: MingaEditor.UI.Theme.color() | nil,
             indent_guide_fg: MingaEditor.UI.Theme.color() | nil,
-            indent_guide_active_fg: MingaEditor.UI.Theme.color() | nil
+            indent_guide_active_fg: MingaEditor.UI.Theme.color() | nil,
+            link_fg: MingaEditor.UI.Theme.color() | nil
           }
   end
 

--- a/lib/minga_editor/ui/theme/builder.ex
+++ b/lib/minga_editor/ui/theme/builder.ex
@@ -226,7 +226,8 @@ defmodule MingaEditor.UI.Theme.Builder do
       selection_bg: p.semantic.selection_bg,
       whitespace_fg: p.base.muted,
       indent_guide_fg: p.base.subtle,
-      indent_guide_active_fg: p.base.muted
+      indent_guide_active_fg: p.base.muted,
+      link_fg: p.semantic.link
     }
   end
 

--- a/lib/minga_editor/ui/theme/doom_one.ex
+++ b/lib/minga_editor/ui/theme/doom_one.ex
@@ -57,7 +57,8 @@ defmodule MingaEditor.UI.Theme.DoomOne do
         selection_bg: 0x264F78,
         whitespace_fg: @base5,
         indent_guide_fg: 0x3B3F4C,
-        indent_guide_active_fg: 0x5C6370
+        indent_guide_active_fg: 0x5C6370,
+        link_fg: 0x61AFEF
       },
       gutter: %MingaEditor.UI.Theme.Gutter{
         fg: @base5,

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -304,6 +304,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if nsView.hasActiveScrollGesture { return }
             nsView.resetSmoothScrollState()
         }
+        // Go-to-definition link cursor (#2630): the BEAM toggles the pointing-hand
+        // cursor when Cmd+hover lands on a navigable symbol.
+        disp.onLinkCursorChanged = { [weak nsView] active in
+            nsView?.setLinkCursorActive(active)
+        }
         nsView.guiState = appState.gui
         nsView.statusBarState = appState.gui.statusBarState
         appState.gui.settingsState.encoder = enc

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -185,6 +185,9 @@ enum RenderCommand: Sendable {
     case setCursorShape(CursorShape)
     case setTitle(String)
     case setWindowBg(r: UInt8, g: UInt8, b: UInt8)
+    /// set_link_cursor (0x19, #2630): toggles the go-to-definition pointing-hand
+    /// cursor while a Cmd+hover link preview is shown. `active` is the 1-byte body.
+    case setLinkCursor(active: Bool)
     /// protocol_error (0x18): the BEAM rejected this frontend's handshake
     /// protocol_version, so it carries a UTF-8 reason the frontend shows as a
     /// blocking error instead of decoding a stream it cannot parse (ticket
@@ -399,6 +402,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
     case OP_SET_WINDOW_BG:
         guard data.count >= rest + 3 else { throw ProtocolDecodeError.malformed }
         return (.setWindowBg(r: data[rest], g: data[rest + 1], b: data[rest + 2]), 4)
+
+    case OP_SET_LINK_CURSOR:
+        guard data.count >= rest + 1 else { throw ProtocolDecodeError.malformed }
+        return (.setLinkCursor(active: data[rest] != 0), 2)
 
     // Config commands.
     case OP_SET_FONT:

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -81,6 +81,10 @@ final class CommandDispatcher {
     /// Called when the BEAM sends a window background color (RGB).
     var onWindowBgChanged: ((NSColor) -> Void)?
 
+    /// Called when the BEAM toggles the go-to-definition link cursor (#2630).
+    /// `true` shows the pointing-hand cursor for a navigable Cmd+hover symbol.
+    var onLinkCursorChanged: ((Bool) -> Void)?
+
     /// Called when the BEAM sends a font configuration change.
     /// Parameters: family, size, ligatures, weight byte.
     var onFontChanged: ((String, UInt16, Bool, UInt8) -> Void)?
@@ -195,12 +199,13 @@ final class CommandDispatcher {
         // transaction it stages for atomic replay; outside one it applies
         // immediately. Mirrors Go's explicit match arms at model.go:444-450.
         //
-        // setTitle / setWindowBg / clipboardWrite: post-commit side-channels.
+        // setTitle / setWindowBg / setLinkCursor / clipboardWrite: post-commit
+        //   side-channels.
         // protocolError: handshake rejection, always pre-transaction.
         // setFont / setFontFallback / registerFont / guiConfigState: startup
         //   config emitted before the first frame (equivalent to Go's CommandNoop
         //   for font commands, but Swift actually applies them).
-        case .setTitle, .setWindowBg, .protocolError,
+        case .setTitle, .setWindowBg, .setLinkCursor, .protocolError,
              .setFont, .setFontFallback, .registerFont,
              .guiConfigState, .clipboardWrite:
             if openFrameSeq != nil {
@@ -533,6 +538,9 @@ final class CommandDispatcher {
             )
             PortLogger.info("Window bg received: r=\(r) g=\(g) b=\(b)")
             onWindowBgChanged?(color)
+
+        case .setLinkCursor(let active):
+            onLinkCursorChanged?(active)
 
         case .protocolError(let message):
             // The BEAM rejected this frontend's handshake protocol_version, so

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -80,6 +80,14 @@ final class EditorNSView: MTKView {
     /// Current resize cursor pushed for split divider hover or drag.
     private var dividerCursorState: DividerCursorState = .none
 
+    /// Whether the BEAM currently reports a navigable go-to-definition symbol
+    /// under the pointer (Cmd+hover, #2630). Drives the pointing-hand cursor.
+    private var linkCursorActive = false
+
+    /// Last observed Command-key state, so `flagsChanged` only re-sends a motion
+    /// event when Cmd is pressed or released (not for other modifier changes).
+    private var lastCommandHeld = false
+
     /// Divider direction captured at mouse-down so drag keeps the resize cursor.
     private var dividerDragState: DividerCursorState = .none
 
@@ -1099,7 +1107,40 @@ final class EditorNSView: MTKView {
     }
 
     override func flagsChanged(with event: NSEvent) {
-        // No action needed for bare modifier presses.
+        // Cmd press/release while the pointer is stationary still needs to update
+        // the go-to-definition link preview (#2630): pressing Cmd over a symbol
+        // should underline it and show the hand cursor, and releasing Cmd should
+        // clear both. AppKit delivers a flagsChanged (not a mouseMoved) for this,
+        // so re-send a motion at the current pointer to let the BEAM recompute.
+        let commandHeld = event.modifierFlags.contains(.command)
+        guard commandHeld != lastCommandHeld else { return }
+        lastCommandHeld = commandHeld
+        resendMotionForModifierChange(event)
+    }
+
+    /// Re-sends a free MOUSE_MOTION at the current pointer cell with the latest
+    /// modifier bits. Used when the Command key toggles without pointer movement
+    /// so the BEAM can (re)resolve the Cmd+hover link preview (#2630).
+    private func resendMotionForModifierChange(_ event: NSEvent) {
+        let rawPoint = convert(event.locationInWindow, from: nil)
+        guard bounds.contains(rawPoint) else { return }
+        let (row, col) = cellPosition(from: event)
+        encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_NONE,
+                               modifiers: modifierBits(from: event.modifierFlags),
+                               eventType: MOUSE_MOTION)
+    }
+
+    /// Shows or hides the pointing-hand cursor for a navigable Cmd+hover symbol
+    /// (#2630). Driven by the BEAM's `set_link_cursor` command via the dispatcher.
+    /// Uses the same guarded push/pop discipline as the split-divider cursor.
+    func setLinkCursorActive(_ active: Bool) {
+        guard linkCursorActive != active else { return }
+        linkCursorActive = active
+        if active {
+            NSCursor.pointingHand.push()
+        } else {
+            NSCursor.pop()
+        }
     }
 
     // MARK: - Space leader helpers

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -105,6 +105,30 @@ struct ProtocolDecoderTests {
         #expect(seq == 0x0000_102A)
     }
 
+    @Test("Decode set_link_cursor active command (#2630)")
+    func decodeSetLinkCursorActive() throws {
+        let data = Data([OP_SET_LINK_CURSOR, 0x01])
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == 2)
+        guard case .setLinkCursor(let active) = cmd else {
+            Issue.record("Expected .setLinkCursor, got \(String(describing: cmd))")
+            return
+        }
+        #expect(active == true)
+    }
+
+    @Test("Decode set_link_cursor inactive command (#2630)")
+    func decodeSetLinkCursorInactive() throws {
+        let data = Data([OP_SET_LINK_CURSOR, 0x00])
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == 2)
+        guard case .setLinkCursor(let active) = cmd else {
+            Issue.record("Expected .setLinkCursor, got \(String(describing: cmd))")
+            return
+        }
+        #expect(active == false)
+    }
+
     @Test("Decode begin_frame command")
     func decodeBeginFrame() throws {
         // begin_frame (#2219): frame_seq:u32 + base_frame_seq:u32.

--- a/test/minga_editor/feature_state_test.exs
+++ b/test/minga_editor/feature_state_test.exs
@@ -63,7 +63,13 @@ defmodule MingaEditor.FeatureStateTest do
       |> Map.delete(:__struct__)
       |> Map.keys()
 
-    assert Enum.sort(TabContext.field_names()) == Enum.sort(workspace_fields)
+    # Every workspace field is either snapshotted per tab (TabContext.field_names/0)
+    # or an explicit, documented transient exclusion (TabContext.transient_fields/0,
+    # e.g. the #2630 Cmd/Ctrl-hover link). A new NON-transient field that is added
+    # to neither will fail this guard, which is the point.
+    accounted_fields = TabContext.field_names() ++ TabContext.transient_fields()
+
+    assert Enum.sort(accounted_fields) == Enum.sort(workspace_fields)
   end
 
   test "session helpers keep feature state scoped to tab snapshots" do

--- a/test/minga_editor/frontend/protocol_schema_test.exs
+++ b/test/minga_editor/frontend/protocol_schema_test.exs
@@ -70,7 +70,8 @@ defmodule MingaEditor.Frontend.ProtocolSchemaTest do
       set_cursor_shape: 0x15,
       set_title: 0x16,
       set_window_bg: 0x17,
-      protocol_error: 0x18
+      protocol_error: 0x18,
+      set_link_cursor: 0x19
     )
   end
 

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -461,6 +461,16 @@ defmodule MingaEditor.Frontend.ProtocolTest do
     end
   end
 
+  describe "set_link_cursor protocol (#2630)" do
+    test "encodes an active link cursor as opcode 0x19 with a 1 byte" do
+      assert <<0x19, 1>> = Protocol.encode_set_link_cursor(true)
+    end
+
+    test "encodes an inactive link cursor as opcode 0x19 with a 0 byte" do
+      assert <<0x19, 0>> = Protocol.encode_set_link_cursor(false)
+    end
+  end
+
   describe "set_font protocol" do
     test "encodes ligatures enabled with default weight" do
       encoded = Protocol.encode_set_font("JetBrains Mono", 14, true)

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -27,6 +27,7 @@ defmodule MingaEditor.MouseTest do
 
   @content_row 1
   @ctrl 0x02
+  @super 0x08
 
   describe "scrolling" do
     test "vertical scroll moves viewport without moving the cursor" do
@@ -671,6 +672,71 @@ defmodule MingaEditor.MouseTest do
       # hovering a symbol after closing a popup would never re-open one. Guards
       # against simplifying the dismiss branch down to just dismiss_hover_popup/1.
       assert state.workspace.mouse.hover_pos == {out_row, col}
+    end
+  end
+
+  describe "Cmd/Ctrl+hover link preview (#2630)" do
+    test "Cmd+motion over a symbol sets the link decoration on the full word range" do
+      {state, _buffer} = start_mouse_state("hello world\nfoo bar baz", width: 80)
+      {row, col} = buffer_screen_pos(state, 0, 8)
+
+      state = mouse(state, row, col, :none, :motion, @super)
+
+      # "world" spans bytes 6..10 inclusive; the decoration range is end-exclusive.
+      assert state.workspace.cmd_hover_link == {{0, 6}, {0, 11}}
+    end
+
+    test "releasing the modifier clears the link decoration" do
+      {state, _buffer} = start_mouse_state("hello world\nfoo bar baz", width: 80)
+      {row, col} = buffer_screen_pos(state, 0, 8)
+
+      state = mouse(state, row, col, :none, :motion, @super)
+      assert state.workspace.cmd_hover_link != nil
+
+      # Same position, modifier released: the preview clears immediately.
+      state = mouse(state, row, col, :none, :motion, 0)
+      assert state.workspace.cmd_hover_link == nil
+    end
+
+    test "moving onto whitespace while Cmd is held clears the link decoration" do
+      {state, _buffer} = start_mouse_state("hello world\nfoo bar baz", width: 80)
+      {word_row, word_col} = buffer_screen_pos(state, 0, 8)
+      {space_row, space_col} = buffer_screen_pos(state, 0, 5)
+
+      state = mouse(state, word_row, word_col, :none, :motion, @super)
+      assert state.workspace.cmd_hover_link != nil
+
+      state = mouse(state, space_row, space_col, :none, :motion, @super)
+      assert state.workspace.cmd_hover_link == nil
+    end
+
+    test "Cmd+motion over whitespace sets no link decoration" do
+      {state, _buffer} = start_mouse_state("hello world\nfoo bar baz", width: 80)
+      {row, col} = buffer_screen_pos(state, 0, 5)
+
+      state = mouse(state, row, col, :none, :motion, @super)
+
+      assert state.workspace.cmd_hover_link == nil
+    end
+
+    test "Ctrl+motion previews the link on the TUI" do
+      {state, _buffer} = start_mouse_state("hello world\nfoo bar baz", width: 80)
+      state = set_capabilities(state, :tui)
+      {row, col} = buffer_screen_pos(state, 0, 8)
+
+      state = mouse(state, row, col, :none, :motion, @ctrl)
+
+      assert state.workspace.cmd_hover_link == {{0, 6}, {0, 11}}
+    end
+
+    test "Ctrl+motion does not preview on native GUI (context-menu modifier)" do
+      {state, _buffer} = start_mouse_state("hello world\nfoo bar baz", width: 80)
+      state = set_capabilities(state, :native_gui)
+      {row, col} = buffer_screen_pos(state, 0, 8)
+
+      state = mouse(state, row, col, :none, :motion, @ctrl)
+
+      assert state.workspace.cmd_hover_link == nil
     end
   end
 

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -738,6 +738,65 @@ defmodule MingaEditor.MouseTest do
 
       assert state.workspace.cmd_hover_link == nil
     end
+
+    test "Cmd+click go-to-definition clears the link preview before navigating" do
+      {state, _buffer} = start_mouse_state("hello world\nfoo bar baz", width: 80)
+      {row, col} = buffer_screen_pos(state, 0, 8)
+
+      state = mouse(state, row, col, :none, :motion, @super)
+      assert state.workspace.cmd_hover_link != nil
+
+      # Cmd+click navigates (possibly to another buffer); the stale underline and
+      # GUI hand cursor (derived from cmd_hover_link != nil) must clear.
+      state = mouse(state, row, col, :left, :press, @super)
+      assert state.workspace.cmd_hover_link == nil
+      assert state.workspace.cmd_hover_cell == nil
+    end
+
+    test "switching tabs clears a standing link preview" do
+      {state, _buf1, _buf2} = start_two_tab_state()
+      [first_tab_id | _] = Enum.map(state.shell_state.tab_bar.tabs, & &1.id)
+      {row, col} = buffer_screen_pos(state, 0, 2)
+
+      state = mouse(state, row, col, :none, :motion, @super)
+      assert state.workspace.cmd_hover_link != nil
+
+      # A keyboard tab switch swaps the active buffer with no intervening motion;
+      # the link preview must not carry over to the new buffer's coordinates.
+      state = EditorState.switch_tab(state, first_tab_id)
+      assert state.workspace.cmd_hover_link == nil
+      assert state.workspace.cmd_hover_cell == nil
+    end
+
+    test "focusing another window clears a standing link preview" do
+      {state, _buffer} = start_mouse_state("hello world\nfoo bar baz", width: 80)
+      state = Movement.execute(state, :split_vertical)
+      {row, col} = buffer_screen_pos(state, 0, 8)
+
+      state = mouse(state, row, col, :none, :motion, @super)
+      assert state.workspace.cmd_hover_link != nil
+
+      other_id =
+        Enum.find(Map.keys(state.workspace.windows.map), &(&1 != state.workspace.windows.active))
+
+      state = EditorState.focus_window(state, other_id)
+      assert state.workspace.cmd_hover_link == nil
+      assert state.workspace.cmd_hover_cell == nil
+    end
+
+    test "a repeated motion at the same cell preserves the link without re-resolving" do
+      {state, _buffer} = start_mouse_state("hello world\nfoo bar baz", width: 80)
+      {row, col} = buffer_screen_pos(state, 0, 8)
+
+      state = mouse(state, row, col, :none, :motion, @super)
+      assert state.workspace.cmd_hover_link == {{0, 6}, {0, 11}}
+      assert state.workspace.cmd_hover_cell == {row, col}
+
+      # Same cell again: the dedup short-circuit returns unchanged state.
+      again = mouse(state, row, col, :none, :motion, @super)
+      assert again.workspace.cmd_hover_link == state.workspace.cmd_hover_link
+      assert again.workspace.cmd_hover_cell == {row, col}
+    end
   end
 
   # Builds a state with an open hover popup and returns its placed screen rect.

--- a/test/minga_editor/render_pipeline/content_helpers_test.exs
+++ b/test/minga_editor/render_pipeline/content_helpers_test.exs
@@ -279,4 +279,58 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
       assert highlight.style.bg == 0x123456
     end
   end
+
+  describe "merge_cmd_hover_link_decoration/4 (#2630)" do
+    setup do
+      %{theme: Theme.get!(Theme.default())}
+    end
+
+    test "underlines the word range in the theme link color", %{theme: theme} do
+      assert theme.editor.link_fg != nil, "builder themes must define an editor link color"
+
+      {result, _cache} =
+        ContentHelpers.merge_cmd_hover_link_decoration(
+          Decorations.new(),
+          {{0, 6}, {0, 11}},
+          theme,
+          nil
+        )
+
+      [highlight] = Decorations.highlights_for_line(result, 0)
+      assert highlight.group == :cmd_hover_link
+      assert highlight.start == {0, 6}
+      assert highlight.end_ == {0, 11}
+      assert highlight.style.underline == true
+      assert highlight.style.fg == theme.editor.link_fg
+    end
+
+    test "a nil link clears any standing link decoration", %{theme: theme} do
+      {with_link, cache} =
+        ContentHelpers.merge_cmd_hover_link_decoration(
+          Decorations.new(),
+          {{0, 6}, {0, 11}},
+          theme,
+          nil
+        )
+
+      assert Decorations.highlights_for_line(with_link, 0) != []
+
+      {cleared, _cache} =
+        ContentHelpers.merge_cmd_hover_link_decoration(with_link, nil, theme, cache)
+
+      assert Decorations.highlights_for_line(cleared, 0) == []
+    end
+
+    test "an unchanged link reuses the cached decorations", %{theme: theme} do
+      decs = Decorations.new()
+      link = {{0, 6}, {0, 11}}
+
+      {result1, cache1} = ContentHelpers.merge_cmd_hover_link_decoration(decs, link, theme, nil)
+
+      {result2, _cache2} =
+        ContentHelpers.merge_cmd_hover_link_decoration(decs, link, theme, cache1)
+
+      assert result2 == result1
+    end
+  end
 end

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -44,6 +44,7 @@ pub const OP_COMMIT_FRAME = opcodes.OP_COMMIT_FRAME;
 pub const OP_SET_CURSOR_SHAPE = opcodes.OP_SET_CURSOR_SHAPE;
 pub const OP_SET_TITLE = opcodes.OP_SET_TITLE;
 pub const OP_SET_WINDOW_BG = opcodes.OP_SET_WINDOW_BG;
+pub const OP_SET_LINK_CURSOR = opcodes.OP_SET_LINK_CURSOR;
 pub const OP_PROTOCOL_ERROR = opcodes.OP_PROTOCOL_ERROR;
 
 // Config


### PR DESCRIPTION
## Summary

Holding **Cmd** (macOS) / **Ctrl** (TUI) while hovering a symbol now previews go-to-definition: the full symbol is **underlined in the theme link/accent color**, and on macOS the pointer becomes `NSCursor.pointingHand`. Releasing the modifier or moving off a navigable symbol clears it immediately. Closes #2630.

> ⚠️ **Stacks on #2629** (sticky hover popup, PR #2644). Base is `feat/sticky-hover-popup`, not `main`. This branch already contains #2629's changes and **extends** the same `:none`-button motion handler in `mouse.ex` rather than replacing it, so #2629's popup hit-test and keep-alive are fully preserved (the link preview and the LSP hover popup are independent layers).

## How navigability is resolved without per-motion LSP spam

On the mouse-motion path, only when the go-to-definition modifier is held, navigability is decided **entirely locally** — no `textDocument/definition` request, no debounced probe:

1. an identifier byte sits under the pointer (ASCII word char or any non-ASCII byte),
2. the **tree-sitter scope** at that position is `:code` (not a comment or string), read from the already-cached `Highlight` spans the renderer holds, and
3. an inner-word text object resolves (reusing `word_boundaries_at` / `Editing.select_inner_word`).

This reuses cached parser/highlight data already in state, so it adds no GenServer round-trips on the hot path and cannot regress input responsiveness. The work only runs while the modifier is held, and the decoration state is only written when the resolved word range actually changes.

## How the decoration is applied and cleared

- The resolved word range is stored on a new transient field `workspace.cmd_hover_link` (`{start, end_exclusive}` | `nil`), owned by `Session.State`, never snapshotted per-tab.
- The render pipeline merges it into the window decorations as a transient underline highlight (group `:cmd_hover_link`) using the theme link color, via the **same cached pattern as document highlights** (`ContentHelpers.merge_cmd_hover_link_decoration/4`). An unchanged preview hits the cache and never rebuilds decorations, so it never forces an idle re-render.
- It clears when the modifier is released or the pointer leaves a navigable symbol (non-modifier or non-navigable motion sets it back to `nil`), and naturally follows scroll because it lives in buffer coordinates.

## Per-frontend changes

**BEAM**
- `mouse.ex`: extended the motion handler with Cmd/Super (all frontends) and Ctrl (TUI only; Ctrl on native GUI keeps context-menu semantics) link resolution.
- `session/state.ex`, `state.ex`: new `cmd_hover_link` field + setter; `render_pipeline/input.ex` carries it into the pipeline.
- `content_helpers.ex` + `renderer/caches.ex`: cached transient underline-decoration merge in the theme link color.
- Theme: added `editor.link_fg` (builder `p.semantic.link`, doom_one `0x61AFEF`), with a blue fallback.

**macOS (GUI-first)**
- New lightweight `set_link_cursor` opcode (`0x19`, `fixed:2`) emitted out-of-band post-commit, mirroring `set_title`/`set_window_bg` (edge-triggered, GUI-only). `protocol_version` bumped to **8**.
- `EditorNSView` toggles `NSCursor.pointingHand` and re-sends a motion on `flagsChanged`, so pressing/releasing Cmd updates the preview without moving the pointer. Wired through `CommandDispatcher.onLinkCursorChanged` and the out-of-band allowlist.

**Go TUI**
- No hand-written code changes: Ctrl already rides on motion modifiers and the underline attr already renders, so the decoration appears automatically. The cursor hint is GUI-only; the TUI sizes-and-skips the new opcode (generated `command_size.go`).

## Validation

- `mix test` mouse / hover / decoration / render_pipeline / frontend / theme / snapshot / protocol suites — all green (incl. #2629's existing hover tests; no regressions).
- New tests: Cmd+motion sets the underline on the full word range; modifier-release and move-to-whitespace clear it; whitespace sets nothing; Ctrl maps to the same on TUI but not on native GUI; the decoration uses the theme link color + underline; `set_link_cursor` encode/decode round-trip (Elixir + Swift).
- `mix swift.build` + Swift `ProtocolDecoderTests` (21 pass, incl. new `setLinkCursor` cases).
- `go build ./...` + `go test ./...` (516 pass).
- `mix protocol.gen --check`, `make lint` (credo + dialyzer) — green.

## Risks / notes

- New protocol opcode + `protocol_version` 8: BEAM and both frontends regenerate from the schema together, so the handshake stays matched; a stale frontend build correctly gets a `protocol_error`.
- Edge case: if an LSP hover popup is open and the user holds Cmd while moving over the buffer (not the popup), the popup lingers until the next non-Cmd motion, since the cmd-hover layer intentionally does not touch the popup. Minor and self-correcting.
- Plain/unparsed buffers degrade scope to `:code`, so a word may underline even without an LSP; clicking is harmless (`No language server`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)