### PR TITLE
feat(render): full-document row residence for under-threshold files, dormant by default

### DIFF
--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -131,6 +131,10 @@ defmodule Minga.Buffer do
   @spec line_count(t()) :: pos_integer()
   defdelegate line_count(server), to: BufferProcess
 
+  @doc "Content size in bytes (used to gate full-document row residence)."
+  @spec content_byte_size(t()) :: non_neg_integer()
+  defdelegate content_byte_size(server), to: BufferProcess
+
   @doc "Byte offset of the start of a line (for tree-sitter integration)."
   @spec byte_offset_for_line(t(), non_neg_integer()) :: non_neg_integer()
   defdelegate byte_offset_for_line(server, line), to: BufferProcess

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -355,6 +355,10 @@ defmodule Minga.Buffer.Process do
   @spec line_count(GenServer.server()) :: pos_integer()
   def line_count(server), do: GenServer.call(server, :line_count)
 
+  @doc "Returns the buffer content size in bytes (gap-buffer halves summed, O(1))."
+  @spec content_byte_size(GenServer.server()) :: non_neg_integer()
+  def content_byte_size(server), do: GenServer.call(server, :content_byte_size)
+
   @doc "Returns whether the buffer has unsaved changes."
   @spec dirty?(GenServer.server()) :: boolean()
   def dirty?(server), do: GenServer.call(server, :dirty?)
@@ -1318,6 +1322,10 @@ defmodule Minga.Buffer.Process do
 
   def handle_call(:line_count, _from, state) do
     {:reply, Document.line_count(state.document), state}
+  end
+
+  def handle_call(:content_byte_size, _from, state) do
+    {:reply, Document.content_byte_size(state.document), state}
   end
 
   def handle_call(:dirty?, _from, state) do

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -133,6 +133,8 @@ defmodule Minga.Config.Options do
           | :default_shell
           | :file_find_excludes
           | :picker_backdrop
+          | :resident_store_max_lines
+          | :resident_store_max_bytes
 
   @typedoc "Line number display style."
   @type line_number_style :: :hybrid | :absolute | :relative | :none
@@ -419,7 +421,11 @@ defmodule Minga.Config.Options do
        ".DS_Store"
      ], "Directory names excluded from the file finder (SPC f f). Stacks with .gitignore."},
     {:picker_backdrop, :boolean, true,
-     "Whether centered floating pickers render a dimmed backdrop overlay."}
+     "Whether centered floating pickers render a dimmed backdrop overlay."},
+    {:resident_store_max_lines, :non_neg_integer, 0,
+     "Maximum buffer line count that still receives full-document row residence (glitch-free fast scrolling). 0 disables full residence entirely (the default); larger buffers fall back to viewport-windowed emit."},
+    {:resident_store_max_bytes, :pos_integer, 10_485_760,
+     "Maximum buffer byte size that still receives full-document row residence. Residence is gated by both this and :resident_store_max_lines, so it stays off while :resident_store_max_lines is 0."}
   ]
   @valid_names Enum.map(@option_specs, &elem(&1, 0))
 

--- a/lib/minga/render_model/window.ex
+++ b/lib/minga/render_model/window.ex
@@ -3,6 +3,8 @@ defmodule Minga.RenderModel.Window do
   Canonical visible model for one buffer-like window.
 
   The Content stage builds this model from current-frame data. Frontend adapters encode it for GUI or composite it into cells for TUI proof-of-concept paths. The struct is pure data and lives in core so products can produce window content without importing `MingaEditor`.
