### PR TITLE
test(editor): add input-only harness mode

### DIFF
--- a/lib/minga_editor/input/router.ex
+++ b/lib/minga_editor/input/router.ex
@@ -325,6 +325,10 @@ defmodule MingaEditor.Input.Router do
   # shortcut is only taken when nothing else can be writing the port concurrently:
   # either there is no async renderer (sync/headless paths), or the renderer is idle.
   @spec emit_operator_pending_frame(EditorState.t()) :: EditorState.t()
+  defp emit_operator_pending_frame(%EditorState{rendering: :disabled} = state) do
+    MingaEditor.do_render(state)
+  end
+
   defp emit_operator_pending_frame(state) do
     if async_renderer_busy?(state) do
       MingaEditor.do_render(state)

--- a/lib/minga_editor/renderer.ex
+++ b/lib/minga_editor/renderer.ex
@@ -40,6 +40,8 @@ defmodule MingaEditor.Renderer do
   returned state for the optimization to work.
   """
   @spec render(state()) :: state()
+  def render(%EditorState{rendering: :disabled} = state), do: state
+
   def render(state) do
     state = EditorState.ensure_shell_available(state)
     EditorState.active_shell_module(state).render(state)
@@ -55,6 +57,7 @@ defmodule MingaEditor.Renderer do
   or when the active shell cannot use the async RenderPipeline path.
   """
   @spec render_or_async(state()) :: state()
+  def render_or_async(%EditorState{rendering: :disabled} = state), do: state
   def render_or_async(%{backend: :headless} = state), do: render(state)
 
   def render_or_async(%{renderer: pid} = state) when is_pid(pid) do

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -71,6 +71,7 @@ defmodule MingaEditor.Startup do
   @spec build_initial_state(keyword()) :: EditorState.t()
   def build_initial_state(opts) do
     backend = Keyword.get(opts, :backend, :headless)
+    rendering = rendering_policy(opts)
     port_manager = Keyword.get(opts, :port_manager, MingaEditor.Frontend.Manager)
     keymap_server = Keyword.get(opts, :keymap_server, Minga.Keymap.default_server())
     events_registry = Keyword.get(opts, :events_registry, Minga.Events.default_registry())
