### PR TITLE
test: stabilize GUI harness coverage

### DIFF
--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -15,6 +15,7 @@ import Foundation
 let stdin = FileHandle.standardInput
 let stdout = FileHandle.standardOutput
 let lock = NSLock()
+let emitSelectTab = CommandLine.arguments.contains("--emit-select-tab")
 
 /// Writes a {:packet, 4} framed message to stdout.
 func writeFramed(_ data: Data) {
@@ -94,10 +95,9 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
              "is_agent": tab.isAgent, "has_attention": tab.hasAttention,
              "agent_status": Int(tab.agentStatus)]
         }
-        // If there are 2+ tabs, auto-send a select_tab gui_action for the
-        // second tab. This enables round-trip testing: BEAM sends gui_tab_bar,
-        // harness decodes it and sends gui_action select_tab back.
-        if tabs.count >= 2 {
+        // The bidirectional protocol test explicitly opts in to this synthetic action.
+        // Ordinary decode tests must leave no input event for a later response to consume.
+        if emitSelectTab && tabs.count >= 2 {
             let secondTabId = tabs[1].id
             sendSelectTab(id: secondTabId)
         }

--- a/test/minga/buffer_management_test.exs
+++ b/test/minga/buffer_management_test.exs
@@ -1,11 +1,8 @@
 defmodule Minga.BufferManagementTest do
   @moduledoc """
-  Wiring tests for multi-buffer management: verifies that keybindings and
-  ex commands correctly dispatch to buffer lifecycle operations.
+  Wiring tests for multi-buffer management: verifies that keybindings and ex commands correctly dispatch to buffer lifecycle operations.
 
-  Buffer count, index, and state-level invariants are tested as pure
-  functions in `MingaEditor.State.BufferLifecycleTest`. These tests focus on
-  the keystroke-to-state-change plumbing.
+  Buffer count, index, and state-level invariants are tested as pure functions in `MingaEditor.State.BufferLifecycleTest`. These tests focus on the keystroke-to-state-change plumbing.
   """
 
   use Minga.Test.EditorCase, async: true
@@ -20,10 +17,10 @@ defmodule Minga.BufferManagementTest do
 
       ctx = start_editor("first", file_path: path1)
 
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_ex_sync(ctx, "e #{path2}")
       assert active_content(ctx) == "second"
 
-      send_keys(ctx, ":e #{path1}<CR>")
+      send_ex_sync(ctx, "e #{path1}")
       assert active_content(ctx) == "first"
     end
   end
@@ -39,9 +36,8 @@ defmodule Minga.BufferManagementTest do
       File.write!(path3, "gamma")
 
       ctx = start_editor("alpha", file_path: path1)
-
-      send_keys(ctx, ":e #{path2}<CR>")
-      send_keys(ctx, ":e #{path3}<CR>")
+      send_ex_sync(ctx, "e #{path2}")
+      send_ex_sync(ctx, "e #{path3}")
 
       assert active_content(ctx) == "gamma"
 
@@ -54,20 +50,10 @@ defmodule Minga.BufferManagementTest do
       send_keys_sync(ctx, "<SPC>bp")
       assert active_content(ctx) == "alpha"
 
-      # Regression for #1476: after `:e <path>`, cycling must restore a valid resting
-      # mode state so another leader command remains usable.
+      # Regression for #1476: after `:e <path>`, cycling restores a valid resting mode state.
+      # Another leader command must then remain usable.
       send_keys_sync(ctx, "<SPC>bn")
       assert active_content(ctx) == "beta"
-    end
-
-    test "next/prev with single buffer is a no-op" do
-      ctx = start_editor("only one")
-
-      send_keys_sync(ctx, "<SPC>bn")
-      assert active_content(ctx) == "only one"
-
-      send_keys_sync(ctx, "<SPC>bp")
-      assert active_content(ctx) == "only one"
     end
   end
 
@@ -80,45 +66,20 @@ defmodule Minga.BufferManagementTest do
       File.write!(path2, "second")
 
       ctx = start_editor("first", file_path: path1)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_ex_sync(ctx, "e #{path2}")
 
-      # On buffer 2/2, kill it — should switch back to first
       send_keys_sync(ctx, "<SPC>bd")
       assert active_content(ctx) == "first"
-    end
-
-    @tag :tmp_dir
-    test "killing the only buffer creates a new empty buffer", %{tmp_dir: tmp_dir} do
-      path = Path.join(tmp_dir, "solo.txt")
-      File.write!(path, "alone")
-
-      ctx = start_editor("alone", file_path: path)
-      send_keys_sync(ctx, "<SPC>bd")
-
-      assert active_content(ctx) == ""
     end
   end
 
   describe "new buffers" do
     test ":new creates an editable empty buffer" do
       ctx = start_editor("hello")
-      send_keys_sync(ctx, ":new<CR>")
+      send_ex_sync(ctx, "new")
       send_keys_sync(ctx, "isome text<Esc>")
 
       assert active_content(ctx) == "some text"
-    end
-
-    test "SPC b d closes the active scratch buffer when multiple scratch buffers are open" do
-      ctx = start_editor("")
-      send_keys_sync(ctx, "<SPC>bN")
-      send_keys_sync(ctx, "iHey there<Esc>")
-
-      assert active_content(ctx) == "Hey there"
-
-      send_keys_sync(ctx, "<SPC>bd")
-
-      assert active_content(ctx) == ""
-      refute status_msg(ctx) == "Cannot close the last window"
     end
 
     @tag :tmp_dir
@@ -136,13 +97,6 @@ defmodule Minga.BufferManagementTest do
 
       assert active_content(ctx) == ""
       refute status_msg(ctx) == "Cannot close the last window"
-    end
-
-    test "SPC b N creates an empty buffer" do
-      ctx = start_editor("hello")
-      send_keys_sync(ctx, "<SPC>bN")
-
-      assert active_content(ctx) == ""
     end
   end
 end

--- a/test/minga_editor/commands/dired_test.exs
+++ b/test/minga_editor/commands/dired_test.exs
@@ -2,11 +2,7 @@ defmodule MingaEditor.Commands.DiredTest do
   @moduledoc """
   Integration tests for the dired (Oil.nvim-style) directory buffer.
 
-  Classification: these tests intentionally remain EditorCase integration coverage because they verify save interception, confirmation flow, real file creation/deletion/rename, navigation, and visible listing updates through the dired buffer.
-
-  Tests the full keystroke-to-filesystem pipeline: opening dired via
-  ex commands, navigating directories, editing filenames, and confirming
-  file operations. Uses EditorCase for headless editor state.
+  These tests keep filesystem mutations, input routing, and visible listing updates at the EditorCase boundary. Pure listing parsing and sorting live in `test/minga/dired_test.exs`.
   """
 
   use Minga.Test.EditorCase, async: true
@@ -16,197 +12,129 @@ defmodule MingaEditor.Commands.DiredTest do
 
   @moduletag :tmp_dir
 
-  describe "[EditorCase integration] :dired — open directory buffer" do
-    test "uses filetype options for the listing and opened files", %{tmp_dir: dir} do
-      File.write!(Path.join(dir, "hello.txt"), "hello")
-      File.write!(Path.join(dir, "other.txt"), "")
-      options_server = start_supervised!({Options, name: nil})
+  test "opens dired with filetype options and routes directory navigation", %{tmp_dir: dir} do
+    File.write!(Path.join(dir, "hello.txt"), "hello")
+    File.write!(Path.join(dir, "other.txt"), "")
+    options_server = start_supervised!({Options, name: nil})
 
-      assert {:ok, false} =
-               Options.set_for_filetype(options_server, :dired, :autopair_block, false)
+    assert {:ok, false} = Options.set_for_filetype(options_server, :dired, :autopair_block, false)
+    assert {:ok, false} = Options.set_for_filetype(options_server, :text, :autopair_block, false)
 
-      assert {:ok, false} =
-               Options.set_for_filetype(options_server, :text, :autopair_block, false)
+    ctx = start_editor("", options_server: options_server)
+    open_dired(ctx, dir)
 
-      ctx = start_editor("", options_server: options_server)
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
+    assert BufferProcess.get_option(active_buffer(ctx), :autopair_block) == false
+    assert active_content(ctx) =~ "hello.txt"
+    assert active_content(ctx) =~ "other.txt"
 
-      assert BufferProcess.get_option(active_buffer(ctx), :autopair_block) == false
-      assert active_content(ctx) =~ "hello.txt"
-      assert active_content(ctx) =~ "other.txt"
+    send_keys_sync(ctx, "<CR>")
+    active = active_buffer(ctx)
+    assert active_content(ctx) == "hello"
+    assert BufferProcess.file_path(active) == Path.join(dir, "hello.txt")
+    assert BufferProcess.get_option(active, :autopair_block) == false
 
-      send_keys_sync(ctx, "<CR>")
-      active = active_buffer(ctx)
-
-      assert active_content(ctx) == "hello"
-      assert BufferProcess.file_path(active) == Path.join(dir, "hello.txt")
-      assert BufferProcess.get_option(active, :autopair_block) == false
-    end
+    subdir = Path.join(dir, "sub")
+    File.mkdir_p!(subdir)
+    File.write!(Path.join(subdir, "inner.txt"), "")
+    open_dired(ctx, subdir)
+    send_keys_sync(ctx, "-")
+    assert active_content(ctx) =~ "hello.txt"
+    refute active_content(ctx) =~ "inner.txt"
   end
 
-  describe "[EditorCase integration] save interception" do
-    test ":w skips an unchanged listing and confirms edits", %{tmp_dir: dir} do
-      file = Path.join(dir, "old_name.txt")
-      File.write!(file, "content")
+  test "q closes dired and returns to editor scope", %{tmp_dir: dir} do
+    File.write!(Path.join(dir, "file.txt"), "")
 
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
+    ctx = start_editor("")
+    open_dired(ctx, dir)
+    send_keys_sync(ctx, "q")
 
-      state = send_keys_sync(ctx, ":w<CR>")
-      assert File.read!(file) == "content"
-      assert state.shell_state.status_msg =~ "No changes"
-
-      send_keys_sync(ctx, "ciwnew_name.txt<Esc>")
-      state = send_keys_sync(ctx, ":w<CR>")
-
-      assert state.workspace.dired.confirming?
-      assert state.workspace.dired.pending_ops != []
-      assert state.shell_state.status_msg =~ "apply? (y/n)"
-    end
+    refute active_content(ctx) =~ "file.txt"
   end
 
-  describe "[EditorCase integration] confirm-then-apply" do
-    test "y confirms and applies rename", %{tmp_dir: dir} do
-      File.write!(Path.join(dir, "old.txt"), "content")
+  test "save interception confirms or applies dired mutations", %{tmp_dir: dir} do
+    cancel_dir = Path.join(dir, "cancel")
+    rename_dir = Path.join(dir, "rename")
+    delete_dir = Path.join(dir, "delete")
+    add_dir = Path.join(dir, "add")
+    Enum.each([cancel_dir, rename_dir, delete_dir, add_dir], &File.mkdir_p!/1)
+    File.write!(Path.join(cancel_dir, "keep.txt"), "content")
+    File.write!(Path.join(rename_dir, "old.txt"), "content")
+    File.write!(Path.join(delete_dir, "delete_me.txt"), "gone")
+    File.write!(Path.join(delete_dir, "keep.txt"), "stay")
+    File.write!(Path.join(add_dir, "existing.txt"), "here")
 
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
+    ctx = start_editor("")
 
-      send_keys_sync(ctx, "0C")
-      send_keys_sync(ctx, "new.txt<Esc>")
-      send_keys_sync(ctx, ":w<CR>")
+    open_dired(ctx, cancel_dir)
+    state = send_ex_sync(ctx, "w")
+    assert state.shell_state.status_msg =~ "No changes"
 
-      state = send_keys_sync(ctx, "y")
+    send_keys_sync(ctx, "ciwgone.txt<Esc>")
+    state = send_ex_sync(ctx, "w")
+    assert state.workspace.dired.confirming?
+    assert state.workspace.dired.pending_ops != []
+    assert state.shell_state.status_msg =~ "apply? (y/n)"
 
-      refute state.workspace.dired.confirming?
-      assert File.exists?(Path.join(dir, "new.txt"))
-      refute File.exists?(Path.join(dir, "old.txt"))
-      assert state.shell_state.status_msg =~ "Applied"
-    end
+    state = send_keys_sync(ctx, "n")
+    refute state.workspace.dired.confirming?
+    assert File.exists?(Path.join(cancel_dir, "keep.txt"))
+    refute File.exists?(Path.join(cancel_dir, "gone.txt"))
 
-    test "n cancels without applying", %{tmp_dir: dir} do
-      File.write!(Path.join(dir, "keep.txt"), "content")
+    open_dired(ctx, rename_dir)
+    send_keys_sync(ctx, "0C")
+    send_keys_sync(ctx, "new.txt<Esc>")
+    send_ex_sync(ctx, "w")
+    state = send_keys_sync(ctx, "y")
+    refute state.workspace.dired.confirming?
+    assert File.exists?(Path.join(rename_dir, "new.txt"))
+    refute File.exists?(Path.join(rename_dir, "old.txt"))
 
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
+    open_dired(ctx, delete_dir)
+    send_keys_sync(ctx, "dd")
+    send_ex_sync(ctx, "w")
+    state = send_keys_sync(ctx, "y")
+    refute state.workspace.dired.confirming?
+    assert Enum.count(File.ls!(delete_dir)) < 2
 
-      send_keys_sync(ctx, "ciwgone.txt<Esc>")
-      send_keys_sync(ctx, ":w<CR>")
-
-      state = send_keys_sync(ctx, "n")
-
-      refute state.workspace.dired.confirming?
-      assert File.exists?(Path.join(dir, "keep.txt"))
-      refute File.exists?(Path.join(dir, "gone.txt"))
-      assert state.shell_state.status_msg =~ "Cancelled"
-    end
-
-    test "y applies file deletion", %{tmp_dir: dir} do
-      File.write!(Path.join(dir, "delete_me.txt"), "gone")
-      File.write!(Path.join(dir, "keep.txt"), "stay")
-
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
-
-      send_keys_sync(ctx, "dd")
-      send_keys_sync(ctx, ":w<CR>")
-
-      state = send_keys_sync(ctx, "y")
-
-      refute state.workspace.dired.confirming?
-      files = File.ls!(dir)
-      assert Enum.count(files) < 2
-      assert state.shell_state.status_msg =~ "Applied"
-    end
-
-    test "y applies added file and directory entries", %{tmp_dir: dir} do
-      File.write!(Path.join(dir, "existing.txt"), "here")
-
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
-
-      BufferProcess.replace_content(active_buffer(ctx), "existing.txt\nnewfile.txt\nnewdir/")
-      send_keys_sync(ctx, ":w<CR>")
-
-      state = send_keys_sync(ctx, "y")
-
-      refute state.workspace.dired.confirming?
-      assert File.exists?(Path.join(dir, "newfile.txt"))
-      assert File.dir?(Path.join(dir, "newdir"))
-    end
+    open_dired(ctx, add_dir)
+    BufferProcess.replace_content(active_buffer(ctx), "existing.txt\nnewfile.txt\nnewdir/")
+    send_ex_sync(ctx, "w")
+    state = send_keys_sync(ctx, "y")
+    refute state.workspace.dired.confirming?
+    assert File.exists?(Path.join(add_dir, "newfile.txt"))
+    assert File.dir?(Path.join(add_dir, "newdir"))
   end
 
-  describe "[EditorCase integration] navigation" do
-    test "Enter on a directory navigates into it", %{tmp_dir: dir} do
-      subdir = Path.join(dir, "sub")
-      File.mkdir_p!(subdir)
-      File.write!(Path.join(subdir, "inner.txt"), "")
-      File.write!(Path.join(dir, "outer.txt"), "")
+  test "display toggles update the listing state", %{tmp_dir: dir} do
+    File.write!(Path.join(dir, ".hidden"), "")
+    File.write!(Path.join(dir, "visible.txt"), "")
+    File.write!(Path.join(dir, "z-small.txt"), "a")
+    File.write!(Path.join(dir, "a-big.txt"), String.duplicate("x", 1000))
 
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
+    ctx = start_editor("")
+    open_dired(ctx, dir)
+    refute active_content(ctx) =~ ".hidden"
 
-      send_keys_sync(ctx, "<CR>")
+    send_keys_sync(ctx, "g.")
+    assert active_content(ctx) =~ ".hidden"
 
-      content = active_content(ctx)
-      assert content =~ "inner.txt"
-    end
+    send_keys_sync(ctx, "gs")
+    lines = String.split(active_content(ctx), "\n", trim: true)
+    small_index = Enum.find_index(lines, &String.contains?(&1, "z-small.txt"))
+    big_index = Enum.find_index(lines, &String.contains?(&1, "a-big.txt"))
+    assert small_index < big_index
 
-    test "- navigates to parent directory", %{tmp_dir: dir} do
-      subdir = Path.join(dir, "child")
-      File.mkdir_p!(subdir)
-      File.write!(Path.join(subdir, "deep.txt"), "")
-      File.write!(Path.join(dir, "shallow.txt"), "")
+    send_keys_sync(ctx, "gd")
+    assert active_content(ctx) =~ "rw"
 
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{subdir}<CR>")
-
-      send_keys_sync(ctx, "-")
-
-      content = active_content(ctx)
-      assert content =~ "shallow.txt"
-      refute content =~ "deep.txt"
-    end
-
-    test "q closes dired and returns to editor scope", %{tmp_dir: dir} do
-      File.write!(Path.join(dir, "file.txt"), "")
-
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
-
-      send_keys_sync(ctx, "q")
-
-      refute active_content(ctx) =~ "file.txt"
-    end
+    refute active_content(ctx) =~ "added_later.txt"
+    File.write!(Path.join(dir, "added_later.txt"), "")
+    send_keys_sync(ctx, "gr")
+    assert active_content(ctx) =~ "added_later.txt"
   end
 
-  describe "[EditorCase integration] display toggles" do
-    test "update the listing state", %{tmp_dir: dir} do
-      File.write!(Path.join(dir, ".hidden"), "")
-      File.write!(Path.join(dir, "visible.txt"), "")
-      File.write!(Path.join(dir, "z-small.txt"), "a")
-      File.write!(Path.join(dir, "a-big.txt"), String.duplicate("x", 1000))
-
-      ctx = start_editor("")
-      send_keys_sync(ctx, ":dired #{dir}<CR>")
-      refute active_content(ctx) =~ ".hidden"
-
-      send_keys_sync(ctx, "g.")
-      assert active_content(ctx) =~ ".hidden"
-
-      send_keys_sync(ctx, "gs")
-      lines = String.split(active_content(ctx), "\n", trim: true)
-      small_index = Enum.find_index(lines, &String.contains?(&1, "z-small.txt"))
-      big_index = Enum.find_index(lines, &String.contains?(&1, "a-big.txt"))
-      assert small_index < big_index
-
-      send_keys_sync(ctx, "gd")
-      assert active_content(ctx) =~ "rw"
-
-      refute active_content(ctx) =~ "added_later.txt"
-      File.write!(Path.join(dir, "added_later.txt"), "")
-      send_keys_sync(ctx, "gr")
-      assert active_content(ctx) =~ "added_later.txt"
-    end
+  defp open_dired(ctx, path) do
+    send_ex_sync(ctx, "dired #{path}")
   end
 end

--- a/test/minga_editor/highlight_integration_test.exs
+++ b/test/minga_editor/highlight_integration_test.exs
@@ -20,7 +20,7 @@ defmodule MingaEditor.HighlightIntegrationTest do
       ctx = start_editor("defmodule A do\nend\n", file_path: path1)
       inject_highlights(ctx, ["keyword"], 1, [%{start_byte: 0, end_byte: 9, capture_id: 0}])
 
-      state = send_keys_sync(ctx, ":e #{path2}<CR>")
+      state = send_ex_sync(ctx, "e #{path2}")
 
       assert HighlightSync.get_active_highlight(state).spans == {}
     end
@@ -36,8 +36,8 @@ defmodule MingaEditor.HighlightIntegrationTest do
       spans = [%{start_byte: 0, end_byte: 9, capture_id: 0}]
       inject_highlights(ctx, ["keyword"], 1, spans)
 
-      send_keys_sync(ctx, ":e #{path2}<CR>")
-      state = send_keys_sync(ctx, ":e #{path1}<CR>")
+      send_ex_sync(ctx, "e #{path2}")
+      state = send_ex_sync(ctx, "e #{path1}")
 
       assert HighlightSync.get_active_highlight(state).spans == List.to_tuple(spans)
     end
@@ -51,26 +51,6 @@ defmodule MingaEditor.HighlightIntegrationTest do
       send_keys_sync(ctx, "dd")
 
       assert buffer_content(ctx) == "line two\nline three"
-    end
-
-    test "insert-mode edits remain usable while highlights are active" do
-      ctx = start_editor("hello")
-      inject_highlights(ctx, ["keyword"], 1, [%{start_byte: 0, end_byte: 5, capture_id: 0}])
-
-      send_key_sync(ctx, ?i)
-      send_key_sync(ctx, ?a)
-
-      assert buffer_content(ctx) == "ahello"
-    end
-
-    @tag :tmp_dir
-    test "unsupported filetype renders without crash", %{tmp_dir: tmp_dir} do
-      path = Path.join(tmp_dir, "test.xyz")
-      File.write!(path, "just plain text")
-
-      ctx = start_editor("just plain text", file_path: path)
-
-      assert_row_contains(ctx, 1, "just plain text")
     end
   end
 end

--- a/test/minga_editor/integration/gui_protocol_action_test.exs
+++ b/test/minga_editor/integration/gui_protocol_action_test.exs
@@ -1,0 +1,39 @@
+defmodule Minga.Integration.GUIProtocolActionTest do
+  @moduledoc false
+
+  # async: false: owns the opt-in Swift harness that emits a synthetic gui_action.
+  use ExUnit.Case, async: false
+
+  alias Minga.Test.GUIHarness
+  alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
+
+  @harness_path Path.join(:code.priv_dir(:minga), "minga-test-harness")
+
+  @moduletag :swift_harness
+
+  setup_all do
+    unless File.exists?(@harness_path) do
+      flunk("Test harness not found at #{@harness_path}. Run: mix swift.harness")
+    end
+
+    {:ok, harness} = start_supervised({GUIHarness, path: @harness_path, emit_select_tab: true})
+    %{harness: harness}
+  end
+
+  test "tab bar triggers an opted-in harness select_tab gui_action", %{harness: harness} do
+    tab1 = %MingaEditor.State.Tab{id: 1, kind: :file, label: "main.ex"}
+    tab2 = %MingaEditor.State.Tab{id: 2, kind: :file, label: "test.ex"}
+    tab_bar = %MingaEditor.State.TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
+
+    {decoded, action} =
+      GUIHarness.round_trip_with_action!(
+        harness,
+        ProtocolGUI.encode_gui_tab_bar(tab_bar),
+        "gui_tab_bar",
+        {:gui_action, {:select_tab, 2}}
+      )
+
+    assert Enum.count(decoded["tabs"]) == 2
+    assert action == {:gui_action, {:select_tab, 2}}
+  end
+end

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -19,6 +19,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   alias Minga.RenderModel.UI.AgentChat.ToolCallView
   alias Minga.RenderModel.UI.Completion
   alias Minga.RenderModel.UI.Picker, as: PickerModel
+  alias Minga.Test.GUIHarness
   alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
   alias MingaEditor.RenderModel.UI.BreadcrumbBuilder
 
@@ -26,30 +27,17 @@ defmodule Minga.Integration.GUIProtocolTest do
 
   @moduletag :swift_harness
 
-  setup do
+  setup_all do
     unless File.exists?(@harness_path) do
       flunk("Test harness not found at #{@harness_path}. Run: mix swift.harness")
     end
 
-    port = Port.open({:spawn_executable, @harness_path}, [:binary, {:packet, 4}])
-
-    # Wait for the ready signal from the harness.
-    assert_receive {^port, {:data, ready_json}}, 5_000
-    assert %{"type" => "ready"} = JSON.decode!(ready_json)
-
-    on_exit(fn ->
-      if Port.info(port) != nil do
-        Port.close(port)
-      end
-    end)
-
-    %{port: port}
+    {:ok, harness} = start_supervised({GUIHarness, path: @harness_path})
+    %{harness: harness}
   end
 
-  defp round_trip(port, command) do
-    Port.command(port, command)
-    assert_receive {^port, {:data, json}}, 5_000
-    JSON.decode!(json)
+  defp round_trip(harness, command, expected_type) do
+    GUIHarness.round_trip!(harness, command, expected_type)
   end
 
   # Encodes an agent chat through the core semantic encoder, accepting the legacy
@@ -82,13 +70,11 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "GUI chrome opcode round-trip" do
-    test "gui_theme encodes and decodes correctly", %{port: port} do
+    test "gui_theme encodes and decodes correctly", %{harness: harness} do
       theme = MingaEditor.UI.Theme.get!(:doom_one)
       cmd = ProtocolGUI.encode_gui_theme(theme)
 
-      Port.command(port, cmd)
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_theme")
 
       assert decoded["type"] == "gui_theme"
       assert is_list(decoded["slots"])
@@ -102,16 +88,13 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert is_integer(editor_bg_slot["b"])
     end
 
-    test "gui_tab_bar encodes and decodes correctly", %{port: port} do
+    test "gui_tab_bar encodes and decodes correctly", %{harness: harness} do
       tab1 = %MingaEditor.State.Tab{id: 1, kind: :file, label: "editor.ex"}
       tab2 = %MingaEditor.State.Tab{id: 2, kind: :agent, label: "Agent", agent_status: :thinking}
       tb = %MingaEditor.State.TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
 
       cmd = ProtocolGUI.encode_gui_tab_bar(tb)
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_tab_bar")
 
       assert decoded["type"] == "gui_tab_bar"
       assert decoded["active_index"] == 0
@@ -124,21 +107,19 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert t1["is_agent"] == false
     end
 
-    test "gui_breadcrumb encodes and decodes correctly", %{port: port} do
+    test "gui_breadcrumb encodes and decodes correctly", %{harness: harness} do
       model =
         BreadcrumbBuilder.build("/home/user/project/lib/foo.ex", "/home/user/project")
 
       {cmd, _caches} = BreadcrumbEncoder.encode(model, Caches.new())
 
-      Port.command(port, cmd)
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_breadcrumb")
 
       assert decoded["type"] == "gui_breadcrumb"
       assert decoded["segments"] == ["lib", "foo.ex"]
     end
 
-    test "gui_status_bar buffer variant encodes and decodes correctly", %{port: port} do
+    test "gui_status_bar buffer variant encodes and decodes correctly", %{harness: harness} do
       data =
         {:buffer,
          %{
@@ -174,9 +155,7 @@ defmodule Minga.Integration.GUIProtocolTest do
          }}
 
       cmd = ProtocolGUI.encode_gui_status_bar(data)
-      Port.command(port, cmd)
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_status_bar")
 
       assert decoded["type"] == "gui_status_bar"
       # content_kind 0 = buffer
@@ -215,7 +194,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert decoded["selection_size"] == 42
     end
 
-    test "gui_status_bar agent variant encodes and decodes correctly", %{port: port} do
+    test "gui_status_bar agent variant encodes and decodes correctly", %{harness: harness} do
       data =
         {:agent,
          %{
@@ -251,9 +230,7 @@ defmodule Minga.Integration.GUIProtocolTest do
          }}
 
       cmd = ProtocolGUI.encode_gui_status_bar(data)
-      Port.command(port, cmd)
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_status_bar")
 
       assert decoded["type"] == "gui_status_bar"
       # content_kind 1 = agent
@@ -283,7 +260,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert decoded["selection_size"] == 3
     end
 
-    test "gui_agent_chat visible with messages", %{port: port} do
+    test "gui_agent_chat visible with messages", %{harness: harness} do
       data = %{
         visible: true,
         messages: [{:user, "hello"}, {:assistant, "hi there"}],
@@ -294,9 +271,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       }
 
       cmd = encode_gui_agent_chat(data)
-      Port.command(port, cmd)
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_agent_chat")
 
       assert decoded["type"] == "gui_agent_chat"
       assert decoded["visible"] == true
@@ -311,7 +286,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert msg2["text"] == "hi there"
     end
 
-    test "gui_agent_chat with styled_tool_call round-trips", %{port: port} do
+    test "gui_agent_chat with styled_tool_call round-trips", %{harness: harness} do
       tc = %ToolCallView{
         name: "bash",
         status: :complete,
@@ -337,9 +312,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       }
 
       cmd = encode_gui_agent_chat(data)
-      Port.command(port, cmd)
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_agent_chat")
 
       assert decoded["type"] == "gui_agent_chat"
       assert decoded["visible"] == true
@@ -363,7 +336,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert run2["bold"] == false
     end
 
-    test "gui_agent_chat with regular tool_call round-trips", %{port: port} do
+    test "gui_agent_chat with regular tool_call round-trips", %{harness: harness} do
       tc = %ToolCallView{
         name: "read_file",
         status: :running,
@@ -384,9 +357,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       }
 
       cmd = encode_gui_agent_chat(data)
-      Port.command(port, cmd)
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_agent_chat")
 
       assert decoded["type"] == "gui_agent_chat"
       assert Enum.count(decoded["messages"]) == 1
@@ -399,7 +370,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert msg["result"] == "file content here"
     end
 
-    test "gui_agent_chat with help overlay round-trips", %{port: port} do
+    test "gui_agent_chat with help overlay round-trips", %{harness: harness} do
       data = %{
         visible: true,
         messages: [],
@@ -415,9 +386,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       }
 
       cmd = encode_gui_agent_chat(data)
-      Port.command(port, cmd)
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_agent_chat")
 
       assert decoded["type"] == "gui_agent_chat"
       assert decoded["help_visible"] == true
@@ -438,7 +407,9 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert hd(copy["bindings"])["key"] == "y"
     end
 
-    test "gui_agent_chat without help data round-trips with help_visible=false", %{port: port} do
+    test "gui_agent_chat without help data round-trips with help_visible=false", %{
+      harness: harness
+    } do
       data = %{
         visible: true,
         messages: [],
@@ -449,9 +420,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       }
 
       cmd = encode_gui_agent_chat(data)
-      Port.command(port, cmd)
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_agent_chat")
 
       assert decoded["type"] == "gui_agent_chat"
       assert decoded["help_visible"] == false
@@ -459,48 +428,10 @@ defmodule Minga.Integration.GUIProtocolTest do
     end
   end
 
-  describe "round-trip: BEAM encode → harness decode → harness sends gui_action → BEAM receives" do
-    test "tab bar triggers harness to send select_tab gui_action back", %{port: port} do
-      alias MingaEditor.Frontend.Protocol
-
-      # and automatically send a gui_action select_tab for the second tab.
-      tab1 = %MingaEditor.State.Tab{id: 1, kind: :file, label: "main.ex"}
-      tab2 = %MingaEditor.State.Tab{id: 2, kind: :file, label: "test.ex"}
-      tb = %MingaEditor.State.TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
-
-      cmd = ProtocolGUI.encode_gui_tab_bar(tb)
-      Port.command(port, cmd)
-
-      # (a) The JSON report of the decoded gui_tab_bar
-      # (b) The raw gui_action binary (select_tab for tab id=2)
-      # Order may vary, so collect both.
-      messages =
-        Enum.map(1..2, fn _ ->
-          assert_receive {^port, {:data, data}}, 5_000
-          data
-        end)
-
-      # Find the JSON report.
-      json_msg = Enum.find(messages, fn d -> String.starts_with?(d, "{") end)
-      assert json_msg != nil
-      tab_decoded = JSON.decode!(json_msg)
-      assert tab_decoded["type"] == "gui_tab_bar"
-      assert Enum.count(tab_decoded["tabs"]) == 2
-
-      # Find the gui_action binary and decode it on the BEAM side.
-      action_msg = Enum.find(messages, fn d -> not String.starts_with?(d, "{") end)
-      assert action_msg != nil
-      assert {:ok, {:gui_action, {:select_tab, 2}}} = Protocol.decode_event(action_msg)
-    end
-  end
-
   describe "gui_gutter_separator" do
-    test "round-trips gutter separator col and color", %{port: port} do
+    test "round-trips gutter separator col and color", %{harness: harness} do
       cmd = <<Opcodes.gui_gutter_sep(), 4::16, 0x3F, 0x44, 0x4A>>
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_gutter_separator")
 
       assert decoded["type"] == "gui_gutter_separator"
       assert decoded["col"] == 4
@@ -511,7 +442,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "hidden GUI chrome commands" do
-    test "round-trip visible false for hidden overlays", %{port: port} do
+    test "round-trip visible false for hidden overlays", %{harness: harness} do
       alias Minga.Frontend.Adapter.GUI.BottomPanelEncoder
       alias Minga.Frontend.Adapter.GUI.Caches
       alias Minga.RenderModel.UI.BottomPanel
@@ -529,7 +460,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       ]
 
       for {type, command} <- cases do