+
+  `contiguous_rows` is a BEAM-internal hint (never encoded on the wire): it is true only for the non-wrapped, non-folded sequential path, where `rows` are consecutive `:normal` buffer lines. It lets `ScrollPresentation` derive the resident line range by arithmetic instead of folding over every row.
   """
 
   alias __MODULE__.{
@@ -44,7 +46,8 @@ defmodule Minga.RenderModel.Window do
             indent_guides: nil,
             geometry: nil,
             content_epoch: 0,
-            full_refresh: true
+            full_refresh: true,
+            contiguous_rows: false
 
   @type t :: %__MODULE__{
           window_id: pos_integer(),
@@ -66,6 +69,7 @@ defmodule Minga.RenderModel.Window do
           indent_guides: IndentGuides.t() | nil,
           geometry: PaneGeometry.t() | nil,
           content_epoch: non_neg_integer(),
-          full_refresh: boolean()
+          full_refresh: boolean(),
+          contiguous_rows: boolean()
         }
 end

--- a/lib/minga/render_model/window/scroll_presentation.ex
+++ b/lib/minga/render_model/window/scroll_presentation.ex
@@ -56,7 +56,7 @@ defmodule Minga.RenderModel.Window.ScrollPresentation do
 
   def from_window(%Window{geometry: %PaneGeometry{} = geometry} = window) do
     {overscan_start_line, overscan_end_line} =
-      line_range(window.rows, geometry.viewport.top)
+      line_range(window.rows, geometry.viewport.top, window.contiguous_rows)
 
     visible_start_line = max(geometry.viewport.top, overscan_start_line)
     visible_end_line = min(visible_start_line + geometry.viewport.rows, overscan_end_line)
@@ -76,10 +76,21 @@ defmodule Minga.RenderModel.Window.ScrollPresentation do
     }
   end
 
-  @spec line_range([Row.t()], non_neg_integer()) :: {non_neg_integer(), non_neg_integer()}
-  defp line_range([], fallback_line), do: {fallback_line, fallback_line}
+  @spec line_range([Row.t()], non_neg_integer(), boolean()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp line_range([], fallback_line, _contiguous?), do: {fallback_line, fallback_line}
 
-  defp line_range(rows, _fallback_line) do
+  # Contiguous non-wrapped sequential rows are consecutive buffer lines, so the
+  # half-open range is arithmetic from the first row's buf_line and the row count.
+  # This avoids folding over the whole (possibly full-document) row list every
+  # frame; `length/1` is a cheap BIF walk rather than a per-row min/max reduce.
+  defp line_range([%Row{buf_line: first} | _] = rows, _fallback_line, true) do
+    {first, first + length(rows)}
+  end
+
+  # Wrapped or folded rows are not 1:1 with buffer lines (wrap continuations share
+  # a buf_line, folds skip hidden lines), so fold for the true min/max.
+  defp line_range(rows, _fallback_line, false) do
     {first, last} =
       Enum.reduce(rows, {nil, nil}, fn %Row{buf_line: line}, {min_line, max_line} ->
         {min_line(min_line, line), max_line(max_line, line)}

--- a/lib/minga/render_model/window/scroll_presentation.ex
+++ b/lib/minga/render_model/window/scroll_presentation.ex
@@ -82,9 +82,10 @@ defmodule Minga.RenderModel.Window.ScrollPresentation do
 
   # Contiguous non-wrapped sequential rows are consecutive buffer lines, so the
   # half-open range is arithmetic from the first row's buf_line and the row count.
-  # This avoids folding over the whole (possibly full-document) row list every
-  # frame; `length/1` is a cheap BIF walk rather than a per-row min/max reduce.
-  defp line_range([%Row{buf_line: first} | _] = rows, _fallback_line, true) do
+  # Both paths are O(n) over the row list, but the arithmetic path avoids the
+  # per-row closure call and tuple allocation of a fold; `length/1` is a C-level
+  # BIF walk.
+  defp line_range([%Row{row_type: :normal, buf_line: first} | _] = rows, _fallback_line, true) do
     {first, first + length(rows)}
   end
 

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -175,7 +175,14 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       )
 
     visible_row_start_index = scroll.visible_row_start_index + viewport.visual_row_offset
-    payload_overscan_before = max(scroll.visible_row_start_index - viewport.visual_row_offset, 0)
+    raw_overscan_before = max(scroll.visible_row_start_index - viewport.visual_row_offset, 0)
+    # Under full residence, visible_row_start_index is the viewport's absolute
+    # document offset, not a small overscan count. Cap the presentation overscan
+    # so the gutter stays viewport-windowed.
+    payload_overscan_before =
+      if scroll.full_residence,
+        do: min(raw_overscan_before, visible_row_count),
+        else: raw_overscan_before
 
     visual_entries =
       trim_visual_entries(all_visual_entries, visible_row_start_index, visible_row_count)
@@ -190,12 +197,12 @@ defmodule MingaEditor.RenderModel.Window.Builder do
 
     # Full-document residence (#2653): the window carries every laid-out row so the
     # frontend store is complete and a fast scroll can never outrun it. The gutter
-    # (build_gutter below) and indent guides stay viewport-windowed off
-    # `presentation_entries`, keeping per-frame chrome bytes bounded; only the row
-    # set and its retained-row cache become resident.
+    # (build_gutter below) stays viewport-windowed off `presentation_entries`;
+    # indent guides are independently viewport-windowed off `scroll.lines`. Only
+    # the row set and its retained-row cache become resident.
     resident_entries =
       if scroll.full_residence do
-        trim_visual_entries(all_visual_entries, 0, length(all_visual_entries))
+        all_visual_entries
       else
         presentation_entries
       end

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -188,12 +188,24 @@ defmodule MingaEditor.RenderModel.Window.Builder do
         payload_overscan_before
       )
 
-    {new_retained, rasterized} = retained_stats(presentation_entries, retain_ctx)
+    # Full-document residence (#2653): the window carries every laid-out row so the
+    # frontend store is complete and a fast scroll can never outrun it. The gutter
+    # (build_gutter below) and indent guides stay viewport-windowed off
+    # `presentation_entries`, keeping per-frame chrome bytes bounded; only the row
+    # set and its retained-row cache become resident.
+    resident_entries =
+      if scroll.full_residence do
+        trim_visual_entries(all_visual_entries, 0, length(all_visual_entries))
+      else
+        presentation_entries
+      end
+
+    {new_retained, rasterized} = retained_stats(resident_entries, retain_ctx)
 
     new_retained_wrap =
-      retained_wrap_lines(presentation_entries, wrap_on and visible_line_map == nil)
+      retained_wrap_lines(resident_entries, wrap_on and visible_line_map == nil)
 
-    presentation_rows = Enum.map(presentation_entries, & &1.row)
+    presentation_rows = Enum.map(resident_entries, & &1.row)
     committed_rows = Enum.map(visual_entries, & &1.row)
     wrapped_coordinates? = wrap_on and visible_line_map == nil
 
@@ -311,7 +323,10 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       indent_guides: build_indent_guides(scroll, ctx, content_kind),
       geometry: geometry,
       content_epoch: scroll.content_epoch,
-      full_refresh: scroll.full_refresh
+      full_refresh: scroll.full_refresh,
+      # Non-wrapped, non-folded windows emit consecutive :normal buffer lines, so
+      # ScrollPresentation can derive the resident line range arithmetically.
+      contiguous_rows: is_nil(visible_line_map) and not wrap_on
     }
 
     {render_window,

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   """
 
   alias Minga.Buffer
