### PR TITLE
fix(layout): native GUI stops reserving a grid row for the native minibuffer

### DIFF
--- a/lib/minga_editor/layout/gui.ex
+++ b/lib/minga_editor/layout/gui.ex
@@ -8,23 +8,44 @@ defmodule MingaEditor.Layout.GUI do
   columns for chrome that SwiftUI renders natively.
   """
 
+  alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
 
   @doc """
-  Computes GUI layout: Metal viewport is editor area plus one minibuffer row.
-  No tab bar, no file tree columns, no agent panel.
+  Computes GUI layout: no tab bar, no file tree columns, no agent panel.
+
+  Row accounting for the minibuffer depends on what the frontend's reported
+  rows already exclude:
+
+  * Native GUI (`Capabilities.gui?/1`): the Metal viewport measures the content
+    area only. The status bar and minibuffer are native SwiftUI chrome rendered
+    outside the Metal surface, so the reported rows already exclude them.
+    Reserving a grid row here would double-book the minibuffer and drop a content
+    row (#2693), so the editor fills the full viewport and the minibuffer rect is
+    anchored just below the content grid for server-side cursor/focus routing.
+  * Terminal frontends (`:tui`, the default): the reported rows are the full
+    terminal grid, so the minibuffer genuinely consumes the last row and must be
+    reserved.
   """
   @spec compute(EditorState.t()) :: Layout.t()
   def compute(state) do
     vp = state.terminal_viewport
     terminal = {0, 0, vp.cols, vp.rows}
 
-    # Minibuffer takes the last row (stays in Metal for command-line input).
-    minibuffer = {vp.rows - 1, 0, vp.cols, 1}
-    editor_height = max(vp.rows - 1, 1)
+    native_gui? = Capabilities.gui?(capabilities(state))
 
-    # Editor area is the full viewport minus the minibuffer row.
+    {editor_height, minibuffer} =
+      if native_gui? do
+        # Native minibuffer chrome lives outside the content grid; the reported
+        # rows already exclude it, so the editor claims the whole viewport and
+        # the minibuffer rect sits on the row directly below the content.
+        {vp.rows, {vp.rows, 0, vp.cols, 1}}
+      else
+        # Terminal grid: the minibuffer occupies the last real row.
+        {max(vp.rows - 1, 1), {vp.rows - 1, 0, vp.cols, 1}}
+      end
+
     editor_area = {0, 0, vp.cols, editor_height}
 
     # All windows are no-modeline; the global SwiftUI status bar handles status display.
@@ -51,4 +72,11 @@ defmodule MingaEditor.Layout.GUI do
       minibuffer: minibuffer
     }
   end
+
+  # Reads frontend capabilities, defaulting to the terminal profile (reserve the
+  # minibuffer row) when they are absent so pre-ready frames and non-struct
+  # callers keep the conservative TUI-compatible geometry.
+  @spec capabilities(EditorState.t() | map()) :: Capabilities.t()
+  defp capabilities(%{capabilities: %Capabilities{} = caps}), do: caps
+  defp capabilities(_state), do: Capabilities.default()
 end

--- a/test/minga_editor/layout/gui_test.exs
+++ b/test/minga_editor/layout/gui_test.exs
@@ -43,12 +43,22 @@ defmodule MingaEditor.Layout.GUITest do
       assert col == 0
     end
 
-    test "minibuffer is the last row" do
+    test "minibuffer sits just below the content grid (native chrome, not reserved)" do
       state = gui_state()
       layout = LayoutGUI.compute(state)
 
       {row, 0, _, 1} = layout.minibuffer
-      assert row == state.workspace.viewport.rows - 1
+      # Native GUI renders the minibuffer outside the Metal surface, so no grid
+      # row is reserved: the rect is anchored on the row directly below content.
+      assert row == state.workspace.viewport.rows
+    end
+
+    test "editor fills the full viewport for native GUI (no phantom minibuffer row)" do
+      state = gui_state()
+      layout = LayoutGUI.compute(state)
+
+      {_r, _c, _w, editor_h} = layout.editor_area
+      assert editor_h == state.workspace.viewport.rows
     end
 
     test "single window has no modeline row" do

--- a/test/minga_editor/layout_test.exs
+++ b/test/minga_editor/layout_test.exs
@@ -16,9 +16,11 @@ defmodule MingaEditor.LayoutTest do
 
   # Every live frontend is semantic (`Layout.GUI`); the legacy cell-grid
   # `Layout.TUI` and its reserved tab-bar/file-tree/agent-panel geometry were
-  # deleted in #2235. These tests drive the surviving GUI layout: the Metal
-  # viewport is pure editor area plus a minibuffer row, and the shared
-  # window-subdivision/split math in `MingaEditor.Layout`.
+  # deleted in #2235. These tests drive the surviving GUI layout under native-GUI
+  # capabilities: the Metal viewport is pure editor area that fills the whole
+  # reported grid (the minibuffer is native chrome rendered outside the surface,
+  # so no grid row is reserved, #2693), plus the shared window-subdivision/split
+  # math in `MingaEditor.Layout`.
 
   setup do
     table = Module.concat(__MODULE__, "Sidebar#{System.unique_integer([:positive])}")
@@ -140,19 +142,21 @@ defmodule MingaEditor.LayoutTest do
   # ── Single window ────────────────────────────────────────────────────────────
 
   describe "compute/1 single window" do
-    test "editor area is the full viewport minus the minibuffer row" do
+    test "native GUI editor area fills the full viewport (minibuffer is native chrome)" do
       state = new_state(24, 80) |> with_window()
       layout = Layout.compute(state)
 
       assert layout.terminal == {0, 0, 80, 24}
-      # SwiftUI/Go render tab bar, status bar, and file tree natively; the BEAM
-      # reserves no rows or columns for them.
+      # SwiftUI/Go render tab bar, status bar, file tree, and minibuffer natively;
+      # the reported rows already exclude them, so the BEAM reserves no rows or
+      # columns. The editor claims the whole viewport (#2693) and the minibuffer
+      # rect is anchored just below the content grid for cursor/focus routing.
       assert layout.tab_bar == nil
       assert layout.status_bar == nil
       assert layout.file_tree == nil
       assert layout.agent_panel == nil
-      assert layout.minibuffer == {23, 0, 80, 1}
-      assert layout.editor_area == {0, 0, 80, 23}
+      assert layout.minibuffer == {24, 0, 80, 1}
+      assert layout.editor_area == {0, 0, 80, 24}
     end
 
     test "single window fills the editor area with a zero-height modeline" do
@@ -160,8 +164,8 @@ defmodule MingaEditor.LayoutTest do
       layout = Layout.compute(state)
 
       assert %{1 => wl} = layout.window_layouts
-      assert wl.total == {0, 0, 80, 23}
-      assert wl.content == {0, 0, 80, 23}
+      assert wl.total == {0, 0, 80, 24}
+      assert wl.content == {0, 0, 80, 24}
       # Per-window modelines are gone; the global status bar (0x76) handles display.
       {_, _, _, ml_h} = wl.modeline
       assert ml_h == 0
@@ -182,7 +186,7 @@ defmodule MingaEditor.LayoutTest do
       layout = Layout.compute(state)
 
       assert layout.agent_panel == nil
-      assert layout.editor_area == {0, 0, 80, 23}
+      assert layout.editor_area == {0, 0, 80, 24}
     end
   end
 
@@ -264,7 +268,7 @@ defmodule MingaEditor.LayoutTest do
       layout2 = Layout.compute(state2)
 
       assert layout2.terminal == {0, 0, 120, 40}
-      assert layout2.minibuffer == {39, 0, 120, 1}
+      assert layout2.minibuffer == {40, 0, 120, 1}
 
       {_, _, w1, h1} = layout1.editor_area
       {_, _, w2, h2} = layout2.editor_area
@@ -328,7 +332,13 @@ defmodule MingaEditor.LayoutTest do
       |> Enum.map(fn wl -> wl.content end)
       |> Enum.reject(fn {_r, _c, _w, h} -> h == 0 end)
 
-    base ++ window_rects
+    # Native chrome (the GUI minibuffer) renders outside the Metal grid, so its
+    # rect is anchored on the row directly below the content and is not a grid
+    # region. Drop off-grid rects from the grid-tiling invariants.
+    {_tr, _tc, _tw, term_h} = layout.terminal
+
+    (base ++ window_rects)
+    |> Enum.reject(fn {r, _c, _w, _h} -> r >= term_h end)
   end
 
   defp assert_no_overlap(layout) do
@@ -448,19 +458,19 @@ defmodule MingaEditor.LayoutTest do
       assert width == 120
     end
 
-    test "minibuffer is the last row" do
+    test "minibuffer is anchored just below the content grid (native chrome)" do
       state = new_state(40, 120) |> with_window()
       layout = Layout.compute(state)
 
-      assert layout.minibuffer == {39, 0, 120, 1}
+      assert layout.minibuffer == {40, 0, 120, 1}
     end
 
-    test "editor area height is the viewport minus the minibuffer" do
+    test "editor area height fills the full viewport (no phantom minibuffer row)" do
       state = new_state(40, 120) |> with_window()
       layout = Layout.compute(state)
 
       {_row, _col, _w, height} = layout.editor_area
-      assert height == 39
+      assert height == 40
     end
 
     test "tab bar, status bar, file tree, and agent panel rects are nil" do

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -103,16 +103,16 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
       model = wf.window_model
 
       assert model.geometry.window_id == state.workspace.windows.active
-      assert model.geometry.total_rect == {0, 0, 80, 23}
-      assert model.geometry.content_rect == {0, 0, 80, 23}
-      assert model.geometry.gutter_rect == {0, 0, 6, 23}
-      assert model.geometry.text_rect == {0, 6, 74, 23}
-      assert model.geometry.viewport.rows == 23
+      assert model.geometry.total_rect == {0, 0, 80, 24}
+      assert model.geometry.content_rect == {0, 0, 80, 24}
+      assert model.geometry.gutter_rect == {0, 0, 6, 24}
+      assert model.geometry.text_rect == {0, 6, 74, 24}
+      assert model.geometry.viewport.rows == 24
       assert model.geometry.gutter_metrics.line_number_width == 3
       assert model.geometry.gutter_metrics.sign_col_width == 3
 
       assert Enum.find(model.geometry.hit_regions, &(&1.kind == :fold_control)).rect ==
-               {0, 2, 1, 23}
+               {0, 2, 1, 24}
 
       assert Enum.map(model.geometry.hit_regions, & &1.kind) == [:text, :gutter, :fold_control]
       assert is_integer(model.content_epoch)
@@ -141,7 +141,7 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
         |> Enum.flat_map(& &1.geometry.hit_regions)
         |> Enum.filter(&(&1.kind == :divider))
 
-      assert Enum.any?(divider_regions, &(&1.rect == {0, 39, 1, 23}))
+      assert Enum.any?(divider_regions, &(&1.rect == {0, 39, 1, 24}))
     end
 
     test "inactive GUI windows hide their cursor" do
@@ -460,7 +460,10 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
 
     test "wrapped selection starts at the pane edge when visual row offset hides its start" do
       content = "\tabcdef界ghijABCDEFGHIJ"
-      state = gui_state(rows: 3, cols: 18, content: content)
+      # rows: 2 yields a 2-row content area. Before #2693 this needed rows: 3
+      # because the GUI layout stole one row for a phantom minibuffer reservation;
+      # now the editor fills the full viewport, so 2 reported rows == 2 content rows.
+      state = gui_state(rows: 2, cols: 18, content: content)
       buffer = state.workspace.buffers.active
       assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
       assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
@@ -541,10 +544,13 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
                ":tail"
              ]
 
-      assert model.indent_guides.line_indent_levels == [1, 2, 1, 0]
+      assert model.indent_guides.line_indent_levels == [0, 1, 2, 1, 0]
       assert presentation != nil
       assert presentation.window_id == model.window_id
-      assert presentation.visible_start_line == 1
+      # With the minibuffer no longer stealing a row, the 5-row viewport now fits
+      # one more line, so the EOF clamp pulls the top back to line 0 and the whole
+      # 6-line file is visible (#2693 interaction: EOF clamp sees the taller area).
+      assert presentation.visible_start_line == 0
       assert presentation.visible_end_line == 5
       assert presentation.overscan_start_line == 0
       assert presentation.overscan_end_line == 6

--- a/test/minga_editor/render_pipeline/viewport_row_accounting_test.exs
+++ b/test/minga_editor/render_pipeline/viewport_row_accounting_test.exs
@@ -1,0 +1,170 @@
+defmodule MingaEditor.RenderPipeline.ViewportRowAccountingTest do
+  @moduledoc """
+  Chain-locking regression for #2693: GUI-reported rows must survive the
+  accounting chain (reported rows -> BEAM layout content height -> emitted
+  window rows) without losing rows to chrome the frontend renders natively.
+
+  These assertions are deliberately content-facing: they lock the emitted row
+  count against the content area the frontend measured, not the internal
+  raw->effective derivation steps (which a future frontend-owned row-fit model
+  will replace). A phantom chrome reservation would drop an emitted content row
+  and fail loudly here regardless of the units the derivation uses.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.Layout
+  alias MingaEditor.RenderPipeline
+  alias MingaEditor.RenderPipeline.Content
+  alias MingaEditor.RenderPipeline.Scroll
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  # Runs scroll + content and returns the flattened window models keyed by id.
+  defp emitted_models(state) do
+    state = EditorState.sync_active_window_cursor(state)
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+    {contents, _cursor, _state} = Content.build_content(state, scrolls)
+
+    models =
+      contents
+      |> Enum.flat_map(& &1.models)
+      |> Map.new(fn model -> {model.window_id, model} end)
+
+    {models, layout}
+  end
+
+  defp content_height({_r, _c, _w, h}), do: h
+
+  # The content area is filled when the emitted rows cover every content row.
+  # The free-scroll path (#2692) may paint one extra partially-visible remainder
+  # row below the last whole row, so "filled to within one spaced row" means the
+  # emitted count is the content height, plus at most that one remainder row.
+  defp assert_fills_content(model, content_rows) do
+    emitted = length(model.rows)
+
+    assert emitted in content_rows..(content_rows + 1),
+           "emitted rows (#{emitted}) should fill the #{content_rows}-row content area (plus at most one sub-row remainder)"
+  end
+
+  describe "native GUI row accounting (#2693)" do
+    test "emitted content rows fill the full reported viewport (no phantom minibuffer row)" do
+      # A phantom chrome reservation would make the emitted content one row
+      # shorter than the viewport the frontend measured. Check several heights.
+      for rows <- [15, 17, 24, 40] do
+        state = gui_state(rows: rows, cols: 108, content: long_content(rows * 3))
+        {models, layout} = emitted_models(state)
+
+        [model] = Map.values(models)
+
+        assert content_height(model.rect) == rows,
+               "window content height should equal the full viewport (#{rows}), got #{content_height(model.rect)}"
+
+        assert_fills_content(model, rows)
+
+        # The editor area itself claims the whole grid: the gap below the last
+        # content row is zero grid rows (the sub-row pixel remainder that #2692
+        # paints is strictly < one spaced row and lives below the grid).
+        assert content_height(layout.editor_area) == rows
+      end
+    end
+
+    test "capability gate: terminal frontends still reserve the minibuffer row" do
+      # The TUI's reported rows are the full terminal grid, so the minibuffer
+      # genuinely consumes the last row. The gate must keep that reservation so
+      # the TUI stays byte-identical; only native GUI reclaims the row.
+      rows = 24
+      base = gui_state(rows: rows, cols: 108, content: long_content(rows * 3))
+      tui_state = %{base | capabilities: %Capabilities{frontend_type: :tui, semantic_ui: true}}
+
+      {models, layout} = emitted_models(tui_state)
+      [model] = Map.values(models)
+
+      assert content_height(layout.editor_area) == rows - 1
+      assert content_height(model.rect) == rows - 1
+      assert_fills_content(model, rows - 1)
+    end
+
+    test "line spacing feeds the row count exactly once, then fills the viewport" do
+      # Reconcile the reported ledger: a 21-raw-cell window at spacing 1.2 must
+      # yield 17 effective rows and emit all 17 as content (the #2693 report saw
+      # 17 effective but only ~16 rendered because of the phantom reservation).
+      raw_rows = 21
+
+      for {spacing, expected} <- [{1.0, 21}, {1.2, 17}] do
+        effective = Viewport.effective_rows(raw_rows, spacing)
+
+        assert effective == expected,
+               "effective_rows(#{raw_rows}, #{spacing}) should be #{expected}"
+
+        state = gui_state(rows: effective, cols: 108, content: long_content(effective * 3))
+        {models, _layout} = emitted_models(state)
+        [model] = Map.values(models)
+
+        # Emitted rows equal the effective viewport rows: spacing applied once,
+        # no phantom chrome deduction on top.
+        assert content_height(model.rect) == effective
+        assert_fills_content(model, effective)
+      end
+    end
+
+    test "splits: each pane fills its share with no per-pane phantom reservation" do
+      rows = 40
+
+      # Vertical split: both panes span the full editor height (no horizontal
+      # separator), so each pane's content height equals the full viewport.
+      vstate =
+        gui_state(rows: rows, cols: 120, content: long_content(rows * 3))
+        |> split_active_window(:vertical)
+
+      {vmodels, _} = emitted_models(vstate)
+      assert map_size(vmodels) == 2
+
+      for {_id, model} <- vmodels do
+        assert content_height(model.rect) == rows
+        assert_fills_content(model, rows)
+      end
+
+      # Horizontal split: the two panes plus the 1-row separator tile the full
+      # viewport, so the pane heights sum to the full grid minus the separator.
+      hstate =
+        gui_state(rows: rows, cols: 120, content: long_content(rows * 3))
+        |> split_active_window(:horizontal)
+
+      {hmodels, hlayout} = emitted_models(hstate)
+      assert map_size(hmodels) == 2
+
+      total_pane_rows =
+        hmodels |> Map.values() |> Enum.map(&content_height(&1.rect)) |> Enum.sum()
+
+      separator_rows = length(hlayout.horizontal_separators)
+      assert total_pane_rows + separator_rows == rows
+    end
+  end
+
+  # Splits the active window using the workspace Windows API so the layout sees a
+  # real split tree. Returns the updated state.
+  defp split_active_window(state, direction) do
+    windows = state.workspace.windows
+    active = windows.active
+    new_id = windows.next_id
+    new_window = Map.fetch!(windows.map, active)
+
+    # Split size 0 means "even split" (WindowTree.clamp_size/2).
+    tree = {:split, direction, {:leaf, active}, {:leaf, new_id}, 0}
+
+    updated = %{
+      windows
+      | tree: tree,
+        map: Map.put(windows.map, new_id, %{new_window | id: new_id}),
+        next_id: new_id + 1
+    }
+
+    put_in(state.workspace.windows, updated)
+  end
+end


### PR DESCRIPTION
Closes #2693 (priority-high: the GUI rendered fewer rows than fit the window).

## The row ledger

For the reported window: **21 raw → ÷1.2 spacing → 17 effective → −1 phantom minibuffer → 16 emitted.** The phantom row: `Layout.GUI` reserved the bottom grid row for a minibuffer both frontends render natively (SwiftUI overlay via 0x7F outside the Metal surface; Go's own footer), and the frontends' reported rows already exclude that chrome — classic double-booking. Stacked on the sub-row spacing remainder (painted by #2692), it read as the multi-row band.

## Fix

Capability-gated at the owning layer: native GUI editor areas fill the full viewport; the minibuffer rect anchors **off-grid** at `vp.rows` for server-side cursor/focus routing only. The review verified the off-grid rect on every axis: the Metal surface is content-only so the reclaimed bottom row hit-tests to buffer content correctly, the native overlay captures its own clicks and owns its own cursor (the geometry-independent `gui_minibuffer` command), the focus-tree node can't match an in-surface coordinate, and the command-mode grid cursor clips cleanly. TUI and absent-capabilities defaults keep `rows − 1` byte-identically.

## The deliberate non-fix

The remaining ≤1-row **double-floor** loss (Swift `floor(px/cell)` then BEAM `floor(raw/spacing)`) is documented in the ledger and *not* patched — ADR-0001 (#2695) records why, and #2694 deletes that arithmetic entirely. The new chain-locking test asserts the content-facing outcome (emitted rows fill the content area within one spaced remainder row, across heights/spacings/splits + the TUI gate) precisely so it survives that re-model.

## Validation

Full suite 9,811 pass; conformance 153 (BEAM) + 12 (Go); zero Swift/Go changes needed (verified in review); lint/dialyzer/format clean. Acceptance review: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1