-        decoded = round_trip(port, command)
+        decoded = round_trip(harness, command, type)
 
         assert decoded["type"] == type
         assert decoded["visible"] == false
@@ -538,7 +469,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_gutter" do
-    test "round-trips gutter with entries", %{port: port} do
+    test "round-trips gutter with entries", %{harness: harness} do
       alias Minga.RenderModel.Window
       alias Minga.RenderModel.Window.Gutter
       alias Minga.RenderModel.Window.GutterEntry
@@ -575,10 +506,7 @@ defmodule Minga.Integration.GUIProtocolTest do
           opcode == Opcodes.gui_gutter()
         end)
 
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_gutter")
 
       assert decoded["type"] == "gui_gutter"
       assert decoded["window_id"] == 1
@@ -604,7 +532,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_completion visible" do
-    test "round-trips visible completion with items", %{port: port} do
+    test "round-trips visible completion with items", %{harness: harness} do
       comp = %Minga.Editing.Completion{
         items: [],
         filtered: [
@@ -659,10 +587,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       }
 
       cmd = CompletionEncoder.encode_command(model)
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_completion")
 
       assert decoded["type"] == "gui_completion"
       assert decoded["visible"] == true
@@ -676,7 +601,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_which_key visible" do
-    test "round-trips visible which-key with bindings", %{port: port} do
+    test "round-trips visible which-key with bindings", %{harness: harness} do
       # Build raw binary: visible=1, prefix="SPC", page=0, pageCount=2, 2 bindings
       prefix = "SPC"
 
@@ -690,10 +615,7 @@ defmodule Minga.Integration.GUIProtocolTest do
         <<0x72, 1::8, byte_size(prefix)::16, prefix::binary, 0::8, 2::8, 2::16, binding1::binary,
           binding2::binary>>
 
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_which_key")
 
       assert decoded["type"] == "gui_which_key"
       assert decoded["visible"] == true
@@ -713,7 +635,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_picker visible" do
-    test "round-trips visible picker with items", %{port: port} do
+    test "round-trips visible picker with items", %{harness: harness} do
       # The production PickerBuilder normalizes a filtered legacy picker into
       # this wire-shaped RenderModel.UI.Picker (flags packed: marked => bit 1 =>
       # 2; query "edi" re-derives match_positions [0, 1, 2] against "editor.ex").
@@ -743,10 +665,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       }
 
       cmd = PickerEncoder.encode_command(model)
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_picker")
 
       assert decoded["type"] == "gui_picker"
       assert decoded["visible"] == true
