### PR TITLE
fix(protocol): validate extension overlay bounds

### DIFF
--- a/lib/minga/frontend/adapter/gui/extension_overlay_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/extension_overlay_encoder.ex
@@ -22,10 +22,11 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionOverlayEncoder do
 
   @spec encode_command(ExtensionOverlay.t()) :: binary()
   def encode_command(%ExtensionOverlay{} = model) do
-    {overlay_binaries, _remaining_budget} =
-      Wire.bounded_entries(model.entries, &encode_entry/1, Wire.max_u8(), Wire.max_u16() - 1)
+    validate!(:entry_count, Enum.count(model.entries), Wire.max_u8())
+    overlay_binaries = Enum.map(model.entries, &encode_entry/1)
 
     payload = IO.iodata_to_binary([<<Enum.count(overlay_binaries)::8>> | overlay_binaries])
+    validate!(:payload_length, byte_size(payload), Wire.max_u16())
     <<@op_gui_extension_overlay, byte_size(payload)::16, payload::binary>>
   end
 
@@ -34,16 +35,19 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionOverlayEncoder do
 
   @spec encode_entry(Entry.t()) :: binary()
   defp encode_entry(%Entry{} = entry) do
-    ext_name = Wire.utf8_prefix_bytes(to_string(entry.extension), Wire.max_u8())
-    oid = Wire.utf8_prefix_bytes(to_string(entry.overlay_id), Wire.max_u8())
-    content = Wire.utf8_prefix_bytes(entry.content, Wire.max_u16())
+    ext_name = encode_string8(to_string(entry.extension), :extension_length)
+    oid = encode_string8(to_string(entry.overlay_id), :overlay_id_length)
+    content = encode_string16(entry.content, :content_length)
     {r, g, b} = Wire.rgb(entry.fg)
     shape = overlay_shape_byte(entry.shape)
 
-    <<byte_size(ext_name)::8, ext_name::binary, byte_size(oid)::8, oid::binary,
-      Wire.clamp_u16(entry.window_id)::16, Wire.clamp_u16(entry.row)::16,
-      Wire.clamp_u16(entry.col)::16, shape::8, r::8, g::8, b::8, Wire.clamp_u8(entry.opacity)::8,
-      byte_size(content)::16, content::binary>>
+    validate!(:window_id, entry.window_id, Wire.max_u16())
+    validate!(:row, entry.row, Wire.max_u16())
+    validate!(:col, entry.col, Wire.max_u16())
+    validate!(:opacity, entry.opacity, Wire.max_u8())
+
+    <<ext_name::binary, oid::binary, entry.window_id::16, entry.row::16, entry.col::16, shape::8,
+      r::8, g::8, b::8, entry.opacity::8, content::binary>>
   end
 
   @spec overlay_shape_byte(Entry.shape()) :: non_neg_integer()
@@ -52,4 +56,22 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionOverlayEncoder do
   defp overlay_shape_byte(:label), do: 2
   defp overlay_shape_byte(:indicator), do: 3
   defp overlay_shape_byte(_shape), do: 3
+
+  @spec encode_string8(iodata(), atom()) :: binary()
+  defp encode_string8(value, field) do
+    bytes = :erlang.iolist_to_binary([value])
+    validate!(field, byte_size(bytes), Wire.max_u8())
+    <<byte_size(bytes)::8, bytes::binary>>
+  end
+
+  @spec encode_string16(iodata(), atom()) :: binary()
+  defp encode_string16(value, field) do
+    bytes = :erlang.iolist_to_binary([value])
+    validate!(field, byte_size(bytes), Wire.max_u16())
+    <<byte_size(bytes)::16, bytes::binary>>
+  end
+
+  @spec validate!(atom(), term(), non_neg_integer()) :: :ok
+  defp validate!(field, value, max),
+    do: Wire.validate_uint!(:gui_extension_overlay, field, value, max)
 end

--- a/test/minga/frontend/adapter/gui/extension_overlay_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/extension_overlay_encoder_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionOverlayEncoderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.Frontend.Adapter.GUI.ExtensionOverlayEncoder
   alias Minga.RenderModel.UI.ExtensionOverlay
   alias Minga.RenderModel.UI.ExtensionOverlay.Entry
@@ -68,77 +69,59 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionOverlayEncoderTest do
                ProtocolGUI.encode_gui_extension_overlays(legacy_entries)
     end
 
