### PR TITLE
fix(render): wrapped windows keep the free-scrolled viewport instead of snapping to the cursor

### DIFF
--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -304,6 +304,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
       maybe_adjust_wrapped_viewport(%{
         wrap_on: wrap_on,
         is_active: is_active,
+        follow_cursor: follow_cursor,
         viewport: viewport,
         first_line: fetch_first,
         lines: lines,
@@ -662,6 +663,24 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
          %{
            wrap_on: true,
            is_active: true,
+           follow_cursor: false
+         } = params
+       ) do
+    # Free-scroll (#2661/#2668): the wheel/trackpad moved `viewport.top` directly
+    # and `scroll_follow_cursor?/3` suppressed cursor-follow, so honor the
+    # free-scrolled top/offset instead of re-anchoring to the cursor. This mirrors
+    # the non-wrapped path, where the same `follow_cursor` gate on
+    # `maybe_scroll_active_window_to_cursor/6` already keeps the viewport put.
+    # Preserving the reported top keeps the #2668 echo contract: the emitted top
+    # equals the top `Window.mark_scroll_echo/2` recorded, so `settle_scroll_seq/1`
+    # does not bump `scroll_seq` on the user's own scroll.
+    present_free_scroll_wrapped_viewport(params)
+  end
+
+  defp maybe_adjust_wrapped_viewport(
+         %{
+           wrap_on: true,
+           is_active: true,
            first_line: first_line,
            lines: lines,
            cursor_line: cursor_line
@@ -672,6 +691,60 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     else
       adjust_wrapped_viewport_from_map(params)
     end
+  end
+
+  # Presents a wrapped active window at its already-committed free-scroll top
+  # without moving toward the cursor. Reuses the lines already fetched at
+  # `first_line` (== the free-scrolled `viewport.top` for wrapped windows, whose
+  # overscan-before is zero), computes the top line's wrap count for the visual
+  # offset, and applies the same near-EOF offset clamp as
+  # `adjust_wrapped_viewport_from_map/1`.
+  @spec present_free_scroll_wrapped_viewport(map()) ::
+          {Viewport.t(), non_neg_integer(), map(), [String.t()], String.t(), non_neg_integer()}
+  defp present_free_scroll_wrapped_viewport(%{
+         viewport: viewport,
+         first_line: first_line,
+         lines: lines,
+         snapshot: snapshot,
+         buf: buf,
+         cursor_line: cursor_line,
+         cursor_byte_col: cursor_byte_col,
+         content_w: content_w,
+         visible_rows: visible_rows,
+         oracle: oracle
+       }) do
+    wrap_map = compute_wrap_map(buf, lines, content_w, oracle)
+
+    top_count =
+      wrap_map
+      |> List.first([%{byte_offset: 0, text: "", source_text: "", indent_width: 0}])
+      |> Enum.count()
+      |> max(1)
+
+    total_lines = Buffer.line_count(buf)
+    near_eof = first_line + visible_rows >= total_lines - 1
+
+    total_visual_rows_to_eof =
+      if near_eof do
+        visual_rows_to_eof(buf, first_line, content_w, oracle)
+      else
+        top_count
+      end
+
+    new_offset =
+      if near_eof do
+        min(
+          viewport.visual_row_offset,
+          Viewport.max_visual_row_offset(total_visual_rows_to_eof, visible_rows)
+        )
+      else
+        viewport.visual_row_offset
+      end
+
+    top_count = max(top_count, total_visual_rows_to_eof)
+    new_viewport = Viewport.put_top_visual(viewport, first_line, new_offset, top_count)
+    text = cursor_line_text(lines, cursor_line, first_line)
+    {new_viewport, first_line, snapshot, lines, text, Unicode.display_col(text, cursor_byte_col)}
   end
 
   @spec adjust_wrapped_viewport_from_map(map()) ::

--- a/test/minga_editor/render_pipeline/wrapped_free_scroll_test.exs
+++ b/test/minga_editor/render_pipeline/wrapped_free_scroll_test.exs
@@ -1,0 +1,207 @@
+defmodule MingaEditor.RenderPipeline.WrappedFreeScrollTest do
+  @moduledoc """
+  Regression tests for wheel/trackpad free-scroll on soft-wrapped GUI windows
+  (#2674, symptom B).
+
+  The wheel path (`Mouse.handle_scroll_batch/4`) commits a new `viewport.top` on
+  the live window and records it as the free-scroll echo top
+  (`Window.mark_scroll_echo/2`). On wrapped active windows the render pipeline's
+  `BufferPrefetch.maybe_adjust_wrapped_viewport/1` used to re-derive the emitted
+  viewport from the cursor unconditionally: because the wheel does not drag the
+  cursor on a wrapped window, the cursor fell above the fetched range and the
+  frame re-anchored to `top: cursor_line` every frame. The emitted top never
+  advanced past the cursor line, so the GUI appeared to snap back and no new
+  content loaded.
+
+  These tests drive the production-shaped async frame: snapshot the live state,
+  run the real scroll stage on the snapshot copy (this is what the frontend
+  receives), then merge only the render cache back (`merge_renderer_window`
+  semantics). They assert the emitted top tracks the free-scrolled top, does not
+  re-anchor to the cursor, and does not bump `scroll_seq` on the user's own echo.
+  """
+
+  # gui_state/1 seeds the global shell registry, so keep this serial.
+  use ExUnit.Case, async: false
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Layout
+  alias MingaEditor.RenderPipeline
+  alias MingaEditor.RenderPipeline.Input, as: PipelineInput
+  alias MingaEditor.RenderPipeline.Scroll
+  alias MingaEditor.State, as: EditorState
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  # One production-shaped async frame: snapshot the live state, run the real
+  # scroll stage on the snapshot copy (what the frontend receives), then merge
+  # only the render cache back onto the live window (merge_renderer_window only
+  # copies the render cache; the viewport is NOT written back).
+  @spec render_frame(EditorState.t()) :: {EditorState.t(), map()}
+  defp render_frame(state) do
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    snapshot = PipelineInput.from_editor_state(state)
+    {scrolls, _out} = Scroll.scroll_windows(snapshot, layout)
+
+    win_id = state.workspace.windows.active
+    scroll = Map.fetch!(scrolls, win_id)
+
+    state =
+      EditorState.update_window(state, win_id, fn live ->
+        %{live | render_cache: scroll.window.render_cache}
+      end)
+
+    trace = %{
+      emitted_top: scroll.viewport.top,
+      emitted_offset: scroll.viewport.visual_row_offset,
+      scroll_seq: scroll.scroll_seq,
+      live_top: live(state, win_id).viewport.top,
+      echo_top: live(state, win_id).scroll_echo_top
+    }
+
+    {state, trace}
+  end
+
+  defp live(state, win_id), do: Map.fetch!(state.workspace.windows.map, win_id)
+
+  defp wheel_down(state, win_id, delta),
+    do: MingaEditor.Mouse.handle_scroll_batch(state, win_id, delta, :down)
+
+  @spec build(keyword()) :: EditorState.t()
+  defp build(opts) do
+    wrap = Keyword.fetch!(opts, :wrap)
+    rows = Keyword.get(opts, :rows, 17)
+    cols = Keyword.get(opts, :cols, 100)
+
+    # Long lines so each logical line wraps into several visual rows at cols=100.
+    content =
+      Enum.map_join(1..200, "\n", fn i ->
+        "line #{i} " <> String.duplicate("word ", 30)
+      end)
+
+    state = gui_state(content: content, rows: rows, cols: cols, filetype: :text)
+    BufferProcess.set_option(state.workspace.buffers.active, :wrap, wrap)
+    BufferProcess.move_to(state.workspace.buffers.active, {0, 0})
+    state
+  end
+
+  describe "wrapped free-scroll (#2674 symptom B)" do
+    test "the emitted viewport advances with the wheel and does not snap back to the cursor" do
+      state = build(wrap: true)
+      win_id = state.workspace.windows.active
+
+      # Warm frame establishes the scroll_seq baseline.
+      {state, warm} = render_frame(state)
+      assert warm.emitted_top == 0
+      assert warm.scroll_seq == 0
+
+      # Six downward wheel batches, rendering a production-shaped frame between
+      # each, exactly like the live interleaving.
+      {_state, tops} =
+        Enum.reduce(1..6, {state, []}, fn _i, {st, acc} ->
+          st = wheel_down(st, win_id, 3)
+          {st, t} = render_frame(st)
+
+          # The frame the frontend receives tracks the free-scrolled top: it does
+          # not re-anchor to the cursor line (0), and matches the echo top.
+          assert t.emitted_top == t.live_top,
+                 "emitted top #{t.emitted_top} should equal free-scrolled live top #{t.live_top}"
+
+          assert t.emitted_top == t.echo_top,
+                 "emitted top #{t.emitted_top} should equal echo top #{t.echo_top} (no re-anchor)"
+
+          assert t.emitted_top > 0, "must not snap back to cursor line 0"
+
+          {st, [t.emitted_top | acc]}
+        end)
+
+      # The emitted top strictly advances and stays advanced across frames.
+      advancing = Enum.reverse(tops)
+
+      assert advancing
+             |> Enum.chunk_every(2, 1, :discard)
+             |> Enum.all?(fn [prev, next] -> next > prev end),
+             "emitted tops must strictly increase across frames, got #{inspect(advancing)}"
+    end
+
+    test "scroll_seq does not bump on the user's own echoed scrolls under wrap" do
+      state = build(wrap: true)
+      win_id = state.workspace.windows.active
+
+      {state, warm} = render_frame(state)
+      baseline = warm.scroll_seq
+
+      state =
+        Enum.reduce(1..6, state, fn _i, st ->
+          st = wheel_down(st, win_id, 3)
+          {st, t} = render_frame(st)
+
+          assert t.scroll_seq == baseline,
+                 "scroll_seq must not advance on an echoed wheel scroll (#2668 contract)"
+
+          st
+        end)
+
+      # A BEAM-initiated jump to a top that is neither the previous committed top
+      # nor the echoed top still advances scroll_seq exactly once.
+      state =
+        EditorState.update_window(state, win_id, fn w ->
+          %{w | viewport: %{w.viewport | top: 120, visual_row_offset: 0}}
+        end)
+
+      # Move the cursor to the jump target so cursor-follow keeps it, then let the
+      # scroll gesture decay by clearing the velocity/detach state (gesture end).
+      BufferProcess.move_to(state.workspace.buffers.active, {120, 0})
+
+      state =
+        EditorState.update_window(state, win_id, fn w ->
+          %{
+            w
+            | scroll_velocity: MingaEditor.Window.ScrollVelocity.new(),
+              scroll_detach_cursor: nil
+          }
+        end)
+
+      {_state, jump} = render_frame(state)
+      assert jump.scroll_seq == baseline + 1
+    end
+
+    test "cursor-follow still re-anchors a wrapped window when the cursor moves off-screen" do
+      # No wheel gesture: fresh (idle) scroll velocity means scroll_follow_cursor?
+      # returns true, so the cursor-anchoring path must still run under wrap.
+      state = build(wrap: true)
+      win_id = state.workspace.windows.active
+
+      # Simulate a settled scroll far below, with the cursor left at line 0.
+      state =
+        EditorState.update_window(state, win_id, fn w ->
+          %{w | viewport: %{w.viewport | top: 60, visual_row_offset: 0}}
+        end)
+
+      {_state, t} = render_frame(state)
+
+      # Cursor at line 0 is above the viewport, so the frame re-anchors up toward
+      # the cursor rather than staying at the free-scroll position.
+      assert t.emitted_top < 60
+      assert t.emitted_top <= 5
+    end
+  end
+
+  describe "non-wrapped parity control" do
+    test "the emitted viewport tracks the wheel without snap-back (wrap off)" do
+      state = build(wrap: false)
+      win_id = state.workspace.windows.active
+
+      {state, _warm} = render_frame(state)
+
+      Enum.reduce(1..6, state, fn _i, st ->
+        st = wheel_down(st, win_id, 3)
+        {st, t} = render_frame(st)
+        assert t.emitted_top == t.live_top
+        assert t.emitted_top == t.echo_top
+        assert t.scroll_seq == 0
+        st
+      end)
+    end
+  end
+end


### PR DESCRIPTION
Fixes symptom B of #2674 (critical): in the GUI, wheel scrolling on a soft-wrapped buffer could not move past the current viewport — no new content loaded and the view snapped back to the cursor line.

## Root cause

`maybe_adjust_wrapped_viewport/1` re-anchored every **emitted** frame to the cursor line whenever `cursor_line < first_line`, ungated by `follow_cursor` — the live viewport advanced (3, 6, 9…) while each committed frame snapped back to the cursor. The non-wrapped path always had this gate. Long-standing bug (predates today's merges): wrap-off was always correct, `line_spacing` is uninvolved, and `scroll_seq` never stormed (production-shaped trace on the issue).

## Fix

Purely additive (+73/-0): thread the already-computed `follow_cursor` into the wrapped adjustment; a new active-wrapped free-scroll clause presents the scrolled `top`/`visual_row_offset`, reusing already-fetched lines and mirroring the existing near-EOF clamp exactly. `follow_cursor: true` (jumps, cursor moves, idle-velocity re-anchor) is byte-identical to before; inactive, folded, and wrap-off windows are untouched by clause ordering.

Preserves the #2668 echo/authority contract: wheel frames are echoes (no `scroll_seq` bump), BEAM jumps bump exactly once — both asserted.

## Tests

New production-shaped regression suite (snapshot → real scroll stage → render-cache-only writeback): wrapped free-scroll persistence, no snap-back, no-bump-on-echo, jump-bumps-once, cursor-follow resume, wrap-off parity control. **Reviewer ran the revert experiment**: with the fix reverted the suite fails on exactly the snap-back assertion (`emitted top 0 should equal free-scrolled live top 3`). Focused 258 render/viewport/window/mouse tests, conformance corpus (148), and the full suite (9,753) all green; lint/dialyzer/format clean. Acceptance review: PASS.

## Remaining on #2674

Symptom A (window underfill at the default 1.2 line spacing) is Swift-side — BEAM emission is correct; audit pointers are on the issue awaiting an owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1