### PR TITLE
perf(render): incremental resident-store build, O(changed rows + viewport) per frame

### DIFF
--- a/bench/resident_frame_bench.exs
+++ b/bench/resident_frame_bench.exs
@@ -1,0 +1,99 @@
+defmodule Minga.Bench.ResidentFrame do
+  @moduledoc false
+
+  # Wall-clock evidence for #2658 AC 1/AC 5: edit-frame build cost is flat across
+  # resident document sizes. NOT a CI gate (wall-clock is noisy); the CI assertion
+  # is the operation-count test in
+  # test/minga_editor/render_pipeline/resident_incremental_test.exs. Run with:
+  #
+  #     MIX_ENV=test mix run bench/resident_frame_bench.exs
+  #
+  # It reports p50/p95 build time for a single-line edit frame at each size, plus
+  # the warm keyframe (first full build) for contrast. Flat p50/p95 across sizes
+  # is the claim.
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Config
+  alias MingaEditor.Layout
+  alias MingaEditor.RenderPipeline
+  alias MingaEditor.RenderPipeline.Content
+  alias MingaEditor.RenderPipeline.Scroll
+  alias MingaEditor.State, as: EditorState
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  @sizes [500, 5_000, 65_000]
+  @warmup 5
+  @measured 60
+
+  def run do
+    original = Config.get(:resident_store_max_lines)
+    Config.set(:resident_store_max_lines, 1_000_000)
+
+    try do
+      IO.puts("\n#2658 resident edit-frame build (p50/p95 µs), single-line in-place edit\n")
+      IO.puts(String.pad_trailing("lines", 10) <> "keyframe   p50      p95")
+
+      for size <- @sizes, do: bench_size(size)
+    after
+      Config.set(:resident_store_max_lines, original)
+    end
+  end
+
+  defp bench_size(size) do
+    state = resident_state(size)
+
+    {keyframe_us, state} = timed_frame(state)
+    {_us, state} = timed_frame(state)
+
+    buffer = state.workspace.buffers.active
+    edit_line = div(size, 2)
+
+    samples =
+      Enum.map(1..(@warmup + @measured), fn i ->
+        BufferProcess.move_to(buffer, {edit_line, 0})
+        BufferProcess.insert_text(buffer, if(rem(i, 2) == 0, do: "a", else: "b"))
+        {us, next} = timed_frame(state)
+        _ = next
+        us
+      end)
+      |> Enum.drop(@warmup)
+      |> Enum.sort()
+
+    IO.puts(
+      String.pad_trailing(Integer.to_string(size), 10) <>
+        String.pad_trailing("#{keyframe_us}", 11) <>
+        String.pad_trailing("#{percentile(samples, 50)}", 9) <>
+        "#{percentile(samples, 95)}"
+    )
+  end
+
+  defp timed_frame(state) do
+    state = Content.reset_rows_rasterized(state)
+    state = EditorState.sync_active_window_cursor(state)
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+
+    start = System.monotonic_time(:microsecond)
+    {_contents, _cursor, state} = Content.build_content(state, scrolls)
+    elapsed = System.monotonic_time(:microsecond) - start
+
+    {elapsed, state}
+  end
+
+  defp resident_state(size) do
+    state = gui_state(content: long_content(size), rows: 40, cols: 100, filetype: :text)
+    BufferProcess.set_option(state.workspace.buffers.active, :wrap, false)
+    state
+  end
+
+  defp percentile([], _p), do: 0
+
+  defp percentile(sorted, p) do
+    index = min(round(length(sorted) * p / 100), length(sorted) - 1)
+    Enum.at(sorted, index)
+  end
+end
+
+Minga.Bench.ResidentFrame.run()

--- a/lib/minga/frontend/adapter/gui.ex
+++ b/lib/minga/frontend/adapter/gui.ex
@@ -356,7 +356,11 @@ defmodule Minga.Frontend.Adapter.GUI do
       window.content_epoch,
       window.full_refresh,
       window.scroll_left,
-      window.rows,
+      # On the residence path the builder maintains an incremental digest of the
+      # row set, so gate on it instead of re-hashing the (full-document) rows list
+      # every frame. Off residence `content_digest` is nil and we hash `rows`
+      # directly, keeping the fingerprint byte-identical to the windowed path.
+      row_content_key(window),
       window.selection,
       window.search_matches,
       window.diagnostic_ranges,
@@ -367,6 +371,17 @@ defmodule Minga.Frontend.Adapter.GUI do
       window.indent_guides
     })
   end
+
+  # Row-content key for the content fingerprint. On the residence path the
+  # builder supplies an incrementally maintained digest keyed by
+  # row_id/content_hash; using it keeps the frame-emit gate O(changed rows)
+  # instead of O(document). Off residence there is no digest and the raw rows
+  # list is hashed, preserving the exact windowed fingerprint.
+  @spec row_content_key(RenderModel.Window.t()) :: term()
+  defp row_content_key(%RenderModel.Window{content_digest: nil} = window), do: window.rows
+
+  defp row_content_key(%RenderModel.Window{content_digest: digest}),
+    do: {:resident_digest, digest}
 
   @spec window_overlay_fingerprint(RenderModel.Window.t()) :: integer()
   defp window_overlay_fingerprint(%RenderModel.Window{} = window) do

--- a/lib/minga/frontend/adapter/gui.ex
+++ b/lib/minga/frontend/adapter/gui.ex
@@ -374,9 +374,10 @@ defmodule Minga.Frontend.Adapter.GUI do
 
   # Row-content key for the content fingerprint. On the residence path the
   # builder supplies an incrementally maintained digest keyed by
-  # row_id/content_hash; using it keeps the frame-emit gate O(changed rows)
-  # instead of O(document). Off residence there is no digest and the raw rows
-  # list is hashed, preserving the exact windowed fingerprint.
+  # row_id/content_hash; the O(changed rows) cost is paid upstream in
+  # ResidentBuild's splice, making this gate O(1). Off residence there is no
+  # digest and the raw rows list is hashed, preserving the exact windowed
+  # fingerprint.
   @spec row_content_key(RenderModel.Window.t()) :: term()
   defp row_content_key(%RenderModel.Window{content_digest: nil} = window), do: window.rows
 

--- a/lib/minga/render_model/window.ex
+++ b/lib/minga/render_model/window.ex
@@ -5,6 +5,8 @@ defmodule Minga.RenderModel.Window do
   The Content stage builds this model from current-frame data. Frontend adapters encode it for GUI or composite it into cells for TUI proof-of-concept paths. The struct is pure data and lives in core so products can produce window content without importing `MingaEditor`.
 
   `contiguous_rows` is a BEAM-internal hint (never encoded on the wire): it is true only for the non-wrapped, non-folded sequential path, where `rows` are consecutive `:normal` buffer lines. It lets `ScrollPresentation` derive the resident line range by arithmetic instead of folding over every row.
+
+  `content_digest` is a BEAM-internal, never-encoded incremental fingerprint of the row set (`Minga.RenderModel.Window.ContentDigest`), set only on the full-document residence path. When present, the GUI adapter's content frame-emit gate uses it instead of hashing the whole `rows` list, so an edit-frame gate is O(changed rows) rather than O(document). It is `nil` off the residence path, where the adapter keeps hashing `rows` directly.
   """
 
   alias __MODULE__.{
@@ -47,7 +49,8 @@ defmodule Minga.RenderModel.Window do
             geometry: nil,
             content_epoch: 0,
             full_refresh: true,
-            contiguous_rows: false
+            contiguous_rows: false,
+            content_digest: nil
 
   @type t :: %__MODULE__{
           window_id: pos_integer(),
@@ -70,6 +73,7 @@ defmodule Minga.RenderModel.Window do
           geometry: PaneGeometry.t() | nil,
           content_epoch: non_neg_integer(),
           full_refresh: boolean(),
-          contiguous_rows: boolean()
+          contiguous_rows: boolean(),
+          content_digest: Minga.RenderModel.Window.ContentDigest.t() | nil
         }
 end

--- a/lib/minga/render_model/window/content_digest.ex
+++ b/lib/minga/render_model/window/content_digest.ex
@@ -14,9 +14,9 @@ defmodule Minga.RenderModel.Window.ContentDigest do
   The digest is a fold over per-row *cells*, where a cell is
   `phash2({row_id, content_hash})`. `row_id` already encodes the row's buffer
   line (`Row.stable_id/4`), so a cell captures both a row's identity/position and
-  its rendered content. Two row lists produce the same digest exactly when they
-  carry the same multiset of `{row_id, content_hash}` pairs, which is exactly
-  when they render identically.
+  its rendered content. Two row lists produce the same digest with overwhelming
+  probability when they carry the same multiset of `{row_id, content_hash}` pairs
+  (see Collision behaviour below for the probabilistic bound).
 
   ## Algebra
 
@@ -29,11 +29,14 @@ defmodule Minga.RenderModel.Window.ContentDigest do
 
   ## Collision behaviour
 
-  The digest is `phash2`-derived, so a content change is missed only when the old
-  and new cells collide (~1 in 2^27 per changed row). This matches the collision
-  profile of the whole-list `phash2` it replaces; it does not add risk. Row ids
-  are assumed unique within a window (guaranteed by `Row.stable_id/4` per
-  position); the digest is a set digest under that assumption.
+  The digest is `phash2`-derived, so a single-row content change is missed only
+  when the old and new cells collide (~1 in 2^27 per changed row). For multi-row
+  splices the deltas of several rows can also XOR-cancel even when no single row
+  collides; the overall miss probability stays in the same ~2^-27 order. This
+  matches the collision profile of the whole-list `phash2` it replaces; it does
+  not add risk. Row ids are assumed unique within a window (guaranteed by
+  `Row.stable_id/4` per position); the digest is a set digest under that
+  assumption.
   """
 
   import Bitwise
@@ -41,7 +44,7 @@ defmodule Minga.RenderModel.Window.ContentDigest do
   alias Minga.RenderModel.Window.Row
 
   @typedoc "An opaque non-negative integer digest."
-  @type t :: non_neg_integer()
+  @opaque t :: non_neg_integer()
 
   @doc "Returns the digest of an empty row set."
   @spec empty() :: t()
