### PR TITLE
fix(protocol): handle invalid surface layout frames

### DIFF
--- a/lib/minga/frontend/adapter/gui/encoding_error.ex
+++ b/lib/minga/frontend/adapter/gui/encoding_error.ex
@@ -7,7 +7,7 @@ defmodule Minga.Frontend.Adapter.GUI.EncodingError do
   @type t :: %__MODULE__{
           command: atom(),
           field: atom(),
-          actual: integer(),
+          actual: term(),
           min: integer(),
           max: integer()
         }
@@ -15,6 +15,6 @@ defmodule Minga.Frontend.Adapter.GUI.EncodingError do
   @impl Exception
   @spec message(t()) :: String.t()
   def message(%__MODULE__{} = error) do
-    "cannot encode #{error.command}.#{error.field}=#{error.actual}; expected #{error.min}..#{error.max}"
+    "cannot encode #{error.command}.#{error.field}=#{inspect(error.actual)}; expected #{error.min}..#{error.max}"
   end
 end

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -157,6 +157,15 @@ defmodule MingaEditor.Frontend.Emit do
         {send_link_cursor(ctx, caches), ctx}
       end
     )
+  rescue
+    error in Minga.Frontend.Adapter.GUI.EncodingError ->
+      Minga.Log.warning(:render, "Discarded invalid GUI frame: #{Exception.message(error)}")
+
+      {%{
+         caches
+         | adapter_gui_caches: Minga.Frontend.Adapter.GUI.Caches.new(),
+           last_emitted_frame_seq: 0
+       }, ctx}
   end
 
   # The async render path threads Renderer.Server's monotonic seq through the

--- a/test/minga/frontend/adapter/gui/surface_layout_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/surface_layout_encoder_test.exs
@@ -1,0 +1,51 @@
+defmodule Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoderTest do
+  use ExUnit.Case, async: true
+  alias Minga.Frontend.Adapter.GUI.{EncodingError, SurfaceLayoutEncoder}
+  @u16_fields [:surface_id, :row, :col, :width, :height, :z]
+  defp placement,
+    do: %{surface_id: 1, rect: %{row: 2, col: 3, width: 40, height: 20}, z: 4, hit_kind: 5}
+
+  test "rejects negative and overflowing values for every bounded field" do
+    for field <- @u16_fields ++ [:hit_kind], value <- [-1, 65_536] do
+      error =
+        assert_raise EncodingError, fn ->
+          SurfaceLayoutEncoder.encode_command([put_field(placement(), field, value)])
+        end
+
+      assert error.command == :gui_surface_layout
+      assert error.field == field
+      assert error.actual == value
+      assert error.min == 0
+      assert error.max == if(field == :hit_kind, do: 255, else: 65_535)
+    end
+  end
+
+  test "accepts the wire maximum for every bounded field" do
+    for field <- @u16_fields,
+        do:
+          assert(
+            is_binary(
+              SurfaceLayoutEncoder.encode_command([put_field(placement(), field, 65_535)])
+            )
+          )
+
+    assert is_binary(
+             SurfaceLayoutEncoder.encode_command([put_field(placement(), :hit_kind, 255)])
+           )
+  end
+
+  test "formats non-integer values safely in encoding errors" do
+    error =
+      assert_raise EncodingError, fn ->
+        SurfaceLayoutEncoder.encode_command([put_field(placement(), :z, %{})])
+      end
+
+    assert Exception.message(error) =~ "z=%{}"
+  end
+
+  defp put_field(placement, field, value) when field in [:surface_id, :z, :hit_kind],
+    do: Map.put(placement, field, value)
+
+  defp put_field(placement, field, value) when field in [:row, :col, :width, :height],
+    do: %{placement | rect: Map.put(placement.rect, field, value)}
+end


### PR DESCRIPTION
## Summary
- keep invalid surface-layout validation inside the frame error boundary
- format arbitrary invalid values safely
- add focused boundary and rejection tests

## Validation
- mix test test/minga/frontend/adapter/gui/surface_layout_encoder_test.exs test/minga_editor/frontend/emit/surface_layout_emit_test.exs

Closes #2774