@@ -166,6 +167,7 @@ defmodule MingaEditor.Startup do
 
     state = %EditorState{
       backend: backend,
+      rendering: rendering,
       workspace: workspace,
       port_manager: port_manager,
       agent_provider_module: Keyword.get(opts, :agent_provider_module),
@@ -203,6 +205,21 @@ defmodule MingaEditor.Startup do
     current_tb = EditorState.tab_bar(state)
     tb = TabBar.update_context(current_tb, current_tb.active_id, context)
     EditorState.set_tab_bar(state, tb)
+  end
+
+  @spec rendering_policy(keyword()) :: EditorState.rendering_policy()
+  defp rendering_policy(opts) do
+    opts
+    |> Keyword.get(:rendering, :enabled)
+    |> validate_rendering_policy()
+  end
+
+  @spec validate_rendering_policy(term()) :: EditorState.rendering_policy()
+  defp validate_rendering_policy(policy) when policy in [:enabled, :disabled], do: policy
+
+  defp validate_rendering_policy(policy) do
+    raise ArgumentError,
+          "expected :rendering to be :enabled or :disabled, got: #{inspect(policy)}"
   end
 
   @spec log_safe_mode_startup() :: :ok

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -98,6 +98,7 @@ defmodule MingaEditor.State do
 
   @enforce_keys [:port_manager, :workspace]
   defstruct backend: :headless,
+            rendering: :enabled,
             port_manager: nil,
             renderer: nil,
             agent_ingest: nil,
@@ -164,6 +165,7 @@ defmodule MingaEditor.State do
             session_started?: false
 
   @type backend :: :tui | :gui | :native_gui | :headless
+  @type rendering_policy :: :enabled | :disabled
 
   @typedoc """
   Per-lane serial gate for `MingaEditor.AsyncAction`: the in-flight operation's
@@ -178,6 +180,7 @@ defmodule MingaEditor.State do
 
   @type t :: %__MODULE__{
           backend: backend(),
+          rendering: rendering_policy(),
           port_manager: GenServer.server() | nil,
           renderer: pid() | nil,
           agent_ingest: pid() | nil,
@@ -227,6 +230,11 @@ defmodule MingaEditor.State do
           gui_config_state: Minga.RenderModel.UI.ConfigState.t() | nil,
           session_started?: boolean()
         }
+
+  @doc "Returns whether this editor instance emits rendered frames."
+  @spec rendering_enabled?(t()) :: boolean()
+  def rendering_enabled?(%__MODULE__{rendering: :enabled}), do: true
+  def rendering_enabled?(%__MODULE__{rendering: :disabled}), do: false
 
   @doc "Returns the cached native settings snapshot emitted in-frame (#2119)."
   @spec gui_config_state(t()) :: Minga.RenderModel.UI.ConfigState.t() | nil

--- a/test/minga/buffer_management_test.exs
+++ b/test/minga/buffer_management_test.exs
@@ -6,7 +6,7 @@ defmodule Minga.BufferManagementTest do
   lower-layer suites.
   """
 
-  use Minga.Test.EditorCase, async: true
+  use Minga.Test.EditorCase, async: true, rendering: :disabled
 
   @tag :tmp_dir
   test ":e and leader keys route buffer navigation, kill, and new commands", %{tmp_dir: dir} do

--- a/test/minga_agent/session_approval_test.exs
+++ b/test/minga_agent/session_approval_test.exs
@@ -223,6 +223,7 @@ defmodule MingaAgent.SessionApprovalTest do
       assert Session.list_tool_trust(session) == %{"read_file" => :session}
     end
 
+    @tag :tmp_dir
     test "turn trust clears before automatically queued follow-up turns", %{tmp_dir: dir} do
       File.write!(Path.join(dir, "test.txt"), "file contents")
       call_count = :counters.new(1, [:atomics])

--- a/test/minga_agent/session_lifecycle_test.exs
+++ b/test/minga_agent/session_lifecycle_test.exs
@@ -88,6 +88,7 @@ defmodule MingaAgent.SessionLifecycleTest do
       assert_receive {:DOWN, ^ref, :process, ^session, :normal}, @event_timeout
     end
 
+    @tag :tmp_dir
     test "idle detached sessions with persist?: false exit normally without writing", %{
       tmp_dir: dir
     } do
@@ -118,6 +119,7 @@ defmodule MingaAgent.SessionLifecycleTest do
       assert File.read!(bad_store_dir) == "not a directory"
     end
 
+    @tag :tmp_dir
     test "sending a prompt while the idle timer is pending keeps the session alive", %{
       tmp_dir: dir
     } do
@@ -245,6 +247,7 @@ defmodule MingaAgent.SessionLifecycleTest do
       assert Session.status(session) == :idle
     end
 
+    @tag :tmp_dir
     test "save_session failures are logged and retried with backoff", %{tmp_dir: dir} do
       bad_store_dir = Path.join(dir, "blocked-store")
       File.write!(bad_store_dir, "not a directory")
@@ -268,6 +271,7 @@ defmodule MingaAgent.SessionLifecycleTest do
       refute_receive {:DOWN, ^ref, :process, ^session, _}, 50
     end
 
+    @tag :tmp_dir
     test "idle detached sessions stay alive when persistence fails", %{tmp_dir: dir} do
       bad_store_dir = Path.join(dir, "blocked-store")
       File.write!(bad_store_dir, "not a directory")

--- a/test/minga_agent/session_persistence_test.exs
+++ b/test/minga_agent/session_persistence_test.exs
@@ -17,23 +17,34 @@ defmodule MingaAgent.SessionPersistenceTest do
       assert id1 != id2
     end
 
-    test "load_session replaces messages" do
-      session = start_subscribed_session()
+    @tag :tmp_dir
+    test "load_session replaces messages", %{tmp_dir: dir} do
+      session =
+        start_test_session(
+          provider: Minga.Test.SessionMockProvider,
+          provider_opts: [],
+          session_store_dir: dir
+        )
+
+      Session.subscribe(session)
       _id = Session.session_id(session)
 
-      SessionStore.save(%{
-        id: "loaded-session",
-        timestamp: DateTime.to_iso8601(DateTime.utc_now()),
-        model_name: "test-model",
-        messages: [{:user, "loaded message"}, {:assistant, "loaded reply"}],
-        usage: %MingaAgent.TurnUsage{
-          input: 500,
-          output: 200,
-          cache_read: 0,
-          cache_write: 0,
-          cost: 0.01
-        }
-      })
+      SessionStore.save(
+        %{
+          id: "loaded-session",
+          timestamp: DateTime.to_iso8601(DateTime.utc_now()),
+          model_name: "test-model",
+          messages: [{:user, "loaded message"}, {:assistant, "loaded reply"}],
+          usage: %MingaAgent.TurnUsage{
+            input: 500,
+            output: 200,
+            cache_read: 0,
+            cache_write: 0,
+            cost: 0.01
+          }
+        },
+        dir
+      )
 
       :ok = Session.load_session(session, "loaded-session")
 
@@ -43,11 +54,19 @@ defmodule MingaAgent.SessionPersistenceTest do
       assert [{:user, "loaded message"}] = user_msgs
     end
 
-    test "load_session returns error for missing session" do
-      session = start_subscribed_session()
+    @tag :tmp_dir
+    test "load_session returns error for missing session", %{tmp_dir: dir} do
+      session =
+        start_test_session(
+          provider: Minga.Test.SessionMockProvider,
+          provider_opts: [],
+          session_store_dir: dir
+        )
+
       assert {:error, _} = Session.load_session(session, "nonexistent")
     end
 
+    @tag :tmp_dir
     test "load_session restores messages, model, provider metadata, and branches", %{tmp_dir: dir} do
       session =
         start_test_session(
@@ -101,6 +120,7 @@ defmodule MingaAgent.SessionPersistenceTest do
              ]
     end
 
+    @tag :tmp_dir
     test "load_session leaves existing memory untouched for legacy sessions without a memory snapshot",
          %{
            tmp_dir: dir
@@ -134,6 +154,7 @@ defmodule MingaAgent.SessionPersistenceTest do
       assert MingaAgent.Memory.read(dir) =~ "keep this memory"
     end
 
+    @tag :tmp_dir
     test "load_session saves the current dirty session before replacement", %{tmp_dir: dir} do
       session =
         start_test_session(

--- a/test/minga_agent/session_provider_error_test.exs
+++ b/test/minga_agent/session_provider_error_test.exs
@@ -2,6 +2,7 @@ defmodule MingaAgent.SessionProviderErrorTest do
   use Minga.Test.SessionCase, async: true
 
   describe "MCP crash handling" do
+    @tag :tmp_dir
     test "adds a system message and can still run a builtin tool", %{tmp_dir: dir} do
       test_pid = self()
       call_count = :counters.new(1, [:atomics])

--- a/test/minga_agent/session_transcript_test.exs
+++ b/test/minga_agent/session_transcript_test.exs
@@ -234,8 +234,16 @@ defmodule MingaAgent.SessionTranscriptTest do
   end
 
   describe "message IDs" do
-    test "IDs increment across turns and reset for new or loaded sessions" do
-      session = start_subscribed_session()
+    @tag :tmp_dir
+    test "IDs increment across turns and reset for new or loaded sessions", %{tmp_dir: dir} do
+      session =
+        start_test_session(
+          provider: Minga.Test.SessionMockProvider,
+          provider_opts: [],
+          session_store_dir: dir
+        )
+
+      Session.subscribe(session)
       assert [{1, {:system, _, :info}}] = Session.messages_with_ids(session)
 
       :ok = Session.send_prompt(session, "first")
@@ -257,19 +265,22 @@ defmodule MingaAgent.SessionTranscriptTest do
 
       loaded_id = "id-test-session-#{System.unique_integer([:positive])}"
 
-      SessionStore.save(%{
-        id: loaded_id,
-        timestamp: DateTime.to_iso8601(DateTime.utc_now()),
-        model_name: "test-model",
-        messages: [{:user, "loaded"}, {:assistant, "reply"}],
-        usage: %MingaAgent.TurnUsage{
-          input: 10,
-          output: 5,
-          cache_read: 0,
-          cache_write: 0,
-          cost: 0.001
-        }
-      })
+      SessionStore.save(
+        %{
+          id: loaded_id,
+          timestamp: DateTime.to_iso8601(DateTime.utc_now()),
+          model_name: "test-model",
+          messages: [{:user, "loaded"}, {:assistant, "reply"}],
+          usage: %MingaAgent.TurnUsage{
+            input: 10,
+            output: 5,
+            cache_read: 0,
+            cache_write: 0,
+            cost: 0.001
+          }
+        },
+        dir
+      )
 
       :ok = Session.load_session(session, loaded_id)
       assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout

--- a/test/minga_agent/tools/subagent_provider_registry_test.exs
+++ b/test/minga_agent/tools/subagent_provider_registry_test.exs
@@ -1,0 +1,166 @@
+defmodule MingaAgent.Tools.SubagentProviderRegistryTest do
+  # Mutates global ProviderRegistry/source state, so these tests must run serially.
+  use ExUnit.Case, async: false
+
+  alias MingaAgent.ProviderPacks.Native, as: NativeProviderPack
+  alias MingaAgent.ProviderRegistry
+  alias MingaAgent.Tools.Subagent
+  alias Minga.Test.SubagentGatedProvider, as: GatedProvider
+  alias Minga.Test.SubagentRecordingProvider, as: RecordingProvider
+
+  @moduletag :tmp_dir
+
+  test "foreground subagent resolves registered string provider ids" do
+    test_pid = self()
+
+    assert :ok =
+             ProviderRegistry.register(
+               id: "gated-test",
+               source: :config,
+               module: GatedProvider,
+               display_name: "Gated Test"
+             )
+
+    on_exit(fn -> ProviderRegistry.unregister_source(:config) end)
+
+    task =
+      Task.async(fn ->
+        Subagent.execute("registered provider task",
+          provider: "gated-test",
+          provider_opts: [test_pid: test_pid]
+        )
+      end)
+
+    assert_receive {:provider_prompt, provider_pid, "registered provider task"}, 1_000
+    assert :ok = GatedProvider.proceed(provider_pid, "registered done")
+    assert {:ok, "registered done"} = Task.await(task)
+  end
+
+  test "native provider atom override is rejected when the bundled source is disabled" do
+    assert :ok = ProviderRegistry.disable("native")
+    on_exit(fn -> ProviderRegistry.enable("native") end)
+
+    assert {:error, message} = Subagent.execute("blocked native", provider: :native)
+    assert message =~ "Failed to resolve subagent provider"
+    assert message =~ ":disabled"
+  end
+
+  test "native provider string override is rejected when the bundled source is disabled" do
+    assert :ok = ProviderRegistry.disable("native")
+    on_exit(fn -> ProviderRegistry.enable("native") end)
+
+    assert {:error, message} = Subagent.execute("blocked native", provider: "native")
+    assert message =~ "Failed to resolve subagent provider"
+    assert message =~ ":disabled"
+  end
+
+  test "default native provider is rejected after bundled source cleanup" do
+    assert :ok = ProviderRegistry.unregister_source(NativeProviderPack.source())
+    on_exit(fn -> NativeProviderPack.register() end)
+
+    assert {:error, message} = Subagent.execute("blocked native")
+    assert message =~ "Failed to resolve subagent provider"
+    assert message =~ ":not_found"
+  end
+
+  test "inherited source-owned providers resolve for child sessions while registered", %{
+    tmp_dir: dir
+  } do
+    source = {:bundle, :recording_subagent_provider_positive}
+    provider_id = "recording-subagent-provider-positive"
+    ref = make_ref()
+
+    assert :ok =
+             ProviderRegistry.register(
+               id: provider_id,
+               source: source,
+               module: RecordingProvider,
+               display_name: "Recording Subagent Provider"
+             )
+
+    {:ok, parent} =
+      MingaAgent.Supervisor.start_session(
+        provider: RecordingProvider,
+        provider_id: provider_id,
+        provider_source: source,
+        model_name: "parent-model",
+        provider_opts: [
+          provider: "recording",
+          model: "parent-model",
+          thinking_level: "high",
+          active_skill_names: ["elixir"],
+          project_root: dir,
+          test_pid: self(),
+          test_ref: ref
+        ]
+      )
+
+    assert_receive {^ref, {:provider_started, _provider_pid, _opts}}, 1_000
+
+    on_exit(fn ->
+      MingaAgent.Supervisor.stop_session(parent)
+      ProviderRegistry.unregister_source(source)
+    end)
+
+    assert {:ok, "child response"} =
+             Subagent.execute("allowed inherited",
+               parent_session: parent,
+               project_root: dir,
+               provider_opts: [test_pid: self(), test_ref: ref]
+             )
+
+    assert_receive {^ref, {:provider_started, _child_provider, child_opts}}, 1_000
+    assert Keyword.fetch!(child_opts, :project_root) == dir
+    assert Keyword.fetch!(child_opts, :provider) == provider_id
+    assert Keyword.fetch!(child_opts, :model) == "parent-model"
+    assert Keyword.fetch!(child_opts, :thinking_level) == "high"
+    assert Keyword.fetch!(child_opts, :active_skill_names) == ["elixir"]
+    assert Keyword.fetch!(child_opts, :test_ref) == ref
+
+    assert_receive {^ref, {:prompt_received, _provider_pid, _subscriber, "allowed inherited"}},
+                   1_000
+  end
+
+  test "inherited source-owned providers are rechecked for child sessions", %{tmp_dir: dir} do
+    source = {:bundle, :recording_subagent_provider}
+    provider_id = "recording-subagent-provider"
+    ref = make_ref()
+
+    assert :ok =
+             ProviderRegistry.register(
+               id: provider_id,
+               source: source,
+               module: RecordingProvider,
+               display_name: "Recording Subagent Provider"
+             )
+
+    {:ok, parent} =
+      MingaAgent.Supervisor.start_session(
+        provider: RecordingProvider,
+        provider_id: provider_id,
+        provider_source: source,
+        model_name: "parent-model",
+        provider_opts: [
+          provider: "recording",
+          model: "parent-model",
+          project_root: dir,
+          test_pid: self(),
+          test_ref: ref
+        ]
+      )
+
+    assert_receive {^ref, {:provider_started, _provider_pid, _opts}}, 1_000
+    assert :ok = ProviderRegistry.unregister_source(source)
+
+    on_exit(fn ->
+      MingaAgent.Supervisor.stop_session(parent)
+      ProviderRegistry.unregister_source(source)
+    end)
+
+    assert {:error, message} =
+             Subagent.execute("blocked inherited", parent_session: parent, project_root: dir)
+
+    assert message =~ "Failed to resolve subagent provider"
+    assert message =~ ":not_found"
+  end
+end

--- a/test/minga_agent/tools/subagent_test.exs
+++ b/test/minga_agent/tools/subagent_test.exs
@@ -1,261 +1,23 @@
 defmodule MingaAgent.Tools.SubagentTest do
-  # Uses the global MingaAgent.Supervisor for child sessions, so this file must run serially.
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Minga.Events
-  alias MingaAgent.Event
-  alias MingaAgent.ProviderPacks.Native, as: NativeProviderPack
-  alias MingaAgent.ProviderRegistry
   alias MingaAgent.Session
   alias MingaAgent.SessionManager
   alias MingaAgent.Subagent.Handle
   alias MingaAgent.Tools.Subagent
+  alias Minga.Test.SubagentErrorProvider, as: ErrorProvider
+  alias Minga.Test.SubagentGatedProvider, as: GatedProvider
+  alias Minga.Test.SubagentOverrideProvider, as: OverrideProvider
+  alias Minga.Test.SubagentRecordingProvider, as: RecordingProvider
+  alias Minga.Test.SubagentTestNotifier, as: TestNotifier
   alias Minga.Test.SubagentWorktreeBackend
   alias Minga.Test.SubagentWorktreeProvider
   alias ReqLLM.StreamResponse.MetadataHandle
   alias ReqLLM.StreamChunk
 
   @moduletag :tmp_dir
-
-  # ── Test providers ────────────────────────────────────────────────────────
-
-  defmodule GatedProvider do
-    @behaviour MingaAgent.Provider
-
-    use GenServer
-
-    @impl MingaAgent.Provider
-    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
-
-    @impl MingaAgent.Provider
-    def send_prompt(pid, text), do: GenServer.call(pid, {:prompt, text})
-
-    @impl MingaAgent.Provider
-    def abort(pid), do: GenServer.call(pid, :abort)
-
-    @impl MingaAgent.Provider
-    def new_session(pid), do: GenServer.call(pid, :new_session)
-
-    @impl MingaAgent.Provider
-    def seed_messages(_pid, _messages), do: :ok
-
-    @impl MingaAgent.Provider
-    def get_state(_pid), do: {:ok, %{model: nil, is_streaming: false, token_usage: nil}}
-
-    @spec proceed(GenServer.server(), String.t()) :: :ok
-    def proceed(pid, text \\ "child done"), do: GenServer.call(pid, {:proceed, text})
-
-    @impl GenServer
-    def init(opts) do
-      {:ok,
-       %{subscriber: Keyword.fetch!(opts, :subscriber), test_pid: Keyword.fetch!(opts, :test_pid)}}
-    end
-
-    @impl GenServer
-    def handle_call({:prompt, text}, _from, state) do
-      send(state.subscriber, {:agent_provider_event, %Event.AgentStart{}})
-      send(state.test_pid, {:provider_prompt, self(), text})
-      {:reply, :ok, state}
-    end
-
-    def handle_call({:proceed, text}, _from, state) do
-      send(state.subscriber, {:agent_provider_event, %Event.TextDelta{delta: text}})
-      send(state.subscriber, {:agent_provider_event, %Event.AgentEnd{}})
-      {:reply, :ok, state}
-    end
-
-    def handle_call(:abort, _from, state), do: {:reply, :ok, state}
-    def handle_call(:new_session, _from, state), do: {:reply, :ok, state}
-  end
-
-  defmodule ErrorProvider do
-    @behaviour MingaAgent.Provider
-
-    use GenServer
-
-    @impl MingaAgent.Provider
-    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
-
-    @impl MingaAgent.Provider
-    def send_prompt(pid, text), do: GenServer.call(pid, {:prompt, text})
-
-    @impl MingaAgent.Provider
-    def abort(pid), do: GenServer.call(pid, :abort)
-
-    @impl MingaAgent.Provider
-    def new_session(pid), do: GenServer.call(pid, :new_session)
-
-    @impl MingaAgent.Provider
-    def seed_messages(_pid, _messages), do: :ok
-
-    @impl MingaAgent.Provider
-    def get_state(_pid), do: {:ok, %{model: nil, is_streaming: false, token_usage: nil}}
-
-    @impl GenServer
-    def init(opts) do
-      {:ok,
-       %{subscriber: Keyword.fetch!(opts, :subscriber), test_pid: Keyword.fetch!(opts, :test_pid)}}
-    end
-
-    @impl GenServer
-    def handle_call({:prompt, text}, _from, state) do
-      send(state.subscriber, {:agent_provider_event, %Event.AgentStart{}})
-      send(state.test_pid, {:provider_prompt, self(), text})
-      send(state.subscriber, {:agent_provider_event, %Event.Error{message: "boom"}})
-      {:reply, :ok, state}
-    end
-
-    def handle_call(:abort, _from, state), do: {:reply, :ok, state}
-    def handle_call(:new_session, _from, state), do: {:reply, :ok, state}
-  end
-
-  defmodule TestNotifier do
-    @spec notify(atom(), String.t(), pid()) :: :ok
-    def notify(trigger, message, test_pid) do
-      send(test_pid, {:notified, trigger, message})
-      :ok
-    end
-  end
-
-  defmodule RecordingProvider do
-    @behaviour MingaAgent.Provider
-
-    use GenServer
-
-    @impl MingaAgent.Provider
-    def start_link(opts) do
-      GenServer.start_link(__MODULE__, opts)
-    end
-
-    @impl MingaAgent.Provider
-    def send_prompt(pid, text) do
-      GenServer.call(pid, {:send_prompt, text})
-    end
-
-    @impl MingaAgent.Provider
-    def abort(pid) do
-      GenServer.cast(pid, :abort)
-      :ok
-    end
-
-    @impl MingaAgent.Provider
-    def new_session(pid) do
-      GenServer.cast(pid, :new_session)
-      :ok
-    end
-
-    @impl MingaAgent.Provider
-    def seed_messages(_pid, _messages), do: :ok
-
-    @impl MingaAgent.Provider
-    def get_state(pid) do
-      GenServer.call(pid, :get_state)
-    end
-
-    @impl GenServer
-    def init(opts) do
-      notify_test(opts, {:provider_started, self(), opts})
-
-      state = %{
-        subscriber: Keyword.fetch!(opts, :subscriber),
-        model: Keyword.get(opts, :model),
-        provider: Keyword.get(opts, :provider, "recording"),
-        thinking_level: Keyword.get(opts, :thinking_level),
-        active_skill_names: Keyword.get(opts, :active_skill_names, []),
-        project_root: Keyword.get(opts, :project_root),
-        blocking: Keyword.get(opts, :blocking, false),
-        test_pid: Keyword.get(opts, :test_pid),
-        test_ref: Keyword.get(opts, :test_ref)
-      }
-
-      {:ok, state}
-    end
-
-    @impl GenServer
-    def handle_call({:send_prompt, text}, _from, state) do
-      notify_test(state, {:prompt_received, self(), state.subscriber, text})
-      notify_session(state, %Event.AgentStart{})
-
-      if state.blocking do
-        {:reply, :ok, state}
-      else
-        notify_session(state, %Event.TextDelta{delta: "child response"})
-        notify_session(state, %Event.AgentEnd{usage: nil})
-        {:reply, :ok, state}
-      end
-    end
-
-    def handle_call(:get_state, _from, state) do
-      provider_state = %{
-        model: %{id: state.model, name: state.model, provider: state.provider},
-        is_streaming: false,
-        token_usage: nil,
-        thinking_level: state.thinking_level,
-        active_skill_names: state.active_skill_names,
-        project_root: state.project_root
-      }
-
-      {:reply, {:ok, provider_state}, state}
-    end
-
-    @impl GenServer
-    def handle_cast(:finish, state) do
-      notify_session(state, %Event.TextDelta{delta: "blocked child response"})
-      notify_session(state, %Event.AgentEnd{usage: nil})
-      {:noreply, state}
-    end
-
-    def handle_cast(_message, state), do: {:noreply, state}
-
-    @spec finish(GenServer.server()) :: :ok
-    def finish(pid) do
-      GenServer.cast(pid, :finish)
-    end
-
-    @spec notify_session(map(), Event.t()) :: :ok
-    defp notify_session(state, event) do
-      send(state.subscriber, {:agent_provider_event, event})
-      :ok
-    end
-
-    @spec notify_test(keyword() | map(), tuple()) :: :ok
-    defp notify_test(opts_or_state, message) do
-      test_pid = get_opt(opts_or_state, :test_pid)
-      test_ref = get_opt(opts_or_state, :test_ref)
-
-      if is_pid(test_pid) and test_ref != nil do
-        send(test_pid, {test_ref, message})
-      end
-
-      :ok
-    end
-
-    @spec get_opt(keyword() | map(), atom()) :: term()
-    defp get_opt(opts, key) when is_list(opts), do: Keyword.get(opts, key)
-    defp get_opt(state, key) when is_map(state), do: Map.get(state, key)
-  end
-
-  defmodule OverrideProvider do
-    @behaviour MingaAgent.Provider
-
-    @impl MingaAgent.Provider
-    def start_link(opts), do: RecordingProvider.start_link(opts)
-
-    @impl MingaAgent.Provider
-    def send_prompt(pid, text), do: RecordingProvider.send_prompt(pid, text)
-
-    @impl MingaAgent.Provider
-    def abort(pid), do: RecordingProvider.abort(pid)
-
-    @impl MingaAgent.Provider
-    def new_session(pid), do: RecordingProvider.new_session(pid)
-
-    @impl MingaAgent.Provider
-    def seed_messages(_pid, _messages), do: :ok
-
-    @impl MingaAgent.Provider
-    def get_state(pid), do: RecordingProvider.get_state(pid)
-  end
+  @event_timeout 5_000
 
   # ── Setup ──────────────────────────────────────────────────────────────────
 
@@ -265,160 +27,6 @@ defmodule MingaAgent.Tools.SubagentTest do
 
   # ── Background subagent tests ──────────────────────────────────────────────
 
-  test "foreground subagent resolves registered string provider ids" do
-    test_pid = self()
-
-    assert :ok =
-             ProviderRegistry.register(
-               id: "gated-test",
-               source: :config,
-               module: GatedProvider,
-               display_name: "Gated Test"
-             )
-
-    on_exit(fn -> ProviderRegistry.unregister_source(:config) end)
-
-    task =
-      Task.async(fn ->
-        Subagent.execute("registered provider task",
-          provider: "gated-test",
-          provider_opts: [test_pid: test_pid]
-        )
-      end)
-
-    assert_receive {:provider_prompt, provider_pid, "registered provider task"}, 1_000
-    assert :ok = GatedProvider.proceed(provider_pid, "registered done")
-    assert {:ok, "registered done"} = Task.await(task)
-  end
-
-  test "native provider atom override is rejected when the bundled source is disabled" do
-    assert :ok = ProviderRegistry.disable("native")
-    on_exit(fn -> ProviderRegistry.enable("native") end)
-
-    assert {:error, message} = Subagent.execute("blocked native", provider: :native)
-    assert message =~ "Failed to resolve subagent provider"
-    assert message =~ ":disabled"
-  end
-
-  test "native provider string override is rejected when the bundled source is disabled" do
-    assert :ok = ProviderRegistry.disable("native")
-    on_exit(fn -> ProviderRegistry.enable("native") end)
-
-    assert {:error, message} = Subagent.execute("blocked native", provider: "native")
-    assert message =~ "Failed to resolve subagent provider"
-    assert message =~ ":disabled"
-  end
-
-  test "default native provider is rejected after bundled source cleanup" do
-    assert :ok = ProviderRegistry.unregister_source(NativeProviderPack.source())
-    on_exit(fn -> NativeProviderPack.register() end)
-
-    assert {:error, message} = Subagent.execute("blocked native")
-    assert message =~ "Failed to resolve subagent provider"
-    assert message =~ ":not_found"
-  end
-
-  test "inherited source-owned providers resolve for child sessions while registered", %{
-    tmp_dir: dir
-  } do
-    source = {:bundle, :recording_subagent_provider_positive}
-    provider_id = "recording-subagent-provider-positive"
-    ref = make_ref()
-
-    assert :ok =
-             ProviderRegistry.register(
-               id: provider_id,
-               source: source,
-               module: RecordingProvider,
-               display_name: "Recording Subagent Provider"
-             )
-
-    {:ok, parent} =
-      MingaAgent.Supervisor.start_session(
-        provider: RecordingProvider,
-        provider_id: provider_id,
-        provider_source: source,
-        model_name: "parent-model",
-        provider_opts: [
-          provider: "recording",
-          model: "parent-model",
-          thinking_level: "high",
-          active_skill_names: ["elixir"],
-          project_root: dir,
-          test_pid: self(),
-          test_ref: ref
-        ]
-      )
-
-    assert_receive {^ref, {:provider_started, _provider_pid, _opts}}, 1_000
-
-    on_exit(fn ->
-      MingaAgent.Supervisor.stop_session(parent)
-      ProviderRegistry.unregister_source(source)
-    end)
-
-    assert {:ok, "child response"} =
-             Subagent.execute("allowed inherited",
-               parent_session: parent,
-               project_root: dir,
-               provider_opts: [test_pid: self(), test_ref: ref]
-             )
-
-    assert_receive {^ref, {:provider_started, _child_provider, child_opts}}, 1_000
-    assert Keyword.fetch!(child_opts, :project_root) == dir
-    assert Keyword.fetch!(child_opts, :provider) == provider_id
-    assert Keyword.fetch!(child_opts, :model) == "parent-model"
-    assert Keyword.fetch!(child_opts, :thinking_level) == "high"
-    assert Keyword.fetch!(child_opts, :active_skill_names) == ["elixir"]
-    assert Keyword.fetch!(child_opts, :test_ref) == ref
-
-    assert_receive {^ref, {:prompt_received, _provider_pid, _subscriber, "allowed inherited"}},
-                   1_000
-  end
-
-  test "inherited source-owned providers are rechecked for child sessions", %{tmp_dir: dir} do
-    source = {:bundle, :recording_subagent_provider}
-    provider_id = "recording-subagent-provider"
-    ref = make_ref()
-
-    assert :ok =
-             ProviderRegistry.register(
-               id: provider_id,
-               source: source,
-               module: RecordingProvider,
-               display_name: "Recording Subagent Provider"
-             )
-
-    {:ok, parent} =
-      MingaAgent.Supervisor.start_session(
-        provider: RecordingProvider,
-        provider_id: provider_id,
-        provider_source: source,
-        model_name: "parent-model",
-        provider_opts: [
-          provider: "recording",
-          model: "parent-model",
-          project_root: dir,
-          test_pid: self(),
-          test_ref: ref
-        ]
-      )
-
-    assert_receive {^ref, {:provider_started, _provider_pid, _opts}}, 1_000
-    assert :ok = ProviderRegistry.unregister_source(source)
-
-    on_exit(fn ->
-      MingaAgent.Supervisor.stop_session(parent)
-      ProviderRegistry.unregister_source(source)
-    end)
-
-    assert {:error, message} =
-             Subagent.execute("blocked inherited", parent_session: parent, project_root: dir)
-
-    assert message =~ "Failed to resolve subagent provider"
-    assert message =~ ":not_found"
-  end
-
   @tag :session_manager
   test "background subagent returns a stable handle before the child finishes", %{
     manager: manager
@@ -427,22 +35,19 @@ defmodule MingaAgent.Tools.SubagentTest do
 
     Events.subscribe(:background_subagent_started)
 
-    task =
-      Task.async(fn ->
-        Subagent.execute("long task",
-          background: true,
-          session_manager: manager,
-          provider: GatedProvider,
-          provider_opts: [test_pid: test_pid]
-        )
-      end)
+    assert {:ok, result} =
+             Subagent.execute("long task",
+               background: true,
+               session_manager: manager,
+               provider: GatedProvider,
+               provider_opts: [test_pid: test_pid]
+             )
 
-    assert {:ok, result} = Task.await(task)
     assert result =~ ~r/Handle: session-1-[0-9a-f]{8}/
 
     assert_receive {:minga_event, :background_subagent_started,
                     %Handle{session_id: session_id, task: "long task"}},
-                   1_000
+                   @event_timeout
 
     assert String.match?(session_id, ~r/^session-1-[0-9a-f]{8}$/)
 
@@ -450,7 +55,7 @@ defmodule MingaAgent.Tools.SubagentTest do
     assert %Handle{session_id: ^session_id, pid: child_pid} = handle
     assert Session.status(child_pid) in [:idle, :thinking]
 
-    assert_receive {:provider_prompt, provider_pid, "long task"}, 1_000
+    assert_receive {:provider_prompt, provider_pid, "long task"}, @event_timeout
     assert Session.status(child_pid) == :thinking
 
     assert :ok = GatedProvider.proceed(provider_pid)
@@ -474,7 +79,7 @@ defmodule MingaAgent.Tools.SubagentTest do
         provider_opts: [test_pid: self()]
       )
 
-    assert_receive {:provider_prompt, _provider_pid, "child work"}, 1_000
+    assert_receive {:provider_prompt, _provider_pid, "child work"}, @event_timeout
     [handle] = SessionManager.list_background_subagents(manager, parent_pid)
     assert handle.parent_pid == parent_pid
 
@@ -498,9 +103,9 @@ defmodule MingaAgent.Tools.SubagentTest do
 
     [handle] = SessionManager.list_background_subagents(manager, nil)
     Session.subscribe(handle.pid)
-    assert_receive {:provider_prompt, provider_pid, "write result"}, 1_000
+    assert_receive {:provider_prompt, provider_pid, "write result"}, @event_timeout
     :ok = GatedProvider.proceed(provider_pid, "saved answer")
-    assert_receive {:agent_event, _pid, {:status_changed, :idle}}, 1_000
+    assert_receive {:agent_event, _pid, {:status_changed, :idle}}, @event_timeout
 
     assert Enum.any?(Session.messages(handle.pid), &(&1 == {:assistant, "saved answer"}))
   end
@@ -520,9 +125,9 @@ defmodule MingaAgent.Tools.SubagentTest do
 
     [handle] = SessionManager.list_background_subagents(manager, nil)
     Session.subscribe(handle.pid)
-    assert_receive {:provider_prompt, _provider_pid, "fail"}, 1_000
+    assert_receive {:provider_prompt, _provider_pid, "fail"}, @event_timeout
     assert Session.status(handle.pid) == :error
-    assert_receive {:notified, :error, "boom"}, 1_000
+    assert_receive {:notified, :error, "boom"}, @event_timeout
     refute_receive {:notified, :error, _}, 50
 
     assert Session.status(handle.pid) == :error
@@ -542,10 +147,10 @@ defmodule MingaAgent.Tools.SubagentTest do
 
     [handle] = SessionManager.list_background_subagents(manager, nil)
     Session.subscribe(handle.pid)
-    assert_receive {:provider_prompt, provider_pid, "notify"}, 1_000
+    assert_receive {:provider_prompt, provider_pid, "notify"}, @event_timeout
     :ok = GatedProvider.proceed(provider_pid)
-    assert_receive {:agent_event, _pid, {:status_changed, :idle}}, 1_000
-    assert_receive {:notified, :complete, message}, 1_000
+    assert_receive {:agent_event, _pid, {:status_changed, :idle}}, @event_timeout
+    assert_receive {:notified, :complete, message}, @event_timeout
     assert String.match?(message, ~r/^Sub-agent session-1-[0-9a-f]{8} finished$/)
     refute_receive {:notified, :complete, _}, 50
   end
@@ -576,7 +181,7 @@ defmodule MingaAgent.Tools.SubagentTest do
 
     assert_receive {:agent_event, _pid,
                     {:approval_rejected, "tc_write_file", "write_file", message}},
-                   1_000
+                   @event_timeout
 
     elapsed_ms = System.monotonic_time(:millisecond) - started_at
     assert elapsed_ms < 2_000
@@ -607,9 +212,9 @@ defmodule MingaAgent.Tools.SubagentTest do
         )
       end)
 
-    assert_receive {:provider_prompt, provider_pid, "foreground"}, 1_000
+    assert_receive {:provider_prompt, provider_pid, "foreground"}, @event_timeout
     :ok = GatedProvider.proceed(provider_pid, "foreground done")
-    assert {:ok, "foreground done"} = Task.await(task)
+    assert {:ok, "foreground done"} = Task.await(task, @event_timeout)
   end
 
   test "worktree-isolated subagent preserves a changed worktree", %{tmp_dir: dir} do
@@ -766,7 +371,7 @@ defmodule MingaAgent.Tools.SubagentTest do
 
     assert_receive {:agent_event, _pid,
                     {:tool_auto_approved, "tc_write_file", "write_file", :session}},
-                   1_000
+                   @event_timeout
 
     assert_eventually_idle(handle.pid)
 
@@ -858,7 +463,7 @@ defmodule MingaAgent.Tools.SubagentTest do
         end)
 
       assert_receive {^ref, {:prompt_received, provider_pid, child_session, "do child task"}},
