### PR TITLE
feat(macos): scroll past end of file (VSCode-style)

### DIFF
--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -140,6 +140,7 @@ defmodule MingaEditor.Mouse do
         total_lines = Buffer.line_count(buf)
         cursor_pos = Buffer.cursor(buf)
 
+        window = sync_viewport_to_rendered_top(window)
         scrolled = Window.scroll_viewport(window, delta_lines, total_lines)
 
         updated =
@@ -153,6 +154,19 @@ defmodule MingaEditor.Mouse do
         state
     end
   end
+
+  # Cursor-movement commands (j, k, G, Ctrl-D, etc.) move the buffer cursor but
+  # do not update Window.viewport. Under async rendering the render pipeline
+  # adjusts the viewport in a snapshot that is never written back. The live
+  # viewport can therefore be stale by many screens. Sync it from the last
+  # rendered position so mouse/trackpad scroll starts where the user actually sees
+  # the content.
+  defp sync_viewport_to_rendered_top(%Window{render_cache: %{scroll_seq_last_top: top}} = window)
+       when is_integer(top) do
+    %{window | viewport: Viewport.put_top(window.viewport, top)}
+  end
+
+  defp sync_viewport_to_rendered_top(window), do: window
 
   @spec native_gui?(state()) :: boolean()
   defp native_gui?(%{capabilities: %Capabilities{frontend_type: :native_gui}}), do: true

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -203,7 +203,12 @@ defmodule MingaEditor.Window do
 
   def scroll_viewport(%__MODULE__{viewport: vp} = window, delta, total_lines) do
     visible = Viewport.content_rows(vp)
