### PR TITLE
fix(viewport): clamp top to EOF on non-wrap cursor-follow and hit-test paths

### DIFF
--- a/lib/minga_editor/mouse/hit_test.ex
+++ b/lib/minga_editor/mouse/hit_test.ex
@@ -185,9 +185,23 @@ defmodule MingaEditor.Mouse.HitTest do
     do: viewport.top
 
   def scroll_top(nil, content_height, content_width, cursor_line, buffer) do
-    viewport = Viewport.new(content_height, content_width, 0)
-    viewport = Viewport.scroll_to_cursor(viewport, {cursor_line, 0}, buffer)
-    viewport.top
+    viewport =
+      Viewport.new(content_height, content_width, 0)
+      |> Viewport.scroll_to_cursor({cursor_line, 0}, buffer)
+
+    # Clamp to EOF so a click near the last line doesn't resolve through an
+    # overscrolled top. Tolerate a dead buffer like the scroll_margin read above.
+    case safe_line_count(buffer) do
+      nil -> viewport.top
+      total_lines -> Viewport.clamp_top_to_eof(viewport, total_lines).top
+    end
+  end
+
+  @spec safe_line_count(pid()) :: pos_integer() | nil
+  defp safe_line_count(buffer) do
+    Buffer.line_count(buffer)
+  catch
+    :exit, _ -> nil
   end
 
   @spec buffer_gutter_width(pid() | nil, non_neg_integer()) :: non_neg_integer()

--- a/lib/minga_editor/mouse/hit_test.ex
+++ b/lib/minga_editor/mouse/hit_test.ex
@@ -190,7 +190,8 @@ defmodule MingaEditor.Mouse.HitTest do
       |> Viewport.scroll_to_cursor({cursor_line, 0}, buffer)
 
     # Clamp to EOF so a click near the last line doesn't resolve through an
-    # overscrolled top. Tolerate a dead buffer like the scroll_margin read above.
+    # overscrolled top. Tolerate a dead buffer (same as Viewport.scroll_to_cursor/3's
+    # internal scroll_margin lookup).
     case safe_line_count(buffer) do
       nil -> viewport.top
       total_lines -> Viewport.clamp_top_to_eof(viewport, total_lines).top

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -204,6 +204,9 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         do: Window.scroll_follow_cursor?(window, {cursor_line, cursor_byte_col}, now),
         else: {window, true}
 
+    total_visible_lines =
+      FoldMap.visible_line_count(fold_map, Buffer.line_count(window.buffer))
+
     viewport =
       if follow_cursor do
         maybe_scroll_active_window_to_cursor(
@@ -211,7 +214,8 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
           visible_cursor_line,
           scroll_margin,
           is_active,
-          wrap_on
+          wrap_on,
+          total_visible_lines
         )
       else
         viewport
@@ -778,14 +782,16 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
           non_neg_integer(),
           non_neg_integer(),
           boolean(),
-          boolean()
+          boolean(),
+          non_neg_integer()
         ) :: Viewport.t()
   defp maybe_scroll_active_window_to_cursor(
          viewport,
          _visible_cursor_line,
          _scroll_margin,
          false,
-         _wrap_on
+         _wrap_on,
+         _total_visible_lines
        ),
        do: viewport
 
@@ -794,7 +800,8 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
          _visible_cursor_line,
          _scroll_margin,
          true,
-         true
+         true,
+         _total_visible_lines
        ) do
     viewport
   end
@@ -804,12 +811,17 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
          visible_cursor_line,
          scroll_margin,
          true,
-         false
+         false,
+         total_visible_lines
        ) do
     saved_left = viewport.left
 
+    # Clamp top to EOF after scrolling so the last line pins to the bottom
+    # instead of scrolling past it (scroll_to_cursor applies scroll_margin
+    # without knowing the buffer length). The wrap path clamps separately.
     viewport
     |> Viewport.scroll_to_cursor({visible_cursor_line, 0}, scroll_margin)
+    |> Viewport.clamp_top_to_eof(total_visible_lines)
     |> Map.put(:left, saved_left)
   end
 

--- a/lib/minga_editor/viewport.ex
+++ b/lib/minga_editor/viewport.ex
@@ -175,6 +175,25 @@ defmodule MingaEditor.Viewport do
     %{vp | visual_row_offset: min(vp.visual_row_offset, visual_row_count - 1)}
   end
 
