### PR TITLE
chore(dev): seed Expert worktree build cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,8 +142,8 @@ All feature branches use git worktrees. This keeps the main checkout clean and l
    scripts/create_worktree <branch-name>
    ```
 2. Do all work inside the created worktree under `../minga-worktrees/`. The agent's working directory must be set to the worktree, not the main checkout.
-3. The helper copies `deps/`, `_build/`, and ElixirLS PLTs into the new worktree when `mix.lock` matches, which keeps first-run `mix` commands and Dialyzer fast. If the helper skips the copy, run `mix deps.get` and let the worktree rebuild normally.
-4. Run the helper from any Minga checkout, but only when no `mix` command is active in the source checkout or target worktree. Copying build caches while they are being written can produce confusing compile or Dialyzer failures.
+3. The helper copies `deps/`, `_build/`, and Expert's `.expert/build/` cache into the new worktree when `mix.lock` matches, which keeps first-run Mix commands, Dialyzer, and Expert fast. It intentionally skips Expert's project indexes because they are large and worktree-specific. If the helper skips the copy, run `mix deps.get` and let the worktree rebuild normally.
+4. Run the helper from any Minga checkout, but only when no Mix or Expert command is active in the source checkout or target worktree. Copying build caches while they are being written can produce confusing compile, Dialyzer, or Expert failures.
 
 **After the PR is merged:**
 

--- a/scripts/create_worktree
+++ b/scripts/create_worktree
@@ -5,9 +5,9 @@ usage() {
   cat <<'USAGE'
 Usage: scripts/create_worktree <branch-name> [base-ref]
 
-Creates a worktree under ../minga-worktrees/ relative to the primary checkout and copies local Mix caches into it so the first mix command does not start cold.
+Creates a worktree under ../minga-worktrees/ relative to the primary checkout and copies local development caches into it so the first Mix and Expert commands do not start cold.
 
-Run this from any Minga checkout when no mix command is active in the source checkout.
+Run this from any Minga checkout when no Mix or Expert command is active in the source checkout.
 USAGE
 }
 
@@ -70,29 +70,21 @@ copy_dir() {
   fi
 }
 
-copy_elixir_ls_plts() {
-  local source_dir="$repo_root/.elixir_ls"
-  local target_dir="$worktree_path/.elixir_ls"
+copy_expert_builds() {
+  local source_dir="$repo_root/.expert/build"
+  local target_dir="$worktree_path/.expert/build"
   if [[ ! -d "$source_dir" ]]; then
     return 0
   fi
 
-  shopt -s nullglob
-  local plts=("$source_dir"/iplt-*)
-  shopt -u nullglob
-
-  if [[ ${#plts[@]} -eq 0 ]]; then
-    return 0
-  fi
-
-  echo "Copying .elixir_ls PLTs"
-  mkdir -p "$target_dir"
-  rsync -a "${plts[@]}" "$target_dir/"
+  echo "Copying .expert/build/"
+  mkdir -p "$(dirname "$target_dir")"
+  rsync -a "$source_dir/" "$target_dir/"
 }
 
 copy_dir deps
 copy_dir _build
-copy_elixir_ls_plts
+copy_expert_builds
 
 echo "Worktree ready: $worktree_path"
 echo "Next: cd $worktree_path && mix deps.get"


### PR DESCRIPTION
# TL;DR

New worktrees seed Expert’s project build cache instead of obsolete ElixirLS PLTs, avoiding a cold Expert compile without copying its multi-gigabyte workspace indexes.

## Changes

- Copy `.expert/build/` alongside the existing `deps/` and `_build/` caches.
- Exclude Expert indexes and logs because indexes are large and specific to each worktree.
- Update the worktree guidance with the Expert cache behavior and its no-concurrent-process requirement.

## Verification

- Created a temporary Git fixture and verified that the helper copies `deps/`, `_build/`, and `.expert/build/`, but not `.expert/indexes/`.
- `bash -n scripts/create_worktree`
- `make lint`
- `mix test.llm` (9893 tests, 0 failures)