### PR TITLE
feat(render): residence on by default with first-paint-then-promote

### DIFF
--- a/bench/resident_frame_bench.exs
+++ b/bench/resident_frame_bench.exs
@@ -43,6 +43,10 @@ defmodule Minga.Bench.ResidentFrame do
   defp bench_size(size) do
     state = resident_state(size)
 
+    # First-paint-then-promote (#2679): the first frame renders windowed (arming
+    # promotion); discard it so `keyframe_us` measures the first full resident
+    # build. The following frame settles the incremental base for the edit samples.
+    {_arm_us, state} = timed_frame(state)
     {keyframe_us, state} = timed_frame(state)
     {_us, state} = timed_frame(state)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,6 +28,8 @@ That's it. Save the file and restart Minga. Your options take effect immediately
 | `:autopair_block` | boolean | `true` | Auto-insert language-aware block-closing keywords on Enter |
 | `:scroll_margin` | non-negative integer | `5` | Lines to keep visible above/below cursor when scrolling |
 | `:max_file_size` | positive integer | `10485760` | Maximum file size in bytes Minga will open. Larger files show a text-only "file too large" surface instead of loading a buffer; checked with a pre-read stat so the gap buffer and tree-sitter parser never touch the content. Default 10 MB. Raise it for the brave. |
