### PR TITLE
fix(frontend): reject bounded GUI wire fields

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -31,6 +31,7 @@
           {Minga.Credo.NoDirectStateMachineWriteCheck, []},
           {Minga.Credo.NoDirectModalOverlayWriteCheck, []},
           {Minga.Credo.NoRawWorkspaceSnapshotCheck, []},
+          {Minga.Credo.NoLossyGuiEncoderCheck, []},
           {Minga.Credo.CommandRegistrationCheck, []},
 
           # ── Editor responsiveness (epic #2445) ─────────────────────────────

--- a/credo/checks/no_lossy_gui_encoder_check.exs
+++ b/credo/checks/no_lossy_gui_encoder_check.exs
@@ -1,0 +1,140 @@
+defmodule Minga.Credo.NoLossyGuiEncoderCheck do
+  @moduledoc false
+
+  use Credo.Check,
+    id: "EX9014",
+    base_priority: :high,
+    category: :warning,
+    explanations: [
+      check: """
+      GUI adapter encoders must not silently clamp, truncate, or drop data to fit a wire field. Use Minga.Frontend.Adapter.GUI.Wire.Writer so an out-of-range value raises EncodingError with command and field metadata. See #2737.
+      """
+    ]
+
+  @impl Credo.Check
+  @spec run(Credo.SourceFile.t(), keyword()) :: [Credo.Issue.t()]
+  def run(%SourceFile{} = source_file, params) do
+    if gui_encoder_file?(source_file) do
+      issue_meta = IssueMeta.for(source_file, params)
+
+      source_file
+      |> Credo.Code.prewalk(&find_lossy_encoder_call(&1, &2, issue_meta))
+      |> List.flatten()
+    else
+      []
+    end
+  end
+
+  defp find_lossy_encoder_call({:min, meta, _args} = ast, issues, issue_meta),
+    do: issue(ast, issues, issue_meta, meta, "min")
+
+  defp find_lossy_encoder_call({:&&&, meta, _args} = ast, issues, issue_meta),
+    do: issue(ast, issues, issue_meta, meta, "&&&")
+
+  defp find_lossy_encoder_call({:utf8_prefix_bytes, meta, _args} = ast, issues, issue_meta),
+    do: issue(ast, issues, issue_meta, meta, "utf8_prefix_bytes")
+
+  defp find_lossy_encoder_call({:<<>>, _, segments} = ast, issues, issue_meta) do
+    issues = Enum.reduce(segments, issues, &dynamic_bounded_segment_issue(&1, &2, issue_meta))
+    {ast, issues}
+  end
+
+  defp find_lossy_encoder_call(
+         {{:., _, [module, function]}, meta, _args} = ast,
+         issues,
+         issue_meta
+       )
+       when function in [
+              :bounded_entries,
+              :clamp_u8,
+              :clamp_u16,
+              :clamp_u32,
+              :encode_section,
+              :encode_string8,
+              :encode_string16,
+              :reduce_while,
+              :rgb,
+              :take,
+              :utf8_prefix_bytes,
+              :validate_uint!
+            ] do
+    if lossy_remote_call?(alias_name(module), function) do
+      issue(ast, issues, issue_meta, meta, Atom.to_string(function))
+    else
+      {ast, issues}
+    end
+  end
+
+  defp find_lossy_encoder_call(ast, issues, _issue_meta), do: {ast, issues}
+
+  defp dynamic_bounded_segment_issue(
+         {:"::", meta, [value, {:-, _, [{:signed, _, _}, 32]}]},
+         issues,
+         issue_meta
+       ) do
+    dynamic_bounded_segment_issue(value, issues, issue_meta, meta, "::32-signed")
+  end
+
+  defp dynamic_bounded_segment_issue({:"::", meta, [value, width]}, issues, issue_meta)
+       when width in [8, 16, 24, 32, 64] do
+    dynamic_bounded_segment_issue(value, issues, issue_meta, meta, "::#{width}")
+  end
+
+  defp dynamic_bounded_segment_issue(_segment, issues, _issue_meta), do: issues
+
+  defp dynamic_bounded_segment_issue(value, issues, issue_meta, meta, trigger) do
+    if dynamic_wire_value?(value) do
+      {_ast, issues} = issue(value, issues, issue_meta, meta, trigger)
+      issues
+    else
+      issues
+    end
+  end
+
+  defp dynamic_wire_value?(value) when is_integer(value), do: false
+  defp dynamic_wire_value?({:@, _, _}), do: false
+  defp dynamic_wire_value?(_value), do: true
+
+  defp issue(ast, issues, issue_meta, meta, trigger) do
+    issue =
+      format_issue(issue_meta,
+        message:
+          "GUI encoders must use Wire.Writer for data-derived bounded fields, not #{trigger}. See #2737.",
+        trigger: trigger,
+        line_no: meta[:line]
+      )
+
+    {ast, [issue | issues]}
+  end
+
+  defp alias_name({:__aliases__, _, names}), do: List.last(names)
+  defp alias_name(_), do: nil
+
+  defp lossy_remote_call?(:Enum, function) when function in [:reduce_while, :take], do: true
+
+  defp lossy_remote_call?(module, function)
+       when module in [:Wire, :Encoding, :AgentChatMessageCodec] and
+              function in [
+                :bounded_entries,
+                :clamp_u8,
+                :clamp_u16,
+                :clamp_u32,
+                :utf8_prefix_bytes,
+                :validate_uint!
+              ],
+       do: true
+
+  defp lossy_remote_call?(:Wire, function)
+       when function in [:encode_section, :encode_string8, :encode_string16, :rgb],
+       do: true
+
+  defp lossy_remote_call?(_module, _function), do: false
+
+  defp gui_encoder_file?(%SourceFile{} = source_file) do
+    filename = Path.expand(source_file.filename)
+
+    String.contains?(filename, "/lib/minga/frontend/adapter/gui/") and
+      not String.ends_with?(filename, "/lib/minga/frontend/adapter/gui/wire.ex") and
+      not String.contains?(filename, "/lib/minga/frontend/adapter/gui/wire/")
+  end
+end

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -207,7 +207,7 @@ Between frames, the frontend must not mutate committed editor state or present n
 
 ## Bounded length carriers
 
-`clipboard_write` uses a u32 outer payload length and u32 text length. `gui_window_content` and its A1/A2 delta commands use u32 section lengths and u32 row counts. These carriers represent values from 0 through 4,294,967,295 bytes or rows, but both shipped frontends reject packets larger than 64 MiB before allocation. A producer must reject a value outside its carrier before writing any part of the command. Fields documented as u8 or u16 remain intentionally bounded and must likewise fail before emission when their value is out of range.
+`clipboard_write` uses a u32 outer payload length and u32 text length. `gui_window_content` and its A1/A2 delta commands use u32 section lengths and u32 row counts. These carriers represent values from 0 through 4,294,967,295 bytes or rows, but both shipped frontends reject packets larger than 64 MiB before allocation. A producer must reject a value outside its carrier before writing any part of the command. Fields documented as u8 or u16 remain intentionally bounded and must likewise fail before emission when their value is out of range. The BEAM reports a rejected field as a structured encoding error with its command, field, actual value, and allowed range, sends no frame commands, then resets its adapter cache so the following valid frame is a base-0 keyframe.
 
 ## Frame Transactions
 

--- a/lib/minga/frontend/adapter/gui/agent_chat_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/agent_chat_encoder.ex
@@ -10,29 +10,25 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
   core views (`AgentChat.ToolCallView`, `AgentChat.ApprovalView`,
   `AgentChat.Usage`) before they reach this encoder.
 