-                     1_000
+                     @event_timeout
 
       [{:system, first_system_message, :info} | _rest] = Session.messages(child_session)
       assert first_system_message =~ "Subagent overrides"
@@ -866,7 +471,7 @@ defmodule MingaAgent.Tools.SubagentTest do
       assert first_system_message =~ "model override: override-model"
 
       RecordingProvider.finish(provider_pid)
-      assert {:ok, "blocked child response"} = Task.await(task, 1_000)
+      assert {:ok, "blocked child response"} = Task.await(task, @event_timeout)
     end
 
     test "falls back to default context when parent session is already dead", %{tmp_dir: dir} do
@@ -874,7 +479,7 @@ defmodule MingaAgent.Tools.SubagentTest do
       parent = start_parent_session(dir, ref)
       monitor_ref = Process.monitor(parent)
       assert :ok = MingaAgent.Supervisor.stop_session(parent)
-      assert_receive {:DOWN, ^monitor_ref, :process, ^parent, _reason}, 1_000
+      assert_receive {:DOWN, ^monitor_ref, :process, ^parent, _reason}, @event_timeout
 
       assert {:ok, "child response"} =
                Subagent.execute("do child task",
@@ -902,10 +507,10 @@ defmodule MingaAgent.Tools.SubagentTest do
                )
 
       assert_receive {^ref, {:prompt_received, _provider_pid, child_session, "do child task"}},
