### PR TITLE
fix(macos): backgrounding never kills the BEAM; BEAM death never wedges the GUI

### DIFF
--- a/macos/Sources/BEAMProcessManager.swift
+++ b/macos/Sources/BEAMProcessManager.swift
@@ -55,6 +55,22 @@ final class BEAMProcessManager {
     /// Flushed to the BEAM once the protocol signals ready.
     private(set) var pendingFileURLs: [URL] = []
 
+    /// App Nap / termination assertion held for the lifetime of the BEAM child.
+    ///
+    /// Without this, macOS can App Nap (suspend) or automatically terminate the
+    /// GUI process once it is fully occluded or hidden. A suspended GUI stops
+    /// draining the BEAM's stdout pipe (render backpressure) and, if the process
+    /// is reaped, drops the BEAM's stdin pipe. A dropped stdin pipe reaches the
+    /// BEAM as EOF, which Frontend.Manager treats as "GUI exited" and answers
+    /// with `System.stop(0)` — tearing down the whole editor node, buffers and
+    /// undo included (#2698). Holding a `userInitiated` activity keeps the GUI
+    /// scheduled and un-reaped while the editor core is alive; system sleep is
+    /// still allowed (handled separately via the sleep/wake notifications).
+    private var backgroundActivity: (any NSObjectProtocol)?
+
+    /// Whether a BEAM child is currently running.
+    var hasLiveProcess: Bool { process?.isRunning ?? false }
+
     /// Resolves the BEAM release executable inside the app bundle.
     /// Returns nil if not running as a bundled app.
     static func beamExecutableURL() -> URL? {
@@ -146,6 +162,9 @@ final class BEAMProcessManager {
             return
         }
 
+        // Prevent App Nap / automatic + sudden termination while the BEAM lives.
+        beginBackgroundActivityIfNeeded()
+
         let proc = Process()
         proc.executableURL = execURL
 
@@ -231,12 +250,26 @@ final class BEAMProcessManager {
         kill(proc.processIdentifier, SIGUSR1)
     }
 
+    /// Re-spawns the BEAM after the automatic restart budget was exhausted.
+    ///
+    /// Called from the recovery surface (user chose "Restart Editor"). Clears
+    /// the crash-backoff history so the fresh process gets a clean budget.
+    func restartAfterRecovery() {
+        restartTimestamps.removeAll()
+        isShuttingDown = false
+        start()
+    }
+
     /// Sends SIGTERM to the BEAM and waits briefly for clean shutdown.
     /// Used during Cmd+Q / applicationShouldTerminate.
     func shutdownGracefully(timeout: TimeInterval = 3.0) {
         guard let proc = process, proc.isRunning else { return }
 
         isShuttingDown = true
+
+        // Real quit: release the App Nap / termination assertion so the GUI
+        // process can exit normally once the BEAM has shut down.
+        endBackgroundActivity()
 
         // SIGTERM triggers orderly OTP shutdown in the BEAM.
         proc.terminate()
@@ -258,46 +291,101 @@ final class BEAMProcessManager {
         }
     }
 
+    // MARK: - Termination decision (pure, testable)
+
+    /// What to do when the BEAM child process exits.
+    enum TerminationOutcome: Equatable {
+        /// Expected exit (graceful shutdown or user quit): let the app close.
+        case normalExit
+        /// Unexpected crash within the restart budget: respawn after `delay`.
+        case restart(delay: TimeInterval)
+        /// Unexpected crash past the restart budget: surface recovery to the user.
+        case giveUp
+    }
+
+    /// Decides the termination outcome from inputs only. Pure and synchronous:
+    /// it performs no I/O and never blocks, so the main actor stays free when
+    /// the termination handler calls it (#2698 defect B).
+    nonisolated static func terminationOutcome(
+        status: Int32,
+        isShuttingDown: Bool,
+        recentRestartCount: Int,
+        maxRestarts: Int
+    ) -> TerminationOutcome {
+        if isShuttingDown { return .normalExit }
+        if status == 0 { return .normalExit }
+        if recentRestartCount >= maxRestarts { return .giveUp }
+
+        let attempt = recentRestartCount + 1
+        // Exponential backoff: 100ms, 200ms, 400ms
+        let delay = 0.1 * pow(2.0, Double(attempt - 1))
+        return .restart(delay: delay)
+    }
+
     // MARK: - Private
 
-    private func handleTermination(status: Int32, reason: Process.TerminationReason) {
+    /// Handles BEAM exit. Kept non-`private` so the termination path can be
+    /// exercised directly in tests that assert the main actor is not blocked.
+    func handleTermination(status: Int32, reason: Process.TerminationReason) {
         NSLog("BEAMProcessManager: BEAM exited (status \(status), reason \(reason.rawValue))")
 
         self.process = nil
         self.readHandle = nil
         self.writeHandle = nil
 
-        // Graceful shutdown in progress (Cmd+Q): don't restart.
-        guard !isShuttingDown else {
-            onNormalExit?()
-            return
-        }
-
-        // Normal exit (user quit): don't restart.
-        guard status != 0 else {
-            onNormalExit?()
-            return
-        }
-
         // Prune old timestamps outside the restart window.
         let now = Date()
         let cutoff = now.addingTimeInterval(-windowSeconds)
         restartTimestamps.removeAll { $0 < cutoff }
 
-        if restartTimestamps.count >= maxRestarts {
+        let outcome = Self.terminationOutcome(
+            status: status,
+            isShuttingDown: isShuttingDown,
+            recentRestartCount: restartTimestamps.count,
+            maxRestarts: maxRestarts
+        )
+
+        switch outcome {
+        case .normalExit:
+            onNormalExit?()
+
+        case .giveUp:
             NSLog("BEAMProcessManager: too many crashes (\(maxRestarts) in \(windowSeconds)s), giving up")
+            // Recovery is presented by onCrash; it must not block the main actor.
             onCrash?()
-            return
+
+        case let .restart(delay):
+            restartTimestamps.append(now)
+            NSLog("BEAMProcessManager: restarting in \(delay)s")
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.start()
+            }
         }
+    }
 
-        restartTimestamps.append(now)
+    // MARK: - App Nap / termination assertion
 
-        // Exponential backoff: 100ms, 200ms, 400ms
-        let delay = 0.1 * pow(2.0, Double(restartTimestamps.count - 1))
-        NSLog("BEAMProcessManager: restarting in \(delay)s")
+    private func beginBackgroundActivityIfNeeded() {
+        guard backgroundActivity == nil else { return }
+        backgroundActivity = ProcessInfo.processInfo.beginActivity(
+            options: [.userInitiatedAllowingIdleSystemSleep, .automaticTerminationDisabled, .suddenTerminationDisabled],
+            reason: "Minga editor core (BEAM) is running"
+        )
+    }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.start()
+    private func endBackgroundActivity() {
+        if let token = backgroundActivity {
+            ProcessInfo.processInfo.endActivity(token)
+            backgroundActivity = nil
         }
+    }
+
+    // MARK: - Test hooks
+
+    /// Seeds the crash-backoff history so tests can drive the give-up path
+    /// without spawning real processes.
+    func primeRestartHistoryForTesting(count: Int) {
+        let now = Date()
+        restartTimestamps = Array(repeating: now, count: count)
     }
 }

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -249,10 +249,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let manager = BEAMProcessManager()
             self.beamManager = manager
 
-            manager.onCrash = {
-                // TODO: show error UI instead of terminating
-                NSLog("BEAM crashed too many times, terminating")
-                NSApp.terminate(nil)
+            manager.onCrash = { [weak self] in
+                // The editor core died and automatic restart gave up. Present the
+                // recovery surface instead of terminating, and keep the app
+                // responsive (clickable/quittable) while the user decides (#2698).
+                self?.presentEditorCoreStoppedRecovery()
             }
             manager.onNormalExit = {
                 NSApp.terminate(nil)
@@ -475,6 +476,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return .terminateNow
         }
 
+        // If the BEAM is already gone (it exited on its own, e.g. a background
+        // death or the user quit the editor core), there is nothing to shut down.
+        // Returning .terminateLater here without a live process to wait on would
+        // wedge the main runloop forever, because shutdownGracefully bails early
+        // and never calls reply(toApplicationShouldTerminate:) (#2698 defect B).
+        guard manager.hasLiveProcess else {
+            return .terminateNow
+        }
+
         // In bundle mode, wait for the BEAM to exit cleanly before
         // allowing the app to terminate. This prevents orphaned BEAM
         // processes running in the background after the Dock icon disappears.
@@ -486,6 +496,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         manager.shutdownGracefully(timeout: 3.0)
         return .terminateLater
+    }
+
+    /// Presents the recovery surface after the editor core exited and automatic
+    /// restart gave up. Scheduled on the next main-actor turn so the termination
+    /// handler that triggers it returns immediately and never blocks the main
+    /// actor; the alert itself is an interactive, quittable surface (#2698).
+    private func presentEditorCoreStoppedRecovery() {
+        recoveryManager?.presentEditorCoreStopped { [weak self] in
+            self?.beamManager?.restartAfterRecovery()
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/macos/Sources/Recovery/RecoveryManager.swift
+++ b/macos/Sources/Recovery/RecoveryManager.swift
@@ -50,6 +50,36 @@ final class RecoveryManager {
         return true
     }
 
+    /// Presents the recovery surface after the BEAM child process has exited and
+    /// automatic restart gave up.
+    ///
+    /// Non-blocking by contract: the alert is scheduled on the next main-actor
+    /// turn, so the caller (the process manager's termination handler) returns
+    /// immediately and the main actor is never blocked by the termination path
+    /// (#2698). The alert itself remains fully interactive and quittable.
+    func presentEditorCoreStopped(onRestart: @escaping @MainActor () -> Void) {
+        guard !isShowingAlert else { return }
+        isShowingAlert = true
+
+        Task { @MainActor in
+            defer { self.isShowingAlert = false }
+
+            let alert = NSAlert()
+            alert.alertStyle = .critical
+            alert.messageText = "Editor Core Stopped"
+            alert.informativeText = "The Minga editor core exited and could not be restarted automatically. Restart it to continue editing, or quit Minga."
+            alert.addButton(withTitle: "Restart Editor")
+            alert.addButton(withTitle: "Quit Minga")
+
+            switch alert.runModal() {
+            case .alertFirstButtonReturn:
+                onRestart()
+            default:
+                NSApp.terminate(nil)
+            }
+        }
+    }
+
     /// Test helper for deterministic timeout checks.
     func setLastFramePresentedTimeForTesting(_ time: CFAbsoluteTime) {
         lastFramePresentedTime = time

--- a/macos/Tests/MingaTests/BEAMProcessManagerTests.swift
+++ b/macos/Tests/MingaTests/BEAMProcessManagerTests.swift
@@ -135,3 +135,109 @@ struct BEAMProcessManagerLaunchArgumentsTests {
         #expect(workingDirectory.path == "/Applications")
     }
 }
+
+@Suite("BEAMProcessManager Termination Handling")
+struct BEAMProcessManagerTerminationTests {
+    // MARK: - Pure decision function
+
+    @Test("graceful shutdown resolves to a normal exit")
+    func gracefulShutdownIsNormalExit() {
+        let outcome = BEAMProcessManager.terminationOutcome(
+            status: 0, isShuttingDown: true, recentRestartCount: 0, maxRestarts: 3
+        )
+        #expect(outcome == .normalExit)
+    }
+
+    @Test("clean exit code resolves to a normal exit")
+    func cleanExitIsNormalExit() {
+        let outcome = BEAMProcessManager.terminationOutcome(
+            status: 0, isShuttingDown: false, recentRestartCount: 2, maxRestarts: 3
+        )
+        #expect(outcome == .normalExit)
+    }
+
+    @Test("crash within budget schedules a backoff restart")
+    func crashWithinBudgetRestarts() {
+        #expect(
+            BEAMProcessManager.terminationOutcome(
+                status: 1, isShuttingDown: false, recentRestartCount: 0, maxRestarts: 3
+            ) == .restart(delay: 0.1)
+        )
+        #expect(
+            BEAMProcessManager.terminationOutcome(
+                status: 1, isShuttingDown: false, recentRestartCount: 1, maxRestarts: 3
+            ) == .restart(delay: 0.2)
+        )
+        #expect(
+            BEAMProcessManager.terminationOutcome(
+                status: 1, isShuttingDown: false, recentRestartCount: 2, maxRestarts: 3
+            ) == .restart(delay: 0.4)
+        )
+    }
+
+    @Test("crash past the budget resolves to give up (recovery surface)")
+    func crashPastBudgetGivesUp() {
+        let outcome = BEAMProcessManager.terminationOutcome(
+            status: 1, isShuttingDown: false, recentRestartCount: 3, maxRestarts: 3
+        )
+        #expect(outcome == .giveUp)
+    }
+
+    // MARK: - Main-actor is never blocked by the termination path (#2698 defect B)
+
+    @Test("give-up path invokes recovery without blocking the main actor")
+    @MainActor func giveUpDoesNotBlockMainActor() {
+        let manager = BEAMProcessManager()
+        var recoveryPresented = false
+        var normalExited = false
+        manager.onCrash = { recoveryPresented = true }
+        manager.onNormalExit = { normalExited = true }
+
+        // Seed the crash history to the restart limit so the next crash gives up.
+        manager.primeRestartHistoryForTesting(count: 3)
+
+        let start = Date()
+        manager.handleTermination(status: 1, reason: .exit)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(recoveryPresented == true)
+        #expect(normalExited == false)
+        // The handler must return effectively instantly; a synchronous restart
+        // wait or a terminate wedge would take far longer than this budget.
+        #expect(elapsed < 0.1)
+        #expect(manager.hasLiveProcess == false)
+    }
+
+    @Test("restart path returns immediately and defers the respawn")
+    @MainActor func restartPathDoesNotBlockMainActor() {
+        let manager = BEAMProcessManager()
+        var recoveryPresented = false
+        var normalExited = false
+        manager.onCrash = { recoveryPresented = true }
+        manager.onNormalExit = { normalExited = true }
+
+        let start = Date()
+        manager.handleTermination(status: 1, reason: .exit)
+        let elapsed = Date().timeIntervalSince(start)
+
+        // First crash: neither give up nor normal exit; the respawn is deferred
+        // to a later main-actor turn, so nothing runs synchronously here.
+        #expect(recoveryPresented == false)
+        #expect(normalExited == false)
+        #expect(elapsed < 0.1)
+    }
+
+    @Test("clean exit routes to normal exit, not recovery")
+    @MainActor func cleanExitRoutesToNormalExit() {
+        let manager = BEAMProcessManager()
+        var recoveryPresented = false
+        var normalExited = false
+        manager.onCrash = { recoveryPresented = true }
+        manager.onNormalExit = { normalExited = true }
+
+        manager.handleTermination(status: 0, reason: .exit)
+
+        #expect(normalExited == true)
+        #expect(recoveryPresented == false)
+    }
+}


### PR DESCRIPTION
Closes #2698 (critical, from the live frozen-app diagnosis).

## Root cause (named, per AC2)

**A — the BEAM died on backgrounding:** the GUI was App Nap eligible (Info.plist disables sudden/automatic termination but nothing held an activity assertion). macOS suspending/reaping the occluded GUI dropped the BEAM's stdin pipe, and the frontend manager's `:eof` handler correctly ran `System.stop(0)` (`frontend/manager.ex:243-245` — orphan cleanup, spuriously triggered). Matches all captured evidence: clean status-0 exit, no crash dump, supervisor `:shutdown` cascade.

**B — the GUI froze on the death:** `handleTermination` → `NSApp.terminate` → `applicationShouldTerminate` returned `.terminateLater`, but `shutdownGracefully` early-returned on the already-dead process so `reply(toApplicationShouldTerminate:)` never fired — the main runloop parked forever (the sampled 100%-parked stack).

## Fix + lifecycle audit (AC4)

- `ProcessInfo.beginActivity` held for the BEAM child's lifetime (idempotent take in `start()`, released only in `shutdownGracefully()`; restart paths retain the token — review-verified no leak/double-begin). BEAM-side EOF contract deliberately unchanged: genuine GUI death must still stop the node.
- Terminate protocol verified reply-safe on every path: live Cmd-Q (reply on clean exit AND SIGKILL timeout), dead-process Cmd-Q (`.terminateNow` — the wedge fix), `:qa` (status-0 → normalExit → terminate → `.terminateNow`; the old wedge site), SIGTERM-vs-handler race safe via main-actor `isShuttingDown` ordering.
- Pure `terminationOutcome` (.normalExit/.restart-with-backoff/.giveUp); give-up defers the **Editor Core Stopped** recovery surface to the next main-actor turn (non-blocking, modal-stacking guarded, Restart Editor respawns, app stays quittable).

## Tests

New termination suite: backoff/give-up/normal-exit decision table + main-actor-not-blocked timing assertions. Full Swift suite: 958 tests in 137 suites pass. `applicationShouldTerminate` paths are manual-only by construction (MingaApp excluded from the test target — the right call for NSApp-coupled code).

## Manual smoke required before/at merge (the live App Nap repro can't run headless)

1. Launch Minga.app, `Cmd-H` (or fully occlude) for **>5 minutes** with the display active → foreground: BEAM PID unchanged (`pgrep beam`), session/buffers intact, no restart.
2. `kill <beam pid>` repeatedly past the restart budget → **Editor Core Stopped** surface appears, app clickable and quittable, Restart Editor works.
3. `Cmd-Q` with a live session → clean quit, no lingering processes.
4. `:qa` from inside the editor → app quits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1