### PR TITLE
fix(frontends): harden the resident transcript consumers per #2710 review

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -1208,7 +1208,7 @@ opcode(1) + action_type(1) + payload...
 | 0x59 | float_popup_dismiss | (empty) | Dismiss the active float popup |
 | 0x5A | system_will_unmount | path_len(2) + path | A volume is about to unmount; BEAM protects buffers under the mount path |
 | 0x5C | chat_scrolled_away_from_bottom | (empty) | Reader left the transcript bottom; pauses BEAM-side auto-follow (pin flag only, no offset move) |
-| 0x5D | chat_returned_to_bottom | (empty) | Reader returned to the transcript bottom; re-pins auto-follow |
+| 0x5D | chat_returned_to_bottom | (empty) | Reader returned to the transcript bottom; re-pins auto-follow (pin flag only, no offset move) |
 | 0x34 | system_will_sleep | (empty) | System is about to sleep |
 | 0x35 | system_did_wake | (empty) | System woke and BEAM should refresh external state |
 | 0x36 | cmd_copy | (empty) | Execute mode-aware copy from the macOS menu |

--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -604,20 +604,25 @@ value = 0x85
 direction = "beam_to_frontend"
 framing = "custom"
 
-# gui_agent_transcript (#2654 slice 1) carries the full, resident agent-chat
-# transcript decoupled from the small gui_agent_chat (0x78) chrome model, so the
-# transcript is no longer capped by the 0x78 u16 sectioned frame. len32 framing:
-# opcode(1) + payload_len(u32) + payload, sized generically by the generated
-# command_size on every frontend, so a frontend that does not yet consume the
-# opcode still skips it by the right length (the slice-1 cross-language safety
-# property). Payload is hand-decoded (like the other len32 opcodes) and reuses the
-# gui_agent_chat per-message body codec. Layout:
-#   version:u8=1, mode:u8 (0=full_replace,1=append), epoch:u32,
-#   base_count:u32 (append: resident count the suffix extends; full_replace: 0),
-#   count:u32, then count * [ id:u32, body_len:u32, body:bytes ].
-# full_replace on structural change (session switch, display_start_index change,
-# compaction/truncation); append (id-keyed upsert) for streaming/new messages
-# within an epoch. Frontends do not decode it until #2654 slices 2-3.
+# gui_agent_transcript (#2654) carries the resident agent-chat transcript (the
+# display-window-scoped conversation, byte-capped to a contiguous most-recent
+# suffix with a truncated flag) decoupled from the small gui_agent_chat (0x78)
+# chrome model, so the transcript is no longer capped by the 0x78 u16 sectioned
+# frame. len32 framing: opcode(1) + payload_len(u32) + payload, sized generically
+# by the generated command_size on every frontend, so a frontend that does not
+# consume the opcode still skips it by the right length. Payload is hand-decoded
+# (like the other len32 opcodes) and reuses the gui_agent_chat per-message body
+# codec. See GUI_PROTOCOL.md "0x86 — gui_agent_transcript" for the normative
+# contract; layout summary:
+#   version:u8=1, mode:u8 (0=full_replace,1=append), epoch:u32, truncated:u8,
+#   full_replace: count:u32
+#   append:       trim_front:u32 (front eviction), base_count:u32, count:u32
+#   both: count * [ id:u32, body_len:u32, body:bytes ].
+# base_count is the encoder's unchanged-leading (content-hash) prefix over the
+# post-trim remainder — NOT the client's resident count, and normally less than
+# it during streaming. Desync (drop the delta, await the next full_replace) is
+# resident < trim_front + base_count. Consumed by macOS (slice 2) and the Go TUI
+# (slice 3).
 [[opcodes]]
 category = "gui_semantic"
 name = "gui_agent_transcript"

--- a/go/tui/internal/protocol/chrome_transcript.go
+++ b/go/tui/internal/protocol/chrome_transcript.go
@@ -81,6 +81,14 @@ func decodeAgentTranscript(payload []byte) (AgentTranscript, string, int) {
 		Epoch:     u32(body, 2),
 		Truncated: body[6] != 0,
 	}
