### PR TITLE
chore: ignore Expert cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ macos/Tests/Snapshots/
 .minga/workspaces/
 
 # Agent / experiment scratch files
+.expert/
 .pi/npm/
 .standup/
 CLAUDE.md


### PR DESCRIPTION
# TL;DR
Ignore the project-local Expert cache so generated analysis state does not appear as untracked work.

## Verification
- `git check-ignore -v .expert .expert/build .expert/credo/checks/no_lossy_gui_encoder_check.exs`