### PR TITLE
chore: add project-local pi-elixir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ macos/Tests/Snapshots/
 .minga/workspaces/
 
 # Agent / experiment scratch files
+.pi/npm/
 .standup/
 CLAUDE.md
 autoresearch.*

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,5 @@
+{
+  "packages": [
+    "npm:pi-elixir"
+  ]
+}


### PR DESCRIPTION
# TL;DR
Add `pi-elixir` as a project-local Pi package so Minga contributors can use BEAM evaluation and Elixir AST tools when working in this repository.

## Changes
- Declare `npm:pi-elixir` in `.pi/settings.json` so new project installs use the current release.
- Ignore Pi's generated project package cache under `.pi/npm/`.

## Compatibility
Pi installs the package after the repository is trusted. The committed configuration contains no credentials or runtime state; each checkout keeps its generated package cache locally.

## Verification
- Ran `mix deps.get` in the bundled `pi_bridge` package.
- Ran a Mix expression that reads the bundled bridge application version and confirmed `pi_bridge=0.8.1`.
