### PR TITLE
feat(editor): refuse huge files with a pre-load size gate and text-only surface

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,6 +27,7 @@ That's it. Save the file and restart Minga. Your options take effect immediately
 | `:autopair` | boolean | `true` | Auto-insert matching brackets and quotes |
 | `:autopair_block` | boolean | `true` | Auto-insert language-aware block-closing keywords on Enter |
 | `:scroll_margin` | non-negative integer | `5` | Lines to keep visible above/below cursor when scrolling |
+| `:max_file_size` | positive integer | `10485760` | Maximum file size in bytes Minga will open. Larger files show a text-only "file too large" surface instead of loading a buffer; checked with a pre-read stat so the gap buffer and tree-sitter parser never touch the content. Default 10 MB. Raise it for the brave. |
 | `:theme` | theme name atom | `:astrodark` | Color theme (see [Themes](#themes) below) |
 | `:indent_with` | `:spaces` or `:tabs` | `:spaces` | Whether to indent with spaces or tab characters |
 | `:trim_trailing_whitespace` | boolean | `false` | Strip trailing whitespace on save |

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -135,6 +135,7 @@ defmodule Minga.Config.Options do
           | :picker_backdrop
           | :resident_store_max_lines
           | :resident_store_max_bytes
+          | :max_file_size
 
   @typedoc "Line number display style."
   @type line_number_style :: :hybrid | :absolute | :relative | :none
@@ -425,7 +426,9 @@ defmodule Minga.Config.Options do
     {:resident_store_max_lines, :non_neg_integer, 0,
      "Maximum buffer line count that still receives full-document row residence (glitch-free fast scrolling). 0 disables full residence entirely (the default); larger buffers fall back to viewport-windowed emit."},
     {:resident_store_max_bytes, :pos_integer, 10_485_760,
-     "Maximum buffer byte size that still receives full-document row residence. Residence is gated by both this and :resident_store_max_lines, so it stays off while :resident_store_max_lines is 0."}
+     "Maximum buffer byte size that still receives full-document row residence. Residence is gated by both this and :resident_store_max_lines, so it stays off while :resident_store_max_lines is 0."},
+    {:max_file_size, :pos_integer, 10_485_760,
+     "Maximum file size in bytes Minga will open. Files larger than this show a text-only \"file too large\" surface instead of loading a buffer; the size is checked with a pre-read stat, so the gap buffer and tree-sitter parser never touch the content. Default 10 MB."}
   ]
   @valid_names Enum.map(@option_specs, &elem(&1, 0))
 

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -694,9 +694,11 @@ defmodule MingaEditor.Commands do
   def start_buffer(file_path, options_server \\ nil) do
     options_server = normalize_options_server(options_server)
 
-    Buffer.ensure_for_path(file_path, Minga.Events.default_registry(),
-      options_server: options_server
-    )
+    MingaEditor.HugeFile.guard(file_path, options_server, fn ->
+      Buffer.ensure_for_path(file_path, Minga.Events.default_registry(),
+        options_server: options_server
+      )
+    end)
   end
 
   @doc "Adds a new buffer to the list and makes it active."