-                     1_000
+                     @event_timeout
 
       monitor_ref = Process.monitor(child_session)
-      assert_receive {:DOWN, ^monitor_ref, :process, ^child_session, _reason}, 1_000
+      assert_receive {:DOWN, ^monitor_ref, :process, ^child_session, _reason}, @event_timeout
     end
   end
 
@@ -920,7 +525,7 @@ defmodule MingaAgent.Tools.SubagentTest do
       receive do
         {:agent_event, ^session_pid, {:status_changed, :idle}} -> :ok
       after
-        1_000 -> flunk("session did not become idle")
+        @event_timeout -> flunk("session did not become idle")
       end
     end
   end
@@ -942,7 +547,7 @@ defmodule MingaAgent.Tools.SubagentTest do
         ]
       )
 
-    assert_receive {^ref, {:provider_started, _provider_pid, opts}}, 1_000
+    assert_receive {^ref, {:provider_started, _provider_pid, opts}}, @event_timeout
     assert Keyword.fetch!(opts, :subscriber) == parent
     on_exit(fn -> MingaAgent.Supervisor.stop_session(parent) end)
     parent
@@ -950,7 +555,7 @@ defmodule MingaAgent.Tools.SubagentTest do
 
   @spec assert_child_started(reference(), (keyword() -> any())) :: :ok
   defp assert_child_started(ref, assertions) do