+  @doc """
+  Clamps the logical `top` so the viewport never scrolls past end-of-file.
+
+  `scroll_to_cursor` applies `scroll_margin` without knowing the buffer length,
+  so at EOF it would push `top` down far enough to leave blank rows below the
+  last line (and start scrolling before the last line reaches the bottom). This
+  pins the last line to the bottom row instead. `total_lines` is the number of
+  scrollable (visible) lines. This is the non-wrap counterpart to the wrap
+  path's `clamp_visual_row_offset/3` EOF clamp.
+  """
+  @spec clamp_top_to_eof(t(), integer()) :: t()
+  def clamp_top_to_eof(%__MODULE__{} = vp, total_lines)
+      when is_integer(total_lines) and total_lines > 0 do
+    max_top = max(total_lines - content_rows(vp), 0)
+    %{vp | top: min(vp.top, max_top)}
+  end
+
+  def clamp_top_to_eof(%__MODULE__{} = vp, _total_lines), do: vp
+
   @doc "Scrolls down by one visual row when wrapping is active."
   @spec scroll_visual_row_down(t(), pos_integer(), non_neg_integer(), non_neg_integer()) :: t()
   def scroll_visual_row_down(%__MODULE__{} = vp, top_line_visual_rows, total_lines, _margin)

--- a/lib/minga_editor/viewport.ex
+++ b/lib/minga_editor/viewport.ex
@@ -183,16 +183,16 @@ defmodule MingaEditor.Viewport do
   last line (and start scrolling before the last line reaches the bottom). This
   pins the last line to the bottom row instead. `total_lines` is the number of
   scrollable (visible) lines. This is the non-wrap counterpart to the wrap