--- a/lib/minga_editor/huge_file.ex
+++ b/lib/minga_editor/huge_file.ex
@@ -1,0 +1,123 @@
+defmodule MingaEditor.HugeFile do
+  @moduledoc """
+  Pre-read size gate for the file-open action path.
+
+  Minga V1 refuses files above `:max_file_size` (default 10 MB) rather than
+  degrading. The decision is made from a `File.stat/1` size check *before* any
+  content is read, so the gap buffer, undo log, and tree-sitter parser never
+  touch a huge file. When a file is refused, the caller receives an ordinary
+  read-only in-memory buffer holding a text-only refusal message. That buffer is
+  normal window content on every frontend: it opens as a tab, renders as static
+  text, and closes/navigates like any other buffer, so there is no new opcode,
+  no card lifecycle, and no external-editor launch machinery.
+
+  This lives in Layer 2 (`MingaEditor.*`) because the gate belongs to the
+  editor's open-file orchestration, not to the Layer 1 buffer service that agent
+  tools and other callers use to read files directly.
+  """
+
+  alias Minga.Config.Options
+
+  @typedoc "Result of the size check for a candidate path."
+  @type check_result :: :ok | {:refuse, size :: non_neg_integer(), limit :: pos_integer()}
+
+  @typedoc "A thunk that performs the real open when the size gate passes."
+  @type open_fun :: (-> {:ok, pid()} | {:error, term()})
+
+  @doc """
+  Runs `open_fun` when `file_path` is at or under the configured limit, or
+  returns a read-only refusal buffer when it is over the limit.
+
+  The size check is a `File.stat/1` on the expanded path. Non-regular files
+  (directories, sockets) and stat errors (missing file) fall through to
+  `open_fun` so the normal open path keeps producing its usual result.
+  """
+  @spec guard(String.t(), Options.server(), open_fun()) :: {:ok, pid()} | {:error, term()}
+  def guard(file_path, options_server, open_fun)
+      when is_binary(file_path) and is_function(open_fun, 0) do
+    case oversize(file_path, limit(options_server)) do
+      {:refuse, size, max_bytes} -> refusal_buffer(file_path, size, max_bytes, options_server)
+      :ok -> open_fun.()
+    end
+  end
+
+  @doc "Configured maximum file size in bytes."
+  @spec limit(Options.server()) :: pos_integer()
+  def limit(options_server), do: Options.get(options_server, :max_file_size)
+
+  @doc """
+  Stats `file_path` and reports whether it exceeds `max_bytes`.
+
+  Reads inode metadata only; the file's content is never opened. Returns
+  `{:refuse, size, max_bytes}` only for a regular file strictly larger than the
+  limit, and `:ok` for everything else (at/under limit, non-regular, or a stat
+  error).
+  """
+  @spec oversize(String.t(), pos_integer()) :: check_result()
+  def oversize(file_path, max_bytes)
+      when is_binary(file_path) and is_integer(max_bytes) and max_bytes > 0 do
+    case File.stat(Path.expand(file_path)) do
+      {:ok, %File.Stat{type: :regular, size: size}} when size > max_bytes ->
+        {:refuse, size, max_bytes}
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc """
+  Builds the text-only refusal message shown in the surface.
+
+  Contains exactly the message, the file path, and the open-in-another-editor
+  suggestion, plus a one-line pointer to the config option. No actions.
+  """
+  @spec message(String.t(), non_neg_integer(), pos_integer()) :: String.t()
+  def message(file_path, size, max_bytes) do
+    """
+    File too large for Minga V1
+
+    #{Path.expand(file_path)}
+
+    This file is #{human_size(size)}, above Minga's #{human_size(max_bytes)} limit.
+    Minga does not open files this large. Open it in another editor to view or edit it.
+
+    Raise the ceiling with the :max_file_size option (in bytes) if you need to.
+    """
+  end
+
+  @spec refusal_buffer(String.t(), non_neg_integer(), pos_integer(), Options.server()) ::
+          {:ok, pid()} | {:error, term()}
+  defp refusal_buffer(file_path, size, max_bytes, options_server) do
+    DynamicSupervisor.start_child(
+      Minga.Buffer.Supervisor,
+      {Minga.Buffer,
+       content: message(file_path, size, max_bytes),
+       buffer_name: Path.basename(file_path),
+       buffer_type: :nofile,
+       filetype: :text,
+       options_server: options_server}
+    )
+  end
+
+  @kib 1024
+  @mib 1024 * 1024
+  @gib 1024 * 1024 * 1024
+
+  @spec human_size(non_neg_integer()) :: String.t()
+  defp human_size(bytes) when bytes >= @gib, do: "#{format_unit(bytes, @gib)} GB"
+  defp human_size(bytes) when bytes >= @mib, do: "#{format_unit(bytes, @mib)} MB"
+  defp human_size(bytes) when bytes >= @kib, do: "#{format_unit(bytes, @kib)} KB"
+  defp human_size(bytes), do: "#{bytes} B"
+
+  @spec format_unit(non_neg_integer(), pos_integer()) :: String.t()
+  defp format_unit(bytes, unit) do
+    value = bytes / unit
+    rounded = Float.round(value, 1)
+
+    if rounded == Float.round(value, 0) do
+      Integer.to_string(trunc(rounded))
+    else
+      :erlang.float_to_binary(rounded, decimals: 1)
+    end
+  end
+end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -1572,10 +1572,12 @@ defmodule MingaEditor.State do
   def start_buffer(file_path, options_server \\ Minga.Config.Options.default_server()) do
     options_server = normalize_options_server(options_server)
 