@@ -766,7 +685,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_picker_preview visible" do
-    test "round-trips visible preview with styled lines", %{port: port} do
+    test "round-trips visible preview with styled lines", %{harness: harness} do
       # Line 1: 2 segments
       seg1 = <<0x51, 0xAF, 0xEF, 0x01, 4::16, "def "::binary>>
       seg2 = <<0xEC, 0xBE, 0x7B, 0x00, 5::16, "hello"::binary>>
@@ -776,10 +695,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       cmd =
         <<0x7D, 1::8, 2::16, 2::8, seg1::binary, seg2::binary, 1::8, seg3::binary>>
 
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_picker_preview")
 
       assert decoded["type"] == "gui_picker_preview"
       assert decoded["visible"] == true
@@ -796,7 +712,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_bottom_panel visible" do
-    test "round-trips visible bottom panel with tabs and entries", %{port: port} do
+    test "round-trips visible bottom panel with tabs and entries", %{harness: harness} do
       # Tab: type=0 (messages), name="Messages"
       tab = <<0::8, 8::8, "Messages"::binary>>
 
@@ -812,10 +728,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       cmd =
         <<0x7C, 1::8, 0::8, 30::8, 0::8, 1::8, tab::binary, 7::32, 1::16, entry::binary>>
 
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_bottom_panel")
 
       assert decoded["type"] == "gui_bottom_panel"
       assert decoded["visible"] == true
