### PR TITLE
feat(macos): live resize presents a crop and defers re-layout to a trailing debounce

### DIFF
--- a/docs/workstreams/resident-scroll.md
+++ b/docs/workstreams/resident-scroll.md
@@ -42,7 +42,7 @@ Applied and approved so far:
 
 - Buffer scrolling: epic [#2652](https://github.com/jsmestad/minga/issues/2652), ready-now slice [#2653](https://github.com/jsmestad/minga/issues/2653).
 - Agent chat transcript residency: [#2654](https://github.com/jsmestad/minga/issues/2654), after #2652's store lifecycle lands.
-- Live resize as local presentation with debounced re-layout: [#2655](https://github.com/jsmestad/minga/issues/2655).
+- Live resize as local presentation with debounced re-layout: [#2655](https://github.com/jsmestad/minga/issues/2655) — **shipped**: during a window-edge drag the GUI presents the last committed frame as a top-left crop and defers re-layout through a trailing debounce (75ms, 250ms max-wait, `LiveResizeBookkeeping` in `LiveResizeDebounce.swift`); the flush is GUI-side only (#2699 sole-emitter), the BEAM and TUI are untouched.
 
 Considered and deliberately skipped for now (revisit only with evidence of real latency pain): local fuzzy-filtering in pickers/completion (duplicates match semantics per frontend), keymap-trie prefetch for instant which-key, and local incremental-search highlighting (duplicates regex semantics; prefer BEAM-computed match spans over the resident store).
 

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0A055CC5C6CDA4314F818D7E /* FrameMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B4D69D3277F2372A8F6F1 /* FrameMetrics.swift */; };
 		0B3E634DA8224698DD9BEE4A /* LatencyRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E156287E8ABA1AB91EBF4014 /* LatencyRecorderTests.swift */; };
 		0BCDFB56E8397D739F52ED34 /* StateLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5634B25BE5BB945A83E30FAD /* StateLifecycleTests.swift */; };
+		0C0F3AF675E0AA401FEC648F /* LiveResizeDebounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F60610CCB4E603ACBA360C1 /* LiveResizeDebounce.swift */; };
 		0C218A1F0FFE238D8B2CD7E5 /* ActivityBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA105569D96F7654005293B2 /* ActivityBar.swift */; };
 		0E41F92F8E0358C4847E871E /* LatencyHUDState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B4CB36A83E4FEBF0B58397 /* LatencyHUDState.swift */; };
 		1042F0D41E737771D9D00FB5 /* TextHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87246A39436BB38B41100F9 /* TextHighlighting.swift */; };
@@ -109,6 +110,7 @@
 		63F3CF3A4746901FDF1C3356 /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
 		647346FE3161B2C2FC4A5436 /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
 		64A5A16E02B3E2694060F1A1 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
+		64F4537439FC69C8D9094419 /* LiveResizeDebounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F60610CCB4E603ACBA360C1 /* LiveResizeDebounce.swift */; };
 		66314FC85298ED8BA412C02F /* ProtocolCommandSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB492F643770698E3E7F419 /* ProtocolCommandSizeTests.swift */; };
 		66FAAD91BF8CF5B72C187D02 /* KeybindingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50661EF3472E892F77AF9C2 /* KeybindingsSettingsView.swift */; };
 		6700C63C4B7070D3388A7BD4 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
@@ -147,6 +149,7 @@
 		86526CCD268BB390F0C14C53 /* AgentSurfaceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483AA21EF140F07296D1E16A /* AgentSurfaceTypes.swift */; };
 		87D39424AC2980D7E33F5DB0 /* PortLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E23DC6E0ACB156F21293E87 /* PortLogger.swift */; };
 		888A35D1348A7A3CAE935561 /* DecoderFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */; };
+		88D0A6915FA4D55AB0859E57 /* LiveResizeDebounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F60610CCB4E603ACBA360C1 /* LiveResizeDebounce.swift */; };
 		88EA849750435A68E025FF03 /* PreviewFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BAB83B99298DE01101D3C60 /* PreviewFixtures.swift */; };
 		8936DB5A36F062C95947CD3C /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A733EF649EF21A761608D75 /* MingaWindow.swift */; };
 		8950511FEBB383E5D73B17DA /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D8E70B7413F570FBAC58C1 /* MessagesContentState.swift */; };
@@ -181,6 +184,7 @@
 		A17019B3C14044971571A5F1 /* ProtocolCommandSize.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762CD389E04B0DE6A86CDBF2 /* ProtocolCommandSize.generated.swift */; };
 		A23A42248D022DE42E122D0B /* WorkspaceIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BD32DD25D2C6C5A90D898 /* WorkspaceIndicatorView.swift */; };
 		A29BB96B8F84AA489CBA0C5F /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
+		A30B81F2A7DAA0C2AEF54DB3 /* LiveResizeDebounceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63680361FC590F8BD01FE061 /* LiveResizeDebounceTests.swift */; };
 		A409AE210CBAE48D4DCE47F7 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
 		A4329C17518FA82F5049A8EF /* PresentationScrollAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DADB6D964450D692B37217 /* PresentationScrollAnimatorTests.swift */; };
 		A4E838B0B19ED0B8F9CC4654 /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
@@ -466,6 +470,7 @@
 		60980E90FDD864409144BA5B /* PickerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerState.swift; sourceTree = "<group>"; };
 		620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentRendererTests.swift; sourceTree = "<group>"; };
 		628AAE1DCC1D559B04B81E35 /* FileTreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowView.swift; sourceTree = "<group>"; };
+		63680361FC590F8BD01FE061 /* LiveResizeDebounceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveResizeDebounceTests.swift; sourceTree = "<group>"; };
 		63D118F59FBCA463A52B84FA /* AgentContextBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentContextBar.swift; sourceTree = "<group>"; };
 		644384B6B8FE5F11CD0DB713 /* GUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIState.swift; sourceTree = "<group>"; };
 		64CEFB02A774E5E8EF19029F /* MingaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MingaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -489,6 +494,7 @@
 		7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEncoder.swift; sourceTree = "<group>"; };
 		7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MingaUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInputTests.swift; sourceTree = "<group>"; };
+		7F60610CCB4E603ACBA360C1 /* LiveResizeDebounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveResizeDebounce.swift; sourceTree = "<group>"; };
 		801F49D62225A511B8510EAA /* ConformanceTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConformanceTranscriptTests.swift; sourceTree = "<group>"; };
 		82B744449C852E13511FFE8D /* MinibufferStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinibufferStateTests.swift; sourceTree = "<group>"; };
 		848E04E4F242C861887769F3 /* MingaProtocol.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MingaProtocol.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -793,6 +799,7 @@
 				13E89640A29C207B9040DC67 /* EditorView.swift */,
 				048C53BF025A1476EE8BC1A7 /* IMEComposition.swift */,
 				E4DCF10EBEB51624A4A1F428 /* InlineEditField.swift */,