-  path's `clamp_visual_row_offset/3` EOF clamp.
+  path's `max_visual_row_offset/2` EOF clamp.
   """
-  @spec clamp_top_to_eof(t(), integer()) :: t()
+  @spec clamp_top_to_eof(t(), non_neg_integer()) :: t()
   def clamp_top_to_eof(%__MODULE__{} = vp, total_lines)
       when is_integer(total_lines) and total_lines > 0 do
     max_top = max(total_lines - content_rows(vp), 0)
     %{vp | top: min(vp.top, max_top)}
   end
 
-  def clamp_top_to_eof(%__MODULE__{} = vp, _total_lines), do: vp
+  def clamp_top_to_eof(%__MODULE__{} = vp, 0), do: vp
 
   @doc "Scrolls down by one visual row when wrapping is active."
   @spec scroll_visual_row_down(t(), pos_integer(), non_neg_integer(), non_neg_integer()) :: t()

--- a/test/minga_editor/mouse/hit_test_test.exs
+++ b/test/minga_editor/mouse/hit_test_test.exs
@@ -172,6 +172,18 @@ defmodule MingaEditor.Mouse.HitTestTest do
     end
   end
 
+  describe "scroll_top/5 (no active window)" do
+    test "clamps to EOF so a click near the last line doesn't resolve through an overscrolled top" do
+      content = Enum.map_join(1..20, "\n", &"line #{&1}")
+      {_state, buffer} = start_mouse_state(content)
+
+      # 10 visible rows, cursor on the last line (index 19). Cursor-following
+      # scroll_margin would push top to 10+margin (blank rows past EOF); the EOF
+      # clamp pins it to total_lines - visible = 20 - 10 = 10.
+      assert HitTest.scroll_top(nil, 10, 80, 19, buffer) == 10
+    end
+  end
+
   defp start_mouse_state(content, opts \\ []) do
     id = :erlang.unique_integer([:positive])
     events_registry = :"#{__MODULE__}.Events.#{id}"

--- a/test/minga_editor/render_pipeline/scroll_test.exs
+++ b/test/minga_editor/render_pipeline/scroll_test.exs
@@ -226,6 +226,23 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
       assert scroll.viewport.visual_row_offset == 1
     end
 
+    test "non-wrap cursor-follow clamps to EOF instead of overscrolling" do
+      content = Enum.map_join(1..20, "\n", &"line #{&1}")
+      state = base_state(content: content, rows: 10, cols: 80)
+      buffer = state.workspace.buffers.active
+
+      _ = BufferProcess.set_option(buffer, :wrap, false)
+      _ = BufferProcess.set_option(buffer, :line_numbers, :none)
+
+      BufferProcess.move_to(buffer, {19, 0})
+
+      {scrolls, _state, _layout} = run_through_scroll(state)
+      [{_win_id, scroll}] = Map.to_list(scrolls)
+
+      visible = Viewport.content_rows(scroll.viewport)
+      assert scroll.viewport.top <= 20 - visible
+    end
+
     test "scroll result includes buf_version" do
       state = base_state()
       {scrolls, _state, _layout} = run_through_scroll(state)

--- a/test/minga_editor/viewport_test.exs
+++ b/test/minga_editor/viewport_test.exs
@@ -407,4 +407,41 @@ defmodule MingaEditor.ViewportTest do
       assert Viewport.effective_rows(24) == 24
     end
   end
+
+  describe "clamp_top_to_eof/2" do
+    test "pins the last line to the bottom instead of scrolling past EOF" do
+      # Reproduces the underfill bug: scroll_to_cursor applies scroll_margin at
+      # EOF, pushing top past the last line and leaving blank rows below.
+      # 16 content rows (reserved: 0), 20-line buffer, cursor on the last line.
+      vp = %Viewport{top: 0, left: 0, rows: 16, cols: 80, reserved: 0}
+      scrolled = Viewport.scroll_to_cursor(vp, {19, 0}, 5)
+      # Without a clamp, margin=5 scrolls to top=9 → lines 20..24 are blank.
+      assert scrolled.top == 9
+
+      clamped = Viewport.clamp_top_to_eof(scrolled, 20)
+      # top = min(9, 20 - 16) = 4 → lines 4..19, last line pinned to the bottom.
+      assert clamped.top == 4
+    end
+
+    test "does not scroll up when content already fits" do
+      vp = %Viewport{top: 0, left: 0, rows: 16, cols: 80, reserved: 0}
+      assert Viewport.clamp_top_to_eof(vp, 8).top == 0
+    end
+
+    test "never produces a negative top" do
+      vp = %Viewport{top: 3, left: 0, rows: 16, cols: 80, reserved: 0}
+      assert Viewport.clamp_top_to_eof(vp, 5).top == 0
+    end
+
+    test "honors reserved rows via content_rows" do
+      # reserved: 2 → 14 content rows; 20 lines → max_top = 6.
+      vp = %Viewport{top: 10, left: 0, rows: 16, cols: 80, reserved: 2}
+      assert Viewport.clamp_top_to_eof(vp, 20).top == 6
+    end
+
+    test "leaves the viewport untouched for a non-positive line count" do
+      vp = %Viewport{top: 7, left: 0, rows: 16, cols: 80, reserved: 0}
+      assert Viewport.clamp_top_to_eof(vp, 0).top == 7
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes viewport underfill at EOF: `scroll_to_cursor` applies `scroll_margin` without knowing the buffer length, so with the cursor on the last line the viewport scrolled past EOF and left blank rows below it. GUI line-spacing made this visible by shrinking the effective row count.

The fix adds `Viewport.clamp_top_to_eof/2` (`top = min(top, max(total_lines - content_rows, 0))`) and applies it on the two non-wrap cursor-follow paths: `BufferPrefetch.maybe_scroll_active_window_to_cursor` (using fold-space `FoldMap.visible_line_count`) and `Mouse.HitTest.scroll_top/5` (with a dead-buffer-tolerant line-count read matching the existing `scroll_margin` read). The wrap path already clamps via `clamp_visual_row_offset/3` and is untouched.

## Tests

- `mix test.llm test/minga_editor/viewport_test.exs test/minga_editor/mouse/hit_test_test.exs` — 66 tests, 0 failures. New coverage: bug-repro clamp test, fits-already no-op, negative-top guard, reserved-rows arithmetic, non-positive line-count fallthrough, and the hit-test EOF click case.
- `make lint` — all checks passed.
- Final reviewer: PASS (verified guard reachability, fold-space consistency, dead-buffer :exit parity).

## Notes

#2653 (full-document row residence, epic #2652) edits `viewport.ex` next; landing this first avoids conflicting edits there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1