### PR TITLE
fix(test): deterministic fixes for gateway and session-recovery flakes

### DIFF
--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -465,10 +465,16 @@ defmodule MingaAgent.Session do
     GenServer.call(session, :cycle_model, 10_000)
   end
 
-  @doc "Sets the model without resetting conversation context."
-  @spec set_model(GenServer.server(), String.t()) :: :ok | {:error, term()}
-  def set_model(session, model) when is_binary(model) do
-    GenServer.call(session, {:set_model, model})
+  @doc """
+  Sets the model without resetting conversation context.
+
+  Setting a model can start the provider synchronously (see `start_provider/1`),
+  so callers may pass a larger `timeout` when a slow provider startup should not
+  surface as a call timeout.
+  """
+  @spec set_model(GenServer.server(), String.t(), timeout()) :: :ok | {:error, term()}
+  def set_model(session, model, timeout \\ 5_000) when is_binary(model) do
+    GenServer.call(session, {:set_model, model}, timeout)
   end
 
   @doc "Toggles the collapsed state of a tool call message."

--- a/test/minga_agent/gateway/integration_test.exs
+++ b/test/minga_agent/gateway/integration_test.exs
@@ -69,6 +69,46 @@ defmodule MingaAgent.Gateway.IntegrationTest do
 
       ws_close(ws)
     end
+
+    # Regression for issue #2663: the gateway subscribes to Minga.Events on connect
+    # and pushes event notifications on the same socket. A notification that
+    # interleaves with a request/response pair must not be mistaken for the
+    # response. Emitting a `:log_message` before the request enqueues the
+    # notification frame ahead of the response frame, so a client that blindly read
+    # "the next frame" would fail here.
+    test "response is returned even when an event notification interleaves", %{
+      port: port,
+      token: token
+    } do
+      {:ok, ws} = ws_connect(port, token)
+
+      # Warm-up round-trip: the WebSocket handler subscribes to Minga.Events in its
+      # init/1, which runs asynchronously after the HTTP upgrade. Completing one
+      # request/response proves init/1 (and thus the subscription) has run, so the
+      # broadcast below is guaranteed to reach this connection.
+      :ok = ws_send(ws, JSON.encode!(%{jsonrpc: "2.0", method: "tool.list", params: %{}, id: 4}))
+      {:ok, warmup} = ws_receive(ws)
+      assert warmup["id"] == 4
+
+      # Now enqueue an event notification ahead of the next response. broadcast/2
+      # delivers synchronously, so {:minga_event, ...} is in the connection's
+      # mailbox (pushed as a notification frame) before the request below is sent.
+      Minga.Events.broadcast(:log_message, %Minga.Events.LogMessageEvent{
+        text: "interleaved notification",
+        level: :info
+      })
+
+      request =
+        JSON.encode!(%{jsonrpc: "2.0", method: "runtime.capabilities", params: %{}, id: 5})
+
+      :ok = ws_send(ws, request)
+
+      {:ok, response} = ws_receive(ws)
+      assert response["id"] == 5
+      assert is_integer(response["result"]["tool_count"])
+
+      ws_close(ws)
+    end
   end
 
   # ── WebSocket helpers using raw :gen_tcp + HTTP upgrade ─────────────────────
@@ -122,7 +162,30 @@ defmodule MingaAgent.Gateway.IntegrationTest do
     :gen_tcp.send(socket, frame)
   end
 
+  # Reads WebSocket frames until a JSON-RPC *response* (a frame carrying an "id")
+  # arrives, skipping any server-pushed notifications that interleave.
+  #
+  # Root cause of issue #2663: the gateway WebSocket subscribes to Minga.Events on
+  # connect (`EventStream.subscribe_all/0`) and pushes event notifications
+  # (`{"jsonrpc":"2.0","method":"event.<topic>",...}` frames with no "id") on the
+  # same socket. Under full-suite load a `:log_message`/`:buffer_changed`/etc. event
+  # can fire between our request and its response, so blindly reading "the next
+  # frame" would read a notification and see the wrong (or missing) id. A real
+  # JSON-RPC-over-WebSocket client correlates responses by id and ignores
+  # notifications, so the test must too.
   defp ws_receive(socket) do
+    frame = ws_read_frame(socket)
+
+    cond do
+      # JSON-RPC responses always carry the request id.
+      Map.has_key?(frame, "id") -> {:ok, frame}
+      # JSON-RPC notifications carry a method and no id: skip and keep reading.
+      Map.has_key?(frame, "method") -> ws_receive(socket)
+      true -> {:ok, frame}
+    end
+  end
+
+  defp ws_read_frame(socket) do
     # Read a text frame. Simplified parser: assumes single unfragmented frame.
     {:ok, <<_fin_opcode, len_byte>>} = :gen_tcp.recv(socket, 2, 5_000)
     # Server frames are unmasked