+  alias Minga.Config
   alias Minga.Core.Decorations
   alias Minga.Core.Unicode
   alias Minga.Core.WidthOracle
@@ -266,37 +267,23 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         {first_line, nil}
       end
 
+    # Full-document residence (#2653): for under-threshold, non-wrapped, non-fold
+    # buffers, fetch and emit the entire laid-out document so a fast scroll can
+    # never outrun the resident row store. Over-threshold, wrapped, or folded
+    # buffers keep today's velocity-aware viewport-plus-overscan windowing.
+    full_residence? =
+      is_nil(visible_line_map) and full_residence?(window.buffer, wrap_on, line_count_approx)
+
     {fetch_first, fetch_count, visible_row_start_index} =
-      case visible_line_map do
-        nil ->
-          now = System.monotonic_time(:millisecond)
-          velocity_tier = Window.scroll_velocity_tier(window, now)
-          total_overscan = boosted_overscan_rows(window, velocity_tier)
-
-          {overscan_behind, overscan_ahead} =
-            directional_split(total_overscan, velocity_tier, Window.scroll_direction(window, now))
-
-          {overscan_before, fetch_first} =
-            scroll_overscan_before(first_line, wrap_on, overscan_behind)
-
-          overscan_after =
-            scroll_overscan_after(
-              first_line,
-              visible_rows,
-              line_count_approx,
-              wrap_on,
-              overscan_ahead
-            )
-
-          fetch_rows =
-            scroll_fetch_rows(visible_rows, overscan_before, overscan_after, wrap_on)
-
-          {fetch_first, fetch_rows, overscan_before}
-
-        entries ->
-          {buf_first, buf_last} = buffer_range_from_entries(entries)
-          {buf_first, buf_last - buf_first + 1, 0}
-      end
+      resolve_fetch_range(%{
+        window: window,
+        visible_line_map: visible_line_map,
+        full_residence?: full_residence?,
+        first_line: first_line,
+        visible_rows: visible_rows,
+        line_count: line_count_approx,
+        wrap_on: wrap_on
+      })
 
     snapshot = Buffer.render_snapshot(window.buffer, fetch_first, fetch_count)
     lines = snapshot.lines
@@ -375,8 +362,95 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
       git_signs: ContentHelpers.signs_for_window(state, window),
       visible_line_map: visible_line_map,
       total_visual_rows: total_visual_rows,
-      visible_row_start_index: visible_row_start_index
+      visible_row_start_index: visible_row_start_index,
+      full_residence: full_residence?
     }