@@ -833,7 +746,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_tool_manager visible" do
-    test "round-trips visible tool manager with tools", %{port: port} do
+    test "round-trips visible tool manager with tools", %{harness: harness} do
       # Tool: name_len(1)+name, label_len(1)+label, desc_len(2)+desc,
       #       category(1)+status(1)+method(1)+lang_count(1),
       #       lang_len(1)+lang, version_len(1)+version,
@@ -855,10 +768,7 @@ defmodule Minga.Integration.GUIProtocolTest do
 
       cmd = <<0x7E, 1::8, 0::8, 0::16, 1::16, tool::binary>>
 
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_tool_manager")
 
       assert decoded["type"] == "gui_tool_manager"
       assert decoded["visible"] == true
@@ -877,7 +787,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert t["provides"] == ["elixir-ls"]
     end
 
-    test "round-trips failed tool with error reason", %{port: port} do
+    test "round-trips failed tool with error reason", %{harness: harness} do
       error = "No matching asset for darwin_arm64"
 
       tool =
@@ -885,18 +795,14 @@ defmodule Minga.Integration.GUIProtocolTest do
           0::8, 0::8, ""::binary, 0::16, ""::binary, 0::8, byte_size(error)::16, error::binary>>
 
       cmd = <<0x7E, 1::8, 0::8, 0::16, 1::16, tool::binary>>
