### PR TITLE
refactor(viewport): frontends own row fit; delete BEAM-side spacing arithmetic

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -25,6 +25,8 @@ ready: opcode(1) + width(2) + height(2) + caps_version(1) + caps_len(1) + caps_d
 caps_data: frontend_type(1) + color_depth(1) + unicode_width(1) + image_support(1) + float_support(1) + text_rendering(1)
 ```
 
+`width`/`height` are **content cells at the current presentation metrics**, not pixels. A native GUI computes rows-that-fit with a single floor where the pixels live (`rows = floor(content_pixels / (cell_height × line_spacing))`) and reports that in `ready` and every `resize` (0x02). The BEAM lays out in exactly those rows and performs no line-spacing arithmetic of its own. See the `0x02 resize` section in `PROTOCOL.md` and `docs/adr/0001-frontend-owns-row-fit.md`.
+
 The `frontend_type` byte describes the rendering surface, not the product implementation:
 
 | Value | Type | Description |
@@ -1350,7 +1352,7 @@ opcode(1=0x92) + payload_length(2=0x0002) + spacing_x100(2)
 Fields:
 - `spacing_x100`: the spacing multiplier times 100 as a 16-bit unsigned integer. For example, 1.0 is 100, 1.2 is 120, 1.5 is 150.
 
-The frontend uses this to compute `displayCellH = cellH * (spacing_x100 / 100.0)` for all row positioning. The BEAM adjusts its viewport row count using the same multiplier, so scrolling math stays correct on both sides.
+The frontend uses this to compute `displayCellH = cellH * (spacing_x100 / 100.0)` for all row positioning. Line spacing is a **draw-time rendering hint only**: it has zero influence on BEAM-side layout, viewport, or scroll math. When the spacing changes at runtime the frontend recomputes its own rows-that-fit (`floor(content_pixels / (cell_height × line_spacing))`, one floor, where the pixels live) and sends an ordinary `resize` (0x02) carrying the new content row count. The BEAM lays out in exactly those rows and never divides by the multiplier itself. This resize does not re-trigger `0x92` (the emit is fingerprint-gated on the spacing value), so there is no feedback loop. See `docs/adr/0001-frontend-owns-row-fit.md`.
 
 ## Behavioral Contract
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -299,30 +299,34 @@ The terminal or window was resized.
 
 ```
 opcode: u8  = 0x02
-width:  u16           new width in columns (or pixels for GUI)
-height: u16           new height in rows (or pixels for GUI)
+width:  u16           content columns available at current presentation metrics
+height: u16           content rows available at current presentation metrics
 ```
 
 Total size: 5 bytes.
 
 **Behavior:** Sent when the frontend detects a size change (SIGWINCH for TUI, window resize event for GUI). The BEAM re-renders to the new dimensions on the next frame.
 
+`width`/`height` are **content cells**, not pixels. Each frontend owns the single row-fit floor and reports how many rows and columns fit its content area at the current font, backing scale, and line spacing: `rows = floor(content_pixels / (cell_height × line_spacing))`, computed once in the layer that owns the pixels. The BEAM lays out in exactly these rows and performs no pixel or line-spacing arithmetic of its own. The TUI reports its terminal grid unchanged (line spacing is 1.0 there by construction). Line spacing reaches the GUI only as a draw-time rendering hint (`gui_line_spacing`, 0x92) and a runtime spacing change arrives back here as an ordinary resize. See `docs/adr/0001-frontend-owns-row-fit.md`.
+
 ### `0x03` ready
 
 The frontend has initialized and is ready to receive render commands.
 
+The `width`/`height` fields carry the same "content cells at current presentation metrics" meaning as `resize` above (see that section for the row-fit rule and ADR-0001 reference).
+
 **Short format (5 bytes):**
 ```
 opcode: u8  = 0x03
-width:  u16           initial width
-height: u16           initial height
+width:  u16           initial content columns available at current presentation metrics
+height: u16           initial content rows available at current presentation metrics
 ```
 
 **Extended format (13 bytes, or 15+ with a version tail):**
 ```
 opcode:           u8  = 0x03