+				7F60610CCB4E603ACBA360C1 /* LiveResizeDebounce.swift */,
 				29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */,
 				25503C21E0D55E1515A38C7D /* ScrollAccumulator.swift */,
 				11AEAD1E631064BE3B13E42C /* ThumbDragSession.swift */,
@@ -983,6 +990,7 @@
 				7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */,
 				DA53378E05335BC93B342123 /* LatencyHUDStateTests.swift */,
 				E156287E8ABA1AB91EBF4014 /* LatencyRecorderTests.swift */,
+				63680361FC590F8BD01FE061 /* LiveResizeDebounceTests.swift */,
 				B4867C8EE01AF6ACFB27DB7C /* MessagesContentStateTests.swift */,
 				82B744449C852E13511FFE8D /* MinibufferStateTests.swift */,
 				AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */,
@@ -1311,6 +1319,7 @@
 				ABE7AA8517D1D7FBD7CC1816 /* IMEComposition.swift in Sources */,
 				8AB3B55F301192FA4F4A4E41 /* Instrumentation.swift in Sources */,
 				EE84DA1BF4952359DD0DC343 /* LineTextureAtlas.swift in Sources */,
+				0C0F3AF675E0AA401FEC648F /* LiveResizeDebounce.swift in Sources */,
 				BFF766FB4240D9E306D3557E /* MingaApp.swift in Sources */,
 				4B2CF3C29FD0F4B63C7E7027 /* MingaWindow.swift in Sources */,
 				067369CB702835E93D254606 /* PipelineCache.swift in Sources */,
@@ -1359,6 +1368,7 @@
 				D916997E44A9619D08995FDA /* IMEComposition.swift in Sources */,
 				6CF0F1BB4E1BDC0182EDCCB1 /* Instrumentation.swift in Sources */,
 				5C9DBC1F399D8F7BE8EA2701 /* LineTextureAtlas.swift in Sources */,
+				88D0A6915FA4D55AB0859E57 /* LiveResizeDebounce.swift in Sources */,
 				8DBD574DB36A054FBCFC5DD8 /* MingaWindow.swift in Sources */,
 				E3B2DB94D802E1831C17474E /* PipelineCache.swift in Sources */,
 				68886327B4EB9F0766EB7DCD /* PowerThermalPolicy.swift in Sources */,
@@ -1538,6 +1548,8 @@
 				25D865A5AD887E5F31FA162D /* LatencyHUDStateTests.swift in Sources */,
 				0B3E634DA8224698DD9BEE4A /* LatencyRecorderTests.swift in Sources */,
 				26DAAF2C2CCC2713AD30C539 /* LineTextureAtlas.swift in Sources */,