-    assert_receive {^ref, {:provider_started, _provider_pid, opts}}, 1_000
+    assert_receive {^ref, {:provider_started, _provider_pid, opts}}, @event_timeout
     assertions.(opts)
     :ok
   end

--- a/test/minga_editor/commands/dired_test.exs
+++ b/test/minga_editor/commands/dired_test.exs
@@ -6,7 +6,7 @@ defmodule MingaEditor.Commands.DiredTest do
   cheaper direct boundaries.
   """
 
-  use Minga.Test.EditorCase, async: true
+  use Minga.Test.EditorCase, async: true, rendering: :disabled
 
   alias Minga.Buffer.Process, as: BufferProcess
 

--- a/test/minga_editor/editor_case_disabled_rendering_test.exs
+++ b/test/minga_editor/editor_case_disabled_rendering_test.exs
@@ -1,0 +1,68 @@
+defmodule MingaEditor.EditorCaseDisabledRenderingTest do
+  @moduledoc "Contract tests for EditorCase's input-only rendering policy."
+
+  use Minga.Test.EditorCase, async: true, rendering: :disabled
+
+  alias Minga.Test.HeadlessPort
+  alias MingaEditor.HighlightSync
+
+  test "readiness and operator-pending input commit no frames while edits still apply" do
+    ctx = start_editor("one\ntwo")
+
+    assert HeadlessPort.frame_count(ctx.port) == 0
+    assert editor_mode(ctx) == :normal
+
+    send_key_sync(ctx, ?d)
+
+    assert editor_mode(ctx) == :operator_pending
+    assert HeadlessPort.frame_count(ctx.port) == 0
+
+    send_key_sync(ctx, ?d)
+
+    assert editor_mode(ctx) == :normal
+    assert buffer_content(ctx) == "two"
+    assert HeadlessPort.frame_count(ctx.port) == 0
+  end
+
+  test "insert input and mode changes commit no frames while buffer state changes" do
+    ctx = start_editor("hello")
+
+    send_key_sync(ctx, ?i)
+    assert editor_mode(ctx) == :insert
+    assert HeadlessPort.frame_count(ctx.port) == 0
+
+    send_key_sync(ctx, ?X)
+    assert buffer_content(ctx) == "Xhello"
+    assert HeadlessPort.frame_count(ctx.port) == 0
+
+    send_key_sync(ctx, 27)
+    assert editor_mode(ctx) == :normal
+    assert HeadlessPort.frame_count(ctx.port) == 0
+  end
+
+  test "highlight events update state without bypassing the rendering policy" do
+    ctx = start_editor("defmodule Example do\nend")
+    spans = [%{start_byte: 0, end_byte: 9, capture_id: 0}]
+
+    inject_highlights(ctx, ["keyword"], 1, spans)
+
+    assert HighlightSync.get_active_highlight(editor_state(ctx)).spans == List.to_tuple(spans)
+    assert HeadlessPort.frame_count(ctx.port) == 0
+  end
+
+  test "frame-dependent helpers fail immediately with the rendering policy" do
+    ctx = start_editor("hello")
+
+    assert_raise ArgumentError, ~r/send_key\/3 requires rendering.*rendering: :disabled/, fn ->
+      send_key(ctx, ?l)
+    end
+
+    assert_raise ArgumentError, ~r/screen_row\/2 requires rendering.*rendering: :disabled/, fn ->
+      screen_row(ctx, 0)
+    end
+
+    assert_raise ArgumentError, ~r/send_resize\/3 requires rendering.*rendering: :disabled/, fn ->
+      send_resize(ctx, 100, 30)
+    end
+  end
+end

--- a/test/minga_editor/editor_case_enabled_rendering_test.exs
+++ b/test/minga_editor/editor_case_enabled_rendering_test.exs
@@ -1,0 +1,20 @@
+defmodule MingaEditor.EditorCaseEnabledRenderingTest do
+  @moduledoc "Smoke test for EditorCase's default rendered-frame contract."
+
+  use Minga.Test.EditorCase, async: true
+
+  alias Minga.Test.HeadlessPort
+
+  test "default mode commits an initial frame and renders subsequent input" do
+    ctx = start_editor("hello")
+    initial_frames = HeadlessPort.frame_count(ctx.port)
+
+    assert initial_frames > 0
+    assert String.contains?(screen_row(ctx, 1), "hello")
+
+    send_key(ctx, ?i)
+
+    assert editor_mode(ctx) == :insert
+    assert HeadlessPort.frame_count(ctx.port) > initial_frames
+  end
+end

--- a/test/minga_editor/ensure_buffer_editor_test.exs
+++ b/test/minga_editor/ensure_buffer_editor_test.exs
@@ -1,7 +1,7 @@
 defmodule MingaEditor.EnsureBufferEditorTest do
   @moduledoc false
 
-  use Minga.Test.EditorCase, async: true
+  use Minga.Test.EditorCase, async: true, rendering: :disabled
 
   alias Minga.Config.Options
 

--- a/test/minga_editor/events_registry_test.exs
+++ b/test/minga_editor/events_registry_test.exs
@@ -1,5 +1,5 @@
 defmodule MingaEditor.EventsRegistryTest do
-  use Minga.Test.EditorCase, async: true
+  use Minga.Test.EditorCase, async: true, rendering: :disabled
 
   alias Minga.Events
 

--- a/test/minga_editor/highlight_integration_test.exs
+++ b/test/minga_editor/highlight_integration_test.exs
@@ -6,7 +6,7 @@ defmodule MingaEditor.HighlightIntegrationTest do
   highlight suites.
   """
 