+  end
+
+  # Resolves the buffer line range to fetch and the visible viewport's offset
+  # within it. Three cases: full-document residence (whole doc from line 0),
+  # folded/decorated windows (the visible_line_map's exact buffer span), and the
+  # default velocity-aware viewport-plus-overscan window.
+  @spec resolve_fetch_range(map()) ::
+          {non_neg_integer(), non_neg_integer(), non_neg_integer()}
+  defp resolve_fetch_range(%{visible_line_map: nil, full_residence?: true} = params) do
+    # first_line is the viewport-top buffer line; the fetch starts at 0, so
+    # first_line doubles as the visible viewport's offset within the store.
+    {0, params.line_count, params.first_line}
+  end
+
+  defp resolve_fetch_range(%{visible_line_map: nil} = params) do
+    %{window: window, first_line: first_line, visible_rows: visible_rows} = params
+    wrap_on = params.wrap_on
+    now = System.monotonic_time(:millisecond)
+    velocity_tier = Window.scroll_velocity_tier(window, now)
+    total_overscan = boosted_overscan_rows(window, velocity_tier)
+
+    {overscan_behind, overscan_ahead} =
+      directional_split(total_overscan, velocity_tier, Window.scroll_direction(window, now))
+
+    {overscan_before, fetch_first} =
+      scroll_overscan_before(first_line, wrap_on, overscan_behind)
+
+    overscan_after =
+      scroll_overscan_after(first_line, visible_rows, params.line_count, wrap_on, overscan_ahead)
+
+    fetch_rows = scroll_fetch_rows(visible_rows, overscan_before, overscan_after, wrap_on)
+    {fetch_first, fetch_rows, overscan_before}
+  end
+
+  defp resolve_fetch_range(%{visible_line_map: entries}) do
+    {buf_first, buf_last} = buffer_range_from_entries(entries)
+    {buf_first, buf_last - buf_first + 1, 0}
+  end
+
+  # Wire-format ceiling: gui_window_content and its row/viewport deltas encode the
+  # row count as a u16, so a resident store may not exceed 65_535 rows regardless
+  # of the configured line threshold. Above this, fall back to windowed emit.
+  @wire_max_rows 0xFFFF
+
+  # A buffer qualifies for full-document residence when it is not wrapped, not
+  # folded/decorated (caller passes the nil-visible_line_map case only), and both
+  # its line count and byte size sit under the configured thresholds and the wire
+  # row ceiling. The byte check runs last so an over-line file skips the extra call.
+  # A line threshold of 0 (or nil) means residence is disabled, which is the
+  # default: the feature ships dormant until explicitly opted in via config.
+  @spec full_residence?(pid(), boolean(), non_neg_integer()) :: boolean()
+  defp full_residence?(_buf, true = _wrap_on, _line_count), do: false
+
+  defp full_residence?(buf, false = _wrap_on, line_count) do
+    residence_within_limits?(buf, line_count, resident_store_max_lines())
+  end
+
+  @spec residence_within_limits?(pid(), non_neg_integer(), non_neg_integer() | nil) :: boolean()
+  defp residence_within_limits?(_buf, _line_count, nil), do: false
+  defp residence_within_limits?(_buf, _line_count, max_lines) when max_lines <= 0, do: false
+
+  defp residence_within_limits?(buf, line_count, max_lines) do
+    line_count <= @wire_max_rows and
+      line_count <= max_lines and
+      buffer_bytes_within_limit?(buf)
+  end
+
+  @spec buffer_bytes_within_limit?(pid()) :: boolean()
+  defp buffer_bytes_within_limit?(buf) do
+    Buffer.content_byte_size(buf) <= resident_store_max_bytes()
+  catch
+    :exit, _ -> false
+  end
+
+  @spec resident_store_max_lines() :: non_neg_integer()
+  defp resident_store_max_lines do
+    Config.get(:resident_store_max_lines)
+  catch
+    :exit, _ -> 0
+  end
+
+  @spec resident_store_max_bytes() :: pos_integer()
+  defp resident_store_max_bytes do
+    Config.get(:resident_store_max_bytes)
+  catch
+    :exit, _ -> 10_485_760
   end
 
   @spec overscan_rows(ScrollVelocity.tier()) :: pos_integer()
@@ -513,6 +587,10 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
       scroll.viewport.rows,
       scroll.viewport.cols,
       scroll.window.fold_map,
+      # A residence toggle mid-session swaps the row set between viewport-sized
+      # and full-document; force a full re-emit so no :patch frame diffs across
+      # differently-sized stores.
+      scroll.full_residence,
       Map.get(options, :breakindent, true),
       Map.get(options, :linebreak, true),
       Map.get(options, :tab_width, 2),

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -205,8 +205,8 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         do: Window.scroll_follow_cursor?(window, {cursor_line, cursor_byte_col}, now),
         else: {window, true}
 
