### PR TITLE
fix(protocol): enforce generated encoder bounds

### DIFF
--- a/credo/checks/no_lossy_gui_encoder_check.exs
+++ b/credo/checks/no_lossy_gui_encoder_check.exs
@@ -7,7 +7,7 @@ defmodule Minga.Credo.NoLossyGuiEncoderCheck do
     category: :warning,
     explanations: [
       check: """
-      GUI adapter encoders must not silently clamp, truncate, or drop data to fit a wire field. Use Minga.Frontend.Adapter.GUI.Wire.Writer so an out-of-range value raises EncodingError with command and field metadata. See #2737.
+      GUI adapter encoders must not silently clamp, truncate, or drop data to fit a wire field. Schema-generated encoders validate their own fields; use Minga.Frontend.Adapter.GUI.Wire.Writer for hand-written bounded framing fields. See #2737.
       """
     ]
 
@@ -17,49 +17,24 @@ defmodule Minga.Credo.NoLossyGuiEncoderCheck do
     if gui_encoder_file?(source_file) do
       issue_meta = IssueMeta.for(source_file, params)
 
-      preflight_helpers =
-        source_file
-        |> Credo.Code.prewalk(&collect_preflight_helper/2)
-        |> List.flatten()
-        |> MapSet.new()
-
       source_file
-      |> Credo.Code.prewalk(&find_lossy_encoder_call(&1, &2, issue_meta, preflight_helpers))
+      |> Credo.Code.prewalk(&find_lossy_encoder_call(&1, &2, issue_meta))
       |> List.flatten()
     else
       []
     end
   end
 
-  defp find_lossy_encoder_call(
-         {definition, meta, [_head, [do: body]]} = ast,
-         issues,
-         issue_meta,
-         preflight_helpers
-       )
-       when definition in [:def, :defp] do
-    if generated_encode?(body) and not writer_preflight?(body, preflight_helpers) do
-      issue(ast, issues, issue_meta, meta, "generated_encode")
-    else
-      {ast, issues}
-    end
-  end
-
-  defp find_lossy_encoder_call({:min, meta, _args} = ast, issues, issue_meta, _preflight_helpers),
+  defp find_lossy_encoder_call({:min, meta, _args} = ast, issues, issue_meta),
     do: issue(ast, issues, issue_meta, meta, "min")
 
-  defp find_lossy_encoder_call({:&&&, meta, _args} = ast, issues, issue_meta, _preflight_helpers),
+  defp find_lossy_encoder_call({:&&&, meta, _args} = ast, issues, issue_meta),
     do: issue(ast, issues, issue_meta, meta, "&&&")
 
-  defp find_lossy_encoder_call(
-         {:utf8_prefix_bytes, meta, _args} = ast,
-         issues,
-         issue_meta,
-         _preflight_helpers
-       ),
-       do: issue(ast, issues, issue_meta, meta, "utf8_prefix_bytes")
+  defp find_lossy_encoder_call({:utf8_prefix_bytes, meta, _args} = ast, issues, issue_meta),
+    do: issue(ast, issues, issue_meta, meta, "utf8_prefix_bytes")
 
-  defp find_lossy_encoder_call({:<<>>, _, segments} = ast, issues, issue_meta, _preflight_helpers) do
+  defp find_lossy_encoder_call({:<<>>, _, segments} = ast, issues, issue_meta) do
     issues = Enum.reduce(segments, issues, &dynamic_bounded_segment_issue(&1, &2, issue_meta))
     {ast, issues}
   end
@@ -67,8 +42,7 @@ defmodule Minga.Credo.NoLossyGuiEncoderCheck do
   defp find_lossy_encoder_call(
          {{:., _, [module, function]}, meta, _args} = ast,
          issues,
-         issue_meta,
-         _preflight_helpers
+         issue_meta
        )
        when function in [
               :bounded_entries,
@@ -91,76 +65,7 @@ defmodule Minga.Credo.NoLossyGuiEncoderCheck do
     end
   end
 
-  defp find_lossy_encoder_call(ast, issues, _issue_meta, _preflight_helpers), do: {ast, issues}
-
-  defp generated_encode?(body) do
-    {_body, found?} =
-      Macro.prewalk(body, false, fn
-        {{:., _, [module, function]}, _meta, _args} = ast, found? ->
-          generated? =
-            alias_name(module) == :Encode and
-              String.starts_with?(Atom.to_string(function), "encode_")
-
-          {ast, found? or generated?}
-
-        ast, found? ->
-          {ast, found?}
-      end)
-
-    found?
-  end
-
-  defp collect_preflight_helper(
-         {definition, _meta, [{name, _head_meta, args}, [do: body]]} = ast,
-         helpers
-       )
-       when definition in [:def, :defp] and is_atom(name) do
-    if String.starts_with?(Atom.to_string(name), "preflight") and contains_writer_check?(body) do
-      {ast, [{name, length(args)} | helpers]}
-    else
-      {ast, helpers}
-    end
-  end
-
-  defp collect_preflight_helper(ast, helpers), do: {ast, helpers}
-
-  defp writer_preflight?(body, preflight_helpers) do
-    contains_writer_check?(body) or calls_preflight_helper?(body, preflight_helpers)
-  end
-
-  defp contains_writer_check?(body) do
-    {_body, found?} =
-      Macro.prewalk(body, false, fn
-        {{:., _, [module, function]}, _meta, _args} = ast, found? ->
-          check? =
-            alias_name(module) == :Writer and
-              String.starts_with?(Atom.to_string(function), "check_")
-
-          {ast, found? or check?}
-
-        ast, found? ->
-          {ast, found?}
-      end)
-
-    found?
-  end
-
-  defp calls_preflight_helper?(body, preflight_helpers) do
-    {_body, found?} =
-      Macro.prewalk(body, false, fn
-        {:|>, _meta, [_left, {function, _call_meta, args}]} = ast, found?
-        when is_atom(function) and is_list(args) ->
-          {ast, found? or MapSet.member?(preflight_helpers, {function, length(args) + 1})}
-
-        {function, _meta, args} = ast, found? when is_atom(function) and is_list(args) ->
-          {ast, found? or MapSet.member?(preflight_helpers, {function, length(args)})}
-
-        ast, found? ->
-          {ast, found?}
-      end)
-
-    found?
-  end
+  defp find_lossy_encoder_call(ast, issues, _issue_meta), do: {ast, issues}
 
   defp dynamic_bounded_segment_issue(
          {:"::", meta, [value, {:-, _, [{:signed, _, _}, 32]}]},
@@ -202,8 +107,11 @@ defmodule Minga.Credo.NoLossyGuiEncoderCheck do
     {ast, [issue | issues]}
   end
 
-  defp alias_name({:__aliases__, _, names}), do: List.last(names)
+  defp alias_name({:__aliases__, _, names}), do: last_alias(names)
   defp alias_name(_), do: nil
+
+  defp last_alias([name]), do: name
+  defp last_alias([_name | rest]), do: last_alias(rest)
 
   defp lossy_remote_call?(:Enum, function) when function in [:reduce_while, :take], do: true
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -159,7 +159,7 @@ end
 
 The `side:` option is the default side when you do not list the segment explicitly. It must be `:left` or `:right`, and `priority:` must be an integer. Invalid declarations fail during config load so you see the mistake immediately. Custom segment names cannot reuse built-in names like `:mode`, `:filename`, or `:git`, because built-ins always win during rendering.
 
-Segment text and click command names are bounded to the GUI protocol's 16-bit string and section limits. Oversized strings are truncated at valid UTF-8 boundaries, and trailing segments are dropped if a GUI status-bar payload would exceed the wire-format limit.
+Segment text and click command names are bounded to the GUI protocol's 16-bit string and section limits. Oversized strings or a status-bar payload that exceeds its wire-format limit are rejected before the frontend Port write; Minga does not truncate strings or drop trailing segments to make a payload fit.
 
 You can still place the segment yourself:
 

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -1008,7 +1008,7 @@ Toast when toast_present == 1:
 `status`: 0 = unknown, 1 = modified, 2 = added, 3 = deleted, 4 = renamed, 5 = copied, 6 = untracked, 7 = conflict.
 `level`: 0 = success, 1 = error.
 `action`: 0 = none, 1 = pull_and_retry.
-`stash_count`: number of stashes in the repository, clamped to 65,535. Frontends should show it only when greater than zero.
+`stash_count`: number of stashes in the repository. It must fit the u16 carrier; an out-of-range value rejects the frame before any bytes reach the frontend. Frontends should show it only when greater than zero.
 
 When the git status panel is closed, the BEAM sends `repo_state = not_a_repo`, no entries, and an empty `entry_base_path` as the hide signal. A non-git project opened in the Source Control tab also uses `repo_state = not_a_repo`, but includes the project root so the frontend can show the native "Not a git repository" empty state instead of hiding the panel. The frontend should still copy `syncing` and `toast` so remote operation feedback remains accurate while the panel is hidden.
 

--- a/lib/minga/frontend/adapter/gui.ex
+++ b/lib/minga/frontend/adapter/gui.ex
@@ -90,7 +90,8 @@ defmodule Minga.Frontend.Adapter.GUI do
   def encode_checked(%RenderModel{} = model, %Caches{} = caches) do
     {:ok, do_encode(model, caches)}
   rescue
-    error in Minga.Frontend.Adapter.GUI.EncodingError -> {:error, error}
+    error in [Minga.Protocol.EncodingError, Minga.Frontend.Adapter.GUI.EncodingError] ->
+      {:error, error}
   end
 
   @spec do_encode(RenderModel.t(), Caches.t()) :: EncodedFrame.t()

--- a/lib/minga/frontend/adapter/gui/breadcrumb_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/breadcrumb_encoder.ex
@@ -26,15 +26,8 @@ defmodule Minga.Frontend.Adapter.GUI.BreadcrumbEncoder do
   # passes it to the generated codec.
   @spec encode_command(Breadcrumb.t()) :: binary()
   def encode_command(%Breadcrumb{} = model) do
-    writer =
-      model.segments
-      |> Enum.reduce(
-        Writer.new(:gui_breadcrumb)
-        |> Writer.check_uint8(:segment_count, Enum.count(model.segments)),
-        fn segment, writer -> Writer.check_string16(writer, :segment, segment) end
-      )
-
-    writer
+    :gui_breadcrumb
+    |> Writer.new()
     |> Writer.append([
       @op_gui_breadcrumb | Encode.encode_gui_breadcrumb(%{segments: model.segments})
     ])

--- a/lib/minga/frontend/adapter/gui/completion_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/completion_encoder.ex
@@ -31,7 +31,6 @@ defmodule Minga.Frontend.Adapter.GUI.CompletionEncoder do
 
     :gui_completion
     |> Writer.new()
-    |> preflight(wire)
     |> Writer.append(<<@op_gui_completion>>)
     |> Writer.append(Encode.encode_gui_completion(wire))
     |> Writer.finish()
@@ -49,29 +48,6 @@ defmodule Minga.Frontend.Adapter.GUI.CompletionEncoder do
       items: Enum.map(model.items, fn item -> Map.from_struct(item) end),
       documentation: model.documentation
     }
-  end
-
-  @spec preflight(Writer.t(), map()) :: Writer.t()
-  defp preflight(%Writer{} = writer, %{visible: 0}), do: Writer.check_uint8(writer, :visible, 0)
-
-  defp preflight(%Writer{} = writer, wire) do
-    writer
-    |> Writer.check_uint8(:visible, wire.visible)
-    |> Writer.check_uint16(:cursor_row, wire.cursor_row)
-    |> Writer.check_uint16(:cursor_col, wire.cursor_col)
-    |> Writer.check_uint16(:selected_offset, wire.selected_offset)
-    |> Writer.check_uint16(:item_count, Enum.count(wire.items))
-    |> preflight_items(wire.items)
-    |> Writer.check_string16(:documentation, wire.documentation)
-  end
-
-  @spec preflight_items(Writer.t(), [map()]) :: Writer.t()
-  defp preflight_items(%Writer{} = writer, items) do
-    Enum.reduce(items, writer, fn item, acc ->
-      acc
-      |> Writer.check_string16(:item_label, item.label)
-      |> Writer.check_string16(:item_detail, item.detail)
-    end)
   end
 
   @spec fingerprint(Completion.t()) :: term()

--- a/lib/minga/frontend/adapter/gui/git_status_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/git_status_encoder.ex
@@ -21,15 +21,13 @@ defmodule Minga.Frontend.Adapter.GUI.GitStatusEncoder do
   end
 
   # The fingerprint/skip-if-unchanged shell stays hand-written; byte production
-  # delegates to the schema-generated pure encoder after Writer has checked every
-  # bounded numeric and length field in the projected wire model.
+  # delegates to the schema-generated encoder, which validates its bounded fields.
   @spec encode_command(GitStatus.t()) :: binary()
   def encode_command(%GitStatus{} = model) do
     wire = to_wire(model)
 
     :gui_git_status
     |> Writer.new()
-    |> preflight(wire)
     |> Writer.append(<<@op_gui_git_status>>)
     |> Writer.append(Encode.encode_gui_git_status(wire))
     |> Writer.finish()
@@ -49,41 +47,5 @@ defmodule Minga.Frontend.Adapter.GUI.GitStatusEncoder do
       last_commit_message: model.last_commit_message,
       stash_count: model.stash_count
     }
