### PR TITLE
fix(render): carry the launchpad through the async render snapshot

### DIFF
--- a/lib/minga_editor/frontend/emit/context.ex
+++ b/lib/minga_editor/frontend/emit/context.ex
@@ -124,7 +124,9 @@ defmodule MingaEditor.Frontend.Emit.Context do
       file_tree: State.file_tree_state(state),
       highlight: state.workspace.highlight,
       agent_ui: state.workspace.agent_ui,
-      launchpad: Map.get(state.workspace, :launchpad),
+      # Strict like every sibling field: a snapshot path that drops the
+      # launchpad key must fail loudly, not render the launchpad hidden.
+      launchpad: state.workspace.launchpad,
       completion: State.ModalOverlay.completion(state),
       keymap_scope: state.workspace.keymap_scope,
       editing: state.workspace.editing,

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -131,7 +131,8 @@ defmodule MingaEditor.RenderPipeline.Input do
           cmd_hover_link: EditorState.cmd_hover_link(),
           mouse: Mouse.t(),
           search: Search.t(),
-          keymap_scope: Minga.Keymap.Scope.scope_name()
+          keymap_scope: Minga.Keymap.Scope.scope_name(),
+          launchpad: MingaEditor.State.Launchpad.t() | nil
         }
 
   @type t :: %__MODULE__{
@@ -214,7 +215,12 @@ defmodule MingaEditor.RenderPipeline.Input do
         cmd_hover_link: ws.cmd_hover_link,
         mouse: ws.mouse,
         search: ws.search,
-        keymap_scope: ws.keymap_scope
+        keymap_scope: ws.keymap_scope,
+        # The zero-buffers launchpad (#2689) must survive the async render
+        # snapshot: Emit.Context reads it to build the gui_empty_state frame,
+        # and omitting it here silently rendered the launchpad hidden on
+        # every production frame while sync-path tests stayed green.
+        launchpad: ws.launchpad
       }
     }
     |> sync_active_window_cursor()

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -31,8 +31,13 @@ defmodule MingaEditor.RenderPipeline.Input do
 
   **From `state.workspace` (per-tab editing context, stored as `workspace` map):**
   `windows`, `buffers`, `viewport`, `file_tree` (FileTree feature state), `highlight`,
-  `agent_ui`, `editing`, `document_highlights`,
-  `search`, `keymap_scope`
+  `agent_ui`, `editing`, `document_highlights`, `cmd_hover_link`, `mouse`,
+  `search`, `keymap_scope`, `launchpad`
+
+  Every `Session.State` field must be either snapshotted here or listed in
+  the explicit exclusions pinned by
+  `test/minga_editor/render_pipeline/input_launchpad_test.exs` — a field in
+  neither silently disappears on the async render path (#2689).
 
   Note: completion lives on `state.shell_state.modal` after #1426; the
   fingerprint includes the modal sum type, so completion changes are
@@ -216,10 +221,9 @@ defmodule MingaEditor.RenderPipeline.Input do
         mouse: ws.mouse,
         search: ws.search,
         keymap_scope: ws.keymap_scope,
-        # The zero-buffers launchpad (#2689) must survive the async render
-        # snapshot: Emit.Context reads it to build the gui_empty_state frame,
-        # and omitting it here silently rendered the launchpad hidden on
-        # every production frame while sync-path tests stayed green.
+        # Emit.Context builds the gui_empty_state frame from this; only the
+        # async path crosses this snapshot, so dropping it is invisible to
+        # sync-path tests (#2689).
         launchpad: ws.launchpad
       }
     }

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -170,7 +170,7 @@ defmodule MingaEditor.StatusBar.Data do
     buf = state.workspace.buffers.active
     {line, col} = if buf, do: Buffer.cursor(buf), else: {0, 0}
     line_count = if buf, do: Buffer.line_count(buf), else: 1
-    file_name = if buf, do: buf_display_name(buf), else: "[no file]"
+    file_name = if buf, do: buf_display_name(buf), else: no_buffer_file_name(state)
     dirty = buf != nil and Buffer.dirty?(buf)
     filetype = if buf, do: buffer_filetype(buf), else: :text
     file_path = if buf, do: buffer_file_path(buf), else: nil
@@ -257,6 +257,14 @@ defmodule MingaEditor.StatusBar.Data do
   @spec register_prefix(String.t()) :: String.t()
   defp register_prefix(""), do: ""
   defp register_prefix(name), do: "\"" <> name
