### PR TITLE
fix(macos): recover failed frame resyncs

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -520,7 +520,8 @@ defmodule MingaEditor do
     {:noreply, new_state}
   end
 
-  def handle_info({:minga_input, {:request_keyframe, _last_good_frame_seq}}, state) do
+  def handle_info({:minga_input, {:request_keyframe, last_good_frame_seq}}, state) do
+    Minga.Log.warning(:render, "Frontend requested keyframe from frame #{last_good_frame_seq}")
     new_state = %{state | keyframe_pending?: true}
     {:noreply, Renderer.render_or_async(new_state)}
   end

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -96,6 +96,13 @@ defmodule MingaEditor.Frontend.Emit do
         encoded_frame.chrome_commands ++
         [surface_layout_command, Protocol.encode_commit_frame(frame_seq, input_seq)]
 
+    if keyframe? do
+      Minga.Log.info(
+        :render,
+        "Emitting keyframe #{frame_seq} in response to frontend recovery or attach"
+      )
+    end
+
     caches = update_tracking(ctx, caches)
     # Record both the seq and whether this frame carried the keyframe so the Editor
     # clears `keyframe_pending?` only when a frame that actually honored the request

--- a/lib/minga_editor/frontend/frame_transaction.ex
+++ b/lib/minga_editor/frontend/frame_transaction.ex
@@ -1,0 +1,94 @@
+defmodule MingaEditor.Frontend.FrameTransaction do
+  @moduledoc """
+  Validates the render-frame boundary before a command batch reaches a frontend.
+
+  Semantic render commands must appear between matching `begin_frame` and `commit_frame` markers. Only a deliberately small set of setup and side-channel commands may be emitted outside a frame. The manager logs violations before it writes the batch so a producer regression is attributable without inspecting payload content.
+  """
+
+  alias Minga.Protocol.Opcodes
+
+  @op_begin_frame Opcodes.begin_frame()
+  @op_commit_frame Opcodes.commit_frame()
+  @out_of_band_opcodes [
+    Opcodes.set_title(),
+    Opcodes.set_window_bg(),
+    Opcodes.set_link_cursor(),
+    Opcodes.protocol_error(),
+    Opcodes.set_font(),
+    Opcodes.set_font_fallback(),
+    Opcodes.register_font(),
+    Opcodes.gui_config_state(),
+    Opcodes.clipboard_write()
+  ]
+
+  @type frame_seq :: non_neg_integer()
+  @type state :: :outside | {:inside, frame_seq()}
+
+  @type validation_error ::
+          {:malformed_command}
+          | {:begin_while_open, frame_seq()}
+          | {:commit_without_begin, frame_seq()}
+          | {:commit_seq_mismatch, expected :: frame_seq(), received :: frame_seq()}
+          | {:unterminated_frame, frame_seq()}
+          | {:out_of_transaction_command, opcode :: non_neg_integer()}
+
+  @doc "Validates one ordered frontend command batch without inspecting payload data."
+  @spec validate([binary()]) :: :ok | {:error, validation_error()}
+  def validate(commands) when is_list(commands), do: validate(commands, :outside)
+
+  @doc "Formats a validation error using only protocol metadata, never command payloads."
+  @spec format_error(validation_error()) :: String.t()
+  def format_error({:malformed_command}), do: "malformed empty command"
+
+  def format_error({:begin_while_open, frame_seq}),
+    do: "begin_frame while frame #{frame_seq} is open"
+
+  def format_error({:commit_without_begin, frame_seq}),
+    do: "commit_frame #{frame_seq} without begin_frame"
+
+  def format_error({:commit_seq_mismatch, expected, received}),
+    do: "commit_frame #{received} does not match begin_frame #{expected}"
+
+  def format_error({:unterminated_frame, frame_seq}), do: "unterminated frame #{frame_seq}"
+
+  def format_error({:out_of_transaction_command, opcode}),
+    do: "opcode 0x#{Integer.to_string(opcode, 16) |> String.pad_leading(2, "0")} outside a frame"
+
+  @spec validate([binary()], state()) :: :ok | {:error, validation_error()}
+  defp validate([], :outside), do: :ok
+  defp validate([], {:inside, frame_seq}), do: {:error, {:unterminated_frame, frame_seq}}
+  defp validate([<<>> | _commands], _state), do: {:error, :malformed_command}
+
+  defp validate([<<@op_begin_frame, frame_seq::32, _base_frame_seq::32>> | commands], :outside),
+    do: validate(commands, {:inside, frame_seq})
+
+  defp validate(
+         [<<@op_begin_frame, _frame_seq::32, _base_frame_seq::32>> | _commands],
+         {:inside, open_frame_seq}
+       ),
+       do: {:error, {:begin_while_open, open_frame_seq}}
+
+  defp validate([<<@op_commit_frame, frame_seq::32, _input_seq::32>> | _commands], :outside),
+    do: {:error, {:commit_without_begin, frame_seq}}
+
+  defp validate(
+         [<<@op_commit_frame, frame_seq::32, _input_seq::32>> | commands],
+         {:inside, frame_seq}
+       ),
+       do: validate(commands, :outside)
+
+  defp validate(
+         [<<@op_commit_frame, received_frame_seq::32, _input_seq::32>> | _commands],
+         {:inside, expected_frame_seq}
+       ),
+       do: {:error, {:commit_seq_mismatch, expected_frame_seq, received_frame_seq}}
+
+  defp validate([<<opcode, _::binary>> | commands], :outside) when opcode in @out_of_band_opcodes,
+    do: validate(commands, :outside)
+
+  defp validate([<<opcode, _::binary>> | _commands], :outside),
+    do: {:error, {:out_of_transaction_command, opcode}}
+
+  defp validate([_command | commands], {:inside, frame_seq}),
+    do: validate(commands, {:inside, frame_seq})
+end