-  This is the legacy transcript transport: the `@section_chat_messages` section
-  carries a windowed, byte-capped tail of the conversation. The full resident
-  transcript now rides the dedicated `gui_agent_transcript` (0x86) stream via
-  `Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder` (#2654). Both share the
-  per-message body codec in `Minga.Frontend.Adapter.GUI.AgentChatMessageCodec`
-  so the two transports encode each message with byte-identical bytes. The
-  `messages` field this encoder consumes stays windowed until the frontends
-  switch to consuming 0x86 (#2654 slices 2-3); the resident transcript never
-  passes through this section.
+  This is the legacy transcript transport. The render model decides which
+  messages belong in its `messages` field; this adapter encodes that list exactly
+  and rejects a section that exceeds the wire's uint16 payload bound. The full
+  resident transcript rides the dedicated `gui_agent_transcript` (0x86) stream
+  via `Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder` (#2654). Both share the
+  per-message body codec in `Minga.Frontend.Adapter.GUI.AgentChatMessageCodec`,
+  so the two transports encode each valid message with byte-identical bytes.
   """
 
   alias Minga.Frontend.Adapter.GUI.AgentChatMessageCodec
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.AgentChat
   alias Minga.RenderModel.UI.AgentChat.PromptCompletion
 
   @op_gui_agent_chat Opcodes.gui_agent_chat()
 
-  @max_u16 65_535
-
-  @chat_message_limit 100
-  @chat_payload_omission_notice "Some agent chat content was omitted because the GUI chat payload exceeded 65KB."
+  @command :gui_agent_chat
 
   # gui_agent_chat sections
   @section_chat_header 0x01
@@ -75,51 +71,66 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
   end
 
   defp encode_binary(%AgentChat{visible?: true} = model) do
-    status_byte = encode_agent_chat_status(model.status)
-    model_bytes = AgentChatMessageCodec.utf8_prefix_bytes(model.model_name || "", @max_u16 - 2)
-    prompt_bytes = AgentChatMessageCodec.utf8_prefix_bytes(model.prompt || "", @max_u16 - 9)
-
-    prompt_line_count = model.prompt_line_count || 1
-    prompt_cursor_line = model.prompt_cursor_line || 0
-    prompt_cursor_col = model.prompt_cursor_col || 0
-    prompt_vim_mode = encode_vim_mode(model.prompt_vim_mode)
-    prompt_visible_rows = model.prompt_visible_rows || 1
-
-    completion_bytes = encode_prompt_completion(model.prompt_completion)
-    pending_bytes = <<0::8>>
-    help_bytes = encode_help_overlay(model.help_visible?, model.help_groups)
-
-    thinking_bytes =
-      AgentChatMessageCodec.utf8_prefix_bytes(model.thinking_level || "", @max_u16 - 2)
-
-    messages_payload = encode_chat_messages(model.messages)
-
     sections = [
-      encode_section(@section_chat_header, <<1::8, status_byte::8>>),
-      encode_section(@section_chat_model, <<byte_size(model_bytes)::16, model_bytes::binary>>),
       encode_section(
-        @section_chat_prompt,
-        <<byte_size(prompt_bytes)::16, prompt_bytes::binary, prompt_line_count::8,
-          prompt_cursor_line::16, prompt_cursor_col::16, prompt_vim_mode::8,
-          prompt_visible_rows::8>>
+        @section_chat_header,
+        Writer.new(@command)
+        |> Writer.uint8(:version, 1)
+        |> Writer.uint8(:status, encode_agent_chat_status(model.status))
+        |> Writer.finish()
       ),
-      encode_section(@section_chat_completion, completion_bytes),
-      encode_section(@section_chat_pending, pending_bytes),
-      encode_section(@section_chat_help, help_bytes),
+      encode_section(
+        @section_chat_model,
+        Writer.new(@command)
+        |> Writer.string16(:model_name, model.model_name || "")
+        |> Writer.finish()
+      ),
+      encode_section(@section_chat_prompt, encode_prompt(model)),
+      encode_section(@section_chat_completion, encode_prompt_completion(model.prompt_completion)),
+      encode_section(@section_chat_pending, <<0::8>>),
+      encode_section(
+        @section_chat_help,
+        encode_help_overlay(model.help_visible?, model.help_groups)
+      ),
       encode_section(
         @section_chat_thinking,
-        <<byte_size(thinking_bytes)::16, thinking_bytes::binary>>
+        Writer.new(@command)
+        |> Writer.string16(:thinking_level, model.thinking_level || "")
+        |> Writer.finish()
       ),
-      encode_section(@section_chat_input_focused, <<bool_byte(model.input_focused)::8>>),
-      encode_section(@section_chat_messages, messages_payload)
+      encode_section(
+        @section_chat_input_focused,
+        Writer.new(@command)
+        |> Writer.uint8(:input_focused, bool_byte(model.input_focused))
+        |> Writer.finish()
+      ),
+      encode_section(@section_chat_messages, encode_chat_messages(model.messages))
     ]
 
-    IO.iodata_to_binary([<<@op_gui_agent_chat, Enum.count(sections)::8>> | sections])
+    Writer.new(@command)
+    |> Writer.uint8(:opcode, @op_gui_agent_chat)
+    |> Writer.uint8(:section_count, Enum.count(sections))
+    |> Writer.append(sections)
+    |> Writer.finish()
+  end
+
+  @spec encode_prompt(AgentChat.t()) :: binary()
+  defp encode_prompt(%AgentChat{} = model) do
+    Writer.new(@command)
+    |> Writer.string16(:prompt, model.prompt || "")
+    |> Writer.uint8(:prompt_line_count, model.prompt_line_count || 1)
+    |> Writer.uint16(:prompt_cursor_line, model.prompt_cursor_line || 0)
+    |> Writer.uint16(:prompt_cursor_col, model.prompt_cursor_col || 0)
+    |> Writer.uint8(:prompt_vim_mode, encode_vim_mode(model.prompt_vim_mode))
+    |> Writer.uint8(:prompt_visible_rows, model.prompt_visible_rows || 1)
+    |> Writer.finish()
   end
 
   @spec encode_section(non_neg_integer(), binary()) :: binary()
   defp encode_section(section_id, payload) do
-    <<section_id::8, byte_size(payload)::16, payload::binary>>
+    Writer.new(@command)
+    |> Writer.section16(:section_payload, section_id, payload)
+    |> Writer.finish()
   end
 
   # ── Prompt completion ──
@@ -132,33 +143,35 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
 
   defp encode_prompt_completion(%PromptCompletion{candidates: candidates} = comp)
        when is_list(candidates) and candidates != [] do
-    type_byte = if comp.type == :slash, do: 1, else: 0
-    anchor_line = comp.anchor_line || 0
-    anchor_col = comp.anchor_col || 0
-    candidate_count = min(Enum.count(candidates), 255)
+    candidate_bins = Enum.map(candidates, &encode_completion_candidate/1)
 
-    candidate_bins =
-      candidates
-      |> Enum.take(candidate_count)
-      |> Enum.map(fn
-        {name, desc} ->
-          n = :erlang.iolist_to_binary([name])
-          d = :erlang.iolist_to_binary([desc])
-          <<byte_size(n)::16, n::binary, byte_size(d)::16, d::binary>>
-
-        name when is_binary(name) ->
-          n = :erlang.iolist_to_binary([name])
-          <<byte_size(n)::16, n::binary, 0::16>>
-      end)
-
-    IO.iodata_to_binary([
-      <<1::8, type_byte::8, min(comp.selected, 255)::8, anchor_line::16, anchor_col::16,
-        candidate_count::8>>
-      | candidate_bins
-    ])
+    Writer.new(@command)
+    |> Writer.uint8(:completion_visible, 1)
+    |> Writer.uint8(:completion_type, if(comp.type == :slash, do: 1, else: 0))
+    |> Writer.uint8(:completion_selected, comp.selected)
+    |> Writer.uint16(:completion_anchor_line, comp.anchor_line || 0)
+    |> Writer.uint16(:completion_anchor_col, comp.anchor_col || 0)
+    |> Writer.uint8(:completion_candidate_count, Enum.count(candidates))
+    |> Writer.append(candidate_bins)
+    |> Writer.finish()
   end
 
   defp encode_prompt_completion(_), do: <<0::8>>
+
+  @spec encode_completion_candidate(PromptCompletion.candidate()) :: binary()
+  defp encode_completion_candidate({name, description}) do
+    Writer.new(@command)
+    |> Writer.string16(:completion_candidate_name, name)
+    |> Writer.string16(:completion_candidate_description, description)
+    |> Writer.finish()
+  end
+
+  defp encode_completion_candidate(name) when is_binary(name) do
+    Writer.new(@command)
+    |> Writer.string16(:completion_candidate_name, name)
+    |> Writer.string16(:completion_candidate_description, "")
+    |> Writer.finish()
+  end
 
   # ── Help overlay ──
 
@@ -167,108 +180,49 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoder do
   @spec encode_help_overlay(boolean() | nil, [{String.t(), [{String.t(), String.t()}]}] | nil) ::
           binary()
   defp encode_help_overlay(true, groups) when is_list(groups) and groups != [] do
-    group_binaries =
-      Enum.map(groups, fn {title, bindings} ->
-        title_b = :erlang.iolist_to_binary([title])
-
-        binding_binaries =
-          Enum.map(bindings, fn {key, desc} ->
-            key_b = :erlang.iolist_to_binary([key])
-            desc_b = :erlang.iolist_to_binary([desc])
-
-            <<byte_size(key_b)::8, key_b::binary, byte_size(desc_b)::16, desc_b::binary>>
-          end)
-
-        IO.iodata_to_binary([
-          <<byte_size(title_b)::16, title_b::binary, Enum.count(bindings)::8>>
-          | binding_binaries
-        ])
-      end)
-
-    IO.iodata_to_binary([<<1::8, Enum.count(groups)::8>> | group_binaries])
+    Writer.new(@command)
+    |> Writer.uint8(:help_visible, 1)
+    |> Writer.uint8(:help_group_count, Enum.count(groups))
+    |> Writer.append(Enum.map(groups, &encode_help_group/1))
+    |> Writer.finish()
   end
 
   defp encode_help_overlay(_, _), do: <<0::8>>
 
-  # ── Chat messages (windowed, byte-capped legacy section) ──
+  @spec encode_help_group({String.t(), [{String.t(), String.t()}]}) :: binary()
+  defp encode_help_group({title, bindings}) do
+    Writer.new(@command)
+    |> Writer.string16(:help_group_title, title)
+    |> Writer.uint8(:help_binding_count, Enum.count(bindings))
+    |> Writer.append(Enum.map(bindings, &encode_help_binding/1))
+    |> Writer.finish()
+  end
+
+  @spec encode_help_binding({String.t(), String.t()}) :: binary()
+  defp encode_help_binding({key, description}) do
+    Writer.new(@command)
+    |> Writer.string8(:help_binding_key, key)
+    |> Writer.string16(:help_binding_description, description)
+    |> Writer.finish()
+  end
+
+  # ── Chat messages ──
 
   @spec encode_chat_messages([AgentChat.message()]) :: binary()
   defp encode_chat_messages(messages) do
-    messages =
-      messages
-      |> recent_chat_messages()
-      |> Enum.map(&AgentChatMessageCodec.bound_message_text/1)
-
-    payload = encode_chat_messages_payload(messages)
-
-    if byte_size(payload) <= @max_u16 do
-      payload
-    else
-      stripped_messages = Enum.map(messages, &AgentChatMessageCodec.strip_message_links/1)
-      stripped_payload = encode_chat_messages_payload(stripped_messages)
-
-      if byte_size(stripped_payload) <= @max_u16 do
-        stripped_payload
-      else
-        stripped_messages
-        |> fit_chat_messages_to_payload_limit()
-        |> encode_chat_messages_payload()
-      end
-    end
+    Writer.new(@command)
+    |> Writer.uint8(:messages_marker, 0xFF)
+    |> Writer.uint8(:messages_version, 1)
+    |> Writer.uint16(:message_count, Enum.count(messages))
+    |> Writer.append(Enum.map(messages, &encode_chat_message/1))
+    |> Writer.finish()
   end
 
-  @spec recent_chat_messages([AgentChat.message()]) :: [AgentChat.message()]
-  defp recent_chat_messages(messages) do
-    messages
-    |> Enum.reverse()
-    |> Enum.take(@chat_message_limit)
-    |> Enum.reverse()
-  end
-
-  @spec fit_chat_messages_to_payload_limit([AgentChat.message()]) :: [AgentChat.message()]
-  defp fit_chat_messages_to_payload_limit(messages) do
-    {selected, omitted?} =
-      messages
-      |> Enum.reverse()
-      |> Enum.reduce({[], false}, fn msg, {selected, omitted?} ->
-        candidate = [msg | selected]
-
-        if byte_size(encode_chat_messages_payload(candidate)) <= @max_u16 do
-          {candidate, omitted?}
-        else
-          {selected, true}
-        end
-      end)
-
-    if omitted?, do: add_chat_payload_omission_notice(selected), else: selected
-  end
-
-  @spec add_chat_payload_omission_notice([AgentChat.message()]) :: [AgentChat.message()]
-  defp add_chat_payload_omission_notice([]) do
-    [{:system, @chat_payload_omission_notice, :info}]
-  end
-
-  defp add_chat_payload_omission_notice(messages) do
-    notice = {:system, @chat_payload_omission_notice, :info}
-
-    if byte_size(encode_chat_messages_payload([notice | messages])) <= @max_u16 do
-      [notice | messages]
-    else
-      [_dropped | rest] = messages
-      add_chat_payload_omission_notice(rest)
-    end
-  end
-
-  @spec encode_chat_messages_payload([AgentChat.message()]) :: binary()
-  defp encode_chat_messages_payload(messages) do
-    msg_binaries = Enum.map(messages, &AgentChatMessageCodec.encode_message/1)
-
-    framed_messages =
-      Enum.map(msg_binaries, fn msg ->
-        <<byte_size(msg)::32, msg::binary>>
-      end)
-
-    IO.iodata_to_binary([<<0xFF::8, 1::8, Enum.count(msg_binaries)::16>> | framed_messages])
+  @spec encode_chat_message(AgentChat.message()) :: binary()
+  defp encode_chat_message(message) do
+    Writer.new(@command)
+    |> Writer.payload32(:message, AgentChatMessageCodec.encode_message(message))
+    |> Writer.finish()
   end
 
   # ── Enum byte helpers ──

--- a/lib/minga/frontend/adapter/gui/agent_chat_message_codec.ex
+++ b/lib/minga/frontend/adapter/gui/agent_chat_message_codec.ex
@@ -2,33 +2,23 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatMessageCodec do
   @moduledoc """
   Shared wire codec for a single agent-chat transcript message body.
 
-  Extracted from `Minga.Frontend.Adapter.GUI.AgentChatEncoder` so the legacy
-  `gui_agent_chat` (0x78) messages section and the resident `gui_agent_transcript`
-  (0x86) stream encode each message with byte-identical bytes. This module owns
-  only the per-message body encoding, the text/link bounding helpers, and the
-  UTF-8 truncation primitive. Frame framing, section layout, and payload-fit
-  policy stay with the two encoders that carry different transports.
-
-  A `message` is a `Minga.RenderModel.UI.AgentChat.message()`: either a
-  `{id, body}` tuple with a stable uint32 id, or a bare body tuple that encodes
-  with id `0`.
+  Both the legacy `gui_agent_chat` (0x78) messages section and the resident
+  `gui_agent_transcript` (0x86) stream use this codec, so valid messages have
+  byte-identical bodies on both transports. Every data-derived bounded field is
+  validated before it is written. Invalid values raise an encoding error rather
+  than being truncated, dropped, or downgraded.
   """
 
   import Bitwise
 
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.RenderModel.UI.AgentChat
   alias Minga.RenderModel.UI.AgentChat.ApprovalView
   alias Minga.RenderModel.UI.AgentChat.MarkdownBlock
   alias Minga.RenderModel.UI.AgentChat.ToolCallView
   alias Minga.RenderModel.UI.AgentChat.Usage
 
-  @max_u16 65_535
-  @max_chat_text_bytes 60_000
-  @truncation_suffix "\n… [truncated]"
-
-  @doc "Maximum per-message text byte budget shared by both transports."
-  @spec max_message_text_bytes() :: pos_integer()
-  def max_message_text_bytes, do: @max_chat_text_bytes
+  @command :gui_agent_chat_message
 
   @doc "Stable uint32 id for a message, or 0 for a bare (unwrapped) body."
   @spec message_id(AgentChat.message()) :: non_neg_integer()
@@ -37,278 +27,165 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatMessageCodec do
 
   @doc "Encodes a full message as `<<id::32, body::binary>>`."
   @spec encode_message(AgentChat.message()) :: binary()
-  def encode_message({id, body}) when is_integer(id),
-    do: <<id::32, encode_message_body(body)::binary>>
+  def encode_message({id, body}) when is_integer(id) do
+    Writer.new(@command)
+    |> Writer.uint32(:message_id, id)
+    |> Writer.append(encode_message_body(body))
+    |> Writer.finish()
+  end
 
-  def encode_message(body) when is_tuple(body),
-    do: <<0::32, encode_message_body(body)::binary>>
-
-  @doc "Bounds a message's inline text to `max_message_text_bytes/0`."
-  @spec bound_message_text(AgentChat.message()) :: AgentChat.message()
-  def bound_message_text({id, msg}) when is_integer(id),
-    do: {id, bound_message_text(msg)}
-
-  def bound_message_text({:user, text}),
-    do: {:user, utf8_prefix_bytes(text, @max_chat_text_bytes)}
-
-  def bound_message_text({:user, text, attachments}),
-    do: {:user, utf8_prefix_bytes(text, @max_chat_text_bytes), attachments}
-
-  def bound_message_text({:assistant, text}),
-    do: {:assistant, utf8_prefix_bytes(text, @max_chat_text_bytes)}
-
-  def bound_message_text({:thinking, text, collapsed}),
-    do: {:thinking, utf8_prefix_bytes(text, @max_chat_text_bytes), collapsed}
-
-  def bound_message_text({:system, text, level}),
-    do: {:system, utf8_prefix_bytes(text, @max_chat_text_bytes), level}
-
-  def bound_message_text(msg), do: msg
-
-  @doc "Strips embedded link URLs from a message (a size-reduction fallback)."
-  @spec strip_message_links(AgentChat.message()) :: AgentChat.message()
-  def strip_message_links({id, msg}) when is_integer(id),
-    do: {id, strip_message_links(msg)}
-
-  def strip_message_links({:styled_assistant, styled_lines}),
-    do: {:styled_assistant, strip_styled_lines_links(styled_lines)}
-
-  def strip_message_links({:styled_tool_call, tc, styled_lines}),
-    do: {:styled_tool_call, tc, strip_styled_lines_links(styled_lines)}
-
-  def strip_message_links({:assistant_markdown, blocks}),
-    do: {:assistant_markdown, strip_markdown_block_links(blocks)}
-
-  def strip_message_links(msg), do: msg
-
-  # ── Message body ──
+  def encode_message(body) when is_tuple(body) do
+    Writer.new(@command)
+    |> Writer.uint32(:message_id, 0)
+    |> Writer.append(encode_message_body(body))
+    |> Writer.finish()
+  end
 
   @spec encode_message_body(AgentChat.message_body()) :: binary()
-  def encode_message_body({:user, text}) do
-    text_bytes = :erlang.iolist_to_binary([text])
-    <<0x01::8, byte_size(text_bytes)::32, text_bytes::binary>>
-  end
+  def encode_message_body({:user, text}), do: encode_text_message(0x01, text)
+  def encode_message_body({:user, text, _attachments}), do: encode_text_message(0x01, text)
+  def encode_message_body({:assistant, text}), do: encode_text_message(0x02, text)
 
-  def encode_message_body({:user, text, _attachments}) do
-    text_bytes = :erlang.iolist_to_binary([text])
-    <<0x01::8, byte_size(text_bytes)::32, text_bytes::binary>>
-  end
-
-  def encode_message_body({:assistant, text}) do
-    text_bytes = :erlang.iolist_to_binary([text])
-    <<0x02::8, byte_size(text_bytes)::32, text_bytes::binary>>
-  end
-
-  # Styled assistant message: opcode 0x07, line_count::16, then per line:
-  # run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8,
-  # and when flags bit 0x08 is set: url_len::16, url.
   def encode_message_body({:styled_assistant, styled_lines}) do
-    line_binaries =
-      Enum.map(styled_lines, fn runs ->
-        run_binaries = Enum.map(runs, &encode_styled_run/1)
-        [<<Enum.count(runs)::16>> | run_binaries]
-      end)
-
-    IO.iodata_to_binary([<<0x07::8, Enum.count(styled_lines)::16>> | line_binaries])
+    Writer.new(@command)
+    |> Writer.uint8(:message_kind, 0x07)
+    |> Writer.uint16(:line_count, Enum.count(styled_lines))
+    |> Writer.append(Enum.map(styled_lines, &encode_styled_line/1))
+    |> Writer.finish()
   end
 
-  # Assistant markdown message: opcode 0x0A, block_count::16, then semantic blocks.
   def encode_message_body({:assistant_markdown, blocks}) do
-    bounded_blocks = bound_markdown_blocks(blocks)
-
-    IO.iodata_to_binary([
-      <<0x0A::8, Enum.count(bounded_blocks)::16>>,
-      Enum.map(bounded_blocks, &encode_markdown_block/1)
-    ])
+    Writer.new(@command)
+    |> Writer.uint8(:message_kind, 0x0A)
+    |> Writer.uint16(:block_count, Enum.count(blocks))
+    |> Writer.append(Enum.map(blocks, &encode_markdown_block/1))
+    |> Writer.finish()
   end
 
   def encode_message_body({:thinking, text, collapsed}) do
-    collapsed_byte = if collapsed, do: 1, else: 0
-    text_bytes = :erlang.iolist_to_binary([text])
-    <<0x03::8, collapsed_byte::8, byte_size(text_bytes)::32, text_bytes::binary>>
+    Writer.new(@command)
+    |> Writer.uint8(:message_kind, 0x03)
+    |> Writer.uint8(:collapsed, bool_byte(collapsed))
+    |> Writer.string32(:text, text)
+    |> Writer.finish()
   end
 
   def encode_message_body({:tool_call, %ToolCallView{} = tc}) do
-    name_bytes = :erlang.iolist_to_binary([tc.name])
-    summary_bytes = utf8_prefix_bytes(tc.summary || "", @max_chat_text_bytes)
-    result_bytes = :erlang.iolist_to_binary([tc.result])
-    status_byte = tool_call_status_byte(tc.status)
-
-    duration = tc.duration_ms || 0
-    error_byte = if tc.is_error, do: 1, else: 0
-    collapsed_byte = if tc.collapsed, do: 1, else: 0
-    auto_approved_byte = auto_approved_scope_byte(tc.auto_approved_scope)
-
-    preview_bytes = encode_preview_payload(tc.preview_kind, tc.preview_lines)
-
-    <<0x04::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32,
-      byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
-      summary_bytes::binary, byte_size(result_bytes)::32, result_bytes::binary,
-      auto_approved_byte::8, preview_bytes::binary>>
+    Writer.new(@command)
+    |> Writer.uint8(:message_kind, 0x04)
+    |> Writer.uint8(:status, tool_call_status_byte(tc.status))
+    |> Writer.uint8(:is_error, bool_byte(tc.is_error))
+    |> Writer.uint8(:collapsed, bool_byte(tc.collapsed))
+    |> Writer.uint32(:duration_ms, tc.duration_ms || 0)
+    |> Writer.string16(:tool_name, tc.name)
+    |> Writer.string16(:summary, tc.summary || "")
+    |> Writer.string32(:result, tc.result)
+    |> Writer.uint8(:auto_approved_scope, auto_approved_scope_byte(tc.auto_approved_scope))
+    |> Writer.append(encode_preview_payload(tc.preview_kind, tc.preview_lines))
+    |> Writer.finish()
   end
 
-  # Approval tool call: inline approval card attached to the tool message.
-  # Sub-opcode 0x09. Layout:
-  #   0x09, status::8, name_len::16, name, summary_len::16, summary,
-  #   tool_call_id_len::16, tool_call_id, preview_kind::8,
-  #   preview_line_count::16, [line_len::16, line]*
   def encode_message_body({:approval_tool_call, %ApprovalView{} = approval}) do
-    name_bytes = preview_text_bytes(approval.name, 120)
-    summary_bytes = approval_summary_bytes(approval.preview_kind, approval.summary)
-    id_bytes = preview_text_bytes(approval.tool_call_id, 120)
-
-    line_binaries =
-      approval.preview_lines
-      |> Enum.take(20)
-      |> Enum.map(fn line ->
-        bytes = preview_text_bytes(line, 1_000)
-        <<byte_size(bytes)::16, bytes::binary>>
-      end)
-
-    preview_bytes = IO.iodata_to_binary(line_binaries)
-
-    <<0x09::8, 0::8, byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
-      summary_bytes::binary, byte_size(id_bytes)::16, id_bytes::binary,
-      preview_kind_byte(approval.preview_kind)::8, Enum.count(line_binaries)::16,
-      preview_bytes::binary>>
+    Writer.new(@command)
+    |> Writer.uint8(:message_kind, 0x09)
+    |> Writer.uint8(:status, 0)
+    |> Writer.string16(:tool_name, approval.name)
+    |> Writer.string16(:summary, approval.summary || "")
+    |> Writer.string16(:tool_call_id, approval.tool_call_id)
+    |> Writer.uint8(:preview_kind, preview_kind_byte(approval.preview_kind))
+    |> Writer.uint16(:preview_line_count, Enum.count(approval.preview_lines))
+    |> Writer.append(Enum.map(approval.preview_lines, &encode_preview_line/1))
+    |> Writer.finish()
   end
 
-  # Styled tool call: same header fields as tool_call (0x04), but result is styled runs.
-  # Sub-opcode 0x08. Layout:
-  #   0x08, status::8, error::8, collapsed::8, duration::32, name_len::16, name,
-  #   summary_len::16, summary, line_count::16, then per line: run_count::16,
-  #   then per run: text_len::16, text, fg::24, bg::24, flags::8,
-  #   and when flags bit 0x08 is set: url_len::16, url.
-  #   auto_approved::8 and preview payload are appended after the styled line payload.
   def encode_message_body({:styled_tool_call, %ToolCallView{} = tc, styled_lines}) do
-    name_bytes = :erlang.iolist_to_binary([tc.name])
-    summary_bytes = utf8_prefix_bytes(tc.summary || "", @max_chat_text_bytes)
-    status_byte = tool_call_status_byte(tc.status)
-
-    duration = tc.duration_ms || 0
-    error_byte = if tc.is_error, do: 1, else: 0
-    collapsed_byte = if tc.collapsed, do: 1, else: 0
-    auto_approved_byte = auto_approved_scope_byte(tc.auto_approved_scope)
-
-    line_binaries =
-      Enum.map(styled_lines, fn runs ->
-        run_binaries = Enum.map(runs, &encode_styled_run/1)
-        [<<Enum.count(runs)::16>> | run_binaries]
-      end)
-
-    preview_bytes = encode_preview_payload(tc.preview_kind, tc.preview_lines)
-
-    IO.iodata_to_binary([
-      <<0x08::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32,
-        byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
-        summary_bytes::binary, Enum.count(styled_lines)::16>>,
-      line_binaries,
-      <<auto_approved_byte::8>>,
-      preview_bytes
-    ])
+    Writer.new(@command)
+    |> Writer.uint8(:message_kind, 0x08)
+    |> Writer.uint8(:status, tool_call_status_byte(tc.status))
+    |> Writer.uint8(:is_error, bool_byte(tc.is_error))
+    |> Writer.uint8(:collapsed, bool_byte(tc.collapsed))
+    |> Writer.uint32(:duration_ms, tc.duration_ms || 0)
+    |> Writer.string16(:tool_name, tc.name)
+    |> Writer.string16(:summary, tc.summary || "")
+    |> Writer.uint16(:line_count, Enum.count(styled_lines))
+    |> Writer.append(Enum.map(styled_lines, &encode_styled_line/1))
+    |> Writer.uint8(:auto_approved_scope, auto_approved_scope_byte(tc.auto_approved_scope))
+    |> Writer.append(encode_preview_payload(tc.preview_kind, tc.preview_lines))
+    |> Writer.finish()
   end
 
   def encode_message_body({:system, text, level}) do
-    level_byte = if level == :error, do: 1, else: 0
-    text_bytes = :erlang.iolist_to_binary([text])
-    <<0x05::8, level_byte::8, byte_size(text_bytes)::32, text_bytes::binary>>
+    Writer.new(@command)
+    |> Writer.uint8(:message_kind, 0x05)
+    |> Writer.uint8(:level, if(level == :error, do: 1, else: 0))
+    |> Writer.string32(:text, text)
+    |> Writer.finish()
   end
 
-  def encode_message_body({:usage, %Usage{} = u}) do
-    cost_int = round((u.cost || 0.0) * 1_000_000)
-    <<0x06::8, u.input::32, u.output::32, u.cache_read::32, u.cache_write::32, cost_int::32>>
+  def encode_message_body({:usage, %Usage{} = usage}) do
+    cost_int = round((usage.cost || 0.0) * 1_000_000)
+
+    Writer.new(@command)
+    |> Writer.uint8(:message_kind, 0x06)
+    |> Writer.uint32(:input_tokens, usage.input)
+    |> Writer.uint32(:output_tokens, usage.output)
+    |> Writer.uint32(:cache_read_tokens, usage.cache_read)
+    |> Writer.uint32(:cache_write_tokens, usage.cache_write)
+    |> Writer.uint32(:cost_micros, cost_int)
+    |> Writer.finish()
   end
 
-  # ── Previews ──
-
-  @spec preview_kind_byte(atom()) :: non_neg_integer()
-  defp preview_kind_byte(:diff), do: 1
-  defp preview_kind_byte(:command), do: 2
-  defp preview_kind_byte(:target), do: 3
-  defp preview_kind_byte(_), do: 0
-
-  @spec preview_text_bytes(term(), pos_integer()) :: binary()
-  defp preview_text_bytes(value, max_length) when is_binary(value) do
-    value |> String.slice(0, max_length) |> :erlang.iolist_to_binary()
-  end
-
-  defp preview_text_bytes(value, max_length) do
-    value
-    |> inspect(printable_limit: max_length)
-    |> String.slice(0, max_length)
-    |> :erlang.iolist_to_binary()
+  @spec encode_text_message(non_neg_integer(), String.t()) :: binary()
+  defp encode_text_message(kind, text) do
+    Writer.new(@command)
+    |> Writer.uint8(:message_kind, kind)
+    |> Writer.string32(:text, text)
+    |> Writer.finish()
   end
 
   @spec encode_preview_payload(ToolCallView.preview_kind(), [String.t()]) :: binary()
   defp encode_preview_payload(kind, lines) when is_list(lines) do
-    line_binaries =
-      lines
-      |> Enum.take(20)
-      |> Enum.map(fn line ->
-        bytes = preview_text_bytes(line, 1_000)
-        <<byte_size(bytes)::16, bytes::binary>>
-      end)
-
-    IO.iodata_to_binary([
-      <<preview_kind_byte(kind)::8, Enum.count(line_binaries)::16>> | line_binaries
-    ])
+    Writer.new(@command)
+    |> Writer.uint8(:preview_kind, preview_kind_byte(kind))
+    |> Writer.uint16(:preview_line_count, Enum.count(lines))
+    |> Writer.append(Enum.map(lines, &encode_preview_line/1))
+    |> Writer.finish()
   end
 
-  defp encode_preview_payload(kind, _lines), do: <<preview_kind_byte(kind)::8, 0::16>>
-
-  @spec tool_call_status_byte(ToolCallView.status()) :: 0 | 1 | 2
-  defp tool_call_status_byte(:running), do: 0
-  defp tool_call_status_byte(:complete), do: 1
-  defp tool_call_status_byte(:error), do: 2
-
-  @spec approval_summary_bytes(ApprovalView.preview_kind(), String.t()) :: binary()
-  defp approval_summary_bytes(:command, summary) do
-    utf8_prefix_bytes(summary || "", @max_chat_text_bytes)
+  defp encode_preview_payload(kind, _lines) do
+    Writer.new(@command)
+    |> Writer.uint8(:preview_kind, preview_kind_byte(kind))
+    |> Writer.uint16(:preview_line_count, 0)
+    |> Writer.finish()
   end
 
-  defp approval_summary_bytes(_kind, summary) do
-    utf8_prefix_bytes(summary || "", 300)
+  @spec encode_preview_line(String.t()) :: binary()
+  defp encode_preview_line(line) do
+    Writer.new(@command)
+    |> Writer.string16(:preview_line, line)
+    |> Writer.finish()
   end
-
-  @spec auto_approved_scope_byte(ToolCallView.auto_approved_scope()) :: 0 | 1 | 2
-  defp auto_approved_scope_byte(:session), do: 1
-  defp auto_approved_scope_byte(:turn), do: 2
-  defp auto_approved_scope_byte(nil), do: 0
-
-  # ── Markdown blocks ──
-
-  @spec bound_markdown_blocks([MarkdownBlock.t()]) :: [MarkdownBlock.t()]
-  defp bound_markdown_blocks(blocks) do
-    Enum.map(blocks, fn %MarkdownBlock{} = block ->
-      MarkdownBlock.map_lines(block, &bound_styled_line/1, 500)
-    end)
-  end
-
-  @spec bound_styled_line(AgentChat.styled_line()) :: AgentChat.styled_line()
-  defp bound_styled_line(runs), do: Enum.map(runs, &bound_styled_run/1)
-
-  @spec bound_styled_run(AgentChat.styled_run()) :: AgentChat.styled_run()
-  defp bound_styled_run({text, fg, bg, flags, url}),
-    do: {utf8_prefix_bytes(text, 2_000), fg, bg, flags, url}
-
-  defp bound_styled_run({text, fg, bg, flags}),
-    do: {utf8_prefix_bytes(text, 2_000), fg, bg, flags}
 
   @spec encode_markdown_block(MarkdownBlock.t()) :: binary()
   defp encode_markdown_block(%MarkdownBlock{kind: :paragraph} = block),
     do: encode_block_header(block, 0x01) <> encode_styled_lines(block.lines)
 
-  defp encode_markdown_block(%MarkdownBlock{kind: :heading} = block),
-    do:
-      encode_block_header(block, 0x02) <>
-        <<min(block.level, 255)::8>> <> encode_styled_lines(block.lines)
+  defp encode_markdown_block(%MarkdownBlock{kind: :heading} = block) do
+    encode_block_header(block, 0x02) <>
+      (Writer.new(@command)
+       |> Writer.uint8(:heading_level, block.level)
+       |> Writer.append(encode_styled_lines(block.lines))
+       |> Writer.finish())
+  end
 
   defp encode_markdown_block(%MarkdownBlock{kind: :list_item} = block) do
-    ordered = if block.ordered, do: 1, else: 0
-
-    encode_block_header(block, 0x03) <>
-      <<min(block.indent, 255)::8, ordered::8, block.ordinal::32>> <>
-      encode_styled_lines(block.lines)
+    Writer.new(@command)
+    |> Writer.append(encode_block_header(block, 0x03))
+    |> Writer.uint8(:list_indent, block.indent)
+    |> Writer.uint8(:list_ordered, bool_byte(block.ordered))
+    |> Writer.uint32(:list_ordinal, block.ordinal)
+    |> Writer.append(encode_styled_lines(block.lines))
+    |> Writer.finish()
   end
 
   defp encode_markdown_block(%MarkdownBlock{kind: :blockquote} = block),
@@ -317,119 +194,95 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatMessageCodec do
   defp encode_markdown_block(%MarkdownBlock{kind: :rule} = block),
     do: encode_block_header(block, 0x05)
 
-  defp encode_markdown_block(%MarkdownBlock{kind: :spacer} = block),
-    do: encode_block_header(block, 0x06) <> <<min(block.height, 255)::8>>
+  defp encode_markdown_block(%MarkdownBlock{kind: :spacer} = block) do
+    Writer.new(@command)
+    |> Writer.append(encode_block_header(block, 0x06))
+    |> Writer.uint8(:spacer_height, block.height)
+    |> Writer.finish()
+  end
 
   defp encode_markdown_block(%MarkdownBlock{kind: :code_block} = block) do
-    language = utf8_prefix_bytes(block.language || "", @max_u16)
-    label = utf8_prefix_bytes(block.label || "", @max_u16)
-    target_path = utf8_prefix_bytes(block.target_path || "", @max_u16)
-
-    IO.iodata_to_binary([
-      encode_block_header(block, 0x07),
-      <<byte_size(language)::16, language::binary, byte_size(label)::16, label::binary,
-        byte_size(target_path)::16, target_path::binary, block.capability_flags::8>>,
-      encode_styled_lines(block.lines)
-    ])
+    Writer.new(@command)
+    |> Writer.append(encode_block_header(block, 0x07))
+    |> Writer.string16(:code_language, block.language)
+    |> Writer.string16(:code_label, block.label)
+    |> Writer.string16(:code_target_path, block.target_path)
+    |> Writer.uint8(:code_capability_flags, block.capability_flags)
+    |> Writer.append(encode_styled_lines(block.lines))
+    |> Writer.finish()
   end
 
   @spec encode_block_header(MarkdownBlock.t(), non_neg_integer()) :: binary()
-  defp encode_block_header(%MarkdownBlock{} = block, kind),
-    do: <<block.id::32, kind::8, block.flags::8>>
+  defp encode_block_header(%MarkdownBlock{} = block, kind) do
+    Writer.new(@command)
+    |> Writer.uint32(:block_id, block.id)
+    |> Writer.uint8(:block_kind, kind)
+    |> Writer.uint8(:block_flags, block.flags)
+    |> Writer.finish()
+  end
 
   @spec encode_styled_lines([AgentChat.styled_line()]) :: binary()
   defp encode_styled_lines(styled_lines) do
-    line_binaries =
-      Enum.map(styled_lines, fn runs ->
-        run_binaries = Enum.map(runs, &encode_styled_run/1)
-        [<<Enum.count(runs)::16>> | run_binaries]
-      end)
+    Writer.new(@command)
+    |> Writer.uint16(:line_count, Enum.count(styled_lines))
+    |> Writer.append(Enum.map(styled_lines, &encode_styled_line/1))
+    |> Writer.finish()
+  end
 
-    IO.iodata_to_binary([<<Enum.count(styled_lines)::16>> | line_binaries])
+  @spec encode_styled_line(AgentChat.styled_line()) :: binary()
+  defp encode_styled_line(runs) do
+    Writer.new(@command)
+    |> Writer.uint16(:run_count, Enum.count(runs))
+    |> Writer.append(Enum.map(runs, &encode_styled_run/1))
+    |> Writer.finish()
   end
 
   @spec encode_styled_run(AgentChat.styled_run()) :: binary()
   defp encode_styled_run({text, fg, bg, flags, url}) do
-    text_bytes = utf8_prefix_bytes(text, @max_u16)
-    url_bytes = :erlang.iolist_to_binary([url])
-
-    if byte_size(url_bytes) <= @max_u16 do
-      link_flags = flags ||| 0x08
-
-      <<byte_size(text_bytes)::16, text_bytes::binary, fg::24, bg::24, link_flags::8,
-        byte_size(url_bytes)::16, url_bytes::binary>>
-    else
-      non_link_flags = flags &&& 0xF3
-      encode_styled_run({text, fg, bg, non_link_flags})
-    end
+    Writer.new(@command)
+    |> Writer.check_uint8(:run_flags, flags)
+    |> Writer.string16(:run_text, text)
+    |> Writer.rgb24(:run_foreground, fg)
+    |> Writer.rgb24(:run_background, bg)
+    |> Writer.uint8(:run_flags, set_link_flag(flags))
+    |> Writer.string16(:run_url, url)
+    |> Writer.finish()
   end
 
   defp encode_styled_run({text, fg, bg, flags}) do
-    text_bytes = utf8_prefix_bytes(text, @max_u16)
-    safe_flags = flags &&& 0xF7
-    <<byte_size(text_bytes)::16, text_bytes::binary, fg::24, bg::24, safe_flags::8>>
+    Writer.new(@command)
+    |> Writer.check_uint8(:run_flags, flags)
+    |> Writer.string16(:run_text, text)
+    |> Writer.rgb24(:run_foreground, fg)
+    |> Writer.rgb24(:run_background, bg)
+    |> Writer.uint8(:run_flags, clear_link_flag(flags))
+    |> Writer.finish()
   end
 
-  # ── Link stripping ──
+  @spec set_link_flag(non_neg_integer()) :: non_neg_integer()
+  defp set_link_flag(flags), do: flags ||| 0x08
 
-  @spec strip_styled_lines_links([AgentChat.styled_line()]) :: [AgentChat.styled_line()]
-  defp strip_styled_lines_links(styled_lines) do
-    Enum.map(styled_lines, &strip_styled_line_links/1)
-  end
+  @spec clear_link_flag(non_neg_integer()) :: non_neg_integer()
+  defp clear_link_flag(flags) when rem(flags, 16) >= 8, do: flags - 8
+  defp clear_link_flag(flags), do: flags
 
-  @spec strip_styled_line_links(AgentChat.styled_line()) :: AgentChat.styled_line()
-  defp strip_styled_line_links(runs), do: Enum.map(runs, &strip_styled_run_link/1)
+  @spec preview_kind_byte(atom()) :: non_neg_integer()
+  defp preview_kind_byte(:diff), do: 1
+  defp preview_kind_byte(:command), do: 2
+  defp preview_kind_byte(:target), do: 3
+  defp preview_kind_byte(_), do: 0
 
-  @spec strip_styled_run_link(AgentChat.styled_run()) :: AgentChat.styled_run()
-  defp strip_styled_run_link({text, fg, bg, flags, _url}), do: {text, fg, bg, flags &&& 0xF3}
-  defp strip_styled_run_link(run), do: run
+  @spec tool_call_status_byte(ToolCallView.status()) :: 0 | 1 | 2
+  defp tool_call_status_byte(:running), do: 0
+  defp tool_call_status_byte(:complete), do: 1
+  defp tool_call_status_byte(:error), do: 2
 
-  @spec strip_markdown_block_links([MarkdownBlock.t()]) :: [MarkdownBlock.t()]
-  defp strip_markdown_block_links(blocks) do
-    Enum.map(blocks, fn %MarkdownBlock{} = block ->
-      MarkdownBlock.map_lines(block, &strip_styled_line_links/1)
-    end)
-  end
+  @spec auto_approved_scope_byte(ToolCallView.auto_approved_scope()) :: 0 | 1 | 2
+  defp auto_approved_scope_byte(:session), do: 1
+  defp auto_approved_scope_byte(:turn), do: 2
+  defp auto_approved_scope_byte(nil), do: 0
 
-  # ── UTF-8 truncation ──
-
-  @doc "Truncates `text` to a valid UTF-8 prefix of at most `max_bytes` bytes."
-  @spec utf8_prefix_bytes(String.t(), non_neg_integer()) :: binary()
-  def utf8_prefix_bytes(text, max_bytes) when byte_size(text) <= max_bytes do
-    if String.valid?(text) do
-      :erlang.iolist_to_binary([text])
-    else
-      valid_utf8_prefix(text, max_bytes)
-    end
-  end
-
-  def utf8_prefix_bytes(text, max_bytes) do
-    suffix_bytes = :erlang.iolist_to_binary([@truncation_suffix])
-
-    if max_bytes <= byte_size(suffix_bytes) do
-      valid_utf8_prefix(text, max_bytes)
-    else
-      valid_utf8_prefix(text, max_bytes - byte_size(suffix_bytes)) <> suffix_bytes
-    end
-  end
-
-  @spec valid_utf8_prefix(String.t(), non_neg_integer()) :: binary()
-  defp valid_utf8_prefix(_text, 0), do: ""
-
-  defp valid_utf8_prefix(text, max_bytes) do
-    text
-    |> binary_part(0, min(max_bytes, byte_size(text)))
-    |> trim_invalid_utf8_suffix()
-  end
-
-  @spec trim_invalid_utf8_suffix(binary()) :: binary()
-  defp trim_invalid_utf8_suffix(<<>>), do: ""
-
-  defp trim_invalid_utf8_suffix(prefix) do
-    if String.valid?(prefix) do
-      prefix
-    else
-      prefix |> binary_part(0, byte_size(prefix) - 1) |> trim_invalid_utf8_suffix()
-    end
-  end
+  @spec bool_byte(boolean()) :: 0 | 1
+  defp bool_byte(true), do: 1
+  defp bool_byte(false), do: 0
 end

--- a/lib/minga/frontend/adapter/gui/agent_context_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/agent_context_encoder.ex
@@ -2,23 +2,15 @@ defmodule Minga.Frontend.Adapter.GUI.AgentContextEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.AgentContext
+  alias Minga.RenderModel.UI.AgentContext.Todo
 
   @op_gui_agent_context Opcodes.gui_agent_context()
+  @command :gui_agent_context
 
   @spec encode(AgentContext.t(), Caches.t()) :: {binary() | nil, Caches.t()}
-  def encode(%AgentContext{visible: false} = model, %Caches{} = caches) do
-    fp = :erlang.phash2(model)
-
-    if fp != caches.last_agent_context_fp do
-      cmd = encode_agent_context_binary(model)
-      {cmd, %{caches | last_agent_context_fp: fp}}
-    else
-      {nil, caches}
-    end
-  end
-
   def encode(%AgentContext{} = model, %Caches{} = caches) do
     fp = :erlang.phash2(model)
 
@@ -32,40 +24,39 @@ defmodule Minga.Frontend.Adapter.GUI.AgentContextEncoder do
 
   @spec encode_agent_context_binary(AgentContext.t()) :: binary()
   defp encode_agent_context_binary(%AgentContext{visible: false}) do
-    # Hidden: visible=0, empty task, current timestamp, idle status, can_approve=0
-    timestamp_seconds = DateTime.to_unix(DateTime.utc_now())
-    task_bytes = ""
+    payload =
+      Writer.new(@command)
+      |> Writer.uint8(:visible, 0)
+      |> Writer.string16(:task, "")
+      |> Writer.uint64(:dispatch_timestamp, DateTime.to_unix(DateTime.utc_now()))
+      |> Writer.uint8(:status, 0)
+      |> Writer.uint8(:can_approve, 0)
+      |> Writer.finish()
 
-    payload = [
-      <<0::8, byte_size(task_bytes)::16, task_bytes::binary, timestamp_seconds::64, 0::8, 0::8>>
-    ]
-
-    IO.iodata_to_binary([
-      @op_gui_agent_context,
-      payload16(payload)
-    ])
+    encode_command(payload)
   end
 
   defp encode_agent_context_binary(%AgentContext{} = model) do
-    visible_byte = 1
-    task_bytes = :erlang.iolist_to_binary([model.task])
-    timestamp_seconds = DateTime.to_unix(model.dispatch_timestamp)
-    status_byte = status_to_byte(model.status)
-    can_approve_byte = if model.can_approve, do: 1, else: 0
-    progress_bytes = encode_progress(model)
-    todo_bytes = encode_todos(model.todos)
+    payload =
+      Writer.new(@command)
+      |> Writer.uint8(:visible, 1)
+      |> Writer.string16(:task, model.task)
+      |> Writer.uint64(:dispatch_timestamp, DateTime.to_unix(model.dispatch_timestamp))
+      |> Writer.uint8(:status, status_to_byte(model.status))
+      |> Writer.uint8(:can_approve, if(model.can_approve, do: 1, else: 0))
+      |> Writer.append(encode_progress(model))
+      |> Writer.append(encode_todos(model.todos))
+      |> Writer.finish()
 
-    payload = [
-      <<visible_byte::8, byte_size(task_bytes)::16, task_bytes::binary, timestamp_seconds::64,
-        status_byte::8, can_approve_byte::8>>,
-      progress_bytes,
-      todo_bytes
-    ]
+    encode_command(payload)
+  end
 
-    IO.iodata_to_binary([
-      @op_gui_agent_context,
-      payload16(payload)
-    ])
+  @spec encode_command(binary()) :: binary()
+  defp encode_command(payload) do
+    Writer.new(@command)
+    |> Writer.uint8(:opcode, @op_gui_agent_context)
+    |> Writer.payload16(:payload, payload)
+    |> Writer.finish()
   end
 
   @spec status_to_byte(AgentContext.status()) :: non_neg_integer()
@@ -76,50 +67,34 @@ defmodule Minga.Frontend.Adapter.GUI.AgentContextEncoder do
   defp status_to_byte(:done), do: 4
   defp status_to_byte(:errored), do: 5
 
-  @spec encode_progress(AgentContext.t()) :: iodata()
+  @spec encode_progress(AgentContext.t()) :: binary()
   defp encode_progress(%AgentContext{progress: progress}) do
-    action = string16(progress.active_action)
-    review_hint = string16(progress.review_hint)
-
-    [
-      action,
-      <<min(progress.tool_count, 0xFFFF)::16, min(progress.file_count, 0xFFFF)::16>>,
-      review_hint
-    ]
+    Writer.new(@command)
+    |> Writer.string16(:active_action, progress.active_action)
+    |> Writer.uint16(:tool_count, progress.tool_count)
+    |> Writer.uint16(:file_count, progress.file_count)
+    |> Writer.string16(:review_hint, progress.review_hint)
+    |> Writer.finish()
   end
 
-  @spec encode_todos([AgentContext.Todo.t()]) :: iodata()
+  @spec encode_todos([Todo.t()]) :: binary()
   defp encode_todos(todos) do
-    count = min(Enum.count(todos), 0xFF)
-
-    entries =
-      todos
-      |> Enum.take(0xFF)
-      |> Enum.map(fn todo ->
-        [<<todo_status_to_byte(todo.status)::8>>, string16(todo.description)]
-      end)
-
-    [<<count::8>>, entries]
+    Writer.new(@command)
+    |> Writer.uint8(:todo_count, Enum.count(todos))
+    |> Writer.append(Enum.map(todos, &encode_todo/1))
+    |> Writer.finish()
   end
 
-  @spec todo_status_to_byte(AgentContext.Todo.status()) :: non_neg_integer()
+  @spec encode_todo(Todo.t()) :: binary()
+  defp encode_todo(%Todo{} = todo) do
+    Writer.new(@command)
+    |> Writer.uint8(:todo_status, todo_status_to_byte(todo.status))
+    |> Writer.string16(:todo_description, todo.description)
+    |> Writer.finish()
+  end
+
+  @spec todo_status_to_byte(Todo.status()) :: non_neg_integer()
   defp todo_status_to_byte(:pending), do: 0
   defp todo_status_to_byte(:in_progress), do: 1
   defp todo_status_to_byte(:done), do: 2
-
-  @spec string16(String.t()) :: iodata()
-  defp string16(value) when is_binary(value) do
-    bytes = :erlang.iolist_to_binary([value])
-    len = min(byte_size(bytes), 0xFFFF)
-    truncated = binary_part(bytes, 0, len)
-    <<len::16, truncated::binary>>
-  end
-
-  @spec payload16(iodata()) :: iodata()
-  defp payload16(payload) do
-    bytes = :erlang.iolist_to_binary(payload)
-    len = min(byte_size(bytes), 0xFFFF)
-    truncated = binary_part(bytes, 0, len)
-    [<<len::16>>, truncated]
-  end
 end

--- a/lib/minga/frontend/adapter/gui/agent_transcript_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/agent_transcript_encoder.ex
@@ -5,22 +5,19 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder do
 
   Carries the resident transcript so a frontend can scroll the session from local
   data without a BEAM round-trip (#2654), decoupled from the small
-  `gui_agent_chat` (0x78) chrome model whose u16 sectioned frame capped the
-  transcript at ~65 KB. The resident set is the conversation **bounded by
-  `:agent_transcript_resident_max_bytes` (a contiguous most-recent suffix) and
-  scoped by `display_start_index`** — not necessarily the whole history. The
-  `truncated` header flag tells the frontend when older messages sit outside the
-  resident window. Reuses the shared per-message body codec
-  (`Minga.Frontend.Adapter.GUI.AgentChatMessageCodec`) so a message encodes
-  byte-identically on both transports.
+  `gui_agent_chat` (0x78) chrome model whose u16 sectioned frame caps its legacy
+  messages section at about 65 KB. The render model owns resident selection. This
+  adapter encodes its `resident_messages` exactly and never selects a suffix,
+  marks content truncated, or drops entries. Reuses the shared per-message body
+  codec (`Minga.Frontend.Adapter.GUI.AgentChatMessageCodec`) so a valid message
+  encodes byte-identically on both transports.
 
   Adopts the #2652 resident-store lifecycle: a full store replace only on genuine
   structural change (`transcript_epoch` flip or a non-prefix divergence such as
   compaction), and id-keyed append/upsert deltas within an epoch for streaming
-  growth, the in-place last-message patch, and cap eviction. Cap eviction never
-  degrades to full_replace-per-frame: the append delta carries `trim_front`, the
-  number of already-evicted leading messages, so over-cap streaming stays bounded
-  and incremental. State for the delta base lives in a
+  growth, the in-place last-message patch, and upstream resident eviction. The
+  append delta carries `trim_front`, the number of leading messages removed by
+  the model. State for the delta base lives in a
   `Minga.Frontend.Adapter.GUI.AgentTranscriptSentState` inside
   `Minga.Frontend.Adapter.GUI.Caches`, never on the BEAM editor state.
 
@@ -29,7 +26,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder do
       version:u8 = 1
       mode:u8            # 0 = full_replace, 1 = append
       epoch:u32
-      truncated:u8       # 1 when older messages sit outside the resident window
+      truncated:u8 = 0   # selection semantics belong to the render model
       # full_replace (mode 0):
       count:u32
       # append (mode 1):
@@ -56,10 +53,11 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder do
     base_count`, i.e. the delta cannot be applied against what the store holds.
   """
 
-  alias Minga.Config
   alias Minga.Frontend.Adapter.GUI.AgentChatMessageCodec, as: Codec
   alias Minga.Frontend.Adapter.GUI.AgentTranscriptSentState, as: SentState
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.AgentChat
 
@@ -69,11 +67,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder do
   @mode_full_replace 0
   @mode_append 1
 
-  # Fallback cap when config is unavailable; mirrors the option default.
-  @default_resident_max_bytes 8_388_608
-
-  # Per-entry wire overhead: id:u32 + body_len:u32.
-  @entry_overhead 8
+  @command :gui_agent_transcript
 
   @typep entry :: {non_neg_integer(), binary()}
   @typep key :: SentState.key()
@@ -109,9 +103,8 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder do
   defp encode_changed(epoch, messages, fp, %Caches{} = caches) do
     prev = caches.last_agent_transcript
 
-    full_entries = messages |> Enum.map(&message_entry/1) |> dedupe_last_wins()
-    {entries, dropped} = cap_to_resident_bytes(full_entries)
-    truncated? = dropped > 0
+    validate_unique_message_ids!(messages)
+    entries = Enum.map(messages, &message_entry/1)
     keys = Enum.map(entries, &entry_key/1)
 
     new_caches = %{caches | last_agent_transcript: %SentState{fp: fp, epoch: epoch, keys: keys}}
@@ -121,11 +114,10 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder do
         {nil, new_caches}
 
       {:full_replace, out} ->
-        {build_full_replace(epoch, truncated?, out), new_caches}
+        {build_full_replace(epoch, out), new_caches}
 
       {:append, trim_front, base_count, out} ->
-        log_eviction(trim_front, length(entries), dropped)
-        {build_append(epoch, truncated?, trim_front, base_count, out), new_caches}
+        {build_append(epoch, trim_front, base_count, out), new_caches}
     end
   end
 
@@ -133,7 +125,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder do
 
   # A full store replace only on genuine structural change: epoch flip, no prior
   # base, an emptied transcript, or a non-prefix divergence. Otherwise an
-  # eviction-aware append: `trim_front` accounts for cap eviction of the store
+  # eviction-aware append: `trim_front` accounts for upstream removal from the store
   # front, `base_count` is the unchanged leading count of the remainder, and the
   # suffix from `base_count` is upserted (new messages plus the last-message
   # streaming patch).
@@ -159,7 +151,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder do
   end
 
   # Aligns the previously-sent keys against the new resident keys. The new head
-  # id is located in the previous keys; everything before it was evicted from the
+  # id is located in the previous keys; everything before it was removed from the
   # store front (`trim_front`). The remainder must be an id-prefix of the new keys
   # (pure forward growth); otherwise the transcript diverged (reorder/compaction)
   # and a full_replace is required. Returns the strict `{id, hash}` prefix length
@@ -202,47 +194,82 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder do
 
   # ── Frame building ──
 
-  @spec build_full_replace(non_neg_integer(), boolean(), [entry()]) :: binary()
-  defp build_full_replace(epoch, truncated?, entries) do
-    header = <<@version::8, @mode_full_replace::8, epoch::32, bool(truncated?)::8>>
-    frame([header, <<Enum.count(entries)::32>>, entries_body(entries)])
+  @spec build_full_replace(non_neg_integer(), [entry()]) :: binary()
+  defp build_full_replace(epoch, entries) do
+    payload =
+      Writer.new(@command)
+      |> Writer.uint8(:version, @version)
+      |> Writer.uint8(:mode, @mode_full_replace)
+      |> Writer.uint32(:epoch, epoch)
+      |> Writer.uint8(:truncated, 0)
+      |> Writer.uint32(:message_count, Enum.count(entries))
+      |> Writer.append(entries_body(entries))
+      |> Writer.finish()
+
+    frame(payload)
   end
 
-  @spec build_append(non_neg_integer(), boolean(), non_neg_integer(), non_neg_integer(), [entry()]) ::
+  @spec build_append(non_neg_integer(), non_neg_integer(), non_neg_integer(), [entry()]) ::
           binary()
-  defp build_append(epoch, truncated?, trim_front, base_count, entries) do
-    header = <<@version::8, @mode_append::8, epoch::32, bool(truncated?)::8>>
+  defp build_append(epoch, trim_front, base_count, entries) do
+    payload =
+      Writer.new(@command)
+      |> Writer.uint8(:version, @version)
+      |> Writer.uint8(:mode, @mode_append)
+      |> Writer.uint32(:epoch, epoch)
+      |> Writer.uint8(:truncated, 0)
+      |> Writer.uint32(:trim_front, trim_front)
+      |> Writer.uint32(:base_count, base_count)
+      |> Writer.uint32(:message_count, Enum.count(entries))
+      |> Writer.append(entries_body(entries))
+      |> Writer.finish()
 
-    frame([
-      header,
-      <<trim_front::32, base_count::32, Enum.count(entries)::32>>,
-      entries_body(entries)
-    ])
+    frame(payload)
   end
 
   @spec entries_body([entry()]) :: iodata()
-  defp entries_body(entries) do
-    Enum.map(entries, fn {id, body_bin} ->
-      <<id::32, byte_size(body_bin)::32, body_bin::binary>>
-    end)
+  defp entries_body(entries), do: Enum.map(entries, &encode_entry/1)
+
+  @spec encode_entry(entry()) :: binary()
+  defp encode_entry({id, body}) do
+    Writer.new(@command)
+    |> Writer.uint32(:message_id, id)
+    |> Writer.payload32(:message_body, body)
+    |> Writer.finish()
   end
 
-  @spec frame(iodata()) :: binary()
-  defp frame(payload_iodata) do
-    payload = IO.iodata_to_binary(payload_iodata)
-    <<@op_gui_agent_transcript, byte_size(payload)::32, payload::binary>>
+  @spec frame(binary()) :: binary()
+  defp frame(payload) do
+    Writer.new(@command)
+    |> Writer.uint8(:opcode, @op_gui_agent_transcript)
+    |> Writer.payload32(:payload, payload)
+    |> Writer.finish()
   end
-
-  @spec bool(boolean()) :: 0 | 1
-  defp bool(true), do: 1
-  defp bool(false), do: 0
 
   # ── Message entries ──
 
+  @spec validate_unique_message_ids!([AgentChat.message()]) :: :ok
+  defp validate_unique_message_ids!(messages) do
+    messages
+    |> Enum.map(&Codec.message_id/1)
+    |> Enum.frequencies()
+    |> Enum.each(fn
+      {_id, 1} ->
+        :ok
+
+      {_id, occurrences} ->
+        raise EncodingError,
+          command: @command,
+          field: :message_id_occurrences,
+          actual: occurrences,
+          min: 0,
+          max: 1
+    end)
+  end
+
   @spec message_entry(AgentChat.message()) :: entry()
   defp message_entry(message) do
-    bounded = Codec.bound_message_text(message)
-    {Codec.message_id(bounded), Codec.encode_message_body(message_body(bounded))}
+    {Codec.message_id(message), Codec.encode_message_body(message_body(message))}
   end
 
   @spec message_body(AgentChat.message()) :: AgentChat.message_body()
@@ -251,78 +278,4 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder do
 
   @spec entry_key(entry()) :: key()
   defp entry_key({id, body_bin}), do: {id, :erlang.phash2(body_bin)}
-
-  # Upsert semantics make duplicate ids silent data loss (a later entry clobbers
-  # an earlier one on the frontend), and session ids and enrichment ids have no
-  # cross-generator uniqueness guarantee. Drop earlier duplicates deterministically
-  # (last-wins, preserving order) and log a warning so the collision is visible.
-  @spec dedupe_last_wins([entry()]) :: [entry()]
-  defp dedupe_last_wins(entries) do
-    {kept, _seen, dropped} =
-      entries
-      |> Enum.reverse()
-      |> Enum.reduce({[], MapSet.new(), 0}, fn {id, _} = entry, {acc, seen, dropped} ->
-        if MapSet.member?(seen, id) do
-          {acc, seen, dropped + 1}
-        else
-          {[entry | acc], MapSet.put(seen, id), dropped}
-        end
-      end)
-
-    if dropped > 0 do
-      Minga.Log.warning(
-        :render,
-        "agent transcript: dropped #{dropped} duplicate-id message(s) (last-wins)"
-      )
-    end
-
-    kept
-  end
-
-  # Keep the most recent messages whose cumulative wire size fits the resident
-  # byte cap as a **contiguous suffix**: iterate newest to oldest and halt at the
-  # first entry that does not fit, so a small older message can never leapfrog a
-  # large one back into the resident window and punch a hole. The newest message
-  # is always kept, even if it alone exceeds the cap. Returns the kept suffix (in
-  # order) and the count dropped from the front.
-  @spec cap_to_resident_bytes([entry()]) :: {[entry()], non_neg_integer()}
-  defp cap_to_resident_bytes(entries) do
-    cap = resident_max_bytes()
-
-    {kept, _used} =
-      entries
-      |> Enum.reverse()
-      |> Enum.reduce_while({[], 0}, fn {_id, body_bin} = entry, {acc, used} ->
-        next = used + @entry_overhead + byte_size(body_bin)
-
-        cond do
-          acc == [] -> {:cont, {[entry], next}}
-          next <= cap -> {:cont, {[entry | acc], next}}
-          true -> {:halt, {acc, used}}
-        end
-      end)
-
-    {kept, length(entries) - length(kept)}
-  end
-
-  @spec log_eviction(non_neg_integer(), non_neg_integer(), non_neg_integer()) :: :ok
-  defp log_eviction(0, _resident, _dropped), do: :ok
-
-  defp log_eviction(trim_front, resident, dropped) do
-    Minga.Log.debug(
-      :render,
-      "agent transcript cap evicted #{trim_front} front message(s) this frame " <>
-        "(resident #{resident}, #{dropped} older not shown)"
-    )
-  end
-
-  @spec resident_max_bytes() :: pos_integer()
-  defp resident_max_bytes do
-    case Config.get(:agent_transcript_resident_max_bytes) do
-      n when is_integer(n) and n > 0 -> n
-      _ -> @default_resident_max_bytes
-    end
-  catch
-    :exit, _ -> @default_resident_max_bytes
-  end
 end

--- a/lib/minga/frontend/adapter/gui/bottom_panel_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/bottom_panel_encoder.ex
@@ -2,10 +2,13 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.BottomPanel
+  alias Minga.RenderModel.UI.BottomPanel.MessageEntry
 
   @op_gui_bottom_panel Opcodes.gui_bottom_panel()
+  @command :gui_bottom_panel
 
   @spec encode(BottomPanel.t(), Caches.t()) :: {binary() | nil, Caches.t()}
   def encode(%BottomPanel{} = model, %Caches{} = caches) do
@@ -28,33 +31,51 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoder do
   #   hidden: opcode + visible=0(1)
   @spec encode_binary(BottomPanel.t()) :: binary()
   defp encode_binary(%BottomPanel{visible?: false}) do
-    <<@op_gui_bottom_panel, 0>>
+    Writer.new(@command)
+    |> Writer.uint8(:opcode, @op_gui_bottom_panel)
+    |> Writer.uint8(:visible, 0)
+    |> Writer.finish()
   end
 
   defp encode_binary(%BottomPanel{} = model) do
-    tab_defs =
-      for {type_byte, name} <- model.tabs, into: <<>> do
-        <<type_byte::8, byte_size(name)::8, name::binary>>
-      end
-
-    header =
-      <<@op_gui_bottom_panel, 1, model.active_tab_index::8, model.height_percent::8,
-        model.filter_byte::8, Enum.count(model.tabs)::8, tab_defs::binary>>
-
-    header <> encode_messages(model.stream_instance, model.messages)
+    Writer.new(@command)
+    |> Writer.uint8(:opcode, @op_gui_bottom_panel)
+    |> Writer.uint8(:visible, 1)
+    |> Writer.uint8(:active_tab_index, model.active_tab_index)
+    |> Writer.uint8(:height_percent, model.height_percent)
+    |> Writer.uint8(:filter, model.filter_byte)
+    |> Writer.uint8(:tab_count, Enum.count(model.tabs))
+    |> Writer.append(Enum.map(model.tabs, &encode_tab/1))
+    |> Writer.append(encode_messages(model.stream_instance, model.messages))
+    |> Writer.finish()
   end
 
-  @spec encode_messages(BottomPanel.stream_instance(), [BottomPanel.MessageEntry.t()]) :: binary()
-  defp encode_messages(stream_instance, entries) when stream_instance in 1..0xFFFF_FFFF do
-    entry_data =
-      for entry <- entries, into: <<>> do
-        path_bytes = entry.file_path || ""
+  @spec encode_tab(BottomPanel.tab()) :: binary()
+  defp encode_tab({type_byte, name}) do
+    Writer.new(@command)
+    |> Writer.uint8(:tab_type, type_byte)
+    |> Writer.string8(:tab_name, name)
+    |> Writer.finish()
+  end
 
-        <<entry.id::32, entry.level_byte::8, entry.subsystem_byte::8, entry.ts_secs::32,
-          byte_size(path_bytes)::16, path_bytes::binary, byte_size(entry.text)::16,
-          entry.text::binary>>
-      end
+  @spec encode_messages(BottomPanel.stream_instance(), [MessageEntry.t()]) :: binary()
+  defp encode_messages(stream_instance, entries) do
+    Writer.new(@command)
+    |> Writer.uint32(:stream_instance, stream_instance)
+    |> Writer.uint16(:entry_count, Enum.count(entries))
+    |> Writer.append(Enum.map(entries, &encode_message/1))
+    |> Writer.finish()
+  end
 
-    <<stream_instance::32, Enum.count(entries)::16, entry_data::binary>>
+  @spec encode_message(MessageEntry.t()) :: binary()
+  defp encode_message(%MessageEntry{} = entry) do
+    Writer.new(@command)
+    |> Writer.uint32(:message_id, entry.id)
+    |> Writer.uint8(:message_level, entry.level_byte)
+    |> Writer.uint8(:message_subsystem, entry.subsystem_byte)
+    |> Writer.uint32(:message_timestamp, entry.ts_secs)
+    |> Writer.string16(:message_path, entry.file_path || "")
+    |> Writer.string16(:message_text, entry.text)
+    |> Writer.finish()
   end
 end

--- a/lib/minga/frontend/adapter/gui/change_summary_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/change_summary_encoder.ex
@@ -2,7 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.ChangeSummaryEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.ChangeSummary
 
@@ -23,38 +23,23 @@ defmodule Minga.Frontend.Adapter.GUI.ChangeSummaryEncoder do
   defp encode_binary(%ChangeSummary{entries: entries, selected_index: selected_index}) do
     visible = if entries == [], do: 0, else: 1
 
-    entry_binaries =
-      Enum.map(entries, fn entry ->
-        path_bytes = :erlang.iolist_to_binary([entry.path])
-        action_byte = action_byte(entry.action)
+    writer =
+      :gui_change_summary
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_change_summary>>)
+      |> Writer.uint8(:visible, visible)
+      |> Writer.uint16(:selected_index, selected_index)
+      |> Writer.uint16(:entry_count, Enum.count(entries))
 
-        Wire.validate_uint!(
-          :gui_change_summary,
-          :path_length,
-          byte_size(path_bytes),
-          Wire.max_u16()
-        )
-
-        Wire.validate_uint!(:gui_change_summary, :lines_added, entry.lines_added, Wire.max_u32())
-
-        Wire.validate_uint!(
-          :gui_change_summary,
-          :lines_removed,
-          entry.lines_removed,
-          Wire.max_u32()
-        )
-
-        <<byte_size(path_bytes)::16, path_bytes::binary, action_byte::8, entry.lines_added::32,
-          entry.lines_removed::32>>
-      end)
-
-    Wire.validate_uint!(:gui_change_summary, :selected_index, selected_index, Wire.max_u16())
-    Wire.validate_uint!(:gui_change_summary, :entry_count, Enum.count(entries), Wire.max_u16())
-
-    IO.iodata_to_binary([
-      <<@op_gui_change_summary, visible::8, selected_index::16, Enum.count(entries)::16>>
-      | entry_binaries
-    ])
+    entries
+    |> Enum.reduce(writer, fn entry, acc ->
+      acc
+      |> Writer.string16(:entry_path, entry.path)
+      |> Writer.uint8(:entry_action, action_byte(entry.action))
+      |> Writer.uint32(:lines_added, entry.lines_added)
+      |> Writer.uint32(:lines_removed, entry.lines_removed)
+    end)
+    |> Writer.finish()
   end
 
   @spec action_byte(ChangeSummary.Entry.action()) :: non_neg_integer()

--- a/lib/minga/frontend/adapter/gui/config_state_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/config_state_encoder.ex
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.ConfigStateEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.ConfigState
 
@@ -33,82 +34,110 @@ defmodule Minga.Frontend.Adapter.GUI.ConfigStateEncoder do
   # so frontends decode it unchanged.
   @spec encode_command(ConfigState.t()) :: binary()
   def encode_command(%ConfigState{} = model) do
-    option_entries = Enum.map(model.options, fn {name, value} -> encode_option(name, value) end)
-    preview_entries = Enum.map(model.theme_previews, &encode_theme_preview/1)
-    binding_entries = Enum.map(model.keybindings, &encode_keybinding/1)
+    writer =
+      :gui_config_state
+      |> Writer.new()
+      |> Writer.uint16(:option_count, Enum.count(model.options))
 
-    payload =
-      IO.iodata_to_binary([
-        <<Enum.count(option_entries)::16>>,
-        option_entries,
-        <<Enum.count(preview_entries)::16>>,
-        preview_entries,
-        <<Enum.count(binding_entries)::16>>,
-        binding_entries
-      ])
+    writer =
+      Enum.reduce(model.options, writer, fn {name, value}, acc ->
+        encode_option(acc, name, value)
+      end)
 
-    <<@op_gui_config_state, byte_size(payload)::16, payload::binary>>
+    writer = Writer.uint16(writer, :theme_preview_count, Enum.count(model.theme_previews))
+
+    writer =
+      Enum.reduce(model.theme_previews, writer, fn preview, acc ->
+        encode_theme_preview(acc, preview)
+      end)
+
+    writer = Writer.uint16(writer, :keybinding_count, Enum.count(model.keybindings))
+
+    writer =
+      Enum.reduce(model.keybindings, writer, fn binding, acc ->
+        encode_keybinding(acc, binding)
+      end)
+
+    payload = Writer.finish(writer)
+
+    :gui_config_state
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_config_state>>)
+    |> Writer.payload16(:payload, payload)
+    |> Writer.finish()
   end
 
-  @spec encode_option(String.t(), ConfigState.value()) :: binary()
-  defp encode_option(name, value) when is_binary(name) do
-    name_bytes = :erlang.iolist_to_binary([name])
-    value_payload = encode_value(value)
-    <<byte_size(name_bytes)::8, name_bytes::binary, value_payload::binary>>
+  @spec encode_option(Writer.t(), String.t(), ConfigState.value()) :: Writer.t()
+  defp encode_option(%Writer{} = writer, name, value) when is_binary(name) do
+    writer
+    |> Writer.string8(:option_name, name)
+    |> encode_value(value)
   end
 
-  @spec encode_value(ConfigState.value()) :: binary()
-  defp encode_value(value) when is_boolean(value) do
+  @spec encode_value(Writer.t(), ConfigState.value()) :: Writer.t()
+  defp encode_value(%Writer{} = writer, value) when is_boolean(value) do
     encoded = if value, do: 1, else: 0
-    <<@value_boolean::8, encoded::8>>
+
+    writer
+    |> Writer.append(<<@value_boolean::8>>)
+    |> Writer.uint8(:boolean_value, encoded)
   end
 
-  defp encode_value(value) when is_integer(value),
-    do: <<@value_integer::8, value::32-signed>>
-
-  defp encode_value(value) when is_binary(value) do
-    bytes = :erlang.iolist_to_binary([value])
-    <<@value_string::8, byte_size(bytes)::16, bytes::binary>>
+  defp encode_value(%Writer{} = writer, value) when is_integer(value) do
+    writer
+    |> Writer.append(<<@value_integer::8>>)
+    |> Writer.int32(:integer_value, value)
   end
 
-  defp encode_value(value) when is_atom(value) do
-    bytes = Atom.to_string(value)
-    <<@value_atom::8, byte_size(bytes)::16, bytes::binary>>
+  defp encode_value(%Writer{} = writer, value) when is_binary(value) do
+    writer
+    |> Writer.append(<<@value_string::8>>)
+    |> Writer.string16(:string_value, value)
   end
 
-  defp encode_value(value) when is_float(value), do: <<@value_float::8, value::float-64>>
-
-  defp encode_value(value) do
-    bytes = inspect(value)
-    <<@value_string::8, byte_size(bytes)::16, bytes::binary>>
+  defp encode_value(%Writer{} = writer, value) when is_atom(value) do
+    writer
+    |> Writer.append(<<@value_atom::8>>)
+    |> Writer.string16(:atom_value, Atom.to_string(value))
   end
 
-  @spec encode_theme_preview(ConfigState.theme_preview()) :: binary()
-  defp encode_theme_preview(%{
+  defp encode_value(%Writer{} = writer, value) when is_float(value) do
+    Writer.append(writer, <<@value_float::8, value::float-64>>)
+  end
+
+  defp encode_value(%Writer{} = writer, value) do
+    writer
+    |> Writer.append(<<@value_string::8>>)
+    |> Writer.string16(:inspected_value, inspect(value))
+  end
+
+  @spec encode_theme_preview(Writer.t(), ConfigState.theme_preview()) :: Writer.t()
+  defp encode_theme_preview(%Writer{} = writer, %{
          name: name,
          atom: atom,
          editor_bg: bg,
          editor_fg: fg,
          accent: accent
        }) do
-    <<string8(name)::binary, string8(atom)::binary, bg::24, fg::24, accent::24>>
+    writer
+    |> Writer.string8(:theme_name, name)
+    |> Writer.string8(:theme_atom, atom)
+    |> Writer.rgb24(:theme_editor_bg, bg)
+    |> Writer.rgb24(:theme_editor_fg, fg)
+    |> Writer.rgb24(:theme_accent, accent)
   end
 
-  @spec encode_keybinding(ConfigState.keybinding()) :: binary()
-  defp encode_keybinding(%{mode: mode, key: key, command: command, description: desc}) do
-    <<string8(mode)::binary, string16(key)::binary, string16(command)::binary,
-      string16(desc)::binary>>
-  end
-
-  @spec string8(String.t()) :: binary()
-  defp string8(value) do
-    bytes = :erlang.iolist_to_binary([value])
-    <<byte_size(bytes)::8, bytes::binary>>
-  end
-
-  @spec string16(String.t()) :: binary()
-  defp string16(value) do
-    bytes = :erlang.iolist_to_binary([value])
-    <<byte_size(bytes)::16, bytes::binary>>
+  @spec encode_keybinding(Writer.t(), ConfigState.keybinding()) :: Writer.t()
+  defp encode_keybinding(%Writer{} = writer, %{
+         mode: mode,
+         key: key,
+         command: command,
+         description: desc
+       }) do
+    writer
+    |> Writer.string8(:keybinding_mode, mode)
+    |> Writer.string16(:keybinding_key, key)
+    |> Writer.string16(:keybinding_command, command)
+    |> Writer.string16(:keybinding_description, desc)
   end
 end

--- a/lib/minga/frontend/adapter/gui/cursor_animation_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/cursor_animation_encoder.ex
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.CursorAnimationEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.CursorAnimation
 
@@ -23,6 +24,11 @@ defmodule Minga.Frontend.Adapter.GUI.CursorAnimationEncoder do
   @spec encode_command(CursorAnimation.t()) :: binary()
   def encode_command(%CursorAnimation{enabled?: enabled?}) do
     enabled_byte = if enabled?, do: 1, else: 0
-    <<@op_gui_cursor_animation, 1::16, enabled_byte::8>>
+
+    :gui_cursor_animation
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_cursor_animation, 1::16>>)
+    |> Writer.uint8(:enabled, enabled_byte)
+    |> Writer.finish()
   end
 end

--- a/lib/minga/frontend/adapter/gui/edit_timeline_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/edit_timeline_encoder.ex
@@ -2,11 +2,14 @@ defmodule Minga.Frontend.Adapter.GUI.EditTimelineEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.EditTimeline
+  alias Minga.RenderModel.UI.EditTimeline.Entry
+  alias Minga.RenderModel.UI.EditTimeline.FileEntry
 
   @op_gui_edit_timeline Opcodes.gui_edit_timeline()
-  @max_u8 255
+  @command :gui_edit_timeline
 
   @spec encode(EditTimeline.t(), Caches.t()) :: {binary() | nil, Caches.t()}
   def encode(%EditTimeline{} = model, %Caches{} = caches) do
@@ -25,59 +28,56 @@ defmodule Minga.Frontend.Adapter.GUI.EditTimelineEncoder do
   # viewing_index of 0xFFFF means "live at latest" (nil).
   @spec encode_binary(EditTimeline.t()) :: binary()
   defp encode_binary(%EditTimeline{} = model) do
-    visible_byte = if model.visible?, do: 1, else: 0
-
-    viewing_u16 =
-      if model.viewing_index == nil, do: 0xFFFF, else: min(model.viewing_index, 0xFFFE)
-
-    count = min(Enum.count(model.entries), @max_u8)
-
-    entry_binaries =
-      model.entries
-      |> Enum.take(@max_u8)
-      |> Enum.map(fn entry ->
-        tool_name_bytes = :erlang.iolist_to_binary([entry.tool_name])
-        tool_name_len = min(byte_size(tool_name_bytes), @max_u8)
-        truncated_name = binary_part(tool_name_bytes, 0, tool_name_len)
-
-        <<entry.index::8, tool_name_len::8, truncated_name::binary, entry.timestamp_delta::32>>
-      end)
-
-    file_binaries = encode_files(model.files)
-
     payload =
-      IO.iodata_to_binary([
-        <<visible_byte::8, viewing_u16::16, count::8>>,
-        entry_binaries,
-        file_binaries
-      ])
+      Writer.new(@command)
+      |> Writer.uint8(:visible, if(model.visible?, do: 1, else: 0))
+      |> encode_viewing_index(model.viewing_index)
+      |> Writer.uint8(:entry_count, Enum.count(model.entries))
+      |> Writer.append(Enum.map(model.entries, &encode_entry/1))
+      |> Writer.append(encode_files(model.files))
+      |> Writer.finish()
 
-    <<@op_gui_edit_timeline, byte_size(payload)::16, payload::binary>>
+    Writer.new(@command)
+    |> Writer.uint8(:opcode, @op_gui_edit_timeline)
+    |> Writer.payload16(:payload, payload)
+    |> Writer.finish()
   end
 
-  @spec encode_files([EditTimeline.FileEntry.t()]) :: iodata()
+  @spec encode_viewing_index(Writer.t(), non_neg_integer() | nil) :: Writer.t()
+  defp encode_viewing_index(writer, nil), do: Writer.uint16(writer, :viewing_index, 0xFFFF)
+
+  defp encode_viewing_index(writer, index),
+    do: Writer.uint16(writer, :viewing_index, index, 0xFFFE)
+
+  @spec encode_entry(Entry.t()) :: binary()
+  defp encode_entry(%Entry{} = entry) do
+    Writer.new(@command)
+    |> Writer.uint8(:entry_index, entry.index)
+    |> Writer.string8(:tool_name, entry.tool_name)
+    |> Writer.uint32(:timestamp_delta, entry.timestamp_delta)
+    |> Writer.finish()
+  end
+
+  @spec encode_files([FileEntry.t()]) :: binary()
   defp encode_files(files) do
-    count = min(Enum.count(files), @max_u8)
-
-    entries =
-      files
-      |> Enum.take(@max_u8)
-      |> Enum.map(fn file ->
-        path_bytes = :erlang.iolist_to_binary([file.path])
-        path_len = min(byte_size(path_bytes), 0xFFFF)
-        truncated_path = binary_part(path_bytes, 0, path_len)
-
-        [
-          <<path_len::16, truncated_path::binary, min(file.entry_count, @max_u8)::8,
-            file.lines_added::32, file.lines_removed::32,
-            review_status_to_byte(file.review_status)::8>>
-        ]
-      end)
-
-    [<<count::8>>, entries]
+    Writer.new(@command)
+    |> Writer.uint8(:file_count, Enum.count(files))
+    |> Writer.append(Enum.map(files, &encode_file/1))
+    |> Writer.finish()
   end
 
-  @spec review_status_to_byte(EditTimeline.FileEntry.review_status()) :: non_neg_integer()
+  @spec encode_file(FileEntry.t()) :: binary()
+  defp encode_file(%FileEntry{} = file) do
+    Writer.new(@command)
+    |> Writer.string16(:path, file.path)
+    |> Writer.uint8(:file_entry_count, file.entry_count)
+    |> Writer.uint32(:lines_added, file.lines_added)
+    |> Writer.uint32(:lines_removed, file.lines_removed)
+    |> Writer.uint8(:review_status, review_status_to_byte(file.review_status))
+    |> Writer.finish()
+  end
+
+  @spec review_status_to_byte(FileEntry.review_status()) :: non_neg_integer()
   defp review_status_to_byte(:pending), do: 0
   defp review_status_to_byte(:reviewing), do: 1
 end

--- a/lib/minga/frontend/adapter/gui/empty_state_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/empty_state_encoder.ex
@@ -2,7 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.EmptyStateEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.EmptyState
   alias Minga.RenderModel.UI.EmptyState.Item
@@ -32,51 +32,52 @@ defmodule Minga.Frontend.Adapter.GUI.EmptyStateEncoder do
   end
 
   def encode_command(%EmptyState{} = model) do
-    payload = encode_payload(model)
-    <<@op_gui_empty_state, byte_size(payload)::16, payload::binary>>
+    :gui_empty_state
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_empty_state>>)
+    |> Writer.payload16(:payload, encode_payload(model))
+    |> Writer.finish()
   end
 
   @spec encode_payload(EmptyState.t()) :: binary()
   defp encode_payload(%EmptyState{} = model) do
     flags = if model.crashed?, do: 0x01, else: 0x00
 
-    IO.iodata_to_binary([
-      <<1::8, flags::8>>,
-      string8(model.version),
-      string8(model.focused_id || ""),
-      <<Enum.count(model.sections)::8>>,
-      Enum.map(model.sections, &encode_section/1)
-    ])
+    writer =
+      :gui_empty_state
+      |> Writer.new()
+      |> Writer.append(<<1::8>>)
+      |> Writer.uint8(:flags, flags)
+      |> Writer.string8(:version, model.version)
+      |> Writer.string8(:focused_id, model.focused_id || "")
+      |> Writer.uint8(:section_count, Enum.count(model.sections))
+
+    model.sections
+    |> Enum.reduce(writer, &encode_section/2)
+    |> Writer.finish()
   end
 
-  @spec encode_section(Section.t()) :: iodata()
-  defp encode_section(%Section{} = section) do
-    [
-      <<Map.fetch!(@section_ids, section.id)::8>>,
-      string8(section.title),
-      <<Enum.count(section.items)::8>>,
-      Enum.map(section.items, &encode_item/1)
-    ]
+  @spec encode_section(Section.t(), Writer.t()) :: Writer.t()
+  defp encode_section(%Section{} = section, %Writer{} = writer) do
+    writer =
+      writer
+      |> Writer.uint8(:section_id, Map.fetch!(@section_ids, section.id))
+      |> Writer.string8(:section_title, section.title)
+      |> Writer.uint8(:section_item_count, Enum.count(section.items))
+
+    Enum.reduce(section.items, writer, &encode_item/2)
   end
 
-  @spec encode_item(Item.t()) :: iodata()
-  defp encode_item(%Item{} = item) do
-    [
-      <<Map.fetch!(@item_kinds, item.kind)::8>>,
-      string8(item.id),
-      string16(item.label),
-      string16(item.detail),
-      string8(item.jump_key || ""),
-      string8(item.chord),
-      string8(item.icon),
-      <<item.icon_color::32>>
-    ]
+  @spec encode_item(Item.t(), Writer.t()) :: Writer.t()
+  defp encode_item(%Item{} = item, %Writer{} = writer) do
+    writer
+    |> Writer.uint8(:item_kind, Map.fetch!(@item_kinds, item.kind))
+    |> Writer.string8(:item_id, item.id)
+    |> Writer.string16(:item_label, item.label)
+    |> Writer.string16(:item_detail, item.detail)
+    |> Writer.string8(:item_jump_key, item.jump_key || "")
+    |> Writer.string8(:item_chord, item.chord)
+    |> Writer.string8(:item_icon, item.icon)
+    |> Writer.uint32(:item_icon_color, item.icon_color)
   end
-
-  @spec string8(String.t()) :: binary()
-  defp string8(value), do: value |> Wire.utf8_prefix_bytes(255) |> Wire.encode_string8()
-
-  @spec string16(String.t()) :: binary()
-  defp string16(value),
-    do: value |> Wire.utf8_prefix_bytes(Wire.max_u16()) |> Wire.encode_string16()
 end

--- a/lib/minga/frontend/adapter/gui/extension_overlay_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/extension_overlay_encoder.ex
@@ -2,7 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionOverlayEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.ExtensionOverlay
   alias Minga.RenderModel.UI.ExtensionOverlay.Entry
@@ -22,32 +22,38 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionOverlayEncoder do
 
   @spec encode_command(ExtensionOverlay.t()) :: binary()
   def encode_command(%ExtensionOverlay{} = model) do
-    validate!(:entry_count, Enum.count(model.entries), Wire.max_u8())
-    overlay_binaries = Enum.map(model.entries, &encode_entry/1)
+    writer =
+      :gui_extension_overlay
+      |> Writer.new()
+      |> Writer.uint8(:entry_count, Enum.count(model.entries))
 
-    payload = IO.iodata_to_binary([<<Enum.count(overlay_binaries)::8>> | overlay_binaries])
-    validate!(:payload_length, byte_size(payload), Wire.max_u16())
-    <<@op_gui_extension_overlay, byte_size(payload)::16, payload::binary>>
+    payload =
+      model.entries
+      |> Enum.reduce(writer, &encode_entry/2)
+      |> Writer.finish()
+
+    :gui_extension_overlay
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_extension_overlay>>)
+    |> Writer.payload16(:payload_length, payload)
+    |> Writer.finish()
   end
 
   @spec fingerprint(ExtensionOverlay.t()) :: term()
   defp fingerprint(%ExtensionOverlay{} = model), do: model.entries
 
