### PR TITLE
feat(macos): full-shell ContentView SwiftUI canvas preview (#2648)

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -37,7 +37,7 @@
 		2189892352237ED1153E70F2 /* MingaUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2198A76504E5C0A41209CF57 /* EditTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE173FAAAC37ACFF47EE03B8 /* EditTimelineView.swift */; };
 		22EFBD4416697A01FDC9C2AD /* ProtocolCommandSize.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762CD389E04B0DE6A86CDBF2 /* ProtocolCommandSize.generated.swift */; };
-		236A0542773564BED642D5AD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84218125A9F97DBE87F349 /* ContentView.swift */; };
+		2388D1CC8878556958DA4A0D /* EditorGeometry+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */; };
 		23DA463A92D1EC2F7BFA5B5A /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
 		25D865A5AD887E5F31FA162D /* LatencyHUDStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA53378E05335BC93B342123 /* LatencyHUDStateTests.swift */; };
@@ -52,7 +52,6 @@
 		2DFDA6E32CE61E6D89341423 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912C5F808709BABFF3126DEE /* AppearanceSettingsView.swift */; };
 		2F0A0D75FA309989C48B32EF /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		2FE07FE013FC3DE8FD01DF39 /* BottomPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A583EB0DCE480D1A5FC7E440 /* BottomPanelState.swift */; };
-		2FF702C4573CDB88FD43AF15 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84218125A9F97DBE87F349 /* ContentView.swift */; };
 		30AF3AD9C1C7F46956940CEC /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
 		30E31170A79F30413D15D858 /* GUIChromeDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */; };
 		310AFFC13B7C85D248C21371 /* InlineEditField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DCF10EBEB51624A4A1F428 /* InlineEditField.swift */; };
@@ -114,6 +113,7 @@
 		6C48A19EB071FA951E15B3D9 /* PreviewRegistry+Chrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF40BCB1722FAD446E1E6E52 /* PreviewRegistry+Chrome.swift */; };
 		6CF0F1BB4E1BDC0182EDCCB1 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
 		6DC4EDE61F449DC8AFF50B20 /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764F85CBFE17A90A0A61F2B6 /* StatusBarView.swift */; };
+		6DC89F81DBC022B3FCBA39BB /* EditorGeometry+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */; };
 		6EE7C16703E92B31CC9CE9C0 /* NonBlockingEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3DDF1EB804D4E31EDFA519 /* NonBlockingEncoderTests.swift */; };
 		6EE844B0AA477984A99FF81A /* MingaUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6F4588B8EB30D91E05176E9E /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25503C21E0D55E1515A38C7D /* ScrollAccumulator.swift */; };
@@ -164,7 +164,6 @@
 		986CED792328DA9C1B22BF84 /* PreviewRegistry+GitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB5DAD0EAB1AE583E45AF5C /* PreviewRegistry+GitStatus.swift */; };
 		9AA31CF152E2CD33E4BD2098 /* MingaProtocol.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 848E04E4F242C861887769F3 /* MingaProtocol.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9B328F29A48C7C7EC810CB1B /* AgentApprovalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492285F3371798B69478BF13 /* AgentApprovalCard.swift */; };
-		9BA59A1D924999EEC65EEBCC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84218125A9F97DBE87F349 /* ContentView.swift */; };
 		9C0676A96179F6068B85CCA1 /* RecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A6769D066EC44A58791CFC /* RecoveryManager.swift */; };
 		9C5FE3A02B819B292912EA4C /* ObservatoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6CC43E02AE08773B90E8AC /* ObservatoryView.swift */; };
 		9CC563AE009A1EA1A0BE0D9F /* SettingsStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C02007D4036FC9C7D0FB71 /* SettingsStateTests.swift */; };
@@ -237,6 +236,7 @@
 		D486A1CE007AF228798286B7 /* SidebarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E34C34EC8FF8D20C141F2290 /* SidebarContainer.swift */; };
 		D5F45455932847E76CA9A4E4 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA08D322A0BCE2491D4489D /* MessagesContentView.swift */; };
 		D916997E44A9619D08995FDA /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048C53BF025A1476EE8BC1A7 /* IMEComposition.swift */; };
+		DA224DFB69915CFBFC50DDAE /* EditorGeometry+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */; };
 		DA2EDB0295FDA3FBF421E0E8 /* ToolManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C576F6F2E779DEEABFE79C /* ToolManagerView.swift */; };
 		DB4EE4C9D35A3CCEA80442D6 /* WorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EC68F918782FE2FCDB2413 /* WorkspaceState.swift */; };
 		DB83E9F1763A0D2E7BD7F7D3 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = BD2531C0969FD21CC18D2FDB /* ViewInspector */; };
@@ -248,6 +248,7 @@
 		E1601C8BE90E7A7CB8F7F5DA /* ResyncState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953A62EE436C9B1F73B97D07 /* ResyncState.swift */; };
 		E20D436BEA6628E24B9FFA2C /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		E27074789DFFC30C49DD40D0 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DB822E0C8D06C7B45D329F /* EditorNSView.swift */; };
+		E28B13C9D7A0CFE84CC086EB /* EditorGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C8650724242FD0A50EC3CA /* EditorGeometry.swift */; };
 		E2BC69E1121328310B830E45 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
 		E3B2DB94D802E1831C17474E /* PipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */; };
 		E4A2887CDB5EDB64080E5096 /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
@@ -264,6 +265,7 @@
 		F0A2BCCA095F1CA4FBE9BE3F /* ProtocolSchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */; };
 		F12D6284209D6D32037E6644 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
 		F3BB64E36F257BD7FACEA5D6 /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
+		F3C4A9DABEF6FD369F8B1F45 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84218125A9F97DBE87F349 /* ContentView.swift */; };
 		F6F56719C285CB9C3EA62A57 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5647A59C841B3C408994CC7 /* Assets.xcassets */; };
 		F984C67E0F2861DE6A25DBD4 /* PreviewRegistry+GitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB5DAD0EAB1AE583E45AF5C /* PreviewRegistry+GitStatus.swift */; };
 		F986D696164E7D7483EF2DB4 /* PreviewRegistry+Overlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0D41B1D748FBFE7916342C /* PreviewRegistry+Overlays.swift */; };
@@ -384,6 +386,7 @@
 		10FA7BF770B3453A402B9F78 /* WhichKeyOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyOverlay.swift; sourceTree = "<group>"; };
 		120944B58F457FF6EEA773CA /* GitStatusHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusHeaderView.swift; sourceTree = "<group>"; };
 		124E376C3B8F6EC62765F5C1 /* CompletionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionState.swift; sourceTree = "<group>"; };
+		13C8650724242FD0A50EC3CA /* EditorGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorGeometry.swift; sourceTree = "<group>"; };
 		13E89640A29C207B9040DC67 /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
 		19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEncoderDisconnectTests.swift; sourceTree = "<group>"; };
 		1BA08D322A0BCE2491D4489D /* MessagesContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentView.swift; sourceTree = "<group>"; };
@@ -444,6 +447,7 @@
 		5A84E92F596D0DDF8FF11049 /* MinibufferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinibufferView.swift; sourceTree = "<group>"; };
 		5C6CC43E02AE08773B90E8AC /* ObservatoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservatoryView.swift; sourceTree = "<group>"; };
 		5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTextMetalRenderer.swift; sourceTree = "<group>"; };
+		5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditorGeometry+App.swift"; sourceTree = "<group>"; };
 		60980E90FDD864409144BA5B /* PickerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerState.swift; sourceTree = "<group>"; };
 		620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentRendererTests.swift; sourceTree = "<group>"; };
 		628AAE1DCC1D559B04B81E35 /* FileTreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowView.swift; sourceTree = "<group>"; };
@@ -794,6 +798,7 @@
 		B603D25CD10F75A12EA94237 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				13C8650724242FD0A50EC3CA /* EditorGeometry.swift */,
 				1BB45C5B630FDEDFD0BD6BE0 /* EditTimelineState.swift */,
 				EE173FAAAC37ACFF47EE03B8 /* EditTimelineView.swift */,
 				644384B6B8FE5F11CD0DB713 /* GUIState.swift */,