+
+  # In the zero-buffers launchpad (#2689) the file segment stays empty
+  # instead of advertising a "[no file]" placeholder; any other nil-buffer
+  # context (transient races) keeps the placeholder.
+  @spec no_buffer_file_name(EditorState.t() | map()) :: String.t()
+  defp no_buffer_file_name(state) do
+    if Map.get(state.workspace, :launchpad), do: "", else: "[no file]"
+  end
 
   @spec buf_display_name(pid()) :: String.t()
   defp buf_display_name(buf) do

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -263,7 +263,7 @@ defmodule MingaEditor.StatusBar.Data do
   # context (transient races) keeps the placeholder.
   @spec no_buffer_file_name(EditorState.t() | map()) :: String.t()
   defp no_buffer_file_name(state) do
-    if Map.get(state.workspace, :launchpad), do: "", else: "[no file]"
+    if state.workspace.launchpad, do: "", else: "[no file]"
   end
 
   @spec buf_display_name(pid()) :: String.t()

--- a/test/minga_editor/render_pipeline/input_launchpad_test.exs
+++ b/test/minga_editor/render_pipeline/input_launchpad_test.exs
@@ -1,0 +1,78 @@
+defmodule MingaEditor.RenderPipeline.InputLaunchpadTest do
+  @moduledoc """
+  Regression pin for the async-render launchpad omission (#2689 follow-up).
+
+  Production rendering snapshots editor state into `RenderPipeline.Input`
+  (a plain workspace map with an explicit field list) before the emit
+  context is built. The launchpad field was missing from that snapshot, so
+  every real frame rendered the launchpad hidden while sync-path tests
+  stayed green. This test drives the exact production layering:
+  state -> Input -> Emit.Context -> UI builder -> encoder.
+  """
+  use ExUnit.Case, async: true
+
+  @moduletag :tmp_dir
+
+  alias Minga.Config.Options
+  alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EmptyStateEncoder
+  alias MingaEditor.Frontend.Emit.Context
+  alias MingaEditor.RenderModel.UI.Builder
+  alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.Startup
+
+  @op_gui_empty_state Minga.Protocol.Opcodes.gui_empty_state()
+
+  test "a bufferless boot emits a visible launchpad through the async render snapshot", %{
+    tmp_dir: tmp
+  } do
+    {:ok, options} = Options.start_link(name: nil)
+
+    state =
+      Startup.build_initial_state(
+        port_manager: nil,
+        options_server: options,
+        buffer: nil,
+        width: 80,
+        height: 24,
+        editing_model: :vim,
+        session_dir: Path.join(tmp, "sessions")
+      )
+
+    input = Input.from_editor_state(state)
+    assert input.workspace.launchpad != nil
+
+    ctx = Context.from_editor_state(input)
+    assert ctx.launchpad != nil
+
+    {ui, _ctx} = Builder.build_ui(ctx)
+    assert ui.empty_state.visible?
+
+    {cmd, _caches} = EmptyStateEncoder.encode(ui.empty_state, Caches.new())
+    assert <<@op_gui_empty_state, _len::16, 1::8, _rest::binary>> = cmd
+  end
+
+  test "a buffer-backed boot emits the launchpad as hidden", %{tmp_dir: tmp} do
+    {:ok, buffer} = Minga.Buffer.Process.start_link(content: "hello")
+    {:ok, options} = Options.start_link(name: nil)
+
+    state =
+      Startup.build_initial_state(
+        port_manager: nil,
+        options_server: options,
+        buffer: buffer,
+        width: 80,
+        height: 24,
+        editing_model: :vim,
+        session_dir: Path.join(tmp, "sessions")
+      )
+
+    input = Input.from_editor_state(state)
+    assert input.workspace.launchpad == nil
+
+    ctx = Context.from_editor_state(input)
+    {ui, _ctx} = Builder.build_ui(ctx)
+
+    refute ui.empty_state.visible?
+  end
+end

--- a/test/minga_editor/render_pipeline/input_launchpad_test.exs
+++ b/test/minga_editor/render_pipeline/input_launchpad_test.exs
@@ -6,8 +6,10 @@ defmodule MingaEditor.RenderPipeline.InputLaunchpadTest do
   (a plain workspace map with an explicit field list) before the emit
   context is built. The launchpad field was missing from that snapshot, so
   every real frame rendered the launchpad hidden while sync-path tests