-
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_tool_manager")
 
       t = hd(decoded["tools"])
       assert t["status"] == 4
       assert t["error_reason"] == "No matching asset for darwin_arm64"
     end
 
-    test "encodes failed tool error_reason through Elixir encoder", %{port: port} do
+    test "encodes failed tool error_reason through Elixir encoder", %{harness: harness} do
       tool = %{
         name: :pyrite,
         label: "Pyrite",
@@ -919,10 +825,7 @@ defmodule Minga.Integration.GUIProtocolTest do
           tools: [tool]
         })
 
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_tool_manager")
 
       t = hd(decoded["tools"])
       assert t["status"] == 4
@@ -931,7 +834,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_file_tree visible" do
-    test "round-trips semantic visible file tree with entries", %{port: port} do
+    test "round-trips semantic visible file tree with entries", %{harness: harness} do
       root = "/project"
 
       rows = [
@@ -971,10 +874,12 @@ defmodule Minga.Integration.GUIProtocolTest do
         )
       ]
 
-      Port.command(port, ProtocolGUI.encode_gui_file_tree(root, 30, :ready, true, rows))
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded =
+        round_trip(
+          harness,
+          ProtocolGUI.encode_gui_file_tree(root, 30, :ready, true, rows),
+          "gui_file_tree"
+        )
 
       assert decoded["type"] == "gui_file_tree"
       assert decoded["version"] == 2