-    total_visible_lines =
-      FoldMap.visible_line_count(fold_map, Buffer.line_count(window.buffer))
+    line_count = Buffer.line_count(window.buffer)
+    total_visible_lines = FoldMap.visible_line_count(fold_map, line_count)
 
     viewport =
       if follow_cursor do
@@ -236,11 +236,10 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
 
     # Compute final gutter dimensions before building the DisplayMap.
     # Dynamic block decorations must see the same text width in scroll, content, and GUI gutter paths.
-    line_count_approx = Buffer.line_count(window.buffer)
     line_number_style = Buffer.get_option(window.buffer, :line_numbers)
 
     {has_sign_column, gutter_w} =
-      gutter_dimensions(state, window.buffer, line_number_style, line_count_approx)
+      gutter_dimensions(state, window.buffer, line_number_style, line_count)
 
     content_w = max(viewport.cols - gutter_w, 1)
 
@@ -259,7 +258,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
           decorations,
           first_line,
           visible_rows,
-          line_count_approx,
+          line_count,
           content_w,
           cursor_line
         )
@@ -272,7 +271,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     # never outrun the resident row store. Over-threshold, wrapped, or folded
     # buffers keep today's velocity-aware viewport-plus-overscan windowing.
     full_residence? =
-      is_nil(visible_line_map) and full_residence?(window.buffer, wrap_on, line_count_approx)
+      is_nil(visible_line_map) and full_residence?(window.buffer, wrap_on, line_count)
 
     {fetch_first, fetch_count, visible_row_start_index} =
       resolve_fetch_range(%{
@@ -281,7 +280,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         full_residence?: full_residence?,
         first_line: first_line,
         visible_rows: visible_rows,
-        line_count: line_count_approx,
+        line_count: line_count,
         wrap_on: wrap_on
       })
 
@@ -379,9 +378,14 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     {0, params.line_count, params.first_line}
   end
 
-  defp resolve_fetch_range(%{visible_line_map: nil} = params) do
-    %{window: window, first_line: first_line, visible_rows: visible_rows} = params
-    wrap_on = params.wrap_on
+  defp resolve_fetch_range(%{
+         visible_line_map: nil,
+         window: window,
+         first_line: first_line,
+         visible_rows: visible_rows,
+         line_count: line_count,
+         wrap_on: wrap_on
+       }) do
     now = System.monotonic_time(:millisecond)
     velocity_tier = Window.scroll_velocity_tier(window, now)
     total_overscan = boosted_overscan_rows(window, velocity_tier)
@@ -393,13 +397,14 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
       scroll_overscan_before(first_line, wrap_on, overscan_behind)
 
     overscan_after =
-      scroll_overscan_after(first_line, visible_rows, params.line_count, wrap_on, overscan_ahead)
+      scroll_overscan_after(first_line, visible_rows, line_count, wrap_on, overscan_ahead)
 
     fetch_rows = scroll_fetch_rows(visible_rows, overscan_before, overscan_after, wrap_on)
     {fetch_first, fetch_rows, overscan_before}
   end
 
-  defp resolve_fetch_range(%{visible_line_map: entries}) do
+  defp resolve_fetch_range(%{visible_line_map: entries, full_residence?: false})
+       when entries != nil do
     {buf_first, buf_last} = buffer_range_from_entries(entries)
     {buf_first, buf_last - buf_first + 1, 0}
   end
@@ -408,6 +413,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   # row count as a u16, so a resident store may not exceed 65_535 rows regardless
   # of the configured line threshold. Above this, fall back to windowed emit.
   @wire_max_rows 0xFFFF
+  @default_resident_store_max_bytes 10_485_760
 
   # A buffer qualifies for full-document residence when it is not wrapped, not
   # folded/decorated (caller passes the nil-visible_line_map case only), and both
@@ -419,17 +425,15 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   defp full_residence?(_buf, true = _wrap_on, _line_count), do: false
 
   defp full_residence?(buf, false = _wrap_on, line_count) do
-    residence_within_limits?(buf, line_count, resident_store_max_lines())
-  end
+    case resident_store_max_lines() do
+      max_lines when is_integer(max_lines) and max_lines > 0 ->
+        line_count <= @wire_max_rows and
+          line_count <= max_lines and
+          buffer_bytes_within_limit?(buf)
 