@@ -65,7 +68,7 @@ defmodule Minga.RenderModel.Window.ContentDigest do
   """
   @spec remove(t(), Row.row_id(), non_neg_integer()) :: t()
   def remove(digest, row_id, content_hash) when is_integer(digest) do
-    bxor(digest, cell(row_id, content_hash))
+    add(digest, row_id, content_hash)
   end
 
   @doc "Replaces a row's content hash under the same id."

--- a/lib/minga/render_model/window/content_digest.ex
+++ b/lib/minga/render_model/window/content_digest.ex
@@ -1,0 +1,100 @@
+defmodule Minga.RenderModel.Window.ContentDigest do
+  @moduledoc """
+  Incrementally maintained content digest for a window's resident row set (#2658).
+
+  The GUI adapter gates each window's content frame-emit on whether the window's
+  rows changed since the last emit. With full-document residence a window's row
+  list is the whole document, so re-hashing the entire list every frame is
+  O(document) and dominates edit-frame build cost. This digest replaces that
+  whole-list hash with a value that updates in O(1) per changed row and stays
+  correct across row insertion and deletion.
+
+  ## Keying
+
+  The digest is a fold over per-row *cells*, where a cell is
+  `phash2({row_id, content_hash})`. `row_id` already encodes the row's buffer
+  line (`Row.stable_id/4`), so a cell captures both a row's identity/position and
+  its rendered content. Two row lists produce the same digest exactly when they
+  carry the same multiset of `{row_id, content_hash}` pairs, which is exactly
+  when they render identically.
+
+  ## Algebra
+
+  Cells are combined with `bxor`, which is associative, commutative, and
+  self-inverse. That gives O(1) `add`/`remove`/`update` and makes the digest
+  independent of iteration order (position is already carried inside `row_id`, so
+  order independence never hides a real change). Editing a row back to its prior
+  content restores the prior cell and therefore the prior digest, so no spurious
+  frame-emit occurs.
+
+  ## Collision behaviour
+
+  The digest is `phash2`-derived, so a content change is missed only when the old
+  and new cells collide (~1 in 2^27 per changed row). This matches the collision
+  profile of the whole-list `phash2` it replaces; it does not add risk. Row ids
+  are assumed unique within a window (guaranteed by `Row.stable_id/4` per
+  position); the digest is a set digest under that assumption.
+  """
+
+  import Bitwise
+
+  alias Minga.RenderModel.Window.Row
+
+  @typedoc "An opaque non-negative integer digest."
+  @type t :: non_neg_integer()
+
+  @doc "Returns the digest of an empty row set."
+  @spec empty() :: t()
+  def empty, do: 0
+
+  @doc "Returns the per-row cell for a `{row_id, content_hash}` pair."
+  @spec cell(Row.row_id(), non_neg_integer()) :: non_neg_integer()
+  def cell(row_id, content_hash), do: :erlang.phash2({row_id, content_hash})
+
+  @doc "Folds a row into the digest."
+  @spec add(t(), Row.row_id(), non_neg_integer()) :: t()
+  def add(digest, row_id, content_hash) when is_integer(digest) do
+    bxor(digest, cell(row_id, content_hash))
+  end
+
+  @doc """
+  Removes a row from the digest.
+
+  Self-inverse with `add/3`: removing a row that was previously added restores
+  the digest to its pre-add value.
+  """
+  @spec remove(t(), Row.row_id(), non_neg_integer()) :: t()
+  def remove(digest, row_id, content_hash) when is_integer(digest) do
+    bxor(digest, cell(row_id, content_hash))
+  end
+
+  @doc "Replaces a row's content hash under the same id."
+  @spec update(t(), Row.row_id(), non_neg_integer(), non_neg_integer()) :: t()
+  def update(digest, row_id, old_content_hash, new_content_hash) do
+    digest
+    |> remove(row_id, old_content_hash)
+    |> add(row_id, new_content_hash)
+  end
+
+  @doc """
+  Computes the digest of a row list from scratch.
+
+  This is the O(document) reference used on a full rebuild and as the oracle in
+  tests; the incremental `add`/`remove`/`update` operations must always agree
+  with it.
+  """
+  @spec of_rows([Row.t()]) :: t()
+  def of_rows(rows) when is_list(rows) do
+    Enum.reduce(rows, empty(), fn %Row{row_id: row_id, content_hash: content_hash}, acc ->
+      add(acc, row_id, content_hash)
+    end)
+  end
+
+  @doc "Computes the digest of a list of `{row_id, content_hash}` pairs from scratch."
+  @spec of_pairs([{Row.row_id(), non_neg_integer()}]) :: t()
+  def of_pairs(pairs) when is_list(pairs) do
+    Enum.reduce(pairs, empty(), fn {row_id, content_hash}, acc ->
+      add(acc, row_id, content_hash)
+    end)
+  end
+end

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -170,9 +170,11 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     #
     # Full-document residence (#2658) takes an incremental path: a persistent
     # ResidentBuild state splices only the rows whose text changed and maintains
-    # the content digest in O(changed rows), so an edit frame no longer rebuilds
-    # the whole document. Off residence this is the unchanged windowed build and
-    # `resident_result` is nil, so behaviour is byte identical.
+    # the content digest in O(changed rows). A tree-sitter re-highlight still
+    # triggers a full rebuild (the highlight fingerprint changes), but the common
+    # case (in-place text edit) avoids the O(document) compose. Off residence this
+    # is the unchanged windowed build and `resident_result` is nil, so behaviour
+    # is byte identical.
     {all_visual_entries, resident_result} =
       if scroll.full_residence do
         build_resident_entries(scroll, lines, first_line, ctx, snapshot, retain_ctx, opts)
@@ -389,6 +391,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       compose_fp: retain_ctx.compose_fp,
       highlight_fp: highlight_content_fingerprint(ctx.highlight),
       reset?: scroll.full_refresh,
+      retained_rows: retain_ctx.prev,
       build_all: fn ->
         build_visual_entries(lines, first_line, nil, false, ctx, snapshot, retain_ctx)
       end,
@@ -398,15 +401,7 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     }
 
     {state, result} = ResidentBuild.run(Keyword.get(opts, :resident_build), inputs)
-
-    {result.payloads,
-     %{
-       retained_rows: result.retained_rows,
-       rasterized: result.rasterized,
-       digest: result.digest,
-       state: state,
-       spliced: result.spliced
-     }}
+    {result.payloads, Map.put(result, :state, state)}
   end
 
   # Composes entries for exactly the dirty sequential line indices, reusing the
@@ -441,20 +436,15 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     end)
   end
 
-  # One byte-offset scan, materializing only the dirty lines' `{text, offset}`.
-  # Cheaper than building the full offset list every edit frame (#2658).
   @spec dirty_line_offsets([String.t()], non_neg_integer(), MapSet.t(non_neg_integer())) ::
           %{non_neg_integer() => {String.t(), non_neg_integer()}}
   defp dirty_line_offsets(lines, first_byte_off, dirty) do
-    {map, _off} =
-      lines
-      |> Enum.with_index()
-      |> Enum.reduce({%{}, first_byte_off}, fn {line, index}, {acc, off} ->
-        acc = if MapSet.member?(dirty, index), do: Map.put(acc, index, {line, off}), else: acc
-        {acc, off + byte_size(line) + 1}
-      end)
-
-    map
+    lines
+    |> build_lines_with_offsets(first_byte_off)
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {{line, off}, index}, acc ->
+      if MapSet.member?(dirty, index), do: Map.put(acc, index, {line, off}), else: acc
+    end)
   end
 
   # Masked highlight segments for exactly the dirty lines, keyed by index. With no

--- a/lib/minga_editor/render_model/window/builder.ex
+++ b/lib/minga_editor/render_model/window/builder.ex
@@ -33,6 +33,8 @@ defmodule MingaEditor.RenderModel.Window.Builder do
   alias MingaEditor.Renderer.Composition
   alias MingaEditor.Renderer.Context
   alias Minga.RenderModel.Window, as: RenderWindow
+  alias Minga.RenderModel.Window.ContentDigest
+  alias MingaEditor.RenderModel.Window.ResidentBuild
   alias Minga.RenderModel.Window.Annotation
   alias Minga.RenderModel.Window.Cursorline
   alias Minga.RenderModel.Window.DiagnosticRange
@@ -90,7 +92,9 @@ defmodule MingaEditor.RenderModel.Window.Builder do
   @type build_stats :: %{
           rasterized: non_neg_integer(),
           retained_rows: %{optional(non_neg_integer()) => {non_neg_integer(), Row.t()}},
-          retained_wrap_lines: %{optional(non_neg_integer()) => {non_neg_integer(), [map()]}}
+          retained_wrap_lines: %{optional(non_neg_integer()) => {non_neg_integer(), [map()]}},
+          resident_build: ResidentBuild.t() | nil,
+          resident_rows_spliced: non_neg_integer()
         }
 
   # Threaded through the visual-entry builders to drive upstream row reuse
@@ -163,16 +167,26 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     # Build visual rows from the same data the draw path uses. Unchanged rows
     # are reused from the retained-row cache (no recompose) when their cheap
     # input fingerprint matches; only composed rows count as rasterized (#2287).
-    all_visual_entries =
-      build_visual_entries(
-        lines,
-        first_line,
-        visible_line_map,
-        wrap_on,
-        ctx,
-        snapshot,
-        retain_ctx
-      )
+    #
+    # Full-document residence (#2658) takes an incremental path: a persistent
+    # ResidentBuild state splices only the rows whose text changed and maintains
+    # the content digest in O(changed rows), so an edit frame no longer rebuilds
+    # the whole document. Off residence this is the unchanged windowed build and
+    # `resident_result` is nil, so behaviour is byte identical.
+    {all_visual_entries, resident_result} =
+      if scroll.full_residence do
+        build_resident_entries(scroll, lines, first_line, ctx, snapshot, retain_ctx, opts)
+      else
+        {build_visual_entries(
+           lines,
+           first_line,
+           visible_line_map,
+           wrap_on,
+           ctx,
+           snapshot,
+           retain_ctx
+         ), nil}
+      end
 
     visible_row_start_index = scroll.visible_row_start_index + viewport.visual_row_offset
     raw_overscan_before = max(scroll.visible_row_start_index - viewport.visual_row_offset, 0)
@@ -200,6 +214,10 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     # (build_gutter below) stays viewport-windowed off `presentation_entries`;
     # indent guides are independently viewport-windowed off `scroll.lines`. Only
     # the row set and its retained-row cache become resident.
+    #
+    # The resident entries feed only `presentation_rows` (the `.row` of each),
+    # which never carries the entry-level `display_row`, so the residence path
+    # skips the whole-document re-index `trim_visual_entries/3` would do (#2658).
     resident_entries =
       if scroll.full_residence do
         all_visual_entries
@@ -207,7 +225,8 @@ defmodule MingaEditor.RenderModel.Window.Builder do
         presentation_entries
       end
 
-    {new_retained, rasterized} = retained_stats(resident_entries, retain_ctx)
+    {new_retained, rasterized, content_digest, resident_build_state, resident_rows_spliced} =
+      resolve_retained_and_digest(resident_result, resident_entries, retain_ctx)
 
     new_retained_wrap =
       retained_wrap_lines(resident_entries, wrap_on and visible_line_map == nil)
@@ -333,15 +352,146 @@ defmodule MingaEditor.RenderModel.Window.Builder do
       full_refresh: scroll.full_refresh,
       # Non-wrapped, non-folded windows emit consecutive :normal buffer lines, so
       # ScrollPresentation can derive the resident line range arithmetically.
-      contiguous_rows: is_nil(visible_line_map) and not wrap_on
+      contiguous_rows: is_nil(visible_line_map) and not wrap_on,
+      # Set only on the residence path; the GUI adapter gates the content
+      # frame-emit on it instead of hashing the full rows list (#2658).
+      content_digest: content_digest
     }
 
     {render_window,
      %{
        rasterized: rasterized,
        retained_rows: new_retained,
-       retained_wrap_lines: new_retained_wrap
+       retained_wrap_lines: new_retained_wrap,
+       resident_build: resident_build_state,
+       resident_rows_spliced: resident_rows_spliced
      }}
+  end
+
+  # ── Full-document residence incremental build (#2658) ──────────────────────
+
+  # Runs the persistent ResidentBuild for the residence path, returning the full
+  # resident entry list and the frame's retained/digest result. The full build
+  # and the dirty-line splice both compose through `compose_sequential_entry/6`,
+  # so a spliced entry is byte identical to a freshly built one.
+  @spec build_resident_entries(
+          WindowScroll.t(),
+          [String.t()],
+          non_neg_integer(),
+          Context.t(),
+          map(),
+          retain_ctx(),
+          keyword()
+        ) :: {[visual_row_entry()], map()}
+  defp build_resident_entries(scroll, lines, first_line, ctx, snapshot, retain_ctx, opts) do
+    inputs = %{
+      line_texts: lines,
+      compose_fp: retain_ctx.compose_fp,
+      highlight_fp: highlight_content_fingerprint(ctx.highlight),
+      reset?: scroll.full_refresh,
+      build_all: fn ->
+        build_visual_entries(lines, first_line, nil, false, ctx, snapshot, retain_ctx)
+      end,
+      build_dirty: fn dirty ->
+        build_dirty_sequential_entries(dirty, lines, first_line, ctx, snapshot, retain_ctx)
+      end
+    }
+
+    {state, result} = ResidentBuild.run(Keyword.get(opts, :resident_build), inputs)
+
+    {result.payloads,
+     %{
+       retained_rows: result.retained_rows,
+       rasterized: result.rasterized,
+       digest: result.digest,
+       state: state,
+       spliced: result.spliced
+     }}
+  end
+
+  # Composes entries for exactly the dirty sequential line indices, reusing the
+  # masked highlight batch so only dirty rows produce styled segments (#2658).
+  @spec build_dirty_sequential_entries(
+          MapSet.t(non_neg_integer()),
+          [String.t()],
+          non_neg_integer(),
+          Context.t(),
+          map(),
+          retain_ctx()
+        ) :: %{non_neg_integer() => visual_row_entry()}
+  defp build_dirty_sequential_entries(dirty, lines, first_line, ctx, snapshot, retain_ctx) do
+    first_byte_off = snapshot.first_line_byte_offset
+    offsets = dirty_line_offsets(lines, first_byte_off, dirty)
+    masked = masked_highlight_by_index(ctx.highlight, lines, first_byte_off, dirty)
+
+    Enum.reduce(dirty, %{}, fn index, acc ->
+      {line_text, line_byte_offset} = Map.fetch!(offsets, index)
+
+      entry =
+        compose_sequential_entry(
+          first_line + index,
+          line_text,
+          Map.get(masked, index),
+          line_byte_offset,
+          ctx,
+          retain_ctx
+        )
+
+      Map.put(acc, index, entry)
+    end)
+  end
+
+  # One byte-offset scan, materializing only the dirty lines' `{text, offset}`.
+  # Cheaper than building the full offset list every edit frame (#2658).
+  @spec dirty_line_offsets([String.t()], non_neg_integer(), MapSet.t(non_neg_integer())) ::
+          %{non_neg_integer() => {String.t(), non_neg_integer()}}
+  defp dirty_line_offsets(lines, first_byte_off, dirty) do
+    {map, _off} =
+      lines
+      |> Enum.with_index()
+      |> Enum.reduce({%{}, first_byte_off}, fn {line, index}, {acc, off} ->
+        acc = if MapSet.member?(dirty, index), do: Map.put(acc, index, {line, off}), else: acc
+        {acc, off + byte_size(line) + 1}
+      end)
+
+    map
+  end
+
+  # Masked highlight segments for exactly the dirty lines, keyed by index. With no
+  # tree-sitter highlight there is nothing to compute. With highlight, the batch
+  # walk keeps byte-offset watermarks correct but only produces segments for the
+  # dirty rows (#2658).
+  @spec masked_highlight_by_index(
+          Highlight.t() | nil,
+          [String.t()],
+          non_neg_integer(),
+          MapSet.t(non_neg_integer())
+        ) :: %{non_neg_integer() => [Highlight.styled_segment()]}
+  defp masked_highlight_by_index(nil, _lines, _first_byte_off, _dirty), do: %{}
+
+  defp masked_highlight_by_index(%Highlight{} = hl, lines, first_byte_off, dirty) do
+    hl
+    |> Highlight.styles_for_text_lines_masked(lines, first_byte_off, dirty)
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {segments, index}, acc ->
+      if is_nil(segments), do: acc, else: Map.put(acc, index, segments)
+    end)
+  end
+
+  @spec highlight_content_fingerprint(Highlight.t() | nil) :: integer() | nil
+  defp highlight_content_fingerprint(nil), do: nil
+  defp highlight_content_fingerprint(%Highlight{} = hl), do: :erlang.phash2(hl)
+
+  @spec resolve_retained_and_digest(map() | nil, [visual_row_entry()], retain_ctx()) ::
+          {%{optional(non_neg_integer()) => {non_neg_integer(), Row.t()}}, non_neg_integer(),
+           ContentDigest.t() | nil, ResidentBuild.t() | nil, non_neg_integer()}
+  defp resolve_retained_and_digest(nil, resident_entries, retain_ctx) do
+    {new_retained, rasterized} = retained_stats(resident_entries, retain_ctx)
+    {new_retained, rasterized, nil, nil, 0}
+  end
+
+  defp resolve_retained_and_digest(%{} = result, _resident_entries, _retain_ctx) do
+    {result.retained_rows, result.rasterized, result.digest, result.state, result.spliced}
   end
 
   # ── Upstream row retention (#2287) ─────────────────────────────────────────
@@ -597,28 +747,56 @@ defmodule MingaEditor.RenderModel.Window.Builder do
     |> Enum.zip(highlight_segments_list)
     |> Enum.with_index()
     |> Enum.map(fn {{{line_text, line_byte_offset}, hl_segments}, idx} ->
-      buf_line = first_line + idx
-      row_id = Row.stable_id(:normal, buf_line)
-
-      {row, input_hash, reused?} =
-        compose_or_reuse(retain_ctx, row_id, {:seq, line_text, hl_segments}, fn ->
-          {composed_text, spans} =
-            compose_line(line_text, hl_segments, ctx, buf_line, line_byte_offset)
-
-          %Row{
-            row_id: row_id,
-            row_type: :normal,
-            buf_line: buf_line,
-            text: composed_text,
-            spans: spans,
-            content_hash: Row.compute_hash(composed_text, spans)
-          }
-        end)
-
-      row
-      |> visual_entry(0, Unicode.display_width(row.text), 0)
-      |> with_retain_meta(input_hash, reused?)
+      compose_sequential_entry(
+        first_line + idx,
+        line_text,
+        hl_segments,
+        line_byte_offset,
+        ctx,
+        retain_ctx
+      )
     end)
+  end
+
+  # Composes (or reuses) the single visual-row entry for one sequential line.
+  # Shared by the full sequential build and the residence dirty-line splice
+  # (#2658) so both produce byte-identical entries for the same inputs.
+  @spec compose_sequential_entry(
+          non_neg_integer(),
+          String.t(),
+          [Highlight.styled_segment()] | nil,
+          non_neg_integer(),
+          Context.t(),
+          retain_ctx()
+        ) :: visual_row_entry()
+  defp compose_sequential_entry(
+         buf_line,
+         line_text,
+         hl_segments,
+         line_byte_offset,
+         ctx,
+         retain_ctx
+       ) do
+    row_id = Row.stable_id(:normal, buf_line)
+
+    {row, input_hash, reused?} =
+      compose_or_reuse(retain_ctx, row_id, {:seq, line_text, hl_segments}, fn ->
+        {composed_text, spans} =
+          compose_line(line_text, hl_segments, ctx, buf_line, line_byte_offset)
+
+        %Row{
+          row_id: row_id,
+          row_type: :normal,
+          buf_line: buf_line,
+          text: composed_text,
+          spans: spans,
+          content_hash: Row.compute_hash(composed_text, spans)
+        }
+      end)
+
+    row
+    |> visual_entry(0, Unicode.display_width(row.text), 0)
+    |> with_retain_meta(input_hash, reused?)
   end
 
   @spec build_visual_entries_wrapped(

--- a/lib/minga_editor/render_model/window/resident_build.ex
+++ b/lib/minga_editor/render_model/window/resident_build.ex
@@ -23,9 +23,12 @@ defmodule MingaEditor.RenderModel.Window.ResidentBuild do
   frame's, so every source that alters a resident row's rendered content routes
   to either a precise splice (buffer text edits) or a conservative full rebuild
   (everything the context fingerprint or the highlight fingerprint captures:
-  selection- and search-driven span overlays, diagnostics, git signs, decorations,
-  re-highlight spans). Nothing that changes a row is allowed to skip the digest,
-  which is the completeness guarantee AC 2 depends on.
+  search-driven and diagnostic-underline decoration spans, generic decorations,
+  re-highlight spans). Overlay- and gutter-only sources (selection, git signs,
+  diagnostic signs) are viewport-windowed fields of the window model, not baked
+  into `Row.content_hash`, so off-screen changes to them correctly produce no
+  resident re-emit. Nothing that changes a row's rendered content is allowed to
+  skip the digest, which is the completeness guarantee AC 2 depends on.
   """
 
   alias Minga.RenderModel.Window.ContentDigest
