### PR TITLE
Cache conversation history for Anthropic agent requests

### DIFF
--- a/lib/minga_agent/providers/native/req_llm_adapter.ex
+++ b/lib/minga_agent/providers/native/req_llm_adapter.ex
@@ -241,7 +241,13 @@ defmodule MingaAgent.Providers.Native.ReqLLMAdapter do
   @spec maybe_add_prompt_cache(keyword(), String.t(), AgentConfig.t()) :: keyword()
   defp maybe_add_prompt_cache(opts, model, config) do
     if anthropic_model?(model) and config.prompt_cache do
-      Keyword.put(opts, :provider_options, anthropic_prompt_cache: true)
+      # anthropic_cache_messages adds a cache_control breakpoint on the last
+      # conversation message so the growing transcript is a rolling cache-read
+      # prefix rather than re-sent at full input price every turn.
+      Keyword.put(opts, :provider_options,
+        anthropic_prompt_cache: true,
+        anthropic_cache_messages: true
+      )
     else
       opts
     end

--- a/test/minga_agent/providers/native/req_llm_adapter_test.exs
+++ b/test/minga_agent/providers/native/req_llm_adapter_test.exs
@@ -48,6 +48,7 @@ defmodule MingaAgent.Providers.Native.ReqLLMAdapterTest do
     assert opts[:max_tokens] == 4096
     assert opts[:base_url] == "https://anthropic.example/v1"
     assert opts[:provider_options][:anthropic_prompt_cache] == true
+    assert opts[:provider_options][:anthropic_cache_messages] == true
     assert opts[:reasoning_effort] == :high
 
     openai_opts = ReqLLMAdapter.stream_opts("gpt-4o@openai", [], "high", 1000, config)


### PR DESCRIPTION
## Why This Change?

The native agent burns far more input tokens than it should on multi-turn sessions. Anthropic prompt caching only caches the request prefix up to the last `cache_control` breakpoint. Today the adapter sets only `anthropic_prompt_cache: true`, which places breakpoints on the system prompt and the last tool — but never on the conversation messages. As a result the entire (and continually growing) transcript sits after the last cached prefix and is re-sent at full input price on every single turn.

## Summary Of Changes

- Add `anthropic_cache_messages: true` alongside `anthropic_prompt_cache: true` in `maybe_add_prompt_cache/3`, so ReqLLM places a `cache_control` breakpoint on the last conversation message.
- This turns the growing transcript into a rolling cache-read prefix instead of a full-price re-send each turn.
- The change is gated by the existing `prompt_cache` config and only applies to Anthropic models; the composition with `base_url`, `codex_oauth`, and `reasoning_effort` stages is unchanged.

## Testing

- Extended the existing `stream_opts` test to assert `anthropic_cache_messages == true` for Anthropic models; `mix test test/minga_agent/providers/native/req_llm_adapter_test.exs` passes (7/7).
- Verified end-to-end against the live Anthropic API through the real `stream_opts` code path on a ~23K-token conversation:
  - Before: warm turn = 23,040 input tokens, cache_read 0, cache_write 0.
  - After: warm turn = 3 input tokens, cache_read 23,037, cache_write 0.
  - ~10x cheaper on the re-sent context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)