-  @spec residence_within_limits?(pid(), non_neg_integer(), non_neg_integer() | nil) :: boolean()
-  defp residence_within_limits?(_buf, _line_count, nil), do: false
-  defp residence_within_limits?(_buf, _line_count, max_lines) when max_lines <= 0, do: false
-
-  defp residence_within_limits?(buf, line_count, max_lines) do
-    line_count <= @wire_max_rows and
-      line_count <= max_lines and
-      buffer_bytes_within_limit?(buf)
+      _disabled ->
+        false
+    end
   end
 
   @spec buffer_bytes_within_limit?(pid()) :: boolean()
@@ -450,7 +454,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   defp resident_store_max_bytes do
     Config.get(:resident_store_max_bytes)
   catch
-    :exit, _ -> 10_485_760
+    :exit, _ -> @default_resident_store_max_bytes
   end
 
   @spec overscan_rows(ScrollVelocity.tier()) :: pos_integer()

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -71,7 +71,8 @@ defmodule MingaEditor.RenderPipeline.Scroll do
       total_visual_rows: nil,
       visible_row_start_index: 0,
       content_epoch: 0,
-      full_refresh: true
+      full_refresh: true,
+      full_residence: false
     ]
 
     @type t :: %__MODULE__{
@@ -100,7 +101,8 @@ defmodule MingaEditor.RenderPipeline.Scroll do
             total_visual_rows: non_neg_integer() | nil,
             visible_row_start_index: non_neg_integer(),
             content_epoch: non_neg_integer(),
-            full_refresh: boolean()
+            full_refresh: boolean(),
+            full_residence: boolean()
           }
   end
 

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -553,6 +553,23 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       assert is_integer(presentation.layout_generation)
     end
 
+    test "contiguous line_range arithmetic matches the fold result for sequential rows" do
+      # ScrollPresentation derives the resident line range by arithmetic when the
+      # window's rows are contiguous non-wrapped buffer lines. It must produce the
+      # same range as folding over every row (the wrap/fold path).
+      state = gui_state(rows: 8, cols: 40, content: long_content(40))
+      {[wf], _cursor, _state} = build_content(state)
+      model = wf.window_model
+
+      assert model.contiguous_rows
+
+      arithmetic = ScrollPresentation.from_window(model)
+      folded = ScrollPresentation.from_window(%{model | contiguous_rows: false})
+
+      assert arithmetic.overscan_start_line == folded.overscan_start_line
+      assert arithmetic.overscan_end_line == folded.overscan_end_line
+    end
+
     test "includes gutter and indent guide models built from current-frame data" do
       state = gui_state(content: "def a do\n  :ok\nend")
       {[wf], _cursor, _state} = build_content(state)

--- a/test/minga_editor/render_pipeline/full_document_residence_threshold_test.exs
+++ b/test/minga_editor/render_pipeline/full_document_residence_threshold_test.exs
@@ -1,0 +1,105 @@
+defmodule MingaEditor.RenderPipeline.FullDocumentResidenceThresholdTest do
+  @moduledoc """
+  Threshold-guard and residence-emit tests for full-document row residence (#2653).
+
+  Residence ships dormant (`:resident_store_max_lines` default 0), so these tests
+  enable it by setting the global config option. That mutation forces the module
+  to run `async: false`; the option is restored after each test.
+  """
+
+  # Mutates the global Config option server (:resident_store_max_lines).
+  use ExUnit.Case, async: false
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Config
+  alias Minga.RenderModel.Window.ScrollPresentation
+  alias MingaEditor.Layout
+  alias MingaEditor.RenderPipeline
+  alias MingaEditor.RenderPipeline.Content
+  alias MingaEditor.RenderPipeline.Scroll
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
+  alias MingaEditor.Window
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  setup do
+    original = Config.get(:resident_store_max_lines)
+    on_exit(fn -> Config.set(:resident_store_max_lines, original) end)
+    :ok
+  end
+
+  defp run_through_scroll(state) do
+    state = EditorState.sync_active_window_cursor(state)
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, _state} = Scroll.scroll_windows(state, layout)
+    scrolls
+  end
+
+  defp build_model(state) do
+    state = EditorState.sync_active_window_cursor(state)
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+    {contents, _cursor, _state} = Content.build_content(state, scrolls)
+    [wc | _] = contents
+    List.first(wc.models)
+  end
+
+  defp scrolled_state(top, opts \\ []) do
+    state = gui_state(rows: 10, cols: 40, content: long_content(500))
+
+    if opts[:wrap] do
+      BufferProcess.set_option(state.workspace.buffers.active, :wrap, true)
+    end
+
+    win_id = state.workspace.windows.active
+    window = Map.fetch!(state.workspace.windows.map, win_id)
+    window = Window.set_viewport(window, Viewport.put_top(window.viewport, top))
+    put_in(state.workspace.windows.map[win_id], window)
+  end
+
+  test "a buffer over the configured line threshold falls back to windowed emit" do
+    Config.set(:resident_store_max_lines, 100)
+
+    [{_win_id, scroll}] = Map.to_list(run_through_scroll(scrolled_state(250)))
+
+    assert scroll.full_residence == false
+    assert Enum.count(scroll.lines) < 500
+  end
+
+  test "a buffer under the configured line threshold stays fully resident" do
+    Config.set(:resident_store_max_lines, 100_000)
+
+    [{_win_id, scroll}] = Map.to_list(run_through_scroll(scrolled_state(250)))
+
+    assert scroll.full_residence == true
+    assert Enum.count(scroll.lines) == 500
+  end
+
+  test "residence emits every document row regardless of scroll position" do
+    Config.set(:resident_store_max_lines, 100_000)
+
+    model = build_model(scrolled_state(250))
+    presentation = ScrollPresentation.from_window(model)
+
+    # The window carries every document row, in buffer order from line 0 to 499.
+    assert Enum.map(model.rows, & &1.buf_line) == Enum.to_list(0..499)
+    assert presentation.overscan_start_line == 0
+    assert presentation.overscan_end_line == 500
+
+    # The gutter stays viewport-windowed so per-frame chrome bytes stay bounded;
+    # only the row set becomes resident.
+    assert Enum.count(model.gutter.entries) < 100
+  end
+
+  test "a wrapped buffer opts out of residence even when it is enabled" do
+    Config.set(:resident_store_max_lines, 100_000)
+
+    [{_win_id, scroll}] = Map.to_list(run_through_scroll(scrolled_state(250, wrap: true)))
+
+    assert scroll.full_residence == false
+    assert Enum.count(scroll.lines) < 500
+  end
+end

