### PR TITLE
fix(protocol): harden wire framing bounds

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -51,13 +51,13 @@ opcode(1) + payload_length(2, big-endian) + payload(payload_length)
 
 This allows old frontends to skip unknown opcodes without crashing. When a frontend encounters an unrecognized opcode >= 0x90, it reads the 2-byte length, advances past the payload, and continues decoding the rest of the batch.
 
-Opcodes below 0x90 generally do NOT include a length prefix and retain their existing positional wire format. The explicit exceptions are `0x86 gui_agent_transcript`, which carries a 32-bit length-prefixed payload (`len32`) because the resident transcript can exceed 64KB, and `0x88 gui_agent_context`, which carries a 16-bit length-prefixed payload for compatibility with its expanded activity fields. Both occupy legacy opcode slots but self-describe their length so a frontend that recognizes the opcode can size and skip them; the schema's generated `command_size` sizes both from their declared framing. If a frontend encounters an *unknown* opcode below 0x90, it cannot determine the message size and must abort decoding. Known 0x90+ opcodes may document a wider envelope when the payload can exceed 64KB, as `gui_file_tree` does.
+Opcodes below 0x90 generally do NOT include a length prefix and retain their existing positional wire format. The explicit exceptions are `0x86 gui_agent_transcript`, which carries a 32-bit length-prefixed payload (`len32`) because the resident transcript can exceed 64KB, and `0x88 gui_agent_context`, which carries a 16-bit length-prefixed payload for compatibility with its expanded activity fields. Both occupy legacy opcode slots but self-describe their length so a frontend that recognizes the opcode can size and skip them; the schema's generated `command_size` sizes both from their declared framing. If a frontend encounters an *unknown* opcode below 0x90, it cannot determine the message size and must abort decoding. Known 0x90+ opcodes may document a wider envelope when the payload can exceed 64KB, as `clipboard_write` and `gui_file_tree` do.
 
 The BEAM-side encoder must use a documented length-prefixed envelope for all new opcodes (0x90+). Currently defined 0x90+ opcodes:
 
 | Opcode | Name | Description |
 |--------|------|-------------|
-| 0x90 | clipboard_write | Write text to the system clipboard |
+| 0x90 | clipboard_write | Write text to the system clipboard. Uses a 32-bit payload length for content beyond 64KB. |
 | 0x91 | gui_indent_guides | Indent guide positions per window |
 | 0x92 | gui_line_spacing | Line spacing multiplier for the renderer |
 | 0x93 | gui_file_tree | Semantic file tree rows for the native sidebar view. Uses a 32-bit payload length because expanded project trees can exceed 64KB. |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -207,7 +207,7 @@ Between frames, the frontend must not mutate committed editor state or present n
 
 ## Bounded length carriers
 
-`clipboard_write` uses a u32 outer payload length and u32 text length. `gui_window_content` and its A1/A2 delta commands use u32 section lengths and u32 row counts. These carriers support values from 0 through 4,294,967,295 bytes or rows. A producer must reject a value outside its carrier before writing any part of the command. Fields documented as u8 or u16 remain intentionally bounded and must likewise fail before emission when their value is out of range.
+`clipboard_write` uses a u32 outer payload length and u32 text length. `gui_window_content` and its A1/A2 delta commands use u32 section lengths and u32 row counts. These carriers represent values from 0 through 4,294,967,295 bytes or rows, but both shipped frontends reject packets larger than 64 MiB before allocation. A producer must reject a value outside its carrier before writing any part of the command. Fields documented as u8 or u16 remain intentionally bounded and must likewise fail before emission when their value is out of range.
 
 ## Frame Transactions
 