-    DynamicSupervisor.start_child(
-      Minga.Buffer.Supervisor,
-      {Minga.Buffer, file_path: file_path, options_server: options_server}
-    )
+    MingaEditor.HugeFile.guard(file_path, options_server, fn ->
+      DynamicSupervisor.start_child(
+        Minga.Buffer.Supervisor,
+        {Minga.Buffer, file_path: file_path, options_server: options_server}
+      )
+    end)
   end
 
   # ── Buffer monitoring ──────────────────────────────────────────────────────

--- a/test/minga_editor/huge_file_test.exs
+++ b/test/minga_editor/huge_file_test.exs
@@ -1,0 +1,122 @@
+defmodule MingaEditor.HugeFileTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer
+  alias Minga.Config.Options
+  alias MingaEditor.HugeFile
+
+  @moduletag :tmp_dir
+
+  @limit 100
+
+  setup do
+    {:ok, server} =
+      Options.start_link(name: :"huge_file_opts_#{System.unique_integer([:positive])}")
+
+    Options.set(server, :max_file_size, @limit)
+    %{server: server}
+  end
+
+  defp write_file(dir, name, byte_count) do
+    path = Path.join(dir, name)
+    File.write!(path, String.duplicate("a", byte_count))
+    path
+  end
+
+  defp track(pid) do
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid, :normal) end)
+    pid
+  end
+
+  describe "oversize/2 (pre-read stat gate)" do
+    test "refuses a file strictly larger than the limit", %{tmp_dir: dir} do
+      path = write_file(dir, "big.txt", @limit + 1)
+      assert HugeFile.oversize(path, @limit) == {:refuse, @limit + 1, @limit}
+    end
+
+    test "opens a file exactly at the limit (boundary)", %{tmp_dir: dir} do
+      path = write_file(dir, "edge.txt", @limit)
+      assert HugeFile.oversize(path, @limit) == :ok
+    end
+
+    test "opens a file under the limit", %{tmp_dir: dir} do
+      path = write_file(dir, "small.txt", @limit - 1)
+      assert HugeFile.oversize(path, @limit) == :ok
+    end
+
+    test "passes through a missing file (normal open handles enoent)", %{tmp_dir: dir} do
+      assert HugeFile.oversize(Path.join(dir, "nope.txt"), @limit) == :ok
+    end
+
+    test "passes through a directory", %{tmp_dir: dir} do
+      assert HugeFile.oversize(dir, @limit) == :ok
+    end
+  end
+
+  describe "guard/3 refusal path" do
+    test "an over-limit file yields a text-only refusal buffer and never opens the file",
+         %{tmp_dir: dir, server: server} do
+      path = write_file(dir, "huge.log", @limit + 500)
+
+      open_fun = fn -> flunk("open_fun ran for an over-limit file") end
+
+      assert {:ok, pid} = HugeFile.guard(path, server, open_fun)
+      track(pid)
+
+      # AC1/AC4: the huge file was never read into a buffer — no buffer is
+      # registered for its path, so no gap buffer and no tree-sitter parse.
+      assert Buffer.pid_for_path(Path.expand(path)) == :not_found
+
+      # The refusal surface is an ordinary read-only, file-less buffer.
+      assert Buffer.read_only?(pid)
+      assert Buffer.file_path(pid) == nil
+
+      content = Buffer.content(pid)
+      assert content =~ "File too large for Minga V1"
+      assert content =~ Path.expand(path)
+      assert content =~ "another editor"
+    end
+  end
+
+  describe "guard/3 open path" do
+    test "an under-limit file opens normally with byte-identical content",
+         %{tmp_dir: dir, server: server} do
+      path = write_file(dir, "ok.txt", @limit - 1)
+      expected = File.read!(path)
+
+      open_fun = fn ->
+        Buffer.ensure_for_path(path, Minga.Events.default_registry(), options_server: server)
+      end
+
+      assert {:ok, pid} = HugeFile.guard(path, server, open_fun)
+      track(pid)
+
+      assert Buffer.pid_for_path(Path.expand(path)) == {:ok, pid}
+      assert Buffer.content(pid) == expected
+    end
+
+    test "a file exactly at the limit opens (boundary)", %{tmp_dir: dir, server: server} do
+      path = write_file(dir, "edge.txt", @limit)
+
+      open_fun = fn ->
+        Buffer.ensure_for_path(path, Minga.Events.default_registry(), options_server: server)
+      end
+
+      assert {:ok, pid} = HugeFile.guard(path, server, open_fun)
+      track(pid)
+
+      assert Buffer.pid_for_path(Path.expand(path)) == {:ok, pid}
+    end
+  end
+
+  describe "message/3" do
+    test "contains the message, the path, and the open-in-another-editor suggestion" do
+      msg = HugeFile.message("/tmp/whatever.bin", 20_000_000, 10_485_760)
+
+      assert msg =~ "File too large for Minga V1"
+      assert msg =~ "/tmp/whatever.bin"
+      assert msg =~ "another editor"
+      assert msg =~ ":max_file_size"
+    end
+  end
+end