-  use Minga.Test.EditorCase, async: true
+  use Minga.Test.EditorCase, async: true, rendering: :disabled
 
   alias MingaEditor.HighlightSync
 

--- a/test/minga_editor/ui/picker/file_source_test.exs
+++ b/test/minga_editor/ui/picker/file_source_test.exs
@@ -2,7 +2,7 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
   @moduledoc "Tests frecency ordering in FileSource candidates."
 
   # Uses the global Minga.Project singleton to drive FileSource.project_root/0.
-  use Minga.Test.EditorCase, async: false
+  use Minga.Test.EditorCase, async: false, rendering: :disabled
 
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.State, as: EditorState

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -23,15 +23,31 @@ defmodule Minga.Test.EditorCase do
   alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Window.Content
 
-  using do
-    quote do
+  using options do
+    rendering = Minga.Test.EditorCase.rendering_option(options, :enabled)
+
+    quote bind_quoted: [editor_case_rendering: rendering] do
       import Minga.Test.EditorCase
       alias Minga.Buffer.Process, as: BufferProcess
+
+      @moduletag editor_case_rendering: editor_case_rendering
+
+      setup context do
+        rendering =
+          Minga.Test.EditorCase.rendering_option(
+            Map.to_list(context),
+            context.editor_case_rendering
+          )
+
+        Process.put(:minga_editor_case_rendering, rendering)
+        :ok
+      end
     end
   end
 
   @typedoc "Test context with editor processes."
   @type editor_ctx :: %{
+          optional(:rendering) => MingaEditor.State.rendering_policy(),
           editor: pid(),
           buffer: pid(),
           port: pid(),
@@ -41,6 +57,35 @@ defmodule Minga.Test.EditorCase do
         }
 
   @sync_timeout 15_000
+  @rendering_process_key :minga_editor_case_rendering
+
+  @doc false
+  @spec rendering_option(keyword(), MingaEditor.State.rendering_policy()) ::
+          MingaEditor.State.rendering_policy()
+  def rendering_option(options, default) do
+    case Keyword.fetch(options, :rendering) do
+      {:ok, policy} -> validate_rendering_policy!(policy)
+      :error -> input_only_rendering_option(options, default)
+    end
+  end
+
+  @spec input_only_rendering_option(keyword(), MingaEditor.State.rendering_policy()) ::
+          MingaEditor.State.rendering_policy()
+  defp input_only_rendering_option(options, default) do
+    case Keyword.get(options, :input_only, false) do
+      true -> :disabled
+      false -> validate_rendering_policy!(default)
+      value -> raise ArgumentError, "expected :input_only to be a boolean, got: #{inspect(value)}"
+    end
+  end
+
+  @spec validate_rendering_policy!(term()) :: MingaEditor.State.rendering_policy()
+  defp validate_rendering_policy!(policy) when policy in [:enabled, :disabled], do: policy
+
+  defp validate_rendering_policy!(policy) do
+    raise ArgumentError,
+          "expected :rendering to be :enabled or :disabled, got: #{inspect(policy)}"
+  end
 
   # ── Setup helpers ────────────────────────────────────────────────────────────
   @doc """
@@ -58,6 +103,7 @@ defmodule Minga.Test.EditorCase do
     height = Keyword.get(opts, :height, 24)
     file_path = Keyword.get(opts, :file_path)
     clipboard = Keyword.get(opts, :clipboard, :none)
+    rendering = rendering_option(opts, Process.get(@rendering_process_key, :enabled))
     id = :erlang.unique_integer([:positive])
 
     events_registry =
@@ -98,6 +144,7 @@ defmodule Minga.Test.EditorCase do
     editor_opts = [
       name: :"headless_editor_#{id}",
       backend: backend,
+      rendering: rendering,
       port_manager: port,
       buffer: buffer,
       width: width,
@@ -134,18 +181,7 @@ defmodule Minga.Test.EditorCase do
 
     {:ok, editor} = MingaEditor.start_link(editor_opts)
 
-    # Send ready event to trigger initial render
-    ref = HeadlessPort.prepare_await(port)
-    send(editor, {:minga_input, {:ready, width, height}})
-    {:ok, snapshot} = HeadlessPort.collect_frame(ref, @sync_timeout)
-    Process.put({:last_frame_snapshot, port}, snapshot)
-
-    # Drain any deferred messages queued by the :ready handler (e.g.
-    # :setup_highlight, :debounced_render). Without this, a background
-    # render can produce a spurious commit_frame that satisfies the next
-    # send_key's frame waiter before the key press is actually processed.
-    _ = sync_editor(editor)
-    _ = sync_port(port)
+    synchronize_ready(editor, port, width, height, rendering)
 
     Map.merge(ctx, %{
       editor: editor,
@@ -153,6 +189,7 @@ defmodule Minga.Test.EditorCase do
       port: port,
       width: width,
       height: height,
+      rendering: rendering,
       events_registry: events_registry,
       sidebar_registry: sidebar_registry
     })
@@ -164,6 +201,7 @@ defmodule Minga.Test.EditorCase do
     width = Keyword.get(opts, :width, 80)
     height = Keyword.get(opts, :height, 24)
     clipboard = Keyword.get(opts, :clipboard, :none)
+    rendering = rendering_option(opts, Process.get(@rendering_process_key, :enabled))
     id = :erlang.unique_integer([:positive])
 
     events_registry =
@@ -190,6 +228,7 @@ defmodule Minga.Test.EditorCase do
     editor_opts = [
       name: :"headless_editor_#{id}",
       backend: :headless,
+      rendering: rendering,
       port_manager: port,
       buffer: buffer,
       width: width,
@@ -212,14 +251,7 @@ defmodule Minga.Test.EditorCase do
 
     {:ok, editor} = MingaEditor.start_link(editor_opts)
 
-    ref = HeadlessPort.prepare_await(port)
-    send(editor, {:minga_input, {:ready, width, height}})
-    {:ok, snapshot} = HeadlessPort.collect_frame(ref, @sync_timeout)
-    Process.put({:last_frame_snapshot, port}, snapshot)
-
-    # Drain deferred messages from :ready (see start_editor/2 comment).
-    _ = sync_editor(editor)
-    _ = sync_port(port)
+    synchronize_ready(editor, port, width, height, rendering)
 
     %{
       editor: editor,
@@ -227,9 +259,40 @@ defmodule Minga.Test.EditorCase do
       port: port,
       width: width,
       height: height,
+      rendering: rendering,
       events_registry: events_registry,
       sidebar_registry: sidebar_registry
     }
+  end
+
+  @spec synchronize_ready(
+          pid(),
+          pid(),
+          pos_integer(),
+          pos_integer(),
+          MingaEditor.State.rendering_policy()
+        ) :: :ok
+  defp synchronize_ready(editor, port, width, height, :enabled) do
+    ref = HeadlessPort.prepare_await(port)
+    send(editor, {:minga_input, {:ready, width, height}})
+    {:ok, snapshot} = HeadlessPort.collect_frame(ref, @sync_timeout)
+    Process.put({:last_frame_snapshot, port}, snapshot)
+    synchronize_processes(editor, port)
+  end
+
+  defp synchronize_ready(editor, port, width, height, :disabled) do
+    send(editor, {:minga_input, {:ready, width, height}})
+    Process.delete({:last_frame_snapshot, port})
+    synchronize_processes(editor, port)
+  end
+
+  @spec synchronize_processes(pid(), pid()) :: :ok
+  defp synchronize_processes(editor, port) do
+    # Drain deferred editor work, then use the HeadlessPort call as a second
+    # mailbox barrier. Disabled rendering must not rely on a frame to become ready.
+    _ = sync_editor(editor)
+    _ = sync_port(port)
+    :ok
   end
 
   # ── Highlight injection helpers ─────────────────────────────────────────────
@@ -299,6 +362,15 @@ defmodule Minga.Test.EditorCase do
   end
 
   # ── Key sending helpers ──────────────────────────────────────────────────────
+  @doc false
+  @spec assert_rendering_enabled!(editor_ctx(), String.t()) :: :ok
+  def assert_rendering_enabled!(%{rendering: :disabled}, helper) do
+    raise ArgumentError,
+          "#{helper} requires rendering, but this EditorCase editor was started with rendering: :disabled"
+  end
+
+  def assert_rendering_enabled!(_ctx, _helper), do: :ok
+
   @doc """
   Sends a key press and waits for the next rendered frame.
   Stores the captured frame snapshot in the process dictionary so
@@ -306,7 +378,9 @@ defmodule Minga.Test.EditorCase do
   instead of reading the (possibly overwritten) HeadlessPort grid.
   """
   @spec send_key(editor_ctx(), non_neg_integer(), non_neg_integer()) :: :ok
-  def send_key(%{editor: editor, port: port}, codepoint, mods \\ 0) do
+  def send_key(%{editor: editor, port: port} = ctx, codepoint, mods \\ 0) do
+    assert_rendering_enabled!(ctx, "send_key/3")
+
     # Drain any pending async messages (timers, highlight events, etc.)
     # before registering the frame waiter. This prevents a pending render
     # from satisfying our waiter instead of the intended key's render.
@@ -374,7 +448,8 @@ defmodule Minga.Test.EditorCase do
   Not needed after `send_key` (which captures a frame snapshot directly).
   """
   @spec sync_screen(editor_ctx()) :: :ok
