### PR TITLE
feat(tui): dev hot-reload for the Go renderer via a connected-mode supervisor

### DIFF
--- a/bin/lib/erl-flags.sh
+++ b/bin/lib/erl-flags.sh
@@ -1,0 +1,10 @@
+# shellcheck shell=bash
+# Editor-tuned BEAM VM flags, shared by the launchers (bin/minga, bin/minga-dev).
+# See rel/vm.args.eex for the rationale behind each flag. Source this file to
+# export ERL_FLAGS with the tuned flags first and any caller-provided ERL_FLAGS
+# appended, so a caller can still override:  ERL_FLAGS="+S 2:2" bin/minga ...
+#
+# This is a sourced snippet, not an executable command; it only sets ERL_FLAGS.
+MINGA_ERL_FLAGS="+A 4 +sbwt none +sbwtdcpu none +sbwtdio none +swt very_low +swtdcpu very_low +swtdio very_low +MBas aobf +Mea min +MBacul 0 +hmbs 32768"
+
+export ERL_FLAGS="${MINGA_ERL_FLAGS} ${ERL_FLAGS:-}"

--- a/bin/lib/erl-flags.sh
+++ b/bin/lib/erl-flags.sh
@@ -1,10 +1,6 @@
 # shellcheck shell=bash
-# Editor-tuned BEAM VM flags, shared by the launchers (bin/minga, bin/minga-dev).
-# See rel/vm.args.eex for the rationale behind each flag. Source this file to
-# export ERL_FLAGS with the tuned flags first and any caller-provided ERL_FLAGS
-# appended, so a caller can still override:  ERL_FLAGS="+S 2:2" bin/minga ...
-#
-# This is a sourced snippet, not an executable command; it only sets ERL_FLAGS.
+# Editor-tuned BEAM VM flags, sourced by bin/minga and bin/minga-dev (see
+# rel/vm.args.eex). Caller-provided ERL_FLAGS are appended so they can override.
 MINGA_ERL_FLAGS="+A 4 +sbwt none +sbwtdcpu none +sbwtdio none +swt very_low +swtdcpu very_low +swtdio very_low +MBas aobf +Mea min +MBacul 0 +hmbs 32768"
 
 export ERL_FLAGS="${MINGA_ERL_FLAGS} ${ERL_FLAGS:-}"

--- a/bin/minga
+++ b/bin/minga
@@ -27,11 +27,10 @@ if [ "${MINGA_SKIP_NATIVE_LAUNCH_BUILD:-}" != "1" ]; then
   fi
 fi
 
-# Editor-tuned VM flags (see rel/vm.args.eex for rationale).
+# Editor-tuned VM flags, shared with bin/minga-dev (see rel/vm.args.eex).
 # ERL_FLAGS set by the caller are appended, so they can override.
