### PR TITLE
fix(macos): optimize release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,9 @@ jobs:
       - name: Clear stale Swift build cache
         run: rm -rf macos/DerivedData/Build macos/DerivedData/ModuleCache.noindex macos/DerivedData/SDKStatCaches.noindex
 
+      - name: Verify Release optimization
+        run: scripts/check_macos_release_optimization
+
       - name: Build
         run: |
           cd macos
@@ -405,6 +408,16 @@ jobs:
             -configuration Debug \
             -derivedDataPath DerivedData \
             CODE_SIGNING_ALLOWED=NO
+
+      - name: Release protocol tests
+        run: |
+          cd macos
+          xcodebuild test \
+            -scheme Minga \
+            -configuration Release \
+            -derivedDataPath DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            ENABLE_TESTABILITY=YES
 
   swift-integration:
     name: Swift Protocol Integration

--- a/lib/mix/tasks/app.assemble.ex
+++ b/lib/mix/tasks/app.assemble.ex
@@ -114,6 +114,7 @@ defmodule Mix.Tasks.App.Assemble do
   end
 
   defp build_xcode_project(false) do
+    verify_release_optimization!()
     macos_dir = Path.join(File.cwd!(), "macos")
     project_path = Path.join(macos_dir, "#{@app_name}.xcodeproj")
 
@@ -156,6 +157,16 @@ defmodule Mix.Tasks.App.Assemble do
     end
 
     app_path
+  end
+
+  @spec verify_release_optimization!() :: :ok
+  defp verify_release_optimization! do
+    script = Path.join([File.cwd!(), "scripts", "check_macos_release_optimization"])
+
+    case System.cmd(script, [], stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {output, _code} -> Mix.raise("Release optimization verification failed:\n#{output}")
+    end
   end
 
   @spec embed_release(String.t(), String.t()) :: :ok

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -1972,7 +1972,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.minga.editor;
 				PRODUCT_NAME = Minga;
 				SDKROOT = macosx;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TOOLCHAINS = com.apple.dt.toolchain.Metal.32023.864;
 			};
 			name = Release;

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -151,7 +151,6 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.minga.editor
         MARKETING_VERSION: "0.1.0"
         CURRENT_PROJECT_VERSION: "1"
-        SWIFT_OPTIMIZATION_LEVEL: "-Onone"
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: Entitlements.plist
         ENABLE_HARDENED_RUNTIME: "YES"
@@ -161,6 +160,11 @@ targets:
         # Workaround: macOS 26 beta cryptex bug prevents Metal toolchain auto-mount.
         # Remove once `metal --version` works without this (check Xcode Settings > Components).
         TOOLCHAINS: com.apple.dt.toolchain.Metal.32023.864
+      configs:
+        Debug:
+          SWIFT_OPTIMIZATION_LEVEL: "-Onone"
+        Release:
+          SWIFT_OPTIMIZATION_LEVEL: "-O"
     dependencies:
       - target: MingaProtocol
       - target: MingaUI

--- a/scripts/check_macos_release_optimization
+++ b/scripts/check_macos_release_optimization
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+project="$repo_root/macos/Minga.xcodeproj"
+
+if [[ $# -eq 1 ]]; then
+  settings="$(cat "$1")"
+else
+  settings="$(xcodebuild -project "$project" -scheme Minga -configuration Release -showBuildSettings)"
+fi
+
+target_count="$(grep -Ec '^[[:space:]]*TARGET_NAME = Minga$' <<<"$settings" || true)"
+optimization_count="$(grep -Ec '^[[:space:]]*SWIFT_OPTIMIZATION_LEVEL = -O$' <<<"$settings" || true)"
+
+if [[ "$target_count" != "1" || "$optimization_count" != "1" ]]; then
+  echo "error: Minga Release must resolve SWIFT_OPTIMIZATION_LEVEL = -O (targets: $target_count, matching settings: $optimization_count)" >&2
+  printf '%s\n' "$settings" | grep -E 'TARGET_NAME|SWIFT_OPTIMIZATION_LEVEL' >&2 || true
+  exit 1
+fi
+
+echo "Minga Release optimization: -O"

--- a/test/fixtures/xcodebuild/minga-release-optimized.txt
+++ b/test/fixtures/xcodebuild/minga-release-optimized.txt
@@ -1,0 +1,2 @@
+    SWIFT_OPTIMIZATION_LEVEL = -O
+    TARGET_NAME = Minga

--- a/test/fixtures/xcodebuild/minga-release-unoptimized.txt
+++ b/test/fixtures/xcodebuild/minga-release-unoptimized.txt
@@ -1,0 +1,2 @@
+    SWIFT_OPTIMIZATION_LEVEL = -Onone
+    TARGET_NAME = Minga

--- a/test/scripts/macos_release_optimization_test.exs
+++ b/test/scripts/macos_release_optimization_test.exs
@@ -1,0 +1,21 @@
+# Runs a shell verifier against fixture output and therefore invokes an OS process.
+defmodule Minga.Scripts.MacosReleaseOptimizationTest do
+  use ExUnit.Case, async: false
+
+  @script Path.join([File.cwd!(), "scripts", "check_macos_release_optimization"])
+  @fixtures Path.join([File.cwd!(), "test", "fixtures", "xcodebuild"])
+
+  test "accepts a Release Minga target optimized with -O" do
+    assert {"Minga Release optimization: -O\n", 0} =
+             System.cmd(@script, [Path.join(@fixtures, "minga-release-optimized.txt")])
+  end
+
+  test "rejects a Release Minga target optimized with -Onone" do
+    {_output, status} =
+      System.cmd(@script, [Path.join(@fixtures, "minga-release-unoptimized.txt")],
+        stderr_to_stdout: true
+      )
+
+    assert status != 0
+  end
+end


### PR DESCRIPTION
# TL;DR
Make the shipping Minga app compile Swift with `-O` in Release while keeping Debug at `-Onone`. CI and app assembly now verify the resolved Release setting.

Closes #2738

## Changes
- Scope Swift optimization settings by configuration in the XcodeGen source.
- Add a resolved-setting verifier with passing and failing fixtures.
- Run the verifier before macOS CI builds and app assembly.
- Add a Release xcodebuild test lane with testability enabled.

## Verification
- `scripts/check_macos_release_optimization`
- `mix test.llm test/scripts/macos_release_optimization_test.exs`
- `xcodebuild build -scheme Minga -configuration Release -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -scheme Minga -configuration Release -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO ENABLE_TESTABILITY=YES`