-  @spec encode_entry(Entry.t()) :: binary()
-  defp encode_entry(%Entry{} = entry) do
-    ext_name = encode_string8(to_string(entry.extension), :extension_length)
-    oid = encode_string8(to_string(entry.overlay_id), :overlay_id_length)
-    content = encode_string16(entry.content, :content_length)
-    {r, g, b} = Wire.rgb(entry.fg)
-    shape = overlay_shape_byte(entry.shape)
-
-    validate!(:window_id, entry.window_id, Wire.max_u16())
-    validate!(:row, entry.row, Wire.max_u16())
-    validate!(:col, entry.col, Wire.max_u16())
-    validate!(:opacity, entry.opacity, Wire.max_u8())
-
-    <<ext_name::binary, oid::binary, entry.window_id::16, entry.row::16, entry.col::16, shape::8,
-      r::8, g::8, b::8, entry.opacity::8, content::binary>>
+  @spec encode_entry(Entry.t(), Writer.t()) :: Writer.t()
+  defp encode_entry(%Entry{} = entry, %Writer{} = writer) do
+    writer
+    |> Writer.string8(:extension_length, to_string(entry.extension))
+    |> Writer.string8(:overlay_id_length, to_string(entry.overlay_id))
+    |> Writer.uint16(:window_id, entry.window_id)
+    |> Writer.uint16(:row, entry.row)
+    |> Writer.uint16(:col, entry.col)
+    |> Writer.uint8(:shape, overlay_shape_byte(entry.shape))
+    |> Writer.rgb24(:fg, entry.fg)
+    |> Writer.uint8(:opacity, entry.opacity)
+    |> Writer.string16(:content_length, entry.content)
   end
 
   @spec overlay_shape_byte(Entry.shape()) :: non_neg_integer()
@@ -56,22 +62,4 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionOverlayEncoder do
   defp overlay_shape_byte(:label), do: 2
   defp overlay_shape_byte(:indicator), do: 3
   defp overlay_shape_byte(_shape), do: 3
-
-  @spec encode_string8(iodata(), atom()) :: binary()
-  defp encode_string8(value, field) do
-    bytes = :erlang.iolist_to_binary([value])
-    validate!(field, byte_size(bytes), Wire.max_u8())
-    <<byte_size(bytes)::8, bytes::binary>>
-  end
-
-  @spec encode_string16(iodata(), atom()) :: binary()
-  defp encode_string16(value, field) do
-    bytes = :erlang.iolist_to_binary([value])
-    validate!(field, byte_size(bytes), Wire.max_u16())
-    <<byte_size(bytes)::16, bytes::binary>>
-  end
-
-  @spec validate!(atom(), term(), non_neg_integer()) :: :ok
-  defp validate!(field, value, max),
-    do: Wire.validate_uint!(:gui_extension_overlay, field, value, max)
 end

--- a/lib/minga/frontend/adapter/gui/extension_panel_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/extension_panel_encoder.ex
@@ -2,7 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionPanelEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.ExtensionPanel
   alias Minga.RenderModel.UI.ExtensionPanel.Content.KeyValue
@@ -32,182 +32,150 @@ defmodule Minga.Frontend.Adapter.GUI.ExtensionPanelEncoder do
 
   @spec encode_command(ExtensionPanel.t()) :: binary()
   def encode_command(%ExtensionPanel{} = model) do
-    validate_uint!(:panel_count, Enum.count(model.panels), Wire.max_u8())
-    panel_binaries = Enum.map(model.panels, &encode_panel/1)
+    writer =
+      :gui_extension_panel
+      |> Writer.new()
+      |> Writer.uint8(:panel_count, Enum.count(model.panels))
 
-    payload = IO.iodata_to_binary([<<Enum.count(panel_binaries)::8>> | panel_binaries])
-    validate_uint!(:payload_length, byte_size(payload), Wire.max_u16())
-    <<@op_gui_extension_panel, byte_size(payload)::16, payload::binary>>
+    payload =
+      model.panels
+      |> Enum.reduce(writer, &encode_panel/2)
+      |> Writer.finish()
+
+    :gui_extension_panel
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_extension_panel>>)
+    |> Writer.payload16(:payload, payload)
+    |> Writer.finish()
   end
 
   @spec fingerprint(ExtensionPanel.t()) :: term()
   defp fingerprint(%ExtensionPanel{} = model), do: model.panels
 
-  @spec encode_panel(Panel.t()) :: binary()
-  defp encode_panel(%Panel{} = panel) do
-    ext = encode_string8(panel.extension, :extension_length)
-    panel_id = encode_string8(panel.panel_id, :panel_id_length)
-    title = encode_string8(panel.title, :title_length)
-    {size_type, size_val} = encode_size(panel.size)
-    position = encode_position(panel.position)
+  @spec encode_panel(Panel.t(), Writer.t()) :: Writer.t()
+  defp encode_panel(%Panel{} = panel, %Writer{} = writer) do
+    {size_type, size_value} = encode_size(panel.size)
     visible = if panel.visible?, do: 1, else: 0
-    {blocks, block_count} = encode_content_blocks(panel.content)
 
-    <<ext::binary, panel_id::binary, title::binary, position::8, size_type::8, size_val::8,
-      visible::8, block_count::8, blocks::binary>>
+    writer =
+      writer
+      |> Writer.string8(:extension, panel.extension)
+      |> Writer.string8(:panel_id, panel.panel_id)
+      |> Writer.string8(:panel_title, panel.title)
+      |> Writer.uint8(:panel_position, encode_position(panel.position))
+      |> Writer.uint8(:panel_size_type, size_type)
+      |> Writer.uint8(:panel_size_value, size_value)
+      |> Writer.uint8(:panel_visible, visible)
+      |> Writer.uint8(:panel_block_count, Enum.count(panel.content))
+
+    Enum.reduce(panel.content, writer, &encode_content_block/2)
   end
 
   @spec encode_size(Panel.size()) :: {non_neg_integer(), non_neg_integer()}
-  defp encode_size({:percent, n}), do: {0, validate_value!(n, :size_percent, Wire.max_u8())}
-  defp encode_size({:lines, n}), do: {1, validate_value!(n, :size_lines, Wire.max_u8())}
+  defp encode_size({:percent, value}), do: {0, value}
+  defp encode_size({:lines, value}), do: {1, value}
 
   @spec encode_position(Panel.position()) :: non_neg_integer()
   defp encode_position(:bottom), do: 0
   defp encode_position(:right), do: 1
   defp encode_position(:float), do: 2
 
-  @spec encode_content_blocks([Panel.content_block()]) :: {binary(), non_neg_integer()}
-  defp encode_content_blocks(blocks) do
-    validate_uint!(:block_count, Enum.count(blocks), Wire.max_u8())
-    block_binaries = Enum.map(blocks, &encode_content_block/1)
-
-    {IO.iodata_to_binary(block_binaries), Enum.count(block_binaries)}
+  @spec encode_content_block(Panel.content_block(), Writer.t()) :: Writer.t()
+  defp encode_content_block(%Text{text: text}, %Writer{} = writer) do
+    writer |> Writer.append(<<0::8>>) |> Writer.string16(:text, text)
   end
 
-  @spec encode_content_block(Panel.content_block()) :: binary()
-  defp encode_content_block(%Text{text: text}) do
-    <<0::8, encode_string16(text, :text_length)::binary>>
+  defp encode_content_block(%StyledText{runs: runs}, %Writer{} = writer) do
+    writer =
+      writer
+      |> Writer.append(<<1::8>>)
+      |> Writer.uint8(:styled_run_count, Enum.count(runs))
+
+    Enum.reduce(runs, writer, &encode_styled_run/2)
   end
 
-  defp encode_content_block(%StyledText{runs: runs}) do
-    validate_uint!(:styled_run_count, Enum.count(runs), Wire.max_u8())
-    run_binaries = Enum.map(runs, &encode_styled_run/1)
+  defp encode_content_block(%Table{} = table, %Writer{} = writer) do
+    writer =
+      writer
+      |> Writer.append(<<2::8>>)
+      |> Writer.uint8(:table_column_count, Enum.count(table.columns))
+      |> Writer.uint16(:table_row_count, Enum.count(table.rows))
+      |> encode_selected(table.selected)
 
-    run_data = IO.iodata_to_binary(run_binaries)
-    <<1::8, Enum.count(run_binaries)::8, run_data::binary>>
+    writer = Enum.reduce(table.columns, writer, &Writer.string16(&2, :table_column, &1))
+
+    Enum.reduce(table.rows, writer, fn row, acc ->
+      Enum.reduce(row, acc, &Writer.string16(&2, :table_cell, &1))
+    end)
   end
 
-  defp encode_content_block(%Table{} = table) do
-    columns = table.columns
-    rows = table.rows
-    validate_uint!(:table_column_count, Enum.count(columns), Wire.max_u8())
-    validate_uint!(:table_row_count, Enum.count(rows), Wire.max_u16())
+  defp encode_content_block(%KeyValue{pairs: pairs}, %Writer{} = writer) do
+    writer =
+      writer
+      |> Writer.append(<<3::8>>)
+      |> Writer.uint8(:key_value_count, Enum.count(pairs))
 
-    col_data =
-      IO.iodata_to_binary(
-        Enum.map(columns, fn col -> encode_string16(col, :table_column_length) end)
-      )
-
-    row_data =
-      IO.iodata_to_binary(
-        Enum.map(rows, fn row ->
-          IO.iodata_to_binary(
-            Enum.map(row, fn cell -> encode_string16(cell, :table_cell_length) end)
-          )
-        end)
-      )
-
-    selected = encode_selected(table.selected)
-
-    <<2::8, Enum.count(columns)::8, Enum.count(rows)::16, selected::16, col_data::binary,
-      row_data::binary>>
+    Enum.reduce(pairs, writer, fn {key, value}, acc ->
+      acc |> Writer.string16(:key, key) |> Writer.string16(:value, value)
+    end)
   end
 
-  defp encode_content_block(%KeyValue{pairs: pairs}) do
-    validate_uint!(:key_value_count, Enum.count(pairs), Wire.max_u8())
+  defp encode_content_block(%Separator{}, %Writer{} = writer),
+    do: Writer.append(writer, <<4::8>>)
 
-    pair_data =
-      IO.iodata_to_binary(
-        Enum.map(pairs, fn {key, value} ->
-          [encode_string16(key, :key_length), encode_string16(value, :value_length)]
-        end)
-      )
-
-    <<3::8, Enum.count(pairs)::8, pair_data::binary>>
+  defp encode_content_block(%Progress{label: label, percent: percent}, %Writer{} = writer) do
+    writer
+    |> Writer.append(<<5::8>>)
+    |> Writer.string16(:progress_label, label)
+    |> Writer.uint16(:progress_percent, round(percent * 100))
   end
 
-  defp encode_content_block(%Separator{}) do
-    <<4::8>>
+  defp encode_content_block(%Tree{nodes: nodes}, %Writer{} = writer) do
+    writer
+    |> Writer.append(<<6::8>>)
+    |> Writer.payload16(:tree, encode_tree_nodes(nodes))
   end
 
-  defp encode_content_block(%Progress{label: label, percent: percent}) do
-    percent_int =
-      percent |> Kernel.*(100) |> round() |> validate_value!(:progress_percent, Wire.max_u16())
+  defp encode_content_block(%Unknown{}, %Writer{} = writer),
+    do: Writer.append(writer, <<255::8>>)
 
-    <<5::8, encode_string16(label, :progress_label_length)::binary, percent_int::16>>
-  end
+  @spec encode_selected(Writer.t(), non_neg_integer() | nil) :: Writer.t()
+  defp encode_selected(%Writer{} = writer, nil),
+    do: Writer.uint16(writer, :table_selected, 0xFFFF)
 
-  defp encode_content_block(%Tree{nodes: nodes}) do
-    node_data = encode_tree_nodes(nodes)
-    validate_uint!(:tree_length, byte_size(node_data), Wire.max_u16())
-    <<6::8, byte_size(node_data)::16, node_data::binary>>
-  end
+  defp encode_selected(%Writer{} = writer, selected),
+    do: Writer.uint16(writer, :table_selected, selected, 65_534)
 
-  defp encode_content_block(%Unknown{}), do: <<255::8>>
-
-  @spec encode_selected(non_neg_integer() | nil) :: non_neg_integer()
-  defp encode_selected(nil), do: 0xFFFF
-
-  defp encode_selected(selected) when is_integer(selected) and selected >= 0,
-    do: min(selected, Wire.max_u16() - 1)
-
-  defp encode_selected(_selected), do: 0xFFFF
-
-  @spec encode_styled_run(StyledRun.t()) :: binary()
-  defp encode_styled_run(%StyledRun{} = run) do
+  @spec encode_styled_run(StyledRun.t(), Writer.t()) :: Writer.t()
+  defp encode_styled_run(%StyledRun{} = run, %Writer{} = writer) do
     bold = if Map.get(run.attrs, :bold?, false), do: 1, else: 0
     italic = if Map.get(run.attrs, :italic?, false), do: 1, else: 0
-    {r, g, b} = Wire.rgb(run.fg)
 
-    <<encode_string16(run.text, :styled_run_length)::binary, r::8, g::8, b::8, bold::8,
-      italic::8>>
+    writer
+    |> Writer.string16(:styled_run, run.text)
+    |> Writer.rgb24(:styled_run_fg, run.fg)
+    |> Writer.uint8(:styled_run_bold, bold)
+    |> Writer.uint8(:styled_run_italic, italic)
   end
 
   @spec encode_tree_nodes([TreeNode.t()]) :: binary()
   defp encode_tree_nodes(nodes) do
-    {data, count} = encode_tree_node_list(nodes)
-    IO.iodata_to_binary([<<count::8>>, data])
+    writer = Writer.uint8(Writer.new(:gui_extension_panel), :tree_node_count, Enum.count(nodes))
+
+    nodes
+    |> Enum.reduce(writer, &encode_tree_node/2)
+    |> Writer.finish()
   end
 