+				64F4537439FC69C8D9094419 /* LiveResizeDebounce.swift in Sources */,
+				A30B81F2A7DAA0C2AEF54DB3 /* LiveResizeDebounceTests.swift in Sources */,
 				637E93B9C1D6B5DBF0E29F05 /* MessagesContentStateTests.swift in Sources */,
 				8936DB5A36F062C95947CD3C /* MingaWindow.swift in Sources */,
 				74AD4B2AD52CF461F0DC5D01 /* MinibufferStateTests.swift in Sources */,

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -108,17 +108,18 @@ final class EditorNSView: MTKView {
     /// keep presenting the last committed frame cropped top-left (the renderer anchors content
     /// in pixel space and fills the grown region with the editor background) and defer the
     /// re-layout to the trailing edge, so the BEAM does one committed re-layout instead of one
-    /// per resize event. The state machine is a pure value type for testability.
-    private var resizeBookkeeping = LiveResizeBookkeeping()
+    /// per resize event. The state machine is a pure value type for testability; the field is
+    /// internal (not private) so integration tests can seed a pending grid and pin the
+    /// exactly-once flush behavior of the wiring.
+    var resizeBookkeeping = LiveResizeBookkeeping()
 
     /// Trailing-edge flush scheduled during a live resize. Cancelled/rescheduled on each resize
     /// frame and flushed immediately at `viewDidEndLiveResize`. Structured concurrency (not a
     /// `DispatchWorkItem`) so the closure is provably main-actor isolated (macOS AGENTS.md).
-    private var resizeDebounceTask: Task<Void, Never>?
+    /// Internal for the same test-seam reason as `resizeBookkeeping`.
+    var resizeDebounceTask: Task<Void, Never>?
 
-    /// Trailing quiescence (75ms) with a 250ms max-wait cap so a continuous drag still
-    /// re-lays out at a bounded rate (AC3) instead of cropping a stale frame forever.
-    private static let resizeDebounceConfig = LiveResizeDebounce.Config(interval: 0.075, maxWait: 0.25)
+    private static let resizeDebounceConfig = LiveResizeDebounce.Config.liveResize
 
     /// Whether macOS has put the displays to sleep. BEAM state may keep changing,
     /// but the Metal surface must not schedule GPU work until screens wake.
@@ -264,6 +265,9 @@ final class EditorNSView: MTKView {
         spaceGraceTimer?.cancel()
         spaceGraceTimer = nil
         cancelResizeFlushTask()
+        // Unlike the thumb drag above (always flushed), a pending resize is deliberately
+        // discarded here: the window is being torn down, so there is no surface left for
+        // the BEAM to lay out.
         resizeBookkeeping = LiveResizeBookkeeping()
         dividerDragState = .none
         setDividerCursorState(.none)
@@ -846,6 +850,10 @@ final class EditorNSView: MTKView {
     /// computed against the old geometry and must not fight the resize.
     override func viewWillStartLiveResize() {
         super.viewWillStartLiveResize()
+        // The crop presented during the drag relies on the drawable auto-tracking the
+        // view (see handleLiveResize); catch a future autoResizeDrawable flip loudly
+        // instead of silently sample-stretching every resize.
+        assert(autoResizeDrawable, "live-resize crop requires MTKView.autoResizeDrawable")
         resetSmoothScrollState()
         // resetSmoothScrollState deliberately spares a live thumb drag; a window
         // resize invalidates the drag's geometry, so it is a forced-reset path:
@@ -853,10 +861,21 @@ final class EditorNSView: MTKView {
         cancelThumbDragWithFlush()
         isDraggingScrollIndicator = false
         scrollIndicatorDragOffset = nil
-        // Drop any in-flight text-drag anchor: pointer input is deferred during the
-        // resize (AC5), so a mouseUp that would clear it may never arrive.
+        // Pointer input is dropped during the resize (AC5), so a mouseUp that would
+        // end an in-flight press may never reach the BEAM. Mirror the thumb-drag
+        // rule: complete the gesture (send the release) before clearing its state.
+        if leftMouseDownPoint != nil {
+            let point = leftMouseDownPoint ?? .zero
+            let (row, col) = rawCellPosition(at: point)
+            encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_LEFT,
+                                   modifiers: 0, eventType: MOUSE_RELEASE)
+        }
         leftMouseDownPoint = nil
         leftMouseDragStarted = false
+        if dividerDragState != .none {
+            dividerDragState = .none
+            setDividerCursorState(.none)
+        }
     }
 
     /// The drag ended. Flush any deferred resize immediately so the view snaps once to a
@@ -917,7 +936,8 @@ final class EditorNSView: MTKView {
     /// Flushes any deferred resize to the BEAM (one committed re-layout) and clears the
     /// debounce bookkeeping. Idempotent: a no-op when nothing is pending or the pending grid
     /// already matches the committed frame (the drag-away-and-back guard, re-applied here).
-    private func flushPendingResize() {
+    /// Internal so integration tests can pin the exactly-once/idempotent contract.
+    func flushPendingResize() {
         cancelResizeFlushTask()
         let committed = LiveResizeBookkeeping.Grid(cols: dispatcher.frameState.cols, rows: dispatcher.frameState.rows)
         guard let target = resizeBookkeeping.takeFlush(committed: committed) else { return }
@@ -1513,9 +1533,12 @@ final class EditorNSView: MTKView {
     // MARK: - Mouse
 
     override func mouseDown(with event: NSEvent) {
-        // Defer pointer input while a live resize is in flight (#2655, AC5): the view
+        // Drop pointer input while a live resize is in flight (#2655, AC5): the view
         // geometry is changing and the on-screen content is a crop of the last committed
-        // frame, so a hit-test would map against stale, in-flux geometry.
+        // frame, so a hit-test would map against stale, in-flux geometry. Events are
+        // discarded, not queued: nothing is replayed after the resize ends. The same
+        // guard gates every geometry-hit-testing handler below; press/release pairs
+        // that straddle a resize are completed by viewWillStartLiveResize instead.
         guard !inLiveResize else { return }
         reclaimFirstResponderIfNeeded()
 
@@ -1574,6 +1597,9 @@ final class EditorNSView: MTKView {
     }
 
     override func rightMouseDown(with event: NSEvent) {
+        // Dropped during a live resize (see mouseDown). The matching rightMouseUp stays
+        // ungated so a press that straddles the resize still delivers its release.
+        guard !inLiveResize else { return }
         reclaimFirstResponderIfNeeded()
         resetCursorBlink()
         let (row, col) = cellPosition(from: event)
@@ -1647,6 +1673,9 @@ final class EditorNSView: MTKView {
     }
 
     override func otherMouseDown(with event: NSEvent) {
+        // Dropped during a live resize (see mouseDown). otherMouseUp stays ungated so a
+        // press that straddles the resize still delivers its release.
+        guard !inLiveResize else { return }
         reclaimFirstResponderIfNeeded()
         let (row, col) = cellPosition(from: event)
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_MIDDLE,
@@ -1789,6 +1818,10 @@ final class EditorNSView: MTKView {
     }
 
     override func scrollWheel(with event: NSEvent) {
+        // Dropped during a live resize like the left-mouse family (see mouseDown): a wheel
+        // event mid-resize would hit-test in-flux geometry and re-establish the scroll
+        // offset the resize discard just cleared.
+        guard !inLiveResize else { return }
         // A resident thumb drag owns scroll presentation while the button is held: ignore concurrent
         // wheel input so the two do not fight over the offset. A post-release reconcile (button up)
         // is superseded by a fresh wheel gesture, so flush-and-drop it and let the wheel take over.
@@ -2487,6 +2520,9 @@ final class EditorNSView: MTKView {
     private let fontSizeReset: UInt8 = 0x02
 
     override func magnify(with event: NSEvent) {
+        // Dropped during a live resize (see mouseDown): font-size changes mid-resize
+        // would invalidate the committed grid the crop is presenting.
+        guard !inLiveResize else { return }
         switch event.phase {
         case .began:
             magnifyAccumulator = 0

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -102,6 +102,24 @@ final class EditorNSView: MTKView {
     /// setFrameSize so we send the actual window dimensions, not hardcoded defaults.
     private var readySent = false
 
+    // MARK: - Live-resize presentation (#2655)
+
+    /// Pending-grid bookkeeping for a live window-edge drag. While a drag is in motion we
+    /// keep presenting the last committed frame cropped top-left (the renderer anchors content
+    /// in pixel space and fills the grown region with the editor background) and defer the
+    /// re-layout to the trailing edge, so the BEAM does one committed re-layout instead of one
+    /// per resize event. The state machine is a pure value type for testability.
+    private var resizeBookkeeping = LiveResizeBookkeeping()
+
+    /// Trailing-edge flush scheduled during a live resize. Cancelled/rescheduled on each resize
+    /// frame and flushed immediately at `viewDidEndLiveResize`. Structured concurrency (not a
+    /// `DispatchWorkItem`) so the closure is provably main-actor isolated (macOS AGENTS.md).
+    private var resizeDebounceTask: Task<Void, Never>?
+
+    /// Trailing quiescence (75ms) with a 250ms max-wait cap so a continuous drag still
+    /// re-lays out at a bounded rate (AC3) instead of cropping a stale frame forever.
+    private static let resizeDebounceConfig = LiveResizeDebounce.Config(interval: 0.075, maxWait: 0.25)
+
     /// Whether macOS has put the displays to sleep. BEAM state may keep changing,
     /// but the Metal surface must not schedule GPU work until screens wake.
     private var isScreenAsleep = false
@@ -245,6 +263,8 @@ final class EditorNSView: MTKView {
         scrollIndicatorDragOffset = nil
         spaceGraceTimer?.cancel()
         spaceGraceTimer = nil
+        cancelResizeFlushTask()
+        resizeBookkeeping = LiveResizeBookkeeping()
         dividerDragState = .none
         setDividerCursorState(.none)
         removeWindowObservers()
@@ -805,11 +825,110 @@ final class EditorNSView: MTKView {
             encoder.sendReady(cols: grid.cols, rows: grid.rows)
             os_signpost(.event, log: startupLog, name: "ReadySent", "%{public}dx%{public}d", grid.cols, grid.rows)
             PortLogger.info("Window ready: \(grid.cols)x\(grid.rows) rows (\(Int(newSize.width))x\(Int(newSize.height))pt)")
+        } else if inLiveResize {
+            // Window-edge drag in progress: present the last committed frame cropped
+            // top-left and defer the BEAM re-layout to the trailing edge (#2655). We do
+            // NOT applyViewportResize here so frameState keeps the committed grid, which
+            // is what the crop displays and what pointer hit-testing must agree with.
+            handleLiveResize(to: grid)
         } else if grid.cols != dispatcher.frameState.cols || grid.rows != dispatcher.frameState.rows {
             dispatcher.applyViewportResize(newCols: grid.cols, newRows: grid.rows)
             encoder.sendResize(cols: grid.cols, rows: grid.rows)
             PortLogger.info("Window resized: \(grid.cols)x\(grid.rows) rows")
         }
+    }
+
+    // MARK: - Live resize
+
+    /// AppKit is about to drive a run of `setFrameSize` calls from a window-edge drag.
+    /// A resize is an authoritative layout change, so discard any in-flight presentation
+    /// scroll animation (settle, rubber-band) and scroll-thumb drag state: they were
+    /// computed against the old geometry and must not fight the resize.
+    override func viewWillStartLiveResize() {
+        super.viewWillStartLiveResize()
+        resetSmoothScrollState()
+        // resetSmoothScrollState deliberately spares a live thumb drag; a window
+        // resize invalidates the drag's geometry, so it is a forced-reset path:
+        // flush the final target (position is never silently dropped), then clear.
+        cancelThumbDragWithFlush()
+        isDraggingScrollIndicator = false
+        scrollIndicatorDragOffset = nil
+        // Drop any in-flight text-drag anchor: pointer input is deferred during the
+        // resize (AC5), so a mouseUp that would clear it may never arrive.
+        leftMouseDownPoint = nil
+        leftMouseDragStarted = false
+    }
+
+    /// The drag ended. Flush any deferred resize immediately so the view snaps once to a
+    /// fresh committed layout at the final size (AC2) instead of waiting for the trailing timer.
+    override func viewDidEndLiveResize() {
+        super.viewDidEndLiveResize()
+        flushPendingResize()
+    }
+
+    /// Observes one live-resize frame through the pure bookkeeping state machine and runs the
+    /// resulting side effect: flush now (max-wait cap), (re)schedule the trailing flush, or
+    /// cancel a pending flush when the drag returns to the committed size. Always repaints the
+    /// crop afterward.
+    private func handleLiveResize(to grid: GridDimensions) {
+        let live = LiveResizeBookkeeping.Grid(cols: grid.cols, rows: grid.rows)
+        let committed = LiveResizeBookkeeping.Grid(cols: dispatcher.frameState.cols, rows: dispatcher.frameState.rows)
+        let now = CACurrentMediaTime()
+
+        switch resizeBookkeeping.onFrame(live: live, committed: committed, now: now, config: Self.resizeDebounceConfig) {
+        case .flushNow(let target):
+            cancelResizeFlushTask()
+            sendLiveResize(cols: target.cols, rows: target.rows)
+        case .schedule(let deadline):
+            scheduleResizeFlush(at: deadline, now: now)
+        case .cancelPending:
+            // The drag came back to the committed grid: drop the timer so no stale resize fires.
+            cancelResizeFlushTask()
+        case .noop:
+            break
+        }
+
+        // Repaint so the crop tracks the live drawable size and the background fill reaches the
+        // freshly grown edge (no blank band). The drawable auto-tracks the view because
+        // `MTKView.autoResizeDrawable` defaults to true (never set false here); if that ever
+        // changes, the crop would sample-stretch instead of crop and this must set drawableSize.
+        renderFrame()
+    }
+
+    /// Schedules a single trailing flush at an absolute `CACurrentMediaTime` deadline,
+    /// replacing any previously scheduled one. Structured concurrency keeps the flush closure
+    /// provably main-actor isolated and cheaply cancelable.
+    private func scheduleResizeFlush(at deadline: TimeInterval, now: TimeInterval) {
+        resizeDebounceTask?.cancel()
+        let delay = max(deadline - now, 0)
+        resizeDebounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.flushPendingResize()
+        }
+    }
+
+    /// Cancels the trailing flush task, if any.
+    private func cancelResizeFlushTask() {
+        resizeDebounceTask?.cancel()
+        resizeDebounceTask = nil
+    }
+
+    /// Flushes any deferred resize to the BEAM (one committed re-layout) and clears the
+    /// debounce bookkeeping. Idempotent: a no-op when nothing is pending or the pending grid
+    /// already matches the committed frame (the drag-away-and-back guard, re-applied here).
+    private func flushPendingResize() {
+        cancelResizeFlushTask()
+        let committed = LiveResizeBookkeeping.Grid(cols: dispatcher.frameState.cols, rows: dispatcher.frameState.rows)
+        guard let target = resizeBookkeeping.takeFlush(committed: committed) else { return }
+        sendLiveResize(cols: target.cols, rows: target.rows)
+    }
+
+    /// Commits a debounced live-resize grid: updates local frame metadata and notifies the BEAM.
+    private func sendLiveResize(cols: UInt16, rows: UInt16) {
+        dispatcher.applyViewportResize(newCols: cols, newRows: rows)
+        encoder.sendResize(cols: cols, rows: rows)
+        PortLogger.info("Window resized (debounced): \(cols)x\(rows) rows")
     }
 
     // MARK: - Scroll indicator interaction
@@ -1394,6 +1513,10 @@ final class EditorNSView: MTKView {
     // MARK: - Mouse
 
     override func mouseDown(with event: NSEvent) {
+        // Defer pointer input while a live resize is in flight (#2655, AC5): the view
+        // geometry is changing and the on-screen content is a crop of the last committed
+        // frame, so a hit-test would map against stale, in-flux geometry.
+        guard !inLiveResize else { return }
         reclaimFirstResponderIfNeeded()
 
         // Scroll indicator track: intercept clicks on the right edge.
@@ -1428,6 +1551,7 @@ final class EditorNSView: MTKView {
     }
 
     override func mouseUp(with event: NSEvent) {
+        guard !inLiveResize else { return }
         if isDraggingScrollIndicator {
             isDraggingScrollIndicator = false
             scrollIndicatorDragOffset = nil
@@ -1538,6 +1662,7 @@ final class EditorNSView: MTKView {
     }
 
     override func mouseDragged(with event: NSEvent) {
+        guard !inLiveResize else { return }
         if isDraggingScrollIndicator {
             let point = convert(event.locationInWindow, from: nil)
             let line = scrollTrackYToLine(point.y)
@@ -1558,6 +1683,7 @@ final class EditorNSView: MTKView {
     }
 
     override func mouseMoved(with event: NSEvent) {
+        guard !inLiveResize else { return }
         let point = convert(event.locationInWindow, from: nil)
         setDividerCursorState(dividerHitState(at: point))
         updateGutterHover(at: point)

--- a/macos/Sources/Views/Editor/LiveResizeDebounce.swift
+++ b/macos/Sources/Views/Editor/LiveResizeDebounce.swift
@@ -32,6 +32,11 @@ enum LiveResizeDebounce {
             self.interval = interval
             self.maxWait = maxWait
         }
+
+        /// The one production tuning for window live-resize (75ms trailing, 250ms cap).
+        /// Tests reference this same value so a retune can never silently desync the
+        /// suite from what ships.
+        static let liveResize = Config(interval: 0.075, maxWait: 0.25)
     }
 
     /// What to do with a resize event observed at a given time.
@@ -86,10 +91,28 @@ struct LiveResizeBookkeeping: Equatable {
         }
     }
 
+    /// The two legal states, as one value: either nothing is pending, or a grid is pending
+    /// with the burst-start time that feeds the max-wait cap. An enum spine (same convention
+    /// as `ThumbDragSession.Phase`) makes "pending grid without a burst start" — the state a
+    /// desynced optional pair could reach — unrepresentable by construction.
+    private enum State: Equatable {
+        case idle
+        case pending(Grid, since: TimeInterval)
+    }
+
+    private var state: State = .idle
+
     /// The latest live grid awaiting a flush, or nil when nothing is pending.
-    private(set) var pending: Grid?
-    /// When the current unflushed burst began (`CACurrentMediaTime`), feeding the max-wait cap.
-    private(set) var firstPendingAt: TimeInterval?
+    var pending: Grid? {
+        guard case .pending(let grid, _) = state else { return nil }
+        return grid
+    }
+
+    /// When the current unflushed burst began (`CACurrentMediaTime`), or nil when idle.
+    var firstPendingAt: TimeInterval? {
+        guard case .pending(_, let since) = state else { return nil }
+        return since
+    }
 
     init() {}
 
@@ -114,20 +137,17 @@ struct LiveResizeBookkeeping: Equatable {
             // Drag returned to the committed size: there is nothing to commit. Drop any pending
             // resize so a later flush can't send a stale (dragged-away) grid for the committed one.
             let hadPending = pending != nil
-            pending = nil
-            firstPendingAt = nil
+            state = .idle
             return hadPending ? .cancelPending : .noop
         }
 
         let decision = LiveResizeDebounce.onResize(now: now, firstPendingAt: firstPendingAt, config: config)
-        pending = live
         switch decision {
         case .flushNow:
-            pending = nil
-            firstPendingAt = nil
+            state = .idle
             return .flushNow(live)
         case .deferUntil(let deadline):
-            if firstPendingAt == nil { firstPendingAt = now }
+            state = .pending(live, since: firstPendingAt ?? now)
             return .schedule(deadline)
         }
     }
@@ -136,9 +156,8 @@ struct LiveResizeBookkeeping: Equatable {
     /// Returns nil when there is nothing to send: no pending grid, or the pending grid already
     /// matches the committed grid (the drag-away-and-back guard, applied again at flush time).
     mutating func takeFlush(committed: Grid) -> Grid? {
-        firstPendingAt = nil
-        guard let grid = pending else { return nil }
-        pending = nil
+        guard case .pending(let grid, _) = state else { return nil }
+        state = .idle
         guard grid != committed else { return nil }
         return grid
     }

--- a/macos/Sources/Views/Editor/LiveResizeDebounce.swift
+++ b/macos/Sources/Views/Editor/LiveResizeDebounce.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/// Pure trailing-edge debounce decision for live window-resize → BEAM re-layout (#2655).
+///
+/// During a macOS window-edge drag, `EditorNSView.setFrameSize` fires many times
+/// per second. Each distinct grid size would otherwise send a `resize` event to the
+/// BEAM, forcing the most expensive render path (full re-layout + full re-send of
+/// every visible window) and thrashing residence promotion (each `layout_generation`
+/// rebuild re-defers residence via `RenderCache.reset`, then re-promotes next frame).
+///
+/// The debounce lives entirely on the GUI side: since #2699 the frontend already
+/// owns rows-that-fit and sends the resize event, so throttling that outgoing event
+/// keeps the BEAM completely ignorant of drag mechanics. The frontend presents the
+/// last committed frame cropped top-left while the drag is in motion (no re-layout),
+/// then flushes one resize on the trailing edge so the view snaps once.
+///
+/// The decision is trailing-edge with a `maxWait` cap: rapid consecutive resizes keep
+/// pushing the flush deadline out, but never past `firstPendingAt + maxWait`. The cap
+/// guarantees that even a pathological never-pausing drag still re-lays out at a rate
+/// bounded by `maxWait` (AC3: bumps bounded by the debounce rate, not the event rate)
+/// rather than cropping a stale frame indefinitely.
+enum LiveResizeDebounce {
+    /// Tuning for the trailing-edge debounce. Times are in seconds (`CACurrentMediaTime` units).
+    struct Config: Equatable {
+        /// Trailing quiescence window: flush this long after the last resize event.
+        var interval: TimeInterval
+        /// Cap measured from the first unflushed event in a burst. Bounds re-layout
+        /// rate during a continuous drag so the crop can't go stale forever.
+        var maxWait: TimeInterval
+
+        init(interval: TimeInterval, maxWait: TimeInterval) {
+            self.interval = interval
+            self.maxWait = maxWait
+        }
+    }
+
+    /// What to do with a resize event observed at a given time.
+    enum Decision: Equatable {
+        /// The `maxWait` cap has been reached; send the resize immediately.
+        case flushNow
+        /// Defer the resize; (re)schedule the trailing flush for this absolute deadline.
+        case deferUntil(TimeInterval)
+    }
+
+    /// Decide how to handle a resize event observed at `now`.
+    ///
+    /// - Parameters:
+    ///   - now: the event time in `CACurrentMediaTime` units.
+    ///   - firstPendingAt: when the current unflushed burst began, or `nil` if nothing is pending
+    ///     (i.e. this is the first event since the last flush).
+    ///   - config: trailing interval and max-wait cap.
+    /// - Returns: `.flushNow` when the cap is already reached, otherwise `.deferUntil(deadline)`
+    ///   where `deadline` is the trailing edge clamped to the burst's max-wait cap.
+    static func onResize(now: TimeInterval, firstPendingAt: TimeInterval?, config: Config) -> Decision {
+        guard let start = firstPendingAt else {
+            // First event of a burst: pure trailing edge.
+            return .deferUntil(now + config.interval)
+        }
+        let cap = start + config.maxWait
+        if cap <= now {
+            return .flushNow
+        }
+        return .deferUntil(min(now + config.interval, cap))
+    }
+}
+
+/// Pure state machine for the live-resize pending-grid bookkeeping (#2655).
+///
+/// Mirrors the deferred-resize state that `EditorNSView` holds during a window-edge drag
+/// so the tricky gestures (especially drag-away-and-back) can be tested without AppKit.
+/// The view delegates every live-resize frame and every flush to this value type and just
+/// executes the returned side effects (schedule a timer, send a resize, cancel a timer).
+///
+/// The load-bearing case is drag-away-and-back: `frameState` stays at the pre-drag committed
+/// grid G0 while the drag is deferred. If the drag moves to G1 (pending = G1) and then returns
+/// so the live grid equals G0 again, the pending G1 must be dropped. Otherwise a later flush
+/// would send G1 for a window that is really G0, committing the wrong row/col count.
+struct LiveResizeBookkeeping: Equatable {
+    /// A viewport grid in cells. Kept tiny and value-typed so it is trivially comparable.
+    struct Grid: Equatable {
+        var cols: UInt16
+        var rows: UInt16
+        init(cols: UInt16, rows: UInt16) {
+            self.cols = cols
+            self.rows = rows
+        }
+    }
+
+    /// The latest live grid awaiting a flush, or nil when nothing is pending.
+    private(set) var pending: Grid?
+    /// When the current unflushed burst began (`CACurrentMediaTime`), feeding the max-wait cap.
+    private(set) var firstPendingAt: TimeInterval?
+
+    init() {}
+
+    /// Side effect the caller should perform after observing one live-resize frame.
+    /// The caller always repaints (crop) regardless of which case is returned.
+    enum Frame: Equatable {
+        /// Max-wait cap reached: send this grid immediately (and cancel any pending timer).
+        case flushNow(Grid)
+        /// (Re)schedule the trailing flush for this absolute deadline.
+        case schedule(TimeInterval)
+        /// The live grid returned to the committed grid: a pending resize was dropped; cancel the timer.
+        case cancelPending
+        /// Nothing to do (grid already matches committed and nothing was pending).
+        case noop
+    }
+
+    /// Observe one live-resize frame: the freshly measured `live` grid against the currently
+    /// committed `committed` grid (i.e. `frameState`). Mutates the pending bookkeeping and
+    /// returns the side effect to run.
+    mutating func onFrame(live: Grid, committed: Grid, now: TimeInterval, config: LiveResizeDebounce.Config) -> Frame {
+        guard live != committed else {
+            // Drag returned to the committed size: there is nothing to commit. Drop any pending
+            // resize so a later flush can't send a stale (dragged-away) grid for the committed one.
+            let hadPending = pending != nil
+            pending = nil
+            firstPendingAt = nil
+            return hadPending ? .cancelPending : .noop
+        }
+
+        let decision = LiveResizeDebounce.onResize(now: now, firstPendingAt: firstPendingAt, config: config)
+        pending = live
+        switch decision {
+        case .flushNow:
+            pending = nil
+            firstPendingAt = nil
+            return .flushNow(live)
+        case .deferUntil(let deadline):
+            if firstPendingAt == nil { firstPendingAt = now }
+            return .schedule(deadline)
+        }
+    }
+
+    /// Take the pending grid to flush against the current `committed` grid, clearing all state.
+    /// Returns nil when there is nothing to send: no pending grid, or the pending grid already
+    /// matches the committed grid (the drag-away-and-back guard, applied again at flush time).
+    mutating func takeFlush(committed: Grid) -> Grid? {
+        firstPendingAt = nil
+        guard let grid = pending else { return nil }
+        pending = nil
+        guard grid != committed else { return nil }
+        return grid
+    }
+}

--- a/macos/Tests/MingaTests/LiveResizeDebounceTests.swift
+++ b/macos/Tests/MingaTests/LiveResizeDebounceTests.swift
@@ -1,11 +1,14 @@
 import Testing
 import Foundation
+import AppKit
 import MingaUI
+import MingaProtocol
 
 /// Tests for the pure live-resize debounce decision and the crop-fill guarantee (#2655).
 @Suite("Live-resize presentation (#2655)")
 struct LiveResizeDebounceTests {
-    private let config = LiveResizeDebounce.Config(interval: 0.075, maxWait: 0.25)
+    // The production tuning, not a copy: a retune cannot silently desync the suite.
+    private let config = LiveResizeDebounce.Config.liveResize
 
     /// Unwraps a `.deferUntil` deadline, failing the test on `.flushNow`.
     private func deadline(_ decision: LiveResizeDebounce.Decision) -> TimeInterval? {
@@ -147,6 +150,44 @@ struct LiveResizeDebounceTests {
         #expect(bk.takeFlush(committed: grid(80, 50)) == nil)
     }
 
+    @Test("drag-away-and-back-and-away-again restarts the max-wait clock from the second departure")
+    func dragAwayBackAwayRestartsBurstClock() {
+        var bk = LiveResizeBookkeeping()
+        let g0 = grid(100, 50)
+
+        // First departure at t=0 starts a burst.
+        #expect(bk.onFrame(live: grid(80, 50), committed: g0, now: 0.0, config: config) == .schedule(0.075))
+        // Back to committed at t=0.02 cancels it entirely.
+        #expect(bk.onFrame(live: g0, committed: g0, now: 0.02, config: config) == .cancelPending)
+        // Second departure at t=0.03 must start a FRESH burst: trailing edge from the new
+        // now (0.105), not clamped against the stale t=0 burst start. A regression that
+        // fails to reset the burst clock on cancel would fire the max-wait cap early here.
+        #expect(bk.onFrame(live: grid(70, 50), committed: g0, now: 0.03, config: config) == .schedule(0.105))
+        #expect(bk.firstPendingAt == 0.03)
+    }
+
+    @Test("a trailing flush mid-pause commits, then a resumed drag opens a fresh burst")
+    func trailingFlushMidPauseThenResumedDrag() {
+        var bk = LiveResizeBookkeeping()
+        var committed = grid(100, 50)
+        let g1 = grid(80, 50)
+
+        // Drag, then pause: the trailing timer fires and takes the flush while the live
+        // resize is still in progress (user is holding the edge, not moving).
+        #expect(bk.onFrame(live: g1, committed: committed, now: 0.0, config: config) == .schedule(0.075))
+        #expect(bk.takeFlush(committed: committed) == g1)
+        committed = g1 // sendLiveResize applied the viewport resize
+
+        // Drag resumes 200ms later: a genuinely fresh burst against the new committed
+        // grid, with the max-wait cap anchored at the resumed time.
+        let g2 = grid(60, 50)
+        #expect(bk.onFrame(live: g2, committed: committed, now: 0.2, config: config) == .schedule(0.275))
+        #expect(bk.firstPendingAt == 0.2)
+
+        // Release commits the second burst's grid.
+        #expect(bk.takeFlush(committed: committed) == g2)
+    }
+
     // MARK: - Crop-fill guarantee
 
     @Test("growing the window mid-drag fills the newly exposed region below the committed rows")
@@ -173,5 +214,92 @@ struct LiveResizeDebounceTests {
         // The fill reaches the grown drawable edge, not just the committed content bottom.
         #expect(fill?.bottom == grownHeight)
         #expect((fill?.bottom ?? 0) > committedHeight)
+    }
+}
+
+/// Integration tests for the EditorNSView live-resize wiring: the exactly-once flush and
+/// the gesture teardown at resize start. These drive the real view methods headlessly
+/// (viewWillStartLiveResize / flushPendingResize are plain overrides/internal methods),
+/// pinning the guarantees the pure state machine alone cannot: Task bookkeeping, encoder
+/// sends, and the press-release contract with the BEAM.
+@Suite("Live-resize view wiring (#2655)")
+struct LiveResizeWiringTests {
+    @MainActor
+    private func makeView(spy: SpyEncoder) -> EditorNSView? {
+        let face = FontFace(name: "Menlo", size: 13.0, scale: 1.0)
+        let fm = FontManager(name: "Menlo", size: 13.0, scale: 1.0)
+        let guiState = GUIState()
+        let disp = CommandDispatcher(cols: 80, rows: 24, guiState: guiState)
+        guard let ctRenderer = CoreTextMetalRenderer() else { return nil }
+        ctRenderer.setupRenderers(fontManager: fm)
+        let view = EditorNSView(encoder: spy, fontFace: face, dispatcher: disp,
+                                coreTextRenderer: ctRenderer, fontManager: fm)
+        view.guiState = guiState
+        view.frame = NSRect(x: 0, y: 0,
+                            width: CGFloat(face.cellWidth) * 80,
+                            height: CGFloat(face.cellHeight) * 24)
+        return view
+    }
+
+    @MainActor
+    @Test("flushPendingResize sends the pending grid exactly once and is then idempotent")
+    func flushPendingResizeIsExactlyOnce() throws {
+        let spy = SpyEncoder()
+        // Skip gracefully when Metal is unavailable (headless local runs), like
+        // MouseInputTests; CI runs these for real.
+        guard let view = makeView(spy: spy) else { return }
+
+        // Seed a pending grid through the real state machine against the committed 80x24.
+        let committed = LiveResizeBookkeeping.Grid(cols: 80, rows: 24)
+        let dragged = LiveResizeBookkeeping.Grid(cols: 100, rows: 30)
+        _ = view.resizeBookkeeping.onFrame(live: dragged, committed: committed, now: 0.0,
+                                           config: .liveResize)
+
+        view.flushPendingResize()
+        #expect(spy.resizeCalls.count == 1)
+        #expect(spy.resizeCalls.first?.cols == 100)
+        #expect(spy.resizeCalls.first?.rows == 30)
+        #expect(view.resizeDebounceTask == nil)
+
+        // A second flush (e.g. the release path racing a fired trailing task) sends nothing.
+        view.flushPendingResize()
+        #expect(spy.resizeCalls.count == 1)
+    }
+
+    @MainActor
+    @Test("resize start releases an outstanding left press so the BEAM never keeps a stuck press")
+    func resizeStartReleasesOutstandingPress() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy) else { return }
+
+        let down = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown, location: NSPoint(x: 40, y: 40), modifierFlags: [],
+            timestamp: 0, windowNumber: 0, context: nil, eventNumber: 1,
+            clickCount: 1, pressure: 1))
+        view.mouseDown(with: down)
+        #expect(spy.mouseEventCalls.last?.eventType == MOUSE_PRESS)
+        let pressCount = spy.mouseEventCalls.count
+
+        // The resize begins before any mouseUp is delivered; the up will be dropped by the
+        // inLiveResize guard, so the teardown must complete the gesture itself.
+        view.viewWillStartLiveResize()
+
+        let release = try #require(spy.mouseEventCalls.last)
+        #expect(spy.mouseEventCalls.count == pressCount + 1)
+        #expect(release.button == MOUSE_BUTTON_LEFT)
+        #expect(release.eventType == MOUSE_RELEASE)
+
+        // The teardown is idempotent: a second resize start (no press outstanding) sends nothing.
+        view.viewWillStartLiveResize()
+        #expect(spy.mouseEventCalls.count == pressCount + 1)
+    }
+
+    @MainActor
+    @Test("resize start with no outstanding press sends no synthetic release")
+    func resizeStartWithoutPressSendsNothing() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy) else { return }
+        view.viewWillStartLiveResize()
+        #expect(spy.mouseEventCalls.isEmpty)
     }
 }

--- a/macos/Tests/MingaTests/LiveResizeDebounceTests.swift
+++ b/macos/Tests/MingaTests/LiveResizeDebounceTests.swift
@@ -1,0 +1,177 @@
+import Testing
+import Foundation
+import MingaUI
+
+/// Tests for the pure live-resize debounce decision and the crop-fill guarantee (#2655).
+@Suite("Live-resize presentation (#2655)")
+struct LiveResizeDebounceTests {
+    private let config = LiveResizeDebounce.Config(interval: 0.075, maxWait: 0.25)
+
+    /// Unwraps a `.deferUntil` deadline, failing the test on `.flushNow`.
+    private func deadline(_ decision: LiveResizeDebounce.Decision) -> TimeInterval? {
+        if case .deferUntil(let d) = decision { return d }
+        return nil
+    }
+
+    @Test("first event of a burst defers a pure trailing interval")
+    func firstEventDefersTrailing() {
+        let decision = LiveResizeDebounce.onResize(now: 100.0, firstPendingAt: nil, config: config)
+        let d = try? #require(deadline(decision))
+        #expect(abs((d ?? 0) - 100.075) < 1e-9)
+    }
+
+    @Test("a rapid follow-up event pushes the trailing edge out, still under the cap")
+    func rapidEventExtendsTrailing() {
+        // Burst started at 100.0; a second event 50ms in. Trailing edge 100.125 is
+        // still well under the 100.25 max-wait cap, so it wins.
+        let decision = LiveResizeDebounce.onResize(now: 100.05, firstPendingAt: 100.0, config: config)
+        let d = try? #require(deadline(decision))
+        #expect(abs((d ?? 0) - 100.125) < 1e-9)
+    }
+
+    @Test("the trailing edge is clamped to the max-wait cap during a continuous drag")
+    func trailingClampedToCap() {
+        // 200ms into the burst: raw trailing edge 100.275 would exceed the cap, so the
+        // deadline is pinned to firstPendingAt + maxWait = 100.25. This is what bounds
+        // re-layout rate during a never-pausing drag (AC3).
+        let decision = LiveResizeDebounce.onResize(now: 100.2, firstPendingAt: 100.0, config: config)
+        let d = try? #require(deadline(decision))
+        #expect(abs((d ?? 0) - 100.25) < 1e-9)
+    }
+
+    @Test("once the max-wait cap is reached the event flushes immediately")
+    func capReachedFlushesNow() {
+        let atCap = LiveResizeDebounce.onResize(now: 100.25, firstPendingAt: 100.0, config: config)
+        #expect(atCap == .flushNow)
+
+        let pastCap = LiveResizeDebounce.onResize(now: 100.26, firstPendingAt: 100.0, config: config)
+        #expect(pastCap == .flushNow)
+    }
+
+    @Test("a 3s continuous 60Hz drag is bounded by the debounce rate, not the event rate")
+    func continuousDragBoundedByDebounceRate() {
+        // Replay a 3-second drag at 60Hz (one resize event every ~16.7ms), feeding the
+        // decision the same way EditorNSView does: a flush resets the burst start to nil.
+        // Count flushes; they must be bounded by ceil(3.0 / maxWait), far below 180 events.
+        var firstPendingAt: TimeInterval? = nil
+        var flushes = 0
+        let start = 0.0
+        let step = 1.0 / 60.0
+        var t = start
+        while t <= start + 3.0 + 1e-9 {
+            switch LiveResizeDebounce.onResize(now: t, firstPendingAt: firstPendingAt, config: config) {
+            case .flushNow:
+                flushes += 1
+                firstPendingAt = nil // flush clears the burst; next event restarts it
+            case .deferUntil:
+                if firstPendingAt == nil { firstPendingAt = t }
+            }
+            t += step
+        }
+
+        let eventCount = 181 // ~3s at 60Hz
+        let bound = Int((3.0 / config.maxWait).rounded(.up)) + 1
+        #expect(flushes <= bound)
+        #expect(flushes < eventCount / 4) // dramatically fewer re-layouts than raw events
+    }
+
+    // MARK: - Pending-grid bookkeeping
+
+    private func grid(_ cols: UInt16, _ rows: UInt16) -> LiveResizeBookkeeping.Grid {
+        LiveResizeBookkeeping.Grid(cols: cols, rows: rows)
+    }
+
+    @Test("a normal drag defers, then the end-of-drag flush commits the pending grid")
+    func normalDragDefersThenFlushes() {
+        var bk = LiveResizeBookkeeping()
+        let g0 = grid(100, 50) // committed
+        let g1 = grid(80, 50)  // dragged-to
+
+        let frame = bk.onFrame(live: g1, committed: g0, now: 0.0, config: config)
+        #expect(frame == .schedule(0.075))
+        #expect(bk.pending == g1)
+
+        // viewDidEndLiveResize path: flush against the still-committed g0.
+        #expect(bk.takeFlush(committed: g0) == g1)
+        #expect(bk.pending == nil)
+    }
+
+    @Test("drag-away-and-back drops the pending grid so no stale resize is committed")
+    func dragAwayAndBackCancelsPending() {
+        var bk = LiveResizeBookkeeping()
+        let g0 = grid(100, 50) // committed (frameState never moved during pure defer)
+        let g1 = grid(80, 50)  // dragged away
+
+        // 1) Drag away: g1 is pending.
+        #expect(bk.onFrame(live: g1, committed: g0, now: 0.0, config: config) == .schedule(0.075))
+        #expect(bk.pending == g1)
+
+        // 2) Drag back so the live grid equals the committed grid within the trailing window.
+        //    This must drop the pending g1, otherwise a later flush would send g1 for a g0 window.
+        #expect(bk.onFrame(live: g0, committed: g0, now: 0.02, config: config) == .cancelPending)
+        #expect(bk.pending == nil)
+        #expect(bk.firstPendingAt == nil)
+
+        // 3) Release: nothing pending, so no resize is committed.
+        #expect(bk.takeFlush(committed: g0) == nil)
+    }
+
+    @Test("returning to the committed grid with nothing pending is a no-op")
+    func returnToCommittedWithoutPendingIsNoop() {
+        var bk = LiveResizeBookkeeping()
+        let g0 = grid(100, 50)
+        #expect(bk.onFrame(live: g0, committed: g0, now: 0.0, config: config) == .noop)
+        #expect(bk.pending == nil)
+    }
+
+    @Test("the max-wait cap flushes the latest grid immediately and clears pending")
+    func maxWaitCapFlushesLatest() {
+        var bk = LiveResizeBookkeeping()
+        let g0 = grid(100, 50)
+
+        // Burst starts at t=0.
+        #expect(bk.onFrame(live: grid(90, 50), committed: g0, now: 0.0, config: config) == .schedule(0.075))
+        // 260ms in: past the 250ms cap → flush the newest grid now, pending cleared.
+        let latest = grid(70, 50)
+        #expect(bk.onFrame(live: latest, committed: g0, now: 0.26, config: config) == .flushNow(latest))
+        #expect(bk.pending == nil)
+        #expect(bk.firstPendingAt == nil)
+    }
+
+    @Test("takeFlush is a no-op when the pending grid already matches the committed grid")
+    func takeFlushNoopWhenPendingMatchesCommitted() {
+        var bk = LiveResizeBookkeeping()
+        let g0 = grid(100, 50)
+        _ = bk.onFrame(live: grid(80, 50), committed: g0, now: 0.0, config: config)
+        // The BEAM committed g0-equivalent out from under us before release.
+        #expect(bk.takeFlush(committed: grid(80, 50)) == nil)
+    }
+
+    // MARK: - Crop-fill guarantee
+
+    @Test("growing the window mid-drag fills the newly exposed region below the committed rows")
+    func grownRegionIsFilledDuringCrop() {
+        // During a live drag the frontend keeps rendering the last committed frame while
+        // the drawable grows. frameState still holds the committed (smaller) grid, so the
+        // bottom-most pane's background fill must absorb the grown region down to the new
+        // drawable height, leaving no blank band (AC1: no blank regions during the drag).
+        let committedRows = 20
+        let displayCellH: Float = 12
+        let committedHeight = Float(committedRows) * displayCellH // 240px committed
+        let grownHeight = committedHeight + 90                    // window dragged 90px taller
+
+        let fill = CoreTextMetalRenderer.windowBackgroundFillBounds(
+            paneTopRow: 0,
+            paneRows: committedRows,
+            totalRows: committedRows,
+            displayCellH: displayCellH,
+            scale: 1,
+            viewportHeight: grownHeight
+        )
+
+        #expect(fill?.top == 0)
+        // The fill reaches the grown drawable edge, not just the committed content bottom.
+        #expect(fill?.bottom == grownHeight)
+        #expect((fill?.bottom ?? 0) > committedHeight)
+    }
+}


### PR DESCRIPTION
Closes #2655 (the last approved follow-up). **Stacked on #2703**; retarget to main after it merges — rebased over it already, both overlapping suites green (24 tests).

## Summary

- **Crop for free:** during a live drag the last committed frame presents as an honest top-left crop — zero renderer changes, because pane anchoring + the frame-anchored background fill (#2692) + the auto-resized drawable already produce exactly that once mid-drag re-layouts stop. Scale was rejected (re-sampled glyph textures = blurry text for extra GPU work).
- **GUI-side trailing debounce (75ms, 250ms max-wait):** #2699 made the GUI the sole resize emitter, so the BEAM stays entirely ignorant of drag mechanics and the TUI is untouched. Release flushes exactly once. Residence re-arming thrash collapses to one arm/promote cycle per flush.
- **The review catch:** drag-away-and-back within the trailing window left a stale pending grid that release would commit — wrong final geometry. Fixed by extracting a pure `LiveResizeBookkeeping` state machine (every live frame routes through it; returning to committed cancels pending; the flush re-guards) with gesture-sequence tests including the exact regression. The re-review confirmed all pending-state mutations live inside the machine and the flush-time guard can't suppress a legitimate final size.
- Structured concurrency: the trailing flush is a cancelable main-actor Task per macos/AGENTS.md (no `@Sendable` dispatch hop), leak-free at all three cancellation sites.

## Tests

11 debounce/bookkeeping tests (trailing, cap, 3s@60Hz bound, drag-away-and-back, flush guards) + the crop-fill guarantee. Full Swift suite 971 pass pre-rebase; post-rebase both overlapping suites (resize + thumb drag) pass. Review: BLOCKED → fixed → CONFIRMED FIXED on all items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1