### PR TITLE
fix(macos): discrete wheel ticks into a document boundary no longer park content off-grid

### DIFF
--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -2110,6 +2110,20 @@ final class EditorNSView: MTKView {
         }
     }
 
+    /// Whether a discrete tick may seed a predicted line, given the boundary availability for the
+    /// target pane. A tick INTO a document edge (scroll up at the top, scroll down at the bottom)
+    /// seeds a line the BEAM can never commit: the eased residual decays to zero while
+    /// `scrollUnconfirmedLines` sticks at ±1, parking content one cell off-grid until the next
+    /// authoritative reset. Suppress the local prediction there; the scroll intent still sends, so
+    /// an at-boundary tick simply does nothing visually, matching reality. `before`/`after` mirror
+    /// `presentationScrollBoundaryAvailability`: `before` is content above (needed to scroll up,
+    /// `lineDelta < 0`), `after` is content below (needed to scroll down, `lineDelta > 0`).
+    nonisolated static func discreteTickSeedsPrediction(lineDelta: Int, boundaryBefore: Int, boundaryAfter: Int) -> Bool {
+        if lineDelta < 0 { return boundaryBefore > 0 }
+        if lineDelta > 0 { return boundaryAfter > 0 }
+        return false
+    }
+
     /// AC3: eases a discrete-wheel line motion locally on the same frame it arrives instead of
     /// teleporting at round-trip latency. The GUI scrolls exactly one line per wheel event
     /// (`@gui_scroll_lines`), so a `lineDelta` of ±1 is seeded as a predicted unconfirmed line;
@@ -2121,6 +2135,19 @@ final class EditorNSView: MTKView {
         guard scrollTargetWindowId == nil else { return }
         guard effectiveCellHeight > 0 else { return }
         guard let windowId = smoothScrollTargetWindowId(row: row, col: col) else { return }
+
+        // A tick into a document boundary can't be committed by the BEAM, so predicting it would
+        // park content one cell off-grid; suppress the seed (the scroll intent already sent above).
+        let windowContent = guiState?.windowContents[windowId]
+        let boundary = Self.presentationScrollBoundaryAvailability(
+            for: windowContent,
+            scrollPresentation: windowContent?.scrollPresentation
+        )
+        guard Self.discreteTickSeedsPrediction(
+            lineDelta: lineDelta,
+            boundaryBefore: boundary.before,
+            boundaryAfter: boundary.after
+        ) else { return }
 
         // Extend any in-flight settle from its current position so rapid ticks accumulate smoothly.
         let residualNow = scrollSettleAnimator.offset()

--- a/macos/Tests/MingaTests/ScrollSettleReconcileTests.swift
+++ b/macos/Tests/MingaTests/ScrollSettleReconcileTests.swift
@@ -100,6 +100,50 @@ struct DiscreteTickEasingTests {
     }
 }
 
+@Suite("Discrete-tick boundary gate suppresses uncommittable predictions")
+struct DiscreteTickBoundaryGateTests {
+
+    // Direction convention mirrors `presentationScrollBoundaryAvailability` and the seed:
+    // scroll up is `lineDelta < 0` and needs content `before` (above); scroll down is
+    // `lineDelta > 0` and needs content `after` (below). GUI ticks are exactly one line
+    // (`@gui_scroll_lines = 1`), so a tick is always ±1 and one available line is enough.
+
+    @Test("a tick into the top boundary seeds nothing")
+    func topBoundarySuppressed() {
+        // At the very top: no content before. A scroll-up tick can't be committed, so no seed.
+        #expect(EditorNSView.discreteTickSeedsPrediction(lineDelta: -1, boundaryBefore: 0, boundaryAfter: 1) == false)
+    }
+
+    @Test("a tick into the bottom boundary seeds nothing")
+    func bottomBoundarySuppressed() {
+        // At the very bottom: no content after. A scroll-down tick can't be committed, so no seed.
+        #expect(EditorNSView.discreteTickSeedsPrediction(lineDelta: 1, boundaryBefore: 1, boundaryAfter: 0) == false)
+    }
+
+    @Test("a mid-document tick seeds normally in both directions")
+    func midDocumentSeeds() {
+        // Content on both sides: either direction commits, so both seed.
+        #expect(EditorNSView.discreteTickSeedsPrediction(lineDelta: -1, boundaryBefore: 1, boundaryAfter: 1) == true)
+        #expect(EditorNSView.discreteTickSeedsPrediction(lineDelta: 1, boundaryBefore: 1, boundaryAfter: 1) == true)
+    }
+
+    @Test("a tick away from a boundary still seeds")
+    func awayFromBoundarySeeds() {
+        // Parked at the top (no content before): scrolling DOWN is still valid and must seed.
+        #expect(EditorNSView.discreteTickSeedsPrediction(lineDelta: 1, boundaryBefore: 0, boundaryAfter: 1) == true)
+        // Parked at the bottom (no content after): scrolling UP is still valid and must seed.
+        #expect(EditorNSView.discreteTickSeedsPrediction(lineDelta: -1, boundaryBefore: 1, boundaryAfter: 0) == true)
+    }
+
+    @Test("exactly one available line satisfies a one-line tick (no partial-availability underflow)")
+    func partialAvailabilityIsExactForOneLineTick() {
+        // A GUI tick is one line, so a boundary "one line away" (availability = 1) commits exactly:
+        // the tick seeds. There is no multi-line discrete tick that could overshoot a 1-line margin.
+        #expect(EditorNSView.discreteTickSeedsPrediction(lineDelta: -1, boundaryBefore: 1, boundaryAfter: 0) == true)
+        #expect(EditorNSView.discreteTickSeedsPrediction(lineDelta: 1, boundaryBefore: 0, boundaryAfter: 1) == true)
+    }
+}
+
 @Suite("Presentation offset reaches the settling pane (render-path gate)")
 struct PresentationScrollWindowResolutionTests {
 


### PR DESCRIPTION
Closes the last open item on the #2652 deferred ledger (found by the settle-jitter trajectory investigation, prescribed there and in #2690's review notes).

## Summary

A discrete physical-wheel tick into a document edge seeded a predicted line the BEAM can never commit — `scrollUnconfirmedLines` stuck at ±1, the eased residual decayed to zero, and content parked one cell off-grid until the next authoritative reset. The seed is now gated on `presentationScrollBoundaryAvailability` for the tick direction (the elastic path's helper — availability semantics stay single-sourced). The intent still sends; only the local prediction is suppressed, so an at-boundary tick does nothing visually, matching reality.

## Tests

5 pure-layer tests (top/bottom boundary suppression, mid-document both directions, away-from-boundary, one-available-line satisfies a one-line tick — GUI ticks are exactly ±1 per `@gui_scroll_lines`). Focused suites 17/17; full Swift suite 965 pass. Additive-only (+27 lines), no conflicts with the open PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1