-  @spec encode_tree_node_list([TreeNode.t()]) :: {binary(), non_neg_integer()}
-  defp encode_tree_node_list(nodes) do
-    validate_uint!(:tree_node_count, Enum.count(nodes), Wire.max_u8())
-    node_binaries = Enum.map(nodes, &encode_tree_node/1)
-
-    {IO.iodata_to_binary(node_binaries), Enum.count(node_binaries)}
-  end
-
-  @spec encode_tree_node(TreeNode.t()) :: binary()
-  defp encode_tree_node(%TreeNode{} = node) do
+  @spec encode_tree_node(TreeNode.t(), Writer.t()) :: Writer.t()
+  defp encode_tree_node(%TreeNode{} = node, %Writer{} = writer) do
     expanded = if node.expanded?, do: 1, else: 0
-    {child_nodes, child_count} = encode_tree_node_list(node.children)
-    child_data = IO.iodata_to_binary([<<child_count::8>>, child_nodes])
+    child_data = encode_tree_nodes(node.children)
 
-    <<encode_string16(node.label, :tree_label_length)::binary, expanded::8, child_count::8,
-      child_data::binary>>
+    writer
+    |> Writer.string16(:tree_label, node.label)
+    |> Writer.uint8(:tree_expanded, expanded)
+    |> Writer.uint8(:tree_child_count, Enum.count(node.children))
+    |> Writer.append(child_data)
   end
-
-  @spec encode_string16(iodata(), atom()) :: binary()
-  defp encode_string16(value, field) do
-    bytes = :erlang.iolist_to_binary([value])
-    validate_uint!(field, byte_size(bytes), Wire.max_u16())
-    <<byte_size(bytes)::16, bytes::binary>>
-  end
-
-  @spec encode_string8(iodata(), atom()) :: binary()
-  defp encode_string8(value, field) do
-    bytes = :erlang.iolist_to_binary([value])
-    validate_uint!(field, byte_size(bytes), Wire.max_u8())
-    <<byte_size(bytes)::8, bytes::binary>>
-  end
-
-  @spec validate_value!(term(), atom(), non_neg_integer()) :: non_neg_integer()
-  defp validate_value!(value, field, max) do
-    validate_uint!(field, value, max)
-    value
-  end
-
-  @spec validate_uint!(atom(), term(), non_neg_integer()) :: :ok
-  defp validate_uint!(field, value, max),
-    do: Wire.validate_uint!(:gui_extension_panel, field, value, max)
 end

--- a/lib/minga/frontend/adapter/gui/file_tree_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/file_tree_encoder.ex
@@ -3,6 +3,7 @@ defmodule Minga.Frontend.Adapter.GUI.FileTreeEncoder do
 
   alias Minga.Frontend.Adapter.GUI.Caches
   alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.FileTree
   alias Minga.RenderModel.UI.FileTree.Row
@@ -47,31 +48,48 @@ defmodule Minga.Frontend.Adapter.GUI.FileTreeEncoder do
   @spec encode_command(FileTree.t()) :: binary()
   def encode_command(%FileTree{} = model) do
     root = model.root_path || ""
-    error_reason = error_reason(model.status)
+
+    writer =
+      :gui_file_tree
+      |> Writer.new()
+      |> Writer.append(<<2::8>>)
+      |> Writer.uint8(
+        :flags,
+        file_tree_flags(model.status, model.focused?, model.local_navigation?)
+      )
+      |> Writer.uint8(:status, encode_file_tree_status(model.status))
+      |> Writer.string16(:selected_id, model.selected_id)
+      |> Writer.string16(:root_path, root)
+      |> Writer.uint16(:tree_width, model.tree_width)
+      |> Writer.uint16(:row_count, Enum.count(model.rows))
+      |> Writer.string16(:error_reason, error_reason(model.status))
 
     payload =
-      IO.iodata_to_binary([
-        <<2::8, file_tree_flags(model.status, model.focused?, model.local_navigation?)::8,
-          encode_file_tree_status(model.status)::8>>,
-        Wire.encode_string16(model.selected_id),
-        Wire.encode_string16(root),
-        <<model.tree_width::16, Enum.count(model.rows)::16>>,
-        Wire.encode_string16(error_reason),
-        Enum.map(model.rows, &encode_row(&1, root, model))
-      ])
+      model.rows
+      |> Enum.reduce(writer, fn row, acc -> encode_row(row, root, model, acc) end)
+      |> Writer.finish()
 
-    <<@op_gui_file_tree, byte_size(payload)::32, payload::binary>>
+    :gui_file_tree
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_file_tree>>)
+    |> Writer.payload32(:payload, payload)
+    |> Writer.finish()
   end
 
   @spec encode_selection_command(FileTree.t()) :: binary()
   defp encode_selection_command(%FileTree{} = model) do
     payload =
-      IO.iodata_to_binary([
-        <<file_tree_selection_flags(model.focused?)::8>>,
-        Wire.encode_string16(model.selected_id)
-      ])
+      :gui_file_tree_selection
+      |> Writer.new()
+      |> Writer.uint8(:flags, file_tree_selection_flags(model.focused?))
+      |> Writer.string16(:selected_id, model.selected_id)
+      |> Writer.finish()
 
-    <<@op_gui_file_tree_selection, byte_size(payload)::16, payload::binary>>
+    :gui_file_tree_selection
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_file_tree_selection>>)
+    |> Writer.payload16(:payload, payload)
+    |> Writer.finish()
   end
 
   # Reached only for non-row statuses (:loading, :empty, :error). Ready and
@@ -100,41 +118,45 @@ defmodule Minga.Frontend.Adapter.GUI.FileTreeEncoder do
     row
   end
 
-  @spec encode_row(Row.t(), String.t(), FileTree.t()) :: iodata()
-  defp encode_row(%Row{} = row, root, %FileTree{} = model) do
+  @spec encode_row(Row.t(), String.t(), FileTree.t(), Writer.t()) :: Writer.t()
+  defp encode_row(%Row{} = row, root, %FileTree{} = model, %Writer{} = writer) do
     editing_type = if row.editing, do: encode_editing_type(row.editing.type), else: 0xFF
     editing_text = if row.editing, do: row.editing.text, else: ""
-    guides = Enum.map(row.guides, fn guide? -> if guide?, do: <<1>>, else: <<0>> end)
-    {errors, warnings, info, hints} = clamp_diagnostics(row.diagnostics)
-    {icon_r, icon_g, icon_b} = Wire.rgb(row.icon_color)
+    {errors, warnings, info, hints} = row.diagnostics
 
-    [
-      <<:erlang.phash2(row.id, 0xFFFFFFFF)::32, file_tree_row_flags(row, model)::16, row.depth::8,
-        encode_git_status(row.git_status)::8, errors::16, warnings::16, info::16, hints::16,
-        Enum.count(row.guides)::8>>,
-      guides,
-      Wire.encode_string16(row.id),
-      Wire.encode_string16(row.path),
-      Wire.encode_string16(Path.relative_to(row.path, root)),
-      Wire.encode_string16(row.name),
-      Wire.encode_string8(row.icon),
-      <<editing_type::8>>,
-      Wire.encode_string16(editing_text),
-      <<icon_r::8, icon_g::8, icon_b::8>>,
-      <<encode_heat_level(row.heat_level)::8>>
-    ]
+    writer =
+      writer
+      |> Writer.uint32(:row_id_hash, :erlang.phash2(row.id, 0xFFFFFFFF))
+      |> Writer.uint16(:row_flags, file_tree_row_flags(row, model))
+      |> Writer.uint8(:row_depth, row.depth)
+      |> Writer.uint8(:row_git_status, encode_git_status(row.git_status))
+      |> Writer.uint16(:row_diagnostic_errors, errors)
+      |> Writer.uint16(:row_diagnostic_warnings, warnings)
+      |> Writer.uint16(:row_diagnostic_info, info)
+      |> Writer.uint16(:row_diagnostic_hints, hints)
+      |> Writer.uint8(:row_guide_count, Enum.count(row.guides))
+
+    writer =
+      Enum.reduce(row.guides, writer, fn guide?, acc ->
+        Writer.uint8(acc, :row_guide, if(guide?, do: 1, else: 0))
+      end)
+
+    writer
+    |> Writer.string16(:row_id, row.id)
+    |> Writer.string16(:row_path, row.path)
+    |> Writer.string16(:row_relative_path, Path.relative_to(row.path, root))
+    |> Writer.string16(:row_name, row.name)
+    |> Writer.string8(:row_icon, row.icon)
+    |> Writer.uint8(:row_editing_type, editing_type)
+    |> Writer.string16(:row_editing_text, editing_text)
+    |> Writer.rgb24(:row_icon_color, row.icon_color)
+    |> Writer.uint8(:row_heat_level, encode_heat_level(row.heat_level))
   end
 
   # Familiarity/heat bucket 0..4, or 0xFF for "no decoration".
   @spec encode_heat_level(0..4 | nil) :: non_neg_integer()
   defp encode_heat_level(nil), do: 0xFF
   defp encode_heat_level(level) when level in 0..4, do: level
-
-  @spec clamp_diagnostics(Row.diagnostics()) :: Row.diagnostics()
-  defp clamp_diagnostics({errors, warnings, info, hints}) do
-    {Wire.clamp_u16(errors), Wire.clamp_u16(warnings), Wire.clamp_u16(info),
-     Wire.clamp_u16(hints)}
-  end
 
   @spec file_tree_selection_flags(boolean()) :: non_neg_integer()
   defp file_tree_selection_flags(focused?), do: Wire.maybe_flag(0, focused?, 0)

--- a/lib/minga/frontend/adapter/gui/float_popup_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/float_popup_encoder.ex
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.FloatPopupEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.FloatPopup
 
@@ -22,19 +23,18 @@ defmodule Minga.Frontend.Adapter.GUI.FloatPopupEncoder do
   def encode_command(%FloatPopup{visible?: false}), do: <<@op_gui_float_popup, 0::8>>
 
   def encode_command(%FloatPopup{} = model) do
-    title_bytes = IO.iodata_to_binary(model.title)
+    writer =
+      :gui_float_popup
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_float_popup, 1::8>>)
+      |> Writer.uint16(:width, model.width)
+      |> Writer.uint16(:height, model.height)
+      |> Writer.string16(:title, model.title)
+      |> Writer.uint16(:line_count, Enum.count(model.lines))
 
-    line_data =
-      Enum.map(model.lines, fn line ->
-        text = IO.iodata_to_binary(line)
-        <<byte_size(text)::16, text::binary>>
-      end)
-
-    IO.iodata_to_binary([
-      <<@op_gui_float_popup, 1::8, model.width::16, model.height::16, byte_size(title_bytes)::16,
-        title_bytes::binary, Enum.count(model.lines)::16>>
-      | line_data
-    ])
+    model.lines
+    |> Enum.reduce(writer, &Writer.string16(&2, :line, &1))
+    |> Writer.finish()
   end
 
   @spec fingerprint(FloatPopup.t()) :: term()

--- a/lib/minga/frontend/adapter/gui/gutter_separator_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/gutter_separator_encoder.ex
@@ -1,9 +1,8 @@
 defmodule Minga.Frontend.Adapter.GUI.GutterSeparatorEncoder do
   @moduledoc false
 
-  import Bitwise
-
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.GutterSeparator
 
@@ -22,15 +21,11 @@ defmodule Minga.Frontend.Adapter.GUI.GutterSeparatorEncoder do
 
   @spec encode_binary(GutterSeparator.t()) :: binary()
   defp encode_binary(%GutterSeparator{col: col, color_rgb: rgb}) do
-    <<@op_gui_gutter_sep, col::16, red(rgb)::8, green(rgb)::8, blue(rgb)::8>>
+    :gui_gutter_separator
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_gutter_sep>>)
+    |> Writer.uint16(:col, col)
+    |> Writer.rgb24(:color_rgb, rgb)
+    |> Writer.finish()
   end
-
-  @spec red(non_neg_integer()) :: non_neg_integer()
-  defp red(rgb), do: rgb >>> 16 &&& 0xFF
-
-  @spec green(non_neg_integer()) :: non_neg_integer()
-  defp green(rgb), do: rgb >>> 8 &&& 0xFF
-
-  @spec blue(non_neg_integer()) :: non_neg_integer()
-  defp blue(rgb), do: rgb &&& 0xFF
 end

--- a/lib/minga/frontend/adapter/gui/hover_popup_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/hover_popup_encoder.ex
@@ -3,7 +3,7 @@ defmodule Minga.Frontend.Adapter.GUI.HoverPopupEncoder do
 
   alias Minga.Core.Face
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.HoverPopup
   alias Minga.RenderModel.UI.HoverPopup.Line
@@ -29,14 +29,21 @@ defmodule Minga.Frontend.Adapter.GUI.HoverPopupEncoder do
 
   def encode_command(%HoverPopup{} = model) do
     focused_byte = if model.focused?, do: 1, else: 0
-    line_data = Enum.map(model.content_lines, &encode_line/1)
+
+    writer =
+      :gui_hover_popup
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_hover_popup, 1::8>>)
+      |> Writer.uint16(:anchor_row, model.anchor_row)
+      |> Writer.uint16(:anchor_col, model.anchor_col)
+      |> Writer.uint8(:focused, focused_byte)
+      |> Writer.uint16(:scroll_offset, model.scroll_offset)
+      |> Writer.uint16(:line_count, Enum.count(model.content_lines))
 
     hover =
-      IO.iodata_to_binary([
-        <<@op_gui_hover_popup, 1::8, model.anchor_row::16, model.anchor_col::16, focused_byte::8,
-          model.scroll_offset::16, Enum.count(model.content_lines)::16>>
-        | line_data
-      ])
+      model.content_lines
+      |> Enum.reduce(writer, &encode_line/2)
+      |> Writer.finish()
 
     IO.iodata_to_binary([hover, encode_hover_action(model.open_action_name)])
   end
@@ -49,38 +56,50 @@ defmodule Minga.Frontend.Adapter.GUI.HoverPopupEncoder do
      model.content_lines, model.open_action_name}
   end
 
-  @spec encode_line(Line.t()) :: iodata()
-  defp encode_line(%Line{} = line) do
-    segment_data = Enum.map(line.segments, &encode_markdown_segment/1)
-    line_type_byte = encode_line_type(line.line_type)
-    [<<line_type_byte::8, Enum.count(line.segments)::16>> | segment_data]
+  @spec encode_line(Line.t(), Writer.t()) :: Writer.t()
+  defp encode_line(%Line{} = line, %Writer{} = writer) do
+    writer =
+      writer
+      |> Writer.uint8(:line_type, encode_line_type(line.line_type))
+      |> Writer.uint16(:segment_count, Enum.count(line.segments))
+
+    Enum.reduce(line.segments, writer, &encode_markdown_segment/2)
   end
 
   @spec encode_hover_action(String.t() | nil) :: binary()
   defp encode_hover_action(nil), do: <<@op_gui_hover_action, 1::16, 0::8>>
 
   defp encode_hover_action(action_name) do
-    action_bytes = :erlang.iolist_to_binary([action_name])
-    payload_len = 1 + 2 + byte_size(action_bytes)
+    payload =
+      :gui_hover_action
+      |> Writer.new()
+      |> Writer.append(<<1::8>>)
+      |> Writer.string16(:action_name, action_name)
+      |> Writer.finish()
 
-    <<@op_gui_hover_action, payload_len::16, 1::8, byte_size(action_bytes)::16,
-      action_bytes::binary>>
+    :gui_hover_action
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_hover_action>>)
+    |> Writer.payload16(:payload, payload)
+    |> Writer.finish()
   end
 
-  @spec encode_markdown_segment(Segment.t()) :: binary()
-  defp encode_markdown_segment(%Segment{text: text, style: {:syntax, %Face{} = face}}) do
-    text_bytes = :erlang.iolist_to_binary([text])
-    fg = face.fg || @syntax_fallback_fg
-    {r, g, b} = Wire.rgb(fg)
-    flags = encode_syntax_flags(face)
-
-    <<13::8, r::8, g::8, b::8, flags::8, byte_size(text_bytes)::16, text_bytes::binary>>
+  @spec encode_markdown_segment(Segment.t(), Writer.t()) :: Writer.t()
+  defp encode_markdown_segment(
+         %Segment{text: text, style: {:syntax, %Face{} = face}},
+         %Writer{} = writer
+       ) do
+    writer
+    |> Writer.append(<<13::8>>)
+    |> Writer.rgb24(:syntax_fg, face.fg || @syntax_fallback_fg)
+    |> Writer.uint8(:syntax_flags, encode_syntax_flags(face))
+    |> Writer.string16(:segment_text, text)
   end
 
-  defp encode_markdown_segment(%Segment{} = segment) do
-    style_byte = encode_markdown_style(segment.style)
-    text_bytes = :erlang.iolist_to_binary([segment.text])
-    <<style_byte::8, byte_size(text_bytes)::16, text_bytes::binary>>
+  defp encode_markdown_segment(%Segment{} = segment, %Writer{} = writer) do
+    writer
+    |> Writer.uint8(:markdown_style, encode_markdown_style(segment.style))
+    |> Writer.string16(:segment_text, segment.text)
   end
 
   @spec encode_syntax_flags(Face.t()) :: non_neg_integer()

--- a/lib/minga/frontend/adapter/gui/line_spacing_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/line_spacing_encoder.ex
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.LineSpacingEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.LineSpacing
 
@@ -25,8 +26,11 @@ defmodule Minga.Frontend.Adapter.GUI.LineSpacingEncoder do
   # need no change.
   @spec encode_command(LineSpacing.t()) :: binary()
   def encode_command(%LineSpacing{} = model) do
-    spacing_x100 = spacing_x100(model.multiplier)
-    <<@op_gui_line_spacing, 2::16, spacing_x100::16>>
+    :gui_line_spacing
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_line_spacing, 2::16>>)
+    |> Writer.uint16(:spacing_x100, spacing_x100(model.multiplier))
+    |> Writer.finish()
   end
 
   @spec spacing_x100(number()) :: non_neg_integer()

--- a/lib/minga/frontend/adapter/gui/minibuffer_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/minibuffer_encoder.ex
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.MinibufferEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.Minibuffer
   alias Minga.RenderModel.UI.Minibuffer.Candidate
@@ -23,20 +24,22 @@ defmodule Minga.Frontend.Adapter.GUI.MinibufferEncoder do
   def encode_command(%Minibuffer{visible?: false}), do: <<@op_gui_minibuffer, 0::8>>
 
   def encode_command(%Minibuffer{} = model) do
-    prompt_bytes = :erlang.iolist_to_binary([model.prompt])
-    input_bytes = :erlang.iolist_to_binary([model.input])
-    context_bytes = :erlang.iolist_to_binary([model.context])
-    candidate_data = Enum.map(model.candidates, &encode_candidate/1)
-    mode = encode_mode(model.mode)
-    cursor_pos = encode_cursor_pos(model.cursor_pos)
+    writer =
+      :gui_minibuffer
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_minibuffer, 1::8>>)
+      |> Writer.uint8(:mode, encode_mode(model.mode))
+      |> Writer.uint16(:cursor_pos, encode_cursor_pos(model.cursor_pos))
+      |> Writer.string8(:prompt, model.prompt)
+      |> Writer.string16(:input, model.input)
+      |> Writer.string16(:context, model.context)
+      |> Writer.uint16(:selected_index, model.selected_index)
+      |> Writer.uint16(:candidate_count, Enum.count(model.candidates))
+      |> Writer.uint16(:total_candidates, model.total_candidates)
 
-    IO.iodata_to_binary([
-      <<@op_gui_minibuffer, 1::8, mode::8, cursor_pos::16, byte_size(prompt_bytes)::8,
-        prompt_bytes::binary, byte_size(input_bytes)::16, input_bytes::binary,
-        byte_size(context_bytes)::16, context_bytes::binary, model.selected_index::16,
-        Enum.count(model.candidates)::16, model.total_candidates::16>>
-      | candidate_data
-    ])
+    model.candidates
+    |> Enum.reduce(writer, &encode_candidate/2)
+    |> Writer.finish()
   end
 
   @spec fingerprint(Minibuffer.t()) :: term()
@@ -65,19 +68,18 @@ defmodule Minga.Frontend.Adapter.GUI.MinibufferEncoder do
   defp encode_cursor_pos(nil), do: 0xFFFF
   defp encode_cursor_pos(cursor_pos), do: cursor_pos
 
-  @spec encode_candidate(Candidate.t()) :: iodata()
-  defp encode_candidate(%Candidate{} = candidate) do
-    label_bytes = :erlang.iolist_to_binary([candidate.label])
-    desc_bytes = :erlang.iolist_to_binary([candidate.description])
-    annotation_bytes = :erlang.iolist_to_binary([candidate.annotation])
-    match_positions = candidate.match_positions
-    pos_binary = Enum.map(match_positions, fn pos -> <<min(pos, 0xFFFF)::16>> end)
+  @spec encode_candidate(Candidate.t(), Writer.t()) :: Writer.t()
+  defp encode_candidate(%Candidate{} = candidate, %Writer{} = writer) do
+    writer =
+      writer
+      |> Writer.uint8(:candidate_match_score, candidate.match_score)
+      |> Writer.string16(:candidate_label, candidate.label)
+      |> Writer.string16(:candidate_description, candidate.description)
+      |> Writer.string16(:candidate_annotation, candidate.annotation)
+      |> Writer.uint8(:candidate_match_position_count, Enum.count(candidate.match_positions))
 
-    [
-      <<min(candidate.match_score, 255)::8, byte_size(label_bytes)::16, label_bytes::binary,
-        byte_size(desc_bytes)::16, desc_bytes::binary, byte_size(annotation_bytes)::16,
-        annotation_bytes::binary, Enum.count(match_positions)::8>>
-      | pos_binary
-    ]
+    Enum.reduce(candidate.match_positions, writer, fn position, acc ->
+      Writer.uint16(acc, :candidate_match_position, position)
+    end)
   end
 end

--- a/lib/minga/frontend/adapter/gui/notifications_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/notifications_encoder.ex
@@ -2,20 +2,13 @@ defmodule Minga.Frontend.Adapter.GUI.NotificationsEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Protocol.Encoding
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.Notifications
 
   @op_gui_notifications Opcodes.gui_notifications()
 
-  @max_u8 255
-  @max_u16 65_535
   @max_u32 4_294_967_295
-
-  @max_notification_title_bytes 512
-  @max_notification_body_bytes 8_192
-  @max_notification_source_bytes 512
-  @max_notification_action_label_bytes 512
 
   @spec encode(Notifications.t(), Caches.t()) :: {binary() | nil, Caches.t()}
   def encode(%Notifications{} = model, %Caches{} = caches) do
@@ -31,59 +24,50 @@ defmodule Minga.Frontend.Adapter.GUI.NotificationsEncoder do
 
   @spec encode_notifications_binary([Notifications.notification_item()]) :: binary()
   defp encode_notifications_binary(items) do
-    {notification_bins, count} = bounded_notification_bins(items)
-    payload = IO.iodata_to_binary([<<1::8, count::16>>, notification_bins])
-    <<@op_gui_notifications, byte_size(payload)::16, payload::binary>>
+    writer =
+      :gui_notifications
+      |> Writer.new()
+      |> Writer.append(<<1::8>>)
+      |> Writer.uint16(:notification_count, Enum.count(items))
+
+    payload =
+      items
+      |> Enum.reduce(writer, &encode_notification/2)
+      |> Writer.finish()
+
+    :gui_notifications
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_notifications>>)
+    |> Writer.payload16(:payload, payload)
+    |> Writer.finish()
   end
 
-  @spec bounded_notification_bins([Notifications.notification_item()]) ::
-          {[binary()], non_neg_integer()}
-  defp bounded_notification_bins(notifications) do
-    notifications
-    |> Enum.take(@max_u16)
-    |> Enum.reduce_while({[], 0, 3}, fn notification, {bins, count, size} ->
-      bin = encode_notification(notification)
-      next_size = size + byte_size(bin)
-
-      if next_size <= @max_u16 do
-        {:cont, {[bin | bins], count + 1, next_size}}
-      else
-        {:halt, {bins, count, size}}
-      end
-    end)
-    |> then(fn {bins, count, _size} -> {Enum.reverse(bins), count} end)
-  end
-
-  @spec encode_notification(Notifications.notification_item()) :: binary()
-  defp encode_notification(notification) do
+  @spec encode_notification(Notifications.notification_item(), Writer.t()) :: Writer.t()
+  defp encode_notification(notification, %Writer{} = writer) do
     flags = if notification.dismissable, do: 0x01, else: 0x00
     auto_dismiss_ms = notification.auto_dismiss_ms || @max_u32
-    actions = Enum.take(notification.actions, @max_u8)
 
-    IO.iodata_to_binary([
-      encode_notification_string16(notification.id, @max_notification_title_bytes),
-      <<notification_level_byte(notification.level)::8, flags::8, notification.created_at::64,
-        notification.updated_at::64, auto_dismiss_ms::32>>,
-      encode_notification_string16(notification.title, @max_notification_title_bytes),
-      encode_notification_string16(notification.body, @max_notification_body_bytes),
-      encode_notification_string16(notification.source, @max_notification_source_bytes),
-      <<Enum.count(actions)::8>>,
-      Enum.map(actions, &encode_notification_action/1)
-    ])
+    writer =
+      writer
+      |> Writer.string16(:notification_id, notification.id)
+      |> Writer.uint8(:notification_level, notification_level_byte(notification.level))
+      |> Writer.uint8(:notification_flags, flags)
+      |> Writer.uint64(:notification_created_at, notification.created_at)
+      |> Writer.uint64(:notification_updated_at, notification.updated_at)
+      |> Writer.uint32(:notification_auto_dismiss_ms, auto_dismiss_ms)
+      |> Writer.string16(:notification_title, notification.title)
+      |> Writer.string16(:notification_body, notification.body)
+      |> Writer.string16(:notification_source, notification.source)
+      |> Writer.uint8(:notification_action_count, Enum.count(notification.actions))
+
+    Enum.reduce(notification.actions, writer, &encode_notification_action/2)
   end
 
-  @spec encode_notification_action(Notifications.action()) :: binary()
-  defp encode_notification_action(action) do
-    IO.iodata_to_binary([
-      encode_notification_string16(action.id, @max_notification_title_bytes),
-      encode_notification_string16(action.label, @max_notification_action_label_bytes)
-    ])
-  end
-
-  @spec encode_notification_string16(String.t(), non_neg_integer()) :: binary()
-  defp encode_notification_string16(text, max_bytes) when is_binary(text) do
-    bytes = Encoding.utf8_prefix_bytes(text, min(max_bytes, @max_u16))
-    <<byte_size(bytes)::16, bytes::binary>>
+  @spec encode_notification_action(Notifications.action(), Writer.t()) :: Writer.t()
+  defp encode_notification_action(action, %Writer{} = writer) do
+    writer
+    |> Writer.string16(:notification_action_id, action.id)
+    |> Writer.string16(:notification_action_label, action.label)
   end
 
   @spec notification_level_byte(Notifications.level()) :: non_neg_integer()

--- a/lib/minga/frontend/adapter/gui/observatory_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/observatory_encoder.ex
@@ -2,14 +2,13 @@ defmodule Minga.Frontend.Adapter.GUI.ObservatoryEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.Observatory
   alias Minga.RenderModel.UI.Observatory.Node
 
   @op_gui_observatory Opcodes.gui_observatory()
   @max_observatory_section_payload_bytes 65_000
-  @max_observatory_name_bytes 64_000
 
   @spec encode(Observatory.t(), Caches.t()) :: {binary() | nil, Caches.t()}
   def encode(%Observatory{} = model, %Caches{} = caches) do
@@ -24,33 +23,53 @@ defmodule Minga.Frontend.Adapter.GUI.ObservatoryEncoder do
 
   @spec encode_command(Observatory.t()) :: binary()
   def encode_command(%Observatory{visible?: false}) do
-    payload = Wire.encode_section(0x01, <<0::8, 0::16>>)
-    <<@op_gui_observatory, byte_size(payload)::32, payload::binary>>
+    payload = Writer.section16(Writer.new(:gui_observatory), :header, 0x01, <<0::8, 0::16>>)
+    encode_envelope(Writer.finish(payload))
   end
 
   def encode_command(%Observatory{visible?: true} = model) do
-    node_entries = Enum.map(model.nodes, &encode_observatory_node/1)
-    sparkline_entries = Enum.map(model.nodes, &encode_observatory_sparkline/1)
+    header =
+      :gui_observatory
+      |> Writer.new()
+      |> Writer.append(<<1::8>>)
+      |> Writer.uint16(:node_count, Enum.count(model.nodes))
+      |> Writer.finish()
 
-    sections = [
-      Wire.encode_section(0x01, <<1::8, Enum.count(model.nodes)::16>>),
-      encode_chunked_sections(0x02, node_entries),
-      encode_chunked_sections(0x03, sparkline_entries)
-    ]
+    writer = Writer.section16(Writer.new(:gui_observatory), :header, 0x01, header)
 
-    payload = IO.iodata_to_binary(sections)
-    <<@op_gui_observatory, byte_size(payload)::32, payload::binary>>
+    writer =
+      encode_chunked_sections(writer, 0x02, Enum.map(model.nodes, &encode_observatory_node/1))
+
+    writer =
+      encode_chunked_sections(
+        writer,
+        0x03,
+        Enum.map(model.nodes, &encode_observatory_sparkline/1)
+      )
+
+    writer |> Writer.finish() |> encode_envelope()
+  end
+
+  @spec encode_envelope(binary()) :: binary()
+  defp encode_envelope(payload) do
+    :gui_observatory
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_observatory>>)
+    |> Writer.payload32(:payload, payload)
+    |> Writer.finish()
   end
 
   @spec fingerprint(Observatory.t()) :: term()
   defp fingerprint(%Observatory{visible?: false}), do: :hidden
   defp fingerprint(%Observatory{} = model), do: {model.visible?, model.nodes}
 
-  @spec encode_chunked_sections(non_neg_integer(), [binary()]) :: iodata()
-  defp encode_chunked_sections(section_id, entries) do
+  @spec encode_chunked_sections(Writer.t(), non_neg_integer(), [binary()]) :: Writer.t()
+  defp encode_chunked_sections(%Writer{} = writer, section_id, entries) do
     entries
     |> chunk_observatory_entries()
-    |> Enum.map(&Wire.encode_section(section_id, &1))
+    |> Enum.reduce(writer, fn payload, acc ->
+      Writer.section16(acc, :observatory_entries, section_id, payload)
+    end)
   end
 
   @spec chunk_observatory_entries([binary()]) :: [binary()]
@@ -100,32 +119,32 @@ defmodule Minga.Frontend.Adapter.GUI.ObservatoryEncoder do
 
   @spec encode_observatory_node(Node.t()) :: binary()
   defp encode_observatory_node(%Node{} = node) do
-    pid_bytes = node.pid |> :erlang.pid_to_list() |> List.to_string()
-    parent_bytes = pid_to_bytes(node.parent_pid)
-    name_bytes = Wire.utf8_prefix_bytes(node.name, @max_observatory_name_bytes)
-
-    <<byte_size(pid_bytes)::8, pid_bytes::binary, byte_size(parent_bytes)::8,
-      parent_bytes::binary, byte_size(name_bytes)::16, name_bytes::binary,
-      observatory_class_byte(node.process_class)::8, node.depth::8,
-      Wire.clamp_u32(node.memory)::32, Wire.clamp_u16(node.message_queue_len)::16,
-      Wire.clamp_u32(node.reductions)::32>>
+    :gui_observatory
+    |> Writer.new()
+    |> Writer.string8(:node_pid, node.pid |> :erlang.pid_to_list() |> List.to_string())
+    |> Writer.string8(:node_parent_pid, pid_to_bytes(node.parent_pid))
+    |> Writer.string16(:node_name, node.name)
+    |> Writer.uint8(:node_class, observatory_class_byte(node.process_class))
+    |> Writer.uint8(:node_depth, node.depth)
+    |> Writer.uint32(:node_memory, node.memory)
+    |> Writer.uint16(:node_message_queue_len, node.message_queue_len)
+    |> Writer.uint32(:node_reductions, node.reductions)
+    |> Writer.finish()
   end
 
   @spec encode_observatory_sparkline(Node.t()) :: binary()
   defp encode_observatory_sparkline(%Node{} = node) do
-    pid_bytes = node.pid |> :erlang.pid_to_list() |> List.to_string()
-    values = Enum.take(node.sparkline_values, 255)
-    sample_bytes = Enum.map(values, &encode_float16/1)
+    writer =
+      :gui_observatory
+      |> Writer.new()
+      |> Writer.string8(:sparkline_pid, node.pid |> :erlang.pid_to_list() |> List.to_string())
+      |> Writer.uint8(:sparkline_sample_count, Enum.count(node.sparkline_values))
 
-    <<byte_size(pid_bytes)::8, pid_bytes::binary, Enum.count(values)::8,
-      IO.iodata_to_binary(sample_bytes)::binary>>
-  end
-
-  @spec encode_float16(float()) :: binary()
-  defp encode_float16(value) do
-    clamped = max(0.0, min(1.0, value))
-    scaled = round(clamped * 65_535.0)
-    <<scaled::16>>
+    node.sparkline_values
+    |> Enum.reduce(writer, fn value, acc ->
+      Writer.uint16(acc, :sparkline_sample, round(value * 65_535.0))
+    end)
+    |> Writer.finish()
   end
 
   @spec pid_to_bytes(pid() | nil) :: binary()

--- a/lib/minga/frontend/adapter/gui/picker_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/picker_encoder.ex
@@ -2,7 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.PickerEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Encode
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.Picker
@@ -60,40 +60,46 @@ defmodule Minga.Frontend.Adapter.GUI.PickerEncoder do
   @spec encode_picker_hidden() :: binary()
   defp encode_picker_hidden, do: <<@op_gui_picker, 0::8>>
 
-  # The hidden/visible dispatch and the Wire.encode_section framing stay
-  # hand-written here; each section body delegates to the schema-generated pure
-  # encoder. The builder has already normalized the model into wire-shaped maps,
-  # so each `to_wire_*` projection is a plain key rename with no derivation.
+  # Each section body delegates to the schema-generated pure encoder. The builder
+  # has already normalized the model into wire-shaped maps, so each projection is
+  # a plain key rename with no derivation.
   @spec encode_picker(Picker.t()) :: binary()
   defp encode_picker(%Picker{} = model) do
-    sections = [
-      Wire.encode_section(
-        @section_picker_header,
-        Encode.encode_gui_picker_header(to_wire_header(model))
-      ),
-      Wire.encode_section(
-        @section_picker_query,
-        Encode.encode_gui_picker_query(%{text: model.query})
-      ),
-      Wire.encode_section(
-        @section_picker_items,
-        Encode.encode_gui_picker_items(model.items)
-      ),
-      Wire.encode_section(
-        @section_picker_action_menu,
-        Encode.encode_gui_picker_action_menu(to_wire_action_menu(model.action_menu))
-      ),
-      Wire.encode_section(
-        @section_picker_mode_prefix,
-        Encode.encode_gui_picker_mode_prefix(%{text: model.mode_prefix})
-      ),
-      Wire.encode_section(
-        @section_picker_load_status,
-        Encode.encode_gui_picker_load_status(to_wire_load_status(model.load_status))
-      )
-    ]
-
-    IO.iodata_to_binary([<<@op_gui_picker, Enum.count(sections)::8>> | sections])
+    :gui_picker
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_picker>>)
+    |> Writer.uint8(:section_count, 6)
+    |> Writer.section16(
+      :picker_header,
+      @section_picker_header,
+      Encode.encode_gui_picker_header(to_wire_header(model))
+    )
+    |> Writer.section16(
+      :picker_query,
+      @section_picker_query,
+      Encode.encode_gui_picker_query(%{text: model.query})
+    )
+    |> Writer.section16(
+      :picker_items,
+      @section_picker_items,
+      Encode.encode_gui_picker_items(model.items)
+    )
+    |> Writer.section16(
+      :picker_action_menu,
+      @section_picker_action_menu,
+      Encode.encode_gui_picker_action_menu(to_wire_action_menu(model.action_menu))
+    )
+    |> Writer.section16(
+      :picker_mode_prefix,
+      @section_picker_mode_prefix,
+      Encode.encode_gui_picker_mode_prefix(%{text: model.mode_prefix})
+    )
+    |> Writer.section16(
+      :picker_load_status,
+      @section_picker_load_status,
+      Encode.encode_gui_picker_load_status(to_wire_load_status(model.load_status))
+    )
+    |> Writer.finish()
   end
 
   @spec to_wire_header(Picker.t()) :: map()
@@ -125,20 +131,30 @@ defmodule Minga.Frontend.Adapter.GUI.PickerEncoder do
   defp encode_preview(nil), do: <<@op_gui_picker_preview, 0::8>>
 
   defp encode_preview(lines) when is_list(lines) do