-    test "bounds extension-controlled counts and 8-bit strings" do
+    test "rejects extension-controlled counts before truncating the command" do
       long_text = String.duplicate("å", 300)
 
       entries =
         for index <- 1..300,
             do: entry(extension: long_text, overlay_id: "overlay-#{index}-#{long_text}")
 
-      command = ExtensionOverlayEncoder.encode_command(%ExtensionOverlay{entries: entries})
+      error =
+        assert_raise EncodingError, fn ->
+          ExtensionOverlayEncoder.encode_command(%ExtensionOverlay{entries: entries})
+        end
 
-      <<@op_gui_extension_overlay, payload_len::16, payload::binary-size(payload_len)>> = command
-      <<entry_count::8, first_entry::binary>> = payload
-
-      <<ext_len::8, ext::binary-size(ext_len), overlay_id_len::8,
-        overlay_id::binary-size(overlay_id_len), _rest::binary>> = first_entry
-
-      assert entry_count <= 255
-      assert ext_len <= 255
-      assert overlay_id_len <= 255
-      assert String.valid?(ext)
-      assert String.valid?(overlay_id)
+      assert %{command: :gui_extension_overlay, field: :entry_count, actual: 300} = error
     end
 
-    test "clamps numeric overlay bounds with a normal payload" do
-      command =
-        ExtensionOverlayEncoder.encode_command(%ExtensionOverlay{
-          entries: [
-            entry(
-              extension: "e",
-              overlay_id: "o",
-              window_id: 99_999,
-              row: 99_999,
-              col: 99_999,
-              opacity: 999,
-              content: "abc"
-            )
-          ]
-        })
+    test "rejects out-of-range numeric overlay fields" do
+      error =
+        assert_raise EncodingError, fn ->
+          ExtensionOverlayEncoder.encode_command(%ExtensionOverlay{
+            entries: [
+              entry(
+                extension: "e",
+                overlay_id: "o",
+                window_id: 99_999,
+                row: 99_999,
+                col: 99_999,
+                opacity: 999,
+                content: "abc"
+              )
+            ]
+          })
+        end
 
-      <<@op_gui_extension_overlay, payload_len::16, payload::binary-size(payload_len)>> = command
-      <<1::8, first_entry::binary>> = payload
-
-      <<ext_len::8, _ext::binary-size(ext_len), overlay_id_len::8,
-        _overlay_id::binary-size(overlay_id_len), window_id::16, row::16, col::16, _shape::8,
-        _r::8, _g::8, _b::8, opacity::8, content_len::16, content::binary-size(content_len)>> =
-        first_entry
-
-      assert ext_len == 1
-      assert overlay_id_len == 1
-      assert window_id == 0xFFFF
-      assert row == 0xFFFF
-      assert col == 0xFFFF
-      assert opacity == 255
-      assert content_len == 3
-      assert content == "abc"
+      assert %{field: :window_id, actual: 99_999} = error
     end
 
-    test "drops oversized overlay content when the encoded entry exceeds the budget" do
+    test "rejects oversized overlay content" do
       long_content = String.duplicate("a", 70_000)
 
-      command =
-        ExtensionOverlayEncoder.encode_command(%ExtensionOverlay{
-          entries: [
-            entry(
-              extension: "e",
-              overlay_id: "o",
-              content: long_content
-            )
-          ]
-        })
+      error =
+        assert_raise EncodingError, fn ->
+          ExtensionOverlayEncoder.encode_command(%ExtensionOverlay{
+            entries: [
+              entry(
+                extension: "e",
+                overlay_id: "o",
+                content: long_content
+              )
+            ]
+          })
+        end
 
-      assert command == <<@op_gui_extension_overlay, 1::16, 0>>
+      assert %{field: :content_length, actual: 70_000} = error
     end
   end
 


### PR DESCRIPTION
Part of #2737.

Rejects oversized extension-overlay entry counts, strings, coordinates, opacity, and payloads with structured encoding errors before bytes are emitted.

Verification: `mix test.debug test/minga/frontend/adapter/gui/extension_overlay_encoder_test.exs`; `mix test.llm test/minga/frontend/adapter/gui/extension_overlay_encoder_test.exs test/minga/frontend/adapter/gui_test.exs test/minga_editor/frontend/emit_test.exs`.

AC 3 partial: extension overlay is covered; other handwritten encoder families remain.