### PR TITLE
feat(tui): resident transcript + local scroll + pin intents — slice 3 of #2654

### DIFF
--- a/go/tui/internal/protocol/chrome_agent.go
+++ b/go/tui/internal/protocol/chrome_agent.go
@@ -128,6 +128,10 @@ func decodeAgentChat(payload []byte) (AgentChat, string, int) {
 			if value, _, ok := readString16(section, 0); ok {
 				chat.ThinkingLevel = value
 			}
+		case 0x09:
+			if len(section) >= 1 {
+				chat.InputFocused = section[0] != 0
+			}
 		case 0x06:
 			chat.Messages = decodeAgentMessages(section)
 		}
@@ -213,8 +217,20 @@ func decodeAgentMessage(body []byte) (AgentChatMessage, bool) {
 	if len(body) < 5 {
 		return AgentChatMessage{}, false
 	}
-	msg := AgentChatMessage{ID: u32(body, 0), Kind: body[4]}
-	offset := 5
+	return decodeAgentMessageBody(u32(body, 0), body[4:])
+}
+
+// decodeAgentMessageBody decodes a message from its id and its kind-first body
+// (the shared per-message body codec, <<kind::8, ...>>). It is the seam both
+// transports decode through: the 0x78 messages section concatenates id + body
+// (decodeAgentMessage splits them here), while the 0x86 resident transcript
+// frames the id separately and hands the raw body straight in.
+func decodeAgentMessageBody(id uint32, body []byte) (AgentChatMessage, bool) {
+	if len(body) < 1 {
+		return AgentChatMessage{}, false
+	}
+	msg := AgentChatMessage{ID: id, Kind: body[0]}
+	offset := 1
 	switch msg.Kind {
 	case 0x01, 0x02:
 		text, ok := decodeAgentTextBody(body, offset)

--- a/go/tui/internal/protocol/chrome_decode.go
+++ b/go/tui/internal/protocol/chrome_decode.go
@@ -59,6 +59,8 @@ func decodeChrome(payload []byte) ChromePayload {
 		chrome.AgentContext, chrome.Summary, chrome.Bytes = decodeAgentContext(payload)
 	case generated.OPGuiAgentChat:
 		chrome.AgentChat, chrome.Summary, chrome.Bytes = decodeAgentChat(payload)
+	case generated.OPGuiAgentTranscript:
+		chrome.AgentTranscript, chrome.Summary, chrome.Bytes = decodeAgentTranscript(payload)
 	case generated.OPGuiEditTimeline:
 		chrome.Timeline, chrome.Summary, chrome.Bytes = decodeEditTimeline(payload)
 	case generated.OPGuiGutterSep:

--- a/go/tui/internal/protocol/chrome_transcript.go
+++ b/go/tui/internal/protocol/chrome_transcript.go
@@ -1,0 +1,126 @@
+package protocol
+
+import "fmt"
+
+// Resident agent transcript transport (gui_agent_transcript, 0x86, #2654).
+//
+// This carries the resident conversation (the display_start_index-scoped
+// conversation, byte-capped by the encoder to a contiguous most-recent suffix)
+// so a frontend scrolls the session from local data without a BEAM round-trip.
+// The per-message body reuses the shared AgentChatMessageCodec, so a message
+// decodes byte-identically to the 0x78 messages section (see
+// decodeAgentMessageBody). See docs/GUI_PROTOCOL.md "0x86 — gui_agent_transcript"
+// for the authoritative wire contract.
+//
+// Wire payload (after the len32 opcode + u32 length framing):
+//
+//	version(1) = 1
+//	mode(1)              # 0 = full_replace, 1 = append
+//	epoch(4)
+//	truncated(1)         # 1 when older messages sit outside the resident window
+//	# full_replace (mode 0):
+//	count(4)
+//	# append (mode 1):
+//	trim_front(4)        # leading messages evicted from the store front this delta
+//	base_count(4)        # unchanged leading messages of the remainder to keep
+//	count(4)
+//	# both modes:
+//	count * [ id(4) + body_len(4) + body(body_len) ]
+const (
+	transcriptVersion     = 1
+	transcriptModeReplace = 0
+	transcriptModeAppend  = 1
+	// Fixed header before the mode-specific counts: version + mode + epoch + truncated.
+	transcriptHeaderLength = 7
+)
+
+// AgentTranscript is one decoded gui_agent_transcript frame: a full snapshot or
+// an incremental delta the resident store folds. It is not the store itself; the
+// store (residentTranscript in the ui package) applies successive frames.
+type AgentTranscript struct {
+	// Present is false when the frame could not be decoded (short/garbled); the
+	// store leaves its prior state untouched rather than clobbering it.
+	Present   bool
+	Version   byte
+	Mode      byte
+	Epoch     uint32
+	Truncated bool
+	// TrimFront is the number of messages evicted from the store front this delta
+	// (append only; 0 for full_replace).
+	TrimFront uint32
+	// BaseCount is the number of unchanged leading messages of the remainder to
+	// keep after the trim_front drop (append only; 0 for full_replace).
+	BaseCount uint32
+	Messages  []AgentChatMessage
+}
+
+// FullReplace reports whether this frame swaps the whole store (first frame of an
+// epoch, epoch change, or a non-prefix divergence the encoder resent as full).
+func (t AgentTranscript) FullReplace() bool { return t.Mode == transcriptModeReplace }
+
+func decodeAgentTranscript(payload []byte) (AgentTranscript, string, int) {
+	// len32 framing: [opcode][len:u32][body]. command_size already validated the
+	// total length, but decode defensively so a truncated survivor cannot panic.
+	if len(payload) < 5 {
+		return AgentTranscript{}, "", len(payload)
+	}
+	length := int(u32(payload, 1))
+	end := 5 + length
+	if end > len(payload) {
+		end = len(payload)
+	}
+	body := payload[5:end]
+	if len(body) < transcriptHeaderLength {
+		return AgentTranscript{}, "", end
+	}
+
+	transcript := AgentTranscript{
+		Present:   true,
+		Version:   body[0],
+		Mode:      body[1],
+		Epoch:     u32(body, 2),
+		Truncated: body[6] != 0,
+	}
+	offset := transcriptHeaderLength
+
+	var count int
+	if transcript.Mode == transcriptModeAppend {
+		if len(body) < offset+12 {
+			return AgentTranscript{}, "", end
+		}
+		transcript.TrimFront = u32(body, offset)
+		transcript.BaseCount = u32(body, offset+4)
+		count = int(u32(body, offset+8))
+		offset += 12
+	} else {
+		if len(body) < offset+4 {
+			return AgentTranscript{}, "", end
+		}
+		count = int(u32(body, offset))
+		offset += 4
+	}
+
+	transcript.Messages = make([]AgentChatMessage, 0, count)
+	for i := 0; i < count && len(body) >= offset+8; i++ {
+		id := u32(body, offset)
+		bodyLen := int(u32(body, offset+4))
+		offset += 8
+		if len(body) < offset+bodyLen {
+			break
+		}
+		if msg, ok := decodeAgentMessageBody(id, body[offset:offset+bodyLen]); ok {
+			transcript.Messages = append(transcript.Messages, msg)
+		}
+		offset += bodyLen
+	}
+
+	summary := fmt.Sprintf("transcript epoch:%d %s %d messages", transcript.Epoch, transcriptModeName(transcript.Mode), len(transcript.Messages))
+	return transcript, summary, end
+}
+
+func transcriptModeName(mode byte) string {
+	if mode == transcriptModeAppend {
+		return "append"
+	}
+	return "full_replace"
+}

--- a/go/tui/internal/protocol/chrome_transcript_test.go
+++ b/go/tui/internal/protocol/chrome_transcript_test.go
@@ -1,0 +1,152 @@
+package protocol
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+)
+
+// userBody builds the shared kind-first message body for a user text message:
+// <<0x01, len:u32, text>>. This is the same body the 0x78 messages section
+// carries after its per-message id, so the resident transcript reuses it.
+func userBody(text string) []byte {
+	body := []byte{0x01}
+	body = binary.BigEndian.AppendUint32(body, uint32(len(text)))
+	return append(body, []byte(text)...)
+}
+
+type transcriptEntry struct {
+	id   uint32
+	body []byte
+}
+
+// replaceFrameBytes builds a full_replace gui_agent_transcript (0x86) wire frame:
+// [opcode][len:u32] version(1) mode(1)=0 epoch(4) truncated(1) count(4)
+// count*[id(4) body_len(4) body].
+func replaceFrameBytes(epoch uint32, truncated bool, entries []transcriptEntry) []byte {
+	payload := []byte{transcriptVersion, transcriptModeReplace}
+	payload = binary.BigEndian.AppendUint32(payload, epoch)
+	payload = append(payload, boolByte(truncated))
+	payload = binary.BigEndian.AppendUint32(payload, uint32(len(entries)))
+	return frameBytes(appendEntries(payload, entries))
+}
+
+// appendFrameBytes builds an append gui_agent_transcript (0x86) wire frame:
+// version(1) mode(1)=1 epoch(4) truncated(1) trim_front(4) base_count(4) count(4)
+// count*entries.
+func appendFrameBytes(epoch uint32, truncated bool, trimFront, base uint32, entries []transcriptEntry) []byte {
+	payload := []byte{transcriptVersion, transcriptModeAppend}
+	payload = binary.BigEndian.AppendUint32(payload, epoch)
+	payload = append(payload, boolByte(truncated))
+	payload = binary.BigEndian.AppendUint32(payload, trimFront)
+	payload = binary.BigEndian.AppendUint32(payload, base)
+	payload = binary.BigEndian.AppendUint32(payload, uint32(len(entries)))
+	return frameBytes(appendEntries(payload, entries))
+}
+
+func appendEntries(payload []byte, entries []transcriptEntry) []byte {
+	for _, e := range entries {
+		payload = binary.BigEndian.AppendUint32(payload, e.id)
+		payload = binary.BigEndian.AppendUint32(payload, uint32(len(e.body)))
+		payload = append(payload, e.body...)
+	}
+	return payload
+}
+
+func frameBytes(payload []byte) []byte {
+	frame := []byte{generated.OPGuiAgentTranscript}
+	frame = binary.BigEndian.AppendUint32(frame, uint32(len(payload)))
+	return append(frame, payload...)
+}
+
+func boolByte(b bool) byte {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func TestDecodeAgentTranscriptFullReplace(t *testing.T) {
+	frame := replaceFrameBytes(7, true, []transcriptEntry{
+		{id: 1, body: userBody("first")},
+		{id: 2, body: userBody("second")},
+	})
+
+	got, _, size := decodeAgentTranscript(frame)
+	if size != len(frame) {
+		t.Fatalf("size = %d, want %d", size, len(frame))
+	}
+	if !got.Present || !got.FullReplace() || got.Epoch != 7 || !got.Truncated {
+		t.Fatalf("unexpected header: %+v", got)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("message count = %d, want 2", len(got.Messages))
+	}
+	if got.Messages[0].ID != 1 || got.Messages[0].Text != "first" {
+		t.Fatalf("message[0] = %+v", got.Messages[0])
+	}
+	if got.Messages[1].ID != 2 || got.Messages[1].Text != "second" {
+		t.Fatalf("message[1] = %+v", got.Messages[1])
+	}
+}
+
+func TestDecodeAgentTranscriptAppend(t *testing.T) {
+	frame := appendFrameBytes(7, false, 2, 3, []transcriptEntry{
+		{id: 4, body: userBody("fourth")},
+	})
+
+	got, _, _ := decodeAgentTranscript(frame)
+	if got.FullReplace() {
+		t.Fatalf("append frame reported full_replace")
+	}
+	if got.Epoch != 7 || got.TrimFront != 2 || got.BaseCount != 3 || got.Truncated {
+		t.Fatalf("header = %+v", got)
+	}
+	if len(got.Messages) != 1 || got.Messages[0].ID != 4 || got.Messages[0].Text != "fourth" {
+		t.Fatalf("messages = %+v", got.Messages)
+	}
+}
+
+func TestDecodeAgentTranscriptTruncatedBodyStops(t *testing.T) {
+	// count claims 2 entries but only one full entry is present; decode keeps the
+	// decodable prefix and does not panic.
+	frame := replaceFrameBytes(1, false, []transcriptEntry{
+		{id: 1, body: userBody("only")},
+	})
+	// Bump the count field. Offset: opcode(1)+len(4)+version(1)+mode(1)+epoch(4)+
+	// truncated(1) = 12 for a full_replace frame.
+	binary.BigEndian.PutUint32(frame[12:], 2)
+
+	got, _, _ := decodeAgentTranscript(frame)
+	if len(got.Messages) != 1 {
+		t.Fatalf("expected 1 decodable message, got %d", len(got.Messages))
+	}
+}
+
+func TestDecodeAgentTranscriptShortHeader(t *testing.T) {
+	frame := []byte{generated.OPGuiAgentTranscript, 0, 0, 0, 2, 0xAA, 0xBB}
+	got, _, size := decodeAgentTranscript(frame)
+	if got.Present {
+		t.Fatalf("short header should not be marked present")
+	}
+	if size != len(frame) {
+		t.Fatalf("size = %d, want %d", size, len(frame))
+	}
+}
+
+func TestDecodeAgentTranscriptRoutesThroughChrome(t *testing.T) {
+	frame := replaceFrameBytes(4, false, []transcriptEntry{
+		{id: 9, body: userBody("hello")},
+	})
+	chrome := decodeChrome(frame)
+	if chrome.Opcode != generated.OPGuiAgentTranscript {
+		t.Fatalf("opcode = %#x", chrome.Opcode)
+	}
+	if !chrome.AgentTranscript.Present || len(chrome.AgentTranscript.Messages) != 1 {
+		t.Fatalf("chrome transcript not decoded: %+v", chrome.AgentTranscript)
+	}
+	if chrome.Bytes != len(frame) {
+		t.Fatalf("chrome.Bytes = %d, want %d", chrome.Bytes, len(frame))
+	}
+}

--- a/go/tui/internal/protocol/chrome_types.go
+++ b/go/tui/internal/protocol/chrome_types.go
@@ -444,9 +444,13 @@ type AgentChat struct {
 	PromptVimMode     byte
 	PromptVisibleRows byte
 	ThinkingLevel     string
-	Messages          []AgentChatMessage
-	Pending           string
-	Completion        []string
+	// InputFocused reports whether the composer captures keys (0x78 section 0x09).
+	// The resident transcript scroll (#2654) gates j/k on this so a scroll key is
+	// not mistaken for composer cursor motion. Absent section leaves it false.
+	InputFocused bool
+	Messages     []AgentChatMessage
+	Pending      string
+	Completion   []string
 }
 
 type AgentChatMessage struct {

--- a/go/tui/internal/protocol/commands.go
+++ b/go/tui/internal/protocol/commands.go
@@ -102,6 +102,7 @@ type ChromePayload struct {
 	Observatory       Observatory
 	AgentContext      AgentContext
 	AgentChat         AgentChat
+	AgentTranscript   AgentTranscript
 	Timeline          EditTimeline
 	Gutter            GutterSeparator
 	CursorlineChrome  CursorlineChrome

--- a/go/tui/internal/protocol/events.go
+++ b/go/tui/internal/protocol/events.go
@@ -268,6 +268,20 @@ func EncodeGUIEmptyStateActivate(itemID string) []byte {
 	return append(out, payload...)
 }
 
+// EncodeGUIChatScrolledAwayFromBottom reports that the agent-chat transcript
+// left the bottom (the reader scrolled up), so the BEAM disengages follow-bottom
+// (#2654). Zero payload: the frontend owns the local scroll offset and only
+// reports the pin transition so the BEAM's authoritative state matches.
+func EncodeGUIChatScrolledAwayFromBottom() []byte {
+	return []byte{generated.OPGuiAction, generated.GUIActionChatScrolledAwayFromBottom}
+}
+
+// EncodeGUIChatReturnedToBottom reports that the transcript returned to the
+// bottom (follow-bottom re-engaged). Pairs with the scrolled-away report (#2654).
+func EncodeGUIChatReturnedToBottom() []byte {
+	return []byte{generated.OPGuiAction, generated.GUIActionChatReturnedToBottom}
+}
+
 // appendString16 appends a length-prefixed string (len:u16 big-endian, then
 // utf8 bytes) to out, truncating to the u16 ceiling, matching the macOS
 // appendString16 helper used by every string-bearing gui_action.

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -15,14 +15,14 @@ type agentPanel struct {
 	animationRunning bool
 }
 
-func (a *agentPanel) animating(chat protocol.AgentChat) bool {
+func (a *agentPanel) animating(chat protocol.AgentChat, messages []protocol.AgentChatMessage) bool {
 	if !chat.Visible {
 		return false
 	}
 	if chat.Status == 1 || chat.Status == 2 || chat.Pending != "" {
 		return true
 	}
-	for _, msg := range chat.Messages {
+	for _, msg := range messages {
 		if msg.Kind == agentKindThinking || ((msg.Kind == agentKindTool || msg.Kind == agentKindStyledTool) && msg.Status == 0) {
 			return true
 		}
@@ -39,7 +39,14 @@ func (a *agentPanel) spinner() string {
 	return frames[int(a.animationFrame)%len(frames)]
 }
 
-func (a *agentPanel) handleKey(chat protocol.AgentChat, msg tea.KeyPressMsg) ([]byte, bool) {
+// handleKey handles the Ctrl+Alt+X/Z collapse toggles. The index is resolved
+// against `messages` (the resident transcript, #2654), not the windowed 0x78
+// list: the BEAM's toggle handler applies List.update_at on the full session
+// conversation, which the resident store mirrors (messages_with_ids, with
+// transcript enrichments appended after the tool/thinking messages), so the
+// latest-tool/thinking index aligns. The windowed 0x78 list would drift once the
+// conversation exceeds the window.
+func (a *agentPanel) handleKey(chat protocol.AgentChat, messages []protocol.AgentChatMessage, msg tea.KeyPressMsg) ([]byte, bool) {
 	if !chat.Visible {
 		return nil, false
 	}
@@ -49,13 +56,13 @@ func (a *agentPanel) handleKey(chat protocol.AgentChat, msg tea.KeyPressMsg) ([]
 	}
 	switch key.Code {
 	case 'x', 'X':
-		index, ok := latestToolMessageIndex(chat.Messages)
+		index, ok := latestToolMessageIndex(messages)
 		if !ok {
 			return nil, false
 		}
 		return protocol.EncodeGUIAgentToolToggle(index), true
 	case 'z', 'Z':
-		index, ok := latestThinkingMessageIndex(chat.Messages)
+		index, ok := latestThinkingMessageIndex(messages)
 		if !ok {
 			return nil, false
 		}
@@ -120,7 +127,7 @@ func (m Model) insetAgentLine(line string, width int) string {
 
 func (m Model) renderAgentChatPanelWithLimit(chat protocol.AgentChat, width int, limit int) []string {
 	limit = max(limit, 1)
-	empty := chat.Pending == "" && strings.TrimSpace(chat.Prompt) == "" && len(chat.Messages) == 0
+	empty := chat.Pending == "" && strings.TrimSpace(chat.Prompt) == "" && len(m.agentTranscriptMessages(chat)) == 0
 	lines := []string{m.renderAgentHeader(chat, width)}
 
 	if agentDetailsVisible(width) && limit > 5 {
@@ -163,7 +170,8 @@ func (m Model) renderAgentMainColumn(chat protocol.AgentChat, width int, budget 
 		statusHeight = 1
 	}
 	contentBudget := max(transcriptBudget-statusHeight, 0)
-	sparse := len(chat.Messages) <= 1 && chat.Pending == "" && strings.TrimSpace(chat.Prompt) == ""
+	messageCount := len(m.agentTranscriptMessages(chat))
+	sparse := messageCount <= 1 && chat.Pending == "" && strings.TrimSpace(chat.Prompt) == ""
 	if chat.Pending != "" && len(lines) < contentBudget {
 		lines = append(lines, m.renderAgentNotice("◆ approval", chat.Pending, width))
 	}
@@ -172,7 +180,7 @@ func (m Model) renderAgentMainColumn(chat protocol.AgentChat, width int, budget 
 		lines = append(lines, m.renderAgentTranscriptHeader(width))
 	}
 
-	messageLines := m.renderAgentTranscriptTail(chat, max(contentBudget-len(lines), 0), width)
+	messageLines := m.renderAgentResidentTranscript(chat, max(contentBudget-len(lines), 0), width)
 	lines = append(lines, messageLines...)
 
 	if empty && len(lines) < contentBudget {
@@ -213,7 +221,7 @@ func (m Model) renderAgentTranscriptHeader(width int) string {
 
 func (m Model) renderAgentTranscriptStatus(chat protocol.AgentChat, width int) string {
 	p := m.palette()
-	messageCount := len(chat.Messages)
+	messageCount := len(m.agentTranscriptMessages(chat))
 	label := "messages"
 	if messageCount == 1 {
 		label = "message"
@@ -315,6 +323,7 @@ func (m Model) joinAgentColumns(left []string, right []string, leftWidth int, ri
 }
 
 func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget int) []string {
+	messages := m.agentTranscriptMessages(chat)
 	provider, model := splitAgentModelName(chat.ModelName)
 	lines := []string{m.renderAgentDetailFrame("top", "◇ Session", width)}
 	lines = append(lines, m.renderAgentDetailRow("Provider", nonEmpty(provider, "unknown"), width))
@@ -323,9 +332,9 @@ func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget
 	if chat.ThinkingLevel != "" {
 		lines = append(lines, m.renderAgentDetailRow("Thinking", chat.ThinkingLevel, width))
 	}
-	lines = append(lines, m.renderAgentDetailRow("Messages", fmt.Sprintf("%d", len(chat.Messages)), width))
+	lines = append(lines, m.renderAgentDetailRow("Messages", fmt.Sprintf("%d", len(messages)), width))
 
-	toolCount, runningTools, erroredTools := agentToolCounts(chat.Messages)
+	toolCount, runningTools, erroredTools := agentToolCounts(messages)
 	if toolCount > 0 {
 		value := fmt.Sprintf("%d", toolCount)
 		if runningTools > 0 || erroredTools > 0 {
@@ -336,11 +345,11 @@ func (m Model) renderAgentDetailsRail(chat protocol.AgentChat, width int, budget
 	if chat.Pending != "" {
 		lines = append(lines, m.renderAgentDetailRow("Approval", "waiting", width))
 	}
-	if lastAgentError(chat.Messages) != "" {
+	if lastAgentError(messages) != "" {
 		lines = append(lines, m.renderAgentDetailsSection("Needs attention", width))
 		lines = append(lines, m.renderAgentDetailRow("Auth", "run /auth or check API key", width))
 	}
-	if usage, ok := lastAgentUsage(chat.Messages); ok {
+	if usage, ok := lastAgentUsage(messages); ok {
 		lines = append(lines, m.renderAgentDetailRow("Context", fmt.Sprintf("%s in · %s out", formatAgentTokens(usage.Input), formatAgentTokens(usage.Output)), width))
 		if usage.CostMicros > 0 {
 			lines = append(lines, m.renderAgentDetailRow("Cost", fmt.Sprintf("$%.2f", float64(usage.CostMicros)/1_000_000), width))
@@ -515,37 +524,98 @@ func (m Model) renderAgentNotice(label string, text string, width int) string {
 	return lipgloss.NewStyle().Background(p.SurfaceAlt()).Width(width).Render(fitStyled(line, width))
 }
 
-func (m Model) renderAgentTranscriptTail(chat protocol.AgentChat, budget int, width int) []string {
-	if budget <= 0 || len(chat.Messages) == 0 {
+// agentTranscriptMessages is the transcript rendering source: the resident 0x86
+// store (#2654). It falls back to the 0x78 chrome messages only when the store
+// is empty (a BEAM that has not sent a transcript frame yet), so a transitional
+// stream still renders.
+func (m Model) agentTranscriptMessages(chat protocol.AgentChat) []protocol.AgentChatMessage {
+	if m.transcript != nil && len(m.transcript.messages) > 0 {
+		return m.transcript.messages
+	}
+	return chat.Messages
+}
+
+// renderAgentResidentTranscript renders the visible transcript window from the
+// resident store, applying any queued local scroll same-frame (#2654). Pinned
+// follows the bottom; unpinned holds a top-anchored offset so a streaming append
+// does not move the reading position. It mutates the shared *transcript pointer
+// (clamp + pin edge), which persists through the value-receiver render chain.
+func (m Model) renderAgentResidentTranscript(chat protocol.AgentChat, budget int, width int) []string {
+	messages := m.agentTranscriptMessages(chat)
+	t := m.transcript
+	if t == nil {
+		return m.agentTranscriptTail(messages, budget, width)
+	}
+	if budget <= 0 || len(messages) == 0 {
+		t.pendingScroll = 0
 		return nil
 	}
-	blocks := make([][]string, 0, len(chat.Messages))
-	used := 0
-	for i := len(chat.Messages) - 1; i >= 0; i-- {
-		block := m.renderAgentMessage(chat.Messages[i], width)
+	// Only pay for the full layout when scrolled up or a scroll is pending; the
+	// common followed case renders just the bottom window.
+	if t.pendingScroll == 0 && t.pinned {
+		return m.agentTranscriptTail(messages, budget, width)
+	}
+	lines := m.agentTranscriptAllLines(messages, width)
+	maxTop := max(len(lines)-budget, 0)
+	t.resolveScroll(maxTop)
+	if t.pinned {
+		return windowBottom(lines, budget)
+	}
+	return windowTopAnchored(lines, budget, t.topOffset)
+}
+
+// agentTranscriptAllLines renders every message top-to-bottom with a separator
+// between messages. It is the full line layout the unpinned (scrolled-up) window
+// slices; the pinned path uses the cheaper bottom-bounded agentTranscriptTail.
+func (m Model) agentTranscriptAllLines(messages []protocol.AgentChatMessage, width int) []string {
+	lines := make([]string, 0, len(messages)*2)
+	first := true
+	for _, msg := range messages {
+		block := m.renderAgentMessage(msg, width)
 		if len(block) == 0 {
 			continue
 		}
-		if used > 0 && used+len(block) > budget {
-			break
-		}
-		blocks = append(blocks, block)
-		used += len(block)
-		if used >= budget {
-			break
-		}
-	}
-	lines := make([]string, 0, budget)
-	for i := len(blocks) - 1; i >= 0; i-- {
-		lines = append(lines, blocks[i]...)
-		if i > 0 && len(lines) < budget {
+		if !first {
 			lines = append(lines, m.renderAgentTranscriptSeparator(width))
 		}
-	}
-	if len(lines) > budget {
-		return lines[:budget]
+		lines = append(lines, block...)
+		first = false
 	}
 	return lines
+}
+
+// agentTranscriptTail renders the bottom `budget` lines, bounded so a followed
+// session only renders enough messages to fill the view regardless of transcript
+// length. Its output equals the bottom `budget` lines of agentTranscriptAllLines
+// (guarded by test) so the pinned and unpinned paths stay visually consistent.
+func (m Model) agentTranscriptTail(messages []protocol.AgentChatMessage, budget int, width int) []string {
+	if budget <= 0 || len(messages) == 0 {
+		return nil
+	}
+	blocks := make([][]string, 0, 8) // newest-first
+	total := 0
+	for i := len(messages) - 1; i >= 0; i-- {
+		block := m.renderAgentMessage(messages[i], width)
+		if len(block) == 0 {
+			continue
+		}
+		if len(blocks) > 0 {
+			total++ // separator above the previously added (newer) block
+		}
+		blocks = append(blocks, block)
+		total += len(block)
+		if total >= budget {
+			break
+		}
+	}
+	lines := make([]string, 0, total)
+	for k := len(blocks) - 1; k >= 0; k-- {
+		if k < len(blocks)-1 {
+			lines = append(lines, m.renderAgentTranscriptSeparator(width))
+		}
+		lines = append(lines, blocks[k]...)
+	}
+	return windowBottom(lines, budget)
 }
 
 func (m Model) renderAgentMessage(msg protocol.AgentChatMessage, width int) []string {

--- a/go/tui/internal/ui/agent_transcript.go
+++ b/go/tui/internal/ui/agent_transcript.go
@@ -1,0 +1,205 @@
+package ui
+
+import "github.com/jsmestad/minga/go/tui/internal/protocol"
+
+// residentTranscript is the Go TUI's resident agent-chat transcript store
+// (#2654). It folds gui_agent_transcript (0x86) frames so the whole session can
+// be scrolled from local data without a BEAM round-trip: a full_replace swaps
+// the entire slice at a new epoch; an append keeps the strict-equal prefix and
+// replaces the suffix (new messages plus the in-place patch of the streaming
+// last message).
+//
+// It is a pointer on Model so it survives the value-copied Update loop, and it
+// owns the local scroll offset + pin flag so j/k/wheel repaint same-frame
+// without waiting for the BEAM. While pinned the view follows the bottom; while
+// unpinned it holds a top-anchored line offset so a streaming append at the
+// bottom never disturbs the reading position.
+type residentTranscript struct {
+	epoch    uint32
+	hasEpoch bool
+	messages []protocol.AgentChatMessage
+	// truncated mirrors the frame flag: older messages sit outside the resident
+	// window (cap eviction), so the top of the local scroll is not the true start
+	// of the conversation.
+	truncated bool
+
+	// pinned true = follow the bottom (default). Unpinned holds topOffset.
+	pinned bool
+	// topOffset is the rendered line at the top of the viewport, counted from the
+	// top of the full transcript. Only meaningful while unpinned. Top-anchored so
+	// bottom appends leave it (and the reading position) untouched.
+	topOffset int
+	// pendingScroll accumulates unresolved scroll rows for this frame (+down /
+	// -up). It is resolved during render, where the full transcript height (and
+	// thus the clamp bounds) is known.
+	pendingScroll int
+	// pinTransition records a pin edge produced by the last resolve so Update can
+	// report it to the BEAM (pinNone once reported).
+	pinTransition int
+}
+
+const (
+	pinNone = iota
+	pinScrolledAway
+	pinReturned
+)
+
+func newResidentTranscript() *residentTranscript {
+	return &residentTranscript{pinned: true}
+}
+
+// apply folds one decoded gui_agent_transcript frame into the store, following
+// the docs/GUI_PROTOCOL.md 0x86 apply rules.
+func (t *residentTranscript) apply(frame protocol.AgentTranscript) {
+	if !frame.Present {
+		return
+	}
+	t.truncated = frame.Truncated
+
+	if frame.FullReplace() {
+		epochChanged := !t.hasEpoch || frame.Epoch != t.epoch
+		next := make([]protocol.AgentChatMessage, len(frame.Messages))
+		copy(next, frame.Messages)
+		t.messages = next
+		t.epoch = frame.Epoch
+		t.hasEpoch = true
+		// A new epoch is a session switch / structural reset: re-pin to the bottom
+		// so the fresh transcript shows its newest content. A same-epoch
+		// full_replace (compaction, resident-cap drop from the front) keeps the pin
+		// state; the render clamps any now-out-of-range offset.
+		if epochChanged {
+			t.pinned = true
+			t.topOffset = 0
+		}
+		return
+	}
+
+	// append: an epoch mismatch means we missed the epoch's full_replace; drop the
+	// delta and await the next full_replace.
+	if t.hasEpoch && frame.Epoch != t.epoch {
+		return
+	}
+	trim := int(frame.TrimFront)
+	base := int(frame.BaseCount)
+	// Desync when the store cannot cover the delta's front assumptions: it holds
+	// fewer than trim_front + base_count messages. Drop and await full_replace.
+	if len(t.messages) < trim+base {
+		return
+	}
+
+	// Apply order (GUI_PROTOCOL.md 0x86): drop trim_front from the front; keep the
+	// first base_count of the remainder unchanged; upsert each frame message by id
+	// (new id appends, matching id patches the streaming last message in place).
+	kept := t.messages[trim : trim+base]
+	next := make([]protocol.AgentChatMessage, len(kept), base+len(frame.Messages))
+	copy(next, kept)
+	for _, msg := range frame.Messages {
+		if idx := indexByID(next, msg.ID); idx >= 0 {
+			next[idx] = msg
+		} else {
+			next = append(next, msg)
+		}
+	}
+	t.messages = next
+	if frame.Epoch != 0 {
+		t.epoch = frame.Epoch
+		t.hasEpoch = true
+	}
+}
+
+// indexByID returns the position of the message with id, or -1. A message id of 0
+// is the "no stable identity" sentinel (bare bodies encode with id 0), so those
+// never match and always append.
+func indexByID(messages []protocol.AgentChatMessage, id uint32) int {
+	if id == 0 {
+		return -1
+	}
+	for i := range messages {
+		if messages[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// scrollBy queues a scroll intent of `rows` lines (+down / -up). It is applied
+// and clamped at render time via resolveScroll.
+func (t *residentTranscript) scrollBy(rows int) {
+	t.pendingScroll += rows
+}
+
+// resolveScroll applies the queued scroll against a transcript whose full
+// rendered height allows a maximum top-anchored offset of maxTop, then clamps
+// and updates the pin flag. It records any pin edge in pinTransition and returns
+// it. maxTop is max(totalLines-budget, 0).
+func (t *residentTranscript) resolveScroll(maxTop int) int {
+	transition := pinNone
+	rows := t.pendingScroll
+	t.pendingScroll = 0
+
+	if rows != 0 {
+		if t.pinned {
+			// A downward scroll while pinned is already at the bottom: ignore it.
+			// An upward scroll leaves the bottom: baseline at maxTop, then move up.
+			if rows < 0 {
+				t.pinned = false
+				t.topOffset = clampInt(maxTop+rows, 0, maxTop)
+				transition = pinScrolledAway
+			}
+		} else {
+			t.topOffset = clampInt(t.topOffset+rows, 0, maxTop)
+			if t.topOffset >= maxTop {
+				t.pinned = true
+				transition = pinReturned
+			}
+		}
+	}
+
+	// Content may have changed height since the last frame; keep an unpinned
+	// offset in range. If the whole transcript now fits (maxTop == 0), there is
+	// nothing to scroll, so fall back to pinned without reporting a user return.
+	if !t.pinned {
+		if maxTop == 0 {
+			t.pinned = true
+			t.topOffset = 0
+		} else {
+			t.topOffset = clampInt(t.topOffset, 0, maxTop)
+		}
+	}
+
+	if transition != pinNone {
+		t.pinTransition = transition
+	}
+	return transition
+}
+
+// takePinTransition returns and clears the pending pin transition so Update
+// reports it to the BEAM exactly once.
+func (t *residentTranscript) takePinTransition() int {
+	transition := t.pinTransition
+	t.pinTransition = pinNone
+	return transition
+}
+
+// windowTopAnchored returns the visible slice of `lines` for a top-anchored
+// viewport of height `budget` whose first visible line is `topOffset`.
+func windowTopAnchored(lines []string, budget, topOffset int) []string {
+	if budget <= 0 || len(lines) == 0 {
+		return nil
+	}
+	maxTop := max(len(lines)-budget, 0)
+	top := clampInt(topOffset, 0, maxTop)
+	end := min(top+budget, len(lines))
+	return lines[top:end]
+}
+
+// windowBottom returns the last `budget` lines (the follow-bottom view).
+func windowBottom(lines []string, budget int) []string {
+	if budget <= 0 || len(lines) == 0 {
+		return nil
+	}
+	if len(lines) <= budget {
+		return lines
+	}
+	return lines[len(lines)-budget:]
+}

--- a/go/tui/internal/ui/agent_transcript_render_test.go
+++ b/go/tui/internal/ui/agent_transcript_render_test.go
@@ -1,0 +1,119 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+func visibleAgentChat() protocol.AgentChat {
+	return protocol.AgentChat{
+		Visible:   true,
+		ModelName: "anthropic:claude-sonnet-4",
+		// A stale 0x78 messages payload the resident store must override.
+		Messages: []protocol.AgentChatMessage{{ID: 999, Kind: 0x01, Text: "STALE_0x78_MESSAGE"}},
+	}
+}
+
+func residentModel(t *testing.T, count int) Model {
+	t.Helper()
+	model := New(80, 30, nil, nil)
+	model.chrome = map[byte]protocol.ChromePayload{
+		generated.OPGuiAgentChat: {AgentChat: visibleAgentChat()},
+	}
+	msgs := make([]protocol.AgentChatMessage, 0, count)
+	for i := 1; i <= count; i++ {
+		msgs = append(msgs, protocol.AgentChatMessage{ID: uint32(i), Kind: 0x01, Text: fmt.Sprintf("USERMSG_%d", i)})
+	}
+	model.transcript.apply(protocol.AgentTranscript{Present: true, Mode: 0, Epoch: 1, Messages: msgs})
+	return model
+}
+
+func TestAgentTranscriptRendersFromResidentStore(t *testing.T) {
+	model := residentModel(t, 12)
+	body := ansi.Strip(model.content())
+
+	if strings.Contains(body, "STALE_0x78_MESSAGE") {
+		t.Fatalf("transcript must render from the resident store, not 0x78 messages: %q", body)
+	}
+	if !strings.Contains(body, "USERMSG_12") {
+		t.Fatalf("newest resident message should be visible at the bottom: %q", body)
+	}
+}
+
+func TestAgentTranscriptLocalScrollRevealsOlderSameFrame(t *testing.T) {
+	model := residentModel(t, 40)
+
+	// Pinned: the oldest message is off-screen.
+	if body := ansi.Strip(model.content()); strings.Contains(body, "USERMSG_1 ") {
+		t.Fatalf("oldest message should be scrolled off while pinned: %q", body)
+	}
+
+	// Scroll up hard; the same frame repaints from local data.
+	model.transcript.scrollBy(-10000)
+	body := ansi.Strip(model.content())
+
+	if model.transcript.pinned {
+		t.Fatalf("scrolling up should unpin the transcript")
+	}
+	if model.transcript.pinTransition != pinScrolledAway {
+		t.Fatalf("scroll-up should record a scrolled-away pin transition, got %d", model.transcript.pinTransition)
+	}
+	if !strings.Contains(body, "USERMSG_1") {
+		t.Fatalf("scrolled-up transcript should reveal the oldest message: %q", body)
+	}
+	if strings.Contains(body, "USERMSG_40") {
+		t.Fatalf("scrolled to the top, the newest message should be off-screen: %q", body)
+	}
+}
+
+func TestAgentToggleIndexesResidentNotWindowed(t *testing.T) {
+	// The BEAM collapse toggle applies List.update_at on the full session
+	// conversation, so the Ctrl+Alt+X/Z index must be resolved against the
+	// resident store, not the windowed 0x78 list (#2654). Here the resident list
+	// puts the latest tool at index 3; a windowed slice would have reported a
+	// different position.
+	var panel agentPanel
+	chat := protocol.AgentChat{Visible: true}
+	resident := []protocol.AgentChatMessage{
+		{ID: 1, Kind: agentKindUser, Text: "u"},
+		{ID: 2, Kind: agentKindAssistant, Text: "a"},
+		{ID: 3, Kind: agentKindUser, Text: "u2"},
+		{ID: 4, Kind: agentKindTool, Text: "tool"},
+	}
+	press := tea.KeyPressMsg(tea.Key{Code: 'x', Mod: tea.ModCtrl | tea.ModAlt})
+
+	packet, handled := panel.handleKey(chat, resident, press)
+	if !handled {
+		t.Fatalf("Ctrl+Alt+X should be handled when a tool message exists")
+	}
+	// packet = [OPGuiAction, GUIActionAgentToolToggle, idx>>8, idx].
+	if packet[0] != generated.OPGuiAction || packet[1] != generated.GUIActionAgentToolToggle {
+		t.Fatalf("unexpected toggle packet header: %v", packet)
+	}
+	if idx := int(packet[2])<<8 | int(packet[3]); idx != 3 {
+		t.Fatalf("toggle index = %d, want 3 (resident position)", idx)
+	}
+}
+
+func TestAgentTranscriptTailMatchesAllLinesBottom(t *testing.T) {
+	// The cheap pinned tail render must equal the bottom of the full layout so the
+	// pinned and unpinned (scrolled-up) paths never diverge at the seam.
+	model := residentModel(t, 25)
+	messages := model.transcript.messages
+	width := max(model.width-2, 1)
+
+	for _, budget := range []int{1, 3, 6, 10, 40} {
+		all := model.agentTranscriptAllLines(messages, width)
+		wantBottom := windowBottom(all, budget)
+		gotTail := model.agentTranscriptTail(messages, budget, width)
+		if strings.Join(gotTail, "\n") != strings.Join(wantBottom, "\n") {
+			t.Fatalf("budget %d: tail != allLines bottom\ntail=%v\nbottom=%v", budget, gotTail, wantBottom)
+		}
+	}
+}

--- a/go/tui/internal/ui/agent_transcript_test.go
+++ b/go/tui/internal/ui/agent_transcript_test.go
@@ -1,0 +1,281 @@
+package ui
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+func msg(id uint32, text string) protocol.AgentChatMessage {
+	return protocol.AgentChatMessage{ID: id, Kind: 0x01, Text: text}
+}
+
+func replaceFrame(epoch uint32, msgs ...protocol.AgentChatMessage) protocol.AgentTranscript {
+	return protocol.AgentTranscript{Present: true, Mode: 0, Epoch: epoch, Messages: msgs}
+}
+
+func appendFrame(epoch, trim, base uint32, msgs ...protocol.AgentChatMessage) protocol.AgentTranscript {
+	return protocol.AgentTranscript{
+		Present:   true,
+		Mode:      1,
+		Epoch:     epoch,
+		TrimFront: trim,
+		BaseCount: base,
+		Messages:  msgs,
+	}
+}
+
+func ids(msgs []protocol.AgentChatMessage) []uint32 {
+	out := make([]uint32, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.ID
+	}
+	return out
+}
+
+func TestResidentTranscriptFullReplace(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.apply(replaceFrame(1, msg(1, "a"), msg(2, "b")))
+
+	if got, want := ids(tr.messages), []uint32{1, 2}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("ids = %v, want %v", got, want)
+	}
+	if !tr.hasEpoch || tr.epoch != 1 {
+		t.Fatalf("epoch not stored: %+v", tr)
+	}
+	if !tr.pinned {
+		t.Fatalf("full_replace should leave the view pinned")
+	}
+}
+
+func TestResidentTranscriptAppendUpsertsSuffix(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.apply(replaceFrame(1, msg(1, "a"), msg(2, "b")))
+	tr.apply(appendFrame(1, 0, 2, msg(3, "c")))
+
+	if got, want := ids(tr.messages), []uint32{1, 2, 3}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("ids = %v, want %v", got, want)
+	}
+	if tr.messages[2].Text != "c" {
+		t.Fatalf("appended text = %q", tr.messages[2].Text)
+	}
+}
+
+func TestResidentTranscriptAppendPatchesStreamingTail(t *testing.T) {
+	// The streaming last message re-sends from base = len-1 with new content.
+	tr := newResidentTranscript()
+	tr.apply(replaceFrame(1, msg(1, "a"), msg(2, "partial")))
+	tr.apply(appendFrame(1, 0, 1, msg(2, "partial complete")))
+
+	if got, want := ids(tr.messages), []uint32{1, 2}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("ids = %v, want %v", got, want)
+	}
+	if tr.messages[1].Text != "partial complete" {
+		t.Fatalf("streaming tail not patched: %q", tr.messages[1].Text)
+	}
+}
+
+func TestResidentTranscriptAppendEvictsFrontViaTrimFront(t *testing.T) {
+	// Over-cap steady streaming: trim_front evicts older messages from the front
+	// while the delta appends new ones at the back.
+	tr := newResidentTranscript()
+	tr.apply(replaceFrame(1, msg(1, "a"), msg(2, "b"), msg(3, "c"), msg(4, "d"), msg(5, "e")))
+	// Evict m1,m2 from the front; keep m3,m4 unchanged; re-send m5 (patched).
+	tr.apply(appendFrame(1, 2, 2, msg(5, "e patched")))
+
+	if got, want := ids(tr.messages), []uint32{3, 4, 5}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("ids = %v, want %v", got, want)
+	}
+	if tr.messages[2].Text != "e patched" {
+		t.Fatalf("re-sent tail not patched: %q", tr.messages[2].Text)
+	}
+}
+
+func TestResidentTranscriptAppendUpsertPatchesWithinKeptPrefix(t *testing.T) {
+	// A matching id inside the kept prefix patches in place (literal id-keyed
+	// upsert) rather than duplicating.
+	tr := newResidentTranscript()
+	tr.apply(replaceFrame(1, msg(1, "a"), msg(2, "b"), msg(3, "c"), msg(4, "d")))
+	// trim 1 (evict m1); keep m2,m3,m4; upsert m4 (id in kept prefix → patch).
+	tr.apply(appendFrame(1, 1, 3, msg(4, "d patched")))
+
+	if got, want := ids(tr.messages), []uint32{2, 3, 4}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("ids = %v, want %v", got, want)
+	}
+	if tr.messages[2].Text != "d patched" {
+		t.Fatalf("upsert should patch in place: %q", tr.messages[2].Text)
+	}
+}
+
+func TestResidentTranscriptTracksTruncatedFlag(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.apply(protocol.AgentTranscript{Present: true, Mode: 0, Epoch: 1, Truncated: true, Messages: []protocol.AgentChatMessage{msg(1, "a")}})
+	if !tr.truncated {
+		t.Fatalf("truncated flag should be tracked from the frame")
+	}
+}
+
+func TestResidentTranscriptEpochFlipReplaces(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.apply(replaceFrame(1, msg(1, "a"), msg(2, "b")))
+	tr.pinned = false
+	tr.topOffset = 3
+	tr.apply(replaceFrame(2, msg(9, "fresh")))
+
+	if got, want := ids(tr.messages), []uint32{9}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("ids = %v, want %v", got, want)
+	}
+	if tr.epoch != 2 {
+		t.Fatalf("epoch = %d, want 2", tr.epoch)
+	}
+	if !tr.pinned || tr.topOffset != 0 {
+		t.Fatalf("epoch flip (session switch) should re-pin to bottom: %+v", tr)
+	}
+}
+
+func TestResidentTranscriptAppendDesyncDropped(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.apply(replaceFrame(1, msg(1, "a")))
+	// resident_count (1) < trim_front + base_count (1 + 1): the delta cannot apply
+	// against what the store holds, so drop it and await full_replace.
+	tr.apply(appendFrame(1, 1, 1, msg(6, "orphan")))
+
+	if got, want := ids(tr.messages), []uint32{1}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("desync append should be dropped, got %v", got)
+	}
+}
+
+func TestResidentTranscriptAppendEpochMismatchDropped(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.apply(replaceFrame(1, msg(1, "a")))
+	tr.apply(appendFrame(2, 0, 1, msg(2, "b")))
+
+	if got, want := ids(tr.messages), []uint32{1}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("epoch-mismatch append should be dropped, got %v", got)
+	}
+}
+
+func TestResolveScrollUnpinsFromBottom(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.scrollBy(-3) // scroll up off the bottom
+	transition := tr.resolveScroll(15)
+
+	if tr.pinned {
+		t.Fatalf("scrolling up should unpin")
+	}
+	if tr.topOffset != 12 {
+		t.Fatalf("topOffset = %d, want 12 (maxTop 15 - 3)", tr.topOffset)
+	}
+	if transition != pinScrolledAway {
+		t.Fatalf("transition = %d, want pinScrolledAway", transition)
+	}
+}
+
+func TestResolveScrollDownWhilePinnedIsNoop(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.scrollBy(4)
+	transition := tr.resolveScroll(15)
+
+	if !tr.pinned || transition != pinNone {
+		t.Fatalf("scroll down while pinned should stay pinned with no transition: %+v t=%d", tr, transition)
+	}
+}
+
+func TestResolveScrollReturnsToBottom(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.pinned = false
+	tr.topOffset = 12
+	tr.scrollBy(5) // past the bottom
+	transition := tr.resolveScroll(15)
+
+	if !tr.pinned {
+		t.Fatalf("scrolling down to the bottom should re-pin")
+	}
+	if transition != pinReturned {
+		t.Fatalf("transition = %d, want pinReturned", transition)
+	}
+}
+
+func TestResolveScrollClampsToTop(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.pinned = false
+	tr.topOffset = 2
+	tr.scrollBy(-10) // way past the top
+	tr.resolveScroll(15)
+
+	if tr.topOffset != 0 {
+		t.Fatalf("topOffset = %d, want 0 (clamped to top)", tr.topOffset)
+	}
+	if tr.pinned {
+		t.Fatalf("scrolled to top should remain unpinned")
+	}
+}
+
+func TestResolveScrollAppendWhileScrolledUpPreservesPosition(t *testing.T) {
+	// Scroll up in a 20-line transcript (budget 5, maxTop 15), then a streaming
+	// append grows it to 25 lines (maxTop 20). Because the offset is top-anchored,
+	// the reading position (topOffset) must not move.
+	tr := newResidentTranscript()
+	tr.scrollBy(-3)
+	tr.resolveScroll(15)
+	if tr.topOffset != 12 {
+		t.Fatalf("precondition topOffset = %d, want 12", tr.topOffset)
+	}
+
+	// Next frame after an append: no new scroll input, larger transcript.
+	tr.resolveScroll(20)
+
+	if tr.pinned {
+		t.Fatalf("append while scrolled up must not re-pin")
+	}
+	if tr.topOffset != 12 {
+		t.Fatalf("append moved the reading position: topOffset = %d, want 12", tr.topOffset)
+	}
+}
+
+func TestResolveScrollContentShrinkRepinsWhenAllFits(t *testing.T) {
+	tr := newResidentTranscript()
+	tr.pinned = false
+	tr.topOffset = 8
+	// Content now fits entirely in the viewport (maxTop 0): nothing to scroll.
+	tr.resolveScroll(0)
+
+	if !tr.pinned || tr.topOffset != 0 {
+		t.Fatalf("all-fits should re-pin to bottom: %+v", tr)
+	}
+}
+
+func lineSeq(n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = fmt.Sprintf("L%d", i)
+	}
+	return out
+}
+
+func TestWindowTopAnchored(t *testing.T) {
+	lines := lineSeq(20)
+
+	got := windowTopAnchored(lines, 5, 12)
+	if fmt.Sprint(got) != fmt.Sprint([]string{"L12", "L13", "L14", "L15", "L16"}) {
+		t.Fatalf("window = %v", got)
+	}
+
+	// Offset past the max clamps so the last budget lines show.
+	clamped := windowTopAnchored(lines, 5, 999)
+	if fmt.Sprint(clamped) != fmt.Sprint([]string{"L15", "L16", "L17", "L18", "L19"}) {
+		t.Fatalf("clamped window = %v", clamped)
+	}
+}
+
+func TestWindowBottom(t *testing.T) {
+	lines := lineSeq(20)
+	got := windowBottom(lines, 5)
+	if fmt.Sprint(got) != fmt.Sprint([]string{"L15", "L16", "L17", "L18", "L19"}) {
+		t.Fatalf("bottom window = %v", got)
+	}
+	if all := windowBottom(lineSeq(3), 5); len(all) != 3 {
+		t.Fatalf("short transcript should return all lines, got %v", all)
+	}
+}

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -110,6 +110,12 @@ type Model struct {
 	surfacePlacements []generated.SurfacePlacement
 	localPresentation localPresentation
 	inputFilter       *InputFilter
+	// transcript is the resident agent-chat transcript store (#2654). It folds
+	// gui_agent_transcript (0x86) frames and owns the local scroll offset + pin
+	// flag so j/k/wheel repaint the transcript same-frame from local data. It is
+	// a pointer so it persists across the value-copied Update loop (same lifetime
+	// trick as lineCache/latency).
+	transcript *residentTranscript
 }
 
 // frameStaging is the open frame transaction buffer (#2219). It lives only
@@ -146,6 +152,7 @@ func New(width, height uint16, out chan<- []byte, filter *InputFilter) Model {
 		lineCache:         newLineCache(),
 		localPresentation: newLocalPresentation(),
 		inputFilter:       filter,
+		transcript:        newResidentTranscript(),
 	}
 	// Seed the layout so the first mouse event lands in the correct
 	// region before the first BEAM frame arrives.
@@ -199,11 +206,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			break
 		}
 		if chat, ok := m.agentChat(); ok {
-			if packet, handled := m.agent.handleKey(chat, msg); handled {
+			if packet, handled := m.agent.handleKey(chat, m.agentTranscriptMessages(chat), msg); handled {
 				m.send(packet)
 				break
 			}
 		}
+		// Local transcript scroll (#2654): when the agent chat owns the view and
+		// its composer is not capturing keys, a nav key adjusts the resident scroll
+		// offset and repaints same-frame. The key is still forwarded so the BEAM's
+		// authoritative scroll/pin state stays in sync (it just no longer gates the
+		// paint).
+		m.queueAgentTranscriptScroll(msg)
 		// Stamp the latency correlation sequence (ticket #2215) before
 		// encoding so the resulting frame's commit_frame resolves the sample.
 		seq := m.latency.Stamp()
@@ -223,6 +236,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m = updated
 		} else if isWheelButton(msg.Mouse().Button) {
 			delta := m.drainScrollDelta(msg)
+			m.queueAgentWheelScroll(msg, delta)
 			m = m.applyPresentationScrollDelta(msg, delta)
 			if !m.sendScrollBatchDelta(msg, delta) {
 				if packet, ok := m.mousePacket(msg); ok {
@@ -246,7 +260,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case agentAnimationTickMsg:
 		m.agent.tick()
-		if chat, ok := m.agentChat(); ok && m.agent.animating(chat) {
+		if chat, ok := m.agentChat(); ok && m.agent.animating(chat, m.agentTranscriptMessages(chat)) {
 			cmd = agentAnimationTick()
 		} else {
 			m.agent.animationRunning = false
@@ -275,7 +289,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.send(protocol.EncodeLogMessage(protocol.LogLevelErr, msg.Err.Error()))
 	}
 
-	if chat, ok := m.agentChat(); ok && m.agent.animating(chat) && !m.agent.animationRunning {
+	if chat, ok := m.agentChat(); ok && m.agent.animating(chat, m.agentTranscriptMessages(chat)) && !m.agent.animationRunning {
 		m.agent.animationRunning = true
 		cmd = tea.Batch(cmd, agentAnimationTick())
 	}
@@ -297,7 +311,107 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.viewport.SetWidth(max(m.width, 1))
 	m.viewport.SetHeight(m.layout.body.Height)
 	m.viewport.SetContent(m.composeBody())
+	// The transcript render resolves any queued local scroll and records a pin
+	// edge (#2654). Report it to the BEAM so its authoritative follow-bottom state
+	// tracks the frontend; rendering already happened without waiting for it.
+	m.reportTranscriptPinTransition()
 	return m, cmd
+}
+
+// reportTranscriptPinTransition sends the pin gui_action for a pin edge produced
+// by this frame's transcript render, if any (#2654). The frontend owns the local
+// scroll offset; this only keeps the BEAM's authoritative pin state in sync.
+func (m *Model) reportTranscriptPinTransition() {
+	if m.transcript == nil {
+		return
+	}
+	switch m.transcript.takePinTransition() {
+	case pinScrolledAway:
+		m.send(protocol.EncodeGUIChatScrolledAwayFromBottom())
+	case pinReturned:
+		m.send(protocol.EncodeGUIChatReturnedToBottom())
+	}
+}
+
+// agentTranscriptScrollTarget reports whether local transcript scroll should
+// intercept input this frame: the agent chat owns the view and its composer is
+// not capturing keys (so a nav key is a scroll, not composer cursor motion).
+func (m Model) agentTranscriptScrollTarget() bool {
+	if m.transcript == nil {
+		return false
+	}
+	chat, ok := m.agentChat()
+	return ok && chat.Visible && !chat.InputFocused
+}
+
+// queueAgentTranscriptScroll queues a local transcript scroll for a nav key when
+// the agent transcript is the scroll target (#2654). The key is still forwarded
+// to the BEAM by the caller.
+func (m *Model) queueAgentTranscriptScroll(msg tea.KeyPressMsg) {
+	if !m.agentTranscriptScrollTarget() {
+		return
+	}
+	if rows, ok := agentTranscriptScrollRows(msg, m.layout.body.Height); ok {
+		m.transcript.scrollBy(rows)
+	}
+}
+
+// queueAgentWheelScroll queues a local transcript scroll for a wheel event over
+// the agent chat body (#2654). Unlike keys this does not need the composer-focus
+// gate: a wheel over the transcript always scrolls it.
+func (m *Model) queueAgentWheelScroll(msg tea.MouseMsg, delta int) {
+	if m.transcript == nil || delta == 0 {
+		return
+	}
+	chat, ok := m.agentChat()
+	if !ok || !chat.Visible {
+		return
+	}
+	mouse := msg.Mouse()
+	if !m.layout.body.Contains(mouse.X, mouse.Y) {
+		return
+	}
+	// wheelDeltaSign: +down / -up, matching the resident store's row convention.
+	m.transcript.scrollBy(delta)
+}
+
+// agentTranscriptScrollRows maps a nav key to a signed scroll amount in rendered
+// lines (+down toward newest / -up toward oldest). page is the visible height,
+// used for half/full-page and jump-to-bottom keys.
+func agentTranscriptScrollRows(msg tea.KeyPressMsg, page int) (int, bool) {
+	page = max(page, 1)
+	half := max(page/2, 1)
+	key := msg.Key()
+	ctrl := key.Mod.Contains(tea.ModCtrl)
+	alt := key.Mod.Contains(tea.ModAlt)
+	switch key.Code {
+	case 'j':
+		if !ctrl && !alt {
+			return 1, true
+		}
+	case 'k':
+		if !ctrl && !alt {
+			return -1, true
+		}
+	case 'd':
+		if ctrl && !alt {
+			return half, true
+		}
+	case 'u':
+		if ctrl && !alt {
+			return -half, true
+		}
+	case 'G':
+		if !ctrl && !alt {
+			// Jump to bottom: a large downward amount the render clamps and re-pins.
+			return 1 << 20, true
+		}
+	case tea.KeyPgDown:
+		return page, true
+	case tea.KeyPgUp:
+		return -page, true
+	}
+	return 0, false
 }
 
 // composeBody renders the editor body (the expensive lipgloss path) and records
@@ -578,6 +692,13 @@ func (m *Model) applyMutation(command protocol.Command) {
 		}
 		m.chrome[command.Chrome.Opcode] = command.Chrome
 		switch command.Chrome.Opcode {
+		case generated.OPGuiAgentTranscript:
+			// Fold the resident transcript delta (#2654). The 0x86 stream, not the
+			// chrome snapshot, is the transcript source; the chrome entry is kept
+			// only so opcode bookkeeping stays uniform.
+			if m.transcript != nil {
+				m.transcript.apply(command.Chrome.AgentTranscript)
+			}
 		case generated.OPGuiTheme:
 			m.activePalette = paletteFromTheme(command.Chrome.Theme)
 			m.themeApplied = true

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1404,7 +1404,7 @@ func TestAgentAnimationCueChangesAcrossFrames(t *testing.T) {
 	}
 	chat := protocol.AgentChat{Visible: true, Status: 1}
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentChat: {AgentChat: chat}}
-	if !model.agent.animating(chat) {
+	if !model.agent.animating(chat, chat.Messages) {
 		t.Fatalf("visible thinking agent should animate")
 	}
 }

--- a/lib/minga/frontend/adapter/gui/agent_chat_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/agent_chat_encoder.ex
@@ -43,6 +43,11 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
   @section_chat_messages 0x06
   @section_chat_completion 0x07
   @section_chat_thinking 0x08
+  # input_focused: whether the composer captures keys. A frontend that owns the
+  # local transcript scroll (#2654) gates j/k on this so a scroll key is not
+  # mistaken for composer cursor motion. Unknown sections are skipped by every
+  # sectioned decoder, so this is backward/forward compatible.
+  @section_chat_input_focused 0x09
 
   @spec encode(AgentChat.t(), Caches.t()) :: {binary() | nil, Caches.t()}
   def encode(%AgentChat{} = model, %Caches{} = caches) do
@@ -105,6 +110,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
         @section_chat_thinking,
         <<byte_size(thinking_bytes)::16, thinking_bytes::binary>>
       ),
+      encode_section(@section_chat_input_focused, <<bool_byte(model.input_focused)::8>>),
       encode_section(@section_chat_messages, messages_payload)
     ]
 
@@ -273,6 +279,10 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
   defp encode_agent_chat_status(:tool_executing), do: 2
   defp encode_agent_chat_status(:error), do: 3
   defp encode_agent_chat_status(_), do: 0
+
+  @spec bool_byte(boolean() | nil) :: 0 | 1
+  defp bool_byte(true), do: 1
+  defp bool_byte(_), do: 0
 
   @spec encode_vim_mode(atom() | nil) :: non_neg_integer()
   defp encode_vim_mode(:normal), do: 0

--- a/lib/minga/render_model/ui/agent_chat.ex
+++ b/lib/minga/render_model/ui/agent_chat.ex
@@ -100,6 +100,7 @@ defmodule Minga.RenderModel.UI.AgentChat do
           prompt_completion: PromptCompletion.t() | nil,
           help_visible?: boolean(),
           help_groups: [{String.t(), [{String.t(), String.t()}]}],
+          input_focused: boolean(),
           messages: [message()],
           resident_messages: [message()],
           transcript_epoch: non_neg_integer()
@@ -118,6 +119,7 @@ defmodule Minga.RenderModel.UI.AgentChat do
             prompt_completion: nil,
             help_visible?: false,
             help_groups: [],
+            input_focused: false,
             messages: [],
             resident_messages: [],
             transcript_epoch: 0

--- a/lib/minga_editor/render_model/ui/agent_chat_builder.ex
+++ b/lib/minga_editor/render_model/ui/agent_chat_builder.ex
@@ -100,6 +100,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
       prompt_completion: build_prompt_completion(panel),
       help_visible?: help_visible,
       help_groups: help_groups,
+      input_focused: panel.input_focused,
       messages: gui_messages,
       resident_messages: resident_messages,
       transcript_epoch: transcript_epoch(session, panel)

--- a/test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs
@@ -80,7 +80,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
       {cmd, _caches} = AgentChatEncoder.encode(visible, caches)
 
       assert cmd != nil
-      assert <<@op_gui_agent_chat, 8::8, _::binary>> = cmd
+      assert <<@op_gui_agent_chat, 9::8, _::binary>> = cmd
     end
 
     test "transitions from visible back to hidden" do
@@ -96,8 +96,13 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
   end
 
   describe "header, model, prompt, thinking sections" do
-    test "visible chat always emits 8 sections" do
-      assert <<@op_gui_agent_chat, 8::8, _::binary>> = encode(%AgentChat{visible?: true})
+    test "visible chat always emits 9 sections" do
+      assert <<@op_gui_agent_chat, 9::8, _::binary>> = encode(%AgentChat{visible?: true})
+    end
+
+    test "input_focused section carries the composer focus flag (#2654)" do
+      assert <<1::8>> = section!(encode(%AgentChat{visible?: true, input_focused: true}), 0x09)
+      assert <<0::8>> = section!(encode(%AgentChat{visible?: true, input_focused: false}), 0x09)
     end
 
     test "header carries the status byte" do

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -1303,7 +1303,7 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
       encoded = encode_gui_agent_chat(data)
       # Sectioned: opcode + section_count + sections
-      assert <<0x78, 8, sections::binary>> = encoded
+      assert <<0x78, 9, sections::binary>> = encoded
       assert gui_agent_chat_section!(sections, 0x04) == <<0::8>>
       assert :binary.match(encoded, "shell") == :nomatch
       assert :binary.match(encoded, "ls -la") == :nomatch
@@ -1321,7 +1321,7 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
       encoded = encode_gui_agent_chat(data)
       # Sectioned: opcode + section_count + sections
-      assert <<0x78, 8, _sections::binary>> = encoded
+      assert <<0x78, 9, _sections::binary>> = encoded
       # Verify model is present
       assert :binary.match(encoded, "claude") != :nomatch
     end
@@ -1338,7 +1338,7 @@ defmodule MingaEditor.Frontend.ProtocolTest do
       }
 
       encoded = encode_gui_agent_chat(data)
-      assert <<0x78, 8, sections::binary>> = encoded
+      assert <<0x78, 9, sections::binary>> = encoded
       assert <<4::16, "high">> = gui_agent_chat_section!(sections, 0x08)
     end
 
@@ -1368,7 +1368,7 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
       encoded = encode_gui_agent_chat(data)
 
-      assert <<0x78, 8, sections::binary>> = encoded
+      assert <<0x78, 9, sections::binary>> = encoded
       messages_payload = gui_agent_chat_section!(sections, 0x06)
 
       assert <<1::16, 0::32, 0x09::8, 0::8, name_len::16, rest::binary>> = messages_payload
@@ -1404,7 +1404,7 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
       encoded = encode_gui_agent_chat(data)
       # Sectioned: opcode + section_count
-      assert <<0x78, 8, _sections::binary>> = encoded
+      assert <<0x78, 9, _sections::binary>> = encoded
 
       # Verify styled_assistant message type byte (0x07) appears in the binary
       assert :binary.match(encoded, <<0x07>>) != :nomatch

--- a/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
@@ -55,6 +55,17 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
     refute {:user, "hidden"} in Enum.map(summaries, fn {_id, type, text} -> {type, text} end)
   end
 
+  test "build/1 carries the composer input focus for transcript scroll gating (#2654)" do
+    session = fake_session_pid()
+    panel = synced_panel([{:assistant, "hi"}])
+
+    focused = context(session, %{panel | input_focused: true}) |> AgentChatBuilder.build()
+    unfocused = context(session, %{panel | input_focused: false}) |> AgentChatBuilder.build()
+
+    assert focused.input_focused
+    refute unfocused.input_focused
+  end
+
   test "build/1 emits semantic assistant markdown blocks when cache has them" do
     session = fake_session_pid()
 


### PR DESCRIPTION
Slice 3 of #2654, **top of the stack: #2704 → #2710 → this** (retarget as they merge). The largest slice: the Go TUI gains what SwiftUI had natively.

## Summary

- **0x86 resident store:** decode + apply per the normative contract (trim_front eviction → keep base_count prefix → id-keyed upsert; desync exactly at `resident < trim_front + base_count`) — review-verified byte-exact and semantics-identical to the macOS slice.
- **Local transcript scroll:** top-anchored offset + pinned flag; j/k/Ctrl-d/u/PgUp/PgDn/G and wheel render same-frame from the resident store; streaming appends never move a scrolled-up reading position (named test). Raw input still forwards — BEAM scroll state stays authoritative for restore.
- **Composer key gating:** new 0x78 `input_focused` section (0x09) so local scroll never steals cursor keys; skip-safe on all frontends (reviewer traced Swift's `default: break`); fail-safe direction: keys forward regardless.
- **Pin intents:** slice 2's gui_actions via generated constants, edge-triggered.
- **Bonus real-bug fix:** the Ctrl+Alt+X/Z toggles indexed the windowed 0x78 list while the BEAM updates the full session conversation — index drift beyond the window, now indexed against the resident store (mirrors the session list exactly), locked by test.

## Tests

Go 576 pass (decode incl. eviction/truncated/malformed; store desync boundaries; scroll clamp/pin edges/append-preserves-position; render-window integration; stale-0x78-override; toggle-index). BEAM full suite green except the known `session_manager_test.exs:315` flake (#2663 family, passes isolated, no `minga_agent` changes here). protocol.gen --check clean post-stack; lint clean. Review: PASS on both headline items.

## Follow-ups noted

Per-message line cache if long scrolled-up streaming sessions show latency; a "more above" affordance for the `truncated` flag; conformance transcripts (slice 5) close out #2654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1