+| `:resident_store_max_lines` | non-negative integer | `65535` | Maximum buffer line count that still gets full-document residence (glitch-free fast scrolling). Defaults to `65535`, the u16 wire ceiling: frames encode the row count as a u16, so the render path caps residence there regardless of this value. Real exposure is bounded well below the line ceiling by `:resident_store_max_bytes` (10 MB) and `:max_file_size` (10 MB, refused pre-load). Set to `0` to disable residence and force the viewport-windowed path. Wrapped and folded buffers always use the windowed path. See [Fast scrolling (residence)](#fast-scrolling-residence) below. |
+| `:resident_store_max_bytes` | positive integer | `10485760` | Maximum buffer byte size that still gets full-document residence. Residence needs both this and `:resident_store_max_lines`; set `:resident_store_max_lines` to `0` to disable residence regardless of byte size. Default 10 MB. |
 | `:theme` | theme name atom | `:astrodark` | Color theme (see [Themes](#themes) below) |
 | `:indent_with` | `:spaces` or `:tabs` | `:spaces` | Whether to indent with spaces or tab characters |
 | `:trim_trailing_whitespace` | boolean | `false` | Strip trailing whitespace on save |
@@ -507,6 +509,21 @@ Available placeholders:
 | `{bufname}` | Buffer display name (filename, or `*scratch*` for unnamed buffers) |
 
 The title is restored to its previous value when Minga exits.
+
+## Fast scrolling (residence)
+
+Minga keeps the whole document resident in the frontend for normal-size files, so scrolling never outruns the data and never shows blank or stale rows during a fast flick. This is on by default.
+
+Two knobs gate it, and both must pass:
+
+- `:resident_store_max_lines` (default `65535`): the maximum line count that still gets residence. The default is the u16 wire ceiling; frames encode the row count as a u16, so this is the hard cap regardless of what you set. Set it to `0` to turn residence off and go back to the viewport-windowed path.
+- `:resident_store_max_bytes` (default `10485760`, 10 MB): the maximum buffer byte size that still gets residence.
+
+In practice the byte gate and the `:max_file_size` pre-load refusal (also 10 MB) bound the real exposure well below the line ceiling: files above `:max_file_size` never open at all, so they never reach the residence gate.
+
+Wrapped and folded buffers always use the viewport-windowed path, not residence.
+
+To open a huge file instantly, residence engages on the frame after first paint: the first frame of a newly opened (or resized) file renders viewport-windowed so content appears immediately, then the full-document store is built on the next frame. You do not need to configure this; it is automatic.
 
 ## Per-filetype settings
 

--- a/docs/workstreams/resident-scroll.md
+++ b/docs/workstreams/resident-scroll.md
@@ -1,6 +1,20 @@
 # Resident-Store Rendering Direction
 
-**Status:** Approved direction, June 2026. Tracked by epic [#2652](https://github.com/jsmestad/minga/issues/2652). This doc captures the decision and its rationale so future work (human or agent) builds toward it instead of extending the machinery it deletes. The normative protocol spec lands in `GUI_PROTOCOL.md` and `ARCHITECTURE.md` as the epic's implementation ships; until then, this doc describes the target, not current behavior.
+**Status:** Shipping. Full-document residence is **on by default** as of [#2679](https://github.com/jsmestad/minga/issues/2679) (`resident_store_max_lines` defaults to `65535`, the u16 wire ceiling). Tracked by epic [#2652](https://github.com/jsmestad/minga/issues/2652). This doc captures the decision and its rationale so future work (human or agent) builds toward it instead of extending the machinery it deletes. The normative protocol spec lives in `GUI_PROTOCOL.md` and `ARCHITECTURE.md`.
+
+## Status ledger (as of #2679)
+
+The prerequisites the epic set for the default flip have all landed:
+
+- Incremental resident store, edit frames O(changed rows) — [#2658](https://github.com/jsmestad/minga/issues/2658). Wall-clock evidence: single-line edit on a 5,000-line resident buffer is ~1 ms p50 / ~1.1 ms p95, flat across sizes; the operation-count CI gate is `test/minga_editor/render_pipeline/resident_incremental_test.exs`.
+- GUI free-scroll zone renders locally — [#2661](https://github.com/jsmestad/minga/issues/2661).
+- Same-top jump discard gap closed (explicit `bump_scroll_seq` at authoritative call sites) — [#2678](https://github.com/jsmestad/minga/issues/2678).
+- Huge files refused pre-load above `:max_file_size` — [#2673](https://github.com/jsmestad/minga/issues/2673).
+- Conformance runs zero-skip on both frontends.
+
+**First-paint-then-promote (#2679).** File-open first paint at the 65k-row ceiling was measured at ~0.5 s for a full resident build versus ~0.7 ms for the windowed path, so residence now engages one frame after first paint: a newly opened or resized window renders viewport-windowed first (instant content), then promotes to full residence on the next frame. The expensive O(document) first build lands on the renderer process after content is on screen, not blocking first paint. The promotion is carried by `residence_armed` in the window render cache and resets on layout_generation rebuilds.
+
+**Closed ledger items:** residence default flip (was AC4 of #2658), first-paint protection (was the ledger's evidence-gated design input). **Still open:** the manual GUI smoke session (the epic's one human gate, signed off on #2679 before merge); residual O(document) passes at the 65k extreme (~30 fps resident scroll at the ceiling; delta-only row-list construction, only if >5k-line residence matters post-launch); wrapped/folded residence (future slice, needs visual-row offset math).
 
 ## The problem
 

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -423,10 +423,10 @@ defmodule Minga.Config.Options do
      ], "Directory names excluded from the file finder (SPC f f). Stacks with .gitignore."},
     {:picker_backdrop, :boolean, true,
      "Whether centered floating pickers render a dimmed backdrop overlay."},
-    {:resident_store_max_lines, :non_neg_integer, 0,
-     "Maximum buffer line count that still receives full-document row residence (glitch-free fast scrolling). 0 disables full residence entirely (the default); larger buffers fall back to viewport-windowed emit."},
+    {:resident_store_max_lines, :non_neg_integer, 65_535,
+     "Maximum buffer line count that still receives full-document row residence (glitch-free fast scrolling). Defaults to 65_535, the u16 wire ceiling: gui_window_content and its row/viewport deltas encode row_count as a u16, so the render path (@wire_max_rows in buffer_prefetch) caps residence there regardless of this value. Real exposure is bounded well below the line ceiling by two byte gates in front of it: :resident_store_max_bytes (10 MB) skips residence for large buffers, and :max_file_size (10 MB, pre-read stat) refuses the file before a buffer is even created. Set to 0 to disable full residence entirely; over-ceiling or over-byte buffers fall back to viewport-windowed emit. Wrapped and folded buffers always use the windowed path."},
     {:resident_store_max_bytes, :pos_integer, 10_485_760,
-     "Maximum buffer byte size that still receives full-document row residence. Residence is gated by both this and :resident_store_max_lines, so it stays off while :resident_store_max_lines is 0."},
+     "Maximum buffer byte size that still receives full-document row residence. Residence is gated by both this and :resident_store_max_lines; set :resident_store_max_lines to 0 to disable residence regardless of byte size."},
     {:max_file_size, :pos_integer, 10_485_760,
      "Maximum file size in bytes Minga will open. Files larger than this show a text-only \"file too large\" surface instead of loading a buffer; the size is checked with a pre-read stat, so the gap buffer and tree-sitter parser never touch the content. Default 10 MB."}
   ]

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -285,8 +285,18 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     # buffers, fetch and emit the entire laid-out document so a fast scroll can
     # never outrun the resident row store. Over-threshold, wrapped, or folded
     # buffers keep today's velocity-aware viewport-plus-overscan windowing.
-    full_residence? =
+    #
+    # First-paint-then-promote (#2679): the O(document) first build is ~0.5s at the
+    # 65k-row ceiling (measured), so an eligible window renders viewport-windowed on
+    # its first frame (fast file-open paint) and promotes to full residence on the
+    # next frame, when `residence_armed?` is true. The expensive build then lands
+    # one frame later on the renderer process, after content is already on screen,
+    # instead of blocking first paint. `residence_armed` resets on layout_generation
+    # rebuilds (RenderCache.reset/1) so resize/font/wrap changes re-defer.
+    residence_eligible? =
       is_nil(visible_line_map) and full_residence?(window.buffer, wrap_on, line_count)
+
+    full_residence? = residence_eligible? and Window.residence_armed?(window)
 
     {fetch_first, fetch_count, visible_row_start_index} =
       resolve_fetch_range(%{
@@ -353,6 +363,11 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         width_oracle,
         snapshot
       )
+
+    # Arm promotion for the next frame whenever this window is residence-eligible,
+    # so an eligible window that rendered windowed this frame goes resident next
+    # frame (#2679). Disarms when eligibility is lost (wrap/fold/over-threshold).
+    window = Window.set_residence_armed(window, residence_eligible?)
 
     %WindowScroll{
       win_id: win_id,
@@ -435,8 +450,8 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   # folded/decorated (caller passes the nil-visible_line_map case only), and both
   # its line count and byte size sit under the configured thresholds and the wire
   # row ceiling. The byte check runs last so an over-line file skips the extra call.
-  # A line threshold of 0 (or nil) means residence is disabled, which is the
-  # default: the feature ships dormant until explicitly opted in via config.
+  # Residence is on by default (:resident_store_max_lines defaults to the u16 wire
+  # ceiling); a line threshold of 0 (or nil) disables it and forces the windowed path.
   @spec full_residence?(pid(), boolean(), non_neg_integer()) :: boolean()
   defp full_residence?(_buf, true = _wrap_on, _line_count), do: false
 

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -219,6 +219,17 @@ defmodule MingaEditor.Window do
   @spec resident?(t()) :: boolean()
   def resident?(%__MODULE__{render_cache: cache}), do: RenderCache.resident?(cache)
 
+  @doc "Arms or disarms residence promotion for the next frame (#2679 first-paint-then-promote)."
+  @spec set_residence_armed(t(), boolean()) :: t()
+  def set_residence_armed(%__MODULE__{render_cache: cache} = window, armed?)
+      when is_boolean(armed?) do
+    %{window | render_cache: RenderCache.set_residence_armed(cache, armed?)}
+  end
+
+  @doc "Returns whether residence was armed by the previous eligible frame (#2679)."
+  @spec residence_armed?(t()) :: boolean()
+  def residence_armed?(%__MODULE__{render_cache: cache}), do: RenderCache.residence_armed?(cache)
+
   @doc """
   Records the committed viewport top of a frontend-reported free-scroll (#2661).
 

--- a/lib/minga_editor/window/render_cache.ex
+++ b/lib/minga_editor/window/render_cache.ex
@@ -80,6 +80,7 @@ defmodule MingaEditor.Window.RenderCache do
           retained_wrap_lines: %{optional(non_neg_integer()) => retained_wrap_line()},
           resident_build: MingaEditor.RenderModel.Window.ResidentBuild.t() | nil,
           resident: boolean(),
+          residence_armed: boolean(),
           scroll_seq: non_neg_integer(),
           scroll_seq_last_top: integer() | nil,
           scroll_seq_last_authoritative: non_neg_integer()
@@ -101,6 +102,7 @@ defmodule MingaEditor.Window.RenderCache do
             retained_wrap_lines: %{},
             resident_build: nil,
             resident: false,
+            residence_armed: false,
             scroll_seq: 0,
             scroll_seq_last_top: nil,
             scroll_seq_last_authoritative: 0
@@ -138,7 +140,8 @@ defmodule MingaEditor.Window.RenderCache do
         total_visual_rows_cache: nil,
         retained_rows: %{},
         retained_wrap_lines: %{},
-        resident_build: nil
+        resident_build: nil,
+        residence_armed: false
     }
   end
 
@@ -451,6 +454,24 @@ defmodule MingaEditor.Window.RenderCache do
   @doc "Returns the residence flag captured by the last rendered frame."
   @spec resident?(t()) :: boolean()
   def resident?(%__MODULE__{resident: resident}), do: resident
+
+  @doc """
+  Arms (or disarms) full-document residence for the next frame (#2679).
+
+  First-paint-then-promote: a resident-eligible window renders viewport-windowed
+  on its first frame after becoming eligible, arming promotion; the next frame
+  sees `residence_armed?/1` true and emits full residence. This keeps the
+  expensive O(document) first build off file-open first paint. The flag is reset
+  by `reset/1` so a layout_generation rebuild (resize, font, wrap) re-defers.
+  """
+  @spec set_residence_armed(t(), boolean()) :: t()
+  def set_residence_armed(%__MODULE__{} = cache, armed?) when is_boolean(armed?) do
+    %{cache | residence_armed: armed?}
+  end
+
+  @doc "Returns whether residence was armed by the previous eligible frame (#2679)."
+  @spec residence_armed?(t()) :: boolean()
+  def residence_armed?(%__MODULE__{residence_armed: armed}), do: armed
 
   @doc "Returns the monotonic scroll-authority sequence (#2661)."
   @spec scroll_seq(t()) :: non_neg_integer()

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -167,6 +167,10 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
 
     test "ordinary buffer edits change row hashes without bumping content epoch or forcing refresh" do
       state = gui_state(content: "hello")
+      # First-paint-then-promote (#2679): frame 1 renders windowed (arming), frame 2
+      # promotes to residence with a full refresh. Settle both before measuring
+      # edit-epoch stability so the edit frame is the only variable.
+      {[_wf], _cursor, state} = build_content(state)
       {[wf], _cursor, state} = build_content(state)
       epoch = wf.window_model.content_epoch
       old_hash = hd(wf.window_model.rows).content_hash

--- a/test/minga_editor/render_pipeline/full_document_residence_threshold_test.exs
+++ b/test/minga_editor/render_pipeline/full_document_residence_threshold_test.exs
@@ -2,9 +2,10 @@ defmodule MingaEditor.RenderPipeline.FullDocumentResidenceThresholdTest do
   @moduledoc """
   Threshold-guard and residence-emit tests for full-document row residence (#2653).
 
-  Residence ships dormant (`:resident_store_max_lines` default 0), so these tests
-  enable it by setting the global config option. That mutation forces the module
-  to run `async: false`; the option is restored after each test.
+  Residence ships on by default (`:resident_store_max_lines` default 65_535). These
+  tests pin the option explicitly per case (raising, lowering, or disabling it) to
+  exercise the threshold boundaries. That mutation forces the module to run
+  `async: false`; the option is restored after each test.
   """
 
   # Mutates the global Config option server (:resident_store_max_lines).
@@ -93,7 +94,9 @@ defmodule MingaEditor.RenderPipeline.FullDocumentResidenceThresholdTest do
   test "a buffer under the configured line threshold stays fully resident" do
     Config.set(:resident_store_max_lines, 100_000)
 
-    [{_win_id, scroll}] = Map.to_list(run_through_scroll(scrolled_state(250)))
+    # First-paint-then-promote (#2679): residence engages on the second frame.
+    state = warm(scrolled_state(250))
+    [{_win_id, scroll}] = Map.to_list(run_through_scroll(state))
 
     assert scroll.full_residence == true
     assert Enum.count(scroll.lines) == 500
@@ -102,7 +105,8 @@ defmodule MingaEditor.RenderPipeline.FullDocumentResidenceThresholdTest do
   test "residence emits every document row regardless of scroll position" do
     Config.set(:resident_store_max_lines, 100_000)
 
-    model = build_model(scrolled_state(250))
+    # First-paint-then-promote (#2679): warm one frame so residence is promoted.
+    model = build_model(warm(scrolled_state(250)))
     presentation = ScrollPresentation.from_window(model)
 
     # The window carries every document row, in buffer order from line 0 to 499.
@@ -125,10 +129,13 @@ defmodule MingaEditor.RenderPipeline.FullDocumentResidenceThresholdTest do
   end
 
   test "toggling residence mid-session forces a full refresh via the render reset fingerprint" do
+    # Residence is on by default, so pin it off first to establish a windowed
+    # baseline fingerprint before toggling it on below.
+    Config.set(:resident_store_max_lines, 0)
     state = scrolled_state(250)
 
-    # Warm up with residence disabled (default 0) to establish a baseline
-    # fingerprint in the window's render cache.
+    # Warm up with residence disabled to establish a baseline fingerprint in the
+    # window's render cache.
     state = warm(state)
 
     # Second frame should be stable (no full refresh).
@@ -137,9 +144,16 @@ defmodule MingaEditor.RenderPipeline.FullDocumentResidenceThresholdTest do
     assert scroll.full_refresh == false
     assert scroll.full_residence == false
 
-    # Enable residence and run a third frame. The fingerprint change should
-    # force full_refresh: true so no :patch frame diffs across differently-sized stores.
+    # Enable residence. First-paint-then-promote (#2679): the first frame after
+    # enabling stays windowed (arming promotion), so it neither becomes resident
+    # nor forces a refresh yet.
     Config.set(:resident_store_max_lines, 100_000)
+    {scrolls, state} = run_through_scroll_with_state(state)
+    [{_win_id, arming}] = Map.to_list(scrolls)
+    assert arming.full_residence == false
+
+    # The next frame promotes to residence. The fingerprint change forces
+    # full_refresh: true so no :patch frame diffs across differently-sized stores.
     {scrolls, _state} = run_through_scroll_with_state(state)
     [{_win_id, scroll}] = Map.to_list(scrolls)
     assert scroll.full_refresh == true
@@ -149,7 +163,8 @@ defmodule MingaEditor.RenderPipeline.FullDocumentResidenceThresholdTest do
   test "gutter stays viewport-bounded under residence even when scrolled deep" do
     Config.set(:resident_store_max_lines, 100_000)
 
-    model = build_model(scrolled_state(400))
+    # First-paint-then-promote (#2679): warm one frame so residence is promoted.
+    model = build_model(warm(scrolled_state(400)))
     visible = model.geometry.viewport.rows
 
     assert Enum.count(model.rows) == 500

--- a/test/minga_editor/render_pipeline/line_patch_fast_path_test.exs
+++ b/test/minga_editor/render_pipeline/line_patch_fast_path_test.exs
@@ -15,6 +15,7 @@ defmodule MingaEditor.RenderPipeline.LinePatchFastPathTest do
   use ExUnit.Case, async: false
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Config
   alias MingaEditor.Layout
   alias MingaEditor.RenderPipeline
   alias MingaEditor.RenderPipeline.BufferPrefetch
@@ -27,6 +28,13 @@ defmodule MingaEditor.RenderPipeline.LinePatchFastPathTest do
   import MingaEditor.RenderPipeline.TestHelpers
 
   setup context do
+    # These tests target the #2287 windowed line-patch fast path, so pin
+    # full-document residence off (it now defaults on, #2679). Safe because the
+    # module is already async: false; the option is restored after each test.
+    original_residence = Config.get(:resident_store_max_lines)
+    Config.set(:resident_store_max_lines, 0)
+    on_exit(fn -> Config.set(:resident_store_max_lines, original_residence) end)
+
     # Capture the pipeline span's stop metadata for assertions. Each test gets a
     # unique handler id so the async suite never crosses streams.
     handler_id = {__MODULE__, context.test, self()}
@@ -134,8 +142,7 @@ defmodule MingaEditor.RenderPipeline.LinePatchFastPathTest do
       # A tall enough buffer that scrolling exposes exactly one new row. The
       # rows still on screen keep their row_id and input fingerprint, so the
       # retained-row cache reuses them; only the row scrolled into view composes.
-      # (Full-document residence is dormant by default, so this windowed path is
-      # what runs.)
+      # (Residence is pinned off in setup so this windowed path is what runs.)
       state = gui_state(content: long_content(100), rows: 8)
       buffer = state.workspace.buffers.active
       state = warm(state)

--- a/test/minga_editor/render_pipeline/resident_incremental_test.exs
+++ b/test/minga_editor/render_pipeline/resident_incremental_test.exs
@@ -61,7 +61,8 @@ defmodule MingaEditor.RenderPipeline.ResidentIncrementalTest do
 
   describe "digest consistency" do
     test "content_digest always equals a from-scratch digest of the emitted rows" do
-      {model, _state} = build_frame(resident_state(300))
+      # First-paint-then-promote (#2679): warm one frame so residence is promoted.
+      {model, _state} = build_frame(warm(resident_state(300)))
 
       refute is_nil(model.content_digest)
       assert model.content_digest == ContentDigest.of_rows(model.rows)

--- a/test/minga_editor/render_pipeline/scroll_test.exs
+++ b/test/minga_editor/render_pipeline/scroll_test.exs
@@ -101,22 +101,26 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
       assert scroll.content_w >= 1
     end
 
-    test "full-document residence is dormant by default and keeps windowed overscan (#2653)" do
-      # residence ships off (resident_store_max_lines default 0); even a large
-      # nowrap buffer stays windowed unless residence is explicitly enabled.
-      # Config-enabled residence behavior is covered in the async:false threshold
-      # suite (full_document_residence_threshold_test.exs).
+    test "full-document residence is on by default for a nowrap buffer under the ceiling (#2679)" do
+      # Residence now ships on (resident_store_max_lines default 65_535), so a
+      # nowrap buffer under the ceiling becomes fully resident regardless of scroll
+      # position. This test relies on the default rather than mutating global config
+      # so it stays async-safe; threshold-boundary and disabled-path behavior are
+      # covered in the async:false suite (full_document_residence_threshold_test.exs).
       state = base_state(rows: 10, cols: 40, content: long_content(500))
       win_id = state.workspace.windows.active
       window = Map.fetch!(state.workspace.windows.map, win_id)
       window = Window.set_viewport(window, Viewport.put_top(window.viewport, 250))
       state = put_in(state.workspace.windows.map[win_id], window)
 
+      # First-paint-then-promote (#2679): the first frame renders windowed (arming
+      # promotion), the second promotes to full residence.
+      {_scrolls, state, _layout} = run_through_scroll(state)
       {scrolls, _state, _layout} = run_through_scroll(state)
       [{_win_id, scroll}] = Map.to_list(scrolls)
 
-      assert scroll.full_residence == false
-      assert Enum.count(scroll.lines) < 500
+      assert scroll.full_residence == true
+      assert Enum.count(scroll.lines) == 500
     end
 
     test "wrap_on is false when folds produce a visible_line_map" do

--- a/test/minga_editor/render_pipeline_test.exs
+++ b/test/minga_editor/render_pipeline_test.exs
@@ -345,6 +345,13 @@ defmodule MingaEditor.RenderPipelineTest do
     end
 
     test "unchanged lines emit a viewport delta instead of a full content frame" do
+      # This exercises the windowed semantic-encoder delta cache (0xA1). Pin
+      # residence off (#2679 defaults it on) so frame 2 stays on the windowed
+      # delta path instead of promoting to a resident full-content keyframe.
+      original = Minga.Config.get(:resident_store_max_lines)
+      Minga.Config.set(:resident_store_max_lines, 0)
+      on_exit(fn -> Minga.Config.set(:resident_store_max_lines, original) end)
+
       state = base_state(content: "hello\nworld\nfoo")
 
       # Frame 1: fresh render emits a full window content (0x80) snapshot.


### PR DESCRIPTION
Closes #2679. The epic's final feature child — **merge gate: the manual smoke session (AC3)**, checklist to follow once #2684 lands.

## Summary

`resident_store_max_lines` flips 0 → 65,535 (u16 wire ceiling; the 10MB byte gate and the #2673 pre-load refusal bound real exposure well below it). Wrapped/folded buffers keep the windowed path; `0` still disables.

**First-paint-then-promote** (the ticket's evidence gate fired): first resident build at the ceiling measured ~482ms vs ~0.7ms windowed — far past a frame budget — so residence engages in two frames: windowed fast paint + arm (`residence_armed` in the render cache, surviving the async writeback via the whole-cache copy), then promotion through the existing full-refresh machinery. The reviewer verified the flag can neither latch nor flap, that per-frame scrolling doesn't clear it (only layout rebuilds re-defer), and that arming lands on the file-open paint frame — so the first gesture is always already resident, resolving the open-then-flick starvation case.

Typing at 5k lines: ~1.0ms p50 / 1.1ms p95 (bench refreshed). Full suite under the new default: 9,806 tests green; conformance corpus untouched; Go 548; Swift green via plain build-for-testing.

## Test changes (all reviewed as honest)

Seven files: default-flip assertions strengthened (not weakened), two-frame engagement warmed before asserting, and the windowed-path suites (#2287 line-patch, 0xA1 delta cache) pin residence off because a resident buffer would bypass their target path entirely.

## Follow-ups (reviewer-recommended, post-merge)

- Optional `Renderer.Server` promotion nudge for the pathological static-file edge (not an AC blocker — arming rides the open-paint frame).
- Cosmetic: list `residence_armed` explicitly in `reset/0` for symmetry with `reset/1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1