@@ -1011,8 +916,13 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_cursorline" do
-    test "round-trips visible and hidden cursorline states", %{port: port} do
-      decoded = round_trip(port, <<Opcodes.gui_cursorline(), 12::16, 0x2C, 0x32, 0x3C>>)
+    test "round-trips visible and hidden cursorline states", %{harness: harness} do
+      decoded =
+        round_trip(
+          harness,
+          <<Opcodes.gui_cursorline(), 12::16, 0x2C, 0x32, 0x3C>>,
+          "gui_cursorline"
+        )
 
       assert decoded["type"] == "gui_cursorline"
       assert decoded["row"] == 12
@@ -1020,7 +930,8 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert decoded["g"] == 0x32
       assert decoded["b"] == 0x3C
 
-      decoded = round_trip(port, <<Opcodes.gui_cursorline(), 0xFFFF::16, 0, 0, 0>>)
+      decoded =
+        round_trip(harness, <<Opcodes.gui_cursorline(), 0xFFFF::16, 0, 0, 0>>, "gui_cursorline")
 
       assert decoded["type"] == "gui_cursorline"
       assert decoded["row"] == 0xFFFF
@@ -1031,7 +942,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_window_content" do
-    test "round-trips window content with rows, selection, and diagnostics", %{port: port} do
+    test "round-trips window content with rows, selection, and diagnostics", %{harness: harness} do
       alias Minga.RenderModel.Window
       alias Minga.RenderModel.Window.{DiagnosticRange, Row, Selection, Span}
 
