### PR TITLE
test(lsp): de-flake sync_server crashed-client reap assertion

### DIFF
--- a/test/minga/lsp/sync_server_test.exs
+++ b/test/minga/lsp/sync_server_test.exs
@@ -156,9 +156,13 @@ defmodule Minga.LSP.SyncServerTest do
       ref = Process.monitor(doomed)
       Process.exit(doomed, :kill)
       assert_receive {:DOWN, ^ref, :process, ^doomed, :killed}
-      sync_server()
 
-      assert SyncServer.clients_for_buffer(buf) == [survivor]
+      # The SyncServer's own monitor :DOWN is delivered by the runtime on
+      # doomed's death, a different sender than this test process. FIFO-per-sender
+      # therefore does not order that :DOWN ahead of a :sys.get_state barrier we
+      # send, so the reap may not have run when we read. Poll the observable ETS
+      # state until the crashed client drops.
+      assert_clients_eventually(buf, [survivor])
     end
   end
 
@@ -217,6 +221,23 @@ defmodule Minga.LSP.SyncServerTest do
   defp sync_server do
     :sys.get_state(SyncServer)
     :ok
+  end
+
+  # Polls the direct-ETS registry read until it matches `expected`, then asserts.
+  # Used for reaps driven by runtime-delivered monitor :DOWN messages, whose
+  # arrival at the SyncServer cannot be ordered by a :sys.get_state barrier sent
+  # from the test process. On timeout the final assert raises a full diff.
+  defp assert_clients_eventually(buf, expected, attempts \\ 100, interval \\ 10) do
+    if SyncServer.clients_for_buffer(buf) == expected do
+      :ok
+    else
+      if attempts > 0 do
+        Process.sleep(interval)
+        assert_clients_eventually(buf, expected, attempts - 1, interval)
+      else
+        assert SyncServer.clients_for_buffer(buf) == expected
+      end
+    end
   end
 
   defp reset_sync_server do


### PR DESCRIPTION
Kills #2663's newest family member the day it was born (observed on #2708's CI — a zero-Elixir diff).

## The race

The SyncServer owns the monitor on the doomed client, so its `:DOWN` arrives from the **runtime**; the test's `:sys.get_state` barrier arrives from the **test process**. FIFO-per-sender guarantees no ordering between different senders, and `clients_for_buffer/1` is a direct ETS read — so the assert could observe the registry before `handle_client_down` processed.

## The fix

Test-owned `assert_receive {:DOWN,…}` stays as the client-is-dead barrier, then a bounded poll (100 × 10ms) on the observable ETS state until the crashed pid drops, falling through to the original assertion so real failures still produce a full diff. Nothing weakened; only synchronization added. Sibling LSP tests scanned and proven non-racy (`Registry.dispatch` callbacks run in the sending process — same-sender FIFO already orders them).

## Validation

20 consecutive file runs green; full suite 9,878 pass; lint/format clean. Sighting log updated on #2663.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBhRXLTesv7LbkjymwX2H1