### PR TITLE
feat(macos): scroll gestures settle like a native app

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00F5A6B58392069C8645B12C /* PresentationScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */; };
 		01EA03A621B455B253E6C7B3 /* MingaUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		058481A528AFB6C7225A067D /* MouseInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */; };
 		05EC70C811170EE160C5E4D9 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
@@ -60,6 +61,7 @@
 		332992D8BDA62035A5B57A41 /* PointingHandModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA51F390E49935563AB0AEB6 /* PointingHandModifier.swift */; };
 		364C48575BB95C9CA535A9C8 /* ProtocolReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */; };
 		3A23159F3A6631F0AD99A702 /* ExtensionViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA6F5FC902DD40A54F100FF /* ExtensionViewsTests.swift */; };
+		3A296C1AF0FDD2A0FDF83E7A /* PresentationScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */; };
 		3B03245A5A6EFA39B99B37F8 /* InputEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E717A483EC2E50C536785C /* InputEncoder.swift */; };
 		3CD15ED81AE384C93557B0C0 /* CompletionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA8938E70ED0123ACECD921 /* CompletionOverlay.swift */; };
 		41DCC27275D0E8E903EAA061 /* SidebarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */; };
@@ -176,6 +178,7 @@
 		A23A42248D022DE42E122D0B /* WorkspaceIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BD32DD25D2C6C5A90D898 /* WorkspaceIndicatorView.swift */; };
 		A29BB96B8F84AA489CBA0C5F /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
 		A409AE210CBAE48D4DCE47F7 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
+		A4329C17518FA82F5049A8EF /* PresentationScrollAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DADB6D964450D692B37217 /* PresentationScrollAnimatorTests.swift */; };
 		A4E838B0B19ED0B8F9CC4654 /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
 		A4F18CE5271CF85A08AFB06F /* ObservatoryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B23834E6FEB75E891AAFE2 /* ObservatoryState.swift */; };
 		A4F2EB67F3AC15AD8F8DAB32 /* SearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6104336F33C41EBE21B10F6 /* SearchState.swift */; };
@@ -187,6 +190,7 @@
 		A9551F6F0EB19FB618A8DB3E /* EditorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9448826AA38AB5FC0CEB79 /* EditorSettingsView.swift */; };
 		A9EE5F81AE818C176D03A6E3 /* RecoveryManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */; };
 		AB200EDC2BD9693D8D52CE98 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
+		AB445AD42EF996DC400DC5BF /* ScrollSettleReconcileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E15F1EAA861D1AAC8832D56 /* ScrollSettleReconcileTests.swift */; };
 		AB6380E87DD09C5259E74DE3 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E4036EB5EED196E5F367CC /* SignatureHelpState.swift */; };
 		AB804A6366BEFE62E30C929B /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		ABE7AA8517D1D7FBD7CC1816 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048C53BF025A1476EE8BC1A7 /* IMEComposition.swift */; };
@@ -245,6 +249,7 @@
 		DD0B958D8ACEFFEF3C1A50AE /* ViewModelComputedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22420E1CC772DAFB9A5043C2 /* ViewModelComputedTests.swift */; };
 		DF3B2A645C089F616B9DBD1B /* ProtocolEncoderDisconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */; };
 		DF3C7F2962B4563C54D82C8C /* PreviewSnapshotPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100F1DE1D6A8C5A2065AC582 /* PreviewSnapshotPolicyTests.swift */; };
+		E0F2C0021D714788A404E845 /* PresentationScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */; };
 		E139B8F9FCA100EBDDC042AB /* ExtensionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9302C5E00767815DD10A7 /* ExtensionOverlayView.swift */; };
 		E1601C8BE90E7A7CB8F7F5DA /* ResyncState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953A62EE436C9B1F73B97D07 /* ResyncState.swift */; };
 		E20D436BEA6628E24B9FFA2C /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
@@ -380,6 +385,7 @@
 		07B59F66E6260DE4B09FB563 /* FloatPopupState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatPopupState.swift; sourceTree = "<group>"; };
 		08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolTypes.swift; sourceTree = "<group>"; };
 		094C95682DA067B3D4E34720 /* ChangeSummarySidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummarySidebarView.swift; sourceTree = "<group>"; };
+		09DADB6D964450D692B37217 /* PresentationScrollAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationScrollAnimatorTests.swift; sourceTree = "<group>"; };
 		0A2CBCDF99282365E723D45A /* TabBarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarState.swift; sourceTree = "<group>"; };
 		0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedLineTexture.swift; sourceTree = "<group>"; };
 		0DCCEC5865DAE0AAF754F2E2 /* NotificationCenterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterState.swift; sourceTree = "<group>"; };
@@ -404,6 +410,7 @@
 		26134C841A15020D9C61E4F9 /* PreviewHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PreviewHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		26C02007D4036FC9C7D0FB71 /* SettingsStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStateTests.swift; sourceTree = "<group>"; };
 		28C576F6F2E779DEEABFE79C /* ToolManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolManagerView.swift; sourceTree = "<group>"; };
+		29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationScrollAnimator.swift; sourceTree = "<group>"; };
 		2BAB83B99298DE01101D3C60 /* PreviewFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewFixtures.swift; sourceTree = "<group>"; };
 		305F0E7D9158C236803224AA /* PreviewRegistry+FileTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreviewRegistry+FileTree.swift"; sourceTree = "<group>"; };
 		31DA375DF5D4047E01761926 /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
@@ -483,6 +490,7 @@
 		8A84218125A9F97DBE87F349 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		8AD9302C5E00767815DD10A7 /* ExtensionOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionOverlayView.swift; sourceTree = "<group>"; };
 		8D450D75A36486FD84AD6BB8 /* StatusBarUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarUpdate.swift; sourceTree = "<group>"; };
+		8E15F1EAA861D1AAC8832D56 /* ScrollSettleReconcileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollSettleReconcileTests.swift; sourceTree = "<group>"; };
 		912C5F808709BABFF3126DEE /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		92E717A483EC2E50C536785C /* InputEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputEncoder.swift; sourceTree = "<group>"; };
 		953A62EE436C9B1F73B97D07 /* ResyncState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResyncState.swift; sourceTree = "<group>"; };
@@ -776,6 +784,7 @@
 				13E89640A29C207B9040DC67 /* EditorView.swift */,
 				048C53BF025A1476EE8BC1A7 /* IMEComposition.swift */,
 				E4DCF10EBEB51624A4A1F428 /* InlineEditField.swift */,
+				29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */,
 				25503C21E0D55E1515A38C7D /* ScrollAccumulator.swift */,
 			);
 			path = Editor;
@@ -970,6 +979,7 @@
 				00EC9D6E3E77B85DF13841B4 /* PickerStateTests.swift */,
 				321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */,
 				9E27E6D9ACEB7DCD7F98FB0F /* PowerThermalPolicyTests.swift */,
+				09DADB6D964450D692B37217 /* PresentationScrollAnimatorTests.swift */,
 				100F1DE1D6A8C5A2065AC582 /* PreviewSnapshotPolicyTests.swift */,
 				3AB492F643770698E3E7F419 /* ProtocolCommandSizeTests.swift */,
 				47BD56B7D6D195D236F9BF40 /* ProtocolEncoderBinaryTests.swift */,
@@ -978,6 +988,7 @@
 				F220A60775A252A728477659 /* ProtocolTests.swift */,
 				E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */,
 				211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */,
+				8E15F1EAA861D1AAC8832D56 /* ScrollSettleReconcileTests.swift */,
 				26C02007D4036FC9C7D0FB71 /* SettingsStateTests.swift */,
 				1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */,
 				9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */,
@@ -1283,6 +1294,7 @@
 				4B2CF3C29FD0F4B63C7E7027 /* MingaWindow.swift in Sources */,
 				067369CB702835E93D254606 /* PipelineCache.swift in Sources */,
 				B7203DF9CF85663B0A266580 /* PowerThermalPolicy.swift in Sources */,
+				00F5A6B58392069C8645B12C /* PresentationScrollAnimator.swift in Sources */,
 				62628D5EAC0BCF980D2C59A3 /* PreviewRegistry+AgentChat.swift in Sources */,
 				77668ADDD66C267D11ACF44C /* PreviewRegistry+Chrome.swift in Sources */,
 				71384FFD82964586B710BD94 /* PreviewRegistry+FileTree.swift in Sources */,