@@ -1077,10 +988,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       }
 
       cmd = WindowEncoder.encode_window_content(sw)
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_window_content")
 
       assert decoded["type"] == "gui_window_content"
       assert decoded["window_id"] == 7
@@ -1107,23 +1015,23 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert decoded["diagnostic_count"] == 1
     end
 
-    test "round-trips a large full row through the viewport delta", %{port: port} do
+    test "round-trips a large full row through the viewport delta", %{harness: harness} do
       assert_large_delta_row_round_trip(
-        port,
+        harness,
         &WindowEncoder.encode_viewport_delta/2,
         "gui_window_viewport_delta"
       )
     end
 
-    test "round-trips a large full row through the rows delta", %{port: port} do
+    test "round-trips a large full row through the rows delta", %{harness: harness} do
       assert_large_delta_row_round_trip(
-        port,
+        harness,
         &WindowEncoder.encode_rows_delta/2,
         "gui_window_rows_delta"
       )
     end
 
-    test "round-trips rows delta with ref and full entries", %{port: port} do
+    test "round-trips rows delta with ref and full entries", %{harness: harness} do
       alias Minga.RenderModel.Window
       alias Minga.RenderModel.Window.Row
 
@@ -1161,10 +1069,7 @@ defmodule Minga.Integration.GUIProtocolTest do
       {cmd, true} =
         WindowEncoder.encode_rows_delta(window, %{retained.row_id => retained.content_hash})
 
-      Port.command(port, cmd)
-
-      assert_receive {^port, {:data, json}}, 5_000
-      decoded = JSON.decode!(json)
+      decoded = round_trip(harness, cmd, "gui_window_rows_delta")
 
       assert decoded["type"] == "gui_window_rows_delta"
       assert decoded["window_id"] == 7
@@ -1180,11 +1085,11 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   @spec assert_large_delta_row_round_trip(
-          port(),
+          GenServer.server(),
           (Minga.RenderModel.Window.t(), map() -> {binary(), boolean()}),
           String.t()
         ) :: :ok
-  defp assert_large_delta_row_round_trip(port, encode_delta, expected_type) do
+  defp assert_large_delta_row_round_trip(harness, encode_delta, expected_type) do
     alias Minga.RenderModel.Window
     alias Minga.RenderModel.Window.Row
 
@@ -1222,7 +1127,7 @@ defmodule Minga.Integration.GUIProtocolTest do
     assert byte_size(rows_payload) > 65_535
     assert row_text == text
 