@@ -40,7 +43,6 @@ defmodule MingaEditor.RenderModel.Window.ResidentBuild do
 
   @type t :: %__MODULE__{
           store: ResidentStore.t(),
-          retained_rows: retained_rows(),
           compose_fp: integer() | nil,
           highlight_fp: integer() | nil,
           line_count: integer(),
@@ -48,7 +50,6 @@ defmodule MingaEditor.RenderModel.Window.ResidentBuild do
         }
 
   defstruct store: %ResidentStore{},
-            retained_rows: %{},
             compose_fp: nil,
             highlight_fp: nil,
             line_count: -1,
@@ -71,6 +72,7 @@ defmodule MingaEditor.RenderModel.Window.ResidentBuild do
           required(:compose_fp) => integer(),
           required(:highlight_fp) => integer() | nil,
           required(:reset?) => boolean(),
+          required(:retained_rows) => retained_rows(),
           required(:build_all) => (-> [payload()]),
           required(:build_dirty) => (MapSet.t(non_neg_integer()) ->
                                        %{non_neg_integer() => payload()})
@@ -123,7 +125,6 @@ defmodule MingaEditor.RenderModel.Window.ResidentBuild do
 
     state = %__MODULE__{
       store: store,
-      retained_rows: retained,
       compose_fp: inputs.compose_fp,
       highlight_fp: inputs.highlight_fp,
       line_count: length(payloads),
@@ -159,7 +160,7 @@ defmodule MingaEditor.RenderModel.Window.ResidentBuild do
      %{
        payloads: ResidentStore.payloads(prev.store),
        digest: ResidentStore.digest(prev.store),
-       retained_rows: prev.retained_rows,
+       retained_rows: inputs.retained_rows,
        rasterized: 0,
        spliced: 0
      }}
