### PR TITLE
fix(protocol): reject invalid GUI frames at emit boundary

### DIFF
--- a/lib/minga/frontend/adapter/gui.ex
+++ b/lib/minga/frontend/adapter/gui.ex
@@ -84,7 +84,17 @@ defmodule Minga.Frontend.Adapter.GUI do
 
   @doc "Encodes a full GUI render model into Metal-critical and SwiftUI chrome command groups."
   @spec encode(RenderModel.t(), Caches.t()) :: EncodedFrame.t()
-  def encode(%RenderModel{} = model, %Caches{} = caches) do
+  def encode(%RenderModel{} = model, %Caches{} = caches), do: do_encode(model, caches)
+
+  @spec encode_checked(RenderModel.t(), Caches.t()) :: {:ok, EncodedFrame.t()} | {:error, term()}
+  def encode_checked(%RenderModel{} = model, %Caches{} = caches) do
+    {:ok, do_encode(model, caches)}
+  rescue
+    error in Minga.Frontend.Adapter.GUI.EncodingError -> {:error, error}
+  end
+
+  @spec do_encode(RenderModel.t(), Caches.t()) :: EncodedFrame.t()
+  defp do_encode(%RenderModel{} = model, %Caches{} = caches) do
     {window_content_cmds, caches, window_metrics} =
       encode_windows_with_metrics(model.windows, caches)
 

--- a/lib/minga/frontend/adapter/gui/encoding_error.ex
+++ b/lib/minga/frontend/adapter/gui/encoding_error.ex
@@ -1,0 +1,20 @@
+defmodule Minga.Frontend.Adapter.GUI.EncodingError do
+  @moduledoc false
+
+  @enforce_keys [:command, :field, :actual, :min, :max]
+  defexception [:command, :field, :actual, :min, :max]
+
+  @type t :: %__MODULE__{
+          command: atom(),
+          field: atom(),
+          actual: integer(),
+          min: integer(),
+          max: integer()
+        }
+
+  @impl Exception
+  @spec message(t()) :: String.t()
+  def message(%__MODULE__{} = error) do
+    "cannot encode #{error.command}.#{error.field}=#{error.actual}; expected #{error.min}..#{error.max}"
+  end
+end

--- a/lib/minga/frontend/adapter/gui/wire.ex
+++ b/lib/minga/frontend/adapter/gui/wire.ex
@@ -37,7 +37,22 @@ defmodule Minga.Frontend.Adapter.GUI.Wire do
   @spec encode_section(non_neg_integer(), iodata()) :: binary()
   def encode_section(section_id, payload) do
     payload = IO.iodata_to_binary(payload)
+    validate_uint!(:gui_section, :section_id, section_id, @max_u8)
+    validate_uint!(:gui_section, :payload_length, byte_size(payload), @max_u16)
     <<section_id::8, byte_size(payload)::16, payload::binary>>
+  end
+
+  @spec validate_uint!(atom(), atom(), integer(), non_neg_integer()) :: :ok
+  def validate_uint!(_command, _field, value, max)
+      when is_integer(value) and value >= 0 and value <= max, do: :ok
+
+  def validate_uint!(command, field, value, max) do
+    raise Minga.Frontend.Adapter.GUI.EncodingError,
+      command: command,
+      field: field,
+      actual: value,
+      min: 0,
+      max: max
   end
 
   @spec encode_string8(iodata()) :: binary()

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -270,11 +270,7 @@ defmodule MingaEditor.Frontend.Emit do
   # ── Side-channel writes (shared) ─────────────────────────────────────────
 
   @spec send_title(Minga.RenderModel.t() | ctx(), Caches.t()) :: Caches.t()
-  defp send_title(%Minga.RenderModel{title: title}, caches), do: do_send_title(title, caches)
-  defp send_title(ctx, caches), do: do_send_title(ctx.title, caches)
-
-  @spec do_send_title(String.t(), Caches.t()) :: Caches.t()
-  defp do_send_title(title, caches) do
+  defp send_title(%Minga.RenderModel{title: title}, caches) do
     if title != caches.last_title do
       MingaEditor.Frontend.set_title(title)
       %{caches | last_title: title}
@@ -284,13 +280,7 @@ defmodule MingaEditor.Frontend.Emit do
   end
 
   @spec send_window_bg(Minga.RenderModel.t() | ctx(), Caches.t()) :: Caches.t()
-  defp send_window_bg(%Minga.RenderModel{window_bg: bg}, caches),
-    do: do_send_window_bg(bg, caches)
-
-  defp send_window_bg(ctx, caches), do: do_send_window_bg(ctx.theme.editor.bg, caches)
-
-  @spec do_send_window_bg(non_neg_integer(), Caches.t()) :: Caches.t()
-  defp do_send_window_bg(bg, caches) do
+  defp send_window_bg(%Minga.RenderModel{window_bg: bg}, caches) do
     if bg != caches.last_window_bg do
       MingaEditor.Frontend.set_window_bg(bg)
       %{caches | last_window_bg: bg}

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -68,24 +68,64 @@ defmodule MingaEditor.Frontend.Emit do
         caches
       end
 