-    decoded = round_trip(port, command)
+    decoded = round_trip(harness, command, expected_type)
     assert decoded["type"] == expected_type
     assert [%{"entry_type" => "full", "text" => ^text}] = decoded["rows"]
     :ok

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -390,6 +390,29 @@ defmodule Minga.Test.EditorCase do
   end
 
   @doc """
+  Sends an ex command with a single editor barrier after the final Enter.
+
+  This is intentionally narrower than `send_keys_sync/2`: command-mode text is
+  processed in one mailbox order, so tests that assert editor state do not need
+  a render barrier for every character. Use `send_keys_sync/2` for arbitrary
+  Vim key sequences, where each key may trigger deferred routing.
+  """
+  @spec send_ex_sync(editor_ctx(), String.t()) :: map()
+  def send_ex_sync(%{editor: editor, port: port}, command) do
+    ":#{command}<CR>"
+    |> parse_key_sequence()
+    |> Enum.each(fn {codepoint, mods} ->
+      send(editor, {:minga_input, {:key_press, codepoint, mods}})
+    end)
+
+    # A normal GenServer call preserves mailbox order with the submitted input.
+    # The later system-state read can then safely observe the completed command.
+    sync_editor(editor)
+    Process.delete({:last_frame_snapshot, port})
+    get_editor_state(editor)
+  end
+
+  @doc """
   Sends a vim-style key sequence. Supports:
   - `<Esc>` — escape (27)
   - `<CR>` or `<Enter>` — enter (13)

--- a/test/support/gui_harness.ex
+++ b/test/support/gui_harness.ex
@@ -1,0 +1,214 @@
+defmodule Minga.Test.GUIHarness do
+  @moduledoc false
+
+  use GenServer
+
+  alias MingaEditor.Frontend.Protocol
+
+  @type response :: map()
+  @type gui_action :: {:gui_action, term()}
+  @type option :: {:path, String.t()} | {:emit_select_tab, boolean()}
+
+  @default_timeout 5_000
+
+  @spec start_link([option()]) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @spec round_trip!(GenServer.server(), binary(), String.t()) :: response()
+  def round_trip!(server, command, expected_type) do
+    call!(server, {:round_trip, command, expected_type}, expected_type)
+  end
+
+  @spec round_trip_with_action!(GenServer.server(), binary(), String.t(), gui_action()) ::
+          {response(), gui_action()}
+  def round_trip_with_action!(server, command, expected_type, expected_action) do
+    call!(
+      server,
+      {:round_trip_with_action, command, expected_type, expected_action},
+      expected_type
+    )
+  end
+
+  @impl GenServer
+  @spec init([option()]) :: {:ok, map()}
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    path = Keyword.fetch!(opts, :path)
+    emit_select_tab = Keyword.get(opts, :emit_select_tab, false)
+    port = open_port(path, emit_select_tab)
+    await_ready(port)
+
+    {:ok, %{path: path, emit_select_tab: emit_select_tab, port: port, pending: nil}}
+  end
+
+  @impl GenServer
+  @spec handle_call(tuple(), GenServer.from(), map()) ::
+          {:noreply, map()} | {:reply, term(), map()}
+  def handle_call({:round_trip, command, expected_type}, from, %{pending: nil} = state) do
+    send_command(state.port, command)
+
+    {:noreply,
+     %{
+       state
+       | pending: %{
+           from: from,
+           expected_type: expected_type,
+           expected_action: nil,
+           action: nil,
+           response: nil
+         }
+     }}
+  end
+
+  def handle_call(
+        {:round_trip_with_action, command, expected_type, expected_action},
+        from,
+        %{pending: nil} = state
+      ) do
+    send_command(state.port, command)
+
+    {:noreply,
+     %{
+       state
+       | pending: %{
+           from: from,
+           expected_type: expected_type,
+           expected_action: expected_action,
+           action: nil,
+           response: nil
+         }
+     }}
+  end
+
+  def handle_call(_request, _from, state) do
+    {:reply, {:error, :request_in_flight}, state}
+  end
+
+  @impl GenServer
+  @spec handle_info(term(), map()) :: {:noreply, map()}
+  def handle_info({port, {:data, data}}, %{port: port, pending: pending} = state)
+      when not is_nil(pending) do
+    handle_response(data, state)
+  end
+
+  def handle_info({port, {:data, data}}, %{port: port} = state) do
+    {:noreply, restart_tainted_harness({:unexpected_response, data}, state)}
+  end
+
+  def handle_info({:EXIT, port, reason}, %{port: port} = state) do
+    {:noreply, restart_tainted_harness({:harness_exited, reason}, state)}
+  end
+
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
+  @spec call!(GenServer.server(), tuple(), String.t()) :: response() | {response(), gui_action()}
+  defp call!(server, request, expected_type) do
+    case GenServer.call(server, request, @default_timeout) do
+      {:ok, result} ->
+        result
+
+      {:error, reason} ->
+        raise "GUI harness expected #{expected_type}, received #{inspect(reason)}"
+    end
+  end
+
+  @spec handle_response(binary(), map()) :: {:noreply, map()}
+  defp handle_response(data, %{pending: %{expected_type: expected_type} = pending} = state) do
+    case JSON.decode(data) do
+      {:ok, %{"type" => ^expected_type} = response} ->
+        finish_response(response, pending, state)
+
+      {:ok, %{"type" => type}} ->
+        reject_response({:unexpected_response_type, type, expected_type}, state)
+
+      {:ok, response} ->
+        reject_response({:response_missing_type, response}, state)
+
+      {:error, _reason} ->
+        handle_action(data, pending, state)
+    end
+  end
+
+  @spec handle_action(binary(), map(), map()) :: {:noreply, map()}
+  defp handle_action(data, %{expected_action: nil}, state) do
+    reject_response({:unexpected_binary_response, data}, state)
+  end
+
+  defp handle_action(data, %{expected_action: expected_action} = pending, state) do
+    case Protocol.decode_event(data) do
+      {:ok, ^expected_action} -> finish_response(nil, %{pending | action: expected_action}, state)
+      other -> reject_response({:unexpected_gui_action, other, expected_action}, state)
+    end
+  end
+
+  @spec finish_response(response() | nil, map(), map()) :: {:noreply, map()}
+  defp finish_response(response, pending, state) do
+    response = response || pending.response
+    pending = if is_map(response), do: %{pending | response: response}, else: pending
+
+    if is_map(pending.response) and
+         (is_nil(pending.expected_action) or pending.action == pending.expected_action) do
+      result =
+        if is_nil(pending.expected_action),
+          do: pending.response,
+          else: {pending.response, pending.action}
+
+      GenServer.reply(pending.from, {:ok, result})
+      {:noreply, %{state | pending: nil}}
+    else
+      {:noreply, %{state | pending: pending}}
+    end
+  end
+
+  @spec reject_response(term(), map()) :: {:noreply, map()}
+  defp reject_response(reason, %{pending: %{from: from}} = state) do
+    GenServer.reply(from, {:error, reason})
+    {:noreply, restart_tainted_harness(reason, %{state | pending: nil})}
+  end
+
+  @spec restart_tainted_harness(term(), map()) :: map()
+  defp restart_tainted_harness(_reason, state) do
+    close_port(state.port)
+    port = open_port(state.path, state.emit_select_tab)
+    await_ready(port)
+    %{state | port: port, pending: nil}
+  end
+
+  @spec open_port(String.t(), boolean()) :: port()
+  defp open_port(path, emit_select_tab) do
+    args = if emit_select_tab, do: [{:args, [~c"--emit-select-tab"]}], else: []
+    Port.open({:spawn_executable, path}, [:binary, {:packet, 4} | args])
+  end
+
+  @spec await_ready(port()) :: :ok
+  defp await_ready(port) do
+    receive do
+      {^port, {:data, ready_json}} ->
+        case JSON.decode(ready_json) do
+          {:ok, %{"type" => "ready"}} -> :ok
+          other -> raise "GUI harness did not send ready: #{inspect(other)}"
+        end
+    after
+      @default_timeout -> raise "GUI harness did not become ready"
+    end
+  end
+
+  @spec send_command(port(), binary()) :: :ok
+  defp send_command(port, command) do
+    true = Port.command(port, command)
+    :ok
+  end
+
+  @spec close_port(port()) :: :ok
+  defp close_port(port) do
+    if Port.info(port) != nil do
+      Port.close(port)
+    end
+
+    :ok
+  end
+end


### PR DESCRIPTION
# TL;DR

Makes the edit-loop GUI protocol test deterministic and reduces repeated EditorCase setup without removing real Swift wire or filesystem routing coverage.

## Changes

- Keeps the Swift harness quiet by default, with synthetic tab selection enabled only for its dedicated bidirectional protocol test.
- Adds a driver-owned harness per serial protocol test module. The driver validates each expected response type, matches the opt-in GUI action, and recreates a harness after an unexpected response.
- Adds `send_ex_sync/2`, which submits an Ex command and uses one ordered editor barrier instead of a render wait per character.
- Consolidates buffer and Dired EditorCase cases while retaining command routing, real filesystem mutations, navigation, confirmation, and display-state coverage.
- Leaves highlight integration focused on file-switch lifecycle and one editing smoke. The existing HighlightSync and handler suites cover state-only behavior.

## Verification

- `mix swift.harness`
- `mix test.llm` (9885 tests, 0 failures)
- `make lint`
- `mix swift.build`
- `xcodebuild -project macos/Minga.xcodeproj -scheme Minga -destination "platform=macOS" test` (1050 tests)

## Review notes

The real external process suites, including native provider, LSP, Zig, shell, parser, Git, and ProjectView coverage, remain unchanged and stay outside this edit-loop reduction.