@@ -175,11 +176,11 @@ defmodule MingaEditor.RenderModel.Window.ResidentBuild do
       end)
 
     retained =
-      Enum.reduce(dirty_payloads, prev.retained_rows, fn {_index, payload}, acc ->
+      Enum.reduce(dirty_payloads, inputs.retained_rows, fn {_index, payload}, acc ->
         Map.put(acc, payload.row.row_id, {retain_hash(payload), payload.row})
       end)
 
-    state = %{prev | store: store, retained_rows: retained, line_texts: inputs.line_texts}
+    state = %{prev | store: store, line_texts: inputs.line_texts}
 
     {state,
      %{

--- a/lib/minga_editor/render_model/window/resident_build.ex
+++ b/lib/minga_editor/render_model/window/resident_build.ex
@@ -1,0 +1,227 @@
+defmodule MingaEditor.RenderModel.Window.ResidentBuild do
+  @moduledoc """
+  Per-window incremental build state for full-document residence (#2658).
+
+  Carried across frames in the window render cache. Given the current frame's
+  line texts and the composition-context fingerprints, it decides between three
+  outcomes and keeps the resident entry list, its retained-row map, and its
+  `Minga.RenderModel.Window.ContentDigest` in sync in O(changed rows):
+
+    * **full rebuild** — first residence frame, a frontend reset, a composition
+      context change (theme, decorations, search overlay, tab width…), a
+      tree-sitter re-highlight, or a row-count change (insert/delete). Runs the
+      caller's `build_all` closure (the ordinary #2287 build, which itself reuses
+      unchanged composed rows), then recomputes the digest from scratch.
+    * **splice** — some line texts changed with the context and row count stable
+      (in-place edits, substitution preview). Only the changed line indices are
+      recomposed via the caller's `build_dirty` closure; the rest of the entry
+      list and the digest are updated incrementally.
+    * **reuse** — nothing changed (scroll, cursor motion). The prior resident
+      entry list, retained-row map, and digest are returned unchanged.
+
+  The dirty set is derived by comparing this frame's line texts against the prior
+  frame's, so every source that alters a resident row's rendered content routes
+  to either a precise splice (buffer text edits) or a conservative full rebuild
+  (everything the context fingerprint or the highlight fingerprint captures:
+  selection- and search-driven span overlays, diagnostics, git signs, decorations,
+  re-highlight spans). Nothing that changes a row is allowed to skip the digest,
+  which is the completeness guarantee AC 2 depends on.
+  """
+
+  alias Minga.RenderModel.Window.ContentDigest
+  alias Minga.RenderModel.Window.Row
+  alias MingaEditor.RenderModel.Window.ResidentStore
+
+  @typedoc "A composed visual-row entry (`MingaEditor.RenderModel.Window.Builder` shape)."
+  @type payload :: %{required(:row) => Row.t(), optional(atom()) => term()}
+
+  @typedoc "Retained composed rows keyed by row id, for #2287 reuse and classifier state."
+  @type retained_rows :: %{optional(Row.row_id()) => {non_neg_integer(), Row.t()}}
+
+  @type t :: %__MODULE__{
+          store: ResidentStore.t(),
+          retained_rows: retained_rows(),
+          compose_fp: integer() | nil,
+          highlight_fp: integer() | nil,
+          line_count: integer(),
+          line_texts: [String.t()]
+        }
+
+  defstruct store: %ResidentStore{},
+            retained_rows: %{},
+            compose_fp: nil,
+            highlight_fp: nil,
+            line_count: -1,
+            line_texts: []
+
+  @typedoc """
+  Per-frame residence build inputs.
+
+  * `line_texts` — the full document's line texts (index = buffer line).
+  * `compose_fp` — the shared composition-context fingerprint (decorations,
+    invisibles, tab width, todo faces…); any change forces a full rebuild.
+  * `highlight_fp` — a fingerprint of the tree-sitter highlight; a re-highlight
+    forces a full rebuild so re-colored rows never stay stale.
+  * `reset?` — a frontend/geometry reset for this frame.
+  * `build_all` — builds every resident entry (the ordinary #2287 build).
+  * `build_dirty` — builds entries for exactly the given dirty line indices.
+  """
+  @type inputs :: %{
+          required(:line_texts) => [String.t()],
+          required(:compose_fp) => integer(),
+          required(:highlight_fp) => integer() | nil,
+          required(:reset?) => boolean(),
+          required(:build_all) => (-> [payload()]),
+          required(:build_dirty) => (MapSet.t(non_neg_integer()) ->
+                                       %{non_neg_integer() => payload()})
+        }
+
+  @typedoc """
+  Per-frame residence build result.
+
+  `payloads` is the full resident entry list; `digest` is the incremental
+  content digest; `retained_rows` carries the #2287 reuse map; `rasterized`
+  counts freshly composed rows; `spliced` counts rows touched by the incremental
+  splice (0 on full rebuild and reuse).
+  """
+  @type result :: %{
+          payloads: [payload()],
+          digest: ContentDigest.t(),
+          retained_rows: retained_rows(),
+          rasterized: non_neg_integer(),
+          spliced: non_neg_integer()
+        }
+
+  @doc """
+  Runs one residence build frame, returning the next persistent state and the
+  frame result.
+  """
+  @spec run(t() | nil, inputs()) :: {t(), result()}
+  def run(prev, inputs) do
+    if full_rebuild?(prev, inputs) do
+      full_rebuild(inputs)
+    else
+      incremental(prev, inputs)
+    end
+  end
+
+  @spec full_rebuild?(t() | nil, inputs()) :: boolean()
+  defp full_rebuild?(nil, _inputs), do: true
+
+  defp full_rebuild?(%__MODULE__{} = prev, inputs) do
+    inputs.reset? or
+      prev.compose_fp != inputs.compose_fp or
+      prev.highlight_fp != inputs.highlight_fp or
+      prev.line_count != length(inputs.line_texts)
+  end
+
+  @spec full_rebuild(inputs()) :: {t(), result()}
+  defp full_rebuild(inputs) do
+    payloads = inputs.build_all.()
+    store = ResidentStore.from_entries(Enum.map(payloads, &to_store_entry/1))
+    retained = retained_of(payloads)
+
+    state = %__MODULE__{
+      store: store,
+      retained_rows: retained,
+      compose_fp: inputs.compose_fp,
+      highlight_fp: inputs.highlight_fp,
+      line_count: length(payloads),
+      line_texts: inputs.line_texts
+    }
+
+    {state,
+     %{
+       payloads: payloads,
+       digest: ResidentStore.digest(store),
+       retained_rows: retained,
+       rasterized: rasterized_of(payloads),
+       spliced: 0
+     }}
+  end
+
+  @spec incremental(t(), inputs()) :: {t(), result()}
+  defp incremental(%__MODULE__{} = prev, inputs) do
+    dirty = dirty_indices(prev.line_texts, inputs.line_texts)
+
+    if MapSet.size(dirty) == 0 do
+      reuse(prev, inputs)
+    else
+      splice(prev, inputs, dirty)
+    end
+  end
+
+  @spec reuse(t(), inputs()) :: {t(), result()}
+  defp reuse(%__MODULE__{} = prev, inputs) do
+    state = %{prev | line_texts: inputs.line_texts}
+
+    {state,
+     %{
+       payloads: ResidentStore.payloads(prev.store),
+       digest: ResidentStore.digest(prev.store),
+       retained_rows: prev.retained_rows,
+       rasterized: 0,
+       spliced: 0
+     }}
+  end
+
+  @spec splice(t(), inputs(), MapSet.t(non_neg_integer())) :: {t(), result()}
+  defp splice(%__MODULE__{} = prev, inputs, dirty) do
+    dirty_payloads = inputs.build_dirty.(dirty)
+
+    store =
+      ResidentStore.rebuild(prev.store, dirty, fn index ->
+        to_store_entry(Map.fetch!(dirty_payloads, index))
+      end)
+
+    retained =
+      Enum.reduce(dirty_payloads, prev.retained_rows, fn {_index, payload}, acc ->
+        Map.put(acc, payload.row.row_id, {retain_hash(payload), payload.row})
+      end)
+
+    state = %{prev | store: store, retained_rows: retained, line_texts: inputs.line_texts}
+
+    {state,
+     %{
+       payloads: ResidentStore.payloads(store),
+       digest: ResidentStore.digest(store),
+       retained_rows: retained,
+       rasterized: map_size(dirty_payloads),
+       spliced: MapSet.size(dirty)
+     }}
+  end
+
+  # Indices where the line text changed between frames. The lists are the same
+  # length (a row-count change forces a full rebuild before we reach here).
+  @spec dirty_indices([String.t()], [String.t()]) :: MapSet.t(non_neg_integer())
+  defp dirty_indices(prev_texts, new_texts) do
+    prev_texts
+    |> Enum.zip(new_texts)
+    |> Enum.with_index()
+    |> Enum.reduce(MapSet.new(), fn {{prev_text, new_text}, index}, acc ->
+      if prev_text == new_text, do: acc, else: MapSet.put(acc, index)
+    end)
+  end
+
+  @spec to_store_entry(payload()) :: ResidentStore.entry()
+  defp to_store_entry(%{row: %Row{} = row} = payload) do
+    ResidentStore.entry(row.row_id, row.content_hash, payload)
+  end
+
+  @spec retained_of([payload()]) :: retained_rows()
+  defp retained_of(payloads) do
+    Map.new(payloads, fn %{row: %Row{} = row} = payload ->
+      {row.row_id, {retain_hash(payload), row}}
+    end)
+  end
+
+  @spec retain_hash(payload()) :: non_neg_integer()
+  defp retain_hash(%{row: %Row{content_hash: content_hash}} = payload) do
+    Map.get(payload, :input_hash, content_hash)
+  end
+
+  @spec rasterized_of([payload()]) :: non_neg_integer()
+  defp rasterized_of(payloads) do
+    Enum.count(payloads, fn payload -> not Map.get(payload, :reused?, false) end)
+  end
+end

--- a/lib/minga_editor/render_model/window/resident_store.ex
+++ b/lib/minga_editor/render_model/window/resident_store.ex
@@ -1,0 +1,203 @@
+defmodule MingaEditor.RenderModel.Window.ResidentStore do
+  @moduledoc """
+  Persistent per-window resident row entry list plus its content digest (#2658).
+
+  With full-document residence a window's row set is the whole document. Rebuilding
+  that list, its retained-row map, and its content fingerprint from scratch every
+  frame makes edit-frame build cost O(document). This structure carries the
+  resident entry list and an incrementally maintained
+  `Minga.RenderModel.Window.ContentDigest` across frames so the per-frame build
+  splices only the rows a dirty set marks changed and updates the digest in O(1)
+  per changed row.
+
+  The store is the single persistent structure the ticket introduces: the render
+  pipeline stashes it in the window render cache and threads it through
+  `MingaEditor.RenderModel.Window.Builder` on the residence path. Off the
+  residence path (the default) it is never constructed, so behaviour is byte
+  identical to the windowed build.
+
+  ## Entries
+
+  An entry is a plain map `%{id, content_hash, payload}`:
+
+  * `id` — the row identity (a `Row.row_id`), unique within the window.
+  * `content_hash` — the row's rendered-content hash, what the digest folds.
+  * `payload` — opaque to the store; the builder stashes the composed visual-row
+    entry (its `Row` and retention metadata) here.
+
+  ## Value-keyed, not identity-memoized
+
+  Reuse keys off `content_hash` (a value), never pointer identity, so this respects
+  the #2445 ruling against identity memoization. The oracle for every operation is
+  a from-scratch rebuild over the same entries; the incremental result must always
+  equal it.
+  """
+
+  alias Minga.RenderModel.Window.ContentDigest
+
+  @typedoc "A resident row entry. `payload` is opaque to the store."
+  @type entry :: %{
+          required(:id) => term(),
+          required(:content_hash) => non_neg_integer(),
+          required(:payload) => term()
+        }
+
+  @type t :: %__MODULE__{
+          entries: [entry()],
+          digest: ContentDigest.t()
+        }
+
+  defstruct entries: [], digest: 0
+
+  @doc "Returns an empty store."
+  @spec new() :: t()
+  def new, do: %__MODULE__{entries: [], digest: ContentDigest.empty()}
+
+  @doc "Builds an entry from its id, content hash, and opaque payload."
+  @spec entry(term(), non_neg_integer(), term()) :: entry()
+  def entry(id, content_hash, payload) when is_integer(content_hash) do
+    %{id: id, content_hash: content_hash, payload: payload}
+  end
+
+  @doc "Builds a store from an ordered entry list, computing the digest from scratch."
+  @spec from_entries([entry()]) :: t()
+  def from_entries(entries) when is_list(entries) do
+    %__MODULE__{entries: entries, digest: digest_of(entries)}
+  end
+
+  @doc "Returns the ordered entry list."
+  @spec entries(t()) :: [entry()]
+  def entries(%__MODULE__{entries: entries}), do: entries
+
+  @doc "Returns the ordered opaque payloads."
+  @spec payloads(t()) :: [term()]
+  def payloads(%__MODULE__{entries: entries}), do: Enum.map(entries, & &1.payload)
+
+  @doc "Returns the current content digest."
+  @spec digest(t()) :: ContentDigest.t()
+  def digest(%__MODULE__{digest: digest}), do: digest
+
+  @doc "Returns the number of resident rows."
+  @spec size(t()) :: non_neg_integer()
+  def size(%__MODULE__{entries: entries}), do: length(entries)
+
+  @doc "Returns true when the store holds no rows."
+  @spec empty?(t()) :: boolean()
+  def empty?(%__MODULE__{entries: []}), do: true
+  def empty?(%__MODULE__{}), do: false
+
+  @doc """
+  Replaces the entry at `index`, updating the digest incrementally.
+
+  Out-of-range indices are ignored (returns the store unchanged), keeping the
+  operation total for property-test sequences.
+  """
+  @spec replace_at(t(), non_neg_integer(), entry()) :: t()
+  def replace_at(%__MODULE__{entries: entries, digest: digest} = store, index, new_entry)
+      when is_integer(index) and index >= 0 do
+    case Enum.fetch(entries, index) do
+      {:ok, old_entry} ->
+        %{
+          store
+          | entries: List.replace_at(entries, index, new_entry),
+            digest: swap_digest(digest, old_entry, new_entry)
+        }
+
+      :error ->
+        store
+    end
+  end
+
+  def replace_at(%__MODULE__{} = store, _index, _new_entry), do: store
+
+  @doc """
+  Inserts `new_entry` at `index`, shifting later entries right and folding the
+  new row into the digest.
+
+  Existing entries keep their `id`/`content_hash`, so their digest cells are
+  unchanged; only the inserted row's cell is added.
+  """
+  @spec insert_at(t(), non_neg_integer(), entry()) :: t()
+  def insert_at(%__MODULE__{entries: entries, digest: digest} = store, index, new_entry)
+      when is_integer(index) and index >= 0 do
+    %{
+      store
+      | entries: List.insert_at(entries, index, new_entry),
+        digest: ContentDigest.add(digest, new_entry.id, new_entry.content_hash)
+    }
+  end
+
+  def insert_at(%__MODULE__{} = store, _index, _new_entry), do: store
+
+  @doc """
+  Deletes the entry at `index`, shifting later entries left and folding the
+  removed row out of the digest.
+  """
+  @spec delete_at(t(), non_neg_integer()) :: t()
+  def delete_at(%__MODULE__{entries: entries, digest: digest} = store, index)
+      when is_integer(index) and index >= 0 do
+    case Enum.fetch(entries, index) do
+      {:ok, removed} ->
+        %{
+          store
+          | entries: List.delete_at(entries, index),
+            digest: ContentDigest.remove(digest, removed.id, removed.content_hash)
+        }
+
+      :error ->
+        store
+    end
+  end
+
+  def delete_at(%__MODULE__{} = store, _index), do: store
+
+  @doc """
+  Rebuilds only the entries at the dirty indices, reusing the rest verbatim.
+
+  `dirty_indices` is a `MapSet` of positions into the current entry list;
+  `build_fun.(index)` composes the fresh entry for a dirty position. The entry
+  count is unchanged (this is the in-place-edit splice; row insert/delete that
+  changes the count is handled by a full `from_entries/1` rebuild upstream). An
+  empty dirty set returns the store unchanged, so pure scroll and cursor frames
+  reuse the resident list and digest with no per-row work.
+  """
+  @spec rebuild(t(), MapSet.t(non_neg_integer()), (non_neg_integer() -> entry())) :: t()
+  def rebuild(%__MODULE__{} = store, dirty_indices, build_fun) when is_function(build_fun, 1) do
+    if MapSet.size(dirty_indices) == 0 do
+      store
+    else
+      splice(store, dirty_indices, build_fun)
+    end
+  end
+
+  @spec splice(t(), MapSet.t(non_neg_integer()), (non_neg_integer() -> entry())) :: t()
+  defp splice(%__MODULE__{entries: entries, digest: digest} = store, dirty_indices, build_fun) do
+    {reversed, new_digest} =
+      entries
+      |> Enum.with_index()
+      |> Enum.reduce({[], digest}, fn {old_entry, index}, {acc, acc_digest} ->
+        if MapSet.member?(dirty_indices, index) do
+          new_entry = build_fun.(index)
+          {[new_entry | acc], swap_digest(acc_digest, old_entry, new_entry)}
+        else
+          {[old_entry | acc], acc_digest}
+        end
+      end)
+
+    %{store | entries: Enum.reverse(reversed), digest: new_digest}
+  end
+
+  @spec swap_digest(ContentDigest.t(), entry(), entry()) :: ContentDigest.t()
+  defp swap_digest(digest, old_entry, new_entry) do
+    digest
+    |> ContentDigest.remove(old_entry.id, old_entry.content_hash)
+    |> ContentDigest.add(new_entry.id, new_entry.content_hash)
+  end
+
+  @spec digest_of([entry()]) :: ContentDigest.t()
+  defp digest_of(entries) do
+    Enum.reduce(entries, ContentDigest.empty(), fn %{id: id, content_hash: content_hash}, acc ->
+      ContentDigest.add(acc, id, content_hash)
+    end)
+  end
+end

--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -199,7 +199,8 @@ defmodule MingaEditor.RenderPipeline.Content do
         WindowModelBuilder.build_with_stats(state, %{scroll | window: window}, render_ctx,
           content_kind: :buffer,
           retained_rows: Window.retained_rows(window),
-          retained_wrap_lines: Window.retained_wrap_lines(window)
+          retained_wrap_lines: Window.retained_wrap_lines(window),
+          resident_build: Window.resident_build(window)
         )
       end)
 
@@ -207,6 +208,7 @@ defmodule MingaEditor.RenderPipeline.Content do
       window
       |> Window.put_retained_rows(build_stats.retained_rows)
       |> Window.put_retained_wrap_lines(build_stats.retained_wrap_lines)
+      |> Window.put_resident_build(build_stats.resident_build)
 
     state = add_rows_rasterized(state, build_stats.rasterized)
 

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -465,6 +465,16 @@ defmodule MingaEditor.Window do
     %{window | render_cache: RenderCache.put_retained_wrap_lines(cache, lines)}
   end
 
+  @doc "Returns the persistent full-document residence build state (#2658)."
+  @spec resident_build(t()) :: MingaEditor.RenderModel.Window.ResidentBuild.t() | nil
+  def resident_build(%__MODULE__{render_cache: cache}), do: RenderCache.resident_build(cache)
+
+  @doc "Stores the current frame's residence build state for incremental reuse next frame (#2658)."
+  @spec put_resident_build(t(), MingaEditor.RenderModel.Window.ResidentBuild.t() | nil) :: t()
+  def put_resident_build(%__MODULE__{render_cache: cache} = window, state) do
+    %{window | render_cache: RenderCache.put_resident_build(cache, state)}
+  end
+
   @doc """
   Checks current frame parameters against last-frame tracking fields
   and returns the window with `dirty_lines: :all` if anything that

--- a/lib/minga_editor/window/render_cache.ex
+++ b/lib/minga_editor/window/render_cache.ex
@@ -77,7 +77,8 @@ defmodule MingaEditor.Window.RenderCache do
           last_reset_fingerprint: term(),
           total_visual_rows_cache: {term(), non_neg_integer()} | nil,
           retained_rows: %{optional(non_neg_integer()) => retained_row()},
-          retained_wrap_lines: %{optional(non_neg_integer()) => retained_wrap_line()}
+          retained_wrap_lines: %{optional(non_neg_integer()) => retained_wrap_line()},
+          resident_build: MingaEditor.RenderModel.Window.ResidentBuild.t() | nil
         }
 
   defstruct dirty_lines: %{},
@@ -93,7 +94,8 @@ defmodule MingaEditor.Window.RenderCache do
             last_reset_fingerprint: nil,
             total_visual_rows_cache: nil,
             retained_rows: %{},
-            retained_wrap_lines: %{}
+            retained_wrap_lines: %{},
+            resident_build: nil
 
   @doc """
   Returns a fresh cache with all lines dirty.
@@ -127,7 +129,8 @@ defmodule MingaEditor.Window.RenderCache do
         reset_pending: true,
         total_visual_rows_cache: nil,
         retained_rows: %{},
-        retained_wrap_lines: %{}
+        retained_wrap_lines: %{},
+        resident_build: nil
     }
   end
 
@@ -404,5 +407,21 @@ defmodule MingaEditor.Window.RenderCache do
           t()
   def put_retained_wrap_lines(%__MODULE__{} = cache, lines) when is_map(lines) do
     %{cache | retained_wrap_lines: lines}
+  end
+
+  # ── Incremental residence build state (#2658) ──────────────────────────────
+
+  @doc """
+  Returns the persistent full-document residence build state, or `nil` when the
+  window has not built on the residence path since the last reset. Carries the
+  resident entry list and its incremental content digest across frames.
+  """
+  @spec resident_build(t()) :: MingaEditor.RenderModel.Window.ResidentBuild.t() | nil
+  def resident_build(%__MODULE__{resident_build: state}), do: state
+
+  @doc "Replaces the persistent residence build state captured by the last frame."
+  @spec put_resident_build(t(), MingaEditor.RenderModel.Window.ResidentBuild.t() | nil) :: t()
+  def put_resident_build(%__MODULE__{} = cache, state) do
+    %{cache | resident_build: state}
   end
 end

--- a/test/minga/render_model/window/content_digest_test.exs
+++ b/test/minga/render_model/window/content_digest_test.exs
@@ -4,8 +4,9 @@ defmodule Minga.RenderModel.Window.ContentDigestTest do
 
   The digest gates the resident-window frame-emit, so the load-bearing
   properties are: (b) the incremental digest always equals a full recompute, and
-  the AC3 corollary that a digest changes exactly when a row's `{row_id,
-  content_hash}` pair changes, with no spurious change on an edit-back-to-original.
+  the AC3 corollary that a digest changes with overwhelming probability when a
+  row's `{row_id, content_hash}` pair changes, with no spurious change on an
+  edit-back-to-original.
   """
 
   use ExUnit.Case, async: true
@@ -94,6 +95,13 @@ defmodule Minga.RenderModel.Window.ContentDigestTest do
 
         changed = ContentDigest.update(base, id, old_hash, new_hash)
         restored = ContentDigest.update(changed, id, new_hash, old_hash)
+
+        # A genuinely different content hash should change the digest (modulo
+        # the ~2^-27 phash2 collision rate, which is vanishingly unlikely with
+        # our small generator range).
+        if old_hash != new_hash do
+          assert changed != base
+        end
 
         # No spurious change when the content did not actually change.
         if old_hash == new_hash do

--- a/test/minga/render_model/window/content_digest_test.exs
+++ b/test/minga/render_model/window/content_digest_test.exs
@@ -1,0 +1,141 @@
+defmodule Minga.RenderModel.Window.ContentDigestTest do
+  @moduledoc """
+  Invariants for the incremental content digest (#2658, AC3).
+
+  The digest gates the resident-window frame-emit, so the load-bearing
+  properties are: (b) the incremental digest always equals a full recompute, and
+  the AC3 corollary that a digest changes exactly when a row's `{row_id,
+  content_hash}` pair changes, with no spurious change on an edit-back-to-original.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Minga.RenderModel.Window.ContentDigest
+  alias Minga.RenderModel.Window.Row
+
+  # ── Generators ─────────────────────────────────────────────────────────
+
+  # A row is a {row_id, content_hash} pair; row_ids are unique within a window,
+  # so we generate distinct ids and let content hashes collide freely.
+  defp content_hash_gen, do: integer(0..1_000)
+
+  defp pair_gen(id), do: gen(all(hash <- content_hash_gen()), do: {id, hash})
+
+  defp pair_list_gen(max_count) do
+    gen all(
+          count <- integer(0..max_count),
+          hashes <- list_of(content_hash_gen(), length: count)
+        ) do
+      Enum.map(Enum.with_index(hashes), fn {hash, id} -> {id, hash} end)
+    end
+  end
+
+  # ── Full recompute agreement ─────────────────────────────────────────────
+
+  describe "property: incremental digest equals full recompute" do
+    property "add-only build equals of_pairs" do
+      check all(pairs <- pair_list_gen(60)) do
+        incremental =
+          Enum.reduce(pairs, ContentDigest.empty(), fn {id, hash}, acc ->
+            ContentDigest.add(acc, id, hash)
+          end)
+
+        assert incremental == ContentDigest.of_pairs(pairs)
+      end
+    end
+
+    property "remove is the inverse of add" do
+      check all(
+              pairs <- pair_list_gen(40),
+              extra <- pair_gen(9_999)
+            ) do
+        {id, hash} = extra
+        base = ContentDigest.of_pairs(pairs)
+
+        assert base
+               |> ContentDigest.add(id, hash)
+               |> ContentDigest.remove(id, hash) == base
+      end
+    end
+
+    property "update equals remove-then-add" do
+      check all(
+              pairs <- pair_list_gen(40),
+              id <- integer(0..39),
+              old_hash <- content_hash_gen(),
+              new_hash <- content_hash_gen()
+            ) do
+        base = ContentDigest.of_pairs(pairs)
+
+        via_update = ContentDigest.update(base, id, old_hash, new_hash)
+
+        via_ops =
+          base
+          |> ContentDigest.remove(id, old_hash)
+          |> ContentDigest.add(id, new_hash)
+
+        assert via_update == via_ops
+      end
+    end
+  end
+
+  # ── Change detection (AC3) ───────────────────────────────────────────────
+
+  describe "property: digest changes iff a row changed" do
+    property "changing a row's content hash changes the digest, restoring it undoes the change" do
+      check all(
+              pairs <- pair_list_gen(40),
+              id <- integer(0..39),
+              old_hash <- content_hash_gen(),
+              new_hash <- content_hash_gen()
+            ) do
+        base = ContentDigest.of_pairs(pairs)
+
+        changed = ContentDigest.update(base, id, old_hash, new_hash)
+        restored = ContentDigest.update(changed, id, new_hash, old_hash)
+
+        # No spurious change when the content did not actually change.
+        if old_hash == new_hash do
+          assert changed == base
+        end
+
+        # Editing back to the original content restores the prior digest, so no
+        # spurious emit.
+        assert restored == base
+      end
+    end
+  end
+
+  # ── AC3 example: insert into the middle of a five-row document ───────────
+
+  describe "insert/delete keep unaffected rows" do
+    test "inserting a row only folds in the new row's cell" do
+      rows =
+        for i <- 0..4 do
+          %Row{row_id: i, row_type: :normal, buf_line: i, text: "row #{i}", spans: []}
+          |> put_hash()
+        end
+
+      digest = ContentDigest.of_rows(rows)
+
+      # A row inserted at index 2 with a fresh id/content only adds one cell; the
+      # untouched rows keep their cells, so the delta is exactly that new cell.
+      new_row =
+        %Row{row_id: 100, row_type: :normal, buf_line: 100, text: "inserted", spans: []}
+        |> put_hash()
+
+      with_insert = ContentDigest.add(digest, new_row.row_id, new_row.content_hash)
+
+      expected = ContentDigest.of_rows(List.insert_at(rows, 2, new_row))
+      assert with_insert == expected
+
+      # Removing it again returns to the original digest (no dropped/duplicate state).
+      assert ContentDigest.remove(with_insert, new_row.row_id, new_row.content_hash) == digest
+    end
+  end
+
+  defp put_hash(%Row{text: text, spans: spans} = row) do
+    %{row | content_hash: Row.compute_hash(text, spans)}
+  end
+end

--- a/test/minga_editor/render_model/window/resident_store_test.exs
+++ b/test/minga_editor/render_model/window/resident_store_test.exs
@@ -1,0 +1,271 @@
+defmodule MingaEditor.RenderModel.Window.ResidentStoreTest do
+  @moduledoc """
+  Invariants for the persistent resident entry-list store (#2658, AC3).
+
+  Ranked properties (per the test strategy):
+
+    a. incremental store state == a from-scratch rebuild after any edit/insert/
+       delete sequence (asserted after every step, not just at the end);
+    c. the digest changes iff a row actually changed (edit-back-to-original
+       produces the prior digest, no spurious emits);
+    b. the incremental digest == a full recompute after any sequence.
+
+  The store is a generic list-with-digest; it sees row-index sets only, never
+  per-dirty-source detail, so no change-source knowledge is tested here.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Minga.RenderModel.Window.ContentDigest
+  alias MingaEditor.RenderModel.Window.ResidentStore
+
+  @max_rows 100
+
+  # ── Generators ─────────────────────────────────────────────────────────
+
+  # Entries carry a unique id (assigned by the harness), a content hash drawn
+  # from a small pool so edits can collide back to a prior value, and an opaque
+  # payload derived from both so a payload mismatch is caught alongside the hash.
+  defp content_hash_gen, do: integer(0..8)
+
+  defp op_gen do
+    one_of([
+      tuple({constant(:insert), content_hash_gen()}),
+      constant(:delete),
+      tuple({constant(:replace), content_hash_gen()})
+    ])
+  end
+
+  defp op_list_gen do
+    gen all(ops <- list_of(op_gen(), max_length: 60)) do
+      ops
+    end
+  end
+
+  # ── Helpers ─────────────────────────────────────────────────────────────
+
+  defp make_entry(id, content_hash) do
+    ResidentStore.entry(id, content_hash, {:payload, id, content_hash})
+  end
+
+  # Applies one op to the store and to the plain-list oracle, choosing an index
+  # deterministically from the current size and the harness's next id.
+  defp apply_op({:insert, hash}, {store, model, next_id}) do
+    size = length(model)
+    index = rem(next_id, size + 1)
+    entry = make_entry(next_id, hash)
+
+    {
+      ResidentStore.insert_at(store, index, entry),
+      List.insert_at(model, index, entry),
+      next_id + 1
+    }
+  end
+
+  defp apply_op(:delete, {store, [], next_id}), do: {store, [], next_id}
+
+  defp apply_op(:delete, {store, model, next_id}) do
+    size = length(model)
+    index = rem(next_id, size)
+    {ResidentStore.delete_at(store, index), List.delete_at(model, index), next_id}
+  end
+
+  defp apply_op({:replace, _hash}, {store, [], next_id}), do: {store, [], next_id}
+
+  defp apply_op({:replace, hash}, {store, model, next_id}) do
+    size = length(model)
+    index = rem(next_id, size)
+    existing = Enum.at(model, index)
+    entry = make_entry(existing.id, hash)
+
+    {
+      ResidentStore.replace_at(store, index, entry),
+      List.replace_at(model, index, entry),
+      next_id + 1
+    }
+  end
+
+  defp assert_consistent(store, model) do
+    assert ResidentStore.entries(store) == model
+
+    assert ResidentStore.digest(store) ==
+             ContentDigest.of_pairs(Enum.map(model, &{&1.id, &1.content_hash}))
+  end
+
+  # ── Property (a) + (b): incremental == from-scratch after every step ─────
+
+  describe "property: incremental store equals from-scratch rebuild" do
+    property "entries and digest match the oracle after every mutation" do
+      check all(
+              initial <- list_of(content_hash_gen(), max_length: 20),
+              ops <- op_list_gen()
+            ) do
+        initial_entries =
+          initial
+          |> Enum.with_index()
+          |> Enum.map(fn {hash, id} -> make_entry(id, hash) end)
+
+        store0 = ResidentStore.from_entries(initial_entries)
+        assert_consistent(store0, initial_entries)
+
+        Enum.reduce(ops, {store0, initial_entries, length(initial_entries)}, fn op, acc ->
+          {store, model, next_id} = apply_op(op, acc)
+          # Assert equality after EVERY step so a mid-sequence divergence fails here.
+          assert_consistent(store, model)
+          assert length(model) <= @max_rows
+          {store, model, next_id}
+        end)
+      end
+    end
+  end
+
+  # ── Property (c): digest change detection ────────────────────────────────
+
+  describe "property: digest changes iff a row changed" do
+    property "editing a row back to its original content restores the prior digest" do
+      check all(
+              hashes <- list_of(content_hash_gen(), min_length: 1, max_length: 30),
+              other_hash <- content_hash_gen()
+            ) do
+        entries =
+          hashes
+          |> Enum.with_index()
+          |> Enum.map(fn {hash, id} -> make_entry(id, hash) end)
+
+        store = ResidentStore.from_entries(entries)
+        index = rem(other_hash, length(entries))
+        original = Enum.at(entries, index)
+
+        changed =
+          ResidentStore.replace_at(store, index, make_entry(original.id, other_hash))
+
+        restored =
+          ResidentStore.replace_at(changed, index, original)
+
+        if other_hash == original.content_hash do
+          assert ResidentStore.digest(changed) == ResidentStore.digest(store)
+        end
+
+        assert ResidentStore.digest(restored) == ResidentStore.digest(store)
+        assert ResidentStore.entries(restored) == entries
+      end
+    end
+  end
+
+  # ── rebuild/3 splice (the builder's in-place-edit path) ──────────────────
+
+  describe "rebuild/3" do
+    test "an empty dirty set returns the store unchanged (scroll/cursor frame)" do
+      entries = for i <- 0..9, do: make_entry(i, i)
+      store = ResidentStore.from_entries(entries)
+
+      rebuilt = ResidentStore.rebuild(store, MapSet.new(), fn _ -> raise "must not build" end)
+
+      assert rebuilt == store
+      assert ResidentStore.digest(rebuilt) == ResidentStore.digest(store)
+    end
+
+    test "only dirty indices are rebuilt and the digest updates incrementally" do
+      entries = for i <- 0..9, do: make_entry(i, i)
+      store = ResidentStore.from_entries(entries)
+
+      dirty = MapSet.new([3, 7])
+      built = fn index -> make_entry(index, index + 100) end
+
+      rebuilt = ResidentStore.rebuild(store, dirty, built)
+
+      expected_entries =
+        entries
+        |> List.replace_at(3, built.(3))
+        |> List.replace_at(7, built.(7))
+
+      assert ResidentStore.entries(rebuilt) == expected_entries
+
+      assert ResidentStore.digest(rebuilt) ==
+               ContentDigest.of_pairs(Enum.map(expected_entries, &{&1.id, &1.content_hash}))
+    end
+
+    property "rebuild equals replacing the dirty positions from scratch" do
+      check all(
+              size <- integer(1..40),
+              hashes <- list_of(content_hash_gen(), length: size),
+              dirty_list <- list_of(integer(0..(size - 1)), max_length: size),
+              new_hashes <- list_of(content_hash_gen(), length: size)
+            ) do
+        entries =
+          hashes
+          |> Enum.with_index()
+          |> Enum.map(fn {hash, id} -> make_entry(id, hash) end)
+
+        store = ResidentStore.from_entries(entries)
+        dirty = MapSet.new(dirty_list)
+        build_fun = fn index -> make_entry(index, Enum.at(new_hashes, index)) end
+
+        rebuilt = ResidentStore.rebuild(store, dirty, build_fun)
+
+        expected =
+          Enum.reduce(dirty, entries, fn index, acc ->
+            List.replace_at(acc, index, build_fun.(index))
+          end)
+
+        assert ResidentStore.entries(rebuilt) == expected
+
+        assert ResidentStore.digest(rebuilt) ==
+                 ContentDigest.of_pairs(Enum.map(expected, &{&1.id, &1.content_hash}))
+      end
+    end
+  end
+
+  # ── Edge cases from the test strategy ────────────────────────────────────
+
+  describe "edge cases" do
+    test "empty document then first insert" do
+      store = ResidentStore.new()
+      assert ResidentStore.empty?(store)
+      assert ResidentStore.digest(store) == ContentDigest.empty()
+
+      entry = make_entry(0, 7)
+      store = ResidentStore.insert_at(store, 0, entry)
+
+      assert ResidentStore.entries(store) == [entry]
+      assert ResidentStore.digest(store) == ContentDigest.of_pairs([{0, 7}])
+    end
+
+    test "deleting the last remaining row yields a well-defined empty digest" do
+      entry = make_entry(0, 7)
+      store = ResidentStore.from_entries([entry])
+
+      store = ResidentStore.delete_at(store, 0)
+
+      assert ResidentStore.empty?(store)
+      assert ResidentStore.digest(store) == ContentDigest.empty()
+    end
+
+    test "two same-frame mutations on adjacent rows both apply (dirty set is a union)" do
+      entries = for i <- 0..4, do: make_entry(i, i)
+      store = ResidentStore.from_entries(entries)
+
+      dirty = MapSet.new([2, 3])
+      rebuilt = ResidentStore.rebuild(store, dirty, fn index -> make_entry(index, index + 50) end)
+
+      assert Enum.at(ResidentStore.entries(rebuilt), 2).content_hash == 52
+      assert Enum.at(ResidentStore.entries(rebuilt), 3).content_hash == 53
+      # Neighbours untouched.
+      assert Enum.at(ResidentStore.entries(rebuilt), 1).content_hash == 1
+      assert Enum.at(ResidentStore.entries(rebuilt), 4).content_hash == 4
+    end
+
+    test "content edited back to original within one batch produces no digest change" do
+      entries = for i <- 0..4, do: make_entry(i, i)
+      store = ResidentStore.from_entries(entries)
+
+      # Rebuild index 2 to the SAME content it already had.
+      rebuilt =
+        ResidentStore.rebuild(store, MapSet.new([2]), fn index -> make_entry(index, index) end)
+
+      assert ResidentStore.digest(rebuilt) == ResidentStore.digest(store)
+      assert ResidentStore.entries(rebuilt) == entries
+    end
+  end
+end

--- a/test/minga_editor/render_pipeline/resident_dirty_completeness_test.exs
+++ b/test/minga_editor/render_pipeline/resident_dirty_completeness_test.exs
@@ -1,0 +1,113 @@
+defmodule MingaEditor.RenderPipeline.ResidentDirtyCompletenessTest do
+  @moduledoc """
+  AC 2 dirty-set completeness for the residence content digest (#2658).
+
+  With full-document residence the content frame-emit gate reads the incremental
+  `content_digest` instead of hashing the whole rows list. The correctness risk is
+  a *missed* source: a change that alters an off-screen resident row's rendered
+  content but fails to move the digest, dropping a needed frame and stranding a
+  stale row. This suite drives the real subsystems that bake into resident row
+  content (buffer text edits and decoration-driven spans, the class that carries
+  search matches and diagnostic underlines) against an off-screen row and asserts
+  the digest moves, so the emit fires.
+
+  Overlay- and gutter-only sources (selection, git signs, diagnostic signs,
+  diagnostic inline ranges) are deliberately *not* asserted here: they are
+  viewport-windowed fields of the window model, unchanged by this ticket, and an
+  off-screen change to them correctly produces no resident re-emit (nothing
+  visible changed). They ride the ordinary content fingerprint when they enter the
+  viewport. See the ticket handoff for the source-by-source routing.
+  """
+
+  # Mutates the global Config option server (:resident_store_max_lines) and drives
+  # buffer subsystems, so the module runs serially.
+  use ExUnit.Case, async: false
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Config
+  alias Minga.Core.Face
+  alias MingaEditor.Layout
+  alias MingaEditor.RenderPipeline
+  alias MingaEditor.RenderPipeline.Content
+  alias MingaEditor.RenderPipeline.Scroll
+  alias MingaEditor.State, as: EditorState
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  @line_count 300
+  # A row well below the top-of-file viewport: resident, never rasterized into the
+  # visible slice, so a naive viewport-only gate would miss a change to it.
+  @off_screen_line 250
+
+  setup do
+    original = Config.get(:resident_store_max_lines)
+    Config.set(:resident_store_max_lines, 1_000_000)
+    on_exit(fn -> Config.set(:resident_store_max_lines, original) end)
+    :ok
+  end
+
+  defp resident_state do
+    state = gui_state(content: long_content(@line_count), rows: 12, cols: 60, filetype: :text)
+    BufferProcess.set_option(state.workspace.buffers.active, :wrap, false)
+    state
+  end
+
+  defp build_frame(state) do
+    state = EditorState.sync_active_window_cursor(state)
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+    {contents, _cursor, state} = Content.build_content(state, scrolls)
+    model = contents |> List.first() |> Map.fetch!(:models) |> List.first()
+    {model, state}
+  end
+
+  defp warm(state) do
+    {_model, state} = build_frame(state)
+    {model, state} = build_frame(state)
+    {model.content_digest, state}
+  end
+
+  # Each case mutates exactly one off-screen resident row through a real subsystem.
+  # `:buffer_text_edit` is a text change; `:decoration_span` is the decoration
+  # highlight class that search matches and diagnostic underlines flow through.
+  defp mutate(:buffer_text_edit, buffer) do
+    BufferProcess.move_to(buffer, {@off_screen_line, 0})
+    BufferProcess.insert_text(buffer, "Z")
+  end
+
+  defp mutate(:decoration_span, buffer) do
+    BufferProcess.add_highlight(
+      buffer,
+      {@off_screen_line, 0},
+      {@off_screen_line, 4},
+      style: Face.new(bg: 0x00FF00)
+    )
+  end
+
+  for name <- [:buffer_text_edit, :decoration_span] do
+    test "an off-screen #{name} moves the content digest so the frame emits" do
+      name = unquote(name)
+
+      state = resident_state()
+      {before_digest, state} = warm(state)
+      refute is_nil(before_digest)
+
+      mutate(name, state.workspace.buffers.active)
+
+      {after_model, _state} = build_frame(state)
+
+      assert after_model.content_digest != before_digest,
+             "#{name}: digest did not move for an off-screen resident row (dropped frame / stale row)"
+    end
+  end
+
+  test "a no-op frame after warm-up does not move the digest (no spurious emit)" do
+    state = resident_state()
+    {before_digest, state} = warm(state)
+
+    {after_model, _state} = build_frame(state)
+
+    assert after_model.content_digest == before_digest
+  end
+end

--- a/test/minga_editor/render_pipeline/resident_incremental_test.exs
+++ b/test/minga_editor/render_pipeline/resident_incremental_test.exs
@@ -1,0 +1,177 @@
+defmodule MingaEditor.RenderPipeline.ResidentIncrementalTest do
+  @moduledoc """
+  End-to-end checks for the incremental full-document residence build (#2658).
+
+  Enabling residence mutates the global `:resident_store_max_lines` option, so the
+  module runs `async: false` and restores the option after each test.
+  """
+
+  # Mutates the global Config option server (:resident_store_max_lines).
+  use ExUnit.Case, async: false
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Config
+  alias Minga.RenderModel.Window.ContentDigest
+  alias MingaEditor.Layout
+  alias MingaEditor.RenderPipeline
+  alias MingaEditor.RenderPipeline.Content
+  alias MingaEditor.RenderPipeline.Scroll
+  alias MingaEditor.State, as: EditorState
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  setup do
+    original = Config.get(:resident_store_max_lines)
+    Config.set(:resident_store_max_lines, 1_000_000)
+    on_exit(fn -> Config.set(:resident_store_max_lines, original) end)
+    :ok
+  end
+
+  # Builds the active window's semantic model for one frame, returning the model
+  # and the state carrying the updated resident build cache into the next frame.
+  # Resets the per-frame rasterized counter so `Content.rows_rasterized/1` reads
+  # only this frame's freshly composed rows.
+  defp build_frame(state) do
+    state = Content.reset_rows_rasterized(state)
+    state = EditorState.sync_active_window_cursor(state)
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+    {contents, _cursor, state} = Content.build_content(state, scrolls)
+    model = contents |> List.first() |> Map.fetch!(:models) |> List.first()
+    {model, state}
+  end
+
+  # Two seed frames: a full-document keyframe, then a no-change reuse frame, so
+  # the resident store and digest are warm before the assertion frame.
+  defp warm(state) do
+    {_model, state} = build_frame(state)
+    {_model, state} = build_frame(state)
+    state
+  end
+
+  # A plain-text, non-wrapped buffer so tree-sitter never re-highlights mid-test
+  # and residence stays eligible (wrap opts out), keeping the path on the splice
+  # (not full-rebuild) branch across an edit.
+  defp resident_state(line_count) do
+    state = gui_state(content: long_content(line_count), rows: 12, cols: 60, filetype: :text)
+    BufferProcess.set_option(state.workspace.buffers.active, :wrap, false)
+    state
+  end
+
+  describe "digest consistency" do
+    test "content_digest always equals a from-scratch digest of the emitted rows" do
+      {model, _state} = build_frame(resident_state(300))
+
+      refute is_nil(model.content_digest)
+      assert model.content_digest == ContentDigest.of_rows(model.rows)
+      assert Enum.map(model.rows, & &1.buf_line) == Enum.to_list(0..299)
+    end
+
+    test "an off-screen single-line edit splices one row and the digest tracks it" do
+      state = warm(resident_state(300))
+      buffer = state.workspace.buffers.active
+
+      {before_model, state} = build_frame(state)
+      before_digest = before_model.content_digest
+      before_hash = row_hash(before_model, 250)
+
+      # Edit an off-screen line (viewport shows the top; line 250 is resident but
+      # far below the fold).
+      BufferProcess.move_to(buffer, {250, 0})
+      BufferProcess.insert_text(buffer, "Z")
+
+      {after_model, _state} = build_frame(state)
+
+      # The edited resident row's content changed, and the digest moved with it,
+      # so the frame-emit gate fires rather than dropping a needed frame.
+      assert row_hash(after_model, 250) != before_hash
+      assert after_model.content_digest != before_digest
+      # The digest is still a faithful fingerprint of the whole (spliced) row set.
+      assert after_model.content_digest == ContentDigest.of_rows(after_model.rows)
+      # No row was dropped or duplicated by the splice.
+      assert Enum.map(after_model.rows, & &1.buf_line) == Enum.to_list(0..299)
+    end
+
+    test "a pure cursor move reuses the resident rows and leaves the digest unchanged" do
+      state = warm(resident_state(300))
+      buffer = state.workspace.buffers.active
+
+      {before_model, state} = build_frame(state)
+      BufferProcess.move_to(buffer, {120, 0})
+      {after_model, _state} = build_frame(state)
+
+      assert after_model.content_digest == before_model.content_digest
+      assert after_model.rows == before_model.rows
+    end
+  end
+
+  describe "AC 3: row insertion and deletion" do
+    test "inserting a line off-screen grows the resident set and moves the digest without dropping or duplicating a row" do
+      state = warm(resident_state(300))
+      buffer = state.workspace.buffers.active
+
+      {before_model, state} = build_frame(state)
+
+      # Insert a whole new line off-screen (row count changes → full rebuild path).
+      BufferProcess.move_to(buffer, {250, 0})
+      BufferProcess.insert_text(buffer, "new line\n")
+
+      {after_model, _state} = build_frame(state)
+
+      assert length(after_model.rows) == length(before_model.rows) + 1
+      assert after_model.content_digest != before_model.content_digest
+      assert after_model.content_digest == ContentDigest.of_rows(after_model.rows)
+      # Every row id is distinct: no duplicate/dropped frame-emit under insert.
+      row_ids = Enum.map(after_model.rows, & &1.row_id)
+      assert length(Enum.uniq(row_ids)) == length(row_ids)
+      assert Enum.map(after_model.rows, & &1.buf_line) == Enum.to_list(0..300)
+    end
+
+    test "deleting a line off-screen shrinks the resident set and keeps the digest faithful" do
+      state = warm(resident_state(300))
+      buffer = state.workspace.buffers.active
+
+      {before_model, state} = build_frame(state)
+
+      # Remove a whole off-screen line (row count changes → full rebuild path).
+      BufferProcess.delete_lines(buffer, 250, 250)
+
+      {after_model, _state} = build_frame(state)
+
+      assert length(after_model.rows) == length(before_model.rows) - 1
+      assert after_model.content_digest != before_model.content_digest
+      assert after_model.content_digest == ContentDigest.of_rows(after_model.rows)
+      assert Enum.map(after_model.rows, & &1.buf_line) == Enum.to_list(0..298)
+    end
+  end
+
+  describe "AC 1/5: edit-frame build cost is flat across resident sizes" do
+    # Operation-count assertion (not wall-clock, per the test strategy): a single
+    # off-screen in-place edit rasterizes exactly one row no matter how many rows
+    # are resident, so edit-frame build stays O(changed) rather than O(document).
+    for line_count <- [500, 5_000, 65_000] do
+      test "a single-line edit rasterizes exactly one row at #{line_count} resident lines" do
+        line_count = unquote(line_count)
+        state = warm(resident_state(line_count))
+        buffer = state.workspace.buffers.active
+
+        edit_line = div(line_count, 2)
+        BufferProcess.move_to(buffer, {edit_line, 0})
+        BufferProcess.insert_text(buffer, "Z")
+
+        {model, state} = build_frame(state)
+
+        assert Content.rows_rasterized(state) == 1
+        assert model.content_digest == ContentDigest.of_rows(model.rows)
+        assert length(model.rows) == line_count
+      end
+    end
+  end
+
+  defp row_hash(model, buf_line) do
+    model.rows
+    |> Enum.find(&(&1.buf_line == buf_line))
+    |> Map.fetch!(:content_hash)
+  end
+end


### PR DESCRIPTION
Closes #2658. Part of epic #2652. **Stacked on #2659** (which stacks on #2656); retarget as the stack merges.

## Summary

Removes the O(document) per-frame build cost that #2653's measurements surfaced ([data](https://github.com/jsmestad/minga/issues/2653#issuecomment-4860564801)). One persistent structure — `ResidentBuild` (entry list + retained-row map + incremental digest) — is carried across frames in the window render cache and updated by a dirty-set-driven splice that recomputes only changed rows. This is value-keyed incremental maintenance (`row_id + content_hash`), not identity memoization.

- **`ContentDigest`** (new pure module): XOR-fold of `phash2({row_id, content_hash})` cells, O(1) add/remove, correct under insert/delete; replaces the whole-list phash2 in `window_content_fingerprint`. Position is baked into `row_id`, so XOR order-independence cannot hide a real change; collision profile matches the phash2 it replaces.
- **Dirty routing:** text edits → precise splice; highlight/compose/reset fingerprint or line-count changes → full rebuild; empty dirty set (cursor/scroll frames) → reuse. Viewport-windowed overlay fields (selection, diagnostics, git signs) remain separate fingerprint inputs, so off-screen overlay changes correctly do not force a resident re-emit.
- **Results:** edit-frame compose cost flat at 500/5k/65k lines (`rows_rasterized == 1`); bench p95 at 65k: ~650ms → ~33ms (~20x); 5k lines ~2.5ms, within frame budget. Residence remains **off by default**; the threshold raise stays gated on epic sequencing (frontends migrate first).

## Tests

- Full `mix test.llm`: 9,720 tests, 0 failures; `make lint` green (dialyzer pass, credo clean on touched files).
- Property suites (`content_digest_test`, `resident_store_test`): incremental state and digest vs from-scratch oracles, asserted after every mutation step; edge cases per test-advisor spec (empty→first insert, delete-to-empty, same-frame adjacent mutations, edit-back-to-original, overscan boundary).
- Pipeline: AC2 completeness matrix drives real subsystems against off-screen rows; AC1/AC5 size-independence via operation-count telemetry (no wall-clock in CI); `bench/resident_frame_bench.exs` for evidence numbers.
- Reviews: acceptance reviewer PASS; prtk bug-hunt found no critical/important issues (its hardening suggestion — `is_integer` guard on the threshold clause — is applied; the "dead" `resident_rows_spliced` field is consumed by the AC1/AC5 tests as the splice-cost counter).

## Follow-up risks

- Residual cheap O(document) passes at the 65k extreme (line-text diff, store rebuild walk) need delta-only row-list construction later; typical files unaffected, residence dormant regardless.
- One-frame trailing highlight staleness after an edit self-heals on reparse; with tree-sitter disabled there are no syntax colors to go stale (verified in review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1