@@ -830,6 +835,7 @@
 				B9FC2118EA77254CBCAE7B0B /* AppState.swift */,
 				F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */,
 				8A84218125A9F97DBE87F349 /* ContentView.swift */,
+				5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */,
 				53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */,
 				4A647814918768E62822D4A1 /* MingaApp.swift */,
 				B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */,
@@ -1162,7 +1168,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"${SRCROOT}/..\"\nif ! command -v mix >/dev/null 2>&1; then\n  echo \"error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen\"\n  exit 1\nfi\nmix protocol.gen\n";
+			shellScript = "cd \"${SRCROOT}/..\"\nif ! command -v mix >/dev/null 2>&1; then\n  if [ -f macos/.generated/protocol/ProtocolOpcodes.generated.swift ]; then\n    echo \"warning: mix not found; reusing existing generated protocol artifacts (e.g. Xcode Preview build sandbox)\"\n    exit 0\n  fi\n  echo \"error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen\"\n  exit 1\nfi\nmix protocol.gen\n";
 		};
 		658E1AB9C3D7AAE877712688 /* Generate protocol opcodes */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1184,7 +1190,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"${SRCROOT}/..\"\nif ! command -v mix >/dev/null 2>&1; then\n  echo \"error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen\"\n  exit 1\nfi\nmix protocol.gen\n";
+			shellScript = "cd \"${SRCROOT}/..\"\nif ! command -v mix >/dev/null 2>&1; then\n  if [ -f macos/.generated/protocol/ProtocolOpcodes.generated.swift ]; then\n    echo \"warning: mix not found; reusing existing generated protocol artifacts (e.g. Xcode Preview build sandbox)\"\n    exit 0\n  fi\n  echo \"error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen\"\n  exit 1\nfi\nmix protocol.gen\n";
 		};
 		77AE57735A00C26BF1B3675A /* Generate protocol opcodes */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1203,7 +1209,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"${SRCROOT}/..\"\nif ! command -v mix >/dev/null 2>&1; then\n  echo \"error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen\"\n  exit 1\nfi\nmix protocol.gen\n";
+			shellScript = "cd \"${SRCROOT}/..\"\nif ! command -v mix >/dev/null 2>&1; then\n  if [ -f macos/.generated/protocol/ProtocolOpcodes.generated.swift ]; then\n    echo \"warning: mix not found; reusing existing generated protocol artifacts (e.g. Xcode Preview build sandbox)\"\n    exit 0\n  fi\n  echo \"error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen\"\n  exit 1\nfi\nmix protocol.gen\n";
 		};
 		DB4598C0910E3166689E6F1A /* Codesign */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1257,9 +1263,9 @@
 				18F0DDA03D08C0B4302DCCF4 /* BitmapRasterizer.swift in Sources */,
 				AFE31388980EE451C8F734A3 /* CachedLineTexture.swift in Sources */,
 				C44D9CF03C49E7BCA39A76A9 /* CommandDispatcher.swift in Sources */,
-				236A0542773564BED642D5AD /* ContentView.swift in Sources */,
 				23DA463A92D1EC2F7BFA5B5A /* CoreTextMetalRenderer.swift in Sources */,
 				16116567DD7218A82575360A /* CoreTextShaders.metal in Sources */,
+				DA224DFB69915CFBFC50DDAE /* EditorGeometry+App.swift in Sources */,
 				ED8592B57E8A2A3EAAE24295 /* EditorNSView.swift in Sources */,
 				281A9531103F9E962B3F31A7 /* EditorScrollTrack.swift in Sources */,
 				78621BB35169CCFF26C753DD /* EditorView.swift in Sources */,
@@ -1303,9 +1309,9 @@
 				932C189ED218AC16620D8C19 /* BitmapRasterizer.swift in Sources */,
 				5CF105289D5A9C9AD4B8548A /* CachedLineTexture.swift in Sources */,
 				45A352459C76907D8E4CB596 /* CommandDispatcher.swift in Sources */,
-				2FF702C4573CDB88FD43AF15 /* ContentView.swift in Sources */,
 				8FB0DF76DEB5112AD590BB11 /* CoreTextMetalRenderer.swift in Sources */,
 				1A7BC027E152504B67F6F418 /* CoreTextShaders.metal in Sources */,
+				6DC89F81DBC022B3FCBA39BB /* EditorGeometry+App.swift in Sources */,
 				E27074789DFFC30C49DD40D0 /* EditorNSView.swift in Sources */,
 				CE65FF332E03ED47ADFBA48E /* EditorScrollTrack.swift in Sources */,
 				BBFA84AD4053D2DDA336FBAF /* EditorView.swift in Sources */,
@@ -1378,8 +1384,10 @@
 				C3460BA2BBD420A4B37C4DFB /* ChangeSummaryView.swift in Sources */,
 				3CD15ED81AE384C93557B0C0 /* CompletionOverlay.swift in Sources */,
 				E8DAC5BD5013095E550BF4E8 /* CompletionState.swift in Sources */,
+				F3C4A9DABEF6FD369F8B1F45 /* ContentView.swift in Sources */,
 				2CFB39859AC1E448147D8C31 /* EditTimelineState.swift in Sources */,
 				2198A76504E5C0A41209CF57 /* EditTimelineView.swift in Sources */,
+				E28B13C9D7A0CFE84CC086EB /* EditorGeometry.swift in Sources */,
 				A9551F6F0EB19FB618A8DB3E /* EditorSettingsView.swift in Sources */,
 				537AA754C723E8F02ED14D32 /* ExtensionOverlayState.swift in Sources */,
 				E139B8F9FCA100EBDDC042AB /* ExtensionOverlayView.swift in Sources */,
@@ -1462,12 +1470,12 @@
 				07C32C28178AE5675ACF4539 /* CommandDispatcher.swift in Sources */,
 				28F3D7BFADCE4A2509D66C2B /* CommandDispatcherTests.swift in Sources */,
 				4A2ED658D250B02BE89A6A56 /* CompletionStateTests.swift in Sources */,
-				9BA59A1D924999EEC65EEBCC /* ContentView.swift in Sources */,
 				527C7DB557EFD09B3161BC20 /* CoreTextMetalRenderer.swift in Sources */,
 				BF89605C029E1F2F4EE328EA /* CoreTextMetalRendererCursorTests.swift in Sources */,
 				F3BB64E36F257BD7FACEA5D6 /* CoreTextShaders.metal in Sources */,
 				888A35D1348A7A3CAE935561 /* DecoderFuzzTests.swift in Sources */,
 				A6327C6FAB3DCFD57327FBF4 /* DecoderRobustnessTests.swift in Sources */,