-  def sync_screen(%{port: port}) do
+  def sync_screen(%{port: port} = ctx) do
+    assert_rendering_enabled!(ctx, "sync_screen/1")
     sync_port(port)
     :ok
   end
@@ -427,7 +502,9 @@ defmodule Minga.Test.EditorCase do
 
   @doc "Returns the rendered text for a specific row."
   @spec screen_row(editor_ctx(), non_neg_integer()) :: String.t()
-  def screen_row(%{port: port}, row) do
+  def screen_row(%{port: port} = ctx, row) do
+    assert_rendering_enabled!(ctx, "screen_row/2")
+
     case Process.get({:last_frame_snapshot, port}) do
       %{grid: grid} ->
         grid
@@ -442,7 +519,9 @@ defmodule Minga.Test.EditorCase do
 
   @doc "Returns all screen rows as a list of strings."
   @spec screen_text(editor_ctx()) :: [String.t()]
-  def screen_text(%{port: port}) do
+  def screen_text(%{port: port} = ctx) do
+    assert_rendering_enabled!(ctx, "screen_text/1")
+
     case Process.get({:last_frame_snapshot, port}) do
       %{grid: grid} ->
         Enum.map(grid, fn row ->
@@ -491,7 +570,9 @@ defmodule Minga.Test.EditorCase do
 
   @doc "Returns the cursor position on screen."
   @spec screen_cursor(editor_ctx()) :: {non_neg_integer(), non_neg_integer()}
-  def screen_cursor(%{port: port}) do
+  def screen_cursor(%{port: port} = ctx) do
+    assert_rendering_enabled!(ctx, "screen_cursor/1")
+
     case Process.get({:last_frame_snapshot, port}) do
       %{cursor: cursor} -> cursor
       nil -> HeadlessPort.get_cursor(port)
@@ -500,7 +581,9 @@ defmodule Minga.Test.EditorCase do
 
   @doc "Returns the current cursor shape."
   @spec cursor_shape(editor_ctx()) :: MingaEditor.Frontend.Protocol.cursor_shape()
-  def cursor_shape(%{port: port}) do
+  def cursor_shape(%{port: port} = ctx) do
+    assert_rendering_enabled!(ctx, "cursor_shape/1")
+
     case Process.get({:last_frame_snapshot, port}) do
       %{cursor_shape: shape} -> shape
       nil -> HeadlessPort.get_cursor_shape(port)
@@ -713,7 +796,8 @@ defmodule Minga.Test.EditorCase do
 
   @doc "Returns the cell at a given screen row and col."
   @spec screen_cell(editor_ctx(), non_neg_integer(), non_neg_integer()) :: map()
-  def screen_cell(%{port: port}, row, col) do
+  def screen_cell(%{port: port} = ctx, row, col) do
+    assert_rendering_enabled!(ctx, "screen_cell/3")
     HeadlessPort.get_cell(port, row, col)
   end
 
@@ -781,6 +865,7 @@ defmodule Minga.Test.EditorCase do
     quote do
       ctx = unquote(ctx)
       name = unquote(snapshot_name)
+      Minga.Test.EditorCase.assert_rendering_enabled!(ctx, "assert_screen_snapshot/2")
       # If a preceding `send_key` captured a frame snapshot, use it.
       # Otherwise (after `send_key_sync`/`send_keys_sync`, which clear
       # the stale snapshot), fall back to reading the live grid from
@@ -891,7 +976,8 @@ defmodule Minga.Test.EditorCase do
   multiple render cycles on loaded CI runners.
   """
   @spec wait_until_screen(editor_ctx(), (-> boolean()), keyword()) :: :ok
-  def wait_until_screen(%{editor: editor, port: port} = _ctx, condition, opts \\ []) do
+  def wait_until_screen(%{editor: editor, port: port} = ctx, condition, opts \\ []) do
+    assert_rendering_enabled!(ctx, "wait_until_screen/3")
     max = Keyword.get(opts, :max_attempts, 50)
     interval = Keyword.get(opts, :interval_ms, 20)
     message = Keyword.get(opts, :message, "Screen condition not met after polling")
@@ -939,7 +1025,7 @@ defmodule Minga.Test.EditorCase do
           pos_integer()
         ) :: :ok
   def send_mouse(
-        %{editor: editor, port: port},
+        %{editor: editor, port: port} = ctx,
         row,
         col,
         button,
@@ -947,6 +1033,7 @@ defmodule Minga.Test.EditorCase do
         event_type \\ :press,
         click_count \\ 1
       ) do
+    assert_rendering_enabled!(ctx, "send_mouse/7")
     _ = sync_editor(editor)
     ref = HeadlessPort.prepare_await(port)
 
@@ -973,7 +1060,8 @@ defmodule Minga.Test.EditorCase do
   clicks, sidebar actions, tab selection) instead of raw cell coordinates.
   """
   @spec send_gui_action(editor_ctx(), term()) :: :ok
-  def send_gui_action(%{editor: editor, port: port}, action) do
+  def send_gui_action(%{editor: editor, port: port} = ctx, action) do
+    assert_rendering_enabled!(ctx, "send_gui_action/2")
     _ = sync_editor(editor)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:gui_action, action}})