-  end
-
-  @spec preflight(Writer.t(), map()) :: Writer.t()
-  defp preflight(%Writer{} = writer, wire) do
-    writer
-    |> Writer.check_uint8(:syncing, wire.syncing)
-    |> Writer.check_uint16(:ahead, wire.ahead)
-    |> Writer.check_uint16(:behind, wire.behind)
-    |> Writer.check_string16(:branch, wire.branch)
-    |> Writer.check_uint16(:entry_count, Enum.count(wire.entries))
-    |> preflight_entries(wire.entries)
-    |> preflight_toast(wire.toast)
-    |> Writer.check_string16(:entry_base_path, wire.entry_base_path)
-    |> Writer.check_string16(:last_commit_message, wire.last_commit_message)
-    |> Writer.check_uint16(:stash_count, wire.stash_count)
-  end
-
-  @spec preflight_entries(Writer.t(), [GitStatus.wire_entry()]) :: Writer.t()
-  defp preflight_entries(%Writer{} = writer, entries) do
-    Enum.reduce(entries, writer, fn entry, acc ->
-      acc
-      |> Writer.check_uint32(:entry_path_hash, entry.path_hash)
-      |> Writer.check_uint8(:entry_section, entry.section)
-      |> Writer.check_string16(:entry_path, entry.path)
-    end)
-  end
-
-  @spec preflight_toast(Writer.t(), GitStatus.wire_toast()) :: Writer.t()
-  defp preflight_toast(%Writer{} = writer, %{present: 0}) do
-    Writer.check_uint8(writer, :toast_present, 0)
-  end
-
-  defp preflight_toast(%Writer{} = writer, %{present: 1} = toast) do
-    writer
-    |> Writer.check_uint8(:toast_present, 1)
-    |> Writer.check_string16(:toast_message, toast.message)
   end
 end

--- a/lib/minga/frontend/adapter/gui/picker_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/picker_encoder.ex
@@ -67,7 +67,6 @@ defmodule Minga.Frontend.Adapter.GUI.PickerEncoder do
   defp encode_picker(%Picker{} = model) do
     :gui_picker
     |> Writer.new()
-    |> preflight_picker(model)
     |> Writer.append(<<@op_gui_picker>>)
     |> Writer.uint8(:section_count, 6)
     |> Writer.section16(
@@ -101,83 +100,6 @@ defmodule Minga.Frontend.Adapter.GUI.PickerEncoder do
       Encode.encode_gui_picker_load_status(to_wire_load_status(model.load_status))
     )
     |> Writer.finish()
-  end
-
-  @spec preflight_picker(Writer.t(), Picker.t()) :: Writer.t()
-  defp preflight_picker(%Writer{} = writer, %Picker{} = model) do
-    writer
-    |> Writer.check_uint8(:visible, 1)
-    |> Writer.check_uint16(:selected_index, model.selected_index)
-    |> Writer.check_uint16(:filtered_count, model.filtered_count)
-    |> Writer.check_uint16(:total_count, model.total_count)
-    |> Writer.check_uint8(:has_preview, if(model.has_preview?, do: 1, else: 0))
-    |> Writer.check_string16(:title, model.title)
-    |> Writer.check_uint16(:marked_count, model.marked_count)
-    |> Writer.check_string16(:query, model.query)
-    |> Writer.check_uint16(:item_count, Enum.count(model.items))
-    |> preflight_items(model.items)
-    |> preflight_action_menu(model.action_menu)
-    |> Writer.check_string16(:mode_prefix, model.mode_prefix)
-    |> preflight_load_status(model.load_status)
-  end
-
-  @spec preflight_items(Writer.t(), [Picker.item()]) :: Writer.t()
-  defp preflight_items(%Writer{} = writer, items) do
-    Enum.reduce(items, writer, &preflight_item/2)
-  end
-
-  @spec preflight_item(Picker.item(), Writer.t()) :: Writer.t()
-  defp preflight_item(item, %Writer{} = writer) do
-    writer
-    |> Writer.check_uint24(:item_icon_color, item.icon_color)
-    |> Writer.check_uint8(:item_flags, item.flags)
-    |> Writer.check_string16(:item_label, item.label)
-    |> Writer.check_string16(:item_description, item.description)
-    |> Writer.check_string16(:item_annotation, item.annotation)
-    |> Writer.check_uint8(:item_match_position_count, Enum.count(item.match_positions))
-    |> preflight_match_positions(item.match_positions)
-  end
-
-  @spec preflight_match_positions(Writer.t(), [non_neg_integer()]) :: Writer.t()
-  defp preflight_match_positions(%Writer{} = writer, positions) do
-    Enum.reduce(positions, writer, fn position, acc ->
-      Writer.check_uint16(acc, :item_match_position, position)
-    end)
-  end
-
-  @spec preflight_action_menu(Writer.t(), ActionMenu.t() | nil) :: Writer.t()
-  defp preflight_action_menu(%Writer{} = writer, nil) do
-    Writer.check_uint8(writer, :action_menu_visible, 0)
-  end
-
-  defp preflight_action_menu(%Writer{} = writer, %ActionMenu{} = menu) do
-    writer
-    |> Writer.check_uint8(:action_menu_visible, 1)
-    |> Writer.check_uint8(:action_menu_selected_index, menu.selected_index)
-    |> Writer.check_uint8(:action_count, Enum.count(menu.actions))
-    |> preflight_actions(menu.actions)
-  end
-
-  @spec preflight_actions(Writer.t(), [String.t()]) :: Writer.t()
-  defp preflight_actions(%Writer{} = writer, actions) do
-    Enum.reduce(actions, writer, fn action, acc ->
-      Writer.check_string16(acc, :action_name, action)
-    end)
-  end
-
-  @spec preflight_load_status(Writer.t(), Picker.load_status()) :: Writer.t()
-  defp preflight_load_status(%Writer{} = writer, :ready) do
-    Writer.check_uint8(writer, :load_status, 0)
-  end
-
-  defp preflight_load_status(%Writer{} = writer, :loading) do
-    Writer.check_uint8(writer, :load_status, 1)
-  end
-
-  defp preflight_load_status(%Writer{} = writer, {:error, reason}) do
-    writer
-    |> Writer.check_uint8(:load_status, 2)
-    |> Writer.check_string16(:load_status_message, reason)
   end
 
   @spec to_wire_header(Picker.t()) :: map()