-  stayed green. This test drives the exact production layering:
-  state -> Input -> Emit.Context -> UI builder -> encoder.
+  stayed green. These tests drive the exact production layering
+  (state -> Input -> Emit.Context -> UI builder -> encoder) and pin the
+  snapshot field list against `Session.State` so the next new field must
+  be explicitly triaged instead of silently dropped.
   """
   use ExUnit.Case, async: true
 
@@ -19,27 +21,39 @@ defmodule MingaEditor.RenderPipeline.InputLaunchpadTest do
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.RenderModel.UI.Builder
   alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Startup
 
   @op_gui_empty_state Minga.Protocol.Opcodes.gui_empty_state()
 
+  # Session.State fields deliberately NOT carried by the async render
+  # snapshot. A new workspace field must land here or in
+  # `Input.from_editor_state/1`'s workspace map; being in neither means it
+  # silently disappears on the async render path (the #2689 launchpad bug).
+  @snapshot_excluded_fields [
+    :dired,
+    :lsp_pending,
+    :injection_ranges,
+    :feature_state,
+    :cmd_hover_cell
+  ]
+
+  test "the async render snapshot triages every Session.State field", %{tmp_dir: tmp} do
+    input = tmp |> boot_state(nil) |> Input.from_editor_state()
+
+    workspace_fields =
+      SessionState.__struct__() |> Map.delete(:__struct__) |> Map.keys() |> Enum.sort()
+
+    accounted_fields =
+      (Map.keys(input.workspace) ++ @snapshot_excluded_fields) |> Enum.sort()
+
+    assert accounted_fields == workspace_fields
+  end
+
   test "a bufferless boot emits a visible launchpad through the async render snapshot", %{
     tmp_dir: tmp
   } do
-    {:ok, options} = Options.start_link(name: nil)
-
-    state =
-      Startup.build_initial_state(
-        port_manager: nil,
-        options_server: options,
-        buffer: nil,
-        width: 80,
-        height: 24,
-        editing_model: :vim,
-        session_dir: Path.join(tmp, "sessions")
-      )
-
-    input = Input.from_editor_state(state)
+    input = tmp |> boot_state(nil) |> Input.from_editor_state()
     assert input.workspace.launchpad != nil
 
     ctx = Context.from_editor_state(input)
@@ -54,25 +68,28 @@ defmodule MingaEditor.RenderPipeline.InputLaunchpadTest do
 
   test "a buffer-backed boot emits the launchpad as hidden", %{tmp_dir: tmp} do
     {:ok, buffer} = Minga.Buffer.Process.start_link(content: "hello")
-    {:ok, options} = Options.start_link(name: nil)
 
-    state =
-      Startup.build_initial_state(
-        port_manager: nil,
-        options_server: options,
-        buffer: buffer,
-        width: 80,
-        height: 24,
-        editing_model: :vim,
-        session_dir: Path.join(tmp, "sessions")
-      )
-
-    input = Input.from_editor_state(state)
+    input = tmp |> boot_state(buffer) |> Input.from_editor_state()
     assert input.workspace.launchpad == nil
 
     ctx = Context.from_editor_state(input)
     {ui, _ctx} = Builder.build_ui(ctx)
 
     refute ui.empty_state.visible?
+  end
+
+  @spec boot_state(String.t(), pid() | nil) :: MingaEditor.State.t()
+  defp boot_state(tmp, buffer) do
+    {:ok, options} = Options.start_link(name: nil)
+
+    Startup.build_initial_state(
+      port_manager: nil,
+      options_server: options,
+      buffer: buffer,
+      width: 80,
+      height: 24,
+      editing_model: :vim,
+      session_dir: Path.join(tmp, "sessions")
+    )
   end
 end


### PR DESCRIPTION
# TL;DR
The launchpad shipped in #2702 never appeared on a real boot: the production async render path snapshots editor state into `RenderPipeline.Input`, whose workspace is a plain map with an explicit field list — and `launchpad` was missing from it. Every real frame therefore emitted `gui_empty_state` as hidden, leaving a blank editor surface with a default flickering cursor on both frontends.

Part of #2689 follow-up (reported from a fresh boot after the merge).

## Context
`Emit.Context` read the missing key with a tolerant `Map.get` (added for bare-map test fixtures), which silently masked the omission instead of crashing. All #2702 tests exercised the state or the sync path directly and stayed green; the gap was the Input snapshot layer that only the live renderer crosses.

## Changes
- `RenderPipeline.Input.from_editor_state/1`: adds `launchpad` to the workspace snapshot (+ typespec), with a comment explaining why omitting it renders the launchpad hidden.
- Regression test pinning the exact production layering — state → Input → Emit.Context → UI builder → encoder — in both directions: bufferless boot emits a visible 0xA5 frame; buffer-backed boot emits hidden.
- Statusline AC follow-through: with zero buffers the file segment is now empty instead of the `[no file]` placeholder (scoped to the launchpad state; agent tabs and transient dead-buffer races keep the placeholder).

## Verification
1. `mix test.llm` — full suite green (9869 tests), incl. the two new regression tests.
2. `make lint` — all checks pass.
3. After merge: rebuild the release/app and boot with no file — the launchpad should render on both frontends (BEAM emission verified end-to-end via the new test; a probe on a bufferless editor produces a 322-byte visible 0xA5 frame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)