### PR TITLE
fix(protocol): validate extension panel bounds

### DIFF
--- a/lib/minga/frontend/adapter/gui/extension_panel_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/extension_panel_encoder.ex
@@ -32,10 +32,11 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionPanelEncoder do
 
   @spec encode_command(ExtensionPanel.t()) :: binary()
   def encode_command(%ExtensionPanel{} = model) do
-    {panel_binaries, _remaining_budget} =
-      Wire.bounded_entries(model.panels, &encode_panel/1, Wire.max_u8(), Wire.max_u16() - 1)
+    validate_uint!(:panel_count, Enum.count(model.panels), Wire.max_u8())
+    panel_binaries = Enum.map(model.panels, &encode_panel/1)
 
     payload = IO.iodata_to_binary([<<Enum.count(panel_binaries)::8>> | panel_binaries])
+    validate_uint!(:payload_length, byte_size(payload), Wire.max_u16())
     <<@op_gui_extension_panel, byte_size(payload)::16, payload::binary>>
   end
 
@@ -44,22 +45,21 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionPanelEncoder do
 
   @spec encode_panel(Panel.t()) :: binary()
   defp encode_panel(%Panel{} = panel) do
-    ext = Wire.utf8_prefix_bytes(panel.extension, Wire.max_u8())
-    panel_id = Wire.utf8_prefix_bytes(panel.panel_id, Wire.max_u8())
-    title = Wire.utf8_prefix_bytes(panel.title, Wire.max_u8())
+    ext = encode_string8(panel.extension, :extension_length)
+    panel_id = encode_string8(panel.panel_id, :panel_id_length)
+    title = encode_string8(panel.title, :title_length)
     {size_type, size_val} = encode_size(panel.size)
     position = encode_position(panel.position)
     visible = if panel.visible?, do: 1, else: 0
     {blocks, block_count} = encode_content_blocks(panel.content)
 
-    <<byte_size(ext)::8, ext::binary, byte_size(panel_id)::8, panel_id::binary,
-      byte_size(title)::8, title::binary, position::8, size_type::8, size_val::8, visible::8,
-      block_count::8, blocks::binary>>
+    <<ext::binary, panel_id::binary, title::binary, position::8, size_type::8, size_val::8,
+      visible::8, block_count::8, blocks::binary>>
   end
 
   @spec encode_size(Panel.size()) :: {non_neg_integer(), non_neg_integer()}
-  defp encode_size({:percent, n}), do: {0, Wire.clamp_u8(n)}
-  defp encode_size({:lines, n}), do: {1, Wire.clamp_u8(n)}
+  defp encode_size({:percent, n}), do: {0, validate_value!(n, :size_percent, Wire.max_u8())}
+  defp encode_size({:lines, n}), do: {1, validate_value!(n, :size_lines, Wire.max_u8())}
 
   @spec encode_position(Panel.position()) :: non_neg_integer()
   defp encode_position(:bottom), do: 0
@@ -68,37 +68,42 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionPanelEncoder do
 
   @spec encode_content_blocks([Panel.content_block()]) :: {binary(), non_neg_integer()}
   defp encode_content_blocks(blocks) do
-    {block_binaries, _remaining_budget} =
-      Wire.bounded_entries(blocks, &encode_content_block/1, Wire.max_u8(), Wire.max_u16())
+    validate_uint!(:block_count, Enum.count(blocks), Wire.max_u8())
+    block_binaries = Enum.map(blocks, &encode_content_block/1)
 
     {IO.iodata_to_binary(block_binaries), Enum.count(block_binaries)}
   end
 
   @spec encode_content_block(Panel.content_block()) :: binary()
   defp encode_content_block(%Text{text: text}) do
-    text = Wire.utf8_prefix_bytes(text, Wire.max_u16())
-    <<0::8, byte_size(text)::16, text::binary>>
+    <<0::8, encode_string16(text, :text_length)::binary>>
   end
 
   defp encode_content_block(%StyledText{runs: runs}) do
-    {run_binaries, _remaining_budget} =
-      Wire.bounded_entries(runs, &encode_styled_run/1, Wire.max_u8(), Wire.max_u16())
+    validate_uint!(:styled_run_count, Enum.count(runs), Wire.max_u8())
+    run_binaries = Enum.map(runs, &encode_styled_run/1)
 
     run_data = IO.iodata_to_binary(run_binaries)
     <<1::8, Enum.count(run_binaries)::8, run_data::binary>>
   end
 
   defp encode_content_block(%Table{} = table) do