--- a/lib/minga_editor/frontend/manager.ex
+++ b/lib/minga_editor/frontend/manager.ex
@@ -29,6 +29,7 @@ defmodule MingaEditor.Frontend.Manager do
 
   alias Minga.Telemetry
   alias Minga.Telemetry.StartupTimer
+  alias MingaEditor.Frontend.FrameTransaction
   alias MingaEditor.Frontend.Protocol
 
   @typedoc "Renderer backend."
@@ -177,6 +178,8 @@ defmodule MingaEditor.Frontend.Manager do
   end
 
   def handle_cast({:send_commands, commands}, state) do
+    log_frame_transaction_violation(commands)
+
     Telemetry.span_with_stop_metadata([:minga, :port, :write], %{}, fn ->
       batch = IO.iodata_to_binary(commands)
       Port.command(state.port, batch)
@@ -256,6 +259,20 @@ defmodule MingaEditor.Frontend.Manager do
   end
 
   # ── Private ──
+
+  @spec log_frame_transaction_violation([binary()]) :: :ok
+  defp log_frame_transaction_violation(commands) do
+    case FrameTransaction.validate(commands) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Minga.Log.warning(
+          :port,
+          "Frontend command batch violates frame transaction: #{FrameTransaction.format_error(reason)}"
+        )
+    end
+  end
 
   @spec start_port(state(), fun()) :: state()
   defp start_port(%{port_mode: :connected} = state, port_opener) do

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -787,8 +787,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func handleProtocolData(_ data: Data) {
         guard let dispatcher else { return }
         do {
-            try decodeCommands(from: data) { command in
-                dispatcher.dispatch(command)
+            try decodeCommands(from: data) { command, opcode in
+                dispatcher.dispatch(command, opcode: opcode)
             }
         } catch {
             // A decode failure (sizing error or unknown opcode) mid-stream means

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -120,11 +120,22 @@ enum ProtocolDecodeError: Error {
 /// an entire frame into one message). This function iterates through the
 /// payload, decoding each command and calling the handler.
 func decodeCommands(from data: Data, handler: (RenderCommand) -> Void) throws {
+    try decodeCommands(from: data) { command, _ in
+        handler(command)
+    }
+}
+
+/// Decodes all commands and reports each command's wire opcode alongside its decoded value.
+///
+/// The opcode is protocol metadata, not payload content. Consumers can therefore identify a
+/// producer that violates frame boundaries without logging editor text or semantic UI data.
+func decodeCommands(from data: Data, handler: (RenderCommand, UInt8) -> Void) throws {
     var offset = 0
     while offset < data.count {
+        let opcode = data[offset]
         let (command, size) = try decodeCommand(data: data, offset: offset)
         if let command {
-            handler(command)
+            handler(command, opcode)
         }
         offset += size
     }

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -156,6 +156,16 @@ final class CommandDispatcher {
     /// can still be told apart from "never committed" when validating a base.
     private var hasCommitted = false
 
+    /// Resync is complete only when a requested base-0 keyframe commits cleanly.
+    /// A keyframe that fails while staged must trigger one fresh request, while stale
+    /// delta frames arriving before that keyframe remain debounced.
+    private enum ResyncRecoveryState: Equatable {
+        case clean
+        case awaitingKeyframe
+        case keyframeInFlight
+    }
+    private var resyncRecoveryState: ResyncRecoveryState = .clean
+
     /// gui_theme must carry the full slot set the frontends rely on. Missing slots are a protocol bug, not a theme fallback case.
     static let requiredThemeSlots: [UInt8] = [
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
@@ -188,7 +198,7 @@ final class CommandDispatcher {
     /// active recovery rather than silent drop. Contrast the old positive-allowlist
     /// design where a missing entry caused an unnecessary keyframe request with no
     /// application of the command.
-    func dispatch(_ command: RenderCommand) {
+    func dispatch(_ command: RenderCommand, opcode: UInt8? = nil) {
         switch command {
         case .beginFrame(let frameSeq, let baseFrameSeq):
             beginTransaction(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq)
@@ -226,7 +236,7 @@ final class CommandDispatcher {
                 // was added to the protocol without a corresponding explicit arm
                 // here, or the byte stream is desynced. Active recovery: discard
                 // staged state and request a keyframe. Mirrors Go model.go:454-456.
-                invalidate(reason: "out-of-transaction command")
+                invalidate(reason: "out-of-transaction command", sourceOpcode: opcode)
             }
         }
     }
@@ -242,6 +252,9 @@ final class CommandDispatcher {
         openFrameSeq = frameSeq
         openBaseFrameSeq = baseFrameSeq
         stagedCommands.removeAll(keepingCapacity: true)
+        if baseFrameSeq == 0 && resyncRecoveryState == .awaitingKeyframe {
+            resyncRecoveryState = .keyframeInFlight
+        }
     }
 
     /// Closes a frame transaction. Validates frame_seq against the open begin and
@@ -305,7 +318,10 @@ final class CommandDispatcher {
         hasCommitted = true
         openFrameSeq = nil
         stagedCommands.removeAll(keepingCapacity: true)
-        guiState.resyncState.clear()
+        if openBaseFrameSeq == 0 && resyncRecoveryState == .keyframeInFlight {
+            resyncRecoveryState = .clean
+            guiState.resyncState.clear()
+        }
 
         // Resolve the keystroke-to-present latency sample for the echoed input
         // correlation sequence (ticket #2215). The frame is fully promoted here
@@ -395,19 +411,16 @@ final class CommandDispatcher {
     /// state is left exactly as the last clean commit left it, so the screen
     /// holds the last good frame until the keyframe arrives. Raises a subtle
     /// resync-pending hint in the meantime.
-    private func invalidate(reason: String) {
-        PortLogger.warn("Frame transaction invalidated (\(reason)); requesting keyframe from \(lastCommittedFrameSeq)")
+    private func invalidate(reason: String, sourceOpcode: UInt8? = nil) {
+        let opcodeContext = sourceOpcode.map { String(format: ", opcode=0x%02X", $0) } ?? ""
+        let shouldRequestKeyframe = resyncRecoveryState != .awaitingKeyframe
+        resyncRecoveryState = .awaitingKeyframe
+        PortLogger.warn("Frame transaction invalidated (\(reason)\(opcodeContext)); \(shouldRequestKeyframe ? "requesting" : "awaiting") keyframe from \(lastCommittedFrameSeq)")
         openFrameSeq = nil
         openBaseFrameSeq = 0
         stagedCommands.removeAll(keepingCapacity: false)
-        // Debounce the keyframe request: after an invalidation, every stale
-        // in-flight frame also fails its base check (the BEAM advances
-        // base_frame_seq for frames we discarded), and re-requesting per frame
-        // would force a duplicate BEAM render each. One request per resync
-        // window; pending clears when a valid commit promotes.
-        let alreadyPending = guiState.resyncState.pending
         guiState.resyncState.markPending()
-        if !alreadyPending {
+        if shouldRequestKeyframe {
             onRequestKeyframe?(lastCommittedFrameSeq)
         }
     }

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -1631,6 +1631,54 @@ struct CommandDispatcherStagingTests {
         #expect(gui.tabBarState.tabs.first?.label == "fresh.ex")
     }
 
+    @Test("a stale delta commit does not clear a pending resync")
+    @MainActor func staleDeltaDoesNotClearPendingResync() {
+        let (dispatcher, gui) = makeDispatcher()
+        var requested: [UInt32] = []
+        dispatcher.onRequestKeyframe = { requested.append($0) }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("rogue.ex")]))
+        #expect(requested == [1])
+
+        // This delta is valid against our retained baseline, but it is not the
+        // requested base-0 recovery frame and must not dismiss the pending hint.
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("stale.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+        #expect(gui.resyncState.pending == true)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
+        #expect(gui.resyncState.pending == false)
+    }
+
+    @Test("invalidating a requested keyframe sends one replacement request")
+    @MainActor func failedKeyframeRequestsReplacement() {
+        let (dispatcher, gui) = makeDispatcher()
+        var requested: [UInt32] = []
+        dispatcher.onRequestKeyframe = { requested.append($0) }
+
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        #expect(requested == [0])
+
+        // A base-0 frame has answered the request, but fails validation before it
+        // can commit. It must reopen the request window instead of hanging forever.
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: []))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+        #expect(requested == [0, 0])
+        #expect(gui.resyncState.pending == true)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
+        #expect(gui.resyncState.pending == false)
+    }
+
     @Test("double begin (truncation) invalidates the open frame and requests keyframe")
     @MainActor func doubleBeginTruncates() {
         let (dispatcher, gui) = makeDispatcher()

--- a/test/minga_editor/frontend/frame_transaction_test.exs
+++ b/test/minga_editor/frontend/frame_transaction_test.exs
@@ -1,0 +1,39 @@
+defmodule MingaEditor.Frontend.FrameTransactionTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Protocol.Opcodes
+  alias MingaEditor.Frontend.FrameTransaction
+  alias MingaEditor.Frontend.Protocol
+
+  test "accepts a complete render frame with semantic commands" do
+    commands = [
+      Protocol.encode_begin_frame(12, 0),
+      <<Opcodes.gui_tab_bar(), 0>>,
+      Protocol.encode_commit_frame(12)
+    ]
+
+    assert FrameTransaction.validate(commands) == :ok
+  end
+
+  test "accepts sanctioned side-channel commands outside a frame" do
+    assert FrameTransaction.validate([Protocol.encode_set_title("Minga")]) == :ok
+  end
+
+  test "rejects a semantic command outside a frame without inspecting its payload" do
+    assert {:error, {:out_of_transaction_command, opcode}} =
+             FrameTransaction.validate([<<Opcodes.gui_tab_bar(), 0>>])
+
+    assert opcode == Opcodes.gui_tab_bar()
+
+    assert FrameTransaction.format_error({:out_of_transaction_command, opcode}) ==
+             "opcode 0x71 outside a frame"
+  end
+
+  test "rejects a mismatched frame commit" do
+    assert {:error, {:commit_seq_mismatch, 12, 13}} =
+             FrameTransaction.validate([
+               Protocol.encode_begin_frame(12, 0),
+               Protocol.encode_commit_frame(13)
+             ])
+  end
+end


### PR DESCRIPTION
# TL;DR

macOS frame resync now recovers when the requested keyframe itself is rejected, instead of leaving the editor permanently in `Resyncing…`. The BEAM also validates and logs frame-boundary violations so the original producer bug is attributable.

## Context

A semantic command observed outside a frame transaction requests a base-0 keyframe. Previously, the frontend debounced every subsequent request until any clean commit, while the BEAM considered recovery complete once it emitted a keyframe. If that recovery keyframe failed frontend validation, both sides stopped acting and the overlay remained visible indefinitely.

## Changes

- Model recovery explicitly as `clean`, `awaitingKeyframe`, and `keyframeInFlight` on macOS.
- Request a replacement keyframe when an in-flight recovery keyframe is invalidated, while continuing to debounce stale delta traffic.
- Keep the resync indicator visible until a requested base-0 frame commits successfully.
- Preserve the incoming opcode through Swift decoding and include it in safe out-of-transaction diagnostics.
- Validate outgoing frontend batches on the BEAM side, allowing only documented side-channel commands outside a frame and logging violations without payload data.
- Log keyframe requests and emitted keyframes to make a failed recovery traceable.

## Verification

- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS,arch=arm64' test`
- `make lint`
- Focused recovery and protocol tests: 47 passing.
- `mix test.llm` ran 9,882 tests. Two unrelated failures remain in `MingaAgent.Tools.FindTest` and `MingaAgent.Tools.GrepTest`; both reproduce on `main` because their fake `PATH` omits `tr`, which breaks the installed Git trace-propagation script.

## Review guide

1. Force an invalidation, then send a base-0 frame missing `gui_theme`; verify the client sends one replacement keyframe request.
2. Send a clean base-0 keyframe afterward; verify `Resyncing…` clears.
3. Send a semantic command outside a frame; verify the BEAM logs only its opcode and the frontend requests recovery.