-    line_binaries = Enum.map(lines, &encode_preview_line/1)
-    IO.iodata_to_binary([@op_gui_picker_preview, <<1::8, Enum.count(lines)::16>> | line_binaries])
+    writer =
+      :gui_picker_preview
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_picker_preview, 1::8>>)
+      |> Writer.uint16(:line_count, Enum.count(lines))
+
+    lines
+    |> Enum.reduce(writer, &encode_preview_line/2)
+    |> Writer.finish()
   end
 
-  @spec encode_preview_line([Picker.preview_segment()]) :: iodata()
-  defp encode_preview_line(segments) do
-    seg_bins = Enum.map(segments, &encode_preview_segment/1)
-    [<<Enum.count(segments)::8>> | seg_bins]
+  @spec encode_preview_line([Picker.preview_segment()], Writer.t()) :: Writer.t()
+  defp encode_preview_line(segments, %Writer{} = writer) do
+    writer = Writer.uint8(writer, :segment_count, Enum.count(segments))
+    Enum.reduce(segments, writer, &encode_preview_segment/2)
   end
 
-  @spec encode_preview_segment(Picker.preview_segment()) :: binary()
-  defp encode_preview_segment({text, fg_color, bold}) do
-    text_bytes = :erlang.iolist_to_binary([text])
+  @spec encode_preview_segment(Picker.preview_segment(), Writer.t()) :: Writer.t()
+  defp encode_preview_segment({text, fg_color, bold}, %Writer{} = writer) do
     flags = if bold, do: 1, else: 0
-    <<fg_color::24, flags::8, byte_size(text_bytes)::16, text_bytes::binary>>
+
+    writer
+    |> Writer.rgb24(:segment_fg_color, fg_color)
+    |> Writer.uint8(:segment_flags, flags)
+    |> Writer.string16(:segment_text, text)
   end
 end

--- a/lib/minga/frontend/adapter/gui/search_state_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/search_state_encoder.ex
@@ -4,17 +4,17 @@ defmodule Minga.Frontend.Adapter.GUI.SearchStateEncoder do
   import Bitwise
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.SearchState
 
   @op_gui_search_state Opcodes.gui_search_state()
+  @command :gui_search_state
 
   @search_flag_replace_mode 0x01
   @search_flag_case_sensitive 0x02
   @search_flag_whole_word 0x04
   @search_flag_regex 0x08
-
-  @max_u16 65_535
 
   @spec encode(SearchState.t(), Caches.t()) :: {binary() | nil, Caches.t()}
   def encode(%SearchState{} = model, %Caches{} = caches) do
@@ -31,8 +31,8 @@ defmodule Minga.Frontend.Adapter.GUI.SearchStateEncoder do
   @spec encode_search_state_binary(SearchState.t()) :: binary()
   defp encode_search_state_binary(%SearchState{} = model) do
     active_byte = if model.active, do: 1, else: 0
-    count = min(model.match_count, @max_u16)
-    idx = min(model.current_index, @max_u16)
+    count = model.match_count
+    idx = model.current_index
 
     flag_byte =
       if(model.replace_mode, do: @search_flag_replace_mode, else: 0) |||
@@ -40,8 +40,17 @@ defmodule Minga.Frontend.Adapter.GUI.SearchStateEncoder do
         if(model.whole_word, do: @search_flag_whole_word, else: 0) |||
         if(model.regex, do: @search_flag_regex, else: 0)
 
-    payload = <<active_byte::8, count::16, idx::16, flag_byte::8>>
+    payload =
+      Writer.new(@command)
+      |> Writer.uint8(:active, active_byte)
+      |> Writer.uint16(:match_count, count)
+      |> Writer.uint16(:current_index, idx)
+      |> Writer.uint8(:flags, flag_byte)
+      |> Writer.finish()
 
-    <<@op_gui_search_state, byte_size(payload)::16, payload::binary>>
+    Writer.new(@command)
+    |> Writer.uint8(:opcode, @op_gui_search_state)
+    |> Writer.payload16(:payload, payload)
+    |> Writer.finish()
   end
 end

--- a/lib/minga/frontend/adapter/gui/sidebars_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/sidebars_encoder.ex
@@ -3,6 +3,7 @@ defmodule Minga.Frontend.Adapter.GUI.SidebarsEncoder do
 
   alias Minga.Frontend.Adapter.GUI.Caches
   alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.Sidebars
   alias Minga.RenderModel.UI.Sidebars.Sidebar
@@ -22,42 +23,46 @@ defmodule Minga.Frontend.Adapter.GUI.SidebarsEncoder do
 
   @spec encode_command(Sidebars.t()) :: binary()
   def encode_command(%Sidebars{} = model) do
-    entries =
-      model.sidebars
-      |> Enum.sort_by(& &1.order)
-      |> Enum.take(Wire.max_u16())
-      |> Enum.map(&encode_sidebar_metadata/1)
+    sidebars = Enum.sort_by(model.sidebars, & &1.order)
+
+    writer =
+      :gui_sidebars
+      |> Writer.new()
+      |> Writer.append(<<1::8>>)
+      |> Writer.uint16(:sidebar_count, Enum.count(sidebars))
+      |> Writer.string16(:active_id, model.active_id || "")
 
     payload =
-      IO.iodata_to_binary([
-        <<1::8, Enum.count(entries)::16>>,
-        Wire.encode_string16(model.active_id || ""),
-        entries
-      ])
+      sidebars
+      |> Enum.reduce(writer, &encode_sidebar_metadata/2)
+      |> Writer.finish()
 
-    <<@op_gui_sidebars, byte_size(payload)::32, payload::binary>>
+    :gui_sidebars
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_sidebars>>)
+    |> Writer.payload32(:payload, payload)
+    |> Writer.finish()
   end
 
-  @spec encode_sidebar_metadata(Sidebar.t()) :: binary()
-  defp encode_sidebar_metadata(%Sidebar{} = sidebar) do
+  @spec encode_sidebar_metadata(Sidebar.t(), Writer.t()) :: Writer.t()
+  defp encode_sidebar_metadata(%Sidebar{} = sidebar, %Writer{} = writer) do
     flags =
       0
       |> Wire.maybe_flag(sidebar.visible?, 0)
       |> Wire.maybe_flag(sidebar.focused?, 1)
 
-    badge_count = badge_count(sidebar.badge_count)
-
-    IO.iodata_to_binary([
-      Wire.encode_string16(sidebar.id),
-      Wire.encode_string16(sidebar.display_name),
-      Wire.encode_string16(sidebar.semantic_kind),
-      Wire.encode_string16(sidebar.icon || ""),
-      <<Wire.clamp_u16(sidebar.order)::16, flags::8, Wire.clamp_u16(sidebar.preferred_width)::16,
-        badge_count::16>>
-    ])
+    writer
+    |> Writer.string16(:sidebar_id, sidebar.id)
+    |> Writer.string16(:sidebar_display_name, sidebar.display_name)
+    |> Writer.string16(:sidebar_semantic_kind, sidebar.semantic_kind)
+    |> Writer.string16(:sidebar_icon, sidebar.icon || "")
+    |> Writer.uint16(:sidebar_order, sidebar.order)
+    |> Writer.uint8(:sidebar_flags, flags)
+    |> Writer.uint16(:sidebar_preferred_width, sidebar.preferred_width)
+    |> Writer.uint16(:sidebar_badge_count, badge_count(sidebar.badge_count))
   end
 
   @spec badge_count(non_neg_integer() | nil) :: non_neg_integer()
-  defp badge_count(count) when is_integer(count), do: Wire.clamp_u16(count)
+  defp badge_count(count) when is_integer(count), do: count
   defp badge_count(nil), do: Wire.max_u16()
 end

--- a/lib/minga/frontend/adapter/gui/signature_help_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/signature_help_encoder.ex
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.SignatureHelpEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.SignatureHelp
   alias Minga.RenderModel.UI.SignatureHelp.Parameter
@@ -24,19 +25,19 @@ defmodule Minga.Frontend.Adapter.GUI.SignatureHelpEncoder do
   def encode_command(%SignatureHelp{visible?: false}), do: <<@op_gui_signature_help, 0::8>>
 
   def encode_command(%SignatureHelp{} = model) do
-    signatures = Enum.take(model.signatures, 255)
-    active_signature = clamp_index(model.active_signature, Enum.count(signatures))
+    writer =
+      :gui_signature_help
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_signature_help, 1::8>>)
+      |> Writer.uint16(:anchor_row, model.anchor_row)
+      |> Writer.uint16(:anchor_col, model.anchor_col)
+      |> Writer.uint8(:active_signature, model.active_signature)
+      |> Writer.uint8(:active_parameter, model.active_parameter)
+      |> Writer.uint8(:signature_count, Enum.count(model.signatures))
 
-    active_parameter =
-      clamp_active_parameter(model.active_parameter, Enum.at(signatures, active_signature))
-
-    sig_data = Enum.map(signatures, &encode_signature/1)
-
-    IO.iodata_to_binary([
-      <<@op_gui_signature_help, 1::8, model.anchor_row::16, model.anchor_col::16,
-        active_signature::8, active_parameter::8, Enum.count(signatures)::8>>
-      | sig_data
-    ])
+    model.signatures
+    |> Enum.reduce(writer, &encode_signature/2)
+    |> Writer.finish()
   end
 
   @spec fingerprint(SignatureHelp.t()) :: term()
@@ -47,37 +48,21 @@ defmodule Minga.Frontend.Adapter.GUI.SignatureHelpEncoder do
      model.active_parameter, model.signatures}
   end
 
-  @spec encode_signature(Signature.t()) :: iodata()
-  defp encode_signature(%Signature{} = signature) do
-    label_bytes = :erlang.iolist_to_binary([signature.label])
-    doc_bytes = :erlang.iolist_to_binary([signature.documentation])
-    parameters = Enum.take(signature.parameters, 255)
-    param_data = Enum.map(parameters, &encode_parameter/1)
+  @spec encode_signature(Signature.t(), Writer.t()) :: Writer.t()
+  defp encode_signature(%Signature{} = signature, %Writer{} = writer) do
+    writer =
+      writer
+      |> Writer.string16(:signature_label, signature.label)
+      |> Writer.string16(:signature_documentation, signature.documentation)
+      |> Writer.uint8(:parameter_count, Enum.count(signature.parameters))
 
-    [
-      <<byte_size(label_bytes)::16, label_bytes::binary, byte_size(doc_bytes)::16,
-        doc_bytes::binary, Enum.count(parameters)::8>>
-      | param_data
-    ]
+    Enum.reduce(signature.parameters, writer, &encode_parameter/2)
   end
 
-  @spec encode_parameter(Parameter.t()) :: binary()
-  defp encode_parameter(%Parameter{} = parameter) do
-    label_bytes = :erlang.iolist_to_binary([parameter.label])
-    doc_bytes = :erlang.iolist_to_binary([parameter.documentation])
-
-    <<byte_size(label_bytes)::16, label_bytes::binary, byte_size(doc_bytes)::16,
-      doc_bytes::binary>>
+  @spec encode_parameter(Parameter.t(), Writer.t()) :: Writer.t()
+  defp encode_parameter(%Parameter{} = parameter, %Writer{} = writer) do
+    writer
+    |> Writer.string16(:parameter_label, parameter.label)
+    |> Writer.string16(:parameter_documentation, parameter.documentation)
   end
-
-  @spec clamp_active_parameter(non_neg_integer(), Signature.t() | nil) :: non_neg_integer()
-  defp clamp_active_parameter(_active_parameter, nil), do: 0
-
-  defp clamp_active_parameter(active_parameter, %Signature{} = signature) do
-    clamp_index(active_parameter, min(Enum.count(signature.parameters), 255))
-  end
-
-  @spec clamp_index(non_neg_integer(), non_neg_integer()) :: non_neg_integer()
-  defp clamp_index(_index, 0), do: 0
-  defp clamp_index(index, count), do: min(index, count - 1)
 end

--- a/lib/minga/frontend/adapter/gui/split_separators_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/split_separators_encoder.ex
@@ -1,9 +1,8 @@
 defmodule Minga.Frontend.Adapter.GUI.SplitSeparatorsEncoder do
   @moduledoc false
 
-  import Bitwise
-
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.SplitSeparators
 
@@ -22,33 +21,31 @@ defmodule Minga.Frontend.Adapter.GUI.SplitSeparatorsEncoder do
 
   @spec encode_binary(SplitSeparators.t()) :: binary()
   defp encode_binary(%SplitSeparators{} = model) do
-    verticals =
-      Enum.map(model.verticals, fn {col, start_row, end_row} ->
-        <<col::16, start_row::16, end_row::16>>
+    writer =
+      :gui_split_separators
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_split_separators>>)
+      |> Writer.rgb24(:border_color_rgb, model.border_color_rgb)
+      |> Writer.uint8(:vertical_count, Enum.count(model.verticals))
+
+    writer =
+      Enum.reduce(model.verticals, writer, fn {col, start_row, end_row}, acc ->
+        acc
+        |> Writer.uint16(:vertical_col, col)
+        |> Writer.uint16(:vertical_start_row, start_row)
+        |> Writer.uint16(:vertical_end_row, end_row)
       end)
 
-    horizontals =
-      Enum.map(model.horizontals, fn {row, col, width, filename} ->
-        name = IO.iodata_to_binary(filename)
-        <<row::16, col::16, width::16, byte_size(name)::16, name::binary>>
-      end)
+    writer = Writer.uint8(writer, :horizontal_count, Enum.count(model.horizontals))
 
-    IO.iodata_to_binary([
-      <<@op_gui_split_separators, red(model.border_color_rgb)::8,
-        green(model.border_color_rgb)::8, blue(model.border_color_rgb)::8,
-        Enum.count(model.verticals)::8>>,
-      verticals,
-      <<Enum.count(model.horizontals)::8>>,
-      horizontals
-    ])
+    model.horizontals
+    |> Enum.reduce(writer, fn {row, col, width, filename}, acc ->
+      acc
+      |> Writer.uint16(:horizontal_row, row)
+      |> Writer.uint16(:horizontal_col, col)
+      |> Writer.uint16(:horizontal_width, width)
+      |> Writer.string16(:horizontal_filename, filename)
+    end)
+    |> Writer.finish()
   end
-
-  @spec red(non_neg_integer()) :: non_neg_integer()
-  defp red(rgb), do: rgb >>> 16 &&& 0xFF
-
-  @spec green(non_neg_integer()) :: non_neg_integer()
-  defp green(rgb), do: rgb >>> 8 &&& 0xFF
-
-  @spec blue(non_neg_integer()) :: non_neg_integer()
-  defp blue(rgb), do: rgb &&& 0xFF
 end

--- a/lib/minga/frontend/adapter/gui/status_bar_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/status_bar_encoder.ex
@@ -4,7 +4,7 @@ defmodule Minga.Frontend.Adapter.GUI.StatusBarEncoder do
   import Bitwise
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.StatusBar
   alias Minga.RenderModel.UI.StatusBar.Agent
@@ -16,6 +16,7 @@ defmodule Minga.Frontend.Adapter.GUI.StatusBarEncoder do
   alias Minga.RenderModel.UI.StatusBar.Workspace
 
   @op_gui_status_bar Opcodes.gui_status_bar()
+  @command :gui_status_bar
   @section_identity 0x01
   @section_cursor 0x02
   @section_diagnostics 0x03
@@ -30,17 +31,19 @@ defmodule Minga.Frontend.Adapter.GUI.StatusBarEncoder do
   @section_selection 0x0C
   @section_workspace 0x0D
   @section_pending_keys 0x0E
-  @max_modeline_segments 128
 
   @spec encode(StatusBar.t(), Caches.t()) :: {binary(), Caches.t()}
-  def encode(%StatusBar{} = model, %Caches{} = caches) do
-    {encode_command(model), caches}
-  end
+  def encode(%StatusBar{} = model, %Caches{} = caches), do: {encode_command(model), caches}
 
   @spec encode_command(StatusBar.t()) :: binary()
   def encode_command(%StatusBar{} = model) do
     sections = encode_sections(model)
-    IO.iodata_to_binary([<<@op_gui_status_bar, Enum.count(sections)::8>> | sections])
+
+    Writer.new(@command)
+    |> Writer.uint8(:opcode, @op_gui_status_bar)
+    |> Writer.uint8(:section_count, Enum.count(sections))
+    |> Writer.append(sections)
+    |> Writer.finish()
   end
 
   @spec encode_sections(StatusBar.t()) :: [binary()]
@@ -49,70 +52,109 @@ defmodule Minga.Frontend.Adapter.GUI.StatusBarEncoder do
          data: %Data{} = data,
          workspace: workspace
        }) do
-    content_kind_byte = content_kind_byte(content_kind)
-    mode_byte = encode_vim_mode(data.mode)
-    flags = build_status_flags(data)
-    lsp_byte = encode_lsp_status(data.language)
-    parser_byte = encode_parser_status(data.language)
-    agent_byte = encode_agent_session_status(data.agent.agent_status)
-    indent_type_byte = encode_indent_type(data.indent)
-    indent_size = Wire.clamp_u8(data.indent.size)
     {selection_mode, selection_size} = encode_selection_info(data.selection)
     {error_count, warning_count, info_count, hint_count} = data.diagnostics.counts
-    macro_byte = encode_macro_recording(data.recording)
     {git_added, git_modified, git_deleted} = git_diff_counts(data.git)