+				2388D1CC8878556958DA4A0D /* EditorGeometry+App.swift in Sources */,
 				BCCC8F959EDD3B7C8525BA61 /* EditorNSView.swift in Sources */,
 				9D1D5E11F9839F86F7A7BA70 /* EditorScrollTrack.swift in Sources */,
 				B308ADA08963E550E47FCDED /* EditorScrollTrackTests.swift in Sources */,

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -134,52 +134,84 @@ struct StartupOverlay: View {
 /// The unified toolbar is a single row spanning the full window width,
 /// containing the sidebar header (project name/branch) and the tab bar.
 /// One shared background eliminates visual seams between sidebar and editor.
-struct ContentView: View {
-    var appState: AppState
+public struct ContentView<EditorSurface: View>: View {
+    let gui: GUIState
+    let encoder: InputEncoder?
+    /// Editor geometry read just-in-time inside the body. This is a closure (not
+    /// a stored value) so each read reflects the live editor metrics: a value
+    /// computed in MingaApp's body would go stale because MingaApp under-renders
+    /// relative to ContentView.
+    let editorGeometry: () -> EditorGeometry
+    /// Window chrome. A plain value is safe: its inputs are `@Observable` on
+    /// AppState, so it stays fresh across ContentView body re-evaluations.
+    let chrome: WindowChrome
+    /// Called when the agent chat visibility changes so the app can hide/show the
+    /// Metal editor NSView layer underneath the SwiftUI chat overlay.
+    let onAgentChatVisibleChange: (Bool) -> Void
+    @ViewBuilder let makeEditorSurface: () -> EditorSurface
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @State private var rightPaneHeight: CGFloat = 600
     @State private var workspaceWidth: CGFloat = 800
     @State private var sidebarWidth: CGFloat = SidebarSizing.defaultWidth
     @State private var changeSummaryWidth: CGFloat = 280
     @Namespace private var frontendExtensionNamespace
 
+    public init(
+        gui: GUIState,
+        encoder: InputEncoder?,
+        editorGeometry: @escaping () -> EditorGeometry,
+        chrome: WindowChrome,
+        onAgentChatVisibleChange: @escaping (Bool) -> Void,
+        @ViewBuilder makeEditorSurface: @escaping () -> EditorSurface
+    ) {
+        self.gui = gui
+        self.encoder = encoder
+        self.editorGeometry = editorGeometry
+        self.chrome = chrome
+        self.onAgentChatVisibleChange = onAgentChatVisibleChange
+        self.makeEditorSurface = makeEditorSurface
+    }
+
     private let activityBarWidth: CGFloat = 32
 
     private var showSidebarContent: Bool {
-        appState.gui.sidebarHostState.hasVisibleSidebar
+        gui.sidebarHostState.hasVisibleSidebar
     }
 
     private var showChangeSummary: Bool {
-        appState.gui.changeSummaryState.visible
+        gui.changeSummaryState.visible
     }
 
-    private var theme: ThemeColors { appState.gui.themeColors }
+    private var theme: ThemeColors { gui.themeColors }
 
     private var titleBarLeadingPadding: CGFloat {
-        appState.isFullScreen ? 10 : 84
+        chrome.isFullScreen ? 10 : 84
     }
 
     private var sidebarHeaderLeadingPadding: CGFloat {
-        appState.isFullScreen ? 12 : 36
+        chrome.isFullScreen ? 12 : 36
     }
 
     private var projectName: String {
-        if !appState.gui.fileTreeState.projectRoot.isEmpty {
-            return (appState.gui.fileTreeState.projectRoot as NSString).lastPathComponent
+        if !gui.fileTreeState.projectRoot.isEmpty {
+            return (gui.fileTreeState.projectRoot as NSString).lastPathComponent
         }
         return "Minga"
     }
 
     private var gitBranch: String {
-        appState.gui.statusBarState.gitBranch
+        gui.statusBarState.gitBranch
     }
 
     private var notificationCenterBottomInset: CGFloat {
         let statusBarHeight: CGFloat = 24
         let panelHeight: CGFloat
 
-        if appState.gui.bottomPanelState.visible {
+        if gui.bottomPanelState.visible {
             let maxPanelHeight = rightPaneHeight * 0.6
-            panelHeight = min(max(appState.gui.bottomPanelState.userHeight, 100), maxPanelHeight)
+            panelHeight = min(max(gui.bottomPanelState.userHeight, 100), maxPanelHeight)
         } else {
             panelHeight = 0
         }
@@ -187,7 +219,7 @@ struct ContentView: View {
         return statusBarHeight + panelHeight + 18
     }
 
-    var body: some View {
+    public var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 unifiedToolbar
@@ -200,21 +232,21 @@ struct ContentView: View {
             frontendExtensionRuntimeLayer
             windowOverlays
         }
-        .environment(\.themeColors, appState.gui.themeColors)
-        .navigationTitle(appState.windowTitle)
+        .environment(\.themeColors, gui.themeColors)
+        .navigationTitle(chrome.title)
         .ignoresSafeArea(.container, edges: .top)
-        .preferredColorScheme(appState.windowBgIsDark ? .dark : .light)
+        .preferredColorScheme(chrome.backgroundIsDark ? .dark : .light)
         .onAppear {
             applyActiveSidebarPreferredWidth()
         }
-        .onChange(of: appState.gui.sidebarHostState.activeSidebar) { _, _ in
+        .onChange(of: gui.sidebarHostState.activeSidebar) { _, _ in
             applyActiveSidebarPreferredWidth()
         }
     }
 
     private func applyActiveSidebarPreferredWidth() {
         sidebarWidth = SidebarSizing.widthByApplyingPreferred(
-            for: appState.gui.sidebarHostState.activeSidebar,
+            for: gui.sidebarHostState.activeSidebar,
             currentWidth: sidebarWidth
         )
     }
@@ -227,7 +259,7 @@ struct ContentView: View {
     private let workspaceHeaderHeight: CGFloat = 30
 
     private var showsWorkspaceHeader: Bool {
-        appState.gui.workspaceState.shouldShowHeader
+        gui.workspaceState.shouldShowHeader
     }
 
     private var toolbarContentHeight: CGFloat {
@@ -235,7 +267,7 @@ struct ContentView: View {
     }
 
     private var toolbarTopPadding: CGFloat {
-        max(appState.trafficLightMidY - contentHeight / 2, 0)
+        max(chrome.trafficLightMidY - contentHeight / 2, 0)
     }
 
     @ViewBuilder
@@ -262,15 +294,15 @@ struct ContentView: View {
                 VStack(spacing: 0) {
                     if showsWorkspaceHeader {
                         WorkspaceHeaderView(
-                            workspaceState: appState.gui.workspaceState,
-                            encoder: appState.encoder
+                            workspaceState: gui.workspaceState,
+                            encoder: encoder
                         )
                     }
 
-                    if !appState.gui.tabBarState.tabs.isEmpty || !appState.gui.workspaceState.visibleTabs.isEmpty {
+                    if !gui.tabBarState.tabs.isEmpty || !gui.workspaceState.visibleTabs.isEmpty {
                         TabBarView(
-                            tabBarState: appState.gui.tabBarState,
-                            encoder: appState.encoder
+                            tabBarState: gui.tabBarState,
+                            encoder: encoder
                         )
                         .accessibilityIdentifier("workspace-tabbar")
                     } else {
@@ -299,7 +331,7 @@ struct ContentView: View {
     /// Renders the header for the BEAM-selected semantic sidebar.
     @ViewBuilder
     private var sidebarHeaderContent: some View {
-        if let activeSidebar = appState.gui.sidebarHostState.activeSidebar {
+        if let activeSidebar = gui.sidebarHostState.activeSidebar {
             NativeSidebarRegistry
                 .adapterOrFallback(for: activeSidebar.semanticKind)
                 .makeHeader(sidebarContext, activeSidebar)
@@ -308,9 +340,9 @@ struct ContentView: View {
 
     private var sidebarContext: NativeSidebarContext {
         NativeSidebarContext(
-            guiState: appState.gui,
+            guiState: gui,
             theme: theme,
-            encoder: appState.encoder,
+            encoder: encoder,
             projectName: projectName,
             gitBranch: gitBranch,
             leadingPadding: sidebarHeaderLeadingPadding
@@ -351,16 +383,16 @@ struct ContentView: View {
     private var sidebarBody: some View {
         HStack(spacing: 0) {
             ActivityBar(
-                guiState: appState.gui,
-                sidebarHostState: appState.gui.sidebarHostState,
-                encoder: appState.encoder
+                guiState: gui,
+                sidebarHostState: gui.sidebarHostState,
+                encoder: encoder
             )
 
-            if let activeSidebar = appState.gui.sidebarHostState.activeSidebar {
+            if let activeSidebar = gui.sidebarHostState.activeSidebar {
                 SidebarContainer(
-                    guiState: appState.gui,
+                    guiState: gui,
                     activeSidebar: activeSidebar,
-                    encoder: appState.encoder,
+                    encoder: encoder,
                     projectName: projectName,
                     gitBranch: gitBranch,
                     leadingPadding: titleBarLeadingPadding,
@@ -375,8 +407,8 @@ struct ContentView: View {
     @ViewBuilder
     private var changeSummarySidebar: some View {
         ChangeSummarySidebarView(
-            changeSummaryState: appState.gui.changeSummaryState,
-            encoder: appState.encoder,
+            changeSummaryState: gui.changeSummaryState,
+            encoder: encoder,
             width: $changeSummaryWidth
         )
     }
@@ -389,26 +421,26 @@ struct ContentView: View {
 
             // Conditionally show agent context bar (when zoomed into an agent card)
             // or breadcrumb bar (when in traditional editor or zoomed into You card)
-            if appState.gui.agentContextBarState.visible {
+            if gui.agentContextBarState.visible {
                 AgentContextBar(
-                    state: appState.gui.agentContextBarState,
-                    encoder: appState.encoder
+                    state: gui.agentContextBarState,
+                    encoder: encoder
                 )
             } else {
                 BreadcrumbBar(
-                    state: appState.gui.breadcrumbState,
-                    encoder: appState.encoder
+                    state: gui.breadcrumbState,
+                    encoder: encoder
                 )
             }
 
             // Search toolbar (appears below breadcrumb bar when active)
-            if appState.gui.searchState.visible {
+            if gui.searchState.visible {
                 SearchToolbar(
-                    searchState: appState.gui.searchState,
-                    encoder: appState.encoder
+                    searchState: gui.searchState,
+                    encoder: encoder
                 )
                 .transition(
-                    NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+                    reduceMotion
                         ? .opacity.animation(.easeInOut(duration: 0.1))
                         : .move(edge: .top)
                             .combined(with: .opacity)
@@ -426,21 +458,21 @@ struct ContentView: View {
 
                 extensionRightPanels
             }
-            .onChange(of: appState.gui.agentChatState.visible) { _, visible in
-                appState.editorNSView?.setAgentChatVisible(visible)
+            .onChange(of: gui.agentChatState.visible) { _, visible in
+                onAgentChatVisibleChange(visible)
             }
 
             // Edit timeline scrubber (between editor and bottom panel)
             EditTimelineView(
-                state: appState.gui.editTimelineState,
-                encoder: appState.encoder
+                state: gui.editTimelineState,
+                encoder: encoder
             )
 
             // Bottom panel (between editor and status bar)
-            if appState.gui.bottomPanelState.visible {
+            if gui.bottomPanelState.visible {
                 BottomPanelView(
-                    state: appState.gui.bottomPanelState,
-                    encoder: appState.encoder,
+                    state: gui.bottomPanelState,
+                    encoder: encoder,
                     availableHeight: rightPaneHeight
                 )
             }
@@ -449,13 +481,13 @@ struct ContentView: View {
             extensionBottomPanels
 
             // Native minibuffer (appears above status bar when active)
-            if appState.gui.minibufferState.visible {
+            if gui.minibufferState.visible {
                 MinibufferView(
-                    state: appState.gui.minibufferState,
-                    encoder: appState.encoder
+                    state: gui.minibufferState,
+                    encoder: encoder
                 )
                 .transition(
-                    NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+                    reduceMotion
                         ? .opacity.animation(.easeInOut(duration: 0.1))
                         : .move(edge: .bottom)
                             .combined(with: .opacity)
@@ -480,75 +512,61 @@ struct ContentView: View {
 
     // MARK: - Editor Surface (Metal + editor-local overlays)
 
-    private func completionOverlayCursor() -> (row: Int, col: Int, gutterPad: CGFloat) {
-        guard let nsView = appState.editorNSView else {
-            return (appState.gui.completionState.anchorRow, appState.gui.completionState.anchorCol, 0)
-        }
-
-        let frameState = nsView.dispatcher.frameState
+    private func completionOverlayCursor(_ geo: EditorGeometry) -> (row: Int, col: Int, gutterPad: CGFloat) {
+        let row = gui.completionState.anchorRow
+        let col = gui.completionState.anchorCol
         let gutterPad: CGFloat
-
-        if frameState.gutterCol > 0 {
-            if frameState.cursorCol >= frameState.gutterCol {
-                gutterPad = CoreTextMetalRenderer.gutterLeftMarginPt + CoreTextMetalRenderer.gutterRightGapPt
-            } else {
-                gutterPad = CoreTextMetalRenderer.gutterLeftMarginPt
-            }
+        if geo.gutterCol > 0 {
+            gutterPad = col >= geo.gutterCol ? geo.gutterLeftMargin + geo.gutterRightGap : geo.gutterLeftMargin
         } else {
             gutterPad = 0
         }
-
-        return (Int(frameState.cursorRow), Int(frameState.cursorCol), gutterPad)
+        return (row, col, gutterPad)
     }
 
     private var editorSurface: some View {
-        ZStack(alignment: .topLeading) {
+        let geo = editorGeometry()
+        return ZStack(alignment: .topLeading) {
             // Metal editor surface (always present for input handling).
             // Hidden when agent chat is visible so the SwiftUI chat overlay
             // is not occluded by the NSView layer (AppKit NSViews render
             // above SwiftUI views in a ZStack regardless of child order).
-            Group {
-                if let nsView = appState.editorNSView {
-                    EditorView(editorNSView: nsView)
-                } else {
-                    Color(red: 0.12, green: 0.12, blue: 0.14)
-                }
-            }
-            .opacity(appState.gui.agentChatState.visible ? 0 : 1)
+            makeEditorSurface()
+                .opacity(gui.agentChatState.visible ? 0 : 1)
 
-            if appState.gui.agentChatState.visible {
+            if gui.agentChatState.visible {
                 AgentChatView(
-                    state: appState.gui.agentChatState,
-                    isInsertMode: appState.gui.statusBarState.isInsertMode,
-                    encoder: appState.encoder,
-                    cellHeight: CGFloat(appState.editorNSView?.cellHeight ?? 16)
+                    state: gui.agentChatState,
+                    isInsertMode: gui.statusBarState.isInsertMode,
+                    encoder: encoder,
+                    cellHeight: geo.cellHeight
                 )
             }
 
             // Completion overlay (positioned at cursor)
-            if appState.gui.completionState.visible {
-                let cw = CGFloat(appState.editorNSView?.cellWidth ?? 8)
-                let ch = CGFloat(appState.editorNSView?.cellHeight ?? 16)
-                let cursor = completionOverlayCursor()
+            if gui.completionState.visible {
+                let cw = geo.cellWidth
+                let ch = geo.cellHeight
+                let cursor = completionOverlayCursor(geo)
                 let x = CGFloat(cursor.col) * cw + cursor.gutterPad
                 let y = (CGFloat(cursor.row) + 1) * ch
 
                 CompletionOverlay(
-                    state: appState.gui.completionState,
-                    encoder: appState.encoder
+                    state: gui.completionState,
+                    encoder: encoder
                 )
                 .offset(x: x, y: y)
             }
 
             // Overlay shared dimensions (computed once for all overlays)
-            let overlayCW = CGFloat(appState.editorNSView?.cellWidth ?? 8)
-            let overlayCH = CGFloat(appState.editorNSView?.cellHeight ?? 16)
-            let overlayVPW = CGFloat(appState.editorNSView?.bounds.width ?? 800)
+            let overlayCW = geo.cellWidth
+            let overlayCH = geo.cellHeight
+            let overlayVPW = geo.viewportWidth
 
             // Signature help overlay (lowest overlay z-order)
-            if appState.gui.signatureHelpState.visible {
+            if gui.signatureHelpState.visible {
                 SignatureHelpOverlay(
-                    state: appState.gui.signatureHelpState,
+                    state: gui.signatureHelpState,
                     cellWidth: overlayCW,
                     cellHeight: overlayCH,
                     viewportHeight: rightPaneHeight,
@@ -557,14 +575,14 @@ struct ContentView: View {
             }
 
             // Hover popup overlay (above signature help, below completion)
-            if appState.gui.hoverPopupState.visible {
+            if gui.hoverPopupState.visible {
                 HoverPopupOverlay(
-                    state: appState.gui.hoverPopupState,
+                    state: gui.hoverPopupState,
                     cellWidth: overlayCW,
                     cellHeight: overlayCH,
                     viewportHeight: rightPaneHeight,
                     viewportWidth: overlayVPW,
-                    encoder: appState.encoder
+                    encoder: encoder
                 )
             }
 
@@ -599,16 +617,17 @@ struct ContentView: View {
     /// active window's gutter column when pane geometry has not been retained yet.
     @ViewBuilder
     private var extensionOverlayLayer: some View {
-        if !appState.gui.extensionOverlayState.entries.isEmpty {
-            let cw = CGFloat(appState.editorNSView?.cellWidth ?? 8)
-            let ch = CGFloat(appState.editorNSView?.cellHeight ?? 16)
-            let frameGutterCols = appState.editorNSView?.dispatcher.frameState.gutterCol ?? 0
+        if !gui.extensionOverlayState.entries.isEmpty {
+            let geo = editorGeometry()
+            let cw = geo.cellWidth
+            let ch = geo.cellHeight
+            let frameGutterCols = UInt16(geo.gutterCol)
             let gutterPad: CGFloat = frameGutterCols > 0
-                ? CoreTextMetalRenderer.gutterLeftMarginPt + CoreTextMetalRenderer.gutterRightGapPt
+                ? geo.gutterLeftMargin + geo.gutterRightGap
                 : 0
 
-            ForEach(appState.gui.extensionOverlayState.windowIDs, id: \.self) { wid in
-                let content = appState.gui.windowContents[wid]
+            ForEach(gui.extensionOverlayState.windowIDs, id: \.self) { wid in
+                let content = gui.windowContents[wid]
                 let geometry = content?.paneGeometry
                 let scrollLeft = content?.scrollLeft ?? 0
                 let origin = Self.overlayContentOrigin(
@@ -621,7 +640,7 @@ struct ContentView: View {
                 )
 
                 ExtensionOverlayView(
-                    overlayState: appState.gui.extensionOverlayState,
+                    overlayState: gui.extensionOverlayState,
                     windowID: wid,
                     cellWidth: cw,
                     cellHeight: ch,
@@ -680,9 +699,9 @@ struct ContentView: View {
     /// the widest panel's requested size.
     @ViewBuilder
     private var extensionRightPanels: some View {
-        let panels = appState.gui.extensionPanelState.panels(forPosition: 1)
+        let panels = gui.extensionPanelState.panels(forPosition: 1)
         if !panels.isEmpty {
-            let cw = CGFloat(appState.editorNSView?.cellWidth ?? 8)
+            let cw = editorGeometry().cellWidth
             // Percent panels size against the stable editor-column width, not the editor
             // NSView (which is the surface left over after the panel takes space, causing
             // a 30% request to converge to ~23% and oscillate as layout settles).
@@ -713,9 +732,9 @@ struct ContentView: View {
     /// the tallest panel's requested size.
     @ViewBuilder
     private var extensionBottomPanels: some View {
-        let panels = appState.gui.extensionPanelState.panels(forPosition: 0)
+        let panels = gui.extensionPanelState.panels(forPosition: 0)
         if !panels.isEmpty {
-            let ch = CGFloat(appState.editorNSView?.cellHeight ?? 16)
+            let ch = editorGeometry().cellHeight
             let height = panels
                 .map { panelCrossSize($0, cellExtent: ch, basis: rightPaneHeight, minimum: 80) }
                 .max() ?? (rightPaneHeight * 0.4)
@@ -740,7 +759,7 @@ struct ContentView: View {
     /// Floating extension panels (position 2), centered over the workspace.
     @ViewBuilder
     private var extensionFloatPanels: some View {
-        let panels = appState.gui.extensionPanelState.panels(forPosition: 2)
+        let panels = gui.extensionPanelState.panels(forPosition: 2)
         if !panels.isEmpty {
             VStack(spacing: 12) {
                 ForEach(panels) { panel in
@@ -761,14 +780,14 @@ struct ContentView: View {
 
     private var statusBar: some View {
         StatusBarView(
-            state: appState.gui.statusBarState,
-            feedbackState: appState.gui.feedbackState,
-            encoder: appState.encoder,
-            isFileTreeVisible: appState.gui.fileTreeState.visible,
-            isGitStatusVisible: appState.gui.gitStatusState.visible,
-            isBottomPanelVisible: appState.gui.bottomPanelState.visible,
-            isAgentChatVisible: appState.gui.agentChatState.visible,
-            gitSyncing: appState.gui.gitStatusState.syncing
+            state: gui.statusBarState,
+            feedbackState: gui.feedbackState,
+            encoder: encoder,
+            isFileTreeVisible: gui.fileTreeState.visible,
+            isGitStatusVisible: gui.gitStatusState.visible,
+            isBottomPanelVisible: gui.bottomPanelState.visible,
+            isAgentChatVisible: gui.agentChatState.visible,
+            gitSyncing: gui.gitStatusState.syncing
         )
     }
 
@@ -776,9 +795,9 @@ struct ContentView: View {
 
     @ViewBuilder
     private var frontendExtensionRuntimeLayer: some View {
-        let context = FrontendExtensionViewContext(theme: appState.gui.themeColors, encoder: appState.encoder, namespace: frontendExtensionNamespace)
-        ForEach(appState.gui.frontendExtensions.activeExtensionIDs, id: \.self) { extensionID in
-            if let view = appState.gui.frontendExtensions.view(for: extensionID, context: context) {
+        let context = FrontendExtensionViewContext(theme: gui.themeColors, encoder: encoder, namespace: frontendExtensionNamespace)
+        ForEach(gui.frontendExtensions.activeExtensionIDs, id: \.self) { extensionID in
+            if let view = gui.frontendExtensions.view(for: extensionID, context: context) {
                 view
             }
         }
@@ -794,7 +813,7 @@ struct ContentView: View {
             HStack {
                 Spacer()
                 WhichKeyOverlay(
-                    state: appState.gui.whichKeyState
+                    state: gui.whichKeyState
                 )
                 Spacer()
             }
@@ -802,23 +821,24 @@ struct ContentView: View {
 
         // Picker overlay (floats over entire window)
         PickerOverlay(
-            state: appState.gui.pickerState,
-            encoder: appState.encoder
+            state: gui.pickerState,
+            encoder: encoder
         )
 
         // Tool manager overlay (floats over entire window)
         ToolManagerView(
-            state: appState.gui.toolManagerState,
-            encoder: appState.encoder
+            state: gui.toolManagerState,
+            encoder: encoder
         )
 
         // Float popup overlay (centered, like picker)
-        if appState.gui.floatPopupState.visible {
-            let cw = CGFloat(appState.editorNSView?.cellWidth ?? 8)
-            let ch = CGFloat(appState.editorNSView?.cellHeight ?? 16)
+        if gui.floatPopupState.visible {
+            let geo = editorGeometry()
+            let cw = geo.cellWidth
+            let ch = geo.cellHeight
 
             FloatPopupOverlay(
-                state: appState.gui.floatPopupState,
+                state: gui.floatPopupState,
                 cellWidth: cw,
                 cellHeight: ch
             )
@@ -829,27 +849,27 @@ struct ContentView: View {
 
         // Notification stack (bottom-right, above regular workspace content).
         NotificationCenterView(
-            state: appState.gui.notificationCenterState,
-            encoder: appState.encoder,
+            state: gui.notificationCenterState,
+            encoder: encoder,
             bottomInset: notificationCenterBottomInset
         )
 
         // Keystroke-to-present latency HUD (ticket #2215). Top-right, client-local
         // debug overlay; visibility is owned by LatencyHUDState.
         LatencyHUDOverlay(
-            state: appState.gui.latencyHUDState
+            state: gui.latencyHUDState
         )
 
         // Frame-transaction resync hint (#2219 child D). Bottom-trailing badge
         // shown while a keyframe is in flight after an invalidation; the editor
         // keeps showing the last good frame underneath.
         ResyncOverlay(
-            state: appState.gui.resyncState
+            state: gui.resyncState
         )
 
         // Startup overlay: covers the empty Metal framebuffer with a
         // spinner while the BEAM boots. Fades out on first commit_frame.
-        if !appState.hasReceivedFirstFrame {
+        if !chrome.hasReceivedFirstFrame {
             StartupOverlay()
                 .transition(.opacity)
         }
@@ -857,10 +877,59 @@ struct ContentView: View {
         // Protocol error overlay: blocks the whole window when the BEAM rejects
         // this frontend's handshake protocol_version (0x18). Highest z-order so
         // it takes precedence over the startup overlay and all content.
-        if appState.gui.protocolErrorState.isPresented {
+        if gui.protocolErrorState.isPresented {
             ProtocolErrorOverlay(
-                state: appState.gui.protocolErrorState
+                state: gui.protocolErrorState
             )
         }
     }
+}
+
+// MARK: - Canvas preview
+
+/// Builds a fully-populated `GUIState` for the canvas shell preview. No `AppState`,
+/// no `EditorNSView`, and no Metal are involved: `ContentView` renders entirely
+/// from injected `MingaUI` values, so the whole shell lays out in Xcode's canvas
+/// with a placeholder rect where the Metal editor surface would be.
+@MainActor
+private func fullShellPreviewGUI() -> GUIState {
+    let gui = GUIState()
+    PreviewFixtures.applyPreviewTheme(to: gui.themeColors)
+    PreviewFixtures.populateFileTree(gui.fileTreeState)
+    PreviewFixtures.populateTabBar(gui.tabBarState)
+    PreviewFixtures.populateGitStatus(gui.gitStatusState)
+    gui.statusBarState.update(from: PreviewFixtures.statusBarUpdate(agentVisible: false))
+    // Mark the file-tree sidebar visible + active so the shell shows the sidebar.
+    gui.fileTreeState.visible = true
+    gui.sidebarHostState.update(
+        activeId: "file_tree",
+        sidebars: [
+            Wire.SidebarMetadata(
+                id: "file_tree",
+                displayName: "File Tree",
+                semanticKind: "file_tree",
+                icon: "folder",
+                order: 10,
+                visible: true,
+                focused: true,
+                preferredWidth: 30,
+                badgeCount: nil
+            )
+        ]
+    )
+    return gui
+}
+
+#Preview("Full Shell", traits: .mingaChrome) {
+    ContentView(
+        gui: fullShellPreviewGUI(),
+        encoder: NullInputEncoder(),
+        editorGeometry: { .preview },
+        chrome: .preview,
+        onAgentChatVisibleChange: { _ in }
+    ) {
+        Color(red: 0.12, green: 0.12, blue: 0.14)
+            .overlay(Text("editor surface").foregroundStyle(.secondary))
+    }
+    .frame(width: 1200, height: 800)
 }

--- a/macos/Sources/EditorGeometry+App.swift
+++ b/macos/Sources/EditorGeometry+App.swift
@@ -1,0 +1,48 @@
+/// App-side builders that pull `EditorGeometry` / `WindowChrome` out of the
+/// Metal-owning types (`EditorNSView`, `FrameState`, `CoreTextMetalRenderer`,
+/// `AppState`) that cannot live in the `MingaUI` framework.
+
+import MingaUI
+import SwiftUI
+
+extension EditorGeometry {
+    /// Reads current editor metrics off the live `EditorNSView`, falling back to
+    /// the same neutral defaults `ContentView` used before this decoupling when
+    /// no editor surface exists yet.
+    @MainActor
+    init(editorNSView: EditorNSView?) {
+        if let v = editorNSView {
+            self.init(
+                cellWidth: v.cellWidth,
+                cellHeight: v.cellHeight,
+                viewportWidth: v.bounds.width,
+                gutterCol: Int(v.dispatcher.frameState.gutterCol),
+                gutterLeftMargin: CoreTextMetalRenderer.gutterLeftMarginPt,
+                gutterRightGap: CoreTextMetalRenderer.gutterRightGapPt
+            )
+        } else {
+            self.init(
+                cellWidth: 8,
+                cellHeight: 16,
+                viewportWidth: 800,
+                gutterCol: 0,
+                gutterLeftMargin: 0,
+                gutterRightGap: 0
+            )
+        }
+    }
+}
+
+extension WindowChrome {
+    /// Snapshots the window chrome metrics off the `@Observable` `AppState`.
+    @MainActor
+    init(appState: AppState) {
+        self.init(
+            isFullScreen: appState.isFullScreen,
+            trafficLightMidY: appState.trafficLightMidY,
+            title: appState.windowTitle,
+            backgroundIsDark: appState.windowBgIsDark,
+            hasReceivedFirstFrame: appState.hasReceivedFirstFrame
+        )
+    }
+}

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -30,7 +30,24 @@ struct MingaApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView(appState: appDelegate.appState)
+            ContentView(
+                gui: appDelegate.appState.gui,
+                encoder: appDelegate.appState.encoder,
+                editorGeometry: { [appState = appDelegate.appState] in
+                    EditorGeometry(editorNSView: appState.editorNSView)
+                },
+                chrome: WindowChrome(appState: appDelegate.appState),
+                onAgentChatVisibleChange: { [appState = appDelegate.appState] visible in
+                    appState.editorNSView?.setAgentChatVisible(visible)
+                },
+                makeEditorSurface: { [appState = appDelegate.appState] in
+                    if let nsView = appState.editorNSView {
+                        EditorView(editorNSView: nsView)
+                    } else {
+                        Color(red: 0.12, green: 0.12, blue: 0.14)
+                    }
+                }
+            )
                 .frame(minWidth: 160, minHeight: 80)
                 // Disable SwiftUI's focus system so it doesn't steal
                 // first responder from the EditorNSView.

--- a/macos/Sources/PreviewFixtures.swift
+++ b/macos/Sources/PreviewFixtures.swift
@@ -63,6 +63,14 @@ public enum PreviewFixtures {
     /// Preview-only theme fixture. Runtime theme selection comes from the BEAM via guiTheme; previews apply explicit slots because ThemeColors itself starts with neutral bootstrap colors.
     public static func theme() -> ThemeColors {
         let theme = ThemeColors()
+        applyPreviewTheme(to: theme)
+        return theme
+    }
+
+    /// Applies the Doom One preview palette to an existing `ThemeColors`.
+    /// Use this to theme a `GUIState`'s owned `themeColors` (which views read
+    /// via `\.themeColors`) rather than a standalone instance.
+    public static func applyPreviewTheme(to theme: ThemeColors) {
         theme.applySlots([
             (GUI_COLOR_EDITOR_BG, 0x28, 0x2C, 0x34),
             (GUI_COLOR_EDITOR_FG, 0xBB, 0xC2, 0xCF),
@@ -80,7 +88,6 @@ public enum PreviewFixtures {
             (GUI_COLOR_ACCENT, 0x51, 0xAF, 0xEF),
             (GUI_COLOR_SELECTION_BG, 0x26, 0x4F, 0x78),
         ])
-        return theme
     }
 
     public static func encoder() -> InputEncoder {

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -13,6 +13,28 @@ enum PreviewRegistry {
         PreviewSnapshotPolicy.size(named: name)
     }
 
+    /// Builds the full-shell `ContentView` from a production preview `AppState`,
+    /// wiring the app-only editor geometry, window chrome, and Metal editor
+    /// surface exactly the way `MingaApp` does.
+    static func productionContentView(_ appState: AppState) -> some View {
+        ContentView(
+            gui: appState.gui,
+            encoder: appState.encoder,
+            editorGeometry: { EditorGeometry(editorNSView: appState.editorNSView) },
+            chrome: WindowChrome(appState: appState),
+            onAgentChatVisibleChange: { visible in
+                appState.editorNSView?.setAgentChatVisible(visible)
+            },
+            makeEditorSurface: {
+                if let nsView = appState.editorNSView {
+                    EditorView(editorNSView: nsView)
+                } else {
+                    Color(red: 0.12, green: 0.12, blue: 0.14)
+                }
+            }
+        )
+    }
+
     /// Returns a preview for the named view, or an error label for unknown names.
     @ViewBuilder
     static func view(named name: String) -> some View {
@@ -131,7 +153,7 @@ enum PreviewRegistry {
     private static func insertModeEditorPreview() -> some View {
         let size = PreviewSnapshotPolicy.size(named: "InsertModeEditorView")
         if let appState = productionPreviewAppState(agentVisible: false, mode: .insert) {
-            ContentView(appState: appState)
+            productionContentView(appState)
                 .frame(width: size.width, height: size.height)
         } else {
             previewFailureView(message: "InsertModeEditorView could not initialize the production editor renderer.")
@@ -145,7 +167,7 @@ enum PreviewRegistry {
     private static func hoverEditorPreview() -> some View {
         let size = PreviewSnapshotPolicy.size(named: "HoverEditorView")
         if let appState = hoverEditorAppState() {
-            ContentView(appState: appState)
+            productionContentView(appState)
                 .frame(width: size.width, height: size.height)
         } else {
             previewFailureView(message: "HoverEditorView could not initialize the production editor renderer.")
@@ -170,7 +192,7 @@ enum PreviewRegistry {
     private static func signatureHelpEditorPreview() -> some View {
         let size = PreviewSnapshotPolicy.size(named: "SignatureHelpEditorView")
         if let appState = signatureHelpEditorAppState() {
-            ContentView(appState: appState)
+            productionContentView(appState)
                 .frame(width: size.width, height: size.height)
         } else {
             previewFailureView(message: "SignatureHelpEditorView could not initialize the production editor renderer.")
@@ -195,7 +217,7 @@ enum PreviewRegistry {
         let size = PreviewSnapshotPolicy.size(named: viewName)
 
         if let appState = productionPreviewAppState(agentVisible: agentVisible) {
-            ContentView(appState: appState)
+            productionContentView(appState)
                 .frame(width: size.width, height: size.height)
         } else {
             previewFailureView(message: failureMessage)
@@ -383,7 +405,7 @@ enum PreviewRegistry {
         let size = PreviewSnapshotPolicy.size(named: "DiagnosticsEditorView")
 
         if let appState = diagnosticsPreviewAppState() {
-            ContentView(appState: appState)
+            productionContentView(appState)
                 .frame(width: size.width, height: size.height)
         } else {
             previewFailureView(message: failureMessage)

--- a/macos/Sources/Views/Shared/EditorGeometry.swift
+++ b/macos/Sources/Views/Shared/EditorGeometry.swift
@@ -1,0 +1,97 @@
+/// Metal-free value types that carry app-only editor and window metrics into
+/// the `MingaUI` framework.
+///
+/// `ContentView` used to read these directly off `AppState`, `EditorNSView`,
+/// `FrameState`, and `CoreTextMetalRenderer` — all of which live in the Metal
+/// app target and cannot be linked into the Metal-free `MingaUI` framework
+/// (which must build SwiftUI canvas previews without the Metal toolchain).
+/// The app builds these plain values and injects them, so `ContentView` renders
+/// in Xcode's canvas.
+
+import SwiftUI
+
+/// Editor surface geometry the chrome needs to position overlays.
+///
+/// Deliberately has NO cursor fields: the cursor is dynamic per-frame state that
+/// lives in `GUIState` (via `CompletionState` anchors, etc.). The app-only
+/// `FrameState` cursor is intentionally not carried here.
+public struct EditorGeometry: Equatable, Sendable {
+    /// Width of one monospaced cell in points.
+    public var cellWidth: CGFloat
+    /// Height of one monospaced cell in points.
+    public var cellHeight: CGFloat
+    /// Width of the editor NSView's bounds in points.
+    public var viewportWidth: CGFloat
+    /// Column at which the gutter ends and text begins (0 when no gutter).
+    public var gutterCol: Int
+    /// Left margin inside the gutter, in points.
+    public var gutterLeftMargin: CGFloat
+    /// Gap between the gutter and the text column, in points.
+    public var gutterRightGap: CGFloat
+
+    public init(
+        cellWidth: CGFloat,
+        cellHeight: CGFloat,
+        viewportWidth: CGFloat,
+        gutterCol: Int,
+        gutterLeftMargin: CGFloat,
+        gutterRightGap: CGFloat
+    ) {
+        self.cellWidth = cellWidth
+        self.cellHeight = cellHeight
+        self.viewportWidth = viewportWidth
+        self.gutterCol = gutterCol
+        self.gutterLeftMargin = gutterLeftMargin
+        self.gutterRightGap = gutterRightGap
+    }
+
+    /// Canvas-preview geometry with plausible metrics for a Metal-free preview.
+    public static let preview = EditorGeometry(
+        cellWidth: 8,
+        cellHeight: 16,
+        viewportWidth: 900,
+        gutterCol: 5,
+        gutterLeftMargin: 4,
+        gutterRightGap: 6
+    )
+}
+
+/// Window chrome metrics the shell needs to lay out the title bar and overlays.
+///
+/// Inputs are `@Observable` on `AppState`, so a plain value stays fresh: the app
+/// rebuilds it whenever `ContentView`'s body re-evaluates.
+public struct WindowChrome: Equatable, Sendable {
+    /// Whether the window is in macOS full-screen mode.
+    public var isFullScreen: Bool
+    /// Vertical center of the traffic-light buttons, measured from the window top.
+    public var trafficLightMidY: CGFloat
+    /// Window title (drives `.navigationTitle`).
+    public var title: String
+    /// Whether the BEAM-selected background is dark (drives `.preferredColorScheme`).
+    public var backgroundIsDark: Bool
+    /// Whether the first commit_frame has arrived (dismisses the startup overlay).
+    public var hasReceivedFirstFrame: Bool
+
+    public init(
+        isFullScreen: Bool,
+        trafficLightMidY: CGFloat,
+        title: String,
+        backgroundIsDark: Bool,
+        hasReceivedFirstFrame: Bool
+    ) {
+        self.isFullScreen = isFullScreen
+        self.trafficLightMidY = trafficLightMidY
+        self.title = title
+        self.backgroundIsDark = backgroundIsDark
+        self.hasReceivedFirstFrame = hasReceivedFirstFrame
+    }
+
+    /// Canvas-preview chrome: windowed, dark, first frame already received.
+    public static let preview = WindowChrome(
+        isFullScreen: false,
+        trafficLightMidY: 20,
+        title: "Minga",
+        backgroundIsDark: true,
+        hasReceivedFirstFrame: true
+    )
+}

--- a/macos/Tests/MingaTests/ExtensionViewsTests.swift
+++ b/macos/Tests/MingaTests/ExtensionViewsTests.swift
@@ -217,7 +217,7 @@ struct ExtensionOverlayViewTests {
 struct OverlayContentOriginTests {
     @Test("origin offsets past the gutter text column")
     func gutterOffset() {
-        let origin = ContentView.overlayContentOrigin(
+        let origin = ContentView<Color>.overlayContentOrigin(
             textCol: 5, textRow: 0, scrollLeft: 0,
             cellWidth: 8, cellHeight: 16, gutterPad: 14
         )
@@ -228,7 +228,7 @@ struct OverlayContentOriginTests {
 
     @Test("split pane uses the pane's text rect row/col")
     func splitPaneOffset() {
-        let origin = ContentView.overlayContentOrigin(
+        let origin = ContentView<Color>.overlayContentOrigin(
             textCol: 40, textRow: 20, scrollLeft: 0,
             cellWidth: 8, cellHeight: 16, gutterPad: 0
         )
@@ -238,7 +238,7 @@ struct OverlayContentOriginTests {
 
     @Test("horizontal scroll shifts the origin left")
     func horizontalScroll() {
-        let origin = ContentView.overlayContentOrigin(
+        let origin = ContentView<Color>.overlayContentOrigin(
             textCol: 5, textRow: 0, scrollLeft: 3,
             cellWidth: 8, cellHeight: 16, gutterPad: 14
         )
@@ -253,7 +253,7 @@ struct OverlayContentOriginTests {
 struct PanelCrossSizeTests {
     @Test("percent resolves against the basis")
     func percentOfBasis() {
-        let size = ContentView.panelCrossSize(
+        let size = ContentView<Color>.panelCrossSize(
             sizeType: 0, sizeValue: 30, cellExtent: 8, basis: 1000, minimum: 160
         )
         #expect(size == 300)
@@ -261,7 +261,7 @@ struct PanelCrossSizeTests {
 
     @Test("lines resolves against the cell extent")
     func linesByCellExtent() {
-        let size = ContentView.panelCrossSize(
+        let size = ContentView<Color>.panelCrossSize(
             sizeType: 1, sizeValue: 20, cellExtent: 8, basis: 1000, minimum: 160
         )
         #expect(size == 160)
@@ -269,7 +269,7 @@ struct PanelCrossSizeTests {
 
     @Test("tiny requests clamp up to the minimum")
     func clampsToMinimum() {
-        let size = ContentView.panelCrossSize(
+        let size = ContentView<Color>.panelCrossSize(
             sizeType: 0, sizeValue: 1, cellExtent: 8, basis: 1000, minimum: 160
         )
         #expect(size == 160)
@@ -277,7 +277,7 @@ struct PanelCrossSizeTests {
 
     @Test("oversized requests clamp to 80% of the basis")
     func clampsToBasisFraction() {
-        let size = ContentView.panelCrossSize(
+        let size = ContentView<Color>.panelCrossSize(
             sizeType: 0, sizeValue: 95, cellExtent: 8, basis: 1000, minimum: 160
         )
         #expect(size == 800)

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -62,6 +62,8 @@ targets:
         type: file
       - path: Sources/Views/Shared/EditTimelineView.swift
         type: file
+      - path: Sources/Views/Shared/EditorGeometry.swift
+        type: file
       - path: Sources/Views/Shared/GUIState.swift
         type: file
       - path: Sources/Views/Shared/SparklineView.swift
@@ -69,6 +71,8 @@ targets:
       - path: Sources/Views/Shared/TextHighlighting.swift
         type: file
       - path: Sources/Views/Shared/ThemeColors.swift
+        type: file
+      - path: Sources/ContentView.swift
         type: file
       - path: Sources/PreviewFixtures.swift
         type: file
@@ -115,6 +119,8 @@ targets:
           - "Views/Editor/InlineEditField.swift"
           - "Views/Editor/BlinkingCursor.swift"
           - "PreviewFixtures.swift"
+          - "ContentView.swift"
+          - "Views/Shared/EditorGeometry.swift"
           - "Views/Agent/**"
           - "Views/EditorChrome/**"
           - "Views/Extensions/**"
@@ -163,6 +169,10 @@ targets:
         script: |
           cd "${SRCROOT}/.."
           if ! command -v mix >/dev/null 2>&1; then
+            if [ -f macos/.generated/protocol/ProtocolOpcodes.generated.swift ]; then
+              echo "warning: mix not found; reusing existing generated protocol artifacts (e.g. Xcode Preview build sandbox)"
+              exit 0
+            fi
             echo "error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen"
             exit 1
           fi
@@ -220,6 +230,8 @@ targets:
           - "Views/Editor/InlineEditField.swift"
           - "Views/Editor/BlinkingCursor.swift"
           - "PreviewFixtures.swift"
+          - "ContentView.swift"
+          - "Views/Shared/EditorGeometry.swift"
           - "Views/Agent/**"
           - "Views/EditorChrome/**"
           - "Views/Extensions/**"
@@ -257,6 +269,10 @@ targets:
         script: |
           cd "${SRCROOT}/.."
           if ! command -v mix >/dev/null 2>&1; then
+            if [ -f macos/.generated/protocol/ProtocolOpcodes.generated.swift ]; then
+              echo "warning: mix not found; reusing existing generated protocol artifacts (e.g. Xcode Preview build sandbox)"
+              exit 0
+            fi
             echo "error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen"
             exit 1
           fi
@@ -286,6 +302,8 @@ targets:
           - "Views/Editor/InlineEditField.swift"
           - "Views/Editor/BlinkingCursor.swift"
           - "PreviewFixtures.swift"
+          - "ContentView.swift"
+          - "Views/Shared/EditorGeometry.swift"
           - "Views/Agent/**"
           - "Views/EditorChrome/**"
           - "Views/Extensions/**"
@@ -324,6 +342,10 @@ targets:
         script: |
           cd "${SRCROOT}/.."
           if ! command -v mix >/dev/null 2>&1; then
+            if [ -f macos/.generated/protocol/ProtocolOpcodes.generated.swift ]; then
+              echo "warning: mix not found; reusing existing generated protocol artifacts (e.g. Xcode Preview build sandbox)"
+              exit 0
+            fi
             echo "error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Moves the window-shell `ContentView` into the `MingaUI` framework so the **full shell** — sidebar + tab bar + editor-column proportions, overlays, unified toolbar background — renders in Xcode's SwiftUI canvas with a stubbed, non-Metal/non-BEAM editor region. You can now hand-tune the whole window layout in the canvas the same way the individual chrome components already can.

This finishes **AC #8 of #2646**, which shipped first-class canvas previews for every chrome *component* (via the `MingaProtocol`/`MingaUI` extraction) but left the full shell coupled to app-only state.

## What changed

`ContentView` is now `public struct ContentView<EditorSurface: View>` living in `MingaUI`, with every app-only coupling injected instead of read directly:

- **`EditorGeometry`** value (cellWidth, cellHeight, viewportWidth, gutterCol, gutterLeftMargin, gutterRightGap) with a `.preview` default, replacing the `editorNSView` metric reads and `CoreTextMetalRenderer` statics. Passed as a `() -> EditorGeometry` **closure** so each read reflects live editor metrics — their inputs aren't `@Observable`, so a value computed in `MingaApp`'s body would go stale (`MingaApp` under-renders relative to `ContentView`). App-side builders live in `EditorGeometry+App.swift`, keeping the Metal reads in the app target.
- **`WindowChrome`** value (isFullScreen, trafficLightMidY, title, backgroundIsDark, hasReceivedFirstFrame). Plain value is safe here: its inputs are `@Observable` on `AppState`, so it stays fresh.
- **`makeEditorSurface`** `@ViewBuilder` closure for the editor region: the app passes the real `EditorView`, previews pass a `Color` placeholder.
- **`onAgentChatVisibleChange`** closure replaces the direct `editorNSView?.setAgentChatVisible(...)` call.
- The two render-time `NSWorkspace…ShouldReduceMotion` reads become `@Environment(\.accessibilityReduceMotion)`. (The one live read in `MingaApp`'s `onFirstRender`, outside `body`, correctly stays `NSWorkspace`.)
- `completionOverlayCursor` positions from the `@Observable` completion **anchor** (consistent with the existing hover/signature-help overlays) instead of the app-only live `frameState` cursor. The BEAM re-emits the completion — and its anchor — on cursor move (`completion_encoder.ex` fingerprint includes `cursor_row/cursor_col`), so the on-screen position is unchanged.

Adds a `#Preview("Full Shell", traits: .mingaChrome)` driven by `PreviewFixtures` + a placeholder editor rect. `MingaApp` constructs `ContentView` with the real geometry/closures; **production behavior is unchanged** — this is a pure decoupling refactor.

## Acceptance criteria (#2648)

All 9 met. `ContentView` no longer references `AppState`/`EditorNSView`/`CoreTextMetalRenderer`/`FrameState`/`NSWorkspace` and lives in the `MingaUI` target (`grep`-confirmed); the Metal reads are isolated in the app-target `EditorGeometry+App.swift`.

## Tests

- `mix swift.build` — green
- `xcodebuild build -scheme Minga` then `xcodebuild build-for-testing` (two steps sharing DerivedData) — **TEST BUILD SUCCEEDED**
- `mix swift.harness` — green
- Focused behavior-preservation bug-hunt: zero drift (independently traced the completion anchor/cursor equivalence on both the Swift and BEAM sides)
- Acceptance review: PASS

## Follow-up risks

None material. The nil-editor geometry fallbacks reproduce the old inline `?? 8 / ?? 16 / ?? 800 / gutter 0` defaults exactly, and target boundaries keep `MingaUI` Metal-free.

Closes #2648

🤖 Generated with [Claude Code](https://claude.com/claude-code)