--- a/go/tui/internal/port/framing_contract_test.go
+++ b/go/tui/internal/port/framing_contract_test.go
@@ -76,11 +76,8 @@ var minimalBodyOverrides = map[byte][]byte{
 	// clipboard_write (len32): decodeClipboardWrite requires payload_len == 5 + text_len. Minimal:
 	// opcode + payload_len(4)=5 + target(1) + text_len(4)=0 = 10 bytes.
 	generated.OPClipboardWrite: {generated.OPClipboardWrite, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00},
-	// gui_window_content (len32): full keyframes wrap the section table in an
-	// outer u32 payload length, and the decoder requires the inner payload to at
-	// least contain section_count. Minimal: opcode + payload_len(4)=1 +
-	// section_count(1)=0.
-	generated.OPGuiWindowContent: {generated.OPGuiWindowContent, 0x00, 0x00, 0x00, 0x01, 0x00},
+	// gui_window_content (len32): full keyframes require a header and rows section.
+	generated.OPGuiWindowContent: minimalWindowContent(),
 	// gui_extension_runtime (len32): decodeExtensionRuntime reads two string16
 	// fields (extension_id, channel) inside payload_len, so payload_len must be >= 4
 	// for two zero-length strings. Minimal: opcode + payload_len(4)=4 + four zero
@@ -250,6 +247,15 @@ func loadGeneratedOpcodes(t *testing.T) []generatedOpcode {
 		t.Fatalf("no OP* constants parsed from %s; the generated format changed", path)
 	}
 	return opcodes
+}
+
+func minimalWindowContent() []byte {
+	header := []byte{0, 7, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	body := []byte{2, 0x01, 0, 0, 0, byte(len(header))}
+	body = append(body, header...)
+	body = append(body, 0x02, 0, 0, 0, 4, 0, 0, 0, 0)
+	result := []byte{generated.OPGuiWindowContent, 0, 0, 0, byte(len(body))}
+	return append(result, body...)
 }
 
 func minimalWindowDelta(opcode byte, windowID byte, flags byte) []byte {

--- a/go/tui/internal/protocol/commands.go
+++ b/go/tui/internal/protocol/commands.go
@@ -270,9 +270,6 @@ func decodeWindowContent(payload []byte) (Command, error) {
 		end = len(payload)
 	}
 
-	requiresSections := opcode == generated.OPGuiWindowRowsDelta || opcode == generated.OPGuiWindowViewportDelta
-	needHeader := requiresSections
-	needRows := requiresSections
 	sawHeader := false
 	sawRows := false
 	window := WindowContent{}
@@ -292,15 +289,15 @@ func decodeWindowContent(payload []byte) (Command, error) {
 
 		switch sectionID {
 		case 0x01:
-			sawHeader = true
-			if !decodeWindowHeader(opcode, section, &window) && needHeader {
+			if sawHeader || !decodeWindowHeader(opcode, section, &window) {
 				return Command{}, fmt.Errorf("malformed semantic window header")
 			}
+			sawHeader = true
 		case 0x02:
-			sawRows = true
-			if !decodeRows(section, &window, opcode != generated.OPGuiWindowContent) {
+			if sawRows || !decodeRows(section, &window, opcode != generated.OPGuiWindowContent) {
 				return Command{}, fmt.Errorf("malformed semantic window rows")
 			}
+			sawRows = true
 		case 0x03:
 			decodeSelection(section, &window)
 		case 0x04:
@@ -320,10 +317,10 @@ func decodeWindowContent(payload []byte) (Command, error) {
 		}
 	}
 
-	if needHeader && !sawHeader {
+	if !sawHeader {
 		return Command{}, fmt.Errorf("missing required semantic window header")
 	}
-	if needRows && !sawRows {
+	if !sawRows {
 		return Command{}, fmt.Errorf("missing required semantic window rows")
 	}
 

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -149,6 +149,30 @@ func TestDecodeWindowContentRows(t *testing.T) {
 	}
 }
 
+func TestDecodeWindowContentRequiresOneHeaderAndRows(t *testing.T) {
+	header := []byte{0, 7, 0x02, 0, 3, 0, 4, 1, 0, 0, 0, 0, 0, 11}
+	rows := []byte{0, 0, 0, 0}
+
+	tests := []struct {
+		name   string
+		packet []byte
+	}{
+		{name: "empty sections", packet: windowContentPacket()},
+		{name: "missing rows", packet: windowContentPacket(section32(0x01, header))},
+		{name: "missing header", packet: windowContentPacket(section32(0x02, rows))},
+		{name: "duplicate header", packet: windowContentPacket(section32(0x01, header), section32(0x01, header), section32(0x02, rows))},
+		{name: "duplicate rows", packet: windowContentPacket(section32(0x01, header), section32(0x02, rows), section32(0x02, rows))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := DecodeCommand(tt.packet); err == nil {
+				t.Fatal("DecodeCommand accepted an incomplete semantic window")
+			}
+		})
+	}
+}
+
 func TestDecodeWindowContentScrollPresentation(t *testing.T) {
 	headerPayload := []byte{0, 7, 0x02, 0, 3, 0, 4, 1, 0, 2, 0, 0, 0, 42}
 	rowsPayload := []byte{0, 0, 0, 0}

--- a/go/tui/internal/protocol/packet.go
+++ b/go/tui/internal/protocol/packet.go
@@ -6,6 +6,8 @@ import (
 	"io"
 )
 
+const maxPacketPayloadLength = 64 * 1_048_576
+
 func ReadPacket(reader io.Reader) ([]byte, error) {
 	var header [4]byte
 	if _, err := io.ReadFull(reader, header[:]); err != nil {
@@ -15,6 +17,9 @@ func ReadPacket(reader io.Reader) ([]byte, error) {
 	length := binary.BigEndian.Uint32(header[:])
 	if length == 0 {
 		return []byte{}, nil
+	}
+	if length > maxPacketPayloadLength {
+		return nil, fmt.Errorf("packet payload length %d exceeds maximum %d", length, maxPacketPayloadLength)
 	}
 
 	payload := make([]byte, length)

--- a/go/tui/internal/protocol/packet_test.go
+++ b/go/tui/internal/protocol/packet_test.go
@@ -1,0 +1,14 @@
+package protocol
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReadPacketRejectsPayloadOverMaximumBeforeAllocation(t *testing.T) {
+	reader := bytes.NewReader([]byte{0xFF, 0xFF, 0xFF, 0xFF})
+
+	if _, err := ReadPacket(reader); err == nil {
+		t.Fatal("ReadPacket accepted an oversized payload length")
+	}
+}

--- a/go/tui/internal/protocol/semantic_guardrail_test.go
+++ b/go/tui/internal/protocol/semantic_guardrail_test.go
@@ -66,7 +66,7 @@ func TestSemanticFrontendOpcodesAreAccountedFor(t *testing.T) {
 		generated.OPGuiPickerPreview:       {generated.OPGuiPickerPreview, 0},
 		generated.OPGuiToolManager:         {generated.OPGuiToolManager, 0},
 		generated.OPGuiMinibuffer:          {generated.OPGuiMinibuffer, 0},
-		generated.OPGuiWindowContent:       {generated.OPGuiWindowContent, 0, 0, 0, 1, 0},
+		generated.OPGuiWindowContent:       semanticWindowContent(),
 		generated.OPGuiHoverPopup:          {generated.OPGuiHoverPopup, 0},
 		generated.OPGuiSignatureHelp:       {generated.OPGuiSignatureHelp, 0},
 		generated.OPGuiFloatPopup:          {generated.OPGuiFloatPopup, 0},
@@ -119,6 +119,15 @@ func TestSemanticFrontendOpcodesAreAccountedFor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func semanticWindowContent() []byte {
+	header := []byte{0, 7, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	body := []byte{2}
+	body = append(body, section32Semantic(0x01, header)...)
+	body = append(body, section32Semantic(0x02, []byte{0, 0, 0, 0})...)
+	result := []byte{generated.OPGuiWindowContent, 0, 0, 0, byte(len(body))}
+	return append(result, body...)
 }
 
 func section32Semantic(id byte, payload []byte) []byte {

--- a/go/tui/internal/protocol/wire_bounds_test.go
+++ b/go/tui/internal/protocol/wire_bounds_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/jsmestad/minga/go/tui/internal/generated"
@@ -21,5 +22,66 @@ func TestDecodeWindowDeltaRejectsRowCountBeyondSectionBytes(t *testing.T) {
 
 	if _, err := DecodeCommand(packet); err == nil {
 		t.Fatal("DecodeCommand accepted a row delta count that cannot fit in the rows section")
+	}
+}
+
+func TestDecodeWindowDeltaRejectsMalformedSections(t *testing.T) {
+	header := []byte{0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0}
+
+	for _, opcode := range []byte{generated.OPGuiWindowRowsDelta, generated.OPGuiWindowViewportDelta} {
+		t.Run("declared section length", func(t *testing.T) {
+			packet := append([]byte{opcode, 1, 0x01, 0, 0, 0, 15}, header...)
+			if _, err := DecodeCommand(packet); err == nil {
+				t.Fatal("DecodeCommand accepted a truncated declared section")
+			}
+		})
+
+		t.Run("trailing row bytes", func(t *testing.T) {
+			rows := []byte{0, 0, 0, 0, 0xFF}
+			packet := append([]byte{opcode, 2}, section32(0x01, header)...)
+			packet = append(packet, section32(0x02, rows)...)
+			if _, err := DecodeCommand(packet); err == nil {
+				t.Fatal("DecodeCommand accepted trailing row bytes")
+			}
+		})
+	}
+}
+
+func TestDecodeClipboardWriteSupportsMoreThanUint16Bytes(t *testing.T) {
+	text := bytes.Repeat([]byte{'x'}, 65_536)
+	packet := []byte{generated.OPClipboardWrite}
+	packet = append(packet, u32Bytes(uint32(5+len(text)))...)
+	packet = append(packet, 0)
+	packet = append(packet, u32Bytes(uint32(len(text)))...)
+	packet = append(packet, text...)
+
+	command, err := DecodeCommand(packet)
+	if err != nil {
+		t.Fatalf("DecodeCommand returned error: %v", err)
+	}
+	if len(command.ClipboardText) != len(text) {
+		t.Fatalf("clipboard text length = %d, want %d", len(command.ClipboardText), len(text))
+	}
+}
+
+func TestDecodeWindowDeltaSupportsMoreThanUint16Rows(t *testing.T) {
+	const rowCount = 65_536
+	header := []byte{0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0}
+	rows := u32Bytes(rowCount)
+
+	for rowID := uint64(0); rowID < rowCount; rowID++ {
+		rows = append(rows, 0)
+		rows = append(rows, byte(rowID>>56), byte(rowID>>48), byte(rowID>>40), byte(rowID>>32), byte(rowID>>24), byte(rowID>>16), byte(rowID>>8), byte(rowID))
+		rows = append(rows, 0, 0, 0, 0)
+	}
+
+	packet := append([]byte{generated.OPGuiWindowRowsDelta, 2}, section32(0x01, header)...)
+	packet = append(packet, section32(0x02, rows)...)
+	command, err := DecodeCommand(packet)
+	if err != nil {
+		t.Fatalf("DecodeCommand returned error: %v", err)
+	}
+	if len(command.Window.Rows) != rowCount {
+		t.Fatalf("decoded rows = %d, want %d", len(command.Window.Rows), rowCount)
 	}
 }

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1601,6 +1601,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         var wcContentEpoch: UInt32 = 0
         var wcRows: [GUIVisualRow] = []
         var wcOverlays = DecodedOverlaySections()
+        var wcSawHeader = false
+        var wcSawRows = false
 
         for _ in 0..<wcSectionCount {
             guard wcPayloadEnd >= wcPos + 5 else { throw ProtocolDecodeError.malformed }
@@ -1611,7 +1613,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
             switch wcSId {
             case 0x01: // Header: window_id(2) + flags(1) + cursor_row(2) + cursor_col(2) + cursor_shape(1) + scroll_left(2) + optional content_epoch(4)
-                guard wcSLen >= 10 else { break }
+                guard !wcSawHeader, wcSLen >= 10 else { throw ProtocolDecodeError.malformed }
+                wcSawHeader = true
                 wcWindowId = readU16(data, wcSStart)
                 wcFlags = data[wcSStart + 2]
                 wcCursorRow = readU16(data, wcSStart + 3)
@@ -1623,6 +1626,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 }
 
             case 0x02: // Rows: row_count(4) + rows...
+                guard !wcSawRows else { throw ProtocolDecodeError.malformed }
+                wcSawRows = true
                 wcRows = try decodeWindowContentRows(data: data, start: wcSStart, end: wcSStart + wcSLen)
 
             case 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A:
@@ -1633,7 +1638,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
             wcPos = wcSStart + wcSLen
         }
-        guard wcPos == wcPayloadEnd else { throw ProtocolDecodeError.malformed }
+        guard wcPos == wcPayloadEnd, wcSawHeader, wcSawRows else { throw ProtocolDecodeError.malformed }
 
         let scrollPresentation = try validatedScrollPresentation(wcOverlays.scrollPresentation, windowId: wcWindowId, contentEpoch: wcContentEpoch)
 
@@ -3095,7 +3100,7 @@ private func decodeWindowRowsDelta(data: Data, offset: Int) throws -> (GUIWindow
 
         switch sectionId {
         case 0x01:
-            guard sectionLen >= 14 else { throw ProtocolDecodeError.malformed }
+            guard !sawHeader, sectionLen >= 14 else { throw ProtocolDecodeError.malformed }
             sawHeader = true
             windowId = readU16(data, sectionStart)
             contentEpoch = readU32(data, sectionStart + 2)
@@ -3106,6 +3111,7 @@ private func decodeWindowRowsDelta(data: Data, offset: Int) throws -> (GUIWindow
             scrollLeft = readU16(data, sectionStart + 12)
 
         case 0x02:
+            guard !sawRows else { throw ProtocolDecodeError.malformed }
             sawRows = true
             rows = try decodeWindowDeltaRows(data: data, start: sectionStart, end: sectionEnd)
 

--- a/macos/Tests/MingaTests/DecoderRobustnessTests.swift
+++ b/macos/Tests/MingaTests/DecoderRobustnessTests.swift
@@ -311,9 +311,28 @@ private func windowContentSection(id: UInt8, payload: Data) -> Data {
 
 private func windowContentRowsPayload(rowBytes: Data) -> Data {
     var payload = Data()
-    appendU16(&payload, 1)
+    appendU32(&payload, 1)
     payload.append(rowBytes)
     return payload
+}
+
+private func windowContentData(sections: [Data]) -> Data {
+    var payload = Data([UInt8(sections.count)])
+    for section in sections {
+        payload.append(section)
+    }
+
+    var data = Data([OP_GUI_WINDOW_CONTENT])
+    appendU32(&data, UInt32(payload.count))
+    data.append(payload)
+    return data
+}
+
+private func windowDeltaData(opcode: UInt8, header: Data, rows: Data) -> Data {
+    var data = Data([opcode, 2])
+    data.append(windowContentSection(id: 0x01, payload: header))
+    data.append(windowContentSection(id: 0x02, payload: rows))
+    return data
 }
 
 private func appendU16(_ data: inout Data, _ value: UInt16) {
@@ -648,5 +667,88 @@ struct DecoderEdgeCaseTests {
         #expect(throws: ProtocolDecodeError.self) {
             try decodeCommand(data: data, offset: 0)
         }
+    }
+}
+
+@Suite("Decoder Robustness: u32 Window Framing")
+struct DecoderU32WindowFramingTests {
+    private let header = Data([0, 1, 0x03, 0, 0, 0, 0, 0, 0, 0])
+    private let deltaHeader = Data([0, 1, 0, 0, 0, 1, 0x01, 0, 0, 0, 0, 0, 0, 0])
+    private let emptyRows = Data([0, 0, 0, 0])
+
+    @Test("gui_window_content requires one header and rows section")
+    func requiresHeaderAndRows() {
+        let headerSection = windowContentSection(id: 0x01, payload: header)
+        let rowsSection = windowContentSection(id: 0x02, payload: emptyRows)
+        let invalidCommands = [
+            windowContentData(sections: []),
+            windowContentData(sections: [headerSection]),
+            windowContentData(sections: [rowsSection]),
+            windowContentData(sections: [headerSection, headerSection, rowsSection]),
+            windowContentData(sections: [headerSection, rowsSection, rowsSection])
+        ]
+
+        for data in invalidCommands {
+            #expect(throws: ProtocolDecodeError.self) {
+                try decodeCommand(data: data, offset: 0)
+            }
+        }
+    }
+
+    @Test("window deltas reject truncated sections and trailing row bytes")
+    func rejectsMalformedDeltaSections() {
+        for opcode in [OP_GUI_WINDOW_ROWS_DELTA, OP_GUI_WINDOW_VIEWPORT_DELTA] {
+            var truncatedSection = Data([opcode, 1, 0x01])
+            appendU32(&truncatedSection, 15)
+            truncatedSection.append(deltaHeader)
+
+            #expect(throws: ProtocolDecodeError.self) {
+                try decodeCommand(data: truncatedSection, offset: 0)
+            }
+
+            let trailingRows = Data([0, 0, 0, 0, 0xFF])
+            let trailingRowsCommand = windowDeltaData(opcode: opcode, header: deltaHeader, rows: trailingRows)
+            #expect(throws: ProtocolDecodeError.self) {
+                try decodeCommand(data: trailingRowsCommand, offset: 0)
+            }
+        }
+    }
+
+    @Test("clipboard_write decodes more than UInt16 bytes")
+    func decodesLargeClipboardWrite() throws {
+        let text = Data(repeating: 0x78, count: 65_536)
+        var data = Data([OP_CLIPBOARD_WRITE])
+        appendU32(&data, UInt32(5 + text.count))
+        data.append(0)
+        appendU32(&data, UInt32(text.count))
+        data.append(text)
+
+        let (command, _) = try decodeCommand(data: data, offset: 0)
+        guard case .clipboardWrite(_, let decoded) = command else {
+            Issue.record("Expected clipboardWrite")
+            return
+        }
+        #expect(decoded.utf8.count == text.count)
+    }
+
+    @Test("window deltas decode more than UInt16 rows")
+    func decodesLargeWindowDelta() throws {
+        let rowCount = 65_536
+        var rows = Data()
+        appendU32(&rows, UInt32(rowCount))
+
+        for rowId in 0..<rowCount {
+            rows.append(0)
+            appendU64(&rows, UInt64(rowId))
+            appendU32(&rows, 0)
+        }
+
+        let data = windowDeltaData(opcode: OP_GUI_WINDOW_ROWS_DELTA, header: deltaHeader, rows: rows)
+        let (command, _) = try decodeCommand(data: data, offset: 0)
+        guard case .guiWindowRowsDelta(let delta) = command else {
+            Issue.record("Expected guiWindowRowsDelta")
+            return
+        }
+        #expect(delta.rows.count == rowCount)
     }
 }


### PR DESCRIPTION
# TL;DR
Harden the widened GUI wire framing so malformed packets cannot allocate unbounded memory or commit incomplete window state.

Follow-up to #2762.

## Changes
- Cap Go packet allocation at 64 MiB, matching the macOS reader's limit.
- Require exactly one valid header and rows section in full window snapshots and deltas.
- Add Go and Swift regression coverage for malformed sections, trailing row bytes, and values beyond 65,535.
- Clarify the documented u32 framing and frontend packet limit.

## Verification
- `make lint`
- `go test ./...` from `go/tui`
- `xcodebuild test -scheme Minga -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO` from `macos`
- `mix protocol.gen --check`
- `mix zig.lint`

`mix test.llm` reported five unrelated Elixir failures that require separate investigation; the same focused tests pass on `main`.