-    {icon_r, icon_g, icon_b} = Wire.rgb(data.file.icon_color)
-
-    git_branch = :erlang.iolist_to_binary([data.git.branch || ""])
-    filetype = :erlang.iolist_to_binary([Atom.to_string(data.file.filetype)])
-    icon_bytes = :erlang.iolist_to_binary([data.file.icon])
-    filename = :erlang.iolist_to_binary([data.file.name])
-    diag_hint = :erlang.iolist_to_binary([data.diagnostics.hint || ""])
-    message = :erlang.iolist_to_binary([data.message || ""])
-    background_label = :erlang.iolist_to_binary([data.agent.background_label || ""])
-    active_tool_name = :erlang.iolist_to_binary([data.agent.active_tool_name || ""])
 
     sections = [
-      Wire.encode_section(@section_identity, <<content_kind_byte::8, mode_byte::8, flags::8>>),
-      Wire.encode_section(
+      section(
+        @section_identity,
+        Writer.new(@command)
+        |> Writer.uint8(:content_kind, content_kind_byte(content_kind))
+        |> Writer.uint8(:mode, encode_vim_mode(data.mode))
+        |> Writer.uint8(:flags, build_status_flags(data))
+        |> Writer.finish()
+      ),
+      section(
         @section_cursor,
-        <<data.cursor.line + 1::32, data.cursor.col + 1::32, data.cursor.line_count::32>>
+        Writer.new(@command)
+        |> Writer.uint32(:cursor_line, data.cursor.line + 1)
+        |> Writer.uint32(:cursor_col, data.cursor.col + 1)
+        |> Writer.uint32(:line_count, data.cursor.line_count)
+        |> Writer.finish()
       ),
-      Wire.encode_section(
+      section(
         @section_diagnostics,
-        <<error_count::16, warning_count::16, info_count::16, hint_count::16,
-          byte_size(diag_hint)::16, diag_hint::binary>>
+        Writer.new(@command)
+        |> Writer.uint16(:diagnostic_error_count, error_count)
+        |> Writer.uint16(:diagnostic_warning_count, warning_count)
+        |> Writer.uint16(:diagnostic_info_count, info_count)
+        |> Writer.uint16(:diagnostic_hint_count, hint_count)
+        |> Writer.string16(:diagnostic_hint, data.diagnostics.hint || "")
+        |> Writer.finish()
       ),
-      Wire.encode_section(@section_language, <<lsp_byte::8, parser_byte::8>>),
-      Wire.encode_section(
+      section(
+        @section_language,
+        Writer.new(@command)
+        |> Writer.uint8(:lsp_status, encode_lsp_status(data.language))
+        |> Writer.uint8(:parser_status, encode_parser_status(data.language))
+        |> Writer.finish()
+      ),
+      section(
         @section_git,
-        <<byte_size(git_branch)::8, git_branch::binary, git_added::16, git_modified::16,
-          git_deleted::16>>
+        Writer.new(@command)
+        |> Writer.string8(:git_branch, data.git.branch || "")
+        |> Writer.uint16(:git_added, git_added)
+        |> Writer.uint16(:git_modified, git_modified)
+        |> Writer.uint16(:git_deleted, git_deleted)
+        |> Writer.finish()
       ),
-      Wire.encode_section(
-        @section_file,
-        <<byte_size(icon_bytes)::8, icon_bytes::binary, icon_r::8, icon_g::8, icon_b::8,
-          byte_size(filename)::16, filename::binary, byte_size(filetype)::8, filetype::binary>>
+      section(@section_file, encode_file(data)),
+      section(
+        @section_message,
+        Writer.new(@command) |> Writer.string16(:message, data.message || "") |> Writer.finish()
       ),
-      Wire.encode_section(@section_message, <<byte_size(message)::16, message::binary>>),
-      Wire.encode_section(@section_recording, <<macro_byte::8>>),
-      Wire.encode_section(@section_indent, <<indent_type_byte::8, indent_size::8>>)
+      section(
+        @section_recording,
+        Writer.new(@command)
+        |> Writer.uint8(:recording, encode_macro_recording(data.recording))
+        |> Writer.finish()
+      ),
+      section(
+        @section_indent,
+        Writer.new(@command)
+        |> Writer.uint8(:indent_type, encode_indent_type(data.indent))
+        |> Writer.uint8(:indent_size, data.indent.size)
+        |> Writer.finish()
+      )
     ]
 
-    sections = Enum.concat(sections, modeline_segment_sections(data.modeline_segments))
-
-    sections = Enum.concat(sections, pending_keys_sections(data.pending_keys))
+    sections = sections ++ modeline_segment_sections(data.modeline_segments)
+    sections = sections ++ pending_keys_sections(data.pending_keys)
 
     sections =
       Enum.concat(sections, [
-        Wire.encode_section(@section_selection, <<selection_mode::8, selection_size::32>>)
+        section(
+          @section_selection,
+          Writer.new(@command)
+          |> Writer.uint8(:selection_mode, selection_mode)
+          |> Writer.uint32(:selection_size, selection_size)
+          |> Writer.finish()
+        )
       ])
 
-    sections = Enum.concat(sections, workspace_sections(workspace))
-
-    Enum.concat(sections, [
-      agent_section(content_kind, data.agent, agent_byte, background_label, active_tool_name)
+    Enum.concat([
+      sections,
+      workspace_sections(workspace),
+      [agent_section(content_kind, data.agent)]
     ])
+  end
+
+  @spec encode_file(Data.t()) :: binary()
+  defp encode_file(%Data{} = data) do
+    Writer.new(@command)
+    |> Writer.string8(:file_icon, data.file.icon)
+    |> Writer.rgb24(:file_icon_color, data.file.icon_color)
+    |> Writer.string16(:file_name, data.file.name)
+    |> Writer.string8(:filetype, Atom.to_string(data.file.filetype))
+    |> Writer.finish()
+  end
+
+  @spec section(non_neg_integer(), iodata()) :: binary()
+  defp section(section_id, payload) do
+    Writer.new(@command)
+    |> Writer.section16(:section_payload, section_id, payload)
+    |> Writer.finish()
   end
 
   @spec content_kind_byte(StatusBar.content_kind()) :: 0 | 1
@@ -120,141 +162,97 @@ defmodule Minga.Frontend.Adapter.GUI.StatusBarEncoder do
   defp content_kind_byte(:buffer), do: 0
 
   @spec workspace_sections(Workspace.t() | nil) :: [binary()]
-  defp workspace_sections(%Workspace{} = workspace) do
-    [Wire.encode_section(@section_workspace, encode_status_workspace(workspace))]
-  end
+  defp workspace_sections(%Workspace{} = workspace),
+    do: [section(@section_workspace, encode_status_workspace(workspace))]
 
   defp workspace_sections(nil), do: []
 
   @spec encode_status_workspace(Workspace.t()) :: binary()
   defp encode_status_workspace(%Workspace{} = workspace) do
-    label_bytes = Wire.utf8_prefix_bytes(workspace.label, 255)
-    icon_bytes = Wire.utf8_prefix_bytes(workspace.icon, 255)
-
-    <<workspace.id::16, encode_workspace_kind(workspace.kind)::8,
-      encode_agent_session_status(workspace.status)::8,
-      encode_workspace_entry_flags(workspace)::16, workspace.draft_count::16,
-      workspace.conflict_count::16, workspace.running_background_count::16,
-      workspace.attention_count::16, byte_size(label_bytes)::8, label_bytes::binary,
-      byte_size(icon_bytes)::8, icon_bytes::binary>>
+    Writer.new(@command)
+    |> Writer.uint16(:workspace_id, workspace.id)
+    |> Writer.uint8(:workspace_kind, encode_workspace_kind(workspace.kind))
+    |> Writer.uint8(:workspace_status, encode_agent_session_status(workspace.status))
+    |> Writer.uint16(:workspace_flags, encode_workspace_entry_flags(workspace))
+    |> Writer.uint16(:workspace_draft_count, workspace.draft_count)
+    |> Writer.uint16(:workspace_conflict_count, workspace.conflict_count)
+    |> Writer.uint16(:workspace_running_background_count, workspace.running_background_count)
+    |> Writer.uint16(:workspace_attention_count, workspace.attention_count)
+    |> Writer.string8(:workspace_label, workspace.label)
+    |> Writer.string8(:workspace_icon, workspace.icon)
+    |> Writer.finish()
   end
 
-  @spec agent_section(StatusBar.content_kind(), Agent.t(), non_neg_integer(), binary(), binary()) ::
-          binary()
-  defp agent_section(:agent, %Agent{} = agent, agent_byte, background_label, active_tool_name) do
-    model_name = :erlang.iolist_to_binary([agent.model_name])
-    session_status_byte = encode_agent_session_status(agent.session_status)
+  @spec agent_section(StatusBar.content_kind(), Agent.t()) :: binary()
+  defp agent_section(:agent, %Agent{} = agent) do
+    payload =
+      Writer.new(@command)
+      |> Writer.string8(:agent_model_name, agent.model_name)
+      |> Writer.uint32(:agent_message_count, agent.message_count)
+      |> Writer.uint8(:agent_session_status, encode_agent_session_status(agent.session_status))
+      |> Writer.uint8(:agent_status, encode_agent_session_status(agent.agent_status))
+      |> Writer.uint16(:agent_background_count, agent.background_count)
+      |> Writer.string16(:agent_background_label, agent.background_label || "")
+      |> Writer.string8(:agent_active_tool_name, agent.active_tool_name || "")
+      |> Writer.finish()
 
-    Wire.encode_section(
-      @section_agent,
-      <<byte_size(model_name)::8, model_name::binary, agent.message_count::32,
-        session_status_byte::8, agent_byte::8, agent.background_count::16,
-        byte_size(background_label)::16, background_label::binary, byte_size(active_tool_name)::8,
-        active_tool_name::binary>>
-    )
+    section(@section_agent, payload)
   end
 
-  defp agent_section(:buffer, %Agent{} = agent, agent_byte, background_label, active_tool_name) do
-    Wire.encode_section(
-      @section_agent,
-      <<agent_byte::8, agent.background_count::16, byte_size(background_label)::16,
-        background_label::binary, byte_size(active_tool_name)::8, active_tool_name::binary>>
-    )
+  defp agent_section(:buffer, %Agent{} = agent) do
+    payload =
+      Writer.new(@command)
+      |> Writer.uint8(:agent_status, encode_agent_session_status(agent.agent_status))
+      |> Writer.uint16(:agent_background_count, agent.background_count)
+      |> Writer.string16(:agent_background_label, agent.background_label || "")
+      |> Writer.string8(:agent_active_tool_name, agent.active_tool_name || "")
+      |> Writer.finish()
+
+    section(@section_agent, payload)
   end
 
   @spec pending_keys_sections(String.t() | nil) :: [binary()]
   defp pending_keys_sections(pending) when pending in [nil, ""], do: []
 
-  defp pending_keys_sections(pending) do
-    bytes = Wire.utf8_prefix_bytes(pending, Wire.max_u16())
-    [Wire.encode_section(@section_pending_keys, <<byte_size(bytes)::16, bytes::binary>>)]
-  end
+  defp pending_keys_sections(pending),
+    do: [
+      section(
+        @section_pending_keys,
+        Writer.new(@command) |> Writer.string16(:pending_keys, pending) |> Writer.finish()
+      )
+    ]
 
   @spec modeline_segment_sections(Data.modeline_segments()) :: [binary()]
   defp modeline_segment_sections(nil), do: []
 
-  defp modeline_segment_sections(modeline_segments) do
-    [Wire.encode_section(@section_modeline_segments, encode_modeline_segments(modeline_segments))]
-  end
+  defp modeline_segment_sections(modeline_segments),
+    do: [section(@section_modeline_segments, encode_modeline_segments(modeline_segments))]
 
   @spec encode_modeline_segments(%{left: [tuple()], right: [tuple()]}) :: binary()
   defp encode_modeline_segments(%{left: left, right: right}) do
-    {left, right} = capped_modeline_segments(left, right)
-    {encoded_left, left_count, remaining} = bounded_modeline_side(left, Wire.max_u16() - 5)
-    {encoded_right, right_count, _remaining} = bounded_modeline_side(right, remaining)
-
-    IO.iodata_to_binary([<<2::8, left_count::16, right_count::16>>, encoded_left, encoded_right])
+    Writer.new(@command)
+    |> Writer.uint8(:modeline_version, 2)
+    |> Writer.uint16(:modeline_left_count, Enum.count(left))
+    |> Writer.uint16(:modeline_right_count, Enum.count(right))
+    |> Writer.append(Enum.map(left, &encode_modeline_segment/1))
+    |> Writer.append(Enum.map(right, &encode_modeline_segment/1))
+    |> Writer.finish()
   end
 
-  @spec capped_modeline_segments([tuple()], [tuple()]) :: {[tuple()], [tuple()]}
-  defp capped_modeline_segments(left, right) do
-    left = Enum.take(left, @max_modeline_segments)
-    right = Enum.take(right, max(0, @max_modeline_segments - Enum.count(left)))
-    {left, right}
+  @spec encode_modeline_segment(tuple()) :: binary()
+  defp encode_modeline_segment({name, text, fg, bg, opts, target}) do
+    Writer.new(@command)
+    |> Writer.string8(:modeline_segment_name, to_string(name))
+    |> Writer.rgb24(:modeline_segment_fg, fg)
+    |> Writer.rgb24(:modeline_segment_bg, bg)
+    |> Writer.uint8(:modeline_segment_attrs, encode_modeline_attrs(opts))
+    |> Writer.string16(:modeline_segment_text, text)
+    |> Writer.string16(:modeline_segment_target, encode_modeline_target(target))
+    |> Writer.finish()
   end
 
-  @spec bounded_modeline_side([tuple()], non_neg_integer()) ::
-          {[binary()], non_neg_integer(), non_neg_integer()}
-  defp bounded_modeline_side(segments, budget) do
-    Enum.reduce_while(segments, {[], 0, budget}, fn segment, {encoded, count, remaining} ->
-      case encode_modeline_segment(segment, remaining) do
-        {:ok, bytes} -> {:cont, {[bytes | encoded], count + 1, remaining - byte_size(bytes)}}
-        :drop -> {:halt, {encoded, count, remaining}}
-      end
-    end)
-    |> then(fn {encoded, count, remaining} -> {Enum.reverse(encoded), count, remaining} end)
-  end
-
-  @spec encode_modeline_segment(tuple(), non_neg_integer()) :: {:ok, binary()} | :drop
-  defp encode_modeline_segment(_segment, remaining) when remaining < 12, do: :drop
-
-  defp encode_modeline_segment({name, text, fg, bg, opts, target}, remaining) do
-    name_bytes = modeline_name_bytes(name)
-    overhead = 12 + byte_size(name_bytes)
-
-    if remaining < overhead do
-      :drop
-    else
-      attrs = encode_modeline_attrs(opts)
-      target = encode_modeline_target(target)
-      payload_budget = remaining - overhead
-      {text_bytes, target_bytes} = bounded_modeline_text_and_target(text, target, payload_budget)
-
-      {:ok,
-       <<byte_size(name_bytes)::8, name_bytes::binary, fg::24, bg::24, attrs::8,
-         byte_size(text_bytes)::16, text_bytes::binary, byte_size(target_bytes)::16,
-         target_bytes::binary>>}
-    end
-  end
-
-  defp encode_modeline_segment({text, fg, bg, opts, target}, remaining) do
-    encode_modeline_segment({:custom, text, fg, bg, opts, target}, remaining)
-  end
-
-  @spec modeline_name_bytes(atom() | String.t()) :: binary()
-  defp modeline_name_bytes(name) do
-    name
-    |> to_string()
-    |> :erlang.iolist_to_binary()
-    |> Wire.utf8_prefix_bytes(255)
-  end
-
-  @spec bounded_modeline_text_and_target(String.t(), String.t(), non_neg_integer()) ::
-          {binary(), binary()}
-  defp bounded_modeline_text_and_target(text, target, budget) do
-    target_bytes = modeline_target_bytes(target, budget)
-    text_budget = budget - byte_size(target_bytes)
-    text_bytes = Wire.utf8_prefix_bytes(text, min(byte_size(text), text_budget))
-    {text_bytes, target_bytes}
-  end
-
-  @spec modeline_target_bytes(String.t(), non_neg_integer()) :: binary()
-  defp modeline_target_bytes("", _budget), do: ""
-
-  defp modeline_target_bytes(target, budget) do
-    target_bytes = :erlang.iolist_to_binary([target])
-    if byte_size(target_bytes) <= budget, do: target_bytes, else: ""
-  end
+  defp encode_modeline_segment({text, fg, bg, opts, target}),
+    do: encode_modeline_segment({:custom, text, fg, bg, opts, target})
 
   @spec encode_modeline_target(atom() | nil) :: String.t()
   defp encode_modeline_target(nil), do: ""
@@ -285,12 +283,8 @@ defmodule Minga.Frontend.Adapter.GUI.StatusBarEncoder do
   defp encode_indent_type(%Indent{}), do: 0
 
   @spec encode_selection_info(Selection.t()) :: {non_neg_integer(), non_neg_integer()}
-  defp encode_selection_info(%Selection{mode: :chars, size: count}),
-    do: {1, min(count, Wire.max_u32())}
-
-  defp encode_selection_info(%Selection{mode: :lines, size: count}),
-    do: {2, min(count, Wire.max_u32())}
-
+  defp encode_selection_info(%Selection{mode: :chars, size: count}), do: {1, count}
+  defp encode_selection_info(%Selection{mode: :lines, size: count}), do: {2, count}
   defp encode_selection_info(%Selection{}), do: {0, 0}
 
   @spec encode_lsp_status(Language.t()) :: non_neg_integer()

--- a/lib/minga/frontend/adapter/gui/surface_layout_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/surface_layout_encoder.ex
@@ -31,7 +31,7 @@ defmodule Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder do
   `placements` (id 0x01), holding a counted array of `surface_placement`.
   """
 
-  alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Encode
   alias Minga.Protocol.Opcodes
 
@@ -63,30 +63,31 @@ defmodule Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder do
   """
   @spec encode_command([wire_placement()]) :: binary()
   def encode_command(placements) when is_list(placements) do
-    validated = Enum.map(placements, &validate/1)
-
-    section =
-      Wire.encode_section(
-        @section_placements,
-        Encode.encode_gui_surface_layout_placements(validated)
+    writer =
+      placements
+      |> Enum.reduce(
+        Writer.new(:gui_surface_layout)
+        |> Writer.check_uint16(:placement_count, Enum.count(placements)),
+        &validate(&2, &1)
       )
 
-    IO.iodata_to_binary([<<@op_gui_surface_layout, 1::8>>, section])
+    payload = Encode.encode_gui_surface_layout_placements(placements)
+
+    writer
+    |> Writer.append(<<@op_gui_surface_layout, 1>>)
+    |> Writer.section16(:placements_payload, @section_placements, payload)
+    |> Writer.finish()
   end
 
-  @spec validate(wire_placement()) :: map()
-  defp validate(%{surface_id: surface_id, rect: rect, z: z, hit_kind: hit_kind} = placement) do
-    validate_uint!(:surface_id, surface_id, Wire.max_u16())
-    validate_uint!(:row, rect.row, Wire.max_u16())
-    validate_uint!(:col, rect.col, Wire.max_u16())
-    validate_uint!(:width, rect.width, Wire.max_u16())
-    validate_uint!(:height, rect.height, Wire.max_u16())
-    validate_uint!(:z, z, Wire.max_u16())
-    validate_uint!(:hit_kind, hit_kind, Wire.max_u8())
-    placement
+  @spec validate(Writer.t(), wire_placement()) :: Writer.t()
+  defp validate(writer, %{surface_id: surface_id, rect: rect, z: z, hit_kind: hit_kind}) do
+    writer
+    |> Writer.check_uint16(:surface_id, surface_id)
+    |> Writer.check_uint16(:row, rect.row)
+    |> Writer.check_uint16(:col, rect.col)
+    |> Writer.check_uint16(:width, rect.width)
+    |> Writer.check_uint16(:height, rect.height)
+    |> Writer.check_uint16(:z, z)
+    |> Writer.check_uint8(:hit_kind, hit_kind)
   end
-
-  @spec validate_uint!(atom(), term(), non_neg_integer()) :: :ok
-  defp validate_uint!(field, value, max),
-    do: Wire.validate_uint!(:gui_surface_layout, field, value, max)
 end

--- a/lib/minga/frontend/adapter/gui/tab_bar_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/tab_bar_encoder.ex
@@ -4,6 +4,7 @@ defmodule Minga.Frontend.Adapter.GUI.TabBarEncoder do
   import Bitwise
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.TabBar
   alias Minga.RenderModel.UI.TabBar.Tab
@@ -26,13 +27,16 @@ defmodule Minga.Frontend.Adapter.GUI.TabBarEncoder do
 
   @spec encode_command(TabBar.t()) :: binary()
   def encode_command(%TabBar{} = model) do
-    active_index = active_index(model)
-    entries = Enum.map(model.tabs, &encode_tab_entry(&1, model.active_tab_id))
+    writer =
+      :gui_tab_bar
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_tab_bar>>)
+      |> Writer.uint8(:active_index, active_index(model))
+      |> Writer.uint8(:tab_count, Enum.count(model.tabs))
 
-    IO.iodata_to_binary([
-      @op_gui_tab_bar,
-      <<active_index::8, Enum.count(model.tabs)::8>> | entries
-    ])
+    model.tabs
+    |> Enum.reduce(writer, &encode_tab_entry(&1, model.active_tab_id, &2))
+    |> Writer.finish()
   end
 
   @spec fingerprint(TabBar.t()) :: integer()
@@ -46,15 +50,17 @@ defmodule Minga.Frontend.Adapter.GUI.TabBarEncoder do
     end
   end
 
-  @spec encode_tab_entry(Tab.t(), non_neg_integer() | nil) :: binary()
-  defp encode_tab_entry(%Tab{} = tab, active_id) do
+  @spec encode_tab_entry(Tab.t(), non_neg_integer() | nil, Writer.t()) :: Writer.t()
+  defp encode_tab_entry(%Tab{} = tab, active_id, %Writer{} = writer) do
     is_active = if tab.id == active_id, do: 1, else: 0
-    flags = build_tab_flags(tab, is_active)
-    icon_bytes = :erlang.iolist_to_binary([tab.icon])
-    label_bytes = :erlang.iolist_to_binary([tab.label])
 
-    <<flags::8, tab.id::32, tab.workspace_id::16, byte_size(icon_bytes)::8, icon_bytes::binary,
-      byte_size(label_bytes)::16, label_bytes::binary, tab.tint_color::32>>
+    writer
+    |> Writer.uint8(:tab_flags, build_tab_flags(tab, is_active))
+    |> Writer.uint32(:tab_id, tab.id)
+    |> Writer.uint16(:workspace_id, tab.workspace_id)
+    |> Writer.string8(:tab_icon, tab.icon)
+    |> Writer.string16(:tab_label, tab.label)
+    |> Writer.uint32(:tab_tint_color, tab.tint_color)
   end
 
   @spec build_tab_flags(Tab.t(), 0 | 1) :: non_neg_integer()
@@ -82,7 +88,7 @@ defmodule Minga.Frontend.Adapter.GUI.TabBarEncoder do
       bor(is_active, bsl(is_dirty, 1)),
       bor(
         bor(bsl(is_agent, 2), bsl(has_attention, 3)),
-        bor(bsl(band(kind_status, 0x07), 4), bsl(is_pinned, 7))
+        bor(bsl(kind_status, 4), bsl(is_pinned, 7))
       )
     )
   end

--- a/lib/minga/frontend/adapter/gui/theme_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/theme_encoder.ex
@@ -1,9 +1,8 @@
 defmodule Minga.Frontend.Adapter.GUI.ThemeEncoder do
   @moduledoc false
 
-  import Bitwise
-
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.RenderModel.UI.Theme
 
   # gui_theme opcode
@@ -23,16 +22,17 @@ defmodule Minga.Frontend.Adapter.GUI.ThemeEncoder do
 
   @spec encode_theme_binary([Theme.color_slot()]) :: binary()
   defp encode_theme_binary(color_slots) do
-    count = Enum.count(color_slots)
+    writer =
+      :gui_theme
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_theme>>)
+      |> Writer.uint8(:color_slot_count, Enum.count(color_slots))
 
-    entries =
-      Enum.map(color_slots, fn {slot, rgb} ->
-        r = bsr(band(rgb, 0xFF0000), 16)
-        g = bsr(band(rgb, 0x00FF00), 8)
-        b = band(rgb, 0x0000FF)
-        <<slot::8, r::8, g::8, b::8>>
-      end)
-
-    IO.iodata_to_binary([@op_gui_theme, <<count::8>> | entries])
+    Enum.reduce(color_slots, writer, fn {slot, rgb}, acc ->
+      acc
+      |> Writer.uint8(:color_slot, slot)
+      |> Writer.rgb24(:color_slot_rgb, rgb)
+    end)
+    |> Writer.finish()
   end
 end

--- a/lib/minga/frontend/adapter/gui/which_key_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/which_key_encoder.ex
@@ -2,8 +2,9 @@ defmodule Minga.Frontend.Adapter.GUI.WhichKeyEncoder do
   @moduledoc false
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.RenderModel.UI.WhichKey
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
+  alias Minga.RenderModel.UI.WhichKey
 
   @op_gui_which_key Opcodes.gui_which_key()
 
@@ -25,24 +26,25 @@ defmodule Minga.Frontend.Adapter.GUI.WhichKeyEncoder do
   end
 
   defp encode_which_key_binary(%WhichKey{} = model) do
-    prefix_bytes = :erlang.iolist_to_binary([model.prefix])
+    writer =
+      :gui_which_key
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_which_key, 1::8>>)
+      |> Writer.string16(:prefix, model.prefix)
+      |> Writer.uint8(:page, model.page)
+      |> Writer.uint8(:page_count, model.page_count)
+      |> Writer.uint16(:binding_count, Enum.count(model.bindings))
 
-    entries =
-      Enum.map(model.bindings, fn b ->
-        kind_byte = if b.kind == :group, do: 1, else: 0
-        key = :erlang.iolist_to_binary([b.key])
-        desc = :erlang.iolist_to_binary([b.description])
-        icon = :erlang.iolist_to_binary([b.icon || ""])
+    model.bindings
+    |> Enum.reduce(writer, fn binding, acc ->
+      kind_byte = if binding.kind == :group, do: 1, else: 0
 
-        <<kind_byte::8, byte_size(key)::8, key::binary, byte_size(desc)::16, desc::binary,
-          byte_size(icon)::8, icon::binary>>
-      end)
-
-    IO.iodata_to_binary([
-      @op_gui_which_key,
-      <<1::8, byte_size(prefix_bytes)::16, prefix_bytes::binary, model.page::8,
-        model.page_count::8, Enum.count(model.bindings)::16>>
-      | entries
-    ])
+      acc
+      |> Writer.uint8(:binding_kind, kind_byte)
+      |> Writer.string8(:binding_key, binding.key)
+      |> Writer.string16(:binding_description, binding.description)
+      |> Writer.string8(:binding_icon, binding.icon || "")
+    end)
+    |> Writer.finish()
   end
 end

--- a/lib/minga/frontend/adapter/gui/window_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/window_encoder.ex
@@ -79,8 +79,7 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   alias Minga.RenderModel.Window.SearchMatch
   alias Minga.RenderModel.Window.Selection
   alias Minga.RenderModel.Window.Span
-  alias Minga.Frontend.Adapter.GUI.Wire
-
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
 
   @op_gui_window_content Opcodes.gui_window_content()
@@ -129,20 +128,24 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   @doc "Encodes a cursor and cursorline overlay delta for a retained GUI window."
   @spec encode_overlay_delta(RenderWindow.t()) :: binary()
   def encode_overlay_delta(%RenderWindow{} = window) do
-    validate_window_fields!(window, :gui_window_overlay_delta)
-    cursorline = encode_cursorline_section(window.cursorline, window.rect)
+    command = :gui_window_overlay_delta
+    cursorline = encode_cursorline_section(window.cursorline, window.rect, command)
 
     flags =
       if(Map.get(window, :cursor_visible, true), do: 0x01, else: 0x00) |||
         if(cursorline != nil, do: 0x02, else: 0x00)
 
-    cursor_shape = encode_cursor_shape(window.cursor_shape)
-
-    header =
-      <<window.window_id::16, window.content_epoch::32, flags::8, window.cursor_row::16,
-        window.cursor_col::16, cursor_shape::8>>
-
-    IO.iodata_to_binary([<<@op_gui_window_overlay_delta>>, header, cursorline || []])
+    command
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_window_overlay_delta>>)
+    |> Writer.uint16(:window_id, window.window_id)
+    |> Writer.uint32(:content_epoch, window.content_epoch)
+    |> Writer.uint8(:flags, flags)
+    |> Writer.uint16(:cursor_row, window.cursor_row)
+    |> Writer.uint16(:cursor_col, window.cursor_col)
+    |> Writer.uint8(:cursor_shape, encode_cursor_shape(window.cursor_shape))
+    |> Writer.append(cursorline || [])
+    |> Writer.finish()
   end
 
   @doc "Encodes a retained viewport delta with ordered ref-or-full row entries."
@@ -188,36 +191,52 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   @doc "Encodes window content with per-section byte metrics."
   @spec encode_window_content_with_metrics(RenderWindow.t()) :: {binary(), metrics()}
   def encode_window_content_with_metrics(%RenderWindow{} = sw) do
-    validate_window_fields!(sw, :gui_window_content)
+    command = :gui_window_content
     # Flags byte: bit 0 = full_refresh, bit 1 = cursor_visible
     flags =
       if(sw.full_refresh, do: 1, else: 0) |||
         if Map.get(sw, :cursor_visible, true), do: 0x02, else: 0
 
-    cursor_shape = encode_cursor_shape(sw.cursor_shape)
-    row_count = Enum.count(sw.rows)
-    validate_uint!(:gui_window_content, :row_count, row_count, Wire.max_u32())
-
     header_payload =
-      <<sw.window_id::16, flags::8, sw.cursor_row::16, sw.cursor_col::16, cursor_shape::8,
-        sw.scroll_left::16, sw.content_epoch::32>>
+      command
+      |> Writer.new()
+      |> Writer.uint16(:window_id, sw.window_id)
+      |> Writer.uint8(:flags, flags)
+      |> Writer.uint16(:cursor_row, sw.cursor_row)
+      |> Writer.uint16(:cursor_col, sw.cursor_col)
+      |> Writer.uint8(:cursor_shape, encode_cursor_shape(sw.cursor_shape))
+      |> Writer.uint16(:scroll_left, sw.scroll_left)
+      |> Writer.uint32(:content_epoch, sw.content_epoch)
+      |> Writer.finish()
 
-    rows_payload = IO.iodata_to_binary([<<row_count::32>> | encode_rows(sw.rows)])
-    header_section = encode_window_content_section(@section_wc_header, header_payload)
-    rows_section = encode_window_content_section(@section_wc_rows, rows_payload)
-    overlay = overlay_sections(sw, &encode_window_content_section/2)
+    rows_payload =
+      command
+      |> Writer.new()
+      |> Writer.uint32(:row_count, Enum.count(sw.rows))
+      |> Writer.append(encode_rows(sw.rows, command))
+      |> Writer.finish()
+
+    header_section = encode_section(command, @section_wc_header, header_payload)
+    rows_section = encode_section(command, @section_wc_rows, rows_payload)
+    overlay = overlay_sections(sw, command)
 
     sections =
       [header_section, rows_section | overlay.sections] ++
         overlay.geometry ++ overlay.cursorline ++ overlay.scroll_presentation
 
-    sections_payload = IO.iodata_to_binary([<<Enum.count(sections)::8>> | sections])
+    sections_payload =
+      command
+      |> Writer.new()
+      |> Writer.uint8(:section_count, Enum.count(sections))
+      |> Writer.append(sections)
+      |> Writer.finish()
 
     binary =
-      IO.iodata_to_binary([
-        <<@op_gui_window_content, byte_size(sections_payload)::32>>,
-        sections_payload
-      ])
+      command
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_window_content>>)
+      |> Writer.payload32(:payload, sections_payload)
+      |> Writer.finish()
 
     metrics = %{
       row_bytes: byte_size(rows_section),
@@ -238,82 +257,104 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
           {binary(), boolean()}
   defp encode_rows_snapshot_delta(opcode, %RenderWindow{} = sw, previous_hashes) do
     command = delta_command(opcode)
-    validate_window_fields!(sw, command)
-    {row_entries, has_refs?} = encode_delta_row_entries(sw.rows, previous_hashes)
+    {row_entries, has_refs?} = encode_delta_row_entries(sw.rows, previous_hashes, command)
 
-    row_count = Enum.count(sw.rows)
-    validate_uint!(command, :row_count, row_count, Wire.max_u32())
-    rows_payload = IO.iodata_to_binary([<<row_count::32>> | row_entries])
-    sections = delta_sections(sw, rows_payload)
-    binary = IO.iodata_to_binary([<<opcode, Enum.count(sections)::8>> | sections])
+    rows_payload =
+      command
+      |> Writer.new()
+      |> Writer.uint32(:row_count, Enum.count(sw.rows))
+      |> Writer.append(row_entries)
+      |> Writer.finish()
+
+    sections = delta_sections(sw, rows_payload, command)
+
+    binary =
+      command
+      |> Writer.new()
+      |> Writer.append(<<opcode>>)
+      |> Writer.uint8(:section_count, Enum.count(sections))
+      |> Writer.append(sections)
+      |> Writer.finish()
 
     {binary, has_refs?}
   end
 
-  @spec delta_sections(RenderWindow.t(), binary()) :: [binary()]
-  defp delta_sections(%RenderWindow{} = sw, rows_payload) do
-    cursor_shape = encode_cursor_shape(sw.cursor_shape)
+  @spec delta_sections(RenderWindow.t(), binary(), atom()) :: [binary()]
+  defp delta_sections(%RenderWindow{} = sw, rows_payload, command) do
     flags = if Map.get(sw, :cursor_visible, true), do: 0x01, else: 0x00
 
     header_payload =
-      <<sw.window_id::16, sw.content_epoch::32, flags::8, sw.cursor_row::16, sw.cursor_col::16,
-        cursor_shape::8, sw.scroll_left::16>>
+      command
+      |> Writer.new()
+      |> Writer.uint16(:window_id, sw.window_id)
+      |> Writer.uint32(:content_epoch, sw.content_epoch)
+      |> Writer.uint8(:flags, flags)
+      |> Writer.uint16(:cursor_row, sw.cursor_row)
+      |> Writer.uint16(:cursor_col, sw.cursor_col)
+      |> Writer.uint8(:cursor_shape, encode_cursor_shape(sw.cursor_shape))
+      |> Writer.uint16(:scroll_left, sw.scroll_left)
+      |> Writer.finish()
 
-    header_section = encode_delta_section(@section_wc_header, header_payload)
-    rows_section = encode_delta_section(@section_wc_rows, rows_payload)
-    overlay = overlay_sections(sw, &encode_delta_section/2)
+    header_section = encode_section(command, @section_wc_header, header_payload)
+    rows_section = encode_section(command, @section_wc_rows, rows_payload)
+    overlay = overlay_sections(sw, command)
 
     [header_section, rows_section | overlay.sections] ++
       overlay.geometry ++ overlay.cursorline ++ overlay.scroll_presentation
   end
 
-  @spec encode_delta_row_entries([Row.t()], map()) :: {iodata(), boolean()}
-  defp encode_delta_row_entries(rows, previous_hashes) do
+  @spec encode_delta_row_entries([Row.t()], map(), atom()) :: {iodata(), boolean()}
+  defp encode_delta_row_entries(rows, previous_hashes, command) do
     Enum.map_reduce(rows, false, fn %Row{} = row, has_refs? ->
       if Map.get(previous_hashes, row.row_id) == row.content_hash do
-        {[<<0::8, row.row_id::64, row.content_hash::32>>], true}
+        entry =
+          command
+          |> Writer.new()
+          |> Writer.uint8(:row_entry_type, 0)
+          |> Writer.uint64(:row_id, row.row_id)
+          |> Writer.uint32(:content_hash, row.content_hash)
+          |> Writer.finish()
+
+        {[entry], true}
       else
-        {[<<1::8>>, encode_row(row)], has_refs?}
+        {[<<1>>, encode_row(row, command)], has_refs?}
       end
     end)
   end
 
-  defp overlay_sections(%RenderWindow{} = sw, section_encoder) do
-    selection =
-      section_encoder.(@section_wc_selection, IO.iodata_to_binary(encode_selection(sw.selection)))
+  defp overlay_sections(%RenderWindow{} = sw, command) do
+    section_encoder = fn section_id, payload -> encode_section(command, section_id, payload) end
+    selection = section_encoder.(@section_wc_selection, encode_selection(sw.selection, command))
 
     search =
-      section_encoder.(
-        @section_wc_search,
-        IO.iodata_to_binary(encode_search_matches(sw.search_matches))
-      )
+      section_encoder.(@section_wc_search, encode_search_matches(sw.search_matches, command))
 
     diagnostics =
       section_encoder.(
         @section_wc_diagnostics,
-        IO.iodata_to_binary(encode_diagnostic_ranges(sw.diagnostic_ranges))
+        encode_diagnostic_ranges(sw.diagnostic_ranges, command)
       )
 
     highlights =
       section_encoder.(
         @section_wc_highlights,
-        IO.iodata_to_binary(encode_document_highlights(sw.document_highlights))
+        encode_document_highlights(sw.document_highlights, command)
       )
 
     annotations =
-      section_encoder.(
-        @section_wc_annotations,
-        IO.iodata_to_binary(encode_annotations(sw.annotations))
-      )
+      section_encoder.(@section_wc_annotations, encode_annotations(sw.annotations, command))
 
-    geometry = geometry_sections(encode_geometry(sw.geometry), section_encoder)
+    geometry = geometry_sections(encode_geometry(sw.geometry, command), section_encoder)
 
     cursorline =
-      cursorline_sections(encode_cursorline_section(sw.cursorline, sw.rect), section_encoder)
+      cursorline_sections(
+        encode_cursorline_section(sw.cursorline, sw.rect, command),
+        section_encoder
+      )
 
     scroll_presentation =
       scroll_presentation_sections(
-        encode_scroll_presentation(ScrollPresentation.from_window(sw)),
+        encode_scroll_presentation(ScrollPresentation.from_window(sw), command),
         section_encoder
       )
 
@@ -335,30 +376,13 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
     %{row_bytes: 0, overlay_bytes: 0, gutter_bytes: 0, annotation_bytes: 0, metadata_bytes: 0}
   end
 
-  @spec encode_section(non_neg_integer(), binary()) :: binary()
-  defp encode_section(section_id, payload) do
-    Wire.encode_section(section_id, payload)
-  end
-
-  @spec encode_delta_section(non_neg_integer(), binary()) :: binary()
-  defp encode_delta_section(section_id, payload) do
-    validate_uint!(:gui_window_delta_section, :section_id, section_id, Wire.max_u8())
-    validate_uint!(:gui_window_delta_section, :payload_length, byte_size(payload), Wire.max_u32())
-    <<section_id::8, byte_size(payload)::32, payload::binary>>
-  end
-
-  @spec encode_window_content_section(non_neg_integer(), binary()) :: binary()
-  defp encode_window_content_section(section_id, payload) do
-    validate_uint!(:gui_window_content_section, :section_id, section_id, Wire.max_u8())
-
-    validate_uint!(
-      :gui_window_content_section,
-      :payload_length,
-      byte_size(payload),
-      Wire.max_u32()
-    )
-
-    <<section_id::8, byte_size(payload)::32, payload::binary>>
+  @spec encode_section(atom(), non_neg_integer(), binary()) :: binary()
+  defp encode_section(command, section_id, payload) do
+    command
+    |> Writer.new()
+    |> Writer.uint8(:section_id, section_id)
+    |> Writer.payload32(:section_payload, payload)
+    |> Writer.finish()
   end
 
   @spec geometry_sections(binary() | nil, function()) :: [binary()]
@@ -379,51 +403,75 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   defp scroll_presentation_sections(payload, section_encoder),
     do: [section_encoder.(@section_wc_scroll_presentation, payload)]
 
-  @spec encode_geometry(PaneGeometry.t() | nil) :: binary() | nil
-  defp encode_geometry(nil), do: nil
+  @spec encode_geometry(PaneGeometry.t() | nil, atom()) :: binary() | nil
+  defp encode_geometry(nil, _command), do: nil
 
-  defp encode_geometry(%PaneGeometry{} = geometry) do
-    hit_regions = encode_hit_regions(geometry.hit_regions)
-
-    IO.iodata_to_binary([
-      <<geometry.window_id::16>>,
-      encode_rect(geometry.total_rect),
-      encode_rect(geometry.content_rect),
-      encode_rect(geometry.text_rect),
-      encode_rect(geometry.gutter_rect),
-      encode_rect(geometry.clip_rect),
-      <<geometry.viewport.top::32, geometry.viewport.left::16, geometry.viewport.rows::16,
-        geometry.viewport.cols::16, geometry.viewport.total_lines::32,
-        geometry.viewport.visual_row_offset::16, geometry.viewport.total_visual_rows::32,
-        geometry.gutter_metrics.line_number_width::16, geometry.gutter_metrics.sign_col_width::16,
-        Enum.count(geometry.hit_regions)::8>>,
-      hit_regions
-    ])
+  defp encode_geometry(%PaneGeometry{} = geometry, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:geometry_window_id, geometry.window_id)
+    |> Writer.append(encode_rect(geometry.total_rect, command))
+    |> Writer.append(encode_rect(geometry.content_rect, command))
+    |> Writer.append(encode_rect(geometry.text_rect, command))
+    |> Writer.append(encode_rect(geometry.gutter_rect, command))
+    |> Writer.append(encode_rect(geometry.clip_rect, command))
+    |> Writer.uint32(:viewport_top, geometry.viewport.top)
+    |> Writer.uint16(:viewport_left, geometry.viewport.left)
+    |> Writer.uint16(:viewport_rows, geometry.viewport.rows)
+    |> Writer.uint16(:viewport_cols, geometry.viewport.cols)
+    |> Writer.uint32(:viewport_total_lines, geometry.viewport.total_lines)
+    |> Writer.uint16(:viewport_visual_row_offset, geometry.viewport.visual_row_offset)
+    |> Writer.uint32(:viewport_total_visual_rows, geometry.viewport.total_visual_rows)
+    |> Writer.uint16(:gutter_line_number_width, geometry.gutter_metrics.line_number_width)
+    |> Writer.uint16(:gutter_sign_col_width, geometry.gutter_metrics.sign_col_width)
+    |> Writer.uint8(:hit_region_count, Enum.count(geometry.hit_regions))
+    |> Writer.append(encode_hit_regions(geometry.hit_regions, command))
+    |> Writer.finish()
   end
 
-  @spec encode_scroll_presentation(ScrollPresentation.t() | nil) :: binary() | nil
-  defp encode_scroll_presentation(nil), do: nil
+  @spec encode_scroll_presentation(ScrollPresentation.t() | nil, atom()) :: binary() | nil
+  defp encode_scroll_presentation(nil, _command), do: nil
 
-  defp encode_scroll_presentation(%ScrollPresentation{} = presentation) do
+  defp encode_scroll_presentation(%ScrollPresentation{} = presentation, command) do
     flags = if presentation.reset_required, do: 0x01, else: 0x00
 
-    <<presentation.window_id::16, flags::8, presentation.anchor_top::32,
-      presentation.anchor_left::16, presentation.anchor_visual_row_offset::16,
-      presentation.visible_start_line::32, presentation.visible_end_line::32,
-      presentation.overscan_start_line::32, presentation.overscan_end_line::32,
-      presentation.content_epoch::32, presentation.layout_generation::32,
-      presentation.scroll_seq::32>>
+    command
+    |> Writer.new()
+    |> Writer.uint16(:scroll_window_id, presentation.window_id)
+    |> Writer.uint8(:scroll_flags, flags)
+    |> Writer.uint32(:anchor_top, presentation.anchor_top)
+    |> Writer.uint16(:anchor_left, presentation.anchor_left)
+    |> Writer.uint16(:anchor_visual_row_offset, presentation.anchor_visual_row_offset)
+    |> Writer.uint32(:visible_start_line, presentation.visible_start_line)
+    |> Writer.uint32(:visible_end_line, presentation.visible_end_line)
+    |> Writer.uint32(:overscan_start_line, presentation.overscan_start_line)
+    |> Writer.uint32(:overscan_end_line, presentation.overscan_end_line)
+    |> Writer.uint32(:scroll_content_epoch, presentation.content_epoch)
+    |> Writer.uint32(:layout_generation, presentation.layout_generation)
+    |> Writer.uint32(:scroll_seq, presentation.scroll_seq)
+    |> Writer.finish()
   end
 
-  @spec encode_rect(PaneGeometry.rect()) :: binary()
-  defp encode_rect({row, col, width, height}) do
-    <<row::16, col::16, width::16, height::16>>
+  @spec encode_rect(PaneGeometry.rect(), atom()) :: binary()
+  defp encode_rect({row, col, width, height}, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:rect_row, row)
+    |> Writer.uint16(:rect_col, col)
+    |> Writer.uint16(:rect_width, width)
+    |> Writer.uint16(:rect_height, height)
+    |> Writer.finish()
   end
 
-  @spec encode_hit_regions([HitRegion.t()]) :: iodata()
-  defp encode_hit_regions(hit_regions) do
+  @spec encode_hit_regions([HitRegion.t()], atom()) :: iodata()
+  defp encode_hit_regions(hit_regions, command) do
     Enum.map(hit_regions, fn %HitRegion{} = region ->
-      [<<encode_hit_kind(region.kind)::8>>, encode_rect(region.rect), <<region.window_id::16>>]
+      command
+      |> Writer.new()
+      |> Writer.uint8(:hit_region_kind, encode_hit_kind(region.kind))
+      |> Writer.append(encode_rect(region.rect, command))
+      |> Writer.uint16(:hit_region_window_id, region.window_id)
+      |> Writer.finish()
     end)
   end
 
@@ -443,26 +491,21 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
 
   # ── Rows ─────────────────────────────────────────────────────────────────
 
-  @spec encode_rows([Row.t()]) :: iodata()
-  defp encode_rows(rows) do
-    Enum.map(rows, &encode_row/1)
-  end
+  @spec encode_rows([Row.t()], atom()) :: iodata()
+  defp encode_rows(rows, command), do: Enum.map(rows, &encode_row(&1, command))
 
-  @spec encode_row(Row.t()) :: binary()
-  defp encode_row(%Row{} = row) do
-    row_type = encode_row_type(row.row_type)
-    text_bytes = row.text
-    text_len = byte_size(text_bytes)
-    span_count = Enum.count(row.spans)
-    validate_uint!(:gui_window_content, :span_count, span_count, Wire.max_u16())
-
-    spans_binary = Enum.map(row.spans, &encode_span/1)
-
-    IO.iodata_to_binary([
-      <<row_type::8, row.row_id::64, row.buf_line::32, row.content_hash::32, text_len::32,
-        text_bytes::binary, span_count::16>>
-      | spans_binary
-    ])
+  @spec encode_row(Row.t(), atom()) :: binary()
+  defp encode_row(%Row{} = row, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint8(:row_type, encode_row_type(row.row_type))
+    |> Writer.uint64(:row_id, row.row_id)
+    |> Writer.uint32(:buf_line, row.buf_line)
+    |> Writer.uint32(:content_hash, row.content_hash)
+    |> Writer.string32(:row_text, row.text)
+    |> Writer.uint16(:span_count, Enum.count(row.spans))
+    |> Writer.append(Enum.map(row.spans, &encode_span(&1, command)))
+    |> Writer.finish()
   end
 
   @spec encode_row_type(Row.row_type()) :: non_neg_integer()
@@ -474,28 +517,34 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
 
   # ── Spans ────────────────────────────────────────────────────────────────
 
-  @spec encode_span(Span.t()) :: binary()
-  defp encode_span(%Span{} = span) do
-    fg_r = span.fg >>> 16 &&& 0xFF
-    fg_g = span.fg >>> 8 &&& 0xFF
-    fg_b = span.fg &&& 0xFF
-    bg_r = span.bg >>> 16 &&& 0xFF
-    bg_g = span.bg >>> 8 &&& 0xFF
-    bg_b = span.bg &&& 0xFF
-
-    <<span.start_col::16, span.end_col::16, fg_r::8, fg_g::8, fg_b::8, bg_r::8, bg_g::8, bg_b::8,
-      span.attrs::8, span.font_weight::8, span.font_id::8>>
+  @spec encode_span(Span.t(), atom()) :: binary()
+  defp encode_span(%Span{} = span, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:span_start_col, span.start_col)
+    |> Writer.uint16(:span_end_col, span.end_col)
+    |> Writer.rgb24(:span_fg, span.fg)
+    |> Writer.rgb24(:span_bg, span.bg)
+    |> Writer.uint8(:span_attrs, span.attrs)
+    |> Writer.uint8(:span_font_weight, span.font_weight)
+    |> Writer.uint8(:span_font_id, span.font_id)
+    |> Writer.finish()
   end
 
   # ── Selection ────────────────────────────────────────────────────────────
 
-  @spec encode_selection(Selection.t() | nil) :: binary()
-  defp encode_selection(nil), do: <<0::8>>
+  @spec encode_selection(Selection.t() | nil, atom()) :: binary()
+  defp encode_selection(nil, _command), do: <<0>>
 
-  defp encode_selection(%Selection{} = sel) do
-    type_byte = encode_selection_type(sel.type)
-
-    <<type_byte::8, sel.start_row::16, sel.start_col::16, sel.end_row::16, sel.end_col::16>>
+  defp encode_selection(%Selection{} = sel, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint8(:selection_type, encode_selection_type(sel.type))
+    |> Writer.uint16(:selection_start_row, sel.start_row)
+    |> Writer.uint16(:selection_start_col, sel.start_col)
+    |> Writer.uint16(:selection_end_row, sel.end_row)
+    |> Writer.uint16(:selection_end_col, sel.end_col)
+    |> Writer.finish()
   end
 
   @spec encode_selection_type(Selection.selection_type()) :: non_neg_integer()
@@ -505,35 +554,47 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
 
   # ── Search matches ──────────────────────────────────────────────────────
 
-  @spec encode_search_matches([SearchMatch.t()]) :: binary()
-  defp encode_search_matches(matches) do
-    count = Enum.count(matches)
-    validate_uint!(:gui_window_content, :search_match_count, count, Wire.max_u16())
-    entries = Enum.map(matches, &encode_search_match/1)
-    IO.iodata_to_binary([<<count::16>> | entries])
+  @spec encode_search_matches([SearchMatch.t()], atom()) :: binary()
+  defp encode_search_matches(matches, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:search_match_count, Enum.count(matches))
+    |> Writer.append(Enum.map(matches, &encode_search_match(&1, command)))
+    |> Writer.finish()
   end
 
-  @spec encode_search_match(SearchMatch.t()) :: binary()
-  defp encode_search_match(%SearchMatch{} = m) do
-    is_current = if m.is_current, do: 1, else: 0
-    <<m.row::16, m.start_col::16, m.end_col::16, is_current::8>>
+  @spec encode_search_match(SearchMatch.t(), atom()) :: binary()
+  defp encode_search_match(%SearchMatch{} = match, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:search_match_row, match.row)
+    |> Writer.uint16(:search_match_start_col, match.start_col)
+    |> Writer.uint16(:search_match_end_col, match.end_col)
+    |> Writer.uint8(:search_match_current, if(match.is_current, do: 1, else: 0))
+    |> Writer.finish()
   end
 
   # ── Diagnostic ranges ──────────────────────────────────────────────────
 
-  @spec encode_diagnostic_ranges([DiagnosticRange.t()]) :: binary()
-  defp encode_diagnostic_ranges(ranges) do
-    count = Enum.count(ranges)
-    validate_uint!(:gui_window_content, :diagnostic_range_count, count, Wire.max_u16())
-    entries = Enum.map(ranges, &encode_diagnostic_range/1)
-    IO.iodata_to_binary([<<count::16>> | entries])
+  @spec encode_diagnostic_ranges([DiagnosticRange.t()], atom()) :: binary()
+  defp encode_diagnostic_ranges(ranges, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:diagnostic_range_count, Enum.count(ranges))
+    |> Writer.append(Enum.map(ranges, &encode_diagnostic_range(&1, command)))
+    |> Writer.finish()
   end
 
-  @spec encode_diagnostic_range(DiagnosticRange.t()) :: binary()
-  defp encode_diagnostic_range(%DiagnosticRange{} = d) do
-    severity = encode_severity(d.severity)
-
-    <<d.start_row::16, d.start_col::16, d.end_row::16, d.end_col::16, severity::8>>
+  @spec encode_diagnostic_range(DiagnosticRange.t(), atom()) :: binary()
+  defp encode_diagnostic_range(%DiagnosticRange{} = diagnostic, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:diagnostic_start_row, diagnostic.start_row)
+    |> Writer.uint16(:diagnostic_start_col, diagnostic.start_col)
+    |> Writer.uint16(:diagnostic_end_row, diagnostic.end_row)
+    |> Writer.uint16(:diagnostic_end_col, diagnostic.end_col)
+    |> Writer.uint8(:diagnostic_severity, encode_severity(diagnostic.severity))
+    |> Writer.finish()
   end
 
   @spec encode_severity(atom()) :: non_neg_integer()
@@ -544,19 +605,25 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
 
   # ── Document highlights ─────────────────────────────────────────────────
 
-  @spec encode_document_highlights([DocumentHighlight.t()]) :: binary()
-  defp encode_document_highlights(highlights) do
-    count = Enum.count(highlights)
-    validate_uint!(:gui_window_content, :document_highlight_count, count, Wire.max_u16())
-    entries = Enum.map(highlights, &encode_document_highlight/1)
-    IO.iodata_to_binary([<<count::16>> | entries])
+  @spec encode_document_highlights([DocumentHighlight.t()], atom()) :: binary()
+  defp encode_document_highlights(highlights, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:document_highlight_count, Enum.count(highlights))
+    |> Writer.append(Enum.map(highlights, &encode_document_highlight(&1, command)))
+    |> Writer.finish()
   end
 
-  @spec encode_document_highlight(DocumentHighlight.t()) :: binary()
-  defp encode_document_highlight(%DocumentHighlight{} = h) do
-    kind = encode_highlight_kind(h.kind)
-
-    <<h.start_row::16, h.start_col::16, h.end_row::16, h.end_col::16, kind::8>>
+  @spec encode_document_highlight(DocumentHighlight.t(), atom()) :: binary()
+  defp encode_document_highlight(%DocumentHighlight{} = highlight, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:highlight_start_row, highlight.start_row)
+    |> Writer.uint16(:highlight_start_col, highlight.start_col)
+    |> Writer.uint16(:highlight_end_row, highlight.end_row)
+    |> Writer.uint16(:highlight_end_col, highlight.end_col)
+    |> Writer.uint8(:highlight_kind, encode_highlight_kind(highlight.kind))
+    |> Writer.finish()
   end
 
   @spec encode_highlight_kind(DocumentHighlight.kind()) :: non_neg_integer()
@@ -566,29 +633,25 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
 
   # ── Line annotations ─────────────────────────────────────────────────────
 
-  @spec encode_annotations([Annotation.t()]) :: binary()
-  defp encode_annotations(annotations) do
-    count = Enum.count(annotations)
-    validate_uint!(:gui_window_content, :annotation_count, count, Wire.max_u16())
-    entries = Enum.map(annotations, &encode_annotation/1)
-    IO.iodata_to_binary([<<count::16>> | entries])
+  @spec encode_annotations([Annotation.t()], atom()) :: binary()
+  defp encode_annotations(annotations, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:annotation_count, Enum.count(annotations))
+    |> Writer.append(Enum.map(annotations, &encode_annotation(&1, command)))
+    |> Writer.finish()
   end
 
-  @spec encode_annotation(Annotation.t()) :: binary()
-  defp encode_annotation(%Annotation{} = ann) do
-    kind = encode_annotation_kind(ann.kind)
-    fg_r = ann.fg >>> 16 &&& 0xFF
-    fg_g = ann.fg >>> 8 &&& 0xFF
-    fg_b = ann.fg &&& 0xFF
-    bg_r = ann.bg >>> 16 &&& 0xFF
-    bg_g = ann.bg >>> 8 &&& 0xFF
-    bg_b = ann.bg &&& 0xFF
-    text_bytes = ann.text
-    text_len = byte_size(text_bytes)
-    validate_uint!(:gui_window_content, :annotation_text_length, text_len, Wire.max_u16())
-
-    <<ann.row::16, kind::8, fg_r::8, fg_g::8, fg_b::8, bg_r::8, bg_g::8, bg_b::8, text_len::16,
-      text_bytes::binary>>
+  @spec encode_annotation(Annotation.t(), atom()) :: binary()
+  defp encode_annotation(%Annotation{} = annotation, command) do
+    command
+    |> Writer.new()
+    |> Writer.uint16(:annotation_row, annotation.row)
+    |> Writer.uint8(:annotation_kind, encode_annotation_kind(annotation.kind))
+    |> Writer.rgb24(:annotation_fg, annotation.fg)
+    |> Writer.rgb24(:annotation_bg, annotation.bg)
+    |> Writer.string16(:annotation_text, annotation.text)
+    |> Writer.finish()
   end
 
   @spec encode_annotation_kind(Minga.Core.Decorations.LineAnnotation.kind()) ::
@@ -605,51 +668,80 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
 
   @spec encode_gutter_binary(Gutter.t()) :: binary()
   defp encode_gutter_binary(%Gutter{} = gutter) do
-    validate_uint!(:gui_gutter, :entry_count, Enum.count(gutter.entries), Wire.max_u16())
+    command = :gui_gutter
 
     entries_payload =
-      IO.iodata_to_binary([
-        <<Enum.count(gutter.entries)::16>> | Enum.map(gutter.entries, &encode_gutter_entry/1)
-      ])
+      command
+      |> Writer.new()
+      |> Writer.uint16(:entry_count, Enum.count(gutter.entries))
+      |> Writer.append(Enum.map(gutter.entries, &encode_gutter_entry/1))
+      |> Writer.finish()
 
-    active_byte = if gutter.is_active, do: 1, else: 0
+    window_payload =
+      command
+      |> Writer.new()
+      |> Writer.uint16(:window_id, gutter.window_id)
+      |> Writer.uint16(:content_row, gutter.content_row)
+      |> Writer.uint16(:content_col, gutter.content_col)
+      |> Writer.uint16(:content_height, gutter.content_height)
+      |> Writer.uint8(:is_active, if(gutter.is_active, do: 1, else: 0))
+      |> Writer.uint16(:content_width, gutter.content_width)
+      |> Writer.finish()
+
+    config_payload =
+      command
+      |> Writer.new()
+      |> Writer.uint32(:cursor_line, gutter.cursor_line)
+      |> Writer.uint8(:line_number_style, encode_line_number_style(gutter.line_number_style))
+      |> Writer.uint8(:line_number_width, gutter.line_number_width)
+      |> Writer.uint8(:sign_col_width, gutter.sign_col_width)
+      |> Writer.finish()
 
     sections = [
-      encode_section(
-        @section_gutter_window,
-        <<gutter.window_id::16, gutter.content_row::16, gutter.content_col::16,
-          gutter.content_height::16, active_byte::8, gutter.content_width::16>>
-      ),
-      encode_section(
-        @section_gutter_config,
-        <<gutter.cursor_line::32, encode_line_number_style(gutter.line_number_style)::8,
-          gutter.line_number_width::8, gutter.sign_col_width::8>>
-      ),
-      encode_section(@section_gutter_entries, entries_payload)
+      encode_gutter_section(@section_gutter_window, window_payload),
+      encode_gutter_section(@section_gutter_config, config_payload),
+      encode_gutter_section(@section_gutter_entries, entries_payload)
     ]
 
-    IO.iodata_to_binary([<<@op_gui_gutter, Enum.count(sections)::8>> | sections])
+    command
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_gutter>>)
+    |> Writer.uint8(:section_count, Enum.count(sections))
+    |> Writer.append(sections)
+    |> Writer.finish()
+  end
+
+  @spec encode_gutter_section(non_neg_integer(), binary()) :: binary()
+  defp encode_gutter_section(section_id, payload) do
+    :gui_gutter
+    |> Writer.new()
+    |> Writer.uint8(:section_id, section_id)
+    |> Writer.payload16(:section_payload, payload)
+    |> Writer.finish()
   end
 
   @spec encode_gutter_entry(GutterEntry.t()) :: binary()
   defp encode_gutter_entry(%GutterEntry{} = entry) do
-    fold_end_line = entry.fold_end_line || @no_fold_range
+    writer =
+      :gui_gutter
+      |> Writer.new()
+      |> Writer.uint32(:buf_line, entry.buf_line)
+      |> Writer.uint8(:display_type, encode_display_type(entry.display_type))
+      |> Writer.uint8(:sign_type, encode_sign_type(entry.sign_type))
+      |> Writer.uint32(:fold_end_line, entry.fold_end_line || @no_fold_range)
 
-    base =
-      <<entry.buf_line::32, encode_display_type(entry.display_type)::8,
-        encode_sign_type(entry.sign_type)::8, fold_end_line::32>>
-
-    case entry.sign_type do
-      :annotation ->
-        fg = entry.sign_fg || 0
-        text = entry.sign_text || ""
-        validate_uint!(:gui_gutter, :annotation_text_length, byte_size(text), Wire.max_u8())
-        <<base::binary, red(fg)::8, green(fg)::8, blue(fg)::8, byte_size(text)::8, text::binary>>
-
-      _ ->
-        base
-    end
+    encode_gutter_annotation(writer, entry)
   end
+
+  @spec encode_gutter_annotation(Writer.t(), GutterEntry.t()) :: binary()
+  defp encode_gutter_annotation(writer, %GutterEntry{sign_type: :annotation} = entry) do
+    writer
+    |> Writer.rgb24(:annotation_fg, entry.sign_fg || 0)
+    |> Writer.string8(:annotation_text, entry.sign_text || "")
+    |> Writer.finish()
+  end
+
+  defp encode_gutter_annotation(writer, %GutterEntry{}), do: Writer.finish(writer)
 
   @spec encode_line_number_style(Gutter.line_number_style()) :: non_neg_integer()
   defp encode_line_number_style(:hybrid), do: 0
@@ -683,18 +775,32 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   @spec encode_cursorline(Cursorline.t() | nil) :: [binary()]
   defp encode_cursorline(_cursorline), do: []
 
-  @spec encode_cursorline_section(Cursorline.t() | nil, RenderWindow.rect()) :: binary() | nil
-  defp encode_cursorline_section(nil, _rect), do: nil
-  defp encode_cursorline_section(%Cursorline{bg_rgb: 0}, _rect), do: nil
-  defp encode_cursorline_section(%Cursorline{row: 0xFFFF}, _rect), do: nil
+  @spec encode_cursorline_section(Cursorline.t() | nil, RenderWindow.rect(), atom()) ::
+          binary() | nil
+  defp encode_cursorline_section(nil, _rect, _command), do: nil
+  defp encode_cursorline_section(%Cursorline{bg_rgb: 0}, _rect, _command), do: nil
+  defp encode_cursorline_section(%Cursorline{row: 0xFFFF}, _rect, _command), do: nil
 
   defp encode_cursorline_section(
          %Cursorline{row: row, bg_rgb: bg_rgb},
-         {rect_row, _col, _width, height}
+         {rect_row, _col, _width, height},
+         command
        ) do
-    local_row = row |> Kernel.-(rect_row) |> max(0) |> min(max(height - 1, 0))
-    <<local_row::16, red(bg_rgb)::8, green(bg_rgb)::8, blue(bg_rgb)::8>>
+    # Cursorline rows are window-relative on the wire, so geometry clipping is intentional.
+    local_row = clip_cursorline_row(row - rect_row, height)
+
+    command
+    |> Writer.new()
+    |> Writer.uint16(:cursorline_row, local_row)
+    |> Writer.rgb24(:cursorline_bg, bg_rgb)
+    |> Writer.finish()
   end
+
+  @spec clip_cursorline_row(integer(), integer()) :: non_neg_integer()
+  defp clip_cursorline_row(_local_row, height) when height <= 0, do: 0
+  defp clip_cursorline_row(local_row, _height) when local_row < 0, do: 0
+  defp clip_cursorline_row(local_row, height) when local_row >= height, do: height - 1
+  defp clip_cursorline_row(local_row, _height), do: local_row
 
   # ── Indent guides ──────────────────────────────────────────────────────
 
@@ -702,36 +808,66 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   defp encode_indent_guides(nil), do: []
 
   defp encode_indent_guides(%IndentGuides{guide_cols: []} = guides) do
+    command = :gui_indent_guides
+
+    payload =
+      command
+      |> Writer.new()
+      |> Writer.uint16(:window_id, guides.window_id)
+      |> Writer.uint8(:tab_width, guides.tab_width)
+      |> Writer.uint16(:active_guide_col, guides.active_guide_col)
+      |> Writer.uint8(:guide_count, 0)
+      |> Writer.finish()
+
     [
-      <<@op_gui_indent_guides, 6::16, guides.window_id::16, guides.tab_width::8, 0xFFFF::16,
-        0::8>>
+      command
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_indent_guides>>)
+      |> Writer.payload16(:payload, payload)
+      |> Writer.finish()
     ]
   end
 
   defp encode_indent_guides(%IndentGuides{} = guides) do
-    guide_count = Enum.count(guides.guide_cols)
-    guide_bytes = for col <- guides.guide_cols, into: <<>>, do: <<col::16>>
-    line_count = Enum.count(guides.line_indent_levels)
-    level_bytes = for level <- guides.line_indent_levels, into: <<>>, do: <<min(level, 255)::8>>
-    payload_len = 6 + 2 * guide_count + 2 + line_count
+    command = :gui_indent_guides
 
-    [
-      <<@op_gui_indent_guides, payload_len::16, guides.window_id::16, guides.tab_width::8,
-        guides.active_guide_col::16, guide_count::8, guide_bytes::binary, line_count::16,
-        level_bytes::binary>>
-    ]
+    payload =
+      command
+      |> Writer.new()
+      |> Writer.uint16(:window_id, guides.window_id)
+      |> Writer.uint8(:tab_width, guides.tab_width)
+      |> Writer.uint16(:active_guide_col, guides.active_guide_col)
+      |> Writer.uint8(:guide_count, Enum.count(guides.guide_cols))
+      |> Writer.append(encode_guide_cols(guides.guide_cols))
+      |> Writer.uint16(:line_count, Enum.count(guides.line_indent_levels))
+      |> Writer.append(encode_indent_levels(guides.line_indent_levels))
+      |> Writer.finish()
+
+    encoded =
+      command
+      |> Writer.new()
+      |> Writer.append(<<@op_gui_indent_guides>>)
+      |> Writer.payload16(:payload, payload)
+      |> Writer.finish()
+
+    [encoded]
   end
 
-  # ── Color helpers ──────────────────────────────────────────────────────
+  @spec encode_guide_cols([non_neg_integer()]) :: binary()
+  defp encode_guide_cols(cols) do
+    Enum.reduce(cols, Writer.new(:gui_indent_guides), fn col, writer ->
+      Writer.uint16(writer, :guide_col, col)
+    end)
+    |> Writer.finish()
+  end
 
-  @spec red(non_neg_integer()) :: non_neg_integer()
-  defp red(rgb), do: rgb >>> 16 &&& 0xFF
-
-  @spec green(non_neg_integer()) :: non_neg_integer()
-  defp green(rgb), do: rgb >>> 8 &&& 0xFF
-
-  @spec blue(non_neg_integer()) :: non_neg_integer()
-  defp blue(rgb), do: rgb &&& 0xFF
+  @spec encode_indent_levels([non_neg_integer()]) :: binary()
+  defp encode_indent_levels(levels) do
+    Enum.reduce(levels, Writer.new(:gui_indent_guides), fn level, writer ->
+      Writer.uint8(writer, :indent_level, level)
+    end)
+    |> Writer.finish()
+  end
 
   # ── Cursor shape ────────────────────────────────────────────────────────
 
@@ -743,18 +879,4 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoder do
   @spec delta_command(non_neg_integer()) :: atom()
   defp delta_command(@op_gui_window_viewport_delta), do: :gui_window_viewport_delta
   defp delta_command(@op_gui_window_rows_delta), do: :gui_window_rows_delta
-
-  @spec validate_window_fields!(RenderWindow.t(), atom()) :: :ok
-  defp validate_window_fields!(%RenderWindow{} = window, command) do
-    validate_uint!(command, :window_id, window.window_id, Wire.max_u16())
-    validate_uint!(command, :cursor_row, window.cursor_row, Wire.max_u16())
-    validate_uint!(command, :cursor_col, window.cursor_col, Wire.max_u16())
-    validate_uint!(command, :scroll_left, window.scroll_left, Wire.max_u16())
-    validate_uint!(command, :content_epoch, window.content_epoch, Wire.max_u32())
-    validate_uint!(command, :scroll_seq, window.scroll_seq, Wire.max_u32())
-  end
-
-  @spec validate_uint!(atom(), atom(), term(), non_neg_integer()) :: :ok
-  defp validate_uint!(command, field, value, max),
-    do: Wire.validate_uint!(command, field, value, max)
 end

--- a/lib/minga/frontend/adapter/gui/wire.ex
+++ b/lib/minga/frontend/adapter/gui/wire.ex
@@ -6,6 +6,8 @@ defmodule Minga.Frontend.Adapter.GUI.Wire do
   @max_u8 255
   @max_u16 65_535
   @max_u32 4_294_967_295
+  @min_i32 -2_147_483_648
+  @max_i32 2_147_483_647
 
   @type bounded_result :: {[binary()], non_neg_integer()}
 
@@ -18,17 +20,29 @@ defmodule Minga.Frontend.Adapter.GUI.Wire do
   @spec max_u32() :: non_neg_integer()
   def max_u32, do: @max_u32
 
+  @spec min_i32() :: integer()
+  def min_i32, do: @min_i32
+
+  @spec max_i32() :: integer()
+  def max_i32, do: @max_i32
+
   @spec clamp_u8(term()) :: non_neg_integer()
-  def clamp_u8(value) when is_integer(value), do: value |> max(0) |> min(@max_u8)
-  def clamp_u8(_value), do: 0
+  def clamp_u8(value) do
+    validate_uint!(:gui_wire, :u8_value, value, @max_u8)
+    value
+  end
 
   @spec clamp_u16(term()) :: non_neg_integer()
-  def clamp_u16(value) when is_integer(value), do: value |> max(0) |> min(@max_u16)
-  def clamp_u16(_value), do: 0
+  def clamp_u16(value) do
+    validate_uint!(:gui_wire, :u16_value, value, @max_u16)
+    value
+  end
 
   @spec clamp_u32(term()) :: non_neg_integer()
-  def clamp_u32(value) when is_integer(value), do: value |> max(0) |> min(@max_u32)
-  def clamp_u32(_value), do: 0
+  def clamp_u32(value) do
+    validate_uint!(:gui_wire, :u32_value, value, @max_u32)
+    value
+  end
 
   @spec maybe_flag(non_neg_integer(), boolean(), non_neg_integer()) :: non_neg_integer()
   def maybe_flag(flags, true, bit), do: bor(flags, bsl(1, bit))
@@ -55,6 +69,20 @@ defmodule Minga.Frontend.Adapter.GUI.Wire do
       max: max
   end
 
+  @spec validate_int!(atom(), atom(), term(), integer(), integer()) :: :ok
+  def validate_int!(_command, _field, value, min, max)
+      when is_integer(value) and value >= min and value <= max,
+      do: :ok
+
+  def validate_int!(command, field, value, min, max) do
+    raise Minga.Frontend.Adapter.GUI.EncodingError,
+      command: command,
+      field: field,
+      actual: value,
+      min: min,
+      max: max
+  end
+
   @spec encode_string8(iodata()) :: binary()
   def encode_string8(value) do
     bytes = :erlang.iolist_to_binary([value])
@@ -71,20 +99,19 @@ defmodule Minga.Frontend.Adapter.GUI.Wire do
 
   @spec utf8_prefix_bytes(iodata(), non_neg_integer()) :: binary()
   def utf8_prefix_bytes(value, max_bytes) do
-    value
-    |> :erlang.iolist_to_binary()
-    |> do_utf8_prefix_bytes(max_bytes, "")
+    bytes = :erlang.iolist_to_binary([value])
+    validate_uint!(:gui_wire, :utf8_byte_length, byte_size(bytes), max_bytes)
+    bytes
   end
 
   @spec bounded_entries([term()], (term() -> binary()), non_neg_integer(), non_neg_integer()) ::
           bounded_result()
   def bounded_entries(items, encode_fun, max_count, budget) do
-    {entries, remaining_budget, _count} =
-      Enum.reduce_while(items, {[], budget, 0}, fn item, acc ->
-        item |> encode_fun.() |> maybe_add_bounded_entry(acc, max_count)
-      end)
-
-    {Enum.reverse(entries), remaining_budget}
+    entries = Enum.map(items, encode_fun)
+    validate_uint!(:gui_wire, :entry_count, Enum.count(entries), max_count)
+    encoded_bytes = IO.iodata_length(entries)
+    validate_uint!(:gui_wire, :entry_bytes, encoded_bytes, budget)
+    {entries, budget - encoded_bytes}
   end
 
   @spec rgb(non_neg_integer()) :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}
@@ -97,39 +124,4 @@ defmodule Minga.Frontend.Adapter.GUI.Wire do
   @spec path_hash(String.t() | nil) :: non_neg_integer()
   def path_hash(nil), do: 0
   def path_hash(path) when is_binary(path), do: :erlang.phash2(path, @max_u32)
-
-  @spec maybe_add_bounded_entry(
-          binary(),
-          {[binary()], non_neg_integer(), non_neg_integer()},
-          non_neg_integer()
-        ) ::
-          {:cont, {[binary()], non_neg_integer(), non_neg_integer()}}
-          | {:halt, {[binary()], non_neg_integer(), non_neg_integer()}}
-  defp maybe_add_bounded_entry(_entry, acc = {_entries, _budget, count}, max_count)
-       when count >= max_count do
-    {:halt, acc}
-  end
-
-  defp maybe_add_bounded_entry(entry, {entries, budget, count}, _max_count)
-       when byte_size(entry) <= budget do
-    {:cont, {[entry | entries], budget - byte_size(entry), count + 1}}
-  end
-
-  defp maybe_add_bounded_entry(_entry, acc, _max_count), do: {:halt, acc}
-
-  @spec do_utf8_prefix_bytes(binary(), non_neg_integer(), binary()) :: binary()
-  defp do_utf8_prefix_bytes(_binary, max_bytes, acc) when byte_size(acc) >= max_bytes, do: acc
-  defp do_utf8_prefix_bytes(<<>>, _max_bytes, acc), do: acc
-
-  defp do_utf8_prefix_bytes(<<char::utf8, rest::binary>>, max_bytes, acc) do
-    char_bytes = <<char::utf8>>
-
-    if byte_size(acc) + byte_size(char_bytes) <= max_bytes do
-      do_utf8_prefix_bytes(rest, max_bytes, acc <> char_bytes)
-    else
-      acc
-    end
-  end
-
-  defp do_utf8_prefix_bytes(_invalid, _max_bytes, acc), do: acc
 end

--- a/lib/minga/frontend/adapter/gui/wire/writer.ex
+++ b/lib/minga/frontend/adapter/gui/wire/writer.ex
@@ -1,0 +1,166 @@
+defmodule Minga.Frontend.Adapter.GUI.Wire.Writer do
+  @moduledoc false
+
+  alias Minga.Frontend.Adapter.GUI.Wire
+
+  @enforce_keys [:command]
+  defstruct command: nil, chunks: []
+
+  @type t :: %__MODULE__{command: atom(), chunks: [iodata()]}
+
+  @spec new(atom()) :: t()
+  def new(command) when is_atom(command), do: %__MODULE__{command: command}
+
+  @spec uint8(t(), atom(), term()) :: t()
+  def uint8(%__MODULE__{} = writer, field, value) do
+    append_uint(writer, field, value, Wire.max_u8(), 8)
+  end
+
+  @spec uint16(t(), atom(), term()) :: t()
+  def uint16(%__MODULE__{} = writer, field, value) do
+    append_uint(writer, field, value, Wire.max_u16(), 16)
+  end
+
+  @spec uint16(t(), atom(), term(), non_neg_integer()) :: t()
+  def uint16(%__MODULE__{} = writer, field, value, max) do
+    append_uint(writer, field, value, max, 16)
+  end
+
+  @spec uint32(t(), atom(), term()) :: t()
+  def uint32(%__MODULE__{} = writer, field, value) do
+    append_uint(writer, field, value, Wire.max_u32(), 32)
+  end
+
+  @spec uint64(t(), atom(), term()) :: t()
+  def uint64(%__MODULE__{} = writer, field, value) do
+    append_uint(writer, field, value, 18_446_744_073_709_551_615, 64)
+  end
+
+  @spec int32(t(), atom(), term()) :: t()
+  def int32(%__MODULE__{} = writer, field, value) do
+    Wire.validate_int!(writer.command, field, value, Wire.min_i32(), Wire.max_i32())
+    append(writer, <<value::signed-32>>)
+  end
+
+  @spec uint24(t(), atom(), term()) :: t()
+  def uint24(%__MODULE__{} = writer, field, value) do
+    append_uint(writer, field, value, 16_777_215, 24)
+  end
+
+  @spec rgb24(t(), atom(), term()) :: t()
+  def rgb24(%__MODULE__{} = writer, field, value), do: uint24(writer, field, value)
+
+  @spec string8(t(), atom(), iodata()) :: t()
+  def string8(%__MODULE__{} = writer, field, value) do
+    append_string(writer, field, value, Wire.max_u8(), 8)
+  end
+
+  @spec string16(t(), atom(), iodata()) :: t()
+  def string16(%__MODULE__{} = writer, field, value) do
+    append_string(writer, field, value, Wire.max_u16(), 16)
+  end
+
+  @spec string32(t(), atom(), iodata()) :: t()
+  def string32(%__MODULE__{} = writer, field, value) do
+    append_payload(writer, field, value, Wire.max_u32(), 32)
+  end
+
+  @spec payload16(t(), atom(), iodata()) :: t()
+  def payload16(%__MODULE__{} = writer, field, value) do
+    append_payload(writer, field, value, Wire.max_u16(), 16)
+  end
+
+  @spec payload32(t(), atom(), iodata()) :: t()
+  def payload32(%__MODULE__{} = writer, field, value) do
+    append_payload(writer, field, value, Wire.max_u32(), 32)
+  end
+
+  @spec check_uint8(t(), atom(), term()) :: t()
+  def check_uint8(%__MODULE__{} = writer, field, value) do
+    check_uint(writer, field, value, Wire.max_u8())
+  end
+
+  @spec check_uint16(t(), atom(), term()) :: t()
+  def check_uint16(%__MODULE__{} = writer, field, value) do
+    check_uint(writer, field, value, Wire.max_u16())
+  end
+
+  @spec check_uint32(t(), atom(), term()) :: t()
+  def check_uint32(%__MODULE__{} = writer, field, value) do
+    check_uint(writer, field, value, Wire.max_u32())
+  end
+
+  @spec check_uint64(t(), atom(), term()) :: t()
+  def check_uint64(%__MODULE__{} = writer, field, value) do
+    check_uint(writer, field, value, 18_446_744_073_709_551_615)
+  end
+
+  @spec section16(t(), atom(), term(), iodata()) :: t()
+  def section16(%__MODULE__{} = writer, field, section_id, payload) do
+    writer
+    |> uint8(:section_id, section_id)
+    |> payload16(field, payload)
+  end
+
+  @spec append(t(), iodata()) :: t()
+  def append(%__MODULE__{} = writer, chunk), do: %{writer | chunks: [chunk | writer.chunks]}
+
+  @spec finish(t()) :: binary()
+  def finish(%__MODULE__{} = writer), do: writer.chunks |> Enum.reverse() |> IO.iodata_to_binary()
+
+  @spec append_uint(t(), atom(), term(), non_neg_integer(), 8 | 16 | 24 | 32 | 64) :: t()
+  defp append_uint(%__MODULE__{} = writer, field, value, max, 8) do
+    Wire.validate_uint!(writer.command, field, value, max)
+    append(writer, <<value::8>>)
+  end
+
+  defp append_uint(%__MODULE__{} = writer, field, value, max, 16) do
+    Wire.validate_uint!(writer.command, field, value, max)
+    append(writer, <<value::16>>)
+  end
+
+  defp append_uint(%__MODULE__{} = writer, field, value, max, 32) do
+    Wire.validate_uint!(writer.command, field, value, max)
+    append(writer, <<value::32>>)
+  end
+
+  defp append_uint(%__MODULE__{} = writer, field, value, max, 24) do
+    Wire.validate_uint!(writer.command, field, value, max)
+    append(writer, <<value::24>>)
+  end
+
+  defp append_uint(%__MODULE__{} = writer, field, value, max, 64) do
+    Wire.validate_uint!(writer.command, field, value, max)
+    append(writer, <<value::64>>)
+  end
+
+  @spec append_string(t(), atom(), iodata(), non_neg_integer(), 8 | 16) :: t()
+  defp append_string(%__MODULE__{} = writer, field, value, max, 8) do
+    bytes = :erlang.iolist_to_binary([value])
+    Wire.validate_uint!(writer.command, field, byte_size(bytes), max)
+    append(writer, <<byte_size(bytes)::8, bytes::binary>>)
+  end
+
+  defp append_string(%__MODULE__{} = writer, field, value, max, 16) do
+    bytes = :erlang.iolist_to_binary([value])
+    Wire.validate_uint!(writer.command, field, byte_size(bytes), max)
+    append(writer, <<byte_size(bytes)::16, bytes::binary>>)
+  end
+
+  defp append_payload(%__MODULE__{} = writer, field, value, max, 16) do
+    bytes = :erlang.iolist_to_binary([value])
+    Wire.validate_uint!(writer.command, field, byte_size(bytes), max)
+    append(writer, <<byte_size(bytes)::16, bytes::binary>>)
+  end
+
+  defp append_payload(%__MODULE__{} = writer, field, value, max, 32) do
+    bytes = :erlang.iolist_to_binary([value])
+    Wire.validate_uint!(writer.command, field, byte_size(bytes), max)
+    append(writer, <<byte_size(bytes)::32, bytes::binary>>)
+  end
+
+  defp check_uint(%__MODULE__{} = writer, field, value, max) do
+    Wire.validate_uint!(writer.command, field, value, max)
+    writer
+  end
+end

--- a/lib/minga/frontend/adapter/gui/workspaces_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/workspaces_encoder.ex
@@ -5,6 +5,7 @@ defmodule Minga.Frontend.Adapter.GUI.WorkspacesEncoder do
 
   alias Minga.Frontend.Adapter.GUI.Caches
   alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI.Workspaces
   alias Minga.RenderModel.UI.Workspaces.VisibleTab
@@ -27,8 +28,11 @@ defmodule Minga.Frontend.Adapter.GUI.WorkspacesEncoder do
 
   @spec encode_command(Workspaces.t()) :: binary()
   def encode_command(%Workspaces{} = model) do
-    payload = encode_payload(model)
-    <<@op_gui_workspaces, byte_size(payload)::16, payload::binary>>
+    :gui_workspaces
+    |> Writer.new()
+    |> Writer.append(<<@op_gui_workspaces>>)
+    |> Writer.payload16(:payload, encode_payload(model))
+    |> Writer.finish()
   end
 
   @spec fingerprint(Workspaces.t()) :: integer()
@@ -44,57 +48,51 @@ defmodule Minga.Frontend.Adapter.GUI.WorkspacesEncoder do
 
   @spec encode_payload(Workspaces.t()) :: binary()
   defp encode_payload(%Workspaces{} = model) do
-    workspace_budget = Wire.max_u16() - 6 - 2
+    writer =
+      :gui_workspaces
+      |> Writer.new()
+      |> Writer.append(<<2::8>>)
+      |> Writer.uint16(:active_workspace_id, model.active_workspace_id)
+      |> Writer.uint8(:workspace_mode, encode_workspace_mode(model.mode))
+      |> Writer.uint8(:workspace_flags, encode_workspace_flags(model))
+      |> Writer.uint8(:workspace_count, Enum.count(model.workspaces))
 
-    {workspace_entries, remaining_budget} =
-      Wire.bounded_entries(
-        model.workspaces,
-        &encode_workspace_summary/1,
-        Wire.max_u8(),
-        workspace_budget
-      )
+    writer = Enum.reduce(model.workspaces, writer, &encode_workspace_summary/2)
+    writer = Writer.uint16(writer, :visible_tab_count, Enum.count(model.visible_tabs))
 
-    {visible_tab_entries, _remaining_budget} =
-      Wire.bounded_entries(
-        model.visible_tabs,
-        &encode_visible_tab/1,
-        Wire.max_u16(),
-        remaining_budget
-      )
-
-    IO.iodata_to_binary([
-      <<2::8, model.active_workspace_id::16, encode_workspace_mode(model.mode)::8,
-        encode_workspace_flags(model)::8, Enum.count(workspace_entries)::8>>,
-      workspace_entries,
-      <<Enum.count(visible_tab_entries)::16>>,
-      visible_tab_entries
-    ])
+    model.visible_tabs
+    |> Enum.reduce(writer, &encode_visible_tab/2)
+    |> Writer.finish()
   end
 
-  @spec encode_workspace_summary(Workspace.t()) :: binary()
-  defp encode_workspace_summary(%Workspace{} = workspace) do
-    {r, g, b} = Wire.rgb(workspace.color)
-    label_bytes = Wire.utf8_prefix_bytes(workspace.label, 255)
-    icon_bytes = Wire.utf8_prefix_bytes(workspace.icon, 255)
-
-    <<workspace.id::16, encode_workspace_kind(workspace.kind)::8,
-      encode_agent_status(workspace.status)::8, encode_workspace_entry_flags(workspace)::16, r::8,
-      g::8, b::8, workspace.tab_count::16, workspace.draft_count::16,
-      workspace.conflict_count::16, workspace.running_background_count::16,
-      byte_size(label_bytes)::8, label_bytes::binary, byte_size(icon_bytes)::8,
-      icon_bytes::binary>>
+  @spec encode_workspace_summary(Workspace.t(), Writer.t()) :: Writer.t()
+  defp encode_workspace_summary(%Workspace{} = workspace, %Writer{} = writer) do
+    writer
+    |> Writer.uint16(:workspace_id, workspace.id)
+    |> Writer.uint8(:workspace_kind, encode_workspace_kind(workspace.kind))
+    |> Writer.uint8(:workspace_agent_status, encode_agent_status(workspace.status))
+    |> Writer.uint16(:workspace_entry_flags, encode_workspace_entry_flags(workspace))
+    |> Writer.rgb24(:workspace_color, workspace.color)
+    |> Writer.uint16(:workspace_tab_count, workspace.tab_count)
+    |> Writer.uint16(:workspace_draft_count, workspace.draft_count)
+    |> Writer.uint16(:workspace_conflict_count, workspace.conflict_count)
+    |> Writer.uint16(:workspace_running_background_count, workspace.running_background_count)
+    |> Writer.string8(:workspace_label, workspace.label)
+    |> Writer.string8(:workspace_icon, workspace.icon)
   end
 
-  @spec encode_visible_tab(VisibleTab.t()) :: binary()
-  defp encode_visible_tab(%VisibleTab{} = tab) do
-    icon_bytes = Wire.utf8_prefix_bytes(tab.icon, 255)
-    label_bytes = Wire.utf8_prefix_bytes(tab.label, Wire.max_u16())
-    path_bytes = Wire.utf8_prefix_bytes(tab.path || "", Wire.max_u16())
-
-    <<tab.id::32, tab.workspace_id::16, encode_tab_kind(tab.kind)::8,
-      encode_visible_tab_flags(tab)::16, Wire.path_hash(tab.path)::32, byte_size(icon_bytes)::8,
-      icon_bytes::binary, byte_size(label_bytes)::16, label_bytes::binary,
-      byte_size(path_bytes)::16, path_bytes::binary, tab.tint_color::32>>
+  @spec encode_visible_tab(VisibleTab.t(), Writer.t()) :: Writer.t()
+  defp encode_visible_tab(%VisibleTab{} = tab, %Writer{} = writer) do
+    writer
+    |> Writer.uint32(:tab_id, tab.id)
+    |> Writer.uint16(:tab_workspace_id, tab.workspace_id)
+    |> Writer.uint8(:tab_kind, encode_tab_kind(tab.kind))
+    |> Writer.uint16(:tab_flags, encode_visible_tab_flags(tab))
+    |> Writer.uint32(:tab_path_hash, Wire.path_hash(tab.path))
+    |> Writer.string8(:tab_icon, tab.icon)
+    |> Writer.string16(:tab_label, tab.label)
+    |> Writer.string16(:tab_path, tab.path || "")
+    |> Writer.uint32(:tab_tint_color, tab.tint_color)
   end
 
   @spec encode_workspace_mode(Workspaces.mode()) :: non_neg_integer()

--- a/test/minga/credo/no_lossy_gui_encoder_check_test.exs
+++ b/test/minga/credo/no_lossy_gui_encoder_check_test.exs
@@ -1,0 +1,122 @@
+Code.require_file("credo/checks/no_lossy_gui_encoder_check.exs")
+
+defmodule Minga.Credo.NoLossyGuiEncoderCheckTest do
+  use Credo.Test.Case, async: true
+
+  alias Minga.Credo.NoLossyGuiEncoderCheck
+
+  @moduletag :credo
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  defp check(source_code, filename \\ "lib/minga/frontend/adapter/gui/example_encoder.ex") do
+    source_code
+    |> to_source_file(filename)
+    |> run_check(NoLossyGuiEncoderCheck, [])
+  end
+
+  test "flags lossy GUI encoder helpers" do
+    """
+    defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
+      def encode(value), do: Wire.clamp_u16(value)
+    end
+    """
+    |> check()
+    |> assert_issue(fn issue -> assert issue.trigger == "clamp_u16" end)
+  end
+
+  test "flags direct prefix truncation and min" do
+    """
+    defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
+      def encode(value), do: utf8_prefix_bytes(value, min(byte_size(value), 255))
+    end
+    """
+    |> check()
+    |> assert_issues(fn issues ->
+      assert Enum.map(issues, & &1.trigger) |> Enum.sort() == ["min", "utf8_prefix_bytes"]
+    end)
+  end
+
+  test "flags direct validation, collection truncation, and dynamic wire fields" do
+    """
+    defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
+      def encode(value, items) do
+        Wire.validate_uint!(:gui_example, :value, value, 255)
+        Enum.take(items, 255)
+        <<value::8, 1::8>>
+      end
+    end
+    """
+    |> check()
+    |> assert_issues(fn issues ->
+      assert Enum.map(issues, & &1.trigger) |> Enum.sort() == ["::8", "take", "validate_uint!"]
+    end)
+  end
+
+  test "flags bitwise masking of a data-derived value" do
+    """
+    defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
+      def encode(value), do: value &&& 0xFF
+    end
+    """
+    |> check()
+    |> assert_issue(fn issue -> assert issue.trigger == "&&&" end)
+  end
+
+  test "flags direct generic Wire carriers and color masking" do
+    """
+    defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
+      def encode(value) do
+        Wire.encode_string8(value)
+        Wire.encode_string16(value)
+        Wire.encode_section(1, value)
+        Wire.rgb(value)
+      end
+    end
+    """
+    |> check()
+    |> assert_issues(fn issues ->
+      assert Enum.map(issues, & &1.trigger) |> Enum.sort() == [
+               "encode_section",
+               "encode_string16",
+               "encode_string8",
+               "rgb"
+             ]
+    end)
+  end
+
+  test "flags every dynamic bounded wire width" do
+    """
+    defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
+      def encode(value), do: <<value::24, value::64, value::signed-32, 1::24, @fixed::64>>
+    end
+    """
+    |> check()
+    |> assert_issues(fn issues ->
+      assert Enum.map(issues, & &1.trigger) |> Enum.sort() == ["::24", "::32-signed", "::64"]
+    end)
+  end
+
+  test "allows the checked writer" do
+    """
+    defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
+      def encode(value), do: Writer.new(:gui_example) |> Writer.uint16(:value, value) |> Writer.finish()
+    end
+    """
+    |> check()
+    |> refute_issues()
+  end
+
+  test "skips non-GUI adapter files" do
+    """
+    defmodule Minga.Other do
+      def encode(value), do: min(value, 255)
+    end
+    """
+    |> check("lib/minga/other.ex")
+    |> refute_issues()
+  end
+end

--- a/test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/agent_chat_encoder_test.exs
@@ -5,6 +5,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
 
   alias Minga.Frontend.Adapter.GUI.AgentChatEncoder
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.RenderModel.UI.AgentChat
   alias Minga.RenderModel.UI.AgentChat.ApprovalView
   alias Minga.RenderModel.UI.AgentChat.MarkdownBlock
@@ -198,20 +199,15 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
       assert <<99::32, 0x02::8, 2::32, "hi">> = m2
     end
 
-    test "message count cap keeps the newest transcript messages" do
-      messages =
-        for id <- 1..105 do
-          {id, {:assistant, "message #{id}"}}
-        end
+    test "encodes every message when the complete section fits" do
+      messages = for id <- 1..105, do: {id, {:assistant, "message #{id}"}}
 
       binary = encode(%AgentChat{visible?: true, messages: messages})
       encoded_messages = messages!(binary)
 
-      assert Enum.count(encoded_messages) == 100
-      assert [first | _] = encoded_messages
-      assert <<6::32, 0x02::8, _rest::binary>> = first
-      assert last = Enum.at(encoded_messages, -1)
-      assert <<105::32, 0x02::8, _rest::binary>> = last
+      assert Enum.count(encoded_messages) == 105
+      assert [<<1::32, 0x02::8, _rest::binary>> | _] = encoded_messages
+      assert [<<105::32, 0x02::8, _rest::binary>> | _] = Enum.reverse(encoded_messages)
     end
 
     test "bare tuple messages encode with ID 0" do
@@ -478,50 +474,78 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
       assert (flags &&& 0x08) == 0
     end
 
-    test "downgrades overlong link urls instead of corrupting framing" do
-      for url <- [String.duplicate("a", 65_535), String.duplicate("a", 65_536)] do
-        styled = [[{"docs", 0x61AFEF, 0, 0x0C, url}]]
-        binary = encode(%AgentChat{visible?: true, messages: [{1, {:styled_assistant, styled}}]})
-        assert [m1] = messages!(binary)
+    test "rejects an out-of-range URL-less run flag before clearing its link bit" do
+      styled = [[{"not a link", 0xBBC2CF, 0, 256}]]
 
-        <<1::32, 0x07::8, 1::16, 1::16, tlen::16, text::binary-size(tlen), _fg::24, _bg::24,
-          flags::8>> = m1
+      error =
+        assert_raise EncodingError, fn ->
+          encode(%AgentChat{visible?: true, messages: [{1, {:styled_assistant, styled}}]})
+        end
 
-        assert text == "docs"
-        assert (flags &&& 0x08) == 0
-        assert (flags &&& 0x04) == 0
-      end
+      assert %{
+               command: :gui_agent_chat_message,
+               field: :run_flags,
+               actual: 256,
+               min: 0,
+               max: 255
+             } = error
+    end
+
+    test "rejects an overlong link URL without stripping link metadata" do
+      url = String.duplicate("a", 65_536)
+      styled = [[{"docs", 0x61AFEF, 0, 0x0C, url}]]
+
+      error =
+        assert_raise EncodingError, fn ->
+          encode(%AgentChat{visible?: true, messages: [{1, {:styled_assistant, styled}}]})
+        end
+
+      assert %{
+               command: :gui_agent_chat_message,
+               field: :run_url,
+               actual: 65_536,
+               min: 0,
+               max: 65_535
+             } = error
     end
   end
 
-  describe "payload limits and truncation" do
-    test "truncates oversized plain chat text" do
+  describe "bounded fields" do
+    test "rejects a messages section that exceeds its uint16 payload" do
       text = String.duplicate("x", 70_000)
-      binary = encode(%AgentChat{visible?: true, messages: [{:assistant, text}]})
 
-      assert byte_size(section!(binary, 0x06)) <= 65_535
-      assert [m1] = messages!(binary)
-      <<0::32, 0x02::8, len::32, encoded::binary-size(len)>> = m1
-      assert byte_size(encoded) == 60_000
-      assert String.ends_with?(encoded, "… [truncated]")
+      error =
+        assert_raise EncodingError, fn ->
+          encode(%AgentChat{visible?: true, messages: [{:assistant, text}]})
+        end
+
+      assert %{
+               command: :gui_agent_chat,
+               field: :section_payload,
+               actual: 70_017,
+               min: 0,
+               max: 65_535
+             } = error
     end
 
-    test "omits older messages instead of overflowing the section" do
+    test "rejects the complete oversized transcript instead of omitting older messages" do
       text = String.duplicate("x", 70_000)
 
-      binary =
-        encode(%AgentChat{
-          visible?: true,
-          messages: [{1, {:assistant, text}}, {2, {:assistant, text}}]
-        })
+      error =
+        assert_raise EncodingError, fn ->
+          encode(%AgentChat{
+            visible?: true,
+            messages: [{1, {:assistant, text}}, {2, {:assistant, text}}]
+          })
+        end
 
-      assert byte_size(section!(binary, 0x06)) <= 65_535
-
-      assert [notice_msg, kept_msg] = messages!(binary)
-      <<0::32, 0x05::8, 0::8, notice_len::32, notice::binary-size(notice_len)>> = notice_msg
-      assert notice =~ "omitted"
-
-      <<2::32, 0x02::8, _len::32, _text::binary>> = kept_msg
+      assert %{
+               command: :gui_agent_chat,
+               field: :section_payload,
+               actual: 140_030,
+               min: 0,
+               max: 65_535
+             } = error
     end
 
     test "keeps long command approval summaries without the short cap" do
@@ -550,20 +574,22 @@ defmodule Minga.Frontend.Adapter.GUI.AgentChatEncoderTest do
       assert summary == command
     end
 
-    test "keeps multibyte summaries within UTF-8 byte limits" do
+    test "rejects multibyte summaries whose byte length exceeds uint16" do
       command = String.duplicate("🚀", 20_000)
       tc = %ToolCallView{name: "shell", summary: command, status: :running, result: ""}
 
-      binary = encode(%AgentChat{visible?: true, messages: [{1, {:tool_call, tc}}]})
-      assert [m1] = messages!(binary)
+      error =
+        assert_raise EncodingError, fn ->
+          encode(%AgentChat{visible?: true, messages: [{1, {:tool_call, tc}}]})
+        end
 
-      <<1::32, 0x04::8, _status::8, _error::8, _collapsed::8, _duration::32, name_len::16,
-        _name::binary-size(name_len), summary_len::16, summary::binary-size(summary_len),
-        _rest::binary>> = m1
-
-      assert summary_len <= 60_000
-      assert String.valid?(summary)
-      assert String.ends_with?(summary, "… [truncated]")
+      assert %{
+               command: :gui_agent_chat_message,
+               field: :summary,
+               actual: 80_000,
+               min: 0,
+               max: 65_535
+             } = error
     end
   end
 

--- a/test/minga/frontend/adapter/gui/agent_context_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/agent_context_encoder_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.AgentContextEncoderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.Frontend.Adapter.GUI.AgentContextEncoder
   alias Minga.RenderModel.UI.AgentContext
   alias Minga.RenderModel.UI.AgentContext.Progress
@@ -96,6 +97,27 @@ defmodule Minga.Frontend.Adapter.GUI.AgentContextEncoderTest do
       assert <<1::8, ^task_len::16, "Done", ^timestamp_unix::64, 3::8, 1::8, 5::16, "shell",
                2::16, 1::16, 33::16, "Review: approve or reject changes", 2::8, 2::8, 13::16,
                "Inspect files", 1::8, 9::16, "Run tests">> = payload
+    end
+
+    test "rejects a todo count that exceeds u8" do
+      model = %AgentContext{
+        visible: true,
+        task: "Task",
+        dispatch_timestamp: ~U[2024-01-15 10:30:00Z],
+        status: :working,
+        todos: List.duplicate(%Todo{description: "item", status: :pending}, 256)
+      }
+
+      assert %{
+               command: :gui_agent_context,
+               field: :todo_count,
+               actual: 256,
+               min: 0,
+               max: 255
+             } =
+               assert_raise(EncodingError, fn ->
+                 AgentContextEncoder.encode(model, Caches.new())
+               end)
     end
 
     test "returns nil on second call with same model (fingerprint skip)" do

--- a/test/minga/frontend/adapter/gui/agent_transcript_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/agent_transcript_encoder_test.exs
@@ -1,14 +1,12 @@
 defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoderTest do
-  # async: false — several tests mutate the global :agent_transcript_resident_max_bytes
-  # config option and restore it, so they must not race other config readers.
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
-  alias Minga.Config
   alias Minga.Frontend.Adapter.GUI
   alias Minga.Frontend.Adapter.GUI.AgentChatMessageCodec, as: Codec
   alias Minga.Frontend.Adapter.GUI.AgentTranscriptEncoder, as: Encoder
   alias Minga.Frontend.Adapter.GUI.AgentTranscriptSentState
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.UI
   alias Minga.RenderModel.UI.AgentChat
@@ -31,17 +29,6 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoderTest do
   # 8 + body_bytes.
   defp sized(id, body_bytes) when body_bytes >= 5 do
     user(id, String.duplicate("x", body_bytes - 5))
-  end
-
-  defp with_cap(bytes, fun) do
-    original = Config.get(:agent_transcript_resident_max_bytes)
-    Config.set_option(:agent_transcript_resident_max_bytes, bytes)
-
-    try do
-      fun.()
-    after
-      Config.set_option(:agent_transcript_resident_max_bytes, original)
-    end
   end
 
   # Decodes one gui_agent_transcript frame into a plain map for assertions.
@@ -155,6 +142,36 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoderTest do
       assert decode(f3).mode == @mode_append
     end
 
+    test "rejects an out-of-range transcript epoch with command metadata" do
+      error =
+        assert_raise EncodingError, fn ->
+          Encoder.encode(model(4_294_967_296, [user(1, "a")]), Caches.new())
+        end
+
+      assert %{
+               command: :gui_agent_transcript,
+               field: :epoch,
+               actual: 4_294_967_296,
+               min: 0,
+               max: 4_294_967_295
+             } = error
+    end
+
+    test "rejects an out-of-range resident message id" do
+      error =
+        assert_raise EncodingError, fn ->
+          Encoder.encode(model(1, [user(4_294_967_296, "a")]), Caches.new())
+        end
+
+      assert %{
+               command: :gui_agent_transcript,
+               field: :message_id,
+               actual: 4_294_967_296,
+               min: 0,
+               max: 4_294_967_295
+             } = error
+    end
+
     test "a changed leading message (compaction) forces a full_replace" do
       m1 = [user(1, "a"), user(2, "b"), user(3, "c")]
       {_f, caches} = Encoder.encode(model(1, m1), Caches.new())
@@ -170,104 +187,40 @@ defmodule Minga.Frontend.Adapter.GUI.AgentTranscriptEncoderTest do
     end
   end
 
-  describe "resident byte cap" do
-    test "keeps a contiguous most-recent suffix and marks the stream truncated" do
-      with_cap(1_000, fn ->
-        big = String.duplicate("x", 200)
-        messages = for i <- 1..50, do: user(i, big)
+  describe "resident selection" do
+    test "encodes every resident message without selecting a suffix" do
+      messages = for i <- 1..50, do: sized(i, 300)
 
-        {frame, _} = Encoder.encode(model(1, messages), Caches.new())
-        decoded = decode(frame)
+      {frame, _} = Encoder.encode(model(1, messages), Caches.new())
+      decoded = decode(frame)
 
-        assert decoded.mode == @mode_full_replace
-        assert decoded.truncated
-        # Contiguous suffix of the tail ids, at least one, fewer than all.
-        assert ids(decoded) == Enum.to_list((51 - decoded.count)..50)
-        assert decoded.count < 50 and decoded.count > 0
-      end)
-    end
-
-    test "does not leapfrog a small older message past a large one (no holes)" do
-      # cap 1000; entries oldest→newest with a large id2 that must halt eviction.
-      # Contiguous suffix keeps [3,4,5]; a buggy non-halting reduce would grab the
-      # small id1 back in, producing [1,3,4,5] with a hole where id2 was.
-      with_cap(1_000, fn ->
-        messages = [
-          sized(1, 20),
-          sized(2, 300),
-          sized(3, 300),
-          sized(4, 300),
-          sized(5, 300)
-        ]
-
-        {frame, _} = Encoder.encode(model(1, messages), Caches.new())
-        decoded = decode(frame)
-
-        assert ids(decoded) == [3, 4, 5]
-        refute 1 in ids(decoded)
-        assert decoded.truncated
-      end)
-    end
-
-    test "a single message larger than the cap still ships" do
-      with_cap(500, fn ->
-        messages = [sized(1, 2_000)]
-        {frame, _} = Encoder.encode(model(1, messages), Caches.new())
-        decoded = decode(frame)
-
-        assert ids(decoded) == [1]
-        refute decoded.truncated
-      end)
-    end
-
-    test "over-cap streaming steady state emits bounded appends, never full_replace" do
-      with_cap(1_000, fn ->
-        # Each message body 300 bytes (wire 308); ~3 fit under 1000. Grow the
-        # transcript one message at a time and encode each frame in sequence.
-        frames =
-          Enum.reduce(1..8, {Caches.new(), []}, fn n, {caches, acc} ->
-            messages = for i <- 1..n, do: sized(i, 300)
-            {frame, caches2} = Encoder.encode(model(1, messages), caches)
-            {caches2, [frame | acc]}
-          end)
-          |> elem(1)
-          |> Enum.reverse()
-
-        [first | rest] = frames
-
-        # First frame is the initial full_replace; every later frame is an append.
-        assert decode(first).mode == @mode_full_replace
-
-        assert Enum.all?(rest, fn f -> decode(f).mode == @mode_append end),
-               "over-cap streaming must not degrade to full_replace"
-
-        # Once the window is full, appends carry a nonzero trim_front (eviction).
-        assert Enum.any?(rest, fn f -> decode(f).trim_front > 0 end)
-
-        # Each delta frame stays bounded (a handful of entries, well under the cap).
-        assert Enum.all?(rest, fn f -> byte_size(f) < 1_000 end)
-      end)
+      assert decoded.mode == @mode_full_replace
+      refute decoded.truncated
+      assert decoded.count == 50
+      assert ids(decoded) == Enum.to_list(1..50)
     end
   end
 
   describe "duplicate ids" do
-    test "deduplicates by id last-wins, preserving order" do
+    test "rejects duplicate ids instead of silently dropping entries" do
       messages = [
         {1, {:user, "a"}},
         {2, {:user, "b"}},
         {1, {:user, "c"}}
       ]
 
-      {frame, _} = Encoder.encode(model(1, messages), Caches.new())
-      decoded = decode(frame)
+      error =
+        assert_raise EncodingError, fn ->
+          Encoder.encode(model(1, messages), Caches.new())
+        end
 
-      # id 1's earlier occurrence is dropped; the last one ("c") survives at its
-      # position, so order is [2, 1].
-      assert ids(decoded) == [2, 1]
-      assert decoded.count == 2
-
-      assert [_first, {1, body}] = decoded.entries
-      assert body == Codec.encode_message_body({:user, "c"})
+      assert %{
+               command: :gui_agent_transcript,
+               field: :message_id_occurrences,
+               actual: 2,
+               min: 0,
+               max: 1
+             } = error
     end
   end
 

--- a/test/minga/frontend/adapter/gui/bottom_panel_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/bottom_panel_encoder_test.exs
@@ -3,6 +3,7 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
 
   alias Minga.Frontend.Adapter.GUI.BottomPanelEncoder
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.RenderModel.UI.BottomPanel
   alias Minga.RenderModel.UI.BottomPanel.MessageEntry
 
@@ -90,6 +91,22 @@ defmodule Minga.Frontend.Adapter.GUI.BottomPanelEncoderTest do
       assert ts == 3661
       assert path == "lib/editor.ex"
       assert text == "File opened"
+    end
+
+    test "rejects a tab name that exceeds its u8 byte length" do
+      model = %BottomPanel{
+        visible?: true,
+        tabs: [{0x01, String.duplicate("x", 256)}],
+        stream_instance: 99
+      }
+
+      assert %{
+               command: :gui_bottom_panel,
+               field: :tab_name,
+               actual: 256,
+               min: 0,
+               max: 255
+             } = assert_raise(EncodingError, fn -> encode(model) end)
     end
 
     test "encodes a nil file_path as an empty path" do

--- a/test/minga/frontend/adapter/gui/edit_timeline_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/edit_timeline_encoder_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.EditTimelineEncoderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.Frontend.Adapter.GUI.EditTimelineEncoder
   alias Minga.RenderModel.UI.EditTimeline
   alias Minga.RenderModel.UI.EditTimeline.Entry
@@ -64,6 +65,20 @@ defmodule Minga.Frontend.Adapter.GUI.EditTimelineEncoderTest do
 
       assert <<1::8, 0xFFFF::16, 0::8, 1::8, 8::16, "lib/a.ex", 2::8, 10::32, 3::32, 1::8>> =
                payload
+    end
+
+    test "rejects a tool name that exceeds its u8 byte length" do
+      model = %EditTimeline{
+        entries: [%Entry{index: 0, tool_name: String.duplicate("x", 256), timestamp_delta: 0}]
+      }
+
+      assert %{
+               command: :gui_edit_timeline,
+               field: :tool_name,
+               actual: 256,
+               min: 0,
+               max: 255
+             } = assert_raise(EncodingError, fn -> encode(model) end)
     end
 
     test "encodes a nil viewing index as 0xFFFF when visible" do

--- a/test/minga/frontend/adapter/gui/minibuffer_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/minibuffer_encoder_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.MinibufferEncoderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.Frontend.Adapter.GUI.MinibufferEncoder
   alias Minga.RenderModel.UI.Minibuffer
   alias Minga.RenderModel.UI.Minibuffer.Candidate
@@ -27,7 +28,7 @@ defmodule Minga.Frontend.Adapter.GUI.MinibufferEncoderTest do
         context: "3 matches",
         selected_index: 1,
         candidates: [
-          %Candidate{label: "term", description: "Match", match_score: 999, annotation: "line 4"}
+          %Candidate{label: "term", description: "Match", match_score: 255, annotation: "line 4"}
         ],
         total_candidates: 4
       }