--- a/test/minga_editor/render_pipeline/full_document_residence_threshold_test.exs
+++ b/test/minga_editor/render_pipeline/full_document_residence_threshold_test.exs
@@ -24,8 +24,12 @@ defmodule MingaEditor.RenderPipeline.FullDocumentResidenceThresholdTest do
   import MingaEditor.RenderPipeline.TestHelpers
 
   setup do
-    original = Config.get(:resident_store_max_lines)
-    on_exit(fn -> Config.set(:resident_store_max_lines, original) end)
+    original_lines = Config.get(:resident_store_max_lines)
+
+    on_exit(fn ->
+      Config.set(:resident_store_max_lines, original_lines)
+    end)
+
     :ok
   end
 
@@ -35,6 +39,23 @@ defmodule MingaEditor.RenderPipeline.FullDocumentResidenceThresholdTest do
     layout = Layout.get(state)
     {scrolls, _state} = Scroll.scroll_windows(state, layout)
     scrolls
+  end
+
+  defp run_through_scroll_with_state(state) do
+    state = EditorState.sync_active_window_cursor(state)
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+    {scrolls, state}
+  end
+
+  defp warm(state) do
+    state = EditorState.sync_active_window_cursor(state)
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+    {_contents, _cursor, state} = Content.build_content(state, scrolls)
+    state
   end
 
   defp build_model(state) do
@@ -101,5 +122,37 @@ defmodule MingaEditor.RenderPipeline.FullDocumentResidenceThresholdTest do
 
     assert scroll.full_residence == false
     assert Enum.count(scroll.lines) < 500
+  end
+
+  test "toggling residence mid-session forces a full refresh via the render reset fingerprint" do
+    state = scrolled_state(250)
+
+    # Warm up with residence disabled (default 0) to establish a baseline
+    # fingerprint in the window's render cache.
+    state = warm(state)
+
+    # Second frame should be stable (no full refresh).
+    {scrolls, state} = run_through_scroll_with_state(state)
+    [{_win_id, scroll}] = Map.to_list(scrolls)
+    assert scroll.full_refresh == false
+    assert scroll.full_residence == false
+
+    # Enable residence and run a third frame. The fingerprint change should
+    # force full_refresh: true so no :patch frame diffs across differently-sized stores.
+    Config.set(:resident_store_max_lines, 100_000)
+    {scrolls, _state} = run_through_scroll_with_state(state)
+    [{_win_id, scroll}] = Map.to_list(scrolls)
+    assert scroll.full_refresh == true
+    assert scroll.full_residence == true
+  end
+
+  test "gutter stays viewport-bounded under residence even when scrolled deep" do
+    Config.set(:resident_store_max_lines, 100_000)
+
+    model = build_model(scrolled_state(400))
+    visible = model.geometry.viewport.rows
+
+    assert Enum.count(model.rows) == 500
+    assert Enum.count(model.gutter.entries) <= visible * 3
   end
 end