-    encoded_frame =
-      Telemetry.span_with_stop_metadata([:minga, :render, :adapter_encode], %{}, fn ->
-        encoded_frame = Minga.Frontend.Adapter.GUI.encode(render_model, caches.adapter_gui_caches)
-        {encoded_frame, adapter_encode_metadata(encoded_frame.metrics)}
-      end)
+    case encode_adapter_frame(render_model, caches) do
+      {:error, error} ->
+        Minga.Log.warning(:render, "Discarded invalid GUI frame: #{Exception.message(error)}")
 
+        {%{
+           caches
+           | adapter_gui_caches: Minga.Frontend.Adapter.GUI.Caches.new(),
+             last_emitted_frame_seq: 0
+         }, ctx}
+
+      {:ok, encoded_frame} ->
+        emit_encoded_frame(
+          encoded_frame,
+          render_model,
+          ctx,
+          caches,
+          frame_seq,
+          base_frame_seq,
+          keyframe?
+        )
+    end
+  end
+
+  @spec encode_adapter_frame(Minga.RenderModel.t(), Caches.t()) ::
+          {:ok, Minga.Frontend.Adapter.GUI.EncodedFrame.t()} | {:error, Exception.t()}
+  defp encode_adapter_frame(render_model, caches) do
+    Telemetry.span_with_stop_metadata([:minga, :render, :adapter_encode], %{}, fn ->
+      case Minga.Frontend.Adapter.GUI.encode_checked(render_model, caches.adapter_gui_caches) do
+        {:ok, encoded_frame} ->
+          {{:ok, encoded_frame}, adapter_encode_metadata(encoded_frame.metrics)}
+
+        {:error, error} ->
+          {{:error, error}, %{encoding_error: true}}
+      end
+    end)
+  end
+
+  @spec emit_encoded_frame(
+          Minga.Frontend.Adapter.GUI.EncodedFrame.t(),
+          Minga.RenderModel.t(),
+          ctx(),
+          Caches.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean()
+        ) :: {Caches.t(), ctx()}
+  defp emit_encoded_frame(
+         encoded_frame,
+         render_model,
+         ctx,
+         caches,
+         frame_seq,
+         base_frame_seq,
+         keyframe?
+       ) do
     caches = %{caches | adapter_gui_caches: encoded_frame.caches}
-
-    # Echo the latest input correlation sequence on commit_frame (ticket #2215) so
-    # the frontend can resolve a keystroke-to-write latency sample.
     input_seq = Map.get(ctx, :last_input_seq, 0)
 
-    # gui_surface_layout (#2219 child E / #2268): the authoritative per-frame
-    # surface placement list, emitted inside the transaction from the SAME
-    # SurfaceRegistry placements that feed BEAM mouse hit-testing. One source,
-    # one rect+z list; Go composites by z and derives mouse zones from these
-    # rects (no more overlayLines precedence chain for placed surfaces). It rides
-    # with the chrome commands so it sits after content and before commit.
     surface_layout_command =
       Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder.encode_command(ctx.surface_placements)
 
@@ -104,9 +144,6 @@ defmodule MingaEditor.Frontend.Emit do
     end
 
     caches = update_tracking(ctx, caches)
-    # Record both the seq and whether this frame carried the keyframe so the Editor
-    # clears `keyframe_pending?` only when a frame that actually honored the request
-    # reached emit (#2219). A concurrent delta writeback must not swallow the flag.
     caches = %{caches | last_emitted_frame_seq: frame_seq, last_frame_keyframe?: keyframe?}
     byte_count = IO.iodata_length(commands)
 
@@ -117,8 +154,7 @@ defmodule MingaEditor.Frontend.Emit do
         MingaEditor.Frontend.send_render_commands(ctx.port_manager, commands)
         caches = send_title(render_model, caches)
         caches = send_window_bg(render_model, caches)
-        caches = send_link_cursor(ctx, caches)
-        {caches, ctx}
+        {send_link_cursor(ctx, caches), ctx}
       end
     )
   end

--- a/test/minga/frontend/adapter/gui/wire_test.exs
+++ b/test/minga/frontend/adapter/gui/wire_test.exs
@@ -1,0 +1,16 @@
+defmodule Minga.Frontend.Adapter.GUI.WireTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Frontend.Adapter.GUI.EncodingError
+  alias Minga.Frontend.Adapter.GUI.Wire
+
+  test "section carrier rejects an oversized payload with structured metadata" do
+    error =
+      assert_raise EncodingError, fn ->
+        Wire.encode_section(1, String.duplicate("x", Wire.max_u16() + 1))
+      end
+
+    assert %{command: :gui_section, field: :payload_length, actual: 65_536, min: 0, max: 65_535} =
+             error
+  end
+end


### PR DESCRIPTION
Partial follow-up for #2737.

Centralizes checked GUI encoding in the adapter and makes `Emit` suppress Port writes, reset GUI frame caches, and force a keyframe after a structured encoder error. The shared 16-bit section carrier now reports command, field, actual value, and allowed range.

Verification:
- `mix test.llm test/minga/frontend/adapter/gui/wire_test.exs test/minga/frontend/adapter/gui_test.exs test/minga_editor/frontend/emit_test.exs`

This does not close #2737.