-width:            u16           initial width
-height:           u16           initial height
+width:            u16           initial content columns available at current presentation metrics
+height:           u16           initial content rows available at current presentation metrics
 caps_version:     u8            capability format version (currently 1)
 caps_len:         u8            length of capability data
 caps_data:        [caps_len]u8  capability fields (see "Capability Negotiation" section)

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -16,7 +16,6 @@ defmodule MingaEditor do
   alias MingaEditor.Agent.Events
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer
-  alias Minga.Config
   alias Minga.Editing.Completion
   alias Minga.Events, as: EventBus
   alias Minga.Git
@@ -392,10 +391,10 @@ defmodule MingaEditor do
     caps = Startup.fetch_capabilities(state.port_manager)
     Startup.apply_gui_defaults(caps, EditorState.options_server(state))
 
-    line_spacing = Config.get(:line_spacing) || 1.0
-    effective_height = Viewport.effective_rows(height, line_spacing)
-
-    vp = Viewport.new(effective_height, width)
+    # The frontend already floored content pixels into rows-that-fit at the
+    # current presentation metrics (ADR-0001); the BEAM lays out in the rows it
+    # is given and derives nothing from line spacing.
+    vp = Viewport.new(height, width)
 
     new_state = %{
       (state
@@ -428,10 +427,9 @@ defmodule MingaEditor do
   end
 
   def handle_info({:minga_input, {:resize, width, height}}, state) do
-    line_spacing = Config.get(:line_spacing) || 1.0
-    effective_height = Viewport.effective_rows(height, line_spacing)
-
-    vp = Viewport.new(effective_height, width)
+    # `height` is content rows-that-fit as measured by the frontend at the
+    # current presentation metrics (ADR-0001). No spacing arithmetic here.
+    vp = Viewport.new(height, width)
 
     new_state =
       state

--- a/lib/minga_editor/viewport.ex
+++ b/lib/minga_editor/viewport.ex
@@ -65,29 +65,6 @@ defmodule MingaEditor.Viewport do
   def footer_rows, do: 2
 
   @doc """
-  Adjusts the raw row count for a line spacing multiplier.
-
-  When `line_spacing > 1.0`, each line takes more vertical space, so fewer
-  lines fit on screen. Returns `floor(rows / line_spacing)`, clamped to at
-  least 1. Returns the input unchanged when spacing is 1.0 (the TUI default).
-
-  The caller reads `Config.get(:line_spacing)` and passes it here. This keeps
-  Viewport a pure module with no config dependency.
-  """
-  @spec effective_rows(pos_integer(), number()) :: pos_integer()
-  def effective_rows(raw_rows, line_spacing \\ 1.0)
-
-  def effective_rows(raw_rows, line_spacing)
-      when is_integer(raw_rows) and raw_rows > 0 and is_number(line_spacing) and
-             line_spacing > 1.0 do
-    max(floor(raw_rows / line_spacing), 1)
-  end
-
-  def effective_rows(raw_rows, _line_spacing) when is_integer(raw_rows) and raw_rows > 0 do
-    raw_rows
-  end
-
-  @doc """
   Scrolls the viewport to keep the cursor visible.
 
   Returns a new viewport adjusted so that the cursor position `{line, col}`

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -114,8 +114,11 @@ final class EditorNSView: MTKView {
 
     private struct GridDimensions {
         let cols: UInt16
-        let rawRows: UInt16
-        let effectiveRows: UInt16
+        /// Content rows-that-fit at the current presentation metrics: one floor of
+        /// content pixels by the spaced cell height (ADR-0001). This is the value
+        /// reported on the wire and the value the BEAM lays out in; there is no
+        /// separate unspaced "raw" row count anymore.
+        let rows: UInt16
     }
 
     /// First responder guard that prevents SwiftUI from stealing keyboard focus.
@@ -515,19 +518,21 @@ final class EditorNSView: MTKView {
         let resolvedCellWidth = cellWidth ?? self.cellWidth
         let resolvedCellHeight = cellHeight ?? self.cellHeight
         guard resolvedCellWidth > 0, resolvedCellHeight > 0 else {
-            return GridDimensions(cols: 1, rawRows: 1, effectiveRows: 1)
+            return GridDimensions(cols: 1, rows: 1)
         }
 
         let gutterPad: CGFloat = dispatcher.frameState.gutterCol > 0 ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
         let cols = UInt16(max((width - gutterPad) / resolvedCellWidth, 1))
-        let rawRows = UInt16(max(height / resolvedCellHeight, 1))
-        let effectiveRows = effectiveRows(from: rawRows, lineSpacing: dispatcher.frameState.lineSpacing)
-        return GridDimensions(cols: cols, rawRows: rawRows, effectiveRows: effectiveRows)
+        let rows = rowsThatFit(height: height, cellHeight: resolvedCellHeight, lineSpacing: dispatcher.frameState.lineSpacing)
+        return GridDimensions(cols: cols, rows: rows)
     }
 
-    private func effectiveRows(from rawRows: UInt16, lineSpacing: Float) -> UInt16 {
-        let spacing = max(Double(lineSpacing), 1.0)
-        return UInt16(max(floor(Double(rawRows) / spacing), 1))
+    /// The one and only row-fit floor (ADR-0001): content pixels divided by the
+    /// spaced cell height, floored once, in the layer that owns the pixels. The
+    /// BEAM consumes this verbatim and never re-derives a row count from spacing.
+    private func rowsThatFit(height: CGFloat, cellHeight: CGFloat, lineSpacing: Float) -> UInt16 {
+        let spacedCellHeight = cellHeight * CGFloat(max(lineSpacing, 1.0))
+        return UInt16(max(floor(height / spacedCellHeight), 1))
     }
 
     // MARK: - Font update
@@ -545,9 +550,9 @@ final class EditorNSView: MTKView {
 
         let grid = gridDimensions(width: frame.width, height: frame.height, cellWidth: newCellW, cellHeight: newCellH)
 
-        if grid.cols != dispatcher.frameState.cols || grid.effectiveRows != dispatcher.frameState.rows {
-            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.effectiveRows)
-            encoder.sendResize(cols: grid.cols, rows: grid.rawRows)
+        if grid.cols != dispatcher.frameState.cols || grid.rows != dispatcher.frameState.rows {
+            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.rows)
+            encoder.sendResize(cols: grid.cols, rows: grid.rows)
         }
 
         // Force a full re-render.
@@ -630,16 +635,16 @@ final class EditorNSView: MTKView {
         guard frame.width > 0, frame.height > 0 else { return }
 
         let grid = currentGridDimensions()
-        dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.effectiveRows)
+        dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.rows)
 
         if readySent {
-            encoder.sendResize(cols: grid.cols, rows: grid.rawRows)
+            encoder.sendResize(cols: grid.cols, rows: grid.rows)
         } else {
             readySent = true
-            encoder.sendReady(cols: grid.cols, rows: grid.rawRows)
+            encoder.sendReady(cols: grid.cols, rows: grid.rows)
         }
 
-        PortLogger.info("\(reason): \(grid.cols)x\(grid.rawRows) raw cells, \(grid.effectiveRows) effective rows")
+        PortLogger.info("\(reason): \(grid.cols)x\(grid.rows) rows")
     }
 
     private func measureTrafficLightPosition(in window: NSWindow) {
@@ -774,14 +779,14 @@ final class EditorNSView: MTKView {
             // First real frame size: send the ready event with actual
             // window dimensions so the BEAM never sees wrong defaults.
             readySent = true
-            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.effectiveRows)
-            encoder.sendReady(cols: grid.cols, rows: grid.rawRows)
-            os_signpost(.event, log: startupLog, name: "ReadySent", "%{public}dx%{public}d", grid.cols, grid.rawRows)
-            PortLogger.info("Window ready: \(grid.cols)x\(grid.rawRows) raw cells, \(grid.effectiveRows) effective rows (\(Int(newSize.width))x\(Int(newSize.height))pt)")
-        } else if grid.cols != dispatcher.frameState.cols || grid.effectiveRows != dispatcher.frameState.rows {
-            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.effectiveRows)
-            encoder.sendResize(cols: grid.cols, rows: grid.rawRows)
-            PortLogger.info("Window resized: \(grid.cols)x\(grid.rawRows) raw cells, \(grid.effectiveRows) effective rows")
+            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.rows)
+            encoder.sendReady(cols: grid.cols, rows: grid.rows)
+            os_signpost(.event, log: startupLog, name: "ReadySent", "%{public}dx%{public}d", grid.cols, grid.rows)
+            PortLogger.info("Window ready: \(grid.cols)x\(grid.rows) rows (\(Int(newSize.width))x\(Int(newSize.height))pt)")
+        } else if grid.cols != dispatcher.frameState.cols || grid.rows != dispatcher.frameState.rows {
+            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.rows)
+            encoder.sendResize(cols: grid.cols, rows: grid.rows)
+            PortLogger.info("Window resized: \(grid.cols)x\(grid.rows) rows")
         }
     }
 
@@ -845,16 +850,19 @@ final class EditorNSView: MTKView {
 
     // MARK: - Line spacing
 
-    /// Called when the BEAM sends a new line_spacing value. Recomputes the grid
-    /// row count based on the new effective cell height and sends a resize event
-    /// so the BEAM adjusts its viewport.
+    /// Called when the BEAM sends a new line_spacing value (opcode 0x92). By the
+    /// time this fires the dispatcher has already stored the new spacing, so we
+    /// recompute rows-that-fit once against the spaced cell height (ADR-0001) and,
+    /// if it changed, send an ordinary resize. The BEAM re-lays-out in the given
+    /// rows without any spacing math of its own. A resize never re-triggers 0x92
+    /// (the emit is fingerprint-gated on the spacing value), so there is no loop.
     func lineSpacingChanged(_ spacing: Float) {
         guard frame.width > 0, frame.height > 0 else { return }
         let grid = currentGridDimensions()
 
-        if grid.cols != dispatcher.frameState.cols || grid.effectiveRows != dispatcher.frameState.rows {
-            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.effectiveRows)
-            encoder.sendResize(cols: grid.cols, rows: grid.rawRows)
+        if grid.cols != dispatcher.frameState.cols || grid.rows != dispatcher.frameState.rows {
+            dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.rows)
+            encoder.sendResize(cols: grid.cols, rows: grid.rows)
         }
     }
 

--- a/test/minga_editor/render_pipeline/viewport_row_accounting_test.exs
+++ b/test/minga_editor/render_pipeline/viewport_row_accounting_test.exs
@@ -19,7 +19,6 @@ defmodule MingaEditor.RenderPipeline.ViewportRowAccountingTest do
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Scroll
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.Viewport
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -91,22 +90,25 @@ defmodule MingaEditor.RenderPipeline.ViewportRowAccountingTest do
     end
 
     test "line spacing feeds the row count exactly once, then fills the viewport" do
-      # Reconcile the reported ledger: a 21-raw-cell window at spacing 1.2 must
-      # yield 17 effective rows and emit all 17 as content (the #2693 report saw
-      # 17 effective but only ~16 rendered because of the phantom reservation).
+      # Reconcile the reported ledger: a 21-cell-tall window at spacing 1.2 floors
+      # once on the frontend to 17 rows-that-fit, and the BEAM emits all 17 as
+      # content (the #2693 report saw 17 but only ~16 rendered because of the
+      # phantom reservation). Per ADR-0001 the single floor lives on the frontend
+      # (floor(cells / spacing)); the BEAM performs no spacing arithmetic and lays
+      # out in exactly the rows it is given.
       raw_rows = 21
 
       for {spacing, expected} <- [{1.0, 21}, {1.2, 17}] do
-        effective = Viewport.effective_rows(raw_rows, spacing)
+        effective = floor(raw_rows / spacing)
 
         assert effective == expected,
-               "effective_rows(#{raw_rows}, #{spacing}) should be #{expected}"
+               "frontend row-fit floor(#{raw_rows} / #{spacing}) should be #{expected}"
 
         state = gui_state(rows: effective, cols: 108, content: long_content(effective * 3))
         {models, _layout} = emitted_models(state)
         [model] = Map.values(models)
 
-        # Emitted rows equal the effective viewport rows: spacing applied once,
+        # Emitted rows equal the reported viewport rows: spacing applied once,
         # no phantom chrome deduction on top.
         assert content_height(model.rect) == effective
         assert_fills_content(model, effective)

--- a/test/minga_editor/viewport_test.exs
+++ b/test/minga_editor/viewport_test.exs
@@ -379,41 +379,6 @@ defmodule MingaEditor.ViewportTest do
     end
   end
 
-  describe "effective_rows/2" do
-    test "line_spacing 1.0 returns raw rows unchanged" do
-      assert Viewport.effective_rows(30, 1.0) == 30
-    end
-
-    test "line_spacing 1.5 reduces visible rows" do
-      # 30 / 1.5 = 20
-      assert Viewport.effective_rows(30, 1.5) == 20
-    end
-
-    test "line_spacing 1.2 reduces visible rows (GUI default)" do
-      # 30 / 1.2 = 25
-      assert Viewport.effective_rows(30, 1.2) == 25
-    end
-
-    test "line_spacing 2.0 halves visible rows" do
-      # 20 / 2.0 = 10
-      assert Viewport.effective_rows(20, 2.0) == 10
-    end
-
-    test "fractional result floors to integer" do
-      # 30 / 1.3 ≈ 23.076... → 23
-      assert Viewport.effective_rows(30, 1.3) == 23
-    end
-
-    test "effective_rows is always at least 1" do
-      assert Viewport.effective_rows(1, 3.0) == 1
-      assert Viewport.effective_rows(2, 5.0) == 1
-    end
-
-    test "default spacing (no second arg) returns raw rows" do
-      assert Viewport.effective_rows(24) == 24
-    end
-  end
-
   describe "clamp_top_to_eof/2" do
     test "pins the last line to the bottom instead of scrolling past EOF" do
       # Reproduces the underfill bug: scroll_to_cursor applies scroll_margin at


### PR DESCRIPTION
Closes #2694, implementing [ADR-0001](../blob/main/docs/adr/0001-frontend-owns-row-fit.md) — the anti-flip-flop re-model from the line-height discussion.

## Summary

One floor, where the pixels live: the GUI computes `rows = floor(content_pixels / (cell_height × line_spacing))` and reports it in ready/resize; the BEAM consumes rows verbatim. `Viewport.effective_rows/2` is **deleted** (zero references repo-wide), `rawRows` leaves the wire and the Swift codebase, and layout/viewport/scroll contain no spacing arithmetic. **Net −50 lines.**

- **0x92 loop closed** (review-verified triple gate): emit fingerprinted on the multiplier only; dispatcher gates on value change; grid resend gates on row-count change. A resize cannot re-trigger 0x92.
- **TUI provably byte-identical:** spacing is always 1.0 for terminals (the 1.2 auto-bump is GUI-gated), so the deleted BEAM call was a mathematical identity on that path.
- **≤1 more row at spacing > 1.0** than the old double floor — the correct fill behavior; the #2693 chain test passes with content-facing assertions byte-identical (the one modification: its input derivation called the deleted helper; the 21@1.2→17 ledger is preserved).
- Docs: rows field redefined as "content rows available at current presentation metrics" in both protocol docs, referencing the ADR; the stale "BEAM adjusts its viewport using the multiplier" 0x92 prose corrected.

## Validation

Full BEAM suite 9,804 pass; conformance 153 with **zero** fixture regeneration; Swift 951; Go 549; lint/dialyzer/format clean. Acceptance review: PASS on all eight verification items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1