--- a/test/minga_editor/render_pipeline/line_patch_fast_path_test.exs
+++ b/test/minga_editor/render_pipeline/line_patch_fast_path_test.exs
@@ -134,6 +134,8 @@ defmodule MingaEditor.RenderPipeline.LinePatchFastPathTest do
       # A tall enough buffer that scrolling exposes exactly one new row. The
       # rows still on screen keep their row_id and input fingerprint, so the
       # retained-row cache reuses them; only the row scrolled into view composes.
+      # (Full-document residence is dormant by default, so this windowed path is
+      # what runs.)
       state = gui_state(content: long_content(100), rows: 8)
       buffer = state.workspace.buffers.active
       state = warm(state)

--- a/test/minga_editor/render_pipeline/scroll_test.exs
+++ b/test/minga_editor/render_pipeline/scroll_test.exs
@@ -101,6 +101,24 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
       assert scroll.content_w >= 1
     end
 
+    test "full-document residence is dormant by default and keeps windowed overscan (#2653)" do
+      # residence ships off (resident_store_max_lines default 0); even a large
+      # nowrap buffer stays windowed unless residence is explicitly enabled.
+      # Config-enabled residence behavior is covered in the async:false threshold
+      # suite (full_document_residence_threshold_test.exs).
+      state = base_state(rows: 10, cols: 40, content: long_content(500))
+      win_id = state.workspace.windows.active
+      window = Map.fetch!(state.workspace.windows.map, win_id)
+      window = Window.set_viewport(window, Viewport.put_top(window.viewport, 250))
+      state = put_in(state.workspace.windows.map[win_id], window)
+
+      {scrolls, _state, _layout} = run_through_scroll(state)
+      [{_win_id, scroll}] = Map.to_list(scrolls)
+
+      assert scroll.full_residence == false
+      assert Enum.count(scroll.lines) < 500
+    end
+
     test "wrap_on is false when folds produce a visible_line_map" do
       state = base_state(content: String.duplicate("a", 120) <> "\n" <> "hidden\nfold\ntail")
       buffer = state.workspace.buffers.active


### PR DESCRIPTION
Closes #2653. Part of epic #2652. **Stacked on #2656** (retarget to main after it merges).

## Summary

Implements the resident-store slice: for under-threshold, non-wrapped, non-folded buffers the BEAM emits the entire laid-out document as the resident row set, so a fast scroll can never outrun the store — scroll deltas become all-refs and the retained row cache covers every document row. Over-threshold, wrapped, and folded buffers keep today's velocity-aware windowed emit. Existing update paths (full content, 0xA1/0xA2 deltas, 0xA0 cursor-only) are untouched; the gutter stays viewport-windowed; `row_count` is capped at the u16 wire ceiling.

**Residence ships OFF by default** (`resident_store_max_lines: 0`). The ticket's own gating measurement found frame build becomes O(document) with residence (~17 ms at 2k lines vs ~1 ms windowed; [data](https://github.com/jsmestad/minga/issues/2653#issuecomment-4860564801)), which would regress typing latency at any useful threshold. Per the architecture consult recorded on #2652, #2658 (incremental resident store) gates the threshold raise; the mechanism lands now because later epic children depend on it.

Also included, per the same consult:
- Zero-risk O(document) cut: `ScrollPresentation.line_range` uses `{first, first + length}` arithmetic for contiguous sequential windows (wrap/fold keep the fold), with an arithmetic-vs-fold equality test.
- A residence toggle now bumps the render reset fingerprint so no `:patch` frame diffs across differently-sized stores (bug-hunt finding).

## Tests

- Full `mix test.llm`: 9,702 tests, 0 failures. Focused suites: 236 tests green.
- `mix credo` clean on touched files; `mix compile --warnings-as-errors` ok; `mix format` clean.
- New `full_document_residence_threshold_test.exs` (async: false, justified): over-threshold fallback, under-threshold residence, full-row emit, wrap opt-out, dormant-by-default.
- Reviews: acceptance reviewer PASS; prtk bug-hunt found no critical issues (both non-critical findings fixed in this diff).

## Follow-up risks

- Residence stays dormant until #2658 lands the O(changed rows) frame build; do not raise the default before that.
- Swift/Go verified by inspection only (keyed row stores, u16 decode, no viewport-size assumptions) — no frontend code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1