### PR TITLE
ci(macos): remove duplicate Release test pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,16 +409,6 @@ jobs:
             -derivedDataPath DerivedData \
             CODE_SIGNING_ALLOWED=NO
 
-      - name: Release protocol tests
-        run: |
-          cd macos
-          xcodebuild test \
-            -scheme Minga \
-            -configuration Release \
-            -derivedDataPath DerivedData \
-            CODE_SIGNING_ALLOWED=NO \
-            ENABLE_TESTABILITY=YES
-
   swift-integration:
     name: Swift Protocol Integration
     runs-on: macos-15


### PR DESCRIPTION
# TL;DR

Swift CI keeps the Release optimization verifier but no longer rebuilds and runs the entire Swift test suite under Release after the Debug suite has already covered behavior.

## Context

The Release test command added for #2738 duplicated all 1,050 Swift tests. Recent runs spent 6 to 7 minutes in that step, almost entirely recompiling the test bundle with `-O`.

## Changes

- Remove the duplicate `xcodebuild test -configuration Release` invocation.
- Keep `scripts/check_macos_release_optimization`, which verifies the resolved Release setting is `-O`.
- Keep the existing Debug build and complete Swift test suite.

## Verification

- `ruby -e "require "yaml"; YAML.load_file(".github/workflows/ci.yml")"`
- `mix test.llm test/scripts/macos_release_optimization_test.exs`
- `make lint`
- `mix test.llm` (9,893 tests, 0 failures)