-    max_top = max(total_lines - visible, 0)
+
+    max_top =
+      if resident?(window),
+        do: max(total_lines - 1, 0),
+        else: max(total_lines - visible, 0)
+
     new_top = (vp.top + delta) |> max(0) |> min(max_top)
     pinned = delta > 0 and new_top >= max_top
 

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -722,6 +722,7 @@ final class CommandDispatcher {
             frameState.windowGutters[data.windowId] = data
             currentFrameWindowIds.insert(data.windowId)
             if data.isActive {
+                frameState.activeWindowId = data.windowId
                 frameState.gutterCol = UInt16(data.lineNumberWidth) + UInt16(data.signColWidth)
                 // Derive viewport top from the first gutter entry's buffer line.
                 if let firstEntry = data.entries.first {

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -1223,9 +1223,8 @@ final class CoreTextMetalRenderer {
             // Compute thumb size and position.
             let proportion = Float(visibleRows) / Float(totalLines)
             let thumbHeight = max(proportion * trackHeight, 20.0 * scale)
-            let maxTop: Float = scrollIndicatorResident
-                ? Float(max(Int64(totalLines) - 1, 1))
-                : Float(max(Int64(totalLines) - Int64(visibleRows), 1))
+            let maxTop = Float(EditorScrollTrack.maxScrollableTop(
+                totalLines: totalLines, visibleRows: visibleRows, resident: scrollIndicatorResident))
             let thumbY = (Float(viewportTop) / maxTop) * (trackHeight - thumbHeight)
 
             let thumbX = Float(viewportSize.width) - indicatorWidth - indicatorMargin

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -1206,9 +1206,12 @@ final class CoreTextMetalRenderer {
         let viewportTop = frameState.viewportTopLine
 
         let scrollIndicatorResident: Bool = {
-            guard let wid = frameState.windowGutters.values.first(where: \.isActive)?.windowId,
-                  let sp = windowContents[wid]?.scrollPresentation else { return false }
-            return sp.overscanStartLine == 0 && sp.overscanEndLine >= totalLines
+            guard let wid = frameState.windowGutters.values.filter(\.isActive)
+                      .sorted(by: { $0.windowId < $1.windowId }).first?.windowId,
+                  let content = windowContents[wid],
+                  let sp = content.scrollPresentation else { return false }
+            let perWindowTotal = content.paneGeometry?.viewport.totalLines ?? totalLines
+            return perWindowTotal > 0 && sp.overscanStartLine == 0 && sp.overscanEndLine >= perWindowTotal
         }()
 
         if totalLines > visibleRows && viewportTop != 0xFFFF_FFFF && scrollIndicatorAlpha > 0 {

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -1206,8 +1206,7 @@ final class CoreTextMetalRenderer {
         let viewportTop = frameState.viewportTopLine
 
         let scrollIndicatorResident: Bool = {
-            guard let wid = frameState.windowGutters.values.filter(\.isActive)
-                      .sorted(by: { $0.windowId < $1.windowId }).first?.windowId,
+            guard let wid = frameState.activeWindowId,
                   let content = windowContents[wid],
                   let sp = content.scrollPresentation else { return false }
             let perWindowTotal = content.paneGeometry?.viewport.totalLines ?? totalLines

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -1205,6 +1205,12 @@ final class CoreTextMetalRenderer {
         let visibleRows = UInt32(frameState.rows)
         let viewportTop = frameState.viewportTopLine
 
+        let scrollIndicatorResident: Bool = {
+            guard let wid = frameState.windowGutters.values.first(where: \.isActive)?.windowId,
+                  let sp = windowContents[wid]?.scrollPresentation else { return false }
+            return sp.overscanStartLine == 0 && sp.overscanEndLine >= totalLines
+        }()
+
         if totalLines > visibleRows && viewportTop != 0xFFFF_FFFF && scrollIndicatorAlpha > 0 {
             let viewportH = Float(viewportSize.height)
             let indicatorWidth: Float = 6.0 * scale
@@ -1214,7 +1220,9 @@ final class CoreTextMetalRenderer {
             // Compute thumb size and position.
             let proportion = Float(visibleRows) / Float(totalLines)
             let thumbHeight = max(proportion * trackHeight, 20.0 * scale)
-            let maxTop = Float(max(Int64(totalLines) - Int64(visibleRows), 1))
+            let maxTop: Float = scrollIndicatorResident
+                ? Float(max(Int64(totalLines) - 1, 1))
+                : Float(max(Int64(totalLines) - Int64(visibleRows), 1))
             let thumbY = (Float(viewportTop) / maxTop) * (trackHeight - thumbHeight)
 
             let thumbX = Float(viewportSize.width) - indicatorWidth - indicatorMargin

--- a/macos/Sources/Renderer/FrameState.swift
+++ b/macos/Sources/Renderer/FrameState.swift
@@ -57,6 +57,7 @@ struct FrameState {
     // NOT cleared between frames: stale data serves as fallback to
     // prevent blank-gutter flash if the gutter command hasn't arrived yet.
     var windowGutters: [UInt16: Wire.WindowGutter] = [:]
+    var activeWindowId: UInt16?
 
     // Split separator data from gui_split_separators (0x84).
     var splitBorderColor: UInt32 = 0

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -1938,11 +1938,7 @@ final class EditorNSView: MTKView {
         }
         let targetWindowContent = scrollTargetWindowId.flatMap { guiState?.windowContents[$0] }
         let targetScrollPresentation = targetWindowContent?.scrollPresentation
-        let payloadOverscan = Self.presentationScrollPayloadOverscanBounds(
-            for: targetWindowContent,
-            scrollPresentation: targetScrollPresentation
-        )
-        let boundaryAvailability = Self.presentationScrollBoundaryAvailability(
+        let scrollBounds = Self.presentationScrollBounds(
             for: targetWindowContent,
             scrollPresentation: targetScrollPresentation
         )
@@ -1956,10 +1952,10 @@ final class EditorNSView: MTKView {
             scrollPresentation: targetScrollPresentation,
             scrollOffsetY: compensatedOffsetY,
             scrollDeltaY: lockedDeltaY,
-            payloadOverscanBefore: payloadOverscan.before,
-            payloadOverscanAfter: payloadOverscan.after,
-            boundaryBefore: boundaryAvailability.before,
-            boundaryAfter: boundaryAvailability.after
+            payloadOverscanBefore: scrollBounds.payloadBefore,
+            payloadOverscanAfter: scrollBounds.payloadAfter,
+            boundaryBefore: scrollBounds.boundaryBefore,
+            boundaryAfter: scrollBounds.boundaryAfter
         )
         let suppressLocalOffset = scrollTargetWindowId == nil || isSelectionDragActive
         let offsetX = suppressLocalOffset ? 0 : scrollAccumulator.pixelOffsetX
@@ -2315,11 +2311,17 @@ final class EditorNSView: MTKView {
 
     /// Result of classifying a vertical scroll delta against the pane's content and boundaries.
     enum ScrollTranslation: Equatable {
-        /// Scrolling within real content: present the given fractional offset, no rubber band.
         case content(offsetY: CGFloat)
-        /// Overscrolling past a document edge: the caller accumulates `pullDelta` (px) into the
-        /// rubber-band curve. The presented content offset is pinned to the boundary (0).
         case elastic(pullDelta: CGFloat)
+    }
+
+    struct PresentationScrollBounds: Equatable {
+        let payloadBefore: Int
+        let payloadAfter: Int
+        let boundaryBefore: Int
+        let boundaryAfter: Int
+
+        static let zero = PresentationScrollBounds(payloadBefore: 0, payloadAfter: 0, boundaryBefore: 0, boundaryAfter: 0)
     }
 
     /// Classifies a vertical scroll delta as in-content or overscroll (rubber band).
@@ -2369,49 +2371,74 @@ final class EditorNSView: MTKView {
         return next
     }
 
+    nonisolated static func presentationScrollBounds(
+        for windowContent: GUIWindowContent?,
+        scrollPresentation: GUIScrollPresentation?
+    ) -> PresentationScrollBounds {
+        guard let scrollPresentation else { return .zero }
+
+        let before = windowContent.map {
+            CoreTextMetalRenderer.presentationPayloadOverscanBeforeRows(rows: $0.rows, scrollPresentation: scrollPresentation)
+        } ?? CoreTextMetalRenderer.scrollOverscanBefore(scrollPresentation)
+
+        let totalLines = windowContent?.paneGeometry?.viewport.totalLines
+        let isResident = totalLines.map {
+            $0 > 0 && Self.thumbDragCanPresentLocally(scrollPresentation: scrollPresentation, totalLines: $0)
+        } ?? false
+
+        let payloadAfter: Int
+        if let windowContent {
+            let visibleRows = presentationPayloadVisibleRows(for: windowContent)
+            if visibleRows > 0 {
+                let rawAfter = max(windowContent.rows.count - visibleRows - before, 0)
+                if rawAfter > 0 {
+                    payloadAfter = rawAfter
+                } else if isResident {
+                    payloadAfter = max(Int(totalLines!) - 1 - Int(scrollPresentation.anchorTop), 0)
+                } else {
+                    payloadAfter = 0
+                }
+            } else {
+                payloadAfter = max(0, Int(scrollPresentation.overscanEndLine) - Int(scrollPresentation.visibleEndLine))
+            }
+        } else {
+            payloadAfter = max(0, Int(scrollPresentation.overscanEndLine) - Int(scrollPresentation.visibleEndLine))
+        }
+
+        let hasContentBefore = scrollPresentation.anchorTop > 0 || scrollPresentation.anchorVisualRowOffset > 0 || before > 0
+        let hasContentAfter: Bool
+        if let totalLines, totalLines > 0 {
+            if isResident {
+                hasContentAfter = scrollPresentation.anchorTop < totalLines - 1 || payloadAfter > 0
+            } else {
+                hasContentAfter = scrollPresentation.visibleEndLine < totalLines || payloadAfter > 0
+            }
+        } else {
+            hasContentAfter = payloadAfter > 0
+        }
+
+        return PresentationScrollBounds(
+            payloadBefore: before,
+            payloadAfter: payloadAfter,
+            boundaryBefore: hasContentBefore ? 1 : 0,
+            boundaryAfter: hasContentAfter ? 1 : 0
+        )
+    }
+
     nonisolated static func presentationScrollBoundaryAvailability(
         for windowContent: GUIWindowContent?,
         scrollPresentation: GUIScrollPresentation?
     ) -> (before: Int, after: Int) {
-        guard let scrollPresentation else { return (0, 0) }
-
-        let payload = presentationScrollPayloadOverscanBounds(for: windowContent, scrollPresentation: scrollPresentation)
-        let hasContentBefore = scrollPresentation.anchorTop > 0 || scrollPresentation.anchorVisualRowOffset > 0 || payload.before > 0
-        let hasContentAfter: Bool
-        if let totalLines = windowContent?.paneGeometry?.viewport.totalLines, totalLines > 0 {
-            if Self.thumbDragCanPresentLocally(scrollPresentation: scrollPresentation, totalLines: totalLines) {
-                hasContentAfter = scrollPresentation.anchorTop < totalLines - 1 || payload.after > 0
-            } else {
-                hasContentAfter = scrollPresentation.visibleEndLine < totalLines || payload.after > 0
-            }
-        } else {
-            hasContentAfter = payload.after > 0
-        }
-
-        return (hasContentBefore ? 1 : 0, hasContentAfter ? 1 : 0)
+        let bounds = presentationScrollBounds(for: windowContent, scrollPresentation: scrollPresentation)
+        return (bounds.boundaryBefore, bounds.boundaryAfter)
     }
 
     nonisolated static func presentationScrollPayloadOverscanBounds(
         for windowContent: GUIWindowContent?,
         scrollPresentation: GUIScrollPresentation?
     ) -> (before: Int, after: Int) {
-        guard let scrollPresentation else { return (0, 0) }
-        let before = windowContent.map { CoreTextMetalRenderer.presentationPayloadOverscanBeforeRows(rows: $0.rows, scrollPresentation: scrollPresentation) } ?? CoreTextMetalRenderer.scrollOverscanBefore(scrollPresentation)
-        if let windowContent {
-            let visibleRows = presentationPayloadVisibleRows(for: windowContent)
-            if visibleRows > 0 {
-                let payloadAfter = max(windowContent.rows.count - visibleRows - before, 0)
-                if payloadAfter > 0 { return (before, payloadAfter) }
-                if let totalLines = windowContent.paneGeometry?.viewport.totalLines, totalLines > 0,
-                   Self.thumbDragCanPresentLocally(scrollPresentation: scrollPresentation, totalLines: totalLines) {
-                    let scrollAfter = max(Int(totalLines) - 1 - Int(scrollPresentation.anchorTop), 0)
-                    return (before, scrollAfter)
-                }
-                return (before, 0)
-            }
-        }
-        let after = max(0, Int(scrollPresentation.overscanEndLine) - Int(scrollPresentation.visibleEndLine))
-        return (before, after)
+        let bounds = presentationScrollBounds(for: windowContent, scrollPresentation: scrollPresentation)
+        return (bounds.payloadBefore, bounds.payloadAfter)
     }
 
     nonisolated static func presentationPayloadVisibleRows(for windowContent: GUIWindowContent) -> Int {

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -981,7 +981,8 @@ final class EditorNSView: MTKView {
             viewHeight: bounds.height,
             totalLines: fs.totalLineCount,
             visibleRows: UInt32(fs.rows),
-            viewportTopLine: fs.viewportTopLine
+            viewportTopLine: fs.viewportTopLine,
+            resident: activeWindowIsResident
         ) else { return nil }
         return EditorScrollTrack.dragOffset(forY: y, thumb: thumb)
     }
@@ -990,6 +991,7 @@ final class EditorNSView: MTKView {
     private func scrollTrackYToLine(_ y: CGFloat) -> UInt32 {
         let fs = dispatcher.frameState
         let visibleRows = UInt32(fs.rows)
+        let resident = activeWindowIsResident
 
         if let scrollIndicatorDragOffset {
             return EditorScrollTrack.line(
@@ -997,7 +999,8 @@ final class EditorNSView: MTKView {
                 dragOffset: scrollIndicatorDragOffset,
                 viewHeight: bounds.height,
                 totalLines: fs.totalLineCount,
-                visibleRows: visibleRows
+                visibleRows: visibleRows,
+                resident: resident
             )
         }
 
@@ -1005,7 +1008,8 @@ final class EditorNSView: MTKView {
             forY: y,
             viewHeight: bounds.height,
             totalLines: fs.totalLineCount,
-            visibleRows: visibleRows
+            visibleRows: visibleRows,
+            resident: resident
         )
     }
 
@@ -1020,6 +1024,15 @@ final class EditorNSView: MTKView {
             .sorted { $0.windowId < $1.windowId }
             .first?
             .windowId
+    }
+
+    private var activeWindowIsResident: Bool {
+        guard let windowId = activeWindowId,
+              let content = guiState?.windowContents[windowId] else { return false }
+        return Self.thumbDragCanPresentLocally(
+            scrollPresentation: content.scrollPresentation,
+            totalLines: content.paneGeometry?.viewport.totalLines ?? dispatcher.frameState.totalLineCount
+        )
     }
 
     /// Establishes resident local presentation for a thumb drag if the active pane is resident,
@@ -2366,7 +2379,12 @@ final class EditorNSView: MTKView {
         let hasContentBefore = scrollPresentation.anchorTop > 0 || scrollPresentation.anchorVisualRowOffset > 0 || payload.before > 0
         let hasContentAfter: Bool
         if let totalLines = windowContent?.paneGeometry?.viewport.totalLines, totalLines > 0 {
-            hasContentAfter = scrollPresentation.visibleEndLine < totalLines || payload.after > 0
+            let isResident = scrollPresentation.overscanStartLine == 0 && scrollPresentation.overscanEndLine >= totalLines
+            if isResident {
+                hasContentAfter = scrollPresentation.anchorTop < totalLines - 1 || payload.after > 0
+            } else {
+                hasContentAfter = scrollPresentation.visibleEndLine < totalLines || payload.after > 0
+            }
         } else {
             hasContentAfter = payload.after > 0
         }
@@ -2383,7 +2401,16 @@ final class EditorNSView: MTKView {
         if let windowContent {
             let visibleRows = presentationPayloadVisibleRows(for: windowContent)
             if visibleRows > 0 {
-                return (before, max(windowContent.rows.count - visibleRows - before, 0))
+                let payloadAfter = max(windowContent.rows.count - visibleRows - before, 0)
+                if payloadAfter > 0 { return (before, payloadAfter) }
+                if let totalLines = windowContent.paneGeometry?.viewport.totalLines, totalLines > 0 {
+                    let isResident = scrollPresentation.overscanStartLine == 0 && scrollPresentation.overscanEndLine >= totalLines
+                    if isResident {
+                        let scrollAfter = max(Int(totalLines) - 1 - Int(scrollPresentation.anchorTop), 0)
+                        return (before, scrollAfter)
+                    }
+                }
+                return (before, 0)
             }
         }
         let after = max(0, Int(scrollPresentation.overscanEndLine) - Int(scrollPresentation.visibleEndLine))

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -2379,8 +2379,7 @@ final class EditorNSView: MTKView {
         let hasContentBefore = scrollPresentation.anchorTop > 0 || scrollPresentation.anchorVisualRowOffset > 0 || payload.before > 0
         let hasContentAfter: Bool
         if let totalLines = windowContent?.paneGeometry?.viewport.totalLines, totalLines > 0 {
-            let isResident = scrollPresentation.overscanStartLine == 0 && scrollPresentation.overscanEndLine >= totalLines
-            if isResident {
+            if Self.thumbDragCanPresentLocally(scrollPresentation: scrollPresentation, totalLines: totalLines) {
                 hasContentAfter = scrollPresentation.anchorTop < totalLines - 1 || payload.after > 0
             } else {
                 hasContentAfter = scrollPresentation.visibleEndLine < totalLines || payload.after > 0
@@ -2403,12 +2402,10 @@ final class EditorNSView: MTKView {
             if visibleRows > 0 {
                 let payloadAfter = max(windowContent.rows.count - visibleRows - before, 0)
                 if payloadAfter > 0 { return (before, payloadAfter) }
-                if let totalLines = windowContent.paneGeometry?.viewport.totalLines, totalLines > 0 {
-                    let isResident = scrollPresentation.overscanStartLine == 0 && scrollPresentation.overscanEndLine >= totalLines
-                    if isResident {
-                        let scrollAfter = max(Int(totalLines) - 1 - Int(scrollPresentation.anchorTop), 0)
-                        return (before, scrollAfter)
-                    }
+                if let totalLines = windowContent.paneGeometry?.viewport.totalLines, totalLines > 0,
+                   Self.thumbDragCanPresentLocally(scrollPresentation: scrollPresentation, totalLines: totalLines) {
+                    let scrollAfter = max(Int(totalLines) - 1 - Int(scrollPresentation.anchorTop), 0)
+                    return (before, scrollAfter)
                 }
                 return (before, 0)
             }

--- a/macos/Sources/Views/Editor/EditorScrollTrack.swift
+++ b/macos/Sources/Views/Editor/EditorScrollTrack.swift
@@ -54,6 +54,7 @@ enum EditorScrollTrack {
         totalLines: UInt32,
         visibleRows: UInt32,
         viewportTopLine: UInt32,
+        resident: Bool = false,
         minThumbHeight: CGFloat = Self.minThumbHeight
     ) -> Thumb? {
         guard totalLines > visibleRows, viewHeight > 0 else { return nil }
@@ -62,7 +63,7 @@ enum EditorScrollTrack {
         let proportion = CGFloat(visibleRows) / CGFloat(totalLines)
         let thumbHeight = min(viewHeight, max(proportion * viewHeight, minThumbHeight))
         let travelHeight = max(viewHeight - thumbHeight, 0)
-        let maxTop = maxScrollableTop(totalLines: totalLines, visibleRows: visibleRows)
+        let maxTop = maxScrollableTop(totalLines: totalLines, visibleRows: visibleRows, resident: resident)
         let clampedTopLine = min(viewportTopLine, maxTop)
         let y = travelHeight > 0 ? (CGFloat(clampedTopLine) / CGFloat(maxTop)) * travelHeight : 0
         return Thumb(y: y, height: thumbHeight, travelHeight: travelHeight)
@@ -81,6 +82,7 @@ enum EditorScrollTrack {
         viewHeight: CGFloat,
         totalLines: UInt32,
         visibleRows: UInt32,
+        resident: Bool = false,
         minThumbHeight: CGFloat = Self.minThumbHeight
     ) -> UInt32 {
         guard let thumb = thumb(
@@ -88,13 +90,14 @@ enum EditorScrollTrack {
             totalLines: totalLines,
             visibleRows: visibleRows,
             viewportTopLine: 0,
+            resident: resident,
             minThumbHeight: minThumbHeight
         ) else { return 0 }
         guard thumb.travelHeight > 0 else { return 0 }
 
         let thumbY = max(0, min(thumb.travelHeight, y - dragOffset))
         let proportion = thumbY / thumb.travelHeight
-        let maxTop = maxScrollableTop(totalLines: totalLines, visibleRows: visibleRows)
+        let maxTop = maxScrollableTop(totalLines: totalLines, visibleRows: visibleRows, resident: resident)
         return UInt32(max(0, min(Int64(maxTop), Int64(Double(proportion) * Double(maxTop)))))
     }
 
@@ -106,17 +109,21 @@ enum EditorScrollTrack {
         forY y: CGFloat,
         viewHeight: CGFloat,
         totalLines: UInt32,
-        visibleRows: UInt32
+        visibleRows: UInt32,
+        resident: Bool = false
     ) -> UInt32 {
         guard totalLines > visibleRows, viewHeight > 0 else { return 0 }
 
         let clampedY = max(0, min(viewHeight, y))
         let proportion = clampedY / viewHeight
-        let maxTop = maxScrollableTop(totalLines: totalLines, visibleRows: visibleRows)
+        let maxTop = maxScrollableTop(totalLines: totalLines, visibleRows: visibleRows, resident: resident)
         return UInt32(max(0, min(Int64(maxTop), Int64(Double(proportion) * Double(maxTop)))))
     }
 
-    private static func maxScrollableTop(totalLines: UInt32, visibleRows: UInt32) -> UInt32 {
-        UInt32(max(Int64(totalLines) - Int64(visibleRows), 1))
+    private static func maxScrollableTop(totalLines: UInt32, visibleRows: UInt32, resident: Bool) -> UInt32 {
+        if resident {
+            return UInt32(max(Int64(totalLines) - 1, 1))
+        }
+        return UInt32(max(Int64(totalLines) - Int64(visibleRows), 1))
     }
 }

--- a/macos/Sources/Views/Editor/EditorScrollTrack.swift
+++ b/macos/Sources/Views/Editor/EditorScrollTrack.swift
@@ -120,10 +120,8 @@ enum EditorScrollTrack {
         return UInt32(max(0, min(Int64(maxTop), Int64(Double(proportion) * Double(maxTop)))))
     }
 
-    private static func maxScrollableTop(totalLines: UInt32, visibleRows: UInt32, resident: Bool) -> UInt32 {
-        if resident {
-            return UInt32(max(Int64(totalLines) - 1, 1))
-        }
-        return UInt32(max(Int64(totalLines) - Int64(visibleRows), 1))
+    static func maxScrollableTop(totalLines: UInt32, visibleRows: UInt32, resident: Bool) -> UInt32 {
+        let subtract: Int64 = resident ? 1 : Int64(visibleRows)
+        return UInt32(max(Int64(totalLines) - subtract, 1))
     }
 }


### PR DESCRIPTION
## Summary

- **BEAM**: `Window.scroll_viewport` now uses `max_top = total_lines - 1` for resident (full-document) windows, allowing the authoritative scroll anchor to reach the last document line at the top of the viewport. Non-resident windows are unchanged (`total_lines - visible`).
- **Swift scroll track**: `EditorScrollTrack.maxScrollableTop` branches on a new `resident` parameter so the thumb travel range and click-to-line mapping cover the full scroll-past-end range.
- **Swift scroll indicator**: `CoreTextMetalRenderer` computes `maxTop` with the wider resident range so the overlay scrollbar thumb tracks correctly to the bottom.
- **Swift boundary availability**: `presentationScrollBoundaryAvailability` uses `anchorTop < totalLines - 1` for resident windows instead of `visibleEndLine < totalLines`, preventing premature rubber-banding in the scroll-past-end region.
- **Swift payload overscan**: `presentationScrollPayloadOverscanBounds` reports remaining scroll distance as "after" rows for resident windows past the old limit, keeping smooth trackpad scrolling alive through the entire range.

Extends the Go TUI scroll-past-end from PR #2717 to macOS.

## Test plan

- [x] BEAM compile clean (`mix compile --warnings-as-errors`)
- [x] BEAM tests pass (window, viewport, scroll, mouse, residence threshold)
- [x] Swift build clean (`xcodebuild build`)
- [x] Swift tests pass (EditorScrollTrackTests, PresentationScrollTests)
- [ ] Manual macOS: open a long file, scroll to the bottom, verify the last line can reach the top of the viewport
- [ ] Manual macOS: scroll indicator thumb tracks correctly through the full range
- [ ] Manual macOS: trackpad smooth scrolling works through the scroll-past-end region
- [ ] Manual macOS: rubber-band only triggers at the true end (last line at top)
- [ ] Manual macOS: non-resident (wrapped) files still clamp at the old limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)