### PR TITLE
fix(tui): launchpad visual polish — geometry, color hierarchy, no empty statusline pill

### DIFF
--- a/go/tui/internal/ui/empty_state_panel.go
+++ b/go/tui/internal/ui/empty_state_panel.go
@@ -265,13 +265,15 @@ func (m Model) emptyKeycap(text string) string {
 	if text == "RET" {
 		text = "↵"
 	}
+	// Content-hugging chips with one padding cell per side: "SPC" and "f"
+	// get the same visual margin, so chord rows read as evenly spaced keys
+	// instead of a ragged band of fixed-width boxes.
 	return lipgloss.NewStyle().
 		Bold(true).
 		Foreground(p.KeycapText()).
 		Background(p.KeycapSurface()).
-		Width(3).
-		Align(lipgloss.Center).
-		Render(fit(text, 3))
+		Padding(0, 1).
+		Render(text)
 }
 
 // emptyBorderColor returns the card border/title/glyph color for the session
@@ -343,7 +345,7 @@ func (m Model) emptyCardInner(item protocol.EmptyStateItem, inner int, focused b
 	}
 	chip := m.emptyKeycap(item.JumpKey)
 	label := base.Render(item.Label)
-	left := base.Render(" ") + marker + chip + base.Render("   ") + label
+	left := base.Render(" ") + marker + chip + base.Render("  ") + label
 
 	right := ""
 	if item.Detail != "" {
@@ -468,11 +470,13 @@ func (m Model) emptyStartAffordance(item protocol.EmptyStateItem, rowBg color.Co
 // a focused (selection) row the glyph takes the selection foreground for
 // contrast; a missing glyph collapses to a single space so columns stay aligned.
 func (m Model) emptyIcon(item protocol.EmptyStateItem, rowBg color.Color, textColor color.Color, focused bool) string {
+	// Fixed two-cell slot: glyph widths vary (missing, single-cell PUA,
+	// double-cell symbols), and the label column must not shift with them.
+	style := lipgloss.NewStyle().Background(rowBg).Width(2).MaxWidth(2)
 	glyph := strings.TrimSpace(item.Icon)
 	if glyph == "" {
-		return lipgloss.NewStyle().Background(rowBg).Render(" ")
+		return style.Render(" ")
 	}
-	style := lipgloss.NewStyle().Background(rowBg)
 	if focused {
 		style = style.Foreground(textColor)
 	} else if item.IconColor != 0 {

--- a/go/tui/internal/ui/empty_state_panel.go
+++ b/go/tui/internal/ui/empty_state_panel.go
@@ -106,13 +106,13 @@ func (m Model) renderEmptyState(state protocol.EmptyState) []string {
 			col = append(col, m.emptyBlankCol(colWidth))
 		case emptyStateSectionRecent:
 			if showChrome {
-				col = append(col, m.emptyRule(section.Title, colWidth, m.palette().PopupBorder()))
+				col = append(col, m.emptyRule(section.Title, colWidth, m.palette().TextFaint()))
 			}
 			col = append(col, m.emptyRecentRows(section, colWidth, focusID, recentCap, dropDir)...)
 			col = append(col, m.emptyBlankCol(colWidth))
 		case emptyStateSectionStart:
 			if showChrome {
-				col = append(col, m.emptyRule(section.Title, colWidth, m.palette().PopupBorder()))
+				col = append(col, m.emptyRule(section.Title, colWidth, m.palette().TextFaint()))
 			}
 			col = append(col, m.emptyStartRows(section, colWidth, focusID)...)
 			col = append(col, m.emptyBlankCol(colWidth))
@@ -144,7 +144,7 @@ func (m Model) emptyStateMinimal(state protocol.EmptyState, width int, height in
 		lipgloss.NewStyle().Background(bg).Render(" ") +
 		lipgloss.NewStyle().Bold(true).Foreground(p.Text()).Background(bg).Render("minga")
 	if v := strings.TrimSpace(state.Version); v != "" {
-		mark += lipgloss.NewStyle().Background(bg).Render(" ") + lipgloss.NewStyle().Foreground(p.Muted()).Background(bg).Render(v)
+		mark += lipgloss.NewStyle().Background(bg).Render(" ") + lipgloss.NewStyle().Foreground(p.TextFaint()).Background(bg).Render(v)
 	}
 
 	col := []string{m.emptyCenterInCol(mark, colWidth)}
@@ -240,45 +240,51 @@ func (m Model) emptyWordmark(version string, colWidth int) string {
 	space := lipgloss.NewStyle().Background(bg)
 	mark := diamond + space.Render("  ") + name
 	if v := strings.TrimSpace(version); v != "" {
-		mark += space.Render("   ") + lipgloss.NewStyle().Foreground(p.Muted()).Background(bg).Render(v)
+		mark += space.Render("   ") + lipgloss.NewStyle().Foreground(p.TextFaint()).Background(bg).Render(v)
 	}
 	return m.emptyCenterInCol(mark, colWidth)
 }
 
-// emptyRule renders a labeled section rule: `─── Label ───────` with the dashes
-// in the border color and the label muted-bold.
+// emptyRule renders a labeled section rule: `─── LABEL ───────`. Rules are
+// tertiary chrome: faint dashes and an uppercase muted label, receding below
+// row labels so the hero card carries the only at-rest emphasis.
 func (m Model) emptyRule(title string, colWidth int, borderColor color.Color) string {
 	p := m.palette()
 	bg := m.editorBackground()
 	dash := lipgloss.NewStyle().Foreground(borderColor).Background(bg)
-	label := lipgloss.NewStyle().Bold(true).Foreground(p.Muted()).Background(bg).Render(title)
+	label := lipgloss.NewStyle().Foreground(p.Muted()).Background(bg).Render(strings.ToUpper(title))
 	content := dash.Render("  ─── ") + label + dash.Render(" ")
 	fill := max(colWidth-lipgloss.Width(content), 0)
 	content += dash.Render(strings.Repeat("─", fill))
 	return m.emptyPadExact(content, colWidth)
 }
 
-// emptyKeycap renders a bold keycap chip on the keycap surface, 3 cells wide and
-// centered, matching the which-key overlay chips. RET renders as ↵.
-func (m Model) emptyKeycap(text string) string {
+// emptyKeycap renders a content-hugging keycap chip (one padding cell per
+// side, so "SPC" and "f" get the same visual margin). Two classes: jump chips
+// are "press me right now" affordances in accent on the accent wash; chord
+// chips are quiet educational neutrals on the chip surface. KeycapSurface is
+// deliberately NOT used here — it is tuned for elevated popup backgrounds
+// (which-key) and outshines everything on the editor surface. RET renders as ↵.
+func (m Model) emptyKeycap(text string, jump bool) string {
 	p := m.palette()
 	if text == "RET" {
 		text = "↵"
 	}
-	// Content-hugging chips with one padding cell per side: "SPC" and "f"
-	// get the same visual margin, so chord rows read as evenly spaced keys
-	// instead of a ragged band of fixed-width boxes.
-	return lipgloss.NewStyle().
-		Bold(true).
-		Foreground(p.KeycapText()).
-		Background(p.KeycapSurface()).
-		Padding(0, 1).
-		Render(text)
+
+	style := lipgloss.NewStyle().Padding(0, 1)
+	if jump {
+		style = style.Bold(true).Foreground(p.Accent()).Background(p.AccentWash())
+	} else {
+		style = style.Foreground(p.Muted()).Background(p.ChipSurface())
+	}
+
+	return style.Render(text)
 }
 
 // emptyBorderColor returns the card border/title/glyph color for the session
-// hero: warning on crash, accent while a row inside is focused, otherwise the
-// dim popup border. Only one accent border exists on screen at a time.
+// hero: warning on crash, accent while a row inside is focused, otherwise a
+// dimmed accent so the hero is the only accent-hued element at rest. Only one
+// full-accent border exists on screen at a time.
 func (m Model) emptyBorderColor(crashed bool, focused bool) color.Color {
 	p := m.palette()
 	switch {
@@ -287,7 +293,7 @@ func (m Model) emptyBorderColor(crashed bool, focused bool) color.Color {
 	case focused:
 		return p.Accent()
 	default:
-		return p.PopupBorder()
+		return p.AccentSoft()
 	}
 }
 
@@ -330,21 +336,21 @@ func (m Model) emptySessionSection(section protocol.EmptyStateSection, colWidth 
 func (m Model) emptyCardInner(item protocol.EmptyStateItem, inner int, focused bool) string {
 	p := m.palette()
 	var rowBg color.Color = m.editorBackground()
-	textColor := p.Text()
-	detailColor := p.Muted()
+	detailColor := p.TextFaint()
 	if focused {
-		rowBg = p.Selection()
-		textColor = p.SelectionText()
-		detailColor = p.SelectionText()
+		// A faint accent wash instead of the heavy text-selection gray: the
+		// bold label, accent marker, and chip keep their contrast on it.
+		rowBg = p.AccentWash()
+		detailColor = p.Muted()
 	}
-	base := lipgloss.NewStyle().Foreground(textColor).Background(rowBg)
+	base := lipgloss.NewStyle().Foreground(p.Text()).Background(rowBg)
 
 	marker := base.Render("  ")
 	if focused {
 		marker = lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(rowBg).Render("▸") + base.Render(" ")
 	}
-	chip := m.emptyKeycap(item.JumpKey)
-	label := base.Render(item.Label)
+	chip := m.emptyKeycap(item.JumpKey, true)
+	label := base.Bold(focused).Render(item.Label)
 	left := base.Render(" ") + marker + chip + base.Render("  ") + label
 
 	right := ""
@@ -381,22 +387,20 @@ func (m Model) emptyRecentRows(section protocol.EmptyStateSection, colWidth int,
 func (m Model) emptyRecentRow(item protocol.EmptyStateItem, colWidth int, focused bool, dropDir bool) string {
 	p := m.palette()
 	var rowBg color.Color = m.editorBackground()
-	textColor := p.Text()
-	detailColor := p.Muted()
+	detailColor := p.TextFaint()
 	if focused {
-		rowBg = p.Selection()
-		textColor = p.SelectionText()
-		detailColor = p.SelectionText()
+		rowBg = p.AccentWash()
+		detailColor = p.Muted()
 	}
-	base := lipgloss.NewStyle().Foreground(textColor).Background(rowBg)
+	base := lipgloss.NewStyle().Foreground(p.Text()).Background(rowBg)
 
 	marker := base.Render("  ")
 	if focused {
 		marker = lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(rowBg).Render("▸") + base.Render(" ")
 	}
-	chip := m.emptyKeycap(item.JumpKey)
-	icon := m.emptyIcon(item, rowBg, textColor, focused)
-	label := base.Render(item.Label)
+	chip := m.emptyKeycap(item.JumpKey, true)
+	icon := m.emptyIcon(item, rowBg, p.Text(), focused)
+	label := base.Bold(focused).Render(item.Label)
 	left := base.Render(" ") + marker + chip + base.Render("  ") + icon + base.Render(" ") + label
 
 	right := ""
@@ -424,19 +428,17 @@ func (m Model) emptyStartRows(section protocol.EmptyStateSection, colWidth int, 
 func (m Model) emptyStartRow(item protocol.EmptyStateItem, colWidth int, focused bool) string {
 	p := m.palette()
 	var rowBg color.Color = m.editorBackground()
-	textColor := p.Text()
 	if focused {
-		rowBg = p.Selection()
-		textColor = p.SelectionText()
+		rowBg = p.AccentWash()
 	}
-	base := lipgloss.NewStyle().Foreground(textColor).Background(rowBg)
+	base := lipgloss.NewStyle().Foreground(p.Text()).Background(rowBg)
 
 	marker := base.Render("  ")
 	if focused {
 		marker = lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(rowBg).Render("▸") + base.Render(" ")
 	}
-	icon := m.emptyIcon(item, rowBg, textColor, focused)
-	label := base.Render(item.Label)
+	icon := m.emptyIcon(item, rowBg, p.Text(), focused)
+	label := base.Bold(focused).Render(item.Label)
 	left := base.Render(" ") + marker + base.Render("  ") + icon + base.Render("  ") + label
 
 	right := m.emptyStartAffordance(item, rowBg, base)
@@ -453,7 +455,7 @@ func (m Model) emptyStartAffordance(item protocol.EmptyStateItem, rowBg color.Co
 		tokens := strings.Fields(item.Chord)
 		parts := make([]string, 0, len(tokens))
 		for _, token := range tokens {
-			parts = append(parts, m.emptyKeycap(token))
+			parts = append(parts, m.emptyKeycap(token, false))
 		}
 		return strings.Join(parts, base.Render(" ")) + base.Render(" ")
 	}
@@ -461,15 +463,15 @@ func (m Model) emptyStartAffordance(item protocol.EmptyStateItem, rowBg color.Co
 		return lipgloss.NewStyle().Bold(true).Foreground(p.Accent()).Background(rowBg).Render(strings.TrimSpace(item.Detail)) + base.Render(" ")
 	}
 	if item.Detail != "" {
-		return lipgloss.NewStyle().Foreground(p.Muted()).Background(rowBg).Render(item.Detail) + base.Render(" ")
+		return lipgloss.NewStyle().Foreground(p.TextFaint()).Background(rowBg).Render(item.Detail) + base.Render(" ")
 	}
 	return ""
 }
 
-// emptyIcon renders an item's devicon glyph colored by its wire icon_color. On
-// a focused (selection) row the glyph takes the selection foreground for
-// contrast; a missing glyph collapses to a single space so columns stay aligned.
-func (m Model) emptyIcon(item protocol.EmptyStateItem, rowBg color.Color, textColor color.Color, focused bool) string {
+// emptyIcon renders an item's devicon glyph colored by its wire icon_color —
+// on focused rows too, since the accent wash is faint enough for full-color
+// glyphs to read against it. A missing glyph keeps the slot so columns align.
+func (m Model) emptyIcon(item protocol.EmptyStateItem, rowBg color.Color, textColor color.Color, _ bool) string {
 	// Fixed two-cell slot: glyph widths vary (missing, single-cell PUA,
 	// double-cell symbols), and the label column must not shift with them.
 	style := lipgloss.NewStyle().Background(rowBg).Width(2).MaxWidth(2)
@@ -477,9 +479,7 @@ func (m Model) emptyIcon(item protocol.EmptyStateItem, rowBg color.Color, textCo
 	if glyph == "" {
 		return style.Render(" ")
 	}
-	if focused {
-		style = style.Foreground(textColor)
-	} else if item.IconColor != 0 {
+	if item.IconColor != 0 {
 		style = style.Foreground(lipgloss.Color(iconColorHex(item.IconColor)))
 	} else {
 		style = style.Foreground(textColor)
@@ -524,5 +524,7 @@ func (m Model) footerFragment(items []protocol.EmptyStateItem) string {
 		}
 		parts = append(parts, fragment)
 	}
-	return strings.Join(parts, verbStyle.Render("  ·  "))
+
+	dotStyle := lipgloss.NewStyle().Foreground(p.TextFaint()).Background(bg)
+	return strings.Join(parts, dotStyle.Render("  ·  "))
 }

--- a/go/tui/internal/ui/empty_state_panel_test.go
+++ b/go/tui/internal/ui/empty_state_panel_test.go
@@ -68,14 +68,14 @@ func TestRenderEmptyStateShowsLaunchpadContent(t *testing.T) {
 
 	for _, want := range []string{
 		"m i n g a", // letter-spaced wordmark
-		"v0.9",      // muted version
-		"Session",   // session card title in the top border
+		"v0.9",      // faint version
+		"Session",   // session card title in the top border (cards keep case)
 		"resume last session",
 		"4 files",          // right-aligned detail
-		"Recent",           // section rule label
+		"RECENT",           // section rule label (uppercased at render time)
 		"startup.ex",       // recent basename
 		"lib/minga_editor", // recent directory (width >= 64 keeps it)
-		"Start",
+		"START",
 		"open file",
 		"SPC",   // chord chip token
 		"write", // footer verb

--- a/go/tui/internal/ui/theme.go
+++ b/go/tui/internal/ui/theme.go
@@ -347,6 +347,26 @@ func (p palette) TreeFocus() color.Color {
 	return p.blendSlots(themeTreeBG, themeTreeSelectBG, 0.4)
 }
 
+// ChipSurface returns a neutral keycap background for chips sitting directly on the editor surface. KeycapSurface is tuned for elevated popup backgrounds (which-key) and reads far too bright here; this blends a whisper above the editor background instead.
+func (p palette) ChipSurface() color.Color {
+	return p.blendSlots(themeEditorBG, themeSelectionBG, 0.55)
+}
+
+// AccentWash returns a faint accent-tinted background for the launchpad focus band and jump-key chips: visible hue without swallowing bold text or colored glyphs rendered over it.
+func (p palette) AccentWash() color.Color {
+	return p.blendSlots(themeEditorBG, themeAccent, 0.16)
+}
+
+// AccentSoft returns a dimmed accent for at-rest emphasis (the launchpad hero border), clearly hued but below the full Accent used for the focused state.
+func (p palette) AccentSoft() color.Color {
+	return p.blendSlots(themeEditorBG, themeAccent, 0.45)
+}
+
+// TextFaint returns a below-Muted foreground tier for tertiary chrome (versions, directories, rule dashes, middots) so secondary text keeps a visible step above it.
+func (p palette) TextFaint() color.Color {
+	return p.blendSlots(themeEditorBG, themeTabInactiveFG, 0.65)
+}
+
 func (p palette) TreeSelectionText() color.Color {
 	return p.slot(themeTreeSelectionFG)
 }

--- a/lib/minga_editor/shell/traditional/modeline.ex
+++ b/lib/minga_editor/shell/traditional/modeline.ex
@@ -494,10 +494,15 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
         _other -> ""
       end
 
-    [
-      {" #{data.file_name}#{data.dirty_marker}#{buf_indicator}#{macro_indicator} ", ctx.info_fg,
-       ctx.info_bg, [], :buffer_list}
-    ]
+    text = " #{data.file_name}#{data.dirty_marker}#{buf_indicator}#{macro_indicator} "
+
+    # An empty file name (the zero-buffers launchpad, #2689) drops the whole
+    # segment instead of rendering a blank padded pill.
+    if String.trim(text) == "" do
+      []
+    else
+      [{text, ctx.info_fg, ctx.info_bg, [], :buffer_list}]
+    end
   end
 
   @spec render_filetype(context()) :: [render_segment()]


### PR DESCRIPTION
# TL;DR
Two polish passes on the launchpad's first real render (screenshot feedback on #2689): a geometry pass (even keycap chips, aligned columns, mockup-true hero spacing, no blank statusline pill) and a minga-ux color/contrast restyle that gives the surface a real visual hierarchy instead of a washed monochrome band.

Part of #2689 follow-up.

## Geometry pass
- `emptyKeycap`: content-hugging chips (`Padding(0,1)`) replace fixed 3-wide centered cells — `SPC` and single-char tokens get identical margins, chord rows share a right edge.
- `emptyIcon`: fixed 2-cell slot so labels stay in one column regardless of glyph width.
- `emptyCardInner`: keycap→label gap matches the v3 mockup.
- `Modeline.render_filename` (Elixir): a blank composed segment (launchpad's empty file name) drops entirely instead of rendering an empty padded pill next to `W:Files`.

## Color/contrast restyle (minga-ux spec)
Root cause: the launchpad borrowed roles tuned for other surfaces — `KeycapSurface` (popup-tuned) made every chip the brightest object on screen, and the `Selection()` focus band (text-selection gray) swallowed the accent marker and `:Tutor`.

Four new theme-derived getters using the existing `blendSlots` mechanism (the `TreeFocus` precedent — no hardcoded hex, degrades sanely on light themes): `ChipSurface` (neutral chips a whisper above the editor bg), `AccentWash` (faint accent tint: focus band + jump chips), `AccentSoft` (at-rest hero border), `TextFaint` (below-Muted tier: version, directories, rule dashes, middots).

Resulting hierarchy: **hero card first** (only accent-hued element at rest, escalating AccentSoft → Accent on focus → Warning on crash), **labels + colored devicons second** (devicons keep wire color on focused rows), **chrome third** (uppercase muted rule labels over faint dashes). Accent now means exactly one thing — actionable right now: jump chips, ex-commands, focus marker, footer keys. Durable chords recede to quiet neutrals.

## Verification
1. Plain-text render dumps at 120×40 before/after confirm mockup-true geometry; a style probe confirmed jump vs chord chips, `ChipSurface` vs `KeycapSurface`, and `AccentWash` vs `Selection()` all render distinctly.
2. `go test ./...` — 562 pass; `gofmt` clean.
3. `mix test.llm` — 9870 pass; `make lint` — all checks pass (Elixir change predates the restyle commit).
4. After merge: rebuild and boot with no file — judge by squinting: hero first, labels second, chrome third. Colors are blend-derived from your theme, so a low-chroma theme intentionally stays quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)