-    columns = Enum.take(table.columns, Wire.max_u8())
-    rows = Enum.take(table.rows, Wire.max_u16())
+    columns = table.columns
+    rows = table.rows
+    validate_uint!(:table_column_count, Enum.count(columns), Wire.max_u8())
+    validate_uint!(:table_row_count, Enum.count(rows), Wire.max_u16())
 
     col_data =
-      IO.iodata_to_binary(Enum.map(columns, fn col -> encode_string16(col) end))
+      IO.iodata_to_binary(
+        Enum.map(columns, fn col -> encode_string16(col, :table_column_length) end)
+      )
 
     row_data =
       IO.iodata_to_binary(
         Enum.map(rows, fn row ->
-          IO.iodata_to_binary(Enum.map(row, fn cell -> encode_string16(cell) end))
+          IO.iodata_to_binary(
+            Enum.map(row, fn cell -> encode_string16(cell, :table_cell_length) end)
+          )
         end)
       )
 
@@ -109,12 +114,12 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionPanelEncoder do
   end
 
   defp encode_content_block(%KeyValue{pairs: pairs}) do
-    pairs = Enum.take(pairs, Wire.max_u8())
+    validate_uint!(:key_value_count, Enum.count(pairs), Wire.max_u8())
 
     pair_data =
       IO.iodata_to_binary(
         Enum.map(pairs, fn {key, value} ->
-          [encode_string16(key), encode_string16(value)]
+          [encode_string16(key, :key_length), encode_string16(value, :value_length)]
         end)
       )
 
@@ -126,13 +131,15 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionPanelEncoder do
   end
 
   defp encode_content_block(%Progress{label: label, percent: percent}) do
-    label = Wire.utf8_prefix_bytes(label, Wire.max_u16())
-    percent_int = percent |> Kernel.*(100) |> round() |> Wire.clamp_u16()
-    <<5::8, byte_size(label)::16, label::binary, percent_int::16>>
+    percent_int =
+      percent |> Kernel.*(100) |> round() |> validate_value!(:progress_percent, Wire.max_u16())
+
+    <<5::8, encode_string16(label, :progress_label_length)::binary, percent_int::16>>
   end
 
   defp encode_content_block(%Tree{nodes: nodes}) do
-    node_data = encode_tree_nodes(nodes, Wire.max_u16() - 2)
+    node_data = encode_tree_nodes(nodes)
+    validate_uint!(:tree_length, byte_size(node_data), Wire.max_u16())
     <<6::8, byte_size(node_data)::16, node_data::binary>>
   end
 
@@ -148,41 +155,59 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionPanelEncoder do
 
   @spec encode_styled_run(StyledRun.t()) :: binary()
   defp encode_styled_run(%StyledRun{} = run) do
-    text = Wire.utf8_prefix_bytes(run.text, Wire.max_u16())
     bold = if Map.get(run.attrs, :bold?, false), do: 1, else: 0
     italic = if Map.get(run.attrs, :italic?, false), do: 1, else: 0
     {r, g, b} = Wire.rgb(run.fg)
-    <<byte_size(text)::16, text::binary, r::8, g::8, b::8, bold::8, italic::8>>
+
+    <<encode_string16(run.text, :styled_run_length)::binary, r::8, g::8, b::8, bold::8,
+      italic::8>>
   end
 
-  @spec encode_tree_nodes([TreeNode.t()], non_neg_integer()) :: binary()
-  defp encode_tree_nodes(nodes, budget) do
-    {data, count} = encode_tree_node_list(nodes, budget)
+  @spec encode_tree_nodes([TreeNode.t()]) :: binary()
+  defp encode_tree_nodes(nodes) do
+    {data, count} = encode_tree_node_list(nodes)
     IO.iodata_to_binary([<<count::8>>, data])
   end
 
-  @spec encode_tree_node_list([TreeNode.t()], non_neg_integer()) :: {binary(), non_neg_integer()}
-  defp encode_tree_node_list(nodes, budget) do
-    {node_binaries, _remaining_budget} =
-      Wire.bounded_entries(nodes, &encode_tree_node/1, Wire.max_u8(), max(budget - 1, 0))
+  @spec encode_tree_node_list([TreeNode.t()]) :: {binary(), non_neg_integer()}
+  defp encode_tree_node_list(nodes) do
+    validate_uint!(:tree_node_count, Enum.count(nodes), Wire.max_u8())
+    node_binaries = Enum.map(nodes, &encode_tree_node/1)
 
     {IO.iodata_to_binary(node_binaries), Enum.count(node_binaries)}
   end
 
   @spec encode_tree_node(TreeNode.t()) :: binary()
   defp encode_tree_node(%TreeNode{} = node) do