### PR DESCRIPTION
Closes #2673. Part of epic #2652 (prerequisite for the compositor-deletion child).

## Summary

Files larger than `:max_file_size` (default 10 MB, documented config option) are refused at open time with a text-only surface — title, expanded path, size vs limit, and the open-in-another-editor suggestion. No buttons, no named editors, no external-launch machinery (per the settled epic decision, which also eliminates the `EDITOR=minga` recursion class).

- **Pre-read gate:** `HugeFile.guard/3` wraps the two (and only two — verified by review) editor file-by-path open choke points with a `File.stat` size check before any `Buffer` construction. The gap buffer, undo log, and tree-sitter never see the content; the test proves it by injecting a `flunk`ing open thunk and asserting no Buffer process exists.
- **Zero new protocol:** the surface is a read-only `:nofile` in-memory buffer (same shape as dired/tutor/`*Messages*`), so both frontends render it natively through the existing window content path, and all ~15 open-file callers (picker, file tree, LSP goto, session restore, agent opens, `:edit`) get it automatically.
- **Byte-identity:** at/under-limit opens, stat errors, and non-regular files fall through unchanged (boundary-tested at exactly the limit).

## Tests

9 new async tests (isolated Options servers, no global mutation): oversize/at-limit/under-limit boundary, missing file and directory pass-through, no-buffer/no-parse proof, read-only + nil file_path assertions, message content. Focused suites green; full suite green (5 environmental tree-sitter failures resolved by building the parser binary); dialyzer/credo/format clean. Acceptance review: PASS on all verification points.

## Notes

Repeated opens of the same huge file create a fresh refusal buffer each time (no file_path to dedup on) — accepted for V1, noted in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1