### PR TITLE
chore(macos): cold build-for-testing works without building the app first

### DIFF
--- a/macos/Minga.xcodeproj/xcshareddata/xcschemes/Minga.xcscheme
+++ b/macos/Minga.xcodeproj/xcshareddata/xcschemes/Minga.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1600"
    version = "1.7">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES"
       runPostActionsOnFailure = "NO">
       <BuildActionEntries>

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -359,6 +359,11 @@ targets:
 schemes:
   Minga:
     build:
+      # parallelizeBuild off makes Xcode build in listed order: the app first,
+      # so MingaTests' `@testable import Minga` resolves on a cold checkout
+      # without a target dependency (which would infer TEST_HOST and embed the
+      # xctest into the app, breaking the app's --deep codesign script).
+      parallelizeBuild: false
       targets:
         Minga: all
         MingaTests: [test]


### PR DESCRIPTION
Closes #2669.

## Summary

Fresh worktrees and CI-from-scratch could not run `xcodebuild build-for-testing` without manually building the app target first (`unable to resolve module dependency: 'Minga'` — MingaTests' `@testable import Minga` raced parallel target builds). This cost two agent-worker sessions in one day.

**The obvious fix is wrong, and this PR documents why:** a `MingaTests → Minga` target dependency makes xcodegen infer `TEST_HOST`/`BUNDLE_LOADER`, converting MingaTests into a *hosted* bundle — Xcode embeds the xctest into `Minga.app/Contents/PlugIns` mid-build, the app's `--deep` codesign script rejects the half-built nested bundle, and hosted tests would run inside the app process (changing runtime semantics). Verified empirically; `link: false`/`embed: false` don't prevent the inference.

**The actual fix is two lines:** `parallelizeBuild: false` on the Minga scheme in `project.yml`. Xcode builds the scheme's targets in listed order (app, then tests), so the module exists before the test bundle compiles. The regenerated `pbxproj` is **byte-identical** to main; only the shared scheme file changes.

## Verification

From fully clean DerivedData in a fresh worktree: `xcodegen generate && xcodebuild build-for-testing -scheme Minga` → exit 0; `test-without-building -only-testing:MingaTests/CommandDispatcherTests` → TEST EXECUTE SUCCEEDED.

## Cost note

Serialized scheme entries add some cold-build wall time, but the previous workaround built the app first anyway — net wash, now automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1