### PR TITLE
fix(macos): editor background fills to the frame edge

### DIFF
--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -520,6 +520,37 @@ final class CoreTextMetalRenderer {
                 )
                 let contentBottomPx = min(contentTopPx + Float(committedVisibleRows) * displayCellH * scale, Float(viewportSize.height))
 
+                // Editor background fill for the pane. The semantic content path
+                // rasterizes rows into text-width, transparent-background textures,
+                // so every pixel that is not covered by text, gutter, or an overlay
+                // shows through to whatever is behind it. Relying on the Metal clear
+                // color alone leaves the remainder below the last row painted by an
+                // implicit global color; here we paint it explicitly in the editor
+                // background so the fill always reaches the status bar edge.
+                //
+                // The bottom-most pane extends to the full drawable height so both
+                // remainder classes are covered: the raw-cell remainder (view height
+                // not a multiple of the cell height) and the effective-rows remainder
+                // (spaced rows * displayCellH < view height). Interior panes stop at
+                // their neighbor's top so horizontal split separators and stacked
+                // panes (including the agent panel edge) have no band above them.
+                if windowBounds.width > 0,
+                   let fill = CoreTextMetalRenderer.windowBackgroundFillBounds(
+                       paneTopRow: Int(paneGeometry?.textRect.row ?? gutter.contentRow),
+                       paneRows: committedVisibleRows,
+                       totalRows: Int(frameState.rows),
+                       displayCellH: displayCellH,
+                       scale: scale,
+                       viewportHeight: Float(viewportSize.height)
+                   ) {
+                    var bgFill = QuadGPU()
+                    bgFill.position = SIMD2<Float>(windowBounds.x, fill.top)
+                    bgFill.size = SIMD2<Float>(windowBounds.width, fill.bottom - fill.top)
+                    bgFill.color = defaultBg
+                    bgFill.alpha = 1.0
+                    bgQuads.append(bgFill)
+                }
+
                 if let cursorline = content.cursorline, cursorline.bg != 0 {
                     let yPos = scrollableWindowRowOffset + Float(cursorline.row) * displayCellH * scale
                     if let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: yPos, height: displayCellH * scale, top: contentTopPx, bottom: contentBottomPx) {
@@ -1963,6 +1994,46 @@ final class CoreTextMetalRenderer {
             return bottom > top ? (top, bottom) : nil
         }
         return nil
+    }
+
+    /// Vertical span (in device pixels) of a window's editor-background fill.
+    ///
+    /// Fills from the pane's top row down to its bottom. A pane whose bottom row
+    /// reaches (or passes) the grid bottom owns the leftover strip down to the
+    /// drawable edge, so the remainder below the last text row is painted the
+    /// editor background instead of exposing the clear color. This covers both
+    /// the raw-cell remainder (view height not a multiple of the cell height) and
+    /// the effective-rows remainder (spaced rows * displayCellH < view height).
+    /// Interior panes stop at their neighbor's top so split separators and the
+    /// agent-panel edge have no band above them.
+    ///
+    /// - Parameters:
+    ///   - paneTopRow: The pane's top text row in grid rows.
+    ///   - paneRows: The pane's committed visible rows (spaced grid rows).
+    ///   - totalRows: The editor grid's total spaced rows (`frameState.rows`).
+    ///   - displayCellH: Spaced cell height in points (`cellH * lineSpacing`).
+    ///   - scale: Backing scale factor.
+    ///   - viewportHeight: Drawable height in device pixels.
+    /// - Returns: The fill's `(top, bottom)` in device pixels, or nil when empty.
+    nonisolated static func windowBackgroundFillBounds(
+        paneTopRow: Int,
+        paneRows: Int,
+        totalRows: Int,
+        displayCellH: Float,
+        scale: Float,
+        viewportHeight: Float
+    ) -> (top: Float, bottom: Float)? {
+        let top = min(Float(max(paneTopRow, 0)) * displayCellH * scale, viewportHeight)
+        let paneBottomRow = max(paneTopRow, 0) + max(paneRows, 0)
+        let bottom: Float
+        if paneBottomRow >= totalRows {
+            // Bottom-most pane: absorb the remainder down to the drawable edge.
+            bottom = viewportHeight
+        } else {
+            bottom = min(Float(paneBottomRow) * displayCellH * scale, viewportHeight)
+        }
+        guard bottom > top else { return nil }
+        return (top, bottom)
     }
 
     nonisolated static func windowWidthCols(gutter: Wire.WindowGutter, frameCols: UInt16) -> Int {

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -356,6 +356,108 @@ struct CoreTextMetalRendererCursorTests {
         #expect(bounds?.bottom == 384)
     }
 
+    // MARK: - Editor background remainder fill (#2687)
+
+    @Test("background fill absorbs the effective-rows remainder at 1.2 spacing")
+    func backgroundFillAbsorbsEffectiveRowsRemainder() {
+        // rawRows 21 at 1.2 spacing -> floor(21/1.2) = 17 effective rows.
+        // Cell height 10pt raw -> 12pt spaced. View height = 21 raw cells = 210px.
+        // The 17 spaced rows only reach 17 * 12 = 204px, leaving a 6px band that
+        // the fill must absorb by extending the bottom-most pane to 210px.
+        let fill = CoreTextMetalRenderer.windowBackgroundFillBounds(
+            paneTopRow: 0,
+            paneRows: 17,
+            totalRows: 17,
+            displayCellH: 12,
+            scale: 1,
+            viewportHeight: 210
+        )
+
+        #expect(fill?.top == 0)
+        #expect(fill?.bottom == 210)
+        // The remainder below the last spaced row is painted, not exposed.
+        #expect((fill?.bottom ?? 0) > 17 * 12)
+    }
+
+    @Test("background fill matches the view height at 1.0 spacing baseline")
+    func backgroundFillIdentityAtUnitSpacing() {
+        // At 1.0 spacing 21 rows * 10px = 210px exactly equals the view height.
+        let fill = CoreTextMetalRenderer.windowBackgroundFillBounds(
+            paneTopRow: 0,
+            paneRows: 21,
+            totalRows: 21,
+            displayCellH: 10,
+            scale: 1,
+            viewportHeight: 210
+        )
+
+        #expect(fill?.top == 0)
+        #expect(fill?.bottom == 210)
+    }
+
+    @Test("background fill absorbs the raw-cell remainder")
+    func backgroundFillAbsorbsRawCellRemainder() {
+        // View height 215px is not a multiple of the 10px cell height: floor gives
+        // 21 rows reaching 210px, leaving a 5px raw-cell remainder the fill covers.
+        let fill = CoreTextMetalRenderer.windowBackgroundFillBounds(
+            paneTopRow: 0,
+            paneRows: 21,
+            totalRows: 21,
+            displayCellH: 10,
+            scale: 1,
+            viewportHeight: 215
+        )
+
+        #expect(fill?.bottom == 215)
+        #expect((fill?.bottom ?? 0) > 21 * 10)
+    }
+
+    @Test("interior split pane stops at its neighbor instead of the view bottom")
+    func backgroundFillInteriorPaneStopsAtNeighbor() {
+        // Stacked split: top pane rows 0..<10, bottom pane rows 10..<17 of a
+        // 17-row grid. displayCellH 12, view height 210.
+        let top = CoreTextMetalRenderer.windowBackgroundFillBounds(
+            paneTopRow: 0,
+            paneRows: 10,
+            totalRows: 17,
+            displayCellH: 12,
+            scale: 1,
+            viewportHeight: 210
+        )
+        // The top pane ends at the separator (10 * 12 = 120), never the view bottom.
+        #expect(top?.top == 0)
+        #expect(top?.bottom == 120)
+
+        let bottom = CoreTextMetalRenderer.windowBackgroundFillBounds(
+            paneTopRow: 10,
+            paneRows: 7,
+            totalRows: 17,
+            displayCellH: 12,
+            scale: 1,
+            viewportHeight: 210
+        )
+        // The bottom pane absorbs the remainder down to the view bottom, so the
+        // two fills tile the full height with no gap above the separator.
+        #expect(bottom?.top == 120)
+        #expect(bottom?.bottom == 210)
+    }
+
+    @Test("background fill applies the backing scale to the pane top")
+    func backgroundFillAppliesScale() {
+        // Retina: paneTopRow 10 at 12pt spaced height, scale 2 -> top = 240px.
+        let fill = CoreTextMetalRenderer.windowBackgroundFillBounds(
+            paneTopRow: 10,
+            paneRows: 7,
+            totalRows: 17,
+            displayCellH: 12,
+            scale: 2,
+            viewportHeight: 500
+        )
+
+        #expect(fill?.top == 240)
+        #expect(fill?.bottom == 500)
+    }
+
     @Test("presentation scroll offset keeps negative x clamped when horizontal scroll is at zero")
     func presentationScrollOffsetKeepsNegativeXClampedAtLeftEdge() {
         let suppressed = CoreTextMetalRenderer.presentationScrollOffset(scrollLeft: 0, scrollOffsetPx: SIMD2<Float>(-12, 5))


### PR DESCRIPTION
Closes #2687 (the remainder-band report).

## Root cause

The semantic rendering path has **no explicit editor-background fill** — that responsibility was silently dropped when the cell-grid path was deleted (`eb6c7cbf5`), leaving the Metal clear color as the sole backstop. The effective-rows floor exposes it: at the default 1.2 spacing, `floor(21/1.2) = 17` rows × spaced height covers 20.4 of ~21 cells, and the uncovered strip (plus the raw-cell remainder) shows the clear. Not a regression of a prior band fix — the recent spacing work fixed row *positions* but never restored a background *fill*.

## Fix

A per-window background quad in `defaultBg`, **anchored to the pane frame** — the bounds helper takes no presentation-offset input, so scroll offsets and #2690's settle animations structurally cannot re-expose the band (reviewer-verified against the offset-shifted cursorline quad two lines below it). Bottom pane extends to the drawable edge; interior panes tile exactly at split separators; z-ordered under everything (text, cursorline, selection, diagnostics, gutter).

## Tests

5 new pure-helper tests including the report's exact numbers (17 rows / 1.2 / 204-of-210px), the 1.0 baseline, raw-cell remainder, interior-pane tiling, and backing scale. Full Swift suite 924 pass on this branch. Review: PASS; its one non-blocking note (a call-site test pinning offset-invariance against future refactors) is a good follow-up candidate for the conformance/visual-regression bucket.

No render-signature changes — no conflict with #2690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1