--- a/lib/minga/frontend/adapter/gui/surface_layout_encoder.ex
+++ b/lib/minga/frontend/adapter/gui/surface_layout_encoder.ex
@@ -58,36 +58,17 @@ defmodule Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder do
   Always emits (one section, possibly with an empty placement array). The
   command is part of the frame transaction, so it ships every frame between
   begin_frame and commit_frame; there is no skip-if-unchanged cache because the
-  placement list IS the per-frame layout authority. Invalid bounded fields are
-  rejected before encoding so a frame can never contain truncated placement data.
+  placement list IS the per-frame layout authority. The schema-generated encoder
+  rejects invalid bounded fields before bytes are constructed, so a frame can
+  never contain truncated placement data.
   """
   @spec encode_command([wire_placement()]) :: binary()
   def encode_command(placements) when is_list(placements) do
-    writer =
-      placements
-      |> Enum.reduce(
-        Writer.new(:gui_surface_layout)
-        |> Writer.check_uint16(:placement_count, Enum.count(placements)),
-        &validate(&2, &1)
-      )
-
     payload = Encode.encode_gui_surface_layout_placements(placements)
 
-    writer
+    Writer.new(:gui_surface_layout)
     |> Writer.append(<<@op_gui_surface_layout, 1>>)
     |> Writer.section16(:placements_payload, @section_placements, payload)
     |> Writer.finish()
-  end
-
-  @spec validate(Writer.t(), wire_placement()) :: Writer.t()
-  defp validate(writer, %{surface_id: surface_id, rect: rect, z: z, hit_kind: hit_kind}) do
-    writer
-    |> Writer.check_uint16(:surface_id, surface_id)
-    |> Writer.check_uint16(:row, rect.row)
-    |> Writer.check_uint16(:col, rect.col)
-    |> Writer.check_uint16(:width, rect.width)
-    |> Writer.check_uint16(:height, rect.height)
-    |> Writer.check_uint16(:z, z)
-    |> Writer.check_uint8(:hit_kind, hit_kind)
   end
 end

--- a/lib/minga/protocol/encoding_error.ex
+++ b/lib/minga/protocol/encoding_error.ex
@@ -1,0 +1,30 @@
+defmodule Minga.Protocol.EncodingError do
+  @moduledoc """
+  Raised when a protocol value cannot fit its schema-owned wire field.
+
+  `field_path` follows the schema from the encoded command root. Array indexes
+  are zero-based so callers can identify the exact failing element.
+  """
+
+  @enforce_keys [:command, :field_path, :actual, :min, :max]
+  defexception [:command, :field, :field_path, :actual, :min, :max]
+
+  @type path_segment :: atom() | non_neg_integer()
+  @type t :: %__MODULE__{
+          command: atom(),
+          field: atom() | nil,
+          field_path: [path_segment()],
+          actual: term(),
+          min: integer(),
+          max: non_neg_integer()
+        }
+
+  @impl Exception
+  @spec message(t()) :: String.t()
+  def message(%__MODULE__{} = error) do
+    path = Enum.map_join(error.field_path, ".", &to_string/1)
+
+    "cannot encode #{error.command}.#{path}=#{inspect(error.actual)}; " <>
+      "expected #{error.min}..#{error.max}"
+  end
+end

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -158,7 +158,7 @@ defmodule MingaEditor.Frontend.Emit do
       end
     )
   rescue
-    error in Minga.Frontend.Adapter.GUI.EncodingError ->
+    error in [Minga.Protocol.EncodingError, Minga.Frontend.Adapter.GUI.EncodingError] ->
       Minga.Log.warning(:render, "Discarded invalid GUI frame: #{Exception.message(error)}")
 
       {%{

--- a/mix/protocol_generator.ex
+++ b/mix/protocol_generator.ex
@@ -3534,8 +3534,19 @@ defmodule Minga.Mix.ProtocolGenerator do
   # before calling these. Field values are read by schema name from the model
   # struct or map, matching the names the hand-written encoders consume today.
 
+  @doc false
+  @spec render_encode_module(schema(), module()) :: String.t()
+  def render_encode_module(schema, module_name) when is_atom(module_name) do
+    schema
+    |> attach_enum_reprs()
+    |> encode_elixir_file(module_name)
+  end
+
   @spec encode_elixir_file(schema()) :: String.t()
-  defp encode_elixir_file(schema) do
+  defp encode_elixir_file(schema), do: encode_elixir_file(schema, Minga.Protocol.Encode)
+
+  @spec encode_elixir_file(schema(), module()) :: String.t()
+  defp encode_elixir_file(schema, module_name) do
     smap = structures_map(schema)
     enums = enums_list(schema)
     structures = Map.get(schema, "structures", [])
@@ -3543,24 +3554,40 @@ defmodule Minga.Mix.ProtocolGenerator do
     command_fields = command_fields_list(schema)
 
     [
-      "defmodule Minga.Protocol.Encode do\n",
+      "defmodule #{inspect(module_name)} do\n",
       "  @moduledoc \"\"\"\n",
       "  Generated pure protocol encoders.\n\n",
       "  Generated from `docs/protocol_schema.toml` by `mix protocol.gen`. Do not edit by hand.\n\n",
-      "  Each `encode_*/1` returns the on-wire iodata for one schema record; the\n",
-      "  adapter layer wraps these with framing and the fingerprint cache, and the\n",
-      "  Layer 2 builders normalize the model before encoding.\n",
+      "  Each `encode_*/1` validates schema-owned bounded fields immediately before\n",
+      "  emitting them and returns the on-wire iodata for one schema record.\n",
       "  \"\"\"\n\n",
+      "  alias Minga.Protocol.EncodingError\n\n",
       Enum.map(enums, &elixir_encode_enum/1),
-      Enum.map(structures, fn s ->
-        elixir_record_encoder(encode_fn_name(s["name"]), s, smap)
+      Enum.map(structures, fn entry ->
+        elixir_record_encoder(
+          encode_fn_name(entry["name"]),
+          String.to_atom(entry["name"]),
+          entry,
+          smap
+        )
       end),
-      Enum.map(sections, fn s ->
-        elixir_record_encoder(section_encode_fn_name(s), s, smap)
+      Enum.map(sections, fn entry ->
+        elixir_record_encoder(
+          section_encode_fn_name(entry),
+          String.to_atom(entry["opcode"]),
+          entry,
+          smap
+        )
       end),
-      Enum.map(command_fields, fn cf ->
-        elixir_record_encoder(command_fields_encode_fn_name(cf), cf, smap)
+      Enum.map(command_fields, fn entry ->
+        elixir_record_encoder(
+          command_fields_encode_fn_name(entry),
+          String.to_atom(entry["opcode"]),
+          entry,
+          smap
+        )
       end),
+      elixir_validation_helpers(),
       "end\n"
     ]
     |> IO.iodata_to_binary()
@@ -3577,10 +3604,6 @@ defmodule Minga.Mix.ProtocolGenerator do
   @spec command_fields_encode_fn_name(command_fields()) :: String.t()
   defp command_fields_encode_fn_name(cf), do: "encode_#{cf["opcode"]}"
 
-  # An enum encoder is the inverse of the Go byte -> constant mapping: one clause
-  # per declared atom plus a catch-all that emits the schema `default` byte. The
-  # atom names mirror the value names (the hand-written encoders pattern-match the
-  # same atoms today).
   @spec elixir_encode_enum(enum()) :: iodata()
   defp elixir_encode_enum(%{"name" => name} = enum) do
     values = Map.get(enum, "values", [])
@@ -3589,8 +3612,8 @@ defmodule Minga.Mix.ProtocolGenerator do
 
     [
       "  @spec #{fn_name}(atom()) :: non_neg_integer()\n",
-      Enum.map(values, fn v ->
-        "  def #{fn_name}(:#{v["name"]}), do: #{v["value"]}\n"
+      Enum.map(values, fn value ->
+        "  def #{fn_name}(:#{value["name"]}), do: #{value["value"]}\n"
       end),
       "  def #{fn_name}(_), do: #{default_byte}\n\n"
     ]
@@ -3600,47 +3623,50 @@ defmodule Minga.Mix.ProtocolGenerator do
   defp enum_default_byte(%{"default" => default} = enum) when is_binary(default) do
     enum
     |> Map.get("values", [])
-    |> Enum.find(fn v -> v["name"] == default end)
+    |> Enum.find(fn value -> value["name"] == default end)
     |> Map.fetch!("value")
   end
 
   defp enum_default_byte(_enum), do: 0
 
-  # A counted_array-layout section (e.g. gui_picker.items) has no named fields:
-  # it decodes to a bare slice, so its encoder takes the list directly and emits
-  # the count prefix + mapped elements, the inverse of the Go counted_array
-  # section decoder.
-  @spec elixir_record_encoder(String.t(), map(), %{String.t() => structure()}) :: iodata()
+  @spec elixir_record_encoder(String.t(), atom(), map(), %{String.t() => structure()}) ::
+          iodata()
   defp elixir_record_encoder(
          fn_name,
+         command,
          %{"layout" => "counted_array", "element" => element} = entry,
          smap
        ) do
     count_type = entry["count_type"] || "u16"
     bits = @primitive_sizes[count_type] * 8
-    element_encoder = elixir_array_element_encoder(element, smap)
+    max = integer_max(bits)
+    root_path = inspect([String.to_atom(entry["name"])])
+    element_encoder = elixir_array_element_encoder(element, smap, "command", "[index | path]")
 
     [
       "  @spec #{fn_name}([term()]) :: iodata()\n",
-      "  def #{fn_name}(items) when is_list(items) do\n",
-      "    [<<Enum.count(items)::#{bits}>> | Enum.map(items, #{element_encoder})]\n",
+      "  def #{fn_name}(items) when is_list(items), do: #{fn_name}(items, #{inspect(command)}, #{root_path})\n\n",
+      "  @spec #{fn_name}([term()], atom(), [atom() | non_neg_integer()]) :: iodata()\n",
+      "  defp #{fn_name}(items, command, path) when is_list(items) do\n",
+      "    count = Enum.count(items)\n",
+      "    validate_uint!(command, path, count, #{max})\n",
+      "    [<<count::#{bits}>> | Enum.map(Stream.with_index(items), #{element_encoder})]\n",
       "  end\n\n"
     ]
   end
 
-  # Emit `encode_<unit>(model) :: iodata()` for one record. Base fields are
-  # encoded in order; an optional conditional tail emits its fields only when the
-  # guard (rewritten to read `model.<field>`) holds. A record with no fields and
-  # no tail (none exist today) still compiles to an empty list.
-  defp elixir_record_encoder(fn_name, entry, smap) do
+  defp elixir_record_encoder(fn_name, command, entry, smap) do
     base_fields = Map.get(entry, "fields", [])
+    root_path = elixir_entry_root_path(entry)
 
     [
       "  @spec #{fn_name}(map()) :: iodata()\n",
-      "  def #{fn_name}(model) do\n",
+      "  def #{fn_name}(model), do: #{fn_name}(model, #{inspect(command)}, #{inspect(root_path)})\n\n",
+      "  @spec #{fn_name}(map(), atom(), [atom() | non_neg_integer()]) :: iodata()\n",
+      "  defp #{fn_name}(model, command, path) do\n",
       "    [\n",
       Enum.map(base_fields, fn field ->
-        "      #{elixir_encode_field(field, "model", smap)},\n"
+        "      #{elixir_encode_field(field, "model", smap, "command", "path")},\n"
       end),
       elixir_encode_conditional_tail(entry, smap),
       "    ]\n",
@@ -3648,10 +3674,6 @@ defmodule Minga.Mix.ProtocolGenerator do
     ]
   end
 
-  # The conditional tail compiles to a nested list guarded by an `if`. The guard
-  # is the schema guard with each base-field identifier rewritten to
-  # `Map.fetch!(model, :<field>)` so it reads the same field the fixed section
-  # decoded, mirroring the Go decoder's substitution of decoded locals.
   @spec elixir_encode_conditional_tail(map(), %{String.t() => structure()}) :: iodata()
   defp elixir_encode_conditional_tail(entry, smap) do
     case conditional_tail_fields(entry) do
@@ -3663,7 +3685,7 @@ defmodule Minga.Mix.ProtocolGenerator do
           "      if #{elixir_guard_expression(entry)} do\n",
           "        [\n",
           Enum.map(tail_fields, fn field ->
-            "          #{elixir_encode_field(field, "model", smap)},\n"
+            "          #{elixir_encode_field(field, "model", smap, "command", "path")},\n"
           end),
           "        ]\n",
           "      else\n",
@@ -3685,46 +3707,49 @@ defmodule Minga.Mix.ProtocolGenerator do
     )
   end
 
-  # Encode one field as iodata, reading its value from `<source>.<name>` (a struct
-  # or map field with the schema name). Mirrors the Go decode-field dispatch.
-  @spec elixir_encode_field(map(), String.t(), %{String.t() => structure()}) :: String.t()
+  @spec elixir_encode_field(
+          map(),
+          String.t(),
+          %{String.t() => structure()},
+          String.t(),
+          String.t()
+        ) :: String.t()
   defp elixir_encode_field(
          %{"name" => name, "type" => "enum", "enum" => enum_name, "repr" => repr},
          source,
-         _smap
+         _smap,
+         command,
+         path
        ) do
     bits = @primitive_sizes[repr] * 8
-    "<<encode_#{enum_name}(#{field_read(source, name)})::#{bits}>>"
+    value = "encode_#{enum_name}(#{field_read(source, name)})"
+    elixir_encode_uint(value, bits, command, field_path(path, name))
   end
 
-  defp elixir_encode_field(%{"name" => name, "type" => type}, source, _smap)
+  defp elixir_encode_field(%{"name" => name, "type" => type}, source, _smap, command, path)
        when type in ["u8", "u16", "u24", "u32", "u64"] do
     bits = @primitive_sizes[type] * 8
-    "<<#{field_read(source, name)}::#{bits}>>"
+    elixir_encode_uint(field_read(source, name), bits, command, field_path(path, name))
   end
 
-  defp elixir_encode_field(%{"name" => name, "type" => "rgb"}, source, _smap) do
-    "<<#{field_read(source, name)}::24>>"
+  defp elixir_encode_field(%{"name" => name, "type" => "rgb"}, source, _smap, command, path) do
+    elixir_encode_uint(field_read(source, name), 24, command, field_path(path, name))
   end
 
-  defp elixir_encode_field(%{"name" => name, "type" => "string8"}, source, _smap) do
-    elixir_encode_string(field_read(source, name), 8)
-  end
-
-  defp elixir_encode_field(%{"name" => name, "type" => "string16"}, source, _smap) do
-    elixir_encode_string(field_read(source, name), 16)
-  end
-
-  defp elixir_encode_field(%{"name" => name, "type" => "string32"}, source, _smap) do
-    elixir_encode_string(field_read(source, name), 32)
+  defp elixir_encode_field(%{"name" => name, "type" => type}, source, _smap, command, path)
+       when type in ["string8", "string16", "string32"] do
+    bits = type |> String.replace_prefix("string", "") |> String.to_integer()
+    elixir_encode_string(field_read(source, name), bits, command, field_path(path, name))
   end
 
   defp elixir_encode_field(
          %{"name" => name, "type" => "struct", "element" => element},
          source,
-         _smap
+         _smap,
+         command,
+         path
        ) do
-    "#{encode_fn_name(element)}(#{field_read(source, name)})"
+    "#{encode_fn_name(element)}(#{field_read(source, name)}, #{command}, #{field_path(path, name)})"
   end
 
   defp elixir_encode_field(
@@ -3735,46 +3760,97 @@ defmodule Minga.Mix.ProtocolGenerator do
            "element" => element
          },
          source,
-         smap
+         smap,
+         command,
+         path
        ) do
     bits = @primitive_sizes[count_type] * 8
+    max = integer_max(bits)
     list = field_read(source, name)
-    element_encoder = elixir_array_element_encoder(element, smap)
-    "[<<Enum.count(#{list})::#{bits}>> | Enum.map(#{list}, #{element_encoder})]"
+    array_path = field_path(path, name)
+
+    element_encoder =
+      elixir_array_element_encoder(element, smap, command, "[index | #{array_path}]")
+
+    "(fn items -> count = Enum.count(items); validate_uint!(#{command}, #{array_path}, count, #{max}); " <>
+      "[<<count::#{bits}>> | Enum.map(Stream.with_index(items), #{element_encoder})] end).(#{list})"
   end
 
-  # A counted_array element is either a bare wire type or a named structure. Bare
-  # primitives/strings encode inline; structures delegate to their encoder. The
-  # returned string is an anonymous fn passed to `Enum.map/2`.
-  @spec elixir_array_element_encoder(String.t(), %{String.t() => structure()}) :: String.t()
-  defp elixir_array_element_encoder(element, _smap)
+  @spec elixir_array_element_encoder(
+          String.t(),
+          %{String.t() => structure()},
+          String.t(),
+          String.t()
+        ) :: String.t()
+  defp elixir_array_element_encoder(element, _smap, command, path)
        when element in ["u8", "u16", "u24", "u32", "u64"] do
     bits = @primitive_sizes[element] * 8
-    "fn v -> <<v::#{bits}>> end"
+    "fn {value, index} -> #{elixir_encode_uint("value", bits, command, path)} end"
   end
 
-  defp elixir_array_element_encoder("rgb", _smap), do: "fn v -> <<v::24>> end"
-
-  defp elixir_array_element_encoder("string8", _smap),
-    do: "fn v -> #{elixir_encode_string("v", 8)} end"
-
-  defp elixir_array_element_encoder("string16", _smap),
-    do: "fn v -> #{elixir_encode_string("v", 16)} end"
-
-  defp elixir_array_element_encoder("string32", _smap),
-    do: "fn v -> #{elixir_encode_string("v", 32)} end"
-
-  defp elixir_array_element_encoder(element, _smap),
-    do: "&#{encode_fn_name(element)}/1"
-
-  # A length-prefixed string: `<<byte_size(bin)::N, bin::binary>>` where `bin` is
-  # the value coerced to a binary. The hand-written encoders use
-  # `:erlang.iolist_to_binary/1`; matching that keeps bytes identical for iodata
-  # values while a plain binary passes through unchanged.
-  @spec elixir_encode_string(String.t(), non_neg_integer()) :: String.t()
-  defp elixir_encode_string(expr, bits) do
-    "(fn bin -> <<byte_size(bin)::#{bits}, bin::binary>> end).(:erlang.iolist_to_binary([#{expr}]))"
+  defp elixir_array_element_encoder("rgb", _smap, command, path) do
+    "fn {value, index} -> #{elixir_encode_uint("value", 24, command, path)} end"
   end
+
+  defp elixir_array_element_encoder(element, _smap, command, path)
+       when element in ["string8", "string16", "string32"] do
+    bits = element |> String.replace_prefix("string", "") |> String.to_integer()
+    "fn {value, index} -> #{elixir_encode_string("value", bits, command, path)} end"
+  end
+
+  defp elixir_array_element_encoder(element, _smap, command, path) do
+    "fn {value, index} -> #{encode_fn_name(element)}(value, #{command}, #{path}) end"
+  end
+
+  @spec elixir_encode_uint(String.t(), pos_integer(), String.t(), String.t()) :: String.t()
+  defp elixir_encode_uint(expr, bits, command, path) do
+    max = integer_max(bits)
+
+    "(fn value -> validate_uint!(#{command}, #{path}, value, #{max}); " <>
+      "<<value::#{bits}>> end).(#{expr})"
+  end
+
+  @spec elixir_encode_string(String.t(), pos_integer(), String.t(), String.t()) :: String.t()
+  defp elixir_encode_string(expr, bits, command, path) do
+    max = integer_max(bits)
+
+    "(fn value -> bin = :erlang.iolist_to_binary([value]); " <>
+      "validate_uint!(#{command}, #{path}, byte_size(bin), #{max}); " <>
+      "<<byte_size(bin)::#{bits}, bin::binary>> end).(#{expr})"
+  end
+
+  @spec elixir_validation_helpers() :: iodata()
+  defp elixir_validation_helpers do
+    [
+      "  @spec validate_uint!(atom(), [atom() | non_neg_integer()], term(), non_neg_integer()) :: :ok\n",
+      "  defp validate_uint!(_command, _path, value, max)\n",
+      "       when is_integer(value) and value >= 0 and value <= max,\n",
+      "       do: :ok\n\n",
+      "  defp validate_uint!(command, reverse_path, value, max) do\n",
+      "    field_path = Enum.reverse(reverse_path)\n",
+      "    raise EncodingError,\n",
+      "      command: command,\n",
+      "      field: Enum.find(reverse_path, &is_atom/1),\n",
+      "      field_path: field_path,\n",
+      "      actual: value,\n",
+      "      min: 0,\n",
+      "      max: max\n",
+      "  end\n\n"
+    ]
+  end
+
+  @spec elixir_entry_root_path(map()) :: [atom()]
+  defp elixir_entry_root_path(%{"opcode" => _opcode, "name" => name}) do
+    [String.to_atom(name)]
+  end
+
+  defp elixir_entry_root_path(_entry), do: []
+
+  @spec field_path(String.t(), String.t()) :: String.t()
+  defp field_path(path, name), do: "[:#{name} | #{path}]"
+
+  @spec integer_max(pos_integer()) :: pos_integer()
+  defp integer_max(bits), do: Bitwise.bsl(1, bits) - 1
 
   @spec field_read(String.t(), String.t()) :: String.t()
   defp field_read(source, name), do: "Map.fetch!(#{source}, :#{name})"

--- a/test/fixtures/protocol_encoder_bounds.toml
+++ b/test/fixtures/protocol_encoder_bounds.toml
@@ -1,0 +1,22 @@
+[[structures]]
+name = "fixture_child"
+fields = [
+  { name = "score", type = "u16" },
+  { name = "label", type = "string8" },
+]
+
+[[command_fields]]
+opcode = "fixture_command"
+fields = [
+  { name = "tiny", type = "u8" },
+  { name = "small", type = "u16" },
+  { name = "color", type = "u24" },
+  { name = "large", type = "u32" },
+  { name = "huge", type = "u64" },
+  { name = "title", type = "string16" },
+  { name = "child", type = "struct", element = "fixture_child" },
+  { name = "children", type = "counted_array", count_type = "u8", element = "fixture_child" },
+]
+conditional_tail = { guard = "tiny == 1", fields = [
+  { name = "conditional_note", type = "string8" },
+] }

--- a/test/minga/credo/no_lossy_gui_encoder_check_test.exs
+++ b/test/minga/credo/no_lossy_gui_encoder_check_test.exs
@@ -100,55 +100,10 @@ defmodule Minga.Credo.NoLossyGuiEncoderCheckTest do
     end)
   end
 
-  test "flags generated encoders without a Writer preflight" do
+  test "allows generated encoders without adapter preflight coupling" do
     """
     defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
       def encode(value), do: Encode.encode_gui_example(%{value: value})