@@ -1328,6 +1340,7 @@
 				8DBD574DB36A054FBCFC5DD8 /* MingaWindow.swift in Sources */,
 				E3B2DB94D802E1831C17474E /* PipelineCache.swift in Sources */,
 				68886327B4EB9F0766EB7DCD /* PowerThermalPolicy.swift in Sources */,
+				E0F2C0021D714788A404E845 /* PresentationScrollAnimator.swift in Sources */,
 				077AF22C34E2851B1F975C78 /* PreviewHostApp.swift in Sources */,
 				28E5444432A6B3AF05FE9762 /* PreviewRegistry+AgentChat.swift in Sources */,
 				6C48A19EB071FA951E15B3D9 /* PreviewRegistry+Chrome.swift in Sources */,
@@ -1511,6 +1524,8 @@
 				4E1EEFA65935DCE58528E02B /* PipelineCacheTests.swift in Sources */,
 				05EC70C811170EE160C5E4D9 /* PowerThermalPolicy.swift in Sources */,
 				BA72343308BCD0E078452868 /* PowerThermalPolicyTests.swift in Sources */,
+				3A296C1AF0FDD2A0FDF83E7A /* PresentationScrollAnimator.swift in Sources */,
+				A4329C17518FA82F5049A8EF /* PresentationScrollAnimatorTests.swift in Sources */,
 				CE8489B606217C3889536EBD /* PreviewRegistry+AgentChat.swift in Sources */,
 				A07B320CE2B623ADBA433732 /* PreviewRegistry+Chrome.swift in Sources */,
 				C1EFCE9E5449DB7B04C386E3 /* PreviewRegistry+FileTree.swift in Sources */,
@@ -1534,6 +1549,7 @@
 				A9EE5F81AE818C176D03A6E3 /* RecoveryManagerTests.swift in Sources */,
 				DCCC540FD702D8D37013173F /* ScrollAccumulator.swift in Sources */,
 				D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */,