@@ -41,7 +42,7 @@ defmodule Minga.Frontend.Adapter.GUI.MinibufferEncoderTest do
         context: "3 matches",
         selected_index: 1,
         candidates: [
-          %{label: "term", description: "Match", match_score: 999, annotation: "line 4"}
+          %{label: "term", description: "Match", match_score: 255, annotation: "line 4"}
         ],
         total_candidates: 4
       }
@@ -118,6 +119,17 @@ defmodule Minga.Frontend.Adapter.GUI.MinibufferEncoderTest do
       {cmd, _caches} = MinibufferEncoder.encode(model, Caches.new())
 
       assert cmd == ProtocolGUI.encode_gui_minibuffer(legacy)
+    end
+
+    test "raises instead of clamping an out-of-range candidate score" do
+      model = %Minibuffer{
+        visible?: true,
+        candidates: [%Candidate{label: "overflow", match_score: 256}]
+      }
+
+      assert_raise EncodingError,
+                   "cannot encode gui_minibuffer.candidate_match_score=256; expected 0..255",
+                   fn -> MinibufferEncoder.encode(model, Caches.new()) end
     end
 
     test "returns nil on second call with same semantic data" do

--- a/test/minga/frontend/adapter/gui/search_state_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/search_state_encoder_test.exs
@@ -115,9 +115,7 @@ defmodule Minga.Frontend.Adapter.GUI.SearchStateEncoderTest do
       end
     end
 