-    end
-    """
-    |> check()
-    |> assert_issue(fn issue -> assert issue.trigger == "generated_encode" end)
-  end
-
-  test "flags a generated encoder after a no-op preflight helper" do
-    """
-    defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
-      def encode(value) do
-        preflight(value)
-        Encode.encode_gui_example(%{value: value})
-      end
-
-      defp preflight(_value), do: :ok
-    end
-    """
-    |> check()
-    |> assert_issue(fn issue -> assert issue.trigger == "generated_encode" end)
-  end
-
-  test "flags a generated encoder after a different-arity preflight helper" do
-    """
-    defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
-      def encode(value) do
-        preflight()
-        Encode.encode_gui_example(%{value: value})
-      end
-
-      defp preflight(value), do: Writer.check_uint16(Writer.new(:gui_example), :value, value)
-      defp preflight, do: :ok
-    end
-    """
-    |> check()
-    |> assert_issue(fn issue -> assert issue.trigger == "generated_encode" end)
-  end
-
-  test "allows generated encoders after a Writer preflight" do
-    """
-    defmodule Minga.Frontend.Adapter.GUI.ExampleEncoder do
-      def encode(value) do
-        Writer.new(:gui_example)
-        |> Writer.check_uint16(:value, value)
-        |> Writer.append(Encode.encode_gui_example(%{value: value}))
-      end
     end
     """
     |> check()

--- a/test/minga/frontend/adapter/gui/breadcrumb_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/breadcrumb_encoder_test.exs
@@ -3,7 +3,7 @@ defmodule Minga.Frontend.Adapter.GUI.BreadcrumbEncoderTest do
 
   alias Minga.Frontend.Adapter.GUI.BreadcrumbEncoder
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.EncodingError
+  alias Minga.Protocol.EncodingError
   alias Minga.RenderModel.UI.Breadcrumb
   alias MingaEditor.RenderModel.UI.BreadcrumbBuilder
 
@@ -42,7 +42,14 @@ defmodule Minga.Frontend.Adapter.GUI.BreadcrumbEncoderTest do
     test "rejects a segment count beyond the uint8 carrier" do
       model = %Breadcrumb{file_path: "ignored", root: "/", segments: List.duplicate("a", 256)}
 
-      assert %{command: :gui_breadcrumb, field: :segment_count, actual: 256, min: 0, max: 255} =
+      assert %{
+               command: :gui_breadcrumb,
+               field: :segments,
+               field_path: [:segments],
+               actual: 256,
+               min: 0,
+               max: 255
+             } =
                assert_raise(EncodingError, fn -> BreadcrumbEncoder.encode(model, Caches.new()) end)
     end
 
@@ -53,7 +60,14 @@ defmodule Minga.Frontend.Adapter.GUI.BreadcrumbEncoderTest do
         segments: [String.duplicate("a", 65_536)]
       }
 
-      assert %{command: :gui_breadcrumb, field: :segment, actual: 65_536, min: 0, max: 65_535} =
+      assert %{
+               command: :gui_breadcrumb,
+               field: :segments,
+               field_path: [:segments, 0],
+               actual: 65_536,
+               min: 0,
+               max: 65_535
+             } =
                assert_raise(EncodingError, fn -> BreadcrumbEncoder.encode(model, Caches.new()) end)
     end
 

--- a/test/minga/frontend/adapter/gui/completion_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/completion_encoder_test.exs
@@ -3,7 +3,7 @@ defmodule Minga.Frontend.Adapter.GUI.CompletionEncoderTest do
 
   alias Minga.Frontend.Adapter.GUI.Caches
   alias Minga.Frontend.Adapter.GUI.CompletionEncoder
-  alias Minga.Frontend.Adapter.GUI.EncodingError
+  alias Minga.Protocol.EncodingError
   alias Minga.RenderModel.UI.Completion
   alias Minga.RenderModel.UI.Completion.Item
 
@@ -130,17 +130,17 @@ defmodule Minga.Frontend.Adapter.GUI.CompletionEncoderTest do
 
       assert_encoding_error(
         %Completion{visible?: true, items: List.duplicate(item, 65_536)},
-        :item_count,
+        [:items],
         65_536
       )
 
       oversized = String.duplicate("x", 65_536)
 
-      for {field, item} <- [
-            item_label: %{item | label: oversized},
-            item_detail: %{item | detail: oversized}
+      for {field_path, item} <- [
+            {[:items, 0, :label], %{item | label: oversized}},
+            {[:items, 0, :detail], %{item | detail: oversized}}
           ] do
-        assert_encoding_error(%Completion{visible?: true, items: [item]}, field, 65_536)
+        assert_encoding_error(%Completion{visible?: true, items: [item]}, field_path, 65_536)
       end
 
       assert_encoding_error(
@@ -151,12 +151,18 @@ defmodule Minga.Frontend.Adapter.GUI.CompletionEncoderTest do
     end
   end
 
-  defp assert_encoding_error(model, field, actual) do
+  defp assert_encoding_error(model, field, actual) when is_atom(field) do
+    assert_encoding_error(model, [field], actual)
+  end
+
+  defp assert_encoding_error(model, field_path, actual) do
+    field = Enum.find(Enum.reverse(field_path), &is_atom/1)
     error = assert_raise EncodingError, fn -> CompletionEncoder.encode_command(model) end
 
     assert %EncodingError{
              command: :gui_completion,
              field: ^field,
+             field_path: ^field_path,
              actual: ^actual,
              min: 0,
              max: 65_535

--- a/test/minga/frontend/adapter/gui/git_status_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/git_status_encoder_test.exs
@@ -2,7 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.GitStatusEncoderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.EncodingError
+  alias Minga.Protocol.EncodingError
   alias Minga.Frontend.Adapter.GUI.GitStatusEncoder
   alias Minga.RenderModel.UI.GitStatus
   alias MingaEditor.RenderModel.UI.GitStatusBuilder
@@ -275,17 +275,27 @@ defmodule Minga.Frontend.Adapter.GUI.GitStatusEncoderTest do
     }
   end
 
-  defp assert_encoding_error(model, field, actual, max) do
+  defp assert_encoding_error(model, adapter_field, actual, max) do
+    field_path = git_status_schema_path(adapter_field)
+    field = Enum.find(Enum.reverse(field_path), &is_atom/1)
     error = assert_raise EncodingError, fn -> GitStatusEncoder.encode_command(model) end
 
     assert %EncodingError{
              command: :gui_git_status,
              field: ^field,
+             field_path: ^field_path,
              actual: ^actual,
              min: 0,
              max: ^max
            } = error
   end
+
+  defp git_status_schema_path(:entry_count), do: [:entries]
+  defp git_status_schema_path(:entry_path), do: [:entries, 0, :path]
+  defp git_status_schema_path(:entry_path_hash), do: [:entries, 0, :path_hash]
+  defp git_status_schema_path(:entry_section), do: [:entries, 0, :section]
+  defp git_status_schema_path(:toast_message), do: [:toast, :message]
+  defp git_status_schema_path(field), do: [field]
 
   # Decodes the production gui_git_status wire format (opcode stripped) into a
   # struct of fields, mirroring the layout the native frontend decodes.

--- a/test/minga/frontend/adapter/gui/picker_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/picker_encoder_test.exs
@@ -2,7 +2,7 @@ defmodule Minga.Frontend.Adapter.GUI.PickerEncoderTest do
   use ExUnit.Case, async: true
 
   alias Minga.Frontend.Adapter.GUI.Caches
-  alias Minga.Frontend.Adapter.GUI.EncodingError
+  alias Minga.Protocol.EncodingError
   alias Minga.Frontend.Adapter.GUI.PickerEncoder
   alias Minga.RenderModel.UI.Picker
   alias Minga.RenderModel.UI.Picker.ActionMenu
@@ -226,17 +226,39 @@ defmodule Minga.Frontend.Adapter.GUI.PickerEncoderTest do
     }
   end
 
-  defp assert_encoding_error(model, field, actual, max) do
+  defp assert_encoding_error(model, adapter_field, actual, max) do
+    field_path = picker_schema_path(adapter_field)
+    field = Enum.find(Enum.reverse(field_path), &is_atom/1)
     error = assert_raise EncodingError, fn -> PickerEncoder.encode_command(model) end
 
     assert %EncodingError{
              command: :gui_picker,
              field: ^field,
+             field_path: ^field_path,
              actual: ^actual,
              min: 0,
              max: ^max
            } = error
   end
+
+  defp picker_schema_path(field)
+       when field in [:selected_index, :filtered_count, :total_count, :marked_count, :title],
+       do: [:header, field]
+
+  defp picker_schema_path(:item_count), do: [:items]
+  defp picker_schema_path(:query), do: [:query, :text]
+  defp picker_schema_path(:mode_prefix), do: [:mode_prefix, :text]
+  defp picker_schema_path(:load_status_message), do: [:load_status, :message]
+  defp picker_schema_path(:item_icon_color), do: [:items, 0, :icon_color]
+  defp picker_schema_path(:item_flags), do: [:items, 0, :flags]
+  defp picker_schema_path(:item_label), do: [:items, 0, :label]
+  defp picker_schema_path(:item_description), do: [:items, 0, :description]
+  defp picker_schema_path(:item_annotation), do: [:items, 0, :annotation]
+  defp picker_schema_path(:item_match_position_count), do: [:items, 0, :match_positions]
+  defp picker_schema_path(:item_match_position), do: [:items, 0, :match_positions, 0]
+  defp picker_schema_path(:action_menu_selected_index), do: [:action_menu, :selected_index]
+  defp picker_schema_path(:action_count), do: [:action_menu, :actions]
+  defp picker_schema_path(:action_name), do: [:action_menu, :actions, 0]
 
   # Splits `count` self-describing sections (id:1, len:2, payload:len) off the
   # front of the picker payload, returning a section-id => payload map and the

--- a/test/minga/frontend/adapter/gui/surface_layout_encoder_test.exs
+++ b/test/minga/frontend/adapter/gui/surface_layout_encoder_test.exs
@@ -1,6 +1,7 @@
 defmodule Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoderTest do
   use ExUnit.Case, async: true
-  alias Minga.Frontend.Adapter.GUI.{EncodingError, SurfaceLayoutEncoder}
+  alias Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder
+  alias Minga.Protocol.EncodingError
   @u16_fields [:surface_id, :row, :col, :width, :height, :z]
   defp placement,
     do: %{surface_id: 1, rect: %{row: 2, col: 3, width: 40, height: 20}, z: 4, hit_kind: 5}
@@ -15,10 +16,25 @@ defmodule Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoderTest do
 
       assert error.command == :gui_surface_layout
       assert error.field == field
+      assert error.field_path == field_path(field)
       assert error.actual == value
       assert error.min == 0
       assert error.max == if(field == :hit_kind, do: 255, else: 65_535)
     end
+  end
+
+  test "rejects an overflowing placement count with its schema field path" do
+    error =
+      assert_raise EncodingError, fn ->
+        SurfaceLayoutEncoder.encode_command(List.duplicate(placement(), 65_536))
+      end
+
+    assert error.command == :gui_surface_layout
+    assert error.field == :placements
+    assert error.field_path == [:placements]
+    assert error.actual == 65_536
+    assert error.min == 0
+    assert error.max == 65_535
   end
 
   test "accepts the wire maximum for every bounded field" do
@@ -43,6 +59,12 @@ defmodule Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoderTest do
 
     assert Exception.message(error) =~ "z=%{}"
   end
+
+  defp field_path(field) when field in [:surface_id, :z, :hit_kind],
+    do: [:placements, 0, field]
+
+  defp field_path(field) when field in [:row, :col, :width, :height],
+    do: [:placements, 0, :rect, field]
 
   defp put_field(placement, field, value) when field in [:surface_id, :z, :hit_kind],
     do: Map.put(placement, field, value)

--- a/test/minga_agent/session_manager_test.exs
+++ b/test/minga_agent/session_manager_test.exs
@@ -14,8 +14,16 @@ defmodule MingaAgent.SessionManagerTest do
     # Start an isolated SessionManager with a unique name per test.
     name = :"session_manager_#{System.unique_integer([:positive])}"
 
-    manager =
-      start_supervised!({SessionManager, [name: name]}, id: name)
+    {:ok, manager} = SessionManager.start_link(name: name)
+    Process.unlink(manager)
+
+    on_exit(fn ->
+      for {session_id, _pid, _metadata} <- SessionManager.list_sessions(manager) do
+        SessionManager.stop_session(manager, session_id)
+      end
+
+      GenServer.stop(manager)
+    end)
 
     %{manager: manager}
   end
@@ -318,29 +326,27 @@ defmodule MingaAgent.SessionManagerTest do
 
     {:ok, session_id, pid} =
       SessionManager.start_session(manager,
+        persist?: false,
         idle_gc_timeout_ms: 60_000,
         idle_gc_token_fn: fn -> idle_gc_token end
       )
 
     assert :ok = MingaAgent.Session.subscribe(pid)
-
-    ref = Process.monitor(pid)
     assert :ok = MingaAgent.Session.unsubscribe(pid)
     send(pid, {:idle_gc_timeout, idle_gc_token})
-    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
 
     assert_receive {
                      :minga_event,
                      :agent_session_stopped,
                      %SessionStoppedEvent{session_id: ^session_id, pid: ^pid, reason: :normal}
                    },
-                   1000
+                   5_000
+
+    assert {:error, :not_found} = SessionManager.get_session(manager, session_id)
 
     refute_receive {:minga_event, :agent_session_restarted,
                     %SessionRestartedEvent{session_id: ^session_id}},
                    50
-
-    assert {:error, :not_found} = SessionManager.get_session(manager, session_id)
   end
 
   test "repeated crash restarts eventually exhaust and stop terminally", %{manager: manager} do

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -353,9 +353,15 @@ defmodule MingaAgent.SessionTest do
     end
   end
 
+  defp start_test_session(opts) do
+    opts = Keyword.put_new(opts, :persist?, false)
+    child_id = {:session, System.unique_integer([:positive, :monotonic])}
+    start_supervised!({Session, opts}, id: child_id)
+  end
+
   defp start_subscribed_session(provider \\ MockProvider, provider_opts \\ []) do
     provider_opts = native_provider_opts(provider, provider_opts)
-    {:ok, session} = Session.start_link(provider: provider, provider_opts: provider_opts)
+    session = start_test_session(provider: provider, provider_opts: provider_opts)
     Session.subscribe(session)
     session
   end
@@ -405,7 +411,8 @@ defmodule MingaAgent.SessionTest do
     session = start_subscribed_session(SlowMockProvider)
     assert is_pid(Session.get_provider(session))
     assert :ok = Session.send_prompt(session, prompt)
-    assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
+    assert_receive {:agent_event, ^session, {:status_changed, :thinking}}, @event_timeout
+    assert_receive {:agent_event, ^session, {:text_delta, ^prompt}}, @event_timeout
     session
   end
 
@@ -442,8 +449,8 @@ defmodule MingaAgent.SessionTest do
   # ── Tests ───────────────────────────────────────────────────────────────────
 
   setup do
-    {:ok, session} =
-      Session.start_link(
+    session =
+      start_test_session(
         provider: MockProvider,
         provider_opts: []
       )
@@ -478,8 +485,8 @@ defmodule MingaAgent.SessionTest do
 
     on_exit(fn -> ProviderRegistry.unregister_source(source) end)
 
-    {:ok, session} =
-      Session.start_link(
+    session =
+      start_test_session(
         provider: SlowMockProvider,
         provider_id: provider_id,
         provider_source: source,
@@ -561,7 +568,7 @@ defmodule MingaAgent.SessionTest do
     end
 
     test "driver role is vacated when the driver process dies" do
-      {:ok, session} = Session.start_link(provider: MockProvider, provider_opts: [])
+      session = start_test_session(provider: MockProvider, provider_opts: [])
       driver = idle_process()
       viewer = idle_process()
 
@@ -593,8 +600,8 @@ defmodule MingaAgent.SessionTest do
     test "idle detached sessions are reclaimed after the configured timeout" do
       idle_gc_token = make_ref()
 
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: MockProvider,
           provider_opts: [],
           idle_gc_timeout_ms: 60_000,
@@ -620,8 +627,8 @@ defmodule MingaAgent.SessionTest do
       File.write!(bad_store_dir, "not a directory")
       idle_gc_token = make_ref()
 
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: MockProvider,
           provider_opts: [],
           persist?: false,
@@ -650,8 +657,8 @@ defmodule MingaAgent.SessionTest do
 
       idle_gc_token = make_ref()
 
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: DeferredMockProvider,
           provider_opts: [test_pid: self()],
           session_store_dir: session_store_dir,
@@ -661,10 +668,7 @@ defmodule MingaAgent.SessionTest do
 
       client = idle_process()
 
-      on_exit(fn ->
-        Process.exit(client, :kill)
-        Process.exit(session, :kill)
-      end)
+      on_exit(fn -> Process.exit(client, :kill) end)
 
       assert :ok = Session.subscribe(session, client)
       assert :ok = Session.unsubscribe(session, client)
@@ -692,16 +696,14 @@ defmodule MingaAgent.SessionTest do
       initial_token = make_ref()
       finished_token = make_ref()
 
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: Minga.Test.StubProvider,
           provider_opts: [],
           persist?: false,
           idle_gc_timeout_ms: 60_000,
           idle_gc_token_fn: idle_gc_token_fn([initial_token, finished_token])
         )
-
-      on_exit(fn -> Process.exit(session, :kill) end)
 
       ref = Process.monitor(session)
 
@@ -720,14 +722,12 @@ defmodule MingaAgent.SessionTest do
     end
 
     test "active detached sessions are not reclaimed" do
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: SlowMockProvider,
           provider_opts: [],
           idle_gc_timeout_ms: 60_000
         )
-
-      on_exit(fn -> Process.exit(session, :kill) end)
 
       {_timer_ref, stale_token} = :sys.get_state(session).idle_gc_timer
 
@@ -741,14 +741,12 @@ defmodule MingaAgent.SessionTest do
     end
 
     test "active plan-mode turns are not reclaimed" do
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: Minga.Test.StubProvider,
           provider_opts: [],
           idle_gc_timeout_ms: 60_000
         )
-
-      on_exit(fn -> Process.exit(session, :kill) end)
 
       assert :ok = Session.enter_plan(session)
       send(session, {:agent_provider_event, %Event.AgentStart{}})
@@ -763,10 +761,8 @@ defmodule MingaAgent.SessionTest do
     end
 
     test "stale idle GC messages are ignored after a client reconnects" do
-      {:ok, session} =
-        Session.start_link(provider: MockProvider, provider_opts: [], idle_gc_timeout_ms: 60_000)
-
-      on_exit(fn -> Process.exit(session, :kill) end)
+      session =
+        start_test_session(provider: MockProvider, provider_opts: [], idle_gc_timeout_ms: 60_000)
 
       assert :ok = Session.subscribe(session)
       assert :ok = Session.unsubscribe(session)
@@ -781,15 +777,14 @@ defmodule MingaAgent.SessionTest do
       bad_store_dir = Path.join(dir, "blocked-store")
       File.write!(bad_store_dir, "not a directory")
 
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: MockProvider,
           provider_opts: [],
+          persist?: true,
           session_store_dir: bad_store_dir,
           idle_gc_timeout_ms: 60_000
         )
-
-      on_exit(fn -> Process.exit(session, :kill) end)
 
       ref = Process.monitor(session)
 
@@ -805,15 +800,14 @@ defmodule MingaAgent.SessionTest do
       bad_store_dir = Path.join(dir, "blocked-store")
       File.write!(bad_store_dir, "not a directory")
 
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: MockProvider,
           provider_opts: [],
+          persist?: true,
           session_store_dir: bad_store_dir,
           idle_gc_timeout_ms: 60_000
         )
-
-      on_exit(fn -> Process.exit(session, :kill) end)
 
       {_timer_ref, token} = :sys.get_state(session).idle_gc_timer
       ref = Process.monitor(session)
@@ -854,8 +848,8 @@ defmodule MingaAgent.SessionTest do
     end
 
     test "provider write tool is refused through a real plan-mode session" do
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: PlanToolProvider,
           provider_opts: [parent: self()]
         )
@@ -1034,8 +1028,8 @@ defmodule MingaAgent.SessionTest do
       # Start a session with a provider that will crash immediately
       # so provider stays nil. Use a simpler approach: check the session
       # can handle the call gracefully when provider is nil.
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: MockProvider,
           provider_opts: []
         )
@@ -1212,7 +1206,14 @@ defmodule MingaAgent.SessionTest do
       assert id1 != id2
     end
 
-    test "save is scheduled after user prompt", %{session: session} do
+    test "save is scheduled after user prompt" do
+      session =
+        start_test_session(
+          provider: MockProvider,
+          provider_opts: [],
+          persist?: true
+        )
+
       # The save fires asynchronously via debounced timer
       Session.send_prompt(session, "test prompt")
       # Just verify no crash; actual file I/O tested in SessionStore tests
@@ -1249,8 +1250,8 @@ defmodule MingaAgent.SessionTest do
     end
 
     test "load_session restores messages, model, provider metadata, and branches", %{tmp_dir: dir} do
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: MockProvider,
           provider_opts: [],
           session_store_dir: dir
@@ -1305,8 +1306,8 @@ defmodule MingaAgent.SessionTest do
          %{
            tmp_dir: dir
          } do
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: MockProvider,
           provider_opts: [],
           session_store_dir: dir
@@ -1335,10 +1336,11 @@ defmodule MingaAgent.SessionTest do
     end
 
     test "load_session saves the current dirty session before replacement", %{tmp_dir: dir} do
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: MockProvider,
           provider_opts: [],
+          persist?: true,
           session_store_dir: dir
         )
 
@@ -2230,8 +2232,8 @@ defmodule MingaAgent.SessionTest do
         mcp_session_stream(chunks)
       end
 
-      {:ok, session} =
-        Session.start_link(
+      session =
+        start_test_session(
           provider: Native,
           provider_opts: [
             model: "anthropic:claude-sonnet-4-20250514",

--- a/test/mix/protocol_generator_test.exs
+++ b/test/mix/protocol_generator_test.exs
@@ -76,7 +76,7 @@ defmodule Minga.Mix.ProtocolGeneratorTest do
 
     extended_schema =
       update_in(schema, ["command_fields", Access.at(0), "fields"], fn fields ->
-        fields ++ [future_field]
+        List.insert_at(fields, -1, future_field)
       end)
 
     compile_encoder(extended_schema, module)
@@ -88,8 +88,11 @@ defmodule Minga.Mix.ProtocolGeneratorTest do
              field_path: [:future_sequence],
              actual: 65_536,
              max: 65_535
-           } = assert_raise(EncodingError, fn -> module.encode_fixture_command(model) end)
+           } =
+             assert_raise(EncodingError, fn -> encode_fixture_command(module, model) end)
   end
+
+  defp encode_fixture_command(module, model), do: module.encode_fixture_command(model)
 
   defp assert_error(model, field_path, actual, max) do
     assert %EncodingError{
@@ -99,7 +102,8 @@ defmodule Minga.Mix.ProtocolGeneratorTest do
              actual: ^actual,
              min: 0,
              max: ^max
-           } = assert_raise(EncodingError, fn -> @encoder.encode_fixture_command(model) end)
+           } =
+             assert_raise(EncodingError, fn -> encode_fixture_command(@encoder, model) end)
 
     assert field == Enum.find(Enum.reverse(field_path), &is_atom/1)
   end

--- a/test/mix/protocol_generator_test.exs
+++ b/test/mix/protocol_generator_test.exs
@@ -1,0 +1,129 @@
+Code.require_file("mix/protocol_generator.ex")
+
+defmodule Minga.Mix.ProtocolGeneratorTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Mix.ProtocolGenerator
+  alias Minga.Protocol.EncodingError
+
+  @fixture_path "test/fixtures/protocol_encoder_bounds.toml"
+  @encoder Minga.ProtocolFixture.Encode
+
+  setup_all do
+    {:ok, schema} = @fixture_path |> File.read!() |> Toml.decode()
+    compile_encoder(schema, @encoder)
+    %{schema: schema}
+  end
+
+  test "validates every bounded numeric primitive from the schema" do
+    for {field, actual, max} <- [
+          {:tiny, 256, 255},
+          {:small, 65_536, 65_535},
+          {:color, 16_777_216, 16_777_215},
+          {:large, 4_294_967_296, 4_294_967_295},
+          {:huge, 18_446_744_073_709_551_616, 18_446_744_073_709_551_615}
+        ] do
+      assert_error(%{valid_model() | field => actual}, [field], actual, max)
+    end
+  end
+
+  test "validates string byte lengths at their schema path" do
+    assert_error(
+      %{valid_model() | title: String.duplicate("x", 65_536)},
+      [:title],
+      65_536,
+      65_535
+    )
+  end
+
+  test "recurses through nested structs and counted array elements" do
+    assert_error(
+      put_in(valid_model(), [:child, :label], String.duplicate("x", 256)),
+      [:child, :label],
+      256,
+      255
+    )
+
+    assert_error(
+      put_in(valid_model(), [:children, Access.at(0), :score], 65_536),
+      [:children, 0, :score],
+      65_536,
+      65_535
+    )
+  end
+
+  test "validates counted array prefixes" do
+    assert_error(
+      %{valid_model() | children: List.duplicate(valid_child(), 256)},
+      [:children],
+      256,
+      255
+    )
+  end
+
+  test "validates fields in an active conditional tail" do
+    model =
+      valid_model()
+      |> Map.put(:tiny, 1)
+      |> Map.put(:conditional_note, String.duplicate("x", 256))
+
+    assert_error(model, [:conditional_note], 256, 255)
+  end
+
+  test "a newly added schema field is enforced by regeneration alone", %{schema: schema} do
+    module = Minga.ProtocolFixture.ExtendedEncode
+    future_field = %{"name" => "future_sequence", "type" => "u16"}
+
+    extended_schema =
+      update_in(schema, ["command_fields", Access.at(0), "fields"], fn fields ->
+        fields ++ [future_field]
+      end)
+
+    compile_encoder(extended_schema, module)
+    model = Map.put(valid_model(), :future_sequence, 65_536)
+
+    assert %EncodingError{
+             command: :fixture_command,
+             field: :future_sequence,
+             field_path: [:future_sequence],
+             actual: 65_536,
+             max: 65_535
+           } = assert_raise(EncodingError, fn -> module.encode_fixture_command(model) end)
+  end
+
+  defp assert_error(model, field_path, actual, max) do
+    assert %EncodingError{
+             command: :fixture_command,
+             field: field,
+             field_path: ^field_path,
+             actual: ^actual,
+             min: 0,
+             max: ^max
+           } = assert_raise(EncodingError, fn -> @encoder.encode_fixture_command(model) end)
+
+    assert field == Enum.find(Enum.reverse(field_path), &is_atom/1)
+  end
+
+  defp valid_model do
+    %{
+      tiny: 0,
+      small: 0,
+      color: 0,
+      large: 0,
+      huge: 0,
+      title: "title",
+      child: valid_child(),
+      children: [valid_child()]
+    }
+  end
+
+  defp valid_child, do: %{score: 1, label: "child"}
+
+  defp compile_encoder(schema, module) do
+    schema
+    |> ProtocolGenerator.render_encode_module(module)
+    |> Code.compile_string()
+
+    :ok
+  end
+end


### PR DESCRIPTION
# TL;DR
This closes the final #2737 gaps: schema-generated encoders now reject every bounded field by construction, and the protocol documentation matches that behavior.

Closes #2737

## Changes
- Generate recursive bound validation for numeric fields, strings, counted arrays, nested records, and conditional tails.
- Raise canonical `Minga.Protocol.EncodingError` values with schema-derived paths, and let GUI frame recovery handle both protocol and legacy adapter errors.
- Remove duplicated generated-payload preflights from GUI adapters, including surface layout.
- Add a generator fixture proving a newly added schema field receives overflow validation without adapter changes.
- Correct GUI protocol and configuration docs that incorrectly promised clamping or truncation.
- Stabilize leaked agent-session test processes so full-suite validation is reliable.

## Verification
- `make lint`
- `mix compile.minga_zig`
- `mix test.llm`
- `mix protocol.gen --check`
- `mix swift.build`
- `cd go/tui && go test ./...`

## Acceptance Criteria Addressed
- Clipboard and A1/A2 carrier widening remains covered. ✅
- Every schema-owned bounded generated field rejects out-of-range data with structured metadata. ✅
- Generated artifacts stay synchronized. ✅
- Invalid frame emission preserves no-write and keyframe recovery behavior. ✅
- Documentation now describes checked rejection rather than lossy adjustment. ✅