-MINGA_ERL_FLAGS="+A 4 +sbwt none +sbwtdcpu none +sbwtdio none +swt very_low +swtdcpu very_low +swtdio very_low +MBas aobf +Mea min +MBacul 0 +hmbs 32768"
-
-export ERL_FLAGS="${MINGA_ERL_FLAGS} ${ERL_FLAGS:-}"
+# shellcheck source=bin/lib/erl-flags.sh
+source "$PROJECT_DIR/bin/lib/erl-flags.sh"
 
 should_redirect_stdio() {
   if [ "${MINGA_DISABLE_LAUNCH_STDIO_REDIRECT:-}" = "1" ]; then

--- a/bin/minga-dev
+++ b/bin/minga-dev
@@ -41,7 +41,7 @@ build_renderer() {
     return 0
   fi
   rm -f "go/tui/$tmp" 2>/dev/null || true
-  log "renderer build FAILED (see $LOG_FILE); keeping previous binary"
+  log "renderer build FAILED (see $LOG_FILE)"
   return 1
 }
 
@@ -56,30 +56,48 @@ renderer_fingerprint() {
 
 watch_and_rebuild() {
   local last current
-  last="$(renderer_fingerprint)"
+  # `|| true` so a transient non-zero from the find/sort pipeline can't trip the
+  # inherited `set -e` and silently kill the watcher (hot-reload would just stop).
+  last="$(renderer_fingerprint || true)"
   while true; do
     sleep 0.5
-    current="$(renderer_fingerprint)"
+    current="$(renderer_fingerprint || true)"
     if [ "$current" != "$last" ]; then
       last="$current"
       log "source change detected; rebuilding renderer"
-      build_renderer || true
+      # On failure the running renderer keeps going untouched; the build error is
+      # in the log and the next successful rebuild triggers the reload.
+      build_renderer || log "keeping previous renderer running (see $LOG_FILE)"
     fi
   done
 }
 
+# Each startup step states what broke ON THE TERMINAL before aborting, rather
+# than exiting silently via `set -e` and leaving the reason only in a log file
+# the user isn't tailing yet.
 log "building renderer + supervisor..."
-build_renderer
-(cd go/tui && go build -o "$SUPERVISOR_BIN" "$SUPERVISOR_SRC") 2>>"$LOG_FILE"
+if ! build_renderer; then
+  log "initial renderer build failed; aborting"
+  exit 1
+fi
+if ! (cd go/tui && go build -o "$SUPERVISOR_BIN" "$SUPERVISOR_SRC") 2>>"$LOG_FILE"; then
+  log "supervisor build FAILED (see $LOG_FILE); aborting"
+  exit 1
+fi
 
 # Pre-compile the BEAM so `mix minga` (launched by the supervisor in connected
 # mode) does not emit compile output onto its protocol stdout. The Go renderer
 # build is owned by the watcher, so skip it here.
 log "compiling BEAM (this may take a moment on a cold build)..."
-MINGA_SKIP_GO_TUI_BUILD=1 mix compile >>"$LOG_FILE" 2>&1
+if ! MINGA_SKIP_GO_TUI_BUILD=1 mix compile >>"$LOG_FILE" 2>&1; then
+  log "BEAM compile FAILED (see $LOG_FILE); aborting"
+  exit 1
+fi
 
-# Start the background rebuild watcher and make sure it dies with us.
-watch_and_rebuild &
+# Start the background rebuild watcher. Redirect it to the log file: once the
+# supervisor starts, the renderer owns the terminal (alt-screen + raw mode), so
+# any watcher output on the tty would corrupt the display. Ensure it dies with us.
+watch_and_rebuild >>"$LOG_FILE" 2>&1 &
 WATCH_PID=$!
 cleanup() {
   kill "$WATCH_PID" 2>/dev/null || true
@@ -87,8 +105,11 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+# Run (do NOT `exec`) so this shell survives to fire the EXIT trap when the
+# supervisor returns. `exec` would replace the shell and discard the trap,
+# orphaning the watcher to keep rebuilding forever after you quit with :q.
 log "starting supervisor (edit go/tui sources to hot-reload; Ctrl-C or :q to quit)"
-exec "go/tui/$SUPERVISOR_BIN" \
+"go/tui/$SUPERVISOR_BIN" \
   -renderer "$PROJECT_DIR/go/tui/$RENDERER_BIN" \
   -log "$LOG_FILE" \
   "$@"

--- a/bin/minga-dev
+++ b/bin/minga-dev
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Launch the Minga TUI with Go-renderer hot-reload.
+#
+# Runs the editor through the dev supervisor (go/tui/cmd/minga-supervisor): BEAM
+# boots in connected mode and stays alive while you edit the Go renderer. A
+# background watcher rebuilds the renderer binary on any go/tui source change,
+# the supervisor notices the new binary and respawns the renderer, and BEAM
+# repaints the current editor state via a keyframe. You get a brief alt-screen
+# blip on each reload (the coordinated-swap tradeoff) but never lose your session.
+#
+# Usage:
+#   bin/minga-dev [filename]
+#
+# Logs (BEAM stderr, renderer stderr, supervisor diagnostics) go to
+#   $XDG_DATA_HOME/minga/minga-dev.log   (default ~/.local/share/minga/)
+# so they never corrupt the renderer's terminal. Tail that file in another pane
+# to watch reloads and build errors.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_DIR"
+
+LOG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/minga"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/minga-dev.log"
+
+RENDERER_SRC="./cmd/minga-renderer-go"
+RENDERER_BIN="bin/minga-renderer-go"
+SUPERVISOR_SRC="./cmd/minga-supervisor"
+SUPERVISOR_BIN="bin/minga-supervisor"
+
+log() { printf '[minga-dev] %s\n' "$*" >&2; }
+
+build_renderer() {
+  # Build to a temp path then atomically rename so the supervisor never stats a
+  # half-written binary. A single mtime bump is what triggers the reload.
+  local tmp="${RENDERER_BIN}.tmp.$$"
+  if (cd go/tui && go build -o "$tmp" "$RENDERER_SRC") 2>>"$LOG_FILE"; then
+    mv "go/tui/$tmp" "go/tui/$RENDERER_BIN"
+    return 0
+  fi
+  rm -f "go/tui/$tmp" 2>/dev/null || true
+  log "renderer build FAILED (see $LOG_FILE); keeping previous binary"
+  return 1
+}
+
+# Compute a fingerprint of all renderer Go sources (path + mtime). Used by the
+# polling watcher to detect edits without depending on fswatch/wgo/entr.
+# Test files are excluded so editing them doesn't trigger a pointless reload.
+# Note: `stat -f` is BSD/macOS syntax (this is a macOS dev helper).
+renderer_fingerprint() {
+  find go/tui/cmd/minga-renderer-go go/tui/internal -name '*.go' -type f \
+    ! -name '*_test.go' -exec stat -f '%N:%m' {} + 2>/dev/null | sort
+}
+
+watch_and_rebuild() {
+  local last current
+  last="$(renderer_fingerprint)"
+  while true; do
+    sleep 0.5
+    current="$(renderer_fingerprint)"
+    if [ "$current" != "$last" ]; then
+      last="$current"
+      log "source change detected; rebuilding renderer"
+      build_renderer || true
+    fi
+  done
+}
+
+log "building renderer + supervisor..."
+build_renderer
+(cd go/tui && go build -o "$SUPERVISOR_BIN" "$SUPERVISOR_SRC") 2>>"$LOG_FILE"
+
+# Pre-compile the BEAM so `mix minga` (launched by the supervisor in connected
+# mode) does not emit compile output onto its protocol stdout. The Go renderer
+# build is owned by the watcher, so skip it here.
+log "compiling BEAM (this may take a moment on a cold build)..."
+MINGA_SKIP_GO_TUI_BUILD=1 mix compile >>"$LOG_FILE" 2>&1
+
+# Start the background rebuild watcher and make sure it dies with us.
+watch_and_rebuild &
+WATCH_PID=$!
+cleanup() {
+  kill "$WATCH_PID" 2>/dev/null || true
+  wait "$WATCH_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+log "starting supervisor (edit go/tui sources to hot-reload; Ctrl-C or :q to quit)"
+exec "go/tui/$SUPERVISOR_BIN" \
+  -renderer "$PROJECT_DIR/go/tui/$RENDERER_BIN" \
+  -log "$LOG_FILE" \
+  "$@"

--- a/bin/minga-dev
+++ b/bin/minga-dev
@@ -1,29 +1,15 @@
 #!/usr/bin/env bash
-# Launch the Minga TUI with Go-renderer hot-reload.
+# Launch the Minga TUI with Go-renderer hot-reload (edit go/tui, see it reload).
 #
-# Runs the editor through the dev supervisor (go/tui/cmd/minga-supervisor): BEAM
-# boots in connected mode and stays alive while you edit the Go renderer. A
-# background watcher rebuilds the renderer binary on any go/tui source change,
-# the supervisor notices the new binary and respawns the renderer, and BEAM
-# repaints the current editor state via a keyframe. You get a brief alt-screen
-# blip on each reload (the coordinated-swap tradeoff) but never lose your session.
+# Usage: bin/minga-dev [filename]
 #
-# Usage:
-#   bin/minga-dev [filename]
-#
-# Logs (BEAM stderr, renderer stderr, supervisor diagnostics) go to
-#   $XDG_DATA_HOME/minga/minga-dev.log   (default ~/.local/share/minga/)
-# so they never corrupt the renderer's terminal. Tail that file in another pane
-# to watch reloads and build errors.
+# Logs go to $XDG_DATA_HOME/minga/minga-dev.log (default ~/.local/share/minga/).
 
 set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_DIR"
 
-# Boot BEAM with the same editor-tuned VM flags as bin/minga. The supervisor
-# launches `mix minga` inheriting our environment, so exporting ERL_FLAGS here is
-# enough; the connected-mode BEAM picks up the tuned scheduler/allocator flags.
 # shellcheck source=bin/lib/erl-flags.sh
 source "$PROJECT_DIR/bin/lib/erl-flags.sh"
 
@@ -39,8 +25,6 @@ SUPERVISOR_BIN="bin/minga-supervisor"
 log() { printf '[minga-dev] %s\n' "$*" >&2; }
 
 build_renderer() {
-  # Build to a temp path then atomically rename so the supervisor never stats a
-  # half-written binary. A single mtime bump is what triggers the reload.
   local tmp="${RENDERER_BIN}.tmp.$$"
   if (cd go/tui && go build -o "$tmp" "$RENDERER_SRC") 2>>"$LOG_FILE"; then
     mv "go/tui/$tmp" "go/tui/$RENDERER_BIN"
@@ -51,10 +35,6 @@ build_renderer() {
   return 1
 }
 
-# Compute a fingerprint of all renderer Go sources (path + mtime). Used by the
-# polling watcher to detect edits without depending on fswatch/wgo/entr.
-# Test files are excluded so editing them doesn't trigger a pointless reload.
-# Note: `stat -f` is BSD/macOS syntax (this is a macOS dev helper).
 renderer_fingerprint() {
   find go/tui/cmd/minga-renderer-go go/tui/internal -name '*.go' -type f \
     ! -name '*_test.go' -exec stat -f '%N:%m' {} + 2>/dev/null | sort
@@ -62,8 +42,6 @@ renderer_fingerprint() {
 
 watch_and_rebuild() {
   local last current
-  # `|| true` so a transient non-zero from the find/sort pipeline can't trip the
-  # inherited `set -e` and silently kill the watcher (hot-reload would just stop).
   last="$(renderer_fingerprint || true)"
   while true; do
     sleep 0.5
@@ -71,16 +49,11 @@ watch_and_rebuild() {
     if [ "$current" != "$last" ]; then
       last="$current"
       log "source change detected; rebuilding renderer"
-      # On failure the running renderer keeps going untouched; the build error is
-      # in the log and the next successful rebuild triggers the reload.
       build_renderer || log "keeping previous renderer running (see $LOG_FILE)"
     fi
   done
 }
 
-# Each startup step states what broke ON THE TERMINAL before aborting, rather
-# than exiting silently via `set -e` and leaving the reason only in a log file
-# the user isn't tailing yet.
 log "building renderer + supervisor..."
 if ! build_renderer; then
   log "initial renderer build failed; aborting"
@@ -91,18 +64,14 @@ if ! (cd go/tui && go build -o "$SUPERVISOR_BIN" "$SUPERVISOR_SRC") 2>>"$LOG_FIL
   exit 1
 fi
 
-# Pre-compile the BEAM so `mix minga` (launched by the supervisor in connected
-# mode) does not emit compile output onto its protocol stdout. The Go renderer
-# build is owned by the watcher, so skip it here.
 log "compiling BEAM (this may take a moment on a cold build)..."
 if ! MINGA_SKIP_GO_TUI_BUILD=1 mix compile >>"$LOG_FILE" 2>&1; then
   log "BEAM compile FAILED (see $LOG_FILE); aborting"
   exit 1
 fi
 
-# Start the background rebuild watcher. Redirect it to the log file: once the
-# supervisor starts, the renderer owns the terminal (alt-screen + raw mode), so
-# any watcher output on the tty would corrupt the display. Ensure it dies with us.
+# Redirect to the log file: once the supervisor starts the renderer owns the
+# terminal, so watcher output on the tty would corrupt it.
 watch_and_rebuild >>"$LOG_FILE" 2>&1 &
 WATCH_PID=$!
 cleanup() {
@@ -111,9 +80,8 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-# Run (do NOT `exec`) so this shell survives to fire the EXIT trap when the
-# supervisor returns. `exec` would replace the shell and discard the trap,
-# orphaning the watcher to keep rebuilding forever after you quit with :q.
+# Run, don't `exec`: the shell must survive to fire the EXIT trap, else the
+# watcher orphans and rebuilds forever after you quit.
 log "starting supervisor (edit go/tui sources to hot-reload; Ctrl-C or :q to quit)"
 "go/tui/$SUPERVISOR_BIN" \
   -renderer "$PROJECT_DIR/go/tui/$RENDERER_BIN" \

--- a/bin/minga-dev
+++ b/bin/minga-dev
@@ -21,6 +21,12 @@ set -euo pipefail
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_DIR"
 
+# Boot BEAM with the same editor-tuned VM flags as bin/minga. The supervisor
+# launches `mix minga` inheriting our environment, so exporting ERL_FLAGS here is
+# enough; the connected-mode BEAM picks up the tuned scheduler/allocator flags.
+# shellcheck source=bin/lib/erl-flags.sh
+source "$PROJECT_DIR/bin/lib/erl-flags.sh"
+
 LOG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/minga"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/minga-dev.log"

--- a/go/tui/cmd/minga-supervisor/main.go
+++ b/go/tui/cmd/minga-supervisor/main.go
@@ -178,8 +178,10 @@ type supervisor struct {
 	// rendIn is the current renderer's stdin, or nil while swapping. It is
 	// io.Writer (not io.WriteCloser) so callers can only forward through it; the
 	// renderer's lifecycle (including Close) is owned solely by spawnRenderer /
-	// stopRenderer via the local WriteCloser they hold.
-	mu     sync.RWMutex
+	// stopRenderer via the local WriteCloser they hold. A plain Mutex suffices:
+	// the sole reader is forwardBeamToRenderer, so there's no read-parallelism to
+	// gain from an RWMutex.
+	mu     sync.Mutex
 	rendIn io.Writer
 }
 
@@ -190,8 +192,8 @@ func (s *supervisor) setRenderer(w io.Writer) {
 }
 
 func (s *supervisor) currentRenderer() io.Writer {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.rendIn
 }
 
@@ -228,28 +230,13 @@ func (s *supervisor) forwardBeamToRenderer(beamOut io.Reader) {
 	}
 }
 
-// startupGrace bounds how quickly a renderer must exit for a clean (status 0)
-// exit to be read as a startup failure on a fresh build rather than a user quit.
-// A user opening then quitting within this window is rare and only costs a "still
-// alive, waiting for rebuild" wait; misreading a crash as a quit would wrongly
-// tear the whole session down, so we bias toward "crash" when it exits instantly.
-const startupGrace = 2 * time.Second
-
-// rendererExit carries the outcome of a renderer process for crash-vs-quit
-// classification. err is nil on a status-0 exit; state may be nil if Wait failed.
-type rendererExit struct {
-	err   error
-	state *os.ProcessState
-}
-
 // rendererHandle bundles a running renderer's process, its stdin (the local
-// WriteCloser that owns Close), a buffered channel delivering its exit exactly
-// once, and when it started (for the startupGrace heuristic).
+// WriteCloser that owns Close), and a buffered channel delivering its exit error
+// exactly once (nil on a clean status-0 exit).
 type rendererHandle struct {
-	cmd     *exec.Cmd
-	stdin   io.WriteCloser
-	done    <-chan rendererExit
-	started time.Time
+	cmd   *exec.Cmd
+	stdin io.WriteCloser
+	done  <-chan error
 }
 
 // outcome is why a running renderer stopped, which decides what the manager does
@@ -315,20 +302,23 @@ func (s *supervisor) superviseRenderer(h *rendererHandle, shutdown <-chan struct
 			s.stopRenderer(h)
 			return outcomeShutdown
 
-		case exit := <-h.done:
+		case err := <-h.done:
 			s.setRenderer(nil)
-			if isCleanQuit(exit, time.Since(h.started)) {
+			// A renderer only exits status 0 when its stdin hits EOF, which only
+			// stopRenderer causes (and that path drains done itself, never reaching
+			// here). So a *spontaneous* exit through this case is a crash: the
+			// renderer os.Exit(1)s on any run error, and a genuine user quit unwinds
+			// through BEAM shutdown -> outcomeShutdown, not this branch. Classify on
+			// exit status alone; nil still means "clean, treat as quit" defensively.
+			if err == nil {
 				s.logger.Printf("renderer exited cleanly (user quit)")
 				return outcomeUserQuit
 			}
-			s.logger.Printf("renderer exited unexpectedly (%s) after %s; keeping BEAM alive, waiting for a rebuild",
-				exitDescription(exit), time.Since(h.started).Round(time.Millisecond))
+			s.logger.Printf("renderer exited unexpectedly (%v); keeping BEAM alive, waiting for a rebuild", err)
 			return outcomeCrash
 
 		case <-ticker.C:
-			m := s.rendererMtime()
-			if m != *lastMtime && m != 0 {
-				*lastMtime = m
+			if s.mtimeChanged(lastMtime) {
 				s.logger.Printf("renderer binary changed; reloading")
 				s.stopRenderer(h)
 				return outcomeReload
@@ -345,9 +335,7 @@ func (s *supervisor) awaitRebuild(shutdown <-chan struct{}, ticker *time.Ticker,
 		case <-shutdown:
 			return false
 		case <-ticker.C:
-			m := s.rendererMtime()
-			if m != *lastMtime && m != 0 {
-				*lastMtime = m
+			if s.mtimeChanged(lastMtime) {
 				s.logger.Printf("renderer rebuilt; respawning")
 				return true
 			}
@@ -355,19 +343,16 @@ func (s *supervisor) awaitRebuild(shutdown <-chan struct{}, ticker *time.Ticker,
 	}
 }
 
-// isCleanQuit reports whether a renderer exit looks like a deliberate user quit
-// (status 0 after running past startupGrace) rather than a crash on a fresh
-// build. A non-zero/signal exit, or a near-instant clean exit, is treated as a
-// crash so it doesn't tear down the session.
-func isCleanQuit(exit rendererExit, uptime time.Duration) bool {
-	return exit.err == nil && uptime >= startupGrace
-}
-
-func exitDescription(exit rendererExit) string {
-	if exit.err != nil {
-		return exit.err.Error()
+// mtimeChanged reports whether the renderer binary's mtime differs from *last,
+// updating *last when it does. A zero mtime (mid-rebuild, binary briefly absent)
+// is ignored so a transient stat failure doesn't count as a change.
+func (s *supervisor) mtimeChanged(last *int64) bool {
+	m := s.rendererMtime()
+	if m != *last && m != 0 {
+		*last = m
+		return true
 	}
-	return "exit status 0"
+	return false
 }
 
 // spawnRenderer starts a renderer process wired to BEAM through the supervisor:
@@ -388,7 +373,6 @@ func (s *supervisor) spawnRenderer() (*rendererHandle, error) {
 	if err != nil {
 		return nil, err
 	}
-	started := time.Now()
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}
@@ -413,13 +397,12 @@ func (s *supervisor) spawnRenderer() (*rendererHandle, error) {
 
 	// Buffered so the Wait goroutine can deliver the exit even if no one is
 	// reading yet (e.g. stopRenderer's timeout path), without leaking.
-	done := make(chan rendererExit, 1)
+	done := make(chan error, 1)
 	go func() {
-		err := cmd.Wait()
-		done <- rendererExit{err: err, state: cmd.ProcessState}
+		done <- cmd.Wait()
 	}()
 
-	return &rendererHandle{cmd: cmd, stdin: stdin, done: done, started: started}, nil
+	return &rendererHandle{cmd: cmd, stdin: stdin, done: done}, nil
 }
 
 // stopRenderer gracefully stops the current renderer. Closing its stdin makes

--- a/go/tui/cmd/minga-supervisor/main.go
+++ b/go/tui/cmd/minga-supervisor/main.go
@@ -1,26 +1,4 @@
 // Command minga-supervisor is a dev-only hot-reload harness for the Minga TUI.
-//
-// It launches the BEAM editor in *connected* mode (MINGA_PORT_MODE=connected),
-// owning BEAM's stdin/stdout as pipes exactly like the macOS GUI parent does,
-// and sits between BEAM and the Go renderer forwarding the {:packet,4} protocol
-// in both directions. Because the supervisor (not BEAM) owns BEAM's stdio, it
-// can stop and respawn the renderer as many times as it likes WITHOUT BEAM ever
-// seeing its frontend die: BEAM stays alive holding all editor state.
-//
-// On each respawn the fresh renderer sends its `ready` handshake, which the
-// supervisor forwards to BEAM; BEAM re-runs its idempotent ready path (see
-// MingaEditor.Startup.ensure_session_started/1) and dispatches a full keyframe,
-// so the reloaded renderer instantly repaints the untouched editor state.
-//
-// Reload is triggered by watching the renderer binary's mtime: an external
-// `go build` watcher rebuilds go/tui/bin/minga-renderer-go on source change,
-// the supervisor notices the new binary, gracefully stops the current renderer
-// (by closing its stdin, which the renderer's port reader turns into tea.Quit),
-// and spawns the new one.
-//
-// This is a development tool. It is never spawned by BEAM and is not part of the
-// production frontend lifecycle. See lib/minga_editor/frontend/manager.ex for
-// the production spawn/connected port handling it deliberately does not touch.
 package main
 
 import (
@@ -41,18 +19,9 @@ import (
 )
 
 const (
-	// mtimePollInterval is how often we stat the renderer binary to detect a
-	// rebuild. 300ms keeps reloads feeling immediate without busy-spinning.
-	mtimePollInterval = 300 * time.Millisecond
-
-	// rendererStopTimeout bounds how long we wait for a renderer to exit after
-	// closing its stdin before we SIGKILL it, so a wedged renderer can't stall a
-	// reload forever.
+	mtimePollInterval   = 300 * time.Millisecond
 	rendererStopTimeout = 3 * time.Second
-
-	// beamStopTimeout bounds how long we wait for BEAM to exit after closing its
-	// stdin before we kill it.
-	beamStopTimeout = 3 * time.Second
+	beamStopTimeout     = 3 * time.Second
 )
 
 func main() {
@@ -83,10 +52,6 @@ func run() error {
 		return fmt.Errorf("renderer binary not found at %s (build it first): %w", rendererPath, err)
 	}
 
-	// All child stderr and our own diagnostics go to the log file, never to the
-	// terminal: the renderer owns the tty (alt-screen + raw mode) and stray
-	// writes would corrupt its display. Default to stderr only when no log path
-	// is given (e.g. running detached).
 	logOut := os.Stderr
 	if logPath != "" {
 		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
@@ -98,8 +63,6 @@ func run() error {
 	}
 	logger := log.New(logOut, "[minga-supervisor] ", log.LstdFlags)
 
-	// Launch BEAM in connected mode. We own its stdio, so it survives every
-	// renderer respawn and only shuts down when we close its stdin (on exit).
 	beamCmd, beamIn, beamOut, err := launchBeam(root, flag.Args(), logOut, logger)
 	if err != nil {
 		return fmt.Errorf("launch BEAM: %w", err)
@@ -116,8 +79,6 @@ func run() error {
 	var shutdownOnce sync.Once
 	requestShutdown := func() { shutdownOnce.Do(func() { close(shutdown) }) }
 
-	// BEAM death (crash, or a normal quit propagated through the port) tears the
-	// whole session down.
 	beamDone := make(chan struct{})
 	go func() {
 		if err := beamCmd.Wait(); err != nil {
@@ -129,16 +90,11 @@ func run() error {
 		requestShutdown()
 	}()
 
-	// Forward render frames BEAM -> current renderer. This runs for the whole
-	// session; renderer swaps just change where it writes. If BEAM's stdout
-	// closes, BEAM is gone and we shut down.
 	go func() {
 		s.forwardBeamToRenderer(beamOut)
 		requestShutdown()
 	}()
 
-	// OS signals (Ctrl-C typically reaches the renderer as a raw byte, so this is
-	// mostly a backstop) trigger a clean shutdown.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
@@ -148,12 +104,8 @@ func run() error {
 		requestShutdown()
 	}()
 
-	// Own the renderer lifecycle: spawn, watch for rebuilds, reload. Returns when
-	// shutdown is requested or the renderer exits on its own (user quit).
 	s.runRendererManager(shutdown, requestShutdown)
 
-	// Tear down: closing BEAM's stdin is how connected mode learns its parent is
-	// gone (the :eof port option), so BEAM shuts itself down cleanly.
 	_ = beamIn.Close()
 	select {
 	case <-beamDone:
@@ -164,28 +116,14 @@ func run() error {
 	return nil
 }
 
-// supervisor holds the pieces shared across the session: the persistent BEAM
-// stdin writer and the swappable current-renderer stdin.
 type supervisor struct {
 	rendererPath string
-	logOut       io.Writer // child stderr sink (the log file)
+	logOut       io.Writer
 	logger       *log.Logger
 
-	// beamIn is BEAM's stdin (persistent across renderer swaps). It is io.Writer
-	// so no forwarding code can Close it; only run()'s shutdown path does, via the
-	// local WriteCloser. beamInMu serializes writes: a whole {:packet,4} frame is
-	// two Write calls (header then payload), and during a swap the old and new
-	// renderer forwarding goroutines can briefly overlap, so without the lock their
-	// header/payload writes could interleave and corrupt the frame BEAM decodes.
 	beamIn   io.Writer
 	beamInMu sync.Mutex
 
-	// rendIn is the current renderer's stdin, or nil while swapping. It is
-	// io.Writer (not io.WriteCloser) so callers can only forward through it; the
-	// renderer's lifecycle (including Close) is owned solely by spawnRenderer /
-	// stopRenderer via the local WriteCloser they hold. A plain Mutex suffices:
-	// the sole reader is forwardBeamToRenderer, so there's no read-parallelism to
-	// gain from an RWMutex.
 	mu     sync.Mutex
 	rendIn io.Writer
 }
@@ -202,18 +140,12 @@ func (s *supervisor) currentRenderer() io.Writer {
 	return s.rendIn
 }
 
-// writeBeam forwards a whole frame to BEAM under beamInMu, keeping header+payload
-// atomic against a concurrently-quiescing renderer's forwarding goroutine.
 func (s *supervisor) writeBeam(pkt []byte) error {
 	s.beamInMu.Lock()
 	defer s.beamInMu.Unlock()
 	return protocol.WritePacket(s.beamIn, pkt)
 }
 
-// forwardBeamToRenderer reads whole protocol frames from BEAM and writes them to
-// whichever renderer is currently attached. Frames that arrive while no renderer
-// is attached (mid-swap) are dropped on purpose: the next renderer's `ready`
-// makes BEAM send a full keyframe, so a dropped delta is always superseded.
 func (s *supervisor) forwardBeamToRenderer(beamOut io.Reader) {
 	for {
 		pkt, err := protocol.ReadPacket(beamOut)
@@ -225,41 +157,29 @@ func (s *supervisor) forwardBeamToRenderer(beamOut io.Reader) {
 		}
 		w := s.currentRenderer()
 		if w == nil {
-			continue // swapping; keyframe on reconnect will rebuild state
+			continue
 		}
 		if err := protocol.WritePacket(w, pkt); err != nil {
-			// The renderer may be shutting down; drop and keep draining BEAM so
-			// backpressure never stalls the editor.
 			s.logger.Printf("write to renderer failed (likely swapping): %v", err)
 		}
 	}
 }
 
-// rendererHandle bundles a running renderer's process, its stdin (the local
-// WriteCloser that owns Close), and a buffered channel delivering its exit error
-// exactly once (nil on a clean status-0 exit).
 type rendererHandle struct {
 	cmd   *exec.Cmd
 	stdin io.WriteCloser
 	done  <-chan error
 }
 
-// outcome is why a running renderer stopped, which decides what the manager does
-// next.
 type outcome int
 
 const (
-	outcomeShutdown outcome = iota // supervisor is shutting down
-	outcomeUserQuit                // renderer exited cleanly; end the session
-	outcomeReload                  // binary changed; respawn immediately
-	outcomeCrash                   // renderer died on this build; keep BEAM alive
+	outcomeShutdown outcome = iota
+	outcomeUserQuit
+	outcomeReload
+	outcomeCrash
 )
 
-// runRendererManager owns the renderer process across its whole lifecycle: spawn
-// it, watch the binary for rebuilds, reload on change, and crucially keep BEAM
-// alive when a rebuilt renderer crashes (a broken build must not end the
-// session). It returns when shutdown is requested or the renderer exits cleanly
-// (user quit), which it propagates to shutdown.
 func (s *supervisor) runRendererManager(shutdown <-chan struct{}, requestShutdown func()) {
 	ticker := time.NewTicker(mtimePollInterval)
 	defer ticker.Stop()
@@ -269,8 +189,6 @@ func (s *supervisor) runRendererManager(shutdown <-chan struct{}, requestShutdow
 	for {
 		h, err := s.spawnRenderer()
 		if err != nil {
-			// A spawn failure (e.g. the freshly-built binary is corrupt) must not
-			// kill the session either: log it and wait for the next rebuild.
 			s.logger.Printf("spawn renderer failed: %v; keeping BEAM alive, waiting for a rebuild", err)
 			if !s.awaitRebuild(shutdown, ticker, &lastMtime) {
 				return
@@ -285,10 +203,8 @@ func (s *supervisor) runRendererManager(shutdown <-chan struct{}, requestShutdow
 			requestShutdown()
 			return
 		case outcomeReload:
-			continue // binary already changed; respawn straight away
+			continue
 		case outcomeCrash:
-			// The rebuilt renderer died. BEAM still holds all editor state, so wait
-			// for the developer to fix the build and rebuild, then respawn.
 			if !s.awaitRebuild(shutdown, ticker, &lastMtime) {
 				return
 			}
@@ -297,9 +213,6 @@ func (s *supervisor) runRendererManager(shutdown <-chan struct{}, requestShutdow
 	}
 }
 
-// superviseRenderer blocks until the running renderer must stop, and reports why.
-// On a reload or shutdown it stops the renderer first; on an exit it classifies
-// the exit as a clean user quit or a crash.
 func (s *supervisor) superviseRenderer(h *rendererHandle, shutdown <-chan struct{}, ticker *time.Ticker, lastMtime *int64) outcome {
 	for {
 		select {
@@ -309,12 +222,6 @@ func (s *supervisor) superviseRenderer(h *rendererHandle, shutdown <-chan struct
 
 		case err := <-h.done:
 			s.setRenderer(nil)
-			// A renderer only exits status 0 when its stdin hits EOF, which only
-			// stopRenderer causes (and that path drains done itself, never reaching
-			// here). So a *spontaneous* exit through this case is a crash: the
-			// renderer os.Exit(1)s on any run error, and a genuine user quit unwinds
-			// through BEAM shutdown -> outcomeShutdown, not this branch. Classify on
-			// exit status alone; nil still means "clean, treat as quit" defensively.
 			if err == nil {
 				s.logger.Printf("renderer exited cleanly (user quit)")
 				return outcomeUserQuit
@@ -332,8 +239,6 @@ func (s *supervisor) superviseRenderer(h *rendererHandle, shutdown <-chan struct
 	}
 }
 
-// awaitRebuild waits, with no renderer running, for the binary to change so we
-// can respawn. Returns false if shutdown is requested first.
 func (s *supervisor) awaitRebuild(shutdown <-chan struct{}, ticker *time.Ticker, lastMtime *int64) bool {
 	for {
 		select {
@@ -348,9 +253,6 @@ func (s *supervisor) awaitRebuild(shutdown <-chan struct{}, ticker *time.Ticker,
 	}
 }
 
-// mtimeChanged reports whether the renderer binary's mtime differs from *last,
-// updating *last when it does. A zero mtime (mid-rebuild, binary briefly absent)
-// is ignored so a transient stat failure doesn't count as a change.
 func (s *supervisor) mtimeChanged(last *int64) bool {
 	m := s.rendererMtime()
 	if m != *last && m != 0 {
@@ -360,14 +262,9 @@ func (s *supervisor) mtimeChanged(last *int64) bool {
 	return false
 }
 
-// spawnRenderer starts a renderer process wired to BEAM through the supervisor:
-// its stdin receives forwarded frames, its stdout (input events + the ready
-// handshake) is forwarded to BEAM, and it inherits the controlling terminal so
-// its own /dev/tty open lands on the real terminal. The returned handle's done
-// channel delivers the process's exit exactly once.
 func (s *supervisor) spawnRenderer() (*rendererHandle, error) {
 	cmd := exec.Command(s.rendererPath)
-	cmd.Env = os.Environ() // MINGA_TTY, if set, is inherited; else renderer uses /dev/tty
+	cmd.Env = os.Environ()
 	cmd.Stderr = s.logOut
 
 	stdin, err := cmd.StdinPipe()
@@ -384,14 +281,6 @@ func (s *supervisor) spawnRenderer() (*rendererHandle, error) {
 
 	s.setRenderer(stdin)
 
-	// One goroutine owns the renderer's stdout for its whole life: forward every
-	// frame (input events + the ready handshake) to BEAM, then Wait once the read
-	// loop drains. Draining before Wait honors the os/exec contract (Wait closes
-	// the pipe, so reads must finish first) and guarantees this goroutine is done
-	// before stopRenderer returns, so it can't overlap the next renderer's
-	// forwarder. writeBeam still holds beamInMu to keep a frame's header+payload
-	// atomic. done is buffered so the exit is delivered even if no one is reading
-	// yet (e.g. stopRenderer's timeout path).
 	done := make(chan error, 1)
 	go func() {
 		for {
@@ -404,17 +293,14 @@ func (s *supervisor) spawnRenderer() (*rendererHandle, error) {
 				break
 			}
 		}
+		// os/exec's Wait closes stdout, so the read loop must finish before Wait;
+		// reordering reintroduces the race the docs warn about.
 		done <- cmd.Wait()
 	}()
 
 	return &rendererHandle{cmd: cmd, stdin: stdin, done: done}, nil
 }
 
-// stopRenderer gracefully stops the current renderer. Closing its stdin makes
-// the renderer's port reader hit EOF and issue tea.Quit, so bubbletea restores
-// the terminal (leaves alt-screen, disables raw mode) on the way out. If it does
-// not exit within rendererStopTimeout we SIGKILL it as a backstop. It drains the
-// handle's done channel, so callers must not read it again.
 func (s *supervisor) stopRenderer(h *rendererHandle) {
 	s.setRenderer(nil)
 	_ = h.stdin.Close()
@@ -427,8 +313,6 @@ func (s *supervisor) stopRenderer(h *rendererHandle) {
 	}
 }
 
-// rendererMtime returns the renderer binary's mtime in nanoseconds, or 0 if it
-// can't be stat'd (e.g. mid-rebuild, when the watcher has removed it briefly).
 func (s *supervisor) rendererMtime() int64 {
 	info, err := os.Stat(s.rendererPath)
 	if err != nil {
@@ -437,10 +321,6 @@ func (s *supervisor) rendererMtime() int64 {
 	return info.ModTime().UnixNano()
 }
 
-// launchBeam starts the dev BEAM editor in connected mode with its stdio wired
-// to pipes we own. We skip the Go renderer build (MINGA_SKIP_GO_TUI_BUILD=1)
-// because the external watcher owns building it; letting mix rebuild it too
-// would fight the watcher over the same binary.
 func launchBeam(root string, args []string, stderr io.Writer, logger *log.Logger) (*exec.Cmd, io.WriteCloser, io.ReadCloser, error) {
 	mixArgs := append([]string{"minga"}, args...)
 	cmd := exec.Command("mix", mixArgs...)
@@ -452,13 +332,9 @@ func launchBeam(root string, args []string, stderr io.Writer, logger *log.Logger
 	)
 	cmd.Stderr = stderr
 
-	// Put BEAM in its own process group. During a renderer swap raw mode is
-	// briefly torn down, so a Ctrl-C on the terminal is delivered to the whole
-	// foreground group as SIGINT; isolating BEAM keeps that signal from reaching
-	// its break handler mid-session. The supervisor catches the signal itself and
-	// shuts BEAM down cleanly by closing its stdin (:eof). The renderer is
-	// deliberately NOT isolated — it needs the controlling terminal, and a
-	// background process group reading the tty would take SIGTTIN.
+	// Isolate BEAM in its own process group so a swap-window Ctrl-C hits the
+	// supervisor, not BEAM's break handler. The renderer must NOT be isolated: a
+	// background process group reading the tty takes SIGTTIN.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	stdin, err := cmd.StdinPipe()
@@ -476,9 +352,6 @@ func launchBeam(root string, args []string, stderr io.Writer, logger *log.Logger
 	return cmd, stdin, stdout, nil
 }
 
-// projectRoot walks up from the working directory to the nearest directory
-// containing mix.exs, so the supervisor can be launched from anywhere in the
-// tree and still run `mix minga` from the project root.
 func projectRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
@@ -487,7 +360,6 @@ func projectRoot() (string, error) {
 	return findProjectRoot(dir)
 }
 
-// findProjectRoot walks up from start to the nearest ancestor containing mix.exs.
 func findProjectRoot(start string) (string, error) {
 	dir := start
 	for {

--- a/go/tui/cmd/minga-supervisor/main.go
+++ b/go/tui/cmd/minga-supervisor/main.go
@@ -49,6 +49,10 @@ const (
 	// closing its stdin before we SIGKILL it, so a wedged renderer can't stall a
 	// reload forever.
 	rendererStopTimeout = 3 * time.Second
+
+	// beamStopTimeout bounds how long we wait for BEAM to exit after closing its
+	// stdin before we kill it.
+	beamStopTimeout = 3 * time.Second
 )
 
 func main() {
@@ -137,6 +141,7 @@ func run() error {
 	// mostly a backstop) trigger a clean shutdown.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
 	go func() {
 		<-sigCh
 		logger.Printf("signal received; shutting down")
@@ -152,7 +157,7 @@ func run() error {
 	_ = beamIn.Close()
 	select {
 	case <-beamDone:
-	case <-time.After(rendererStopTimeout):
+	case <-time.After(beamStopTimeout):
 		logger.Printf("BEAM did not exit in time; killing")
 		_ = beamCmd.Process.Kill()
 	}
@@ -379,26 +384,26 @@ func (s *supervisor) spawnRenderer() (*rendererHandle, error) {
 
 	s.setRenderer(stdin)
 
-	// Forward renderer -> BEAM (input events and the ready handshake). writeBeam
-	// holds beamInMu so a quiescing previous renderer's goroutine can't interleave
-	// a half-written frame with this one's.
+	// One goroutine owns the renderer's stdout for its whole life: forward every
+	// frame (input events + the ready handshake) to BEAM, then Wait once the read
+	// loop drains. Draining before Wait honors the os/exec contract (Wait closes
+	// the pipe, so reads must finish first) and guarantees this goroutine is done
+	// before stopRenderer returns, so it can't overlap the next renderer's
+	// forwarder. writeBeam still holds beamInMu to keep a frame's header+payload
+	// atomic. done is buffered so the exit is delivered even if no one is reading
+	// yet (e.g. stopRenderer's timeout path).
+	done := make(chan error, 1)
 	go func() {
 		for {
 			pkt, err := protocol.ReadPacket(stdout)
 			if err != nil {
-				return
+				break
 			}
 			if err := s.writeBeam(pkt); err != nil {
 				s.logger.Printf("renderer->BEAM write error: %v", err)
-				return
+				break
 			}
 		}
-	}()
-
-	// Buffered so the Wait goroutine can deliver the exit even if no one is
-	// reading yet (e.g. stopRenderer's timeout path), without leaking.
-	done := make(chan error, 1)
-	go func() {
 		done <- cmd.Wait()
 	}()
 
@@ -446,6 +451,15 @@ func launchBeam(root string, args []string, stderr io.Writer, logger *log.Logger
 		"MINGA_SKIP_GO_TUI_BUILD=1",
 	)
 	cmd.Stderr = stderr
+
+	// Put BEAM in its own process group. During a renderer swap raw mode is
+	// briefly torn down, so a Ctrl-C on the terminal is delivered to the whole
+	// foreground group as SIGINT; isolating BEAM keeps that signal from reaching
+	// its break handler mid-session. The supervisor catches the signal itself and
+	// shuts BEAM down cleanly by closing its stdin (:eof). The renderer is
+	// deliberately NOT isolated — it needs the controlling terminal, and a
+	// background process group reading the tty would take SIGTTIN.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/go/tui/cmd/minga-supervisor/main.go
+++ b/go/tui/cmd/minga-supervisor/main.go
@@ -116,8 +116,11 @@ func run() error {
 	// whole session down.
 	beamDone := make(chan struct{})
 	go func() {
-		_ = beamCmd.Wait()
-		logger.Printf("BEAM exited")
+		if err := beamCmd.Wait(); err != nil {
+			logger.Printf("BEAM exited: %v", err)
+		} else {
+			logger.Printf("BEAM exited cleanly")
+		}
 		close(beamDone)
 		requestShutdown()
 	}()
@@ -160,24 +163,44 @@ func run() error {
 // stdin writer and the swappable current-renderer stdin.
 type supervisor struct {
 	rendererPath string
-	beamIn       io.Writer // BEAM stdin (persistent across renderer swaps)
 	logOut       io.Writer // child stderr sink (the log file)
 	logger       *log.Logger
 
+	// beamIn is BEAM's stdin (persistent across renderer swaps). It is io.Writer
+	// so no forwarding code can Close it; only run()'s shutdown path does, via the
+	// local WriteCloser. beamInMu serializes writes: a whole {:packet,4} frame is
+	// two Write calls (header then payload), and during a swap the old and new
+	// renderer forwarding goroutines can briefly overlap, so without the lock their
+	// header/payload writes could interleave and corrupt the frame BEAM decodes.
+	beamIn   io.Writer
+	beamInMu sync.Mutex
+
+	// rendIn is the current renderer's stdin, or nil while swapping. It is
+	// io.Writer (not io.WriteCloser) so callers can only forward through it; the
+	// renderer's lifecycle (including Close) is owned solely by spawnRenderer /
+	// stopRenderer via the local WriteCloser they hold.
 	mu     sync.RWMutex
-	rendIn io.WriteCloser // current renderer stdin; nil while swapping
+	rendIn io.Writer
 }
 
-func (s *supervisor) setRenderer(w io.WriteCloser) {
+func (s *supervisor) setRenderer(w io.Writer) {
 	s.mu.Lock()
 	s.rendIn = w
 	s.mu.Unlock()
 }
 
-func (s *supervisor) currentRenderer() io.WriteCloser {
+func (s *supervisor) currentRenderer() io.Writer {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.rendIn
+}
+
+// writeBeam forwards a whole frame to BEAM under beamInMu, keeping header+payload
+// atomic against a concurrently-quiescing renderer's forwarding goroutine.
+func (s *supervisor) writeBeam(pkt []byte) error {
+	s.beamInMu.Lock()
+	defer s.beamInMu.Unlock()
+	return protocol.WritePacket(s.beamIn, pkt)
 }
 
 // forwardBeamToRenderer reads whole protocol frames from BEAM and writes them to
@@ -205,10 +228,46 @@ func (s *supervisor) forwardBeamToRenderer(beamOut io.Reader) {
 	}
 }
 
-// runRendererManager owns the renderer process across its whole lifecycle:
-// spawn it, forward its input events to BEAM, watch the binary for rebuilds, and
-// reload on change. It returns when shutdown is requested or the renderer exits
-// on its own (which we treat as a user quit and propagate to shutdown).
+// startupGrace bounds how quickly a renderer must exit for a clean (status 0)
+// exit to be read as a startup failure on a fresh build rather than a user quit.
+// A user opening then quitting within this window is rare and only costs a "still
+// alive, waiting for rebuild" wait; misreading a crash as a quit would wrongly
+// tear the whole session down, so we bias toward "crash" when it exits instantly.
+const startupGrace = 2 * time.Second
+
+// rendererExit carries the outcome of a renderer process for crash-vs-quit
+// classification. err is nil on a status-0 exit; state may be nil if Wait failed.
+type rendererExit struct {
+	err   error
+	state *os.ProcessState
+}
+
+// rendererHandle bundles a running renderer's process, its stdin (the local
+// WriteCloser that owns Close), a buffered channel delivering its exit exactly
+// once, and when it started (for the startupGrace heuristic).
+type rendererHandle struct {
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	done    <-chan rendererExit
+	started time.Time
+}
+
+// outcome is why a running renderer stopped, which decides what the manager does
+// next.
+type outcome int
+
+const (
+	outcomeShutdown outcome = iota // supervisor is shutting down
+	outcomeUserQuit                // renderer exited cleanly; end the session
+	outcomeReload                  // binary changed; respawn immediately
+	outcomeCrash                   // renderer died on this build; keep BEAM alive
+)
+
+// runRendererManager owns the renderer process across its whole lifecycle: spawn
+// it, watch the binary for rebuilds, reload on change, and crucially keep BEAM
+// alive when a rebuilt renderer crashes (a broken build must not end the
+// session). It returns when shutdown is requested or the renderer exits cleanly
+// (user quit), which it propagates to shutdown.
 func (s *supervisor) runRendererManager(shutdown <-chan struct{}, requestShutdown func()) {
 	ticker := time.NewTicker(mtimePollInterval)
 	defer ticker.Stop()
@@ -216,102 +275,167 @@ func (s *supervisor) runRendererManager(shutdown <-chan struct{}, requestShutdow
 	lastMtime := s.rendererMtime()
 
 	for {
-		cmd, stdin, done, err := s.spawnRenderer()
+		h, err := s.spawnRenderer()
 		if err != nil {
-			s.logger.Printf("spawn renderer failed: %v", err)
-			requestShutdown()
-			return
+			// A spawn failure (e.g. the freshly-built binary is corrupt) must not
+			// kill the session either: log it and wait for the next rebuild.
+			s.logger.Printf("spawn renderer failed: %v; keeping BEAM alive, waiting for a rebuild", err)
+			if !s.awaitRebuild(shutdown, ticker, &lastMtime) {
+				return
+			}
+			continue
 		}
 
-		reload := false
-		for !reload {
-			select {
-			case <-shutdown:
-				s.stopRenderer(cmd, stdin, done)
+		switch s.superviseRenderer(h, shutdown, ticker, &lastMtime) {
+		case outcomeShutdown:
+			return
+		case outcomeUserQuit:
+			requestShutdown()
+			return
+		case outcomeReload:
+			continue // binary already changed; respawn straight away
+		case outcomeCrash:
+			// The rebuilt renderer died. BEAM still holds all editor state, so wait
+			// for the developer to fix the build and rebuild, then respawn.
+			if !s.awaitRebuild(shutdown, ticker, &lastMtime) {
 				return
+			}
+			continue
+		}
+	}
+}
 
-			case <-done:
-				// The renderer exited without us asking (user quit with :q, or a
-				// crash). Bring the whole session down.
-				s.logger.Printf("renderer exited on its own; shutting down")
-				s.setRenderer(nil)
-				requestShutdown()
-				return
+// superviseRenderer blocks until the running renderer must stop, and reports why.
+// On a reload or shutdown it stops the renderer first; on an exit it classifies
+// the exit as a clean user quit or a crash.
+func (s *supervisor) superviseRenderer(h *rendererHandle, shutdown <-chan struct{}, ticker *time.Ticker, lastMtime *int64) outcome {
+	for {
+		select {
+		case <-shutdown:
+			s.stopRenderer(h)
+			return outcomeShutdown
 
-			case <-ticker.C:
-				m := s.rendererMtime()
-				if m != lastMtime && m != 0 {
-					lastMtime = m
-					s.logger.Printf("renderer binary changed; reloading")
-					s.stopRenderer(cmd, stdin, done)
-					reload = true
-				}
+		case exit := <-h.done:
+			s.setRenderer(nil)
+			if isCleanQuit(exit, time.Since(h.started)) {
+				s.logger.Printf("renderer exited cleanly (user quit)")
+				return outcomeUserQuit
+			}
+			s.logger.Printf("renderer exited unexpectedly (%s) after %s; keeping BEAM alive, waiting for a rebuild",
+				exitDescription(exit), time.Since(h.started).Round(time.Millisecond))
+			return outcomeCrash
+
+		case <-ticker.C:
+			m := s.rendererMtime()
+			if m != *lastMtime && m != 0 {
+				*lastMtime = m
+				s.logger.Printf("renderer binary changed; reloading")
+				s.stopRenderer(h)
+				return outcomeReload
 			}
 		}
 	}
 }
 
+// awaitRebuild waits, with no renderer running, for the binary to change so we
+// can respawn. Returns false if shutdown is requested first.
+func (s *supervisor) awaitRebuild(shutdown <-chan struct{}, ticker *time.Ticker, lastMtime *int64) bool {
+	for {
+		select {
+		case <-shutdown:
+			return false
+		case <-ticker.C:
+			m := s.rendererMtime()
+			if m != *lastMtime && m != 0 {
+				*lastMtime = m
+				s.logger.Printf("renderer rebuilt; respawning")
+				return true
+			}
+		}
+	}
+}
+
+// isCleanQuit reports whether a renderer exit looks like a deliberate user quit
+// (status 0 after running past startupGrace) rather than a crash on a fresh
+// build. A non-zero/signal exit, or a near-instant clean exit, is treated as a
+// crash so it doesn't tear down the session.
+func isCleanQuit(exit rendererExit, uptime time.Duration) bool {
+	return exit.err == nil && uptime >= startupGrace
+}
+
+func exitDescription(exit rendererExit) string {
+	if exit.err != nil {
+		return exit.err.Error()
+	}
+	return "exit status 0"
+}
+
 // spawnRenderer starts a renderer process wired to BEAM through the supervisor:
 // its stdin receives forwarded frames, its stdout (input events + the ready
 // handshake) is forwarded to BEAM, and it inherits the controlling terminal so
-// its own /dev/tty open lands on the real terminal. The returned done channel
-// closes when the process exits.
-func (s *supervisor) spawnRenderer() (*exec.Cmd, io.WriteCloser, <-chan struct{}, error) {
+// its own /dev/tty open lands on the real terminal. The returned handle's done
+// channel delivers the process's exit exactly once.
+func (s *supervisor) spawnRenderer() (*rendererHandle, error) {
 	cmd := exec.Command(s.rendererPath)
 	cmd.Env = os.Environ() // MINGA_TTY, if set, is inherited; else renderer uses /dev/tty
 	cmd.Stderr = s.logOut
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
+	started := time.Now()
 	if err := cmd.Start(); err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	s.setRenderer(stdin)
 
-	// Forward renderer -> BEAM (input events and the ready handshake). Only one
-	// renderer runs at a time, so writes to BEAM's stdin stay serialized.
+	// Forward renderer -> BEAM (input events and the ready handshake). writeBeam
+	// holds beamInMu so a quiescing previous renderer's goroutine can't interleave
+	// a half-written frame with this one's.
 	go func() {
 		for {
 			pkt, err := protocol.ReadPacket(stdout)
 			if err != nil {
 				return
 			}
-			if err := protocol.WritePacket(s.beamIn, pkt); err != nil {
+			if err := s.writeBeam(pkt); err != nil {
 				s.logger.Printf("renderer->BEAM write error: %v", err)
 				return
 			}
 		}
 	}()
 
-	done := make(chan struct{})
+	// Buffered so the Wait goroutine can deliver the exit even if no one is
+	// reading yet (e.g. stopRenderer's timeout path), without leaking.
+	done := make(chan rendererExit, 1)
 	go func() {
-		_ = cmd.Wait()
-		close(done)
+		err := cmd.Wait()
+		done <- rendererExit{err: err, state: cmd.ProcessState}
 	}()
 
-	return cmd, stdin, done, nil
+	return &rendererHandle{cmd: cmd, stdin: stdin, done: done, started: started}, nil
 }
 
 // stopRenderer gracefully stops the current renderer. Closing its stdin makes
 // the renderer's port reader hit EOF and issue tea.Quit, so bubbletea restores
 // the terminal (leaves alt-screen, disables raw mode) on the way out. If it does
-// not exit within rendererStopTimeout we SIGKILL it as a backstop.
-func (s *supervisor) stopRenderer(cmd *exec.Cmd, stdin io.WriteCloser, done <-chan struct{}) {
+// not exit within rendererStopTimeout we SIGKILL it as a backstop. It drains the
+// handle's done channel, so callers must not read it again.
+func (s *supervisor) stopRenderer(h *rendererHandle) {
 	s.setRenderer(nil)
-	_ = stdin.Close()
+	_ = h.stdin.Close()
 	select {
-	case <-done:
+	case <-h.done:
 	case <-time.After(rendererStopTimeout):
 		s.logger.Printf("renderer did not exit after stdin close; killing")
-		_ = cmd.Process.Kill()
-		<-done
+		_ = h.cmd.Process.Kill()
+		<-h.done
 	}
 }
 
@@ -363,6 +487,12 @@ func projectRoot() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return findProjectRoot(dir)
+}
+
+// findProjectRoot walks up from start to the nearest ancestor containing mix.exs.
+func findProjectRoot(start string) (string, error) {
+	dir := start
 	for {
 		if _, err := os.Stat(filepath.Join(dir, "mix.exs")); err == nil {
 			return dir, nil

--- a/go/tui/cmd/minga-supervisor/main.go
+++ b/go/tui/cmd/minga-supervisor/main.go
@@ -1,0 +1,376 @@
+// Command minga-supervisor is a dev-only hot-reload harness for the Minga TUI.
+//
+// It launches the BEAM editor in *connected* mode (MINGA_PORT_MODE=connected),
+// owning BEAM's stdin/stdout as pipes exactly like the macOS GUI parent does,
+// and sits between BEAM and the Go renderer forwarding the {:packet,4} protocol
+// in both directions. Because the supervisor (not BEAM) owns BEAM's stdio, it
+// can stop and respawn the renderer as many times as it likes WITHOUT BEAM ever
+// seeing its frontend die: BEAM stays alive holding all editor state.
+//
+// On each respawn the fresh renderer sends its `ready` handshake, which the
+// supervisor forwards to BEAM; BEAM re-runs its idempotent ready path (see
+// MingaEditor.Startup.ensure_session_started/1) and dispatches a full keyframe,
+// so the reloaded renderer instantly repaints the untouched editor state.
+//
+// Reload is triggered by watching the renderer binary's mtime: an external
+// `go build` watcher rebuilds go/tui/bin/minga-renderer-go on source change,
+// the supervisor notices the new binary, gracefully stops the current renderer
+// (by closing its stdin, which the renderer's port reader turns into tea.Quit),
+// and spawns the new one.
+//
+// This is a development tool. It is never spawned by BEAM and is not part of the
+// production frontend lifecycle. See lib/minga_editor/frontend/manager.ex for
+// the production spawn/connected port handling it deliberately does not touch.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+const (
+	// mtimePollInterval is how often we stat the renderer binary to detect a
+	// rebuild. 300ms keeps reloads feeling immediate without busy-spinning.
+	mtimePollInterval = 300 * time.Millisecond
+
+	// rendererStopTimeout bounds how long we wait for a renderer to exit after
+	// closing its stdin before we SIGKILL it, so a wedged renderer can't stall a
+	// reload forever.
+	rendererStopTimeout = 3 * time.Second
+)
+
+func main() {
+	log.SetFlags(0)
+	if err := run(); err != nil {
+		log.Printf("[minga-supervisor] fatal: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		rendererPath string
+		logPath      string
+	)
+	flag.StringVar(&rendererPath, "renderer", "", "path to the minga-renderer-go binary (default: <root>/go/tui/bin/minga-renderer-go)")
+	flag.StringVar(&logPath, "log", "", "path to the supervisor log file (default: stderr)")
+	flag.Parse()
+
+	root, err := projectRoot()
+	if err != nil {
+		return err
+	}
+	if rendererPath == "" {
+		rendererPath = filepath.Join(root, "go", "tui", "bin", "minga-renderer-go")
+	}
+	if _, err := os.Stat(rendererPath); err != nil {
+		return fmt.Errorf("renderer binary not found at %s (build it first): %w", rendererPath, err)
+	}
+
+	// All child stderr and our own diagnostics go to the log file, never to the
+	// terminal: the renderer owns the tty (alt-screen + raw mode) and stray
+	// writes would corrupt its display. Default to stderr only when no log path
+	// is given (e.g. running detached).
+	logOut := os.Stderr
+	if logPath != "" {
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			return fmt.Errorf("open log file: %w", err)
+		}
+		defer f.Close()
+		logOut = f
+	}
+	logger := log.New(logOut, "[minga-supervisor] ", log.LstdFlags)
+
+	// Launch BEAM in connected mode. We own its stdio, so it survives every
+	// renderer respawn and only shuts down when we close its stdin (on exit).
+	beamCmd, beamIn, beamOut, err := launchBeam(root, flag.Args(), logOut, logger)
+	if err != nil {
+		return fmt.Errorf("launch BEAM: %w", err)
+	}
+
+	s := &supervisor{
+		rendererPath: rendererPath,
+		beamIn:       beamIn,
+		logOut:       logOut,
+		logger:       logger,
+	}
+
+	shutdown := make(chan struct{})
+	var shutdownOnce sync.Once
+	requestShutdown := func() { shutdownOnce.Do(func() { close(shutdown) }) }
+
+	// BEAM death (crash, or a normal quit propagated through the port) tears the
+	// whole session down.
+	beamDone := make(chan struct{})
+	go func() {
+		_ = beamCmd.Wait()
+		logger.Printf("BEAM exited")
+		close(beamDone)
+		requestShutdown()
+	}()
+
+	// Forward render frames BEAM -> current renderer. This runs for the whole
+	// session; renderer swaps just change where it writes. If BEAM's stdout
+	// closes, BEAM is gone and we shut down.
+	go func() {
+		s.forwardBeamToRenderer(beamOut)
+		requestShutdown()
+	}()
+
+	// OS signals (Ctrl-C typically reaches the renderer as a raw byte, so this is
+	// mostly a backstop) trigger a clean shutdown.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		logger.Printf("signal received; shutting down")
+		requestShutdown()
+	}()
+
+	// Own the renderer lifecycle: spawn, watch for rebuilds, reload. Returns when
+	// shutdown is requested or the renderer exits on its own (user quit).
+	s.runRendererManager(shutdown, requestShutdown)
+
+	// Tear down: closing BEAM's stdin is how connected mode learns its parent is
+	// gone (the :eof port option), so BEAM shuts itself down cleanly.
+	_ = beamIn.Close()
+	select {
+	case <-beamDone:
+	case <-time.After(rendererStopTimeout):
+		logger.Printf("BEAM did not exit in time; killing")
+		_ = beamCmd.Process.Kill()
+	}
+	return nil
+}
+
+// supervisor holds the pieces shared across the session: the persistent BEAM
+// stdin writer and the swappable current-renderer stdin.
+type supervisor struct {
+	rendererPath string
+	beamIn       io.Writer // BEAM stdin (persistent across renderer swaps)
+	logOut       io.Writer // child stderr sink (the log file)
+	logger       *log.Logger
+
+	mu     sync.RWMutex
+	rendIn io.WriteCloser // current renderer stdin; nil while swapping
+}
+
+func (s *supervisor) setRenderer(w io.WriteCloser) {
+	s.mu.Lock()
+	s.rendIn = w
+	s.mu.Unlock()
+}
+
+func (s *supervisor) currentRenderer() io.WriteCloser {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.rendIn
+}
+
+// forwardBeamToRenderer reads whole protocol frames from BEAM and writes them to
+// whichever renderer is currently attached. Frames that arrive while no renderer
+// is attached (mid-swap) are dropped on purpose: the next renderer's `ready`
+// makes BEAM send a full keyframe, so a dropped delta is always superseded.
+func (s *supervisor) forwardBeamToRenderer(beamOut io.Reader) {
+	for {
+		pkt, err := protocol.ReadPacket(beamOut)
+		if err != nil {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+				s.logger.Printf("BEAM->renderer read error: %v", err)
+			}
+			return
+		}
+		w := s.currentRenderer()
+		if w == nil {
+			continue // swapping; keyframe on reconnect will rebuild state
+		}
+		if err := protocol.WritePacket(w, pkt); err != nil {
+			// The renderer may be shutting down; drop and keep draining BEAM so
+			// backpressure never stalls the editor.
+			s.logger.Printf("write to renderer failed (likely swapping): %v", err)
+		}
+	}
+}
+
+// runRendererManager owns the renderer process across its whole lifecycle:
+// spawn it, forward its input events to BEAM, watch the binary for rebuilds, and
+// reload on change. It returns when shutdown is requested or the renderer exits
+// on its own (which we treat as a user quit and propagate to shutdown).
+func (s *supervisor) runRendererManager(shutdown <-chan struct{}, requestShutdown func()) {
+	ticker := time.NewTicker(mtimePollInterval)
+	defer ticker.Stop()
+
+	lastMtime := s.rendererMtime()
+
+	for {
+		cmd, stdin, done, err := s.spawnRenderer()
+		if err != nil {
+			s.logger.Printf("spawn renderer failed: %v", err)
+			requestShutdown()
+			return
+		}
+
+		reload := false
+		for !reload {
+			select {
+			case <-shutdown:
+				s.stopRenderer(cmd, stdin, done)
+				return
+
+			case <-done:
+				// The renderer exited without us asking (user quit with :q, or a
+				// crash). Bring the whole session down.
+				s.logger.Printf("renderer exited on its own; shutting down")
+				s.setRenderer(nil)
+				requestShutdown()
+				return
+
+			case <-ticker.C:
+				m := s.rendererMtime()
+				if m != lastMtime && m != 0 {
+					lastMtime = m
+					s.logger.Printf("renderer binary changed; reloading")
+					s.stopRenderer(cmd, stdin, done)
+					reload = true
+				}
+			}
+		}
+	}
+}
+
+// spawnRenderer starts a renderer process wired to BEAM through the supervisor:
+// its stdin receives forwarded frames, its stdout (input events + the ready
+// handshake) is forwarded to BEAM, and it inherits the controlling terminal so
+// its own /dev/tty open lands on the real terminal. The returned done channel
+// closes when the process exits.
+func (s *supervisor) spawnRenderer() (*exec.Cmd, io.WriteCloser, <-chan struct{}, error) {
+	cmd := exec.Command(s.rendererPath)
+	cmd.Env = os.Environ() // MINGA_TTY, if set, is inherited; else renderer uses /dev/tty
+	cmd.Stderr = s.logOut
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, nil, nil, err
+	}
+
+	s.setRenderer(stdin)
+
+	// Forward renderer -> BEAM (input events and the ready handshake). Only one
+	// renderer runs at a time, so writes to BEAM's stdin stay serialized.
+	go func() {
+		for {
+			pkt, err := protocol.ReadPacket(stdout)
+			if err != nil {
+				return
+			}
+			if err := protocol.WritePacket(s.beamIn, pkt); err != nil {
+				s.logger.Printf("renderer->BEAM write error: %v", err)
+				return
+			}
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+
+	return cmd, stdin, done, nil
+}
+
+// stopRenderer gracefully stops the current renderer. Closing its stdin makes
+// the renderer's port reader hit EOF and issue tea.Quit, so bubbletea restores
+// the terminal (leaves alt-screen, disables raw mode) on the way out. If it does
+// not exit within rendererStopTimeout we SIGKILL it as a backstop.
+func (s *supervisor) stopRenderer(cmd *exec.Cmd, stdin io.WriteCloser, done <-chan struct{}) {
+	s.setRenderer(nil)
+	_ = stdin.Close()
+	select {
+	case <-done:
+	case <-time.After(rendererStopTimeout):
+		s.logger.Printf("renderer did not exit after stdin close; killing")
+		_ = cmd.Process.Kill()
+		<-done
+	}
+}
+
+// rendererMtime returns the renderer binary's mtime in nanoseconds, or 0 if it
+// can't be stat'd (e.g. mid-rebuild, when the watcher has removed it briefly).
+func (s *supervisor) rendererMtime() int64 {
+	info, err := os.Stat(s.rendererPath)
+	if err != nil {
+		return 0
+	}
+	return info.ModTime().UnixNano()
+}
+
+// launchBeam starts the dev BEAM editor in connected mode with its stdio wired
+// to pipes we own. We skip the Go renderer build (MINGA_SKIP_GO_TUI_BUILD=1)
+// because the external watcher owns building it; letting mix rebuild it too
+// would fight the watcher over the same binary.
+func launchBeam(root string, args []string, stderr io.Writer, logger *log.Logger) (*exec.Cmd, io.WriteCloser, io.ReadCloser, error) {
+	mixArgs := append([]string{"minga"}, args...)
+	cmd := exec.Command("mix", mixArgs...)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"MINGA_PORT_MODE=connected",
+		"MINGA_CONNECTED_BACKEND=tui",
+		"MINGA_SKIP_GO_TUI_BUILD=1",
+	)
+	cmd.Stderr = stderr
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	logger.Printf("launching BEAM: mix %v (cwd=%s)", mixArgs, root)
+	if err := cmd.Start(); err != nil {
+		return nil, nil, nil, err
+	}
+	return cmd, stdin, stdout, nil
+}
+
+// projectRoot walks up from the working directory to the nearest directory
+// containing mix.exs, so the supervisor can be launched from anywhere in the
+// tree and still run `mix minga` from the project root.
+func projectRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "mix.exs")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("could not find project root (no mix.exs in any parent directory)")
+		}
+		dir = parent
+	}
+}

--- a/go/tui/cmd/minga-supervisor/main_test.go
+++ b/go/tui/cmd/minga-supervisor/main_test.go
@@ -14,28 +14,6 @@ import (
 
 func discardLogger() *log.Logger { return log.New(io.Discard, "", 0) }
 
-func TestIsCleanQuit(t *testing.T) {
-	tests := []struct {
-		name   string
-		exit   rendererExit
-		uptime time.Duration
-		want   bool
-	}{
-		{"status 0 after running: user quit", rendererExit{err: nil}, startupGrace + time.Second, true},
-		{"status 0 but near-instant: startup crash", rendererExit{err: nil}, 10 * time.Millisecond, false},
-		{"non-zero exit: crash", rendererExit{err: io.ErrUnexpectedEOF}, startupGrace + time.Second, false},
-		{"non-zero and instant: crash", rendererExit{err: io.ErrUnexpectedEOF}, time.Millisecond, false},
-		{"exactly at grace: user quit", rendererExit{err: nil}, startupGrace, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isCleanQuit(tt.exit, tt.uptime); got != tt.want {
-				t.Fatalf("isCleanQuit(%v, %v) = %v, want %v", tt.exit, tt.uptime, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestFindProjectRoot(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "mix.exs"), []byte("# marker"), 0o644); err != nil {

--- a/go/tui/cmd/minga-supervisor/main_test.go
+++ b/go/tui/cmd/minga-supervisor/main_test.go
@@ -28,15 +28,13 @@ func TestFindProjectRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// t.TempDir may live under a symlinked path (e.g. /var -> /private/var on
-	// macOS); compare resolved paths so the symlink doesn't fail the assertion.
 	if resolve(t, got) != resolve(t, root) {
 		t.Fatalf("findProjectRoot = %q, want %q", got, root)
 	}
 }
 
 func TestFindProjectRoot_NoMarker(t *testing.T) {
-	dir := t.TempDir() // a temp dir with no mix.exs above it (up to the fs root)
+	dir := t.TempDir()
 	if _, err := findProjectRoot(dir); err == nil {
 		t.Fatal("expected an error when no mix.exs exists in any parent, got nil")
 	}
@@ -76,7 +74,7 @@ func TestMtimeChanged(t *testing.T) {
 	}
 	s := &supervisor{logger: discardLogger(), rendererPath: bin}
 
-	var last int64 // zero baseline
+	var last int64
 	if !s.mtimeChanged(&last) {
 		t.Fatal("first check against a zero baseline should report changed")
 	}
@@ -84,7 +82,6 @@ func TestMtimeChanged(t *testing.T) {
 		t.Fatal("no rebuild between checks should report unchanged")
 	}
 
-	// Simulate a rebuild by bumping the binary's mtime forward.
 	future := time.Now().Add(time.Second)
 	if err := os.Chtimes(bin, future, future); err != nil {
 		t.Fatal(err)
@@ -94,11 +91,9 @@ func TestMtimeChanged(t *testing.T) {
 	}
 }
 
-// TestForwardBeamToRenderer_DeliversWhenAttached feeds framed packets through the
-// forwarder while a renderer is attached and asserts every frame arrives intact.
 func TestForwardBeamToRenderer_DeliversWhenAttached(t *testing.T) {
 	s := &supervisor{logger: discardLogger()}
-	var out bytes.Buffer // sole writer is the forward goroutine; read after it exits
+	var out bytes.Buffer
 	s.setRenderer(&out)
 
 	pr, pw := io.Pipe()
@@ -114,7 +109,7 @@ func TestForwardBeamToRenderer_DeliversWhenAttached(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	_ = pw.Close() // EOF -> forwarder drains everything read so far, then returns
+	_ = pw.Close()
 	<-done
 
 	got := readAllPackets(t, out.Bytes())
@@ -128,11 +123,9 @@ func TestForwardBeamToRenderer_DeliversWhenAttached(t *testing.T) {
 	}
 }
 
-// TestForwardBeamToRenderer_DropsWhenDetached asserts that frames arriving while
-// no renderer is attached (mid-swap) are dropped without panicking or blocking.
 func TestForwardBeamToRenderer_DropsWhenDetached(t *testing.T) {
 	s := &supervisor{logger: discardLogger()}
-	s.setRenderer(nil) // detached
+	s.setRenderer(nil)
 
 	pr, pw := io.Pipe()
 	done := make(chan struct{})
@@ -153,7 +146,6 @@ func TestForwardBeamToRenderer_DropsWhenDetached(t *testing.T) {
 	}
 }
 
-// readAllPackets splits a byte stream of {:packet,4} frames back into payloads.
 func readAllPackets(t *testing.T, data []byte) [][]byte {
 	t.Helper()
 	var out [][]byte

--- a/go/tui/cmd/minga-supervisor/main_test.go
+++ b/go/tui/cmd/minga-supervisor/main_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+func discardLogger() *log.Logger { return log.New(io.Discard, "", 0) }
+
+func TestIsCleanQuit(t *testing.T) {
+	tests := []struct {
+		name   string
+		exit   rendererExit
+		uptime time.Duration
+		want   bool
+	}{
+		{"status 0 after running: user quit", rendererExit{err: nil}, startupGrace + time.Second, true},
+		{"status 0 but near-instant: startup crash", rendererExit{err: nil}, 10 * time.Millisecond, false},
+		{"non-zero exit: crash", rendererExit{err: io.ErrUnexpectedEOF}, startupGrace + time.Second, false},
+		{"non-zero and instant: crash", rendererExit{err: io.ErrUnexpectedEOF}, time.Millisecond, false},
+		{"exactly at grace: user quit", rendererExit{err: nil}, startupGrace, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCleanQuit(tt.exit, tt.uptime); got != tt.want {
+				t.Fatalf("isCleanQuit(%v, %v) = %v, want %v", tt.exit, tt.uptime, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "mix.exs"), []byte("# marker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(root, "go", "tui", "cmd")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findProjectRoot(nested)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// t.TempDir may live under a symlinked path (e.g. /var -> /private/var on
+	// macOS); compare resolved paths so the symlink doesn't fail the assertion.
+	if resolve(t, got) != resolve(t, root) {
+		t.Fatalf("findProjectRoot = %q, want %q", got, root)
+	}
+}
+
+func TestFindProjectRoot_NoMarker(t *testing.T) {
+	dir := t.TempDir() // a temp dir with no mix.exs above it (up to the fs root)
+	if _, err := findProjectRoot(dir); err == nil {
+		t.Fatal("expected an error when no mix.exs exists in any parent, got nil")
+	}
+}
+
+func resolve(t *testing.T, path string) string {
+	t.Helper()
+	r, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", path, err)
+	}
+	return r
+}
+
+func TestRendererMtime(t *testing.T) {
+	s := &supervisor{logger: discardLogger()}
+
+	s.rendererPath = filepath.Join(t.TempDir(), "does-not-exist")
+	if got := s.rendererMtime(); got != 0 {
+		t.Fatalf("mtime of missing binary = %d, want 0", got)
+	}
+
+	bin := filepath.Join(t.TempDir(), "renderer")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s.rendererPath = bin
+	if got := s.rendererMtime(); got == 0 {
+		t.Fatal("mtime of existing binary = 0, want non-zero")
+	}
+}
+
+// TestForwardBeamToRenderer_DeliversWhenAttached feeds framed packets through the
+// forwarder while a renderer is attached and asserts every frame arrives intact.
+func TestForwardBeamToRenderer_DeliversWhenAttached(t *testing.T) {
+	s := &supervisor{logger: discardLogger()}
+	var out bytes.Buffer // sole writer is the forward goroutine; read after it exits
+	s.setRenderer(&out)
+
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		s.forwardBeamToRenderer(pr)
+		close(done)
+	}()
+
+	frames := [][]byte{{0x01, 0x02}, {0x03}, {0xAA, 0xBB, 0xCC}}
+	for _, f := range frames {
+		if err := protocol.WritePacket(pw, f); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = pw.Close() // EOF -> forwarder drains everything read so far, then returns
+	<-done
+
+	got := readAllPackets(t, out.Bytes())
+	if len(got) != len(frames) {
+		t.Fatalf("delivered %d frames, want %d", len(got), len(frames))
+	}
+	for i := range frames {
+		if !bytes.Equal(got[i], frames[i]) {
+			t.Fatalf("frame %d = %v, want %v", i, got[i], frames[i])
+		}
+	}
+}
+
+// TestForwardBeamToRenderer_DropsWhenDetached asserts that frames arriving while
+// no renderer is attached (mid-swap) are dropped without panicking or blocking.
+func TestForwardBeamToRenderer_DropsWhenDetached(t *testing.T) {
+	s := &supervisor{logger: discardLogger()}
+	s.setRenderer(nil) // detached
+
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		s.forwardBeamToRenderer(pr)
+		close(done)
+	}()
+
+	if err := protocol.WritePacket(pw, []byte{0x01, 0x02}); err != nil {
+		t.Fatal(err)
+	}
+	_ = pw.Close()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwarder did not return after EOF while detached (possible block on nil renderer)")
+	}
+}
+
+// readAllPackets splits a byte stream of {:packet,4} frames back into payloads.
+func readAllPackets(t *testing.T, data []byte) [][]byte {
+	t.Helper()
+	var out [][]byte
+	r := bytes.NewReader(data)
+	for {
+		pkt, err := protocol.ReadPacket(r)
+		if err == io.EOF {
+			return out
+		}
+		if err != nil {
+			t.Fatalf("ReadPacket: %v", err)
+		}
+		out = append(out, pkt)
+	}
+}

--- a/go/tui/cmd/minga-supervisor/main_test.go
+++ b/go/tui/cmd/minga-supervisor/main_test.go
@@ -69,6 +69,31 @@ func TestRendererMtime(t *testing.T) {
 	}
 }
 
+func TestMtimeChanged(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "renderer")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s := &supervisor{logger: discardLogger(), rendererPath: bin}
+
+	var last int64 // zero baseline
+	if !s.mtimeChanged(&last) {
+		t.Fatal("first check against a zero baseline should report changed")
+	}
+	if s.mtimeChanged(&last) {
+		t.Fatal("no rebuild between checks should report unchanged")
+	}
+
+	// Simulate a rebuild by bumping the binary's mtime forward.
+	future := time.Now().Add(time.Second)
+	if err := os.Chtimes(bin, future, future); err != nil {
+		t.Fatal(err)
+	}
+	if !s.mtimeChanged(&last) {
+		t.Fatal("after an mtime bump should report changed")
+	}
+}
+
 // TestForwardBeamToRenderer_DeliversWhenAttached feeds framed packets through the
 // forwarder while a renderer is attached and asserts every frame arrives intact.
 func TestForwardBeamToRenderer_DeliversWhenAttached(t *testing.T) {

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -52,7 +52,6 @@ defmodule MingaEditor do
   alias MingaEditor.Handlers.LspEventHandler
   alias MingaEditor.Handlers.RenderHandler
   alias MingaEditor.Handlers.SessionHandler
-  alias MingaEditor.Handlers.SessionRestore
   alias MingaEditor.Handlers.ToolHandler
   # WarningLog removed in #825; warnings route through MessageLog with level override
   alias MingaEditor.Window
@@ -84,8 +83,6 @@ defmodule MingaEditor do
           | {:suppress_tool_prompts, boolean()}
 
   alias MingaEditor.State, as: EditorState
-
-  alias MingaEditor.State.Session, as: EditorSessionState
 
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.ModalOverlay
@@ -415,22 +412,14 @@ defmodule MingaEditor do
     StartupTimer.mark(:first_render_dispatched)
     StartupTimer.report()
 
-    # Setup highlighting after first paint with correct viewport
+    # Setup highlighting after first paint with correct viewport. Idempotent:
+    # re-requests highlight for the current buffer, safe on renderer reconnect.
     new_state = setup_highlight_or_defer(new_state)
 
-    SessionRestore.maybe_check_swap_recovery(new_state)
-
-    # If the agentic view was activated at init, start the session now
-    # that the port is connected and the viewport is known.
-    new_state = AgentLifecycle.maybe_start_session(new_state)
-    # Start the periodic session save timer (30 seconds); skip in headless
-    # to avoid non-deterministic timer messages during tests.
-    new_state =
-      if new_state.backend != :headless do
-        %{new_state | session: EditorSessionState.start_timer(new_state.session)}
-      else
-        new_state
-      end
+    # Everything above is idempotent rehydration and re-runs on every `ready`
+    # (including a renderer reconnect / dev hot-reload). The one-time,
+    # non-idempotent startup work runs exactly once, guarded internally.
+    new_state = Startup.ensure_session_started(new_state)
 
     {:noreply, new_state}
   end

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -412,13 +412,7 @@ defmodule MingaEditor do
     StartupTimer.mark(:first_render_dispatched)
     StartupTimer.report()
 
-    # Setup highlighting after first paint with correct viewport. Idempotent:
-    # re-requests highlight for the current buffer, safe on renderer reconnect.
     new_state = setup_highlight_or_defer(new_state)
-
-    # Everything above is idempotent rehydration and re-runs on every `ready`
-    # (including a renderer reconnect / dev hot-reload). The one-time,
-    # non-idempotent startup work runs exactly once, guarded internally.
     new_state = Startup.ensure_session_started(new_state)
 
     {:noreply, new_state}

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -45,11 +45,13 @@ defmodule MingaEditor.Startup do
   the parts that are NOT safe to re-run:
 
     * swap recovery — re-sends `:check_swap_recovery`, would re-prompt/re-recover
-    * agent session start — should not restart an already-running session
     * the 30s session-save timer — `start_timer/1` leaks a new timer ref per call
+    * agent session start — already self-guarded via `AgentAccess.session/1`, so
+      re-running is a no-op on its own; kept here for locality with the other two
 
-  Guarded by `state.session_started?` so subsequent readys skip it and take the
-  pure rehydration path. Returns the state unchanged once already started.
+  The first two have no internal guard, so the `state.session_started?` gate is
+  load-bearing for them. Subsequent readys skip the whole block and take the pure
+  rehydration path. Returns the state unchanged once already started.
   """
   @spec ensure_session_started(EditorState.t()) :: EditorState.t()
   def ensure_session_started(%EditorState{session_started?: true} = state), do: state

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -59,18 +59,21 @@ defmodule MingaEditor.Startup do
   def ensure_session_started(%EditorState{} = state) do
     SessionRestore.maybe_check_swap_recovery(state)
 
-    state = AgentLifecycle.maybe_start_session(state)
-
-    # Start the periodic session save timer (30 seconds); skip in headless to
-    # avoid non-deterministic timer messages during tests.
     state =
-      if state.backend != :headless do
-        %{state | session: EditorSessionState.start_timer(state.session)}
-      else
-        state
-      end
+      state
+      |> AgentLifecycle.maybe_start_session()
+      |> maybe_start_save_timer()
 
     %{state | session_started?: true}
+  end
+
+  # Starts the periodic session save timer (30s). Skipped in headless so tests
+  # don't receive non-deterministic timer messages.
+  @spec maybe_start_save_timer(EditorState.t()) :: EditorState.t()
+  defp maybe_start_save_timer(%EditorState{backend: :headless} = state), do: state
+
+  defp maybe_start_save_timer(%EditorState{} = state) do
+    %{state | session: EditorSessionState.start_timer(state.session)}
   end
 
   @doc """

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -11,6 +11,8 @@ defmodule MingaEditor.Startup do
   @dialyzer {:no_opaque, build_initial_state: 1}
 
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.AgentLifecycle
+  alias MingaEditor.Handlers.SessionRestore
   alias Minga.Buffer
   alias Minga.Log
   alias Minga.Config
@@ -32,6 +34,42 @@ defmodule MingaEditor.Startup do
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
   alias Minga.Config.Options
+
+  @doc """
+  Runs the one-time, non-idempotent startup work triggered by the first
+  `ready` handshake, exactly once per session.
+
+  The `ready` handler resets frontend render state and dispatches a full
+  keyframe on *every* ready, so it is safe to re-run when a renderer
+  reconnects (dev hot-reload, late-subscriber replay). This function isolates
+  the parts that are NOT safe to re-run:
+
+    * swap recovery — re-sends `:check_swap_recovery`, would re-prompt/re-recover
+    * agent session start — should not restart an already-running session
+    * the 30s session-save timer — `start_timer/1` leaks a new timer ref per call
+
+  Guarded by `state.session_started?` so subsequent readys skip it and take the
+  pure rehydration path. Returns the state unchanged once already started.
+  """
+  @spec ensure_session_started(EditorState.t()) :: EditorState.t()
+  def ensure_session_started(%EditorState{session_started?: true} = state), do: state
+
+  def ensure_session_started(%EditorState{} = state) do
+    SessionRestore.maybe_check_swap_recovery(state)
+
+    state = AgentLifecycle.maybe_start_session(state)
+
+    # Start the periodic session save timer (30 seconds); skip in headless to
+    # avoid non-deterministic timer messages during tests.
+    state =
+      if state.backend != :headless do
+        %{state | session: EditorSessionState.start_timer(state.session)}
+      else
+        state
+      end
+
+    %{state | session_started?: true}
+  end
 
   @doc """
   Builds the complete initial EditorState from startup opts.

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -35,24 +35,7 @@ defmodule MingaEditor.Startup do
   alias MingaEditor.WindowTree
   alias Minga.Config.Options
 
-  @doc """
-  Runs the one-time, non-idempotent startup work triggered by the first
-  `ready` handshake, exactly once per session.
-
-  The `ready` handler resets frontend render state and dispatches a full
-  keyframe on *every* ready, so it is safe to re-run when a renderer
-  reconnects (dev hot-reload, late-subscriber replay). This function isolates
-  the parts that are NOT safe to re-run:
-
-    * swap recovery — re-sends `:check_swap_recovery`, would re-prompt/re-recover
-    * the 30s session-save timer — `start_timer/1` leaks a new timer ref per call
-    * agent session start — already self-guarded via `AgentAccess.session/1`, so
-      re-running is a no-op on its own; kept here for locality with the other two
-
-  The first two have no internal guard, so the `state.session_started?` gate is
-  load-bearing for them. Subsequent readys skip the whole block and take the pure
-  rehydration path. Returns the state unchanged once already started.
-  """
+  @doc "Runs the one-time startup work (swap recovery, agent session, save timer) exactly once per session."
   @spec ensure_session_started(EditorState.t()) :: EditorState.t()
   def ensure_session_started(%EditorState{session_started?: true} = state), do: state
 
@@ -67,8 +50,6 @@ defmodule MingaEditor.Startup do
     %{state | session_started?: true}
   end
 
-  # Starts the periodic session save timer (30s). Skipped in headless so tests
-  # don't receive non-deterministic timer messages.
   @spec maybe_start_save_timer(EditorState.t()) :: EditorState.t()
   defp maybe_start_save_timer(%EditorState{backend: :headless} = state), do: state
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -158,11 +158,9 @@ defmodule MingaEditor.State do
             # (see MingaEditor.refresh_gui_config_state/1), so the render pipeline
             # reads it for free each frame. nil until the first GUI frontend attaches.
             gui_config_state: nil,
-            # Set true once the one-time, non-idempotent startup work has run on
-            # the first `ready` handshake (swap recovery, agent session, save
-            # timer). Guards `Startup.ensure_session_started/1` so a renderer
-            # reconnect (e.g. dev hot-reload) re-sends `ready` and gets a full
-            # rehydration keyframe WITHOUT re-triggering that once-only work.
+            # Latched once the first `ready` runs the one-time startup work, so a
+            # renderer reconnect (dev hot-reload) re-runs the idempotent ready path
+            # without re-triggering it. See `Startup.ensure_session_started/1`.
             session_started?: false
 
   @type backend :: :tui | :gui | :native_gui | :headless

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -157,7 +157,13 @@ defmodule MingaEditor.State do
             # semantic model (#2119). Rebuilt only when a settings option changes
             # (see MingaEditor.refresh_gui_config_state/1), so the render pipeline
             # reads it for free each frame. nil until the first GUI frontend attaches.
-            gui_config_state: nil
+            gui_config_state: nil,
+            # Set true once the one-time, non-idempotent startup work has run on
+            # the first `ready` handshake (swap recovery, agent session, save
+            # timer). Guards `Startup.ensure_session_started/1` so a renderer
+            # reconnect (e.g. dev hot-reload) re-sends `ready` and gets a full
+            # rehydration keyframe WITHOUT re-triggering that once-only work.
+            session_started?: false
 
   @type backend :: :tui | :gui | :native_gui | :headless
 
@@ -220,7 +226,8 @@ defmodule MingaEditor.State do
           font_size_override: pos_integer() | nil,
           last_input_seq: non_neg_integer(),
           keyframe_pending?: boolean(),
-          gui_config_state: Minga.RenderModel.UI.ConfigState.t() | nil
+          gui_config_state: Minga.RenderModel.UI.ConfigState.t() | nil,
+          session_started?: boolean()
         }
 
   @doc "Returns the cached native settings snapshot emitted in-frame (#2119)."

--- a/macos/Tests/MingaTests/FeedbackStateTests.swift
+++ b/macos/Tests/MingaTests/FeedbackStateTests.swift
@@ -128,8 +128,14 @@ struct FeedbackStateTests {
     @MainActor func fastCompletionPreventsSpinner() async throws {
         let state = FeedbackState()
         state.update(message: "Formatting…")
-        try await Task.sleep(for: .milliseconds(50))
+        // Completion arrives in the same synchronous main-actor turn, before the
+        // delayed show-task can run, so it cancels the pending spinner
+        // deterministically. The previous version slept 50ms hoping to land inside
+        // the 100ms delay window, but a loaded CI runner overruns that sleep past
+        // the delay, letting the spinner fire and flakily failing this assertion.
         state.update(message: "Formatted")
+        // Wait past the spinner delay to prove the cancelled show-task never fires.
+        try await Task.sleep(for: FeedbackState.spinnerDelay + .milliseconds(100))
         #expect(!state.showingSpinner)
     }
 

--- a/macos/Tests/MingaTests/FeedbackStateTests.swift
+++ b/macos/Tests/MingaTests/FeedbackStateTests.swift
@@ -128,13 +128,9 @@ struct FeedbackStateTests {
     @MainActor func fastCompletionPreventsSpinner() async throws {
         let state = FeedbackState()
         state.update(message: "Formatting…")
-        // Completion arrives in the same synchronous main-actor turn, before the
-        // delayed show-task can run, so it cancels the pending spinner
-        // deterministically. The previous version slept 50ms hoping to land inside
-        // the 100ms delay window, but a loaded CI runner overruns that sleep past
-        // the delay, letting the spinner fire and flakily failing this assertion.
+        // Complete in the same synchronous turn so the delayed show-task is
+        // cancelled before it can run; a real sleep here flakes on a loaded CI.
         state.update(message: "Formatted")
-        // Wait past the spinner delay to prove the cancelled show-task never fires.
         try await Task.sleep(for: FeedbackState.spinnerDelay + .milliseconds(100))
         #expect(!state.showingSpinner)
     }

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -17,6 +17,7 @@ defmodule MingaEditor.StartupTest do
   alias MingaEditor.Shell.Registry, as: ShellRegistry
   alias MingaEditor.Startup
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Session
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace
   alias MingaEditor.State.Workspace.Persistence
@@ -770,6 +771,38 @@ defmodule MingaEditor.StartupTest do
       options_server: server || Options.default_server(),
       capabilities: %Capabilities{frontend_type: frontend_type}
     }
+  end
+
+  describe "ensure_session_started/1" do
+    test "runs once: flips session_started? on the first call" do
+      state = %EditorState{
+        port_manager: self(),
+        workspace: nil,
+        backend: :headless,
+        session_started?: false
+      }
+
+      result = Startup.ensure_session_started(state)
+
+      assert result.session_started? == true
+    end
+
+    test "is a no-op on an already-started state (renderer reconnect / hot-reload)" do
+      # A reconnecting renderer re-sends `ready`, which must NOT re-run the
+      # once-only startup work. The guard returns the state untouched, so no
+      # duplicate save timer is created and swap recovery is not re-triggered.
+      timer_ref = make_ref()
+
+      state = %EditorState{
+        port_manager: self(),
+        workspace: nil,
+        session_started?: true,
+        session: %Session{timer: timer_ref}
+      }
+
+      assert Startup.ensure_session_started(state) == state
+      assert Startup.ensure_session_started(state).session.timer == timer_ref
+    end
   end
 
   defp window_state(scope, window) do

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -774,35 +774,43 @@ defmodule MingaEditor.StartupTest do
   end
 
   describe "ensure_session_started/1" do
-    test "runs once: flips session_started? on the first call" do
-      state = %EditorState{
-        port_manager: self(),
-        workspace: nil,
-        backend: :headless,
-        session_started?: false
-      }
-
-      result = Startup.ensure_session_started(state)
+    test "runs the once-only startup work on the first call" do
+      result = Startup.ensure_session_started(unstarted_state())
 
       assert result.session_started? == true
+      # The save timer was actually started (not skipped), so we have something
+      # real whose non-recreation the reconnect test can assert on.
+      assert is_reference(result.session.timer)
     end
 
     test "is a no-op on an already-started state (renderer reconnect / hot-reload)" do
-      # A reconnecting renderer re-sends `ready`, which must NOT re-run the
-      # once-only startup work. The guard returns the state untouched, so no
-      # duplicate save timer is created and swap recovery is not re-triggered.
-      timer_ref = make_ref()
+      # A reconnecting renderer re-sends `ready`. The guard must prevent re-running
+      # the non-idempotent work: no second save timer, no re-triggered swap recovery.
+      first = Startup.ensure_session_started(unstarted_state())
+      timer = first.session.timer
+      assert is_reference(timer)
 
-      state = %EditorState{
-        port_manager: self(),
-        workspace: nil,
-        session_started?: true,
-        session: %Session{timer: timer_ref}
-      }
+      second = Startup.ensure_session_started(first)
 
-      assert Startup.ensure_session_started(state) == state
-      assert Startup.ensure_session_started(state).session.timer == timer_ref
+      # Identical state back, and crucially the SAME timer ref: if the guard were
+      # removed, start_timer/1 would run again and mint a new ref here.
+      assert second == first
+      assert second.session.timer == timer
     end
+  end
+
+  # A non-headless backend with a session_dir makes the once-only work observable:
+  # start_timer/1 actually creates a save-timer ref (it no-ops on :headless or a
+  # nil session_dir), so a re-run would produce a *different* ref. This is what
+  # makes the "no-op on reconnect" test fail if the guard clause is removed.
+  defp unstarted_state do
+    %EditorState{
+      port_manager: self(),
+      workspace: nil,
+      backend: :tui,
+      session_started?: false,
+      session: %Session{session_dir: System.tmp_dir!()}
+    }
   end
 
   defp window_state(scope, window) do


### PR DESCRIPTION
## What & why

Edit the Go renderer and see the **running** TUI repaint without restarting or losing editor state. The renderer is a thin frame-consumer; all editor state lives in BEAM. This adds a dev-only supervisor that keeps BEAM alive across renderer respawns, so a rebuilt renderer reconnects and BEAM repaints the untouched state via a keyframe.

Approach vetted with `archie`: own the reload lifecycle in a **connected-mode Go supervisor** (reusing the same decoupling the macOS GUI parent already uses in production) rather than branching BEAM's production exit handler. `lib/minga_editor/frontend/manager.ex` is untouched.

## Two parts

### 1. Production hardening (mergeable on its own)
The `ready` handler is now idempotent. Once-only startup work (swap recovery, agent-session start, the 30s save timer) moves into `Startup.ensure_session_started/1`, guarded by a new `session_started?` flag. A renderer reconnect re-sends `ready` and gets a full rehydration keyframe **without** re-triggering that work, which would otherwise leak a duplicate save timer and re-run swap recovery. The late-subscriber `ready` replay (`manager.ex:139`) already made this latently double-fire-prone, so this is a correctness fix independent of the dev tool.

### 2. Dev tooling
- **`go/tui/cmd/minga-supervisor`**: connected-mode parent that forwards `{:packet,4}` frames between BEAM and a hot-swappable renderer. Stops a renderer cleanly by closing its stdin (the port reader turns EOF into `tea.Quit`, restoring the tty). **The renderer binary is unchanged.**
- **`bin/minga-dev`**: builds renderer + supervisor, pre-compiles BEAM (keeps protocol stdout clean), polls `go/tui` sources and rebuilds the renderer on change, execs the supervisor.

Coordinated-swap design (chosen over PTY): a brief alt-screen blip on reload, but no session loss and far less code.

## How to test
\`\`\`
bin/minga-dev README.md
# another pane:
tail -f ~/.local/share/minga/minga-dev.log
\`\`\`
Edit something in `go/tui/internal/ui/` (e.g. a label/color in `render_chrome.go`), save, and watch the same editor state repaint with your change, no restart. The log shows `source change detected; rebuilding renderer` → `renderer binary changed; reloading`.

## Validation
- 30 startup tests + 169 frontend manager/protocol tests pass (2 new idempotency tests, key one asserts a reconnect is a no-op).
- Go module builds + `go vet` clean; supervisor error paths smoke-tested.
- `mix format --check-formatted` + `mix credo --strict` clean on changed Elixir.
- **Not yet run:** the full interactive end-to-end session (needs a real tty); that's the reviewer/author check above.

## Notes / risks
- **stdout cleanliness**: if BEAM emits anything to stdout at boot, it corrupts the protocol stream. The pre-compile step guards against compile noise; a tighter stdout guard can be added if it surfaces.
- `stat -f` in `bin/minga-dev` is macOS-only (BSD stat).
- Excludes the pre-existing unrelated change to `macos/Sources/Protocol/InputEncoder.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)