@@ -988,6 +1076,7 @@ defmodule Minga.Test.EditorCase do
   """
   @spec send_resize(editor_ctx(), pos_integer(), pos_integer()) :: editor_ctx()
   def send_resize(%{editor: editor, port: port} = ctx, new_width, new_height) do
+    assert_rendering_enabled!(ctx, "send_resize/3")
     _ = sync_editor(editor)
     HeadlessPort.resize(port, new_width, new_height)
     ref = HeadlessPort.prepare_await(port)

--- a/test/support/minga_agent/session_case.ex
+++ b/test/support/minga_agent/session_case.ex
@@ -15,7 +15,6 @@ defmodule Minga.Test.SessionCase do
       alias MingaAgent.Session
       alias MingaAgent.SessionStore
 
-      @moduletag :tmp_dir
       @event_timeout 5_000
     end
   end

--- a/test/support/minga_agent/subagent_error_provider.ex
+++ b/test/support/minga_agent/subagent_error_provider.ex
@@ -1,0 +1,54 @@
+defmodule Minga.Test.SubagentErrorProvider do
+  @moduledoc false
+
+  @behaviour MingaAgent.Provider
+
+  use GenServer
+
+  alias MingaAgent.Event
+
+  @type state :: %{subscriber: pid(), test_pid: pid()}
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  @impl MingaAgent.Provider
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+  @spec send_prompt(GenServer.server(), String.t()) :: :ok
+  @impl MingaAgent.Provider
+  def send_prompt(pid, text), do: GenServer.call(pid, {:prompt, text})
+
+  @spec abort(GenServer.server()) :: :ok
+  @impl MingaAgent.Provider
+  def abort(pid), do: GenServer.call(pid, :abort)
+
+  @spec new_session(GenServer.server()) :: :ok
+  @impl MingaAgent.Provider
+  def new_session(pid), do: GenServer.call(pid, :new_session)
+
+  @spec seed_messages(GenServer.server(), [term()]) :: :ok
+  @impl MingaAgent.Provider
+  def seed_messages(_pid, _messages), do: :ok
+
+  @spec get_state(GenServer.server()) :: {:ok, map()}
+  @impl MingaAgent.Provider
+  def get_state(_pid), do: {:ok, %{model: nil, is_streaming: false, token_usage: nil}}
+
+  @spec init(keyword()) :: {:ok, state()}
+  @impl GenServer
+  def init(opts) do
+    {:ok,
+     %{subscriber: Keyword.fetch!(opts, :subscriber), test_pid: Keyword.fetch!(opts, :test_pid)}}
+  end
+
+  @spec handle_call(term(), GenServer.from(), state()) :: {:reply, :ok, state()}
+  @impl GenServer
+  def handle_call({:prompt, text}, _from, state) do
+    send(state.subscriber, {:agent_provider_event, %Event.AgentStart{}})
+    send(state.test_pid, {:provider_prompt, self(), text})
+    send(state.subscriber, {:agent_provider_event, %Event.Error{message: "boom"}})
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:abort, _from, state), do: {:reply, :ok, state}
+  def handle_call(:new_session, _from, state), do: {:reply, :ok, state}
+end

--- a/test/support/minga_agent/subagent_gated_provider.ex
+++ b/test/support/minga_agent/subagent_gated_provider.ex
@@ -1,0 +1,62 @@
+defmodule Minga.Test.SubagentGatedProvider do
+  @moduledoc false
+
+  @behaviour MingaAgent.Provider
+
+  use GenServer
+
+  alias MingaAgent.Event
+
+  @type state :: %{subscriber: pid(), test_pid: pid()}
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  @impl MingaAgent.Provider
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+  @spec send_prompt(GenServer.server(), String.t()) :: :ok
+  @impl MingaAgent.Provider
+  def send_prompt(pid, text), do: GenServer.call(pid, {:prompt, text})
+
+  @spec abort(GenServer.server()) :: :ok
+  @impl MingaAgent.Provider
+  def abort(pid), do: GenServer.call(pid, :abort)
+
+  @spec new_session(GenServer.server()) :: :ok
+  @impl MingaAgent.Provider
+  def new_session(pid), do: GenServer.call(pid, :new_session)
+
+  @spec seed_messages(GenServer.server(), [term()]) :: :ok
+  @impl MingaAgent.Provider
+  def seed_messages(_pid, _messages), do: :ok
+
+  @spec get_state(GenServer.server()) :: {:ok, map()}
+  @impl MingaAgent.Provider
+  def get_state(_pid), do: {:ok, %{model: nil, is_streaming: false, token_usage: nil}}
+
+  @spec proceed(GenServer.server(), String.t()) :: :ok
+  def proceed(pid, text \\ "child done"), do: GenServer.call(pid, {:proceed, text})
+
+  @spec init(keyword()) :: {:ok, state()}
+  @impl GenServer
+  def init(opts) do
+    {:ok,
+     %{subscriber: Keyword.fetch!(opts, :subscriber), test_pid: Keyword.fetch!(opts, :test_pid)}}
+  end
+
+  @spec handle_call(term(), GenServer.from(), state()) :: {:reply, :ok, state()}
+  @impl GenServer
+  def handle_call({:prompt, text}, _from, state) do
+    send(state.subscriber, {:agent_provider_event, %Event.AgentStart{}})
+    send(state.test_pid, {:provider_prompt, self(), text})
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:proceed, text}, _from, state) do
+    send(state.subscriber, {:agent_provider_event, %Event.TextDelta{delta: text}})
+    send(state.subscriber, {:agent_provider_event, %Event.AgentEnd{}})
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:abort, _from, state), do: {:reply, :ok, state}
+  def handle_call(:new_session, _from, state), do: {:reply, :ok, state}
+end

--- a/test/support/minga_agent/subagent_override_provider.ex
+++ b/test/support/minga_agent/subagent_override_provider.ex
@@ -1,0 +1,31 @@
+defmodule Minga.Test.SubagentOverrideProvider do
+  @moduledoc false
+
+  @behaviour MingaAgent.Provider
+
+  alias Minga.Test.SubagentRecordingProvider
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  @impl MingaAgent.Provider
+  def start_link(opts), do: SubagentRecordingProvider.start_link(opts)
+
+  @spec send_prompt(GenServer.server(), String.t()) :: :ok
+  @impl MingaAgent.Provider
+  def send_prompt(pid, text), do: SubagentRecordingProvider.send_prompt(pid, text)
+
+  @spec abort(GenServer.server()) :: :ok
+  @impl MingaAgent.Provider
+  def abort(pid), do: SubagentRecordingProvider.abort(pid)
+
+  @spec new_session(GenServer.server()) :: :ok
+  @impl MingaAgent.Provider
+  def new_session(pid), do: SubagentRecordingProvider.new_session(pid)
+
+  @spec seed_messages(GenServer.server(), [term()]) :: :ok
+  @impl MingaAgent.Provider
+  def seed_messages(_pid, _messages), do: :ok
+
+  @spec get_state(GenServer.server()) :: {:ok, map()}
+  @impl MingaAgent.Provider
+  def get_state(pid), do: SubagentRecordingProvider.get_state(pid)
+end

--- a/test/support/minga_agent/subagent_recording_provider.ex
+++ b/test/support/minga_agent/subagent_recording_provider.ex
@@ -1,0 +1,132 @@
+defmodule Minga.Test.SubagentRecordingProvider do
+  @moduledoc false
+
+  @behaviour MingaAgent.Provider
+
+  use GenServer
+
+  alias MingaAgent.Event
+
+  @type state :: map()
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  @impl MingaAgent.Provider
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @spec send_prompt(GenServer.server(), String.t()) :: :ok
+  @impl MingaAgent.Provider
+  def send_prompt(pid, text) do
+    GenServer.call(pid, {:send_prompt, text})
+  end
+
+  @spec abort(GenServer.server()) :: :ok
+  @impl MingaAgent.Provider
+  def abort(pid) do
+    GenServer.cast(pid, :abort)
+    :ok
+  end
+
+  @spec new_session(GenServer.server()) :: :ok
+  @impl MingaAgent.Provider
+  def new_session(pid) do
+    GenServer.cast(pid, :new_session)
+    :ok
+  end
+
+  @spec seed_messages(GenServer.server(), [term()]) :: :ok
+  @impl MingaAgent.Provider
+  def seed_messages(_pid, _messages), do: :ok
+
+  @spec get_state(GenServer.server()) :: {:ok, map()}
+  @impl MingaAgent.Provider
+  def get_state(pid) do
+    GenServer.call(pid, :get_state)
+  end
+
+  @spec init(keyword()) :: {:ok, state()}
+  @impl GenServer
+  def init(opts) do
+    notify_test(opts, {:provider_started, self(), opts})
+
+    state = %{
+      subscriber: Keyword.fetch!(opts, :subscriber),
+      model: Keyword.get(opts, :model),
+      provider: Keyword.get(opts, :provider, "recording"),
+      thinking_level: Keyword.get(opts, :thinking_level),
+      active_skill_names: Keyword.get(opts, :active_skill_names, []),
+      project_root: Keyword.get(opts, :project_root),
+      blocking: Keyword.get(opts, :blocking, false),
+      test_pid: Keyword.get(opts, :test_pid),
+      test_ref: Keyword.get(opts, :test_ref)
+    }
+
+    {:ok, state}
+  end
+
+  @spec handle_call(term(), GenServer.from(), state()) :: {:reply, term(), state()}
+  @impl GenServer
+  def handle_call({:send_prompt, text}, _from, state) do
+    notify_test(state, {:prompt_received, self(), state.subscriber, text})
+    notify_session(state, %Event.AgentStart{})
+
+    if state.blocking do
+      {:reply, :ok, state}
+    else
+      notify_session(state, %Event.TextDelta{delta: "child response"})
+      notify_session(state, %Event.AgentEnd{usage: nil})
+      {:reply, :ok, state}
+    end
+  end
+
+  def handle_call(:get_state, _from, state) do
+    provider_state = %{
+      model: %{id: state.model, name: state.model, provider: state.provider},
+      is_streaming: false,
+      token_usage: nil,
+      thinking_level: state.thinking_level,
+      active_skill_names: state.active_skill_names,
+      project_root: state.project_root
+    }
+
+    {:reply, {:ok, provider_state}, state}
+  end
+
+  @spec handle_cast(term(), state()) :: {:noreply, state()}
+  @impl GenServer
+  def handle_cast(:finish, state) do
+    notify_session(state, %Event.TextDelta{delta: "blocked child response"})
+    notify_session(state, %Event.AgentEnd{usage: nil})
+    {:noreply, state}
+  end
+
+  def handle_cast(_message, state), do: {:noreply, state}
+
+  @spec finish(GenServer.server()) :: :ok
+  def finish(pid) do
+    GenServer.cast(pid, :finish)
+  end
+
+  @spec notify_session(map(), Event.t()) :: :ok
+  defp notify_session(state, event) do
+    send(state.subscriber, {:agent_provider_event, event})
+    :ok
+  end
+
+  @spec notify_test(keyword() | map(), tuple()) :: :ok
+  defp notify_test(opts_or_state, message) do
+    test_pid = get_opt(opts_or_state, :test_pid)
+    test_ref = get_opt(opts_or_state, :test_ref)
+
+    if is_pid(test_pid) and test_ref != nil do
+      send(test_pid, {test_ref, message})
+    end
+
+    :ok
+  end
+
+  @spec get_opt(keyword() | map(), atom()) :: term()
+  defp get_opt(opts, key) when is_list(opts), do: Keyword.get(opts, key)
+  defp get_opt(state, key) when is_map(state), do: Map.get(state, key)
+end

--- a/test/support/minga_agent/subagent_test_notifier.ex
+++ b/test/support/minga_agent/subagent_test_notifier.ex
@@ -1,0 +1,9 @@
+defmodule Minga.Test.SubagentTestNotifier do
+  @moduledoc false
+
+  @spec notify(atom(), String.t(), pid()) :: :ok
+  def notify(trigger, message, test_pid) do
+    send(test_pid, {:notified, trigger, message})
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary

Adds an explicit input-only mode to `EditorCase` so state and input-routing tests can exercise the real Editor process without paying for render pipeline work they do not assert on.

This follows the structural test acceleration in #2785 and reduces the full `mix test.llm` run from the 83.0s parent measurement to 67.4s in the final validated run.

## What changed

- Adds an immutable `rendering: :enabled | :disabled` policy to editor state and startup.
- Enforces disabled rendering at both renderer entry points and the operator-pending bare-frame shortcut.
- Extends `EditorCase` with input-only synchronization and clear failures for frame-dependent helpers.
- Migrates six state-only EditorCase suites while retaining enabled-rendering contract coverage.
- Splits deterministic Subagent tests into an async module and isolates global ProviderRegistry mutation tests in a documented serialized module.
- Keeps real Git worktree contracts in the existing heavy tests.
- Removes the blanket SessionCase temp-directory tag and applies it only to filesystem-dependent tests.
- Uses consistent event timeouts in the newly parallel Subagent suite to tolerate full-suite scheduler load without adding sleeps.

## Performance

- Parent slice: 83.0s for `mix test.llm`
- This slice: 67.4s for `mix test.llm`
- Improvement: 15.6s, about 19%

## Validation

- `make lint`
- `mix test.llm` (9,850 tests, 0 failures)
- Five repeated focused runs of `test/minga_agent/tools/subagent_test.exs`
- `mix test.heavy test/minga_agent/tools/subagent_worktree_heavy_test.exs`
- Focused post-rebase harness and Subagent tests (31 tests, 0 failures)
- Final reviewer: PASS