@@ -143,7 +206,7 @@ defmodule MingaAgent.Gateway.IntegrationTest do
       end
 
     {:ok, payload} = :gen_tcp.recv(socket, actual_len, 5_000)
-    {:ok, JSON.decode!(payload)}
+    JSON.decode!(payload)
   end
 
   defp ws_close(socket) do

--- a/test/minga_agent/session_recovery_test.exs
+++ b/test/minga_agent/session_recovery_test.exs
@@ -6,6 +6,22 @@ defmodule MingaAgent.SessionRecoveryTest do
   alias MingaAgent.Providers.Native
   alias MingaAgent.Session
 
+  # Provider startup runs synchronously inside the Session process
+  # (`start_provider/1` -> `provider_module.start_link/1` -> `Native.init/1`).
+  # That startup is only ~10ms idle, but under full-suite scheduler contention the
+  # Session can stall well past the default 5s `GenServer.call` timeout, so any
+  # call that triggers or waits behind startup times out (issue #2663). We wait for
+  # startup to finish with `:sys.get_state/2` (a synchronization barrier that
+  # drains the Session mailbox) and give startup-triggering calls a generous
+  # ceiling, instead of racing the 5s default.
+  @startup_timeout 30_000
+
+  # Blocks until the Session has processed every message enqueued before this call,
+  # including any `:start_provider` scheduled during `start_link/1` or a preceding
+  # `refresh_credentials/1` cast. After it returns the Session is idle, so the
+  # following assertions run against a settled provider without racing the timeout.
+  defp await_provider_startup(session), do: :sys.get_state(session, @startup_timeout)
+
   defp start_credential_checker(initial_state) do
     checker =
       {Agent, fn -> initial_state end}
@@ -28,6 +44,10 @@ defmodule MingaAgent.SessionRecoveryTest do
         |> Keyword.put(:provider_opts, provider_opts)
         |> Keyword.put(:credentials_configured_fn, credentials_configured_fn)
       )
+
+    # `start_link/1` schedules `:start_provider` when credentials are already
+    # configured; wait it out here so callers observe a settled session.
+    await_provider_startup(session)
 
     {session, checker}
   end
@@ -160,6 +180,9 @@ defmodule MingaAgent.SessionRecoveryTest do
 
     Agent.update(checker, fn _ -> true end)
     assert :ok = Session.refresh_credentials(session)
+    # refresh_credentials/1 is a cast that starts the provider synchronously in
+    # handle_cast; wait for that before reading provider-dependent state.
+    await_provider_startup(session)
     assert Session.editor_snapshot(session).credentials_configured == true
     assert is_pid(Session.get_provider(session))
   end
@@ -172,7 +195,9 @@ defmodule MingaAgent.SessionRecoveryTest do
       )
 
     assert Session.get_provider(session) == nil
-    assert :ok = Session.set_model(session, "claude-opus-4-20250514@anthropic")
+    # set_model/2 starts the provider synchronously in handle_call, so pass a
+    # generous timeout rather than racing the default 5s under suite load.
+    assert :ok = Session.set_model(session, "claude-opus-4-20250514@anthropic", @startup_timeout)
     assert is_pid(Session.get_provider(session))
 
     metadata = Session.metadata(session)


### PR DESCRIPTION
Fixes 2 of the 3 flakes in #2663 with deterministic reproductions (issue stays open for the third).

## Summary

- **Gateway WebSocket (`integration_test.exs:47`):** the socket pushes subscribed-event JSON-RPC *notification* frames interleaved with responses; the test helper read the next frame blindly. `ws_receive/1` now correlates by `id` (notifications skipped; a malformed id-less response is still returned, never swallowed; recv timeout fails loudly). New regression test forces a notification ahead of the response and fails deterministically on the old reader.
- **Session recovery (3 cases):** provider startup runs synchronously in the Session process; under full-suite contention, calls queued behind it blew the 5s default timeout (reproduced at `--max-cases 96`, seed 7 — pre-fix 4 failures, post-fix clean on the same seed). Fix: `:sys.get_state` mailbox-drain barriers (the AGENTS.md pattern) plus an optional timeout on `Session.set_model/3` (default unchanged, backward compatible, mirrors `cycle_model`; genuinely needed where startup runs inside the call itself so no barrier can help).
- **`gui_action_handler_test:128`:** not reproduced across seeds/concurrency/50x loops; static analysis and a hardening candidate (`file_tree.ex:913` `Project.root()` → `resolve_root/0`) documented on #2663 instead of a speculative change.

## Validation

50x loops green per fixed test; deterministic repro proofs both directions; two full suites 10,060 pass; reviewer independently re-ran both files at seeds 7/42/99 with `--max-cases 96` — clean. `make lint` green. Acceptance review: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1