-    label = Wire.utf8_prefix_bytes(node.label, Wire.max_u16())
     expanded = if node.expanded?, do: 1, else: 0
-    child_budget = max(Wire.max_u16() - byte_size(label) - 4, 0)
-    {child_nodes, child_count} = encode_tree_node_list(node.children, child_budget)
+    {child_nodes, child_count} = encode_tree_node_list(node.children)
     child_data = IO.iodata_to_binary([<<child_count::8>>, child_nodes])
 
-    <<byte_size(label)::16, label::binary, expanded::8, child_count::8, child_data::binary>>
+    <<encode_string16(node.label, :tree_label_length)::binary, expanded::8, child_count::8,
+      child_data::binary>>
   end
 
-  @spec encode_string16(iodata()) :: binary()
-  defp encode_string16(value) do
-    bytes = Wire.utf8_prefix_bytes(value, Wire.max_u16())
+  @spec encode_string16(iodata(), atom()) :: binary()
+  defp encode_string16(value, field) do
+    bytes = :erlang.iolist_to_binary([value])
+    validate_uint!(field, byte_size(bytes), Wire.max_u16())
     <<byte_size(bytes)::16, bytes::binary>>
   end
+
+  @spec encode_string8(iodata(), atom()) :: binary()
+  defp encode_string8(value, field) do
+    bytes = :erlang.iolist_to_binary([value])
+    validate_uint!(field, byte_size(bytes), Wire.max_u8())
+    <<byte_size(bytes)::8, bytes::binary>>
+  end
+
+  @spec validate_value!(term(), atom(), non_neg_integer()) :: non_neg_integer()
+  defp validate_value!(value, field, max) do
+    validate_uint!(field, value, max)
+    value
+  end
+
+  @spec validate_uint!(atom(), term(), non_neg_integer()) :: :ok
+  defp validate_uint!(field, value, max),
+    do: Wire.validate_uint!(:gui_extension_panel, field, value, max)
 end

--- a/test/minga/frontend/adapter/gui/extension_panel_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/extension_panel_encoder_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionPanelEncoderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.Frontend.Adapter.GUI.ExtensionPanelEncoder
   alias Minga.RenderModel.UI.ExtensionPanel
   alias Minga.RenderModel.UI.ExtensionPanel.Content.KeyValue
@@ -140,26 +141,17 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionPanelEncoderTest do
                ProtocolGUI.encode_gui_extension_panels(legacy_panels)
     end
 
-    test "bounds extension-controlled counts and 8-bit strings" do
+    test "rejects extension-controlled counts before truncating the command" do
       long_text = String.duplicate("å", 300)
       panels = for index <- 1..300, do: oversized_panel(index, long_text)
 
-      command = ExtensionPanelEncoder.encode_command(%ExtensionPanel{panels: panels})
+      error =
+        assert_raise EncodingError, fn ->
+          ExtensionPanelEncoder.encode_command(%ExtensionPanel{panels: panels})
+        end
 
-      <<@op_gui_extension_panel, payload_len::16, payload::binary-size(payload_len)>> = command
-      <<panel_count::8, first_panel::binary>> = payload
-
-      <<ext_len::8, ext::binary-size(ext_len), panel_id_len::8,
-        panel_id::binary-size(panel_id_len), title_len::8, title::binary-size(title_len),
-        _rest::binary>> = first_panel
-
-      assert panel_count <= 255
-      assert ext_len <= 255
-      assert panel_id_len <= 255
-      assert title_len <= 255
-      assert String.valid?(ext)
-      assert String.valid?(panel_id)
-      assert String.valid?(title)
+      assert %{command: :gui_extension_panel, field: :panel_count, actual: 300, min: 0, max: 255} =
+               error
     end
   end
 


### PR DESCRIPTION
# TL;DR

Extension-panel commands now reject out-of-range data instead of truncating panels, strings, content blocks, tables, or tree nodes.

Part of #2737

## Changes

- Replace extension-panel string prefix truncation and collection budget dropping with checked carriers.
- Validate u8/u16 counts, string lengths, payload lengths, sizes, and progress values before command construction.
- Preserve byte-identical output for valid legacy-compatible payloads.

## Verification

- `mix test.debug test/minga/frontend/adapter/gui/extension_panel_encoder_test.exs`
- `mix test.llm test/minga/frontend/adapter/gui/extension_panel_encoder_test.exs test/minga/frontend/adapter/gui_test.exs test/minga_editor/frontend/emit_test.exs`

## Acceptance Criteria Addressed

- Partially advances #2737 AC 3 for the extension-panel command. Remaining handwritten encoder families remain open.