+				AB445AD42EF996DC400DC5BF /* ScrollSettleReconcileTests.swift in Sources */,
 				9CC563AE009A1EA1A0BE0D9F /* SettingsStateTests.swift in Sources */,
 				41DCC27275D0E8E903EAA061 /* SidebarViewTests.swift in Sources */,
 				6700C63C4B7070D3388A7BD4 /* SlotAllocator.swift in Sources */,

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -375,7 +375,12 @@ final class CoreTextMetalRenderer {
                 gutterHoverRow: UInt16? = nil,
                 drawable: CAMetalDrawable, viewportSize: CGSize,
                 contentScale: Float, scrollOffset: SIMD2<Float> = .zero,
-                scrollTargetWindowId: UInt16? = nil) {
+                presentationWindowId: UInt16? = nil) {
+        // The window that owns the current presentation scroll offset. During a live gesture this
+        // is the gesture target; during a settle / spring-back / discrete ease the gesture target
+        // is already nil, so the view resolves this from the settle/elastic window instead. The
+        // gate below is unchanged: the offset applies only to this one pane.
+        let scrollTargetWindowId = presentationWindowId
 
         frameMetrics.reset()
         let renderSignpostID = OSSignpostID(log: renderLog)

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -215,6 +215,7 @@ final class EditorNSView: MTKView {
         (layer as? CAMetalLayer)?.maximumDrawableCount = 3
 
         coreTextRenderer.setCursorAnimationReduceMotionDisabled(NSWorkspace.shared.accessibilityDisplayShouldReduceMotion)
+        scrollAnimationsReduceMotionDisabled = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
     }
 
     @available(*, unavailable)
@@ -335,7 +336,13 @@ final class EditorNSView: MTKView {
         accessibilityTask = Task { @MainActor [weak self] in
             for await _ in NotificationCenter.default.notifications(named: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification) {
                 guard let self else { return }
-                self.coreTextRenderer.setCursorAnimationReduceMotionDisabled(NSWorkspace.shared.accessibilityDisplayShouldReduceMotion)
+                let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+                self.coreTextRenderer.setCursorAnimationReduceMotionDisabled(reduceMotion)
+                self.scrollAnimationsReduceMotionDisabled = reduceMotion
+                if reduceMotion {
+                    // Snap any in-flight presentation scroll animation straight to the grid.
+                    self.resetSmoothScrollState()
+                }
                 if SystemBlinkTiming.blinkingDisabled {
                     self.stopCursorBlink()
                 } else {
@@ -354,6 +361,61 @@ final class EditorNSView: MTKView {
     /// Client-only boundary elasticity applied when the target pane is already
     /// at the top or bottom of the committed overscan range.
     private var scrollElasticOffsetY: CGFloat = 0
+
+    /// Raw accumulated overscroll pull (px) feeding the asymptotic rubber-band curve (AC2).
+    private var scrollElasticRawDistance: CGFloat = 0
+
+    /// Presentation-only decay of the residual sub-line offset toward the grid.
+    /// Drives the AC1 gesture-end settle and the AC3 eased discrete-wheel tick.
+    private var scrollSettleAnimator = PresentationScrollAnimator()
+
+    /// Presentation-only spring-back of the rubber-band elastic offset on release (AC2).
+    private var scrollElasticAnimator = PresentationScrollAnimator()
+
+    /// Window whose committed anchor the settle/discrete animation reconciles against.
+    /// Distinct from `scrollTargetWindowId`: it outlives the live gesture so the momentum-end
+    /// settle can keep unconfirmed-line compensation stable while the BEAM's anchor eases
+    /// forward, eliminating the back-then-forward stutter (AC1).
+    private var scrollSettleWindowId: UInt16?
+
+    /// Window whose rubber-band spring-back (AC2) is in flight. Like `scrollSettleWindowId`, it
+    /// outlives the live gesture so the renderer keeps applying the elastic offset to that pane
+    /// after `scrollTargetWindowId` has been released.
+    private var scrollElasticWindowId: UInt16?
+
+    /// The pane that should receive the presentation scroll/elastic offset this frame.
+    /// Decouples "which window shows the offset" from "a gesture is active": during a settle or
+    /// spring-back the gesture target is nil (so `onScrollPresentationReset` discards can win),
+    /// but the offset must still land on the settling/elastic pane.
+    private var presentationScrollWindowId: UInt16? {
+        Self.presentationScrollWindowId(
+            targetWindowId: scrollTargetWindowId,
+            settleWindowId: scrollSettleWindowId,
+            elasticWindowId: scrollElasticWindowId
+        )
+    }
+
+    /// Resolves the pane that owns the presentation offset, preferring the live gesture target,
+    /// then the settling window, then the elastic spring-back window. Pure for testability.
+    nonisolated static func presentationScrollWindowId(targetWindowId: UInt16?, settleWindowId: UInt16?, elasticWindowId: UInt16?) -> UInt16? {
+        targetWindowId ?? settleWindowId ?? elasticWindowId
+    }
+
+    /// System Reduce Motion state, which disables all presentation scroll animations (AC4).
+    private var scrollAnimationsReduceMotionDisabled = false
+
+    /// Whether presentation scroll animations may run. Mirrors the cursor-animation
+    /// accessibility check: Reduce Motion turns every animation into an instant snap.
+    private var scrollAnimateEnabled: Bool { !scrollAnimationsReduceMotionDisabled }
+
+    /// Gesture-end settle duration (AC1): roughly 80-120ms per the acceptance criteria.
+    private static let scrollSettleDuration: CFTimeInterval = 0.10
+    /// Rubber-band spring-back duration on release (AC2).
+    private static let scrollElasticSpringBackDuration: CFTimeInterval = 0.35
+    /// Eased discrete-wheel tick duration (AC3).
+    private static let scrollDiscreteTickDuration: CFTimeInterval = 0.12
+    /// Rubber-band asymptote, in cells (AC2: about 3-4 cells of pull).
+    private static let scrollElasticLimitCells: CGFloat = 3.5
 
     /// Window receiving the current fractional smooth-scroll offset.
     /// Nil means the event location did not resolve to a scrollable editor window, so fractional offset is disabled instead of shifting every pane.
@@ -416,6 +478,7 @@ final class EditorNSView: MTKView {
         }
 
         clearSmoothScrollStateIfTargetWindowMissing()
+        advancePresentationScrollAnimation()
 
         let validGutterHoverWindowId = gutterHoverWindowId.flatMap { windowId in
             dispatcher.currentFrameWindowIds.contains(windowId) ? windowId : nil
@@ -433,7 +496,7 @@ final class EditorNSView: MTKView {
                                 drawable: drawable, viewportSize: drawableSize,
                                 contentScale: scale,
                                 scrollOffset: SIMD2<Float>(Float(scrollPixelOffset.x), Float(scrollPixelOffset.y + scrollElasticOffsetY)),
-                                scrollTargetWindowId: scrollTargetWindowId)
+                                presentationWindowId: presentationScrollWindowId)
         if coreTextRenderer.cursorAnimationGeneration != cursorAnimationGeneration {
             resetCursorBlink()
         }
@@ -1438,7 +1501,9 @@ final class EditorNSView: MTKView {
 
     override func scrollWheel(with event: NSEvent) {
         if event.hasPreciseScrollingDeltas && event.phase == .began {
-            finishSmoothScrollGesture()
+            // A fresh trackpad gesture supersedes any in-flight settle; the `.began`
+            // branch in handleTrackpadScroll performs the full reset.
+            cancelScrollAnimations()
         }
 
         let (row, col) = cellPosition(from: event)
@@ -1479,11 +1544,19 @@ final class EditorNSView: MTKView {
 
     private func handleTrackpadScroll(event: NSEvent, row: Int16, col: Int16, mods: UInt8) {
         if event.phase == .began {
+            cancelScrollAnimations()
             scrollAccumulator.reset()
+            scrollPixelOffset = .zero
             scrollElasticOffsetY = 0
             scrollTargetWindowId = nil
             scrollTargetCellPosition = nil
             resetScrollTrackingState()
+        } else if event.momentumPhase == .began || event.momentumPhase == .changed {
+            // Momentum resuming after finger-lift: cancel the tentative settle started at
+            // `.ended` so the animator and live momentum don't both drive the offset. The
+            // unconfirmed-line bookkeeping is preserved for continuity; momentum re-latches
+            // the target below via establishSmoothScrollTargetIfNeeded.
+            cancelScrollAnimations()
         }
 
         let (lockedDeltaX, lockedDeltaY) = axisLockedDeltas(
@@ -1554,41 +1627,24 @@ final class EditorNSView: MTKView {
         }
 
         if let sp = targetScrollPresentation {
-            if let lastAnchor = scrollLastConfirmedAnchorTop {
-                let anchorDelta = Int(sp.anchorTop) - Int(lastAnchor)
-                if anchorDelta != 0 {
-                    let prev = scrollUnconfirmedLines
-                    scrollUnconfirmedLines -= anchorDelta
-                    if prev >= 0 && scrollUnconfirmedLines < 0 { scrollUnconfirmedLines = 0 }
-                    if prev <= 0 && scrollUnconfirmedLines > 0 { scrollUnconfirmedLines = 0 }
-                    scrollLastConfirmedAnchorTop = sp.anchorTop
-                }
-            } else {
-                scrollLastConfirmedAnchorTop = sp.anchorTop
-            }
+            reconcileUnconfirmedLines(against: sp)
         }
 
         let compensatedOffsetY = scrollAccumulator.pixelOffsetY + CGFloat(scrollUnconfirmedLines) * effectiveCellHeight
         let translation = Self.presentationScrollTranslation(
             scrollPresentation: targetScrollPresentation,
-            scrollOffset: CGPoint(x: scrollAccumulator.pixelOffsetX, y: compensatedOffsetY),
+            scrollOffsetY: compensatedOffsetY,
             scrollDeltaY: lockedDeltaY,
-            currentElasticOffsetY: scrollElasticOffsetY,
-            cellHeight: effectiveCellHeight,
             payloadOverscanBefore: payloadOverscan.before,
             payloadOverscanAfter: payloadOverscan.after,
             boundaryBefore: boundaryAvailability.before,
             boundaryAfter: boundaryAvailability.after
         )
-        if translation.scrollOffset.y == 0, translation.elasticOffsetY != 0 {
-            scrollAccumulator.snapVertical()
-            scrollUnconfirmedLines = 0
-        }
         let suppressLocalOffset = scrollTargetWindowId == nil || isSelectionDragActive
-        scrollPixelOffset = suppressLocalOffset ? CGPoint(x: 0, y: 0) : translation.scrollOffset
-        scrollElasticOffsetY = suppressLocalOffset ? 0 : translation.elasticOffsetY
+        let offsetX = suppressLocalOffset ? 0 : scrollAccumulator.pixelOffsetX
+        applyPresentationTranslation(translation, offsetX: offsetX, suppressLocalOffset: suppressLocalOffset)
 
-        // Snap to zero when gesture/momentum ends
+        // Settle onto the grid when the gesture, then any following momentum, truly ends.
         if (event.phase == .ended || event.phase == .cancelled) && event.momentumPhase == [] {
             finishSmoothScrollGesture()
         }
@@ -1601,16 +1657,71 @@ final class EditorNSView: MTKView {
         needsDisplay = true
     }
 
+    /// Ends a smooth-scroll gesture. With animations enabled this eases the residual sub-line
+    /// offset to the grid (AC1) and springs the rubber band back (AC2) instead of snapping;
+    /// under Reduce Motion it hard-resets to the grid immediately.
     private func finishSmoothScrollGesture() {
+        guard scrollAnimateEnabled else {
+            hardResetSmoothScroll()
+            return
+        }
+
+        var startedAnimation = false
+
+        // AC2: release at an overscrolled edge springs the elastic offset back to 0.
+        if scrollElasticOffsetY != 0 {
+            scrollElasticAnimator.start(offset: scrollElasticOffsetY, duration: Self.scrollElasticSpringBackDuration)
+            scrollElasticRawDistance = 0
+            // Keep applying the elastic to its pane after the gesture target is released.
+            scrollElasticWindowId = scrollTargetWindowId ?? scrollElasticWindowId
+            startedAnimation = true
+        }
+
+        // AC1: ease the residual sub-line offset to the grid while unconfirmed-line
+        // reconciliation keeps the anchor easing forward (no back-then-forward stutter).
+        if let windowId = scrollTargetWindowId, scrollUnconfirmedLines != 0 || scrollAccumulator.pixelOffsetY != 0 {
+            let residual = scrollAccumulator.pixelOffsetY
+            scrollAccumulator.reset()
+            beginScrollSettle(windowId: windowId, residual: residual, duration: Self.scrollSettleDuration)
+            startedAnimation = true
+        }
+
+        // Release live-gesture-only state; the settle keeps reconciling via scrollSettleWindowId.
+        if let windowId = scrollTargetWindowId {
+            scrollPrefetchEpoch.removeValue(forKey: windowId)
+        }
+        scrollTargetWindowId = nil
+        scrollTargetCellPosition = nil
+        scrollAxisLock = .undecided
+        scrollAxisAccumulatedX = 0
+        scrollAxisAccumulatedY = 0
+
+        if !startedAnimation {
+            scrollAccumulator.reset()
+            scrollPixelOffset = .zero
+            scrollElasticOffsetY = 0
+            scrollElasticRawDistance = 0
+            scrollUnconfirmedLines = 0
+            scrollLastConfirmedAnchorTop = nil
+            scrollSettleWindowId = nil
+            scrollElasticWindowId = nil
+        }
+        needsDisplay = true
+    }
+
+    /// Instantly resets all smooth-scroll and animation state to the grid (Reduce Motion / cleanup).
+    private func hardResetSmoothScroll() {
         scrollAccumulator.reset()
-        scrollPixelOffset = CGPoint(x: 0, y: 0)
+        scrollPixelOffset = .zero
         scrollElasticOffsetY = 0
         if let windowId = scrollTargetWindowId {
             scrollPrefetchEpoch.removeValue(forKey: windowId)
         }
         scrollTargetWindowId = nil
         scrollTargetCellPosition = nil
+        cancelScrollAnimations()
         resetScrollTrackingState()
+        needsDisplay = true
     }
 
     private func resetScrollTrackingState() {
@@ -1619,6 +1730,131 @@ final class EditorNSView: MTKView {
         scrollAxisAccumulatedY = 0
         scrollUnconfirmedLines = 0
         scrollLastConfirmedAnchorTop = nil
+    }
+
+    /// Cancels in-flight presentation scroll animations without moving the offset.
+    /// Callers snap or reset the offset separately. Preserves unconfirmed-line bookkeeping
+    /// so a resuming momentum gesture stays continuous.
+    private func cancelScrollAnimations() {
+        scrollSettleAnimator.cancel()
+        scrollElasticAnimator.cancel()
+        scrollSettleWindowId = nil
+        scrollElasticWindowId = nil
+        scrollElasticRawDistance = 0
+    }
+
+    /// Begins the AC1/AC3 settle: decays `residual` px to the grid while the draw loop
+    /// reconciles unconfirmed lines against `windowId`'s committed anchor.
+    private func beginScrollSettle(windowId: UInt16, residual: CGFloat, duration: CFTimeInterval) {
+        if let current = scrollSettleWindowId, current != windowId {
+            // Settling switched panes: rebase the anchor reconciliation baseline.
+            scrollLastConfirmedAnchorTop = nil
+        }
+        scrollSettleWindowId = windowId
+        if scrollLastConfirmedAnchorTop == nil {
+            scrollLastConfirmedAnchorTop = guiState?.windowContents[windowId]?.scrollPresentation?.anchorTop
+        }
+        scrollSettleAnimator.start(offset: residual, duration: duration)
+        // Reflect the seeded offset immediately so this frame is continuous with the last.
+        scrollPixelOffset = CGPoint(x: scrollPixelOffset.x, y: residual + CGFloat(scrollUnconfirmedLines) * effectiveCellHeight)
+        needsDisplay = true
+    }
+
+    /// Reconciles the predicted unconfirmed-line count against a freshly committed anchor.
+    /// Keeps the rendered position stable as the BEAM's anchor catches up to local prediction.
+    private func reconcileUnconfirmedLines(against sp: GUIScrollPresentation) {
+        guard let lastAnchor = scrollLastConfirmedAnchorTop else {
+            scrollLastConfirmedAnchorTop = sp.anchorTop
+            return
+        }
+        let anchorDelta = Int(sp.anchorTop) - Int(lastAnchor)
+        guard anchorDelta != 0 else { return }
+        scrollUnconfirmedLines = Self.reconciledUnconfirmedLines(current: scrollUnconfirmedLines, anchorDelta: anchorDelta)
+        scrollLastConfirmedAnchorTop = sp.anchorTop
+    }
+
+    /// Advances the settle and rubber-band spring-back animations one frame.
+    ///
+    /// The MTKView is paused, so this self-retriggers `needsDisplay` while an animation runs,
+    /// mirroring the cursor animation's draw-loop self-retrigger. Discards always win: the state
+    /// is cleared out from under this by `resetSmoothScrollState()` before it runs.
+    private func advancePresentationScrollAnimation() {
+        guard scrollAnimateEnabled else { return }
+        let now = CACurrentMediaTime()
+        var keepAnimating = false
+
+        if let windowId = scrollSettleWindowId {
+            if let sp = guiState?.windowContents[windowId]?.scrollPresentation {
+                reconcileUnconfirmedLines(against: sp)
+            }
+            let residual = scrollSettleAnimator.offset(now: now)
+            let offsetY = residual + CGFloat(scrollUnconfirmedLines) * effectiveCellHeight
+            scrollPixelOffset = CGPoint(x: scrollPixelOffset.x, y: offsetY)
+            if scrollSettleAnimator.isActive {
+                keepAnimating = true
+            } else if scrollUnconfirmedLines == 0 {
+                // Fully settled: residual is exactly 0 and no unconfirmed lines remain.
+                scrollSettleWindowId = nil
+                scrollLastConfirmedAnchorTop = nil
+                scrollPixelOffset = CGPoint(x: scrollPixelOffset.x, y: 0)
+            }
+            // Otherwise the residual is done but whole (on-grid) lines are still committing;
+            // keep reconciling on future BEAM frames, which drive their own redraws.
+        }
+
+        if scrollElasticAnimator.isActive {
+            scrollElasticOffsetY = scrollElasticAnimator.offset(now: now)
+            if scrollElasticAnimator.isActive {
+                keepAnimating = true
+            } else {
+                scrollElasticOffsetY = 0
+                scrollElasticRawDistance = 0
+                scrollElasticWindowId = nil
+            }
+        }
+
+        if keepAnimating {
+            needsDisplay = true
+        }
+    }
+
+    /// Applies the pure translation decision to the live presentation offset and rubber band.
+    private func applyPresentationTranslation(_ translation: ScrollTranslation, offsetX: CGFloat, suppressLocalOffset: Bool) {
+        switch translation {
+        case .content(let offsetY):
+            // Scrolling within real content: no rubber band.
+            scrollElasticOffsetY = 0
+            scrollElasticRawDistance = 0
+            scrollPixelOffset = CGPoint(x: offsetX, y: suppressLocalOffset ? 0 : offsetY)
+
+        case .elastic(let pullDelta):
+            let limit = effectiveCellHeight * Self.scrollElasticLimitCells
+            // AC2: on the frame the elastic engages, fold the residual sub-line offset into the
+            // rubber band instead of popping it to 0. The whole-line overscroll can't be
+            // predicted past the boundary, so it snaps (usually 0 near the edge).
+            let enteringElastic = scrollElasticRawDistance == 0 && scrollElasticOffsetY == 0
+            if enteringElastic {
+                let residual = scrollAccumulator.pixelOffsetY
+                scrollAccumulator.snapVertical()
+                scrollUnconfirmedLines = 0
+                if scrollAnimateEnabled, residual != 0 {
+                    let sign: CGFloat = pullDelta >= 0 ? 1 : -1
+                    scrollElasticRawDistance = sign * PresentationScrollAnimator.inverseRubberBandDistance(offset: abs(residual), limit: limit)
+                }
+            } else {
+                scrollAccumulator.snapVertical()
+                scrollUnconfirmedLines = 0
+            }
+
+            if scrollAnimateEnabled && !suppressLocalOffset {
+                scrollElasticRawDistance += pullDelta
+                scrollElasticOffsetY = PresentationScrollAnimator.rubberBandOffset(rawDistance: scrollElasticRawDistance, limit: limit)
+            } else {
+                scrollElasticOffsetY = 0
+                scrollElasticRawDistance = 0
+            }
+            scrollPixelOffset = CGPoint(x: offsetX, y: 0)
+        }
     }
 
     private func axisLockedDeltas(deltaX: CGFloat, deltaY: CGFloat) -> (CGFloat, CGFloat) {
@@ -1655,16 +1891,28 @@ final class EditorNSView: MTKView {
         scrollElasticOffsetY = 0
         scrollTargetWindowId = nil
         scrollTargetCellPosition = nil
+        cancelScrollAnimations()
         resetScrollTrackingState()
         needsDisplay = true
     }
 
     private func clearSmoothScrollStateIfTargetWindowMissing() {
-        guard let targetWindowId = scrollTargetWindowId else { return }
-        guard dispatcher.currentFrameWindowIds.contains(targetWindowId), guiState?.windowContents[targetWindowId] != nil else {
+        // Covers the live gesture target and the settle / elastic windows that outlive it: if any
+        // pane owning presentation state has closed, drop the offset and cancel its animation so a
+        // stale whole-cell offset can't linger after the animator finishes on a vanished pane.
+        let available = Set(dispatcher.currentFrameWindowIds.filter { guiState?.windowContents[$0] != nil })
+        if Self.missingPresentationWindow(
+            candidateWindowIds: [scrollTargetWindowId, scrollSettleWindowId, scrollElasticWindowId],
+            availableWindowIds: available
+        ) {
             resetSmoothScrollState()
-            return
         }
+    }
+
+    /// Returns true when any non-nil presentation window is no longer available (frame missing or
+    /// content dropped), so the caller can clear stale offset/animation state. Pure for testability.
+    nonisolated static func missingPresentationWindow(candidateWindowIds: [UInt16?], availableWindowIds: Set<UInt16>) -> Bool {
+        candidateWindowIds.compactMap { $0 }.contains { !availableWindowIds.contains($0) }
     }
 
     nonisolated static func smoothScrollEventCellPosition(targetCell: (row: Int16, col: Int16)?, row: Int16, col: Int16) -> (row: Int16, col: Int16) {
@@ -1701,6 +1949,7 @@ final class EditorNSView: MTKView {
         scrollAccumulator.reset()
         scrollPixelOffset = CGPoint(x: 0, y: 0)
         scrollElasticOffsetY = 0
+        cancelScrollAnimations()
     }
 
     nonisolated static func shouldResetSmoothScrollTarget(currentTargetWindowId: UInt16?, pointerWindowId: UInt16?, hasPixelOffset: Bool) -> Bool {
@@ -1738,20 +1987,31 @@ final class EditorNSView: MTKView {
         return NSPoint(x: point.x, y: normalizedY)
     }
 
+    /// Result of classifying a vertical scroll delta against the pane's content and boundaries.
+    enum ScrollTranslation: Equatable {
+        /// Scrolling within real content: present the given fractional offset, no rubber band.
+        case content(offsetY: CGFloat)
+        /// Overscrolling past a document edge: the caller accumulates `pullDelta` (px) into the
+        /// rubber-band curve. The presented content offset is pinned to the boundary (0).
+        case elastic(pullDelta: CGFloat)
+    }
+
+    /// Classifies a vertical scroll delta as in-content or overscroll (rubber band).
+    ///
+    /// The rubber-band magnitude is no longer computed here: the caller maps accumulated pull
+    /// through `PresentationScrollAnimator.rubberBandOffset` so the curve is asymptotic and the
+    /// spring-back animation can own the offset on release (AC2).
     nonisolated static func presentationScrollTranslation(
         scrollPresentation: GUIScrollPresentation?,
-        scrollOffset: CGPoint,
+        scrollOffsetY: CGFloat,
         scrollDeltaY: CGFloat,
-        currentElasticOffsetY: CGFloat,
-        cellHeight: CGFloat,
         payloadOverscanBefore: Int,
         payloadOverscanAfter: Int,
         boundaryBefore: Int,
         boundaryAfter: Int
-    ) -> (scrollOffset: CGPoint, elasticOffsetY: CGFloat) {
-        guard scrollPresentation != nil else { return (scrollOffset, 0) }
-        guard cellHeight > 0 else { return (scrollOffset, 0) }
-        guard scrollDeltaY != 0 else { return (scrollOffset, currentElasticOffsetY) }
+    ) -> ScrollTranslation {
+        guard scrollPresentation != nil else { return .content(offsetY: scrollOffsetY) }
+        guard scrollDeltaY != 0 else { return .content(offsetY: scrollOffsetY) }
 
         let pullingTowardBefore = scrollDeltaY > 0
         let pullingTowardAfter = scrollDeltaY < 0
@@ -1759,19 +2019,28 @@ final class EditorNSView: MTKView {
             (pullingTowardBefore && payloadOverscanBefore > 0) ||
             (pullingTowardAfter && payloadOverscanAfter > 0)
         if hasRenderablePayload {
-            return (scrollOffset, 0)
+            return .content(offsetY: scrollOffsetY)
         }
 
         let pullingPastTop = pullingTowardBefore && boundaryBefore == 0
         let pullingPastBottom = pullingTowardAfter && boundaryAfter == 0
         guard pullingPastTop || pullingPastBottom else {
-            return (CGPoint(x: scrollOffset.x, y: 0), 0)
+            return .content(offsetY: 0)
         }
 
-        let maxElastic = max(cellHeight * 0.75, 1)
-        let dampedPull = -scrollDeltaY * 0.35
-        let elasticOffsetY = min(max(currentElasticOffsetY + dampedPull, -maxElastic), maxElastic)
-        return (CGPoint(x: scrollOffset.x, y: 0), elasticOffsetY)
+        return .elastic(pullDelta: -scrollDeltaY)
+    }
+
+    /// Reconciles a predicted unconfirmed-line count against a committed anchor delta.
+    ///
+    /// Subtracts the delta and clamps to 0 when the confirmation overshoots (sign flip), which
+    /// keeps the presentation from fighting an authoritative anchor jump. Pure for testability.
+    nonisolated static func reconciledUnconfirmedLines(current: Int, anchorDelta: Int) -> Int {
+        guard anchorDelta != 0 else { return current }
+        let next = current - anchorDelta
+        if current >= 0 && next < 0 { return 0 }
+        if current <= 0 && next > 0 { return 0 }
+        return next
     }
 
     nonisolated static func presentationScrollBoundaryAvailability(
@@ -1850,9 +2119,11 @@ final class EditorNSView: MTKView {
         if event.scrollingDeltaY > 0 {
             encoder.sendMouseEvent(row: row, col: col, button: MOUSE_SCROLL_UP,
                                    modifiers: mods, eventType: MOUSE_PRESS)
+            seedDiscreteScrollAnimation(row: row, col: col, lineDelta: -1)
         } else if event.scrollingDeltaY < 0 {
             encoder.sendMouseEvent(row: row, col: col, button: MOUSE_SCROLL_DOWN,
                                    modifiers: mods, eventType: MOUSE_PRESS)
+            seedDiscreteScrollAnimation(row: row, col: col, lineDelta: 1)
         }
         if event.scrollingDeltaX > 0 {
             encoder.sendMouseEvent(row: row, col: col, button: MOUSE_SCROLL_LEFT,
@@ -1861,6 +2132,25 @@ final class EditorNSView: MTKView {
             encoder.sendMouseEvent(row: row, col: col, button: MOUSE_SCROLL_RIGHT,
                                    modifiers: mods, eventType: MOUSE_PRESS)
         }
+    }
+
+    /// AC3: eases a discrete-wheel line motion locally on the same frame it arrives instead of
+    /// teleporting at round-trip latency. The GUI scrolls exactly one line per wheel event
+    /// (`@gui_scroll_lines`), so a `lineDelta` of ±1 is seeded as a predicted unconfirmed line;
+    /// the draw loop reconciles it against the committed anchor and decays the residual to the
+    /// grid. The scroll intent already sent above is unchanged: the BEAM sees an identical report.
+    private func seedDiscreteScrollAnimation(row: Int16, col: Int16, lineDelta: Int) {
+        guard scrollAnimateEnabled, !isSelectionDragActive else { return }
+        // Never fight a live trackpad gesture; discrete and precise input are mutually exclusive.
+        guard scrollTargetWindowId == nil else { return }
+        guard effectiveCellHeight > 0 else { return }
+        guard let windowId = smoothScrollTargetWindowId(row: row, col: col) else { return }
+
+        // Extend any in-flight settle from its current position so rapid ticks accumulate smoothly.
+        let residualNow = scrollSettleAnimator.offset()
+        scrollUnconfirmedLines += lineDelta
+        let residual = residualNow - CGFloat(lineDelta) * effectiveCellHeight
+        beginScrollSettle(windowId: windowId, residual: residual, duration: Self.scrollDiscreteTickDuration)
     }
 
     /// Maps a ScrollAccumulator.Event to a protocol mouse event.

--- a/macos/Sources/Views/Editor/PresentationScrollAnimator.swift
+++ b/macos/Sources/Views/Editor/PresentationScrollAnimator.swift
@@ -1,0 +1,98 @@
+import CoreGraphics
+import QuartzCore
+
+/// Shared presentation-only scroll animation ticker.
+///
+/// The editor's MTKView is paused (`enableSetNeedsDisplay`), so nothing redraws on its own.
+/// This animator decays a pixel offset toward the line grid (0) over a short duration and the
+/// owner self-retriggers `setNeedsDisplay` while `isActive` is true, mirroring the ~35ms cursor
+/// animation in `CoreTextMetalRenderer`. It is intentionally free of AppKit/NSView dependencies
+/// so the easing and rubber-band math can be unit tested.
+///
+/// All three gesture-boundary polish animations (settle at gesture end, rubber-band spring-back,
+/// eased discrete-wheel ticks) are the same shape: an offset that eases to exactly 0 (the grid).
+/// The animation is purely visual and discardable: it never changes what scroll intent the BEAM
+/// sees, and it always terminates on the grid.
+struct PresentationScrollAnimator {
+    /// True while an animation is in flight. The owner keeps redrawing while this holds.
+    private(set) var isActive = false
+
+    private var startTime: CFTimeInterval = 0
+    private var duration: CFTimeInterval = 0
+    private var startOffset: CGFloat = 0
+
+    /// Offsets smaller than this (in points) are not worth animating; snap instead.
+    static let minAnimatableOffset: CGFloat = 0.5
+
+    /// Begins an ease-out decay from `offset` px to exactly 0 over `duration` seconds.
+    /// A tiny offset or non-positive duration deactivates instead of animating.
+    mutating func start(offset: CGFloat, duration: CFTimeInterval, now: CFTimeInterval = CACurrentMediaTime()) {
+        guard duration > 0, abs(offset) >= Self.minAnimatableOffset else {
+            isActive = false
+            startOffset = 0
+            return
+        }
+        self.startOffset = offset
+        self.duration = duration
+        self.startTime = now
+        self.isActive = true
+    }
+
+    /// Immediately stops the animation. The owner is responsible for snapping to the grid.
+    mutating func cancel() {
+        isActive = false
+        startOffset = 0
+    }
+
+    /// Returns the current animated offset, deactivating and returning exactly 0 when finished.
+    mutating func offset(now: CFTimeInterval = CACurrentMediaTime()) -> CGFloat {
+        guard isActive else { return 0 }
+        let progress = Self.progress(now: now, startTime: startTime, duration: duration)
+        if progress >= 1 {
+            isActive = false
+            startOffset = 0
+            return 0
+        }
+        return Self.easedOffset(startOffset: startOffset, progress: progress)
+    }
+
+    // MARK: - Pure math (unit tested)
+
+    /// Normalized [0, 1] animation progress, clamped to the timeline bounds.
+    nonisolated static func progress(now: CFTimeInterval, startTime: CFTimeInterval, duration: CFTimeInterval) -> CGFloat {
+        guard duration > 0 else { return 1 }
+        return min(max(CGFloat((now - startTime) / duration), 0), 1)
+    }
+
+    /// Ease-out cubic decay of `startOffset` toward 0.
+    ///
+    /// Guarantees the endpoints exactly: `progress 0` returns `startOffset`, `progress 1` returns 0.
+    /// This is what makes the settle land precisely on the line grid regardless of the start value.
+    nonisolated static func easedOffset(startOffset: CGFloat, progress: CGFloat) -> CGFloat {
+        let clamped = min(max(progress, 0), 1)
+        let eased = 1 - pow(1 - clamped, 3) // ease-out cubic: 0 -> 1
+        return startOffset * (1 - eased)    // startOffset -> 0
+    }
+
+    /// macOS-native rubber-band map: asymptotic, monotonic, bounded, passes through the origin.
+    ///
+    /// As `rawDistance` grows the returned offset approaches `±limit` but never reaches it, so a
+    /// hard overscroll pull settles to roughly `limit` (about 3-4 cells) instead of a stiff clamp.
+    nonisolated static func rubberBandOffset(rawDistance: CGFloat, limit: CGFloat) -> CGFloat {
+        guard limit > 0 else { return 0 }
+        let sign: CGFloat = rawDistance < 0 ? -1 : 1
+        let magnitude = abs(rawDistance)
+        return sign * (1 - 1 / (magnitude / limit + 1)) * limit
+    }
+
+    /// Inverse of `rubberBandOffset`: the raw distance that produces a given displayed `offset`.
+    ///
+    /// Used to fold a residual sub-line offset into the rubber band on the frame elastic engages,
+    /// so the transition is continuous (no one-frame pop). Only valid for `|offset| < limit`.
+    nonisolated static func inverseRubberBandDistance(offset: CGFloat, limit: CGFloat) -> CGFloat {
+        guard limit > 0 else { return 0 }
+        let sign: CGFloat = offset < 0 ? -1 : 1
+        let magnitude = min(abs(offset), limit * 0.999)
+        return sign * magnitude / (1 - magnitude / limit)
+    }
+}

--- a/macos/Tests/MingaTests/MouseInputTests.swift
+++ b/macos/Tests/MingaTests/MouseInputTests.swift
@@ -551,20 +551,16 @@ struct MouseInputTests {
 
         let translation = EditorNSView.presentationScrollTranslation(
             scrollPresentation: presentation,
-            scrollOffset: CGPoint(x: 4, y: 8),
+            scrollOffsetY: 8,
             scrollDeltaY: 120,
-            currentElasticOffsetY: 0,
-            cellHeight: 20,
             payloadOverscanBefore: 0,
             payloadOverscanAfter: 1,
             boundaryBefore: 0,
             boundaryAfter: 1
         )
 
-        #expect(translation.scrollOffset.x == 4)
-        #expect(translation.scrollOffset.y == 0)
-        #expect(translation.elasticOffsetY < 0)
-        #expect(abs(translation.elasticOffsetY) <= 15)
+        // Pulling past the top: the caller feeds the negative pull into the rubber-band curve.
+        #expect(translation == .elastic(pullDelta: -120))
     }
 
     @Test("bottom boundary smooth scroll becomes bounded elastic while content stays clamped")
@@ -585,20 +581,16 @@ struct MouseInputTests {
 
         let translation = EditorNSView.presentationScrollTranslation(
             scrollPresentation: presentation,
-            scrollOffset: CGPoint(x: 4, y: 8),
+            scrollOffsetY: 8,
             scrollDeltaY: -120,
-            currentElasticOffsetY: 0,
-            cellHeight: 20,
             payloadOverscanBefore: 1,
             payloadOverscanAfter: 0,
             boundaryBefore: 1,
             boundaryAfter: 0
         )
 
-        #expect(translation.scrollOffset.x == 4)
-        #expect(translation.scrollOffset.y == 0)
-        #expect(translation.elasticOffsetY > 0)
-        #expect(abs(translation.elasticOffsetY) <= 15)
+        // Pulling past the bottom: the caller feeds the positive pull into the rubber-band curve.
+        #expect(translation == .elastic(pullDelta: 120))
     }
 
     @Test("middle smooth scroll keeps normal content offset")
@@ -619,19 +611,16 @@ struct MouseInputTests {
 
         let translation = EditorNSView.presentationScrollTranslation(
             scrollPresentation: presentation,
-            scrollOffset: CGPoint(x: 4, y: 8),
+            scrollOffsetY: 8,
             scrollDeltaY: 12,
-            currentElasticOffsetY: 3,
-            cellHeight: 20,
             payloadOverscanBefore: 1,
             payloadOverscanAfter: 1,
             boundaryBefore: 1,
             boundaryAfter: 1
         )
 
-        #expect(translation.scrollOffset.x == 4)
-        #expect(translation.scrollOffset.y == 8)
-        #expect(translation.elasticOffsetY == 0)
+        // Renderable payload exists in the pull direction: present the content offset, no elastic.
+        #expect(translation == .content(offsetY: 8))
     }
 
     @Test("smooth scroll clamps when document has rows but payload cannot render them")
@@ -652,19 +641,16 @@ struct MouseInputTests {
 
         let translation = EditorNSView.presentationScrollTranslation(
             scrollPresentation: presentation,
-            scrollOffset: CGPoint(x: 4, y: 8),
+            scrollOffsetY: 8,
             scrollDeltaY: 12,
-            currentElasticOffsetY: 3,
-            cellHeight: 20,
             payloadOverscanBefore: 0,
             payloadOverscanAfter: 0,
             boundaryBefore: 5,
             boundaryAfter: 7
         )
 
-        #expect(translation.scrollOffset.x == 4)
-        #expect(translation.scrollOffset.y == 0)
-        #expect(translation.elasticOffsetY == 0)
+        // No renderable payload but content still exists at the boundary: clamp to grid, no elastic.
+        #expect(translation == .content(offsetY: 0))
     }
 
     @Test("mid-document wrapped scroll with no payload rows before does not bounce at top")
@@ -709,10 +695,8 @@ struct MouseInputTests {
         let boundary = EditorNSView.presentationScrollBoundaryAvailability(for: content, scrollPresentation: presentation)
         let translation = EditorNSView.presentationScrollTranslation(
             scrollPresentation: presentation,
-            scrollOffset: CGPoint(x: 4, y: 8),
+            scrollOffsetY: 8,
             scrollDeltaY: 120,
-            currentElasticOffsetY: 0,
-            cellHeight: 20,
             payloadOverscanBefore: payload.before,
             payloadOverscanAfter: payload.after,
             boundaryBefore: boundary.before,
@@ -721,9 +705,8 @@ struct MouseInputTests {
 
         #expect(payload.before == 0)
         #expect(boundary.before == 1)
-        #expect(translation.scrollOffset.x == 4)
-        #expect(translation.scrollOffset.y == 0)
-        #expect(translation.elasticOffsetY == 0)
+        // Content still exists above (boundary.before == 1), so no top rubber band.
+        #expect(translation == .content(offsetY: 0))
     }
 
     @Test("mouseMoved sends motion event")

--- a/macos/Tests/MingaTests/PresentationScrollAnimatorTests.swift
+++ b/macos/Tests/MingaTests/PresentationScrollAnimatorTests.swift
@@ -1,0 +1,124 @@
+/// Tests for the shared presentation scroll animation ticker and its pure math (issue #2664).
+
+import Testing
+import Foundation
+import CoreGraphics
+
+@Suite("PresentationScrollAnimator easing")
+struct PresentationScrollAnimatorEasingTests {
+
+    @Test("progress clamps to the timeline bounds")
+    func progressClamps() {
+        #expect(PresentationScrollAnimator.progress(now: 0, startTime: 1, duration: 0.1) == 0)
+        #expect(PresentationScrollAnimator.progress(now: 5, startTime: 1, duration: 0.1) == 1)
+        let mid = PresentationScrollAnimator.progress(now: 1.05, startTime: 1, duration: 0.1)
+        #expect(abs(mid - 0.5) < 1e-9)
+    }
+
+    @Test("zero duration is treated as complete")
+    func zeroDurationComplete() {
+        #expect(PresentationScrollAnimator.progress(now: 1, startTime: 1, duration: 0) == 1)
+    }
+
+    @Test("eased offset hits its endpoints exactly so the settle lands on the grid")
+    func easedOffsetEndpoints() {
+        // At progress 0 the full start offset is returned.
+        #expect(PresentationScrollAnimator.easedOffset(startOffset: 12.5, progress: 0) == 12.5)
+        #expect(PresentationScrollAnimator.easedOffset(startOffset: -7, progress: 0) == -7)
+        // At progress 1 the offset is exactly 0 for any start value: always terminates on the grid.
+        #expect(PresentationScrollAnimator.easedOffset(startOffset: 12.5, progress: 1) == 0)
+        #expect(PresentationScrollAnimator.easedOffset(startOffset: -7, progress: 1) == 0)
+        #expect(PresentationScrollAnimator.easedOffset(startOffset: 1234.5, progress: 1) == 0)
+    }
+
+    @Test("eased offset decays monotonically toward zero")
+    func easedOffsetMonotonic() {
+        let start: CGFloat = 20
+        var previous = PresentationScrollAnimator.easedOffset(startOffset: start, progress: 0)
+        var p: CGFloat = 0.05
+        while p <= 1.0001 {
+            let value = PresentationScrollAnimator.easedOffset(startOffset: start, progress: p)
+            #expect(value <= previous)   // magnitude never increases for a positive start
+            #expect(value >= 0)
+            previous = value
+            p += 0.05
+        }
+    }
+
+    @Test("animator terminates exactly on the grid")
+    func animatorTerminatesOnGrid() {
+        var animator = PresentationScrollAnimator()
+        animator.start(offset: 15, duration: 0.1, now: 0)
+        #expect(animator.isActive)
+        // Mid-flight the offset is between the start and the grid.
+        let mid = animator.offset(now: 0.05)
+        #expect(mid > 0 && mid < 15)
+        #expect(animator.isActive)
+        // Past the end it snaps to exactly 0 and deactivates.
+        let end = animator.offset(now: 0.2)
+        #expect(end == 0)
+        #expect(!animator.isActive)
+    }
+
+    @Test("tiny offsets do not start an animation")
+    func tinyOffsetNoAnimation() {
+        var animator = PresentationScrollAnimator()
+        animator.start(offset: 0.1, duration: 0.1, now: 0)
+        #expect(!animator.isActive)
+        #expect(animator.offset(now: 0.05) == 0)
+    }
+
+    @Test("cancel stops the animation without reporting an offset")
+    func cancelStops() {
+        var animator = PresentationScrollAnimator()
+        animator.start(offset: 15, duration: 0.1, now: 0)
+        animator.cancel()
+        #expect(!animator.isActive)
+        #expect(animator.offset(now: 0.05) == 0)
+    }
+}
+
+@Suite("PresentationScrollAnimator rubber band")
+struct PresentationScrollAnimatorRubberBandTests {
+
+    @Test("rubber band passes through the origin")
+    func passesThroughOrigin() {
+        #expect(PresentationScrollAnimator.rubberBandOffset(rawDistance: 0, limit: 70) == 0)
+    }
+
+    @Test("rubber band is monotonic and bounded by the limit")
+    func monotonicAndBounded() {
+        let limit: CGFloat = 70 // ~3.5 cells at cellHeight 20
+        var previous = PresentationScrollAnimator.rubberBandOffset(rawDistance: 0, limit: limit)
+        var raw: CGFloat = 5
+        while raw <= 2000 {
+            let value = PresentationScrollAnimator.rubberBandOffset(rawDistance: raw, limit: limit)
+            #expect(value > previous)      // strictly increasing with pull
+            #expect(value < limit)         // never reaches the asymptote
+            previous = value
+            raw += 5
+        }
+        // A very large pull approaches but stays under the limit.
+        let huge = PresentationScrollAnimator.rubberBandOffset(rawDistance: 100_000, limit: limit)
+        #expect(huge < limit)
+        #expect(huge > limit * 0.99)
+    }
+
+    @Test("rubber band is symmetric across the origin")
+    func symmetric() {
+        let limit: CGFloat = 70
+        let positive = PresentationScrollAnimator.rubberBandOffset(rawDistance: 40, limit: limit)
+        let negative = PresentationScrollAnimator.rubberBandOffset(rawDistance: -40, limit: limit)
+        #expect(abs(positive + negative) < 1e-9)
+    }
+
+    @Test("inverse rubber band round-trips within the limit")
+    func inverseRoundTrips() {
+        let limit: CGFloat = 70
+        for offset: CGFloat in [1, 5, 12.5, 30, 55] {
+            let raw = PresentationScrollAnimator.inverseRubberBandDistance(offset: offset, limit: limit)
+            let backToOffset = PresentationScrollAnimator.rubberBandOffset(rawDistance: raw, limit: limit)
+            #expect(abs(backToOffset - offset) < 1e-6)
+        }
+    }
+}

--- a/macos/Tests/MingaTests/ScrollSettleReconcileTests.swift
+++ b/macos/Tests/MingaTests/ScrollSettleReconcileTests.swift
@@ -1,0 +1,161 @@
+/// Tests for gesture-end settle / discrete-tick reconciliation math (issue #2664).
+
+import Testing
+import Foundation
+import CoreGraphics
+import simd
+
+@Suite("Scroll settle unconfirmed-line reconciliation")
+struct ScrollSettleReconcileTests {
+
+    @Test("no anchor delta leaves the prediction untouched")
+    func noDelta() {
+        #expect(EditorNSView.reconciledUnconfirmedLines(current: 3, anchorDelta: 0) == 3)
+        #expect(EditorNSView.reconciledUnconfirmedLines(current: -2, anchorDelta: 0) == -2)
+    }
+
+    @Test("a matching commit brings the prediction to zero")
+    func matchingCommit() {
+        #expect(EditorNSView.reconciledUnconfirmedLines(current: 3, anchorDelta: 3) == 0)
+        #expect(EditorNSView.reconciledUnconfirmedLines(current: -2, anchorDelta: -2) == 0)
+    }
+
+    @Test("a partial commit reduces the prediction toward zero")
+    func partialCommit() {
+        #expect(EditorNSView.reconciledUnconfirmedLines(current: 3, anchorDelta: 1) == 2)
+        #expect(EditorNSView.reconciledUnconfirmedLines(current: -3, anchorDelta: -1) == -2)
+    }
+
+    @Test("an overshooting commit clamps to zero instead of flipping sign")
+    func overshootClamps() {
+        // A BEAM jump larger than the prediction (e.g. ctrl-d racing a settle) must not
+        // invert the prediction and animate the wrong way; it clamps to the grid.
+        #expect(EditorNSView.reconciledUnconfirmedLines(current: 2, anchorDelta: 5) == 0)
+        #expect(EditorNSView.reconciledUnconfirmedLines(current: -2, anchorDelta: -5) == 0)
+    }
+}
+
+@Suite("Discrete-tick easing converges to the committed anchor")
+struct DiscreteTickEasingTests {
+
+    /// Rendered presentation offset during a discrete tick: the decaying residual plus the
+    /// whole-line prediction still awaiting the BEAM's committed anchor.
+    private func renderedOffset(residualStart: CGFloat, unconfirmed: Int, cellHeight: CGFloat, progress: CGFloat) -> CGFloat {
+        PresentationScrollAnimator.easedOffset(startOffset: residualStart, progress: progress)
+            + CGFloat(unconfirmed) * cellHeight
+    }
+
+    @Test("a one-line tick starts at rest and slides exactly one line")
+    func slidesOneLine() {
+        let cell: CGFloat = 20
+        // Seed: predict +1 line (scroll down), residual = -cell so the content starts unmoved.
+        let residualStart = -cell
+        let unconfirmed = 1
+
+        // At the first frame the content is still at its old position (no jump).
+        let atStart = renderedOffset(residualStart: residualStart, unconfirmed: unconfirmed, cellHeight: cell, progress: 0)
+        #expect(atStart == 0)
+
+        // As the residual decays (before the anchor commits) it slides toward one full line.
+        let atEnd = renderedOffset(residualStart: residualStart, unconfirmed: unconfirmed, cellHeight: cell, progress: 1)
+        #expect(atEnd == cell)
+    }
+
+    @Test("the slide is monotonic toward the target line")
+    func monotonicSlide() {
+        let cell: CGFloat = 20
+        var previous = renderedOffset(residualStart: -cell, unconfirmed: 1, cellHeight: cell, progress: 0)
+        var p: CGFloat = 0.05
+        while p <= 1.0001 {
+            let value = renderedOffset(residualStart: -cell, unconfirmed: 1, cellHeight: cell, progress: p)
+            #expect(value >= previous)
+            #expect(value <= cell + 1e-9)
+            previous = value
+            p += 0.05
+        }
+    }
+
+    @Test("once the anchor commits, the offset rests exactly on the grid")
+    func restsOnGrid() {
+        let cell: CGFloat = 20
+        // The BEAM commits the predicted line: reconcile to zero unconfirmed lines.
+        let unconfirmedAfterCommit = EditorNSView.reconciledUnconfirmedLines(current: 1, anchorDelta: 1)
+        #expect(unconfirmedAfterCommit == 0)
+        // With the residual fully decayed and the anchor committed, the presentation is on the grid.
+        let rested = renderedOffset(residualStart: -cell, unconfirmed: unconfirmedAfterCommit, cellHeight: cell, progress: 1)
+        #expect(rested == 0)
+    }
+
+    @Test("a scroll-up tick slides the opposite direction and still rests on the grid")
+    func scrollUpRestsOnGrid() {
+        let cell: CGFloat = 20
+        // Scroll up: predict -1 line, residual = +cell.
+        let atStart = renderedOffset(residualStart: cell, unconfirmed: -1, cellHeight: cell, progress: 0)
+        #expect(atStart == 0)
+        let atEnd = renderedOffset(residualStart: cell, unconfirmed: -1, cellHeight: cell, progress: 1)
+        #expect(atEnd == -cell)
+        let unconfirmedAfterCommit = EditorNSView.reconciledUnconfirmedLines(current: -1, anchorDelta: -1)
+        let rested = renderedOffset(residualStart: cell, unconfirmed: unconfirmedAfterCommit, cellHeight: cell, progress: 1)
+        #expect(rested == 0)
+    }
+}
+
+@Suite("Presentation offset reaches the settling pane (render-path gate)")
+struct PresentationScrollWindowResolutionTests {
+
+    @Test("live gesture target owns the offset")
+    func livePreferred() {
+        let resolved = EditorNSView.presentationScrollWindowId(targetWindowId: 3, settleWindowId: 9, elasticWindowId: 8)
+        #expect(resolved == 3)
+    }
+
+    @Test("target nil falls back to the settling window so the settle stays visible")
+    func settleFallback() {
+        let resolved = EditorNSView.presentationScrollWindowId(targetWindowId: nil, settleWindowId: 5, elasticWindowId: nil)
+        #expect(resolved == 5)
+        // The renderer gate applies the offset to exactly that pane, not to every window.
+        let offset = SIMD2<Float>(0, 12)
+        #expect(CoreTextMetalRenderer.smoothScrollOffset(for: 5, targetWindowId: resolved, scrollOffsetPx: offset) == offset)
+        #expect(CoreTextMetalRenderer.smoothScrollOffset(for: 6, targetWindowId: resolved, scrollOffsetPx: offset) == .zero)
+    }
+
+    @Test("target nil and no settle falls back to the elastic spring-back window")
+    func elasticFallback() {
+        let resolved = EditorNSView.presentationScrollWindowId(targetWindowId: nil, settleWindowId: nil, elasticWindowId: 7)
+        #expect(resolved == 7)
+    }
+
+    @Test("all windows nil resolves to nil so the renderer zeroes the offset")
+    func allNilZeroes() {
+        let resolved = EditorNSView.presentationScrollWindowId(targetWindowId: nil, settleWindowId: nil, elasticWindowId: nil)
+        #expect(resolved == nil)
+        // Mirrors the state after a discard cancels an in-flight settle: no pane shows the offset.
+        #expect(CoreTextMetalRenderer.smoothScrollOffset(for: 5, targetWindowId: resolved, scrollOffsetPx: SIMD2<Float>(0, 12)) == .zero)
+    }
+}
+
+@Suite("Settle state clears when its pane closes (cleanup guard)")
+struct PresentationScrollCleanupGuardTests {
+
+    @Test("no presentation windows means nothing to clean up")
+    func noneToClean() {
+        #expect(EditorNSView.missingPresentationWindow(candidateWindowIds: [nil, nil, nil], availableWindowIds: [1, 2]) == false)
+    }
+
+    @Test("a present settle window is not treated as missing")
+    func settleWindowPresent() {
+        // target nil (settling), settle window 2 still live.
+        #expect(EditorNSView.missingPresentationWindow(candidateWindowIds: [nil, 2, nil], availableWindowIds: [1, 2]) == false)
+    }
+
+    @Test("a settle window that closed mid-settle is detected as missing")
+    func settleWindowClosed() {
+        // The settling pane 9 is gone from the live set: the guard must reset.
+        #expect(EditorNSView.missingPresentationWindow(candidateWindowIds: [nil, 9, nil], availableWindowIds: [1, 2]) == true)
+    }
+
+    @Test("a closed elastic spring-back window is detected as missing")
+    func elasticWindowClosed() {
+        #expect(EditorNSView.missingPresentationWindow(candidateWindowIds: [nil, nil, 4], availableWindowIds: [1, 2]) == true)
+    }
+}


### PR DESCRIPTION
Closes #2664 (minga-ux feel track, ranked #1 by feel-per-effort).

## Summary

The last 100ms of every scroll gesture stops snapping:

- **Animated settle (AC1):** momentum end eases the fractional offset to the grid over 100ms, preserving unconfirmed lines — the back-then-forward stutter is gone. Tentative settle on finger-lift, cancelled cleanly if momentum follows.
- **Real rubber band (AC2):** asymptotic pull bounded at 3.5 cells, 350ms spring-back, and the `snapVertical` fractional pop is folded continuously into the band via the curve's inverse.
- **Eased wheel ticks (AC3):** discrete ticks seed the predicted line same-frame and ease toward the committed anchor (intent reporting byte-identical — the seed never touches the encoder).
- **Reduce Motion (AC4):** gates all three, live-updating, matching the cursor animation's existing check.

One shared `PresentationScrollAnimator` (pure, unit-tested math) drives everything through the paused MTKView's self-retriggered draw pattern — no continuous GPU loop.

## The review catch worth reading

The first review round **blocked** on a real one: the animations computed but never rendered — the renderer's offset gate keyed on `scrollTargetWindowId`, which is necessarily nil during post-gesture animations (that nil is what lets discards win). The fix decouples "which pane shows the offset" (resolved target → settle → elastic) from "gesture active" (still keyed on target, so `scroll_seq`/anchor discards cancel everything instantly). The targeted re-review confirmed all five seams with line evidence, including that `currentFrameWindowIds` is BEAM-batch-only so the extended cleanup guard can't false-positive mid-settle.

## Boundaries held (settled architecture)

Never rests off the line grid; never animates BEAM-initiated jumps (`ctrl-d`/`zz`/search stay instant); discards win instantly; TUI untouched.

## Tests

946 Swift tests pass; 12 new across four suites: easing endpoints/monotonicity, rubber-band bounds/inverse round-trip, discrete convergence to committed anchor, render-path resolution (the actual bug's seam), and the cleanup guard contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1