-    test "clamps match_count and current_index to u16 max" do
-      legacy_binary = ProtocolGUI.encode_gui_search_state(true, 70_000, 70_000, %{})
-
+    test "rejects out-of-range match_count before narrowing it to u16" do
       model = %SearchState{
         active: true,
         match_count: 70_000,
@@ -128,10 +126,16 @@ defmodule Minga.Frontend.Adapter.GUI.SearchStateEncoderTest do
         replace_mode: false
       }
 
-      caches = Caches.new()
-      {new_binary, _caches} = SearchStateEncoder.encode(model, caches)
-
-      assert new_binary == legacy_binary
+      assert %{
+               command: :gui_search_state,
+               field: :match_count,
+               actual: 70_000,
+               min: 0,
+               max: 65_535
+             } =
+               assert_raise(Minga.Frontend.Adapter.GUI.EncodingError, fn ->
+                 SearchStateEncoder.encode(model, Caches.new())
+               end)
     end
   end
 end

--- a/test/minga/frontend/adapter/gui/signature_help_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/signature_help_encoder_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.SignatureHelpEncoderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.Frontend.Adapter.GUI.SignatureHelpEncoder
   alias Minga.RenderModel.UI.SignatureHelp
   alias Minga.RenderModel.UI.SignatureHelp.Parameter
@@ -58,36 +59,19 @@ defmodule Minga.Frontend.Adapter.GUI.SignatureHelpEncoderTest do
                ProtocolGUI.encode_gui_signature_help(legacy)
     end
 
-    test "clamps active indexes and counts to protocol byte fields" do
-      parameters =
-        for index <- 1..260 do
-          %Parameter{label: "param-#{index}", documentation: "doc-#{index}"}
-        end
-
-      signatures =
-        for index <- 1..260 do
-          %Signature{label: "sig-#{index}", documentation: "doc-#{index}", parameters: parameters}
-        end
-
+    test "raises instead of clamping active indexes to protocol byte fields" do
       model = %SignatureHelp{
         visible?: true,
         anchor_row: 4,
         anchor_col: 9,
-        active_signature: 300,
-        active_parameter: 300,
-        signatures: signatures
+        active_signature: 256,
+        active_parameter: 0,
+        signatures: []
       }
 
-      <<@op_gui_signature_help, 1, 4::16, 9::16, active_signature::8, active_parameter::8,
-        signature_count::8, first_signature::binary>> = SignatureHelpEncoder.encode_command(model)
-
-      <<label_len::16, _label::binary-size(label_len), doc_len::16, _doc::binary-size(doc_len),
-        parameter_count::8, _rest::binary>> = first_signature
-
-      assert active_signature == 254
-      assert active_parameter == 254
-      assert signature_count == 255
-      assert parameter_count == 255
+      assert_raise EncodingError,
+                   "cannot encode gui_signature_help.active_signature=256; expected 0..255",
+                   fn -> SignatureHelpEncoder.encode_command(model) end
     end
   end
 

--- a/test/minga/frontend/adapter/gui/status_bar_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/status_bar_encoder_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.StatusBarEncoderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Frontend.Adapter.GUI.Caches
+  alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.Frontend.Adapter.GUI.StatusBarEncoder
   alias Minga.RenderModel.UI.StatusBar
   alias Minga.RenderModel.UI.StatusBar.Agent
@@ -128,6 +129,51 @@ defmodule Minga.Frontend.Adapter.GUI.StatusBarEncoderTest do
                _rest::binary>> = sections[0x09]
 
       assert model_name == "Claude"
+    end
+
+    test "encodes every wire-valid modeline segment instead of taking only 128" do
+      segment = {:mode, "N", 0xFFFFFF, 0x000000, [], nil}
+
+      data = %{
+        status_data()
+        | modeline_segments: %{left: List.duplicate(segment, 129), right: []}
+      }
+
+      model = %StatusBar{content_kind: :buffer, data: data}
+
+      {cmd, _caches} = StatusBarEncoder.encode(model, Caches.new())
+      sections = decode_sections(cmd)
+
+      assert <<2::8, 129::16, 0::16, _segments::binary>> = sections[0x0B]
+    end
+
+    test "rejects an out-of-range indent size instead of clamping it" do
+      data = %{status_data() | indent: %Indent{type: :spaces, size: 256}}
+      model = %StatusBar{content_kind: :buffer, data: data}
+
+      assert %{
+               command: :gui_status_bar,
+               field: :indent_size,
+               actual: 256,
+               min: 0,
+               max: 255
+             } =
+               assert_raise(EncodingError, fn -> StatusBarEncoder.encode(model, Caches.new()) end)
+    end
+
+    test "rejects an out-of-range icon color instead of masking it" do
+      file = Map.put(status_data().file, :icon_color, 0x1000000)
+      data = %{status_data() | file: file}
+      model = %StatusBar{content_kind: :buffer, data: data}
+
+      assert %{
+               command: :gui_status_bar,
+               field: :file_icon_color,
+               actual: 0x1000000,
+               min: 0,
+               max: 0xFFFFFF
+             } =
+               assert_raise(EncodingError, fn -> StatusBarEncoder.encode(model, Caches.new()) end)
     end
 
     test "always returns a command" do

--- a/test/minga/frontend/adapter/gui/surface_layout_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/surface_layout_encoder_test.exs
@@ -6,7 +6,8 @@ defmodule Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoderTest do
     do: %{surface_id: 1, rect: %{row: 2, col: 3, width: 40, height: 20}, z: 4, hit_kind: 5}
 
   test "rejects negative and overflowing values for every bounded field" do
-    for field <- @u16_fields ++ [:hit_kind], value <- [-1, 65_536] do
+    for field <- [:surface_id, :row, :col, :width, :height, :z, :hit_kind],
+        value <- [-1, 65_536] do
       error =
         assert_raise EncodingError, fn ->
           SurfaceLayoutEncoder.encode_command([put_field(placement(), field, value)])

--- a/test/minga/frontend/adapter/gui/window_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/window_encoder_test.exs
@@ -542,6 +542,53 @@ defmodule Minga.Frontend.Adapter.GUI.WindowEncoderTest do
                cached_metrics.metadata_bytes
   end
 
+  test "rejects RGB values that do not fit the span color field" do
+    row = %Row{
+      row_id: Row.stable_id(:normal, 0),
+      row_type: :normal,
+      buf_line: 0,
+      text: "x",
+      spans: [%Span{start_col: 0, end_col: 1, fg: 0x1000000, bg: 0, attrs: 0}],
+      content_hash: 0
+    }
+
+    error =
+      assert_raise EncodingError, fn ->
+        WindowEncoder.encode_window_content(window(rows: [row]))
+      end
+
+    assert %{
+             command: :gui_window_content,
+             field: :span_fg,
+             actual: 0x1000000,
+             min: 0,
+             max: 0xFFFFFF
+           } = error
+  end
+
+  test "rejects a late indent level that does not fit instead of clipping it" do
+    guides = %IndentGuides{
+      window_id: 1,
+      tab_width: 2,
+      active_guide_col: 2,
+      guide_cols: [2, 4],
+      line_indent_levels: [0, 1, 256]
+    }
+
+    error =
+      assert_raise EncodingError, fn ->
+        WindowEncoder.encode_frame_metadata(window(indent_guides: guides))
+      end
+
+    assert %{
+             command: :gui_indent_guides,
+             field: :indent_level,
+             actual: 256,
+             min: 0,
+             max: 255
+           } = error
+  end
+
   test "adapter encodes first-class non-buffer window models" do
     model = window(content_kind: :agent_prompt, window_id: 65_534)
 

--- a/test/minga/frontend/adapter/gui/wire_test.exs
+++ b/test/minga/frontend/adapter/gui/wire_test.exs
@@ -3,6 +3,7 @@ defmodule Minga.Frontend.Adapter.GUI.WireTest do
 
   alias Minga.Frontend.Adapter.GUI.EncodingError
   alias Minga.Frontend.Adapter.GUI.Wire
+  alias Minga.Frontend.Adapter.GUI.Wire.Writer
 
   test "section carrier rejects an oversized payload with structured metadata" do
     error =
@@ -22,5 +23,89 @@ defmodule Minga.Frontend.Adapter.GUI.WireTest do
       assert_raise EncodingError, fn -> Wire.encode_string16(String.duplicate("x", 65_536)) end
 
     assert %{command: :gui_string, field: :byte_length, actual: 65_536, max: 65_535} = error
+  end
+
+  test "formerly lossy helpers reject values instead of changing wire content" do
+    assert %{command: :gui_wire, field: :u8_value, actual: 256, min: 0, max: 255} =
+             assert_raise(EncodingError, fn -> Wire.clamp_u8(256) end)
+
+    assert %{command: :gui_wire, field: :utf8_byte_length, actual: 256, min: 0, max: 255} =
+             assert_raise(EncodingError, fn ->
+               Wire.utf8_prefix_bytes(String.duplicate("x", 256), 255)
+             end)
+
+    assert %{command: :gui_wire, field: :entry_count, actual: 2, min: 0, max: 1} =
+             assert_raise(EncodingError, fn ->
+               Wire.bounded_entries(["one", "two"], & &1, 1, 10)
+             end)
+
+    assert %{command: :gui_wire, field: :entry_bytes, actual: 4, min: 0, max: 3} =
+             assert_raise(EncodingError, fn -> Wire.bounded_entries(["four"], & &1, 1, 3) end)
+  end
+
+  test "command-scoped writer carries field metadata through checked packing" do
+    assert <<1::8, 2::16, 3::32, 2::8, "ok">> ==
+             :gui_test
+             |> Writer.new()
+             |> Writer.uint8(:small, 1)
+             |> Writer.uint16(:medium, 2)
+             |> Writer.uint32(:large, 3)
+             |> Writer.string8(:label, "ok")
+             |> Writer.finish()
+
+    assert %{command: :gui_test, field: :medium, actual: 65_536, min: 0, max: 65_535} =
+             assert_raise(EncodingError, fn ->
+               :gui_test |> Writer.new() |> Writer.uint16(:medium, 65_536)
+             end)
+  end
+
+  test "writer packs signed, wide, color, and nested payload fields" do
+    assert <<-1::signed-32, 4::64, 0x112233::24, 7::8, 2::16, "ok">> ==
+             :gui_test
+             |> Writer.new()
+             |> Writer.int32(:offset, -1)
+             |> Writer.uint64(:row_id, 4)
+             |> Writer.rgb24(:foreground, 0x112233)
+             |> Writer.section16(:payload, 7, "ok")
+             |> Writer.finish()
+
+    assert %{
+             command: :gui_test,
+             field: :offset,
+             actual: 2_147_483_648,
+             min: -2_147_483_648,
+             max: 2_147_483_647
+           } =
+             assert_raise(EncodingError, fn ->
+               :gui_test |> Writer.new() |> Writer.int32(:offset, 2_147_483_648)
+             end)
+
+    assert %{command: :gui_test, field: :foreground, actual: 16_777_216, min: 0, max: 16_777_215} =
+             assert_raise(EncodingError, fn ->
+               :gui_test |> Writer.new() |> Writer.rgb24(:foreground, 16_777_216)
+             end)
+  end
+
+  test "writer validation-only checks preserve the output" do
+    assert "payload" ==
+             :gui_test
+             |> Writer.new()
+             |> Writer.check_uint8(:small, 1)
+             |> Writer.check_uint16(:medium, 2)
+             |> Writer.check_uint32(:large, 3)
+             |> Writer.check_uint64(:row_id, 4)
+             |> Writer.append("payload")
+             |> Writer.finish()
+
+    assert %{
+             command: :gui_test,
+             field: :row_id,
+             actual: -1,
+             min: 0,
+             max: 18_446_744_073_709_551_615
+           } =
+             assert_raise(EncodingError, fn ->
+               :gui_test |> Writer.new() |> Writer.check_uint64(:row_id, -1)
+             end)
   end
 end

--- a/test/minga_editor/frontend/emit_test.exs
+++ b/test/minga_editor/frontend/emit_test.exs
@@ -17,6 +17,7 @@ defmodule MingaEditor.Frontend.EmitTest do
   alias Minga.Core.Face
   alias Minga.Protocol.Opcodes
   alias Minga.RenderModel.Window, as: RenderWindow
+  alias Minga.RenderModel.Window.IndentGuides
   alias Minga.RenderModel.Window.Row, as: RenderRow
   alias Minga.RenderModel.Window.Span, as: RenderSpan
   alias MingaEditor.Renderer.Caches
@@ -140,6 +141,27 @@ defmodule MingaEditor.Frontend.EmitTest do
 
       assert [<<_, 22::32, base_frame_seq::32>> | _] = commands
       assert base_frame_seq == 11, "non-keyframe bases on the previously emitted frame_seq"
+    end
+
+    test "an invalid late window field writes nothing and the next valid frame recovers with a keyframe" do
+      frame = window_frame_with_content()
+      state = semantic_state()
+
+      {_commands, caches} = emit_and_capture(frame, state, %Caches{}, frame_seq: 11)
+      invalid_frame = frame_with_invalid_indent_level(frame)
+      ctx = %{Context.from_editor_state(state) | frame_seq: 22}
+
+      {recovered_caches, _font_registry, _message_store} =
+        Emit.emit(invalid_frame, ctx, nil, caches)
+
+      refute_receive {:"$gen_cast", {:send_commands, _}}
+      assert recovered_caches.adapter_gui_caches == Minga.Frontend.Adapter.GUI.Caches.new()
+      assert recovered_caches.last_emitted_frame_seq == 0
+
+      {commands, _caches} = emit_and_capture(frame, state, recovered_caches, frame_seq: 33)
+
+      assert [<<_, 33::32, 0::32>> | _] = commands
+      assert Enum.any?(commands, &match?(<<0x80, _::binary>>, &1))
     end
 
     test "request_keyframe forces the next frame back to base 0 with full window content" do
@@ -335,6 +357,20 @@ defmodule MingaEditor.Frontend.EmitTest do
     }
 
     %{frame | windows: [window_model]}
+  end
+
+  defp frame_with_invalid_indent_level(frame) do
+    [window] = frame.windows
+
+    indent_guides = %IndentGuides{
+      window_id: window.window_id,
+      tab_width: 2,
+      active_guide_col: 2,
+      guide_cols: [2],
+      line_indent_levels: [0, 256]
+    }
+
+    %{frame | windows: [%{window | indent_guides: indent_guides}]}
   end
 
   # Drives Emit.emit/4 with an explicit frame_seq and optional keyframe forcing,

--- a/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
+++ b/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
@@ -708,7 +708,7 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
       assert levels == <<2, 4, 4, 3, 1>>
     end
 
-    test "indent levels above 255 are clamped to fit uint8 wire format" do
+    test "indent levels above 255 are rejected instead of clamped to fit uint8 wire format" do
       data = %{
         window_id: 1,
         tab_width: 2,
@@ -717,13 +717,18 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
         line_indent_levels: [300, 0, 256, 255]
       }
 
-      binary = encode_indent_guides(data)
+      error =
+        assert_raise Minga.Frontend.Adapter.GUI.EncodingError, fn ->
+          encode_indent_guides(data)
+        end
 
-      <<0x91, _len::16, _win::16, _tw::8, _active::16, _count::8, _col::16, line_count::16,
-        levels::binary>> = binary
-
-      assert line_count == 4
-      assert levels == <<255, 0, 255, 255>>
+      assert %{
+               command: :gui_indent_guides,
+               field: :indent_level,
+               actual: 300,
+               min: 0,
+               max: 255
+             } = error
     end
   end
 


### PR DESCRIPTION
# TL;DR
GUI frame encoding now rejects every out-of-range bounded field before a Port write, then recovers with a full keyframe on the next valid render.

Closes #2737

## Context
Large payload carriers were widened in earlier work, but adapter encoders still contained local truncation, clamping, masking, and unchecked bit packing. This PR makes one command-scoped Writer the checked boundary for GUI protocol encoding.

## Changes
- Add `Wire.Writer`, including checked unsigned, signed, color, string, payload, section, and validation-only operations with structured `EncodingError` metadata.
- Migrate GUI adapter encoders, including Window, Agent Chat, transcript, chrome, popups, and observability surfaces, so valid bytes remain stable and invalid data is rejected instead of changed.
- Add EX9014 to prevent lossy helpers, masking, generic wire carriers, and unchecked data-derived bounded bit fields from returning.
- Cover late Window metadata failure in Emit: no commands are written, adapter caches reset, and the following valid render uses base frame sequence zero with full window content.
- Document bounded-carrier rejection and keyframe recovery behavior.

## Verification
- `make lint`
- `mix test.llm` (9,921 tests, 0 failures)
- `mix protocol.gen`
- `mix swift.build`
- `cd go/tui && go test ./...` (616 tests)
- `git diff --check`

## Acceptance Criteria Addressed
- Clipboard payloads through 64 KiB remain covered by protocol tests. ✅
- Large A1/A2 row carriers retain their u32 round-trip coverage. ✅
- Bounded fields now reject with `command`, `field`, `actual`, `min`, and `max` metadata. ✅
- BEAM protocol generation, Swift build, and Go protocol tests pass. ✅
- Invalid frames write nothing and recover through a base-0 full keyframe. ✅
- `docs/PROTOCOL.md` documents rejection and recovery behavior. ✅
