### PR TITLE
fix(protocol): validate GUI string carriers

### DIFF
--- a/lib/minga/frontend/adapter/gui/change_summary_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/change_summary_encoder.ex
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.ChangeSummaryEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.ChangeSummary
 
@@ -27,9 +28,28 @@ defmodule Minga.Frontend.Adapter.GUI.ChangeSummaryEncoder do
         path_bytes = :erlang.iolist_to_binary([entry.path])
         action_byte = action_byte(entry.action)
 
+        Wire.validate_uint!(
+          :gui_change_summary,
+          :path_length,
+          byte_size(path_bytes),
+          Wire.max_u16()
+        )
+
+        Wire.validate_uint!(:gui_change_summary, :lines_added, entry.lines_added, Wire.max_u32())
+
+        Wire.validate_uint!(
+          :gui_change_summary,
+          :lines_removed,
+          entry.lines_removed,
+          Wire.max_u32()
+        )
+
         <<byte_size(path_bytes)::16, path_bytes::binary, action_byte::8, entry.lines_added::32,
           entry.lines_removed::32>>
       end)
+
+    Wire.validate_uint!(:gui_change_summary, :selected_index, selected_index, Wire.max_u16())
+    Wire.validate_uint!(:gui_change_summary, :entry_count, Enum.count(entries), Wire.max_u16())
 
     IO.iodata_to_binary([
       <<@op_gui_change_summary, visible::8, selected_index::16, Enum.count(entries)::16>>

--- a/lib/minga/frontend/adapter/gui/wire.ex
+++ b/lib/minga/frontend/adapter/gui/wire.ex
@@ -58,12 +58,14 @@ defmodule Minga.Frontend.Adapter.GUI.Wire do
   @spec encode_string8(iodata()) :: binary()
   def encode_string8(value) do
     bytes = :erlang.iolist_to_binary([value])
+    validate_uint!(:gui_string, :byte_length, byte_size(bytes), @max_u8)
     <<byte_size(bytes)::8, bytes::binary>>
   end
 
   @spec encode_string16(iodata()) :: binary()
   def encode_string16(value) do
     bytes = :erlang.iolist_to_binary([value])
+    validate_uint!(:gui_string, :byte_length, byte_size(bytes), @max_u16)
     <<byte_size(bytes)::16, bytes::binary>>
   end
 

--- a/test/minga/frontend/adapter/gui/wire_test.exs
+++ b/test/minga/frontend/adapter/gui/wire_test.exs
@@ -13,4 +13,14 @@ defmodule Minga.Frontend.Adapter.GUI.WireTest do
     assert %{command: :gui_section, field: :payload_length, actual: 65_536, min: 0, max: 65_535} =
              error
   end
+
+  test "string carriers reject oversized values with their wire limit" do
+    error = assert_raise EncodingError, fn -> Wire.encode_string8(String.duplicate("x", 256)) end
+    assert %{command: :gui_string, field: :byte_length, actual: 256, max: 255} = error
+
+    error =
+      assert_raise EncodingError, fn -> Wire.encode_string16(String.duplicate("x", 65_536)) end
+
+    assert %{command: :gui_string, field: :byte_length, actual: 65_536, max: 65_535} = error
+  end
 end


### PR DESCRIPTION
Partial follow-up for #2737.

Routes shared 8-bit and 16-bit GUI string carriers through the existing structured range validation at the wire boundary.

Verification: `mix test.llm test/minga/frontend/adapter/gui/wire_test.exs`

This does not close #2737.