+	// Reject unknown versions and modes outright. Mode validation is load-bearing:
+	// the layout branch below is append-shaped (mode==1) while the store's apply
+	// branch is full_replace-shaped (mode==0), so an unknown mode passed through
+	// would be parsed with one layout and applied with the other (split-brain).
+	if transcript.Version != transcriptVersion ||
+		(transcript.Mode != transcriptModeReplace && transcript.Mode != transcriptModeAppend) {
+		return AgentTranscript{}, "", end
+	}
 	offset := transcriptHeaderLength
 
 	var count int
@@ -100,17 +108,31 @@ func decodeAgentTranscript(payload []byte) (AgentTranscript, string, int) {
 		offset += 4
 	}
 
+	// A corrupt count must fail cleanly, not request a giant allocation: each entry
+	// needs at least its 8-byte id+body_len header.
+	if count > (len(body)-offset)/8 {
+		return AgentTranscript{}, "", end
+	}
 	transcript.Messages = make([]AgentChatMessage, 0, count)
-	for i := 0; i < count && len(body) >= offset+8; i++ {
+	for i := 0; i < count; i++ {
+		// A truncated or undecodable entry poisons the whole frame: the Present
+		// contract above promises the store's prior state stays untouched, and
+		// folding a PARTIAL delta would silently corrupt the resident transcript,
+		// which is worse than skipping the frame.
+		if len(body) < offset+8 {
+			return AgentTranscript{}, "", end
+		}
 		id := u32(body, offset)
 		bodyLen := int(u32(body, offset+4))
 		offset += 8
 		if len(body) < offset+bodyLen {
-			break
+			return AgentTranscript{}, "", end
 		}
-		if msg, ok := decodeAgentMessageBody(id, body[offset:offset+bodyLen]); ok {
-			transcript.Messages = append(transcript.Messages, msg)
+		msg, ok := decodeAgentMessageBody(id, body[offset:offset+bodyLen])
+		if !ok {
+			return AgentTranscript{}, "", end
 		}
+		transcript.Messages = append(transcript.Messages, msg)
 		offset += bodyLen
 	}
 

--- a/go/tui/internal/protocol/chrome_transcript_test.go
+++ b/go/tui/internal/protocol/chrome_transcript_test.go
@@ -108,9 +108,11 @@ func TestDecodeAgentTranscriptAppend(t *testing.T) {
 	}
 }
 
-func TestDecodeAgentTranscriptTruncatedBodyStops(t *testing.T) {
-	// count claims 2 entries but only one full entry is present; decode keeps the
-	// decodable prefix and does not panic.
+func TestDecodeAgentTranscriptTruncatedBodyRejectsFrame(t *testing.T) {
+	// count claims 2 entries but only one full entry is present. The whole frame
+	// must be rejected (Present=false): folding a PARTIAL delta would silently
+	// corrupt the resident store, which is worse than skipping the frame and
+	// letting the next full_replace resync.
 	frame := replaceFrameBytes(1, false, []transcriptEntry{
 		{id: 1, body: userBody("only")},
 	})
@@ -119,8 +121,53 @@ func TestDecodeAgentTranscriptTruncatedBodyStops(t *testing.T) {
 	binary.BigEndian.PutUint32(frame[12:], 2)
 
 	got, _, _ := decodeAgentTranscript(frame)
-	if len(got.Messages) != 1 {
-		t.Fatalf("expected 1 decodable message, got %d", len(got.Messages))
+	if got.Present {
+		t.Fatalf("truncated frame should be rejected, got Present with %d messages", len(got.Messages))
+	}
+}
+
+func TestDecodeAgentTranscriptUnknownModeRejected(t *testing.T) {
+	// Only modes 0 (full_replace) and 1 (append) exist. An unknown mode must be
+	// rejected at decode: the decoder's layout branch is append-shaped (mode==1)
+	// while the store's apply branch is full_replace-shaped (mode==0), so a mode
+	// that passed through would be parsed with one layout and applied with the
+	// other (split-brain).
+	frame := replaceFrameBytes(1, false, []transcriptEntry{
+		{id: 1, body: userBody("hi")},
+	})
+	// mode byte offset: opcode(1)+len(4)+version(1) = 6.
+	frame[6] = 2
+
+	got, _, _ := decodeAgentTranscript(frame)
+	if got.Present {
+		t.Fatalf("unknown mode should be rejected, got Present")
+	}
+}
+
+func TestDecodeAgentTranscriptUnknownVersionRejected(t *testing.T) {
+	frame := replaceFrameBytes(1, false, []transcriptEntry{
+		{id: 1, body: userBody("hi")},
+	})
+	// version byte offset: opcode(1)+len(4) = 5.
+	frame[5] = 9
+
+	got, _, _ := decodeAgentTranscript(frame)
+	if got.Present {
+		t.Fatalf("unknown version should be rejected, got Present")
+	}
+}
+
+func TestDecodeAgentTranscriptHugeCountRejected(t *testing.T) {
+	// A corrupt count far beyond what the payload could hold must be rejected
+	// cleanly rather than sized into a giant allocation.
+	frame := replaceFrameBytes(1, false, []transcriptEntry{
+		{id: 1, body: userBody("only")},
+	})
+	binary.BigEndian.PutUint32(frame[12:], 0xFFFF_FFFF)
+
+	got, _, _ := decodeAgentTranscript(frame)
+	if got.Present {
+		t.Fatalf("huge count should be rejected, got Present")
 	}
 }
 

--- a/go/tui/internal/ui/agent_transcript.go
+++ b/go/tui/internal/ui/agent_transcript.go
@@ -48,15 +48,31 @@ func newResidentTranscript() *residentTranscript {
 	return &residentTranscript{pinned: true}
 }
 
+// transcriptDropReason names why a transcript frame was not folded into the
+// store; empty means it applied. The drop cases are defense-in-depth (a fresh
+// connection's encoder state makes every epoch's first frame a full_replace),
+// but if one ever fires the transcript is frozen until the next full_replace,
+// so the caller must surface it rather than let the freeze be invisible.
+type transcriptDropReason string
+
+const (
+	transcriptApplied            transcriptDropReason = ""
+	transcriptDroppedBeforeSeed  transcriptDropReason = "append before seed"
+	transcriptDroppedEpoch       transcriptDropReason = "epoch mismatch"
+	transcriptDroppedDesync      transcriptDropReason = "desynced (short store)"
+	transcriptDroppedUndecodable transcriptDropReason = "undecodable frame"
+)
+
 // apply folds one decoded gui_agent_transcript frame into the store, following
-// the docs/GUI_PROTOCOL.md 0x86 apply rules.
-func (t *residentTranscript) apply(frame protocol.AgentTranscript) {
+// the docs/GUI_PROTOCOL.md 0x86 apply rules. Returns transcriptApplied, or the
+// reason the frame was dropped so the caller can log it.
+func (t *residentTranscript) apply(frame protocol.AgentTranscript) transcriptDropReason {
 	if !frame.Present {
-		return
+		return transcriptDroppedUndecodable
 	}
-	t.truncated = frame.Truncated
 
 	if frame.FullReplace() {
+		t.truncated = frame.Truncated
 		epochChanged := !t.hasEpoch || frame.Epoch != t.epoch
 		next := make([]protocol.AgentChatMessage, len(frame.Messages))
 		copy(next, frame.Messages)
@@ -71,20 +87,26 @@ func (t *residentTranscript) apply(frame protocol.AgentTranscript) {
 			t.pinned = true
 			t.topOffset = 0
 		}
-		return
+		return transcriptApplied
 	}
 
-	// append: an epoch mismatch means we missed the epoch's full_replace; drop the
-	// delta and await the next full_replace.
-	if t.hasEpoch && frame.Epoch != t.epoch {
-		return
+	// append drop conditions per GUI_PROTOCOL.md 0x86 (await the next
+	// full_replace). An unseeded store drops appends too: every epoch's first
+	// frame is a full_replace, so an early append means a missed seed, and folding
+	// it against an empty store would fabricate a partial transcript. The Swift
+	// consumer drops this case as well; the two frontends must agree.
+	if !t.hasEpoch {
+		return transcriptDroppedBeforeSeed
+	}
+	if frame.Epoch != t.epoch {
+		return transcriptDroppedEpoch
 	}
 	trim := int(frame.TrimFront)
 	base := int(frame.BaseCount)
 	// Desync when the store cannot cover the delta's front assumptions: it holds
 	// fewer than trim_front + base_count messages. Drop and await full_replace.
 	if len(t.messages) < trim+base {
-		return
+		return transcriptDroppedDesync
 	}
 
 	// Apply order (GUI_PROTOCOL.md 0x86): drop trim_front from the front; keep the
@@ -101,10 +123,8 @@ func (t *residentTranscript) apply(frame protocol.AgentTranscript) {
 		}
 	}
 	t.messages = next
-	if frame.Epoch != 0 {
-		t.epoch = frame.Epoch
-		t.hasEpoch = true
-	}
+	t.truncated = frame.Truncated
+	return transcriptApplied
 }
 
 // indexByID returns the position of the message with id, or -1. A message id of 0

--- a/go/tui/internal/ui/agent_transcript_test.go
+++ b/go/tui/internal/ui/agent_transcript_test.go
@@ -139,7 +139,9 @@ func TestResidentTranscriptAppendDesyncDropped(t *testing.T) {
 	tr.apply(replaceFrame(1, msg(1, "a")))
 	// resident_count (1) < trim_front + base_count (1 + 1): the delta cannot apply
 	// against what the store holds, so drop it and await full_replace.
-	tr.apply(appendFrame(1, 1, 1, msg(6, "orphan")))
+	if reason := tr.apply(appendFrame(1, 1, 1, msg(6, "orphan"))); reason != transcriptDroppedDesync {
+		t.Fatalf("expected desync drop reason, got %q", reason)
+	}
 
 	if got, want := ids(tr.messages), []uint32{1}; fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("desync append should be dropped, got %v", got)
@@ -149,10 +151,30 @@ func TestResidentTranscriptAppendDesyncDropped(t *testing.T) {
 func TestResidentTranscriptAppendEpochMismatchDropped(t *testing.T) {
 	tr := newResidentTranscript()
 	tr.apply(replaceFrame(1, msg(1, "a")))
-	tr.apply(appendFrame(2, 0, 1, msg(2, "b")))
+	if reason := tr.apply(appendFrame(2, 0, 1, msg(2, "b"))); reason != transcriptDroppedEpoch {
+		t.Fatalf("expected epoch drop reason, got %q", reason)
+	}
 
 	if got, want := ids(tr.messages), []uint32{1}; fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("epoch-mismatch append should be dropped, got %v", got)
+	}
+}
+
+func TestResidentTranscriptAppendBeforeSeedDropped(t *testing.T) {
+	// An append arriving before any full_replace means the epoch's seed frame was
+	// missed. Folding it against the empty store (even with trim=base=0) would
+	// fabricate a partial transcript; the Swift consumer drops this case too, and
+	// the two frontends must agree.
+	tr := newResidentTranscript()
+	if reason := tr.apply(appendFrame(1, 0, 0, msg(1, "early"))); reason != transcriptDroppedBeforeSeed {
+		t.Fatalf("expected before-seed drop reason, got %q", reason)
+	}
+
+	if len(tr.messages) != 0 {
+		t.Fatalf("pre-seed append should not populate the store, got %d messages", len(tr.messages))
+	}
+	if tr.hasEpoch {
+		t.Fatalf("pre-seed append should not adopt an epoch")
 	}
 }
 

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -697,7 +697,14 @@ func (m *Model) applyMutation(command protocol.Command) {
 			// chrome snapshot, is the transcript source; the chrome entry is kept
 			// only so opcode bookkeeping stays uniform.
 			if m.transcript != nil {
-				m.transcript.apply(command.Chrome.AgentTranscript)
+				if reason := m.transcript.apply(command.Chrome.AgentTranscript); reason != transcriptApplied {
+					// A dropped delta freezes the transcript until the next
+					// full_replace; that must never be invisible.
+					frame := command.Chrome.AgentTranscript
+					m.send(protocol.EncodeLogMessage(protocol.LogLevelWarn,
+						fmt.Sprintf("transcript frame dropped: %s (epoch %d, trim %d, base %d, count %d)",
+							reason, frame.Epoch, frame.TrimFront, frame.BaseCount, len(frame.Messages))))
+				}
 			}
 		case generated.OPGuiTheme:
 			m.activePalette = paletteFromTheme(command.Chrome.Theme)

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1330,6 +1330,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let transcriptVersion = data[transcriptPayloadStart]
         guard transcriptVersion == 1 else { throw ProtocolDecodeError.malformed }
         let transcriptMode = data[transcriptPayloadStart + 1]
+        // Only full_replace (0) and append (1) exist. Rejecting anything else here is
+        // load-bearing: the layout branch below is mode==1-shaped while the consumer's
+        // apply branch is mode==0-shaped, so an unknown mode passed through would be
+        // parsed with one layout and applied with the other (split-brain).
+        guard transcriptMode <= 1 else { throw ProtocolDecodeError.malformed }
         let transcriptEpoch = readU32(data, transcriptPayloadStart + 2)
         let transcriptTruncated = data[transcriptPayloadStart + 6] != 0
 
@@ -1352,6 +1357,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             transcriptPos = transcriptPayloadStart + 11
         }
 
+        // A corrupt count must fail as .malformed, not as a giant allocation: each entry
+        // needs at least its 8-byte id+body_len header, so count is bounded by the payload.
+        guard transcriptCount <= (transcriptEnd - transcriptPos) / 8 else {
+            throw ProtocolDecodeError.malformed
+        }
         var transcriptMessages: [Wire.ChatMessage] = []
         transcriptMessages.reserveCapacity(transcriptCount)
         for _ in 0..<transcriptCount {

--- a/macos/Sources/Views/Agent/AgentChatState.swift
+++ b/macos/Sources/Views/Agent/AgentChatState.swift
@@ -70,7 +70,16 @@ public final class AgentChatState {
     public var model: String = ""
     public var thinkingLevel: String = "medium"
     public var prompt: String = ""
-    public var messages: [ChatMessageEntry] = []
+    // private(set): the resident array must only change together with its epoch
+    // bookkeeping (applyTranscript/update/hide/seed), never by direct assignment.
+    public private(set) var messages: [ChatMessageEntry] = []
+
+    /// Seeds the message list directly for previews and view tests. Production
+    /// mutation goes through `applyTranscript`; this bypasses the epoch
+    /// bookkeeping on purpose and must not be called on a live transcript.
+    public func seed(messages: [ChatMessageEntry]) {
+        self.messages = messages
+    }
 
     /// Transcript epoch of the resident stream currently held in `messages` (0x86).
     /// A `full_replace` carrying a new epoch swaps the array wholesale and adopts
@@ -192,7 +201,25 @@ public final class AgentChatState {
     /// (await the next full_replace) only when it cannot be applied safely: before
     /// any full_replace, an epoch mismatch, or the remainder being shorter than
     /// `baseCount` (a genuinely dropped frame).
-    public func applyTranscript(mode: UInt8, epoch: UInt32, truncated: Bool = false, trimFront: Int = 0, baseCount: Int, messages rawMessages: [Wire.ChatMessage]) {
+    /// Named outcome of one transcript frame, so drops are observable instead of a
+    /// silent void return. The dropped cases are defense-in-depth: they are unreachable
+    /// while the encoder's per-connection cache lifecycle holds (a fresh frontend
+    /// connection starts from an empty `AgentTranscriptSentState`, so every epoch's
+    /// first frame is a full_replace). If one ever fires, the transcript is frozen
+    /// until the next full_replace — which is exactly why it must be loud.
+    public enum TranscriptApplyOutcome: Equatable {
+        case appliedFullReplace
+        case appliedAppend
+        /// An append arrived before any full_replace seeded the store.
+        case droppedBeforeSeed
+        /// An append carried a different epoch than the store holds.
+        case droppedEpochMismatch
+        /// The store is shorter than `trim_front + base_count` (GUI_PROTOCOL.md 0x86).
+        case droppedDesynced
+    }
+
+    @discardableResult
+    public func applyTranscript(mode: UInt8, epoch: UInt32, truncated: Bool = false, trimFront: Int = 0, baseCount: Int, messages rawMessages: [Wire.ChatMessage]) -> TranscriptApplyOutcome {
         let mapped = rawMessages.map(Self.mapMessage)
 
         if mode == 0 {
@@ -201,19 +228,32 @@ public final class AgentChatState {
             self.hasTranscript = true
             self.transcriptTruncated = truncated
             self.promptVersion += 1
-            return
+            return .appliedFullReplace
         }
 
-        // Desync (drop the delta, await the next full_replace) exactly when the store
-        // is shorter than trim_front + base_count, per GUI_PROTOCOL.md 0x86.
-        guard hasTranscript, epoch == transcriptEpoch, trimFront >= 0, baseCount >= 0,
-              messages.count >= trimFront + baseCount else { return }
+        // Drop conditions (await the next full_replace), per GUI_PROTOCOL.md 0x86.
+        // Each is named and logged: a drop means the transcript stops updating until
+        // the next full_replace, and an invisible freeze is the worst failure mode
+        // this stream can have.
+        guard hasTranscript else {
+            PortLogger.warn("transcript append before seed dropped (epoch \(epoch))")
+            return .droppedBeforeSeed
+        }
+        guard epoch == transcriptEpoch else {
+            PortLogger.warn("transcript append epoch mismatch dropped (frame \(epoch), store \(transcriptEpoch))")
+            return .droppedEpochMismatch
+        }
+        guard trimFront >= 0, baseCount >= 0, messages.count >= trimFront + baseCount else {
+            PortLogger.warn("transcript append desynced dropped (resident \(messages.count), trimFront \(trimFront), baseCount \(baseCount), epoch \(epoch))")
+            return .droppedDesynced
+        }
 
         // Evict trim_front from the front, keep [0, base_count) of the remainder, upsert.
         let kept = messages[trimFront ..< (trimFront + baseCount)]
         self.messages = Array(kept) + mapped
         self.transcriptTruncated = truncated
         self.promptVersion += 1
+        return .appliedAppend
     }
 
     /// Maps a decoded wire message onto its displayable `ChatMessageEntry`.

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -2117,6 +2117,63 @@ struct GUIAgentChatDecoderTests {
         #expect(collapsed == true)
     }
 
+    @Test("0x78 and 0x86 decode the same message body identically")
+    func bodyByteIdentityAcrossOpcodes() throws {
+        // The shared body codec is a structural guarantee; this pins it from the
+        // decode side so a fork of decodeChatMessageBodyCandidates cannot drift
+        // the two transports apart silently. (The BEAM has the encoder-side pin.)
+        // tool_call is the body kind with the most fields and an optional preview,
+        // so it is the strongest identity probe.
+        var body = Data()
+        body.append(0x04) // tool_call
+        body.append(1); body.append(0); body.append(1) // status, isError, collapsed
+        appendU32(&body, 1234) // durationMs
+        appendString16(&body, "read_file")
+        appendString16(&body, "lib/minga.ex")
+        let result = "file contents here"
+        appendU32(&body, UInt32(result.utf8.count))
+        body.append(contentsOf: result.utf8)
+        body.append(2) // autoApprovedScope
+        body.append(1) // previewKind diff
+        appendU16(&body, 2)
+        appendString16(&body, "-old")
+        appendString16(&body, "+new")
+
+        var chatMsgs = Data()
+        appendU32(&chatMsgs, 5) // beam_id
+        chatMsgs.append(body)
+        let chatData = buildChatData(status: 1, model: "m", messages: buildMessagesPayload(count: 1, chatMsgs))
+        let (chatCmd, _) = try decodeCommand(data: chatData, offset: 0)
+        guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, let chatMessages) = chatCmd else {
+            Issue.record("Expected .guiAgentChat"); return
+        }
+
+        // Inline 0x86 full_replace frame: header + count(4) + one entry.
+        var trPayload = Data()
+        trPayload.append(1) // version
+        trPayload.append(0) // mode full_replace
+        appendU32(&trPayload, 1) // epoch
+        trPayload.append(0) // truncated
+        appendU32(&trPayload, 1) // count
+        appendU32(&trPayload, 5) // id
+        appendU32(&trPayload, UInt32(body.count))
+        trPayload.append(body)
+        var trData = Data()
+        trData.append(OP_GUI_AGENT_TRANSCRIPT)
+        appendU32(&trData, UInt32(trPayload.count))
+        trData.append(trPayload)
+
+        let (trCmd, _) = try decodeCommand(data: trData, offset: 0)
+        guard case .guiAgentTranscript(_, _, _, _, _, let trMessages) = trCmd else {
+            Issue.record("Expected .guiAgentTranscript"); return
+        }
+
+        guard chatMessages.count == 1, trMessages.count == 1 else {
+            Issue.record("Expected one message on each path"); return
+        }
+        #expect(String(describing: chatMessages[0]) == String(describing: trMessages[0]))
+    }
+
     @Test("Decode gui_agent_chat with tool_call message (sectioned)")
     func decodeToolCall() throws {
         var msgs = Data()
@@ -3277,4 +3334,81 @@ struct AgentTranscriptDecoderTests {
             try decodeCommand(data: frame(payload), offset: 0)
         }
     }
+
+    @Test("unknown mode throws malformed instead of a split-brain parse")
+    func unknownModeThrows() {
+        // Only modes 0/1 exist. An unknown mode must be rejected at decode: the
+        // decoder's layout branch is append-shaped (mode == 1) while the consumer's
+        // apply branch is full_replace-shaped (mode == 0), so a mode that passed
+        // through would be parsed with one layout and applied with the other.
+        var payload = Data()
+        payload.append(1) // version
+        payload.append(2) // mode = unknown
+        appendU32(&payload, 1) // epoch
+        payload.append(0) // truncated
+        appendU32(&payload, 0) // count
+
+        #expect(throws: ProtocolDecodeError.self) {
+            try decodeCommand(data: frame(payload), offset: 0)
+        }
+    }
+
+    @Test("a corrupt huge count throws malformed instead of a giant allocation")
+    func hugeCountThrows() {
+        var payload = Data()
+        payload.append(1) // version
+        payload.append(0) // mode full_replace
+        appendU32(&payload, 1) // epoch
+        payload.append(0) // truncated
+        appendU32(&payload, 0xFFFF_FFFF) // count far beyond the payload
+
+        #expect(throws: ProtocolDecodeError.self) {
+            try decodeCommand(data: frame(payload), offset: 0)
+        }
+    }
+
+    /// tool_call message body (sub-opcode 0x04) with an optional preview section.
+    /// This is the one body kind that yields MULTIPLE decode candidates (with and
+    /// without the preview), so it is what actually exercises the 0x86 path's
+    /// exact-consumption disambiguation.
+    private func toolCallBody(withPreview: Bool) -> Data {
+        var d = Data()
+        d.append(0x04) // tool_call
+        d.append(1) // status
+        d.append(0) // isError
+        d.append(1) // collapsed
+        appendU32(&d, 1234) // durationMs
+        appendString16(&d, "read_file")
+        appendString16(&d, "lib/minga.ex")
+        let result = "file contents here"
+        appendU32(&d, UInt32(result.utf8.count))
+        d.append(contentsOf: result.utf8)
+        d.append(2) // autoApprovedScope
+        if withPreview {
+            d.append(1) // previewKind diff
+            appendU16(&d, 2)
+            appendString16(&d, "-old")
+            appendString16(&d, "+new")
+        }
+        return d
+    }
+
+    @Test("tool_call bodies disambiguate via exact consumption", arguments: [true, false])
+    func toolCallExactConsumption(withPreview: Bool) throws {
+        let data = buildFullReplace(epoch: 3, entries: [
+            (id: 5, body: toolCallBody(withPreview: withPreview))
+        ])
+
+        let (cmd, _) = try decodeCommand(data: data, offset: 0)
+        guard case .guiAgentTranscript(_, _, _, _, _, let messages) = cmd else {
+            Issue.record("Expected .guiAgentTranscript"); return
+        }
+        guard messages.count == 1,
+              case .toolCall(let name, _, _, _, _, _, _, _, _, let previewLines) = messages[0].content else {
+            Issue.record("Expected one toolCall message"); return
+        }
+        #expect(name == "read_file")
+        #expect(previewLines.isEmpty == !withPreview)
+    }
+
 }

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -489,9 +489,10 @@ struct AgentChatTranscriptTests {
     @MainActor func appendEpochMismatchDropped() {
         let state = AgentChatState()
         state.applyTranscript(mode: 0, epoch: 1, baseCount: 0, messages: [user(1, "a"), assistant(2, "b")])
-        state.applyTranscript(mode: 1, epoch: 2, baseCount: 2, messages: [assistant(3, "c")])
+        let outcome = state.applyTranscript(mode: 1, epoch: 2, baseCount: 2, messages: [assistant(3, "c")])
 
         // Stale-epoch append ignored; the resident transcript is untouched.
+        #expect(outcome == .droppedEpochMismatch)
         #expect(state.messages.map(\.id) == [1, 2])
         #expect(state.transcriptEpoch == 1)
     }
@@ -500,16 +501,18 @@ struct AgentChatTranscriptTests {
     @MainActor func appendBaseOverrunDropped() {
         let state = AgentChatState()
         state.applyTranscript(mode: 0, epoch: 1, baseCount: 0, messages: [user(1, "a")])
-        state.applyTranscript(mode: 1, epoch: 1, baseCount: 5, messages: [assistant(2, "c")])
+        let outcome = state.applyTranscript(mode: 1, epoch: 1, baseCount: 5, messages: [assistant(2, "c")])
 
+        #expect(outcome == .droppedDesynced)
         #expect(state.messages.map(\.id) == [1])
     }
 
     @Test("append before any full_replace is dropped")
     @MainActor func appendBeforeSeedDropped() {
         let state = AgentChatState()
-        state.applyTranscript(mode: 1, epoch: 1, baseCount: 0, messages: [user(1, "a")])
+        let outcome = state.applyTranscript(mode: 1, epoch: 1, baseCount: 0, messages: [user(1, "a")])
 
+        #expect(outcome == .droppedBeforeSeed)
         #expect(state.messages.isEmpty)
     }
 

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -1038,7 +1038,7 @@ struct AgentChatViewTests {
         state.visible = true
         state.model = "claude-sonnet-4"
         state.status = 0
-        state.messages = messages
+        state.seed(messages: messages)
         return state
     }
 
@@ -1216,7 +1216,7 @@ struct AgentChatViewTests {
         let state = AgentChatState()
         state.visible = true
         state.model = "test-model"
-        state.messages = [.user(id: 0, text: "Hello world")]
+        state.seed(messages: [.user(id: 0, text: "Hello world")])
 
         let sut = AgentChatView(state: state, isInsertMode: false, encoder: nil)
             .environment(\.themeColors, ThemeColors())
@@ -1232,7 +1232,7 @@ struct AgentChatViewTests {
         let state = AgentChatState()
         state.visible = true
         state.model = "test-model"
-        state.messages = [.system(id: 0, text: "Session started", isError: false)]
+        state.seed(messages: [.system(id: 0, text: "Session started", isError: false)])
 
         let sut = AgentChatView(state: state, isInsertMode: false, encoder: nil)
             .environment(\.themeColors, ThemeColors())


### PR DESCRIPTION
# TL;DR
Review-response hardening for the merged #2654 slices 2-3: both 0x86 consumers (Swift + Go TUI) close the same mode split-brain at decode, make every dropped delta observable instead of a silent freeze, and align on append-before-seed semantics; the schema TOML stops teaching the slice-1 freeze-bug contract.

Part of #2654 follow-up (five-agent review of #2710, extended to the slice-3 Go consumer which shipped the same patterns).

## Context
The #2710 review found no criticals in the merged contract (independently re-decoded end to end), but four Important gaps — and since slice 3 landed a second consumer built the same way, each fix applies to both frontends so they cannot drift.

## Changes
- **Mode split-brain closed at decode (both consumers).** Decoders branched their *layout* on `mode == 1` while stores branch their *apply* on `mode == 0`; an unknown mode would parse with one layout and apply with the other. Unknown modes (and unknown versions in Go, previously unvalidated) now reject as malformed, with negative tests.
- **Dropped frames are loud.** `applyTranscript` returns a named `TranscriptApplyOutcome` and warn-logs each drop; the Go store returns a `transcriptDropReason` the model warn-logs to the BEAM. A dropped delta freezes the transcript until the next full_replace; the per-connection cache-lifecycle assumption that makes drops unreachable is now documented at both stores.
- **Append-before-seed alignment.** Go folded a `trim=0/base=0` append into an empty store and adopted epochs from appends; it now drops the frame like Swift.
- **Go decode honors its own `Present` contract.** Truncated/undecodable entries used to yield a *partial* transcript that was then applied; the whole frame is now rejected.
- **Corrupt counts fail as malformed** on both sides instead of sizing a multi-GB allocation.
- **`AgentChatState.messages` is `private(set)`** with an explicit `seed()` door for previews/tests.
- **Docs:** the schema TOML 0x86 block now carries `trim_front`/`truncated`, the content-hash meaning of `base_count`, and the desync rule (it previously restated the fixed slice-1 freeze framing); `GUI_PROTOCOL.md`'s 0x5D row gains the no-offset-move note.

## Verification
1. Swift: full MingaTests bundle 1018/1018 (13 new: unknown mode/version, huge count, tool_call — the only multi-candidate body kind — through 0x86 exact-consumption ± preview, a 0x78/0x86 decoder byte-identity pin, outcome assertions on every drop path).
2. Go: 600 tests across 8 packages (5 new/updated incl. before-seed alignment and whole-frame rejection); `gofmt` clean.
3. `mix swift.build` green; protocol schema test green (TOML parses); `make lint` all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)